### PR TITLE
geos/BUILD.bzl: missing `-lm`

### DIFF
--- a/pkg/geo/geos/BUILD.bazel
+++ b/pkg/geo/geos/BUILD.bazel
@@ -10,43 +10,43 @@ go_library(
     cgo = True,
     clinkopts = select({
         "@io_bazel_rules_go//go/platform:aix": [
-            "-ldl",
+            "-ldl -lm",
         ],
         "@io_bazel_rules_go//go/platform:android": [
-            "-ldl",
+            "-ldl -lm",
         ],
         "@io_bazel_rules_go//go/platform:darwin": [
-            "-ldl",
+            "-ldl -lm",
         ],
         "@io_bazel_rules_go//go/platform:dragonfly": [
-            "-ldl",
+            "-ldl -lm",
         ],
         "@io_bazel_rules_go//go/platform:freebsd": [
-            "-ldl",
+            "-ldl -lm",
         ],
         "@io_bazel_rules_go//go/platform:illumos": [
-            "-ldl",
+            "-ldl -lm",
         ],
         "@io_bazel_rules_go//go/platform:ios": [
-            "-ldl",
+            "-ldl -lm",
         ],
         "@io_bazel_rules_go//go/platform:js": [
-            "-ldl",
+            "-ldl -lm",
         ],
         "@io_bazel_rules_go//go/platform:linux": [
-            "-ldl",
+            "-ldl -lm",
         ],
         "@io_bazel_rules_go//go/platform:netbsd": [
-            "-ldl",
+            "-ldl -lm",
         ],
         "@io_bazel_rules_go//go/platform:openbsd": [
-            "-ldl",
+            "-ldl -lm",
         ],
         "@io_bazel_rules_go//go/platform:plan9": [
-            "-ldl",
+            "-ldl -lm",
         ],
         "@io_bazel_rules_go//go/platform:solaris": [
-            "-ldl",
+            "-ldl -lm",
         ],
         "//conditions:default": [],
     }),

--- a/pkg/geo/geos/geos.go
+++ b/pkg/geo/geos/geos.go
@@ -29,7 +29,7 @@ import (
 )
 
 // #cgo CXXFLAGS: -std=c++14
-// #cgo !windows LDFLAGS: -ldl
+// #cgo !windows LDFLAGS: -ldl -lm
 //
 // #include "geos.h"
 import "C"


### PR DESCRIPTION
Fixes #64713.

The math functions are not included in libc in BSD.

Release note: None