### PR TITLE
changefeedccl: Treat memory monitor errors as retryable.

### DIFF
--- a/pkg/ccl/changefeedccl/bench_test.go
+++ b/pkg/ccl/changefeedccl/bench_test.go
@@ -216,15 +216,16 @@ func createBenchmarkChangefeed(
 	}
 	_, withDiff := details.Opts[changefeedbase.OptDiff]
 	kvfeedCfg := kvfeed.Config{
-		Settings:         settings,
-		DB:               s.DB(),
-		Clock:            feedClock,
-		Gossip:           gossip.MakeOptionalGossip(s.GossipI().(*gossip.Gossip)),
-		Spans:            spans,
-		Targets:          details.Targets,
-		Sink:             buf,
-		Metrics:          &metrics.KVFeedMetrics,
-		MM:               mm,
+		Settings: settings,
+		DB:       s.DB(),
+		Clock:    feedClock,
+		Gossip:   gossip.MakeOptionalGossip(s.GossipI().(*gossip.Gossip)),
+		Spans:    spans,
+		Targets:  details.Targets,
+		Sink:     buf,
+		EventBufferFactory: func() kvfeed.EventBuffer {
+			return kvfeed.MakeMemBuffer(mm.MakeBoundAccount(), &metrics.KVFeedMetrics)
+		},
 		InitialHighWater: initialHighWater,
 		WithDiff:         withDiff,
 		NeedsInitialScan: needsInitialScan,

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -599,6 +599,13 @@ func (b *changefeedResumer) Resume(ctx context.Context, execCtx interface{}) err
 		if err = distChangefeedFlow(ctx, jobExec, jobID, details, progress, startedCh); err == nil {
 			return nil
 		}
+
+		if knobs, ok := execCfg.DistSQLSrv.TestingKnobs.Changefeed.(*TestingKnobs); ok {
+			if knobs != nil && knobs.HandleDistChangefeedError != nil {
+				err = knobs.HandleDistChangefeedError(err)
+			}
+		}
+
 		if !IsRetryableError(err) {
 			if ctx.Err() != nil {
 				return ctx.Err()

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -57,7 +57,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
-	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -3081,7 +3080,7 @@ func TestChangefeedTelemetry(t *testing.T) {
 	t.Run(`enterprise`, enterpriseTest(testFn))
 }
 
-func TestChangefeedMemBufferCapacity(t *testing.T) {
+func TestChangefeedMemBufferCapacityErrorRetryable(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
@@ -3145,6 +3144,15 @@ func TestChangefeedMemBufferCapacity(t *testing.T) {
 				return nil
 			}
 
+			distErrCh := make(chan error, numFeeds)
+			knobs.HandleDistChangefeedError = func(err error) error {
+				// NB: do not use t.Fatal (or anything that can call that) here.
+				// This function is invoked form a different go routine -- and calling
+				// t.Fatal will likely deadlock the test.
+				distErrCh <- err
+				return MaybeStripRetryableErrorMarker(err)
+			}
+
 			sqlDB := sqlutils.MakeSQLRunner(db)
 			sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING)`)
 
@@ -3188,33 +3196,12 @@ func TestChangefeedMemBufferCapacity(t *testing.T) {
 				`INSERT INTO foo SELECT i, 'foofoofoo' FROM generate_series(1, $1) AS g(i)`,
 				numRows)
 
-			// We don't quite know which feed will error out first, so, just call Next on all of
-			// them and record the first error encountered.
-			firstErr := make(chan error, 1)
-			_ = ctxgroup.GroupWorkers(context.Background(), len(feeds),
-				func(ctx context.Context, i int) error {
-					_, err := feeds[i].Next()
-					if err != nil {
-						select {
-						case firstErr <- err:
-							// As soon as we get an error, close beforeEmitRowCh to unblock
-							// any other changfeeds that maybe blocked emitting rows.
-							close(beforeEmitRowCh)
-						default:
-						}
-					}
-					return err
-				})
-
-			err := <-firstErr
+			err := <-distErrCh
 			require.Regexp(t, `memory budget exceeded`, err)
+			require.True(t, IsRetryableError(err))
 		}
 	}
 
-	// The mem buffer is only used with RangeFeed.
-	t.Run(`sinkless-one-feed`, sinklessTest(memLimitTest(1)))
-	t.Run(`sinkless-two-feeds`, sinklessTest(memLimitTest(2)))
-	t.Run(`sinkless-many-feeds`, sinklessTest(memLimitTest(3)))
 	t.Run(`enterprise-one-feed`, enterpriseTest(memLimitTest(1)))
 	t.Run(`enterprise-two-feeds`, enterpriseTest(memLimitTest(2)))
 	t.Run(`enterprise-many-feeds`, enterpriseTest(memLimitTest(3)))

--- a/pkg/ccl/changefeedccl/kvfeed/buffer.go
+++ b/pkg/ccl/changefeedccl/kvfeed/buffer.go
@@ -232,7 +232,9 @@ type memBuffer struct {
 	}
 }
 
-func makeMemBuffer(acc mon.BoundAccount, metrics *Metrics) *memBuffer {
+// MakeMemBuffer returns an EventBuffer backed by memory, limited
+// as specified by bound account.
+func MakeMemBuffer(acc mon.BoundAccount, metrics *Metrics) EventBuffer {
 	b := &memBuffer{
 		metrics:  metrics,
 		signalCh: make(chan struct{}, 1),

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed_test.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed_test.go
@@ -98,7 +98,7 @@ func TestKVFeed(t *testing.T) {
 		)
 		metrics := MakeMetrics(time.Minute)
 		bufferFactory := func() EventBuffer {
-			return makeMemBuffer(mm.MakeBoundAccount(), &metrics)
+			return MakeMemBuffer(mm.MakeBoundAccount(), &metrics)
 		}
 		scans := make(chan physicalConfig)
 		sf := scannerFunc(func(ctx context.Context, sink EventBufferWriter, cfg physicalConfig) error {

--- a/pkg/ccl/changefeedccl/testing_knobs.go
+++ b/pkg/ccl/changefeedccl/testing_knobs.go
@@ -25,6 +25,9 @@ type TestingKnobs struct {
 	MemMonitor *mon.BytesMonitor
 	// Dial, if set, is a function that overrides normal sink "dial" functionality.
 	Dial func(s Sink)
+	// HandleDistChangfeedError is called with the result error from
+	// the distributed changefeed.
+	HandleDistChangefeedError func(error) error
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.


### PR DESCRIPTION
Treat memory errors as retryable when ingesting new events,
just like we treat such errors as retryable when emitting
them to the sink.

Release Notes: Changefeeds can better handle slow or unavailable
sinks by treating "memory exceeded" errors as retryable.