### PR TITLE
bazel: stage all go source files in a temp dir named after the package

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,7 +12,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 # Load go bazel tools. This gives us access to the go bazel SDK/toolchains.
 git_repository(
     name = "io_bazel_rules_go",
-    commit = "2fe8a6256c818840cc9a10cf3f366d8410437245",
+    commit = "a94a425d26532613e71f9c7432c19c36302e1f1d",
     remote = "https://github.com/cockroachdb/rules_go",
 )
 

--- a/pkg/util/json/BUILD.bazel
+++ b/pkg/util/json/BUILD.bazel
@@ -40,9 +40,9 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":json"],
     deps = [
-        "//pkg/build/bazel",
         "//pkg/sql/inverted",
         "//pkg/sql/pgwire/pgerror",
+        "//pkg/testutils",
         "//pkg/util/encoding",
         "//pkg/util/randutil",
         "//pkg/util/timeutil",

--- a/pkg/util/json/encode_test.go
+++ b/pkg/util/json/encode_test.go
@@ -16,11 +16,10 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/build/bazel"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
@@ -63,18 +62,7 @@ func TestJSONRandomEncodeRoundTrip(t *testing.T) {
 }
 
 func TestFilesEncode(t *testing.T) {
-	_, fname, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("couldn't get directory")
-	}
-	dir := filepath.Join(filepath.Dir(fname), "testdata", "raw")
-	if bazel.BuiltWithBazel() {
-		runfile, err := bazel.Runfile(dir)
-		if err != nil {
-			t.Fatal(err)
-		}
-		dir = runfile
-	}
+	dir := testutils.TestDataPath(t, "raw")
 	dirContents, err := ioutil.ReadDir(dir)
 	if err != nil {
 		t.Fatal(err)
@@ -121,18 +109,8 @@ func TestFilesEncode(t *testing.T) {
 			// rerun with -rewrite-results-in-testfiles.
 			t.Run(`explicit encoding`, func(t *testing.T) {
 				stringifiedEncoding := fmt.Sprintf("%v", encoded)
-				fixtureFilename := filepath.Join(
-					filepath.Dir(fname),
-					"testdata", "encoded",
-					tc.Name()+".bytes",
-				)
-				if bazel.BuiltWithBazel() {
-					runfile, err := bazel.Runfile(fixtureFilename)
-					if err != nil {
-						t.Fatal(err)
-					}
-					fixtureFilename = runfile
-				}
+				fixtureFilename := testutils.TestDataPath(
+					t, "encoded", tc.Name()+".bytes")
 
 				if *rewriteResultsInTestfiles {
 					err := ioutil.WriteFile(fixtureFilename, []byte(stringifiedEncoding), 0644)


### PR DESCRIPTION
This works around an issue where Go source file names as stored in the
`cockroach` binary were truncated (e.g., with the leading
`github.com/cockroachdb/cockroach` prefix, or even the entire package
name prefix, removed). This breaks unit tests (#61913) and some other
internal stuff.

We solve this by staging all Go source files during the build in a
temporary directory named after the package. This incurs an additional
I/O cost, but for now while our codebase isn't able to deal with the
differing file names, we can deal with it.

Fixes #64379
See also #64383

Release note: None