### PR TITLE
release-21.1: storage: fix usage of in-memory size attribute

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -161,10 +161,13 @@ type TestClusterArgs struct {
 }
 
 var (
-	// DefaultTestStoreSpec is just a single in memory store of 100 MiB
+	// DefaultTestStoreSpec is just a single in memory store of 512 MiB
 	// with no special attributes.
 	DefaultTestStoreSpec = StoreSpec{
 		InMemory: true,
+		Size: SizeSpec{
+			InBytes: 512 << 20,
+		},
 	}
 )
 

--- a/pkg/kv/kvserver/client_metrics_test.go
+++ b/pkg/kv/kvserver/client_metrics_test.go
@@ -232,12 +232,13 @@ func TestStoreMetrics(t *testing.T) {
 		base.TestClusterArgs{
 			ReplicationMode: base.ReplicationManual,
 			ServerArgs: base.TestServerArgs{
+				CacheSize: 1 << 20, /* 1 MiB */
 				StoreSpecs: []base.StoreSpec{
 					{
 						InMemory: true,
 						// Specify a size to trigger the BlockCache in Pebble.
 						Size: base.SizeSpec{
-							InBytes: 1 << 20,
+							InBytes: 512 << 20, /* 512 MiB */
 						},
 					},
 				},

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -930,7 +930,12 @@ func SendEmptySnapshot(
 ) error {
 	// Create an engine to use as a buffer for the empty snapshot.
 	eng := storage.NewInMem(
-		context.Background(), roachpb.Attributes{}, 1<<20, nil /* settings */)
+		context.Background(),
+		roachpb.Attributes{},
+		1<<20,   /* cacheSize 1MiB */
+		512<<20, /* storeSize 512 MiB */
+		nil,     /* settings */
+	)
 	defer eng.Close()
 
 	var ms enginepb.MVCCStats

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -509,13 +509,13 @@ func (cfg *Config) CreateEngines(ctx context.Context) (Engines, error) {
 						"engine no registry available. Please use " +
 						"Knobs.Server.StickyEngineRegistry to provide one.")
 				}
-				e, err := knobs.StickyEngineRegistry.GetOrCreateStickyInMemEngine(ctx, spec)
+				e, err := knobs.StickyEngineRegistry.GetOrCreateStickyInMemEngine(ctx, cfg, spec)
 				if err != nil {
 					return Engines{}, err
 				}
 				engines = append(engines, e)
 			} else {
-				engines = append(engines, storage.NewInMem(ctx, spec.Attributes, sizeInBytes, cfg.Settings))
+				engines = append(engines, storage.NewInMem(ctx, spec.Attributes, cfg.CacheSize, sizeInBytes, cfg.Settings))
 			}
 		} else {
 			if spec.Size.Percent > 0 {

--- a/pkg/server/settings_cache_test.go
+++ b/pkg/server/settings_cache_test.go
@@ -43,8 +43,8 @@ func TestCachedSettingsStoreAndLoad(t *testing.T) {
 
 	ctx := context.Background()
 	attrs := roachpb.Attributes{}
-	cacheSize := int64(1 << 20)
-	engine := storage.NewInMemForTesting(ctx, attrs, cacheSize)
+	storeSize := int64(512 << 20) /* 512 MiB */
+	engine := storage.NewInMemForTesting(ctx, attrs, storeSize)
 	defer engine.Close()
 
 	require.NoError(t, storeCachedSettingsKVs(ctx, engine, testSettings))

--- a/pkg/server/sticky_engine.go
+++ b/pkg/server/sticky_engine.go
@@ -46,9 +46,7 @@ type StickyInMemEnginesRegistry interface {
 	// Note that if you re-create an existing sticky engine the new attributes
 	// and cache size will be ignored.
 	// One must Close() on the sticky engine before another can be fetched.
-	GetOrCreateStickyInMemEngine(
-		ctx context.Context, spec base.StoreSpec,
-	) (storage.Engine, error)
+	GetOrCreateStickyInMemEngine(ctx context.Context, cfg *Config, spec base.StoreSpec) (storage.Engine, error)
 	// CloseAllStickyInMemEngines closes all sticky in memory engines that were
 	// created by this registry.
 	CloseAllStickyInMemEngines()
@@ -86,7 +84,7 @@ func NewStickyInMemEnginesRegistry() StickyInMemEnginesRegistry {
 
 // GetOrCreateStickyInMemEngine implements the StickyInMemEnginesRegistry interface.
 func (registry *stickyInMemEnginesRegistryImpl) GetOrCreateStickyInMemEngine(
-	ctx context.Context, spec base.StoreSpec,
+	ctx context.Context, cfg *Config, spec base.StoreSpec,
 ) (storage.Engine, error) {
 	registry.mu.Lock()
 	defer registry.mu.Unlock()
@@ -110,7 +108,7 @@ func (registry *stickyInMemEnginesRegistryImpl) GetOrCreateStickyInMemEngine(
 		// create a random one since that is what we like to do in tests (for
 		// better test coverage).
 		Engine: storage.NewInMem(
-			ctx, spec.Attributes, spec.Size.InBytes, storage.MakeRandomSettingsForSeparatedIntents()),
+			ctx, spec.Attributes, cfg.CacheSize, spec.Size.InBytes, storage.MakeRandomSettingsForSeparatedIntents()),
 	}
 	registry.entries[spec.StickyInMemoryEngineID] = engine
 	return engine, nil

--- a/pkg/storage/batch_test.go
+++ b/pkg/storage/batch_test.go
@@ -1100,7 +1100,13 @@ func TestDecodeKey(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	e := newPebbleInMem(context.Background(), roachpb.Attributes{}, 1<<20, nil /* settings */)
+	e := newPebbleInMem(
+		context.Background(),
+		roachpb.Attributes{},
+		1<<20,   /* cacheSize */
+		512<<20, /* storeSize */
+		nil,     /* settings */
+	)
 	defer e.Close()
 
 	tests := []MVCCKey{

--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -1503,7 +1503,14 @@ func TestSupportsPrev(t *testing.T) {
 		})
 	}
 	t.Run("pebble", func(t *testing.T) {
-		eng := newPebbleInMem(context.Background(), roachpb.Attributes{}, 1<<20, nil /* settings */)
+
+		eng := newPebbleInMem(
+			context.Background(),
+			roachpb.Attributes{},
+			1<<20,   /* cacheSize */
+			512<<20, /* storeSize */
+			nil,     /* settings */
+		)
 		defer eng.Close()
 		runTest(t, eng, engineTest{
 			engineIterSupportsPrev:   true,
@@ -1627,7 +1634,13 @@ func TestScanSeparatedIntents(t *testing.T) {
 	for name, enableSeparatedIntents := range map[string]bool{"interleaved": false, "separated": true} {
 		t.Run(name, func(t *testing.T) {
 			settings := makeSettingsForSeparatedIntents(false, enableSeparatedIntents)
-			eng := newPebbleInMem(ctx, roachpb.Attributes{}, 1<<20, settings)
+			eng := newPebbleInMem(
+				ctx,
+				roachpb.Attributes{},
+				1<<20,   /* cacheSize */
+				512<<20, /* storeSize */
+				settings,
+			)
 			defer eng.Close()
 
 			for _, key := range keys {

--- a/pkg/storage/in_mem.go
+++ b/pkg/storage/in_mem.go
@@ -25,9 +25,12 @@ import (
 //
 // FIXME(tschottdorf): make the signature similar to NewPebble (require a cfg).
 func NewInMem(
-	ctx context.Context, attrs roachpb.Attributes, cacheSize int64, settings *cluster.Settings,
+	ctx context.Context,
+	attrs roachpb.Attributes,
+	cacheSize, storeSize int64,
+	settings *cluster.Settings,
 ) Engine {
-	return newPebbleInMem(ctx, attrs, cacheSize, settings)
+	return newPebbleInMem(ctx, attrs, cacheSize, storeSize, settings)
 }
 
 // The ForTesting functions randomize the settings for separated intents. This
@@ -43,9 +46,9 @@ func NewInMem(
 
 // NewInMemForTesting allocates and returns a new, opened in-memory engine. The caller
 // must call the engine's Close method when the engine is no longer needed.
-func NewInMemForTesting(ctx context.Context, attrs roachpb.Attributes, cacheSize int64) Engine {
+func NewInMemForTesting(ctx context.Context, attrs roachpb.Attributes, storeSize int64) Engine {
 	settings := MakeRandomSettingsForSeparatedIntents()
-	return newPebbleInMem(ctx, attrs, cacheSize, settings)
+	return newPebbleInMem(ctx, attrs, 0 /* cacheSize */, storeSize, settings)
 }
 
 // NewDefaultInMemForTesting allocates and returns a new, opened in-memory engine with

--- a/pkg/storage/multi_iterator_test.go
+++ b/pkg/storage/multi_iterator_test.go
@@ -27,7 +27,13 @@ func TestMultiIterator(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	pebble := newPebbleInMem(context.Background(), roachpb.Attributes{}, 1<<20, nil /* settings */)
+	pebble := newPebbleInMem(
+		context.Background(),
+		roachpb.Attributes{},
+		1<<20,   /* cacheSize */
+		512<<20, /* storeSize */
+		nil,     /* settings */
+	)
 	defer pebble.Close()
 
 	// Each `input` is turned into an iterator and these are passed to a new

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -85,7 +85,13 @@ func createTestPebbleEngine() Engine {
 }
 
 func createTestPebbleEngineWithSettings(settings *cluster.Settings) Engine {
-	return newPebbleInMem(context.Background(), roachpb.Attributes{}, 1<<20, settings)
+	return newPebbleInMem(
+		context.Background(),
+		roachpb.Attributes{},
+		1<<20,   /* cacheSize */
+		512<<20, /* storeSize */
+		settings,
+	)
 }
 
 // TODO(sumeer): the following is legacy from when we had multiple engine

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -576,7 +576,10 @@ func NewPebble(ctx context.Context, cfg PebbleConfig) (*Pebble, error) {
 }
 
 func newPebbleInMem(
-	ctx context.Context, attrs roachpb.Attributes, cacheSize int64, settings *cluster.Settings,
+	ctx context.Context,
+	attrs roachpb.Attributes,
+	cacheSize, storeSize int64,
+	settings *cluster.Settings,
 ) *Pebble {
 	opts := DefaultPebbleOptions()
 	opts.Cache = pebble.NewCache(cacheSize)
@@ -587,10 +590,8 @@ func newPebbleInMem(
 		ctx,
 		PebbleConfig{
 			StorageConfig: base.StorageConfig{
-				Attrs: attrs,
-				// TODO(bdarnell): The hard-coded 512 MiB is wrong; see
-				// https://github.com/cockroachdb/cockroach/issues/16750
-				MaxSize:  512 << 20, /* 512 MiB */
+				Attrs:    attrs,
+				MaxSize:  storeSize,
 				Settings: settings,
 			},
 			Opts: opts,

--- a/pkg/storage/pebble_test.go
+++ b/pkg/storage/pebble_test.go
@@ -424,7 +424,13 @@ func TestPebbleDiskSlowEmit(t *testing.T) {
 
 	settings := cluster.MakeTestingClusterSettings()
 	MaxSyncDurationFatalOnExceeded.Override(&settings.SV, false)
-	p := newPebbleInMem(context.Background(), roachpb.Attributes{}, 1<<20, settings)
+	p := newPebbleInMem(
+		context.Background(),
+		roachpb.Attributes{},
+		1<<20,   /* cacheSize */
+		512<<20, /* storeSize */
+		settings,
+	)
 	defer p.Close()
 
 	require.Equal(t, uint64(0), p.diskSlowCount)

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -133,8 +133,13 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initFacto
 	clusterID := &cfg.RPCContext.ClusterID
 	server := rpc.NewServer(cfg.RPCContext) // never started
 	ltc.Gossip = gossip.New(ambient, clusterID, nc, cfg.RPCContext, server, ltc.stopper, metric.NewRegistry(), roachpb.Locality{}, zonepb.DefaultZoneConfigRef())
-	ltc.Eng = storage.NewInMem(ambient.AnnotateCtx(context.Background()), roachpb.Attributes{},
-		50<<20, storage.MakeRandomSettingsForSeparatedIntents())
+	ltc.Eng = storage.NewInMem(
+		ambient.AnnotateCtx(context.Background()),
+		roachpb.Attributes{},
+		0,      /* cacheSize */
+		50<<20, /* storeSize */
+		storage.MakeRandomSettingsForSeparatedIntents(),
+	)
 	ltc.stopper.AddCloser(ltc.Eng)
 
 	ltc.Stores = kvserver.NewStores(ambient, ltc.Clock)


### PR DESCRIPTION
Backport 1/1 commits from #64095.

/cc @cockroachdb/release

---

fixes #16750

The size parameter is supposed to set the size of the store, but it was
setting the size of the cache.

When it was harmless, I made the cacheSize 0, but for non-test code or
tests that relied on the cache, I made sure the actual cache/store sizes
matched what was there before this commit.

I stumbled into this issue since my team is planning to recommend
in-memory testing more to people who want to run their application's unit
tests against CockroachDB.

Release note: None
