### PR TITLE
build: remove unnecessary race flag and broken tests

### DIFF
--- a/build/teamcity-opttest.sh
+++ b/build/teamcity-opttest.sh
@@ -21,7 +21,7 @@ tc_end_block "Compile C dependencies"
 tc_start_block "Run opt tests with fast_int_set_large"
 run_json_test build/builder.sh \
   stdbuf -oL -eL \
-  make testrace \
+  make test \
   GOTESTFLAGS=-json \
   TAGS=fast_int_set_large \
   PKG=./pkg/sql/opt... \
@@ -32,7 +32,7 @@ tc_end_block "Run opt tests with fast_int_set_large"
 tc_start_block "Run opt tests with fast_int_set_small"
 run_json_test build/builder.sh \
   stdbuf -oL -eL \
-  make testrace \
+  make test \
   GOTESTFLAGS=-json \
   TAGS=fast_int_set_small \
   PKG=./pkg/sql/opt... \

--- a/build/teamcity-testlogicrace.sh
+++ b/build/teamcity-testlogicrace.sh
@@ -16,38 +16,3 @@ run_json_test build/builder.sh \
   GOTESTFLAGS=-json \
   PKG=./pkg/sql/logictest \
   TESTTIMEOUT="${TESTTIMEOUT}"
-
-# Run each of the optimizer tests again with randomized alternate query plans.
-
-# Perturb the cost of each expression by up to 90%.
-run_json_test build/builder.sh \
-  stdbuf -oL -eL \
-  make testrace \
-  GOTESTFLAGS=-json \
-  PKG=./pkg/sql/logictest \
-  TESTS='^TestLogic/local$$' \
-  TESTTIMEOUT="${TESTTIMEOUT}" \
-  TESTFLAGS='-optimizer-cost-perturbation=0.9'
-
-LOGICTESTS=`ls -A pkg/sql/logictest/testdata/logic_test/`
-
-# Exclude the following tests when running with -disable-opt-rule-probability.
-# These files either do not use the opt configurations or contain queries that
-# rely on normalization rules for optimization, to avoid out-of-memory errors,
-# or for subquery decorrelation.
-EXCLUDE="(cluster_version|distsql_.*|explain_analyze.*|feature_counts|join|\
-optimizer|orms|sequences_distsql|show_trace|subquery_correlated)"
-
-# Disable each rule with 50% probability.
-for file in $LOGICTESTS; do
-    if [[ ! "$file" =~ (^|[[:space:]])${EXCLUDE}($|[[:space:]]) ]]; then
-        run_json_test build/builder.sh \
-          stdbuf -oL -eL \
-          make testrace \
-          GOTESTFLAGS=-json \
-          PKG=./pkg/sql/logictest \
-          TESTS='^TestLogic/local/'${file}'$$' \
-          TESTTIMEOUT="${TESTTIMEOUT}" \
-          TESTFLAGS='-disable-opt-rule-probability=0.5'
-    fi
-done


### PR DESCRIPTION
#### build: do not run fast_int_set_large and fast_int_set_small with race

The optimizer nightly build runs optimizer tests with the
`fast_int_set_large` and `fast_int_set_small` build tags which alter the
behavior of `util.FastIntSet`. These tests do not need to be run with
the race detector.

Release note: None

#### build: remove randomized optimizer tests from testlogicrace

This commit removes randomized optimizer tests from testlogicrace. These
tests are not currently working. We hope to be able to add them back in
as optimizer-specific nightly tests in the near future.

Release note: None
