### PR TITLE
workflows: add github action to close stale issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,29 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: "30 1 * * *"
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+    - uses: actions/stale@v3
+      with:
+        operations-per-run: 1000
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'We have marked this issue as stale because it has been inactive for 18 months. If this issue is still relevant, removing the stale label or adding a comment will keep it active. Otherwise, we'll close it in 5 days to keep the issue queue tidy. Thank you for your contribution to CockroachDB!'
+        stale-pr-message: 'Stale pull request message'
+        stale-issue-label: 'no-issue-activity'
+        stale-pr-label: 'no-pr-activity'
+        close-issue-label: 'X-stale'
+        close-pr-label: 'X-stale'
+        # Disable this for PR's, by setting a very high bar
+        days-before-pr-stale: 99999
+        days-before-issue-stale: 540
+        days-before-close: 5
+        exempt-issue-labels: 'X-anchored-telemetry,X-nostale'


### PR DESCRIPTION
This PR adds a github action workflow to close stale
issues in the main cockroach repo. An issue is considered
stale if it has not received any activity for more than 18 months.
The backlog of open issues in the repo has grown out of control
over the past few years and this bot is an attempt to put a backstop
to that process. The intuition is that if we have not worked on
a bug/feature in over a year and a half, it is unlikely we will work
on it in the next 6-12 months. There are approximately ~250 issues
that will be affected by this bot on the first run. An issue
that is closed by the bot will be marked with the X-stale
label. An issue with X-nostale label will be ignored by the bot. 

Pull-requests are unaffected by this change and the stale checker
for them is disabled.

Release note: None