### PR TITLE
security: Add version number to base64 form of join tokens

### DIFF
--- a/pkg/cli/connect_join_test.go
+++ b/pkg/cli/connect_join_test.go
@@ -100,7 +100,7 @@ func TestNodeJoinBadToken(t *testing.T) {
 		require.NotEmpty(t, token)
 	}
 	// Rewrite token to something else entirely.
-	token = "Zm9vYmFyYmF6"
+	token = "0Zm9vYmFyYmF6"
 
 	oldCfg := *baseCfg
 	defer func() {


### PR DESCRIPTION
Add version number to base64 form of join tokens, to future proof the encoding and prevent command line issues when base64 encoded token starts with `-`. 
Add unit test for version (un)marshaling. 
Add error types to distinguish between version related error and other (i.e. encoding) errors in tests.

Release note: None.