### PR TITLE
kvserver,sql,server: rework dependencies for `compact_engine_span`

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -465,11 +465,6 @@ func (ds *DistSender) FirstRange() (*roachpb.RangeDescriptor, error) {
 	return ds.firstRangeProvider.GetFirstRangeDescriptor()
 }
 
-// NodeDialer returns a Dialer.
-func (ds *DistSender) NodeDialer() *nodedialer.Dialer {
-	return ds.nodeDialer
-}
-
 // getNodeID attempts to return the local node ID. It returns 0 if the DistSender
 // does not have access to the Gossip network.
 func (ds *DistSender) getNodeID() roachpb.NodeID {

--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "allocator.go",
         "allocator_scorer.go",
         "cclglue.go",
+        "compact_span_client.go",
         "consistency_queue.go",
         "debug_print.go",
         "doc.go",

--- a/pkg/kv/kvserver/compact_span_client.go
+++ b/pkg/kv/kvserver/compact_span_client.go
@@ -1,0 +1,51 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package kvserver
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
+	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
+	"github.com/cockroachdb/errors"
+)
+
+// CompactEngineSpanClient is used to request compaction for a span
+// of data on a store.
+type CompactEngineSpanClient struct {
+	nd *nodedialer.Dialer
+}
+
+// NewCompactEngineSpanClient constructs a new CompactEngineSpanClient.
+func NewCompactEngineSpanClient(nd *nodedialer.Dialer) *CompactEngineSpanClient {
+	return &CompactEngineSpanClient{nd: nd}
+}
+
+// CompactEngineSpan is a tree.CompactEngineSpanFunc.
+func (c *CompactEngineSpanClient) CompactEngineSpan(
+	ctx context.Context, nodeID, storeID int32, startKey, endKey []byte,
+) error {
+	conn, err := c.nd.Dial(ctx, roachpb.NodeID(nodeID), rpc.DefaultClass)
+	if err != nil {
+		return errors.Wrapf(err, "could not dial node ID %d", nodeID)
+	}
+	client := NewPerStoreClient(conn)
+	req := &CompactEngineSpanRequest{
+		StoreRequestHeader: StoreRequestHeader{
+			NodeID:  roachpb.NodeID(nodeID),
+			StoreID: roachpb.StoreID(storeID),
+		},
+		Span: roachpb.Span{Key: roachpb.Key(startKey), EndKey: roachpb.Key(endKey)},
+	}
+	_, err = client.CompactEngineSpan(ctx, req)
+	return err
+}

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -147,6 +147,7 @@ go_library(
         "//pkg/util",
         "//pkg/util/contextutil",
         "//pkg/util/envutil",
+        "//pkg/util/errorutil",
         "//pkg/util/grpcutil",
         "//pkg/util/hlc",
         "//pkg/util/httputil",

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -2201,6 +2201,7 @@ func (ex *connExecutor) initEvalCtx(ctx context.Context, evalCtx *extendedEvalCo
 			DB:                 ex.server.cfg.DB,
 			SQLLivenessReader:  ex.server.cfg.SQLLivenessReader,
 			SQLStatsResetter:   ex.server,
+			CompactEngineSpan:  ex.server.cfg.CompactEngineSpanFunc,
 		},
 		SessionMutator:       ex.dataMutator,
 		VirtualSchemas:       ex.server.cfg.VirtualSchemas,

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -873,6 +873,10 @@ type ExecutorConfig struct {
 	// use this for normal purposes. It is to be used to establish any new
 	// root-level memory accounts that are not related to a user sessions.
 	RootMemoryMonitor *mon.BytesMonitor
+
+	// CompactEngineSpanFunc is used to inform a storage engine of the need to
+	// perform compaction over a key span.
+	CompactEngineSpanFunc tree.CompactEngineSpanFunc
 }
 
 // Organization returns the value of cluster.organization.

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -179,13 +179,6 @@ func (ep *DummyEvalPlanner) UnsafeDeleteNamespaceEntry(
 	return errors.WithStack(errEvalPlanner)
 }
 
-// CompactEngineSpan is part of the EvalPlanner interface.
-func (ep *DummyEvalPlanner) CompactEngineSpan(
-	ctx context.Context, nodeID int32, storeID int32, startKey []byte, endKey []byte,
-) error {
-	return errors.WithStack(errEvalPlanner)
-}
-
 // MemberOfWithAdminOption is part of the EvalPlanner interface.
 func (ep *DummyEvalPlanner) MemberOfWithAdminOption(
 	ctx context.Context, member security.SQLUsername,

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -17,10 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/kv"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/migration"
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
@@ -41,7 +38,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/cancelchecker"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
-	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/errors"
@@ -770,29 +766,6 @@ type txnModesSetter interface {
 	// transaction.
 	// asOfTs, if not empty, is the evaluation of modes.AsOf.
 	setTransactionModes(modes tree.TransactionModes, asOfTs hlc.Timestamp) error
-}
-
-// CompactEngineSpan is part of the EvalPlanner interface.
-func (p *planner) CompactEngineSpan(
-	ctx context.Context, nodeID int32, storeID int32, startKey []byte, endKey []byte,
-) error {
-	if !p.ExecCfg().Codec.ForSystemTenant() {
-		return errorutil.UnsupportedWithMultiTenancy(errorutil.FeatureNotAvailableToNonSystemTenantsIssue)
-	}
-	conn, err := p.ExecCfg().DistSender.NodeDialer().Dial(ctx, roachpb.NodeID(nodeID), rpc.DefaultClass)
-	if err != nil {
-		return errors.Wrapf(err, "could not dial node ID %d", nodeID)
-	}
-	client := kvserver.NewPerStoreClient(conn)
-	req := &kvserver.CompactEngineSpanRequest{
-		StoreRequestHeader: kvserver.StoreRequestHeader{
-			NodeID:  roachpb.NodeID(nodeID),
-			StoreID: roachpb.StoreID(storeID),
-		},
-		Span: roachpb.Span{Key: roachpb.Key(startKey), EndKey: roachpb.Key(endKey)},
-	}
-	_, err = client.CompactEngineSpan(ctx, req)
-	return err
 }
 
 // validateDescriptor is a convenience function for validating

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -4972,7 +4972,7 @@ may increase either contention or retry errors, or both.`,
 				storeID := int32(tree.MustBeDInt(args[1]))
 				startKey := []byte(tree.MustBeDBytes(args[2]))
 				endKey := []byte(tree.MustBeDBytes(args[3]))
-				if err := ctx.Planner.CompactEngineSpan(
+				if err := ctx.CompactEngineSpan(
 					ctx.Context, nodeID, storeID, startKey, endKey); err != nil {
 					return nil, err
 				}

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3102,14 +3102,6 @@ type EvalPlanner interface {
 		force bool,
 	) error
 
-	// CompactEngineSpan is used to compact an engine key span at the given
-	// (nodeID, storeID). If we add more overloads to the compact_span builtin,
-	// this parameter list should be changed to a struct union to accommodate
-	// those overloads.
-	CompactEngineSpan(
-		ctx context.Context, nodeID int32, storeID int32, startKey []byte, endKey []byte,
-	) error
-
 	// MemberOfWithAdminOption is used to collect a list of roles (direct and
 	// indirect) that the member is part of. See the comment on the planner
 	// implementation in authorization.go
@@ -3118,6 +3110,14 @@ type EvalPlanner interface {
 		member security.SQLUsername,
 	) (map[security.SQLUsername]bool, error)
 }
+
+// CompactEngineSpanFunc is used to compact an engine key span at the given
+// (nodeID, storeID). If we add more overloads to the compact_span builtin,
+// this parameter list should be changed to a struct union to accommodate
+// those overloads.
+type CompactEngineSpanFunc func(
+	ctx context.Context, nodeID, storeID int32, startKey, endKey []byte,
+) error
 
 // EvalSessionAccessor is a limited interface to access session variables.
 type EvalSessionAccessor interface {
@@ -3425,6 +3425,9 @@ type EvalContext struct {
 	SQLLivenessReader sqlliveness.Reader
 
 	SQLStatsResetter SQLStatsResetter
+
+	// CompactEngineSpan is used to force compaction of a span in a store.
+	CompactEngineSpan CompactEngineSpanFunc
 }
 
 // MakeTestingEvalContext returns an EvalContext that includes a MemoryMonitor.


### PR DESCRIPTION
The usage of `kvserver` in the `sql` package is generally forbidden.
The tests to enforce that were broken. This patch reworks the
dependency to move the business logic into the `kvserver` package.

Part of #64450.

Release note: None