### PR TITLE
roachtest: add ternary logic partitioning (TLP) test

### DIFF
--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -111,6 +111,7 @@ go_library(
         "test.go",
         "test_registry.go",
         "test_runner.go",
+        "tlp.go",
         "toxiproxy.go",
         "tpc_utils.go",
         "tpcc.go",

--- a/pkg/cmd/roachtest/registry.go
+++ b/pkg/cmd/roachtest/registry.go
@@ -101,6 +101,7 @@ func registerTests(r *testRegistry) {
 	registerSQLSmith(r)
 	registerSyncTest(r)
 	registerSysbench(r)
+	registerTLP(r)
 	registerTPCC(r)
 	registerTPCDSVec(r)
 	registerTPCE(r)

--- a/pkg/cmd/roachtest/sqlsmith.go
+++ b/pkg/cmd/roachtest/sqlsmith.go
@@ -154,6 +154,10 @@ func registerSQLSmith(r *testRegistry) {
 			err := func() error {
 				done := make(chan error, 1)
 				go func(context.Context) {
+					// Generate can potentially panic in bad cases, so
+					// to avoid Go routines from dying we are going
+					// catch that here, and only pass the error into
+					// the channel.
 					defer func() {
 						if r := recover(); r != nil {
 							done <- errors.Newf("Caught error %s", r)
@@ -161,10 +165,6 @@ func registerSQLSmith(r *testRegistry) {
 						}
 					}()
 
-					// Generate can potentially panic in bad cases, so
-					// to avoid Go routines from dying we are going
-					// catch that here, and only pass the error into
-					// the channel.
 					stmt = smither.Generate()
 					if stmt == "" {
 						// If an empty statement is generated, then ignore it.

--- a/pkg/cmd/roachtest/tlp.go
+++ b/pkg/cmd/roachtest/tlp.go
@@ -1,0 +1,210 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+package main
+
+import (
+	"context"
+	gosql "database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/internal/sqlsmith"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/errors"
+)
+
+const statementTimeout = time.Minute
+
+func registerTLP(r *testRegistry) {
+	r.Add(testSpec{
+		Name:       "tlp",
+		Owner:      OwnerSQLQueries,
+		Timeout:    time.Minute * 5,
+		MinVersion: "v20.2.0",
+		Tags:       nil,
+		Cluster:    makeClusterSpec(1),
+		Run:        runTLP,
+	})
+}
+
+func runTLP(ctx context.Context, t *test, c *cluster) {
+	// Set up a statement logger for easy reproduction. We only
+	// want to log successful statements and statements that
+	// produced a TLP error.
+	tlpLog, err := os.Create(filepath.Join(t.artifactsDir, "tlp.log"))
+	if err != nil {
+		t.Fatalf("could not create tlp.log: %v", err)
+	}
+	defer tlpLog.Close()
+	logStmt := func(stmt string) {
+		stmt = strings.TrimSpace(stmt)
+		if stmt == "" {
+			return
+		}
+		fmt.Fprint(tlpLog, stmt)
+		if !strings.HasSuffix(stmt, ";") {
+			fmt.Fprint(tlpLog, ";")
+		}
+		fmt.Fprint(tlpLog, "\n\n")
+	}
+
+	conn := c.Conn(ctx, 1)
+
+	rnd, seed := randutil.NewPseudoRand()
+	c.l.Printf("seed: %d", seed)
+
+	c.Put(ctx, cockroach, "./cockroach")
+	if err := c.PutLibraries(ctx, "./lib"); err != nil {
+		t.Fatalf("could not initialize libraries: %v", err)
+	}
+	c.Start(ctx, t)
+
+	setup := sqlsmith.Setups["rand-tables"](rnd)
+
+	t.Status("executing setup")
+	c.l.Printf("setup:\n%s", setup)
+	if _, err := conn.Exec(setup); err != nil {
+		t.Fatal(err)
+	} else {
+		logStmt(setup)
+	}
+
+	setStmtTimeout := fmt.Sprintf("SET statement_timeout='%s';", statementTimeout.String())
+	t.Status("setting statement_timeout")
+	c.l.Printf("statement timeout:\n%s", setStmtTimeout)
+	if _, err := conn.Exec(setStmtTimeout); err != nil {
+		t.Fatal(err)
+	}
+	logStmt(setStmtTimeout)
+
+	// Initialize a smither that generates only INSERT, UPDATE, and DELETE
+	// statements with the MutationsOnly option. Smither.GenerateTLP always
+	// returns SELECT queries, so the MutationsOnly option is used only for
+	// randomly mutating the database.
+	smither, err := sqlsmith.NewSmither(conn, rnd, sqlsmith.MutationsOnly())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer smither.Close()
+
+	t.Status("running TLP")
+	until := time.After(t.spec.Timeout / 2)
+	done := ctx.Done()
+	for i := 1; ; i++ {
+		select {
+		case <-until:
+			return
+		case <-done:
+			return
+		default:
+		}
+
+		if i%1000 == 0 {
+			t.Status("running TLP: ", i, " statements completed")
+		}
+
+		// Run 1000 mutations first so that the tables have rows. Run a mutation
+		// for a tenth of the iterations after that to continually change the
+		// state of the database.
+		if i < 1000 || i%10 == 0 {
+			runMutationStatement(conn, smither, logStmt)
+			continue
+		}
+
+		if err := runTLPQuery(conn, smither, logStmt); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// runMutationsStatement runs a random INSERT, UPDATE, or DELETE statement that
+// potentially modifies the state of the database.
+func runMutationStatement(conn *gosql.DB, smither *sqlsmith.Smither, logStmt func(string)) {
+	// Ignore panics from Generate.
+	defer func() {
+		if r := recover(); r != nil {
+			return
+		}
+	}()
+
+	stmt := smither.Generate()
+
+	// Ignore timeouts.
+	_ = runWithTimeout(func() error {
+		// Ignore errors. Log successful statements.
+		if _, err := conn.Exec(stmt); err == nil {
+			logStmt(stmt)
+		}
+		return nil
+	})
+}
+
+// runTLPQuery runs two queries to perform TLP. If the results of the query are
+// not equal, an error is returned. Currently GenerateTLP always returns
+// unpartitioned and partitioned queries of the form "SELECT count(*) ...". The
+// resulting counts of the queries are compared in order to verify logical
+// correctness. See GenerateTLP for more information on TLP and the generated
+// queries.
+func runTLPQuery(conn *gosql.DB, smither *sqlsmith.Smither, logStmt func(string)) error {
+	// Ignore panics from GenerateTLP.
+	defer func() {
+		if r := recover(); r != nil {
+			return
+		}
+	}()
+
+	unpartitioned, partitioned := smither.GenerateTLP()
+
+	return runWithTimeout(func() error {
+		var unpartitionedCount int
+		row := conn.QueryRow(unpartitioned)
+		if err := row.Scan(&unpartitionedCount); err != nil {
+			// Ignore errors.
+			//nolint:returnerrcheck
+			return nil
+		}
+
+		var partitionedCount int
+		row = conn.QueryRow(partitioned)
+		if err := row.Scan(&partitionedCount); err != nil {
+			// Ignore errors.
+			//nolint:returnerrcheck
+			return nil
+		}
+
+		if unpartitionedCount != partitionedCount {
+			logStmt(unpartitioned)
+			logStmt(partitioned)
+			return errors.Newf(
+				"expected unpartitioned count %d to equal partitioned count %d\nsql: %s\n%s",
+				unpartitionedCount, partitionedCount, unpartitioned, partitioned)
+		}
+
+		return nil
+	})
+}
+
+func runWithTimeout(f func() error) error {
+	done := make(chan error, 1)
+	go func() {
+		err := f()
+		done <- err
+	}()
+	select {
+	case <-time.After(statementTimeout + time.Second*5):
+		// Ignore timeouts.
+		return nil
+	case err := <-done:
+		return err
+	}
+}

--- a/pkg/internal/sqlsmith/BUILD.bazel
+++ b/pkg/internal/sqlsmith/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "scope.go",
         "setup.go",
         "sqlsmith.go",
+        "tlp.go",
         "type.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/internal/sqlsmith",

--- a/pkg/internal/sqlsmith/sqlsmith.go
+++ b/pkg/internal/sqlsmith/sqlsmith.go
@@ -292,6 +292,16 @@ var SimpleDatums = simpleOption("simple datums", func(s *Smither) {
 	s.simpleDatums = true
 })
 
+// MutationsOnly causes the Smither to emit 80% INSERT, 10% UPDATE, and 10%
+// DELETE statements.
+var MutationsOnly = simpleOption("mutations only", func(s *Smither) {
+	s.stmtWeights = []statementWeight{
+		{8, makeInsert},
+		{1, makeUpdate},
+		{1, makeDelete},
+	}
+})
+
 // IgnoreFNs causes the Smither to ignore functions that match the regex.
 func IgnoreFNs(regex string) SmitherOption {
 	r := regexp.MustCompile(regex)

--- a/pkg/internal/sqlsmith/tlp.go
+++ b/pkg/internal/sqlsmith/tlp.go
@@ -1,0 +1,81 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sqlsmith
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/errors"
+)
+
+// GenerateTLP returns two SQL queries as strings that can be used for Ternary
+// Logic Partitioning (TLP). TLP is a method for logically testing DBMSs which
+// is based on the logical guarantee that for a given predicate p, all rows must
+// satisfy exactly one of the following three predicates: p, NOT p, p IS NULL.
+// TLP can find bugs when an unpartitioned query and a query partitioned into
+// three sub-queries do not yield the same results.
+//
+// More information on TLP: https://www.manuelrigger.at/preprints/TLP.pdf.
+//
+// We currently implement a limited form of TLP that can only verify that the
+// number of rows returned by the unpartitioned and the partitioned queries are
+// equal.
+//
+// This TLP implementation is also limited in the types of queries that are
+// tested. We currently only test basic SELECT query filters. It is possible to
+// use TLP to test aggregations, GROUP BY, HAVING, and JOINs, which have all
+// been implemented in SQLancer. See:
+// https://github.com/sqlancer/sqlancer/tree/1.1.0/src/sqlancer/cockroachdb/oracle/tlp.
+//
+// The first query returned is an unpartitioned query of the form:
+//
+//   SELECT count(*) FROM table
+//
+// The second query returned is a partitioned query of the form:
+//
+//   SELECT count(*) FROM (
+//     SELECT * FROM table WHERE (p)
+//     UNION ALL
+//     SELECT * FROM table WHERE NOT (p)
+//     UNION ALL
+//     SELECT * FROM table WHERE (p) IS NULL
+//   )
+//
+// If the resulting counts of the two queries are not equal, there is a logical
+// bug.
+func (s *Smither) GenerateTLP() (unpartitioned, partitioned string) {
+	f := tree.NewFmtCtx(tree.FmtParsable)
+
+	table, _, _, cols, ok := s.getSchemaTable()
+	if !ok {
+		panic(errors.AssertionFailedf("failed to find random table"))
+	}
+	table.Format(f)
+	tableName := f.CloseAndGetString()
+
+	unpartitioned = fmt.Sprintf("SELECT count(*) FROM %s", tableName)
+
+	pred := makeBoolExpr(s, cols)
+	pred.Format(f)
+	predicate := f.CloseAndGetString()
+
+	part1 := fmt.Sprintf("SELECT * FROM %s WHERE %s", tableName, predicate)
+	part2 := fmt.Sprintf("SELECT * FROM %s WHERE NOT (%s)", tableName, predicate)
+	part3 := fmt.Sprintf("SELECT * FROM %s WHERE (%s) IS NULL", tableName, predicate)
+
+	partitioned = fmt.Sprintf(
+		"SELECT count(*) FROM (%s UNION ALL %s UNION ALL %s)",
+		part1, part2, part3,
+	)
+
+	return unpartitioned, partitioned
+}


### PR DESCRIPTION
#### roachtest: clarify SQLSmith comment

Release note: None

#### roachtest: add ternary logic partitioning (TLP) test

This commit adds a roachtest that performs ternary logic partitioning
(TLP) testing. TLP is a method for logically testing a database which is
based on the logical guarantee that for a given predicate `p`, all rows
must satisfy exactly one of the following three predicates: `p`, `NOT
p`, `p IS NULL`. Unioning the results of all three "partitions" should
yield the same result as an "unpartitioned" query with a `true`
predicate.

TLP is implemented in [SQLancer](https://github.com/sqlancer/sqlancer)
and more information can be found at
https://www.manuelrigger.at/preprints/TLP.pdf.

We currently implement a limited form of TLP that only runs queries of
the form `SELECT * FROM table WHERE <predicate>` where `<predicate>` is
randomly generated. We also only verify that the number of rows returned
by the unpartitioned and partitioned queries are equal, not that the
values of the rows are equal. See the documentation for
`Smither.GenerateTLP` for more details.

Fixes #62900

Release note: None