### PR TITLE
colexecbase: fix casting integers to smaller widths

### DIFF
--- a/pkg/sql/colexec/colexecbase/cast.eg.go
+++ b/pkg/sql/colexec/colexecbase/cast.eg.go
@@ -1454,9 +1454,7 @@ func (c *castInt16Int32Op) Next() coldata.Batch {
 						}
 						v := inputCol.Get(tupleIdx)
 						var r int32
-
 						r = int32(v)
-
 						outputCol[tupleIdx] = r
 					}
 				} else {
@@ -1472,9 +1470,7 @@ func (c *castInt16Int32Op) Next() coldata.Batch {
 						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r int32
-
 						r = int32(v)
-
 						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
@@ -1490,9 +1486,7 @@ func (c *castInt16Int32Op) Next() coldata.Batch {
 						tupleIdx = sel[i]
 						v := inputCol.Get(tupleIdx)
 						var r int32
-
 						r = int32(v)
-
 						outputCol[tupleIdx] = r
 					}
 				} else {
@@ -1505,9 +1499,7 @@ func (c *castInt16Int32Op) Next() coldata.Batch {
 						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r int32
-
 						r = int32(v)
-
 						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
@@ -1563,9 +1555,7 @@ func (c *castInt16Int64Op) Next() coldata.Batch {
 						}
 						v := inputCol.Get(tupleIdx)
 						var r int64
-
 						r = int64(v)
-
 						outputCol[tupleIdx] = r
 					}
 				} else {
@@ -1581,9 +1571,7 @@ func (c *castInt16Int64Op) Next() coldata.Batch {
 						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r int64
-
 						r = int64(v)
-
 						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
@@ -1599,9 +1587,7 @@ func (c *castInt16Int64Op) Next() coldata.Batch {
 						tupleIdx = sel[i]
 						v := inputCol.Get(tupleIdx)
 						var r int64
-
 						r = int64(v)
-
 						outputCol[tupleIdx] = r
 					}
 				} else {
@@ -1614,9 +1600,7 @@ func (c *castInt16Int64Op) Next() coldata.Batch {
 						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r int64
-
 						r = int64(v)
-
 						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
@@ -2016,6 +2000,10 @@ func (c *castInt32Int16Op) Next() coldata.Batch {
 						v := inputCol.Get(tupleIdx)
 						var r int16
 
+						shifted := v >> uint(15)
+						if (v >= 0 && shifted > 0) || (v < 0 && shifted < -1) {
+							colexecerror.ExpectedError(tree.ErrInt2OutOfRange)
+						}
 						r = int16(v)
 
 						outputCol[tupleIdx] = r
@@ -2034,6 +2022,10 @@ func (c *castInt32Int16Op) Next() coldata.Batch {
 						v := inputCol.Get(tupleIdx)
 						var r int16
 
+						shifted := v >> uint(15)
+						if (v >= 0 && shifted > 0) || (v < 0 && shifted < -1) {
+							colexecerror.ExpectedError(tree.ErrInt2OutOfRange)
+						}
 						r = int16(v)
 
 						//gcassert:bce
@@ -2052,6 +2044,10 @@ func (c *castInt32Int16Op) Next() coldata.Batch {
 						v := inputCol.Get(tupleIdx)
 						var r int16
 
+						shifted := v >> uint(15)
+						if (v >= 0 && shifted > 0) || (v < 0 && shifted < -1) {
+							colexecerror.ExpectedError(tree.ErrInt2OutOfRange)
+						}
 						r = int16(v)
 
 						outputCol[tupleIdx] = r
@@ -2067,6 +2063,10 @@ func (c *castInt32Int16Op) Next() coldata.Batch {
 						v := inputCol.Get(tupleIdx)
 						var r int16
 
+						shifted := v >> uint(15)
+						if (v >= 0 && shifted > 0) || (v < 0 && shifted < -1) {
+							colexecerror.ExpectedError(tree.ErrInt2OutOfRange)
+						}
 						r = int16(v)
 
 						//gcassert:bce
@@ -2225,9 +2225,7 @@ func (c *castInt32Int64Op) Next() coldata.Batch {
 						}
 						v := inputCol.Get(tupleIdx)
 						var r int64
-
 						r = int64(v)
-
 						outputCol[tupleIdx] = r
 					}
 				} else {
@@ -2243,9 +2241,7 @@ func (c *castInt32Int64Op) Next() coldata.Batch {
 						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r int64
-
 						r = int64(v)
-
 						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
@@ -2261,9 +2257,7 @@ func (c *castInt32Int64Op) Next() coldata.Batch {
 						tupleIdx = sel[i]
 						v := inputCol.Get(tupleIdx)
 						var r int64
-
 						r = int64(v)
-
 						outputCol[tupleIdx] = r
 					}
 				} else {
@@ -2276,9 +2270,7 @@ func (c *castInt32Int64Op) Next() coldata.Batch {
 						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r int64
-
 						r = int64(v)
-
 						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
@@ -2678,6 +2670,10 @@ func (c *castInt64Int16Op) Next() coldata.Batch {
 						v := inputCol.Get(tupleIdx)
 						var r int16
 
+						shifted := v >> uint(15)
+						if (v >= 0 && shifted > 0) || (v < 0 && shifted < -1) {
+							colexecerror.ExpectedError(tree.ErrInt2OutOfRange)
+						}
 						r = int16(v)
 
 						outputCol[tupleIdx] = r
@@ -2696,6 +2692,10 @@ func (c *castInt64Int16Op) Next() coldata.Batch {
 						v := inputCol.Get(tupleIdx)
 						var r int16
 
+						shifted := v >> uint(15)
+						if (v >= 0 && shifted > 0) || (v < 0 && shifted < -1) {
+							colexecerror.ExpectedError(tree.ErrInt2OutOfRange)
+						}
 						r = int16(v)
 
 						//gcassert:bce
@@ -2714,6 +2714,10 @@ func (c *castInt64Int16Op) Next() coldata.Batch {
 						v := inputCol.Get(tupleIdx)
 						var r int16
 
+						shifted := v >> uint(15)
+						if (v >= 0 && shifted > 0) || (v < 0 && shifted < -1) {
+							colexecerror.ExpectedError(tree.ErrInt2OutOfRange)
+						}
 						r = int16(v)
 
 						outputCol[tupleIdx] = r
@@ -2729,6 +2733,10 @@ func (c *castInt64Int16Op) Next() coldata.Batch {
 						v := inputCol.Get(tupleIdx)
 						var r int16
 
+						shifted := v >> uint(15)
+						if (v >= 0 && shifted > 0) || (v < 0 && shifted < -1) {
+							colexecerror.ExpectedError(tree.ErrInt2OutOfRange)
+						}
 						r = int16(v)
 
 						//gcassert:bce
@@ -2787,6 +2795,10 @@ func (c *castInt64Int32Op) Next() coldata.Batch {
 						v := inputCol.Get(tupleIdx)
 						var r int32
 
+						shifted := v >> uint(31)
+						if (v >= 0 && shifted > 0) || (v < 0 && shifted < -1) {
+							colexecerror.ExpectedError(tree.ErrInt4OutOfRange)
+						}
 						r = int32(v)
 
 						outputCol[tupleIdx] = r
@@ -2805,6 +2817,10 @@ func (c *castInt64Int32Op) Next() coldata.Batch {
 						v := inputCol.Get(tupleIdx)
 						var r int32
 
+						shifted := v >> uint(31)
+						if (v >= 0 && shifted > 0) || (v < 0 && shifted < -1) {
+							colexecerror.ExpectedError(tree.ErrInt4OutOfRange)
+						}
 						r = int32(v)
 
 						//gcassert:bce
@@ -2823,6 +2839,10 @@ func (c *castInt64Int32Op) Next() coldata.Batch {
 						v := inputCol.Get(tupleIdx)
 						var r int32
 
+						shifted := v >> uint(31)
+						if (v >= 0 && shifted > 0) || (v < 0 && shifted < -1) {
+							colexecerror.ExpectedError(tree.ErrInt4OutOfRange)
+						}
 						r = int32(v)
 
 						outputCol[tupleIdx] = r
@@ -2838,6 +2858,10 @@ func (c *castInt64Int32Op) Next() coldata.Batch {
 						v := inputCol.Get(tupleIdx)
 						var r int32
 
+						shifted := v >> uint(31)
+						if (v >= 0 && shifted > 0) || (v < 0 && shifted < -1) {
+							colexecerror.ExpectedError(tree.ErrInt4OutOfRange)
+						}
 						r = int32(v)
 
 						//gcassert:bce

--- a/pkg/sql/logictest/testdata/logic_test/cast
+++ b/pkg/sql/logictest/testdata/logic_test/cast
@@ -32,3 +32,31 @@ SELECT t0.c0 FROM t0 WHERE t0.c0 BETWEEN t0.c0 AND INTERVAL '-1'::DECIMAL
 query T
 SELECT t1.c0 FROM t1 WHERE t1.c0 BETWEEN t1.c0 AND INTERVAL '-1'::DECIMAL
 ----
+
+# Regression test for incorrectly casting integers out of range (#64429).
+statement ok
+CREATE TABLE t64429 (_int8 INT8, _int4 INT4);
+INSERT INTO t64429 VALUES (3000000000, 300000);
+
+statement error integer out of range for type int2
+SELECT _int8::INT2 FROM t64429
+
+statement error integer out of range for type int4
+SELECT _int8::INT4 FROM t64429
+
+statement error integer out of range for type int2
+SELECT _int4::INT2 FROM t64429
+
+# Also check the negative overflow.
+statement ok
+DELETE FROM t64429 WHERE true;
+INSERT INTO t64429 VALUES (-3000000000, -300000);
+
+statement error integer out of range for type int2
+SELECT _int8::INT2 FROM t64429
+
+statement error integer out of range for type int4
+SELECT _int8::INT4 FROM t64429
+
+statement error integer out of range for type int2
+SELECT _int4::INT2 FROM t64429

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -55,6 +55,10 @@ import (
 var (
 	// ErrIntOutOfRange is reported when integer arithmetic overflows.
 	ErrIntOutOfRange = pgerror.New(pgcode.NumericValueOutOfRange, "integer out of range")
+	// ErrInt4OutOfRange is reported when casting to INT4 overflows.
+	ErrInt4OutOfRange = pgerror.New(pgcode.NumericValueOutOfRange, "integer out of range for type int4")
+	// ErrInt2OutOfRange is reported when casting to INT2 overflows.
+	ErrInt2OutOfRange = pgerror.New(pgcode.NumericValueOutOfRange, "integer out of range for type int2")
 	// ErrFloatOutOfRange is reported when float arithmetic overflows.
 	ErrFloatOutOfRange = pgerror.New(pgcode.NumericValueOutOfRange, "float out of range")
 	errDecOutOfRange   = pgerror.New(pgcode.NumericValueOutOfRange, "decimal out of range")


### PR DESCRIPTION
This was fixed for row-by-row engine during 21.1 time frame, and this
commit fixes the issue in the vectorized engine.

Fixes: #64429.

Release note (bug fix): Previously, CockroachDB could incorrectly cast
integers of larger widths to integers of smaller widths (e.g. INT8 to
INT2) when the former is out of range for the latter. Now this is fixed.