### PR TITLE
storage: fix go1.16 incompatibility on release20.2

### DIFF
--- a/pkg/storage/batch_test.go
+++ b/pkg/storage/batch_test.go
@@ -209,12 +209,12 @@ func TestReadOnlyBasics(t *testing.T) {
 				}
 				shouldPanic(t, func() { ro.Close() }, "Close", "closing an already-closed "+name)
 				for i, f := range successTestCases {
-					shouldPanic(t, f, string(i), "using a closed "+name)
+					shouldPanic(t, f, fmt.Sprint(i), "using a closed "+name)
 				}
 			}()
 
 			for i, f := range successTestCases {
-				shouldNotPanic(t, f, string(i))
+				shouldNotPanic(t, f, fmt.Sprint(i))
 			}
 
 			// For a read-only ReadWriter, all Writer methods should panic.
@@ -227,7 +227,7 @@ func TestReadOnlyBasics(t *testing.T) {
 				func() { _ = ro.Put(a, nil) },
 			}
 			for i, f := range failureTestCases {
-				shouldPanic(t, f, string(i), "not implemented")
+				shouldPanic(t, f, fmt.Sprint(i), "not implemented")
 			}
 
 			if err := e.Put(mvccKey("a"), []byte("value")); err != nil {


### PR DESCRIPTION
Converting int to string doesn't produce string with number but produces
a rune which is not what is intended. Such conversion is forbidden in
go1.16 so this changes makes in compilable with newer versions of go.

Release note: None