### PR TITLE
release-21.1: backupccl: include dropped databases in cluster backups with rev history

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -820,6 +820,62 @@ func backupPlanHook(
 			}
 		}
 
+		defaultURI, urisByLocalityKV, err := getURIsByLocalityKV(to, "")
+		if err != nil {
+			return err
+		}
+
+		makeCloudStorage := p.ExecCfg().DistSQLSrv.ExternalStorageFromURI
+
+		switch encryptionParams.encryptMode {
+		case passphrase:
+			pw, err := pwFn()
+			if err != nil {
+				return err
+			}
+			if err := requireEnterprise("encryption"); err != nil {
+				return err
+			}
+			encryptionParams.encryptionPassphrase = []byte(pw)
+		case kms:
+			encryptionParams.kmsURIs, encryptionParams.kmsEnv, err = kmsFn()
+			if err != nil {
+				return err
+			}
+			if err := requireEnterprise("encryption"); err != nil {
+				return err
+			}
+		}
+
+		// TODO(pbardea): Refactor (defaultURI and urisByLocalityKV) pairs into a
+		// backupDestination struct.
+		collectionURI, defaultURI, resolvedSubdir, urisByLocalityKV, prevs, err :=
+			resolveDest(ctx, p.User(), backupStmt.Nested, backupStmt.AppendToLatest, defaultURI,
+				urisByLocalityKV, makeCloudStorage, endTime, to, incrementalFrom, subdir)
+		if err != nil {
+			return err
+		}
+		prevBackups, encryptionOptions, err := fetchPreviousBackups(ctx, p.User(), makeCloudStorage, prevs,
+			encryptionParams)
+		if err != nil {
+			return err
+		}
+		if len(prevBackups) > 0 {
+			baseManifest := prevBackups[0]
+			if baseManifest.DescriptorCoverage == tree.AllDescriptors &&
+				backupStmt.Coverage() != tree.AllDescriptors {
+				return errors.Errorf("cannot append a backup of specific tables or databases to a cluster backup")
+			}
+		}
+
+		var startTime hlc.Timestamp
+		if len(prevBackups) > 0 {
+			if err := requireEnterprise("incremental"); err != nil {
+				return err
+			}
+			startTime = prevBackups[len(prevBackups)-1].EndTime
+		}
+
 		mvccFilter := MVCCFilter_Latest
 		if backupStmt.Options.CaptureRevisionHistory {
 			if err := requireEnterprise("revision_history"); err != nil {
@@ -839,10 +895,24 @@ func backupPlanHook(
 				return errors.Wrap(err, "failed to resolve targets specified in the BACKUP stmt")
 			}
 		case tree.AllDescriptors:
-			allDescs, err := backupresolver.LoadAllDescs(ctx, p.ExecCfg().Codec, p.ExecCfg().DB, endTime)
+			// Cluster backups include all of the descriptors in the cluster.
+			var allDescs []catalog.Descriptor
+			var err error
+			switch mvccFilter {
+			case MVCCFilter_All:
+				// Usually, revision_history backups include all previous versions of the
+				// descriptors at exist as of end time since they have not been GC'ed yet.
+				// However, since database descriptors are deleted as soon as the database
+				// is deleted, cluster backups need to explicitly go looking for these
+				// dropped descriptors up front.
+				allDescs, err = loadAllDescsInInterval(ctx, p.ExecCfg().Codec, p.ExecCfg().DB, startTime, endTime)
+			case MVCCFilter_Latest:
+				allDescs, err = backupresolver.LoadAllDescs(ctx, p.ExecCfg().Codec, p.ExecCfg().DB, endTime)
+			}
 			if err != nil {
 				return err
 			}
+
 			targetDescs, completeDBs, err = fullClusterTargetsBackup(allDescs)
 			if err != nil {
 				return err
@@ -891,54 +961,6 @@ func backupPlanHook(
 			return err
 		}
 
-		makeCloudStorage := p.ExecCfg().DistSQLSrv.ExternalStorageFromURI
-
-		switch encryptionParams.encryptMode {
-		case passphrase:
-			pw, err := pwFn()
-			if err != nil {
-				return err
-			}
-			if err := requireEnterprise("encryption"); err != nil {
-				return err
-			}
-			encryptionParams.encryptionPassphrase = []byte(pw)
-		case kms:
-			encryptionParams.kmsURIs, encryptionParams.kmsEnv, err = kmsFn()
-			if err != nil {
-				return err
-			}
-			if err := requireEnterprise("encryption"); err != nil {
-				return err
-			}
-		}
-
-		defaultURI, urisByLocalityKV, err := getURIsByLocalityKV(to, "")
-		if err != nil {
-			return err
-		}
-
-		// TODO(pbardea): Refactor (defaultURI and urisByLocalityKV) pairs into a
-		// backupDestination struct.
-		collectionURI, defaultURI, resolvedSubdir, urisByLocalityKV, prevs, err :=
-			resolveDest(ctx, p.User(), backupStmt.Nested, backupStmt.AppendToLatest, defaultURI,
-				urisByLocalityKV, makeCloudStorage, endTime, to, incrementalFrom, subdir)
-		if err != nil {
-			return err
-		}
-		prevBackups, encryptionOptions, err := fetchPreviousBackups(ctx, p.User(), makeCloudStorage, prevs,
-			encryptionParams)
-		if err != nil {
-			return err
-		}
-		if len(prevBackups) > 0 {
-			baseManifest := prevBackups[0]
-			if baseManifest.DescriptorCoverage == tree.AllDescriptors &&
-				backupStmt.Coverage() != tree.AllDescriptors {
-				return errors.Errorf("cannot append a backup of specific tables or databases to a cluster backup")
-			}
-		}
-
 		clusterID := p.ExecCfg().ClusterID()
 		for i := range prevBackups {
 			// IDs are how we identify tables, and those are only meaningful in the
@@ -949,14 +971,7 @@ func backupPlanHook(
 			}
 		}
 
-		var startTime hlc.Timestamp
 		var newSpans roachpb.Spans
-		if len(prevBackups) > 0 {
-			if err := requireEnterprise("incremental"); err != nil {
-				return err
-			}
-			startTime = prevBackups[len(prevBackups)-1].EndTime
-		}
 
 		var priorIDs map[descpb.ID]descpb.ID
 

--- a/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
+++ b/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
@@ -721,6 +721,7 @@ func TestClusterRevisionHistory(t *testing.T) {
 	_, _, sqlDB, tempDir, cleanupFn := BackupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)
 	defer cleanupFn()
 	sqlDB.Exec(t, `CREATE DATABASE d1`)
+	sqlDB.Exec(t, `CREATE TABLE d1.t (a INT)`)
 	sqlDB.QueryRow(t, `SELECT cluster_logical_timestamp()`).Scan(&ts[0])
 	tc = testCase{
 		ts: ts[0],
@@ -732,6 +733,7 @@ func TestClusterRevisionHistory(t *testing.T) {
 	testCases = append(testCases, tc)
 
 	sqlDB.Exec(t, `CREATE DATABASE d2`)
+	sqlDB.Exec(t, `CREATE TABLE d2.t (a INT)`)
 	sqlDB.QueryRow(t, `SELECT cluster_logical_timestamp()`).Scan(&ts[1])
 	tc = testCase{
 		ts: ts[1],
@@ -749,7 +751,9 @@ func TestClusterRevisionHistory(t *testing.T) {
 		ts: ts[2],
 		check: func(t *testing.T, checkSQLDB *sqlutils.SQLRunner) {
 			checkSQLDB.Exec(t, `CREATE DATABASE d1`)
+			checkSQLDB.Exec(t, `CREATE TABLE d1.t (a INT)`)
 			checkSQLDB.ExpectErr(t, `database "d2" already exists`, `CREATE DATABASE d2`)
+			checkSQLDB.ExpectErr(t, `relation "d2.public.t" already exists`, `CREATE TABLE d2.t (a INT)`)
 		},
 	}
 	testCases = append(testCases, tc)
@@ -764,19 +768,24 @@ func TestClusterRevisionHistory(t *testing.T) {
 		check: func(t *testing.T, checkSQLDB *sqlutils.SQLRunner) {
 			// Neither database should exist at this point in time.
 			checkSQLDB.Exec(t, `CREATE DATABASE d1`)
+			checkSQLDB.Exec(t, `CREATE TABLE d1.t (a INT)`)
 			checkSQLDB.Exec(t, `CREATE DATABASE d2`)
+			checkSQLDB.Exec(t, `CREATE TABLE d2.t (a INT)`)
 		},
 	}
 	testCases = append(testCases, tc)
 	sqlDB.Exec(t, `BACKUP TO $1 WITH revision_history`, LocalFoo)
 
 	sqlDB.Exec(t, `CREATE DATABASE d1`)
+	sqlDB.Exec(t, `CREATE TABLE d1.t (a INT)`)
 	sqlDB.QueryRow(t, `SELECT cluster_logical_timestamp()`).Scan(&ts[4])
 	tc = testCase{
 		ts: ts[4],
 		check: func(t *testing.T, checkSQLDB *sqlutils.SQLRunner) {
 			checkSQLDB.ExpectErr(t, `database "d1" already exists`, `CREATE DATABASE d1`)
+			checkSQLDB.ExpectErr(t, `relation "d1.public.t" already exists`, `CREATE TABLE d1.t (a INT)`)
 			checkSQLDB.Exec(t, `CREATE DATABASE d2`)
+			checkSQLDB.Exec(t, `CREATE TABLE d2.t (a INT)`)
 		},
 	}
 	testCases = append(testCases, tc)
@@ -787,7 +796,9 @@ func TestClusterRevisionHistory(t *testing.T) {
 		ts: ts[5],
 		check: func(t *testing.T, checkSQLDB *sqlutils.SQLRunner) {
 			checkSQLDB.Exec(t, `CREATE DATABASE d1`)
+			checkSQLDB.Exec(t, `CREATE TABLE d1.t (a INT)`)
 			checkSQLDB.Exec(t, `CREATE DATABASE d2`)
+			checkSQLDB.Exec(t, `CREATE TABLE d2.t (a INT)`)
 		},
 	}
 	testCases = append(testCases, tc)

--- a/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
+++ b/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
@@ -759,18 +759,15 @@ func TestClusterRevisionHistory(t *testing.T) {
 	testCases = append(testCases, tc)
 	sqlDB.Exec(t, `BACKUP TO $1 WITH revision_history`, LocalFoo)
 
-	// Now let's test an incremental backup with revision history. At the start of
-	// the incremental backup, we expect only d2 to exist.
-	sqlDB.Exec(t, `DROP DATABASE d2;`)
 	sqlDB.QueryRow(t, `SELECT cluster_logical_timestamp()`).Scan(&ts[3])
+	sqlDB.Exec(t, `DROP DATABASE d2;`)
 	tc = testCase{
 		ts: ts[3],
 		check: func(t *testing.T, checkSQLDB *sqlutils.SQLRunner) {
-			// Neither database should exist at this point in time.
 			checkSQLDB.Exec(t, `CREATE DATABASE d1`)
 			checkSQLDB.Exec(t, `CREATE TABLE d1.t (a INT)`)
-			checkSQLDB.Exec(t, `CREATE DATABASE d2`)
-			checkSQLDB.Exec(t, `CREATE TABLE d2.t (a INT)`)
+			checkSQLDB.ExpectErr(t, `database "d2" already exists`, `CREATE DATABASE d2`)
+			checkSQLDB.ExpectErr(t, `relation "d2.public.t" already exists`, `CREATE TABLE d2.t (a INT)`)
 		},
 	}
 	testCases = append(testCases, tc)

--- a/pkg/ccl/backupccl/manifest_handling.go
+++ b/pkg/ccl/backupccl/manifest_handling.go
@@ -421,6 +421,8 @@ func getEncryptionKey(
 		return encryption.Key, nil
 	case jobspb.EncryptionMode_KMS:
 		// Contact the selected KMS to derive the decrypted data key.
+		// TODO(pbardea): Add a check here if encryption.KMSInfo is unexpectedly nil
+		// here to avoid a panic, and return an error instead.
 		kms, err := cloud.KMSFromURI(encryption.KMSInfo.Uri, &backupKMSEnv{
 			settings: settings,
 			conf:     &ioConf,

--- a/pkg/ccl/backupccl/targets.go
+++ b/pkg/ccl/backupccl/targets.go
@@ -210,6 +210,46 @@ func getAllDescChanges(
 	return res, nil
 }
 
+func loadAllDescsInInterval(
+	ctx context.Context, codec keys.SQLCodec, db *kv.DB, startTime, endTime hlc.Timestamp,
+) ([]catalog.Descriptor, error) {
+	seen := make(map[descpb.ID]struct{})
+	allDescs := make([]catalog.Descriptor, 0)
+
+	currentDescs, err := backupresolver.LoadAllDescs(ctx, codec, db, endTime)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, desc := range currentDescs {
+		if _, wasSeen := seen[desc.GetID()]; wasSeen {
+			continue
+		}
+		seen[desc.GetID()] = struct{}{}
+		allDescs = append(allDescs, desc)
+	}
+
+	revs, err := getAllDescChanges(ctx, codec, db, startTime, endTime, nil /* priorIDs */)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, rev := range revs {
+		if rev.Desc == nil {
+			// rev.Desc may be nil when the descriptor was deleted in this revision.
+			continue
+		}
+		desc := catalogkv.NewBuilder(rev.Desc).BuildImmutable()
+		if _, wasSeen := seen[desc.GetID()]; wasSeen {
+			continue
+		}
+		seen[desc.GetID()] = struct{}{}
+		allDescs = append(allDescs, desc)
+	}
+
+	return allDescs, nil
+}
+
 // validateMultiRegionBackup validates that for all tables included in the
 // backup, their parent database is also being backed up. For multi-region
 // tables, we require that the parent database is included to ensure that the


### PR DESCRIPTION
Backport 2/2 commits from #63176.

/cc @cockroachdb/release

---

Previously, cluster backups taken with revision_history would not
include a database descriptor if it was dropped at the time of the
backup. This patch ensures that these database descriptors are picked up
by the backup and can therefore be restored with an AOST restore.

This bug appeared because backup incorrectly assumed that dropped
descriptors remained in the DROP state until their GC TTL. This is not
the case for database descriptors which are immediately deleted.

Release note (bug fix): Previously revision_history cluster backups
would not include dropped databases. This means that dropped databases
could not be restored from backups that were taken after the database
was dropped.
