### PR TITLE
ccl/importccl: skip TestImportJobEventLogging

### DIFF
--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -7124,6 +7124,7 @@ func TestDetachedImport(t *testing.T) {
 
 func TestImportJobEventLogging(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 65290, "flaky test")
 	defer log.ScopeWithoutShowLogs(t).Close(t)
 
 	defer jobs.TestingSetProgressThresholds()()


### PR DESCRIPTION
Refs: #65290

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None