### PR TITLE
release-20.2: opt: change SplitScanIntoUnionScans to use UnionAll operators

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/limit
+++ b/pkg/sql/logictest/testdata/logic_test/limit
@@ -189,3 +189,16 @@ SELECT w FROM t ORDER BY k LIMIT 1;
 
 statement ok
 SET disallow_full_table_scans = false;
+
+# Regression test for incorrectly de-duplicating rows before reaching LIMIT. (Issue #65171)
+statement ok
+CREATE TABLE t65171 (x INT, y INT, INDEX(x, y))
+
+statement ok
+INSERT INTO t65171 VALUES (1, 2), (1, 2), (2, 3)
+
+query II
+SELECT * FROM t65171 WHERE x = 1 OR x = 2 ORDER BY y LIMIT 2
+----
+1  2
+1  2

--- a/pkg/sql/opt/xform/limit_funcs.go
+++ b/pkg/sql/opt/xform/limit_funcs.go
@@ -158,10 +158,10 @@ func (c *CustomFuncs) ScanIsInverted(sp *memo.ScanPrivate) bool {
 	return idx.IsInverted()
 }
 
-// SplitScanIntoUnionScans returns a Union of Scan operators with hard limits
-// that each scan over a single key from the original scan's constraints. This
-// is beneficial in cases where the original scan had to scan over many rows but
-// had relatively few keys to scan over.
+// SplitScanIntoUnionScans returns a UnionAll tree of Scan operators with hard
+// limits that each scan over a single key from the original Scan's constraints.
+// This is beneficial in cases where the original scan had to scan over many
+// rows but had relatively few keys to scan over.
 // TODO(drewk): handle inverted scans.
 func (c *CustomFuncs) SplitScanIntoUnionScans(
 	limitOrdering physical.OrderingChoice, scan memo.RelExpr, sp *memo.ScanPrivate, limit tree.Datum,
@@ -235,7 +235,7 @@ func (c *CustomFuncs) SplitScanIntoUnionScans(
 	last := c.makeNewScan(sp, cons.Columns, newHardLimit, newSpans.Get(0))
 	for i, cnt := 1, newSpans.Count(); i < cnt; i++ {
 		newScan := c.makeNewScan(sp, cons.Columns, newHardLimit, newSpans.Get(i))
-		last = c.e.f.ConstructUnion(last, newScan, &memo.SetPrivate{
+		last = c.e.f.ConstructUnionAll(last, newScan, &memo.SetPrivate{
 			LeftCols:  opt.ColSetToList(last.Relational().OutputCols),
 			RightCols: opt.ColSetToList(newScan.Relational().OutputCols),
 			OutCols:   oldColList,

--- a/pkg/sql/opt/xform/rules/limit.opt
+++ b/pkg/sql/opt/xform/rules/limit.opt
@@ -55,8 +55,8 @@
     $indexJoinPrivate
 )
 
-# SplitScanIntoUnionScans splits a non-inverted scan under a limit into a union
-# of limited scans. Example:
+# SplitScanIntoUnionScans splits a non-inverted scan under a limit into a
+# union-all of limited scans over disjoint intervals. Example:
 #
 #    CREATE TABLE tab (region STRING, data INT NOT NULL, INDEX (region, data));
 #

--- a/pkg/sql/opt/xform/testdata/external/trading
+++ b/pkg/sql/opt/xform/testdata/external/trading
@@ -606,57 +606,53 @@ project
  │    │    ├── sort
  │    │    │    ├── columns: dealerid:8!null version:16!null
  │    │    │    ├── cardinality: [0 - 4]
- │    │    │    ├── stats: [rows=4, distinct(8,16)=4, null(8,16)=0]
- │    │    │    ├── key: (8,16)
+ │    │    │    ├── stats: [rows=4]
  │    │    │    ├── ordering: -16
  │    │    │    ├── limit hint: 1.00
- │    │    │    └── union
+ │    │    │    └── union-all
  │    │    │         ├── columns: dealerid:8!null version:16!null
  │    │    │         ├── left columns: dealerid:8!null version:16!null
  │    │    │         ├── right columns: dealerid:65 version:73
  │    │    │         ├── cardinality: [0 - 4]
- │    │    │         ├── stats: [rows=4, distinct(8,16)=4, null(8,16)=0]
- │    │    │         ├── key: (8,16)
- │    │    │         ├── union
+ │    │    │         ├── stats: [rows=4]
+ │    │    │         ├── union-all
  │    │    │         │    ├── columns: dealerid:8!null version:16!null
  │    │    │         │    ├── left columns: dealerid:8!null version:16!null
  │    │    │         │    ├── right columns: dealerid:55 version:63
  │    │    │         │    ├── cardinality: [0 - 3]
- │    │    │         │    ├── stats: [rows=3, distinct(8,16)=3, null(8,16)=0]
- │    │    │         │    ├── key: (8,16)
- │    │    │         │    ├── union
+ │    │    │         │    ├── stats: [rows=3]
+ │    │    │         │    ├── union-all
  │    │    │         │    │    ├── columns: dealerid:8!null version:16!null
  │    │    │         │    │    ├── left columns: dealerid:35 version:43
  │    │    │         │    │    ├── right columns: dealerid:45 version:53
  │    │    │         │    │    ├── cardinality: [0 - 2]
- │    │    │         │    │    ├── stats: [rows=2, distinct(8,16)=2, null(8,16)=0]
- │    │    │         │    │    ├── key: (8,16)
+ │    │    │         │    │    ├── stats: [rows=2]
  │    │    │         │    │    ├── scan cardsinfo@cardsinfoversionindex,rev
  │    │    │         │    │    │    ├── columns: dealerid:35!null version:43!null
  │    │    │         │    │    │    ├── constraint: /35/43: [/1 - /1]
  │    │    │         │    │    │    ├── limit: 1(rev)
- │    │    │         │    │    │    ├── stats: [rows=1, distinct(35)=1, null(35)=0, distinct(35,43)=1, null(35,43)=0]
+ │    │    │         │    │    │    ├── stats: [rows=1, distinct(35)=1, null(35)=0]
  │    │    │         │    │    │    ├── key: ()
  │    │    │         │    │    │    └── fd: ()-->(35,43)
  │    │    │         │    │    └── scan cardsinfo@cardsinfoversionindex,rev
  │    │    │         │    │         ├── columns: dealerid:45!null version:53!null
  │    │    │         │    │         ├── constraint: /45/53: [/2 - /2]
  │    │    │         │    │         ├── limit: 1(rev)
- │    │    │         │    │         ├── stats: [rows=1, distinct(45)=1, null(45)=0, distinct(45,53)=1, null(45,53)=0]
+ │    │    │         │    │         ├── stats: [rows=1, distinct(45)=1, null(45)=0]
  │    │    │         │    │         ├── key: ()
  │    │    │         │    │         └── fd: ()-->(45,53)
  │    │    │         │    └── scan cardsinfo@cardsinfoversionindex,rev
  │    │    │         │         ├── columns: dealerid:55!null version:63!null
  │    │    │         │         ├── constraint: /55/63: [/3 - /3]
  │    │    │         │         ├── limit: 1(rev)
- │    │    │         │         ├── stats: [rows=1, distinct(55)=1, null(55)=0, distinct(55,63)=1, null(55,63)=0]
+ │    │    │         │         ├── stats: [rows=1, distinct(55)=1, null(55)=0]
  │    │    │         │         ├── key: ()
  │    │    │         │         └── fd: ()-->(55,63)
  │    │    │         └── scan cardsinfo@cardsinfoversionindex,rev
  │    │    │              ├── columns: dealerid:65!null version:73!null
  │    │    │              ├── constraint: /65/73: [/4 - /4]
  │    │    │              ├── limit: 1(rev)
- │    │    │              ├── stats: [rows=1, distinct(65)=1, null(65)=0, distinct(65,73)=1, null(65,73)=0]
+ │    │    │              ├── stats: [rows=1, distinct(65)=1, null(65)=0]
  │    │    │              ├── key: ()
  │    │    │              └── fd: ()-->(65,73)
  │    │    └── 1

--- a/pkg/sql/opt/xform/testdata/external/trading-mutation
+++ b/pkg/sql/opt/xform/testdata/external/trading-mutation
@@ -612,57 +612,53 @@ project
  │    │    ├── sort
  │    │    │    ├── columns: dealerid:8!null version:16!null
  │    │    │    ├── cardinality: [0 - 4]
- │    │    │    ├── stats: [rows=4, distinct(8,16)=4, null(8,16)=0]
- │    │    │    ├── key: (8,16)
+ │    │    │    ├── stats: [rows=4]
  │    │    │    ├── ordering: -16
  │    │    │    ├── limit hint: 1.00
- │    │    │    └── union
+ │    │    │    └── union-all
  │    │    │         ├── columns: dealerid:8!null version:16!null
  │    │    │         ├── left columns: dealerid:8!null version:16!null
  │    │    │         ├── right columns: dealerid:81 version:89
  │    │    │         ├── cardinality: [0 - 4]
- │    │    │         ├── stats: [rows=4, distinct(8,16)=4, null(8,16)=0]
- │    │    │         ├── key: (8,16)
- │    │    │         ├── union
+ │    │    │         ├── stats: [rows=4]
+ │    │    │         ├── union-all
  │    │    │         │    ├── columns: dealerid:8!null version:16!null
  │    │    │         │    ├── left columns: dealerid:8!null version:16!null
  │    │    │         │    ├── right columns: dealerid:67 version:75
  │    │    │         │    ├── cardinality: [0 - 3]
- │    │    │         │    ├── stats: [rows=3, distinct(8,16)=3, null(8,16)=0]
- │    │    │         │    ├── key: (8,16)
- │    │    │         │    ├── union
+ │    │    │         │    ├── stats: [rows=3]
+ │    │    │         │    ├── union-all
  │    │    │         │    │    ├── columns: dealerid:8!null version:16!null
  │    │    │         │    │    ├── left columns: dealerid:39 version:47
  │    │    │         │    │    ├── right columns: dealerid:53 version:61
  │    │    │         │    │    ├── cardinality: [0 - 2]
- │    │    │         │    │    ├── stats: [rows=2, distinct(8,16)=2, null(8,16)=0]
- │    │    │         │    │    ├── key: (8,16)
+ │    │    │         │    │    ├── stats: [rows=2]
  │    │    │         │    │    ├── scan cardsinfo@cardsinfoversionindex,rev
  │    │    │         │    │    │    ├── columns: dealerid:39!null version:47!null
  │    │    │         │    │    │    ├── constraint: /39/47: [/1 - /1]
  │    │    │         │    │    │    ├── limit: 1(rev)
- │    │    │         │    │    │    ├── stats: [rows=1, distinct(39)=1, null(39)=0, distinct(39,47)=1, null(39,47)=0]
+ │    │    │         │    │    │    ├── stats: [rows=1, distinct(39)=1, null(39)=0]
  │    │    │         │    │    │    ├── key: ()
  │    │    │         │    │    │    └── fd: ()-->(39,47)
  │    │    │         │    │    └── scan cardsinfo@cardsinfoversionindex,rev
  │    │    │         │    │         ├── columns: dealerid:53!null version:61!null
  │    │    │         │    │         ├── constraint: /53/61: [/2 - /2]
  │    │    │         │    │         ├── limit: 1(rev)
- │    │    │         │    │         ├── stats: [rows=1, distinct(53)=1, null(53)=0, distinct(53,61)=1, null(53,61)=0]
+ │    │    │         │    │         ├── stats: [rows=1, distinct(53)=1, null(53)=0]
  │    │    │         │    │         ├── key: ()
  │    │    │         │    │         └── fd: ()-->(53,61)
  │    │    │         │    └── scan cardsinfo@cardsinfoversionindex,rev
  │    │    │         │         ├── columns: dealerid:67!null version:75!null
  │    │    │         │         ├── constraint: /67/75: [/3 - /3]
  │    │    │         │         ├── limit: 1(rev)
- │    │    │         │         ├── stats: [rows=1, distinct(67)=1, null(67)=0, distinct(67,75)=1, null(67,75)=0]
+ │    │    │         │         ├── stats: [rows=1, distinct(67)=1, null(67)=0]
  │    │    │         │         ├── key: ()
  │    │    │         │         └── fd: ()-->(67,75)
  │    │    │         └── scan cardsinfo@cardsinfoversionindex,rev
  │    │    │              ├── columns: dealerid:81!null version:89!null
  │    │    │              ├── constraint: /81/89: [/4 - /4]
  │    │    │              ├── limit: 1(rev)
- │    │    │              ├── stats: [rows=1, distinct(81)=1, null(81)=0, distinct(81,89)=1, null(81,89)=0]
+ │    │    │              ├── stats: [rows=1, distinct(81)=1, null(81)=0]
  │    │    │              ├── key: ()
  │    │    │              └── fd: ()-->(81,89)
  │    │    └── 1

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -814,21 +814,18 @@ limit
  ├── sort
  │    ├── columns: val:2!null data1:6!null
  │    ├── cardinality: [0 - 30]
- │    ├── key: (2,6)
  │    ├── ordering: +6
  │    ├── limit hint: 10.00
- │    └── union
+ │    └── union-all
  │         ├── columns: val:2!null data1:6!null
  │         ├── left columns: val:2!null data1:6!null
  │         ├── right columns: val:32 data1:36
  │         ├── cardinality: [0 - 30]
- │         ├── key: (2,6)
- │         ├── union
+ │         ├── union-all
  │         │    ├── columns: val:2!null data1:6!null
  │         │    ├── left columns: val:12 data1:16
  │         │    ├── right columns: val:22 data1:26
  │         │    ├── cardinality: [0 - 20]
- │         │    ├── key: (2,6)
  │         │    ├── scan index_tab@b
  │         │    │    ├── columns: val:12!null data1:16!null
  │         │    │    ├── constraint: /12/16/17/11: [/1 - /1]
@@ -864,15 +861,13 @@ scalar-group-by
  │    ├── sort
  │    │    ├── columns: region:3!null data1:6!null
  │    │    ├── cardinality: [0 - 2]
- │    │    ├── key: (3,6)
  │    │    ├── ordering: -6
  │    │    ├── limit hint: 1.00
- │    │    └── union
+ │    │    └── union-all
  │    │         ├── columns: region:3!null data1:6!null
  │    │         ├── left columns: region:14 data1:17
  │    │         ├── right columns: region:24 data1:27
  │    │         ├── cardinality: [0 - 2]
- │    │         ├── key: (3,6)
  │    │         ├── scan index_tab@c,rev
  │    │         │    ├── columns: region:14!null data1:17!null
  │    │         │    ├── constraint: /14/17/18/12: [/'US_EAST' - /'US_EAST']
@@ -910,15 +905,13 @@ scalar-group-by
  │    ├── sort
  │    │    ├── columns: latitude:4!null longitude:5!null data1:6!null
  │    │    ├── cardinality: [0 - 2]
- │    │    ├── key: (4-6)
  │    │    ├── ordering: -6
  │    │    ├── limit hint: 1.00
- │    │    └── union
+ │    │    └── union-all
  │    │         ├── columns: latitude:4!null longitude:5!null data1:6!null
  │    │         ├── left columns: latitude:15 longitude:16 data1:17
  │    │         ├── right columns: latitude:25 longitude:26 data1:27
  │    │         ├── cardinality: [0 - 2]
- │    │         ├── key: (4-6)
  │    │         ├── scan index_tab@d,rev
  │    │         │    ├── columns: latitude:15!null longitude:16!null data1:17!null
  │    │         │    ├── constraint: /15/16/17/18/12: [/1/2 - /1/2]
@@ -954,21 +947,18 @@ scalar-group-by
  │    ├── sort
  │    │    ├── columns: val:2!null data1:6!null
  │    │    ├── cardinality: [0 - 3]
- │    │    ├── key: (2,6)
  │    │    ├── ordering: -6
  │    │    ├── limit hint: 1.00
- │    │    └── union
+ │    │    └── union-all
  │    │         ├── columns: val:2!null data1:6!null
  │    │         ├── left columns: val:2!null data1:6!null
  │    │         ├── right columns: val:33 data1:37
  │    │         ├── cardinality: [0 - 3]
- │    │         ├── key: (2,6)
- │    │         ├── union
+ │    │         ├── union-all
  │    │         │    ├── columns: val:2!null data1:6!null
  │    │         │    ├── left columns: val:13 data1:17
  │    │         │    ├── right columns: val:23 data1:27
  │    │         │    ├── cardinality: [0 - 2]
- │    │         │    ├── key: (2,6)
  │    │         │    ├── scan index_tab@b,rev
  │    │         │    │    ├── columns: val:13!null data1:17!null
  │    │         │    │    ├── constraint: /13/17/18/12: [/1 - /1]
@@ -1008,15 +998,13 @@ limit
  ├── sort
  │    ├── columns: region:3!null data1:6!null data2:7!null
  │    ├── cardinality: [0 - 20]
- │    ├── key: (3,6,7)
  │    ├── ordering: +6,+7
  │    ├── limit hint: 10.00
- │    └── union
+ │    └── union-all
  │         ├── columns: region:3!null data1:6!null data2:7!null
  │         ├── left columns: region:13 data1:16 data2:17
  │         ├── right columns: region:23 data1:26 data2:27
  │         ├── cardinality: [0 - 20]
- │         ├── key: (3,6,7)
  │         ├── scan index_tab@c
  │         │    ├── columns: region:13!null data1:16!null data2:17!null
  │         │    ├── constraint: /13/16/17/11: [/'US_EAST' - /'US_EAST']
@@ -1051,15 +1039,13 @@ index-join index_tab
       ├── sort
       │    ├── columns: id:1!null region:3!null data1:6!null data2:7!null
       │    ├── cardinality: [0 - 20]
-      │    ├── key: (1,3,6,7)
       │    ├── ordering: +6
       │    ├── limit hint: 10.00
-      │    └── union
+      │    └── union-all
       │         ├── columns: id:1!null region:3!null data1:6!null data2:7!null
       │         ├── left columns: id:11 region:13 data1:16 data2:17
       │         ├── right columns: id:21 region:23 data1:26 data2:27
       │         ├── cardinality: [0 - 20]
-      │         ├── key: (1,3,6,7)
       │         ├── scan index_tab@c
       │         │    ├── columns: id:11!null region:13!null data1:16!null data2:17!null
       │         │    ├── constraint: /13/16/17/11: [/'US_EAST' - /'US_EAST']
@@ -1088,21 +1074,18 @@ limit
  ├── sort
  │    ├── columns: p:1!null q:2!null r:3!null s:4!null
  │    ├── cardinality: [0 - 15]
- │    ├── key: (1-4)
  │    ├── ordering: +2
  │    ├── limit hint: 5.00
- │    └── union
+ │    └── union-all
  │         ├── columns: p:1!null q:2!null r:3!null s:4!null
  │         ├── left columns: p:1!null q:2!null r:3!null s:4!null
  │         ├── right columns: p:16 q:17 r:18 s:19
  │         ├── cardinality: [0 - 15]
- │         ├── key: (1-4)
- │         ├── union
+ │         ├── union-all
  │         │    ├── columns: p:1!null q:2!null r:3!null s:4!null
  │         │    ├── left columns: p:6 q:7 r:8 s:9
  │         │    ├── right columns: p:11 q:12 r:13 s:14
  │         │    ├── cardinality: [0 - 10]
- │         │    ├── key: (1-4)
  │         │    ├── scan pqrs
  │         │    │    ├── columns: p:6!null q:7!null r:8!null s:9!null
  │         │    │    ├── constraint: /6/7: [/1 - /1]
@@ -1138,15 +1121,13 @@ limit
  ├── sort
  │    ├── columns: p:1!null q:2!null r:3!null s:4!null
  │    ├── cardinality: [0 - 20]
- │    ├── key: (1-4)
  │    ├── ordering: +4
  │    ├── limit hint: 10.00
- │    └── union
+ │    └── union-all
  │         ├── columns: p:1!null q:2!null r:3!null s:4!null
  │         ├── left columns: p:6 q:7 r:8 s:9
  │         ├── right columns: p:11 q:12 r:13 s:14
  │         ├── cardinality: [0 - 20]
- │         ├── key: (1-4)
  │         ├── scan pqrs@secondary
  │         │    ├── columns: p:6!null q:7!null r:8!null s:9!null
  │         │    ├── constraint: /8/9/6/7: [/1 - /1]
@@ -1176,15 +1157,13 @@ limit
  ├── sort
  │    ├── columns: p:1!null q:2!null r:3!null s:4!null
  │    ├── cardinality: [0 - 10]
- │    ├── key: (1-4)
  │    ├── ordering: +2
  │    ├── limit hint: 5.00
- │    └── union
+ │    └── union-all
  │         ├── columns: p:1!null q:2!null r:3!null s:4!null
  │         ├── left columns: p:6 q:7 r:8 s:9
  │         ├── right columns: p:11 q:12 r:13 s:14
  │         ├── cardinality: [0 - 10]
- │         ├── key: (1-4)
  │         ├── scan pqrs
  │         │    ├── columns: p:6!null q:7!null r:8!null s:9!null
  │         │    ├── constraint: /6/7: [/1 - /1]


### PR DESCRIPTION
Backport 1/1 commits from #65173.

/cc @cockroachdb/release

---

Previously, the `SplitScanIntoUnionScans` rule used `Union` operators
to unify the results of a series of scans over disjoint intervals over
the same table. However, the de-duplication step provided by `Union` is
actually not correct in this case - we want to preserve all rows from the
scans. Ex:
```
statement ok
CREATE TABLE split_test (x INT, y INT, INDEX(x, y))

statement ok
INSERT INTO split_test VALUES (1, 2), (1, 2), (2, 3)

query II
SELECT * FROM split_test WHERE x = 1 OR x = 2 ORDER BY y LIMIT 2
----
1  2
2  3 # expecting 1 2
```

This patch modifies `SplitScanIntoUnionScans` to instead use `UnionAll`
operators, which do not de-duplicate their input.

Fixes #65171

Release note (bug fix): Fixed a bug introduced in 20.2 that caused rows
to be incorrectly de-duplicated from a scan with a non-unique index.
