### PR TITLE
release-20.2: sql: full table scan metric no longer counts limit scans

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/limit
+++ b/pkg/sql/logictest/testdata/logic_test/limit
@@ -176,3 +176,16 @@ INSERT INTO t_47283 VALUES (1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6)
 query II
 SELECT * FROM (SELECT * FROM t_47283 ORDER BY k LIMIT 4) WHERE a > 5 LIMIT 1
 ----
+
+# Regression test for #60751. Do not incorrectly treat a limited scan as
+# containing full scan.
+statement ok
+SET disallow_full_table_scans = true;
+
+query I
+SELECT w FROM t ORDER BY k LIMIT 1;
+----
+1
+
+statement ok
+SET disallow_full_table_scans = false;

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -568,7 +568,7 @@ func (b *Builder) buildScan(scan *memo.ScanExpr) (execPlan, error) {
 
 	// Save if we planned a full table/index scan on the builder so that the
 	// planner can be made aware later. We only do this for non-virtual tables.
-	if !tab.IsVirtualTable() && scan.Constraint == nil && scan.InvertedConstraint == nil {
+	if !tab.IsVirtualTable() && scan.Constraint == nil && scan.InvertedConstraint == nil && !scan.HardLimit.IsSet() {
 		if scan.Index == cat.PrimaryIndex {
 			b.ContainsFullTableScan = true
 		} else {


### PR DESCRIPTION
Backport 1/1 commits from #61178.

/cc @cockroachdb/release

---

Previous full table / index scan queries were counted
as limit scans, now limit scans are no longer counted.

Fixes: #60751

Release justification: bug fix and low-risk update

Release note (bug fix): limit scans are no longer counted
as full scans
