### PR TITLE
server,cli/demo: make the SQL and HTTP listeners configurable

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -59,6 +59,9 @@ type TestServerArgs struct {
 	TenantAddr *string
 	// HTTPAddr (if nonempty) is the HTTP address to use for the test server.
 	HTTPAddr string
+	// HTTPAdvertiseAddr (if nonempty) is the advertised HTTP address to use.
+	HTTPAdvertiseAddr string
+
 	// DisableTLSForHTTP if set, disables TLS for the HTTP interface.
 	DisableTLSForHTTP bool
 

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -1125,11 +1125,57 @@ There should be as many TCP ports available as the value of --nodes
 starting at the specified value.`,
 	}
 
+	DemoSQLAddr = FlagInfo{
+		Name: "sql-addr",
+		Description: `The network address for demo nodes
+to listen for connection requests from SQL clients.
+The port number must not be included.`,
+	}
+
 	DemoHTTPPort = FlagInfo{
 		Name: "http-port",
 		Description: `First port number for HTTP servers.
 There should be as many TCP ports available as the value of --nodes
 starting at the specified value.`,
+	}
+
+	DemoHTTPAddr = FlagInfo{
+		Name: "http-addr",
+		Description: `The network address for demo nodes
+to listen for connection requests from HTTP clients.
+The port number must not be included.
+
+Attention: if using --secure-http=false with a non-default
+--http-addr, the resulting configuration may expose an unsecured
+HTTP service over a shared network, resulting in possible
+remote access to the local machine.`,
+	}
+
+	DemoHTTPAdvertiseAddr = FlagInfo{
+		Name: "http-advertise-addr",
+		Description: `The address to include in the web UI URL
+displayed upon server startup and \demo ls. It is also
+the address embedded in the server TLS certificate as
+Common Name (CN) when the HTTPS console is enabled with
+--secure-http.
+The port number should be included; add :0 after the network
+address to reuse the same HTTP port as each simulated node.
+
+The default is the same as --http-addr.`,
+	}
+
+	DemoSecureHTTP = FlagInfo{
+		Name: "secure-http",
+		Description: `If set, enable TLS for accessing the web UI.
+This causes the demo nodes to use a self-signed
+TLS certificate for the HTTP port.
+Use --http-advertise-addr to control the network
+address listed as Common Name (CN) in the TLS certificate.
+
+Attention: if using --secure-http=false with a non-default
+--http-addr, the resulting configuration may expose an unsecured
+HTTP service over a shared network, resulting in possible
+remote access to the local machine.`,
 	}
 
 	DemoNodes = FlagInfo{

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -564,6 +564,11 @@ var demoCtx struct {
 	insecure                  bool
 	sqlPort                   int
 	httpPort                  int
+
+	sqlAddr           string
+	httpAddr          string
+	httpAdvertiseAddr string
+	secureHTTP        bool
 }
 
 // setDemoContextDefaults set the default values in demoCtx.  This
@@ -584,6 +589,10 @@ func setDemoContextDefaults() {
 	demoCtx.insecure = false
 	demoCtx.sqlPort, _ = strconv.Atoi(base.DefaultPort)
 	demoCtx.httpPort, _ = strconv.Atoi(base.DefaultHTTPPort)
+	demoCtx.sqlAddr = "127.0.0.1"
+	demoCtx.httpAddr = "127.0.0.1"
+	demoCtx.httpAdvertiseAddr = ""
+	demoCtx.secureHTTP = false
 }
 
 // stmtDiagCtx captures the command-line parameters of the 'statement-diag'

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -780,6 +780,11 @@ func init() {
 
 		intFlag(f, &demoCtx.sqlPort, cliflags.DemoSQLPort)
 		intFlag(f, &demoCtx.httpPort, cliflags.DemoHTTPPort)
+
+		stringFlag(f, &demoCtx.sqlAddr, cliflags.DemoSQLAddr)
+		stringFlag(f, &demoCtx.httpAddr, cliflags.DemoHTTPAddr)
+		stringFlag(f, &demoCtx.httpAdvertiseAddr, cliflags.DemoHTTPAdvertiseAddr)
+		boolFlag(f, &demoCtx.secureHTTP, cliflags.DemoSecureHTTP)
 	}
 
 	// statement-diag command.

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -218,6 +218,9 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 	if params.HTTPAddr != "" {
 		cfg.HTTPAddr = params.HTTPAddr
 	}
+	if params.HTTPAdvertiseAddr != "" {
+		cfg.HTTPAdvertiseAddr = params.HTTPAdvertiseAddr
+	}
 	cfg.DisableTLSForHTTP = params.DisableTLSForHTTP
 	if params.DisableWebSessionAuthentication {
 		cfg.EnableWebSessionAuthentication = false


### PR DESCRIPTION
Fixes #64148.

Prior to this change, a `demo` instance would restrict
all its network listeners to 127.0.0.1.

Since this choice was initially made, we discovered the utility of
embedding a `demo` shell inside a Katakoda instance, where the
Katakoda infrastructure is able to provide a secure HTTPS proxy with a
public CA for a service running inside the sandbox.

Since that proxying requires the service to be exposed on the
sandbox's external address, we wanted the `demo` shell
to make its listeners configurable.

Release note (cli change): It is now possible to enable TLS for the
web UI console of `cockroach demo` with the new flag
`--secure-http`. This makes it possible to expose the HTTP interface
to a shared network.

Note however that this configuration still uses an ephemeral
self-signed CA generated by `demo` itself, and is thus insufficient
for use by end users web browsers directly: it should still be
combined with a HTTP proxy that exposes the service using a public CA.

This feature is not enabled by default.

Release note (cli change): The network address bound by `cockroach
demo` simulated nodes is now configurable via the new command-line
flags `--http-addr` (for the HTTP interface) and `--sql-addr` (for the
TCP interface for SQL clients).

The default for these flags results in the same configuration as
in previous versions, that is, the `demo` nodes only listen
on 127.0.0.1.

Note that `--http-addr` cannot be used without passing `--secure-http`
explicitly (either via `--secure-http=true` or
`--secure-http=false`), so as to clearly signal intent.


Release note (cli change): The CommonName (CN) field of the TLS server
certificate generated for the HTTP port in `cockroach demo` (when
`--secure-http` is used) is now configurable via the new flag
`--http-advertise-addr`. This is also the address displayed in the web
UI URLs printed to the user via the `\demo ls` client-side command.

The default for this value is the same as `--http-addr`.