### PR TITLE
release-21.1: sql/opt: support implicit SELECT FOR UPDATE locking with nested renders

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -1122,12 +1122,10 @@ func (b *Builder) shouldApplyImplicitLockingToUpdateInput(upd *memo.UpdateExpr) 
 
 	// Try to match the Update's input expression against the pattern:
 	//
-	//   [Project] [IndexJoin] Scan
+	//   [Project]* [IndexJoin] Scan
 	//
 	input := upd.Input
-	if proj, ok := input.(*memo.ProjectExpr); ok {
-		input = proj.Input
-	}
+	input = unwrapProjectExprs(input)
 	if idxJoin, ok := input.(*memo.IndexJoinExpr); ok {
 		input = idxJoin.Input
 	}
@@ -1138,9 +1136,6 @@ func (b *Builder) shouldApplyImplicitLockingToUpdateInput(upd *memo.UpdateExpr) 
 // tryApplyImplicitLockingToUpsertInput determines whether or not the builder
 // should apply a FOR UPDATE row-level locking mode to the initial row scan of
 // an UPSERT statement.
-//
-// TODO(nvanbenschoten): implement this method to match on appropriate Upsert
-// expression trees and apply a row-level locking mode.
 func (b *Builder) shouldApplyImplicitLockingToUpsertInput(ups *memo.UpsertExpr) bool {
 	if !b.evalCtx.SessionData.ImplicitSelectForUpdate {
 		return false
@@ -1148,12 +1143,10 @@ func (b *Builder) shouldApplyImplicitLockingToUpsertInput(ups *memo.UpsertExpr) 
 
 	// Try to match the Upsert's input expression against the pattern:
 	//
-	//   [Project] (LeftJoin Scan | LookupJoin) [Project] Values
+	//   [Project]* (LeftJoin Scan | LookupJoin) [Project]* Values
 	//
 	input := ups.Input
-	if proj, ok := input.(*memo.ProjectExpr); ok {
-		input = proj.Input
-	}
+	input = unwrapProjectExprs(input)
 	switch join := input.(type) {
 	case *memo.LeftJoinExpr:
 		if _, ok := join.Right.(*memo.ScanExpr); !ok {
@@ -1167,9 +1160,7 @@ func (b *Builder) shouldApplyImplicitLockingToUpsertInput(ups *memo.UpsertExpr) 
 	default:
 		return false
 	}
-	if proj, ok := input.(*memo.ProjectExpr); ok {
-		input = proj.Input
-	}
+	input = unwrapProjectExprs(input)
 	_, ok := input.(*memo.ValuesExpr)
 	return ok
 }
@@ -1182,4 +1173,13 @@ func (b *Builder) shouldApplyImplicitLockingToUpsertInput(ups *memo.UpsertExpr) 
 // expression trees and apply a row-level locking mode.
 func (b *Builder) shouldApplyImplicitLockingToDeleteInput(del *memo.DeleteExpr) bool {
 	return false
+}
+
+// unwrapProjectExprs unwraps zero or more nested ProjectExprs. It returns the
+// first non-ProjectExpr in the chain, or the input if it is not a ProjectExpr.
+func unwrapProjectExprs(input memo.RelExpr) memo.RelExpr {
+	if proj, ok := input.(*memo.ProjectExpr); ok {
+		return unwrapProjectExprs(proj.Input)
+	}
+	return input
 }

--- a/pkg/sql/opt/exec/execbuilder/testdata/check_constraints
+++ b/pkg/sql/opt/exec/execbuilder/testdata/check_constraints
@@ -51,6 +51,7 @@ vectorized: true
               estimated row count: 1 (missing stats)
               table: t9@primary
               spans: /5/0-/5/1/2
+              locking strength: for update
 
 query T
 EXPLAIN (VERBOSE) UPDATE t9 SET a = 2 WHERE a = 5

--- a/pkg/sql/opt/exec/execbuilder/testdata/unique
+++ b/pkg/sql/opt/exec/execbuilder/testdata/unique
@@ -2188,6 +2188,7 @@ vectorized: true
 │                     estimated row count: 10 (missing stats)
 │                     table: uniq_enum@primary
 │                     spans: /"\xc0"-/"\xc0"/PrefixEnd
+│                     locking strength: for update
 │
 ├── • constraint-check
 │   │
@@ -3393,6 +3394,7 @@ vectorized: true
 │                       │ table: uniq_enum@primary
 │                       │ equality: (column1, column3) = (r,i)
 │                       │ equality cols are key
+│                       │ locking strength: for update
 │                       │
 │                       └── • values
 │                             columns: (column1, column2, column3, column4)
@@ -3543,6 +3545,7 @@ vectorized: true
 │                       │ table: uniq_enum@uniq_enum_r_s_j_key
 │                       │ equality cols are key
 │                       │ lookup condition: ((column2 = s) AND (column4 = j)) AND (r IN ('us-east', 'us-west', 'eu-west'))
+│                       │ locking strength: for update
 │                       │
 │                       └── • values
 │                             columns: (column1, column2, column3, column4)
@@ -4071,6 +4074,7 @@ vectorized: true
 │                       │ table: uniq_partial_enum@primary
 │                       │ equality: (column1, column2) = (r,a)
 │                       │ equality cols are key
+│                       │ locking strength: for update
 │                       │
 │                       └── • values
 │                             columns: (column1, column2, column3, column4)

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -271,6 +271,76 @@ vectorized: true
                       row 2, expr 0: 3
                       row 3, expr 0: 4
 
+query T
+EXPLAIN (VERBOSE)
+INSERT INTO indexed
+VALUES (1, 2, 3)
+ON CONFLICT (a)
+DO UPDATE SET b = 2, c = 3
+----
+distribution: local
+vectorized: true
+·
+• upsert
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ into: indexed(a, b, c, d)
+│ auto commit
+│ arbiter indexes: primary
+│
+└── • project
+    │ columns: (column1, column2, column3, column10, a, b, c, d, upsert_b, upsert_c, upsert_d, a, check1)
+    │
+    └── • render
+        │ columns: (check1, column1, column2, column3, column10, a, b, c, d, upsert_b, upsert_c, upsert_d)
+        │ estimated row count: 1 (missing stats)
+        │ render check1: upsert_c > 0
+        │ render column1: column1
+        │ render column2: column2
+        │ render column3: column3
+        │ render column10: column10
+        │ render a: a
+        │ render b: b
+        │ render c: c
+        │ render d: d
+        │ render upsert_b: upsert_b
+        │ render upsert_c: upsert_c
+        │ render upsert_d: upsert_d
+        │
+        └── • render
+            │ columns: (upsert_b, upsert_c, upsert_d, column1, column2, column3, column10, a, b, c, d)
+            │ estimated row count: 1 (missing stats)
+            │ render upsert_b: CASE WHEN a IS NULL THEN column2 ELSE 2 END
+            │ render upsert_c: CASE WHEN a IS NULL THEN column3 ELSE 3 END
+            │ render upsert_d: CASE WHEN a IS NULL THEN column10 ELSE a + 3 END
+            │ render column1: column1
+            │ render column2: column2
+            │ render column3: column3
+            │ render column10: column10
+            │ render a: a
+            │ render b: b
+            │ render c: c
+            │ render d: d
+            │
+            └── • cross join (left outer)
+                │ columns: (column1, column2, column3, column10, a, b, c, d)
+                │ estimated row count: 1 (missing stats)
+                │
+                ├── • values
+                │     columns: (column1, column2, column3, column10)
+                │     size: 4 columns, 1 row
+                │     row 0, expr 0: 1
+                │     row 0, expr 1: 2
+                │     row 0, expr 2: 3
+                │     row 0, expr 3: 4
+                │
+                └── • scan
+                      columns: (a, b, c, d)
+                      estimated row count: 1 (missing stats)
+                      table: indexed@primary
+                      spans: /1-/1/#
+                      locking strength: for update
+
 # Drop index and verify that existing values no longer need to be fetched.
 statement ok
 DROP INDEX indexed@secondary CASCADE

--- a/pkg/sql/opt/exec/execbuilder/testdata/virtual_columns
+++ b/pkg/sql/opt/exec/execbuilder/testdata/virtual_columns
@@ -423,6 +423,7 @@ vectorized: true
               estimated row count: 1,000 (missing stats)
               table: t@primary
               spans: FULL SCAN
+              locking strength: for update
 
 query T
 EXPLAIN (VERBOSE) UPDATE t SET b=b+1 WHERE v=45 RETURNING a,b,v
@@ -504,6 +505,7 @@ vectorized: true
               estimated row count: 1,000 (missing stats)
               table: t_idx@primary
               spans: FULL SCAN
+              locking strength: for update
 
 query T
 EXPLAIN (VERBOSE) UPDATE t_idx SET b=b+1 RETURNING v, w
@@ -546,6 +548,7 @@ vectorized: true
                   estimated row count: 1,000 (missing stats)
                   table: t_idx@primary
                   spans: FULL SCAN
+                  locking strength: for update
 
 query T
 EXPLAIN (VERBOSE) UPDATE t_idx SET b=b+1 WHERE v=45 RETURNING v, w
@@ -594,6 +597,7 @@ vectorized: true
                       estimated row count: 10 (missing stats)
                       table: t_idx@t_idx_v_idx
                       spans: /45-/46
+                      locking strength: for update
 
 query T
 EXPLAIN (VERBOSE) UPDATE t_idx SET c=6 WHERE a=2
@@ -663,6 +667,7 @@ vectorized: true
               estimated row count: 1,000 (missing stats)
               table: t_idx@primary
               spans: FULL SCAN
+              locking strength: for update
 
 query T
 EXPLAIN (VERBOSE) UPDATE t_idx SET b=b+1 RETURNING w
@@ -705,6 +710,7 @@ vectorized: true
                   estimated row count: 1,000 (missing stats)
                   table: t_idx@primary
                   spans: FULL SCAN
+                  locking strength: for update
 
 subtest Upsert
 
@@ -825,6 +831,7 @@ vectorized: true
                 │ table: t@primary
                 │ equality: (column1) = (a)
                 │ equality cols are key
+                │ locking strength: for update
                 │
                 └── • render
                     │ columns: (column8, column1, column2)
@@ -887,6 +894,7 @@ vectorized: true
                 │ table: t@primary
                 │ equality: (column1) = (a)
                 │ equality cols are key
+                │ locking strength: for update
                 │
                 └── • render
                     │ columns: (column8, column1, column2)
@@ -1019,6 +1027,7 @@ vectorized: true
                 │ table: t_idx@primary
                 │ equality: (column1) = (a)
                 │ equality cols are key
+                │ locking strength: for update
                 │
                 └── • render
                     │ columns: (column11, column12, column1, column2, column3)
@@ -1155,6 +1164,7 @@ vectorized: true
                 │ table: t_idx@primary
                 │ equality: (column1) = (a)
                 │ equality cols are key
+                │ locking strength: for update
                 │
                 └── • render
                     │ columns: (column11, column12, column1, column2, column3)
@@ -1233,6 +1243,7 @@ vectorized: true
                 │ table: t_idx@primary
                 │ equality: (column1) = (a)
                 │ equality cols are key
+                │ locking strength: for update
                 │
                 └── • render
                     │ columns: (column11, column12, column1, column2, column3)


### PR DESCRIPTION
Backport 1/1 commits from #65332.

/cc @cockroachdb/release

---

This commit adds support for implicit SELECT FOR UPDATE to a collection of UPDATE and UPSERT queries that previously did not use row-level locking because they included 2 or more nested `ProjExprs`. The pattern matching that enabled implicit SELECT FOR UPDATE was not handling this case correctly.

The most common case where this had an effect was with
```sql
INSERT INTO ... ON CONFLICT ... DO UPDATE SET
```
statements without a predicate. This class of statement always seems to include nested render expressions, and so it wasn't acquiring row-level locks during its initial row scan.

Release note (sql change): `INSERT INTO ... ON CONFLICT ... DO UPDATE SET` statements without predicates now acquire locks using the FOR UPDATE locking mode during their initial row scan, which improves performance for contended workloads. This behavior is configurable using the enable_implicit_select_for_update session variable and the sql.defaults.implicit_select_for_update.enabled cluster setting.
