### PR TITLE
kv: resolve conflicting intents immediately for latency-sensitive requests

### DIFF
--- a/pkg/kv/kvserver/concurrency/lock_table_waiter_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter_test.go
@@ -35,8 +35,8 @@ import (
 
 type mockIntentResolver struct {
 	pushTxn        func(context.Context, *enginepb.TxnMeta, roachpb.Header, roachpb.PushTxnType) (*roachpb.Transaction, *Error)
-	resolveIntent  func(context.Context, roachpb.LockUpdate) *Error
-	resolveIntents func(context.Context, []roachpb.LockUpdate) *Error
+	resolveIntent  func(context.Context, roachpb.LockUpdate, intentresolver.ResolveOptions) *Error
+	resolveIntents func(context.Context, []roachpb.LockUpdate, intentresolver.ResolveOptions) *Error
 }
 
 // mockIntentResolver implements the IntentResolver interface.
@@ -47,15 +47,15 @@ func (m *mockIntentResolver) PushTransaction(
 }
 
 func (m *mockIntentResolver) ResolveIntent(
-	ctx context.Context, intent roachpb.LockUpdate, _ intentresolver.ResolveOptions,
+	ctx context.Context, intent roachpb.LockUpdate, opts intentresolver.ResolveOptions,
 ) *Error {
-	return m.resolveIntent(ctx, intent)
+	return m.resolveIntent(ctx, intent, opts)
 }
 
 func (m *mockIntentResolver) ResolveIntents(
 	ctx context.Context, intents []roachpb.LockUpdate, opts intentresolver.ResolveOptions,
 ) *Error {
-	return m.resolveIntents(ctx, intents)
+	return m.resolveIntents(ctx, intents, opts)
 }
 
 type mockLockTableGuard struct {
@@ -343,10 +343,13 @@ func testWaitPush(t *testing.T, k waitKind, makeReq func() Request, expPushTS hl
 						require.Equal(t, pusheeTxn.ID, txn.ID)
 						require.Equal(t, roachpb.ABORTED, txn.Status)
 					}
-					ir.resolveIntent = func(_ context.Context, intent roachpb.LockUpdate) *Error {
+					ir.resolveIntent = func(_ context.Context, intent roachpb.LockUpdate, opts intentresolver.ResolveOptions) *Error {
 						require.Equal(t, keyA, intent.Key)
 						require.Equal(t, pusheeTxn.ID, intent.Txn.ID)
 						require.Equal(t, roachpb.ABORTED, intent.Status)
+						require.Equal(t, true, opts.Poison)
+						require.Equal(t, hlc.Timestamp{}, opts.MinTimestamp)
+						require.Equal(t, true, opts.SendImmediately)
 						g.state = waitingState{kind: doneWaiting}
 						g.notify()
 						return nil
@@ -497,10 +500,13 @@ func testErrorWaitPush(t *testing.T, k waitKind, makeReq func() Request, expPush
 				require.Equal(t, pusheeTxn.ID, txn.ID)
 				require.Equal(t, roachpb.ABORTED, txn.Status)
 			}
-			ir.resolveIntent = func(_ context.Context, intent roachpb.LockUpdate) *Error {
+			ir.resolveIntent = func(_ context.Context, intent roachpb.LockUpdate, opts intentresolver.ResolveOptions) *Error {
 				require.Equal(t, keyA, intent.Key)
 				require.Equal(t, pusheeTxn.ID, intent.Txn.ID)
 				require.Equal(t, roachpb.ABORTED, intent.Status)
+				require.Equal(t, true, opts.Poison)
+				require.Equal(t, hlc.Timestamp{}, opts.MinTimestamp)
+				require.Equal(t, true, opts.SendImmediately)
 				g.state = waitingState{kind: doneWaiting}
 				g.notify()
 				return nil
@@ -564,7 +570,7 @@ func TestLockTableWaiterIntentResolverError(t *testing.T) {
 			) (*roachpb.Transaction, *Error) {
 				return &pusheeTxn, nil
 			}
-			ir.resolveIntent = func(_ context.Context, intent roachpb.LockUpdate) *Error {
+			ir.resolveIntent = func(_ context.Context, intent roachpb.LockUpdate, _ intentresolver.ResolveOptions) *Error {
 				return err2
 			}
 			err = w.WaitOn(ctx, req, g)
@@ -604,11 +610,14 @@ func TestLockTableWaiterDeferredIntentResolverError(t *testing.T) {
 
 	// Errors are propagated when observed while resolving batches of intents.
 	err1 := roachpb.NewErrorf("error1")
-	ir.resolveIntents = func(_ context.Context, intents []roachpb.LockUpdate) *Error {
+	ir.resolveIntents = func(_ context.Context, intents []roachpb.LockUpdate, opts intentresolver.ResolveOptions) *Error {
 		require.Len(t, intents, 1)
 		require.Equal(t, keyA, intents[0].Key)
 		require.Equal(t, pusheeTxn.ID, intents[0].Txn.ID)
 		require.Equal(t, roachpb.ABORTED, intents[0].Status)
+		require.Equal(t, true, opts.Poison)
+		require.Equal(t, hlc.Timestamp{}, opts.MinTimestamp)
+		require.Equal(t, true, opts.SendImmediately)
 		return err1
 	}
 	err := w.WaitOn(ctx, req, g)

--- a/pkg/kv/kvserver/intentresolver/intent_resolver_test.go
+++ b/pkg/kv/kvserver/intentresolver/intent_resolver_test.go
@@ -717,25 +717,25 @@ func TestCleanupIntents(t *testing.T) {
 			expectedErr: true,
 		},
 		{
-			intents: append(makeTxnIntents(t, clock, 3*intentResolverBatchSize),
+			intents: append(makeTxnIntents(t, clock, 3*IntentResolverBatchSize),
 				// Three intents with the same transaction will only attempt to push the
 				// txn 1 time. Hence 3 full batches plus 1 extra.
 				testIntents[0], testIntents[0], testIntents[0]),
 			sendFuncs: func() *sendFuncs {
 				sf := newSendFuncs(t)
 				sf.pushFrontLocked( // don't need to lock
-					pushTxnSendFuncs(sf, intentResolverBatchSize),
+					pushTxnSendFuncs(sf, IntentResolverBatchSize),
 					resolveIntentsSendFuncs(sf, 102 /* numIntents */, 2 /* minNumReqs */),
-					pushTxnSendFuncs(sf, intentResolverBatchSize),
+					pushTxnSendFuncs(sf, IntentResolverBatchSize),
 					resolveIntentsSendFuncs(sf, 100 /* numIntents */, 1 /* minNumReqs */),
-					pushTxnSendFuncs(sf, intentResolverBatchSize),
+					pushTxnSendFuncs(sf, IntentResolverBatchSize),
 					resolveIntentsSendFuncs(sf, 100 /* numIntents */, 1 /* minNumReqs */),
 					pushTxnSendFuncs(sf, 1),
 					resolveIntentsSendFuncs(sf, 1 /* numIntents */, 1 /* minNumReqs */),
 				)
 				return sf
 			}(),
-			expectedNum: 3*intentResolverBatchSize + 3,
+			expectedNum: 3*IntentResolverBatchSize + 3,
 			cfg: Config{
 				MaxIntentResolutionBatchWait: -1, // disabled
 				MaxIntentResolutionBatchIdle: 1 * time.Microsecond,


### PR DESCRIPTION
Related to #60585.
Fixes #50390.

This commit adds a new `SendImmediately` option to the `IntentResolver` `ResolveOptions`, which instructs the `IntentResolver` to send the provided intent resolution requests immediately, instead of adding them to a batch and waiting up to 10ms (`defaultIntentResolutionBatchWait`) for that batch to fill up with other intent resolution requests.  This can be used to avoid any batching-induced latency and should be used only by foreground traffic that is willing to trade off some throughput for lower latency.

The commit then sets this flag for intent resolution requests initiated by the `lockTableWaiter`. Unlike most calls into the `IntentResolver`, which are performed by background tasks that are more than happy to trade increased latency for increased throughput, the `lockTableWaiter` calls into the `IntentResolver` on behalf of a foreground operation. It wants intent resolution to complete as soon as possible, so it is willing to trade reduced throughput for reduced latency.

I tested this out by abandoning 100 different intents by different transactions in a table by disabling async intent resolution and then scanning over the table:
```
./cockroach sql --insecure -e 'create table a (i int); create table b (i int);'

for i in {1..100}; do
    ./cockroach sql --insecure -e "begin; insert into a values (${i}); insert into b values (${i}); commit;"
done

./cockroach sql --insecure -e 'select count(*) from b'
```

Without this change, the scan took 8.1s. With this change, the scan took 7.6s. This 6% speedup of about 500ms checks out. In either case, the waiter needs to wait for the (configurable) 50ms `kv.lock_table.coordinator_liveness_push_delay` to expire before it pushes each txn. However, without this change, it then waits another 5ms (`defaultIntentResolutionBatchIdle`) before issuing each of its resolve intent requests. With this change, these resolve intent requests are issued immediately. The speedup is more pronounced with a high-priority scan, which does not wait for the 50ms `kv.lock_table.coordinator_liveness_push_delay`. If we run the scan with high priority, then without this change, it takes 3.3s and with it, it takes 2.8s, a 15% speedup.

Release note (performance improvement): SQL statements that must clean up intents from previous statements now do so moderately more efficiently.

/cc @cockroachdb/kv 