### PR TITLE
lint: githooks to check for documentation

### DIFF
--- a/githooks/commit-msg
+++ b/githooks/commit-msg
@@ -175,3 +175,58 @@ else
     done
     if test -n "$informed"; then echo >&2; fi
 fi
+
+# Lint for the existence of an issue reference, an epic reference or a Docs section
+# describing why the change is being made.
+# TODO: add the correct link for documentation
+# https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/2009039063/DRAFT+Jira+Epic+Ref+GitHub+Issue+Ref+Docs+Note
+
+# All the test cases for the below regex logic is located in `githooks/commit-msg-regex`
+
+ISSUE="[Cc]lose [Cc]loses [Cc]losed [Ff]ix [Ff]ixes [Ff]ixed [Rr]esolve [Rr]esolves [Rr]esolved"
+
+isdocs=`$grep -cE '^[Dd]ocs note:\s' "$1"`
+isepic=`$grep -cE "^[Ee]pic:?\s+[A-Z][A-Z]+-[0-9]+(\s.*)?$" "$1"`
+iskeyphrase1=`$grep -cE "^([Ss]ee also|[Ii]nforms):?\s+#[0-9]+([,\s].*)?$" "$1"`
+iskeyphrase2=`$grep -cE "^([Ss]ee also|[Ii]nforms):?\s+[A-Za-z0-9_.-]+[/][A-Za-z0-9_.-]+#[0-9]+([,\s].*)?$" "$1"`
+
+if [[ $(($isdocs + $isepic + $iskeyphrase1 + $iskeyphrase2)) -eq 0 ]]; then
+    FAILED="yes"
+    for status in $ISSUE; do
+        isissue1=$($grep -cE "^($status):?\s+#[0-9]+([\s,].*)?$" "$1")
+        # Only check for valid github usernames, repo and org name characters
+        # https://stackoverflow.com/questions/59081778/rules-for-special-characters-in-github-repository-name
+        isissue2=$($grep -cE "^($status):?\s+[A-Za-z0-9_.-]+[/][A-Za-z0-9_.-]+#[[0-9]+([\s,].*)?$" "$1")
+        if [[ $isissue1 -ne 0 || $isissue2 -ne 0 ]]; then
+            FAILED="no"
+            break
+        fi
+    done
+    if [ "$FAILED" == "yes" ]; then
+        warn "Missing one of: issue reference, epic reference, Docs note"
+        echo "Try one of these:" >&2
+        echo >&2
+        echo "  Fixes #12345" >&2
+        echo "  Epic CRDB-12345" >&2
+        echo "  See also: #62585" >&2
+        echo "  Docs note: This change is being made because ..." >&2
+        echo >&2
+    fi
+fi
+
+# Check for unchanged template docs note from githooks/prepare-commit-msg and
+# alert the user if it is present in the message.
+
+if $grep -qcE '^[Dd]ocs note:\s<why>' "$1" ; then
+    warn "Warning: malformed Docs note: <why>"
+    echo "Try:" >&2
+    echo  >&2
+    echo "  Docs note: This change is being made because ...">&2
+    echo >&2
+    echo "Or one of these:" >&2
+    echo >&2
+    echo "  Epic CRDB-123" >&2
+    echo "  Fixes #123" >&2
+    echo "  See also: #123" >&2
+    echo >&2
+fi

--- a/githooks/commit-msg-regex/isdocs/fail_test.txt
+++ b/githooks/commit-msg-regex/isdocs/fail_test.txt
@@ -1,0 +1,4 @@
+FAIL
+
+
+Release note: none

--- a/githooks/commit-msg-regex/isdocs/pass_test.txt
+++ b/githooks/commit-msg-regex/isdocs/pass_test.txt
@@ -1,0 +1,8 @@
+roachprod: change X to Y
+
+Notes on before, why, now...
+
+docs note: Passing test
+
+
+Release note: none

--- a/githooks/commit-msg-regex/isepic/fail_test1.txt
+++ b/githooks/commit-msg-regex/isepic/fail_test1.txt
@@ -1,0 +1,4 @@
+Epic:CRDB-4820323232323232
+
+
+Release note: none

--- a/githooks/commit-msg-regex/isepic/fail_test2.txt
+++ b/githooks/commit-msg-regex/isepic/fail_test2.txt
@@ -1,0 +1,3 @@
+epic:  CRDB-4802asdf
+
+Release note: none

--- a/githooks/commit-msg-regex/isepic/pass_test1.txt
+++ b/githooks/commit-msg-regex/isepic/pass_test1.txt
@@ -1,0 +1,8 @@
+roachprod: change X to Y
+
+Notes on before, why, now...
+
+epic CRDB-31
+
+
+Release note: none

--- a/githooks/commit-msg-regex/isepic/pass_test2.txt
+++ b/githooks/commit-msg-regex/isepic/pass_test2.txt
@@ -1,0 +1,8 @@
+roachprod: change X to Y
+
+Notes on before, why, now...
+
+Epic:   	CRDB-4810   
+
+
+Release note: none

--- a/githooks/commit-msg-regex/isissue1/fail_test1.txt
+++ b/githooks/commit-msg-regex/isissue1/fail_test1.txt
@@ -1,0 +1,4 @@
+Fixes: 434343, #4444
+
+
+Release note: none

--- a/githooks/commit-msg-regex/isissue1/fail_test2.txt
+++ b/githooks/commit-msg-regex/isissue1/fail_test2.txt
@@ -1,0 +1,4 @@
+Fixes: #434343-
+
+
+Release note: none

--- a/githooks/commit-msg-regex/isissue1/pass_test1.txt
+++ b/githooks/commit-msg-regex/isissue1/pass_test1.txt
@@ -1,0 +1,8 @@
+roachprod: change X to Y
+
+Notes on before, why, now...
+
+Fixes: #434343, #4444
+
+
+Release note: none

--- a/githooks/commit-msg-regex/isissue1/pass_test2.txt
+++ b/githooks/commit-msg-regex/isissue1/pass_test2.txt
@@ -1,0 +1,8 @@
+roachprod: change X to Y
+
+Notes on before, why, now...
+
+Resolved: #434343, #4444, #43434
+
+
+Release note: none

--- a/githooks/commit-msg-regex/isissue1/pass_test3.txt
+++ b/githooks/commit-msg-regex/isissue1/pass_test3.txt
@@ -1,0 +1,8 @@
+roachprod: change X to Y
+
+Notes on before, why, now...
+
+close: #434343
+
+
+Release note: none

--- a/githooks/commit-msg-regex/isissue1/pass_test4.txt
+++ b/githooks/commit-msg-regex/isissue1/pass_test4.txt
@@ -1,0 +1,8 @@
+roachprod: change X to Y
+
+Notes on before, why, now...
+
+fix: #434343, #4444, #4343jj
+
+
+Release note: none

--- a/githooks/commit-msg-regex/isissue1/pass_test5.txt
+++ b/githooks/commit-msg-regex/isissue1/pass_test5.txt
@@ -1,0 +1,8 @@
+roachprod: change X to Y
+
+Notes on before, why, now...
+
+Resolve: #434343, #4444, eeee
+
+
+Release note: none

--- a/githooks/commit-msg-regex/isissue1/pass_test6.txt
+++ b/githooks/commit-msg-regex/isissue1/pass_test6.txt
@@ -1,0 +1,8 @@
+roachprod: change X to Y
+
+Notes on before, why, now...
+
+Closes: #434343, #4444,#4343
+
+
+Release note: none

--- a/githooks/commit-msg-regex/isissue2/fail_test1.txt
+++ b/githooks/commit-msg-regex/isissue2/fail_test1.txt
@@ -1,0 +1,4 @@
+Fixes: test#2212
+
+
+Release note: none

--- a/githooks/commit-msg-regex/isissue2/fail_test2.txt
+++ b/githooks/commit-msg-regex/isissue2/fail_test2.txt
@@ -1,0 +1,4 @@
+Fixes #323232-
+
+
+Release note: none

--- a/githooks/commit-msg-regex/isissue2/pass_test1.txt
+++ b/githooks/commit-msg-regex/isissue2/pass_test1.txt
@@ -1,0 +1,8 @@
+roachprod: change X to Y
+
+Notes on before, why, now...
+
+Fixes: test/test#2212
+
+
+Release note: none

--- a/githooks/commit-msg-regex/isissue2/pass_test2.txt
+++ b/githooks/commit-msg-regex/isissue2/pass_test2.txt
@@ -1,0 +1,8 @@
+roachprod: change X to Y
+
+Notes on before, why, now...
+
+Fixes: test/test#2212, test1/test1#43343
+
+
+Release note: none

--- a/githooks/commit-msg-regex/isissue2/pass_test3.txt
+++ b/githooks/commit-msg-regex/isissue2/pass_test3.txt
@@ -1,0 +1,8 @@
+roachprod: change X to Y
+
+Notes on before, why, now...
+
+Closed: test/test#2212,test1/test1#4343
+
+
+Release note: none

--- a/githooks/commit-msg-regex/isissue2/pass_test4.txt
+++ b/githooks/commit-msg-regex/isissue2/pass_test4.txt
@@ -1,0 +1,8 @@
+roachprod: change X to Y
+
+Notes on before, why, now...
+
+Fixed: test/test#2212,test1/test1#4343
+
+
+Release note: none

--- a/githooks/commit-msg-regex/isissue2/pass_test5.txt
+++ b/githooks/commit-msg-regex/isissue2/pass_test5.txt
@@ -1,0 +1,8 @@
+roachprod: change X to Y
+
+Notes on before, why, now...
+
+Resolves: test/test#32323, #323232
+
+
+Release note: none

--- a/githooks/commit-msg-regex/iskeyphrase1/fail_test1.txt
+++ b/githooks/commit-msg-regex/iskeyphrase1/fail_test1.txt
@@ -1,0 +1,4 @@
+see also #3333h
+
+
+Release note: none

--- a/githooks/commit-msg-regex/iskeyphrase1/fail_test2.txt
+++ b/githooks/commit-msg-regex/iskeyphrase1/fail_test2.txt
@@ -1,0 +1,3 @@
+informs #333h
+
+Release note: none

--- a/githooks/commit-msg-regex/iskeyphrase1/pass_test1.txt
+++ b/githooks/commit-msg-regex/iskeyphrase1/pass_test1.txt
@@ -1,0 +1,8 @@
+roachprod: change X to Y
+
+Notes on before, why, now...
+
+See also: #323234
+
+
+Release note: none

--- a/githooks/commit-msg-regex/iskeyphrase1/pass_test2.txt
+++ b/githooks/commit-msg-regex/iskeyphrase1/pass_test2.txt
@@ -1,0 +1,8 @@
+roachprod: change X to Y
+
+Notes on before, why, now...
+
+see also: #323234
+
+
+Release note: none

--- a/githooks/commit-msg-regex/iskeyphrase1/pass_test3.txt
+++ b/githooks/commit-msg-regex/iskeyphrase1/pass_test3.txt
@@ -1,0 +1,7 @@
+roachprod: change X to Y
+
+Notes on before, why, now...
+
+See also: #323234, #3333, #434343
+
+Release note: none

--- a/githooks/commit-msg-regex/iskeyphrase1/pass_test4.txt
+++ b/githooks/commit-msg-regex/iskeyphrase1/pass_test4.txt
@@ -1,0 +1,8 @@
+roachprod: change X to Y
+
+Notes on before, why, now...
+
+Informs: #3434343
+
+
+Release note: none

--- a/githooks/commit-msg-regex/iskeyphrase1/pass_test5.txt
+++ b/githooks/commit-msg-regex/iskeyphrase1/pass_test5.txt
@@ -1,0 +1,8 @@
+roachprod: change X to Y
+
+Notes on before, why, now...
+
+informs: #3434343
+
+
+Release note: none

--- a/githooks/commit-msg-regex/iskeyphrase1/pass_test6.txt
+++ b/githooks/commit-msg-regex/iskeyphrase1/pass_test6.txt
@@ -1,0 +1,8 @@
+roachprod: change X to Y
+
+Notes on before, why, now...
+
+Informs: #3434343, #434343, #4444
+
+
+Release note: none

--- a/githooks/commit-msg-regex/iskeyphrase1/pass_test7.txt
+++ b/githooks/commit-msg-regex/iskeyphrase1/pass_test7.txt
@@ -1,0 +1,8 @@
+roachprod: change X to Y
+
+Notes on before, why, now...
+
+informs: #2322, 34343
+
+
+Release note: none

--- a/githooks/commit-msg-regex/iskeyphrase1/pass_test8.txt
+++ b/githooks/commit-msg-regex/iskeyphrase1/pass_test8.txt
@@ -1,0 +1,8 @@
+roachprod: change X to Y
+
+Notes on before, why, now...
+
+see also: #434343, 3333
+
+
+Release note: none

--- a/githooks/commit-msg-regex/iskeyphrase2/fail_test1.txt
+++ b/githooks/commit-msg-regex/iskeyphrase2/fail_test1.txt
@@ -1,0 +1,3 @@
+informs:test/test#3232,test1/test1#5454
+
+Release note: none

--- a/githooks/commit-msg-regex/iskeyphrase2/fail_test2.txt
+++ b/githooks/commit-msg-regex/iskeyphrase2/fail_test2.txt
@@ -1,0 +1,3 @@
+informs: test/test
+
+Release note: none

--- a/githooks/commit-msg-regex/iskeyphrase2/pass_test1.txt
+++ b/githooks/commit-msg-regex/iskeyphrase2/pass_test1.txt
@@ -1,0 +1,8 @@
+roachprod: change X to Y
+
+Notes on before, why, now...
+
+Informs: test/test#3232
+
+
+Release note: none

--- a/githooks/commit-msg-regex/iskeyphrase2/pass_test2.txt
+++ b/githooks/commit-msg-regex/iskeyphrase2/pass_test2.txt
@@ -1,0 +1,8 @@
+roachprod: change X to Y
+
+Notes on before, why, now...
+
+informs: test/test#3232, #43433
+
+
+Release note: none

--- a/githooks/commit-msg-regex/iskeyphrase2/pass_test3.txt
+++ b/githooks/commit-msg-regex/iskeyphrase2/pass_test3.txt
@@ -1,0 +1,7 @@
+roachprod: change X to Y
+
+Notes on before, why, now...
+
+informs: test/test#3232, test1/test1#5454
+
+Release note: none

--- a/githooks/commit-msg-regex/iskeyphrase2/pass_test4.txt
+++ b/githooks/commit-msg-regex/iskeyphrase2/pass_test4.txt
@@ -1,0 +1,7 @@
+roachprod: change X to Y
+
+Notes on before, why, now...
+
+informs:    test/test#3232,    test1/test1#5454
+
+Release note: none

--- a/githooks/commit-msg-regex/iskeyphrase2/pass_test5.txt
+++ b/githooks/commit-msg-regex/iskeyphrase2/pass_test5.txt
@@ -1,0 +1,8 @@
+roachprod: change X to Y
+
+Notes on before, why, now...
+
+see also:    test/test#3232,    test2/test2#5454, test3/test3#5454
+
+
+Release note: none

--- a/githooks/commit-msg-regex/regex_test.sh
+++ b/githooks/commit-msg-regex/regex_test.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+#
+# -u: we want the variables to be properly assigned.
+# -o pipefail: we want to test the result of pipes.
+set -euo pipefail
+
+# Trap to ensure files are getting deleted
+remove_files_on_exit() {
+  rm -f out-test.txt common_fail_message.txt
+}
+trap remove_files_on_exit EXIT
+
+# Creating common error file
+
+TEXT='''
+Missing one of: issue reference, epic reference, Docs note
+
+Try one of these:
+
+  Fixes #12345
+  Epic CRDB-12345
+  See also: #62585
+  Docs note: This change is being made because ...
+'''
+
+tmpfile=$(mktemp common_fail_message.txt)
+
+root=$(cd "$(dirname "$0")/.." && pwd)
+
+echo "$root"
+
+echo "$TEXT" > "$tmpfile" 
+
+red=$([ -t 2 ] && { tput setaf 1 || tput AF 1; } 2>/dev/null)
+reset=$([ -t 2 ] && { tput sgr0 || tput me; } 2>/dev/null)
+warn() {
+    echo >&2
+    echo "${red}$*${reset}" >&2
+    echo >&2
+}
+
+green=$([ -t 2 ] && { tput setaf 2 || tput AF 2; } 2>/dev/null)
+reset=$([ -t 2 ] && { tput sgr0 || tput me; } 2>/dev/null)
+testing() {
+    echo >&2
+    echo "${green}$*${reset}" >&2
+    echo >&2
+}
+
+PositiveTest() {
+    # $1 Name of the file
+    # $2 Name of the test
+    # $3 String that you are testing it
+    $root/commit-msg $1 > out_test.txt 2>&1
+    if [ -s out_test.txt ]; then
+        warn "$2 test is failed, files not matching"
+        echo "'$3' string is failing"
+        PASS="FALSE"
+    fi
+}
+
+NegativeTest() {
+    # $1 Name of the file
+    # $2 Name of the test
+    # $3 String that you are testing it
+    $root/commit-msg $1 > out_test.txt 2>&1
+    if ! cmp -s "$tmpfile" out_test.txt; then
+        warn "$2 test is failed, files not matching"
+        echo "'$3' is failing"
+        PASS="FALSE"
+    fi
+}
+
+PASS="TRUE"
+
+testing "Testing: 'isdocs'"
+# Positive test
+PositiveTest isdocs/pass_test.txt "isdocs" "docs note: Passing test"
+
+# Negative test
+NegativeTest isdocs/fail_test.txt "isdocs" "FAIL"
+
+
+testing "Testing: 'isepic'"
+# Positive tests
+PositiveTest isepic/pass_test1.txt "isdocs" "epic CRDB-31"
+PositiveTest isepic/pass_test2.txt "isdocs" "Epic:    CRDB-4810   "
+
+# # Negative tests
+NegativeTest isepic/fail_test1.txt "isdocs" "Epic:CRDB-4820323232323232"
+NegativeTest isepic/fail_test2.txt "isdocs" "epic:  CRDB-4802asdf"
+
+
+testing "Testing: 'iskeyphrase1'"
+# Positive tests
+PositiveTest iskeyphrase1/pass_test1.txt "iskeyphrase1" "See also: #323234"
+PositiveTest iskeyphrase1/pass_test2.txt "iskeyphrase1" "see also: #323234"
+PositiveTest iskeyphrase1/pass_test3.txt "iskeyphrase1" "See also: #323234, #3333, #434343"
+PositiveTest iskeyphrase1/pass_test4.txt "iskeyphrase1" "Informs: #3434343"
+PositiveTest iskeyphrase1/pass_test5.txt "iskeyphrase1" "informs: #3434343"
+PositiveTest iskeyphrase1/pass_test6.txt "iskeyphrase1" "Informs: #3434343, #434343, #4444"
+PositiveTest iskeyphrase1/pass_test7.txt "iskeyphrase1" "informs: #2322, 34343"
+PositiveTest iskeyphrase1/pass_test8.txt "iskeyphrase1" "see also: #434343, 3333"
+
+# Negative tests
+NegativeTest iskeyphrase1/fail_test1.txt "iskeyphrase1" "see also #3333h"
+NegativeTest iskeyphrase1/fail_test2.txt "iskeyphrase1" "informs #333h"
+
+
+testing "Testing: 'iskeyphrase2'"
+# Positive tests
+PositiveTest iskeyphrase2/pass_test1.txt "iskeyphrase2" "Informs: test/test#3232"
+PositiveTest iskeyphrase2/pass_test2.txt "iskeyphrase2" "informs: test/test#3232, #43433"
+PositiveTest iskeyphrase2/pass_test3.txt "iskeyphrase2" "informs: test/test#3232, test1/test1#5454"
+PositiveTest iskeyphrase2/pass_test4.txt "iskeyphrase2" "informs:    test/test#3232,    test1/test1#5454"
+PositiveTest iskeyphrase2/pass_test5.txt "iskeyphrase2" "see also:    test/test#3232,    test2/test2#5454, test3/test3#5454"
+
+# Negative tests
+NegativeTest iskeyphrase2/fail_test1.txt "iskeyphrase2" "informs:test/test#3232,test1/test1#5454"
+NegativeTest iskeyphrase2/fail_test2.txt "iskeyphrase2" "informs: test/test"
+
+
+testing "Testing: 'isissue1'"
+# Positive tests
+PositiveTest isissue1/pass_test1.txt "isissue1" "Fixes: #434343, #4444"
+PositiveTest isissue1/pass_test2.txt "isissue1" "Resolved: #434343, #4444, #43434"
+PositiveTest isissue1/pass_test3.txt "isissue1" "close: #434343"
+PositiveTest isissue1/pass_test4.txt "isissue1" "fix: #434343, #4444, #4343jj"
+PositiveTest isissue1/pass_test5.txt "isissue1" "Resolve: #434343, #4444, eeee"
+PositiveTest isissue1/pass_test6.txt "isissue1" "Closes: #434343, #4444,#4343"
+
+# Negative tests
+NegativeTest isissue1/fail_test1.txt "isissue1" "Fixes: 434343, #4444"
+NegativeTest isissue1/fail_test2.txt "isissue1" "Fixes: #434343-"
+
+
+testing "Testing: 'isissue2'"
+# Positive tests
+PositiveTest isissue2/pass_test1.txt "isissue2" "Fixes: test/test#2212"
+PositiveTest isissue2/pass_test2.txt "isissue2" "Fixes: test/test#2212, test1/test1#43343"
+PositiveTest isissue2/pass_test3.txt "isissue2" "Closed: test/test#2212,test1/test1#4343"
+PositiveTest isissue2/pass_test4.txt "isissue2" "Fixed: test/test#2212,test1/test1#4343"
+PositiveTest isissue2/pass_test5.txt "isissue2" "Resolves: test/test#32323, #323232"
+
+# Negative tests
+NegativeTest isissue2/fail_test1.txt "isissue2" "Fixes: 434343, #4444"
+NegativeTest isissue2/fail_test2.txt "isissue2" "Fixes #323232-"
+
+# Removing dummy out file and commit message
+rm out_test.txt
+rm "$tmpfile"
+
+# Final review
+if [ "$PASS" == "FALSE" ]; then
+    warn "Some of the tests failed. Please review the test output."
+    exit 1
+fi

--- a/githooks/prepare-commit-msg
+++ b/githooks/prepare-commit-msg
@@ -72,6 +72,19 @@ $cchar Note: to disable this commit template, run: git config --global --add coc
 	fi
 fi
 
+# Add an explicit "Docs note: <why>" if no epic ref, issue ref or docs note
+# specified.
+docs_note_regex='^([Dd]ocs note|[Ee]pic|[Ss]ee also|[Ii]nforms|[Cc]lose|[Cc]loses|[Cc]losed|[Ff]ix|[Ff]ixes|[Ff]ixed|[Rr]esolve|[Rr]esolves|[Rr]esolved):?\s'
+if ! grep -Eq "$docs_note_regex" "$1" ; then
+    sed_script+="/$cchar Please enter the commit message for your changes./i\\
+$cchar The 'Docs note:' section can be removed if an epic or issue is\\
+$cchar referenced elsewhere.\\
+${tchar}Docs note: <why>\\
+
+;
+"
+fi
+
 # Add an explicit "Release note: None" if no release note was specified.
 if ! grep -q '^Release note' "$1"; then
 	sed_script+="/$cchar Please enter the commit message for your changes./i\\
@@ -101,6 +114,8 @@ $cchar     <what was there before: Previously, ...>\\
 $cchar     <why it needed to change: This was inadequate because ...>\\
 $cchar     <what you did about it: To address this, this patch ...>\\
 $cchar\\
+$cchar     Epic: CRDB-123\\
+$cchar\\
 $cchar     Release note (<category>): <what> <show> <why>\\
 $cchar     ---\\
 $cchar\\
@@ -120,8 +135,22 @@ $cchar\\
 "
 fi
 
-sed_script+="$cchar The release note must be present if your commit has user-facing\\
+sed_script+="$cchar An epic reference, an issue reference or the docs note section must be\\
+$cchar present. When using 'Release note: None', you may use 'Docs note: None'.\\
+$cchar\\
+$cchar The release note must be present if your commit has user-facing\\
 $cchar or backward-incompatible changes. Use 'Release note: None' otherwise.\\
+$cchar\\
+$cchar Things to keep in mind for epic refs, issue refs and docs notes:\\
+$cchar   - epic refs or issue refs to issues containing an epic link in the\\
+$cchar     body are preferred\\
+$cchar   - when no epic exists for the commit, use the docs note or referenced\\
+$cchar     issue to explain why the change / what motivated the change. Include\\
+$cchar     enough detail for writers to understand the context for the change.\\
+$cchar   - epic ref format: '[Ee]pic:? CRDB-123'\\
+$cchar   - issue ref format: 'Fixes:? #123' or 'See also:? #123, #456'\\
+$cchar\\
+$cchar See also: https://wiki.crdb.io/wiki/spaces/CRDB/pages/2009039063/\\
 $cchar\\
 $cchar Things to keep in mind for release notes:\\
 $cchar   - past tense (this was changed...) or present tense (now possible to...)\\


### PR DESCRIPTION
Fixes #64909

The purpose of this linter is to provide information to the Docs team about why a commit was made. This can be a reference to an epic, a reference to an issue or via free-form text describing why the change was necessary. The Docs team will use this information to determine if the change requires changes to any documentation.

For more information about commit documentation please refer to:
    https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/2009039063/DRAFT+Jira+Epic+Ref+GitHub+Issue+Ref+Docs+Note

Release note: None