### PR TITLE
bazel: delete some unnecessary stuff from `pkg/sql/parser/BUILD.bazel`

### DIFF
--- a/pkg/sql/parser/BUILD.bazel
+++ b/pkg/sql/parser/BUILD.bazel
@@ -69,7 +69,6 @@ go_test(
 sh_binary(
     name = "sql-gen",
     srcs = ["sql-gen.sh"],
-    data = ["sql-gen.sh"],
 )
 
 # Define the target to auto-generate sql.go from the grammar file.
@@ -96,7 +95,6 @@ genrule(
 sh_binary(
     name = "help-gen-test",
     srcs = ["help_gen_test.sh"],
-    data = ["help_gen_test.sh"],
 )
 
 # Define the target to auto-generate a helpmap test helper file.


### PR DESCRIPTION
The duplication between `srcs` and `data` here is not necessary.

Release note: None