### PR TITLE
release-21.1: opt: support SplitScanIntoUnionScans for exclusive constraint boundaries

### DIFF
--- a/pkg/sql/opt/constraint/span_test.go
+++ b/pkg/sql/opt/constraint/span_test.go
@@ -835,6 +835,28 @@ func TestSpan_KeyCount(t *testing.T) {
 			},
 			expected: "3",
 		},
+		{ // 19
+			// Allow exclusive boundaries if the key is longer than the prefix.
+			keyCtx:   kcAscAsc,
+			length:   1,
+			span:     ParseSpan(&evalCtx, "(/US_WEST/post - /US_WEST]"),
+			expected: "1",
+		},
+		{ // 20
+			// Allow exclusive boundaries if the key is longer than the prefix.
+			keyCtx:   kcAscAsc,
+			length:   1,
+			span:     ParseSpan(&evalCtx, "[/1 - /2/fix)"),
+			expected: "2",
+		},
+		{ // 21
+			// Fails since the key is the same length as the prefix and the boundary
+			// is exclusive.
+			keyCtx:   kcAscAsc,
+			length:   1,
+			span:     ParseSpan(&evalCtx, "(/US_WEST - /US_WEST/fix]"),
+			expected: "FAIL",
+		},
 	}
 
 	for i, tc := range testCases {
@@ -989,6 +1011,28 @@ func TestSpan_SplitSpan(t *testing.T) {
 				endBoundary:   IncludeBoundary,
 			},
 			expected: "[/'hello' - /'hello'] [/'hey' - /'hey'] [/'hi' - /'hi']",
+		},
+		{ // 15
+			// Allow exclusive boundaries if the key is longer than the prefix.
+			keyCtx:   kcAscAsc,
+			length:   1,
+			span:     ParseSpan(&evalCtx, "(/1/post - /2]"),
+			expected: "(/1/'post' - /1] [/2 - /2]",
+		},
+		{ // 16
+			// Allow exclusive boundaries if the key is longer than the prefix.
+			keyCtx:   kcAscAsc,
+			length:   1,
+			span:     ParseSpan(&evalCtx, "[/1 - /2/fix)"),
+			expected: "[/1 - /1] [/2 - /2/'fix')",
+		},
+		{ // 17
+			// Fails since the key is the same length as the prefix and the boundary
+			// is exclusive.
+			keyCtx:   kcAscAsc,
+			length:   1,
+			span:     ParseSpan(&evalCtx, "(/US_WEST - /US_WEST/fix]"),
+			expected: "FAIL",
 		},
 	}
 

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -1364,6 +1364,71 @@ limit
  │              └── fd: ()-->(11), (12)-->(13,14)
  └── 5
 
+# Span boundary is exclusive, but the rule applies since the key is longer than
+# the prefix.
+opt expect=SplitScanIntoUnionScans
+SELECT id, latitude, longitude FROM index_tab
+WHERE (latitude = 0 OR latitude = 10) AND longitude IS NOT NULL
+ORDER BY longitude LIMIT 10
+----
+limit
+ ├── columns: id:1!null latitude:4!null longitude:5!null
+ ├── internal-ordering: +5
+ ├── cardinality: [0 - 10]
+ ├── key: (1)
+ ├── fd: (1)-->(4,5)
+ ├── ordering: +5
+ ├── sort
+ │    ├── columns: id:1!null latitude:4!null longitude:5!null
+ │    ├── cardinality: [0 - 20]
+ │    ├── ordering: +5
+ │    ├── limit hint: 10.00
+ │    └── union-all
+ │         ├── columns: id:1!null latitude:4!null longitude:5!null
+ │         ├── left columns: id:11 latitude:14 longitude:15
+ │         ├── right columns: id:21 latitude:24 longitude:25
+ │         ├── cardinality: [0 - 20]
+ │         ├── scan index_tab@d
+ │         │    ├── columns: id:11!null latitude:14!null longitude:15!null
+ │         │    ├── constraint: /14/15/16/17/11: (/0/NULL - /0]
+ │         │    ├── limit: 10
+ │         │    ├── key: (11)
+ │         │    └── fd: ()-->(14), (11)-->(15)
+ │         └── scan index_tab@d
+ │              ├── columns: id:21!null latitude:24!null longitude:25!null
+ │              ├── constraint: /24/25/26/27/21: (/10/NULL - /10]
+ │              ├── limit: 10
+ │              ├── key: (21)
+ │              └── fd: ()-->(24), (21)-->(25)
+ └── 10
+
+# No-op case since span boundary is exclusive and the key length equals the
+# prefix length.
+opt expect-not=SplitScanIntoUnionScans
+SELECT id, latitude, longitude FROM index_tab
+WHERE latitude IS NOT NULL AND latitude < 4
+ORDER BY longitude LIMIT 10
+----
+limit
+ ├── columns: id:1!null latitude:4!null longitude:5
+ ├── internal-ordering: +5
+ ├── cardinality: [0 - 10]
+ ├── key: (1)
+ ├── fd: (1)-->(4,5)
+ ├── ordering: +5
+ ├── sort
+ │    ├── columns: id:1!null latitude:4!null longitude:5
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(4,5)
+ │    ├── ordering: +5
+ │    ├── limit hint: 10.00
+ │    └── scan index_tab@d
+ │         ├── columns: id:1!null latitude:4!null longitude:5
+ │         ├── constraint: /4/5/6/7/1: (/NULL - /3]
+ │         ├── key: (1)
+ │         └── fd: (1)-->(4,5)
+ └── 10
+
 # No-op case because the scan has an inverted index.
 opt expect-not=SplitScanIntoUnionScans
 SELECT geom FROM index_tab WHERE ST_Intersects('POINT(3.0 3.0)'::geometry, geom)


### PR DESCRIPTION
Backport 1/1 commits from #65350.

/cc @cockroachdb/release

---

This commit adds support for applying the `SplitScanIntoUnionScans`
rule in some cases if the constraint boundary is exclusive. For example,
prior to this commit, `SplitScanIntoUnionScans` did not apply for the following
query, even if an index was available on (x, y):
```
  SELECT x, y FROM tab
  WHERE (x = 0 OR x = 10) AND y IS NOT NULL
  ORDER BY y LIMIT 10
```
This was because the index constraint, `(/0/NULL - /0] (/10/NULL - /10]`, had an
exclusive boundary. This commit adds support for applying the rule in such
cases, as long as the prefix length is shorter than the key length. In this
case, the prefix length is 1 (for column x), and the key with the exclusive
boundary has length 2, so it is valid to apply `SplitScanIntoUnionScans`.

Release note (performance improvement): The optimizer can now avoid
full table scans for queries with a LIMIT and ORDER BY clause in some
additional cases where the ORDER BY columns are not a prefix of an index.
