### PR TITLE
roachtest: allow overriding binaries for past versions

### DIFF
--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -161,6 +161,13 @@ type test struct {
 		status map[int64]testStatus
 		output []byte
 	}
+	// Map from version to path to the cockroach binary to be used when
+	// mixed-version test wants a binary for that binary. If a particular version
+	// <ver> is found in this map, it is used instead of the binary coming from
+	// `roachprod stage release <ver>`. See the --version-binary-override flags.
+	//
+	// Version strings look like "20.1.4".
+	versionsBinaryOverride map[string]string
 }
 
 func (t *test) Helper() {}

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -138,6 +138,10 @@ func (c clustersOpt) validate() error {
 	return nil
 }
 
+type testOpts struct {
+	versionsBinaryOverride map[string]string
+}
+
 // Run runs tests.
 //
 // Args:
@@ -155,7 +159,7 @@ func (r *testRunner) Run(
 	count int,
 	parallelism int,
 	clustersOpt clustersOpt,
-	artifactsDir string,
+	topt testOpts,
 	lopt loggingOpt,
 ) error {
 	// Validate options.
@@ -288,6 +292,7 @@ func (r *testRunner) Run(
 				clustersOpt.keepClustersOnTestFailure,
 				lopt.artifactsDir, lopt.runnerLogPath, lopt.tee, lopt.stdout,
 				allocateCluster,
+				topt,
 				l,
 			); err != nil {
 				// A worker returned an error. Let's shut down.
@@ -369,6 +374,7 @@ func (r *testRunner) runWorker(
 	teeOpt teeOptType,
 	stdout io.Writer,
 	allocateCluster clusterAllocatorFn,
+	topt testOpts,
 	l *logger,
 ) error {
 	ctx = logtags.AddTag(ctx, name, nil /* value */)
@@ -463,11 +469,12 @@ func (r *testRunner) runWorker(
 			return err
 		}
 		t := &test{
-			spec:          &testToRun.spec,
-			buildVersion:  r.buildVersion,
-			artifactsDir:  artifactsDir,
-			artifactsSpec: artifactsSpec,
-			l:             testL,
+			spec:                   &testToRun.spec,
+			buildVersion:           r.buildVersion,
+			artifactsDir:           artifactsDir,
+			artifactsSpec:          artifactsSpec,
+			l:                      testL,
+			versionsBinaryOverride: topt.versionsBinaryOverride,
 		}
 		// Tell the cluster that, from now on, it will be run "on behalf of this
 		// test".

--- a/pkg/cmd/roachtest/test_test.go
+++ b/pkg/cmd/roachtest/test_test.go
@@ -126,7 +126,7 @@ func TestRunnerRun(t *testing.T) {
 				keepClustersOnTestFailure: false,
 			}
 			err := runner.Run(ctx, tests, 1, /* count */
-				defaultParallelism, copt, "" /* artifactsDir */, lopt)
+				defaultParallelism, copt, testOpts{}, lopt)
 
 			if !testutils.IsError(err, c.expErr) {
 				t.Fatalf("expected err: %q, but found %v. Filters: %s", c.expErr, err, c.filters)
@@ -182,7 +182,7 @@ func TestRunnerTestTimeout(t *testing.T) {
 		},
 	}
 	err := runner.Run(ctx, []testSpec{test}, 1, /* count */
-		defaultParallelism, copt, "" /* artifactsDir */, lopt)
+		defaultParallelism, copt, testOpts{}, lopt)
 	if !testutils.IsError(err, "some tests failed") {
 		t.Fatalf("expected error \"some tests failed\", got: %v", err)
 	}
@@ -319,7 +319,7 @@ func TestRegistryMinVersion(t *testing.T) {
 			cr := newClusterRegistry()
 			runner := newTestRunner(cr, r.buildVersion)
 			err = runner.Run(ctx, tests, 1, /* count */
-				defaultParallelism, copt, "" /* artifactsDir */, lopt)
+				defaultParallelism, copt, testOpts{}, lopt)
 			if !testutils.IsError(err, c.expErr) {
 				t.Fatalf("expected err: %q, got: %v", c.expErr, err)
 			}


### PR DESCRIPTION
Many times I've wanted to be able to specify a locally-built binary to
be used by mixed-version tests as the old-version binary. Now you can,
through a new roachtest flag
--versions-binary-override=20.1.3=<path>,21.2.0=<path>.

Release note: None