### PR TITLE
blobs: provide io.Writer API for steaming blob writes

### DIFF
--- a/pkg/blobs/bench_test.go
+++ b/pkg/blobs/bench_test.go
@@ -13,6 +13,7 @@ package blobs
 import (
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -22,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/errors"
 )
 
 // filesize should be at least 1 GB when running these benchmarks.
@@ -88,8 +90,14 @@ func benchmarkStreamingReadFile(b *testing.B, tc *benchmarkTestCase) {
 		if err != nil {
 			b.Fatal(err)
 		}
-		err = writeTo.WriteFile(tc.fileName, reader)
+		w, err := writeTo.Writer(tc.fileName)
 		if err != nil {
+			b.Fatal(err)
+		}
+		if _, err := io.Copy(w, reader); err != nil {
+			b.Fatal(errors.CombineErrors(err, w.CloseWithError(err)))
+		}
+		if err := w.Close(); err != nil {
 			b.Fatal(err)
 		}
 		stat, err := writeTo.Stat(tc.fileName)
@@ -134,8 +142,14 @@ func benchmarkStreamingWriteFile(b *testing.B, tc *benchmarkTestCase) {
 	b.ResetTimer()
 	b.SetBytes(tc.fileSize)
 	for i := 0; i < b.N; i++ {
-		err := tc.blobClient.WriteFile(context.Background(), tc.fileName, bytes.NewReader(content))
+		w, err := tc.blobClient.Writer(context.Background(), tc.fileName)
 		if err != nil {
+			b.Fatal(err)
+		}
+		if _, err := io.Copy(w, bytes.NewReader(content)); err != nil {
+			b.Fatal(errors.CombineErrors(err, w.CloseWithError(err)))
+		}
+		if err := w.Close(); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/pkg/blobs/client.go
+++ b/pkg/blobs/client.go
@@ -22,6 +22,14 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
+// WriteCloserWithError extends WriteCloser with an extra CloseWithError func.
+type WriteCloserWithError interface {
+	io.WriteCloser
+	// CloseWithError closes the writer with an error, which may choose to abort
+	// rather than complete any write operations.
+	CloseWithError(error) error
+}
+
 // BlobClient provides an interface for file access on all nodes' local storage.
 // Given the nodeID of the node on which the operation should occur, the a blob
 // client should be able to find the correct node and call its blob service API.
@@ -31,10 +39,8 @@ type BlobClient interface {
 	// read the contents.
 	ReadFile(ctx context.Context, file string, offset int64) (io.ReadCloser, int64, error)
 
-	// WriteFile sends the named payload to the requested node.
-	// This method will read entire content of file and send
-	// it over to another node, based on the nodeID.
-	WriteFile(ctx context.Context, file string, content io.Reader) error
+	// Writer opens the named payload on the requested node for writing.
+	Writer(ctx context.Context, file string) (WriteCloserWithError, error)
 
 	// List lists the corresponding filenames from the requested node.
 	// The requested node can be the current node.
@@ -75,20 +81,52 @@ func (c *remoteClient) ReadFile(
 	return newGetStreamReader(stream), st.Filesize, errors.Wrap(err, "fetching file")
 }
 
-func (c *remoteClient) WriteFile(ctx context.Context, file string, content io.Reader) (err error) {
+type streamWriter struct {
+	s      blobspb.Blob_PutStreamClient
+	buf    blobspb.StreamChunk
+	cancel func()
+}
+
+func (w *streamWriter) Write(p []byte) (int, error) {
+	n := 0
+	for len(p) > 0 {
+		l := copy(w.buf.Payload[:cap(w.buf.Payload)], p)
+		w.buf.Payload = w.buf.Payload[:l]
+		p = p[l:]
+		if l > 0 {
+			if err := w.s.Send(&w.buf); err != nil {
+				return n, err
+			}
+		}
+		n += l
+	}
+	return n, nil
+}
+
+func (w *streamWriter) Close() error {
+	_, err := w.s.CloseAndRecv()
+	w.cancel()
+	return err
+}
+
+func (w *streamWriter) CloseWithError(err error) error {
+	if err == nil {
+		return w.Close()
+	}
+	w.cancel()
+	return nil
+}
+
+func (c *remoteClient) Writer(ctx context.Context, file string) (WriteCloserWithError, error) {
 	ctx = metadata.AppendToOutgoingContext(ctx, "filename", file)
+	ctx, cancel := context.WithCancel(ctx)
 	stream, err := c.blobClient.PutStream(ctx)
 	if err != nil {
-		return
+		cancel()
+		return nil, err
 	}
-	defer func() {
-		_, closeErr := stream.CloseAndRecv()
-		if err == nil {
-			err = closeErr
-		}
-	}()
-	err = streamContent(stream, content)
-	return
+	buf := make([]byte, 0, chunkSize)
+	return &streamWriter{s: stream, buf: blobspb.StreamChunk{Payload: buf}, cancel: cancel}, nil
 }
 
 func (c *remoteClient) List(ctx context.Context, pattern string) ([]string, error) {
@@ -141,8 +179,8 @@ func (c *localClient) ReadFile(
 	return c.localStorage.ReadFile(file, offset)
 }
 
-func (c *localClient) WriteFile(ctx context.Context, file string, content io.Reader) error {
-	return c.localStorage.WriteFile(file, content)
+func (c *localClient) Writer(ctx context.Context, file string) (WriteCloserWithError, error) {
+	return c.localStorage.Writer(file)
 }
 
 func (c *localClient) List(ctx context.Context, pattern string) ([]string, error) {

--- a/pkg/blobs/client_test.go
+++ b/pkg/blobs/client_test.go
@@ -14,6 +14,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net"
 	"os"
@@ -250,7 +251,17 @@ func TestBlobClientWriteFile(t *testing.T) {
 				t.Fatal(err)
 			}
 			byteContent := []byte(tc.fileContent)
-			err = blobClient.WriteFile(ctx, tc.filename, bytes.NewReader(byteContent))
+
+			err = func() error {
+				w, err := blobClient.Writer(ctx, tc.filename)
+				if err != nil {
+					return err
+				}
+				if _, err := io.Copy(w, bytes.NewReader(byteContent)); err != nil {
+					return errors.CombineErrors(err, w.CloseWithError(err))
+				}
+				return w.Close()
+			}()
 			if err != nil {
 				if testutils.IsError(err, tc.err) {
 					// correct error was returned

--- a/pkg/blobs/local_storage.go
+++ b/pkg/blobs/local_storage.go
@@ -64,16 +64,48 @@ func (l *LocalStorage) prependExternalIODir(path string) (string, error) {
 	return localBase, nil
 }
 
-// WriteFile prepends IO dir to filename and writes the content to that local file.
-func (l *LocalStorage) WriteFile(filename string, content io.Reader) (err error) {
+type localWriter struct {
+	f         *os.File
+	tmp, dest string
+}
+
+func (l localWriter) Write(p []byte) (int, error) {
+	return l.f.Write(p)
+}
+
+func (l localWriter) Close() error {
+	syncErr := l.f.Sync()
+	closeErr := l.f.Close()
+	if err := errors.CombineErrors(closeErr, syncErr); err != nil {
+		return err
+	}
+	// Finally put the file to its final location.
+	return errors.Wrapf(
+		fileutil.Move(l.tmp, l.dest),
+		"moving temporary file to final location %q",
+		l.dest,
+	)
+}
+
+func (l localWriter) CloseWithError(err error) error {
+	if err == nil {
+		return l.Close()
+	}
+	closeErr := l.f.Close()
+	rmErr := os.Remove(l.tmp)
+	return errors.CombineErrors(rmErr, closeErr)
+}
+
+// Writer prepends IO dir to filename and writes the content to that local file.
+func (l *LocalStorage) Writer(filename string) (WriteCloserWithError, error) {
 	fullPath, err := l.prependExternalIODir(filename)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	targetDir := filepath.Dir(fullPath)
 	if err = os.MkdirAll(targetDir, 0755); err != nil {
-		return errors.Wrapf(err, "creating target local directory %q", targetDir)
+		return nil, errors.Wrapf(err, "creating target local directory %q", targetDir)
 	}
 
 	// We generate the temporary file in the desired target directory.
@@ -87,45 +119,9 @@ func (l *LocalStorage) WriteFile(filename string, content io.Reader) (err error)
 	// what the "*" in the suffix means.
 	tmpFile, err := ioutil.TempFile(targetDir, filepath.Base(fullPath)+"*.tmp")
 	if err != nil {
-		return errors.Wrap(err, "creating temporary file")
+		return nil, errors.Wrap(err, "creating temporary file")
 	}
-	tmpFileFullName := tmpFile.Name()
-	defer func() {
-		if err != nil {
-			// When an error occurs, we need to clean up the newly created
-			// temporary file.
-			_ = os.Remove(tmpFileFullName)
-			//
-			// TODO(someone): in the special case where an attempt is made
-			// to upload to a sub-directory of the ext i/o dir for the first
-			// time (MkdirAll above did create the sub-directory), and the
-			// copy/rename fails, we're now left with a newly created but empty
-			// sub-directory.
-			//
-			// We cannot safely remove that target directory here, because
-			// perhaps there is another concurrent operation that is also
-			// targeting it. A more principled approach could be to use a
-			// mutex lock on directory accesses, and/or occasionally prune
-			// empty sub-directories upon node start-ups.
-		}
-	}()
-
-	// Copy the data into the temp file. We use a closure here to
-	// ensure the temp file is closed after the copy is done.
-	if err = func() error {
-		defer tmpFile.Close()
-		if _, err := io.Copy(tmpFile, content); err != nil {
-			return errors.Wrapf(err, "writing to temporary file %q", tmpFileFullName)
-		}
-		return errors.Wrapf(tmpFile.Sync(), "flushing temporary file %q", tmpFileFullName)
-	}(); err != nil {
-		return err
-	}
-
-	// Finally put the file to its final location.
-	return errors.Wrapf(
-		fileutil.Move(tmpFileFullName, fullPath),
-		"moving temporary file to final location %q", fullPath)
+	return localWriter{tmp: tmpFile.Name(), dest: fullPath, f: tmpFile}, nil
 }
 
 // ReadFile prepends IO dir to filename and reads the content of that local file.

--- a/pkg/sql/pgwire/testdata/pgtest/copy_file_upload
+++ b/pkg/sql/pgwire/testdata/pgtest/copy_file_upload
@@ -16,7 +16,6 @@ until crdb_only
 ErrorResponse
 ReadyForQuery
 ----
-{"Type":"CopyInResponse","ColumnFormatCodes":[0]}
 {"Type":"ErrorResponse","Code":"XXUUU"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 

--- a/pkg/storage/cloud/nodelocal/nodelocal_storage.go
+++ b/pkg/storage/cloud/nodelocal/nodelocal_storage.go
@@ -131,10 +131,7 @@ func joinRelativePath(filePath string, file string) string {
 func (l *localFileStorage) Writer(
 	ctx context.Context, basename string,
 ) (cloud.WriteCloserWithError, error) {
-	// TODO(dt): don't need this pipe.
-	return cloud.BackgroundPipe(ctx, func(ctx context.Context, r io.Reader) error {
-		return l.blobClient.WriteFile(ctx, joinRelativePath(l.base, basename), r)
-	}), nil
+	return l.blobClient.Writer(ctx, joinRelativePath(l.base, basename))
 }
 
 // ReadFile is shorthand for ReadFileAt with offset 0.


### PR DESCRIPTION
This changes the API for the blob service's Write method from one which
takes a Reader and writes its content to one which provides a Writer and
leaves it to the caller to write to it. This allows the nodelocal
ExternalStorage implementation to expose the blob writer directly rather
than spin up an extra goroutine run this blob stream off a pipe to yeild
a writer.

Release note: none.