### PR TITLE
bazel: mark `kvserver` test as `exclusive`

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -286,6 +286,7 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":kvserver"],
     shard_count = 16,
+    tags = ["exclusive"],
     deps = [
         "//pkg/base",
         "//pkg/cli/exit",

--- a/pkg/kv/kvserver/intent_resolver_integration_test.go
+++ b/pkg/kv/kvserver/intent_resolver_integration_test.go
@@ -187,7 +187,6 @@ func TestRollbackSyncRangedIntentResolution(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	skip.UnderRace(t, "timing-sensitive test")
-	skip.UnderBazelWithIssue(t, 65407, "times out due to high concurrency")
 
 	ctx := context.Background()
 	srv, _, _ := serverutils.StartServer(t, base.TestServerArgs{


### PR DESCRIPTION
This tag tells Bazel the test shouldn't be run at the same time as any
other build or test tasks, which solves a problem where timing-sensitive
tests will sometimes spuriously time out.

Ref: https://docs.bazel.build/versions/master/be/common-definitions.html

Closes #65407.
Release note: None