### PR TITLE
release-20.2: sql/opt: support implicit SELECT FOR UPDATE locking with nested renders

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -986,12 +986,10 @@ func (b *Builder) shouldApplyImplicitLockingToUpdateInput(upd *memo.UpdateExpr) 
 
 	// Try to match the Update's input expression against the pattern:
 	//
-	//   [Project] [IndexJoin] Scan
+	//   [Project]* [IndexJoin] Scan
 	//
 	input := upd.Input
-	if proj, ok := input.(*memo.ProjectExpr); ok {
-		input = proj.Input
-	}
+	input = unwrapProjectExprs(input)
 	if idxJoin, ok := input.(*memo.IndexJoinExpr); ok {
 		input = idxJoin.Input
 	}
@@ -1002,9 +1000,6 @@ func (b *Builder) shouldApplyImplicitLockingToUpdateInput(upd *memo.UpdateExpr) 
 // tryApplyImplicitLockingToUpsertInput determines whether or not the builder
 // should apply a FOR UPDATE row-level locking mode to the initial row scan of
 // an UPSERT statement.
-//
-// TODO(nvanbenschoten): implement this method to match on appropriate Upsert
-// expression trees and apply a row-level locking mode.
 func (b *Builder) shouldApplyImplicitLockingToUpsertInput(ups *memo.UpsertExpr) bool {
 	if !b.evalCtx.SessionData.ImplicitSelectForUpdate {
 		return false
@@ -1012,12 +1007,10 @@ func (b *Builder) shouldApplyImplicitLockingToUpsertInput(ups *memo.UpsertExpr) 
 
 	// Try to match the Upsert's input expression against the pattern:
 	//
-	//   [Project] (LeftJoin Scan | LookupJoin) [Project] Values
+	//   [Project]* (LeftJoin Scan | LookupJoin) [Project]* Values
 	//
 	input := ups.Input
-	if proj, ok := input.(*memo.ProjectExpr); ok {
-		input = proj.Input
-	}
+	input = unwrapProjectExprs(input)
 	switch join := input.(type) {
 	case *memo.LeftJoinExpr:
 		if _, ok := join.Right.(*memo.ScanExpr); !ok {
@@ -1031,9 +1024,7 @@ func (b *Builder) shouldApplyImplicitLockingToUpsertInput(ups *memo.UpsertExpr) 
 	default:
 		return false
 	}
-	if proj, ok := input.(*memo.ProjectExpr); ok {
-		input = proj.Input
-	}
+	input = unwrapProjectExprs(input)
 	_, ok := input.(*memo.ValuesExpr)
 	return ok
 }
@@ -1046,4 +1037,13 @@ func (b *Builder) shouldApplyImplicitLockingToUpsertInput(ups *memo.UpsertExpr) 
 // expression trees and apply a row-level locking mode.
 func (b *Builder) shouldApplyImplicitLockingToDeleteInput(del *memo.DeleteExpr) bool {
 	return false
+}
+
+// unwrapProjectExprs unwraps zero or more nested ProjectExprs. It returns the
+// first non-ProjectExpr in the chain, or the input if it is not a ProjectExpr.
+func unwrapProjectExprs(input memo.RelExpr) memo.RelExpr {
+	if proj, ok := input.(*memo.ProjectExpr); ok {
+		return unwrapProjectExprs(proj.Input)
+	}
+	return input
 }

--- a/pkg/sql/opt/exec/execbuilder/testdata/check_constraints
+++ b/pkg/sql/opt/exec/execbuilder/testdata/check_constraints
@@ -45,6 +45,7 @@ update               ·                    ·                          ()       
 ·                    estimated row count  1 (missing stats)          ·                              ·
 ·                    table                t9@primary                 ·                              ·
 ·                    spans                /5/0-/5/1/2 /5/3/1-/5/3/2  ·                              ·
+·                    locking strength     for update                 ·                              ·
 
 query TTTTT
 EXPLAIN (VERBOSE) UPDATE t9 SET a = 2 WHERE a = 5

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -211,6 +211,64 @@ upsert                                   ·                      ·
 ·                                        row 2, expr 0          3
 ·                                        row 3, expr 0          4
 
+query TTT
+SELECT tree, field, description FROM [
+EXPLAIN (VERBOSE)
+INSERT INTO indexed
+VALUES (1, 2, 3)
+ON CONFLICT (a)
+DO UPDATE SET b = 2, c = 3
+]
+----
+·                                            distribution         local
+·                                            vectorized           false
+upsert                                       ·                    ·
+ │                                           estimated row count  0 (missing stats)
+ │                                           into                 indexed(a, b, c, d)
+ │                                           auto commit          ·
+ │                                           arbiter indexes      primary
+ └── project                                 ·                    ·
+      └── render                             ·                    ·
+           │                                 estimated row count  1 (missing stats)
+           │                                 render 0             upsert_c > 0
+           │                                 render 1             column1
+           │                                 render 2             column2
+           │                                 render 3             column3
+           │                                 render 4             column10
+           │                                 render 5             a
+           │                                 render 6             b
+           │                                 render 7             c
+           │                                 render 8             d
+           │                                 render 9             upsert_b
+           │                                 render 10            upsert_c
+           │                                 render 11            upsert_d
+           └── render                        ·                    ·
+                │                            estimated row count  1 (missing stats)
+                │                            render 0             CASE WHEN a IS NULL THEN column2 ELSE 2 END
+                │                            render 1             CASE WHEN a IS NULL THEN column3 ELSE 3 END
+                │                            render 2             CASE WHEN a IS NULL THEN column10 ELSE a + 3 END
+                │                            render 3             column1
+                │                            render 4             column2
+                │                            render 5             column3
+                │                            render 6             column10
+                │                            render 7             a
+                │                            render 8             b
+                │                            render 9             c
+                │                            render 10            d
+                └── cross join (left outer)  ·                    ·
+                     │                       estimated row count  1 (missing stats)
+                     ├── values              ·                    ·
+                     │                       size                 4 columns, 1 row
+                     │                       row 0, expr 0        1
+                     │                       row 0, expr 1        2
+                     │                       row 0, expr 2        3
+                     │                       row 0, expr 3        4
+                     └── scan                ·                    ·
+·                                            estimated row count  1 (missing stats)
+·                                            table                indexed@primary
+·                                            spans                /1-/1/#
+·                                            locking strength     for update
+
 # Drop index and verify that existing values no longer need to be fetched.
 statement ok
 DROP INDEX indexed@secondary CASCADE


### PR DESCRIPTION
Backport 1/1 commits from #65332.

/cc @cockroachdb/release

---

This commit adds support for implicit SELECT FOR UPDATE to a collection of UPDATE and UPSERT queries that previously did not use row-level locking because they included 2 or more nested `ProjExprs`. The pattern matching that enabled implicit SELECT FOR UPDATE was not handling this case correctly.

The most common case where this had an effect was with
```sql
INSERT INTO ... ON CONFLICT ... DO UPDATE SET
```
statements without a predicate. This class of statement always seems to include nested render expressions, and so it wasn't acquiring row-level locks during its initial row scan.

Release note (sql change): `INSERT INTO ... ON CONFLICT ... DO UPDATE SET` statements without predicates now acquire locks using the FOR UPDATE locking mode during their initial row scan, which improves performance for contended workloads. This behavior is configurable using the enable_implicit_select_for_update session variable and the sql.defaults.implicit_select_for_update.enabled cluster setting.
