### PR TITLE
jobs: don't check the number of deleted rows

### DIFF
--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -933,7 +933,7 @@ func (r *Registry) cleanupOldJobsPage(
 
 	log.VEventf(ctx, 2, "read potentially expired jobs: %d", numRows)
 	if len(toDelete.Array) > 0 {
-		log.Infof(ctx, "cleaning up expired job records: %d", len(toDelete.Array))
+		log.Infof(ctx, "attempting to clean up %d expired job records", len(toDelete.Array))
 		const stmt = `DELETE FROM system.jobs WHERE id = ANY($1)`
 		var nDeleted int
 		if nDeleted, err = r.ex.Exec(
@@ -941,10 +941,7 @@ func (r *Registry) cleanupOldJobsPage(
 		); err != nil {
 			return false, 0, errors.Wrap(err, "deleting old jobs")
 		}
-		if nDeleted != len(toDelete.Array) {
-			return false, 0, errors.AssertionFailedf("asked to delete %d rows but %d were actually deleted",
-				len(toDelete.Array), nDeleted)
-		}
+		log.Infof(ctx, "cleaned up %d expired job records", nDeleted)
 	}
 	// If we got as many rows as we asked for, there might be more.
 	morePages := numRows == pageSize


### PR DESCRIPTION
When attempting to delete expired job records it's entirely possible to
legitimately delete less records than expected. This can happen when
another node is concurrently attempting cleanup. Previously, we returned
an assertion failure in these cases.

Fixes #65048.

Release note: None