### PR TITLE
sql/event_log: reduce tech debt, simplify and fix bugs

### DIFF
--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -824,8 +824,8 @@ func (n *Node) recordJoinEvent(ctx context.Context) {
 				return sql.InsertEventRecord(ctx, n.sqlExec,
 					txn,
 					int32(n.Descriptor.NodeID), /* reporting ID: the node where the event is logged */
-					sql.LogToSystemTable,       /* LogEventDestination: we already call log.StructuredEvent above */
-					int32(n.Descriptor.NodeID), /* target ID: the node that is joining (ourselves) */
+					sql.LogToSystemTable|sql.LogToDevChannelIfVerbose, /* LogEventDestination: we already call log.StructuredEvent above */
+					int32(n.Descriptor.NodeID),                        /* target ID: the node that is joining (ourselves) */
 					event,
 				)
 			}); err != nil {

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -823,11 +823,10 @@ func (n *Node) recordJoinEvent(ctx context.Context) {
 			if err := n.storeCfg.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 				return sql.InsertEventRecord(ctx, n.sqlExec,
 					txn,
-					int32(n.Descriptor.NodeID),
-					int32(n.Descriptor.NodeID),
-					true, /* skipExternalLog - we already call log.StructuredEvent above */
+					int32(n.Descriptor.NodeID), /* reporting ID: the node where the event is logged */
+					sql.LogToSystemTable,       /* LogEventDestination: we already call log.StructuredEvent above */
+					int32(n.Descriptor.NodeID), /* target ID: the node that is joining (ourselves) */
 					event,
-					false, /* onlyLog */
 				)
 			}); err != nil {
 				log.Warningf(ctx, "%s: unable to log event %v: %v", n, event, err)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2346,10 +2346,10 @@ func (s *Server) Decommission(
 					ctx,
 					s.sqlServer.execCfg.InternalExecutor,
 					txn,
-					int32(nodeID), int32(s.NodeID()),
-					true, /* skipExternalLog - we already call log.StructuredEvent above */
+					int32(s.NodeID()),    /* reporting ID: the node where the event is logged */
+					sql.LogToSystemTable, /* we already call log.StructuredEvent above */
+					int32(nodeID),        /* target ID: the node that we wee a membership change for */
 					event,
-					false, /* onlyLog */
 				)
 			}); err != nil {
 				log.Ops.Errorf(ctx, "unable to record event: %+v: %+v", event, err)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2346,9 +2346,9 @@ func (s *Server) Decommission(
 					ctx,
 					s.sqlServer.execCfg.InternalExecutor,
 					txn,
-					int32(s.NodeID()),    /* reporting ID: the node where the event is logged */
-					sql.LogToSystemTable, /* we already call log.StructuredEvent above */
-					int32(nodeID),        /* target ID: the node that we wee a membership change for */
+					int32(s.NodeID()), /* reporting ID: the node where the event is logged */
+					sql.LogToSystemTable|sql.LogToDevChannelIfVerbose, /* we already call log.StructuredEvent above */
+					int32(nodeID), /* target ID: the node that we wee a membership change for */
 					event,
 				)
 			}); err != nil {

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -577,6 +577,7 @@ func (r *createStatsResumer) Resume(ctx context.Context, execCtx interface{}) er
 	return evalCtx.ExecCfg.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 		return logEventInternalForSQLStatements(ctx,
 			evalCtx.ExecCfg, txn,
+			0, /* depth: use event_log=2 for vmodule filtering */
 			eventLogOptions{dst: LogEverywhere},
 			sqlEventCommonExecPayload{
 				user:         evalCtx.SessionData.User(),

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -580,8 +580,8 @@ func (r *createStatsResumer) Resume(ctx context.Context, execCtx interface{}) er
 			evalCtx.SessionData.ApplicationName,
 			details.Statement,
 			"CREATE STATISTICS",
-			nil,  /* no placeholders known at this point */
-			true, /* writeToEventLog */
+			nil, /* no placeholders known at this point */
+			eventLogOptions{dst: LogEverywhere},
 			eventLogEntry{
 				targetID: int32(details.Table.ID),
 				event: &eventpb.CreateStatistics{

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -576,16 +576,17 @@ func (r *createStatsResumer) Resume(ctx context.Context, execCtx interface{}) er
 	// See: https://github.com/cockroachdb/cockroach/issues/57739
 	return evalCtx.ExecCfg.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 		return logEventInternalForSQLStatements(ctx, evalCtx.ExecCfg, txn,
-			descpb.IDs{details.Table.ID},
 			evalCtx.SessionData.User(),
 			evalCtx.SessionData.ApplicationName,
 			details.Statement,
 			"CREATE STATISTICS",
 			nil,  /* no placeholders known at this point */
 			true, /* writeToEventLog */
-			&eventpb.CreateStatistics{
-				TableName: details.FQTableName,
-			},
+			eventLogEntry{
+				targetID: int32(details.Table.ID),
+				event: &eventpb.CreateStatistics{
+					TableName: details.FQTableName,
+				}},
 		)
 	})
 }

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -575,18 +575,22 @@ func (r *createStatsResumer) Resume(ctx context.Context, execCtx interface{}) er
 	// CREATE STATISTICS statement.
 	// See: https://github.com/cockroachdb/cockroach/issues/57739
 	return evalCtx.ExecCfg.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-		return logEventInternalForSQLStatements(ctx, evalCtx.ExecCfg, txn,
-			evalCtx.SessionData.User(),
-			evalCtx.SessionData.ApplicationName,
-			details.Statement,
-			"CREATE STATISTICS",
-			nil, /* no placeholders known at this point */
+		return logEventInternalForSQLStatements(ctx,
+			evalCtx.ExecCfg, txn,
 			eventLogOptions{dst: LogEverywhere},
+			sqlEventCommonExecPayload{
+				user:         evalCtx.SessionData.User(),
+				appName:      evalCtx.SessionData.ApplicationName,
+				stmt:         details.Statement,
+				stmtTag:      "CREATE STATISTICS",
+				placeholders: nil, /* no placeholders known at this point */
+			},
 			eventLogEntry{
 				targetID: int32(details.Table.ID),
 				event: &eventpb.CreateStatistics{
 					TableName: details.FQTableName,
-				}},
+				},
+			},
 		)
 	})
 }

--- a/pkg/sql/event_log.go
+++ b/pkg/sql/event_log.go
@@ -223,7 +223,7 @@ func LogEventForJobs(
 	)
 }
 
-var eventLogEnabled = settings.RegisterBoolSetting(
+var eventLogSystemTableEnabled = settings.RegisterBoolSetting(
 	"server.eventlog.enabled",
 	"if set, logged notable events are also stored in the table system.eventlog",
 	true,
@@ -280,7 +280,7 @@ func insertEventRecords(
 	}
 
 	// If we only want to log externally and not write to the events table, early exit.
-	loggingToSystemTable := !onlyLog && eventLogEnabled.Get(&ex.s.cfg.Settings.SV)
+	loggingToSystemTable := !onlyLog && eventLogSystemTableEnabled.Get(&ex.s.cfg.Settings.SV)
 	if !loggingToSystemTable {
 		// Simply emit the events to their respective channels and call it a day.
 		if !skipExternalLog {

--- a/pkg/sql/event_log.go
+++ b/pkg/sql/event_log.go
@@ -59,12 +59,6 @@ func (p *planner) logEvents(ctx context.Context, entries ...eventLogEntry) error
 	return p.logEventsWithSystemEventLogOption(ctx, true /* writeToEventLog */, entries...)
 }
 
-func (p *planner) logEventsOnlyExternally(ctx context.Context, entries ...eventLogEntry) {
-	// The API contract for logEventWithSystemEventLogOption() is that it returns
-	// no error when system.eventlog is not written to.
-	_ = p.logEventsWithSystemEventLogOption(ctx, false /* writeToEventLog */, entries...)
-}
-
 // logEventsWithSystemEventLogOption is like logEvent() but it gives
 // control to the caller as to whether the entry is written into
 // system.eventlog.

--- a/pkg/sql/exec_log.go
+++ b/pkg/sql/exec_log.go
@@ -345,10 +345,10 @@ func (p *planner) maybeLogStatementInternal(
 }
 
 func (p *planner) logEventsOnlyExternally(ctx context.Context, entries ...eventLogEntry) {
-	// The API contract for logEventsWithSystemEventLogOption() is that it returns
+	// The API contract for logEventsWithOptions() is that it returns
 	// no error when system.eventlog is not written to.
-	_ = p.logEventsWithSystemEventLogOption(ctx,
-		false, /* writeToEventLog */
+	_ = p.logEventsWithOptions(ctx,
+		eventLogOptions{dst: LogExternally},
 		entries...)
 }
 

--- a/pkg/sql/grant_revoke.go
+++ b/pkg/sql/grant_revoke.go
@@ -177,12 +177,7 @@ func (n *changePrivilegesNode) startExec(params runParams) error {
 		return err
 	}
 
-	// The events to log at the end.
-	type eventEntry struct {
-		descID descpb.ID
-		event  eventpb.EventPayload
-	}
-	var events []eventEntry
+	var events []eventLogEntry
 
 	// First, update the descriptors. We want to catch all errors before
 	// we update them in KV below.
@@ -239,8 +234,9 @@ func (n *changePrivilegesNode) startExec(params runParams) error {
 			for _, grantee := range n.grantees {
 				privs := eventDetails // copy the granted/revoked privilege list.
 				privs.Grantee = grantee.Normalized()
-				events = append(events, eventEntry{d.ID,
-					&eventpb.ChangeDatabasePrivilege{
+				events = append(events, eventLogEntry{
+					targetID: int32(d.ID),
+					event: &eventpb.ChangeDatabasePrivilege{
 						CommonSQLPrivilegeEventDetails: privs,
 						DatabaseName:                   (*tree.Name)(&d.Name).String(),
 					}})
@@ -264,8 +260,9 @@ func (n *changePrivilegesNode) startExec(params runParams) error {
 			for _, grantee := range n.grantees {
 				privs := eventDetails // copy the granted/revoked privilege list.
 				privs.Grantee = grantee.Normalized()
-				events = append(events, eventEntry{d.ID,
-					&eventpb.ChangeTablePrivilege{
+				events = append(events, eventLogEntry{
+					targetID: int32(d.ID),
+					event: &eventpb.ChangeTablePrivilege{
 						CommonSQLPrivilegeEventDetails: privs,
 						TableName:                      d.Name, // FIXME
 					}})
@@ -278,8 +275,9 @@ func (n *changePrivilegesNode) startExec(params runParams) error {
 			for _, grantee := range n.grantees {
 				privs := eventDetails // copy the granted/revoked privilege list.
 				privs.Grantee = grantee.Normalized()
-				events = append(events, eventEntry{d.ID,
-					&eventpb.ChangeTypePrivilege{
+				events = append(events, eventLogEntry{
+					targetID: int32(d.ID),
+					event: &eventpb.ChangeTypePrivilege{
 						CommonSQLPrivilegeEventDetails: privs,
 						TypeName:                       d.Name, // FIXME
 					}})
@@ -295,8 +293,9 @@ func (n *changePrivilegesNode) startExec(params runParams) error {
 			for _, grantee := range n.grantees {
 				privs := eventDetails // copy the granted/revoked privilege list.
 				privs.Grantee = grantee.Normalized()
-				events = append(events, eventEntry{d.ID,
-					&eventpb.ChangeSchemaPrivilege{
+				events = append(events, eventLogEntry{
+					targetID: int32(d.ID),
+					event: &eventpb.ChangeSchemaPrivilege{
 						CommonSQLPrivilegeEventDetails: privs,
 						SchemaName:                     d.Name, // FIXME
 					}})
@@ -312,13 +311,7 @@ func (n *changePrivilegesNode) startExec(params runParams) error {
 	// Record the privilege changes in the event log. This is an
 	// auditable log event and is recorded in the same transaction as
 	// the table descriptor update.
-	descIDs := make(descpb.IDs, 0, len(events))
-	eventPayloads := make([]eventpb.EventPayload, 0, len(events))
-	for _, ev := range events {
-		descIDs = append(descIDs, ev.descID)
-		eventPayloads = append(eventPayloads, ev.event)
-	}
-	if err := params.p.batchLogEvents(params.ctx, descIDs, eventPayloads...); err != nil {
+	if err := params.p.logEvents(params.ctx, events...); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
Fixes #64685.
First commit from #64871. 

Prior to this patch, there was a little mess in `sql/event_log.go`
that had been introduced when "optimizing" GRANT/REVOKE to only
use one write batch for all the events logged:

- a lot of code had been duplicated;
- the control flow had been rendered more complex;
- the API interface for the functions in event_log.go
  were complex to use, requiring callers to provide descriptor
  IDs and structured events as separate slices;
- the optimizing logic was not properly applied to the
  other case where multiple events are emitted:
  SQL audit logging in `exec_log.go`.

This patch streamlines this by reducing `event_log.go` back to its
simpler form: an overall event refinement pipeline with a
straightforward control flow.

To guide future maintainers, the patch also adds an explanatory
comment at the top of the file that sketches the overall structure of
the pipeline.

Finally, this patch fixes a bug introduced when query logging
started using structured events: the ability to automatically
copy all the execution events to the DEV channel when
setting the `vmodule` setting to `exec_log=2` (or above).

In addition to fixing that bug, the following new vmodule-based
abilities are added:

- events for DDL statements and others that call `logEvent()` can now
  be collected in the DEV channel by using the name of the source file
  where they were generated as filter (e.g. `vmodule=create_table=2` for
  the CREATE TABLE events.
- events of other kinds can be collected in the DEV channel
  by setting `vmodule=event_log=2`.

(Note a subtle difference between `vmodule=create_table=2` and
`vmodule=exec_log=2`: the former emits the event to the DEV channel
while the stmt is executed; the latter emits the event after the stmt
completes. If both are enabled, TWO events are sent to the DEV channel.)

Since all the vmodule filtering options are subject to change without
notice between versions, we do not wish to document these nuances.
For this reason, the release note below is left blank.

Release note: None