### PR TITLE
release-21.1: build: add script for automated diagram generation

### DIFF
--- a/build/release/teamcity-support.sh
+++ b/build/release/teamcity-support.sh
@@ -1,9 +1,12 @@
 # Common helpers for teamcity-*.sh scripts.
 
+# root is the absolute path to the root directory of the repository.
+root=$(cd "$(dirname "$0")/.." && pwd)
+source "$root/build/teamcity-common-support.sh"
+
 remove_files_on_exit() {
-  rm -f .google-credentials.json
-  rm -f .cockroach-teamcity-key
   rm -rf ~/.docker
+  common_support_remove_files_on_exit
 }
 trap remove_files_on_exit EXIT
 
@@ -51,19 +54,4 @@ EOF
 
 docker_login_with_redhat() {
   echo "${REDHAT_REGISTRY_KEY}" | docker login --username unused --password-stdin $rhel_registry
-}
-
-configure_git_ssh_key() {
-  # Write a private key file and populate known_hosts
-  touch .cockroach-teamcity-key
-  chmod 600 .cockroach-teamcity-key
-  echo "${github_ssh_key}" > .cockroach-teamcity-key
-
-  mkdir -p "$HOME/.ssh"
-  ssh-keyscan github.com > "$HOME/.ssh/known_hosts"
-}
-
-push_to_git() {
-  # $@ passes all arguments to this function to the command
-  GIT_SSH_COMMAND="ssh -i .cockroach-teamcity-key" git push "$@"
 }

--- a/build/teamcity-common-support.sh
+++ b/build/teamcity-common-support.sh
@@ -1,0 +1,31 @@
+# Common logic shared by build/teamcity-support.sh and build/release/teamcity-support.sh.
+
+# Call this to clean up after using any other functions from this file.
+common_support_remove_files_on_exit() {
+  rm -f .cockroach-teamcity-key
+  rm -f .google-credentials.json
+}
+
+log_into_gcloud() {
+  if [[ "${google_credentials}" ]]; then
+    echo "${google_credentials}" > .google-credentials.json
+    gcloud auth activate-service-account --key-file=.google-credentials.json
+  else
+    echo 'warning: `google_credentials` not set' >&2
+  fi
+}
+
+configure_git_ssh_key() {
+  # Write a private key file and populate known_hosts
+  touch .cockroach-teamcity-key
+  chmod 600 .cockroach-teamcity-key
+  echo "${github_ssh_key}" > .cockroach-teamcity-key
+
+  mkdir -p "$HOME/.ssh"
+  ssh-keyscan github.com > "$HOME/.ssh/known_hosts"
+}
+
+push_to_git() {
+  # $@ passes all arguments to this function to the command
+  GIT_SSH_COMMAND="ssh -i .cockroach-teamcity-key" git push "$@"
+}

--- a/build/teamcity-diagram-generation.sh
+++ b/build/teamcity-diagram-generation.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+source "$(dirname "${0}")/teamcity-support.sh"
+
+tc_start_block "Get Railroad Jar"
+log_into_gcloud
+gsutil cp gs://cockroach-railroad-jar/Railroad-1.45-java7/Railroad.jar ./Railroad.jar
+railroadPath=`pwd`/Railroad.jar
+tc_end_block "Get Railroad Jar"
+
+cockroach_ref=$(git describe --tags --exact-match 2>/dev/null || git rev-parse HEAD)
+
+make bin/docgen
+
+git clone https://github.com/cockroachdb/generated-diagrams.git
+
+# Update diagrams on Github.
+export GIT_AUTHOR_NAME="Cockroach TeamCity"
+export GIT_COMMITTER_NAME="Cockroach TeamCity"
+export GIT_AUTHOR_EMAIL="teamcity@cockroachlabs.com"
+export GIT_COMMITTER_EMAIL="teamcity@cockroachlabs.com"
+
+cd generated-diagrams
+
+git checkout $TC_BUILD_BRANCH || git checkout -b $TC_BUILD_BRANCH
+
+# Clean out old diagrams.
+rm -rf bnf
+rm -rf grammar_svg
+
+tc_start_block "Generate Diagrams"
+# docgen has to be run in the cockroach root directory to find
+# the sql.y grammar file.
+cd ..
+bin/docgen grammar bnf ./generated-diagrams/bnf
+bin/docgen grammar svg ./generated-diagrams/bnf ./generated-diagrams/grammar_svg --railroad $railroadPath
+tc_end_block "Generate Diagrams"
+
+tc_start_block "Push Diagrams to Git"
+cd generated-diagrams
+
+git add .
+git commit -m "Snapshot $cockroach_ref"
+
+github_ssh_key="${PRIVATE_DEPLOY_KEY_FOR_GENERATED_DIAGRAMS}"
+configure_git_ssh_key
+
+push_to_git -f ssh://git@github.com/cockroachdb/generated-diagrams.git
+tc_end_block "Push Diagrams to Git"


### PR DESCRIPTION
Backport 1/1 commits from #64780.

/cc @cockroachdb/release

---

Added script to automatically generate grammar diagrams to be
uploaded to the cockroachdb/generated-diagrams repo.

Release note: None
