### PR TITLE
opt/optbuilder: support using table name as projection

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/tuple
+++ b/pkg/sql/logictest/testdata/logic_test/tuple
@@ -914,10 +914,23 @@ a  b
 1  one
 2  two
 
-
-# Pending #26719
-query error pq: column "t" does not exist
+query I rowsort
 SELECT (t).a FROM t
+----
+1
+2
+
+query T rowsort
+SELECT t FROM t
+----
+(1,one)
+(2,two)
+
+query T rowsort
+SELECT row_to_json(t) FROM t
+----
+{"a": 1, "b": "one"}
+{"a": 2, "b": "two"}
 
 statement ok
 DROP TABLE t

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -235,6 +235,31 @@ project
       └── columns: k:1!null v:2 crdb_internal_mvcc_timestamp:3
 
 build
+SELECT row_to_json(kv) FROM kv
+----
+project
+ ├── columns: row_to_json:4
+ ├── scan kv
+ │    └── columns: k:1!null v:2 crdb_internal_mvcc_timestamp:3
+ └── projections
+      └── row_to_json(((k:1, v:2) AS k, v)) [as=row_to_json:4]
+
+build
+SELECT kv FROM kv
+----
+project
+ ├── columns: kv:4
+ ├── scan kv
+ │    └── columns: k:1!null v:2 crdb_internal_mvcc_timestamp:3
+ └── projections
+      └── ((k:1, v:2) AS k, v) [as=kv:4]
+
+build
+SELECT log(kv) FROM kv
+----
+error (42883): unknown signature: log(tuple{char AS k, char AS v})
+
+build
 SELECT (kv.*) AS r FROM kv
 ----
 project
@@ -1478,3 +1503,40 @@ build
 DELETE FROM inaccessible RETURNING v
 ----
 error (42703): column "v" does not exist
+
+exec-ddl
+CREATE TABLE same_name (
+  same_name TEXT PRIMARY KEY,
+  b INT
+)
+----
+
+build
+SELECT same_name FROM same_name
+----
+project
+ ├── columns: same_name:1!null
+ └── scan same_name
+      └── columns: same_name:1!null b:2 crdb_internal_mvcc_timestamp:3
+
+build
+SELECT row_to_json(same_name) FROM same_name
+----
+error (42883): unknown signature: row_to_json(string)
+
+build
+SELECT log(same_name) FROM same_name
+----
+error (42883): unknown signature: log(string)
+
+build
+SELECT t FROM (VALUES (1,2), (3,4)) t(x, y);
+----
+project
+ ├── columns: t:3!null
+ ├── values
+ │    ├── columns: column1:1!null column2:2!null
+ │    ├── (1, 2)
+ │    └── (3, 4)
+ └── projections
+      └── ((column1:1, column2:2) AS x, y) [as=t:3]


### PR DESCRIPTION
* Fix projection code to be able to use the column name as a table name
  by catching undefined columns error and evaluating it as a TupleStar
* Fix scope VisitPre to do something similar to above, to make this work
  for functions.

Resolves #60549
Resolves #26719
Resolves #45854

Release note (sql change): Using the table name as a projection now
works, e.g. SELECT table_name FROM table_name or SELECT
row_to_json(table_name) FROM table_name.