### PR TITLE
admission: add admission control package

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -299,6 +299,7 @@ ALL_TESTS = [
     "//pkg/testutils:testutils_test",
     "//pkg/ts/testmodel:testmodel_test",
     "//pkg/ts:ts_test",
+    "//pkg/util/admission:admission_test",
     "//pkg/util/binfetcher:binfetcher_test",
     "//pkg/util/bitarray:bitarray_test",
     "//pkg/util/cache:cache_test",

--- a/pkg/util/admission/BUILD.bazel
+++ b/pkg/util/admission/BUILD.bazel
@@ -1,0 +1,38 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "admission",
+    srcs = [
+        "doc.go",
+        "granter.go",
+        "work_queue.go",
+    ],
+    importpath = "github.com/cockroachdb/cockroach/pkg/util/admission",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/base",
+        "//pkg/roachpb",
+        "//pkg/util/metric",
+        "//pkg/util/syncutil",
+        "//pkg/util/timeutil",
+        "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
+    ],
+)
+
+go_test(
+    name = "admission_test",
+    srcs = [
+        "granter_test.go",
+        "work_queue_test.go",
+    ],
+    data = glob(["testdata/**"]),
+    embed = [":admission"],
+    deps = [
+        "//pkg/roachpb",
+        "//pkg/util/leaktest",
+        "//pkg/util/log",
+        "//pkg/util/syncutil",
+        "@com_github_cockroachdb_datadriven//:datadriven",
+    ],
+)

--- a/pkg/util/admission/doc.go
+++ b/pkg/util/admission/doc.go
@@ -1,0 +1,121 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// The admission package contains abstractions for admission control for
+// CockroachDB nodes, both for single-tenant and multi-tenant (aka serverless)
+// clusters. In the latter, both KV and SQL nodes are expected to use these
+// abstractions.
+//
+// Admission control has the goal of
+// - Limiting node overload, so that bad things don't happen due to starvation
+//   of resources.
+// - Providing performance isolation between low and high importance
+//   activities, so that overload caused by the latter does not impact the
+//   latency of the former. Additionally, for multi-tenant KV nodes, the
+//   isolation should extend to inter-tenant performance isolation.
+//   Isolation is strictly harder than limiting node overload, and the
+//   abstractions here are likely to be average quality in doing so.
+//
+// At a high-level we are trying to shift queueing from system-provided
+// resource allocation abstractions that we do not control, like the goroutine
+// scheduler, to queueing in admission control, where we can reorder. This
+// needs to be done while maintaining high utilization of the resource.
+//
+// Note that everything here operates at a single node level, and not at a
+// cluster level. Cluster level admission control is insufficient for limiting
+// node overload or to provide performance isolation in a distributed system
+// with strong work affinity (which is true for a stateful system like
+// CockroachDB, since rebalancing operates at time scales that can be higher
+// than what we need). Cluster level admission control can complement node
+// level admission control, in that it can prevent severe abuse, or provide
+// cost controls to tenants.
+//
+// It is possible to also have intermediate mechanisms that gate admission of
+// work on load signals of all the nodes in the raft group of the range. This
+// could be especially useful for writes where non-leaseholder nodes could be
+// suffering from cpu or disk IO overload. This is not considered in the
+// following interfaces.
+//
+// TODO(sumeer): describe more of the design thinking documented in
+// https://github.com/sumeerbhola/cockroach/blob/27ab4062ad1b036ab1e686a66a04723bd9f2b5a0/pkg/util/cpupool/cpu_pool.go
+// either in a comment here or a separate RFC.
+//
+
+// Internal organization:
+//
+// The package is mostly structured as a set of interfaces that are meant to
+// provide a general framework, and specific implementations that are
+// initially quite simple in their heuristics but may become more
+// sophisticated over time. The concrete abstractions:
+// - Tokens and slots are the two ways admission is granted (see grantKind)
+// - Categorization of kinds of work (see WorkKind), and a priority ordering
+//   across WorkKinds that is used to reflect their shared need for underlying
+//   resources.
+// - The top-level GrantCoordinator which coordinates grants across these
+//   WorkKinds. The WorkKinds handled by an instantiation of GrantCoordinator
+//   will differ for single-tenant clusters, and multi-tenant clusters
+//   consisting of (multi-tenant) KV nodes and (single-tenant) SQL nodes.
+//
+// The interfaces involved:
+// -  requester: handles all requests for a particular WorkKind. Implemented by
+//   WorkQueue. The requester implementation is responsible for controlling
+//   the admission order within a WorkKind based on tenant fairness,
+//   importance of work etc.
+// - granter: the counterpart to requester which grants admission tokens or
+//   slots. The implementations are slotGranter and tokenGranter. The
+//   implementation of requester interacts with the granter interface.
+// - granterWithLockedCalls: this is an extension of granter that is used
+//   as part of the implementation of GrantCoordinator. This arrangement
+//   is partly to centralize locking in the GrantCoordinator (except for
+//   the lock in WorkQueue).
+// - cpuOverloadIndicator: this serves as an optional additional gate on
+//   granting, by providing an (ideally) instantaneous signal of cpu overload.
+//   The kvSlotAdjuster is the concrete implementation, except for SQL
+//   nodes, where this is implemented by sqlNodeCPUOverloadIndicator.
+//   CPULoadListener is also implemented by these structs, to listen to
+//   the latest CPU load information from the scheduler.
+//
+// Load observation and slot count or token burst adjustment: Currently the
+// only dynamic adjustment is performed by kvSlotAdjuster for KVWork slots.
+// This is because KVWork is expected to usually be CPU bound (due to good
+// caching), and unlike SQLKVResponseWork and SQLSQLResponseWork (which are
+// even more CPU bound), we have a completion indicator -- so we can expect to
+// have a somewhat stable KVWork slot count even if the work sizes are
+// extremely heterogeneous.
+//
+// Since there isn't token burst adjustment, the burst limits should be chosen
+// to err on the side of fully saturating CPU, since we have the fallback of
+// the cpuOverloadIndicator to stop granting even if tokens are available.
+// If we figure out a way to dynamically tune the token burst count, or
+// (even more ambitious) figure out a way to come up with a token rate, it
+// should fit in the general framework that is setup here.
+//
+
+// Partial usage example (regular cluster):
+//
+// var metricRegistry *metric.Registry = ...
+// coord, metrics := admission.NewGrantCoordinator(admission.Options{...})
+// for i := range metrics {
+//   registry.AddMetricStruct(metrics[i])
+// }
+// kvQueue := coord.GetWorkQueue(admission.KVWork)
+// // Pass kvQueue to server.Node that implements roachpb.InternalServer.
+// ...
+// // Do similar things with the other WorkQueues.
+//
+// Usage of WorkQueue for KV:
+// // Before starting some work
+// if err := kvQueue.Admit(ctx, WorkInfo{TenantID: tid, ...}); err != nil {
+//   return err
+// }
+// doWork()
+// kvQueue.AdmittedWorkDone(tid)
+
+package admission

--- a/pkg/util/admission/granter.go
+++ b/pkg/util/admission/granter.go
@@ -1,0 +1,966 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package admission
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
+)
+
+// requester is an interface implemented by an object that orders admission
+// work for a particular WorkKind. See WorkQueue for the implementation of
+// requester.
+type requester interface {
+	// hasWaitingRequests returns whether there are any waiting/queued requests
+	// of this WorkKind.
+	hasWaitingRequests() bool
+	// granted is called by a granter to grant admission to queued requests. It
+	// returns true if the grant was accepted, else returns false. A grant may
+	// not be accepted if the grant raced with request cancellation and there
+	// are now no waiting requests.
+	granted() bool
+}
+
+// grantKind represents the two kind of ways we grant admission: using a slot
+// or a token. The slot terminology is akin to a scheduler, where a scheduling
+// slot must be free for a thread to run. But unlike a scheduler, we don't
+// have visibility into the fact that work execution may be blocked on IO. So
+// a slot can also be viewed as a limit on concurrency of ongoing work. The
+// token terminology is inspired by token buckets. In this case the token is
+// handed out for admission but it is not returned (unlike a slot). Unlike a
+// token bucket, which shapes the rate, the current implementation (see
+// tokenGranter) limits burstiness and does not do rate shaping -- this is
+// because it is hard to predict what rate is appropriate given the difference
+// in sizes of the work. This lack of rate shaping may change in the future
+// and is not a limitation of the interfaces. Similarly, there is no rate
+// shaping applied when granting slots and that may also change in the future.
+// The main difference between a slot and a token is that a slot is used when
+// we can know when the work is complete. Having this extra completion
+// information can be advantageous in admission control decisions, so
+// WorkKinds where this information is easily available use slots.
+type grantKind int8
+
+const (
+	slot grantKind = iota
+	token
+)
+
+// granter is paired with a requester in that a requester for a particular
+// WorkKind will interact with a granter. See doc.go for an overview of how
+// this fits into the overall structure.
+type granter interface {
+	grantKind() grantKind
+	// tryGet is used by a requester to get a slot/token for a piece of work
+	// that has encountered no waiting/queued work. This is the fast path that
+	// avoids queueing in the requester.
+	tryGet() bool
+	// returnGrant is called for returning slots after use, and used for
+	// returning either slots or tokens when the grant raced with the work being
+	// canceled, and the grantee did not end up doing any work. The latter case
+	// occurs despite the bool return value on the requester.granted method --
+	// it is possible that the work was not canceled at the time when
+	// requester.grant was called, and hence returned true, but later when the
+	// goroutine doing the work noticed that it had been granted, there is a
+	// possibility that that raced with cancellation.
+	returnGrant()
+	// tookWithoutPermission informs the granter that a slot/token was taken
+	// unilaterally, without permission. Currently we only implement this for
+	// slots, since only KVWork is allowed to bypass admission control for high
+	// priority internal activities (e.g. node liveness) and for KVWork that
+	// generates other KVWork (like intent resolution of discovered intents).
+	// Not bypassing for the latter could result in single node or distributed
+	// deadlock, and since such work is typically not a major (on average)
+	// consumer of resources, we consider bypassing to be acceptable.
+	tookWithoutPermission()
+	// continueGrantChain is called by the requester at some point after grant
+	// was called on the requester. The expectation is that this is called by
+	// the grantee after its goroutine runs and notices that it has been granted
+	// a slot/token. This provides a natural throttling that reduces grant
+	// bursts by taking into immediate account the capability of the goroutine
+	// scheduler to schedule such work.
+	//
+	// In an experiment, using such grant chains reduced burstiness of grants by
+	// 5x and shifted ~2s of latency (at p99) from the scheduler into admission
+	// control (which is desirable since the latter is where we can
+	// differentiate between work).
+	// TODO(sumeer): the above experiments used grant chains only for
+	// non-KVWork. It is possible that grant chains could under-utilize CPU. Run
+	// more experiments.
+	continueGrantChain()
+}
+
+// WorkKind represents various types of work that are subject to admission
+// control.
+type WorkKind int8
+
+// The list of WorkKinds are ordered from lower level to higher level, and
+// also serves as a hard-wired ordering from most important to least important
+// (for details on how this ordering is enacted, see the GrantCoordinator
+// code).
+//
+// KVWork, SQLKVResponseWork, SQLSQLResponseWork are the lower-level work
+// units that are expected to be primarily CPU bound (with disk IO for KVWork,
+// but cache hit rates are typically high), and expected to be where most of
+// the CPU consumption happens. These are prioritized in the order
+//   KVWork > SQLKVResponseWork > SQLSQLResponseWork
+//
+// The high prioritization of KVWork reduces the likelihood that non-SQL KV
+// work will be starved. SQLKVResponseWork is prioritized over
+// SQLSQLResponseWork since the former includes leaf DistSQL processing and we
+// would like to release memory used up in RPC responses at lower layers of
+// RPC tree. We expect that if SQLSQLResponseWork is delayed, it will
+// eventually reduce new work being issued, which is a desirable form of
+// natural backpressure.
+//
+// Furthermore, SQLStatementLeafStartWork and SQLStatementRootStartWork are
+// prioritized lowest with
+//   SQLStatementLeafStartWork > SQLStatementRootStartWork
+// This follows the same idea of prioritizing lower layers above higher layers
+// since it releases memory caught up in lower layers, and exerts natural
+// backpressure on the higher layer.
+//
+// Consider the example of a less important long-running single statement OLAP
+// query competing with more important small OLTP queries in a single node
+// setting. Say the OLAP query starts first and uses up all the KVWork slots,
+// and the OLTP queries queue up for the KVWork slots. As the OLAP query
+// KVWork completes, it will queue up for SQLKVResponseWork, which will not
+// start because the OLTP queries are using up all available KVWork slots. As
+// this OLTP KVWork completes, their SQLKVResponseWork will queue up. The
+// WorkQueue for SQLKVResponseWork, when granting tokens, will first admit
+// those for the more important OLTP queries. This will prevent or slow down
+// admission of further work by the OLAP query.
+//
+// In an ideal world with the only shared resource (across WorkKinds) being
+// CPU, and control over the CPU scheduler, we could pool all work, regardless
+// of WorkKind into a single queue, and would not need to rely on this
+// indirect backpressure and hard-wired ordering. However, we do not have
+// control over the CPU scheduler, so we cannot preempt work with widely
+// different cpu consumption. Additionally, (non-preemptible) memory is also a
+// shared resource, and we wouldn't want to have partially done KVWork not
+// finish, due to preemption in the CPU scheduler, since it can be holding
+// significant amounts of memory (e.g. in scans).
+//
+// The aforementioned prioritization also enables us to get instantaneous
+// feedback on CPU resource overload. This instantaneous feedback for a grant
+// chain (mentioned earlier) happens in two ways:
+// - the chain requires the grantee's goroutine to run.
+// - the cpuOverloadIndicator (see later), specifically the implementation
+//   provided by kvSlotAdjuster, provides instantaneous feedback (which is
+//   viable only because KVWork is the highest priority).
+//
+// Weaknesses of this strict prioritization across WorkKinds:
+// - Priority inversion: Lower importance KVWork, not derived from SQL, like
+//   GC of MVCC versions, will happen before user-facing SQLKVResponseWork.
+//   This is because the backpressure, described in the example above, does
+//   not apply to work generated from within the KV layer.
+//   TODO(sumeer): introduce a KVLowPriWork and put it last in this ordering,
+//   to get over this limitation.
+// - Insufficient competition leading to poor isolation: Putting
+//   SQLStatementLeafStartWork, SQLStatementRootStartWork in this list, within
+//   the same GrantCoordinator, does provide node overload protection, but not
+//   necessarily performance isolation when we have WorkKinds of different
+//   importance. Consider the same OLAP example above: if the KVWork slots
+//   being full due to the OLAP query prevents SQLStatementRootStartWork for
+//   the OLTP queries, the competition is starved out before it has an
+//   opportunity to submit any KVWork. Given that control over admitting
+//   SQLStatement{Leaf,Root}StartWork is not primarily about CPU control (the
+//   lower-level work items are where cpu is consumed), we could decouple
+//   these two into a separate GrantCoordinator and only gate them with (high)
+//   fixed slot counts that allow for enough competition, plus a memory
+//   overload indicator.
+//   TODO(sumeer): experiment with this approach.
+// - Continuing the previous bullet, low priority long-lived
+//   {SQLStatementLeafStartWork, SQLStatementRootStartWork} could use up all
+//   the slots, if there was no high priority work for some period of time,
+//   and therefore starve admission of the high priority work when it does
+//   appear. The typical solution to this is to put a max on the number of
+//   slots low priority can use. This would be viable if we did not allow
+//   arbitrary int8 values to be set for WorkPriority.
+
+const (
+	// KVWork represents requests submitted to the KV layer, from the same node
+	// or a different node. They may originate from the SQL layer or the KV
+	// layer.
+	KVWork WorkKind = iota
+	// SQLKVResponseWork is response processing in SQL for a KV response from a
+	// local or remote node. This can be either leaf or root DistSQL work, i.e.,
+	// this is inter-layer and not necessarily inter-node.
+	SQLKVResponseWork
+	// SQLSQLResponseWork is response processing in SQL, for DistSQL RPC
+	// responses. This is root work happening in response to leaf SQL work,
+	// i.e., it is inter-node.
+	SQLSQLResponseWork
+	// SQLStatementLeafStartWork represents the start of leaf-level processing
+	// for a SQL statement.
+	SQLStatementLeafStartWork
+	// SQLStatementRootStartWork represents the start of root-level processing
+	// for a SQL statement.
+	SQLStatementRootStartWork
+	numWorkKinds
+)
+
+func workKindString(workKind WorkKind) redact.RedactableString {
+	switch workKind {
+	case KVWork:
+		return "kv"
+	case SQLKVResponseWork:
+		return "sql-kv-response"
+	case SQLSQLResponseWork:
+		return "sql-sql-response"
+	case SQLStatementLeafStartWork:
+		return "sql-leaf-start"
+	case SQLStatementRootStartWork:
+		return "sql-root-start"
+	default:
+		panic(errors.AssertionFailedf("unknown WorkKind"))
+	}
+}
+
+type grantResult int8
+
+const (
+	grantSuccess grantResult = iota
+	// grantFailDueToSharedResource is returned when the granter is unable to
+	// grant because a shared resource (CPU or memory) is overloaded. For grant
+	// chains, this is a signal to terminate.
+	grantFailDueToSharedResource
+	// grantFailLocal is returned when the granter is unable to grant due to a
+	// local constraint -- insufficient tokens or slots.
+	grantFailLocal
+)
+
+// granterWithLockedCalls is an extension of the granter and requester
+// interfaces that is used as an internal implementation detail of the
+// GrantCoordinator. Note that an implementer of granterWithLockedCalls is
+// mainly passing things through to the GrantCoordinator where the main logic
+// lives. The *Locked() methods are where the differences in slots and tokens
+// are handled.
+type granterWithLockedCalls interface {
+	granter
+	// tryGetLocked is the real implementation of tryGet in the granter interface.
+	// Additionally, it is also used when continuing a grant chain.
+	tryGetLocked() grantResult
+	// returnGrantLocked is the real implementation of returnGrant.
+	returnGrantLocked()
+	// tookWithoutPermissionLocked is the real implementation of
+	// tookWithoutPermission.
+	tookWithoutPermissionLocked()
+
+	// getPairedRequester returns the requester implementation that this granter
+	// interacts with.
+	getPairedRequester() requester
+}
+
+// slotGranter implements granterWithLockedCalls.
+type slotGranter struct {
+	coord      *GrantCoordinator
+	workKind   WorkKind
+	requester  requester
+	usedSlots  int
+	totalSlots int
+
+	// Optional. Nil for a slotGranter used for KVWork since the slots for that
+	// slotGranter are directly adjusted by the kvSlotAdjuster (using the
+	// kvSlotAdjuster here would provide a redundant identical signal).
+	cpuOverload cpuOverloadIndicator
+	// TODO(sumeer): Add an optional overload indicator for memory, that will be
+	// relevant for SQLStatementLeafStartWork and SQLStatementRootStartWork.
+
+	usedSlotsMetric *metric.Gauge
+}
+
+var _ granterWithLockedCalls = &slotGranter{}
+
+func (sg *slotGranter) getPairedRequester() requester {
+	return sg.requester
+}
+
+func (sg *slotGranter) grantKind() grantKind {
+	return slot
+}
+
+func (sg *slotGranter) tryGet() bool {
+	return sg.coord.tryGet(sg.workKind)
+}
+
+func (sg *slotGranter) tryGetLocked() grantResult {
+	if sg.cpuOverload != nil && sg.cpuOverload.isOverloaded() {
+		return grantFailDueToSharedResource
+	}
+	if sg.usedSlots < sg.totalSlots {
+		sg.usedSlots++
+		sg.usedSlotsMetric.Update(int64(sg.usedSlots))
+		return grantSuccess
+	}
+	if sg.workKind == KVWork {
+		return grantFailDueToSharedResource
+	}
+	return grantFailLocal
+}
+
+func (sg *slotGranter) returnGrant() {
+	sg.coord.returnGrant(sg.workKind)
+}
+
+func (sg *slotGranter) returnGrantLocked() {
+	sg.usedSlots--
+	if sg.usedSlots < 0 {
+		panic(errors.AssertionFailedf("used slots is negative %d", sg.usedSlots))
+	}
+	sg.usedSlotsMetric.Update(int64(sg.usedSlots))
+}
+
+func (sg *slotGranter) tookWithoutPermission() {
+	sg.coord.tookWithoutPermission(sg.workKind)
+}
+
+func (sg *slotGranter) tookWithoutPermissionLocked() {
+	sg.usedSlots++
+	sg.usedSlotsMetric.Update(int64(sg.usedSlots))
+}
+
+func (sg *slotGranter) continueGrantChain() {
+	sg.coord.continueGrantChain(sg.workKind)
+}
+
+// tokenGranter implements granterWithLockedCalls.
+type tokenGranter struct {
+	coord                *GrantCoordinator
+	workKind             WorkKind
+	requester            requester
+	availableBurstTokens int
+	maxBurstTokens       int
+	// Optional. Practically, both uses of tokenGranter, for SQLKVResponseWork
+	// and SQLSQLResponseWork have a non-nil value. We don't expect to use
+	// memory overload indicators here since memory accounting and disk spilling
+	// is what should be tasked with preventing OOMs, and we want to finish
+	// processing this lower-level work.
+	cpuOverload cpuOverloadIndicator
+}
+
+var _ granterWithLockedCalls = &tokenGranter{}
+
+func (tg *tokenGranter) getPairedRequester() requester {
+	return tg.requester
+}
+
+func (tg *tokenGranter) refillBurstTokens() {
+	tg.availableBurstTokens = tg.maxBurstTokens
+}
+
+func (tg *tokenGranter) grantKind() grantKind {
+	return token
+}
+
+func (tg *tokenGranter) tryGet() bool {
+	return tg.coord.tryGet(tg.workKind)
+}
+
+func (tg *tokenGranter) tryGetLocked() grantResult {
+	if tg.cpuOverload != nil && tg.cpuOverload.isOverloaded() {
+		return grantFailDueToSharedResource
+	}
+	if tg.availableBurstTokens > 0 {
+		tg.availableBurstTokens--
+		return grantSuccess
+	}
+	return grantFailLocal
+}
+
+func (tg *tokenGranter) returnGrant() {
+	tg.coord.returnGrant(tg.workKind)
+}
+
+func (tg *tokenGranter) returnGrantLocked() {
+	tg.availableBurstTokens++
+	if tg.availableBurstTokens > tg.maxBurstTokens {
+		tg.availableBurstTokens = tg.maxBurstTokens
+	}
+}
+
+func (tg *tokenGranter) tookWithoutPermission() {
+	panic(errors.AssertionFailedf("unimplemented"))
+}
+
+func (tg *tokenGranter) tookWithoutPermissionLocked() {
+	panic(errors.AssertionFailedf("unimplemented"))
+}
+
+func (tg *tokenGranter) continueGrantChain() {
+	tg.coord.continueGrantChain(tg.workKind)
+}
+
+// GrantCoordinator is the top-level object that coordinates grants across
+// different WorkKinds (for more context see the comment in doc.go, and the
+// comment where WorkKind is declared). Typically there will one
+// GrantCoordinator in a node (see the NewGrantCoordinator*() functions for
+// the different kinds of nodes).
+type GrantCoordinator struct {
+	// mu is ordered before any mutex acquired in a requester implementation.
+	mu syncutil.Mutex
+	// NB: Some granters can be nil.
+	granters [numWorkKinds]granterWithLockedCalls
+	// The WorkQueues behaving as requesters in each granterWithLockedCalls.
+	// This is kept separately only to service GetWorkQueue calls.
+	queues               [numWorkKinds]requester
+	cpuOverloadIndicator cpuOverloadIndicator
+	cpuLoadListener      CPULoadListener
+
+	// See the comment at continueGrantChain that explains how a grant chain
+	// functions and the motivation.
+
+	// grantChainActive indicates whether a grant chain is active.
+	grantChainActive bool
+	// forceTerminateGrantChain implies we should start another grant chain
+	// since the previous one did not die a natural death.
+	forceTerminateGrantChain bool
+	// Index into granters, which represents the current WorkKind at which the
+	// grant chain is operating. Only relevant when grantChainActive is true.
+	grantChainIndex WorkKind
+}
+
+var _ CPULoadListener = &GrantCoordinator{}
+
+// Options for constructing a GrantCoordinator.
+type Options struct {
+	MinCPUSlots                    int
+	MaxCPUSlots                    int
+	SQLKVResponseBurstTokens       int
+	SQLSQLResponseBurstTokens      int
+	SQLStatementLeafStartWorkSlots int
+	SQLStatementRootStartWorkSlots int
+	// Only non-nil for tests.
+	makeRequesterFunc func(
+		workKind WorkKind, granter granter, usesTokens bool, tiedToRange bool) requester
+}
+
+// NewGrantCoordinator constructs a GrantCoordinator and WorkQueues for a
+// regular cluster node. Caller is responsible for hooking this up to receive
+// calls to CPULoad.
+func NewGrantCoordinator(opts Options) (*GrantCoordinator, []metric.Struct) {
+	makeRequester := makeWorkQueue
+	if opts.makeRequesterFunc != nil {
+		makeRequester = opts.makeRequesterFunc
+	}
+
+	metrics := makeGranterMetrics()
+	metricStructs := append([]metric.Struct(nil), metrics)
+	kvSlotAdjuster := &kvSlotAdjuster{
+		minCPUSlots:      opts.MinCPUSlots,
+		maxCPUSlots:      opts.MaxCPUSlots,
+		totalSlotsMetric: metrics.KVTotalSlots,
+	}
+	coord := &GrantCoordinator{
+		cpuOverloadIndicator: kvSlotAdjuster,
+		cpuLoadListener:      kvSlotAdjuster,
+	}
+
+	sg := &slotGranter{
+		coord:           coord,
+		workKind:        KVWork,
+		totalSlots:      opts.MinCPUSlots,
+		usedSlotsMetric: metrics.KVUsedSlots,
+	}
+	kvSlotAdjuster.granter = sg
+	coord.queues[KVWork] = makeRequester(
+		KVWork, sg, false /* usesTokens */, true /* tiedToRange */)
+	sg.requester = coord.queues[KVWork]
+	coord.granters[KVWork] = sg
+
+	tg := &tokenGranter{
+		coord:                coord,
+		workKind:             SQLKVResponseWork,
+		availableBurstTokens: opts.SQLKVResponseBurstTokens,
+		maxBurstTokens:       opts.SQLKVResponseBurstTokens,
+		cpuOverload:          kvSlotAdjuster,
+	}
+	coord.queues[SQLKVResponseWork] = makeRequester(
+		SQLKVResponseWork, tg, true /* usesTokens */, false /* tiedToRange */)
+	tg.requester = coord.queues[SQLKVResponseWork]
+	coord.granters[SQLKVResponseWork] = tg
+
+	tg = &tokenGranter{
+		coord:                coord,
+		workKind:             SQLSQLResponseWork,
+		availableBurstTokens: opts.SQLSQLResponseBurstTokens,
+		maxBurstTokens:       opts.SQLSQLResponseBurstTokens,
+		cpuOverload:          kvSlotAdjuster,
+	}
+	coord.queues[SQLSQLResponseWork] = makeRequester(
+		SQLSQLResponseWork, tg, true /* usesTokens */, false /* tiedToRange */)
+	tg.requester = coord.queues[SQLSQLResponseWork]
+	coord.granters[SQLSQLResponseWork] = tg
+
+	sg = &slotGranter{
+		coord:           coord,
+		workKind:        SQLStatementLeafStartWork,
+		totalSlots:      opts.SQLStatementLeafStartWorkSlots,
+		cpuOverload:     kvSlotAdjuster,
+		usedSlotsMetric: metrics.SQLLeafStartUsedSlots,
+	}
+	coord.queues[SQLStatementLeafStartWork] = makeRequester(
+		SQLStatementLeafStartWork, sg, false /* usesTokens */, false /* tiedToRange */)
+	sg.requester = coord.queues[SQLStatementLeafStartWork]
+	coord.granters[SQLStatementLeafStartWork] = sg
+
+	sg = &slotGranter{
+		coord:           coord,
+		workKind:        SQLStatementRootStartWork,
+		totalSlots:      opts.SQLStatementRootStartWorkSlots,
+		cpuOverload:     kvSlotAdjuster,
+		usedSlotsMetric: metrics.SQLRootStartUsedSlots,
+	}
+	coord.queues[SQLStatementRootStartWork] = makeRequester(
+		SQLStatementRootStartWork, sg, false /* usesTokens */, false /* tiedToRange */)
+	sg.requester = coord.queues[SQLStatementRootStartWork]
+	coord.granters[SQLStatementRootStartWork] = sg
+
+	return coord, appendMetricStructs(metricStructs, coord)
+}
+
+// NewGrantCoordinatorMultiTenantKV constructs a GrantCoordinator and
+// WorkQueues for a multi-tenant KV node. Caller is responsible for hooking
+// this up to receive calls to CPULoad.
+func NewGrantCoordinatorMultiTenantKV(opts Options) (*GrantCoordinator, []metric.Struct) {
+	makeRequester := makeWorkQueue
+	if opts.makeRequesterFunc != nil {
+		makeRequester = opts.makeRequesterFunc
+	}
+
+	metrics := makeGranterMetrics()
+	metricStructs := append([]metric.Struct(nil), metrics)
+	kvSlotAdjuster := &kvSlotAdjuster{
+		minCPUSlots:      opts.MinCPUSlots,
+		maxCPUSlots:      opts.MaxCPUSlots,
+		totalSlotsMetric: metrics.KVTotalSlots,
+	}
+	coord := &GrantCoordinator{
+		cpuOverloadIndicator: kvSlotAdjuster,
+		cpuLoadListener:      kvSlotAdjuster,
+	}
+
+	sg := &slotGranter{
+		coord:           coord,
+		workKind:        KVWork,
+		totalSlots:      opts.MinCPUSlots,
+		usedSlotsMetric: metrics.KVUsedSlots,
+	}
+	kvSlotAdjuster.granter = sg
+	coord.queues[KVWork] = makeRequester(
+		KVWork, sg, false /* usesTokens */, true /* tiedToRange */)
+	sg.requester = coord.queues[KVWork]
+	coord.granters[KVWork] = sg
+
+	return coord, appendMetricStructs(metricStructs, coord)
+}
+
+// NewGrantCoordinatorSQL constructs a GrantCoordinator and WorkQueues for a
+// single-tenant SQL node in a multi-tenant cluster. Caller is responsible for
+// hooking this up to receive calls to CPULoad.
+func NewGrantCoordinatorSQL(opts Options) (*GrantCoordinator, []metric.Struct) {
+	makeRequester := makeWorkQueue
+	if opts.makeRequesterFunc != nil {
+		makeRequester = opts.makeRequesterFunc
+	}
+
+	metrics := makeGranterMetrics()
+	metricStructs := append([]metric.Struct(nil), metrics)
+	sqlNodeCPU := &sqlNodeCPUOverloadIndicator{}
+	coord := &GrantCoordinator{
+		cpuOverloadIndicator: sqlNodeCPU,
+		cpuLoadListener:      sqlNodeCPU,
+	}
+
+	tg := &tokenGranter{
+		coord:                coord,
+		workKind:             SQLKVResponseWork,
+		availableBurstTokens: opts.SQLKVResponseBurstTokens,
+		maxBurstTokens:       opts.SQLKVResponseBurstTokens,
+		cpuOverload:          sqlNodeCPU,
+	}
+	coord.queues[SQLKVResponseWork] = makeRequester(
+		SQLKVResponseWork, tg, true /* usesTokens */, false /* tiedToRange */)
+	tg.requester = coord.queues[SQLKVResponseWork]
+	coord.granters[SQLKVResponseWork] = tg
+
+	tg = &tokenGranter{
+		coord:                coord,
+		workKind:             SQLSQLResponseWork,
+		availableBurstTokens: opts.SQLSQLResponseBurstTokens,
+		maxBurstTokens:       opts.SQLSQLResponseBurstTokens,
+		cpuOverload:          sqlNodeCPU,
+	}
+	coord.queues[SQLSQLResponseWork] = makeRequester(
+		SQLSQLResponseWork, tg, true /* usesTokens */, false /* tiedToRange */)
+	tg.requester = coord.queues[SQLSQLResponseWork]
+	coord.granters[SQLSQLResponseWork] = tg
+
+	sg := &slotGranter{
+		coord:           coord,
+		workKind:        SQLStatementLeafStartWork,
+		totalSlots:      opts.SQLStatementLeafStartWorkSlots,
+		cpuOverload:     sqlNodeCPU,
+		usedSlotsMetric: metrics.SQLLeafStartUsedSlots,
+	}
+	coord.queues[SQLStatementLeafStartWork] = makeRequester(
+		SQLStatementLeafStartWork, sg, false /* usesTokens */, false /* tiedToRange */)
+	sg.requester = coord.queues[SQLStatementLeafStartWork]
+	coord.granters[SQLStatementLeafStartWork] = sg
+
+	sg = &slotGranter{
+		coord:           coord,
+		workKind:        SQLStatementRootStartWork,
+		totalSlots:      opts.SQLStatementRootStartWorkSlots,
+		cpuOverload:     sqlNodeCPU,
+		usedSlotsMetric: metrics.SQLRootStartUsedSlots,
+	}
+	coord.queues[SQLStatementRootStartWork] = makeRequester(
+		SQLStatementRootStartWork, sg, false /* usesTokens */, false /* tiedToRange */)
+	sg.requester = coord.queues[SQLStatementRootStartWork]
+	coord.granters[SQLStatementRootStartWork] = sg
+
+	return coord, appendMetricStructs(metricStructs, coord)
+}
+
+func appendMetricStructs(ms []metric.Struct, coord *GrantCoordinator) []metric.Struct {
+	for i := range coord.queues {
+		if coord.queues[i] != nil {
+			q, ok := coord.queues[i].(*WorkQueue)
+			if ok {
+				ms = append(ms, q.metrics)
+			}
+		}
+	}
+	return ms
+}
+
+// GetWorkQueue returns the WorkQueue for a particular WorkKind. Can be nil if
+// the NewGrantCoordinator* function does not construct a WorkQueue for that
+// work.
+func (coord *GrantCoordinator) GetWorkQueue(workKind WorkKind) *WorkQueue {
+	return coord.queues[workKind].(*WorkQueue)
+}
+
+// CPULoad implements CPULoadListener and is called every 1ms. The same
+// frequency is used for refilling the burst tokens since synchronizing the
+// two means that the refilled burst can take into account the latest
+// schedulers stats (indirectly, via the implementation of
+// cpuOverloadIndicator).
+// TODO(sumeer): after experimentation, possibly generalize the 1ms ticks used
+// for CPULoad.
+func (coord *GrantCoordinator) CPULoad(runnable int, procs int) {
+	coord.mu.Lock()
+	defer coord.mu.Unlock()
+	coord.cpuLoadListener.CPULoad(runnable, procs)
+	coord.granters[SQLKVResponseWork].(*tokenGranter).refillBurstTokens()
+	coord.granters[SQLSQLResponseWork].(*tokenGranter).refillBurstTokens()
+	if coord.grantChainActive {
+		coord.forceTerminateGrantChain = true
+		return
+	}
+	coord.tryGrant()
+}
+
+// tryGet is called by granter.tryGet with the WorkKind.
+func (coord *GrantCoordinator) tryGet(workKind WorkKind) bool {
+	coord.mu.Lock()
+	defer coord.mu.Unlock()
+	// It is possible that a grant chain is active, and has not yet made its way
+	// to this workKind. So it may be more reasonable to queue. But we have some
+	// concerns about incurring the delay of multiple goroutine context switches
+	// so we ignore this case.
+	res := coord.granters[workKind].tryGetLocked()
+	switch res {
+	case grantSuccess:
+		// Grant chain may be active, but it did not get in the way of this grant,
+		// and the effect of this grant in terms of overload will be felt by the
+		// grant chain.
+		return true
+	case grantFailDueToSharedResource:
+		// This could be a transient overload, that may not be noticed by the
+		// grant chain. We don't want it to continue granting to lower priority
+		// WorkKinds, while a higher priority one is waiting, so we terminate it.
+		if coord.grantChainActive && coord.grantChainIndex >= workKind {
+			coord.forceTerminateGrantChain = true
+		}
+		return false
+	case grantFailLocal:
+		return false
+	default:
+		panic(errors.AssertionFailedf("unknown case"))
+	}
+}
+
+// returnGrant is called by granter.returnGrant with the WorkKind.
+func (coord *GrantCoordinator) returnGrant(workKind WorkKind) {
+	coord.mu.Lock()
+	defer coord.mu.Unlock()
+	coord.granters[workKind].returnGrantLocked()
+	if coord.grantChainActive {
+		if coord.grantChainIndex > workKind && coord.granters[workKind].getPairedRequester().hasWaitingRequests() {
+			// There are waiting requests that will not be served by the grant chain.
+			// Better to terminate it and start afresh.
+			coord.forceTerminateGrantChain = true
+		}
+		// Else either the grant chain will get to this workKind, or there are no waiting requests.
+		return
+	}
+	coord.tryGrant()
+}
+
+// tookWithoutPermission is called by granter.tookWithoutPermission with the
+// WorkKind.
+func (coord *GrantCoordinator) tookWithoutPermission(workKind WorkKind) {
+	coord.mu.Lock()
+	defer coord.mu.Unlock()
+	coord.granters[workKind].tookWithoutPermissionLocked()
+}
+
+// continueGrantChain is called by granter.continueGrantChain with the
+// WorkKind.
+func (coord *GrantCoordinator) continueGrantChain(workKind WorkKind) {
+	coord.mu.Lock()
+	defer coord.mu.Unlock()
+	if coord.forceTerminateGrantChain {
+		coord.forceTerminateGrantChain = false
+		coord.grantChainActive = false
+	}
+	coord.tryGrant()
+}
+
+// tryGrant tries to either continue an existing grant chain, or tries to
+// start a new grant chain. It assumes that the caller has already handled
+// forceTerminateGrantChain=true, by setting it to false, and setting
+// grantChainActive=false.
+func (coord *GrantCoordinator) tryGrant() {
+	if !coord.grantChainActive {
+		coord.grantChainIndex = 0
+	}
+	// Assume that we will not be able to start a new grant chain, or that the
+	// existing one will die out. The code below will set it to true if neither
+	// is true.
+	coord.grantChainActive = false
+	for ; coord.grantChainIndex < numWorkKinds; coord.grantChainIndex++ {
+		localDone := false
+		granter := coord.granters[coord.grantChainIndex]
+		req := granter.getPairedRequester()
+		for req.hasWaitingRequests() && !localDone {
+			res := granter.tryGetLocked()
+			switch res {
+			case grantSuccess:
+				if !req.granted() {
+					granter.returnGrantLocked()
+				} else {
+					coord.grantChainActive = true
+					return
+				}
+			case grantFailDueToSharedResource:
+				return
+			case grantFailLocal:
+				localDone = true
+			}
+		}
+	}
+}
+
+func (coord *GrantCoordinator) String() string {
+	return redact.StringWithoutMarkers(coord)
+}
+
+// SafeFormat implements the redact.SafeFormatter interface.
+func (coord *GrantCoordinator) SafeFormat(s redact.SafePrinter, verb rune) {
+	coord.mu.Lock()
+	defer coord.mu.Unlock()
+	s.Printf("(chain: active: %t index: %d term: %t)",
+		coord.grantChainActive, coord.grantChainIndex, coord.forceTerminateGrantChain,
+	)
+
+	spaceStr := redact.RedactableString(" ")
+	newlineStr := redact.RedactableString("\n")
+	curSep := spaceStr
+	for i := range coord.granters {
+		kind := WorkKind(i)
+		switch kind {
+		case KVWork, SQLStatementLeafStartWork, SQLStatementRootStartWork:
+			g := coord.granters[i].(*slotGranter)
+			s.Printf("%s%s: used: %d, total: %d", curSep, workKindString(kind), g.usedSlots, g.totalSlots)
+		case SQLKVResponseWork, SQLSQLResponseWork:
+			g := coord.granters[i].(*tokenGranter)
+			s.Printf("%s%s: avail: %d", curSep, workKindString(kind), g.availableBurstTokens)
+			if kind == SQLKVResponseWork {
+				curSep = newlineStr
+			} else {
+				curSep = spaceStr
+			}
+		}
+	}
+}
+
+// cpuOverloadIndicator is meant to be an instantaneous indicator of cpu
+// availability. Since actual scheduler stats are periodic, we prefer to use
+// the KV slot availability, since it is instantaneous. The
+// cpuOverloadIndicator is used to gate admission of work other than KVWork
+// (KVWork only looks at slot availability). An instantaneous indicator limits
+// over-admission and queueing in the scheduler, and thereby provider better
+// isolation, especially in multi-tenant environments where tenants not
+// responsible for a load spike expect to suffer no increase in latency.
+//
+// In multi-tenant settings, for single-tenant SQL nodes, which do not do KV
+// work, we do not have an instantaneous indicator and instead use
+// sqlNodeCPUOverloadIndicator.
+type cpuOverloadIndicator interface {
+	isOverloaded() bool
+}
+
+// CPULoadListener listens to the latest CPU load information. Currently we
+// expect this to be called every 1ms.
+// TODO(sumeer): experiment with more smoothing.
+type CPULoadListener interface {
+	CPULoad(runnable int, procs int)
+}
+
+// kvSlotAdjuster is an implementer of CPULoadListener and
+// cpuOverloadIndicator.
+type kvSlotAdjuster struct {
+	// This is the slotGranter used for KVWork. In single-tenant settings, it
+	// is the only one we adjust using the periodic cpu overload signal. We
+	// don't adjust slots for SQLStatementLeafStartWork and
+	// SQLStatementRootStartWork using the periodic cpu overload signal since:
+	// - these are potentially long-lived work items and not CPU bound
+	// - we don't know how to coordinate adjustment of those slots and the KV
+	//   slots.
+	granter     *slotGranter
+	minCPUSlots int
+	maxCPUSlots int
+
+	totalSlotsMetric *metric.Gauge
+
+	// TODO(sumeer): also compute slots for disk IO and use min(totalCPUSlots,
+	// totalIOSlots) to configure granter. In this setting the
+	// cpuOverloadIndicator.isOverloaded implementation will compare usedSlots
+	// >= totalCPUSlots. That is, if totalIOSlots < totalCPUSlots, which means
+	// KV is constrained by IO, the isOverloaded signal will be false, and will
+	// therefore not constrain admission of non-KVWork. If this lack of
+	// constraint on non-KVWork overloads the CPU, totalCPUSlots will be
+	// decreased, and eventually totalCPUSlots could become <= totalIOSlots and
+	// the isOverloaded signal will become true.
+}
+
+var _ cpuOverloadIndicator = &kvSlotAdjuster{}
+var _ CPULoadListener = &kvSlotAdjuster{}
+
+func (kvsa *kvSlotAdjuster) CPULoad(runnable int, procs int) {
+	// Simple heuristic, which worked ok in experiments. More sophisticated ones
+	// could be devised.
+	// TODO(sumeer): add some configurability after more experimentation.
+	if runnable >= procs {
+		// Overload.
+		// If using some slots, and the used slots is less than the total slots,
+		// and total slots hasn't bottomed out at the min, decrease the total
+		// slots. If currently using more than the total slots, it suggests that
+		// the previous slot reduction has not taken effect yet, so we hold off on
+		// further decreasing.
+		if kvsa.granter.usedSlots > 0 && kvsa.granter.totalSlots > kvsa.minCPUSlots &&
+			kvsa.granter.usedSlots <= kvsa.granter.totalSlots {
+			kvsa.granter.totalSlots--
+		}
+	} else if float64(runnable) <= float64(procs/2) {
+		// Underload.
+		// Used all its slots and can increase further, so additive increase.
+		if kvsa.granter.usedSlots >= kvsa.granter.totalSlots &&
+			kvsa.granter.totalSlots < kvsa.maxCPUSlots {
+			kvsa.granter.totalSlots++
+		}
+	}
+	kvsa.totalSlotsMetric.Update(int64(kvsa.granter.totalSlots))
+}
+
+func (kvsa *kvSlotAdjuster) isOverloaded() bool {
+	return kvsa.granter.usedSlots >= kvsa.granter.totalSlots
+}
+
+// sqlNodeCPUOverloadIndicator is the implementation of cpuOverloadIndicator
+// for a single-tenant SQL node in a multi-tenant cluster. This has to rely on
+// the periodic load information from the cpu scheduler and will therefore be
+// tuned towards indicating overload at higher overload points (otherwise we
+// could fluctuate into underloaded territory due to restricting admission,
+// and not be work conserving). Such tuning towards more overload, and
+// therefore more queueing inside the scheduler, is somewhat acceptable since
+// a SQL node is not multi-tenant.
+//
+// TODO(sumeer): implement.
+type sqlNodeCPUOverloadIndicator struct {
+}
+
+var _ cpuOverloadIndicator = &sqlNodeCPUOverloadIndicator{}
+var _ CPULoadListener = &sqlNodeCPUOverloadIndicator{}
+
+func (sn *sqlNodeCPUOverloadIndicator) CPULoad(runnable int, procs int) {
+}
+
+func (sn *sqlNodeCPUOverloadIndicator) isOverloaded() bool {
+	return false
+}
+
+var (
+	totalSlots = metric.Metadata{
+		Name:        "admission.granter.total_slots.kv",
+		Help:        "Total slots for kv work",
+		Measurement: "Slots",
+		Unit:        metric.Unit_COUNT,
+	}
+	usedSlots = metric.Metadata{
+		Name:        "admission.granter.used_slots.",
+		Help:        "Used slots",
+		Measurement: "Slots",
+		Unit:        metric.Unit_COUNT,
+	}
+)
+
+// GranterMetrics are metrics associated with a GrantCoordinator.
+type GranterMetrics struct {
+	KVTotalSlots          *metric.Gauge
+	KVUsedSlots           *metric.Gauge
+	SQLLeafStartUsedSlots *metric.Gauge
+	SQLRootStartUsedSlots *metric.Gauge
+}
+
+// MetricStruct implements the metric.Struct interface.
+func (GranterMetrics) MetricStruct() {}
+
+func makeGranterMetrics() GranterMetrics {
+	m := GranterMetrics{
+		KVTotalSlots: metric.NewGauge(totalSlots),
+		KVUsedSlots:  metric.NewGauge(addName(string(workKindString(KVWork)), usedSlots)),
+		SQLLeafStartUsedSlots: metric.NewGauge(
+			addName(string(workKindString(SQLStatementLeafStartWork)), usedSlots)),
+		SQLRootStartUsedSlots: metric.NewGauge(
+			addName(string(workKindString(SQLStatementRootStartWork)), usedSlots)),
+	}
+	return m
+}
+
+// Prevent the linter from emitting unused warnings.
+var _ = NewGrantCoordinatorMultiTenantKV
+var _ = NewGrantCoordinatorSQL
+var _ = (*GrantCoordinator)(nil).GetWorkQueue
+
+// TODO(sumeer): experiment with approaches to adjust slots for
+// SQLStatementLeafStartWork and SQLStatementRootStartWork for SQL nodes. Note
+// that for these WorkKinds we are currently setting very high slot counts
+// since we rely on other signals like memory and cpuOverloadIndicator to gate
+// admission. One could debate whether we should be using rate limiting
+// instead of counting slots for such work. The only reason the above code
+// uses the term "slot" for these is that we have a completion indicator, and
+// when we do have such an indicator it can be beneficial to be able to keep
+// track of how many ongoing work items we have.

--- a/pkg/util/admission/granter_test.go
+++ b/pkg/util/admission/granter_test.go
@@ -1,0 +1,172 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package admission
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/datadriven"
+)
+
+type testRequester struct {
+	workKind   WorkKind
+	granter    granter
+	usesTokens bool
+	buf        *strings.Builder
+
+	waitingRequests        bool
+	returnFalseFromGranted bool
+}
+
+func (tr *testRequester) hasWaitingRequests() bool {
+	return tr.waitingRequests
+}
+
+func (tr *testRequester) granted() bool {
+	fmt.Fprintf(tr.buf, "%s: granted, and returning %t\n", workKindString(tr.workKind),
+		!tr.returnFalseFromGranted)
+	return !tr.returnFalseFromGranted
+}
+
+func (tr *testRequester) tryGet() {
+	rv := tr.granter.tryGet()
+	fmt.Fprintf(tr.buf, "%s: tryGet returned %t\n", workKindString(tr.workKind), rv)
+}
+
+func (tr *testRequester) returnGrant() {
+	fmt.Fprintf(tr.buf, "%s: returnGrant\n", workKindString(tr.workKind))
+	tr.granter.returnGrant()
+}
+
+func (tr *testRequester) tookWithoutPermission() {
+	fmt.Fprintf(tr.buf, "%s: tookWithoutPermission\n", workKindString(tr.workKind))
+	tr.granter.tookWithoutPermission()
+}
+
+func (tr *testRequester) continueGrantChain() {
+	fmt.Fprintf(tr.buf, "%s: continueGrantChain\n", workKindString(tr.workKind))
+	tr.granter.continueGrantChain()
+}
+
+// TestGranterBasic is a datadriven test with the following commands:
+//
+// init-grant-coordinator min-cpu=<int> max-cpu=<int> sql-kv-tokens=<int>
+//   sql-sql-tokens=<int> sql-leaf=<int> sql-root=<int>
+// set-has-waiting-requests work=<kind> v=<true|false>
+// set-return-value-from-granted work=<kind> v=<true|false>
+// try-get work=<kind>
+// return-grant work=<kind>
+// took-without-permission work=<kind>
+// continue-grant-chain work=<kind>
+// cpu-load runnable=<int> procs=<int>
+func TestGranterBasic(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	var requesters [numWorkKinds]*testRequester
+	var coord *GrantCoordinator
+	var buf strings.Builder
+	flushAndReset := func() string {
+		fmt.Fprintf(&buf, "GrantCoordinator:\n%s\n", coord.String())
+		str := buf.String()
+		buf.Reset()
+		return str
+	}
+	datadriven.RunTest(t, "testdata/granter", func(t *testing.T, d *datadriven.TestData) string {
+		switch d.Cmd {
+		case "init-grant-coordinator":
+			var opts Options
+			d.ScanArgs(t, "min-cpu", &opts.MinCPUSlots)
+			d.ScanArgs(t, "max-cpu", &opts.MaxCPUSlots)
+			d.ScanArgs(t, "sql-kv-tokens", &opts.SQLKVResponseBurstTokens)
+			d.ScanArgs(t, "sql-sql-tokens", &opts.SQLSQLResponseBurstTokens)
+			d.ScanArgs(t, "sql-leaf", &opts.SQLStatementLeafStartWorkSlots)
+			d.ScanArgs(t, "sql-root", &opts.SQLStatementRootStartWorkSlots)
+			opts.makeRequesterFunc = func(
+				workKind WorkKind, granter granter, usesTokens bool, tiedToRange bool) requester {
+				req := &testRequester{
+					workKind:   workKind,
+					granter:    granter,
+					usesTokens: usesTokens,
+					buf:        &buf,
+				}
+				requesters[workKind] = req
+				return req
+			}
+			coord, _ = NewGrantCoordinator(opts)
+			return flushAndReset()
+
+		case "set-has-waiting-requests":
+			var v bool
+			d.ScanArgs(t, "v", &v)
+			requesters[scanWorkKind(t, d)].waitingRequests = v
+			return flushAndReset()
+
+		case "set-return-value-from-granted":
+			var v bool
+			d.ScanArgs(t, "v", &v)
+			requesters[scanWorkKind(t, d)].returnFalseFromGranted = !v
+			return flushAndReset()
+
+		case "try-get":
+			requesters[scanWorkKind(t, d)].tryGet()
+			return flushAndReset()
+
+		case "return-grant":
+			requesters[scanWorkKind(t, d)].returnGrant()
+			return flushAndReset()
+
+		case "took-without-permission":
+			requesters[scanWorkKind(t, d)].tookWithoutPermission()
+			return flushAndReset()
+
+		case "continue-grant-chain":
+			requesters[scanWorkKind(t, d)].continueGrantChain()
+			return flushAndReset()
+
+		case "cpu-load":
+			var runnable, procs int
+			d.ScanArgs(t, "runnable", &runnable)
+			d.ScanArgs(t, "procs", &procs)
+			coord.CPULoad(runnable, procs)
+			return flushAndReset()
+
+		default:
+			return fmt.Sprintf("unknown command: %s", d.Cmd)
+		}
+	})
+}
+
+func scanWorkKind(t *testing.T, d *datadriven.TestData) WorkKind {
+	var kindStr string
+	d.ScanArgs(t, "work", &kindStr)
+	switch kindStr {
+	case "kv":
+		return KVWork
+	case "sql-kv-response":
+		return SQLKVResponseWork
+	case "sql-sql-response":
+		return SQLSQLResponseWork
+	case "sql-leaf-start":
+		return SQLStatementLeafStartWork
+	case "sql-root-start":
+		return SQLStatementRootStartWork
+	}
+	panic("unknown WorkKind")
+}
+
+// TODO(sumeer):
+// - Test metrics
+// - Test GrantCoordinator with multi-tenant configurations

--- a/pkg/util/admission/testdata/granter
+++ b/pkg/util/admission/testdata/granter
@@ -1,0 +1,246 @@
+init-grant-coordinator min-cpu=1 max-cpu=3 sql-kv-tokens=2 sql-sql-tokens=1 sql-leaf=2 sql-root=1
+----
+GrantCoordinator:
+(chain: active: false index: 0 term: false) kv: used: 0, total: 1 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+try-get work=kv
+----
+kv: tryGet returned true
+GrantCoordinator:
+(chain: active: false index: 0 term: false) kv: used: 1, total: 1 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+# No more slots.
+try-get work=kv
+----
+kv: tryGet returned false
+GrantCoordinator:
+(chain: active: false index: 0 term: false) kv: used: 1, total: 1 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+set-has-waiting-requests work=kv v=true
+----
+GrantCoordinator:
+(chain: active: false index: 0 term: false) kv: used: 1, total: 1 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+# Since no more KV slots, couldn't get.
+try-get work=sql-kv-response
+----
+sql-kv-response: tryGet returned false
+GrantCoordinator:
+(chain: active: false index: 0 term: false) kv: used: 1, total: 1 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+set-has-waiting-requests work=sql-kv-response v=true
+----
+GrantCoordinator:
+(chain: active: false index: 0 term: false) kv: used: 1, total: 1 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+# Since no more KV slots, couldn't get.
+try-get work=sql-leaf-start
+----
+sql-leaf-start: tryGet returned false
+GrantCoordinator:
+(chain: active: false index: 0 term: false) kv: used: 1, total: 1 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+set-has-waiting-requests work=sql-leaf-start v=true
+----
+GrantCoordinator:
+(chain: active: false index: 0 term: false) kv: used: 1, total: 1 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+# Since no more KV slots, couldn't get.
+try-get work=sql-root-start
+----
+sql-root-start: tryGet returned false
+GrantCoordinator:
+(chain: active: false index: 0 term: false) kv: used: 1, total: 1 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+set-has-waiting-requests work=sql-root-start v=true
+----
+GrantCoordinator:
+(chain: active: false index: 0 term: false) kv: used: 1, total: 1 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+return-grant work=kv
+----
+kv: returnGrant
+kv: granted, and returning true
+GrantCoordinator:
+(chain: active: true index: 0 term: false) kv: used: 1, total: 1 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+set-has-waiting-requests work=kv v=false
+----
+GrantCoordinator:
+(chain: active: true index: 0 term: false) kv: used: 1, total: 1 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+set-return-value-from-granted work=kv v=false
+----
+GrantCoordinator:
+(chain: active: true index: 0 term: false) kv: used: 1, total: 1 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+# The grant chain dies out since kv slots are fully used.
+continue-grant-chain work=kv
+----
+kv: continueGrantChain
+GrantCoordinator:
+(chain: active: false index: 1 term: false) kv: used: 1, total: 1 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+# Grant to sql-kv-response consumes a token.
+return-grant work=kv
+----
+kv: returnGrant
+sql-kv-response: granted, and returning true
+GrantCoordinator:
+(chain: active: true index: 1 term: false) kv: used: 0, total: 1 sql-kv-response: avail: 1
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+# Grant to sql-kv-response consumes another token. None left.
+continue-grant-chain work=sql-kv-response
+----
+sql-kv-response: continueGrantChain
+sql-kv-response: granted, and returning true
+GrantCoordinator:
+(chain: active: true index: 1 term: false) kv: used: 0, total: 1 sql-kv-response: avail: 0
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+# Even though there are still waiting requests for sql-kv-response, no more
+# tokens, so the grant chain can continue past it.
+continue-grant-chain work=sql-kv-response
+----
+sql-kv-response: continueGrantChain
+sql-leaf-start: granted, and returning true
+GrantCoordinator:
+(chain: active: true index: 3 term: false) kv: used: 0, total: 1 sql-kv-response: avail: 0
+sql-sql-response: avail: 1 sql-leaf-start: used: 1, total: 2 sql-root-start: used: 0, total: 1
+
+continue-grant-chain work=sql-leaf-start
+----
+sql-leaf-start: continueGrantChain
+sql-leaf-start: granted, and returning true
+GrantCoordinator:
+(chain: active: true index: 3 term: false) kv: used: 0, total: 1 sql-kv-response: avail: 0
+sql-sql-response: avail: 1 sql-leaf-start: used: 2, total: 2 sql-root-start: used: 0, total: 1
+
+# Even though there are still waiting requests for sql-leaf-start, no more
+# tokens, so the grant chain can continue past it.
+continue-grant-chain work=sql-leaf-start
+----
+sql-leaf-start: continueGrantChain
+sql-root-start: granted, and returning true
+GrantCoordinator:
+(chain: active: true index: 4 term: false) kv: used: 0, total: 1 sql-kv-response: avail: 0
+sql-sql-response: avail: 1 sql-leaf-start: used: 2, total: 2 sql-root-start: used: 1, total: 1
+
+# sql-root-start ran out of tokens. Grant chain dies out.
+continue-grant-chain work=sql-root-start
+----
+sql-root-start: continueGrantChain
+GrantCoordinator:
+(chain: active: false index: 5 term: false) kv: used: 0, total: 1 sql-kv-response: avail: 0
+sql-sql-response: avail: 1 sql-leaf-start: used: 2, total: 2 sql-root-start: used: 1, total: 1
+
+# Return sql-leaf-start slot. This will cause another grant chain to start
+# which will eventually find a free slot to give to sql-leaf-start.
+return-grant work=sql-leaf-start
+----
+sql-leaf-start: returnGrant
+sql-leaf-start: granted, and returning true
+GrantCoordinator:
+(chain: active: true index: 3 term: false) kv: used: 0, total: 1 sql-kv-response: avail: 0
+sql-sql-response: avail: 1 sql-leaf-start: used: 2, total: 2 sql-root-start: used: 1, total: 1
+
+# Return another sql-leaf-start slot. The grant chain is already active and
+# not past this WorkKind, so no grant is done.
+return-grant work=sql-leaf-start
+----
+sql-leaf-start: returnGrant
+GrantCoordinator:
+(chain: active: true index: 3 term: false) kv: used: 0, total: 1 sql-kv-response: avail: 0
+sql-sql-response: avail: 1 sql-leaf-start: used: 1, total: 2 sql-root-start: used: 1, total: 1
+
+# The kv slots are fully used after this tryGet, which succeeds.
+try-get work=kv
+----
+kv: tryGet returned true
+GrantCoordinator:
+(chain: active: true index: 3 term: false) kv: used: 1, total: 1 sql-kv-response: avail: 0
+sql-sql-response: avail: 1 sql-leaf-start: used: 1, total: 2 sql-root-start: used: 1, total: 1
+
+# This tryGet for kv fails and asks to terminate the grant chain.
+try-get work=kv
+----
+kv: tryGet returned false
+GrantCoordinator:
+(chain: active: true index: 3 term: true) kv: used: 1, total: 1 sql-kv-response: avail: 0
+sql-sql-response: avail: 1 sql-leaf-start: used: 1, total: 2 sql-root-start: used: 1, total: 1
+
+set-has-waiting-requests work=kv v=true
+----
+GrantCoordinator:
+(chain: active: true index: 3 term: true) kv: used: 1, total: 1 sql-kv-response: avail: 0
+sql-sql-response: avail: 1 sql-leaf-start: used: 1, total: 2 sql-root-start: used: 1, total: 1
+
+# The grant chain terminates and is not able to restart since there are no
+# free kv slots.
+continue-grant-chain work=sql-leaf-start
+----
+sql-leaf-start: continueGrantChain
+GrantCoordinator:
+(chain: active: false index: 0 term: false) kv: used: 1, total: 1 sql-kv-response: avail: 0
+sql-sql-response: avail: 1 sql-leaf-start: used: 1, total: 2 sql-root-start: used: 1, total: 1
+
+# Pretend that the kv work that was waiting is gone.
+set-has-waiting-requests work=kv v=false
+----
+GrantCoordinator:
+(chain: active: false index: 0 term: false) kv: used: 1, total: 1 sql-kv-response: avail: 0
+sql-sql-response: avail: 1 sql-leaf-start: used: 1, total: 2 sql-root-start: used: 1, total: 1
+
+# Some other kv work takes without permission.
+took-without-permission work=kv
+----
+kv: tookWithoutPermission
+GrantCoordinator:
+(chain: active: false index: 0 term: false) kv: used: 2, total: 1 sql-kv-response: avail: 0
+sql-sql-response: avail: 1 sql-leaf-start: used: 1, total: 2 sql-root-start: used: 1, total: 1
+
+# Refill the tokens and increase the kv slots to 2.
+cpu-load runnable=3 procs=8
+----
+GrantCoordinator:
+(chain: active: false index: 1 term: false) kv: used: 2, total: 2 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 1, total: 2 sql-root-start: used: 1, total: 1
+
+# Tokens don't get overfull. And kv slots increased to 3. This causes a grant
+# to sql-kv-response and the grant chain is again active.
+cpu-load runnable=3 procs=8
+----
+sql-kv-response: granted, and returning true
+GrantCoordinator:
+(chain: active: true index: 1 term: false) kv: used: 2, total: 3 sql-kv-response: avail: 1
+sql-sql-response: avail: 1 sql-leaf-start: used: 1, total: 2 sql-root-start: used: 1, total: 1
+
+# Overload and kv slots decreased. Asks to terminate grant chain.
+cpu-load runnable=10 procs=8
+----
+GrantCoordinator:
+(chain: active: true index: 1 term: true) kv: used: 2, total: 2 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 1, total: 2 sql-root-start: used: 1, total: 1
+
+# Grant chain terminates.
+continue-grant-chain work=sql-kv-response
+----
+sql-kv-response: continueGrantChain
+GrantCoordinator:
+(chain: active: false index: 1 term: false) kv: used: 2, total: 2 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 1, total: 2 sql-root-start: used: 1, total: 1

--- a/pkg/util/admission/testdata/work_queue
+++ b/pkg/util/admission/testdata/work_queue
@@ -1,0 +1,138 @@
+init
+----
+
+set-try-get-return-value v=true
+----
+
+admit id=1 tenant=53 priority=0 create-time=1 bypass=false
+----
+tryGet: returning true
+id 1: admit succeeded
+
+print
+----
+tenantHeap len: 0
+ tenant-id: 53 used: 1
+
+# tryGet will return false, so work will queue up.
+set-try-get-return-value v=false
+----
+
+# bypass=true is ignored since not system tenant.
+admit id=2 tenant=53 priority=0 create-time=3 bypass=true
+----
+tryGet: returning false
+
+print
+----
+tenantHeap len: 1 top tenant: 53
+ tenant-id: 53 used: 1 heap: 0: pri: 0, ct: 3
+
+admit id=3 tenant=53 priority=0 create-time=2 bypass=false
+----
+
+# Tenant 53 has two waiting requests. The one that arrived second is earlier
+# in the heap because of a smaller create-time.
+print
+----
+tenantHeap len: 1 top tenant: 53
+ tenant-id: 53 used: 1 heap: 0: pri: 0, ct: 2 1: pri: 0, ct: 3
+
+# Request from tenant 71.
+admit id=4 tenant=71 priority=-128 create-time=4 bypass=false
+----
+
+# Another request from tenant 71. This one has higher priority so will be
+# earlier in the heap, even though it has higher create-time.
+admit id=5 tenant=71 priority=0 create-time=5 bypass=false
+----
+
+# Tenant 71 is the top of the heap since not using any slots.
+print
+----
+tenantHeap len: 2 top tenant: 71
+ tenant-id: 53 used: 1 heap: 0: pri: 0, ct: 2 1: pri: 0, ct: 3
+ tenant-id: 71 used: 0 heap: 0: pri: 0, ct: 5 1: pri: -128, ct: 4
+
+granted
+----
+continueGrantChain
+id 5: admit succeeded
+granted: returned true
+
+# Both tenants are using 1 slot. The tie is broken arbitrarily in favor of
+# tenant 71.
+print
+----
+tenantHeap len: 2 top tenant: 71
+ tenant-id: 53 used: 1 heap: 0: pri: 0, ct: 2 1: pri: 0, ct: 3
+ tenant-id: 71 used: 1 heap: 0: pri: -128, ct: 4
+
+# Cancel a request from tenant 53.
+cancel-work id=3
+----
+id 3: admit failed
+
+print
+----
+tenantHeap len: 2 top tenant: 71
+ tenant-id: 53 used: 1 heap: 0: pri: 0, ct: 3
+ tenant-id: 71 used: 1 heap: 0: pri: -128, ct: 4
+
+# The work admitted for tenant 53 is done.
+work-done id=1
+----
+returnGrant
+
+# Tenant 53 now using fewer slots so it becomes the top of the heap.
+print
+----
+tenantHeap len: 2 top tenant: 53
+ tenant-id: 53 used: 0 heap: 0: pri: 0, ct: 3
+ tenant-id: 71 used: 1 heap: 0: pri: -128, ct: 4
+
+# A request from the system tenant bypasses admission control, but is
+# reflected in the WorkQueue state.
+admit id=6 tenant=1 priority=0 create-time=6 bypass=true
+----
+tookWithoutPermission
+id 6: admit succeeded
+
+print
+----
+tenantHeap len: 2 top tenant: 53
+ tenant-id: 1 used: 1
+ tenant-id: 53 used: 0 heap: 0: pri: 0, ct: 3
+ tenant-id: 71 used: 1 heap: 0: pri: -128, ct: 4
+
+granted
+----
+continueGrantChain
+id 2: admit succeeded
+granted: returned true
+
+granted
+----
+continueGrantChain
+id 4: admit succeeded
+granted: returned true
+
+# No more waiting requests.
+print
+----
+tenantHeap len: 0
+ tenant-id: 1 used: 1
+ tenant-id: 53 used: 1
+ tenant-id: 71 used: 2
+
+# Granted returns false.
+granted
+----
+granted: returned false
+
+print
+----
+tenantHeap len: 0
+ tenant-id: 1 used: 1
+ tenant-id: 53 used: 1
+ tenant-id: 71 used: 2

--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -1,0 +1,588 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package admission
+
+import (
+	"container/heap"
+	"context"
+	"math"
+	"sort"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
+)
+
+// WorkPriority represents the priority of work. In an WorkQueue, it is only
+// used for ordering within a tenant. High priority work can starve lower
+// priority work.
+type WorkPriority int8
+
+const (
+	// LowPri is low priority work.
+	LowPri WorkPriority = math.MinInt8
+	// NormalPri is normal priority work.
+	NormalPri WorkPriority = 0
+	// HighPri is high priority work.
+	HighPri WorkPriority = math.MaxInt8
+)
+
+// Prevent the linter from emitting unused warnings.
+var _ = LowPri
+var _ = NormalPri
+var _ = HighPri
+
+// WorkInfo provides information that is used to order work within an
+// WorkQueue. The WorkKind is not included as a field since an WorkQueue deals
+// with a single WorkKind.
+type WorkInfo struct {
+	// TenantID is the id of the tenant. For single-tenant clusters, this will
+	// always be the SystemTenantID.
+	TenantID roachpb.TenantID
+	// Priority is utilized within a tenant.
+	Priority WorkPriority
+	// CreateTime is equivalent to Time.UnixNano() at the creation time of this
+	// work or a parent work (e.g. could be the start time of the transaction,
+	// if this work was created as part of a transaction). It is used to order
+	// work within a (TenantID, Priority) pair -- earlier CreateTime is given
+	// preference.
+	CreateTime int64
+	// BypassAdmission allows the work to bypass admission control, but allows
+	// for it to be accounted for. Ignored unless TenantID is the
+	// SystemTenantID. It should be used for high-priority intra-KV work, and
+	// when KV work generates other KV work (to avoid deadlock). Ignored
+	// otherwise.
+	BypassAdmission bool
+
+	// Optional information specified only for WorkQueues where the work is tied
+	// to a range. This allows queued work to return early as soon as the range
+	// is no longer in a relevant state at this node. Currently only KVWork is
+	// tied to a range.
+	// TODO(sumeer): use these in the WorkQueue implementation.
+
+	// RangeID is the range at which this work must be performed. Optional (see
+	// comment above).
+	RangeID roachpb.RangeID
+	// RequiresLeaseholder is true iff the work requires the leaseholder.
+	// Optional (see comment above).
+	RequiresLeaseholder bool
+}
+
+// WorkQueue maintains a queue of work waiting to be admitted. Ordering of
+// work is achieved via 2 heaps: a tenant heap orders the tenants with waiting
+// work in increasing order of used slots or tokens. Within each tenant, the
+// waiting work is ordered based on priority and create time. Tenants with
+// non-zero values of used slots or tokens are tracked even if they have no
+// more waiting work. Token usage is reset to zero every second. The choice of
+// 1 second of memory for token distribution fairness is somewhat arbitrary.
+// The same 1 second interval is also used to garbage collect tenants who have
+// no waiting requests and no used slots or tokens.
+//
+// Note that currently there are no weights associated with tenants -- one
+// could imagine using weights and comparing used/weight values for
+// inter-tenant fairness.
+//
+// Usage example:
+//  var grantCoord *GrantCoordinator
+//  <initialize grantCoord>
+//  kvQueue := grantCoord.GetWorkQueue(KVWork)
+//  <hand kvQueue to the code that does kv server work>
+//
+//  // Before starting some kv server work
+//  if err := kvQueue.Admit(ctx, WorkInfo{TenantID: tid, ...}); err != nil {
+//    return err
+//  }
+//  <do the work>
+//  kvQueue.AdmittedWorkDone(tid)
+type WorkQueue struct {
+	workKind    WorkKind
+	granter     granter
+	usesTokens  bool
+	tiedToRange bool
+
+	// Prevents more than one caller to be in Admit and calling tryGet or adding
+	// to the queue. It allows WorkQueue to release mu before calling tryGet and
+	// be assured that it is not competing with another Admit.
+	// Lock ordering is admitMu < mu.
+	admitMu syncutil.Mutex
+	mu      struct {
+		syncutil.Mutex
+		// Tenants with waiting work.
+		tenantHeap tenantHeap
+		// All tenants, including those without waiting work. Periodically cleaned.
+		tenants map[uint64]*tenantInfo
+	}
+	metrics  WorkQueueMetrics
+	gcStopCh chan struct{}
+}
+
+var _ requester = &WorkQueue{}
+
+func makeWorkQueue(
+	workKind WorkKind, granter granter, usesTokens bool, tiedToRange bool,
+) requester {
+	gcStopCh := make(chan struct{})
+	q := &WorkQueue{
+		workKind:    workKind,
+		granter:     granter,
+		usesTokens:  usesTokens,
+		tiedToRange: tiedToRange,
+		metrics:     makeWorkQueueMetrics(string(workKindString(workKind))),
+		gcStopCh:    gcStopCh,
+	}
+	q.mu.tenants = make(map[uint64]*tenantInfo)
+	go func() {
+		ticker := time.NewTicker(time.Second)
+		done := false
+		for !done {
+			select {
+			case <-ticker.C:
+				q.gcTenantsAndResetTokens()
+			case <-gcStopCh:
+				done = true
+			}
+		}
+		close(gcStopCh)
+	}()
+	return q
+}
+
+// TODO(sumeer): reduce allocations by using a pool for tenantInfo, waitingWork,
+// waitingWork.ch.
+
+// Admit is called when requesting admission for some work.
+func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) error {
+	q.metrics.Requested.Inc(1)
+	tenantID := info.TenantID.ToUint64()
+
+	// The code in this method does not use defer to unlock the mutexes because
+	// it needs the flexibility of selectively unlocking one of these on a
+	// certain code path. When changing the code, be careful in making sure the
+	// mutexes are properly unlocked on all code paths.
+	q.admitMu.Lock()
+	q.mu.Lock()
+	tenant, ok := q.mu.tenants[tenantID]
+	if !ok {
+		tenant = makeTenantInfo(tenantID)
+		q.mu.tenants[tenantID] = tenant
+	}
+	if info.BypassAdmission && roachpb.IsSystemTenantID(tenantID) && q.workKind == KVWork {
+		tenant.used++
+		if len(tenant.waitingWorkHeap) > 0 {
+			q.mu.tenantHeap.fix(tenant)
+		}
+		q.mu.Unlock()
+		q.admitMu.Unlock()
+		q.granter.tookWithoutPermission()
+		q.metrics.Admitted.Inc(1)
+		return nil
+	}
+
+	if len(q.mu.tenantHeap) == 0 {
+		// Fast-path. Try to grab token/slot.
+		// Optimistically update used to avoid locking again.
+		tenant.used++
+		q.mu.Unlock()
+		if q.granter.tryGet() {
+			q.admitMu.Unlock()
+			q.metrics.Admitted.Inc(1)
+			return nil
+		}
+		// Did not get token/slot.
+		//
+		// There is a race here: before q.mu is acquired, the granter could
+		// experience a reduction in load and call
+		// WorkQueue.hasWaitingRequests to see if it should grant, but since
+		// there is nothing in the queue that method will return false. Then the
+		// work here queues up even though granter has spare capacity. We could
+		// add additional synchronization (and complexity to the granter
+		// interface) to deal with this, by keeping the granter's lock
+		// (GrantCoordinator.mu) locked when returning from tryGrant and call
+		// granter again to release that lock after this work has been queued. But
+		// it has the downside of extending the scope of GrantCoordinator.mu.
+		// Instead we tolerate this race in the knowledge that GrantCoordinator
+		// will periodically, at a high frequency, look at the state of the
+		// requesters to see if there is any queued work that can be granted
+		// admission.
+		q.mu.Lock()
+		tenant.used--
+	}
+	// Check for cancellation.
+	startTime := timeutil.Now()
+	doneCh := ctx.Done()
+	if doneCh != nil {
+		select {
+		case _, ok := <-doneCh:
+			if !ok {
+				// Already canceled. More likely to happen if cpu starvation is
+				// causing entering into the work queue to be delayed.
+				q.mu.Unlock()
+				q.admitMu.Unlock()
+				q.metrics.Errored.Inc(1)
+				deadline, _ := ctx.Deadline()
+				return errors.Newf("work %s deadline already expired: deadline: %v, now: %v",
+					workKindString(q.workKind), deadline, startTime)
+			}
+		default:
+		}
+	}
+	// Push onto heap(s).
+	work := makeWaitingWork(info.Priority, info.CreateTime)
+	heap.Push(&tenant.waitingWorkHeap, work)
+	if len(tenant.waitingWorkHeap) == 1 {
+		heap.Push(&q.mu.tenantHeap, tenant)
+	}
+	// Else already in tenantHeap.
+	q.metrics.WaitQueueLength.Inc(1)
+
+	// Release all locks and start waiting.
+	q.mu.Unlock()
+	q.admitMu.Unlock()
+	select {
+	case <-doneCh:
+		q.mu.Lock()
+		if work.heapIndex == -1 {
+			// No longer in heap. Raced with token/slot grant.
+			tenant.used--
+			q.mu.Unlock()
+			q.granter.returnGrant()
+			q.granter.continueGrantChain()
+		} else {
+			tenant.waitingWorkHeap.remove(work)
+			if len(tenant.waitingWorkHeap) == 0 {
+				q.mu.tenantHeap.remove(tenant)
+			}
+			q.mu.Unlock()
+		}
+		q.metrics.Errored.Inc(1)
+		waitDur := timeutil.Since(startTime)
+		q.metrics.WaitDurationSum.Inc(waitDur.Microseconds())
+		q.metrics.WaitDurations.RecordValue(waitDur.Nanoseconds())
+		q.metrics.WaitQueueLength.Dec(1)
+		deadline, _ := ctx.Deadline()
+		return errors.Newf("work %s deadline expired while waiting: deadline: %v, start: %v, dur: %v",
+			workKindString(q.workKind), deadline, startTime, waitDur)
+	case _, ok := <-work.ch:
+		if !ok {
+			panic(errors.AssertionFailedf("channel should not be closed"))
+		}
+		q.metrics.Admitted.Inc(1)
+		waitDur := timeutil.Since(startTime)
+		q.metrics.WaitDurationSum.Inc(waitDur.Microseconds())
+		q.metrics.WaitDurations.RecordValue(waitDur.Nanoseconds())
+		q.metrics.WaitQueueLength.Dec(1)
+		if work.heapIndex != -1 {
+			panic(errors.AssertionFailedf("grantee should be removed from heap"))
+		}
+		q.granter.continueGrantChain()
+		return nil
+	}
+}
+
+// AdmittedWorkDone is used to inform the WorkQueue that some admitted work is
+// finished. It must be called iff the WorkKind of this WorkQueue uses slots
+// (not tokens), i.e., KVWork, SQLStatementLeafStartWork,
+// SQLStatementRootStartWork.
+func (q *WorkQueue) AdmittedWorkDone(tenantID roachpb.TenantID) {
+	if q.usesTokens {
+		panic(errors.AssertionFailedf("tokens should not be returned"))
+	}
+	q.mu.Lock()
+	tenant, ok := q.mu.tenants[tenantID.ToUint64()]
+	if !ok {
+		panic(errors.AssertionFailedf("tenant not found"))
+	}
+	tenant.used--
+	if len(tenant.waitingWorkHeap) > 0 {
+		q.mu.tenantHeap.fix(tenant)
+	}
+	q.mu.Unlock()
+	q.granter.returnGrant()
+}
+
+func (q *WorkQueue) hasWaitingRequests() bool {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return len(q.mu.tenantHeap) > 0
+}
+
+func (q *WorkQueue) granted() bool {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if len(q.mu.tenantHeap) == 0 {
+		return false
+	}
+	tenant := q.mu.tenantHeap[0]
+	item := heap.Pop(&tenant.waitingWorkHeap).(*waitingWork)
+	item.ch <- struct{}{}
+	tenant.used++
+	if len(tenant.waitingWorkHeap) > 0 {
+		q.mu.tenantHeap.fix(tenant)
+	} else {
+		q.mu.tenantHeap.remove(tenant)
+	}
+	return true
+}
+
+func (q *WorkQueue) gcTenantsAndResetTokens() {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	// With large numbers of active tenants, this iteration could hold the lock
+	// longer than desired. We could break this iteration into smaller parts if
+	// needed.
+	for id, info := range q.mu.tenants {
+		if info.used == 0 && len(info.waitingWorkHeap) == 0 {
+			delete(q.mu.tenants, id)
+		}
+		if q.usesTokens {
+			info.used = 0
+			// All the heap members will reset used=0, so no need to change heap
+			// ordering.
+		}
+	}
+}
+
+func (q *WorkQueue) String() string {
+	return redact.StringWithoutMarkers(q)
+}
+
+// SafeFormat implements the redact.SafeFormatter interface.
+func (q *WorkQueue) SafeFormat(s redact.SafePrinter, verb rune) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	s.Printf("tenantHeap len: %d", len(q.mu.tenantHeap))
+	if len(q.mu.tenantHeap) > 0 {
+		s.Printf(" top tenant: %d", q.mu.tenantHeap[0].id)
+	}
+	var ids []uint64
+	for id := range q.mu.tenants {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	for _, id := range ids {
+		tenant := q.mu.tenants[id]
+		s.Printf("\n tenant-id: %d used: %d", tenant.id, tenant.used)
+		if len(tenant.waitingWorkHeap) > 0 {
+			s.Printf(" heap:")
+			for i := range tenant.waitingWorkHeap {
+				s.Printf(" %d: pri: %d, ct: %d", i, tenant.waitingWorkHeap[i].priority,
+					tenant.waitingWorkHeap[i].createTime)
+			}
+		}
+	}
+}
+
+// closeForTesting only exists to "cleanly" shutdown WorkQueue in a unit test setting.
+func (q *WorkQueue) closeForTesting() {
+	q.gcStopCh <- struct{}{}
+	// The gc goroutine has seen the close signal. We can't have a way to wait
+	// for the goroutine to exit, so just sleep a bit.
+	time.Sleep(50 * time.Millisecond)
+}
+
+// tenantInfo is the per-tenant information in the tenantHeap.
+type tenantInfo struct {
+	id uint64
+	// used can be the currently used slots, or the tokens granted within the last
+	// interval.
+	used            uint64
+	waitingWorkHeap waitingWorkHeap
+
+	// The heapIndex is maintained by the heap.Interface methods, and represents
+	// the heapIndex of the item in the heap.
+	heapIndex int
+}
+
+// tenantHeap is a heap of tenants with waiting work, ordered in increasing
+// order of tenantInfo.used. That is, we prefer tenants that are using less.
+type tenantHeap []*tenantInfo
+
+var _ heap.Interface = (*tenantHeap)(nil)
+
+func makeTenantInfo(id uint64) *tenantInfo {
+	return &tenantInfo{id: id, heapIndex: -1}
+}
+
+func (th *tenantHeap) fix(item *tenantInfo) {
+	heap.Fix(th, item.heapIndex)
+}
+
+func (th *tenantHeap) remove(item *tenantInfo) {
+	heap.Remove(th, item.heapIndex)
+}
+
+func (th *tenantHeap) Len() int {
+	return len(*th)
+}
+
+func (th *tenantHeap) Less(i, j int) bool {
+	return (*th)[i].used < (*th)[j].used
+}
+
+func (th *tenantHeap) Swap(i, j int) {
+	(*th)[i], (*th)[j] = (*th)[j], (*th)[i]
+	(*th)[i].heapIndex = i
+	(*th)[j].heapIndex = j
+}
+
+func (th *tenantHeap) Push(x interface{}) {
+	n := len(*th)
+	item := x.(*tenantInfo)
+	item.heapIndex = n
+	*th = append(*th, item)
+}
+
+func (th *tenantHeap) Pop() interface{} {
+	old := *th
+	n := len(old)
+	item := old[n-1]
+	old[n-1] = nil
+	item.heapIndex = -1
+	*th = old[0 : n-1]
+	return item
+}
+
+// waitingWork is the per-work information in the waitingWorkHeap.
+type waitingWork struct {
+	priority   WorkPriority
+	createTime int64
+	ch         chan struct{}
+	// The heapIndex is maintained by the heap.Interface methods, and represents
+	// the heapIndex of the item in the heap. -1 when not in the heap.
+	heapIndex int
+}
+
+// waitingWorkHeap is a heap of waiting work within a tenant. It is ordered in
+// decreasing order of priority, and within the same priority in increasing
+// order of createTime (to prefer older work).
+type waitingWorkHeap []*waitingWork
+
+var _ heap.Interface = (*waitingWorkHeap)(nil)
+
+func makeWaitingWork(priority WorkPriority, createTime int64) *waitingWork {
+	return &waitingWork{
+		priority:   priority,
+		createTime: createTime,
+		ch:         make(chan struct{}, 1),
+		heapIndex:  -1,
+	}
+}
+
+func (wwh *waitingWorkHeap) remove(item *waitingWork) {
+	heap.Remove(wwh, item.heapIndex)
+}
+
+func (wwh *waitingWorkHeap) Len() int { return len(*wwh) }
+
+func (wwh *waitingWorkHeap) Less(i, j int) bool {
+	if (*wwh)[i].priority == (*wwh)[j].priority {
+		return (*wwh)[i].createTime < (*wwh)[j].createTime
+	}
+	return (*wwh)[i].priority > (*wwh)[j].priority
+}
+
+func (wwh *waitingWorkHeap) Swap(i, j int) {
+	(*wwh)[i], (*wwh)[j] = (*wwh)[j], (*wwh)[i]
+	(*wwh)[i].heapIndex = i
+	(*wwh)[j].heapIndex = j
+}
+
+func (wwh *waitingWorkHeap) Push(x interface{}) {
+	n := len(*wwh)
+	item := x.(*waitingWork)
+	item.heapIndex = n
+	*wwh = append(*wwh, item)
+}
+
+func (wwh *waitingWorkHeap) Pop() interface{} {
+	old := *wwh
+	n := len(old)
+	item := old[n-1]
+	old[n-1] = nil
+	item.heapIndex = -1
+	*wwh = old[0 : n-1]
+	return item
+}
+
+var (
+	requestedMeta = metric.Metadata{
+		Name:        "admission.requested.",
+		Help:        "Number of requests",
+		Measurement: "Requests",
+		Unit:        metric.Unit_COUNT,
+	}
+	admittedMeta = metric.Metadata{
+		Name:        "admission.admitted.",
+		Help:        "Number of requests admitted",
+		Measurement: "Requests",
+		Unit:        metric.Unit_COUNT,
+	}
+	erroredMeta = metric.Metadata{
+		Name:        "admission.errored.",
+		Help:        "Number of requests not admitted due to error",
+		Measurement: "Requests",
+		Unit:        metric.Unit_COUNT,
+	}
+	waitDurationSumMeta = metric.Metadata{
+		Name:        "admission.wait_sum.",
+		Help:        "Total wait time in micros",
+		Measurement: "Microseconds",
+		Unit:        metric.Unit_COUNT,
+	}
+	waitDurationsMeta = metric.Metadata{
+		Name:        "admission.wait_durations.",
+		Help:        "Wait time durations for requests that waited",
+		Measurement: "Wait time Duration",
+		Unit:        metric.Unit_NANOSECONDS,
+	}
+	waitQueueLengthMeta = metric.Metadata{
+		Name:        "admission.wait_queue_length.",
+		Help:        "Length of wait queue",
+		Measurement: "Requests",
+		Unit:        metric.Unit_COUNT,
+	}
+)
+
+func addName(name string, meta metric.Metadata) metric.Metadata {
+	rv := meta
+	rv.Name = rv.Name + name
+	return rv
+}
+
+// WorkQueueMetrics are metrics associated with a WorkQueue.
+type WorkQueueMetrics struct {
+	Requested       *metric.Counter
+	Admitted        *metric.Counter
+	Errored         *metric.Counter
+	WaitDurationSum *metric.Counter
+	WaitDurations   *metric.Histogram
+	WaitQueueLength *metric.Gauge
+}
+
+// MetricStruct implements the metric.Struct interface.
+func (WorkQueueMetrics) MetricStruct() {}
+
+func makeWorkQueueMetrics(name string) WorkQueueMetrics {
+	return WorkQueueMetrics{
+		Requested:       metric.NewCounter(addName(name, requestedMeta)),
+		Admitted:        metric.NewCounter(addName(name, admittedMeta)),
+		Errored:         metric.NewCounter(addName(name, erroredMeta)),
+		WaitDurationSum: metric.NewCounter(addName(name, waitDurationSumMeta)),
+		WaitDurations: metric.NewLatency(
+			addName(name, waitDurationsMeta), base.DefaultHistogramWindowInterval()),
+		WaitQueueLength: metric.NewGauge(addName(name, waitQueueLengthMeta)),
+	}
+}

--- a/pkg/util/admission/work_queue_test.go
+++ b/pkg/util/admission/work_queue_test.go
@@ -1,0 +1,246 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package admission
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/datadriven"
+)
+
+type builderWithMu struct {
+	mu  syncutil.Mutex
+	buf strings.Builder
+}
+
+func (b *builderWithMu) printf(format string, a ...interface{}) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.buf.Len() > 0 {
+		fmt.Fprintf(&b.buf, "\n")
+	}
+	fmt.Fprintf(&b.buf, format, a...)
+}
+
+func (b *builderWithMu) stringAndReset() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	str := b.buf.String()
+	b.buf.Reset()
+	return str
+}
+
+type testGranter struct {
+	buf                   *builderWithMu
+	r                     requester
+	returnValueFromTryGet bool
+}
+
+func (tg *testGranter) grantKind() grantKind {
+	return slot
+}
+func (tg *testGranter) tryGet() bool {
+	tg.buf.printf("tryGet: returning %t", tg.returnValueFromTryGet)
+	return tg.returnValueFromTryGet
+}
+func (tg *testGranter) returnGrant() {
+	tg.buf.printf("returnGrant")
+}
+func (tg *testGranter) tookWithoutPermission() {
+	tg.buf.printf("tookWithoutPermission")
+}
+func (tg *testGranter) continueGrantChain() {
+	tg.buf.printf("continueGrantChain")
+}
+func (tg *testGranter) grant() {
+	rv := tg.r.granted()
+	if rv {
+		// Need deterministic output, and this is racing with the goroutine that
+		// was admitted. Sleep to let it get scheduled. We could do something more
+		// sophisticated like monitoring goroutine states like in
+		// concurrency_manager_test.go.
+		time.Sleep(50 * time.Millisecond)
+	}
+	tg.buf.printf("granted: returned %t", rv)
+}
+
+type testWork struct {
+	tenantID roachpb.TenantID
+	cancel   context.CancelFunc
+	admitted bool
+}
+
+type workMap struct {
+	mu      syncutil.Mutex
+	workMap map[int]*testWork
+}
+
+func (m *workMap) set(id int, w *testWork) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.workMap[id] = w
+}
+
+func (m *workMap) delete(id int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.workMap, id)
+}
+
+func (m *workMap) setAdmitted(id int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.workMap[id].admitted = true
+}
+
+func (m *workMap) get(id int) (work testWork, ok bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	w, ok := m.workMap[id]
+	if ok {
+		work = *w
+	}
+	return work, ok
+}
+
+/*
+TestWorkQueueBasic is a datadriven test with the following commands:
+init
+admit id=<int> tenant=<int> priority=<int> create-time=<int> bypass=<bool>
+set-try-get-return-value v=<bool>
+granted
+cancel-work id=<int>
+work-done id=<int>
+print
+*/
+func TestWorkQueueBasic(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	var q *WorkQueue
+	var tg *testGranter
+	var workMap workMap
+	var buf builderWithMu
+	datadriven.RunTest(t, "testdata/work_queue",
+		func(t *testing.T, d *datadriven.TestData) string {
+			switch d.Cmd {
+			case "init":
+				tg = &testGranter{buf: &buf}
+				q = makeWorkQueue(KVWork, tg, false, true).(*WorkQueue)
+				tg.r = q
+				workMap.workMap = make(map[int]*testWork)
+				return ""
+
+			case "admit":
+				var id int
+				d.ScanArgs(t, "id", &id)
+				if _, ok := workMap.get(id); ok {
+					panic(fmt.Sprintf("id %d is already used", id))
+				}
+				tenant := scanTenantID(t, d)
+				var priority, createTime int
+				d.ScanArgs(t, "priority", &priority)
+				d.ScanArgs(t, "create-time", &createTime)
+				var bypass bool
+				d.ScanArgs(t, "bypass", &bypass)
+				ctx, cancel := context.WithCancel(context.Background())
+				workMap.set(id, &testWork{tenantID: tenant, cancel: cancel})
+				workInfo := WorkInfo{
+					TenantID:        tenant,
+					Priority:        WorkPriority(priority),
+					CreateTime:      int64(createTime),
+					BypassAdmission: bypass,
+				}
+				go func(ctx context.Context, info WorkInfo, id int) {
+					err := q.Admit(ctx, info)
+					if err != nil {
+						buf.printf("id %d: admit failed", id)
+						workMap.delete(id)
+					} else {
+						buf.printf("id %d: admit succeeded", id)
+						workMap.setAdmitted(id)
+					}
+				}(ctx, workInfo, id)
+				// Need deterministic output, and this is racing with the goroutine
+				// which is trying to get admitted. Sleep to let it get scheduled.
+				time.Sleep(50 * time.Millisecond)
+				return buf.stringAndReset()
+
+			case "set-try-get-return-value":
+				var v bool
+				d.ScanArgs(t, "v", &v)
+				tg.returnValueFromTryGet = v
+				return ""
+
+			case "granted":
+				tg.grant()
+				return buf.stringAndReset()
+
+			case "cancel-work":
+				var id int
+				d.ScanArgs(t, "id", &id)
+				work, ok := workMap.get(id)
+				if !ok {
+					return fmt.Sprintf("unknown id: %d", id)
+				}
+				if work.admitted {
+					return fmt.Sprintf("work already admitted id: %d", id)
+				}
+				work.cancel()
+				// Need deterministic output, and this is racing with the goroutine
+				// whose work is canceled. Sleep to let it get scheduled.
+				time.Sleep(50 * time.Millisecond)
+				return buf.stringAndReset()
+
+			case "work-done":
+				var id int
+				d.ScanArgs(t, "id", &id)
+				work, ok := workMap.get(id)
+				if !ok {
+					return fmt.Sprintf("unknown id: %d\n", id)
+				}
+				if !work.admitted {
+					return fmt.Sprintf("id not admitted: %d\n", id)
+				}
+				q.AdmittedWorkDone(work.tenantID)
+				workMap.delete(id)
+				return buf.stringAndReset()
+
+			case "print":
+				return q.String()
+
+			default:
+				return fmt.Sprintf("unknown command: %s", d.Cmd)
+			}
+		})
+	if q != nil {
+		q.closeForTesting()
+	}
+}
+
+func scanTenantID(t *testing.T, d *datadriven.TestData) roachpb.TenantID {
+	var id int
+	d.ScanArgs(t, "tenant", &id)
+	return roachpb.MakeTenantID(uint64(id))
+}
+
+// TODO(sumeer):
+// - Test metrics
+// - Test race between grant and cancellation
+// - Test WorkQueue for tokens


### PR DESCRIPTION
The current code is intended for node-level admission
control of various kinds of work and is intended for
both regular clusters and serverless settings (both
KV and SQL nodes).
The goals encompass overload protection, and performance
isolation between tenants and within a tenant (for work
of different importance within a tenant).

It generalizes the code structure used in the successful
experiments from
https://github.com/sumeerbhola/cockroach/tree/admission
This generalization is meant to allow tweaking of
heuristics without requiring extensive changes to the
framework, and to allow integration of both IO and memory
overload signals.

There are a number of TODOs that are for exploration in
later, more sophisticated, experiments.

Release note: None