### PR TITLE
release-20.2: builtins: mark ST_GeomFromGeoJSON(string) as preferred

### DIFF
--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -625,18 +625,22 @@ SELECT ST_S2Covering(geography, 's2_max_level=15,s2_level_mod=3').
 	),
 	"st_geomfromgeojson": makeBuiltin(
 		defProps(),
-		stringOverload1(
-			func(_ *tree.EvalContext, s string) (tree.Datum, error) {
-				g, err := geo.ParseGeometryFromGeoJSON([]byte(s))
+		tree.Overload{
+			Types:      tree.ArgTypes{{"val", types.String}},
+			ReturnType: tree.FixedReturnType(types.Geometry),
+			Fn: func(evalCtx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				g, err := geo.ParseGeometryFromGeoJSON([]byte(tree.MustBeDString(args[0])))
 				if err != nil {
 					return nil, err
 				}
 				return tree.NewDGeometry(g), nil
 			},
-			types.Geometry,
-			infoBuilder{info: "Returns the Geometry from an GeoJSON representation."}.String(),
-			tree.VolatilityImmutable,
-		),
+			// Simulate PostgreSQL's ambiguity type resolving check that prefers
+			// strings over JSON.
+			PreferredOverload: true,
+			Info:              infoBuilder{info: "Returns the Geometry from an GeoJSON representation."}.String(),
+			Volatility:        tree.VolatilityImmutable,
+		},
 		jsonOverload1(
 			func(_ *tree.EvalContext, s json.JSON) (tree.Datum, error) {
 				// TODO(otan): optimize to not string it first.

--- a/pkg/sql/sem/tree/type_check_test.go
+++ b/pkg/sql/sem/tree/type_check_test.go
@@ -200,6 +200,9 @@ func TestTypeCheck(t *testing.T) {
 		{`(('{' || 'a' ||'}')::STRING[])[1]::STRING`, `((('{':::STRING || 'a':::STRING) || '}':::STRING)::STRING[])[1:::INT8]`},
 		{`(('{' || '1' ||'}')::INT[])[1]`, `((('{':::STRING || '1':::STRING) || '}':::STRING)::INT8[])[1:::INT8]`},
 		{`(ARRAY[1, 2, 3]::int[])[2]`, `(ARRAY[1:::INT8, 2:::INT8, 3:::INT8]:::INT8[])[2:::INT8]`},
+
+		// String preference.
+		{`st_geomfromgeojson($1)`, `st_geomfromgeojson($1:::STRING):::GEOMETRY`},
 	}
 	ctx := context.Background()
 	for _, d := range testData {


### PR DESCRIPTION
Backport 1/1 commits from #65370.

/cc @cockroachdb/release

---

This best imitates the PostgreSQL ambiguous type resolution in that it
always prefers strings.

Resolves https://github.com/cockroachdb/sequelize-cockroachdb/issues/52

Release note (sql change): Mark ST_GeomFromGeoJSON(string) as the
preferred overload, meaning it will resolve correctly in more contexts.
