### PR TITLE
stmtdiagnostics: remove unused JSON trace datum

### DIFF
--- a/pkg/sql/stmtdiagnostics/statement_diagnostics.go
+++ b/pkg/sql/stmtdiagnostics/statement_diagnostics.go
@@ -333,7 +333,6 @@ func (r *Registry) InsertStatementDiagnostics(
 	requestID RequestID,
 	stmtFingerprint string,
 	stmt string,
-	traceJSON tree.Datum,
 	bundle []byte,
 	collectionErr error,
 ) (CollectedInstanceID, error) {


### PR DESCRIPTION
In 2d05a54 we stopped writing JSON
trace datums to the system table, but some remnants of that work still
remained. This commit cleans that up.

Release note: None