### PR TITLE
release-20.2: sql: fix ordered set aggregates with constant ORDER BY expressions

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -2853,3 +2853,40 @@ query RI
 SELECT corr(DISTINCT y, x), count(DISTINCT y) FROM t55776
 ----
 0.522232967867094 3
+
+# Regression test for #64319. Percentiles of constants should not panic.
+subtest 63436
+
+query I
+SELECT percentile_disc(0.95) WITHIN GROUP (ORDER BY 33) FROM osagg
+----
+33
+
+query R
+SELECT percentile_disc(0.95) WITHIN GROUP (ORDER BY 33.0) FROM osagg
+----
+33.0
+
+query I
+SELECT percentile_disc(0.95) WITHIN GROUP (ORDER BY 33::INT) FROM osagg
+----
+33
+
+query I
+SELECT percentile_disc(0.95) WITHIN GROUP (ORDER BY '33'::INT) FROM osagg
+----
+33
+
+# Note: In this case Postgres returns "ERROR: 42804: could not determine
+# polymorphic type because input has type unknown". However, Postgres does allow
+# ... (ORDER BY s) ... where s is a TEXT column. It would require additional
+# complexity for us to error in this case, so we return a result instead.
+query T
+SELECT percentile_disc(0.95) WITHIN GROUP (ORDER BY 'foo') FROM osagg
+----
+foo
+
+query T
+SELECT percentile_disc(0.95) WITHIN GROUP (ORDER BY current_database()) FROM osagg
+----
+test

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -1091,7 +1091,7 @@ func (s *scope) replaceAggregate(f *tree.FuncExpr, def *tree.FunctionDefinition)
 		copy(fCopy.Exprs, oldExprs)
 
 		// Add implicit column to the input expressions.
-		fCopy.Exprs = append(fCopy.Exprs, fCopy.OrderBy[0].Expr.(tree.TypedExpr))
+		fCopy.Exprs = append(fCopy.Exprs, s.resolveType(fCopy.OrderBy[0].Expr, types.Any))
 	}
 
 	expr := fCopy.Walk(s)


### PR DESCRIPTION
Backport 1/1 commits from #64892.

/cc @cockroachdb/release

---

This commit fixes a bug that caused an error when providing a constant
ORDER BY expressions in an ordered set aggregate.

Fixes #64319
Fixes #64318

Release note (bug fix): Providing a constant value as an ORDER BY value
in an ordered set aggregate, such as `percentile_dist` or
`percentile_cont`, no longer errors. This bug has been present since
order set aggregates were added in version 20.2.
