### PR TITLE
release-21.1: kvserver: improve suspect replica GC heuristics

### DIFF
--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -2046,7 +2046,7 @@ func runReplicateRestartAfterTruncation(t *testing.T, removeBeforeTruncateAndReA
 	if removeBeforeTruncateAndReAdd {
 		// Verify old replica is GC'd. Wait out the replica gc queue
 		// inactivity threshold and force a gc scan.
-		manualClock.Increment(int64(kvserver.ReplicaGCQueueInactivityThreshold + 1))
+		manualClock.Increment(int64(kvserver.ReplicaGCQueueCheckInterval + 1))
 		testutils.SucceedsSoon(t, func() error {
 			tc.GetFirstStoreFromServer(t, 1).MustForceReplicaGCScanAndProcess()
 			_, err := tc.GetFirstStoreFromServer(t, 1).GetReplica(desc.RangeID)
@@ -2156,7 +2156,7 @@ func testReplicaAddRemove(t *testing.T, addFirst bool) {
 
 	// Wait out the range lease and the unleased duration to make the replica GC'able.
 	manualClock.Increment(store.GetStoreConfig().LeaseExpiration())
-	manualClock.Increment(int64(kvserver.ReplicaGCQueueInactivityThreshold + 1))
+	manualClock.Increment(int64(kvserver.ReplicaGCQueueCheckInterval + 1))
 	tc.GetFirstStoreFromServer(t, 1).SetReplicaGCQueueActive(true)
 	tc.GetFirstStoreFromServer(t, 1).MustForceReplicaGCScanAndProcess()
 
@@ -3303,7 +3303,7 @@ func TestReplicateRogueRemovedNode(t *testing.T) {
 	testutils.SucceedsSoon(t, func() error {
 		manualClock.Increment(store.GetStoreConfig().LeaseExpiration())
 		manualClock.Increment(int64(
-			kvserver.ReplicaGCQueueInactivityThreshold) + 1)
+			kvserver.ReplicaGCQueueCheckInterval) + 1)
 		tc.GetFirstStoreFromServer(t, 1).MustForceReplicaGCScanAndProcess()
 
 		actual := tc.ReadIntFromStores(key)
@@ -3386,7 +3386,7 @@ func TestReplicateRogueRemovedNode(t *testing.T) {
 	tc.GetFirstStoreFromServer(t, 2).SetReplicaGCQueueActive(true)
 	manualClock.Increment(store.GetStoreConfig().LeaseExpiration())
 	manualClock.Increment(int64(
-		kvserver.ReplicaGCQueueInactivityThreshold) + 1)
+		kvserver.ReplicaGCQueueCheckInterval) + 1)
 	tc.GetFirstStoreFromServer(t, 2).MustForceReplicaGCScanAndProcess()
 	tc.WaitForValues(t, key, []int64{16, 0, 0})
 

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -488,13 +488,6 @@ func SetMockAddSSTable() (undo func()) {
 	}
 }
 
-// IsQuiescent returns whether the replica is quiescent or not.
-func (r *Replica) IsQuiescent() bool {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	return r.mu.quiescent
-}
-
 // GetQueueLastProcessed returns the last processed timestamp for the
 // specified queue, or the zero timestamp if not available.
 func (r *Replica) GetQueueLastProcessed(ctx context.Context, queue string) (hlc.Timestamp, error) {

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -732,6 +732,13 @@ func (r *Replica) isDestroyedRLocked() (DestroyReason, error) {
 	return r.mu.destroyStatus.reason, r.mu.destroyStatus.err
 }
 
+// IsQuiescent returns whether the replica is quiescent or not.
+func (r *Replica) IsQuiescent() bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.mu.quiescent
+}
+
 // DescAndZone returns the authoritative range descriptor as well
 // as the zone config for the replica.
 func (r *Replica) DescAndZone() (*roachpb.RangeDescriptor, *zonepb.ZoneConfig) {

--- a/pkg/kv/kvserver/replica_gc_queue.go
+++ b/pkg/kv/kvserver/replica_gc_queue.go
@@ -27,27 +27,16 @@ import (
 
 const (
 	// replicaGCQueueTimerDuration is the duration between GCs of queued replicas.
-	replicaGCQueueTimerDuration = 50 * time.Millisecond
+	replicaGCQueueTimerDuration = 100 * time.Millisecond
 
-	// ReplicaGCQueueInactivityThreshold is the inactivity duration after which
+	// ReplicaGCQueueCheckInterval is the inactivity duration after which
 	// a range will be considered for garbage collection. Exported for testing.
-	ReplicaGCQueueInactivityThreshold = 12 * time.Hour
-	// ReplicaGCQueueSuspectTimeout is the duration after which a Replica which
-	// is suspected to be removed should be processed by the queue.
-	// A Replica is suspected to have been removed if either it is in the
-	// candidate Raft state (which is a typical sign of having been removed
-	// from the group) or it is not in the VOTER_FULL state. Replicas which are
-	// in the LEARNER state will never become candidates. It seems possible that
-	// a range will quiesce and never tell a VOTER_OUTGOING that is was removed.
-	// Cases where a replica gets stuck in VOTER_INCOMING seem farfetched and
-	// would require the replica to be removed from the range before it ever
-	// learned about its promotion but that state shouldn't last long so we
-	// also treat idle replicas in that state as suspect.
-	//
-	// A leader unable to make progress (e.g. because it's lost a quorum) is
-	// also considered suspect, since Node.ResetQuorum() may be used to restore
-	// the range elsewhere.
-	ReplicaGCQueueSuspectTimeout = 1 * time.Second
+	ReplicaGCQueueCheckInterval = 12 * time.Hour
+	// ReplicaGCQueueSuspectCheckInterval is the duration after which a Replica
+	// which is suspected to be removed should be considered for garbage
+	// collection. See replicaIsSuspect() for details on what makes a replica
+	// suspect.
+	ReplicaGCQueueSuspectCheckInterval = 5 * time.Second
 )
 
 // Priorities for the replica GC queue.
@@ -129,96 +118,110 @@ func newReplicaGCQueue(store *Store, db *kv.DB, gossip *gossip.Gossip) *replicaG
 func (rgcq *replicaGCQueue) shouldQueue(
 	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, _ *config.SystemConfig,
 ) (shouldQ bool, prio float64) {
-
+	if _, currentMember := repl.Desc().GetReplicaDescriptor(repl.store.StoreID()); !currentMember {
+		return true, replicaGCPriorityRemoved
+	}
 	lastCheck, err := repl.GetLastReplicaGCTimestamp(ctx)
 	if err != nil {
 		log.Errorf(ctx, "could not read last replica GC timestamp: %+v", err)
 		return false, 0
 	}
-	replDesc, currentMember := repl.Desc().GetReplicaDescriptor(repl.store.StoreID())
-	if !currentMember {
-		return true, replicaGCPriorityRemoved
-	}
+	isSuspect := replicaIsSuspect(repl)
 
-	lastActivity := hlc.Timestamp{
-		WallTime: repl.store.startedAt,
-	}
+	return replicaGCShouldQueueImpl(now.ToTimestamp(), lastCheck, isSuspect)
+}
 
-	if lease, _ := repl.GetLease(); lease.ProposedTS != nil {
-		lastActivity.Forward(lease.ProposedTS.ToTimestamp())
-	}
-
+func replicaIsSuspect(repl *Replica) bool {
 	// It is critical to think of the replica as suspect if it is a learner as
 	// it both shouldn't be a learner for long but will never become a candidate.
 	// It is less critical to consider joint configuration members as suspect
 	// but in cases where a replica is removed but only ever hears about the
 	// command which sets it to VOTER_OUTGOING we would conservatively wait
-	// 10 days before removing the node. Finally we consider replicas which are
+	// 12 hours before removing the node. Finally we consider replicas which are
 	// VOTER_INCOMING as suspect because no replica should stay in that state for
 	// too long and being conservative here doesn't seem worthwhile.
-	var isSuspect bool
-	if raftStatus := repl.RaftStatus(); raftStatus == nil {
-		// If a replica doesn't have an active raft group, we should check
-		// whether or not it is active. If not, we should process the replica
-		// because it has probably already been removed from its raft group but
-		// doesn't know it. Without this, node decommissioning can stall on such
-		// dormant ranges. Make sure NodeLiveness isn't nil because it can be in
-		// tests/benchmarks.
-		if repl.store.cfg.NodeLiveness != nil {
-			if liveness, ok := repl.store.cfg.NodeLiveness.Self(); ok && !liveness.Membership.Active() {
-				return true, replicaGCPriorityDefault
-			}
+	replDesc, ok := repl.Desc().GetReplicaDescriptor(repl.store.StoreID())
+	if !ok {
+		return true
+	}
+	if t := replDesc.GetType(); t != roachpb.VOTER_FULL && t != roachpb.NON_VOTER {
+		return true
+	}
+
+	// NodeLiveness can be nil in tests/benchmarks.
+	if repl.store.cfg.NodeLiveness == nil {
+		return false
+	}
+
+	// If a replica doesn't have an active raft group, we should check whether
+	// or not the node is active. If not, we should consider the replica suspect
+	// because it has probably already been removed from its raft group but
+	// doesn't know it. Without this, node decommissioning can stall on such
+	// dormant ranges.
+	raftStatus := repl.RaftStatus()
+	if raftStatus == nil {
+		liveness, ok := repl.store.cfg.NodeLiveness.Self()
+		return ok && !liveness.Membership.Active()
+	}
+
+	livenessMap := repl.store.cfg.NodeLiveness.GetIsLiveMap()
+	switch raftStatus.SoftState.RaftState {
+	// If a replica is a candidate, then by definition it has lost contact with
+	// its leader and possibly the rest of the Raft group, so consider it suspect.
+	case raft.StateCandidate, raft.StatePreCandidate:
+		return true
+
+	// If the replica is a follower, check that the leader is in our range
+	// descriptor and that we're still in touch with it. This handles e.g. a
+	// non-voting replica which has lost its leader.
+	case raft.StateFollower:
+		leadDesc, ok := repl.Desc().GetReplicaDescriptorByID(roachpb.ReplicaID(raftStatus.Lead))
+		if !ok || !livenessMap[leadDesc.NodeID].IsLive {
+			return true
 		}
-	} else if t := replDesc.GetType(); t != roachpb.VOTER_FULL && t != roachpb.NON_VOTER {
-		isSuspect = true
-	} else {
-		switch raftStatus.SoftState.RaftState {
-		case raft.StateCandidate, raft.StatePreCandidate:
-			isSuspect = true
-		case raft.StateLeader:
-			// If the replica is the leader, we check whether it has a quorum.
-			// Otherwise, it's possible that e.g. Node.ResetQuorum will be used
-			// to recover the range elsewhere, and we should relinquish our
-			// lease and GC the range.
-			if repl.store.cfg.NodeLiveness != nil {
-				livenessMap := repl.store.cfg.NodeLiveness.GetIsLiveMap()
-				isSuspect = !repl.Desc().Replicas().CanMakeProgress(func(d roachpb.ReplicaDescriptor) bool {
-					return livenessMap[d.NodeID].IsLive
-				})
+
+	// If the replica is a leader, check that it has a quorum. This handles e.g.
+	// a stuck leader with a lost quorum being replaced via Node.ResetQuorum,
+	// which must cause the stale leader to relinquish its lease and GC itself.
+	case raft.StateLeader:
+		if !repl.Desc().Replicas().CanMakeProgress(func(d roachpb.ReplicaDescriptor) bool {
+			return livenessMap[d.NodeID].IsLive
+		}) {
+			return true
+		}
+	}
+
+	// If the replica is quiesced, consider it suspect if any of the other
+	// voters are unavailable. This tries to detect cases where a quiesced
+	// replica does not notice that it's been removed from the range and then
+	// triggers an underreplicated alert when the range membership changes again
+	// later. In other cases where a quiesced replica fails to notice that it's
+	// been removed it will be GCed during the next periodic check (every 12 hours).
+	if repl.IsQuiescent() {
+		for _, rd := range repl.Desc().Replicas().VoterDescriptors() {
+			if !livenessMap[rd.NodeID].IsLive {
+				return true
 			}
 		}
 	}
-	return replicaGCShouldQueueImpl(now.ToTimestamp(), lastCheck, lastActivity, isSuspect)
+
+	return false
 }
 
-func replicaGCShouldQueueImpl(
-	now, lastCheck, lastActivity hlc.Timestamp, isSuspect bool,
-) (bool, float64) {
-	timeout := ReplicaGCQueueInactivityThreshold
+func replicaGCShouldQueueImpl(now, lastCheck hlc.Timestamp, isSuspect bool) (bool, float64) {
+	timeout := ReplicaGCQueueCheckInterval
 	priority := replicaGCPriorityDefault
 
 	if isSuspect {
-		// If the range is suspect (which happens if its former replica set
-		// ignores it), let it expire much earlier.
-		timeout = ReplicaGCQueueSuspectTimeout
+		timeout = ReplicaGCQueueSuspectCheckInterval
 		priority = replicaGCPrioritySuspect
-	} else if now.Less(lastCheck.Add(ReplicaGCQueueInactivityThreshold.Nanoseconds(), 0)) {
-		// Return false immediately if the previous check was less than the
-		// check interval in the past. Note that we don't do this if the
-		// replica is in candidate state, in which case we want to be more
-		// aggressive - a failed rebalance attempt could have checked this
-		// range, and candidate state suggests that a retry succeeded. See
-		// #7489.
-		return false, 0
 	}
 
-	shouldQ := lastActivity.Add(timeout.Nanoseconds(), 0).Less(now)
-
-	if !shouldQ {
+	// Only queue for GC if the timeout interval has passed since the last check.
+	if !lastCheck.Add(timeout.Nanoseconds(), 0).Less(now) {
 		return false, 0
 	}
-
-	return shouldQ, priority
+	return true, priority
 }
 
 // process performs a consistent lookup on the range descriptor to see if we are


### PR DESCRIPTION
Backport 1/1 commits from #65062.
Backport 1/1 commits from #65609.

/cc @cockroachdb/release @cockroachdb/kv

---

### kvserver: improve suspect replica GC heuristics

The replica GC queue will normally check a replica against the canonical
range descriptor every 12 hours. Under some circumstances the replica
may be considered suspect, which causes it to be checked against the
canonical descriptor every second instead. However, these heuristics
were fairly limited and missed a couple of cases that could cause stale
replicas to linger.

This patch adds two conditions to the suspect replica heuristics:
followers that have lost contact with their leader (which in particular
handles non-voting replicas), and quiescent replicas that lose contact
with any other voters (which could cause false underreplication alerts).

Since this change is expected to increase suspect replica matches, the
`ReplicaGCQueueSuspectCheckInterval` duration between checking suspect
replica descriptors was also increased from 1 to 5 seconds, and the
`replicaGCQueueTimerDuration` interval between replica GCs was increased
from 50 to 100 ms.

The previous logic would take into account replica activity such as
store startup and lease proposals as the offset for timeouts, but this
did not appear to have any significant benefit over simply using the
last check time, so these have been removed and the timeouts given more
appropriate names. The previous logic also failed to enforce the check
interval for suspect replicas, and would always check them in a tight
50ms loop, this has been fixed as well.

Resolves #62075, resolves #60259.

Release note (bug fix): Improved garbage collection of stale replicas by
proactively checking certain replicas that have lost contact with other
voting replicas.

### kvserver: remove replica GC heuristic for quiesced followers

In #65062 we added a condition to the replica GC queue that quiescent
followers with a single unavailable voter would be considered suspect.
This was added to try to detect followers who were partitioned away from
the Raft group during its own removal from the range. However, this case
has a very high false positive rate, and on second thought it is probably
higher than it is worth.

There is already a secondary condition that considers followers who have
lost touch with their leader suspect, which would be somewhat sufficient
in this case, and with a far lower false positive rate. Even though this
heuristic is vulnerable to race conditions, it seems a better fit
considering that in the worst case the replica will always be GCed
within 12 hours anyway. We have also since moved range-level metrics
to the leaseholder, which reduces the impact of these stale replicas.

This patch therefore removes the quiescent replica condition, and
reduces `ReplicaGCQueueSuspectCheckInterval` from 5 to 3 seconds since
we now expect far fewer false positives.

Touches #65202.

Release note: None