### PR TITLE
ui: style fix of login password input

### DIFF
--- a/pkg/ui/src/components/input/input.styl
+++ b/pkg/ui/src/components/input/input.styl
@@ -61,3 +61,10 @@
     &--error-message
       color $colors--functional-red-3
       position absolute
+  &__password
+    font-family sans-serif
+    &[type="text"]
+      font-family $font-family--base
+    &::-webkit-credentials-auto-fill-button
+      position absolute
+      right 45px


### PR DESCRIPTION
before: on login screen on Safari is displaying Yen symbols
insteas of dots
<img width="934" alt="Screenshot 2021-05-11 at 12 55 54" src="https://user-images.githubusercontent.com/12850886/117799357-ae89cf80-b25a-11eb-81e6-b94d2dd453aa.png">

after: fixed issue above and in addition fixed position of key
button overlap with "view password" button
<img width="959" alt="Screenshot 2021-05-11 at 13 00 44" src="https://user-images.githubusercontent.com/12850886/117799406-bb0e2800-b25a-11eb-9efa-3924828cf511.png">

Resolves: #49386

Release note (ui): style fix of password input field for Safari
