### PR TITLE
builtins: Added pg_relation_is_updatable and pg_column_is_updatable builtins

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -2992,7 +2992,11 @@ SELECT * FROM crdb_internal.check_consistency(true, ‘\x02’, ‘\x04’)</p>
 </span></td></tr>
 <tr><td><a name="oid"></a><code>oid(int: <a href="int.html">int</a>) &rarr; oid</code></td><td><span class="funcdesc"><p>Converts an integer to an OID.</p>
 </span></td></tr>
+<tr><td><a name="pg_column_is_updatable"></a><code>pg_column_is_updatable(reloid: oid, attnum: int2, include_triggers: <a href="bool.html">bool</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns whether the given column can be updated.</p>
+</span></td></tr>
 <tr><td><a name="pg_column_size"></a><code>pg_column_size(anyelement...) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Return size in bytes of the column provided as an argument</p>
+</span></td></tr>
+<tr><td><a name="pg_relation_is_updatable"></a><code>pg_relation_is_updatable(reloid: oid, include_triggers: <a href="bool.html">bool</a>) &rarr; int4</code></td><td><span class="funcdesc"><p>Returns the update events the relation supports.</p>
 </span></td></tr>
 <tr><td><a name="pg_sleep"></a><code>pg_sleep(seconds: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>pg_sleep makes the current session’s process sleep until seconds seconds have elapsed. seconds is a value of type double precision, so fractional-second delays can be specified.</p>
 </span></td></tr>

--- a/pkg/sql/catalog/tabledesc/table_desc.go
+++ b/pkg/sql/catalog/tabledesc/table_desc.go
@@ -12,11 +12,11 @@
 package tabledesc
 
 import (
-	"fmt"
-
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/errors"
 )
@@ -362,7 +362,8 @@ func (desc *wrapper) FindColumnWithID(id descpb.ColumnID) (catalog.Column, error
 			return col, nil
 		}
 	}
-	return nil, fmt.Errorf("column-id \"%d\" does not exist", id)
+
+	return nil, pgerror.Newf(pgcode.UndefinedColumn, "column-id \"%d\" does not exist", id)
 }
 
 // FindColumnWithName returns the first column found whose name matches the

--- a/pkg/sql/logictest/testdata/logic_test/pg_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/pg_builtins
@@ -158,3 +158,84 @@ query TT
 SELECT pg_get_partkeydef(1), pg_get_partkeydef(NULL)
 ----
 NULL  NULL
+
+statement ok
+CREATE TABLE is_updatable(a INT PRIMARY KEY, b INT, c INT AS (b * 10) STORED);
+CREATE VIEW is_updatable_view AS SELECT a, b FROM is_updatable
+
+query TTOIIB colnames
+SELECT
+  c.relname,
+  a.attname,
+  c.oid,
+  a.attnum,
+  pg_relation_is_updatable(c.oid, false),
+  pg_column_is_updatable(c.oid, a.attnum, false)
+FROM pg_class c
+JOIN pg_attribute a ON a.attrelid = c.oid
+WHERE c.relname IN ('is_updatable', 'is_updatable_view', 'pg_class')
+ORDER BY c.oid, a.attnum
+----
+relname            attname              oid         attnum  pg_relation_is_updatable  pg_column_is_updatable
+is_updatable       a                    66          1       28                        true
+is_updatable       b                    66          2       28                        true
+is_updatable       c                    66          3       28                        false
+is_updatable_view  a                    67          1       0                         false
+is_updatable_view  b                    67          2       0                         false
+pg_class           oid                  4294967205  1       0                         false
+pg_class           relname              4294967205  2       0                         false
+pg_class           relnamespace         4294967205  3       0                         false
+pg_class           reltype              4294967205  4       0                         false
+pg_class           reloftype            4294967205  5       0                         false
+pg_class           relowner             4294967205  6       0                         false
+pg_class           relam                4294967205  7       0                         false
+pg_class           relfilenode          4294967205  8       0                         false
+pg_class           reltablespace        4294967205  9       0                         false
+pg_class           relpages             4294967205  10      0                         false
+pg_class           reltuples            4294967205  11      0                         false
+pg_class           relallvisible        4294967205  12      0                         false
+pg_class           reltoastrelid        4294967205  13      0                         false
+pg_class           relhasindex          4294967205  14      0                         false
+pg_class           relisshared          4294967205  15      0                         false
+pg_class           relpersistence       4294967205  16      0                         false
+pg_class           relistemp            4294967205  17      0                         false
+pg_class           relkind              4294967205  18      0                         false
+pg_class           relnatts             4294967205  19      0                         false
+pg_class           relchecks            4294967205  20      0                         false
+pg_class           relhasoids           4294967205  21      0                         false
+pg_class           relhaspkey           4294967205  22      0                         false
+pg_class           relhasrules          4294967205  23      0                         false
+pg_class           relhastriggers       4294967205  24      0                         false
+pg_class           relhassubclass       4294967205  25      0                         false
+pg_class           relfrozenxid         4294967205  26      0                         false
+pg_class           relacl               4294967205  27      0                         false
+pg_class           reloptions           4294967205  28      0                         false
+pg_class           relforcerowsecurity  4294967205  29      0                         false
+pg_class           relispartition       4294967205  30      0                         false
+pg_class           relispopulated       4294967205  31      0                         false
+pg_class           relreplident         4294967205  32      0                         false
+pg_class           relrewrite           4294967205  33      0                         false
+pg_class           relrowsecurity       4294967205  34      0                         false
+pg_class           relpartbound         4294967205  35      0                         false
+pg_class           relminmxid           4294967205  36      0                         false
+
+# Check that the oid does not exist. If this test fail, change the oid here and in
+# the next test at 'relation does not exist' value.
+query I
+SELECT count(1) FROM pg_class WHERE oid = 1
+----
+0
+
+query TT
+SELECT * FROM (VALUES
+   ('system column', (SELECT CAST(pg_column_is_updatable(oid, -1, true) AS TEXT) FROM pg_class WHERE relname = 'is_updatable')),
+   ('relation does not exist', CAST(pg_relation_is_updatable(1, true) AS TEXT)),
+   ('relation does not exist', CAST(pg_column_is_updatable(1, 1, true) AS TEXT)),
+   ('relation exists, but column does not', (SELECT CAST(pg_column_is_updatable(oid, 15, true) AS TEXT) FROM pg_class WHERE relname = 'is_updatable'))
+   ) AS tbl(description, value)
+ORDER BY 1
+----
+relation does not exist               0
+relation does not exist               false
+relation exists, but column does not  true
+system column                         false

--- a/pkg/sql/sem/builtins/BUILD.bazel
+++ b/pkg/sql/sem/builtins/BUILD.bazel
@@ -58,6 +58,7 @@ go_library(
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/sql/sessiondatapb",
+        "//pkg/sql/sqlerrors",
         "//pkg/sql/sqlliveness",
         "//pkg/sql/sqltelemetry",
         "//pkg/sql/sqlutil",

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
@@ -82,6 +83,21 @@ var typeBuiltinsHaveUnderscore = map[oid.Oid]struct{}{
 	types.TimestampTZ.Oid(): {},
 	types.AnyTuple.Oid():    {},
 }
+
+// UpdatableCommand matches update operations in postgres.
+type UpdatableCommand tree.DInt
+
+// The following constants are the values for UpdatableCommand enumeration.
+const (
+	UpdateCommand UpdatableCommand = 2 + iota
+	InsertCommand
+	DeleteCommand
+)
+
+var (
+	nonUpdatableEvents = tree.NewDInt(0)
+	allUpdatableEvents = tree.NewDInt((1 << UpdateCommand) | (1 << InsertCommand) | (1 << DeleteCommand))
+)
 
 // PGIOBuiltinPrefix returns the string prefix to a type's IO functions. This
 // is either the type's postgres display name or the type's postgres display
@@ -1141,6 +1157,92 @@ SELECT description
 				return tree.MakeDBool(tree.DBool(isVisible)), nil
 			},
 			Info:       "Returns whether the type with the given OID belongs to one of the schemas on the search path.",
+			Volatility: tree.VolatilityStable,
+		},
+	),
+
+	"pg_relation_is_updatable": makeBuiltin(
+		defProps(),
+		tree.Overload{
+			Types:      tree.ArgTypes{{"reloid", types.Oid}, {"include_triggers", types.Bool}},
+			ReturnType: tree.FixedReturnType(types.Int4),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				oidArg := tree.MustBeDOid(args[0])
+				oid := int(oidArg.DInt)
+				table, err := ctx.Planner.GetImmutableTableInterfaceByID(ctx.Ctx(), oid)
+				if err != nil {
+					// For postgres compatibility, it is expected that rather returning
+					// an error this return nonUpdatableEvents (Zero) because there could
+					// be oid references on deleted tables.
+					if sqlerrors.IsUndefinedRelationError(err) {
+						return nonUpdatableEvents, nil
+					}
+					return nonUpdatableEvents, err
+				}
+				tableDesc, ok := table.(catalog.TableDescriptor)
+				if !ok || !tableDesc.IsTable() || tableDesc.IsVirtualTable() {
+					return nonUpdatableEvents, nil
+				}
+
+				// pg_relation_is_updatable was created for compatibility. This
+				// should return the update events the relation supports, but as crdb
+				// does not support updatable views or foreign tables, right now this
+				// basically return allEvents or none.
+				return allUpdatableEvents, nil
+			},
+			Info:       `Returns the update events the relation supports.`,
+			Volatility: tree.VolatilityStable,
+		},
+	),
+
+	"pg_column_is_updatable": makeBuiltin(
+		defProps(),
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"reloid", types.Oid},
+				{"attnum", types.Int2},
+				{"include_triggers", types.Bool},
+			},
+			ReturnType: tree.FixedReturnType(types.Bool),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				oidArg := tree.MustBeDOid(args[0])
+				attNumArg := tree.MustBeDInt(args[1])
+				oid := int(oidArg.DInt)
+				attNum := uint32(attNumArg)
+				if attNumArg < 0 {
+					// System columns are not updatable.
+					return tree.DBoolFalse, nil
+				}
+				table, err := ctx.Planner.GetImmutableTableInterfaceByID(ctx.Ctx(), oid)
+				if err != nil {
+					if sqlerrors.IsUndefinedRelationError(err) {
+						// For postgres compatibility, it is expected that rather returning
+						// an error this return nonUpdatableEvents (Zero) because there could
+						// be oid references on deleted tables.
+						return tree.DBoolFalse, nil
+					}
+					return tree.DBoolFalse, err
+				}
+				tableDesc, ok := table.(catalog.TableDescriptor)
+				if !ok || !tableDesc.IsTable() || tableDesc.IsVirtualTable() {
+					return tree.DBoolFalse, nil
+				}
+
+				column, err := tableDesc.FindColumnWithID(descpb.ColumnID(attNum))
+				if err != nil {
+					if sqlerrors.IsUndefinedColumnError(err) {
+						// When column does not exist postgres returns true.
+						return tree.DBoolTrue, nil
+					}
+					return tree.DBoolFalse, err
+				}
+
+				// pg_column_is_updatable was created for compatibility. This
+				// will return true if is a table (not virtual) and column is not
+				// a computed column.
+				return tree.MakeDBool(tree.DBool(!column.IsComputed())), nil
+			},
+			Info:       `Returns whether the given column can be updated.`,
 			Volatility: tree.VolatilityStable,
 		},
 	),


### PR DESCRIPTION
Previously, there were not functions pg_relation_is_updatable
and pg_column_is_updatable
This was inadequate because PostGraphile tool rely on these builtins
To address this, this patch adds these builtin functions

Release note (sql change): Added pg_relation_is_updatable and pg_column_is_updatable builtin functions

Fixes #61715