### PR TITLE
cloudimpl: move towards registering implementations

### DIFF
--- a/pkg/ccl/importccl/read_import_workload.go
+++ b/pkg/ccl/importccl/read_import_workload.go
@@ -128,10 +128,11 @@ func (w *workloadReader) readFiles(
 		if err != nil {
 			return err
 		}
-		conf, err := cloudimpl.ParseWorkloadConfig(file)
+		e, err := cloudimpl.ParseWorkloadConfig(cloudimpl.ExternalStorageURIContext{}, file)
 		if err != nil {
 			return err
 		}
+		conf := e.WorkloadConfig
 		meta, err := workload.Get(conf.Generator)
 		if err != nil {
 			return err

--- a/pkg/storage/cloudimpl/cloudimpltests/http_storage_test.go
+++ b/pkg/storage/cloudimpl/cloudimpltests/http_storage_test.go
@@ -247,7 +247,8 @@ func TestHttpGet(t *testing.T) {
 				return nil
 			})
 
-			store, err := cloudimpl.MakeHTTPStorage(s.URL, testSettings, base.ExternalIODirConfig{})
+			conf := roachpb.ExternalStorage{HttpPath: roachpb.ExternalStorage_Http{BaseUri: s.URL}}
+			store, err := cloudimpl.MakeHTTPStorage(ctx, cloudimpl.ExternalStorageContext{Settings: testSettings}, conf)
 			require.NoError(t, err)
 
 			var file io.ReadCloser
@@ -282,7 +283,8 @@ func TestHttpGetWithCancelledContext(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	defer s.Close()
 
-	store, err := cloudimpl.MakeHTTPStorage(s.URL, testSettings, base.ExternalIODirConfig{})
+	conf := roachpb.ExternalStorage{HttpPath: roachpb.ExternalStorage_Http{BaseUri: s.URL}}
+	store, err := cloudimpl.MakeHTTPStorage(context.Background(), cloudimpl.ExternalStorageContext{Settings: testSettings}, conf)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, store.Close())
@@ -397,8 +399,8 @@ func TestExhaustRetries(t *testing.T) {
 	cloudimpl.HTTPRetryOptions.MaxBackoff = 10 * time.Millisecond
 	cloudimpl.HTTPRetryOptions.MaxRetries = 10
 
-	store, err := cloudimpl.MakeHTTPStorage(
-		"http://does.not.matter", testSettings, base.ExternalIODirConfig{})
+	conf := roachpb.ExternalStorage{HttpPath: roachpb.ExternalStorage_Http{BaseUri: "http://does.not.matter"}}
+	store, err := cloudimpl.MakeHTTPStorage(context.Background(), cloudimpl.ExternalStorageContext{Settings: testSettings}, conf)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, store.Close())

--- a/pkg/storage/cloudimpl/cloudimpltests/s3_storage_test.go
+++ b/pkg/storage/cloudimpl/cloudimpltests/s3_storage_test.go
@@ -208,9 +208,12 @@ func TestPutS3Endpoint(t *testing.T) {
 
 func TestS3DisallowCustomEndpoints(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	dest := roachpb.ExternalStorage{S3Config: &roachpb.ExternalStorage_S3{Endpoint: "http://do.not.go.there/"}}
 	s3, err := cloudimpl.MakeS3Storage(context.Background(),
-		base.ExternalIODirConfig{DisableHTTP: true},
-		&roachpb.ExternalStorage_S3{Endpoint: "http://do.not.go.there/"}, nil,
+		cloudimpl.ExternalStorageContext{
+			IOConf: base.ExternalIODirConfig{DisableHTTP: true},
+		},
+		dest,
 	)
 	require.Nil(t, s3)
 	require.Error(t, err)
@@ -218,12 +221,14 @@ func TestS3DisallowCustomEndpoints(t *testing.T) {
 
 func TestS3DisallowImplicitCredentials(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	dest := roachpb.ExternalStorage{S3Config: &roachpb.ExternalStorage_S3{Endpoint: "http://do-not-go-there", Auth: cloudimpl.AuthParamImplicit}}
+
 	s3, err := cloudimpl.MakeS3Storage(context.Background(),
-		base.ExternalIODirConfig{DisableImplicitCredentials: true},
-		&roachpb.ExternalStorage_S3{
-			Endpoint: "http://do-not-go-there",
-			Auth:     cloudimpl.AuthParamImplicit,
-		}, testSettings,
+		cloudimpl.ExternalStorageContext{
+			IOConf:   base.ExternalIODirConfig{DisableImplicitCredentials: true},
+			Settings: testSettings,
+		},
+		dest,
 	)
 	require.Nil(t, s3)
 	require.Error(t, err)

--- a/pkg/storage/cloudimpl/external_storage.go
+++ b/pkg/storage/cloudimpl/external_storage.go
@@ -12,10 +12,10 @@ package cloudimpl
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/url"
 	"path"
-	"strconv"
 	"strings"
 	"time"
 
@@ -25,7 +25,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
-	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
@@ -123,125 +122,65 @@ var ErrListingUnsupported = errors.New("listing is not supported")
 // This error is raised by the ReadFile method.
 var ErrFileDoesNotExist = errors.New("external_storage: file doesn't exist")
 
+var confParsers = map[string]ExternalStorageURIParser{}
+var implementations = map[roachpb.ExternalStorageProvider]ExternalStorageConstructor{}
+
+// RegisterExternalStorageProvider registers an external storage provider for a
+// given URI scheme and provider type.
+func RegisterExternalStorageProvider(
+	providerType roachpb.ExternalStorageProvider,
+	parseFn ExternalStorageURIParser,
+	constructFn ExternalStorageConstructor,
+	schemes ...string,
+) {
+	for _, scheme := range schemes {
+		if _, ok := confParsers[scheme]; ok {
+			panic(fmt.Sprintf("external storage provider already registered for %s", scheme))
+		}
+		confParsers[scheme] = parseFn
+	}
+	if _, ok := implementations[providerType]; ok {
+		panic(fmt.Sprintf("external storage provider already registered for %s", providerType.String()))
+	}
+	implementations[providerType] = constructFn
+}
+
 func init() {
 	cloud.AccessIsWithExplicitAuth = AccessIsWithExplicitAuth
+	RegisterExternalStorageProvider(roachpb.ExternalStorageProvider_Azure, parseAzureURL, makeAzureStorage, "azure")
+	RegisterExternalStorageProvider(roachpb.ExternalStorageProvider_GoogleCloud, parseGSURL, makeGCSStorage, "gs")
+	RegisterExternalStorageProvider(roachpb.ExternalStorageProvider_Http, parseHTTPURL, MakeHTTPStorage, "http", "https")
+	RegisterExternalStorageProvider(roachpb.ExternalStorageProvider_LocalFile, parseNodelocalURL, makeLocalStorage, "nodelocal")
+	RegisterExternalStorageProvider(roachpb.ExternalStorageProvider_NullSink, parseNullURL, makeNullSinkStorage, "null")
+	RegisterExternalStorageProvider(roachpb.ExternalStorageProvider_S3, parseS3URL, MakeS3Storage, "s3")
+	RegisterExternalStorageProvider(roachpb.ExternalStorageProvider_FileTable, parseUserfileURL, makeFileTableStorage, "userfile")
+	RegisterExternalStorageProvider(roachpb.ExternalStorageProvider_Workload, ParseWorkloadConfig, makeWorkloadStorage, "workload")
 }
+
+// ExternalStorageURIContext contains arguments needed to parse external storage
+// URIs.
+type ExternalStorageURIContext struct {
+	CurrentUser security.SQLUsername
+}
+
+// ExternalStorageURIParser functions parses a URL into a structured
+// ExternalStorage configuration.
+type ExternalStorageURIParser func(ExternalStorageURIContext, *url.URL) (roachpb.ExternalStorage, error)
 
 // ExternalStorageConfFromURI generates an ExternalStorage config from a URI string.
 func ExternalStorageConfFromURI(
 	path string, user security.SQLUsername,
 ) (roachpb.ExternalStorage, error) {
-	conf := roachpb.ExternalStorage{}
 	uri, err := url.Parse(path)
 	if err != nil {
-		return conf, err
+		return roachpb.ExternalStorage{}, err
 	}
-	switch uri.Scheme {
-	case "s3":
-		conf.Provider = roachpb.ExternalStorageProvider_S3
-		conf.S3Config = &roachpb.ExternalStorage_S3{
-			Bucket:        uri.Host,
-			Prefix:        uri.Path,
-			AccessKey:     uri.Query().Get(AWSAccessKeyParam),
-			Secret:        uri.Query().Get(AWSSecretParam),
-			TempToken:     uri.Query().Get(AWSTempTokenParam),
-			Endpoint:      uri.Query().Get(AWSEndpointParam),
-			Region:        uri.Query().Get(S3RegionParam),
-			Auth:          uri.Query().Get(AuthParam),
-			ServerEncMode: uri.Query().Get(AWSServerSideEncryptionMode),
-			ServerKMSID:   uri.Query().Get(AWSServerSideEncryptionKMSID),
-			/* NB: additions here should also update s3QueryParams() serializer */
-		}
-		conf.S3Config.Prefix = strings.TrimLeft(conf.S3Config.Prefix, "/")
-		// AWS secrets often contain + characters, which must be escaped when
-		// included in a query string; otherwise, they represent a space character.
-		// More than a few users have been bitten by this.
-		//
-		// Luckily, AWS secrets are base64-encoded data and thus will never actually
-		// contain spaces. We can convert any space characters we see to +
-		// characters to recover the original secret.
-		conf.S3Config.Secret = strings.Replace(conf.S3Config.Secret, " ", "+", -1)
-	case "gs":
-		conf.Provider = roachpb.ExternalStorageProvider_GoogleCloud
-		conf.GoogleCloudConfig = &roachpb.ExternalStorage_GCS{
-			Bucket:         uri.Host,
-			Prefix:         uri.Path,
-			Auth:           uri.Query().Get(AuthParam),
-			BillingProject: uri.Query().Get(GoogleBillingProjectParam),
-			Credentials:    uri.Query().Get(CredentialsParam),
-			/* NB: additions here should also update gcsQueryParams() serializer */
-		}
-		conf.GoogleCloudConfig.Prefix = strings.TrimLeft(conf.GoogleCloudConfig.Prefix, "/")
-	case "azure":
-		conf.Provider = roachpb.ExternalStorageProvider_Azure
-		conf.AzureConfig = &roachpb.ExternalStorage_Azure{
-			Container:   uri.Host,
-			Prefix:      uri.Path,
-			AccountName: uri.Query().Get(AzureAccountNameParam),
-			AccountKey:  uri.Query().Get(AzureAccountKeyParam),
-			/* NB: additions here should also update azureQueryParams() serializer */
-		}
-		if conf.AzureConfig.AccountName == "" {
-			return conf, errors.Errorf("azure uri missing %q parameter", AzureAccountNameParam)
-		}
-		if conf.AzureConfig.AccountKey == "" {
-			return conf, errors.Errorf("azure uri missing %q parameter", AzureAccountKeyParam)
-		}
-		conf.AzureConfig.Prefix = strings.TrimLeft(conf.AzureConfig.Prefix, "/")
-	case "http", "https":
-		conf.Provider = roachpb.ExternalStorageProvider_Http
-		conf.HttpPath.BaseUri = path
-	case "nodelocal":
-		if uri.Host == "" {
-			return conf, errors.Errorf(
-				"host component of nodelocal URI must be a node ID ("+
-					"use 'self' to specify each node should access its own local filesystem): %s",
-				path,
-			)
-		} else if uri.Host == "self" {
-			uri.Host = "0"
-		}
-
-		nodeID, err := strconv.Atoi(uri.Host)
-		if err != nil {
-			return conf, errors.Errorf("host component of nodelocal URI must be a node ID: %s", path)
-		}
-		conf.Provider = roachpb.ExternalStorageProvider_LocalFile
-		conf.LocalFile.Path = uri.Path
-		conf.LocalFile.NodeID = roachpb.NodeID(nodeID)
-	case "experimental-workload", "workload":
-		conf.Provider = roachpb.ExternalStorageProvider_Workload
-		if conf.WorkloadConfig, err = ParseWorkloadConfig(uri); err != nil {
-			return conf, err
-		}
-	case "userfile":
-		qualifiedTableName := uri.Host
-		if user.Undefined() {
-			return conf, errors.Errorf("user creating the FileTable ExternalStorage must be specified")
-		}
-
-		// If the import statement does not specify a qualified table name then use
-		// the default to attempt to locate the file(s).
-		if qualifiedTableName == "" {
-			composedTableName := security.MakeSQLUsernameFromPreNormalizedString(
-				DefaultQualifiedNamePrefix + user.Normalized())
-			qualifiedTableName = DefaultQualifiedNamespace +
-				// Escape special identifiers as needed.
-				composedTableName.SQLIdentifier()
-		}
-
-		conf.Provider = roachpb.ExternalStorageProvider_FileTable
-		conf.FileTableConfig.User = user.Normalized()
-		conf.FileTableConfig.QualifiedTableName = qualifiedTableName
-		conf.FileTableConfig.Path = uri.Path
-	case "null":
-		conf.Provider = roachpb.ExternalStorageProvider_NullSink
-	default:
-		// TODO(adityamaru): Link dedicated ExternalStorage scheme docs once ready.
-		return conf, errors.Errorf("unsupported storage scheme: %q - refer to docs to find supported"+
-			" storage schemes", uri.Scheme)
+	if fn, ok := confParsers[uri.Scheme]; ok {
+		return fn(ExternalStorageURIContext{CurrentUser: user}, uri)
 	}
-	return conf, nil
+	// TODO(adityamaru): Link dedicated ExternalStorage scheme docs once ready.
+	return roachpb.ExternalStorage{}, errors.Errorf("unsupported storage scheme: %q - refer to docs to find supported"+
+		" storage schemes", uri.Scheme)
 }
 
 // ExternalStorageFromURI returns an ExternalStorage for the given URI.
@@ -296,6 +235,22 @@ func SanitizeExternalStorageURI(path string, extraParams []string) (string, erro
 	return uri.String(), nil
 }
 
+// ExternalStorageContext contains the dependencies passed to external storage
+// implementations during creation.
+type ExternalStorageContext struct {
+	IOConf            base.ExternalIODirConfig
+	Settings          *cluster.Settings
+	BlobClientFactory blobs.BlobClientFactory
+	InternalExecutor  *sql.InternalExecutor
+	DB                *kv.DB
+}
+
+// ExternalStorageConstructor is a function registered to create instances
+// of a given external storage implamentation.
+type ExternalStorageConstructor func(
+	context.Context, ExternalStorageContext, roachpb.ExternalStorage,
+) (cloud.ExternalStorage, error)
+
 // MakeExternalStorage creates an ExternalStorage from the given config.
 func MakeExternalStorage(
 	ctx context.Context,
@@ -306,40 +261,18 @@ func MakeExternalStorage(
 	ie *sql.InternalExecutor,
 	kvDB *kv.DB,
 ) (cloud.ExternalStorage, error) {
+	args := ExternalStorageContext{
+		IOConf:            conf,
+		Settings:          settings,
+		BlobClientFactory: blobClientFactory,
+		InternalExecutor:  ie,
+		DB:                kvDB,
+	}
 	if conf.DisableOutbound && dest.Provider != roachpb.ExternalStorageProvider_FileTable {
 		return nil, errors.New("external network access is disabled")
 	}
-	switch dest.Provider {
-	case roachpb.ExternalStorageProvider_LocalFile:
-		telemetry.Count("external-io.nodelocal")
-		if blobClientFactory == nil {
-			return nil, errors.New("nodelocal storage is not available")
-		}
-		return makeLocalStorage(ctx, dest.LocalFile, settings, blobClientFactory, conf)
-	case roachpb.ExternalStorageProvider_Http:
-		if conf.DisableHTTP {
-			return nil, errors.New("external http access disabled")
-		}
-		telemetry.Count("external-io.http")
-		return MakeHTTPStorage(dest.HttpPath.BaseUri, settings, conf)
-	case roachpb.ExternalStorageProvider_S3:
-		telemetry.Count("external-io.s3")
-		return MakeS3Storage(ctx, conf, dest.S3Config, settings)
-	case roachpb.ExternalStorageProvider_GoogleCloud:
-		telemetry.Count("external-io.google_cloud")
-		return makeGCSStorage(ctx, conf, dest.GoogleCloudConfig, settings)
-	case roachpb.ExternalStorageProvider_Azure:
-		telemetry.Count("external-io.azure")
-		return makeAzureStorage(dest.AzureConfig, settings, conf)
-	case roachpb.ExternalStorageProvider_Workload:
-		telemetry.Count("external-io.workload")
-		return makeWorkloadStorage(dest.WorkloadConfig, settings, conf)
-	case roachpb.ExternalStorageProvider_FileTable:
-		telemetry.Count("external-io.filetable")
-		return makeFileTableStorage(ctx, dest.FileTableConfig, ie, kvDB, settings, conf)
-	case roachpb.ExternalStorageProvider_NullSink:
-		telemetry.Count("external-io.nullsink")
-		return makeNullSinkStorage()
+	if fn, ok := implementations[dest.Provider]; ok {
+		return fn(ctx, args, dest)
 	}
 	return nil, errors.Errorf("unsupported external destination type: %s", dest.Provider.String())
 }

--- a/pkg/storage/cloudimpl/file_table_storage.go
+++ b/pkg/storage/cloudimpl/file_table_storage.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/storage/cloud"
@@ -40,6 +41,33 @@ const (
 	DefaultQualifiedNamePrefix = "userfiles_"
 )
 
+func parseUserfileURL(
+	args ExternalStorageURIContext, uri *url.URL,
+) (roachpb.ExternalStorage, error) {
+	conf := roachpb.ExternalStorage{}
+	qualifiedTableName := uri.Host
+	if args.CurrentUser.Undefined() {
+		return conf, errors.Errorf("user creating the FileTable ExternalStorage must be specified")
+	}
+	normUser := args.CurrentUser.Normalized()
+
+	// If the import statement does not specify a qualified table name then use
+	// the default to attempt to locate the file(s).
+	if qualifiedTableName == "" {
+		composedTableName := security.MakeSQLUsernameFromPreNormalizedString(
+			DefaultQualifiedNamePrefix + normUser)
+		qualifiedTableName = DefaultQualifiedNamespace +
+			// Escape special identifiers as needed.
+			composedTableName.SQLIdentifier()
+	}
+
+	conf.Provider = roachpb.ExternalStorageProvider_FileTable
+	conf.FileTableConfig.User = normUser
+	conf.FileTableConfig.QualifiedTableName = qualifiedTableName
+	conf.FileTableConfig.Path = uri.Path
+	return conf, nil
+}
+
 type fileTableStorage struct {
 	fs       *filetable.FileToTableSystem
 	cfg      roachpb.ExternalStorage_FileTable
@@ -53,13 +81,11 @@ type fileTableStorage struct {
 var _ cloud.ExternalStorage = &fileTableStorage{}
 
 func makeFileTableStorage(
-	ctx context.Context,
-	cfg roachpb.ExternalStorage_FileTable,
-	ie *sql.InternalExecutor,
-	db *kv.DB,
-	settings *cluster.Settings,
-	ioConf base.ExternalIODirConfig,
+	ctx context.Context, args ExternalStorageContext, dest roachpb.ExternalStorage,
 ) (cloud.ExternalStorage, error) {
+	telemetry.Count("external-io.filetable")
+
+	cfg := dest.FileTableConfig
 	if cfg.User == "" || cfg.QualifiedTableName == "" {
 		return nil, errors.Errorf("FileTable storage requested but username or qualified table name" +
 			" not provided")
@@ -86,7 +112,7 @@ func makeFileTableStorage(
 
 	// cfg.User is already a normalized SQL username.
 	username := security.MakeSQLUsernameFromPreNormalizedString(cfg.User)
-	executor := filetable.MakeInternalFileToTableExecutor(ie, db)
+	executor := filetable.MakeInternalFileToTableExecutor(args.InternalExecutor, args.DB)
 	fileToTableSystem, err := filetable.NewFileToTableSystem(ctx,
 		cfg.QualifiedTableName, executor, username)
 	if err != nil {
@@ -95,11 +121,11 @@ func makeFileTableStorage(
 	return &fileTableStorage{
 		fs:       fileToTableSystem,
 		cfg:      cfg,
-		ioConf:   ioConf,
-		db:       db,
-		ie:       ie,
+		ioConf:   args.IOConf,
+		db:       args.DB,
+		ie:       args.InternalExecutor,
 		prefix:   cfg.Path,
-		settings: settings,
+		settings: args.Settings,
 	}, nil
 }
 

--- a/pkg/storage/cloudimpl/http_storage.go
+++ b/pkg/storage/cloudimpl/http_storage.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/cloud"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
@@ -34,6 +35,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/errors"
 )
+
+func parseHTTPURL(_ ExternalStorageURIContext, uri *url.URL) (roachpb.ExternalStorage, error) {
+	conf := roachpb.ExternalStorage{}
+	conf.Provider = roachpb.ExternalStorageProvider_Http
+	conf.HttpPath.BaseUri = uri.String()
+	return conf, nil
+}
 
 type httpStorage struct {
 	base     *url.URL
@@ -94,13 +102,18 @@ func makeHTTPClient(settings *cluster.Settings) (*http.Client, error) {
 
 // MakeHTTPStorage returns an instance of HTTPStorage ExternalStorage.
 func MakeHTTPStorage(
-	base string, settings *cluster.Settings, ioConf base.ExternalIODirConfig,
+	ctx context.Context, args ExternalStorageContext, dest roachpb.ExternalStorage,
 ) (cloud.ExternalStorage, error) {
+	telemetry.Count("external-io.http")
+	if args.IOConf.DisableHTTP {
+		return nil, errors.New("external http access disabled")
+	}
+	base := dest.HttpPath.BaseUri
 	if base == "" {
 		return nil, errors.Errorf("HTTP storage requested but prefix path not provided")
 	}
 
-	client, err := makeHTTPClient(settings)
+	client, err := makeHTTPClient(args.Settings)
 	if err != nil {
 		return nil, err
 	}
@@ -112,8 +125,8 @@ func MakeHTTPStorage(
 		base:     uri,
 		client:   client,
 		hosts:    strings.Split(uri.Host, ","),
-		settings: settings,
-		ioConf:   ioConf,
+		settings: args.Settings,
+		ioConf:   args.IOConf,
 	}, nil
 }
 

--- a/pkg/storage/cloudimpl/nullsink_storage.go
+++ b/pkg/storage/cloudimpl/nullsink_storage.go
@@ -15,12 +15,18 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net/url"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/cloud"
 )
+
+func parseNullURL(_ ExternalStorageURIContext, _ *url.URL) (roachpb.ExternalStorage, error) {
+	return roachpb.ExternalStorage{Provider: roachpb.ExternalStorageProvider_NullSink}, nil
+}
 
 // MakeNullSinkStorageURI returns a valid null sink URI.
 func MakeNullSinkStorageURI(path string) string {
@@ -30,7 +36,10 @@ func MakeNullSinkStorageURI(path string) string {
 type nullSinkStorage struct {
 }
 
-func makeNullSinkStorage() (cloud.ExternalStorage, error) {
+func makeNullSinkStorage(
+	_ context.Context, _ ExternalStorageContext, _ roachpb.ExternalStorage,
+) (cloud.ExternalStorage, error) {
+	telemetry.Count("external-io.nullsink")
 	return &nullSinkStorage{}, nil
 }
 


### PR DESCRIPTION
This refactors the cloudimpl package to switch to a common interface for
the methods that parse provider-specific options from URIs into structured
config and that construct an instance of a provider from a structured config.

These methods can then be registered for a given URI schema / config type
at init time, paving the way for a future change to start splitting up this
package, moving implmementaitons into their own packages.

Release note: none.