### PR TITLE
release-20.2: colrpc: shut down outbox tree on a graceful termination of a stream

### DIFF
--- a/pkg/sql/colflow/colrpc/colrpc_test.go
+++ b/pkg/sql/colflow/colrpc/colrpc_test.go
@@ -139,14 +139,15 @@ func TestOutboxInbox(t *testing.T) {
 	rng, _ := randutil.NewPseudoRand()
 	type cancellationType int
 	const (
-		// In this scenario, no cancellation happens and all the data is pushed from
-		// the Outbox to the Inbox.
+		// In this scenario, no cancellation happens and all the data is pushed
+		// from the Outbox to the Inbox.
 		noCancel cancellationType = iota
-		// streamCtxCancel models a scenario in which the Outbox host cancels the
-		// flow.
+		// streamCtxCancel models a scenario in which the Outbox host cancels
+		// the flow.
 		streamCtxCancel
 		// readerCtxCancel models a scenario in which the Inbox host cancels the
-		// flow. This is considered a graceful termination.
+		// flow. This is considered a graceful termination, and the flow context
+		// isn't canceled.
 		readerCtxCancel
 		// transportBreaks models a scenario in which the transport breaks.
 		transportBreaks
@@ -192,9 +193,9 @@ func TestOutboxInbox(t *testing.T) {
 			typs        = []*types.T{types.Int}
 			inputBuffer = colexecbase.NewBatchBuffer()
 			// Generate some random behavior before passing the random number
-			// generator to be used in the Outbox goroutine (to avoid races). These
-			// sleep variables enable a sleep for up to half a millisecond with a .25
-			// probability before cancellation.
+			// generator to be used in the Outbox goroutine (to avoid races).
+			// These sleep variables enable a sleep for up to half a millisecond
+			// with a .25 probability before cancellation.
 			sleepBeforeCancellation = rng.Float64() <= 0.25
 			sleepTime               = time.Microsecond * time.Duration(rng.Intn(500))
 			// stopwatch is used to measure how long it takes for the outbox to
@@ -203,9 +204,9 @@ func TestOutboxInbox(t *testing.T) {
 			transportBreaksProducerSleep = 4 * time.Second
 		)
 
-		// Test random selection as the Outbox should be deselecting before sending
-		// over data. Nulls and types are not worth testing as those are tested in
-		// colserde.
+		// Test random selection as the Outbox should be deselecting before
+		// sending over data. Nulls and types are not worth testing as those are
+		// tested in colserde.
 		args := coldatatestutils.RandomDataOpArgs{
 			DeterministicTyps: typs,
 			NumBatches:        64,
@@ -216,8 +217,8 @@ func TestOutboxInbox(t *testing.T) {
 		}
 
 		if cancellationScenario != noCancel {
-			// Crank up the number of batches so cancellation always happens in the
-			// middle of execution (or before).
+			// Crank up the number of batches so cancellation always happens in
+			// the middle of execution (or before).
 			args.NumBatches = math.MaxInt64
 			if cancellationScenario == transportBreaks {
 				// Insert an artificial sleep in order to simulate that the
@@ -253,8 +254,12 @@ func TestOutboxInbox(t *testing.T) {
 		streamHandlerErrCh := handleStream(serverStream.Context(), inbox, serverStream, func() { close(serverStreamNotification.Donec) })
 
 		var (
-			canceled uint32
-			wg       sync.WaitGroup
+			flowCtxCanceled uint32
+			// Because the outboxCtx must be a child of the flow context, we
+			// assume that if flowCtxCanceled is non-zero, then
+			// outboxCtxCanceled is too and don't check that explicitly.
+			outboxCtxCanceled uint32
+			wg                sync.WaitGroup
 		)
 		wg.Add(1)
 		go func() {
@@ -264,9 +269,13 @@ func TestOutboxInbox(t *testing.T) {
 			// to create a context of the node on which the outbox runs and keep
 			// it different from the streamCtx. This matters in
 			// 'transportBreaks' scenario.
-			var flowCtxCancel context.CancelFunc
-			outbox.runnerCtx, flowCtxCancel = context.WithCancel(ctx)
-			outbox.runWithStream(streamCtx, clientStream, flowCtxCancel, func() { atomic.StoreUint32(&canceled, 1) })
+			var flowCtxCancelFn context.CancelFunc
+			outbox.runnerCtx, flowCtxCancelFn = context.WithCancel(ctx)
+			flowCtxCancel := func() {
+				atomic.StoreUint32(&flowCtxCanceled, 1)
+				flowCtxCancelFn()
+			}
+			outbox.runWithStream(streamCtx, clientStream, flowCtxCancel, func() { atomic.StoreUint32(&outboxCtxCanceled, 1) })
 			wg.Done()
 		}()
 
@@ -343,14 +352,16 @@ func TestOutboxInbox(t *testing.T) {
 		// Verify expected state.
 		switch cancellationScenario {
 		case noCancel:
-			// Verify that the Outbox terminated gracefully (did not cancel its flow).
-			require.True(t, atomic.LoadUint32(&canceled) == 0)
+			// Verify that the Outbox terminated gracefully (did not cancel the
+			// flow context).
+			require.True(t, atomic.LoadUint32(&flowCtxCanceled) == 0)
+			require.True(t, atomic.LoadUint32(&outboxCtxCanceled) == 1)
 			// And the Inbox did as well.
 			require.NoError(t, streamHandlerErr)
 			require.NoError(t, readerErr)
 
-			// If no cancellation happened, the output can be fully verified against
-			// the input.
+			// If no cancellation happened, the output can be fully verified
+			// against the input.
 			for batchNum := 0; ; batchNum++ {
 				outputBatch := outputBatches.Next(ctx)
 				inputBatch := inputBatches.Next(ctx)
@@ -368,17 +379,17 @@ func TestOutboxInbox(t *testing.T) {
 				}
 			}
 		case streamCtxCancel:
-			// If the stream context gets canceled, GRPC should take care of closing
-			// and cleaning up the stream. The Inbox stream handler should have
-			// received the context cancellation and returned.
+			// If the stream context gets canceled, gRPC should take care of
+			// closing and cleaning up the stream. The Inbox stream handler
+			// should have received the context cancellation and returned.
 			require.Regexp(t, "context canceled", streamHandlerErr)
 			// The Inbox propagates this cancellation on its host.
 			require.True(t, testutils.IsError(readerErr, "context canceled"), readerErr)
 
-			// Recving on a canceled stream produces a context canceled error, but
-			// Sending produces an EOF, that should have triggered a flow context
-			// cancellation (which is redundant) in the Outbox.
-			require.True(t, atomic.LoadUint32(&canceled) == 1)
+			// Recving on a canceled stream produces a context canceled error
+			// which prompts the watchdog goroutine of the outbox to cancel the
+			// flow.
+			require.True(t, atomic.LoadUint32(&flowCtxCanceled) == 1)
 		case readerCtxCancel:
 			// If the reader context gets canceled, it is treated as a graceful
 			// termination of the stream, so we expect no error from the stream
@@ -387,12 +398,14 @@ func TestOutboxInbox(t *testing.T) {
 			// The Inbox should still propagate this error upwards.
 			require.True(t, testutils.IsError(readerErr, "context canceled"), readerErr)
 
-			// The cancellation should have been communicated to the Outbox, resulting
-			// in a Send EOF and a flow cancellation on the Outbox's host.
-			require.True(t, atomic.LoadUint32(&canceled) == 1)
+			// The cancellation should have been communicated to the Outbox,
+			// resulting in the watchdog goroutine canceling the outbox context
+			// (but not the flow).
+			require.True(t, atomic.LoadUint32(&flowCtxCanceled) == 0)
+			require.True(t, atomic.LoadUint32(&outboxCtxCanceled) == 1)
 		case transportBreaks:
 			// If the transport breaks, the scenario is very similar to
-			// streamCtxCancel. GRPC will cancel the stream handler's context.
+			// streamCtxCancel. gRPC will cancel the stream handler's context.
 			stopwatch.Stop()
 			// We expect that the outbox exits much sooner than it receives the
 			// next batch from its input in this scenario.
@@ -400,7 +413,7 @@ func TestOutboxInbox(t *testing.T) {
 			require.True(t, testutils.IsError(streamHandlerErr, "context canceled"), streamHandlerErr)
 			require.True(t, testutils.IsError(readerErr, "context canceled"), readerErr)
 
-			require.True(t, atomic.LoadUint32(&canceled) == 1)
+			require.True(t, atomic.LoadUint32(&flowCtxCanceled) == 1)
 		}
 	})
 }
@@ -540,12 +553,17 @@ func TestOutboxInboxMetadataPropagation(t *testing.T) {
 			require.NoError(t, err)
 
 			var (
-				canceled uint32
-				wg       sync.WaitGroup
+				flowCanceled, outboxCanceled uint32
+				wg                           sync.WaitGroup
 			)
 			wg.Add(1)
 			go func() {
-				outbox.runWithStream(ctx, clientStream, nil /* flowCtxCancel */, func() { atomic.StoreUint32(&canceled, 1) })
+				outbox.runWithStream(
+					ctx,
+					clientStream,
+					func() { atomic.StoreUint32(&flowCanceled, 1) },
+					func() { atomic.StoreUint32(&outboxCanceled, 1) },
+				)
 				wg.Done()
 			}()
 
@@ -555,9 +573,10 @@ func TestOutboxInboxMetadataPropagation(t *testing.T) {
 
 			wg.Wait()
 			require.NoError(t, <-streamHanderErrCh)
-			// Require that the outbox did not cancel the flow, this is a graceful
-			// drain.
-			require.True(t, atomic.LoadUint32(&canceled) == 0)
+			// Require that the outbox did not cancel the flow and did cancel
+			// the outbox since this is a graceful drain.
+			require.True(t, atomic.LoadUint32(&flowCanceled) == 0)
+			require.True(t, atomic.LoadUint32(&outboxCanceled) == 1)
 
 			// Verify that we received the expected metadata.
 			if tc.verifyExpectedMetadata != nil {

--- a/pkg/sql/colflow/colrpc/outbox.go
+++ b/pkg/sql/colflow/colrpc/outbox.go
@@ -193,9 +193,9 @@ func (o *Outbox) Run(
 
 // handleStreamErr is a utility method used to handle an error when calling
 // a method on a flowStreamClient. If err is an io.EOF, outboxCtxCancel is
-// called, for all other error flowCtxCancel is. The given error is logged with
+// called, for all other errors flowCtxCancel is. The given error is logged with
 // the associated opName.
-func (o *Outbox) handleStreamErr(
+func handleStreamErr(
 	ctx context.Context, opName string, err error, flowCtxCancel, outboxCtxCancel context.CancelFunc,
 ) {
 	if err == io.EOF {
@@ -269,7 +269,7 @@ func (o *Outbox) sendBatches(
 			// soon as the message is written to the control buffer. The message is
 			// marshaled (bytes are copied) before writing.
 			if err := stream.Send(o.scratch.msg); err != nil {
-				o.handleStreamErr(ctx, "Send (batches)", err, flowCtxCancel, outboxCtxCancel)
+				handleStreamErr(ctx, "Send (batches)", err, flowCtxCancel, outboxCtxCancel)
 				return
 			}
 		}
@@ -303,33 +303,41 @@ func (o *Outbox) sendMetadata(ctx context.Context, stream flowStreamClient, errT
 func (o *Outbox) runWithStream(
 	ctx context.Context, stream flowStreamClient, flowCtxCancel, outboxCtxCancel context.CancelFunc,
 ) {
+	// Cancellation functions might be nil in some tests, but we'll make them
+	// noops for convenience.
 	if flowCtxCancel == nil {
-		// The flowCtxCancel might be nil in some tests, but we'll make it a
-		// noop for convenience.
 		flowCtxCancel = func() {}
+	}
+	if outboxCtxCancel == nil {
+		outboxCtxCancel = func() {}
 	}
 	waitCh := make(chan struct{})
 	go func() {
 		// This goroutine's job is to listen continually on the stream from the
 		// consumer for errors or drain requests, while the remainder of this
 		// function concurrently is producing data and sending it over the
-		// network. This goroutine will tear down the flow if non-io.EOF error
+		// network.
+		//
+		// This goroutine will tear down the flow if non-io.EOF error
 		// is received - without it, a producer goroutine might spin doing work
 		// forever after a connection is closed, since it wouldn't notice a
 		// closed connection until it tried to Send over that connection.
+		//
+		// Similarly, if an io.EOF error is received, it indicates that the
+		// server side of FlowStream RPC (the inbox) has exited gracefully, so
+		// the inbox doesn't need anything else from this outbox, and this
+		// goroutine will shut down the tree of operators rooted in this outbox.
 		for {
 			msg, err := stream.Recv()
 			if err != nil {
-				if err != io.EOF {
-					log.Warningf(ctx, "Outbox calling flowCtxCancel after Recv connection error: %+v", err)
-					flowCtxCancel()
-				}
+				handleStreamErr(ctx, "watchdog Recv", err, flowCtxCancel, outboxCtxCancel)
 				break
 			}
 			switch {
 			case msg.Handshake != nil:
 				log.VEventf(ctx, 2, "Outbox received handshake: %v", msg.Handshake)
 			case msg.DrainRequest != nil:
+				log.VEventf(ctx, 2, "Outbox received drain request")
 				o.moveToDraining(ctx)
 			}
 		}
@@ -340,14 +348,14 @@ func (o *Outbox) runWithStream(
 	if terminatedGracefully || errToSend != nil {
 		o.moveToDraining(ctx)
 		if err := o.sendMetadata(ctx, stream, errToSend); err != nil {
-			o.handleStreamErr(ctx, "Send (metadata)", err, flowCtxCancel, outboxCtxCancel)
+			handleStreamErr(ctx, "Send (metadata)", err, flowCtxCancel, outboxCtxCancel)
 		} else {
 			// Close the stream. Note that if this block isn't reached, the stream
 			// is unusable.
 			// The receiver goroutine will read from the stream until any error
 			// is returned (most likely an io.EOF).
 			if err := stream.CloseSend(); err != nil {
-				o.handleStreamErr(ctx, "CloseSend", err, flowCtxCancel, outboxCtxCancel)
+				handleStreamErr(ctx, "CloseSend", err, flowCtxCancel, outboxCtxCancel)
 			}
 		}
 	}


### PR DESCRIPTION
Backport 1/1 commits from #64940.

/cc @cockroachdb/release

---

Previously, if a query were gracefully cancelled that had related remote
flows, those remote flows would not be actively cancelled. They would
cancel themselves only when they next tried to write to the network and
got an io.EOF.

Now, the outbox "watchdog goroutine" will cancel the tree rooted in the
outbox actively once it sees an io.EOF. Note that such behavior is
reasonable because the inbox stream handler must have exited, so we
don't need to concern ourselves with doing any other work; however, the
flow context is not canceled since other trees planned on the same node
might still be doing useful work on behalf of other streams.

Addresses #64916.

Release note (sql change): improve cancellation behavior for DistSQL
flows.
