### PR TITLE
sql: allow references to top-level WITH from apply-join

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/apply_join
+++ b/pkg/sql/logictest/testdata/logic_test/apply_join
@@ -349,8 +349,7 @@ FROM
 	t40589 AS t, t40589;
 ----
 
-# Test that a reasonable error is generated for the unsupported case of an
-# apply join that references a top-level WITH clause.
+# Test that the "inner" plan of an apply join can refer to a top-level WITH clause.
 
 statement ok
 CREATE TABLE IF NOT EXISTS cpk (
@@ -366,17 +365,24 @@ INSERT INTO cpk VALUES ('k1', 1, 1), ('k2', 2, 2), ('k3', 3, 3)
 # Inner join with correlated values prevents decorrelation. This ensures the
 # final plan contains a correlated InnerJoin operator with a reference to the
 # With clause.
-query error references to WITH expressions from correlated subqueries are unsupported
-WITH new_values (k, v, x) AS (
-  VALUES ('k1', 1, 10), ('k3', 3, 30))
+statement ok
+WITH target_values (k, v) AS (
+  VALUES ('k1', 1), ('k3', 3))
 UPDATE cpk SET extra = (
-    SELECT y
-    FROM new_values
+    SELECT y+10
+    FROM target_values
     INNER JOIN (VALUES (cpk.value)) v(y)
     ON TRUE
     WHERE k='k1'
 )
-WHERE ((cpk.key, cpk.value) IN (SELECT new_values.k, new_values.v FROM new_values))
+WHERE ((cpk.key, cpk.value) IN (SELECT target_values.k, target_values.v FROM target_values))
+
+query TII rowsort
+SELECT * FROM cpk
+----
+k1  1  11
+k2  2  2
+k3  3  13
 
 # Regression test for #65040. Rows fetched for the right side of the apply join
 # were not cleared for successive rows on the left, causing a panic.


### PR DESCRIPTION
This change fixes an unsupported case where the "inner" plan of an
apply-join refers to a WITH that is above the apply join. This change
adds support for this case by populating the necessary metadata in the
memo and the execbuilder.

Release note (sql change): references to WITH expressions from
correlated subqueries are now always supported.