### PR TITLE
sql: allow cast from constant to regclass

### DIFF
--- a/pkg/sql/catalog/schemaexpr/BUILD.bazel
+++ b/pkg/sql/catalog/schemaexpr/BUILD.bazel
@@ -29,7 +29,6 @@ go_library(
         "//pkg/sql/types",
         "//pkg/util/errorutil/unimplemented",
         "@com_github_cockroachdb_errors//:errors",
-        "@com_github_lib_pq//oid",
     ],
 )
 

--- a/pkg/sql/catalog/schemaexpr/column.go
+++ b/pkg/sql/catalog/schemaexpr/column.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/lib/pq/oid"
 )
 
 // DequalifyColumnRefs returns a serialized expression with database and table
@@ -317,7 +316,7 @@ func GetSeqIDFromExpr(expr tree.Expr) (int64, bool) {
 	// a *tree.DOid (if type checked).
 	switch n := expr.(type) {
 	case *tree.AnnotateTypeExpr:
-		if typ, safe := tree.GetStaticallyKnownType(n.Type); !safe || typ.Oid() != oid.T_regclass {
+		if typ, safe := tree.GetStaticallyKnownType(n.Type); !safe || typ.Family() != types.OidFamily {
 			return 0, false
 		}
 		numVal, ok := n.Expr.(*tree.NumVal)

--- a/pkg/sql/logictest/testdata/logic_test/pgoidtype
+++ b/pkg/sql/logictest/testdata/logic_test/pgoidtype
@@ -486,3 +486,15 @@ query O
 SELECT (-1)::REGCLASS
 ----
 4294967295
+
+# Test that we can cast a constant directly to regclass.
+statement ok
+CREATE TABLE regression_62205(a INT PRIMARY KEY)
+
+let $regression_62205_oid
+SELECT 'regression_62205'::regclass::oid
+
+query O
+SELECT $regression_62205_oid::regclass
+----
+regression_62205

--- a/pkg/sql/logictest/testdata/logic_test/sequences_regclass
+++ b/pkg/sql/logictest/testdata/logic_test/sequences_regclass
@@ -20,7 +20,7 @@ statement ok
 CREATE TABLE foo (i SERIAL PRIMARY KEY)
 
 statement ok
-ALTER TABLE foo ADD COLUMN j INT NOT NULL DEFAULT nextval($test_seq_id::regclass)
+ALTER TABLE foo ADD COLUMN j INT NOT NULL DEFAULT nextval($test_seq_id)
 
 statement ok
 ALTER TABLE foo ADD COLUMN k SERIAL
@@ -106,7 +106,7 @@ CREATE SEQUENCE s2
 statement ok
 CREATE TABLE bar (
   i SERIAL PRIMARY KEY,
-  j INT NOT NULL DEFAULT currval($s1_id::regclass),
+  j INT NOT NULL DEFAULT currval($s1_id),
   k INT NOT NULL DEFAULT nextval('s2'),
   FAMILY (i, j, k))
 
@@ -169,7 +169,7 @@ CREATE SEQUENCE other_db.s2
 
 statement ok
 CREATE TABLE other_db.t (
-  i INT NOT NULL DEFAULT nextval($s_id::regclass),
+  i INT NOT NULL DEFAULT nextval($s_id),
   j INT NOT NULL DEFAULT currval('other_db.public.s2'),
   FAMILY (i, j))
 
@@ -227,7 +227,7 @@ CREATE SCHEMA test_schema
 statement ok
 CREATE TABLE tb (
   i SERIAL PRIMARY KEY,
-  j INT NOT NULL DEFAULT nextval($sc_s1_id::regclass),
+  j INT NOT NULL DEFAULT nextval($sc_s1_id),
   k INT NOT NULL DEFAULT currval('test.public.sc_s2'),
   FAMILY (i, j, k))
 
@@ -288,7 +288,7 @@ CREATE SEQUENCE s4
 statement ok
 CREATE TABLE foo (
   i SERIAL PRIMARY KEY,
-  j INT NOT NULL DEFAULT nextval($s3_id::regclass),
+  j INT NOT NULL DEFAULT nextval($s3_id),
   k INT NOT NULL DEFAULT currval('test.test_schema.s4'),
   FAMILY (i, j, k))
 
@@ -424,7 +424,7 @@ v2  CREATE VIEW public.v2 (currval) AS SELECT currval FROM (SELECT currval('publ
 
 # Union containing sequences.
 statement ok
-CREATE VIEW v3 AS SELECT nextval($view_seq_id::regclass), i FROM t3 UNION SELECT nextval('view_seq'), i FROM t4
+CREATE VIEW v3 AS SELECT nextval($view_seq_id), i FROM t3 UNION SELECT nextval('view_seq'), i FROM t4
 
 query TT
 SHOW CREATE VIEW v3
@@ -432,7 +432,7 @@ SHOW CREATE VIEW v3
 v3  CREATE VIEW public.v3 (nextval, i) AS SELECT nextval('public.view_seq'::REGCLASS), i FROM test.public.t3 UNION SELECT nextval('public.view_seq'::REGCLASS), i FROM test.public.t4
 
 statement ok
-CREATE VIEW v4 AS SELECT t3.i, nextval('view_seq') FROM t3 INNER JOIN (SELECT j, currval($view_seq_id::regclass) FROM t4) as t5 ON t3.i = t5.j
+CREATE VIEW v4 AS SELECT t3.i, nextval('view_seq') FROM t3 INNER JOIN (SELECT j, currval($view_seq_id) FROM t4) as t5 ON t3.i = t5.j
 
 # Join containing sequences.
 query TT
@@ -454,7 +454,7 @@ statement ok
 CREATE view v6 AS SELECT nextval('view_seq') AS i
 
 statement ok
-CREATE OR REPLACE VIEW v6 AS SELECT currval($view_seq_id::regclass) AS i
+CREATE OR REPLACE VIEW v6 AS SELECT currval($view_seq_id) AS i
 
 query TT
 SHOW CREATE VIEW v6
@@ -472,7 +472,7 @@ v7  CREATE VIEW public.v7 (i, nextval) AS (SELECT i, (SELECT nextval('public.vie
 
 # Sequence in the WHERE clause.
 statement ok
-CREATE VIEW v8 AS SELECT i FROM t3 WHERE i = nextval($view_seq_id::regclass)
+CREATE VIEW v8 AS SELECT i FROM t3 WHERE i = nextval($view_seq_id)
 
 query TT
 SHOW CREATE VIEW v8

--- a/pkg/sql/sem/tree/constant.go
+++ b/pkg/sql/sem/tree/constant.go
@@ -361,7 +361,6 @@ func (expr *NumVal) ResolveAsType(
 			return nil, err
 		}
 		oid := NewDOid(*d.(*DInt))
-		oid.semanticType = typ
 		return oid, nil
 	default:
 		return nil, errors.AssertionFailedf("could not resolve %T %v into a %T", expr, expr, typ)

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -464,7 +464,8 @@ func (expr *CastExpr) TypeCheck(
 			// is in its resolvable type set), we desire the cast's type for the
 			// Constant. In many cases, the CastExpr will then become a no-op and will
 			// be elided below. In other cases, the types may be equivalent but not
-			// Identical (e.g. string vs char(2)) and the CastExpr is still needed.
+			// Identical (e.g. string::char(2) or oid::regclass) and the CastExpr is
+			// still needed.
 			desired = exprType
 		}
 	case semaCtx.isUnresolvedPlaceholder(expr.Expr):

--- a/pkg/sql/show_create_clauses.go
+++ b/pkg/sql/show_create_clauses.go
@@ -107,7 +107,7 @@ func ShowCreateView(
 	}
 	f.WriteString(") AS ")
 
-	// Convert sequences referenced by ID in the view back to their names.
+	// Deserialize user-defined types in the view query.
 	typeReplacedViewQuery, err := formatViewQueryTypesForDisplay(ctx, semaCtx, desc)
 	if err != nil {
 		log.Warningf(ctx,
@@ -115,7 +115,7 @@ func ShowCreateView(
 			desc.GetName(), desc.GetID(), err)
 		f.WriteString(desc.GetViewQuery())
 	} else {
-		// Deserialize user-defined types in the view query.
+		// Convert sequences referenced by ID in the view back to their names.
 		sequenceReplacedViewQuery, err := formatViewQuerySequencesForDisplay(
 			ctx, semaCtx, typeReplacedViewQuery)
 		if err != nil {

--- a/pkg/util/sequence/sequence_test.go
+++ b/pkg/util/sequence/sequence_test.go
@@ -28,6 +28,8 @@ func TestGetSequenceFromFunc(t *testing.T) {
 		{`nextval('seq')`, &SeqIdentifier{SeqName: "seq"}},
 		{`nextval(123::REGCLASS)`, &SeqIdentifier{SeqID: 123}},
 		{`nextval(123)`, &SeqIdentifier{SeqID: 123}},
+		{`nextval(123::OID::REGCLASS)`, &SeqIdentifier{SeqID: 123}},
+		{`nextval(123::OID)`, &SeqIdentifier{SeqID: 123}},
 	}
 
 	ctx := context.Background()
@@ -127,7 +129,8 @@ func TestReplaceSequenceNamesWithIDs(t *testing.T) {
 	}{
 		{`nextval('seq')`, `nextval(123:::REGCLASS)`},
 		{`nextval('non_existent')`, `nextval('non_existent')`},
-		{`nextval(123::REGCLASS)`, `nextval(123)`},
+		{`nextval(123::REGCLASS)`, `nextval(123::REGCLASS)`},
+		{`nextval(123)`, `nextval(123)`},
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
fixes #62205 

Release note (sql change): A constant can now be cast to regclass
without first converting the constant to an OID. E.g., 52::regclass
can now be done instead of 52::oid::regclass.