### PR TITLE
ccl/changefeedccl: set sarama to use kafka version 1.0 and later

### DIFF
--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -444,6 +444,7 @@ func makeKafkaSink(
 	config.ClientID = `CockroachDB`
 	config.Producer.Return.Successes = true
 	config.Producer.Partitioner = newChangefeedPartitioner
+	config.Version = sarama.V1_0_0_0
 
 	if cfg.caCert != nil {
 		if !cfg.tlsEnabled {


### PR DESCRIPTION
Previously the Kafka sink didn't specify a version to sarama, so it
defaulted to the minimum version of 0.8.2. This behavior has been
changed in the latest version of sarama to use version 1.0 of the
Kafka API. Information on why this change was made by sarama can be
found here:
https://github.com/Shopify/sarama/issues/1787

Resolves #64842

Release note (enterprise change): Set the Kafka CDC sink to use the 1.0
version of the Kafka API.