### PR TITLE
tree: mark whether OPERATOR is used in UnaryExpr

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -250,7 +250,7 @@ func (b *Builder) buildUnary(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.T
 		return nil, err
 	}
 	operator := opt.UnaryOpReverseMap[scalar.Op()]
-	return tree.NewTypedUnaryExpr(operator, input, scalar.DataType()), nil
+	return tree.NewTypedUnaryExpr(tree.MakeUnaryOperator(operator), input, scalar.DataType()), nil
 }
 
 func (b *Builder) buildBinary(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.TypedExpr, error) {

--- a/pkg/sql/opt/operator.go
+++ b/pkg/sql/opt/operator.go
@@ -169,7 +169,7 @@ var BinaryOpReverseMap = map[Operator]tree.BinaryOperator{
 
 // UnaryOpReverseMap maps from an optimizer operator type to a semantic tree
 // unary operator type.
-var UnaryOpReverseMap = map[Operator]tree.UnaryOperator{
+var UnaryOpReverseMap = map[Operator]tree.UnaryOperatorSymbol{
 	UnaryMinusOp:      tree.UnaryMinus,
 	UnaryComplementOp: tree.UnaryComplement,
 	UnarySqrtOp:       tree.UnarySqrt,

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -765,7 +765,7 @@ func (b *Builder) constructBinary(
 func (b *Builder) constructUnary(
 	un tree.UnaryOperator, input opt.ScalarExpr, typ *types.T,
 ) opt.ScalarExpr {
-	switch un {
+	switch un.Symbol {
 	case tree.UnaryMinus:
 		return b.factory.ConstructUnaryMinus(input)
 	case tree.UnaryComplement:

--- a/pkg/sql/parser/parse.go
+++ b/pkg/sql/parser/parse.go
@@ -228,7 +228,10 @@ func unaryNegation(e tree.Expr) tree.Expr {
 	}
 
 	// Common case.
-	return &tree.UnaryExpr{Operator: tree.UnaryMinus, Expr: e}
+	return &tree.UnaryExpr{
+		Operator: tree.MakeUnaryOperator(tree.UnaryMinus),
+		Expr:     e,
+	}
 }
 
 // Parse parses a sql statement string and returns a list of Statements.

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -207,8 +207,8 @@ func TestParsePrecedence(t *testing.T) {
 	//   9: AND
 	//  10: OR
 
-	unary := func(op tree.UnaryOperator, expr tree.Expr) tree.Expr {
-		return &tree.UnaryExpr{Operator: op, Expr: expr}
+	unary := func(op tree.UnaryOperatorSymbol, expr tree.Expr) tree.Expr {
+		return &tree.UnaryExpr{Operator: tree.MakeUnaryOperator(op), Expr: expr}
 	}
 	binary := func(op tree.BinaryOperator, left, right tree.Expr) tree.Expr {
 		return &tree.BinaryExpr{Operator: op, Left: left, Right: right}

--- a/pkg/sql/parser/testdata/parse/select_exprs
+++ b/pkg/sql/parser/testdata/parse/select_exprs
@@ -1635,7 +1635,15 @@ SELECT 1 << 2, 1 << 2 -- identifiers removed
 parse
 SELECT OPERATOR(+) 1, OPERATOR(-) 1, OPERATOR(~) 1, OPERATOR(|/) 1, OPERATOR(||/) 1
 ----
-SELECT 1, -1, ~1, |/1, ||/1 -- normalized!
-SELECT (1), (-1), (~(1)), (|/(1)), (||/(1)) -- fully parenthetized
-SELECT _, _, ~_, |/_, ||/_ -- literals removed
-SELECT 1, -1, ~1, |/1, ||/1 -- identifiers removed
+SELECT 1, -1, OPERATOR(~)1, OPERATOR(|/)1, OPERATOR(||/)1 -- normalized!
+SELECT (1), (-1), (OPERATOR(~)(1)), (OPERATOR(|/)(1)), (OPERATOR(||/)(1)) -- fully parenthetized
+SELECT _, _, OPERATOR(~)_, OPERATOR(|/)_, OPERATOR(||/)_ -- literals removed
+SELECT 1, -1, OPERATOR(~)1, OPERATOR(|/)1, OPERATOR(||/)1 -- identifiers removed
+
+parse
+SELECT OPERATOR ( ~ ) 1 COLLATE ident AS ILIKE FROM ident
+----
+SELECT OPERATOR(~)1 COLLATE ident AS ilike FROM ident -- normalized!
+SELECT (OPERATOR(~)((1) COLLATE ident)) AS ilike FROM ident -- fully parenthetized
+SELECT OPERATOR(~)_ COLLATE ident AS ilike FROM ident -- literals removed
+SELECT OPERATOR(~)1 COLLATE ident AS _ FROM _ -- identifiers removed

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -108,7 +108,9 @@ func (*UnaryOp) preferred() bool {
 	return false
 }
 
-func unaryOpFixups(ops map[UnaryOperator]unaryOpOverload) map[UnaryOperator]unaryOpOverload {
+func unaryOpFixups(
+	ops map[UnaryOperatorSymbol]unaryOpOverload,
+) map[UnaryOperatorSymbol]unaryOpOverload {
 	for op, overload := range ops {
 		for i, impl := range overload {
 			casted := impl.(*UnaryOp)
@@ -124,7 +126,7 @@ func unaryOpFixups(ops map[UnaryOperator]unaryOpOverload) map[UnaryOperator]unar
 type unaryOpOverload []overloadImpl
 
 // UnaryOps contains the unary operations indexed by operation type.
-var UnaryOps = unaryOpFixups(map[UnaryOperator]unaryOpOverload{
+var UnaryOps = unaryOpFixups(map[UnaryOperatorSymbol]unaryOpOverload{
 	UnaryMinus: {
 		&UnaryOp{
 			Typ:        types.Int,

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -103,7 +103,7 @@ type Operator interface {
 	operator()
 }
 
-var _ Operator = UnaryOperator(0)
+var _ Operator = (*UnaryOperator)(nil)
 var _ Operator = BinaryOperator(0)
 var _ Operator = ComparisonOperator(0)
 
@@ -1254,22 +1254,41 @@ func (node *BinaryExpr) Format(ctx *FmtCtx) {
 	binExprFmtWithParen(ctx, node.Left, node.Operator.String(), node.Right, node.Operator.isPadded())
 }
 
-// UnaryOperator represents a unary operator.
-type UnaryOperator int
+// UnaryOperator represents a unary operator used in a UnaryExpr.
+type UnaryOperator struct {
+	Symbol UnaryOperatorSymbol
+	// IsOperator is true if OPERATOR(symbol) is used.
+	IsOperator bool
+}
+
+// MakeUnaryOperator creates a UnaryOperator given a symbol.
+func MakeUnaryOperator(symbol UnaryOperatorSymbol) UnaryOperator {
+	return UnaryOperator{Symbol: symbol}
+}
+
+func (o UnaryOperator) String() string {
+	if o.IsOperator {
+		return fmt.Sprintf("OPERATOR(%s)", o.Symbol.String())
+	}
+	return o.Symbol.String()
+}
 
 func (UnaryOperator) operator() {}
 
-// UnaryExpr.Operator
+// UnaryOperatorSymbol represents a unary operator.
+type UnaryOperatorSymbol int
+
+// UnaryExpr.Operator.Symbol
 const (
-	UnaryMinus UnaryOperator = iota
+	UnaryMinus UnaryOperatorSymbol = iota
 	UnaryComplement
 	UnarySqrt
 	UnaryCbrt
 
-	NumUnaryOperators
+	NumUnaryOperatorSymbols
 )
 
-var _ = NumUnaryOperators
+var _ = NumUnaryOperatorSymbols
 
 var unaryOpName = [...]string{
 	UnaryMinus:      "-",
@@ -1278,8 +1297,8 @@ var unaryOpName = [...]string{
 	UnaryCbrt:       "||/",
 }
 
-func (i UnaryOperator) String() string {
-	if i < 0 || i > UnaryOperator(len(unaryOpName)-1) {
+func (i UnaryOperatorSymbol) String() string {
+	if i < 0 || i > UnaryOperatorSymbol(len(unaryOpName)-1) {
 		return fmt.Sprintf("UnaryOp(%d)", i)
 	}
 	return unaryOpName[i]
@@ -1303,7 +1322,7 @@ func (node *UnaryExpr) Format(ctx *FmtCtx) {
 	_, isOp := e.(operatorExpr)
 	_, isDatum := e.(Datum)
 	_, isConstant := e.(Constant)
-	if isOp || (node.Operator == UnaryMinus && (isDatum || isConstant)) {
+	if isOp || (node.Operator.Symbol == UnaryMinus && (isDatum || isConstant)) {
 		ctx.WriteByte('(')
 		ctx.FormatNode(e)
 		ctx.WriteByte(')')
@@ -1322,14 +1341,14 @@ func NewTypedUnaryExpr(op UnaryOperator, expr TypedExpr, typ *types.T) *UnaryExp
 	node := &UnaryExpr{Operator: op, Expr: expr}
 	node.typ = typ
 	innerType := expr.ResolvedType()
-	for _, o := range UnaryOps[op] {
+	for _, o := range UnaryOps[op.Symbol] {
 		o := o.(*UnaryOp)
 		if innerType.Equivalent(o.Typ) && node.typ.Equivalent(o.ReturnType) {
 			node.fn = o
 			return node
 		}
 	}
-	panic(errors.AssertionFailedf("invalid TypedExpr with unary op %d: %s", op, expr))
+	panic(errors.AssertionFailedf("invalid TypedExpr with unary op %d: %s", op.Symbol, expr))
 }
 
 // FuncExpr represents a function call.

--- a/pkg/sql/sem/tree/normalize.go
+++ b/pkg/sql/sem/tree/normalize.go
@@ -84,7 +84,7 @@ func (expr *UnaryExpr) normalize(v *NormalizeVisitor) TypedExpr {
 		return val
 	}
 
-	switch expr.Operator {
+	switch expr.Operator.Symbol {
 	case UnaryMinus:
 		// -0 -> 0 (except for float which has negative zero)
 		if val.ResolvedType().Family() != types.FloatFamily && v.isNumericZero(val) {
@@ -104,7 +104,7 @@ func (expr *UnaryExpr) normalize(v *NormalizeVisitor) TypedExpr {
 			}
 		// - (- a) -> a
 		case *UnaryExpr:
-			if b.Operator == UnaryMinus {
+			if b.Operator.Symbol == UnaryMinus {
 				return b.TypedInnerExpr()
 			}
 		}

--- a/pkg/sql/sem/tree/operators_test.go
+++ b/pkg/sql/sem/tree/operators_test.go
@@ -131,7 +131,7 @@ func TestOperatorVolatilityMatchesPostgres(t *testing.T) {
 
 	// Check unary ops. We don't just go through the map so we process them in
 	// an orderly fashion.
-	for op := UnaryOperator(0); op < NumUnaryOperators; op++ {
+	for op := UnaryOperatorSymbol(0); op < NumUnaryOperatorSymbols; op++ {
 		for _, impl := range UnaryOps[op] {
 			o := impl.(*UnaryOp)
 			check(op.String(), nil /* leftType */, o.Typ, o.Volatility)

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -1323,7 +1323,7 @@ func (expr *Subquery) TypeCheck(_ context.Context, sc *SemaContext, _ *types.T) 
 func (expr *UnaryExpr) TypeCheck(
 	ctx context.Context, semaCtx *SemaContext, desired *types.T,
 ) (TypedExpr, error) {
-	ops := UnaryOps[expr.Operator]
+	ops := UnaryOps[expr.Operator.Symbol]
 
 	typedSubExprs, fns, err := typeCheckOverloadedExprs(ctx, semaCtx, desired, ops, false, expr.Expr)
 	if err != nil {


### PR DESCRIPTION
Seems like there's some weird parenthesising thing happening
with OPERATOR such that it is worth storing whether OPERATOR
was used in tree.UnaryExpr.

This commit changes UnaryOperator to be composed of UnaryOperatorSymbol
(the former usage of UnaryOperator) and IsOperator to do so.

Resolves #65078 - not sure whether we need to do Comparison/BinaryExpr.

Release note: None