### PR TITLE
release-20.2: backupccl: include dropped databases in cluster backups with rev history

### DIFF
--- a/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
+++ b/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
@@ -705,24 +705,21 @@ func TestClusterRevisionHistory(t *testing.T) {
 			checkSQLDB.Exec(t, `CREATE DATABASE d1`)
 			checkSQLDB.Exec(t, `CREATE TABLE d1.t (a INT)`)
 			checkSQLDB.ExpectErr(t, `database "d2" already exists`, `CREATE DATABASE d2`)
-			checkSQLDB.ExpectErr(t, `relation "d2.public.t" already exists`, `CREATE TABLE d2.t (a INT)`)
+			checkSQLDB.ExpectErr(t, `relation "t" already exists`, `CREATE TABLE d2.t (a INT)`)
 		},
 	}
 	testCases = append(testCases, tc)
 	sqlDB.Exec(t, `BACKUP TO $1 WITH revision_history`, LocalFoo)
 
-	// Now let's test an incremental backup with revision history. At the start of
-	// the incremental backup, we expect only d2 to exist.
-	sqlDB.Exec(t, `DROP DATABASE d2;`)
 	sqlDB.QueryRow(t, `SELECT cluster_logical_timestamp()`).Scan(&ts[3])
+	sqlDB.Exec(t, `DROP DATABASE d2;`)
 	tc = testCase{
 		ts: ts[3],
 		check: func(t *testing.T, checkSQLDB *sqlutils.SQLRunner) {
-			// Neither database should exist at this point in time.
 			checkSQLDB.Exec(t, `CREATE DATABASE d1`)
 			checkSQLDB.Exec(t, `CREATE TABLE d1.t (a INT)`)
-			checkSQLDB.Exec(t, `CREATE DATABASE d2`)
-			checkSQLDB.Exec(t, `CREATE TABLE d2.t (a INT)`)
+			checkSQLDB.ExpectErr(t, `database "d2" already exists`, `CREATE DATABASE d2`)
+			checkSQLDB.ExpectErr(t, `relation "t" already exists`, `CREATE TABLE d2.t (a INT)`)
 		},
 	}
 	testCases = append(testCases, tc)
@@ -735,7 +732,7 @@ func TestClusterRevisionHistory(t *testing.T) {
 		ts: ts[4],
 		check: func(t *testing.T, checkSQLDB *sqlutils.SQLRunner) {
 			checkSQLDB.ExpectErr(t, `database "d1" already exists`, `CREATE DATABASE d1`)
-			checkSQLDB.ExpectErr(t, `relation "d1.public.t" already exists`, `CREATE TABLE d1.t (a INT)`)
+			checkSQLDB.ExpectErr(t, `relation "t" already exists`, `CREATE TABLE d1.t (a INT)`)
 			checkSQLDB.Exec(t, `CREATE DATABASE d2`)
 			checkSQLDB.Exec(t, `CREATE TABLE d2.t (a INT)`)
 		},

--- a/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
+++ b/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
@@ -673,6 +673,7 @@ func TestClusterRevisionHistory(t *testing.T) {
 	_, _, sqlDB, tempDir, cleanupFn := BackupRestoreTestSetup(t, singleNode, numAccounts, InitNone)
 	defer cleanupFn()
 	sqlDB.Exec(t, `CREATE DATABASE d1`)
+	sqlDB.Exec(t, `CREATE TABLE d1.t (a INT)`)
 	sqlDB.QueryRow(t, `SELECT cluster_logical_timestamp()`).Scan(&ts[0])
 	tc = testCase{
 		ts: ts[0],
@@ -684,6 +685,7 @@ func TestClusterRevisionHistory(t *testing.T) {
 	testCases = append(testCases, tc)
 
 	sqlDB.Exec(t, `CREATE DATABASE d2`)
+	sqlDB.Exec(t, `CREATE TABLE d2.t (a INT)`)
 	sqlDB.QueryRow(t, `SELECT cluster_logical_timestamp()`).Scan(&ts[1])
 	tc = testCase{
 		ts: ts[1],
@@ -701,7 +703,9 @@ func TestClusterRevisionHistory(t *testing.T) {
 		ts: ts[2],
 		check: func(t *testing.T, checkSQLDB *sqlutils.SQLRunner) {
 			checkSQLDB.Exec(t, `CREATE DATABASE d1`)
+			checkSQLDB.Exec(t, `CREATE TABLE d1.t (a INT)`)
 			checkSQLDB.ExpectErr(t, `database "d2" already exists`, `CREATE DATABASE d2`)
+			checkSQLDB.ExpectErr(t, `relation "d2.public.t" already exists`, `CREATE TABLE d2.t (a INT)`)
 		},
 	}
 	testCases = append(testCases, tc)
@@ -716,19 +720,24 @@ func TestClusterRevisionHistory(t *testing.T) {
 		check: func(t *testing.T, checkSQLDB *sqlutils.SQLRunner) {
 			// Neither database should exist at this point in time.
 			checkSQLDB.Exec(t, `CREATE DATABASE d1`)
+			checkSQLDB.Exec(t, `CREATE TABLE d1.t (a INT)`)
 			checkSQLDB.Exec(t, `CREATE DATABASE d2`)
+			checkSQLDB.Exec(t, `CREATE TABLE d2.t (a INT)`)
 		},
 	}
 	testCases = append(testCases, tc)
 	sqlDB.Exec(t, `BACKUP TO $1 WITH revision_history`, LocalFoo)
 
 	sqlDB.Exec(t, `CREATE DATABASE d1`)
+	sqlDB.Exec(t, `CREATE TABLE d1.t (a INT)`)
 	sqlDB.QueryRow(t, `SELECT cluster_logical_timestamp()`).Scan(&ts[4])
 	tc = testCase{
 		ts: ts[4],
 		check: func(t *testing.T, checkSQLDB *sqlutils.SQLRunner) {
 			checkSQLDB.ExpectErr(t, `database "d1" already exists`, `CREATE DATABASE d1`)
+			checkSQLDB.ExpectErr(t, `relation "d1.public.t" already exists`, `CREATE TABLE d1.t (a INT)`)
 			checkSQLDB.Exec(t, `CREATE DATABASE d2`)
+			checkSQLDB.Exec(t, `CREATE TABLE d2.t (a INT)`)
 		},
 	}
 	testCases = append(testCases, tc)
@@ -739,7 +748,9 @@ func TestClusterRevisionHistory(t *testing.T) {
 		ts: ts[5],
 		check: func(t *testing.T, checkSQLDB *sqlutils.SQLRunner) {
 			checkSQLDB.Exec(t, `CREATE DATABASE d1`)
+			checkSQLDB.Exec(t, `CREATE TABLE d1.t (a INT)`)
 			checkSQLDB.Exec(t, `CREATE DATABASE d2`)
+			checkSQLDB.Exec(t, `CREATE TABLE d2.t (a INT)`)
 		},
 	}
 	testCases = append(testCases, tc)

--- a/pkg/ccl/backupccl/manifest_handling.go
+++ b/pkg/ccl/backupccl/manifest_handling.go
@@ -420,6 +420,8 @@ func getEncryptionKey(
 		return encryption.Key, nil
 	case jobspb.EncryptionMode_KMS:
 		// Contact the selected KMS to derive the decrypted data key.
+		// TODO(pbardea): Add a check here if encryption.KMSInfo is unexpectedly nil
+		// here to avoid a panic, and return an error instead.
 		kms, err := cloud.KMSFromURI(encryption.KMSInfo.Uri, &backupKMSEnv{
 			settings: settings,
 			conf:     &ioConf,


### PR DESCRIPTION
Backport 2/2 commits from #63176.

/cc @cockroachdb/release

---

Previously, cluster backups taken with revision_history would not
include a database descriptor if it was dropped at the time of the
backup. This patch ensures that these database descriptors are picked up
by the backup and can therefore be restored with an AOST restore.

This bug appeared because backup incorrectly assumed that dropped
descriptors remained in the DROP state until their GC TTL. This is not
the case for database descriptors which are immediately deleted.

Release note (bug fix): Previously revision_history cluster backups
would not include dropped databases. This means that dropped databases
could not be restored from backups that were taken after the database
was dropped.
