### PR TITLE
build: fix teamcity-nightly-roachtest.sh

### DIFF
--- a/build/teamcity-nightly-roachtest.sh
+++ b/build/teamcity-nightly-roachtest.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
+source "$(dirname "${0}")/teamcity-support.sh"
+
 # Entry point for the nightly roachtests. These are run from CI and require
 # appropriate secrets for the ${CLOUD} parameter (along with other things,
 # apologies, you're going to have to dig around for them below or even better


### PR DESCRIPTION
As of #64209, the script was failing when trying to upload the
`stats.json` files, as `tc_release_branch` was undefined. This
should fix that.

[Example of failing build](https://teamcity.cockroachdb.com/viewLog.html?buildId=2934234&buildTypeId=Cockroach_Nightlies_WorkloadNightly&tab=buildLog&branch_Cockroach_Nightlies=%3Cdefault%3E&_focus=10052)

Release note: None
