### PR TITLE
changefeedccl: support avro encoding for collated strings

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -195,5 +195,6 @@ go_test(
         "@com_github_shopify_sarama//:sarama",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@org_golang_x_text//collate",
     ],
 )

--- a/pkg/ccl/changefeedccl/avro.go
+++ b/pkg/ccl/changefeedccl/avro.go
@@ -296,6 +296,16 @@ func typeToAvroSchema(typ *types.T, reuseMap bool) (*avroSchemaField, error) {
 				return tree.NewDString(x.(string)), nil
 			},
 		)
+	case types.CollatedStringFamily:
+		setNullable(
+			avroSchemaString,
+			func(d tree.Datum) (interface{}, error) {
+				return d.(*tree.DCollatedString).Contents, nil
+			},
+			func(x interface{}) (tree.Datum, error) {
+				return tree.NewDCollatedString(x.(string), typ.Locale(), &tree.CollationEnvironment{})
+			},
+		)
 	case types.BytesFamily:
 		setNullable(
 			avroSchemaBytes,

--- a/pkg/ccl/changefeedccl/avro_test.go
+++ b/pkg/ccl/changefeedccl/avro_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil/pgdate"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/text/collate"
 )
 
 func parseTableDesc(createTableStmt string) (catalog.TableDescriptor, error) {
@@ -247,8 +248,7 @@ func TestAvroSchema(t *testing.T) {
 		case types.AnyFamily, types.OidFamily, types.TupleFamily:
 			// These aren't expected to be needed for changefeeds.
 			return true
-		case types.IntervalFamily, types.BitFamily,
-			types.CollatedStringFamily:
+		case types.IntervalFamily, types.BitFamily:
 			// Implement these as customer demand dictates.
 			return true
 		case types.ArrayFamily:
@@ -262,11 +262,24 @@ func TestAvroSchema(t *testing.T) {
 		return !randgen.IsLegalColumnType(typ)
 	}
 
-	// Generate a test for each column type with a random datum of that type.
+	typesToTest := make([]*types.T, 0, 256)
+
 	for _, typ := range types.OidToType {
 		if skipType(typ) {
 			continue
 		}
+		typesToTest = append(typesToTest, typ)
+		switch typ.Family() {
+		case types.StringFamily:
+			collationTags := collate.Supported()
+			randCollationTag := collationTags[rand.Intn(len(collationTags))]
+			collatedType := types.MakeCollatedString(typ, randCollationTag.String())
+			typesToTest = append(typesToTest, collatedType)
+		}
+	}
+
+	// Generate a test for each column type with a random datum of that type.
+	for _, typ := range typesToTest {
 		var datum tree.Datum
 		datum, typ = overrideRandGen(typ)
 		if datum == nil {
@@ -352,27 +365,28 @@ func TestAvroSchema(t *testing.T) {
 	// reference.
 	t.Run("type_goldens", func(t *testing.T) {
 		goldens := map[string]string{
-			`BOOL`:         `["null","boolean"]`,
-			`BOOL[]`:       `["null",{"type":"array","items":["null","boolean"]}]`,
-			`BOX2D`:        `["null","string"]`,
-			`BYTES`:        `["null","bytes"]`,
-			`DATE`:         `["null",{"type":"int","logicalType":"date"}]`,
-			`FLOAT8`:       `["null","double"]`,
-			`GEOGRAPHY`:    `["null","bytes"]`,
-			`GEOMETRY`:     `["null","bytes"]`,
-			`INET`:         `["null","string"]`,
-			`INT8`:         `["null","long"]`,
-			`JSONB`:        `["null","string"]`,
-			`STRING`:       `["null","string"]`,
-			`TIME`:         `["null",{"type":"long","logicalType":"time-micros"}]`,
-			`TIMETZ`:       `["null","string"]`,
-			`TIMESTAMP`:    `["null",{"type":"long","logicalType":"timestamp-micros"}]`,
-			`TIMESTAMPTZ`:  `["null",{"type":"long","logicalType":"timestamp-micros"}]`,
-			`UUID`:         `["null","string"]`,
-			`DECIMAL(3,2)`: `["null",{"type":"bytes","logicalType":"decimal","precision":3,"scale":2}]`,
+			`BOOL`:              `["null","boolean"]`,
+			`BOOL[]`:            `["null",{"type":"array","items":["null","boolean"]}]`,
+			`BOX2D`:             `["null","string"]`,
+			`BYTES`:             `["null","bytes"]`,
+			`DATE`:              `["null",{"type":"int","logicalType":"date"}]`,
+			`FLOAT8`:            `["null","double"]`,
+			`GEOGRAPHY`:         `["null","bytes"]`,
+			`GEOMETRY`:          `["null","bytes"]`,
+			`INET`:              `["null","string"]`,
+			`INT8`:              `["null","long"]`,
+			`JSONB`:             `["null","string"]`,
+			`STRING`:            `["null","string"]`,
+			`STRING COLLATE fr`: `["null","string"]`,
+			`TIME`:              `["null",{"type":"long","logicalType":"time-micros"}]`,
+			`TIMETZ`:            `["null","string"]`,
+			`TIMESTAMP`:         `["null",{"type":"long","logicalType":"timestamp-micros"}]`,
+			`TIMESTAMPTZ`:       `["null",{"type":"long","logicalType":"timestamp-micros"}]`,
+			`UUID`:              `["null","string"]`,
+			`DECIMAL(3,2)`:      `["null",{"type":"bytes","logicalType":"decimal","precision":3,"scale":2}]`,
 		}
 
-		for _, typ := range append(types.Scalar, types.BoolArray) {
+		for _, typ := range append(types.Scalar, types.BoolArray, types.MakeCollatedString(types.String, `fr`)) {
 			switch typ.Family() {
 			case types.IntervalFamily, types.OidFamily, types.BitFamily:
 				continue
@@ -499,6 +513,9 @@ func TestAvroSchema(t *testing.T) {
 			{sqlType: `BOOL[]`,
 				sql:  `'{true, true, false, null}'`,
 				avro: `{"array":[{"boolean":true},{"boolean":true},{"boolean":false},null]}`},
+			{sqlType: `VARCHAR COLLATE "fr"`,
+				sql:  `'Bonjour' COLLATE "fr"`,
+				avro: `{"string":"Bonjour"}`},
 		}
 
 		for _, test := range goldens {
@@ -801,6 +818,12 @@ func BenchmarkEncodeBytes(b *testing.B) {
 
 func BenchmarkEncodeString(b *testing.B) {
 	benchmarkEncodeType(b, types.String, randEncDatumRow(types.String))
+}
+
+var collatedStringType *types.T = types.MakeCollatedString(types.String, `fr`)
+
+func BenchmarkEncodeCollatedString(b *testing.B) {
+	benchmarkEncodeType(b, collatedStringType, randEncDatumRow(collatedStringType))
 }
 
 func BenchmarkEncodeDate(b *testing.B) {

--- a/pkg/ccl/changefeedccl/encoder_test.go
+++ b/pkg/ccl/changefeedccl/encoder_test.go
@@ -347,6 +347,31 @@ func TestAvroArray(t *testing.T) {
 	t.Run(`enterprise`, enterpriseTest(testFn))
 }
 
+func TestAvroCollatedString(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
+		reg := cdctest.MakeTestSchemaRegistry()
+		defer reg.Close()
+
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b string collate "fr-CA")`)
+		sqlDB.Exec(t, `INSERT INTO foo VALUES (1, 'désolée' collate "fr-CA")`)
+
+		foo := feed(t, f, `CREATE CHANGEFEED FOR foo `+
+			`WITH format=$1, confluent_schema_registry=$2`,
+			changefeedbase.OptFormatAvro, reg.URL())
+		defer closeFeed(t, foo)
+		assertPayloadsAvro(t, reg, foo, []string{
+			`foo: {"a":{"long":1}}->{"after":{"foo":{"a":{"long":1},"b":{"string":"désolée"}}}}`,
+		})
+	}
+
+	t.Run(`sinkless`, sinklessTest(testFn))
+	t.Run(`enterprise`, enterpriseTest(testFn))
+}
+
 func TestAvroSchemaNaming(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)


### PR DESCRIPTION
Collated strings are technically a different type from string,
but collation doesn't affect datum encoding or serialization in CDB,
so no real reason not to encode them the same way in avro.

Release note (bug fix): Avro encoding supports collated string types