### PR TITLE
geomfn: fix panic with ShortestLine/LongestLine with NaN coords

### DIFF
--- a/pkg/geo/geomfn/distance.go
+++ b/pkg/geo/geomfn/distance.go
@@ -443,7 +443,7 @@ func (u *geomMinDistanceUpdater) Update(aPoint geodist.Point, bPoint geodist.Poi
 	b := bPoint.GeomPoint
 
 	dist := coordNorm(coordSub(a, b))
-	if dist < u.currentValue {
+	if dist < u.currentValue || u.coordA == nil {
 		u.currentValue = dist
 		if u.geometricalObjOrder == geometricalObjectsFlipped {
 			u.coordA = b
@@ -526,7 +526,7 @@ func (u *geomMaxDistanceUpdater) Update(aPoint geodist.Point, bPoint geodist.Poi
 	b := bPoint.GeomPoint
 
 	dist := coordNorm(coordSub(a, b))
-	if dist > u.currentValue {
+	if dist > u.currentValue || u.coordA == nil {
 		u.currentValue = dist
 		if u.geometricalObjOrder == geometricalObjectsFlipped {
 			u.coordA = b

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -2488,6 +2488,16 @@ Square overlapping left and right square  Square (left)                         
 Square overlapping left and right square  Square (right)                            POLYGON ((0 0, -0.1 0, -0.1 1, 0 1, 0 0))
 Square overlapping left and right square  Square overlapping left and right square  POLYGON EMPTY
 
+query TT
+SELECT
+  st_astext(st_shortestline(a, b)),
+  st_astext(st_longestline(a, b))
+FROM ( VALUES
+  (st_scale('multipoint (0 0, 1 1)', 0, 'NaN'::float)::geometry, 'linestring (0 0, 1 1)'::geometry)
+) regression_t65422(a, b)
+----
+LINESTRING (0 NaN, 0 0)  LINESTRING (0 NaN, 0 0)
+
 # Binary predicates
 query TTBBBBBBBBBBBB
 SELECT


### PR DESCRIPTION
Resolves #65422 

Release note (bug fix): Fix a bug where NaN coordinates could make
ShortestLine/LongestLine panic.