### PR TITLE
bazel: prevent a spurious diff

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -35,6 +35,7 @@ load("@bazel_gazelle//:def.bzl", "gazelle")
 # gazelle:resolve proto go google/api/annotations.proto @org_golang_google_genproto//googleapis/api/annotations:go_default_library
 # gazelle:resolve proto prometheus/client_model/metrics.proto @com_github_prometheus_client_model//:client_proto
 # gazelle:resolve proto go prometheus/client_model/metrics.proto @com_github_prometheus_client_model//go
+# gazelle:resolve go github.com/prometheus/client_model/go @com_github_prometheus_client_model//go
 
 # See pkg/roachpb/gen/BUILD.bazel for more details.
 #


### PR DESCRIPTION
Fixes #65569.

Because the way the prometheus proto package is imported, and in
combination with a bug inside gazelle, the resolved dependency for
packages that depend on `github.com/prometheus/client_model/go`
is relative to `_bazel` by default. This is incorrect.

This patch alleviates this by overriding the dependency resolution
with an explicit directive.

Release note: None