### PR TITLE
sql: fix panic in CTAS with some virtual tables

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -836,6 +836,16 @@ func execStatVar(count int64, n roachpb.NumericStat) tree.Datum {
 	return tree.NewDFloat(tree.DFloat(n.GetVariance(count)))
 }
 
+// getSQLStats retrieves a sqlStats object from the planner or returns an error
+// if not available. virtualTableName specifies the virtual table for which this
+// sqlStats object is needed.
+func getSQLStats(p *planner, virtualTableName string) (*sqlStats, error) {
+	if p.extendedEvalCtx.sqlStatsCollector == nil || p.extendedEvalCtx.sqlStatsCollector.sqlStats == nil {
+		return nil, errors.Newf("%s cannot be used in CREATE TABLE AS", virtualTableName)
+	}
+	return p.extendedEvalCtx.sqlStatsCollector.sqlStats, nil
+}
+
 var crdbInternalStmtStatsTable = virtualSchemaTable{
 	comment: `statement statistics (in-memory, not durable; local node only). ` +
 		`This table is wiped periodically (by default, at least every two hours)`,
@@ -890,10 +900,9 @@ CREATE TABLE crdb_internal.node_statement_statistics (
 				"user %s does not have %s privilege", p.User(), roleoption.VIEWACTIVITY)
 		}
 
-		sqlStats := p.extendedEvalCtx.sqlStatsCollector.sqlStats
-		if sqlStats == nil {
-			return errors.AssertionFailedf(
-				"cannot access sql statistics from this context")
+		sqlStats, err := getSQLStats(p, "crdb_internal.node_statement_statistics")
+		if err != nil {
+			return err
 		}
 
 		nodeID, _ := p.execCfg.NodeID.OptionalNodeID() // zero if not available
@@ -1038,10 +1047,9 @@ CREATE TABLE crdb_internal.node_transaction_statistics (
 			return pgerror.Newf(pgcode.InsufficientPrivilege,
 				"user %s does not have %s privilege", p.User(), roleoption.VIEWACTIVITY)
 		}
-		sqlStats := p.extendedEvalCtx.sqlStatsCollector.sqlStats
-		if sqlStats == nil {
-			return errors.AssertionFailedf(
-				"cannot access sql statistics from this context")
+		sqlStats, err := getSQLStats(p, "crdb_internal.node_transaction_statistics")
+		if err != nil {
+			return err
 		}
 
 		nodeID, _ := p.execCfg.NodeID.OptionalNodeID() // zero if not available
@@ -1147,10 +1155,9 @@ CREATE TABLE crdb_internal.node_txn_stats (
 			return err
 		}
 
-		sqlStats := p.extendedEvalCtx.sqlStatsCollector.sqlStats
-		if sqlStats == nil {
-			return errors.AssertionFailedf(
-				"cannot access sql statistics from this context")
+		sqlStats, err := getSQLStats(p, "crdb_internal.node_txn_stats")
+		if err != nil {
+			return err
 		}
 
 		nodeID, _ := p.execCfg.NodeID.OptionalNodeID() // zero if not available

--- a/pkg/sql/logictest/testdata/logic_test/create_table
+++ b/pkg/sql/logictest/testdata/logic_test/create_table
@@ -430,3 +430,15 @@ CREATE TABLE error (a INT, b INT, INDEX idx (a), UNIQUE INDEX idx (b))
 
 statement error pgcode 42P07 duplicate index name: \"idx\"
 CREATE TABLE error (a INT, b INT, UNIQUE INDEX idx (a), UNIQUE INDEX idx (b))
+
+# Regression test for using some virtual tables in CREATE TABLE AS which is not
+# supported at the moment (#65512).
+
+query error crdb_internal.node_statement_statistics cannot be used in CREATE TABLE AS
+CREATE TABLE ctas AS (SELECT * FROM crdb_internal.node_statement_statistics);
+
+query error crdb_internal.node_transaction_statistics cannot be used in CREATE TABLE AS
+CREATE TABLE ctas AS (SELECT * FROM crdb_internal.node_transaction_statistics);
+
+query error crdb_internal.node_txn_stats cannot be used in CREATE TABLE AS
+CREATE TABLE ctas AS (SELECT * FROM crdb_internal.node_txn_stats);


### PR DESCRIPTION
CTAS creates a fake planner that doesn't have `sqlStatsCollector` set
(which lives on the `connExecutor`), so the usage of several virtual
tables in CTAS would previously lead to a crash. The proper fix doesn't
appear to be easy, so this commit prohibits the usage of those virtual
tables in CTAS context.

Fixes: #65512.

Release note (bug fix): CockroachDB would previously crash when
attempting to create a table using CREATE TABLE ... AS syntax where AS
part selects from `crdb_internal.node_statement_statistics`,
`crdb_internal.node_transaction_statistics`, or
`crdb_internal.node_txn_stats` virtual tables.