### PR TITLE
release-20.2: duration,builtins: fix DST boundary handling

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/timestamp
+++ b/pkg/sql/logictest/testdata/logic_test/timestamp
@@ -474,3 +474,17 @@ FROM (VALUES
 -1 mons -1 days -17:16:56               1 mon 1 day 17:16:56                         -29 days -17:16:56        29 days 17:16:56            -29 days -18:16:56        29 days 18:16:56
 -18:16:56                               18:16:56                                     -18:16:56                 18:16:56                    -18:16:56                 18:16:56
 22:58:58.888889                         -22:58:58.888889                             22:58:58.888889           -22:58:58.888889            22:58:58.888889           -22:58:58.888889
+
+query T
+SET TIME ZONE 'Europe/Bucharest';
+SELECT t FROM (VALUES
+  ('2020-10-25 03:00+3'::TIMESTAMPTZ + '0 hour'::interval),
+  ('2020-10-25 03:00+3'::TIMESTAMPTZ + '1 hour'::interval),
+  ('2020-10-25 03:00+2'::TIMESTAMPTZ + '0 hour'::interval),
+  ('2020-10-25 03:00+2'::TIMESTAMPTZ + '1 hour'::interval)
+) interval_math_regression_64772(t)
+----
+2020-10-25 03:00:00 +0300 EEST
+2020-10-25 03:00:00 +0200 EET
+2020-10-25 03:00:00 +0200 EET
+2020-10-25 04:00:00 +0200 EET

--- a/pkg/sql/logictest/testdata/logic_test/timestamp
+++ b/pkg/sql/logictest/testdata/logic_test/timestamp
@@ -488,3 +488,13 @@ SELECT t FROM (VALUES
 2020-10-25 03:00:00 +0200 EET
 2020-10-25 03:00:00 +0200 EET
 2020-10-25 04:00:00 +0200 EET
+
+query TT
+SET TIME ZONE 'Europe/Bucharest';
+SELECT date_trunc('day', t), date_trunc('hour', t) FROM (VALUES
+  ('2020-10-25 03:00+03:00'::timestamptz),
+  ('2020-10-25 03:00+02:00'::timestamptz)
+) date_trunc_regression_64772(t)
+----
+2020-10-25 00:00:00 +0300 EEST  2020-10-25 03:00:00 +0300 EEST
+2020-10-25 00:00:00 +0300 EEST  2020-10-25 03:00:00 +0200 EET

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -6423,6 +6423,8 @@ func truncateTimestamp(fromTime time.Time, timeSpan string) (*tree.DTimestampTZ,
 	nsec := fromTime.Nanosecond()
 	loc := fromTime.Location()
 
+	_, origZoneOffset := fromTime.Zone()
+
 	monthTrunc := time.January
 	dayTrunc := 1
 	hourTrunc := 0
@@ -6502,6 +6504,24 @@ func truncateTimestamp(fromTime time.Time, timeSpan string) (*tree.DTimestampTZ,
 	}
 
 	toTime := time.Date(year, month, day, hour, min, sec, nsec, loc)
+	_, newZoneOffset := toTime.Zone()
+	// If we have a mismatching zone offset, check whether the truncated timestamp
+	// can exist at both the new and original zone time offset.
+	// e.g. in Bucharest, 2020-10-25 has 03:00+02 and 03:00+03. Using time.Date
+	// automatically assumes 03:00+02.
+	if origZoneOffset != newZoneOffset {
+		// To remedy this, try set the time.Date to have the same fixed offset as the original timezone
+		// and force it to use the same location as the incoming time.
+		// If using the fixed offset in the given location gives us a timestamp that is the
+		// same as the original time offset, use that timestamp instead.
+		fixedOffsetLoc := timeutil.FixedOffsetTimeZoneToLocation(origZoneOffset, "date_trunc")
+		fixedOffsetTime := time.Date(year, month, day, hour, min, sec, nsec, fixedOffsetLoc)
+		locCorrectedOffsetTime := fixedOffsetTime.In(loc)
+
+		if _, zoneOffset := locCorrectedOffsetTime.Zone(); origZoneOffset == zoneOffset {
+			toTime = locCorrectedOffsetTime
+		}
+	}
 	return tree.MakeDTimestampTZ(toTime, time.Microsecond)
 }
 

--- a/pkg/sql/sem/builtins/builtins_test.go
+++ b/pkg/sql/sem/builtins/builtins_test.go
@@ -447,22 +447,95 @@ func TestTruncateTimestamp(t *testing.T) {
 		timeSpan string
 		expected *tree.DTimestampTZ
 	}{
-		{time.Date(2118, time.March, 11, 5, 6, 7, 80009001, loc), "millennium", tree.MustMakeDTimestampTZ(time.Date(2001, time.January, 1, 0, 0, 0, 0, loc), time.Microsecond)},
-		{time.Date(2118, time.March, 11, 5, 6, 7, 80009001, loc), "century", tree.MustMakeDTimestampTZ(time.Date(2101, time.January, 1, 0, 0, 0, 0, loc), time.Microsecond)},
-		{time.Date(2118, time.March, 11, 5, 6, 7, 80009001, loc), "decade", tree.MustMakeDTimestampTZ(time.Date(2110, time.January, 1, 0, 0, 0, 0, loc), time.Microsecond)},
-		{time.Date(2118, time.March, 11, 5, 6, 7, 80009001, loc), "year", tree.MustMakeDTimestampTZ(time.Date(2118, time.January, 1, 0, 0, 0, 0, loc), time.Microsecond)},
-		{time.Date(2118, time.March, 11, 5, 6, 7, 80009001, loc), "quarter", tree.MustMakeDTimestampTZ(time.Date(2118, time.January, 1, 0, 0, 0, 0, loc), time.Microsecond)},
-		{time.Date(2118, time.March, 11, 5, 6, 7, 80009001, loc), "month", tree.MustMakeDTimestampTZ(time.Date(2118, time.March, 1, 0, 0, 0, 0, loc), time.Microsecond)},
-		{time.Date(2118, time.March, 11, 5, 6, 7, 80009001, loc), "day", tree.MustMakeDTimestampTZ(time.Date(2118, time.March, 11, 0, 0, 0, 0, loc), time.Microsecond)},
-		{time.Date(2118, time.March, 11, 5, 6, 7, 80009001, loc), "week", tree.MustMakeDTimestampTZ(time.Date(2118, time.March, 7, 0, 0, 0, 0, loc), time.Microsecond)},
-		{time.Date(2118, time.March, 11, 5, 6, 7, 80009001, loc), "hour", tree.MustMakeDTimestampTZ(time.Date(2118, time.March, 11, 5, 0, 0, 0, loc), time.Microsecond)},
-		{time.Date(2118, time.March, 11, 5, 6, 7, 80009001, loc), "second", tree.MustMakeDTimestampTZ(time.Date(2118, time.March, 11, 5, 6, 7, 0, loc), time.Microsecond)},
-		{time.Date(2118, time.March, 11, 5, 6, 7, 80009001, loc), "millisecond", tree.MustMakeDTimestampTZ(time.Date(2118, time.March, 11, 5, 6, 7, 80000000, loc), time.Microsecond)},
-		{time.Date(2118, time.March, 11, 5, 6, 7, 80009001, loc), "microsecond", tree.MustMakeDTimestampTZ(time.Date(2118, time.March, 11, 5, 6, 7, 80009000, loc), time.Microsecond)},
+		{
+			time.Date(2118, time.March, 11, 5, 6, 7, 80009001, loc),
+			"millennium",
+			tree.MustMakeDTimestampTZ(time.Date(2001, time.January, 1, 0, 0, 0, 0, loc), time.Microsecond),
+		},
+		{
+			time.Date(2118, time.March, 11, 5, 6, 7, 80009001, loc),
+			"century",
+			tree.MustMakeDTimestampTZ(time.Date(2101, time.January, 1, 0, 0, 0, 0, loc), time.Microsecond),
+		},
+		{
+			time.Date(2118, time.March, 11, 5, 6, 7, 80009001, loc),
+			"decade",
+			tree.MustMakeDTimestampTZ(time.Date(2110, time.January, 1, 0, 0, 0, 0, loc), time.Microsecond),
+		},
+		{
+			time.Date(2118, time.March, 11, 5, 6, 7, 80009001, loc),
+			"year",
+			tree.MustMakeDTimestampTZ(time.Date(2118, time.January, 1, 0, 0, 0, 0, loc), time.Microsecond),
+		},
+		{
+			time.Date(2118, time.March, 11, 5, 6, 7, 80009001, loc),
+			"quarter",
+			tree.MustMakeDTimestampTZ(time.Date(2118, time.January, 1, 0, 0, 0, 0, loc), time.Microsecond),
+		},
+		{
+			time.Date(2118, time.March, 11, 5, 6, 7, 80009001, loc),
+			"month",
+			tree.MustMakeDTimestampTZ(time.Date(2118, time.March, 1, 0, 0, 0, 0, loc), time.Microsecond),
+		},
+		{
+			time.Date(2118, time.March, 11, 5, 6, 7, 80009001, loc),
+			"day",
+			tree.MustMakeDTimestampTZ(time.Date(2118, time.March, 11, 0, 0, 0, 0, loc), time.Microsecond),
+		},
+		{
+			time.Date(2118, time.March, 11, 5, 6, 7, 80009001, loc),
+			"week",
+			tree.MustMakeDTimestampTZ(time.Date(2118, time.March, 7, 0, 0, 0, 0, loc), time.Microsecond),
+		},
+		{
+			time.Date(2118, time.March, 11, 5, 6, 7, 80009001, loc),
+			"hour",
+			tree.MustMakeDTimestampTZ(time.Date(2118, time.March, 11, 5, 0, 0, 0, loc), time.Microsecond),
+		},
+		{
+			time.Date(2118, time.March, 11, 5, 6, 7, 80009001, loc),
+			"second",
+			tree.MustMakeDTimestampTZ(time.Date(2118, time.March, 11, 5, 6, 7, 0, loc), time.Microsecond),
+		},
+		{
+			time.Date(2118, time.March, 11, 5, 6, 7, 80009001, loc),
+			"millisecond",
+			tree.MustMakeDTimestampTZ(time.Date(2118, time.March, 11, 5, 6, 7, 80000000, loc), time.Microsecond),
+		},
+		{
+			time.Date(2118, time.March, 11, 5, 6, 7, 80009001, loc),
+			"microsecond",
+			tree.MustMakeDTimestampTZ(time.Date(2118, time.March, 11, 5, 6, 7, 80009000, loc), time.Microsecond),
+		},
 
 		// Test Monday and Sunday boundaries.
-		{time.Date(2019, time.November, 11, 5, 6, 7, 80009001, loc), "week", tree.MustMakeDTimestampTZ(time.Date(2019, time.November, 11, 0, 0, 0, 0, loc), time.Microsecond)},
-		{time.Date(2019, time.November, 10, 5, 6, 7, 80009001, loc), "week", tree.MustMakeDTimestampTZ(time.Date(2019, time.November, 4, 0, 0, 0, 0, loc), time.Microsecond)},
+		{
+			time.Date(2019, time.November, 11, 5, 6, 7, 80009001, loc),
+			"week",
+			tree.MustMakeDTimestampTZ(time.Date(2019, time.November, 11, 0, 0, 0, 0, loc), time.Microsecond),
+		},
+		{
+			time.Date(2019, time.November, 10, 5, 6, 7, 80009001, loc),
+			"week",
+			tree.MustMakeDTimestampTZ(time.Date(2019, time.November, 4, 0, 0, 0, 0, loc), time.Microsecond),
+		},
+
+		// Test DST boundaries.
+		{
+			time.Date(2021, time.April, 4, 0, 0, 0, 0, loc).Add(time.Hour * 2),
+			"hour",
+			tree.MustMakeDTimestampTZ(time.Date(2021, time.April, 4, 0, 0, 0, 0, loc).Add(time.Hour*2), time.Microsecond),
+		},
+		{
+			time.Date(2021, time.April, 4, 0, 0, 0, 0, loc).Add(time.Hour * 2),
+			"day",
+			tree.MustMakeDTimestampTZ(time.Date(2021, time.April, 4, 0, 0, 0, 0, loc), time.Microsecond),
+		},
+		{
+			time.Date(2021, time.April, 4, 2, 0, 0, 0, loc),
+			"day",
+			tree.MustMakeDTimestampTZ(time.Date(2021, time.April, 4, 0, 0, 0, 0, loc), time.Microsecond),
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Backport 2/2 commits from #64845.

/cc @cockroachdb/release

---

See individual commits for details.

Resolves #64772
