### PR TITLE
release-21.1: kv: copy key memory before assigning to unreplicated lock

### DIFF
--- a/pkg/kv/kvserver/batcheval/intent.go
+++ b/pkg/kv/kvserver/batcheval/intent.go
@@ -116,16 +116,35 @@ func acquireUnreplicatedLocksOnKeys(
 	case roachpb.BATCH_RESPONSE:
 		var i int
 		return storage.MVCCScanDecodeKeyValues(scanRes.KVData, func(key storage.MVCCKey, _ []byte) error {
-			res.Local.AcquiredLocks[i] = roachpb.MakeLockAcquisition(txn, key.Key, lock.Unreplicated)
+			res.Local.AcquiredLocks[i] = roachpb.MakeLockAcquisition(txn, copyKey(key.Key), lock.Unreplicated)
 			i++
 			return nil
 		})
 	case roachpb.KEY_VALUES:
 		for i, row := range scanRes.KVs {
-			res.Local.AcquiredLocks[i] = roachpb.MakeLockAcquisition(txn, row.Key, lock.Unreplicated)
+			res.Local.AcquiredLocks[i] = roachpb.MakeLockAcquisition(txn, copyKey(row.Key), lock.Unreplicated)
 		}
 		return nil
 	default:
 		panic("unexpected scanFormat")
 	}
+}
+
+// copyKey copies the provided roachpb.Key into a new byte slice, returning the
+// copy. It is used in acquireUnreplicatedLocksOnKeys for two reasons:
+// 1. the keys in an MVCCScanResult, regardless of the scan format used, point
+//    to a small number of large, contiguous byte slices. These "MVCCScan
+//    batches" contain keys and their associated values in the same backing
+//    array. To avoid holding these entire backing arrays in memory and
+//    preventing them from being garbage collected indefinitely, we copy the key
+//    slices before coupling their lifetimes to those of unreplicated locks.
+// 2. the KV API has a contract that byte slices returned from KV will not be
+//    mutated by higher levels. However, we have seen cases (e.g.#64228) where
+//    this contract is broken due to bugs. To defensively guard against this
+//    class of memory aliasing bug and prevent keys associated with unreplicated
+//    locks from being corrupted, we copy them.
+func copyKey(k roachpb.Key) roachpb.Key {
+	k2 := make([]byte, len(k))
+	copy(k2, k)
+	return k2
 }

--- a/pkg/sql/tests/kv_test.go
+++ b/pkg/sql/tests/kv_test.go
@@ -80,7 +80,7 @@ func (kv *kvNative) Update(rows, run int) error {
 		// Don't permute the rows, to be similar to SQL which sorts the spans in a
 		// batch.
 		for i := 0; i < rows; i++ {
-			b.Get(fmt.Sprintf("%s%08d", kv.prefix, i))
+			b.GetForUpdate(fmt.Sprintf("%s%08d", kv.prefix, i))
 		}
 		if err := txn.Run(ctx, b); err != nil {
 			return err


### PR DESCRIPTION
Backport 2/2 commits from #64428.

/cc @cockroachdb/release

---

Informs #64228.

This commit avoids aliasing between the roachpb.Key assigned to each
unreplicated lock and the bytes returned in the ScanResponse that acquired the
unreplicated lock. It does so by copying keys pulled from ScanResponse memory
before assigning them to unreplicate lock acquisitions.

This is done for two reasons:

1. the keys in an MVCCScanResult, regardless of the scan format used, point
   to a small number of large, contiguous byte slices. These "MVCCScan
   batches" contain keys and their associated values in the same backing
   array. To avoid holding these entire backing arrays in memory and
   preventing them from being garbage collected indefinitely, we copy the key
   slices before coupling their lifetimes to those of unreplicated locks.
2. the KV API has a contract that byte slices returned from KV will not be
   mutated by higher levels. However, we have seen cases (e.g.#64228) where
   this contract is broken due to bugs. To defensively guard against this
   class of memory aliasing bug and prevent keys associated with unreplicated
   locks from being corrupted, we copy them.

Release note (bug fix): large SELECT FOR UPDATE scans will no longer prevent the
memory associated with their entire result set from being reclaimed by the Go
garbage collector for the lifetime of the locks that they acquire.
