### PR TITLE
opt: allow OrderingChoices to imply more orderings

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/prepare
+++ b/pkg/sql/logictest/testdata/logic_test/prepare
@@ -1181,7 +1181,8 @@ select
  │    ├── cost: 1054.41
  │    ├── key: (1)
  │    ├── fd: (1)-->(2)
- │    └── prune: (1,2)
+ │    ├── prune: (1,2)
+ │    └── interesting orderings: (+1)
  └── filters
       └── (k:1 % 2) = 1 [outer=(1), immutable]
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -1179,25 +1179,22 @@ EXPLAIN (VERBOSE) SELECT * FROM xyz WHERE z=1 AND x=y ORDER BY x;
 distribution: local
 vectorized: true
 ·
-• sort
+• filter
 │ columns: (x, y, z)
-│ ordering: +x
+│ ordering: +y
 │ estimated row count: 1 (missing stats)
-│ order: +x
+│ filter: x = y
 │
-└── • filter
+└── • index join
     │ columns: (x, y, z)
-    │ estimated row count: 1 (missing stats)
-    │ filter: x = y
+    │ ordering: +y
+    │ estimated row count: 10 (missing stats)
+    │ table: xyz@primary
+    │ key columns: rowid
     │
-    └── • index join
-        │ columns: (x, y, z)
-        │ estimated row count: 10 (missing stats)
-        │ table: xyz@primary
-        │ key columns: rowid
-        │
-        └── • scan
-              columns: (y, z, rowid)
-              estimated row count: 10 (missing stats)
-              table: xyz@xyz_z_y_idx
-              spans: /1/!NULL-/2
+    └── • scan
+          columns: (y, z, rowid)
+          ordering: +y
+          estimated row count: 10 (missing stats)
+          table: xyz@xyz_z_y_idx
+          spans: /1/!NULL-/2

--- a/pkg/sql/opt/exec/execbuilder/testdata/union
+++ b/pkg/sql/opt/exec/execbuilder/testdata/union
@@ -476,41 +476,33 @@ vectorized: true
 │ ordering: +b,+c,+d,+a,+e
 │ estimated row count: 2 (missing stats)
 │
-├── • sort
+├── • filter
 │   │ columns: (a, b, c, d, e)
 │   │ ordering: +b,+d,+a
 │   │ estimated row count: 1 (missing stats)
-│   │ order: +b,+d,+a
+│   │ filter: (c = 1) AND (d = e)
 │   │
-│   └── • filter
-│       │ columns: (a, b, c, d, e)
-│       │ estimated row count: 1 (missing stats)
-│       │ filter: (c = 1) AND (d = e)
-│       │
-│       └── • scan
-│             columns: (a, b, c, d, e)
-│             estimated row count: 1,000 (missing stats)
-│             table: abcde@primary
-│             spans: FULL SCAN
+│   └── • scan
+│         columns: (a, b, c, d, e)
+│         ordering: +b,+c,+d,+e,+a
+│         estimated row count: 1,000 (missing stats)
+│         table: abcde@abcde_b_c_d_e_idx
+│         spans: FULL SCAN
 │
-└── • sort
+└── • filter
     │ columns: (a, b, c, d, e)
     │ ordering: +b,+d,+a
     │ estimated row count: 1 (missing stats)
-    │ order: +b,+d,+a
+    │ filter: (c = 1) AND (d = e)
     │
-    └── • filter
-        │ columns: (a, b, c, d, e)
-        │ estimated row count: 1 (missing stats)
-        │ filter: (c = 1) AND (d = e)
-        │
-        └── • scan
-              columns: (a, b, c, d, e)
-              estimated row count: 1,000 (missing stats)
-              table: abcde@primary
-              spans: FULL SCAN
+    └── • scan
+          columns: (a, b, c, d, e)
+          ordering: +b,+c,+d,+e,+a
+          estimated row count: 1,000 (missing stats)
+          table: abcde@abcde_b_c_d_e_idx
+          spans: FULL SCAN
 ·
-Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyskF2L2kAUhu_7Kw7nSuspmi-3DAizW7M0YOM2sV8UL2LmsATcxM6M0CL-95KkdFfRUHd7OefkOc-bd4fmxxoFhl_vZtdRDL1plC7SjzOCz2FyM0_DPqThLHy3gNdwm8w_QO_wma1yxfApjuYxnNj04cv7MAmhl8MEnD5cx1PoKZgA92GeTMMEbr7BiiAnUARMkCFhWSmOswc2KL6jg0vCja5yNqbS9WjXfBCpnyhGhEW52dp6vCTMK80odmgLu2YUuMhWa044U6yHIyRUbLNi3Zxt0smNLh4y_QsJ001WGgFvcLknrLb28aix2T2jcPb07-LbYm1Zsx46h9Z2LqAnvboPIUQUL97-qUX6MAEZ9M9GcC-JkFbash66hwGkOyDpD0g6g7Ma7xLN04q9F1bsP6ti_39WHDyj4uDyisdnNY_XK61Yszpx3PsrIBnUkhPZpoWxRZnb4fjogEPSJemR9EkGZwNeXdJDwmZTlYYPTOcuj-q0rO65_VtTbXXOd7rKG037nDdcM1BsbLt12kdUtqs64FPY6YTdbtjthMcHsHMMe52w3232O-GgGw5eEnvcCV8dmZf7V78DAAD__4t08R0=
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyskG-Lm0AQxt_3UwzzKmmmJEYDZSGwd41HhVSvmv6jiBh3OASr6e4GDkK-e1ELd4ZL6PXujTAzPs_z2-eA5neFAv3vt-urIITRKkg2yec1wVc_vo4SfwyJv_Y_bOAt3MTRJxgNx3xbKIYvYRCF8MRlDN8--rEPowKW4IzhKlzBSMESeAxRvPJjuP4BW4KCQBEwQY6EdaM4zH-xQfETHUwJd7op2JhGt6tD90Og7lHMCMt6t7ftOiUsGs0oDmhLWzEK3OTbimPOFevpDAkV27ysOtuOTnbfbJsVmco4K9U9Eia7vDYC3mF6JGz29sHe2PyOUThH-neEm7KyrFlPnWF-vxcwkm7bjBAiCDfv_xYkPViCXIzPIsyfg_C4hfmrteD-Vwvua7bgnUV4SG60Ys1qGCvnE5LuhKQ3IelMSC4mmB6f4F6VxpZ1YafeiYFDck7SJemRXJwFXDyno5jNrqkND5LOOc9aWlZ33L_WNHtd8K1uii6mH6NO1y0UG9tfnX4I6v7UAj4WOxfF3kDsnIrnF8Xu5WT3JcneRfHiJDk9vvkTAAD__6G3jwo=
 
 query T
 EXPLAIN (DISTSQL,VERBOSE) SELECT * FROM (SELECT * FROM abcde UNION ALL SELECT * FROM abcde) WHERE c = 1 AND d = e ORDER BY a
@@ -562,41 +554,33 @@ vectorized: true
 │ ordering: +b,+c,+d,+a
 │ estimated row count: 2 (missing stats)
 │
-├── • sort
+├── • filter
 │   │ columns: (a, b, c, d, e)
 │   │ ordering: +b,+d,+a
 │   │ estimated row count: 1 (missing stats)
-│   │ order: +b,+d,+a
+│   │ filter: (c = 1) AND (d = e)
 │   │
-│   └── • filter
-│       │ columns: (a, b, c, d, e)
-│       │ estimated row count: 1 (missing stats)
-│       │ filter: (c = 1) AND (d = e)
-│       │
-│       └── • scan
-│             columns: (a, b, c, d, e)
-│             estimated row count: 1,000 (missing stats)
-│             table: abcde@primary
-│             spans: FULL SCAN
+│   └── • scan
+│         columns: (a, b, c, d, e)
+│         ordering: +b,+c,+d,+e,+a
+│         estimated row count: 1,000 (missing stats)
+│         table: abcde@abcde_b_c_d_e_idx
+│         spans: FULL SCAN
 │
-└── • sort
+└── • filter
     │ columns: (a, b, c, d, e)
     │ ordering: +b,+d,+a
     │ estimated row count: 1 (missing stats)
-    │ order: +b,+d,+a
+    │ filter: (c = 1) AND (d = e)
     │
-    └── • filter
-        │ columns: (a, b, c, d, e)
-        │ estimated row count: 1 (missing stats)
-        │ filter: (c = 1) AND (d = e)
-        │
-        └── • scan
-              columns: (a, b, c, d, e)
-              estimated row count: 1,000 (missing stats)
-              table: abcde@primary
-              spans: FULL SCAN
+    └── • scan
+          columns: (a, b, c, d, e)
+          ordering: +b,+c,+d,+e,+a
+          estimated row count: 1,000 (missing stats)
+          table: abcde@abcde_b_c_d_e_idx
+          spans: FULL SCAN
 ·
-Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyskN1q20AQhe_7FMNcWc0GW39uWTDIqRUqUKVUcv8oupC1QxAoWnVXhhbjdy-WCrGCLeKklzOz3zlnzw71rwo5-t_vwmUQwWQVpOv0c8jgq5_cxKlvQOqH_oc1vIXbJP4Ek-GYbwpB8CUK4giWYQgnrgZ8--gnPkwKWIBpwDJawUTAAsiAOFn5Cdz8gA2DgoFgQAxyZFhLQVH-QBr5TzQxY9goWZDWUh1Wu-5BIH4jnzEs62bbHtYZw0IqQr7DtmwrQo7rfFNRQrkgNZ0hQ0FtXladbJfOa1T5kKs_yDBt8lpzuMZsz1Bu20dR3eb3hNzcs-cb35ZVS4rU1By69nsOE88-9ME5D6L1-3-1eA4swHONsxGsSyKkUrWkptYwgGddMc-5Yp55ddbGvsTmuGL7lRU7L6rY-Z8Vuy-o2L284vlZm0d1qQQpEifE7WODE7kieS2b6XxAnksyu-TDCelG1pqeqZwxJHFP_be03KqC7pQsOpt-jDuuWwjSbX81-yGo-9Mh4DFsjsLWOGyNwvMBbD6F7VHYGXd2RmF3HHZfE3s-Cr974pzt3_wNAAD__wOb7Jc=
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyskG9rm1AUxt_vUxzOq7ickhgtjAsB08UywWmn2T-GiPEeiuC87l4DhZDvPqKD1tKEdu0b4TzH5zy_--zR_KlRoP_jJlwFEUzWQbpJv4QE3_zkKk59C1I_9D9u4D1cJ_FnmIzHYltKhq9REEewCkN4YmvB909-4sOkhCXYFqyiNUwkLIEtiJO1n8DVT9gSlASSgAkKJGyU5Kj4zQbFL7QxI2y1KtkYpY_Svv8hkHco5oRV0-66o5wRlkozij12VVczCtwU25oTLiTr2RwJJXdFVfdnezqv_-bbvMxlznkl75AwbYvGCLjA7ECodt39edMVt4zCPtDzEa6rumPNemaP8wddwMRzjs0IIYJo8-FfQZ4LS_AurZMIi5cgPGxh8WYtOP_VgvOWLbgnEe6TlZasWY5jvcWUPGdKnjslz55idniCOVIXqp25I-cpkvlLykjYtKox_MzLGSHLWx6eZdROl3yjVdnHDGPc-3pBsumGrT0MQTOsjoAPzfZZszsy24_Ni7Nm53yy85pk96z58lFydnj3NwAA__-m3oqG
 
 query T
 EXPLAIN (DISTSQL,VERBOSE) SELECT * FROM (SELECT * FROM abcde INTERSECT SELECT * FROM abcde) WHERE c = 1 AND d = e ORDER BY a
@@ -643,39 +627,38 @@ EXPLAIN (DISTSQL,VERBOSE) SELECT * FROM (SELECT * FROM abcde EXCEPT SELECT * FRO
 distribution: local
 vectorized: true
 ·
-• sort
+• except
 │ columns: (a, b, c, d, e)
-│ ordering: +b,+c,+d,+a
+│ ordering: +b,+c,+d,+a,+e
 │ estimated row count: 1 (missing stats)
-│ order: +b,+c,+d,+a
 │
-└── • except
+├── • filter
+│   │ columns: (a, b, c, d, e)
+│   │ ordering: +b,+d,+a
+│   │ estimated row count: 1 (missing stats)
+│   │ filter: (c = 1) AND (d = e)
+│   │
+│   └── • scan
+│         columns: (a, b, c, d, e)
+│         ordering: +b,+c,+d,+e,+a
+│         estimated row count: 1,000 (missing stats)
+│         table: abcde@abcde_b_c_d_e_idx
+│         spans: FULL SCAN
+│
+└── • filter
     │ columns: (a, b, c, d, e)
+    │ ordering: +b,+d,+a
     │ estimated row count: 1 (missing stats)
+    │ filter: (c = 1) AND (d = e)
     │
-    ├── • filter
-    │   │ columns: (a, b, c, d, e)
-    │   │ estimated row count: 1 (missing stats)
-    │   │ filter: (c = 1) AND (d = e)
-    │   │
-    │   └── • scan
-    │         columns: (a, b, c, d, e)
-    │         estimated row count: 1,000 (missing stats)
-    │         table: abcde@primary
-    │         spans: FULL SCAN
-    │
-    └── • filter
-        │ columns: (a, b, c, d, e)
-        │ estimated row count: 1 (missing stats)
-        │ filter: (c = 1) AND (d = e)
-        │
-        └── • scan
-              columns: (a, b, c, d, e)
-              estimated row count: 1,000 (missing stats)
-              table: abcde@primary
-              spans: FULL SCAN
+    └── • scan
+          columns: (a, b, c, d, e)
+          ordering: +b,+c,+d,+e,+a
+          estimated row count: 1,000 (missing stats)
+          table: abcde@abcde_b_c_d_e_idx
+          spans: FULL SCAN
 ·
-Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJysk11vmzwUx--fT3F0ruCJp5S3pLIUyW1D1UhZ6ABtnaZcUDhrkSgw25FWVf3uE7CpJUtYk-3Sx_6d_wviCdW3Ajn6N9fLs8UKjPkiiqMPSwYf_fA8iHwTIn_pX8TwP1yGwXsw-sfkNs0I_JsL_zqGHVcmfLryQx-MFGZgmXC2moORwQzIhCCc-yGcf4ZbBimDjAExSJBhWWW0Sh5IIf-CFq4Z1rJKSalKNqOn9sEi-478hGFe1hvdjNcM00oS8ifUuS4IOcbJbUEhJRnJ8QkyzEgnedGubd2JWuYPiXxEhlGdlIrDO1w_M6w2-mWp0skdIbee2duFL_NCkyQ5tvqq3ZyDIZymD875YhWf_qxFuDAD4Zl7LdiHWHid3f7L7M5R2Z1_md09xMI8VzovUz12-xaExYTNhMOEy4S3V8s7Sss7SmuyV-tFYlNWMiNJWU9h3ZB_erLD8FWi7iPSQT2e9B3HjzXxX__y2XKJDAv6qo1-EnMm87v736bIMNhoDm-MPT2k4qiSmuR4ulWwPWLCGTHhjpiwRnulTg-RCknVValou-mdm0-aeim7o-5zqWojU7qWVdrKdMeg5dpBRkp3t1Z3WJTdVWPwNWwNwu4wbA_CzjDsDMLeMOwOwpMebG3D3gGwvQ1PBuHpsO3pIHy6Ba-f__sRAAD__7MJRLg=
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyslNFr20AMxt_3Vwg9JYtG6thOx0Hg2sZlgTTpbLN1jBAcn5YZPNs7X6Cj9H8ftjdah8RbSl8Cku6n79MX8AOWP1MU6N3dzi9mC-hNZ0EYfJwTfPL8y2Xg9SHw5t5VCG_h2l_eQK9dRptYMXh3V95tCAdGffj8wfM96MUwAasPF4sp9BRMgPuw9KeeD5dfYEMQEygCJoiQMMsVL6IfXKL4ihauCAudx1yWua5aD_WDmbpHcUaYZMXOVO0VYZxrRvGAJjEpo8Aw2qTsc6RYD8-QULGJkrReW7uT9e96s47Xas3rRN0jYVBEWSngHa4eCfOdeVpfmmjLKKxH-n8L10lqWLMeWm39pi-gJ-0qGSHEbBG-_xOQdGAC0u0ftTA6xcLzFEavloL9ohTs10zBOcXCNClNksVm6LQtSIvkiKRN0iHpIuFSK9asBFRth6R1VN99kb77avrjo_pPsrssb_a1VFcV-a8nB464Yb3lgM2yGI7bZ4S_ChZ_PwQX8zkSpvzN9ORoQNIekHQGJK0BSXfQn-hk-_3wqLp_ZwTspXIsgfNT_gGfyyLPSt5P4uDms-p8Vltu4izznY75VudxLdOUy5qrG4pL00ytpphlzagy-By2OmGnGx51wnY3bHfCbjfsdMLjFmztw-4J8GgfHnfC53u2V49vfgcAAP__jLsjDg==
 
 query T
 EXPLAIN (DISTSQL,VERBOSE) SELECT * FROM (SELECT * FROM abcde EXCEPT ALL SELECT * FROM abcde) WHERE c = 1 AND d = e ORDER BY a
@@ -722,39 +705,38 @@ EXPLAIN (DISTSQL,VERBOSE) SELECT * FROM (SELECT * FROM abcde INTERSECT ALL SELEC
 distribution: local
 vectorized: true
 ·
-• sort
+• intersect all
 │ columns: (a, b, c, d, e)
-│ ordering: +b,+c,+d,+a
+│ ordering: +b,+c,+d,+a,+e
 │ estimated row count: 1 (missing stats)
-│ order: +b,+c,+d,+a
 │
-└── • intersect all
+├── • filter
+│   │ columns: (a, b, c, d, e)
+│   │ ordering: +b,+d,+a
+│   │ estimated row count: 1 (missing stats)
+│   │ filter: (c = 1) AND (d = e)
+│   │
+│   └── • scan
+│         columns: (a, b, c, d, e)
+│         ordering: +b,+c,+d,+e,+a
+│         estimated row count: 1,000 (missing stats)
+│         table: abcde@abcde_b_c_d_e_idx
+│         spans: FULL SCAN
+│
+└── • filter
     │ columns: (a, b, c, d, e)
+    │ ordering: +b,+d,+a
     │ estimated row count: 1 (missing stats)
+    │ filter: (c = 1) AND (d = e)
     │
-    ├── • filter
-    │   │ columns: (a, b, c, d, e)
-    │   │ estimated row count: 1 (missing stats)
-    │   │ filter: (c = 1) AND (d = e)
-    │   │
-    │   └── • scan
-    │         columns: (a, b, c, d, e)
-    │         estimated row count: 1,000 (missing stats)
-    │         table: abcde@primary
-    │         spans: FULL SCAN
-    │
-    └── • filter
-        │ columns: (a, b, c, d, e)
-        │ estimated row count: 1 (missing stats)
-        │ filter: (c = 1) AND (d = e)
-        │
-        └── • scan
-              columns: (a, b, c, d, e)
-              estimated row count: 1,000 (missing stats)
-              table: abcde@primary
-              spans: FULL SCAN
+    └── • scan
+          columns: (a, b, c, d, e)
+          ordering: +b,+c,+d,+e,+a
+          estimated row count: 1,000 (missing stats)
+          table: abcde@abcde_b_c_d_e_idx
+          spans: FULL SCAN
 ·
-Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyskt-Lm04Uxd-_f8XlPuk3U7L-WspAYLKNywpp3Kr0ByUPRm-zgqt2ZgJdQv73ohZ2TRPbtH2cM_O555yre1RfS-Tof7xfzoMVGIsgTuJ3Swbv_egmjH0TYn_pv0ngf7iNwrdgDI_pJssJglXiR3Erz5dLOPHChA93fuSDkcEMLBPmqwUYOcyATAijhR_BzSfYMMgY5AyIQYoMqzqnVfpICvlntHDNsJF1RkrVspX23YMg_4b8imFRNTvdymuGWS0J-R51oUtCjkm6KSmiNCc5vUKGOem0KLuxXTrRyOIxlU_IMG7SSnF4hesDw3qnn4cqnW4JuXVgv298W5SaJMmpNXTtdQ6GcNp9cM6DVfL6x1qECzMQnnk2gn1JhJfd7b_s7vxRd-dfdnfPRnh23lW1zElSPjBet-SvnpzocZeqh5h02EzdYZHkqSE-_PWRYUlftCEsJmwmHCZcJjxzJovtw08qMgx3msNQPtvcu2T5cS01yak3TCzsCRPOhAl3woQ1OWt1fYlVRKqpK0XHyz45-ardMOVb6r-Yqncyo3tZZ51Nfww7rhNyUrq_tfpDUPVXbcCXsDUKuwPYPobtUdgZd3YucLaOYXcU9sadvVH4-gheH_77HgAA__-rHNsg
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJysk9uLm1AQxt_7VwzzpM2UjZdAORA42calQjZuVXqhhGA801Swao8GtoT870Ut7BqStCn7EpjLN993fsE91j9zFOh9fljM_CUYcz-Kow8Lgo9eeBtEngmRt_DexfAa7sLgHoxhmWxSxeAvYy-M2vZssYATGyZ8eu-FHhgpTMEyYbacg6FgCmxCEM69EG6_wIYgJVAETJAgYVEqXiY_uEbxFS1cEVa6TLmuS9229t2Crx5RjAmzoto1bXtFmJaaUeyxyZqcUWCcbHIOOVGsb8ZIqLhJsrw726WT3e96s07Xas3rTD0iYVQlRS3gDa4OhOWueTpfN8mWUVgH-vcId1nesGZ9Yw39-74AQzotGSGEv4zf_gEkXZiCnJhnI9jXRHhOwX4xCs5_UXBekoJ7NsKT864otWLNamC8apV_WznxjnvWW464Caobd_iS-FfFYvg9IGHO3xpD2iOSzoikOyJpjUhORuZUZ9vvp0dIGOwaAdIiaZN0SLokJ2chTK75H0Kuq7Ko-RjGycvjlgCrLfdE63KnU37QZdrZ9GXQ6bqG4rrpp1Zf-EU_agM-F1sXxe5AbB-L7Yti57Kzc4WzdSx2L4onR86rw6vfAQAA___SNa8C
 
 # Regression test for #64181. Ensure that a projection on top of an ordered
 # UNION ALL correctly projects away ordering columns.

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q17
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q17
@@ -126,7 +126,7 @@ project
  │    │    │    │    │    │    │    │    │    │                 <--- 'JUMBO BAG' ------------ 'WRAP PKG'
  │    │    │    │    │    │    │    │    │    ├── key: (18)
  │    │    │    │    │    │    │    │    │    ├── fd: (18)-->(21,24)
- │    │    │    │    │    │    │    │    │    └── ordering: +18 opt(21,24) [actual: +18]
+ │    │    │    │    │    │    │    │    │    └── ordering: +18
  │    │    │    │    │    │    │    │    └── filters
  │    │    │    │    │    │    │    │         ├── p_brand:21 = 'Brand#23' [type=bool, outer=(21), constraints=(/21: [/'Brand#23' - /'Brand#23']; tight), fd=()-->(21)]
  │    │    │    │    │    │    │    │         └── p_container:24 = 'MED BOX' [type=bool, outer=(24), constraints=(/24: [/'MED BOX' - /'MED BOX']; tight), fd=()-->(24)]

--- a/pkg/sql/opt/norm/testdata/rules/combo
+++ b/pkg/sql/opt/norm/testdata/rules/combo
@@ -364,7 +364,7 @@ GenerateMergeJoins
          │    │    ├── key: (1)
   -      │    │    └── fd: (1)-->(2,4)
   +      │    │    ├── fd: (1)-->(2,4)
-  +      │    │    └── ordering: +1 opt(2) [actual: +1]
+  +      │    │    └── ordering: +1
          │    └── filters
          │         └── i:2 = 9 [outer=(2), constraints=(/2: [/9 - /9]; tight), fd=()-->(2)]
   -      └── filters
@@ -398,7 +398,7 @@ GenerateLookupJoins
          │    │    ├── columns: k:1!null i:2 s:4
          │    │    ├── key: (1)
   -      │    │    ├── fd: (1)-->(2,4)
-  -      │    │    └── ordering: +1 opt(2) [actual: +1]
+  -      │    │    └── ordering: +1
   +      │    │    └── fd: (1)-->(2,4)
          │    └── filters
          │         └── i:2 = 9 [outer=(2), constraints=(/2: [/9 - /9]; tight), fd=()-->(2)]
@@ -431,7 +431,7 @@ GenerateMergeJoins (higher cost)
          │    │    ├── key: (1)
   -      │    │    └── fd: (1)-->(2,4)
   +      │    │    ├── fd: (1)-->(2,4)
-  +      │    │    └── ordering: +1 opt(2) [actual: +1]
+  +      │    │    └── ordering: +1
          │    └── filters
          │         └── i:2 = 9 [outer=(2), constraints=(/2: [/9 - /9]; tight), fd=()-->(2)]
   +      ├── scan xy
@@ -470,7 +470,7 @@ GenerateMergeJoins (higher cost)
          │    │    ├── key: (1)
   -      │    │    └── fd: (1)-->(2,4)
   +      │    │    ├── fd: (1)-->(2,4)
-  +      │    │    └── ordering: +1 opt(2) [actual: +1]
+  +      │    │    └── ordering: +1
          │    └── filters
          │         └── i:2 = 9 [outer=(2), constraints=(/2: [/9 - /9]; tight), fd=()-->(2)]
          └── filters (true)
@@ -501,7 +501,7 @@ GenerateLookupJoinsWithFilter (higher cost)
   -      │    │    ├── columns: k:1!null i:2 s:4
   -      │    │    ├── key: (1)
   -      │    │    ├── fd: (1)-->(2,4)
-  -      │    │    └── ordering: +1 opt(2) [actual: +1]
+  -      │    │    └── ordering: +1
   -      │    └── filters
   -      │         └── i:2 = 9 [outer=(2), constraints=(/2: [/9 - /9]; tight), fd=()-->(2)]
   -      └── filters (true)

--- a/pkg/sql/opt/optbuilder/testdata/orderby
+++ b/pkg/sql/opt/optbuilder/testdata/orderby
@@ -267,7 +267,7 @@ project
       ├── ordering: +1 opt(2)
       ├── scan t
       │    ├── columns: a:1!null b:2 c:3 crdb_internal_mvcc_timestamp:4
-      │    └── ordering: +1 opt(2)
+      │    └── ordering: +1
       └── filters
            └── b:2 = 7
 
@@ -779,7 +779,7 @@ project
            ├── ordering: +2,+3 opt(1)
            ├── scan abc
            │    ├── columns: a:1!null b:2!null c:3!null d:4 crdb_internal_mvcc_timestamp:5
-           │    └── ordering: +2,+3 opt(1)
+           │    └── ordering: +1,+2,+3
            └── filters
                 └── a:1 = 1
 

--- a/pkg/sql/opt/ordering/BUILD.bazel
+++ b/pkg/sql/opt/ordering/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "doc.go",
         "group_by.go",
+        "interesting_orderings.go",
         "inverted_join.go",
         "limit.go",
         "lookup_join.go",
@@ -23,6 +24,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/sql/opt",
+        "//pkg/sql/opt/cat",
         "//pkg/sql/opt/memo",
         "//pkg/sql/opt/props",
         "//pkg/sql/sem/tree",

--- a/pkg/sql/opt/ordering/interesting_orderings.go
+++ b/pkg/sql/opt/ordering/interesting_orderings.go
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package xform
+package ordering
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"

--- a/pkg/sql/opt/ordering/select.go
+++ b/pkg/sql/opt/ordering/select.go
@@ -27,7 +27,37 @@ func selectBuildChildReqOrdering(
 	if childIdx != 0 {
 		return props.OrderingChoice{}
 	}
-	return trimColumnGroups(required, &parent.(*memo.SelectExpr).Input.Relational().FuncDeps)
+	child := parent.(*memo.SelectExpr).Input
+
+	// Use interesting orderings from the child to "guide" the required ordering
+	// that gets passed down and make it more likely that the child will be able
+	// to provide the ordering. This step is needed before the call to
+	// trimColumnGroups, since that function will arbitrarily remove columns from
+	// each group to ensure all columns in the group are equivalent according to
+	// the child FDs.
+	//
+	// For example, suppose the required ordering is +(1|2),+3, and the child has
+	// an interesting ordering of +1,+2,+3. +1,+2,+3 implies +(1|2),+3, so the
+	// child can provide the ordering. However, trimColumnGroups will convert
+	// +(1|2),+3 to +1,+3, which the child cannot provide. We should instead pass
+	// down +1,+2,+3 as the required ordering to avoid an unnecessary sort.
+	//
+	// See #33023 for more details.
+	orders := DeriveInterestingOrderings(child)
+	for i := range orders {
+		if orders[i].Implies(required) {
+			// Get the common prefix of this ordering and the required ordering to
+			// make sure the child required ordering is no stronger than needed. Since
+			// we know that orders[i] implies required, the result of CommonPrefix
+			// will also imply required. For example, if orders[i] is +1,+2 and
+			// required is +1, we should only pass down +1 as the child required
+			// ordering.
+			order := orders[i].CommonPrefix(required)
+			required = &order
+			break
+		}
+	}
+	return trimColumnGroups(required, &child.Relational().FuncDeps)
 }
 
 // trimColumnGroups removes columns from ColumnOrderingChoice groups as

--- a/pkg/sql/opt/props/ordering_choice_test.go
+++ b/pkg/sql/opt/props/ordering_choice_test.go
@@ -93,6 +93,7 @@ func TestOrderingChoice_Implies(t *testing.T) {
 		{left: "+(1|2)", right: "+(1|2|3)", expected: true},
 		{left: "+(1|2),-4", right: "+(1|2|3),-(4|5)", expected: true},
 		{left: "+(1|2) opt(4)", right: "+(1|2|3) opt(4)", expected: true},
+		{left: "+1,+2,+3", right: "+(1|2),+3", expected: true},
 
 		{left: "", right: "+1", expected: false},
 		{left: "+1", right: "-1", expected: false},
@@ -148,6 +149,7 @@ func TestOrderingChoice_Intersection(t *testing.T) {
 		{left: "+1,+4,+5", right: "+4,+5 opt(1)", expected: "+1,+4,+5"},
 		{left: "+(1|2),+(3|4)", right: "+(2|3),+(4|5)", expected: "+2,+4"},
 		{left: "+(1|2|3),+(4|5)", right: "+(2|3),+(4|5|6)", expected: "+(2|3),+(4|5)"},
+		{left: "+(1|2),+3,+4", right: "+1,+2,+(3|4)", expected: "+1,+2,+3,+4"},
 
 		{left: "+1", right: "+2", expected: "NO"},
 		{left: "+1", right: "+2 opt(2)", expected: "NO"},
@@ -170,7 +172,7 @@ func TestOrderingChoice_Intersection(t *testing.T) {
 		{
 			left:           "+(1|2),+(3|4) opt(6)",
 			right:          "+(2|3),+(5|6) opt(4)",
-			expected:       "+2,+4,+(5|6)",
+			expected:       "+2,+(3|4),+(5|6)",
 			nonCommutative: true,
 		},
 		{
@@ -270,13 +272,13 @@ func TestOrderingChoice_CommonPrefix(t *testing.T) {
 		{
 			left:           "+(1|2),+(3|4) opt(6)",
 			right:          "+(2|3),+(5|6) opt(4)",
-			expected:       "+2,+4,+6",
+			expected:       "+2,+(3|4),+6",
 			nonCommutative: true,
 		},
 		{
 			left:           "+(2|3),+(5|6) opt(4)",
 			right:          "+(1|2),+(3|4) opt(6)",
-			expected:       "+2,+6,+4",
+			expected:       "+2,+6,+(3|4)",
 			nonCommutative: true,
 		},
 		{
@@ -289,6 +291,18 @@ func TestOrderingChoice_CommonPrefix(t *testing.T) {
 			left:           "-7 opt(2,3,5,6)",
 			right:          "+(1|2|3),-(4|5|6) opt(7)",
 			expected:       "-7,+(2|3),-(5|6)",
+			nonCommutative: true,
+		},
+		{
+			left:           "+1 opt(2)",
+			right:          "+1,+2",
+			expected:       "+1,+2",
+			nonCommutative: true,
+		},
+		{
+			left:           "+1,+2",
+			right:          "+1 opt(2)",
+			expected:       "+1",
 			nonCommutative: true,
 		},
 	}

--- a/pkg/sql/opt/testutils/opttester/BUILD.bazel
+++ b/pkg/sql/opt/testutils/opttester/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//pkg/sql/opt/norm",
         "//pkg/sql/opt/optbuilder",
         "//pkg/sql/opt/optgen/exprgen",
+        "//pkg/sql/opt/ordering",
         "//pkg/sql/opt/props/physical",
         "//pkg/sql/opt/testutils/testcat",
         "//pkg/sql/opt/xform",

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -44,6 +44,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/norm"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/optbuilder"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/optgen/exprgen"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/ordering"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/testcat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/xform"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
@@ -751,7 +752,7 @@ func fillInLazyProps(e opt.Expr) {
 		norm.DeriveRejectNullCols(rel)
 
 		// Make sure the interesting orderings are calculated.
-		xform.DeriveInterestingOrderings(rel)
+		ordering.DeriveInterestingOrderings(rel)
 	}
 
 	for i, n := 0, e.ChildCount(); i < n; i++ {

--- a/pkg/sql/opt/xform/BUILD.bazel
+++ b/pkg/sql/opt/xform/BUILD.bazel
@@ -8,7 +8,6 @@ go_library(
         "general_funcs.go",
         "groupby_funcs.go",
         "index_scan_builder.go",
-        "interesting_orderings.go",
         "join_funcs.go",
         "join_order_builder.go",
         "limit_funcs.go",

--- a/pkg/sql/opt/xform/groupby_funcs.go
+++ b/pkg/sql/opt/xform/groupby_funcs.go
@@ -13,6 +13,7 @@ package xform
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/ordering"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/errors"
 )
@@ -65,7 +66,7 @@ func (c *CustomFuncs) GenerateStreamingGroupBy(
 	aggs memo.AggregationsExpr,
 	private *memo.GroupingPrivate,
 ) {
-	orders := DeriveInterestingOrderings(input)
+	orders := ordering.DeriveInterestingOrderings(input)
 	intraOrd := private.Ordering
 	for _, ord := range orders {
 		o := ord.ToOrdering()

--- a/pkg/sql/opt/xform/join_funcs.go
+++ b/pkg/sql/opt/xform/join_funcs.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/invertedidx"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/ordering"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -50,7 +51,7 @@ func (c *CustomFuncs) GenerateMergeJoins(
 	// We generate MergeJoin expressions based on interesting orderings from the
 	// left side. The CommuteJoin rule will ensure that we actually try both
 	// sides.
-	orders := DeriveInterestingOrderings(left).Copy()
+	orders := ordering.DeriveInterestingOrderings(left).Copy()
 	leftCols, leftFDs := leftEq.ToSet(), &left.Relational().FuncDeps
 	orders.RestrictToCols(leftCols, leftFDs)
 
@@ -64,7 +65,7 @@ func (c *CustomFuncs) GenerateMergeJoins(
 	if !c.NoJoinHints(joinPrivate) || c.e.evalCtx.SessionData.ReorderJoinsLimit == 0 {
 		// If we are using a hint, or the join limit is set to zero, the join won't
 		// be commuted. Add the orderings from the right side.
-		rightOrders := DeriveInterestingOrderings(right).Copy()
+		rightOrders := ordering.DeriveInterestingOrderings(right).Copy()
 		rightOrders.RestrictToCols(rightEq.ToSet(), &right.Relational().FuncDeps)
 		orders = append(orders, rightOrders...)
 

--- a/pkg/sql/opt/xform/optimizer.go
+++ b/pkg/sql/opt/xform/optimizer.go
@@ -605,7 +605,7 @@ func deriveInterestingOrderingPrefix(
 	member memo.RelExpr, requiredOrdering props.OrderingChoice,
 ) props.OrderingChoice {
 	// Find the interesting orderings of the member expression.
-	interestingOrderings := DeriveInterestingOrderings(member)
+	interestingOrderings := ordering.DeriveInterestingOrderings(member)
 
 	// Find the longest interesting ordering that is a prefix of the required ordering.
 	var longestCommonPrefix props.OrderingChoice

--- a/pkg/sql/opt/xform/testdata/external/customer
+++ b/pkg/sql/opt/xform/testdata/external/customer
@@ -110,7 +110,7 @@ project
            │    │    ├── constraint: /1: [/1 - ]
            │    │    ├── key: (1)
            │    │    ├── fd: (1)-->(2,3,9)
-           │    │    ├── ordering: +1 opt(9) [actual: +1]
+           │    │    ├── ordering: +1
            │    │    └── limit hint: 101.01
            │    └── filters
            │         └── NOT read:9 [outer=(9), constraints=(/9: [/false - /false]; tight), fd=()-->(9)]
@@ -153,7 +153,7 @@ project
            │    │    ├── flags: force-index=article_idx_read_key
            │    │    ├── key: (1)
            │    │    ├── fd: (1)-->(2,3,9)
-           │    │    ├── ordering: +1 opt(9) [actual: +1]
+           │    │    ├── ordering: +1
            │    │    └── limit hint: 101.01
            │    └── filters
            │         └── NOT read:9 [outer=(9), constraints=(/9: [/false - /false]; tight), fd=()-->(9)]
@@ -181,7 +181,7 @@ limit
  │    │    ├── constraint: /1: [/1 - ]
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(9)
- │    │    ├── ordering: +1 opt(9) [actual: +1]
+ │    │    ├── ordering: +1
  │    │    └── limit hint: 5.27
  │    └── filters
  │         └── NOT read:9 [outer=(9), constraints=(/9: [/false - /false]; tight), fd=()-->(9)]

--- a/pkg/sql/opt/xform/testdata/external/hibernate
+++ b/pkg/sql/opt/xform/testdata/external/hibernate
@@ -1405,7 +1405,7 @@ project
       │         ├── ordering: +8 opt(9) [actual: +8]
       │         ├── scan person_addresses [as=addresses1_]
       │         │    ├── columns: person_id:8!null addresses:9
-      │         │    └── ordering: +8 opt(9) [actual: +8]
+      │         │    └── ordering: +8
       │         └── filters
       │              └── addresses:9 = 'Home address' [outer=(9), constraints=(/9: [/'Home address' - /'Home address']; tight), fd=()-->(9)]
       └── filters (true)

--- a/pkg/sql/opt/xform/testdata/external/nova
+++ b/pkg/sql/opt/xform/testdata/external/nova
@@ -392,7 +392,7 @@ sort
            │    │    │         │    │    │    │    ├── has-placeholder
            │    │    │         │    │    │    │    ├── key: (1)
            │    │    │         │    │    │    │    ├── fd: ()-->(11), (1)-->(2-12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
-           │    │    │         │    │    │    │    ├── ordering: +1 opt(11) [actual: +1]
+           │    │    │         │    │    │    │    ├── ordering: +1
            │    │    │         │    │    │    │    ├── left-join (merge)
            │    │    │         │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:18 true:31
            │    │    │         │    │    │    │    │    ├── left ordering: +1
@@ -410,7 +410,7 @@ sort
            │    │    │         │    │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
            │    │    │         │    │    │    │    │    │    │    ├── key: (1)
            │    │    │         │    │    │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-           │    │    │         │    │    │    │    │    │    │    └── ordering: +1 opt(11) [actual: +1]
+           │    │    │         │    │    │    │    │    │    │    └── ordering: +1
            │    │    │         │    │    │    │    │    │    └── filters
            │    │    │         │    │    │    │    │    │         └── disabled:11 = false [outer=(11), constraints=(/11: [/false - /false]; tight), fd=()-->(11)]
            │    │    │         │    │    │    │    │    ├── project
@@ -428,7 +428,7 @@ sort
            │    │    │         │    │    │    │    │    │    │    ├── scan flavor_projects@secondary
            │    │    │         │    │    │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:18!null project_id:19!null
            │    │    │         │    │    │    │    │    │    │    │    ├── key: (18,19)
-           │    │    │         │    │    │    │    │    │    │    │    └── ordering: +18 opt(19) [actual: +18]
+           │    │    │         │    │    │    │    │    │    │    │    └── ordering: +18
            │    │    │         │    │    │    │    │    │    │    └── filters
            │    │    │         │    │    │    │    │    │    │         └── project_id:19 = $1 [outer=(19), constraints=(/19: (/NULL - ]), fd=()-->(19)]
            │    │    │         │    │    │    │    │    │    └── projections
@@ -480,7 +480,7 @@ sort
            │    │    │         │    │    │    │    ├── scan flavor_projects@secondary
            │    │    │         │    │    │    │    │    ├── columns: flavor_projects.flavor_id:25!null project_id:26!null
            │    │    │         │    │    │    │    │    ├── key: (25,26)
-           │    │    │         │    │    │    │    │    └── ordering: +25 opt(26) [actual: +25]
+           │    │    │         │    │    │    │    │    └── ordering: +25
            │    │    │         │    │    │    │    └── filters
            │    │    │         │    │    │    │         └── project_id:26 = $2 [outer=(26), constraints=(/26: (/NULL - ]), fd=()-->(26)]
            │    │    │         │    │    │    └── projections
@@ -658,7 +658,7 @@ sort
            │    │    │         │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13 instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
            │    │    │         │    │    │    │    ├── key: (1)
            │    │    │         │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    │         │    │    │    │    └── ordering: +1 opt(13) [actual: +1]
+           │    │    │         │    │    │    │    └── ordering: +1
            │    │    │         │    │    │    └── filters
            │    │    │         │    │    │         └── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ]), fd=()-->(13)]
            │    │    │         │    │    ├── project
@@ -676,7 +676,7 @@ sort
            │    │    │         │    │    │    │    ├── scan instance_type_projects@secondary
            │    │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:19!null project_id:20 instance_type_projects.deleted:21
            │    │    │         │    │    │    │    │    ├── lax-key: (19-21)
-           │    │    │         │    │    │    │    │    └── ordering: +19 opt(20,21) [actual: +19]
+           │    │    │         │    │    │    │    │    └── ordering: +19
            │    │    │         │    │    │    │    └── filters
            │    │    │         │    │    │    │         ├── instance_type_projects.deleted:21 = $2 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
            │    │    │         │    │    │    │         ├── instance_type_projects.deleted:21 = $3 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
@@ -819,7 +819,7 @@ sort
            │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13 instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
            │    │    │    │    │    ├── key: (1)
            │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    │    │    │    └── ordering: +1 opt(13) [actual: +1]
+           │    │    │    │    │    └── ordering: +1
            │    │    │    │    └── filters
            │    │    │    │         └── instance_types.deleted:13 = $2 [outer=(13), constraints=(/13: (/NULL - ]), fd=()-->(13)]
            │    │    │    ├── project
@@ -837,7 +837,7 @@ sort
            │    │    │    │    │    ├── scan instance_type_projects@secondary
            │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:28!null project_id:29 instance_type_projects.deleted:30
            │    │    │    │    │    │    ├── lax-key: (28-30)
-           │    │    │    │    │    │    └── ordering: +28 opt(29,30) [actual: +28]
+           │    │    │    │    │    │    └── ordering: +28
            │    │    │    │    │    └── filters
            │    │    │    │    │         ├── instance_type_projects.deleted:30 = $3 [outer=(30), constraints=(/30: (/NULL - ]), fd=()-->(30)]
            │    │    │    │    │         └── project_id:29 = $4 [outer=(29), constraints=(/29: (/NULL - ]), fd=()-->(29)]
@@ -1689,7 +1689,7 @@ sort
            │    │    │         │    │    │    │    ├── scan flavor_projects@secondary
            │    │    │         │    │    │    │    │    ├── columns: flavor_projects.flavor_id:18!null project_id:19!null
            │    │    │         │    │    │    │    │    ├── key: (18,19)
-           │    │    │         │    │    │    │    │    └── ordering: +18 opt(19) [actual: +18]
+           │    │    │         │    │    │    │    │    └── ordering: +18
            │    │    │         │    │    │    │    └── filters
            │    │    │         │    │    │    │         └── project_id:19 = $1 [outer=(19), constraints=(/19: (/NULL - ]), fd=()-->(19)]
            │    │    │         │    │    │    └── projections
@@ -1866,7 +1866,7 @@ sort
            │    │    │         │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13 instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
            │    │    │         │    │    │    │    ├── key: (1)
            │    │    │         │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    │         │    │    │    │    └── ordering: +1 opt(13) [actual: +1]
+           │    │    │         │    │    │    │    └── ordering: +1
            │    │    │         │    │    │    └── filters
            │    │    │         │    │    │         └── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ]), fd=()-->(13)]
            │    │    │         │    │    ├── project
@@ -1884,7 +1884,7 @@ sort
            │    │    │         │    │    │    │    ├── scan instance_type_projects@secondary
            │    │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:19!null project_id:20 instance_type_projects.deleted:21
            │    │    │         │    │    │    │    │    ├── lax-key: (19-21)
-           │    │    │         │    │    │    │    │    └── ordering: +19 opt(20,21) [actual: +19]
+           │    │    │         │    │    │    │    │    └── ordering: +19
            │    │    │         │    │    │    │    └── filters
            │    │    │         │    │    │    │         ├── instance_type_projects.deleted:21 = $2 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
            │    │    │         │    │    │    │         └── project_id:20 = $3 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
@@ -2202,7 +2202,7 @@ sort
            │    │    │    │    │    ├── scan flavor_projects@secondary
            │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:25!null project_id:26!null
            │    │    │    │    │    │    ├── key: (25,26)
-           │    │    │    │    │    │    └── ordering: +25 opt(26) [actual: +25]
+           │    │    │    │    │    │    └── ordering: +25
            │    │    │    │    │    └── filters
            │    │    │    │    │         └── project_id:26 = $1 [outer=(26), constraints=(/26: (/NULL - ]), fd=()-->(26)]
            │    │    │    │    └── projections
@@ -2380,7 +2380,7 @@ sort
            │    │    │         │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13 instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
            │    │    │         │    │    │    │    ├── key: (1)
            │    │    │         │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    │         │    │    │    │    └── ordering: +1 opt(13) [actual: +1]
+           │    │    │         │    │    │    │    └── ordering: +1
            │    │    │         │    │    │    └── filters
            │    │    │         │    │    │         ├── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ]), fd=()-->(13)]
            │    │    │         │    │    │         └── (flavorid:7 > $4) OR ((flavorid:7 = $5) AND (instance_types.id:1 > $6)) [outer=(1,7), constraints=(/7: (/NULL - ])]
@@ -2399,7 +2399,7 @@ sort
            │    │    │         │    │    │    │    ├── scan instance_type_projects@secondary
            │    │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:19!null project_id:20 instance_type_projects.deleted:21
            │    │    │         │    │    │    │    │    ├── lax-key: (19-21)
-           │    │    │         │    │    │    │    │    └── ordering: +19 opt(20,21) [actual: +19]
+           │    │    │         │    │    │    │    │    └── ordering: +19
            │    │    │         │    │    │    │    └── filters
            │    │    │         │    │    │    │         ├── instance_type_projects.deleted:21 = $2 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
            │    │    │         │    │    │    │         └── project_id:20 = $3 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
@@ -2574,7 +2574,7 @@ sort
            │    │    │         │    │    │    │    ├── scan flavor_projects@secondary
            │    │    │         │    │    │    │    │    ├── columns: flavor_projects.flavor_id:18!null project_id:19!null
            │    │    │         │    │    │    │    │    ├── key: (18,19)
-           │    │    │         │    │    │    │    │    └── ordering: +18 opt(19) [actual: +18]
+           │    │    │         │    │    │    │    │    └── ordering: +18
            │    │    │         │    │    │    │    └── filters
            │    │    │         │    │    │    │         └── project_id:19 = $1 [outer=(19), constraints=(/19: (/NULL - ]), fd=()-->(19)]
            │    │    │         │    │    │    └── projections
@@ -2756,7 +2756,7 @@ project
       │    │    │    │         │    │    │    │    ├── has-placeholder
       │    │    │    │         │    │    │    │    ├── key: (1)
       │    │    │    │         │    │    │    │    ├── fd: ()-->(11,13), (1)-->(2-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
-      │    │    │    │         │    │    │    │    ├── ordering: +1 opt(11,13) [actual: +1]
+      │    │    │    │         │    │    │    │    ├── ordering: +1
       │    │    │    │         │    │    │    │    ├── left-join (merge)
       │    │    │    │         │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:19 true:36
       │    │    │    │         │    │    │    │    │    ├── left ordering: +1
@@ -2775,7 +2775,7 @@ project
       │    │    │    │         │    │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13 instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
       │    │    │    │         │    │    │    │    │    │    │    ├── key: (1)
       │    │    │    │         │    │    │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │    │    │    │         │    │    │    │    │    │    │    └── ordering: +1 opt(11,13) [actual: +1]
+      │    │    │    │         │    │    │    │    │    │    │    └── ordering: +1
       │    │    │    │         │    │    │    │    │    │    └── filters
       │    │    │    │         │    │    │    │    │    │         ├── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ]), fd=()-->(13)]
       │    │    │    │         │    │    │    │    │    │         └── disabled:11 = false [outer=(11), constraints=(/11: [/false - /false]; tight), fd=()-->(11)]
@@ -2794,7 +2794,7 @@ project
       │    │    │    │         │    │    │    │    │    │    │    ├── scan instance_type_projects@secondary
       │    │    │    │         │    │    │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:19!null project_id:20 instance_type_projects.deleted:21
       │    │    │    │         │    │    │    │    │    │    │    │    ├── lax-key: (19-21)
-      │    │    │    │         │    │    │    │    │    │    │    │    └── ordering: +19 opt(20,21) [actual: +19]
+      │    │    │    │         │    │    │    │    │    │    │    │    └── ordering: +19
       │    │    │    │         │    │    │    │    │    │    │    └── filters
       │    │    │    │         │    │    │    │    │    │    │         ├── instance_type_projects.deleted:21 = $2 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
       │    │    │    │         │    │    │    │    │    │    │         └── project_id:20 = $3 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
@@ -2851,7 +2851,7 @@ project
       │    │    │    │         │    │    │    │    ├── scan instance_type_projects@secondary
       │    │    │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:28!null project_id:29 instance_type_projects.deleted:30
       │    │    │    │         │    │    │    │    │    ├── lax-key: (28-30)
-      │    │    │    │         │    │    │    │    │    └── ordering: +28 opt(29,30) [actual: +28]
+      │    │    │    │         │    │    │    │    │    └── ordering: +28
       │    │    │    │         │    │    │    │    └── filters
       │    │    │    │         │    │    │    │         ├── instance_type_projects.deleted:30 = $4 [outer=(30), constraints=(/30: (/NULL - ]), fd=()-->(30)]
       │    │    │    │         │    │    │    │         ├── instance_type_projects.deleted:30 = $5 [outer=(30), constraints=(/30: (/NULL - ]), fd=()-->(30)]
@@ -3363,7 +3363,7 @@ sort
            │    │         │    │    │    │    ├── scan flavor_projects@secondary
            │    │         │    │    │    │    │    ├── columns: flavor_projects.flavor_id:18!null project_id:19!null
            │    │         │    │    │    │    │    ├── key: (18,19)
-           │    │         │    │    │    │    │    └── ordering: +18 opt(19) [actual: +18]
+           │    │         │    │    │    │    │    └── ordering: +18
            │    │         │    │    │    │    └── filters
            │    │         │    │    │    │         └── project_id:19 = $1 [outer=(19), constraints=(/19: (/NULL - ]), fd=()-->(19)]
            │    │         │    │    │    └── projections

--- a/pkg/sql/opt/xform/testdata/external/pgjdbc
+++ b/pkg/sql/opt/xform/testdata/external/pgjdbc
@@ -220,7 +220,7 @@ sort
       │    │    │    │    │    │    │    │    │    ├── ordering: +43 opt(59) [actual: +43]
       │    │    │    │    │    │    │    │    │    ├── scan pg_attribute@secondary [as=a]
       │    │    │    │    │    │    │    │    │    │    ├── columns: attrelid:43!null attname:44 atttypid:45 attlen:47 attnum:48 atttypmod:51 a.attnotnull:55 attisdropped:59
-      │    │    │    │    │    │    │    │    │    │    └── ordering: +43 opt(59) [actual: +43]
+      │    │    │    │    │    │    │    │    │    │    └── ordering: +43
       │    │    │    │    │    │    │    │    │    └── filters
       │    │    │    │    │    │    │    │    │         ├── attnum:48 > 0 [outer=(48), constraints=(/48: [/1 - ]; tight)]
       │    │    │    │    │    │    │    │    │         └── NOT attisdropped:59 [outer=(59), constraints=(/59: [/false - /false]; tight), fd=()-->(59)]

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -1395,7 +1395,7 @@ scalar-group-by
  │    │    │         │    ├── columns: o_id:1!null o_d_id:2!null o_w_id:3!null o_carrier_id:6
  │    │    │         │    ├── key: (1-3)
  │    │    │         │    ├── fd: (1-3)-->(6)
- │    │    │         │    └── ordering: +3,+2,-1 opt(6) [actual: +3,+2,-1]
+ │    │    │         │    └── ordering: +3,+2,-1
  │    │    │         └── filters
  │    │    │              └── o_carrier_id:6 IS NULL [outer=(6), constraints=(/6: [/NULL - /NULL]; tight), fd=()-->(6)]
  │    │    ├── project
@@ -1407,7 +1407,7 @@ scalar-group-by
  │    │    │         ├── ordering: +12,+11,-10 opt(16) [actual: +12,+11,-10]
  │    │    │         ├── scan order_line
  │    │    │         │    ├── columns: ol_o_id:10!null ol_d_id:11!null ol_w_id:12!null ol_delivery_d:16
- │    │    │         │    └── ordering: +12,+11,-10 opt(16) [actual: +12,+11,-10]
+ │    │    │         │    └── ordering: +12,+11,-10
  │    │    │         └── filters
  │    │    │              └── ol_delivery_d:16 IS NULL [outer=(16), constraints=(/16: [/NULL - /NULL]; tight), fd=()-->(16)]
  │    │    └── filters (true)

--- a/pkg/sql/opt/xform/testdata/external/tpce
+++ b/pkg/sql/opt/xform/testdata/external/tpce
@@ -253,7 +253,7 @@ limit
  │         │    │    │    │    │    │    │    └── ca_tax_st:5 IN (0, 1, 2) [outer=(5), constraints=(/5: [/0 - /0] [/1 - /1] [/2 - /2]; tight)]
  │         │    │    │    │    │    │    ├── key: (1)
  │         │    │    │    │    │    │    ├── fd: (1)-->(3,6)
- │         │    │    │    │    │    │    └── ordering: +1 opt(3) [actual: +1]
+ │         │    │    │    │    │    │    └── ordering: +1
  │         │    │    │    │    │    └── filters
  │         │    │    │    │    │         └── ca_c_id:3 = 0 [outer=(3), constraints=(/3: [/0 - /0]; tight), fd=()-->(3)]
  │         │    │    │    │    └── filters (true)

--- a/pkg/sql/opt/xform/testdata/external/tpce-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpce-no-stats
@@ -242,7 +242,7 @@ limit
  │         │    │    │    │    │    │    │    └── ca_tax_st:5 IN (0, 1, 2) [outer=(5), constraints=(/5: [/0 - /0] [/1 - /1] [/2 - /2]; tight)]
  │         │    │    │    │    │    │    ├── key: (1)
  │         │    │    │    │    │    │    ├── fd: (1)-->(3,6)
- │         │    │    │    │    │    │    └── ordering: +1 opt(3) [actual: +1]
+ │         │    │    │    │    │    │    └── ordering: +1
  │         │    │    │    │    │    └── filters
  │         │    │    │    │    │         └── ca_c_id:3 = 0 [outer=(3), constraints=(/3: [/0 - /0]; tight), fd=()-->(3)]
  │         │    │    │    │    └── filters (true)

--- a/pkg/sql/opt/xform/testdata/external/tpch
+++ b/pkg/sql/opt/xform/testdata/external/tpch
@@ -1865,7 +1865,7 @@ project
  │    │    │    │    │    │    │    │    │    ├── columns: p_partkey:18!null p_brand:21!null p_container:24!null
  │    │    │    │    │    │    │    │    │    ├── key: (18)
  │    │    │    │    │    │    │    │    │    ├── fd: (18)-->(21,24)
- │    │    │    │    │    │    │    │    │    └── ordering: +18 opt(21,24) [actual: +18]
+ │    │    │    │    │    │    │    │    │    └── ordering: +18
  │    │    │    │    │    │    │    │    └── filters
  │    │    │    │    │    │    │    │         ├── p_brand:21 = 'Brand#23' [outer=(21), constraints=(/21: [/'Brand#23' - /'Brand#23']; tight), fd=()-->(21)]
  │    │    │    │    │    │    │    │         └── p_container:24 = 'MED BOX' [outer=(24), constraints=(/24: [/'MED BOX' - /'MED BOX']; tight), fd=()-->(24)]

--- a/pkg/sql/opt/xform/testdata/external/tpch-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpch-no-stats
@@ -1807,7 +1807,7 @@ project
  │    │    │    │    │    │    │    │    │    ├── columns: p_partkey:18!null p_brand:21!null p_container:24!null
  │    │    │    │    │    │    │    │    │    ├── key: (18)
  │    │    │    │    │    │    │    │    │    ├── fd: (18)-->(21,24)
- │    │    │    │    │    │    │    │    │    └── ordering: +18 opt(21,24) [actual: +18]
+ │    │    │    │    │    │    │    │    │    └── ordering: +18
  │    │    │    │    │    │    │    │    └── filters
  │    │    │    │    │    │    │    │         ├── p_brand:21 = 'Brand#23' [outer=(21), constraints=(/21: [/'Brand#23' - /'Brand#23']; tight), fd=()-->(21)]
  │    │    │    │    │    │    │    │         └── p_container:24 = 'MED BOX' [outer=(24), constraints=(/24: [/'MED BOX' - /'MED BOX']; tight), fd=()-->(24)]

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -1492,34 +1492,28 @@ union
  ├── key: (10,11)
  ├── fd: (9)==(10), (10)==(9)
  ├── ordering: +(9|10) [actual: +9]
- ├── sort
+ ├── select
  │    ├── columns: abc.a:1!null abc.b:2!null abc.c:3!null
  │    ├── key: (2,3)
  │    ├── fd: (1)==(2), (2)==(1)
  │    ├── ordering: +(1|2),+3 [actual: +1,+3]
- │    └── select
- │         ├── columns: abc.a:1!null abc.b:2!null abc.c:3!null
- │         ├── key: (2,3)
- │         ├── fd: (1)==(2), (2)==(1)
- │         ├── scan abc
- │         │    ├── columns: abc.a:1!null abc.b:2!null abc.c:3!null
- │         │    └── key: (1-3)
- │         └── filters
- │              └── abc.a:1 = abc.b:2 [outer=(1,2), fd=(1)==(2), (2)==(1)]
- └── sort
+ │    ├── scan abc
+ │    │    ├── columns: abc.a:1!null abc.b:2!null abc.c:3!null
+ │    │    ├── key: (1-3)
+ │    │    └── ordering: +1,+2,+3
+ │    └── filters
+ │         └── abc.a:1 = abc.b:2 [outer=(1,2), fd=(1)==(2), (2)==(1)]
+ └── select
       ├── columns: x:5!null y:6!null z:7!null
       ├── key: (6,7)
       ├── fd: (5)==(6), (6)==(5)
       ├── ordering: +(5|6),+7 [actual: +5,+7]
-      └── select
-           ├── columns: x:5!null y:6!null z:7!null
-           ├── key: (6,7)
-           ├── fd: (5)==(6), (6)==(5)
-           ├── scan xyz
-           │    ├── columns: x:5!null y:6!null z:7!null
-           │    └── key: (5-7)
-           └── filters
-                └── y:6 = x:5 [outer=(5,6), fd=(5)==(6), (6)==(5)]
+      ├── scan xyz
+      │    ├── columns: x:5!null y:6!null z:7!null
+      │    ├── key: (5-7)
+      │    └── ordering: +5,+6,+7
+      └── filters
+           └── y:6 = x:5 [outer=(5,6), fd=(5)==(6), (6)==(5)]
 
 opt
 SELECT * FROM (SELECT a, b, c, d FROM abcd UNION ALL SELECT c, d, a, b FROM abcd) ORDER BY a, b
@@ -1561,33 +1555,34 @@ intersect
 opt
 SELECT * FROM (SELECT a, b, c FROM abc INTERSECT ALL SELECT y, x, z FROM xyz) WHERE a = b ORDER BY b
 ----
-sort
+intersect-all
  ├── columns: a:1!null b:2!null c:3!null
+ ├── left columns: a:1!null b:2!null c:3!null
+ ├── right columns: y:6 x:5 z:7
  ├── fd: (1)==(2), (2)==(1)
  ├── ordering: +(1|2) [actual: +1]
- └── intersect-all
-      ├── columns: a:1!null b:2!null c:3!null
-      ├── left columns: a:1!null b:2!null c:3!null
-      ├── right columns: y:6 x:5 z:7
-      ├── fd: (1)==(2), (2)==(1)
-      ├── select
-      │    ├── columns: a:1!null b:2!null c:3!null
-      │    ├── key: (2,3)
-      │    ├── fd: (1)==(2), (2)==(1)
-      │    ├── scan abc
-      │    │    ├── columns: a:1!null b:2!null c:3!null
-      │    │    └── key: (1-3)
-      │    └── filters
-      │         └── a:1 = b:2 [outer=(1,2), fd=(1)==(2), (2)==(1)]
-      └── select
-           ├── columns: x:5!null y:6!null z:7!null
-           ├── key: (6,7)
-           ├── fd: (5)==(6), (6)==(5)
-           ├── scan xyz
-           │    ├── columns: x:5!null y:6!null z:7!null
-           │    └── key: (5-7)
-           └── filters
-                └── y:6 = x:5 [outer=(5,6), fd=(5)==(6), (6)==(5)]
+ ├── select
+ │    ├── columns: a:1!null b:2!null c:3!null
+ │    ├── key: (2,3)
+ │    ├── fd: (1)==(2), (2)==(1)
+ │    ├── ordering: +(1|2),+3 [actual: +1,+3]
+ │    ├── scan abc
+ │    │    ├── columns: a:1!null b:2!null c:3!null
+ │    │    ├── key: (1-3)
+ │    │    └── ordering: +1,+2,+3
+ │    └── filters
+ │         └── a:1 = b:2 [outer=(1,2), fd=(1)==(2), (2)==(1)]
+ └── select
+      ├── columns: x:5!null y:6!null z:7!null
+      ├── key: (6,7)
+      ├── fd: (5)==(6), (6)==(5)
+      ├── ordering: +(5|6),+7 [actual: +5,+7]
+      ├── scan xyz
+      │    ├── columns: x:5!null y:6!null z:7!null
+      │    ├── key: (5-7)
+      │    └── ordering: +5,+6,+7
+      └── filters
+           └── y:6 = x:5 [outer=(5,6), fd=(5)==(6), (6)==(5)]
 
 opt
 SELECT * FROM (SELECT a, b, c FROM abc EXCEPT SELECT z, y, x FROM xyz) WHERE a = c ORDER BY a, b

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -1250,11 +1250,11 @@ memo (optimized, ~12KB, required=[presentation: array_agg:6])
  ├── G3: (projections)
  ├── G4: (select G6 G7) (select G8 G7) (select G9 G7)
  │    ├── [ordering: +(2|3) opt(4)]
- │    │    ├── best: (select G8="[ordering: +2 opt(4)]" G7)
+ │    │    ├── best: (select G8="[ordering: +2]" G7)
  │    │    └── cost: 1083.13
  │    ├── [ordering: +(2|3),+4]
- │    │    ├── best: (sort G4)
- │    │    └── cost: 1084.42
+ │    │    ├── best: (select G8="[ordering: +2,+3,+4]" G7)
+ │    │    └── cost: 1083.13
  │    ├── [ordering: +4,+(2|3)]
  │    │    ├── best: (sort G4)
  │    │    └── cost: 1084.42
@@ -1263,19 +1263,13 @@ memo (optimized, ~12KB, required=[presentation: array_agg:6])
  │         └── cost: 1083.13
  ├── G5: (aggregations G10)
  ├── G6: (scan kuvw,cols=(1-4)) (scan kuvw@uvw,cols=(1-4)) (scan kuvw@wvu,cols=(1-4)) (scan kuvw@vw,cols=(1-4)) (scan kuvw@w,cols=(1-4))
- │    ├── [ordering: +2 opt(4)]
+ │    ├── [ordering: +2,+3,+4]
  │    │    ├── best: (scan kuvw@uvw,cols=(1-4))
  │    │    └── cost: 1094.81
- │    ├── [ordering: +2,+4]
- │    │    ├── best: (sort G6="[ordering: +2]")
- │    │    └── cost: 1231.26
  │    ├── [ordering: +2]
  │    │    ├── best: (scan kuvw@uvw,cols=(1-4))
  │    │    └── cost: 1094.81
- │    ├── [ordering: +4,+2]
- │    │    ├── best: (sort G6="[ordering: +4]")
- │    │    └── cost: 1231.26
- │    ├── [ordering: +4]
+ │    ├── [ordering: +4,+3]
  │    │    ├── best: (scan kuvw@wvu,cols=(1-4))
  │    │    └── cost: 1094.81
  │    └── []
@@ -1283,12 +1277,9 @@ memo (optimized, ~12KB, required=[presentation: array_agg:6])
  │         └── cost: 1094.81
  ├── G7: (filters G11)
  ├── G8: (scan kuvw@uvw,cols=(1-4),constrained)
- │    ├── [ordering: +2 opt(4)]
+ │    ├── [ordering: +2,+3,+4]
  │    │    ├── best: (scan kuvw@uvw,cols=(1-4),constrained)
  │    │    └── cost: 1073.21
- │    ├── [ordering: +2,+4]
- │    │    ├── best: (sort G8="[ordering: +2]")
- │    │    └── cost: 1208.01
  │    ├── [ordering: +2]
  │    │    ├── best: (scan kuvw@uvw,cols=(1-4),constrained)
  │    │    └── cost: 1073.21
@@ -1299,12 +1290,12 @@ memo (optimized, ~12KB, required=[presentation: array_agg:6])
  │         ├── best: (scan kuvw@uvw,cols=(1-4),constrained)
  │         └── cost: 1073.21
  ├── G9: (scan kuvw@vw,cols=(1-4),constrained)
- │    ├── [ordering: +2 opt(4)]
- │    │    ├── best: (sort G9)
- │    │    └── cost: 1329.66
- │    ├── [ordering: +2,+4]
- │    │    ├── best: (sort G9)
- │    │    └── cost: 1340.50
+ │    ├── [ordering: +3,+4]
+ │    │    ├── best: (scan kuvw@vw,cols=(1-4),constrained)
+ │    │    └── cost: 1073.21
+ │    ├── [ordering: +3]
+ │    │    ├── best: (scan kuvw@vw,cols=(1-4),constrained)
+ │    │    └── cost: 1073.21
  │    ├── [ordering: +4,+2]
  │    │    ├── best: (sort G9)
  │    │    └── cost: 1340.50
@@ -1324,16 +1315,16 @@ memo (optimized, ~12KB, required=[presentation: sum:6])
  ├── G1: (project G2 G3 sum)
  │    └── [presentation: sum:6]
  │         ├── best: (project G2 G3 sum)
- │         └── cost: 1083.75
+ │         └── cost: 1083.65
  ├── G2: (group-by G4 G5 cols=(2,4)) (group-by G4 G5 cols=(2,4),ordering=+(2|3),+4) (group-by G4 G5 cols=(2,4),ordering=+4,+(2|3)) (group-by G4 G5 cols=(2,4),ordering=+4)
  │    └── []
- │         ├── best: (group-by G4 G5 cols=(2,4))
- │         └── cost: 1083.64
+ │         ├── best: (group-by G4="[ordering: +(2|3),+4]" G5 cols=(2,4),ordering=+(2|3),+4)
+ │         └── cost: 1083.54
  ├── G3: (projections)
  ├── G4: (select G6 G7) (select G8 G7) (select G9 G7)
  │    ├── [ordering: +(2|3),+4]
- │    │    ├── best: (sort G4)
- │    │    └── cost: 1084.42
+ │    │    ├── best: (select G8="[ordering: +2,+3,+4]" G7)
+ │    │    └── cost: 1083.13
  │    ├── [ordering: +4,+(2|3)]
  │    │    ├── best: (sort G4)
  │    │    └── cost: 1084.42
@@ -1345,15 +1336,12 @@ memo (optimized, ~12KB, required=[presentation: sum:6])
  │         └── cost: 1083.13
  ├── G5: (aggregations G10)
  ├── G6: (scan kuvw,cols=(1-4)) (scan kuvw@uvw,cols=(1-4)) (scan kuvw@wvu,cols=(1-4)) (scan kuvw@vw,cols=(1-4)) (scan kuvw@w,cols=(1-4))
- │    ├── [ordering: +2,+4]
- │    │    ├── best: (sort G6="[ordering: +2]")
- │    │    └── cost: 1231.26
- │    ├── [ordering: +2]
+ │    ├── [ordering: +2,+3,+4]
  │    │    ├── best: (scan kuvw@uvw,cols=(1-4))
  │    │    └── cost: 1094.81
- │    ├── [ordering: +4,+2]
- │    │    ├── best: (sort G6="[ordering: +4]")
- │    │    └── cost: 1231.26
+ │    ├── [ordering: +4,+3]
+ │    │    ├── best: (scan kuvw@wvu,cols=(1-4))
+ │    │    └── cost: 1094.81
  │    ├── [ordering: +4]
  │    │    ├── best: (scan kuvw@wvu,cols=(1-4))
  │    │    └── cost: 1094.81
@@ -1362,10 +1350,7 @@ memo (optimized, ~12KB, required=[presentation: sum:6])
  │         └── cost: 1094.81
  ├── G7: (filters G11)
  ├── G8: (scan kuvw@uvw,cols=(1-4),constrained)
- │    ├── [ordering: +2,+4]
- │    │    ├── best: (sort G8="[ordering: +2]")
- │    │    └── cost: 1208.01
- │    ├── [ordering: +2]
+ │    ├── [ordering: +2,+3,+4]
  │    │    ├── best: (scan kuvw@uvw,cols=(1-4),constrained)
  │    │    └── cost: 1073.21
  │    ├── [ordering: +4,+2]
@@ -1378,9 +1363,9 @@ memo (optimized, ~12KB, required=[presentation: sum:6])
  │         ├── best: (scan kuvw@uvw,cols=(1-4),constrained)
  │         └── cost: 1073.21
  ├── G9: (scan kuvw@vw,cols=(1-4),constrained)
- │    ├── [ordering: +2,+4]
- │    │    ├── best: (sort G9)
- │    │    └── cost: 1340.50
+ │    ├── [ordering: +3,+4]
+ │    │    ├── best: (scan kuvw@vw,cols=(1-4),constrained)
+ │    │    └── cost: 1073.21
  │    ├── [ordering: +4,+2]
  │    │    ├── best: (sort G9)
  │    │    └── cost: 1340.50
@@ -1803,7 +1788,7 @@ memo (optimized, ~37KB, required=[presentation: w:10] [ordering: +11,+1])
  ├── G17: (variable x)
  ├── G18: (const 1)
  ├── G19: (scan kuvw,cols=(6-8)) (scan kuvw@uvw,cols=(6-8)) (scan kuvw@wvu,cols=(6-8)) (scan kuvw@vw,cols=(6-8)) (scan kuvw@w,cols=(6-8))
- │    ├── [ordering: +6 opt(7)]
+ │    ├── [ordering: +6]
  │    │    ├── best: (scan kuvw@uvw,cols=(6-8))
  │    │    └── cost: 1084.71
  │    └── []

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -1194,18 +1194,21 @@ SELECT s, i, f FROM kifs WHERE s='foo' ORDER BY s, k, i
 GenerateConstrainedScans
 ================================================================================
 Source expression:
-  select
+  sort
    ├── columns: s:4!null i:2 f:3  [hidden: k:1!null]
    ├── key: (1)
    ├── fd: ()-->(4), (1)-->(2,3)
    ├── ordering: +1 opt(4) [actual: +1]
-   ├── scan kifs@s_idx
-   │    ├── columns: k:1!null i:2 f:3 s:4
-   │    ├── key: (1)
-   │    ├── fd: (1)-->(2-4)
-   │    └── ordering: +1 opt(4) [actual: +4,+1]
-   └── filters
-        └── s:4 = 'foo' [outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
+   └── select
+        ├── columns: k:1!null i:2 f:3 s:4!null
+        ├── key: (1)
+        ├── fd: ()-->(4), (1)-->(2,3)
+        ├── scan kifs@s_idx
+        │    ├── columns: k:1!null i:2 f:3 s:4
+        │    ├── key: (1)
+        │    └── fd: (1)-->(2-4)
+        └── filters
+             └── s:4 = 'foo' [outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
 
 New expression 1 of 2:
   scan kifs@s_idx
@@ -6406,7 +6409,7 @@ distinct-on
  │    │    │    ├── columns: k:6!null u:7 v:8 w:9
  │    │    │    ├── key: (6)
  │    │    │    ├── fd: ()-->(7), (6)-->(8,9)
- │    │    │    ├── ordering: +6 opt(7,9) [actual: +6]
+ │    │    │    ├── ordering: +6 opt(7) [actual: +6]
  │    │    │    └── scan d@u
  │    │    │         ├── columns: k:6!null u:7!null
  │    │    │         ├── constraint: /7/6: [/1 - /1]
@@ -6424,7 +6427,7 @@ distinct-on
  │         │    ├── columns: k:11!null u:12 v:13 w:14
  │         │    ├── key: (11)
  │         │    ├── fd: ()-->(13), (11)-->(12,14)
- │         │    ├── ordering: +11 opt(13,14) [actual: +11]
+ │         │    ├── ordering: +11 opt(13) [actual: +11]
  │         │    └── scan d@v
  │         │         ├── columns: k:11!null v:13!null
  │         │         ├── constraint: /13/11: [/1 - /1]
@@ -6964,7 +6967,7 @@ project
       │    │    │    ├── columns: k:6!null u:7 v:8 w:9
       │    │    │    ├── key: (6)
       │    │    │    ├── fd: ()-->(7), (6)-->(8,9)
-      │    │    │    ├── ordering: +6 opt(7,9) [actual: +6]
+      │    │    │    ├── ordering: +6 opt(7) [actual: +6]
       │    │    │    └── scan d@u
       │    │    │         ├── columns: k:6!null u:7!null
       │    │    │         ├── constraint: /7/6: [/1 - /1]
@@ -6982,7 +6985,7 @@ project
       │         │    ├── columns: k:11!null u:12 v:13 w:14
       │         │    ├── key: (11)
       │         │    ├── fd: ()-->(13), (11)-->(12,14)
-      │         │    ├── ordering: +11 opt(13,14) [actual: +11]
+      │         │    ├── ordering: +11 opt(13) [actual: +11]
       │         │    └── scan d@v
       │         │         ├── columns: k:11!null v:13!null
       │         │         ├── constraint: /13/11: [/1 - /1]
@@ -7216,7 +7219,7 @@ project
       │    │    │    ├── columns: k:6!null u:7 v:8 w:9
       │    │    │    ├── key: (6)
       │    │    │    ├── fd: ()-->(7), (6)-->(8,9)
-      │    │    │    ├── ordering: +6 opt(7,9) [actual: +6]
+      │    │    │    ├── ordering: +6 opt(7) [actual: +6]
       │    │    │    └── scan d@u
       │    │    │         ├── columns: k:6!null u:7!null
       │    │    │         ├── constraint: /7/6: [/3 - /3]
@@ -7866,7 +7869,7 @@ project
       │    │    │    ├── columns: k:6!null u:7 v:8 w:9
       │    │    │    ├── key: (6)
       │    │    │    ├── fd: ()-->(7), (6)-->(8,9)
-      │    │    │    ├── ordering: +6 opt(7,9) [actual: +6]
+      │    │    │    ├── ordering: +6 opt(7) [actual: +6]
       │    │    │    └── scan d@u
       │    │    │         ├── columns: k:6!null u:7!null
       │    │    │         ├── constraint: /7/6: [/1 - /1]
@@ -7884,7 +7887,7 @@ project
       │         │    ├── columns: k:11!null u:12 v:13 w:14
       │         │    ├── key: (11)
       │         │    ├── fd: ()-->(13), (11)-->(12,14)
-      │         │    ├── ordering: +11 opt(13,14) [actual: +11]
+      │         │    ├── ordering: +11 opt(13) [actual: +11]
       │         │    └── scan d@v
       │         │         ├── columns: k:11!null v:13!null
       │         │         ├── constraint: /13/11: [/1 - /1]
@@ -8473,7 +8476,7 @@ project
            │    │    │    ├── columns: k:6!null u:7 v:8 w:9
            │    │    │    ├── key: (6)
            │    │    │    ├── fd: ()-->(7), (6)-->(8,9)
-           │    │    │    ├── ordering: +6 opt(7,9) [actual: +6]
+           │    │    │    ├── ordering: +6 opt(7) [actual: +6]
            │    │    │    └── scan d@u
            │    │    │         ├── columns: k:6!null u:7!null
            │    │    │         ├── constraint: /7/6: [/1 - /1]
@@ -8491,7 +8494,7 @@ project
            │         │    ├── columns: k:11!null u:12 v:13 w:14
            │         │    ├── key: (11)
            │         │    ├── fd: ()-->(13), (11)-->(12,14)
-           │         │    ├── ordering: +11 opt(13,14) [actual: +11]
+           │         │    ├── ordering: +11 opt(13) [actual: +11]
            │         │    └── scan d@v
            │         │         ├── columns: k:11!null v:13!null
            │         │         ├── constraint: /13/11: [/1 - /1]
@@ -8733,7 +8736,7 @@ project
            │    │    │    ├── columns: k:6!null u:7 v:8 w:9
            │    │    │    ├── key: (6)
            │    │    │    ├── fd: ()-->(7), (6)-->(8,9)
-           │    │    │    ├── ordering: +6 opt(7,9) [actual: +6]
+           │    │    │    ├── ordering: +6 opt(7) [actual: +6]
            │    │    │    └── scan d@u
            │    │    │         ├── columns: k:6!null u:7!null
            │    │    │         ├── constraint: /7/6: [/3 - /3]


### PR DESCRIPTION
This commit updates the logic for determining whether an `OrderingChoice`
can imply another `OrderingChoice`. The new logic allows columns in a group to be
treated like optional columns after one of the columns is used. For example,
"+1,+2,+3" implies "+(1|2),+3" now returns true. Prior to this commit, it
returned false, which resulted in unnecessary sort operations in some cases.
This commit also updates the corresponding logic for intersecting and finding
the common prefix of two `OrderingChoice`s.

Furthermore, we now use interesting orderings to inform the required ordering
passed down to the children of `Select` expressions. This makes it more likely
that the child will be able to provide the required ordering.

Informs #33023

Release note (performance improvement): increased the intelligence
of the optimizer around orderings that can be provided by certain
relational expressions when there are equalities between columns.
This can allow the optimizer to remove unnecessary sort operations in
some cases, thus improving performance.