### PR TITLE
release: label each merged PR with the earliest version that contains it

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -173,6 +173,7 @@
 /pkg/cmd/roachprod/          @cockroachdb/dev-inf
 /pkg/cmd/roachprod-stress/   @cockroachdb/test-eng
 /pkg/cmd/roachtest/          @cockroachdb/test-eng
+/pkg/cmd/tag-merged-pr/      @cockroachdb/dev-inf
 # This isn't quite right, each file should ideally be owned
 # by a team (or at least most of them), namely the team that
 # is the Owner for the roachtest, but until we unify these

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -84,6 +84,7 @@ ALL_TESTS = [
     "//pkg/cmd/roachtest/spec:spec_test",
     "//pkg/cmd/roachtest/tests:tests_test",
     "//pkg/cmd/roachtest:roachtest_test",
+    "//pkg/cmd/tag-merged-pr:tag-merged-pr_test",
     "//pkg/cmd/teamcity-trigger:teamcity-trigger_test",
     "//pkg/cmd/testfilter:testfilter_test",
     "//pkg/col/coldata:coldata_test",

--- a/pkg/cmd/tag-merged-pr/BUILD.bazel
+++ b/pkg/cmd/tag-merged-pr/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+
+go_library(
+    name = "tag-merged-pr_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/cmd/tag-merged-pr",
+    visibility = ["//visibility:private"],
+)
+
+go_binary(
+    name = "tag-merged-pr",
+    embed = [":tag-merged-pr_lib"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "tag-merged-pr_test",
+    srcs = ["main_test.go"],
+    embed = [":tag-merged-pr_lib"],
+    deps = [
+        "//pkg/testutils/skip",
+        "@com_github_stretchr_testify//assert",
+    ],
+)

--- a/pkg/cmd/tag-merged-pr/main.go
+++ b/pkg/cmd/tag-merged-pr/main.go
@@ -1,0 +1,240 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+)
+
+func main() {
+	log.SetFlags(0)
+	var tokenPath, fromRef, toRef, repository, gitCheckoutDir string
+	var dryRun bool
+
+	flag.StringVar(&tokenPath, "token", "", "Path to GitHub token with repo:public_repo scope")
+	flag.StringVar(&fromRef, "from", "", "From git ref")
+	flag.StringVar(&toRef, "to", "", "To git ref")
+	flag.StringVar(&repository, "repo", "", "Github repository to work on in 'owner/repo")
+	flag.StringVar(&gitCheckoutDir, "dir", "", "Git checkout directory")
+	flag.BoolVar(&dryRun, "dry-run", false, "Dry run")
+	flag.Parse()
+
+	// Validating required flags.
+	allRequiredFlagsSet := true
+	if tokenPath == "" {
+		allRequiredFlagsSet = false
+		log.Println("missing required --token-path argument/flag")
+	}
+	if fromRef == "" {
+		allRequiredFlagsSet = false
+		log.Println("missing required --from argument/flag")
+	}
+	if toRef == "" {
+		allRequiredFlagsSet = false
+		log.Println("missing required --to argument/flag")
+	}
+	if repository == "" {
+		allRequiredFlagsSet = false
+		log.Println("missing required --repo argument/flag")
+	}
+	if gitCheckoutDir == "" {
+		allRequiredFlagsSet = false
+		log.Println("missing required --dir argument/flag")
+	}
+
+	if !allRequiredFlagsSet {
+		log.Fatal("Please provide all required parameters")
+	}
+
+	if gitCheckoutDir != "" {
+		if err := os.Chdir(gitCheckoutDir); err != nil {
+			log.Fatalf("Cannot chdir to %s: %+v\n", gitCheckoutDir, err)
+		}
+	}
+	token, err := readToken(tokenPath)
+	if err != nil {
+		log.Fatalf("Cannot read token from %s: %+v\n", tokenPath, err)
+	}
+	refList, err := getRefs(fromRef, toRef)
+	if err != nil {
+		log.Fatalf("Cannot get refs: %+v\n", err)
+	}
+
+	for _, ref := range refList {
+		tag, err := getTag(ref)
+		if err != nil {
+			log.Fatalf("Cannot get tag for ref %s: %+v\n", ref, err)
+		}
+		pr, err := getPrInfo(ref)
+		if err != nil {
+			log.Fatalf("Cannot find PR for ref %s: %+v\n", ref, err)
+		}
+		log.Printf("Labeling PR#%s (ref %s) using tag %s", pr, ref, tag)
+		if dryRun {
+			log.Println("DRY RUN: skipping labeling")
+			continue
+		}
+		if err := labelPR(http.DefaultClient, repository, token, pr, tag); err != nil {
+			log.Fatalf("Failed on tag creation for Pull Request %s, error : '%s'\n", pr, err)
+		}
+	}
+}
+
+func readToken(path string) (string, error) {
+	token, err := ioutil.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(token)), nil
+}
+
+func filterPullRequests(text string) []string {
+	var shas []string
+	for _, line := range strings.Split(text, "\n") {
+		if !strings.Contains(line, "Merge pull request") {
+			continue
+		}
+		sha := strings.Fields(line)[0]
+		shas = append(shas, sha)
+	}
+	return shas
+}
+
+func getRefs(fromRef, toRef string) ([]string, error) {
+	cmd := exec.Command("git", "log", "--merges", "--reverse", "--oneline",
+		"--format=format:%h %s", "--ancestry-path", fmt.Sprintf("%s..%s", fromRef, toRef))
+	out, err := cmd.Output()
+	if err != nil {
+		return []string{}, err
+	}
+	return filterPullRequests(string(out)), nil
+}
+
+func matchVersion(text string) string {
+	for _, line := range strings.Fields(text) {
+		// Only looking for version tags.
+		regVersion := regexp.MustCompile(`^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)`)
+		if !regVersion.MatchString(line) {
+			continue
+		}
+		// Should avoid *-alpha.00000000 tag, so we continue with the next line value.
+		alpha00Regex := regexp.MustCompile(`v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-alpha.00+$`)
+		if alpha00Regex.MatchString(line) {
+			continue
+		}
+		// Checking first for An alpha/beta/rc tag.
+		// if present, return line value
+		alphaBetaRcRegex := regexp.MustCompile(`^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-[-.0-9A-Za-z]+$`)
+		if alphaBetaRcRegex.MatchString(line) {
+			return line
+		}
+		// Second check is vX.Y.Z patch release >= .1 is first (ex: v20.1.1).
+		patchRegex := regexp.MustCompile(`^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.[1-9][0-9]*$`)
+		if patchRegex.MatchString(line) {
+			return line
+		}
+		// Third check is major release A vX.Y.0 release.
+		majorReleaseRegex := regexp.MustCompile(`^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.0$`)
+		if majorReleaseRegex.MatchString(line) {
+			return line
+		}
+	}
+	return ""
+}
+
+func getTag(ref string) (string, error) {
+	cmd := exec.Command("git", "tag", "--contains", ref)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	version := matchVersion(string(out))
+	if version == "" {
+		return "", fmt.Errorf("cannot find valid version")
+	}
+	return version, nil
+}
+
+func getPrNumber(text string) string {
+	for _, prNumber := range strings.Fields(text) {
+		if strings.HasPrefix(prNumber, "#") {
+			return strings.TrimPrefix(prNumber, "#")
+		}
+	}
+	return ""
+}
+
+func getPrInfo(ref string) (string, error) {
+	cmd := exec.Command("git", "show", "--oneline", "--format=format:%h %s", ref)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	pr := getPrNumber(string(out))
+	if pr == "" {
+		return "", fmt.Errorf("cannot find PR number")
+	}
+	return pr, nil
+}
+
+func apiCall(client *http.Client, url string, token string, payload interface{}) error {
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequest("POST", url, bytes.NewReader(payloadJSON))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("token %s", token))
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	// Status code 422 is returned when a label already exist
+	if !(resp.StatusCode == http.StatusCreated || resp.StatusCode == http.StatusUnprocessableEntity || resp.
+		StatusCode == http.StatusOK) {
+		return fmt.Errorf("status code %d from %s", resp.StatusCode, url)
+	}
+	return nil
+}
+
+func labelPR(client *http.Client, repository string, token string, pr string, tag string) error {
+	label := fmt.Sprintf("earliest-release-%s", tag)
+	payload := struct {
+		Name  string `json:"name"`
+		Color string `json:"color"`
+	}{
+		Name:  label,
+		Color: "000000",
+	}
+	if err := apiCall(client, fmt.Sprintf("https://api.github.com/repos/%s/labels", repository), token,
+		payload); err != nil {
+		return err
+	}
+	url := fmt.Sprintf("https://api.github.com/repos/%s/issues/%s/labels", repository, pr)
+	labels := []string{label}
+	if err := apiCall(client, url, token, labels); err != nil {
+		return err
+	}
+	log.Printf("Label %s added to PR %s\n", label, pr)
+	return nil
+}

--- a/pkg/cmd/tag-merged-pr/main_test.go
+++ b/pkg/cmd/tag-merged-pr/main_test.go
@@ -1,0 +1,153 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetPrNumber(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"Test #1212 pass test", "1212"},
+		{"FAIL", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			assert.Equal(t, getPrNumber(tc.input), tc.expected)
+		})
+	}
+}
+
+func TestReadToken(t *testing.T) {
+	output, err := ioutil.TempFile("", "token_test_file")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := os.Remove(output.Name()); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// Writing to the test file
+	text := []byte("hjk23434343j\n" + "SPACE")
+	if _, err = output.Write(text); err != nil {
+		log.Fatal("Failed to write to temporary file", err)
+	}
+	if err := output.Close(); err != nil {
+		log.Fatal(err)
+	}
+
+	token, _ := readToken(output.Name())
+	failToken, _ := readToken("Fail")
+	dat, _ := ioutil.ReadFile(output.Name())
+
+	assert.Equal(t, token, string(dat))
+	assert.Equal(t, failToken, "")
+}
+
+func TestFilterPullRequests(t *testing.T) {
+
+	tests := []struct {
+		input    string
+		expected []string
+	}{
+		{`1111 Merge pull request #1111 
+						 2222 Merge pull request #2222
+						 3333 Merge pull request #3333
+						 4444 Merge pull request #4444`, []string{"1111", "2222", "3333", "4444"}},
+		{`1111 Pull request #1111
+						 2222 Merge request #2222
+					   3333 Super pull request #3333
+					   4444 Ultra pull request #4444`, []string(nil)},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			assert.Equal(t, filterPullRequests(tc.input), tc.expected)
+		})
+	}
+
+}
+
+func TestMatchVersion(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		// No other than versions tags should be accepted.
+		{"Version1.0.1", ""},
+		{"Undefined", ""},
+		// Accepted version tags.
+		{"v1.0.1", "v1.0.1"},
+		{"v2.2.2", "v2.2.2"},
+		// Skipping *-alpha.00000000 tag.
+		{"v1.0.1-alpha.00000000", ""},
+		{"v2.2.2-alpha.00000000", ""},
+		// Checking for An alpha/beta/rc tag.
+		{"v1.0.1-alpha.1", "v1.0.1-alpha.1"},
+		{"v1.0.1-beta.1", "v1.0.1-beta.1"},
+		{"v1.0.1-rc.1", "v1.0.1-rc.1"},
+		// Check is vX.Y.Z patch release >= .1 is first (ex: v20.1.1).
+		{"v20.0.1", "v20.0.1"},
+		{"v22.1.2", "v22.1.2"},
+		// Checking for major releases.
+		{"v1.1.0", "v1.1.0"},
+		{"v2.2.0", "v2.2.0"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			assert.Equal(t, matchVersion(tc.input), tc.expected)
+		})
+	}
+}
+
+func TestApiCall(t *testing.T) {
+	skip.UnderStress(t, "Tests fail running in parallel due to the race condition in httptest binding the same port for"+
+		" multiple server instances.")
+	responseCodes := []int{201, 422, 500}
+	for _, respCode := range responseCodes {
+		t.Run(fmt.Sprintf("Resp code: %d", respCode), func(t *testing.T) {
+			testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+				res.WriteHeader(respCode)
+				_, err := res.Write([]byte("body"))
+				if err != nil {
+					return
+				}
+			}))
+			defer testServer.Close()
+
+			// Checking for any other error status "500"
+			if respCode != 500 {
+				err := apiCall(http.DefaultClient, testServer.URL, "test", "test")
+				assert.NoError(t, err)
+				return
+			}
+			// Checking for StatusUnprocessableEntity "422" and StatusCreated "201"
+			err := apiCall(http.DefaultClient, testServer.URL, "test", "test")
+			assert.Error(t, err)
+		})
+	}
+}

--- a/pkg/cmd/tag-merged-pr/tag-merged-pr-wrapper.sh
+++ b/pkg/cmd/tag-merged-pr/tag-merged-pr-wrapper.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -uo pipefail
+
+this_dir=$(cd "$(dirname "$0")" && pwd)
+cd $this_dir/..
+mkdir -p artifacts
+bazel build //pkg/cmd/tag-merged-pr &> artifacts/build.log
+status=$?
+if [ $status -eq 0 ]
+then
+    $(bazel info bazel-bin)/pkg/cmd/tag-merged-pr/tag-merged-pr_/tag-merged-pr "$@"
+else
+    echo 'Failed to build pkg/cmd/tag-merged-pr! Got output:'
+    cat artifacts/build.log
+    exit $status
+fi


### PR DESCRIPTION
People often want to known which cockroach release contained the commits for
a merged PR. For non-cockroach engineers, this can be a difficult thing to
figure out.

With this commit, a new command is being added that will evaluate all PRs
merged between two commits and add a label to those PRs indicting the version
in which the PR commits were first released.

Informs #44122

Release justification: Non-production code changes.

Release note: None