### PR TITLE
testutils/lint: remove old linter about t.Parallel

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -3313,7 +3313,7 @@ func RunLogicTestWithDefaultConfig(
 						//
 						// TODO(jordan, radu): make sqlbase.kvBatchSize non-global to fix this.
 						if filepath.Base(path) != "select_index_span_ranges" {
-							t.Parallel() // SAFE FOR TESTING (this comments satisfies the linter)
+							t.Parallel()
 						}
 					}
 					rng, _ := randutil.NewPseudoRand()

--- a/pkg/sql/plan_opt_test.go
+++ b/pkg/sql/plan_opt_test.go
@@ -112,7 +112,7 @@ func TestQueryCache(t *testing.T) {
 	// call above to work as expected.
 	t.Run("group", func(t *testing.T) {
 		t.Run("simple", func(t *testing.T) {
-			t.Parallel() // SAFE FOR TESTING
+			t.Parallel()
 			const numConns = 4
 			h := makeQueryCacheTestHelper(t, numConns)
 			defer h.Stop()
@@ -128,7 +128,7 @@ func TestQueryCache(t *testing.T) {
 		})
 
 		t.Run("simple-prepare", func(t *testing.T) {
-			t.Parallel() // SAFE FOR TESTING
+			t.Parallel()
 			const numConns = 4
 			h := makeQueryCacheTestHelper(t, numConns)
 			defer h.Stop()
@@ -154,7 +154,7 @@ func TestQueryCache(t *testing.T) {
 		})
 
 		t.Run("simple-prepare-with-args", func(t *testing.T) {
-			t.Parallel() // SAFE FOR TESTING
+			t.Parallel()
 			const numConns = 4
 			h := makeQueryCacheTestHelper(t, numConns)
 			defer h.Stop()
@@ -187,7 +187,7 @@ func TestQueryCache(t *testing.T) {
 		// Verify that using a relative timestamp literal interacts correctly with
 		// the query cache (#48717).
 		t.Run("relative-timestamp", func(t *testing.T) {
-			t.Parallel() // SAFE FOR TESTING
+			t.Parallel()
 			h := makeQueryCacheTestHelper(t, 1 /* numConns */)
 			defer h.Stop()
 
@@ -201,7 +201,7 @@ func TestQueryCache(t *testing.T) {
 		})
 
 		t.Run("parallel", func(t *testing.T) {
-			t.Parallel() // SAFE FOR TESTING
+			t.Parallel()
 			const numConns = 4
 			h := makeQueryCacheTestHelper(t, numConns)
 			defer h.Stop()
@@ -232,7 +232,7 @@ func TestQueryCache(t *testing.T) {
 		})
 
 		t.Run("parallel-prepare", func(t *testing.T) {
-			t.Parallel() // SAFE FOR TESTING
+			t.Parallel()
 			const numConns = 4
 			h := makeQueryCacheTestHelper(t, numConns)
 			defer h.Stop()
@@ -275,7 +275,7 @@ SELECT cte.x, cte.y FROM cte LEFT JOIN cte as cte2 on cte.y = cte2.x`, j)
 
 		// Test connections running the same statement but under different databases.
 		t.Run("multidb", func(t *testing.T) {
-			t.Parallel() // SAFE FOR TESTING
+			t.Parallel()
 			const numConns = 4
 			h := makeQueryCacheTestHelper(t, numConns)
 			defer h.Stop()
@@ -304,7 +304,7 @@ SELECT cte.x, cte.y FROM cte LEFT JOIN cte as cte2 on cte.y = cte2.x`, j)
 		})
 
 		t.Run("multidb-prepare", func(t *testing.T) {
-			t.Parallel() // SAFE FOR TESTING
+			t.Parallel()
 			const numConns = 4
 			h := makeQueryCacheTestHelper(t, numConns)
 			defer h.Stop()
@@ -335,7 +335,7 @@ SELECT cte.x, cte.y FROM cte LEFT JOIN cte as cte2 on cte.y = cte2.x`, j)
 
 		// Test that a schema change triggers cache invalidation.
 		t.Run("schemachange", func(t *testing.T) {
-			t.Parallel() // SAFE FOR TESTING
+			t.Parallel()
 			h := makeQueryCacheTestHelper(t, 2 /* numConns */)
 			defer h.Stop()
 			r0, r1 := h.runners[0], h.runners[1]
@@ -351,7 +351,7 @@ SELECT cte.x, cte.y FROM cte LEFT JOIN cte as cte2 on cte.y = cte2.x`, j)
 
 		// Test that creating new statistics triggers cache invalidation.
 		t.Run("statschange", func(t *testing.T) {
-			t.Parallel() // SAFE FOR TESTING
+			t.Parallel()
 			h := makeQueryCacheTestHelper(t, 2 /* numConns */)
 			defer h.Stop()
 			r0, r1 := h.runners[0], h.runners[1]
@@ -376,7 +376,7 @@ SELECT cte.x, cte.y FROM cte LEFT JOIN cte as cte2 on cte.y = cte2.x`, j)
 
 		// Test that a schema change triggers cache invalidation.
 		t.Run("schemachange-prepare", func(t *testing.T) {
-			t.Parallel() // SAFE FOR TESTING
+			t.Parallel()
 			h := makeQueryCacheTestHelper(t, 2 /* numConns */)
 			defer h.Stop()
 			r0, r1 := h.runners[0], h.runners[1]
@@ -391,7 +391,7 @@ SELECT cte.x, cte.y FROM cte LEFT JOIN cte as cte2 on cte.y = cte2.x`, j)
 		// Test a schema change where the other connections are running the query in
 		// parallel.
 		t.Run("schemachange-parallel", func(t *testing.T) {
-			t.Parallel() // SAFE FOR TESTING
+			t.Parallel()
 			const numConns = 4
 
 			h := makeQueryCacheTestHelper(t, numConns)
@@ -473,7 +473,7 @@ SELECT cte.x, cte.y FROM cte LEFT JOIN cte as cte2 on cte.y = cte2.x`, j)
 		// Verify the case where a PREPARE encounters a query cache entry that was
 		// created by a direct execution (and hence has no PrepareMetadata).
 		t.Run("exec-and-prepare", func(t *testing.T) {
-			t.Parallel() // SAFE FOR TESTING
+			t.Parallel()
 			h := makeQueryCacheTestHelper(t, 1 /* numConns */)
 			defer h.Stop()
 
@@ -496,7 +496,7 @@ SELECT cte.x, cte.y FROM cte LEFT JOIN cte as cte2 on cte.y = cte2.x`, j)
 
 		// Verify the case where we PREPARE the same statement with different hints.
 		t.Run("prepare-hints", func(t *testing.T) {
-			t.Parallel() // SAFE FOR TESTING
+			t.Parallel()
 			h := makeQueryCacheTestHelper(t, 1 /* numConns */)
 			defer h.Stop()
 

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -912,42 +912,6 @@ func TestLint(t *testing.T) {
 		}
 	})
 
-	t.Run("TestTParallel", func(t *testing.T) {
-		t.Parallel()
-		cmd, stderr, filter, err := dirCmd(
-			pkgDir,
-			"git",
-			"grep",
-			"-nE",
-			`\.Parallel\(\)`,
-			"--",
-			"*.go",
-			":!testutils/lint/*.go",
-		)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if err := cmd.Start(); err != nil {
-			t.Fatal(err)
-		}
-
-		if err := stream.ForEach(stream.Sequence(
-			filter,
-			stream.GrepNot(`// SAFE FOR TESTING`),
-		), func(s string) {
-			t.Errorf("\n%s <- forbidden, use a sync.WaitGroup instead (cf https://github.com/golang/go/issues/31651)", s)
-		}); err != nil {
-			t.Error(err)
-		}
-
-		if err := cmd.Wait(); err != nil {
-			if out := stderr.String(); len(out) > 0 {
-				t.Fatalf("err=%s, stderr=%s", err, out)
-			}
-		}
-	})
-
 	t.Run("TestTSkipNotUsed", func(t *testing.T) {
 		cmd, stderr, filter, err := dirCmd(
 			pkgDir,

--- a/pkg/util/fast_int_map_test.go
+++ b/pkg/util/fast_int_map_test.go
@@ -29,7 +29,7 @@ func TestFastIntMap(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(fmt.Sprintf("%d-%d", tc.keyRange, tc.valRange), func(t *testing.T) {
-			t.Parallel() // SAFE FOR TESTING (this comment is for the linter)
+			t.Parallel()
 			rng, _ := randutil.NewPseudoRand()
 			var fm FastIntMap
 			m := make(map[int]int)

--- a/pkg/util/fast_int_set_test.go
+++ b/pkg/util/fast_int_set_test.go
@@ -22,7 +22,7 @@ func TestFastIntSet(t *testing.T) {
 	for _, mVal := range []int{1, 8, 30, smallCutoff, 2 * smallCutoff, 4 * smallCutoff} {
 		m := mVal
 		t.Run(fmt.Sprintf("%d", m), func(t *testing.T) {
-			t.Parallel() // SAFE FOR TESTING (this comment is for the linter)
+			t.Parallel()
 			rng, _ := randutil.NewPseudoRand()
 			in := make([]bool, m)
 			forEachRes := make([]bool, m)

--- a/pkg/util/ulid/ulid_test.go
+++ b/pkg/util/ulid/ulid_test.go
@@ -52,7 +52,7 @@ func ExampleULID() {
 }
 
 func TestNew(t *testing.T) {
-	t.Parallel() // SAFE FOR TESTING (this comment is for the linter)
+	t.Parallel()
 
 	t.Run("ULID", testULID(func(ms uint64, e io.Reader) ulid.ULID {
 		id, err := ulid.New(ms, e)
@@ -78,7 +78,7 @@ func TestNew(t *testing.T) {
 }
 
 func TestMustNew(t *testing.T) {
-	t.Parallel() // SAFE FOR TESTING (this comment is for the linter)
+	t.Parallel()
 
 	t.Run("ULID", testULID(ulid.MustNew))
 
@@ -93,7 +93,7 @@ func TestMustNew(t *testing.T) {
 }
 
 func TestMustParse(t *testing.T) {
-	t.Parallel() // SAFE FOR TESTING (this comment is for the linter)
+	t.Parallel()
 
 	for _, tc := range []struct {
 		name string
@@ -130,7 +130,7 @@ func testULID(mk func(uint64, io.Reader) ulid.ULID) func(*testing.T) {
 }
 
 func TestRoundTrips(t *testing.T) {
-	t.Parallel() // SAFE FOR TESTING (this comment is for the linter)
+	t.Parallel()
 
 	prop := func(id ulid.ULID) bool {
 		bin, err := id.MarshalBinary()
@@ -165,7 +165,7 @@ func TestRoundTrips(t *testing.T) {
 }
 
 func TestMarshalingErrors(t *testing.T) {
-	t.Parallel() // SAFE FOR TESTING (this comment is for the linter)
+	t.Parallel()
 
 	var id ulid.ULID
 	for _, tc := range []struct {
@@ -189,7 +189,7 @@ func TestMarshalingErrors(t *testing.T) {
 }
 
 func TestParseStrictInvalidCharacters(t *testing.T) {
-	t.Parallel() // SAFE FOR TESTING (this comment is for the linter)
+	t.Parallel()
 
 	type testCase struct {
 		name  string
@@ -220,7 +220,7 @@ func TestParseStrictInvalidCharacters(t *testing.T) {
 }
 
 func TestAlizainCompatibility(t *testing.T) {
-	t.Parallel() // SAFE FOR TESTING (this comment is for the linter)
+	t.Parallel()
 
 	ts := uint64(1469918176385)
 	got := ulid.MustNew(ts, bytes.NewReader(make([]byte, 16)))
@@ -231,7 +231,7 @@ func TestAlizainCompatibility(t *testing.T) {
 }
 
 func TestEncoding(t *testing.T) {
-	t.Parallel() // SAFE FOR TESTING (this comment is for the linter)
+	t.Parallel()
 
 	enc := make(map[rune]bool, len(ulid.Encoding))
 	for _, r := range ulid.Encoding {
@@ -253,7 +253,7 @@ func TestEncoding(t *testing.T) {
 }
 
 func TestLexicographicalOrder(t *testing.T) {
-	t.Parallel() // SAFE FOR TESTING (this comment is for the linter)
+	t.Parallel()
 
 	prop := func(a, b ulid.ULID) bool {
 		t1, t2 := a.Time(), b.Time()
@@ -282,7 +282,7 @@ func TestLexicographicalOrder(t *testing.T) {
 }
 
 func TestCaseInsensitivity(t *testing.T) {
-	t.Parallel() // SAFE FOR TESTING (this comment is for the linter)
+	t.Parallel()
 
 	upper := func(id ulid.ULID) (out ulid.ULID) {
 		return ulid.MustParse(strings.ToUpper(id.String()))
@@ -299,7 +299,7 @@ func TestCaseInsensitivity(t *testing.T) {
 }
 
 func TestParseRobustness(t *testing.T) {
-	t.Parallel() // SAFE FOR TESTING (this comment is for the linter)
+	t.Parallel()
 
 	cases := [][]byte{
 		{0x1, 0xc0, 0x73, 0x62, 0x4a, 0xaf, 0x39, 0x78, 0x51, 0x4e, 0xf8, 0x44, 0x3b,
@@ -341,7 +341,7 @@ func TestParseRobustness(t *testing.T) {
 }
 
 func TestNow(t *testing.T) {
-	t.Parallel() // SAFE FOR TESTING (this comment is for the linter)
+	t.Parallel()
 
 	before := ulid.Now()
 	after := ulid.Timestamp(timeutil.Now().UTC().Add(time.Millisecond))
@@ -352,7 +352,7 @@ func TestNow(t *testing.T) {
 }
 
 func TestTimestamp(t *testing.T) {
-	t.Parallel() // SAFE FOR TESTING (this comment is for the linter)
+	t.Parallel()
 
 	tm := timeutil.Unix(1, 1000) // will be truncated
 	if got, want := ulid.Timestamp(tm), uint64(1000); got != want {
@@ -368,7 +368,7 @@ func TestTimestamp(t *testing.T) {
 }
 
 func TestTime(t *testing.T) {
-	t.Parallel() // SAFE FOR TESTING (this comment is for the linter)
+	t.Parallel()
 
 	original := timeutil.Now()
 	diff := original.Sub(ulid.Time(ulid.Timestamp(original)))
@@ -380,7 +380,7 @@ func TestTime(t *testing.T) {
 }
 
 func TestTimestampRoundTrips(t *testing.T) {
-	t.Parallel() // SAFE FOR TESTING (this comment is for the linter)
+	t.Parallel()
 
 	prop := func(ts uint64) bool {
 		return ts == ulid.Timestamp(ulid.Time(ts))
@@ -393,7 +393,7 @@ func TestTimestampRoundTrips(t *testing.T) {
 }
 
 func TestULIDTime(t *testing.T) {
-	t.Parallel() // SAFE FOR TESTING (this comment is for the linter)
+	t.Parallel()
 
 	maxTime := ulid.MaxTime()
 
@@ -419,7 +419,7 @@ func TestULIDTime(t *testing.T) {
 }
 
 func TestEntropy(t *testing.T) {
-	t.Parallel() // SAFE FOR TESTING (this comment is for the linter)
+	t.Parallel()
 
 	var id ulid.ULID
 	got, want := id.SetEntropy([]byte{}), ulid.ErrDataSize
@@ -448,7 +448,7 @@ func TestEntropy(t *testing.T) {
 }
 
 func TestEntropyRead(t *testing.T) {
-	t.Parallel() // SAFE FOR TESTING (this comment is for the linter)
+	t.Parallel()
 
 	prop := func(e [10]byte) bool {
 		flakyReader := iotest.HalfReader(bytes.NewReader(e[:]))
@@ -473,7 +473,7 @@ func TestEntropyRead(t *testing.T) {
 }
 
 func TestCompare(t *testing.T) {
-	t.Parallel() // SAFE FOR TESTING (this comment is for the linter)
+	t.Parallel()
 
 	a := func(a, b ulid.ULID) int {
 		return strings.Compare(a.String(), b.String())
@@ -490,7 +490,7 @@ func TestCompare(t *testing.T) {
 }
 
 func TestOverflowHandling(t *testing.T) {
-	t.Parallel() // SAFE FOR TESTING (this comment is for the linter)
+	t.Parallel()
 
 	for s, want := range map[string]error{
 		"00000000000000000000000000": nil,
@@ -523,7 +523,7 @@ func TestScan(t *testing.T) {
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel() // SAFE FOR TESTING (this comment is for the linter)
+			t.Parallel()
 
 			var out ulid.ULID
 			err := out.Scan(tc.in)
@@ -559,7 +559,7 @@ func TestMonotonic(t *testing.T) {
 			entropy := ulid.Monotonic(e.mk(), inc)
 
 			t.Run(fmt.Sprintf("entropy=%s/inc=%d", e.name, inc), func(t *testing.T) {
-				t.Parallel() // SAFE FOR TESTING (this comment is for the linter)
+				t.Parallel()
 
 				var prev ulid.ULID
 				for i := 0; i < 10000; i++ {
@@ -581,7 +581,7 @@ func TestMonotonic(t *testing.T) {
 }
 
 func TestMonotonicOverflow(t *testing.T) {
-	t.Parallel() // SAFE FOR TESTING (this comment is for the linter)
+	t.Parallel()
 
 	entropy := ulid.Monotonic(
 		io.MultiReader(
@@ -605,7 +605,7 @@ func TestMonotonicOverflow(t *testing.T) {
 }
 
 func TestMonotonicSafe(t *testing.T) {
-	t.Parallel() // SAFE FOR TESTING (this comment is for the linter)
+	t.Parallel()
 
 	var (
 		src       = rand.NewSource(timeutil.Now().UnixNano())


### PR DESCRIPTION
Previously, there was an issue with using of `t.Parallel` in subtests
when the parent test needed to perform some cleanup work. As a result,
we introduced a linter that prohibited the pattern in general unless the
writer of the test explicitly marked the test as safe for being run in
parallel.

The underlying issue (https://github.com/golang/go/issues/31651) has been
resolved over a year ago in Go, so the linter is no longer needed and is,
thus, removed.

Release note: None