### PR TITLE
changefeedccl: Add simplistic pushback mechanism.

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -496,6 +496,8 @@ func (ca *changeAggregator) tick() error {
 		if ca.knobs.ShouldSkipResolved == nil || !ca.knobs.ShouldSkipResolved(resolved) {
 			return ca.noteResolvedSpan(resolved)
 		}
+	case kvevent.TypeFlush:
+		return ca.sink.Flush(ca.Ctx)
 	}
 
 	return nil

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdctest"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/kvevent"
 	// Imported to allow multi-tenant tests
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/kvccl/kvtenantccl"
 	// Imported to allow locality-related table mutations
@@ -66,6 +67,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
@@ -4580,4 +4582,120 @@ func TestChangefeedCaseInsensitiveOpts(t *testing.T) {
 		})
 	}
 	t.Run(`sinkless`, sinklessTest(testFn))
+}
+
+func startMonitorWithBudget(budget int64) *mon.BytesMonitor {
+	mm := mon.NewMonitorWithLimit(
+		"test-mm", mon.MemoryResource, budget,
+		nil, nil,
+		128 /* small allocation increment */, 100,
+		cluster.MakeTestingClusterSettings())
+	mm.Start(context.Background(), nil, mon.MakeStandaloneBudget(budget))
+	return mm
+}
+
+type memoryHoggingSink struct {
+	expectedRows int
+	allEmitted   chan struct{}
+	numFlushes   int
+	alloc        kvevent.Alloc
+}
+
+var _ Sink = (*memoryHoggingSink)(nil)
+
+func (s *memoryHoggingSink) expectRows(n int) chan struct{} {
+	if n <= 0 {
+		panic("n<=0")
+	}
+	s.expectedRows = n
+	s.numFlushes = 0
+	s.allEmitted = make(chan struct{})
+	s.alloc.Release(context.Background()) // Release leftover alloc
+	return s.allEmitted
+}
+
+func (s *memoryHoggingSink) Dial() error {
+	return nil
+}
+
+func (s *memoryHoggingSink) EmitRow(
+	ctx context.Context,
+	topic TopicDescriptor,
+	key, value []byte,
+	updated hlc.Timestamp,
+	alloc kvevent.Alloc,
+) error {
+	s.expectedRows--
+	s.alloc.Merge(&alloc)
+	if s.expectedRows == 0 {
+		close(s.allEmitted)
+	}
+	return nil
+}
+
+func (s *memoryHoggingSink) EmitResolvedTimestamp(
+	ctx context.Context, encoder Encoder, resolved hlc.Timestamp,
+) error {
+	panic("should not be called")
+}
+
+func (s *memoryHoggingSink) Flush(ctx context.Context) error {
+	s.numFlushes++
+	s.alloc.Release(ctx)
+	return nil
+}
+
+func (s *memoryHoggingSink) Close() error {
+	s.alloc.Release(context.Background())
+	return nil
+}
+
+func TestChangefeedFlushesSinkToReleaseMemory(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	s, db, stopServer := startTestServer(t, newTestOptions())
+	defer stopServer()
+
+	sqlDB := sqlutils.MakeSQLRunner(db)
+	knobs := s.TestingKnobs().
+		DistSQL.(*execinfra.TestingKnobs).
+		Changefeed.(*TestingKnobs)
+
+	// Arrange for a small memory budget.
+	knobs.MemMonitor = startMonitorWithBudget(4096)
+
+	// Ignore resolved events delivered to this changefeed.  This has
+	// an effect of never advancing the frontier, and thus never flushing
+	// the sink due to frontier advancement.  The only time we flush the sink
+	// is if the memory pressure causes flush request to be delivered.
+	knobs.ShouldSkipResolved = func(_ *jobspb.ResolvedSpan) bool {
+		return true
+	}
+
+	// Arrange for custom sink to be used -- a sink that does not
+	// release its resources.
+	sink := &memoryHoggingSink{}
+	knobs.WrapSink = func(_ Sink, _ jobspb.JobID) Sink {
+		return sink
+	}
+
+	// Create table, and insert 123 rows in it -- this fills up
+	// our tiny memory buffer (~26 rows do)
+	sqlDB.Exec(t, `CREATE TABLE foo(key INT PRIMARY KEY DEFAULT unique_rowid(), val INT)`)
+	sqlDB.Exec(t, `INSERT INTO foo (val) SELECT * FROM generate_series(1, 123)`)
+
+	// Expect 1000 rows from backfill.
+	allEmitted := sink.expectRows(123)
+
+	sqlDB.Exec(t, `CREATE CHANGEFEED FOR foo INTO 'http://host/does/not/matter'`)
+
+	<-allEmitted
+	require.Greater(t, sink.numFlushes, 0)
+
+	// Insert another thousand rows.  This now uses rangefeeds.
+	allEmitted = sink.expectRows(123)
+	sqlDB.Exec(t, `INSERT INTO foo (val) SELECT * FROM generate_series(1, 123)`)
+	<-allEmitted
+	require.Greater(t, sink.numFlushes, 0)
 }

--- a/pkg/ccl/changefeedccl/kvevent/blocking_buffer.go
+++ b/pkg/ccl/changefeedccl/kvevent/blocking_buffer.go
@@ -33,9 +33,10 @@ type blockingBuffer struct {
 
 	mu struct {
 		syncutil.Mutex
-		closed  bool
-		drainCh chan struct{}
-		queue   bufferEntryQueue
+		closed  bool             // True when buffer closed.
+		drainCh chan struct{}    // Set when Drain request issued.
+		blocked *bufferEntry     // Set when event is blocked, waiting to acquire quota.
+		queue   bufferEntryQueue // Queue of added events.
 	}
 }
 
@@ -53,15 +54,18 @@ func NewMemBuffer(
 				metrics.BufferPushbackNanos.Inc(timeutil.Since(start).Nanoseconds())
 			}))
 
-	return &blockingBuffer{
+	b := &blockingBuffer{
 		signalCh: make(chan struct{}, 1),
 		metrics:  metrics,
 		sv:       sv,
-		qp: allocPool{
-			AbstractPool: quotapool.New("changefeed", &memQuota{acc: acc}, opts...),
-			metrics:      metrics,
-		},
 	}
+	quota := &memQuota{acc: acc, notifyOutOfQuota: b.notifyOutOfQuota}
+	b.qp = allocPool{
+		AbstractPool: quotapool.New("changefeed", quota, opts...),
+		metrics:      metrics,
+	}
+
+	return b
 }
 
 var _ Buffer = (*blockingBuffer)(nil)
@@ -72,12 +76,42 @@ func (b *blockingBuffer) pop() (e *bufferEntry, err error) {
 	if b.mu.closed {
 		return nil, ErrBufferClosed
 	}
+
 	e = b.mu.queue.dequeue()
+
+	if e == nil && b.mu.blocked != nil {
+		// Here, we know that we are blocked, waiting for memory; yet we have nothing queued up
+		// (and thus, no resources that could be released by draining the queue).
+		// This means that all the previously added entries have been read by the consumer,
+		// but their resources have not been yet released.
+		// The delayed release could happen when multiple events, along with their allocs,
+		// are batched prior to being released (e.g. a sink producing files).
+		// If the batching event consumer does not have periodic flush configured,
+		// we may never be able to make forward progress.
+		// So, we issue the flush request to the consumer to ensure that we release some memory.
+		e = newBufferEntry(Event{flush: true})
+		// Ensure we notify only once.
+		b.mu.blocked = nil
+	}
+
 	if b.mu.drainCh != nil && b.mu.queue.empty() {
 		close(b.mu.drainCh)
 		b.mu.drainCh = nil
 	}
 	return e, nil
+}
+
+// notifyOutOfQuota is invoked by memQuota to notify blocking buffer that
+// event is blocked, waiting for more resources.
+func (b *blockingBuffer) notifyOutOfQuota(e *bufferEntry) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.mu.blocked = e
+
+	select {
+	case b.signalCh <- struct{}{}:
+	default:
+	}
 }
 
 // Get implements kvevent.Reader interface.
@@ -119,43 +153,16 @@ func (b *blockingBuffer) ensureOpenedLocked(ctx context.Context) error {
 	return nil
 }
 
-// Add implements Writer interface.
-func (b *blockingBuffer) Add(ctx context.Context, e Event) error {
-	if err := b.ensureOpened(ctx); err != nil {
-		return err
-	}
-
-	var be *bufferEntry
-	if e.alloc.ap == nil {
-		// Acquire the quota first.
-		alloc := int64(changefeedbase.EventMemoryMultiplier.Get(b.sv) * float64(e.approxSize))
-		if l := changefeedbase.PerChangefeedMemLimit.Get(b.sv); alloc > l {
-			return errors.Newf("event size %d exceeds per changefeed limit %d", alloc, l)
-		}
-		e.alloc = Alloc{
-			bytes:   alloc,
-			entries: 1,
-			ap:      &b.qp,
-		}
-		be = newBufferEntry(e)
-
-		if err := b.qp.Acquire(ctx, be); err != nil {
-			bufferEntryPool.Put(be)
-			return err
-		}
-		b.metrics.BufferEntriesMemAcquired.Inc(alloc)
-	} else {
-		// Use allocation associated with the event itself.
-		be = newBufferEntry(e)
-	}
-
+func (b *blockingBuffer) enqueue(ctx context.Context, be *bufferEntry) error {
 	// Enqueue message, and signal if anybody is waiting.
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if err := b.ensureOpenedLocked(ctx); err != nil {
 		return err
 	}
+
 	b.metrics.BufferEntriesIn.Inc(1)
+	b.mu.blocked = nil
 	b.mu.queue.enqueue(be)
 
 	select {
@@ -163,6 +170,37 @@ func (b *blockingBuffer) Add(ctx context.Context, e Event) error {
 	default:
 	}
 	return nil
+}
+
+// Add implements Writer interface.
+func (b *blockingBuffer) Add(ctx context.Context, e Event) error {
+	if err := b.ensureOpened(ctx); err != nil {
+		return err
+	}
+
+	if e.alloc.ap != nil {
+		// Use allocation associated with the event itself.
+		return b.enqueue(ctx, newBufferEntry(e))
+	}
+
+	// Acquire the quota first.
+	alloc := int64(changefeedbase.EventMemoryMultiplier.Get(b.sv) * float64(e.approxSize))
+	if l := changefeedbase.PerChangefeedMemLimit.Get(b.sv); alloc > l {
+		return errors.Newf("event size %d exceeds per changefeed limit %d", alloc, l)
+	}
+	e.alloc = Alloc{
+		bytes:   alloc,
+		entries: 1,
+		ap:      &b.qp,
+	}
+	be := newBufferEntry(e)
+
+	if err := b.qp.Acquire(ctx, be); err != nil {
+		bufferEntryPool.Put(be)
+		return err
+	}
+	b.metrics.BufferEntriesMemAcquired.Inc(alloc)
+	return b.enqueue(ctx, be)
 }
 
 // tryDrain attempts to see if the buffer already empty.
@@ -257,6 +295,11 @@ type memQuota struct {
 	// again until the allocated budget drops to below half that level.
 	canAllocateBelow int64
 
+	// When memQuota blocks waiting for resources, invoke the callback
+	// to notify about this. The notification maybe invoked multiple
+	// times for a single request that's blocked.
+	notifyOutOfQuota func(request *bufferEntry)
+
 	acc mon.BoundAccount
 }
 
@@ -290,6 +333,18 @@ func (be *bufferEntry) Acquire(
 	ctx context.Context, resource quotapool.Resource,
 ) (fulfilled bool, tryAgainAfter time.Duration) {
 	quota := resource.(*memQuota)
+	fulfilled, tryAgainAfter = be.acquireQuota(ctx, quota)
+
+	if !fulfilled {
+		quota.notifyOutOfQuota(be)
+	}
+
+	return fulfilled, tryAgainAfter
+}
+
+func (be *bufferEntry) acquireQuota(
+	ctx context.Context, quota *memQuota,
+) (fulfilled bool, tryAgainAfter time.Duration) {
 	if quota.canAllocateBelow > 0 {
 		if quota.allocated > quota.canAllocateBelow {
 			return false, 0
@@ -305,7 +360,7 @@ func (be *bufferEntry) Acquire(
 			// single request, but we may succeed if we try again later since some other
 			// process may release it into the pool.
 			// TODO(yevgeniy): Consider making retry configurable; possibly with backoff.
-			return true, time.Second
+			return false, time.Second
 		}
 
 		// Back off on allocating until we've cleared up half of our usage.

--- a/pkg/ccl/changefeedccl/kvevent/blocking_buffer_test.go
+++ b/pkg/ccl/changefeedccl/kvevent/blocking_buffer_test.go
@@ -111,3 +111,51 @@ func TestBlockingBuffer(t *testing.T) {
 	}
 	stopProducers()
 }
+
+func TestBlockingBufferNotifiesConsumerWhenOutOfMemory(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	metrics := kvevent.MakeMetrics(time.Minute)
+	ba, release := getBoundAccountWithBudget(4096)
+	defer release()
+
+	st := cluster.MakeTestingClusterSettings()
+	buf := kvevent.NewMemBuffer(ba, &st.SV, &metrics)
+	defer func() {
+		require.NoError(t, buf.Close(context.Background()))
+	}()
+
+	producerCtx, stopProducer := context.WithCancel(context.Background())
+	wg := ctxgroup.WithContext(producerCtx)
+	defer func() {
+		_ = wg.Wait() // Ignore error -- this group returns context cancellation.
+	}()
+
+	// Start adding KVs to the buffer until we block.
+	wg.GoCtx(func(ctx context.Context) error {
+		rnd, _ := randutil.NewTestPseudoRand()
+		for {
+			err := buf.Add(ctx, kvevent.MakeKVEvent(makeKV(t, rnd), roachpb.Value{}, hlc.Timestamp{}))
+			if err != nil {
+				return nil
+			}
+		}
+	})
+
+	// Consume events until we get a flush event.
+	var outstanding kvevent.Alloc
+	for i := 0; ; i++ {
+		e, err := buf.Get(context.Background())
+		require.NoError(t, err)
+		if e.Type() == kvevent.TypeFlush {
+			break
+		}
+
+		// detach alloc associated with an event and merge (but not release) it into outstanding.
+		a := e.DetachAlloc()
+		outstanding.Merge(&a)
+	}
+
+	stopProducer()
+}

--- a/pkg/ccl/changefeedccl/kvevent/event.go
+++ b/pkg/ccl/changefeedccl/kvevent/event.go
@@ -62,6 +62,11 @@ const (
 	// meaningful.
 	TypeResolved
 
+	// TypeFlush indicates a request to flush buffered data.
+	// This request is type is emitted by blocking buffer when it's blocked, waiting
+	// for more memory.
+	TypeFlush
+
 	// TypeUnknown indicates the event could not be parsed. Will fail the feed.
 	TypeUnknown
 )
@@ -71,6 +76,7 @@ const (
 type Event struct {
 	kv                 roachpb.KeyValue
 	prevVal            roachpb.Value
+	flush              bool
 	resolved           *jobspb.ResolvedSpan
 	backfillTimestamp  hlc.Timestamp
 	bufferGetTimestamp time.Time
@@ -85,6 +91,9 @@ func (b *Event) Type() Type {
 	}
 	if b.resolved != nil {
 		return TypeResolved
+	}
+	if b.flush {
+		return TypeFlush
 	}
 	return TypeUnknown
 }

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
@@ -467,7 +467,7 @@ func copyFromSourceToDestUntilTableEvent(
 		}
 		addEntry = func(e kvevent.Event) error {
 			switch e.Type() {
-			case kvevent.TypeKV:
+			case kvevent.TypeKV, kvevent.TypeFlush:
 				return dest.Add(ctx, e)
 			case kvevent.TypeResolved:
 				// TODO(ajwerner): technically this doesn't need to happen for most


### PR DESCRIPTION
Add a simplistic pushback mechanism to changefeeds.  This mechanism
uses channel buffer, instead of the default memory buffer.
The effect is that if we are slow to read off of the channel
(perhaps due to slow sink, or very high request rate), we will
no longer be reading from the channel, which results in a pushback effect.

This is a simplistic implementation most likely has
higher CPU and memory allocation/deallocation costs.
The pushback mechanism will be improved upon in the future.
The default is to use memory buffer, but this mechanism can
be enabled via `changefeed.enable_pushback` setting.

Informs #63186
Informs #60697

Release Notes: None