### PR TITLE
sysutil: add ProcFDUsage gosigar wrapper

### DIFF
--- a/pkg/server/status/BUILD.bazel
+++ b/pkg/server/status/BUILD.bazel
@@ -61,6 +61,7 @@ go_library(
         "//pkg/util/metric",
         "//pkg/util/syncutil",
         "//pkg/util/system",
+        "//pkg/util/sysutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_dustin_go_humanize//:go-humanize",

--- a/pkg/server/status/runtime.go
+++ b/pkg/server/status/runtime.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/cockroach/pkg/util/sysutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/elastic/gosigar"
 	"github.com/shirou/gopsutil/net"
@@ -452,8 +453,8 @@ func (rsr *RuntimeStatSampler) SampleEnvironment(
 	cgroupCPU, _ := cgroups.GetCgroupCPU()
 	cpuShare := cgroupCPU.CPUShares()
 
-	fds := gosigar.ProcFDUsage{}
-	if err := fds.Get(pid); err != nil {
+	fds := sysutil.ProcFDUsage{}
+	if err := fds.Get(); err != nil {
 		if gosigar.IsNotImplemented(err) {
 			if !rsr.fdUsageNotImplemented {
 				rsr.fdUsageNotImplemented = true

--- a/pkg/util/sysutil/BUILD.bazel
+++ b/pkg/util/sysutil/BUILD.bazel
@@ -3,6 +3,9 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "sysutil",
     srcs = [
+        "fd_usage.go",
+        "fd_usage_darwin.go",
+        "fd_usage_gosigar.go",
         "large_file_linux.go",
         "large_file_naive.go",
         "sysutil.go",
@@ -13,6 +16,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_elastic_gosigar//:gosigar",
     ] + select({
         "@io_bazel_rules_go//go/platform:aix": [
             "@org_golang_x_sys//unix",
@@ -61,6 +65,7 @@ go_test(
     name = "sysutil_test",
     size = "small",
     srcs = [
+        "fd_usage_test.go",
         "large_file_test.go",
         "sysutil_test.go",
         "sysutil_unix_test.go",
@@ -69,6 +74,8 @@ go_test(
     deps = [
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//oserror",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ] + select({
         "@io_bazel_rules_go//go/platform:aix": [
             "@org_golang_x_sys//unix",

--- a/pkg/util/sysutil/fd_usage.go
+++ b/pkg/util/sysutil/fd_usage.go
@@ -1,0 +1,28 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sysutil
+
+// ProcFDUsage is used to retrieve the file descriptor usage of the
+// _current_ process.
+//
+// Its API follows the pattern of the gosigar library.
+//
+//```
+// fdu := &ProcFDUsage{}
+// if err := fdu.Get(); err != nil {
+//    return err
+// }
+//```
+type ProcFDUsage struct {
+	Open      uint64
+	SoftLimit uint64
+	HardLimit uint64
+}

--- a/pkg/util/sysutil/fd_usage_darwin.go
+++ b/pkg/util/sysutil/fd_usage_darwin.go
@@ -1,0 +1,52 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// +build darwin
+
+package sysutil
+
+import (
+	"os"
+	"syscall"
+
+	"github.com/cockroachdb/errors"
+)
+
+// Get populates ProcFDUsage for the current process.
+func (u *ProcFDUsage) Get() error {
+	openFDs, err := getOpenFileDescriptors()
+	if err != nil {
+		return errors.Wrap(err, "listing open file descriptors")
+	}
+
+	var rlim syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rlim); err != nil {
+		return errors.Wrap(err, "getrlimit")
+	}
+
+	u.Open = openFDs
+	u.SoftLimit = rlim.Cur
+	u.HardLimit = rlim.Max
+	return nil
+}
+
+// getOpenFileDescriptors determines the number of open files for the
+// process by counting the number of files in /dev/fd.
+func getOpenFileDescriptors() (uint64, error) {
+	const fdDir = "/dev/fd"
+	f, err := os.Open(fdDir)
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+	// Readdirnames doesn't return . and ..
+	names, err := f.Readdirnames(0 /* limit, 0 is unlimited */)
+	return uint64(len(names)), err
+}

--- a/pkg/util/sysutil/fd_usage_gosigar.go
+++ b/pkg/util/sysutil/fd_usage_gosigar.go
@@ -1,0 +1,35 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// +build !darwin
+
+package sysutil
+
+import (
+	"os"
+
+	"github.com/elastic/gosigar"
+)
+
+// Get populates ProcFDUsage for the current process.
+//
+// This is the default implementation used on most platforms.
+func (u *ProcFDUsage) Get() error {
+	pid := os.Getpid()
+	fds := gosigar.ProcFDUsage{}
+	err := fds.Get(pid)
+	if err != nil {
+		return err
+	}
+	u.Open = fds.Open
+	u.SoftLimit = fds.SoftLimit
+	u.HardLimit = fds.HardLimit
+	return nil
+}

--- a/pkg/util/sysutil/fd_usage_test.go
+++ b/pkg/util/sysutil/fd_usage_test.go
@@ -1,0 +1,37 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sysutil_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/sysutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcFDUsage(t *testing.T) {
+	fdUsage := &sysutil.ProcFDUsage{}
+	require.NoError(t, fdUsage.Get())
+
+	beforeOpen := fdUsage.Open
+	f, err := ioutil.TempFile(t.TempDir(), "test-open-1")
+	require.NoError(t, err)
+	defer f.Close()
+
+	require.NoError(t, fdUsage.Get())
+	assert.Equal(t, beforeOpen+1, fdUsage.Open, "opening file increase Open count")
+
+	require.NoError(t, f.Close())
+	require.NoError(t, fdUsage.Get())
+	assert.Equal(t, beforeOpen, fdUsage.Open, "closing file decreases Open count")
+}


### PR DESCRIPTION
The Gosigar library's ProcFDUsage does not support
macOs/darwin. Fixing this in Gosigar itself may be a bit difficult
because the form of their API:

    func (p *ProcFDUsage) Get(pid int) error

seems to assume that you can get the FDUsage for any process given
sufficient permissions. On MacOS, while you can get the open file
descriptors for other processes (via `proc_pidinfo`), I don't know of
a clean way to get the current rlimit data for another process.

This change wraps the gosigar library and provides an alternate macOS
implementation via build tags.

I've changed the interface to

    func (p *ProcFDUsage) Get() error

to avoid the assumption we can get the usage for another process. This
comes at the expense of another Getpid call.

The macOS implementation uses /dev/fd to count open files and
getrlimit to get the rlimits. We could alternatively use proc_pidinfo
to get the open file count. The only real advantage I know of is that
we would trade 3 system calls (open, read, close) for 2 calls to
proc_pidinfo.

Release note (ops change): File descriptor usage is now tracked on
macOS.