### PR TITLE
vendor: Bump pebble to 7506c674f9afa156623731b4edb65b404b1d850e

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f
-	github.com/cockroachdb/pebble v0.0.0-20210503175044-ce69122e2ef3
+	github.com/cockroachdb/pebble v0.0.0-20210518010609-7506c674f9af
 	github.com/cockroachdb/redact v1.0.8
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2

--- a/go.sum
+++ b/go.sum
@@ -156,8 +156,8 @@ github.com/cockroachdb/grpc-gateway v1.14.6-0.20200519165156-52697fc4a249 h1:pZu
 github.com/cockroachdb/grpc-gateway v1.14.6-0.20200519165156-52697fc4a249/go.mod h1:UJ0EZAp832vCd54Wev9N1BMKEyvcZ5+IM0AwDrnlkEc=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f h1:o/kfcElHqOiXqcou5a3rIlMc7oJbMQkeLk0VQJ7zgqY=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/cockroachdb/pebble v0.0.0-20210503175044-ce69122e2ef3 h1:wBAo7aJyu5holPdMeNFJPcH0tN0kVuLg2s1uQ751jEA=
-github.com/cockroachdb/pebble v0.0.0-20210503175044-ce69122e2ef3/go.mod h1:hU7vhtrqonEphNF+xt8/lHdaBprxmV1h8BOGrd9XwmQ=
+github.com/cockroachdb/pebble v0.0.0-20210518010609-7506c674f9af h1:PpQBEO1NCJVKknTInNhmnd2es6KJWWldwBVFSPBZCy4=
+github.com/cockroachdb/pebble v0.0.0-20210518010609-7506c674f9af/go.mod h1:hU7vhtrqonEphNF+xt8/lHdaBprxmV1h8BOGrd9XwmQ=
 github.com/cockroachdb/redact v0.0.0-20200622112456-cd282804bbd3/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/redact v1.0.8 h1:8QG/764wK+vmEYoOlfobpe12EQcS81ukx/a4hdVMxNw=
 github.com/cockroachdb/redact v1.0.8/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=


### PR DESCRIPTION
Changes pulled in:

```
7506c674f9afa156623731b4edb65b404b1d850e db: heuristic to prevent tiny flushed files due to Lbase
```

Release note (performance improvement): Create fewer, larger files on
disk in one rare case under a write-heavy workload.