### PR TITLE
release-21.1: build: save roachtest stats for all release branches

### DIFF
--- a/build/teamcity-nightly-roachtest.sh
+++ b/build/teamcity-nightly-roachtest.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
+source "$(dirname "${0}")/teamcity-support.sh"
+
 # Entry point for the nightly roachtests. These are run from CI and require
 # appropriate secrets for the ${CLOUD} parameter (along with other things,
 # apologies, you're going to have to dig around for them below or even better


### PR DESCRIPTION
Holding off for 21.1.0.

Backport:
  * 1/1 commits from "build: save roachtest stats for all release branches" (#64209)
  * 1/1 commits from "build: fix teamcity-nightly-roachtest.sh" (#64380)

Please see individual PRs for details.

/cc @cockroachdb/release
