### PR TITLE
kvserver: disallow replica rebalancing to dead nodes

### DIFF
--- a/pkg/kv/kvserver/allocator_scorer.go
+++ b/pkg/kv/kvserver/allocator_scorer.go
@@ -422,7 +422,13 @@ func rankedCandidateListForAllocation(
 			continue
 		}
 		if !isNodeValidForRoutineReplicaTransfer(ctx, s.Node.NodeID) {
-			log.VEventf(ctx, 3, "not considering non-ready node n%d for allocate", s.Node.NodeID)
+			log.VEventf(
+				ctx,
+				3,
+				"not considering store s%d as a potential rebalance candidate because it is on a non-live node n%d",
+				s.StoreID,
+				s.Node.NodeID,
+			)
 			continue
 		}
 		constraintsOK, necessary := constraintsCheck(s)
@@ -540,7 +546,7 @@ func rankedCandidateListForRebalancing(
 	allStores StoreList,
 	removalConstraintsChecker constraintsCheckFn,
 	rebalanceConstraintsChecker rebalanceConstraintsCheckFn,
-	existingReplicasForType, replicasWithExcludedStores []roachpb.ReplicaDescriptor,
+	existingReplicasForType, replicasOnExemptedStores []roachpb.ReplicaDescriptor,
 	existingStoreLocalities map[roachpb.StoreID]roachpb.Locality,
 	isNodeValidForRoutineReplicaTransfer func(context.Context, roachpb.NodeID) bool,
 	options scorerOptions,
@@ -550,10 +556,6 @@ func rankedCandidateListForRebalancing(
 	var needRebalanceFrom bool
 	curDiversityScore := rangeDiversityScore(existingStoreLocalities)
 	for _, store := range allStores.stores {
-		if !isNodeValidForRoutineReplicaTransfer(ctx, store.Node.NodeID) {
-			log.VEventf(ctx, 3, "not considering non-ready node n%d for rebalance", store.Node.NodeID)
-			continue
-		}
 		for _, repl := range existingReplicasForType {
 			if store.StoreID != repl.StoreID {
 				continue
@@ -626,10 +628,20 @@ func rankedCandidateListForRebalancing(
 		}
 		var comparableCands candidateList
 		for _, store := range allStores.stores {
-			// Ignore any stores that contain any of the replicas within
-			// `replicasWithExcludedStores`.
-			for _, excluded := range replicasWithExcludedStores {
-				if store.StoreID == excluded.StoreID {
+			// Ignore any stores on dead nodes or stores that contain any of the
+			// replicas within `replicasOnExemptedStores`.
+			if !isNodeValidForRoutineReplicaTransfer(ctx, store.Node.NodeID) {
+				log.VEventf(
+					ctx,
+					3,
+					"not considering store s%d as a potential rebalance candidate because it is on a non-live node n%d",
+					store.StoreID,
+					store.Node.NodeID,
+				)
+				continue
+			}
+			for _, replOnExemptedStore := range replicasOnExemptedStores {
+				if store.StoreID == replOnExemptedStore.StoreID {
 					continue
 				}
 			}

--- a/pkg/kv/kvserver/allocator_scorer.go
+++ b/pkg/kv/kvserver/allocator_scorer.go
@@ -518,15 +518,23 @@ func rankedCandidateListForRemoval(
 	return candidates
 }
 
+// rebalanceOptions contains two candidate lists:
+//
+// 1. a ranked list of existing replicas ordered from best to worst -- i.e.
+// least qualified for rebalancing to most qualified (see `candidateList.best()`
+// and `candidateList.worst()`)
+// 2. a corresponding list of comparable stores that could be legal replacements
+// for the aforementioned existing replicas -- also ordered from `best()` to
+// `worst()`.
 type rebalanceOptions struct {
 	existingCandidates candidateList
 	candidates         candidateList
 }
 
-// rankedCandidateListForRebalancing creates two candidate lists. The first
-// contains all existing replica's stores, ordered from least qualified for
-// rebalancing to most qualified. The second list is of all potential stores
-// that could be used as rebalancing receivers, ordered from best to worst.
+// rankedCandidateListForRebalancing returns a list of `rebalanceOptions`, i.e.
+// groups of candidate stores and the existing replicas that they could legally
+// replace in the range. See comment above `rebalanceOptions()` for more
+// details.
 func rankedCandidateListForRebalancing(
 	ctx context.Context,
 	allStores StoreList,

--- a/pkg/kv/kvserver/allocator_test.go
+++ b/pkg/kv/kvserver/allocator_test.go
@@ -2582,6 +2582,8 @@ func TestAllocateCandidatesExcludeNonReadyNodes(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	// NB: These stores are ordered from least likely to most likely to receive a
+	// replica.
 	stores := []*roachpb.StoreDescriptor{
 		{
 			StoreID:  1,
@@ -2591,17 +2593,17 @@ func TestAllocateCandidatesExcludeNonReadyNodes(t *testing.T) {
 		{
 			StoreID:  2,
 			Node:     roachpb.NodeDescriptor{NodeID: 2},
-			Capacity: roachpb.StoreCapacity{Capacity: 200, Available: 100, RangeCount: 600},
+			Capacity: roachpb.StoreCapacity{Capacity: 200, Available: 100, RangeCount: 450},
 		},
 		{
 			StoreID:  3,
 			Node:     roachpb.NodeDescriptor{NodeID: 3},
-			Capacity: roachpb.StoreCapacity{Capacity: 200, Available: 100, RangeCount: 600},
+			Capacity: roachpb.StoreCapacity{Capacity: 200, Available: 100, RangeCount: 300},
 		},
 		{
 			StoreID:  4,
 			Node:     roachpb.NodeDescriptor{NodeID: 4},
-			Capacity: roachpb.StoreCapacity{Capacity: 200, Available: 100, RangeCount: 600},
+			Capacity: roachpb.StoreCapacity{Capacity: 200, Available: 100, RangeCount: 150},
 		},
 	}
 
@@ -2630,6 +2632,11 @@ func TestAllocateCandidatesExcludeNonReadyNodes(t *testing.T) {
 			[]roachpb.StoreID{1},
 			[]roachpb.StoreID{2, 3, 4},
 			[]roachpb.StoreID{},
+		},
+		{
+			[]roachpb.StoreID{1},
+			[]roachpb.StoreID{2, 4},
+			[]roachpb.StoreID{3},
 		},
 	}
 
@@ -2676,7 +2683,7 @@ func TestAllocateCandidatesExcludeNonReadyNodes(t *testing.T) {
 		})
 
 		t.Run(fmt.Sprintf("%d/rebalance", testIdx), func(t *testing.T) {
-			results := rankedCandidateListForRebalancing(
+			rebalanceOpts := rankedCandidateListForRebalancing(
 				context.Background(),
 				sl,
 				removalConstraintsChecker,
@@ -2687,24 +2694,20 @@ func TestAllocateCandidatesExcludeNonReadyNodes(t *testing.T) {
 				a.storePool.isNodeReadyForRoutineReplicaTransfer,
 				a.scorerOptions(),
 			)
-
-			for i := range results {
-				if !expectedStoreIDsMatch(tc.existing, results[i].existingCandidates) {
-					t.Errorf(
-						"results[%d]: expected existing candidates %v, got %v",
-						i,
-						tc.existing,
-						results[i].existingCandidates,
-					)
+			if len(tc.expected) > 0 {
+				require.Len(t, rebalanceOpts, 1)
+				candidateStores := make([]roachpb.StoreID, len(rebalanceOpts[0].candidates))
+				for i, cand := range rebalanceOpts[0].candidates {
+					candidateStores[i] = cand.store.StoreID
 				}
-				if !expectedStoreIDsMatch(tc.expected, results[i].candidates) {
-					t.Errorf(
-						"results[%d]: expected candidates %v, got %v",
-						i,
-						tc.expected,
-						results[i].candidates,
-					)
+				require.ElementsMatch(t, tc.expected, candidateStores)
+				existingStores := make([]roachpb.StoreID, len(rebalanceOpts[0].existingCandidates))
+				for i, cand := range rebalanceOpts[0].existingCandidates {
+					existingStores[i] = cand.store.StoreID
 				}
+				require.ElementsMatch(t, tc.existing, existingStores)
+			} else {
+				require.Len(t, rebalanceOpts, 0)
 			}
 		})
 	}


### PR DESCRIPTION
The previously existing logic to prevent replica rebalances to dead nodes was
totally broken, and it was never caught because the accompanying unit test was
also broken.

The previous logic had an early return clause during the computation of
diversity stats for _existing replicas_ rather than during the computation of
stats for _potential candidates_. Additionally, the scenario that was
previously created by this unit test was never going to trigger a replica
rebalance, and the unit test would never actually execute any of its checks in
the face of an empty result set.

This commit fixes the check to actually prevent rebalancing to dead nodes and
also re-structures the test.

Noticed while working on #61883.

/cc @cockroachdb/kv

Release note (bug fix): Replica rebalancing could previously sometimes
rebalance to stores on dead nodes. This bug is now fixed.
