### PR TITLE
release-21.1: colrpc: mark flow ctx cancellation in inbox as ungraceful

### DIFF
--- a/pkg/sql/colflow/colrpc/BUILD.bazel
+++ b/pkg/sql/colflow/colrpc/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/types",
+        "//pkg/util/cancelchecker",
         "//pkg/util/log",
         "//pkg/util/log/logcrash",
         "//pkg/util/timeutil",

--- a/pkg/sql/colflow/colrpc/inbox.go
+++ b/pkg/sql/colflow/colrpc/inbox.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/cancelchecker"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -215,8 +216,8 @@ func (i *Inbox) close() {
 }
 
 // RunWithStream sets the Inbox's stream and waits until either streamCtx is
-// canceled, a caller of Next cancels the first context passed into Next, or
-// an EOF is encountered on the stream by the Next goroutine.
+// canceled, a caller of Next cancels the first context passed into Next, or any
+// error is encountered on the stream by the Next goroutine.
 func (i *Inbox) RunWithStream(streamCtx context.Context, stream flowStreamServer) error {
 	streamCtx = logtags.AddTag(streamCtx, "streamID", i.streamID)
 	log.VEvent(streamCtx, 2, "Inbox handling stream")
@@ -234,15 +235,18 @@ func (i *Inbox) RunWithStream(streamCtx context.Context, stream flowStreamServer
 	case <-streamCtx.Done():
 		return fmt.Errorf("%s: streamCtx while waiting for reader (remote client canceled)", streamCtx.Err())
 	case <-i.flowCtx.Done():
-		// The inbox host canceled the stream meaning that it no longer needs
-		// any more data from the outbox. This is a graceful termination, so we
-		// return nil.
-		return nil
+		// The flow context of the inbox host has been canceled. This can occur
+		// e.g. when the query is canceled, or when another stream encountered
+		// an unrecoverable error forcing it to shutdown the flow.
+		return cancelchecker.QueryCanceledError
 	}
 
 	// Now wait for one of the events described in the method comment. If a
 	// cancellation is encountered, nothing special must be done to cancel the
 	// reader goroutine as returning from the handler will close the stream.
+	//
+	// Note that we don't listen for cancellation on flowCtx.Done() because
+	// readerCtx must be the child of the flow context.
 	select {
 	case err := <-i.errCh:
 		// nil will be read from errCh when the channel is closed.


### PR DESCRIPTION
We have recently fixed the shutdown of the gRPC streams used by DistSQL.
However, during the backport of that commit (which wasn't clean) I made
a suboptimal decision of treating the flow context cancellation during
the inbox setup as "graceful" termination of the stream - I believe it
should be treated as ungraceful (and this what we'll have on master).
This commit makes it so.

The difference between two is that if the termination of the stream is
ungraceful, the outbox (the client of the FlowStream RPC) will cancel
the flow context of its host whereas if the termination is graceful, the
outbox will only shutdown its own tree of components (by canceling its
own context). These things are equivalent from the correctness point of
view, but the former is more optimal way of shutting things down.

Release note: None