### PR TITLE
roachtest: fix segfault logging in sysbench

### DIFF
--- a/pkg/cmd/roachtest/sysbench.go
+++ b/pkg/cmd/roachtest/sysbench.go
@@ -116,9 +116,9 @@ func runSysbench(ctx context.Context, t *test, c *cluster, opts sysbenchOptions)
 		// Sysbench occasionally segfaults. When that happens, don't fail the
 		// test.
 		if err != nil && !strings.Contains(err.Error(), "Segmentation fault") {
-			c.l.Printf("sysbench segfaulted; passing test anyway")
 			return err
 		}
+		c.l.Printf("sysbench segfaulted; passing test anyway")
 		return nil
 	})
 	m.Wait()


### PR DESCRIPTION
It was logging in the wrong place.

Closes #61058.

The failures in the above issue are inactionable due to age. We'll
have to look faster next time, but it appears likely that there was
a segfault we didn't catch (exit code 139), and that we need to
improve the code to look at the exit status instead. Next time will
tell for sure.

Release note: None
