### PR TITLE
sql: fix keyword bug in ALTER DATABASE ... SET OWNER ...

### DIFF
--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -27,7 +27,7 @@ type alterDatabaseOwnerNode struct {
 func (p *planner) AlterDatabaseOwner(
 	ctx context.Context, n *tree.AlterDatabaseOwner,
 ) (planNode, error) {
-	dbDesc, err := p.ResolveMutableDatabaseDescriptor(ctx, n.Name.String(), true)
+	dbDesc, err := p.ResolveMutableDatabaseDescriptor(ctx, string(n.Name), true)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/logictest/testdata/logic_test/alter_database_owner
+++ b/pkg/sql/logictest/testdata/logic_test/alter_database_owner
@@ -74,3 +74,10 @@ query T
 SELECT r.rolname FROM pg_database d JOIN pg_roles r ON d.datdba = r.oid WHERE d.datname = 'd';
 ----
 b
+
+user root
+
+# Regression test for #62012
+statement ok
+CREATE DATABASE "order";
+ALTER DATABASE "order" OWNER TO testuser


### PR DESCRIPTION
Release note (bug fix): Fixed a bug where ALTER DATABASE ... SET OWNER
... did not work if the database name was a keyword.

Resolves #62012