### PR TITLE
roachtest: use TEAMS.yaml for team metadata

### DIFF
--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -137,6 +137,7 @@ go_library(
         "//pkg/cmd/internal/issues",
         "//pkg/gossip",
         "//pkg/internal/sqlsmith",
+        "//pkg/internal/team",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
         "//pkg/kv",

--- a/pkg/cmd/roachtest/interleavedpartitioned.go
+++ b/pkg/cmd/roachtest/interleavedpartitioned.go
@@ -119,7 +119,7 @@ func registerInterleaved(r *testRegistry) {
 
 	r.Add(testSpec{
 		Name:    "interleavedpartitioned",
-		Owner:   OwnerPartitioning,
+		Owner:   OwnerKV,
 		Cluster: makeClusterSpec(12, geo(), zones("us-east1-b,us-west1-b,europe-west2-b")),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runInterleaved(ctx, t, c,

--- a/pkg/cmd/roachtest/roachmart.go
+++ b/pkg/cmd/roachtest/roachmart.go
@@ -65,7 +65,7 @@ func registerRoachmart(r *testRegistry) {
 		v := v
 		r.Add(testSpec{
 			Name:    fmt.Sprintf("roachmart/partition=%v", v),
-			Owner:   OwnerPartitioning,
+			Owner:   OwnerKV,
 			Cluster: makeClusterSpec(9, geo(), zones("us-central1-b,us-west1-b,europe-west2-b")),
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				runRoachmart(ctx, t, c, v)

--- a/pkg/cmd/roachtest/test_registry.go
+++ b/pkg/cmd/roachtest/test_registry.go
@@ -19,6 +19,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/internal/team"
 	"github.com/cockroachdb/cockroach/pkg/util/version"
 	"github.com/cockroachdb/errors"
 )
@@ -30,72 +31,17 @@ type Owner string
 // The allowable values of Owner.
 const (
 	OwnerSQLExperience Owner = `sql-experience`
-	OwnerBulkIO        Owner = `bulkio`
+	OwnerBulkIO        Owner = `bulk-io`
 	OwnerCDC           Owner = `cdc`
 	OwnerKV            Owner = `kv`
-	OwnerPartitioning  Owner = `partitioning`
 	OwnerServer        Owner = `server`
 	OwnerSQLQueries    Owner = `sql-queries`
 	OwnerSQLSchema     Owner = `sql-schema`
 	OwnerStorage       Owner = `storage`
 )
 
-// OwnerMetadata contains information about a roachtest owning team, such as
-// team slack room, and github project.
-type OwnerMetadata struct {
-	SlackRoom string
-	// Mention is a slice of Github handles to notify (via mentioning) in posted
-	// issues.
-	Mention []string
-	// TriageColumnID is the column id of the project column the team uses to
-	// triage issues. Unfortunately, there appears to be no way to retrieve this
-	// programmatically from the API.
-	//
-	// To find the triage column for a project, run the following curl command:
-	// curl -u yourusername:githubaccesstoken -H "Accept: application/vnd.githubinertia-preview+json" \
-	// https://api.github.com/repos/cockroachdb/cockroach/projects
-	//
-	// Then, for the project you care about, curl its columns URL, which looks
-	// like this:
-	// https://api.github.com/projects/3842382/columns
-	//
-	// Find the triage column you want, and pick its ID field.
-	TriageColumnID int
-}
-
-// roachtestOwners maps an owner in code (as specified on a roachtest spec) to
-// metadata used for github issue posting/slack rooms, etc.
-var roachtestOwners = map[Owner]OwnerMetadata{
-	OwnerSQLExperience: {SlackRoom: `sql-experience`, Mention: []string{`@cockroachdb/sql-experience`},
-		TriageColumnID: 7259065,
-	},
-	OwnerBulkIO: {SlackRoom: `bulk-io`, Mention: []string{`@cockroachdb/bulk-io`},
-		TriageColumnID: 3097123,
-	},
-	OwnerCDC: {SlackRoom: `cdc`, Mention: []string{`@cockroachdb/cdc`},
-		TriageColumnID: 3570120,
-	},
-	OwnerKV: {SlackRoom: `kv`, Mention: []string{`@cockroachdb/kv-triage`},
-		TriageColumnID: 3550674,
-	},
-	// This is an alias for the KV team.
-	OwnerPartitioning: {SlackRoom: `kv`, Mention: []string{`@cockroachdb/kv`},
-		TriageColumnID: 3550674,
-	},
-	OwnerServer: {SlackRoom: `server`, Mention: []string{`@cockroachdb/server`},
-		TriageColumnID: 2521812,
-	},
-	OwnerSQLQueries: {SlackRoom: `sql-queries`, Mention: []string{`@cockroachdb/sql-queries`},
-		TriageColumnID: 13549252,
-	},
-	OwnerSQLSchema: {SlackRoom: `sql-schema`, Mention: []string{`@cockroachdb/sql-schema`},
-		TriageColumnID: 8946818,
-	},
-	OwnerStorage: {SlackRoom: `storage`, Mention: []string{`@cockroachdb/storage`},
-		TriageColumnID: 6668367,
-	},
-	// Only for use in roachtest package unittests.
-	`unittest`: {},
+func ownerToAlias(o Owner) team.Alias {
+	return team.Alias(fmt.Sprintf("cockroachdb/%s", o))
 }
 
 const defaultTag = "default"
@@ -169,7 +115,11 @@ func (r *testRegistry) prepareSpec(spec *testSpec) error {
 	if spec.Owner == `` {
 		return fmt.Errorf(`%s: unspecified owner`, spec.Name)
 	}
-	if _, ok := roachtestOwners[spec.Owner]; !ok {
+	teams, err := team.DefaultLoadTeams()
+	if err != nil {
+		return err
+	}
+	if _, ok := teams[ownerToAlias(spec.Owner)]; !ok {
 		return fmt.Errorf(`%s: unknown owner [%s]`, spec.Name, spec.Owner)
 	}
 	if len(spec.Tags) == 0 {

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/internal/issues"
+	"github.com/cockroachdb/cockroach/pkg/internal/team"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -653,7 +654,12 @@ func (r *testRunner) runTest(
 			shout(ctx, l, stdout, "--- FAIL: %s (%s)\n%s", t.Name(), durationStr, output)
 			// NB: check NodeCount > 0 to avoid posting issues from this pkg's unit tests.
 			if issues.DefaultOptionsFromEnv().CanPost() && t.spec.Run != nil && t.spec.Cluster.NodeCount > 0 {
-				owner := roachtestOwners[t.spec.Owner]
+				teams, err := team.DefaultLoadTeams()
+				if err != nil {
+					t.Fatalf("could not load teams: %v", err)
+				}
+				alias := ownerToAlias(t.spec.Owner)
+				owner := teams[ownerToAlias(t.spec.Owner)]
 
 				branch := "<unknown branch>"
 				if b := os.Getenv("TC_BUILD_BRANCH"); b != "" {
@@ -673,7 +679,7 @@ func (r *testRunner) runTest(
 
 				req := issues.PostRequest{
 					AuthorEmail:     "", // intentionally unset - we add to the board and cc the team
-					Mention:         owner.Mention,
+					Mention:         []string{string(alias)},
 					ProjectColumnID: owner.TriageColumnID,
 					PackageName:     "roachtest",
 					TestName:        t.Name(),

--- a/pkg/cmd/roachtest/test_test.go
+++ b/pkg/cmd/roachtest/test_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/kr/pretty"
 )
 
-const OwnerUnitTest Owner = `unittest`
+const OwnerUnitTest Owner = `unowned`
 
 const defaultParallelism = 10
 


### PR DESCRIPTION
No more duplication of triage_column_id!

Release note: None