### PR TITLE
workloadccl: add missing AUTH=implicit

### DIFF
--- a/pkg/ccl/workloadccl/fixture.go
+++ b/pkg/ccl/workloadccl/fixture.go
@@ -72,9 +72,12 @@ func (s FixtureConfig) objectPathToURI(folder string) string {
 		Host:   s.GCSBucket,
 		Path:   folder,
 	}
+	q := url.Values{}
 	if s.BillingProject != `` {
-		u.RawQuery = `GOOGLE_BILLING_PROJECT=` + url.QueryEscape(s.BillingProject)
+		q.Add("GOOGLE_BILLING_PROJECT", s.BillingProject)
 	}
+	q.Add("AUTH", "implicit")
+	u.RawQuery = q.Encode()
 	return u.String()
 }
 

--- a/pkg/cmd/roachtest/copy.go
+++ b/pkg/cmd/roachtest/copy.go
@@ -69,14 +69,7 @@ func registerCopy(r *testRegistry) {
 				var count int
 				const q = "SELECT count(*) FROM [SHOW RANGES FROM TABLE bank.bank]"
 				if err := db.QueryRow(q).Scan(&count); err != nil {
-					// TODO(rafi): Remove experimental_ranges query once we stop testing
-					// 19.1 or earlier.
-					if strings.Contains(err.Error(), "syntax error at or near \"ranges\"") {
-						err = db.QueryRow("SELECT count(*) FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE bank.bank]").Scan(&count)
-					}
-					if err != nil {
-						t.Fatalf("failed to get range count: %v", err)
-					}
+					t.Fatalf("failed to get range count: %v", err)
 				}
 				return count
 			}


### PR DESCRIPTION
This adds one sneaky little AUTH that was missed in #64840.

Fixes #64926.

Release note: None
