### PR TITLE
sql: generalize error message

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -841,7 +841,7 @@ func execStatVar(count int64, n roachpb.NumericStat) tree.Datum {
 // sqlStats object is needed.
 func getSQLStats(p *planner, virtualTableName string) (*sqlStats, error) {
 	if p.extendedEvalCtx.sqlStatsCollector == nil || p.extendedEvalCtx.sqlStatsCollector.sqlStats == nil {
-		return nil, errors.Newf("%s cannot be used in CREATE TABLE AS", virtualTableName)
+		return nil, errors.Newf("%s cannot be used in this context", virtualTableName)
 	}
 	return p.extendedEvalCtx.sqlStatsCollector.sqlStats, nil
 }

--- a/pkg/sql/logictest/testdata/logic_test/create_table
+++ b/pkg/sql/logictest/testdata/logic_test/create_table
@@ -434,11 +434,11 @@ CREATE TABLE error (a INT, b INT, UNIQUE INDEX idx (a), UNIQUE INDEX idx (b))
 # Regression test for using some virtual tables in CREATE TABLE AS which is not
 # supported at the moment (#65512).
 
-query error crdb_internal.node_statement_statistics cannot be used in CREATE TABLE AS
+query error crdb_internal.node_statement_statistics cannot be used in this context
 CREATE TABLE ctas AS (SELECT * FROM crdb_internal.node_statement_statistics);
 
-query error crdb_internal.node_transaction_statistics cannot be used in CREATE TABLE AS
+query error crdb_internal.node_transaction_statistics cannot be used in this context
 CREATE TABLE ctas AS (SELECT * FROM crdb_internal.node_transaction_statistics);
 
-query error crdb_internal.node_txn_stats cannot be used in CREATE TABLE AS
+query error crdb_internal.node_txn_stats cannot be used in this context
 CREATE TABLE ctas AS (SELECT * FROM crdb_internal.node_txn_stats);


### PR DESCRIPTION
This commit generalizes the error message introduced in
03ca31b3cbad90191ead63b6929cbc3bd3c0651f.

Release note: None