### PR TITLE
kv: add trace events to latch and lock wait-queue state transitions

### DIFF
--- a/pkg/kv/kvserver/concurrency/lock_table_waiter.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter.go
@@ -155,6 +155,7 @@ func (w *lockTableWaiterImpl) WaitOn(
 		case <-newStateC:
 			timerC = nil
 			state := guard.CurState()
+			log.Eventf(ctx, "lock wait-queue event: %s", state)
 			h.emitAndInit(state)
 			switch state.kind {
 			case waitFor, waitForDistinguished:

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/basic
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/basic
@@ -143,6 +143,7 @@ sequence req=req4
 ----
 [3] sequence req4: sequencing request
 [3] sequence req4: acquiring latches
+[3] sequence req4: waiting to acquire write latch k@10.000000000,1, held by read latch k{-2}@14.000000000,1
 [3] sequence req4: blocked on select in spanlatch.(*Manager).waitForSignal
 
 debug-latch-manager
@@ -239,11 +240,14 @@ sequence req=req7
 ----
 [4] sequence req7: sequencing request
 [4] sequence req7: acquiring latches
+[4] sequence req7: waiting to acquire write latch k@12.000000000,1, held by read latch {a-m}@14.000000000,1
 [4] sequence req7: blocked on select in spanlatch.(*Manager).waitForSignal
 
 finish req=req5
 ----
 [-] finish req5: finishing request
+[4] sequence req7: waiting to acquire write latch k@12.000000000,1, held by read latch {c-z}@16.000000000,1
+[4] sequence req7: blocked on select in spanlatch.(*Manager).waitForSignal
 
 finish req=req6
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/basic
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/basic
@@ -125,7 +125,7 @@ on-txn-updated txn=txn2 status=committed
 [-] update txn: committing txn2
 [2] sequence req3: resolving intent "k" for txn 00000002 with COMMITTED status
 [2] sequence req3: lock wait-queue event: done waiting
-[2] sequence req3: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 1.23s
+[2] sequence req3: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 1.234s
 [2] sequence req3: acquiring latches
 [2] sequence req3: scanning lock table for conflicting locks
 [2] sequence req3: sequencing complete, returned guard
@@ -222,12 +222,12 @@ on-txn-updated txn=txn2 status=pending ts=18,1
 [-] update txn: increasing timestamp of txn2
 [2] sequence req5: resolving intent "k" for txn 00000002 with PENDING status
 [2] sequence req5: lock wait-queue event: done waiting
-[2] sequence req5: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 1.23s
+[2] sequence req5: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 1.234s
 [2] sequence req5: acquiring latches
 [2] sequence req5: scanning lock table for conflicting locks
 [2] sequence req5: sequencing complete, returned guard
 [3] sequence req6: lock wait-queue event: done waiting
-[3] sequence req6: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 1.23s
+[3] sequence req6: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 1.234s
 [3] sequence req6: acquiring latches
 [3] sequence req6: scanning lock table for conflicting locks
 [3] sequence req6: sequencing complete, returned guard
@@ -263,7 +263,7 @@ on-txn-updated txn=txn2 status=committed
 [-] update txn: committing txn2
 [4] sequence req7: resolving intent "k" for txn 00000002 with COMMITTED status
 [4] sequence req7: lock wait-queue event: done waiting
-[4] sequence req7: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 1.23s
+[4] sequence req7: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 1.234s
 [4] sequence req7: acquiring latches
 [4] sequence req7: scanning lock table for conflicting locks
 [4] sequence req7: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/basic
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/basic
@@ -116,6 +116,7 @@ sequence req=req3
 [2] sequence req3: acquiring latches
 [2] sequence req3: scanning lock table for conflicting locks
 [2] sequence req3: waiting in lock wait-queues
+[2] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 1)
 [2] sequence req3: pushing timestamp of txn 00000002 above 14.000000000,1
 [2] sequence req3: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -123,6 +124,7 @@ on-txn-updated txn=txn2 status=committed
 ----
 [-] update txn: committing txn2
 [2] sequence req3: resolving intent "k" for txn 00000002 with COMMITTED status
+[2] sequence req3: lock wait-queue event: done waiting
 [2] sequence req3: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 1.23s
 [2] sequence req3: acquiring latches
 [2] sequence req3: scanning lock table for conflicting locks
@@ -197,6 +199,7 @@ sequence req=req5
 [2] sequence req5: acquiring latches
 [2] sequence req5: scanning lock table for conflicting locks
 [2] sequence req5: waiting in lock wait-queues
+[2] sequence req5: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 1)
 [2] sequence req5: pushing timestamp of txn 00000002 above 14.000000000,1
 [2] sequence req5: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -210,16 +213,19 @@ sequence req=req6
 [3] sequence req6: acquiring latches
 [3] sequence req6: scanning lock table for conflicting locks
 [3] sequence req6: waiting in lock wait-queues
+[3] sequence req6: lock wait-queue event: wait for txn 00000002 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 2)
 [3] sequence req6: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
 on-txn-updated txn=txn2 status=pending ts=18,1
 ----
 [-] update txn: increasing timestamp of txn2
 [2] sequence req5: resolving intent "k" for txn 00000002 with PENDING status
+[2] sequence req5: lock wait-queue event: done waiting
 [2] sequence req5: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 1.23s
 [2] sequence req5: acquiring latches
 [2] sequence req5: scanning lock table for conflicting locks
 [2] sequence req5: sequencing complete, returned guard
+[3] sequence req6: lock wait-queue event: done waiting
 [3] sequence req6: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 1.23s
 [3] sequence req6: acquiring latches
 [3] sequence req6: scanning lock table for conflicting locks
@@ -244,6 +250,7 @@ finish req=req6
 [-] finish req6: finishing request
 [4] sequence req7: scanning lock table for conflicting locks
 [4] sequence req7: waiting in lock wait-queues
+[4] sequence req7: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "k" (queuedWriters: 1, queuedReaders: 0)
 [4] sequence req7: pushing txn 00000002 to abort
 [4] sequence req7: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -251,6 +258,7 @@ on-txn-updated txn=txn2 status=committed
 ----
 [-] update txn: committing txn2
 [4] sequence req7: resolving intent "k" for txn 00000002 with COMMITTED status
+[4] sequence req7: lock wait-queue event: done waiting
 [4] sequence req7: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 1.23s
 [4] sequence req7: acquiring latches
 [4] sequence req7: scanning lock table for conflicting locks

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents
@@ -64,6 +64,7 @@ sequence req=req1
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: waiting in lock wait-queues
+[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "a" (queuedWriters: 0, queuedReaders: 1)
 [3] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
 [3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -102,6 +103,7 @@ on-txn-updated txn=txn2 status=aborted
 ----
 [-] update txn: aborting txn2
 [3] sequence req1: resolving intent "a" for txn 00000002 with ABORTED status
+[3] sequence req1: lock wait-queue event: done waiting
 [3] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on "a" for 1.23s
 [3] sequence req1: resolving a batch of 9 intent(s)
 [3] sequence req1: resolving intent "b" for txn 00000002 with ABORTED status
@@ -172,6 +174,7 @@ sequence req=req1
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: waiting in lock wait-queues
+[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "a" (queuedWriters: 1, queuedReaders: 0)
 [3] sequence req1: pushing txn 00000002 to abort
 [3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -179,6 +182,7 @@ on-txn-updated txn=txn2 status=committed
 ----
 [-] update txn: committing txn2
 [3] sequence req1: resolving intent "a" for txn 00000002 with COMMITTED status
+[3] sequence req1: lock wait-queue event: done waiting
 [3] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on "a" for 1.23s
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
@@ -206,6 +210,7 @@ sequence req=req1
 [5] sequence req1: acquiring latches
 [5] sequence req1: scanning lock table for conflicting locks
 [5] sequence req1: waiting in lock wait-queues
+[5] sequence req1: lock wait-queue event: done waiting
 [5] sequence req1: resolving a batch of 1 intent(s)
 [5] sequence req1: resolving intent "b" for txn 00000002 with COMMITTED status
 [5] sequence req1: acquiring latches
@@ -236,6 +241,7 @@ sequence req=req1
 [7] sequence req1: acquiring latches
 [7] sequence req1: scanning lock table for conflicting locks
 [7] sequence req1: waiting in lock wait-queues
+[7] sequence req1: lock wait-queue event: done waiting
 [7] sequence req1: resolving a batch of 1 intent(s)
 [7] sequence req1: resolving intent "c" for txn 00000002 with COMMITTED status
 [7] sequence req1: acquiring latches
@@ -341,6 +347,7 @@ sequence req=req1
 [4] sequence req1: acquiring latches
 [4] sequence req1: scanning lock table for conflicting locks
 [4] sequence req1: waiting in lock wait-queues
+[4] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "a" (queuedWriters: 0, queuedReaders: 1)
 [4] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
 [4] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -364,6 +371,7 @@ on-txn-updated txn=txn2 status=aborted
 ----
 [-] update txn: aborting txn2
 [4] sequence req1: resolving intent "a" for txn 00000002 with ABORTED status
+[4] sequence req1: lock wait-queue event: done waiting
 [4] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on "a" for 1.23s
 [4] sequence req1: resolving a batch of 1 intent(s)
 [4] sequence req1: resolving intent "b" for txn 00000002 with ABORTED status
@@ -453,6 +461,7 @@ sequence req=req1
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: waiting in lock wait-queues
+[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key "c" (queuedWriters: 1, queuedReaders: 0)
 [3] sequence req1: pushing txn 00000003 to abort
 [3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -545,6 +554,7 @@ sequence req=req2
 [6] sequence req2: acquiring latches
 [6] sequence req2: scanning lock table for conflicting locks
 [6] sequence req2: waiting in lock wait-queues
+[6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key "a" (queuedWriters: 0, queuedReaders: 1)
 [6] sequence req2: pushing timestamp of txn 00000003 above 11.000000000,1
 [6] sequence req2: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -579,10 +589,12 @@ on-txn-updated txn=txn3 status=aborted
 ----
 [-] update txn: aborting txn3
 [3] sequence req1: resolving intent "c" for txn 00000003 with ABORTED status
+[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000005 holding lock @ key "e" (queuedWriters: 1, queuedReaders: 0)
 [3] sequence req1: conflicted with 00000003-0000-0000-0000-000000000000 on "c" for 1.23s
 [3] sequence req1: pushing txn 00000005 to abort
 [3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
 [6] sequence req2: resolving intent "a" for txn 00000003 with ABORTED status
+[6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000004 holding lock @ key "b" (queuedWriters: 0, queuedReaders: 1)
 [6] sequence req2: conflicted with 00000003-0000-0000-0000-000000000000 on "a" for 1.23s
 [6] sequence req2: pushing timestamp of txn 00000004 above 11.000000000,1
 [6] sequence req2: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -614,6 +626,7 @@ on-txn-updated txn=txn4 status=aborted
 ----
 [-] update txn: aborting txn4
 [6] sequence req2: resolving intent "b" for txn 00000004 with ABORTED status
+[6] sequence req2: lock wait-queue event: done waiting
 [6] sequence req2: conflicted with 00000004-0000-0000-0000-000000000000 on "b" for 1.23s
 [6] sequence req2: resolving a batch of 1 intent(s)
 [6] sequence req2: resolving intent "d" for txn 00000003 with ABORTED status
@@ -645,6 +658,7 @@ on-txn-updated txn=txn5 status=aborted
 ----
 [-] update txn: aborting txn5
 [3] sequence req1: resolving intent "e" for txn 00000005 with ABORTED status
+[3] sequence req1: lock wait-queue event: done waiting
 [3] sequence req1: conflicted with 00000005-0000-0000-0000-000000000000 on "e" for 1.23s
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents
@@ -104,7 +104,7 @@ on-txn-updated txn=txn2 status=aborted
 [-] update txn: aborting txn2
 [3] sequence req1: resolving intent "a" for txn 00000002 with ABORTED status
 [3] sequence req1: lock wait-queue event: done waiting
-[3] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on "a" for 1.23s
+[3] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on "a" for 1.234s
 [3] sequence req1: resolving a batch of 9 intent(s)
 [3] sequence req1: resolving intent "b" for txn 00000002 with ABORTED status
 [3] sequence req1: resolving intent "c" for txn 00000002 with ABORTED status
@@ -183,7 +183,7 @@ on-txn-updated txn=txn2 status=committed
 [-] update txn: committing txn2
 [3] sequence req1: resolving intent "a" for txn 00000002 with COMMITTED status
 [3] sequence req1: lock wait-queue event: done waiting
-[3] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on "a" for 1.23s
+[3] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on "a" for 1.234s
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: sequencing complete, returned guard
@@ -372,7 +372,7 @@ on-txn-updated txn=txn2 status=aborted
 [-] update txn: aborting txn2
 [4] sequence req1: resolving intent "a" for txn 00000002 with ABORTED status
 [4] sequence req1: lock wait-queue event: done waiting
-[4] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on "a" for 1.23s
+[4] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on "a" for 1.234s
 [4] sequence req1: resolving a batch of 1 intent(s)
 [4] sequence req1: resolving intent "b" for txn 00000002 with ABORTED status
 [4] sequence req1: acquiring latches
@@ -590,12 +590,12 @@ on-txn-updated txn=txn3 status=aborted
 [-] update txn: aborting txn3
 [3] sequence req1: resolving intent "c" for txn 00000003 with ABORTED status
 [3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000005 holding lock @ key "e" (queuedWriters: 1, queuedReaders: 0)
-[3] sequence req1: conflicted with 00000003-0000-0000-0000-000000000000 on "c" for 1.23s
+[3] sequence req1: conflicted with 00000003-0000-0000-0000-000000000000 on "c" for 1.234s
 [3] sequence req1: pushing txn 00000005 to abort
 [3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
 [6] sequence req2: resolving intent "a" for txn 00000003 with ABORTED status
 [6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000004 holding lock @ key "b" (queuedWriters: 0, queuedReaders: 1)
-[6] sequence req2: conflicted with 00000003-0000-0000-0000-000000000000 on "a" for 1.23s
+[6] sequence req2: conflicted with 00000003-0000-0000-0000-000000000000 on "a" for 1.234s
 [6] sequence req2: pushing timestamp of txn 00000004 above 11.000000000,1
 [6] sequence req2: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -627,7 +627,7 @@ on-txn-updated txn=txn4 status=aborted
 [-] update txn: aborting txn4
 [6] sequence req2: resolving intent "b" for txn 00000004 with ABORTED status
 [6] sequence req2: lock wait-queue event: done waiting
-[6] sequence req2: conflicted with 00000004-0000-0000-0000-000000000000 on "b" for 1.23s
+[6] sequence req2: conflicted with 00000004-0000-0000-0000-000000000000 on "b" for 1.234s
 [6] sequence req2: resolving a batch of 1 intent(s)
 [6] sequence req2: resolving intent "d" for txn 00000003 with ABORTED status
 [6] sequence req2: acquiring latches
@@ -659,7 +659,7 @@ on-txn-updated txn=txn5 status=aborted
 [-] update txn: aborting txn5
 [3] sequence req1: resolving intent "e" for txn 00000005 with ABORTED status
 [3] sequence req1: lock wait-queue event: done waiting
-[3] sequence req1: conflicted with 00000005-0000-0000-0000-000000000000 on "e" for 1.23s
+[3] sequence req1: conflicted with 00000005-0000-0000-0000-000000000000 on "e" for 1.234s
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents_without_adding_to_lock_table
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents_without_adding_to_lock_table
@@ -64,7 +64,7 @@ on-txn-updated txn=txn2 status=aborted
 [-] update txn: aborting txn2
 [3] sequence req1: resolving intent "a" for txn 00000002 with ABORTED status
 [3] sequence req1: lock wait-queue event: done waiting
-[3] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on "a" for 1.23s
+[3] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on "a" for 1.234s
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents_without_adding_to_lock_table
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents_without_adding_to_lock_table
@@ -43,6 +43,7 @@ sequence req=req1
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: waiting in lock wait-queues
+[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "a" (queuedWriters: 0, queuedReaders: 1)
 [3] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
 [3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -62,6 +63,7 @@ on-txn-updated txn=txn2 status=aborted
 ----
 [-] update txn: aborting txn2
 [3] sequence req1: resolving intent "a" for txn 00000002 with ABORTED status
+[3] sequence req1: lock wait-queue event: done waiting
 [3] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on "a" for 1.23s
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/deadlocks
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/deadlocks
@@ -164,11 +164,11 @@ on-txn-updated txn=txn1 status=aborted
 ----
 [-] update txn: aborting txn1
 [4] sequence req1r: detected pusher aborted
-[4] sequence req1r: conflicted with 00000002-0000-0000-0000-000000000000 on "b" for 1.23s
+[4] sequence req1r: conflicted with 00000002-0000-0000-0000-000000000000 on "b" for 1.234s
 [4] sequence req1r: sequencing complete, returned error: TransactionAbortedError(ABORT_REASON_PUSHER_ABORTED): <nil>
 [6] sequence req3r: resolving intent "a" for txn 00000001 with ABORTED status
 [6] sequence req3r: lock wait-queue event: done waiting
-[6] sequence req3r: conflicted with 00000001-0000-0000-0000-000000000000 on "a" for 1.23s
+[6] sequence req3r: conflicted with 00000001-0000-0000-0000-000000000000 on "a" for 1.234s
 [6] sequence req3r: acquiring latches
 [6] sequence req3r: scanning lock table for conflicting locks
 [6] sequence req3r: sequencing complete, returned guard
@@ -183,7 +183,7 @@ on-txn-updated txn=txn3 status=committed
 [-] update txn: committing txn3
 [5] sequence req2r: resolving intent "c" for txn 00000003 with COMMITTED status
 [5] sequence req2r: lock wait-queue event: done waiting
-[5] sequence req2r: conflicted with 00000003-0000-0000-0000-000000000000 on "c" for 1.23s
+[5] sequence req2r: conflicted with 00000003-0000-0000-0000-000000000000 on "c" for 1.234s
 [5] sequence req2r: acquiring latches
 [5] sequence req2r: scanning lock table for conflicting locks
 [5] sequence req2r: sequencing complete, returned guard
@@ -389,16 +389,16 @@ on-txn-updated txn=txn1 status=aborted
 [-] update txn: aborting txn1
 [4] sequence req4w: resolving intent "a" for txn 00000001 with ABORTED status
 [4] sequence req4w: lock wait-queue event: done waiting
-[4] sequence req4w: conflicted with 00000001-0000-0000-0000-000000000000 on "a" for 1.23s
+[4] sequence req4w: conflicted with 00000001-0000-0000-0000-000000000000 on "a" for 1.234s
 [4] sequence req4w: acquiring latches
 [4] sequence req4w: scanning lock table for conflicting locks
 [4] sequence req4w: sequencing complete, returned guard
 [5] sequence req1w2: detected pusher aborted
-[5] sequence req1w2: conflicted with 00000002-0000-0000-0000-000000000000 on "b" for 1.23s
+[5] sequence req1w2: conflicted with 00000002-0000-0000-0000-000000000000 on "b" for 1.234s
 [5] sequence req1w2: sequencing complete, returned error: TransactionAbortedError(ABORT_REASON_PUSHER_ABORTED): <nil>
 [7] sequence req3w2: resolving intent "a" for txn 00000001 with ABORTED status
 [7] sequence req3w2: lock wait-queue event: wait for (distinguished) txn 00000004 running request @ key "a" (queuedWriters: 1, queuedReaders: 0)
-[7] sequence req3w2: conflicted with 00000001-0000-0000-0000-000000000000 on "a" for 1.23s
+[7] sequence req3w2: conflicted with 00000001-0000-0000-0000-000000000000 on "a" for 1.234s
 [7] sequence req3w2: pushing txn 00000004 to detect request deadlock
 [7] sequence req3w2: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -407,7 +407,7 @@ finish req=req4w
 ----
 [-] finish req4w: finishing request
 [7] sequence req3w2: lock wait-queue event: done waiting
-[7] sequence req3w2: conflicted with 00000004-0000-0000-0000-000000000000 on "a" for 1.23s
+[7] sequence req3w2: conflicted with 00000004-0000-0000-0000-000000000000 on "a" for 1.234s
 [7] sequence req3w2: acquiring latches
 [7] sequence req3w2: scanning lock table for conflicting locks
 [7] sequence req3w2: sequencing complete, returned guard
@@ -422,7 +422,7 @@ on-txn-updated txn=txn3 status=committed
 [-] update txn: committing txn3
 [6] sequence req2w2: resolving intent "c" for txn 00000003 with COMMITTED status
 [6] sequence req2w2: lock wait-queue event: done waiting
-[6] sequence req2w2: conflicted with 00000003-0000-0000-0000-000000000000 on "c" for 1.23s
+[6] sequence req2w2: conflicted with 00000003-0000-0000-0000-000000000000 on "c" for 1.234s
 [6] sequence req2w2: acquiring latches
 [6] sequence req2w2: scanning lock table for conflicting locks
 [6] sequence req2w2: sequencing complete, returned guard
@@ -560,7 +560,7 @@ on-txn-updated txn=txn2 status=committed
 [-] update txn: committing txn2
 [4] sequence req4w: resolving intent "b" for txn 00000002 with COMMITTED status
 [4] sequence req4w: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key "c" (queuedWriters: 1, queuedReaders: 0)
-[4] sequence req4w: conflicted with 00000002-0000-0000-0000-000000000000 on "b" for 1.23s
+[4] sequence req4w: conflicted with 00000002-0000-0000-0000-000000000000 on "b" for 1.234s
 [4] sequence req4w: pushing txn 00000003 to abort
 [4] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -638,10 +638,10 @@ on-txn-updated txn=txn4 status=aborted
 ----
 [-] update txn: aborting txn4
 [4] sequence req4w: detected pusher aborted
-[4] sequence req4w: conflicted with 00000003-0000-0000-0000-000000000000 on "c" for 1.23s
+[4] sequence req4w: conflicted with 00000003-0000-0000-0000-000000000000 on "c" for 1.234s
 [4] sequence req4w: sequencing complete, returned error: TransactionAbortedError(ABORT_REASON_PUSHER_ABORTED): <nil>
 [5] sequence req1w2: lock wait-queue event: done waiting
-[5] sequence req1w2: conflicted with 00000004-0000-0000-0000-000000000000 on "b" for 1.23s
+[5] sequence req1w2: conflicted with 00000004-0000-0000-0000-000000000000 on "b" for 1.234s
 [5] sequence req1w2: acquiring latches
 [5] sequence req1w2: scanning lock table for conflicting locks
 [5] sequence req1w2: sequencing complete, returned guard
@@ -656,7 +656,7 @@ on-txn-updated txn=txn1 status=committed
 [-] update txn: committing txn1
 [6] sequence req3w2: resolving intent "a" for txn 00000001 with COMMITTED status
 [6] sequence req3w2: lock wait-queue event: done waiting
-[6] sequence req3w2: conflicted with 00000001-0000-0000-0000-000000000000 on "a" for 1.23s
+[6] sequence req3w2: conflicted with 00000001-0000-0000-0000-000000000000 on "a" for 1.234s
 [6] sequence req3w2: acquiring latches
 [6] sequence req3w2: scanning lock table for conflicting locks
 [6] sequence req3w2: sequencing complete, returned guard
@@ -794,7 +794,7 @@ on-txn-updated txn=txn2 status=committed
 [-] update txn: committing txn2
 [4] sequence req4w: resolving intent "b" for txn 00000002 with COMMITTED status
 [4] sequence req4w: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key "c" (queuedWriters: 1, queuedReaders: 0)
-[4] sequence req4w: conflicted with 00000002-0000-0000-0000-000000000000 on "b" for 1.23s
+[4] sequence req4w: conflicted with 00000002-0000-0000-0000-000000000000 on "b" for 1.234s
 [4] sequence req4w: pushing txn 00000003 to abort
 [4] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -872,11 +872,11 @@ on-txn-updated txn=txn1 status=aborted
 ----
 [-] update txn: aborting txn1
 [5] sequence req1w2: detected pusher aborted
-[5] sequence req1w2: conflicted with 00000004-0000-0000-0000-000000000000 on "b" for 1.23s
+[5] sequence req1w2: conflicted with 00000004-0000-0000-0000-000000000000 on "b" for 1.234s
 [5] sequence req1w2: sequencing complete, returned error: TransactionAbortedError(ABORT_REASON_PUSHER_ABORTED): <nil>
 [6] sequence req3w2: resolving intent "a" for txn 00000001 with ABORTED status
 [6] sequence req3w2: lock wait-queue event: done waiting
-[6] sequence req3w2: conflicted with 00000001-0000-0000-0000-000000000000 on "a" for 1.23s
+[6] sequence req3w2: conflicted with 00000001-0000-0000-0000-000000000000 on "a" for 1.234s
 [6] sequence req3w2: acquiring latches
 [6] sequence req3w2: scanning lock table for conflicting locks
 [6] sequence req3w2: sequencing complete, returned guard
@@ -891,7 +891,7 @@ on-txn-updated txn=txn3 status=committed
 [-] update txn: committing txn3
 [4] sequence req4w: resolving intent "c" for txn 00000003 with COMMITTED status
 [4] sequence req4w: lock wait-queue event: done waiting
-[4] sequence req4w: conflicted with 00000003-0000-0000-0000-000000000000 on "c" for 1.23s
+[4] sequence req4w: conflicted with 00000003-0000-0000-0000-000000000000 on "c" for 1.234s
 [4] sequence req4w: acquiring latches
 [4] sequence req4w: scanning lock table for conflicting locks
 [4] sequence req4w: sequencing complete, returned guard
@@ -1050,7 +1050,7 @@ on-txn-updated txn=txn1 status=committed
 [-] update txn: committing txn1
 [5] sequence req4w: resolving intent "a" for txn 00000001 with COMMITTED status
 [5] sequence req4w: lock wait-queue event: wait for txn 00000002 holding lock @ key "b" (queuedWriters: 2, queuedReaders: 0)
-[5] sequence req4w: conflicted with 00000001-0000-0000-0000-000000000000 on "a" for 1.23s
+[5] sequence req4w: conflicted with 00000001-0000-0000-0000-000000000000 on "a" for 1.234s
 [5] sequence req4w: pushing txn 00000002 to abort
 [5] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -1059,12 +1059,12 @@ on-txn-updated txn=txn2 status=committed
 [-] update txn: committing txn2
 [4] sequence req5w: resolving intent "b" for txn 00000002 with COMMITTED status
 [4] sequence req5w: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key "c" (queuedWriters: 1, queuedReaders: 0)
-[4] sequence req5w: conflicted with 00000002-0000-0000-0000-000000000000 on "b" for 1.23s
+[4] sequence req5w: conflicted with 00000002-0000-0000-0000-000000000000 on "b" for 1.234s
 [4] sequence req5w: pushing txn 00000003 to abort
 [4] sequence req5w: blocked on select in concurrency_test.(*cluster).PushTransaction
 [5] sequence req4w: resolving intent "b" for txn 00000002 with COMMITTED status
 [5] sequence req4w: lock wait-queue event: wait for (distinguished) txn 00000005 running request @ key "b" (queuedWriters: 1, queuedReaders: 0)
-[5] sequence req4w: conflicted with 00000002-0000-0000-0000-000000000000 on "b" for 1.23s
+[5] sequence req4w: conflicted with 00000002-0000-0000-0000-000000000000 on "b" for 1.234s
 [5] sequence req4w: pushing txn 00000005 to detect request deadlock
 [5] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -1131,10 +1131,10 @@ on-txn-updated txn=txn4 status=aborted
 ----
 [-] update txn: aborting txn4
 [5] sequence req4w: detected pusher aborted
-[5] sequence req4w: conflicted with 00000005-0000-0000-0000-000000000000 on "b" for 1.23s
+[5] sequence req4w: conflicted with 00000005-0000-0000-0000-000000000000 on "b" for 1.234s
 [5] sequence req4w: sequencing complete, returned error: TransactionAbortedError(ABORT_REASON_PUSHER_ABORTED): <nil>
 [6] sequence req3w2: lock wait-queue event: done waiting
-[6] sequence req3w2: conflicted with 00000004-0000-0000-0000-000000000000 on "a" for 1.23s
+[6] sequence req3w2: conflicted with 00000004-0000-0000-0000-000000000000 on "a" for 1.234s
 [6] sequence req3w2: acquiring latches
 [6] sequence req3w2: scanning lock table for conflicting locks
 [6] sequence req3w2: sequencing complete, returned guard
@@ -1149,7 +1149,7 @@ on-txn-updated txn=txn3 status=committed
 [-] update txn: committing txn3
 [4] sequence req5w: resolving intent "c" for txn 00000003 with COMMITTED status
 [4] sequence req5w: lock wait-queue event: done waiting
-[4] sequence req5w: conflicted with 00000003-0000-0000-0000-000000000000 on "c" for 1.23s
+[4] sequence req5w: conflicted with 00000003-0000-0000-0000-000000000000 on "c" for 1.234s
 [4] sequence req5w: acquiring latches
 [4] sequence req5w: scanning lock table for conflicting locks
 [4] sequence req5w: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/deadlocks
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/deadlocks
@@ -112,6 +112,7 @@ sequence req=req1r
 [4] sequence req1r: acquiring latches
 [4] sequence req1r: scanning lock table for conflicting locks
 [4] sequence req1r: waiting in lock wait-queues
+[4] sequence req1r: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "b" (queuedWriters: 0, queuedReaders: 1)
 [4] sequence req1r: pushing timestamp of txn 00000002 above 10.000000000,1
 [4] sequence req1r: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -121,6 +122,7 @@ sequence req=req2r
 [5] sequence req2r: acquiring latches
 [5] sequence req2r: scanning lock table for conflicting locks
 [5] sequence req2r: waiting in lock wait-queues
+[5] sequence req2r: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key "c" (queuedWriters: 0, queuedReaders: 1)
 [5] sequence req2r: pushing timestamp of txn 00000003 above 10.000000000,1
 [5] sequence req2r: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -132,6 +134,7 @@ sequence req=req3r
 [6] sequence req3r: acquiring latches
 [6] sequence req3r: scanning lock table for conflicting locks
 [6] sequence req3r: waiting in lock wait-queues
+[6] sequence req3r: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "a" (queuedWriters: 0, queuedReaders: 1)
 [6] sequence req3r: pushing timestamp of txn 00000001 above 10.000000000,1
 [6] sequence req3r: blocked on select in concurrency_test.(*cluster).PushTransaction
 [6] sequence req3r: dependency cycle detected 00000003->00000001->00000002->00000003
@@ -164,6 +167,7 @@ on-txn-updated txn=txn1 status=aborted
 [4] sequence req1r: conflicted with 00000002-0000-0000-0000-000000000000 on "b" for 1.23s
 [4] sequence req1r: sequencing complete, returned error: TransactionAbortedError(ABORT_REASON_PUSHER_ABORTED): <nil>
 [6] sequence req3r: resolving intent "a" for txn 00000001 with ABORTED status
+[6] sequence req3r: lock wait-queue event: done waiting
 [6] sequence req3r: conflicted with 00000001-0000-0000-0000-000000000000 on "a" for 1.23s
 [6] sequence req3r: acquiring latches
 [6] sequence req3r: scanning lock table for conflicting locks
@@ -178,6 +182,7 @@ on-txn-updated txn=txn3 status=committed
 ----
 [-] update txn: committing txn3
 [5] sequence req2r: resolving intent "c" for txn 00000003 with COMMITTED status
+[5] sequence req2r: lock wait-queue event: done waiting
 [5] sequence req2r: conflicted with 00000003-0000-0000-0000-000000000000 on "c" for 1.23s
 [5] sequence req2r: acquiring latches
 [5] sequence req2r: scanning lock table for conflicting locks
@@ -320,6 +325,7 @@ sequence req=req4w
 [4] sequence req4w: acquiring latches
 [4] sequence req4w: scanning lock table for conflicting locks
 [4] sequence req4w: waiting in lock wait-queues
+[4] sequence req4w: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "a" (queuedWriters: 1, queuedReaders: 0)
 [4] sequence req4w: pushing txn 00000001 to abort
 [4] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -329,6 +335,7 @@ sequence req=req1w2
 [5] sequence req1w2: acquiring latches
 [5] sequence req1w2: scanning lock table for conflicting locks
 [5] sequence req1w2: waiting in lock wait-queues
+[5] sequence req1w2: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "b" (queuedWriters: 1, queuedReaders: 0)
 [5] sequence req1w2: pushing txn 00000002 to abort
 [5] sequence req1w2: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -338,6 +345,7 @@ sequence req=req2w2
 [6] sequence req2w2: acquiring latches
 [6] sequence req2w2: scanning lock table for conflicting locks
 [6] sequence req2w2: waiting in lock wait-queues
+[6] sequence req2w2: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key "c" (queuedWriters: 1, queuedReaders: 0)
 [6] sequence req2w2: pushing txn 00000003 to abort
 [6] sequence req2w2: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -349,6 +357,7 @@ sequence req=req3w2
 [7] sequence req3w2: acquiring latches
 [7] sequence req3w2: scanning lock table for conflicting locks
 [7] sequence req3w2: waiting in lock wait-queues
+[7] sequence req3w2: lock wait-queue event: wait for txn 00000001 holding lock @ key "a" (queuedWriters: 2, queuedReaders: 0)
 [7] sequence req3w2: pushing txn 00000001 to abort
 [7] sequence req3w2: blocked on select in concurrency_test.(*cluster).PushTransaction
 [7] sequence req3w2: dependency cycle detected 00000003->00000001->00000002->00000003
@@ -379,6 +388,7 @@ on-txn-updated txn=txn1 status=aborted
 ----
 [-] update txn: aborting txn1
 [4] sequence req4w: resolving intent "a" for txn 00000001 with ABORTED status
+[4] sequence req4w: lock wait-queue event: done waiting
 [4] sequence req4w: conflicted with 00000001-0000-0000-0000-000000000000 on "a" for 1.23s
 [4] sequence req4w: acquiring latches
 [4] sequence req4w: scanning lock table for conflicting locks
@@ -387,6 +397,7 @@ on-txn-updated txn=txn1 status=aborted
 [5] sequence req1w2: conflicted with 00000002-0000-0000-0000-000000000000 on "b" for 1.23s
 [5] sequence req1w2: sequencing complete, returned error: TransactionAbortedError(ABORT_REASON_PUSHER_ABORTED): <nil>
 [7] sequence req3w2: resolving intent "a" for txn 00000001 with ABORTED status
+[7] sequence req3w2: lock wait-queue event: wait for (distinguished) txn 00000004 running request @ key "a" (queuedWriters: 1, queuedReaders: 0)
 [7] sequence req3w2: conflicted with 00000001-0000-0000-0000-000000000000 on "a" for 1.23s
 [7] sequence req3w2: pushing txn 00000004 to detect request deadlock
 [7] sequence req3w2: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -395,6 +406,7 @@ on-txn-updated txn=txn1 status=aborted
 finish req=req4w
 ----
 [-] finish req4w: finishing request
+[7] sequence req3w2: lock wait-queue event: done waiting
 [7] sequence req3w2: conflicted with 00000004-0000-0000-0000-000000000000 on "a" for 1.23s
 [7] sequence req3w2: acquiring latches
 [7] sequence req3w2: scanning lock table for conflicting locks
@@ -409,6 +421,7 @@ on-txn-updated txn=txn3 status=committed
 ----
 [-] update txn: committing txn3
 [6] sequence req2w2: resolving intent "c" for txn 00000003 with COMMITTED status
+[6] sequence req2w2: lock wait-queue event: done waiting
 [6] sequence req2w2: conflicted with 00000003-0000-0000-0000-000000000000 on "c" for 1.23s
 [6] sequence req2w2: acquiring latches
 [6] sequence req2w2: scanning lock table for conflicting locks
@@ -538,6 +551,7 @@ sequence req=req4w
 [4] sequence req4w: acquiring latches
 [4] sequence req4w: scanning lock table for conflicting locks
 [4] sequence req4w: waiting in lock wait-queues
+[4] sequence req4w: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "b" (queuedWriters: 1, queuedReaders: 0)
 [4] sequence req4w: pushing txn 00000002 to abort
 [4] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -545,6 +559,7 @@ on-txn-updated txn=txn2 status=committed
 ----
 [-] update txn: committing txn2
 [4] sequence req4w: resolving intent "b" for txn 00000002 with COMMITTED status
+[4] sequence req4w: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key "c" (queuedWriters: 1, queuedReaders: 0)
 [4] sequence req4w: conflicted with 00000002-0000-0000-0000-000000000000 on "b" for 1.23s
 [4] sequence req4w: pushing txn 00000003 to abort
 [4] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -581,6 +596,7 @@ sequence req=req1w2
 [5] sequence req1w2: acquiring latches
 [5] sequence req1w2: scanning lock table for conflicting locks
 [5] sequence req1w2: waiting in lock wait-queues
+[5] sequence req1w2: lock wait-queue event: wait for (distinguished) txn 00000004 running request @ key "b" (queuedWriters: 1, queuedReaders: 0)
 [5] sequence req1w2: pushing txn 00000004 to detect request deadlock
 [5] sequence req1w2: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -592,6 +608,7 @@ sequence req=req3w2
 [6] sequence req3w2: acquiring latches
 [6] sequence req3w2: scanning lock table for conflicting locks
 [6] sequence req3w2: waiting in lock wait-queues
+[6] sequence req3w2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "a" (queuedWriters: 1, queuedReaders: 0)
 [6] sequence req3w2: pushing txn 00000001 to abort
 [6] sequence req3w2: blocked on select in concurrency_test.(*cluster).PushTransaction
 [6] sequence req3w2: dependency cycle detected 00000003->00000001->00000004->00000003
@@ -623,6 +640,7 @@ on-txn-updated txn=txn4 status=aborted
 [4] sequence req4w: detected pusher aborted
 [4] sequence req4w: conflicted with 00000003-0000-0000-0000-000000000000 on "c" for 1.23s
 [4] sequence req4w: sequencing complete, returned error: TransactionAbortedError(ABORT_REASON_PUSHER_ABORTED): <nil>
+[5] sequence req1w2: lock wait-queue event: done waiting
 [5] sequence req1w2: conflicted with 00000004-0000-0000-0000-000000000000 on "b" for 1.23s
 [5] sequence req1w2: acquiring latches
 [5] sequence req1w2: scanning lock table for conflicting locks
@@ -637,6 +655,7 @@ on-txn-updated txn=txn1 status=committed
 ----
 [-] update txn: committing txn1
 [6] sequence req3w2: resolving intent "a" for txn 00000001 with COMMITTED status
+[6] sequence req3w2: lock wait-queue event: done waiting
 [6] sequence req3w2: conflicted with 00000001-0000-0000-0000-000000000000 on "a" for 1.23s
 [6] sequence req3w2: acquiring latches
 [6] sequence req3w2: scanning lock table for conflicting locks
@@ -766,6 +785,7 @@ sequence req=req4w
 [4] sequence req4w: acquiring latches
 [4] sequence req4w: scanning lock table for conflicting locks
 [4] sequence req4w: waiting in lock wait-queues
+[4] sequence req4w: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "b" (queuedWriters: 1, queuedReaders: 0)
 [4] sequence req4w: pushing txn 00000002 to abort
 [4] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -773,6 +793,7 @@ on-txn-updated txn=txn2 status=committed
 ----
 [-] update txn: committing txn2
 [4] sequence req4w: resolving intent "b" for txn 00000002 with COMMITTED status
+[4] sequence req4w: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key "c" (queuedWriters: 1, queuedReaders: 0)
 [4] sequence req4w: conflicted with 00000002-0000-0000-0000-000000000000 on "b" for 1.23s
 [4] sequence req4w: pushing txn 00000003 to abort
 [4] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -809,6 +830,7 @@ sequence req=req1w2
 [5] sequence req1w2: acquiring latches
 [5] sequence req1w2: scanning lock table for conflicting locks
 [5] sequence req1w2: waiting in lock wait-queues
+[5] sequence req1w2: lock wait-queue event: wait for (distinguished) txn 00000004 running request @ key "b" (queuedWriters: 1, queuedReaders: 0)
 [5] sequence req1w2: pushing txn 00000004 to detect request deadlock
 [5] sequence req1w2: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -820,6 +842,7 @@ sequence req=req3w2
 [6] sequence req3w2: acquiring latches
 [6] sequence req3w2: scanning lock table for conflicting locks
 [6] sequence req3w2: waiting in lock wait-queues
+[6] sequence req3w2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "a" (queuedWriters: 1, queuedReaders: 0)
 [6] sequence req3w2: pushing txn 00000001 to abort
 [6] sequence req3w2: blocked on select in concurrency_test.(*cluster).PushTransaction
 [6] sequence req3w2: dependency cycle detected 00000003->00000001->00000004->00000003
@@ -852,6 +875,7 @@ on-txn-updated txn=txn1 status=aborted
 [5] sequence req1w2: conflicted with 00000004-0000-0000-0000-000000000000 on "b" for 1.23s
 [5] sequence req1w2: sequencing complete, returned error: TransactionAbortedError(ABORT_REASON_PUSHER_ABORTED): <nil>
 [6] sequence req3w2: resolving intent "a" for txn 00000001 with ABORTED status
+[6] sequence req3w2: lock wait-queue event: done waiting
 [6] sequence req3w2: conflicted with 00000001-0000-0000-0000-000000000000 on "a" for 1.23s
 [6] sequence req3w2: acquiring latches
 [6] sequence req3w2: scanning lock table for conflicting locks
@@ -866,6 +890,7 @@ on-txn-updated txn=txn3 status=committed
 ----
 [-] update txn: committing txn3
 [4] sequence req4w: resolving intent "c" for txn 00000003 with COMMITTED status
+[4] sequence req4w: lock wait-queue event: done waiting
 [4] sequence req4w: conflicted with 00000003-0000-0000-0000-000000000000 on "c" for 1.23s
 [4] sequence req4w: acquiring latches
 [4] sequence req4w: scanning lock table for conflicting locks
@@ -1006,6 +1031,7 @@ sequence req=req5w
 [4] sequence req5w: acquiring latches
 [4] sequence req5w: scanning lock table for conflicting locks
 [4] sequence req5w: waiting in lock wait-queues
+[4] sequence req5w: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "b" (queuedWriters: 1, queuedReaders: 0)
 [4] sequence req5w: pushing txn 00000002 to abort
 [4] sequence req5w: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -1015,6 +1041,7 @@ sequence req=req4w
 [5] sequence req4w: acquiring latches
 [5] sequence req4w: scanning lock table for conflicting locks
 [5] sequence req4w: waiting in lock wait-queues
+[5] sequence req4w: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "a" (queuedWriters: 1, queuedReaders: 0)
 [5] sequence req4w: pushing txn 00000001 to abort
 [5] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -1022,6 +1049,7 @@ on-txn-updated txn=txn1 status=committed
 ----
 [-] update txn: committing txn1
 [5] sequence req4w: resolving intent "a" for txn 00000001 with COMMITTED status
+[5] sequence req4w: lock wait-queue event: wait for txn 00000002 holding lock @ key "b" (queuedWriters: 2, queuedReaders: 0)
 [5] sequence req4w: conflicted with 00000001-0000-0000-0000-000000000000 on "a" for 1.23s
 [5] sequence req4w: pushing txn 00000002 to abort
 [5] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -1030,10 +1058,12 @@ on-txn-updated txn=txn2 status=committed
 ----
 [-] update txn: committing txn2
 [4] sequence req5w: resolving intent "b" for txn 00000002 with COMMITTED status
+[4] sequence req5w: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key "c" (queuedWriters: 1, queuedReaders: 0)
 [4] sequence req5w: conflicted with 00000002-0000-0000-0000-000000000000 on "b" for 1.23s
 [4] sequence req5w: pushing txn 00000003 to abort
 [4] sequence req5w: blocked on select in concurrency_test.(*cluster).PushTransaction
 [5] sequence req4w: resolving intent "b" for txn 00000002 with COMMITTED status
+[5] sequence req4w: lock wait-queue event: wait for (distinguished) txn 00000005 running request @ key "b" (queuedWriters: 1, queuedReaders: 0)
 [5] sequence req4w: conflicted with 00000002-0000-0000-0000-000000000000 on "b" for 1.23s
 [5] sequence req4w: pushing txn 00000005 to detect request deadlock
 [5] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -1071,6 +1101,7 @@ sequence req=req3w2
 [6] sequence req3w2: acquiring latches
 [6] sequence req3w2: scanning lock table for conflicting locks
 [6] sequence req3w2: waiting in lock wait-queues
+[6] sequence req3w2: lock wait-queue event: wait for (distinguished) txn 00000004 running request @ key "a" (queuedWriters: 1, queuedReaders: 0)
 [6] sequence req3w2: pushing txn 00000004 to detect request deadlock
 [6] sequence req3w2: blocked on select in concurrency_test.(*cluster).PushTransaction
 [6] sequence req3w2: dependency cycle detected 00000003->00000004->00000005->00000003
@@ -1102,6 +1133,7 @@ on-txn-updated txn=txn4 status=aborted
 [5] sequence req4w: detected pusher aborted
 [5] sequence req4w: conflicted with 00000005-0000-0000-0000-000000000000 on "b" for 1.23s
 [5] sequence req4w: sequencing complete, returned error: TransactionAbortedError(ABORT_REASON_PUSHER_ABORTED): <nil>
+[6] sequence req3w2: lock wait-queue event: done waiting
 [6] sequence req3w2: conflicted with 00000004-0000-0000-0000-000000000000 on "a" for 1.23s
 [6] sequence req3w2: acquiring latches
 [6] sequence req3w2: scanning lock table for conflicting locks
@@ -1116,6 +1148,7 @@ on-txn-updated txn=txn3 status=committed
 ----
 [-] update txn: committing txn3
 [4] sequence req5w: resolving intent "c" for txn 00000003 with COMMITTED status
+[4] sequence req5w: lock wait-queue event: done waiting
 [4] sequence req5w: conflicted with 00000003-0000-0000-0000-000000000000 on "c" for 1.23s
 [4] sequence req5w: acquiring latches
 [4] sequence req5w: scanning lock table for conflicting locks

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discover_lock_after_lease_race
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discover_lock_after_lease_race
@@ -149,6 +149,7 @@ sequence req=req4
 [5] sequence req4: acquiring latches
 [5] sequence req4: scanning lock table for conflicting locks
 [5] sequence req4: waiting in lock wait-queues
+[5] sequence req4: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 1)
 [5] sequence req4: pushing timestamp of txn 00000003 above 10.000000000,0
 [5] sequence req4: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -173,6 +174,7 @@ sequence req=req2
 [7] sequence req2: acquiring latches
 [7] sequence req2: scanning lock table for conflicting locks
 [7] sequence req2: waiting in lock wait-queues
+[7] sequence req2: lock wait-queue event: wait for txn 00000003 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 2)
 [7] sequence req2: pushing timestamp of txn 00000003 above 10.000000000,0
 [7] sequence req2: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -180,11 +182,13 @@ on-txn-updated txn=txn3 status=committed
 ----
 [-] update txn: committing txn3
 [5] sequence req4: resolving intent "k" for txn 00000003 with COMMITTED status
+[5] sequence req4: lock wait-queue event: done waiting
 [5] sequence req4: conflicted with 00000003-0000-0000-0000-000000000000 on "k" for 1.23s
 [5] sequence req4: acquiring latches
 [5] sequence req4: scanning lock table for conflicting locks
 [5] sequence req4: sequencing complete, returned guard
 [7] sequence req2: resolving intent "k" for txn 00000003 with COMMITTED status
+[7] sequence req2: lock wait-queue event: done waiting
 [7] sequence req2: conflicted with 00000003-0000-0000-0000-000000000000 on "k" for 1.23s
 [7] sequence req2: acquiring latches
 [7] sequence req2: scanning lock table for conflicting locks

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discover_lock_after_lease_race
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discover_lock_after_lease_race
@@ -183,13 +183,13 @@ on-txn-updated txn=txn3 status=committed
 [-] update txn: committing txn3
 [5] sequence req4: resolving intent "k" for txn 00000003 with COMMITTED status
 [5] sequence req4: lock wait-queue event: done waiting
-[5] sequence req4: conflicted with 00000003-0000-0000-0000-000000000000 on "k" for 1.23s
+[5] sequence req4: conflicted with 00000003-0000-0000-0000-000000000000 on "k" for 1.234s
 [5] sequence req4: acquiring latches
 [5] sequence req4: scanning lock table for conflicting locks
 [5] sequence req4: sequencing complete, returned guard
 [7] sequence req2: resolving intent "k" for txn 00000003 with COMMITTED status
 [7] sequence req2: lock wait-queue event: done waiting
-[7] sequence req2: conflicted with 00000003-0000-0000-0000-000000000000 on "k" for 1.23s
+[7] sequence req2: conflicted with 00000003-0000-0000-0000-000000000000 on "k" for 1.234s
 [7] sequence req2: acquiring latches
 [7] sequence req2: scanning lock table for conflicting locks
 [7] sequence req2: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discovered_lock
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discovered_lock
@@ -38,6 +38,7 @@ sequence req=req1
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: waiting in lock wait-queues
+[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 1)
 [3] sequence req1: pushing timestamp of txn 00000001 above 12.000000000,1
 [3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -45,6 +46,7 @@ on-txn-updated txn=txn1 status=aborted
 ----
 [-] update txn: aborting txn1
 [3] sequence req1: resolving intent "k" for txn 00000001 with ABORTED status
+[3] sequence req1: lock wait-queue event: done waiting
 [3] sequence req1: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.23s
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discovered_lock
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discovered_lock
@@ -47,7 +47,7 @@ on-txn-updated txn=txn1 status=aborted
 [-] update txn: aborting txn1
 [3] sequence req1: resolving intent "k" for txn 00000001 with ABORTED status
 [3] sequence req1: lock wait-queue event: done waiting
-[3] sequence req1: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.23s
+[3] sequence req1: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/range_state_listener
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/range_state_listener
@@ -94,6 +94,7 @@ sequence req=req2
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: waiting in lock wait-queues
+[2] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 1, queuedReaders: 0)
 [2] sequence req2: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
 debug-lock-table
@@ -112,6 +113,7 @@ local: num=0
 on-lease-updated leaseholder=false lease-seq=2
 ----
 [-] transfer lease: released
+[2] sequence req2: lock wait-queue event: done waiting
 [2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.23s
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
@@ -236,6 +238,7 @@ sequence req=req3
 [11] sequence req3: acquiring latches
 [11] sequence req3: scanning lock table for conflicting locks
 [11] sequence req3: waiting in lock wait-queues
+[11] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "k" (queuedWriters: 1, queuedReaders: 0)
 [11] sequence req3: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
 debug-lock-table
@@ -261,6 +264,7 @@ sequence req=reqRes2
 on-lock-updated req=reqRes2 txn=txn2 key=k status=committed
 ----
 [-] update lock: committing txn 00000002 @ k
+[11] sequence req3: lock wait-queue event: done waiting
 [11] sequence req3: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 1.23s
 [11] sequence req3: acquiring latches
 [11] sequence req3: blocked on select in spanlatch.(*Manager).waitForSignal
@@ -361,6 +365,7 @@ sequence req=req2
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: waiting in lock wait-queues
+[2] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 1, queuedReaders: 0)
 [2] sequence req2: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
 debug-lock-table
@@ -376,6 +381,7 @@ local: num=0
 on-split
 ----
 [-] split range: complete
+[2] sequence req2: lock wait-queue event: done waiting
 [2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.23s
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
@@ -406,6 +412,7 @@ sequence req=req2
 [4] sequence req2: acquiring latches
 [4] sequence req2: scanning lock table for conflicting locks
 [4] sequence req2: waiting in lock wait-queues
+[4] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 1, queuedReaders: 0)
 [4] sequence req2: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
 new-request name=reqRes1 txn=none ts=10,1
@@ -421,6 +428,7 @@ sequence req=reqRes1
 on-lock-updated req=reqRes1 txn=txn1 key=k status=committed
 ----
 [-] update lock: committing txn 00000001 @ k
+[4] sequence req2: lock wait-queue event: done waiting
 [4] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.23s
 [4] sequence req2: acquiring latches
 [4] sequence req2: blocked on select in spanlatch.(*Manager).waitForSignal
@@ -531,6 +539,7 @@ sequence req=req2
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: waiting in lock wait-queues
+[2] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 1, queuedReaders: 0)
 [2] sequence req2: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
 debug-lock-table
@@ -548,6 +557,7 @@ local: num=0
 on-merge
 ----
 [-] merge range: complete
+[2] sequence req2: lock wait-queue event: done waiting
 [2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.23s
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
@@ -682,6 +692,7 @@ sequence req=req2
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: waiting in lock wait-queues
+[2] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 1, queuedReaders: 0)
 [2] sequence req2: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
 debug-lock-table
@@ -697,6 +708,7 @@ local: num=0
 on-snapshot-applied
 ----
 [-] snapshot replica: applied
+[2] sequence req2: lock wait-queue event: done waiting
 [2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.23s
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
@@ -727,6 +739,7 @@ sequence req=req2
 [4] sequence req2: acquiring latches
 [4] sequence req2: scanning lock table for conflicting locks
 [4] sequence req2: waiting in lock wait-queues
+[4] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 1, queuedReaders: 0)
 [4] sequence req2: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
 new-request name=reqRes1 txn=none ts=10,1
@@ -742,6 +755,7 @@ sequence req=reqRes1
 on-lock-updated req=reqRes1 txn=txn1 key=k status=committed
 ----
 [-] update lock: committing txn 00000001 @ k
+[4] sequence req2: lock wait-queue event: done waiting
 [4] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.23s
 [4] sequence req2: acquiring latches
 [4] sequence req2: blocked on select in spanlatch.(*Manager).waitForSignal

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/range_state_listener
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/range_state_listener
@@ -267,6 +267,7 @@ on-lock-updated req=reqRes2 txn=txn2 key=k status=committed
 [11] sequence req3: lock wait-queue event: done waiting
 [11] sequence req3: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 1.23s
 [11] sequence req3: acquiring latches
+[11] sequence req3: waiting to acquire write latch k@10.000000000,1, held by write latch k@10.000000000,1
 [11] sequence req3: blocked on select in spanlatch.(*Manager).waitForSignal
 
 finish req=reqRes2
@@ -431,6 +432,7 @@ on-lock-updated req=reqRes1 txn=txn1 key=k status=committed
 [4] sequence req2: lock wait-queue event: done waiting
 [4] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.23s
 [4] sequence req2: acquiring latches
+[4] sequence req2: waiting to acquire write latch k@10.000000000,1, held by write latch k@10.000000000,1
 [4] sequence req2: blocked on select in spanlatch.(*Manager).waitForSignal
 
 finish req=reqRes1
@@ -758,6 +760,7 @@ on-lock-updated req=reqRes1 txn=txn1 key=k status=committed
 [4] sequence req2: lock wait-queue event: done waiting
 [4] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.23s
 [4] sequence req2: acquiring latches
+[4] sequence req2: waiting to acquire write latch k@10.000000000,1, held by write latch k@10.000000000,1
 [4] sequence req2: blocked on select in spanlatch.(*Manager).waitForSignal
 
 finish req=reqRes1

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/range_state_listener
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/range_state_listener
@@ -114,7 +114,7 @@ on-lease-updated leaseholder=false lease-seq=2
 ----
 [-] transfer lease: released
 [2] sequence req2: lock wait-queue event: done waiting
-[2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.23s
+[2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: sequencing complete, returned guard
@@ -265,7 +265,7 @@ on-lock-updated req=reqRes2 txn=txn2 key=k status=committed
 ----
 [-] update lock: committing txn 00000002 @ k
 [11] sequence req3: lock wait-queue event: done waiting
-[11] sequence req3: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 1.23s
+[11] sequence req3: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 1.234s
 [11] sequence req3: acquiring latches
 [11] sequence req3: waiting to acquire write latch k@10.000000000,1, held by write latch k@10.000000000,1
 [11] sequence req3: blocked on select in spanlatch.(*Manager).waitForSignal
@@ -383,7 +383,7 @@ on-split
 ----
 [-] split range: complete
 [2] sequence req2: lock wait-queue event: done waiting
-[2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.23s
+[2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: sequencing complete, returned guard
@@ -430,7 +430,7 @@ on-lock-updated req=reqRes1 txn=txn1 key=k status=committed
 ----
 [-] update lock: committing txn 00000001 @ k
 [4] sequence req2: lock wait-queue event: done waiting
-[4] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.23s
+[4] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
 [4] sequence req2: acquiring latches
 [4] sequence req2: waiting to acquire write latch k@10.000000000,1, held by write latch k@10.000000000,1
 [4] sequence req2: blocked on select in spanlatch.(*Manager).waitForSignal
@@ -560,7 +560,7 @@ on-merge
 ----
 [-] merge range: complete
 [2] sequence req2: lock wait-queue event: done waiting
-[2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.23s
+[2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: sequencing complete, returned guard
@@ -711,7 +711,7 @@ on-snapshot-applied
 ----
 [-] snapshot replica: applied
 [2] sequence req2: lock wait-queue event: done waiting
-[2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.23s
+[2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: sequencing complete, returned guard
@@ -758,7 +758,7 @@ on-lock-updated req=reqRes1 txn=txn1 key=k status=committed
 ----
 [-] update lock: committing txn 00000001 @ k
 [4] sequence req2: lock wait-queue event: done waiting
-[4] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.23s
+[4] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
 [4] sequence req2: acquiring latches
 [4] sequence req2: waiting to acquire write latch k@10.000000000,1, held by write latch k@10.000000000,1
 [4] sequence req2: blocked on select in spanlatch.(*Manager).waitForSignal

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/uncertainty
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/uncertainty
@@ -40,6 +40,7 @@ sequence req=req1
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: waiting in lock wait-queues
+[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 1)
 [3] sequence req1: pushing timestamp of txn 00000001 above 15.000000000,1
 [3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -47,6 +48,7 @@ on-txn-updated txn=txn1 status=pending ts=15,2
 ----
 [-] update txn: increasing timestamp of txn1
 [3] sequence req1: resolving intent "k" for txn 00000001 with PENDING status
+[3] sequence req1: lock wait-queue event: done waiting
 [3] sequence req1: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.23s
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
@@ -104,6 +106,7 @@ sequence req=req1
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: waiting in lock wait-queues
+[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 1)
 [3] sequence req1: pushing timestamp of txn 00000001 above 135.000000000,0
 [3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -111,6 +114,7 @@ on-txn-updated txn=txn1 status=pending ts=135,1
 ----
 [-] update txn: increasing timestamp of txn1
 [3] sequence req1: resolving intent "k" for txn 00000001 with PENDING status
+[3] sequence req1: lock wait-queue event: done waiting
 [3] sequence req1: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.23s
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
@@ -171,6 +175,7 @@ sequence req=req1
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: waiting in lock wait-queues
+[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 1)
 [3] sequence req1: pushing timestamp of txn 00000001 above 150.000000000,1?
 [3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -178,6 +183,7 @@ on-txn-updated txn=txn1 status=pending ts=150,2?
 ----
 [-] update txn: increasing timestamp of txn1
 [3] sequence req1: resolving intent "k" for txn 00000001 with PENDING status
+[3] sequence req1: lock wait-queue event: done waiting
 [3] sequence req1: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.23s
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
@@ -244,6 +250,7 @@ sequence req=req1
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: waiting in lock wait-queues
+[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 1)
 [3] sequence req1: pushing timestamp of txn 00000001 above 15.000000000,1
 [3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -281,6 +288,7 @@ sequence req=req2-retry
 [5] sequence req2-retry: acquiring latches
 [5] sequence req2-retry: scanning lock table for conflicting locks
 [5] sequence req2-retry: waiting in lock wait-queues
+[5] sequence req2-retry: lock wait-queue event: wait for txn 00000001 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 2)
 [5] sequence req2-retry: pushing timestamp of txn 00000001 above 15.000000000,1
 [5] sequence req2-retry: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -289,11 +297,13 @@ on-txn-updated txn=txn1 status=committed
 ----
 [-] update txn: committing txn1
 [3] sequence req1: resolving intent "k" for txn 00000001 with COMMITTED status
+[3] sequence req1: lock wait-queue event: done waiting
 [3] sequence req1: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.23s
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: sequencing complete, returned guard
 [5] sequence req2-retry: resolving intent "k" for txn 00000001 with COMMITTED status
+[5] sequence req2-retry: lock wait-queue event: done waiting
 [5] sequence req2-retry: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.23s
 [5] sequence req2-retry: acquiring latches
 [5] sequence req2-retry: scanning lock table for conflicting locks

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/uncertainty
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/uncertainty
@@ -49,7 +49,7 @@ on-txn-updated txn=txn1 status=pending ts=15,2
 [-] update txn: increasing timestamp of txn1
 [3] sequence req1: resolving intent "k" for txn 00000001 with PENDING status
 [3] sequence req1: lock wait-queue event: done waiting
-[3] sequence req1: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.23s
+[3] sequence req1: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: sequencing complete, returned guard
@@ -115,7 +115,7 @@ on-txn-updated txn=txn1 status=pending ts=135,1
 [-] update txn: increasing timestamp of txn1
 [3] sequence req1: resolving intent "k" for txn 00000001 with PENDING status
 [3] sequence req1: lock wait-queue event: done waiting
-[3] sequence req1: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.23s
+[3] sequence req1: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: sequencing complete, returned guard
@@ -184,7 +184,7 @@ on-txn-updated txn=txn1 status=pending ts=150,2?
 [-] update txn: increasing timestamp of txn1
 [3] sequence req1: resolving intent "k" for txn 00000001 with PENDING status
 [3] sequence req1: lock wait-queue event: done waiting
-[3] sequence req1: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.23s
+[3] sequence req1: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: sequencing complete, returned guard
@@ -298,13 +298,13 @@ on-txn-updated txn=txn1 status=committed
 [-] update txn: committing txn1
 [3] sequence req1: resolving intent "k" for txn 00000001 with COMMITTED status
 [3] sequence req1: lock wait-queue event: done waiting
-[3] sequence req1: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.23s
+[3] sequence req1: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: sequencing complete, returned guard
 [5] sequence req2-retry: resolving intent "k" for txn 00000001 with COMMITTED status
 [5] sequence req2-retry: lock wait-queue event: done waiting
-[5] sequence req2-retry: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.23s
+[5] sequence req2-retry: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
 [5] sequence req2-retry: acquiring latches
 [5] sequence req2-retry: scanning lock table for conflicting locks
 [5] sequence req2-retry: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/update
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/update
@@ -72,7 +72,7 @@ on-txn-updated txn=txn1 status=pending ts=12,2
 [-] update txn: increasing timestamp of txn1
 [2] sequence req2: resolving intent "k" for txn 00000001 with PENDING status
 [2] sequence req2: lock wait-queue event: done waiting
-[2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.23s
+[2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: sequencing complete, returned guard
@@ -193,7 +193,7 @@ on-txn-updated txn=txn1 status=pending ts=12,2
 [-] update txn: increasing timestamp of txn1
 [2] sequence req2: resolving intent "k" for txn 00000001 with PENDING status
 [2] sequence req2: lock wait-queue event: done waiting
-[2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.23s
+[2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: sequencing complete, returned guard
@@ -323,7 +323,7 @@ on-txn-updated txn=txn1 status=pending ts=12,2
 [-] update txn: increasing timestamp of txn1
 [2] sequence req2: resolving intent "k" for txn 00000001 with PENDING status
 [2] sequence req2: lock wait-queue event: done waiting
-[2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.23s
+[2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: sequencing complete, returned guard
@@ -397,7 +397,7 @@ on-txn-updated txn=txn1 status=committed
 [-] update txn: committing txn1
 [3] sequence req4: resolving intent "k" for txn 00000001 with COMMITTED status
 [3] sequence req4: lock wait-queue event: done waiting
-[3] sequence req4: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.23s
+[3] sequence req4: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
 [3] sequence req4: acquiring latches
 [3] sequence req4: scanning lock table for conflicting locks
 [3] sequence req4: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/update
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/update
@@ -49,6 +49,7 @@ sequence req=req2
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: waiting in lock wait-queues
+[2] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 1)
 [2] sequence req2: pushing timestamp of txn 00000001 above 12.000000000,1
 [2] sequence req2: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -70,6 +71,7 @@ on-txn-updated txn=txn1 status=pending ts=12,2
 ----
 [-] update txn: increasing timestamp of txn1
 [2] sequence req2: resolving intent "k" for txn 00000001 with PENDING status
+[2] sequence req2: lock wait-queue event: done waiting
 [2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.23s
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
@@ -168,6 +170,7 @@ sequence req=req2
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: waiting in lock wait-queues
+[2] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 1)
 [2] sequence req2: pushing timestamp of txn 00000001 above 12.000000000,1
 [2] sequence req2: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -189,6 +192,7 @@ on-txn-updated txn=txn1 status=pending ts=12,2
 ----
 [-] update txn: increasing timestamp of txn1
 [2] sequence req2: resolving intent "k" for txn 00000001 with PENDING status
+[2] sequence req2: lock wait-queue event: done waiting
 [2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.23s
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
@@ -296,6 +300,7 @@ sequence req=req2
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: waiting in lock wait-queues
+[2] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 1)
 [2] sequence req2: pushing timestamp of txn 00000001 above 12.000000000,1
 [2] sequence req2: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -317,6 +322,7 @@ on-txn-updated txn=txn1 status=pending ts=12,2
 ----
 [-] update txn: increasing timestamp of txn1
 [2] sequence req2: resolving intent "k" for txn 00000001 with PENDING status
+[2] sequence req2: lock wait-queue event: done waiting
 [2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.23s
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
@@ -352,6 +358,7 @@ sequence req=req4
 [3] sequence req4: acquiring latches
 [3] sequence req4: scanning lock table for conflicting locks
 [3] sequence req4: waiting in lock wait-queues
+[3] sequence req4: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 1, queuedReaders: 0)
 [3] sequence req4: pushing txn 00000001 to abort
 [3] sequence req4: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -389,6 +396,7 @@ on-txn-updated txn=txn1 status=committed
 ----
 [-] update txn: committing txn1
 [3] sequence req4: resolving intent "k" for txn 00000001 with COMMITTED status
+[3] sequence req4: lock wait-queue event: done waiting
 [3] sequence req4: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.23s
 [3] sequence req4: acquiring latches
 [3] sequence req4: scanning lock table for conflicting locks

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_error
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_error
@@ -70,6 +70,7 @@ sequence req=req3
 [3] sequence req3: acquiring latches
 [3] sequence req3: scanning lock table for conflicting locks
 [3] sequence req3: waiting in lock wait-queues
+[3] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k2" (queuedWriters: 1, queuedReaders: 0)
 [3] sequence req3: pushing txn 00000001 to abort
 [3] sequence req3: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -102,6 +103,7 @@ sequence req=reqNoWait1
 [4] sequence reqNoWait1: acquiring latches
 [4] sequence reqNoWait1: scanning lock table for conflicting locks
 [4] sequence reqNoWait1: waiting in lock wait-queues
+[4] sequence reqNoWait1: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 1)
 [4] sequence reqNoWait1: pushing txn 00000001 to check if abandoned
 [4] sequence reqNoWait1: pushee not abandoned
 [4] sequence reqNoWait1: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.23s
@@ -116,6 +118,7 @@ on-txn-updated txn=txn1 status=committed
 ----
 [-] update txn: committing txn1
 [3] sequence req3: resolving intent "k2" for txn 00000001 with COMMITTED status
+[3] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "k3" (queuedWriters: 1, queuedReaders: 0)
 [3] sequence req3: conflicted with 00000001-0000-0000-0000-000000000000 on "k2" for 1.23s
 [3] sequence req3: pushing txn 00000002 to abort
 [3] sequence req3: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -159,6 +162,7 @@ sequence req=reqNoWait2
 [6] sequence reqNoWait2: acquiring latches
 [6] sequence reqNoWait2: scanning lock table for conflicting locks
 [6] sequence reqNoWait2: waiting in lock wait-queues
+[6] sequence reqNoWait2: lock wait-queue event: wait for (distinguished) txn 00000003 running request @ key "k2" (queuedWriters: 1, queuedReaders: 0)
 [6] sequence reqNoWait2: conflicted with 00000003-0000-0000-0000-000000000000 on "k2" for 1.23s
 [6] sequence reqNoWait2: sequencing complete, returned error: conflicting intents on "k2"
 
@@ -189,6 +193,7 @@ sequence req=reqNoWait3
 [9] sequence reqNoWait3: acquiring latches
 [9] sequence reqNoWait3: scanning lock table for conflicting locks
 [9] sequence reqNoWait3: waiting in lock wait-queues
+[9] sequence reqNoWait3: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "k4" (queuedWriters: 0, queuedReaders: 1)
 [9] sequence reqNoWait3: pushing txn 00000002 to check if abandoned
 [9] sequence reqNoWait3: pushee not abandoned
 [9] sequence reqNoWait3: conflicted with 00000002-0000-0000-0000-000000000000 on "k4" for 1.23s
@@ -217,6 +222,7 @@ on-txn-updated txn=txn2 status=aborted
 ----
 [-] update txn: aborting txn2
 [3] sequence req3: resolving intent "k3" for txn 00000002 with ABORTED status
+[3] sequence req3: lock wait-queue event: done waiting
 [3] sequence req3: conflicted with 00000002-0000-0000-0000-000000000000 on "k3" for 1.23s
 [3] sequence req3: acquiring latches
 [3] sequence req3: scanning lock table for conflicting locks
@@ -244,6 +250,7 @@ sequence req=reqNoWait4
 [12] sequence reqNoWait4: acquiring latches
 [12] sequence reqNoWait4: scanning lock table for conflicting locks
 [12] sequence reqNoWait4: waiting in lock wait-queues
+[12] sequence reqNoWait4: lock wait-queue event: done waiting
 [12] sequence reqNoWait4: resolving a batch of 1 intent(s)
 [12] sequence reqNoWait4: resolving intent "k5" for txn 00000002 with ABORTED status
 [12] sequence reqNoWait4: acquiring latches

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_error
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_error
@@ -106,7 +106,7 @@ sequence req=reqNoWait1
 [4] sequence reqNoWait1: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 1)
 [4] sequence reqNoWait1: pushing txn 00000001 to check if abandoned
 [4] sequence reqNoWait1: pushee not abandoned
-[4] sequence reqNoWait1: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.23s
+[4] sequence reqNoWait1: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
 [4] sequence reqNoWait1: sequencing complete, returned error: conflicting intents on "k"
 
 # -------------------------------------------------------------
@@ -119,7 +119,7 @@ on-txn-updated txn=txn1 status=committed
 [-] update txn: committing txn1
 [3] sequence req3: resolving intent "k2" for txn 00000001 with COMMITTED status
 [3] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "k3" (queuedWriters: 1, queuedReaders: 0)
-[3] sequence req3: conflicted with 00000001-0000-0000-0000-000000000000 on "k2" for 1.23s
+[3] sequence req3: conflicted with 00000001-0000-0000-0000-000000000000 on "k2" for 1.234s
 [3] sequence req3: pushing txn 00000002 to abort
 [3] sequence req3: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -163,7 +163,7 @@ sequence req=reqNoWait2
 [6] sequence reqNoWait2: scanning lock table for conflicting locks
 [6] sequence reqNoWait2: waiting in lock wait-queues
 [6] sequence reqNoWait2: lock wait-queue event: wait for (distinguished) txn 00000003 running request @ key "k2" (queuedWriters: 1, queuedReaders: 0)
-[6] sequence reqNoWait2: conflicted with 00000003-0000-0000-0000-000000000000 on "k2" for 1.23s
+[6] sequence reqNoWait2: conflicted with 00000003-0000-0000-0000-000000000000 on "k2" for 1.234s
 [6] sequence reqNoWait2: sequencing complete, returned error: conflicting intents on "k2"
 
 # -------------------------------------------------------------
@@ -196,7 +196,7 @@ sequence req=reqNoWait3
 [9] sequence reqNoWait3: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "k4" (queuedWriters: 0, queuedReaders: 1)
 [9] sequence reqNoWait3: pushing txn 00000002 to check if abandoned
 [9] sequence reqNoWait3: pushee not abandoned
-[9] sequence reqNoWait3: conflicted with 00000002-0000-0000-0000-000000000000 on "k4" for 1.23s
+[9] sequence reqNoWait3: conflicted with 00000002-0000-0000-0000-000000000000 on "k4" for 1.234s
 [9] sequence reqNoWait3: sequencing complete, returned error: conflicting intents on "k4"
 
 debug-lock-table
@@ -223,7 +223,7 @@ on-txn-updated txn=txn2 status=aborted
 [-] update txn: aborting txn2
 [3] sequence req3: resolving intent "k3" for txn 00000002 with ABORTED status
 [3] sequence req3: lock wait-queue event: done waiting
-[3] sequence req3: conflicted with 00000002-0000-0000-0000-000000000000 on "k3" for 1.23s
+[3] sequence req3: conflicted with 00000002-0000-0000-0000-000000000000 on "k3" for 1.234s
 [3] sequence req3: acquiring latches
 [3] sequence req3: scanning lock table for conflicting locks
 [3] sequence req3: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_self
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_self
@@ -76,18 +76,18 @@ on-txn-updated txn=txnOld status=committed
 [-] update txn: committing txnOld
 [2] sequence reqTxn1: resolving intent "k" for txn 00000002 with COMMITTED status
 [2] sequence reqTxn1: lock wait-queue event: done waiting
-[2] sequence reqTxn1: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 1.23s
+[2] sequence reqTxn1: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 1.234s
 [2] sequence reqTxn1: acquiring latches
 [2] sequence reqTxn1: scanning lock table for conflicting locks
 [2] sequence reqTxn1: sequencing complete, returned guard
 [3] sequence reqTxnMiddle: resolving intent "k" for txn 00000002 with COMMITTED status
 [3] sequence reqTxnMiddle: lock wait-queue event: wait for (distinguished) txn 00000001 running request @ key "k" (queuedWriters: 2, queuedReaders: 0)
-[3] sequence reqTxnMiddle: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 1.23s
+[3] sequence reqTxnMiddle: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 1.234s
 [3] sequence reqTxnMiddle: pushing txn 00000001 to detect request deadlock
 [3] sequence reqTxnMiddle: blocked on select in concurrency_test.(*cluster).PushTransaction
 [4] sequence reqTxn2: resolving intent "k" for txn 00000002 with COMMITTED status
 [4] sequence reqTxn2: lock wait-queue event: wait self @ key "k"
-[4] sequence reqTxn2: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 1.23s
+[4] sequence reqTxn2: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 1.234s
 [4] sequence reqTxn2: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
 debug-lock-table
@@ -111,12 +111,12 @@ finish req=reqTxn1
 ----
 [-] finish reqTxn1: finishing request
 [3] sequence reqTxnMiddle: lock wait-queue event: done waiting
-[3] sequence reqTxnMiddle: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.23s
+[3] sequence reqTxnMiddle: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
 [3] sequence reqTxnMiddle: acquiring latches
 [3] sequence reqTxnMiddle: scanning lock table for conflicting locks
 [3] sequence reqTxnMiddle: sequencing complete, returned guard
 [4] sequence reqTxn2: lock wait-queue event: wait for (distinguished) txn 00000003 running request @ key "k" (queuedWriters: 1, queuedReaders: 0)
-[4] sequence reqTxn2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.23s
+[4] sequence reqTxn2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
 [4] sequence reqTxn2: pushing txn 00000003 to detect request deadlock
 [4] sequence reqTxn2: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -124,7 +124,7 @@ finish req=reqTxnMiddle
 ----
 [-] finish reqTxnMiddle: finishing request
 [4] sequence reqTxn2: lock wait-queue event: done waiting
-[4] sequence reqTxn2: conflicted with 00000003-0000-0000-0000-000000000000 on "k" for 1.23s
+[4] sequence reqTxn2: conflicted with 00000003-0000-0000-0000-000000000000 on "k" for 1.234s
 [4] sequence reqTxn2: acquiring latches
 [4] sequence reqTxn2: scanning lock table for conflicting locks
 [4] sequence reqTxn2: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_self
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_self
@@ -47,6 +47,7 @@ sequence req=reqTxn1
 [2] sequence reqTxn1: acquiring latches
 [2] sequence reqTxn1: scanning lock table for conflicting locks
 [2] sequence reqTxn1: waiting in lock wait-queues
+[2] sequence reqTxn1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "k" (queuedWriters: 1, queuedReaders: 0)
 [2] sequence reqTxn1: pushing txn 00000002 to abort
 [2] sequence reqTxn1: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -56,6 +57,7 @@ sequence req=reqTxnMiddle
 [3] sequence reqTxnMiddle: acquiring latches
 [3] sequence reqTxnMiddle: scanning lock table for conflicting locks
 [3] sequence reqTxnMiddle: waiting in lock wait-queues
+[3] sequence reqTxnMiddle: lock wait-queue event: wait for txn 00000002 holding lock @ key "k" (queuedWriters: 2, queuedReaders: 0)
 [3] sequence reqTxnMiddle: pushing txn 00000002 to abort
 [3] sequence reqTxnMiddle: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -65,6 +67,7 @@ sequence req=reqTxn2
 [4] sequence reqTxn2: acquiring latches
 [4] sequence reqTxn2: scanning lock table for conflicting locks
 [4] sequence reqTxn2: waiting in lock wait-queues
+[4] sequence reqTxn2: lock wait-queue event: wait for txn 00000002 holding lock @ key "k" (queuedWriters: 3, queuedReaders: 0)
 [4] sequence reqTxn2: pushing txn 00000002 to abort
 [4] sequence reqTxn2: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -72,15 +75,18 @@ on-txn-updated txn=txnOld status=committed
 ----
 [-] update txn: committing txnOld
 [2] sequence reqTxn1: resolving intent "k" for txn 00000002 with COMMITTED status
+[2] sequence reqTxn1: lock wait-queue event: done waiting
 [2] sequence reqTxn1: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 1.23s
 [2] sequence reqTxn1: acquiring latches
 [2] sequence reqTxn1: scanning lock table for conflicting locks
 [2] sequence reqTxn1: sequencing complete, returned guard
 [3] sequence reqTxnMiddle: resolving intent "k" for txn 00000002 with COMMITTED status
+[3] sequence reqTxnMiddle: lock wait-queue event: wait for (distinguished) txn 00000001 running request @ key "k" (queuedWriters: 2, queuedReaders: 0)
 [3] sequence reqTxnMiddle: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 1.23s
 [3] sequence reqTxnMiddle: pushing txn 00000001 to detect request deadlock
 [3] sequence reqTxnMiddle: blocked on select in concurrency_test.(*cluster).PushTransaction
 [4] sequence reqTxn2: resolving intent "k" for txn 00000002 with COMMITTED status
+[4] sequence reqTxn2: lock wait-queue event: wait self @ key "k"
 [4] sequence reqTxn2: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 1.23s
 [4] sequence reqTxn2: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
@@ -104,10 +110,12 @@ local: num=0
 finish req=reqTxn1
 ----
 [-] finish reqTxn1: finishing request
+[3] sequence reqTxnMiddle: lock wait-queue event: done waiting
 [3] sequence reqTxnMiddle: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.23s
 [3] sequence reqTxnMiddle: acquiring latches
 [3] sequence reqTxnMiddle: scanning lock table for conflicting locks
 [3] sequence reqTxnMiddle: sequencing complete, returned guard
+[4] sequence reqTxn2: lock wait-queue event: wait for (distinguished) txn 00000003 running request @ key "k" (queuedWriters: 1, queuedReaders: 0)
 [4] sequence reqTxn2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.23s
 [4] sequence reqTxn2: pushing txn 00000003 to detect request deadlock
 [4] sequence reqTxn2: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -115,6 +123,7 @@ finish req=reqTxn1
 finish req=reqTxnMiddle
 ----
 [-] finish reqTxnMiddle: finishing request
+[4] sequence reqTxn2: lock wait-queue event: done waiting
 [4] sequence reqTxn2: conflicted with 00000003-0000-0000-0000-000000000000 on "k" for 1.23s
 [4] sequence reqTxn2: acquiring latches
 [4] sequence reqTxn2: scanning lock table for conflicting locks

--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -1529,7 +1529,7 @@ func (r *JoinNodeResponse) CreateStoreIdent() (StoreIdent, error) {
 
 // SafeFormat implements redact.SafeFormatter.
 func (c *ContentionEvent) SafeFormat(w redact.SafePrinter, _ rune) {
-	w.Printf("conflicted with %s on %s for %.2fs", c.TxnMeta.ID, c.Key, c.Duration.Seconds())
+	w.Printf("conflicted with %s on %s for %.3fs", c.TxnMeta.ID, c.Key, c.Duration.Seconds())
 }
 
 // String implements fmt.Stringer.

--- a/pkg/roachpb/api_test.go
+++ b/pkg/roachpb/api_test.go
@@ -257,6 +257,6 @@ func TestContentionEvent_SafeFormat(t *testing.T) {
 		Key:     Key("foo"),
 		TxnMeta: enginepb.TxnMeta{ID: uuid.FromStringOrNil("51b5ef6a-f18f-4e85-bc3f-c44e33f2bb27")},
 	}
-	const exp = redact.RedactableString(`conflicted with ‹51b5ef6a-f18f-4e85-bc3f-c44e33f2bb27› on ‹"foo"› for 0.00s`)
+	const exp = redact.RedactableString(`conflicted with ‹51b5ef6a-f18f-4e85-bc3f-c44e33f2bb27› on ‹"foo"› for 0.000s`)
 	require.Equal(t, exp, redact.Sprint(ce))
 }


### PR DESCRIPTION
This PR improves tracing around various aspects of contention and conflict resolution. This provides better observability into places where a request/transaction may block on the progress of another request/transaction.

The best way to visualize the impact of these changes is to look at the effect they had on the `pkg/kv/kvserver/concurrency/testdata/concurrency_manager` datadriven files.

#### kv: add trace events to lock wait-queue state transitions

This change adds trace events to each state transition observed by the ockTableWaiter while waiting on a collection of lockWaitQueues. This provides increased observability into the behavior of lock wait-queues on contended keys, including information about queue depth.

#### kv: add trace events to latch manager

This change adds trace events to the latch manager, indicating when a latch acquisition blocks on a currently held latch. This provides increased observability into blocking within the latch manager.

#### roachpb: print millisecond resolution in ContentionEvents

This commit updates ContentionEvent formatting to print with millisecond resolution, instead of truncating the output to 10ms resolution.

/cc @cockroachdb/kv 