### PR TITLE
colexec: release the VecToDatum converter in most cases

### DIFF
--- a/pkg/sql/colconv/vec_to_datum.eg.go
+++ b/pkg/sql/colconv/vec_to_datum.eg.go
@@ -57,8 +57,25 @@ var vecToDatumConverterPool = sync.Pool{
 	},
 }
 
-func getNewVecToDatumConverter(batchWidth int) *VecToDatumConverter {
-	c := vecToDatumConverterPool.Get().(*VecToDatumConverter)
+// getNewVecToDatumConverter returns a new VecToDatumConverter that is able to
+// handle batchWidth number of columns. willRelease indicates whether the caller
+// will call Release() on the converter.
+func getNewVecToDatumConverter(batchWidth int, willRelease bool) *VecToDatumConverter {
+	var c *VecToDatumConverter
+	// Having willRelease knob (i.e. not defaulting to using the pool all the
+	// time) is justified by the following scenario: there is constant workload
+	// running against the cluster (e.g. TPCC) that has the same "access
+	// pattern", so all converters used by that workload can be reused very
+	// effectively - the width of the batches are the same, etc. However, when a
+	// random query comes in and picks up a converter from the sync.Pool, it'll
+	// use it once and discard it afterwards. It is likely that for this random
+	// query it's better to allocate a fresh converter and not touch the ones in
+	// the pool.
+	if willRelease {
+		c = vecToDatumConverterPool.Get().(*VecToDatumConverter)
+	} else {
+		c = &VecToDatumConverter{}
+	}
 	if cap(c.convertedVecs) < batchWidth {
 		c.convertedVecs = make([]tree.Datums, batchWidth)
 	} else {
@@ -70,16 +87,21 @@ func getNewVecToDatumConverter(batchWidth int) *VecToDatumConverter {
 // NewVecToDatumConverter creates a new VecToDatumConverter.
 // - batchWidth determines the width of the batches that it will be converting.
 // - vecIdxsToConvert determines which vectors need to be converted.
-func NewVecToDatumConverter(batchWidth int, vecIdxsToConvert []int) *VecToDatumConverter {
-	c := getNewVecToDatumConverter(batchWidth)
+// - willRelease indicates whether the caller intends to call Release() on the
+//   converter.
+func NewVecToDatumConverter(
+	batchWidth int, vecIdxsToConvert []int, willRelease bool,
+) *VecToDatumConverter {
+	c := getNewVecToDatumConverter(batchWidth, willRelease)
 	c.vecIdxsToConvert = vecIdxsToConvert
 	return c
 }
 
 // NewAllVecToDatumConverter is like NewVecToDatumConverter except all of the
 // vectors in the batch will be converted.
+// NOTE: it is assumed that the caller will Release the returned converter.
 func NewAllVecToDatumConverter(batchWidth int) *VecToDatumConverter {
-	c := getNewVecToDatumConverter(batchWidth)
+	c := getNewVecToDatumConverter(batchWidth, true /* willRelease */)
 	if cap(c.vecIdxsToConvert) < batchWidth {
 		c.vecIdxsToConvert = make([]int, batchWidth)
 	} else {
@@ -150,6 +172,11 @@ func (c *VecToDatumConverter) ConvertBatchAndDeselect(batch coldata.Batch) {
 // GetDatumColumn(colIdx)[sel[tupleIdx]] and *NOT*
 // GetDatumColumn(colIdx)[tupleIdx].
 func (c *VecToDatumConverter) ConvertBatch(batch coldata.Batch) {
+	if c == nil {
+		// If the converter is nil, then it wasn't allocated because there are
+		// no vectors to convert, so exit early.
+		return
+	}
 	c.ConvertVecs(batch.ColVecs(), batch.Length(), batch.Selection())
 }
 

--- a/pkg/sql/colconv/vec_to_datum_tmpl.go
+++ b/pkg/sql/colconv/vec_to_datum_tmpl.go
@@ -60,8 +60,25 @@ var vecToDatumConverterPool = sync.Pool{
 	},
 }
 
-func getNewVecToDatumConverter(batchWidth int) *VecToDatumConverter {
-	c := vecToDatumConverterPool.Get().(*VecToDatumConverter)
+// getNewVecToDatumConverter returns a new VecToDatumConverter that is able to
+// handle batchWidth number of columns. willRelease indicates whether the caller
+// will call Release() on the converter.
+func getNewVecToDatumConverter(batchWidth int, willRelease bool) *VecToDatumConverter {
+	var c *VecToDatumConverter
+	// Having willRelease knob (i.e. not defaulting to using the pool all the
+	// time) is justified by the following scenario: there is constant workload
+	// running against the cluster (e.g. TPCC) that has the same "access
+	// pattern", so all converters used by that workload can be reused very
+	// effectively - the width of the batches are the same, etc. However, when a
+	// random query comes in and picks up a converter from the sync.Pool, it'll
+	// use it once and discard it afterwards. It is likely that for this random
+	// query it's better to allocate a fresh converter and not touch the ones in
+	// the pool.
+	if willRelease {
+		c = vecToDatumConverterPool.Get().(*VecToDatumConverter)
+	} else {
+		c = &VecToDatumConverter{}
+	}
 	if cap(c.convertedVecs) < batchWidth {
 		c.convertedVecs = make([]tree.Datums, batchWidth)
 	} else {
@@ -73,16 +90,21 @@ func getNewVecToDatumConverter(batchWidth int) *VecToDatumConverter {
 // NewVecToDatumConverter creates a new VecToDatumConverter.
 // - batchWidth determines the width of the batches that it will be converting.
 // - vecIdxsToConvert determines which vectors need to be converted.
-func NewVecToDatumConverter(batchWidth int, vecIdxsToConvert []int) *VecToDatumConverter {
-	c := getNewVecToDatumConverter(batchWidth)
+// - willRelease indicates whether the caller intends to call Release() on the
+//   converter.
+func NewVecToDatumConverter(
+	batchWidth int, vecIdxsToConvert []int, willRelease bool,
+) *VecToDatumConverter {
+	c := getNewVecToDatumConverter(batchWidth, willRelease)
 	c.vecIdxsToConvert = vecIdxsToConvert
 	return c
 }
 
 // NewAllVecToDatumConverter is like NewVecToDatumConverter except all of the
 // vectors in the batch will be converted.
+// NOTE: it is assumed that the caller will Release the returned converter.
 func NewAllVecToDatumConverter(batchWidth int) *VecToDatumConverter {
-	c := getNewVecToDatumConverter(batchWidth)
+	c := getNewVecToDatumConverter(batchWidth, true /* willRelease */)
 	if cap(c.vecIdxsToConvert) < batchWidth {
 		c.vecIdxsToConvert = make([]int, batchWidth)
 	} else {
@@ -153,6 +175,11 @@ func (c *VecToDatumConverter) ConvertBatchAndDeselect(batch coldata.Batch) {
 // GetDatumColumn(colIdx)[sel[tupleIdx]] and *NOT*
 // GetDatumColumn(colIdx)[tupleIdx].
 func (c *VecToDatumConverter) ConvertBatch(batch coldata.Batch) {
+	if c == nil {
+		// If the converter is nil, then it wasn't allocated because there are
+		// no vectors to convert, so exit early.
+		return
+	}
 	c.ConvertVecs(batch.ColVecs(), batch.Length(), batch.Selection())
 }
 

--- a/pkg/sql/colexec/aggregators_util.go
+++ b/pkg/sql/colexec/aggregators_util.go
@@ -297,7 +297,7 @@ func newDistinctAggregatorHelperBase(
 			}
 		}
 	}
-	b.aggColsConverter = colconv.NewVecToDatumConverter(len(args.InputTypes), vecIdxsToConvert)
+	b.aggColsConverter = colconv.NewVecToDatumConverter(len(args.InputTypes), vecIdxsToConvert, false /* willRelease */)
 	b.scratch.converted = []tree.Datum{nil}
 	b.scratch.sel = make([]int, maxBatchSize)
 	return b

--- a/pkg/sql/colexec/builtin_funcs_test.go
+++ b/pkg/sql/colexec/builtin_funcs_test.go
@@ -200,7 +200,7 @@ func BenchmarkCompareSpecializedOperators(b *testing.B) {
 		outputIdx:           outputIdx,
 		columnTypes:         typs,
 		outputType:          types.String,
-		toDatumConverter:    colconv.NewVecToDatumConverter(len(typs), inputCols),
+		toDatumConverter:    colconv.NewVecToDatumConverter(len(typs), inputCols, false /* willRelease */),
 		datumToVecConverter: colconv.GetDatumToPhysicalFn(types.String),
 		row:                 make(tree.Datums, outputIdx),
 		argumentCols:        inputCols,

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -1328,7 +1328,7 @@ func NewColOperator(
 		Op:          result.Root,
 		ColumnTypes: result.ColumnTypes,
 	}
-	err = ppr.planPostProcessSpec(ctx, flowCtx, evalCtx, args, post, factory)
+	err = ppr.planPostProcessSpec(ctx, flowCtx, evalCtx, args, post, factory, &r.Releasables)
 	if err != nil {
 		if log.V(2) {
 			log.Infof(
@@ -1438,7 +1438,7 @@ func (r opResult) planAndMaybeWrapFilter(
 	factory coldata.ColumnFactory,
 ) error {
 	op, err := planFilterExpr(
-		ctx, flowCtx, evalCtx, r.Root, r.ColumnTypes, filter, args.StreamingMemAccount, factory, args.ExprHelper,
+		ctx, flowCtx, evalCtx, r.Root, r.ColumnTypes, filter, args.StreamingMemAccount, factory, args.ExprHelper, &r.Releasables,
 	)
 	if err != nil {
 		// Filter expression planning failed. Fall back to planning the filter
@@ -1509,6 +1509,7 @@ func (r *postProcessResult) planPostProcessSpec(
 	args *colexecargs.NewColOperatorArgs,
 	post *execinfrapb.PostProcessSpec,
 	factory coldata.ColumnFactory,
+	releasables *[]execinfra.Releasable,
 ) error {
 	if post.Projection {
 		r.Op, r.ColumnTypes = addProjection(r.Op, r.ColumnTypes, post.OutputColumns)
@@ -1525,7 +1526,7 @@ func (r *postProcessResult) planPostProcessSpec(
 			}
 			var outputIdx int
 			r.Op, outputIdx, r.ColumnTypes, err = planProjectionOperators(
-				ctx, evalCtx, expr, r.ColumnTypes, r.Op, args.StreamingMemAccount, factory,
+				ctx, evalCtx, expr, r.ColumnTypes, r.Op, args.StreamingMemAccount, factory, releasables,
 			)
 			if err != nil {
 				return errors.Wrapf(err, "unable to columnarize render expression %q", expr)
@@ -1654,6 +1655,7 @@ func planFilterExpr(
 	acc *mon.BoundAccount,
 	factory coldata.ColumnFactory,
 	helper *colexecargs.ExprHelper,
+	releasables *[]execinfra.Releasable,
 ) (colexecop.Operator, error) {
 	semaCtx := flowCtx.TypeResolverFactory.NewSemaContext(evalCtx.Txn)
 	expr, err := helper.ProcessExpr(filter, semaCtx, evalCtx, columnTypes)
@@ -1666,7 +1668,7 @@ func planFilterExpr(
 		return colexecutils.NewZeroOp(input), nil
 	}
 	op, _, filterColumnTypes, err := planSelectionOperators(
-		ctx, evalCtx, expr, columnTypes, input, acc, factory,
+		ctx, evalCtx, expr, columnTypes, input, acc, factory, releasables,
 	)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to columnarize filter expression %q", filter)
@@ -1703,6 +1705,7 @@ func planSelectionOperators(
 	input colexecop.Operator,
 	acc *mon.BoundAccount,
 	factory coldata.ColumnFactory,
+	releasables *[]execinfra.Releasable,
 ) (op colexecop.Operator, resultIdx int, typs []*types.T, err error) {
 	switch t := expr.(type) {
 	case *tree.IndexedVar:
@@ -1715,13 +1718,13 @@ func planSelectionOperators(
 		// tuples that are true on the right side.
 		var leftOp, rightOp colexecop.Operator
 		leftOp, _, typs, err = planSelectionOperators(
-			ctx, evalCtx, t.TypedLeft(), columnTypes, input, acc, factory,
+			ctx, evalCtx, t.TypedLeft(), columnTypes, input, acc, factory, releasables,
 		)
 		if err != nil {
 			return nil, resultIdx, typs, err
 		}
 		rightOp, resultIdx, typs, err = planSelectionOperators(
-			ctx, evalCtx, t.TypedRight(), typs, leftOp, acc, factory,
+			ctx, evalCtx, t.TypedRight(), typs, leftOp, acc, factory, releasables,
 		)
 		return rightOp, resultIdx, typs, err
 	case *tree.OrExpr:
@@ -1746,7 +1749,7 @@ func planSelectionOperators(
 			return nil, resultIdx, typs, err
 		}
 		op, resultIdx, typs, err = planProjectionOperators(
-			ctx, evalCtx, caseExpr, columnTypes, input, acc, factory,
+			ctx, evalCtx, caseExpr, columnTypes, input, acc, factory, releasables,
 		)
 		if err != nil {
 			return nil, resultIdx, typs, err
@@ -1755,7 +1758,7 @@ func planSelectionOperators(
 		return op, resultIdx, typs, err
 	case *tree.CaseExpr:
 		op, resultIdx, typs, err = planProjectionOperators(
-			ctx, evalCtx, expr, columnTypes, input, acc, factory,
+			ctx, evalCtx, expr, columnTypes, input, acc, factory, releasables,
 		)
 		if err != nil {
 			return op, resultIdx, typs, err
@@ -1764,7 +1767,7 @@ func planSelectionOperators(
 		return op, resultIdx, typs, err
 	case *tree.IsNullExpr:
 		op, resultIdx, typs, err = planProjectionOperators(
-			ctx, evalCtx, t.TypedInnerExpr(), columnTypes, input, acc, factory,
+			ctx, evalCtx, t.TypedInnerExpr(), columnTypes, input, acc, factory, releasables,
 		)
 		if err != nil {
 			return op, resultIdx, typs, err
@@ -1775,7 +1778,7 @@ func planSelectionOperators(
 		return op, resultIdx, typs, err
 	case *tree.IsNotNullExpr:
 		op, resultIdx, typs, err = planProjectionOperators(
-			ctx, evalCtx, t.TypedInnerExpr(), columnTypes, input, acc, factory,
+			ctx, evalCtx, t.TypedInnerExpr(), columnTypes, input, acc, factory, releasables,
 		)
 		if err != nil {
 			return op, resultIdx, typs, err
@@ -1787,7 +1790,7 @@ func planSelectionOperators(
 	case *tree.ComparisonExpr:
 		cmpOp := t.Operator
 		leftOp, leftIdx, ct, err := planProjectionOperators(
-			ctx, evalCtx, t.TypedLeft(), columnTypes, input, acc, factory,
+			ctx, evalCtx, t.TypedLeft(), columnTypes, input, acc, factory, releasables,
 		)
 		if err != nil {
 			return nil, resultIdx, ct, err
@@ -1831,11 +1834,14 @@ func planSelectionOperators(
 				op, err = colexecsel.GetSelectionConstOperator(
 					cmpOp, leftOp, ct, leftIdx, constArg, evalCtx, t,
 				)
+				if r, ok := op.(execinfra.Releasable); ok {
+					*releasables = append(*releasables, r)
+				}
 			}
 			return op, resultIdx, ct, err
 		}
 		rightOp, rightIdx, ct, err := planProjectionOperators(
-			ctx, evalCtx, t.TypedRight(), ct, leftOp, acc, factory,
+			ctx, evalCtx, t.TypedRight(), ct, leftOp, acc, factory, releasables,
 		)
 		if err != nil {
 			return nil, resultIdx, ct, err
@@ -1843,6 +1849,9 @@ func planSelectionOperators(
 		op, err = colexecsel.GetSelectionOperator(
 			cmpOp, rightOp, ct, leftIdx, rightIdx, evalCtx, t,
 		)
+		if r, ok := op.(execinfra.Releasable); ok {
+			*releasables = append(*releasables, r)
+		}
 		return op, resultIdx, ct, err
 	default:
 		return nil, resultIdx, nil, errors.Errorf("unhandled selection expression type: %s", reflect.TypeOf(t))
@@ -1880,6 +1889,7 @@ func planProjectionOperators(
 	input colexecop.Operator,
 	acc *mon.BoundAccount,
 	factory coldata.ColumnFactory,
+	releasables *[]execinfra.Releasable,
 ) (op colexecop.Operator, resultIdx int, typs []*types.T, err error) {
 	// projectDatum is a helper function that adds a new constant projection
 	// operator for the given datum. typs are updated accordingly.
@@ -1902,7 +1912,7 @@ func planProjectionOperators(
 	case *tree.ComparisonExpr:
 		return planProjectionExpr(
 			ctx, evalCtx, t.Operator, t.ResolvedType(), t.TypedLeft(), t.TypedRight(),
-			columnTypes, input, acc, factory, nil /* binFn */, t,
+			columnTypes, input, acc, factory, nil /* binFn */, t, releasables,
 		)
 	case *tree.BinaryExpr:
 		if err = checkSupportedBinaryExpr(t.TypedLeft(), t.TypedRight(), t.ResolvedType()); err != nil {
@@ -1910,16 +1920,16 @@ func planProjectionOperators(
 		}
 		return planProjectionExpr(
 			ctx, evalCtx, t.Operator, t.ResolvedType(), t.TypedLeft(), t.TypedRight(),
-			columnTypes, input, acc, factory, t.Fn.Fn, nil, /* cmpExpr */
+			columnTypes, input, acc, factory, t.Fn.Fn, nil /* cmpExpr */, releasables,
 		)
 	case *tree.IsNullExpr:
-		return planIsNullProjectionOp(ctx, evalCtx, t.ResolvedType(), t.TypedInnerExpr(), columnTypes, input, acc, false /* negate */, factory)
+		return planIsNullProjectionOp(ctx, evalCtx, t.ResolvedType(), t.TypedInnerExpr(), columnTypes, input, acc, false /* negate */, factory, releasables)
 	case *tree.IsNotNullExpr:
-		return planIsNullProjectionOp(ctx, evalCtx, t.ResolvedType(), t.TypedInnerExpr(), columnTypes, input, acc, true /* negate */, factory)
+		return planIsNullProjectionOp(ctx, evalCtx, t.ResolvedType(), t.TypedInnerExpr(), columnTypes, input, acc, true /* negate */, factory, releasables)
 	case *tree.CastExpr:
 		expr := t.Expr.(tree.TypedExpr)
 		op, resultIdx, typs, err = planProjectionOperators(
-			ctx, evalCtx, expr, columnTypes, input, acc, factory,
+			ctx, evalCtx, expr, columnTypes, input, acc, factory, releasables,
 		)
 		if err != nil {
 			return nil, 0, nil, err
@@ -1937,7 +1947,7 @@ func planProjectionOperators(
 			// of constant arguments, because the vectorized engine right now
 			// creates a new column full of the constant value.
 			op, resultIdx, typs, err = planProjectionOperators(
-				ctx, evalCtx, e.(tree.TypedExpr), typs, op, acc, factory,
+				ctx, evalCtx, e.(tree.TypedExpr), typs, op, acc, factory, releasables,
 			)
 			if err != nil {
 				return nil, resultIdx, nil, err
@@ -1948,6 +1958,9 @@ func planProjectionOperators(
 		op, err = colexec.NewBuiltinFunctionOperator(
 			colmem.NewAllocator(ctx, acc, factory), evalCtx, t, typs, inputCols, resultIdx, op,
 		)
+		if r, ok := op.(execinfra.Releasable); ok {
+			*releasables = append(*releasables, r)
+		}
 		typs = appendOneType(typs, t.ResolvedType())
 		return op, resultIdx, typs, err
 	case tree.Datum:
@@ -1977,7 +1990,7 @@ func planProjectionOperators(
 		tupleContentsIdxs := make([]int, len(t.Exprs))
 		for i, expr := range t.Exprs {
 			input, tupleContentsIdxs[i], typs, err = planProjectionOperators(
-				ctx, evalCtx, expr.(tree.TypedExpr), typs, input, acc, factory,
+				ctx, evalCtx, expr.(tree.TypedExpr), typs, input, acc, factory, releasables,
 			)
 			if err != nil {
 				return nil, resultIdx, typs, err
@@ -1987,6 +2000,7 @@ func planProjectionOperators(
 		op = colexec.NewTupleProjOp(
 			colmem.NewAllocator(ctx, acc, factory), typs, tupleContentsIdxs, outputType, input, resultIdx,
 		)
+		*releasables = append(*releasables, op.(execinfra.Releasable))
 		typs = appendOneType(typs, outputType)
 		return op, resultIdx, typs, err
 	case *tree.CaseExpr:
@@ -2029,7 +2043,7 @@ func planProjectionOperators(
 			// final result of the case projection.
 			whenTyped := when.Cond.(tree.TypedExpr)
 			caseOps[i], resultIdx, typs, err = planProjectionOperators(
-				ctx, evalCtx, whenTyped, typs, buffer, acc, factory,
+				ctx, evalCtx, whenTyped, typs, buffer, acc, factory, releasables,
 			)
 			if err != nil {
 				return nil, resultIdx, typs, err
@@ -2047,7 +2061,7 @@ func planProjectionOperators(
 				right := tree.NewTypedOrdinalReference(resultIdx, whenTyped.ResolvedType())
 				cmpExpr := tree.NewTypedComparisonExpr(tree.EQ, left, right)
 				caseOps[i], resultIdx, typs, err = planProjectionOperators(
-					ctx, evalCtx, cmpExpr, typs, caseOps[i], acc, factory,
+					ctx, evalCtx, cmpExpr, typs, caseOps[i], acc, factory, releasables,
 				)
 				if err != nil {
 					return nil, resultIdx, typs, err
@@ -2060,7 +2074,7 @@ func planProjectionOperators(
 
 			// Run the "then" clause on those tuples that were selected.
 			caseOps[i], thenIdxs[i], typs, err = planProjectionOperators(
-				ctx, evalCtx, when.Val.(tree.TypedExpr), typs, caseOps[i], acc, factory,
+				ctx, evalCtx, when.Val.(tree.TypedExpr), typs, caseOps[i], acc, factory, releasables,
 			)
 			if err != nil {
 				return nil, resultIdx, typs, err
@@ -2085,7 +2099,7 @@ func planProjectionOperators(
 			elseExpr = tree.DNull
 		}
 		elseOp, thenIdxs[len(t.Whens)], typs, err = planProjectionOperators(
-			ctx, evalCtx, elseExpr.(tree.TypedExpr), typs, buffer, acc, factory,
+			ctx, evalCtx, elseExpr.(tree.TypedExpr), typs, buffer, acc, factory, releasables,
 		)
 		if err != nil {
 			return nil, resultIdx, typs, err
@@ -2108,7 +2122,7 @@ func planProjectionOperators(
 		op := colexec.NewCaseOp(allocator, buffer, caseOps, elseOp, thenIdxs, caseOutputIdx, caseOutputType)
 		return op, caseOutputIdx, typs, err
 	case *tree.AndExpr, *tree.OrExpr:
-		return planLogicalProjectionOp(ctx, evalCtx, expr, columnTypes, input, acc, factory)
+		return planLogicalProjectionOp(ctx, evalCtx, expr, columnTypes, input, acc, factory, releasables)
 	default:
 		return nil, resultIdx, nil, errors.Errorf("unhandled projection expression type: %s", reflect.TypeOf(t))
 	}
@@ -2155,6 +2169,7 @@ func planProjectionExpr(
 	factory coldata.ColumnFactory,
 	binFn tree.TwoArgFn,
 	cmpExpr *tree.ComparisonExpr,
+	releasables *[]execinfra.Releasable,
 ) (op colexecop.Operator, resultIdx int, typs []*types.T, err error) {
 	if err := checkSupportedProjectionExpr(left, right); err != nil {
 		return nil, resultIdx, typs, err
@@ -2171,7 +2186,7 @@ func planProjectionExpr(
 		// this case.
 		var rightIdx int
 		input, rightIdx, typs, err = planProjectionOperators(
-			ctx, evalCtx, right, columnTypes, input, acc, factory,
+			ctx, evalCtx, right, columnTypes, input, acc, factory, releasables,
 		)
 		if err != nil {
 			return nil, resultIdx, typs, err
@@ -2186,7 +2201,7 @@ func planProjectionExpr(
 	} else {
 		var leftIdx int
 		input, leftIdx, typs, err = planProjectionOperators(
-			ctx, evalCtx, left, columnTypes, input, acc, factory,
+			ctx, evalCtx, left, columnTypes, input, acc, factory, releasables,
 		)
 		if err != nil {
 			return nil, resultIdx, typs, err
@@ -2269,7 +2284,7 @@ func planProjectionExpr(
 			// Case 3: neither are constant.
 			var rightIdx int
 			input, rightIdx, typs, err = planProjectionOperators(
-				ctx, evalCtx, right, typs, input, acc, factory,
+				ctx, evalCtx, right, typs, input, acc, factory, releasables,
 			)
 			if err != nil {
 				return nil, resultIdx, nil, err
@@ -2283,6 +2298,9 @@ func planProjectionExpr(
 	}
 	if err != nil {
 		return op, resultIdx, typs, err
+	}
+	if r, ok := op.(execinfra.Releasable); ok {
+		*releasables = append(*releasables, r)
 	}
 	typs = appendOneType(typs, outputType)
 	return op, resultIdx, typs, err
@@ -2298,6 +2316,7 @@ func planLogicalProjectionOp(
 	input colexecop.Operator,
 	acc *mon.BoundAccount,
 	factory coldata.ColumnFactory,
+	releasables *[]execinfra.Releasable,
 ) (op colexecop.Operator, resultIdx int, typs []*types.T, err error) {
 	// Add a new boolean column that will store the result of the projection.
 	resultIdx = len(columnTypes)
@@ -2320,13 +2339,13 @@ func planLogicalProjectionOp(
 		colexecerror.InternalError(errors.AssertionFailedf("unexpected logical expression type %s", t.String()))
 	}
 	leftProjOpChain, leftIdx, typs, err = planProjectionOperators(
-		ctx, evalCtx, typedLeft, typs, leftFeedOp, acc, factory,
+		ctx, evalCtx, typedLeft, typs, leftFeedOp, acc, factory, releasables,
 	)
 	if err != nil {
 		return nil, resultIdx, typs, err
 	}
 	rightProjOpChain, rightIdx, typs, err = planProjectionOperators(
-		ctx, evalCtx, typedRight, typs, rightFeedOp, acc, factory,
+		ctx, evalCtx, typedRight, typs, rightFeedOp, acc, factory, releasables,
 	)
 	if err != nil {
 		return nil, resultIdx, typs, err
@@ -2366,9 +2385,10 @@ func planIsNullProjectionOp(
 	acc *mon.BoundAccount,
 	negate bool,
 	factory coldata.ColumnFactory,
+	releasables *[]execinfra.Releasable,
 ) (op colexecop.Operator, resultIdx int, typs []*types.T, err error) {
 	op, resultIdx, typs, err = planProjectionOperators(
-		ctx, evalCtx, expr, columnTypes, input, acc, factory,
+		ctx, evalCtx, expr, columnTypes, input, acc, factory, releasables,
 	)
 	if err != nil {
 		return op, resultIdx, typs, err

--- a/pkg/sql/colexec/colexecagg/aggregate_funcs.go
+++ b/pkg/sql/colexec/colexecagg/aggregate_funcs.go
@@ -221,7 +221,12 @@ func NewAggregateFuncsAlloc(
 			}
 		}
 	}
-	inputArgsConverter := colconv.NewVecToDatumConverter(len(args.InputTypes), vecIdxsToConvert)
+	var inputArgsConverter *colconv.VecToDatumConverter
+	if len(vecIdxsToConvert) > 0 {
+		// Only create the converter if we actually need to convert some vectors
+		// for the default aggregate functions.
+		inputArgsConverter = colconv.NewVecToDatumConverter(len(args.InputTypes), vecIdxsToConvert, false /* willRelease */)
+	}
 	for i, aggFn := range args.Spec.Aggregations {
 		var err error
 		switch aggFn.Func {

--- a/pkg/sql/colexec/colexecproj/BUILD.bazel
+++ b/pkg/sql/colexec/colexecproj/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//pkg/sql/colexecerror",  # keep
         "//pkg/sql/colexecop",
         "//pkg/sql/colmem",
+        "//pkg/sql/execinfra",  # keep
         "//pkg/sql/sem/tree",
         "//pkg/sql/sqltelemetry",  # keep
         "//pkg/sql/types",

--- a/pkg/sql/colexec/colexecproj/default_cmp_proj_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/default_cmp_proj_ops.eg.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexeccmp"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
@@ -27,6 +28,7 @@ type defaultCmpProjOp struct {
 }
 
 var _ colexecop.Operator = &defaultCmpProjOp{}
+var _ execinfra.Releasable = &defaultCmpProjOp{}
 
 func (d *defaultCmpProjOp) Next() coldata.Batch {
 	batch := d.Input.Next()
@@ -74,6 +76,10 @@ func (d *defaultCmpProjOp) Next() coldata.Batch {
 	return batch
 }
 
+func (d *defaultCmpProjOp) Release() {
+	d.toDatumConverter.Release()
+}
+
 type defaultCmpRConstProjOp struct {
 	projConstOpBase
 	constArg tree.Datum
@@ -84,6 +90,7 @@ type defaultCmpRConstProjOp struct {
 }
 
 var _ colexecop.Operator = &defaultCmpRConstProjOp{}
+var _ execinfra.Releasable = &defaultCmpRConstProjOp{}
 
 func (d *defaultCmpRConstProjOp) Next() coldata.Batch {
 	batch := d.Input.Next()
@@ -127,4 +134,8 @@ func (d *defaultCmpRConstProjOp) Next() coldata.Batch {
 	// the length anyway (this helps maintaining the invariant of flat bytes).
 	batch.SetLength(n)
 	return batch
+}
+
+func (d *defaultCmpRConstProjOp) Release() {
+	d.toDatumConverter.Release()
 }

--- a/pkg/sql/colexec/colexecproj/default_cmp_proj_ops_tmpl.go
+++ b/pkg/sql/colexec/colexecproj/default_cmp_proj_ops_tmpl.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexeccmp"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
@@ -44,6 +45,7 @@ type defaultCmp_KINDProjOp struct {
 }
 
 var _ colexecop.Operator = &defaultCmp_KINDProjOp{}
+var _ execinfra.Releasable = &defaultCmp_KINDProjOp{}
 
 func (d *defaultCmp_KINDProjOp) Next() coldata.Batch {
 	batch := d.Input.Next()
@@ -99,6 +101,10 @@ func (d *defaultCmp_KINDProjOp) Next() coldata.Batch {
 	// the length anyway (this helps maintaining the invariant of flat bytes).
 	batch.SetLength(n)
 	return batch
+}
+
+func (d *defaultCmp_KINDProjOp) Release() {
+	d.toDatumConverter.Release()
 }
 
 // {{end}}

--- a/pkg/sql/colexec/colexecproj/proj_const_ops_tmpl.go
+++ b/pkg/sql/colexec/colexecproj/proj_const_ops_tmpl.go
@@ -376,7 +376,7 @@ func GetProjection_CONST_SIDEConstOperator(
 			projConstOpBase:     projConstOpBase,
 			adapter:             colexeccmp.NewComparisonExprAdapter(cmpExpr, evalCtx),
 			constArg:            constArg,
-			toDatumConverter:    colconv.NewVecToDatumConverter(len(inputTypes), []int{colIdx}),
+			toDatumConverter:    colconv.NewVecToDatumConverter(len(inputTypes), []int{colIdx}, true /* willRelease */),
 			datumToVecConverter: colconv.GetDatumToPhysicalFn(outputType),
 		}, nil
 		// {{end}}

--- a/pkg/sql/colexec/colexecproj/proj_const_right_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/proj_const_right_ops.eg.go
@@ -62481,7 +62481,7 @@ func GetProjectionRConstOperator(
 			projConstOpBase:     projConstOpBase,
 			adapter:             colexeccmp.NewComparisonExprAdapter(cmpExpr, evalCtx),
 			constArg:            constArg,
-			toDatumConverter:    colconv.NewVecToDatumConverter(len(inputTypes), []int{colIdx}),
+			toDatumConverter:    colconv.NewVecToDatumConverter(len(inputTypes), []int{colIdx}, true /* willRelease */),
 			datumToVecConverter: colconv.GetDatumToPhysicalFn(outputType),
 		}, nil
 	}

--- a/pkg/sql/colexec/colexecproj/proj_non_const_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/proj_non_const_ops.eg.go
@@ -64451,7 +64451,7 @@ func GetProjectionOperator(
 		return &defaultCmpProjOp{
 			projOpBase:          projOpBase,
 			adapter:             colexeccmp.NewComparisonExprAdapter(cmpExpr, evalCtx),
-			toDatumConverter:    colconv.NewVecToDatumConverter(len(inputTypes), []int{col1Idx, col2Idx}),
+			toDatumConverter:    colconv.NewVecToDatumConverter(len(inputTypes), []int{col1Idx, col2Idx}, true /* willRelease */),
 			datumToVecConverter: colconv.GetDatumToPhysicalFn(outputType),
 		}, nil
 	}

--- a/pkg/sql/colexec/colexecproj/proj_non_const_ops_tmpl.go
+++ b/pkg/sql/colexec/colexecproj/proj_non_const_ops_tmpl.go
@@ -327,7 +327,7 @@ func GetProjectionOperator(
 		return &defaultCmpProjOp{
 			projOpBase:          projOpBase,
 			adapter:             colexeccmp.NewComparisonExprAdapter(cmpExpr, evalCtx),
-			toDatumConverter:    colconv.NewVecToDatumConverter(len(inputTypes), []int{col1Idx, col2Idx}),
+			toDatumConverter:    colconv.NewVecToDatumConverter(len(inputTypes), []int{col1Idx, col2Idx}, true /* willRelease */),
 			datumToVecConverter: colconv.GetDatumToPhysicalFn(outputType),
 		}, nil
 	}

--- a/pkg/sql/colexec/colexecsel/BUILD.bazel
+++ b/pkg/sql/colexec/colexecsel/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/sql/colexec/execgen",  # keep
         "//pkg/sql/colexecerror",  # keep
         "//pkg/sql/colexecop",
+        "//pkg/sql/execinfra",  # keep
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",  # keep
         "//pkg/util/duration",  # keep

--- a/pkg/sql/colexec/colexecsel/default_cmp_sel_ops.eg.go
+++ b/pkg/sql/colexec/colexecsel/default_cmp_sel_ops.eg.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexeccmp"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
@@ -26,6 +27,7 @@ type defaultCmpSelOp struct {
 }
 
 var _ colexecop.Operator = &defaultCmpSelOp{}
+var _ execinfra.Releasable = &defaultCmpSelOp{}
 
 func (d *defaultCmpSelOp) Next() coldata.Batch {
 	for {
@@ -69,6 +71,10 @@ func (d *defaultCmpSelOp) Next() coldata.Batch {
 	}
 }
 
+func (d *defaultCmpSelOp) Release() {
+	d.toDatumConverter.Release()
+}
+
 type defaultCmpConstSelOp struct {
 	selConstOpBase
 	constArg tree.Datum
@@ -78,6 +84,7 @@ type defaultCmpConstSelOp struct {
 }
 
 var _ colexecop.Operator = &defaultCmpConstSelOp{}
+var _ execinfra.Releasable = &defaultCmpConstSelOp{}
 
 func (d *defaultCmpConstSelOp) Next() coldata.Batch {
 	for {
@@ -117,4 +124,8 @@ func (d *defaultCmpConstSelOp) Next() coldata.Batch {
 			return batch
 		}
 	}
+}
+
+func (d *defaultCmpConstSelOp) Release() {
+	d.toDatumConverter.Release()
 }

--- a/pkg/sql/colexec/colexecsel/default_cmp_sel_ops_tmpl.go
+++ b/pkg/sql/colexec/colexecsel/default_cmp_sel_ops_tmpl.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexeccmp"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
@@ -43,6 +44,7 @@ type defaultCmp_KINDSelOp struct {
 }
 
 var _ colexecop.Operator = &defaultCmp_KINDSelOp{}
+var _ execinfra.Releasable = &defaultCmp_KINDSelOp{}
 
 func (d *defaultCmp_KINDSelOp) Next() coldata.Batch {
 	for {
@@ -94,6 +96,10 @@ func (d *defaultCmp_KINDSelOp) Next() coldata.Batch {
 			return batch
 		}
 	}
+}
+
+func (d *defaultCmp_KINDSelOp) Release() {
+	d.toDatumConverter.Release()
 }
 
 // {{end}}

--- a/pkg/sql/colexec/colexecsel/selection_ops.eg.go
+++ b/pkg/sql/colexec/colexecsel/selection_ops.eg.go
@@ -60658,7 +60658,7 @@ func GetSelectionConstOperator(
 		selConstOpBase:   selConstOpBase,
 		adapter:          colexeccmp.NewComparisonExprAdapter(cmpExpr, evalCtx),
 		constArg:         constArg,
-		toDatumConverter: colconv.NewVecToDatumConverter(len(inputTypes), []int{colIdx}),
+		toDatumConverter: colconv.NewVecToDatumConverter(len(inputTypes), []int{colIdx}, true /* willRelease */),
 	}, nil
 }
 
@@ -61997,6 +61997,6 @@ func GetSelectionOperator(
 	return &defaultCmpSelOp{
 		selOpBase:        selOpBase,
 		adapter:          colexeccmp.NewComparisonExprAdapter(cmpExpr, evalCtx),
-		toDatumConverter: colconv.NewVecToDatumConverter(len(inputTypes), []int{col1Idx, col2Idx}),
+		toDatumConverter: colconv.NewVecToDatumConverter(len(inputTypes), []int{col1Idx, col2Idx}, true /* willRelease */),
 	}, nil
 }

--- a/pkg/sql/colexec/colexecsel/selection_ops_tmpl.go
+++ b/pkg/sql/colexec/colexecsel/selection_ops_tmpl.go
@@ -331,7 +331,7 @@ func GetSelectionConstOperator(
 		selConstOpBase:   selConstOpBase,
 		adapter:          colexeccmp.NewComparisonExprAdapter(cmpExpr, evalCtx),
 		constArg:         constArg,
-		toDatumConverter: colconv.NewVecToDatumConverter(len(inputTypes), []int{colIdx}),
+		toDatumConverter: colconv.NewVecToDatumConverter(len(inputTypes), []int{colIdx}, true /* willRelease */),
 	}, nil
 }
 
@@ -386,6 +386,6 @@ func GetSelectionOperator(
 	return &defaultCmpSelOp{
 		selOpBase:        selOpBase,
 		adapter:          colexeccmp.NewComparisonExprAdapter(cmpExpr, evalCtx),
-		toDatumConverter: colconv.NewVecToDatumConverter(len(inputTypes), []int{col1Idx, col2Idx}),
+		toDatumConverter: colconv.NewVecToDatumConverter(len(inputTypes), []int{col1Idx, col2Idx}, true /* willRelease */),
 	}, nil
 }


### PR DESCRIPTION
`colconv.NewVecToDatumConverter` previously would always get the
converter from the corresponding `sync.Pool`, yet it was almost never
released back to the pool (the only exception is the materializer). This
is suboptimal because it defeats the purpose of reusing the objects in
order to reduce allocations. This commit augments the contructor method
with `willRelease` boolean argument indicating the caller's intention of
releasing or not the converter (in the latter case a fresh struct is
allocated). All callers have been audited, and in most cases they now
properly release the converter. This required a bit of plumbing in the
planning code.

Release note: None