### PR TITLE
storage: make ExportMVCCToSST take a writer

### DIFF
--- a/pkg/ccl/storageccl/export.go
+++ b/pkg/ccl/storageccl/export.go
@@ -164,11 +164,13 @@ func evalExport(
 	useTBI := args.EnableTimeBoundIteratorOptimization && !args.StartTime.IsEmpty()
 	var curSizeOfExportedSSTs int64
 	for start := args.Key; start != nil; {
-		data, summary, resume, err := e.ExportMVCCToSst(start, args.EndKey, args.StartTime,
-			h.Timestamp, exportAllRevisions, targetSize, maxSize, useTBI)
+		destFile := &storage.MemFile{}
+		summary, resume, err := e.ExportMVCCToSst(start, args.EndKey, args.StartTime,
+			h.Timestamp, exportAllRevisions, targetSize, maxSize, useTBI, destFile)
 		if err != nil {
 			return result.Result{}, err
 		}
+		data := destFile.Data()
 
 		// NB: This should only happen on the first page of results. If there were
 		// more data to be read that lead to pagination then we'd see it in this

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -12,6 +12,7 @@ package spanset
 
 import (
 	"context"
+	"io"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -361,9 +362,10 @@ func (s spanSetReader) ExportMVCCToSst(
 	exportAllRevisions bool,
 	targetSize, maxSize uint64,
 	useTBI bool,
-) ([]byte, roachpb.BulkOpSummary, roachpb.Key, error) {
+	dest io.WriteCloser,
+) (roachpb.BulkOpSummary, roachpb.Key, error) {
 	return s.r.ExportMVCCToSst(startKey, endKey, startTS, endTS, exportAllRevisions, targetSize,
-		maxSize, useTBI)
+		maxSize, useTBI, dest)
 }
 
 func (s spanSetReader) MVCCGet(key storage.MVCCKey) ([]byte, error) {

--- a/pkg/storage/bench_test.go
+++ b/pkg/storage/bench_test.go
@@ -1352,11 +1352,16 @@ func runExportToSst(
 	for i := 0; i < b.N; i++ {
 		startTS := hlc.Timestamp{WallTime: int64(numRevisions / 2)}
 		endTS := hlc.Timestamp{WallTime: int64(numRevisions + 2)}
-		_, _, _, err := engine.ExportMVCCToSst(keys.LocalMax, roachpb.KeyMax, startTS, endTS,
-			exportAllRevisions, 0 /* targetSize */, 0 /* maxSize */, useTBI)
+		_, _, err := engine.ExportMVCCToSst(keys.LocalMax, roachpb.KeyMax, startTS, endTS,
+			exportAllRevisions, 0 /* targetSize */, 0 /* maxSize */, useTBI, noopWriter{})
 		if err != nil {
 			b.Fatal(err)
 		}
 	}
 	b.StopTimer()
 }
+
+type noopWriter struct{}
+
+func (noopWriter) Close() error                { return nil }
+func (noopWriter) Write(p []byte) (int, error) { return len(p), nil }

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -14,6 +14,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -364,7 +365,8 @@ type Reader interface {
 	ExportMVCCToSst(
 		startKey, endKey roachpb.Key, startTS, endTS hlc.Timestamp,
 		exportAllRevisions bool, targetSize uint64, maxSize uint64, useTBI bool,
-	) (sst []byte, _ roachpb.BulkOpSummary, resumeKey roachpb.Key, _ error)
+		dest io.WriteCloser,
+	) (_ roachpb.BulkOpSummary, resumeKey roachpb.Key, _ error)
 	// Get returns the value for the given key, nil otherwise. Semantically, it
 	// behaves as if an iterator with MVCCKeyAndIntentsIterKind was used.
 	//

--- a/pkg/storage/mvcc_incremental_iterator_test.go
+++ b/pkg/storage/mvcc_incremental_iterator_test.go
@@ -77,10 +77,11 @@ func assertExportedKVs(
 	useTBI bool,
 ) {
 	const big = 1 << 30
-	data, _, _, err := e.ExportMVCCToSst(startKey, endKey, startTime, endTime, revisions, big, big,
-		useTBI)
+	sstFile := &MemFile{}
+	_, _, err := e.ExportMVCCToSst(startKey, endKey, startTime, endTime, revisions, big, big,
+		useTBI, sstFile)
 	require.NoError(t, err)
-
+	data := sstFile.Data()
 	if data == nil {
 		require.Nil(t, expected)
 		return

--- a/pkg/storage/pebble_batch.go
+++ b/pkg/storage/pebble_batch.go
@@ -12,6 +12,7 @@ package storage
 
 import (
 	"context"
+	"io"
 	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -133,7 +134,8 @@ func (p *pebbleBatch) ExportMVCCToSst(
 	exportAllRevisions bool,
 	targetSize, maxSize uint64,
 	useTBI bool,
-) ([]byte, roachpb.BulkOpSummary, roachpb.Key, error) {
+	dest io.WriteCloser,
+) (roachpb.BulkOpSummary, roachpb.Key, error) {
 	panic("unimplemented")
 }
 

--- a/pkg/storage/sst_writer.go
+++ b/pkg/storage/sst_writer.go
@@ -38,6 +38,14 @@ type writeCloseSyncer interface {
 	Sync() error
 }
 
+type noopSync struct {
+	io.WriteCloser
+}
+
+func (noopSync) Sync() error {
+	return nil
+}
+
 // MakeBackupSSTWriter creates a new SSTWriter tailored for backup SSTs. These
 // SSTs have bloom filters disabled and format set to LevelDB.
 func MakeBackupSSTWriter(f writeCloseSyncer) SSTWriter {


### PR DESCRIPTION
This refactors ExportMVCCToSST to take a Writer argument instead of returning []byte.

The caller of it passes MemFile and then gets the []byte result out of the memfile,
just like ExportMVCCToSST did internally before.

Release note: none.