### PR TITLE
release-21.1: colexecbase: fix casting integers to smaller widths

### DIFF
--- a/pkg/sql/colexec/colexecbase/cast.eg.go
+++ b/pkg/sql/colexec/colexecbase/cast.eg.go
@@ -1494,9 +1494,7 @@ func (c *castInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 						}
 						v := inputCol.Get(tupleIdx)
 						var r int32
-
 						r = int32(v)
-
 						outputCol[tupleIdx] = r
 					}
 				} else {
@@ -1512,9 +1510,7 @@ func (c *castInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r int32
-
 						r = int32(v)
-
 						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
@@ -1530,9 +1526,7 @@ func (c *castInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 						tupleIdx = sel[i]
 						v := inputCol.Get(tupleIdx)
 						var r int32
-
 						r = int32(v)
-
 						outputCol[tupleIdx] = r
 					}
 				} else {
@@ -1545,9 +1539,7 @@ func (c *castInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r int32
-
 						r = int32(v)
-
 						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
@@ -1607,9 +1599,7 @@ func (c *castInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 						}
 						v := inputCol.Get(tupleIdx)
 						var r int64
-
 						r = int64(v)
-
 						outputCol[tupleIdx] = r
 					}
 				} else {
@@ -1625,9 +1615,7 @@ func (c *castInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r int64
-
 						r = int64(v)
-
 						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
@@ -1643,9 +1631,7 @@ func (c *castInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 						tupleIdx = sel[i]
 						v := inputCol.Get(tupleIdx)
 						var r int64
-
 						r = int64(v)
-
 						outputCol[tupleIdx] = r
 					}
 				} else {
@@ -1658,9 +1644,7 @@ func (c *castInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r int64
-
 						r = int64(v)
-
 						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
@@ -2076,6 +2060,10 @@ func (c *castInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 						v := inputCol.Get(tupleIdx)
 						var r int16
 
+						shifted := v >> uint(15)
+						if (v >= 0 && shifted > 0) || (v < 0 && shifted < -1) {
+							colexecerror.ExpectedError(tree.ErrInt2OutOfRange)
+						}
 						r = int16(v)
 
 						outputCol[tupleIdx] = r
@@ -2094,6 +2082,10 @@ func (c *castInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 						v := inputCol.Get(tupleIdx)
 						var r int16
 
+						shifted := v >> uint(15)
+						if (v >= 0 && shifted > 0) || (v < 0 && shifted < -1) {
+							colexecerror.ExpectedError(tree.ErrInt2OutOfRange)
+						}
 						r = int16(v)
 
 						//gcassert:bce
@@ -2112,6 +2104,10 @@ func (c *castInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 						v := inputCol.Get(tupleIdx)
 						var r int16
 
+						shifted := v >> uint(15)
+						if (v >= 0 && shifted > 0) || (v < 0 && shifted < -1) {
+							colexecerror.ExpectedError(tree.ErrInt2OutOfRange)
+						}
 						r = int16(v)
 
 						outputCol[tupleIdx] = r
@@ -2127,6 +2123,10 @@ func (c *castInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 						v := inputCol.Get(tupleIdx)
 						var r int16
 
+						shifted := v >> uint(15)
+						if (v >= 0 && shifted > 0) || (v < 0 && shifted < -1) {
+							colexecerror.ExpectedError(tree.ErrInt2OutOfRange)
+						}
 						r = int16(v)
 
 						//gcassert:bce
@@ -2293,9 +2293,7 @@ func (c *castInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 						}
 						v := inputCol.Get(tupleIdx)
 						var r int64
-
 						r = int64(v)
-
 						outputCol[tupleIdx] = r
 					}
 				} else {
@@ -2311,9 +2309,7 @@ func (c *castInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r int64
-
 						r = int64(v)
-
 						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
@@ -2329,9 +2325,7 @@ func (c *castInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 						tupleIdx = sel[i]
 						v := inputCol.Get(tupleIdx)
 						var r int64
-
 						r = int64(v)
-
 						outputCol[tupleIdx] = r
 					}
 				} else {
@@ -2344,9 +2338,7 @@ func (c *castInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 						//gcassert:bce
 						v := inputCol.Get(tupleIdx)
 						var r int64
-
 						r = int64(v)
-
 						//gcassert:bce
 						outputCol[tupleIdx] = r
 					}
@@ -2762,6 +2754,10 @@ func (c *castInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 						v := inputCol.Get(tupleIdx)
 						var r int16
 
+						shifted := v >> uint(15)
+						if (v >= 0 && shifted > 0) || (v < 0 && shifted < -1) {
+							colexecerror.ExpectedError(tree.ErrInt2OutOfRange)
+						}
 						r = int16(v)
 
 						outputCol[tupleIdx] = r
@@ -2780,6 +2776,10 @@ func (c *castInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 						v := inputCol.Get(tupleIdx)
 						var r int16
 
+						shifted := v >> uint(15)
+						if (v >= 0 && shifted > 0) || (v < 0 && shifted < -1) {
+							colexecerror.ExpectedError(tree.ErrInt2OutOfRange)
+						}
 						r = int16(v)
 
 						//gcassert:bce
@@ -2798,6 +2798,10 @@ func (c *castInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 						v := inputCol.Get(tupleIdx)
 						var r int16
 
+						shifted := v >> uint(15)
+						if (v >= 0 && shifted > 0) || (v < 0 && shifted < -1) {
+							colexecerror.ExpectedError(tree.ErrInt2OutOfRange)
+						}
 						r = int16(v)
 
 						outputCol[tupleIdx] = r
@@ -2813,6 +2817,10 @@ func (c *castInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 						v := inputCol.Get(tupleIdx)
 						var r int16
 
+						shifted := v >> uint(15)
+						if (v >= 0 && shifted > 0) || (v < 0 && shifted < -1) {
+							colexecerror.ExpectedError(tree.ErrInt2OutOfRange)
+						}
 						r = int16(v)
 
 						//gcassert:bce
@@ -2875,6 +2883,10 @@ func (c *castInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 						v := inputCol.Get(tupleIdx)
 						var r int32
 
+						shifted := v >> uint(31)
+						if (v >= 0 && shifted > 0) || (v < 0 && shifted < -1) {
+							colexecerror.ExpectedError(tree.ErrInt4OutOfRange)
+						}
 						r = int32(v)
 
 						outputCol[tupleIdx] = r
@@ -2893,6 +2905,10 @@ func (c *castInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 						v := inputCol.Get(tupleIdx)
 						var r int32
 
+						shifted := v >> uint(31)
+						if (v >= 0 && shifted > 0) || (v < 0 && shifted < -1) {
+							colexecerror.ExpectedError(tree.ErrInt4OutOfRange)
+						}
 						r = int32(v)
 
 						//gcassert:bce
@@ -2911,6 +2927,10 @@ func (c *castInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 						v := inputCol.Get(tupleIdx)
 						var r int32
 
+						shifted := v >> uint(31)
+						if (v >= 0 && shifted > 0) || (v < 0 && shifted < -1) {
+							colexecerror.ExpectedError(tree.ErrInt4OutOfRange)
+						}
 						r = int32(v)
 
 						outputCol[tupleIdx] = r
@@ -2926,6 +2946,10 @@ func (c *castInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 						v := inputCol.Get(tupleIdx)
 						var r int32
 
+						shifted := v >> uint(31)
+						if (v >= 0 && shifted > 0) || (v < 0 && shifted < -1) {
+							colexecerror.ExpectedError(tree.ErrInt4OutOfRange)
+						}
 						r = int32(v)
 
 						//gcassert:bce

--- a/pkg/sql/logictest/testdata/logic_test/cast
+++ b/pkg/sql/logictest/testdata/logic_test/cast
@@ -32,3 +32,31 @@ SELECT t0.c0 FROM t0 WHERE t0.c0 BETWEEN t0.c0 AND INTERVAL '-1'::DECIMAL
 query T
 SELECT t1.c0 FROM t1 WHERE t1.c0 BETWEEN t1.c0 AND INTERVAL '-1'::DECIMAL
 ----
+
+# Regression test for incorrectly casting integers out of range (#64429).
+statement ok
+CREATE TABLE t64429 (_int8 INT8, _int4 INT4);
+INSERT INTO t64429 VALUES (3000000000, 300000);
+
+statement error integer out of range for type int2
+SELECT _int8::INT2 FROM t64429
+
+statement error integer out of range for type int4
+SELECT _int8::INT4 FROM t64429
+
+statement error integer out of range for type int2
+SELECT _int4::INT2 FROM t64429
+
+# Also check the negative overflow.
+statement ok
+DELETE FROM t64429 WHERE true;
+INSERT INTO t64429 VALUES (-3000000000, -300000);
+
+statement error integer out of range for type int2
+SELECT _int8::INT2 FROM t64429
+
+statement error integer out of range for type int4
+SELECT _int8::INT4 FROM t64429
+
+statement error integer out of range for type int2
+SELECT _int4::INT2 FROM t64429

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -55,6 +55,10 @@ import (
 var (
 	// ErrIntOutOfRange is reported when integer arithmetic overflows.
 	ErrIntOutOfRange = pgerror.New(pgcode.NumericValueOutOfRange, "integer out of range")
+	// ErrInt4OutOfRange is reported when casting to INT4 overflows.
+	ErrInt4OutOfRange = pgerror.New(pgcode.NumericValueOutOfRange, "integer out of range for type int4")
+	// ErrInt2OutOfRange is reported when casting to INT2 overflows.
+	ErrInt2OutOfRange = pgerror.New(pgcode.NumericValueOutOfRange, "integer out of range for type int2")
 	// ErrFloatOutOfRange is reported when float arithmetic overflows.
 	ErrFloatOutOfRange = pgerror.New(pgcode.NumericValueOutOfRange, "float out of range")
 	errDecOutOfRange   = pgerror.New(pgcode.NumericValueOutOfRange, "decimal out of range")


### PR DESCRIPTION
Backport 1/1 commits from #64841.

/cc @cockroachdb/release

---

This was fixed for row-by-row engine during 21.1 time frame, and this
commit fixes the issue in the vectorized engine.

Fixes: #64429.

Release note (bug fix): Previously, CockroachDB could incorrectly cast
integers of larger widths to integers of smaller widths (e.g. INT8 to
INT2) when the former is out of range for the latter. Now this is fixed.
