### PR TITLE
sem/tree: remove redundant allocation when pg-encoding chars

### DIFF
--- a/pkg/sql/sem/tree/pgwire_encode.go
+++ b/pkg/sql/sem/tree/pgwire_encode.go
@@ -22,9 +22,9 @@ import (
 // ResolveBlankPaddedChar pads the given string with spaces if blank padding is
 // required or returns the string unmodified otherwise.
 func ResolveBlankPaddedChar(s string, t *types.T) string {
-	if t.Oid() == oid.T_bpchar {
-		// Pad spaces on the right of the string to make it of length specified in
-		// the type t.
+	if t.Oid() == oid.T_bpchar && len(s) < int(t.Width()) {
+		// Pad spaces on the right of the string to make it of length specified
+		// in the type t.
 		return fmt.Sprintf("%-*v", t.Width(), s)
 	}
 	return s


### PR DESCRIPTION
In order to handle chars of the specified width previously we would
always allocate a new string. This is not needed if the given string
already satisfies the width requirement, so this commit removes that
allocation.

Release note: None