### PR TITLE
storage/cloud,cloudimpl: move sentinel error types to interface pkg

### DIFF
--- a/pkg/ccl/backupccl/backup_destination.go
+++ b/pkg/ccl/backupccl/backup_destination.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/storage/cloud"
-	"github.com/cockroachdb/cockroach/pkg/storage/cloudimpl"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/errors"
@@ -254,7 +253,7 @@ func resolveBackupCollection(
 		defer collection.Close()
 		latestFile, err := collection.ReadFile(ctx, latestFileName)
 		if err != nil {
-			if errors.Is(err, cloudimpl.ErrFileDoesNotExist) {
+			if errors.Is(err, cloud.ErrFileDoesNotExist) {
 				return "", "", pgerror.Wrapf(err, pgcode.UndefinedFile, "path does not contain a completed latest backup")
 			}
 			return "", "", pgerror.WithCandidateCode(err, pgcode.Io)

--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -599,7 +599,7 @@ func (b *backupResumer) readManifestOnResume(
 		details.EncryptionOptions)
 
 	if err != nil {
-		if !errors.Is(err, cloudimpl.ErrFileDoesNotExist) {
+		if !errors.Is(err, cloud.ErrFileDoesNotExist) {
 			return nil, errors.Wrapf(err, "reading backup checkpoint")
 		}
 		// Try reading temp checkpoint.

--- a/pkg/ccl/backupccl/create_scheduled_backup.go
+++ b/pkg/ccl/backupccl/create_scheduled_backup.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/storage/cloud"
 	"github.com/cockroachdb/cockroach/pkg/storage/cloudimpl"
 	"github.com/cockroachdb/errors"
 	"github.com/gogo/protobuf/jsonpb"
@@ -416,7 +417,7 @@ func checkForExistingBackupsInCollection(
 			"the schedule can be created with the 'ignore_existing_backups' option",
 			collectionURI)
 	}
-	if !errors.Is(err, cloudimpl.ErrFileDoesNotExist) {
+	if !errors.Is(err, cloud.ErrFileDoesNotExist) {
 		return errors.Newf("unexpected error occurred when checking for existing backups in %s",
 			collectionURI)
 	}

--- a/pkg/ccl/backupccl/manifest_handling.go
+++ b/pkg/ccl/backupccl/manifest_handling.go
@@ -158,7 +158,7 @@ func ReadBackupManifestFromStore(
 func containsManifest(ctx context.Context, exportStore cloud.ExternalStorage) (bool, error) {
 	r, err := exportStore.ReadFile(ctx, backupManifestName)
 	if err != nil {
-		if errors.Is(err, cloudimpl.ErrFileDoesNotExist) {
+		if errors.Is(err, cloud.ErrFileDoesNotExist) {
 			return false, nil
 		}
 		return false, err
@@ -228,7 +228,7 @@ func readBackupManifest(
 		}
 	} else {
 		// If we don't have a checksum file, carry on. This might be an old version.
-		if !errors.Is(err, cloudimpl.ErrFileDoesNotExist) {
+		if !errors.Is(err, cloud.ErrFileDoesNotExist) {
 			return BackupManifest{}, err
 		}
 	}
@@ -698,7 +698,7 @@ func resolveBackupManifests(
 		// automatically created incremental layers inside the base layer.
 		prev, err := findPriorBackupNames(ctx, baseStores[0])
 		if err != nil {
-			if errors.Is(err, cloudimpl.ErrListingUnsupported) {
+			if errors.Is(err, cloud.ErrListingUnsupported) {
 				log.Warningf(ctx, "storage sink %T does not support listing, only resolving the base backup", baseStores[0])
 				// If we do not support listing, we have to just assume there are none
 				// and restore the specified base.
@@ -942,7 +942,7 @@ func writeEncryptionInfoIfNotExists(
 		return nil
 	}
 
-	if !errors.Is(err, cloudimpl.ErrFileDoesNotExist) {
+	if !errors.Is(err, cloud.ErrFileDoesNotExist) {
 		return errors.Wrapf(err,
 			"returned an unexpected error when checking for the existence of %s file",
 			backupEncryptionInfoFile)
@@ -984,7 +984,7 @@ func checkForPreviousBackup(
 			redactedURI, backupManifestName)
 	}
 
-	if !errors.Is(err, cloudimpl.ErrFileDoesNotExist) {
+	if !errors.Is(err, cloud.ErrFileDoesNotExist) {
 		return errors.Wrapf(err,
 			"%s returned an unexpected error when checking for the existence of %s file",
 			redactedURI, backupManifestName)
@@ -998,7 +998,7 @@ func checkForPreviousBackup(
 			redactedURI, backupManifestCheckpointName)
 	}
 
-	if !errors.Is(err, cloudimpl.ErrFileDoesNotExist) {
+	if !errors.Is(err, cloud.ErrFileDoesNotExist) {
 		return errors.Wrapf(err,
 			"%s returned an unexpected error when checking for the existence of %s file",
 			redactedURI, backupManifestCheckpointName)

--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -33,7 +33,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/storage/cloud"
-	"github.com/cockroachdb/cockroach/pkg/storage/cloudimpl"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -182,7 +181,7 @@ func showBackupPlanHook(
 
 		incPaths, err := findPriorBackupNames(ctx, store)
 		if err != nil {
-			if errors.Is(err, cloudimpl.ErrListingUnsupported) {
+			if errors.Is(err, cloud.ErrListingUnsupported) {
 				// If we do not support listing, we have to just assume there are none
 				// and show the specified base.
 				log.Warningf(ctx, "storage sink %T does not support listing, only resolving the base backup", store)

--- a/pkg/storage/cloud/external_storage.go
+++ b/pkg/storage/cloud/external_storage.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/errors"
 )
 
 // This file is for interfaces only and should not contain any implementation
@@ -100,3 +101,11 @@ type SQLConnI interface {
 // AccessIsWithExplicitAuth is used to check if the provided path has explicit
 // authentication.
 var AccessIsWithExplicitAuth func(path string) (bool, string, error)
+
+// ErrFileDoesNotExist is a sentinel error for indicating that a specified
+// bucket/object/key/file (depending on storage terminology) does not exist.
+// This error is raised by the ReadFile method.
+var ErrFileDoesNotExist = errors.New("external_storage: file doesn't exist")
+
+// ErrListingUnsupported is a marker for indicating listing is unsupported.
+var ErrListingUnsupported = errors.New("listing is not supported")

--- a/pkg/storage/cloudimpl/azure_storage.go
+++ b/pkg/storage/cloudimpl/azure_storage.go
@@ -150,7 +150,7 @@ func (s *azureStorage) ReadFileAt(
 			switch azerr.ServiceCode() {
 			// TODO(adityamaru): Investigate whether both these conditions are required.
 			case azblob.ServiceCodeBlobNotFound, azblob.ServiceCodeResourceNotFound:
-				return nil, 0, errors.Wrapf(ErrFileDoesNotExist, "azure blob does not exist: %s", err.Error())
+				return nil, 0, errors.Wrapf(cloud.ErrFileDoesNotExist, "azure blob does not exist: %s", err.Error())
 			}
 		}
 		return nil, 0, errors.Wrap(err, "failed to create azure reader")

--- a/pkg/storage/cloudimpl/cloudimpltests/external_storage_test.go
+++ b/pkg/storage/cloudimpl/cloudimpltests/external_storage_test.go
@@ -356,7 +356,7 @@ func testExportStoreWithExternalIOConfig(
 		// Attempt to read a file which does not exist.
 		_, err = singleFile.ReadFile(ctx, "file_does_not_exist")
 		require.Error(t, err)
-		require.True(t, errors.Is(err, cloudimpl.ErrFileDoesNotExist), "Expected a file does not exist error but returned %s")
+		require.True(t, errors.Is(err, cloud.ErrFileDoesNotExist), "Expected a file does not exist error but returned %s")
 		require.NoError(t, s.Delete(ctx, testingFilename))
 	})
 }
@@ -787,12 +787,12 @@ func TestFileExistence(t *testing.T) {
 		// Try reading a file that doesn't exist and assert we get the error the
 		// interface claims it provides.
 		_, err := es.ReadFile(ctx, "this-doesnt-exist")
-		if !errors.Is(err, cloudimpl.ErrFileDoesNotExist) {
+		if !errors.Is(err, cloud.ErrFileDoesNotExist) {
 			t.Fatalf("expected a file does not exist error, got %+v", err)
 		}
 
 		_, _, err = es.ReadFileAt(ctx, "this-doesnt-exist", 0 /* offset */)
-		if !errors.Is(err, cloudimpl.ErrFileDoesNotExist) {
+		if !errors.Is(err, cloud.ErrFileDoesNotExist) {
 			t.Fatalf("expected a file does not exist error, got %+v", err)
 		}
 

--- a/pkg/storage/cloudimpl/cloudimpltests/gcs_storage_test.go
+++ b/pkg/storage/cloudimpl/cloudimpltests/gcs_storage_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/storage/cloud"
 	"github.com/cockroachdb/cockroach/pkg/storage/cloudimpl"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -61,7 +62,7 @@ func TestFileDoesNotExist(t *testing.T) {
 		require.NoError(t, err)
 		_, err = s.ReadFile(context.Background(), "")
 		require.Error(t, err, "")
-		require.True(t, errors.Is(err, cloudimpl.ErrFileDoesNotExist))
+		require.True(t, errors.Is(err, cloud.ErrFileDoesNotExist))
 	}
 
 	{
@@ -76,7 +77,7 @@ func TestFileDoesNotExist(t *testing.T) {
 		require.NoError(t, err)
 		_, err = s.ReadFile(context.Background(), "")
 		require.Error(t, err, "")
-		require.True(t, errors.Is(err, cloudimpl.ErrFileDoesNotExist))
+		require.True(t, errors.Is(err, cloud.ErrFileDoesNotExist))
 	}
 }
 

--- a/pkg/storage/cloudimpl/cloudimpltests/s3_storage_test.go
+++ b/pkg/storage/cloudimpl/cloudimpltests/s3_storage_test.go
@@ -287,7 +287,7 @@ func TestS3BucketDoesNotExist(t *testing.T) {
 
 	_, err = s.ReadFile(ctx, "")
 	require.Error(t, err, "")
-	require.True(t, errors.Is(err, cloudimpl.ErrFileDoesNotExist))
+	require.True(t, errors.Is(err, cloud.ErrFileDoesNotExist))
 }
 
 func TestAntagonisticS3Read(t *testing.T) {

--- a/pkg/storage/cloudimpl/external_storage.go
+++ b/pkg/storage/cloudimpl/external_storage.go
@@ -114,14 +114,6 @@ var redactedQueryParams = map[string]struct{}{
 	CredentialsParam:     {},
 }
 
-// ErrListingUnsupported is a marker for indicating listing is unsupported.
-var ErrListingUnsupported = errors.New("listing is not supported")
-
-// ErrFileDoesNotExist is a sentinel error for indicating that a specified
-// bucket/object/key/file (depending on storage terminology) does not exist.
-// This error is raised by the ReadFile method.
-var ErrFileDoesNotExist = errors.New("external_storage: file doesn't exist")
-
 var confParsers = map[string]ExternalStorageURIParser{}
 var implementations = map[roachpb.ExternalStorageProvider]ExternalStorageConstructor{}
 

--- a/pkg/storage/cloudimpl/file_table_storage.go
+++ b/pkg/storage/cloudimpl/file_table_storage.go
@@ -232,7 +232,7 @@ func (f *fileTableStorage) ReadFileAt(
 	}
 	reader, size, err := f.fs.ReadFile(ctx, filepath, offset)
 	if oserror.IsNotExist(err) {
-		return nil, 0, errors.Wrapf(ErrFileDoesNotExist,
+		return nil, 0, errors.Wrapf(cloud.ErrFileDoesNotExist,
 			"file %s does not exist in the UserFileTableSystem", filepath)
 	}
 

--- a/pkg/storage/cloudimpl/gcs_storage.go
+++ b/pkg/storage/cloudimpl/gcs_storage.go
@@ -210,7 +210,7 @@ func (g *gcsStorage) ReadFileAt(
 			// if file does not exist.  Regardless why we couldn't open the stream
 			// (whether its invalid bucket or file doesn't exist),
 			// return our internal ErrFileDoesNotExist.
-			err = errors.Wrapf(ErrFileDoesNotExist, "gcs object does not exist: %s", err.Error())
+			err = errors.Wrapf(cloud.ErrFileDoesNotExist, "gcs object does not exist: %s", err.Error())
 		}
 		return nil, 0, err
 	}

--- a/pkg/storage/cloudimpl/http_storage.go
+++ b/pkg/storage/cloudimpl/http_storage.go
@@ -263,7 +263,7 @@ func (h *httpStorage) WriteFile(ctx context.Context, basename string, content io
 }
 
 func (h *httpStorage) ListFiles(_ context.Context, _ string) ([]string, error) {
-	return nil, errors.Mark(errors.New("http storage does not support listing"), ErrListingUnsupported)
+	return nil, errors.Mark(errors.New("http storage does not support listing"), cloud.ErrListingUnsupported)
 }
 
 func (h *httpStorage) Delete(ctx context.Context, basename string) error {
@@ -349,7 +349,7 @@ func (h *httpStorage) req(
 		_ = resp.Body.Close()
 		err := errors.Errorf("error response from server: %s %q", resp.Status, body)
 		if err != nil && resp.StatusCode == 404 {
-			err = errors.Wrapf(ErrFileDoesNotExist, "http storage file does not exist: %s", err.Error())
+			err = errors.Wrapf(cloud.ErrFileDoesNotExist, "http storage file does not exist: %s", err.Error())
 		}
 		return nil, err
 	}

--- a/pkg/storage/cloudimpl/nodelocal_storage.go
+++ b/pkg/storage/cloudimpl/nodelocal_storage.go
@@ -148,7 +148,7 @@ func (l *localFileStorage) ReadFileAt(
 		// The local store returns a golang native ErrNotFound, whereas the remote
 		// store returns a gRPC native NotFound error.
 		if oserror.IsNotExist(err) || status.Code(err) == codes.NotFound {
-			return nil, 0, errors.Wrapf(ErrFileDoesNotExist, "nodelocal storage file does not exist: %s", err.Error())
+			return nil, 0, errors.Wrapf(cloud.ErrFileDoesNotExist, "nodelocal storage file does not exist: %s", err.Error())
 		}
 		return nil, 0, err
 	}

--- a/pkg/storage/cloudimpl/s3_storage.go
+++ b/pkg/storage/cloudimpl/s3_storage.go
@@ -290,7 +290,7 @@ func (s *s3Storage) openStreamAt(
 			switch aerr.Code() {
 			// Relevant 404 errors reported by AWS.
 			case s3.ErrCodeNoSuchBucket, s3.ErrCodeNoSuchKey:
-				return nil, errors.Wrapf(ErrFileDoesNotExist, "s3 object does not exist: %s", err.Error())
+				return nil, errors.Wrapf(cloud.ErrFileDoesNotExist, "s3 object does not exist: %s", err.Error())
 			}
 		}
 		return nil, errors.Wrap(err, "failed to get s3 object")


### PR DESCRIPTION
The sentinel errors for listing-unsupported or file-does-not-exist are part
of the public API. We _expect_ implementations of ReadFile to return the
ErrFileDoesNotExist when opening a non-existent file, based on the fact that
callers test for it. That suggests that these types should be defined in the
package that defines the ExternalStorage interface, not in the implementation
package, as callers should not need to depend directly on the implementation.

Release note: none.