### PR TITLE
build: limit parallel processing during tests

### DIFF
--- a/build/teamcity-test.sh
+++ b/build/teamcity-test.sh
@@ -18,5 +18,23 @@ tc_end_block "Compile C dependencies"
 maybe_stress stress
 
 tc_start_block "Run Go tests"
-run_json_test build/builder.sh stdbuf -oL -eL make test GOTESTFLAGS=-json TESTFLAGS='-v'
+
+# Many of our tests start many goroutines that do a non-trivial amount
+# of work. Here, we limit the concurrent test programs that will be
+# run to 80% of the available CPU.
+GOTESTFLAGS="-json"
+if command -v nproc >/dev/null 2>&1; then
+    PROCCOUNT=$(nproc)
+    if [[ "$PROCCOUNT" -ge 4 ]]; then
+        MAXJOBS=$(echo "$PROCCOUNT*0.8/1" | bc)
+        echo "Setting -p $MAXJOBS (cpu count: $PROCCOUNT)"
+        GOTESTFLAGS="$GOTESTFLAGS -p $MAXJOBS"
+    else
+        echo "less than 4 CPUs, not setting -p flag"
+    fi
+else
+    echo "warning: nproc not found, not setting -p flag"
+fi
+
+run_json_test build/builder.sh stdbuf -oL -eL make test GOTESTFLAGS="$GOTESTFLAGS" TESTFLAGS="-v"
 tc_end_block "Run Go tests"


### PR DESCRIPTION
We've recently been seeing LogicTest fail in about 10% of runs. In
most cases these appear to be timeouts attempting to communicate
between nodes in the test cluster these tests run.

One recent suggestion was to limit the number of tests we run in
parallel. This commits does that by setting the `-p` flag to 80% of
the available CPUs.

In my local tests, this still results in saturation of the CPUs so
hopefully it doesn't slow down the total test time by too much.

Release note: None