### PR TITLE
backupccl: pipeline opening iterators during RESTORE

### DIFF
--- a/pkg/ccl/backupccl/restore_data_processor.go
+++ b/pkg/ccl/backupccl/restore_data_processor.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
 	"github.com/cockroachdb/cockroach/pkg/kv/bulk"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
@@ -22,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
@@ -39,14 +41,31 @@ type restoreDataProcessor struct {
 	input   execinfra.RowSource
 	output  execinfra.RowReceiver
 
-	alloc rowenc.DatumAlloc
-	kr    *KeyRewriter
+	kr *KeyRewriter
+
+	// numWorkers is decide at processor start time. It controls the size of
+	// channels and the number of parallel workers sending AddSSTable requests in
+	// parallel.
+	numWorkers int
+	progCh     chan RestoreProgress
+	// Metas from the input are sent to the workers on this channel.
+	metaCh chan *execinfrapb.ProducerMetadata
+
+	// phaseGroup runs each phase of the pipelined restore process in a separate
+	// goroutine.
+	phaseGroup ctxgroup.Group
 }
 
 var _ execinfra.Processor = &restoreDataProcessor{}
 var _ execinfra.RowSource = &restoreDataProcessor{}
 
 const restoreDataProcName = "restoreDataProcessor"
+
+var numWorkersSetting = settings.RegisterIntSetting(
+	"kv.bulk_io_write.restore_node_concurrency",
+	"the number of workers per node processing a restore job",
+	1,
+)
 
 func newRestoreDataProcessor(
 	flowCtx *execinfra.FlowCtx,
@@ -56,11 +75,15 @@ func newRestoreDataProcessor(
 	input execinfra.RowSource,
 	output execinfra.RowReceiver,
 ) (execinfra.Processor, error) {
+	numWorkers := numWorkersSetting.Get(&flowCtx.EvalCtx.Settings.SV)
+
 	rd := &restoreDataProcessor{
 		flowCtx: flowCtx,
 		input:   input,
 		spec:    spec,
 		output:  output,
+		progCh:  make(chan RestoreProgress, numWorkers),
+		metaCh:  make(chan *execinfrapb.ProducerMetadata, 1),
 	}
 
 	var err error
@@ -72,6 +95,10 @@ func newRestoreDataProcessor(
 	if err := rd.Init(rd, post, restoreDataOutputTypes, flowCtx, processorID, output, nil, /* memMonitor */
 		execinfra.ProcStateOpts{
 			InputsToDrain: []execinfra.RowSource{input},
+			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {
+				rd.ConsumerClosed()
+				return nil
+			},
 		}); err != nil {
 		return nil, err
 	}
@@ -82,6 +109,104 @@ func newRestoreDataProcessor(
 func (rd *restoreDataProcessor) Start(ctx context.Context) {
 	ctx = rd.StartInternal(ctx, restoreDataProcName)
 	rd.input.Start(ctx)
+
+	rd.phaseGroup = ctxgroup.WithContext(ctx)
+	entries := make(chan execinfrapb.RestoreSpanEntry, rd.numWorkers)
+	rd.phaseGroup.GoCtx(func(ctx context.Context) error {
+		defer close(entries)
+		return inputReader(ctx, rd.input, entries, rd.metaCh)
+	})
+
+	rd.phaseGroup.GoCtx(func(ctx context.Context) error {
+		defer close(rd.progCh)
+		return rd.runRestoreWorkers(entries)
+	})
+}
+
+func inputReader(
+	ctx context.Context,
+	input execinfra.RowSource,
+	entries chan execinfrapb.RestoreSpanEntry,
+	metaCh chan *execinfrapb.ProducerMetadata,
+) error {
+	var alloc rowenc.DatumAlloc
+
+	for {
+		// We read rows from the SplitAndScatter processor. We expect each row to
+		// contain 2 columns. The first is used to route the row to this processor,
+		// and the second contains the RestoreSpanEntry that we're interested in.
+		row, meta := input.Next()
+		if meta != nil {
+			if meta.Err != nil {
+				return meta.Err
+			}
+
+			select {
+			case metaCh <- meta:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+			continue
+		}
+
+		if row == nil {
+			// Consumed all rows.
+			return nil
+		}
+
+		if len(row) != 2 {
+			return errors.New("expected input rows to have exactly 2 columns")
+		}
+		if err := row[1].EnsureDecoded(types.Bytes, &alloc); err != nil {
+			return err
+		}
+		datum := row[1].Datum
+		entryDatumBytes, ok := datum.(*tree.DBytes)
+		if !ok {
+			return errors.AssertionFailedf(`unexpected datum type %T: %+v`, datum, row)
+		}
+
+		var entry execinfrapb.RestoreSpanEntry
+		if err := protoutil.Unmarshal([]byte(*entryDatumBytes), &entry); err != nil {
+			return errors.Wrap(err, "un-marshaling restore span entry")
+		}
+
+		select {
+		case entries <- entry:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+func (rd *restoreDataProcessor) runRestoreWorkers(entries chan execinfrapb.RestoreSpanEntry) error {
+	numWorkers := numWorkersSetting.Get(&rd.flowCtx.EvalCtx.Settings.SV)
+
+	return ctxgroup.GroupWorkers(rd.Ctx, int(numWorkers), func(ctx context.Context, n int) error {
+		for entry := range entries {
+			newSpanKey, err := rewriteBackupSpanKey(rd.flowCtx.Codec(), rd.kr, entry.Span.Key)
+			if err != nil {
+				return errors.Wrap(err, "re-writing span key to import")
+			}
+
+			summary, err := rd.processRestoreSpanEntry(entry, newSpanKey)
+			if err != nil {
+				return err
+			}
+
+			progDetails := RestoreProgress{}
+			progDetails.Summary = countRows(summary, rd.spec.PKIDs)
+			progDetails.ProgressIdx = entry.ProgressIdx
+			progDetails.DataSpan = entry.Span
+			select {
+			case rd.progCh <- progDetails:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+
+		return nil
+	})
 }
 
 // Next is part of the RowSource interface.
@@ -89,61 +214,45 @@ func (rd *restoreDataProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.Produce
 	if rd.State != execinfra.StateRunning {
 		return nil, rd.DrainHelper()
 	}
-	// We read rows from the SplitAndScatter processor. We expect each row to
-	// contain 2 columns. The first is used to route the row to this processor,
-	// and the second contains the RestoreSpanEntry that we're interested in.
-	row, meta := rd.input.Next()
-	if meta != nil {
-		if meta.Err != nil {
-			rd.MoveToDraining(nil /* err */)
-		}
-		return nil, meta
-	}
-	if row == nil {
-		rd.MoveToDraining(nil /* err */)
-		return nil, rd.DrainHelper()
-	}
-
-	if len(row) != 2 {
-		rd.MoveToDraining(errors.New("expected input rows to have exactly 2 columns"))
-		return nil, rd.DrainHelper()
-	}
-	if err := row[1].EnsureDecoded(types.Bytes, &rd.alloc); err != nil {
-		rd.MoveToDraining(err)
-		return nil, rd.DrainHelper()
-	}
-	datum := row[1].Datum
-	entryDatumBytes, ok := datum.(*tree.DBytes)
-	if !ok {
-		rd.MoveToDraining(errors.AssertionFailedf(`unexpected datum type %T: %+v`, datum, row))
-		return nil, rd.DrainHelper()
-	}
-
-	var entry execinfrapb.RestoreSpanEntry
-	if err := protoutil.Unmarshal([]byte(*entryDatumBytes), &entry); err != nil {
-		rd.MoveToDraining(errors.Wrap(err, "un-marshaling restore span entry"))
-		return nil, rd.DrainHelper()
-	}
-
-	log.VEventf(rd.Ctx, 1 /* level */, "ingesting span [%s-%s)", entry.Span.Key, entry.Span.EndKey)
-	summary, err := rd.processRestoreSpanEntry(entry)
-	if err != nil {
-		rd.MoveToDraining(err)
-		return nil, rd.DrainHelper()
-	}
 
 	var prog execinfrapb.RemoteProducerMetadata_BulkProcessorProgress
-	progDetails := RestoreProgress{}
-	progDetails.Summary = countRows(summary, rd.spec.PKIDs)
-	progDetails.ProgressIdx = entry.ProgressIdx
-	progDetails.DataSpan = entry.Span
-	details, err := gogotypes.MarshalAny(&progDetails)
-	if err != nil {
-		rd.MoveToDraining(err)
+
+	select {
+	case progDetails, ok := <-rd.progCh:
+		if !ok {
+			// Done. Check if workers exited early with an error.
+			err := rd.phaseGroup.Wait()
+			rd.MoveToDraining(err)
+			return nil, rd.DrainHelper()
+		}
+
+		details, err := gogotypes.MarshalAny(&progDetails)
+		if err != nil {
+			rd.MoveToDraining(err)
+			return nil, rd.DrainHelper()
+		}
+		prog.ProgressDetails = *details
+	case meta := <-rd.metaCh:
+		if meta == nil {
+			// We should not be sending nil metas of rd.metaCh.
+			log.Warningf(rd.Ctx, "unexpected nil meta")
+		}
+		return nil, meta
+	case <-rd.Ctx.Done():
+		rd.MoveToDraining(rd.Ctx.Err())
 		return nil, rd.DrainHelper()
 	}
-	prog.ProgressDetails = *details
+
 	return nil, &execinfrapb.ProducerMetadata{BulkProcessorProgress: &prog}
+}
+
+// ConsumerClosed is part of the RowSource interface.
+func (rd *restoreDataProcessor) ConsumerClosed() {
+	if rd.InternalClose() {
+		if rd.metaCh != nil {
+			close(rd.metaCh)
+		}
+	}
 }
 
 func init() {


### PR DESCRIPTION
Tracing revealed that restore data processors were spending a
considerable amount of time just opening iterators to backup SSTs,
rather than ingesting it. This PR builds on top of parallelization
changes in RESTORE which enables concurrent AddSSTable requests, and
pipelines the opening of the iterators.

Release note: None
