### PR TITLE
release-21.1: sql: add memory accounting for the results of the subqueries

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1036,8 +1036,13 @@ func (ex *connExecutor) execWithDistSQLEngine(
 	}
 
 	if len(planner.curPlan.subqueryPlans) != 0 {
+		// Create a separate memory account for the results of the subqueries.
+		// Note that we intentionally defer the closure of the account until we
+		// return from this method (after the main query is executed).
+		subqueryResultMemAcc := planner.EvalContext().Mon.MakeBoundAccount()
+		defer subqueryResultMemAcc.Close(ctx)
 		if !ex.server.cfg.DistSQLPlanner.PlanAndRunSubqueries(
-			ctx, planner, evalCtxFactory, planner.curPlan.subqueryPlans, recv,
+			ctx, planner, evalCtxFactory, planner.curPlan.subqueryPlans, recv, &subqueryResultMemAcc,
 		) {
 			return recv.stats, recv.commErr
 		}

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -803,12 +803,17 @@ func (r *DistSQLReceiver) Types() []*types.T {
 // function will have closed all the subquery plans because it assumes that the
 // caller will not try to run the main plan given that the subqueries'
 // evaluation failed.
+// - subqueryResultMemAcc must be a non-nil memory account that the result of
+//   subqueries' evaluation will be registered with. It is the caller's
+//   responsibility to shrink (or close) the account accordingly, once the
+//   references to those results are lost.
 func (dsp *DistSQLPlanner) PlanAndRunSubqueries(
 	ctx context.Context,
 	planner *planner,
 	evalCtxFactory func() *extendedEvalContext,
 	subqueryPlans []subquery,
 	recv *DistSQLReceiver,
+	subqueryResultMemAcc *mon.BoundAccount,
 ) bool {
 	for planIdx, subqueryPlan := range subqueryPlans {
 		if err := dsp.planAndRunSubquery(
@@ -819,6 +824,7 @@ func (dsp *DistSQLPlanner) PlanAndRunSubqueries(
 			evalCtxFactory(),
 			subqueryPlans,
 			recv,
+			subqueryResultMemAcc,
 		); err != nil {
 			recv.SetError(err)
 			// Usually we leave the closure of subqueries to occur when the
@@ -836,6 +842,10 @@ func (dsp *DistSQLPlanner) PlanAndRunSubqueries(
 	return true
 }
 
+// subqueryResultMemAcc must be a non-nil memory account that the result of the
+// subquery's evaluation will be registered with. It is the caller's
+// responsibility to shrink it (or close it) accordingly, once the references to
+// those results are lost.
 func (dsp *DistSQLPlanner) planAndRunSubquery(
 	ctx context.Context,
 	planIdx int,
@@ -844,6 +854,7 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 	evalCtx *extendedEvalContext,
 	subqueryPlans []subquery,
 	recv *DistSQLReceiver,
+	subqueryResultMemAcc *mon.BoundAccount,
 ) error {
 	subqueryMonitor := mon.NewMonitor(
 		"subquery",
@@ -947,6 +958,11 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 		}
 	default:
 		return fmt.Errorf("unexpected subqueryExecMode: %d", subqueryPlan.execMode)
+	}
+	// Account for the result of the subquery using the separate memory account
+	// since it outlives the execution of the subquery itself.
+	if err := subqueryResultMemAcc.Grow(ctx, int64(subqueryPlans[planIdx].result.Size())); err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -309,9 +309,15 @@ func (sc *SchemaChanger) backfillQueryIntoTable(
 		localPlanner.runWithOptions(resolveFlags{skipCache: true}, func() {
 			// Resolve subqueries before running the queries' physical plan.
 			if len(localPlanner.curPlan.subqueryPlans) != 0 {
+				// Create a separate memory account for the results of the
+				// subqueries. Note that we intentionally defer the closure of
+				// the account until we return from this method (after the main
+				// query is executed).
+				subqueryResultMemAcc := localPlanner.EvalContext().Mon.MakeBoundAccount()
+				defer subqueryResultMemAcc.Close(ctx)
 				if !sc.distSQLPlanner.PlanAndRunSubqueries(
 					ctx, localPlanner, localPlanner.ExtendedEvalContextCopy,
-					localPlanner.curPlan.subqueryPlans, recv,
+					localPlanner.curPlan.subqueryPlans, recv, &subqueryResultMemAcc,
 				) {
 					if planAndRunErr = rw.Err(); planAndRunErr != nil {
 						return


### PR DESCRIPTION
Backport 1/1 commits from #64691.

/cc @cockroachdb/release

---

After executing a subquery, the result is materialized into a single
tuple (or row, or value). In some cases that tuple can be arbitrarily
large. This commit adds after-the-fact memory accounting for the size of
the resulting datum. The burden of clearing the memory account is put
onto the caller of `PlanAndRunSubqueries` method.

Fixes: #64464.

Release note (bug fix): CockroachDB now should crash less often due to OOM
conditions caused by the subqueries returning multiple rows of large
size.
