### PR TITLE
kvserver: fix possile NPE in follower read condition

### DIFF
--- a/pkg/kv/kvserver/replica_follower_read.go
+++ b/pkg/kv/kvserver/replica_follower_read.go
@@ -62,7 +62,7 @@ func (r *Replica) canServeFollowerReadRLocked(
 ) bool {
 	var lErr *roachpb.NotLeaseHolderError
 	eligible := errors.As(err, &lErr) &&
-		lErr.LeaseHolder != nil && lErr.Lease.Type() == roachpb.LeaseEpoch &&
+		lErr.LeaseHolder != nil && lErr.Lease != nil && lErr.Lease.Type() == roachpb.LeaseEpoch &&
 		BatchCanBeEvaluatedOnFollower(*ba) &&
 		FollowerReadsEnabled.Get(&r.store.cfg.Settings.SV)
 


### PR DESCRIPTION
The handling of a NLHE with a set Leaseholder but a nil Lease was
crashing. Such an error is explicitly documented as possible.

I've only seen this crash in a synthetic test; I haven't checked to what
extent it's possible in production, but I think it is.

Release note: None