### PR TITLE
util/log,docs/generated: add missing table syntax

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -2066,7 +2066,7 @@ authentication failure.
 
 
 | Value | Textual alias in code or documentation | Description |
-|--|--|
+|--|--|--|
 | 0 | UNKNOWN | is reported when the reason is unknown. |
 | 1 | USER_RETRIEVAL_ERROR | occurs when there was an internal error accessing the principals. |
 | 2 | USER_NOT_FOUND | occurs when the principal is unknown. |

--- a/pkg/util/log/eventpb/gen.go
+++ b/pkg/util/log/eventpb/gen.go
@@ -604,7 +604,7 @@ Events in this category are logged to the ` + "`" + `{{.LogChannel}}` + "`" + ` 
 {{ .Comment }}
 
 | Value | Textual alias in code or documentation | Description |
-|--|--|
+|--|--|--|
 {{range .Values -}}
 | {{ .Value }} | {{ .Name }} | {{ .Comment | tableCell }} |
 {{end}}


### PR DESCRIPTION
Added missing table syntax that was preventing the Markdown table from rendering correctly in the [generated doc](https://cockroachlabs.com/docs/v21.1/eventlog.html).

Fixes https://github.com/cockroachdb/docs/issues/10600.