### PR TITLE
opt: inline constant values for FK and uniqueness checks

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_tpcc
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_tpcc
@@ -191,7 +191,8 @@ EXPLAIN INSERT
 INTO
   history (h_c_id, h_c_d_id, h_c_w_id, h_d_id, h_w_id, h_amount, h_date, h_data)
 VALUES
-  (2057, 4, 3, 4, 3, 2100.9, '2021-04-15 15:22:14', '9    zmssaF9m')
+  (2057, 4, 3, 4, 3, 2100.9, '2021-04-15 15:22:14', '9    zmssaF9m'),
+  (2058, 4, 3, 4, 3, 2100.9, '2021-04-15 15:22:14', '9    zmssaF9m')
 ----
 distribution: local
 vectorized: true
@@ -204,8 +205,14 @@ vectorized: true
 │   └── • buffer
 │       │ label: buffer 1
 │       │
-│       └── • values
-│             size: 11 columns, 1 row
+│       └── • render
+│           │ estimated row count: 2
+│           │
+│           └── • render
+│               │ estimated row count: 2
+│               │
+│               └── • values
+│                     size: 8 columns, 2 rows
 │
 ├── • constraint-check
 │   │
@@ -218,7 +225,7 @@ vectorized: true
 │           │ lookup condition: (((column3 = c_w_id) AND (column2 = c_d_id)) AND (column1 = c_id)) AND (crdb_region IN ('ca-central-1', 'us-east-1'))
 │           │
 │           └── • lookup join (anti)
-│               │ estimated row count: 1
+│               │ estimated row count: 2
 │               │ table: customer@primary
 │               │ equality cols are key
 │               │ lookup condition: (((column3 = c_w_id) AND (column2 = c_d_id)) AND (column1 = c_id)) AND (crdb_region = 'ap-southeast-2')
@@ -237,7 +244,7 @@ vectorized: true
             │ lookup condition: ((column5 = d_w_id) AND (column4 = d_id)) AND (crdb_region IN ('ca-central-1', 'us-east-1'))
             │
             └── • lookup join (anti)
-                │ estimated row count: 1
+                │ estimated row count: 2
                 │ table: district@primary
                 │ equality cols are key
                 │ lookup condition: ((column5 = d_w_id) AND (column4 = d_id)) AND (crdb_region = 'ap-southeast-2')

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
@@ -238,44 +238,42 @@ vectorized: true
 ├── • insert
 │   │ into: fk_using_implicit_columns_against_t(pk, ref_t_pk, ref_t_c)
 │   │
-│   └── • buffer
-│       │ label: buffer 1
-│       │
-│       └── • values
-│             size: 3 columns, 1 row
+│   └── • values
+│         size: 3 columns, 1 row
 │
 ├── • constraint-check
 │   │
 │   └── • error if rows
 │       │
-│       └── • hash join (right anti)
-│           │ equality: (pk) = (column2)
-│           │ left cols are key
-│           │ right cols are key
+│       └── • cross join (anti)
 │           │
-│           ├── • scan
-│           │     missing stats
-│           │     table: t@t_b_idx
-│           │     spans: FULL SCAN
+│           ├── • values
+│           │     size: 1 column, 1 row
 │           │
-│           └── • scan buffer
-│                 label: buffer 1
+│           └── • filter
+│               │ filter: pk = 1
+│               │
+│               └── • scan
+│                     missing stats
+│                     table: t@primary
+│                     spans: [ - /0/1] [/1/1 - /1/1] [/2/1 - ]
 │
 └── • constraint-check
     │
     └── • error if rows
         │
-        └── • hash join (right anti)
-            │ equality: (c) = (column3)
-            │ right cols are key
+        └── • cross join (anti)
             │
-            ├── • scan
-            │     missing stats
-            │     table: t@t_c_key
-            │     spans: FULL SCAN
+            ├── • values
+            │     size: 1 column, 1 row
             │
-            └── • scan buffer
-                  label: buffer 1
+            └── • filter
+                │ filter: c = 4
+                │
+                └── • scan
+                      missing stats
+                      table: t@t_c_key
+                      spans: [ - /2/4] [/3/4 - /3/4] [/4/4 - ]
 
 statement ok
 INSERT INTO fk_using_implicit_columns_against_t VALUES (1, 1, 4)
@@ -701,74 +699,54 @@ vectorized: true
 ├── • insert
 │   │ into: t(pk, pk2, partition_by, a, b, c, d)
 │   │
-│   └── • buffer
-│       │ label: buffer 1
-│       │
-│       └── • values
-│             size: 8 columns, 1 row
+│   └── • values
+│         size: 8 columns, 1 row
 │
 ├── • constraint-check
 │   │
 │   └── • error if rows
 │       │
-│       └── • hash join (right semi)
-│           │ equality: (pk) = (column1)
-│           │ right cols are key
-│           │ pred: column3 != partition_by
+│       └── • cross join
 │           │
-│           ├── • scan
-│           │     missing stats
-│           │     table: t@t_a_idx
-│           │     spans: FULL SCAN
+│           ├── • values
+│           │     size: 1 column, 1 row
 │           │
-│           └── • scan buffer
-│                 label: buffer 1
+│           └── • limit
+│               │ count: 1
+│               │
+│               └── • filter
+│                   │ filter: pk = 1
+│                   │
+│                   └── • scan
+│                         missing stats
+│                         table: t@t_a_idx
+│                         spans: [ - /0] [/2 - ]
 │
 ├── • constraint-check
 │   │
 │   └── • error if rows
 │       │
-│       └── • hash join (right semi)
-│           │ equality: (b) = (column5)
-│           │ right cols are key
-│           │ pred: (column1 != pk) OR (column3 != partition_by)
+│       └── • cross join
 │           │
-│           ├── • scan
-│           │     missing stats
-│           │     table: t@t_b_key
-│           │     spans: FULL SCAN
+│           ├── • values
+│           │     size: 1 column, 1 row
 │           │
-│           └── • scan buffer
-│                 label: buffer 1
+│           └── • limit
+│               │ count: 1
+│               │
+│               └── • filter
+│                   │ filter: (b = 1) AND ((pk != 1) OR (partition_by != 1))
+│                   │
+│                   └── • scan
+│                         missing stats
+│                         table: t@t_b_key
+│                         spans: FULL SCAN
 │
 └── • constraint-check
     │
     └── • error if rows
         │
-        └── • limit
-            │ count: 1
-            │
-            └── • lookup join
-                │ table: t@primary
-                │ equality: (partition_by, pk) = (partition_by,pk)
-                │ equality cols are key
-                │
-                └── • hash join
-                    │ equality: (c) = (column6)
-                    │ right cols are key
-                    │ pred: (column1 != pk) OR (column3 != partition_by)
-                    │
-                    ├── • scan
-                    │     missing stats
-                    │     table: t@t_c_key (partial index)
-                    │     spans: FULL SCAN
-                    │
-                    └── • filter
-                        │ estimated row count: 1
-                        │ filter: column7 > 100
-                        │
-                        └── • scan buffer
-                              label: buffer 1
+        └── • norows
 
 statement ok
 INSERT INTO t VALUES (1, 1, 1, 1, 1, 1, 1), (2, 2, 2, 2, 2, 2, 2)

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -977,18 +977,23 @@ SELECT * FROM [EXPLAIN INSERT INTO child VALUES (1, 1)] OFFSET 2
     │
     └── • error if rows
         │
-        └── • lookup join (anti)
-            │ table: parent@primary
-            │ equality cols are key
-            │ lookup condition: (column2 = p_id) AND (crdb_region IN ('ca-central-1', 'us-east-1'))
+        └── • cross join (anti)
             │
-            └── • lookup join (anti)
-                │ table: parent@primary
-                │ equality cols are key
-                │ lookup condition: (column2 = p_id) AND (crdb_region = 'ap-southeast-2')
+            ├── • values
+            │     size: 1 column, 1 row
+            │
+            └── • union all
+                │ limit: 1
                 │
-                └── • scan buffer
-                      label: buffer 1
+                ├── • scan
+                │     missing stats
+                │     table: parent@primary
+                │     spans: [/'ap-southeast-2'/1 - /'ap-southeast-2'/1]
+                │
+                └── • scan
+                      missing stats
+                      table: parent@primary
+                      spans: [/'ca-central-1'/1 - /'ca-central-1'/1] [/'us-east-1'/1 - /'us-east-1'/1]
 
 query T
 SELECT * FROM [EXPLAIN UPSERT INTO child VALUES (1, 1)] OFFSET 2
@@ -1027,18 +1032,23 @@ SELECT * FROM [EXPLAIN UPSERT INTO child VALUES (1, 1)] OFFSET 2
     │
     └── • error if rows
         │
-        └── • lookup join (anti)
-            │ table: parent@primary
-            │ equality cols are key
-            │ lookup condition: (column2 = p_id) AND (crdb_region IN ('ca-central-1', 'us-east-1'))
+        └── • cross join (anti)
             │
-            └── • lookup join (anti)
-                │ table: parent@primary
-                │ equality cols are key
-                │ lookup condition: (column2 = p_id) AND (crdb_region = 'ap-southeast-2')
+            ├── • values
+            │     size: 1 column, 1 row
+            │
+            └── • union all
+                │ limit: 1
                 │
-                └── • scan buffer
-                      label: buffer 1
+                ├── • scan
+                │     missing stats
+                │     table: parent@primary
+                │     spans: [/'ap-southeast-2'/1 - /'ap-southeast-2'/1]
+                │
+                └── • scan
+                      missing stats
+                      table: parent@primary
+                      spans: [/'ca-central-1'/1 - /'ca-central-1'/1] [/'us-east-1'/1 - /'us-east-1'/1]
 
 # We don't yet support locality optimized search for semi join.
 query T
@@ -1100,6 +1110,53 @@ SELECT * FROM [EXPLAIN DELETE FROM parent WHERE p_id = 1] OFFSET 2
                           missing stats
                           table: child@child_c_p_id_idx
                           spans: [/'us-east-1' - /'us-east-1']
+
+# An insert FK check only needs to search a single region when the region is a
+# computed column dependent on the FK column and a constant value is inserted.
+statement ok
+CREATE TABLE parent_comp (
+  pk INT PRIMARY KEY,
+  crdb_region crdb_internal_region AS (
+    CASE WHEN pk <= 10 THEN 'us-east-1' ELSE 'ap-southeast-2' END
+  ) STORED,
+  FAMILY (pk, crdb_region)
+) LOCALITY REGIONAL BY ROW;
+
+statement ok
+CREATE TABLE child_comp (
+  pk INT PRIMARY KEY,
+  p_pk INT REFERENCES parent_comp (pk),
+  crdb_region crdb_internal_region AS (
+    CASE WHEN pk <= 10 THEN 'us-east-1' ELSE 'ap-southeast-2' END
+  ) STORED,
+  FAMILY (pk, p_pk, crdb_region)
+) LOCALITY REGIONAL BY ROW;
+
+query T
+SELECT * FROM [EXPLAIN INSERT INTO child_comp VALUES (1, 1)] OFFSET 2
+----
+·
+• root
+│
+├── • insert
+│   │ into: child_comp(pk, p_pk, crdb_region)
+│   │
+│   └── • values
+│         size: 4 columns, 1 row
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │
+        └── • cross join (anti)
+            │
+            ├── • values
+            │     size: 1 column, 1 row
+            │
+            └── • scan
+                  missing stats
+                  table: parent_comp@primary
+                  spans: [/'us-east-1'/1 - /'us-east-1'/1]
 
 # Tests creating a index and a unique constraint on a REGIONAL BY ROW table.
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/fk
+++ b/pkg/sql/opt/exec/execbuilder/testdata/fk
@@ -999,17 +999,36 @@ CREATE TABLE nonunique_idx_child (
   CONSTRAINT "fk" FOREIGN KEY (ref1, ref2) REFERENCES nonunique_idx_parent (k1, k2)
 )
 
+# TODO(mgartner/radu): This query should use the insert fast path. Inlining the
+# values removes the lookup join in the FK check  that the insert fast path
+# relies on.
 query T
 EXPLAIN INSERT INTO nonunique_idx_child VALUES (0, 1, 10)
 ----
 distribution: local
 vectorized: true
 ·
-• insert fast path
-  into: nonunique_idx_child(k, ref1, ref2)
-  auto commit
-  FK check: nonunique_idx_parent@nonunique_idx_parent_k2_idx
-  size: 3 columns, 1 row
+• root
+│
+├── • insert
+│   │ into: nonunique_idx_child(k, ref1, ref2)
+│   │
+│   └── • values
+│         size: 3 columns, 1 row
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │
+        └── • cross join (anti)
+            │
+            ├── • values
+            │     size: 2 columns, 1 row
+            │
+            └── • scan
+                  missing stats
+                  table: nonunique_idx_parent@nonunique_idx_parent_k2_idx
+                  spans: [/10/1 - /10/1]
 
 # Regression test for #46397: upserter was looking at the incorrect ordinal for
 # the check because of an extra input column used by the FK check.

--- a/pkg/sql/opt/exec/execbuilder/testdata/insert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/insert
@@ -647,19 +647,46 @@ statement ok
 CREATE TABLE t62270_parent (id INT PRIMARY KEY);
 CREATE TABLE t62270_child (c UUID DEFAULT (gen_random_uuid()), p INT REFERENCES t62270_parent (id));
 
+# TODO(mgartner/radu): This query should use the insert fast path. Inlining the
+# values removes the lookup join in the FK check  that the insert fast path
+# relies on.
 query T
 EXPLAIN (VERBOSE) INSERT INTO t62270_child (p) VALUES (1)
 ----
 distribution: local
 vectorized: true
 ·
-• insert fast path
-  columns: ()
-  estimated row count: 0 (missing stats)
-  into: t62270_child(c, p, rowid)
-  auto commit
-  FK check: t62270_parent@primary
-  size: 3 columns, 1 row
-  row 0, expr 0: gen_random_uuid()
-  row 0, expr 1: 1
-  row 0, expr 2: unique_rowid()
+• root
+│ columns: ()
+│
+├── • insert
+│   │ columns: ()
+│   │ estimated row count: 0 (missing stats)
+│   │ into: t62270_child(c, p, rowid)
+│   │
+│   └── • values
+│         columns: (c_default, column1, rowid_default)
+│         size: 3 columns, 1 row
+│         row 0, expr 0: 1
+│         row 0, expr 1: gen_random_uuid()
+│         row 0, expr 2: unique_rowid()
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │ columns: ()
+        │
+        └── • cross join (anti)
+            │ columns: (p)
+            │ estimated row count: 0 (missing stats)
+            │
+            ├── • values
+            │     columns: (p)
+            │     size: 1 column, 1 row
+            │     row 0, expr 0: 1
+            │
+            └── • scan
+                  columns: (id)
+                  estimated row count: 1 (missing stats)
+                  table: t62270_parent@primary
+                  spans: /1/0

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -811,6 +811,52 @@ func (prj *ProjectExpr) InternalFDs() *props.FuncDepSet {
 	return &prj.internalFuncDeps
 }
 
+// FindInlinableConstants returns the set of input columns that are synthesized
+// constant value expressions: ConstOp, TrueOp, FalseOp, or NullOp. Constant
+// value expressions can often be inlined into referencing expressions. Only
+// Project and Values operators synthesize constant value expressions.
+func FindInlinableConstants(input RelExpr) opt.ColSet {
+	var cols opt.ColSet
+	if project, ok := input.(*ProjectExpr); ok {
+		for i := range project.Projections {
+			item := &project.Projections[i]
+			if opt.IsConstValueOp(item.Element) {
+				cols.Add(item.Col)
+			}
+		}
+	} else if values, ok := input.(*ValuesExpr); ok && len(values.Rows) == 1 {
+		tup := values.Rows[0].(*TupleExpr)
+		for i, scalar := range tup.Elems {
+			if opt.IsConstValueOp(scalar) {
+				cols.Add(values.Cols[i])
+			}
+		}
+	}
+	return cols
+}
+
+// ExtractColumnFromProjectOrValues searches a Project or Values input
+// expression for the column having the given id. It returns the expression for
+// that column.
+func ExtractColumnFromProjectOrValues(input RelExpr, col opt.ColumnID) opt.ScalarExpr {
+	if project, ok := input.(*ProjectExpr); ok {
+		for i := range project.Projections {
+			item := &project.Projections[i]
+			if item.Col == col {
+				return item.Element
+			}
+		}
+	} else if values, ok := input.(*ValuesExpr); ok && len(values.Rows) == 1 {
+		tup := values.Rows[0].(*TupleExpr)
+		for i, scalar := range tup.Elems {
+			if values.Cols[i] == col {
+				return scalar
+			}
+		}
+	}
+	panic(errors.AssertionFailedf("could not find column to extract"))
+}
+
 // ExprIsNeverNull makes a best-effort attempt to prove that the provided
 // scalar is always non-NULL, given the set of outer columns that are known
 // to be not null. This is particularly useful with check constraints.

--- a/pkg/sql/opt/norm/testdata/rules/with
+++ b/pkg/sql/opt/norm/testdata/rules/with
@@ -546,29 +546,28 @@ CREATE TABLE child (c INT PRIMARY KEY, p INT REFERENCES parent(p))
 norm format=show-all
 WITH cte AS (INSERT INTO child VALUES (1, 1) RETURNING c) SELECT c FROM cte UNION SELECT c+1 FROM cte
 ----
-with &2 (cte)
+with &1 (cte)
  ├── columns: c:12(int!null)
  ├── cardinality: [1 - 2]
  ├── volatile, mutations
  ├── stats: [rows=2, distinct(12)=2, null(12)=0]
- ├── cost: 1046.9075
+ ├── cost: 1044.44
  ├── key: (12)
  ├── insert t.public.child
  │    ├── columns: t.public.child.c:1(int!null)
  │    ├── insert-mapping:
  │    │    ├── column1:4 => t.public.child.c:1
  │    │    └── column2:5 => t.public.child.p:2
- │    ├── input binding: &1
  │    ├── cardinality: [1 - 1]
  │    ├── volatile, mutations
  │    ├── stats: [rows=1, distinct(1)=1, null(1)=0]
- │    ├── cost: 1046.7975
+ │    ├── cost: 1044.33
  │    ├── key: ()
  │    ├── fd: ()-->(1)
  │    ├── values
  │    │    ├── columns: column1:4(int!null) column2:5(int!null)
  │    │    ├── cardinality: [1 - 1]
- │    │    ├── stats: [rows=1, distinct(4)=1, null(4)=0, distinct(5)=1, null(5)=0]
+ │    │    ├── stats: [rows=1, distinct(4)=1, null(4)=0]
  │    │    ├── cost: 0.02
  │    │    ├── key: ()
  │    │    ├── fd: ()-->(4,5)
@@ -578,39 +577,43 @@ with &2 (cte)
  │    │         └── const: 1 [type=int]
  │    └── f-k-checks
  │         └── f-k-checks-item: child(p) -> parent(p)
- │              └── anti-join (hash)
+ │              └── anti-join (cross)
  │                   ├── columns: p:6(int!null)
  │                   ├── cardinality: [0 - 1]
  │                   ├── stats: [rows=1e-10]
- │                   ├── cost: 1046.7675
+ │                   ├── cost: 1044.3
  │                   ├── key: ()
  │                   ├── fd: ()-->(6)
- │                   ├── cte-uses
- │                   │    └── &1: count=1 used-columns=(5)
- │                   ├── with-scan &1
+ │                   ├── prune: (6)
+ │                   ├── values
  │                   │    ├── columns: p:6(int!null)
- │                   │    ├── mapping:
- │                   │    │    └──  column2:5(int) => p:6(int)
  │                   │    ├── cardinality: [1 - 1]
- │                   │    ├── stats: [rows=1, distinct(6)=1, null(6)=0]
- │                   │    ├── cost: 0.01
+ │                   │    ├── stats: [rows=1]
+ │                   │    ├── cost: 0.02
  │                   │    ├── key: ()
  │                   │    ├── fd: ()-->(6)
  │                   │    ├── prune: (6)
- │                   │    └── cte-uses
- │                   │         └── &1: count=1 used-columns=(5)
- │                   ├── scan t.public.parent
+ │                   │    └── tuple [type=tuple{int}]
+ │                   │         └── const: 1 [type=int]
+ │                   ├── select
  │                   │    ├── columns: t.public.parent.p:7(int!null)
- │                   │    ├── stats: [rows=1000, distinct(7)=1000, null(7)=0]
- │                   │    ├── cost: 1034.21
- │                   │    ├── key: (7)
- │                   │    ├── prune: (7)
- │                   │    ├── interesting orderings: (+7)
- │                   │    └── unfiltered-cols: (7,8)
- │                   └── filters
- │                        └── eq [type=bool, outer=(6,7), constraints=(/6: (/NULL - ]; /7: (/NULL - ]), fd=(6)==(7), (7)==(6)]
- │                             ├── variable: p:6 [type=int]
- │                             └── variable: t.public.parent.p:7 [type=int]
+ │                   │    ├── cardinality: [0 - 1]
+ │                   │    ├── stats: [rows=1, distinct(7)=1, null(7)=0]
+ │                   │    ├── cost: 1044.23
+ │                   │    ├── key: ()
+ │                   │    ├── fd: ()-->(7)
+ │                   │    ├── scan t.public.parent
+ │                   │    │    ├── columns: t.public.parent.p:7(int!null)
+ │                   │    │    ├── stats: [rows=1000, distinct(7)=1000, null(7)=0]
+ │                   │    │    ├── cost: 1034.21
+ │                   │    │    ├── key: (7)
+ │                   │    │    ├── prune: (7)
+ │                   │    │    └── interesting orderings: (+7)
+ │                   │    └── filters
+ │                   │         └── eq [type=bool, outer=(7), constraints=(/7: [/1 - /1]; tight), fd=()-->(7)]
+ │                   │              ├── variable: t.public.parent.p:7 [type=int]
+ │                   │              └── const: 1 [type=int]
+ │                   └── filters (true)
  └── union
       ├── columns: c:12(int!null)
       ├── left columns: c:9(int)
@@ -620,7 +623,7 @@ with &2 (cte)
       ├── stats: [rows=2, distinct(12)=2, null(12)=0]
       ├── cost: 0.1
       ├── key: (12)
-      ├── with-scan &2 (cte)
+      ├── with-scan &1 (cte)
       │    ├── columns: c:9(int!null)
       │    ├── mapping:
       │    │    └──  t.public.child.c:1(int) => c:9(int)
@@ -639,7 +642,7 @@ with &2 (cte)
            ├── key: ()
            ├── fd: ()-->(11)
            ├── prune: (11)
-           ├── with-scan &2 (cte)
+           ├── with-scan &1 (cte)
            │    ├── columns: c:10(int!null)
            │    ├── mapping:
            │    │    └──  t.public.child.c:1(int) => c:10(int)

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -273,6 +273,10 @@ func (b *Builder) buildInsert(ins *tree.Insert, inScope *scope) (outScope *scope
 	// both cases, include columns undergoing mutations in the write-only state.
 	mb.addSynthesizedColsForInsert()
 
+	// Set insertExpr. This expression is used when building FK and uniqueness
+	// checks. See mutationBuilder.buildCheckInputScan.
+	mb.insertExpr = mb.outScope.expr
+
 	var returning tree.ReturningExprs
 	if resultsNeeded(ins.Returning) {
 		returning = *ins.Returning.(*tree.ReturningExprs)

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -60,6 +60,11 @@ type mutationBuilder struct {
 	// fetchScope contains the set of columns fetched from the target table.
 	fetchScope *scope
 
+	// insertExpr is the expression that produces the values which will be
+	// inserted into the target table. It is only populated for INSERT and
+	// UPSERT expressions.
+	insertExpr memo.RelExpr
+
 	// targetColList is an ordered list of IDs of the table columns into which
 	// values will be inserted, or which will be updated with new values. It is
 	// incrementally built as the mutation operator is built.
@@ -1338,27 +1343,28 @@ const (
 	checkInputScanFetchedVals
 )
 
-// buildCheckInputScan constructs a WithScan that iterates over the input to the
-// mutation operator. Used in expressions that generate rows for checking for FK
-// and uniqueness violations.
+// buildCheckInputScan constructs an expression that produces the new values of
+// rows during a mutation. It is used in expressions that generate rows for
+// checking for FK and uniqueness violations. It returns either a WithScan that
+// iterates over the input to the mutation operator, or a Values expression with
+// constant mutation values inlined.
 //
 // The WithScan expression will scan either the new values or the fetched values
 // for the given table ordinals (which correspond to FK or unique columns).
 //
-// Returns a scope containing the WithScan expression and the output columns
-// from the WithScan. The output columns map 1-to-1 to tabOrdinals. Also returns
-// the subset of these columns that can be assumed to be not null (either
-// because they are not null in the mutation input or because they are
+// Returns a scope containing the WithScan or Values expression and the output
+// columns from the WithScan. The output columns map 1-to-1 to tabOrdinals. Also
+// returns the subset of these columns that can be assumed to be not null
+// (either because they are not null in the mutation input or because they are
 // non-nullable table columns).
-//
 func (mb *mutationBuilder) buildCheckInputScan(
 	typ checkInputScanType, tabOrdinals []int,
-) (withScanScope *scope, notNullOutCols opt.ColSet) {
+) (outScope *scope, notNullOutCols opt.ColSet) {
 	// inputCols are the column IDs from the mutation input that we are scanning.
 	inputCols := make(opt.ColList, len(tabOrdinals))
 
-	withScanScope = mb.b.allocScope()
-	withScanScope.cols = make([]scopeColumn, len(inputCols))
+	outScope = mb.b.allocScope()
+	outScope.cols = make([]scopeColumn, len(inputCols))
 
 	for i, tabOrd := range tabOrdinals {
 		if typ == checkInputScanNewVals {
@@ -1373,11 +1379,11 @@ func (mb *mutationBuilder) buildCheckInputScan(
 		// Synthesize a new output column for the input column, using the name
 		// of the column in the underlying table. The table's column names are
 		// used because partial unique constraint checks must filter the
-		// WithScan rows with a predicate expression that references the table's
-		// columns.
+		// WithScan or Values rows with a predicate expression that references
+		// the table's columns.
 		tableCol := mb.b.factory.Metadata().Table(mb.tabID).Column(tabOrd)
 		outCol := mb.md.AddColumn(string(tableCol.ColName()), tableCol.DatumType())
-		withScanScope.cols[i] = scopeColumn{
+		outScope.cols[i] = scopeColumn{
 			id:   outCol,
 			name: scopeColName(tableCol.ColName()),
 			typ:  tableCol.DatumType(),
@@ -1392,11 +1398,35 @@ func (mb *mutationBuilder) buildCheckInputScan(
 		}
 	}
 
-	withScanScope.expr = mb.b.factory.ConstructWithScan(&memo.WithScanPrivate{
+	if mb.insertExpr != nil {
+		constCols := memo.FindInlinableConstants(mb.insertExpr)
+		if inputCols.ToSet().SubsetOf(constCols) {
+			elems := make(memo.ScalarListExpr, len(inputCols))
+			colTypes := make([]*types.T, len(inputCols))
+			for i, colID := range inputCols {
+				elem := memo.ExtractColumnFromProjectOrValues(mb.insertExpr, colID)
+				elems[i] = elem
+				colTypes[i] = elem.DataType()
+			}
+
+			tupleTyp := types.MakeTuple(colTypes)
+			row := mb.b.factory.ConstructTuple(elems, tupleTyp)
+			outScope.expr = mb.b.factory.ConstructValues(memo.ScalarListExpr{row}, &memo.ValuesPrivate{
+				Cols: outScope.colList(),
+				ID:   mb.b.factory.Metadata().NextUniqueID(),
+			})
+
+			return outScope, notNullOutCols
+		}
+	}
+
+	mb.ensureWithID()
+	outScope.expr = mb.b.factory.ConstructWithScan(&memo.WithScanPrivate{
 		With:    mb.withID,
 		InCols:  inputCols,
-		OutCols: withScanScope.colList(),
+		OutCols: outScope.colList(),
 		ID:      mb.b.factory.Metadata().NextUniqueID(),
 	})
-	return withScanScope, notNullOutCols
+
+	return outScope, notNullOutCols
 }

--- a/pkg/sql/opt/optbuilder/mutation_builder_unique.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder_unique.go
@@ -40,7 +40,6 @@ func (mb *mutationBuilder) buildUniqueChecksForInsert() {
 		return
 	}
 
-	mb.ensureWithID()
 	h := &mb.uniqueCheckHelper
 
 	for i, n := 0, mb.tab.UniqueCount(); i < n; i++ {

--- a/pkg/sql/opt/optbuilder/testdata/fk-checks-insert
+++ b/pkg/sql/opt/optbuilder/testdata/fk-checks-insert
@@ -32,6 +32,54 @@ insert child
                 └── filters
                      └── p:6 = parent.p:7
 
+# Build a Values expression instead of a WithScan when the INSERT FK columns are
+# constant.
+build
+INSERT INTO child VALUES (100, 1)
+----
+insert child
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:4 => c:1
+ │    └── column2:5 => child.p:2
+ ├── values
+ │    ├── columns: column1:4!null column2:5!null
+ │    └── (100, 1)
+ └── f-k-checks
+      └── f-k-checks-item: child(p) -> parent(p)
+           └── anti-join (hash)
+                ├── columns: p:6!null
+                ├── values
+                │    ├── columns: p:6!null
+                │    └── (1,)
+                ├── scan parent
+                │    └── columns: parent.p:7!null
+                └── filters
+                     └── p:6 = parent.p:7
+
+build
+INSERT INTO child VALUES ((floor(random() * 100))::INT, 1)
+----
+insert child
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:4 => c:1
+ │    └── column2:5 => child.p:2
+ ├── values
+ │    ├── columns: column1:4 column2:5!null
+ │    └── (floor(random() * 100.0)::INT8, 1)
+ └── f-k-checks
+      └── f-k-checks-item: child(p) -> parent(p)
+           └── anti-join (hash)
+                ├── columns: p:6!null
+                ├── values
+                │    ├── columns: p:6!null
+                │    └── (1,)
+                ├── scan parent
+                │    └── columns: parent.p:7!null
+                └── filters
+                     └── p:6 = parent.p:7
+
 build
 INSERT INTO child VALUES (100, 1), (200, 1) ON CONFLICT DO NOTHING
 ----
@@ -354,7 +402,6 @@ insert multi_col_child
  │    ├── column2:7 => multi_col_child.p:2
  │    ├── column3:8 => multi_col_child.q:3
  │    └── column4:9 => multi_col_child.r:4
- ├── input binding: &1
  ├── values
  │    ├── columns: column1:6!null column2:7!null column3:8!null column4:9!null
  │    └── (1, 10, 10, 10)
@@ -362,12 +409,9 @@ insert multi_col_child
       └── f-k-checks-item: multi_col_child(p,q,r) -> multi_col_parent(p,q,r)
            └── anti-join (hash)
                 ├── columns: p:10!null q:11!null r:12!null
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: p:10!null q:11!null r:12!null
-                │    └── mapping:
-                │         ├──  column2:7 => p:10
-                │         ├──  column3:8 => q:11
-                │         └──  column4:9 => r:12
+                │    └── (10, 10, 10)
                 ├── scan multi_col_parent
                 │    └── columns: multi_col_parent.p:13!null multi_col_parent.q:14!null multi_col_parent.r:15!null
                 └── filters
@@ -479,7 +523,6 @@ insert multi_col_child_full
  │    ├── column2:7 => multi_col_child_full.p:2
  │    ├── column3:8 => multi_col_child_full.q:3
  │    └── column4:9 => multi_col_child_full.r:4
- ├── input binding: &1
  ├── values
  │    ├── columns: column1:6!null column2:7!null column3:8!null column4:9!null
  │    └── (1, 10, 10, 10)
@@ -487,12 +530,9 @@ insert multi_col_child_full
       └── f-k-checks-item: multi_col_child_full(p,q,r) -> multi_col_parent(p,q,r)
            └── anti-join (hash)
                 ├── columns: p:10!null q:11!null r:12!null
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: p:10!null q:11!null r:12!null
-                │    └── mapping:
-                │         ├──  column2:7 => p:10
-                │         ├──  column3:8 => q:11
-                │         └──  column4:9 => r:12
+                │    └── (10, 10, 10)
                 ├── scan multi_col_parent
                 │    └── columns: multi_col_parent.p:13!null multi_col_parent.q:14!null multi_col_parent.r:15!null
                 └── filters

--- a/pkg/sql/opt/optbuilder/testdata/fk-checks-upsert
+++ b/pkg/sql/opt/optbuilder/testdata/fk-checks-upsert
@@ -61,6 +61,32 @@ upsert c1
                 └── filters
                      └── p:8 = p.p:9
 
+# Build a Values expression instead of a WithScan when the INSERT FK columns are
+# constant.
+build
+UPSERT INTO c1 VALUES (100, 1, 10)
+----
+upsert c1
+ ├── columns: <none>
+ ├── upsert-mapping:
+ │    ├── column1:5 => c:1
+ │    ├── column2:6 => c1.p:2
+ │    └── column3:7 => i:3
+ ├── values
+ │    ├── columns: column1:5!null column2:6!null column3:7!null
+ │    └── (100, 1, 10)
+ └── f-k-checks
+      └── f-k-checks-item: c1(p) -> p(p)
+           └── anti-join (hash)
+                ├── columns: p:8!null
+                ├── values
+                │    ├── columns: p:8!null
+                │    └── (1,)
+                ├── scan p
+                │    └── columns: p.p:9!null
+                └── filters
+                     └── p:8 = p.p:9
+
 build
 UPSERT INTO c1(c) VALUES (100), (200)
 ----
@@ -570,7 +596,6 @@ upsert cpq
  │    ├── column2:7 => cpq.p:2
  │    ├── column3:8 => cpq.q:3
  │    └── column4:9 => cpq.other:4
- ├── input binding: &1
  ├── values
  │    ├── columns: column1:6!null column2:7!null column3:8!null column4:9!null
  │    └── (1, 1, 1, 1)
@@ -578,11 +603,9 @@ upsert cpq
       └── f-k-checks-item: cpq(p,q) -> pq(p,q)
            └── anti-join (hash)
                 ├── columns: p:10!null q:11!null
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: p:10!null q:11!null
-                │    └── mapping:
-                │         ├──  column2:7 => p:10
-                │         └──  column3:8 => q:11
+                │    └── (1, 1)
                 ├── scan pq
                 │    └── columns: pq.p:13 pq.q:14
                 └── filters
@@ -771,7 +794,6 @@ upsert cpq
  │    ├── p_default:12 => cpq.p:2
  │    ├── q_default:13 => cpq.q:3
  │    └── other_default:14 => cpq.other:4
- ├── input binding: &1
  ├── project
  │    ├── columns: p_default:12!null q_default:13!null other_default:14 x:6
  │    ├── project
@@ -786,11 +808,9 @@ upsert cpq
       └── f-k-checks-item: cpq(p,q) -> pq(p,q)
            └── anti-join (hash)
                 ├── columns: p:15!null q:16!null
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: p:15!null q:16!null
-                │    └── mapping:
-                │         ├──  p_default:12 => p:15
-                │         └──  q_default:13 => q:16
+                │    └── (4, 8)
                 ├── scan pq
                 │    └── columns: pq.p:18 pq.q:19
                 └── filters

--- a/pkg/sql/opt/optbuilder/testdata/unique-checks-insert
+++ b/pkg/sql/opt/optbuilder/testdata/unique-checks-insert
@@ -354,7 +354,6 @@ insert uniq
  │    ├── column3:9 => uniq.w:3
  │    ├── column4:10 => uniq.x:4
  │    └── column5:11 => uniq.y:5
- ├── input binding: &1
  ├── upsert-distinct-on
  │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null column5:11!null
  │    ├── grouping columns: column3:9!null
@@ -382,14 +381,9 @@ insert uniq
                 ├── columns: x:27!null y:28!null
                 └── semi-join (hash)
                      ├── columns: k:24!null v:25!null w:26!null x:27!null y:28!null
-                     ├── with-scan &1
+                     ├── values
                      │    ├── columns: k:24!null v:25!null w:26!null x:27!null y:28!null
-                     │    └── mapping:
-                     │         ├──  column1:7 => k:24
-                     │         ├──  column2:8 => v:25
-                     │         ├──  column3:9 => w:26
-                     │         ├──  column4:10 => x:27
-                     │         └──  column5:11 => y:28
+                     │    └── (1, 2, 3, 4, 5)
                      ├── scan uniq
                      │    └── columns: uniq.k:18!null uniq.v:19 uniq.w:20 uniq.x:21 uniq.y:22
                      └── filters
@@ -1303,6 +1297,13 @@ CREATE TABLE uniq_partial_constraint_and_index (
 # Use a pseudo-partial index as the only arbiter. Note that we use the "norm"
 # directive instead of "build" to ensure that partial index predicates are fully
 # normalized when choosing arbiter indexes.
+# TODO(mgartner): There is no need to plan a uniqueness check because the
+# pseudo-partial index arbiter ensures that the unique constraint is not
+# violated. In this particular case, with one constant row being inserted, the
+# unique check is normalized to an empty Values expression. One option is to
+# recognize an empty Values uniqueness check and eliminate it. Eliminating this
+# uniqueness check in more general cases would require recognizing that the
+# check is not necessary and not building it in the first place.
 norm
 INSERT INTO uniq_partial_constraint_and_index VALUES (1, 1, 1)
 ON CONFLICT (a) WHERE b > 10 DO NOTHING
@@ -1315,7 +1316,6 @@ insert uniq_partial_constraint_and_index
  │    ├── column2:6 => uniq_partial_constraint_and_index.a:2
  │    └── column3:7 => uniq_partial_constraint_and_index.b:3
  ├── partial index put columns: partial_index_put1:13
- ├── input binding: &1
  ├── project
  │    ├── columns: partial_index_put1:13!null column1:5!null column2:6!null column3:7!null
  │    ├── anti-join (cross)
@@ -1336,31 +1336,8 @@ insert uniq_partial_constraint_and_index
  │         └── true [as=partial_index_put1:13]
  └── unique-checks
       └── unique-checks-item: uniq_partial_constraint_and_index(a)
-           └── project
-                ├── columns: a:19!null
-                └── semi-join (hash)
-                     ├── columns: k:18!null a:19!null b:20!null
-                     ├── select
-                     │    ├── columns: k:18!null a:19!null b:20!null
-                     │    ├── with-scan &1
-                     │    │    ├── columns: k:18!null a:19!null b:20!null
-                     │    │    └── mapping:
-                     │    │         ├──  column1:5 => k:18
-                     │    │         ├──  column2:6 => a:19
-                     │    │         └──  column3:7 => b:20
-                     │    └── filters
-                     │         └── b:20 > 10
-                     ├── select
-                     │    ├── columns: uniq_partial_constraint_and_index.k:14!null uniq_partial_constraint_and_index.a:15 uniq_partial_constraint_and_index.b:16!null
-                     │    ├── scan uniq_partial_constraint_and_index
-                     │    │    ├── columns: uniq_partial_constraint_and_index.k:14!null uniq_partial_constraint_and_index.a:15 uniq_partial_constraint_and_index.b:16
-                     │    │    └── partial index predicates
-                     │    │         └── secondary: filters (true)
-                     │    └── filters
-                     │         └── uniq_partial_constraint_and_index.b:16 > 10
-                     └── filters
-                          ├── a:19 = uniq_partial_constraint_and_index.a:15
-                          └── k:18 != uniq_partial_constraint_and_index.k:14
+           └── values
+                └── columns: a:19!null
 
 exec-ddl
 CREATE TABLE uniq_constraint_and_partial_index (
@@ -1574,3 +1551,45 @@ insert uniq_computed_pk
                      └── filters
                           ├── d:40 = uniq_computed_pk.d:32
                           └── (i:38 != uniq_computed_pk.i:30) OR (c_i_expr:41 != uniq_computed_pk.c_i_expr:33)
+
+exec-ddl
+CREATE TABLE uniq_default (
+  k INT PRIMARY KEY,
+  a INT DEFAULT (10),
+  b INT,
+  UNIQUE WITHOUT INDEX (a, b)
+)
+----
+
+# Inline default values in uniqueness check. The norm directive is used so that
+# the projection of the default value is normalized into the values expression.
+# This normalization is required for the values to be inlined in the constraint
+# check.
+norm
+INSERT INTO uniq_default (k, b) VALUES (1, 100)
+----
+insert uniq_default
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:5 => uniq_default.k:1
+ │    ├── a_default:7 => uniq_default.a:2
+ │    └── column2:6 => uniq_default.b:3
+ ├── values
+ │    ├── columns: column1:5!null column2:6!null a_default:7!null
+ │    └── (1, 100, 10)
+ └── unique-checks
+      └── unique-checks-item: uniq_default(a,b)
+           └── semi-join (cross)
+                ├── columns: a:13!null b:14!null
+                ├── values
+                │    ├── columns: a:13!null b:14!null
+                │    └── (10, 100)
+                ├── select
+                │    ├── columns: uniq_default.k:8!null uniq_default.a:9!null uniq_default.b:10!null
+                │    ├── scan uniq_default
+                │    │    └── columns: uniq_default.k:8!null uniq_default.a:9 uniq_default.b:10
+                │    └── filters
+                │         ├── uniq_default.a:9 = 10
+                │         ├── uniq_default.b:10 = 100
+                │         └── uniq_default.k:8 != 1
+                └── filters (true)

--- a/pkg/sql/opt/optbuilder/testdata/unique-checks-upsert
+++ b/pkg/sql/opt/optbuilder/testdata/unique-checks-upsert
@@ -1507,7 +1507,6 @@ upsert uniq_fk_child
  ├── upsert-mapping:
  │    ├── column1:4 => k:1
  │    └── column2:5 => uniq_fk_child.a:2
- ├── input binding: &1
  ├── values
  │    ├── columns: column1:4!null column2:5!null
  │    └── (1, 2)
@@ -1515,10 +1514,9 @@ upsert uniq_fk_child
       └── f-k-checks-item: uniq_fk_child(a) -> uniq_fk_parent(a)
            └── anti-join (hash)
                 ├── columns: a:6!null
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: a:6!null
-                │    └── mapping:
-                │         └──  column2:5 => a:6
+                │    └── (2,)
                 ├── scan uniq_fk_parent
                 │    └── columns: uniq_fk_parent.a:7
                 └── filters

--- a/pkg/sql/opt/xform/testdata/coster/join
+++ b/pkg/sql/opt/xform/testdata/coster/join
@@ -869,39 +869,43 @@ insert c
  ├── insert-mapping:
  │    ├── column1:4 => c:1
  │    └── column2:5 => c.p:2
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── stats: [rows=0]
- ├── cost: 6.08
+ ├── cost: 5.13
  ├── values
  │    ├── columns: column1:4!null column2:5!null
  │    ├── cardinality: [1 - 1]
- │    ├── stats: [rows=1, distinct(5)=1, null(5)=0]
+ │    ├── stats: [rows=1]
  │    ├── cost: 0.02
  │    ├── key: ()
  │    ├── fd: ()-->(4,5)
  │    └── (1, 1)
  └── f-k-checks
       └── f-k-checks-item: c(p) -> p(p)
-           └── anti-join (lookup p)
+           └── anti-join (cross)
                 ├── columns: p:6!null
-                ├── key columns: [6] = [7]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── stats: [rows=1e-10]
-                ├── cost: 6.05
+                ├── cost: 5.1
                 ├── key: ()
                 ├── fd: ()-->(6)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: p:6!null
-                │    ├── mapping:
-                │    │    └──  column2:5 => p:6
                 │    ├── cardinality: [1 - 1]
-                │    ├── stats: [rows=1, distinct(6)=1, null(6)=0]
-                │    ├── cost: 0.01
+                │    ├── stats: [rows=1]
+                │    ├── cost: 0.02
                 │    ├── key: ()
-                │    └── fd: ()-->(6)
+                │    ├── fd: ()-->(6)
+                │    └── (1,)
+                ├── scan p
+                │    ├── columns: p.p:7!null
+                │    ├── constraint: /7: [/1 - /1]
+                │    ├── cardinality: [0 - 1]
+                │    ├── stats: [rows=1, distinct(7)=1, null(7)=0]
+                │    ├── cost: 5.03
+                │    ├── key: ()
+                │    └── fd: ()-->(7)
                 └── filters (true)
 
 # Avoid performing a lookup join with virtual tables if the filter is

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -149,7 +149,6 @@ insert order
  │    ├── o_carrier_id_default:17 => o_carrier_id:6
  │    ├── column6:15 => o_ol_cnt:7
  │    └── column7:16 => o_all_local:8
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -160,22 +159,23 @@ insert order
  │    └── (100, 5, 10, 50, '2019-08-26 16:50:41', 10, 1, NULL)
  └── f-k-checks
       └── f-k-checks-item: order(o_w_id,o_d_id,o_c_id) -> customer(c_w_id,c_d_id,c_id)
-           └── anti-join (lookup customer)
+           └── anti-join (cross)
                 ├── columns: o_w_id:18!null o_d_id:19!null o_c_id:20!null
-                ├── key columns: [18 19 20] = [23 22 21]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(18-20)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: o_w_id:18!null o_d_id:19!null o_c_id:20!null
-                │    ├── mapping:
-                │    │    ├──  column3:12 => o_w_id:18
-                │    │    ├──  column2:11 => o_d_id:19
-                │    │    └──  column4:13 => o_c_id:20
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(18-20)
+                │    ├── fd: ()-->(18-20)
+                │    └── (10, 5, 50)
+                ├── scan customer
+                │    ├── columns: c_id:21!null c_d_id:22!null c_w_id:23!null
+                │    ├── constraint: /23/22/21: [/10/5/50 - /10/5/50]
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(21-23)
                 └── filters (true)
 
 opt format=hide-qual
@@ -187,7 +187,6 @@ insert new_order
  │    ├── column1:5 => new_order.no_o_id:1
  │    ├── column2:6 => new_order.no_d_id:2
  │    └── column3:7 => new_order.no_w_id:3
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -198,22 +197,23 @@ insert new_order
  │    └── (2000, 100, 10)
  └── f-k-checks
       └── f-k-checks-item: new_order(no_w_id,no_d_id,no_o_id) -> order(o_w_id,o_d_id,o_id)
-           └── anti-join (lookup order)
+           └── anti-join (cross)
                 ├── columns: no_w_id:8!null no_d_id:9!null no_o_id:10!null
-                ├── key columns: [8 9 10] = [13 12 11]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(8-10)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: no_w_id:8!null no_d_id:9!null no_o_id:10!null
-                │    ├── mapping:
-                │    │    ├──  column3:7 => no_w_id:8
-                │    │    ├──  column2:6 => no_d_id:9
-                │    │    └──  column1:5 => no_o_id:10
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(8-10)
+                │    ├── fd: ()-->(8-10)
+                │    └── (10, 100, 2000)
+                ├── scan order
+                │    ├── columns: o_id:11!null o_d_id:12!null o_w_id:13!null
+                │    ├── constraint: /13/12/-11: [/10/100/2000 - /10/100/2000]
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(11-13)
                 └── filters (true)
 
 opt format=hide-qual
@@ -609,7 +609,6 @@ insert history
  │    ├── column7:17 => h_date:7
  │    ├── h_amount:20 => history.h_amount:8
  │    └── column8:18 => h_data:9
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -621,39 +620,42 @@ insert history
  │    └── (1343, 5, 10, 5, 10, '2019-08-26 16:50:41', '8    Kdcgphy3', gen_random_uuid(), 3860.61)
  └── f-k-checks
       ├── f-k-checks-item: history(h_c_w_id,h_c_d_id,h_c_id) -> customer(c_w_id,c_d_id,c_id)
-      │    └── anti-join (lookup customer)
+      │    └── anti-join (cross)
       │         ├── columns: h_c_w_id:21!null h_c_d_id:22!null h_c_id:23!null
-      │         ├── key columns: [21 22 23] = [26 25 24]
-      │         ├── lookup columns are key
       │         ├── cardinality: [0 - 1]
       │         ├── key: ()
       │         ├── fd: ()-->(21-23)
-      │         ├── with-scan &1
+      │         ├── values
       │         │    ├── columns: h_c_w_id:21!null h_c_d_id:22!null h_c_id:23!null
-      │         │    ├── mapping:
-      │         │    │    ├──  column3:13 => h_c_w_id:21
-      │         │    │    ├──  column2:12 => h_c_d_id:22
-      │         │    │    └──  column1:11 => h_c_id:23
       │         │    ├── cardinality: [1 - 1]
       │         │    ├── key: ()
-      │         │    └── fd: ()-->(21-23)
+      │         │    ├── fd: ()-->(21-23)
+      │         │    └── (10, 5, 1343)
+      │         ├── scan customer
+      │         │    ├── columns: c_id:24!null c_d_id:25!null c_w_id:26!null
+      │         │    ├── constraint: /26/25/24: [/10/5/1343 - /10/5/1343]
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── key: ()
+      │         │    └── fd: ()-->(24-26)
       │         └── filters (true)
       └── f-k-checks-item: history(h_w_id,h_d_id) -> district(d_w_id,d_id)
-           └── anti-join (lookup district)
+           └── anti-join (cross)
                 ├── columns: h_w_id:46!null h_d_id:47!null
-                ├── key columns: [46 47] = [49 48]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(46,47)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: h_w_id:46!null h_d_id:47!null
-                │    ├── mapping:
-                │    │    ├──  column5:15 => h_w_id:46
-                │    │    └──  column4:14 => h_d_id:47
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(46,47)
+                │    ├── fd: ()-->(46,47)
+                │    └── (10, 5)
+                ├── scan district
+                │    ├── columns: d_id:48!null d_w_id:49!null
+                │    ├── constraint: /49/48: [/10/5 - /10/5]
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(48,49)
                 └── filters (true)
 
 # --------------------------------------------------

--- a/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
@@ -152,7 +152,6 @@ insert order
  │    ├── o_carrier_id_default:17 => o_carrier_id:6
  │    ├── column6:15 => o_ol_cnt:7
  │    └── column7:16 => o_all_local:8
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -163,22 +162,23 @@ insert order
  │    └── (100, 5, 10, 50, '2019-08-26 16:50:41', 10, 1, NULL)
  └── f-k-checks
       └── f-k-checks-item: order(o_w_id,o_d_id,o_c_id) -> customer(c_w_id,c_d_id,c_id)
-           └── anti-join (lookup customer)
+           └── anti-join (cross)
                 ├── columns: o_w_id:18!null o_d_id:19!null o_c_id:20!null
-                ├── key columns: [18 19 20] = [23 22 21]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(18-20)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: o_w_id:18!null o_d_id:19!null o_c_id:20!null
-                │    ├── mapping:
-                │    │    ├──  column3:12 => o_w_id:18
-                │    │    ├──  column2:11 => o_d_id:19
-                │    │    └──  column4:13 => o_c_id:20
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(18-20)
+                │    ├── fd: ()-->(18-20)
+                │    └── (10, 5, 50)
+                ├── scan customer
+                │    ├── columns: c_id:21!null c_d_id:22!null c_w_id:23!null
+                │    ├── constraint: /23/22/21: [/10/5/50 - /10/5/50]
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(21-23)
                 └── filters (true)
 
 opt format=hide-qual
@@ -190,7 +190,6 @@ insert new_order
  │    ├── column1:5 => new_order.no_o_id:1
  │    ├── column2:6 => new_order.no_d_id:2
  │    └── column3:7 => new_order.no_w_id:3
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -201,22 +200,23 @@ insert new_order
  │    └── (2000, 100, 10)
  └── f-k-checks
       └── f-k-checks-item: new_order(no_w_id,no_d_id,no_o_id) -> order(o_w_id,o_d_id,o_id)
-           └── anti-join (lookup order)
+           └── anti-join (cross)
                 ├── columns: no_w_id:8!null no_d_id:9!null no_o_id:10!null
-                ├── key columns: [8 9 10] = [13 12 11]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(8-10)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: no_w_id:8!null no_d_id:9!null no_o_id:10!null
-                │    ├── mapping:
-                │    │    ├──  column3:7 => no_w_id:8
-                │    │    ├──  column2:6 => no_d_id:9
-                │    │    └──  column1:5 => no_o_id:10
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(8-10)
+                │    ├── fd: ()-->(8-10)
+                │    └── (10, 100, 2000)
+                ├── scan order
+                │    ├── columns: o_id:11!null o_d_id:12!null o_w_id:13!null
+                │    ├── constraint: /13/12/-11: [/10/100/2000 - /10/100/2000]
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(11-13)
                 └── filters (true)
 
 opt format=hide-qual
@@ -612,7 +612,6 @@ insert history
  │    ├── column7:17 => h_date:7
  │    ├── h_amount:20 => history.h_amount:8
  │    └── column8:18 => h_data:9
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -624,39 +623,42 @@ insert history
  │    └── (1343, 5, 10, 5, 10, '2019-08-26 16:50:41', '8    Kdcgphy3', gen_random_uuid(), 3860.61)
  └── f-k-checks
       ├── f-k-checks-item: history(h_c_w_id,h_c_d_id,h_c_id) -> customer(c_w_id,c_d_id,c_id)
-      │    └── anti-join (lookup customer)
+      │    └── anti-join (cross)
       │         ├── columns: h_c_w_id:21!null h_c_d_id:22!null h_c_id:23!null
-      │         ├── key columns: [21 22 23] = [26 25 24]
-      │         ├── lookup columns are key
       │         ├── cardinality: [0 - 1]
       │         ├── key: ()
       │         ├── fd: ()-->(21-23)
-      │         ├── with-scan &1
+      │         ├── values
       │         │    ├── columns: h_c_w_id:21!null h_c_d_id:22!null h_c_id:23!null
-      │         │    ├── mapping:
-      │         │    │    ├──  column3:13 => h_c_w_id:21
-      │         │    │    ├──  column2:12 => h_c_d_id:22
-      │         │    │    └──  column1:11 => h_c_id:23
       │         │    ├── cardinality: [1 - 1]
       │         │    ├── key: ()
-      │         │    └── fd: ()-->(21-23)
+      │         │    ├── fd: ()-->(21-23)
+      │         │    └── (10, 5, 1343)
+      │         ├── scan customer
+      │         │    ├── columns: c_id:24!null c_d_id:25!null c_w_id:26!null
+      │         │    ├── constraint: /26/25/24: [/10/5/1343 - /10/5/1343]
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── key: ()
+      │         │    └── fd: ()-->(24-26)
       │         └── filters (true)
       └── f-k-checks-item: history(h_w_id,h_d_id) -> district(d_w_id,d_id)
-           └── anti-join (lookup district)
+           └── anti-join (cross)
                 ├── columns: h_w_id:46!null h_d_id:47!null
-                ├── key columns: [46 47] = [49 48]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(46,47)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: h_w_id:46!null h_d_id:47!null
-                │    ├── mapping:
-                │    │    ├──  column5:15 => h_w_id:46
-                │    │    └──  column4:14 => h_d_id:47
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(46,47)
+                │    ├── fd: ()-->(46,47)
+                │    └── (10, 5)
+                ├── scan district
+                │    ├── columns: d_id:48!null d_w_id:49!null
+                │    ├── constraint: /49/48: [/10/5 - /10/5]
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(48,49)
                 └── filters (true)
 
 # --------------------------------------------------

--- a/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
@@ -146,7 +146,6 @@ insert order
  │    ├── o_carrier_id_default:17 => o_carrier_id:6
  │    ├── column6:15 => o_ol_cnt:7
  │    └── column7:16 => o_all_local:8
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -157,22 +156,29 @@ insert order
  │    └── (100, 5, 10, 50, '2019-08-26 16:50:41', 10, 1, NULL)
  └── f-k-checks
       └── f-k-checks-item: order(o_w_id,o_d_id,o_c_id) -> customer(c_w_id,c_d_id,c_id)
-           └── anti-join (lookup customer)
+           └── anti-join (cross)
                 ├── columns: o_w_id:18!null o_d_id:19!null o_c_id:20!null
-                ├── key columns: [18 19 20] = [23 22 21]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(18-20)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: o_w_id:18!null o_d_id:19!null o_c_id:20!null
-                │    ├── mapping:
-                │    │    ├──  column3:12 => o_w_id:18
-                │    │    ├──  column2:11 => o_d_id:19
-                │    │    └──  column4:13 => o_c_id:20
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(18-20)
+                │    ├── fd: ()-->(18-20)
+                │    └── (10, 5, 50)
+                ├── select
+                │    ├── columns: c_id:21!null c_d_id:22!null c_w_id:23!null
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    ├── fd: ()-->(21-23)
+                │    ├── scan customer@customer_idx
+                │    │    ├── columns: c_id:21!null c_d_id:22!null c_w_id:23!null
+                │    │    ├── constraint: /23/22/26/24/21: [/10/5 - /10/5]
+                │    │    ├── key: (21)
+                │    │    └── fd: ()-->(22,23)
+                │    └── filters
+                │         └── c_id:21 = 50 [outer=(21), constraints=(/21: [/50 - /50]; tight), fd=()-->(21)]
                 └── filters (true)
 
 opt format=hide-qual
@@ -184,7 +190,6 @@ insert new_order
  │    ├── column1:5 => new_order.no_o_id:1
  │    ├── column2:6 => new_order.no_d_id:2
  │    └── column3:7 => new_order.no_w_id:3
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -195,22 +200,23 @@ insert new_order
  │    └── (2000, 100, 10)
  └── f-k-checks
       └── f-k-checks-item: new_order(no_w_id,no_d_id,no_o_id) -> order(o_w_id,o_d_id,o_id)
-           └── anti-join (lookup order)
+           └── anti-join (cross)
                 ├── columns: no_w_id:8!null no_d_id:9!null no_o_id:10!null
-                ├── key columns: [8 9 10] = [13 12 11]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(8-10)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: no_w_id:8!null no_d_id:9!null no_o_id:10!null
-                │    ├── mapping:
-                │    │    ├──  column3:7 => no_w_id:8
-                │    │    ├──  column2:6 => no_d_id:9
-                │    │    └──  column1:5 => no_o_id:10
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(8-10)
+                │    ├── fd: ()-->(8-10)
+                │    └── (10, 100, 2000)
+                ├── scan order
+                │    ├── columns: o_id:11!null o_d_id:12!null o_w_id:13!null
+                │    ├── constraint: /13/12/-11: [/10/100/2000 - /10/100/2000]
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(11-13)
                 └── filters (true)
 
 opt format=hide-qual
@@ -606,7 +612,6 @@ insert history
  │    ├── column7:17 => h_date:7
  │    ├── h_amount:20 => history.h_amount:8
  │    └── column8:18 => h_data:9
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -618,39 +623,48 @@ insert history
  │    └── (1343, 5, 10, 5, 10, '2019-08-26 16:50:41', '8    Kdcgphy3', gen_random_uuid(), 3860.61)
  └── f-k-checks
       ├── f-k-checks-item: history(h_c_w_id,h_c_d_id,h_c_id) -> customer(c_w_id,c_d_id,c_id)
-      │    └── anti-join (lookup customer)
+      │    └── anti-join (cross)
       │         ├── columns: h_c_w_id:21!null h_c_d_id:22!null h_c_id:23!null
-      │         ├── key columns: [21 22 23] = [26 25 24]
-      │         ├── lookup columns are key
       │         ├── cardinality: [0 - 1]
       │         ├── key: ()
       │         ├── fd: ()-->(21-23)
-      │         ├── with-scan &1
+      │         ├── values
       │         │    ├── columns: h_c_w_id:21!null h_c_d_id:22!null h_c_id:23!null
-      │         │    ├── mapping:
-      │         │    │    ├──  column3:13 => h_c_w_id:21
-      │         │    │    ├──  column2:12 => h_c_d_id:22
-      │         │    │    └──  column1:11 => h_c_id:23
       │         │    ├── cardinality: [1 - 1]
       │         │    ├── key: ()
-      │         │    └── fd: ()-->(21-23)
+      │         │    ├── fd: ()-->(21-23)
+      │         │    └── (10, 5, 1343)
+      │         ├── select
+      │         │    ├── columns: c_id:24!null c_d_id:25!null c_w_id:26!null
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── key: ()
+      │         │    ├── fd: ()-->(24-26)
+      │         │    ├── scan customer@customer_idx
+      │         │    │    ├── columns: c_id:24!null c_d_id:25!null c_w_id:26!null
+      │         │    │    ├── constraint: /26/25/29/27/24: [/10/5 - /10/5]
+      │         │    │    ├── key: (24)
+      │         │    │    └── fd: ()-->(25,26)
+      │         │    └── filters
+      │         │         └── c_id:24 = 1343 [outer=(24), constraints=(/24: [/1343 - /1343]; tight), fd=()-->(24)]
       │         └── filters (true)
       └── f-k-checks-item: history(h_w_id,h_d_id) -> district(d_w_id,d_id)
-           └── anti-join (lookup district)
+           └── anti-join (cross)
                 ├── columns: h_w_id:46!null h_d_id:47!null
-                ├── key columns: [46 47] = [49 48]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(46,47)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: h_w_id:46!null h_d_id:47!null
-                │    ├── mapping:
-                │    │    ├──  column5:15 => h_w_id:46
-                │    │    └──  column4:14 => h_d_id:47
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(46,47)
+                │    ├── fd: ()-->(46,47)
+                │    └── (10, 5)
+                ├── scan district
+                │    ├── columns: d_id:48!null d_w_id:49!null
+                │    ├── constraint: /49/48: [/10/5 - /10/5]
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(48,49)
                 └── filters (true)
 
 # --------------------------------------------------

--- a/pkg/sql/opt/xform/testdata/external/tpce
+++ b/pkg/sql/opt/xform/testdata/external/tpce
@@ -477,7 +477,6 @@ insert trade_history
  │    ├── column1:5 => trade_history.th_t_id:1
  │    ├── column2:6 => th_dts:2
  │    └── column3:7 => trade_history.th_st_id:3
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -488,36 +487,42 @@ insert trade_history
  │    └── (0, '2020-06-17 22:27:42.148484', 'SBMT')
  └── f-k-checks
       ├── f-k-checks-item: trade_history(th_t_id) -> trade(t_id)
-      │    └── anti-join (lookup trade)
+      │    └── anti-join (cross)
       │         ├── columns: th_t_id:8!null
-      │         ├── key columns: [8] = [9]
-      │         ├── lookup columns are key
       │         ├── cardinality: [0 - 1]
       │         ├── key: ()
       │         ├── fd: ()-->(8)
-      │         ├── with-scan &1
+      │         ├── values
       │         │    ├── columns: th_t_id:8!null
-      │         │    ├── mapping:
-      │         │    │    └──  column1:5 => th_t_id:8
       │         │    ├── cardinality: [1 - 1]
       │         │    ├── key: ()
-      │         │    └── fd: ()-->(8)
+      │         │    ├── fd: ()-->(8)
+      │         │    └── (0,)
+      │         ├── scan trade
+      │         │    ├── columns: t_id:9!null
+      │         │    ├── constraint: /9: [/0 - /0]
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── key: ()
+      │         │    └── fd: ()-->(9)
       │         └── filters (true)
       └── f-k-checks-item: trade_history(th_st_id) -> status_type(st_id)
-           └── anti-join (lookup status_type)
+           └── anti-join (cross)
                 ├── columns: th_st_id:25!null
-                ├── key columns: [25] = [26]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(25)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: th_st_id:25!null
-                │    ├── mapping:
-                │    │    └──  column3:7 => th_st_id:25
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(25)
+                │    ├── fd: ()-->(25)
+                │    └── ('SBMT',)
+                ├── scan status_type
+                │    ├── columns: st_id:26!null
+                │    ├── constraint: /26: [/'SBMT' - /'SBMT']
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(26)
                 └── filters (true)
 
 # --------------------------------------------------
@@ -1735,7 +1740,6 @@ insert trade
  │    ├── t_tax:36 => trade.t_tax:14
  │    └── column15:31 => t_lifo:15
  ├── check columns: check1:37 check2:38 check3:39 check4:40 check5:41
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -1746,68 +1750,80 @@ insert trade
  │    └── (0, '2020-06-17 22:27:42.148484', 'SBMT', 'TMB', true, 'SYMB', 10, 0, 'Name', true, 1E+2, NULL, 1, 0, 0, true, true, true, true, true)
  └── f-k-checks
       ├── f-k-checks-item: trade(t_st_id) -> status_type(st_id)
-      │    └── anti-join (lookup status_type)
+      │    └── anti-join (cross)
       │         ├── columns: t_st_id:42!null
-      │         ├── key columns: [42] = [43]
-      │         ├── lookup columns are key
       │         ├── cardinality: [0 - 1]
       │         ├── key: ()
       │         ├── fd: ()-->(42)
-      │         ├── with-scan &1
+      │         ├── values
       │         │    ├── columns: t_st_id:42!null
-      │         │    ├── mapping:
-      │         │    │    └──  column3:19 => t_st_id:42
       │         │    ├── cardinality: [1 - 1]
       │         │    ├── key: ()
-      │         │    └── fd: ()-->(42)
+      │         │    ├── fd: ()-->(42)
+      │         │    └── ('SBMT',)
+      │         ├── scan status_type
+      │         │    ├── columns: st_id:43!null
+      │         │    ├── constraint: /43: [/'SBMT' - /'SBMT']
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── key: ()
+      │         │    └── fd: ()-->(43)
       │         └── filters (true)
       ├── f-k-checks-item: trade(t_tt_id) -> trade_type(tt_id)
-      │    └── anti-join (lookup trade_type)
+      │    └── anti-join (cross)
       │         ├── columns: t_tt_id:46!null
-      │         ├── key columns: [46] = [47]
-      │         ├── lookup columns are key
       │         ├── cardinality: [0 - 1]
       │         ├── key: ()
       │         ├── fd: ()-->(46)
-      │         ├── with-scan &1
+      │         ├── values
       │         │    ├── columns: t_tt_id:46!null
-      │         │    ├── mapping:
-      │         │    │    └──  column4:20 => t_tt_id:46
       │         │    ├── cardinality: [1 - 1]
       │         │    ├── key: ()
-      │         │    └── fd: ()-->(46)
+      │         │    ├── fd: ()-->(46)
+      │         │    └── ('TMB',)
+      │         ├── scan trade_type
+      │         │    ├── columns: tt_id:47!null
+      │         │    ├── constraint: /47: [/'TMB' - /'TMB']
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── key: ()
+      │         │    └── fd: ()-->(47)
       │         └── filters (true)
       ├── f-k-checks-item: trade(t_s_symb) -> security(s_symb)
-      │    └── anti-join (lookup security)
+      │    └── anti-join (cross)
       │         ├── columns: t_s_symb:52!null
-      │         ├── key columns: [52] = [53]
-      │         ├── lookup columns are key
       │         ├── cardinality: [0 - 1]
       │         ├── key: ()
       │         ├── fd: ()-->(52)
-      │         ├── with-scan &1
+      │         ├── values
       │         │    ├── columns: t_s_symb:52!null
-      │         │    ├── mapping:
-      │         │    │    └──  column6:22 => t_s_symb:52
       │         │    ├── cardinality: [1 - 1]
       │         │    ├── key: ()
-      │         │    └── fd: ()-->(52)
+      │         │    ├── fd: ()-->(52)
+      │         │    └── ('SYMB',)
+      │         ├── scan security
+      │         │    ├── columns: s_symb:53!null
+      │         │    ├── constraint: /53: [/'SYMB' - /'SYMB']
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── key: ()
+      │         │    └── fd: ()-->(53)
       │         └── filters (true)
       └── f-k-checks-item: trade(t_ca_id) -> customer_account(ca_id)
-           └── anti-join (lookup customer_account)
+           └── anti-join (cross)
                 ├── columns: t_ca_id:70!null
-                ├── key columns: [70] = [71]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(70)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: t_ca_id:70!null
-                │    ├── mapping:
-                │    │    └──  column9:25 => t_ca_id:70
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(70)
+                │    ├── fd: ()-->(70)
+                │    └── (0,)
+                ├── scan customer_account
+                │    ├── columns: ca_id:71!null
+                │    ├── constraint: /71: [/0 - /0]
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(71)
                 └── filters (true)
 
 # Q20
@@ -1825,7 +1841,6 @@ insert trade_request
  │    ├── tr_bid_price:14 => trade_request.tr_bid_price:5
  │    └── column6:13 => trade_request.tr_b_id:6
  ├── check columns: check1:15 check2:16
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -1836,68 +1851,80 @@ insert trade_request
  │    └── (0, 'TMB', 'SYMB', 10, 0, 1E+2, true, true)
  └── f-k-checks
       ├── f-k-checks-item: trade_request(tr_t_id) -> trade(t_id)
-      │    └── anti-join (lookup trade)
+      │    └── anti-join (cross)
       │         ├── columns: tr_t_id:17!null
-      │         ├── key columns: [17] = [18]
-      │         ├── lookup columns are key
       │         ├── cardinality: [0 - 1]
       │         ├── key: ()
       │         ├── fd: ()-->(17)
-      │         ├── with-scan &1
+      │         ├── values
       │         │    ├── columns: tr_t_id:17!null
-      │         │    ├── mapping:
-      │         │    │    └──  column1:8 => tr_t_id:17
       │         │    ├── cardinality: [1 - 1]
       │         │    ├── key: ()
-      │         │    └── fd: ()-->(17)
+      │         │    ├── fd: ()-->(17)
+      │         │    └── (0,)
+      │         ├── scan trade
+      │         │    ├── columns: t_id:18!null
+      │         │    ├── constraint: /18: [/0 - /0]
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── key: ()
+      │         │    └── fd: ()-->(18)
       │         └── filters (true)
       ├── f-k-checks-item: trade_request(tr_tt_id) -> trade_type(tt_id)
-      │    └── anti-join (lookup trade_type)
+      │    └── anti-join (cross)
       │         ├── columns: tr_tt_id:34!null
-      │         ├── key columns: [34] = [35]
-      │         ├── lookup columns are key
       │         ├── cardinality: [0 - 1]
       │         ├── key: ()
       │         ├── fd: ()-->(34)
-      │         ├── with-scan &1
+      │         ├── values
       │         │    ├── columns: tr_tt_id:34!null
-      │         │    ├── mapping:
-      │         │    │    └──  column2:9 => tr_tt_id:34
       │         │    ├── cardinality: [1 - 1]
       │         │    ├── key: ()
-      │         │    └── fd: ()-->(34)
+      │         │    ├── fd: ()-->(34)
+      │         │    └── ('TMB',)
+      │         ├── scan trade_type
+      │         │    ├── columns: tt_id:35!null
+      │         │    ├── constraint: /35: [/'TMB' - /'TMB']
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── key: ()
+      │         │    └── fd: ()-->(35)
       │         └── filters (true)
       ├── f-k-checks-item: trade_request(tr_s_symb) -> security(s_symb)
-      │    └── anti-join (lookup security)
+      │    └── anti-join (cross)
       │         ├── columns: tr_s_symb:40!null
-      │         ├── key columns: [40] = [41]
-      │         ├── lookup columns are key
       │         ├── cardinality: [0 - 1]
       │         ├── key: ()
       │         ├── fd: ()-->(40)
-      │         ├── with-scan &1
+      │         ├── values
       │         │    ├── columns: tr_s_symb:40!null
-      │         │    ├── mapping:
-      │         │    │    └──  column3:10 => tr_s_symb:40
       │         │    ├── cardinality: [1 - 1]
       │         │    ├── key: ()
-      │         │    └── fd: ()-->(40)
+      │         │    ├── fd: ()-->(40)
+      │         │    └── ('SYMB',)
+      │         ├── scan security
+      │         │    ├── columns: s_symb:41!null
+      │         │    ├── constraint: /41: [/'SYMB' - /'SYMB']
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── key: ()
+      │         │    └── fd: ()-->(41)
       │         └── filters (true)
       └── f-k-checks-item: trade_request(tr_b_id) -> broker(b_id)
-           └── anti-join (lookup broker)
+           └── anti-join (cross)
                 ├── columns: tr_b_id:58!null
-                ├── key columns: [58] = [59]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(58)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: tr_b_id:58!null
-                │    ├── mapping:
-                │    │    └──  column6:13 => tr_b_id:58
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(58)
+                │    ├── fd: ()-->(58)
+                │    └── (0,)
+                ├── scan broker
+                │    ├── columns: b_id:59!null
+                │    ├── constraint: /59: [/0 - /0]
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(59)
                 └── filters (true)
 
 # Q21
@@ -1911,7 +1938,6 @@ insert trade_history
  │    ├── column1:5 => trade_history.th_t_id:1
  │    ├── column2:6 => th_dts:2
  │    └── column3:7 => trade_history.th_st_id:3
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -1922,36 +1948,42 @@ insert trade_history
  │    └── (0, '2020-06-15 22:27:42.148484', 'SBMT')
  └── f-k-checks
       ├── f-k-checks-item: trade_history(th_t_id) -> trade(t_id)
-      │    └── anti-join (lookup trade)
+      │    └── anti-join (cross)
       │         ├── columns: th_t_id:8!null
-      │         ├── key columns: [8] = [9]
-      │         ├── lookup columns are key
       │         ├── cardinality: [0 - 1]
       │         ├── key: ()
       │         ├── fd: ()-->(8)
-      │         ├── with-scan &1
+      │         ├── values
       │         │    ├── columns: th_t_id:8!null
-      │         │    ├── mapping:
-      │         │    │    └──  column1:5 => th_t_id:8
       │         │    ├── cardinality: [1 - 1]
       │         │    ├── key: ()
-      │         │    └── fd: ()-->(8)
+      │         │    ├── fd: ()-->(8)
+      │         │    └── (0,)
+      │         ├── scan trade
+      │         │    ├── columns: t_id:9!null
+      │         │    ├── constraint: /9: [/0 - /0]
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── key: ()
+      │         │    └── fd: ()-->(9)
       │         └── filters (true)
       └── f-k-checks-item: trade_history(th_st_id) -> status_type(st_id)
-           └── anti-join (lookup status_type)
+           └── anti-join (cross)
                 ├── columns: th_st_id:25!null
-                ├── key columns: [25] = [26]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(25)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: th_st_id:25!null
-                │    ├── mapping:
-                │    │    └──  column3:7 => th_st_id:25
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(25)
+                │    ├── fd: ()-->(25)
+                │    └── ('SBMT',)
+                ├── scan status_type
+                │    ├── columns: st_id:26!null
+                │    ├── constraint: /26: [/'SBMT' - /'SBMT']
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(26)
                 └── filters (true)
 
 # --------------------------------------------------
@@ -2049,7 +2081,6 @@ insert holding_summary
  │    ├── column1:5 => holding_summary.hs_ca_id:1
  │    ├── column2:6 => holding_summary.hs_s_symb:2
  │    └── column3:7 => hs_qty:3
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -2060,36 +2091,42 @@ insert holding_summary
  │    └── (0, 'SYMB', 10)
  └── f-k-checks
       ├── f-k-checks-item: holding_summary(hs_ca_id) -> customer_account(ca_id)
-      │    └── anti-join (lookup customer_account)
+      │    └── anti-join (cross)
       │         ├── columns: hs_ca_id:8!null
-      │         ├── key columns: [8] = [9]
-      │         ├── lookup columns are key
       │         ├── cardinality: [0 - 1]
       │         ├── key: ()
       │         ├── fd: ()-->(8)
-      │         ├── with-scan &1
+      │         ├── values
       │         │    ├── columns: hs_ca_id:8!null
-      │         │    ├── mapping:
-      │         │    │    └──  column1:5 => hs_ca_id:8
       │         │    ├── cardinality: [1 - 1]
       │         │    ├── key: ()
-      │         │    └── fd: ()-->(8)
+      │         │    ├── fd: ()-->(8)
+      │         │    └── (0,)
+      │         ├── scan customer_account
+      │         │    ├── columns: ca_id:9!null
+      │         │    ├── constraint: /9: [/0 - /0]
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── key: ()
+      │         │    └── fd: ()-->(9)
       │         └── filters (true)
       └── f-k-checks-item: holding_summary(hs_s_symb) -> security(s_symb)
-           └── anti-join (lookup security)
+           └── anti-join (cross)
                 ├── columns: hs_s_symb:16!null
-                ├── key columns: [16] = [17]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(16)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: hs_s_symb:16!null
-                │    ├── mapping:
-                │    │    └──  column2:6 => hs_s_symb:16
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(16)
+                │    ├── fd: ()-->(16)
+                │    └── ('SYMB',)
+                ├── scan security
+                │    ├── columns: s_symb:17!null
+                │    ├── constraint: /17: [/'SYMB' - /'SYMB']
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(17)
                 └── filters (true)
 
 # Q6
@@ -2176,7 +2213,6 @@ insert holding_history
  │    ├── column2:7 => holding_history.hh_t_id:2
  │    ├── column3:8 => hh_before_qty:3
  │    └── column4:9 => hh_after_qty:4
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -2187,36 +2223,42 @@ insert holding_history
  │    └── (0, 0, 0, 10)
  └── f-k-checks
       ├── f-k-checks-item: holding_history(hh_h_t_id) -> trade(t_id)
-      │    └── anti-join (lookup trade)
+      │    └── anti-join (cross)
       │         ├── columns: hh_h_t_id:10!null
-      │         ├── key columns: [10] = [11]
-      │         ├── lookup columns are key
       │         ├── cardinality: [0 - 1]
       │         ├── key: ()
       │         ├── fd: ()-->(10)
-      │         ├── with-scan &1
+      │         ├── values
       │         │    ├── columns: hh_h_t_id:10!null
-      │         │    ├── mapping:
-      │         │    │    └──  column1:6 => hh_h_t_id:10
       │         │    ├── cardinality: [1 - 1]
       │         │    ├── key: ()
-      │         │    └── fd: ()-->(10)
+      │         │    ├── fd: ()-->(10)
+      │         │    └── (0,)
+      │         ├── scan trade
+      │         │    ├── columns: t_id:11!null
+      │         │    ├── constraint: /11: [/0 - /0]
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── key: ()
+      │         │    └── fd: ()-->(11)
       │         └── filters (true)
       └── f-k-checks-item: holding_history(hh_t_id) -> trade(t_id)
-           └── anti-join (lookup trade)
+           └── anti-join (cross)
                 ├── columns: hh_t_id:27!null
-                ├── key columns: [27] = [28]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(27)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: hh_t_id:27!null
-                │    ├── mapping:
-                │    │    └──  column2:7 => hh_t_id:27
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(27)
+                │    ├── fd: ()-->(27)
+                │    └── (0,)
+                ├── scan trade
+                │    ├── columns: t_id:28!null
+                │    ├── constraint: /28: [/0 - /0]
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(28)
                 └── filters (true)
 
 # Q10
@@ -2282,7 +2324,6 @@ insert holding
  │    ├── h_price:14 => holding.h_price:5
  │    └── column6:13 => h_qty:6
  ├── check columns: check1:15
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -2293,37 +2334,42 @@ insert holding
  │    └── (0, 0, 'SYMB', '2020-06-17 22:27:42.148484', 10, 1E+2, true)
  └── f-k-checks
       ├── f-k-checks-item: holding(h_t_id) -> trade(t_id)
-      │    └── anti-join (lookup trade)
+      │    └── anti-join (cross)
       │         ├── columns: h_t_id:16!null
-      │         ├── key columns: [16] = [17]
-      │         ├── lookup columns are key
       │         ├── cardinality: [0 - 1]
       │         ├── key: ()
       │         ├── fd: ()-->(16)
-      │         ├── with-scan &1
+      │         ├── values
       │         │    ├── columns: h_t_id:16!null
-      │         │    ├── mapping:
-      │         │    │    └──  column1:8 => h_t_id:16
       │         │    ├── cardinality: [1 - 1]
       │         │    ├── key: ()
-      │         │    └── fd: ()-->(16)
+      │         │    ├── fd: ()-->(16)
+      │         │    └── (0,)
+      │         ├── scan trade
+      │         │    ├── columns: t_id:17!null
+      │         │    ├── constraint: /17: [/0 - /0]
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── key: ()
+      │         │    └── fd: ()-->(17)
       │         └── filters (true)
       └── f-k-checks-item: holding(h_ca_id,h_s_symb) -> holding_summary(hs_ca_id,hs_s_symb)
-           └── anti-join (lookup holding_summary)
+           └── anti-join (cross)
                 ├── columns: h_ca_id:33!null h_s_symb:34!null
-                ├── key columns: [33 34] = [35 36]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(33,34)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: h_ca_id:33!null h_s_symb:34!null
-                │    ├── mapping:
-                │    │    ├──  column2:9 => h_ca_id:33
-                │    │    └──  column3:10 => h_s_symb:34
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(33,34)
+                │    ├── fd: ()-->(33,34)
+                │    └── (0, 'SYMB')
+                ├── scan holding_summary
+                │    ├── columns: hs_ca_id:35!null hs_s_symb:36!null
+                │    ├── constraint: /35/36: [/0/'SYMB' - /0/'SYMB']
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(35,36)
                 └── filters (true)
 
 # Q13
@@ -2371,7 +2417,6 @@ insert holding_summary
  │    ├── column1:5 => holding_summary.hs_ca_id:1
  │    ├── column2:6 => holding_summary.hs_s_symb:2
  │    └── column3:7 => hs_qty:3
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -2382,36 +2427,42 @@ insert holding_summary
  │    └── (0, 'SYMB', 10)
  └── f-k-checks
       ├── f-k-checks-item: holding_summary(hs_ca_id) -> customer_account(ca_id)
-      │    └── anti-join (lookup customer_account)
+      │    └── anti-join (cross)
       │         ├── columns: hs_ca_id:8!null
-      │         ├── key columns: [8] = [9]
-      │         ├── lookup columns are key
       │         ├── cardinality: [0 - 1]
       │         ├── key: ()
       │         ├── fd: ()-->(8)
-      │         ├── with-scan &1
+      │         ├── values
       │         │    ├── columns: hs_ca_id:8!null
-      │         │    ├── mapping:
-      │         │    │    └──  column1:5 => hs_ca_id:8
       │         │    ├── cardinality: [1 - 1]
       │         │    ├── key: ()
-      │         │    └── fd: ()-->(8)
+      │         │    ├── fd: ()-->(8)
+      │         │    └── (0,)
+      │         ├── scan customer_account
+      │         │    ├── columns: ca_id:9!null
+      │         │    ├── constraint: /9: [/0 - /0]
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── key: ()
+      │         │    └── fd: ()-->(9)
       │         └── filters (true)
       └── f-k-checks-item: holding_summary(hs_s_symb) -> security(s_symb)
-           └── anti-join (lookup security)
+           └── anti-join (cross)
                 ├── columns: hs_s_symb:16!null
-                ├── key columns: [16] = [17]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(16)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: hs_s_symb:16!null
-                │    ├── mapping:
-                │    │    └──  column2:6 => hs_s_symb:16
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(16)
+                │    ├── fd: ()-->(16)
+                │    └── ('SYMB',)
+                ├── scan security
+                │    ├── columns: s_symb:17!null
+                │    ├── constraint: /17: [/'SYMB' - /'SYMB']
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(17)
                 └── filters (true)
 
 
@@ -2456,7 +2507,6 @@ insert holding_history
  │    ├── column2:7 => holding_history.hh_t_id:2
  │    ├── column3:8 => hh_before_qty:3
  │    └── column4:9 => hh_after_qty:4
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -2467,36 +2517,42 @@ insert holding_history
  │    └── (0, 0, 0, 10)
  └── f-k-checks
       ├── f-k-checks-item: holding_history(hh_h_t_id) -> trade(t_id)
-      │    └── anti-join (lookup trade)
+      │    └── anti-join (cross)
       │         ├── columns: hh_h_t_id:10!null
-      │         ├── key columns: [10] = [11]
-      │         ├── lookup columns are key
       │         ├── cardinality: [0 - 1]
       │         ├── key: ()
       │         ├── fd: ()-->(10)
-      │         ├── with-scan &1
+      │         ├── values
       │         │    ├── columns: hh_h_t_id:10!null
-      │         │    ├── mapping:
-      │         │    │    └──  column1:6 => hh_h_t_id:10
       │         │    ├── cardinality: [1 - 1]
       │         │    ├── key: ()
-      │         │    └── fd: ()-->(10)
+      │         │    ├── fd: ()-->(10)
+      │         │    └── (0,)
+      │         ├── scan trade
+      │         │    ├── columns: t_id:11!null
+      │         │    ├── constraint: /11: [/0 - /0]
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── key: ()
+      │         │    └── fd: ()-->(11)
       │         └── filters (true)
       └── f-k-checks-item: holding_history(hh_t_id) -> trade(t_id)
-           └── anti-join (lookup trade)
+           └── anti-join (cross)
                 ├── columns: hh_t_id:27!null
-                ├── key columns: [27] = [28]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(27)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: hh_t_id:27!null
-                │    ├── mapping:
-                │    │    └──  column2:7 => hh_t_id:27
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(27)
+                │    ├── fd: ()-->(27)
+                │    └── (0,)
+                ├── scan trade
+                │    ├── columns: t_id:28!null
+                │    ├── constraint: /28: [/0 - /0]
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(28)
                 └── filters (true)
 
 # Q17
@@ -2711,7 +2767,6 @@ insert trade_history
  │    ├── column1:5 => trade_history.th_t_id:1
  │    ├── column2:6 => th_dts:2
  │    └── column3:7 => trade_history.th_st_id:3
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -2722,36 +2777,42 @@ insert trade_history
  │    └── (0, '2020-06-17 22:27:42.148484', 'SBMT')
  └── f-k-checks
       ├── f-k-checks-item: trade_history(th_t_id) -> trade(t_id)
-      │    └── anti-join (lookup trade)
+      │    └── anti-join (cross)
       │         ├── columns: th_t_id:8!null
-      │         ├── key columns: [8] = [9]
-      │         ├── lookup columns are key
       │         ├── cardinality: [0 - 1]
       │         ├── key: ()
       │         ├── fd: ()-->(8)
-      │         ├── with-scan &1
+      │         ├── values
       │         │    ├── columns: th_t_id:8!null
-      │         │    ├── mapping:
-      │         │    │    └──  column1:5 => th_t_id:8
       │         │    ├── cardinality: [1 - 1]
       │         │    ├── key: ()
-      │         │    └── fd: ()-->(8)
+      │         │    ├── fd: ()-->(8)
+      │         │    └── (0,)
+      │         ├── scan trade
+      │         │    ├── columns: t_id:9!null
+      │         │    ├── constraint: /9: [/0 - /0]
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── key: ()
+      │         │    └── fd: ()-->(9)
       │         └── filters (true)
       └── f-k-checks-item: trade_history(th_st_id) -> status_type(st_id)
-           └── anti-join (lookup status_type)
+           └── anti-join (cross)
                 ├── columns: th_st_id:25!null
-                ├── key columns: [25] = [26]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(25)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: th_st_id:25!null
-                │    ├── mapping:
-                │    │    └──  column3:7 => th_st_id:25
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(25)
+                │    ├── fd: ()-->(25)
+                │    └── ('SBMT',)
+                ├── scan status_type
+                │    ├── columns: st_id:26!null
+                │    ├── constraint: /26: [/'SBMT' - /'SBMT']
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(26)
                 └── filters (true)
 
 # Q24
@@ -2797,7 +2858,6 @@ insert settlement
  │    ├── column2:7 => se_cash_type:2
  │    ├── column3:8 => se_cash_due_date:3
  │    └── se_amt:10 => settlement.se_amt:4
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -2808,20 +2868,23 @@ insert settlement
  │    └── (0, 'Cash Account', '2020-06-19', 1E+2)
  └── f-k-checks
       └── f-k-checks-item: settlement(se_t_id) -> trade(t_id)
-           └── anti-join (lookup trade)
+           └── anti-join (cross)
                 ├── columns: se_t_id:11!null
-                ├── key columns: [11] = [12]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(11)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: se_t_id:11!null
-                │    ├── mapping:
-                │    │    └──  column1:6 => se_t_id:11
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(11)
+                │    ├── fd: ()-->(11)
+                │    └── (0,)
+                ├── scan trade
+                │    ├── columns: t_id:12!null
+                │    ├── constraint: /12: [/0 - /0]
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(12)
                 └── filters (true)
 
 # Q26
@@ -2880,7 +2943,6 @@ insert cash_transaction
  │    ├── column2:7 => ct_dts:2
  │    ├── ct_amt:10 => cash_transaction.ct_amt:3
  │    └── column4:9 => ct_name:4
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -2891,20 +2953,23 @@ insert cash_transaction
  │    └── (0, '2020-06-18 22:27:42.148484', 'Market Buy 10 shares of SYMB', 1E+2)
  └── f-k-checks
       └── f-k-checks-item: cash_transaction(ct_t_id) -> trade(t_id)
-           └── anti-join (lookup trade)
+           └── anti-join (cross)
                 ├── columns: ct_t_id:11!null
-                ├── key columns: [11] = [12]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(11)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: ct_t_id:11!null
-                │    ├── mapping:
-                │    │    └──  column1:6 => ct_t_id:11
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(11)
+                │    ├── fd: ()-->(11)
+                │    └── (0,)
+                ├── scan trade
+                │    ├── columns: t_id:12!null
+                │    ├── constraint: /12: [/0 - /0]
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(12)
                 └── filters (true)
 
 # Q28
@@ -4218,7 +4283,6 @@ insert trade_history
  │    ├── column1:5 => trade_history.th_t_id:1
  │    ├── column2:6 => th_dts:2
  │    └── column3:7 => trade_history.th_st_id:3
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -4229,36 +4293,42 @@ insert trade_history
  │    └── (0, '2020-06-17 22:27:42.148484', 'SBMT')
  └── f-k-checks
       ├── f-k-checks-item: trade_history(th_t_id) -> trade(t_id)
-      │    └── anti-join (lookup trade)
+      │    └── anti-join (cross)
       │         ├── columns: th_t_id:8!null
-      │         ├── key columns: [8] = [9]
-      │         ├── lookup columns are key
       │         ├── cardinality: [0 - 1]
       │         ├── key: ()
       │         ├── fd: ()-->(8)
-      │         ├── with-scan &1
+      │         ├── values
       │         │    ├── columns: th_t_id:8!null
-      │         │    ├── mapping:
-      │         │    │    └──  column1:5 => th_t_id:8
       │         │    ├── cardinality: [1 - 1]
       │         │    ├── key: ()
-      │         │    └── fd: ()-->(8)
+      │         │    ├── fd: ()-->(8)
+      │         │    └── (0,)
+      │         ├── scan trade
+      │         │    ├── columns: t_id:9!null
+      │         │    ├── constraint: /9: [/0 - /0]
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── key: ()
+      │         │    └── fd: ()-->(9)
       │         └── filters (true)
       └── f-k-checks-item: trade_history(th_st_id) -> status_type(st_id)
-           └── anti-join (lookup status_type)
+           └── anti-join (cross)
                 ├── columns: th_st_id:25!null
-                ├── key columns: [25] = [26]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(25)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: th_st_id:25!null
-                │    ├── mapping:
-                │    │    └──  column3:7 => th_st_id:25
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(25)
+                │    ├── fd: ()-->(25)
+                │    └── ('SBMT',)
+                ├── scan status_type
+                │    ├── columns: st_id:26!null
+                │    ├── constraint: /26: [/'SBMT' - /'SBMT']
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(26)
                 └── filters (true)
 
 # Q3

--- a/pkg/sql/opt/xform/testdata/external/tpce-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpce-no-stats
@@ -467,7 +467,6 @@ insert trade_history
  │    ├── column1:5 => trade_history.th_t_id:1
  │    ├── column2:6 => th_dts:2
  │    └── column3:7 => trade_history.th_st_id:3
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -478,36 +477,42 @@ insert trade_history
  │    └── (0, '2020-06-17 22:27:42.148484', 'SBMT')
  └── f-k-checks
       ├── f-k-checks-item: trade_history(th_t_id) -> trade(t_id)
-      │    └── anti-join (lookup trade)
+      │    └── anti-join (cross)
       │         ├── columns: th_t_id:8!null
-      │         ├── key columns: [8] = [9]
-      │         ├── lookup columns are key
       │         ├── cardinality: [0 - 1]
       │         ├── key: ()
       │         ├── fd: ()-->(8)
-      │         ├── with-scan &1
+      │         ├── values
       │         │    ├── columns: th_t_id:8!null
-      │         │    ├── mapping:
-      │         │    │    └──  column1:5 => th_t_id:8
       │         │    ├── cardinality: [1 - 1]
       │         │    ├── key: ()
-      │         │    └── fd: ()-->(8)
+      │         │    ├── fd: ()-->(8)
+      │         │    └── (0,)
+      │         ├── scan trade
+      │         │    ├── columns: t_id:9!null
+      │         │    ├── constraint: /9: [/0 - /0]
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── key: ()
+      │         │    └── fd: ()-->(9)
       │         └── filters (true)
       └── f-k-checks-item: trade_history(th_st_id) -> status_type(st_id)
-           └── anti-join (lookup status_type)
+           └── anti-join (cross)
                 ├── columns: th_st_id:25!null
-                ├── key columns: [25] = [26]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(25)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: th_st_id:25!null
-                │    ├── mapping:
-                │    │    └──  column3:7 => th_st_id:25
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(25)
+                │    ├── fd: ()-->(25)
+                │    └── ('SBMT',)
+                ├── scan status_type
+                │    ├── columns: st_id:26!null
+                │    ├── constraint: /26: [/'SBMT' - /'SBMT']
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(26)
                 └── filters (true)
 
 # --------------------------------------------------
@@ -1751,7 +1756,6 @@ insert trade
  │    ├── t_tax:36 => trade.t_tax:14
  │    └── column15:31 => t_lifo:15
  ├── check columns: check1:37 check2:38 check3:39 check4:40 check5:41
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -1762,68 +1766,80 @@ insert trade
  │    └── (0, '2020-06-17 22:27:42.148484', 'SBMT', 'TMB', true, 'SYMB', 10, 0, 'Name', true, 1E+2, NULL, 1, 0, 0, true, true, true, true, true)
  └── f-k-checks
       ├── f-k-checks-item: trade(t_st_id) -> status_type(st_id)
-      │    └── anti-join (lookup status_type)
+      │    └── anti-join (cross)
       │         ├── columns: t_st_id:42!null
-      │         ├── key columns: [42] = [43]
-      │         ├── lookup columns are key
       │         ├── cardinality: [0 - 1]
       │         ├── key: ()
       │         ├── fd: ()-->(42)
-      │         ├── with-scan &1
+      │         ├── values
       │         │    ├── columns: t_st_id:42!null
-      │         │    ├── mapping:
-      │         │    │    └──  column3:19 => t_st_id:42
       │         │    ├── cardinality: [1 - 1]
       │         │    ├── key: ()
-      │         │    └── fd: ()-->(42)
+      │         │    ├── fd: ()-->(42)
+      │         │    └── ('SBMT',)
+      │         ├── scan status_type
+      │         │    ├── columns: st_id:43!null
+      │         │    ├── constraint: /43: [/'SBMT' - /'SBMT']
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── key: ()
+      │         │    └── fd: ()-->(43)
       │         └── filters (true)
       ├── f-k-checks-item: trade(t_tt_id) -> trade_type(tt_id)
-      │    └── anti-join (lookup trade_type)
+      │    └── anti-join (cross)
       │         ├── columns: t_tt_id:46!null
-      │         ├── key columns: [46] = [47]
-      │         ├── lookup columns are key
       │         ├── cardinality: [0 - 1]
       │         ├── key: ()
       │         ├── fd: ()-->(46)
-      │         ├── with-scan &1
+      │         ├── values
       │         │    ├── columns: t_tt_id:46!null
-      │         │    ├── mapping:
-      │         │    │    └──  column4:20 => t_tt_id:46
       │         │    ├── cardinality: [1 - 1]
       │         │    ├── key: ()
-      │         │    └── fd: ()-->(46)
+      │         │    ├── fd: ()-->(46)
+      │         │    └── ('TMB',)
+      │         ├── scan trade_type
+      │         │    ├── columns: tt_id:47!null
+      │         │    ├── constraint: /47: [/'TMB' - /'TMB']
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── key: ()
+      │         │    └── fd: ()-->(47)
       │         └── filters (true)
       ├── f-k-checks-item: trade(t_s_symb) -> security(s_symb)
-      │    └── anti-join (lookup security)
+      │    └── anti-join (cross)
       │         ├── columns: t_s_symb:52!null
-      │         ├── key columns: [52] = [53]
-      │         ├── lookup columns are key
       │         ├── cardinality: [0 - 1]
       │         ├── key: ()
       │         ├── fd: ()-->(52)
-      │         ├── with-scan &1
+      │         ├── values
       │         │    ├── columns: t_s_symb:52!null
-      │         │    ├── mapping:
-      │         │    │    └──  column6:22 => t_s_symb:52
       │         │    ├── cardinality: [1 - 1]
       │         │    ├── key: ()
-      │         │    └── fd: ()-->(52)
+      │         │    ├── fd: ()-->(52)
+      │         │    └── ('SYMB',)
+      │         ├── scan security
+      │         │    ├── columns: s_symb:53!null
+      │         │    ├── constraint: /53: [/'SYMB' - /'SYMB']
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── key: ()
+      │         │    └── fd: ()-->(53)
       │         └── filters (true)
       └── f-k-checks-item: trade(t_ca_id) -> customer_account(ca_id)
-           └── anti-join (lookup customer_account)
+           └── anti-join (cross)
                 ├── columns: t_ca_id:70!null
-                ├── key columns: [70] = [71]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(70)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: t_ca_id:70!null
-                │    ├── mapping:
-                │    │    └──  column9:25 => t_ca_id:70
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(70)
+                │    ├── fd: ()-->(70)
+                │    └── (0,)
+                ├── scan customer_account
+                │    ├── columns: ca_id:71!null
+                │    ├── constraint: /71: [/0 - /0]
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(71)
                 └── filters (true)
 
 # Q20
@@ -1841,7 +1857,6 @@ insert trade_request
  │    ├── tr_bid_price:14 => trade_request.tr_bid_price:5
  │    └── column6:13 => trade_request.tr_b_id:6
  ├── check columns: check1:15 check2:16
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -1852,68 +1867,80 @@ insert trade_request
  │    └── (0, 'TMB', 'SYMB', 10, 0, 1E+2, true, true)
  └── f-k-checks
       ├── f-k-checks-item: trade_request(tr_t_id) -> trade(t_id)
-      │    └── anti-join (lookup trade)
+      │    └── anti-join (cross)
       │         ├── columns: tr_t_id:17!null
-      │         ├── key columns: [17] = [18]
-      │         ├── lookup columns are key
       │         ├── cardinality: [0 - 1]
       │         ├── key: ()
       │         ├── fd: ()-->(17)
-      │         ├── with-scan &1
+      │         ├── values
       │         │    ├── columns: tr_t_id:17!null
-      │         │    ├── mapping:
-      │         │    │    └──  column1:8 => tr_t_id:17
       │         │    ├── cardinality: [1 - 1]
       │         │    ├── key: ()
-      │         │    └── fd: ()-->(17)
+      │         │    ├── fd: ()-->(17)
+      │         │    └── (0,)
+      │         ├── scan trade
+      │         │    ├── columns: t_id:18!null
+      │         │    ├── constraint: /18: [/0 - /0]
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── key: ()
+      │         │    └── fd: ()-->(18)
       │         └── filters (true)
       ├── f-k-checks-item: trade_request(tr_tt_id) -> trade_type(tt_id)
-      │    └── anti-join (lookup trade_type)
+      │    └── anti-join (cross)
       │         ├── columns: tr_tt_id:34!null
-      │         ├── key columns: [34] = [35]
-      │         ├── lookup columns are key
       │         ├── cardinality: [0 - 1]
       │         ├── key: ()
       │         ├── fd: ()-->(34)
-      │         ├── with-scan &1
+      │         ├── values
       │         │    ├── columns: tr_tt_id:34!null
-      │         │    ├── mapping:
-      │         │    │    └──  column2:9 => tr_tt_id:34
       │         │    ├── cardinality: [1 - 1]
       │         │    ├── key: ()
-      │         │    └── fd: ()-->(34)
+      │         │    ├── fd: ()-->(34)
+      │         │    └── ('TMB',)
+      │         ├── scan trade_type
+      │         │    ├── columns: tt_id:35!null
+      │         │    ├── constraint: /35: [/'TMB' - /'TMB']
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── key: ()
+      │         │    └── fd: ()-->(35)
       │         └── filters (true)
       ├── f-k-checks-item: trade_request(tr_s_symb) -> security(s_symb)
-      │    └── anti-join (lookup security)
+      │    └── anti-join (cross)
       │         ├── columns: tr_s_symb:40!null
-      │         ├── key columns: [40] = [41]
-      │         ├── lookup columns are key
       │         ├── cardinality: [0 - 1]
       │         ├── key: ()
       │         ├── fd: ()-->(40)
-      │         ├── with-scan &1
+      │         ├── values
       │         │    ├── columns: tr_s_symb:40!null
-      │         │    ├── mapping:
-      │         │    │    └──  column3:10 => tr_s_symb:40
       │         │    ├── cardinality: [1 - 1]
       │         │    ├── key: ()
-      │         │    └── fd: ()-->(40)
+      │         │    ├── fd: ()-->(40)
+      │         │    └── ('SYMB',)
+      │         ├── scan security
+      │         │    ├── columns: s_symb:41!null
+      │         │    ├── constraint: /41: [/'SYMB' - /'SYMB']
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── key: ()
+      │         │    └── fd: ()-->(41)
       │         └── filters (true)
       └── f-k-checks-item: trade_request(tr_b_id) -> broker(b_id)
-           └── anti-join (lookup broker)
+           └── anti-join (cross)
                 ├── columns: tr_b_id:58!null
-                ├── key columns: [58] = [59]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(58)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: tr_b_id:58!null
-                │    ├── mapping:
-                │    │    └──  column6:13 => tr_b_id:58
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(58)
+                │    ├── fd: ()-->(58)
+                │    └── (0,)
+                ├── scan broker
+                │    ├── columns: b_id:59!null
+                │    ├── constraint: /59: [/0 - /0]
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(59)
                 └── filters (true)
 
 # Q21
@@ -1927,7 +1954,6 @@ insert trade_history
  │    ├── column1:5 => trade_history.th_t_id:1
  │    ├── column2:6 => th_dts:2
  │    └── column3:7 => trade_history.th_st_id:3
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -1938,36 +1964,42 @@ insert trade_history
  │    └── (0, '2020-06-15 22:27:42.148484', 'SBMT')
  └── f-k-checks
       ├── f-k-checks-item: trade_history(th_t_id) -> trade(t_id)
-      │    └── anti-join (lookup trade)
+      │    └── anti-join (cross)
       │         ├── columns: th_t_id:8!null
-      │         ├── key columns: [8] = [9]
-      │         ├── lookup columns are key
       │         ├── cardinality: [0 - 1]
       │         ├── key: ()
       │         ├── fd: ()-->(8)
-      │         ├── with-scan &1
+      │         ├── values
       │         │    ├── columns: th_t_id:8!null
-      │         │    ├── mapping:
-      │         │    │    └──  column1:5 => th_t_id:8
       │         │    ├── cardinality: [1 - 1]
       │         │    ├── key: ()
-      │         │    └── fd: ()-->(8)
+      │         │    ├── fd: ()-->(8)
+      │         │    └── (0,)
+      │         ├── scan trade
+      │         │    ├── columns: t_id:9!null
+      │         │    ├── constraint: /9: [/0 - /0]
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── key: ()
+      │         │    └── fd: ()-->(9)
       │         └── filters (true)
       └── f-k-checks-item: trade_history(th_st_id) -> status_type(st_id)
-           └── anti-join (lookup status_type)
+           └── anti-join (cross)
                 ├── columns: th_st_id:25!null
-                ├── key columns: [25] = [26]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(25)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: th_st_id:25!null
-                │    ├── mapping:
-                │    │    └──  column3:7 => th_st_id:25
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(25)
+                │    ├── fd: ()-->(25)
+                │    └── ('SBMT',)
+                ├── scan status_type
+                │    ├── columns: st_id:26!null
+                │    ├── constraint: /26: [/'SBMT' - /'SBMT']
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(26)
                 └── filters (true)
 
 # --------------------------------------------------
@@ -2065,7 +2097,6 @@ insert holding_summary
  │    ├── column1:5 => holding_summary.hs_ca_id:1
  │    ├── column2:6 => holding_summary.hs_s_symb:2
  │    └── column3:7 => hs_qty:3
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -2076,36 +2107,42 @@ insert holding_summary
  │    └── (0, 'SYMB', 10)
  └── f-k-checks
       ├── f-k-checks-item: holding_summary(hs_ca_id) -> customer_account(ca_id)
-      │    └── anti-join (lookup customer_account)
+      │    └── anti-join (cross)
       │         ├── columns: hs_ca_id:8!null
-      │         ├── key columns: [8] = [9]
-      │         ├── lookup columns are key
       │         ├── cardinality: [0 - 1]
       │         ├── key: ()
       │         ├── fd: ()-->(8)
-      │         ├── with-scan &1
+      │         ├── values
       │         │    ├── columns: hs_ca_id:8!null
-      │         │    ├── mapping:
-      │         │    │    └──  column1:5 => hs_ca_id:8
       │         │    ├── cardinality: [1 - 1]
       │         │    ├── key: ()
-      │         │    └── fd: ()-->(8)
+      │         │    ├── fd: ()-->(8)
+      │         │    └── (0,)
+      │         ├── scan customer_account
+      │         │    ├── columns: ca_id:9!null
+      │         │    ├── constraint: /9: [/0 - /0]
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── key: ()
+      │         │    └── fd: ()-->(9)
       │         └── filters (true)
       └── f-k-checks-item: holding_summary(hs_s_symb) -> security(s_symb)
-           └── anti-join (lookup security)
+           └── anti-join (cross)
                 ├── columns: hs_s_symb:16!null
-                ├── key columns: [16] = [17]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(16)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: hs_s_symb:16!null
-                │    ├── mapping:
-                │    │    └──  column2:6 => hs_s_symb:16
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(16)
+                │    ├── fd: ()-->(16)
+                │    └── ('SYMB',)
+                ├── scan security
+                │    ├── columns: s_symb:17!null
+                │    ├── constraint: /17: [/'SYMB' - /'SYMB']
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(17)
                 └── filters (true)
 
 # Q6
@@ -2192,7 +2229,6 @@ insert holding_history
  │    ├── column2:7 => holding_history.hh_t_id:2
  │    ├── column3:8 => hh_before_qty:3
  │    └── column4:9 => hh_after_qty:4
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -2203,36 +2239,42 @@ insert holding_history
  │    └── (0, 0, 0, 10)
  └── f-k-checks
       ├── f-k-checks-item: holding_history(hh_h_t_id) -> trade(t_id)
-      │    └── anti-join (lookup trade)
+      │    └── anti-join (cross)
       │         ├── columns: hh_h_t_id:10!null
-      │         ├── key columns: [10] = [11]
-      │         ├── lookup columns are key
       │         ├── cardinality: [0 - 1]
       │         ├── key: ()
       │         ├── fd: ()-->(10)
-      │         ├── with-scan &1
+      │         ├── values
       │         │    ├── columns: hh_h_t_id:10!null
-      │         │    ├── mapping:
-      │         │    │    └──  column1:6 => hh_h_t_id:10
       │         │    ├── cardinality: [1 - 1]
       │         │    ├── key: ()
-      │         │    └── fd: ()-->(10)
+      │         │    ├── fd: ()-->(10)
+      │         │    └── (0,)
+      │         ├── scan trade
+      │         │    ├── columns: t_id:11!null
+      │         │    ├── constraint: /11: [/0 - /0]
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── key: ()
+      │         │    └── fd: ()-->(11)
       │         └── filters (true)
       └── f-k-checks-item: holding_history(hh_t_id) -> trade(t_id)
-           └── anti-join (lookup trade)
+           └── anti-join (cross)
                 ├── columns: hh_t_id:27!null
-                ├── key columns: [27] = [28]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(27)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: hh_t_id:27!null
-                │    ├── mapping:
-                │    │    └──  column2:7 => hh_t_id:27
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(27)
+                │    ├── fd: ()-->(27)
+                │    └── (0,)
+                ├── scan trade
+                │    ├── columns: t_id:28!null
+                │    ├── constraint: /28: [/0 - /0]
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(28)
                 └── filters (true)
 
 # Q10
@@ -2298,7 +2340,6 @@ insert holding
  │    ├── h_price:14 => holding.h_price:5
  │    └── column6:13 => h_qty:6
  ├── check columns: check1:15
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -2309,37 +2350,42 @@ insert holding
  │    └── (0, 0, 'SYMB', '2020-06-17 22:27:42.148484', 10, 1E+2, true)
  └── f-k-checks
       ├── f-k-checks-item: holding(h_t_id) -> trade(t_id)
-      │    └── anti-join (lookup trade)
+      │    └── anti-join (cross)
       │         ├── columns: h_t_id:16!null
-      │         ├── key columns: [16] = [17]
-      │         ├── lookup columns are key
       │         ├── cardinality: [0 - 1]
       │         ├── key: ()
       │         ├── fd: ()-->(16)
-      │         ├── with-scan &1
+      │         ├── values
       │         │    ├── columns: h_t_id:16!null
-      │         │    ├── mapping:
-      │         │    │    └──  column1:8 => h_t_id:16
       │         │    ├── cardinality: [1 - 1]
       │         │    ├── key: ()
-      │         │    └── fd: ()-->(16)
+      │         │    ├── fd: ()-->(16)
+      │         │    └── (0,)
+      │         ├── scan trade
+      │         │    ├── columns: t_id:17!null
+      │         │    ├── constraint: /17: [/0 - /0]
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── key: ()
+      │         │    └── fd: ()-->(17)
       │         └── filters (true)
       └── f-k-checks-item: holding(h_ca_id,h_s_symb) -> holding_summary(hs_ca_id,hs_s_symb)
-           └── anti-join (lookup holding_summary)
+           └── anti-join (cross)
                 ├── columns: h_ca_id:33!null h_s_symb:34!null
-                ├── key columns: [33 34] = [35 36]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(33,34)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: h_ca_id:33!null h_s_symb:34!null
-                │    ├── mapping:
-                │    │    ├──  column2:9 => h_ca_id:33
-                │    │    └──  column3:10 => h_s_symb:34
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(33,34)
+                │    ├── fd: ()-->(33,34)
+                │    └── (0, 'SYMB')
+                ├── scan holding_summary
+                │    ├── columns: hs_ca_id:35!null hs_s_symb:36!null
+                │    ├── constraint: /35/36: [/0/'SYMB' - /0/'SYMB']
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(35,36)
                 └── filters (true)
 
 # Q13
@@ -2387,7 +2433,6 @@ insert holding_summary
  │    ├── column1:5 => holding_summary.hs_ca_id:1
  │    ├── column2:6 => holding_summary.hs_s_symb:2
  │    └── column3:7 => hs_qty:3
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -2398,36 +2443,42 @@ insert holding_summary
  │    └── (0, 'SYMB', 10)
  └── f-k-checks
       ├── f-k-checks-item: holding_summary(hs_ca_id) -> customer_account(ca_id)
-      │    └── anti-join (lookup customer_account)
+      │    └── anti-join (cross)
       │         ├── columns: hs_ca_id:8!null
-      │         ├── key columns: [8] = [9]
-      │         ├── lookup columns are key
       │         ├── cardinality: [0 - 1]
       │         ├── key: ()
       │         ├── fd: ()-->(8)
-      │         ├── with-scan &1
+      │         ├── values
       │         │    ├── columns: hs_ca_id:8!null
-      │         │    ├── mapping:
-      │         │    │    └──  column1:5 => hs_ca_id:8
       │         │    ├── cardinality: [1 - 1]
       │         │    ├── key: ()
-      │         │    └── fd: ()-->(8)
+      │         │    ├── fd: ()-->(8)
+      │         │    └── (0,)
+      │         ├── scan customer_account
+      │         │    ├── columns: ca_id:9!null
+      │         │    ├── constraint: /9: [/0 - /0]
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── key: ()
+      │         │    └── fd: ()-->(9)
       │         └── filters (true)
       └── f-k-checks-item: holding_summary(hs_s_symb) -> security(s_symb)
-           └── anti-join (lookup security)
+           └── anti-join (cross)
                 ├── columns: hs_s_symb:16!null
-                ├── key columns: [16] = [17]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(16)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: hs_s_symb:16!null
-                │    ├── mapping:
-                │    │    └──  column2:6 => hs_s_symb:16
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(16)
+                │    ├── fd: ()-->(16)
+                │    └── ('SYMB',)
+                ├── scan security
+                │    ├── columns: s_symb:17!null
+                │    ├── constraint: /17: [/'SYMB' - /'SYMB']
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(17)
                 └── filters (true)
 
 
@@ -2472,7 +2523,6 @@ insert holding_history
  │    ├── column2:7 => holding_history.hh_t_id:2
  │    ├── column3:8 => hh_before_qty:3
  │    └── column4:9 => hh_after_qty:4
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -2483,36 +2533,42 @@ insert holding_history
  │    └── (0, 0, 0, 10)
  └── f-k-checks
       ├── f-k-checks-item: holding_history(hh_h_t_id) -> trade(t_id)
-      │    └── anti-join (lookup trade)
+      │    └── anti-join (cross)
       │         ├── columns: hh_h_t_id:10!null
-      │         ├── key columns: [10] = [11]
-      │         ├── lookup columns are key
       │         ├── cardinality: [0 - 1]
       │         ├── key: ()
       │         ├── fd: ()-->(10)
-      │         ├── with-scan &1
+      │         ├── values
       │         │    ├── columns: hh_h_t_id:10!null
-      │         │    ├── mapping:
-      │         │    │    └──  column1:6 => hh_h_t_id:10
       │         │    ├── cardinality: [1 - 1]
       │         │    ├── key: ()
-      │         │    └── fd: ()-->(10)
+      │         │    ├── fd: ()-->(10)
+      │         │    └── (0,)
+      │         ├── scan trade
+      │         │    ├── columns: t_id:11!null
+      │         │    ├── constraint: /11: [/0 - /0]
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── key: ()
+      │         │    └── fd: ()-->(11)
       │         └── filters (true)
       └── f-k-checks-item: holding_history(hh_t_id) -> trade(t_id)
-           └── anti-join (lookup trade)
+           └── anti-join (cross)
                 ├── columns: hh_t_id:27!null
-                ├── key columns: [27] = [28]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(27)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: hh_t_id:27!null
-                │    ├── mapping:
-                │    │    └──  column2:7 => hh_t_id:27
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(27)
+                │    ├── fd: ()-->(27)
+                │    └── (0,)
+                ├── scan trade
+                │    ├── columns: t_id:28!null
+                │    ├── constraint: /28: [/0 - /0]
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(28)
                 └── filters (true)
 
 # Q17
@@ -2731,7 +2787,6 @@ insert trade_history
  │    ├── column1:5 => trade_history.th_t_id:1
  │    ├── column2:6 => th_dts:2
  │    └── column3:7 => trade_history.th_st_id:3
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -2742,36 +2797,42 @@ insert trade_history
  │    └── (0, '2020-06-17 22:27:42.148484', 'SBMT')
  └── f-k-checks
       ├── f-k-checks-item: trade_history(th_t_id) -> trade(t_id)
-      │    └── anti-join (lookup trade)
+      │    └── anti-join (cross)
       │         ├── columns: th_t_id:8!null
-      │         ├── key columns: [8] = [9]
-      │         ├── lookup columns are key
       │         ├── cardinality: [0 - 1]
       │         ├── key: ()
       │         ├── fd: ()-->(8)
-      │         ├── with-scan &1
+      │         ├── values
       │         │    ├── columns: th_t_id:8!null
-      │         │    ├── mapping:
-      │         │    │    └──  column1:5 => th_t_id:8
       │         │    ├── cardinality: [1 - 1]
       │         │    ├── key: ()
-      │         │    └── fd: ()-->(8)
+      │         │    ├── fd: ()-->(8)
+      │         │    └── (0,)
+      │         ├── scan trade
+      │         │    ├── columns: t_id:9!null
+      │         │    ├── constraint: /9: [/0 - /0]
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── key: ()
+      │         │    └── fd: ()-->(9)
       │         └── filters (true)
       └── f-k-checks-item: trade_history(th_st_id) -> status_type(st_id)
-           └── anti-join (lookup status_type)
+           └── anti-join (cross)
                 ├── columns: th_st_id:25!null
-                ├── key columns: [25] = [26]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(25)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: th_st_id:25!null
-                │    ├── mapping:
-                │    │    └──  column3:7 => th_st_id:25
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(25)
+                │    ├── fd: ()-->(25)
+                │    └── ('SBMT',)
+                ├── scan status_type
+                │    ├── columns: st_id:26!null
+                │    ├── constraint: /26: [/'SBMT' - /'SBMT']
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(26)
                 └── filters (true)
 
 # Q24
@@ -2817,7 +2878,6 @@ insert settlement
  │    ├── column2:7 => se_cash_type:2
  │    ├── column3:8 => se_cash_due_date:3
  │    └── se_amt:10 => settlement.se_amt:4
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -2828,20 +2888,23 @@ insert settlement
  │    └── (0, 'Cash Account', '2020-06-19', 1E+2)
  └── f-k-checks
       └── f-k-checks-item: settlement(se_t_id) -> trade(t_id)
-           └── anti-join (lookup trade)
+           └── anti-join (cross)
                 ├── columns: se_t_id:11!null
-                ├── key columns: [11] = [12]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(11)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: se_t_id:11!null
-                │    ├── mapping:
-                │    │    └──  column1:6 => se_t_id:11
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(11)
+                │    ├── fd: ()-->(11)
+                │    └── (0,)
+                ├── scan trade
+                │    ├── columns: t_id:12!null
+                │    ├── constraint: /12: [/0 - /0]
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(12)
                 └── filters (true)
 
 # Q26
@@ -2900,7 +2963,6 @@ insert cash_transaction
  │    ├── column2:7 => ct_dts:2
  │    ├── ct_amt:10 => cash_transaction.ct_amt:3
  │    └── column4:9 => ct_name:4
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -2911,20 +2973,23 @@ insert cash_transaction
  │    └── (0, '2020-06-18 22:27:42.148484', 'Market Buy 10 shares of SYMB', 1E+2)
  └── f-k-checks
       └── f-k-checks-item: cash_transaction(ct_t_id) -> trade(t_id)
-           └── anti-join (lookup trade)
+           └── anti-join (cross)
                 ├── columns: ct_t_id:11!null
-                ├── key columns: [11] = [12]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(11)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: ct_t_id:11!null
-                │    ├── mapping:
-                │    │    └──  column1:6 => ct_t_id:11
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(11)
+                │    ├── fd: ()-->(11)
+                │    └── (0,)
+                ├── scan trade
+                │    ├── columns: t_id:12!null
+                │    ├── constraint: /12: [/0 - /0]
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(12)
                 └── filters (true)
 
 # Q28
@@ -4232,7 +4297,6 @@ insert trade_history
  │    ├── column1:5 => trade_history.th_t_id:1
  │    ├── column2:6 => th_dts:2
  │    └── column3:7 => trade_history.th_st_id:3
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -4243,36 +4307,42 @@ insert trade_history
  │    └── (0, '2020-06-17 22:27:42.148484', 'SBMT')
  └── f-k-checks
       ├── f-k-checks-item: trade_history(th_t_id) -> trade(t_id)
-      │    └── anti-join (lookup trade)
+      │    └── anti-join (cross)
       │         ├── columns: th_t_id:8!null
-      │         ├── key columns: [8] = [9]
-      │         ├── lookup columns are key
       │         ├── cardinality: [0 - 1]
       │         ├── key: ()
       │         ├── fd: ()-->(8)
-      │         ├── with-scan &1
+      │         ├── values
       │         │    ├── columns: th_t_id:8!null
-      │         │    ├── mapping:
-      │         │    │    └──  column1:5 => th_t_id:8
       │         │    ├── cardinality: [1 - 1]
       │         │    ├── key: ()
-      │         │    └── fd: ()-->(8)
+      │         │    ├── fd: ()-->(8)
+      │         │    └── (0,)
+      │         ├── scan trade
+      │         │    ├── columns: t_id:9!null
+      │         │    ├── constraint: /9: [/0 - /0]
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── key: ()
+      │         │    └── fd: ()-->(9)
       │         └── filters (true)
       └── f-k-checks-item: trade_history(th_st_id) -> status_type(st_id)
-           └── anti-join (lookup status_type)
+           └── anti-join (cross)
                 ├── columns: th_st_id:25!null
-                ├── key columns: [25] = [26]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(25)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: th_st_id:25!null
-                │    ├── mapping:
-                │    │    └──  column3:7 => th_st_id:25
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(25)
+                │    ├── fd: ()-->(25)
+                │    └── ('SBMT',)
+                ├── scan status_type
+                │    ├── columns: st_id:26!null
+                │    ├── constraint: /26: [/'SBMT' - /'SBMT']
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(26)
                 └── filters (true)
 
 # Q3

--- a/pkg/sql/opt/xform/testdata/rules/scan
+++ b/pkg/sql/opt/xform/testdata/rules/scan
@@ -403,7 +403,6 @@ insert fk_b
  ├── insert-mapping:
  │    ├── column1:4 => b:1
  │    └── column2:5 => fk_b.a:2
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -414,20 +413,23 @@ insert fk_b
  │    └── (1, 1)
  └── f-k-checks
       └── f-k-checks-item: fk_b(a) -> fk_a(a)
-           └── anti-join (lookup fk_a)
+           └── anti-join (cross)
                 ├── columns: a:6!null
-                ├── key columns: [6] = [7]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(6)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: a:6!null
-                │    ├── mapping:
-                │    │    └──  column2:5 => a:6
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(6)
+                │    ├── fd: ()-->(6)
+                │    └── (1,)
+                ├── scan fk_a
+                │    ├── columns: fk_a.a:7!null
+                │    ├── constraint: /7: [/1 - /1]
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(7)
                 └── filters (true)
 
 # --------------------------------------------------


### PR DESCRIPTION
In FK and uniqueness checks, WithScans that buffer the mutation's input
are replaced with Values expression when inserted values are constant.
This is especially beneficial for `REGIONAL BY ROW` tables where the
`crdb_region` column is a computed column dependent on a FK. Because the
constant values are inlined, the optimizer is not able to reduce a FK
check that scans multiple regions with a FK check that checks only a
single region.

Informs #63882

Release note (performance improvement): Previously, foreign key checks
performed for inserts into `REGIONAL BY ROW` tables always searched the
parent table in all regions to check for FK violations. Now, only a
single region is searched if constant values are inserted and the
`crdb_region` column is a computed column dependent on the FK column.