### PR TITLE
opt: normalize UNION to DISTINCT ON + UNION ALL

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/union
+++ b/pkg/sql/opt/exec/execbuilder/testdata/union
@@ -427,7 +427,7 @@ statement ok
 CREATE TABLE abcde (a INT PRIMARY KEY, b INT, c INT, d INT, e INT, INDEX (b, c, d, e))
 
 query T
-EXPLAIN (DISTSQL,VERBOSE) SELECT * FROM (SELECT * FROM abcde UNION SELECT * FROM abcde) WHERE c = 1 AND d = e ORDER BY a
+EXPLAIN (DISTSQL,VERBOSE) SELECT * FROM (SELECT a, b, c, d, e FROM abcde UNION SELECT a, c, b, d, e FROM abcde) WHERE c = 1 AND d = e ORDER BY a
 ----
 distribution: local
 vectorized: true
@@ -450,23 +450,27 @@ vectorized: true
 │         table: abcde@primary
 │         spans: FULL SCAN
 │
-└── • filter
-    │ columns: (a, b, c, d, e)
+└── • sort
+    │ columns: (a, c, b, d, e)
     │ ordering: +a
     │ estimated row count: 1 (missing stats)
-    │ filter: (c = 1) AND (d = e)
+    │ order: +a
     │
-    └── • scan
-          columns: (a, b, c, d, e)
-          ordering: +a
-          estimated row count: 1,000 (missing stats)
-          table: abcde@primary
-          spans: FULL SCAN
+    └── • filter
+        │ columns: (a, b, c, d, e)
+        │ estimated row count: 1 (missing stats)
+        │ filter: d = e
+        │
+        └── • scan
+              columns: (a, b, c, d, e)
+              estimated row count: 10 (missing stats)
+              table: abcde@abcde_b_c_d_e_idx
+              spans: /1-/2
 ·
-Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyskF-Lm0AUxd_7KS73SeuUxH9QBgKz27hUSHWr6T-KD65zWQRX7cwEWkK-e1ELu4ZN6DZ9nHvnnN85d4_6R4Mco6-3m6s4AWsd59v844bB5yi7TvPIhjzaRO-28BpusvQDWPNneVdJgk9JnCbwzMaGL--jLAKrghW4Nlwla7AkrIBsSLN1lMH1NyiRYdtJSsoH0si_o4sFw151FWndqWG0Hz_E8ifyJcO67XdmGBcMq04R8j2a2jSEHLflXUMZlZLUYokMJZmybkbbMZHoVf1Qql_IMO_LVnN4g8WBYbczj6balPeE3D2wvwff1I0hRWrhzqnTnIMl_OEGnPM42b79cwoRwApEaJ-M4L0kwtPu3oXd_X_q7v_P7sHJCI_kTklSJOdY4TpMeA4TvsNE4DAROlgcnsm9rrWp28osgmMDJjwmfCYCJsKTAcOX3Cgj3XetphnplPNySEvynqa2utupim5VV42Y6ZmOunEgSZtp606PuJ1WQ8CnYvesOJiJ3WOxd1bsnyf7l5CDs-LwiFwcXv0OAAD__4ZyhRo=
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJykku-L2k4Qxt9__4phXunXOWJ-HWVB2LuaowGbXBP7iyISs8MR8BK7WeGK-L8XE8HTalrbN4GdmWc-T57dDdbflygw-PI4uQsj6I3DdJp-mBB8CpL7OA36kAaT4O0U_oeHJH4Pvf0xI1gQ5ASKgNtWtsgVw8cojCM4TOXN4MlUHz6_C5IAejmMwO7DXTSGnoIRcB_iZBwkcP8VMiQsK8VR9sw1im9o44xwpauc67rSu9KmGQjVC4ohYVGu1mZXnhHmlWYUGzSFWTIKnGaLJSecKdbWEAkVm6xYNmsbR7L5zhfzfK7mPC_UCxKmq6ysBVj2jeXgbEtYrc0BUZvsiVHYW_pzGw_F0rBmbdnHHtq6AOnBCKR_EeZcA0srbVhbzjFK2gMkjNdGgLRJuiQdkh51QN1roK-Dds8FvdLFc6Z_HOK9uQj2_ipa73y0PenuHpsQIoymb_Zvbp93_6IF_6KFA7nSijWrX2Im6QxIugOS3oCkP8DZ9ozvcVGbosyN5Z8uaG7G_c3l3F6TUcL1qiprPiJd2jzcuWX1xO3f1tVa5_yoq7zBtMe40TUFxbVpu3Z7CMu2tTP4Wmx3ip1usdMp9o_E9qnY7RR73WTvX8h-p_j2hDzb_vczAAD__6qVwrQ=
 
 query T
-EXPLAIN (DISTSQL,VERBOSE) SELECT * FROM (SELECT * FROM abcde UNION SELECT * FROM abcde) WHERE c = 1 AND d = e ORDER BY b, c, d, e, a
+EXPLAIN (DISTSQL,VERBOSE) SELECT * FROM (SELECT a, b, c, d, e FROM abcde UNION SELECT  a, c, b, d, e FROM abcde) WHERE c = 1 AND d = e ORDER BY b, c, d, e, a
 ----
 distribution: local
 vectorized: true
@@ -490,19 +494,19 @@ vectorized: true
 │         spans: FULL SCAN
 │
 └── • filter
-    │ columns: (a, b, c, d, e)
-    │ ordering: +b,+d,+a
+    │ columns: (a, c, b, d, e)
+    │ ordering: +c,+d,+a
     │ estimated row count: 1 (missing stats)
-    │ filter: (c = 1) AND (d = e)
+    │ filter: d = e
     │
     └── • scan
           columns: (a, b, c, d, e)
-          ordering: +b,+c,+d,+e,+a
-          estimated row count: 1,000 (missing stats)
+          ordering: +c,+d,+e,+a
+          estimated row count: 10 (missing stats)
           table: abcde@abcde_b_c_d_e_idx
-          spans: FULL SCAN
+          spans: /1-/2
 ·
-Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyskG-Lm0AQxt_3UwzzKmmmJEYDZSGwd41HhVSvmv6jiBh3OASr6e4GDkK-e1ELd4ZL6PXujTAzPs_z2-eA5neFAv3vt-urIITRKkg2yec1wVc_vo4SfwyJv_Y_bOAt3MTRJxgNx3xbKIYvYRCF8MRlDN8--rEPowKW4IzhKlzBSMESeAxRvPJjuP4BW4KCQBEwQY6EdaM4zH-xQfETHUwJd7op2JhGt6tD90Og7lHMCMt6t7ftOiUsGs0oDmhLWzEK3OTbimPOFevpDAkV27ysOtuOTnbfbJsVmco4K9U9Eia7vDYC3mF6JGz29sHe2PyOUThH-neEm7KyrFlPnWF-vxcwkm7bjBAiCDfv_xYkPViCXIzPIsyfg_C4hfmrteD-Vwvua7bgnUV4SG60Ys1qGCvnE5LuhKQ3IelMSC4mmB6f4F6VxpZ1YafeiYFDck7SJemRXJwFXDyno5jNrqkND5LOOc9aWlZ33L_WNHtd8K1uii6mH6NO1y0UG9tfnX4I6v7UAj4WOxfF3kDsnIrnF8Xu5WT3JcneRfHiJDk9vvkTAAD__6G3jwo=
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJykkm-L2kAQxt_3UwzzSuscukmEsiDsXc3RgE2u0f6jiMTscARsYndXOBC_ezER_MPF1vZNYGfmmeeXZ3eL9tcKJYbfnib3UQydcTSdTT9NCL6E6UMyDbswDSfh-xm8hcc0-QidwzEjWBLkBJqAm1a2zDXD5zhKYjhO5fXgxVQXvn4I0xA6OYxAdOE-HkNHwwi4C0k6DlN4-H6ynyBDwrLSHGc_2aL8gQLnhGtT5WxtZfalbT0Q6ReUA8KiXG_cvjwnzCvDKLfoCrdilDjLlitOOdNs-gMk1OyyYlWvrelU_V0sF_lCL3hR6BcknK6z0kroi7u-h_MdYbVxRwvrsmdGKXb09xiPxcqxYdMX5wxNXYIKYARqiITJxklQgpRPyiMVkBq2Ini3IJwm4d2YxF0rgv9PKfivp9BR_v6NSCmjePbu8FQO0XRbEYJWhKNzZTQb1ue2yuuR8nukgh4p0SM17OF89wr3uLCuKHPXDy4WiPqO_D9c0_CWjFK266q0fObUtnmwp2X9zM3f2mpjcn4yVV7bNMek1tUFzdY1XdEcorJp7QFPxeKqODgTi0uxd1XsX3f2_8c5uCoeXjjPd29-BwAA__-0e5X_
 
 query T
 EXPLAIN (DISTSQL,VERBOSE) SELECT * FROM (SELECT * FROM abcde UNION ALL SELECT * FROM abcde) WHERE c = 1 AND d = e ORDER BY a

--- a/pkg/sql/opt/memo/testdata/logprops/set
+++ b/pkg/sql/opt/memo/testdata/logprops/set
@@ -359,51 +359,62 @@ SELECT a, b, c FROM abc WHERE a > 0 AND a = c
 UNION
 SELECT a, b, c FROM abc WHERE a > 10 AND a = c
 ----
-union
+distinct-on
  ├── columns: a:9(int!null) b:10(int) c:11(int!null)
- ├── left columns: abc.a:1(int) abc.b:2(int) abc.c:3(int)
- ├── right columns: abc.a:5(int) abc.b:6(int) abc.c:7(int)
- ├── key: (10,11)
- ├── fd: (9)==(11), (11)==(9)
- ├── interesting orderings: (+(9|11))
- ├── select
- │    ├── columns: abc.a:1(int!null) abc.b:2(int) abc.c:3(int!null)
- │    ├── key: (1)
- │    ├── fd: (1)-->(2), (1)==(3), (3)==(1)
- │    ├── prune: (2)
- │    ├── interesting orderings: (+(1|3))
- │    ├── scan abc
- │    │    ├── columns: abc.a:1(int!null) abc.b:2(int) abc.c:3(int)
+ ├── grouping columns: a:9(int!null)
+ ├── key: (9)
+ ├── fd: (9)==(11), (11)==(9), (9)-->(10,11)
+ ├── prune: (10,11)
+ ├── union-all
+ │    ├── columns: a:9(int!null) b:10(int) c:11(int!null)
+ │    ├── left columns: abc.a:1(int) abc.b:2(int) abc.c:3(int)
+ │    ├── right columns: abc.a:5(int) abc.b:6(int) abc.c:7(int)
+ │    ├── fd: (9)==(11), (11)==(9)
+ │    ├── prune: (10)
+ │    ├── interesting orderings: (+(9|11))
+ │    ├── select
+ │    │    ├── columns: abc.a:1(int!null) abc.b:2(int) abc.c:3(int!null)
  │    │    ├── key: (1)
- │    │    ├── fd: (1)-->(2,3)
- │    │    ├── prune: (1-3)
- │    │    └── interesting orderings: (+1)
- │    └── filters
- │         ├── gt [type=bool, outer=(1), constraints=(/1: [/1 - ]; tight)]
- │         │    ├── variable: abc.a:1 [type=int]
- │         │    └── const: 0 [type=int]
- │         └── eq [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
- │              ├── variable: abc.a:1 [type=int]
- │              └── variable: abc.c:3 [type=int]
- └── select
-      ├── columns: abc.a:5(int!null) abc.b:6(int) abc.c:7(int!null)
-      ├── key: (5)
-      ├── fd: (5)-->(6), (5)==(7), (7)==(5)
-      ├── prune: (6)
-      ├── interesting orderings: (+(5|7))
-      ├── scan abc
-      │    ├── columns: abc.a:5(int!null) abc.b:6(int) abc.c:7(int)
-      │    ├── key: (5)
-      │    ├── fd: (5)-->(6,7)
-      │    ├── prune: (5-7)
-      │    └── interesting orderings: (+5)
-      └── filters
-           ├── gt [type=bool, outer=(5), constraints=(/5: [/11 - ]; tight)]
-           │    ├── variable: abc.a:5 [type=int]
-           │    └── const: 10 [type=int]
-           └── eq [type=bool, outer=(5,7), constraints=(/5: (/NULL - ]; /7: (/NULL - ]), fd=(5)==(7), (7)==(5)]
-                ├── variable: abc.a:5 [type=int]
-                └── variable: abc.c:7 [type=int]
+ │    │    ├── fd: (1)-->(2), (1)==(3), (3)==(1)
+ │    │    ├── prune: (2)
+ │    │    ├── interesting orderings: (+(1|3))
+ │    │    ├── scan abc
+ │    │    │    ├── columns: abc.a:1(int!null) abc.b:2(int) abc.c:3(int)
+ │    │    │    ├── key: (1)
+ │    │    │    ├── fd: (1)-->(2,3)
+ │    │    │    ├── prune: (1-3)
+ │    │    │    └── interesting orderings: (+1)
+ │    │    └── filters
+ │    │         ├── gt [type=bool, outer=(1), constraints=(/1: [/1 - ]; tight)]
+ │    │         │    ├── variable: abc.a:1 [type=int]
+ │    │         │    └── const: 0 [type=int]
+ │    │         └── eq [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+ │    │              ├── variable: abc.a:1 [type=int]
+ │    │              └── variable: abc.c:3 [type=int]
+ │    └── select
+ │         ├── columns: abc.a:5(int!null) abc.b:6(int) abc.c:7(int!null)
+ │         ├── key: (5)
+ │         ├── fd: (5)-->(6), (5)==(7), (7)==(5)
+ │         ├── prune: (6)
+ │         ├── interesting orderings: (+(5|7))
+ │         ├── scan abc
+ │         │    ├── columns: abc.a:5(int!null) abc.b:6(int) abc.c:7(int)
+ │         │    ├── key: (5)
+ │         │    ├── fd: (5)-->(6,7)
+ │         │    ├── prune: (5-7)
+ │         │    └── interesting orderings: (+5)
+ │         └── filters
+ │              ├── gt [type=bool, outer=(5), constraints=(/5: [/11 - ]; tight)]
+ │              │    ├── variable: abc.a:5 [type=int]
+ │              │    └── const: 10 [type=int]
+ │              └── eq [type=bool, outer=(5,7), constraints=(/5: (/NULL - ]; /7: (/NULL - ]), fd=(5)==(7), (7)==(5)]
+ │                   ├── variable: abc.a:5 [type=int]
+ │                   └── variable: abc.c:7 [type=int]
+ └── aggregations
+      ├── const-agg [as=b:10, type=int, outer=(10)]
+      │    └── variable: b:10 [type=int]
+      └── const-agg [as=c:11, type=int, outer=(11)]
+           └── variable: c:11 [type=int]
 
 # Do not include equivalencies from only the left or right input.
 norm
@@ -411,50 +422,61 @@ SELECT a, b, c FROM abc WHERE a > 0 AND a = c
 UNION
 SELECT a, b, c FROM abc WHERE a > 10 AND a = b
 ----
-union
+distinct-on
  ├── columns: a:9(int!null) b:10(int) c:11(int)
- ├── left columns: abc.a:1(int) abc.b:2(int) abc.c:3(int)
- ├── right columns: abc.a:5(int) abc.b:6(int) abc.c:7(int)
- ├── key: (9-11)
- ├── interesting orderings: (+9)
- ├── select
- │    ├── columns: abc.a:1(int!null) abc.b:2(int) abc.c:3(int!null)
- │    ├── key: (1)
- │    ├── fd: (1)-->(2), (1)==(3), (3)==(1)
- │    ├── prune: (2)
- │    ├── interesting orderings: (+(1|3))
- │    ├── scan abc
- │    │    ├── columns: abc.a:1(int!null) abc.b:2(int) abc.c:3(int)
+ ├── grouping columns: a:9(int!null)
+ ├── key: (9)
+ ├── fd: (9)-->(10,11)
+ ├── prune: (10,11)
+ ├── union-all
+ │    ├── columns: a:9(int!null) b:10(int) c:11(int)
+ │    ├── left columns: abc.a:1(int) abc.b:2(int) abc.c:3(int)
+ │    ├── right columns: abc.a:5(int) abc.b:6(int) abc.c:7(int)
+ │    ├── prune: (10,11)
+ │    ├── interesting orderings: (+9)
+ │    ├── select
+ │    │    ├── columns: abc.a:1(int!null) abc.b:2(int) abc.c:3(int!null)
  │    │    ├── key: (1)
- │    │    ├── fd: (1)-->(2,3)
- │    │    ├── prune: (1-3)
- │    │    └── interesting orderings: (+1)
- │    └── filters
- │         ├── gt [type=bool, outer=(1), constraints=(/1: [/1 - ]; tight)]
- │         │    ├── variable: abc.a:1 [type=int]
- │         │    └── const: 0 [type=int]
- │         └── eq [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
- │              ├── variable: abc.a:1 [type=int]
- │              └── variable: abc.c:3 [type=int]
- └── select
-      ├── columns: abc.a:5(int!null) abc.b:6(int!null) abc.c:7(int)
-      ├── key: (5)
-      ├── fd: (5)-->(7), (5)==(6), (6)==(5)
-      ├── prune: (7)
-      ├── interesting orderings: (+(5|6))
-      ├── scan abc
-      │    ├── columns: abc.a:5(int!null) abc.b:6(int) abc.c:7(int)
-      │    ├── key: (5)
-      │    ├── fd: (5)-->(6,7)
-      │    ├── prune: (5-7)
-      │    └── interesting orderings: (+5)
-      └── filters
-           ├── gt [type=bool, outer=(5), constraints=(/5: [/11 - ]; tight)]
-           │    ├── variable: abc.a:5 [type=int]
-           │    └── const: 10 [type=int]
-           └── eq [type=bool, outer=(5,6), constraints=(/5: (/NULL - ]; /6: (/NULL - ]), fd=(5)==(6), (6)==(5)]
-                ├── variable: abc.a:5 [type=int]
-                └── variable: abc.b:6 [type=int]
+ │    │    ├── fd: (1)-->(2), (1)==(3), (3)==(1)
+ │    │    ├── prune: (2)
+ │    │    ├── interesting orderings: (+(1|3))
+ │    │    ├── scan abc
+ │    │    │    ├── columns: abc.a:1(int!null) abc.b:2(int) abc.c:3(int)
+ │    │    │    ├── key: (1)
+ │    │    │    ├── fd: (1)-->(2,3)
+ │    │    │    ├── prune: (1-3)
+ │    │    │    └── interesting orderings: (+1)
+ │    │    └── filters
+ │    │         ├── gt [type=bool, outer=(1), constraints=(/1: [/1 - ]; tight)]
+ │    │         │    ├── variable: abc.a:1 [type=int]
+ │    │         │    └── const: 0 [type=int]
+ │    │         └── eq [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+ │    │              ├── variable: abc.a:1 [type=int]
+ │    │              └── variable: abc.c:3 [type=int]
+ │    └── select
+ │         ├── columns: abc.a:5(int!null) abc.b:6(int!null) abc.c:7(int)
+ │         ├── key: (5)
+ │         ├── fd: (5)-->(7), (5)==(6), (6)==(5)
+ │         ├── prune: (7)
+ │         ├── interesting orderings: (+(5|6))
+ │         ├── scan abc
+ │         │    ├── columns: abc.a:5(int!null) abc.b:6(int) abc.c:7(int)
+ │         │    ├── key: (5)
+ │         │    ├── fd: (5)-->(6,7)
+ │         │    ├── prune: (5-7)
+ │         │    └── interesting orderings: (+5)
+ │         └── filters
+ │              ├── gt [type=bool, outer=(5), constraints=(/5: [/11 - ]; tight)]
+ │              │    ├── variable: abc.a:5 [type=int]
+ │              │    └── const: 10 [type=int]
+ │              └── eq [type=bool, outer=(5,6), constraints=(/5: (/NULL - ]; /6: (/NULL - ]), fd=(5)==(6), (6)==(5)]
+ │                   ├── variable: abc.a:5 [type=int]
+ │                   └── variable: abc.b:6 [type=int]
+ └── aggregations
+      ├── const-agg [as=b:10, type=int, outer=(10)]
+      │    └── variable: b:10 [type=int]
+      └── const-agg [as=c:11, type=int, outer=(11)]
+           └── variable: c:11 [type=int]
 
 # Intersect FDs include equivalencies for columns that have equivalencies in the
 # left input.

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -425,7 +425,7 @@ func (md *Metadata) DuplicateTable(
 		col := tab.Column(i)
 		oldColID := tabID.ColumnID(i)
 		newColID := md.AddColumn(string(col.ColName()), col.DatumType())
-		md.ColumnMeta(newColID).Table = tabID
+		md.ColumnMeta(newColID).Table = newTabID
 		colMap.Set(int(oldColID), int(newColID))
 	}
 

--- a/pkg/sql/opt/metadata_test.go
+++ b/pkg/sql/opt/metadata_test.go
@@ -337,6 +337,16 @@ func TestDuplicateTable(t *testing.T) {
 		t.Fatalf("expected partial index predicates to be duplicated")
 	}
 
+	colMeta := md.ColumnMeta(dupB)
+	if colMeta.Table != dupA {
+		t.Fatalf("expected new column to reference new table ID")
+	}
+
+	colMeta = md.ColumnMeta(dupB2)
+	if colMeta.Table != dupA {
+		t.Fatalf("expected new column to reference new table ID")
+	}
+
 	col = pred.(*memo.VariableExpr).Col
 	if col == b {
 		t.Errorf("expected partial index predicate to reference new column ID %d, got %d", dupB, col)

--- a/pkg/sql/opt/norm/rules/set.opt
+++ b/pkg/sql/opt/norm/rules/set.opt
@@ -61,3 +61,68 @@
     []
     (MakeGrouping (OutputCols $project) (EmptyOrdering))
 )
+
+# ConvertUnionToDistinctUnionAll replaces a Union with a DistinctOn on top of a
+# UnionAll when the left and right inputs satisfy the following conditions:
+#
+#    1) All columns from both inputs originate from the same base table. This is
+#       necessary because it is safe to de-duplicate over a subset of columns
+#       that form a key over the base table (assuming condition #2 is also
+#       satisfied).
+#
+#    2) All columns from a given side originate from the same meta table. This
+#       avoids cases where joins reuse the same ColumnIDs but add nulls or mix
+#       columns from different subqueries on the same table.
+#
+#    3) Each pair of columns whose rows are unioned together occupy the same
+#       ordinal positions in the original base table. This ensures that the
+#       output (and inputs) of the UnionAll only contains tuples that existed in
+#       the base table (though it may contain duplicates).
+#
+#    4) The output columns of each of the inputs form a strict key over the base
+#       table. It is not sufficient to use keys directly from the input
+#       expressions because the keys from the input expressions may have dropped
+#       columns due to filtering, when those columns may be necessary to
+#       distinguish rows resulting from the union. Ex: union together the same
+#       (single) row, for which the empty set is a key.
+#
+#    5) Finally, the key columns must form a strict subset of the union columns.
+#       This is not strictly necessary for correctness, but the transformation
+#       does not gain anything if the number of columns to de-duplicate on does
+#       not decrease.
+#
+# The above conditions ensure that the DistinctOn-UnionAll complex is equivalent
+# to the original Union. This transformation allows less comparisons to be made
+# in de-duplicating the rows, which can add up to significant speedups when rows
+# are wide. Cases like this one can be produced by rules like SplitDisjunction
+# and SplitScanIntoUnionScans, which produce a Union over a series of scans over
+# the same table.
+[ConvertUnionToDistinctUnionAll, Normalize]
+(Union
+    $left:*
+    $right:*
+    $private:(SetPrivate $leftCols:* $rightCols:* $outCols:*) &
+        (Let
+            ($keyCols $ok):(CanConvertUnionToDistinctUnionAll
+                $leftCols
+                $rightCols
+            )
+            $ok
+        )
+)
+=>
+(DistinctOn
+    (UnionAll $left $right $private)
+    (MakeAggCols
+        ConstAgg
+        (TranslateColSet
+            (DifferenceCols (OutputCols $left) $keyCols)
+            $leftCols
+            $outCols
+        )
+    )
+    (MakeGrouping
+        (TranslateColSet $keyCols $leftCols $outCols)
+        (EmptyOrdering)
+    )
+)

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -599,7 +599,7 @@ project
 # --------------------------------------------------
 # EliminateGroupByProject
 # --------------------------------------------------
-norm expect=EliminateGroupByProject
+norm expect=EliminateGroupByProject disable=ConvertUnionToDistinctUnionAll
 SELECT min(s) FROM (SELECT i, s FROM (SELECT * FROM a UNION SELECT * FROM a)) GROUP BY i
 ----
 project
@@ -627,7 +627,7 @@ project
                 └── s:16
 
 # ScalarGroupBy case.
-norm expect=EliminateGroupByProject
+norm expect=EliminateGroupByProject disable=ConvertUnionToDistinctUnionAll
 SELECT min(s) FROM (SELECT i, s FROM (SELECT * FROM a UNION SELECT * FROM a))
 ----
 scalar-group-by
@@ -653,7 +653,7 @@ scalar-group-by
            └── s:16
 
 # DistinctOn case.
-norm expect=EliminateGroupByProject
+norm expect=EliminateGroupByProject disable=ConvertUnionToDistinctUnionAll
 SELECT DISTINCT ON (i) s FROM (SELECT i, s, f FROM (SELECT * FROM a UNION SELECT * FROM a))
 ----
 distinct-on

--- a/pkg/sql/opt/norm/testdata/rules/set
+++ b/pkg/sql/opt/norm/testdata/rules/set
@@ -6,6 +6,22 @@ exec-ddl
 CREATE TABLE a (v INT PRIMARY KEY, w INT, x FLOAT, y STRING NOT NULL, z JSON)
 ----
 
+exec-ddl
+CREATE TABLE t (a INT PRIMARY KEY, b INT, c INT)
+----
+
+exec-ddl
+CREATE TABLE t2 (
+  a INT,
+  b INT,
+  c INT NOT NULL,
+  d INT,
+  PRIMARY KEY(a, b),
+  UNIQUE INDEX (c),
+  UNIQUE INDEX (d)
+)
+----
+
 # --------------------------------------------------
 # EliminateUnionAllLeft
 # --------------------------------------------------
@@ -105,3 +121,747 @@ values
  ├── cardinality: [0 - 0]
  ├── key: ()
  └── fd: ()-->(13)
+
+# -------------------------------------------------
+# ConvertUnionToDistinctUnionAll
+# -------------------------------------------------
+
+norm expect=ConvertUnionToDistinctUnionAll
+SELECT a, b, c FROM
+  (SELECT a, b, c FROM t WHERE a < 0)
+UNION
+  (SELECT a, b, c FROM t WHERE b > 10)
+----
+distinct-on
+ ├── columns: a:9!null b:10 c:11
+ ├── grouping columns: a:9!null
+ ├── key: (9)
+ ├── fd: (9)-->(10,11)
+ ├── union-all
+ │    ├── columns: a:9!null b:10 c:11
+ │    ├── left columns: t.a:1 t.b:2 t.c:3
+ │    ├── right columns: t.a:5 t.b:6 t.c:7
+ │    ├── select
+ │    │    ├── columns: t.a:1!null t.b:2 t.c:3
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2,3)
+ │    │    ├── scan t
+ │    │    │    ├── columns: t.a:1!null t.b:2 t.c:3
+ │    │    │    ├── key: (1)
+ │    │    │    └── fd: (1)-->(2,3)
+ │    │    └── filters
+ │    │         └── t.a:1 < 0 [outer=(1), constraints=(/1: (/NULL - /-1]; tight)]
+ │    └── select
+ │         ├── columns: t.a:5!null t.b:6!null t.c:7
+ │         ├── key: (5)
+ │         ├── fd: (5)-->(6,7)
+ │         ├── scan t
+ │         │    ├── columns: t.a:5!null t.b:6 t.c:7
+ │         │    ├── key: (5)
+ │         │    └── fd: (5)-->(6,7)
+ │         └── filters
+ │              └── t.b:6 > 10 [outer=(6), constraints=(/6: [/11 - ]; tight)]
+ └── aggregations
+      ├── const-agg [as=b:10, outer=(10)]
+      │    └── b:10
+      └── const-agg [as=c:11, outer=(11)]
+           └── c:11
+
+# Case with union between three same-table scans. The rule doesn't match on the
+# outer Union because the inner Union's output columns do not have an associated
+# meta table.
+norm expect=ConvertUnionToDistinctUnionAll
+SELECT a, b, c FROM
+  (SELECT a, b, c FROM t WHERE a < 0)
+UNION
+  (SELECT a, b, c FROM t WHERE b > 10 AND b < 100)
+UNION
+  (SELECT a, b, c FROM t WHERE b > 1000)
+----
+union
+ ├── columns: a:16!null b:17 c:18
+ ├── left columns: a:9 b:10 c:11
+ ├── right columns: t.a:12 t.b:13 t.c:14
+ ├── key: (16-18)
+ ├── distinct-on
+ │    ├── columns: a:9!null b:10 c:11
+ │    ├── grouping columns: a:9!null
+ │    ├── key: (9)
+ │    ├── fd: (9)-->(10,11)
+ │    ├── union-all
+ │    │    ├── columns: a:9!null b:10 c:11
+ │    │    ├── left columns: t.a:1 t.b:2 t.c:3
+ │    │    ├── right columns: t.a:5 t.b:6 t.c:7
+ │    │    ├── select
+ │    │    │    ├── columns: t.a:1!null t.b:2 t.c:3
+ │    │    │    ├── key: (1)
+ │    │    │    ├── fd: (1)-->(2,3)
+ │    │    │    ├── scan t
+ │    │    │    │    ├── columns: t.a:1!null t.b:2 t.c:3
+ │    │    │    │    ├── key: (1)
+ │    │    │    │    └── fd: (1)-->(2,3)
+ │    │    │    └── filters
+ │    │    │         └── t.a:1 < 0 [outer=(1), constraints=(/1: (/NULL - /-1]; tight)]
+ │    │    └── select
+ │    │         ├── columns: t.a:5!null t.b:6!null t.c:7
+ │    │         ├── key: (5)
+ │    │         ├── fd: (5)-->(6,7)
+ │    │         ├── scan t
+ │    │         │    ├── columns: t.a:5!null t.b:6 t.c:7
+ │    │         │    ├── key: (5)
+ │    │         │    └── fd: (5)-->(6,7)
+ │    │         └── filters
+ │    │              └── (t.b:6 > 10) AND (t.b:6 < 100) [outer=(6), constraints=(/6: [/11 - /99]; tight)]
+ │    └── aggregations
+ │         ├── const-agg [as=b:10, outer=(10)]
+ │         │    └── b:10
+ │         └── const-agg [as=c:11, outer=(11)]
+ │              └── c:11
+ └── select
+      ├── columns: t.a:12!null t.b:13!null t.c:14
+      ├── key: (12)
+      ├── fd: (12)-->(13,14)
+      ├── scan t
+      │    ├── columns: t.a:12!null t.b:13 t.c:14
+      │    ├── key: (12)
+      │    └── fd: (12)-->(13,14)
+      └── filters
+           └── t.b:13 > 1000 [outer=(13), constraints=(/13: [/1001 - ]; tight)]
+
+# The DistinctOn should group on the entire primary key (a, b) instead of just
+# on column b, otherwise extra rows will be removed.
+norm expect=ConvertUnionToDistinctUnionAll
+SELECT a, b, d FROM
+  (SELECT a, b, d FROM t2 WHERE a = 1)
+UNION
+  (SELECT a, b, d FROM t2 WHERE a = 2)
+----
+distinct-on
+ ├── columns: a:11!null b:12!null d:13
+ ├── grouping columns: a:11!null b:12!null
+ ├── key: (11,12)
+ ├── fd: (11,12)-->(13)
+ ├── union-all
+ │    ├── columns: a:11!null b:12!null d:13
+ │    ├── left columns: t2.a:1 t2.b:2 t2.d:4
+ │    ├── right columns: t2.a:6 t2.b:7 t2.d:9
+ │    ├── select
+ │    │    ├── columns: t2.a:1!null t2.b:2!null t2.d:4
+ │    │    ├── key: (2)
+ │    │    ├── fd: ()-->(1), (2)-->(4), (4)~~>(2)
+ │    │    ├── scan t2
+ │    │    │    ├── columns: t2.a:1!null t2.b:2!null t2.d:4
+ │    │    │    ├── key: (1,2)
+ │    │    │    └── fd: (1,2)-->(4), (4)~~>(1,2)
+ │    │    └── filters
+ │    │         └── t2.a:1 = 1 [outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
+ │    └── select
+ │         ├── columns: t2.a:6!null t2.b:7!null t2.d:9
+ │         ├── key: (7)
+ │         ├── fd: ()-->(6), (7)-->(9), (9)~~>(7)
+ │         ├── scan t2
+ │         │    ├── columns: t2.a:6!null t2.b:7!null t2.d:9
+ │         │    ├── key: (6,7)
+ │         │    └── fd: (6,7)-->(9), (9)~~>(6,7)
+ │         └── filters
+ │              └── t2.a:6 = 2 [outer=(6), constraints=(/6: [/2 - /2]; tight), fd=()-->(6)]
+ └── aggregations
+      └── const-agg [as=d:13, outer=(13)]
+           └── d:13
+
+# Case where the inputs have empty keys. Should group on the entire primary
+# key nevertheless.
+norm expect=ConvertUnionToDistinctUnionAll
+SELECT a, b, d FROM
+  (SELECT a, b, d FROM t2 LIMIT 1)
+UNION
+  (SELECT a, b, d FROM t2 LIMIT 1)
+----
+distinct-on
+ ├── columns: a:11!null b:12!null d:13
+ ├── grouping columns: a:11!null b:12!null
+ ├── cardinality: [0 - 2]
+ ├── key: (11,12)
+ ├── fd: (11,12)-->(13)
+ ├── union-all
+ │    ├── columns: a:11!null b:12!null d:13
+ │    ├── left columns: t2.a:1 t2.b:2 t2.d:4
+ │    ├── right columns: t2.a:6 t2.b:7 t2.d:9
+ │    ├── cardinality: [0 - 2]
+ │    ├── limit
+ │    │    ├── columns: t2.a:1!null t2.b:2!null t2.d:4
+ │    │    ├── cardinality: [0 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(1,2,4)
+ │    │    ├── scan t2
+ │    │    │    ├── columns: t2.a:1!null t2.b:2!null t2.d:4
+ │    │    │    ├── key: (1,2)
+ │    │    │    ├── fd: (1,2)-->(4), (4)~~>(1,2)
+ │    │    │    └── limit hint: 1.00
+ │    │    └── 1
+ │    └── limit
+ │         ├── columns: t2.a:6!null t2.b:7!null t2.d:9
+ │         ├── cardinality: [0 - 1]
+ │         ├── key: ()
+ │         ├── fd: ()-->(6,7,9)
+ │         ├── scan t2
+ │         │    ├── columns: t2.a:6!null t2.b:7!null t2.d:9
+ │         │    ├── key: (6,7)
+ │         │    ├── fd: (6,7)-->(9), (9)~~>(6,7)
+ │         │    └── limit hint: 1.00
+ │         └── 1
+ └── aggregations
+      └── const-agg [as=d:13, outer=(13)]
+           └── d:13
+
+# Case where a secondary index key is used for the grouping.
+norm expect=ConvertUnionToDistinctUnionAll
+SELECT c, d FROM
+  (SELECT c, d FROM t2 LIMIT 1)
+UNION
+  (SELECT c, d FROM t2 WHERE a = 1)
+----
+distinct-on
+ ├── columns: c:11!null d:12
+ ├── grouping columns: c:11!null
+ ├── key: (11)
+ ├── fd: (11)-->(12)
+ ├── union-all
+ │    ├── columns: c:11!null d:12
+ │    ├── left columns: t2.c:3 t2.d:4
+ │    ├── right columns: t2.c:8 t2.d:9
+ │    ├── limit
+ │    │    ├── columns: t2.c:3!null t2.d:4
+ │    │    ├── cardinality: [0 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(3,4)
+ │    │    ├── scan t2
+ │    │    │    ├── columns: t2.c:3!null t2.d:4
+ │    │    │    ├── key: (3)
+ │    │    │    ├── fd: (3)-->(4), (4)~~>(3)
+ │    │    │    └── limit hint: 1.00
+ │    │    └── 1
+ │    └── project
+ │         ├── columns: t2.c:8!null t2.d:9
+ │         ├── key: (8)
+ │         ├── fd: (8)-->(9), (9)~~>(8)
+ │         └── select
+ │              ├── columns: a:6!null t2.c:8!null t2.d:9
+ │              ├── key: (8)
+ │              ├── fd: ()-->(6), (8)-->(9), (9)~~>(8)
+ │              ├── scan t2
+ │              │    ├── columns: a:6!null t2.c:8!null t2.d:9
+ │              │    ├── key: (8)
+ │              │    └── fd: (8)-->(6,9), (9)~~>(6,8)
+ │              └── filters
+ │                   └── a:6 = 1 [outer=(6), constraints=(/6: [/1 - /1]; tight), fd=()-->(6)]
+ └── aggregations
+      └── const-agg [as=d:12, outer=(12)]
+           └── d:12
+
+# Case where the left columns are null-extended (all columns filled with null
+# values for null-extended rows). This is ok because grouping on any
+# null-extended column has the same effect as grouping on all of them for the
+# null rows - they all get grouped together.
+norm expect=ConvertUnionToDistinctUnionAll
+SELECT a, b, c FROM
+  (SELECT a, b, c FROM
+    (SELECT * FROM t
+      FULL JOIN (VALUES (1), (2))
+      ON False
+    )
+  )
+UNION
+  (SELECT a, b, c FROM t WHERE b > 10)
+----
+distinct-on
+ ├── columns: a:10 b:11 c:12
+ ├── grouping columns: a:10
+ ├── cardinality: [1 - ]
+ ├── key: (10)
+ ├── fd: (10)-->(11,12)
+ ├── union-all
+ │    ├── columns: a:10 b:11 c:12
+ │    ├── left columns: t.a:1 t.b:2 t.c:3
+ │    ├── right columns: t.a:6 t.b:7 t.c:8
+ │    ├── cardinality: [2 - ]
+ │    ├── full-join (cross)
+ │    │    ├── columns: t.a:1 t.b:2 t.c:3
+ │    │    ├── cardinality: [2 - ]
+ │    │    ├── fd: (1)-->(2,3)
+ │    │    ├── scan t
+ │    │    │    ├── columns: t.a:1!null t.b:2 t.c:3
+ │    │    │    ├── key: (1)
+ │    │    │    └── fd: (1)-->(2,3)
+ │    │    ├── values
+ │    │    │    ├── cardinality: [2 - 2]
+ │    │    │    ├── ()
+ │    │    │    └── ()
+ │    │    └── filters
+ │    │         └── false [constraints=(contradiction; tight)]
+ │    └── select
+ │         ├── columns: t.a:6!null t.b:7!null t.c:8
+ │         ├── key: (6)
+ │         ├── fd: (6)-->(7,8)
+ │         ├── scan t
+ │         │    ├── columns: t.a:6!null t.b:7 t.c:8
+ │         │    ├── key: (6)
+ │         │    └── fd: (6)-->(7,8)
+ │         └── filters
+ │              └── t.b:7 > 10 [outer=(7), constraints=(/7: [/11 - ]; tight)]
+ └── aggregations
+      ├── const-agg [as=b:11, outer=(11)]
+      │    └── b:11
+      └── const-agg [as=c:12, outer=(12)]
+           └── c:12
+
+# Case where the right columns are null-extended.
+norm expect=ConvertUnionToDistinctUnionAll
+SELECT a, b, c FROM
+  (SELECT a, b, c FROM t WHERE b > 10)
+UNION
+  (SELECT a, b, c FROM
+    (SELECT * FROM t
+      FULL JOIN (VALUES (1), (2))
+      ON False
+    )
+  )
+----
+distinct-on
+ ├── columns: a:10 b:11 c:12
+ ├── grouping columns: a:10
+ ├── cardinality: [1 - ]
+ ├── key: (10)
+ ├── fd: (10)-->(11,12)
+ ├── union-all
+ │    ├── columns: a:10 b:11 c:12
+ │    ├── left columns: t.a:1 t.b:2 t.c:3
+ │    ├── right columns: t.a:5 t.b:6 t.c:7
+ │    ├── cardinality: [2 - ]
+ │    ├── select
+ │    │    ├── columns: t.a:1!null t.b:2!null t.c:3
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2,3)
+ │    │    ├── scan t
+ │    │    │    ├── columns: t.a:1!null t.b:2 t.c:3
+ │    │    │    ├── key: (1)
+ │    │    │    └── fd: (1)-->(2,3)
+ │    │    └── filters
+ │    │         └── t.b:2 > 10 [outer=(2), constraints=(/2: [/11 - ]; tight)]
+ │    └── full-join (cross)
+ │         ├── columns: t.a:5 t.b:6 t.c:7
+ │         ├── cardinality: [2 - ]
+ │         ├── fd: (5)-->(6,7)
+ │         ├── scan t
+ │         │    ├── columns: t.a:5!null t.b:6 t.c:7
+ │         │    ├── key: (5)
+ │         │    └── fd: (5)-->(6,7)
+ │         ├── values
+ │         │    ├── cardinality: [2 - 2]
+ │         │    ├── ()
+ │         │    └── ()
+ │         └── filters
+ │              └── false [constraints=(contradiction; tight)]
+ └── aggregations
+      ├── const-agg [as=b:11, outer=(11)]
+      │    └── b:11
+      └── const-agg [as=c:12, outer=(12)]
+           └── c:12
+
+# Case where the left columns are duplicated. This is ok because there are no
+# tuples that did not exist in the base table, meaning it is ok to group on a
+# set of columns that form a key over the base table.
+norm expect=ConvertUnionToDistinctUnionAll
+SELECT a, b, c FROM
+  (SELECT a, b, c FROM
+    (SELECT * FROM t
+      INNER JOIN (VALUES (1), (2))
+      ON True
+    )
+  )
+UNION
+  (SELECT a, b, c FROM t WHERE b > 10)
+----
+distinct-on
+ ├── columns: a:10!null b:11 c:12
+ ├── grouping columns: a:10!null
+ ├── key: (10)
+ ├── fd: (10)-->(11,12)
+ ├── union-all
+ │    ├── columns: a:10!null b:11 c:12
+ │    ├── left columns: t.a:1 t.b:2 t.c:3
+ │    ├── right columns: t.a:6 t.b:7 t.c:8
+ │    ├── inner-join (cross)
+ │    │    ├── columns: t.a:1!null t.b:2 t.c:3
+ │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
+ │    │    ├── fd: (1)-->(2,3)
+ │    │    ├── scan t
+ │    │    │    ├── columns: t.a:1!null t.b:2 t.c:3
+ │    │    │    ├── key: (1)
+ │    │    │    └── fd: (1)-->(2,3)
+ │    │    ├── values
+ │    │    │    ├── cardinality: [2 - 2]
+ │    │    │    ├── ()
+ │    │    │    └── ()
+ │    │    └── filters (true)
+ │    └── select
+ │         ├── columns: t.a:6!null t.b:7!null t.c:8
+ │         ├── key: (6)
+ │         ├── fd: (6)-->(7,8)
+ │         ├── scan t
+ │         │    ├── columns: t.a:6!null t.b:7 t.c:8
+ │         │    ├── key: (6)
+ │         │    └── fd: (6)-->(7,8)
+ │         └── filters
+ │              └── t.b:7 > 10 [outer=(7), constraints=(/7: [/11 - ]; tight)]
+ └── aggregations
+      ├── const-agg [as=b:11, outer=(11)]
+      │    └── b:11
+      └── const-agg [as=c:12, outer=(12)]
+           └── c:12
+
+# Case where the right columns are duplicated. This is ok because there are no
+# tuples that did not exist in the base table, meaning it is ok to group on a
+# set of columns that form a key over the base table.
+norm expect=ConvertUnionToDistinctUnionAll
+SELECT a, b, c FROM
+  (SELECT a, b, c FROM t WHERE b > 10)
+UNION
+  (SELECT a, b, c FROM
+    (SELECT * FROM t
+      INNER JOIN (VALUES (1), (2))
+      ON True
+    )
+  )
+----
+distinct-on
+ ├── columns: a:10!null b:11 c:12
+ ├── grouping columns: a:10!null
+ ├── key: (10)
+ ├── fd: (10)-->(11,12)
+ ├── union-all
+ │    ├── columns: a:10!null b:11 c:12
+ │    ├── left columns: t.a:1 t.b:2 t.c:3
+ │    ├── right columns: t.a:5 t.b:6 t.c:7
+ │    ├── select
+ │    │    ├── columns: t.a:1!null t.b:2!null t.c:3
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2,3)
+ │    │    ├── scan t
+ │    │    │    ├── columns: t.a:1!null t.b:2 t.c:3
+ │    │    │    ├── key: (1)
+ │    │    │    └── fd: (1)-->(2,3)
+ │    │    └── filters
+ │    │         └── t.b:2 > 10 [outer=(2), constraints=(/2: [/11 - ]; tight)]
+ │    └── inner-join (cross)
+ │         ├── columns: t.a:5!null t.b:6 t.c:7
+ │         ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
+ │         ├── fd: (5)-->(6,7)
+ │         ├── scan t
+ │         │    ├── columns: t.a:5!null t.b:6 t.c:7
+ │         │    ├── key: (5)
+ │         │    └── fd: (5)-->(6,7)
+ │         ├── values
+ │         │    ├── cardinality: [2 - 2]
+ │         │    ├── ()
+ │         │    └── ()
+ │         └── filters (true)
+ └── aggregations
+      ├── const-agg [as=b:11, outer=(11)]
+      │    └── b:11
+      └── const-agg [as=c:12, outer=(12)]
+           └── c:12
+
+# No-op case because there is no key.
+norm expect-not=ConvertUnionToDistinctUnionAll
+SELECT b, c FROM
+  (SELECT b, c FROM t WHERE c < 0)
+UNION
+  (SELECT b, c FROM t WHERE b > 10)
+----
+union
+ ├── columns: b:9 c:10
+ ├── left columns: t.b:2 t.c:3
+ ├── right columns: t.b:6 t.c:7
+ ├── key: (9,10)
+ ├── select
+ │    ├── columns: t.b:2 t.c:3!null
+ │    ├── scan t
+ │    │    └── columns: t.b:2 t.c:3
+ │    └── filters
+ │         └── t.c:3 < 0 [outer=(3), constraints=(/3: (/NULL - /-1]; tight)]
+ └── select
+      ├── columns: t.b:6!null t.c:7
+      ├── scan t
+      │    └── columns: t.b:6 t.c:7
+      └── filters
+           └── t.b:6 > 10 [outer=(6), constraints=(/6: [/11 - ]; tight)]
+
+# No-op case because of the projection.
+norm expect-not=ConvertUnionToDistinctUnionAll
+SELECT a, b, c FROM
+  (SELECT a, b, c FROM t WHERE a < 0)
+UNION
+  (SELECT a, b, c*2 FROM t WHERE b > 10)
+----
+union
+ ├── columns: a:10!null b:11 c:12
+ ├── left columns: t.a:1 t.b:2 t.c:3
+ ├── right columns: t.a:5 t.b:6 "?column?":9
+ ├── immutable
+ ├── key: (10-12)
+ ├── select
+ │    ├── columns: t.a:1!null t.b:2 t.c:3
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    ├── scan t
+ │    │    ├── columns: t.a:1!null t.b:2 t.c:3
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2,3)
+ │    └── filters
+ │         └── t.a:1 < 0 [outer=(1), constraints=(/1: (/NULL - /-1]; tight)]
+ └── project
+      ├── columns: "?column?":9 t.a:5!null t.b:6!null
+      ├── immutable
+      ├── key: (5)
+      ├── fd: (5)-->(6,9)
+      ├── select
+      │    ├── columns: t.a:5!null t.b:6!null t.c:7
+      │    ├── key: (5)
+      │    ├── fd: (5)-->(6,7)
+      │    ├── scan t
+      │    │    ├── columns: t.a:5!null t.b:6 t.c:7
+      │    │    ├── key: (5)
+      │    │    └── fd: (5)-->(6,7)
+      │    └── filters
+      │         └── t.b:6 > 10 [outer=(6), constraints=(/6: [/11 - ]; tight)]
+      └── projections
+           └── t.c:7 * 2 [as="?column?":9, outer=(7), immutable]
+
+# No-op case because the columns don't all have the same ordinal positions.
+norm expect-not=ConvertUnionToDistinctUnionAll
+SELECT a, b, c FROM
+  (SELECT a, b, c FROM t WHERE a < 0)
+UNION
+  (SELECT a, c, b FROM t WHERE b > 10)
+----
+union
+ ├── columns: a:9!null b:10 c:11
+ ├── left columns: t.a:1 t.b:2 t.c:3
+ ├── right columns: t.a:5 t.c:7 t.b:6
+ ├── key: (9-11)
+ ├── select
+ │    ├── columns: t.a:1!null t.b:2 t.c:3
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    ├── scan t
+ │    │    ├── columns: t.a:1!null t.b:2 t.c:3
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2,3)
+ │    └── filters
+ │         └── t.a:1 < 0 [outer=(1), constraints=(/1: (/NULL - /-1]; tight)]
+ └── select
+      ├── columns: t.a:5!null t.b:6!null t.c:7
+      ├── key: (5)
+      ├── fd: (5)-->(6,7)
+      ├── scan t
+      │    ├── columns: t.a:5!null t.b:6 t.c:7
+      │    ├── key: (5)
+      │    └── fd: (5)-->(6,7)
+      └── filters
+           └── t.b:6 > 10 [outer=(6), constraints=(/6: [/11 - ]; tight)]
+
+# No-op case because there is no base table.
+norm expect-not=ConvertUnionToDistinctUnionAll
+SELECT * FROM
+  (SELECT * FROM (VALUES (1, 1), (2, 1)))
+UNION
+  (SELECT * FROM (VALUES (1, 1), (2, 1)))
+----
+union
+ ├── columns: column1:5!null column2:6!null
+ ├── left columns: column1:1 column2:2
+ ├── right columns: column1:3 column2:4
+ ├── cardinality: [1 - 4]
+ ├── key: (5,6)
+ ├── values
+ │    ├── columns: column1:1!null column2:2!null
+ │    ├── cardinality: [2 - 2]
+ │    ├── (1, 1)
+ │    └── (2, 1)
+ └── values
+      ├── columns: column1:3!null column2:4!null
+      ├── cardinality: [2 - 2]
+      ├── (1, 1)
+      └── (2, 1)
+
+# No-op case because the index key is nullable.
+norm expect-not=ConvertUnionToDistinctUnionAll
+SELECT d FROM
+  (SELECT d FROM t2 LIMIT 1)
+UNION
+  (SELECT d FROM t2 WHERE a = 1)
+----
+union
+ ├── columns: d:11
+ ├── left columns: t2.d:4
+ ├── right columns: t2.d:9
+ ├── key: (11)
+ ├── limit
+ │    ├── columns: t2.d:4
+ │    ├── cardinality: [0 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(4)
+ │    ├── scan t2
+ │    │    ├── columns: t2.d:4
+ │    │    ├── lax-key: (4)
+ │    │    └── limit hint: 1.00
+ │    └── 1
+ └── project
+      ├── columns: t2.d:9
+      ├── lax-key: (9)
+      └── select
+           ├── columns: a:6!null t2.d:9
+           ├── lax-key: (9)
+           ├── fd: ()-->(6)
+           ├── scan t2
+           │    ├── columns: a:6!null t2.d:9
+           │    ├── lax-key: (6,9)
+           │    └── fd: (9)~~>(6)
+           └── filters
+                └── a:6 = 1 [outer=(6), constraints=(/6: [/1 - /1]; tight), fd=()-->(6)]
+
+# No-op case because the left side has columns from more than one meta table.
+norm expect-not=ConvertUnionToDistinctUnionAll
+SELECT a, b, c FROM
+  (SELECT t.a, t.b, foo.c FROM t FULL JOIN t as foo ON False)
+UNION
+  (SELECT a, b, c FROM t WHERE a > 10)
+----
+union
+ ├── columns: a:13 b:14 c:15
+ ├── left columns: t.a:1 t.b:2 foo.c:7
+ ├── right columns: t.a:9 t.b:10 t.c:11
+ ├── key: (13-15)
+ ├── full-join (cross)
+ │    ├── columns: t.a:1 t.b:2 foo.c:7
+ │    ├── fd: (1)-->(2)
+ │    ├── scan t
+ │    │    ├── columns: t.a:1!null t.b:2
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2)
+ │    ├── scan t [as=foo]
+ │    │    └── columns: foo.c:7
+ │    └── filters
+ │         └── false [constraints=(contradiction; tight)]
+ └── select
+      ├── columns: t.a:9!null t.b:10 t.c:11
+      ├── key: (9)
+      ├── fd: (9)-->(10,11)
+      ├── scan t
+      │    ├── columns: t.a:9!null t.b:10 t.c:11
+      │    ├── key: (9)
+      │    └── fd: (9)-->(10,11)
+      └── filters
+           └── t.a:9 > 10 [outer=(9), constraints=(/9: [/11 - ]; tight)]
+
+# No-op case because the right side has columns from more than one meta table.
+norm expect-not=ConvertUnionToDistinctUnionAll
+SELECT a, b, c FROM
+  (SELECT a, b, c FROM t WHERE a > 10)
+UNION
+  (SELECT t.a, t.b, foo.c FROM t FULL JOIN t as foo ON False)
+----
+union
+ ├── columns: a:13 b:14 c:15
+ ├── left columns: t.a:1 t.b:2 t.c:3
+ ├── right columns: t.a:5 t.b:6 foo.c:11
+ ├── key: (13-15)
+ ├── select
+ │    ├── columns: t.a:1!null t.b:2 t.c:3
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    ├── scan t
+ │    │    ├── columns: t.a:1!null t.b:2 t.c:3
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2,3)
+ │    └── filters
+ │         └── t.a:1 > 10 [outer=(1), constraints=(/1: [/11 - ]; tight)]
+ └── full-join (cross)
+      ├── columns: t.a:5 t.b:6 foo.c:11
+      ├── fd: (5)-->(6)
+      ├── scan t
+      │    ├── columns: t.a:5!null t.b:6
+      │    ├── key: (5)
+      │    └── fd: (5)-->(6)
+      ├── scan t [as=foo]
+      │    └── columns: foo.c:11
+      └── filters
+           └── false [constraints=(contradiction; tight)]
+
+# No-op case because the left and right columns come from different base tables.
+norm expect-not=ConvertUnionToDistinctUnionAll
+SELECT a, b, c FROM
+  (SELECT a, b, c FROM t WHERE a < 0)
+UNION
+  (SELECT a, b, c FROM t2 WHERE b > 10)
+----
+union
+ ├── columns: a:10!null b:11 c:12
+ ├── left columns: t.a:1 t.b:2 t.c:3
+ ├── right columns: t2.a:5 t2.b:6 t2.c:7
+ ├── key: (10-12)
+ ├── select
+ │    ├── columns: t.a:1!null t.b:2 t.c:3
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    ├── scan t
+ │    │    ├── columns: t.a:1!null t.b:2 t.c:3
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2,3)
+ │    └── filters
+ │         └── t.a:1 < 0 [outer=(1), constraints=(/1: (/NULL - /-1]; tight)]
+ └── select
+      ├── columns: t2.a:5!null t2.b:6!null t2.c:7!null
+      ├── key: (7)
+      ├── fd: (5,6)-->(7), (7)-->(5,6)
+      ├── scan t2
+      │    ├── columns: t2.a:5!null t2.b:6!null t2.c:7!null
+      │    ├── key: (7)
+      │    └── fd: (5,6)-->(7), (7)-->(5,6)
+      └── filters
+           └── t2.b:6 > 10 [outer=(6), constraints=(/6: [/11 - ]; tight)]
+
+# No-op case because the key columns are not a strict subset of the union cols.
+norm expect-not=ConvertUnionToDistinctUnionAll
+SELECT a FROM
+  (SELECT a FROM t WHERE a < 0)
+UNION
+  (SELECT a FROM t WHERE b > 10)
+----
+union
+ ├── columns: a:9!null
+ ├── left columns: t.a:1
+ ├── right columns: t.a:5
+ ├── key: (9)
+ ├── select
+ │    ├── columns: t.a:1!null
+ │    ├── key: (1)
+ │    ├── scan t
+ │    │    ├── columns: t.a:1!null
+ │    │    └── key: (1)
+ │    └── filters
+ │         └── t.a:1 < 0 [outer=(1), constraints=(/1: (/NULL - /-1]; tight)]
+ └── project
+      ├── columns: t.a:5!null
+      ├── key: (5)
+      └── select
+           ├── columns: t.a:5!null b:6!null
+           ├── key: (5)
+           ├── fd: (5)-->(6)
+           ├── scan t
+           │    ├── columns: t.a:5!null b:6
+           │    ├── key: (5)
+           │    └── fd: (5)-->(6)
+           └── filters
+                └── b:6 > 10 [outer=(6), constraints=(/6: [/11 - ]; tight)]

--- a/pkg/sql/opt/xform/rules/select.opt
+++ b/pkg/sql/opt/xform/rules/select.opt
@@ -214,53 +214,49 @@
 )
 =>
 (Project
-    (DistinctOn
-        (UnionAll
-            (Select
-                $leftScan:(Scan
-                    (AddPrimaryKeyColsToScanPrivate
-                        (DuplicateScanPrivate $scanPrivate)
-                    )
-                )
-                (MapFilterCols
-                    (ReplaceFiltersItem
-                        $filters
-                        $itemToReplace
-                        $leftFilter
-                    )
-                    $outCols:(UnionCols
-                        (OutputCols $input)
-                        $groupingCols:(PrimaryKeyCols
-                            (TableIDFromScanPrivate $scanPrivate)
-                        )
-                    )
-                    (OutputCols $leftScan)
+    (Union
+        (Select
+            $leftScan:(Scan
+                (AddPrimaryKeyColsToScanPrivate
+                    (DuplicateScanPrivate $scanPrivate)
                 )
             )
-            (Select
-                $rightScan:(Scan
-                    (AddPrimaryKeyColsToScanPrivate
-                        (DuplicateScanPrivate $scanPrivate)
+            (MapFilterCols
+                (ReplaceFiltersItem
+                    $filters
+                    $itemToReplace
+                    $leftFilter
+                )
+                $outCols:(UnionCols
+                    (OutputCols $input)
+                    (PrimaryKeyCols
+                        (TableIDFromScanPrivate $scanPrivate)
                     )
                 )
-                (MapFilterCols
-                    (ReplaceFiltersItem
-                        $filters
-                        $itemToReplace
-                        $rightFilter
-                    )
-                    $outCols
-                    (OutputCols $rightScan)
-                )
-            )
-            (MakeSetPrivate
                 (OutputCols $leftScan)
-                (OutputCols $rightScan)
-                $outCols
             )
         )
-        (MakeAggCols ConstAgg (OutputCols $input))
-        (MakeGrouping $groupingCols (EmptyOrdering))
+        (Select
+            $rightScan:(Scan
+                (AddPrimaryKeyColsToScanPrivate
+                    (DuplicateScanPrivate $scanPrivate)
+                )
+            )
+            (MapFilterCols
+                (ReplaceFiltersItem
+                    $filters
+                    $itemToReplace
+                    $rightFilter
+                )
+                $outCols
+                (OutputCols $rightScan)
+            )
+        )
+        (MakeSetPrivate
+            (OutputCols $leftScan)
+            (OutputCols $rightScan)
+            $outCols
+        )
     )
     []
     (OutputCols $input)

--- a/pkg/sql/opt/xform/testdata/physprops/limit_hint
+++ b/pkg/sql/opt/xform/testdata/physprops/limit_hint
@@ -86,7 +86,7 @@ limit
 # --------------------------------------------------
 
 opt
-SELECT * FROM (SELECT * FROM t UNION SELECT * from t) LIMIT 10
+SELECT * FROM (SELECT x, y, z FROM t UNION SELECT x, z, y from t) LIMIT 10
 ----
 limit
  ├── columns: x:9!null y:10 z:11
@@ -95,7 +95,7 @@ limit
  ├── union
  │    ├── columns: x:9!null y:10 z:11
  │    ├── left columns: t.x:1 t.y:2 t.z:3
- │    ├── right columns: t.x:5 t.y:6 t.z:7
+ │    ├── right columns: t.x:5 t.z:7 t.y:6
  │    ├── key: (9-11)
  │    ├── limit hint: 10.00
  │    ├── scan t

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -6975,6 +6975,69 @@ project
            └── const-agg [as=w:4, outer=(4)]
                 └── w:4
 
+# Apply when outer columns of both sides of OR are a superset of index columns.
+opt expect=SplitDisjunction
+SELECT k, u, v FROM d WHERE (u = 1 AND w = 2) OR (v = 1 AND w = 3)
+----
+project
+ ├── columns: k:1!null u:2 v:3
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ └── distinct-on
+      ├── columns: k:1!null u:2 v:3 w:4!null
+      ├── grouping columns: k:1!null
+      ├── internal-ordering: +1
+      ├── key: (1)
+      ├── fd: (1)-->(2-4)
+      ├── union-all
+      │    ├── columns: k:1!null u:2 v:3 w:4!null
+      │    ├── left columns: k:6 u:7 v:8 w:9
+      │    ├── right columns: k:11 u:12 v:13 w:14
+      │    ├── ordering: +1
+      │    ├── select
+      │    │    ├── columns: k:6!null u:7!null v:8 w:9!null
+      │    │    ├── key: (6)
+      │    │    ├── fd: ()-->(7,9), (6)-->(8)
+      │    │    ├── ordering: +6 opt(7,9) [actual: +6]
+      │    │    ├── index-join d
+      │    │    │    ├── columns: k:6!null u:7 v:8 w:9
+      │    │    │    ├── key: (6)
+      │    │    │    ├── fd: ()-->(7), (6)-->(8,9)
+      │    │    │    ├── ordering: +6 opt(7) [actual: +6]
+      │    │    │    └── scan d@u
+      │    │    │         ├── columns: k:6!null u:7!null
+      │    │    │         ├── constraint: /7/6: [/1 - /1]
+      │    │    │         ├── key: (6)
+      │    │    │         ├── fd: ()-->(7)
+      │    │    │         └── ordering: +6 opt(7) [actual: +6]
+      │    │    └── filters
+      │    │         └── w:9 = 2 [outer=(9), constraints=(/9: [/2 - /2]; tight), fd=()-->(9)]
+      │    └── select
+      │         ├── columns: k:11!null u:12 v:13!null w:14!null
+      │         ├── key: (11)
+      │         ├── fd: ()-->(13,14), (11)-->(12)
+      │         ├── ordering: +11 opt(13,14) [actual: +11]
+      │         ├── index-join d
+      │         │    ├── columns: k:11!null u:12 v:13 w:14
+      │         │    ├── key: (11)
+      │         │    ├── fd: ()-->(13), (11)-->(12,14)
+      │         │    ├── ordering: +11 opt(13) [actual: +11]
+      │         │    └── scan d@v
+      │         │         ├── columns: k:11!null v:13!null
+      │         │         ├── constraint: /13/11: [/1 - /1]
+      │         │         ├── key: (11)
+      │         │         ├── fd: ()-->(13)
+      │         │         └── ordering: +11 opt(13) [actual: +11]
+      │         └── filters
+      │              └── w:14 = 3 [outer=(14), constraints=(/14: [/3 - /3]; tight), fd=()-->(14)]
+      └── aggregations
+           ├── const-agg [as=u:2, outer=(2)]
+           │    └── u:2
+           ├── const-agg [as=v:3, outer=(3)]
+           │    └── v:3
+           └── const-agg [as=w:4, outer=(4)]
+                └── w:4
+
 # Group sub-expr with the same columns together.
 opt expect=SplitDisjunction
 SELECT k, u, v FROM d WHERE (u = 1 OR v = 2) OR (u = 3 OR v = 4)


### PR DESCRIPTION
This patch adds a normalization rule that transforms a `Union` into
a `DistinctOn` and a `UnionAll` under the following circumstances:
1) All columns from both inputs originate from the same base table.
2) All columns from a given side originate from the same meta table.
3) Each pair of columns whose rows are unioned together occupy the
   same ordinal positions in the original base table.
4) The output columns of each input form a strict key over the base
   table rows. A key from the base table is used for the `DistinctOn`
   grouping columns.
5) The candidate key forms a strict subset of the union columns. This
   is not necessary for correctness, but ensures that the transformation
   is worth making.

A `Union` operator has to perform de-duplication on all input columns.
This transformation allows only key columns to be considered when
de-duplicating, which can save a lot of time when rows are wide.
The above conditions are often satisfied when a rule such as
`SplitDisjunction` or `SplitScanIntoUnionScans` produces a `Union` over
a series of same-table scans.

Fixes #58745

Release note: None