### PR TITLE
release-21.1: colrpc: use the correct pgcode for connection failure

### DIFF
--- a/pkg/sql/colflow/colrpc/BUILD.bazel
+++ b/pkg/sql/colflow/colrpc/BUILD.bazel
@@ -18,6 +18,8 @@ go_library(
         "//pkg/sql/colmem",
         "//pkg/sql/execinfra",
         "//pkg/sql/execinfrapb",
+        "//pkg/sql/pgwire/pgcode",
+        "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/types",
         "//pkg/util/log",
         "//pkg/util/log/logcrash",

--- a/pkg/sql/flowinfra/inbound.go
+++ b/pkg/sql/flowinfra/inbound.go
@@ -136,7 +136,7 @@ func processInboundStreamHelper(
 			if err != nil {
 				if err != io.EOF {
 					// Communication error.
-					err = pgerror.Newf(pgcode.InternalConnectionFailure, "communication error: %s", err)
+					err = pgerror.Newf(pgcode.InternalConnectionFailure, "inbox communication error: %s", err)
 					sendErrToConsumer(err)
 					errChan <- err
 					return


### PR DESCRIPTION
Backport 1/2 commits from #64312.

/cc @cockroachdb/release

---

**colrpc: use the correct pgcode for connection failure**

This brings the vectorized inbox in line with the row-based equivalent.

Release note: None
