### PR TITLE
sql, privilege: update privilege.Kind definition to be less error prone

### DIFF
--- a/pkg/sql/privilege/privilege.go
+++ b/pkg/sql/privilege/privilege.go
@@ -28,20 +28,20 @@ type Kind uint32
 
 // List of privileges. ALL is specifically encoded so that it will automatically
 // pick up new privileges.
-// New privileges must be added to the end since this is a bitfield.
+// Do not change values of privileges. These correspond to the position
+// of the privilege in a bit field and are expected to stay constant.
 const (
-	_ Kind = iota
-	ALL
-	CREATE
-	DROP
-	GRANT
-	SELECT
-	INSERT
-	DELETE
-	UPDATE
-	USAGE
-	ZONECONFIG
-	CONNECT
+	ALL        Kind = 1
+	CREATE     Kind = 2
+	DROP       Kind = 3
+	GRANT      Kind = 4
+	SELECT     Kind = 5
+	INSERT     Kind = 6
+	DELETE     Kind = 7
+	UPDATE     Kind = 8
+	USAGE      Kind = 9
+	ZONECONFIG Kind = 10
+	CONNECT    Kind = 11
 )
 
 // ObjectType represents objects that can have privileges.


### PR DESCRIPTION
Previously privilege.Kind was defined as an go enum but represented
a bitfield. This made it very error prone as a new enum value could be
added somewhere other than the end of the enum definition causing it to
override another enum in the bitfield.

Release note: None

Fixes https://github.com/cockroachdb/cockroach/issues/58675