### PR TITLE
release-20.2: restore performance consistency improvements

### DIFF
--- a/pkg/ccl/backupccl/import_spans_test.go
+++ b/pkg/ccl/backupccl/import_spans_test.go
@@ -9,11 +9,12 @@
 package backupccl
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
-	roachpb "github.com/cockroachdb/cockroach/pkg/roachpb"
-	hlc "github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/stretchr/testify/require"
@@ -39,8 +40,8 @@ func makeBackupManifest(
 ) BackupManifest {
 	// We only care about the files' span.
 	files := make([]BackupManifest_File, 0)
-	for _, span := range append(spans, introducedSpans...) {
-		files = append(files, BackupManifest_File{Span: span})
+	for i, span := range append(spans, introducedSpans...) {
+		files = append(files, BackupManifest_File{Span: span, Path: fmt.Sprintf("%d.sst", i)})
 	}
 
 	return BackupManifest{

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -266,6 +266,17 @@ rangeLoop:
 					return nil, hlc.Timestamp{}, err
 				}
 			}
+			if len(files) == 0 {
+				// There may be import entries that refer to no data, and hence
+				// no files. These are caused because file spans start at a
+				// specific key. E.g. consider the first file backing up data
+				// from table 51. It will cover span ‹/Table/51/1/0/0› -
+				// ‹/Table/51/1/3273›. When merged with the backup span:
+				// ‹/Table/51› - ‹/Table/52›, we get an empty span with no
+				// files: ‹/Table/51› - ‹/Table/51/1/0/0›. We should ignore
+				// these to avoid thrashing during restore's split and scatter.
+				continue
+			}
 			// If needed is false, we have data backed up that is not necessary
 			// for this restore. Skip it.
 			requestEntries = append(requestEntries, execinfrapb.RestoreSpanEntry{
@@ -570,6 +581,10 @@ func restore(
 		highWaterMark, errOnMissingRange)
 	if err != nil {
 		return emptyRowCount, errors.Wrapf(err, "making import requests for %d backups", len(backupManifests))
+	}
+	if len(importSpans) == 0 {
+		// There are no files to restore.
+		return emptyRowCount, nil
 	}
 
 	for i := range importSpans {

--- a/pkg/ccl/backupccl/restore_processor_planning.go
+++ b/pkg/ccl/backupccl/restore_processor_planning.go
@@ -187,7 +187,11 @@ func distRestore(
 
 	for _, srcProc := range splitAndScatterProcs {
 		slot := 0
-		for _, destProc := range restoreDataProcs {
+		for _, destNode := range nodes {
+			// Streams were added to the range router in the same order that the
+			// nodes appeared in `nodes`. Make sure that the `slot`s here are
+			// ordered the same way.
+			destProc := restoreDataProcs[destNode]
 			p.Streams = append(p.Streams, physicalplan.Stream{
 				SourceProcessor:  srcProc,
 				SourceRouterSlot: slot,

--- a/pkg/ccl/backupccl/split_and_scatter_processor.go
+++ b/pkg/ccl/backupccl/split_and_scatter_processor.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -31,42 +32,89 @@ import (
 )
 
 type splitAndScatterer interface {
-	// splitAndScatterSpan issues a split request at a given key and then scatters
-	// the range around the cluster. It returns the node ID of the leaseholder of
-	// the span after the scatter.
-	splitAndScatterKey(ctx context.Context, db *kv.DB, kr *storageccl.KeyRewriter, key roachpb.Key, randomizeLeases bool) (roachpb.NodeID, error)
+	// split issues a split request at the given key, which may be rewritten to
+	// the RESTORE keyspace.
+	split(ctx context.Context, codec keys.SQLCodec, splitKey roachpb.Key) error
+	// scatter issues a scatter request at the given key. It returns the node ID
+	// of where the range was scattered to.
+	scatter(ctx context.Context, codec keys.SQLCodec, scatterKey roachpb.Key) (roachpb.NodeID, error)
+}
+
+type noopSplitAndScatterer struct{}
+
+var _ splitAndScatterer = noopSplitAndScatterer{}
+
+// split implements splitAndScatterer.
+func (n noopSplitAndScatterer) split(_ context.Context, _ keys.SQLCodec, _ roachpb.Key) error {
+	return nil
+}
+
+// scatter implements splitAndScatterer.
+func (n noopSplitAndScatterer) scatter(
+	_ context.Context, _ keys.SQLCodec, _ roachpb.Key,
+) (roachpb.NodeID, error) {
+	return 0, nil
 }
 
 // dbSplitAndScatter is the production implementation of this processor's
-// scatterer. It actually issues the split and scatter requests for KV. This is
-// mocked out in some tests.
-type dbSplitAndScatterer struct{}
+// scatterer. It actually issues the split and scatter requests against the KV
+// layer.
+type dbSplitAndScatterer struct {
+	db *kv.DB
+	kr *storageccl.KeyRewriter
+}
 
-// splitAndScatterKey implements the splitAndScatterer interface.
-// It splits and scatters a span specified by a given key, and returns the node
-// to which the span was scattered. If the destination node could not be
-// determined, node ID of 0 is returned.
-func (s dbSplitAndScatterer) splitAndScatterKey(
-	ctx context.Context, db *kv.DB, kr *storageccl.KeyRewriter, key roachpb.Key, randomizeLeases bool,
+var _ splitAndScatterer = dbSplitAndScatterer{}
+
+func makeSplitAndScatterer(db *kv.DB, kr *storageccl.KeyRewriter) splitAndScatterer {
+	return dbSplitAndScatterer{db: db, kr: kr}
+}
+
+// split implements splitAndScatterer.
+func (s dbSplitAndScatterer) split(
+	ctx context.Context, codec keys.SQLCodec, splitKey roachpb.Key,
+) error {
+	if s.kr == nil {
+		return errors.AssertionFailedf("KeyRewriter was not set when expected to be")
+	}
+	if s.db == nil {
+		return errors.AssertionFailedf("split and scatterer's database was not set when expected")
+	}
+
+	expirationTime := s.db.Clock().Now().Add(time.Hour.Nanoseconds(), 0)
+	newSplitKey, err := rewriteBackupSpanKey(s.kr, splitKey)
+	if err != nil {
+		return err
+	}
+	log.VEventf(ctx, 1, "presplitting new key %+v", newSplitKey)
+	if err := s.db.AdminSplit(ctx, newSplitKey, expirationTime); err != nil {
+		return errors.Wrapf(err, "splitting key %s", newSplitKey)
+	}
+
+	return nil
+}
+
+// scatter implements splitAndScatterer.
+func (s dbSplitAndScatterer) scatter(
+	ctx context.Context, codec keys.SQLCodec, scatterKey roachpb.Key,
 ) (roachpb.NodeID, error) {
-	expirationTime := db.Clock().Now().Add(time.Hour.Nanoseconds(), 0)
-	newSpanKey, err := rewriteBackupSpanKey(kr, key)
+	if s.kr == nil {
+		return 0, errors.AssertionFailedf("KeyRewriter was not set when expected to be")
+	}
+	if s.db == nil {
+		return 0, errors.AssertionFailedf("split and scatterer's database was not set when expected")
+	}
+
+	newScatterKey, err := rewriteBackupSpanKey(s.kr, scatterKey)
 	if err != nil {
 		return 0, err
 	}
 
-	// TODO(pbardea): Really, this should be splitting the Key of the _next_
-	// entry.
-	log.VEventf(ctx, 1, "presplitting new key %+v", newSpanKey)
-	if err := db.AdminSplit(ctx, newSpanKey, expirationTime); err != nil {
-		return 0, errors.Wrapf(err, "splitting key %s", newSpanKey)
-	}
-
-	log.VEventf(ctx, 1, "scattering new key %+v", newSpanKey)
+	log.VEventf(ctx, 1, "scattering new key %+v", newScatterKey)
 	req := &roachpb.AdminScatterRequest{
 		RequestHeader: roachpb.RequestHeaderFromSpan(roachpb.Span{
-			Key:    newSpanKey,
-			EndKey: newSpanKey.Next(),
+			Key:    newScatterKey,
+			EndKey: newScatterKey.Next(),
 		}),
 		// This is a bit of a hack, but it seems to be an effective one (see #36665
 		// for graphs). As of the commit that added this, scatter is not very good
@@ -75,10 +123,10 @@ func (s dbSplitAndScatterer) splitAndScatterKey(
 		// much better and 2) scatter has to operate by balancing leases for all
 		// ranges in a cluster, but in RESTORE, we really just want it to be
 		// balancing the span being restored into.
-		RandomizeLeases: randomizeLeases,
+		RandomizeLeases: true,
 	}
 
-	res, pErr := kv.SendWrapped(ctx, db.NonTransactionalSender(), req)
+	res, pErr := kv.SendWrapped(ctx, s.db.NonTransactionalSender(), req)
 	if pErr != nil {
 		// TODO(pbardea): Unfortunately, Scatter is still too unreliable to
 		// fail the RESTORE when Scatter fails. I'm uncomfortable that
@@ -86,7 +134,7 @@ func (s dbSplitAndScatterer) splitAndScatterKey(
 		// but on the bright side, it doesn't affect correctness, only
 		// throughput.
 		log.Errorf(ctx, "failed to scatter span [%s,%s): %+v",
-			newSpanKey, newSpanKey.Next(), pErr.GoError())
+			newScatterKey, newScatterKey.Next(), pErr.GoError())
 		return 0, nil
 	}
 
@@ -141,11 +189,18 @@ func newSplitAndScatterProcessor(
 	spec execinfrapb.SplitAndScatterSpec,
 	output execinfra.RowReceiver,
 ) (execinfra.Processor, error) {
+	db := flowCtx.Cfg.DB
+	kr, err := storageccl.MakeKeyRewriterFromRekeys(spec.Rekeys)
+	if err != nil {
+		return nil, err
+	}
+
+	var scatterer splitAndScatterer = makeSplitAndScatterer(db, kr)
 	ssp := &splitAndScatterProcessor{
 		flowCtx:   flowCtx,
 		spec:      spec,
 		output:    output,
-		scatterer: dbSplitAndScatterer{},
+		scatterer: scatterer,
 	}
 	return ssp, nil
 }
@@ -153,6 +208,13 @@ func newSplitAndScatterProcessor(
 type entryNode struct {
 	entry execinfrapb.RestoreSpanEntry
 	node  roachpb.NodeID
+}
+
+// scatteredChunk is the entries of a chunk of entries to process along with the
+// node the chunk was scattered to.
+type scatteredChunk struct {
+	destination roachpb.NodeID
+	entries     []execinfrapb.RestoreSpanEntry
 }
 
 // Run implements the execinfra.Processor interface.
@@ -221,25 +283,36 @@ func runSplitAndScatter(
 	doneScatterCh chan entryNode,
 ) error {
 	g := ctxgroup.WithContext(ctx)
-	db := flowCtx.Cfg.DB
-	kr, err := storageccl.MakeKeyRewriterFromRekeys(spec.Rekeys)
-	if err != nil {
-		return err
-	}
 
-	importSpanChunksCh := make(chan []execinfrapb.RestoreSpanEntry)
+	importSpanChunksCh := make(chan scatteredChunk)
 	g.GoCtx(func(ctx context.Context) error {
+		// Chunks' leaseholders should be randomly placed throughout the
+		// cluster.
 		defer close(importSpanChunksCh)
-		for _, importSpanChunk := range spec.Chunks {
-			_, err := scatterer.splitAndScatterKey(ctx, db, kr, importSpanChunk.Entries[0].Span.Key, true /* randomizeLeases */)
+		for i, importSpanChunk := range spec.Chunks {
+			scatterKey := importSpanChunk.Entries[0].Span.Key
+			if i+1 < len(spec.Chunks) {
+				// Split at the start of the next chunk, to partition off a
+				// prefix of the space to scatter.
+				splitKey := spec.Chunks[i+1].Entries[0].Span.Key
+				if err := scatterer.split(ctx, flowCtx.Codec(), splitKey); err != nil {
+					return err
+				}
+			}
+			chunkDestination, err := scatterer.scatter(ctx, flowCtx.Codec(), scatterKey)
 			if err != nil {
 				return err
+			}
+
+			sc := scatteredChunk{
+				destination: chunkDestination,
+				entries:     importSpanChunk.Entries,
 			}
 
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
-			case importSpanChunksCh <- importSpanChunk.Entries:
+			case importSpanChunksCh <- sc:
 			}
 		}
 		return nil
@@ -251,17 +324,23 @@ func runSplitAndScatter(
 	for worker := 0; worker < splitScatterWorkers; worker++ {
 		g.GoCtx(func(ctx context.Context) error {
 			for importSpanChunk := range importSpanChunksCh {
-				log.Infof(ctx, "processing a chunk")
-				for _, importSpan := range importSpanChunk {
-					log.Infof(ctx, "processing a span [%s,%s)", importSpan.Span.Key, importSpan.Span.EndKey)
-					destination, err := scatterer.splitAndScatterKey(ctx, db, kr, importSpan.Span.Key, false /* randomizeLeases */)
-					if err != nil {
-						return err
+				chunkDestination := importSpanChunk.destination
+				for i, importEntry := range importSpanChunk.entries {
+					nextChunkIdx := i + 1
+
+					log.VInfof(ctx, 2, "processing a span [%s,%s)", importEntry.Span.Key, importEntry.Span.EndKey)
+					var splitKey roachpb.Key
+					if nextChunkIdx < len(importSpanChunk.entries) {
+						// Split at the next entry.
+						splitKey = importSpanChunk.entries[nextChunkIdx].Span.Key
+						if err := scatterer.split(ctx, flowCtx.Codec(), splitKey); err != nil {
+							return err
+						}
 					}
 
 					scatteredEntry := entryNode{
-						entry: importSpan,
-						node:  destination,
+						entry: importEntry,
+						node:  chunkDestination,
 					}
 
 					select {

--- a/pkg/ccl/backupccl/split_and_scatter_processor_test.go
+++ b/pkg/ccl/backupccl/split_and_scatter_processor_test.go
@@ -15,11 +15,10 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
-	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	descpb "github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowflow"
@@ -37,16 +36,22 @@ type mockScatterer struct {
 	numNodes int
 }
 
+var _ splitAndScatterer = &mockScatterer{}
+
 // This mock implementation of the split and scatterer simulates a scattering of
 // ranges.
-func (s *mockScatterer) splitAndScatterKey(
-	_ context.Context, _ *kv.DB, _ *storageccl.KeyRewriter, _ roachpb.Key, _ bool,
+func (s *mockScatterer) scatter(
+	_ context.Context, _ keys.SQLCodec, _ roachpb.Key,
 ) (roachpb.NodeID, error) {
 	s.Lock()
 	defer s.Unlock()
 	targetNodeID := roachpb.NodeID(s.curNode + 1)
 	s.curNode = (s.curNode + 1) % s.numNodes
 	return targetNodeID, nil
+}
+
+func (s *mockScatterer) split(_ context.Context, _ keys.SQLCodec, _ roachpb.Key) error {
+	return nil
 }
 
 // TestSplitAndScatterProcessor does not test the underlying split and scatter
@@ -61,6 +66,7 @@ func TestSplitAndScatterProcessor(t *testing.T) {
 	kvDB := tc.Server(0).DB()
 
 	testCases := []struct {
+		name     string
 		procSpec execinfrapb.SplitAndScatterSpec
 		// The number of output streams.
 		numStreams int
@@ -72,40 +78,9 @@ func TestSplitAndScatterProcessor(t *testing.T) {
 		// expectedDistribution is a mapping from stream to the expected number of
 		// rows we expect to receive on this stream.
 		expectedDistribution map[int]int
-		// If there is more than one chunk in the test case, we may not be able to
-		// deterministically determine where each row ends up since chunks are
-		// scattered in parallel with the entries, but we can expect a range of
-		// distributions. For an example, see the second test case below.
-		allowedDelta int
 	}{
 		{
-			procSpec: execinfrapb.SplitAndScatterSpec{
-				Chunks: []execinfrapb.SplitAndScatterSpec_RestoreEntryChunk{
-					{
-						Entries: []execinfrapb.RestoreSpanEntry{
-							{Span: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")}},
-							{Span: roachpb.Span{Key: roachpb.Key("c"), EndKey: roachpb.Key("d")}},
-							{Span: roachpb.Span{Key: roachpb.Key("e"), EndKey: roachpb.Key("f")}},
-							{Span: roachpb.Span{Key: roachpb.Key("g"), EndKey: roachpb.Key("h")}},
-							{Span: roachpb.Span{Key: roachpb.Key("i"), EndKey: roachpb.Key("j")}},
-							{Span: roachpb.Span{Key: roachpb.Key("k"), EndKey: roachpb.Key("l")}},
-							{Span: roachpb.Span{Key: roachpb.Key("m"), EndKey: roachpb.Key("n")}},
-						},
-					},
-				},
-			},
-			numStreams: 4,
-			numNodes:   4,
-			// Expect a round-robin distribution, but the first scatter request will
-			// go to scattering the chunk.
-			expectedDistribution: map[int]int{
-				0: 1, // Chunk 1 (not counted), Entry 4
-				1: 2, // Entry 1, Entry 5
-				2: 2, // Entry 2, Entry 6
-				3: 2, // Entry 3, Entry 7
-			},
-		},
-		{
+			name: "chunks-roundrobin",
 			procSpec: execinfrapb.SplitAndScatterSpec{
 				Chunks: []execinfrapb.SplitAndScatterSpec_RestoreEntryChunk{
 					{
@@ -131,31 +106,54 @@ func TestSplitAndScatterProcessor(t *testing.T) {
 			numStreams: 4,
 			numNodes:   4,
 			expectedDistribution: map[int]int{
-				0: 2,
-				1: 2,
-				2: 2,
-				3: 2,
+				0: 7, // all entries from chunk 1
+				1: 3, // all entries from chunk 2
+				2: 0,
+				3: 0,
 			},
-			// Allow each stream to have received 1-3 rows.
-			// We have 2 chunks and 10 entries across 4 streams, we expect every
-			// stream to get between 1 and 3 entries. We have 12 scatters, when
-			// distributed in a round robin evenly produces the distribution (3,3,3,3)
-			// and the chunk scatters are not counted, so we'll see 2 streams only
-			// receive 2 rows or 1 stream only receive 1 row, rather than all 3.
-			allowedDelta: 1,
 		},
 		{
+			name: "more-chunks-than-processors-with-redirect",
 			procSpec: execinfrapb.SplitAndScatterSpec{
 				Chunks: []execinfrapb.SplitAndScatterSpec_RestoreEntryChunk{
 					{
 						Entries: []execinfrapb.RestoreSpanEntry{
 							{Span: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")}},
+						},
+					},
+					{
+						Entries: []execinfrapb.RestoreSpanEntry{
+							{Span: roachpb.Span{Key: roachpb.Key("b"), EndKey: roachpb.Key("c")}},
+						},
+					},
+					{
+						Entries: []execinfrapb.RestoreSpanEntry{
 							{Span: roachpb.Span{Key: roachpb.Key("c"), EndKey: roachpb.Key("d")}},
+						},
+					},
+					{
+						Entries: []execinfrapb.RestoreSpanEntry{
+							{Span: roachpb.Span{Key: roachpb.Key("d"), EndKey: roachpb.Key("e")}},
+						},
+					},
+					{
+						Entries: []execinfrapb.RestoreSpanEntry{
 							{Span: roachpb.Span{Key: roachpb.Key("e"), EndKey: roachpb.Key("f")}},
+						},
+					},
+					{
+						Entries: []execinfrapb.RestoreSpanEntry{
+							{Span: roachpb.Span{Key: roachpb.Key("f"), EndKey: roachpb.Key("g")}},
+						},
+					},
+					{
+						Entries: []execinfrapb.RestoreSpanEntry{
 							{Span: roachpb.Span{Key: roachpb.Key("g"), EndKey: roachpb.Key("h")}},
-							{Span: roachpb.Span{Key: roachpb.Key("i"), EndKey: roachpb.Key("j")}},
-							{Span: roachpb.Span{Key: roachpb.Key("k"), EndKey: roachpb.Key("l")}},
-							{Span: roachpb.Span{Key: roachpb.Key("m"), EndKey: roachpb.Key("n")}},
+						},
+					},
+					{
+						Entries: []execinfrapb.RestoreSpanEntry{
+							{Span: roachpb.Span{Key: roachpb.Key("h"), EndKey: roachpb.Key("i")}},
 						},
 					},
 				},
@@ -169,39 +167,11 @@ func TestSplitAndScatterProcessor(t *testing.T) {
 			// to plan a specific processor on a node (perhaps due to incompatible
 			// distsql versions).
 			expectedDistribution: map[int]int{
-				0: 2, // Chunk (doesn't emit a row), Entry 4 (redirected here), Entry 5
-				1: 2, // Entry 1, Entry 6
-				2: 2, // Entry 2, Entry 7
-				3: 1, // Entry 3
-				// 4: 0 // Entry 4 gets redirected to stream 0 since stream 4 does not exist.
-			},
-		},
-		{
-			procSpec: execinfrapb.SplitAndScatterSpec{
-				Chunks: []execinfrapb.SplitAndScatterSpec_RestoreEntryChunk{
-					{
-						Entries: []execinfrapb.RestoreSpanEntry{
-							{Span: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")}},
-							{Span: roachpb.Span{Key: roachpb.Key("c"), EndKey: roachpb.Key("d")}},
-							{Span: roachpb.Span{Key: roachpb.Key("e"), EndKey: roachpb.Key("f")}},
-							{Span: roachpb.Span{Key: roachpb.Key("g"), EndKey: roachpb.Key("h")}},
-							{Span: roachpb.Span{Key: roachpb.Key("i"), EndKey: roachpb.Key("j")}},
-							{Span: roachpb.Span{Key: roachpb.Key("k"), EndKey: roachpb.Key("l")}},
-							{Span: roachpb.Span{Key: roachpb.Key("m"), EndKey: roachpb.Key("n")}},
-						},
-					},
-				},
-			},
-			numStreams: 4,
-			numNodes:   3,
-			// Expect a round-robin distribution, but the first scatter request will
-			// go to scattering the chunk. We also expect the last stream to get no
-			// entries.
-			expectedDistribution: map[int]int{
-				0: 2, // Chunk (doesn't emit a row), Entry 3, Entry 6
-				1: 3, // Entry 1, Entry 4, Entry 7
-				2: 2, // Entry 2, Entry 5
-				3: 0, // No scatterings to this stream, since we only have 3 nodes.
+				0: 3, // Entry 1, Entry 5 (redirected here), Entry 6
+				1: 2, // Entry 2, Entry 7
+				2: 2, // Entry 3, Entry 8
+				3: 1, // Entry 4
+				// 4: 0 // Entry 5 gets redirected to stream 0 since stream 4 does not exist.
 			},
 		},
 	}
@@ -209,7 +179,11 @@ func TestSplitAndScatterProcessor(t *testing.T) {
 	ctx := context.Background()
 
 	for _, c := range testCases {
-		t.Run(fmt.Sprintf("%d-streams/%d-chunks", c.numStreams, len(c.procSpec.Chunks)), func(t *testing.T) {
+		testName := c.name
+		if len(testName) == 0 {
+			testName = fmt.Sprintf("%d-streams/%d-chunks", c.numStreams, len(c.procSpec.Chunks))
+		}
+		t.Run(testName, func(t *testing.T) {
 			defaultStream := int32(0)
 			rangeRouterSpec := execinfrapb.OutputRouterSpec_RangeRouterSpec{
 				Encodings: []execinfrapb.OutputRouterSpec_RangeRouterSpec_ColumnEncoding{
@@ -302,7 +276,7 @@ func TestSplitAndScatterProcessor(t *testing.T) {
 					streamDistribution[streamID]++
 				}
 			}
-			require.InDeltaMapValues(t, c.expectedDistribution, streamDistribution, float64(c.allowedDelta))
+			require.Equal(t, c.expectedDistribution, streamDistribution)
 
 			// Check that the number of entries that we receive is the same as the
 			// number we specified.


### PR DESCRIPTION
Backport:
  * 2/2 commits from "backupccl: rework split and scatter mechanism" (#63471)
  * 1/1 commits from "backupccl: fix a bug in routing scattered ranges" (#63875)
  * 1/1 commits from "backupccl: create more chunks on larger clusters" (#64067)

Please see individual PRs for details.

/cc @cockroachdb/release

Backport wasn't 100% clean, but the diff is mainly around codec handling.