### PR TITLE
bazel: upgrade to bazel 4.0.0 in the builder image

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -122,7 +122,7 @@ yarn_install(
 # NB: @bazel_skylib comes from go_rules_dependencies().
 load("@bazel_skylib//lib:versions.bzl", "versions")
 
-versions.check(minimum_bazel_version = "3.5.0")
+versions.check(minimum_bazel_version = "4.0.0")
 
 # Load gazelle dependencies.
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")

--- a/build/bazelbuilder/Dockerfile
+++ b/build/bazelbuilder/Dockerfile
@@ -36,7 +36,7 @@ RUN echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.
  && curl https://bazel.build/bazel-release.pub.gpg | apt-key add - \
  && apt-get update \
  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    bazel-3.6.0
+    bazel-4.0.0
 
 # git - Upgrade to a more modern version
 RUN DEBIAN_FRONTEND=noninteractive apt-get install dh-autoreconf libcurl4-gnutls-dev libexpat1-dev gettext libz-dev libssl-dev -y && \
@@ -58,7 +58,7 @@ RUN apt-get purge -y \
 
 RUN rm -rf /tmp/* /var/lib/apt/lists/*
 
-RUN ln -s /usr/bin/bazel-3.6.0 /usr/bin/bazel
+RUN ln -s /usr/bin/bazel-4.0.0 /usr/bin/bazel
 
 COPY entrypoint.sh /usr/bin
 ENTRYPOINT ["/usr/bin/entrypoint.sh"]

--- a/build/teamcity-bazel-support.sh
+++ b/build/teamcity-bazel-support.sh
@@ -1,4 +1,4 @@
-BAZEL_IMAGE=cockroachdb/bazel:20210408-113636
+BAZEL_IMAGE=cockroachdb/bazel:20210505-134517
 
 # Call `run_bazel $NAME_OF_SCRIPT` to start an appropriately-configured Docker
 # container with the `cockroachdb/bazel` image running the given script.


### PR DESCRIPTION
This will allow us to pick up the latest version of `rules_foreign_cc`,
(for example, for #64334) which doesn't build with an earlier bazel
(#64709). Also make sure the version assertion in `WORKSPACE` is
up-to-date.

Release note: None