### PR TITLE
release-20.2: use uPlot lib for line graphs on metrics page

### DIFF
--- a/pkg/ui/ccl/src/views/clusterviz/components/nodeOrLocality/capacityArc.tsx
+++ b/pkg/ui/ccl/src/views/clusterviz/components/nodeOrLocality/capacityArc.tsx
@@ -15,7 +15,11 @@ import {
   MAIN_BLUE,
 } from "src/views/shared/colors";
 import { Bytes } from "src/util/format";
-import { NodeArcPercentageTooltip, NodeArcUsedCapacityTooltip, NodeArcTotalCapacityTooltip } from "src/views/clusterviz/components/nodeOrLocality/tooltips.tsx";
+import {
+  NodeArcPercentageTooltip,
+  NodeArcUsedCapacityTooltip,
+  NodeArcTotalCapacityTooltip,
+} from "src/views/clusterviz/components/nodeOrLocality/tooltips";
 
 const ARC_INNER_RADIUS = 56;
 const ARC_WIDTH = 6;

--- a/pkg/ui/package.json
+++ b/pkg/ui/package.json
@@ -127,6 +127,7 @@
     "ts-loader": "^6.2.1",
     "tslint": "^5.10.0",
     "typescript": "4.2.4",
+    "uplot": "^1.6.8",
     "url-loader": "2.1.0",
     "us-atlas": "^1.0.2",
     "webpack": "^4.41.5",

--- a/pkg/ui/package.json
+++ b/pkg/ui/package.json
@@ -126,7 +126,7 @@
     "topojson": "^3.0.2",
     "ts-loader": "^6.2.1",
     "tslint": "^5.10.0",
-    "typescript": "^3.7.2",
+    "typescript": "4.2.4",
     "url-loader": "2.1.0",
     "us-atlas": "^1.0.2",
     "webpack": "^4.41.5",

--- a/pkg/ui/src/redux/queryManager/saga.ts
+++ b/pkg/ui/src/redux/queryManager/saga.ts
@@ -217,6 +217,7 @@ export function *processQueryManagementAction(state: ManagedQuerySagaState) {
  * when the query is being executed.
  */
 export function *refreshQuery(state: ManagedQuerySagaState) {
+    // @ts-ignore
     const queryTask = yield fork(runQuery, state);
     while (queryTask.isRunning()) {
         // While the query is running, we still need to increment or
@@ -237,12 +238,14 @@ export function *waitForNextRefresh(state: ManagedQuerySagaState) {
     // If this query should be auto-refreshed, compute the time until
     // the query is out of date. If the request is already out of date,
     // refresh the query immediately.
+    // @ts-ignore
     const delayTime = yield call(timeToNextRefresh, state);
     if (delayTime <= 0) {
         state.shouldRefreshQuery = true;
         return;
     }
 
+    // @ts-ignore
     const delayTask = yield fork(delayGenerator, delayTime);
     while (delayTask.isRunning()) {
         yield race({

--- a/pkg/ui/src/util/convert.ts
+++ b/pkg/ui/src/util/convert.ts
@@ -19,6 +19,17 @@ export function NanoToMilli(nano: number): number {
   return nano / 1.0e6;
 }
 
+export function MilliToSeconds(milli: number): number {
+  return milli / 1.0e3;
+}
+
+/**
+ * NanoToSeconds converts a nanoseconds value into seconds.
+ */
+export function NanoToSeconds(nano: number): number {
+  return nano / 1.0e9;
+}
+
 /**
  * MilliToNano converts a millisecond value into nanoseconds.
  */

--- a/pkg/ui/src/views/cluster/components/linegraph/index.tsx
+++ b/pkg/ui/src/views/cluster/components/linegraph/index.tsx
@@ -14,18 +14,34 @@ import moment from "moment";
 import * as nvd3 from "nvd3";
 import { createSelector } from "reselect";
 
-import * as protos from  "src/js/protos";
+import * as protos from "src/js/protos";
 import { HoverState, hoverOn, hoverOff } from "src/redux/hover";
 import { findChildrenOfType } from "src/util/find";
 import {
-  ConfigureLineChart, InitLineChart, CHART_MARGINS, ConfigureLinkedGuideline,
+  AxisDomain,
+  calculateXAxisDomain,
+  calculateYAxisDomain,
+  CHART_MARGINS,
+  ConfigureLineChart,
+  ConfigureLinkedGuideline,
+  configureUPlotLineChart,
+  InitLineChart,
 } from "src/views/cluster/util/graphs";
 import {
-  Metric, MetricProps, Axis, AxisProps, QueryTimeInfo,
+  Axis,
+  AxisProps,
+  Metric,
+  MetricProps,
+  MetricsDataComponentProps,
+  QueryTimeInfo,
 } from "src/views/shared/components/metricQuery";
-import { MetricsDataComponentProps } from "src/views/shared/components/metricQuery";
 import Visualization from "src/views/cluster/components/visualization";
-import { NanoToMilli } from "src/util/convert";
+import { MilliToSeconds, NanoToMilli } from "src/util/convert";
+import uPlot from "uplot";
+import "uplot/dist/uPlot.min.css";
+import { findClosestTimeScale } from "src/redux/timewindow";
+import TimeSeriesQueryResponse = cockroach.ts.tspb.TimeSeriesQueryResponse;
+import {cockroach} from "src/js/protos";
 
 type TSResponse = protos.cockroach.ts.tspb.TimeSeriesQueryResponse;
 
@@ -40,7 +56,7 @@ interface LineGraphProps extends MetricsDataComponentProps {
   hoverState?: HoverState;
 }
 
-interface LineGraphState {
+interface LineGraphStateOld {
   lastData?: TSResponse;
   lastTimeInfo?: QueryTimeInfo;
 }
@@ -50,7 +66,10 @@ interface LineGraphState {
  * supports a single Y-axis, but multiple metrics can be graphed on the same
  * axis.
  */
-export class LineGraph extends React.Component<LineGraphProps, LineGraphState> {
+export class LineGraphOld extends React.Component<
+  LineGraphProps,
+  LineGraphStateOld
+> {
   // The SVG Element reference in the DOM used to render the graph.
   graphEl: React.RefObject<SVGSVGElement> = React.createRef();
 
@@ -236,6 +255,227 @@ export class LineGraph extends React.Component<LineGraphProps, LineGraphState> {
       <Visualization title={title} subtitle={subtitle} tooltip={tooltip} loading={!data} >
         <div className="linegraph">
           <svg className="graph linked-guideline" ref={this.graphEl} {...hoverProps} />
+        </div>
+      </Visualization>
+    );
+  }
+}
+
+// touPlot formats our timeseries data into the format
+// uPlot expects which is a 2-dimensional array where the
+// first array contains the x-values (time).
+function touPlot(data: TimeSeriesQueryResponse): any {
+  // Here's an example of what this code is attempting to control for.
+  // We produce `result` series that contain their own x-values. uPlot
+  // expects *one* x-series that all y-values match up to. So first we
+  // need to take the union of all timestamps across all series, and then
+  // produce y-values that match up to those. Any missing values will
+  // be set to null and uPlot expects that.
+  //
+  // our data: [
+  //   [(11:00, 1),             (11:05, 2),  (11:06, 3), (11:10, 4),           ],
+  //   [(11:00, 1), (11:03, 20),             (11:06, 7),            (11:11, 40)],
+  // ]
+  //
+  // for uPlot: [
+  //   [11:00, 11:03, 11:05, 11:06, 11:10, 11:11]
+  //   [1, null, 2, 3, 4, null],
+  //   [1, 20, null, 7, null, 40],
+  // ]
+  if (!data || !data.results) {
+    return [];
+  }
+
+  const xValuesComplete: number[] = [
+    ...new Set(
+      data.results.flatMap((result) =>
+        result.datapoints.map((d) => d.timestamp_nanos.toNumber()),
+      ),
+    ),
+  ].sort((a, b) => a - b);
+
+  const yValuesComplete: (number | null)[][] = data.results.map((result) => {
+    return xValuesComplete.map((ts) => {
+      const found = result.datapoints.find(
+        (dp) => dp.timestamp_nanos.toNumber() === ts,
+      );
+      return found ? found.value : null;
+    });
+  });
+
+  return [xValuesComplete.map((ts) => NanoToMilli(ts)), ...yValuesComplete];
+}
+
+// LineGraph wraps the uPlot library into a React component
+// when the component is first initialized, we wait until
+// data is available and then construct the uPlot object
+// and store its ref in a global variable.
+// Once we receive updates to props, we push new data to the
+// uPlot object.
+export class LineGraph extends React.Component<LineGraphProps, {}> {
+  // axis is copied from the nvd3 LineGraph component above
+  axis = createSelector(
+    (props: { children?: React.ReactNode }) => props.children,
+    (children) => {
+      const axes: React.ReactElement<AxisProps>[] = findChildrenOfType(
+        children as any,
+        Axis,
+      );
+      if (axes.length === 0) {
+        console.warn(
+          "LineGraph requires the specification of at least one axis.",
+        );
+        return null;
+      }
+      if (axes.length > 1) {
+        console.warn(
+          "LineGraph currently only supports a single axis; ignoring additional axes.",
+        );
+      }
+      return axes[0];
+    },
+  );
+
+  // metrics is copied from the nvd3 LineGraph component above
+  metrics = createSelector(
+    (props: { children?: React.ReactNode }) => props.children,
+    (children) => {
+      return findChildrenOfType(
+        children as any,
+        Metric,
+      ) as React.ReactElement<MetricProps>[];
+    },
+  );
+
+  u: uPlot;
+  el = React.createRef<HTMLDivElement>();
+
+  // yAxisDomain holds our computed AxisDomain object
+  // for the y Axis. The function to compute this was
+  // created to support the prior iteration
+  // of our line graphs. We recompute it manually
+  // when data changes, and uPlot options have access
+  // to a closure that holds a reference to this value.
+  yAxisDomain: AxisDomain;
+
+  // xAxisDomain holds our computed AxisDomain object
+  // for the x Axis. The function to compute this was
+  // created to support the prior iteration
+  // of our line graphs. We recompute it manually
+  // when data changes, and uPlot options have access
+  // to a closure that holds a reference to this value.
+  xAxisDomain: AxisDomain;
+
+  constructor(props: LineGraphProps) {
+    super(props);
+
+    this.setNewTimeRange = this.setNewTimeRange.bind(this);
+  }
+
+  // setNewTimeRange uses code from the TimeScaleDropdown component
+  // to set new start/end ranges in the query params and force a
+  // reload of the rest of the dashboard at new ranges via the props
+  // `setTimeRange` and `setTimeScale`.
+  // TODO(davidh): centralize management of query params for time range
+  // TODO(davidh): figure out why the timescale doesn't get more granular
+  // automatically when a narrower time frame is selected.
+  setNewTimeRange(startMillis: number, endMillis: number) {
+    const start = MilliToSeconds(startMillis);
+    // Enforce 10m minimum range from start
+    const end = Math.max(start + 600, MilliToSeconds(endMillis));
+    this.props.setTimeRange({
+      start: moment.unix(start),
+      end: moment.unix(end),
+    });
+    const newTimeScale = findClosestTimeScale(end - start);
+    this.props.setTimeScale(newTimeScale);
+    const { pathname, search } = this.props.history.location;
+    const urlParams = new URLSearchParams(search);
+
+    urlParams.set("start", moment.unix(start).format("X"));
+    urlParams.set("end", moment.unix(end).format("X"));
+
+    this.props.history.push({
+      pathname,
+      search: urlParams.toString(),
+    });
+  }
+
+  componentDidUpdate(prevProps: Readonly<LineGraphProps>) {
+    if (
+      // data was missing last time or we already have a `u`
+      // the latter could happen if we click away to a
+      // different dashboard and then back to one we had
+      // open previously.
+      (!prevProps.data || !this.u) &&
+      this.props.data &&
+      this.props.data.results
+    ) {
+      const data = this.props.data;
+      const metrics = this.metrics(this.props);
+      const axis = this.axis(this.props);
+      const uPlotData = touPlot(data);
+      this.yAxisDomain = calculateYAxisDomain(axis.props.units, data);
+      this.xAxisDomain = calculateXAxisDomain(this.props.timeInfo);
+
+      const options = configureUPlotLineChart(
+        metrics,
+        axis,
+        data,
+        this.setNewTimeRange,
+        () => this.xAxisDomain,
+        () => this.yAxisDomain,
+      );
+
+      this.u = new uPlot(options, uPlotData, this.el.current);
+    }
+    if (this.u && this.props.data && prevProps.data !== this.props.data) {
+      const axis = this.axis(this.props);
+      // The values of `this.yAxisDomain` and `this.xAxisDomain`
+      // are captured in arguments to `configureUPlotLineChart`
+      // and are called when recomputing certain axis and
+      // series options. This lets us use updated domains
+      // when redrawing the uPlot chart on data change.
+      this.yAxisDomain = calculateYAxisDomain(
+        axis.props.units,
+        this.props.data,
+      );
+      this.xAxisDomain = calculateXAxisDomain(this.props.timeInfo);
+
+      // The axis label option on uPlot doesn't accept
+      // a function that recomputes the label, so we need
+      // to manually update it in cases where we change
+      // the scale (this happens on byte/time-based Y
+      // axes where can change from MiB or KiB scales,
+      // for instance).
+      this.u.axes[1].label =
+        axis.props.label +
+        (this.yAxisDomain.label ? ` (${this.yAxisDomain.label})` : "");
+
+      const uPlotData = touPlot(this.props.data);
+      this.u.setData(uPlotData);
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.u) {
+      this.u.destroy();
+      this.u = null;
+    }
+  }
+
+  render() {
+    const { title, subtitle, tooltip, data } = this.props;
+
+    return (
+      <Visualization
+        title={title}
+        subtitle={subtitle}
+        tooltip={tooltip}
+        loading={!data}
+      >
+        <div className="linegraph">
+          <div ref={this.el} />
         </div>
       </Visualization>
     );

--- a/pkg/ui/src/views/cluster/components/visualization/visualizations.styl
+++ b/pkg/ui/src/views/cluster/components/visualization/visualizations.styl
@@ -26,7 +26,6 @@ $viz-sides = 62px
 
   &__content
     padding 0 10px 15px
-    height 200px
     &.visualization--loading
       display flex
       justify-content center
@@ -89,3 +88,25 @@ $viz-sides = 62px
 
 .linked-guideline__line
   stroke $link-color
+
+.uplot
+  display flex
+
+.uplot > .u-legend
+  display none
+  position absolute
+  left 0
+  top 0
+  font-size 10px
+  background-color white
+  text-align left
+  margin-top 20px
+  z-index 100
+  pointer-events: none;
+  width: fit-content;
+  border-radius: 5px
+  padding: 10px;
+  border 1px solid rgba(0,0,0,0.1)
+
+.u-legend .u-series
+  display block

--- a/pkg/ui/src/views/cluster/components/visualization/visualizations.styl
+++ b/pkg/ui/src/views/cluster/components/visualization/visualizations.styl
@@ -77,6 +77,13 @@ $viz-sides = 62px
   .icon-warning
     color $warning-color
 
+// TODO(davidh): Remove this rule once the legend display
+// is redesign for uPlot. Currently it takes up a lot of
+// space below the graph so the last graph needs to make
+// extra room for it.
+.visualization:last-child
+  margin-bottom: 600px
+
 .linegraph
   height 100%
 
@@ -91,22 +98,43 @@ $viz-sides = 62px
 
 .uplot
   display flex
+  > .u-legend
+    display none
+    position absolute
+    left 0
+    top 0
+    font-size 10px
+    background-color white
+    text-align left
+    margin-top 20px
+    z-index 100
+    pointer-events: none;
+    width: fit-content;
+    border-radius: 5px
+    padding: 10px;
+    border 1px solid rgba(0,0,0,0.1)
 
-.uplot > .u-legend
-  display none
-  position absolute
-  left 0
-  top 0
-  font-size 10px
-  background-color white
-  text-align left
-  margin-top 20px
-  z-index 100
-  pointer-events: none;
-  width: fit-content;
-  border-radius: 5px
-  padding: 10px;
-  border 1px solid rgba(0,0,0,0.1)
+  // stick the legend to the char's bottom.
+  // Chart height is hardcoded to 300px (pkg/ui/src/views/cluster/util/graphs.ts)
+  > .u-legend.u-legend--place-bottom
+    top 300px!important
+    left 0!important
+    width auto
+    margin-left -1px
+    margin-right -1px
+    border-top none
+    border-radius 0px 0px 5px 5px
+    padding-left 50px
 
-.u-legend .u-series
-  display block
+    // the first line in the legend represents Y-axis and it occupies an entire line
+    // to stand out from the rest of x-axis values
+    > tr:first-child
+      width 100%
+      font-size $font-size--small
+
+    > tr
+      min-width 30%
+
+.u-legend:not(.u-legend--place-bottom)
+  .u-series
+    display block

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/index.tsx
@@ -205,16 +205,15 @@ export class NodeGraphs extends React.Component<NodeGraphsProps, {}> {
     const graphComponents = _.map(graphs, (graph, idx) => {
       const key = `nodes.${dashboard}.${idx}`;
       return (
-        <div key={key}>
-          <MetricsDataProvider
-            id={key}
-            setTimeRange={this.props.setTimeRange}
-            setTimeScale={this.props.setTimeScale}
-            history={this.props.history}
-          >
-            {React.cloneElement(graph, forwardParams)}
-          </MetricsDataProvider>
-        </div>
+        <MetricsDataProvider
+          id={key}
+          key={key}
+          setTimeRange={this.props.setTimeRange}
+          setTimeScale={this.props.setTimeScale}
+          history={this.props.history}
+        >
+          {React.cloneElement(graph, forwardParams)}
+        </MetricsDataProvider>
       );
     });
 

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/index.tsx
@@ -45,6 +45,13 @@ import requestsDashboard from "./dashboards/requests";
 import hardwareDashboard from "./dashboards/hardware";
 import changefeedsDashboard from "./dashboards/changefeeds";
 import { getMatchParamByName } from "src/util/query";
+import { PayloadAction } from "src/interfaces/action";
+import {
+  setTimeRange,
+  setTimeScale,
+  TimeWindow,
+  TimeScale,
+} from "src/redux/timewindow";
 
 interface GraphDashboard {
   label: string;
@@ -83,6 +90,8 @@ interface NodeGraphsOwnProps {
   livenessQueryValid: boolean;
   nodesSummary: NodesSummary;
   hoverState: HoverState;
+  setTimeRange: (tw: TimeWindow) => PayloadAction<TimeWindow>;
+  setTimeScale: (ts: TimeScale) => PayloadAction<TimeScale>;
 }
 
 type NodeGraphsProps = NodeGraphsOwnProps & RouteComponentProps;
@@ -197,8 +206,13 @@ export class NodeGraphs extends React.Component<NodeGraphsProps, {}> {
       const key = `nodes.${dashboard}.${idx}`;
       return (
         <div key={key}>
-          <MetricsDataProvider id={key}>
-            { React.cloneElement(graph, forwardParams) }
+          <MetricsDataProvider
+            id={key}
+            setTimeRange={this.props.setTimeRange}
+            setTimeScale={this.props.setTimeScale}
+            history={this.props.history}
+          >
+            {React.cloneElement(graph, forwardParams)}
           </MetricsDataProvider>
         </div>
       );
@@ -260,5 +274,7 @@ export default withRouter(connect(
     refreshLiveness,
     hoverOn,
     hoverOff,
+    setTimeRange: setTimeRange,
+    setTimeScale: setTimeScale,
   },
 )(NodeGraphs));

--- a/pkg/ui/src/views/cluster/util/graphs.spec.ts
+++ b/pkg/ui/src/views/cluster/util/graphs.spec.ts
@@ -1,0 +1,42 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { ComputeByteAxisDomain } from "oss/src/views/cluster/util/graphs";
+import assert from "assert";
+
+describe("ComputeByteAxisDomain", () => {
+  it("should compute an IEC-based domain", () => {
+    const domain = ComputeByteAxisDomain([0, 1000000]);
+    assert.deepEqual(domain.ticks, [256000, 512000, 768000]);
+    assert.equal(domain.tickFormat(256000), "250");
+    assert.equal(domain.guideFormat(256000), "250.00 KiB");
+    assert.equal(domain.label, "KiB");
+  });
+  // This test is here to demonstrate some of the issues that arise
+  // when reusing a tick formatter with different ranges of data than
+  // it was created with
+  it("will produce odd data when extent changes but same tickformat is used", () => {
+    const originalDomain = ComputeByteAxisDomain([0, 1000000]);
+    assert.deepEqual(originalDomain.ticks, [256000, 512000, 768000]);
+    assert.equal(originalDomain.tickFormat(256000), "250");
+    assert.equal(originalDomain.guideFormat(256000), "250.00 KiB");
+    assert.equal(originalDomain.label, "KiB");
+    const newDomain = ComputeByteAxisDomain([0, 1000000000]);
+    assert.deepEqual(newDomain.ticks, [262144000, 524288000, 786432000]);
+    assert.equal(newDomain.tickFormat(262144000), "250");
+    assert.equal(newDomain.guideFormat(262144000), "250.00 MiB");
+    assert.equal(newDomain.label, "MiB");
+    // Now trying new domain with old ticks
+    // The `m` in this case is "milli" meaning `10^-3`
+    // see: https://github.com/d3/d3-format#locale_formatPrefix
+    assert.equal(newDomain.tickFormat(256000), "244.140625m");
+    assert.equal(newDomain.guideFormat(256000), "0.24 MiB");
+  });
+});

--- a/pkg/ui/src/views/cluster/util/graphs.ts
+++ b/pkg/ui/src/views/cluster/util/graphs.ts
@@ -21,6 +21,7 @@ import {  DurationFitScale, BytesFitScale, ComputeByteScale, ComputeDurationScal
 import {
   MetricProps, AxisProps, AxisUnits, QueryTimeInfo,
 } from "src/views/shared/components/metricQuery";
+import uPlot from "uplot";
 
 type TSResponse = protos.cockroach.ts.tspb.TimeSeriesQueryResponse;
 
@@ -43,14 +44,14 @@ const Y_AXIS_TICK_COUNT: number = 3;
 const X_AXIS_TICK_COUNT: number = 10;
 
 // A tuple of numbers for the minimum and maximum values of an axis.
-type Extent = [number, number];
+export type Extent = [number, number];
 
 /**
  * AxisDomain is a class that describes the domain of a graph axis; this
  * includes the minimum/maximum extend, tick values, and formatting information
  * for axis values as displayed in various contexts.
  */
-class AxisDomain {
+export class AxisDomain {
   // the values at the ends of the axis.
   extent: Extent;
   // numbers at which an intermediate tick should be displayed on the axis.
@@ -163,7 +164,7 @@ function ComputeCountAxisDomain(extent: Extent): AxisDomain {
   return axisDomain;
 }
 
-function ComputeByteAxisDomain(extent: Extent): AxisDomain {
+export function ComputeByteAxisDomain(extent: Extent): AxisDomain {
   // Compute an appropriate unit for the maximum value to be displayed.
   const scale = ComputeByteScale(extent[1]);
   const prefixFactor = scale.value;
@@ -249,13 +250,18 @@ function ComputeTimeAxisDomain(extent: Extent): AxisDomain {
   };
 
   axisDomain.guideFormat = (num) => {
-    return moment(num).utc().format("HH:mm:ss [<span class=\"legend-subtext\">on</span>] MMM Do, YYYY");
+    return moment(num).utc().format("HH:mm:ss on MMM Do, YYYY");
   };
   return axisDomain;
 }
 
-function calculateYAxisDomain(axisUnits: AxisUnits, data: TSResponse): AxisDomain {
-  const resultDatapoints = _.flatMap(data.results, (result) => _.map(result.datapoints, (dp) => dp.value));
+export function calculateYAxisDomain(
+  axisUnits: AxisUnits,
+  data: TSResponse,
+): AxisDomain {
+  const resultDatapoints = _.flatMap(data.results, (result) =>
+    _.map(result.datapoints, (dp) => dp.value),
+  );
   // TODO(couchand): Remove these random datapoints when NVD3 is gone.
   const allDatapoints = resultDatapoints.concat([0, 1]);
   const yExtent = d3.extent(allDatapoints);
@@ -272,12 +278,15 @@ function calculateYAxisDomain(axisUnits: AxisUnits, data: TSResponse): AxisDomai
   }
 }
 
-function calculateXAxisDomain(timeInfo: QueryTimeInfo): AxisDomain {
-  const xExtent: Extent = [NanoToMilli(timeInfo.start.toNumber()), NanoToMilli(timeInfo.end.toNumber())];
+export function calculateXAxisDomain(timeInfo: QueryTimeInfo): AxisDomain {
+  const xExtent: Extent = [
+    NanoToMilli(timeInfo.start.toNumber()),
+    NanoToMilli(timeInfo.end.toNumber()),
+  ];
   return ComputeTimeAxisDomain(xExtent);
 }
 
-type formattedSeries = {
+export type formattedSeries = {
   values: protos.cockroach.ts.tspb.ITimeSeriesDatapoint[],
   key: string,
   area: boolean,
@@ -462,4 +471,156 @@ function updateLinkedGuideline(svgEl: SVGElement, x: d3.scale.Linear<number, num
     .attr("x2", (d) => d)
     .attr("y1", () => yExtent[0])
     .attr("y2", () => yExtent[1]);
+}
+
+// configureUPlotLineChart constructs the uplot Options object based on
+// information about the metrics, axis, and data that we'd like to plot.
+// Most of the settings are defined as functions instead of static values
+// in order to take advantage of auto-updating behavior built into uPlot
+// when we send new data to the uPlot object. This will ensure that all
+// axis labeling and extent settings get updated properly.
+export function configureUPlotLineChart(
+  metrics: React.ReactElement<MetricProps>[],
+  axis: React.ReactElement<AxisProps>,
+  data: TSResponse,
+  setTimeRange: (startMillis: number, endMillis: number) => void,
+  getLatestXAxisDomain: () => AxisDomain,
+  getLatestYAxisDomain: () => AxisDomain,
+): uPlot.Options {
+  const formattedRaw = formatMetricData(metrics, data);
+  // Copy palette over since we mutate it in the `series` function
+  // below to cycle through the colors. This ensures that we always
+  // start from the same color for each graph so a single-series
+  // graph will always have the first color, etc.
+  const strokeColors = [...seriesPalette];
+
+  const tooltipPlugin = () => {
+    return {
+      hooks: {
+        init: (self: uPlot) => {
+          const over: HTMLElement = self.root.querySelector(".u-over");
+          const legend: HTMLElement = self.root.querySelector(".u-legend");
+
+          // Show/hide legend when we enter/exit the bounds of the graph
+          over.onmouseenter = () => {
+            legend.style.display = "block";
+          };
+
+          over.onmouseleave = () => {
+            legend.style.display = "none";
+          };
+        },
+        setCursor: (self: uPlot) => {
+          // Place legend to the right of the mouse pointer
+          const legend: HTMLElement = self.root.querySelector(".u-legend");
+          if (self.cursor.left > 0 && self.cursor.top > 0) {
+            // TODO(davidh): This placement is not aware of the viewport edges
+            legend.style.left = self.cursor.left + 100 + "px";
+            legend.style.top = self.cursor.top - 10 + "px";
+          }
+        },
+      },
+    };
+  };
+
+  // Please see https://github.com/leeoniya/uPlot/tree/master/docs for
+  // information on how to construct this object.
+  return {
+    width: 947,
+    height: 300,
+    // TODO(davidh): Enable sync-ed guidelines once legend is redesigned
+    // currently, if you enable this with a hovering legend, the FPS
+    // gets quite choppy on large clusters.
+    // cursor: {
+    //   sync: {
+    //     // graphs with matching keys will get their guidelines
+    //     // sync-ed so we just use the same key for the page
+    //     key: "sync-everything",
+    //   },
+    // },
+    legend: {
+      show: true,
+
+      // This setting sets the default legend behavior to isolate
+      // a series when it's clicked in the legend.
+      isolate: true,
+    },
+    // By default, uPlot expects unix seconds in the x axis.
+    // This setting defaults it to milliseconds which our
+    // internal functions already supported.
+    ms: 1,
+    // These settings govern how the individual series are
+    // drawn and how their values are displayed in the legend.
+    series: [
+      {
+        value: (_u, rawValue) => getLatestXAxisDomain().guideFormat(rawValue),
+      },
+      // Generate a series object for reach of our results
+      // picking colors from our palette.
+      ...formattedRaw.map((result) => {
+        const color = strokeColors.shift();
+        strokeColors.push(color);
+        return {
+          show: true,
+          scale: "yAxis",
+          width: 1,
+          label: result.key,
+          stroke: color,
+          // Adds transparency to the fill color
+          fill: color + "10",
+          points: {
+            show: false,
+          },
+          // value determines how these values show up in the legend
+          value: (_u: uPlot, rawValue: number) =>
+            getLatestYAxisDomain().guideFormat(rawValue),
+        };
+      }),
+    ],
+    axes: [
+      {
+        values: (_u, vals) => vals.map(getLatestXAxisDomain().tickFormat),
+        splits: () => getLatestXAxisDomain().ticks,
+      },
+      {
+        // This label will get overridden in the linegraph's update
+        // callback when we change the y Axis domain.
+        label:
+          axis.props.label +
+          (getLatestYAxisDomain().label
+            ? ` (${getLatestYAxisDomain().label})`
+            : ""),
+        values: (_u, vals) => vals.map(getLatestYAxisDomain().tickFormat),
+        splits: () => {
+          const domain = getLatestYAxisDomain();
+          return [domain.extent[0], ...domain.ticks, domain.extent[1]];
+        },
+        scale: "yAxis",
+      },
+    ],
+    scales: {
+      x: {
+        range: () => getLatestXAxisDomain().extent,
+      },
+      yAxis: {
+        range: () => getLatestYAxisDomain().extent,
+      },
+    },
+    plugins: [tooltipPlugin()],
+    hooks: {
+      // setSelect is a hook that fires when a selection is made on the graph
+      // by dragging a range to zoom.
+      setSelect: [
+        (self) => {
+          // From what I understand, `self.select` contains the pixel edges
+          // of the user's selection. Then I use the `posToIdx` to tell me
+          // what the xAxis range is of the pixels.
+          setTimeRange(
+            self.data[0][self.posToIdx(self.select.left)],
+            self.data[0][self.posToIdx(self.select.left + self.select.width)],
+          );
+        },
+      ],
+    },
+  };
 }

--- a/pkg/ui/src/views/cluster/util/graphs.ts
+++ b/pkg/ui/src/views/cluster/util/graphs.ts
@@ -501,6 +501,11 @@ export function configureUPlotLineChart(
           const over: HTMLElement = self.root.querySelector(".u-over");
           const legend: HTMLElement = self.root.querySelector(".u-legend");
 
+          // apply class to stick a legend to the bottom of a chart if it has more than 10 series
+          if (self.series.length > 10) {
+            legend.classList.add("u-legend--place-bottom");
+          }
+
           // Show/hide legend when we enter/exit the bounds of the graph
           over.onmouseenter = () => {
             legend.style.display = "block";

--- a/pkg/ui/src/views/shared/components/metricQuery/index.tsx
+++ b/pkg/ui/src/views/shared/components/metricQuery/index.tsx
@@ -35,6 +35,10 @@ import * as protos from  "src/js/protos";
 type TSResponse = protos.cockroach.ts.tspb.TimeSeriesQueryResponse;
 import TimeSeriesQueryAggregator = protos.cockroach.ts.tspb.TimeSeriesQueryAggregator;
 import TimeSeriesQueryDerivative = protos.cockroach.ts.tspb.TimeSeriesQueryDerivative;
+import Long from "long";
+import { History } from "history";
+import { TimeWindow, TimeScale } from "src/redux/timewindow";
+import { PayloadAction } from "src/interfaces/action";
 
 /**
  * AxisUnits is an enumeration used to specify the type of units being displayed
@@ -154,4 +158,7 @@ export interface MetricsDataComponentProps {
   // convenient syntax for a common use case where all metrics on a graph are
   // are from the same source set.
   sources?: string[];
+  setTimeRange?: (tw: TimeWindow) => PayloadAction<TimeWindow>;
+  setTimeScale?: (ts: TimeScale) => PayloadAction<TimeScale>;
+  history?: History;
 }

--- a/pkg/ui/src/views/shared/containers/metricDataProvider/index.tsx
+++ b/pkg/ui/src/views/shared/containers/metricDataProvider/index.tsx
@@ -19,7 +19,15 @@ import { MetricsQuery, requestMetrics as requestMetricsAction } from "src/redux/
 import { AdminUIState } from "src/redux/state";
 import { MilliToNano } from "src/util/convert";
 import { findChildrenOfType } from "src/util/find";
-import { Metric, MetricProps, MetricsDataComponentProps, QueryTimeInfo } from "src/views/shared/components/metricQuery";
+import {
+  Metric,
+  MetricProps,
+  MetricsDataComponentProps,
+  QueryTimeInfo,
+} from "src/views/shared/components/metricQuery";
+import { PayloadAction } from "src/interfaces/action";
+import { TimeWindow, TimeScale } from "src/redux/timewindow";
+import { History } from "history";
 
 /**
  * queryFromProps is a helper method which generates a TimeSeries Query data
@@ -77,6 +85,9 @@ interface MetricsDataProviderConnectProps {
   metrics: MetricsQuery;
   timeInfo: QueryTimeInfo;
   requestMetrics: typeof requestMetricsAction;
+  setTimeRange?: (tw: TimeWindow) => PayloadAction<TimeWindow>;
+  setTimeScale?: (ts: TimeScale) => PayloadAction<TimeScale>;
+  history?: History;
 }
 
 /**
@@ -190,6 +201,9 @@ class MetricsDataProvider extends React.Component<MetricsDataProviderProps, {}> 
     const dataProps: MetricsDataComponentProps = {
       data: this.getData(),
       timeInfo: this.props.timeInfo,
+      setTimeRange: this.props.setTimeRange,
+      setTimeScale: this.props.setTimeScale,
+      history: this.props.history,
     };
     return React.cloneElement(child as React.ReactElement<MetricsDataComponentProps>, dataProps);
   }

--- a/pkg/ui/yarn.lock
+++ b/pkg/ui/yarn.lock
@@ -12779,6 +12779,11 @@ upath@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.0.tgz#35256597e46a581db4793d0ce47fa9aebfc9fabd"
 
+uplot@^1.6.8:
+  version "1.6.8"
+  resolved "https://registry.yarnpkg.com/uplot/-/uplot-1.6.8.tgz#0a7920018de24fa9aa0ba78ab59c99b4a23f8322"
+  integrity sha512-Hqg7iv/3fJlD9nockD7heaUj28RhrIwzugXglnoX//W27wgRAJIJMV2VFMZ5oRVM0RIchByAle1ylf/GdnXgjA==
+
 upper-case@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-1.1.3.tgz#f6b4501c2ec4cdd26ba78be7222961de77621598"

--- a/pkg/ui/yarn.lock
+++ b/pkg/ui/yarn.lock
@@ -12676,10 +12676,10 @@ typescript-tuple@^2.2.1:
   dependencies:
     typescript-compare "^0.0.2"
 
-typescript@^3.7.2:
-  version "3.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.2.tgz#27e489b95fa5909445e9fef5ee48d81697ad18fb"
-  integrity sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==
+typescript@4.2.4:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
+  integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
 
 ua-parser-js@0.7.20, ua-parser-js@^0.7.18, ua-parser-js@^0.7.9:
   version "0.7.20"


### PR DESCRIPTION
Backport:
  * 1/1 commits from "ui: upgrade Typescript from 3.8.0 to 4.2.4" (#64367)
  * 2/2 commits from "ui: use uPlot lib for line graphs on metrics page " (#63087)

Please see individual PRs for details.

/cc @cockroachdb/release
