### PR TITLE
pkg/cli: new flag `--log-config-file` to simplify log configuration

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1111,22 +1111,26 @@ Available Commands:
   help              Help about any command
 
 Flags:
-  -h, --help                 help for cockroach
-      --log <string>         
-                              Logging configuration, expressed using YAML syntax. For example, you can
-                              change the default logging directory with: --log='file-defaults: {dir: ...}'.
-                              See the documentation for more options and details.  To preview how the log
-                              configuration is applied, or preview the default configuration, you can use
-                              the 'cockroach debug check-log-config' sub-command.
-                             
-      --version              version for cockroach
+  -h, --help                     help for cockroach
+      --log <string>             
+                                  Logging configuration, expressed using YAML syntax. For example, you can
+                                  change the default logging directory with: --log='file-defaults: {dir: ...}'.
+                                  See the documentation for more options and details.  To preview how the log
+                                  configuration is applied, or preview the default configuration, you can use
+                                  the 'cockroach debug check-log-config' sub-command.
+                                 
+      --log-config-file <file>   
+                                  File name to read the logging configuration from. This has the same effect as
+                                  passing the content of the file via the --log flag.
+                                  (default <unset>)
+      --version                  version for cockroach
 
 Use "cockroach [command] --help" for more information about a command.
 `
 	helpExpected := fmt.Sprintf("CockroachDB command-line interface and server.\n\n%s",
 		// Due to a bug in spf13/cobra, 'cockroach help' does not include the --version
 		// flag. Strangely, 'cockroach --help' does, as well as usage error messages.
-		strings.ReplaceAll(expUsage, "      --version              version for cockroach\n", ""))
+		strings.ReplaceAll(expUsage, "      --version                  version for cockroach\n", ""))
 	badFlagExpected := fmt.Sprintf("%s\nError: unknown flag: --foo\n", expUsage)
 
 	testCases := []struct {

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -1467,6 +1467,13 @@ default configuration, you can use the 'cockroach debug check-log-config' sub-co
 `,
 	}
 
+	LogConfigFile = FlagInfo{
+		Name: "log-config-file",
+		Description: `File name to read the logging configuration from.
+This has the same effect as passing the content of the file via
+the --log flag.`,
+	}
+
 	DeprecatedStderrThreshold = FlagInfo{
 		Name:        "logtostderr",
 		Description: `Write log messages beyond the specified severity to stderr.`,

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -296,7 +296,8 @@ func init() {
 	// Logging flags common to all commands.
 	{
 		// Logging configuration.
-		varFlag(pf, &cliCtx.logConfigInput, cliflags.Log)
+		varFlag(pf, &stringValue{settableString: &cliCtx.logConfigInput}, cliflags.Log)
+		varFlag(pf, &fileContentsValue{settableString: &cliCtx.logConfigInput, fileName: "<unset>"}, cliflags.LogConfigFile)
 
 		// Pre-v21.1 overrides. Deprecated.
 		// TODO(knz): Remove this.
@@ -310,7 +311,7 @@ func init() {
 		_ = pf.MarkDeprecated(cliflags.DeprecatedStderrNoColor.Name,
 			"use --"+cliflags.Log.Name+" instead to specify 'sinks: {stderr: {no-color: true}}'")
 
-		varFlag(pf, &cliCtx.deprecatedLogOverrides.logDir, cliflags.DeprecatedLogDir)
+		varFlag(pf, &stringValue{&cliCtx.deprecatedLogOverrides.logDir}, cliflags.DeprecatedLogDir)
 		_ = pf.MarkDeprecated(cliflags.DeprecatedLogDir.Name,
 			"use --"+cliflags.Log.Name+" instead to specify 'file-defaults: {dir: ...}'")
 
@@ -330,7 +331,7 @@ func init() {
 		_ = pf.MarkDeprecated(cliflags.DeprecatedRedactableLogs.Name,
 			"use --"+cliflags.Log.Name+" instead to specify 'file-defaults: {redactable: ...}")
 
-		varFlag(pf, &cliCtx.deprecatedLogOverrides.sqlAuditLogDir, cliflags.DeprecatedSQLAuditLogDir)
+		varFlag(pf, &stringValue{&cliCtx.deprecatedLogOverrides.sqlAuditLogDir}, cliflags.DeprecatedSQLAuditLogDir)
 		_ = pf.MarkDeprecated(cliflags.DeprecatedSQLAuditLogDir.Name,
 			"use --"+cliflags.Log.Name+" instead to specify 'sinks: {file-groups: {sql-audit: {channels: SENSITIVE_ACCESS, dir: ...}}}")
 	}


### PR DESCRIPTION
Fixes #64349.
cc @thtruo 

Release note (cli change): The new parameter `--log-config-file`
simplifies the process of loading the logging configuration from a
YAML file. Instead of passing the content of the file via
e.g. `--log=$(cat file.yaml)`, it is now possible to pass the path to
the file `--log-config-file=file.yaml`.

Note: each occurrence of `--log` and `--log-config-file` on the
command line overrides the configuration set from previous
occurrences.