### PR TITLE
release-21.1: opt: reduce the cost of locality optimized scan

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -2275,3 +2275,36 @@ INSERT INTO t63109 VALUES (1, 'one');
 UPSERT INTO t63109 VALUES (1, 'two');
 UPSERT INTO t63109 (crdb_region, a, b) VALUES ('ap-southeast-2', 1, 'three');
 UPSERT INTO t63109 (a, b) VALUES (1, 'four');
+
+# Regression test for #65064. We should always choose locality optimized scan
+# even if the stats show zero rows.
+statement ok
+CREATE DATABASE db PRIMARY REGION "ca-central-1" REGIONS "ap-southeast-2", "us-east-1";
+USE db;
+CREATE TABLE t65064 (username STRING NOT NULL UNIQUE) LOCALITY REGIONAL BY ROW;
+ALTER TABLE t65064 INJECT STATISTICS '[
+  {
+    "columns": ["username"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 0,
+    "distinct_count": 0
+  }
+]';
+
+query T
+SELECT * FROM [EXPLAIN SELECT * FROM t65064 WHERE username = 'kharris'] OFFSET 2
+----
+·
+• union all
+│ estimated row count: 1
+│ limit: 1
+│
+├── • scan
+│     estimated row count: 1 (100% of the table; stats collected <hidden> ago)
+│     table: t65064@t65064_username_key
+│     spans: [/'ap-southeast-2'/'kharris' - /'ap-southeast-2'/'kharris']
+│
+└── • scan
+      estimated row count: 1 (100% of the table; stats collected <hidden> ago)
+      table: t65064@t65064_username_key
+      spans: [/'ca-central-1'/'kharris' - /'ca-central-1'/'kharris'] [/'us-east-1'/'kharris' - /'us-east-1'/'kharris']

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -627,13 +627,13 @@ func (c *coster) computeScanCost(scan *memo.ScanExpr, required *physical.Require
 
 	cost := baseCost + memo.Cost(rowCount)*(seqIOCostFactor+perRowCost)
 
-	// If this scan is locality optimized, divide the cost in two in order to make
-	// the total cost of the two scans in the locality optimized plan less then
+	// If this scan is locality optimized, divide the cost by 3 in order to make
+	// the total cost of the two scans in the locality optimized plan less than
 	// the cost of the single scan in the non-locality optimized plan.
 	// TODO(rytaft): This is hacky. We should really be making this determination
 	// based on the latency between regions.
 	if scan.LocalityOptimized {
-		cost /= 2
+		cost /= 3
 	}
 	return cost
 }

--- a/pkg/sql/opt/xform/testdata/coster/zone
+++ b/pkg/sql/opt/xform/testdata/coster/zone
@@ -715,7 +715,7 @@ locality-optimized-search
  ├── right columns: t.public.abc_part.r:11(string) t.public.abc_part.a:12(int) t.public.abc_part.b:13(int) t.public.abc_part.c:14(string)
  ├── cardinality: [0 - 1]
  ├── stats: [rows=0.910000001, distinct(3)=0.910000001, null(3)=0, distinct(4)=0.910000001, null(4)=0, distinct(3,4)=0.910000001, null(3,4)=0]
- ├── cost: 5.101218
+ ├── cost: 3.419846
  ├── key: ()
  ├── fd: ()-->(1-4)
  ├── prune: (1,2)
@@ -725,7 +725,7 @@ locality-optimized-search
  │    ├── constraint: /6/8/9: [/'east'/1/'foo' - /'east'/1/'foo']
  │    ├── cardinality: [0 - 1]
  │    ├── stats: [rows=0.9001, distinct(6)=0.9001, null(6)=0, distinct(8)=0.9001, null(8)=0, distinct(9)=0.9001, null(9)=0, distinct(6,8,9)=0.9001, null(6,8,9)=0]
- │    ├── cost: 2.532058
+ │    ├── cost: 1.691372
  │    ├── key: ()
  │    ├── fd: ()-->(6-9)
  │    ├── prune: (6-9)
@@ -735,7 +735,7 @@ locality-optimized-search
       ├── constraint: /11/13/14: [/'west'/1/'foo' - /'west'/1/'foo']
       ├── cardinality: [0 - 1]
       ├── stats: [rows=0.9001, distinct(11)=0.9001, null(11)=0, distinct(13)=0.9001, null(13)=0, distinct(14)=0.9001, null(14)=0, distinct(11,13,14)=0.9001, null(11,13,14)=0]
-      ├── cost: 2.532058
+      ├── cost: 1.691372
       ├── key: ()
       ├── fd: ()-->(11-14)
       ├── prune: (11-14)


### PR DESCRIPTION
Backport 1/1 commits from #65071.

/cc @cockroachdb/release

---

Prior to this commit, there were some edge cases (e.g., when we
estimated that a table had 0 rows) when the optimizer chose a regular
scan over a locality optimized scan. This commit reduces the optimizer's
estimated cost of a locality optimized scan so that it is always chosen
over a regular scan when possible.

Fixes #65064

Release note (performance improvement): The optimizer now always prefers
to plan a locality optimized scan over a regular scan when possible. This
may enable the execution engine to avoid communicating with remote nodes,
thus reducing query latency.
