### PR TITLE
release-21.1: roachtest: fix import/nodeShutdown

### DIFF
--- a/pkg/cmd/roachtest/import.go
+++ b/pkg/cmd/roachtest/import.go
@@ -23,20 +23,26 @@ import (
 func registerImportNodeShutdown(r *testRegistry) {
 	getImportRunner := func(ctx context.Context, gatewayNode int) jobStarter {
 		startImport := func(c *cluster) (jobID string, err error) {
-			importStmt := `
-				IMPORT TABLE partsupp
-				CREATE USING 'gs://cockroach-fixtures/tpch-csv/schema/partcupp.sql'
+			// partsupp is 11.2 GiB.
+			tableName := "partsupp"
+			if local {
+				// part is 2.264 GiB.
+				tableName = "part"
+			}
+			importStmt := fmt.Sprintf(`
+				IMPORT TABLE %[1]s
+				CREATE USING 'gs://cockroach-fixtures/tpch-csv/schema/%[1]s.sql'
 				CSV DATA (
-				'gs://cockroach-fixtures/tpch-csv/sf-100/partsupp.tbl.1',
-				'gs://cockroach-fixtures/tpch-csv/sf-100/partsupp.tbl.2',
-				'gs://cockroach-fixtures/tpch-csv/sf-100/partsupp.tbl.3',
-				'gs://cockroach-fixtures/tpch-csv/sf-100/partsupp.tbl.4',
-				'gs://cockroach-fixtures/tpch-csv/sf-100/partsupp.tbl.5',
-				'gs://cockroach-fixtures/tpch-csv/sf-100/partsupp.tbl.6',
-				'gs://cockroach-fixtures/tpch-csv/sf-100/partsupp.tbl.7',
-				'gs://cockroach-fixtures/tpch-csv/sf-100/partsupp.tbl.8'
+				'gs://cockroach-fixtures/tpch-csv/sf-100/%[1]s.tbl.1',
+				'gs://cockroach-fixtures/tpch-csv/sf-100/%[1]s.tbl.2',
+				'gs://cockroach-fixtures/tpch-csv/sf-100/%[1]s.tbl.3',
+				'gs://cockroach-fixtures/tpch-csv/sf-100/%[1]s.tbl.4',
+				'gs://cockroach-fixtures/tpch-csv/sf-100/%[1]s.tbl.5',
+				'gs://cockroach-fixtures/tpch-csv/sf-100/%[1]s.tbl.6',
+				'gs://cockroach-fixtures/tpch-csv/sf-100/%[1]s.tbl.7',
+				'gs://cockroach-fixtures/tpch-csv/sf-100/%[1]s.tbl.8'
 				) WITH  delimiter='|', detached
-			`
+			`, tableName)
 			gatewayDB := c.Conn(ctx, gatewayNode)
 			defer gatewayDB.Close()
 


### PR DESCRIPTION
This commit is a clean cherry-pick of https://github.com/cockroachdb/cockroach/pull/62986/commits/db2775d6878675bd412f37cc8a00de70c03893b5.

This roachtest had a typo in the name of the schema that it was
importing. This commit fixes the typo and also changes the table to a
smaller one when running the roachtest locally.

Fixes https://github.com/cockroachdb/cockroach/issues/65477.
Fixes https://github.com/cockroachdb/cockroach/issues/65476.

Release note: None