### PR TITLE
release-20.1: roachtest: disable old ORM tests for 20.1 

### DIFF
--- a/pkg/cmd/roachtest/activerecord.go
+++ b/pkg/cmd/roachtest/activerecord.go
@@ -227,7 +227,7 @@ func registerActiveRecord(r *testRegistry) {
 	}
 
 	r.Add(testSpec{
-		MinVersion: "v20.1.0",
+		MinVersion: "v20.2.0",
 		Name:       "activerecord",
 		Owner:      OwnerAppDev,
 		Cluster:    makeClusterSpec(1),

--- a/pkg/cmd/roachtest/django.go
+++ b/pkg/cmd/roachtest/django.go
@@ -205,7 +205,7 @@ func registerDjango(r *testRegistry) {
 	}
 
 	r.Add(testSpec{
-		MinVersion: "v20.1.0",
+		MinVersion: "v20.2.0",
 		Name:       "django",
 		Owner:      OwnerAppDev,
 		Cluster:    makeClusterSpec(1, cpu(16)),

--- a/pkg/cmd/roachtest/gopg.go
+++ b/pkg/cmd/roachtest/gopg.go
@@ -146,7 +146,7 @@ func registerGopg(r *testRegistry) {
 		Name:       "gopg",
 		Owner:      OwnerAppDev,
 		Cluster:    makeClusterSpec(1),
-		MinVersion: "v19.2.0",
+		MinVersion: "v20.2.0",
 		Tags:       []string{`default`, `orm`},
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runGopg(ctx, t, c)

--- a/pkg/cmd/roachtest/libpq.go
+++ b/pkg/cmd/roachtest/libpq.go
@@ -130,7 +130,7 @@ func registerLibPQ(r *testRegistry) {
 	r.Add(testSpec{
 		Name:       "lib/pq",
 		Owner:      OwnerAppDev,
-		MinVersion: "v20.1.0",
+		MinVersion: "v20.2.0",
 		Cluster:    makeClusterSpec(1),
 		Tags:       []string{`default`, `driver`},
 		Run:        runLibPQ,

--- a/pkg/cmd/roachtest/pgx.go
+++ b/pkg/cmd/roachtest/pgx.go
@@ -125,7 +125,7 @@ func registerPgx(r *testRegistry) {
 		Name:       "pgx",
 		Owner:      OwnerAppDev,
 		Cluster:    makeClusterSpec(1),
-		MinVersion: "v19.2.0",
+		MinVersion: "v20.1.0",
 		Tags:       []string{`default`, `driver`},
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runPgx(ctx, t, c)


### PR DESCRIPTION
20.1 is ending maintenance support soon, and the latest version of
Django will not support v20.1.

fixes #62295
fixes https://github.com/cockroachdb/cockroach/issues/54338
fixes https://github.com/cockroachdb/cockroach/issues/53730
fixes https://github.com/cockroachdb/cockroach/issues/64113
fixes https://github.com/cockroachdb/cockroach/issues/64105

Release note: None