### PR TITLE
release-20.2: kvcoord: fix sorting of replicas

### DIFF
--- a/pkg/kv/kvclient/kvcoord/replica_slice.go
+++ b/pkg/kv/kvclient/kvcoord/replica_slice.go
@@ -177,12 +177,21 @@ func (rs ReplicaSlice) OptimizeReplicaOrder(
 		shuffle.Shuffle(rs)
 		return
 	}
+
 	// Sort replicas by latency and then attribute affinity.
 	sort.Slice(rs, func(i, j int) bool {
-		// If there is a replica in local node, it sorts first.
-		if rs[i].NodeID == nodeDesc.NodeID {
-			return true
+		// Replicas on the same node have the same latency.
+		if rs[i].NodeID == rs[j].NodeID {
+			return false // i == j
 		}
+		// Replicas on the local node sort first.
+		if rs[i].NodeID == nodeDesc.NodeID {
+			return true // i < j
+		}
+		if rs[j].NodeID == nodeDesc.NodeID {
+			return false // j < i
+		}
+
 		if latencyFn != nil {
 			latencyI, okI := latencyFn(rs[i].addr())
 			latencyJ, okJ := latencyFn(rs[j].addr())

--- a/pkg/kv/kvclient/kvcoord/replica_slice_test.go
+++ b/pkg/kv/kvclient/kvcoord/replica_slice_test.go
@@ -181,17 +181,6 @@ func TestReplicaSliceOptimizeReplicaOrder(t *testing.T) {
 			name: "order by locality matching",
 			node: nodeDesc(t, 1, []string{"country=us", "region=west", "city=la"}),
 			slice: ReplicaSlice{
-				info(t, 2, 2, []string{"country=us", "region=west", "city=sf"}),
-				info(t, 3, 3, []string{"country=uk", "city=london"}),
-				info(t, 3, 33, []string{"country=uk", "city=london"}),
-				info(t, 4, 4, []string{"country=us", "region=east", "city=ny"}),
-			},
-			expOrdered: []roachpb.NodeID{2, 4, 3},
-		},
-		{
-			name: "order by locality matching, put node first",
-			node: nodeDesc(t, 1, []string{"country=us", "region=west", "city=la"}),
-			slice: ReplicaSlice{
 				info(t, 1, 1, []string{"country=us", "region=west", "city=la"}),
 				info(t, 2, 2, []string{"country=us", "region=west", "city=sf"}),
 				info(t, 3, 3, []string{"country=uk", "city=london"}),

--- a/pkg/kv/kvclient/kvcoord/replica_slice_test.go
+++ b/pkg/kv/kvclient/kvcoord/replica_slice_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/shuffle"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
@@ -168,9 +169,13 @@ func TestReplicaSliceOptimizeReplicaOrder(t *testing.T) {
 		name string
 		node *roachpb.NodeDescriptor
 		// map from node address (see nodeDesc()) to latency to that node.
-		latencies  map[string]time.Duration
-		slice      ReplicaSlice
-		expOrdered ReplicaSlice
+		latencies map[string]time.Duration
+		slice     ReplicaSlice
+		// expOrder is the expected order in which the replicas sort. Replicas are
+		// only identified by their node. If multiple replicas are on different
+		// stores of the same node, the node only appears once in this list (as the
+		// ordering between replicas on the same node is not deterministic).
+		expOrdered []roachpb.NodeID
 	}{
 		{
 			name: "order by locality matching",
@@ -178,13 +183,10 @@ func TestReplicaSliceOptimizeReplicaOrder(t *testing.T) {
 			slice: ReplicaSlice{
 				info(t, 2, 2, []string{"country=us", "region=west", "city=sf"}),
 				info(t, 3, 3, []string{"country=uk", "city=london"}),
+				info(t, 3, 33, []string{"country=uk", "city=london"}),
 				info(t, 4, 4, []string{"country=us", "region=east", "city=ny"}),
 			},
-			expOrdered: ReplicaSlice{
-				info(t, 2, 2, []string{"country=us", "region=west", "city=sf"}),
-				info(t, 4, 4, []string{"country=us", "region=east", "city=ny"}),
-				info(t, 3, 3, []string{"country=uk", "city=london"}),
-			},
+			expOrdered: []roachpb.NodeID{2, 4, 3},
 		},
 		{
 			name: "order by locality matching, put node first",
@@ -193,14 +195,10 @@ func TestReplicaSliceOptimizeReplicaOrder(t *testing.T) {
 				info(t, 1, 1, []string{"country=us", "region=west", "city=la"}),
 				info(t, 2, 2, []string{"country=us", "region=west", "city=sf"}),
 				info(t, 3, 3, []string{"country=uk", "city=london"}),
+				info(t, 3, 33, []string{"country=uk", "city=london"}),
 				info(t, 4, 4, []string{"country=us", "region=east", "city=ny"}),
 			},
-			expOrdered: ReplicaSlice{
-				info(t, 1, 1, []string{"country=us", "region=west", "city=la"}),
-				info(t, 2, 2, []string{"country=us", "region=west", "city=sf"}),
-				info(t, 4, 4, []string{"country=us", "region=east", "city=ny"}),
-				info(t, 3, 3, []string{"country=uk", "city=london"}),
-			},
+			expOrdered: []roachpb.NodeID{1, 2, 4, 3},
 		},
 		{
 			name: "order by latency",
@@ -213,13 +211,10 @@ func TestReplicaSliceOptimizeReplicaOrder(t *testing.T) {
 			slice: ReplicaSlice{
 				info(t, 2, 2, []string{"country=us", "region=west", "city=sf"}),
 				info(t, 4, 4, []string{"country=us", "region=east", "city=ny"}),
+				info(t, 4, 44, []string{"country=us", "region=east", "city=ny"}),
 				info(t, 3, 3, []string{"country=uk", "city=london"}),
 			},
-			expOrdered: ReplicaSlice{
-				info(t, 4, 4, []string{"country=us", "region=east", "city=ny"}),
-				info(t, 3, 3, []string{"country=uk", "city=london"}),
-				info(t, 2, 2, []string{"country=us", "region=west", "city=sf"}),
-			},
+			expOrdered: []roachpb.NodeID{4, 3, 2},
 		},
 	}
 	for _, test := range testCases {
@@ -231,9 +226,19 @@ func TestReplicaSliceOptimizeReplicaOrder(t *testing.T) {
 					return lat, ok
 				}
 			}
+			// Randomize the input order, as it's not supposed to matter.
+			shuffle.Shuffle(test.slice)
 			test.slice.OptimizeReplicaOrder(test.node, latencyFn)
-			if !reflect.DeepEqual(test.slice, test.expOrdered) {
-				t.Errorf("expected order %+v; got %+v", test.expOrdered, test.slice)
+			var sortedNodes []roachpb.NodeID
+			sortedNodes = append(sortedNodes, test.slice[0].NodeID)
+			for i := 1; i < len(test.slice); i++ {
+				l := len(sortedNodes)
+				if nid := test.slice[i].NodeID; nid != sortedNodes[l-1] {
+					sortedNodes = append(sortedNodes, nid)
+				}
+			}
+			if !reflect.DeepEqual(sortedNodes, test.expOrdered) {
+				t.Errorf("expected node order %+v; got %+v", test.expOrdered, test.slice)
 			}
 		})
 	}

--- a/pkg/kv/kvclient/kvcoord/replica_slice_test.go
+++ b/pkg/kv/kvclient/kvcoord/replica_slice_test.go
@@ -147,19 +147,17 @@ func locality(t *testing.T, locStrs []string) roachpb.Locality {
 	return locality
 }
 
-func nodeDesc(
-	t *testing.T, nid roachpb.NodeID, sid roachpb.StoreID, locStrs []string,
-) *roachpb.NodeDescriptor {
+func nodeDesc(t *testing.T, nid roachpb.NodeID, locStrs []string) *roachpb.NodeDescriptor {
 	return &roachpb.NodeDescriptor{
 		Locality: locality(t, locStrs),
-		Address:  addr(nid, sid),
+		Address:  util.MakeUnresolvedAddr("tcp", fmt.Sprintf("%d:26257", nid)),
 	}
 }
 
 func info(t *testing.T, nid roachpb.NodeID, sid roachpb.StoreID, locStrs []string) ReplicaInfo {
 	return ReplicaInfo{
 		ReplicaDescriptor: desc(nid, sid),
-		NodeDesc:          nodeDesc(t, nid, sid, locStrs),
+		NodeDesc:          nodeDesc(t, nid, locStrs),
 	}
 }
 
@@ -167,15 +165,16 @@ func TestReplicaSliceOptimizeReplicaOrder(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	testCases := []struct {
-		name       string
-		node       *roachpb.NodeDescriptor
+		name string
+		node *roachpb.NodeDescriptor
+		// map from node address (see nodeDesc()) to latency to that node.
 		latencies  map[string]time.Duration
 		slice      ReplicaSlice
 		expOrdered ReplicaSlice
 	}{
 		{
 			name: "order by locality matching",
-			node: nodeDesc(t, 1, 1, []string{"country=us", "region=west", "city=la"}),
+			node: nodeDesc(t, 1, []string{"country=us", "region=west", "city=la"}),
 			slice: ReplicaSlice{
 				info(t, 2, 2, []string{"country=us", "region=west", "city=sf"}),
 				info(t, 3, 3, []string{"country=uk", "city=london"}),
@@ -189,7 +188,7 @@ func TestReplicaSliceOptimizeReplicaOrder(t *testing.T) {
 		},
 		{
 			name: "order by locality matching, put node first",
-			node: nodeDesc(t, 1, 1, []string{"country=us", "region=west", "city=la"}),
+			node: nodeDesc(t, 1, []string{"country=us", "region=west", "city=la"}),
 			slice: ReplicaSlice{
 				info(t, 1, 1, []string{"country=us", "region=west", "city=la"}),
 				info(t, 2, 2, []string{"country=us", "region=west", "city=sf"}),
@@ -205,11 +204,11 @@ func TestReplicaSliceOptimizeReplicaOrder(t *testing.T) {
 		},
 		{
 			name: "order by latency",
-			node: nodeDesc(t, 1, 1, []string{"country=us", "region=west", "city=la"}),
+			node: nodeDesc(t, 1, []string{"country=us", "region=west", "city=la"}),
 			latencies: map[string]time.Duration{
-				"2:2": time.Hour,
-				"3:3": time.Minute,
-				"4:4": time.Second,
+				"2:26257": time.Hour,
+				"3:26257": time.Minute,
+				"4:26257": time.Second,
 			},
 			slice: ReplicaSlice{
 				info(t, 2, 2, []string{"country=us", "region=west", "city=sf"}),

--- a/pkg/sql/physicalplan/replicaoracle/oracle_test.go
+++ b/pkg/sql/physicalplan/replicaoracle/oracle_test.go
@@ -51,13 +51,16 @@ func TestClosest(t *testing.T) {
 		return time.Millisecond, true
 	}
 	o := of.Oracle(nil)
-	info, err := o.ChoosePreferredReplica(ctx, &roachpb.RangeDescriptor{
-		InternalReplicas: []roachpb.ReplicaDescriptor{
-			{NodeID: 1, StoreID: 1},
-			{NodeID: 2, StoreID: 2},
-			{NodeID: 3, StoreID: 3},
+	info, err := o.ChoosePreferredReplica(
+		ctx,
+		&roachpb.RangeDescriptor{
+			InternalReplicas: []roachpb.ReplicaDescriptor{
+				{NodeID: 4, StoreID: 4},
+				{NodeID: 2, StoreID: 2},
+				{NodeID: 3, StoreID: 3},
+			},
 		},
-	}, nil /* leaseHolder */, QueryState{})
+		nil /* leaseHolder */, QueryState{})
 	if err != nil {
 		t.Fatalf("Failed to choose closest replica: %v", err)
 	}


### PR DESCRIPTION
Backport 4/4 commits from #64394.

/cc @cockroachdb/release

---

This patch fixes a bug in replica sorting. When it think that a
particular request can be served through follower reads, the DistSender
sorts the replicas by latency, falling back to locality attributes. It
also has a special provision for ordering the local replica(s) first,
but that provision was buggy: the `Less` function was only correctly
comparing a local replica with a non-local one when the local replica
was on the left side of the compairison. This patch fixes the bug by
extracting the prioritization of local replicas out of the main sort,
giving them a dedicate phase for clarity.

Release note: A certain percentage of cases in which a node could
have served a follower read were not handled correctly, resulting in the
node routing the request to another nearby node for no reason. This has
been fixed.
