### PR TITLE
release-21.1: storage: discard memory in pebbleMVCCScanner before putting in pool

### DIFF
--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -866,7 +866,7 @@ func mvccGet(
 	}
 
 	mvccScanner := pebbleMVCCScannerPool.Get().(*pebbleMVCCScanner)
-	defer pebbleMVCCScannerPool.Put(mvccScanner)
+	defer mvccScanner.release()
 
 	// MVCCGet is implemented as an MVCCScan where we retrieve a single key. We
 	// specify an empty key for the end key which will ensure we don't retrieve a
@@ -2362,7 +2362,7 @@ func mvccScanToBytes(
 	}
 
 	mvccScanner := pebbleMVCCScannerPool.Get().(*pebbleMVCCScanner)
-	defer pebbleMVCCScannerPool.Put(mvccScanner)
+	defer mvccScanner.release()
 
 	*mvccScanner = pebbleMVCCScanner{
 		parent:           iter,

--- a/pkg/storage/pebble_mvcc_scanner.go
+++ b/pkg/storage/pebble_mvcc_scanner.go
@@ -159,6 +159,14 @@ var pebbleMVCCScannerPool = sync.Pool{
 	},
 }
 
+func (p *pebbleMVCCScanner) release() {
+	// Discard most memory references before placing in pool.
+	*p = pebbleMVCCScanner{
+		keyBuf: p.keyBuf,
+	}
+	pebbleMVCCScannerPool.Put(p)
+}
+
 // init sets bounds on the underlying pebble iterator, and initializes other
 // fields not set by the calling method.
 func (p *pebbleMVCCScanner) init(txn *roachpb.Transaction, localUncertaintyLimit hlc.Timestamp) {


### PR DESCRIPTION
Backport 1/1 commits from #64946.

/cc @cockroachdb/release

---

Previously we would clear fields that can consume significant
memory, like pebbleResults, after getting from the pool. Now this
is done before the put, so that we don't retain memory
unnecessarily.

Informs #64906

Release note: None
