### PR TITLE
sql: Add telemetry for zone configuration override

### DIFF
--- a/pkg/ccl/telemetryccl/testdata/telemetry/multiregion
+++ b/pkg/ccl/telemetryccl/testdata/telemetry/multiregion
@@ -366,3 +366,72 @@ SELECT * FROM t8 WHERE a = 1
 ----
 sql.plan.opt.locality-optimized-search
 
+exec
+USE survive_region;
+CREATE TABLE t9 (a INT PRIMARY KEY) LOCALITY REGIONAL BY ROW
+----
+
+feature-allowlist
+sql.multiregion.zone_configuration.override.*
+----
+
+feature-counters
+SET override_multi_region_zone_config = true;
+ALTER TABLE t9 CONFIGURE ZONE USING num_replicas=10;
+SET override_multi_region_zone_config = false
+----
+sql.multiregion.zone_configuration.override.user  1
+
+# Note that this case illustrates that once the session variable is set, we'll
+# count all instances where a zone configuration is modified, even if that
+# modification didn't strictly require overriding.
+feature-counters
+SET override_multi_region_zone_config = true;
+ALTER TABLE t9 CONFIGURE ZONE USING gc.ttlseconds=10;
+SET override_multi_region_zone_config = false
+----
+sql.multiregion.zone_configuration.override.user  1
+
+feature-counters
+ALTER TABLE t9 CONFIGURE ZONE USING gc.ttlseconds=5
+----
+
+feature-counters
+SET override_multi_region_zone_config = true;
+ALTER TABLE t9 SET LOCALITY GLOBAL;
+SET override_multi_region_zone_config = false
+----
+sql.multiregion.zone_configuration.override.system.table  1
+
+# Ensure that no counters are set in the case where we're not overriding
+feature-counters
+ALTER TABLE t9 SET LOCALITY REGIONAL BY TABLE IN PRIMARY REGION;
+----
+
+# Note that this case illustrates that once the session variable is set, we'll
+# count all instances where a table's zone configuration is modified, even if
+# that modification didn't strictly require overriding.
+feature-counters
+SET override_multi_region_zone_config = true;
+ALTER TABLE t9 SET LOCALITY GLOBAL;
+SET override_multi_region_zone_config = false
+----
+sql.multiregion.zone_configuration.override.system.table  1
+
+feature-counters
+SET override_multi_region_zone_config = true;
+ALTER DATABASE d CONFIGURE ZONE USING num_replicas=10;
+SET override_multi_region_zone_config = false
+----
+sql.multiregion.zone_configuration.override.user  1
+
+feature-counters
+ALTER DATABASE d CONFIGURE ZONE USING gc.ttlseconds=5;
+----
+
+feature-counters
+SET override_multi_region_zone_config = true;
+ALTER DATABASE d ADD REGION "us-east-1";
+SET override_multi_region_zone_config = false
+----
+sql.multiregion.zone_configuration.override.system.database  1

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -194,7 +194,6 @@ func (p *planner) SetZoneConfig(ctx context.Context, n *tree.SetZoneConfig) (pla
 		ctx,
 		n.ZoneSpecifier,
 		n.Options,
-		p.SessionData().OverrideMultiRegionZoneConfigEnabled,
 	); err != nil {
 		return nil, err
 	}

--- a/pkg/sql/sqltelemetry/multiregion.go
+++ b/pkg/sql/sqltelemetry/multiregion.go
@@ -56,6 +56,26 @@ var (
 	ImportIntoMultiRegionDatabaseCounter = telemetry.GetCounterOnce(
 		"sql.multiregion.import",
 	)
+
+	// OverrideMultiRegionZoneConfigurationUser is to be incremented when a
+	// multi-region zone configuration is overridden by the user.
+	OverrideMultiRegionZoneConfigurationUser = telemetry.GetCounterOnce(
+		"sql.multiregion.zone_configuration.override.user",
+	)
+
+	// OverrideMultiRegionDatabaseZoneConfigurationSystem is to be incremented
+	// when a multi-region database zone configuration is overridden by the
+	// system.
+	OverrideMultiRegionDatabaseZoneConfigurationSystem = telemetry.GetCounterOnce(
+		"sql.multiregion.zone_configuration.override.system.database",
+	)
+
+	// OverrideMultiRegionTableZoneConfigurationSystem is to be incremented when
+	// a multi-region table/index/partition zone configuration is overridden by
+	// the system.
+	OverrideMultiRegionTableZoneConfigurationSystem = telemetry.GetCounterOnce(
+		"sql.multiregion.zone_configuration.override.system.table",
+	)
 )
 
 // CreateDatabaseSurvivalGoalCounter is to be incremented when the survival goal


### PR DESCRIPTION
Add telemetry for cases where the zone configuration of a multi-region
database or table is overridden by the user.

Release note: None

Closes #64268.