### PR TITLE
roachtest: skip acceptance/version-upgrade

### DIFF
--- a/pkg/cmd/roachtest/acceptance.go
+++ b/pkg/cmd/roachtest/acceptance.go
@@ -58,6 +58,7 @@ func registerAcceptance(r *testRegistry) {
 			// to head after 19.2 fails.
 			minVersion: "v19.2.0",
 			timeout:    30 * time.Minute,
+			skip:       "https://github.com/cockroachdb/cockroach/issues/64491",
 		},
 	}
 	tags := []string{"default", "quick"}


### PR DESCRIPTION
Broken on master. Being investigated over at
https://github.com/cockroachdb/cockroach/issues/64491.

Release note: None