### PR TITLE
importccl: parallelize the file upload in export csv

### DIFF
--- a/pkg/ccl/importccl/exportcsv.go
+++ b/pkg/ccl/importccl/exportcsv.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/storage/cloudimpl"
+	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding/csv"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
@@ -137,12 +138,22 @@ func newCSVWriterProcessor(
 		spec:        spec,
 		input:       input,
 		output:      output,
+		csvFileCh:   make(chan csvFile),
+		resCh:       make(chan csvFile),
+		emitResDone: make(chan struct{}),
 	}
 	semaCtx := tree.MakeSemaContext()
 	if err := c.out.Init(&execinfrapb.PostProcessSpec{}, c.OutputTypes(), &semaCtx, flowCtx.NewEvalCtx(), output); err != nil {
 		return nil, err
 	}
 	return c, nil
+}
+
+type csvFile struct {
+	filename string
+	content  []byte
+	size     int
+	rows     int64
 }
 
 type csvWriter struct {
@@ -152,6 +163,9 @@ type csvWriter struct {
 	input       execinfra.RowSource
 	out         execinfra.ProcOutputHelper
 	output      execinfra.RowReceiver
+	csvFileCh   chan csvFile
+	resCh       chan csvFile
+	emitResDone chan struct{}
 }
 
 var _ execinfra.Processor = &csvWriter{}
@@ -168,11 +182,98 @@ func (sp *csvWriter) MustBeStreaming() bool {
 	return false
 }
 
+func (sp *csvWriter) uploadCSVFile(ctx context.Context) error {
+	conf, err := cloudimpl.ExternalStorageConfFromURI(sp.spec.Destination, sp.spec.User())
+	if err != nil {
+		return err
+	}
+	es, err := sp.flowCtx.Cfg.ExternalStorage(sp.flowCtx.EvalCtx.Context, conf)
+	if err != nil {
+		return err
+	}
+
+	for file := range sp.csvFileCh {
+		if err := es.WriteFile(ctx, file.filename, bytes.NewReader(file.content)); err != nil {
+			return err
+		}
+		select {
+		case <-sp.emitResDone:
+			// Goroutine emitting the result rows has closed unexpectedly.
+			return nil
+		case sp.resCh <- file:
+		}
+	}
+	return nil
+}
+
+func (sp *csvWriter) emitResultRow(ctx context.Context) error {
+	for res := range sp.resCh {
+		res := rowenc.EncDatumRow{
+			rowenc.DatumToEncDatum(
+				types.String,
+				tree.NewDString(res.filename),
+			),
+			rowenc.DatumToEncDatum(
+				types.Int,
+				tree.NewDInt(tree.DInt(res.rows)),
+			),
+			rowenc.DatumToEncDatum(
+				types.Int,
+				tree.NewDInt(tree.DInt(res.size)),
+			),
+		}
+		cs, err := sp.out.EmitRow(ctx, res)
+		if err != nil {
+			return err
+		}
+		if cs != execinfra.NeedMoreRows {
+			// TODO(dt): presumably this is because our recv already closed due to
+			// another error... so do we really need another one?
+			return errors.New("unexpected closure of consumer")
+		}
+	}
+	return nil
+}
+
 func (sp *csvWriter) Run(ctx context.Context) {
 	ctx, span := tracing.ChildSpan(ctx, "csvWriter")
 	defer span.Finish()
 
+	numWorkers := 10
+	// Leave enough space for the upload workers and the goroutine emitting a row
+	// to buffer errors. We will only use the first when reporting an error.
+	errCh := make(chan error, numWorkers+1)
+	defer close(errCh)
+	group := ctxgroup.WithContext(ctx)
+	// Start workers responsible for uploading generated CSV files to external
+	// storage.
+	group.GoCtx(func(ctx context.Context) error {
+		// Once all the workers are done uploading files there will be no more
+		// result rows to be emitted.
+		defer close(sp.resCh)
+		return ctxgroup.GroupWorkers(ctx, numWorkers, func(ctx context.Context, _ int) error {
+			if err := sp.uploadCSVFile(ctx); err != nil {
+				errCh <- err
+				return err
+			}
+			return nil
+		})
+	})
+
+	// Start goroutine responsible for emitting rows corresponding to the files
+	// that have been uploaded by the above workers.
+	group.GoCtx(func(ctx context.Context) error {
+		defer close(sp.emitResDone)
+		if err := sp.emitResultRow(ctx); err != nil {
+			errCh <- err
+			return err
+		}
+		return nil
+	})
+
 	err := func() error {
+		// No more CSV files will be uploaded once this function returns.
+		defer close(sp.csvFileCh)
 		typs := sp.input.OutputTypes()
 		sp.input.Start(ctx)
 		input := execinfra.MakeNoMetadataRowSource(sp.input, sp.output)
@@ -237,16 +338,6 @@ func (sp *csvWriter) Run(ctx context.Context) {
 				return errors.Wrap(err, "failed to flush csv writer")
 			}
 
-			conf, err := cloudimpl.ExternalStorageConfFromURI(sp.spec.Destination, sp.spec.User())
-			if err != nil {
-				return err
-			}
-			es, err := sp.flowCtx.Cfg.ExternalStorage(ctx, conf)
-			if err != nil {
-				return err
-			}
-			defer es.Close()
-
 			nodeID, err := sp.flowCtx.EvalCtx.NodeID.OptionalNodeIDErr(47970)
 			if err != nil {
 				return err
@@ -263,33 +354,25 @@ func (sp *csvWriter) Run(ctx context.Context) {
 
 			size := writer.Len()
 
-			if err := es.WriteFile(ctx, filename, bytes.NewReader(writer.Bytes())); err != nil {
+			// Check for an error reported by the upload workers or goroutine emitting
+			// result rows. If an error is reported we can stop reading and converting
+			// chunks.
+			select {
+			case err := <-errCh:
 				return err
-			}
-			res := rowenc.EncDatumRow{
-				rowenc.DatumToEncDatum(
-					types.String,
-					tree.NewDString(filename),
-				),
-				rowenc.DatumToEncDatum(
-					types.Int,
-					tree.NewDInt(tree.DInt(rows)),
-				),
-				rowenc.DatumToEncDatum(
-					types.Int,
-					tree.NewDInt(tree.DInt(size)),
-				),
+			default:
 			}
 
-			cs, err := sp.out.EmitRow(ctx, res)
-			if err != nil {
-				return err
+			// Send CSV file to the upload workers.
+			f := csvFile{
+				filename: filename,
+				content:  make([]byte, len(writer.Bytes())),
+				size:     size,
+				rows:     rows,
 			}
-			if cs != execinfra.NeedMoreRows {
-				// TODO(dt): presumably this is because our recv already closed due to
-				// another error... so do we really need another one?
-				return errors.New("unexpected closure of consumer")
-			}
+			copy(f.content, writer.Bytes())
+			sp.csvFileCh <- f
+
 			if done {
 				break
 			}
@@ -297,7 +380,14 @@ func (sp *csvWriter) Run(ctx context.Context) {
 
 		return nil
 	}()
+	if err != nil {
+		_ = group.Wait()
+		execinfra.DrainAndClose(
+			ctx, sp.output, err, func(context.Context) {} /* pushTrailingMeta */, sp.input)
+		return
+	}
 
+	err = group.Wait()
 	// TODO(dt): pick up tracing info in trailing meta
 	execinfra.DrainAndClose(
 		ctx, sp.output, err, func(context.Context) {} /* pushTrailingMeta */, sp.input)

--- a/pkg/ccl/importccl/exportcsv_test.go
+++ b/pkg/ccl/importccl/exportcsv_test.go
@@ -424,11 +424,11 @@ func TestExportFeatureFlag(t *testing.T) {
 	sqlDB.Exec(t, `SET CLUSTER SETTING feature.export.enabled = FALSE`)
 	sqlDB.Exec(t, `CREATE TABLE feature_flags (a INT PRIMARY KEY)`)
 	sqlDB.ExpectErr(t, `feature EXPORT was disabled by the database administrator`,
-		`EXPORT INTO CSV 'nodelocal://0/%s/' FROM TABLE feature_flags`)
+		`EXPORT INTO CSV 'nodelocal://0/foo/' FROM TABLE feature_flags`)
 
 	// Feature flag is on — test that EXPORT does not error.
 	sqlDB.Exec(t, `SET CLUSTER SETTING feature.export.enabled = TRUE`)
-	sqlDB.Exec(t, `EXPORT INTO CSV 'nodelocal://0/%s/' FROM TABLE feature_flags`)
+	sqlDB.Exec(t, `EXPORT INTO CSV 'nodelocal://0/foo/' FROM TABLE feature_flags`)
 }
 
 func TestExportPrivileges(t *testing.T) {


### PR DESCRIPTION
This change parallelizes the stage of export where we upload
files to external storage. Benchmarks have shown that this
is where we spend the maximum amount of time. Adding parallelization
means that we increase the chances of OOMing since we do not
support streaming writes (yet). To protect against this, the
next commit will add a max file size guard.

Release note: None