### PR TITLE
release-20.1: kvserver: synchronize replica removal with read-only requests

### DIFF
--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
+	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
@@ -232,14 +233,11 @@ func TestStoreRangeMergeWithData(t *testing.T) {
 
 func mergeWithData(t *testing.T, retries int64) {
 	ctx := context.Background()
-	storeCfg := kvserver.TestStoreConfig(nil)
-	storeCfg.TestingKnobs.DisableReplicateQueue = true
-	storeCfg.TestingKnobs.DisableMergeQueue = true
-	storeCfg.Clock = nil // manual clock
 
+	manualClock := hlc.NewHybridManualClock()
+	var store *kvserver.Store
 	// Maybe inject some retryable errors when the merge transaction commits.
-	var mtc *multiTestContext
-	storeCfg.TestingKnobs.TestingRequestFilter = func(_ context.Context, ba roachpb.BatchRequest) *roachpb.Error {
+	testingRequestFilter := func(_ context.Context, ba roachpb.BatchRequest) *roachpb.Error {
 		for _, req := range ba.Requests {
 			if et := req.GetEndTxn(); et != nil && et.InternalCommitTrigger.GetMergeTrigger() != nil {
 				if atomic.AddInt64(&retries, -1) >= 0 {
@@ -252,148 +250,114 @@ func mergeWithData(t *testing.T, retries int64) {
 				// Subsume can execute. This triggers an unusual code path where the
 				// lease acquisition, not Subsume, notices the merge and installs a
 				// mergeComplete channel on the replica.
-				mtc.advanceClock(ctx)
+				manualClock.Increment(store.GetStoreConfig().LeaseExpiration())
 			}
 		}
 		return nil
 	}
 
-	mtc = &multiTestContext{
-		storeConfig: &storeCfg,
-		// This test was written before the multiTestContext started creating many
-		// system ranges at startup, and hasn't been update to take that into
-		// account.
-		startWithSingleRange: true,
-	}
+	serv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			Store: &kvserver.StoreTestingKnobs{
+				DisableMergeQueue:    true,
+				DisableSplitQueue:    true,
+				TestingRequestFilter: testingRequestFilter,
+			},
+			Server: &server.TestingKnobs{
+				ClockSource: manualClock.UnixNano,
+			},
+		},
+	})
+	s := serv.(*server.TestServer)
+	defer s.Stopper().Stop(ctx)
+	store, err := s.Stores().GetStore(s.GetFirstStoreID())
+	require.NoError(t, err)
 
-	var store1, store2 *kvserver.Store
-	mtc.Start(t, 1)
-	store1, store2 = mtc.stores[0], mtc.stores[0]
-	defer mtc.Stop()
+	scratchKey, err := s.ScratchRangeWithExpirationLease()
+	repl := store.LookupReplica(roachpb.RKey(scratchKey))
+	require.NoError(t, err)
 
-	lhsDesc, rhsDesc, pErr := createSplitRanges(ctx, store1)
-	if pErr != nil {
-		t.Fatal(pErr)
-	}
+	lhsDesc, rhsDesc, pErr := s.SplitRange(scratchKey.Next().Next())
+	require.NoError(t, pErr)
 
 	content := []byte("testing!")
 
 	// Write some values left and right of the proposed split key.
-	pArgs := putArgs(roachpb.Key("aaa"), content)
-	if _, pErr := kv.SendWrapped(ctx, store1.TestSender(), pArgs); pErr != nil {
-		t.Fatal(pErr)
-	}
-	pArgs = putArgs(roachpb.Key("ccc"), content)
-	if _, pErr := kv.SendWrappedWith(ctx, store2.TestSender(), roachpb.Header{
-		RangeID: rhsDesc.RangeID,
-	}, pArgs); pErr != nil {
-		t.Fatal(pErr)
+
+	put := func(key roachpb.Key, rangeID roachpb.RangeID, value []byte) {
+		pArgs := putArgs(key, value)
+		if _, pErr := kv.SendWrappedWith(ctx, store.TestSender(), roachpb.Header{
+			RangeID: rangeID,
+		}, pArgs); pErr != nil {
+			t.Fatal(pErr)
+		}
 	}
 
-	// Confirm the values are there.
-	gArgs := getArgs(roachpb.Key("aaa"))
-	if reply, pErr := kv.SendWrapped(ctx, store1.TestSender(), gArgs); pErr != nil {
-		t.Fatal(pErr)
-	} else if replyBytes, err := reply.(*roachpb.GetResponse).Value.GetBytes(); err != nil {
-		t.Fatal(err)
-	} else if !bytes.Equal(replyBytes, content) {
-		t.Fatalf("actual value %q did not match expected value %q", replyBytes, content)
+	verify := func(key roachpb.Key, rangeID roachpb.RangeID, value []byte) {
+		// Confirm the values are there.
+		gArgs := getArgs(key)
+		if reply, pErr := kv.SendWrappedWith(ctx, store.TestSender(), roachpb.Header{
+			RangeID: rangeID,
+		}, gArgs); pErr != nil {
+		} else if replyBytes, err := reply.(*roachpb.GetResponse).Value.GetBytes(); err != nil {
+			t.Fatal(err)
+		} else if !bytes.Equal(replyBytes, value) {
+			t.Fatalf("actual value %q did not match expected value %q", replyBytes, content)
+		}
 	}
-	gArgs = getArgs(roachpb.Key("ccc"))
-	if reply, pErr := kv.SendWrappedWith(ctx, store2.TestSender(), roachpb.Header{
-		RangeID: rhsDesc.RangeID,
-	}, gArgs); pErr != nil {
-		t.Fatal(pErr)
-	} else if replyBytes, err := reply.(*roachpb.GetResponse).Value.GetBytes(); err != nil {
-		t.Fatal(err)
-	} else if !bytes.Equal(replyBytes, content) {
-		t.Fatalf("actual value %q did not match expected value %q", replyBytes, content)
-	}
+
+	put(lhsDesc.StartKey.Next().AsRawKey(), lhsDesc.RangeID, content)
+	put(rhsDesc.StartKey.Next().AsRawKey(), rhsDesc.RangeID, content)
+
+	verify(lhsDesc.StartKey.Next().AsRawKey(), lhsDesc.RangeID, content)
+	verify(rhsDesc.StartKey.Next().AsRawKey(), rhsDesc.RangeID, content)
 
 	// Merge the b range back into the a range.
 	args := adminMergeArgs(lhsDesc.StartKey.AsRawKey())
-	if _, pErr := kv.SendWrapped(ctx, store1.TestSender(), args); pErr != nil {
+	if _, pErr := kv.SendWrapped(ctx, store.TestSender(), args); pErr != nil {
 		t.Fatal(pErr)
 	}
 
 	// Verify no intents remains on range descriptor keys.
 	for _, key := range []roachpb.Key{keys.RangeDescriptorKey(lhsDesc.StartKey), keys.RangeDescriptorKey(rhsDesc.StartKey)} {
 		if _, _, err := storage.MVCCGet(
-			ctx, store1.Engine(), key, store1.Clock().Now(), storage.MVCCGetOptions{},
+			ctx, store.Engine(), key, store.Clock().Now(), storage.MVCCGetOptions{},
 		); err != nil {
 			t.Fatal(err)
 		}
 	}
 
 	// Verify the merge by looking up keys from both ranges.
-	lhsRepl := store1.LookupReplica(roachpb.RKey("a"))
-	rhsRepl := store1.LookupReplica(roachpb.RKey("c"))
+	lhsRepl := store.LookupReplica(lhsDesc.StartKey.Next())
+	rhsRepl := store.LookupReplica(rhsDesc.StartKey.Next())
 
 	if lhsRepl != rhsRepl {
 		t.Fatalf("ranges were not merged %+v=%+v", lhsRepl.Desc(), rhsRepl.Desc())
 	}
-	if startKey := lhsRepl.Desc().StartKey; !bytes.Equal(startKey, roachpb.RKeyMin) {
+	if startKey := lhsRepl.Desc().StartKey; !bytes.Equal(startKey, repl.Desc().StartKey) {
 		t.Fatalf("The start key is not equal to KeyMin %q=%q", startKey, roachpb.RKeyMin)
 	}
-	if endKey := rhsRepl.Desc().EndKey; !bytes.Equal(endKey, roachpb.RKeyMax) {
+	if endKey := rhsRepl.Desc().EndKey; !bytes.Equal(endKey, repl.Desc().EndKey) {
 		t.Fatalf("The end key is not equal to KeyMax %q=%q", endKey, roachpb.RKeyMax)
 	}
 
-	// Try to get values from after the merge.
-	gArgs = getArgs(roachpb.Key("aaa"))
-	if reply, pErr := kv.SendWrapped(ctx, store1.TestSender(), gArgs); pErr != nil {
-		t.Fatal(pErr)
-	} else if replyBytes, err := reply.(*roachpb.GetResponse).Value.GetBytes(); err != nil {
-		t.Fatal(err)
-	} else if !bytes.Equal(replyBytes, content) {
-		t.Fatalf("actual value %q did not match expected value %q", replyBytes, content)
-	}
-	gArgs = getArgs(roachpb.Key("ccc"))
-	if reply, pErr := kv.SendWrappedWith(ctx, store1.TestSender(), roachpb.Header{
-		RangeID: rhsRepl.RangeID,
-	}, gArgs); pErr != nil {
-		t.Fatal(pErr)
-	} else if replyBytes, err := reply.(*roachpb.GetResponse).Value.GetBytes(); err != nil {
-		t.Fatal(err)
-	} else if !bytes.Equal(replyBytes, content) {
-		t.Fatalf("actual value %q did not match expected value %q", replyBytes, content)
-	}
+	verify(lhsDesc.StartKey.Next().AsRawKey(), lhsRepl.RangeID, content)
+	verify(rhsDesc.StartKey.Next().AsRawKey(), rhsRepl.RangeID, content)
 
+	newContent := []byte("testing!better!")
 	// Put new values after the merge on both sides.
-	pArgs = putArgs(roachpb.Key("aaaa"), content)
-	if _, pErr := kv.SendWrapped(ctx, store1.TestSender(), pArgs); pErr != nil {
-		t.Fatal(pErr)
-	}
-	pArgs = putArgs(roachpb.Key("cccc"), content)
-	if _, pErr := kv.SendWrappedWith(ctx, store1.TestSender(), roachpb.Header{
-		RangeID: rhsRepl.RangeID,
-	}, pArgs); pErr != nil {
-		t.Fatal(pErr)
-	}
+	put(lhsDesc.StartKey.Next().AsRawKey(), lhsRepl.RangeID, newContent)
+	put(rhsDesc.StartKey.Next().AsRawKey(), rhsRepl.RangeID, newContent)
 
 	// Try to get the newly placed values.
-	gArgs = getArgs(roachpb.Key("aaaa"))
-	if reply, pErr := kv.SendWrapped(ctx, store1.TestSender(), gArgs); pErr != nil {
-		t.Fatal(pErr)
-	} else if replyBytes, err := reply.(*roachpb.GetResponse).Value.GetBytes(); err != nil {
-		t.Fatal(err)
-	} else if !bytes.Equal(replyBytes, content) {
-		t.Fatalf("actual value %q did not match expected value %q", replyBytes, content)
-	}
-	gArgs = getArgs(roachpb.Key("cccc"))
-	if reply, pErr := kv.SendWrapped(ctx, store1.TestSender(), gArgs); pErr != nil {
-		t.Fatal(pErr)
-	} else if replyBytes, err := reply.(*roachpb.GetResponse).Value.GetBytes(); err != nil {
-		t.Fatal(err)
-	} else if !bytes.Equal(replyBytes, content) {
-		t.Fatalf("actual value %q did not match expected value %q", replyBytes, content)
-	}
+	verify(lhsDesc.StartKey.Next().AsRawKey(), lhsRepl.RangeID, newContent)
+	verify(rhsDesc.StartKey.Next().AsRawKey(), rhsRepl.RangeID, newContent)
 
-	gArgs = getArgs(roachpb.Key("cccc"))
-	if _, pErr := kv.SendWrappedWith(ctx, store2, roachpb.Header{
+	gArgs := getArgs(lhsDesc.StartKey.Next().AsRawKey())
+	if _, pErr := kv.SendWrappedWith(ctx, store, roachpb.Header{
 		RangeID: rhsDesc.RangeID,
 	}, gArgs); !testutils.IsPError(
-		pErr, `r2 was not found`,
+		pErr, `was not found on s`,
 	) {
 		t.Fatalf("expected get on rhs to fail after merge, but got err=%v", pErr)
 	}

--- a/pkg/kv/kvserver/client_relocate_range_test.go
+++ b/pkg/kv/kvserver/client_relocate_range_test.go
@@ -14,15 +14,22 @@ import (
 	"context"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -198,4 +205,109 @@ func TestAdminRelocateRange(t *testing.T) {
 			return relocateAndCheck(t, tc, k, tc.Targets(2, 4))
 		})
 	}
+}
+
+// Regression test for https://github.com/cockroachdb/cockroach/issues/64325
+// which makes sure an in-flight read operation during replica removal won't
+// return empty results.
+func TestReplicaRemovalDuringRequestEvaluation(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	type magicKey struct{}
+
+	// delayReadC is used to synchronize the in-flight read request with the main
+	// test goroutine. It is read from twice:
+	//
+	// 1. The first read allows the test to block until the request eval filter
+	//    is called, i.e. when the read request is ready.
+	// 2. The second read allows the test to close the channel to unblock
+	//    the eval filter, causing the read request to be evaluated.
+	delayReadC := make(chan struct{})
+	evalFilter := func(args storagebase.FilterArgs) *roachpb.Error {
+		if args.Ctx.Value(magicKey{}) != nil {
+			<-delayReadC
+			<-delayReadC
+		}
+		return nil
+	}
+
+	ctx := context.Background()
+	manual := hlc.NewHybridManualClock()
+	args := base.TestClusterArgs{
+		ReplicationMode: base.ReplicationManual,
+		ServerArgs: base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				Store: &kvserver.StoreTestingKnobs{
+					EvalKnobs: storagebase.BatchEvalTestingKnobs{
+						TestingEvalFilter: evalFilter,
+					},
+				},
+				Server: &server.TestingKnobs{
+					ClockSource: manual.UnixNano,
+				},
+			},
+		},
+	}
+	tc := testcluster.StartTestCluster(t, 2, args)
+	defer tc.Stopper().Stop(ctx)
+
+	// Create range and upreplicate.
+	key := tc.ScratchRange(t)
+	tc.AddReplicasOrFatal(t, key, tc.Target(1))
+
+	// Perform write.
+	pArgs := putArgs(key, []byte("foo"))
+	_, pErr := kv.SendWrapped(ctx, tc.Servers[0].DistSender(), pArgs)
+	require.Nil(t, pErr)
+
+	// Perform read on write and wait for read to block.
+	type reply struct {
+		resp roachpb.Response
+		err  *roachpb.Error
+	}
+	readResC := make(chan reply)
+	err := tc.Stopper().RunAsyncTask(ctx, "get", func(ctx context.Context) {
+		readCtx := context.WithValue(ctx, magicKey{}, struct{}{})
+		gArgs := getArgs(key)
+		resp, pErr := kv.SendWrapped(readCtx, tc.Servers[0].DistSender(), gArgs)
+		readResC <- reply{resp, pErr}
+	})
+	require.NoError(t, err)
+	delayReadC <- struct{}{}
+
+	// Transfer leaseholder to other store.
+	rangeDesc, err := tc.LookupRange(key)
+	require.NoError(t, err)
+	store, err := tc.Server(0).GetStores().(*kvserver.Stores).GetStore(tc.Server(0).GetFirstStoreID())
+	require.NoError(t, err)
+	repl, err := store.GetReplica(rangeDesc.RangeID)
+	require.NoError(t, err)
+	err = tc.MoveRangeLeaseNonCooperatively(rangeDesc, tc.Target(1), manual)
+	require.NoError(t, err)
+
+	// Remove first store from raft group.
+	tc.RemoveReplicasOrFatal(t, key, tc.Target(0))
+
+	// This is a bit iffy. We want to make sure that, in the buggy case, we
+	// will typically fail (i.e. the read returns empty because the replica was
+	// removed). However, in the non-buggy case the in-flight read request will
+	// be holding readOnlyCmdMu until evaluated, blocking the replica removal,
+	// so waiting for replica removal would deadlock. We therefore take the
+	// easy way out by starting an async replica GC and sleeping for a bit.
+	err = tc.Stopper().RunAsyncTask(ctx, "replicaGC", func(ctx context.Context) {
+		assert.NoError(t, store.ManualReplicaGC(repl))
+	})
+	require.NoError(t, err)
+	time.Sleep(500 * time.Millisecond)
+
+	// Allow read to resume. Should return "foo".
+	close(delayReadC)
+	r := <-readResC
+	require.Nil(t, r.err)
+	require.NotNil(t, r.resp)
+	require.NotNil(t, r.resp.(*roachpb.GetResponse).Value)
+	val, err := r.resp.(*roachpb.GetResponse).Value.GetBytes()
+	require.NoError(t, err)
+	require.Equal(t, []byte("foo"), val)
 }

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -688,11 +688,13 @@ func (b *replicaAppBatch) runPreApplyTriggersAfterStagingWriteBatch(
 		//
 		// NB: we must be holding the raftMu here because we're in the
 		// midst of application.
+		b.r.readOnlyCmdMu.Lock()
 		b.r.mu.Lock()
 		b.r.mu.destroyStatus.Set(
 			roachpb.NewRangeNotFoundError(b.r.RangeID, b.r.store.StoreID()),
 			destroyReasonRemoved)
 		b.r.mu.Unlock()
+		b.r.readOnlyCmdMu.Unlock()
 		b.changeRemovesReplica = true
 
 		// Delete all of the local data. We're going to delete the hard state too.

--- a/pkg/kv/kvserver/replica_corruption.go
+++ b/pkg/kv/kvserver/replica_corruption.go
@@ -49,6 +49,8 @@ func (r *Replica) maybeSetCorrupt(ctx context.Context, pErr *roachpb.Error) *roa
 func (r *Replica) setCorruptRaftMuLocked(
 	ctx context.Context, cErr *roachpb.ReplicaCorruptionError,
 ) *roachpb.Error {
+	r.readOnlyCmdMu.Lock()
+	defer r.readOnlyCmdMu.Unlock()
 	r.mu.Lock()
 	defer r.mu.Unlock()
 

--- a/pkg/kv/kvserver/replica_destroy.go
+++ b/pkg/kv/kvserver/replica_destroy.go
@@ -234,8 +234,6 @@ func (r *Replica) destroyRaftMuLocked(ctx context.Context, nextReplicaID roachpb
 // is one, and removes the in-memory raft state.
 func (r *Replica) disconnectReplicationRaftMuLocked(ctx context.Context) {
 	r.raftMu.AssertHeld()
-	r.readOnlyCmdMu.Lock()
-	defer r.readOnlyCmdMu.Unlock()
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	// NB: In the very rare scenario that we're being removed but currently

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -774,6 +774,11 @@ func (sc *StoreConfig) SetDefaults() {
 	}
 }
 
+// GetStoreConfig exposes the config used for this store.
+func (s *Store) GetStoreConfig() *StoreConfig {
+	return &s.cfg
+}
+
 // LeaseExpiration returns an int64 to increment a manual clock with to
 // make sure that all active range leases expire.
 func (sc *StoreConfig) LeaseExpiration() int64 {

--- a/pkg/kv/kvserver/store_create_replica.go
+++ b/pkg/kv/kvserver/store_create_replica.go
@@ -162,6 +162,9 @@ func (s *Store) tryGetOrCreateReplica(
 	repl.creatingReplica = creatingReplica
 	repl.raftMu.Lock() // not unlocked
 
+	// Take out read-only lock. Not strictly necessary here, but follows the
+	// normal lock protocol for destroyStatus.Set().
+	repl.readOnlyCmdMu.Lock()
 	// Install the replica in the store's replica map. The replica is in an
 	// inconsistent state, but nobody will be accessing it while we hold its
 	// locks.
@@ -190,6 +193,7 @@ func (s *Store) tryGetOrCreateReplica(
 	if err := s.addReplicaToRangeMapLocked(repl); err != nil {
 		repl.mu.Unlock()
 		s.mu.Unlock()
+		repl.readOnlyCmdMu.Unlock()
 		repl.raftMu.Unlock()
 		return nil, false, errRetry
 	}
@@ -229,10 +233,12 @@ func (s *Store) tryGetOrCreateReplica(
 		s.mu.Lock()
 		s.unlinkReplicaByRangeIDLocked(rangeID)
 		s.mu.Unlock()
+		repl.readOnlyCmdMu.Unlock()
 		repl.raftMu.Unlock()
 		return nil, false, err
 	}
 	repl.mu.Unlock()
+	repl.readOnlyCmdMu.Unlock()
 	return repl, true, nil
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -222,6 +222,10 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 			return nil, errors.Wrap(err, "instantiating clock source")
 		}
 		clock = hlc.NewClock(clockSrc.UnixNano, time.Duration(cfg.MaxOffset))
+	} else if cfg.TestingKnobs.Server != nil &&
+		cfg.TestingKnobs.Server.(*TestingKnobs).ClockSource != nil {
+		clock = hlc.NewClock(cfg.TestingKnobs.Server.(*TestingKnobs).ClockSource,
+			time.Duration(cfg.MaxOffset))
 	} else {
 		clock = hlc.NewClock(hlc.UnixNano, time.Duration(cfg.MaxOffset))
 	}

--- a/pkg/server/testing_knobs.go
+++ b/pkg/server/testing_knobs.go
@@ -65,6 +65,9 @@ type TestingKnobs struct {
 	// TODO(irfansharif): Update users of this testing knob to use the
 	// appropriate clusterversion.Handle instead.
 	BootstrapVersionOverride roachpb.Version
+	// Clock Source used to an inject a custom clock for testing the server. It is
+	// typically either an hlc.HybridManualClock or hlc.ManualClock.
+	ClockSource func() int64
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -48,6 +48,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/errors"
 	"github.com/gogo/protobuf/proto"
@@ -313,6 +314,26 @@ func (ts *TestServer) MigrationManager() interface{} {
 		return ts.migMgr
 	}
 	return nil
+}
+
+// HeartbeatNodeLiveness heartbeats the server's NodeLiveness record.
+func (ts *TestServer) HeartbeatNodeLiveness() error {
+	if ts == nil {
+		return errors.New("no node liveness instance")
+	}
+	nl := ts.nodeLiveness
+	l, err := nl.Self()
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	for r := retry.StartWithCtx(ctx, retry.Options{MaxRetries: 5}); r.Next(); {
+		if err = nl.Heartbeat(ctx, l); !errors.Is(err, kvserver.ErrEpochIncremented) {
+			break
+		}
+	}
+	return err
 }
 
 // RPCContext returns the rpc context used by the TestServer.

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -11,6 +11,7 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net/http"
@@ -905,6 +906,18 @@ func (ts *TestServer) ForceTableGC(
 	}
 	_, pErr := kv.SendWrapped(ctx, ts.distSender, &gcr)
 	return pErr.GoError()
+}
+
+// ScratchRangeWithExpirationLease is like ScratchRange but creates a range with
+// an expiration based lease.
+func (ts *TestServer) ScratchRangeWithExpirationLease() (roachpb.Key, error) {
+	scratchKey := roachpb.Key(bytes.Join([][]byte{keys.SystemPrefix,
+		roachpb.RKey("\x00aaa-testing")}, nil))
+	_, _, err := ts.SplitRange(scratchKey)
+	if err != nil {
+		return nil, err
+	}
+	return scratchKey, nil
 }
 
 type testServerFactoryImpl struct{}

--- a/pkg/testutils/serverutils/test_cluster_shim.go
+++ b/pkg/testutils/serverutils/test_cluster_shim.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 )
 
@@ -98,6 +99,21 @@ type TestClusterInterface interface {
 	// new lease holder).
 	TransferRangeLease(
 		rangeDesc roachpb.RangeDescriptor, dest roachpb.ReplicationTarget,
+	) error
+
+	// MoveRangeLeaseNonCooperatively performs a non-cooperative transfer of the
+	// lease for a range from whoever has it to a particular store. That store
+	// must already have a replica of the range. If that replica already has the
+	// (active) lease, this method is a no-op.
+	//
+	// The transfer is non-cooperative in that the lease is made to expire by
+	// advancing the manual clock. The target is then instructed to acquire the
+	// ownerless lease. Most tests should use the cooperative version of this
+	// method, TransferRangeLease.
+	MoveRangeLeaseNonCooperatively(
+		rangeDesc roachpb.RangeDescriptor,
+		dest roachpb.ReplicationTarget,
+		manual *hlc.HybridManualClock,
 	) error
 
 	// LookupRange returns the descriptor of the range containing key.

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -104,6 +104,9 @@ type TestServerInterface interface {
 	// MigrationManager returns the *jobs.Registry as an interface{}.
 	MigrationManager() interface{}
 
+	// HeartbeatNodeLiveness heartbeats the server's NodeLiveness record.
+	HeartbeatNodeLiveness() error
+
 	// SetDistSQLSpanResolver changes the SpanResolver used for DistSQL inside the
 	// server's executor. The argument must be a physicalplan.SpanResolver
 	// instance.

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -696,6 +696,17 @@ func (tc *TestCluster) ScratchRange(t testing.TB) roachpb.Key {
 	return scratchKey
 }
 
+// ScratchRangeWithExpirationLease returns the start key of a span of keyspace
+// suitable for use as kv scratch space and that has an expiration based lease.
+// The range is lazily split off on the first call to ScratchRangeWithExpirationLease.
+func (tc *TestCluster) ScratchRangeWithExpirationLease(t testing.TB) roachpb.Key {
+	scratchKey, err := tc.Servers[0].ScratchRangeWithExpirationLease()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return scratchKey
+}
+
 // WaitForSplitAndInitialization waits for a range which starts with startKey
 // and then verifies that each replica in the range descriptor has been created.
 //

--- a/pkg/testutils/testcluster/testcluster_test.go
+++ b/pkg/testutils/testcluster/testcluster_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
@@ -26,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
 )
 
 func TestManualReplication(t *testing.T) {
@@ -256,4 +258,29 @@ func TestStopServer(t *testing.T) {
 	if err := httputil.GetJSON(httpClient1, url, &response); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestExpirationBasedLeases(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	tc := StartTestCluster(t, 1,
+		base.TestClusterArgs{
+			ReplicationMode: base.ReplicationManual,
+		})
+	defer tc.Stopper().Stop(ctx)
+
+	store, err := tc.Server(0).GetStores().(*kvserver.Stores).GetStore(tc.Server(0).GetFirstStoreID())
+	require.NoError(t, err)
+
+	key := tc.ScratchRangeWithExpirationLease(t)
+	repl := store.LookupReplica(roachpb.RKey(key))
+	lease, _ := repl.GetLease()
+	require.NotNil(t, lease.Expiration)
+
+	// Verify idempotence of ScratchRangeWithExpirationLease
+	keyAgain := tc.ScratchRangeWithExpirationLease(t)
+	replAgain := store.LookupReplica(roachpb.RKey(keyAgain))
+	require.Equal(t, repl, replAgain)
 }

--- a/pkg/util/hlc/hlc.go
+++ b/pkg/util/hlc/hlc.go
@@ -122,26 +122,40 @@ func (m *ManualClock) Set(nanos int64) {
 // HybridManualClock is a convenience type to facilitate
 // creating a hybrid logical clock whose physical clock
 // ticks with the wall clock, but that can be moved arbitrarily
-// into the future. HybridManualClock is thread safe.
+// into the future or paused. HybridManualClock is thread safe.
 type HybridManualClock struct {
 	nanos         int64
 	physicalClock func() int64
+	// nanosAtPause records the timestamp of the clock if it was paused. A 0 value
+	// indicates the clock was never paused.
+	nanosAtPause int64
 }
 
 // NewHybridManualClock returns a new instance, initialized with
 // specified timestamp.
 func NewHybridManualClock() *HybridManualClock {
-	return &HybridManualClock{nanos: 0, physicalClock: UnixNano}
+	return &HybridManualClock{nanos: 0, physicalClock: UnixNano, nanosAtPause: 0}
 }
 
 // UnixNano returns the underlying hybrid manual clock's timestamp.
 func (m *HybridManualClock) UnixNano() int64 {
-	return atomic.LoadInt64(&m.nanos) + m.physicalClock()
+	nanosAtPause := atomic.LoadInt64(&m.nanosAtPause)
+	nanos := atomic.LoadInt64(&m.nanos)
+	if nanosAtPause > 0 {
+		return nanos + nanosAtPause
+	}
+	return nanos + m.physicalClock()
 }
 
 // Increment atomically increments the hybrid manual clock's timestamp.
 func (m *HybridManualClock) Increment(incr int64) {
 	atomic.AddInt64(&m.nanos, incr)
+}
+
+// Pause pauses the hybrid manual clock and forces it to always return the
+// current timestamp.
+func (m *HybridManualClock) Pause() {
+	atomic.StoreInt64(&m.nanosAtPause, m.physicalClock())
 }
 
 // UnixNano returns the local machine's physical nanosecond

--- a/pkg/util/hlc/hlc.go
+++ b/pkg/util/hlc/hlc.go
@@ -124,38 +124,49 @@ func (m *ManualClock) Set(nanos int64) {
 // ticks with the wall clock, but that can be moved arbitrarily
 // into the future or paused. HybridManualClock is thread safe.
 type HybridManualClock struct {
-	nanos         int64
 	physicalClock func() int64
-	// nanosAtPause records the timestamp of the clock if it was paused. A 0 value
-	// indicates the clock was never paused.
-	nanosAtPause int64
+	mu            struct {
+		syncutil.RWMutex
+		// nanos, if not 0, is the amount of time the clock was manually incremented
+		// by; it is added to physicalClock.
+		nanos int64
+		// nanosAtPause records the timestamp of the physical clock when it gets
+		// paused. 0 means that the clock is not paused.
+		nanosAtPause int64
+	}
 }
 
 // NewHybridManualClock returns a new instance, initialized with
 // specified timestamp.
 func NewHybridManualClock() *HybridManualClock {
-	return &HybridManualClock{nanos: 0, physicalClock: UnixNano, nanosAtPause: 0}
+	return &HybridManualClock{physicalClock: UnixNano}
 }
 
 // UnixNano returns the underlying hybrid manual clock's timestamp.
 func (m *HybridManualClock) UnixNano() int64 {
-	nanosAtPause := atomic.LoadInt64(&m.nanosAtPause)
-	nanos := atomic.LoadInt64(&m.nanos)
+	m.mu.RLock()
+	nanosAtPause := m.mu.nanosAtPause
+	nanos := m.mu.nanos
+	m.mu.RUnlock()
 	if nanosAtPause > 0 {
 		return nanos + nanosAtPause
 	}
 	return nanos + m.physicalClock()
 }
 
-// Increment atomically increments the hybrid manual clock's timestamp.
-func (m *HybridManualClock) Increment(incr int64) {
-	atomic.AddInt64(&m.nanos, incr)
+// Increment increments the hybrid manual clock's timestamp.
+func (m *HybridManualClock) Increment(nanos int64) {
+	m.mu.Lock()
+	m.mu.nanos += nanos
+	m.mu.Unlock()
 }
 
-// Pause pauses the hybrid manual clock and forces it to always return the
-// current timestamp.
+// Pause pauses the hybrid manual clock; the passage of time no longer causes
+// the clock to tick. Increment can still be used, though.
 func (m *HybridManualClock) Pause() {
-	atomic.StoreInt64(&m.nanosAtPause, m.physicalClock())
+	m.mu.Lock()
+	m.mu.nanosAtPause = m.physicalClock()
+	m.mu.Unlock()
 }
 
 // UnixNano returns the local machine's physical nanosecond

--- a/pkg/util/hlc/hlc.go
+++ b/pkg/util/hlc/hlc.go
@@ -124,8 +124,7 @@ func (m *ManualClock) Set(nanos int64) {
 // ticks with the wall clock, but that can be moved arbitrarily
 // into the future or paused. HybridManualClock is thread safe.
 type HybridManualClock struct {
-	physicalClock func() int64
-	mu            struct {
+	mu struct {
 		syncutil.RWMutex
 		// nanos, if not 0, is the amount of time the clock was manually incremented
 		// by; it is added to physicalClock.
@@ -139,7 +138,7 @@ type HybridManualClock struct {
 // NewHybridManualClock returns a new instance, initialized with
 // specified timestamp.
 func NewHybridManualClock() *HybridManualClock {
-	return &HybridManualClock{physicalClock: UnixNano}
+	return &HybridManualClock{}
 }
 
 // UnixNano returns the underlying hybrid manual clock's timestamp.
@@ -151,7 +150,7 @@ func (m *HybridManualClock) UnixNano() int64 {
 	if nanosAtPause > 0 {
 		return nanos + nanosAtPause
 	}
-	return nanos + m.physicalClock()
+	return nanos + UnixNano()
 }
 
 // Increment increments the hybrid manual clock's timestamp.
@@ -165,7 +164,7 @@ func (m *HybridManualClock) Increment(nanos int64) {
 // the clock to tick. Increment can still be used, though.
 func (m *HybridManualClock) Pause() {
 	m.mu.Lock()
-	m.mu.nanosAtPause = m.physicalClock()
+	m.mu.nanosAtPause = UnixNano()
 	m.mu.Unlock()
 }
 

--- a/pkg/util/hlc/hlc.go
+++ b/pkg/util/hlc/hlc.go
@@ -119,6 +119,31 @@ func (m *ManualClock) Set(nanos int64) {
 	atomic.StoreInt64(&m.nanos, nanos)
 }
 
+// HybridManualClock is a convenience type to facilitate
+// creating a hybrid logical clock whose physical clock
+// ticks with the wall clock, but that can be moved arbitrarily
+// into the future. HybridManualClock is thread safe.
+type HybridManualClock struct {
+	nanos         int64
+	physicalClock func() int64
+}
+
+// NewHybridManualClock returns a new instance, initialized with
+// specified timestamp.
+func NewHybridManualClock() *HybridManualClock {
+	return &HybridManualClock{nanos: 0, physicalClock: UnixNano}
+}
+
+// UnixNano returns the underlying hybrid manual clock's timestamp.
+func (m *HybridManualClock) UnixNano() int64 {
+	return atomic.LoadInt64(&m.nanos) + m.physicalClock()
+}
+
+// Increment atomically increments the hybrid manual clock's timestamp.
+func (m *HybridManualClock) Increment(incr int64) {
+	atomic.AddInt64(&m.nanos, incr)
+}
+
 // UnixNano returns the local machine's physical nanosecond
 // unix epoch timestamp as a convenience to create a HLC via
 // c := hlc.NewClock(hlc.UnixNano, ...).

--- a/pkg/util/hlc/hlc_test.go
+++ b/pkg/util/hlc/hlc_test.go
@@ -374,6 +374,23 @@ func TestHybridManualClock(t *testing.T) {
 	require.LessOrEqual(t, UnixNano()+10, c.Now().WallTime)
 }
 
+// TestHybridManualClockPause test the Pause() functionality of the
+// HybridManualClock.
+func TestHybridManualClockPause(t *testing.T) {
+	m := NewHybridManualClock()
+	c := NewClock(m.UnixNano, time.Nanosecond)
+	now := c.Now().WallTime
+	time.Sleep(10 * time.Millisecond)
+	require.Less(t, now, c.Now().WallTime)
+	m.Pause()
+	now = c.Now().WallTime
+	require.Equal(t, now, c.Now().WallTime)
+	time.Sleep(10 * time.Millisecond)
+	require.Equal(t, now, c.Now().WallTime)
+	m.Increment(10)
+	require.Equal(t, now+10, c.Now().WallTime)
+}
+
 func TestHLCMonotonicityCheck(t *testing.T) {
 	m := NewManualClock(100000)
 	c := NewClock(m.UnixNano, 100*time.Nanosecond)

--- a/pkg/util/hlc/hlc_test.go
+++ b/pkg/util/hlc/hlc_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type Event uint8
@@ -353,6 +354,24 @@ func TestExampleManualClock(t *testing.T) {
 	if wallNanos := c.Now().WallTime; wallNanos != 20 {
 		t.Fatalf("unexpected wall time: %d", wallNanos)
 	}
+}
+
+// TestHybridManualClock test the basic functionality of the
+// TestHybridManualClock.
+func TestHybridManualClock(t *testing.T) {
+	m := NewHybridManualClock()
+	c := NewClock(m.UnixNano, time.Nanosecond)
+
+	// We do a two sided test to make sure that the physical clock matches
+	// the hybrid value. Since we cant pull a value off both clocks at the same
+	// time, we use two LessOrEqual comparisons with reverse order, to establish
+	// that the values are roughly equal.
+	require.LessOrEqual(t, c.Now().WallTime, UnixNano())
+	require.LessOrEqual(t, UnixNano(), c.Now().WallTime)
+
+	m.Increment(10)
+	require.LessOrEqual(t, c.Now().WallTime, UnixNano()+10)
+	require.LessOrEqual(t, UnixNano()+10, c.Now().WallTime)
 }
 
 func TestHLCMonotonicityCheck(t *testing.T) {


### PR DESCRIPTION
Backport 1/1 commits from #64324. Also backport necessary test infrastructure from #59059, #59086 (partial), #59333 (partial), and #64242.

/cc @cockroachdb/release @cockroachdb/kv

---

Replica removal did not synchronize with in-flight read-only requests,
which could cause them to be evaluated on a removed (empty) replica,
returning an empty result.

This patch fixes the problem by locking `Replica.readOnlyCmdMu` during
replica removal, thus either waiting for read-only requests to complete
or not evaluating them.

Resolves #64325.

Release note (bug fix): Fixed a race condition where read-only requests
during replica removal (e.g. during range merges or rebalancing) could
be evaluated on the removed replica, returning an empty result.