### PR TITLE
colfetcher: fix recent bug with cfetcher

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/vectorize_types
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_types
@@ -118,3 +118,21 @@ query T
 SELECT 'a'::"char" FROM t47131_0
 ----
 a
+
+# Regression test for the cFetcher not setting the not-needed columns to all
+# nulls in some cases (#64676).
+statement ok
+CREATE TABLE t64676 (
+  i INT,
+  d DATE,
+  u UUID
+);
+INSERT INTO t64676 VALUES
+  (1, '2021-05-05', '00000000-0000-0000-0000-100000000000'),
+  (2, '2021-05-05', '00000000-0000-0000-0000-200000000000'),
+  (3, '2021-05-05', '00000000-0000-0000-0000-300000000000'),
+  (4, '2021-05-05', '00000000-0000-0000-0000-400000000000'),
+  (5, '2021-05-05', '00000000-0000-0000-0000-500000000000')
+
+statement ok
+SELECT i + d FROM t64676


### PR DESCRIPTION
2223a60137c200f7defd08ed701b4f0308cb66b9 intended to set all not needed
vectors to all null values in the cFetcher, but one case was overlooked.
This commit fixes that problem.

Fixes: #64676.

Release note: None (no release with this bug)