### PR TITLE
serverutils: Add TestTenantID

### DIFF
--- a/pkg/ccl/serverccl/server_sql_test.go
+++ b/pkg/ccl/serverccl/server_sql_test.go
@@ -51,7 +51,7 @@ func TestSQLServer(t *testing.T) {
 	_, db := serverutils.StartTenant(
 		t,
 		tc.Server(0),
-		base.TestTenantArgs{TenantID: roachpb.MakeTenantID(security.EmbeddedTenantIDs()[0])},
+		base.TestTenantArgs{TenantID: serverutils.TestTenantID()},
 	)
 	defer db.Close()
 	r := sqlutils.MakeSQLRunner(db)
@@ -74,7 +74,7 @@ func TestTenantCannotSetClusterSetting(t *testing.T) {
 	defer tc.Stopper().Stop(ctx)
 
 	// StartTenant with the default permissions to
-	_, db := serverutils.StartTenant(t, tc.Server(0), base.TestTenantArgs{TenantID: roachpb.MakeTenantID(10), AllowSettingClusterSettings: false})
+	_, db := serverutils.StartTenant(t, tc.Server(0), base.TestTenantArgs{TenantID: serverutils.TestTenantID(), AllowSettingClusterSettings: false})
 	defer db.Close()
 	_, err := db.Exec(`SET CLUSTER SETTING sql.defaults.vectorize=off`)
 	require.NoError(t, err)
@@ -118,7 +118,7 @@ func TestTenantHTTP(t *testing.T) {
 
 	tenant, err := tc.Server(0).StartTenant(ctx,
 		base.TestTenantArgs{
-			TenantID: roachpb.MakeTenantID(security.EmbeddedTenantIDs()[0]),
+			TenantID: serverutils.TestTenantID(),
 		})
 	require.NoError(t, err)
 	t.Run("prometheus", func(t *testing.T) {
@@ -154,7 +154,7 @@ func TestIdleExit(t *testing.T) {
 	countdownDuration := 4000 * time.Millisecond
 	tenant, err := tc.Server(0).StartTenant(ctx,
 		base.TestTenantArgs{
-			TenantID:      roachpb.MakeTenantID(10),
+			TenantID:      serverutils.TestTenantID(),
 			IdleExitAfter: warmupDuration,
 			TestingKnobs: base.TestingKnobs{
 				TenantTestingKnobs: &sql.TenantTestingKnobs{

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job_test.go
@@ -21,7 +21,6 @@ import (
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/streamingccl/streamproducer"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/jobutils"
@@ -50,7 +49,7 @@ func TestTenantStreaming(t *testing.T) {
 	defer source.Stopper().Stop(ctx)
 
 	// Start tenant server in the srouce cluster.
-	tenantID := roachpb.MakeTenantID(10)
+	tenantID := serverutils.TestTenantID()
 	_, tenantConn := serverutils.StartTenant(t, source, base.TestTenantArgs{TenantID: tenantID})
 	defer tenantConn.Close()
 	// sourceSQL refers to the tenant generating the data.

--- a/pkg/ccl/streamingccl/streamingtest/replication_helpers.go
+++ b/pkg/ccl/streamingccl/streamingtest/replication_helpers.go
@@ -186,7 +186,7 @@ SET CLUSTER SETTING sql.defaults.experimental_stream_replication.enabled = 'on';
 	require.NoError(t, err)
 
 	// Start tenant server
-	tenantID := roachpb.MakeTenantID(10)
+	tenantID := serverutils.TestTenantID()
 	_, tenantConn := serverutils.StartTenant(t, s, base.TestTenantArgs{TenantID: tenantID})
 
 	// Sink to read data from.

--- a/pkg/ccl/testccl/sqlccl/BUILD.bazel
+++ b/pkg/ccl/testccl/sqlccl/BUILD.bazel
@@ -35,7 +35,6 @@ go_test(
     deps = [
         "//pkg/base",
         "//pkg/ccl/kvccl/kvtenantccl",
-        "//pkg/roachpb",
         "//pkg/security",
         "//pkg/security/securitytest",
         "//pkg/server",

--- a/pkg/ccl/testccl/sqlccl/run_control_test.go
+++ b/pkg/ccl/testccl/sqlccl/run_control_test.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/kvccl/kvtenantccl"
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltestutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -48,7 +47,7 @@ func makeRunControlTestCases(t *testing.T) ([]runControlTestCase, func()) {
 	testCases[0].conn1 = tc.ServerConn(0).Conn
 	testCases[0].conn2 = tc.ServerConn(1).Conn
 
-	_, tenantDB := serverutils.StartTenant(t, tc.Server(0), base.TestTenantArgs{TenantID: roachpb.MakeTenantID(10)})
+	_, tenantDB := serverutils.StartTenant(t, tc.Server(0), base.TestTenantArgs{TenantID: serverutils.TestTenantID()})
 	testCases[1].name = "Tenant"
 	testCases[1].conn1 = tenantDB.Conn
 	testCases[1].conn2 = tenantDB.Conn

--- a/pkg/kv/kvserver/client_tenant_test.go
+++ b/pkg/kv/kvserver/client_tenant_test.go
@@ -60,7 +60,7 @@ func TestTenantsStorageMetricsOnSplit(t *testing.T) {
 	require.NoError(t, err)
 	defer store.Stopper().Stop(ctx)
 
-	tenantID := roachpb.MakeTenantID(10)
+	tenantID := serverutils.TestTenantID()
 	codec := keys.MakeSQLCodec(tenantID)
 
 	tenantPrefix := codec.TenantPrefix()
@@ -162,7 +162,7 @@ func TestTenantRateLimiter(t *testing.T) {
 	ctx := context.Background()
 	defer s.Stopper().Stop(ctx)
 
-	tenantID := roachpb.MakeTenantID(10)
+	tenantID := serverutils.TestTenantID()
 	codec := keys.MakeSQLCodec(tenantID)
 
 	tenantPrefix := codec.TenantPrefix()
@@ -235,7 +235,7 @@ func TestTenantRateLimiter(t *testing.T) {
 		return string(read)
 	}
 	makeMetricStr := func(expCount int64) string {
-		const tenantMetricStr = `kv_tenant_rate_limit_write_requests_admitted{store="1",tenant_id="10"}`
+		tenantMetricStr := fmt.Sprintf(`kv_tenant_rate_limit_write_requests_admitted{store="1",tenant_id="%d"}`, tenantID.ToUint64())
 		return fmt.Sprintf("%s %d", tenantMetricStr, expCount)
 	}
 

--- a/pkg/server/diagnostics/reporter_test.go
+++ b/pkg/server/diagnostics/reporter_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/server/diagnostics"
 	"github.com/cockroachdb/cockroach/pkg/server/diagnostics/diagnosticspb"
@@ -55,7 +54,7 @@ func TestTenantReport(t *testing.T) {
 	defer rt.Close()
 
 	tenantArgs := base.TestTenantArgs{
-		TenantID:                    roachpb.MakeTenantID(security.EmbeddedTenantIDs()[0]),
+		TenantID:                    serverutils.TestTenantID(),
 		AllowSettingClusterSettings: true,
 		TestingKnobs:                rt.testingKnobs,
 	}

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1446,7 +1446,7 @@ func (t *logicTest) newCluster(serverArgs TestServerArgs) {
 	if cfg.useTenant {
 		var err error
 		tenantArgs := base.TestTenantArgs{
-			TenantID:                    roachpb.MakeTenantID(10),
+			TenantID:                    serverutils.TestTenantID(),
 			AllowSettingClusterSettings: true,
 			TestingKnobs: base.TestingKnobs{
 				SQLExecutor: &sql.ExecutorTestingKnobs{

--- a/pkg/sql/sqltestutils/BUILD.bazel
+++ b/pkg/sql/sqltestutils/BUILD.bazel
@@ -16,7 +16,6 @@ go_library(
         "//pkg/keys",
         "//pkg/kv",
         "//pkg/roachpb",
-        "//pkg/security",
         "//pkg/server",
         "//pkg/server/diagnostics",
         "//pkg/sql",

--- a/pkg/sql/sqltestutils/telemetry.go
+++ b/pkg/sql/sqltestutils/telemetry.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/server/diagnostics"
 	"github.com/cockroachdb/cockroach/pkg/sql"
@@ -161,7 +160,7 @@ func (tt *telemetryTest) Start(t *testing.T, serverArgs []base.TestServerArgs) {
 	log.TestingClearServerIdentifiers()
 
 	tt.tenant, tt.tenantDB = serverutils.StartTenant(tt.t, tt.server, base.TestTenantArgs{
-		TenantID:                    roachpb.MakeTenantID(security.EmbeddedTenantIDs()[0]),
+		TenantID:                    serverutils.TestTenantID(),
 		AllowSettingClusterSettings: true,
 		TestingKnobs:                mapServerArgs[0].Knobs,
 	})

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -355,6 +355,13 @@ func StartTenant(
 	return tenant, goDB
 }
 
+// TestTenantID returns a roachpb.TenantID that can be used when
+// starting a test Tenant. The returned tenant IDs match those built
+// into the test certificates.
+func TestTenantID() roachpb.TenantID {
+	return roachpb.MakeTenantID(security.EmbeddedTenantIDs()[0])
+}
+
 // GetJSONProto uses the supplied client to GET the URL specified by the parameters
 // and unmarshals the result into response.
 func GetJSONProto(ts TestServerInterface, path string, response protoutil.Message) error {


### PR DESCRIPTION
The certificates used for testing are only valid for a specified set
of tenant IDs. If you happen to copy and paste some Tenant creation
code but then for some reason change the constant, your test will
start failing.  While not too hard debug, it would be nice if test
code didn't have to know about this in most cases.

The new serverutils.TestTenantID() returns the first tenant ID that
the certs will work for. Many callsites that don't care about the
particular ID can use this directly.

Release note: None