### PR TITLE
sql: fixed information_schema.columns.data_type for enum type columns

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -3792,25 +3792,26 @@ other_db       public        t2          d            2
 statement ok
 SET DATABASE = test
 
-# Testing udt_type at information_schema.columns
+# Testing udt_type at information_schema.columns and data_type
 statement ok
 CREATE DATABASE enum_db;
 SET DATABASE = enum_db;
 CREATE SCHEMA sh;
 CREATE TYPE e AS ENUM ('a', 'b');
 CREATE TYPE sh.d AS ENUM('x', 'y');
-CREATE TABLE t (e e, d sh.d);
+CREATE TABLE t (e e, d sh.d, a e[]);
 
-query TT colnames
-select udt_schema, udt_name
+query TTT colnames
+select udt_schema, udt_name, data_type
 from information_schema.columns
 where table_name = 't'
 ORDER BY udt_name
 ----
-udt_schema  udt_name
-sh          d
-public      e
-pg_catalog  int8
+udt_schema  udt_name  data_type
+public      _e        ARRAY
+sh          d         USER-DEFINED
+public      e         USER-DEFINED
+pg_catalog  int8      bigint
 
 # Testing information_schema.columns.is_identity which for now is False for every column
 statement ok

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -1637,6 +1637,10 @@ func (t *T) InformationSchemaName() string {
 	if t.Family() == ArrayFamily {
 		return "ARRAY"
 	}
+	// TypeMeta attributes are populated only when it is user defined type.
+	if t.TypeMeta.Name != nil {
+		return "USER-DEFINED"
+	}
 	return t.SQLStandardName()
 }
 


### PR DESCRIPTION
Previously, information_schema.columns.data_type returned the name of
the user defined types
This was inadequate because for postgres compatibility, this kind of
types it is expected to have "USER-DEFINED"
To address this, this patch changes the value for data_type column to
"USER-DEFINED" when the data type is ENUM (or any user defined)

Release note (sql change): information_schema.columns.data_type now
returns "USER-DEFINED" when the column is a user defined type (Like
ENUM)

Fixes #64433