### PR TITLE
storage/cloud: replace WriteFile(Reader) with Writer

### DIFF
--- a/pkg/blobs/client.go
+++ b/pkg/blobs/client.go
@@ -34,7 +34,7 @@ type BlobClient interface {
 	// WriteFile sends the named payload to the requested node.
 	// This method will read entire content of file and send
 	// it over to another node, based on the nodeID.
-	WriteFile(ctx context.Context, file string, content io.ReadSeeker) error
+	WriteFile(ctx context.Context, file string, content io.Reader) error
 
 	// List lists the corresponding filenames from the requested node.
 	// The requested node can be the current node.
@@ -75,9 +75,7 @@ func (c *remoteClient) ReadFile(
 	return newGetStreamReader(stream), st.Filesize, errors.Wrap(err, "fetching file")
 }
 
-func (c *remoteClient) WriteFile(
-	ctx context.Context, file string, content io.ReadSeeker,
-) (err error) {
+func (c *remoteClient) WriteFile(ctx context.Context, file string, content io.Reader) (err error) {
 	ctx = metadata.AppendToOutgoingContext(ctx, "filename", file)
 	stream, err := c.blobClient.PutStream(ctx)
 	if err != nil {
@@ -143,7 +141,7 @@ func (c *localClient) ReadFile(
 	return c.localStorage.ReadFile(file, offset)
 }
 
-func (c *localClient) WriteFile(ctx context.Context, file string, content io.ReadSeeker) error {
+func (c *localClient) WriteFile(ctx context.Context, file string, content io.Reader) error {
 	return c.localStorage.WriteFile(file, content)
 }
 

--- a/pkg/ccl/backupccl/backup_destination_test.go
+++ b/pkg/ccl/backupccl/backup_destination_test.go
@@ -63,7 +63,7 @@ func TestBackupRestoreResolveDestination(t *testing.T) {
 		storage, err := externalStorageFromURI(ctx, uri, security.RootUserName())
 		defer storage.Close()
 		require.NoError(t, err)
-		require.NoError(t, storage.WriteFile(ctx, backupManifestName, emptyReader))
+		require.NoError(t, cloud.WriteFile(ctx, storage, backupManifestName, emptyReader))
 	}
 
 	// writeLatest writes latestBackupSuffix to the LATEST file in the given
@@ -72,7 +72,7 @@ func TestBackupRestoreResolveDestination(t *testing.T) {
 		storage, err := externalStorageFromURI(ctx, collectionURI, security.RootUserName())
 		defer storage.Close()
 		require.NoError(t, err)
-		require.NoError(t, storage.WriteFile(ctx, latestFileName, bytes.NewReader([]byte(latestBackupSuffix))))
+		require.NoError(t, cloud.WriteFile(ctx, storage, latestFileName, bytes.NewReader([]byte(latestBackupSuffix))))
 	}
 
 	// localizeURI returns a slice of just the base URI if localities is nil.

--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -524,7 +524,7 @@ func (b *backupResumer) Resume(ctx context.Context, execCtx interface{}) error {
 			return err
 		}
 		defer c.Close()
-		if err := c.WriteFile(ctx, latestFileName, strings.NewReader(suffix)); err != nil {
+		if err := cloud.WriteFile(ctx, c, latestFileName, strings.NewReader(suffix)); err != nil {
 			return err
 		}
 	}

--- a/pkg/ccl/backupccl/backup_processor.go
+++ b/pkg/ccl/backupccl/backup_processor.go
@@ -456,7 +456,7 @@ func writeFile(
 		exportStore = localitySpecificStore
 	}
 
-	if err := exportStore.WriteFile(ctx, file.Path, bytes.NewReader(data)); err != nil {
+	if err := cloud.WriteFile(ctx, exportStore, file.Path, bytes.NewReader(data)); err != nil {
 		log.VEventf(ctx, 1, "failed to put file: %+v", err)
 		return errors.Wrap(err, "writing SST")
 	}

--- a/pkg/ccl/backupccl/manifest_handling.go
+++ b/pkg/ccl/backupccl/manifest_handling.go
@@ -391,7 +391,7 @@ func writeBackupManifest(
 		}
 	}
 
-	if err := exportStore.WriteFile(ctx, filename, bytes.NewReader(descBuf)); err != nil {
+	if err := cloud.WriteFile(ctx, exportStore, filename, bytes.NewReader(descBuf)); err != nil {
 		return err
 	}
 
@@ -400,7 +400,7 @@ func writeBackupManifest(
 	if err != nil {
 		return errors.Wrap(err, "calculating checksum")
 	}
-	if err := exportStore.WriteFile(ctx, filename+backupManifestChecksumSuffix, bytes.NewReader(checksum)); err != nil {
+	if err := cloud.WriteFile(ctx, exportStore, filename+backupManifestChecksumSuffix, bytes.NewReader(checksum)); err != nil {
 		return errors.Wrap(err, "writing manifest checksum")
 	}
 
@@ -487,7 +487,7 @@ func writeBackupPartitionDescriptor(
 		}
 	}
 
-	return exportStore.WriteFile(ctx, filename, bytes.NewReader(descBuf))
+	return cloud.WriteFile(ctx, exportStore, filename, bytes.NewReader(descBuf))
 }
 
 // writeTableStatistics writes a StatsTable object to a file of the filename
@@ -515,7 +515,7 @@ func writeTableStatistics(
 			return err
 		}
 	}
-	return exportStore.WriteFile(ctx, filename, bytes.NewReader(statsBuf))
+	return cloud.WriteFile(ctx, exportStore, filename, bytes.NewReader(statsBuf))
 }
 
 func loadBackupManifests(
@@ -951,7 +951,7 @@ func writeEncryptionInfoIfNotExists(
 	if err != nil {
 		return err
 	}
-	if err := dest.WriteFile(ctx, backupEncryptionInfoFile, bytes.NewReader(buf)); err != nil {
+	if err := cloud.WriteFile(ctx, dest, backupEncryptionInfoFile, bytes.NewReader(buf)); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/ccl/changefeedccl/sink_cloudstorage.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage.go
@@ -452,7 +452,7 @@ func (s *cloudStorageSink) EmitResolvedTimestamp(
 	if log.V(1) {
 		log.Infof(ctx, "writing file %s %s", filename, resolved.AsOfSystemTime())
 	}
-	return s.es.WriteFile(ctx, filepath.Join(part, filename), bytes.NewReader(payload))
+	return cloud.WriteFile(ctx, s.es, filepath.Join(part, filename), bytes.NewReader(payload))
 }
 
 // flushTopicVersions flushes all open files for the provided topic up to and
@@ -553,7 +553,7 @@ func (s *cloudStorageSink) flushFile(ctx context.Context, file *cloudStorageSink
 			"precedes a file emitted before: %s", filename, s.prevFilename)
 	}
 	s.prevFilename = filename
-	if err := s.es.WriteFile(ctx, filepath.Join(s.dataFilePartition, filename), bytes.NewReader(file.buf.Bytes())); err != nil {
+	if err := cloud.WriteFile(ctx, s.es, filepath.Join(s.dataFilePartition, filename), bytes.NewReader(file.buf.Bytes())); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/ccl/cliccl/debug_backup.go
+++ b/pkg/ccl/cliccl/debug_backup.go
@@ -517,7 +517,7 @@ func showData(
 		if err != nil {
 			return errors.Wrapf(err, "unable to open store to write files: %s", debugBackupArgs.destination)
 		}
-		if err = store.WriteFile(ctx, file, bytes.NewReader(buf.Bytes())); err != nil {
+		if err = cloud.WriteFile(ctx, store, file, bytes.NewReader(buf.Bytes())); err != nil {
 			_ = store.Close()
 			return err
 		}

--- a/pkg/ccl/importccl/exportcsv.go
+++ b/pkg/ccl/importccl/exportcsv.go
@@ -268,7 +268,7 @@ func (sp *csvWriter) Run(ctx context.Context) {
 
 			size := writer.Len()
 
-			if err := es.WriteFile(ctx, filename, bytes.NewReader(writer.Bytes())); err != nil {
+			if err := cloud.WriteFile(ctx, es, filename, bytes.NewReader(writer.Bytes())); err != nil {
 				return err
 			}
 			res := rowenc.EncDatumRow{

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -1693,7 +1693,7 @@ func (u *unsupportedStmtLogger) flush() error {
 	} else {
 		logFileName = path.Join(logFileName, pgDumpUnsupportedSchemaStmtLog, fmt.Sprintf("%d.log", u.flushCount))
 	}
-	err = s.WriteFile(u.ctx, logFileName, bytes.NewReader(u.logBuffer.Bytes()))
+	err = cloud.WriteFile(u.ctx, s, logFileName, bytes.NewReader(u.logBuffer.Bytes()))
 	if err != nil {
 		return errors.Wrap(err, "failed to log unsupported stmts to log during IMPORT PGDUMP")
 	}

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -2286,7 +2286,7 @@ b STRING) CSV DATA (%s)`, testFiles.files[0])); err != nil {
 		require.NoError(t, err)
 
 		data := []byte("1,2")
-		require.NoError(t, userfileStorage.WriteFile(ctx, "", bytes.NewReader(data)))
+		require.NoError(t, cloud.WriteFile(ctx, userfileStorage, "", bytes.NewReader(data)))
 
 		sqlDB.Exec(t, fmt.Sprintf("IMPORT TABLE foo (id INT PRIMARY KEY, "+
 			"id2 INT) CSV DATA ('%s')", userfileURI))
@@ -2302,7 +2302,7 @@ b STRING) CSV DATA (%s)`, testFiles.files[0])); err != nil {
 		require.NoError(t, err)
 
 		data := []byte("1,2")
-		require.NoError(t, userfileStorage.WriteFile(ctx, "", bytes.NewReader(data)))
+		require.NoError(t, cloud.WriteFile(ctx, userfileStorage, "", bytes.NewReader(data)))
 
 		sqlDB.Exec(t, fmt.Sprintf("IMPORT TABLE baz (id INT PRIMARY KEY, "+
 			"id2 INT) CSV DATA ('%s')", userfileURI))
@@ -2412,7 +2412,7 @@ func TestImportObjectLevelRBAC(t *testing.T) {
 		fileTableSystem1, err := cloud.ExternalStorageFromURI(ctx, dest, base.ExternalIODirConfig{},
 			cluster.NoSettings, blobs.TestEmptyBlobClientFactory, security.TestUserName(), ie, tc.Server(0).DB())
 		require.NoError(t, err)
-		require.NoError(t, fileTableSystem1.WriteFile(ctx, filename, bytes.NewReader([]byte("1,aaa"))))
+		require.NoError(t, cloud.WriteFile(ctx, fileTableSystem1, filename, bytes.NewReader([]byte("1,aaa"))))
 	}
 
 	t.Run("import-RBAC", func(t *testing.T) {
@@ -3440,7 +3440,7 @@ func TestImportIntoCSV(t *testing.T) {
 		require.NoError(t, err)
 
 		data := []byte("1,2")
-		require.NoError(t, userfileStorage.WriteFile(ctx, "", bytes.NewReader(data)))
+		require.NoError(t, cloud.WriteFile(ctx, userfileStorage, "", bytes.NewReader(data)))
 
 		sqlDB.Exec(t, "CREATE TABLE foo (id INT PRIMARY KEY, id2 INT)")
 		sqlDB.Exec(t, fmt.Sprintf("IMPORT INTO foo (id, id2) CSV DATA ('%s')", userfileURI))
@@ -3507,7 +3507,7 @@ func benchUserUpload(b *testing.B, uploadBaseURI string) {
 		require.NoError(b, err)
 		content, err := ioutil.ReadAll(r)
 		require.NoError(b, err)
-		err = userfileStorage.WriteFile(ctx, "", bytes.NewReader(content))
+		err = cloud.WriteFile(ctx, userfileStorage, "", bytes.NewReader(content))
 		require.NoError(b, err)
 		numBytes = int64(len(content))
 	} else {

--- a/pkg/ccl/importccl/read_import_base.go
+++ b/pkg/ccl/importccl/read_import_base.go
@@ -249,7 +249,7 @@ func readInputFiles(
 						return err
 					}
 					defer rejectedStorage.Close()
-					if err := rejectedStorage.WriteFile(ctx, "", bytes.NewReader(buf)); err != nil {
+					if err := cloud.WriteFile(ctx, rejectedStorage, "", bytes.NewReader(buf)); err != nil {
 						return err
 					}
 					return nil

--- a/pkg/ccl/importccl/testutils_test.go
+++ b/pkg/ccl/importccl/testutils_test.go
@@ -271,10 +271,10 @@ func (es *generatorExternalStorage) Size(ctx context.Context, basename string) (
 	return int64(es.gen.size), nil
 }
 
-func (es *generatorExternalStorage) WriteFile(
-	ctx context.Context, basename string, content io.ReadSeeker,
-) error {
-	return errors.New("unsupported")
+func (es *generatorExternalStorage) Writer(
+	ctx context.Context, basename string,
+) (cloud.WriteCloserWithError, error) {
+	return nil, errors.New("unsupported")
 }
 
 func (es *generatorExternalStorage) ListFiles(ctx context.Context, _ string) ([]string, error) {

--- a/pkg/ccl/storageccl/export.go
+++ b/pkg/ccl/storageccl/export.go
@@ -215,7 +215,7 @@ func evalExport(
 			if err := retry.WithMaxAttempts(ctx, base.DefaultRetryOptions(), maxUploadRetries, func() error {
 				// We blindly retry any error here because we expect the caller to have
 				// verified the target is writable before sending ExportRequests for it.
-				if err := exportStore.WriteFile(ctx, exported.Path, bytes.NewReader(data)); err != nil {
+				if err := cloud.WriteFile(ctx, exportStore, exported.Path, bytes.NewReader(data)); err != nil {
 					log.VEventf(ctx, 1, "failed to put file: %+v", err)
 					return err
 				}

--- a/pkg/sql/copy_file_upload.go
+++ b/pkg/sql/copy_file_upload.go
@@ -16,7 +16,6 @@ import (
 	"io"
 	"net/url"
 	"strings"
-	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
@@ -42,8 +41,7 @@ var _ copyMachineInterface = &fileUploadMachine{}
 
 type fileUploadMachine struct {
 	c              *copyMachine
-	writeToFile    *io.PipeWriter
-	wg             *sync.WaitGroup
+	w              cloud.WriteCloserWithError
 	failureCleanup func()
 }
 
@@ -94,8 +92,7 @@ func newFileUploadMachine(
 		p: planner{execCfg: execCfg, alloc: &rowenc.DatumAlloc{}},
 	}
 	f = &fileUploadMachine{
-		c:  c,
-		wg: &sync.WaitGroup{},
+		c: c,
 	}
 
 	// We need a planner to do the initial planning, even if a planner
@@ -124,7 +121,6 @@ func newFileUploadMachine(
 		return nil, err
 	}
 
-	pr, pw := io.Pipe()
 	store, err := c.p.execCfg.DistSQLSrv.ExternalStorageFromURI(ctx, dest, c.p.User())
 	if err != nil {
 		return nil, err
@@ -135,15 +131,11 @@ func newFileUploadMachine(
 		return nil, err
 	}
 
-	f.wg.Add(1)
-	go func() {
-		err := cloud.WriteFile(ctx, store, "", &noopReadSeeker{pr})
-		if err != nil {
-			_ = pr.CloseWithError(err)
-		}
-		f.wg.Done()
-	}()
-	f.writeToFile = pw
+	f.w, err = store.Writer(ctx, "")
+	if err != nil {
+		return nil, err
+	}
+
 	f.failureCleanup = func() {
 		// Ignoring this error because deletion would only fail
 		// if the file was not created in the first place.
@@ -174,20 +166,24 @@ func CopyInFileStmt(destination, schema, table string) string {
 	)
 }
 
-func (f *fileUploadMachine) run(ctx context.Context) (err error) {
-	err = f.c.run(ctx)
-	_ = f.writeToFile.Close()
+func (f *fileUploadMachine) run(ctx context.Context) error {
+	err := f.c.run(ctx)
+	if err != nil {
+		err = errors.CombineErrors(err, f.w.CloseWithError(err))
+	} else {
+		err = f.w.Close()
+	}
+
 	if err != nil {
 		f.failureCleanup()
 	}
-	f.wg.Wait()
-	return
+	return err
 }
 
 func (f *fileUploadMachine) writeFile(ctx context.Context) error {
 	for _, r := range f.c.rows {
 		b := []byte(*r[0].(*tree.DBytes))
-		n, err := f.writeToFile.Write(b)
+		n, err := f.w.Write(b)
 		if err != nil {
 			return err
 		}
@@ -197,7 +193,7 @@ func (f *fileUploadMachine) writeFile(ctx context.Context) error {
 	}
 
 	// Issue a final zero-byte write to ensure we observe any errors in the pipe.
-	_, err := f.writeToFile.Write(nil)
+	_, err := f.w.Write(nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/copy_file_upload.go
+++ b/pkg/sql/copy_file_upload.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/storage/cloud"
 	"github.com/cockroachdb/errors"
 	"github.com/lib/pq"
 )
@@ -136,7 +137,7 @@ func newFileUploadMachine(
 
 	f.wg.Add(1)
 	go func() {
-		err := store.WriteFile(ctx, "", &noopReadSeeker{pr})
+		err := cloud.WriteFile(ctx, store, "", &noopReadSeeker{pr})
 		if err != nil {
 			_ = pr.CloseWithError(err)
 		}

--- a/pkg/storage/cloud/BUILD.bazel
+++ b/pkg/storage/cloud/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/sql/sqlutil",
+        "//pkg/util/ctxgroup",
         "//pkg/util/log",
         "//pkg/util/retry",
         "//pkg/util/sysutil",

--- a/pkg/storage/cloud/amazon/s3_storage.go
+++ b/pkg/storage/cloud/amazon/s3_storage.go
@@ -244,7 +244,7 @@ func s3ErrDelay(err error) time.Duration {
 	return 0
 }
 
-func (s *s3Storage) newS3Client(ctx context.Context) (*s3.S3, error) {
+func (s *s3Storage) newSession(ctx context.Context) (*session.Session, error) {
 	sess, err := session.NewSessionWithOptions(s.opts)
 	if err != nil {
 		return nil, errors.Wrap(err, "new aws session")
@@ -259,6 +259,14 @@ func (s *s3Storage) newS3Client(ctx context.Context) (*s3.S3, error) {
 		}
 	}
 	sess.Config.Region = aws.String(s.conf.Region)
+	return sess, err
+}
+
+func (s *s3Storage) newS3Client(ctx context.Context) (*s3.S3, error) {
+	sess, err := s.newSession(ctx)
+	if err != nil {
+		return nil, err
+	}
 	return s3.New(sess), nil
 }
 
@@ -277,39 +285,27 @@ func (s *s3Storage) Settings() *cluster.Settings {
 	return s.settings
 }
 
-func (s *s3Storage) WriteFile(ctx context.Context, basename string, content io.ReadSeeker) error {
-	client, err := s.newS3Client(ctx)
+func (s *s3Storage) Writer(
+	ctx context.Context, basename string,
+) (cloud.WriteCloserWithError, error) {
+	sess, err := s.newSession(ctx)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	err = contextutil.RunWithTimeout(ctx, "put s3 object",
-		cloud.Timeout.Get(&s.settings.SV),
-		func(ctx context.Context) error {
-			putObjectInput := s3.PutObjectInput{
-				Bucket: s.bucket,
-				Key:    aws.String(path.Join(s.prefix, basename)),
-				Body:   content,
-			}
+	uploader := s3manager.NewUploader(sess)
 
-			// If a server side encryption mode is provided in the URI, we must set
-			// the header values to enable SSE before writing the file to the s3
-			// bucket.
-			if s.conf.ServerEncMode != "" {
-				switch s.conf.ServerEncMode {
-				case string(aes256Enc):
-					putObjectInput.SetServerSideEncryption(s.conf.ServerEncMode)
-				case string(kmsEnc):
-					putObjectInput.SetServerSideEncryption(s.conf.ServerEncMode)
-					putObjectInput.SetSSEKMSKeyId(s.conf.ServerKMSID)
-				default:
-					return errors.Newf("unsupported server encryption mode %s. "+
-						"Supported values are `aws:kms` and `AES256`.", s.conf.ServerEncMode)
-				}
-			}
-			_, err := client.PutObjectWithContext(ctx, &putObjectInput)
-			return err
+	return cloud.BackgroundPipe(ctx, func(ctx context.Context, r io.Reader) error {
+		// Upload the file to S3.
+		// TODO(dt): test and tune the uploader parameters.
+		_, err := uploader.UploadWithContext(ctx, &s3manager.UploadInput{
+			Bucket:               s.bucket,
+			Key:                  aws.String(path.Join(s.prefix, basename)),
+			Body:                 r,
+			ServerSideEncryption: nilIfEmpty(s.conf.ServerEncMode),
+			SSEKMSKeyId:          nilIfEmpty(s.conf.ServerKMSID),
 		})
-	return errors.Wrap(err, "failed to put s3 object")
+		return errors.Wrap(err, "upload failed")
+	}), nil
 }
 
 func (s *s3Storage) openStreamAt(
@@ -479,6 +475,13 @@ func (s *s3Storage) Size(ctx context.Context, basename string) (int64, error) {
 
 func (s *s3Storage) Close() error {
 	return nil
+}
+
+func nilIfEmpty(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return aws.String(s)
 }
 
 func init() {

--- a/pkg/storage/cloud/cloud_io.go
+++ b/pkg/storage/cloud/cloud_io.go
@@ -251,3 +251,9 @@ func CheckHTTPContentRangeHeader(h string, pos int64) (int64, error) {
 
 	return size, nil
 }
+
+// WriteFile is a helper for writing the content of a Reader to the given path
+// of an ExternalStorage.
+func WriteFile(ctx context.Context, dest ExternalStorage, basename string, src io.ReadSeeker) error {
+	return dest.WriteFile(ctx, basename, src)
+}

--- a/pkg/storage/cloud/cloud_io.go
+++ b/pkg/storage/cloud/cloud_io.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/sysutil"
@@ -252,8 +253,59 @@ func CheckHTTPContentRangeHeader(h string, pos int64) (int64, error) {
 	return size, nil
 }
 
+// BackgroundPipe is a helper for providing a Writer that is backed by a pipe
+// that has a background process reading from it. It *must* be Closed().
+func BackgroundPipe(
+	ctx context.Context, fn func(ctx context.Context, pr io.Reader) error,
+) WriteCloserWithError {
+	pr, pw := io.Pipe()
+	w := &backgroundPipe{w: pw, grp: ctxgroup.WithContext(ctx)}
+	w.grp.GoCtx(func(ctc context.Context) error {
+		err := fn(ctx, pr)
+		if err != nil {
+			closeErr := pr.CloseWithError(err)
+			err = errors.CombineErrors(err, closeErr)
+		} else {
+			err = pr.Close()
+		}
+		return err
+	})
+	return w
+}
+
+type backgroundPipe struct {
+	w   *io.PipeWriter
+	grp ctxgroup.Group
+}
+
+// Write writes to the writer.
+func (s *backgroundPipe) Write(p []byte) (int, error) {
+	return s.w.Write(p)
+}
+
+// Close closes the writer, finishing the write operation.
+func (s *backgroundPipe) Close() error {
+	err := s.w.Close()
+	return errors.CombineErrors(err, s.grp.Wait())
+}
+
+// CloseWithError closes the Writer with an error, which may discard prior
+// writes and abort the overall write operation.
+func (s *backgroundPipe) CloseWithError(err error) error {
+	e := s.w.CloseWithError(err)
+	return errors.CombineErrors(e, s.grp.Wait())
+}
+
 // WriteFile is a helper for writing the content of a Reader to the given path
 // of an ExternalStorage.
-func WriteFile(ctx context.Context, dest ExternalStorage, basename string, src io.ReadSeeker) error {
-	return dest.WriteFile(ctx, basename, src)
+func WriteFile(ctx context.Context, dest ExternalStorage, basename string, src io.Reader) error {
+	w, err := dest.Writer(ctx, basename)
+	if err != nil {
+		return errors.Wrap(err, "opening object for writing")
+	}
+	if _, err := io.Copy(w, src); err != nil {
+		closeErr := w.CloseWithError(err)
+		return errors.CombineErrors(err, closeErr)
+	}
+	return errors.Wrap(w.Close(), "closing object")
 }

--- a/pkg/storage/cloud/cloudtestutils/cloud_test_helpers.go
+++ b/pkg/storage/cloud/cloudtestutils/cloud_test_helpers.go
@@ -163,7 +163,7 @@ func CheckExportStore(
 		for i := 0; i < 10; i++ {
 			name := fmt.Sprintf("%s-%d", sampleName, i)
 			payload := []byte(strings.Repeat(sampleBytes, i))
-			if err := s.WriteFile(ctx, name, bytes.NewReader(payload)); err != nil {
+			if err := cloud.WriteFile(ctx, s, name, bytes.NewReader(payload)); err != nil {
 				t.Fatal(err)
 			}
 
@@ -199,7 +199,7 @@ func CheckExportStore(
 		testingFilename := "testing-123"
 
 		// Write some random data (random so it doesn't compress).
-		if err := s.WriteFile(ctx, testingFilename, bytes.NewReader(testingContent)); err != nil {
+		if err := cloud.WriteFile(ctx, s, testingFilename, bytes.NewReader(testingContent)); err != nil {
 			t.Fatal(err)
 		}
 
@@ -248,7 +248,7 @@ func CheckExportStore(
 	}
 	t.Run("read-single-file-by-uri", func(t *testing.T) {
 		const testingFilename = "A"
-		if err := s.WriteFile(ctx, testingFilename, bytes.NewReader([]byte("aaa"))); err != nil {
+		if err := cloud.WriteFile(ctx, s, testingFilename, bytes.NewReader([]byte("aaa"))); err != nil {
 			t.Fatal(err)
 		}
 		singleFile := storeFromURI(ctx, t, appendPath(t, storeURI, testingFilename), clientFactory,
@@ -276,7 +276,7 @@ func CheckExportStore(
 			user, ie, kvDB, testSettings)
 		defer singleFile.Close()
 
-		if err := singleFile.WriteFile(ctx, "", bytes.NewReader([]byte("bbb"))); err != nil {
+		if err := cloud.WriteFile(ctx, singleFile, "", bytes.NewReader([]byte("bbb"))); err != nil {
 			t.Fatal(err)
 		}
 
@@ -301,7 +301,7 @@ func CheckExportStore(
 	// (based on the storage system) could not be found.
 	t.Run("file-does-not-exist", func(t *testing.T) {
 		const testingFilename = "A"
-		if err := s.WriteFile(ctx, testingFilename, bytes.NewReader([]byte("aaa"))); err != nil {
+		if err := cloud.WriteFile(ctx, s, testingFilename, bytes.NewReader([]byte("aaa"))); err != nil {
 			t.Fatal(err)
 		}
 		singleFile := storeFromURI(ctx, t, storeURI, clientFactory, user, ie, kvDB, testSettings)
@@ -375,7 +375,7 @@ func CheckListFilesCanonical(
 	clientFactory := blobs.TestBlobServiceClient(testSettings.ExternalIODir)
 	for _, fileName := range fileNames {
 		file := storeFromURI(ctx, t, storeURI, clientFactory, user, ie, kvDB, testSettings)
-		if err := file.WriteFile(ctx, fileName, bytes.NewReader([]byte("bbb"))); err != nil {
+		if err := cloud.WriteFile(ctx, file, fileName, bytes.NewReader([]byte("bbb"))); err != nil {
 			t.Fatal(err)
 		}
 		_ = file.Close()
@@ -537,7 +537,7 @@ func uploadData(
 		nil, nil, nil)
 	require.NoError(t, err)
 	defer s.Close()
-	require.NoError(t, s.WriteFile(ctx, basename, bytes.NewReader(data)))
+	require.NoError(t, cloud.WriteFile(ctx, s, basename, bytes.NewReader(data)))
 	return data, func() {
 		_ = s.Delete(ctx, basename)
 	}

--- a/pkg/storage/cloud/gcp/BUILD.bazel
+++ b/pkg/storage/cloud/gcp/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
         "//pkg/settings/cluster",
         "//pkg/storage/cloud",
         "//pkg/util/contextutil",
-        "//pkg/util/retry",
         "@com_github_cockroachdb_errors//:errors",
         "@com_google_cloud_go_storage//:storage",
         "@org_golang_google_api//iterator",

--- a/pkg/storage/cloud/httpsink/http_storage_test.go
+++ b/pkg/storage/cloud/httpsink/http_storage_test.go
@@ -166,10 +166,10 @@ func TestPutHttp(t *testing.T) {
 
 		const file = "file"
 		var content = []byte("contents")
-		if err := s.WriteFile(ctx, file, bytes.NewReader(content)); err != nil {
+		if err := cloud.WriteFile(ctx, s, file, bytes.NewReader(content)); err != nil {
 			t.Fatal(err)
 		}
-		if err := s.WriteFile(ctx, badHeadResponse, bytes.NewReader(content)); err != nil {
+		if err := cloud.WriteFile(ctx, s, badHeadResponse, bytes.NewReader(content)); err != nil {
 			t.Fatal(err)
 		}
 		if sz, err := s.Size(ctx, file); err != nil {

--- a/pkg/storage/cloud/nullsink/nullsink_storage_test.go
+++ b/pkg/storage/cloud/nullsink/nullsink_storage_test.go
@@ -43,7 +43,7 @@ func TestNullSinkReadAndWrite(t *testing.T) {
 	defer s.Close()
 
 	require.Equal(t, roachpb.ExternalStorage{Provider: roachpb.ExternalStorageProvider_null}, s.Conf())
-	require.NoError(t, s.WriteFile(ctx, "", bytes.NewReader([]byte("abc"))))
+	require.NoError(t, cloud.WriteFile(ctx, s, "", bytes.NewReader([]byte("abc"))))
 	sz, err := s.Size(ctx, "")
 	require.NoError(t, err)
 	require.Equal(t, int64(0), sz)

--- a/pkg/storage/cloud/userfile/file_table_storage_test.go
+++ b/pkg/storage/cloud/userfile/file_table_storage_test.go
@@ -73,7 +73,7 @@ func TestPutUserFileTable(t *testing.T) {
 		require.NoError(t, err)
 		defer store.Close()
 
-		err = store.WriteFile(ctx, testfile, bytes.NewReader([]byte{0}))
+		err = cloud.WriteFile(ctx, store, testfile, bytes.NewReader([]byte{0}))
 		require.True(t, testutils.IsError(err, "does not permit such constructs"))
 	})
 }
@@ -118,7 +118,7 @@ func TestUserScoping(t *testing.T) {
 	fileTableSystem1, err := cloud.ExternalStorageFromURI(ctx, dest, base.ExternalIODirConfig{},
 		cluster.NoSettings, blobs.TestEmptyBlobClientFactory, user1, ie, kvDB)
 	require.NoError(t, err)
-	require.NoError(t, fileTableSystem1.WriteFile(ctx, filename, bytes.NewReader([]byte("aaa"))))
+	require.NoError(t, cloud.WriteFile(ctx, fileTableSystem1, filename, bytes.NewReader([]byte("aaa"))))
 
 	// Attempt to read/write file as user2 and expect to fail.
 	fileTableSystem2, err := cloud.ExternalStorageFromURI(ctx, dest, base.ExternalIODirConfig{},
@@ -126,7 +126,7 @@ func TestUserScoping(t *testing.T) {
 	require.NoError(t, err)
 	_, err = fileTableSystem2.ReadFile(ctx, filename)
 	require.Error(t, err)
-	require.Error(t, fileTableSystem2.WriteFile(ctx, filename, bytes.NewReader([]byte("aaa"))))
+	require.Error(t, cloud.WriteFile(ctx, fileTableSystem2, filename, bytes.NewReader([]byte("aaa"))))
 
 	// Read file as root and expect to succeed.
 	fileTableSystem3, err := cloud.ExternalStorageFromURI(ctx, dest, base.ExternalIODirConfig{},

--- a/pkg/storage/cloudimpl/filetable/file_table_read_writer.go
+++ b/pkg/storage/cloudimpl/filetable/file_table_read_writer.go
@@ -597,6 +597,10 @@ func (w *chunkWriter) Write(buf []byte) (int, error) {
 	return bufLen, nil
 }
 
+func (w *chunkWriter) CloseWithError(err error) error {
+	return w.Close()
+}
+
 // Close implements the io.Closer interface by flushing the underlying writer
 // thereby writing remaining data to the Payload table. It also updates the file
 // metadata entry in the File table with the number of bytes written.
@@ -918,7 +922,7 @@ users WHERE NOT "username" = 'root' AND NOT "username" = 'admin' AND NOT "userna
 // the last chunk and commit the txn within which all writes occur.
 func (f *FileToTableSystem) NewFileWriter(
 	ctx context.Context, filename string, chunkSize int,
-) (io.WriteCloser, error) {
+) (cloud.WriteCloserWithError, error) {
 	e, err := resolveInternalFileToTableExecutor(f.executor)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This changes the ExternalStorage API's writing method from WriteFile which takes an io.Reader
and writes its content to the requested destination or returns an error encountered while doing
so to instead have Writer() which returns an io.Writer pointing to the destination that can be
written to later and then closed to finish the upload (or CloseWithError'ed to cancel it).

All existing callers use the shim and are unaffected, but can later choose to change to a
push-based model and use the Writer directly. This is left to a follow-up change.

(note: first commit is just adding a shim for existing callers and switching them)

Release note: none.