### PR TITLE
util/sysutil: noop if existing ballast file matches size

### DIFF
--- a/pkg/util/sysutil/large_file_linux.go
+++ b/pkg/util/sysutil/large_file_linux.go
@@ -26,6 +26,13 @@ import (
 func CreateLargeFile(path string, bytes int64) error {
 	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0666)
 	if err != nil {
+		if f, openErr := os.Open(path); openErr == nil {
+			defer f.Close()
+			// TODO(dt): should this allow approx match for fs size rounding?
+			if stat, statErr := f.Stat(); statErr == nil && stat.Size() == bytes {
+				return nil
+			}
+		}
 		return err
 	}
 	defer f.Close()

--- a/pkg/util/sysutil/large_file_naive.go
+++ b/pkg/util/sysutil/large_file_naive.go
@@ -25,6 +25,12 @@ import (
 func CreateLargeFile(path string, bytes int64) error {
 	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0666)
 	if err != nil {
+		if f, openErr := os.Open(path); openErr == nil {
+			defer f.Close()
+			if stat, statErr := f.Stat(); statErr == nil && stat.Size() == bytes {
+				return nil
+			}
+		}
 		return err
 	}
 	defer f.Close()

--- a/pkg/util/sysutil/large_file_test.go
+++ b/pkg/util/sysutil/large_file_test.go
@@ -45,7 +45,12 @@ func TestLargeFile(t *testing.T) {
 	}
 
 	// Check that an existing file cannot be overwritten.
-	if err = CreateLargeFile(fname, n); !(oserror.IsExist(err) || strings.Contains(err.Error(), "exists")) {
+	if err = CreateLargeFile(fname, n+(8<<10)); !(oserror.IsExist(err) || strings.Contains(err.Error(), "exists")) {
 		t.Fatalf("expected 'already exists' error, got (%T) %+v", err, err)
+	}
+
+	// Check that an existing file of requested size satisfies request.
+	if err = CreateLargeFile(fname, n); err != nil {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
While typically a request to create a ballast file will fail if
the requested path already exists (to avoid accidentally overwriting
e.g. a raw block device),  a special case is made for when the named
file already exists with the requested size: in this case the result
state -- a file with that size existing -- can be achieved by just doing
nothing. This means we can silently return without an error, even though the target
file exists. This allows scripts to include ballast creation of a set size
and be idempotent, without needing to rm/re-write it every time.

Release note (ops change): the 'debug ballast' command no longer errors if asked
to re-create a ballast file at an existing path if the file at that path has the
requested size, and instead just leaves the existing file in-place as-is.