### PR TITLE
colexecop: clarify ClosableOperator interface

### DIFF
--- a/pkg/sql/colexec/aggregators_test.go
+++ b/pkg/sql/colexec/aggregators_test.go
@@ -1071,7 +1071,7 @@ func benchmarkAggregateFunction(
 				// Exhaust aggregator until all batches have been read.
 				for b := a.Next(); b.Length() != 0; b = a.Next() {
 				}
-				if err = a.(colexecop.Closer).Close(ctx); err != nil {
+				if err = a.(colexecop.Closer).Close(); err != nil {
 					b.Fatal(err)
 				}
 				source.Reset(ctx)

--- a/pkg/sql/colexec/colexecagg/default_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/default_agg_tmpl.go
@@ -207,9 +207,9 @@ func (a *default_AGGKINDAggAlloc) newAggFunc() AggregateFunc {
 	return f
 }
 
-func (a *default_AGGKINDAggAlloc) Close(ctx context.Context) error {
+func (a *default_AGGKINDAggAlloc) Close() error {
 	for _, fn := range a.returnedFns {
-		fn.fn.Close(ctx)
+		fn.fn.Close(fn.ctx)
 	}
 	a.returnedFns = nil
 	return nil

--- a/pkg/sql/colexec/colexecagg/hash_default_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_default_agg.eg.go
@@ -176,9 +176,9 @@ func (a *defaultHashAggAlloc) newAggFunc() AggregateFunc {
 	return f
 }
 
-func (a *defaultHashAggAlloc) Close(ctx context.Context) error {
+func (a *defaultHashAggAlloc) Close() error {
 	for _, fn := range a.returnedFns {
-		fn.fn.Close(ctx)
+		fn.fn.Close(fn.ctx)
 	}
 	a.returnedFns = nil
 	return nil

--- a/pkg/sql/colexec/colexecagg/ordered_default_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_default_agg.eg.go
@@ -241,9 +241,9 @@ func (a *defaultOrderedAggAlloc) newAggFunc() AggregateFunc {
 	return f
 }
 
-func (a *defaultOrderedAggAlloc) Close(ctx context.Context) error {
+func (a *defaultOrderedAggAlloc) Close() error {
 	for _, fn := range a.returnedFns {
-		fn.fn.Close(ctx)
+		fn.fn.Close(fn.ctx)
 	}
 	a.returnedFns = nil
 	return nil

--- a/pkg/sql/colexec/colexecjoin/crossjoiner.go
+++ b/pkg/sql/colexec/colexecjoin/crossjoiner.go
@@ -79,7 +79,12 @@ var _ colexecop.ClosableOperator = &crossJoiner{}
 var _ colexecop.ResettableOperator = &crossJoiner{}
 
 func (c *crossJoiner) Init(ctx context.Context) {
-	c.init(ctx)
+	if !c.joinHelper.init(ctx) {
+		return
+	}
+	// Note that c.joinHelper.Ctx might contain an updated context, so we use
+	// that rather than ctx.
+	c.crossJoinerBase.init(c.joinHelper.Ctx)
 }
 
 func (c *crossJoiner) Next() coldata.Batch {
@@ -88,7 +93,7 @@ func (c *crossJoiner) Next() coldata.Batch {
 		c.setupForBuilding()
 	}
 	if c.numTotalOutputTuples == c.numAlreadyEmitted {
-		if err := c.Close(c.Ctx); err != nil {
+		if err := c.Close(); err != nil {
 			colexecerror.InternalError(err)
 		}
 		return coldata.ZeroBatch
@@ -300,6 +305,7 @@ func newCrossJoinerBase(
 }
 
 type crossJoinerBase struct {
+	initHelper   colexecop.InitHelper
 	joinType     descpb.JoinType
 	left, right  cjState
 	builderState struct {
@@ -310,6 +316,10 @@ type crossJoinerBase struct {
 		rightColOffset int
 	}
 	output coldata.Batch
+}
+
+func (b *crossJoinerBase) init(ctx context.Context) {
+	b.initHelper.Init(ctx)
 }
 
 func (b *crossJoinerBase) setupBuilder() {
@@ -428,7 +438,8 @@ func (b *crossJoinerBase) Reset(ctx context.Context) {
 	b.builderState.right.reset()
 }
 
-func (b *crossJoinerBase) Close(ctx context.Context) error {
+func (b *crossJoinerBase) Close() error {
+	ctx := b.initHelper.EnsureCtx()
 	var lastErr error
 	if b.left.tuples != nil {
 		lastErr = b.left.tuples.Close(ctx)

--- a/pkg/sql/colexec/colexecjoin/mergejoiner.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner.go
@@ -521,6 +521,7 @@ func (o *mergeJoinBase) Init(ctx context.Context) {
 		o.unlimitedAllocator, o.joinType, o.left.sourceTypes, o.right.sourceTypes,
 		o.memoryLimit, o.diskQueueCfg, o.fdSemaphore, o.diskAcc,
 	)
+	o.bufferedGroup.helper.init(o.Ctx)
 
 	o.builderState.lGroups = make([]group, 1)
 	o.builderState.rGroups = make([]group, 1)
@@ -766,20 +767,20 @@ func (o *mergeJoinBase) finishProbe() {
 	)
 }
 
-func (o *mergeJoinBase) Close(ctx context.Context) error {
+func (o *mergeJoinBase) Close() error {
 	if !o.CloserHelper.Close() {
 		return nil
 	}
 	var lastErr error
 	for _, op := range []colexecop.Operator{o.left.source, o.right.source} {
 		if c, ok := op.(colexecop.Closer); ok {
-			if err := c.Close(ctx); err != nil {
+			if err := c.Close(); err != nil {
 				lastErr = err
 			}
 		}
 	}
 	if h := o.bufferedGroup.helper; h != nil {
-		if err := h.Close(ctx); err != nil {
+		if err := h.Close(); err != nil {
 			lastErr = err
 		}
 	}

--- a/pkg/sql/colexec/colexectestutils/utils.go
+++ b/pkg/sql/colexec/colexectestutils/utils.go
@@ -397,8 +397,8 @@ func RunTestsWithTyps(
 				"non-nulls in the input tuples, we expect for all nulls injection to "+
 				"change the output")
 		}
-		closeIfCloser(ctx, t, originalOp)
-		closeIfCloser(ctx, t, opWithNulls)
+		closeIfCloser(t, originalOp)
+		closeIfCloser(t, opWithNulls)
 	}
 }
 
@@ -407,9 +407,9 @@ func RunTestsWithTyps(
 //
 // RunTests harness needs to do that once it is done with op. In non-test
 // setting, the closing happens at the end of the query execution.
-func closeIfCloser(ctx context.Context, t *testing.T, op colexecop.Operator) {
+func closeIfCloser(t *testing.T, op colexecop.Operator) {
 	if c, ok := op.(colexecop.Closer); ok {
-		if err := c.Close(ctx); err != nil {
+		if err := c.Close(); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -469,7 +469,7 @@ func RunTestsWithoutAllNullsInjection(
 				t.Fatal(err)
 			}
 		}
-		closeIfCloser(ctx, t, op)
+		closeIfCloser(t, op)
 	})
 
 	if !skipVerifySelAndNullsResets {
@@ -501,7 +501,7 @@ func RunTestsWithoutAllNullsInjection(
 				t.Fatal(err)
 			}
 			// We might short-circuit, so defer the closing of the operator.
-			defer closeIfCloser(ctx, t, op)
+			defer closeIfCloser(t, op)
 			op.Init(ctx)
 			b := op.Next()
 			if b.Length() == 0 {
@@ -566,7 +566,7 @@ func RunTestsWithoutAllNullsInjection(
 		op.Init(ctx)
 		for b := op.Next(); b.Length() > 0; b = op.Next() {
 		}
-		closeIfCloser(ctx, t, op)
+		closeIfCloser(t, op)
 	}
 }
 

--- a/pkg/sql/colexec/colexecwindow/ntile.eg.go
+++ b/pkg/sql/colexec/colexecwindow/ntile.eg.go
@@ -357,7 +357,7 @@ func (r *nTileNoPartitionOp) Next() coldata.Batch {
 			colexecerror.InternalError(
 				errors.AssertionFailedf("ntile operator in processing state without buffered rows"))
 		case nTileFinished:
-			if err = r.Close(r.Ctx); err != nil {
+			if err = r.Close(); err != nil {
 				colexecerror.InternalError(err)
 			}
 			return coldata.ZeroBatch
@@ -528,7 +528,7 @@ func (r *nTileWithPartitionOp) Next() coldata.Batch {
 			colexecerror.InternalError(
 				errors.AssertionFailedf("ntile operator in processing state without buffered rows"))
 		case nTileFinished:
-			if err = r.Close(r.Ctx); err != nil {
+			if err = r.Close(); err != nil {
 				colexecerror.InternalError(err)
 			}
 			return coldata.ZeroBatch
@@ -601,9 +601,9 @@ func (r *nTileBase) setNTile(batch coldata.Batch, endIdx int) {
 	}
 }
 
-func (r *nTileBase) Close(ctx context.Context) error {
+func (r *nTileBase) Close() error {
 	if !r.CloserHelper.Close() {
 		return nil
 	}
-	return r.bufferQueue.Close(ctx)
+	return r.bufferQueue.Close(r.nTileInitFields.EnsureCtx())
 }

--- a/pkg/sql/colexec/colexecwindow/ntile_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/ntile_tmpl.go
@@ -21,6 +21,7 @@ package colexecwindow
 
 import (
 	"context"
+	"math"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colcontainer"
@@ -403,7 +404,7 @@ func (r *_NTILE_STRINGOp) Next() coldata.Batch {
 			colexecerror.InternalError(
 				errors.AssertionFailedf("ntile operator in processing state without buffered rows"))
 		case nTileFinished:
-			if err = r.Close(r.Ctx); err != nil {
+			if err = r.Close(); err != nil {
 				colexecerror.InternalError(err)
 			}
 			return coldata.ZeroBatch
@@ -478,9 +479,9 @@ func (r *nTileBase) setNTile(batch coldata.Batch, endIdx int) {
 	}
 }
 
-func (r *nTileBase) Close(ctx context.Context) error {
+func (r *nTileBase) Close() error {
 	if !r.CloserHelper.Close() {
 		return nil
 	}
-	return r.bufferQueue.Close(ctx)
+	return r.bufferQueue.Close(r.nTileInitFields.EnsureCtx())
 }

--- a/pkg/sql/colexec/colexecwindow/relative_rank.eg.go
+++ b/pkg/sql/colexec/colexecwindow/relative_rank.eg.go
@@ -338,7 +338,7 @@ func (r *percentRankNoPartitionOp) Next() coldata.Batch {
 			return r.output
 
 		case relativeRankFinished:
-			if err := r.Close(r.Ctx); err != nil {
+			if err := r.Close(); err != nil {
 				colexecerror.InternalError(err)
 			}
 			return coldata.ZeroBatch
@@ -351,10 +351,11 @@ func (r *percentRankNoPartitionOp) Next() coldata.Batch {
 	}
 }
 
-func (r *percentRankNoPartitionOp) Close(ctx context.Context) error {
+func (r *percentRankNoPartitionOp) Close() error {
 	if !r.CloserHelper.Close() {
 		return nil
 	}
+	ctx := r.EnsureCtx()
 	var lastErr error
 	if err := r.bufferedTuples.Close(ctx); err != nil {
 		lastErr = err
@@ -632,7 +633,7 @@ func (r *percentRankWithPartitionOp) Next() coldata.Batch {
 			return r.output
 
 		case relativeRankFinished:
-			if err := r.Close(r.Ctx); err != nil {
+			if err := r.Close(); err != nil {
 				colexecerror.InternalError(err)
 			}
 			return coldata.ZeroBatch
@@ -645,10 +646,11 @@ func (r *percentRankWithPartitionOp) Next() coldata.Batch {
 	}
 }
 
-func (r *percentRankWithPartitionOp) Close(ctx context.Context) error {
+func (r *percentRankWithPartitionOp) Close() error {
 	if !r.CloserHelper.Close() {
 		return nil
 	}
+	ctx := r.EnsureCtx()
 	var lastErr error
 	if err := r.bufferedTuples.Close(ctx); err != nil {
 		lastErr = err
@@ -914,7 +916,7 @@ func (r *cumeDistNoPartitionOp) Next() coldata.Batch {
 			return r.output
 
 		case relativeRankFinished:
-			if err := r.Close(r.Ctx); err != nil {
+			if err := r.Close(); err != nil {
 				colexecerror.InternalError(err)
 			}
 			return coldata.ZeroBatch
@@ -927,10 +929,11 @@ func (r *cumeDistNoPartitionOp) Next() coldata.Batch {
 	}
 }
 
-func (r *cumeDistNoPartitionOp) Close(ctx context.Context) error {
+func (r *cumeDistNoPartitionOp) Close() error {
 	if !r.CloserHelper.Close() {
 		return nil
 	}
+	ctx := r.EnsureCtx()
 	var lastErr error
 	if err := r.bufferedTuples.Close(ctx); err != nil {
 		lastErr = err
@@ -1290,7 +1293,7 @@ func (r *cumeDistWithPartitionOp) Next() coldata.Batch {
 			return r.output
 
 		case relativeRankFinished:
-			if err := r.Close(r.Ctx); err != nil {
+			if err := r.Close(); err != nil {
 				colexecerror.InternalError(err)
 			}
 			return coldata.ZeroBatch
@@ -1303,10 +1306,11 @@ func (r *cumeDistWithPartitionOp) Next() coldata.Batch {
 	}
 }
 
-func (r *cumeDistWithPartitionOp) Close(ctx context.Context) error {
+func (r *cumeDistWithPartitionOp) Close() error {
 	if !r.CloserHelper.Close() {
 		return nil
 	}
+	ctx := r.EnsureCtx()
 	var lastErr error
 	if err := r.bufferedTuples.Close(ctx); err != nil {
 		lastErr = err

--- a/pkg/sql/colexec/colexecwindow/relative_rank_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/relative_rank_tmpl.go
@@ -598,7 +598,7 @@ func (r *_RELATIVE_RANK_STRINGOp) Next() coldata.Batch {
 			return r.output
 
 		case relativeRankFinished:
-			if err := r.Close(r.Ctx); err != nil {
+			if err := r.Close(); err != nil {
 				colexecerror.InternalError(err)
 			}
 			return coldata.ZeroBatch
@@ -611,10 +611,11 @@ func (r *_RELATIVE_RANK_STRINGOp) Next() coldata.Batch {
 	}
 }
 
-func (r *_RELATIVE_RANK_STRINGOp) Close(ctx context.Context) error {
+func (r *_RELATIVE_RANK_STRINGOp) Close() error {
 	if !r.CloserHelper.Close() {
 		return nil
 	}
+	ctx := r.EnsureCtx()
 	var lastErr error
 	if err := r.bufferedTuples.Close(ctx); err != nil {
 		lastErr = err

--- a/pkg/sql/colexec/columnarizer.go
+++ b/pkg/sql/colexec/columnarizer.go
@@ -126,7 +126,7 @@ func newColumnarizer(
 				// Close will call InternalClose(). Note that we don't return
 				// any trailing metadata here because the columnarizers
 				// propagate it in DrainMeta.
-				if err := c.Close(c.Ctx); util.CrdbTestBuild && err != nil {
+				if err := c.Close(); util.CrdbTestBuild && err != nil {
 					// Close never returns an error.
 					colexecerror.InternalError(errors.AssertionFailedf("unexpected error %v from Columnarizer.Close", err))
 				}
@@ -137,7 +137,7 @@ func newColumnarizer(
 	return c
 }
 
-// Init is part of the Operator interface.
+// Init is part of the colexecop.Operator interface.
 func (c *Columnarizer) Init(ctx context.Context) {
 	if c.removedFromFlow {
 		return
@@ -181,7 +181,7 @@ func (c *Columnarizer) GetStats() *execinfrapb.ComponentStats {
 	return s
 }
 
-// Next is part of the Operator interface.
+// Next is part of the colexecop.Operator interface.
 func (c *Columnarizer) Next() coldata.Batch {
 	if c.removedFromFlow {
 		return coldata.ZeroBatch
@@ -281,8 +281,8 @@ func (c *Columnarizer) DrainMeta() []execinfrapb.ProducerMetadata {
 	return c.accumulatedMeta
 }
 
-// Close is part of the colexecop.Operator interface.
-func (c *Columnarizer) Close(context.Context) error {
+// Close is part of the colexecop.ClosableOperator interface.
+func (c *Columnarizer) Close() error {
 	if c.removedFromFlow {
 		return nil
 	}
@@ -290,7 +290,7 @@ func (c *Columnarizer) Close(context.Context) error {
 	return nil
 }
 
-// ChildCount is part of the Operator interface.
+// ChildCount is part of the execinfra.OpNode interface.
 func (c *Columnarizer) ChildCount(verbose bool) int {
 	if _, ok := c.input.(execinfra.OpNode); ok {
 		return 1
@@ -298,7 +298,7 @@ func (c *Columnarizer) ChildCount(verbose bool) int {
 	return 0
 }
 
-// Child is part of the Operator interface.
+// Child is part of the execinfra.OpNode interface.
 func (c *Columnarizer) Child(nth int, verbose bool) execinfra.OpNode {
 	if nth == 0 {
 		if n, ok := c.input.(execinfra.OpNode); ok {

--- a/pkg/sql/colexec/columnarizer_test.go
+++ b/pkg/sql/colexec/columnarizer_test.go
@@ -109,7 +109,7 @@ func TestColumnarizerDrainsAndClosesInput(t *testing.T) {
 
 			if tc.consumerClosed {
 				// Closing the Columnarizer should call ConsumerClosed on the processor.
-				require.NoError(t, c.Close(ctx))
+				require.NoError(t, c.Close())
 				require.Equal(t, execinfra.ConsumerClosed, rb.ConsumerStatus, "unexpected consumer status %d", rb.ConsumerStatus)
 			} else {
 				// Calling DrainMeta from the vectorized execution engine should propagate to

--- a/pkg/sql/colexec/disk_spiller.go
+++ b/pkg/sql/colexec/disk_spiller.go
@@ -234,16 +234,16 @@ func (d *diskSpillerBase) Reset(ctx context.Context) {
 }
 
 // Close implements the Closer interface.
-func (d *diskSpillerBase) Close(ctx context.Context) error {
+func (d *diskSpillerBase) Close() error {
 	if !d.CloserHelper.Close() {
 		return nil
 	}
 	var retErr error
 	if c, ok := d.inMemoryOp.(colexecop.Closer); ok {
-		retErr = c.Close(ctx)
+		retErr = c.Close()
 	}
 	if c, ok := d.diskBackedOp.(colexecop.Closer); ok {
-		if err := c.Close(ctx); err != nil {
+		if err := c.Close(); err != nil {
 			retErr = err
 		}
 	}

--- a/pkg/sql/colexec/external_sort_test.go
+++ b/pkg/sql/colexec/external_sort_test.go
@@ -307,7 +307,7 @@ func TestExternalSortMemoryAccounting(t *testing.T) {
 	for b := sorter.Next(); b.Length() > 0; b = sorter.Next() {
 	}
 	for _, c := range closers {
-		require.NoError(t, c.Close(ctx))
+		require.NoError(t, c.Close())
 	}
 
 	require.True(t, spilled)

--- a/pkg/sql/colexec/hash_aggregator.go
+++ b/pkg/sql/colexec/hash_aggregator.go
@@ -539,15 +539,15 @@ func (op *hashAggregator) Reset(ctx context.Context) {
 	op.state = hashAggregatorBuffering
 }
 
-func (op *hashAggregator) Close(ctx context.Context) error {
+func (op *hashAggregator) Close() error {
 	if !op.CloserHelper.Close() {
 		return nil
 	}
 	var retErr error
 	if op.inputTrackingState.tuples != nil {
-		retErr = op.inputTrackingState.tuples.Close(ctx)
+		retErr = op.inputTrackingState.tuples.Close(op.EnsureCtx())
 	}
-	if err := op.toClose.Close(ctx); err != nil {
+	if err := op.toClose.Close(); err != nil {
 		retErr = err
 	}
 	return retErr

--- a/pkg/sql/colexec/hash_based_partitioner.go
+++ b/pkg/sql/colexec/hash_based_partitioner.go
@@ -620,7 +620,7 @@ StateChanged:
 			return b
 
 		case hbpFinished:
-			if err := op.Close(op.Ctx); err != nil {
+			if err := op.Close(); err != nil {
 				colexecerror.InternalError(err)
 			}
 			return coldata.ZeroBatch
@@ -631,10 +631,11 @@ StateChanged:
 	}
 }
 
-func (op *hashBasedPartitioner) Close(ctx context.Context) error {
+func (op *hashBasedPartitioner) Close() error {
 	if !op.CloserHelper.Close() {
 		return nil
 	}
+	ctx := op.EnsureCtx()
 	log.VEventf(ctx, 1, "%s is closed", op.name)
 	var retErr error
 	for i := range op.inputs {
@@ -645,7 +646,7 @@ func (op *hashBasedPartitioner) Close(ctx context.Context) error {
 	// The in-memory main operator might be a Closer (e.g. the in-memory hash
 	// aggregator), and we need to close it if so.
 	if c, ok := op.inMemMainOp.(colexecop.Closer); ok {
-		if err := c.Close(ctx); err != nil {
+		if err := c.Close(); err != nil {
 			retErr = err
 		}
 	}
@@ -653,7 +654,7 @@ func (op *hashBasedPartitioner) Close(ctx context.Context) error {
 	// it will still be closed appropriately because we accumulate all closers
 	// in NewColOperatorResult.
 	if c, ok := op.diskBackedFallbackOp.(colexecop.Closer); ok {
-		if err := c.Close(ctx); err != nil {
+		if err := c.Close(); err != nil {
 			retErr = err
 		}
 	}

--- a/pkg/sql/colexec/invariants_checker.go
+++ b/pkg/sql/colexec/invariants_checker.go
@@ -112,10 +112,10 @@ func (i *InvariantsChecker) DrainMeta() []execinfrapb.ProducerMetadata {
 }
 
 // Close is part of the colexecop.ClosableOperator interface.
-func (i *InvariantsChecker) Close(ctx context.Context) error {
+func (i *InvariantsChecker) Close() error {
 	c, ok := i.Input.(colexecop.Closer)
 	if !ok {
 		return nil
 	}
-	return c.Close(ctx)
+	return c.Close()
 }

--- a/pkg/sql/colexec/ordered_aggregator.go
+++ b/pkg/sql/colexec/ordered_aggregator.go
@@ -418,6 +418,6 @@ func (a *orderedAggregator) Reset(ctx context.Context) {
 	}
 }
 
-func (a *orderedAggregator) Close(ctx context.Context) error {
-	return a.toClose.Close(ctx)
+func (a *orderedAggregator) Close() error {
+	return a.toClose.Close()
 }

--- a/pkg/sql/colexec/ordered_synchronizer.eg.go
+++ b/pkg/sql/colexec/ordered_synchronizer.eg.go
@@ -405,9 +405,9 @@ func (o *OrderedSynchronizer) DrainMeta() []execinfrapb.ProducerMetadata {
 	return bufferedMeta
 }
 
-func (o *OrderedSynchronizer) Close(ctx context.Context) error {
+func (o *OrderedSynchronizer) Close() error {
 	for _, input := range o.inputs {
-		input.ToClose.CloseAndLogOnErr(ctx, "ordered synchronizer")
+		input.ToClose.CloseAndLogOnErr(o.EnsureCtx(), "ordered synchronizer")
 	}
 	if o.span != nil {
 		o.span.Finish()

--- a/pkg/sql/colexec/ordered_synchronizer_tmpl.go
+++ b/pkg/sql/colexec/ordered_synchronizer_tmpl.go
@@ -280,9 +280,9 @@ func (o *OrderedSynchronizer) DrainMeta() []execinfrapb.ProducerMetadata {
 	return bufferedMeta
 }
 
-func (o *OrderedSynchronizer) Close(ctx context.Context) error {
+func (o *OrderedSynchronizer) Close() error {
 	for _, input := range o.inputs {
-		input.ToClose.CloseAndLogOnErr(ctx, "ordered synchronizer")
+		input.ToClose.CloseAndLogOnErr(o.EnsureCtx(), "ordered synchronizer")
 	}
 	if o.span != nil {
 		o.span.Finish()

--- a/pkg/sql/colexec/parallel_unordered_synchronizer.go
+++ b/pkg/sql/colexec/parallel_unordered_synchronizer.go
@@ -420,7 +420,7 @@ func (s *ParallelUnorderedSynchronizer) DrainMeta() []execinfrapb.ProducerMetada
 }
 
 // Close is part of the colexecop.ClosableOperator interface.
-func (s *ParallelUnorderedSynchronizer) Close(context.Context) error {
+func (s *ParallelUnorderedSynchronizer) Close() error {
 	if state := s.getState(); state != parallelUnorderedSynchronizerStateUninitialized {
 		// Input goroutines have been started and will take care of closing the
 		// closers from the corresponding input trees, so we don't need to do
@@ -438,7 +438,7 @@ func (s *ParallelUnorderedSynchronizer) Close(context.Context) error {
 	// so it is safe to close all closers from this goroutine.
 	var lastErr error
 	for _, input := range s.inputs {
-		if err := input.ToClose.Close(s.Ctx); err != nil {
+		if err := input.ToClose.Close(); err != nil {
 			lastErr = err
 		}
 	}

--- a/pkg/sql/colexec/parallel_unordered_synchronizer_test.go
+++ b/pkg/sql/colexec/parallel_unordered_synchronizer_test.go
@@ -212,7 +212,7 @@ func TestParallelUnorderedSyncClosesInputs(t *testing.T) {
 	// closure occurred as expected.
 	closed := false
 	firstInput := &colexecop.CallbackOperator{
-		CloseCb: func(context.Context) error {
+		CloseCb: func() error {
 			closed = true
 			return nil
 		},
@@ -237,7 +237,7 @@ func TestParallelUnorderedSyncClosesInputs(t *testing.T) {
 	// In the production setting, the user of the synchronizer is still expected
 	// to close it, even if a panic is encountered in Init, so we do the same
 	// thing here and verify that the first input is properly closed.
-	require.NoError(t, s.Close(ctx))
+	require.NoError(t, s.Close())
 	require.True(t, closed)
 }
 

--- a/pkg/sql/colexec/serial_unordered_synchronizer.go
+++ b/pkg/sql/colexec/serial_unordered_synchronizer.go
@@ -106,10 +106,10 @@ func (s *SerialUnorderedSynchronizer) DrainMeta() []execinfrapb.ProducerMetadata
 	return bufferedMeta
 }
 
-// Close is part of the Closer interface.
-func (s *SerialUnorderedSynchronizer) Close(ctx context.Context) error {
+// Close is part of the colexecop.ClosableOperator interface.
+func (s *SerialUnorderedSynchronizer) Close() error {
 	for _, input := range s.inputs {
-		input.ToClose.CloseAndLogOnErr(ctx, "serial unordered synchronizer")
+		input.ToClose.CloseAndLogOnErr(s.EnsureCtx(), "serial unordered synchronizer")
 	}
 	if s.span != nil {
 		s.span.Finish()

--- a/pkg/sql/colexecop/operator.go
+++ b/pkg/sql/colexecop/operator.go
@@ -31,12 +31,11 @@ type Operator interface {
 	//
 	// Canceling the provided context results in forceful termination of
 	// execution. The operators are expected to hold onto the provided context
-	// (and derive a new one if needed) that is then used for Next() calls.
+	// (and derive a new one if needed) that is then used for Next(),
+	// DrainMeta(), and Close() calls (when applicable).
 	//
 	// It might panic with an expected error, so there must be a "root"
 	// component that will catch that panic.
-	// TODO(yuzefovich): use the stored context for DrainMeta calls (when
-	// applicable) too.
 	Init(ctx context.Context)
 
 	// Next returns the next Batch from this operator. Once the operator is
@@ -138,11 +137,11 @@ type BufferingInMemoryOperator interface {
 // if we have a simple project on top of a disk-backed operator, that simple
 // project needs to implement this interface so that Close() call could be
 // propagated correctly).
-// TODO(yuzefovich): clarify the contract that Close must be safe to call even
-// if the Operator - when it implements the Closer interface - hasn't been
-// initialized.
 type Closer interface {
-	Close(ctx context.Context) error
+	// Close releases the resources associated with this Closer. If this Closer
+	// is an Operator, the implementation of Close must be safe to execute even
+	// if Operator.Init wasn't called.
+	Close() error
 }
 
 // Closers is a slice of Closers.
@@ -155,17 +154,17 @@ type Closers []Closer
 func (c Closers) CloseAndLogOnErr(ctx context.Context, prefix string) {
 	prefix += ":"
 	for _, closer := range c {
-		if err := closer.Close(ctx); err != nil && log.V(1) {
+		if err := closer.Close(); err != nil && log.V(1) {
 			log.Infof(ctx, "%s error closing Closer: %v", prefix, err)
 		}
 	}
 }
 
 // Close closes all Closers and returns the last error (if any occurs).
-func (c Closers) Close(ctx context.Context) error {
+func (c Closers) Close() error {
 	var lastErr error
 	for _, closer := range c {
-		if err := closer.Close(ctx); err != nil {
+		if err := closer.Close(); err != nil {
 			lastErr = err
 		}
 	}
@@ -225,6 +224,8 @@ type NonExplainable interface {
 type InitHelper struct {
 	// Ctx is the context passed on the first call to Init(). If it is nil, then
 	// Init() hasn't been called yet.
+	// NOTE: if a non-nil context is needed, use EnsureCtx() to retrieve it
+	// instead of accessing this field directly.
 	Ctx context.Context
 }
 
@@ -239,6 +240,15 @@ func (h *InitHelper) Init(ctx context.Context) bool {
 	}
 	h.Ctx = ctx
 	return true
+}
+
+// EnsureCtx returns the context which this helper was initialized with or the
+// background context if Init hasn't been called.
+func (h *InitHelper) EnsureCtx() context.Context {
+	if h.Ctx == nil {
+		return context.Background()
+	}
+	return h.Ctx
 }
 
 // MakeOneInputHelper returns a new OneInputHelper.
@@ -286,6 +296,8 @@ func (c *CloserHelper) Reset() {
 }
 
 // ClosableOperator is an Operator that needs to be Close()'d.
+// NOTE: even if the Operator wasn't Init()'ed properly, it must still be safe
+// to Close().
 type ClosableOperator interface {
 	Operator
 	Closer
@@ -308,12 +320,12 @@ type OneInputCloserHelper struct {
 var _ Closer = &OneInputCloserHelper{}
 
 // Close implements the Closer interface.
-func (c *OneInputCloserHelper) Close(ctx context.Context) error {
+func (c *OneInputCloserHelper) Close() error {
 	if !c.CloserHelper.Close() {
 		return nil
 	}
 	if closer, ok := c.Input.(Closer); ok {
-		return closer.Close(ctx)
+		return closer.Close()
 	}
 	return nil
 }

--- a/pkg/sql/colexecop/testutils.go
+++ b/pkg/sql/colexecop/testutils.go
@@ -143,7 +143,7 @@ type CallbackOperator struct {
 	ZeroInputNode
 	InitCb  func(context.Context)
 	NextCb  func() coldata.Batch
-	CloseCb func(context.Context) error
+	CloseCb func() error
 }
 
 var _ ClosableOperator = &CallbackOperator{}
@@ -165,11 +165,11 @@ func (o *CallbackOperator) Next() coldata.Batch {
 }
 
 // Close is part of the ClosableOperator interface.
-func (o *CallbackOperator) Close(ctx context.Context) error {
+func (o *CallbackOperator) Close() error {
 	if o.CloseCb == nil {
 		return nil
 	}
-	return o.CloseCb(ctx)
+	return o.CloseCb()
 }
 
 // TestingSemaphore is a semaphore.Semaphore that never blocks and is always

--- a/pkg/sql/colfetcher/colbatch_scan.go
+++ b/pkg/sql/colfetcher/colbatch_scan.go
@@ -299,7 +299,7 @@ func (s *ColBatchScan) Release() {
 }
 
 // Close implements the colexecop.Closer interface.
-func (s *ColBatchScan) Close(context.Context) error {
+func (s *ColBatchScan) Close() error {
 	if s.tracingSpan != nil {
 		s.tracingSpan.Finish()
 		s.tracingSpan = nil

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -1023,14 +1023,14 @@ func (s *vectorizedFlowCreator) setupOutput(
 // callbackCloser is a utility struct that implements the Closer interface by
 // calling the provided callback.
 type callbackCloser struct {
-	closeCb func(context.Context) error
+	closeCb func() error
 }
 
 var _ colexecop.Closer = &callbackCloser{}
 
 // Close implements the Closer interface.
-func (c *callbackCloser) Close(ctx context.Context) error {
-	return c.closeCb(ctx)
+func (c *callbackCloser) Close() error {
+	return c.closeCb()
 }
 
 func (s *vectorizedFlowCreator) setupFlow(
@@ -1120,12 +1120,12 @@ func (s *vectorizedFlowCreator) setupFlow(
 				for i := range toCloseCopy {
 					func(idx int) {
 						closed := false
-						result.ToClose[idx] = &callbackCloser{closeCb: func(ctx context.Context) error {
+						result.ToClose[idx] = &callbackCloser{closeCb: func() error {
 							if !closed {
 								closed = true
 								atomic.AddInt32(&s.numClosed, 1)
 							}
-							return toCloseCopy[idx].Close(ctx)
+							return toCloseCopy[idx].Close()
 						}}
 					}(i)
 				}

--- a/pkg/sql/colflow/vectorized_flow_shutdown_test.go
+++ b/pkg/sql/colflow/vectorized_flow_shutdown_test.go
@@ -60,7 +60,9 @@ type callbackCloser struct {
 	closeCb func() error
 }
 
-func (c callbackCloser) Close(_ context.Context) error {
+var _ colexecop.Closer = callbackCloser{}
+
+func (c callbackCloser) Close() error {
 	return c.closeCb()
 }
 


### PR DESCRIPTION
This commit clarifies `ClosableOperator` interface that the
implementations of `Close` must work even if `Init` hasn't been called.

Additionally, the context argument is now removed from `Close` method
and the operators are expected to reuse the one they got in `Init`. If
that is not called, then the background context is used.

Fixes: #65156.

Release note: None