### PR TITLE
kvserver: fix metrics collection for rejected lease requests

### DIFF
--- a/pkg/kv/kvserver/replica_proposal_buf.go
+++ b/pkg/kv/kvserver/replica_proposal_buf.go
@@ -1136,6 +1136,7 @@ func (rp *replicaProposer) rejectProposalWithRedirectLocked(
 	r := (*Replica)(rp)
 	rangeDesc := r.descRLocked()
 	storeID := r.store.StoreID()
+	r.store.metrics.LeaseRequestErrorCount.Inc(1)
 	redirectRep, _ /* ok */ := rangeDesc.GetReplicaDescriptorByID(redirectTo)
 	speculativeLease := roachpb.Lease{
 		Replica: redirectRep,


### PR DESCRIPTION
Previously, we were only updating the `leases.error` (metric measuring the
number of failed lease requests) if a lease request failed during command
evaluation. However after #55148, lease requests can be rejected by the replica
proposal buffer if there is a known raft leader that is different from the
replica requesting the lease. We were not recording such rejections as failed
lease requests in the metrics.

This commit fixes this oversight.

Release note: None