### PR TITLE
backupccl: skip flaky backup partitioned test

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -591,6 +591,8 @@ func TestBackupRestorePartitioned(t *testing.T) {
 
 	// Test that we're selecting the most specific locality tier for a location.
 	t.Run("partition-by-different-tiers", func(t *testing.T) {
+		skip.WithIssue(t, 64974, "flaky test")
+
 		testSubDir := t.Name()
 		locations := []string{
 			LocalFoo + "/" + testSubDir + "/1",


### PR DESCRIPTION
This test is flaking due to inconsistency in placing data on all the
nodes. Skipping until resolved to stabilize master.

Informs https://github.com/cockroachdb/cockroach/issues/64974.

Release note: None