### PR TITLE
tabledesc: prevent panic when removing constraint from Checks slice

### DIFF
--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -1572,6 +1572,7 @@ func (desc *Mutable) MakeMutationComplete(m descpb.DescriptorMutation) error {
 				for i, c := range desc.Checks {
 					if c.Name == t.Constraint.Check.Name {
 						desc.Checks = append(desc.Checks[:i], desc.Checks[i+1:]...)
+						break
 					}
 				}
 				col, err := desc.FindColumnWithID(t.Constraint.NotNullColumn)


### PR DESCRIPTION
Recently, a run of the TestRandomSyntaxSchemaChangeColumn test failed
with a panic in tabledesc.MakeMutationComplete, see #63944. The panic
was triggered by removing multiple elements from the Checks slice in the
descriptor. While the underlying issue of _how_ this slice could
possibly contain two constraints sharing the same name has not yet been
resolved, deleting only the first constraint matching the target name
will prevent future panics and perhaps help diagnose the underlying
issue.

Release note: None