### PR TITLE
kvserver: clean up miscellaneous comments over `replicaRankings`

### DIFF
--- a/pkg/kv/kvserver/replica_rankings.go
+++ b/pkg/kv/kvserver/replica_rankings.go
@@ -17,19 +17,17 @@ import (
 )
 
 const (
-	// TODO(a-robinson): Scale this up based on the number of replicas on a store?
+	// TODO(aayush): Scale this up based on the number of replicas on a store?
 	numTopReplicasToTrack = 128
 )
 
 type replicaWithStats struct {
 	repl *Replica
 	qps  float64
-	// TODO(a-robinson): Include writes-per-second and logicalBytes of storage?
+	// TODO(aayush): Include writes-per-second and logicalBytes of storage?
 }
 
-// replicaRankings maintains top-k orderings of the replicas in a store along
-// different dimensions of concern, such as QPS, keys written per second, and
-// disk used.
+// replicaRankings maintains top-k orderings of the replicas in a store by QPS.
 type replicaRankings struct {
 	mu struct {
 		syncutil.Mutex


### PR DESCRIPTION
Release note: None