### PR TITLE
release-21.1: sql: return a SQL Notice if "CREATE TYPE IF NOT EXISTS" command is used to create a type and the type's already existed.

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_type
@@ -610,3 +610,13 @@ ALTER TYPE typ_64101 DROP VALUE 'a'
 
 statement error could not remove enum value "b" as it is being used by table "test.public.t2_64101"
 ALTER TYPE typ_64101 DROP VALUE 'b'
+
+subtest if_not_exists
+
+statement ok
+CREATE TYPE ifNotExists AS ENUM()
+
+query T noticetrace
+CREATE TYPE IF NOT EXISTS ifNotExists AS ENUM();
+----
+NOTICE: type "ifnotexists" already exists, skipping


### PR DESCRIPTION
Backport 1/1 commits from #63326.

/cc @cockroachdb/release

---

sql: return a SQL Notice if "CREATE TYPE IF NOT EXISTS" command is used to create a type and the type's already existed.

Previously, a command "CREATE TYPE IF NOT EXISTS" returned "CREATE TYPE" message
even if the type had already existed. This patch changes the message to a notice
"NOTICE: type already exists, skipping" to inform the user about a no-op and to
be compliant with PG CREATE TABLE command.

Fixes #62074 

Release note (sql change): return a SQL Notice if "CREATE TYPE IF NOT EXISTS"
command is used to create a type and the type's already existed.
