### PR TITLE
build: add build/teamcity-common-support.sh as source to build/teamcity-support.sh

### DIFF
--- a/build/release/teamcity-support.sh
+++ b/build/release/teamcity-support.sh
@@ -18,15 +18,6 @@ tc_end_block() {
   echo "##teamcity[blockClosed name='$1']"
 }
 
-log_into_gcloud() {
-  if [[ "${google_credentials}" ]]; then
-    echo "${google_credentials}" > .google-credentials.json
-    gcloud auth activate-service-account --key-file=.google-credentials.json
-  else
-    echo 'warning: `google_credentials` not set' >&2
-  fi
-}
-
 docker_login_with_google() {
   # https://cloud.google.com/container-registry/docs/advanced-authentication#json-key
   echo "${google_credentials}" | docker login -u _json_key --password-stdin "https://${gcr_hostname}"

--- a/build/teamcity-support.sh
+++ b/build/teamcity-support.sh
@@ -3,6 +3,13 @@
 # root is the absolute path to the root directory of the repository.
 root=$(cd "$(dirname "$0")/.." && pwd)
 
+source "$root/build/teamcity-common-support.sh"
+
+remove_files_on_exit() {
+  common_support_remove_files_on_exit
+}
+trap remove_files_on_exit EXIT
+
 # maybe_ccache turns on ccache to speed up compilation, but only for PR builds.
 # This speeds up the CI cycle for developers while preventing ccache from
 # corrupting a release build.


### PR DESCRIPTION
Also removed duplicate definition log_into_gcloud.

Release note: None

Follow up from https://github.com/cockroachdb/cockroach/pull/65166#pullrequestreview-660046148