### PR TITLE
bazel: prefer `exec_tools` to `tools` in `BUILD` files

### DIFF
--- a/pkg/cmd/roachprod/vm/aws/BUILD.bazel
+++ b/pkg/cmd/roachprod/vm/aws/BUILD.bazel
@@ -31,7 +31,7 @@ genrule(
     cmd = """
       $(location //pkg/cmd/roachprod/vm/aws/terraformgen) -o $@
     """,
-    tools = ["//pkg/cmd/roachprod/vm/aws/terraformgen"],
+    exec_tools = ["//pkg/cmd/roachprod/vm/aws/terraformgen"],
 )
 
 bindata(

--- a/pkg/col/coldata/BUILD.bazel
+++ b/pkg/col/coldata/BUILD.bazel
@@ -62,7 +62,7 @@ genrule(
         -fmt=false pkg/col/coldata/$@ > $@
       $(location @com_github_cockroachdb_gostdlib//x/tools/cmd/goimports) -w $@
     """,
-    tools = [
+    exec_tools = [
         "//pkg/sql/colexec/execgen/cmd/execgen",
         "@com_github_cockroachdb_gostdlib//x/tools/cmd/goimports",
     ],

--- a/pkg/geo/wkt/BUILD.bazel
+++ b/pkg/geo/wkt/BUILD.bazel
@@ -38,7 +38,7 @@ genrule(
     cat $(location wkt_generated.go) | sed -e 's/wktErrorVerbose = false/wktErrorVerbose = true/' > wkt_generated.go.tmp
     mv wkt_generated.go.tmp $(location wkt_generated.go)
     """,
-    tools = [
+    exec_tools = [
         "@org_golang_x_tools//cmd/goyacc",
     ],
 )

--- a/pkg/sql/opt/BUILD.bazel
+++ b/pkg/sql/opt/BUILD.bazel
@@ -73,7 +73,7 @@ genrule(
     cmd = """
       $(location //pkg/sql/opt/optgen/cmd/optgen) -out $@ ops $(locations :ops)
     """,
-    tools = ["//pkg/sql/opt/optgen/cmd/optgen"],
+    exec_tools = ["//pkg/sql/opt/optgen/cmd/optgen"],
 )
 
 # Define the generator for the enumeration of rulenames.
@@ -89,7 +89,7 @@ genrule(
       $(location //pkg/sql/opt/optgen/cmd/optgen) -out $@ rulenames \
           $(locations :ops) $(locations //pkg/sql/opt/norm:rules) $(locations //pkg/sql/opt/xform:rules)
     """,
-    tools = ["//pkg/sql/opt/optgen/cmd/optgen"],
+    exec_tools = ["//pkg/sql/opt/optgen/cmd/optgen"],
 )
 
 # Define the generator for the stringification of rulenames.
@@ -116,7 +116,7 @@ genrule(
       $(location @org_golang_x_tools//cmd/stringer:stringer) -output=$@ \
       -type=RuleName `dirname $(location :gen-rulenames)`/rule_name.go $(location :gen-rulenames)
     """,
-    tools = [
+    exec_tools = [
         "@go_sdk//:bin/go",
         "@org_golang_x_tools//cmd/stringer",
     ],

--- a/pkg/sql/opt/exec/BUILD.bazel
+++ b/pkg/sql/opt/exec/BUILD.bazel
@@ -42,5 +42,5 @@ genrule(
     cmd = """
       $(location //pkg/sql/opt/optgen/cmd/optgen) -out $@ execfactory $(locations :defs)
     """,
-    tools = ["//pkg/sql/opt/optgen/cmd/optgen"],
+    exec_tools = ["//pkg/sql/opt/optgen/cmd/optgen"],
 )

--- a/pkg/sql/opt/exec/explain/BUILD.bazel
+++ b/pkg/sql/opt/exec/explain/BUILD.bazel
@@ -76,5 +76,5 @@ genrule(
     cmd = """
       $(location //pkg/sql/opt/optgen/cmd/optgen) -out $@ execexplain $(locations //pkg/sql/opt/exec:defs)
     """,
-    tools = ["//pkg/sql/opt/optgen/cmd/optgen"],
+    exec_tools = ["//pkg/sql/opt/optgen/cmd/optgen"],
 )

--- a/pkg/sql/opt/memo/BUILD.bazel
+++ b/pkg/sql/opt/memo/BUILD.bazel
@@ -101,6 +101,6 @@ genrule(
     cmd = """
       $(location //pkg/sql/opt/optgen/cmd/optgen) -out $@ exprs $(locations //pkg/sql/opt:ops)
     """,
-    tools = ["//pkg/sql/opt/optgen/cmd/optgen"],
+    exec_tools = ["//pkg/sql/opt/optgen/cmd/optgen"],
     visibility = ["//visibility:public"],
 )

--- a/pkg/sql/opt/norm/BUILD.bazel
+++ b/pkg/sql/opt/norm/BUILD.bazel
@@ -104,5 +104,5 @@ genrule(
     cmd = """
       $(location //pkg/sql/opt/optgen/cmd/optgen) -out $@ factory $(locations //pkg/sql/opt:ops) $(locations :rules)
     """,
-    tools = ["//pkg/sql/opt/optgen/cmd/optgen"],
+    exec_tools = ["//pkg/sql/opt/optgen/cmd/optgen"],
 )

--- a/pkg/sql/opt/optgen/lang/BUILD.bazel
+++ b/pkg/sql/opt/optgen/lang/BUILD.bazel
@@ -68,7 +68,7 @@ genrule(
     cmd = """
       $(location //pkg/sql/opt/optgen/cmd/langgen) -out $@ exprs $(location lang.opt)
     """,
-    tools = ["//pkg/sql/opt/optgen/cmd/langgen"],
+    exec_tools = ["//pkg/sql/opt/optgen/cmd/langgen"],
 )
 
 genrule(
@@ -78,7 +78,7 @@ genrule(
     cmd = """
       $(location //pkg/sql/opt/optgen/cmd/langgen) -out $@ ops $(location lang.opt)
     """,
-    tools = ["//pkg/sql/opt/optgen/cmd/langgen"],
+    exec_tools = ["//pkg/sql/opt/optgen/cmd/langgen"],
 )
 
 stringer(

--- a/pkg/sql/opt/xform/BUILD.bazel
+++ b/pkg/sql/opt/xform/BUILD.bazel
@@ -106,5 +106,5 @@ genrule(
     cmd = """
       $(location //pkg/sql/opt/optgen/cmd/optgen) -out $@ explorer $(locations //pkg/sql/opt:ops) $(locations :rules)
     """,
-    tools = ["//pkg/sql/opt/optgen/cmd/optgen"],
+    exec_tools = ["//pkg/sql/opt/optgen/cmd/optgen"],
 )

--- a/pkg/sql/parser/BUILD.bazel
+++ b/pkg/sql/parser/BUILD.bazel
@@ -85,7 +85,7 @@ genrule(
           $(location sql.go) $(location @org_golang_x_tools//cmd/goyacc) \
           $(location @com_github_cockroachdb_gostdlib//x/tools/cmd/goimports)
     """,
-    tools = [
+    exec_tools = [
         ":sql-gen",
         "@com_github_cockroachdb_gostdlib//x/tools/cmd/goimports",
         "@org_golang_x_tools//cmd/goyacc",
@@ -110,7 +110,7 @@ genrule(
       $(location :help-gen-test) < $< >$@.tmp
       mv -f $@.tmp $@
     """,
-    tools = [
+    exec_tools = [
         ":help-gen-test",
     ],
 )

--- a/pkg/sql/schemachange/BUILD.bazel
+++ b/pkg/sql/schemachange/BUILD.bazel
@@ -61,7 +61,7 @@ genrule(
        env PATH=$$GO_ABS_PATH HOME=$(GENDIR) \
        $(location @org_golang_x_tools//cmd/stringer:stringer) -output=$@ -type=ColumnConversionKind -trimprefix ColumnConversion $<
     """,
-    tools = [
+    exec_tools = [
         "@go_sdk//:bin/go",
         "@org_golang_x_tools//cmd/stringer",
     ],

--- a/pkg/util/encoding/BUILD.bazel
+++ b/pkg/util/encoding/BUILD.bazel
@@ -87,7 +87,7 @@ genrule(
        env PATH=$$GO_ABS_PATH HOME=$(GENDIR) \
          $(location @org_golang_x_tools//cmd/stringer:stringer) -output=$@ -type=Type encoding_tmp.go
     """,
-    tools = [
+    exec_tools = [
         "@go_sdk//:bin/go",
         "@org_golang_x_tools//cmd/stringer",
     ],


### PR DESCRIPTION
The [documentation](https://docs.bazel.build/versions/master/be/general.html#genrule_args)
specifies that `exec_tools` is preferred to `tools` wherever possible.
It doesn't matter in our case, so let's just standardize on `exec_tools`
everywhere.

Release note: None