### PR TITLE
sql: deflake TestStatsWithLowTTL

### DIFF
--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -587,6 +587,13 @@ func (rf *Fetcher) StartScan(
 	return rf.StartScanFrom(ctx, &f)
 }
 
+// TestingInconsistentScanSleep introduces a sleep inside the fetcher after
+// every KV batch (for inconsistent scans, currently used only for table
+// statistics collection).
+// TODO(radu): consolidate with forceProductionKVBatchSize into a
+// FetcherTestingKnobs struct.
+var TestingInconsistentScanSleep time.Duration
+
 // StartInconsistentScan initializes and starts an inconsistent scan, where each
 // KV batch can be read at a different historical timestamp.
 //
@@ -645,6 +652,9 @@ func (rf *Fetcher) StartInconsistentScan(
 		res, err := txn.Send(ctx, ba)
 		if err != nil {
 			return nil, err.GoError()
+		}
+		if TestingInconsistentScanSleep != 0 {
+			time.Sleep(TestingInconsistentScanSleep)
 		}
 		return res, nil
 	}

--- a/pkg/sql/rowexec/sampler.go
+++ b/pkg/sql/rowexec/sampler.go
@@ -232,11 +232,6 @@ func (s *samplerProcessor) Run(ctx context.Context) {
 	s.MoveToDraining(nil /* err */)
 }
 
-// TestingSamplerSleep introduces a sleep inside the sampler, every
-// <samplerProgressInterval>. Used to simulate a heavily throttled
-// run for testing.
-var TestingSamplerSleep time.Duration
-
 func (s *samplerProcessor) mainLoop(ctx context.Context) (earlyExit bool, err error) {
 	rng, _ := randutil.NewPseudoRand()
 	var da rowenc.DatumAlloc
@@ -313,10 +308,6 @@ func (s *samplerProcessor) mainLoop(ctx context.Context) (earlyExit bool, err er
 					}
 				}
 				lastWakeupTime = timeutil.Now()
-			}
-
-			if TestingSamplerSleep != 0 {
-				time.Sleep(TestingSamplerSleep)
 			}
 		}
 


### PR DESCRIPTION
This test flakes in a way that could be explained by the processing of
one KV batch taking longer than 0.7s. To make the test more reliable,
we use a much smaller table and set the KV batch size to 1 and relax
the timings in the test to allow for slower operations.

Fixes #64922.

Release note: None