### PR TITLE
release-20.2: delegate: fix SHOW CREATE TABLE showing zone configs of other schemas

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -2659,6 +2659,7 @@ CREATE TABLE crdb_internal.zones (
   target           STRING,
   range_name       STRING,
   database_name    STRING,
+  schema_name          STRING,
   table_name       STRING,
   index_name       STRING,
   partition_name   STRING,

--- a/pkg/sql/delegate/show_table.go
+++ b/pkg/sql/delegate/show_table.go
@@ -27,6 +27,7 @@ func (d *delegator) delegateShowCreate(n *tree.ShowCreate) (tree.Statement, erro
       SELECT string_agg(raw_config_sql, e';\n') FROM crdb_internal.zones
       WHERE database_name = %[1]s
       AND table_name = %[2]s 
+			AND schema_name = %[5]s
       AND raw_config_yaml IS NOT NULL
       AND raw_config_sql IS NOT NULL
     )

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -242,10 +242,10 @@ SELECT * FROM crdb_internal.forward_dependencies WHERE descriptor_name = ''
 ----
 descriptor_id  descriptor_name  index_id  dependedonby_id  dependedonby_type  dependedonby_index_id  dependedonby_name  dependedonby_details
 
-query IITTTTTTTTTTT colnames
+query IITTTTTTTTTTTT colnames
 SELECT * FROM crdb_internal.zones WHERE false
 ----
-zone_id  subzone_id  target  range_name  database_name  table_name  index_name  partition_name
+zone_id  subzone_id  target  range_name  database_name  schema_name  table_name  index_name  partition_name
 raw_config_yaml  raw_config_sql  raw_config_protobuf full_config_yaml full_config_sql
 
 query ITTTTTTTTTTTTI colnames

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal_tenant
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal_tenant
@@ -251,10 +251,10 @@ SELECT * FROM crdb_internal.forward_dependencies WHERE descriptor_name = ''
 ----
 descriptor_id  descriptor_name  index_id  dependedonby_id  dependedonby_type  dependedonby_index_id  dependedonby_name  dependedonby_details
 
-query IITTTTTTTTTTT colnames
+query IITTTTTTTTTTTT colnames
 SELECT * FROM crdb_internal.zones WHERE false
 ----
-zone_id  subzone_id  target  range_name  database_name  table_name  index_name  partition_name
+zone_id  subzone_id  target  range_name  database_name  schema_name  table_name  index_name  partition_name
 raw_config_yaml  raw_config_sql  raw_config_protobuf full_config_yaml full_config_sql
 
 statement error not fully contained in tenant keyspace

--- a/pkg/sql/logictest/testdata/logic_test/zone_config
+++ b/pkg/sql/logictest/testdata/logic_test/zone_config
@@ -173,9 +173,7 @@ ALTER TABLE test.public.a CONFIGURE ZONE USING
   gc.ttlseconds = 3600,
   num_replicas = 1,
   constraints = '[+region=test]',
-  lease_preferences = '[[+region=test]]';
-ALTER TABLE test.test.a CONFIGURE ZONE USING
-  gc.ttlseconds = 1234
+  lease_preferences = '[[+region=test]]'
 
 # Check that we can reset the configuration to defaults.
 
@@ -214,3 +212,29 @@ ORDER BY feature_name
 ----
 sql.schema.alter_range.configure_zone
 sql.schema.alter_table.configure_zone
+
+# Test tables in different schemas do not show the zone configs
+# of the other.
+
+statement ok
+CREATE TABLE same_table_name();
+ALTER TABLE same_table_name CONFIGURE ZONE USING gc.ttlseconds = 500;
+CREATE SCHEMA alternative_schema;
+CREATE TABLE alternative_schema.same_table_name();
+ALTER TABLE alternative_schema.same_table_name CONFIGURE ZONE USING gc.ttlseconds = 600
+
+query TT
+SHOW CREATE TABLE same_table_name
+----
+same_table_name  CREATE TABLE public.same_table_name (FAMILY "primary" (rowid)
+);
+ALTER TABLE test.public.same_table_name CONFIGURE ZONE USING
+  gc.ttlseconds = 500
+
+query TT
+SHOW CREATE TABLE alternative_schema.same_table_name
+----
+alternative_schema.same_table_name  CREATE TABLE alternative_schema.same_table_name (FAMILY "primary" (rowid)
+);
+ALTER TABLE test.alternative_schema.same_table_name CONFIGURE ZONE USING
+  gc.ttlseconds = 600

--- a/pkg/sql/show_zone_config.go
+++ b/pkg/sql/show_zone_config.go
@@ -35,6 +35,7 @@ var showZoneConfigColumns = colinfo.ResultColumns{
 	{Name: "target", Typ: types.String},
 	{Name: "range_name", Typ: types.String, Hidden: true},
 	{Name: "database_name", Typ: types.String, Hidden: true},
+	{Name: "schema_name", Typ: types.String, Hidden: true},
 	{Name: "table_name", Typ: types.String, Hidden: true},
 	{Name: "index_name", Typ: types.String, Hidden: true},
 	{Name: "partition_name", Typ: types.String, Hidden: true},
@@ -52,6 +53,7 @@ const (
 	targetCol
 	rangeNameCol
 	databaseNameCol
+	schemaNameCol
 	tableNameCol
 	indexNameCol
 	partitionNameCol
@@ -244,6 +246,7 @@ func generateZoneConfigIntrospectionValues(
 	values[targetCol] = tree.DNull
 	values[rangeNameCol] = tree.DNull
 	values[databaseNameCol] = tree.DNull
+	values[schemaNameCol] = tree.DNull
 	values[tableNameCol] = tree.DNull
 	values[indexNameCol] = tree.DNull
 	values[partitionNameCol] = tree.DNull
@@ -257,6 +260,7 @@ func generateZoneConfigIntrospectionValues(
 		}
 		if zs.TableOrIndex.Table.ObjectName != "" {
 			values[databaseNameCol] = tree.NewDString(string(zs.TableOrIndex.Table.CatalogName))
+			values[schemaNameCol] = tree.NewDString(string(zs.TableOrIndex.Table.SchemaName))
 			values[tableNameCol] = tree.NewDString(string(zs.TableOrIndex.Table.ObjectName))
 		}
 		if zs.TableOrIndex.Index != "" {


### PR DESCRIPTION
Backport 1/1 commits from #65178.

/cc @cockroachdb/release

---

Release note (bug fix): Fixed a bug where SHOW CREATE TABLE would show
the zone configs of a table of the same name from a different schema.
