### PR TITLE
changefeedccl: Merge adjacent spans in the frontier.

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -204,7 +204,12 @@ func (ca *changeAggregator) Start(ctx context.Context) {
 	ctx, ca.cancel = context.WithCancel(ctx)
 	ca.Ctx = ctx
 
-	spans := ca.setupSpansAndFrontier()
+	spans, err := ca.setupSpansAndFrontier()
+	if err != nil {
+		ca.MoveToDraining(err)
+		ca.cancel()
+		return
+	}
 	timestampOracle := &changeAggregatorLowerBoundOracle{sf: ca.spanFrontier, initialInclusiveLowerBound: ca.spec.Feed.StatementTime}
 
 	if cfKnobs, ok := ca.flowCtx.TestingKnobs().Changefeed.(*TestingKnobs); ok {
@@ -222,7 +227,6 @@ func (ca *changeAggregator) Start(ctx context.Context) {
 	kvFeedMemMon.Start(ctx, pool, mon.BoundAccount{})
 	ca.kvFeedMemMon = kvFeedMemMon
 
-	var err error
 	ca.sink, err = getSink(
 		ctx, ca.flowCtx.Cfg, ca.spec.Feed, timestampOracle,
 		ca.spec.User(), kvFeedMemMon.MakeBoundAccount())
@@ -438,16 +442,22 @@ func getKVFeedInitialParameters(
 // different SpanFrontier elsewhere for the entire changefeed. This object is
 // used to filter out some previously emitted rows, and by the cloudStorageSink
 // to name its output files in lexicographically monotonic fashion.
-func (ca *changeAggregator) setupSpansAndFrontier() []roachpb.Span {
-	spans := make([]roachpb.Span, 0, len(ca.spec.Watches))
+func (ca *changeAggregator) setupSpansAndFrontier() (spans []roachpb.Span, err error) {
+	spans = make([]roachpb.Span, 0, len(ca.spec.Watches))
 	for _, watch := range ca.spec.Watches {
 		spans = append(spans, watch.Span)
 	}
-	ca.spanFrontier = span.MakeFrontier(spans...)
-	for _, watch := range ca.spec.Watches {
-		ca.spanFrontier.Forward(watch.Span, watch.InitialResolved)
+
+	ca.spanFrontier, err = span.MakeFrontier(spans...)
+	if err != nil {
+		return nil, err
 	}
-	return spans
+	for _, watch := range ca.spec.Watches {
+		if _, err := ca.spanFrontier.Forward(watch.Span, watch.InitialResolved); err != nil {
+			return nil, err
+		}
+	}
+	return spans, nil
 }
 
 // close has two purposes: to synchronize on the completion of the helper
@@ -540,7 +550,9 @@ func (ca *changeAggregator) tick() error {
 // maybeFlush flushes sink and emits resolved timestamp if needed.
 func (ca *changeAggregator) maybeFlush(resolvedSpan *jobspb.ResolvedSpan) error {
 	if resolvedSpan != nil {
-		ca.spanFrontier.Forward(resolvedSpan.Span, resolvedSpan.Timestamp)
+		if _, err := ca.spanFrontier.Forward(resolvedSpan.Span, resolvedSpan.Timestamp); err != nil {
+			return err
+		}
 		ca.spansToFlush = append(ca.spansToFlush, resolvedSpan)
 	}
 
@@ -961,12 +973,16 @@ func newChangeFrontierProcessor(
 ) (execinfra.Processor, error) {
 	ctx := flowCtx.EvalCtx.Ctx()
 	memMonitor := execinfra.NewMonitor(ctx, flowCtx.EvalCtx.Mon, "changefntr-mem")
+	sf, err := span.MakeFrontier(spec.TrackedSpans...)
+	if err != nil {
+		return nil, err
+	}
 	cf := &changeFrontier{
 		flowCtx:       flowCtx,
 		spec:          spec,
 		memAcc:        memMonitor.MakeBoundAccount(),
 		input:         input,
-		sf:            span.MakeFrontier(spec.TrackedSpans...),
+		sf:            sf,
 		slowLogEveryN: log.Every(slowSpanMaxFrequency),
 	}
 	if err := cf.Init(
@@ -1000,7 +1016,6 @@ func newChangeFrontierProcessor(
 		cf.freqEmitResolved = emitNoResolved
 	}
 
-	var err error
 	if cf.encoder, err = getEncoder(spec.Feed.Opts, spec.Feed.Targets); err != nil {
 		return nil, err
 	}
@@ -1264,7 +1279,10 @@ func (cf *changeFrontier) noteResolvedSpan(d rowenc.EncDatum) error {
 		cf.boundaryType = resolved.BoundaryType
 	}
 
-	frontierChanged := cf.sf.Forward(resolved.Span, resolved.Timestamp)
+	frontierChanged, err := cf.sf.Forward(resolved.Span, resolved.Timestamp)
+	if err != nil {
+		return err
+	}
 	isBehind := cf.maybeLogBehindSpan(frontierChanged)
 	if frontierChanged {
 		if err := cf.handleFrontierChanged(isBehind); err != nil {

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_frontier_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_frontier_processor.go
@@ -12,7 +12,6 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
@@ -61,12 +60,16 @@ func newStreamIngestionFrontierProcessor(
 	post *execinfrapb.PostProcessSpec,
 	output execinfra.RowReceiver,
 ) (execinfra.Processor, error) {
+	frontier, err := span.MakeFrontier(spec.TrackedSpans...)
+	if err != nil {
+		return nil, err
+	}
 	sf := &streamIngestionFrontier{
 		flowCtx:          flowCtx,
 		spec:             spec,
 		input:            input,
 		highWaterAtStart: spec.HighWaterAtStart,
-		frontier:         span.MakeFrontier(spec.TrackedSpans...),
+		frontier:         frontier,
 	}
 	if err := sf.Init(
 		sf,
@@ -164,20 +167,12 @@ func (sf *streamIngestionFrontier) noteResolvedTimestamps(d rowenc.EncDatum) (bo
 				redact.Safe(resolved.Timestamp), redact.Safe(sf.highWaterAtStart))
 		}
 
-		if sf.maybeMoveFrontier(resolved.Span, resolved.Timestamp) {
-			frontierChanged = true
+		if changed, err := sf.frontier.Forward(resolved.Span, resolved.Timestamp); err == nil {
+			frontierChanged = frontierChanged || changed
+		} else {
+			return false, err
 		}
 	}
 
 	return frontierChanged, nil
-}
-
-// maybeMoveFrontier updates the resolved ts for the provided span, and returns
-// true if the update causes the frontier to move to higher resolved ts.
-func (sf *streamIngestionFrontier) maybeMoveFrontier(
-	span roachpb.Span, resolved hlc.Timestamp,
-) bool {
-	prevResolved := sf.frontier.Frontier()
-	sf.frontier.Forward(span, resolved)
-	return prevResolved.Less(sf.frontier.Frontier())
 }

--- a/pkg/kv/kvnemesis/watcher.go
+++ b/pkg/kv/kvnemesis/watcher.go
@@ -55,7 +55,10 @@ func Watch(ctx context.Context, env *Env, dbs []*kv.DB, dataSpan roachpb.Span) (
 	if w.mu.kvs, err = MakeEngine(); err != nil {
 		return nil, err
 	}
-	w.mu.frontier = span.MakeFrontier(dataSpan)
+	w.mu.frontier, err = span.MakeFrontier(dataSpan)
+	if err != nil {
+		return nil, err
+	}
 	w.mu.frontierWaiters = make(map[hlc.Timestamp][]chan error)
 	ctx, w.cancel = context.WithCancel(ctx)
 	w.g = ctxgroup.WithContext(ctx)
@@ -187,7 +190,11 @@ func (w *Watcher) processEvents(ctx context.Context, eventC chan *roachpb.RangeF
 				}
 			case *roachpb.RangeFeedCheckpoint:
 				w.mu.Lock()
-				if w.mu.frontier.Forward(e.Span, e.ResolvedTS) {
+				frontierAdvanced, err := w.mu.frontier.Forward(e.Span, e.ResolvedTS)
+				if err != nil {
+					panic(errors.Wrapf(err, "unexpected frontier error advancing to %s@%s", e.Span, e.ResolvedTS))
+				}
+				if frontierAdvanced {
 					frontier := w.mu.frontier.Frontier()
 					log.Infof(ctx, `watcher reached frontier %s lagging by %s`,
 						frontier, timeutil.Now().Sub(frontier.GoTime()))

--- a/pkg/util/span/BUILD.bazel
+++ b/pkg/util/span/BUILD.bazel
@@ -8,7 +8,6 @@ go_library(
     deps = [
         "//pkg/keys",
         "//pkg/roachpb",
-        "//pkg/sql/covering",
         "//pkg/util/hlc",
         "//pkg/util/interval",
     ],

--- a/pkg/util/span/BUILD.bazel
+++ b/pkg/util/span/BUILD.bazel
@@ -22,7 +22,10 @@ go_test(
     deps = [
         "//pkg/roachpb",
         "//pkg/util/hlc",
+        "//pkg/util/interval",
         "//pkg/util/leaktest",
+        "//pkg/util/log",
+        "//pkg/util/randutil",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/util/span/frontier.go
+++ b/pkg/util/span/frontier.go
@@ -18,7 +18,6 @@ import (
 	// Needed for roachpb.Span.String().
 	_ "github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/covering"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/interval"
 )
@@ -107,9 +106,13 @@ type Frontier struct {
 	idAlloc int64
 }
 
-func spanCopy(s roachpb.Span) (res roachpb.Span) {
-	res.Key = append(res.Key, s.Key...)
-	res.EndKey = append(res.EndKey, s.EndKey...)
+// makeSpan copies intervals start/end points and returns a span.
+// Whenever we store user provided span objects inside frontier
+// datastructures, we must make a copy lest the user later mutates
+// underlying start/end []byte slices in the range.
+func makeSpan(r interval.Range) (res roachpb.Span) {
+	res.Key = append(res.Key, r.Start...)
+	res.EndKey = append(res.EndKey, r.End...)
 	return
 }
 
@@ -117,7 +120,7 @@ func spanCopy(s roachpb.Span) (res roachpb.Span) {
 func MakeFrontier(spans ...roachpb.Span) (*Frontier, error) {
 	f := &Frontier{tree: interval.NewTree(interval.ExclusiveOverlapper)}
 	for _, s := range spans {
-		span := spanCopy(s)
+		span := makeSpan(s.AsRange())
 		e := &frontierEntry{
 			id:   f.idAlloc,
 			keys: span.AsRange(),
@@ -166,94 +169,189 @@ func (f *Frontier) Forward(span roachpb.Span, ts hlc.Timestamp) (bool, error) {
 	return prevFrontier.Less(f.Frontier()), nil
 }
 
-func (f *Frontier) insert(s roachpb.Span, ts hlc.Timestamp) error {
-	span := spanCopy(s)
-	entryKeys := span.AsRange()
-	overlapping := f.tree.Get(entryKeys)
-
-	// TODO(dan): OverlapCoveringMerge is overkill, do this without it. See
-	// `tscache/treeImpl.Add` for inspiration.
-	entryCov := covering.Covering{{Start: span.Key, End: span.EndKey, Payload: ts}}
-	overlapCov := make(covering.Covering, len(overlapping))
-	for i, o := range overlapping {
-		spe := o.(*frontierEntry)
-		overlapCov[i] = covering.Range{
-			Start: spe.span.Key, End: spe.span.EndKey, Payload: spe,
+// extendRangeToTheLeft extends the range to the left of the range, provided those
+// ranges all have specified timestamp.
+// Updates provided range with the new starting position.
+// Returns the list of frontier entries covered by the updated range; the caller
+// is expected to remove those covered ranges from the tree.
+func extendRangeToTheLeft(
+	t interval.Tree, r *interval.Range, ts hlc.Timestamp,
+) (covered []*frontierEntry) {
+	for {
+		// Get the range to the left of the range.
+		// Since we request an inclusive overlap of the range containing exactly
+		// 1 key, we expect to get two extensions if there is anything to the left:
+		// the range (r) itself, and the one to the left of r.
+		left := t.GetWithOverlapper(
+			interval.Range{Start: r.Start, End: r.Start},
+			interval.InclusiveOverlapper,
+		)
+		if len(left) == 2 && left[0].(*frontierEntry).ts.Equal(ts) {
+			e := left[0].(*frontierEntry)
+			covered = append(covered, e)
+			r.Start = e.keys.Start
+		} else {
+			return
 		}
 	}
-	merged := covering.OverlapCoveringMerge([]covering.Covering{entryCov, overlapCov})
+}
 
-	toInsert := make([]frontierEntry, 0, len(merged))
-	for _, m := range merged {
-		// Compute the newest timestamp seen for this span and note whether it's
-		// tracked. There will be either 1 or 2 payloads. If there's 2, it will
-		// be the new span and the old entry. If it's 1 it could be either a new
-		// span (which is untracked and should be ignored) or an old entry which
-		// has been clipped.
-		var mergedTs hlc.Timestamp
-		var tracked bool
-		for _, payload := range m.Payload.([]interface{}) {
-			switch p := payload.(type) {
-			case hlc.Timestamp:
-				if mergedTs.Less(p) {
-					mergedTs = p
-				}
-			case *frontierEntry:
-				tracked = true
-				if mergedTs.Less(p.ts) {
-					mergedTs = p.ts
-				}
+// extendRangeToTheRight extends the range to the right of the range, provided those
+// ranges all have specified timestamp.
+// Updates provided range with the new ending position.
+// Returns the list of frontier entries covered by the updated range; the caller
+// is expected to remove those covered ranges from the tree.
+func extendRangeToTheRight(
+	t interval.Tree, r *interval.Range, ts hlc.Timestamp,
+) (covered []*frontierEntry) {
+	for {
+		// Get the range to the right of the range.
+		// Since we request an exclusive overlap of the range containing exactly
+		// 1 key, we expect to get exactly 1 extensions if there is anything to the right of the span.
+		endKey := roachpb.Key(r.End)
+		rightSpan := roachpb.Span{Key: endKey, EndKey: endKey.Next()}
+		right := t.GetWithOverlapper(rightSpan.AsRange(), interval.ExclusiveOverlapper)
+		if len(right) == 1 && right[0].(*frontierEntry).ts.Equal(ts) {
+			e := right[0].(*frontierEntry)
+			covered = append(covered, e)
+			r.End = e.keys.End
+		} else {
+			return
+		}
+	}
+}
+
+func (f *Frontier) insert(span roachpb.Span, insertTS hlc.Timestamp) error {
+	const continueMatch = false
+
+	// Set of frontier entries to add and remove.
+	var toAdd, toRemove []*frontierEntry
+
+	// addEntry adds frontier entry to the toAdd list.
+	addEntry := func(r interval.Range, ts hlc.Timestamp) {
+		sp := makeSpan(r)
+		toAdd = append(toAdd, &frontierEntry{
+			id:   f.idAlloc,
+			span: sp,
+			keys: sp.AsRange(),
+			ts:   ts,
+		})
+		f.idAlloc++
+	}
+
+	// todoRange is the range we're adding. It gets updated as we process the range.
+	todoRange := span.AsRange()
+
+	// pendingSpan (if not empty) is the span of multiple overlap intervals
+	// we'll merge together (because all of those intervals have timestamp lower
+	// than insertTS).
+	var pendingSpan interval.Range
+
+	// consumePrefix consumes todoRange prefix ending at 'end' and moves
+	// that prefix into pendingSpan.
+	consumePrefix := func(end interval.Comparable) {
+		if pendingSpan.Start == nil {
+			pendingSpan.Start = todoRange.Start
+		}
+		todoRange.Start = end
+		pendingSpan.End = end
+	}
+
+	extendLeft := true // can the merged span be extended to the left?
+
+	// addPending adds frontier entry for the pendingSpan if it's non-empty, and resets it.
+	addPending := func() {
+		if !pendingSpan.Start.Equal(pendingSpan.End) {
+			if extendLeft {
+				toRemove = append(toRemove, extendRangeToTheLeft(f.tree, &pendingSpan, insertTS)...)
 			}
+			addEntry(pendingSpan, insertTS)
 		}
-		// TODO(dan): Collapse span-adjacent entries with the same value for
-		// timestamp and tracked to save space.
-		if tracked {
-			toInsert = append(toInsert, frontierEntry{
-				id:   f.idAlloc,
-				keys: interval.Range{Start: m.Start, End: m.End},
-				span: roachpb.Span{Key: m.Start, EndKey: m.End},
-				ts:   mergedTs,
-			})
-			f.idAlloc++
-		}
+
+		pendingSpan.Start = nil
+		pendingSpan.End = nil
+		extendLeft = true
 	}
 
-	// All the entries in `overlapping` have been replaced by updated ones in
-	// `toInsert`, so remove them all from the tree and heap.
-	needAdjust := false
-	if len(overlapping) == 1 {
-		spe := overlapping[0].(*frontierEntry)
-		if err := f.tree.Delete(spe, false /* fast */); err != nil {
+	// Main work: start iterating through all ranges that overlap our span.
+	f.tree.DoMatching(func(k interval.Interface) (done bool) {
+		overlap := k.(*frontierEntry)
+
+		// If overlap does not start immediately after our pendingSpan,
+		// then add and reset pending.
+		if !overlap.span.Key.Equal(roachpb.Key(pendingSpan.End)) {
+			addPending()
+		}
+
+		// Trim todoRange if it falls outside the span(s) tracked by this frontier.
+		// This establishes the invariant that overlap start must be at or before todoRange start.
+		if todoRange.Start.Compare(overlap.keys.Start) < 0 {
+			todoRange.Start = overlap.keys.Start
+		}
+
+		// Fast case: we already recorded higher timestamp for this overlap.
+		if insertTS.LessEq(overlap.ts) {
+			todoRange.Start = overlap.keys.End
+			return continueMatch
+		}
+
+		// At this point, we know that overlap timestamp is not ahead of the insertTS
+		// (otherwise we'd hit fast case above).
+		// We need split overlap range, so mark overlap for removal.
+		toRemove = append(toRemove, overlap)
+
+		// We need to split overlap range into multiple parts.
+		// 1. Possibly empty part before todoRange.Start
+		if overlap.keys.Start.Compare(todoRange.Start) < 0 {
+			extendLeft = false
+			addEntry(interval.Range{Start: overlap.keys.Start, End: todoRange.Start}, overlap.ts)
+		}
+
+		// 2. Middle part (with updated timestamp), and...
+		// 3. Possibly empty part after todoRange end.
+		if cmp := todoRange.End.Compare(overlap.keys.End); cmp <= 0 {
+			// Our todoRange ends before the overlap ends, so consume all of it.
+			consumePrefix(todoRange.End)
+
+			if cmp < 0 && overlap.ts != insertTS {
+				// Add the rest of the overlap.
+				addEntry(interval.Range{Start: todoRange.End, End: overlap.keys.End}, overlap.ts)
+			} else {
+				// We can consume all the way until the end of the overlap
+				// since overlap extends to the end of todoRange or it has the same timestamp as insertTS.
+				consumePrefix(overlap.keys.End)
+				// We can also attempt to merge more ranges with the same timestamp to the right
+				// of overlap.  Extending range to the right adjusts pendingSpan.End and returns the
+				// list of extended ranges, which we remove because they are subsumed by pendingSpan.
+				// Note also, that at this point, we know that this is the last overlap entry, and that
+				// we will exit DoMatching, at which point we add whatever range was accumulated
+				// in the pendingRange.
+				toRemove = append(toRemove, extendRangeToTheRight(f.tree, &pendingSpan, insertTS)...)
+			}
+		} else {
+			// Our todoRange extends beyond overlap: consume until the end of the overlap.
+			consumePrefix(overlap.keys.End)
+		}
+
+		return continueMatch
+	}, span.AsRange())
+
+	// Add remaining pending range.
+	addPending()
+
+	const withRangeAdjust = false
+	for _, e := range toRemove {
+		if err := f.tree.Delete(e, withRangeAdjust); err != nil {
 			return err
 		}
-		heap.Remove(&f.minHeap, spe.index)
-	} else {
-		for i := range overlapping {
-			spe := overlapping[i].(*frontierEntry)
-			if err := f.tree.Delete(spe, true /* fast */); err != nil {
-				return err
-			}
-			heap.Remove(&f.minHeap, spe.index)
-		}
-		needAdjust = true
+		heap.Remove(&f.minHeap, e.index)
 	}
-	// Then insert!
-	if len(toInsert) == 1 {
-		if err := f.tree.Insert(&toInsert[0], false /* fast */); err != nil {
+
+	for _, e := range toAdd {
+		if err := f.tree.Insert(e, withRangeAdjust); err != nil {
 			return err
 		}
-		heap.Push(&f.minHeap, &toInsert[0])
-	} else {
-		for i := range toInsert {
-			if err := f.tree.Insert(&toInsert[i], true /* fast */); err != nil {
-				return err
-			}
-			heap.Push(&f.minHeap, &toInsert[i])
-		}
-		needAdjust = true
-	}
-	if needAdjust {
-		f.tree.AdjustRanges()
+		heap.Push(&f.minHeap, e)
 	}
 	return nil
 }

--- a/pkg/util/span/frontier_test.go
+++ b/pkg/util/span/frontier_test.go
@@ -229,6 +229,13 @@ func TestSpanFrontierDisjointSpans(t *testing.T) {
 		expectedAdvanced(true).
 		expectFrontier(2).
 		expectEntries(`{a-b}@3 {c-d}@3 {d-e}@2`)
+
+	// Advance span that overlaps all the spans tracked by this frontier.
+	// {c-d} and {d-e} should collaps.
+	forwardFrontier(roachpb.Span{Key: roachpb.Key(`0`), EndKey: roachpb.Key(`q`)}, 4).
+		expectedAdvanced(true).
+		expectFrontier(4).
+		expectEntries(`{a-b}@4 {c-e}@4`)
 }
 
 func TestSpanFrontierHeap(t *testing.T) {


### PR DESCRIPTION
Harden span frontier API against bugs at the call sites by
changing frontier methods to return an error instead of panic-ing.

Implement frontier benchmark to mesure frontier performance.

Rewrite frontier `Forward` implementation to be a single pass
over the tree of spans.  Update all required timestamps in one
pass, while merging adjacent spans that have advanced to the
same timestamp.

The implementation no longer scales sub-linearly, and has much
better per op performance, and much lower per op allocations.

The difference between old and new code is substantial, with the old code
able to perform 10000 operations, each around 6.5 milliseconds

```
BenchmarkFrontier-16               10000           6496607 ns/op         2655966 B/op      20599 allocs/op
```

The new code was able to execute over 1/2 million ops, at around 2.5 microseconds.
```
BenchmarkFrontier-16              544978              2250 ns/op             806 B/op         17 allocs/op
```


Release Notes: None
