### PR TITLE
kvserver: stop reconciling range count imbalance in the StoreRebalancer

### DIFF
--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -525,8 +525,7 @@ func (sr *StoreRebalancer) chooseRangeToRebalance(
 		// just unnecessary churn with no benefit to move ranges responsible for,
 		// for example, 1 qps on a store with 5000 qps.
 		const minQPSFraction = .001
-		if replWithStats.qps < localDesc.Capacity.QueriesPerSecond*minQPSFraction &&
-			float64(localDesc.Capacity.RangeCount) <= storeList.candidateRanges.mean {
+		if replWithStats.qps < localDesc.Capacity.QueriesPerSecond*minQPSFraction {
 			log.VEventf(
 				ctx,
 				5,


### PR DESCRIPTION
Previously, the `StoreRebalancer` would rebalance ranges off of a node if
it had more than the average number of replicas compared to the cluster
average. This was undesirable because the `StoreRebalancer` was not respecting
the {over,under}fullness thresholds that the replicateQueue does, which could
lead to redundant range relocations even in a well balanced cluster.

This commit is an opinionated fix to prevent this behavior and an attempt to
more clearly delineate the responsibilities of the replica rebalancing aspects
of the `StoreRebalancer` and the `replicateQueue`.

Noticed while looking into #64064.

Release note: None