### PR TITLE
workload/tpcc: add multiregion TPC-C setup

### DIFF
--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -36,6 +36,8 @@ cockroachdb/geospatial:
   triage_column_id: 9487269
 cockroachdb/dev-inf:
   triage_column_id: 10210759
+cockroachdb/multiregion:
+  triage_column_id: 11926170
 cockroachdb/storage:
   triage_column_id: 6668367
 cockroachdb/test-eng:

--- a/pkg/cmd/roachtest/test_registry.go
+++ b/pkg/cmd/roachtest/test_registry.go
@@ -34,6 +34,7 @@ const (
 	OwnerBulkIO        Owner = `bulk-io`
 	OwnerCDC           Owner = `cdc`
 	OwnerKV            Owner = `kv`
+	OwnerMultiRegion   Owner = `multiregion`
 	OwnerServer        Owner = `server`
 	OwnerSQLQueries    Owner = `sql-queries`
 	OwnerSQLSchema     Owner = `sql-schema`

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -349,6 +349,53 @@ func registerTPCC(r *testRegistry) {
 		},
 	})
 
+	for _, survivalGoal := range []string{"zone", "region"} {
+		zs := []string{
+			"us-east1-b", "us-west1-b", "europe-west2-b",
+		}
+		regions := []string{
+			"us-east1",
+			"us-west1",
+			"europe-west2",
+		}
+		r.Add(testSpec{
+			Name:       fmt.Sprintf("tpcc/multiregion/survive=%s/chaos=true", survivalGoal),
+			Owner:      OwnerMultiRegion,
+			MinVersion: "v21.1.0",
+			// 3 nodes per region + 1 node for workload.
+			Cluster: makeClusterSpec(10, geo(), zones(strings.Join(zs, ","))),
+			Run: func(ctx context.Context, t *test, c *cluster) {
+				duration := 90 * time.Minute
+				partitionArgs := fmt.Sprintf(
+					`--survival-goal=%s --regions=%s --partitions=%d`,
+					survivalGoal,
+					strings.Join(regions, ","),
+					len(regions),
+				)
+				// TODO(#multiregion): setup workload to run specifically for a given partition
+				// on each node of a cluster, instead of one node using a workload on all clusters.
+				runTPCC(ctx, t, c, tpccOptions{
+					Warehouses:     len(regions) * 5,
+					Duration:       duration,
+					ExtraSetupArgs: partitionArgs,
+					ExtraRunArgs:   `--method=simple --wait=false --tolerate-errors ` + partitionArgs,
+					Chaos: func() Chaos {
+						return Chaos{
+							Timer: Periodic{
+								Period:   300 * time.Second,
+								DownTime: 300 * time.Second,
+							},
+							Target:       func() nodeListOption { return c.Node(1 + rand.Intn(c.spec.NodeCount-1)) },
+							Stopper:      time.After(duration),
+							DrainAndQuit: false,
+						}
+					},
+					SetupType: usingInit,
+				})
+			},
+		})
+	}
+
 	r.Add(testSpec{
 		Name:       "tpcc/w=100/nodes=3/chaos=true",
 		Owner:      OwnerKV,

--- a/pkg/workload/tpcc/ddls.go
+++ b/pkg/workload/tpcc/ddls.go
@@ -13,6 +13,7 @@ package tpcc
 import (
 	gosql "database/sql"
 	"fmt"
+	"strings"
 
 	"github.com/cockroachdb/errors"
 	"golang.org/x/sync/errgroup"
@@ -30,7 +31,7 @@ const (
 		w_zip       char(9)       not null,
 		w_tax       decimal(4,4)  not null,
 		w_ytd       decimal(12,2) not null`
-	tpccWarehouseColumnFamiliesSuffix = `, 
+	tpccWarehouseColumnFamiliesSuffix = `
 		family      f1 (w_id, w_name, w_street_1, w_street_2, w_city, w_state, w_zip, w_ytd),
 		family      f2 (w_tax)`
 
@@ -48,7 +49,7 @@ const (
 		d_ytd        decimal(12,2) not null,
 		d_next_o_id  integer       not null,
 		primary key  (d_w_id, d_id)`
-	tpccDistrictColumnFamiliesSuffix = `,
+	tpccDistrictColumnFamiliesSuffix = `
 		family       static    (d_w_id, d_id, d_name, d_street_1, d_street_2, d_city, d_state, d_zip),
 		family       dynamic_1 (d_ytd),
 		family       dynamic_2 (d_next_o_id, d_tax)`
@@ -80,7 +81,7 @@ const (
 		c_data         varchar(500)  not null,
 		primary key        (c_w_id, c_d_id, c_id),
 		index customer_idx (c_w_id, c_d_id, c_last, c_first)`
-	tpccCustomerColumnFamiliesSuffix = `, 
+	tpccCustomerColumnFamiliesSuffix = `
 		family static      (
 			c_id, c_d_id, c_w_id, c_first, c_middle, c_last, c_street_1, c_street_2,
 			c_city, c_state, c_zip, c_phone, c_since, c_credit, c_credit_lim, c_discount
@@ -117,7 +118,7 @@ const (
 		o_all_local  integer,
 		primary key  (o_w_id, o_d_id, o_id DESC),
 		unique index order_idx (o_w_id, o_d_id, o_c_id, o_id DESC) storing (o_entry_d, o_carrier_id)
-	)`
+	`
 	tpccOrderSchemaInterleaveSuffix = `
 		interleave in parent district (o_w_id, o_d_id)`
 
@@ -127,7 +128,7 @@ const (
 		no_d_id  integer   not null,
 		no_w_id  integer   not null,
 		primary key (no_w_id, no_d_id, no_o_id)
-	)`
+	`
 	// This natural-seeming interleave makes performance worse, because this
 	// table has a ton of churn and produces a lot of MVCC tombstones, which
 	// then will gum up the works of scans over the parent table.
@@ -142,7 +143,7 @@ const (
 		i_price  decimal(5,2),
 		i_data   varchar(50),
 		primary key (i_id)
-	)`
+	`
 
 	// STOCK table.
 	tpccStockSchemaBase = `(
@@ -187,28 +188,97 @@ const (
 	tpccOrderLineSchemaInterleaveSuffix = `
 		interleave in parent "order" (ol_w_id, ol_d_id, ol_o_id)`
 
+	localityRegionalByRowSuffix = `
+		locality regional by row`
+	localityGlobalSuffix = `
+		locality global`
+
 	endSchema = "\n\t)"
 )
 
-func maybeAddFkSuffix(fks bool, base, suffix string) string {
-	if !fks {
-		return base + endSchema
-	}
-	return base + "," + suffix + endSchema
+type schemaOptions struct {
+	fkClause         string
+	familyClause     string
+	columnClause     string
+	localityClause   string
+	interleaveClause string
 }
 
-func maybeAddColumnFamiliesSuffix(separateColumnFamilies bool, base, suffix string) string {
-	if !separateColumnFamilies {
-		return base + endSchema
+type makeSchemaOption func(o *schemaOptions)
+
+func maybeAddFkSuffix(fks bool, suffix string) makeSchemaOption {
+	return func(o *schemaOptions) {
+		if fks {
+			o.fkClause = suffix
+		}
 	}
-	return base + suffix + endSchema
 }
 
-func maybeAddInterleaveSuffix(interleave bool, base, suffix string) string {
-	if !interleave {
-		return base
+func maybeAddColumnFamiliesSuffix(separateColumnFamilies bool, suffix string) makeSchemaOption {
+	return func(o *schemaOptions) {
+		if separateColumnFamilies {
+			o.familyClause = suffix
+		}
 	}
-	return base + suffix
+}
+
+func maybeAddInterleaveSuffix(interleave bool, suffix string) makeSchemaOption {
+	return func(o *schemaOptions) {
+		if interleave {
+			o.interleaveClause = suffix
+		}
+	}
+}
+
+func maybeAddLocalityRegionalByRow(
+	multiRegionCfg multiRegionConfig, partColName string,
+) makeSchemaOption {
+	return func(o *schemaOptions) {
+		if len(multiRegionCfg.regions) > 0 {
+			// We mod the ID by the number of partitions.
+			// This gives an even distribution of rows in each region.
+			// Note new regions being added after initialization time
+			// will not automatically have any data in its partitions.
+			var b strings.Builder
+			fmt.Fprintf(&b, `
+               crdb_region crdb_internal_region NOT VISIBLE NOT NULL AS (
+                       CASE %s %% %d`, partColName, len(multiRegionCfg.regions))
+			for i, region := range multiRegionCfg.regions {
+				fmt.Fprintf(&b, `
+                       WHEN %d THEN '%s'`, i, region)
+			}
+			b.WriteString(`
+                       END
+               ) STORED`)
+			o.columnClause = b.String()
+			o.localityClause = localityRegionalByRowSuffix
+		}
+	}
+}
+
+func makeSchema(base string, opts ...makeSchemaOption) string {
+	var o schemaOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
+	ret := base
+	if o.fkClause != "" {
+		ret += "," + o.fkClause
+	}
+	if o.familyClause != "" {
+		ret += "," + o.familyClause
+	}
+	if o.columnClause != "" {
+		ret += "," + o.columnClause
+	}
+	if o.interleaveClause != "" {
+		ret += "," + o.interleaveClause
+	}
+	ret += endSchema
+	if o.localityClause != "" {
+		ret += o.localityClause
+	}
+	return ret
 }
 
 func scatterRanges(db *gosql.DB) error {

--- a/pkg/workload/tpcc/partition.go
+++ b/pkg/workload/tpcc/partition.go
@@ -116,6 +116,47 @@ type zoneConfig struct {
 	strategy partitionStrategy
 }
 
+type survivalGoal int
+
+const (
+	survivalGoalZone survivalGoal = iota
+	survivalGoalRegion
+)
+
+// Part of pflag's Value interface.
+func (s survivalGoal) String() string {
+	switch s {
+	case survivalGoalZone:
+		return "zone"
+	case survivalGoalRegion:
+		return "region"
+	}
+	panic("unexpected")
+}
+
+// Part of pflag's Value interface.
+func (s *survivalGoal) Set(value string) error {
+	switch value {
+	case "zone":
+		*s = survivalGoalZone
+	case "region":
+		*s = survivalGoalRegion
+	default:
+		return errors.Errorf("unknown survival goal %q", value)
+	}
+	return nil
+}
+
+// Part of pflag's Value interface.
+func (s survivalGoal) Type() string {
+	return "survival_goal"
+}
+
+type multiRegionConfig struct {
+	regions      []string
+	survivalGoal survivalGoal
+}
+
 // partitioner encapsulates all logic related to partitioning discrete numbers
 // of warehouses into disjoint sets of roughly equal sizes. Partitions are then
 // evenly assigned "active" warehouses, which allows for an even split of live

--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -77,6 +77,7 @@ type tpcc struct {
 	affinityPartitions []int
 	wPart              *partitioner
 	zoneCfg            zoneConfig
+	multiRegionCfg     multiRegionConfig
 
 	usePostgres  bool
 	serializable bool
@@ -200,7 +201,9 @@ var tpccMeta = workload.Meta{
 			`Note that if one value is provided, the assumption is that all urls are associated with that partition. In all other cases the assumption `+
 			`is that the URLs are distributed evenly over the partitions`)
 		g.flags.Var(&g.zoneCfg.strategy, `partition-strategy`, `Partition tables according to which strategy [replication, leases]`)
-		g.flags.StringSliceVar(&g.zoneCfg.zones, "zones", []string{}, "Zones for partitioning, the number of zones should match the number of partitions and the zones used to start cockroach.")
+		g.flags.StringSliceVar(&g.zoneCfg.zones, "zones", []string{}, "Zones for legacy partitioning, the number of zones should match the number of partitions and the zones used to start cockroach. Does not work with --regions.")
+		g.flags.StringSliceVar(&g.multiRegionCfg.regions, "regions", []string{}, "Regions to use for multi-region partitioning. The first region is the PRIMARY REGION. Does not work with --zones.")
+		g.flags.Var(&g.multiRegionCfg.survivalGoal, "survival-goal", "Survival goal to use for multi-region setups. Allowed values: [az, region].")
 		g.flags.IntVar(&g.activeWarehouses, `active-warehouses`, 0, `Run the load generator against a specific number of warehouses. Defaults to --warehouses'`)
 		g.flags.BoolVar(&g.scatter, `scatter`, false, `Scatter ranges`)
 		g.flags.BoolVar(&g.serializable, `serializable`, false, `Force serializable mode`)
@@ -241,8 +244,11 @@ func (w *tpcc) Hooks() workload.Hooks {
 				return errors.Errorf(`--partitions must be positive`)
 			}
 
-			if w.clientPartitions > 0 {
+			if len(w.zoneCfg.zones) > 0 && len(w.multiRegionCfg.regions) > 0 {
+				return errors.Errorf("cannot specify both --regions and --zones")
+			}
 
+			if w.clientPartitions > 0 {
 				if w.partitions > 1 {
 					return errors.Errorf(`cannot specify both --partitions and --client-partitions;
 					--partitions actually partitions underlying data.
@@ -261,15 +267,22 @@ func (w *tpcc) Hooks() workload.Hooks {
 				}
 
 			} else {
-
 				for _, p := range w.affinityPartitions {
 					if p < 0 || p >= w.partitions {
 						return errors.Errorf(`--partition-affinity out of bounds of --partitions`)
 					}
 				}
 
+				if len(w.multiRegionCfg.regions) > 0 && (len(w.multiRegionCfg.regions) != w.partitions) {
+					return errors.Errorf(`--regions should have the same length as --partitions.`)
+				}
+
+				if len(w.multiRegionCfg.regions) < 3 && w.multiRegionCfg.survivalGoal == survivalGoalRegion {
+					return errors.Errorf(`REGION survivability needs at least 3 regions.`)
+				}
+
 				if len(w.zoneCfg.zones) > 0 && (len(w.zoneCfg.zones) != w.partitions) {
-					return errors.Errorf(`--zones should have the sames length as --partitions.`)
+					return errors.Errorf(`--zones should have the same length as --partitions.`)
 				}
 			}
 
@@ -318,6 +331,74 @@ func (w *tpcc) Hooks() workload.Hooks {
 
 			return initializeMix(w)
 		},
+		PreCreate: func(db *gosql.DB) error {
+			if len(w.multiRegionCfg.regions) == 0 {
+				// Not a multi-region deployment.
+				return nil
+			}
+
+			regions := make(map[string]struct{})
+			rows, err := db.Query(`SELECT region FROM [SHOW REGIONS FROM DATABASE]`)
+			if err != nil {
+				return err
+			}
+			defer func() {
+				_ = rows.Close()
+			}()
+			for rows.Next() {
+				if rows.Err() != nil {
+					return err
+				}
+				var region string
+				if err := rows.Scan(&region); err != nil {
+					return err
+				}
+				regions[region] = struct{}{}
+			}
+			if rows.Err() != nil {
+				return err
+			}
+
+			var dbName string
+			if err := db.QueryRow(`SHOW DATABASE`).Scan(&dbName); err != nil {
+				return err
+			}
+
+			var stmts []string
+			for i, region := range w.multiRegionCfg.regions {
+				var stmt string
+				// The first region is the PRIMARY region.
+				if i == 0 {
+					stmt = fmt.Sprintf(`alter database %s set primary region %q`, dbName, region)
+				} else {
+					// Region additions should be idempotent.
+					if _, ok := regions[region]; ok {
+						continue
+					}
+					stmt = fmt.Sprintf(`alter database %s add region %q`, dbName, region)
+				}
+				stmts = append(stmts, stmt)
+			}
+
+			var survivalGoal string
+			switch w.multiRegionCfg.survivalGoal {
+			case survivalGoalZone:
+				survivalGoal = `zone failure`
+			case survivalGoalRegion:
+				survivalGoal = `region failure`
+			default:
+				panic("unexpected")
+			}
+			stmts = append(stmts, fmt.Sprintf(`alter database %s survive %s`, dbName, survivalGoal))
+
+			for _, stmt := range stmts {
+				if _, err := db.Exec(stmt); err != nil {
+					return err
+				}
+			}
+
+			return nil
+		},
 		PostLoad: func(db *gosql.DB) error {
 			if w.fks {
 				// We avoid validating foreign keys because we just generated
@@ -358,8 +439,23 @@ func (w *tpcc) Hooks() workload.Hooks {
 						}
 					}
 				}
+				// Set GLOBAL only after data is loaded to speed up initialization
+				// time. Otherwise, the mass INSERT at workload init time takes
+				// extraordinarily longer. If data is imported with IMPORT, this
+				// statement is idempotent.
+				if len(w.multiRegionCfg.regions) > 0 {
+					if _, err := db.Exec(fmt.Sprintf(`ALTER TABLE item SET %s`, localityGlobalSuffix)); err != nil {
+						return err
+					}
+				}
 			}
 
+			// With multi-region enabled, we do not need to partition and scatter
+			// our data anymore as it has already been partitioned by the
+			// computed column on REGIONAL BY ROW tables.
+			if len(w.multiRegionCfg.regions) != 0 {
+				return nil
+			}
 			return w.partitionAndScatterWithDB(db)
 		},
 		PostRun: func(startElapsed time.Duration) error {
@@ -446,10 +542,13 @@ func (w *tpcc) Tables() []workload.Table {
 	}
 	warehouse := workload.Table{
 		Name: `warehouse`,
-		Schema: maybeAddColumnFamiliesSuffix(
-			w.separateColumnFamilies,
+		Schema: makeSchema(
 			tpccWarehouseSchema,
-			tpccWarehouseColumnFamiliesSuffix,
+			maybeAddLocalityRegionalByRow(w.multiRegionCfg, `w_id`),
+			maybeAddColumnFamiliesSuffix(
+				w.separateColumnFamilies,
+				tpccWarehouseColumnFamiliesSuffix,
+			),
 		),
 		InitialRows: workload.BatchedTuples{
 			NumBatches: w.warehouses,
@@ -465,12 +564,17 @@ func (w *tpcc) Tables() []workload.Table {
 	}
 	district := workload.Table{
 		Name: `district`,
-		Schema: maybeAddInterleaveSuffix(
-			w.interleaved,
+		Schema: makeSchema(
+			tpccDistrictSchemaBase,
 			maybeAddColumnFamiliesSuffix(
-				w.separateColumnFamilies, tpccDistrictSchemaBase, tpccDistrictColumnFamiliesSuffix,
+				w.separateColumnFamilies,
+				tpccDistrictColumnFamiliesSuffix,
 			),
-			tpccDistrictSchemaInterleaveSuffix,
+			maybeAddInterleaveSuffix(
+				w.interleaved,
+				tpccDistrictSchemaInterleaveSuffix,
+			),
+			maybeAddLocalityRegionalByRow(w.multiRegionCfg, `d_w_id`),
 		),
 		InitialRows: workload.BatchedTuples{
 			NumBatches: numDistrictsPerWarehouse * w.warehouses,
@@ -486,14 +590,17 @@ func (w *tpcc) Tables() []workload.Table {
 	}
 	customer := workload.Table{
 		Name: `customer`,
-		Schema: maybeAddInterleaveSuffix(
-			w.interleaved,
+		Schema: makeSchema(
+			tpccCustomerSchemaBase,
+			maybeAddInterleaveSuffix(
+				w.interleaved,
+				tpccCustomerSchemaInterleaveSuffix,
+			),
 			maybeAddColumnFamiliesSuffix(
 				w.separateColumnFamilies,
-				tpccCustomerSchemaBase,
 				tpccCustomerColumnFamiliesSuffix,
 			),
-			tpccCustomerSchemaInterleaveSuffix,
+			maybeAddLocalityRegionalByRow(w.multiRegionCfg, `c_w_id`),
 		),
 		InitialRows: workload.BatchedTuples{
 			NumBatches: numCustomersPerWarehouse * w.warehouses,
@@ -503,10 +610,13 @@ func (w *tpcc) Tables() []workload.Table {
 	}
 	history := workload.Table{
 		Name: `history`,
-		Schema: maybeAddFkSuffix(
-			w.deprecatedFkIndexes,
+		Schema: makeSchema(
 			tpccHistorySchemaBase,
-			deprecatedTpccHistorySchemaFkSuffix,
+			maybeAddFkSuffix(
+				w.deprecatedFkIndexes,
+				deprecatedTpccHistorySchemaFkSuffix,
+			),
+			maybeAddLocalityRegionalByRow(w.multiRegionCfg, `h_w_id`),
 		),
 		InitialRows: workload.BatchedTuples{
 			NumBatches: numHistoryPerWarehouse * w.warehouses,
@@ -522,10 +632,13 @@ func (w *tpcc) Tables() []workload.Table {
 	}
 	order := workload.Table{
 		Name: `order`,
-		Schema: maybeAddInterleaveSuffix(
-			w.interleaved,
+		Schema: makeSchema(
 			tpccOrderSchemaBase,
-			tpccOrderSchemaInterleaveSuffix,
+			maybeAddInterleaveSuffix(
+				w.interleaved,
+				tpccOrderSchemaInterleaveSuffix,
+			),
+			maybeAddLocalityRegionalByRow(w.multiRegionCfg, `o_w_id`),
 		),
 		InitialRows: workload.BatchedTuples{
 			NumBatches: numOrdersPerWarehouse * w.warehouses,
@@ -534,8 +647,11 @@ func (w *tpcc) Tables() []workload.Table {
 		Stats: w.tpccOrderStats(),
 	}
 	newOrder := workload.Table{
-		Name:   `new_order`,
-		Schema: tpccNewOrderSchema,
+		Name: `new_order`,
+		Schema: makeSchema(
+			tpccNewOrderSchema,
+			maybeAddLocalityRegionalByRow(w.multiRegionCfg, `no_w_id`),
+		),
 		InitialRows: workload.BatchedTuples{
 			NumBatches: numNewOrdersPerWarehouse * w.warehouses,
 			FillBatch:  w.tpccNewOrderInitialRowBatch,
@@ -543,8 +659,10 @@ func (w *tpcc) Tables() []workload.Table {
 		Stats: w.tpccNewOrderStats(),
 	}
 	item := workload.Table{
-		Name:   `item`,
-		Schema: tpccItemSchema,
+		Name: `item`,
+		Schema: makeSchema(
+			tpccItemSchema,
+		),
 		InitialRows: workload.BatchedTuples{
 			NumBatches: numItems,
 			FillBatch:  w.tpccItemInitialRowBatch,
@@ -559,14 +677,17 @@ func (w *tpcc) Tables() []workload.Table {
 	}
 	stock := workload.Table{
 		Name: `stock`,
-		Schema: maybeAddInterleaveSuffix(
-			w.interleaved,
+		Schema: makeSchema(
+			tpccStockSchemaBase,
+			maybeAddInterleaveSuffix(
+				w.interleaved,
+				tpccStockSchemaInterleaveSuffix,
+			),
 			maybeAddFkSuffix(
 				w.deprecatedFkIndexes,
-				tpccStockSchemaBase,
 				deprecatedTpccStockSchemaFkSuffix,
 			),
-			tpccStockSchemaInterleaveSuffix,
+			maybeAddLocalityRegionalByRow(w.multiRegionCfg, `s_w_id`),
 		),
 		InitialRows: workload.BatchedTuples{
 			NumBatches: numStockPerWarehouse * w.warehouses,
@@ -576,14 +697,17 @@ func (w *tpcc) Tables() []workload.Table {
 	}
 	orderLine := workload.Table{
 		Name: `order_line`,
-		Schema: maybeAddInterleaveSuffix(
-			w.interleaved,
+		Schema: makeSchema(
+			tpccOrderLineSchemaBase,
+			maybeAddInterleaveSuffix(
+				w.interleaved,
+				tpccOrderLineSchemaInterleaveSuffix,
+			),
 			maybeAddFkSuffix(
 				w.deprecatedFkIndexes,
-				tpccOrderLineSchemaBase,
 				deprecatedTpccOrderLineSchemaFkSuffix,
 			),
-			tpccOrderLineSchemaInterleaveSuffix,
+			maybeAddLocalityRegionalByRow(w.multiRegionCfg, `ol_w_id`),
 		),
 		InitialRows: workload.BatchedTuples{
 			NumBatches: numOrdersPerWarehouse * w.warehouses,
@@ -600,12 +724,14 @@ func (w *tpcc) Tables() []workload.Table {
 func (w *tpcc) Ops(
 	ctx context.Context, urls []string, reg *histogram.Registry,
 ) (workload.QueryLoad, error) {
-	// It would be nice to remove the need for this and to require that
-	// partitioning and scattering occurs only when the PostLoad hook is
-	// run, but to maintain backward compatibility, it's easiest to allow
-	// partitioning and scattering during `workload run`.
-	if err := w.partitionAndScatter(urls); err != nil {
-		return workload.QueryLoad{}, err
+	if len(w.multiRegionCfg.regions) == 0 {
+		// It would be nice to remove the need for this and to require that
+		// partitioning and scattering occurs only when the PostLoad hook is
+		// run, but to maintain backward compatibility, it's easiest to allow
+		// partitioning and scattering during `workload run`.
+		if err := w.partitionAndScatter(urls); err != nil {
+			return workload.QueryLoad{}, err
+		}
 	}
 
 	sqlDatabase, err := workload.SanitizeUrls(w, w.dbOverride, urls)


### PR DESCRIPTION
Introduce a tpcc workload for multi-region, which can be triggered by
specifying `--regions comma-separated-list-of-regions`. I've preserved
the existing TPC-C options in case we want to test legacy
configurations.

The schema creation was changed to something using the options pattern
which makes it a lot cleaner to specify the schema.

Release note: None