### PR TITLE
.github: provide link for security vulnerability reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Security Vulnerabilities
+    url: https://www.cockroachlabs.com/security/responsible-disclosure-policy/
+    about: "Report a security vulnerability or security-related bug in CockroachDB or Cockroach Cloud"
   - name: CockroachDB Community Forum
     url: https://forum.cockroachlabs.com/
     about: "For general questions about CockroachDB"


### PR DESCRIPTION
Release note: None