### PR TITLE
release-21.1: colencoding: no memory aliasing during key decode

### DIFF
--- a/pkg/sql/colencoding/key_encoding.go
+++ b/pkg/sql/colencoding/key_encoding.go
@@ -33,8 +33,7 @@ import (
 // tenant id and first table id / index id prefix removed. If matches is false,
 // the key is from a different table, and the returned remainingKey indicates a
 // "seek prefix": the next key that might be part of the table being searched
-// for. The input key will also be mutated if matches is false. See the analog
-// in sqlbase/index_encoding.go.
+// for. See the analog in sqlbase/index_encoding.go.
 func DecodeIndexKeyToCols(
 	da *rowenc.DatumAlloc,
 	vecs []coldata.Vec,
@@ -66,7 +65,8 @@ func DecodeIndexKeyToCols(
 					// We don't match. Return a key with the table ID / index ID we're
 					// searching for, so the caller knows what to seek to.
 					curPos := len(origKey) - len(key)
-					key = rowenc.EncodePartialTableIDIndexID(origKey[:curPos], ancestor.TableID, ancestor.IndexID)
+					// Prevent unwanted aliasing on the origKey by setting the capacity.
+					key = rowenc.EncodePartialTableIDIndexID(origKey[:curPos:curPos], ancestor.TableID, ancestor.IndexID)
 					return key, false, false, nil
 				}
 			}
@@ -92,7 +92,8 @@ func DecodeIndexKeyToCols(
 				// We're expecting an interleaved sentinel but didn't find one. Append
 				// one so the caller can seek to it.
 				curPos := len(origKey) - len(key)
-				key = encoding.EncodeInterleavedSentinel(origKey[:curPos])
+				// Prevent unwanted aliasing on the origKey by setting the capacity.
+				key = encoding.EncodeInterleavedSentinel(origKey[:curPos:curPos])
 				return key, false, false, nil
 			}
 		}
@@ -105,7 +106,8 @@ func DecodeIndexKeyToCols(
 			// We don't match. Return a key with the table ID / index ID we're
 			// searching for, so the caller knows what to seek to.
 			curPos := len(origKey) - len(key)
-			key = rowenc.EncodePartialTableIDIndexID(origKey[:curPos], desc.GetID(), index.ID)
+            // Prevent unwanted aliasing on the origKey by setting the capacity.
+			key = rowenc.EncodePartialTableIDIndexID(origKey[:curPos:curPos], desc.GetID(), index.ID)
 			return key, false, false, nil
 		}
 	}
@@ -124,7 +126,8 @@ func DecodeIndexKeyToCols(
 	// table.
 	if _, ok := encoding.DecodeIfInterleavedSentinel(key); ok {
 		curPos := len(origKey) - len(key)
-		key = encoding.EncodeNullDescending(origKey[:curPos])
+		// Prevent unwanted aliasing on the origKey by setting the capacity.
+		key = encoding.EncodeNullDescending(origKey[:curPos:curPos])
 		return key, false, false, nil
 	}
 


### PR DESCRIPTION
Backports #64374.

Previously, some interleaved tables could put the database into a bad
state due to memory aliasing during key decode. This problem is now
corrected.

Release note (bug fix): prevent a rare crash that could occur when
reading data from interleaved tables.