### PR TITLE
release-21.1: opt: add support for SplitScanIntoUnionScans with enum columns

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -669,6 +669,54 @@ pk  pk2  a   b   j
 statement error cannot drop column crdb_region as it is used to store the region in a REGIONAL BY ROW table\nHINT: You must change the table locality before dropping this table
 ALTER TABLE regional_by_row_table DROP COLUMN crdb_region
 
+# Test that a limited, ordered scan is efficient.
+query T
+SELECT * FROM [EXPLAIN (VERBOSE) SELECT * FROM regional_by_row_table
+ORDER BY pk LIMIT 5] OFFSET 2
+----
+·
+• limit
+│ columns: (pk, pk2, a, b, j)
+│ estimated row count: 5 (missing stats)
+│ count: 5
+│
+└── • sort
+    │ columns: (pk, pk2, a, b, j)
+    │ ordering: +pk
+    │ estimated row count: 15 (missing stats)
+    │ order: +pk
+    │
+    └── • union all
+        │ columns: (pk, pk2, a, b, j)
+        │ estimated row count: 15 (missing stats)
+        │
+        ├── • union all
+        │   │ columns: (pk, pk2, a, b, j)
+        │   │ estimated row count: 10 (missing stats)
+        │   │
+        │   ├── • scan
+        │   │     columns: (pk, pk2, a, b, j)
+        │   │     estimated row count: 5 (missing stats)
+        │   │     table: regional_by_row_table@primary
+        │   │     spans: /"@"-/"@"/PrefixEnd
+        │   │     limit: 5
+        │   │
+        │   └── • scan
+        │         columns: (pk, pk2, a, b, j)
+        │         estimated row count: 5 (missing stats)
+        │         table: regional_by_row_table@primary
+        │         spans: /"\x80"-/"\x80"/PrefixEnd
+        │         limit: 5
+        │
+        └── • scan
+              columns: (pk, pk2, a, b, j)
+              estimated row count: 5 (missing stats)
+              table: regional_by_row_table@primary
+              spans: /"\xc0"-/"\xc0"/PrefixEnd
+              limit: 5
+
+# Tests for locality optimized search.
+
 statement ok
 SET locality_optimized_partitioned_index_scan = false
 

--- a/pkg/sql/opt/constraint/BUILD.bazel
+++ b/pkg/sql/opt/constraint/BUILD.bazel
@@ -36,10 +36,12 @@ go_test(
     embed = [":constraint"],
     deps = [
         "//pkg/settings/cluster",
+        "//pkg/sql/catalog/typedesc",
         "//pkg/sql/opt",
         "//pkg/sql/opt/testutils/testcat",
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
+        "//pkg/util/encoding",
         "//pkg/util/leaktest",
         "//pkg/util/randutil",
     ],

--- a/pkg/sql/opt/constraint/span_test.go
+++ b/pkg/sql/opt/constraint/span_test.go
@@ -19,8 +19,10 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 )
 
 func TestSpanSet(t *testing.T) {
@@ -671,6 +673,7 @@ func TestSpan_KeyCount(t *testing.T) {
 	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 	kcAscAsc := testKeyContext(1, 2)
 	kcDescDesc := testKeyContext(-1, -2)
+	enums := makeEnums(t)
 
 	testCases := []struct {
 		keyCtx   *KeyContext
@@ -791,8 +794,8 @@ func TestSpan_KeyCount(t *testing.T) {
 			span: Span{
 				start:         MakeKey(tree.NewDInt(math.MinInt64)),
 				end:           MakeKey(tree.NewDInt(math.MaxInt64)),
-				startBoundary: false,
-				endBoundary:   false,
+				startBoundary: IncludeBoundary,
+				endBoundary:   IncludeBoundary,
 			},
 			expected: "FAIL",
 		},
@@ -803,10 +806,34 @@ func TestSpan_KeyCount(t *testing.T) {
 			span: Span{
 				start:         MakeKey(tree.NewDInt(math.MaxInt64)),
 				end:           MakeKey(tree.NewDInt(math.MinInt64)),
-				startBoundary: false,
-				endBoundary:   false,
+				startBoundary: IncludeBoundary,
+				endBoundary:   IncludeBoundary,
 			},
 			expected: "FAIL",
+		},
+		{ // 17
+			// Test enums.
+			keyCtx: kcAscAsc,
+			length: 1,
+			span: Span{
+				start:         MakeKey(enums[0]),
+				end:           MakeKey(enums[1]),
+				startBoundary: IncludeBoundary,
+				endBoundary:   IncludeBoundary,
+			},
+			expected: "2",
+		},
+		{ // 18
+			// Test enums.
+			keyCtx: kcAscAsc,
+			length: 1,
+			span: Span{
+				start:         MakeKey(enums[0]),
+				end:           MakeKey(enums[2]),
+				startBoundary: IncludeBoundary,
+				endBoundary:   IncludeBoundary,
+			},
+			expected: "3",
 		},
 	}
 
@@ -830,6 +857,7 @@ func TestSpan_SplitSpan(t *testing.T) {
 	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 	kcAscAsc := testKeyContext(1, 2)
 	kcDescDesc := testKeyContext(-1, -2)
+	enums := makeEnums(t)
 
 	testCases := []struct {
 		keyCtx   *KeyContext
@@ -938,6 +966,30 @@ func TestSpan_SplitSpan(t *testing.T) {
 			span:     ParseSpan(&evalCtx, "[/-1/1 - /5]"),
 			expected: "FAIL",
 		},
+		{ // 13
+			// Test enums.
+			keyCtx: kcAscAsc,
+			length: 1,
+			span: Span{
+				start:         MakeKey(enums[0]),
+				end:           MakeKey(enums[1]),
+				startBoundary: IncludeBoundary,
+				endBoundary:   IncludeBoundary,
+			},
+			expected: "[/'hello' - /'hello'] [/'hey' - /'hey']",
+		},
+		{ // 14
+			// Test enums.
+			keyCtx: kcAscAsc,
+			length: 1,
+			span: Span{
+				start:         MakeKey(enums[0]),
+				end:           MakeKey(enums[2]),
+				startBoundary: IncludeBoundary,
+				endBoundary:   IncludeBoundary,
+			},
+			expected: "[/'hello' - /'hello'] [/'hey' - /'hey'] [/'hi' - /'hi']",
+		},
 	}
 
 	for i, tc := range testCases {
@@ -954,4 +1006,38 @@ func TestSpan_SplitSpan(t *testing.T) {
 			}
 		})
 	}
+}
+
+func makeEnums(t *testing.T) tree.Datums {
+	t.Helper()
+	enumMembers := []string{"hello", "hey", "hi"}
+	enumType := types.MakeEnum(typedesc.TypeIDToOID(500), typedesc.TypeIDToOID(100500))
+	enumType.TypeMeta = types.UserDefinedTypeMetadata{
+		Name: &types.UserDefinedTypeName{
+			Schema: "test",
+			Name:   "greeting",
+		},
+		EnumData: &types.EnumMetadata{
+			LogicalRepresentations: enumMembers,
+			PhysicalRepresentations: [][]byte{
+				encoding.EncodeUntaggedIntValue(nil, 0),
+				encoding.EncodeUntaggedIntValue(nil, 1),
+				encoding.EncodeUntaggedIntValue(nil, 2),
+			},
+			IsMemberReadOnly: make([]bool, len(enumMembers)),
+		},
+	}
+	enumHello, err := tree.MakeDEnumFromLogicalRepresentation(enumType, enumMembers[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	enumHey, err := tree.MakeDEnumFromLogicalRepresentation(enumType, enumMembers[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+	enumHi, err := tree.MakeDEnumFromLogicalRepresentation(enumType, enumMembers[2])
+	if err != nil {
+		t.Fatal(err)
+	}
+	return tree.Datums{enumHello, enumHey, enumHi}
 }

--- a/pkg/sql/opt/exec/execbuilder/testdata/enums
+++ b/pkg/sql/opt/exec/execbuilder/testdata/enums
@@ -95,3 +95,29 @@ scan checks@checks_x_y_idx
       ├── [/'howdy'/2 - /'howdy'/2]
       ├── [/'hi'/2 - /'hi'/2]
       └── [/'cheers'/2 - /'cheers'/2]
+
+# Test that a limited, ordered scan is efficient.
+statement ok
+CREATE TABLE composite_key (x greeting, y INT, PRIMARY KEY (x, y), FAMILY (x, y));
+
+query T
+EXPLAIN (opt) SELECT * FROM composite_key ORDER BY y LIMIT 5
+----
+limit
+ ├── sort
+ │    └── union-all
+ │         ├── union-all
+ │         │    ├── union-all
+ │         │    │    ├── scan composite_key
+ │         │    │    │    ├── constraint: /6/7: [/'hello' - /'hello']
+ │         │    │    │    └── limit: 5
+ │         │    │    └── scan composite_key
+ │         │    │         ├── constraint: /10/11: [/'howdy' - /'howdy']
+ │         │    │         └── limit: 5
+ │         │    └── scan composite_key
+ │         │         ├── constraint: /18/19: [/'hi' - /'hi']
+ │         │         └── limit: 5
+ │         └── scan composite_key
+ │              ├── constraint: /26/27: [/'cheers' - /'cheers']
+ │              └── limit: 5
+ └── 5


### PR DESCRIPTION
Backport 1/1 commits from #65282.

/cc @cockroachdb/release

---

This commit updates the logic in `SplitScanIntoUnionScans` so that
it works with columns that have a user-defined enum column type.
This is important for this optimization to be able to work with
`REGIONAL BY ROW` tables.

Release note (performance improvement): The optimizer can now avoid
full table scans for queries with a LIMIT and ORDER BY clause, where
the ORDER BY columns form a prefix on an index in a REGIONAL BY ROW
table (excluding the crdb_region column). Instead of a full table scan,
at most LIMIT rows are scanned per region.
