### PR TITLE
debug: add record type filter to debug keys

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -1030,6 +1030,14 @@ long and not particularly human-readable.`,
 Base64-encoded Descriptor to use as the table when decoding KVs.`,
 	}
 
+	FilterKeys = FlagInfo{
+		Name: "type",
+		Description: `
+Only show certain types of keys: values, intents, txns. If omitted all keys
+types are shown. Showing transactions will also implicitly limit key range
+to local keys if keys are not specified explicitly.`,
+	}
+
 	DrainWait = FlagInfo{
 		Name: "drain-wait",
 		Description: `

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -405,6 +405,7 @@ var debugCtx struct {
 	maxResults        int
 	decodeAsTableDesc string
 	verbose           bool
+	keyTypes          keyTypeFilter
 }
 
 // setDebugContextDefaults set the default values in debugCtx.  This
@@ -412,7 +413,7 @@ var debugCtx struct {
 // test that exercises command-line parsing.
 func setDebugContextDefaults() {
 	debugCtx.startKey = storage.NilKey
-	debugCtx.endKey = storage.MVCCKeyMax
+	debugCtx.endKey = storage.NilKey
 	debugCtx.values = false
 	debugCtx.sizes = false
 	debugCtx.replicated = false
@@ -422,6 +423,7 @@ func setDebugContextDefaults() {
 	debugCtx.printSystemConfig = false
 	debugCtx.decodeAsTableDesc = ""
 	debugCtx.verbose = false
+	debugCtx.keyTypes = showAll
 }
 
 // startCtx captures the command-line arguments for the `start` command.

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -229,6 +229,46 @@ var clusterNameRe = regexp.MustCompile(`^[a-zA-Z](?:[-a-zA-Z0-9]*[a-zA-Z0-9]|)$`
 
 const maxClusterNameLength = 256
 
+type keyTypeFilter int8
+
+const (
+	showAll keyTypeFilter = iota
+	showValues
+	showIntents
+	showTxns
+)
+
+// String implements the pflag.Value interface.
+func (f *keyTypeFilter) String() string {
+	switch *f {
+	case showValues:
+		return "values"
+	case showIntents:
+		return "intents"
+	case showTxns:
+		return "txns"
+	}
+	return "all"
+}
+
+// Type implements the pflag.Value interface.
+func (f *keyTypeFilter) Type() string { return "<key type>" }
+
+// Set implements the pflag.Value interface.
+func (f *keyTypeFilter) Set(v string) error {
+	switch v {
+	case "values":
+		*f = showValues
+	case "intents":
+		*f = showIntents
+	case "txns":
+		*f = showTxns
+	default:
+		return errors.Newf("invalid key filter type '%s'", v)
+	}
+	return nil
+}
+
 const backgroundEnvVar = "COCKROACH_BACKGROUND_RESTART"
 
 // flagSetForCmd is a replacement for cmd.Flag() that properly merges
@@ -838,6 +878,7 @@ func init() {
 		boolFlag(f, &debugCtx.values, cliflags.Values)
 		boolFlag(f, &debugCtx.sizes, cliflags.Sizes)
 		stringFlag(f, &debugCtx.decodeAsTableDesc, cliflags.DecodeAsTable)
+		varFlag(f, &debugCtx.keyTypes, cliflags.FilterKeys)
 	}
 	{
 		f := debugCheckLogConfigCmd.Flags()


### PR DESCRIPTION
Previously debug keys could only print storage keys that belong to a range.
To investigate transaction commit anomalies it is helpful to extract data about
intents, transactions and keys separately as number of keys could be too big
to process.
To address this, new command line flag --type is added that allows selecting
only single key type to dump (values, intents or txns).

Release note (cli change): --type option to debug keys