### PR TITLE
sql: prevent assertion due to bad use of leases in bind

### DIFF
--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -713,7 +713,7 @@ func (txn *Txn) UpdateDeadline(ctx context.Context, deadline hlc.Timestamp) erro
 
 	readTimestamp := txn.readTimestampLocked()
 	if deadline.Less(readTimestamp) {
-		log.Fatalf(ctx, "deadline below read timestamp is nonsensical; "+
+		return errors.AssertionFailedf("deadline below read timestamp is nonsensical; "+
 			"txn has would have no chance to commit. Deadline: %s. Read timestamp: %s Previous Deadline: %s.",
 			deadline, readTimestamp, txn.mu.deadline)
 	}

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -413,6 +413,15 @@ func (ex *connExecutor) execBind(
 		}
 	}
 
+	// This is a huge kludge to deal with the fact that we're resolving types
+	// using a planner with a committed transaction. This ends up being almost
+	// okay because the execution is going to re-acquire leases on these types.
+	// Regardless, holding this lease is worse than not holding it. Users might
+	// expect to get type mismatch errors if a rename of the type occurred.
+	if ex.getTransactionState() == NoTxnStateStr {
+		ex.planner.Descriptors().ReleaseAll(ctx)
+	}
+
 	// Create the new PreparedPortal.
 	if err := ex.addPortal(ctx, portalName, ps, qargs, columnFormatCodes); err != nil {
 		return retErr(err)

--- a/pkg/sql/tests/enum_test.go
+++ b/pkg/sql/tests/enum_test.go
@@ -109,3 +109,32 @@ type intItem int
 func (i intItem) Less(o btree.Item) bool {
 	return i < o.(intItem)
 }
+
+// TestEnumPlaceholderWithAsOfSystemTime is a regression test for an edge case
+// with bind where we would not properly deal with leases involving types. At
+// the time of writing this test, we still don't deal with such leases properly
+// but we did fix any really dangerous hazards.
+func TestEnumPlaceholderWithAsOfSystemTime(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
+	defer tc.Stopper().Stop(ctx)
+
+	db := sqlutils.MakeSQLRunner(tc.ServerConn(0))
+	db.Exec(t, "CREATE TYPE typ AS ENUM ('a', 'b')")
+	db.Exec(t, "CREATE TABLE tab (k INT PRIMARY KEY, v typ)")
+	db.Exec(t, "INSERT INTO tab VALUES ($1, $2)", 1, "a")
+	var afterInsert string
+	db.QueryRow(t, "SELECT cluster_logical_timestamp()").Scan(&afterInsert)
+	db.Exec(t, "ALTER TYPE typ ADD VALUE 'c'")
+	db.Exec(t, "INSERT INTO tab VALUES ($1, $2)", 2, "c")
+	// Before the commit which introduced this test, the below statement would
+	// crash the server.
+	q := fmt.Sprintf("SELECT k FROM tab AS OF SYSTEM TIME %s WHERE v = $1", afterInsert)
+	db.Exec(t, q, "a")
+	db.Exec(t, "ALTER TYPE typ RENAME VALUE 'a' TO 'd'")
+	db.Exec(t, "ALTER TYPE typ RENAME VALUE 'b' TO 'a'")
+	got := db.QueryStr(t, q, "a")
+	require.Equal(t, [][]string{{"1"}}, got)
+}


### PR DESCRIPTION
The code which deals with resolving placeholder types and OIDs is totally
bogus when it comes to the transaction and leasing life-cycle. This has been
discussed at some length in #64140. The enum test in #64725 surfaced another
problematic case whereby the bad bind is combined with an AS OF SYSTEM TIME.

We deal with this case by dropping any leases which might have been acquired
by the bind operation. There are some edge cases where the types may mismatch,
the values may be bogus, or an OID may be resolved to the wrong value. However,
the first few of these *should* be detected and *should* be hard to hit. We're
going to need to do something about all of this in 21.2 anyway, howver, this
fix here is good for backport to 21.1 and 20.2.

Also, this change converted the fatal to an assertion failure error.

Fixes #65136.
Relates to #64140.

Release note (bug fix): Fixed a bug whereby using an enum value as a
placeholder in an AS OF SYSTEM TIME query which precedes a recent change
to that enum could result in a fatal error.