### PR TITLE
changefeedccl: allow user to configure kafka server version

### DIFF
--- a/pkg/ccl/changefeedccl/sink_kafka.go
+++ b/pkg/ccl/changefeedccl/sink_kafka.go
@@ -108,9 +108,11 @@ type saramaConfig struct {
 		Frequency   jsonDuration `json:",omitempty"`
 		MaxMessages int          `json:",omitempty"`
 	}
+
+	Version string `json:",omitempty"`
 }
 
-var defaultSaramaConfig = func() *saramaConfig {
+func defaultSaramaConfig() *saramaConfig {
 	config := &saramaConfig{}
 
 	// When we emit messages to sarama, they're placed in a queue (as does any
@@ -149,7 +151,7 @@ var defaultSaramaConfig = func() *saramaConfig {
 	config.Flush.Frequency = jsonDuration(time.Hour)
 
 	return config
-}()
+}
 
 func (s *kafkaSink) start() {
 	s.stopWorkerCh = make(chan struct{})
@@ -424,19 +426,25 @@ func (j *jsonDuration) UnmarshalJSON(b []byte) error {
 }
 
 // Apply configures provided kafka configuration struct based on this config.
-func (c *saramaConfig) Apply(kafka *sarama.Config) {
+func (c *saramaConfig) Apply(kafka *sarama.Config) error {
 	kafka.Producer.Flush.Bytes = c.Flush.Bytes
 	kafka.Producer.Flush.Messages = c.Flush.Messages
 	kafka.Producer.Flush.Frequency = time.Duration(c.Flush.Frequency)
 	kafka.Producer.Flush.MaxMessages = c.Flush.MaxMessages
+	if c.Version != "" {
+		parsedVersion, err := sarama.ParseKafkaVersion(c.Version)
+		if err != nil {
+			return err
+		}
+		kafka.Version = parsedVersion
+	}
+	return nil
 }
 
 func getSaramaConfig(opts map[string]string) (config *saramaConfig, err error) {
+	config = defaultSaramaConfig()
 	if configStr, haveOverride := opts[changefeedbase.OptKafkaSinkConfig]; haveOverride {
-		config = &saramaConfig{}
 		err = json.Unmarshal([]byte(configStr), config)
-	} else {
-		config = defaultSaramaConfig
 	}
 	return
 }
@@ -608,7 +616,9 @@ func buildKafkaConfig(u sinkURL, opts map[string]string) (*sarama.Config, error)
 		return nil, errors.Wrapf(err,
 			"failed to parse sarama config; check %s option", changefeedbase.OptKafkaSinkConfig)
 	}
-	saramaCfg.Apply(config)
+	if err := saramaCfg.Apply(config); err != nil {
+		return nil, errors.Wrap(err, "failed to apply kafka client configuration")
+	}
 	return config, nil
 }
 

--- a/pkg/ccl/changefeedccl/sink_test.go
+++ b/pkg/ccl/changefeedccl/sink_test.go
@@ -493,19 +493,62 @@ func TestSaramaConfigOptionParsing(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	opts := make(map[string]string)
-	cfg, err := getSaramaConfig(opts)
-	require.NoError(t, err)
-	require.Equal(t, defaultSaramaConfig, cfg)
+	t.Run("defaults returned if not option set", func(t *testing.T) {
+		opts := make(map[string]string)
 
-	expected := &saramaConfig{}
-	expected.Flush.MaxMessages = 1000
-	expected.Flush.Frequency = jsonDuration(time.Second)
+		expected := defaultSaramaConfig()
 
-	opts[changefeedbase.OptKafkaSinkConfig] = `{"Flush": {"MaxMessages": 1000, "Frequency": "1s"}}`
-	cfg, err = getSaramaConfig(opts)
-	require.NoError(t, err)
-	require.Equal(t, expected, cfg)
+		cfg, err := getSaramaConfig(opts)
+		require.NoError(t, err)
+		require.Equal(t, expected, cfg)
+	})
+	t.Run("options overlay defaults", func(t *testing.T) {
+		opts := make(map[string]string)
+		opts[changefeedbase.OptKafkaSinkConfig] = `{"Flush": {"MaxMessages": 1000, "Frequency": "1s"}}`
+
+		expected := defaultSaramaConfig()
+		expected.Flush.MaxMessages = 1000
+		expected.Flush.Frequency = jsonDuration(time.Second)
+
+		cfg, err := getSaramaConfig(opts)
+		require.NoError(t, err)
+		require.Equal(t, expected, cfg)
+	})
+	t.Run("apply parses valid version", func(t *testing.T) {
+		opts := make(map[string]string)
+		opts[changefeedbase.OptKafkaSinkConfig] = `{"version": "0.8.2.0"}`
+
+		cfg, err := getSaramaConfig(opts)
+		require.NoError(t, err)
+
+		saramaCfg := &sarama.Config{}
+		err = cfg.Apply(saramaCfg)
+		require.NoError(t, err)
+		require.Equal(t, sarama.V0_8_2_0, saramaCfg.Version)
+	})
+	t.Run("apply allows for unset version", func(t *testing.T) {
+		opts := make(map[string]string)
+		opts[changefeedbase.OptKafkaSinkConfig] = `{}`
+
+		cfg, err := getSaramaConfig(opts)
+		require.NoError(t, err)
+
+		saramaCfg := &sarama.Config{}
+		err = cfg.Apply(saramaCfg)
+		require.NoError(t, err)
+		require.Equal(t, sarama.KafkaVersion{}, saramaCfg.Version)
+	})
+	t.Run("apply errors if version is invalid", func(t *testing.T) {
+		opts := make(map[string]string)
+		opts[changefeedbase.OptKafkaSinkConfig] = `{"version": "invalid"}`
+
+		cfg, err := getSaramaConfig(opts)
+		require.NoError(t, err)
+
+		saramaCfg := &sarama.Config{}
+		err = cfg.Apply(saramaCfg)
+		require.Error(t, err)
+	})
 }
 
 func TestKafkaSinkTracksMemory(t *testing.T) {


### PR DESCRIPTION
The upgrade to the sarama library in
facbd60f04fea1eb95787d6e453aa77ab314af5c included a change to the
default Version assumed by sarama from 0.8.2.0 to 1.0.0.

The result of this is that we no longer support Kafka < 1.0 (Confluent
Platform < 4.0) out of the box.

All of the impacted versions are EOL according to:

https://docs.confluent.io/platform/current/installation/versions-interoperability.html

However, it may be nice to allow users still on those versions to
continue to use changefeeds.

While we could reduce the Version constant back to its original value,
that comes at the cost of potentially making the Kafka server do more
work to handle the older protocol messages.

This change allows the user to set the version via the
kafka_sink_config option. For example, users who need to connect to
Confluent 3 would use this new option like so:

```
CREATE CHANGEFEED FOR target_table INTO 'kafka://localhost:9092' WITH kafka_sink_config='{"version": "0.8.2.0"}';
```

Release note (enterprise): `kafka_sink_config` now supports a
`version` configuration item to specify Kafka server versions. This is
likely only necessary for old (Kafka 0.11/Confluent 3.3 or early)
Kafka servers. Further, unspecified items in `kafka_sink_config` now
retain their default values.