### PR TITLE
opt: calculate more accurate selectivity for disjunctions

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_merge_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_merge_join
@@ -515,7 +515,7 @@ vectorized: true
     ├── • filter
     │   │ columns: (pid1, pa1)
     │   │ ordering: +pid1
-    │   │ estimated row count: 333 (missing stats)
+    │   │ estimated row count: 342 (missing stats)
     │   │ filter: ((((pid1 >= 11) AND (pid1 <= 13)) OR ((pid1 >= 19) AND (pid1 <= 21))) OR ((pid1 >= 31) AND (pid1 <= 33))) OR (pa1 > 0)
     │   │
     │   └── • scan
@@ -594,7 +594,7 @@ vectorized: true
     └── • filter
         │ columns: (pid1, pa1)
         │ ordering: +pid1
-        │ estimated row count: 333 (missing stats)
+        │ estimated row count: 342 (missing stats)
         │ filter: ((((pid1 >= 11) AND (pid1 <= 13)) OR ((pid1 >= 19) AND (pid1 <= 21))) OR ((pid1 >= 31) AND (pid1 <= 33))) OR (pa1 > 0)
         │
         └── • scan
@@ -666,7 +666,7 @@ vectorized: true
 # creates a giant parent span which requires reading from all rows.
 query T
 EXPLAIN (DISTSQL)
-  SELECT * FROM child2 JOIN grandchild2 ON
+  SELECT * FROM child2 INNER MERGE JOIN grandchild2 ON
     child2.pid1=grandchild2.pid1
     AND child2.cid2=grandchild2.cid2
     AND child2.cid3=grandchild2.cid3
@@ -695,11 +695,11 @@ vectorized: true
           table: grandchild2@primary
           spans: FULL SCAN
 ·
-Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJzsl12P4jYUhu_7K6zTG9IxTex8ECKNlFWXVVnNwpYZqZVaLrLEhUgsoUmQuhrNf69CYMgH-MSTHdGLuUtsP_E5x-_rozxC-s8aPBj98fnu3XhCeu_H9w_3v91p5H50N_rlgfxEPsymn8hiFa1DTj5OxxOyTIJNeBiYTkivVzz_vI1CRm7L0_shjbybvCfHRYso5LVF-ZDWWGU2V5ka-f3X0WxEetU9_9oZhiluiV39yGlucUsGmkams1Ow-ziOIONngjySzNKO7LJCWcMDtayst5mmAYVNHIpJ8FWk4P0JDChwoGACBQso2DCnsE3ihUjTOMmXPO6BcfgveAaFaLPdZfnwnMIiTgR4j5BF2VqABw_Bl7WYiSAUiW4AhVBkQbTeb1OE72-T6GuQfAMK99tgk3qkr3P9R912dKZbvHh2daZzEmxCYpI4W4kkhfkThXiXHXY-bfjlG1kF6aq6lc-oz6lvwvxpTiHNgqUAjz3Rl-VhVz9eOvfvk8wpRK4S4odonYlEJDqrFbqY8HIh-iX9eZ43njy4B1n4JfUdZw5C8svaq1Fl5T1jR84qqa_GWSUFPnPf4VDNixU7fS1OQpGIsP61G-rzG-qbN3kYSqvPHMYnkSzFxzja5OdRE8xa_J31Sl_QbpNouaoOAYXpLvPIMUnqW9S3qe9Qf0B9l_rDi6KxWpRgtzmX1tlMJnE_3urcqK08v7dd2Zu19xRrdzdccFNft_JnOx-3XveeUMjJUbgnuiZ26c5Awj3dGeztzmhW7Ip3hnPFO4O31zhv6duSjPu686x1p3jOte68rm8Vchqo-LZjYpd8i4R78i1_822zYlf07eCKvjXba9xs6dvziu7r7uu6VSETV8WtL0rnkkeRIE8eNd882qzYFT3qXtGjVntlWy096vZ1ZhyFbRuHl1zZzHhdmyokM1Sx6UszuuRUJM6TU603pzYrdkWnDv8nf85n4pyJdBtvUtHqv9jIMxXhUhT1TONdshCfk3ix36Z4ne65_Q9IKNKsmDWLl_GmmMoDbA-7XWDGO9FOF5obcprVaaNCV2CjDnOFgnM12O0C1wquSjtd6FrBG7QpLbglPy1LflpMflx2F3_IYcQfchjzB0Ij_pDTmD8cacUH8oIPuvhDDiP-kMOYPxAa8YecxvzhdvHHsIvC5TCicDmMKRyhEYXLabQDNBpIpeIMuVRYo4OoiByhEZUjNCZzDEd0juCY0Fmjj6gonTX6iIrUERrROkJjYsdwRO0Ijspd3kOZjchdpYk2z1yli6rSqNyV-qgqjspd3kkxuau0UlUak7tSM1XGMbkrtdMmLu-nbIjIXaWjNs9cpaWq0qjclZqqKo7Jncu7al3u86cf_gsAAP__Ue8MMQ==
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJzsl12PozYUhu_7Kyz3JnScgs1HCNJIrLrZNqsZss2M1EptLtjgJkhZSIFIXY3mv1eEZPhKfPCwo-xF7gD7sc85fl8f8YTTfzfYwZM_P929m3po8H768Pjw-52CHiZ3k18e0U_ow3x2j5brcBMwNPW8yRzdT-a_TtDH2dRDq8SPgsPgzEODQfH88zYMKLqtDu8_Keid9x4dJy3DgDUm5Z-U1iy9PUtX0B-_TeYTNKjv-fdO03R-i8z6IuXY8haNFAXN5mWw-ziOIGUngjyS1FCO7KpGGeMDtarNN6miYIKjOOCe_4Wn2PkLU0wwwwTrmGADE2ziBcHbJF7yNI2TfMrTHpgG_2FHIziMtrss_7wgeBknHDtPOAuzDccOfvQ_b_ic-wFPVA0THPDMDzf7bYrw3W0SfvGTr5jgh60fpQ4aqkz9UTUtlaoGK55tlaoM-VGAdBRna56kePFMcLzLDjuXG37-itZ-uq5v5VLiMuLqePG8IDjN_BXHDn0mr8vDrC9eOfdvk0wZIpMJ8UO4yXjCE5U2Cl0MOLkQ3Yr-HMeZeo_2QRZuRX3HkYOQ3Kr2GlRVeS_YkTMq6mtwRkWBL9w3OFT9bMXK1eIk4AkPmqvdEJfdEFe_ycOQmn3iMO55suIf4zDKz6MhmA3_JxtUVlBuk3C1rn_CBM92mYOOSRLXIK5JXIu4I-LaxB2fFY3RoQS76FRaJzPx4mG8VZnWmHl6b7O2N-3uKdrtbjjjpqFq5M9m_t1423tCIidL4p7om9i5OwMIt7wz6PXOaFfsgneGdcE7g3XXOOvo24qMh6r1onWreM61br2tbyVyGsn4tmdi53wLhFv6ll19267YBX07uqBv9e4a1zv69rSih6r9tm6VyMSWceur0jnnUSDI0qP61aPtil3Qo_YFPWp0V7bR0aP2UKXaUdimdnjJlU21t7WpRDJjGZu-NqNzTgXiLJ1qXJ3artgFnTr-Tv6cT8Q55-k2jlLe6b9YyzPlwYoX9UzjXbLkn5J4ud-meJ3tuf0PSMDTrBjVi5dpVAzlAXaH7T4wZb1oqw_NNDFNm7RWo2uw1oSZRMGZHGz3gRsFl6WtPnSj4C1aFxbcEJ-WIT4tKj4us48_xDDgDzEM-QOgAX-IacgflrDiI3HBR338IYYBf4hhyB8ADfhDTEP-sPv4Y9xH4WIYULgYhhQO0IDCxTTYAVoNpFZxClwqtNVBZEQO0IDKARqSOYQDOgdwSOi01UdklE5bfURG6gANaB2gIbFDOKB2AAflLu6h1ATkLtNE22cu00VlaVDuUn1UFgflLu6kkNxlWqksDcldqplK45DcpdppGxf3UzoG5C7TUdtnLtNSZWlQ7lJNVRaH5M7EXbUp98XzD_8HAAD__0ujD10=
 
 query T
 EXPLAIN
-  SELECT * FROM child2 JOIN grandchild2 ON
+  SELECT * FROM child2 INNER MERGE JOIN grandchild2 ON
     child2.pid1=grandchild2.pid1
     AND child2.cid2=grandchild2.cid2
     AND child2.cid3=grandchild2.cid3

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -2966,11 +2966,12 @@ func (sb *statisticsBuilder) applyFiltersItem(
 	// want to make sure that we don't include columns that were only present in
 	// equality conjuncts such as var1=var2. The selectivity of these conjuncts
 	// will be accounted for in selectivityFromEquivalencies.
+	s := &relProps.Stats
 	scalarProps := filter.ScalarProps()
 	constrainedCols.UnionWith(scalarProps.OuterCols)
 	if scalarProps.Constraints != nil {
 		histColsLocal := sb.applyConstraintSet(
-			scalarProps.Constraints, scalarProps.TightConstraints, e, relProps,
+			scalarProps.Constraints, scalarProps.TightConstraints, e, relProps, s,
 		)
 		histCols.UnionWith(histColsLocal)
 		if !scalarProps.TightConstraints {
@@ -2982,11 +2983,121 @@ func (sb *statisticsBuilder) applyFiltersItem(
 				numUnappliedConjuncts++
 			}
 		}
+	} else if constraintUnion := sb.buildDisjunctionConstraints(filter); len(constraintUnion) > 0 {
+		// The filters are one or more disjunctions and tight constraint sets
+		// could be built for each.
+		var tmpStats, unionStats props.Statistics
+		unionStats.CopyFrom(s)
+
+		// Get the stats for each constraint set, apply the selectivity to a
+		// temporary stats struct, and union the selectivity and row counts.
+		sb.constrainExpr(e, constraintUnion[0], relProps, &unionStats)
+		for i := 1; i < len(constraintUnion); i++ {
+			tmpStats.CopyFrom(s)
+			sb.constrainExpr(e, constraintUnion[i], relProps, &tmpStats)
+			unionStats.UnionWith(&tmpStats)
+		}
+
+		// The stats are unioned naively; the selectivity may be greater than 1
+		// and the row count may be greater than the row count of the input
+		// stats. We use the minimum selectivity and row count of the unioned
+		// stats and the input stats.
+		// TODO(mgartner): Calculate and set the column statistics based on
+		// constraintUnion.
+		s.Selectivity = props.MinSelectivity(s.Selectivity, unionStats.Selectivity)
+		s.RowCount = min(s.RowCount, unionStats.RowCount)
 	} else {
 		numUnappliedConjuncts++
 	}
 
 	return numUnappliedConjuncts, constrainedCols, histCols
+}
+
+// buildDisjunctionConstraints returns a slice of tight constraint sets that are
+// built from one or more adjacent Or expressions in filter. This allows more
+// accurate stats to be calculated for disjunctions. If any adjacent Or cannot
+// be tightly constrained, then nil is returned.
+func (sb *statisticsBuilder) buildDisjunctionConstraints(filter *FiltersItem) []*constraint.Set {
+	expr := filter.Condition
+
+	// If the expression is not an Or, we cannot build disjunction constraint
+	// sets.
+	or, ok := expr.(*OrExpr)
+	if !ok {
+		return nil
+	}
+
+	cb := constraintsBuilder{md: sb.md, evalCtx: sb.evalCtx}
+
+	unconstrained := false
+	var constraints []*constraint.Set
+	var collectConstraints func(opt.ScalarExpr)
+	collectConstraints = func(e opt.ScalarExpr) {
+		// If a constraint can be built from e, collect the constraint and its
+		// tightness.
+		c, tight := cb.buildConstraints(e)
+		if !c.IsUnconstrained() && tight {
+			constraints = append(constraints, c)
+			return
+		}
+
+		innerOr, ok := e.(*OrExpr)
+		if !ok {
+			// If a tight constraint could not be built and the expression is
+			// not an Or, set unconstrained so we can return nil.
+			unconstrained = true
+			return
+		}
+
+		// If a constraint could not be built and the expression is an Or,
+		// attempt to build a constraint for the left and right children.
+		collectConstraints(innerOr.Left)
+		collectConstraints(innerOr.Right)
+	}
+
+	// We intentionally call collectConstraints on the left and right of the
+	// top-level Or expression here. collectConstraints attempts to build a
+	// constraint for the given expression before recursing. This would be
+	// wasted computation because if a constraint could have been built for the
+	// top-level or expression, we would not have reached this point -
+	// applyFiltersItem would have handled this case before calling
+	// buildDisjunctionConstraints.
+	collectConstraints(or.Left)
+	collectConstraints(or.Right)
+
+	if unconstrained {
+		return nil
+	}
+
+	return constraints
+}
+
+// constrainExpr calculates the stats for a relational expression based on the
+// constraint set. The constraint set must be tight.
+func (sb *statisticsBuilder) constrainExpr(
+	e RelExpr, cs *constraint.Set, relProps *props.Relational, s *props.Statistics,
+) {
+	constrainedCols := cs.ExtractCols()
+
+	// Calculate distinct counts and histograms for constrained columns
+	// ----------------------------------------------------------------
+	histCols := sb.applyConstraintSet(cs, true /* tight */, e, relProps, s)
+
+	// Set null counts to 0 for non-nullable columns
+	// ---------------------------------------------
+	notNullCols := relProps.NotNullCols.Copy()
+	// Add any not-null columns from this constraint set.
+	notNullCols.UnionWith(cs.ExtractNotNullCols(sb.evalCtx))
+	sb.updateNullCountsFromNotNullCols(notNullCols, s)
+
+	// Calculate row count and selectivity
+	// -----------------------------------
+	s.ApplySelectivity(sb.selectivityFromHistograms(histCols, e, s))
+	s.ApplySelectivity(sb.selectivityFromMultiColDistinctCounts(constrainedCols, e, s))
+	s.ApplySelectivity(sb.selectivityFromNullsRemoved(e, notNullCols, constrainedCols))
+
+	// Adjust the selectivity so we don't double-count the histogram columns.
+	s.UnapplySelectivity(sb.selectivityFromSingleColDistinctCounts(histCols, e, s))
 }
 
 // applyIndexConstraint is used to update the distinct counts and histograms
@@ -3058,7 +3169,7 @@ func (sb *statisticsBuilder) applyIndexConstraint(
 // for the constrained columns in a constraint set. Returns the set of
 // columns with a filtered histogram.
 func (sb *statisticsBuilder) applyConstraintSet(
-	cs *constraint.Set, tight bool, e RelExpr, relProps *props.Relational,
+	cs *constraint.Set, tight bool, e RelExpr, relProps *props.Relational, s *props.Statistics,
 ) (histCols opt.ColSet) {
 	// If unconstrained, then no constraint could be derived from the expression,
 	// so fall back to estimate.
@@ -3068,7 +3179,6 @@ func (sb *statisticsBuilder) applyConstraintSet(
 		return opt.ColSet{}
 	}
 
-	s := &relProps.Stats
 	for i := 0; i < cs.Length(); i++ {
 		c := cs.Constraint(i)
 		col := c.Columns.Get(0).ID()

--- a/pkg/sql/opt/memo/statistics_builder_test.go
+++ b/pkg/sql/opt/memo/statistics_builder_test.go
@@ -118,7 +118,7 @@ func TestGetStatsFromConstraint(t *testing.T) {
 		s.Init(relProps)
 
 		// Calculate distinct counts.
-		sb.applyConstraintSet(cs, true /* tight */, sel, relProps)
+		sb.applyConstraintSet(cs, true /* tight */, sel, relProps, &relProps.Stats)
 
 		// Calculate row count and selectivity.
 		s.RowCount = scan.Relational().Stats.RowCount

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -2521,3 +2521,505 @@ select
       ├── c31:31 = 1 [type=bool, outer=(31), constraints=(/31: [/1 - /1]; tight), fd=()-->(31)]
       ├── c32:32 = 1 [type=bool, outer=(32), constraints=(/32: [/1 - /1]; tight), fd=()-->(32)]
       └── c33:33 = 1 [type=bool, outer=(33), constraints=(/33: [/1 - /1]; tight), fd=()-->(33)]
+
+# Estimate statistics for filters with disjunctions by unioning the selectivity
+# of each disjunction. As a result, the optimizer can prefer unions of multiple
+# index scans over full table scans in more cases. See #58744.
+
+exec-ddl
+CREATE TABLE disjunction (
+  k INT PRIMARY KEY,
+  a STRING,
+  b STRING,
+  c STRING,
+  INDEX a_idx (a),
+  INDEX b_idx (b),
+  INDEX c_idx (c)
+)
+----
+
+exec-ddl
+ALTER TABLE disjunction INJECT STATISTICS '[
+  {
+    "columns": ["a"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 2000,
+    "distinct_count": 2000
+  },
+  {
+    "columns": ["b"],
+    "created_at": "2018-01-01 1:30:00.00000+00:00",
+    "row_count": 2000,
+    "distinct_count": 2000
+  },
+  {
+    "columns": ["c"],
+    "created_at": "2018-01-01 1:30:00.00000+00:00",
+    "row_count": 2000,
+    "distinct_count": 2000
+  }
+]'
+----
+
+# Disjunction without histograms.
+opt
+SELECT * FROM disjunction WHERE a = 'foo' OR b = 'foo' LIMIT 5
+----
+limit
+ ├── columns: k:1(int!null) a:2(string) b:3(string) c:4(string)
+ ├── cardinality: [0 - 5]
+ ├── stats: [rows=2]
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ ├── distinct-on
+ │    ├── columns: k:1(int!null) a:2(string) b:3(string) c:4(string)
+ │    ├── grouping columns: k:1(int!null)
+ │    ├── internal-ordering: +1
+ │    ├── stats: [rows=2]
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4)
+ │    ├── limit hint: 5.00
+ │    ├── union-all
+ │    │    ├── columns: k:1(int!null) a:2(string) b:3(string) c:4(string)
+ │    │    ├── left columns: k:6(int) a:7(string) b:8(string) c:9(string)
+ │    │    ├── right columns: k:11(int) a:12(string) b:13(string) c:14(string)
+ │    │    ├── stats: [rows=2]
+ │    │    ├── ordering: +1
+ │    │    ├── index-join disjunction
+ │    │    │    ├── columns: k:6(int!null) a:7(string!null) b:8(string) c:9(string)
+ │    │    │    ├── stats: [rows=1, distinct(7)=1, null(7)=0]
+ │    │    │    ├── key: (6)
+ │    │    │    ├── fd: ()-->(7), (6)-->(8,9)
+ │    │    │    ├── ordering: +6 opt(7) [actual: +6]
+ │    │    │    └── scan disjunction@a_idx
+ │    │    │         ├── columns: k:6(int!null) a:7(string!null)
+ │    │    │         ├── constraint: /7/6: [/'foo' - /'foo']
+ │    │    │         ├── stats: [rows=1, distinct(7)=1, null(7)=0]
+ │    │    │         ├── key: (6)
+ │    │    │         ├── fd: ()-->(7)
+ │    │    │         └── ordering: +6 opt(7) [actual: +6]
+ │    │    └── index-join disjunction
+ │    │         ├── columns: k:11(int!null) a:12(string) b:13(string!null) c:14(string)
+ │    │         ├── stats: [rows=1, distinct(13)=1, null(13)=0]
+ │    │         ├── key: (11)
+ │    │         ├── fd: ()-->(13), (11)-->(12,14)
+ │    │         ├── ordering: +11 opt(13) [actual: +11]
+ │    │         └── scan disjunction@b_idx
+ │    │              ├── columns: k:11(int!null) b:13(string!null)
+ │    │              ├── constraint: /13/11: [/'foo' - /'foo']
+ │    │              ├── stats: [rows=1, distinct(13)=1, null(13)=0]
+ │    │              ├── key: (11)
+ │    │              ├── fd: ()-->(13)
+ │    │              └── ordering: +11 opt(13) [actual: +11]
+ │    └── aggregations
+ │         ├── const-agg [as=a:2, type=string, outer=(2)]
+ │         │    └── a:2 [type=string]
+ │         ├── const-agg [as=b:3, type=string, outer=(3)]
+ │         │    └── b:3 [type=string]
+ │         └── const-agg [as=c:4, type=string, outer=(4)]
+ │              └── c:4 [type=string]
+ └── 5 [type=int]
+
+# Multiple disjunctions without histograms.
+opt
+SELECT * FROM disjunction WHERE a = 'foo' OR b = 'foo' OR c = 'foo' LIMIT 5
+----
+limit
+ ├── columns: k:1(int!null) a:2(string) b:3(string) c:4(string)
+ ├── cardinality: [0 - 5]
+ ├── stats: [rows=3]
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ ├── distinct-on
+ │    ├── columns: k:1(int!null) a:2(string) b:3(string) c:4(string)
+ │    ├── grouping columns: k:1(int!null)
+ │    ├── internal-ordering: +1
+ │    ├── stats: [rows=3]
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4)
+ │    ├── limit hint: 5.00
+ │    ├── union-all
+ │    │    ├── columns: k:1(int!null) a:2(string) b:3(string) c:4(string)
+ │    │    ├── left columns: k:6(int) a:7(string) b:8(string) c:9(string)
+ │    │    ├── right columns: k:11(int) a:12(string) b:13(string) c:14(string)
+ │    │    ├── stats: [rows=3]
+ │    │    ├── ordering: +1
+ │    │    ├── index-join disjunction
+ │    │    │    ├── columns: k:6(int!null) a:7(string!null) b:8(string) c:9(string)
+ │    │    │    ├── stats: [rows=1, distinct(7)=1, null(7)=0]
+ │    │    │    ├── key: (6)
+ │    │    │    ├── fd: ()-->(7), (6)-->(8,9)
+ │    │    │    ├── ordering: +6 opt(7) [actual: +6]
+ │    │    │    └── scan disjunction@a_idx
+ │    │    │         ├── columns: k:6(int!null) a:7(string!null)
+ │    │    │         ├── constraint: /7/6: [/'foo' - /'foo']
+ │    │    │         ├── stats: [rows=1, distinct(7)=1, null(7)=0]
+ │    │    │         ├── key: (6)
+ │    │    │         ├── fd: ()-->(7)
+ │    │    │         └── ordering: +6 opt(7) [actual: +6]
+ │    │    └── distinct-on
+ │    │         ├── columns: k:11(int!null) a:12(string) b:13(string) c:14(string)
+ │    │         ├── grouping columns: k:11(int!null)
+ │    │         ├── stats: [rows=2]
+ │    │         ├── key: (11)
+ │    │         ├── fd: (11)-->(12-14)
+ │    │         ├── ordering: +11
+ │    │         ├── union-all
+ │    │         │    ├── columns: k:11(int!null) a:12(string) b:13(string) c:14(string)
+ │    │         │    ├── left columns: k:16(int) a:17(string) b:18(string) c:19(string)
+ │    │         │    ├── right columns: k:21(int) a:22(string) b:23(string) c:24(string)
+ │    │         │    ├── stats: [rows=2]
+ │    │         │    ├── ordering: +11
+ │    │         │    ├── index-join disjunction
+ │    │         │    │    ├── columns: k:16(int!null) a:17(string) b:18(string) c:19(string!null)
+ │    │         │    │    ├── stats: [rows=1, distinct(19)=1, null(19)=0]
+ │    │         │    │    ├── key: (16)
+ │    │         │    │    ├── fd: ()-->(19), (16)-->(17,18)
+ │    │         │    │    ├── ordering: +16 opt(19) [actual: +16]
+ │    │         │    │    └── scan disjunction@c_idx
+ │    │         │    │         ├── columns: k:16(int!null) c:19(string!null)
+ │    │         │    │         ├── constraint: /19/16: [/'foo' - /'foo']
+ │    │         │    │         ├── stats: [rows=1, distinct(19)=1, null(19)=0]
+ │    │         │    │         ├── key: (16)
+ │    │         │    │         ├── fd: ()-->(19)
+ │    │         │    │         └── ordering: +16 opt(19) [actual: +16]
+ │    │         │    └── index-join disjunction
+ │    │         │         ├── columns: k:21(int!null) a:22(string) b:23(string!null) c:24(string)
+ │    │         │         ├── stats: [rows=1, distinct(23)=1, null(23)=0]
+ │    │         │         ├── key: (21)
+ │    │         │         ├── fd: ()-->(23), (21)-->(22,24)
+ │    │         │         ├── ordering: +21 opt(23) [actual: +21]
+ │    │         │         └── scan disjunction@b_idx
+ │    │         │              ├── columns: k:21(int!null) b:23(string!null)
+ │    │         │              ├── constraint: /23/21: [/'foo' - /'foo']
+ │    │         │              ├── stats: [rows=1, distinct(23)=1, null(23)=0]
+ │    │         │              ├── key: (21)
+ │    │         │              ├── fd: ()-->(23)
+ │    │         │              └── ordering: +21 opt(23) [actual: +21]
+ │    │         └── aggregations
+ │    │              ├── const-agg [as=a:12, type=string, outer=(12)]
+ │    │              │    └── a:12 [type=string]
+ │    │              ├── const-agg [as=b:13, type=string, outer=(13)]
+ │    │              │    └── b:13 [type=string]
+ │    │              └── const-agg [as=c:14, type=string, outer=(14)]
+ │    │                   └── c:14 [type=string]
+ │    └── aggregations
+ │         ├── const-agg [as=a:2, type=string, outer=(2)]
+ │         │    └── a:2 [type=string]
+ │         ├── const-agg [as=b:3, type=string, outer=(3)]
+ │         │    └── b:3 [type=string]
+ │         └── const-agg [as=c:4, type=string, outer=(4)]
+ │              └── c:4 [type=string]
+ └── 5 [type=int]
+
+opt
+SELECT * FROM disjunction WHERE (a = 'foo' OR b = 'foo') AND c = 'foo' LIMIT 5
+----
+limit
+ ├── columns: k:1(int!null) a:2(string) b:3(string) c:4(string!null)
+ ├── cardinality: [0 - 5]
+ ├── stats: [rows=0.001]
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3)
+ ├── select
+ │    ├── columns: k:1(int!null) a:2(string) b:3(string) c:4(string!null)
+ │    ├── stats: [rows=0.001, distinct(4)=0.001, null(4)=0]
+ │    ├── key: (1)
+ │    ├── fd: ()-->(4), (1)-->(2,3)
+ │    ├── limit hint: 5.00
+ │    ├── index-join disjunction
+ │    │    ├── columns: k:1(int!null) a:2(string) b:3(string) c:4(string)
+ │    │    ├── stats: [rows=1]
+ │    │    ├── key: (1)
+ │    │    ├── fd: ()-->(4), (1)-->(2,3)
+ │    │    └── scan disjunction@c_idx
+ │    │         ├── columns: k:1(int!null) c:4(string!null)
+ │    │         ├── constraint: /4/1: [/'foo' - /'foo']
+ │    │         ├── stats: [rows=1, distinct(4)=1, null(4)=0]
+ │    │         ├── key: (1)
+ │    │         └── fd: ()-->(4)
+ │    └── filters
+ │         └── (a:2 = 'foo') OR (b:3 = 'foo') [type=bool, outer=(2,3)]
+ └── 5 [type=int]
+
+exec-ddl
+ALTER TABLE disjunction INJECT STATISTICS '[
+  {
+    "columns": ["a"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 10000,
+    "distinct_count": 5010,
+    "histo_col_type": "string",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "aaa"},
+      {"num_eq": 10, "num_range": 990, "distinct_range": 999, "upper_bound": "foo"},
+      {"num_eq": 990, "num_range": 10, "distinct_range": 9, "upper_bound": "fop"},
+      {"num_eq": 0, "num_range": 8000, "distinct_range": 4000, "upper_bound": "zoo"}
+    ]
+  },
+  {
+    "columns": ["b"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 10000,
+    "distinct_count": 5010,
+    "histo_col_type": "string",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "aaa"},
+      {"num_eq": 10, "num_range": 990, "distinct_range": 999, "upper_bound": "foo"},
+      {"num_eq": 990, "num_range": 10, "distinct_range": 9, "upper_bound": "fop"},
+      {"num_eq": 0, "num_range": 8000, "distinct_range": 4000, "upper_bound": "zoo"}
+    ]
+  },
+  {
+    "columns": ["c"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 10000,
+    "distinct_count": 5010,
+    "histo_col_type": "string",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "aaa"},
+      {"num_eq": 10, "num_range": 990, "distinct_range": 999, "upper_bound": "foo"},
+      {"num_eq": 990, "num_range": 10, "distinct_range": 9, "upper_bound": "fop"},
+      {"num_eq": 0, "num_range": 8000, "distinct_range": 4000, "upper_bound": "zoo"}
+    ]
+  }
+]'
+----
+
+# Disjunction with histograms.
+opt
+SELECT * FROM disjunction WHERE a LIKE 'foo%' OR b LIKE 'foo%' LIMIT 5
+----
+limit
+ ├── columns: k:1(int!null) a:2(string) b:3(string) c:4(string)
+ ├── cardinality: [0 - 5]
+ ├── stats: [rows=5]
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ ├── distinct-on
+ │    ├── columns: k:1(int!null) a:2(string) b:3(string) c:4(string)
+ │    ├── grouping columns: k:1(int!null)
+ │    ├── stats: [rows=40]
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4)
+ │    ├── limit hint: 5.00
+ │    ├── union-all
+ │    │    ├── columns: k:1(int!null) a:2(string) b:3(string) c:4(string)
+ │    │    ├── left columns: k:6(int) a:7(string) b:8(string) c:9(string)
+ │    │    ├── right columns: k:11(int) a:12(string) b:13(string) c:14(string)
+ │    │    ├── stats: [rows=40]
+ │    │    ├── limit hint: 6.44
+ │    │    ├── index-join disjunction
+ │    │    │    ├── columns: k:6(int!null) a:7(string!null) b:8(string) c:9(string)
+ │    │    │    ├── stats: [rows=20, distinct(7)=10, null(7)=0]
+ │    │    │    │   histogram(7)=  0   10    10    0
+ │    │    │    │                <--- 'foo' ---- 'fop'
+ │    │    │    ├── key: (6)
+ │    │    │    ├── fd: (6)-->(7-9)
+ │    │    │    ├── limit hint: 6.44
+ │    │    │    └── scan disjunction@a_idx
+ │    │    │         ├── columns: k:6(int!null) a:7(string!null)
+ │    │    │         ├── constraint: /7/6: [/'foo' - /'fop')
+ │    │    │         ├── stats: [rows=20, distinct(7)=10, null(7)=0]
+ │    │    │         │   histogram(7)=  0   10    10    0
+ │    │    │         │                <--- 'foo' ---- 'fop'
+ │    │    │         ├── key: (6)
+ │    │    │         ├── fd: (6)-->(7)
+ │    │    │         └── limit hint: 6.44
+ │    │    └── index-join disjunction
+ │    │         ├── columns: k:11(int!null) a:12(string) b:13(string!null) c:14(string)
+ │    │         ├── stats: [rows=20, distinct(13)=10, null(13)=0]
+ │    │         │   histogram(13)=  0   10    10    0
+ │    │         │                 <--- 'foo' ---- 'fop'
+ │    │         ├── key: (11)
+ │    │         ├── fd: (11)-->(12-14)
+ │    │         ├── limit hint: 6.44
+ │    │         └── scan disjunction@b_idx
+ │    │              ├── columns: k:11(int!null) b:13(string!null)
+ │    │              ├── constraint: /13/11: [/'foo' - /'fop')
+ │    │              ├── stats: [rows=20, distinct(13)=10, null(13)=0]
+ │    │              │   histogram(13)=  0   10    10    0
+ │    │              │                 <--- 'foo' ---- 'fop'
+ │    │              ├── key: (11)
+ │    │              ├── fd: (11)-->(13)
+ │    │              └── limit hint: 6.44
+ │    └── aggregations
+ │         ├── const-agg [as=a:2, type=string, outer=(2)]
+ │         │    └── a:2 [type=string]
+ │         ├── const-agg [as=b:3, type=string, outer=(3)]
+ │         │    └── b:3 [type=string]
+ │         └── const-agg [as=c:4, type=string, outer=(4)]
+ │              └── c:4 [type=string]
+ └── 5 [type=int]
+
+
+# Multiple disjunctions with histograms.
+opt
+SELECT * FROM disjunction WHERE a LIKE 'foo%' OR b LIKE 'foo%' OR c LIKE 'foo%' LIMIT 5
+----
+limit
+ ├── columns: k:1(int!null) a:2(string) b:3(string) c:4(string)
+ ├── cardinality: [0 - 5]
+ ├── stats: [rows=5]
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ ├── distinct-on
+ │    ├── columns: k:1(int!null) a:2(string) b:3(string) c:4(string)
+ │    ├── grouping columns: k:1(int!null)
+ │    ├── stats: [rows=60]
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4)
+ │    ├── limit hint: 5.00
+ │    ├── union-all
+ │    │    ├── columns: k:1(int!null) a:2(string) b:3(string) c:4(string)
+ │    │    ├── left columns: k:6(int) a:7(string) b:8(string) c:9(string)
+ │    │    ├── right columns: k:11(int) a:12(string) b:13(string) c:14(string)
+ │    │    ├── stats: [rows=60]
+ │    │    ├── limit hint: 6.28
+ │    │    ├── index-join disjunction
+ │    │    │    ├── columns: k:6(int!null) a:7(string!null) b:8(string) c:9(string)
+ │    │    │    ├── stats: [rows=20, distinct(7)=10, null(7)=0]
+ │    │    │    │   histogram(7)=  0   10    10    0
+ │    │    │    │                <--- 'foo' ---- 'fop'
+ │    │    │    ├── key: (6)
+ │    │    │    ├── fd: (6)-->(7-9)
+ │    │    │    ├── limit hint: 6.28
+ │    │    │    └── scan disjunction@a_idx
+ │    │    │         ├── columns: k:6(int!null) a:7(string!null)
+ │    │    │         ├── constraint: /7/6: [/'foo' - /'fop')
+ │    │    │         ├── stats: [rows=20, distinct(7)=10, null(7)=0]
+ │    │    │         │   histogram(7)=  0   10    10    0
+ │    │    │         │                <--- 'foo' ---- 'fop'
+ │    │    │         ├── key: (6)
+ │    │    │         ├── fd: (6)-->(7)
+ │    │    │         └── limit hint: 6.28
+ │    │    └── distinct-on
+ │    │         ├── columns: k:11(int!null) a:12(string) b:13(string) c:14(string)
+ │    │         ├── grouping columns: k:11(int!null)
+ │    │         ├── stats: [rows=40]
+ │    │         ├── key: (11)
+ │    │         ├── fd: (11)-->(12-14)
+ │    │         ├── limit hint: 6.28
+ │    │         ├── union-all
+ │    │         │    ├── columns: k:11(int!null) a:12(string) b:13(string) c:14(string)
+ │    │         │    ├── left columns: k:16(int) a:17(string) b:18(string) c:19(string)
+ │    │         │    ├── right columns: k:21(int) a:22(string) b:23(string) c:24(string)
+ │    │         │    ├── stats: [rows=40]
+ │    │         │    ├── limit hint: 8.28
+ │    │         │    ├── index-join disjunction
+ │    │         │    │    ├── columns: k:16(int!null) a:17(string) b:18(string) c:19(string!null)
+ │    │         │    │    ├── stats: [rows=20, distinct(19)=10, null(19)=0]
+ │    │         │    │    │   histogram(19)=  0   10    10    0
+ │    │         │    │    │                 <--- 'foo' ---- 'fop'
+ │    │         │    │    ├── key: (16)
+ │    │         │    │    ├── fd: (16)-->(17-19)
+ │    │         │    │    ├── limit hint: 8.28
+ │    │         │    │    └── scan disjunction@c_idx
+ │    │         │    │         ├── columns: k:16(int!null) c:19(string!null)
+ │    │         │    │         ├── constraint: /19/16: [/'foo' - /'fop')
+ │    │         │    │         ├── stats: [rows=20, distinct(19)=10, null(19)=0]
+ │    │         │    │         │   histogram(19)=  0   10    10    0
+ │    │         │    │         │                 <--- 'foo' ---- 'fop'
+ │    │         │    │         ├── key: (16)
+ │    │         │    │         ├── fd: (16)-->(19)
+ │    │         │    │         └── limit hint: 8.28
+ │    │         │    └── index-join disjunction
+ │    │         │         ├── columns: k:21(int!null) a:22(string) b:23(string!null) c:24(string)
+ │    │         │         ├── stats: [rows=20, distinct(23)=10, null(23)=0]
+ │    │         │         │   histogram(23)=  0   10    10    0
+ │    │         │         │                 <--- 'foo' ---- 'fop'
+ │    │         │         ├── key: (21)
+ │    │         │         ├── fd: (21)-->(22-24)
+ │    │         │         ├── limit hint: 8.28
+ │    │         │         └── scan disjunction@b_idx
+ │    │         │              ├── columns: k:21(int!null) b:23(string!null)
+ │    │         │              ├── constraint: /23/21: [/'foo' - /'fop')
+ │    │         │              ├── stats: [rows=20, distinct(23)=10, null(23)=0]
+ │    │         │              │   histogram(23)=  0   10    10    0
+ │    │         │              │                 <--- 'foo' ---- 'fop'
+ │    │         │              ├── key: (21)
+ │    │         │              ├── fd: (21)-->(23)
+ │    │         │              └── limit hint: 8.28
+ │    │         └── aggregations
+ │    │              ├── const-agg [as=a:12, type=string, outer=(12)]
+ │    │              │    └── a:12 [type=string]
+ │    │              ├── const-agg [as=b:13, type=string, outer=(13)]
+ │    │              │    └── b:13 [type=string]
+ │    │              └── const-agg [as=c:14, type=string, outer=(14)]
+ │    │                   └── c:14 [type=string]
+ │    └── aggregations
+ │         ├── const-agg [as=a:2, type=string, outer=(2)]
+ │         │    └── a:2 [type=string]
+ │         ├── const-agg [as=b:3, type=string, outer=(3)]
+ │         │    └── b:3 [type=string]
+ │         └── const-agg [as=c:4, type=string, outer=(4)]
+ │              └── c:4 [type=string]
+ └── 5 [type=int]
+
+# One disjunction filter and one simple filter.
+opt
+SELECT * FROM disjunction WHERE (a LIKE 'foo%' OR b LIKE 'foo%') AND c LIKE 'foo%' LIMIT 5
+----
+limit
+ ├── columns: k:1(int!null) a:2(string) b:3(string) c:4(string!null)
+ ├── cardinality: [0 - 5]
+ ├── stats: [rows=0.08]
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ ├── select
+ │    ├── columns: k:1(int!null) a:2(string) b:3(string) c:4(string!null)
+ │    ├── stats: [rows=0.08, distinct(4)=0.08, null(4)=0]
+ │    │   histogram(4)=  0  0.04   0.04    0
+ │    │                <--- 'foo' ------ 'fop'
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4)
+ │    ├── limit hint: 5.00
+ │    ├── index-join disjunction
+ │    │    ├── columns: k:1(int!null) a:2(string) b:3(string) c:4(string)
+ │    │    ├── stats: [rows=20]
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2-4)
+ │    │    └── scan disjunction@c_idx
+ │    │         ├── columns: k:1(int!null) c:4(string!null)
+ │    │         ├── constraint: /4/1: [/'foo' - /'fop')
+ │    │         ├── stats: [rows=20, distinct(4)=10, null(4)=0]
+ │    │         │   histogram(4)=  0   10    10    0
+ │    │         │                <--- 'foo' ---- 'fop'
+ │    │         ├── key: (1)
+ │    │         └── fd: (1)-->(4)
+ │    └── filters
+ │         └── (a:2 LIKE 'foo%') OR (b:3 LIKE 'foo%') [type=bool, outer=(2,3)]
+ └── 5 [type=int]
+
+# The row count should not exceed the number of rows in the table when
+# disjunctions have high selectivity values.
+opt
+SELECT * FROM disjunction WHERE a > 'fop' OR b > 'fop' OR c > 'fop' LIMIT 5
+----
+limit
+ ├── columns: k:1(int!null) a:2(string) b:3(string) c:4(string)
+ ├── cardinality: [0 - 5]
+ ├── stats: [rows=5]
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ ├── select
+ │    ├── columns: k:1(int!null) a:2(string) b:3(string) c:4(string)
+ │    ├── stats: [rows=10000]
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4)
+ │    ├── limit hint: 5.00
+ │    ├── scan disjunction
+ │    │    ├── columns: k:1(int!null) a:2(string) b:3(string) c:4(string)
+ │    │    ├── stats: [rows=10000, distinct(1)=10000, null(1)=0, distinct(2)=5010, null(2)=0, distinct(3)=5010, null(3)=0, distinct(4)=5010, null(4)=0]
+ │    │    │   histogram(2)=  0    0    990   10    10   990   8000    0
+ │    │    │                <--- 'aaa' ----- 'foo' ---- 'fop' ------ 'zoo'
+ │    │    │   histogram(3)=  0    0    990   10    10   990   8000    0
+ │    │    │                <--- 'aaa' ----- 'foo' ---- 'fop' ------ 'zoo'
+ │    │    │   histogram(4)=  0    0    990   10    10   990   8000    0
+ │    │    │                <--- 'aaa' ----- 'foo' ---- 'fop' ------ 'zoo'
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2-4)
+ │    │    └── limit hint: 5.00
+ │    └── filters
+ │         └── ((a:2 > 'fop') OR (b:3 > 'fop')) OR (c:4 > 'fop') [type=bool, outer=(2-4)]
+ └── 5 [type=int]

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpcc
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpcc
@@ -1637,7 +1637,7 @@ scalar-group-by
  ├── select
  │    ├── save-table-name: consistency_12_select_2
  │    ├── columns: o_id:1(int) o_d_id:2(int) o_w_id:3(int) ol_o_id:10(int) ol_d_id:11(int) ol_w_id:12(int)
- │    ├── stats: [rows=299711.333, distinct(1)=2999, null(1)=209767.952, distinct(2)=10, null(2)=209767.952, distinct(3)=10, null(3)=209767.952, distinct(10)=2999, null(10)=0, distinct(11)=10, null(11)=0, distinct(12)=10, null(12)=0]
+ │    ├── stats: [rows=629603.668, distinct(1)=2999, null(1)=440659.586, distinct(2)=10, null(2)=440659.586, distinct(3)=10, null(3)=440659.586, distinct(10)=2999, null(10)=0, distinct(11)=10, null(11)=0, distinct(12)=10, null(12)=0]
  │    ├── full-join (hash)
  │    │    ├── save-table-name: consistency_12_full_join_3
  │    │    ├── columns: o_id:1(int) o_d_id:2(int) o_w_id:3(int) ol_o_id:10(int) ol_d_id:11(int) ol_w_id:12(int)
@@ -1721,12 +1721,12 @@ column_names  row_count  distinct_count  null_count
 {ol_w_id}     0          0               0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{o_d_id}      299711.00      +Inf <==       10.00               +Inf <==            209768.00       +Inf <==
-{o_id}        299711.00      +Inf <==       2999.00             +Inf <==            209768.00       +Inf <==
-{o_w_id}      299711.00      +Inf <==       10.00               +Inf <==            209768.00       +Inf <==
-{ol_d_id}     299711.00      +Inf <==       10.00               +Inf <==            0.00            1.00
-{ol_o_id}     299711.00      +Inf <==       2999.00             +Inf <==            0.00            1.00
-{ol_w_id}     299711.00      +Inf <==       10.00               +Inf <==            0.00            1.00
+{o_d_id}      629604.00      +Inf <==       10.00               +Inf <==            440660.00       +Inf <==
+{o_id}        629604.00      +Inf <==       2999.00             +Inf <==            440660.00       +Inf <==
+{o_w_id}      629604.00      +Inf <==       10.00               +Inf <==            440660.00       +Inf <==
+{ol_d_id}     629604.00      +Inf <==       10.00               +Inf <==            0.00            1.00
+{ol_o_id}     629604.00      +Inf <==       2999.00             +Inf <==            0.00            1.00
+{ol_w_id}     629604.00      +Inf <==       10.00               +Inf <==            0.00            1.00
 
 ----Stats for consistency_12_full_join_3----
 column_names  row_count  distinct_count  null_count

--- a/pkg/sql/opt/xform/testdata/external/nova
+++ b/pkg/sql/opt/xform/testdata/external/nova
@@ -593,22 +593,12 @@ sort
       ├── immutable, has-placeholder
       ├── key: (1,30)
       ├── fd: ()-->(13), (1)-->(2-12,14-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (30)-->(31-33,35-37), (31,33,34)~~>(30,32,35-37), (1,30)-->(34)
-      └── right-join (hash)
+      └── left-join (hash)
            ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28 instance_type_extra_specs_1.id:30 key:31 value:32 instance_type_extra_specs_1.instance_type_id:33 instance_type_extra_specs_1.deleted:34 instance_type_extra_specs_1.deleted_at:35 instance_type_extra_specs_1.created_at:36 instance_type_extra_specs_1.updated_at:37
+           ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-one)
            ├── immutable, has-placeholder
            ├── key: (1,30)
            ├── fd: ()-->(13), (1)-->(2-12,14-16,28), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (30)-->(31-33,35-37), (31,33,34)~~>(30,32,35-37), (1,30)-->(34)
-           ├── select
-           │    ├── columns: instance_type_extra_specs_1.id:30!null key:31 value:32 instance_type_extra_specs_1.instance_type_id:33!null instance_type_extra_specs_1.deleted:34!null instance_type_extra_specs_1.deleted_at:35 instance_type_extra_specs_1.created_at:36 instance_type_extra_specs_1.updated_at:37
-           │    ├── has-placeholder
-           │    ├── key: (30)
-           │    ├── fd: ()-->(34), (30)-->(31-33,35-37), (31,33,34)~~>(30,32,35-37)
-           │    ├── scan instance_type_extra_specs [as=instance_type_extra_specs_1]
-           │    │    ├── columns: instance_type_extra_specs_1.id:30!null key:31 value:32 instance_type_extra_specs_1.instance_type_id:33!null instance_type_extra_specs_1.deleted:34 instance_type_extra_specs_1.deleted_at:35 instance_type_extra_specs_1.created_at:36 instance_type_extra_specs_1.updated_at:37
-           │    │    ├── key: (30)
-           │    │    └── fd: (30)-->(31-37), (31,33,34)~~>(30,32,35-37)
-           │    └── filters
-           │         └── instance_type_extra_specs_1.deleted:34 = $7 [outer=(34), constraints=(/34: (/NULL - ]), fd=()-->(34)]
            ├── limit
            │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28
            │    ├── internal-ordering: +7,+1 opt(13)
@@ -721,6 +711,17 @@ sort
            │    │    │              └── (is_public:12 = true) OR (true_agg:28 IS NOT NULL) [outer=(12,28)]
            │    │    └── $5
            │    └── $6
+           ├── select
+           │    ├── columns: instance_type_extra_specs_1.id:30!null key:31 value:32 instance_type_extra_specs_1.instance_type_id:33!null instance_type_extra_specs_1.deleted:34!null instance_type_extra_specs_1.deleted_at:35 instance_type_extra_specs_1.created_at:36 instance_type_extra_specs_1.updated_at:37
+           │    ├── has-placeholder
+           │    ├── key: (30)
+           │    ├── fd: ()-->(34), (30)-->(31-33,35-37), (31,33,34)~~>(30,32,35-37)
+           │    ├── scan instance_type_extra_specs [as=instance_type_extra_specs_1]
+           │    │    ├── columns: instance_type_extra_specs_1.id:30!null key:31 value:32 instance_type_extra_specs_1.instance_type_id:33!null instance_type_extra_specs_1.deleted:34 instance_type_extra_specs_1.deleted_at:35 instance_type_extra_specs_1.created_at:36 instance_type_extra_specs_1.updated_at:37
+           │    │    ├── key: (30)
+           │    │    └── fd: (30)-->(31-37), (31,33,34)~~>(30,32,35-37)
+           │    └── filters
+           │         └── instance_type_extra_specs_1.deleted:34 = $7 [outer=(34), constraints=(/34: (/NULL - ]), fd=()-->(34)]
            └── filters
                 └── instance_type_extra_specs_1.instance_type_id:33 = instance_types.id:1 [outer=(1,33), constraints=(/1: (/NULL - ]; /33: (/NULL - ]), fd=(1)==(33), (33)==(1)]
 
@@ -773,22 +774,12 @@ sort
       ├── has-placeholder
       ├── key: (1,18)
       ├── fd: ()-->(13), (1)-->(2-12,14-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (18)-->(19-21,23-25), (19,21,22)~~>(18,20,23-25), (1,18)-->(22)
-      └── right-join (hash)
+      └── left-join (hash)
            ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_extra_specs_1.id:18 key:19 value:20 instance_type_extra_specs_1.instance_type_id:21 instance_type_extra_specs_1.deleted:22 instance_type_extra_specs_1.deleted_at:23 instance_type_extra_specs_1.created_at:24 instance_type_extra_specs_1.updated_at:25 true_agg:37
+           ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-one)
            ├── has-placeholder
            ├── key: (1,18)
            ├── fd: ()-->(13), (1)-->(2-12,14-16,37), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (18)-->(19-21,23-25), (19,21,22)~~>(18,20,23-25), (1,18)-->(22)
-           ├── select
-           │    ├── columns: instance_type_extra_specs_1.id:18!null key:19 value:20 instance_type_extra_specs_1.instance_type_id:21!null instance_type_extra_specs_1.deleted:22!null instance_type_extra_specs_1.deleted_at:23 instance_type_extra_specs_1.created_at:24 instance_type_extra_specs_1.updated_at:25
-           │    ├── has-placeholder
-           │    ├── key: (18)
-           │    ├── fd: ()-->(22), (18)-->(19-21,23-25), (19,21,22)~~>(18,20,23-25)
-           │    ├── scan instance_type_extra_specs [as=instance_type_extra_specs_1]
-           │    │    ├── columns: instance_type_extra_specs_1.id:18!null key:19 value:20 instance_type_extra_specs_1.instance_type_id:21!null instance_type_extra_specs_1.deleted:22 instance_type_extra_specs_1.deleted_at:23 instance_type_extra_specs_1.created_at:24 instance_type_extra_specs_1.updated_at:25
-           │    │    ├── key: (18)
-           │    │    └── fd: (18)-->(19-25), (19,21,22)~~>(18,20,23-25)
-           │    └── filters
-           │         └── instance_type_extra_specs_1.deleted:22 = $1 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
            ├── select
            │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:37
            │    ├── has-placeholder
@@ -879,6 +870,17 @@ sort
            │    │              └── instance_types.updated_at:16
            │    └── filters
            │         └── (is_public:12 = true) OR (true_agg:37 IS NOT NULL) [outer=(12,37)]
+           ├── select
+           │    ├── columns: instance_type_extra_specs_1.id:18!null key:19 value:20 instance_type_extra_specs_1.instance_type_id:21!null instance_type_extra_specs_1.deleted:22!null instance_type_extra_specs_1.deleted_at:23 instance_type_extra_specs_1.created_at:24 instance_type_extra_specs_1.updated_at:25
+           │    ├── has-placeholder
+           │    ├── key: (18)
+           │    ├── fd: ()-->(22), (18)-->(19-21,23-25), (19,21,22)~~>(18,20,23-25)
+           │    ├── scan instance_type_extra_specs [as=instance_type_extra_specs_1]
+           │    │    ├── columns: instance_type_extra_specs_1.id:18!null key:19 value:20 instance_type_extra_specs_1.instance_type_id:21!null instance_type_extra_specs_1.deleted:22 instance_type_extra_specs_1.deleted_at:23 instance_type_extra_specs_1.created_at:24 instance_type_extra_specs_1.updated_at:25
+           │    │    ├── key: (18)
+           │    │    └── fd: (18)-->(19-25), (19,21,22)~~>(18,20,23-25)
+           │    └── filters
+           │         └── instance_type_extra_specs_1.deleted:22 = $1 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
            └── filters
                 └── instance_type_extra_specs_1.instance_type_id:21 = instance_types.id:1 [outer=(1,21), constraints=(/1: (/NULL - ]; /21: (/NULL - ]), fd=(1)==(21), (21)==(1)]
 
@@ -1801,22 +1803,12 @@ sort
       ├── immutable, has-placeholder
       ├── key: (1,30)
       ├── fd: ()-->(13), (1)-->(2-12,14-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (30)-->(31-33,35-37), (31,33,34)~~>(30,32,35-37), (1,30)-->(34)
-      └── right-join (hash)
+      └── left-join (hash)
            ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28 instance_type_extra_specs_1.id:30 key:31 value:32 instance_type_extra_specs_1.instance_type_id:33 instance_type_extra_specs_1.deleted:34 instance_type_extra_specs_1.deleted_at:35 instance_type_extra_specs_1.created_at:36 instance_type_extra_specs_1.updated_at:37
+           ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-one)
            ├── immutable, has-placeholder
            ├── key: (1,30)
            ├── fd: ()-->(13), (1)-->(2-12,14-16,28), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (30)-->(31-33,35-37), (31,33,34)~~>(30,32,35-37), (1,30)-->(34)
-           ├── select
-           │    ├── columns: instance_type_extra_specs_1.id:30!null key:31 value:32 instance_type_extra_specs_1.instance_type_id:33!null instance_type_extra_specs_1.deleted:34!null instance_type_extra_specs_1.deleted_at:35 instance_type_extra_specs_1.created_at:36 instance_type_extra_specs_1.updated_at:37
-           │    ├── has-placeholder
-           │    ├── key: (30)
-           │    ├── fd: ()-->(34), (30)-->(31-33,35-37), (31,33,34)~~>(30,32,35-37)
-           │    ├── scan instance_type_extra_specs [as=instance_type_extra_specs_1]
-           │    │    ├── columns: instance_type_extra_specs_1.id:30!null key:31 value:32 instance_type_extra_specs_1.instance_type_id:33!null instance_type_extra_specs_1.deleted:34 instance_type_extra_specs_1.deleted_at:35 instance_type_extra_specs_1.created_at:36 instance_type_extra_specs_1.updated_at:37
-           │    │    ├── key: (30)
-           │    │    └── fd: (30)-->(31-37), (31,33,34)~~>(30,32,35-37)
-           │    └── filters
-           │         └── instance_type_extra_specs_1.deleted:34 = $6 [outer=(34), constraints=(/34: (/NULL - ]), fd=()-->(34)]
            ├── limit
            │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28
            │    ├── internal-ordering: +7,+1 opt(13)
@@ -1928,6 +1920,17 @@ sort
            │    │    │              └── (is_public:12 = true) OR (true_agg:28 IS NOT NULL) [outer=(12,28)]
            │    │    └── $4
            │    └── $5
+           ├── select
+           │    ├── columns: instance_type_extra_specs_1.id:30!null key:31 value:32 instance_type_extra_specs_1.instance_type_id:33!null instance_type_extra_specs_1.deleted:34!null instance_type_extra_specs_1.deleted_at:35 instance_type_extra_specs_1.created_at:36 instance_type_extra_specs_1.updated_at:37
+           │    ├── has-placeholder
+           │    ├── key: (30)
+           │    ├── fd: ()-->(34), (30)-->(31-33,35-37), (31,33,34)~~>(30,32,35-37)
+           │    ├── scan instance_type_extra_specs [as=instance_type_extra_specs_1]
+           │    │    ├── columns: instance_type_extra_specs_1.id:30!null key:31 value:32 instance_type_extra_specs_1.instance_type_id:33!null instance_type_extra_specs_1.deleted:34 instance_type_extra_specs_1.deleted_at:35 instance_type_extra_specs_1.created_at:36 instance_type_extra_specs_1.updated_at:37
+           │    │    ├── key: (30)
+           │    │    └── fd: (30)-->(31-37), (31,33,34)~~>(30,32,35-37)
+           │    └── filters
+           │         └── instance_type_extra_specs_1.deleted:34 = $6 [outer=(34), constraints=(/34: (/NULL - ]), fd=()-->(34)]
            └── filters
                 └── instance_type_extra_specs_1.instance_type_id:33 = instance_types.id:1 [outer=(1,33), constraints=(/1: (/NULL - ]; /33: (/NULL - ]), fd=(1)==(33), (33)==(1)]
 
@@ -2153,15 +2156,12 @@ sort
       ├── has-placeholder
       ├── key: (1,17)
       ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (17)-->(18-22), (18,20)-->(17,19,21,22)
-      └── right-join (hash)
+      └── left-join (hash)
            ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_extra_specs_1.id:17 key:18 value:19 flavor_extra_specs_1.flavor_id:20 flavor_extra_specs_1.created_at:21 flavor_extra_specs_1.updated_at:22 true_agg:32
+           ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-one)
            ├── has-placeholder
            ├── key: (1,17)
            ├── fd: (1)-->(2-12,14,15,32), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (17)-->(18-22), (18,20)-->(17,19,21,22)
-           ├── scan flavor_extra_specs [as=flavor_extra_specs_1]
-           │    ├── columns: flavor_extra_specs_1.id:17!null key:18!null value:19 flavor_extra_specs_1.flavor_id:20!null flavor_extra_specs_1.created_at:21 flavor_extra_specs_1.updated_at:22
-           │    ├── key: (17)
-           │    └── fd: (17)-->(18-22), (18,20)-->(17,19,21,22)
            ├── select
            │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:32
            │    ├── has-placeholder
@@ -2239,6 +2239,10 @@ sort
            │    │              └── flavors.updated_at:15
            │    └── filters
            │         └── (is_public:12 = true) OR (true_agg:32 IS NOT NULL) [outer=(12,32)]
+           ├── scan flavor_extra_specs [as=flavor_extra_specs_1]
+           │    ├── columns: flavor_extra_specs_1.id:17!null key:18!null value:19 flavor_extra_specs_1.flavor_id:20!null flavor_extra_specs_1.created_at:21 flavor_extra_specs_1.updated_at:22
+           │    ├── key: (17)
+           │    └── fd: (17)-->(18-22), (18,20)-->(17,19,21,22)
            └── filters
                 └── flavor_extra_specs_1.flavor_id:20 = flavors.id:1 [outer=(1,20), constraints=(/1: (/NULL - ]; /20: (/NULL - ]), fd=(1)==(20), (20)==(1)]
 
@@ -2506,15 +2510,12 @@ sort
       ├── immutable, has-placeholder
       ├── key: (1,27)
       ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (27)-->(28-32), (28,30)-->(27,29,31,32)
-      └── right-join (hash)
+      └── left-join (hash)
            ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:25 flavor_extra_specs_1.id:27 key:28 value:29 flavor_extra_specs_1.flavor_id:30 flavor_extra_specs_1.created_at:31 flavor_extra_specs_1.updated_at:32
+           ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-one)
            ├── immutable, has-placeholder
            ├── key: (1,27)
            ├── fd: (1)-->(2-12,14,15,25), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (27)-->(28-32), (28,30)-->(27,29,31,32)
-           ├── scan flavor_extra_specs [as=flavor_extra_specs_1]
-           │    ├── columns: flavor_extra_specs_1.id:27!null key:28!null value:29 flavor_extra_specs_1.flavor_id:30!null flavor_extra_specs_1.created_at:31 flavor_extra_specs_1.updated_at:32
-           │    ├── key: (27)
-           │    └── fd: (27)-->(28-32), (28,30)-->(27,29,31,32)
            ├── limit
            │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:25
            │    ├── internal-ordering: +7
@@ -2613,6 +2614,10 @@ sort
            │    │    │              └── (is_public:12 = true) OR (true_agg:25 IS NOT NULL) [outer=(12,25)]
            │    │    └── $2
            │    └── $3
+           ├── scan flavor_extra_specs [as=flavor_extra_specs_1]
+           │    ├── columns: flavor_extra_specs_1.id:27!null key:28!null value:29 flavor_extra_specs_1.flavor_id:30!null flavor_extra_specs_1.created_at:31 flavor_extra_specs_1.updated_at:32
+           │    ├── key: (27)
+           │    └── fd: (27)-->(28-32), (28,30)-->(27,29,31,32)
            └── filters
                 └── flavor_extra_specs_1.flavor_id:30 = flavors.id:1 [outer=(1,30), constraints=(/1: (/NULL - ]; /30: (/NULL - ]), fd=(1)==(30), (30)==(1)]
 
@@ -2683,222 +2688,226 @@ from (select instance_types.created_at as instance_types_created_at,
 order by anon_1.instance_types_flavorid asc,
          anon_1.instance_types_id asc
 ----
-project
+sort
  ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2 anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7 anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11!null anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:48 instance_type_extra_specs_1_updated_at:49 instance_type_extra_specs_1_deleted_at:47 instance_type_extra_specs_1_deleted:46 instance_type_extra_specs_1_id:42 instance_type_extra_specs_1_key:43 instance_type_extra_specs_1_value:44 instance_type_extra_specs_1_instance_type_id:45
  ├── immutable, has-placeholder
  ├── key: (1,42)
  ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), (42)-->(43-45,47-49), (43,45,46)~~>(42,44,47-49), (1,42)-->(46)
  ├── ordering: +7,+1 opt(11,13) [actual: +7,+1]
- └── left-join (lookup instance_type_extra_specs [as=instance_type_extra_specs_1])
-      ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:40 instance_type_extra_specs_1.id:42 key:43 value:44 instance_type_extra_specs_1.instance_type_id:45 instance_type_extra_specs_1.deleted:46 instance_type_extra_specs_1.deleted_at:47 instance_type_extra_specs_1.created_at:48 instance_type_extra_specs_1.updated_at:49
-      ├── key columns: [42] = [42]
-      ├── lookup columns are key
+ └── project
+      ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_extra_specs_1.id:42 key:43 value:44 instance_type_extra_specs_1.instance_type_id:45 instance_type_extra_specs_1.deleted:46 instance_type_extra_specs_1.deleted_at:47 instance_type_extra_specs_1.created_at:48 instance_type_extra_specs_1.updated_at:49
       ├── immutable, has-placeholder
       ├── key: (1,42)
-      ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,40), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), (42)-->(43-45,47-49), (43,45,46)~~>(42,44,47-49), (1,42)-->(46)
-      ├── ordering: +7,+1 opt(11,13) [actual: +7,+1]
-      ├── left-join (lookup instance_type_extra_specs@secondary [as=instance_type_extra_specs_1])
-      │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:40 instance_type_extra_specs_1.id:42 key:43 instance_type_extra_specs_1.instance_type_id:45 instance_type_extra_specs_1.deleted:46
-      │    ├── key columns: [1] = [45]
-      │    ├── immutable, has-placeholder
-      │    ├── key: (1,42)
-      │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,40), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), (42)-->(43,45,46), (43,45,46)~~>(42)
-      │    ├── ordering: +7,+1 opt(11,13) [actual: +7,+1]
-      │    ├── limit
-      │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:40
-      │    │    ├── internal-ordering: +7,+1 opt(11,13)
-      │    │    ├── immutable, has-placeholder
-      │    │    ├── key: (1)
-      │    │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,40), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
-      │    │    ├── ordering: +7,+1 opt(11,13) [actual: +7,+1]
-      │    │    ├── offset
-      │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:40
-      │    │    │    ├── internal-ordering: +7,+1 opt(11,13)
-      │    │    │    ├── has-placeholder
-      │    │    │    ├── key: (1)
-      │    │    │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,40), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
-      │    │    │    ├── ordering: +7,+1 opt(11,13) [actual: +7,+1]
-      │    │    │    ├── sort
-      │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:40
-      │    │    │    │    ├── has-placeholder
-      │    │    │    │    ├── key: (1)
-      │    │    │    │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,40), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
-      │    │    │    │    ├── ordering: +7,+1 opt(11,13) [actual: +7,+1]
-      │    │    │    │    └── select
-      │    │    │    │         ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:40
-      │    │    │    │         ├── has-placeholder
-      │    │    │    │         ├── key: (1)
-      │    │    │    │         ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,40), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
-      │    │    │    │         ├── group-by
-      │    │    │    │         │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:40
-      │    │    │    │         │    ├── grouping columns: instance_types.id:1!null
-      │    │    │    │         │    ├── internal-ordering: +1 opt(11,13)
-      │    │    │    │         │    ├── has-placeholder
-      │    │    │    │         │    ├── key: (1)
-      │    │    │    │         │    ├── fd: ()-->(11,13), (1)-->(2-16,40), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
-      │    │    │    │         │    ├── left-join (merge)
-      │    │    │    │         │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:28 true_agg:37 true:39
-      │    │    │    │         │    │    ├── left ordering: +1
-      │    │    │    │         │    │    ├── right ordering: +28
-      │    │    │    │         │    │    ├── has-placeholder
-      │    │    │    │         │    │    ├── key: (1)
-      │    │    │    │         │    │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,28,37,39), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
-      │    │    │    │         │    │    ├── ordering: +1 opt(11,13) [actual: +1]
-      │    │    │    │         │    │    ├── select
-      │    │    │    │         │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:37
-      │    │    │    │         │    │    │    ├── has-placeholder
-      │    │    │    │         │    │    │    ├── key: (1)
-      │    │    │    │         │    │    │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
-      │    │    │    │         │    │    │    ├── ordering: +1 opt(11,13) [actual: +1]
-      │    │    │    │         │    │    │    ├── group-by
-      │    │    │    │         │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:37
-      │    │    │    │         │    │    │    │    ├── grouping columns: instance_types.id:1!null
-      │    │    │    │         │    │    │    │    ├── has-placeholder
-      │    │    │    │         │    │    │    │    ├── key: (1)
-      │    │    │    │         │    │    │    │    ├── fd: ()-->(11,13), (1)-->(2-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
-      │    │    │    │         │    │    │    │    ├── ordering: +1
-      │    │    │    │         │    │    │    │    ├── left-join (merge)
-      │    │    │    │         │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:19 true:36
-      │    │    │    │         │    │    │    │    │    ├── left ordering: +1
-      │    │    │    │         │    │    │    │    │    ├── right ordering: +19
-      │    │    │    │         │    │    │    │    │    ├── has-placeholder
-      │    │    │    │         │    │    │    │    │    ├── key: (1)
-      │    │    │    │         │    │    │    │    │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,19,36), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
-      │    │    │    │         │    │    │    │    │    ├── ordering: +1 opt(11,13) [actual: +1]
-      │    │    │    │         │    │    │    │    │    ├── select
-      │    │    │    │         │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
-      │    │    │    │         │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │         │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │         │    │    │    │    │    │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
-      │    │    │    │         │    │    │    │    │    │    ├── ordering: +1 opt(11,13) [actual: +1]
-      │    │    │    │         │    │    │    │    │    │    ├── scan instance_types
-      │    │    │    │         │    │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13 instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
-      │    │    │    │         │    │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │         │    │    │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │    │    │    │         │    │    │    │    │    │    │    └── ordering: +1
-      │    │    │    │         │    │    │    │    │    │    └── filters
-      │    │    │    │         │    │    │    │    │    │         ├── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ]), fd=()-->(13)]
-      │    │    │    │         │    │    │    │    │    │         └── disabled:11 = false [outer=(11), constraints=(/11: [/false - /false]; tight), fd=()-->(11)]
-      │    │    │    │         │    │    │    │    │    ├── project
-      │    │    │    │         │    │    │    │    │    │    ├── columns: true:36!null instance_type_projects.instance_type_id:19!null
-      │    │    │    │         │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │         │    │    │    │    │    │    ├── key: (19)
-      │    │    │    │         │    │    │    │    │    │    ├── fd: ()-->(36)
-      │    │    │    │         │    │    │    │    │    │    ├── ordering: +19 opt(36) [actual: +19]
-      │    │    │    │         │    │    │    │    │    │    ├── select
-      │    │    │    │         │    │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:19!null project_id:20!null instance_type_projects.deleted:21!null
-      │    │    │    │         │    │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │         │    │    │    │    │    │    │    ├── key: (19)
-      │    │    │    │         │    │    │    │    │    │    │    ├── fd: ()-->(20,21)
-      │    │    │    │         │    │    │    │    │    │    │    ├── ordering: +19 opt(20,21) [actual: +19]
-      │    │    │    │         │    │    │    │    │    │    │    ├── scan instance_type_projects@secondary
-      │    │    │    │         │    │    │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:19!null project_id:20 instance_type_projects.deleted:21
-      │    │    │    │         │    │    │    │    │    │    │    │    ├── lax-key: (19-21)
-      │    │    │    │         │    │    │    │    │    │    │    │    └── ordering: +19
-      │    │    │    │         │    │    │    │    │    │    │    └── filters
-      │    │    │    │         │    │    │    │    │    │    │         ├── instance_type_projects.deleted:21 = $2 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
-      │    │    │    │         │    │    │    │    │    │    │         └── project_id:20 = $3 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
-      │    │    │    │         │    │    │    │    │    │    └── projections
-      │    │    │    │         │    │    │    │    │    │         └── true [as=true:36]
-      │    │    │    │         │    │    │    │    │    └── filters (true)
-      │    │    │    │         │    │    │    │    └── aggregations
-      │    │    │    │         │    │    │    │         ├── const-not-null-agg [as=true_agg:37, outer=(36)]
-      │    │    │    │         │    │    │    │         │    └── true:36
-      │    │    │    │         │    │    │    │         ├── const-agg [as=name:2, outer=(2)]
-      │    │    │    │         │    │    │    │         │    └── name:2
-      │    │    │    │         │    │    │    │         ├── const-agg [as=memory_mb:3, outer=(3)]
-      │    │    │    │         │    │    │    │         │    └── memory_mb:3
-      │    │    │    │         │    │    │    │         ├── const-agg [as=vcpus:4, outer=(4)]
-      │    │    │    │         │    │    │    │         │    └── vcpus:4
-      │    │    │    │         │    │    │    │         ├── const-agg [as=root_gb:5, outer=(5)]
-      │    │    │    │         │    │    │    │         │    └── root_gb:5
-      │    │    │    │         │    │    │    │         ├── const-agg [as=ephemeral_gb:6, outer=(6)]
-      │    │    │    │         │    │    │    │         │    └── ephemeral_gb:6
-      │    │    │    │         │    │    │    │         ├── const-agg [as=flavorid:7, outer=(7)]
-      │    │    │    │         │    │    │    │         │    └── flavorid:7
-      │    │    │    │         │    │    │    │         ├── const-agg [as=swap:8, outer=(8)]
-      │    │    │    │         │    │    │    │         │    └── swap:8
-      │    │    │    │         │    │    │    │         ├── const-agg [as=rxtx_factor:9, outer=(9)]
-      │    │    │    │         │    │    │    │         │    └── rxtx_factor:9
-      │    │    │    │         │    │    │    │         ├── const-agg [as=vcpu_weight:10, outer=(10)]
-      │    │    │    │         │    │    │    │         │    └── vcpu_weight:10
-      │    │    │    │         │    │    │    │         ├── const-agg [as=disabled:11, outer=(11)]
-      │    │    │    │         │    │    │    │         │    └── disabled:11
-      │    │    │    │         │    │    │    │         ├── const-agg [as=is_public:12, outer=(12)]
-      │    │    │    │         │    │    │    │         │    └── is_public:12
-      │    │    │    │         │    │    │    │         ├── const-agg [as=instance_types.deleted:13, outer=(13)]
-      │    │    │    │         │    │    │    │         │    └── instance_types.deleted:13
-      │    │    │    │         │    │    │    │         ├── const-agg [as=instance_types.deleted_at:14, outer=(14)]
-      │    │    │    │         │    │    │    │         │    └── instance_types.deleted_at:14
-      │    │    │    │         │    │    │    │         ├── const-agg [as=instance_types.created_at:15, outer=(15)]
-      │    │    │    │         │    │    │    │         │    └── instance_types.created_at:15
-      │    │    │    │         │    │    │    │         └── const-agg [as=instance_types.updated_at:16, outer=(16)]
-      │    │    │    │         │    │    │    │              └── instance_types.updated_at:16
-      │    │    │    │         │    │    │    └── filters
-      │    │    │    │         │    │    │         └── (is_public:12 = true) OR (true_agg:37 IS NOT NULL) [outer=(12,37)]
-      │    │    │    │         │    │    ├── project
-      │    │    │    │         │    │    │    ├── columns: true:39!null instance_type_projects.instance_type_id:28!null
-      │    │    │    │         │    │    │    ├── has-placeholder
-      │    │    │    │         │    │    │    ├── key: (28)
-      │    │    │    │         │    │    │    ├── fd: ()-->(39)
-      │    │    │    │         │    │    │    ├── ordering: +28 opt(39) [actual: +28]
-      │    │    │    │         │    │    │    ├── select
-      │    │    │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:28!null project_id:29!null instance_type_projects.deleted:30!null
-      │    │    │    │         │    │    │    │    ├── has-placeholder
-      │    │    │    │         │    │    │    │    ├── key: (28)
-      │    │    │    │         │    │    │    │    ├── fd: ()-->(29,30)
-      │    │    │    │         │    │    │    │    ├── ordering: +28 opt(29,30) [actual: +28]
-      │    │    │    │         │    │    │    │    ├── scan instance_type_projects@secondary
-      │    │    │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:28!null project_id:29 instance_type_projects.deleted:30
-      │    │    │    │         │    │    │    │    │    ├── lax-key: (28-30)
-      │    │    │    │         │    │    │    │    │    └── ordering: +28
-      │    │    │    │         │    │    │    │    └── filters
-      │    │    │    │         │    │    │    │         ├── instance_type_projects.deleted:30 = $4 [outer=(30), constraints=(/30: (/NULL - ]), fd=()-->(30)]
-      │    │    │    │         │    │    │    │         ├── instance_type_projects.deleted:30 = $5 [outer=(30), constraints=(/30: (/NULL - ]), fd=()-->(30)]
-      │    │    │    │         │    │    │    │         └── project_id:29 = $6 [outer=(29), constraints=(/29: (/NULL - ]), fd=()-->(29)]
-      │    │    │    │         │    │    │    └── projections
-      │    │    │    │         │    │    │         └── true [as=true:39]
-      │    │    │    │         │    │    └── filters (true)
-      │    │    │    │         │    └── aggregations
-      │    │    │    │         │         ├── const-not-null-agg [as=true_agg:40, outer=(39)]
-      │    │    │    │         │         │    └── true:39
-      │    │    │    │         │         ├── const-agg [as=name:2, outer=(2)]
-      │    │    │    │         │         │    └── name:2
-      │    │    │    │         │         ├── const-agg [as=memory_mb:3, outer=(3)]
-      │    │    │    │         │         │    └── memory_mb:3
-      │    │    │    │         │         ├── const-agg [as=vcpus:4, outer=(4)]
-      │    │    │    │         │         │    └── vcpus:4
-      │    │    │    │         │         ├── const-agg [as=root_gb:5, outer=(5)]
-      │    │    │    │         │         │    └── root_gb:5
-      │    │    │    │         │         ├── const-agg [as=ephemeral_gb:6, outer=(6)]
-      │    │    │    │         │         │    └── ephemeral_gb:6
-      │    │    │    │         │         ├── const-agg [as=flavorid:7, outer=(7)]
-      │    │    │    │         │         │    └── flavorid:7
-      │    │    │    │         │         ├── const-agg [as=swap:8, outer=(8)]
-      │    │    │    │         │         │    └── swap:8
-      │    │    │    │         │         ├── const-agg [as=rxtx_factor:9, outer=(9)]
-      │    │    │    │         │         │    └── rxtx_factor:9
-      │    │    │    │         │         ├── const-agg [as=vcpu_weight:10, outer=(10)]
-      │    │    │    │         │         │    └── vcpu_weight:10
-      │    │    │    │         │         ├── const-agg [as=disabled:11, outer=(11)]
-      │    │    │    │         │         │    └── disabled:11
-      │    │    │    │         │         ├── const-agg [as=is_public:12, outer=(12)]
-      │    │    │    │         │         │    └── is_public:12
-      │    │    │    │         │         ├── const-agg [as=instance_types.deleted:13, outer=(13)]
-      │    │    │    │         │         │    └── instance_types.deleted:13
-      │    │    │    │         │         ├── const-agg [as=instance_types.deleted_at:14, outer=(14)]
-      │    │    │    │         │         │    └── instance_types.deleted_at:14
-      │    │    │    │         │         ├── const-agg [as=instance_types.created_at:15, outer=(15)]
-      │    │    │    │         │         │    └── instance_types.created_at:15
-      │    │    │    │         │         └── const-agg [as=instance_types.updated_at:16, outer=(16)]
-      │    │    │    │         │              └── instance_types.updated_at:16
-      │    │    │    │         └── filters
-      │    │    │    │              └── (is_public:12 = true) OR (true_agg:40 IS NOT NULL) [outer=(12,40)]
-      │    │    │    └── $7
-      │    │    └── $8
-      │    └── filters
-      │         └── instance_type_extra_specs_1.deleted:46 = $9 [outer=(46), constraints=(/46: (/NULL - ]), fd=()-->(46)]
-      └── filters (true)
+      ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), (42)-->(43-45,47-49), (43,45,46)~~>(42,44,47-49), (1,42)-->(46)
+      └── right-join (hash)
+           ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:40 instance_type_extra_specs_1.id:42 key:43 value:44 instance_type_extra_specs_1.instance_type_id:45 instance_type_extra_specs_1.deleted:46 instance_type_extra_specs_1.deleted_at:47 instance_type_extra_specs_1.created_at:48 instance_type_extra_specs_1.updated_at:49
+           ├── immutable, has-placeholder
+           ├── key: (1,42)
+           ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,40), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), (42)-->(43-45,47-49), (43,45,46)~~>(42,44,47-49), (1,42)-->(46)
+           ├── select
+           │    ├── columns: instance_type_extra_specs_1.id:42!null key:43 value:44 instance_type_extra_specs_1.instance_type_id:45!null instance_type_extra_specs_1.deleted:46!null instance_type_extra_specs_1.deleted_at:47 instance_type_extra_specs_1.created_at:48 instance_type_extra_specs_1.updated_at:49
+           │    ├── has-placeholder
+           │    ├── key: (42)
+           │    ├── fd: ()-->(46), (42)-->(43-45,47-49), (43,45,46)~~>(42,44,47-49)
+           │    ├── scan instance_type_extra_specs [as=instance_type_extra_specs_1]
+           │    │    ├── columns: instance_type_extra_specs_1.id:42!null key:43 value:44 instance_type_extra_specs_1.instance_type_id:45!null instance_type_extra_specs_1.deleted:46 instance_type_extra_specs_1.deleted_at:47 instance_type_extra_specs_1.created_at:48 instance_type_extra_specs_1.updated_at:49
+           │    │    ├── key: (42)
+           │    │    └── fd: (42)-->(43-49), (43,45,46)~~>(42,44,47-49)
+           │    └── filters
+           │         └── instance_type_extra_specs_1.deleted:46 = $9 [outer=(46), constraints=(/46: (/NULL - ]), fd=()-->(46)]
+           ├── limit
+           │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:40
+           │    ├── internal-ordering: +7,+1 opt(11,13)
+           │    ├── immutable, has-placeholder
+           │    ├── key: (1)
+           │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,40), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+           │    ├── offset
+           │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:40
+           │    │    ├── internal-ordering: +7,+1 opt(11,13)
+           │    │    ├── has-placeholder
+           │    │    ├── key: (1)
+           │    │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,40), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+           │    │    ├── ordering: +7,+1 opt(11,13) [actual: +7,+1]
+           │    │    ├── sort
+           │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:40
+           │    │    │    ├── has-placeholder
+           │    │    │    ├── key: (1)
+           │    │    │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,40), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+           │    │    │    ├── ordering: +7,+1 opt(11,13) [actual: +7,+1]
+           │    │    │    └── select
+           │    │    │         ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:40
+           │    │    │         ├── has-placeholder
+           │    │    │         ├── key: (1)
+           │    │    │         ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,40), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+           │    │    │         ├── group-by
+           │    │    │         │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:40
+           │    │    │         │    ├── grouping columns: instance_types.id:1!null
+           │    │    │         │    ├── internal-ordering: +1 opt(11,13)
+           │    │    │         │    ├── has-placeholder
+           │    │    │         │    ├── key: (1)
+           │    │    │         │    ├── fd: ()-->(11,13), (1)-->(2-16,40), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+           │    │    │         │    ├── left-join (merge)
+           │    │    │         │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:28 true_agg:37 true:39
+           │    │    │         │    │    ├── left ordering: +1
+           │    │    │         │    │    ├── right ordering: +28
+           │    │    │         │    │    ├── has-placeholder
+           │    │    │         │    │    ├── key: (1)
+           │    │    │         │    │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,28,37,39), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+           │    │    │         │    │    ├── ordering: +1 opt(11,13) [actual: +1]
+           │    │    │         │    │    ├── select
+           │    │    │         │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:37
+           │    │    │         │    │    │    ├── has-placeholder
+           │    │    │         │    │    │    ├── key: (1)
+           │    │    │         │    │    │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+           │    │    │         │    │    │    ├── ordering: +1 opt(11,13) [actual: +1]
+           │    │    │         │    │    │    ├── group-by
+           │    │    │         │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:37
+           │    │    │         │    │    │    │    ├── grouping columns: instance_types.id:1!null
+           │    │    │         │    │    │    │    ├── has-placeholder
+           │    │    │         │    │    │    │    ├── key: (1)
+           │    │    │         │    │    │    │    ├── fd: ()-->(11,13), (1)-->(2-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+           │    │    │         │    │    │    │    ├── ordering: +1
+           │    │    │         │    │    │    │    ├── left-join (merge)
+           │    │    │         │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:19 true:36
+           │    │    │         │    │    │    │    │    ├── left ordering: +1
+           │    │    │         │    │    │    │    │    ├── right ordering: +19
+           │    │    │         │    │    │    │    │    ├── has-placeholder
+           │    │    │         │    │    │    │    │    ├── key: (1)
+           │    │    │         │    │    │    │    │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,19,36), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+           │    │    │         │    │    │    │    │    ├── ordering: +1 opt(11,13) [actual: +1]
+           │    │    │         │    │    │    │    │    ├── select
+           │    │    │         │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
+           │    │    │         │    │    │    │    │    │    ├── has-placeholder
+           │    │    │         │    │    │    │    │    │    ├── key: (1)
+           │    │    │         │    │    │    │    │    │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+           │    │    │         │    │    │    │    │    │    ├── ordering: +1 opt(11,13) [actual: +1]
+           │    │    │         │    │    │    │    │    │    ├── scan instance_types
+           │    │    │         │    │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13 instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
+           │    │    │         │    │    │    │    │    │    │    ├── key: (1)
+           │    │    │         │    │    │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │         │    │    │    │    │    │    │    └── ordering: +1
+           │    │    │         │    │    │    │    │    │    └── filters
+           │    │    │         │    │    │    │    │    │         ├── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ]), fd=()-->(13)]
+           │    │    │         │    │    │    │    │    │         └── disabled:11 = false [outer=(11), constraints=(/11: [/false - /false]; tight), fd=()-->(11)]
+           │    │    │         │    │    │    │    │    ├── project
+           │    │    │         │    │    │    │    │    │    ├── columns: true:36!null instance_type_projects.instance_type_id:19!null
+           │    │    │         │    │    │    │    │    │    ├── has-placeholder
+           │    │    │         │    │    │    │    │    │    ├── key: (19)
+           │    │    │         │    │    │    │    │    │    ├── fd: ()-->(36)
+           │    │    │         │    │    │    │    │    │    ├── ordering: +19 opt(36) [actual: +19]
+           │    │    │         │    │    │    │    │    │    ├── select
+           │    │    │         │    │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:19!null project_id:20!null instance_type_projects.deleted:21!null
+           │    │    │         │    │    │    │    │    │    │    ├── has-placeholder
+           │    │    │         │    │    │    │    │    │    │    ├── key: (19)
+           │    │    │         │    │    │    │    │    │    │    ├── fd: ()-->(20,21)
+           │    │    │         │    │    │    │    │    │    │    ├── ordering: +19 opt(20,21) [actual: +19]
+           │    │    │         │    │    │    │    │    │    │    ├── scan instance_type_projects@secondary
+           │    │    │         │    │    │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:19!null project_id:20 instance_type_projects.deleted:21
+           │    │    │         │    │    │    │    │    │    │    │    ├── lax-key: (19-21)
+           │    │    │         │    │    │    │    │    │    │    │    └── ordering: +19
+           │    │    │         │    │    │    │    │    │    │    └── filters
+           │    │    │         │    │    │    │    │    │    │         ├── instance_type_projects.deleted:21 = $2 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
+           │    │    │         │    │    │    │    │    │    │         └── project_id:20 = $3 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
+           │    │    │         │    │    │    │    │    │    └── projections
+           │    │    │         │    │    │    │    │    │         └── true [as=true:36]
+           │    │    │         │    │    │    │    │    └── filters (true)
+           │    │    │         │    │    │    │    └── aggregations
+           │    │    │         │    │    │    │         ├── const-not-null-agg [as=true_agg:37, outer=(36)]
+           │    │    │         │    │    │    │         │    └── true:36
+           │    │    │         │    │    │    │         ├── const-agg [as=name:2, outer=(2)]
+           │    │    │         │    │    │    │         │    └── name:2
+           │    │    │         │    │    │    │         ├── const-agg [as=memory_mb:3, outer=(3)]
+           │    │    │         │    │    │    │         │    └── memory_mb:3
+           │    │    │         │    │    │    │         ├── const-agg [as=vcpus:4, outer=(4)]
+           │    │    │         │    │    │    │         │    └── vcpus:4
+           │    │    │         │    │    │    │         ├── const-agg [as=root_gb:5, outer=(5)]
+           │    │    │         │    │    │    │         │    └── root_gb:5
+           │    │    │         │    │    │    │         ├── const-agg [as=ephemeral_gb:6, outer=(6)]
+           │    │    │         │    │    │    │         │    └── ephemeral_gb:6
+           │    │    │         │    │    │    │         ├── const-agg [as=flavorid:7, outer=(7)]
+           │    │    │         │    │    │    │         │    └── flavorid:7
+           │    │    │         │    │    │    │         ├── const-agg [as=swap:8, outer=(8)]
+           │    │    │         │    │    │    │         │    └── swap:8
+           │    │    │         │    │    │    │         ├── const-agg [as=rxtx_factor:9, outer=(9)]
+           │    │    │         │    │    │    │         │    └── rxtx_factor:9
+           │    │    │         │    │    │    │         ├── const-agg [as=vcpu_weight:10, outer=(10)]
+           │    │    │         │    │    │    │         │    └── vcpu_weight:10
+           │    │    │         │    │    │    │         ├── const-agg [as=disabled:11, outer=(11)]
+           │    │    │         │    │    │    │         │    └── disabled:11
+           │    │    │         │    │    │    │         ├── const-agg [as=is_public:12, outer=(12)]
+           │    │    │         │    │    │    │         │    └── is_public:12
+           │    │    │         │    │    │    │         ├── const-agg [as=instance_types.deleted:13, outer=(13)]
+           │    │    │         │    │    │    │         │    └── instance_types.deleted:13
+           │    │    │         │    │    │    │         ├── const-agg [as=instance_types.deleted_at:14, outer=(14)]
+           │    │    │         │    │    │    │         │    └── instance_types.deleted_at:14
+           │    │    │         │    │    │    │         ├── const-agg [as=instance_types.created_at:15, outer=(15)]
+           │    │    │         │    │    │    │         │    └── instance_types.created_at:15
+           │    │    │         │    │    │    │         └── const-agg [as=instance_types.updated_at:16, outer=(16)]
+           │    │    │         │    │    │    │              └── instance_types.updated_at:16
+           │    │    │         │    │    │    └── filters
+           │    │    │         │    │    │         └── (is_public:12 = true) OR (true_agg:37 IS NOT NULL) [outer=(12,37)]
+           │    │    │         │    │    ├── project
+           │    │    │         │    │    │    ├── columns: true:39!null instance_type_projects.instance_type_id:28!null
+           │    │    │         │    │    │    ├── has-placeholder
+           │    │    │         │    │    │    ├── key: (28)
+           │    │    │         │    │    │    ├── fd: ()-->(39)
+           │    │    │         │    │    │    ├── ordering: +28 opt(39) [actual: +28]
+           │    │    │         │    │    │    ├── select
+           │    │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:28!null project_id:29!null instance_type_projects.deleted:30!null
+           │    │    │         │    │    │    │    ├── has-placeholder
+           │    │    │         │    │    │    │    ├── key: (28)
+           │    │    │         │    │    │    │    ├── fd: ()-->(29,30)
+           │    │    │         │    │    │    │    ├── ordering: +28 opt(29,30) [actual: +28]
+           │    │    │         │    │    │    │    ├── scan instance_type_projects@secondary
+           │    │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:28!null project_id:29 instance_type_projects.deleted:30
+           │    │    │         │    │    │    │    │    ├── lax-key: (28-30)
+           │    │    │         │    │    │    │    │    └── ordering: +28
+           │    │    │         │    │    │    │    └── filters
+           │    │    │         │    │    │    │         ├── instance_type_projects.deleted:30 = $4 [outer=(30), constraints=(/30: (/NULL - ]), fd=()-->(30)]
+           │    │    │         │    │    │    │         ├── instance_type_projects.deleted:30 = $5 [outer=(30), constraints=(/30: (/NULL - ]), fd=()-->(30)]
+           │    │    │         │    │    │    │         └── project_id:29 = $6 [outer=(29), constraints=(/29: (/NULL - ]), fd=()-->(29)]
+           │    │    │         │    │    │    └── projections
+           │    │    │         │    │    │         └── true [as=true:39]
+           │    │    │         │    │    └── filters (true)
+           │    │    │         │    └── aggregations
+           │    │    │         │         ├── const-not-null-agg [as=true_agg:40, outer=(39)]
+           │    │    │         │         │    └── true:39
+           │    │    │         │         ├── const-agg [as=name:2, outer=(2)]
+           │    │    │         │         │    └── name:2
+           │    │    │         │         ├── const-agg [as=memory_mb:3, outer=(3)]
+           │    │    │         │         │    └── memory_mb:3
+           │    │    │         │         ├── const-agg [as=vcpus:4, outer=(4)]
+           │    │    │         │         │    └── vcpus:4
+           │    │    │         │         ├── const-agg [as=root_gb:5, outer=(5)]
+           │    │    │         │         │    └── root_gb:5
+           │    │    │         │         ├── const-agg [as=ephemeral_gb:6, outer=(6)]
+           │    │    │         │         │    └── ephemeral_gb:6
+           │    │    │         │         ├── const-agg [as=flavorid:7, outer=(7)]
+           │    │    │         │         │    └── flavorid:7
+           │    │    │         │         ├── const-agg [as=swap:8, outer=(8)]
+           │    │    │         │         │    └── swap:8
+           │    │    │         │         ├── const-agg [as=rxtx_factor:9, outer=(9)]
+           │    │    │         │         │    └── rxtx_factor:9
+           │    │    │         │         ├── const-agg [as=vcpu_weight:10, outer=(10)]
+           │    │    │         │         │    └── vcpu_weight:10
+           │    │    │         │         ├── const-agg [as=disabled:11, outer=(11)]
+           │    │    │         │         │    └── disabled:11
+           │    │    │         │         ├── const-agg [as=is_public:12, outer=(12)]
+           │    │    │         │         │    └── is_public:12
+           │    │    │         │         ├── const-agg [as=instance_types.deleted:13, outer=(13)]
+           │    │    │         │         │    └── instance_types.deleted:13
+           │    │    │         │         ├── const-agg [as=instance_types.deleted_at:14, outer=(14)]
+           │    │    │         │         │    └── instance_types.deleted_at:14
+           │    │    │         │         ├── const-agg [as=instance_types.created_at:15, outer=(15)]
+           │    │    │         │         │    └── instance_types.created_at:15
+           │    │    │         │         └── const-agg [as=instance_types.updated_at:16, outer=(16)]
+           │    │    │         │              └── instance_types.updated_at:16
+           │    │    │         └── filters
+           │    │    │              └── (is_public:12 = true) OR (true_agg:40 IS NOT NULL) [outer=(12,40)]
+           │    │    └── $7
+           │    └── $8
+           └── filters
+                └── instance_type_extra_specs_1.instance_type_id:45 = instance_types.id:1 [outer=(1,45), constraints=(/1: (/NULL - ]; /45: (/NULL - ]), fd=(1)==(45), (45)==(1)]
 
 opt
 select anon_1.instance_types_created_at as anon_1_instance_types_created_at,
@@ -3302,15 +3311,12 @@ sort
       ├── immutable, has-placeholder
       ├── key: (1,27)
       ├── fd: (1)-->(2-15), (7)-->(1-6,8-15), (2)-->(1,3-15), (27)-->(28-32), (28,30)-->(27,29,31,32)
-      └── right-join (hash)
+      └── left-join (hash)
            ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 description:13 flavors.created_at:14 flavors.updated_at:15 true_agg:25 flavor_extra_specs_1.id:27 key:28 value:29 flavor_extra_specs_1.flavor_id:30 flavor_extra_specs_1.created_at:31 flavor_extra_specs_1.updated_at:32
+           ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-one)
            ├── immutable, has-placeholder
            ├── key: (1,27)
            ├── fd: (1)-->(2-15,25), (7)-->(1-6,8-15), (2)-->(1,3-15), (27)-->(28-32), (28,30)-->(27,29,31,32)
-           ├── scan flavor_extra_specs [as=flavor_extra_specs_1]
-           │    ├── columns: flavor_extra_specs_1.id:27!null key:28!null value:29 flavor_extra_specs_1.flavor_id:30!null flavor_extra_specs_1.created_at:31 flavor_extra_specs_1.updated_at:32
-           │    ├── key: (27)
-           │    └── fd: (27)-->(28-32), (28,30)-->(27,29,31,32)
            ├── limit
            │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 description:13 flavors.created_at:14 flavors.updated_at:15 true_agg:25
            │    ├── internal-ordering: +7
@@ -3403,5 +3409,9 @@ sort
            │    │         └── filters
            │    │              └── (is_public:12 = true) OR (true_agg:25 IS NOT NULL) [outer=(12,25)]
            │    └── $2
+           ├── scan flavor_extra_specs [as=flavor_extra_specs_1]
+           │    ├── columns: flavor_extra_specs_1.id:27!null key:28!null value:29 flavor_extra_specs_1.flavor_id:30!null flavor_extra_specs_1.created_at:31 flavor_extra_specs_1.updated_at:32
+           │    ├── key: (27)
+           │    └── fd: (27)-->(28-32), (28,30)-->(27,29,31,32)
            └── filters
                 └── flavor_extra_specs_1.flavor_id:30 = flavors.id:1 [outer=(1,30), constraints=(/1: (/NULL - ]; /30: (/NULL - ]), fd=(1)==(30), (30)==(1)]

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -6776,64 +6776,50 @@ SELECT k FROM d WHERE (u = 1 OR v = 1) AND EXISTS (SELECT * FROM a WHERE a.u = d
 project
  ├── columns: k:1!null
  ├── key: (1)
- └── project
+ └── semi-join (lookup a@u)
       ├── columns: d.k:1!null d.u:2 d.v:3
+      ├── key columns: [2] = [7]
       ├── key: (1)
       ├── fd: (1)-->(2,3)
-      └── inner-join (merge)
-           ├── columns: d.k:1!null d.u:2!null d.v:3 a.u:7!null
-           ├── left ordering: +2
-           ├── right ordering: +7
-           ├── key: (1)
-           ├── fd: (1)-->(2,3), (2)==(7), (7)==(2)
-           ├── distinct-on
-           │    ├── columns: d.k:1!null d.u:2 d.v:3
-           │    ├── grouping columns: d.k:1!null
-           │    ├── key: (1)
-           │    ├── fd: (1)-->(2,3)
-           │    ├── ordering: +2
-           │    ├── union-all
-           │    │    ├── columns: d.k:1!null d.u:2 d.v:3
-           │    │    ├── left columns: d.k:10 d.u:11 d.v:12
-           │    │    ├── right columns: d.k:15 d.u:16 d.v:17
-           │    │    ├── ordering: +2
-           │    │    ├── index-join d
-           │    │    │    ├── columns: d.k:10!null d.u:11!null d.v:12
-           │    │    │    ├── key: (10)
-           │    │    │    ├── fd: ()-->(11), (10)-->(12)
-           │    │    │    └── scan d@u
-           │    │    │         ├── columns: d.k:10!null d.u:11!null
-           │    │    │         ├── constraint: /11/10: [/1 - /1]
-           │    │    │         ├── key: (10)
-           │    │    │         └── fd: ()-->(11)
-           │    │    └── sort
-           │    │         ├── columns: d.k:15!null d.u:16 d.v:17!null
-           │    │         ├── key: (15)
-           │    │         ├── fd: ()-->(17), (15)-->(16)
-           │    │         ├── ordering: +16 opt(17) [actual: +16]
-           │    │         └── index-join d
-           │    │              ├── columns: d.k:15!null d.u:16 d.v:17!null
-           │    │              ├── key: (15)
-           │    │              ├── fd: ()-->(17), (15)-->(16)
-           │    │              └── scan d@v
-           │    │                   ├── columns: d.k:15!null d.v:17!null
-           │    │                   ├── constraint: /17/15: [/1 - /1]
-           │    │                   ├── key: (15)
-           │    │                   └── fd: ()-->(17)
-           │    └── aggregations
-           │         ├── const-agg [as=d.u:2, outer=(2)]
-           │         │    └── d.u:2
-           │         └── const-agg [as=d.v:3, outer=(3)]
-           │              └── d.v:3
-           ├── distinct-on
-           │    ├── columns: a.u:7
-           │    ├── grouping columns: a.u:7
-           │    ├── key: (7)
-           │    ├── ordering: +7
-           │    └── scan a@u
-           │         ├── columns: a.u:7
-           │         └── ordering: +7
-           └── filters (true)
+      ├── distinct-on
+      │    ├── columns: d.k:1!null d.u:2 d.v:3
+      │    ├── grouping columns: d.k:1!null
+      │    ├── internal-ordering: +1
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2,3)
+      │    ├── union-all
+      │    │    ├── columns: d.k:1!null d.u:2 d.v:3
+      │    │    ├── left columns: d.k:10 d.u:11 d.v:12
+      │    │    ├── right columns: d.k:15 d.u:16 d.v:17
+      │    │    ├── ordering: +1
+      │    │    ├── index-join d
+      │    │    │    ├── columns: d.k:10!null d.u:11!null d.v:12
+      │    │    │    ├── key: (10)
+      │    │    │    ├── fd: ()-->(11), (10)-->(12)
+      │    │    │    ├── ordering: +10 opt(11) [actual: +10]
+      │    │    │    └── scan d@u
+      │    │    │         ├── columns: d.k:10!null d.u:11!null
+      │    │    │         ├── constraint: /11/10: [/1 - /1]
+      │    │    │         ├── key: (10)
+      │    │    │         ├── fd: ()-->(11)
+      │    │    │         └── ordering: +10 opt(11) [actual: +10]
+      │    │    └── index-join d
+      │    │         ├── columns: d.k:15!null d.u:16 d.v:17!null
+      │    │         ├── key: (15)
+      │    │         ├── fd: ()-->(17), (15)-->(16)
+      │    │         ├── ordering: +15 opt(17) [actual: +15]
+      │    │         └── scan d@v
+      │    │              ├── columns: d.k:15!null d.v:17!null
+      │    │              ├── constraint: /17/15: [/1 - /1]
+      │    │              ├── key: (15)
+      │    │              ├── fd: ()-->(17)
+      │    │              └── ordering: +15 opt(17) [actual: +15]
+      │    └── aggregations
+      │         ├── const-agg [as=d.u:2, outer=(2)]
+      │         │    └── d.u:2
+      │         └── const-agg [as=d.v:3, outer=(3)]
+      │              └── d.v:3
+      └── filters (true)
 
 # Correlated subquery with references to outer columns not in the scan columns.
 opt expect=SplitDisjunction
@@ -6842,65 +6828,52 @@ SELECT k FROM d WHERE (u = 1 OR v = 1) AND EXISTS (SELECT * FROM a WHERE a.u = d
 project
  ├── columns: k:1!null
  ├── key: (1)
- └── project
+ └── semi-join (lookup a@u)
       ├── columns: d.k:1!null d.u:2 d.v:3 w:4
+      ├── key columns: [4] = [7]
       ├── key: (1)
       ├── fd: (1)-->(2-4)
-      └── inner-join (hash)
-           ├── columns: d.k:1!null d.u:2 d.v:3 w:4!null a.u:7!null
-           ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
-           ├── key: (1)
-           ├── fd: (1)-->(2-4), (4)==(7), (7)==(4)
-           ├── distinct-on
-           │    ├── columns: d.k:1!null d.u:2 d.v:3 w:4
-           │    ├── grouping columns: d.k:1!null
-           │    ├── internal-ordering: +1
-           │    ├── key: (1)
-           │    ├── fd: (1)-->(2-4)
-           │    ├── union-all
-           │    │    ├── columns: d.k:1!null d.u:2 d.v:3 w:4
-           │    │    ├── left columns: d.k:10 d.u:11 d.v:12 w:13
-           │    │    ├── right columns: d.k:15 d.u:16 d.v:17 w:18
-           │    │    ├── ordering: +1
-           │    │    ├── index-join d
-           │    │    │    ├── columns: d.k:10!null d.u:11!null d.v:12 w:13
-           │    │    │    ├── key: (10)
-           │    │    │    ├── fd: ()-->(11), (10)-->(12,13)
-           │    │    │    ├── ordering: +10 opt(11) [actual: +10]
-           │    │    │    └── scan d@u
-           │    │    │         ├── columns: d.k:10!null d.u:11!null
-           │    │    │         ├── constraint: /11/10: [/1 - /1]
-           │    │    │         ├── key: (10)
-           │    │    │         ├── fd: ()-->(11)
-           │    │    │         └── ordering: +10 opt(11) [actual: +10]
-           │    │    └── index-join d
-           │    │         ├── columns: d.k:15!null d.u:16 d.v:17!null w:18
-           │    │         ├── key: (15)
-           │    │         ├── fd: ()-->(17), (15)-->(16,18)
-           │    │         ├── ordering: +15 opt(17) [actual: +15]
-           │    │         └── scan d@v
-           │    │              ├── columns: d.k:15!null d.v:17!null
-           │    │              ├── constraint: /17/15: [/1 - /1]
-           │    │              ├── key: (15)
-           │    │              ├── fd: ()-->(17)
-           │    │              └── ordering: +15 opt(17) [actual: +15]
-           │    └── aggregations
-           │         ├── const-agg [as=d.u:2, outer=(2)]
-           │         │    └── d.u:2
-           │         ├── const-agg [as=d.v:3, outer=(3)]
-           │         │    └── d.v:3
-           │         └── const-agg [as=w:4, outer=(4)]
-           │              └── w:4
-           ├── distinct-on
-           │    ├── columns: a.u:7
-           │    ├── grouping columns: a.u:7
-           │    ├── internal-ordering: +7
-           │    ├── key: (7)
-           │    └── scan a@u
-           │         ├── columns: a.u:7
-           │         └── ordering: +7
-           └── filters
-                └── a.u:7 = w:4 [outer=(4,7), constraints=(/4: (/NULL - ]; /7: (/NULL - ]), fd=(4)==(7), (7)==(4)]
+      ├── distinct-on
+      │    ├── columns: d.k:1!null d.u:2 d.v:3 w:4
+      │    ├── grouping columns: d.k:1!null
+      │    ├── internal-ordering: +1
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-4)
+      │    ├── union-all
+      │    │    ├── columns: d.k:1!null d.u:2 d.v:3 w:4
+      │    │    ├── left columns: d.k:10 d.u:11 d.v:12 w:13
+      │    │    ├── right columns: d.k:15 d.u:16 d.v:17 w:18
+      │    │    ├── ordering: +1
+      │    │    ├── index-join d
+      │    │    │    ├── columns: d.k:10!null d.u:11!null d.v:12 w:13
+      │    │    │    ├── key: (10)
+      │    │    │    ├── fd: ()-->(11), (10)-->(12,13)
+      │    │    │    ├── ordering: +10 opt(11) [actual: +10]
+      │    │    │    └── scan d@u
+      │    │    │         ├── columns: d.k:10!null d.u:11!null
+      │    │    │         ├── constraint: /11/10: [/1 - /1]
+      │    │    │         ├── key: (10)
+      │    │    │         ├── fd: ()-->(11)
+      │    │    │         └── ordering: +10 opt(11) [actual: +10]
+      │    │    └── index-join d
+      │    │         ├── columns: d.k:15!null d.u:16 d.v:17!null w:18
+      │    │         ├── key: (15)
+      │    │         ├── fd: ()-->(17), (15)-->(16,18)
+      │    │         ├── ordering: +15 opt(17) [actual: +15]
+      │    │         └── scan d@v
+      │    │              ├── columns: d.k:15!null d.v:17!null
+      │    │              ├── constraint: /17/15: [/1 - /1]
+      │    │              ├── key: (15)
+      │    │              ├── fd: ()-->(17)
+      │    │              └── ordering: +15 opt(17) [actual: +15]
+      │    └── aggregations
+      │         ├── const-agg [as=d.u:2, outer=(2)]
+      │         │    └── d.u:2
+      │         ├── const-agg [as=d.v:3, outer=(3)]
+      │         │    └── d.v:3
+      │         └── const-agg [as=w:4, outer=(4)]
+      │              └── w:4
+      └── filters (true)
 
 # Apply when outer columns of both sides of OR are a subset of index columns.
 opt expect=SplitDisjunction
@@ -7531,7 +7504,7 @@ memo (optimized, ~19KB, required=[presentation: k:1,a:2,b:3,c:4])
  ├── G4: (scan t58390@secondary,partial,cols=(1,4))
  │    └── []
  │         ├── best: (scan t58390@secondary,partial,cols=(1,4))
- │         └── cost: 350.68
+ │         └── cost: 697.34
  ├── G5: (union-all G8 G9)
  │    ├── [ordering: +1]
  │    │    ├── best: (union-all G8="[ordering: +6]" G9="[ordering: +11]")
@@ -7571,10 +7544,10 @@ memo (optimized, ~19KB, required=[presentation: k:1,a:2,b:3,c:4])
  ├── G17: (index-join G26 t58390,cols=(6-9))
  │    ├── [ordering: +6]
  │    │    ├── best: (index-join G26="[ordering: +6]" t58390,cols=(6-9))
- │    │    └── cost: 2443.24
+ │    │    └── cost: 4895.77
  │    └── []
  │         ├── best: (index-join G26 t58390,cols=(6-9))
- │         └── cost: 2374.02
+ │         └── cost: 4744.02
  ├── G18: (scan t58390,cols=(11-14))
  │    ├── [ordering: +11]
  │    │    ├── best: (scan t58390,cols=(11-14))
@@ -7586,10 +7559,10 @@ memo (optimized, ~19KB, required=[presentation: k:1,a:2,b:3,c:4])
  ├── G20: (index-join G28 t58390,cols=(11-14))
  │    ├── [ordering: +11]
  │    │    ├── best: (index-join G28="[ordering: +11]" t58390,cols=(11-14))
- │    │    └── cost: 2443.24
+ │    │    └── cost: 4895.77
  │    └── []
  │         ├── best: (index-join G28 t58390,cols=(11-14))
- │         └── cost: 2374.02
+ │         └── cost: 4744.02
  ├── G21: (variable a)
  ├── G22: (variable b)
  ├── G23: (variable c)
@@ -7598,18 +7571,18 @@ memo (optimized, ~19KB, required=[presentation: k:1,a:2,b:3,c:4])
  ├── G26: (scan t58390@secondary,partial,cols=(6,9))
  │    ├── [ordering: +6]
  │    │    ├── best: (sort G26)
- │    │    └── cost: 419.89
+ │    │    └── cost: 849.10
  │    └── []
  │         ├── best: (scan t58390@secondary,partial,cols=(6,9))
- │         └── cost: 350.68
+ │         └── cost: 697.34
  ├── G27: (gt G30 G24)
  ├── G28: (scan t58390@secondary,partial,cols=(11,14))
  │    ├── [ordering: +11]
  │    │    ├── best: (sort G28)
- │    │    └── cost: 419.89
+ │    │    └── cost: 849.10
  │    └── []
  │         ├── best: (scan t58390@secondary,partial,cols=(11,14))
- │         └── cost: 350.68
+ │         └── cost: 697.34
  ├── G29: (variable a)
  └── G30: (variable b)
 
@@ -8238,64 +8211,50 @@ project
 opt expect=SplitDisjunctionAddKey
 SELECT u, v FROM d WHERE (u = 1 OR v = 1) AND EXISTS (SELECT * FROM a WHERE a.u = d.u)
 ----
-project
+semi-join (lookup a@u)
  ├── columns: u:2 v:3
- └── project
-      ├── columns: d.u:2!null d.v:3 a.u:7!null
-      ├── fd: (2)==(7), (7)==(2)
-      └── inner-join (hash)
-           ├── columns: d.k:1!null d.u:2!null d.v:3 a.u:7!null
-           ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
-           ├── key: (1)
-           ├── fd: (1)-->(2,3), (2)==(7), (7)==(2)
-           ├── distinct-on
-           │    ├── columns: a.u:7
-           │    ├── grouping columns: a.u:7
-           │    ├── internal-ordering: +7
-           │    ├── key: (7)
-           │    └── scan a@u
-           │         ├── columns: a.u:7
-           │         └── ordering: +7
-           ├── distinct-on
-           │    ├── columns: d.k:1!null d.u:2 d.v:3
-           │    ├── grouping columns: d.k:1!null
-           │    ├── internal-ordering: +1
-           │    ├── key: (1)
-           │    ├── fd: (1)-->(2,3)
-           │    ├── union-all
-           │    │    ├── columns: d.k:1!null d.u:2 d.v:3
-           │    │    ├── left columns: d.k:10 d.u:11 d.v:12
-           │    │    ├── right columns: d.k:15 d.u:16 d.v:17
-           │    │    ├── ordering: +1
-           │    │    ├── index-join d
-           │    │    │    ├── columns: d.k:10!null d.u:11!null d.v:12
-           │    │    │    ├── key: (10)
-           │    │    │    ├── fd: ()-->(11), (10)-->(12)
-           │    │    │    ├── ordering: +10 opt(11) [actual: +10]
-           │    │    │    └── scan d@u
-           │    │    │         ├── columns: d.k:10!null d.u:11!null
-           │    │    │         ├── constraint: /11/10: [/1 - /1]
-           │    │    │         ├── key: (10)
-           │    │    │         ├── fd: ()-->(11)
-           │    │    │         └── ordering: +10 opt(11) [actual: +10]
-           │    │    └── index-join d
-           │    │         ├── columns: d.k:15!null d.u:16 d.v:17!null
-           │    │         ├── key: (15)
-           │    │         ├── fd: ()-->(17), (15)-->(16)
-           │    │         ├── ordering: +15 opt(17) [actual: +15]
-           │    │         └── scan d@v
-           │    │              ├── columns: d.k:15!null d.v:17!null
-           │    │              ├── constraint: /17/15: [/1 - /1]
-           │    │              ├── key: (15)
-           │    │              ├── fd: ()-->(17)
-           │    │              └── ordering: +15 opt(17) [actual: +15]
-           │    └── aggregations
-           │         ├── const-agg [as=d.u:2, outer=(2)]
-           │         │    └── d.u:2
-           │         └── const-agg [as=d.v:3, outer=(3)]
-           │              └── d.v:3
-           └── filters
-                └── a.u:7 = d.u:2 [outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ]), fd=(2)==(7), (7)==(2)]
+ ├── key columns: [2] = [7]
+ ├── project
+ │    ├── columns: d.u:2 d.v:3
+ │    └── distinct-on
+ │         ├── columns: d.k:1!null d.u:2 d.v:3
+ │         ├── grouping columns: d.k:1!null
+ │         ├── internal-ordering: +1
+ │         ├── key: (1)
+ │         ├── fd: (1)-->(2,3)
+ │         ├── union-all
+ │         │    ├── columns: d.k:1!null d.u:2 d.v:3
+ │         │    ├── left columns: d.k:10 d.u:11 d.v:12
+ │         │    ├── right columns: d.k:15 d.u:16 d.v:17
+ │         │    ├── ordering: +1
+ │         │    ├── index-join d
+ │         │    │    ├── columns: d.k:10!null d.u:11!null d.v:12
+ │         │    │    ├── key: (10)
+ │         │    │    ├── fd: ()-->(11), (10)-->(12)
+ │         │    │    ├── ordering: +10 opt(11) [actual: +10]
+ │         │    │    └── scan d@u
+ │         │    │         ├── columns: d.k:10!null d.u:11!null
+ │         │    │         ├── constraint: /11/10: [/1 - /1]
+ │         │    │         ├── key: (10)
+ │         │    │         ├── fd: ()-->(11)
+ │         │    │         └── ordering: +10 opt(11) [actual: +10]
+ │         │    └── index-join d
+ │         │         ├── columns: d.k:15!null d.u:16 d.v:17!null
+ │         │         ├── key: (15)
+ │         │         ├── fd: ()-->(17), (15)-->(16)
+ │         │         ├── ordering: +15 opt(17) [actual: +15]
+ │         │         └── scan d@v
+ │         │              ├── columns: d.k:15!null d.v:17!null
+ │         │              ├── constraint: /17/15: [/1 - /1]
+ │         │              ├── key: (15)
+ │         │              ├── fd: ()-->(17)
+ │         │              └── ordering: +15 opt(17) [actual: +15]
+ │         └── aggregations
+ │              ├── const-agg [as=d.u:2, outer=(2)]
+ │              │    └── d.u:2
+ │              └── const-agg [as=d.v:3, outer=(3)]
+ │                   └── d.v:3
+ └── filters (true)
 
 # Correlated subquery with references to outer columns not in the scan columns.
 opt expect=SplitDisjunctionAddKey
@@ -8303,66 +8262,52 @@ SELECT u, v FROM d WHERE (u = 1 OR v = 1) AND EXISTS (SELECT * FROM a WHERE a.u 
 ----
 project
  ├── columns: u:2 v:3
- └── project
+ └── semi-join (lookup a@u)
       ├── columns: d.u:2 d.v:3 w:4
-      └── project
-           ├── columns: d.u:2 d.v:3 w:4!null a.u:7!null
-           ├── fd: (4)==(7), (7)==(4)
-           └── inner-join (hash)
-                ├── columns: d.k:1!null d.u:2 d.v:3 w:4!null a.u:7!null
-                ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
-                ├── key: (1)
-                ├── fd: (1)-->(2-4), (4)==(7), (7)==(4)
-                ├── distinct-on
-                │    ├── columns: a.u:7
-                │    ├── grouping columns: a.u:7
-                │    ├── internal-ordering: +7
-                │    ├── key: (7)
-                │    └── scan a@u
-                │         ├── columns: a.u:7
-                │         └── ordering: +7
-                ├── distinct-on
-                │    ├── columns: d.k:1!null d.u:2 d.v:3 w:4
-                │    ├── grouping columns: d.k:1!null
-                │    ├── internal-ordering: +1
-                │    ├── key: (1)
-                │    ├── fd: (1)-->(2-4)
-                │    ├── union-all
-                │    │    ├── columns: d.k:1!null d.u:2 d.v:3 w:4
-                │    │    ├── left columns: d.k:10 d.u:11 d.v:12 w:13
-                │    │    ├── right columns: d.k:15 d.u:16 d.v:17 w:18
-                │    │    ├── ordering: +1
-                │    │    ├── index-join d
-                │    │    │    ├── columns: d.k:10!null d.u:11!null d.v:12 w:13
-                │    │    │    ├── key: (10)
-                │    │    │    ├── fd: ()-->(11), (10)-->(12,13)
-                │    │    │    ├── ordering: +10 opt(11) [actual: +10]
-                │    │    │    └── scan d@u
-                │    │    │         ├── columns: d.k:10!null d.u:11!null
-                │    │    │         ├── constraint: /11/10: [/1 - /1]
-                │    │    │         ├── key: (10)
-                │    │    │         ├── fd: ()-->(11)
-                │    │    │         └── ordering: +10 opt(11) [actual: +10]
-                │    │    └── index-join d
-                │    │         ├── columns: d.k:15!null d.u:16 d.v:17!null w:18
-                │    │         ├── key: (15)
-                │    │         ├── fd: ()-->(17), (15)-->(16,18)
-                │    │         ├── ordering: +15 opt(17) [actual: +15]
-                │    │         └── scan d@v
-                │    │              ├── columns: d.k:15!null d.v:17!null
-                │    │              ├── constraint: /17/15: [/1 - /1]
-                │    │              ├── key: (15)
-                │    │              ├── fd: ()-->(17)
-                │    │              └── ordering: +15 opt(17) [actual: +15]
-                │    └── aggregations
-                │         ├── const-agg [as=d.u:2, outer=(2)]
-                │         │    └── d.u:2
-                │         ├── const-agg [as=d.v:3, outer=(3)]
-                │         │    └── d.v:3
-                │         └── const-agg [as=w:4, outer=(4)]
-                │              └── w:4
-                └── filters
-                     └── a.u:7 = w:4 [outer=(4,7), constraints=(/4: (/NULL - ]; /7: (/NULL - ]), fd=(4)==(7), (7)==(4)]
+      ├── key columns: [4] = [7]
+      ├── project
+      │    ├── columns: d.u:2 d.v:3 w:4
+      │    └── distinct-on
+      │         ├── columns: d.k:1!null d.u:2 d.v:3 w:4
+      │         ├── grouping columns: d.k:1!null
+      │         ├── internal-ordering: +1
+      │         ├── key: (1)
+      │         ├── fd: (1)-->(2-4)
+      │         ├── union-all
+      │         │    ├── columns: d.k:1!null d.u:2 d.v:3 w:4
+      │         │    ├── left columns: d.k:10 d.u:11 d.v:12 w:13
+      │         │    ├── right columns: d.k:15 d.u:16 d.v:17 w:18
+      │         │    ├── ordering: +1
+      │         │    ├── index-join d
+      │         │    │    ├── columns: d.k:10!null d.u:11!null d.v:12 w:13
+      │         │    │    ├── key: (10)
+      │         │    │    ├── fd: ()-->(11), (10)-->(12,13)
+      │         │    │    ├── ordering: +10 opt(11) [actual: +10]
+      │         │    │    └── scan d@u
+      │         │    │         ├── columns: d.k:10!null d.u:11!null
+      │         │    │         ├── constraint: /11/10: [/1 - /1]
+      │         │    │         ├── key: (10)
+      │         │    │         ├── fd: ()-->(11)
+      │         │    │         └── ordering: +10 opt(11) [actual: +10]
+      │         │    └── index-join d
+      │         │         ├── columns: d.k:15!null d.u:16 d.v:17!null w:18
+      │         │         ├── key: (15)
+      │         │         ├── fd: ()-->(17), (15)-->(16,18)
+      │         │         ├── ordering: +15 opt(17) [actual: +15]
+      │         │         └── scan d@v
+      │         │              ├── columns: d.k:15!null d.v:17!null
+      │         │              ├── constraint: /17/15: [/1 - /1]
+      │         │              ├── key: (15)
+      │         │              ├── fd: ()-->(17)
+      │         │              └── ordering: +15 opt(17) [actual: +15]
+      │         └── aggregations
+      │              ├── const-agg [as=d.u:2, outer=(2)]
+      │              │    └── d.u:2
+      │              ├── const-agg [as=d.v:3, outer=(3)]
+      │              │    └── d.v:3
+      │              └── const-agg [as=w:4, outer=(4)]
+      │                   └── w:4
+      └── filters (true)
 
 # Use rowid when there is no explicit primary key.
 opt expect=SplitDisjunctionAddKey


### PR DESCRIPTION
#### opt: refactor statisticsBuilder.applyFilter

This commit refactors `statisticsBuilder.applyFilter` by renaming it to
`applyFilters` and moving the logic in the `applyConjunction` closure to
a separate `applyFiltersItem` function.

Release note: None

#### opt: calculate more accurate selectivity for disjunctions

The optimal plan for a query with a disjunctive filter is often a
DistinctOn+UnionAll of the results of two index scans, when two separate
indexes can satisfy either side of the disjunction. For example:

    SELECT * FROM t WHERE a = 'foo' OR b = 'foo' LIMIT 5

    limit
     ├── distinct-on
     │    └── union-all
     │         ├── scan t@a_idx
     │         │    └── constraint: /a: [/'foo' - /'foo']
     │         └── scan t@a_idx
     │              └── constraint: /b: [/'foo' - /'foo']
     └── 5

However, this optimal plan is not always chosen. A `constraint.Set`
cannot be built for a disjunction involving multiple columns, so the
statistics builder assumes the selectivity of the disjunction to be 1/3,
often resulting in an over-estimated row count. When the DistinctOn is
built during exploration it is added to the same memo group as the
Select that it replaces, so it shares the same row count estimate. Even
though the UnionAll's cost is low because it produces a small subset of
the table, the DistinctOn's cost is high because the coster is under the
assumption that the DistinctOn will produce 1/3 of the rows in the
table. The overhead of producing so many rows adds significant overhead
to the overall cost, preventing this plan from being chosen by the
optimizer.

This commit fixes the issue by attempting to build a constraint set for
each side of a disjunction in a filter. By unioning the selectivity of
each constraint set, a more accurate row count estimate is calculated
for the filter. As a result, the cost of the DistinctOn is more accurate
and the optimal plan is chosen.

Resolves #58744

Release note (performance improvement): The selectivity of query filters
with OR expressions is now calculated more accurately during query
optimization, improving query plans in some cases.
