### PR TITLE
changefeedccl: add test for sinkless changefeed on tenant

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -259,4 +259,8 @@ type TestTenantArgs struct {
 	// TempStorageConfig is used to configure temp storage, which stores
 	// ephemeral data when processing large queries.
 	TempStorageConfig *TempStorageConfig
+
+	// ExternalIODirConfig is used to initialize the same-named
+	// field on the server.Config struct.
+	ExternalIODirConfig ExternalIODirConfig
 }

--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -127,6 +127,7 @@ go_test(
         "//pkg/ccl/changefeedccl/changefeedbase",
         "//pkg/ccl/changefeedccl/kvfeed",
         "//pkg/ccl/importccl",
+        "//pkg/ccl/kvccl/kvtenantccl",
         "//pkg/ccl/multiregionccl",
         "//pkg/ccl/partitionccl",
         "//pkg/ccl/storageccl",

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -29,6 +29,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdctest"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
+	// Imported to allow multi-tenant tests
+	_ "github.com/cockroachdb/cockroach/pkg/ccl/kvccl/kvtenantccl"
 	// Imported to allow locality-related table mutations
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/multiregionccl"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/partitionccl"
@@ -207,6 +209,78 @@ func TestChangefeedDiff(t *testing.T) {
 	t.Run(`enterprise`, enterpriseTest(testFn))
 	t.Run(`cloudstorage`, cloudStorageTest(testFn))
 	t.Run(`kafka`, kafkaTest(testFn))
+}
+
+func TestChangefeedTenants(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	defer changefeedbase.TestingSetDefaultFlushFrequency(testSinkFlushFrequency)()
+
+	kvServer, kvSQLdb, _ := serverutils.StartServer(t, base.TestServerArgs{
+		ExternalIODirConfig: base.ExternalIODirConfig{
+			DisableOutbound: true,
+		},
+	})
+	defer kvServer.Stopper().Stop(ctx)
+
+	tenantArgs := base.TestTenantArgs{
+		// crdb_internal.create_tenant called by StartTenant
+		TenantID: serverutils.TestTenantID(),
+		// Non-enterprise changefeeds are currently only
+		// disabled by setting DisableOutbound true
+		// everywhere.
+		ExternalIODirConfig: base.ExternalIODirConfig{
+			DisableOutbound: true,
+		},
+	}
+
+	tenantServer, tenantDB := serverutils.StartTenant(t, kvServer, tenantArgs)
+	tenantSQL := sqlutils.MakeSQLRunner(tenantDB)
+	// TODO(ssd): Cleanup this shared setup code once the refactor
+	// in #64693 is setttled.
+	tenantSQL.Exec(t, `SET CLUSTER SETTING kv.rangefeed.enabled = true`)
+	tenantSQL.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'`)
+	tenantSQL.Exec(t, `SET CLUSTER SETTING changefeed.experimental_poll_interval = '10ms'`)
+
+	// Database `d` is hardcoded in a number of places. Create it
+	// and create a new connection to that database.
+	tenantSQL.Exec(t, `CREATE DATABASE d`)
+	tenantSQL = sqlutils.MakeSQLRunner(
+		serverutils.OpenDBConn(t,
+			tenantServer.SQLAddr(), `d`, false /* insecure */, kvServer.Stopper()))
+	tenantSQL.Exec(t, `CREATE TABLE foo_in_tenant (pk INT PRIMARY KEY)`)
+
+	t.Run("changefeed on non-tenant table fails", func(t *testing.T) {
+		kvSQL := sqlutils.MakeSQLRunner(kvSQLdb)
+		kvSQL.Exec(t, `CREATE DATABASE d`)
+		kvSQL.Exec(t, `CREATE TABLE d.foo (pk INT PRIMARY KEY)`)
+
+		tenantSQL.ExpectErr(t, `table "foo" does not exist`,
+			`CREATE CHANGEFEED FOR foo`,
+		)
+	})
+	t.Run("sinkful changefeed fails", func(t *testing.T) {
+		tenantSQL.ExpectErr(t, "Outbound IO is disabled by configuration, cannot create changefeed into kafka",
+			`CREATE CHANGEFEED FOR foo_in_tenant INTO 'kafka://does-not-matter'`,
+		)
+	})
+	t.Run("sinkless changefeed works", func(t *testing.T) {
+		sqlAddr := tenantServer.SQLAddr()
+		sink, cleanup := sqlutils.PGUrl(t, sqlAddr, t.Name(), url.User(security.RootUser))
+		defer cleanup()
+
+		// kvServer is used here because we require a
+		// TestServerInterface implementor. It is only used as
+		// the return value for f.Server()
+		f := cdctest.MakeSinklessFeedFactory(kvServer, sink)
+		tenantSQL.Exec(t, `INSERT INTO foo_in_tenant VALUES (1)`)
+		feed := feed(t, f, `CREATE CHANGEFEED FOR foo_in_tenant`)
+		assertPayloads(t, feed, []string{
+			`foo_in_tenant: [1]->{"after": {"pk": 1}}`,
+		})
+	})
 }
 
 func TestChangefeedEnvelope(t *testing.T) {

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -586,7 +586,7 @@ func makeSQLServerArgs(
 		return esb.makeExternalStorageFromURI(ctx, uri, user)
 	}
 
-	esb.init(base.ExternalIODirConfig{}, baseCfg.Settings, nil, circularInternalExecutor, db)
+	esb.init(sqlCfg.ExternalIODirConfig, baseCfg.Settings, nil, circularInternalExecutor, db)
 
 	// We don't need this for anything except some services that want a gRPC
 	// server to register against (but they'll never get RPCs at the time of
@@ -734,6 +734,7 @@ func (ts *TestServer) StartTenant(
 	}
 	sqlCfg := makeTestSQLConfig(st, params.TenantID)
 	sqlCfg.TenantKVAddrs = []string{ts.ServingRPCAddr()}
+	sqlCfg.ExternalIODirConfig = params.ExternalIODirConfig
 	if params.MemoryPoolSize != 0 {
 		sqlCfg.MemoryPoolSize = params.MemoryPoolSize
 	}


### PR DESCRIPTION
This tests that we can start sinkless tenants on changefeeds.

Currently, sinkful tenants are only prohibited via the
--external-io-disabled flag and no other mechanism. Thus, to test that
they are disabled we also thread through the ExternalIODirConfig into
the tenant server setup.

There is some cleanup that would have made this easier in the
TestFeed, but there is currently another refactoring of that code
underway that I didn't want to conflict with.

Release note: None