### PR TITLE
storage/cloud: remove gcs key cluster setting

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -1,6 +1,5 @@
 Setting	Type	Default	Description
 bulkio.stream_ingestion.minimum_flush_interval	duration	5s	the minimum timestamp between flushes; flushes may still occur if internal buffers fill up
-cloudstorage.gs.default.key	string		[deprecated] if set, JSON key to use during Google Cloud Storage operations. This setting will be removed in 21.2, as we will no longer support the `default` AUTH mode for GCS operations.
 cloudstorage.http.custom_ca	string		custom root CA (appended to system's default CAs) for verifying certificates when interacting with HTTPS storage
 cloudstorage.timeout	duration	10m0s	the timeout for import/export storage operations
 cluster.organization	string		organization name

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -2,7 +2,6 @@
 <thead><tr><th>Setting</th><th>Type</th><th>Default</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>bulkio.stream_ingestion.minimum_flush_interval</code></td><td>duration</td><td><code>5s</code></td><td>the minimum timestamp between flushes; flushes may still occur if internal buffers fill up</td></tr>
-<tr><td><code>cloudstorage.gs.default.key</code></td><td>string</td><td><code></code></td><td>[deprecated] if set, JSON key to use during Google Cloud Storage operations. This setting will be removed in 21.2, as we will no longer support the `default` AUTH mode for GCS operations.</td></tr>
 <tr><td><code>cloudstorage.http.custom_ca</code></td><td>string</td><td><code></code></td><td>custom root CA (appended to system's default CAs) for verifying certificates when interacting with HTTPS storage</td></tr>
 <tr><td><code>cloudstorage.timeout</code></td><td>duration</td><td><code>10m0s</code></td><td>the timeout for import/export storage operations</td></tr>
 <tr><td><code>cluster.organization</code></td><td>string</td><td><code></code></td><td>organization name</td></tr>

--- a/pkg/ccl/workloadccl/fixture_test.go
+++ b/pkg/ccl/workloadccl/fixture_test.go
@@ -109,7 +109,6 @@ func TestFixture(t *testing.T) {
 	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 	sqlDB := sqlutils.MakeSQLRunner(db)
-	sqlDB.Exec(t, `SET CLUSTER SETTING cloudstorage.gs.default.key = $1`, gcsKey)
 
 	gen := makeTestWorkload()
 	flag := fmt.Sprintf(`val=%d`, timeutil.Now().UnixNano())

--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -1327,7 +1327,7 @@ func (m *ExternalStorage) AccessIsWithExplicitAuth() bool {
 	switch m.Provider {
 	case ExternalStorageProvider_s3:
 		// custom endpoints could be a network resource only accessible via this
-		// noode's network context and thus have an element of implicit auth.
+		// node's network context and thus have an element of implicit auth.
 		if m.S3Config.Endpoint != "" {
 			return false
 		}

--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -79,6 +79,7 @@ var retiredSettings = map[string]struct{}{
 	"kv.atomic_replication_changes.enabled": {},
 	// removed as of 21.2.
 	"sql.defaults.vectorize_row_count_threshold": {},
+	"cloudstorage.gs.default.key":                {},
 }
 
 // register adds a setting to the registry.

--- a/pkg/sql/logictest/testdata/logic_test/cluster_settings
+++ b/pkg/sql/logictest/testdata/logic_test/cluster_settings
@@ -32,12 +32,6 @@ SET CLUSTER SETTING sql.defaults.default_int_size = 4
 statement error only users with the MODIFYCLUSTERSETTING privilege are allowed to show cluster setting 'sql.defaults.default_int_size'
 SHOW CLUSTER SETTING sql.defaults.default_int_size
 
-statement error only users with the admin role are allowed to set cluster setting 'cloudstorage.gs.default.key'
-SET CLUSTER SETTING cloudstorage.gs.default.key = 'foo'
-
-statement error only users with the admin role are allowed to show cluster setting 'cloudstorage.gs.default.key'
-SHOW CLUSTER SETTING cloudstorage.gs.default.key
-
 statement error only users with the MODIFYCLUSTERSETTING privilege are allowed to SHOW CLUSTER SETTINGS
 SHOW CLUSTER SETTINGS
 
@@ -59,21 +53,15 @@ SHOW CLUSTER SETTING sql.defaults.default_int_size
 ----
 4
 
-statement error only users with the admin role are allowed to set cluster setting 'cloudstorage.gs.default.key'
-SET CLUSTER SETTING cloudstorage.gs.default.key = 'foo'
-
-statement error only users with the admin role are allowed to show cluster setting 'cloudstorage.gs.default.key'
-SHOW CLUSTER SETTING cloudstorage.gs.default.key
-
 query TT
 SELECT variable, value FROM [SHOW CLUSTER SETTINGS]
-WHERE variable IN ('cloudstorage.gs.default.key', 'sql.defaults.default_int_size')
+WHERE variable IN ('sql.defaults.default_int_size')
 ----
 sql.defaults.default_int_size  4
 
 query TT
 SELECT variable, value FROM [SHOW ALL CLUSTER SETTINGS]
-WHERE variable IN ('cloudstorage.gs.default.key', 'sql.defaults.default_int_size')
+WHERE variable IN ('sql.defaults.default_int_size')
 ----
 sql.defaults.default_int_size  4
 
@@ -94,26 +82,16 @@ GRANT admin TO testuser
 
 user testuser
 
-statement ok
-SET CLUSTER SETTING cloudstorage.gs.default.key = 'foo'
-
-query T
-SHOW CLUSTER SETTING cloudstorage.gs.default.key
-----
-foo
-
 query TT rowsort
 SELECT variable, value FROM [SHOW CLUSTER SETTINGS]
-WHERE variable IN ('cloudstorage.gs.default.key', 'sql.defaults.default_int_size')
+WHERE variable IN ( 'sql.defaults.default_int_size')
 ----
-cloudstorage.gs.default.key    foo
 sql.defaults.default_int_size  4
 
 query TT rowsort
 SELECT variable, value FROM [SHOW ALL CLUSTER SETTINGS]
-WHERE variable IN ('cloudstorage.gs.default.key', 'sql.defaults.default_int_size')
+WHERE variable IN ('sql.defaults.default_int_size')
 ----
-cloudstorage.gs.default.key    foo
 sql.defaults.default_int_size  4
 
 query B

--- a/pkg/sql/show_test.go
+++ b/pkg/sql/show_test.go
@@ -909,7 +909,6 @@ func TestLintClusterSettingNames(t *testing.T) {
 				"sql.metrics.statement_details.sample_logical_plans": `sql.metrics.statement_details.sample_logical_plans: use .enabled for booleans`,
 				"sql.trace.log_statement_execute":                    `sql.trace.log_statement_execute: use .enabled for booleans`,
 				"trace.debug.enable":                                 `trace.debug.enable: use .enabled for booleans`,
-				"cloudstorage.gs.default.key":                        `cloudstorage.gs.default.key: part "default" is a reserved keyword`,
 				// These two settings have been deprecated in favor of a new (better named) setting
 				// but the old name is still around to support migrations.
 				// TODO(knz): remove these cases when these settings are retired.

--- a/pkg/storage/cloudimpl/external_storage.go
+++ b/pkg/storage/cloudimpl/external_storage.go
@@ -75,9 +75,6 @@ const (
 	// AuthParamImplicit is the query parameter for the implicit authentication
 	// mode in a URI.
 	AuthParamImplicit = roachpb.ExternalStorageAuthImplicit
-	// AuthParamDefault is the query parameter for the default authentication
-	// mode in a URI.
-	AuthParamDefault = "default"
 	// AuthParamSpecified is the query parameter for the specified authentication
 	// mode in a URI.
 	AuthParamSpecified = roachpb.ExternalStorageAuthSpecified
@@ -87,21 +84,11 @@ const (
 	CredentialsParam = "CREDENTIALS"
 
 	cloudstoragePrefix = "cloudstorage"
-	cloudstorageGS     = cloudstoragePrefix + ".gs"
-	cloudstorageHTTP   = cloudstoragePrefix + ".http"
-
-	cloudstorageDefault = ".default"
-	cloudstorageKey     = ".key"
-
-	cloudstorageGSDefault = cloudstorageGS + cloudstorageDefault
-	// CloudstorageGSDefaultKey is the setting whose value is the JSON key to use
-	// during Google Cloud Storage operations.
-	CloudstorageGSDefaultKey = cloudstorageGSDefault + cloudstorageKey
 
 	// CloudstorageHTTPCASetting is the setting whose value is the custom root CA
 	// (appended to system's default CAs) for verifying certificates when
 	// interacting with HTTPS storage.
-	CloudstorageHTTPCASetting = cloudstorageHTTP + ".custom_ca"
+	CloudstorageHTTPCASetting = cloudstoragePrefix + ".http.custom_ca"
 
 	cloudStorageTimeout = cloudstoragePrefix + ".timeout"
 )
@@ -306,15 +293,6 @@ func containsGlob(str string) bool {
 }
 
 var (
-	// GcsDefault is the setting which defines the JSON key to use during GCS
-	// operations.
-	GcsDefault = settings.RegisterStringSetting(
-		CloudstorageGSDefaultKey,
-		"[deprecated] if set, JSON key to use during Google Cloud Storage operations. "+
-			"This setting will be removed in "+
-			"21.2, as we will no longer support the `default` AUTH mode for GCS operations.",
-		"",
-	).WithPublic()
 	httpCustomCA = settings.RegisterStringSetting(
 		CloudstorageHTTPCASetting,
 		"custom root CA (appended to system's default CAs) for verifying certificates when interacting with HTTPS storage",


### PR DESCRIPTION
This was deprecated in 21.1 because it does make sense in multi-user/multi-tenant
clusters. This change removes it.

This also changes the behavior of the AUTH option in google cloud storage URIs:
Previously AUTH=specified was required to use passed credentials, while
no value for AUTH or the value 'default' would attempt to use the value saved
in the cluster setting cloudstorage.gs.default.key. AUTH=default would fail if
this value was not set, while an empty value of AUTH and an empty setting would
fall back to AUTH=implicit. After this change, AUTH=implicit is the only configuration
in which implicit (node's role / machine account / env) will be used, and
any other value for AUTH, including unset or specified, will use credentials
from the CREDENTIALS param, or return an error if it is not set.

Release note (backward-incompatible change): The deprecated setting cloudstorage.gs.default.key has been removed, and the behavior of the 'AUTH' param in Google Cloud Storage BACKUP and IMPORT URIs has been changed, with the default behavior now being that of 'AUTH=specified' which uses the credentials passed in the CREDENTIALS parameter, and the previous default behavior of using the node's implicit access (via its machine account or role) now requires explicitly passing 'AUTH=implicit'.