### PR TITLE
ccl/backupccl: skip TestBackupWorkerFailure

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -8193,6 +8193,7 @@ func TestBackupOnlyPublicIndexes(t *testing.T) {
 
 func TestBackupWorkerFailure(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 64773, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	skip.UnderStress(t, "under stress the test unexpectedly surfaces non-retryable errors on"+


### PR DESCRIPTION
Refs: #64773

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None