### PR TITLE
cli/flags.go: fix typo in comment

### DIFF
--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -999,7 +999,7 @@ const (
 // registerEnvVarDefault registers a deferred initialization of a flag
 // from an environment variable.
 // The caller is responsible for ensuring that the flagInfo has been
-// efined in the FlagSet already.
+// defined in the FlagSet already.
 func registerEnvVarDefault(f *pflag.FlagSet, flagInfo cliflags.FlagInfo) {
 	if flagInfo.EnvVar == "" {
 		return


### PR DESCRIPTION
Thanks to @stevendanna for spotting this.