### PR TITLE
sql: fix has_database_privilege to work cross-DB

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/privilege_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/privilege_builtins
@@ -392,6 +392,34 @@ SELECT has_database_privilege('test'::Name, 'CREATE'),
 ----
 true  true  true  true  true
 
+query T
+SELECT datname FROM pg_database WHERE has_database_privilege(datname, 'CREATE') ORDER BY datname
+----
+defaultdb
+postgres
+test
+
+query T
+SELECT datname FROM pg_database WHERE has_database_privilege(datname, 'CONNECT') ORDER BY datname
+----
+defaultdb
+postgres
+test
+
+query T
+SELECT datname FROM pg_database WHERE has_database_privilege(datname, 'TEMP') ORDER BY datname
+----
+defaultdb
+postgres
+test
+
+query T
+SELECT datname FROM pg_database WHERE has_database_privilege(datname, 'TEMPORARY') ORDER BY datname
+----
+defaultdb
+postgres
+test
+
 query error pgcode 22023 unrecognized privilege type: "UPDATE"
 SELECT has_database_privilege('test', 'UPDATE')
 

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -1453,14 +1453,13 @@ SELECT description
 				}
 			}
 
-			schemaPrivilegePred := fmt.Sprintf("table_catalog = '%s'", db)
 			databasePrivilegePred := fmt.Sprintf("database_name = '%s'", db)
 			return parsePrivilegeStr(args[1], pgPrivList{
 				"CREATE": func(withGrantOpt bool) (tree.Datum, error) {
 					if retNull {
 						return tree.DNull, nil
 					}
-					return evalPrivilegeCheck(ctx, "crdb_internal",
+					return evalPrivilegeCheck(ctx, `"".crdb_internal`,
 						"cluster_database_privileges", user, databasePrivilegePred,
 						privilege.CREATE, withGrantOpt)
 				},
@@ -1468,7 +1467,7 @@ SELECT description
 					if retNull {
 						return tree.DNull, nil
 					}
-					return evalPrivilegeCheck(ctx, "crdb_internal",
+					return evalPrivilegeCheck(ctx, `"".crdb_internal`,
 						"cluster_database_privileges", user, databasePrivilegePred,
 						privilege.CONNECT, withGrantOpt)
 				},
@@ -1476,16 +1475,16 @@ SELECT description
 					if retNull {
 						return tree.DNull, nil
 					}
-					return evalPrivilegeCheck(ctx, "information_schema",
-						"schema_privileges", user, schemaPrivilegePred,
+					return evalPrivilegeCheck(ctx, `"".crdb_internal`,
+						"cluster_database_privileges", user, databasePrivilegePred,
 						privilege.CREATE, withGrantOpt)
 				},
 				"TEMP": func(withGrantOpt bool) (tree.Datum, error) {
 					if retNull {
 						return tree.DNull, nil
 					}
-					return evalPrivilegeCheck(ctx, "information_schema",
-						"schema_privileges", user, schemaPrivilegePred,
+					return evalPrivilegeCheck(ctx, `"".crdb_internal`,
+						"cluster_database_privileges", user, databasePrivilegePred,
 						privilege.CREATE, withGrantOpt)
 				},
 			})


### PR DESCRIPTION
fixes #65421 

This is fixed using the `"".crdb_internal.table` syntax for name
resolution, which is well-defined, and causes metadata from all
databases to appear in the crdb_internal virtual schema.

Release note (bug fix): The has_database_privilege function now
correctly will check privileges on databases that are not the current
database being used by the session.