### PR TITLE
docs, server: fix link in logformats.md

### DIFF
--- a/docs/generated/logformats.md
+++ b/docs/generated/logformats.md
@@ -77,18 +77,18 @@ Each line of output starts with the following prefix:
 
      Lyymmdd hh:mm:ss.uuuuuu goid [chan@]file:line marker
 
-| Field           | Description                                                                                                               |
-|-----------------|---------------------------------------------------------------------------------------------------------------------------|
-| L               | A single character, representing the [log level](logging.html#logging-levels) (e.g., `I` for `INFO`). |
-| yy              | The year (zero padded; i.e., 2016 is `16`).                                                                     |
-| mm              | The month (zero padded; i.e., May is `05`).                                                                     |
-| dd              | The day (zero padded).                                                                                                    |
-| hh:mm:ss.uuuuuu | Time in hours, minutes and fractional seconds. Timezone is UTC.                                                           |
-| goid            | The goroutine id (omitted if zero for use by tests).                                                                      |
-| chan            | The channel number (omitted if zero for backward compatibility).                                                          |
-| file            | The file name where the entry originated.                                                                                 |
-| line            | The line number where the entry originated.                                                                               |
-| marker          | Redactability marker ` + redactableIndicator + ` (see below for details).                                       |
+| Field           | Description                                                                                                                          |
+|-----------------|--------------------------------------------------------------------------------------------------------------------------------------|
+| L               | A single character, representing the [log level](logging.html#logging-levels-severities) (e.g., `I` for `INFO`). |
+| yy              | The year (zero padded; i.e., 2016 is `16`).                                                                                |
+| mm              | The month (zero padded; i.e., May is `05`).                                                                                |
+| dd              | The day (zero padded).                                                                                                               |
+| hh:mm:ss.uuuuuu | Time in hours, minutes and fractional seconds. Timezone is UTC.                                                                      |
+| goid            | The goroutine id (omitted if zero for use by tests).                                                                                 |
+| chan            | The channel number (omitted if zero for backward compatibility).                                                                     |
+| file            | The file name where the entry originated.                                                                                            |
+| line            | The line number where the entry originated.                                                                                          |
+| marker          | Redactability marker ` + redactableIndicator + ` (see below for details).                                                  |
 
 The redactability marker can be empty; in this case, its position in the common prefix is
 a double ASCII space character which can be used to reliably identify this situation.
@@ -142,18 +142,18 @@ Each line of output starts with the following prefix:
 
      Lyymmdd hh:mm:ss.uuuuuu goid [chan@]file:line marker tags counter
 
-| Field           | Description                                                                                                               |
-|-----------------|---------------------------------------------------------------------------------------------------------------------------|
-| L               | A single character, representing the [log level](logging.html#logging-levels) (e.g., `I` for `INFO`). |
-| yy              | The year (zero padded; i.e., 2016 is `16`).                                                                     |
-| mm              | The month (zero padded; i.e., May is `05`).                                                                     |
-| dd              | The day (zero padded).                                                                                                    |
-| hh:mm:ss.uuuuuu | Time in hours, minutes and fractional seconds. Timezone is UTC.                                                           |
-| goid            | The goroutine id (omitted if zero for use by tests).                                                                      |
-| chan            | The channel number (omitted if zero for backward compatibility).                                                          |
-| file            | The file name where the entry originated.                                                                                 |
-| line            | The line number where the entry originated.                                                                               |
-| marker          | Redactability marker ` + redactableIndicator + ` (see below for details).                                       |
+| Field           | Description                                                                                                                          |
+|-----------------|--------------------------------------------------------------------------------------------------------------------------------------|
+| L               | A single character, representing the [log level](logging.html#logging-levels-severities) (e.g., `I` for `INFO`). |
+| yy              | The year (zero padded; i.e., 2016 is `16`).                                                                                |
+| mm              | The month (zero padded; i.e., May is `05`).                                                                                |
+| dd              | The day (zero padded).                                                                                                               |
+| hh:mm:ss.uuuuuu | Time in hours, minutes and fractional seconds. Timezone is UTC.                                                                      |
+| goid            | The goroutine id (omitted if zero for use by tests).                                                                                 |
+| chan            | The channel number (omitted if zero for backward compatibility).                                                                     |
+| file            | The file name where the entry originated.                                                                                            |
+| line            | The line number where the entry originated.                                                                                          |
+| marker          | Redactability marker ` + redactableIndicator + ` (see below for details).                                                  |
 | tags    | The logging tags, enclosed between `[` and `]`. May be absent. |
 | counter | The entry counter. Always present.                                                 |
 
@@ -195,21 +195,21 @@ Each line of output starts with the following prefix:
 
      Lyymmdd hh:mm:ss.uuuuuu goid [chan@]file:line marker [tags...] counter cont
 
-| Field           | Description                                                                                                               |
-|-----------------|---------------------------------------------------------------------------------------------------------------------------|
-| L               | A single character, representing the [log level](logging.html#logging-levels) (e.g., `I` for `INFO`). |
-| yy              | The year (zero padded; i.e., 2016 is `16`).                                                                     |
-| mm              | The month (zero padded; i.e., May is `05`).                                                                     |
-| dd              | The day (zero padded).                                                                                                    |
-| hh:mm:ss.uuuuuu | Time in hours, minutes and fractional seconds. Timezone is UTC.                                                           |
-| goid            | The goroutine id (zero when cannot be determined).                                                                        |
-| chan            | The channel number (omitted if zero for backward compatibility).                                                          |
-| file            | The file name where the entry originated. Also see below.                                                                 |
-| line            | The line number where the entry originated.                                                                               |
-| marker          | Redactability marker "⋮" (see below for details).                                               |
-| tags            | The logging tags, enclosed between `[` and `]`. See below.                                            |
-| counter         | The optional entry counter (see below for details).                                                                       |
-| cont            | Continuation mark for structured and multi-line entries. See below.                                                       |
+| Field           | Description                                                                                                                          |
+|-----------------|--------------------------------------------------------------------------------------------------------------------------------------|
+| L               | A single character, representing the [log level](logging.html#logging-levels-severities) (e.g., `I` for `INFO`). |
+| yy              | The year (zero padded; i.e., 2016 is `16`).                                                                                |
+| mm              | The month (zero padded; i.e., May is `05`).                                                                                |
+| dd              | The day (zero padded).                                                                                                               |
+| hh:mm:ss.uuuuuu | Time in hours, minutes and fractional seconds. Timezone is UTC.                                                                      |
+| goid            | The goroutine id (zero when cannot be determined).                                                                                   |
+| chan            | The channel number (omitted if zero for backward compatibility).                                                                     |
+| file            | The file name where the entry originated. Also see below.                                                                            |
+| line            | The line number where the entry originated.                                                                                          |
+| marker          | Redactability marker "⋮" (see below for details).                                                          |
+| tags            | The logging tags, enclosed between `[` and `]`. See below.                                                       |
+| counter         | The optional entry counter (see below for details).                                                                                  |
+| cont            | Continuation mark for structured and multi-line entries. See below.                                                                  |
 
 The `chan@` prefix before the file name indicates the logging channel,
 and is omitted if the channel is `DEV`.

--- a/docs/generated/logsinks.md
+++ b/docs/generated/logsinks.md
@@ -138,7 +138,7 @@ For example:
 The default output format for Fluent sinks is
 `json-fluent-compact`. The `fluent` variants of the JSON formats
 include a `tag` field as required by the Fluentd protocol, which
-the non-`fluent` JSON [format variants](logformats.html) do not include.
+the non-`fluent` JSON [format variants](log-formats.html) do not include.
 
 {{site.data.alerts.callout_info}}
 Run `cockroach debug check-log-config` to verify the effect of defaults inheritance.

--- a/pkg/util/log/format_crdb_v1.go
+++ b/pkg/util/log/format_crdb_v1.go
@@ -128,18 +128,18 @@ Each line of output starts with the following prefix:
 
 	buf.WriteString(`
 
-| Field           | Description                                                                                                               |
-|-----------------|---------------------------------------------------------------------------------------------------------------------------|
-| L               | A single character, representing the [log level](logging.html#logging-levels) (e.g., ` + "`I`" + ` for ` + "`INFO`" + `). |
-| yy              | The year (zero padded; i.e., 2016 is ` + "`16`" + `).                                                                     |
-| mm              | The month (zero padded; i.e., May is ` + "`05`" + `).                                                                     |
-| dd              | The day (zero padded).                                                                                                    |
-| hh:mm:ss.uuuuuu | Time in hours, minutes and fractional seconds. Timezone is UTC.                                                           |
-| goid            | The goroutine id (omitted if zero for use by tests).                                                                      |
-| chan            | The channel number (omitted if zero for backward compatibility).                                                          |
-| file            | The file name where the entry originated.                                                                                 |
-| line            | The line number where the entry originated.                                                                               |
-| marker          | Redactability marker ` + "` + redactableIndicator + `" + ` (see below for details).                                       |`)
+| Field           | Description                                                                                                                          |
+|-----------------|--------------------------------------------------------------------------------------------------------------------------------------|
+| L               | A single character, representing the [log level](logging.html#logging-levels-severities) (e.g., ` + "`I`" + ` for ` + "`INFO`" + `). |
+| yy              | The year (zero padded; i.e., 2016 is ` + "`16`" + `).                                                                                |
+| mm              | The month (zero padded; i.e., May is ` + "`05`" + `).                                                                                |
+| dd              | The day (zero padded).                                                                                                               |
+| hh:mm:ss.uuuuuu | Time in hours, minutes and fractional seconds. Timezone is UTC.                                                                      |
+| goid            | The goroutine id (omitted if zero for use by tests).                                                                                 |
+| chan            | The channel number (omitted if zero for backward compatibility).                                                                     |
+| file            | The file name where the entry originated.                                                                                            |
+| line            | The line number where the entry originated.                                                                                          |
+| marker          | Redactability marker ` + "` + redactableIndicator + `" + ` (see below for details).                                                  |`)
 
 	if withCounter {
 		buf.WriteString(`

--- a/pkg/util/log/format_crdb_v2.go
+++ b/pkg/util/log/format_crdb_v2.go
@@ -46,21 +46,21 @@ Each line of output starts with the following prefix:
 
      Lyymmdd hh:mm:ss.uuuuuu goid [chan@]file:line marker [tags...] counter cont
 
-| Field           | Description                                                                                                               |
-|-----------------|---------------------------------------------------------------------------------------------------------------------------|
-| L               | A single character, representing the [log level](logging.html#logging-levels) (e.g., ` + "`I`" + ` for ` + "`INFO`" + `). |
-| yy              | The year (zero padded; i.e., 2016 is ` + "`16`" + `).                                                                     |
-| mm              | The month (zero padded; i.e., May is ` + "`05`" + `).                                                                     |
-| dd              | The day (zero padded).                                                                                                    |
-| hh:mm:ss.uuuuuu | Time in hours, minutes and fractional seconds. Timezone is UTC.                                                           |
-| goid            | The goroutine id (zero when cannot be determined).                                                                        |
-| chan            | The channel number (omitted if zero for backward compatibility).                                                          |
-| file            | The file name where the entry originated. Also see below.                                                                 |
-| line            | The line number where the entry originated.                                                                               |
-| marker          | Redactability marker "` + redactableIndicator + `" (see below for details).                                               |
-| tags            | The logging tags, enclosed between ` + "`[`" + ` and ` + "`]`" + `. See below.                                            |
-| counter         | The optional entry counter (see below for details).                                                                       |
-| cont            | Continuation mark for structured and multi-line entries. See below.                                                       |
+| Field           | Description                                                                                                                          |
+|-----------------|--------------------------------------------------------------------------------------------------------------------------------------|
+| L               | A single character, representing the [log level](logging.html#logging-levels-severities) (e.g., ` + "`I`" + ` for ` + "`INFO`" + `). |
+| yy              | The year (zero padded; i.e., 2016 is ` + "`16`" + `).                                                                                |
+| mm              | The month (zero padded; i.e., May is ` + "`05`" + `).                                                                                |
+| dd              | The day (zero padded).                                                                                                               |
+| hh:mm:ss.uuuuuu | Time in hours, minutes and fractional seconds. Timezone is UTC.                                                                      |
+| goid            | The goroutine id (zero when cannot be determined).                                                                                   |
+| chan            | The channel number (omitted if zero for backward compatibility).                                                                     |
+| file            | The file name where the entry originated. Also see below.                                                                            |
+| line            | The line number where the entry originated.                                                                                          |
+| marker          | Redactability marker "` + redactableIndicator + `" (see below for details).                                                          |
+| tags            | The logging tags, enclosed between ` + "`[`" + ` and ` + "`]`" + `. See below.                                                       |
+| counter         | The optional entry counter (see below for details).                                                                                  |
+| cont            | Continuation mark for structured and multi-line entries. See below.                                                                  |
 
 The ` + "`chan@`" + ` prefix before the file name indicates the logging channel,
 and is omitted if the channel is ` + "`DEV`" + `.

--- a/pkg/util/log/logconfig/config.go
+++ b/pkg/util/log/logconfig/config.go
@@ -280,7 +280,7 @@ type FluentDefaults struct {
 // The default output format for Fluent sinks is
 // `json-fluent-compact`. The `fluent` variants of the JSON formats
 // include a `tag` field as required by the Fluentd protocol, which
-// the non-`fluent` JSON [format variants](logformats.html) do not include.
+// the non-`fluent` JSON [format variants](log-formats.html) do not include.
 //
 // {{site.data.alerts.callout_info}}
 // Run `cockroach debug check-log-config` to verify the effect of defaults inheritance.


### PR DESCRIPTION
Fixed incorrect links in the generated logformats.md that were causing a build error on https://github.com/cockroachdb/docs/pull/10273

@knz I wasn't able to correctly generate logformats.md with the changes I made to the code. The command `docgen logformats docs/generated/logformats.md` was causing logformats.md to revert to an even earlier version of that doc, and I don't know why. I manually updated logformats.md with the correct URL and have included that file in this PR; not sure if this will work. I apologize if this creates more housekeeping work. 