### PR TITLE
scexec: simplify descriptor helpers

### DIFF
--- a/pkg/sql/schemachanger/scbuild/BUILD.bazel
+++ b/pkg/sql/schemachanger/scbuild/BUILD.bazel
@@ -20,7 +20,6 @@ go_library(
         "//pkg/sql/sem/tree",
         "//pkg/sql/sqlerrors",
         "//pkg/sql/types",
-        "//pkg/util/protoutil",
         "//pkg/util/sequence",
         "@com_github_cockroachdb_errors//:errors",
     ],

--- a/pkg/sql/schemachanger/scexec/descriptorutils/helpers.go
+++ b/pkg/sql/schemachanger/scexec/descriptorutils/helpers.go
@@ -16,34 +16,43 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// GetIndexMutation returns a reference to a specified index add/drop mutation
-// on a table.
-func GetIndexMutation(
-	table catalog.TableDescriptor, idxID descpb.IndexID,
-) (mut *descpb.DescriptorMutation, sliceIdx int, err error) {
-	mutations := table.TableDesc().Mutations
-	for i := range mutations {
-		mut := &mutations[i]
-		idx := mut.GetIndex()
-		if idx != nil && idx.ID == idxID {
-			return mut, i, nil
+// MutationSelector defines a predicate on a catalog.Mutation with no
+// side-effects.
+type MutationSelector func(mutation catalog.Mutation) (matches bool)
+
+// FindMutation returns the first mutation in table for which the selector
+// returns true.
+// Such a mutation is expected to exist, if none are found, an internal error
+// is returned.
+func FindMutation(
+	table catalog.TableDescriptor, selector MutationSelector,
+) (catalog.Mutation, error) {
+	for _, mut := range table.AllMutations() {
+		if selector(mut) {
+			return mut, nil
 		}
 	}
-	return nil, 0, errors.AssertionFailedf("mutation not found")
+	return nil, errors.AssertionFailedf("matching mutation not found in table %d", table.GetID())
 }
 
-// GetColumnMutation returns a reference to a specified column add/drop mutation
-// on a table.
-func GetColumnMutation(
-	table catalog.TableDescriptor, colID descpb.ColumnID,
-) (mut *descpb.DescriptorMutation, sliceIdx int, err error) {
-	mutations := table.TableDesc().Mutations
-	for i := range mutations {
-		mut := &mutations[i]
-		col := mut.GetColumn()
-		if col != nil && col.ID == colID {
-			return mut, i, nil
+// MakeIndexIDMutationSelector returns a MutationSelector which matches an
+// index mutation with the correct ID.
+func MakeIndexIDMutationSelector(indexID descpb.IndexID) MutationSelector {
+	return func(mut catalog.Mutation) bool {
+		if mut.AsIndex() == nil {
+			return false
 		}
+		return mut.AsIndex().GetID() == indexID
 	}
-	return nil, 0, errors.AssertionFailedf("mutation not found")
+}
+
+// MakeColumnIDMutationSelector returns a MutationSelector which matches a
+// column mutation with the correct ID.
+func MakeColumnIDMutationSelector(columnID descpb.ColumnID) MutationSelector {
+	return func(mut catalog.Mutation) bool {
+		if mut.AsColumn() == nil {
+			return false
+		}
+		return mut.AsColumn().GetID() == columnID
+	}
 }

--- a/pkg/sql/schemachanger/scexec/executor.go
+++ b/pkg/sql/schemachanger/scexec/executor.go
@@ -142,19 +142,19 @@ func (ex *Executor) executeIndexBackfillOp(ctx context.Context, op scop.Backfill
 	if err != nil {
 		return err
 	}
-	mut, _, err := descriptorutils.GetIndexMutation(table, op.IndexID)
+	mut, err := descriptorutils.FindMutation(table, descriptorutils.MakeIndexIDMutationSelector(op.IndexID))
 	if err != nil {
 		return err
 	}
 
 	// Must be the right index given the above call.
-	idxToBackfill := mut.GetIndex()
+	idxToBackfill := mut.AsIndex()
 
 	// Split off the index span prior to backfilling.
-	if err := ex.maybeSplitIndexSpans(ctx, table.IndexSpan(ex.codec, idxToBackfill.ID)); err != nil {
+	if err := ex.maybeSplitIndexSpans(ctx, table.IndexSpan(ex.codec, idxToBackfill.GetID())); err != nil {
 		return err
 	}
-	return ex.indexBackfiller.BackfillIndex(ctx, ex.jobTracker, table, table.GetPrimaryIndexID(), idxToBackfill.ID)
+	return ex.indexBackfiller.BackfillIndex(ctx, ex.jobTracker, table, table.GetPrimaryIndexID(), idxToBackfill.GetID())
 }
 
 // IndexBackfiller is an abstract index backfiller that performs index backfills

--- a/pkg/sql/schemachanger/scexec/scmutationexec/scmutationexec.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/scmutationexec.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec/descriptorutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scop"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
@@ -46,7 +47,7 @@ func (m *visitor) MakeAddedColumnDeleteAndWriteOnly(
 	return mutationStateChange(
 		ctx,
 		table,
-		getColumnMutation(op.ColumnID),
+		descriptorutils.MakeColumnIDMutationSelector(op.ColumnID),
 		descpb.DescriptorMutation_DELETE_ONLY,
 		descpb.DescriptorMutation_DELETE_AND_WRITE_ONLY,
 	)
@@ -60,7 +61,7 @@ func (m *visitor) MakeColumnPublic(ctx context.Context, op scop.MakeColumnPublic
 	mut, err := removeMutation(
 		ctx,
 		table,
-		getColumnMutation(op.ColumnID),
+		descriptorutils.MakeColumnIDMutationSelector(op.ColumnID),
 		descpb.DescriptorMutation_DELETE_AND_WRITE_ONLY,
 	)
 	if err != nil {
@@ -130,7 +131,7 @@ func (m *visitor) MakeDroppedColumnDeleteOnly(
 	return mutationStateChange(
 		ctx,
 		table,
-		getColumnMutation(op.ColumnID),
+		descriptorutils.MakeColumnIDMutationSelector(op.ColumnID),
 		descpb.DescriptorMutation_DELETE_AND_WRITE_ONLY,
 		descpb.DescriptorMutation_DELETE_ONLY,
 	)
@@ -144,7 +145,7 @@ func (m *visitor) MakeColumnAbsent(ctx context.Context, op scop.MakeColumnAbsent
 	mut, err := removeMutation(
 		ctx,
 		table,
-		getColumnMutation(op.ColumnID),
+		descriptorutils.MakeColumnIDMutationSelector(op.ColumnID),
 		descpb.DescriptorMutation_DELETE_ONLY,
 	)
 	if err != nil {
@@ -165,7 +166,7 @@ func (m *visitor) MakeAddedIndexDeleteAndWriteOnly(
 	return mutationStateChange(
 		ctx,
 		table,
-		getIndexMutation(op.IndexID),
+		descriptorutils.MakeIndexIDMutationSelector(op.IndexID),
 		descpb.DescriptorMutation_DELETE_ONLY,
 		descpb.DescriptorMutation_DELETE_AND_WRITE_ONLY,
 	)
@@ -221,7 +222,7 @@ func (m *visitor) MakeDroppedIndexDeleteOnly(
 	return mutationStateChange(
 		ctx,
 		table,
-		getIndexMutation(op.IndexID),
+		descriptorutils.MakeIndexIDMutationSelector(op.IndexID),
 		descpb.DescriptorMutation_DELETE_AND_WRITE_ONLY,
 		descpb.DescriptorMutation_DELETE_ONLY,
 	)
@@ -295,7 +296,7 @@ func (m *visitor) MakeAddedPrimaryIndexPublic(
 	if _, err := removeMutation(
 		ctx,
 		table,
-		getIndexMutation(op.Index.ID),
+		descriptorutils.MakeIndexIDMutationSelector(op.Index.ID),
 		descpb.DescriptorMutation_DELETE_AND_WRITE_ONLY,
 	); err != nil {
 		return err
@@ -309,7 +310,11 @@ func (m *visitor) MakeIndexAbsent(ctx context.Context, op scop.MakeIndexAbsent) 
 	if err != nil {
 		return err
 	}
-	_, err = removeMutation(ctx, table, getIndexMutation(op.IndexID), descpb.DescriptorMutation_DELETE_ONLY)
+	_, err = removeMutation(ctx,
+		table,
+		descriptorutils.MakeIndexIDMutationSelector(op.IndexID),
+		descpb.DescriptorMutation_DELETE_ONLY,
+	)
 	return err
 }
 


### PR DESCRIPTION
This refactor makes better use of Mutation and similar catalog interfaces
in the scexec package.

Release note: None