### PR TITLE
roachtest: fix team mentions

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -681,7 +681,7 @@ func (r *testRunner) runTest(
 
 				req := issues.PostRequest{
 					AuthorEmail:     "", // intentionally unset - we add to the board and cc the team
-					Mention:         []string{string(alias)},
+					Mention:         []string{"@" + string(alias)},
 					ProjectColumnID: owner.TriageColumnID,
 					PackageName:     "roachtest",
 					TestName:        t.Name(),


### PR DESCRIPTION
This was accidentally broken in
67119330a28659c38895ea40441869a31c5a34d0, so we'd end up with
`cockroachdb/kv` in issues instead of `@cockroachdb/kv`.

Release note: None
