### PR TITLE
docgen: create spec for all sql.y statements

### DIFF
--- a/docs/generated/sql/bnf/abort_stmt.bnf
+++ b/docs/generated/sql/bnf/abort_stmt.bnf
@@ -1,0 +1,2 @@
+abort_stmt ::=
+	'ABORT' opt_abort_mod

--- a/docs/generated/sql/bnf/alter_database_add_region_stmt.bnf
+++ b/docs/generated/sql/bnf/alter_database_add_region_stmt.bnf
@@ -1,0 +1,3 @@
+alter_database_add_region_stmt ::=
+	'ALTER' 'DATABASE' database_name 'ADD' 'REGION' region_name
+	| 'ALTER' 'DATABASE' database_name 'ADD' 'REGION' 'IF' 'NOT' 'EXISTS' region_name

--- a/docs/generated/sql/bnf/alter_database_drop_region_stmt.bnf
+++ b/docs/generated/sql/bnf/alter_database_drop_region_stmt.bnf
@@ -1,0 +1,3 @@
+alter_database_drop_region_stmt ::=
+	'ALTER' 'DATABASE' database_name 'DROP' 'REGION' region_name
+	| 'ALTER' 'DATABASE' database_name 'DROP' 'REGION' 'IF' 'EXISTS' region_name

--- a/docs/generated/sql/bnf/alter_database_owner.bnf
+++ b/docs/generated/sql/bnf/alter_database_owner.bnf
@@ -1,0 +1,2 @@
+alter_database_owner ::=
+	'ALTER' 'DATABASE' database_name 'OWNER' 'TO' role_spec

--- a/docs/generated/sql/bnf/alter_database_primary_region_stmt.bnf
+++ b/docs/generated/sql/bnf/alter_database_primary_region_stmt.bnf
@@ -1,0 +1,2 @@
+alter_database_primary_region_stmt ::=
+	'ALTER' 'DATABASE' database_name primary_region_clause

--- a/docs/generated/sql/bnf/alter_database_stmt.bnf
+++ b/docs/generated/sql/bnf/alter_database_stmt.bnf
@@ -1,0 +1,9 @@
+alter_database_stmt ::=
+	alter_rename_database_stmt
+	| alter_zone_database_stmt
+	| alter_database_owner
+	| alter_database_to_schema_stmt
+	| alter_database_add_region_stmt
+	| alter_database_drop_region_stmt
+	| alter_database_survival_goal_stmt
+	| alter_database_primary_region_stmt

--- a/docs/generated/sql/bnf/alter_database_survival_goal_stmt.bnf
+++ b/docs/generated/sql/bnf/alter_database_survival_goal_stmt.bnf
@@ -1,0 +1,2 @@
+alter_database_survival_goal_stmt ::=
+	'ALTER' 'DATABASE' database_name survival_goal_clause

--- a/docs/generated/sql/bnf/alter_database_to_schema_stmt.bnf
+++ b/docs/generated/sql/bnf/alter_database_to_schema_stmt.bnf
@@ -1,0 +1,2 @@
+alter_database_to_schema_stmt ::=
+	'ALTER' 'DATABASE' database_name 'CONVERT' 'TO' 'SCHEMA' 'WITH' 'PARENT' database_name

--- a/docs/generated/sql/bnf/alter_ddl_stmt.bnf
+++ b/docs/generated/sql/bnf/alter_ddl_stmt.bnf
@@ -1,0 +1,10 @@
+alter_ddl_stmt ::=
+	alter_table_stmt
+	| alter_index_stmt
+	| alter_view_stmt
+	| alter_sequence_stmt
+	| alter_database_stmt
+	| alter_range_stmt
+	| alter_partition_stmt
+	| alter_schema_stmt
+	| alter_type_stmt

--- a/docs/generated/sql/bnf/alter_index_stmt.bnf
+++ b/docs/generated/sql/bnf/alter_index_stmt.bnf
@@ -1,0 +1,7 @@
+alter_index_stmt ::=
+	alter_oneindex_stmt
+	| alter_split_index_stmt
+	| alter_unsplit_index_stmt
+	| alter_scatter_index_stmt
+	| alter_rename_index_stmt
+	| alter_zone_index_stmt

--- a/docs/generated/sql/bnf/alter_partition_stmt.bnf
+++ b/docs/generated/sql/bnf/alter_partition_stmt.bnf
@@ -1,0 +1,2 @@
+alter_partition_stmt ::=
+	alter_zone_partition_stmt

--- a/docs/generated/sql/bnf/alter_range_stmt.bnf
+++ b/docs/generated/sql/bnf/alter_range_stmt.bnf
@@ -1,0 +1,2 @@
+alter_range_stmt ::=
+	alter_zone_range_stmt

--- a/docs/generated/sql/bnf/alter_rename_view_stmt.bnf
+++ b/docs/generated/sql/bnf/alter_rename_view_stmt.bnf
@@ -1,0 +1,5 @@
+alter_rename_view_stmt ::=
+	'ALTER' 'VIEW' relation_expr 'RENAME' 'TO' view_name
+	| 'ALTER' 'MATERIALIZED' 'VIEW' relation_expr 'RENAME' 'TO' view_name
+	| 'ALTER' 'VIEW' 'IF' 'EXISTS' relation_expr 'RENAME' 'TO' view_name
+	| 'ALTER' 'MATERIALIZED' 'VIEW' 'IF' 'EXISTS' relation_expr 'RENAME' 'TO' view_name

--- a/docs/generated/sql/bnf/alter_scatter_index_stmt.bnf
+++ b/docs/generated/sql/bnf/alter_scatter_index_stmt.bnf
@@ -1,0 +1,3 @@
+alter_scatter_index_stmt ::=
+	'ALTER' 'INDEX' table_index_name 'SCATTER'
+	| 'ALTER' 'INDEX' table_index_name 'SCATTER' 'FROM' '(' expr_list ')' 'TO' '(' expr_list ')'

--- a/docs/generated/sql/bnf/alter_scatter_stmt.bnf
+++ b/docs/generated/sql/bnf/alter_scatter_stmt.bnf
@@ -1,0 +1,3 @@
+alter_scatter_stmt ::=
+	'ALTER' 'TABLE' table_name 'SCATTER'
+	| 'ALTER' 'TABLE' table_name 'SCATTER' 'FROM' '(' expr_list ')' 'TO' '(' expr_list ')'

--- a/docs/generated/sql/bnf/alter_sequence_options_stmt.bnf
+++ b/docs/generated/sql/bnf/alter_sequence_options_stmt.bnf
@@ -1,0 +1,3 @@
+alter_sequence_options_stmt ::=
+	'ALTER' 'SEQUENCE' sequence_name sequence_option_list
+	| 'ALTER' 'SEQUENCE' 'IF' 'EXISTS' sequence_name sequence_option_list

--- a/docs/generated/sql/bnf/alter_sequence_owner_stmt.bnf
+++ b/docs/generated/sql/bnf/alter_sequence_owner_stmt.bnf
@@ -1,0 +1,3 @@
+alter_sequence_owner_stmt ::=
+	'ALTER' 'SEQUENCE' relation_expr 'OWNER' 'TO' role_spec
+	| 'ALTER' 'SEQUENCE' 'IF' 'EXISTS' relation_expr 'OWNER' 'TO' role_spec

--- a/docs/generated/sql/bnf/alter_sequence_set_schema_stmt.bnf
+++ b/docs/generated/sql/bnf/alter_sequence_set_schema_stmt.bnf
@@ -1,0 +1,3 @@
+alter_sequence_set_schema_stmt ::=
+	'ALTER' 'SEQUENCE' relation_expr 'SET' 'SCHEMA' schema_name
+	| 'ALTER' 'SEQUENCE' 'IF' 'EXISTS' relation_expr 'SET' 'SCHEMA' schema_name

--- a/docs/generated/sql/bnf/alter_stmt.bnf
+++ b/docs/generated/sql/bnf/alter_stmt.bnf
@@ -1,0 +1,3 @@
+alter_stmt ::=
+	alter_ddl_stmt
+	| alter_role_stmt

--- a/docs/generated/sql/bnf/alter_table_locality_stmt.bnf
+++ b/docs/generated/sql/bnf/alter_table_locality_stmt.bnf
@@ -1,0 +1,3 @@
+alter_table_locality_stmt ::=
+	'ALTER' 'TABLE' relation_expr 'SET' locality
+	| 'ALTER' 'TABLE' 'IF' 'EXISTS' relation_expr 'SET' locality

--- a/docs/generated/sql/bnf/alter_table_owner_stmt.bnf
+++ b/docs/generated/sql/bnf/alter_table_owner_stmt.bnf
@@ -1,0 +1,3 @@
+alter_table_owner_stmt ::=
+	'ALTER' 'TABLE' relation_expr 'OWNER' 'TO' role_spec
+	| 'ALTER' 'TABLE' 'IF' 'EXISTS' relation_expr 'OWNER' 'TO' role_spec

--- a/docs/generated/sql/bnf/alter_table_set_schema_stmt.bnf
+++ b/docs/generated/sql/bnf/alter_table_set_schema_stmt.bnf
@@ -1,0 +1,3 @@
+alter_table_set_schema_stmt ::=
+	'ALTER' 'TABLE' relation_expr 'SET' 'SCHEMA' schema_name
+	| 'ALTER' 'TABLE' 'IF' 'EXISTS' relation_expr 'SET' 'SCHEMA' schema_name

--- a/docs/generated/sql/bnf/alter_table_stmt.bnf
+++ b/docs/generated/sql/bnf/alter_table_stmt.bnf
@@ -1,0 +1,10 @@
+alter_table_stmt ::=
+	alter_onetable_stmt
+	| alter_split_stmt
+	| alter_unsplit_stmt
+	| alter_scatter_stmt
+	| alter_zone_table_stmt
+	| alter_rename_table_stmt
+	| alter_table_set_schema_stmt
+	| alter_table_locality_stmt
+	| alter_table_owner_stmt

--- a/docs/generated/sql/bnf/alter_view_owner_stmt.bnf
+++ b/docs/generated/sql/bnf/alter_view_owner_stmt.bnf
@@ -1,0 +1,5 @@
+alter_view_owner_stmt ::=
+	'ALTER' 'VIEW' relation_expr 'OWNER' 'TO' role_spec
+	| 'ALTER' 'MATERIALIZED' 'VIEW' relation_expr 'OWNER' 'TO' role_spec
+	| 'ALTER' 'VIEW' 'IF' 'EXISTS' relation_expr 'OWNER' 'TO' role_spec
+	| 'ALTER' 'MATERIALIZED' 'VIEW' 'IF' 'EXISTS' relation_expr 'OWNER' 'TO' role_spec

--- a/docs/generated/sql/bnf/alter_view_set_schema_stmt.bnf
+++ b/docs/generated/sql/bnf/alter_view_set_schema_stmt.bnf
@@ -1,0 +1,5 @@
+alter_view_set_schema_stmt ::=
+	'ALTER' 'VIEW' relation_expr 'SET' 'SCHEMA' schema_name
+	| 'ALTER' 'MATERIALIZED' 'VIEW' relation_expr 'SET' 'SCHEMA' schema_name
+	| 'ALTER' 'VIEW' 'IF' 'EXISTS' relation_expr 'SET' 'SCHEMA' schema_name
+	| 'ALTER' 'MATERIALIZED' 'VIEW' 'IF' 'EXISTS' relation_expr 'SET' 'SCHEMA' schema_name

--- a/docs/generated/sql/bnf/begin_stmt.bnf
+++ b/docs/generated/sql/bnf/begin_stmt.bnf
@@ -1,0 +1,19 @@
+begin_stmt ::=
+	'BEGIN' 'TRANSACTION' 'PRIORITY' 'LOW' ( ( ( ',' |  ) ( ( 'PRIORITY' ( 'LOW' | 'NORMAL' | 'HIGH' ) ) | ( 'READ' 'ONLY' | 'READ' 'WRITE' ) | ( 'AS' 'OF' 'SYSTEM' 'TIME' a_expr ) | ( 'DEFERRABLE' | 'NOT' 'DEFERRABLE' ) ) ) )*
+	| 'BEGIN' 'TRANSACTION' 'PRIORITY' 'NORMAL' ( ( ( ',' |  ) ( ( 'PRIORITY' ( 'LOW' | 'NORMAL' | 'HIGH' ) ) | ( 'READ' 'ONLY' | 'READ' 'WRITE' ) | ( 'AS' 'OF' 'SYSTEM' 'TIME' a_expr ) | ( 'DEFERRABLE' | 'NOT' 'DEFERRABLE' ) ) ) )*
+	| 'BEGIN' 'TRANSACTION' 'PRIORITY' 'HIGH' ( ( ( ',' |  ) ( ( 'PRIORITY' ( 'LOW' | 'NORMAL' | 'HIGH' ) ) | ( 'READ' 'ONLY' | 'READ' 'WRITE' ) | ( 'AS' 'OF' 'SYSTEM' 'TIME' a_expr ) | ( 'DEFERRABLE' | 'NOT' 'DEFERRABLE' ) ) ) )*
+	| 'BEGIN' 'TRANSACTION' 'READ' 'ONLY' ( ( ( ',' |  ) ( ( 'PRIORITY' ( 'LOW' | 'NORMAL' | 'HIGH' ) ) | ( 'READ' 'ONLY' | 'READ' 'WRITE' ) | ( 'AS' 'OF' 'SYSTEM' 'TIME' a_expr ) | ( 'DEFERRABLE' | 'NOT' 'DEFERRABLE' ) ) ) )*
+	| 'BEGIN' 'TRANSACTION' 'READ' 'WRITE' ( ( ( ',' |  ) ( ( 'PRIORITY' ( 'LOW' | 'NORMAL' | 'HIGH' ) ) | ( 'READ' 'ONLY' | 'READ' 'WRITE' ) | ( 'AS' 'OF' 'SYSTEM' 'TIME' a_expr ) | ( 'DEFERRABLE' | 'NOT' 'DEFERRABLE' ) ) ) )*
+	| 'BEGIN' 'TRANSACTION' 'AS' 'OF' 'SYSTEM' 'TIME' a_expr ( ( ( ',' |  ) ( ( 'PRIORITY' ( 'LOW' | 'NORMAL' | 'HIGH' ) ) | ( 'READ' 'ONLY' | 'READ' 'WRITE' ) | ( 'AS' 'OF' 'SYSTEM' 'TIME' a_expr ) | ( 'DEFERRABLE' | 'NOT' 'DEFERRABLE' ) ) ) )*
+	| 'BEGIN' 'TRANSACTION' 'DEFERRABLE' ( ( ( ',' |  ) ( ( 'PRIORITY' ( 'LOW' | 'NORMAL' | 'HIGH' ) ) | ( 'READ' 'ONLY' | 'READ' 'WRITE' ) | ( 'AS' 'OF' 'SYSTEM' 'TIME' a_expr ) | ( 'DEFERRABLE' | 'NOT' 'DEFERRABLE' ) ) ) )*
+	| 'BEGIN' 'TRANSACTION' 'NOT' 'DEFERRABLE' ( ( ( ',' |  ) ( ( 'PRIORITY' ( 'LOW' | 'NORMAL' | 'HIGH' ) ) | ( 'READ' 'ONLY' | 'READ' 'WRITE' ) | ( 'AS' 'OF' 'SYSTEM' 'TIME' a_expr ) | ( 'DEFERRABLE' | 'NOT' 'DEFERRABLE' ) ) ) )*
+	| 'BEGIN' 'TRANSACTION' 
+	| 'BEGIN'  'PRIORITY' 'LOW' ( ( ( ',' |  ) ( ( 'PRIORITY' ( 'LOW' | 'NORMAL' | 'HIGH' ) ) | ( 'READ' 'ONLY' | 'READ' 'WRITE' ) | ( 'AS' 'OF' 'SYSTEM' 'TIME' a_expr ) | ( 'DEFERRABLE' | 'NOT' 'DEFERRABLE' ) ) ) )*
+	| 'BEGIN'  'PRIORITY' 'NORMAL' ( ( ( ',' |  ) ( ( 'PRIORITY' ( 'LOW' | 'NORMAL' | 'HIGH' ) ) | ( 'READ' 'ONLY' | 'READ' 'WRITE' ) | ( 'AS' 'OF' 'SYSTEM' 'TIME' a_expr ) | ( 'DEFERRABLE' | 'NOT' 'DEFERRABLE' ) ) ) )*
+	| 'BEGIN'  'PRIORITY' 'HIGH' ( ( ( ',' |  ) ( ( 'PRIORITY' ( 'LOW' | 'NORMAL' | 'HIGH' ) ) | ( 'READ' 'ONLY' | 'READ' 'WRITE' ) | ( 'AS' 'OF' 'SYSTEM' 'TIME' a_expr ) | ( 'DEFERRABLE' | 'NOT' 'DEFERRABLE' ) ) ) )*
+	| 'BEGIN'  'READ' 'ONLY' ( ( ( ',' |  ) ( ( 'PRIORITY' ( 'LOW' | 'NORMAL' | 'HIGH' ) ) | ( 'READ' 'ONLY' | 'READ' 'WRITE' ) | ( 'AS' 'OF' 'SYSTEM' 'TIME' a_expr ) | ( 'DEFERRABLE' | 'NOT' 'DEFERRABLE' ) ) ) )*
+	| 'BEGIN'  'READ' 'WRITE' ( ( ( ',' |  ) ( ( 'PRIORITY' ( 'LOW' | 'NORMAL' | 'HIGH' ) ) | ( 'READ' 'ONLY' | 'READ' 'WRITE' ) | ( 'AS' 'OF' 'SYSTEM' 'TIME' a_expr ) | ( 'DEFERRABLE' | 'NOT' 'DEFERRABLE' ) ) ) )*
+	| 'BEGIN'  'AS' 'OF' 'SYSTEM' 'TIME' a_expr ( ( ( ',' |  ) ( ( 'PRIORITY' ( 'LOW' | 'NORMAL' | 'HIGH' ) ) | ( 'READ' 'ONLY' | 'READ' 'WRITE' ) | ( 'AS' 'OF' 'SYSTEM' 'TIME' a_expr ) | ( 'DEFERRABLE' | 'NOT' 'DEFERRABLE' ) ) ) )*
+	| 'BEGIN'  'DEFERRABLE' ( ( ( ',' |  ) ( ( 'PRIORITY' ( 'LOW' | 'NORMAL' | 'HIGH' ) ) | ( 'READ' 'ONLY' | 'READ' 'WRITE' ) | ( 'AS' 'OF' 'SYSTEM' 'TIME' a_expr ) | ( 'DEFERRABLE' | 'NOT' 'DEFERRABLE' ) ) ) )*
+	| 'BEGIN'  'NOT' 'DEFERRABLE' ( ( ( ',' |  ) ( ( 'PRIORITY' ( 'LOW' | 'NORMAL' | 'HIGH' ) ) | ( 'READ' 'ONLY' | 'READ' 'WRITE' ) | ( 'AS' 'OF' 'SYSTEM' 'TIME' a_expr ) | ( 'DEFERRABLE' | 'NOT' 'DEFERRABLE' ) ) ) )*
+	| 'BEGIN'  

--- a/docs/generated/sql/bnf/begin_transaction.bnf
+++ b/docs/generated/sql/bnf/begin_transaction.bnf
@@ -1,19 +1,2 @@
-begin_stmt ::=
-	'BEGIN' 'TRANSACTION' 'PRIORITY' 'LOW' ( ( ( ',' |  ) ( ( 'PRIORITY' ( 'LOW' | 'NORMAL' | 'HIGH' ) ) | ( 'READ' 'ONLY' | 'READ' 'WRITE' ) | ( 'AS' 'OF' 'SYSTEM' 'TIME' a_expr ) | ( 'DEFERRABLE' | 'NOT' 'DEFERRABLE' ) ) ) )*
-	| 'BEGIN' 'TRANSACTION' 'PRIORITY' 'NORMAL' ( ( ( ',' |  ) ( ( 'PRIORITY' ( 'LOW' | 'NORMAL' | 'HIGH' ) ) | ( 'READ' 'ONLY' | 'READ' 'WRITE' ) | ( 'AS' 'OF' 'SYSTEM' 'TIME' a_expr ) | ( 'DEFERRABLE' | 'NOT' 'DEFERRABLE' ) ) ) )*
-	| 'BEGIN' 'TRANSACTION' 'PRIORITY' 'HIGH' ( ( ( ',' |  ) ( ( 'PRIORITY' ( 'LOW' | 'NORMAL' | 'HIGH' ) ) | ( 'READ' 'ONLY' | 'READ' 'WRITE' ) | ( 'AS' 'OF' 'SYSTEM' 'TIME' a_expr ) | ( 'DEFERRABLE' | 'NOT' 'DEFERRABLE' ) ) ) )*
-	| 'BEGIN' 'TRANSACTION' 'READ' 'ONLY' ( ( ( ',' |  ) ( ( 'PRIORITY' ( 'LOW' | 'NORMAL' | 'HIGH' ) ) | ( 'READ' 'ONLY' | 'READ' 'WRITE' ) | ( 'AS' 'OF' 'SYSTEM' 'TIME' a_expr ) | ( 'DEFERRABLE' | 'NOT' 'DEFERRABLE' ) ) ) )*
-	| 'BEGIN' 'TRANSACTION' 'READ' 'WRITE' ( ( ( ',' |  ) ( ( 'PRIORITY' ( 'LOW' | 'NORMAL' | 'HIGH' ) ) | ( 'READ' 'ONLY' | 'READ' 'WRITE' ) | ( 'AS' 'OF' 'SYSTEM' 'TIME' a_expr ) | ( 'DEFERRABLE' | 'NOT' 'DEFERRABLE' ) ) ) )*
-	| 'BEGIN' 'TRANSACTION' 'AS' 'OF' 'SYSTEM' 'TIME' a_expr ( ( ( ',' |  ) ( ( 'PRIORITY' ( 'LOW' | 'NORMAL' | 'HIGH' ) ) | ( 'READ' 'ONLY' | 'READ' 'WRITE' ) | ( 'AS' 'OF' 'SYSTEM' 'TIME' a_expr ) | ( 'DEFERRABLE' | 'NOT' 'DEFERRABLE' ) ) ) )*
-	| 'BEGIN' 'TRANSACTION' 'DEFERRABLE' ( ( ( ',' |  ) ( ( 'PRIORITY' ( 'LOW' | 'NORMAL' | 'HIGH' ) ) | ( 'READ' 'ONLY' | 'READ' 'WRITE' ) | ( 'AS' 'OF' 'SYSTEM' 'TIME' a_expr ) | ( 'DEFERRABLE' | 'NOT' 'DEFERRABLE' ) ) ) )*
-	| 'BEGIN' 'TRANSACTION' 'NOT' 'DEFERRABLE' ( ( ( ',' |  ) ( ( 'PRIORITY' ( 'LOW' | 'NORMAL' | 'HIGH' ) ) | ( 'READ' 'ONLY' | 'READ' 'WRITE' ) | ( 'AS' 'OF' 'SYSTEM' 'TIME' a_expr ) | ( 'DEFERRABLE' | 'NOT' 'DEFERRABLE' ) ) ) )*
-	| 'BEGIN' 'TRANSACTION' 
-	| 'BEGIN'  'PRIORITY' 'LOW' ( ( ( ',' |  ) ( ( 'PRIORITY' ( 'LOW' | 'NORMAL' | 'HIGH' ) ) | ( 'READ' 'ONLY' | 'READ' 'WRITE' ) | ( 'AS' 'OF' 'SYSTEM' 'TIME' a_expr ) | ( 'DEFERRABLE' | 'NOT' 'DEFERRABLE' ) ) ) )*
-	| 'BEGIN'  'PRIORITY' 'NORMAL' ( ( ( ',' |  ) ( ( 'PRIORITY' ( 'LOW' | 'NORMAL' | 'HIGH' ) ) | ( 'READ' 'ONLY' | 'READ' 'WRITE' ) | ( 'AS' 'OF' 'SYSTEM' 'TIME' a_expr ) | ( 'DEFERRABLE' | 'NOT' 'DEFERRABLE' ) ) ) )*
-	| 'BEGIN'  'PRIORITY' 'HIGH' ( ( ( ',' |  ) ( ( 'PRIORITY' ( 'LOW' | 'NORMAL' | 'HIGH' ) ) | ( 'READ' 'ONLY' | 'READ' 'WRITE' ) | ( 'AS' 'OF' 'SYSTEM' 'TIME' a_expr ) | ( 'DEFERRABLE' | 'NOT' 'DEFERRABLE' ) ) ) )*
-	| 'BEGIN'  'READ' 'ONLY' ( ( ( ',' |  ) ( ( 'PRIORITY' ( 'LOW' | 'NORMAL' | 'HIGH' ) ) | ( 'READ' 'ONLY' | 'READ' 'WRITE' ) | ( 'AS' 'OF' 'SYSTEM' 'TIME' a_expr ) | ( 'DEFERRABLE' | 'NOT' 'DEFERRABLE' ) ) ) )*
-	| 'BEGIN'  'READ' 'WRITE' ( ( ( ',' |  ) ( ( 'PRIORITY' ( 'LOW' | 'NORMAL' | 'HIGH' ) ) | ( 'READ' 'ONLY' | 'READ' 'WRITE' ) | ( 'AS' 'OF' 'SYSTEM' 'TIME' a_expr ) | ( 'DEFERRABLE' | 'NOT' 'DEFERRABLE' ) ) ) )*
-	| 'BEGIN'  'AS' 'OF' 'SYSTEM' 'TIME' a_expr ( ( ( ',' |  ) ( ( 'PRIORITY' ( 'LOW' | 'NORMAL' | 'HIGH' ) ) | ( 'READ' 'ONLY' | 'READ' 'WRITE' ) | ( 'AS' 'OF' 'SYSTEM' 'TIME' a_expr ) | ( 'DEFERRABLE' | 'NOT' 'DEFERRABLE' ) ) ) )*
-	| 'BEGIN'  'DEFERRABLE' ( ( ( ',' |  ) ( ( 'PRIORITY' ( 'LOW' | 'NORMAL' | 'HIGH' ) ) | ( 'READ' 'ONLY' | 'READ' 'WRITE' ) | ( 'AS' 'OF' 'SYSTEM' 'TIME' a_expr ) | ( 'DEFERRABLE' | 'NOT' 'DEFERRABLE' ) ) ) )*
-	| 'BEGIN'  'NOT' 'DEFERRABLE' ( ( ( ',' |  ) ( ( 'PRIORITY' ( 'LOW' | 'NORMAL' | 'HIGH' ) ) | ( 'READ' 'ONLY' | 'READ' 'WRITE' ) | ( 'AS' 'OF' 'SYSTEM' 'TIME' a_expr ) | ( 'DEFERRABLE' | 'NOT' 'DEFERRABLE' ) ) ) )*
-	| 'BEGIN'  
+begin_transaction ::=
+	transaction_mode_list

--- a/docs/generated/sql/bnf/cancel_stmt.bnf
+++ b/docs/generated/sql/bnf/cancel_stmt.bnf
@@ -1,0 +1,4 @@
+cancel_stmt ::=
+	cancel_jobs_stmt
+	| cancel_queries_stmt
+	| cancel_sessions_stmt

--- a/docs/generated/sql/bnf/close_cursor_stmt.bnf
+++ b/docs/generated/sql/bnf/close_cursor_stmt.bnf
@@ -1,0 +1,2 @@
+close_cursor_stmt ::=
+	'CLOSE' 'ALL'

--- a/docs/generated/sql/bnf/create_ddl_stmt.bnf
+++ b/docs/generated/sql/bnf/create_ddl_stmt.bnf
@@ -1,0 +1,9 @@
+create_ddl_stmt ::=
+	create_database_stmt
+	| create_index_stmt
+	| create_schema_stmt
+	| create_table_stmt
+	| create_table_as_stmt
+	| create_type_stmt
+	| create_view_stmt
+	| create_sequence_stmt

--- a/docs/generated/sql/bnf/create_extension_stmt.bnf
+++ b/docs/generated/sql/bnf/create_extension_stmt.bnf
@@ -1,0 +1,3 @@
+create_extension_stmt ::=
+	'CREATE' 'EXTENSION' 'IF' 'NOT' 'EXISTS' name
+	| 'CREATE' 'EXTENSION' name

--- a/docs/generated/sql/bnf/create_replication_stream_stmt.bnf
+++ b/docs/generated/sql/bnf/create_replication_stream_stmt.bnf
@@ -1,0 +1,2 @@
+create_replication_stream_stmt ::=
+	'CREATE' 'REPLICATION' 'STREAM' 'FOR' targets opt_changefeed_sink opt_with_replication_options

--- a/docs/generated/sql/bnf/create_stmt.bnf
+++ b/docs/generated/sql/bnf/create_stmt.bnf
@@ -1,0 +1,8 @@
+create_stmt ::=
+	create_role_stmt
+	| create_ddl_stmt
+	| create_stats_stmt
+	| create_schedule_for_backup_stmt
+	| create_changefeed_stmt
+	| create_replication_stream_stmt
+	| create_extension_stmt

--- a/docs/generated/sql/bnf/deallocate_stmt.bnf
+++ b/docs/generated/sql/bnf/deallocate_stmt.bnf
@@ -1,0 +1,5 @@
+deallocate_stmt ::=
+	'DEALLOCATE' name
+	| 'DEALLOCATE' 'PREPARE' name
+	| 'DEALLOCATE' 'ALL'
+	| 'DEALLOCATE' 'PREPARE' 'ALL'

--- a/docs/generated/sql/bnf/discard_stmt.bnf
+++ b/docs/generated/sql/bnf/discard_stmt.bnf
@@ -1,0 +1,2 @@
+discard_stmt ::=
+	'DISCARD' 'ALL'

--- a/docs/generated/sql/bnf/drop_ddl_stmt.bnf
+++ b/docs/generated/sql/bnf/drop_ddl_stmt.bnf
@@ -1,0 +1,8 @@
+drop_ddl_stmt ::=
+	drop_database_stmt
+	| drop_index_stmt
+	| drop_table_stmt
+	| drop_view_stmt
+	| drop_sequence_stmt
+	| drop_schema_stmt
+	| drop_type_stmt

--- a/docs/generated/sql/bnf/drop_owned_by_stmt.bnf
+++ b/docs/generated/sql/bnf/drop_owned_by_stmt.bnf
@@ -1,0 +1,2 @@
+drop_owned_by_stmt ::=
+	'DROP' 'OWNED' 'BY' role_spec_list opt_drop_behavior

--- a/docs/generated/sql/bnf/drop_schedule_stmt.bnf
+++ b/docs/generated/sql/bnf/drop_schedule_stmt.bnf
@@ -1,0 +1,3 @@
+drop_schedule_stmt ::=
+	'DROP' 'SCHEDULE' a_expr
+	| 'DROP' 'SCHEDULES' select_stmt

--- a/docs/generated/sql/bnf/execute_stmt.bnf
+++ b/docs/generated/sql/bnf/execute_stmt.bnf
@@ -1,0 +1,2 @@
+execute_stmt ::=
+	'EXECUTE' table_alias_name execute_param_clause

--- a/docs/generated/sql/bnf/explainable_stmt.bnf
+++ b/docs/generated/sql/bnf/explainable_stmt.bnf
@@ -1,0 +1,3 @@
+explainable_stmt ::=
+	preparable_stmt
+	| execute_stmt

--- a/docs/generated/sql/bnf/generic_set.bnf
+++ b/docs/generated/sql/bnf/generic_set.bnf
@@ -1,0 +1,2 @@
+generic_set ::=
+	var_name to_or_eq var_list

--- a/docs/generated/sql/bnf/insert_rest.bnf
+++ b/docs/generated/sql/bnf/insert_rest.bnf
@@ -1,0 +1,4 @@
+insert_rest ::=
+	select_stmt
+	| '(' insert_column_list ')' select_stmt
+	| 'DEFAULT' 'VALUES'

--- a/docs/generated/sql/bnf/pause_stmt.bnf
+++ b/docs/generated/sql/bnf/pause_stmt.bnf
@@ -1,0 +1,3 @@
+pause_stmt ::=
+	pause_jobs_stmt
+	| pause_schedules_stmt

--- a/docs/generated/sql/bnf/preparable_stmt.bnf
+++ b/docs/generated/sql/bnf/preparable_stmt.bnf
@@ -1,0 +1,22 @@
+preparable_stmt ::=
+	alter_stmt
+	| backup_stmt
+	| cancel_stmt
+	| create_stmt
+	| delete_stmt
+	| drop_stmt
+	| explain_stmt
+	| import_stmt
+	| insert_stmt
+	| pause_stmt
+	| reset_stmt
+	| restore_stmt
+	| resume_stmt
+	| export_stmt
+	| scrub_stmt
+	| select_stmt
+	| preparable_set_stmt
+	| show_stmt
+	| truncate_stmt
+	| update_stmt
+	| upsert_stmt

--- a/docs/generated/sql/bnf/prepare_stmt.bnf
+++ b/docs/generated/sql/bnf/prepare_stmt.bnf
@@ -1,0 +1,2 @@
+prepare_stmt ::=
+	'PREPARE' table_alias_name prep_type_clause 'AS' preparable_stmt

--- a/docs/generated/sql/bnf/reassign_owned_by_stmt.bnf
+++ b/docs/generated/sql/bnf/reassign_owned_by_stmt.bnf
@@ -1,0 +1,2 @@
+reassign_owned_by_stmt ::=
+	'REASSIGN' 'OWNED' 'BY' role_spec_list 'TO' role_spec

--- a/docs/generated/sql/bnf/reset_csetting_stmt.bnf
+++ b/docs/generated/sql/bnf/reset_csetting_stmt.bnf
@@ -1,0 +1,2 @@
+reset_csetting_stmt ::=
+	'RESET' 'CLUSTER' 'SETTING' var_name

--- a/docs/generated/sql/bnf/reset_session_stmt.bnf
+++ b/docs/generated/sql/bnf/reset_session_stmt.bnf
@@ -1,0 +1,3 @@
+reset_session_stmt ::=
+	'RESET' session_var
+	| 'RESET' 'SESSION' session_var

--- a/docs/generated/sql/bnf/reset_stmt.bnf
+++ b/docs/generated/sql/bnf/reset_stmt.bnf
@@ -1,0 +1,3 @@
+reset_stmt ::=
+	reset_session_stmt
+	| reset_csetting_stmt

--- a/docs/generated/sql/bnf/resume_stmt.bnf
+++ b/docs/generated/sql/bnf/resume_stmt.bnf
@@ -1,0 +1,3 @@
+resume_stmt ::=
+	resume_jobs_stmt
+	| resume_schedules_stmt

--- a/docs/generated/sql/bnf/row_source_extension_stmt.bnf
+++ b/docs/generated/sql/bnf/row_source_extension_stmt.bnf
@@ -1,0 +1,8 @@
+row_source_extension_stmt ::=
+	delete_stmt
+	| explain_stmt
+	| insert_stmt
+	| select_stmt
+	| show_stmt
+	| update_stmt
+	| upsert_stmt

--- a/docs/generated/sql/bnf/scrub_database_stmt.bnf
+++ b/docs/generated/sql/bnf/scrub_database_stmt.bnf
@@ -1,0 +1,2 @@
+scrub_database_stmt ::=
+	'EXPERIMENTAL' 'SCRUB' 'DATABASE' database_name opt_as_of_clause

--- a/docs/generated/sql/bnf/scrub_stmt.bnf
+++ b/docs/generated/sql/bnf/scrub_stmt.bnf
@@ -1,0 +1,3 @@
+scrub_stmt ::=
+	scrub_table_stmt
+	| scrub_database_stmt

--- a/docs/generated/sql/bnf/scrub_table_stmt.bnf
+++ b/docs/generated/sql/bnf/scrub_table_stmt.bnf
@@ -1,0 +1,2 @@
+scrub_table_stmt ::=
+	'EXPERIMENTAL' 'SCRUB' 'TABLE' table_name opt_as_of_clause opt_scrub_options_clause

--- a/docs/generated/sql/bnf/set_csetting_stmt.bnf
+++ b/docs/generated/sql/bnf/set_csetting_stmt.bnf
@@ -1,0 +1,2 @@
+set_csetting_stmt ::=
+	'SET' 'CLUSTER' 'SETTING' var_name to_or_eq var_value

--- a/docs/generated/sql/bnf/set_exprs_internal.bnf
+++ b/docs/generated/sql/bnf/set_exprs_internal.bnf
@@ -1,0 +1,2 @@
+set_exprs_internal ::=
+	'SET' 'ROW' '(' expr_list ')'

--- a/docs/generated/sql/bnf/set_rest_more.bnf
+++ b/docs/generated/sql/bnf/set_rest_more.bnf
@@ -1,0 +1,2 @@
+set_rest_more ::=
+	generic_set

--- a/docs/generated/sql/bnf/set_session_stmt.bnf
+++ b/docs/generated/sql/bnf/set_session_stmt.bnf
@@ -1,0 +1,4 @@
+set_session_stmt ::=
+	'SET' 'SESSION' set_rest_more
+	| 'SET' set_rest_more
+	| 'SET' 'SESSION' 'CHARACTERISTICS' 'AS' 'TRANSACTION' transaction_mode_list

--- a/docs/generated/sql/bnf/set_transaction_stmt.bnf
+++ b/docs/generated/sql/bnf/set_transaction_stmt.bnf
@@ -1,0 +1,3 @@
+set_transaction_stmt ::=
+	'SET' 'TRANSACTION' transaction_mode_list
+	| 'SET' 'SESSION' 'TRANSACTION' transaction_mode_list

--- a/docs/generated/sql/bnf/show_constraints_stmt.bnf
+++ b/docs/generated/sql/bnf/show_constraints_stmt.bnf
@@ -1,0 +1,3 @@
+show_constraints_stmt ::=
+	'SHOW' 'CONSTRAINT' 'FROM' table_name
+	| 'SHOW' 'CONSTRAINTS' 'FROM' table_name

--- a/docs/generated/sql/bnf/show_locality_stmt.bnf
+++ b/docs/generated/sql/bnf/show_locality_stmt.bnf
@@ -1,0 +1,2 @@
+show_locality_stmt ::=
+	'SHOW' 'LOCALITY'

--- a/docs/generated/sql/bnf/show_session_stmt.bnf
+++ b/docs/generated/sql/bnf/show_session_stmt.bnf
@@ -1,0 +1,3 @@
+show_session_stmt ::=
+	'SHOW' session_var
+	| 'SHOW' 'SESSION' session_var

--- a/docs/generated/sql/bnf/show_survival_goal_stmt.bnf
+++ b/docs/generated/sql/bnf/show_survival_goal_stmt.bnf
@@ -1,0 +1,3 @@
+show_survival_goal_stmt ::=
+	'SHOW' 'SURVIVAL' 'GOAL' 'FROM' 'DATABASE'
+	| 'SHOW' 'SURVIVAL' 'GOAL' 'FROM' 'DATABASE' database_name

--- a/docs/generated/sql/bnf/show_transactions_stmt.bnf
+++ b/docs/generated/sql/bnf/show_transactions_stmt.bnf
@@ -1,0 +1,3 @@
+show_transactions_stmt ::=
+	'SHOW' opt_cluster 'TRANSACTIONS'
+	| 'SHOW' 'ALL' opt_cluster 'TRANSACTIONS'

--- a/docs/generated/sql/bnf/show_types_stmt.bnf
+++ b/docs/generated/sql/bnf/show_types_stmt.bnf
@@ -1,0 +1,2 @@
+show_types_stmt ::=
+	'SHOW' 'TYPES'

--- a/docs/generated/sql/bnf/stmt.bnf
+++ b/docs/generated/sql/bnf/stmt.bnf
@@ -1,0 +1,20 @@
+stmt ::=
+	'HELPTOKEN'
+	| preparable_stmt
+	| analyze_stmt
+	| copy_from_stmt
+	| comment_stmt
+	| execute_stmt
+	| deallocate_stmt
+	| discard_stmt
+	| grant_stmt
+	| prepare_stmt
+	| revoke_stmt
+	| savepoint_stmt
+	| reassign_owned_by_stmt
+	| drop_owned_by_stmt
+	| release_stmt
+	| refresh_stmt
+	| nonpreparable_set_stmt
+	| transaction_stmt
+	| close_cursor_stmt

--- a/docs/generated/sql/bnf/transaction_stmt.bnf
+++ b/docs/generated/sql/bnf/transaction_stmt.bnf
@@ -1,0 +1,5 @@
+transaction_stmt ::=
+	begin_stmt
+	| commit_stmt
+	| rollback_stmt
+	| abort_stmt

--- a/docs/generated/sql/bnf/use_stmt.bnf
+++ b/docs/generated/sql/bnf/use_stmt.bnf
@@ -1,0 +1,2 @@
+use_stmt ::=
+	'USE' var_value

--- a/pkg/cmd/docgen/diagrams.go
+++ b/pkg/cmd/docgen/diagrams.go
@@ -11,6 +11,7 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
 	"io"
@@ -82,17 +83,18 @@ func init() {
 				write(filepath.Join(bnfDir, name+".bnf"), g)
 			}
 
-			for _, s := range specs {
+			stmtSpecs, err := getAllStmtSpecs(addr, bnfAPITimeout)
+			if err != nil {
+				log.Fatal(err)
+			}
+			for _, s := range stmtSpecs {
 				if filterRE.MatchString(s.name) == invertMatch {
 					continue
 				}
 				if !quiet {
 					fmt.Println("processing", s.name)
 				}
-				if s.stmt == "" {
-					s.stmt = s.name
-				}
-				g, err := runParse(br(), s.inline, s.stmt, false, s.nosplit, s.match, s.exclude)
+				g, err := runParse(br(), s.inline, s.GetStatement(), false, s.nosplit, s.match, s.exclude)
 				if err != nil {
 					log.Fatalf("%s: %+v", s.name, err)
 				}
@@ -170,10 +172,14 @@ func init() {
 			}
 
 			specMap := make(map[string]stmtSpec)
-			for _, s := range specs {
+			stmtSpecs, err := getAllStmtSpecs(addr, bnfAPITimeout)
+			if err != nil {
+				log.Fatal(err)
+			}
+			for _, s := range stmtSpecs {
 				specMap[s.name] = s
 			}
-			if len(specs) != len(specMap) {
+			if len(stmtSpecs) != len(specMap) {
 				log.Fatal("duplicate spec name")
 			}
 
@@ -279,6 +285,15 @@ type stmtSpec struct {
 	unlink         []string
 	relink         map[string]string
 	nosplit        bool
+}
+
+// GetStatement returns the sql statement of a stmtSpec.
+func (s stmtSpec) GetStatement() string {
+	if s.stmt == "" {
+		return s.name
+	}
+
+	return s.stmt
 }
 
 func runBNF(addr string, bnfAPITimeout time.Duration) ([]byte, error) {
@@ -468,8 +483,7 @@ var specs = []stmtSpec{
 		exclude: []*regexp.Regexp{regexp.MustCompile("'IN'")},
 	},
 	{
-		name: "begin_transaction",
-		stmt: "begin_stmt",
+		name: "begin_stmt",
 		inline: []string{
 			"opt_transaction",
 			"begin_transaction",
@@ -1524,6 +1538,73 @@ var specs = []stmtSpec{
 		name:   "opt_frame_clause",
 		inline: []string{"frame_extent"},
 	},
+}
+
+// getAllStmtSpecs returns a slice of stmtSpecs for all sql.y statements that
+// should have a diagram generated for.
+// getAllStmtSpecs appends to the "specs" slice any sql.y statements that do
+// not have an entry in specs but are not specified to be skipped.
+func getAllStmtSpecs(sqlGrammarFile string, bnfAPITimeout time.Duration) ([]stmtSpec, error) {
+	sqlStmts := make(map[string]struct{})
+	// Map all the sql stmts that are defined in specs.
+	for _, s := range specs {
+		sqlStmts[s.GetStatement()] = struct{}{}
+	}
+
+	file, err := os.Open(sqlGrammarFile)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	bnf, err := runBNF(sqlGrammarFile, bnfAPITimeout)
+	if err != nil {
+		return nil, err
+	}
+
+	br := func() io.Reader {
+		return bytes.NewReader(bnf)
+	}
+
+	grammar, err := extract.ParseGrammar(br())
+	if err != nil {
+		return nil, err
+	}
+
+	stmtRegex := regexp.MustCompile(`%type\s*<tree.Statement>\s*(.*)$`)
+
+	scanner := bufio.NewScanner(file)
+	if err != nil {
+		return nil, err
+	}
+	for scanner.Scan() {
+		text := scanner.Text()
+		if matches := stmtRegex.FindAllStringSubmatch(text, -1); len(matches) > 0 {
+			for _, match := range matches {
+				// The second submatch does not include <tree.Statement>.
+				// We want to get only the stmt names.
+				stmts := strings.Split(match[1], " ")
+				for _, stmt := range stmts {
+					// If the statement does not appear in grammar, the statement
+					// has no branches that are required to be documented, we can
+					// skip it.
+					if _, ok := grammar[stmt]; !ok {
+						continue
+					}
+
+					// If the statement is not defined in specs, create an entry.
+					if _, found := sqlStmts[stmt]; !found {
+						specs = append(specs, stmtSpec{
+							name: stmt,
+						})
+						sqlStmts[stmt] = struct{}{}
+					}
+				}
+			}
+		}
+	}
+
+	return specs, nil
 }
 
 // regList is a common regex used when removing loops from alter and drop


### PR DESCRIPTION
Release note (sql): This is strictly a change for docgen and sql grammar.
Now all sql.y statements (excluding those that are unimplemented or specified
to be skipped) will have automatically have a stmtSpec defined for them and
thus will have a bnf and svg file automatically generated in
cockroachdb/generated-diagrams.