### PR TITLE
kvserver: actually renew expiration-based leases

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -253,6 +253,7 @@ go_test(
         "replica_gc_queue_test.go",
         "replica_init_test.go",
         "replica_learner_test.go",
+        "replica_lease_renewal_test.go",
         "replica_metrics_test.go",
         "replica_proposal_buf_test.go",
         "replica_protected_timestamp_test.go",

--- a/pkg/kv/kvserver/replica_lease_renewal_test.go
+++ b/pkg/kv/kvserver/replica_lease_renewal_test.go
@@ -1,0 +1,107 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package kvserver_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func setupLeaseRenewerTest(
+	ctx context.Context, t *testing.T, init func(*base.TestClusterArgs),
+) (
+	cycles *int32, /* atomic */
+	_ *testcluster.TestCluster,
+) {
+	cycles = new(int32)
+	var args base.TestClusterArgs
+	args.ServerArgs.Knobs.Store = &kvserver.StoreTestingKnobs{
+		LeaseRenewalOnPostCycle: func() {
+			atomic.AddInt32(cycles, 1)
+		},
+	}
+	init(&args)
+	tc := testcluster.StartTestCluster(t, 1, args)
+	t.Cleanup(func() { tc.Stopper().Stop(ctx) })
+
+	desc := tc.LookupRangeOrFatal(t, tc.ScratchRangeWithExpirationLease(t))
+	s := tc.GetFirstStoreFromServer(t, 0)
+
+	_, err := s.DB().Get(ctx, desc.StartKey)
+	require.NoError(t, err)
+
+	repl, err := s.GetReplica(desc.RangeID)
+	require.NoError(t, err)
+
+	// There's a lease since we just split off the range.
+	lease, _ := repl.GetLease()
+	require.Equal(t, s.NodeID(), lease.Replica.NodeID)
+
+	return cycles, tc
+}
+
+func TestLeaseRenewerExtendsExpirationBasedLeases(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	t.Run("triggered", func(t *testing.T) {
+		renewCh := make(chan struct{})
+		cycles, tc := setupLeaseRenewerTest(ctx, t, func(args *base.TestClusterArgs) {
+			args.ServerArgs.Knobs.Store.(*kvserver.StoreTestingKnobs).LeaseRenewalSignalChan = renewCh
+		})
+		defer tc.Stopper().Stop(ctx)
+
+		trigger := func() {
+			// Need to signal the chan twice to make sure we see the effect
+			// of at least the first iteration.
+			for i := 0; i < 2; i++ {
+				select {
+				case renewCh <- struct{}{}:
+				case <-time.After(10 * time.Second):
+					t.Fatal("unable to send on renewal chan for 10s")
+				}
+			}
+		}
+
+		for i := 0; i < 5; i++ {
+			trigger()
+			n := atomic.LoadInt32(cycles)
+			require.NotZero(t, n, "during cycle #%v", i+1)
+			atomic.AddInt32(cycles, -n)
+		}
+	})
+
+	t.Run("periodic", func(t *testing.T) {
+		cycles, tc := setupLeaseRenewerTest(ctx, t, func(args *base.TestClusterArgs) {
+			args.ServerArgs.Knobs.Store.(*kvserver.StoreTestingKnobs).LeaseRenewalDurationOverride = 10 * time.Millisecond
+		})
+		defer tc.Stopper().Stop(ctx)
+
+		testutils.SucceedsSoon(t, func() error {
+			if n := atomic.LoadInt32(cycles); n < 5 {
+				return errors.Errorf("saw only %d renewal cycles", n)
+			}
+			return nil
+		})
+	})
+}

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -450,7 +450,7 @@ type Store struct {
 	// renew. An object is sent on the signal whenever a new entry is added to
 	// the map.
 	renewableLeases       syncutil.IntMap // map[roachpb.RangeID]*Replica
-	renewableLeasesSignal chan struct{}
+	renewableLeasesSignal chan struct{}   // 1-buffered
 
 	// draining holds a bool which indicates whether this store is draining. See
 	// SetDraining() for a more detailed explanation of behavior changes.
@@ -845,7 +845,11 @@ func NewStore(
 	s.metrics.registry.AddMetricStruct(s.txnWaitMetrics)
 	s.snapshotApplySem = make(chan struct{}, cfg.concurrentSnapshotApplyLimit)
 
-	s.renewableLeasesSignal = make(chan struct{})
+	if ch := s.cfg.TestingKnobs.LeaseRenewalSignalChan; ch != nil {
+		s.renewableLeasesSignal = ch
+	} else {
+		s.renewableLeasesSignal = make(chan struct{}, 1)
+	}
 
 	s.limiters.BulkIOWriteRate = rate.NewLimiter(rate.Limit(bulkIOWriteLimit.Get(&cfg.Settings.SV)), bulkIOWriteBurst)
 	bulkIOWriteLimit.SetOnChange(&cfg.Settings.SV, func(ctx context.Context) {
@@ -1720,7 +1724,6 @@ func (s *Store) startLeaseRenewer(ctx context.Context) {
 	// Start a goroutine that watches and proactively renews certain
 	// expiration-based leases.
 	_ = s.stopper.RunAsyncTask(ctx, "lease-renewer", func(ctx context.Context) {
-		repls := make(map[*Replica]struct{})
 		timer := timeutil.NewTimer()
 		defer timer.Stop()
 
@@ -1732,8 +1735,13 @@ func (s *Store) startLeaseRenewer(ctx context.Context) {
 		// attempting to accurately determine exactly when each iteration of a
 		// lease expires and when we should attempt to renew it as a result.
 		renewalDuration := s.cfg.RangeLeaseActiveDuration() / 5
+		if d := s.cfg.TestingKnobs.LeaseRenewalDurationOverride; d > 0 {
+			renewalDuration = d
+		}
 		for {
+			var numRenewableLeases int
 			s.renewableLeases.Range(func(k int64, v unsafe.Pointer) bool {
+				numRenewableLeases++
 				repl := (*Replica)(v)
 				annotatedCtx := repl.AnnotateCtx(ctx)
 				if _, pErr := repl.redirectOnOrAcquireLease(annotatedCtx); pErr != nil {
@@ -1745,8 +1753,11 @@ func (s *Store) startLeaseRenewer(ctx context.Context) {
 				return true
 			})
 
-			if len(repls) > 0 {
+			if numRenewableLeases > 0 {
 				timer.Reset(renewalDuration)
+			}
+			if fn := s.cfg.TestingKnobs.LeaseRenewalOnPostCycle; fn != nil {
+				fn()
 			}
 			select {
 			case <-s.renewableLeasesSignal:

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -339,6 +339,14 @@ type StoreTestingKnobs struct {
 	// is called under the replica lock and raftMu, so basically don't
 	// acquire any locks in this method.
 	OnRaftTimeoutCampaign func(roachpb.RangeID)
+
+	// LeaseRenewalSignalChan populates `Store.renewableLeasesSignal`.
+	LeaseRenewalSignalChan chan struct{}
+	// LeaseRenewalOnPostCycle is invoked after each lease renewal cycle.
+	LeaseRenewalOnPostCycle func()
+	// LeaseRenewalDurationOverride replaces the timer duration for proactively
+	// renewing expiration based leases.
+	LeaseRenewalDurationOverride time.Duration
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.


### PR DESCRIPTION
We were never looping around more than once as a result of
never resetting the timer. This was noticed by contributor
@llllash in #65393. Thank you!

Closes https://github.com/cockroachdb/cockroach/pull/65393.

It seems as though the mechanism to prevent ping-ponging of the r1 lease never quite worked, i.e. this issue wasn't actually closed: https://github.com/cockroachdb/cockroach/issues/24753

It's unclear why this hasn't caused more trouble over the last three years. However, looking at the original issue, it seems like you need very precise timing to get the problem to appear. Maybe that is a good enough explanation.

Release note: None
