### PR TITLE
release-21.1: kvserver: reduce ReplicaGCQueueInactivityThreshold to 12 hours

### DIFF
--- a/pkg/kv/kvserver/replica_gc_queue.go
+++ b/pkg/kv/kvserver/replica_gc_queue.go
@@ -31,7 +31,7 @@ const (
 
 	// ReplicaGCQueueInactivityThreshold is the inactivity duration after which
 	// a range will be considered for garbage collection. Exported for testing.
-	ReplicaGCQueueInactivityThreshold = 10 * 24 * time.Hour // 10 days
+	ReplicaGCQueueInactivityThreshold = 12 * time.Hour
 	// ReplicaGCQueueSuspectTimeout is the duration after which a Replica which
 	// is suspected to be removed should be processed by the queue.
 	// A Replica is suspected to have been removed if either it is in the


### PR DESCRIPTION
Backport 1/1 commits from #63214.

/cc @cockroachdb/release @cockroachdb/kv

---

`ReplicaGCQueueInactivityThreshold` specifies the interval at which the
GC queue checks whether a replica has been removed from the canonical
range descriptor, and was set to 10 days. This is a fallback for when we
fail to detect the removal and GC the replica immediately. However, this
could occasionally cause stale replicas to linger for 10 days, which
surprises users (e.g. by causing alerts if the stale replica thinks the
range has become underreplicated).

This patch reduces the threshold to 12 hours, which is a more reasonable
timeframe for users to expect things to "sort themselves out". The
operation to read the range descriptor is fairly cheap, so this is not
likely to cause any problems, and the interval is therefore not jittered
either.

Resolves #63212, touches #60259.

Release note (ops change): Replica garbage collection now checks
replicas against the range descriptor every 12 hours (down from 10 days)
to see if they should be removed. Replicas that fail to notice they have
been removed from a range will therefore linger for at most 12 hours
rather than 10 days.