### PR TITLE
changefeedccl: add test for disabled outbound IO

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -85,6 +85,10 @@ type TestServerArgs struct {
 	// ExternalIODir is used to initialize field in cluster.Settings.
 	ExternalIODir string
 
+	// ExternalIODirConfig is used to initialize the same-named
+	// field on the server.Config struct.
+	ExternalIODirConfig ExternalIODirConfig
+
 	// Fields copied to the server.Config.
 	Insecure                    bool
 	RetryOptions                retry.Options // TODO(tbg): make testing knob.

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -147,6 +147,7 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 		cfg.JoinList = []string{params.JoinAddr}
 	}
 	cfg.ClusterName = params.ClusterName
+	cfg.ExternalIODirConfig = params.ExternalIODirConfig
 	cfg.Insecure = params.Insecure
 	cfg.AutoInitializeCluster = !params.NoAutoInitializeCluster
 	cfg.SocketFile = params.SocketFile


### PR DESCRIPTION
This adds a test to ensure that we do not allow sinkful changefeeds to
be started when the --external-io-disabled flag has been set.

Note that this only tests a single node setup. For the flag to be
effective, it needs to be set on all nodes in a cluster.

Release note: None