### PR TITLE
cloud: add new stanza to specify custom certs for Prometheus

### DIFF
--- a/cloud/kubernetes/prometheus/README.md
+++ b/cloud/kubernetes/prometheus/README.md
@@ -34,6 +34,9 @@ one another, we'd have two different prometheus jobs that had duplicated
 backends.
 * `kubectl label svc cockroachdb prometheus=cockroachdb`
 
+Check for the latest Prometheus Operator 
+[release version](https://github.com/prometheus-operator/prometheus-operator/blob/master/RELEASE.md). 
+Specify the version number in the below command.
 
 Install Prometheus Operator:
 * `kubectl apply -f

--- a/cloud/kubernetes/prometheus/README.md
+++ b/cloud/kubernetes/prometheus/README.md
@@ -37,7 +37,7 @@ backends.
 
 Install Prometheus Operator:
 * `kubectl apply -f
-https://raw.githubusercontent.com/coreos/prometheus-operator/release-0.20/bundle.yaml`
+https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.47.1/bundle.yaml`
 
 Ensure that the instance of prometheus-operator has started before
 continuing.  The `kubectl get` command and its desired output is below:

--- a/cloud/kubernetes/prometheus/prometheus.yaml
+++ b/cloud/kubernetes/prometheus/prometheus.yaml
@@ -60,11 +60,12 @@ spec:
   - port: http
     path: /_status/vars
     tlsConfig:
-      # The HTTPS certs are signed by the kubernetes internal
-      # certificate authority.
-      caFile: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
-      # This overrides the hostname verification check for the admin
-      # UI port to match our quickstart secure-mode cluster setup.
+      ca:
+        secret:
+          key: ca.crt
+          # This is the secret name used by the CockroachDB Kubernetes Operator.
+          # When using a custom CA, replace this with your secret name
+          name: cockroachdb-node
       serverName: "127.0.0.1"
 ---
 # Have prometheus-operator run a replicated Prometheus cluster


### PR DESCRIPTION
Add a stanza to the Prometheus manifest that allows the user to specify custom certs. The `cockroach-node` specifies the default node secret used by the K8s Operator, as advised by @chrisseto.

Relates to https://github.com/cockroachdb/cockroach-operator/issues/469.

A doc update to the Prometheus tutorial will refer to this change.