### PR TITLE
cli: add support for `-r` flag to `userfile upload` CLI command

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -1597,4 +1597,46 @@ The bytekey format does not require table-key prefix.`,
 		Name:        "up-to",
 		Description: `Export revisions of data from a backup table up to a specific timestamp.`,
 	}
+
+	Recursive = FlagInfo{
+		Name:      "recursive",
+		Shorthand: "r",
+		Description: `
+When set, the entire subtree rooted at the source directory will be uploaded to
+the destination. Every file in the subtree will be uploaded to the corresponding
+path under the destination; i.e. the relative path will be maintained. À la
+rsync, a trailing slash in the source will avoid creating an additional
+directory level under the destination. The destination can be expressed one of
+four ways: empty (not specified), a relative path, a well-formed URI with no
+host, or a full well-formed URI.
+<PRE>
+
+</PRE>
+If a destination is not specified, the default URI scheme and host will be used,
+and the basename from the source will be used as the destination directory.
+For example: 'userfile://defaultdb.public.userfiles_root/yourdirectory' 
+<PRE>
+
+</PRE>
+If the destination is a relative path such as 'path/to/dir', the default
+userfile URI schema and host will be used
+('userfile://defaultdb.public.userfiles_$user/'), and the relative path will be
+appended to it.
+For example: 'userfile://defaultdb.public.userfiles_root/path/to/dir'
+<PRE>
+
+</PRE>
+If the destination is a well-formed URI with no host, such as
+'userfile:///path/to/dir/', the default userfile URI schema and host will be
+used ('userfile://defaultdb.public.userfiles_$user/').
+For example: 'userfile://defaultdb.public.userfiles_root/path/to/dir'
+<PRE>
+
+</PRE>
+If the destination is a full well-formed URI, such as
+'userfile://db.schema.tablename_prefix/path/to/dir', then it will be used
+verbatim.
+For example: 'userfile://foo.bar.baz_root/path/to/dir'
+`,
+	}
 )

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -57,6 +57,7 @@ func initCLIDefaults() {
 	setImportContextDefaults()
 	setProxyContextDefaults()
 	setTestDirectorySvrContextDefaults()
+	setUserfileContextDefaults()
 
 	initPreFlagsDefaults()
 
@@ -662,6 +663,22 @@ var testDirectorySvrContext struct {
 
 func setTestDirectorySvrContextDefaults() {
 	testDirectorySvrContext.port = 36257
+}
+
+// userfileCtx captures the command-line parameters of the
+// `userfile` command.
+// See below for defaults.
+var userfileCtx struct {
+	// When set, the entire subtree rooted at the source directory will be
+	// uploaded to the destination.
+	recursive bool
+}
+
+// setUserfileContextDefaults sets the default values in userfileCtx.
+// This function is called by initCLIDefaults() and thus re-called in
+// every test that exercises command-line parsing.
+func setUserfileContextDefaults() {
+	userfileCtx.recursive = false
 }
 
 // GetServerCfgStores provides direct public access to the StoreSpecList inside

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -961,6 +961,7 @@ func init() {
 		boolFlag(f, &serverCfg.ExternalIODirConfig.DisableImplicitCredentials, cliflags.ExternalIODisableImplicitCredentials)
 
 	}
+
 	// Multi-tenancy proxy command flags.
 	{
 		f := mtStartSQLProxyCmd.Flags()
@@ -982,6 +983,11 @@ func init() {
 	{
 		f := mtTestDirectorySvr.Flags()
 		intFlag(f, &testDirectorySvrContext.port, cliflags.TestDirectoryListenPort)
+	}
+
+	// userfile upload command.
+	{
+		boolFlag(userFileUploadCmd.Flags(), &userfileCtx.recursive, cliflags.Recursive)
 	}
 }
 

--- a/pkg/cli/import.go
+++ b/pkg/cli/import.go
@@ -111,12 +111,6 @@ func runImport(
 		return err
 	}
 
-	reader, err := openUserFile(source)
-	if err != nil {
-		return err
-	}
-	defer reader.Close()
-
 	connURL, err := url.Parse(conn.url)
 	if err != nil {
 		return err
@@ -139,7 +133,7 @@ func runImport(
 		_, _ = deleteUserFile(ctx, conn, unescapedUserfileURL)
 	}()
 
-	_, err = uploadUserFile(ctx, conn, reader, source, userfileDestinationURI)
+	_, err = uploadUserFile(ctx, conn, source, userfileDestinationURI)
 	if err != nil {
 		return errors.Wrap(err, "failed to upload file to userfile before importing")
 	}

--- a/pkg/cli/userfile.go
+++ b/pkg/cli/userfile.go
@@ -15,6 +15,7 @@ import (
 	"database/sql/driver"
 	"fmt"
 	"io"
+	"io/fs"
 	"net/url"
 	"os"
 	"path"
@@ -45,7 +46,8 @@ var userFileUploadCmd = &cobra.Command{
 	Use:   "upload <source> <destination>",
 	Short: "upload file from source to destination",
 	Long: `
-Uploads a file to the user scoped file storage using a SQL connection.
+Uploads a single file, or, with the -r flag, all the files in the subtree rooted
+at a directory, to the user-scoped file storage using a SQL connection.
 `,
 	Args: cobra.MinimumNArgs(1),
 	RunE: maybeShoutError(runUserFileUpload),
@@ -136,6 +138,52 @@ func runUserFileList(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+func uploadUserFileRecursive(conn *sqlConn, srcDir, dstDir string) error {
+	srcHasTrailingSlash := strings.HasSuffix(srcDir, "/")
+	var err error
+	srcDir, err = filepath.Abs(srcDir)
+	if err != nil {
+		return err
+	}
+	dstDir = strings.TrimSuffix(dstDir, "/")
+	// We append the last element of the (absolute) source path, i.e. the source
+	// directory name, to the destination path in the following two cases:
+	//   1. The user has not specified a destination, i.e. it is empty.
+	//   2. The source has no trailing slash (à la rsync).
+	srcDirBase := filepath.Base(srcDir)
+	if dstDir == "" {
+		dstDir = srcDirBase
+	} else if !srcHasTrailingSlash {
+		dstDir = dstDir + "/" + srcDirBase
+	}
+
+	ctx := context.Background()
+
+	err = filepath.WalkDir(srcDir,
+		func(path string, info fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if !info.IsDir() {
+				relativePath := strings.TrimPrefix(path, srcDir+"/")
+				fmt.Printf("uploading: %s\n", relativePath)
+
+				uploadedFile, err := uploadUserFile(ctx, conn, path, dstDir+"/"+relativePath)
+				if err != nil {
+					return err
+				}
+				fmt.Printf("successfully uploaded to %s\n", uploadedFile)
+			}
+			return nil
+		})
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("successfully uploaded all files in the subtree rooted at %s\n", filepath.Base(srcDir))
+	return nil
+}
+
 func runUserFileUpload(cmd *cobra.Command, args []string) error {
 	conn, err := makeSQLClient("cockroach userfile", useDefaultDb)
 	if err != nil {
@@ -150,20 +198,20 @@ func runUserFileUpload(cmd *cobra.Command, args []string) error {
 		destination = args[1]
 	}
 
-	reader, err := openUserFile(source)
-	if err != nil {
-		return err
-	}
-	defer reader.Close()
-
-	var uploadedFile string
-	if uploadedFile, err = uploadUserFile(context.Background(), conn, reader, source,
-		destination); err != nil {
-		return err
+	if userfileCtx.recursive {
+		if err := uploadUserFileRecursive(conn, source, destination); err != nil {
+			return err
+		}
+	} else {
+		uploadedFile, err := uploadUserFile(context.Background(), conn, source,
+			destination)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("successfully uploaded to %s\n", uploadedFile)
 	}
 
 	telemetry.Count("userfile.command.upload")
-	fmt.Printf("successfully uploaded to %s\n", uploadedFile)
 	return nil
 }
 
@@ -514,8 +562,14 @@ func renameUserFile(
 // This method returns the complete userfile URI representation to which the
 // file is uploaded to.
 func uploadUserFile(
-	ctx context.Context, conn *sqlConn, reader io.Reader, source, destination string,
+	ctx context.Context, conn *sqlConn, source, destination string,
 ) (string, error) {
+	reader, err := openUserFile(source)
+	if err != nil {
+		return "", err
+	}
+	defer reader.Close()
+
 	if err := conn.ensureConn(); err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This change adds the `--recursive` or `-r` flag to the `userfile upload`
CLI command allowing users to upload the entire subtree rooted at a specified
directory to user-scoped file storage. À la `rsync`, a trailing slash in
the source will avoid creating an additional directory level under the
destination.

The logic in this change filepath.Walk()'s the source directory and uses the
existing COPY protocol (similar to `nodelocal upload`) to upload files and
write them to the UserFileTableSystem.

NB: Destination paths must remain constant under normalization. We do not
support paths containing, e.g. `..`, since UserFileTableSystem is not a real
file system.

Release note (cli change): adds the `--recursive` or `-r` flag to the
`userfile upload` CLI command allowing users to upload the entire subtree
rooted at a specified directory to user-scoped file storage:
`userfile upload -r path/to/source/dir destination`

The destination can be expressed one of four ways:
 - empty (not specified)
 - a relative path, such as `path/to/dir`
 - a well-formed URI with no host, such as `userfile:///path/to/dir/`
 - a full well-formed URI, such as
     `userfile://db.schema.tablename_prefix/path/to/dir`

If a destination is not specified, the default URI scheme and host will be
used, and the basename from the source will be used as the destination
directory.
For example: `userfile://defaultdb.public.userfiles_root/yourdirectory`

If the destination is a relative path such as `path/to/dir`, the default
userfile URI schema and host will be used
(`userfile://defaultdb.public.userfiles_$user/`), and the relative path will be
appended to it.
For example: `userfile://defaultdb.public.userfiles_root/path/to/dir`

If the destination is a well-formed URI with no host, such as
`userfile:///path/to/dir/`, the default userfile URI schema and host will be
used (`userfile://defaultdb.public.userfiles_$user/`).
For example: `userfile://defaultdb.public.userfiles_root/path/to/dir`

If the destination is a full well-formed URI, such as
`userfile://db.schema.tablename_prefix/path/to/dir`, then it will be used
verbatim.
For example: `userfile://foo.bar.baz_root/path/to/dir`