### PR TITLE
sql: clear right rows correctly during apply-join

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/apply_join
+++ b/pkg/sql/logictest/testdata/logic_test/apply_join
@@ -377,3 +377,21 @@ UPDATE cpk SET extra = (
     WHERE k='k1'
 )
 WHERE ((cpk.key, cpk.value) IN (SELECT new_values.k, new_values.v FROM new_values))
+
+# Regression test for #65040. Rows fetched for the right side of the apply join
+# were not cleared for successive rows on the left, causing a panic.
+
+statement ok
+CREATE TABLE t65040 (a INT, b TIMESTAMP);
+INSERT INTO t65040 VALUES (1, '2001-01-01');
+INSERT INTO t65040 VALUES (2, '2002-02-02');
+
+statement ok
+SELECT NULL
+FROM t65040 AS t1
+WHERE t1.b IN (
+  SELECT t2.b
+  FROM t65040,
+    (VALUES (t1.a)) AS v (a)
+      JOIN t65040 AS t2 ON v.a = t2.a
+)


### PR DESCRIPTION
This commit fixes a bug introduced in #63900 which causes execution of
semi and anti apply-joins to panic. For a each row on the left side of
the apply-join, rows are fetched for the right side of the join and
added to an iterator. For semi and anti apply-joins, the right rows are
only consumed until a match is found. These right rows were not being
cleared for the next successive left row. This caused a panic when the
apply-join predicate would be applied on a `nil` left row during the
next call to `applyJoinNode.Next`; the next left row is only fetched if
the right row iterator has been cleared.

Fixes #65040

There is no release note because this bug is only present in
21.2.0-alpha, which has not yet been released.

Release note: None