### PR TITLE
schemaexpr: remove unnecessary structs

### DIFF
--- a/pkg/sql/add_column.go
+++ b/pkg/sql/add_column.go
@@ -157,13 +157,9 @@ func (p *planner) addColumnImpl(
 	}
 
 	if d.IsComputed() {
-		computedColValidator := schemaexpr.MakeComputedColumnValidator(
-			params.ctx,
-			n.tableDesc,
-			&params.p.semaCtx,
-			tn,
+		serializedExpr, err := schemaexpr.ValidateComputedColumnExpression(
+			params.ctx, n.tableDesc, d, tn, params.p.SemaCtx(),
 		)
-		serializedExpr, err := computedColValidator.Validate(d)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -497,13 +497,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 			}
 
 			// We cannot remove this column if there are computed columns that use it.
-			computedColValidator := schemaexpr.MakeComputedColumnValidator(
-				params.ctx,
-				n.tableDesc,
-				&params.p.semaCtx,
-				tn,
-			)
-			if err := computedColValidator.ValidateNoDependents(colToDrop); err != nil {
+			if err := schemaexpr.ValidateColumnHasNoDependents(n.tableDesc, colToDrop); err != nil {
 				return err
 			}
 

--- a/pkg/sql/catalog/schemaexpr/partial_index_test.go
+++ b/pkg/sql/catalog/schemaexpr/partial_index_test.go
@@ -38,8 +38,6 @@ func TestIndexPredicateValidator_Validate(t *testing.T) {
 		[]testCol{{"c", types.String}},
 	)
 
-	validator := schemaexpr.MakeIndexPredicateValidator(ctx, tn, desc, &semaCtx)
-
 	testData := []struct {
 		expr          string
 		expectedValid bool
@@ -91,7 +89,9 @@ func TestIndexPredicateValidator_Validate(t *testing.T) {
 				t.Fatalf("%s: unexpected error: %s", d.expr, err)
 			}
 
-			deqExpr, err := validator.Validate(expr)
+			deqExpr, err := schemaexpr.ValidatePartialIndexPredicate(
+				ctx, desc, expr, &tn, &semaCtx,
+			)
 
 			if !d.expectedValid {
 				if err == nil {

--- a/pkg/sql/catalog/tabledesc/table.go
+++ b/pkg/sql/catalog/tabledesc/table.go
@@ -104,6 +104,11 @@ func MakeColumnDefDescs(
 	}
 
 	if d.IsComputed() {
+		// Note: We do not validate the computed column expression here because
+		// it may reference columns that have not yet been added to a table
+		// descriptor. Callers must validate the expression with
+		// schemaexpr.ValidateComputedColumnExpression once all possible
+		// reference columns are part of the table descriptor.
 		s := tree.Serialize(d.Computed.Expr)
 		col.ComputeExpr = &s
 	}

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -242,8 +242,9 @@ func MakeIndexDescriptor(
 	}
 
 	if n.Predicate != nil {
-		idxValidator := schemaexpr.MakeIndexPredicateValidator(params.ctx, n.Table, tableDesc, &params.p.semaCtx)
-		expr, err := idxValidator.Validate(n.Predicate)
+		expr, err := schemaexpr.ValidatePartialIndexPredicate(
+			params.ctx, tableDesc, n.Predicate, &n.Table, params.p.SemaCtx(),
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -2290,17 +2290,13 @@ func NewTableDesc(
 
 	// Now that we have all the other columns set up, we can validate
 	// any computed columns.
-	computedColValidator := schemaexpr.MakeComputedColumnValidator(
-		ctx,
-		&desc,
-		semaCtx,
-		&n.Table,
-	)
 	for _, def := range n.Defs {
 		switch d := def.(type) {
 		case *tree.ColumnTableDef:
 			if d.IsComputed() {
-				serializedExpr, err := computedColValidator.Validate(d)
+				serializedExpr, err := schemaexpr.ValidateComputedColumnExpression(
+					ctx, &desc, d, &n.Table, semaCtx,
+				)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1879,7 +1879,6 @@ func NewTableDesc(
 		return newColumns, nil
 	}
 
-	idxValidator := schemaexpr.MakeIndexPredicateValidator(ctx, n.Table, &desc, semaCtx)
 	for _, def := range n.Defs {
 		switch d := def.(type) {
 		case *tree.ColumnTableDef, *tree.LikeTableDef:
@@ -1964,7 +1963,9 @@ func NewTableDesc(
 				}
 			}
 			if d.Predicate != nil {
-				expr, err := idxValidator.Validate(d.Predicate)
+				expr, err := schemaexpr.ValidatePartialIndexPredicate(
+					ctx, &desc, d.Predicate, &n.Table, semaCtx,
+				)
 				if err != nil {
 					return nil, err
 				}
@@ -2061,7 +2062,9 @@ func NewTableDesc(
 				}
 			}
 			if d.Predicate != nil {
-				expr, err := idxValidator.Validate(d.Predicate)
+				expr, err := schemaexpr.ValidatePartialIndexPredicate(
+					ctx, &desc, d.Predicate, &n.Table, semaCtx,
+				)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/sql/schemachanger/scbuild/table.go
+++ b/pkg/sql/schemachanger/scbuild/table.go
@@ -132,13 +132,9 @@ func (b *buildContext) alterTableAddColumn(
 	if d.IsComputed() {
 		// TODO (lucy): This is not going to work when the computed column
 		// references columns created in the same transaction.
-		computedColValidator := schemaexpr.MakeComputedColumnValidator(
-			ctx,
-			table,
-			b.SemaCtx,
-			tn,
+		serializedExpr, err := schemaexpr.ValidateComputedColumnExpression(
+			ctx, table, d, tn, b.SemaCtx,
 		)
-		serializedExpr, err := computedColValidator.Validate(d)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
#### schemaexpr: remove ComputedColumnValidator struct

This commit removes `schemaexpr.ComputedColumnValidator`. The struct's
methods did not store any state in the struct, so they have been
converted to functions without a receiver.

Release note: None

#### schemaexpr: remove IndexPredicateValidator struct

This commit removes `schemaexpr.IndexPredicateValidator`. The struct's
methods did not store any state in the struct, so they have been
converted to functions without a receiver.

Release note: None
