### PR TITLE
release-21.1: sql: fix panic in CTAS with some virtual tables

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/create_table
+++ b/pkg/sql/logictest/testdata/logic_test/create_table
@@ -422,3 +422,15 @@ subtest regression_57630
 
 statement error pgcode 42P07 duplicate index name: \"idx\"
 CREATE TABLE error (a INT, b INT, INDEX idx (a), INDEX idx (b))
+
+# Regression test for using some virtual tables in CREATE TABLE AS which is not
+# supported at the moment (#65512).
+
+query error crdb_internal.node_statement_statistics cannot be used in this context
+CREATE TABLE ctas AS (SELECT * FROM crdb_internal.node_statement_statistics);
+
+query error crdb_internal.node_transaction_statistics cannot be used in this context
+CREATE TABLE ctas AS (SELECT * FROM crdb_internal.node_transaction_statistics);
+
+query error crdb_internal.node_txn_stats cannot be used in this context
+CREATE TABLE ctas AS (SELECT * FROM crdb_internal.node_txn_stats);


### PR DESCRIPTION
Note that the two original commits are squashed.

Backport:
  * 1/1 commits from "sql: fix panic in CTAS with some virtual tables" (#65516)
  * 1/1 commits from "sql: generalize error message" (#65537)

CTAS creates a fake planner that doesn't have `sqlStatsCollector` set
(which lives on the `connExecutor`), so the usage of several virtual
tables in CTAS would previously lead to a crash. The proper fix doesn't
appear to be easy, so this commit prohibits the usage of those virtual
tables in CTAS context.

Release note (bug fix): CockroachDB would previously crash when
attempting to create a table using CREATE TABLE ... AS syntax where AS
part selects from `crdb_internal.node_statement_statistics`,
`crdb_internal.node_transaction_statistics`, or
`crdb_internal.node_txn_stats` virtual tables.

/cc @cockroachdb/release
