### PR TITLE
sql: fix error on ALTER/DROP TYPE on builtin type

### DIFF
--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -551,18 +551,6 @@ func (tc *Collection) GetObjectDesc(
 	); isVirtual || err != nil {
 		return desc, err
 	}
-	// Resolve type aliases which are usually available in the PostgreSQL as an extension
-	// on the public schema.
-	// TODO(ajwerner): Pull this underneath type resolution.
-	if schema == tree.PublicSchema && flags.DesiredObjectKind == tree.TypeObject {
-		if alias, ok := types.PublicSchemaAliases[object]; ok {
-			if flags.RequireMutable {
-				return nil, errors.AssertionFailedf(
-					"cannot use mutable descriptor of aliased type %s.%s", schema, object)
-			}
-			return typedesc.MakeSimpleAlias(alias, keys.PublicSchemaID), nil
-		}
-	}
 	// Fall back to physical descriptor access.
 	switch flags.DesiredObjectKind {
 	case tree.TypeObject:

--- a/pkg/sql/logictest/testdata/logic_test/alter_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_type
@@ -619,3 +619,19 @@ ALTER TYPE typ_64101 DROP VALUE 'a'
 statement error could not remove enum value "b" as it is being used by table "test.public.t2_64101"
 ALTER TYPE typ_64101 DROP VALUE 'b'
 
+subtest regression_64398
+
+statement error pgcode 42809 type "geometry" is a built-in type
+ALTER TYPE sc64398.geometry RENAME TO bar
+
+statement error pgcode 42809 type "geometry" is a built-in type
+ALTER TYPE sc64398.public.geometry RENAME TO bar
+
+statement ok
+CREATE SCHEMA sc64398;
+
+statement ok
+CREATE TYPE sc64398.geometry AS ENUM()
+
+statement ok
+ALTER TYPE sc64398.geometry RENAME TO bar


### PR DESCRIPTION
Previously, an assertion failure would be raised when executing
a statement along the lines of:

    ALTER TYPE foo.GEOMETRY RENAME TO bar

The name GEOMETRY is one of a handful of builtin types that warrant
special treatment during name resolution. This commit instead causes
a pgerror to be raised when attempting to mutate a builtin type.

Fixes #64398

Release note: None