### PR TITLE
kvserver: make GC intent scoring more aggressive

### DIFF
--- a/pkg/ccl/storageccl/export.go
+++ b/pkg/ccl/storageccl/export.go
@@ -62,7 +62,7 @@ func declareKeysExport(
 	latchSpans, lockSpans *spanset.SpanSet,
 ) {
 	batcheval.DefaultDeclareIsolatedKeys(rs, header, req, latchSpans, lockSpans)
-	latchSpans.AddNonMVCC(spanset.SpanReadOnly, roachpb.Span{Key: keys.RangeLastGCKey(header.RangeID)})
+	latchSpans.AddNonMVCC(spanset.SpanReadOnly, roachpb.Span{Key: keys.RangeGCThresholdKey(header.RangeID)})
 }
 
 // evalExport dumps the requested keys into files of non-overlapping key ranges

--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -77,8 +77,9 @@ var (
 	LocalAbortSpanSuffix = []byte("abc-")
 	// localRangeFrozenStatusSuffix is DEPRECATED and remains to prevent reuse.
 	localRangeFrozenStatusSuffix = []byte("fzn-")
-	// LocalRangeLastGCSuffix is the suffix for the last GC.
-	LocalRangeLastGCSuffix = []byte("lgc-")
+	// LocalRangeGCThresholdSuffix is the suffix for the GC threshold. It keeps
+	// the lgc- ("last GC") representation for backwards compatibility.
+	LocalRangeGCThresholdSuffix = []byte("lgc-")
 	// LocalRangeAppliedStateSuffix is the suffix for the range applied state
 	// key.
 	LocalRangeAppliedStateSuffix = []byte("rask")

--- a/pkg/keys/doc.go
+++ b/pkg/keys/doc.go
@@ -186,7 +186,7 @@ var _ = [...]interface{}{
 	//   Typical examples are MVCC stats and the abort span. They all share
 	//   `LocalRangeIDPrefix` and `LocalRangeIDReplicatedInfix`.
 	AbortSpanKey,                // "abc-"
-	RangeLastGCKey,              // "lgc-"
+	RangeGCThresholdKey,         // "lgc-"
 	RangeAppliedStateKey,        // "rask"
 	RaftAppliedIndexLegacyKey,   // "rfta"
 	RaftTruncatedStateLegacyKey, // "rftt"

--- a/pkg/keys/keys.go
+++ b/pkg/keys/keys.go
@@ -284,12 +284,10 @@ func RangeStatsLegacyKey(rangeID roachpb.RangeID) roachpb.Key {
 	return MakeRangeIDPrefixBuf(rangeID).RangeStatsLegacyKey()
 }
 
-// RangeLastGCKey returns a system-local key for last used GC threshold on the
+// RangeGCThresholdKey returns a system-local key for last used GC threshold on the
 // user keyspace. Reads and writes <= this timestamp will not be served.
-//
-// TODO(tschottdorf): should be renamed to RangeGCThresholdKey.
-func RangeLastGCKey(rangeID roachpb.RangeID) roachpb.Key {
-	return MakeRangeIDPrefixBuf(rangeID).RangeLastGCKey()
+func RangeGCThresholdKey(rangeID roachpb.RangeID) roachpb.Key {
+	return MakeRangeIDPrefixBuf(rangeID).RangeGCThresholdKey()
 }
 
 // RangeVersionKey returns a system-local for the range version.
@@ -971,9 +969,9 @@ func (b RangeIDPrefixBuf) RangeStatsLegacyKey() roachpb.Key {
 	return append(b.replicatedPrefix(), LocalRangeStatsLegacySuffix...)
 }
 
-// RangeLastGCKey returns a system-local key for the last GC.
-func (b RangeIDPrefixBuf) RangeLastGCKey() roachpb.Key {
-	return append(b.replicatedPrefix(), LocalRangeLastGCSuffix...)
+// RangeGCThresholdKey returns a system-local key for the GC threshold.
+func (b RangeIDPrefixBuf) RangeGCThresholdKey() roachpb.Key {
+	return append(b.replicatedPrefix(), LocalRangeGCThresholdSuffix...)
 }
 
 // RangeVersionKey returns a system-local key for the range version.

--- a/pkg/keys/printer.go
+++ b/pkg/keys/printer.go
@@ -171,7 +171,7 @@ var (
 		{name: "RangeLease", suffix: LocalRangeLeaseSuffix},
 		{name: "RangePriorReadSummary", suffix: LocalRangePriorReadSummarySuffix},
 		{name: "RangeStats", suffix: LocalRangeStatsLegacySuffix},
-		{name: "RangeLastGC", suffix: LocalRangeLastGCSuffix},
+		{name: "RangeGCThreshold", suffix: LocalRangeGCThresholdSuffix},
 		{name: "RangeVersion", suffix: LocalRangeVersionSuffix},
 	}
 

--- a/pkg/keys/printer_test.go
+++ b/pkg/keys/printer_test.go
@@ -76,7 +76,7 @@ func TestPrettyPrint(t *testing.T) {
 		{keys.RangeLeaseKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/r/RangeLease", revertSupportUnknown},
 		{keys.RangePriorReadSummaryKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/r/RangePriorReadSummary", revertSupportUnknown},
 		{keys.RangeStatsLegacyKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/r/RangeStats", revertSupportUnknown},
-		{keys.RangeLastGCKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/r/RangeLastGC", revertSupportUnknown},
+		{keys.RangeGCThresholdKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/r/RangeGCThreshold", revertSupportUnknown},
 		{keys.RangeVersionKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/r/RangeVersion", revertSupportUnknown},
 
 		{keys.RaftHardStateKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/u/RaftHardState", revertSupportUnknown},

--- a/pkg/kv/kvserver/batcheval/cmd_gc.go
+++ b/pkg/kv/kvserver/batcheval/cmd_gc.go
@@ -45,7 +45,7 @@ func declareKeysGC(
 	// request first to bump the thresholds, and then another one that actually does work
 	// but can avoid declaring these keys below.
 	if !gcr.Threshold.IsEmpty() {
-		latchSpans.AddNonMVCC(spanset.SpanReadWrite, roachpb.Span{Key: keys.RangeLastGCKey(rs.GetRangeID())})
+		latchSpans.AddNonMVCC(spanset.SpanReadWrite, roachpb.Span{Key: keys.RangeGCThresholdKey(rs.GetRangeID())})
 	}
 	// Needed for Range bounds checks in calls to EvalContext.ContainsKey.
 	latchSpans.AddNonMVCC(spanset.SpanReadOnly, roachpb.Span{Key: keys.RangeDescriptorKey(rs.GetStartKey())})

--- a/pkg/kv/kvserver/batcheval/cmd_revert_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_revert_range.go
@@ -36,7 +36,7 @@ func declareKeysRevertRange(
 	// We look up the range descriptor key to check whether the span
 	// is equal to the entire range for fast stats updating.
 	latchSpans.AddNonMVCC(spanset.SpanReadOnly, roachpb.Span{Key: keys.RangeDescriptorKey(rs.GetStartKey())})
-	latchSpans.AddNonMVCC(spanset.SpanReadOnly, roachpb.Span{Key: keys.RangeLastGCKey(rs.GetRangeID())})
+	latchSpans.AddNonMVCC(spanset.SpanReadOnly, roachpb.Span{Key: keys.RangeGCThresholdKey(rs.GetRangeID())})
 }
 
 // isEmptyKeyTimeRange checks if the span has no writes in (since,until].

--- a/pkg/kv/kvserver/client_protectedts_test.go
+++ b/pkg/kv/kvserver/client_protectedts_test.go
@@ -53,7 +53,10 @@ func TestProtectedTimestamps(t *testing.T) {
 	skip.UnderShort(t)
 
 	args := base.TestClusterArgs{}
-	args.ServerArgs.Knobs.Store = &kvserver.StoreTestingKnobs{DisableGCQueue: true}
+	args.ServerArgs.Knobs.Store = &kvserver.StoreTestingKnobs{
+		DisableGCQueue:            true,
+		DisableLastProcessedCheck: true,
+	}
 	tc := testcluster.StartTestCluster(t, 3, args)
 	defer tc.Stopper().Stop(ctx)
 	s0 := tc.Server(0)

--- a/pkg/kv/kvserver/debug_print.go
+++ b/pkg/kv/kvserver/debug_print.go
@@ -274,7 +274,7 @@ func tryRangeIDKey(kv storage.MVCCKeyValue) (string, error) {
 	case bytes.Equal(suffix, keys.LocalAbortSpanSuffix):
 		msg = &roachpb.AbortSpanEntry{}
 
-	case bytes.Equal(suffix, keys.LocalRangeLastGCSuffix):
+	case bytes.Equal(suffix, keys.LocalRangeGCThresholdSuffix):
 		msg = &hlc.Timestamp{}
 
 	case bytes.Equal(suffix, keys.LocalRangeVersionSuffix):

--- a/pkg/kv/kvserver/gc/gc.go
+++ b/pkg/kv/kvserver/gc/gc.go
@@ -222,6 +222,12 @@ func Run(
 	log.Eventf(ctx, "GC'ed keys; stats %+v", info)
 
 	// Push transactions (if pending) and resolve intents.
+	//
+	// FIXME(erikgrinaker): We should have a timeout for suboperations here now
+	// that the overall GC timeout has been increased, to make sure we'll make
+	// progress even with range unavailability. That's probably best done once
+	// batching is implemented, so we'll wait for that:
+	// https://github.com/cockroachdb/cockroach/pull/65847
 	var intents []roachpb.Intent
 	for txnID, txn := range txnMap {
 		intents = append(intents, roachpb.AsIntents(&txn.TxnMeta, intentKeyMap[txnID])...)

--- a/pkg/kv/kvserver/gc_queue.go
+++ b/pkg/kv/kvserver/gc_queue.go
@@ -38,6 +38,11 @@ const (
 	gcQueueTimerDuration = 1 * time.Second
 	// gcQueueTimeout is the timeout for a single GC run.
 	gcQueueTimeout = 10 * time.Minute
+	// gcQueueIntentCooldownDuration is the duration to wait between GC attempts
+	// of the same range when triggered solely by intents. This is to prevent
+	// continually spinning on intents that belong to active transactions, which
+	// can't be cleaned up.
+	gcQueueIntentCooldownDuration = 2 * time.Hour
 	// intentAgeNormalization is the average age of outstanding intents
 	// which amount to a score of "1" added to total replica priority.
 	intentAgeNormalization = 24 * time.Hour // 1 day
@@ -122,7 +127,7 @@ func newGCQueue(store *Store, gossip *gossip.Gossip) *gcQueue {
 // makeGCQueueScoreImpl.
 type gcQueueScore struct {
 	TTL                 time.Duration
-	LikelyLastGC        time.Duration
+	LastGC              time.Duration
 	DeadFraction        float64
 	ValuesScalableScore float64
 	IntentScore         float64
@@ -142,14 +147,14 @@ func (r gcQueueScore) String() string {
 	if r.ExpMinGCByteAgeReduction < 0 {
 		r.ExpMinGCByteAgeReduction = 0
 	}
-	likelyLastGC := "never"
-	if r.LikelyLastGC != 0 {
-		likelyLastGC = fmt.Sprintf("%s ago", r.LikelyLastGC)
+	lastGC := "never"
+	if r.LastGC != 0 {
+		lastGC = fmt.Sprintf("%s ago", r.LastGC)
 	}
 	return fmt.Sprintf("queue=%t with %.2f/fuzz(%.2f)=%.2f=valScaleScore(%.2f)*deadFrac(%.2f)+intentScore(%.2f)\n"+
 		"likely last GC: %s, %s non-live, curr. age %s*s, min exp. reduction: %s*s",
 		r.ShouldQueue, r.FinalScore, r.FuzzFactor, r.FinalScore/r.FuzzFactor, r.ValuesScalableScore,
-		r.DeadFraction, r.IntentScore, likelyLastGC, humanizeutil.IBytes(r.GCBytes),
+		r.DeadFraction, r.IntentScore, lastGC, humanizeutil.IBytes(r.GCBytes),
 		humanizeutil.IBytes(r.GCByteAge), humanizeutil.IBytes(r.ExpMinGCByteAgeReduction))
 }
 
@@ -173,24 +178,34 @@ func (gcq *gcQueue) shouldQueue(
 	if newThreshold.Equal(oldThreshold) {
 		return false, 0
 	}
-	r := makeGCQueueScore(ctx, repl, gcTimestamp, *zone.GC)
+	lastGC, err := repl.getQueueLastProcessed(ctx, gcq.name)
+	if err != nil {
+		log.VErrEventf(ctx, 2, "failed to fetch last processed time: %v", err)
+		return false, 0
+	}
+	r := makeGCQueueScore(ctx, repl, gcTimestamp, lastGC, *zone.GC)
 	return r.ShouldQueue, r.FinalScore
 }
 
 func makeGCQueueScore(
-	ctx context.Context, repl *Replica, now hlc.Timestamp, policy zonepb.GCPolicy,
+	ctx context.Context,
+	repl *Replica,
+	now hlc.Timestamp,
+	lastGC hlc.Timestamp,
+	policy zonepb.GCPolicy,
 ) gcQueueScore {
 	repl.mu.Lock()
 	ms := *repl.mu.state.Stats
-	gcThreshold := *repl.mu.state.GCThreshold
 	repl.mu.Unlock()
+
+	if repl.store.cfg.TestingKnobs.DisableLastProcessedCheck {
+		lastGC = hlc.Timestamp{}
+	}
 
 	// Use desc.RangeID for fuzzing the final score, so that different ranges
 	// have slightly different priorities and even symmetrical workloads don't
 	// trigger GC at the same time.
-	r := makeGCQueueScoreImpl(
-		ctx, int64(repl.RangeID), now, ms, policy, gcThreshold,
-	)
+	r := makeGCQueueScoreImpl(ctx, int64(repl.RangeID), now, ms, policy, lastGC)
 	return r
 }
 
@@ -201,7 +216,8 @@ func makeGCQueueScore(
 // additionally weigh it so that GC is delayed when a large proportion of the
 // data in the replica is live. Additionally, returned scores are slightly
 // perturbed to avoid groups of replicas becoming eligible for GC at the same
-// time repeatedly.
+// time repeatedly. We also use gcQueueIntentCooldownTimer to avoid spinning
+// when GCing solely based on intents, since we may not be able to GC them.
 //
 // More details below.
 //
@@ -288,14 +304,14 @@ func makeGCQueueScoreImpl(
 	now hlc.Timestamp,
 	ms enginepb.MVCCStats,
 	policy zonepb.GCPolicy,
-	gcThreshold hlc.Timestamp,
+	lastGC hlc.Timestamp,
 ) gcQueueScore {
 	ms.Forward(now.WallTime)
 	var r gcQueueScore
-	if !gcThreshold.IsEmpty() {
-		r.LikelyLastGC = time.Duration(now.WallTime - gcThreshold.Add(r.TTL.Nanoseconds(), 0).WallTime)
-	}
 
+	if !lastGC.IsEmpty() {
+		r.LastGC = time.Duration(now.WallTime - lastGC.WallTime)
+	}
 	r.TTL = policy.TTL()
 
 	// Treat a zero TTL as a one-second TTL, which avoids a priority of infinity
@@ -355,11 +371,22 @@ func makeGCQueueScoreImpl(
 
 	// Compute priority.
 	valScore := r.DeadFraction * r.ValuesScalableScore
-	r.ShouldQueue = r.FuzzFactor*valScore > gcKeyScoreThreshold || r.FuzzFactor*r.IntentScore > gcIntentScoreThreshold
 	r.FinalScore = r.FuzzFactor * (valScore + r.IntentScore)
 
+	// First determine whether we should queue based on MVCC score alone.
+	r.ShouldQueue = r.FuzzFactor*valScore > gcKeyScoreThreshold
+
+	// Next, determine whether we should queue based on intent score. For
+	// intents, we also enforce a cooldown time since we may not actually
+	// be able to clean up any intents (for active transactions).
+	if !r.ShouldQueue && r.FuzzFactor*r.IntentScore > gcIntentScoreThreshold &&
+		(r.LastGC == 0 || r.LastGC >= gcQueueIntentCooldownDuration) {
+		r.ShouldQueue = true
+	}
+
+	// Finally, queue if we find large abort spans for abandoned transactions.
 	if largeAbortSpan(ms) && !r.ShouldQueue &&
-		(r.LikelyLastGC == 0 || r.LikelyLastGC > kvserverbase.TxnCleanupThreshold) {
+		(r.LastGC == 0 || r.LastGC > kvserverbase.TxnCleanupThreshold) {
 		r.ShouldQueue = true
 		r.FinalScore++
 	}
@@ -453,11 +480,19 @@ func (gcq *gcQueue) process(
 	// Consult the protected timestamp state to determine whether we can GC and
 	// the timestamp which can be used to calculate the score and updated GC
 	// threshold.
-	canGC, cacheTimestamp, gcTimestamp, _, newThreshold := repl.checkProtectedTimestampsForGC(ctx, *zone.GC)
+	canGC, cacheTimestamp, gcTimestamp, _, newThreshold :=
+		repl.checkProtectedTimestampsForGC(ctx, *zone.GC)
 	if !canGC {
 		return false, nil
 	}
-	r := makeGCQueueScore(ctx, repl, gcTimestamp, *zone.GC)
+	// We don't recheck ShouldQueue here, since the range may have been enqueued
+	// manually e.g. via the admin server.
+	lastGC, err := repl.getQueueLastProcessed(ctx, gcq.name)
+	if err != nil {
+		lastGC = hlc.Timestamp{}
+		log.VErrEventf(ctx, 2, "failed to fetch last processed time: %v", err)
+	}
+	r := makeGCQueueScore(ctx, repl, gcTimestamp, lastGC, *zone.GC)
 	log.VEventf(ctx, 2, "processing replica %s with score %s", repl.String(), r)
 	// Synchronize the new GC threshold decision with concurrent
 	// AdminVerifyProtectedTimestamp requests.
@@ -465,6 +500,11 @@ func (gcq *gcQueue) process(
 		log.VEventf(ctx, 1, "not gc'ing replica %v due to pending protection: %v", repl, err)
 		return false, nil
 	}
+	// Update the last processed timestamp.
+	if err := repl.setQueueLastProcessed(ctx, gcq.name, repl.store.Clock().Now()); err != nil {
+		log.VErrEventf(ctx, 2, "failed to update last processed time: %v", err)
+	}
+
 	snap := repl.store.Engine().NewSnapshot()
 	defer snap.Close()
 
@@ -502,7 +542,8 @@ func (gcq *gcQueue) process(
 	}
 
 	log.Eventf(ctx, "MVCC stats after GC: %+v", repl.GetMVCCStats())
-	log.Eventf(ctx, "GC score after GC: %s", makeGCQueueScore(ctx, repl, repl.store.Clock().Now(), *zone.GC))
+	log.Eventf(ctx, "GC score after GC: %s", makeGCQueueScore(
+		ctx, repl, repl.store.Clock().Now(), lastGC, *zone.GC))
 	updateStoreMetricsWithGCInfo(gcq.store.metrics, info)
 	return true, nil
 }

--- a/pkg/kv/kvserver/gc_queue.go
+++ b/pkg/kv/kvserver/gc_queue.go
@@ -474,7 +474,7 @@ func (gcq *gcQueue) process(
 		&replicaGCer{repl: repl},
 		func(ctx context.Context, intents []roachpb.Intent) error {
 			intentCount, err := repl.store.intentResolver.
-				CleanupIntents(ctx, intents, gcTimestamp, roachpb.PUSH_ABORT)
+				CleanupIntents(ctx, intents, gcTimestamp, roachpb.PUSH_TOUCH)
 			if err == nil {
 				gcq.store.metrics.GCResolveSuccess.Inc(int64(intentCount))
 			}

--- a/pkg/kv/kvserver/gc_queue_test.go
+++ b/pkg/kv/kvserver/gc_queue_test.go
@@ -69,7 +69,7 @@ func TestGCQueueScoreString(t *testing.T) {
 			ExpMinGCByteAgeReduction: 256 * 1024,
 			GCByteAge:                512 * 1024,
 			GCBytes:                  1024 * 3,
-			LikelyLastGC:             5 * time.Second,
+			LastGC:                   5 * time.Second,
 		},
 			`queue=true with 4.31/fuzz(1.25)=3.45=valScaleScore(4.00)*deadFrac(0.25)+intentScore(0.45)
 likely last GC: 5s ago, 3.0 KiB non-live, curr. age 512 KiB*s, min exp. reduction: 256 KiB*s`},
@@ -109,7 +109,8 @@ func TestGCQueueMakeGCScoreInvariantQuick(t *testing.T) {
 			GCBytesAge:      gcByteAge,
 		}
 		now := initialNow.Add(timePassed.Nanoseconds(), 0)
-		r := makeGCQueueScoreImpl(ctx, int64(seed), now, ms, zonepb.GCPolicy{TTLSeconds: ttlSec}, hlc.Timestamp{})
+		r := makeGCQueueScoreImpl(
+			ctx, int64(seed), now, ms, zonepb.GCPolicy{TTLSeconds: ttlSec}, hlc.Timestamp{})
 		wouldHaveToDeleteSomething := gcBytes*int64(ttlSec) < ms.GCByteAge(now.WallTime)
 		result := !r.ShouldQueue || wouldHaveToDeleteSomething
 		if !result {
@@ -147,7 +148,6 @@ func TestGCQueueMakeGCScoreLargeAbortSpan(t *testing.T) {
 	ms.SysBytes += largeAbortSpanBytesThreshold
 	ms.SysCount++
 
-	gcThresh := hlc.Timestamp{WallTime: 1}
 	expiration := kvserverbase.TxnCleanupThreshold.Nanoseconds() + 1
 
 	// GC triggered if abort span should all be gc'able and it's large.
@@ -156,7 +156,7 @@ func TestGCQueueMakeGCScoreLargeAbortSpan(t *testing.T) {
 			context.Background(), seed,
 			hlc.Timestamp{WallTime: expiration + 1},
 			ms, zonepb.GCPolicy{TTLSeconds: 10000},
-			gcThresh,
+			hlc.Timestamp{},
 		)
 		require.True(t, r.ShouldQueue)
 		require.NotZero(t, r.FinalScore)
@@ -171,21 +171,59 @@ func TestGCQueueMakeGCScoreLargeAbortSpan(t *testing.T) {
 			context.Background(), seed,
 			hlc.Timestamp{WallTime: expiration + 1},
 			ms, zonepb.GCPolicy{TTLSeconds: 10000},
-			gcThresh,
+			hlc.Timestamp{},
 		)
 		require.True(t, r.ShouldQueue)
 		require.NotZero(t, r.FinalScore)
 	}
 
-	// Heuristic doesn't fire if likely last GC within TxnCleanupThreshold.
+	// Heuristic doesn't fire if last GC within TxnCleanupThreshold.
 	{
 		r := makeGCQueueScoreImpl(context.Background(), seed,
 			hlc.Timestamp{WallTime: expiration},
 			ms, zonepb.GCPolicy{TTLSeconds: 10000},
-			gcThresh,
+			hlc.Timestamp{WallTime: expiration - 100},
 		)
 		require.False(t, r.ShouldQueue)
 		require.Zero(t, r.FinalScore)
+	}
+}
+
+func TestGCQueueMakeGCScoreIntentCooldown(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	const seed = 1
+	ctx := context.Background()
+	now := hlc.Timestamp{WallTime: 1e6 * 1e9}
+	policy := zonepb.GCPolicy{TTLSeconds: 1}
+
+	testcases := map[string]struct {
+		lastGC   hlc.Timestamp
+		mvccGC   bool
+		expectGC bool
+	}{
+		"never GCed":               {lastGC: hlc.Timestamp{}, expectGC: true},
+		"just GCed":                {lastGC: now.Add(-1, 0), expectGC: false},
+		"future GC":                {lastGC: now.Add(1, 0), expectGC: false},
+		"MVCC GC ignores cooldown": {lastGC: now.Add(-1, 0), mvccGC: true, expectGC: true},
+		"before GC cooldown":       {lastGC: now.Add(-gcQueueIntentCooldownDuration.Nanoseconds()+1, 0), expectGC: false},
+		"at GC cooldown":           {lastGC: now.Add(-gcQueueIntentCooldownDuration.Nanoseconds(), 0), expectGC: true},
+		"after GC cooldown":        {lastGC: now.Add(-gcQueueIntentCooldownDuration.Nanoseconds()-1, 0), expectGC: true},
+	}
+	for name, tc := range testcases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			ms := enginepb.MVCCStats{
+				IntentCount: 1e9,
+			}
+			if tc.mvccGC {
+				ms.ValBytes = 1e9
+			}
+
+			r := makeGCQueueScoreImpl(ctx, seed, now, ms, policy, tc.lastGC)
+			require.Equal(t, tc.expectGC, r.ShouldQueue)
+		})
 	}
 }
 

--- a/pkg/kv/kvserver/kvserverpb/state.pb.go
+++ b/pkg/kv/kvserver/kvserverpb/state.pb.go
@@ -60,7 +60,7 @@ type ReplicaState struct {
 	Lease *roachpb.Lease `protobuf:"bytes,4,opt,name=lease,proto3" json:"lease,omitempty"`
 	// The truncation state of the Raft log.
 	TruncatedState *roachpb.RaftTruncatedState `protobuf:"bytes,5,opt,name=truncated_state,json=truncatedState,proto3" json:"truncated_state,omitempty"`
-	// gcThreshold is the GC threshold of the Range, typically updated when keys
+	// GCThreshold is the GC threshold of the Range, typically updated when keys
 	// are garbage collected. Reads and writes at timestamps <= this time will
 	// not be served.
 	GCThreshold *hlc.Timestamp      `protobuf:"bytes,6,opt,name=gc_threshold,json=gcThreshold,proto3" json:"gc_threshold,omitempty"`

--- a/pkg/kv/kvserver/kvserverpb/state.proto
+++ b/pkg/kv/kvserver/kvserverpb/state.proto
@@ -54,7 +54,7 @@ message ReplicaState {
   roachpb.Lease lease = 4;
   // The truncation state of the Raft log.
   roachpb.RaftTruncatedState truncated_state = 5;
-  // gcThreshold is the GC threshold of the Range, typically updated when keys
+  // GCThreshold is the GC threshold of the Range, typically updated when keys
   // are garbage collected. Reads and writes at timestamps <= this time will
   // not be served.
   util.hlc.Timestamp gc_threshold = 6 [(gogoproto.customname) = "GCThreshold"];

--- a/pkg/kv/kvserver/rditer/replica_data_iter_test.go
+++ b/pkg/kv/kvserver/rditer/replica_data_iter_test.go
@@ -80,7 +80,7 @@ func createRangeData(
 	}{
 		{keys.AbortSpanKey(desc.RangeID, testTxnID), ts0},
 		{keys.AbortSpanKey(desc.RangeID, testTxnID2), ts0},
-		{keys.RangeLastGCKey(desc.RangeID), ts0},
+		{keys.RangeGCThresholdKey(desc.RangeID), ts0},
 		{keys.RangeAppliedStateKey(desc.RangeID), ts0},
 		{keys.RaftAppliedIndexLegacyKey(desc.RangeID), ts0},
 		{keys.RaftTruncatedStateLegacyKey(desc.RangeID), ts0},

--- a/pkg/kv/kvserver/replica_eval_context_span.go
+++ b/pkg/kv/kvserver/replica_eval_context_span.go
@@ -178,7 +178,7 @@ func (rec SpanSetReplicaEvalContext) CanCreateTxnRecord(
 // not be served.
 func (rec SpanSetReplicaEvalContext) GetGCThreshold() hlc.Timestamp {
 	rec.ss.AssertAllowed(spanset.SpanReadOnly,
-		roachpb.Span{Key: keys.RangeLastGCKey(rec.GetRangeID())},
+		roachpb.Span{Key: keys.RangeGCThresholdKey(rec.GetRangeID())},
 	)
 	return rec.i.GetGCThreshold()
 }

--- a/pkg/kv/kvserver/spanset/spanset_test.go
+++ b/pkg/kv/kvserver/spanset/spanset_test.go
@@ -29,11 +29,11 @@ func TestSpanSetGetSpansScope(t *testing.T) {
 
 	var ss SpanSet
 	ss.AddNonMVCC(SpanReadOnly, roachpb.Span{Key: roachpb.Key("a")})
-	ss.AddNonMVCC(SpanReadOnly, roachpb.Span{Key: keys.RangeLastGCKey(1)})
+	ss.AddNonMVCC(SpanReadOnly, roachpb.Span{Key: keys.RangeGCThresholdKey(1)})
 	ss.AddNonMVCC(SpanReadOnly, roachpb.Span{Key: roachpb.Key("b"), EndKey: roachpb.Key("c")})
 
 	exp := []Span{
-		{Span: roachpb.Span{Key: keys.RangeLastGCKey(1)}},
+		{Span: roachpb.Span{Key: keys.RangeGCThresholdKey(1)}},
 	}
 	if act := ss.GetSpans(SpanReadOnly, SpanLocal); !reflect.DeepEqual(act, exp) {
 		t.Errorf("get local spans: got %v, expected %v", act, exp)
@@ -70,7 +70,7 @@ func TestSpanSetIterate(t *testing.T) {
 	spA := roachpb.Span{Key: roachpb.Key("a")}
 	spRO := roachpb.Span{Key: roachpb.Key("r"), EndKey: roachpb.Key("o")}
 	spRW := roachpb.Span{Key: roachpb.Key("r"), EndKey: roachpb.Key("w")}
-	spLocal := roachpb.Span{Key: keys.RangeLastGCKey(1)}
+	spLocal := roachpb.Span{Key: keys.RangeGCThresholdKey(1)}
 
 	ss := new(SpanSet)
 	ss.AddNonMVCC(SpanReadOnly, spLocal)
@@ -104,7 +104,7 @@ func TestSpanSetMerge(t *testing.T) {
 	spBC := roachpb.Span{Key: roachpb.Key("b"), EndKey: roachpb.Key("c")}
 	spCE := roachpb.Span{Key: roachpb.Key("c"), EndKey: roachpb.Key("e")}
 	spBE := roachpb.Span{Key: roachpb.Key("b"), EndKey: roachpb.Key("e")}
-	spLocal := roachpb.Span{Key: keys.RangeLastGCKey(1)}
+	spLocal := roachpb.Span{Key: keys.RangeGCThresholdKey(1)}
 
 	var ss SpanSet
 	ss.AddNonMVCC(SpanReadOnly, spLocal)
@@ -205,7 +205,7 @@ func TestSpanSetCheckAllowedAtTimestamps(t *testing.T) {
 	ss.AddMVCC(SpanReadOnly, roachpb.Span{Key: roachpb.Key("g")}, hlc.Timestamp{WallTime: 2})
 	ss.AddMVCC(SpanReadWrite, roachpb.Span{Key: roachpb.Key("m"), EndKey: roachpb.Key("o")}, hlc.Timestamp{WallTime: 2})
 	ss.AddMVCC(SpanReadWrite, roachpb.Span{Key: roachpb.Key("s")}, hlc.Timestamp{WallTime: 2})
-	ss.AddNonMVCC(SpanReadWrite, roachpb.Span{Key: keys.RangeLastGCKey(1)})
+	ss.AddNonMVCC(SpanReadWrite, roachpb.Span{Key: keys.RangeGCThresholdKey(1)})
 
 	var allowedRO = []struct {
 		span roachpb.Span
@@ -225,8 +225,8 @@ func TestSpanSetCheckAllowedAtTimestamps(t *testing.T) {
 		{roachpb.Span{Key: roachpb.Key("s")}, hlc.Timestamp{WallTime: 1}},
 
 		// Local keys.
-		{roachpb.Span{Key: keys.RangeLastGCKey(1)}, hlc.Timestamp{}},
-		{roachpb.Span{Key: keys.RangeLastGCKey(1)}, hlc.Timestamp{WallTime: 1}},
+		{roachpb.Span{Key: keys.RangeGCThresholdKey(1)}, hlc.Timestamp{}},
+		{roachpb.Span{Key: keys.RangeGCThresholdKey(1)}, hlc.Timestamp{WallTime: 1}},
 	}
 	for _, tc := range allowedRO {
 		if err := ss.CheckAllowedAt(SpanReadOnly, tc.span, tc.ts); err != nil {
@@ -257,7 +257,7 @@ func TestSpanSetCheckAllowedAtTimestamps(t *testing.T) {
 		{roachpb.Span{Key: roachpb.Key("m"), EndKey: roachpb.Key("n")}, hlc.Timestamp{WallTime: 3}},
 
 		// Local keys.
-		{roachpb.Span{Key: keys.RangeLastGCKey(1)}, hlc.Timestamp{}},
+		{roachpb.Span{Key: keys.RangeGCThresholdKey(1)}, hlc.Timestamp{}},
 	}
 	for _, tc := range allowedRW {
 		if err := ss.CheckAllowedAt(SpanReadWrite, tc.span, tc.ts); err != nil {

--- a/pkg/kv/kvserver/stateloader/stateloader.go
+++ b/pkg/kv/kvserver/stateloader/stateloader.go
@@ -528,7 +528,7 @@ func (rsl StateLoader) LoadGCThreshold(
 	ctx context.Context, reader storage.Reader,
 ) (*hlc.Timestamp, error) {
 	var t hlc.Timestamp
-	_, err := storage.MVCCGetProto(ctx, reader, rsl.RangeLastGCKey(),
+	_, err := storage.MVCCGetProto(ctx, reader, rsl.RangeGCThresholdKey(),
 		hlc.Timestamp{}, &t, storage.MVCCGetOptions{})
 	return &t, err
 }
@@ -544,7 +544,7 @@ func (rsl StateLoader) SetGCThreshold(
 		return errors.New("cannot persist nil GCThreshold")
 	}
 	return storage.MVCCPutProto(ctx, readWriter, ms,
-		rsl.RangeLastGCKey(), hlc.Timestamp{}, nil, threshold)
+		rsl.RangeGCThresholdKey(), hlc.Timestamp{}, nil, threshold)
 }
 
 // LoadVersion loads the replica version.


### PR DESCRIPTION
### keys: rename RangeLastGCKey to RangeGCThresholdKey

The key `RangeLastGCKey` was not actually used to store the last GC
timestamp, but rather the last GC threshold. This commit renames the key
to the more appropriate `RangeGCThresholdKey`.

Release note: None

### kvserver: increase GC queue timeout

The MVCC GC queue timeout was left at the default of 1 minute. Since the
`GCThreshold` is advanced and persisted at the very start of the GC run
(to coordinate with other processes such as exports and rangefeeds
before removing any data), this means that if a GC run takes more than 1
minute to complete it will be aborted due to the timeout and may not run
again for some time.

This patch increases the timeout to 10 minutes. The primary purpose of
the timeout is to avoid head-of-line blocking in the case of unavailable
ranges, and a larger timeout still satisfies this property while also
allowing more expensive cleanup attempts to complete.

Release note (ops change): increased the timeout for range MVCC
garbage collection from 1 minute to 10 minutes, to allow larger jobs to
run to completion.

### kvserver: use PUSH_TOUCH during GC to push intent owners

Using `PUSH_ABORT` to push intent owners during intent GC can cause it
to block on (or possibly abort) long-running transactions.

Since we would prefer GC to continue with other intents rather than
waiting for active transactions, this patch changes the GC queue to use
`PUSH_TOUCH` instead. This will still clean up abandoned txns.

Resolves #65777.

Release note (bug fix): Intent garbage collection no longer waits for
or aborts running transactions.

### kvserver: add GC queue cooldown timer

When the GC queue considered replicas for MVCC GC, it primarily
considered the previous GC threshold and the amount of MVCC garbage that
would be removed by advancing the threshold. We would like to also
trigger GC based solely on intent stats. However, we can't know whether
we'll actually be able to clean up any intents, since they may belong to
an in-progress long-running transaction. There is therefore a risk that
we will keep spinning on GC attempts due to high intent counts.

This patch records the last GC queue processing timestamp, and adds a
cooldown timer of 2 hours between each range GC attempt triggered by
intent score alone to prevent spinning on GC attempts.

Release note: None

### kvserver: make GC intent scoring more aggressive

Users often experience buildup of intents due to the GC queue not being
aggressive enough in cleaning them up. Currently, the GC queue will only
trigger based on intents if the average intent age is 10 days and if
there is also MVCC garbage that can be cleaned up.

This patch makes the intent scoring more aggressive, triggering GC when
the average intent age is 8 hours regardless of other MVCC garbage. The
previous commit added a cooldown timer to prevent the GC queue from
spinning on a replica if the intents couldn't be cleaned up (e.g.
because they belong to an in-progress long-running transaction).

Resolves #64266.
Touches  #60585.

Release note (ops change): trigger MVCC and intent garbage collection
when the average intent age is 8 hours, down from 10 days.

/cc @cockroachdb/kv 