### PR TITLE
logictest: increase --max-sql-memory for SQLLite logic tests

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -251,4 +251,12 @@ type TestTenantArgs struct {
 	// Test server starts with secure mode by default. When this is set to true
 	// it will switch to insecure
 	ForceInsecure bool
+
+	// MemoryPoolSize is the amount of memory in bytes that can be used by SQL
+	// clients to store row data in server RAM.
+	MemoryPoolSize int64
+
+	// TempStorageConfig is used to configure temp storage, which stores
+	// ephemeral data when processing large queries.
+	TempStorageConfig *TempStorageConfig
 }

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -120,11 +120,7 @@ func makeTestKVConfig() KVConfig {
 }
 
 func makeTestSQLConfig(st *cluster.Settings, tenID roachpb.TenantID) SQLConfig {
-	sqlCfg := MakeSQLConfig(tenID, base.DefaultTestTempStorageConfig(st))
-	// Configure the default in-memory temp storage for all tests unless
-	// otherwise configured.
-	sqlCfg.TempStorageConfig = base.DefaultTestTempStorageConfig(st)
-	return sqlCfg
+	return MakeSQLConfig(tenID, base.DefaultTestTempStorageConfig(st))
 }
 
 // makeTestConfigFromParams creates a Config from a TestServerParams.
@@ -738,6 +734,12 @@ func (ts *TestServer) StartTenant(
 	}
 	sqlCfg := makeTestSQLConfig(st, params.TenantID)
 	sqlCfg.TenantKVAddrs = []string{ts.ServingRPCAddr()}
+	if params.MemoryPoolSize != 0 {
+		sqlCfg.MemoryPoolSize = params.MemoryPoolSize
+	}
+	if params.TempStorageConfig != nil {
+		sqlCfg.TempStorageConfig = *params.TempStorageConfig
+	}
 	baseCfg := makeTestBaseConfig(st)
 	baseCfg.TestingKnobs = params.TestingKnobs
 	baseCfg.IdleExitAfter = params.IdleExitAfter


### PR DESCRIPTION
This commit increases the limit from 192 MiB to 512 MiB.

Additionally, this commit uses custom limits for tenants in logic tests.
Previously, the default values were used but aren't sufficient in some
cases, so this commit fixes the problem.

Addresses: #59346.

Release note: None