### PR TITLE
release-20.2: build: correct root path in build/release/teamcity-support.sh

### DIFF
--- a/build/release/teamcity-support.sh
+++ b/build/release/teamcity-support.sh
@@ -1,7 +1,7 @@
 # Common helpers for teamcity-*.sh scripts.
 
 # root is the absolute path to the root directory of the repository.
-root=$(cd "$(dirname "$0")/.." && pwd)
+root=$(cd "$(dirname "$0")/../.." && pwd)
 source "$root/build/teamcity-common-support.sh"
 
 remove_files_on_exit() {


### PR DESCRIPTION
The path to the root of the repo was off by one directory in the
build/release/teamcity-support.sh script. This commit corrects that.


Without this fix, [this error](https://teamcity.cockroachdb.com/buildConfiguration/Internal_Release_MakeAndPublishBuild/2992280?showLog=2992280_1636_1626.1636) happens in _Make and Publish Build_.

Release note: None