### PR TITLE
sql: support parsing a BIT value from hexadecimal digits

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/bit
+++ b/pkg/sql/logictest/testdata/logic_test/bit
@@ -5,7 +5,6 @@ SELECT B'1000101'::BIT(4)::STRING,
 ----
 1000  1000  1000101
 
-
 statement ok
 CREATE TABLE bits (
   a BIT, b BIT(4), c VARBIT, d VARBIT(4),
@@ -293,3 +292,29 @@ SELECT * FROM obitsa
 {01,1001001010101}
 {01,01001001010101}
 {01,11001001010101}
+
+subtest bit_conversions
+
+# Invalid digit in constant literal.
+statement error "A" is not a valid binary digit
+SELECT B'AB'::BIT(8)
+
+# Invalid digit in cast conversion from string.
+statement error "A" is not a valid binary digit
+SELECT 'AB'::BIT(8)
+
+# Conversion from string.
+query T
+SELECT '10101011'::STRING::BIT(8)
+----
+10101011
+
+# Invalid digit in hex cast conversion from string.
+statement error "Z" is not a valid hexadecimal digit
+SELECT 'xZZ'::BIT(8)
+
+# Conversion from string.
+query TT
+SELECT 'xAb'::STRING::BIT(8), 'XaB'::STRING::BIT(8)
+----
+10101011 10101011


### PR DESCRIPTION
Fixes #65183.
Informs #65184.

Release note (sql change): CockroachDB now supports converting strings
of hexadecimal digits prefixed by `x` or `X` to a BIT value, in
the same way as PostgreSQL.

Note that only the conversion via casts is
supported (e.g. `'XAB'::BIT(8)`); PostgreSQL's literal constant syntax
(e.g. `X'AB'::BIT(8)`) continues to have different meaning in
CockroachDB (byte array) due to historical reasons.