### PR TITLE
kvserver: fix TestRejectedLeaseDoesntDictateClosedTimestamp 

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -71,11 +71,11 @@ const (
 	// used by the rpc context.
 	defaultRPCHeartbeatInterval = 3 * time.Second
 
-	// rangeLeaseRenewalFraction specifies what fraction the range lease
+	// defaultRangeLeaseRenewalFraction specifies what fraction the range lease
 	// renewal duration should be of the range lease active time. For example,
 	// with a value of 0.2 and a lease duration of 10 seconds, leases would be
 	// eagerly renewed 8 seconds into each lease.
-	rangeLeaseRenewalFraction = 0.5
+	defaultRangeLeaseRenewalFraction = 0.5
 
 	// livenessRenewalFraction specifies what fraction the node liveness
 	// renewal duration should be of the node liveness duration. For example,
@@ -317,6 +317,13 @@ type RaftConfig struct {
 	// RangeLeaseRaftElectionTimeoutMultiplier specifies what multiple the leader
 	// lease active duration should be of the raft election timeout.
 	RangeLeaseRaftElectionTimeoutMultiplier float64
+	// RangeLeaseRenewalFraction specifies what fraction the range lease renewal
+	// duration should be of the range lease active time. For example, with a
+	// value of 0.2 and a lease duration of 10 seconds, leases would be eagerly
+	// renewed 8 seconds into each lease. A value of zero means use the default
+	// and a value of -1 means never pre-emptively renew the lease. A value of 1
+	// means always renew.
+	RangeLeaseRenewalFraction float64
 
 	// RaftLogTruncationThreshold controls how large a single Range's Raft log
 	// can grow. When a Range's Raft log grows above this size, the Range will
@@ -384,6 +391,15 @@ func (cfg *RaftConfig) SetDefaults() {
 	if cfg.RangeLeaseRaftElectionTimeoutMultiplier == 0 {
 		cfg.RangeLeaseRaftElectionTimeoutMultiplier = defaultRangeLeaseRaftElectionTimeoutMultiplier
 	}
+	if cfg.RangeLeaseRenewalFraction == 0 {
+		cfg.RangeLeaseRenewalFraction = defaultRangeLeaseRenewalFraction
+	}
+	// TODO(andrei): -1 is a special value for RangeLeaseRenewalFraction which
+	// really means "0" (never renew), except that the zero value means "use
+	// default". We can't turn the -1 into 0 here because, unfortunately,
+	// SetDefaults is called multiple times (see NewStore()). So, we leave -1
+	// alone and ask all the users to handle it specially.
+
 	if cfg.RaftLogTruncationThreshold == 0 {
 		cfg.RaftLogTruncationThreshold = defaultRaftLogTruncationThreshold
 	}
@@ -438,7 +454,11 @@ func (cfg RaftConfig) RaftElectionTimeout() time.Duration {
 func (cfg RaftConfig) RangeLeaseDurations() (rangeLeaseActive, rangeLeaseRenewal time.Duration) {
 	rangeLeaseActive = time.Duration(cfg.RangeLeaseRaftElectionTimeoutMultiplier *
 		float64(cfg.RaftElectionTimeout()))
-	rangeLeaseRenewal = time.Duration(float64(rangeLeaseActive) * rangeLeaseRenewalFraction)
+	renewalFraction := cfg.RangeLeaseRenewalFraction
+	if renewalFraction == -1 {
+		renewalFraction = 0
+	}
+	rangeLeaseRenewal = time.Duration(float64(rangeLeaseActive) * renewalFraction)
 	return
 }
 

--- a/pkg/kv/kvserver/replica_closedts_test.go
+++ b/pkg/kv/kvserver/replica_closedts_test.go
@@ -602,6 +602,7 @@ func TestRejectedLeaseDoesntDictateClosedTimestamp(t *testing.T) {
 	select {
 	case <-leaseAcqCh:
 	case err := <-leaseAcqErrCh:
+		close(leaseTransferCh)
 		t.Fatalf("lease request unexpectedly finished. err: %v", err)
 	}
 	// Let the previously blocked transfer succeed. n2's lease acquisition remains

--- a/pkg/kv/kvserver/replica_closedts_test.go
+++ b/pkg/kv/kvserver/replica_closedts_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -450,7 +449,6 @@ func TestBumpSideTransportClosed(t *testing.T) {
 // 6, the lease proposal doesn't bump the assignedClosedTimestamp.
 func TestRejectedLeaseDoesntDictateClosedTimestamp(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.WithIssue(t, 65109, "flaky test")
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 
@@ -517,6 +515,16 @@ func TestRejectedLeaseDoesntDictateClosedTimestamp(t *testing.T) {
 	tc := testcluster.StartTestCluster(t, 2, base.TestClusterArgs{
 		ReplicationMode: base.ReplicationManual,
 		ServerArgs: base.TestServerArgs{
+			RaftConfig: base.RaftConfig{
+				// Disable preemptive lease extensions because, if the server startup
+				// takes too long before we pause the clock, such an extension can
+				// happen on the range of interest, and messes up the test that expects
+				// the lease to expire.
+				RangeLeaseRenewalFraction: -1,
+				// Also make expiration-based leases last for a long time, as the test
+				// wants a valid lease after cluster start.
+				RaftElectionTimeoutTicks: 1000,
+			},
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
 					ClockSource: manual.UnixNano,


### PR DESCRIPTION
This test was flaky (and skipped) in the case where cluster startup is
taking sufficiently many seconds such that, by the time it finishes,
the original lease on r1 is either expired or at least almost expired
such that the test inadvertendly kicks off a preemptive lease refresh.
The test tries to control exactly what lease requests get proposed, so
it doesn't like these refreshes happening.
The fix is to disable the preemptive refreshes, and also to make lease
duration longer.

Fixes #65109

cc @cockroachdb/kv 