### PR TITLE
logictest: speed up aggregate test

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -893,8 +893,8 @@ CREATE TABLE mnop (
 )
 
 statement ok
-INSERT INTO mnop (m, n) SELECT i, (1e9 + i/2e4)::float FROM
-  generate_series(1, 2e4) AS i(i)
+INSERT INTO mnop (m, n) SELECT i, (1e9 + i/100.0)::float FROM
+  generate_series(1, 100) AS i(i)
 
 statement ok
 UPDATE mnop SET o = n::decimal, p = (n * 10)::bigint


### PR DESCRIPTION
Use a table with 100 rows instead of 20k for some aggregate logic tests.
This speeds up the whole file noticeably without reducing the test
coverage.

The reason is that with 20k row table when `crdb_test` build tag is
specified, the test takes tens of seconds to run in each config.

Fixes: #64455.

Release note: None