### PR TITLE
cli: change exit codes from constant functions to consts

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -58,7 +58,7 @@ func Main() {
 	cmdName := commandName(cmd)
 
 	err := doMain(cmd, cmdName)
-	errCode := exit.Success()
+	errCode := exit.Success
 	if err != nil {
 		// Display the error and its details/hints.
 		cliOutputError(stderr, err, true /*showSeverity*/, false /*verbose*/)
@@ -68,7 +68,7 @@ func Main() {
 
 		// Finally, extract the error code, as optionally specified
 		// by the sub-command.
-		errCode = exit.UnspecifiedError()
+		errCode = exit.UnspecifiedError
 		var cliErr *cliError
 		if errors.As(err, &cliErr) {
 			errCode = cliErr.exitCode
@@ -256,7 +256,7 @@ func init() {
 		}
 		fmt.Fprintln(c.OutOrStderr()) // provide a line break between usage and error
 		return &cliError{
-			exitCode: exit.CommandLineFlagError(),
+			exitCode: exit.CommandLineFlagError,
 			cause:    err,
 		}
 	})

--- a/pkg/cli/doctor.go
+++ b/pkg/cli/doctor.go
@@ -146,7 +146,7 @@ func runDoctor(
 		if err == nil {
 			if !valid {
 				return &cliError{
-					exitCode: exit.DoctorValidationFailed(),
+					exitCode: exit.DoctorValidationFailed,
 					cause:    errors.New("validation failed"),
 				}
 			}
@@ -162,7 +162,7 @@ func runDoctor(
 		// Note: we are using "unspecified" here because the error
 		// return does not distinguish errors like connection errors
 		// etc, from errors during extraction.
-		exitCode: exit.UnspecifiedError(),
+		exitCode: exit.UnspecifiedError,
 		cause:    errors.Wrapf(err, "doctor command %q failed", commandName),
 	}
 }

--- a/pkg/cli/error_test.go
+++ b/pkg/cli/error_test.go
@@ -143,7 +143,7 @@ func TestErrorReporting(t *testing.T) {
 		{
 			desc: "single cliError",
 			err: &cliError{
-				exitCode: exit.UnspecifiedError(),
+				exitCode: exit.UnspecifiedError,
 				severity: severity.INFO,
 				cause:    errors.New("routine"),
 			},
@@ -153,10 +153,10 @@ func TestErrorReporting(t *testing.T) {
 		{
 			desc: "double cliError",
 			err: &cliError{
-				exitCode: exit.UnspecifiedError(),
+				exitCode: exit.UnspecifiedError,
 				severity: severity.INFO,
 				cause: &cliError{
-					exitCode: exit.UnspecifiedError(),
+					exitCode: exit.UnspecifiedError,
 					severity: severity.ERROR,
 					cause:    errors.New("serious"),
 				},
@@ -167,7 +167,7 @@ func TestErrorReporting(t *testing.T) {
 		{
 			desc: "wrapped cliError",
 			err: fmt.Errorf("some context: %w", &cliError{
-				exitCode: exit.UnspecifiedError(),
+				exitCode: exit.UnspecifiedError,
 				severity: severity.INFO,
 				cause:    errors.New("routine"),
 			}),

--- a/pkg/cli/exit/codes.go
+++ b/pkg/cli/exit/codes.go
@@ -10,60 +10,66 @@
 
 package exit
 
-// Codes that are common to all command times (server + client) follow.
+const (
+	//
+	// Codes that are common to all command times (server + client) follow.
+	//
 
-// Success (0) represents a normal process termination.
-func Success() Code { return Code{0} }
+	// Success represents a normal process termination.
+	Success Code = 0
 
-// UnspecifiedError (1) indicates the process has terminated with an
-// error condition. The specific cause of the error can be found in
-// the logging output.
-func UnspecifiedError() Code { return Code{1} }
+	// UnspecifiedError indicates the process has terminated with an
+	// error condition. The specific cause of the error can be found in
+	// the logging output.
+	UnspecifiedError = 1
 
-// UnspecifiedGoPanic (2) indicates the process has terminated due to
-// an uncaught Go panic or some other error in the Go runtime.
-//
-// The reporting of this exit code likely indicates a programming
-// error inside CockroachDB.
-//
-// Conversely, this should not be used when implementing features.
-func UnspecifiedGoPanic() Code { return Code{2} }
+	// UnspecifiedGoPanic indicates the process has terminated due to
+	// an uncaught Go panic or some other error in the Go runtime.
+	//
+	// The reporting of this exit code likely indicates a programming
+	// error inside CockroachDB.
+	//
+	// Conversely, this should not be used when implementing features.
+	UnspecifiedGoPanic = 2
 
-// Interrupted (3) indicates the server process was interrupted with
-// Ctrl+C / SIGINT.
-func Interrupted() Code { return Code{3} }
+	// Interrupted indicates the server process was interrupted with
+	// Ctrl+C / SIGINT.
+	Interrupted = 3
 
-// CommandLineFlagError (4) indicates there was an error in the
-// command-line parameters.
-func CommandLineFlagError() Code { return Code{4} }
+	// CommandLineFlagError indicates there was an error in the
+	// command-line parameters.
+	CommandLineFlagError = 4
 
-// LoggingStderrUnavailable (5) indicates that an error occurred
-// during a logging operation to the process' stderr stream.
-func LoggingStderrUnavailable() Code { return Code{5} }
+	// LoggingStderrUnavailable indicates that an error occurred
+	// during a logging operation to the process' stderr stream.
+	LoggingStderrUnavailable = 5
 
-// LoggingFileUnavailable (6) indicates that an error occurred
-// during a logging operation to a file.
-func LoggingFileUnavailable() Code { return Code{6} }
+	// LoggingFileUnavailable indicates that an error occurred
+	// during a logging operation to a file.
+	LoggingFileUnavailable = 6
 
-// FatalError (7) indicates that a logical error in the server caused
-// an emergency shutdown.
-func FatalError() Code { return Code{7} }
+	// FatalError indicates that a logical error in the server caused
+	// an emergency shutdown.
+	FatalError = 7
 
-// TimeoutAfterFatalError (8) indicates that an emergency shutdown
-// due to a fatal error did not occur properly due to some blockage
-// in the logging system.
-func TimeoutAfterFatalError() Code { return Code{8} }
+	// TimeoutAfterFatalError indicates that an emergency shutdown
+	// due to a fatal error did not occur properly due to some blockage
+	// in the logging system.
+	TimeoutAfterFatalError = 8
 
-// LoggingNetCollectorUnavailable (9) indicates that an error occurred
-// during a logging operation to a network collector.
-func LoggingNetCollectorUnavailable() Code { return Code{9} }
+	// LoggingNetCollectorUnavailable indicates that an error occurred
+	// during a logging operation to a network collector.
+	LoggingNetCollectorUnavailable = 9
 
-// Codes that are specific to client commands follow. It's possible
-// for codes to be reused across separate client or server commands.
-// Command-specific exit codes should be allocated down from 125.
+	//
+	// Codes that are specific to client commands follow. It's possible
+	// for codes to be reused across separate client or server commands.
+	// Command-specific exit codes should be allocated down from 125.
+	//
 
-// 'doctor' exit codes.
+	// 'doctor' exit codes.
 
-// DoctorValidationFailed indicates that the 'doctor' command has detected
-// an inconsistency in the SQL metaschema.
-func DoctorValidationFailed() Code { return Code{125} }
+	// DoctorValidationFailed indicates that the 'doctor' command has detected
+	// an inconsistency in the SQL metaschema.
+	DoctorValidationFailed = 125
+)

--- a/pkg/cli/exit/codes_test.go
+++ b/pkg/cli/exit/codes_test.go
@@ -11,4 +11,4 @@
 package exit
 
 // Silence the linter.
-var _ = UnspecifiedGoPanic()
+var _ = UnspecifiedGoPanic

--- a/pkg/cli/exit/exit.go
+++ b/pkg/cli/exit/exit.go
@@ -18,26 +18,24 @@ import (
 )
 
 // Code represents an exit code.
-type Code struct {
-	code int
-}
+type Code int
 
 // String implements the fmt.Stringer interface.
-func (c Code) String() string { return fmt.Sprint(c.code) }
+func (c Code) String() string { return fmt.Sprint(int(c)) }
 
 // Format implements the fmt.Formatter interface.
 func (c Code) Format(s fmt.State, verb rune) {
 	_, f := redact.MakeFormat(s, verb)
-	fmt.Fprintf(s, f, c.code)
+	fmt.Fprintf(s, f, int(c))
 }
 
 // SafeValue implements the redact.SafeValue interface.
 func (c Code) SafeValue() {}
 
-var _ redact.SafeValue = Code{}
+var _ redact.SafeValue = Code(0)
 
 // WithCode terminates the process and sets its exit status code to
 // the provided code.
 func WithCode(code Code) {
-	os.Exit(code.code)
+	os.Exit(int(code))
 }

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -371,7 +371,7 @@ func runStart(cmd *cobra.Command, args []string, startSingleNode bool) (returnEr
 	// If any store has something to say against a server start-up
 	// (e.g. previously detected corruption), listen to them now.
 	if err := serverCfg.Stores.PriorCriticalAlertError(); err != nil {
-		return &cliError{exitCode: exit.FatalError(), cause: err}
+		return &cliError{exitCode: exit.FatalError, cause: err}
 	}
 
 	// We don't care about GRPCs fairly verbose logs in most client commands,
@@ -760,7 +760,7 @@ If problems persist, please see %s.`
 			// "legitimate" and should be acknowledged with a success exit
 			// code. So we keep the error state here for later.
 			returnErr = &cliError{
-				exitCode: exit.Interrupted(),
+				exitCode: exit.Interrupted,
 				// INFO because a single interrupt is rather innocuous.
 				severity: severity.INFO,
 				cause:    errors.New("interrupted"),

--- a/pkg/cli/start_windows.go
+++ b/pkg/cli/start_windows.go
@@ -32,7 +32,7 @@ func handleSignalDuringShutdown(os.Signal) {
 	// Windows doesn't indicate whether a process exited due to a signal in the
 	// exit code, so we don't need to do anything but exit with a failing code.
 	// The error message has already been printed.
-	exit.WithCode(exit.UnspecifiedError())
+	exit.WithCode(exit.UnspecifiedError)
 }
 
 func maybeRerunBackground() (bool, error) {

--- a/pkg/cmd/docgen/logformats.go
+++ b/pkg/cmd/docgen/logformats.go
@@ -34,7 +34,7 @@ func init() {
 func runLogFormats(_ *cobra.Command, args []string) {
 	if err := runLogFormatsInternal(args); err != nil {
 		fmt.Fprintln(os.Stderr, "ERROR:", err)
-		exit.WithCode(exit.UnspecifiedError())
+		exit.WithCode(exit.UnspecifiedError)
 	}
 }
 

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -3369,7 +3369,7 @@ func TestReplicaAbortSpanReadError(t *testing.T) {
 	if !testutils.IsPError(pErr, "replica corruption") {
 		t.Fatal(pErr)
 	}
-	if exitStatus != exit.FatalError() {
+	if exitStatus != exit.FatalError {
 		t.Fatalf("did not fatal (exit status %d)", exitStatus)
 	}
 }
@@ -4165,7 +4165,7 @@ func TestEndTxnWithMalformedSplitTrigger(t *testing.T) {
 		t.Errorf("unexpected error: %s", pErr)
 	}
 
-	if exitStatus != exit.FatalError() {
+	if exitStatus != exit.FatalError {
 		t.Fatalf("unexpected exit status %d", exitStatus)
 	}
 }
@@ -6572,7 +6572,7 @@ func TestReplicaCorruption(t *testing.T) {
 	require.NoError(t, err)
 
 	// Should have triggered fatal error.
-	if exitStatus != exit.FatalError() {
+	if exitStatus != exit.FatalError {
 		t.Fatalf("unexpected exit status %d", exitStatus)
 	}
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -821,7 +821,7 @@ func TestPersistHLCUpperBound(t *testing.T) {
 	defer log.ResetExitFunc()
 	log.SetExitFunc(true /* hideStack */, func(r exit.Code) {
 		defer log.Flush()
-		if r == exit.FatalError() {
+		if r == exit.FatalError {
 			fatal = true
 		}
 	})

--- a/pkg/sql/schemachanger/scop/generate_visitor.go
+++ b/pkg/sql/schemachanger/scop/generate_visitor.go
@@ -29,7 +29,7 @@ import (
 func main() {
 	if err := run(); err != nil {
 		fmt.Fprintln(os.Stderr, "ERROR:", err)
-		exit.WithCode(exit.UnspecifiedError())
+		exit.WithCode(exit.UnspecifiedError)
 	}
 }
 

--- a/pkg/util/hlc/hlc_test.go
+++ b/pkg/util/hlc/hlc_test.go
@@ -137,7 +137,7 @@ func TestHLCPhysicalClockJump(t *testing.T) {
 	var fatal bool
 	defer log.ResetExitFunc()
 	log.SetExitFunc(true /* hideStack */, func(r exit.Code) {
-		if r == exit.FatalError() {
+		if r == exit.FatalError {
 			fatal = true
 		}
 	})
@@ -429,7 +429,7 @@ func TestHLCEnforceWallTimeWithinBoundsInNow(t *testing.T) {
 	defer log.ResetExitFunc()
 	log.SetExitFunc(true /* hideStack */, func(r exit.Code) {
 		defer log.Flush()
-		if r == exit.FatalError() {
+		if r == exit.FatalError {
 			fatal = true
 		}
 	})
@@ -478,7 +478,7 @@ func TestHLCEnforceWallTimeWithinBoundsInUpdate(t *testing.T) {
 	defer log.ResetExitFunc()
 	log.SetExitFunc(true /* hideStack */, func(r exit.Code) {
 		defer log.Flush()
-		if r == exit.FatalError() {
+		if r == exit.FatalError {
 			fatal = true
 		}
 	})

--- a/pkg/util/log/channels.go
+++ b/pkg/util/log/channels.go
@@ -66,7 +66,7 @@ func shoutfDepth(
 		// Fatal error handling later already tries to exit even if I/O should
 		// block, but crash reporting might also be in the way.
 		t := time.AfterFunc(10*time.Second, func() {
-			exit.WithCode(exit.TimeoutAfterFatalError())
+			exit.WithCode(exit.TimeoutAfterFatalError)
 		})
 		defer t.Stop()
 	}

--- a/pkg/util/log/clog.go
+++ b/pkg/util/log/clog.go
@@ -320,7 +320,7 @@ func (l *loggerT) outputLogEntry(entry logEntry) {
 			case <-time.After(10 * time.Second):
 			case <-fatalTrigger:
 			}
-			exitFunc(exit.FatalError(), nil)
+			exitFunc(exit.FatalError, nil)
 			close(exitCalled)
 		}()
 	}

--- a/pkg/util/log/clog_test.go
+++ b/pkg/util/log/clog_test.go
@@ -803,7 +803,7 @@ func TestExitOnFullDisk(t *testing.T) {
 	}
 
 	l.outputMu.Lock()
-	l.exitLocked(fmt.Errorf("out of space"), exit.UnspecifiedError())
+	l.exitLocked(fmt.Errorf("out of space"), exit.UnspecifiedError)
 	l.outputMu.Unlock()
 
 	exited.Wait()

--- a/pkg/util/log/eventpb/gen.go
+++ b/pkg/util/log/eventpb/gen.go
@@ -32,7 +32,7 @@ import (
 func main() {
 	if err := run(); err != nil {
 		fmt.Fprintln(os.Stderr, "ERROR:", err)
-		exit.WithCode(exit.UnspecifiedError())
+		exit.WithCode(exit.UnspecifiedError)
 	}
 }
 

--- a/pkg/util/log/file.go
+++ b/pkg/util/log/file.go
@@ -195,7 +195,7 @@ func (l *fileSink) output(extraFlush bool, b []byte) error {
 
 // exitCode implements the logSink interface.
 func (l *fileSink) exitCode() exit.Code {
-	return exit.LoggingFileUnavailable()
+	return exit.LoggingFileUnavailable
 }
 
 // emergencyOutput implements the logSink interface.

--- a/pkg/util/log/fluent_client.go
+++ b/pkg/util/log/fluent_client.go
@@ -56,7 +56,7 @@ func (l *fluentSink) attachHints(stacks []byte) []byte {
 
 // exitCode implements the logSink interface.
 func (l *fluentSink) exitCode() exit.Code {
-	return exit.LoggingNetCollectorUnavailable()
+	return exit.LoggingNetCollectorUnavailable
 }
 
 // output implements the logSink interface.

--- a/pkg/util/log/gen/main.go
+++ b/pkg/util/log/gen/main.go
@@ -26,7 +26,7 @@ import (
 func main() {
 	if err := run(); err != nil {
 		fmt.Fprintln(os.Stderr, "ERROR:", err)
-		exit.WithCode(exit.UnspecifiedError())
+		exit.WithCode(exit.UnspecifiedError)
 	}
 }
 

--- a/pkg/util/log/logconfig/gen.go
+++ b/pkg/util/log/logconfig/gen.go
@@ -30,7 +30,7 @@ import (
 func main() {
 	if err := run(); err != nil {
 		fmt.Fprintln(os.Stderr, "ERROR:", err)
-		exit.WithCode(exit.UnspecifiedError())
+		exit.WithCode(exit.UnspecifiedError)
 	}
 }
 

--- a/pkg/util/log/stderr_sink.go
+++ b/pkg/util/log/stderr_sink.go
@@ -38,7 +38,7 @@ func (l *stderrSink) output(_ bool, b []byte) error {
 
 // exitCode implements the logSink interface.
 func (l *stderrSink) exitCode() exit.Code {
-	return exit.LoggingStderrUnavailable()
+	return exit.LoggingStderrUnavailable
 }
 
 // emergencyOutput implements the logSink interface.

--- a/pkg/workload/cli/cli.go
+++ b/pkg/workload/cli/cli.go
@@ -77,7 +77,7 @@ func HandleErrs(
 			if hint != "" {
 				cmd.Println("Hint:", hint)
 			}
-			exit.WithCode(exit.UnspecifiedError())
+			exit.WithCode(exit.UnspecifiedError)
 		}
 	}
 }


### PR DESCRIPTION
This is mostly just a style issue, though it also makes clear there can be no dependency on
global state.

Release note: None