### PR TITLE
bazel: handle `mockgen` in Bazel sandbox

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -75,6 +75,7 @@ load("@bazel_gazelle//:def.bzl", "gazelle")
 # gazelle:exclude **/*.pb.gw.go
 # gazelle:exclude **/*_interval_btree.go
 # gazelle:exclude **/*_interval_btree_test.go
+# gazelle:exclude **/mocks_generated.go
 # gazelle:exclude pkg/sql/parser/sql.go
 # gazelle:exclude pkg/sql/parser/helpmap_test.go
 # gazelle:exclude pkg/sql/parser/help_messages.go

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -178,3 +178,12 @@ rules_foreign_cc_dependencies()
 load("//build:toolchains/REPOSITORIES.bzl", "toolchain_dependencies")
 
 toolchain_dependencies()
+
+http_archive(
+    name = "bazel_gomock",
+    sha256 = "692421b0c5e04ae4bc0bfff42fb1ce8671fe68daee2b8d8ea94657bb1fcddc0a",
+    strip_prefix = "bazel_gomock-fde78c91cf1783cc1e33ba278922ba67a6ee2a84",
+    urls = [
+        "https://github.com/jmhodges/bazel_gomock/archive/fde78c91cf1783cc1e33ba278922ba67a6ee2a84.tar.gz",
+    ],
+)

--- a/pkg/ccl/sqlproxyccl/admitter/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/admitter/BUILD.bazel
@@ -1,19 +1,29 @@
+load("@bazel_gomock//:gomock.bzl", "gomock")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+# gazelle:exclude service.go
+
+go_library(
+    name = "service",
+    srcs = ["service.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/admitter",
+    visibility = ["//visibility:private"],
+)
 
 go_library(
     name = "admitter",
     srcs = [
         "local.go",
-        "mocks_generated.go",
-        "service.go",
+        ":mocks_admitter",  # keep
     ],
+    embed = [":service"],  # keep
     importpath = "github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/admitter",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/util/log",
         "//pkg/util/syncutil",
         "@com_github_cockroachdb_errors//:errors",
-        "@com_github_golang_mock//gomock",
+        "@com_github_golang_mock//gomock",  # keep
     ],
 )
 
@@ -22,4 +32,12 @@ go_test(
     srcs = ["local_test.go"],
     embed = [":admitter"],
     deps = ["@com_github_stretchr_testify//require"],
+)
+
+gomock(
+    name = "mocks_admitter",
+    out = "mocks_generated.go",
+    interfaces = ["Service"],
+    library = ":service",
+    package = "admitter",
 )

--- a/pkg/ccl/sqlproxyccl/denylist/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/denylist/BUILD.bazel
@@ -1,12 +1,22 @@
+load("@bazel_gomock//:gomock.bzl", "gomock")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+# gazelle:exclude service.go
+
+go_library(
+    name = "service",
+    srcs = ["service.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/denylist",
+    visibility = ["//visibility:private"],
+)
 
 go_library(
     name = "denylist",
     srcs = [
         "local_file.go",
-        "mocks_generated.go",
-        "service.go",
+        ":mocks_denylist",  # keep
     ],
+    embed = [":service"],  # keep
     importpath = "github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/denylist",
     visibility = ["//visibility:public"],
     deps = [
@@ -15,7 +25,7 @@ go_library(
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
-        "@com_github_golang_mock//gomock",
+        "@com_github_golang_mock//gomock",  # keep
         "@com_github_spf13_viper//:viper",
     ],
 )
@@ -28,4 +38,13 @@ go_test(
         "//pkg/util/leaktest",
         "@com_github_stretchr_testify//require",
     ],
+)
+
+gomock(
+    name = "mocks_denylist",
+    out = "mocks_generated.go",
+    interfaces = ["Service"],
+    library = ":service",
+    package = "denylist",
+    self_package = "github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/denylist",
 )

--- a/pkg/ccl/sqlproxyccl/tenant/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/tenant/BUILD.bazel
@@ -1,6 +1,7 @@
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@bazel_gomock//:gomock.bzl", "gomock")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "tenant_proto",
@@ -24,8 +25,8 @@ go_library(
     srcs = [
         "directory.go",
         "entry.go",
-        "mocks_generated.go",
         "test_directory_svr.go",
+        ":mocks_tenant",  # keep
     ],
     embed = [":tenant_go_proto"],
     importpath = "github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/tenant",
@@ -39,9 +40,9 @@ go_library(
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",
-        "@com_github_golang_mock//gomock",
+        "@com_github_golang_mock//gomock",  # keep
         "@org_golang_google_grpc//:go_default_library",
-        "@org_golang_google_grpc//metadata",
+        "@org_golang_google_grpc//metadata",  # keep
         "@org_golang_google_grpc//status",
     ],
 )
@@ -72,4 +73,16 @@ go_test(
         "@com_github_stretchr_testify//require",
         "@org_golang_google_grpc//:go_default_library",
     ],
+)
+
+gomock(
+    name = "mocks_tenant",
+    out = "mocks_generated.go",
+    interfaces = [
+        "DirectoryClient",
+        "Directory_WatchEndpointsClient",
+    ],
+    library = ":tenant_go_proto",
+    package = "tenant",
+    self_package = "github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/tenant",
 )

--- a/pkg/security/certmgr/BUILD.bazel
+++ b/pkg/security/certmgr/BUILD.bazel
@@ -1,13 +1,23 @@
+load("@bazel_gomock//:gomock.bzl", "gomock")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+# gazelle:exclude cert.go
+
+go_library(
+    name = "certlib",
+    srcs = ["cert.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/security/certmgr",
+    visibility = ["//visibility:private"],
+)
 
 go_library(
     name = "certmgr",
     srcs = [
-        "cert.go",
         "cert_manager.go",
         "file_cert.go",
-        "mocks_generated.go",
+        ":mocks_certmgr",  # keep
     ],
+    embed = [":certlib"],  # keep
     importpath = "github.com/cockroachdb/cockroach/pkg/security/certmgr",
     visibility = ["//visibility:public"],
     deps = [
@@ -16,7 +26,7 @@ go_library(
         "//pkg/util/syncutil",
         "//pkg/util/sysutil",
         "@com_github_cockroachdb_errors//:errors",
-        "@com_github_golang_mock//gomock",
+        "@com_github_golang_mock//gomock",  # keep
     ],
 )
 
@@ -38,4 +48,12 @@ go_test(
         "@com_github_stretchr_testify//require",
         "@org_golang_x_sys//unix",
     ],
+)
+
+gomock(
+    name = "mocks_certmgr",
+    out = "mocks_generated.go",
+    interfaces = ["Cert"],
+    library = ":certlib",
+    package = "certmgr",
 )


### PR DESCRIPTION
There's an open-source library to do this for us, and it works well
enough, so I just pull it in and use it everywhere we call into
`mockgen`.

Now there's only one un-bazelfied `go:generate` in-tree:
`pkg/server/api_v2.go` :)

Release note: None