### PR TITLE
release-21.1: kvserver: disallow replica rebalancing to non-live nodes

### DIFF
--- a/pkg/kv/kvserver/allocator_scorer.go
+++ b/pkg/kv/kvserver/allocator_scorer.go
@@ -518,15 +518,23 @@ func rankedCandidateListForRemoval(
 	return candidates
 }
 
+// rebalanceOptions contains two candidate lists:
+//
+// 1. a ranked list of existing replicas ordered from best to worst -- i.e.
+// least qualified for rebalancing to most qualified (see `candidateList.best()`
+// and `candidateList.worst()`)
+// 2. a corresponding list of comparable stores that could be legal replacements
+// for the aforementioned existing replicas -- also ordered from `best()` to
+// `worst()`.
 type rebalanceOptions struct {
 	existingCandidates candidateList
 	candidates         candidateList
 }
 
-// rankedCandidateListForRebalancing creates two candidate lists. The first
-// contains all existing replica's stores, ordered from least qualified for
-// rebalancing to most qualified. The second list is of all potential stores
-// that could be used as rebalancing receivers, ordered from best to worst.
+// rankedCandidateListForRebalancing returns a list of `rebalanceOptions`, i.e.
+// groups of candidate stores and the existing replicas that they could legally
+// replace in the range. See comment above `rebalanceOptions()` for more
+// details.
 func rankedCandidateListForRebalancing(
 	ctx context.Context,
 	allStores StoreList,

--- a/pkg/kv/kvserver/allocator_scorer.go
+++ b/pkg/kv/kvserver/allocator_scorer.go
@@ -422,7 +422,13 @@ func rankedCandidateListForAllocation(
 			continue
 		}
 		if !isNodeValidForRoutineReplicaTransfer(ctx, s.Node.NodeID) {
-			log.VEventf(ctx, 3, "not considering non-ready node n%d for allocate", s.Node.NodeID)
+			log.VEventf(
+				ctx,
+				3,
+				"not considering store s%d as a potential rebalance candidate because it is on a non-live node n%d",
+				s.StoreID,
+				s.Node.NodeID,
+			)
 			continue
 		}
 		constraintsOK, necessary := constraintsCheck(s)
@@ -540,7 +546,7 @@ func rankedCandidateListForRebalancing(
 	allStores StoreList,
 	removalConstraintsChecker constraintsCheckFn,
 	rebalanceConstraintsChecker rebalanceConstraintsCheckFn,
-	existingReplicasForType, replicasWithExcludedStores []roachpb.ReplicaDescriptor,
+	existingReplicasForType, replicasOnExemptedStores []roachpb.ReplicaDescriptor,
 	existingStoreLocalities map[roachpb.StoreID]roachpb.Locality,
 	isNodeValidForRoutineReplicaTransfer func(context.Context, roachpb.NodeID) bool,
 	options scorerOptions,
@@ -551,10 +557,6 @@ func rankedCandidateListForRebalancing(
 	var needRebalanceFrom bool
 	curDiversityScore := rangeDiversityScore(existingStoreLocalities)
 	for _, store := range allStores.stores {
-		if !isNodeValidForRoutineReplicaTransfer(ctx, store.Node.NodeID) {
-			log.VEventf(ctx, 3, "not considering non-ready node n%d for rebalance", store.Node.NodeID)
-			continue
-		}
 		for _, repl := range existingReplicasForType {
 			if store.StoreID != repl.StoreID {
 				continue
@@ -627,10 +629,20 @@ func rankedCandidateListForRebalancing(
 		}
 		var comparableCands candidateList
 		for _, store := range allStores.stores {
-			// Ignore any stores that contain any of the replicas within
-			// `replicasWithExcludedStores`.
-			for _, excluded := range replicasWithExcludedStores {
-				if store.StoreID == excluded.StoreID {
+			// Ignore any stores on dead nodes or stores that contain any of the
+			// replicas within `replicasOnExemptedStores`.
+			if !isNodeValidForRoutineReplicaTransfer(ctx, store.Node.NodeID) {
+				log.VEventf(
+					ctx,
+					3,
+					"not considering store s%d as a potential rebalance candidate because it is on a non-live node n%d",
+					store.StoreID,
+					store.Node.NodeID,
+				)
+				continue
+			}
+			for _, replOnExemptedStore := range replicasOnExemptedStores {
+				if store.StoreID == replOnExemptedStore.StoreID {
 					continue
 				}
 			}


### PR DESCRIPTION
Backport 2/2 commits from #65312.

/cc @cockroachdb/release

---

The previously existing logic to prevent replica rebalances to dead nodes was
totally broken, and it was never caught because the accompanying unit test was
also broken.

The previous logic had an early return clause during the computation of
diversity stats for _existing replicas_ rather than during the computation of
stats for _potential candidates_. Additionally, the scenario that was
previously created by this unit test was never going to trigger a replica
rebalance, and the unit test would never actually execute any of its checks in
the face of an empty result set.

This commit fixes the check to actually prevent rebalancing to dead nodes and
also re-structures the test.

Noticed while working on #61883.

/cc @cockroachdb/kv

Release note (bug fix): Replica rebalancing could previously sometimes
rebalance to stores on dead nodes. This bug is now fixed.

