### PR TITLE
build: run logictests with optimizer cost perturbation

### DIFF
--- a/build/teamcity-opttest.sh
+++ b/build/teamcity-opttest.sh
@@ -38,3 +38,14 @@ run_json_test build/builder.sh \
   PKG=./pkg/sql/opt... \
   TESTFLAGS='-v'
 tc_end_block "Run opt tests with fast_int_set_small"
+
+# Run logic tests and perturb the cost of each expression by up to 90% to
+# randomize query plans.
+run_json_test build/builder.sh \
+  stdbuf -oL -eL \
+  make test \
+  GOTESTFLAGS=-json \
+  PKG=./pkg/sql/logictest \
+  TESTS='^TestLogic/local$$' \
+  TESTTIMEOUT='24h' \
+  TESTFLAGS='-optimizer-cost-perturbation=0.9'

--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -1,3 +1,5 @@
+# LogicTest: !metamorphic
+
 statement ok
 SET experimental_enable_hash_sharded_indexes = true
 

--- a/pkg/sql/logictest/testdata/logic_test/dist_vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/dist_vectorize
@@ -1,4 +1,4 @@
-# LogicTest: 5node 5node-disk
+# LogicTest: 5node 5node-disk !metamorphic
 
 statement ok
 CREATE TABLE kv (k INT PRIMARY KEY, v INT)

--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -1092,6 +1092,8 @@ CREATE TYPE local_type AS ENUM ('local');
 CREATE TABLE local_table (x INT);
 INSERT INTO local_table VALUES (1), (2)
 
+# Note: using EXPLAIN in this test without the !metamorphic directive at the top
+# of the file is acceptable because only the first row is printed.
 query T
 SELECT * FROM [EXPLAIN SELECT * FROM local_table] LIMIT 1
 ----
@@ -1106,6 +1108,8 @@ ALTER TYPE greeting RENAME TO greeting_local;
 CREATE TABLE local_table (x INT);
 INSERT INTO local_table VALUES (1), (2)
 
+# Note: using EXPLAIN in this test without the !metamorphic directive at the top
+# of the file is acceptable because only the first row is printed.
 query T
 SELECT * FROM [EXPLAIN SELECT * FROM local_table] LIMIT 1
 ----

--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -1,4 +1,4 @@
-# LogicTest: local local-vec-off local-spec-planning
+# LogicTest: local local-vec-off local-spec-planning !metamorphic
 
 statement ok
 CREATE TABLE t (a INT PRIMARY KEY)

--- a/pkg/sql/logictest/testdata/logic_test/explain_analyze
+++ b/pkg/sql/logictest/testdata/logic_test/explain_analyze
@@ -1,4 +1,4 @@
-# LogicTest: local fakedist fakedist-disk !local-spec-planning !fakedist-spec-planning
+# LogicTest: local fakedist fakedist-disk !local-spec-planning !fakedist-spec-planning !metamorphic
 #
 # TODO(yuzefovich): we run this file only with vectorize=on configs because
 # EXPLAIN ANALYZE (PLAN, VERBOSE) output differs depending on the execution

--- a/pkg/sql/logictest/testdata/logic_test/family
+++ b/pkg/sql/logictest/testdata/logic_test/family
@@ -1,3 +1,5 @@
+# LogicTest: !metamorphic
+
 # a is the primary key so b gets optimized into a one column value. The c, d
 # family has two columns, so it's encoded as a tuple
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/inverted_filter_geospatial_dist
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_filter_geospatial_dist
@@ -1,4 +1,4 @@
-# LogicTest: 5node
+# LogicTest: 5node !metamorphic
 
 statement ok
 CREATE TABLE geo_table(

--- a/pkg/sql/logictest/testdata/logic_test/inverted_filter_json_array_dist
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_filter_json_array_dist
@@ -1,4 +1,4 @@
-# LogicTest: 5node
+# LogicTest: 5node !metamorphic
 
 statement ok
 CREATE TABLE json_tab (

--- a/pkg/sql/logictest/testdata/logic_test/inverted_index_geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index_geospatial
@@ -1,4 +1,4 @@
-# LogicTest: local
+# LogicTest: local !metamorphic
 
 # SRID of the geometry column is unspecified, so default index bounds are used.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/inverted_join_geospatial_dist
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_join_geospatial_dist
@@ -1,4 +1,4 @@
-# LogicTest: 5node-default-configs !5node-metadata
+# LogicTest: 5node-default-configs !5node-metadata !metamorphic
 
 statement ok
 CREATE TABLE ltable(

--- a/pkg/sql/logictest/testdata/logic_test/inverted_join_multi_column_dist
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_join_multi_column_dist
@@ -1,4 +1,4 @@
-# LogicTest: 5node-default-configs !5node-metadata
+# LogicTest: 5node-default-configs !5node-metadata !metamorphic
 
 statement ok
 CREATE TABLE j1 (

--- a/pkg/sql/logictest/testdata/logic_test/merge_join_dist_vec
+++ b/pkg/sql/logictest/testdata/logic_test/merge_join_dist_vec
@@ -1,4 +1,4 @@
-# LogicTest: 5node
+# LogicTest: 5node !metamorphic
 
 # Regression test for #39317.
 

--- a/pkg/sql/logictest/testdata/logic_test/rename_column
+++ b/pkg/sql/logictest/testdata/logic_test/rename_column
@@ -122,13 +122,8 @@ username
 statement ok
 SET vectorize=on
 
-query T
+statement ok
 EXPLAIN ALTER TABLE users RENAME COLUMN species TO woo
-----
-distribution: local
-vectorized: true
-·
-• alter table
 
 statement ok
 RESET vectorize

--- a/pkg/sql/logictest/testdata/logic_test/rename_database
+++ b/pkg/sql/logictest/testdata/logic_test/rename_database
@@ -178,13 +178,8 @@ v          root  NULL  {}  NULL
 statement ok
 SET vectorize=on
 
-query T
+statement ok
 EXPLAIN ALTER DATABASE v RENAME TO x
-----
-distribution: local
-vectorized: true
-·
-• rename database
 
 statement ok
 RESET vectorize

--- a/pkg/sql/logictest/testdata/logic_test/rename_index
+++ b/pkg/sql/logictest/testdata/logic_test/rename_index
@@ -143,13 +143,8 @@ SELECT * FROM users@pk
 statement ok
 SET vectorize=on
 
-query T
+statement ok
 EXPLAIN ALTER INDEX users@bar RENAME TO woo
-----
-distribution: local
-vectorized: true
-·
-• rename index
 
 statement ok
 RESET vectorize

--- a/pkg/sql/logictest/testdata/logic_test/rename_table
+++ b/pkg/sql/logictest/testdata/logic_test/rename_table
@@ -254,13 +254,8 @@ public  kv  table  root  0  NULL
 statement ok
 SET vectorize=on
 
-query T
+statement ok
 EXPLAIN ALTER TABLE kv RENAME TO kv2
-----
-distribution: local
-vectorized: true
-·
-• rename table
 
 statement ok
 RESET vectorize

--- a/pkg/sql/logictest/testdata/logic_test/tpch_vec
+++ b/pkg/sql/logictest/testdata/logic_test/tpch_vec
@@ -1,4 +1,4 @@
-# LogicTest: local
+# LogicTest: local !metamorphic
 
 # Note that statistics are populated for TPCH Scale Factor 1.
 

--- a/pkg/sql/logictest/testdata/logic_test/truncate
+++ b/pkg/sql/logictest/testdata/logic_test/truncate
@@ -165,13 +165,8 @@ CREATE TABLE tt AS SELECT 'foo'
 statement ok
 SET vectorize=on
 
-query T
+statement ok
 EXPLAIN TRUNCATE TABLE tt
-----
-distribution: local
-vectorized: true
-·
-• truncate
 
 statement ok
 RESET vectorize

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_local
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_local
@@ -1,4 +1,4 @@
-# LogicTest: local
+# LogicTest: local !metamorphic
 
 statement ok
 CREATE TABLE a (a INT, b INT, c INT4, PRIMARY KEY (a, b))

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_overloads
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_overloads
@@ -1,4 +1,4 @@
-# LogicTest: local
+# LogicTest: local !metamorphic
 
 statement ok
 CREATE TABLE many_types (


### PR DESCRIPTION
#### logictest: use the statement directive for EXPLAIN tests

Some logic tests using the `query` directive for `EXPLAIN` queries now
use the `statement` directive. The `statement` directive if preferred in
these tests because they verify that `EXPLAIN` has no side-effects and
they are not concerned with `EXPLAIN` output. These tests will not fail
in future optimizer nightly builds that run logic tests with randomized
query plans.

Release note: None

#### build: run logictests with optimizer cost perturbation

Optimizer nightly builds now run logic tests while perturbing the cost
of each expression during query planning. By perturbing the cost of
expressions by up to 90%, the optimizer will choose alternate plans at
random. Running logic tests with alternate query plans may reveal
optimizer or execution bugs.

There are a number of logic tests that verify the output of `EXPLAIN`
queries. These tests would fail with cost perturbation. In order to
prevent these tests from failing, the `!metamorphic` blocklist directive
has been added to these files, and the directive has been extended such
that the `-optimizer-cost-perturbation` test flag is ignored for all
tests in the file.

Release note: None
