### PR TITLE
release-21.1: tracing: fix benign data race

### DIFF
--- a/pkg/util/tracing/crdbspan.go
+++ b/pkg/util/tracing/crdbspan.go
@@ -34,7 +34,6 @@ type crdbSpan struct {
 	parentSpanID uint64
 	goroutineID  uint64
 
-	operation string
 	startTime time.Time
 
 	// logTags are set to the log tags that were available when this Span was
@@ -58,7 +57,8 @@ type testingKnob struct {
 type crdbSpanMu struct {
 	syncutil.Mutex
 	// duration is initialized to -1 and set on Finish().
-	duration time.Duration
+	duration  time.Duration
+	operation string // name of operation associated with the span
 
 	recording struct {
 		// recordingType is the recording type of the ongoing recording, if any.
@@ -324,7 +324,7 @@ func (s *crdbSpan) getRecordingLocked(wantTags bool) tracingpb.RecordedSpan {
 		SpanID:       s.spanID,
 		ParentSpanID: s.parentSpanID,
 		GoroutineID:  s.goroutineID,
-		Operation:    s.operation,
+		Operation:    s.mu.operation,
 		StartTime:    s.startTime,
 		Duration:     s.mu.duration,
 	}

--- a/pkg/util/tracing/span_inner.go
+++ b/pkg/util/tracing/span_inner.go
@@ -176,7 +176,9 @@ func (s *spanInner) SetOperationName(operationName string) *spanInner {
 	if s.ot.shadowSpan != nil {
 		s.ot.shadowSpan.SetOperationName(operationName)
 	}
-	s.crdb.operation = operationName
+	s.crdb.mu.Lock()
+	s.crdb.mu.operation = operationName
+	s.crdb.mu.Unlock()
 	return s
 }
 

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -362,7 +362,6 @@ func (t *Tracer) startSpanGeneric(
 		traceID:      traceID,
 		spanID:       spanID,
 		goroutineID:  goroutineID,
-		operation:    opName,
 		startTime:    startTime,
 		parentSpanID: opts.parentSpanID(),
 		logTags:      opts.LogTags,
@@ -371,6 +370,7 @@ func (t *Tracer) startSpanGeneric(
 		},
 		testing: t.testing,
 	}
+	helper.crdbSpan.mu.operation = opName
 	helper.crdbSpan.mu.recording.logs = newSizeLimitedBuffer(maxLogBytesPerSpan)
 	helper.crdbSpan.mu.recording.structured = newSizeLimitedBuffer(maxStructuredBytesPerSpan)
 	helper.span.i = spanInner{


### PR DESCRIPTION
Backport 1/1 commits from #65339.

/cc @cockroachdb/release

---

Fixes #65148, it's possible to override the op name associated with a
trace after having instantiated it. We'll want to protect access to it
through a mutex.

Release note: None
