### PR TITLE
opt: fix bug in placeholder fast path

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/prepare
+++ b/pkg/sql/logictest/testdata/logic_test/prepare
@@ -1381,3 +1381,13 @@ DROP TABLE greeting_table
 # drop the type using prepared statement.
 statement ok
 EXECUTE enum_drop
+
+# Regression test for #64765.
+statement ok
+CREATE TABLE t64765 (x INT PRIMARY KEY, y INT, z INT)
+
+statement ok
+PREPARE q64765 as SELECT * FROM t64765 WHERE x = $1 AND y = $2
+
+statement ok
+EXECUTE q64765(1, 1)

--- a/pkg/sql/opt/xform/placeholder_fast_path.go
+++ b/pkg/sql/opt/xform/placeholder_fast_path.go
@@ -149,8 +149,9 @@ func (o *Optimizer) TryPlaceholderFastPath() (_ opt.Expr, ok bool, err error) {
 			}
 		}
 
-		idxColCount := index.ColumnCount()
-		if idxColCount < numConstrained {
+		// Verify that the constraint columns are (in some permutation) a prefix of
+		// the indexed columns.
+		if index.LaxKeyColumnCount() < numConstrained {
 			continue
 		}
 
@@ -166,7 +167,7 @@ func (o *Optimizer) TryPlaceholderFastPath() (_ opt.Expr, ok bool, err error) {
 
 		// Check if the index is covering.
 		indexCols := prefixCols.Copy()
-		for i := numConstrained; i < idxColCount; i++ {
+		for i, n := numConstrained, index.ColumnCount(); i < n; i++ {
 			ord := index.Column(i).Ordinal()
 			indexCols.Add(tabMeta.MetaID.ColumnID(ord))
 		}

--- a/pkg/sql/opt/xform/testdata/placeholder-fast-path/scan
+++ b/pkg/sql/opt/xform/testdata/placeholder-fast-path/scan
@@ -15,6 +15,14 @@ CREATE TABLE abcd (
 )
 ----
 
+exec-ddl
+CREATE TABLE xyz (
+  x INT PRIMARY KEY,
+  y INT,
+  z INT
+)
+----
+
 placeholder-fast-path
 SELECT * FROM kv WHERE k = $1
 ----
@@ -286,3 +294,9 @@ placeholder-scan partial1@pseudo_ab,partial
  ├── fd: ()-->(2)
  └── span
       └── $1
+
+# Regression test for #64765 - we cannot constrain both columns.
+placeholder-fast-path
+SELECT * FROM xyz WHERE x = $1 AND y = $2
+----
+no fast path


### PR DESCRIPTION
This commit fixes a bug in the placeholder fast path where we try to
constrain the primary index by more than the primary key columns (we
were using the wrong column count).

Fixes #64765.

Release note (bug fix): fixed an "index out of range" internal error
with certain simple queries.