### PR TITLE
sql: pg_rewrite implemented for table-view dependencies

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1137,13 +1137,13 @@ FROM pg_catalog.pg_depend
 ORDER BY objid
 ----
 classid     objid       objsubid  refclassid  refobjid   refobjsubid  deptype
-4294967204  58          0         4294967204  55         1            n
-4294967204  58          0         4294967204  55         2            n
-4294967204  58          0         4294967204  55         3            n
-4294967204  58          0         4294967204  55         4            n
 4294967201  2143281868  0         4294967204  450499961  0            n
 4294967201  2355671820  0         4294967204  0          0            n
 4294967201  3911002394  0         4294967204  0          0            n
+4294967158  4079785839  0         4294967204  55         3            n
+4294967158  4079785839  0         4294967204  55         4            n
+4294967158  4079785839  0         4294967204  55         1            n
+4294967158  4079785839  0         4294967204  55         2            n
 4294967201  4089604113  0         4294967204  450499960  0            n
 
 # Some entries in pg_depend are dependency links from the pg_constraint system
@@ -1157,7 +1157,7 @@ JOIN pg_class cla ON classid=cla.oid
 JOIN pg_class refcla ON refclassid=refcla.oid
 ----
 classid     refclassid  tablename      reftablename
-4294967204  4294967204  pg_class       pg_class
+4294967158  4294967204  pg_rewrite     pg_class
 4294967201  4294967204  pg_constraint  pg_class
 
 # Some entries in pg_depend are foreign key constraints that reference an index
@@ -1189,11 +1189,6 @@ JOIN pg_constraint ON objid=pg_constraint.oid AND refobjid=pg_constraint.conindi
 contype
 f
 
-# Testing table-view dependencies in pg_depend, This query will not work the same way
-# In PostgreSQL as pg_depend.objid refers to pg_rewrite.oid, then pg_rewrite ev_class
-# refers to the dependent object, but cockroach db does not implements pg_rewrite yet
-# (Issue #57417: https://github.com/cockroachdb/cockroach/issues/57417)
-
 statement ok
 CREATE TABLE source_table(a INT PRIMARY KEY, b INT, c INT);
 CREATE VIEW depend_view AS SELECT b, c FROM source_table;
@@ -1208,7 +1203,8 @@ SELECT
 	   pg_attribute.attname column_name,
 	   pg_depend.deptype
   FROM pg_depend
-  JOIN pg_class depend_class ON pg_depend.objid = depend_class.oid
+  JOIN pg_rewrite ON pg_rewrite.oid = pg_depend.objid
+  JOIN pg_class depend_class ON depend_class.oid = pg_rewrite.ev_class
   JOIN pg_class source_class ON pg_depend.refobjid = source_class.oid
   JOIN pg_class depend_cat_class ON pg_depend.classid = depend_cat_class.oid
   JOIN pg_class source_cat_class ON pg_depend.refclassid = source_cat_class.oid
@@ -1218,10 +1214,20 @@ SELECT
   ORDER BY 3, 4, 5
 ----
 depend_catalog  source_catalog  source        depend                 column_name  deptype
-pg_class        pg_class        depend_view   view_dependingon_view  b            n
-pg_class        pg_class        depend_view   view_dependingon_view  c            n
-pg_class        pg_class        source_table  depend_view            b            n
-pg_class        pg_class        source_table  depend_view            c            n
+pg_rewrite      pg_class        depend_view   view_dependingon_view  b            n
+pg_rewrite      pg_class        depend_view   view_dependingon_view  c            n
+pg_rewrite      pg_class        source_table  depend_view            b            n
+pg_rewrite      pg_class        source_table  depend_view            c            n
+
+# Testing pg_rewrite
+query OTOTTBTT colnames
+SELECT * FROM pg_rewrite WHERE ev_class IN (
+  SELECT oid FROM pg_class WHERE relname IN ('depend_view', 'view_dependingon_view')
+) ORDER BY oid
+----
+oid         rulename  ev_class  ev_type  ev_enabled  is_instead  ev_qual  ev_action
+1454665107  _RETURN   69        1        NULL        true        NULL     NULL
+3319214789  _RETURN   68        1        NULL        true        NULL     NULL
 
 ## pg_catalog.pg_enum
 statement ok
@@ -2007,7 +2013,7 @@ objoid      classoid    objsubid  description
 4294967160  4294967204  0         pg_replication_origin was created for compatibility and is currently unimplemented
 4294967161  4294967204  0         pg_replication_origin_status was created for compatibility and is currently unimplemented
 4294967159  4294967204  0         pg_replication_slots was created for compatibility and is currently unimplemented
-4294967158  4294967204  0         rewrite rules (empty - feature does not exist)
+4294967158  4294967204  0         rewrite rules (only for referencing on pg_depend for table-view dependencies)
 4294967157  4294967204  0         database roles
 4294967156  4294967204  0         pg_rules was created for compatibility and is currently unimplemented
 4294967154  4294967204  0         security labels (empty - feature does not exist)

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -68,6 +68,11 @@ const (
 	indoptionNullsFirst = 0x02
 )
 
+// RewriteEvTypes could be a enumeration if rewrite rules gets implemented
+type RewriteEvTypes string
+
+const evTypeSelect RewriteEvTypes = "1"
+
 var forwardIndexOid = stringOid(indexTypeForwardIndex)
 var invertedIndexOid = stringOid(indexTypeInvertedIndex)
 
@@ -1121,6 +1126,7 @@ var (
 
 	pgConstraintsTableName = tree.MakeTableNameWithSchema("", tree.Name(pgCatalogName), tree.Name("pg_constraint"))
 	pgClassTableName       = tree.MakeTableNameWithSchema("", tree.Name(pgCatalogName), tree.Name("pg_class"))
+	pgRewriteTableName     = tree.MakeTableNameWithSchema("", tree.Name(pgCatalogName), tree.Name("pg_rewrite"))
 )
 
 // pg_depend is a fairly complex table that details many different kinds of
@@ -1145,6 +1151,10 @@ https://www.postgresql.org/docs/9.5/catalog-pg-depend.html`,
 		if err != nil {
 			return errors.New("could not find pg_catalog.pg_class")
 		}
+		pgRewriteDesc, err := vt.getVirtualTableDesc(&pgRewriteTableName)
+		if err != nil {
+			return errors.New("could not find pg_catalog.pg_rewrite")
+		}
 		h := makeOidHasher()
 		return forEachTableDescWithTableLookup(ctx, p, dbContext, hideVirtual /*virtual tables have no constraints*/, func(
 			db catalog.DatabaseDescriptor,
@@ -1154,6 +1164,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-depend.html`,
 		) error {
 			pgConstraintTableOid := tableOid(pgConstraintsDesc.GetID())
 			pgClassTableOid := tableOid(pgClassDesc.GetID())
+			pgRewriteTableOid := tableOid(pgRewriteDesc.GetID())
 			if table.IsSequence() &&
 				!table.GetSequenceOpts().SequenceOwner.Equal(descpb.TableDescriptor_SequenceOpts_SequenceOwner{}) {
 				refObjID := tableOid(table.GetSequenceOpts().SequenceOwner.OwnerTableID)
@@ -1171,18 +1182,17 @@ https://www.postgresql.org/docs/9.5/catalog-pg-depend.html`,
 			}
 
 			// In the case of table/view relationship, In PostgreSQL pg_depend.objid refers to
-			// pg_rewrite.oid, then pg_rewrite ev_class refers to the dependent object, but
-			// cockroach db does not implements pg_rewrite yet
-			//
-			// Issue #57417: https://github.com/cockroachdb/cockroach/issues/57417
+			// pg_rewrite.oid, then pg_rewrite ev_class refers to the dependent object.
 			reportViewDependency := func(dep *descpb.TableDescriptor_Reference) error {
+				refObjOid := tableOid(table.GetID())
+				objID := h.rewriteOid(table.GetID(), dep.ID)
 				for _, colID := range dep.ColumnIDs {
 					if err := addRow(
-						pgClassTableOid,                //classid
-						tableOid(dep.ID),               //objid
+						pgRewriteTableOid,              //classid
+						objID,                          //objid
 						zeroVal,                        //objsubid
 						pgClassTableOid,                //refclassid
-						tableOid(table.GetID()),        //refobjid
+						refObjOid,                      //refobjid
 						tree.NewDInt(tree.DInt(colID)), //refobjsubid
 						depTypeNormal,                  //deptype
 					); err != nil {
@@ -2061,14 +2071,39 @@ https://www.postgresql.org/docs/9.5/catalog-pg-range.html`,
 }
 
 var pgCatalogRewriteTable = virtualSchemaTable{
-	comment: `rewrite rules (empty - feature does not exist)
+	comment: `rewrite rules (only for referencing on pg_depend for table-view dependencies)
 https://www.postgresql.org/docs/9.5/catalog-pg-rewrite.html`,
 	schema: vtable.PGCatalogRewrite,
-	populate: func(_ context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		// Rewrite rules are not supported.
-		return nil
+	populate: func(ctx context.Context, p *planner, dbContext catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
+		h := makeOidHasher()
+		ruleName := tree.NewDString("_RETURN")
+		evType := tree.NewDString(string(evTypeSelect))
+		return forEachTableDescWithTableLookup(ctx, p, dbContext, hideVirtual /*virtual tables have no constraints*/, func(
+			db catalog.DatabaseDescriptor,
+			scName string,
+			table catalog.TableDescriptor,
+			tableLookup tableLookupFn,
+		) error {
+			if !table.IsTable() && !table.IsView() {
+				return nil
+			}
+
+			return table.ForeachDependedOnBy(func(dep *descpb.TableDescriptor_Reference) error {
+				rewriteOid := h.rewriteOid(table.GetID(), dep.ID)
+				evClass := tableOid(dep.ID)
+				return addRow(
+					rewriteOid,     // oid
+					ruleName,       // rulename
+					evClass,        // ev_class
+					evType,         // ev_type
+					tree.DNull,     // ev_enabled
+					tree.DBoolTrue, // is_instead
+					tree.DNull,     // ev_qual
+					tree.DNull,     // ev_action
+				)
+			})
+		})
 	},
-	unimplemented: true,
 }
 
 var pgCatalogRolesTable = virtualSchemaTable{
@@ -3216,6 +3251,7 @@ const (
 	collationTypeTag
 	operatorTypeTag
 	enumEntryTypeTag
+	rewriteTypeTag
 )
 
 func (h oidHasher) writeTypeTag(tag oidTypeTag) {
@@ -3376,6 +3412,13 @@ func (h oidHasher) EnumEntryOid(typOID *tree.DOid, physicalRep []byte) *tree.DOi
 	h.writeTypeTag(enumEntryTypeTag)
 	h.writeOID(typOID)
 	h.writeBytes(physicalRep)
+	return h.getOid()
+}
+
+func (h oidHasher) rewriteOid(source descpb.ID, depended descpb.ID) *tree.DOid {
+	h.writeTypeTag(rewriteTypeTag)
+	h.writeUInt32(uint32(source))
+	h.writeUInt32(uint32(depended))
 	return h.getOid()
 }
 


### PR DESCRIPTION
Previously, pg_depend referenced directly to pg_class for table-view
dependencies
This was inadequate because in postgres pg_depend reference to
pg_rewrite and pg_rewrite have a reference to pg_class
To address this, this patch implements pg_rewrite for table-view
dependencies and fix the reference over pg_depend

Release note (sql change): pg_rewrite implemented for table-view
dependencies, Table-view dependencies are no longer stored directly
in pg_depend

Fixes #57417