### PR TITLE
server: de-flake TestServerWithTimeseriesImport

### DIFF
--- a/pkg/ts/db.go
+++ b/pkg/ts/db.go
@@ -157,9 +157,9 @@ func (db *DB) PollSource(
 // start begins the goroutine for this poller, which will periodically request
 // time series data from the DataSource and store it.
 func (p *poller) start() {
+	// Poll once immediately and synchronously.
+	p.poll()
 	_ = p.stopper.RunAsyncTask(context.TODO(), "ts-poller", func(context.Context) {
-		// Poll once immediately.
-		p.poll()
 		ticker := time.NewTicker(p.frequency)
 		defer ticker.Stop()
 		for {


### PR DESCRIPTION
Dumping the timeseries could race with the (non-atomic) first batch of
timeseries write. If this ended up not returning any of the node time
series, the test would fail as the import expects at least one node to
be present in the timeseries.

This commit makes the first timeseries write synchronous in
`(*Server).PreStart`. To do this, we have to move the call past the
initialization of the KV layer (in particular, starting the node and
node liveness).

Fixes #64913.

Release note: None
