### PR TITLE
builtins: mark ST_GeomFromGeoJSON(string) as preferred

### DIFF
--- a/pkg/sql/sem/tree/type_check_test.go
+++ b/pkg/sql/sem/tree/type_check_test.go
@@ -200,6 +200,9 @@ func TestTypeCheck(t *testing.T) {
 		{`(('{' || 'a' ||'}')::STRING[])[1]::STRING`, `((('{':::STRING || 'a':::STRING) || '}':::STRING)::STRING[])[1:::INT8]`},
 		{`(('{' || '1' ||'}')::INT[])[1]`, `((('{':::STRING || '1':::STRING) || '}':::STRING)::INT8[])[1:::INT8]`},
 		{`(ARRAY[1, 2, 3]::int[])[2]`, `(ARRAY[1:::INT8, 2:::INT8, 3:::INT8]:::INT8[])[2:::INT8]`},
+
+		// String preference.
+		{`st_geomfromgeojson($1)`, `st_geomfromgeojson($1:::STRING):::GEOMETRY`},
 	}
 	ctx := context.Background()
 	for _, d := range testData {


### PR DESCRIPTION
This best imitates the PostgreSQL ambiguous type resolution in that it
always prefers strings.

Resolves https://github.com/cockroachdb/sequelize-cockroachdb/issues/52

Release note (sql change): Mark ST_GeomFromGeoJSON(string) as the
preferred overload, meaning it will resolve correctly in more contexts.