### PR TITLE
release-21.1: opt: fix null reject rule cycle

### DIFF
--- a/pkg/sql/opt/norm/testdata/ruleprops/reject-nulls
+++ b/pkg/sql/opt/norm/testdata/ruleprops/reject-nulls
@@ -1,0 +1,88 @@
+exec-ddl
+CREATE TABLE abc (
+  a INT PRIMARY KEY,
+  b INT,
+  c INT,
+  INDEX idx_c (c) STORING (b) WHERE (b IS NOT NULL),
+  INDEX idx_b (b)
+)
+----
+
+exec-ddl
+CREATE TABLE def (
+  d INT PRIMARY KEY,
+  e INT,
+  f INT
+)
+----
+
+# Verify that we request null rejection on b, which allows use of the partial
+# index.
+norm
+SELECT a, b, d FROM abc JOIN def ON b=d
+----
+inner-join (hash)
+ ├── columns: a:1!null b:2!null d:5!null
+ ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ ├── key: (1)
+ ├── fd: (1)-->(2), (2)==(5), (5)==(2)
+ ├── prune: (1)
+ ├── interesting orderings: (+1) (+2,+1) (+5)
+ ├── select
+ │    ├── columns: a:1!null b:2!null
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2)
+ │    ├── prune: (1)
+ │    ├── interesting orderings: (+1) (+2,+1)
+ │    ├── scan abc
+ │    │    ├── columns: a:1!null b:2
+ │    │    ├── partial index predicates
+ │    │    │    └── idx_c: filters
+ │    │    │         └── b:2 IS NOT NULL [outer=(2), constraints=(/2: (/NULL - ]; tight)]
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2)
+ │    │    ├── prune: (1,2)
+ │    │    ├── reject-nulls: (2)
+ │    │    └── interesting orderings: (+1) (+2,+1)
+ │    └── filters
+ │         └── b:2 IS NOT NULL [outer=(2), constraints=(/2: (/NULL - ]; tight)]
+ ├── scan def
+ │    ├── columns: d:5!null
+ │    ├── key: (5)
+ │    ├── prune: (5)
+ │    ├── interesting orderings: (+5)
+ │    └── unfiltered-cols: (5-8)
+ └── filters
+      └── b:2 = d:5 [outer=(2,5), constraints=(/2: (/NULL - ]; /5: (/NULL - ]), fd=(2)==(5), (5)==(2)]
+
+# Regression test for #64661: don't request null rejection on a non-nullable
+# scan column.
+opt
+SELECT * FROM abc JOIN def ON b = 1 AND a = d AND b < f
+----
+inner-join (lookup abc)
+ ├── columns: a:1!null b:2!null c:3 d:5!null e:6 f:7!null
+ ├── key columns: [1] = [1]
+ ├── lookup columns are key
+ ├── key: (5)
+ ├── fd: ()-->(2), (1)-->(3), (5)-->(6,7), (1)==(5), (5)==(1)
+ ├── prune: (3,6)
+ ├── interesting orderings: (+1) (+3,+1) (+2,+1) (+5)
+ ├── inner-join (lookup def)
+ │    ├── columns: a:1!null b:2!null d:5!null e:6 f:7!null
+ │    ├── key columns: [1] = [5]
+ │    ├── lookup columns are key
+ │    ├── key: (5)
+ │    ├── fd: ()-->(2), (5)-->(6,7), (1)==(5), (5)==(1)
+ │    ├── prune: (6)
+ │    ├── interesting orderings: (+1) (+2,+1) (+5)
+ │    ├── scan abc@idx_b
+ │    │    ├── columns: a:1!null b:2!null
+ │    │    ├── constraint: /2/1: [/1 - /1]
+ │    │    ├── key: (1)
+ │    │    ├── fd: ()-->(2)
+ │    │    ├── prune: (1,2)
+ │    │    └── interesting orderings: (+1) (+2,+1)
+ │    └── filters
+ │         └── b:2 < f:7 [outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ])]
+ └── filters (true)


### PR DESCRIPTION
Backport 1/1 commits from #64698.

/cc @cockroachdb/release

---

Fixing a corner case where we are requesting null rejection on a
non-null Scan column. This causes a stack overflow.

We also add an assertion that would have caught this (and returned an
internal error instead of crashing the node).

Fixes #64661.

Release note (bug fix): fixed a stack overflow that can happen in some
cornercases involving partial indexes with predicates containing `(x
IS NOT NULL)`.
