### PR TITLE
release-20.2: delegate: fix zone configs for SHOW CREATE TABLE with no partitions

### DIFF
--- a/pkg/sql/delegate/show_table.go
+++ b/pkg/sql/delegate/show_table.go
@@ -34,11 +34,11 @@ func (d *delegator) delegateShowCreate(n *tree.ShowCreate) (tree.Statement, erro
 			%[3]s AS table_name,
       concat(create_statement,
              CASE
+               WHEN (SELECT * FROM zone_configs) IS NOT NULL
+               THEN concat(e';\n', (SELECT * FROM zone_configs))
                WHEN NOT has_partitions
                THEN NULL
-               WHEN (SELECT * FROM zone_configs) IS NULL
-               THEN e'\n-- Warning: Partitioned table with no zone configurations.'
-               ELSE concat(e';\n', (SELECT * FROM zone_configs))
+               ELSE e'\n-- Warning: Partitioned table with no zone configurations.'
              END
 			) AS create_statement
 		FROM

--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -172,6 +172,13 @@ child  CREATE TABLE public.child (
        FAMILY fam_0_x_y_z (x, y, z)
 )
 
+# Check zone configs behave as appropriate.
+query TT
+SELECT target, raw_config_sql FROM crdb_internal.zones
+WHERE target = 'TABLE test.public.child'
+----
+
+
 query TTT
 SELECT * FROM [EXPLAIN SELECT * FROM child WHERE y >=2 AND y <= 6] OFFSET 2
 ----

--- a/pkg/sql/logictest/testdata/logic_test/zone_config
+++ b/pkg/sql/logictest/testdata/logic_test/zone_config
@@ -158,6 +158,25 @@ SELECT zone_id, raw_config_sql FROM [SHOW ZONE CONFIGURATION FOR TABLE a]
     constraints = '[+region=test]',
     lease_preferences = '[[+region=test]]'
 
+# Test SHOW CREATE TABLE correctly shows the CREATE TABLE.
+query TT
+SHOW CREATE TABLE a
+----
+a  CREATE TABLE public.a (
+   id INT8 NOT NULL,
+   CONSTRAINT "primary" PRIMARY KEY (id ASC),
+   FAMILY "primary" (id)
+);
+ALTER TABLE test.public.a CONFIGURE ZONE USING
+  range_min_bytes = 200001,
+  range_max_bytes = 400000,
+  gc.ttlseconds = 3600,
+  num_replicas = 1,
+  constraints = '[+region=test]',
+  lease_preferences = '[[+region=test]]';
+ALTER TABLE test.test.a CONFIGURE ZONE USING
+  gc.ttlseconds = 1234
+
 # Check that we can reset the configuration to defaults.
 
 statement ok

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -928,8 +928,10 @@ func RemoveIndexZoneConfigs(
 	zone, err := getZoneConfigRaw(ctx, txn, execCfg.Codec, tableID)
 	if err != nil {
 		return err
-	} else if zone == nil {
-		zone = zonepb.NewZoneConfig()
+	}
+	// If there are no zone configs, there's nothing to remove.
+	if zone == nil {
+		return nil
 	}
 
 	for _, indexDesc := range indexDescs {


### PR DESCRIPTION
Backport commits from #65167 and #61235.

/cc @cockroachdb/release

---

See individual PRs for details.
