### PR TITLE
ui: fix rejoin event message

### DIFF
--- a/pkg/ui/src/util/events.ts
+++ b/pkg/ui/src/util/events.ts
@@ -82,7 +82,7 @@ export function getEventDescription(e: Event$Properties): string {
     case eventTypes.NODE_RECOMMISSIONED:
       return `Node Recommissioned: Node ${info.TargetNodeID} was recommissioned`;
     case eventTypes.NODE_RESTART:
-      return `Node Rejoined: Node ${info.TargetNodeID} rejoined the cluster`;
+      return `Node Rejoined: Node ${info.NodeID} rejoined the cluster`;
     case eventTypes.SET_CLUSTER_SETTING:
       if (info.Value && info.Value.length > 0) {
         return `Cluster Setting Changed: User ${info.User} set ${info.SettingName} to ${info.Value}`;


### PR DESCRIPTION
adjust event string parse to match new event format

Resolves: #65455

Release note (ui): fix missing node id in rejoin event message

before:
![Screenshot 2021-05-20 at 17 26 10](https://user-images.githubusercontent.com/12850886/118997824-9d933980-b991-11eb-9a2a-d017e89118d7.png)
after:
![Screenshot 2021-05-20 at 17 26 48](https://user-images.githubusercontent.com/12850886/118997841-a257ed80-b991-11eb-9364-7eed81cde4a5.png)

