### PR TITLE
reducesql: reduce index flags, computed columns, and index predicates

### DIFF
--- a/pkg/testutils/reduce/reducesql/testdata/simple
+++ b/pkg/testutils/reduce/reducesql/testdata/simple
@@ -10,7 +10,7 @@ WITH
 		)
 SELECT * FROM with_t1
 ----
-SELECT 1 / 0;
+SELECT 0 / 0;
 
 reduce
 WITH
@@ -26,7 +26,7 @@ SELECT
 FROM
 	w;
 ----
-VALUES (1 / 0);
+VALUES (0 / 0);
 
 reduce
 SELECT
@@ -34,7 +34,7 @@ SELECT
 FROM
 	(SELECT 1), (SELECT 2);
 ----
-SELECT 1 / 0;
+SELECT 0 / 0;
 
 reduce
 CREATE TABLE a (i) AS VALUES (1);
@@ -47,7 +47,7 @@ FROM
 	a, a AS c JOIN b ON true;
 ----
 ----
-CREATE TABLE a (i) AS VALUES (1);
+CREATE TABLE a (i) AS VALUES (0);
 
 CREATE TABLE b (j) AS VALUES (0);
 

--- a/pkg/testutils/reduce/reducesql/testdata/ungrouped-column
+++ b/pkg/testutils/reduce/reducesql/testdata/ungrouped-column
@@ -28,7 +28,7 @@ WITH
 						max(tab_1222.col3::UUID)::UUID AS col_3479,
 						stddev(tab_1222.col5::INT8)::DECIMAL AS col_3480
 					FROM
-						defaultdb.public.table1 AS tab_1222
+						defaultdb.public.table1@primary AS tab_1222
 					WHERE
 						false
 					GROUP BY


### PR DESCRIPTION
The `reduce` program now attempts to reduce problematic SQL by:

  1. Removing index flags:

    SELECT * FROM t@idx
    =>
    SELECT * FROM t

  2. Simplifying computed column expressions:

    CREATE TABLE t (i INT, j INT AS (i + 1234) STORED)
    =>
    CREATE TABLE t (i INT, j INT AS (i + 0) STORED)

  3. Transforming computed columns to non-computed columns:

    CREATE TABLE t (i INT, j INT AS (i + 10) STORED)
    =>
    CREATE TABLE t (i INT, j INT)

  4. Simplifying partial index predicates:

    CREATE TABLE t (i INT, INDEX (i) WHERE i > 1234)
    =>
    CREATE TABLE t (i INT, INDEX (i) WHERE i > 0)

  5. Transforming partial indexes to non-partial indexes:

    CREATE TABLE t (i INT, INDEX (i) WHERE i > 0)
    =>
    CREATE TABLE t (i INT, INDEX (i))

Release note: None