### PR TITLE
release-21.1: sql/table: returns notice when table already exist in case of CREATE TABLE IF NOT EXISTS

### DIFF
--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -262,6 +262,10 @@ func (n *createTableNode) startExec(params runParams) error {
 		tree.ResolveRequireTableDesc, n.n.IfNotExists)
 	if err != nil {
 		if sqlerrors.IsRelationAlreadyExistsError(err) && n.n.IfNotExists {
+			params.p.BufferClientNotice(
+				params.ctx,
+				pgnotice.Newf("relation %q already exists, skipping", n.n.Table.Table()),
+			)
 			return nil
 		}
 		return err

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -1794,3 +1794,13 @@ visible_table  CREATE TABLE public.visible_table (
                CONSTRAINT "primary" PRIMARY KEY (a ASC),
                FAMILY "primary" (a)
 )
+
+subtest if_table_exists_already
+
+statement ok
+CREATE TABLE new_table()
+
+query T noticetrace
+CREATE TABLE IF NOT EXISTS new_table();
+----
+NOTICE: relation "new_table" already exists, skipping


### PR DESCRIPTION
Backport 1/1 commits from #63404.

/cc @cockroachdb/release

---

Fixes: #62073 

Release note (SQL change): return a SQL Notice if "CREATE TABLE IF NOT EXISTS"
command is used to create a TABLE and the TABLE already existed.
