### PR TITLE
opt: assert that ConstExpr do not wrap booleans

### DIFF
--- a/pkg/sql/opt/memo/check_expr.go
+++ b/pkg/sql/opt/memo/check_expr.go
@@ -292,6 +292,12 @@ func (m *Memo) CheckExpr(e opt.Expr) {
 		if t.Value == tree.DNull {
 			panic(errors.AssertionFailedf("NULL values should always use NullExpr, not ConstExpr"))
 		}
+		if t.Value == tree.DBoolTrue {
+			panic(errors.AssertionFailedf("true values should always use TrueSingleton, not ConstExpr"))
+		}
+		if t.Value == tree.DBoolFalse {
+			panic(errors.AssertionFailedf("false values should always use FalseSingleton, not ConstExpr"))
+		}
 
 	default:
 		if opt.IsJoinOp(e) {

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -95,7 +95,8 @@ define Variable {
 }
 
 # Const is a typed scalar constant value. The Value field is a tree.Datum value
-# having any datum type that's legal in the expression's context.
+# having any datum type that's legal in the expression's context. Do NOT call
+# ConstructConst directly; use ConstructConstVal instead.
 [Scalar, ConstValue]
 define Const {
     Value Datum

--- a/pkg/sql/opt/xform/join_funcs.go
+++ b/pkg/sql/opt/xform/join_funcs.go
@@ -978,7 +978,7 @@ func (c *CustomFuncs) constructJoinWithConstants(
 	constRows := make(memo.ScalarListExpr, len(vals))
 	for i := range constRows {
 		constRows[i] = c.e.f.ConstructTuple(
-			memo.ScalarListExpr{c.e.f.ConstructConst(vals[i], typ)},
+			memo.ScalarListExpr{c.e.f.ConstructConstVal(vals[i], typ)},
 			tupleType,
 		)
 	}

--- a/pkg/sql/opt/xform/scan_index_iter.go
+++ b/pkg/sql/opt/xform/scan_index_iter.go
@@ -367,14 +367,7 @@ func (it *scanIndexIter) buildConstProjectionsFromPredicate(
 			panic(errors.AssertionFailedf("could not extract constant value for column %d", col))
 		}
 
-		var scalar opt.ScalarExpr
-		if val == tree.DNull {
-			// NULL values should always be a memo.NullExpr, not a
-			// memo.ConstExpr.
-			scalar = memo.NullSingleton
-		} else {
-			scalar = it.f.ConstructConst(val, typ)
-		}
+		scalar := it.f.ConstructConstVal(val, typ)
 
 		proj = append(proj, it.f.ConstructProjectionsItem(
 			scalar,

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -357,7 +357,7 @@ project
  │    └── fd: (1)-->(5)
  └── projections
       ├── 0 [as=i:2]
-      └── NULL [as=s:4]
+      └── CAST(NULL AS STRING) [as=s:4]
 
 # Do not project constant columns in a partial index predicate when an index
 # join must be performed to fetch other columns.
@@ -402,7 +402,7 @@ project
       │    │    ├── key: (1)
       │    │    └── fd: (1)-->(2,5)
       │    └── projections
-      │         └── NULL [as=s:4]
+      │         └── CAST(NULL AS STRING) [as=s:4]
       └── filters
            └── i:2 = 0 [outer=(2), constraints=(/2: [/0 - /0]; tight), fd=()-->(2)]
 
@@ -1830,7 +1830,7 @@ project
  │    └── fd: ()-->(5)
  └── projections
       ├── 0 [as=i:2]
-      └── NULL [as=s:4]
+      └── CAST(NULL AS STRING) [as=s:4]
 
 # Do not project constant columns in a partial index predicate when an index
 # join must be performed to fetch other columns.
@@ -1877,7 +1877,7 @@ project
       │    │    ├── key: (1)
       │    │    └── fd: ()-->(5), (1)-->(2)
       │    └── projections
-      │         └── NULL [as=s:4]
+      │         └── CAST(NULL AS STRING) [as=s:4]
       └── filters
            └── i:2 = 0 [outer=(2), constraints=(/2: [/0 - /0]; tight), fd=()-->(2)]
 


### PR DESCRIPTION
This commit adds a `memo.CheckExpr` assertion that panics during a test
build if a true or false value are wrapped in a `ConstExpr`. Several
rules assume that this invariant is held in order to make matching
easier.

The assertion revealed two cases which violated this invariant. Both
have been fixed.

Fixes #56253

Release note: None