### PR TITLE
sql: add a hint for string-to-timestamp cast error

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -310,6 +310,13 @@ CREATE TABLE y (
   b TIMESTAMPTZ AS (a::TIMESTAMPTZ) STORED
 )
 
+# Make sure the error has a hint that mentions parse_timestamp().
+statement error context-dependent operators are not allowed in computed column.*\nHINT:.*use parse_timestamp
+CREATE TABLE y (
+  a STRING,
+  b TIMESTAMP AS (a::TIMESTAMP) STORED
+)
+
 statement error context-dependent operators are not allowed in computed column
 CREATE TABLE y (
   a TIMESTAMPTZ,

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -500,7 +500,13 @@ func (expr *CastExpr) TypeCheck(
 		return nil, pgerror.Newf(pgcode.CannotCoerce, "invalid cast: %s -> %s", castFrom, exprType)
 	}
 	if err := semaCtx.checkVolatility(volatility); err != nil {
-		return nil, pgerror.Wrapf(err, pgcode.InvalidParameterValue, "%s::%s", castFrom, exprType)
+		err = pgerror.Wrapf(err, pgcode.InvalidParameterValue, "%s::%s", castFrom, exprType)
+		// Special cases where we can provide useful hints.
+		if castFrom.Family() == types.StringFamily && exprType.Family() == types.TimestampFamily {
+			err = errors.WithHint(err, "string to timestamp casts are context-dependent because "+
+				"of relative timestamp strings like 'now'; use parse_timestamp() instead.")
+		}
+		return nil, err
 	}
 
 	telemetry.Inc(c)


### PR DESCRIPTION
The timestamp to string cast is marked as non-immutable and
consequently it cannot be used in computed columns. The reason is that
strings like 'now' or 'tomorrow' are supported by the cast.

As a workaround, we have added a `parse_timestamp()` builtin which
does not support the relative timestamp strings and is immutable.

This change adds a hint to the "context-dependent cast is not
supported" error in this case, mentioning that `parse_timestamp()` can
be used instead.

Release note: None