### PR TITLE
opt: change SplitScanIntoUnionScans to use UnionAll operators

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/limit
+++ b/pkg/sql/logictest/testdata/logic_test/limit
@@ -331,3 +331,16 @@ SELECT w FROM t ORDER BY k LIMIT 1;
 
 statement ok
 SET disallow_full_table_scans = false;
+
+# Regression test for incorrectly de-duplicating rows before reaching LIMIT. (Issue #65171)
+statement ok
+CREATE TABLE t65171 (x INT, y INT, INDEX(x, y))
+
+statement ok
+INSERT INTO t65171 VALUES (1, 2), (1, 2), (2, 3)
+
+query II
+SELECT * FROM t65171 WHERE x = 1 OR x = 2 ORDER BY y LIMIT 2
+----
+1  2
+1  2

--- a/pkg/sql/opt/exec/execbuilder/testdata/limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/limit
@@ -411,25 +411,25 @@ vectorized: true
 │ estimated row count: 5
 │ count: 5
 │
-└── • union
+└── • union all
     │ estimated row count: 40
     │
-    ├── • union
+    ├── • union all
     │   │ estimated row count: 35
     │   │
-    │   ├── • union
+    │   ├── • union all
     │   │   │ estimated row count: 30
     │   │   │
-    │   │   ├── • union
+    │   │   ├── • union all
     │   │   │   │ estimated row count: 25
     │   │   │   │
-    │   │   │   ├── • union
+    │   │   │   ├── • union all
     │   │   │   │   │ estimated row count: 20
     │   │   │   │   │
-    │   │   │   │   ├── • union
+    │   │   │   │   ├── • union all
     │   │   │   │   │   │ estimated row count: 15
     │   │   │   │   │   │
-    │   │   │   │   │   ├── • union
+    │   │   │   │   │   ├── • union all
     │   │   │   │   │   │   │ estimated row count: 10
     │   │   │   │   │   │   │
     │   │   │   │   │   │   ├── • scan

--- a/pkg/sql/opt/xform/rules/limit.opt
+++ b/pkg/sql/opt/xform/rules/limit.opt
@@ -55,8 +55,8 @@
     $indexJoinPrivate
 )
 
-# SplitScanIntoUnionScans splits a non-inverted scan under a limit into a union
-# of limited scans. Example:
+# SplitScanIntoUnionScans splits a non-inverted scan under a limit into a
+# union-all of limited scans over disjoint intervals. Example:
 #
 #    CREATE TABLE tab (region STRING, data INT NOT NULL, INDEX (region, data));
 #

--- a/pkg/sql/opt/xform/testdata/external/trading
+++ b/pkg/sql/opt/xform/testdata/external/trading
@@ -603,38 +603,35 @@ project
  │    │    ├── stats: [rows=1]
  │    │    ├── key: ()
  │    │    ├── fd: ()-->(8,16)
- │    │    ├── union
+ │    │    ├── union-all
  │    │    │    ├── columns: dealerid:8!null version:16!null
  │    │    │    ├── left columns: dealerid:75 version:83
  │    │    │    ├── right columns: dealerid:85 version:93
  │    │    │    ├── cardinality: [0 - 4]
- │    │    │    ├── stats: [rows=4, distinct(8,16)=4, null(8,16)=0]
- │    │    │    ├── key: (8,16)
+ │    │    │    ├── stats: [rows=4]
  │    │    │    ├── ordering: -16
  │    │    │    ├── limit hint: 1.00
- │    │    │    ├── union
+ │    │    │    ├── union-all
  │    │    │    │    ├── columns: dealerid:75!null version:83!null
  │    │    │    │    ├── left columns: dealerid:55 version:63
  │    │    │    │    ├── right columns: dealerid:65 version:73
  │    │    │    │    ├── cardinality: [0 - 3]
- │    │    │    │    ├── stats: [rows=3, distinct(75,83)=3, null(75,83)=0]
- │    │    │    │    ├── key: (75,83)
- │    │    │    │    ├── ordering: -83,+75
+ │    │    │    │    ├── stats: [rows=3]
+ │    │    │    │    ├── ordering: -83
  │    │    │    │    ├── limit hint: 1.00
- │    │    │    │    ├── union
+ │    │    │    │    ├── union-all
  │    │    │    │    │    ├── columns: dealerid:55!null version:63!null
  │    │    │    │    │    ├── left columns: dealerid:35 version:43
  │    │    │    │    │    ├── right columns: dealerid:45 version:53
  │    │    │    │    │    ├── cardinality: [0 - 2]
- │    │    │    │    │    ├── stats: [rows=2, distinct(55,63)=2, null(55,63)=0]
- │    │    │    │    │    ├── key: (55,63)
- │    │    │    │    │    ├── ordering: -63,+55
+ │    │    │    │    │    ├── stats: [rows=2]
+ │    │    │    │    │    ├── ordering: -63
  │    │    │    │    │    ├── limit hint: 1.00
  │    │    │    │    │    ├── scan cardsinfo@cardsinfoversionindex,rev
  │    │    │    │    │    │    ├── columns: dealerid:35!null version:43!null
  │    │    │    │    │    │    ├── constraint: /35/43: [/1 - /1]
  │    │    │    │    │    │    ├── limit: 1(rev)
- │    │    │    │    │    │    ├── stats: [rows=1, distinct(35)=1, null(35)=0, distinct(35,43)=1, null(35,43)=0]
+ │    │    │    │    │    │    ├── stats: [rows=1, distinct(35)=1, null(35)=0]
  │    │    │    │    │    │    ├── key: ()
  │    │    │    │    │    │    ├── fd: ()-->(35,43)
  │    │    │    │    │    │    └── limit hint: 1.00
@@ -642,7 +639,7 @@ project
  │    │    │    │    │         ├── columns: dealerid:45!null version:53!null
  │    │    │    │    │         ├── constraint: /45/53: [/2 - /2]
  │    │    │    │    │         ├── limit: 1(rev)
- │    │    │    │    │         ├── stats: [rows=1, distinct(45)=1, null(45)=0, distinct(45,53)=1, null(45,53)=0]
+ │    │    │    │    │         ├── stats: [rows=1, distinct(45)=1, null(45)=0]
  │    │    │    │    │         ├── key: ()
  │    │    │    │    │         ├── fd: ()-->(45,53)
  │    │    │    │    │         └── limit hint: 1.00
@@ -650,7 +647,7 @@ project
  │    │    │    │         ├── columns: dealerid:65!null version:73!null
  │    │    │    │         ├── constraint: /65/73: [/3 - /3]
  │    │    │    │         ├── limit: 1(rev)
- │    │    │    │         ├── stats: [rows=1, distinct(65)=1, null(65)=0, distinct(65,73)=1, null(65,73)=0]
+ │    │    │    │         ├── stats: [rows=1, distinct(65)=1, null(65)=0]
  │    │    │    │         ├── key: ()
  │    │    │    │         ├── fd: ()-->(65,73)
  │    │    │    │         └── limit hint: 1.00
@@ -658,7 +655,7 @@ project
  │    │    │         ├── columns: dealerid:85!null version:93!null
  │    │    │         ├── constraint: /85/93: [/4 - /4]
  │    │    │         ├── limit: 1(rev)
- │    │    │         ├── stats: [rows=1, distinct(85)=1, null(85)=0, distinct(85,93)=1, null(85,93)=0]
+ │    │    │         ├── stats: [rows=1, distinct(85)=1, null(85)=0]
  │    │    │         ├── key: ()
  │    │    │         ├── fd: ()-->(85,93)
  │    │    │         └── limit hint: 1.00

--- a/pkg/sql/opt/xform/testdata/external/trading-mutation
+++ b/pkg/sql/opt/xform/testdata/external/trading-mutation
@@ -609,38 +609,35 @@ project
  │    │    ├── stats: [rows=1]
  │    │    ├── key: ()
  │    │    ├── fd: ()-->(8,16)
- │    │    ├── union
+ │    │    ├── union-all
  │    │    │    ├── columns: dealerid:8!null version:16!null
  │    │    │    ├── left columns: dealerid:95 version:103
  │    │    │    ├── right columns: dealerid:109 version:117
  │    │    │    ├── cardinality: [0 - 4]
- │    │    │    ├── stats: [rows=4, distinct(8,16)=4, null(8,16)=0]
- │    │    │    ├── key: (8,16)
+ │    │    │    ├── stats: [rows=4]
  │    │    │    ├── ordering: -16
  │    │    │    ├── limit hint: 1.00
- │    │    │    ├── union
+ │    │    │    ├── union-all
  │    │    │    │    ├── columns: dealerid:95!null version:103!null
  │    │    │    │    ├── left columns: dealerid:67 version:75
  │    │    │    │    ├── right columns: dealerid:81 version:89
  │    │    │    │    ├── cardinality: [0 - 3]
- │    │    │    │    ├── stats: [rows=3, distinct(95,103)=3, null(95,103)=0]
- │    │    │    │    ├── key: (95,103)
- │    │    │    │    ├── ordering: -103,+95
+ │    │    │    │    ├── stats: [rows=3]
+ │    │    │    │    ├── ordering: -103
  │    │    │    │    ├── limit hint: 1.00
- │    │    │    │    ├── union
+ │    │    │    │    ├── union-all
  │    │    │    │    │    ├── columns: dealerid:67!null version:75!null
  │    │    │    │    │    ├── left columns: dealerid:39 version:47
  │    │    │    │    │    ├── right columns: dealerid:53 version:61
  │    │    │    │    │    ├── cardinality: [0 - 2]
- │    │    │    │    │    ├── stats: [rows=2, distinct(67,75)=2, null(67,75)=0]
- │    │    │    │    │    ├── key: (67,75)
- │    │    │    │    │    ├── ordering: -75,+67
+ │    │    │    │    │    ├── stats: [rows=2]
+ │    │    │    │    │    ├── ordering: -75
  │    │    │    │    │    ├── limit hint: 1.00
  │    │    │    │    │    ├── scan cardsinfo@cardsinfoversionindex,rev
  │    │    │    │    │    │    ├── columns: dealerid:39!null version:47!null
  │    │    │    │    │    │    ├── constraint: /39/47: [/1 - /1]
  │    │    │    │    │    │    ├── limit: 1(rev)
- │    │    │    │    │    │    ├── stats: [rows=1, distinct(39)=1, null(39)=0, distinct(39,47)=1, null(39,47)=0]
+ │    │    │    │    │    │    ├── stats: [rows=1, distinct(39)=1, null(39)=0]
  │    │    │    │    │    │    ├── key: ()
  │    │    │    │    │    │    ├── fd: ()-->(39,47)
  │    │    │    │    │    │    └── limit hint: 1.00
@@ -648,7 +645,7 @@ project
  │    │    │    │    │         ├── columns: dealerid:53!null version:61!null
  │    │    │    │    │         ├── constraint: /53/61: [/2 - /2]
  │    │    │    │    │         ├── limit: 1(rev)
- │    │    │    │    │         ├── stats: [rows=1, distinct(53)=1, null(53)=0, distinct(53,61)=1, null(53,61)=0]
+ │    │    │    │    │         ├── stats: [rows=1, distinct(53)=1, null(53)=0]
  │    │    │    │    │         ├── key: ()
  │    │    │    │    │         ├── fd: ()-->(53,61)
  │    │    │    │    │         └── limit hint: 1.00
@@ -656,7 +653,7 @@ project
  │    │    │    │         ├── columns: dealerid:81!null version:89!null
  │    │    │    │         ├── constraint: /81/89: [/3 - /3]
  │    │    │    │         ├── limit: 1(rev)
- │    │    │    │         ├── stats: [rows=1, distinct(81)=1, null(81)=0, distinct(81,89)=1, null(81,89)=0]
+ │    │    │    │         ├── stats: [rows=1, distinct(81)=1, null(81)=0]
  │    │    │    │         ├── key: ()
  │    │    │    │         ├── fd: ()-->(81,89)
  │    │    │    │         └── limit hint: 1.00
@@ -664,7 +661,7 @@ project
  │    │    │         ├── columns: dealerid:109!null version:117!null
  │    │    │         ├── constraint: /109/117: [/4 - /4]
  │    │    │         ├── limit: 1(rev)
- │    │    │         ├── stats: [rows=1, distinct(109)=1, null(109)=0, distinct(109,117)=1, null(109,117)=0]
+ │    │    │         ├── stats: [rows=1, distinct(109)=1, null(109)=0]
  │    │    │         ├── key: ()
  │    │    │         ├── fd: ()-->(109,117)
  │    │    │         └── limit hint: 1.00

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -91,25 +91,24 @@ limit
  ├── internal-ordering: +2
  ├── cardinality: [0 - 5]
  ├── ordering: +2
- ├── union
+ ├── union-all
  │    ├── columns: e:2 f:3
  │    ├── left columns: e:7 f:8
  │    ├── right columns: e:12 f:13
  │    ├── cardinality: [0 - 10]
- │    ├── key: (2,3)
  │    ├── ordering: +2
  │    ├── limit hint: 5.00
  │    ├── scan def@secondary
  │    │    ├── columns: e:7 f:8
  │    │    ├── constraint: /6/7/8/9: [/1 - /1]
  │    │    ├── limit: 5
- │    │    ├── ordering: +7,+8
+ │    │    ├── ordering: +7
  │    │    └── limit hint: 5.00
  │    └── scan def@secondary
  │         ├── columns: e:12 f:13
  │         ├── constraint: /11/12/13/14: [/3 - /3]
  │         ├── limit: 5
- │         ├── ordering: +12,+13
+ │         ├── ordering: +12
  │         └── limit hint: 5.00
  └── 5
 

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -305,12 +305,11 @@ index-join kuv
       ├── key: (4)
       ├── fd: (4)-->(1,2)
       ├── ordering: +2
-      ├── union
+      ├── union-all
       │    ├── columns: k:1!null u:2 rowid:4!null
       │    ├── left columns: k:6 u:7 rowid:9
       │    ├── right columns: k:11 u:12 rowid:14
       │    ├── cardinality: [0 - 10]
-      │    ├── key: (1,2,4)
       │    ├── ordering: +2
       │    ├── limit hint: 5.00
       │    ├── scan kuv@secondary
@@ -319,7 +318,7 @@ index-join kuv
       │    │    ├── limit: 5
       │    │    ├── key: (9)
       │    │    ├── fd: ()-->(6), (9)-->(7)
-      │    │    ├── ordering: +7,+9 opt(6) [actual: +7,+9]
+      │    │    ├── ordering: +7 opt(6) [actual: +7]
       │    │    └── limit hint: 5.00
       │    └── scan kuv@secondary
       │         ├── columns: k:11!null u:12 rowid:14!null
@@ -327,7 +326,7 @@ index-join kuv
       │         ├── limit: 5
       │         ├── key: (14)
       │         ├── fd: ()-->(11), (14)-->(12)
-      │         ├── ordering: +12,+14 opt(11) [actual: +12,+14]
+      │         ├── ordering: +12 opt(11) [actual: +12]
       │         └── limit hint: 5.00
       └── 5
 
@@ -834,21 +833,19 @@ limit
  ├── internal-ordering: +6
  ├── cardinality: [0 - 10]
  ├── ordering: +6
- ├── union
+ ├── union-all
  │    ├── columns: val:2!null data1:6!null
  │    ├── left columns: val:32 data1:36
  │    ├── right columns: val:42 data1:46
  │    ├── cardinality: [0 - 30]
- │    ├── key: (2,6)
  │    ├── ordering: +6
  │    ├── limit hint: 10.00
- │    ├── union
+ │    ├── union-all
  │    │    ├── columns: val:32!null data1:36!null
  │    │    ├── left columns: val:12 data1:16
  │    │    ├── right columns: val:22 data1:26
  │    │    ├── cardinality: [0 - 20]
- │    │    ├── key: (32,36)
- │    │    ├── ordering: +36,+32
+ │    │    ├── ordering: +36
  │    │    ├── limit hint: 10.00
  │    │    ├── scan index_tab@b
  │    │    │    ├── columns: val:12!null data1:16!null
@@ -888,12 +885,11 @@ scalar-group-by
  │    ├── cardinality: [0 - 1]
  │    ├── key: ()
  │    ├── fd: ()-->(3,6)
- │    ├── union
+ │    ├── union-all
  │    │    ├── columns: region:3!null data1:6!null
  │    │    ├── left columns: region:14 data1:17
  │    │    ├── right columns: region:24 data1:27
  │    │    ├── cardinality: [0 - 2]
- │    │    ├── key: (3,6)
  │    │    ├── ordering: -6
  │    │    ├── limit hint: 1.00
  │    │    ├── scan index_tab@c,rev
@@ -932,12 +928,11 @@ scalar-group-by
  │    ├── cardinality: [0 - 1]
  │    ├── key: ()
  │    ├── fd: ()-->(4-6)
- │    ├── union
+ │    ├── union-all
  │    │    ├── columns: latitude:4!null longitude:5!null data1:6!null
  │    │    ├── left columns: latitude:15 longitude:16 data1:17
  │    │    ├── right columns: latitude:25 longitude:26 data1:27
  │    │    ├── cardinality: [0 - 2]
- │    │    ├── key: (4-6)
  │    │    ├── ordering: -6
  │    │    ├── limit hint: 1.00
  │    │    ├── scan index_tab@d,rev
@@ -974,21 +969,19 @@ scalar-group-by
  │    ├── cardinality: [0 - 1]
  │    ├── key: ()
  │    ├── fd: ()-->(2,6)
- │    ├── union
+ │    ├── union-all
  │    │    ├── columns: val:2!null data1:6!null
  │    │    ├── left columns: val:33 data1:37
  │    │    ├── right columns: val:43 data1:47
  │    │    ├── cardinality: [0 - 3]
- │    │    ├── key: (2,6)
  │    │    ├── ordering: -6
  │    │    ├── limit hint: 1.00
- │    │    ├── union
+ │    │    ├── union-all
  │    │    │    ├── columns: val:33!null data1:37!null
  │    │    │    ├── left columns: val:13 data1:17
  │    │    │    ├── right columns: val:23 data1:27
  │    │    │    ├── cardinality: [0 - 2]
- │    │    │    ├── key: (33,37)
- │    │    │    ├── ordering: -37,+33
+ │    │    │    ├── ordering: -37
  │    │    │    ├── limit hint: 1.00
  │    │    │    ├── scan index_tab@b,rev
  │    │    │    │    ├── columns: val:13!null data1:17!null
@@ -1029,12 +1022,11 @@ limit
  ├── internal-ordering: +6,+7
  ├── cardinality: [0 - 10]
  ├── ordering: +6,+7
- ├── union
+ ├── union-all
  │    ├── columns: region:3!null data1:6!null data2:7!null
  │    ├── left columns: region:13 data1:16 data2:17
  │    ├── right columns: region:23 data1:26 data2:27
  │    ├── cardinality: [0 - 20]
- │    ├── key: (3,6,7)
  │    ├── ordering: +6,+7
  │    ├── limit hint: 10.00
  │    ├── scan index_tab@c
@@ -1067,12 +1059,11 @@ limit
  ├── internal-ordering: +6,+7
  ├── cardinality: [0 - 10]
  ├── ordering: +6,+7
- ├── union
+ ├── union-all
  │    ├── columns: region:3!null data1:6!null data2:7!null
  │    ├── left columns: region:13 data1:16 data2:17
  │    ├── right columns: region:23 data1:26 data2:27
  │    ├── cardinality: [0 - 20]
- │    ├── key: (3,6,7)
  │    ├── ordering: +6,+7
  │    ├── limit hint: 10.00
  │    ├── scan index_tab@c
@@ -1105,12 +1096,11 @@ limit
  ├── internal-ordering: +6,+7
  ├── cardinality: [0 - 10]
  ├── ordering: +6,+7
- ├── union
+ ├── union-all
  │    ├── columns: region:3!null data1:6!null data2:7!null
  │    ├── left columns: region:13 data1:16 data2:17
  │    ├── right columns: region:23 data1:26 data2:27
  │    ├── cardinality: [0 - 20]
- │    ├── key: (3,6,7)
  │    ├── ordering: +6,+7
  │    ├── limit hint: 10.00
  │    ├── scan index_tab@c
@@ -1144,12 +1134,11 @@ limit
  ├── internal-ordering: +6,+7
  ├── cardinality: [0 - 10]
  ├── ordering: +6,+7
- ├── union
+ ├── union-all
  │    ├── columns: region:3!null data1:6!null data2:7!null
  │    ├── left columns: region:13 data1:16 data2:17
  │    ├── right columns: region:23 data1:26 data2:27
  │    ├── cardinality: [0 - 20]
- │    ├── key: (3,6,7)
  │    ├── ordering: +6,+7
  │    ├── limit hint: 10.00
  │    ├── scan index_tab@c
@@ -1184,28 +1173,25 @@ limit
  ├── internal-ordering: +6,+7
  ├── cardinality: [0 - 10]
  ├── ordering: +6,+7
- ├── union
+ ├── union-all
  │    ├── columns: latitude:4!null longitude:5 data1:6!null data2:7!null
  │    ├── left columns: latitude:74 longitude:75 data1:76 data2:77
  │    ├── right columns: latitude:84 longitude:85 data1:86 data2:87
- │    ├── key: (4-7)
  │    ├── ordering: +6,+7
  │    ├── limit hint: 10.00
- │    ├── union
+ │    ├── union-all
  │    │    ├── columns: latitude:74!null longitude:75!null data1:76!null data2:77!null
  │    │    ├── left columns: latitude:54 longitude:55 data1:56 data2:57
  │    │    ├── right columns: latitude:64 longitude:65 data1:66 data2:67
  │    │    ├── cardinality: [0 - 30]
- │    │    ├── key: (74-77)
- │    │    ├── ordering: +76,+77,+74,+75
+ │    │    ├── ordering: +76,+77
  │    │    ├── limit hint: 10.00
- │    │    ├── union
+ │    │    ├── union-all
  │    │    │    ├── columns: latitude:54!null longitude:55!null data1:56!null data2:57!null
  │    │    │    ├── left columns: latitude:34 longitude:35 data1:36 data2:37
  │    │    │    ├── right columns: latitude:44 longitude:45 data1:46 data2:47
  │    │    │    ├── cardinality: [0 - 20]
- │    │    │    ├── key: (54-57)
- │    │    │    ├── ordering: +56,+57,+54,+55
+ │    │    │    ├── ordering: +56,+57
  │    │    │    ├── limit hint: 10.00
  │    │    │    ├── scan index_tab@d
  │    │    │    │    ├── columns: latitude:34!null longitude:35!null data1:36!null data2:37!null
@@ -1230,7 +1216,7 @@ limit
  │    │         └── limit hint: 10.00
  │    └── sort
  │         ├── columns: latitude:84!null longitude:85 data1:86!null data2:87!null
- │         ├── ordering: +86,+87,+84,+85
+ │         ├── ordering: +86,+87
  │         ├── limit hint: 10.00
  │         └── scan index_tab@d
  │              ├── columns: latitude:84!null longitude:85 data1:86!null data2:87!null
@@ -1258,42 +1244,29 @@ index-join index_tab
       ├── key: (1)
       ├── fd: (1)-->(3,6,7)
       ├── ordering: +6
-      ├── union
+      ├── union-all
       │    ├── columns: id:1!null region:3!null data1:6!null data2:7!null
       │    ├── left columns: id:11 region:13 data1:16 data2:17
       │    ├── right columns: id:21 region:23 data1:26 data2:27
       │    ├── cardinality: [0 - 20]
-      │    ├── key: (1,3,6,7)
       │    ├── ordering: +6
       │    ├── limit hint: 10.00
-      │    ├── sort (segmented)
+      │    ├── scan index_tab@c
       │    │    ├── columns: id:11!null region:13!null data1:16!null data2:17!null
-      │    │    ├── cardinality: [0 - 10]
+      │    │    ├── constraint: /13/16/17/11: [/'US_EAST' - /'US_EAST']
+      │    │    ├── limit: 10
       │    │    ├── key: (11)
       │    │    ├── fd: ()-->(13), (11)-->(16,17)
-      │    │    ├── ordering: +16,+11 opt(13) [actual: +16,+11]
-      │    │    ├── limit hint: 10.00
-      │    │    └── scan index_tab@c
-      │    │         ├── columns: id:11!null region:13!null data1:16!null data2:17!null
-      │    │         ├── constraint: /13/16/17/11: [/'US_EAST' - /'US_EAST']
-      │    │         ├── limit: 10
-      │    │         ├── key: (11)
-      │    │         ├── fd: ()-->(13), (11)-->(16,17)
-      │    │         └── ordering: +16 opt(13) [actual: +16]
-      │    └── sort (segmented)
+      │    │    ├── ordering: +16 opt(13) [actual: +16]
+      │    │    └── limit hint: 10.00
+      │    └── scan index_tab@c
       │         ├── columns: id:21!null region:23!null data1:26!null data2:27!null
-      │         ├── cardinality: [0 - 10]
+      │         ├── constraint: /23/26/27/21: [/'US_WEST' - /'US_WEST']
+      │         ├── limit: 10
       │         ├── key: (21)
       │         ├── fd: ()-->(23), (21)-->(26,27)
-      │         ├── ordering: +26,+21 opt(23) [actual: +26,+21]
-      │         ├── limit hint: 10.00
-      │         └── scan index_tab@c
-      │              ├── columns: id:21!null region:23!null data1:26!null data2:27!null
-      │              ├── constraint: /23/26/27/21: [/'US_WEST' - /'US_WEST']
-      │              ├── limit: 10
-      │              ├── key: (21)
-      │              ├── fd: ()-->(23), (21)-->(26,27)
-      │              └── ordering: +26 opt(23) [actual: +26]
+      │         ├── ordering: +26 opt(23) [actual: +26]
+      │         └── limit hint: 10.00
       └── 10
 
 # Case where check constraints are used.
@@ -1307,21 +1280,19 @@ limit
  ├── key: (1,2)
  ├── fd: (1,2)-->(3,4)
  ├── ordering: +2
- ├── union
+ ├── union-all
  │    ├── columns: p:1!null q:2!null r:3!null s:4!null
  │    ├── left columns: p:16 q:17 r:18 s:19
  │    ├── right columns: p:21 q:22 r:23 s:24
  │    ├── cardinality: [0 - 15]
- │    ├── key: (1-4)
  │    ├── ordering: +2
  │    ├── limit hint: 5.00
- │    ├── union
+ │    ├── union-all
  │    │    ├── columns: p:16!null q:17!null r:18!null s:19!null
  │    │    ├── left columns: p:6 q:7 r:8 s:9
  │    │    ├── right columns: p:11 q:12 r:13 s:14
  │    │    ├── cardinality: [0 - 10]
- │    │    ├── key: (16-19)
- │    │    ├── ordering: +17,+16,+18,+19
+ │    │    ├── ordering: +17
  │    │    ├── limit hint: 5.00
  │    │    ├── scan pqrs
  │    │    │    ├── columns: p:6!null q:7!null r:8!null s:9!null
@@ -1361,12 +1332,11 @@ limit
  ├── key: (1,2)
  ├── fd: (1,2)-->(3,4)
  ├── ordering: +4
- ├── union
+ ├── union-all
  │    ├── columns: p:1!null q:2!null r:3!null s:4!null
  │    ├── left columns: p:6 q:7 r:8 s:9
  │    ├── right columns: p:11 q:12 r:13 s:14
  │    ├── cardinality: [0 - 20]
- │    ├── key: (1-4)
  │    ├── ordering: +4
  │    ├── limit hint: 10.00
  │    ├── scan pqrs@secondary
@@ -1375,7 +1345,7 @@ limit
  │    │    ├── limit: 10
  │    │    ├── key: (6,7)
  │    │    ├── fd: ()-->(8), (6,7)-->(9)
- │    │    ├── ordering: +9,+6,+7 opt(8) [actual: +9,+6,+7]
+ │    │    ├── ordering: +9 opt(8) [actual: +9]
  │    │    └── limit hint: 10.00
  │    └── scan pqrs@secondary
  │         ├── columns: p:11!null q:12!null r:13!null s:14!null
@@ -1383,7 +1353,7 @@ limit
  │         ├── limit: 10
  │         ├── key: (11,12)
  │         ├── fd: ()-->(13), (11,12)-->(14)
- │         ├── ordering: +14,+11,+12 opt(13) [actual: +14,+11,+12]
+ │         ├── ordering: +14 opt(13) [actual: +14]
  │         └── limit hint: 10.00
  └── 10
 
@@ -1399,12 +1369,11 @@ limit
  ├── key: (1,2)
  ├── fd: (1,2)-->(3,4)
  ├── ordering: +2
- ├── union
+ ├── union-all
  │    ├── columns: p:1!null q:2!null r:3!null s:4!null
  │    ├── left columns: p:6 q:7 r:8 s:9
  │    ├── right columns: p:11 q:12 r:13 s:14
  │    ├── cardinality: [0 - 10]
- │    ├── key: (1-4)
  │    ├── ordering: +2
  │    ├── limit hint: 5.00
  │    ├── scan pqrs


### PR DESCRIPTION
Previously, the `SplitScanIntoUnionScans` rule used `Union` operators
to unify the results of a series of scans over disjoint intervals over
the same table. However, the de-duplication step provided by `Union` is
actually not correct in this case - we want to preserve all rows from the
scans. Ex:
```
statement ok
CREATE TABLE split_test (x INT, y INT, INDEX(x, y))

statement ok
INSERT INTO split_test VALUES (1, 2), (1, 2), (2, 3)

query II
SELECT * FROM split_test WHERE x = 1 OR x = 2 ORDER BY y LIMIT 2
----
1  2
2  3 # expecting 1 2
```

This patch modifies `SplitScanIntoUnionScans` to instead use `UnionAll`
operators, which do not de-duplicate their input.

Fixes #65171

Release note (bug fix): Fixed a bug introduced in 20.2 that caused rows
to be incorrectly de-duplicated from a scan with a non-unique index.