### PR TITLE
blobs, cloud: return correct error from Writer

### DIFF
--- a/pkg/blobs/client.go
+++ b/pkg/blobs/client.go
@@ -114,7 +114,8 @@ func (w *streamWriter) CloseWithError(err error) error {
 		return w.Close()
 	}
 	w.cancel()
-	return nil
+	_, err = w.s.CloseAndRecv()
+	return err
 }
 
 func (c *remoteClient) Writer(ctx context.Context, file string) (WriteCloserWithError, error) {

--- a/pkg/blobs/client_test.go
+++ b/pkg/blobs/client_test.go
@@ -258,7 +258,7 @@ func TestBlobClientWriteFile(t *testing.T) {
 					return err
 				}
 				if _, err := io.Copy(w, bytes.NewReader(byteContent)); err != nil {
-					return errors.CombineErrors(err, w.CloseWithError(err))
+					return errors.CombineErrors(w.CloseWithError(err), err)
 				}
 				return w.Close()
 			}()

--- a/pkg/sql/copy_file_upload.go
+++ b/pkg/sql/copy_file_upload.go
@@ -169,7 +169,7 @@ func CopyInFileStmt(destination, schema, table string) string {
 func (f *fileUploadMachine) run(ctx context.Context) error {
 	err := f.c.run(ctx)
 	if err != nil {
-		err = errors.CombineErrors(err, f.w.CloseWithError(err))
+		err = errors.CombineErrors(f.w.CloseWithError(err), err)
 	} else {
 		err = f.w.Close()
 	}

--- a/pkg/storage/cloud/cloud_io.go
+++ b/pkg/storage/cloud/cloud_io.go
@@ -305,7 +305,7 @@ func WriteFile(ctx context.Context, dest ExternalStorage, basename string, src i
 	}
 	if _, err := io.Copy(w, src); err != nil {
 		closeErr := w.CloseWithError(err)
-		return errors.CombineErrors(err, closeErr)
+		return errors.CombineErrors(closeErr, err)
 	}
 	return errors.Wrap(w.Close(), "closing object")
 }


### PR DESCRIPTION
The gRPC stream used by blobs closes the writer with EOF on error and then
replies with that error on msg recv, which requires the client to actually
CloseAndRecv to get that error.

We could do that during the Write call that sees the EOF, so it could return
a more useful error that caused the EOF, but it points to a larger issue:
Errors during Close() must be handled/surfaced. Instead, this amends the
usage comment to make this fact clear and fixes the useage.

Fixes #65179.

Release note: none.