### PR TITLE
server: report the node start history

### DIFF
--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -177,6 +177,8 @@ var (
 	// is to allow a restarting node to discover approximately how long it has
 	// been down without needing to retrieve liveness records from the cluster.
 	localStoreLastUpSuffix = []byte("uptm")
+	// localStoreStartSuffix stores the most recent restart timestamp for node.
+	localStoreStartSuffix = []byte("sttm")
 	// localRemovedLeakedRaftEntriesSuffix is DEPRECATED and remains to prevent
 	// reuse.
 	localRemovedLeakedRaftEntriesSuffix = []byte("dlre")

--- a/pkg/keys/doc.go
+++ b/pkg/keys/doc.go
@@ -223,6 +223,7 @@ var _ = [...]interface{}{
 	StoreIdentKey,          // "iden"
 	StoreNodeTombstoneKey,  // "ntmb"
 	StoreLastUpKey,         // "uptm"
+	StoreStartKey,          // "sttm"
 	StoreCachedSettingsKey, // "stng"
 
 	//   5. Range lock keys for all replicated locks. All range locks share

--- a/pkg/keys/keys.go
+++ b/pkg/keys/keys.go
@@ -70,6 +70,11 @@ func StoreLastUpKey() roachpb.Key {
 	return MakeStoreKey(localStoreLastUpSuffix, nil)
 }
 
+// StoreStartKey returns a store-local key for node's most recent restart timestamp.
+func StoreStartKey() roachpb.Key {
+	return MakeStoreKey(localStoreStartSuffix, nil)
+}
+
 // StoreHLCUpperBoundKey returns the store-local key for storing an upper bound
 // to the wall time used by HLC.
 func StoreHLCUpperBoundKey() roachpb.Key {


### PR DESCRIPTION
[WIP]

Fixes [#54102](https://github.com/cockroachdb/cockroach/issues/54102).

Node start history was obtainable from logs but somewhat laborious.
A recap of recent restarts at the beginning of process' logs is more instructive.
The most recent restart, if it is recent, is now noted at the beginning of logs.

Release note (cli change): recent restarts are now logged at the beginning of process' logs.