### PR TITLE
ui: return node region info to transaction pages

### DIFF
--- a/pkg/ui/src/util/appStats.spec.ts
+++ b/pkg/ui/src/util/appStats.spec.ts
@@ -180,6 +180,7 @@ function randomStats(sensitiveInfo?: ISensitiveInfo): StatementStatistics {
     sensitive_info: sensitiveInfo || makeSensitiveInfo(null, null),
     exec_stats: randomExecStats(),
     sql_type: "DDL",
+    nodes: [Long.fromInt(1), Long.fromInt(2)],
     last_exec_timestamp: {
       seconds: Long.fromInt(1599670292),
       nanos: 111613000,

--- a/pkg/ui/src/util/appStats.ts
+++ b/pkg/ui/src/util/appStats.ts
@@ -15,6 +15,7 @@
 import _ from "lodash";
 import * as protos from "src/js/protos";
 import { FixLong } from "src/util/fixLong";
+import { uniqueLong } from "src/util/arrays";
 
 export type ISensitiveInfo = protos.cockroach.sql.ISensitiveInfo;
 export type StatementStatistics = protos.cockroach.sql.IStatementStatistics;
@@ -90,7 +91,7 @@ export function addStatementStats(
       a.last_exec_timestamp.seconds > b.last_exec_timestamp.seconds
         ? a.last_exec_timestamp
         : b.last_exec_timestamp,
-    nodes: combinesUnique(a.nodes, b.nodes),
+    nodes: uniqueLong([...a.nodes, ...b.nodes]),
   };
 }
 
@@ -135,17 +136,6 @@ function addExecStats(a: ExecStats, b: ExecStats): Required<ExecStats> {
       countB,
     ),
   };
-}
-
-function combinesUnique<T>(a: Array<T>, b: Array<T>): Array<T> {
-  if (a !== undefined && b !== undefined) {
-    b.forEach((value: any) => {
-      if (!a.includes(value)) a.push(value);
-    });
-  } else if (b !== undefined) {
-    return b;
-  }
-  return a;
 }
 
 function addMaybeUnsetNumericStat(

--- a/pkg/ui/src/util/arrays.ts
+++ b/pkg/ui/src/util/arrays.ts
@@ -1,0 +1,23 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import Long from "long";
+import { longToInt } from "./fixLong";
+
+// Remove duplicates and return an array with unique elements.
+export const unique = <T>(a: T[]): T[] => [...new Set([...a])];
+
+// Remove duplicates of an array of Long, returning an array with
+// unique elements. Since Long is an object, `Set` cannot identify
+// unique elements, so the array needs to be converted before
+// creating the Set and converted back to be returned.
+export const uniqueLong = (a: Long[]): Long[] => {
+  return unique(a.map(longToInt)).map((n) => Long.fromInt(n));
+};

--- a/pkg/ui/src/util/fixLong.ts
+++ b/pkg/ui/src/util/fixLong.ts
@@ -19,3 +19,5 @@ export function FixLong(value: Long | number): Long {
   }
   return value as Long;
 }
+
+export const longToInt = (value: number | Long) => Number(FixLong(value));

--- a/pkg/ui/src/views/transactions/transactionsPage.tsx
+++ b/pkg/ui/src/views/transactions/transactionsPage.tsx
@@ -21,6 +21,7 @@ import { TimestampToMoment } from "src/util/convert";
 import { PrintTime } from "src/views/reports/containers/range/print";
 
 import { TransactionsPage } from "@cockroachlabs/cluster-ui";
+import { nodeRegionsByIDSelector } from "src/redux/nodes";
 
 // selectStatements returns the array of AggregateStatistics to show on the
 // TransactionsPage, based on if the appAttr route parameter is set.
@@ -56,6 +57,7 @@ const TransactionsPageConnected = withRouter(
       statementsError: state.cachedData.statements.lastError,
       lastReset: selectLastReset(state),
       error: selectLastError(state),
+      nodeRegions: nodeRegionsByIDSelector(state),
     }),
     {
       refreshData: refreshStatements,


### PR DESCRIPTION
Return information about node region to transactions pages.
Part of issue cockroachdb/cockroach#64779

Release note (ui change): Return information about region of a node
on Transactions Page.