### PR TITLE
colflow: introduce flow coordinator and simplify materializer

### DIFF
--- a/pkg/ccl/backupccl/restore_data_processor.go
+++ b/pkg/ccl/backupccl/restore_data_processor.go
@@ -56,9 +56,10 @@ func newTestingRestoreDataProcessor(
 ) (*restoreDataProcessor, error) {
 	rd := &restoreDataProcessor{
 		ProcessorBase: execinfra.ProcessorBase{
-			Ctx:     ctx,
-			EvalCtx: evalCtx,
-		},
+			ProcessorBaseNoHelper: execinfra.ProcessorBaseNoHelper{
+				Ctx:     ctx,
+				EvalCtx: evalCtx,
+			}},
 		flowCtx: flowCtx,
 		spec:    spec,
 	}

--- a/pkg/ccl/importccl/exportcsv.go
+++ b/pkg/ccl/importccl/exportcsv.go
@@ -139,7 +139,7 @@ func newCSVWriterProcessor(
 		output:      output,
 	}
 	semaCtx := tree.MakeSemaContext()
-	if err := c.out.Init(&execinfrapb.PostProcessSpec{}, c.OutputTypes(), &semaCtx, flowCtx.NewEvalCtx(), output); err != nil {
+	if err := c.out.Init(&execinfrapb.PostProcessSpec{}, c.OutputTypes(), &semaCtx, flowCtx.NewEvalCtx()); err != nil {
 		return nil, err
 	}
 	return c, nil
@@ -286,7 +286,7 @@ func (sp *csvWriter) Run(ctx context.Context) {
 				),
 			}
 
-			cs, err := sp.out.EmitRow(ctx, res)
+			cs, err := sp.out.EmitRow(ctx, res, sp.output)
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -82,7 +82,7 @@ func wrapRowSources(
 			c.MarkAsRemovedFromFlow()
 			toWrapInputs = append(toWrapInputs, c.Input())
 		} else {
-			toWrapInput, err := colexec.NewMaterializer(
+			toWrapInput := colexec.NewMaterializer(
 				flowCtx,
 				processorID,
 				inputs[i],
@@ -90,9 +90,6 @@ func wrapRowSources(
 				nil, /* output */
 				nil, /* cancelFlow */
 			)
-			if err != nil {
-				return nil, releasables, err
-			}
 			// We passed the ownership over the meta components to the
 			// materializer.
 			// TODO(yuzefovich): possibly set the length to 0 in order to be
@@ -118,15 +115,15 @@ func wrapRowSources(
 	}
 	var c *colexec.Columnarizer
 	if proc.MustBeStreaming() {
-		c, err = colexec.NewStreamingColumnarizer(
+		c = colexec.NewStreamingColumnarizer(
 			colmem.NewAllocator(ctx, streamingMemAccount, factory), flowCtx, processorID, toWrap,
 		)
 	} else {
-		c, err = colexec.NewBufferingColumnarizer(
+		c = colexec.NewBufferingColumnarizer(
 			colmem.NewAllocator(ctx, streamingMemAccount, factory), flowCtx, processorID, toWrap,
 		)
 	}
-	return c, releasables, err
+	return c, releasables, nil
 }
 
 type opResult struct {

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -87,8 +87,6 @@ func wrapRowSources(
 				processorID,
 				inputs[i],
 				inputTypes[i],
-				nil, /* output */
-				nil, /* cancelFlow */
 			)
 			// We passed the ownership over the meta components to the
 			// materializer.
@@ -594,14 +592,43 @@ func (r opResult) createAndWrapRowSource(
 	}
 	r.Root = c
 	r.Columnarizer = c
-	if args.TestingKnobs.PlanInvariantsCheckers {
+	if util.CrdbTestBuild {
 		r.Root = colexec.NewInvariantsChecker(r.Root)
 	}
 	takeOverMetaInfo(&r.OpWithMetaInfo, inputs)
 	r.MetadataSources = append(r.MetadataSources, r.Root.(colexecop.MetadataSource))
-	r.ToClose = append(r.ToClose, c)
+	r.ToClose = append(r.ToClose, r.Root.(colexecop.Closer))
 	r.Releasables = append(r.Releasables, releasables...)
 	return nil
+}
+
+// MaybeRemoveRootColumnarizer examines whether r represents such a tree of
+// operators that has a columnarizer as its root with no responsibility over
+// other meta components. If that's the case, the input to the columnarizer is
+// returned and the columnarizer is marked as removed from the flow; otherwise,
+// nil is returned.
+func MaybeRemoveRootColumnarizer(r colexecargs.OpWithMetaInfo) execinfra.RowSource {
+	root := r.Root
+	if util.CrdbTestBuild {
+		// We might have an invariants checker as the root right now, we gotta
+		// peek inside of it if so.
+		if i, ok := root.(*colexec.InvariantsChecker); ok {
+			root = i.Input
+		}
+	}
+	c, isColumnarizer := root.(*colexec.Columnarizer)
+	if !isColumnarizer {
+		return nil
+	}
+	// We have the columnarizer as the root, and it must be included into the
+	// MetadataSources and ToClose slices, so if we don't see any other objects,
+	// then the responsibility over other meta components has been claimed by
+	// the children of the columnarizer.
+	if len(r.StatsCollectors) != 0 || len(r.MetadataSources) != 1 || len(r.ToClose) != 1 {
+		return nil
+	}
+	c.MarkAsRemovedFromFlow()
+	return c.Input()
 }
 
 // NOTE: throughout this file we do not append an output type of a projecting
@@ -741,7 +768,7 @@ func NewColOperator(
 				log.Infof(ctx, "made op %T\n", scanOp)
 			}
 			result.Root = scanOp
-			if args.TestingKnobs.PlanInvariantsCheckers {
+			if util.CrdbTestBuild {
 				result.Root = colexec.NewInvariantsChecker(result.Root)
 			}
 			result.KVReader = scanOp
@@ -1349,14 +1376,17 @@ func NewColOperator(
 	if projection != nil {
 		r.Root, r.ColumnTypes = addProjection(r.Root, r.ColumnTypes, projection)
 	}
-	if args.TestingKnobs.PlanInvariantsCheckers {
-		// Plan an invariants checker if it isn't already the root of the tree.
-		if _, isInvariantsChecker := r.Root.(*colexec.InvariantsChecker); !isInvariantsChecker {
-			r.Root = colexec.NewInvariantsChecker(r.Root)
-		}
-	}
 	takeOverMetaInfo(&result.OpWithMetaInfo, inputs)
 	if util.CrdbTestBuild {
+		// TODO(yuzefovich): remove the testing knob.
+		if args.TestingKnobs.PlanInvariantsCheckers {
+			// Plan an invariants checker if it isn't already the root of the
+			// tree.
+			if _, isInvariantsChecker := r.Root.(*colexec.InvariantsChecker); !isInvariantsChecker {
+				r.Root = colexec.NewInvariantsChecker(r.Root)
+			}
+		}
+		// Also verify planning assumptions.
 		r.AssertInvariants()
 	}
 	return r, err

--- a/pkg/sql/colexec/colbuilder/execplan_test.go
+++ b/pkg/sql/colexec/colbuilder/execplan_test.go
@@ -119,7 +119,7 @@ func TestNewColOperatorExpectedTypeSchema(t *testing.T) {
 	r, err = NewColOperator(ctx, flowCtx, args)
 	require.NoError(t, err)
 
-	m, err := colexec.NewMaterializer(
+	m := colexec.NewMaterializer(
 		flowCtx,
 		0, /* processorID */
 		r.OpWithMetaInfo,
@@ -127,7 +127,6 @@ func TestNewColOperatorExpectedTypeSchema(t *testing.T) {
 		nil, /* output */
 		nil, /* cancelFlow */
 	)
-	require.NoError(t, err)
 
 	m.Start(ctx)
 	var rowIdx int

--- a/pkg/sql/colexec/colbuilder/execplan_test.go
+++ b/pkg/sql/colexec/colbuilder/execplan_test.go
@@ -124,8 +124,6 @@ func TestNewColOperatorExpectedTypeSchema(t *testing.T) {
 		0, /* processorID */
 		r.OpWithMetaInfo,
 		[]*types.T{types.Int},
-		nil, /* output */
-		nil, /* cancelFlow */
 	)
 
 	m.Start(ctx)

--- a/pkg/sql/colexec/columnarizer_test.go
+++ b/pkg/sql/colexec/columnarizer_test.go
@@ -51,10 +51,7 @@ func TestColumnarizerResetsInternalBatch(t *testing.T) {
 		EvalCtx: &evalCtx,
 	}
 
-	c, err := NewBufferingColumnarizer(testAllocator, flowCtx, 0, input)
-	if err != nil {
-		t.Fatal(err)
-	}
+	c := NewBufferingColumnarizer(testAllocator, flowCtx, 0, input)
 	c.Init(ctx)
 	foundRows := 0
 	for {
@@ -101,14 +98,13 @@ func TestColumnarizerDrainsAndClosesInput(t *testing.T) {
 			const errMsg = "artificial error"
 			rb := distsqlutils.NewRowBuffer([]*types.T{types.Int}, nil /* rows */, distsqlutils.RowBufferArgs{})
 			rb.Push(nil, &execinfrapb.ProducerMetadata{Err: errors.New(errMsg)})
-			c, err := NewBufferingColumnarizer(testAllocator, flowCtx, 0 /* processorID */, rb)
-			require.NoError(t, err)
+			c := NewBufferingColumnarizer(testAllocator, flowCtx, 0 /* processorID */, rb)
 
 			c.Init(ctx)
 
 			// If the metadata is obtained through this Next call, the Columnarizer still
 			// returns it in DrainMeta.
-			err = colexecerror.CatchVectorizedRuntimeError(func() { c.Next() })
+			err := colexecerror.CatchVectorizedRuntimeError(func() { c.Next() })
 			require.True(t, testutils.IsError(err, errMsg), "unexpected error %v", err)
 
 			if tc.consumerClosed {
@@ -148,10 +144,7 @@ func BenchmarkColumnarize(b *testing.B) {
 
 	b.SetBytes(int64(nRows * nCols * int(unsafe.Sizeof(int64(0)))))
 
-	c, err := NewBufferingColumnarizer(testAllocator, flowCtx, 0, input)
-	if err != nil {
-		b.Fatal(err)
-	}
+	c := NewBufferingColumnarizer(testAllocator, flowCtx, 0, input)
 	c.Init(ctx)
 	for i := 0; i < b.N; i++ {
 		foundRows := 0

--- a/pkg/sql/colexec/invariants_checker.go
+++ b/pkg/sql/colexec/invariants_checker.go
@@ -32,6 +32,7 @@ type InvariantsChecker struct {
 }
 
 var _ colexecop.DrainableOperator = &InvariantsChecker{}
+var _ colexecop.ClosableOperator = &InvariantsChecker{}
 
 // NewInvariantsChecker creates a new InvariantsChecker.
 func NewInvariantsChecker(input colexecop.Operator) *InvariantsChecker {
@@ -108,4 +109,13 @@ func (i *InvariantsChecker) DrainMeta() []execinfrapb.ProducerMetadata {
 		return nil
 	}
 	return i.metadataSource.DrainMeta()
+}
+
+// Close is part of the colexecop.ClosableOperator interface.
+func (i *InvariantsChecker) Close(ctx context.Context) error {
+	c, ok := i.Input.(colexecop.Closer)
+	if !ok {
+		return nil
+	}
+	return c.Close(ctx)
 }

--- a/pkg/sql/colexec/materializer_test.go
+++ b/pkg/sql/colexec/materializer_test.go
@@ -64,8 +64,6 @@ func TestColumnarizeMaterialize(t *testing.T) {
 		1, /* processorID */
 		colexecargs.OpWithMetaInfo{Root: c},
 		typs,
-		nil, /* output */
-		nil, /* cancelFlow */
 	)
 	m.Start(ctx)
 
@@ -143,8 +141,6 @@ func BenchmarkMaterializer(b *testing.B) {
 							0, /* processorID */
 							colexecargs.OpWithMetaInfo{Root: input},
 							typs,
-							nil, /* output */
-							nil, /* cancelFlow */
 						)
 						m.Start(ctx)
 
@@ -195,8 +191,6 @@ func TestMaterializerNextErrorAfterConsumerDone(t *testing.T) {
 			MetadataSources: colexecop.MetadataSources{metadataSource},
 		},
 		nil, /* typ */
-		nil, /* output */
-		nil, /* cancelFlow */
 	)
 
 	m.Start(ctx)
@@ -238,8 +232,6 @@ func BenchmarkColumnarizeMaterialize(b *testing.B) {
 			1, /* processorID */
 			colexecargs.OpWithMetaInfo{Root: c},
 			types,
-			nil, /* output */
-			nil, /* cancelFlow */
 		)
 		m.Start(ctx)
 

--- a/pkg/sql/colexec/materializer_test.go
+++ b/pkg/sql/colexec/materializer_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/errors"
-	"github.com/stretchr/testify/require"
 )
 
 func TestColumnarizeMaterialize(t *testing.T) {
@@ -58,12 +57,9 @@ func TestColumnarizeMaterialize(t *testing.T) {
 		Cfg:     &execinfra.ServerConfig{Settings: st},
 		EvalCtx: &evalCtx,
 	}
-	c, err := NewBufferingColumnarizer(testAllocator, flowCtx, 0, input)
-	if err != nil {
-		t.Fatal(err)
-	}
+	c := NewBufferingColumnarizer(testAllocator, flowCtx, 0, input)
 
-	m, err := NewMaterializer(
+	m := NewMaterializer(
 		flowCtx,
 		1, /* processorID */
 		colexecargs.OpWithMetaInfo{Root: c},
@@ -71,9 +67,6 @@ func TestColumnarizeMaterialize(t *testing.T) {
 		nil, /* output */
 		nil, /* cancelFlow */
 	)
-	if err != nil {
-		t.Fatal(err)
-	}
 	m.Start(ctx)
 
 	for i := 0; i < nRows; i++ {
@@ -145,7 +138,7 @@ func BenchmarkMaterializer(b *testing.B) {
 
 					b.SetBytes(int64(nRows * nCols * int(unsafe.Sizeof(int64(0)))))
 					for i := 0; i < b.N; i++ {
-						m, err := NewMaterializer(
+						m := NewMaterializer(
 							flowCtx,
 							0, /* processorID */
 							colexecargs.OpWithMetaInfo{Root: input},
@@ -153,9 +146,6 @@ func BenchmarkMaterializer(b *testing.B) {
 							nil, /* output */
 							nil, /* cancelFlow */
 						)
-						if err != nil {
-							b.Fatal(err)
-						}
 						m.Start(ctx)
 
 						foundRows := 0
@@ -197,7 +187,7 @@ func TestMaterializerNextErrorAfterConsumerDone(t *testing.T) {
 		EvalCtx: &evalCtx,
 	}
 
-	m, err := NewMaterializer(
+	m := NewMaterializer(
 		flowCtx,
 		0, /* processorID */
 		colexecargs.OpWithMetaInfo{
@@ -208,7 +198,6 @@ func TestMaterializerNextErrorAfterConsumerDone(t *testing.T) {
 		nil, /* output */
 		nil, /* cancelFlow */
 	)
-	require.NoError(t, err)
 
 	m.Start(ctx)
 	// Call ConsumerDone.
@@ -240,14 +229,11 @@ func BenchmarkColumnarizeMaterialize(b *testing.B) {
 		Cfg:     &execinfra.ServerConfig{Settings: st},
 		EvalCtx: &evalCtx,
 	}
-	c, err := NewBufferingColumnarizer(testAllocator, flowCtx, 0, input)
-	if err != nil {
-		b.Fatal(err)
-	}
+	c := NewBufferingColumnarizer(testAllocator, flowCtx, 0, input)
 
 	b.SetBytes(int64(nRows * nCols * int(unsafe.Sizeof(int64(0)))))
 	for i := 0; i < b.N; i++ {
-		m, err := NewMaterializer(
+		m := NewMaterializer(
 			flowCtx,
 			1, /* processorID */
 			colexecargs.OpWithMetaInfo{Root: c},
@@ -255,9 +241,6 @@ func BenchmarkColumnarizeMaterialize(b *testing.B) {
 			nil, /* output */
 			nil, /* cancelFlow */
 		)
-		if err != nil {
-			b.Fatal(err)
-		}
 		m.Start(ctx)
 
 		foundRows := 0

--- a/pkg/sql/colexec/types_integration_test.go
+++ b/pkg/sql/colexec/types_integration_test.go
@@ -78,8 +78,7 @@ func TestSQLTypesIntegration(t *testing.T) {
 			typs := []*types.T{typ}
 			source := execinfra.NewRepeatableRowSource(typs, rows)
 
-			columnarizer, err := NewBufferingColumnarizer(testAllocator, flowCtx, 0 /* processorID */, source)
-			require.NoError(t, err)
+			columnarizer := NewBufferingColumnarizer(testAllocator, flowCtx, 0 /* processorID */, source)
 
 			c, err := colserde.NewArrowBatchConverter(typs)
 			require.NoError(t, err)
@@ -88,7 +87,7 @@ func TestSQLTypesIntegration(t *testing.T) {
 			arrowOp := newArrowTestOperator(columnarizer, c, r, typs)
 
 			output := distsqlutils.NewRowBuffer(typs, nil /* rows */, distsqlutils.RowBufferArgs{})
-			materializer, err := NewMaterializer(
+			materializer := NewMaterializer(
 				flowCtx,
 				1, /* processorID */
 				colexecargs.OpWithMetaInfo{Root: arrowOp},
@@ -96,7 +95,6 @@ func TestSQLTypesIntegration(t *testing.T) {
 				output,
 				nil, /* cancelFlow */
 			)
-			require.NoError(t, err)
 
 			materializer.Start(ctx)
 			materializer.Run(ctx)

--- a/pkg/sql/colexec/values_test.go
+++ b/pkg/sql/colexec/values_test.go
@@ -159,7 +159,7 @@ func BenchmarkValues(b *testing.B) {
 					}
 					return NewBufferingColumnarizer(
 						testAllocator, &flowCtx, 0, proc.(execinfra.RowSource),
-					)
+					), nil
 				})
 		}
 	}

--- a/pkg/sql/colflow/BUILD.bazel
+++ b/pkg/sql/colflow/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "colflow",
     srcs = [
         "explain_vec.go",
+        "flow_coordinator.go",
         "panic_injector.go",
         "routers.go",
         "stats.go",
@@ -31,6 +32,7 @@ go_library(
         "//pkg/sql/execinfra",
         "//pkg/sql/execinfrapb",
         "//pkg/sql/flowinfra",
+        "//pkg/sql/rowenc",
         "//pkg/sql/rowexec",
         "//pkg/sql/sessiondatapb",
         "//pkg/sql/types",
@@ -90,7 +92,6 @@ go_test(
         "//pkg/sql/colexec/colexecutils",
         "//pkg/sql/colexecerror",
         "//pkg/sql/colexecop",
-        "//pkg/sql/colfetcher",
         "//pkg/sql/colflow/colrpc",
         "//pkg/sql/colmem",
         "//pkg/sql/execinfra",

--- a/pkg/sql/colflow/colbatch_scan_test.go
+++ b/pkg/sql/colflow/colbatch_scan_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colbuilder"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecargs"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecutils"
-	"github.com/cockroachdb/cockroach/pkg/sql/colfetcher"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -95,7 +95,7 @@ func TestColBatchScanMeta(t *testing.T) {
 	}
 	tr := res.Root
 	tr.Init(ctx)
-	meta := tr.(*colexecutils.CancelChecker).Input.(*colfetcher.ColBatchScan).DrainMeta()
+	meta := tr.(*colexecutils.CancelChecker).Input.(colexecop.DrainableOperator).DrainMeta()
 	var txnFinalStateSeen bool
 	for _, m := range meta {
 		if m.LeafTxnFinalState != nil {

--- a/pkg/sql/colflow/flow_coordinator.go
+++ b/pkg/sql/colflow/flow_coordinator.go
@@ -1,0 +1,176 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package colflow
+
+import (
+	"context"
+	"sync"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/errors"
+)
+
+// FlowCoordinator is the execinfra.Processor that is responsible for shutting
+// down the vectorized flow on the gateway node.
+type FlowCoordinator struct {
+	execinfra.ProcessorBaseNoHelper
+	colexecop.NonExplainable
+
+	input execinfra.RowSource
+
+	// row and meta are the results produced by calling input.Next stored here
+	// in order for that call to be wrapped in the panic-catcher.
+	row  rowenc.EncDatumRow
+	meta *execinfrapb.ProducerMetadata
+
+	// cancelFlow will return a function to cancel the context of the flow. It
+	// is a function in order to be lazily evaluated, since the context
+	// cancellation function is only available after the flow is Start()'ed.
+	cancelFlow func() context.CancelFunc
+}
+
+var flowCoordinatorPool = sync.Pool{
+	New: func() interface{} {
+		return &FlowCoordinator{}
+	},
+}
+
+// NewFlowCoordinator creates a new FlowCoordinator processor that is the root
+// of the vectorized flow.
+// - cancelFlow should return the context cancellation function that cancels
+// the context of the flow (i.e. it is Flow.ctxCancel).
+func NewFlowCoordinator(
+	flowCtx *execinfra.FlowCtx,
+	processorID int32,
+	input execinfra.RowSource,
+	output execinfra.RowReceiver,
+	cancelFlow func() context.CancelFunc,
+) *FlowCoordinator {
+	f := flowCoordinatorPool.Get().(*FlowCoordinator)
+	f.input = input
+	f.cancelFlow = cancelFlow
+	f.Init(
+		f,
+		flowCtx,
+		// FlowCoordinator doesn't modify the eval context, so it is safe to
+		// reuse the one from the flow context.
+		flowCtx.EvalCtx,
+		processorID,
+		output,
+		execinfra.ProcStateOpts{
+			// We append input to inputs to drain below in order to reuse
+			// the same underlying slice from the pooled FlowCoordinator.
+			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {
+				// Note that the input must have been drained by the
+				// ProcessorBaseNoHelper by this point, so we can just close the
+				// FlowCoordinator.
+				f.close()
+				return nil
+			},
+		},
+	)
+	f.AddInputToDrain(input)
+	return f
+}
+
+var _ execinfra.OpNode = &FlowCoordinator{}
+var _ execinfra.Processor = &FlowCoordinator{}
+var _ execinfra.Releasable = &FlowCoordinator{}
+
+// ChildCount is part of the execinfra.OpNode interface.
+func (f *FlowCoordinator) ChildCount(verbose bool) int {
+	return 1
+}
+
+// Child is part of the execinfra.OpNode interface.
+func (f *FlowCoordinator) Child(nth int, verbose bool) execinfra.OpNode {
+	if nth == 0 {
+		// The input must be the execinfra.OpNode (it's either a materializer or
+		// a wrapped row-execution processor).
+		return f.input.(execinfra.OpNode)
+	}
+	colexecerror.InternalError(errors.AssertionFailedf("invalid index %d", nth))
+	// This code is unreachable, but the compiler cannot infer that.
+	return nil
+}
+
+// OutputTypes is part of the execinfra.Processor interface.
+func (f *FlowCoordinator) OutputTypes() []*types.T {
+	return f.input.OutputTypes()
+}
+
+// Start is part of the execinfra.RowSource interface.
+func (f *FlowCoordinator) Start(ctx context.Context) {
+	ctx = f.StartInternalNoSpan(ctx)
+	if err := colexecerror.CatchVectorizedRuntimeError(func() {
+		f.input.Start(ctx)
+	}); err != nil {
+		f.MoveToDraining(err)
+	}
+}
+
+func (f *FlowCoordinator) next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetadata) {
+	if f.State == execinfra.StateRunning {
+		row, meta := f.input.Next()
+		if meta != nil {
+			if meta.Err != nil {
+				f.MoveToDraining(nil /* err */)
+			}
+			return nil, meta
+		}
+		if row != nil {
+			return row, nil
+		}
+		// Both row and meta are nil, so we transition to draining.
+		f.MoveToDraining(nil /* err */)
+	}
+	return nil, f.DrainHelper()
+}
+
+func (f *FlowCoordinator) nextAdapter() {
+	f.row, f.meta = f.next()
+}
+
+// Next is part of the execinfra.RowSource interface.
+func (f *FlowCoordinator) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetadata) {
+	if err := colexecerror.CatchVectorizedRuntimeError(f.nextAdapter); err != nil {
+		f.MoveToDraining(err)
+		return nil, f.DrainHelper()
+	}
+	return f.row, f.meta
+}
+
+func (f *FlowCoordinator) close() {
+	if f.InternalClose() {
+		f.cancelFlow()()
+	}
+}
+
+// ConsumerClosed is part of the execinfra.RowSource interface.
+func (f *FlowCoordinator) ConsumerClosed() {
+	f.close()
+}
+
+// Release implements the execinfra.Releasable interface.
+func (f *FlowCoordinator) Release() {
+	f.ProcessorBaseNoHelper.Reset()
+	*f = FlowCoordinator{
+		// We're keeping the reference to the same ProcessorBaseNoHelper since
+		// it allows us to reuse some of the slices.
+		ProcessorBaseNoHelper: f.ProcessorBaseNoHelper,
+	}
+	flowCoordinatorPool.Put(f)
+}

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -986,7 +986,7 @@ func (s *vectorizedFlowCreator) setupOutput(
 		s.opChains = append(s.opChains, outbox)
 	case execinfrapb.StreamEndpointSpec_SYNC_RESPONSE:
 		// Make the materializer, which will write to the given receiver.
-		proc, err := colexec.NewMaterializer(
+		proc := colexec.NewMaterializer(
 			flowCtx,
 			pspec.ProcessorID,
 			opWithMetaInfo,
@@ -994,9 +994,6 @@ func (s *vectorizedFlowCreator) setupOutput(
 			s.syncFlowConsumer,
 			s.getCancelFlowFn,
 		)
-		if err != nil {
-			return err
-		}
 		// A materializer is a root of its operator chain.
 		s.opChains = append(s.opChains, proc)
 		s.addMaterializer(proc)

--- a/pkg/sql/colflow/vectorized_flow_shutdown_test.go
+++ b/pkg/sql/colflow/vectorized_flow_shutdown_test.go
@@ -346,7 +346,7 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 
 				ctxLocal, cancelLocal := context.WithCancel(ctxLocal)
 				materializerCalledClose := false
-				materializer, err := colexec.NewMaterializer(
+				materializer := colexec.NewMaterializer(
 					flowCtx,
 					1, /* processorID */
 					colexecargs.OpWithMetaInfo{
@@ -361,7 +361,6 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 					nil, /* output */
 					func() context.CancelFunc { return cancelLocal },
 				)
-				require.NoError(t, err)
 				materializer.Start(ctxLocal)
 
 				for i := 0; i < 10; i++ {

--- a/pkg/sql/colflow/vectorized_meta_propagation_test.go
+++ b/pkg/sql/colflow/vectorized_meta_propagation_test.go
@@ -78,8 +78,6 @@ func TestVectorizedMetaPropagation(t *testing.T) {
 			MetadataSources: colexecop.MetadataSources{col},
 		},
 		typs,
-		nil, /* output */
-		nil, /* cancelFlow */
 	)
 
 	mtr, err := execinfra.NewMetadataTestReceiver(

--- a/pkg/sql/colflow/vectorized_meta_propagation_test.go
+++ b/pkg/sql/colflow/vectorized_meta_propagation_test.go
@@ -68,13 +68,9 @@ func TestVectorizedMetaPropagation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	col, err := colexec.NewBufferingColumnarizer(testAllocator, &flowCtx, 1, mts)
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	col := colexec.NewBufferingColumnarizer(testAllocator, &flowCtx, 1, mts)
 	noop := colexecop.NewNoop(col)
-	mat, err := colexec.NewMaterializer(
+	mat := colexec.NewMaterializer(
 		&flowCtx,
 		2, /* processorID */
 		colexecargs.OpWithMetaInfo{
@@ -85,9 +81,6 @@ func TestVectorizedMetaPropagation(t *testing.T) {
 		nil, /* output */
 		nil, /* cancelFlow */
 	)
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	mtr, err := execinfra.NewMetadataTestReceiver(
 		&flowCtx,

--- a/pkg/sql/colflow/vectorized_panic_propagation_test.go
+++ b/pkg/sql/colflow/vectorized_panic_propagation_test.go
@@ -50,13 +50,9 @@ func TestVectorizedInternalPanic(t *testing.T) {
 	typs := types.OneIntCol
 	input := execinfra.NewRepeatableRowSource(typs, randgen.MakeIntRows(nRows, nCols))
 
-	col, err := colexec.NewBufferingColumnarizer(testAllocator, &flowCtx, 0 /* processorID */, input)
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	col := colexec.NewBufferingColumnarizer(testAllocator, &flowCtx, 0 /* processorID */, input)
 	vee := newTestVectorizedInternalPanicEmitter(col)
-	mat, err := colexec.NewMaterializer(
+	mat := colexec.NewMaterializer(
 		&flowCtx,
 		1, /* processorID */
 		colexecargs.OpWithMetaInfo{Root: vee},
@@ -64,9 +60,6 @@ func TestVectorizedInternalPanic(t *testing.T) {
 		nil, /* output */
 		nil, /* cancelFlow */
 	)
-	if err != nil {
-		t.Fatal(err)
-	}
 	mat.Start(ctx)
 
 	var meta *execinfrapb.ProducerMetadata
@@ -94,13 +87,9 @@ func TestNonVectorizedPanicPropagation(t *testing.T) {
 	typs := types.OneIntCol
 	input := execinfra.NewRepeatableRowSource(typs, randgen.MakeIntRows(nRows, nCols))
 
-	col, err := colexec.NewBufferingColumnarizer(testAllocator, &flowCtx, 0 /* processorID */, input)
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	col := colexec.NewBufferingColumnarizer(testAllocator, &flowCtx, 0 /* processorID */, input)
 	nvee := newTestNonVectorizedPanicEmitter(col)
-	mat, err := colexec.NewMaterializer(
+	mat := colexec.NewMaterializer(
 		&flowCtx,
 		1, /* processorID */
 		colexecargs.OpWithMetaInfo{Root: nvee},
@@ -108,9 +97,6 @@ func TestNonVectorizedPanicPropagation(t *testing.T) {
 		nil, /* output */
 		nil, /* cancelFlow */
 	)
-	if err != nil {
-		t.Fatal(err)
-	}
 	mat.Start(ctx)
 
 	require.Panics(t, func() { mat.Next() }, "NonVectorizedPanic was caught by the operators")

--- a/pkg/sql/colflow/vectorized_panic_propagation_test.go
+++ b/pkg/sql/colflow/vectorized_panic_propagation_test.go
@@ -57,8 +57,6 @@ func TestVectorizedInternalPanic(t *testing.T) {
 		1, /* processorID */
 		colexecargs.OpWithMetaInfo{Root: vee},
 		typs,
-		nil, /* output */
-		nil, /* cancelFlow */
 	)
 	mat.Start(ctx)
 
@@ -94,8 +92,6 @@ func TestNonVectorizedPanicPropagation(t *testing.T) {
 		1, /* processorID */
 		colexecargs.OpWithMetaInfo{Root: nvee},
 		typs,
-		nil, /* output */
-		nil, /* cancelFlow */
 	)
 	mat.Start(ctx)
 

--- a/pkg/sql/distsql/columnar_utils_test.go
+++ b/pkg/sql/distsql/columnar_utils_test.go
@@ -171,8 +171,6 @@ func verifyColOperator(t *testing.T, args verifyColOperatorArgs) error {
 		int32(len(args.inputs))+2,
 		result.OpWithMetaInfo,
 		args.pspec.ResultTypes,
-		nil, /* output */
-		nil, /* cancelFlow */
 	)
 
 	outProc.Start(ctx)

--- a/pkg/sql/distsql/columnar_utils_test.go
+++ b/pkg/sql/distsql/columnar_utils_test.go
@@ -130,11 +130,7 @@ func verifyColOperator(t *testing.T, args verifyColOperatorArgs) error {
 	testAllocator := colmem.NewAllocator(ctx, &acc, coldataext.NewExtendedColumnFactory(&evalCtx))
 	columnarizers := make([]colexecop.Operator, len(args.inputs))
 	for i, input := range inputsColOp {
-		c, err := colexec.NewBufferingColumnarizer(testAllocator, flowCtx, int32(i)+1, input)
-		if err != nil {
-			return err
-		}
-		columnarizers[i] = c
+		columnarizers[i] = colexec.NewBufferingColumnarizer(testAllocator, flowCtx, int32(i)+1, input)
 	}
 
 	constructorArgs := &colexecargs.NewColOperatorArgs{
@@ -170,7 +166,7 @@ func verifyColOperator(t *testing.T, args verifyColOperatorArgs) error {
 		}
 	}()
 
-	outColOp, err := colexec.NewMaterializer(
+	outColOp := colexec.NewMaterializer(
 		flowCtx,
 		int32(len(args.inputs))+2,
 		result.OpWithMetaInfo,
@@ -178,9 +174,6 @@ func verifyColOperator(t *testing.T, args verifyColOperatorArgs) error {
 		nil, /* output */
 		nil, /* cancelFlow */
 	)
-	if err != nil {
-		return err
-	}
 
 	outProc.Start(ctx)
 	outColOp.Start(ctx)

--- a/pkg/sql/distsql/vectorized_panic_propagation_test.go
+++ b/pkg/sql/distsql/vectorized_panic_propagation_test.go
@@ -51,7 +51,7 @@ func TestNonVectorizedPanicDoesntHangServer(t *testing.T) {
 	)
 	flow := colflow.NewVectorizedFlow(base)
 
-	mat, err := colexec.NewMaterializer(
+	mat := colexec.NewMaterializer(
 		&flowCtx,
 		0, /* processorID */
 		colexecargs.OpWithMetaInfo{Root: &colexecop.CallbackOperator{
@@ -63,11 +63,8 @@ func TestNonVectorizedPanicDoesntHangServer(t *testing.T) {
 		&distsqlutils.RowBuffer{},
 		nil, /* cancelFlow */
 	)
-	if err != nil {
-		t.Fatal(err)
-	}
 
-	ctx, _, err = base.Setup(ctx, nil, flowinfra.FuseAggressively)
+	ctx, _, err := base.Setup(ctx, nil, flowinfra.FuseAggressively)
 	require.NoError(t, err)
 
 	base.SetProcessors([]execinfra.Processor{mat})

--- a/pkg/sql/distsql/vectorized_panic_propagation_test.go
+++ b/pkg/sql/distsql/vectorized_panic_propagation_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/flowinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/testutils/distsqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/stretchr/testify/require"
 )
@@ -60,8 +59,6 @@ func TestNonVectorizedPanicDoesntHangServer(t *testing.T) {
 			},
 		}},
 		nil, /* typs */
-		&distsqlutils.RowBuffer{},
-		nil, /* cancelFlow */
 	)
 
 	ctx, _, err := base.Setup(ctx, nil, flowinfra.FuseAggressively)

--- a/pkg/sql/execinfra/metadata_test_receiver.go
+++ b/pkg/sql/execinfra/metadata_test_receiver.go
@@ -212,7 +212,7 @@ func (mtr *MetadataTestReceiver) Next() (rowenc.EncDatumRow, *execinfrapb.Produc
 		// We don't use ProcessorBase.ProcessRowHelper() here because we need
 		// special handling for errors: this proc never starts draining in order for
 		// it to be as unintrusive as possible.
-		outRow, ok, err := mtr.Out.ProcessRow(mtr.Ctx, row)
+		outRow, ok, err := mtr.OutputHelper.ProcessRow(mtr.Ctx, row)
 		if err != nil {
 			mtr.trailingMeta = append(mtr.trailingMeta, execinfrapb.ProducerMetadata{Err: err})
 			continue

--- a/pkg/sql/logictest/testdata/logic_test/dist_vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/dist_vectorize
@@ -129,43 +129,38 @@ statement ok
 RESET vectorize
 
 # Regression test for #38919.
-statement ok
-SET optimizer = on
-
 query B
 SELECT EXISTS(SELECT * FROM kv WHERE k > 2)
 ----
 true
-
-statement ok
-RESET optimizer
 
 query T
 EXPLAIN (VEC, VERBOSE) SELECT count(*) FROM kv
 ----
 │
 ├ Node 1
-│ └ *colexec.Materializer
-│   └ *colexec.InvariantsChecker
-│     └ *colexec.orderedAggregator
-│       └ *colexecbase.distinctChainOps
-│         └ *colexec.InvariantsChecker
-│           └ *colexec.ParallelUnorderedSynchronizer
-│             ├ *colexec.InvariantsChecker
-│             │ └ *colexec.countOp
-│             │   └ *colexec.InvariantsChecker
-│             │     └ *colexecbase.simpleProjectOp
-│             │       └ *colexecutils.CancelChecker
-│             │         └ *colexec.InvariantsChecker
-│             │           └ *colfetcher.ColBatchScan
-│             ├ *colexec.InvariantsChecker
-│             │ └ *colrpc.Inbox
-│             ├ *colexec.InvariantsChecker
-│             │ └ *colrpc.Inbox
-│             ├ *colexec.InvariantsChecker
-│             │ └ *colrpc.Inbox
-│             └ *colexec.InvariantsChecker
-│               └ *colrpc.Inbox
+│ └ *colflow.FlowCoordinator
+│   └ *colexec.Materializer
+│     └ *colexec.InvariantsChecker
+│       └ *colexec.orderedAggregator
+│         └ *colexecbase.distinctChainOps
+│           └ *colexec.InvariantsChecker
+│             └ *colexec.ParallelUnorderedSynchronizer
+│               ├ *colexec.InvariantsChecker
+│               │ └ *colexec.countOp
+│               │   └ *colexec.InvariantsChecker
+│               │     └ *colexecbase.simpleProjectOp
+│               │       └ *colexecutils.CancelChecker
+│               │         └ *colexec.InvariantsChecker
+│               │           └ *colfetcher.ColBatchScan
+│               ├ *colexec.InvariantsChecker
+│               │ └ *colrpc.Inbox
+│               ├ *colexec.InvariantsChecker
+│               │ └ *colrpc.Inbox
+│               ├ *colexec.InvariantsChecker
+│               │ └ *colrpc.Inbox
+│               └ *colexec.InvariantsChecker
+│                 └ *colrpc.Inbox
 ├ Node 2
 │ └ *colrpc.Outbox
 │   └ *colexecutils.deselectorOp
@@ -212,65 +207,66 @@ EXPLAIN (VEC, VERBOSE) SELECT count(*) FROM kv NATURAL INNER HASH JOIN kv kv2
 ----
 │
 ├ Node 1
-│ └ *colexec.Materializer
-│   └ *colexec.InvariantsChecker
-│     └ *colexec.orderedAggregator
-│       └ *colexecbase.distinctChainOps
-│         └ *colexec.InvariantsChecker
-│           └ *colexec.ParallelUnorderedSynchronizer
-│             ├ *colexec.InvariantsChecker
-│             │ └ *colexec.countOp
-│             │   └ *colexec.InvariantsChecker
-│             │     └ *colexecbase.simpleProjectOp
-│             │       └ *colexec.diskSpillerBase
-│             │         ├ *colexecjoin.hashJoiner
-│             │         │ ├ *colexec.InvariantsChecker
-│             │         │ │ └ *colexec.ParallelUnorderedSynchronizer
-│             │         │ │   ├ *colexec.InvariantsChecker
-│             │         │ │   │ └ *colflow.routerOutputOp
-│             │         │ │   │   └ *colflow.HashRouter
-│             │         │ │   │     └ *colexec.InvariantsChecker
-│             │         │ │   │       └ *colexecutils.CancelChecker
-│             │         │ │   │         └ *colexec.InvariantsChecker
-│             │         │ │   │           └ *colfetcher.ColBatchScan
-│             │         │ │   ├ *colexec.InvariantsChecker
-│             │         │ │   │ └ *colrpc.Inbox
-│             │         │ │   ├ *colexec.InvariantsChecker
-│             │         │ │   │ └ *colrpc.Inbox
-│             │         │ │   ├ *colexec.InvariantsChecker
-│             │         │ │   │ └ *colrpc.Inbox
-│             │         │ │   └ *colexec.InvariantsChecker
-│             │         │ │     └ *colrpc.Inbox
-│             │         │ └ *colexec.InvariantsChecker
-│             │         │   └ *colexec.ParallelUnorderedSynchronizer
-│             │         │     ├ *colexec.InvariantsChecker
-│             │         │     │ └ *colflow.routerOutputOp
-│             │         │     │   └ *colflow.HashRouter
-│             │         │     │     └ *colexec.InvariantsChecker
-│             │         │     │       └ *colexecutils.CancelChecker
-│             │         │     │         └ *colexec.InvariantsChecker
-│             │         │     │           └ *colfetcher.ColBatchScan
-│             │         │     ├ *colexec.InvariantsChecker
-│             │         │     │ └ *colrpc.Inbox
-│             │         │     ├ *colexec.InvariantsChecker
-│             │         │     │ └ *colrpc.Inbox
-│             │         │     ├ *colexec.InvariantsChecker
-│             │         │     │ └ *colrpc.Inbox
-│             │         │     └ *colexec.InvariantsChecker
-│             │         │       └ *colrpc.Inbox
-│             │         ├ *colexec.InvariantsChecker
-│             │         ├ *colexec.InvariantsChecker
-│             │         └ *colexec.hashBasedPartitioner
-│             │           ├ *colexec.bufferExportingOperator
-│             │           └ *colexec.bufferExportingOperator
-│             ├ *colexec.InvariantsChecker
-│             │ └ *colrpc.Inbox
-│             ├ *colexec.InvariantsChecker
-│             │ └ *colrpc.Inbox
-│             ├ *colexec.InvariantsChecker
-│             │ └ *colrpc.Inbox
-│             └ *colexec.InvariantsChecker
-│               └ *colrpc.Inbox
+│ └ *colflow.FlowCoordinator
+│   └ *colexec.Materializer
+│     └ *colexec.InvariantsChecker
+│       └ *colexec.orderedAggregator
+│         └ *colexecbase.distinctChainOps
+│           └ *colexec.InvariantsChecker
+│             └ *colexec.ParallelUnorderedSynchronizer
+│               ├ *colexec.InvariantsChecker
+│               │ └ *colexec.countOp
+│               │   └ *colexec.InvariantsChecker
+│               │     └ *colexecbase.simpleProjectOp
+│               │       └ *colexec.diskSpillerBase
+│               │         ├ *colexecjoin.hashJoiner
+│               │         │ ├ *colexec.InvariantsChecker
+│               │         │ │ └ *colexec.ParallelUnorderedSynchronizer
+│               │         │ │   ├ *colexec.InvariantsChecker
+│               │         │ │   │ └ *colflow.routerOutputOp
+│               │         │ │   │   └ *colflow.HashRouter
+│               │         │ │   │     └ *colexec.InvariantsChecker
+│               │         │ │   │       └ *colexecutils.CancelChecker
+│               │         │ │   │         └ *colexec.InvariantsChecker
+│               │         │ │   │           └ *colfetcher.ColBatchScan
+│               │         │ │   ├ *colexec.InvariantsChecker
+│               │         │ │   │ └ *colrpc.Inbox
+│               │         │ │   ├ *colexec.InvariantsChecker
+│               │         │ │   │ └ *colrpc.Inbox
+│               │         │ │   ├ *colexec.InvariantsChecker
+│               │         │ │   │ └ *colrpc.Inbox
+│               │         │ │   └ *colexec.InvariantsChecker
+│               │         │ │     └ *colrpc.Inbox
+│               │         │ └ *colexec.InvariantsChecker
+│               │         │   └ *colexec.ParallelUnorderedSynchronizer
+│               │         │     ├ *colexec.InvariantsChecker
+│               │         │     │ └ *colflow.routerOutputOp
+│               │         │     │   └ *colflow.HashRouter
+│               │         │     │     └ *colexec.InvariantsChecker
+│               │         │     │       └ *colexecutils.CancelChecker
+│               │         │     │         └ *colexec.InvariantsChecker
+│               │         │     │           └ *colfetcher.ColBatchScan
+│               │         │     ├ *colexec.InvariantsChecker
+│               │         │     │ └ *colrpc.Inbox
+│               │         │     ├ *colexec.InvariantsChecker
+│               │         │     │ └ *colrpc.Inbox
+│               │         │     ├ *colexec.InvariantsChecker
+│               │         │     │ └ *colrpc.Inbox
+│               │         │     └ *colexec.InvariantsChecker
+│               │         │       └ *colrpc.Inbox
+│               │         ├ *colexec.InvariantsChecker
+│               │         ├ *colexec.InvariantsChecker
+│               │         └ *colexec.hashBasedPartitioner
+│               │           ├ *colexec.bufferExportingOperator
+│               │           └ *colexec.bufferExportingOperator
+│               ├ *colexec.InvariantsChecker
+│               │ └ *colrpc.Inbox
+│               ├ *colexec.InvariantsChecker
+│               │ └ *colrpc.Inbox
+│               ├ *colexec.InvariantsChecker
+│               │ └ *colrpc.Inbox
+│               └ *colexec.InvariantsChecker
+│                 └ *colrpc.Inbox
 ├ Node 2
 │ └ *colrpc.Outbox
 │   └ *colexecutils.deselectorOp

--- a/pkg/sql/opt/exec/execbuilder/testdata/vectorized_planning
+++ b/pkg/sql/opt/exec/execbuilder/testdata/vectorized_planning
@@ -1,0 +1,27 @@
+# LogicTest: local
+
+statement ok
+CREATE TABLE t (id INT PRIMARY KEY);
+
+# Check that there is no columnarizer-materializer pair on top of the root of
+# the execution tree if the root is a wrapped row-execution processor.
+query T
+EXPLAIN (VEC, VERBOSE) INSERT INTO t VALUES (1)
+----
+│
+└ Node 1
+  └ *colflow.FlowCoordinator
+    └ *sql.planNodeToRowSource
+
+query T
+EXPLAIN (VEC, VERBOSE) SELECT * FROM t AS t1 INNER LOOKUP JOIN t AS t2 ON t1.id = t2.id
+----
+│
+└ Node 1
+  └ *colflow.FlowCoordinator
+    └ *rowexec.joinReader
+      └ *colexec.Materializer
+        └ *colexec.InvariantsChecker
+          └ *colexecutils.CancelChecker
+            └ *colexec.InvariantsChecker
+              └ *colfetcher.ColBatchScan

--- a/pkg/sql/rowexec/aggregator.go
+++ b/pkg/sql/rowexec/aggregator.go
@@ -162,7 +162,7 @@ func (ag *aggregatorBase) execStatsForTrace() *execinfrapb.ComponentStats {
 		Exec: execinfrapb.ExecStats{
 			MaxAllocatedMem: optional.MakeUint(uint64(ag.MemMonitor.MaximumBytes())),
 		},
-		Output: ag.Out.Stats(),
+		Output: ag.OutputHelper.Stats(),
 	}
 }
 

--- a/pkg/sql/rowexec/backfiller.go
+++ b/pkg/sql/rowexec/backfiller.go
@@ -92,14 +92,14 @@ func (b *backfiller) Run(ctx context.Context) {
 	defer span.Finish()
 	meta := b.doRun(ctx)
 	execinfra.SendTraceData(ctx, b.output)
-	if emitHelper(ctx, &b.out, nil /* row */, meta, func(ctx context.Context) {}) {
+	if emitHelper(ctx, b.output, &b.out, nil /* row */, meta, func(ctx context.Context) {}) {
 		b.output.ProducerDone()
 	}
 }
 
 func (b *backfiller) doRun(ctx context.Context) *execinfrapb.ProducerMetadata {
 	semaCtx := tree.MakeSemaContext()
-	if err := b.out.Init(&execinfrapb.PostProcessSpec{}, nil, &semaCtx, b.flowCtx.NewEvalCtx(), b.output); err != nil {
+	if err := b.out.Init(&execinfrapb.PostProcessSpec{}, nil, &semaCtx, b.flowCtx.NewEvalCtx()); err != nil {
 		return &execinfrapb.ProducerMetadata{Err: err}
 	}
 	finishedSpans, err := b.mainLoop(ctx)

--- a/pkg/sql/rowexec/countrows.go
+++ b/pkg/sql/rowexec/countrows.go
@@ -85,7 +85,7 @@ func (ag *countAggregator) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMeta
 		if row == nil {
 			ret := make(rowenc.EncDatumRow, 1)
 			ret[0] = rowenc.EncDatum{Datum: tree.NewDInt(tree.DInt(ag.count))}
-			rendered, _, err := ag.Out.ProcessRow(ag.Ctx, ret)
+			rendered, _, err := ag.OutputHelper.ProcessRow(ag.Ctx, ret)
 			// We're done as soon as we process our one output row, so we
 			// transition into draining state. We will, however, return non-nil
 			// error (if such occurs during rendering) separately below.
@@ -108,6 +108,6 @@ func (ag *countAggregator) execStatsForTrace() *execinfrapb.ComponentStats {
 	}
 	return &execinfrapb.ComponentStats{
 		Inputs: []execinfrapb.InputStats{is},
-		Output: ag.Out.Stats(),
+		Output: ag.OutputHelper.Stats(),
 	}
 }

--- a/pkg/sql/rowexec/distinct.go
+++ b/pkg/sql/rowexec/distinct.go
@@ -125,7 +125,7 @@ func newDistinct(
 		}); err != nil {
 		return nil, err
 	}
-	d.lastGroupKey = d.Out.RowAlloc.AllocRow(len(d.types))
+	d.lastGroupKey = d.OutputHelper.RowAlloc.AllocRow(len(d.types))
 	d.haveLastGroupKey = false
 	// If we set up the arena when d is created, the pointer to the memAcc
 	// will be changed because the sortedDistinct case makes a copy of d.
@@ -354,7 +354,7 @@ func (d *distinct) execStatsForTrace() *execinfrapb.ComponentStats {
 		Exec: execinfrapb.ExecStats{
 			MaxAllocatedMem: optional.MakeUint(uint64(d.MemMonitor.MaximumBytes())),
 		},
-		Output: d.Out.Stats(),
+		Output: d.OutputHelper.Stats(),
 	}
 }
 

--- a/pkg/sql/rowexec/filterer.go
+++ b/pkg/sql/rowexec/filterer.go
@@ -114,7 +114,7 @@ func (f *filtererProcessor) execStatsForTrace() *execinfrapb.ComponentStats {
 	}
 	return &execinfrapb.ComponentStats{
 		Inputs: []execinfrapb.InputStats{is},
-		Output: f.Out.Stats(),
+		Output: f.OutputHelper.Stats(),
 	}
 }
 

--- a/pkg/sql/rowexec/hashjoiner.go
+++ b/pkg/sql/rowexec/hashjoiner.go
@@ -569,7 +569,7 @@ func (h *hashJoiner) execStatsForTrace() *execinfrapb.ComponentStats {
 			MaxAllocatedMem:  optional.MakeUint(uint64(h.MemMonitor.MaximumBytes())),
 			MaxAllocatedDisk: optional.MakeUint(uint64(h.diskMonitor.MaximumBytes())),
 		},
-		Output: h.Out.Stats(),
+		Output: h.OutputHelper.Stats(),
 	}
 }
 

--- a/pkg/sql/rowexec/indexbackfiller.go
+++ b/pkg/sql/rowexec/indexbackfiller.go
@@ -358,8 +358,7 @@ func (ib *indexBackfiller) Run(ctx context.Context) {
 	progCh := make(chan execinfrapb.RemoteProducerMetadata_BulkProcessorProgress)
 
 	semaCtx := tree.MakeSemaContext()
-	if err := ib.out.Init(&execinfrapb.PostProcessSpec{}, nil, &semaCtx, ib.flowCtx.NewEvalCtx(),
-		ib.output); err != nil {
+	if err := ib.out.Init(&execinfrapb.PostProcessSpec{}, nil, &semaCtx, ib.flowCtx.NewEvalCtx()); err != nil {
 		ib.output.Push(nil, &execinfrapb.ProducerMetadata{Err: err})
 		return
 	}

--- a/pkg/sql/rowexec/inverted_filterer.go
+++ b/pkg/sql/rowexec/inverted_filterer.go
@@ -321,7 +321,7 @@ func (ifr *invertedFilterer) execStatsForTrace() *execinfrapb.ComponentStats {
 			MaxAllocatedMem:  optional.MakeUint(uint64(ifr.MemMonitor.MaximumBytes())),
 			MaxAllocatedDisk: optional.MakeUint(uint64(ifr.diskMonitor.MaximumBytes())),
 		},
-		Output: ifr.Out.Stats(),
+		Output: ifr.OutputHelper.Stats(),
 	}
 }
 

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -782,7 +782,7 @@ func (ij *invertedJoiner) execStatsForTrace() *execinfrapb.ComponentStats {
 			MaxAllocatedMem:  optional.MakeUint(uint64(ij.MemMonitor.MaximumBytes())),
 			MaxAllocatedDisk: optional.MakeUint(uint64(ij.diskMonitor.MaximumBytes())),
 		},
-		Output: ij.Out.Stats(),
+		Output: ij.OutputHelper.Stats(),
 	}
 }
 

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -460,7 +460,7 @@ func (jr *joinReader) Spilled() bool {
 // neededRightCols returns the set of column indices which need to be fetched
 // from the right side of the join (jr.desc).
 func (jr *joinReader) neededRightCols() util.FastIntSet {
-	neededCols := jr.Out.NeededColumns()
+	neededCols := jr.OutputHelper.NeededColumns()
 
 	if jr.readerType == indexJoinReaderType {
 		// For index joins, all columns from the left side are not output, so no
@@ -743,7 +743,7 @@ func (jr *joinReader) execStatsForTrace() *execinfrapb.ComponentStats {
 			KVTime:         fis.WaitTime,
 			ContentionTime: optional.MakeTimeValue(execinfra.GetCumulativeContentionTime(jr.Ctx)),
 		},
-		Output: jr.Out.Stats(),
+		Output: jr.OutputHelper.Stats(),
 	}
 }
 

--- a/pkg/sql/rowexec/mergejoiner.go
+++ b/pkg/sql/rowexec/mergejoiner.go
@@ -285,7 +285,7 @@ func (m *mergeJoiner) execStatsForTrace() *execinfrapb.ComponentStats {
 		Exec: execinfrapb.ExecStats{
 			MaxAllocatedMem: optional.MakeUint(uint64(m.MemMonitor.MaximumBytes())),
 		},
-		Output: m.Out.Stats(),
+		Output: m.OutputHelper.Stats(),
 	}
 }
 

--- a/pkg/sql/rowexec/noop.go
+++ b/pkg/sql/rowexec/noop.go
@@ -99,7 +99,7 @@ func (n *noopProcessor) execStatsForTrace() *execinfrapb.ComponentStats {
 	}
 	return &execinfrapb.ComponentStats{
 		Inputs: []execinfrapb.InputStats{is},
-		Output: n.Out.Stats(),
+		Output: n.OutputHelper.Stats(),
 	}
 }
 

--- a/pkg/sql/rowexec/ordinality.go
+++ b/pkg/sql/rowexec/ordinality.go
@@ -112,6 +112,6 @@ func (o *ordinalityProcessor) execStatsForTrace() *execinfrapb.ComponentStats {
 	}
 	return &execinfrapb.ComponentStats{
 		Inputs: []execinfrapb.InputStats{is},
-		Output: o.Out.Stats(),
+		Output: o.OutputHelper.Stats(),
 	}
 }

--- a/pkg/sql/rowexec/processors_test.go
+++ b/pkg/sql/rowexec/processors_test.go
@@ -203,7 +203,7 @@ func TestPostProcess(t *testing.T) {
 			semaCtx := tree.MakeSemaContext()
 			evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 			defer evalCtx.Stop(context.Background())
-			if err := out.Init(&tc.post, inBuf.OutputTypes(), &semaCtx, evalCtx, outBuf); err != nil {
+			if err := out.Init(&tc.post, inBuf.OutputTypes(), &semaCtx, evalCtx); err != nil {
 				t.Fatal(err)
 			}
 
@@ -223,12 +223,12 @@ func TestPostProcess(t *testing.T) {
 			}
 			// Run the rows through the helper.
 			for i := range input {
-				status, err := out.EmitRow(context.Background(), input[i])
+				status, err := out.EmitRow(context.Background(), input[i], outBuf)
 				if err != nil {
 					t.Fatal(err)
 				}
 				if status != execinfra.NeedMoreRows {
-					out.Close()
+					outBuf.ProducerDone()
 					break
 				}
 			}

--- a/pkg/sql/rowexec/sample_aggregator.go
+++ b/pkg/sql/rowexec/sample_aggregator.go
@@ -264,7 +264,7 @@ func (s *sampleAggregator) mainLoop(ctx context.Context) (earlyExit bool, err er
 						sr.Disable()
 					}
 				}
-			} else if !emitHelper(ctx, s.Output, &s.Out, nil /* row */, meta, s.pushTrailingMeta, s.input) {
+			} else if !emitHelper(ctx, s.Output, &s.OutputHelper, nil /* row */, meta, s.pushTrailingMeta, s.input) {
 				// No cleanup required; emitHelper() took care of it.
 				return true, nil
 			}

--- a/pkg/sql/rowexec/sample_aggregator.go
+++ b/pkg/sql/rowexec/sample_aggregator.go
@@ -176,7 +176,7 @@ func newSampleAggregator(
 }
 
 func (s *sampleAggregator) pushTrailingMeta(ctx context.Context) {
-	execinfra.SendTraceData(ctx, s.Out.Output())
+	execinfra.SendTraceData(ctx, s.Output)
 }
 
 // Run is part of the Processor interface.
@@ -186,11 +186,11 @@ func (s *sampleAggregator) Run(ctx context.Context) {
 
 	earlyExit, err := s.mainLoop(ctx)
 	if err != nil {
-		execinfra.DrainAndClose(ctx, s.Out.Output(), err, s.pushTrailingMeta, s.input)
+		execinfra.DrainAndClose(ctx, s.Output, err, s.pushTrailingMeta, s.input)
 	} else if !earlyExit {
 		s.pushTrailingMeta(ctx)
 		s.input.ConsumerClosed()
-		s.Out.Close()
+		s.Output.ProducerDone()
 	}
 	s.MoveToDraining(nil /* err */)
 }
@@ -264,7 +264,7 @@ func (s *sampleAggregator) mainLoop(ctx context.Context) (earlyExit bool, err er
 						sr.Disable()
 					}
 				}
-			} else if !emitHelper(ctx, &s.Out, nil /* row */, meta, s.pushTrailingMeta, s.input) {
+			} else if !emitHelper(ctx, s.Output, &s.Out, nil /* row */, meta, s.pushTrailingMeta, s.input) {
 				// No cleanup required; emitHelper() took care of it.
 				return true, nil
 			}

--- a/pkg/sql/rowexec/sampler.go
+++ b/pkg/sql/rowexec/sampler.go
@@ -252,7 +252,7 @@ func (s *samplerProcessor) mainLoop(ctx context.Context) (earlyExit bool, err er
 	for {
 		row, meta := s.input.Next()
 		if meta != nil {
-			if !emitHelper(ctx, s.Output, &s.Out, nil /* row */, meta, s.pushTrailingMeta, s.input) {
+			if !emitHelper(ctx, s.Output, &s.OutputHelper, nil /* row */, meta, s.pushTrailingMeta, s.input) {
 				// No cleanup required; emitHelper() took care of it.
 				return true, nil
 			}
@@ -269,7 +269,7 @@ func (s *samplerProcessor) mainLoop(ctx context.Context) (earlyExit bool, err er
 			meta := &execinfrapb.ProducerMetadata{SamplerProgress: &execinfrapb.RemoteProducerMetadata_SamplerProgress{
 				RowsProcessed: uint64(SamplerProgressInterval),
 			}}
-			if !emitHelper(ctx, s.Output, &s.Out, nil /* row */, meta, s.pushTrailingMeta, s.input) {
+			if !emitHelper(ctx, s.Output, &s.OutputHelper, nil /* row */, meta, s.pushTrailingMeta, s.input) {
 				return true, nil
 			}
 
@@ -369,7 +369,7 @@ func (s *samplerProcessor) mainLoop(ctx context.Context) (earlyExit bool, err er
 	for _, sample := range s.sr.Get() {
 		copy(outRow, sample.Row)
 		outRow[s.rankCol] = rowenc.EncDatum{Datum: tree.NewDInt(tree.DInt(sample.Rank))}
-		if !emitHelper(ctx, s.Output, &s.Out, outRow, nil /* meta */, s.pushTrailingMeta, s.input) {
+		if !emitHelper(ctx, s.Output, &s.OutputHelper, outRow, nil /* meta */, s.pushTrailingMeta, s.input) {
 			return true, nil
 		}
 	}
@@ -383,7 +383,7 @@ func (s *samplerProcessor) mainLoop(ctx context.Context) (earlyExit bool, err er
 			// Reuse the rank column for inverted index keys.
 			outRow[s.rankCol] = rowenc.EncDatum{Datum: tree.NewDInt(tree.DInt(sample.Rank))}
 			outRow[s.invIdxKeyCol] = sample.Row[0]
-			if !emitHelper(ctx, s.Output, &s.Out, outRow, nil /* meta */, s.pushTrailingMeta, s.input) {
+			if !emitHelper(ctx, s.Output, &s.OutputHelper, outRow, nil /* meta */, s.pushTrailingMeta, s.input) {
 				return true, nil
 			}
 		}
@@ -418,7 +418,7 @@ func (s *samplerProcessor) mainLoop(ctx context.Context) (earlyExit bool, err er
 	meta := &execinfrapb.ProducerMetadata{SamplerProgress: &execinfrapb.RemoteProducerMetadata_SamplerProgress{
 		RowsProcessed: uint64(rowCount % SamplerProgressInterval),
 	}}
-	if !emitHelper(ctx, s.Output, &s.Out, nil /* row */, meta, s.pushTrailingMeta, s.input) {
+	if !emitHelper(ctx, s.Output, &s.OutputHelper, nil /* row */, meta, s.pushTrailingMeta, s.input) {
 		return true, nil
 	}
 
@@ -435,7 +435,7 @@ func (s *samplerProcessor) emitSketchRow(
 		return false, err
 	}
 	outRow[s.sketchCol] = rowenc.EncDatum{Datum: tree.NewDBytes(tree.DBytes(data))}
-	if !emitHelper(ctx, s.Output, &s.Out, outRow, nil /* meta */, s.pushTrailingMeta, s.input) {
+	if !emitHelper(ctx, s.Output, &s.OutputHelper, outRow, nil /* meta */, s.pushTrailingMeta, s.input) {
 		return true, nil
 	}
 	return false, nil
@@ -462,7 +462,7 @@ func (s *samplerProcessor) sampleRow(
 		meta := &execinfrapb.ProducerMetadata{SamplerProgress: &execinfrapb.RemoteProducerMetadata_SamplerProgress{
 			HistogramDisabled: true,
 		}}
-		if !emitHelper(ctx, s.Output, &s.Out, nil /* row */, meta, s.pushTrailingMeta, s.input) {
+		if !emitHelper(ctx, s.Output, &s.OutputHelper, nil /* row */, meta, s.pushTrailingMeta, s.input) {
 			return true, nil
 		}
 	}

--- a/pkg/sql/rowexec/sorter.go
+++ b/pkg/sql/rowexec/sorter.go
@@ -136,7 +136,7 @@ func (s *sorterBase) execStatsForTrace() *execinfrapb.ComponentStats {
 			MaxAllocatedMem:  optional.MakeUint(uint64(s.MemMonitor.MaximumBytes())),
 			MaxAllocatedDisk: optional.MakeUint(uint64(s.diskMonitor.MaximumBytes())),
 		},
-		Output: s.Out.Stats(),
+		Output: s.OutputHelper.Stats(),
 	}
 }
 

--- a/pkg/sql/rowexec/tablereader.go
+++ b/pkg/sql/rowexec/tablereader.go
@@ -126,7 +126,7 @@ func newTableReader(
 		return nil, err
 	}
 
-	neededColumns := tr.Out.NeededColumns()
+	neededColumns := tr.OutputHelper.NeededColumns()
 
 	var fetcher row.Fetcher
 	if _, _, err := initRowFetcher(
@@ -301,7 +301,7 @@ func (tr *tableReader) execStatsForTrace() *execinfrapb.ComponentStats {
 			KVTime:         is.WaitTime,
 			ContentionTime: optional.MakeTimeValue(execinfra.GetCumulativeContentionTime(tr.Ctx)),
 		},
-		Output: tr.Out.Stats(),
+		Output: tr.OutputHelper.Stats(),
 	}
 }
 

--- a/pkg/sql/rowexec/windower.go
+++ b/pkg/sql/rowexec/windower.go
@@ -843,7 +843,7 @@ func (w *windower) execStatsForTrace() *execinfrapb.ComponentStats {
 			MaxAllocatedMem:  optional.MakeUint(uint64(w.MemMonitor.MaximumBytes())),
 			MaxAllocatedDisk: optional.MakeUint(uint64(w.diskMonitor.MaximumBytes())),
 		},
-		Output: w.Out.Stats(),
+		Output: w.OutputHelper.Stats(),
 	}
 }
 

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -447,7 +447,7 @@ func (z *zigzagJoiner) setupInfo(
 
 	// Add the outputted columns.
 	neededCols := util.MakeFastIntSet()
-	outCols := z.Out.NeededColumns()
+	outCols := z.OutputHelper.NeededColumns()
 	maxCol := colOffset + len(info.table.PublicColumns())
 	for i, ok := outCols.Next(colOffset); ok && i < maxCol; i, ok = outCols.Next(i + 1) {
 		neededCols.Add(i - colOffset)
@@ -1004,7 +1004,7 @@ func (z *zigzagJoiner) execStatsForTrace() *execinfrapb.ComponentStats {
 	}
 	return &execinfrapb.ComponentStats{
 		KV:     kvStats,
-		Output: z.Out.Stats(),
+		Output: z.OutputHelper.Stats(),
 	}
 }
 

--- a/pkg/sql/sem/tree/eval_test/eval_test.go
+++ b/pkg/sql/sem/tree/eval_test/eval_test.go
@@ -202,8 +202,6 @@ func TestEval(t *testing.T) {
 				0, /* processorID */
 				result.OpWithMetaInfo,
 				[]*types.T{typedExpr.ResolvedType()},
-				nil, /* output */
-				nil, /* cancelFlow */
 			)
 
 			var (

--- a/pkg/sql/sem/tree/eval_test/eval_test.go
+++ b/pkg/sql/sem/tree/eval_test/eval_test.go
@@ -197,7 +197,7 @@ func TestEval(t *testing.T) {
 			result, err := colbuilder.NewColOperator(ctx, flowCtx, args)
 			require.NoError(t, err)
 
-			mat, err := colexec.NewMaterializer(
+			mat := colexec.NewMaterializer(
 				flowCtx,
 				0, /* processorID */
 				result.OpWithMetaInfo,
@@ -205,7 +205,6 @@ func TestEval(t *testing.T) {
 				nil, /* output */
 				nil, /* cancelFlow */
 			)
-			require.NoError(t, err)
 
 			var (
 				row  rowenc.EncDatumRow


### PR DESCRIPTION
**execinfra: refactor ProcessorBase slightly**

Previously, the output of a processor was embedded in
`ProcOutputHelper`. This commit moves it out into the `ProcessorBase`
because the follow-up commit will take advantage of such placement.

Release note: None

**execinfra: rename a field in ProcOutputHelper**

This commit renames `ProcessorBase.Out` to `ProcessorBase.OutputHelper`.
It also removes the large part of the comment on `ProcessorBase` since
it has become quite stale, and it is better to take a look at the
existing users of the struct as a guide (the actual code should be
up-to-date!).

Release note: None

**execinfra: separate out ProcOutputHelper from ProcessorBase**

In some cases, `ProcOutputHelper` that lives in the `ProcessorBase` is
not used by the caller, yet it is always allocated. This commit extracts
`ProcessorBaseNoHelper` that doesn't contain the helper (as well as some
other fields) and uses that in the materializer. This should reduce the
size of the materializers slightly.

This commit was prompted by the fact that the follow-up commit will
introduce another processor (the vectorized flow coordinator) that also
doesn't utilize the `ProcOutputHelper`.

Release note: None

**colflow: introduce flow coordinator and simplify materializer**

This commit extracts the logic of shutting down the vectorized flow out
of the materializer which simplifies the latter. This allows us to
optimize the case when the root of the whole plan is a wrapped
row-execution processor. Previously, in such a scenario we would plan
a columnarizer followed by a materializer because the latter was needed
in order to shut the flow down. This commit removes this redundant pair
of operators.

Informs: #50857.
Informs: #55758.

Release note: None