### PR TITLE
bulk: memory monitor sst batching during RESTORE

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -202,6 +202,7 @@ go_test(
         "//pkg/util/hlc",
         "//pkg/util/leaktest",
         "//pkg/util/log",
+        "//pkg/util/mon",
         "//pkg/util/protoutil",
         "//pkg/util/randutil",
         "//pkg/util/retry",

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
@@ -260,7 +260,7 @@ func (sip *streamIngestionProcessor) ConsumerClosed() {
 func (sip *streamIngestionProcessor) close() {
 	if sip.InternalClose() {
 		if sip.batcher != nil {
-			sip.batcher.Close()
+			sip.batcher.Close(sip.Ctx)
 		}
 		if sip.maxFlushRateTimer != nil {
 			sip.maxFlushRateTimer.Stop()

--- a/pkg/kv/bulk/BUILD.bazel
+++ b/pkg/kv/bulk/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "bulk",
     srcs = [
+        "accounted_mem_file.go",
         "buffering_adder.go",
         "bulk_metrics.go",
         "kv_buf.go",

--- a/pkg/kv/bulk/accounted_mem_file.go
+++ b/pkg/kv/bulk/accounted_mem_file.go
@@ -1,0 +1,77 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package bulk
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
+)
+
+// accountedMemFile wraps a MemFile so that can account for the memory it uses
+// in the given monitor if one is provided.
+type accountedMemFile struct {
+	storage.MemFile
+
+	ctx    context.Context
+	memAcc *mon.BoundAccount
+}
+
+// makeAccountedMemFile creates an accountedMemFile that can keep track of its
+// allocations towards the memory monitor provided.
+// Memory written to this buffer will be freed upon Close().
+func makeAccountedMemFile(ctx context.Context, memMon *mon.BytesMonitor) (f accountedMemFile) {
+	f.ctx = ctx
+	if memMon != nil {
+		memAcc := memMon.MakeBoundAccount()
+		f.memAcc = &memAcc
+	}
+
+	return
+}
+
+// Write implements the writeCloseSyncer interface. It accounts for memory it
+// uses.
+func (f *accountedMemFile) Write(p []byte) (n int, err error) {
+	oldCap := f.MemFile.Cap()
+	n, err = f.MemFile.Write(p)
+	if err != nil {
+		return n, err
+	}
+
+	// Although this accounts for the memory after allocating it, the SST batcher
+	// predicts if it expects the capacity to increase and will flush eagerly if it
+	// does.
+	if f.memAcc != nil {
+		newCap := f.MemFile.Cap()
+		amountToGrow := int64(newCap - oldCap)
+		// We do not expect for this allocation to error. If it does that means that
+		// the prediction of the caller was not aggressive enough (ie it was less than
+		// amountToGrow).
+		if err := f.memAcc.Grow(f.ctx, amountToGrow); err != nil {
+			log.Errorf(f.ctx, "unexpectedly could not grow accounted mem file; grew by %d", amountToGrow)
+			return n, err
+		}
+	}
+
+	return n, nil
+}
+
+// Close implements the writeCloseSyncer interface.
+func (f *accountedMemFile) Close() error {
+	if f.memAcc != nil {
+		f.memAcc.Close(f.ctx)
+	}
+
+	return f.MemFile.Close()
+}

--- a/pkg/kv/bulk/buffering_adder.go
+++ b/pkg/kv/bulk/buffering_adder.go
@@ -155,7 +155,7 @@ func (b *BufferingAdder) Close(ctx context.Context) {
 		b.sink.flushCounts.total, b.sink.flushCounts.files,
 		b.sink.flushCounts.split, b.sink.flushCounts.sstSize,
 	)
-	b.sink.Close()
+	b.sink.Close(ctx)
 
 	if b.bulkMon != nil {
 		b.memAcc.Close(ctx)

--- a/pkg/kv/bulk/sst_batcher_test.go
+++ b/pkg/kv/bulk/sst_batcher_test.go
@@ -334,7 +334,8 @@ func TestAddBigSpanningSSTWithSplits(t *testing.T) {
 
 	t.Logf("Adding %dkb sst spanning %d splits from %v to %v", len(sst)/kb, len(splits), start, end)
 	if _, err := bulk.AddSSTable(
-		ctx, mock, start, end, sst, false /* disallowShadowing */, enginepb.MVCCStats{}, cluster.MakeTestingClusterSettings(), hlc.Timestamp{},
+		ctx, mock, start, end, sst, false /* disallowShadowing */, enginepb.MVCCStats{},
+		cluster.MakeTestingClusterSettings(), hlc.Timestamp{}, nil /* memMon */, nil, /* memAcc */
 	); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -351,6 +351,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 	bulkMemoryMonitor.Start(context.Background(), rootSQLMemoryMonitor, mon.BoundAccount{})
 
 	backfillMemoryMonitor := execinfra.NewMonitor(ctx, bulkMemoryMonitor, "backfill-mon")
+	restoreMemoryMonitor := execinfra.NewMonitor(ctx, bulkMemoryMonitor, "restore-mon")
 
 	// Set up the DistSQL temp engine.
 
@@ -422,6 +423,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		VecFDSemaphore:    semaphore.New(envutil.EnvOrDefaultInt("COCKROACH_VEC_MAX_OPEN_FDS", colexec.VecMaxOpenFDsLimit)),
 		ParentDiskMonitor: cfg.TempStorageConfig.Mon,
 		BackfillerMonitor: backfillMemoryMonitor,
+		RestoreMemMonitor: restoreMemoryMonitor,
 
 		ParentMemoryMonitor: rootSQLMemoryMonitor,
 		BulkAdder: func(

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1097,6 +1097,11 @@ type BackupRestoreTestingKnobs struct {
 	// RunAfterExportingSpanEntry allows blocking the BACKUP job after a single
 	// span has been exported.
 	RunAfterExportingSpanEntry func(ctx context.Context)
+
+	// RestoreMemMonitor is used to overwrite the monitor used by restore during
+	// testing. It is typically
+	// This is typically the bulk mem monitor if not specified here.
+	RestoreMemMonitor *mon.BytesMonitor
 }
 
 var _ base.ModuleTestingKnobs = &BackupRestoreTestingKnobs{}

--- a/pkg/sql/execinfra/server_config.go
+++ b/pkg/sql/execinfra/server_config.go
@@ -96,6 +96,10 @@ type ServerConfig struct {
 	// used by the column and index backfillers.
 	BackfillerMonitor *mon.BytesMonitor
 
+	// Child monitor of the bulk monitor which will be used to monitor the memory
+	// used during RESTORE.
+	RestoreMemMonitor *mon.BytesMonitor
+
 	// ParentDiskMonitor is normally the root disk monitor. It should only be used
 	// when setting up a server, a child monitor (usually belonging to a sql
 	// execution flow), or in tests. It is used to monitor temporary storage disk

--- a/pkg/storage/sst_writer.go
+++ b/pkg/storage/sst_writer.go
@@ -68,11 +68,16 @@ func MakeBackupSSTWriter(f writeCloseSyncer) SSTWriter {
 // These SSTs have bloom filters enabled (as set in DefaultPebbleOptions) and
 // format set to RocksDBv2.
 func MakeIngestionSSTWriter(f writeCloseSyncer) SSTWriter {
+	opts := MakeIngestionWriterOpts()
+	sst := sstable.NewWriter(f, opts)
+	return SSTWriter{fw: sst, f: f}
+}
+
+func MakeIngestionWriterOpts() sstable.WriterOptions {
 	opts := DefaultPebbleOptions().MakeWriterOptions(0)
 	opts.TableFormat = sstable.TableFormatRocksDBv2
 	opts.MergerName = "nullptr"
-	sst := sstable.NewWriter(f, opts)
-	return SSTWriter{fw: sst, f: f}
+	return opts
 }
 
 // Finish finalizes the writer and returns the constructed file's contents,


### PR DESCRIPTION
This commit narrowly focuses on adding memory monitoring for the
buffering portion of a RESTORE. SSTs are buffered during restore before
being flushed with an AddSSTable request. The memory used to buffer the
table is now accounted for under the bulk memory monitor.

Memory pressure becomes more likely once this buffering is parallelized
in https://github.com/cockroachdb/cockroach/pull/61942.

Memory used by iterators will be tracked in a separate PR.

Informs https://github.com/cockroachdb/cockroach/issues/64936.

Release note (enterprise change): Data buffeed during RESTORE is now
counted towards the cluster's --sql-max-memory limit to help guard
against OOMs. If not enough memory is available, the RESTORE will fail.