### PR TITLE
bulk: stop splitting on range flushes during RESTORE

### DIFF
--- a/pkg/kv/bulk/buffering_adder.go
+++ b/pkg/kv/bulk/buffering_adder.go
@@ -94,7 +94,7 @@ func MakeBulkAdder(
 		// splitting _before_ hitting max reduces chance of auto-splitting after the
 		// range is full and is more expensive to split/move.
 		opts.SplitAndScatterAfter = func() int64 { return 48 << 20 }
-	} else if opts.SplitAndScatterAfter() == -1 {
+	} else if opts.SplitAndScatterAfter() == kvserverbase.DisableExplicitSplits {
 		opts.SplitAndScatterAfter = nil
 	}
 

--- a/pkg/kv/bulk/sst_batcher.go
+++ b/pkg/kv/bulk/sst_batcher.go
@@ -281,7 +281,11 @@ func (b *SSTBatcher) doFlush(ctx context.Context, reason int, nextKey roachpb.Ke
 		// non-overlapping keyspace this split partitions off "our" target space for
 		// future splitting/scattering, while if they don't, doing this only once
 		// minimizes impact on other adders (e.g. causing extra SST splitting).
-		if b.flushCounts.total == 1 {
+		//
+		// We only do this splitting if the caller expects the sst_batcher to
+		// split and scatter the data as it ingests it (which is the case when
+		// splitAfter) is set.
+		if b.flushCounts.total == 1 && b.splitAfter != nil {
 			if splitAt, err := keys.EnsureSafeSplitKey(start); err != nil {
 				log.Warningf(ctx, "%v", err)
 			} else {


### PR DESCRIPTION
The SST batcher maintains logic to preemptively split a range when it
sees the first size flush. However, we only want to do this when the SST
batcher is enabled to split and scatter ranges after consuming a certain
amount of data (which is indicated by setting the SplitAfter setting).

SplitAfter is enabled by default when the SST batcher is used by the
bulk adder (e.g. in IMPORT and backfills). In other cases (ie RESTORE),
spans are already pre-split so this splitting and scattering is
detrimental to RESTORE performance (range leaseholders get moved after
they went through the split and scattering process).

Release note: None