### PR TITLE
[release-21.1] vendor: Bump pebble to f7a68a4d19a49e434f7d90e18a0e7a5730799293

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -518,8 +518,8 @@ def go_deps():
         name = "com_github_cockroachdb_pebble",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/cockroachdb/pebble",
-        sum = "h1:9Ydk2DZyu/YEL1W7Kha7Ax78R2rUvbTgS/U2nW3O8iw=",
-        version = "v0.0.0-20210406181039-e3809b89b488",
+        sum = "h1:o0DLnNsZJLbeduC+0OaD65YHQrt7cwTKYX/oq+kC/eM=",
+        version = "v0.0.0-20210516191704-f7a68a4d19a4",
     )
     go_repository(
         name = "com_github_cockroachdb_redact",

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f
-	github.com/cockroachdb/pebble v0.0.0-20210406181039-e3809b89b488
+	github.com/cockroachdb/pebble v0.0.0-20210516191704-f7a68a4d19a4
 	github.com/cockroachdb/redact v1.0.9
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2

--- a/go.sum
+++ b/go.sum
@@ -203,8 +203,8 @@ github.com/cockroachdb/grpc-gateway v1.14.6-0.20200519165156-52697fc4a249 h1:pZu
 github.com/cockroachdb/grpc-gateway v1.14.6-0.20200519165156-52697fc4a249/go.mod h1:UJ0EZAp832vCd54Wev9N1BMKEyvcZ5+IM0AwDrnlkEc=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f h1:o/kfcElHqOiXqcou5a3rIlMc7oJbMQkeLk0VQJ7zgqY=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/cockroachdb/pebble v0.0.0-20210406181039-e3809b89b488 h1:9Ydk2DZyu/YEL1W7Kha7Ax78R2rUvbTgS/U2nW3O8iw=
-github.com/cockroachdb/pebble v0.0.0-20210406181039-e3809b89b488/go.mod h1:1XpB4cLQcF189RAcWi4gUc110zJgtOfT7SVNGY8sOe0=
+github.com/cockroachdb/pebble v0.0.0-20210516191704-f7a68a4d19a4 h1:o0DLnNsZJLbeduC+0OaD65YHQrt7cwTKYX/oq+kC/eM=
+github.com/cockroachdb/pebble v0.0.0-20210516191704-f7a68a4d19a4/go.mod h1:1XpB4cLQcF189RAcWi4gUc110zJgtOfT7SVNGY8sOe0=
 github.com/cockroachdb/redact v1.0.8/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/redact v1.0.9 h1:sjlUvGorKMIVQfo+w2RqDi5eewCHn453C/vdIXMzjzI=
 github.com/cockroachdb/redact v1.0.9/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=


### PR DESCRIPTION
Changes pulled in:

```
f7a68a4d19a49e434f7d90e18a0e7a5730799293 db: flesh out CompactionInfo.Reason
ae1926b60081c617e4ab1b4f0148fe432dde6fe7 db: add missing options to the OPTIONS file
402772d68425a623f40dba983f0a8907c5c002fa db: fix elision-only compaction max output size
23421fe72d0c8e46df36eee79312d9d71d594c35 *: Don't block flushes on cleaning turns
0f79851d4bc346f3bd99fdcb4b23dfcab55dc207 internal/manifest: Let L0Sublevels get GCd on non-newest Versions
```

Release note (bug fix): Improve memory utilization under some write-heavy
workloads. Add better logging to storage engine to surface compaction
type. Persist previously-missing Pebble options in OPTIONS file.

Release justification: Adds missing logging that will be key
in determining cause of a release blocker.