### PR TITLE
roachtest: unskip acceptance/version-upgrade

### DIFF
--- a/pkg/cmd/roachtest/acceptance.go
+++ b/pkg/cmd/roachtest/acceptance.go
@@ -53,7 +53,6 @@ func registerAcceptance(r *testRegistry) {
 				// to head after 19.2 fails.
 				minVersion: "v19.2.0",
 				timeout:    30 * time.Minute,
-				skip:       "https://github.com/cockroachdb/cockroach/issues/64491",
 			},
 		},
 		OwnerServer: {


### PR DESCRIPTION
This test should pass again, now that #64610 is in.

Fixes #64491.

Release note: None
