### PR TITLE
release-21.1: logictest: increase --max-sql-memory for SQLLite logic tests

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -239,4 +239,12 @@ type TestTenantArgs struct {
 
 	// TestingKnobs for the test server.
 	TestingKnobs TestingKnobs
+
+	// MemoryPoolSize is the amount of memory in bytes that can be used by SQL
+	// clients to store row data in server RAM.
+	MemoryPoolSize int64
+
+	// TempStorageConfig is used to configure temp storage, which stores
+	// ephemeral data when processing large queries.
+	TempStorageConfig *TempStorageConfig
 }

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -121,11 +121,7 @@ func makeTestKVConfig() KVConfig {
 }
 
 func makeTestSQLConfig(st *cluster.Settings, tenID roachpb.TenantID) SQLConfig {
-	sqlCfg := MakeSQLConfig(tenID, base.DefaultTestTempStorageConfig(st))
-	// Configure the default in-memory temp storage for all tests unless
-	// otherwise configured.
-	sqlCfg.TempStorageConfig = base.DefaultTestTempStorageConfig(st)
-	return sqlCfg
+	return MakeSQLConfig(tenID, base.DefaultTestTempStorageConfig(st))
 }
 
 // makeTestConfigFromParams creates a Config from a TestServerParams.
@@ -724,6 +720,12 @@ func (ts *TestServer) StartTenant(
 	st := cluster.MakeTestingClusterSettings()
 	sqlCfg := makeTestSQLConfig(st, params.TenantID)
 	sqlCfg.TenantKVAddrs = []string{ts.ServingRPCAddr()}
+	if params.MemoryPoolSize != 0 {
+		sqlCfg.MemoryPoolSize = params.MemoryPoolSize
+	}
+	if params.TempStorageConfig != nil {
+		sqlCfg.TempStorageConfig = *params.TempStorageConfig
+	}
 	baseCfg := makeTestBaseConfig(st)
 	baseCfg.TestingKnobs = params.TestingKnobs
 	baseCfg.IdleExitAfter = params.IdleExitAfter

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1306,6 +1306,11 @@ func (t *logicTest) newCluster(serverArgs TestServerArgs) {
 	// it installs detects a transaction that doesn't have
 	// modifiedSystemConfigSpan set even though it should, for
 	// "testdata/rename_table". Figure out what's up with that.
+	if serverArgs.maxSQLMemoryLimit == 0 {
+		// Specify a fixed memory limit (some test cases verify OOM conditions;
+		// we don't want those to take long on large machines).
+		serverArgs.maxSQLMemoryLimit = 192 * 1024 * 1024
+	}
 	var tempStorageConfig base.TempStorageConfig
 	if serverArgs.tempStorageDiskLimit == 0 {
 		tempStorageConfig = base.DefaultTestTempStorageConfig(cluster.MakeTestingClusterSettings())
@@ -1315,9 +1320,7 @@ func (t *logicTest) newCluster(serverArgs TestServerArgs) {
 
 	params := base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
-			// Specify a fixed memory limit (some test cases verify OOM conditions; we
-			// don't want those to take long on large machines).
-			SQLMemoryPoolSize: 192 * 1024 * 1024,
+			SQLMemoryPoolSize: serverArgs.maxSQLMemoryLimit,
 			TempStorageConfig: tempStorageConfig,
 			Knobs: base.TestingKnobs{
 				Store: &kvserver.StoreTestingKnobs{
@@ -1444,6 +1447,8 @@ func (t *logicTest) newCluster(serverArgs TestServerArgs) {
 					DeterministicExplain: true,
 				},
 			},
+			MemoryPoolSize:    params.ServerArgs.SQLMemoryPoolSize,
+			TempStorageConfig: &params.ServerArgs.TempStorageConfig,
 		}
 
 		// Prevent a logging assertion that the server ID is initialized multiple times.
@@ -3129,6 +3134,10 @@ var logicTestsConfigFilter = envutil.EnvOrDefaultString("COCKROACH_LOGIC_TESTS_C
 // TestServerArgs contains the parameters that callers of RunLogicTest might
 // want to specify for the test clusters to be created with.
 type TestServerArgs struct {
+	// maxSQLMemoryLimit determines the value of --max-sql-memory startup
+	// argument for the server. If unset, then the default limit of 192MiB will
+	// be used.
+	maxSQLMemoryLimit int64
 	// tempStorageDiskLimit determines the limit for the temp storage (that is
 	// actually in-memory). If it is unset, then the default limit of 100MB
 	// will be used.
@@ -3416,9 +3425,10 @@ func runSQLLiteLogicTest(t *testing.T, configOverride string, globs ...string) {
 		prefixedGlobs[i] = logicTestPath + glob
 	}
 
-	// SQLLite logic tests can be very disk (with '-disk' configs) intensive,
-	// so we give them larger temp storage limit than other logic tests get.
+	// SQLLite logic tests can be very memory and disk intensive, so we give
+	// them larger limits than other logic tests get.
 	serverArgs := TestServerArgs{
+		maxSQLMemoryLimit:    512 << 20, // 512 MiB
 		tempStorageDiskLimit: 512 << 20, // 512 MiB
 	}
 	RunLogicTestWithDefaultConfig(t, serverArgs, configOverride, true /* runCCLConfigs */, prefixedGlobs...)


### PR DESCRIPTION
Backport 1/1 commits from #64749.

/cc @cockroachdb/release

---

This commit increases the limit from 192 MiB to 512 MiB.

Additionally, this commit uses custom limits for tenants in logic tests.
Previously, the default values were used but aren't sufficient in some
cases, so this commit fixes the problem.

Fixes: #62197.

Release note: None
