### PR TITLE
server: Add descriptions for apiv2 response parameters

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -649,7 +649,7 @@ Closely mirrors the upstream definitions in github.com/etcd-io/etcd/raft.
 <a name="cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RangeProblems"></a>
 #### RangeProblems
 
-
+RangeProblems describes issues reported by a range. For internal use only.
 
 | Field | Type | Label | Description | Support status |
 | ----- | ---- | ----- | ----------- | -------------- |
@@ -669,12 +669,13 @@ Closely mirrors the upstream definitions in github.com/etcd-io/etcd/raft.
 <a name="cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RangeStatistics"></a>
 #### RangeStatistics
 
-
+RangeStatistics describes statistics reported by a range. For internal use
+only.
 
 | Field | Type | Label | Description | Support status |
 | ----- | ---- | ----- | ----------- | -------------- |
-| queries_per_second | [double](#cockroach.server.serverpb.RaftDebugResponse-double) |  | Note that queries per second will only be known by the leaseholder. All other replicas will report it as 0. | [reserved](#support-status) |
-| writes_per_second | [double](#cockroach.server.serverpb.RaftDebugResponse-double) |  |  | [reserved](#support-status) |
+| queries_per_second | [double](#cockroach.server.serverpb.RaftDebugResponse-double) |  | Queries per second served by this range.<br><br>Note that queries per second will only be known by the leaseholder. All other replicas will report it as 0. | [reserved](#support-status) |
+| writes_per_second | [double](#cockroach.server.serverpb.RaftDebugResponse-double) |  | Writes per second served by this range. | [reserved](#support-status) |
 
 
 
@@ -832,7 +833,7 @@ Closely mirrors the upstream definitions in github.com/etcd-io/etcd/raft.
 <a name="cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RangeProblems"></a>
 #### RangeProblems
 
-
+RangeProblems describes issues reported by a range. For internal use only.
 
 | Field | Type | Label | Description | Support status |
 | ----- | ---- | ----- | ----------- | -------------- |
@@ -852,12 +853,13 @@ Closely mirrors the upstream definitions in github.com/etcd-io/etcd/raft.
 <a name="cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RangeStatistics"></a>
 #### RangeStatistics
 
-
+RangeStatistics describes statistics reported by a range. For internal use
+only.
 
 | Field | Type | Label | Description | Support status |
 | ----- | ---- | ----- | ----------- | -------------- |
-| queries_per_second | [double](#cockroach.server.serverpb.RangesResponse-double) |  | Note that queries per second will only be known by the leaseholder. All other replicas will report it as 0. | [reserved](#support-status) |
-| writes_per_second | [double](#cockroach.server.serverpb.RangesResponse-double) |  |  | [reserved](#support-status) |
+| queries_per_second | [double](#cockroach.server.serverpb.RangesResponse-double) |  | Queries per second served by this range.<br><br>Note that queries per second will only be known by the leaseholder. All other replicas will report it as 0. | [reserved](#support-status) |
+| writes_per_second | [double](#cockroach.server.serverpb.RangesResponse-double) |  | Writes per second served by this range. | [reserved](#support-status) |
 
 
 
@@ -1181,7 +1183,7 @@ ActiveQuery represents a query in flight on some Session.
 | start | [google.protobuf.Timestamp](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Timestamp) |  | Start timestamp of this query. | [reserved](#support-status) |
 | is_distributed | [bool](#cockroach.server.serverpb.ListSessionsResponse-bool) |  | True if this query is distributed. | [reserved](#support-status) |
 | phase | [ActiveQuery.Phase](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.ActiveQuery.Phase) |  | phase stores the current phase of execution for this query. | [reserved](#support-status) |
-| progress | [float](#cockroach.server.serverpb.ListSessionsResponse-float) |  |  | [reserved](#support-status) |
+| progress | [float](#cockroach.server.serverpb.ListSessionsResponse-float) |  | progress is an estimate of the fraction of this query that has been processed. | [reserved](#support-status) |
 | sql_anon | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | The SQL statement fingerprint, compatible with StatementStatisticsKey. | [reserved](#support-status) |
 
 
@@ -1309,7 +1311,7 @@ ActiveQuery represents a query in flight on some Session.
 | start | [google.protobuf.Timestamp](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Timestamp) |  | Start timestamp of this query. | [reserved](#support-status) |
 | is_distributed | [bool](#cockroach.server.serverpb.ListSessionsResponse-bool) |  | True if this query is distributed. | [reserved](#support-status) |
 | phase | [ActiveQuery.Phase](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.ActiveQuery.Phase) |  | phase stores the current phase of execution for this query. | [reserved](#support-status) |
-| progress | [float](#cockroach.server.serverpb.ListSessionsResponse-float) |  |  | [reserved](#support-status) |
+| progress | [float](#cockroach.server.serverpb.ListSessionsResponse-float) |  | progress is an estimate of the fraction of this query that has been processed. | [reserved](#support-status) |
 | sql_anon | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | The SQL statement fingerprint, compatible with StatementStatisticsKey. | [reserved](#support-status) |
 
 
@@ -2341,7 +2343,7 @@ Closely mirrors the upstream definitions in github.com/etcd-io/etcd/raft.
 <a name="cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RangeProblems"></a>
 #### RangeProblems
 
-
+RangeProblems describes issues reported by a range. For internal use only.
 
 | Field | Type | Label | Description | Support status |
 | ----- | ---- | ----- | ----------- | -------------- |
@@ -2361,12 +2363,13 @@ Closely mirrors the upstream definitions in github.com/etcd-io/etcd/raft.
 <a name="cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RangeStatistics"></a>
 #### RangeStatistics
 
-
+RangeStatistics describes statistics reported by a range. For internal use
+only.
 
 | Field | Type | Label | Description | Support status |
 | ----- | ---- | ----- | ----------- | -------------- |
-| queries_per_second | [double](#cockroach.server.serverpb.RangeResponse-double) |  | Note that queries per second will only be known by the leaseholder. All other replicas will report it as 0. | [reserved](#support-status) |
-| writes_per_second | [double](#cockroach.server.serverpb.RangeResponse-double) |  |  | [reserved](#support-status) |
+| queries_per_second | [double](#cockroach.server.serverpb.RangeResponse-double) |  | Queries per second served by this range.<br><br>Note that queries per second will only be known by the leaseholder. All other replicas will report it as 0. | [reserved](#support-status) |
+| writes_per_second | [double](#cockroach.server.serverpb.RangeResponse-double) |  | Writes per second served by this range. | [reserved](#support-status) |
 
 
 

--- a/docs/generated/swagger/spec.json
+++ b/docs/generated/swagger/spec.json
@@ -608,6 +608,7 @@
           "$ref": "#/definitions/ActiveQuery_Phase"
         },
         "progress": {
+          "description": "progress is an estimate of the fraction of this query that has been\nprocessed.",
           "type": "number",
           "format": "float",
           "x-go-name": "Progress"
@@ -936,13 +937,6 @@
       "format": "int32",
       "x-go-package": "github.com/cockroachdb/cockroach/pkg/roachpb"
     },
-    "NodeLivenessStatus": {
-      "description": "TODO(irfansharif): We should reconsider usage of NodeLivenessStatus.\nIt's unclear if the enum is well considered. It enumerates across two\ndistinct set of things: the \"membership\" status (live/active,\ndecommissioning, decommissioned), and the node \"process\" status (live,\nunavailable, available). It's possible for two of these \"states\" to be true,\nsimultaneously (consider a decommissioned, dead node). It makes for confusing\nsemantics, and the code attempting to disambiguate across these states\n(kvserver.LivenessStatus() for e.g.) seem wholly arbitrary.\n\nSee #50707 for more details.",
-      "type": "integer",
-      "format": "int32",
-      "title": "NodeLivenessStatus describes the status of a node from the perspective of the\nliveness system. See comment on LivenessStatus() for a description of the\nstates.",
-      "x-go-package": "github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
-    },
     "PrettySpan": {
       "type": "object",
       "properties": {
@@ -957,19 +951,9 @@
       },
       "x-go-package": "github.com/cockroachdb/cockroach/pkg/server/serverpb"
     },
-    "RKey": {
-      "description": "RKey stands for \"resolved key,\" as in a key whose address has been resolved.",
-      "title": "RKey denotes a Key whose local addressing has been accounted for.\nA key can be transformed to an RKey by keys.Addr().",
-      "$ref": "#/definitions/Key"
-    },
-    "RangeID": {
-      "type": "integer",
-      "format": "int64",
-      "title": "A RangeID is a unique ID associated to a Raft consensus group.",
-      "x-go-package": "github.com/cockroachdb/cockroach/pkg/roachpb"
-    },
     "RangeProblems": {
       "type": "object",
+      "title": "RangeProblems describes issues reported by a range. For internal use only.",
       "properties": {
         "leader_not_lease_holder": {
           "type": "boolean",
@@ -1009,15 +993,17 @@
       "x-go-package": "github.com/cockroachdb/cockroach/pkg/server/serverpb"
     },
     "RangeStatistics": {
+      "description": "RangeStatistics describes statistics reported by a range. For internal use\nonly.",
       "type": "object",
       "properties": {
         "queries_per_second": {
-          "description": "Note that queries per second will only be known by the leaseholder.\nAll other replicas will report it as 0.",
+          "description": "Queries per second served by this range.\n\nNote that queries per second will only be known by the leaseholder.\nAll other replicas will report it as 0.",
           "type": "number",
           "format": "double",
           "x-go-name": "QueriesPerSecond"
         },
         "writes_per_second": {
+          "description": "Writes per second served by this range.",
           "type": "number",
           "format": "double",
           "x-go-name": "WritesPerSecond"
@@ -1814,11 +1800,13 @@
       "title": "Response struct for listNodeRanges.",
       "properties": {
         "next": {
+          "description": "Continuation token for the next limited run. Use in the `offset` parameter.",
           "type": "integer",
           "format": "int64",
           "x-go-name": "Next"
         },
         "ranges": {
+          "description": "Info about retrieved ranges.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/rangeInfo"
@@ -1830,6 +1818,7 @@
     },
     "nodeStatus": {
       "type": "object",
+      "title": "Status about a node.",
       "properties": {
         "ServerVersion": {
           "$ref": "#/definitions/Version"
@@ -1841,21 +1830,26 @@
           "$ref": "#/definitions/Attributes"
         },
         "build_tag": {
+          "description": "BuildTag is an internal build marker.",
           "type": "string",
           "x-go-name": "BuildTag"
         },
         "cluster_name": {
+          "description": "ClusterName is the string name of this cluster, if set.",
           "type": "string",
           "x-go-name": "ClusterName"
         },
         "liveness_status": {
-          "$ref": "#/definitions/NodeLivenessStatus"
+          "description": "LivenessStatus is the status of the node from the perspective of the\nliveness subsystem. For internal use only.",
+          "type": "integer",
+          "format": "int32",
+          "x-go-name": "LivenessStatus"
         },
         "locality": {
           "$ref": "#/definitions/Locality"
         },
         "metrics": {
-          "description": "Other fields that are a subset of roachpb.NodeStatus.",
+          "description": "Metrics contain the last sampled metrics for this node.",
           "type": "object",
           "additionalProperties": {
             "type": "number",
@@ -1864,9 +1858,13 @@
           "x-go-name": "Metrics"
         },
         "node_id": {
-          "$ref": "#/definitions/NodeID"
+          "description": "NodeID is the integer ID of this node.",
+          "type": "integer",
+          "format": "int32",
+          "x-go-name": "NodeID"
         },
         "num_cpus": {
+          "description": "NumCpus is the number of CPUs on this node.",
           "type": "integer",
           "format": "int32",
           "x-go-name": "NumCpus"
@@ -1875,16 +1873,19 @@
           "$ref": "#/definitions/UnresolvedAddr"
         },
         "started_at": {
+          "description": "StartedAt is the time when this node was started, expressed as\nnanoseconds since Unix epoch.",
           "type": "integer",
           "format": "int64",
           "x-go-name": "StartedAt"
         },
         "total_system_memory": {
+          "description": "TotalSystemMemory is the total amount of available system memory on this\nnode (or cgroup), in bytes.",
           "type": "integer",
           "format": "int64",
           "x-go-name": "TotalSystemMemory"
         },
         "updated_at": {
+          "description": "UpdatedAt is the time at which the node status record was last updated,\nin nanoseconds since Unix epoch.",
           "type": "integer",
           "format": "int64",
           "x-go-name": "UpdatedAt"
@@ -1903,6 +1904,7 @@
           "x-go-name": "Next"
         },
         "nodes": {
+          "description": "Status of nodes.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/nodeStatus"
@@ -1913,40 +1915,62 @@
       "x-go-package": "github.com/cockroachdb/cockroach/pkg/server"
     },
     "rangeDescriptorInfo": {
-      "description": "rangeDescriptorInfo contains a subset of fields from roachpb.RangeDescriptor\nthat are safe to be returned from APIs.",
+      "description": "rangeDescriptorInfo contains a subset of fields from the Cockroach-internal\nrange descriptor that are safe to be returned from APIs.",
       "type": "object",
       "properties": {
         "end_key": {
-          "$ref": "#/definitions/RKey"
+          "description": "EndKey is the resolved Cockroach-internal key that denotes the end of\nthis range.",
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "uint8"
+          },
+          "x-go-name": "EndKey"
         },
         "queries_per_second": {
+          "description": "QueriesPerSecond is the number of queries per second this range is\nserving. Only set for hot ranges.",
           "type": "number",
           "format": "double",
           "x-go-name": "QueriesPerSecond"
         },
         "range_id": {
-          "$ref": "#/definitions/RangeID"
+          "description": "RangeID is the integer id of this range.",
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "RangeID"
         },
         "start_key": {
-          "$ref": "#/definitions/RKey"
+          "description": "StartKey is the resolved Cockroach-internal key that denotes the start of\nthis range.",
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "uint8"
+          },
+          "x-go-name": "StartKey"
         },
         "store_id": {
-          "$ref": "#/definitions/StoreID"
+          "description": "StoreID is the ID of the store this hot range is on. Only set for hot\nranges.",
+          "type": "integer",
+          "format": "int32",
+          "x-go-name": "StoreID"
         }
       },
       "x-go-package": "github.com/cockroachdb/cockroach/pkg/server"
     },
     "rangeInfo": {
       "type": "object",
+      "title": "Info related to a range.",
       "properties": {
         "desc": {
           "$ref": "#/definitions/rangeDescriptorInfo"
         },
         "error_message": {
+          "description": "ErrorMessage is any error retrieved from the internal range info. For\ninternal use only.",
           "type": "string",
           "x-go-name": "ErrorMessage"
         },
         "lease_history": {
+          "description": "LeaseHistory is for internal use only.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/Lease"
@@ -1957,14 +1981,21 @@
           "$ref": "#/definitions/RangeProblems"
         },
         "quiescent": {
+          "description": "Quiescent is for internal use only.",
           "type": "boolean",
           "x-go-name": "Quiescent"
         },
         "source_node_id": {
-          "$ref": "#/definitions/NodeID"
+          "description": "SourceNodeID is the ID of the node where this range info was retrieved\nfrom.",
+          "type": "integer",
+          "format": "int32",
+          "x-go-name": "SourceNodeID"
         },
         "source_store_id": {
-          "$ref": "#/definitions/StoreID"
+          "description": "SourceStoreID is the ID of the store on the node where this range info was\nretrieved from.",
+          "type": "integer",
+          "format": "int32",
+          "x-go-name": "SourceStoreID"
         },
         "span": {
           "$ref": "#/definitions/PrettySpan"
@@ -1973,6 +2004,7 @@
           "$ref": "#/definitions/RangeStatistics"
         },
         "ticking": {
+          "description": "Ticking is for internal use only.",
           "type": "boolean",
           "x-go-name": "Ticking"
         }

--- a/pkg/server/api_v2_ranges.go
+++ b/pkg/server/api_v2_ranges.go
@@ -18,39 +18,54 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/gorilla/mux"
 )
 
+// Status about a node.
 type nodeStatus struct {
-	// Fields that are a subset of NodeDescriptor.
-	NodeID        roachpb.NodeID      `json:"node_id"`
-	Address       util.UnresolvedAddr `json:"address"`
-	Attrs         roachpb.Attributes  `json:"attrs"`
-	Locality      roachpb.Locality    `json:"locality"`
-	ServerVersion roachpb.Version     `json:"ServerVersion"`
-	BuildTag      string              `json:"build_tag"`
-	StartedAt     int64               `json:"started_at"`
-	ClusterName   string              `json:"cluster_name"`
-	SQLAddress    util.UnresolvedAddr `json:"sql_address"`
+	// NodeID is the integer ID of this node.
+	NodeID int32 `json:"node_id"`
+	// Address is the unresolved network listen address of this node.
+	Address  util.UnresolvedAddr `json:"address"`
+	Attrs    roachpb.Attributes  `json:"attrs"`
+	Locality roachpb.Locality    `json:"locality"`
+	// ServerVersion is the exact version of Cockroach this node is running.
+	ServerVersion roachpb.Version `json:"ServerVersion"`
+	// BuildTag is an internal build marker.
+	BuildTag string `json:"build_tag"`
+	// StartedAt is the time when this node was started, expressed as
+	// nanoseconds since Unix epoch.
+	StartedAt int64 `json:"started_at"`
+	// ClusterName is the string name of this cluster, if set.
+	ClusterName string `json:"cluster_name"`
+	// SQLAddress is the listen address to which SQL clients can connect.
+	SQLAddress util.UnresolvedAddr `json:"sql_address"`
 
-	// Other fields that are a subset of roachpb.NodeStatus.
-	Metrics           map[string]float64 `json:"metrics,omitempty"`
-	TotalSystemMemory int64              `json:"total_system_memory,omitempty"`
-	NumCpus           int32              `json:"num_cpus,omitempty"`
-	UpdatedAt         int64              `json:"updated_at,omitempty"`
+	// Metrics contain the last sampled metrics for this node.
+	Metrics map[string]float64 `json:"metrics,omitempty"`
+	// TotalSystemMemory is the total amount of available system memory on this
+	// node (or cgroup), in bytes.
+	TotalSystemMemory int64 `json:"total_system_memory,omitempty"`
+	// NumCpus is the number of CPUs on this node.
+	NumCpus int32 `json:"num_cpus,omitempty"`
+	// UpdatedAt is the time at which the node status record was last updated,
+	// in nanoseconds since Unix epoch.
+	UpdatedAt int64 `json:"updated_at,omitempty"`
 
-	// Retrieved from the liveness status map.
-	LivenessStatus livenesspb.NodeLivenessStatus `json:"liveness_status"`
+	// LivenessStatus is the status of the node from the perspective of the
+	// liveness subsystem. For internal use only.
+	LivenessStatus int32 `json:"liveness_status"`
 }
 
 // Response struct for listNodes.
 //
 // swagger:model nodesResponse
 type nodesResponse struct {
+	// Status of nodes.
+	//
 	// swagger:allOf
 	Nodes []nodeStatus `json:"nodes"`
 	// Continuation offset for the next paginated call, if more values are present.
@@ -101,7 +116,7 @@ func (a *apiV2Server) listNodes(w http.ResponseWriter, r *http.Request) {
 	resp.Next = next
 	for _, n := range nodes.Nodes {
 		resp.Nodes = append(resp.Nodes, nodeStatus{
-			NodeID:            n.Desc.NodeID,
+			NodeID:            int32(n.Desc.NodeID),
 			Address:           n.Desc.Address,
 			Attrs:             n.Desc.Attrs,
 			Locality:          n.Desc.Locality,
@@ -114,7 +129,7 @@ func (a *apiV2Server) listNodes(w http.ResponseWriter, r *http.Request) {
 			TotalSystemMemory: n.TotalSystemMemory,
 			NumCpus:           n.NumCpus,
 			UpdatedAt:         n.UpdatedAt,
-			LivenessStatus:    nodes.LivenessByNodeID[n.Desc.NodeID],
+			LivenessStatus:    int32(nodes.LivenessByNodeID[n.Desc.NodeID]),
 		})
 	}
 	writeJSONResponse(ctx, w, 200, resp)
@@ -223,16 +238,24 @@ func (a *apiV2Server) listRange(w http.ResponseWriter, r *http.Request) {
 	writeJSONResponse(ctx, w, 200, response)
 }
 
-// rangeDescriptorInfo contains a subset of fields from roachpb.RangeDescriptor
-// that are safe to be returned from APIs.
+// rangeDescriptorInfo contains a subset of fields from the Cockroach-internal
+// range descriptor that are safe to be returned from APIs.
 type rangeDescriptorInfo struct {
-	RangeID  roachpb.RangeID `json:"range_id"`
-	StartKey roachpb.RKey    `json:"start_key,omitempty"`
-	EndKey   roachpb.RKey    `json:"end_key,omitempty"`
+	// RangeID is the integer id of this range.
+	RangeID int64 `json:"range_id"`
+	// StartKey is the resolved Cockroach-internal key that denotes the start of
+	// this range.
+	StartKey []byte `json:"start_key,omitempty"`
+	// EndKey is the resolved Cockroach-internal key that denotes the end of
+	// this range.
+	EndKey []byte `json:"end_key,omitempty"`
 
-	// Set for HotRanges.
-	StoreID          roachpb.StoreID `json:"store_id"`
-	QueriesPerSecond float64         `json:"queries_per_second"`
+	// StoreID is the ID of the store this hot range is on. Only set for hot
+	// ranges.
+	StoreID int32 `json:"store_id"`
+	// QueriesPerSecond is the number of queries per second this range is
+	// serving. Only set for hot ranges.
+	QueriesPerSecond float64 `json:"queries_per_second"`
 }
 
 func (r *rangeDescriptorInfo) init(rd *roachpb.RangeDescriptor) {
@@ -241,33 +264,46 @@ func (r *rangeDescriptorInfo) init(rd *roachpb.RangeDescriptor) {
 		return
 	}
 	*r = rangeDescriptorInfo{
-		RangeID:  rd.RangeID,
+		RangeID:  int64(rd.RangeID),
 		StartKey: rd.StartKey,
 		EndKey:   rd.EndKey,
 	}
 }
 
+// Info related to a range.
 type rangeInfo struct {
 	// swagger:allOf
 	Desc rangeDescriptorInfo `json:"desc"`
 
-	// Subset of fields copied from serverpb.RangeInfo
-	Span          serverpb.PrettySpan      `json:"span"`
-	SourceNodeID  roachpb.NodeID           `json:"source_node_id,omitempty"`
-	SourceStoreID roachpb.StoreID          `json:"source_store_id,omitempty"`
-	ErrorMessage  string                   `json:"error_message,omitempty"`
-	LeaseHistory  []roachpb.Lease          `json:"lease_history"`
-	Problems      serverpb.RangeProblems   `json:"problems"`
-	Stats         serverpb.RangeStatistics `json:"stats"`
-	Quiescent     bool                     `json:"quiescent,omitempty"`
-	Ticking       bool                     `json:"ticking,omitempty"`
+	// Span is the pretty-ified start/end key span for this range.
+	Span serverpb.PrettySpan `json:"span"`
+	// SourceNodeID is the ID of the node where this range info was retrieved
+	// from.
+	SourceNodeID int32 `json:"source_node_id,omitempty"`
+	// SourceStoreID is the ID of the store on the node where this range info was
+	// retrieved from.
+	SourceStoreID int32 `json:"source_store_id,omitempty"`
+	// ErrorMessage is any error retrieved from the internal range info. For
+	// internal use only.
+	ErrorMessage string `json:"error_message,omitempty"`
+	// LeaseHistory is for internal use only.
+	LeaseHistory []roachpb.Lease `json:"lease_history"`
+	// Problems is a map of any issues reported by this range. For internal use
+	// only.
+	Problems serverpb.RangeProblems `json:"problems"`
+	// Stats is for internal use only.
+	Stats serverpb.RangeStatistics `json:"stats"`
+	// Quiescent is for internal use only.
+	Quiescent bool `json:"quiescent,omitempty"`
+	// Ticking is for internal use only.
+	Ticking bool `json:"ticking,omitempty"`
 }
 
 func (ri *rangeInfo) init(r serverpb.RangeInfo) {
 	*ri = rangeInfo{
 		Span:          r.Span,
-		SourceNodeID:  r.SourceNodeID,
-		SourceStoreID: r.SourceStoreID,
+		SourceNodeID:  int32(r.SourceNodeID),
+		SourceStoreID: int32(r.SourceStoreID),
 		ErrorMessage:  r.ErrorMessage,
 		LeaseHistory:  r.LeaseHistory,
 		Problems:      r.Problems,
@@ -282,8 +318,10 @@ func (ri *rangeInfo) init(r serverpb.RangeInfo) {
 //
 // swagger:model nodeRangesResponse
 type nodeRangesResponse struct {
+	// Info about retrieved ranges.
 	Ranges []rangeInfo `json:"ranges"`
-	Next   int         `json:"next,omitempty"`
+	// Continuation token for the next limited run. Use in the `offset` parameter.
+	Next int `json:"next,omitempty"`
 }
 
 // swagger:operation GET /nodes/{node_id}/ranges/ listNodeRanges
@@ -455,7 +493,7 @@ func (a *apiV2Server) listHotRanges(w http.ResponseWriter, r *http.Request) {
 			for _, hotRange := range store.HotRanges {
 				var r rangeDescriptorInfo
 				r.init(&hotRange.Desc)
-				r.StoreID = store.StoreID
+				r.StoreID = int32(store.StoreID)
 				r.QueriesPerSecond = hotRange.QueriesPerSecond
 				rangeDescriptorInfos = append(rangeDescriptorInfos, r)
 			}

--- a/pkg/server/api_v2_ranges_test.go
+++ b/pkg/server/api_v2_ranges_test.go
@@ -99,8 +99,8 @@ func TestNodeRangesV2(t *testing.T) {
 		t.Errorf("didn't get any ranges")
 	}
 	for _, ri := range nodeRangesResp.Ranges {
-		require.Equal(t, roachpb.NodeID(1), ri.SourceNodeID)
-		require.Equal(t, roachpb.StoreID(1), ri.SourceStoreID)
+		require.Equal(t, int32(1), ri.SourceNodeID)
+		require.Equal(t, int32(1), ri.SourceStoreID)
 		require.GreaterOrEqual(t, len(ri.LeaseHistory), 1)
 		require.NotEmpty(t, ri.Span.StartKey)
 		require.NotEmpty(t, ri.Span.EndKey)

--- a/pkg/server/serverpb/status.pb.go
+++ b/pkg/server/serverpb/status.pb.go
@@ -644,6 +644,7 @@ func (m *RaftState_Progress) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_RaftState_Progress proto.InternalMessageInfo
 
+// RangeProblems describes issues reported by a range. For internal use only.
 type RangeProblems struct {
 	Unavailable          bool `protobuf:"varint,1,opt,name=unavailable,proto3" json:"unavailable,omitempty"`
 	LeaderNotLeaseHolder bool `protobuf:"varint,2,opt,name=leader_not_lease_holder,json=leaderNotLeaseHolder,proto3" json:"leader_not_lease_holder,omitempty"`
@@ -689,11 +690,16 @@ func (m *RangeProblems) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_RangeProblems proto.InternalMessageInfo
 
+// RangeStatistics describes statistics reported by a range. For internal use
+// only.
 type RangeStatistics struct {
+	// Queries per second served by this range.
+	//
 	// Note that queries per second will only be known by the leaseholder.
 	// All other replicas will report it as 0.
 	QueriesPerSecond float64 `protobuf:"fixed64,1,opt,name=queries_per_second,json=queriesPerSecond,proto3" json:"queries_per_second,omitempty"`
-	WritesPerSecond  float64 `protobuf:"fixed64,2,opt,name=writes_per_second,json=writesPerSecond,proto3" json:"writes_per_second,omitempty"`
+	// Writes per second served by this range.
+	WritesPerSecond float64 `protobuf:"fixed64,2,opt,name=writes_per_second,json=writesPerSecond,proto3" json:"writes_per_second,omitempty"`
 }
 
 func (m *RangeStatistics) Reset()         { *m = RangeStatistics{} }
@@ -1932,8 +1938,10 @@ type ActiveQuery struct {
 	// True if this query is distributed.
 	IsDistributed bool `protobuf:"varint,4,opt,name=is_distributed,json=isDistributed,proto3" json:"is_distributed,omitempty"`
 	// phase stores the current phase of execution for this query.
-	Phase    ActiveQuery_Phase `protobuf:"varint,5,opt,name=phase,proto3,enum=cockroach.server.serverpb.ActiveQuery_Phase" json:"phase,omitempty"`
-	Progress float32           `protobuf:"fixed32,6,opt,name=progress,proto3" json:"progress,omitempty"`
+	Phase ActiveQuery_Phase `protobuf:"varint,5,opt,name=phase,proto3,enum=cockroach.server.serverpb.ActiveQuery_Phase" json:"phase,omitempty"`
+	// progress is an estimate of the fraction of this query that has been
+	// processed.
+	Progress float32 `protobuf:"fixed32,6,opt,name=progress,proto3" json:"progress,omitempty"`
 	// The SQL statement fingerprint, compatible with StatementStatisticsKey.
 	SqlAnon string `protobuf:"bytes,8,opt,name=sql_anon,json=sqlAnon,proto3" json:"sql_anon,omitempty"`
 }

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -159,6 +159,7 @@ message RaftState {
   uint64 lead_transferee = 7;
 }
 
+// RangeProblems describes issues reported by a range. For internal use only.
 message RangeProblems {
   bool unavailable = 1;
   bool leader_not_lease_holder = 2;
@@ -177,10 +178,15 @@ message RangeProblems {
   bool raft_log_too_large = 7;
 }
 
+// RangeStatistics describes statistics reported by a range. For internal use
+// only.
 message RangeStatistics {
+  // Queries per second served by this range.
+  //
   // Note that queries per second will only be known by the leaseholder.
   // All other replicas will report it as 0.
   double queries_per_second = 1;
+  // Writes per second served by this range.
   double writes_per_second = 2;
 }
 
@@ -530,6 +536,8 @@ message ActiveQuery {
   // phase stores the current phase of execution for this query.
   Phase phase = 5;
 
+  // progress is an estimate of the fraction of this query that has been
+  // processed.
   float progress = 6;
 
   // The SQL statement fingerprint, compatible with StatementStatisticsKey.


### PR DESCRIPTION
Some Api V2 response payloads were missing descriptions in
their response parameters. Others were mostly for internal
use only. This PR updates/adds comments so that almost all
response fields for node/range related APIv2 endpoints have
descriptions in the Swagger spec.

Release note: None.