### PR TITLE
release-21.1: delegate: fix zone configs for SHOW CREATE TABLE with no partitions

### DIFF
--- a/pkg/sql/delegate/show_table.go
+++ b/pkg/sql/delegate/show_table.go
@@ -45,16 +45,17 @@ SELECT
     %[3]s AS table_name,
     concat(create_statement,
         CASE
-        WHEN NOT has_partitions
-            THEN NULL
 				WHEN is_multi_region THEN
 					CASE
 						WHEN (SELECT mr FROM zone_configs) IS NULL THEN NULL
 						ELSE concat(e';\n', (SELECT mr FROM zone_configs))
 					END
-        WHEN (SELECT raw FROM zone_configs) IS NULL THEN
+        WHEN (SELECT raw FROM zone_configs) IS NOT NULL THEN
+					concat(e';\n', (SELECT raw FROM zone_configs))
+        WHEN NOT has_partitions
+          THEN NULL
+				ELSE
 					e'\n-- Warning: Partitioned table with no zone configurations.'
-        ELSE concat(e';\n', (SELECT raw FROM zone_configs))
         END
     ) AS create_statement
 FROM

--- a/pkg/sql/logictest/testdata/logic_test/zone_config
+++ b/pkg/sql/logictest/testdata/logic_test/zone_config
@@ -158,6 +158,25 @@ SELECT zone_id, raw_config_sql FROM [SHOW ZONE CONFIGURATION FOR TABLE a]
     constraints = '[+region=test]',
     lease_preferences = '[[+region=test]]'
 
+# Test SHOW CREATE TABLE correctly shows the CREATE TABLE.
+query TT
+SHOW CREATE TABLE a
+----
+a  CREATE TABLE public.a (
+   id INT8 NOT NULL,
+   CONSTRAINT "primary" PRIMARY KEY (id ASC),
+   FAMILY "primary" (id)
+);
+ALTER TABLE test.public.a CONFIGURE ZONE USING
+  range_min_bytes = 200001,
+  range_max_bytes = 400000,
+  gc.ttlseconds = 3600,
+  num_replicas = 1,
+  constraints = '[+region=test]',
+  lease_preferences = '[[+region=test]]';
+ALTER TABLE test.test.a CONFIGURE ZONE USING
+  gc.ttlseconds = 1234
+
 # Check that we can reset the configuration to defaults.
 
 statement ok
@@ -195,7 +214,6 @@ ORDER BY feature_name
 ----
 sql.schema.alter_range.configure_zone
 sql.schema.alter_table.configure_zone
-
 
 # Check that configuring num_voters separately from num_replicas behaves as
 # expected, across setting them directly and through inheritance.


### PR DESCRIPTION
Backport 1/1 commits from #65167.

/cc @cockroachdb/release

---

Fixed the regression in c44619c38ba6f22d8d6590a34600ba0c2fd7fdd9 which
had no tests to cover this case.

Release note (bug fix): Fixed a bug where if the zone configurations
would not display on a SHOW CREATE TABLE if there are no partitions
even though there are zone configurations on the index or tables
themselves.
