### PR TITLE
kvserver: test replica removal read inconsistency on 19.2

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -194,6 +194,11 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	}
 
 	clock := hlc.NewClock(hlc.UnixNano, time.Duration(cfg.MaxOffset))
+	if cfg.TestingKnobs.Server != nil &&
+		cfg.TestingKnobs.Server.(*TestingKnobs).ClockSource != nil {
+		clock = hlc.NewClock(cfg.TestingKnobs.Server.(*TestingKnobs).ClockSource,
+			time.Duration(cfg.MaxOffset))
+	}
 	s := &Server{
 		st:       st,
 		clock:    clock,

--- a/pkg/server/testing_knobs.go
+++ b/pkg/server/testing_knobs.go
@@ -47,6 +47,10 @@ type TestingKnobs struct {
 	// TODO(bdarnell): That doesn't give us a good way to clean up if the
 	// server fails to start.
 	RPCListener net.Listener
+
+	// Clock Source used to an inject a custom clock for testing the server. It is
+	// typically either an hlc.HybridManualClock or hlc.ManualClock.
+	ClockSource func() int64
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.

--- a/pkg/storage/client_relocate_range_test.go
+++ b/pkg/storage/client_relocate_range_test.go
@@ -14,15 +14,22 @@ import (
 	"context"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -198,4 +205,116 @@ func TestAdminRelocateRange(t *testing.T) {
 			return relocateAndCheck(t, tc, k, tc.Targets(2, 4))
 		})
 	}
+}
+
+// Regression test for https://github.com/cockroachdb/cockroach/issues/64325
+// which makes sure an in-flight read operation during replica removal won't
+// return empty results.
+func TestReplicaRemovalDuringRequestEvaluation(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	type magicKey struct{}
+
+	// delayReadC is used to synchronize the in-flight read request with the main
+	// test goroutine. It is read from twice:
+	//
+	// 1. The first read allows the test to block until the request eval filter
+	//    is called, i.e. when the read request is ready.
+	// 2. The second read allows the test to close the channel to unblock
+	//    the eval filter, causing the read request to be evaluated.
+	delayReadC := make(chan struct{})
+	evalFilter := func(args storagebase.FilterArgs) *roachpb.Error {
+		if args.Ctx.Value(magicKey{}) != nil {
+			<-delayReadC
+			<-delayReadC
+		}
+		return nil
+	}
+
+	ctx := context.Background()
+	manual := hlc.NewHybridManualClock()
+	args := base.TestClusterArgs{
+		ReplicationMode: base.ReplicationManual,
+		ServerArgs: base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				Store: &storage.StoreTestingKnobs{
+					EvalKnobs: storagebase.BatchEvalTestingKnobs{
+						TestingEvalFilter: evalFilter,
+					},
+				},
+				Server: &server.TestingKnobs{
+					ClockSource: manual.UnixNano,
+				},
+			},
+		},
+	}
+	tc := testcluster.StartTestCluster(t, 2, args)
+	defer tc.Stopper().Stop(ctx)
+
+	// Create range and upreplicate.
+	key := tc.ScratchRange(t)
+	tc.AddReplicasOrFatal(t, key, tc.Target(1))
+
+	// Perform write.
+	pArgs := putArgs(key, []byte("foo"))
+	_, pErr := client.SendWrapped(ctx, tc.Servers[0].DistSender(), pArgs)
+	require.Nil(t, pErr)
+
+	// Perform read on write and wait for read to block.
+	type reply struct {
+		resp roachpb.Response
+		err  *roachpb.Error
+	}
+	readResC := make(chan reply)
+	err := tc.Stopper().RunAsyncTask(ctx, "get", func(ctx context.Context) {
+		readCtx := context.WithValue(ctx, magicKey{}, struct{}{})
+		gArgs := getArgs(key)
+		resp, pErr := client.SendWrapped(readCtx, tc.Servers[0].DistSender(), gArgs)
+		readResC <- reply{resp, pErr}
+	})
+	require.NoError(t, err)
+	delayReadC <- struct{}{}
+
+	// Transfer leaseholder to other store.
+	rangeDesc, err := tc.LookupRange(key)
+	require.NoError(t, err)
+	store, err := tc.Server(0).GetStores().(*storage.Stores).GetStore(tc.Server(0).GetFirstStoreID())
+	require.NoError(t, err)
+	repl, err := store.GetReplica(rangeDesc.RangeID)
+	require.NoError(t, err)
+	err = tc.MoveRangeLeaseNonCooperatively(rangeDesc, tc.Target(1), manual)
+	require.NoError(t, err)
+
+	t.Log("removing replica")
+
+	// Remove first store from raft group. This deadlocks with the
+	// in-flight request if the following lines are uncommented.
+	close(delayReadC)
+	r := <-readResC
+	tc.RemoveReplicasOrFatal(t, key, tc.Target(0))
+
+	t.Log("removed replica")
+
+	// This is a bit iffy. We want to make sure that, in the buggy case, we
+	// will typically fail (i.e. the read returns empty because the replica was
+	// removed). However, in the non-buggy case the in-flight read request will
+	// be holding readOnlyCmdMu until evaluated, blocking the replica removal,
+	// so waiting for replica removal would deadlock. We therefore take the
+	// easy way out by starting an async replica GC and sleeping for a bit.
+	err = tc.Stopper().RunAsyncTask(ctx, "replicaGC", func(ctx context.Context) {
+		assert.NoError(t, store.ManualReplicaGC(repl))
+	})
+	require.NoError(t, err)
+	time.Sleep(500 * time.Millisecond)
+
+	// Allow read to resume. Should return "foo".
+	//close(delayReadC)
+	//r := <-readResC
+	require.Nil(t, r.err)
+	require.NotNil(t, r.resp)
+	require.NotNil(t, r.resp.(*roachpb.GetResponse).Value)
+	val, err := r.resp.(*roachpb.GetResponse).Value.GetBytes()
+	require.NoError(t, err)
+	require.Equal(t, []byte("foo"), val)
 }

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -972,6 +972,11 @@ func NewStore(
 	return s
 }
 
+// GetStoreConfig exposes the config used for this store.
+func (s *Store) GetStoreConfig() *StoreConfig {
+	return &s.cfg
+}
+
 // String formats a store for debug output.
 func (s *Store) String() string {
 	return fmt.Sprintf("[n%d,s%d]", s.Ident.NodeID, s.Ident.StoreID)

--- a/pkg/testutils/serverutils/test_cluster_shim.go
+++ b/pkg/testutils/serverutils/test_cluster_shim.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 )
 
@@ -98,6 +99,21 @@ type TestClusterInterface interface {
 	// new lease holder).
 	TransferRangeLease(
 		rangeDesc roachpb.RangeDescriptor, dest roachpb.ReplicationTarget,
+	) error
+
+	// MoveRangeLeaseNonCooperatively performs a non-cooperative transfer of the
+	// lease for a range from whoever has it to a particular store. That store
+	// must already have a replica of the range. If that replica already has the
+	// (active) lease, this method is a no-op.
+	//
+	// The transfer is non-cooperative in that the lease is made to expire by
+	// advancing the manual clock. The target is then instructed to acquire the
+	// ownerless lease. Most tests should use the cooperative version of this
+	// method, TransferRangeLease.
+	MoveRangeLeaseNonCooperatively(
+		rangeDesc roachpb.RangeDescriptor,
+		dest roachpb.ReplicationTarget,
+		manual *hlc.HybridManualClock,
 	) error
 
 	// LookupRange returns the descriptor of the range containing key.

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
@@ -609,6 +610,80 @@ func (tc *TestCluster) TransferRangeLease(
 	return nil
 }
 
+// MoveRangeLeaseNonCooperatively is part of the TestClusterInterface.
+func (tc *TestCluster) MoveRangeLeaseNonCooperatively(
+	rangeDesc roachpb.RangeDescriptor, dest roachpb.ReplicationTarget, manual *hlc.HybridManualClock,
+) error {
+	destServer, err := tc.findMemberServer(dest.StoreID)
+	if err != nil {
+		return err
+	}
+	destStore, err := destServer.Stores().GetStore(dest.StoreID)
+	if err != nil {
+		return err
+	}
+
+	// We are going to advance the manual clock so that the current lease
+	// expires and then issue a request to the target in hopes that it grabs the
+	// lease. But it is possible that another replica grabs the lease before us
+	// when it's up for grabs. To handle that case, we wrap the entire operation
+	// in an outer retry loop.
+	const retryDur = testutils.DefaultSucceedsSoonDuration
+	return retry.ForDuration(retryDur, func() error {
+		// Find the current lease.
+		prevLease, _, err := tc.FindRangeLease(rangeDesc, nil /* hint */)
+		if err != nil {
+			return err
+		}
+		if prevLease.Replica.StoreID == dest.StoreID {
+			return nil
+		}
+
+		// Advance the manual clock past the lease's expiration.
+		lhStore, err := tc.findMemberStore(prevLease.Replica.StoreID)
+		if err != nil {
+			return err
+		}
+		manual.Increment(lhStore.GetStoreConfig().LeaseExpiration())
+
+		// Heartbeat the destination server's liveness record so that if we are
+		// attempting to acquire an epoch-based lease, the server will be live.
+		err = destServer.HeartbeatNodeLiveness()
+		if err != nil {
+			return err
+		}
+
+		// Issue a request to the target replica, which should notice that the
+		// old lease has expired and that it can acquire the lease.
+		var newLease *roachpb.Lease
+		ctx := context.Background()
+		req := &roachpb.LeaseInfoRequest{
+			RequestHeader: roachpb.RequestHeader{
+				Key: rangeDesc.StartKey.AsRawKey(),
+			},
+		}
+		h := roachpb.Header{RangeID: rangeDesc.RangeID}
+		reply, pErr := client.SendWrappedWith(ctx, destStore, h, req)
+		if pErr != nil {
+			log.Infof(ctx, "LeaseInfoRequest failed: %v", pErr)
+			if lErr, ok := pErr.GetDetail().(*roachpb.NotLeaseHolderError); ok && lErr.Lease != nil {
+				newLease = lErr.Lease
+			} else {
+				return pErr.GoError()
+			}
+		} else {
+			newLease = &reply.(*roachpb.LeaseInfoResponse).Lease
+		}
+
+		// Is the lease in the right place?
+		if newLease.Replica.StoreID != dest.StoreID {
+			return errors.Errorf("LeaseInfoRequest succeeded, "+
+				"but lease in wrong location, want %v, got %v", dest, newLease.Replica)
+		}
+		return nil
+	})
+}
+
 // FindRangeLease is similar to FindRangeLeaseHolder but returns a Lease proto
 // without verifying if the lease is still active. Instead, it returns a time-
 // stamp taken off the queried node's clock.
@@ -719,6 +794,16 @@ func (tc *TestCluster) WaitForSplitAndInitialization(startKey roachpb.Key) error
 		}
 		return nil
 	})
+}
+
+// findMemberServer returns the server containing a given store.
+func (tc *TestCluster) findMemberServer(storeID roachpb.StoreID) (*server.TestServer, error) {
+	for _, server := range tc.Servers {
+		if server.Stores().HasStore(storeID) {
+			return server, nil
+		}
+	}
+	return nil, errors.Errorf("store not found")
 }
 
 // findMemberStore returns the store containing a given replica.

--- a/pkg/util/hlc/hlc.go
+++ b/pkg/util/hlc/hlc.go
@@ -84,6 +84,55 @@ type Clock struct {
 	}
 }
 
+// HybridManualClock is a convenience type to facilitate
+// creating a hybrid logical clock whose physical clock
+// ticks with the wall clock, but that can be moved arbitrarily
+// into the future or paused. HybridManualClock is thread safe.
+type HybridManualClock struct {
+	mu struct {
+		syncutil.RWMutex
+		// nanos, if not 0, is the amount of time the clock was manually incremented
+		// by; it is added to physicalClock.
+		nanos int64
+		// nanosAtPause records the timestamp of the physical clock when it gets
+		// paused. 0 means that the clock is not paused.
+		nanosAtPause int64
+	}
+}
+
+// NewHybridManualClock returns a new instance, initialized with
+// specified timestamp.
+func NewHybridManualClock() *HybridManualClock {
+	return &HybridManualClock{}
+}
+
+// UnixNano returns the underlying hybrid manual clock's timestamp.
+func (m *HybridManualClock) UnixNano() int64 {
+	m.mu.RLock()
+	nanosAtPause := m.mu.nanosAtPause
+	nanos := m.mu.nanos
+	m.mu.RUnlock()
+	if nanosAtPause > 0 {
+		return nanos + nanosAtPause
+	}
+	return nanos + UnixNano()
+}
+
+// Increment increments the hybrid manual clock's timestamp.
+func (m *HybridManualClock) Increment(nanos int64) {
+	m.mu.Lock()
+	m.mu.nanos += nanos
+	m.mu.Unlock()
+}
+
+// Pause pauses the hybrid manual clock; the passage of time no longer causes
+// the clock to tick. Increment can still be used, though.
+func (m *HybridManualClock) Pause() {
+	m.mu.Lock()
+	m.mu.nanosAtPause = UnixNano()
+	m.mu.Unlock()
+}
+
 // ManualClock is a convenience type to facilitate
 // creating a hybrid logical clock whose physical clock
 // is manually controlled. ManualClock is thread safe.


### PR DESCRIPTION
Backports the test case from #64324 to check whether 19.2 has the
replica removal read race condition. It does not appear so, as
replica removal blocks until the in-flight read completes.

Release note: None