### PR TITLE
bazel: don't pollute the workspace with directory aliases that confuse `gopls`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,7 +1,7 @@
 # TODO(irfansharif): We should fold this into `dev` instead (#56965).
 
-build --ui_event_filters=-DEBUG --define gotags=bazel,crdb_test_off
-test --define gotags=bazel,crdb_test
+build --symlink_prefix=_bazel/ --ui_event_filters=-DEBUG --define gotags=bazel,crdb_test_off
+test --symlink_prefix=_bazel/ --define gotags=bazel,crdb_test
 query --ui_event_filters=-DEBUG
 
 try-import %workspace%/.bazelrc.user

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ build/Railroad.jar
 
 # Bazel generated symlinks
 /bazel-*
+/_bazel
 
 # Per-user .bazelrc
 /.bazelrc.user

--- a/Makefile
+++ b/Makefile
@@ -1805,6 +1805,12 @@ fuzz: bin/fuzz
 	bin/fuzz $(TESTFLAGS) -tests $(TESTS) -timeout $(TESTTIMEOUT) $(PKG)
 
 # Short hand to re-generate all bazel BUILD files.
+#
+# Even with --symlink_prefix, some sub-command somewhere hardcodes the
+# creation of a "bazel-out" symlink. This bazel-out symlink can only
+# be blocked by the existence of a file before the bazel command is
+# invoked. For now, this is left as an exercise for the user.
+#
 bazel-generate: ## Generate all bazel BUILD files.
 	@echo 'Generating DEPS.bzl and BUILD files using gazelle'
 	./build/bazelutil/bazel-generate.sh


### PR DESCRIPTION
This patch changes the target symlinks created by bazel to
sub-directories of `_bazel`, since `gopls` automatically
ignores directories starting with an underscore.