### PR TITLE
CODEOWNERS: add dirs to SQL-Experience ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,10 +26,16 @@
 /pkg/sql/parser/             @cockroachdb/sql-syntax-prs
 /pkg/sql/lex/                @cockroachdb/sql-syntax-prs
 /pkg/sql/show_create*.go     @cockroachdb/sql-syntax-prs
+/pkg/sql/types/              @cockroachdb/sql-syntax-prs
 
 /pkg/sql/crdb_internal.go    @cockroachdb/sql-api-prs
 /pkg/sql/pg_catalog.go       @cockroachdb/sql-api-prs
+/pkg/sql/pgwire/             @cockroachdb/sql-api-prs
 /pkg/sql/sem/builtins/       @cockroachdb/sql-api-prs
+/pkg/sql/vtable/             @cockroachdb/sql-api-prs
+
+/pkg/sql/sessiondata/        @cockroachdb/sql-experience
+/pkg/sql/tests/rsg_test.go   @cockroachdb/sql-experience
 
 /pkg/cli/                    @cockroachdb/cli-prs
 # last-rule-wins so bulk i/o takes userfile.go even though cli-prs takes pkg/cli
@@ -74,6 +80,7 @@
 /pkg/acceptance/             @cockroachdb/sql-experience
 /pkg/base/                   @cockroachdb/server-prs
 /pkg/bench/                  @cockroachdb/sql-queries
+/pkg/bench/ddl_analysis      @cockroachdb/sql-experience
 /pkg/blobs/                  @cockroachdb/bulk-prs
 /pkg/build/                  @cockroachdb/dev-inf
 /pkg/ccl/baseccl/            @cockroachdb/cli-prs

--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -20,7 +20,7 @@
 cockroachdb/docs:
   triage_column_id: 3971225
 cockroachdb/sql-experience:
-  aliases: [cockroachdb/sql-syntax-prs, cockroachdb/sqlproxy-prs]
+  aliases: [cockroachdb/sql-syntax-prs, cockroachdb/sqlproxy-prs, cockroachdb/sql-api-prs]
   triage_column_id: 7259065
 cockroachdb/sql-schema:
   triage_column_id: 8946818
@@ -28,7 +28,6 @@ cockroachdb/sql-queries:
   aliases: [cockroachdb/sql-optimizer, cockroachdb/sql-opt-prs]
   triage_column_id: 13549252
 cockroachdb/sql-observability:
-  aliases: [cockroachdb/sql-api-prs]
   triage_column_id: 12618343
 cockroachdb/kv:
   aliases: [cockroachdb/kv-triage]


### PR DESCRIPTION
The sql-api-prs alias was only being used for vtables, which are firmly
owned by SQL-Experence. This commit uses the alias in a few more places,
and also marks a few other areas as owned by SQL-Experience (most
notably sql/pgwire).

Release note: None