### PR TITLE
sql: make error during subquery eval more specific

### DIFF
--- a/pkg/cmd/roachtest/sqlsmith.go
+++ b/pkg/cmd/roachtest/sqlsmith.go
@@ -205,7 +205,7 @@ func registerSQLSmith(r *testRegistry) {
 					// that are because of #39433 and #40929.
 					var expectedError bool
 					for _, exp := range []string{
-						"internal error: invalid index",
+						"internal error: subquery eval: invalid index",
 						"could not parse \"0E-2019\" as type decimal",
 					} {
 						expectedError = expectedError || strings.Contains(es, exp)

--- a/pkg/sql/subquery.go
+++ b/pkg/sql/subquery.go
@@ -36,7 +36,7 @@ func (p *planner) EvalSubquery(expr *tree.Subquery) (result tree.Datum, err erro
 		return nil, errors.AssertionFailedf("subquery %q was not processed", expr)
 	}
 	if expr.Idx < 0 || expr.Idx-1 >= len(p.curPlan.subqueryPlans) {
-		return nil, errors.AssertionFailedf("invalid index %d for %q", expr.Idx, expr)
+		return nil, errors.AssertionFailedf("subquery eval: invalid index %d for %q", expr.Idx, expr)
 	}
 
 	s := &p.curPlan.subqueryPlans[expr.Idx-1]


### PR DESCRIPTION
We have a known limitation (#39433) around subqueries and apply joins, so
we ignore errors that occur because of it during `sqlsmith` roachtest.
This commit makes the error message a bit more specific so that we
didn't mistakenly ignore other issues.

Release note: None