### PR TITLE
sql,ui: only include DML statement in service latency metrics

### DIFF
--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -263,27 +263,7 @@ func (ex *connExecutor) updateOptCounters(planFlags planFlags) {
 	}
 }
 
-// Bulk IO operations cause spikes in our time series chart for service latency. We exclude them from the service
-// latency metrics to avoid confusions.
+// We only want to keep track of DML (Data Manipulation Language) statements in our latency metrics.
 func shouldIncludeStmtInLatencyMetrics(stmt *Statement) bool {
-	switch stmt.AST.(type) {
-	case *tree.Backup:
-		return false
-	case *tree.ShowBackup:
-		return false
-	case *tree.Restore:
-		return false
-	case *tree.Import:
-		return false
-	case *tree.Export:
-		return false
-	case *tree.ScheduledBackup:
-		return false
-	case *tree.StreamIngestion:
-		return false
-	case *tree.ReplicationStream:
-		return false
-	}
-
-	return true
+	return stmt.AST.StatementType() == tree.TypeDML
 }

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/overview.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/overview.tsx
@@ -66,14 +66,14 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
-      title="Service Latency: SQL, 99th percentile"
+      title="Service Latency: SQL Statements, 99th percentile"
       tooltip={
         <div>
-          Over the last minute, this node executed 99% of queries within this
-          time.&nbsp;
+          Over the last minute, this node executed 99% of SQL statements within
+          this time.&nbsp;
           <em>
-            This time does not include network latency between the node and
-            client.
+            This time only includes SELECT, INSERT, UPDATE and DELETE statements
+            and does not include network latency between the node and client.
           </em>
         </div>
       }

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
@@ -154,14 +154,14 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
-      title="Service Latency: SQL, 99th percentile"
+      title="Service Latency: SQL Statements, 99th percentile"
       tooltip={
         <div>
-          Over the last minute, this node executed 99% of queries within this
-          time.{" "}
+          Over the last minute, this node executed 99% of SQL statements within
+          this time.&nbsp;
           <em>
-            This time does not include network latency between the node and
-            client.
+            This time only includes SELECT, INSERT, UPDATE and DELETE statements
+            and does not include network latency between the node and client.
           </em>
         </div>
       }
@@ -180,14 +180,14 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
-      title="Service Latency: SQL, 90th percentile"
+      title="Service Latency: SQL Statements, 90th percentile"
       tooltip={
         <div>
-          Over the last minute, this node executed 90% of queries within this
-          time.{" "}
+          Over the last minute, this node executed 90% of SQL statements within
+          this time.&nbsp;
           <em>
-            This time does not include network latency between the node and
-            client.
+            This time only includes SELECT, INSERT, UPDATE and DELETE statements
+            and does not include network latency between the node and client.
           </em>
         </div>
       }


### PR DESCRIPTION
Previously, we only excluded Bulk IO operations from service latency
metric. However, other operations such as DDL or RangeFeed can also
cause latency spikes in our metrics chart.
We now only include DML statements in our service latency metric.

Closes #64741

Release note (sql change, ui change): SQL Service Latency now only
includes metrics from DML statements.