### PR TITLE
util/ring: Reduce the time cost by TestRingBuffer

### DIFF
--- a/pkg/util/ring/BUILD.bazel
+++ b/pkg/util/ring/BUILD.bazel
@@ -9,7 +9,7 @@ go_library(
 
 go_test(
     name = "ring_test",
-    size = "medium",
+    size = "small",
     srcs = ["ring_buffer_test.go"],
     embed = [":ring"],
     deps = ["@com_github_stretchr_testify//require"],

--- a/pkg/util/ring/ring_buffer_test.go
+++ b/pkg/util/ring/ring_buffer_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const maxCount = 1000
+const maxCount = 100
 
 func testRingBuffer(t *testing.T, count int) {
 	var buffer Buffer
@@ -60,7 +60,10 @@ func testRingBuffer(t *testing.T, count int) {
 
 func TestRingBuffer(t *testing.T) {
 	for count := 1; count <= maxCount; count++ {
-		testRingBuffer(t, count)
+		t.Run("Parallel", func(t *testing.T) {
+			t.Parallel() // SAFE FOR TESTING
+			testRingBuffer(t, count)
+		})
 	}
 }
 


### PR DESCRIPTION
Use t.Parallel to speed up tests by running tests in parallel,
reduce `maxCount` from 1000 to 100, and, revert the change of #63388.

fixes: #65050 
see also: #65045, #63388

Release note: None