### PR TITLE
bazel: add additional resolve hints for `gazelle`

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -36,6 +36,8 @@ load("@bazel_gazelle//:def.bzl", "gazelle")
 # gazelle:resolve proto prometheus/client_model/metrics.proto @com_github_prometheus_client_model//:client_proto
 # gazelle:resolve proto go prometheus/client_model/metrics.proto @com_github_prometheus_client_model//go
 # gazelle:resolve go github.com/prometheus/client_model/go @com_github_prometheus_client_model//go
+# gazelle:resolve go github.com/cockroachdb/cockroach/pkg/util/caller_test @cockroach//pkg/util/caller:caller_test
+# gazelle:resolve go github.com/cockroachdb/cockroach/pkg/util/json_test @cockroach//pkg/util/json:json_test
 
 # See pkg/roachpb/gen/BUILD.bazel for more details.
 #


### PR DESCRIPTION
I'm not really sure why gazelle wants these, but this quiets some error
messages.

Fixes #65615.

Release note: None