### PR TITLE
roachtest: simplify tpchvec given we run roachtests from each branch

### DIFF
--- a/pkg/cmd/roachtest/sqlsmith.go
+++ b/pkg/cmd/roachtest/sqlsmith.go
@@ -122,29 +122,18 @@ func registerSQLSmith(r *testRegistry) {
 			t.Fatal(err)
 		}
 
-		versionString, err := fetchCockroachVersion(ctx, c, c.Node(1)[0], nil)
-		if err != nil {
+		// We will enable panic injection on this connection in the vectorized
+		// engine (and will ignore the injected errors) in order to test that
+		// the panic-catching mechanism of error propagation works as expected.
+		// Note: it is important to enable this testing knob only after all
+		// other setup queries have already completed, including the smither
+		// instantiation (otherwise, the setup might fail because of the
+		// injected panics).
+		injectPanicsStmt := "SET testing_vectorize_inject_panics=true;"
+		if _, err := conn.Exec(injectPanicsStmt); err != nil {
 			t.Fatal(err)
 		}
-		crdbVersion, err := toCRDBVersion(versionString)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if crdbVersion >= crdbVersion21_1 {
-			// We will enable panic injection on this connection in the
-			// vectorized engine (and will ignore the injected errors) in order
-			// to test that the panic-catching mechanism of error propagation
-			// works as expected.
-			// Note: it is important to enable this testing knob only after all
-			// other setup queries have already completed, including the smither
-			// instantiation (otherwise, the setup might fail because of the
-			// injected panics).
-			injectPanicsStmt := "SET testing_vectorize_inject_panics=true;"
-			if _, err := conn.Exec(injectPanicsStmt); err != nil {
-				t.Fatal(err)
-			}
-			logStmt(injectPanicsStmt)
-		}
+		logStmt(injectPanicsStmt)
 
 		t.Status("smithing")
 		until := time.After(t.spec.Timeout / 2)


### PR DESCRIPTION
We used to run the roachtests from the master against the old binaries
which required that we have some custom logic for different CRDB
versions in some roachtests. This is no longer the case, so this commit
simplifies `tpchvec` and `sqlsmith` roachtests a bit.

Fixes: #64515.
Fixes: #64516.
Fixes: #64517.
Fixes: #64519.
Fixes: #64520.
Fixes: #64521.
Fixes: #64522.
Fixes: #64523.
Fixes: #64527.
Fixes: #64528.
Fixes: #64539.
Fixes: #64540.
Fixes: #64541.
Fixes: #64542.
Fixes: #64543.
Fixes: #64544.
Fixes: #64545.
Fixes: #64546.
Fixes: #64548.
Fixes: #64549.

Release note: None