### PR TITLE
roachtest,TEAMS: add cockroachdb/kv-triage handle

### DIFF
--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -31,6 +31,7 @@ cockroachdb/sql-observability:
   aliases: [cockroachdb/sql-api-prs]
   triage_column_id: 12618343
 cockroachdb/kv:
+  aliases: [cockroachdb/kv-triage]
   triage_column_id: 3550674
 cockroachdb/geospatial:
   triage_column_id: 9487269

--- a/pkg/cmd/roachtest/test_registry.go
+++ b/pkg/cmd/roachtest/test_registry.go
@@ -75,7 +75,7 @@ var roachtestOwners = map[Owner]OwnerMetadata{
 	OwnerCDC: {SlackRoom: `cdc`, Mention: []string{`@cockroachdb/cdc`},
 		TriageColumnID: 3570120,
 	},
-	OwnerKV: {SlackRoom: `kv`, Mention: []string{`@cockroachdb/kv`},
+	OwnerKV: {SlackRoom: `kv`, Mention: []string{`@cockroachdb/kv-triage`},
 		TriageColumnID: 3550674,
 	},
 	// This is an alias for the KV team.


### PR DESCRIPTION
This will ping @cockroachdb/kv-triage on roachtest-filed issues. It
won't yet do the same for unit tests but we'll add that at some point.

Release note: None
