### PR TITLE
sql: minor fixes to fix panics related to type resolution and bad planner usage

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -46,6 +46,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
+	"github.com/lib/pq/oid"
 )
 
 // execStmt executes one statement by dispatching according to the current
@@ -521,8 +522,9 @@ func (ex *connExecutor) execStmtInOpenState(
 			},
 			ex.generateID(),
 		)
+		var rawTypeHints []oid.Oid
 		if _, err := ex.addPreparedStmt(
-			ctx, name, prepStmt, typeHints, PreparedStatementOriginSQL,
+			ctx, name, prepStmt, typeHints, rawTypeHints, PreparedStatementOriginSQL,
 		); err != nil {
 			return makeErrEvent(err)
 		}

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1106,7 +1106,17 @@ func (ex *connExecutor) beginTransactionTimestampsAndReadMode(
 	}
 	ex.statsCollector.reset(&ex.server.sqlStats, ex.appStats, &ex.phaseTimes)
 	p := &ex.planner
-	ex.resetPlanner(ctx, p, nil /* txn */, now)
+
+	// NB: this use of p.txn is totally bogus. The planner's txn should
+	// definitely be finalized at this point. We preserve it here because we
+	// need to make sure that the planner's txn is not made to be nil in the
+	// case of an error below. The planner's txn is never written to nil at
+	// any other point after the first prepare or exec has been run. We abuse
+	// this transaction in bind and some other contexts for resolving types and
+	// oids. Avoiding set this to nil side-steps a nil pointer panic but is still
+	// awful. Instead we ought to clear the planner state when we clear the reset
+	// the connExecutor in finishTxn.
+	ex.resetPlanner(ctx, p, p.txn, now)
 	ts, err := p.EvalAsOfTimestamp(ctx, asOf)
 	if err != nil {
 		return 0, time.Time{}, nil, err

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -49,36 +49,13 @@ func (ex *connExecutor) execPrepare(
 		ex.deletePreparedStmt(ctx, "")
 	}
 
-	// If we were provided any type hints, attempt to resolve any user defined
-	// type OIDs into types.T's.
-	if parseCmd.TypeHints != nil {
-		for i := range parseCmd.TypeHints {
-			if parseCmd.TypeHints[i] == nil {
-				if i >= len(parseCmd.RawTypeHints) {
-					return retErr(
-						pgwirebase.NewProtocolViolationErrorf(
-							"expected %d arguments, got %d",
-							len(parseCmd.TypeHints),
-							len(parseCmd.RawTypeHints),
-						),
-					)
-				}
-				if types.IsOIDUserDefinedType(parseCmd.RawTypeHints[i]) {
-					var err error
-					parseCmd.TypeHints[i], err = ex.planner.ResolveTypeByOID(ctx, parseCmd.RawTypeHints[i])
-					if err != nil {
-						return retErr(err)
-					}
-				}
-			}
-		}
-	}
 	stmt := makeStatement(parseCmd.Statement, ex.generateID())
 	ps, err := ex.addPreparedStmt(
 		ctx,
 		parseCmd.Name,
 		stmt,
 		parseCmd.TypeHints,
+		parseCmd.RawTypeHints,
 		PreparedStatementOriginWire,
 	)
 	if err != nil {
@@ -115,12 +92,15 @@ func (ex *connExecutor) execPrepare(
 // also returned. It is illegal to call this when a statement with that name
 // already exists (even for anonymous prepared statements).
 //
-// placeholderHints are used to assist in inferring placeholder types.
+// placeholderHints are used to assist in inferring placeholder types. The
+// rawTypeHints are optional and represent OIDs indicated for the placeholders
+// coming from the client via the wire protocol.
 func (ex *connExecutor) addPreparedStmt(
 	ctx context.Context,
 	name string,
 	stmt Statement,
 	placeholderHints tree.PlaceholderTypes,
+	rawTypeHints []oid.Oid,
 	origin PreparedStatementOrigin,
 ) (*PreparedStatement, error) {
 	if _, ok := ex.extraTxnState.prepStmtsNamespace.prepStmts[name]; ok {
@@ -128,7 +108,7 @@ func (ex *connExecutor) addPreparedStmt(
 	}
 
 	// Prepare the query. This completes the typing of placeholders.
-	prepared, err := ex.prepare(ctx, stmt, placeholderHints, origin)
+	prepared, err := ex.prepare(ctx, stmt, placeholderHints, rawTypeHints, origin)
 	if err != nil {
 		return nil, err
 	}
@@ -151,18 +131,11 @@ func (ex *connExecutor) prepare(
 	ctx context.Context,
 	stmt Statement,
 	placeholderHints tree.PlaceholderTypes,
+	rawTypeHints []oid.Oid,
 	origin PreparedStatementOrigin,
 ) (*PreparedStatement, error) {
-	if placeholderHints == nil {
-		placeholderHints = make(tree.PlaceholderTypes, stmt.NumPlaceholders)
-	}
 
 	prepared := &PreparedStatement{
-		PrepareMetadata: querycache.PrepareMetadata{
-			PlaceholderTypesInfo: tree.PlaceholderTypesInfo{
-				TypeHints: placeholderHints,
-			},
-		},
 		memAcc:   ex.sessionMon.MakeBoundAccount(),
 		refCount: 1,
 
@@ -175,16 +148,6 @@ func (ex *connExecutor) prepare(
 
 	if stmt.AST == nil {
 		return prepared, nil
-	}
-	prepared.Statement = stmt.Statement
-	prepared.AnonymizedStr = stmt.AnonymizedStr
-
-	// Point to the prepared state, which can be further populated during query
-	// preparation.
-	stmt.Prepared = prepared
-
-	if err := tree.ProcessPlaceholderAnnotations(&ex.planner.semaCtx, stmt.AST, placeholderHints); err != nil {
-		return nil, err
 	}
 
 	// Preparing needs a transaction because it needs to retrieve db/table
@@ -209,6 +172,48 @@ func (ex *connExecutor) prepare(
 			// instrumentation.
 			ex.resetPlanner(ctx, p, txn, ex.server.cfg.Clock.PhysicalTime() /* stmtTS */)
 		}
+
+		if placeholderHints == nil {
+			placeholderHints = make(tree.PlaceholderTypes, stmt.NumPlaceholders)
+		} else if rawTypeHints != nil {
+			// If we were provided any type hints, attempt to resolve any user defined
+			// type OIDs into types.T's.
+			for i := range placeholderHints {
+				if placeholderHints[i] == nil {
+					if i >= len(rawTypeHints) {
+						return pgwirebase.NewProtocolViolationErrorf(
+							"expected %d arguments, got %d",
+							len(placeholderHints),
+							len(rawTypeHints),
+						)
+					}
+					if types.IsOIDUserDefinedType(rawTypeHints[i]) {
+						var err error
+						placeholderHints[i], err = ex.planner.ResolveTypeByOID(ctx, rawTypeHints[i])
+						if err != nil {
+							return err
+						}
+					}
+				}
+			}
+		}
+
+		prepared.PrepareMetadata = querycache.PrepareMetadata{
+			PlaceholderTypesInfo: tree.PlaceholderTypesInfo{
+				TypeHints: placeholderHints,
+			},
+		}
+		prepared.Statement = stmt.Statement
+		prepared.AnonymizedStr = stmt.AnonymizedStr
+
+		// Point to the prepared state, which can be further populated during query
+		// preparation.
+		stmt.Prepared = prepared
+
+		if err := tree.ProcessPlaceholderAnnotations(&ex.planner.semaCtx, stmt.AST, placeholderHints); err != nil {
+			return err
+		}
+
 		p.stmt = stmt
 		p.semaCtx.Annotations = tree.MakeAnnotations(stmt.NumAnnotations)
 		flags, err = ex.populatePrepared(ctx, txn, placeholderHints, p)

--- a/pkg/sql/pgwire/testdata/pgtest/bind_and_resolve
+++ b/pkg/sql/pgwire/testdata/pgtest/bind_and_resolve
@@ -1,0 +1,70 @@
+# Test binding calls which reference names via either types or oid casts work
+# after a bizarre turn of events whereby we used to set the planner txn to nil.
+# The long and the short of it is that we totally abuse the planner when
+# performing BIND and the fact that it continues to carry a transaction that
+# does not correspond to the connExecutor's transaction is, generally, a big
+# problem. Before the changes made in the commit adding this test, this test
+# would result in a nil pointer panic.
+
+send
+Query {"String": "CREATE TABLE t (a INT PRIMARY KEY)"}
+----
+
+until
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"CREATE TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+
+# 83 = ASCII 'S' for Statement
+# 84 = ASCII 'T'
+# ParameterFormatCodes = [0] for text format
+send
+Parse {"Name": "s7", "Query": "SELECT $1::REGCLASS::INT8"}
+Describe {"ObjectType": 83, "Name": "s7"}
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"ParameterDescription","ParameterOIDs":[2205]}
+{"Type":"RowDescription","Fields":[{"Name":"int8","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":20,"DataTypeSize":8,"TypeModifier":-1,"Format":0}]}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# The below incantation used to trigger a code path which would nil the
+# planner transaction but never set it. This was pretty much the only
+# way you could do such a thing.
+
+send
+Query {"String": "BEGIN AS OF SYSTEM TIME '1s'"}
+Sync
+----
+
+
+# TODO(ajwerner): Why are there two ReadyForQuery?
+
+until
+ErrorResponse
+ReadyForQuery
+ReadyForQuery
+----
+{"Type":"ErrorResponse","Code":"XXUUU"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Bind {"DestinationPortal": "p7", "PreparedStatement": "s7", "ParameterFormatCodes": [0], "Parameters": [[84]]}
+Execute {"Portal": "p7"}
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"BindComplete"}
+{"Type":"DataRow","Values":[{"text":"52"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/sql/pgwire/testdata/pgtest/enum
+++ b/pkg/sql/pgwire/testdata/pgtest/enum
@@ -1,5 +1,23 @@
 # This test verifies some of the pgwire encoding process for ENUMs.
 
+# Demonstrate that attempting to prepare a query which hints a user-defined
+# type as the very first thing on a new connection does not cause a panic.
+# Prior to the change which introduced this test logic, the below prepare
+# would hit a nil-pointer panic.
+
+send crdb_only
+Parse {"Name": "s1", "Query": "SELECT $1", "ParameterOIDs": [100052]}
+Sync
+----
+
+until crdb_only
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"ErrorResponse","Code":"42704"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+
 # Prepare the environment.
 send noncrdb_only
 Query {"String": "DROP TYPE IF EXISTS te CASCADE"}


### PR DESCRIPTION
See individual commits. The first commit matters but does not leave one with a good feeling. The second one is more copacetic.

Relates to #64140. 

Fixes #64975.

Release note (bug fix): Fixed a bug which could cause a panic when
running a EXECUTE of a previously PREPARE'd statement with a REGCLASS,
REGTYPE parameter or a user-defined type argument after running BEGIN
AS OF SYSTEM TIME with an invalid timestamp.

Release note (bug fix): Fixed a bug which could cause a panic when issuing
a query referencing a user-defined type as a placeholder as the first operation
on a new connection.