### PR TITLE
ccl/backupccl: Wait for single version inside restore

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1435,13 +1435,6 @@ func createImportingDescriptors(
 		if err != nil {
 			return nil, nil, err
 		}
-
-		// Wait for one version on any existing changed types.
-		for existing := range existingTypeIDs {
-			if err := sql.WaitToUpdateLeases(ctx, p.ExecCfg().LeaseManager, existing); err != nil {
-				return nil, nil, err
-			}
-		}
 	}
 
 	// Get TableRekeys to use when importing raw data.
@@ -2157,6 +2150,7 @@ func (r *restoreResumer) dropDescriptors(
 			tableToDrop.Name,
 			false, /* kvTrace */
 		)
+		descsCol.AddDeletedDescriptor(tableToDrop)
 		if err := descsCol.WriteDescToBatch(ctx, false /* kvTrace */, tableToDrop, b); err != nil {
 			return errors.Wrap(err, "writing dropping table to batch")
 		}
@@ -2192,6 +2186,7 @@ func (r *restoreResumer) dropDescriptors(
 		}
 		// Remove the system.descriptor entry.
 		b.Del(catalogkeys.MakeDescMetadataKey(codec, typDesc.ID))
+		descsCol.AddDeletedDescriptor(mutType)
 	}
 
 	// Queue a GC job.
@@ -2260,6 +2255,7 @@ func (r *restoreResumer) dropDescriptors(
 			false, /* kvTrace */
 		)
 		b.Del(catalogkeys.MakeDescMetadataKey(codec, sc.GetID()))
+		descsCol.AddDeletedDescriptor(sc)
 		dbsWithDeletedSchemas[sc.GetParentID()] = append(dbsWithDeletedSchemas[sc.GetParentID()], sc)
 	}
 
@@ -2293,6 +2289,7 @@ func (r *restoreResumer) dropDescriptors(
 		descKey := catalogkeys.MakeDescMetadataKey(codec, db.GetID())
 		b.Del(descKey)
 		b.Del(catalogkeys.NewDatabaseKey(db.GetName()).Key(codec))
+		descsCol.AddDeletedDescriptor(db)
 		deletedDBs[db.GetID()] = struct{}{}
 	}
 

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -2024,15 +2024,6 @@ func (r *importResumer) Resume(ctx context.Context, execCtx interface{}) error {
 	// to see the same version of the updated table descriptor, after which we
 	// shall chose a ts to import from.
 	if details.Walltime == 0 {
-		// TODO(dt): update job status to mention waiting for tables to go offline.
-		for _, i := range details.Tables {
-			if !i.IsNew {
-				if _, err := p.ExecCfg().LeaseManager.WaitForOneVersion(ctx, i.Desc.ID, retry.Options{}); err != nil {
-					return err
-				}
-			}
-		}
-
 		// Now that we know all the tables are offline, pick a walltime at which we
 		// will write.
 		details.Walltime = p.ExecCfg().Clock.Now().WallTime
@@ -2274,14 +2265,6 @@ func (r *importResumer) publishTables(ctx context.Context, execCfg *sql.Executor
 		return err
 	}
 
-	// Wait for the table to be public before completing.
-	for _, tbl := range details.Tables {
-		_, err := lm.WaitForOneVersion(ctx, tbl.Desc.ID, retry.Options{})
-		if err != nil {
-			return errors.Wrap(err, "publishing tables waiting for one version")
-		}
-	}
-
 	// Initiate a run of CREATE STATISTICS. We don't know the actual number of
 	// rows affected per table, so we use a large number because we want to make
 	// sure that stats always get created/refreshed here.
@@ -2328,15 +2311,6 @@ func (r *importResumer) OnFailOrCancel(ctx context.Context, execCtx interface{})
 		return r.releaseProtectedTimestamp(ctx, txn, cfg.ProtectedTimestampProvider)
 	}); err != nil {
 		return err
-	}
-	// Wait for the tables to become public before completing.
-	if details.PrepareComplete {
-		for _, tableDesc := range details.Tables {
-			_, err := cfg.LeaseManager.WaitForOneVersion(ctx, tableDesc.Desc.ID, retry.Options{})
-			if err != nil {
-				return errors.Wrap(err, "rolling back tables waiting for them to be public")
-			}
-		}
 	}
 
 	// Run any jobs which might have been queued when dropping the schemas.
@@ -2565,6 +2539,7 @@ func (r *importResumer) dropTables(
 				false, /* kvTrace */
 			)
 			tablesToGC = append(tablesToGC, newTableDesc.ID)
+			descsCol.AddDeletedDescriptor(newTableDesc)
 		} else {
 			// IMPORT did not create this table, so we should not drop it.
 			newTableDesc.SetPublic()

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -476,15 +476,6 @@ func (sc *SchemaChanger) dropConstraints(
 		return nil, err
 	}
 
-	if err := WaitToUpdateLeases(ctx, sc.leaseMgr, sc.descID); err != nil {
-		return nil, err
-	}
-	for id := range fksByBackrefTable {
-		if err := WaitToUpdateLeases(ctx, sc.leaseMgr, id); err != nil {
-			return nil, err
-		}
-	}
-
 	log.Info(ctx, "finished dropping constraints")
 	tableDescs := make(map[descpb.ID]catalog.TableDescriptor, len(fksByBackrefTable)+1)
 	if err := sc.txn(ctx, func(
@@ -637,15 +628,6 @@ func (sc *SchemaChanger) addConstraints(
 		return txn.Run(ctx, b)
 	}); err != nil {
 		return err
-	}
-
-	if err := WaitToUpdateLeases(ctx, sc.leaseMgr, sc.descID); err != nil {
-		return err
-	}
-	for id := range fksByBackrefTable {
-		if err := WaitToUpdateLeases(ctx, sc.leaseMgr, id); err != nil {
-			return err
-		}
 	}
 	log.Info(ctx, "finished adding constraints")
 	return nil

--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -230,6 +230,10 @@ type Collection struct {
 	// skipValidationOnWrite should only be set to true during forced descriptor
 	// repairs.
 	skipValidationOnWrite bool
+
+	// droppedDescriptors that will not need to wait for new
+	// lease versions.
+	deletedDescs []catalog.Descriptor
 }
 
 var _ catalog.Accessor = (*Collection)(nil)
@@ -1469,6 +1473,7 @@ func (tc *Collection) ReleaseAll(ctx context.Context) {
 	tc.ReleaseLeases(ctx)
 	tc.uncommittedDescriptors = nil
 	tc.syntheticDescriptors = nil
+	tc.deletedDescs = nil
 	tc.releaseAllDescriptors()
 }
 
@@ -2120,6 +2125,17 @@ func (tc *Collection) SetSyntheticDescriptors(descs []catalog.Descriptor) {
 
 func (tc *Collection) codec() keys.SQLCodec {
 	return tc.leaseMgr.Codec()
+}
+
+// AddDeletedDescriptor is temporarily tracking descriptors that have been,
+// deleted which from an add state without any intermediate steps
+// Any descriptors marked as deleted will be skipped for the
+// wait for one version logic inside descs.Txn, since they will no longer
+// be inside storage.
+// Note: that this happens, at time of writing, only when reverting an
+// IMPORT or RESTORE.
+func (tc *Collection) AddDeletedDescriptor(desc catalog.Descriptor) {
+	tc.deletedDescs = append(tc.deletedDescs, desc)
 }
 
 // LeaseManager returns the lease.Manager.

--- a/pkg/sql/catalog/descs/txn.go
+++ b/pkg/sql/catalog/descs/txn.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -30,7 +31,9 @@ var errTwoVersionInvariantViolated = errors.Errorf("two version invariant violat
 // retrieved immutable descriptors are properly leased and all mutable
 // descriptors are handled. The function deals with verifying the two version
 // invariant and retrying when it is violated. Callers need not worry that they
-// write mutable descriptors multiple times.
+// write mutable descriptors multiple times. The call will explicitly wait for
+// the leases to drain on old versions of descriptors modified or deleted in the
+// transaction; callers do not need to call lease.WaitForOneVersion.
 //
 // The passed transaction is pre-emptively anchored to the system config key on
 // the system tenant.
@@ -48,8 +51,39 @@ func Txn(
 		nil, // hydratedTables
 		nil, // virtualSchemas
 	)
+	// Waits for descriptors that were modified, skipping
+	// over ones that had their descriptor wiped.
+	waitForDescriptors := func(modifiedDescriptors []lease.IDVersion, deletedDescs []catalog.Descriptor) error {
+		// Wait for a single version on leased descriptors.
+		for _, ld := range modifiedDescriptors {
+			waitForNoVersion := false
+			// Detect unpublished ones..
+			for _, deletedDesc := range deletedDescs {
+				if deletedDesc.GetID() == ld.ID {
+					waitForNoVersion = true
+					break
+				}
+			}
+			if waitForNoVersion {
+				err := leaseMgr.WaitForNoVersion(ctx, ld.ID, retry.Options{})
+				if err != nil {
+					return err
+				}
+			} else {
+				_, err := leaseMgr.WaitForOneVersion(ctx, ld.ID, retry.Options{})
+				if err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}
 	for {
+		var modifiedDescriptors []lease.IDVersion
+		var deletedDescs []catalog.Descriptor
 		if err := db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+			modifiedDescriptors = nil
+			deletedDescs = nil
 			defer descsCol.ReleaseAll(ctx)
 			if err := txn.SetSystemConfigTrigger(leaseMgr.Codec().ForSystemTenant()); err != nil {
 				return err
@@ -57,18 +91,24 @@ func Txn(
 			if err := f(ctx, txn, descsCol); err != nil {
 				return err
 			}
+
 			if err := descsCol.ValidateUncommittedDescriptors(ctx, txn); err != nil {
 				return err
 			}
+			modifiedDescriptors = descsCol.GetDescriptorsWithNewVersion()
 			retryErr, err := CheckTwoVersionInvariant(
 				ctx, db.Clock(), ie, descsCol, txn, nil /* onRetryBackoff */)
 			if retryErr {
 				return errTwoVersionInvariantViolated
 			}
+			deletedDescs = descsCol.deletedDescs
 			return err
 		}); errors.Is(err, errTwoVersionInvariantViolated) {
 			continue
 		} else {
+			if err == nil {
+				err = waitForDescriptors(modifiedDescriptors, deletedDescs)
+			}
 			return err
 		}
 	}

--- a/pkg/sql/indexbackfiller_test.go
+++ b/pkg/sql/indexbackfiller_test.go
@@ -45,7 +45,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
-	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
@@ -515,8 +514,6 @@ INSERT INTO foo VALUES (1), (10), (100);
 			table = mut.ImmutableCopy().(catalog.TableDescriptor)
 			return descriptors.WriteDesc(ctx, false /* kvTrace */, mut, txn)
 		}))
-		_, err := lm.WaitForOneVersion(ctx, tableID, retry.Options{})
-		require.NoError(t, err)
 
 		// Run the index backfill
 		changer := sql.NewSchemaChangerForTesting(

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -386,13 +386,6 @@ func (sc *SchemaChanger) maybeMakeAddTablePublic(
 	}
 	log.Info(ctx, "making table public")
 
-	fks := table.AllActiveAndInactiveForeignKeys()
-	for _, fk := range fks {
-		if err := WaitToUpdateLeases(ctx, sc.leaseMgr, fk.ReferencedTableID); err != nil {
-			return err
-		}
-	}
-
 	return sc.txn(ctx, func(ctx context.Context, txn *kv.Txn, descsCol *descs.Collection) error {
 		mut, err := descsCol.GetMutableTableVersionByID(ctx, table.GetID(), txn)
 		if err != nil {
@@ -985,9 +978,7 @@ func (sc *SchemaChanger) RunStateMachineBeforeBackfill(ctx context.Context) erro
 	}
 
 	log.Info(ctx, "finished stepping through state machine")
-
-	// wait for the state change to propagate to all leases.
-	return WaitToUpdateLeases(ctx, sc.leaseMgr, sc.descID)
+	return nil
 }
 
 func (sc *SchemaChanger) createIndexGCJob(
@@ -1029,19 +1020,6 @@ func WaitToUpdateLeases(ctx context.Context, leaseMgr *lease.Manager, descID des
 	return err
 }
 
-// WaitToUpdateLeasesMultiple waits until the entire cluster has been updated to
-// the latest versions of all the specified descriptors.
-func WaitToUpdateLeasesMultiple(
-	ctx context.Context, leaseMgr *lease.Manager, ids []lease.IDVersion,
-) error {
-	for _, idVer := range ids {
-		if err := WaitToUpdateLeases(ctx, leaseMgr, idVer.ID); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 // done finalizes the mutations (adds new cols/indexes to the table).
 // It ensures that all nodes are on the current (pre-update) version of
 // sc.descID and that all nodes are on the new (post-update) version of
@@ -1054,7 +1032,7 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 	// descriptor updates are published.
 	var didUpdate bool
 	var depMutationJobs []jobspb.JobID
-	modified, err := sc.txnWithModified(ctx, func(
+	err := descs.Txn(ctx, sc.settings, sc.leaseMgr, sc.execCfg.InternalExecutor, sc.db, func(
 		ctx context.Context, txn *kv.Txn, descsCol *descs.Collection,
 	) error {
 		var err error
@@ -1385,17 +1363,6 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	// Wait for the modified versions of tables other than the table we're
-	// updating to have their leases updated.
-	for _, desc := range modified {
-		// sc.descID gets waited for above this call in sc.exec().
-		if desc.ID == sc.descID {
-			continue
-		}
-		if err := WaitToUpdateLeases(ctx, sc.leaseMgr, desc.ID); err != nil {
-			return err
-		}
-	}
 	// Notify the job registry to start jobs, in case we started any.
 	if err := sc.jobRegistry.NotifyToAdoptJobs(ctx); err != nil {
 		return err
@@ -1678,16 +1645,6 @@ func (sc *SchemaChanger) maybeReverseMutations(ctx context.Context, causingError
 	if err != nil || alreadyReversed {
 		return err
 	}
-
-	if err := WaitToUpdateLeases(ctx, sc.leaseMgr, sc.descID); err != nil {
-		return err
-	}
-	for id := range fksByBackrefTable {
-		if err := WaitToUpdateLeases(ctx, sc.leaseMgr, id); err != nil {
-			return err
-		}
-	}
-
 	return nil
 }
 
@@ -2003,28 +1960,8 @@ func (*SchemaChangerTestingKnobs) ModuleTestingKnobs() {}
 func (sc *SchemaChanger) txn(
 	ctx context.Context, f func(context.Context, *kv.Txn, *descs.Collection) error,
 ) error {
-	_, err := sc.txnWithModified(ctx, f)
+	err := descs.Txn(ctx, sc.settings, sc.leaseMgr, sc.execCfg.InternalExecutor, sc.db, f)
 	return err
-}
-
-// txnWithModified is a convenient wrapper around descs.Txn() which additionally
-// returns the set of modified descriptors.
-func (sc *SchemaChanger) txnWithModified(
-	ctx context.Context, f func(context.Context, *kv.Txn, *descs.Collection) error,
-) (descsWithNewVersions []lease.IDVersion, _ error) {
-	ie := sc.ieFactory(ctx, NewFakeSessionData(sc.execCfg.SV()))
-	if err := descs.Txn(ctx, sc.settings, sc.leaseMgr, ie, sc.db, func(
-		ctx context.Context, txn *kv.Txn, descsCol *descs.Collection,
-	) error {
-		if err := f(ctx, txn, descsCol); err != nil {
-			return err
-		}
-		descsWithNewVersions = descsCol.GetDescriptorsWithNewVersion()
-		return nil
-	}); err != nil {
-		return nil, err
-	}
-	return descsWithNewVersions, nil
 }
 
 // createSchemaChangeEvalCtx creates an extendedEvalContext() to be used for backfills.

--- a/pkg/sql/schemachanger/scexec/BUILD.bazel
+++ b/pkg/sql/schemachanger/scexec/BUILD.bazel
@@ -67,7 +67,6 @@ go_test(
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",
         "//pkg/util/randutil",
-        "//pkg/util/retry",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/sql/schemachanger/scjob/BUILD.bazel
+++ b/pkg/sql/schemachanger/scjob/BUILD.bazel
@@ -15,7 +15,6 @@ go_library(
         "//pkg/sql",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/descs",
-        "//pkg/sql/catalog/lease",
         "//pkg/sql/schemachanger/scexec",
         "//pkg/sql/schemachanger/scpb",
         "//pkg/sql/schemachanger/scplan",

--- a/pkg/sql/type_change.go
+++ b/pkg/sql/type_change.go
@@ -593,14 +593,6 @@ func (t *typeSchemaChanger) cleanupEnumValues(ctx context.Context) error {
 		return err
 	}
 
-	// Finally, make sure all of the leases are updated.
-	if err := WaitToUpdateLeases(ctx, t.execCfg.LeaseManager, t.typeID); err != nil {
-		if errors.Is(err, catalog.ErrDescriptorNotFound) {
-			return nil
-		}
-		return err
-	}
-
 	if regionChangeFinalizer != nil {
 		if err := regionChangeFinalizer.waitToUpdateLeases(ctx, t.execCfg.LeaseManager); err != nil {
 			return err


### PR DESCRIPTION
Previously, we made changes to cache offline leases,
which can allow older version to remain active. Before
this we would never cache these leases leading to live
lock scenarios trying online them. Unfortunately, when
onlining tables in restore we didn't validate that only
a single table was active. So, a select after a restore
can hit an table offline error. To address this, this
patch will wait for a single version on any descs.Txn
operation.

Release note: None