### PR TITLE
parser: support OPERATOR syntax (cross compatible)

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1318,7 +1318,7 @@ backup_options_list ::=
 	( backup_options ) ( ( ',' backup_options ) )*
 
 a_expr ::=
-	( c_expr | '+' a_expr | '-' a_expr | '~' a_expr | 'SQRT' a_expr | 'CBRT' a_expr | 'NOT' a_expr | 'NOT' a_expr | 'DEFAULT' ) ( ( 'TYPECAST' cast_target | 'TYPEANNOTATE' typename | 'COLLATE' collation_name | 'AT' 'TIME' 'ZONE' a_expr | '+' a_expr | '-' a_expr | '*' a_expr | '/' a_expr | 'FLOORDIV' a_expr | '%' a_expr | '^' a_expr | '#' a_expr | '&' a_expr | '|' a_expr | '<' a_expr | '>' a_expr | '?' a_expr | 'JSON_SOME_EXISTS' a_expr | 'JSON_ALL_EXISTS' a_expr | 'CONTAINS' a_expr | 'CONTAINED_BY' a_expr | '=' a_expr | 'CONCAT' a_expr | 'LSHIFT' a_expr | 'RSHIFT' a_expr | 'FETCHVAL' a_expr | 'FETCHTEXT' a_expr | 'FETCHVAL_PATH' a_expr | 'FETCHTEXT_PATH' a_expr | 'REMOVE_PATH' a_expr | 'INET_CONTAINED_BY_OR_EQUALS' a_expr | 'AND_AND' a_expr | 'INET_CONTAINS_OR_EQUALS' a_expr | 'LESS_EQUALS' a_expr | 'GREATER_EQUALS' a_expr | 'NOT_EQUALS' a_expr | qual_op a_expr | 'AND' a_expr | 'OR' a_expr | 'LIKE' a_expr | 'LIKE' a_expr 'ESCAPE' a_expr | 'NOT' 'LIKE' a_expr | 'NOT' 'LIKE' a_expr 'ESCAPE' a_expr | 'ILIKE' a_expr | 'ILIKE' a_expr 'ESCAPE' a_expr | 'NOT' 'ILIKE' a_expr | 'NOT' 'ILIKE' a_expr 'ESCAPE' a_expr | 'SIMILAR' 'TO' a_expr | 'SIMILAR' 'TO' a_expr 'ESCAPE' a_expr | 'NOT' 'SIMILAR' 'TO' a_expr | 'NOT' 'SIMILAR' 'TO' a_expr 'ESCAPE' a_expr | '~' a_expr | 'NOT_REGMATCH' a_expr | 'REGIMATCH' a_expr | 'NOT_REGIMATCH' a_expr | 'IS' 'NAN' | 'IS' 'NOT' 'NAN' | 'IS' 'NULL' | 'ISNULL' | 'IS' 'NOT' 'NULL' | 'NOTNULL' | 'IS' 'TRUE' | 'IS' 'NOT' 'TRUE' | 'IS' 'FALSE' | 'IS' 'NOT' 'FALSE' | 'IS' 'UNKNOWN' | 'IS' 'NOT' 'UNKNOWN' | 'IS' 'DISTINCT' 'FROM' a_expr | 'IS' 'NOT' 'DISTINCT' 'FROM' a_expr | 'IS' 'OF' '(' type_list ')' | 'IS' 'NOT' 'OF' '(' type_list ')' | 'BETWEEN' opt_asymmetric b_expr 'AND' a_expr | 'NOT' 'BETWEEN' opt_asymmetric b_expr 'AND' a_expr | 'BETWEEN' 'SYMMETRIC' b_expr 'AND' a_expr | 'NOT' 'BETWEEN' 'SYMMETRIC' b_expr 'AND' a_expr | 'IN' in_expr | 'NOT' 'IN' in_expr | subquery_op sub_type a_expr ) )*
+	( c_expr | '+' a_expr | '-' a_expr | '~' a_expr | 'SQRT' a_expr | 'CBRT' a_expr | qual_op a_expr | 'NOT' a_expr | 'NOT' a_expr | 'DEFAULT' ) ( ( 'TYPECAST' cast_target | 'TYPEANNOTATE' typename | 'COLLATE' collation_name | 'AT' 'TIME' 'ZONE' a_expr | '+' a_expr | '-' a_expr | '*' a_expr | '/' a_expr | 'FLOORDIV' a_expr | '%' a_expr | '^' a_expr | '#' a_expr | '&' a_expr | '|' a_expr | '<' a_expr | '>' a_expr | '?' a_expr | 'JSON_SOME_EXISTS' a_expr | 'JSON_ALL_EXISTS' a_expr | 'CONTAINS' a_expr | 'CONTAINED_BY' a_expr | '=' a_expr | 'CONCAT' a_expr | 'LSHIFT' a_expr | 'RSHIFT' a_expr | 'FETCHVAL' a_expr | 'FETCHTEXT' a_expr | 'FETCHVAL_PATH' a_expr | 'FETCHTEXT_PATH' a_expr | 'REMOVE_PATH' a_expr | 'INET_CONTAINED_BY_OR_EQUALS' a_expr | 'AND_AND' a_expr | 'INET_CONTAINS_OR_EQUALS' a_expr | 'LESS_EQUALS' a_expr | 'GREATER_EQUALS' a_expr | 'NOT_EQUALS' a_expr | qual_op a_expr | 'AND' a_expr | 'OR' a_expr | 'LIKE' a_expr | 'LIKE' a_expr 'ESCAPE' a_expr | 'NOT' 'LIKE' a_expr | 'NOT' 'LIKE' a_expr 'ESCAPE' a_expr | 'ILIKE' a_expr | 'ILIKE' a_expr 'ESCAPE' a_expr | 'NOT' 'ILIKE' a_expr | 'NOT' 'ILIKE' a_expr 'ESCAPE' a_expr | 'SIMILAR' 'TO' a_expr | 'SIMILAR' 'TO' a_expr 'ESCAPE' a_expr | 'NOT' 'SIMILAR' 'TO' a_expr | 'NOT' 'SIMILAR' 'TO' a_expr 'ESCAPE' a_expr | '~' a_expr | 'NOT_REGMATCH' a_expr | 'REGIMATCH' a_expr | 'NOT_REGIMATCH' a_expr | 'IS' 'NAN' | 'IS' 'NOT' 'NAN' | 'IS' 'NULL' | 'ISNULL' | 'IS' 'NOT' 'NULL' | 'NOTNULL' | 'IS' 'TRUE' | 'IS' 'NOT' 'TRUE' | 'IS' 'FALSE' | 'IS' 'NOT' 'FALSE' | 'IS' 'UNKNOWN' | 'IS' 'NOT' 'UNKNOWN' | 'IS' 'DISTINCT' 'FROM' a_expr | 'IS' 'NOT' 'DISTINCT' 'FROM' a_expr | 'IS' 'OF' '(' type_list ')' | 'IS' 'NOT' 'OF' '(' type_list ')' | 'BETWEEN' opt_asymmetric b_expr 'AND' a_expr | 'NOT' 'BETWEEN' opt_asymmetric b_expr 'AND' a_expr | 'BETWEEN' 'SYMMETRIC' b_expr 'AND' a_expr | 'NOT' 'BETWEEN' 'SYMMETRIC' b_expr 'AND' a_expr | 'IN' in_expr | 'NOT' 'IN' in_expr | subquery_op sub_type a_expr ) )*
 
 for_schedules_clause ::=
 	'FOR' 'SCHEDULES' select_stmt
@@ -1787,21 +1787,21 @@ c_expr ::=
 	| case_expr
 	| 'EXISTS' select_with_parens
 
+qual_op ::=
+	'OPERATOR' '(' operator_op ')'
+
 cast_target ::=
 	typename
 
 collation_name ::=
 	unrestricted_name
 
-qual_op ::=
-	'OPERATOR' '(' operator_op ')'
-
 opt_asymmetric ::=
 	'ASYMMETRIC'
 	| 
 
 b_expr ::=
-	( c_expr | '+' b_expr | '-' b_expr | '~' b_expr ) ( ( 'TYPECAST' cast_target | 'TYPEANNOTATE' typename | '+' b_expr | '-' b_expr | '*' b_expr | '/' b_expr | 'FLOORDIV' b_expr | '%' b_expr | '^' b_expr | '#' b_expr | '&' b_expr | '|' b_expr | '<' b_expr | '>' b_expr | '=' b_expr | 'CONCAT' b_expr | 'LSHIFT' b_expr | 'RSHIFT' b_expr | 'LESS_EQUALS' b_expr | 'GREATER_EQUALS' b_expr | 'NOT_EQUALS' b_expr | qual_op b_expr | 'IS' 'DISTINCT' 'FROM' b_expr | 'IS' 'NOT' 'DISTINCT' 'FROM' b_expr | 'IS' 'OF' '(' type_list ')' | 'IS' 'NOT' 'OF' '(' type_list ')' ) )*
+	( c_expr | '+' b_expr | '-' b_expr | '~' b_expr | qual_op b_expr ) ( ( 'TYPECAST' cast_target | 'TYPEANNOTATE' typename | '+' b_expr | '-' b_expr | '*' b_expr | '/' b_expr | 'FLOORDIV' b_expr | '%' b_expr | '^' b_expr | '#' b_expr | '&' b_expr | '|' b_expr | '<' b_expr | '>' b_expr | '=' b_expr | 'CONCAT' b_expr | 'LSHIFT' b_expr | 'RSHIFT' b_expr | 'LESS_EQUALS' b_expr | 'GREATER_EQUALS' b_expr | 'NOT_EQUALS' b_expr | qual_op b_expr | 'IS' 'DISTINCT' 'FROM' b_expr | 'IS' 'NOT' 'DISTINCT' 'FROM' b_expr | 'IS' 'OF' '(' type_list ')' | 'IS' 'NOT' 'OF' '(' type_list ')' ) )*
 
 in_expr ::=
 	select_with_parens
@@ -2333,6 +2333,9 @@ all_op ::=
 	| 'REGIMATCH'
 	| 'NOT_REGIMATCH'
 	| 'AND_AND'
+	| '~'
+	| 'SQRT'
+	| 'CBRT'
 
 opt_equal ::=
 	'='

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1318,7 +1318,7 @@ backup_options_list ::=
 	( backup_options ) ( ( ',' backup_options ) )*
 
 a_expr ::=
-	( c_expr | '+' a_expr | '-' a_expr | '~' a_expr | 'SQRT' a_expr | 'CBRT' a_expr | 'NOT' a_expr | 'NOT' a_expr | 'DEFAULT' ) ( ( 'TYPECAST' cast_target | 'TYPEANNOTATE' typename | 'COLLATE' collation_name | 'AT' 'TIME' 'ZONE' a_expr | '+' a_expr | '-' a_expr | '*' a_expr | '/' a_expr | 'FLOORDIV' a_expr | '%' a_expr | '^' a_expr | '#' a_expr | '&' a_expr | '|' a_expr | '<' a_expr | '>' a_expr | '?' a_expr | 'JSON_SOME_EXISTS' a_expr | 'JSON_ALL_EXISTS' a_expr | 'CONTAINS' a_expr | 'CONTAINED_BY' a_expr | '=' a_expr | 'CONCAT' a_expr | 'LSHIFT' a_expr | 'RSHIFT' a_expr | 'FETCHVAL' a_expr | 'FETCHTEXT' a_expr | 'FETCHVAL_PATH' a_expr | 'FETCHTEXT_PATH' a_expr | 'REMOVE_PATH' a_expr | 'INET_CONTAINED_BY_OR_EQUALS' a_expr | 'AND_AND' a_expr | 'INET_CONTAINS_OR_EQUALS' a_expr | 'LESS_EQUALS' a_expr | 'GREATER_EQUALS' a_expr | 'NOT_EQUALS' a_expr | 'AND' a_expr | 'OR' a_expr | 'LIKE' a_expr | 'LIKE' a_expr 'ESCAPE' a_expr | 'NOT' 'LIKE' a_expr | 'NOT' 'LIKE' a_expr 'ESCAPE' a_expr | 'ILIKE' a_expr | 'ILIKE' a_expr 'ESCAPE' a_expr | 'NOT' 'ILIKE' a_expr | 'NOT' 'ILIKE' a_expr 'ESCAPE' a_expr | 'SIMILAR' 'TO' a_expr | 'SIMILAR' 'TO' a_expr 'ESCAPE' a_expr | 'NOT' 'SIMILAR' 'TO' a_expr | 'NOT' 'SIMILAR' 'TO' a_expr 'ESCAPE' a_expr | '~' a_expr | 'NOT_REGMATCH' a_expr | 'REGIMATCH' a_expr | 'NOT_REGIMATCH' a_expr | 'IS' 'NAN' | 'IS' 'NOT' 'NAN' | 'IS' 'NULL' | 'ISNULL' | 'IS' 'NOT' 'NULL' | 'NOTNULL' | 'IS' 'TRUE' | 'IS' 'NOT' 'TRUE' | 'IS' 'FALSE' | 'IS' 'NOT' 'FALSE' | 'IS' 'UNKNOWN' | 'IS' 'NOT' 'UNKNOWN' | 'IS' 'DISTINCT' 'FROM' a_expr | 'IS' 'NOT' 'DISTINCT' 'FROM' a_expr | 'IS' 'OF' '(' type_list ')' | 'IS' 'NOT' 'OF' '(' type_list ')' | 'BETWEEN' opt_asymmetric b_expr 'AND' a_expr | 'NOT' 'BETWEEN' opt_asymmetric b_expr 'AND' a_expr | 'BETWEEN' 'SYMMETRIC' b_expr 'AND' a_expr | 'NOT' 'BETWEEN' 'SYMMETRIC' b_expr 'AND' a_expr | 'IN' in_expr | 'NOT' 'IN' in_expr | subquery_op sub_type a_expr ) )*
+	( c_expr | '+' a_expr | '-' a_expr | '~' a_expr | 'SQRT' a_expr | 'CBRT' a_expr | 'NOT' a_expr | 'NOT' a_expr | 'DEFAULT' ) ( ( 'TYPECAST' cast_target | 'TYPEANNOTATE' typename | 'COLLATE' collation_name | 'AT' 'TIME' 'ZONE' a_expr | '+' a_expr | '-' a_expr | '*' a_expr | '/' a_expr | 'FLOORDIV' a_expr | '%' a_expr | '^' a_expr | '#' a_expr | '&' a_expr | '|' a_expr | '<' a_expr | '>' a_expr | '?' a_expr | 'JSON_SOME_EXISTS' a_expr | 'JSON_ALL_EXISTS' a_expr | 'CONTAINS' a_expr | 'CONTAINED_BY' a_expr | '=' a_expr | 'CONCAT' a_expr | 'LSHIFT' a_expr | 'RSHIFT' a_expr | 'FETCHVAL' a_expr | 'FETCHTEXT' a_expr | 'FETCHVAL_PATH' a_expr | 'FETCHTEXT_PATH' a_expr | 'REMOVE_PATH' a_expr | 'INET_CONTAINED_BY_OR_EQUALS' a_expr | 'AND_AND' a_expr | 'INET_CONTAINS_OR_EQUALS' a_expr | 'LESS_EQUALS' a_expr | 'GREATER_EQUALS' a_expr | 'NOT_EQUALS' a_expr | qual_op a_expr | 'AND' a_expr | 'OR' a_expr | 'LIKE' a_expr | 'LIKE' a_expr 'ESCAPE' a_expr | 'NOT' 'LIKE' a_expr | 'NOT' 'LIKE' a_expr 'ESCAPE' a_expr | 'ILIKE' a_expr | 'ILIKE' a_expr 'ESCAPE' a_expr | 'NOT' 'ILIKE' a_expr | 'NOT' 'ILIKE' a_expr 'ESCAPE' a_expr | 'SIMILAR' 'TO' a_expr | 'SIMILAR' 'TO' a_expr 'ESCAPE' a_expr | 'NOT' 'SIMILAR' 'TO' a_expr | 'NOT' 'SIMILAR' 'TO' a_expr 'ESCAPE' a_expr | '~' a_expr | 'NOT_REGMATCH' a_expr | 'REGIMATCH' a_expr | 'NOT_REGIMATCH' a_expr | 'IS' 'NAN' | 'IS' 'NOT' 'NAN' | 'IS' 'NULL' | 'ISNULL' | 'IS' 'NOT' 'NULL' | 'NOTNULL' | 'IS' 'TRUE' | 'IS' 'NOT' 'TRUE' | 'IS' 'FALSE' | 'IS' 'NOT' 'FALSE' | 'IS' 'UNKNOWN' | 'IS' 'NOT' 'UNKNOWN' | 'IS' 'DISTINCT' 'FROM' a_expr | 'IS' 'NOT' 'DISTINCT' 'FROM' a_expr | 'IS' 'OF' '(' type_list ')' | 'IS' 'NOT' 'OF' '(' type_list ')' | 'BETWEEN' opt_asymmetric b_expr 'AND' a_expr | 'NOT' 'BETWEEN' opt_asymmetric b_expr 'AND' a_expr | 'BETWEEN' 'SYMMETRIC' b_expr 'AND' a_expr | 'NOT' 'BETWEEN' 'SYMMETRIC' b_expr 'AND' a_expr | 'IN' in_expr | 'NOT' 'IN' in_expr | subquery_op sub_type a_expr ) )*
 
 for_schedules_clause ::=
 	'FOR' 'SCHEDULES' select_stmt
@@ -1793,19 +1793,23 @@ cast_target ::=
 collation_name ::=
 	unrestricted_name
 
+qual_op ::=
+	'OPERATOR' '(' operator_op ')'
+
 opt_asymmetric ::=
 	'ASYMMETRIC'
 	| 
 
 b_expr ::=
-	( c_expr | '+' b_expr | '-' b_expr | '~' b_expr ) ( ( 'TYPECAST' cast_target | 'TYPEANNOTATE' typename | '+' b_expr | '-' b_expr | '*' b_expr | '/' b_expr | 'FLOORDIV' b_expr | '%' b_expr | '^' b_expr | '#' b_expr | '&' b_expr | '|' b_expr | '<' b_expr | '>' b_expr | '=' b_expr | 'CONCAT' b_expr | 'LSHIFT' b_expr | 'RSHIFT' b_expr | 'LESS_EQUALS' b_expr | 'GREATER_EQUALS' b_expr | 'NOT_EQUALS' b_expr | 'IS' 'DISTINCT' 'FROM' b_expr | 'IS' 'NOT' 'DISTINCT' 'FROM' b_expr | 'IS' 'OF' '(' type_list ')' | 'IS' 'NOT' 'OF' '(' type_list ')' ) )*
+	( c_expr | '+' b_expr | '-' b_expr | '~' b_expr ) ( ( 'TYPECAST' cast_target | 'TYPEANNOTATE' typename | '+' b_expr | '-' b_expr | '*' b_expr | '/' b_expr | 'FLOORDIV' b_expr | '%' b_expr | '^' b_expr | '#' b_expr | '&' b_expr | '|' b_expr | '<' b_expr | '>' b_expr | '=' b_expr | 'CONCAT' b_expr | 'LSHIFT' b_expr | 'RSHIFT' b_expr | 'LESS_EQUALS' b_expr | 'GREATER_EQUALS' b_expr | 'NOT_EQUALS' b_expr | qual_op b_expr | 'IS' 'DISTINCT' 'FROM' b_expr | 'IS' 'NOT' 'DISTINCT' 'FROM' b_expr | 'IS' 'OF' '(' type_list ')' | 'IS' 'NOT' 'OF' '(' type_list ')' ) )*
 
 in_expr ::=
 	select_with_parens
 	| expr_tuple1_ambiguous
 
 subquery_op ::=
-	math_op
+	all_op
+	| qual_op
 	| 'LIKE'
 	| 'NOT' 'LIKE'
 	| 'ILIKE'
@@ -2289,27 +2293,46 @@ array_subscripts ::=
 case_expr ::=
 	'CASE' case_arg when_clause_list case_default 'END'
 
+operator_op ::=
+	all_op
+
 expr_tuple1_ambiguous ::=
 	'(' ')'
 	| '(' tuple1_ambiguous_values ')'
 
-math_op ::=
+all_op ::=
 	'+'
 	| '-'
 	| '*'
 	| '/'
-	| 'FLOORDIV'
 	| '%'
-	| '&'
-	| '|'
 	| '^'
-	| '#'
 	| '<'
 	| '>'
 	| '='
 	| 'LESS_EQUALS'
 	| 'GREATER_EQUALS'
 	| 'NOT_EQUALS'
+	| '?'
+	| '&'
+	| '|'
+	| '#'
+	| 'FLOORDIV'
+	| 'CONTAINS'
+	| 'CONTAINED_BY'
+	| 'LSHIFT'
+	| 'RSHIFT'
+	| 'CONCAT'
+	| 'FETCHVAL'
+	| 'FETCHTEXT'
+	| 'FETCHVAL_PATH'
+	| 'FETCHTEXT_PATH'
+	| 'JSON_SOME_EXISTS'
+	| 'JSON_ALL_EXISTS'
+	| 'NOT_REGMATCH'
+	| 'REGIMATCH'
+	| 'NOT_REGIMATCH'
+	| 'AND_AND'
 
 opt_equal ::=
 	'='

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -573,6 +573,8 @@ func TestUnimplementedSyntax(t *testing.T) {
 		{`REINDEX SYSTEM a`, 0, `reindex system`, `CockroachDB does not require reindexing.`},
 
 		{`UPSERT INTO foo(a, a.b) VALUES (1,2)`, 27792, ``, ``},
+
+		{`SELECT 1 OPERATOR(public.+) 2`, 0, `user defined operator`, ``},
 	}
 	for _, d := range testData {
 		t.Run(d.sql, func(t *testing.T) {

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -409,7 +409,7 @@ func TestUnimplementedSyntax(t *testing.T) {
 		{`CREATE FUNCTION a`, 17511, `create`, ``},
 		{`CREATE OR REPLACE FUNCTION a`, 17511, `create`, ``},
 		{`CREATE LANGUAGE a`, 17511, `create language a`, ``},
-		{`CREATE OPERATOR a`, 0, `create operator`, ``},
+		{`CREATE OPERATOR a`, 65017, ``, ``},
 		{`CREATE PUBLICATION a`, 0, `create publication`, ``},
 		{`CREATE RULE a`, 0, `create rule`, ``},
 		{`CREATE SERVER a`, 0, `create server`, ``},
@@ -574,7 +574,7 @@ func TestUnimplementedSyntax(t *testing.T) {
 
 		{`UPSERT INTO foo(a, a.b) VALUES (1,2)`, 27792, ``, ``},
 
-		{`SELECT 1 OPERATOR(public.+) 2`, 0, `user defined operator`, ``},
+		{`SELECT 1 OPERATOR(public.+) 2`, 65017, ``, ``},
 	}
 	for _, d := range testData {
 		t.Run(d.sql, func(t *testing.T) {

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -3276,7 +3276,7 @@ create_unsupported:
 | CREATE FUNCTION error { return unimplementedWithIssueDetail(sqllex, 17511, "create function") }
 | CREATE OR REPLACE FUNCTION error { return unimplementedWithIssueDetail(sqllex, 17511, "create function") }
 | CREATE opt_or_replace opt_trusted opt_procedural LANGUAGE name error { return unimplementedWithIssueDetail(sqllex, 17511, "create language " + $6) }
-| CREATE OPERATOR error { return unimplemented(sqllex, "create operator") }
+| CREATE OPERATOR error { return unimplementedWithIssue(sqllex, 65017) }
 | CREATE PUBLICATION error { return unimplemented(sqllex, "create publication") }
 | CREATE opt_or_replace RULE error { return unimplemented(sqllex, "create rule") }
 | CREATE SERVER error { return unimplemented(sqllex, "create server") }
@@ -11588,7 +11588,7 @@ operator_op:
   {
     // Only support operators on pg_catalog.
     if $1 != "pg_catalog" {
-      return unimplemented(sqllex, "user defined operator")
+      return unimplementedWithIssue(sqllex, 65017)
     }
     $$ = $3
   }

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -71,6 +71,22 @@ func unimplementedWithIssueDetail(sqllex sqlLexer, issue int, detail string) int
     return 1
 }
 
+func processBinaryQualOp(
+  sqllex sqlLexer,
+  op tree.Operator,
+  lhs tree.Expr,
+  rhs tree.Expr,
+) (tree.Expr, int) {
+    switch op := op.(type) {
+    case tree.BinaryOperator:
+      return &tree.BinaryExpr{Operator: op, Left: lhs, Right: rhs}, 0
+    case tree.ComparisonOperator:
+      return &tree.ComparisonExpr{Operator: op, Left: lhs, Right: rhs}, 0
+    default:
+      sqllex.Error(fmt.Sprintf("unknown binary operator %s", op))
+      return nil, 1
+    }
+}
 
 %}
 
@@ -1011,7 +1027,7 @@ func (u *sqlSymUnion) objectNamePrefixList() tree.ObjectNamePrefixList {
 %type <*tree.TableIndexName> table_index_name
 %type <tree.TableIndexNames> table_index_name_list
 
-%type <tree.Operator> math_op
+%type <tree.Operator> all_op qual_op operator_op
 
 %type <tree.IsolationLevel> iso_level
 %type <tree.UserPriority> user_priority
@@ -1278,6 +1294,7 @@ func (u *sqlSymUnion) objectNamePrefixList() tree.ObjectNamePrefixList {
 %left      '#'
 %left      '&'
 %left      LSHIFT RSHIFT INET_CONTAINS_OR_EQUALS INET_CONTAINED_BY_OR_EQUALS AND_AND SQRT CBRT
+%left      OPERATOR // if changing the last token before OPERATOR, change all instances of %prec <last token>
 %left      '+' '-'
 %left      '*' '/' FLOORDIV '%'
 %left      '^'
@@ -8886,9 +8903,6 @@ opt_nulls_order:
     $$.val = tree.DefaultNullsOrder
   }
 
-// TODO(pmattis): Support ordering using arbitrary math ops?
-// | a_expr USING math_op {}
-
 select_limit:
   limit_clause offset_clause
   {
@@ -10241,7 +10255,7 @@ a_expr:
   // operators will have the same precedence.
   //
   // If you add more explicitly-known operators, be sure to add them also to
-  // b_expr and to the math_op list below.
+  // b_expr and to the all_op list below.
 | '+' a_expr %prec UMINUS
   {
     // Unary plus is a no-op. Desugar immediately.
@@ -10390,6 +10404,16 @@ a_expr:
 | a_expr NOT_EQUALS a_expr
   {
     $$.val = &tree.ComparisonExpr{Operator: tree.NE, Left: $1.expr(), Right: $3.expr()}
+  }
+| a_expr qual_op a_expr %prec CBRT
+  {
+    {
+      var retCode int
+      $$.val, retCode = processBinaryQualOp(sqllex, $2.op(), $1.expr(), $3.expr())
+      if retCode != 0 {
+        return retCode
+      }
+    }
   }
 | a_expr AND a_expr
   {
@@ -10689,6 +10713,16 @@ b_expr:
 | b_expr NOT_EQUALS b_expr
   {
     $$.val = &tree.ComparisonExpr{Operator: tree.NE, Left: $1.expr(), Right: $3.expr()}
+  }
+| b_expr qual_op b_expr %prec CBRT
+  {
+    {
+      var retCode int
+      $$.val, retCode = processBinaryQualOp(sqllex, $2.op(), $1.expr(), $3.expr())
+      if retCode != 0 {
+        return retCode
+      }
+    }
   }
 | b_expr IS DISTINCT FROM b_expr %prec IS
   {
@@ -11456,26 +11490,78 @@ sub_type:
     $$.val = tree.All
   }
 
-math_op:
+// We combine mathOp and Op from PostgreSQL's gram.y there.
+// In PostgreSQL, mathOp have an order of operations as defined by the
+// assoc rules.
+//
+// In CockroachDB, we have defined further operations that have a defined
+// order of operations (e.g. <@, |, &, ~, #, FLOORDIV) which is broken
+// if we split them up to math_ops and ops, which breaks compatibility
+// with PostgreSQL's qual_op.
+//
+// Ensure you also update process.*QualOp above when adding to this.
+all_op:
+  // exactly from MathOp
   '+' { $$.val = tree.Plus  }
 | '-' { $$.val = tree.Minus }
 | '*' { $$.val = tree.Mult  }
 | '/' { $$.val = tree.Div   }
-| FLOORDIV { $$.val = tree.FloorDiv }
 | '%' { $$.val = tree.Mod    }
-| '&' { $$.val = tree.Bitand }
-| '|' { $$.val = tree.Bitor  }
 | '^' { $$.val = tree.Pow }
-| '#' { $$.val = tree.Bitxor }
 | '<' { $$.val = tree.LT }
 | '>' { $$.val = tree.GT }
 | '=' { $$.val = tree.EQ }
 | LESS_EQUALS    { $$.val = tree.LE }
 | GREATER_EQUALS { $$.val = tree.GE }
 | NOT_EQUALS     { $$.val = tree.NE }
+  // partial set of operators from from Op
+| '?' { $$.val = tree.JSONExists }
+| '&' { $$.val = tree.Bitand }
+| '|' { $$.val = tree.Bitor  }
+| '#' { $$.val = tree.Bitxor }
+| FLOORDIV { $$.val = tree.FloorDiv }
+| CONTAINS { $$.val = tree.Contains }
+| CONTAINED_BY { $$.val = tree.ContainedBy }
+| LSHIFT { $$.val = tree.LShift }
+| RSHIFT { $$.val = tree.RShift }
+| CONCAT { $$.val = tree.Concat }
+| FETCHVAL { $$.val = tree.JSONFetchVal }
+| FETCHTEXT { $$.val = tree.JSONFetchText }
+| FETCHVAL_PATH { $$.val = tree.JSONFetchValPath }
+| FETCHTEXT_PATH { $$.val = tree.JSONFetchTextPath }
+| JSON_SOME_EXISTS { $$.val = tree.JSONSomeExists }
+| JSON_ALL_EXISTS { $$.val = tree.JSONAllExists }
+| NOT_REGMATCH { $$.val = tree.NotRegMatch }
+| REGIMATCH { $$.val = tree.RegIMatch }
+| NOT_REGIMATCH { $$.val = tree.NotRegIMatch }
+| AND_AND { $$.val = tree.Overlaps }
+
+operator_op:
+  all_op
+| name '.' all_op
+  {
+    // Only support operators on pg_catalog.
+    if $1 != "pg_catalog" {
+      return unimplemented(sqllex, "user defined operator")
+    }
+    $$ = $3
+  }
+
+// qual_op partially matches qualOp PostgreSQL's gram.y.
+// In an ideal circumstance, we also include non math_ops in this
+// definition. However, this would break cross compatibility as we
+// need %prec (keyword before OPERATOR) in a_expr/b_expr, which
+// breaks order of operations for older versions of CockroachDB.
+// See #64699 for the attempt.
+qual_op:
+  OPERATOR '(' operator_op ')'
+  {
+    $$ = $3
+  }
 
 subquery_op:
-  math_op
+  all_op
+| qual_op
 | LIKE         { $$.val = tree.Like     }
 | NOT_LA LIKE  { $$.val = tree.NotLike  }
 | ILIKE        { $$.val = tree.ILike    }

--- a/pkg/sql/parser/testdata/errors
+++ b/pkg/sql/parser/testdata/errors
@@ -740,3 +740,20 @@ at or near "EOF": syntax error: type unknown[] does not exist
 DETAIL: source SQL:
 SELECT ARRAY[]::unknown[]
                          ^
+
+error
+SELECT 1 ||/ 5
+----
+at or near "5": syntax error
+DETAIL: source SQL:
+SELECT 1 ||/ 5
+             ^
+HINT: try \h SELECT
+
+error
+SELECT OPERATOR(#) 5
+----
+at or near "EOF": syntax error: unknown unary operator #
+DETAIL: source SQL:
+SELECT OPERATOR(#) 5
+                    ^

--- a/pkg/sql/parser/testdata/parse/create_table
+++ b/pkg/sql/parser/testdata/parse/create_table
@@ -2158,3 +2158,14 @@ CREATE TABLE arr_t (i INT8 DEFAULT (ARRAY[1, 2, 3]::INT8[])[2]) -- normalized!
 CREATE TABLE arr_t (i INT8 DEFAULT (((((ARRAY[(1), (2), (3)])::INT8[])))[(2)])) -- fully parenthetized
 CREATE TABLE arr_t (i INT8 DEFAULT (ARRAY[_, _, __more1__]::INT8[])[_]) -- literals removed
 CREATE TABLE _ (_ INT8 DEFAULT (ARRAY[1, 2, 3]::INT8[])[2]) -- identifiers removed
+
+parse
+CREATE TABLE operator_tbl (
+  a INT DEFAULT 1 OPERATOR(+) 2,
+  b INT DEFAULT 1 OPERATOR(pg_catalog.+) 2
+)
+----
+CREATE TABLE operator_tbl (a INT8 DEFAULT 1 + 2, b INT8 DEFAULT 1 + 2) -- normalized!
+CREATE TABLE operator_tbl (a INT8 DEFAULT ((1) + (2)), b INT8 DEFAULT ((1) + (2))) -- fully parenthetized
+CREATE TABLE operator_tbl (a INT8 DEFAULT _ + _, b INT8 DEFAULT _ + _) -- literals removed
+CREATE TABLE _ (_ INT8 DEFAULT 1 + 2, _ INT8 DEFAULT 1 + 2) -- identifiers removed

--- a/pkg/sql/parser/testdata/parse/select_exprs
+++ b/pkg/sql/parser/testdata/parse/select_exprs
@@ -1631,3 +1631,11 @@ SELECT 1 << 2, 1 << 2 -- normalized!
 SELECT ((1) << (2)), ((1) << (2)) -- fully parenthetized
 SELECT _ << _, _ << _ -- literals removed
 SELECT 1 << 2, 1 << 2 -- identifiers removed
+
+parse
+SELECT OPERATOR(+) 1, OPERATOR(-) 1, OPERATOR(~) 1, OPERATOR(|/) 1, OPERATOR(||/) 1
+----
+SELECT 1, -1, ~1, |/1, ||/1 -- normalized!
+SELECT (1), (-1), (~(1)), (|/(1)), (||/(1)) -- fully parenthetized
+SELECT _, _, ~_, |/_, ||/_ -- literals removed
+SELECT 1, -1, ~1, |/1, ||/1 -- identifiers removed

--- a/pkg/sql/parser/testdata/parse/select_exprs
+++ b/pkg/sql/parser/testdata/parse/select_exprs
@@ -1615,3 +1615,19 @@ SELECT (1 + COALESCE(NULL, 'a', x)) - ARRAY[3.14] -- normalized!
 SELECT ((((1) + (COALESCE((NULL), ('a'), (x))))) - (ARRAY[(3.14)])) -- fully parenthetized
 SELECT (_ + COALESCE(_, _, x)) - ARRAY[_] -- literals removed
 SELECT (1 + COALESCE(NULL, 'a', _)) - ARRAY[3.14] -- identifiers removed
+
+parse
+SELECT 1 OPERATOR(+) 2, 1 OPERATOR(pg_catalog.+) 2
+----
+SELECT 1 + 2, 1 + 2 -- normalized!
+SELECT ((1) + (2)), ((1) + (2)) -- fully parenthetized
+SELECT _ + _, _ + _ -- literals removed
+SELECT 1 + 2, 1 + 2 -- identifiers removed
+
+parse
+SELECT 1 OPERATOR(<<) 2, 1 OPERATOR(pg_catalog.<<) 2
+----
+SELECT 1 << 2, 1 << 2 -- normalized!
+SELECT ((1) << (2)), ((1) << (2)) -- fully parenthetized
+SELECT _ << _, _ << _ -- literals removed
+SELECT 1 << 2, 1 << 2 -- identifiers removed


### PR DESCRIPTION
See individual commits for details.

Resolves #53080. This version is cross compatible with older versions of CRDB.