### PR TITLE
release-21.1: sql: fix ordered set aggregates with constant ORDER BY expressions

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -3846,3 +3846,40 @@ SELECT a, b, count(*) FROM t63159 GROUP BY a,b ORDER BY a
 statement ok
 CREATE TABLE t63436 (a INT, b FLOAT, c DECIMAL, INDEX(a));
 SELECT count(*) FROM t63436@t63436_a_idx GROUP BY b, c ORDER BY c;
+
+# Regression test for #64319. Percentiles of constants should not panic.
+subtest 63436
+
+query I
+SELECT percentile_disc(0.95) WITHIN GROUP (ORDER BY 33) FROM osagg
+----
+33
+
+query R
+SELECT percentile_disc(0.95) WITHIN GROUP (ORDER BY 33.0) FROM osagg
+----
+33.0
+
+query I
+SELECT percentile_disc(0.95) WITHIN GROUP (ORDER BY 33::INT) FROM osagg
+----
+33
+
+query I
+SELECT percentile_disc(0.95) WITHIN GROUP (ORDER BY '33'::INT) FROM osagg
+----
+33
+
+# Note: In this case Postgres returns "ERROR: 42804: could not determine
+# polymorphic type because input has type unknown". However, Postgres does allow
+# ... (ORDER BY s) ... where s is a TEXT column. It would require additional
+# complexity for us to error in this case, so we return a result instead.
+query T
+SELECT percentile_disc(0.95) WITHIN GROUP (ORDER BY 'foo') FROM osagg
+----
+foo
+
+query T
+SELECT percentile_disc(0.95) WITHIN GROUP (ORDER BY current_database()) FROM osagg
+----
+test

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -1119,7 +1119,7 @@ func (s *scope) replaceAggregate(f *tree.FuncExpr, def *tree.FunctionDefinition)
 		copy(fCopy.Exprs, oldExprs)
 
 		// Add implicit column to the input expressions.
-		fCopy.Exprs = append(fCopy.Exprs, fCopy.OrderBy[0].Expr.(tree.TypedExpr))
+		fCopy.Exprs = append(fCopy.Exprs, s.resolveType(fCopy.OrderBy[0].Expr, types.Any))
 	}
 
 	expr := fCopy.Walk(s)


### PR DESCRIPTION
Backport 1/1 commits from #64892.

/cc @cockroachdb/release

---

This commit fixes a bug that caused an error when providing a constant
ORDER BY expressions in an ordered set aggregate.

Fixes #64319
Fixes #64318

Release note (bug fix): Providing a constant value as an ORDER BY value
in an ordered set aggregate, such as `percentile_dist` or
`percentile_cont`, no longer errors. This bug has been present since
order set aggregates were added in version 20.2.
