### PR TITLE
[release-21.1] storage: Disable read sampling and read-triggered compactions

### DIFF
--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -357,6 +357,9 @@ func DefaultPebbleOptions() *pebble.Options {
 	// SSDs, that kick off an expensive GC if a lot of files are deleted at
 	// once.
 	opts.Experimental.MinDeletionRate = 128 << 20 // 128 MB
+	// Disable read compactions. These can cause excessive write amplification
+	// on some workloads; see https://github.com/cockroachdb/pebble/issues/1143.
+	opts.Experimental.ReadSamplingMultiplier = -1
 
 	for i := 0; i < len(opts.Levels); i++ {
 		l := &opts.Levels[i]


### PR DESCRIPTION
This change sets the ReadSamplingMultiplier to a negative
value, effectively disabling read sampling and therefore
read-triggered compactions.

This is a mitigation of
https://github.com/cockroachdb/pebble/issues/1143 to unblock
the 21.1 release while we try to understand the issue.

Release note (general change): Disable read-triggered compactions
to avoid instances where the storage engine would compact excessively.