### PR TITLE
cli: stop attributing time spent running schema changes to network lat 

### DIFF
--- a/pkg/cli/sql_util.go
+++ b/pkg/cli/sql_util.go
@@ -200,7 +200,7 @@ func (c *sqlConn) ensureConn() error {
 // SHOW LAST QUERY STATISTICS statements. This allows the CLI client to report
 // server side execution timings instead of timing on the client.
 func (c *sqlConn) tryEnableServerExecutionTimings() {
-	_, _, _, _, err := c.getLastQueryStatistics()
+	_, _, _, _, _, _, err := c.getLastQueryStatistics()
 	if err != nil {
 		fmt.Fprintf(stderr, "warning: cannot show server execution timings: unexpected column found\n")
 		sqlCtx.enableServerExecutionTimings = false
@@ -382,28 +382,36 @@ func (c *sqlConn) getServerValue(what, sql string) (driver.Value, string, bool) 
 // performs sanity checks, and returns the exec latency and service latency from
 // the sql row parsed as time.Duration.
 func (c *sqlConn) getLastQueryStatistics() (
-	parseLat, planLat, execLat, serviceLat time.Duration,
+	parseLat, planLat, execLat, serviceLat, jobsLat time.Duration,
+	containsJobLat bool,
 	err error,
 ) {
 	rows, err := c.Query("SHOW LAST QUERY STATISTICS", nil)
 	if err != nil {
-		return 0, 0, 0, 0, err
+		return 0, 0, 0, 0, 0, false, err
 	}
 	defer func() {
 		closeErr := rows.Close()
 		err = errors.CombineErrors(err, closeErr)
 	}()
 
-	if len(rows.Columns()) != 4 {
-		return 0, 0, 0, 0,
-			errors.New("unexpected number of columns in SHOW LAST QUERY STATISTICS")
+	// TODO(arul): In 21.1, SHOW LAST QUERY STATISTICS returned 4 columns. In 21.2,
+	// it returns 5. Depending on which server version the CLI is connected to,
+	// both are valid. We won't have to account for this mixed version state in
+	// 22.1. All this logic can be simplified in 22.1.
+	if len(rows.Columns()) == 5 {
+		containsJobLat = true
+	} else if len(rows.Columns()) != 4 {
+		return 0, 0, 0, 0, 0, false,
+			errors.Newf("unexpected number of columns in SHOW LAST QUERY STATISTICS")
 	}
 
 	if rows.Columns()[0] != "parse_latency" ||
 		rows.Columns()[1] != "plan_latency" ||
 		rows.Columns()[2] != "exec_latency" ||
-		rows.Columns()[3] != "service_latency" {
-		return 0, 0, 0, 0,
+		rows.Columns()[3] != "service_latency" ||
+		(containsJobLat && rows.Columns()[4] != "post_commit_jobs_latency") {
+		return 0, 0, 0, 0, 0, containsJobLat,
 			errors.New("unexpected columns in SHOW LAST QUERY STATISTICS")
 	}
 
@@ -413,24 +421,28 @@ func (c *sqlConn) getLastQueryStatistics() (
 	var planLatencyRaw string
 	var execLatencyRaw string
 	var serviceLatencyRaw string
+	var jobsLatencyRaw string
 	for {
 		row, err := iter.Next()
 		if err == io.EOF {
 			break
 		} else if err != nil {
-			return 0, 0, 0, 0, err
+			return 0, 0, 0, 0, 0, containsJobLat, err
 		}
 
 		parseLatencyRaw = formatVal(row[0], iter.colTypes[0], false, false)
 		planLatencyRaw = formatVal(row[1], iter.colTypes[1], false, false)
 		execLatencyRaw = formatVal(row[2], iter.colTypes[2], false, false)
 		serviceLatencyRaw = formatVal(row[3], iter.colTypes[3], false, false)
+		if containsJobLat {
+			jobsLatencyRaw = formatVal(row[4], iter.colTypes[4], false, false)
+		}
 
 		nRows++
 	}
 
 	if nRows != 1 {
-		return 0, 0, 0, 0,
+		return 0, 0, 0, 0, 0, containsJobLat,
 			errors.Newf("unexpected number of rows in SHOW LAST QUERY STATISTICS: %d", nRows)
 	}
 
@@ -439,10 +451,17 @@ func (c *sqlConn) getLastQueryStatistics() (
 	parsedPlanLatency, _ := tree.ParseDInterval(planLatencyRaw)
 	parsedParseLatency, _ := tree.ParseDInterval(parseLatencyRaw)
 
+	if containsJobLat {
+		parsedJobsLatency, _ := tree.ParseDInterval(jobsLatencyRaw)
+		jobsLat = time.Duration(parsedJobsLatency.Duration.Nanos())
+	}
+
 	return time.Duration(parsedParseLatency.Duration.Nanos()),
 		time.Duration(parsedPlanLatency.Duration.Nanos()),
 		time.Duration(parsedExecLatency.Duration.Nanos()),
 		time.Duration(parsedServiceLatency.Duration.Nanos()),
+		jobsLat,
+		containsJobLat,
 		nil
 }
 
@@ -1012,7 +1031,7 @@ func maybeShowTimes(
 	}
 
 	// If discrete server/network timings are available, also print them.
-	parseLat, planLat, execLat, serviceLat, err := conn.getLastQueryStatistics()
+	parseLat, planLat, execLat, serviceLat, jobsLat, containsJobLat, err := conn.getLastQueryStatistics()
 	if err != nil {
 		fmt.Fprintf(stderr, "\nwarning: %v", err)
 		return
@@ -1020,7 +1039,7 @@ func maybeShowTimes(
 
 	fmt.Fprint(stderr, " total")
 
-	networkLat := clientSideQueryLatency - serviceLat
+	networkLat := clientSideQueryLatency - (serviceLat + jobsLat)
 	// serviceLat can be greater than clientSideQueryLatency for some extremely quick
 	// statements (eg. BEGIN). So as to not confuse the user, we attribute all of
 	// the clientSideQueryLatency to the network in such cases.
@@ -1029,8 +1048,16 @@ func maybeShowTimes(
 	}
 	otherLat := serviceLat - parseLat - planLat - execLat
 	if sqlCtx.verboseTimings {
-		fmt.Fprintf(w, " (parse %s / plan %s / exec %s / other %s / network %s)\n",
-			parseLat, planLat, execLat, otherLat, networkLat)
+		// Only display schema change latency if the server provided that
+		// information to not confuse users.
+		// TODO(arul): this can be removed in 22.1.
+		if containsJobLat {
+			fmt.Fprintf(w, " (parse %s / plan %s / exec %s / schema change %s / other %s / network %s)\n",
+				parseLat, planLat, execLat, jobsLat, otherLat, networkLat)
+		} else {
+			fmt.Fprintf(w, " (parse %s / plan %s / exec %s / other %s / network %s)\n",
+				parseLat, planLat, execLat, otherLat, networkLat)
+		}
 	} else {
 		// Simplified display: just show the execution/network breakdown.
 		//
@@ -1042,7 +1069,7 @@ func maybeShowTimes(
 			fmt.Fprintf(w, "%s%s %.*f%s", sep, label, precision, lat.Seconds()*multiplier, unit)
 			sep = " / "
 		}
-		reportTiming("execution", serviceLat)
+		reportTiming("execution", serviceLat+jobsLat)
 		reportTiming("network", networkLat)
 		fmt.Fprintln(w, ")")
 	}

--- a/pkg/sql/catalog/colinfo/result_columns.go
+++ b/pkg/sql/catalog/colinfo/result_columns.go
@@ -193,6 +193,7 @@ var ShowLastQueryStatisticsColumns = ResultColumns{
 	{Name: "plan_latency", Typ: types.Interval},
 	{Name: "exec_latency", Typ: types.Interval},
 	{Name: "service_latency", Typ: types.Interval},
+	{Name: "post_commit_jobs_latency", Typ: types.Interval},
 }
 
 // ShowFingerprintsColumns are the result columns of a

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -2462,12 +2462,14 @@ func (ex *connExecutor) txnStateTransitionsApplyWrapper(
 		}
 		ex.notifyStatsRefresherOfNewTables(ex.Ctx())
 
+		ex.statsCollector.phaseTimes[sessionStartPostCommitJob] = timeutil.Now()
 		if err := ex.server.cfg.JobRegistry.Run(
 			ex.ctxHolder.connCtx,
 			ex.server.cfg.InternalExecutor,
 			ex.extraTxnState.jobs); err != nil {
 			handleErr(err)
 		}
+		ex.statsCollector.phaseTimes[sessionEndPostCommitJob] = timeutil.Now()
 
 		fallthrough
 	case txnRestart, txnRollback:

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1338,6 +1338,7 @@ func (ex *connExecutor) runShowLastQueryStatistics(
 	// Since the last query has already finished, it is safe to retrieve its
 	// total service latency.
 	svcLat := phaseTimes.getServiceLatencyTotal().Seconds()
+	postCommitJobsLat := phaseTimes.getPostCommitJobsLatency().Seconds()
 
 	return res.AddRow(ctx,
 		tree.Datums{
@@ -1345,6 +1346,7 @@ func (ex *connExecutor) runShowLastQueryStatistics(
 			tree.NewDInterval(duration.FromFloat64(planLat), types.DefaultIntervalTypeMetadata),
 			tree.NewDInterval(duration.FromFloat64(runLat), types.DefaultIntervalTypeMetadata),
 			tree.NewDInterval(duration.FromFloat64(svcLat), types.DefaultIntervalTypeMetadata),
+			tree.NewDInterval(duration.FromFloat64(postCommitJobsLat), types.DefaultIntervalTypeMetadata),
 		})
 }
 

--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -856,20 +856,31 @@ func TestShowLastQueryStatistics(t *testing.T) {
 	defer s.Stopper().Stop(ctx)
 
 	testCases := []struct {
-		stmt           string
-		usesExecEngine bool
+		stmt                             string
+		usesExecEngine                   bool
+		expectNonTrivialSchemaChangeTime bool
 	}{
 		{
-			stmt:           "CREATE TABLE t(a INT, b INT)",
-			usesExecEngine: true,
+			stmt:                             "CREATE TABLE t(a INT, b INT)",
+			usesExecEngine:                   true,
+			expectNonTrivialSchemaChangeTime: false,
 		},
 		{
-			stmt:           "SHOW SYNTAX 'SELECT * FROM t'",
-			usesExecEngine: false,
+			stmt:                             "SHOW SYNTAX 'SELECT * FROM t'",
+			usesExecEngine:                   false,
+			expectNonTrivialSchemaChangeTime: false,
 		},
 		{
-			stmt:           "PREPARE stmt(INT) AS INSERT INTO t VALUES(1, $1)",
-			usesExecEngine: false,
+			stmt:                             "PREPARE stmt(INT) AS INSERT INTO t VALUES(1, $1)",
+			usesExecEngine:                   false,
+			expectNonTrivialSchemaChangeTime: false,
+		},
+		{
+			stmt: `CREATE TABLE t1(a INT); 
+INSERT INTO t1 SELECT i FROM generate_series(1, 10000) AS g(i);
+ALTER TABLE t1 ADD COLUMN b INT DEFAULT 1`,
+			usesExecEngine:                   true,
+			expectNonTrivialSchemaChangeTime: true,
 		},
 	}
 
@@ -885,7 +896,7 @@ func TestShowLastQueryStatistics(t *testing.T) {
 		resultColumns, err := rows.Columns()
 		require.NoError(t, err)
 
-		const expectedNumColumns = 4
+		const expectedNumColumns = 5
 		if len(resultColumns) != expectedNumColumns {
 			t.Fatalf(
 				"unexpected number of columns in result; expected %d, found %d",
@@ -898,11 +909,13 @@ func TestShowLastQueryStatistics(t *testing.T) {
 		var planLatency string
 		var execLatency string
 		var serviceLatency string
+		var postCommitJobsLatency string
 
 		rows.Next()
-		if err := rows.Scan(&parseLatency, &planLatency, &execLatency, &serviceLatency); err != nil {
-			t.Fatalf("unexpected error while reading last query statistics: %v", err)
-		}
+		err = rows.Scan(
+			&parseLatency, &planLatency, &execLatency, &serviceLatency, &postCommitJobsLatency,
+		)
+		require.NoError(t, err, "unexpected error while reading last query statistics")
 
 		parseInterval, err := tree.ParseDInterval(parseLatency)
 		require.NoError(t, err)
@@ -916,6 +929,9 @@ func TestShowLastQueryStatistics(t *testing.T) {
 		serviceInterval, err := tree.ParseDInterval(serviceLatency)
 		require.NoError(t, err)
 
+		postCommitJobsInterval, err := tree.ParseDInterval(postCommitJobsLatency)
+		require.NoError(t, err)
+
 		if parseInterval.AsFloat64() <= 0 || parseInterval.AsFloat64() > 1 {
 			t.Fatalf("unexpected parse latency: %v", parseInterval.AsFloat64())
 		}
@@ -924,12 +940,27 @@ func TestShowLastQueryStatistics(t *testing.T) {
 			t.Fatalf("unexpected plan latency: %v", planInterval.AsFloat64())
 		}
 
-		if serviceInterval.AsFloat64() <= 0 || serviceInterval.AsFloat64() > 1 {
+		// Service latencies with tests that do schema changes are hard to constrain
+		// a window for, so don't bother.
+		if !tc.expectNonTrivialSchemaChangeTime &&
+			(serviceInterval.AsFloat64() <= 0 || serviceInterval.AsFloat64() > 1) {
 			t.Fatalf("unexpected service latency: %v", serviceInterval.AsFloat64())
 		}
 
 		if tc.usesExecEngine && (execInterval.AsFloat64() <= 0 || execInterval.AsFloat64() > 1) {
 			t.Fatalf("unexpected execution latency: %v", execInterval.AsFloat64())
+		}
+
+		if !tc.expectNonTrivialSchemaChangeTime &&
+			(postCommitJobsInterval.AsFloat64() < 0 || postCommitJobsInterval.AsFloat64() > 1) {
+			t.Fatalf("unexpected post commit jobs latency: %v", postCommitJobsInterval.AsFloat64())
+		}
+
+		if tc.expectNonTrivialSchemaChangeTime && postCommitJobsInterval.AsFloat64() < 0.1 {
+			t.Fatalf(
+				"expected schema changes to take longer than 0.1 seconds, took: %v",
+				postCommitJobsInterval.AsFloat64(),
+			)
 		}
 
 		if rows.Next() {

--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -875,14 +875,24 @@ func TestShowLastQueryStatistics(t *testing.T) {
 
 	for _, tc := range testCases {
 		if _, err := sqlConn.Exec(tc.stmt); err != nil {
-			t.Fatalf("executing %s. failed: %v ", tc.stmt, err)
+			require.NoError(t, err, "executing %s  ", tc.stmt)
 		}
 
 		rows, err := sqlConn.Query("SHOW LAST QUERY STATISTICS")
-		if err != nil {
-			t.Fatalf("show last query statistics failed: %v", err)
-		}
+		require.NoError(t, err, "show last query statistics failed")
 		defer rows.Close()
+
+		resultColumns, err := rows.Columns()
+		require.NoError(t, err)
+
+		const expectedNumColumns = 4
+		if len(resultColumns) != expectedNumColumns {
+			t.Fatalf(
+				"unexpected number of columns in result; expected %d, found %d",
+				expectedNumColumns,
+				len(resultColumns),
+			)
+		}
 
 		var parseLatency string
 		var planLatency string
@@ -895,21 +905,16 @@ func TestShowLastQueryStatistics(t *testing.T) {
 		}
 
 		parseInterval, err := tree.ParseDInterval(parseLatency)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+
 		planInterval, err := tree.ParseDInterval(planLatency)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+
 		execInterval, err := tree.ParseDInterval(execLatency)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+
 		serviceInterval, err := tree.ParseDInterval(serviceLatency)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		if parseInterval.AsFloat64() <= 0 || parseInterval.AsFloat64() > 1 {
 			t.Fatalf("unexpected parse latency: %v", parseInterval.AsFloat64())

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -56,6 +56,8 @@ const (
 	sessionEndExecTransaction             // Transaction is committed/rolled back.
 	sessionStartTransactionCommit         // Transaction `COMMIT` starts.
 	sessionEndTransactionCommit           // Transaction `COMMIT` ends.
+	sessionStartPostCommitJob             // Post transaction `COMMIT` jobs start.
+	sessionEndPostCommitJob               // Post transaction `COMMIT` jobs end.
 
 	// sessionNumPhases must be listed last so that it can be used to
 	// define arrays sufficiently large to hold all the other values.
@@ -113,6 +115,12 @@ func (p *phaseTimes) getPlanningLatency() time.Duration {
 // getParsingLatency returns the time it takes for a query to be parsed.
 func (p *phaseTimes) getParsingLatency() time.Duration {
 	return p[sessionEndParse].Sub(p[sessionStartParse])
+}
+
+// getPostCommitJobsLatency returns the time spent running the post transaction
+// commit jobs, such as schema changes.
+func (p *phaseTimes) getPostCommitJobsLatency() time.Duration {
+	return p[sessionEndPostCommitJob].Sub(p[sessionStartPostCommitJob])
 }
 
 func (p *phaseTimes) getTransactionRetryLatency() time.Duration {


### PR DESCRIPTION
See individual commits for details.