### PR TITLE
release-21.1: opt: change SplitScanIntoUnionScans to use UnionAll operators

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/limit
+++ b/pkg/sql/logictest/testdata/logic_test/limit
@@ -331,3 +331,16 @@ SELECT w FROM t ORDER BY k LIMIT 1;
 
 statement ok
 SET disallow_full_table_scans = false;
+
+# Regression test for incorrectly de-duplicating rows before reaching LIMIT. (Issue #65171)
+statement ok
+CREATE TABLE t65171 (x INT, y INT, INDEX(x, y))
+
+statement ok
+INSERT INTO t65171 VALUES (1, 2), (1, 2), (2, 3)
+
+query II
+SELECT * FROM t65171 WHERE x = 1 OR x = 2 ORDER BY y LIMIT 2
+----
+1  2
+1  2

--- a/pkg/sql/opt/exec/execbuilder/testdata/limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/limit
@@ -415,25 +415,25 @@ vectorized: true
     │ estimated row count: 40
     │ order: +date_should_be_completed
     │
-    └── • union
+    └── • union all
         │ estimated row count: 40
         │
-        ├── • union
+        ├── • union all
         │   │ estimated row count: 35
         │   │
-        │   ├── • union
+        │   ├── • union all
         │   │   │ estimated row count: 30
         │   │   │
-        │   │   ├── • union
+        │   │   ├── • union all
         │   │   │   │ estimated row count: 25
         │   │   │   │
-        │   │   │   ├── • union
+        │   │   │   ├── • union all
         │   │   │   │   │ estimated row count: 20
         │   │   │   │   │
-        │   │   │   │   ├── • union
+        │   │   │   │   ├── • union all
         │   │   │   │   │   │ estimated row count: 15
         │   │   │   │   │   │
-        │   │   │   │   │   ├── • union
+        │   │   │   │   │   ├── • union all
         │   │   │   │   │   │   │ estimated row count: 10
         │   │   │   │   │   │   │
         │   │   │   │   │   │   ├── • scan

--- a/pkg/sql/opt/xform/limit_funcs.go
+++ b/pkg/sql/opt/xform/limit_funcs.go
@@ -158,10 +158,10 @@ func (c *CustomFuncs) ScanIsInverted(sp *memo.ScanPrivate) bool {
 	return idx.IsInverted()
 }
 
-// SplitScanIntoUnionScans returns a Union of Scan operators with hard limits
-// that each scan over a single key from the original Scan's constraints. This
-// is beneficial in cases where the original Scan had to scan over many rows but
-// had relatively few keys to scan over.
+// SplitScanIntoUnionScans returns a UnionAll tree of Scan operators with hard
+// limits that each scan over a single key from the original Scan's constraints.
+// This is beneficial in cases where the original Scan had to scan over many
+// rows but had relatively few keys to scan over.
 // TODO(drewk): handle inverted scans.
 func (c *CustomFuncs) SplitScanIntoUnionScans(
 	limitOrdering physical.OrderingChoice, scan memo.RelExpr, sp *memo.ScanPrivate, limit tree.Datum,
@@ -247,10 +247,11 @@ func (c *CustomFuncs) SplitScanIntoUnionScans(
 	}
 	newHardLimit := memo.MakeScanLimit(int64(limitVal), reverse)
 
-	// makeNewUnion extends the Union tree rooted at 'last' to include 'newScan'.
-	// The ColumnIDs of the original Scan are used by the resulting expression.
+	// makeNewUnion extends the UnionAll tree rooted at 'last' to include
+	// 'newScan'. The ColumnIDs of the original Scan are used by the resulting
+	// expression.
 	makeNewUnion := func(last, newScan memo.RelExpr, outCols opt.ColList) memo.RelExpr {
-		return c.e.f.ConstructUnion(last, newScan, &memo.SetPrivate{
+		return c.e.f.ConstructUnionAll(last, newScan, &memo.SetPrivate{
 			LeftCols:  last.Relational().OutputCols.ToList(),
 			RightCols: newScan.Relational().OutputCols.ToList(),
 			OutCols:   outCols,
@@ -258,8 +259,9 @@ func (c *CustomFuncs) SplitScanIntoUnionScans(
 	}
 
 	// Attempt to extract single-key spans and use them to construct limited
-	// Scans. Add these Scans to a Union tree. Any remaining spans will be used to
-	// construct a single unlimited Scan, which will also be added to the Unions.
+	// Scans. Add these Scans to a UnionAll tree. Any remaining spans will be used
+	// to construct a single unlimited Scan, which will also be added to the
+	// UnionAll tree.
 	var noLimitSpans constraint.Spans
 	var last memo.RelExpr
 	for i, n := 0, spans.Count(); i < n; i++ {
@@ -277,7 +279,7 @@ func (c *CustomFuncs) SplitScanIntoUnionScans(
 		}
 		for j, m := 0, singleKeySpans.Count(); j < m; j++ {
 			if last == nil {
-				// This is the first limited Scan, so no Union necessary.
+				// This is the first limited Scan, so no UnionAll necessary.
 				last = c.makeNewScan(sp, cons.Columns, newHardLimit, singleKeySpans.Get(j))
 				continue
 			}
@@ -310,7 +312,7 @@ func (c *CustomFuncs) SplitScanIntoUnionScans(
 	}
 
 	// If any spans could not be used to generate limited Scans, use them to
-	// construct an unlimited Scan and add it to the Union tree.
+	// construct an unlimited Scan and add it to the UnionAll tree.
 	newScanPrivate := c.DuplicateScanPrivate(sp)
 	newScanPrivate.Constraint = &constraint.Constraint{
 		Columns: sp.Constraint.Columns.RemapColumns(sp.Table, newScanPrivate.Table),

--- a/pkg/sql/opt/xform/rules/limit.opt
+++ b/pkg/sql/opt/xform/rules/limit.opt
@@ -55,8 +55,8 @@
     $indexJoinPrivate
 )
 
-# SplitScanIntoUnionScans splits a non-inverted scan under a limit into a union
-# of limited scans. Example:
+# SplitScanIntoUnionScans splits a non-inverted scan under a limit into a
+# union-all of limited scans over disjoint intervals. Example:
 #
 #    CREATE TABLE tab (region STRING, data INT NOT NULL, INDEX (region, data));
 #

--- a/pkg/sql/opt/xform/testdata/external/trading
+++ b/pkg/sql/opt/xform/testdata/external/trading
@@ -606,57 +606,53 @@ project
  │    │    ├── sort
  │    │    │    ├── columns: dealerid:8!null version:16!null
  │    │    │    ├── cardinality: [0 - 4]
- │    │    │    ├── stats: [rows=4, distinct(8,16)=4, null(8,16)=0]
- │    │    │    ├── key: (8,16)
+ │    │    │    ├── stats: [rows=4]
  │    │    │    ├── ordering: -16
  │    │    │    ├── limit hint: 1.00
- │    │    │    └── union
+ │    │    │    └── union-all
  │    │    │         ├── columns: dealerid:8!null version:16!null
  │    │    │         ├── left columns: dealerid:75 version:83
  │    │    │         ├── right columns: dealerid:85 version:93
  │    │    │         ├── cardinality: [0 - 4]
- │    │    │         ├── stats: [rows=4, distinct(8,16)=4, null(8,16)=0]
- │    │    │         ├── key: (8,16)
- │    │    │         ├── union
+ │    │    │         ├── stats: [rows=4]
+ │    │    │         ├── union-all
  │    │    │         │    ├── columns: dealerid:75!null version:83!null
  │    │    │         │    ├── left columns: dealerid:55 version:63
  │    │    │         │    ├── right columns: dealerid:65 version:73
  │    │    │         │    ├── cardinality: [0 - 3]
- │    │    │         │    ├── stats: [rows=3, distinct(75,83)=3, null(75,83)=0]
- │    │    │         │    ├── key: (75,83)
- │    │    │         │    ├── union
+ │    │    │         │    ├── stats: [rows=3]
+ │    │    │         │    ├── union-all
  │    │    │         │    │    ├── columns: dealerid:55!null version:63!null
  │    │    │         │    │    ├── left columns: dealerid:35 version:43
  │    │    │         │    │    ├── right columns: dealerid:45 version:53
  │    │    │         │    │    ├── cardinality: [0 - 2]
- │    │    │         │    │    ├── stats: [rows=2, distinct(55,63)=2, null(55,63)=0]
- │    │    │         │    │    ├── key: (55,63)
+ │    │    │         │    │    ├── stats: [rows=2]
  │    │    │         │    │    ├── scan cardsinfo@cardsinfoversionindex,rev
  │    │    │         │    │    │    ├── columns: dealerid:35!null version:43!null
  │    │    │         │    │    │    ├── constraint: /35/43: [/1 - /1]
  │    │    │         │    │    │    ├── limit: 1(rev)
- │    │    │         │    │    │    ├── stats: [rows=1, distinct(35)=1, null(35)=0, distinct(35,43)=1, null(35,43)=0]
+ │    │    │         │    │    │    ├── stats: [rows=1, distinct(35)=1, null(35)=0]
  │    │    │         │    │    │    ├── key: ()
  │    │    │         │    │    │    └── fd: ()-->(35,43)
  │    │    │         │    │    └── scan cardsinfo@cardsinfoversionindex,rev
  │    │    │         │    │         ├── columns: dealerid:45!null version:53!null
  │    │    │         │    │         ├── constraint: /45/53: [/2 - /2]
  │    │    │         │    │         ├── limit: 1(rev)
- │    │    │         │    │         ├── stats: [rows=1, distinct(45)=1, null(45)=0, distinct(45,53)=1, null(45,53)=0]
+ │    │    │         │    │         ├── stats: [rows=1, distinct(45)=1, null(45)=0]
  │    │    │         │    │         ├── key: ()
  │    │    │         │    │         └── fd: ()-->(45,53)
  │    │    │         │    └── scan cardsinfo@cardsinfoversionindex,rev
  │    │    │         │         ├── columns: dealerid:65!null version:73!null
  │    │    │         │         ├── constraint: /65/73: [/3 - /3]
  │    │    │         │         ├── limit: 1(rev)
- │    │    │         │         ├── stats: [rows=1, distinct(65)=1, null(65)=0, distinct(65,73)=1, null(65,73)=0]
+ │    │    │         │         ├── stats: [rows=1, distinct(65)=1, null(65)=0]
  │    │    │         │         ├── key: ()
  │    │    │         │         └── fd: ()-->(65,73)
  │    │    │         └── scan cardsinfo@cardsinfoversionindex,rev
  │    │    │              ├── columns: dealerid:85!null version:93!null
  │    │    │              ├── constraint: /85/93: [/4 - /4]
  │    │    │              ├── limit: 1(rev)
- │    │    │              ├── stats: [rows=1, distinct(85)=1, null(85)=0, distinct(85,93)=1, null(85,93)=0]
+ │    │    │              ├── stats: [rows=1, distinct(85)=1, null(85)=0]
  │    │    │              ├── key: ()
  │    │    │              └── fd: ()-->(85,93)
  │    │    └── 1

--- a/pkg/sql/opt/xform/testdata/external/trading-mutation
+++ b/pkg/sql/opt/xform/testdata/external/trading-mutation
@@ -612,57 +612,53 @@ project
  │    │    ├── sort
  │    │    │    ├── columns: dealerid:8!null version:16!null
  │    │    │    ├── cardinality: [0 - 4]
- │    │    │    ├── stats: [rows=4, distinct(8,16)=4, null(8,16)=0]
- │    │    │    ├── key: (8,16)
+ │    │    │    ├── stats: [rows=4]
  │    │    │    ├── ordering: -16
  │    │    │    ├── limit hint: 1.00
- │    │    │    └── union
+ │    │    │    └── union-all
  │    │    │         ├── columns: dealerid:8!null version:16!null
  │    │    │         ├── left columns: dealerid:95 version:103
  │    │    │         ├── right columns: dealerid:109 version:117
  │    │    │         ├── cardinality: [0 - 4]
- │    │    │         ├── stats: [rows=4, distinct(8,16)=4, null(8,16)=0]
- │    │    │         ├── key: (8,16)
- │    │    │         ├── union
+ │    │    │         ├── stats: [rows=4]
+ │    │    │         ├── union-all
  │    │    │         │    ├── columns: dealerid:95!null version:103!null
  │    │    │         │    ├── left columns: dealerid:67 version:75
  │    │    │         │    ├── right columns: dealerid:81 version:89
  │    │    │         │    ├── cardinality: [0 - 3]
- │    │    │         │    ├── stats: [rows=3, distinct(95,103)=3, null(95,103)=0]
- │    │    │         │    ├── key: (95,103)
- │    │    │         │    ├── union
+ │    │    │         │    ├── stats: [rows=3]
+ │    │    │         │    ├── union-all
  │    │    │         │    │    ├── columns: dealerid:67!null version:75!null
  │    │    │         │    │    ├── left columns: dealerid:39 version:47
  │    │    │         │    │    ├── right columns: dealerid:53 version:61
  │    │    │         │    │    ├── cardinality: [0 - 2]
- │    │    │         │    │    ├── stats: [rows=2, distinct(67,75)=2, null(67,75)=0]
- │    │    │         │    │    ├── key: (67,75)
+ │    │    │         │    │    ├── stats: [rows=2]
  │    │    │         │    │    ├── scan cardsinfo@cardsinfoversionindex,rev
  │    │    │         │    │    │    ├── columns: dealerid:39!null version:47!null
  │    │    │         │    │    │    ├── constraint: /39/47: [/1 - /1]
  │    │    │         │    │    │    ├── limit: 1(rev)
- │    │    │         │    │    │    ├── stats: [rows=1, distinct(39)=1, null(39)=0, distinct(39,47)=1, null(39,47)=0]
+ │    │    │         │    │    │    ├── stats: [rows=1, distinct(39)=1, null(39)=0]
  │    │    │         │    │    │    ├── key: ()
  │    │    │         │    │    │    └── fd: ()-->(39,47)
  │    │    │         │    │    └── scan cardsinfo@cardsinfoversionindex,rev
  │    │    │         │    │         ├── columns: dealerid:53!null version:61!null
  │    │    │         │    │         ├── constraint: /53/61: [/2 - /2]
  │    │    │         │    │         ├── limit: 1(rev)
- │    │    │         │    │         ├── stats: [rows=1, distinct(53)=1, null(53)=0, distinct(53,61)=1, null(53,61)=0]
+ │    │    │         │    │         ├── stats: [rows=1, distinct(53)=1, null(53)=0]
  │    │    │         │    │         ├── key: ()
  │    │    │         │    │         └── fd: ()-->(53,61)
  │    │    │         │    └── scan cardsinfo@cardsinfoversionindex,rev
  │    │    │         │         ├── columns: dealerid:81!null version:89!null
  │    │    │         │         ├── constraint: /81/89: [/3 - /3]
  │    │    │         │         ├── limit: 1(rev)
- │    │    │         │         ├── stats: [rows=1, distinct(81)=1, null(81)=0, distinct(81,89)=1, null(81,89)=0]
+ │    │    │         │         ├── stats: [rows=1, distinct(81)=1, null(81)=0]
  │    │    │         │         ├── key: ()
  │    │    │         │         └── fd: ()-->(81,89)
  │    │    │         └── scan cardsinfo@cardsinfoversionindex,rev
  │    │    │              ├── columns: dealerid:109!null version:117!null
  │    │    │              ├── constraint: /109/117: [/4 - /4]
  │    │    │              ├── limit: 1(rev)
- │    │    │              ├── stats: [rows=1, distinct(109)=1, null(109)=0, distinct(109,117)=1, null(109,117)=0]
+ │    │    │              ├── stats: [rows=1, distinct(109)=1, null(109)=0]
  │    │    │              ├── key: ()
  │    │    │              └── fd: ()-->(109,117)
  │    │    └── 1

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -308,15 +308,13 @@ index-join kuv
       ├── sort
       │    ├── columns: k:1!null u:2 rowid:4!null
       │    ├── cardinality: [0 - 10]
-      │    ├── key: (1,2,4)
       │    ├── ordering: +2
       │    ├── limit hint: 5.00
-      │    └── union
+      │    └── union-all
       │         ├── columns: k:1!null u:2 rowid:4!null
       │         ├── left columns: k:6 u:7 rowid:9
       │         ├── right columns: k:11 u:12 rowid:14
       │         ├── cardinality: [0 - 10]
-      │         ├── key: (1,2,4)
       │         ├── scan kuv@secondary
       │         │    ├── columns: k:6!null u:7 rowid:9!null
       │         │    ├── constraint: /6/7/9: [/1 - /1]
@@ -837,21 +835,18 @@ limit
  ├── sort
  │    ├── columns: val:2!null data1:6!null
  │    ├── cardinality: [0 - 30]
- │    ├── key: (2,6)
  │    ├── ordering: +6
  │    ├── limit hint: 10.00
- │    └── union
+ │    └── union-all
  │         ├── columns: val:2!null data1:6!null
  │         ├── left columns: val:32 data1:36
  │         ├── right columns: val:42 data1:46
  │         ├── cardinality: [0 - 30]
- │         ├── key: (2,6)
- │         ├── union
+ │         ├── union-all
  │         │    ├── columns: val:32!null data1:36!null
  │         │    ├── left columns: val:12 data1:16
  │         │    ├── right columns: val:22 data1:26
  │         │    ├── cardinality: [0 - 20]
- │         │    ├── key: (32,36)
  │         │    ├── scan index_tab@b
  │         │    │    ├── columns: val:12!null data1:16!null
  │         │    │    ├── constraint: /12/16/17/11: [/1 - /1]
@@ -887,15 +882,13 @@ scalar-group-by
  │    ├── sort
  │    │    ├── columns: region:3!null data1:6!null
  │    │    ├── cardinality: [0 - 2]
- │    │    ├── key: (3,6)
  │    │    ├── ordering: -6
  │    │    ├── limit hint: 1.00
- │    │    └── union
+ │    │    └── union-all
  │    │         ├── columns: region:3!null data1:6!null
  │    │         ├── left columns: region:14 data1:17
  │    │         ├── right columns: region:24 data1:27
  │    │         ├── cardinality: [0 - 2]
- │    │         ├── key: (3,6)
  │    │         ├── scan index_tab@c,rev
  │    │         │    ├── columns: region:14!null data1:17!null
  │    │         │    ├── constraint: /14/17/18/12: [/'US_EAST' - /'US_EAST']
@@ -933,15 +926,13 @@ scalar-group-by
  │    ├── sort
  │    │    ├── columns: latitude:4!null longitude:5!null data1:6!null
  │    │    ├── cardinality: [0 - 2]
- │    │    ├── key: (4-6)
  │    │    ├── ordering: -6
  │    │    ├── limit hint: 1.00
- │    │    └── union
+ │    │    └── union-all
  │    │         ├── columns: latitude:4!null longitude:5!null data1:6!null
  │    │         ├── left columns: latitude:15 longitude:16 data1:17
  │    │         ├── right columns: latitude:25 longitude:26 data1:27
  │    │         ├── cardinality: [0 - 2]
- │    │         ├── key: (4-6)
  │    │         ├── scan index_tab@d,rev
  │    │         │    ├── columns: latitude:15!null longitude:16!null data1:17!null
  │    │         │    ├── constraint: /15/16/17/18/12: [/1/2 - /1/2]
@@ -977,21 +968,18 @@ scalar-group-by
  │    ├── sort
  │    │    ├── columns: val:2!null data1:6!null
  │    │    ├── cardinality: [0 - 3]
- │    │    ├── key: (2,6)
  │    │    ├── ordering: -6
  │    │    ├── limit hint: 1.00
- │    │    └── union
+ │    │    └── union-all
  │    │         ├── columns: val:2!null data1:6!null
  │    │         ├── left columns: val:33 data1:37
  │    │         ├── right columns: val:43 data1:47
  │    │         ├── cardinality: [0 - 3]
- │    │         ├── key: (2,6)
- │    │         ├── union
+ │    │         ├── union-all
  │    │         │    ├── columns: val:33!null data1:37!null
  │    │         │    ├── left columns: val:13 data1:17
  │    │         │    ├── right columns: val:23 data1:27
  │    │         │    ├── cardinality: [0 - 2]
- │    │         │    ├── key: (33,37)
  │    │         │    ├── scan index_tab@b,rev
  │    │         │    │    ├── columns: val:13!null data1:17!null
  │    │         │    │    ├── constraint: /13/17/18/12: [/1 - /1]
@@ -1031,15 +1019,13 @@ limit
  ├── sort
  │    ├── columns: region:3!null data1:6!null data2:7!null
  │    ├── cardinality: [0 - 20]
- │    ├── key: (3,6,7)
  │    ├── ordering: +6,+7
  │    ├── limit hint: 10.00
- │    └── union
+ │    └── union-all
  │         ├── columns: region:3!null data1:6!null data2:7!null
  │         ├── left columns: region:13 data1:16 data2:17
  │         ├── right columns: region:23 data1:26 data2:27
  │         ├── cardinality: [0 - 20]
- │         ├── key: (3,6,7)
  │         ├── scan index_tab@c
  │         │    ├── columns: region:13!null data1:16!null data2:17!null
  │         │    ├── constraint: /13/16/17/11: [/'US_EAST' - /'US_EAST']
@@ -1069,15 +1055,13 @@ limit
  ├── sort
  │    ├── columns: region:3!null data1:6!null data2:7!null
  │    ├── cardinality: [0 - 20]
- │    ├── key: (3,6,7)
  │    ├── ordering: +6,+7
  │    ├── limit hint: 10.00
- │    └── union
+ │    └── union-all
  │         ├── columns: region:3!null data1:6!null data2:7!null
  │         ├── left columns: region:13 data1:16 data2:17
  │         ├── right columns: region:23 data1:26 data2:27
  │         ├── cardinality: [0 - 20]
- │         ├── key: (3,6,7)
  │         ├── scan index_tab@c
  │         │    ├── columns: region:13!null data1:16!null data2:17!null
  │         │    ├── constraint: /13/16/17/11: [/'US_EAST'/4 - /'US_EAST']
@@ -1107,15 +1091,13 @@ limit
  ├── sort
  │    ├── columns: region:3!null data1:6!null data2:7!null
  │    ├── cardinality: [0 - 20]
- │    ├── key: (3,6,7)
  │    ├── ordering: +6,+7
  │    ├── limit hint: 10.00
- │    └── union
+ │    └── union-all
  │         ├── columns: region:3!null data1:6!null data2:7!null
  │         ├── left columns: region:13 data1:16 data2:17
  │         ├── right columns: region:23 data1:26 data2:27
  │         ├── cardinality: [0 - 20]
- │         ├── key: (3,6,7)
  │         ├── scan index_tab@c
  │         │    ├── columns: region:13!null data1:16!null data2:17!null
  │         │    ├── constraint: /13/16/17/11: [/'US_EAST' - /'US_EAST'/2]
@@ -1146,15 +1128,13 @@ limit
  ├── sort
  │    ├── columns: region:3!null data1:6!null data2:7!null
  │    ├── cardinality: [0 - 20]
- │    ├── key: (3,6,7)
  │    ├── ordering: +6,+7
  │    ├── limit hint: 10.00
- │    └── union
+ │    └── union-all
  │         ├── columns: region:3!null data1:6!null data2:7!null
  │         ├── left columns: region:13 data1:16 data2:17
  │         ├── right columns: region:23 data1:26 data2:27
  │         ├── cardinality: [0 - 20]
- │         ├── key: (3,6,7)
  │         ├── scan index_tab@c
  │         │    ├── columns: region:13!null data1:16!null data2:17!null
  │         │    ├── constraint: /13/16/17/11: [/'US_EAST'/4 - /'US_EAST'/999]
@@ -1185,26 +1165,22 @@ limit
  ├── ordering: +6,+7
  ├── sort
  │    ├── columns: latitude:4!null longitude:5 data1:6!null data2:7!null
- │    ├── key: (4-7)
  │    ├── ordering: +6,+7
  │    ├── limit hint: 10.00
- │    └── union
+ │    └── union-all
  │         ├── columns: latitude:4!null longitude:5 data1:6!null data2:7!null
  │         ├── left columns: latitude:74 longitude:75 data1:76 data2:77
  │         ├── right columns: latitude:84 longitude:85 data1:86 data2:87
- │         ├── key: (4-7)
- │         ├── union
+ │         ├── union-all
  │         │    ├── columns: latitude:74!null longitude:75!null data1:76!null data2:77!null
  │         │    ├── left columns: latitude:54 longitude:55 data1:56 data2:57
  │         │    ├── right columns: latitude:64 longitude:65 data1:66 data2:67
  │         │    ├── cardinality: [0 - 30]
- │         │    ├── key: (74-77)
- │         │    ├── union
+ │         │    ├── union-all
  │         │    │    ├── columns: latitude:54!null longitude:55!null data1:56!null data2:57!null
  │         │    │    ├── left columns: latitude:34 longitude:35 data1:36 data2:37
  │         │    │    ├── right columns: latitude:44 longitude:45 data1:46 data2:47
  │         │    │    ├── cardinality: [0 - 20]
- │         │    │    ├── key: (54-57)
  │         │    │    ├── scan index_tab@d
  │         │    │    │    ├── columns: latitude:34!null longitude:35!null data1:36!null data2:37!null
  │         │    │    │    ├── constraint: /34/35/36/37/31: [/10/11 - /10/11]
@@ -1249,15 +1225,13 @@ index-join index_tab
       ├── sort
       │    ├── columns: id:1!null region:3!null data1:6!null data2:7!null
       │    ├── cardinality: [0 - 20]
-      │    ├── key: (1,3,6,7)
       │    ├── ordering: +6
       │    ├── limit hint: 10.00
-      │    └── union
+      │    └── union-all
       │         ├── columns: id:1!null region:3!null data1:6!null data2:7!null
       │         ├── left columns: id:11 region:13 data1:16 data2:17
       │         ├── right columns: id:21 region:23 data1:26 data2:27
       │         ├── cardinality: [0 - 20]
-      │         ├── key: (1,3,6,7)
       │         ├── scan index_tab@c
       │         │    ├── columns: id:11!null region:13!null data1:16!null data2:17!null
       │         │    ├── constraint: /13/16/17/11: [/'US_EAST' - /'US_EAST']
@@ -1286,21 +1260,18 @@ limit
  ├── sort
  │    ├── columns: p:1!null q:2!null r:3!null s:4!null
  │    ├── cardinality: [0 - 15]
- │    ├── key: (1-4)
  │    ├── ordering: +2
  │    ├── limit hint: 5.00
- │    └── union
+ │    └── union-all
  │         ├── columns: p:1!null q:2!null r:3!null s:4!null
  │         ├── left columns: p:16 q:17 r:18 s:19
  │         ├── right columns: p:21 q:22 r:23 s:24
  │         ├── cardinality: [0 - 15]
- │         ├── key: (1-4)
- │         ├── union
+ │         ├── union-all
  │         │    ├── columns: p:16!null q:17!null r:18!null s:19!null
  │         │    ├── left columns: p:6 q:7 r:8 s:9
  │         │    ├── right columns: p:11 q:12 r:13 s:14
  │         │    ├── cardinality: [0 - 10]
- │         │    ├── key: (16-19)
  │         │    ├── scan pqrs
  │         │    │    ├── columns: p:6!null q:7!null r:8!null s:9!null
  │         │    │    ├── constraint: /6/7: [/1 - /1]
@@ -1336,15 +1307,13 @@ limit
  ├── sort
  │    ├── columns: p:1!null q:2!null r:3!null s:4!null
  │    ├── cardinality: [0 - 20]
- │    ├── key: (1-4)
  │    ├── ordering: +4
  │    ├── limit hint: 10.00
- │    └── union
+ │    └── union-all
  │         ├── columns: p:1!null q:2!null r:3!null s:4!null
  │         ├── left columns: p:6 q:7 r:8 s:9
  │         ├── right columns: p:11 q:12 r:13 s:14
  │         ├── cardinality: [0 - 20]
- │         ├── key: (1-4)
  │         ├── scan pqrs@secondary
  │         │    ├── columns: p:6!null q:7!null r:8!null s:9!null
  │         │    ├── constraint: /8/9/6/7: [/1 - /1]
@@ -1374,15 +1343,13 @@ limit
  ├── sort
  │    ├── columns: p:1!null q:2!null r:3!null s:4!null
  │    ├── cardinality: [0 - 10]
- │    ├── key: (1-4)
  │    ├── ordering: +2
  │    ├── limit hint: 5.00
- │    └── union
+ │    └── union-all
  │         ├── columns: p:1!null q:2!null r:3!null s:4!null
  │         ├── left columns: p:6 q:7 r:8 s:9
  │         ├── right columns: p:11 q:12 r:13 s:14
  │         ├── cardinality: [0 - 10]
- │         ├── key: (1-4)
  │         ├── scan pqrs
  │         │    ├── columns: p:6!null q:7!null r:8!null s:9!null
  │         │    ├── constraint: /6/7: [/1 - /1]


### PR DESCRIPTION
Backport 1/1 commits from #65173.

/cc @cockroachdb/release

---

Previously, the `SplitScanIntoUnionScans` rule used `Union` operators
to unify the results of a series of scans over disjoint intervals over
the same table. However, the de-duplication step provided by `Union` is
actually not correct in this case - we want to preserve all rows from the
scans. Ex:
```
statement ok
CREATE TABLE split_test (x INT, y INT, INDEX(x, y))

statement ok
INSERT INTO split_test VALUES (1, 2), (1, 2), (2, 3)

query II
SELECT * FROM split_test WHERE x = 1 OR x = 2 ORDER BY y LIMIT 2
----
1  2
2  3 # expecting 1 2
```

This patch modifies `SplitScanIntoUnionScans` to instead use `UnionAll`
operators, which do not de-duplicate their input.

Fixes #65171

Release note (bug fix): Fixed a bug introduced in 20.2 that caused rows
to be incorrectly de-duplicated from a scan with a non-unique index.
