### PR TITLE
server: simplify an error case

### DIFF
--- a/pkg/server/init.go
+++ b/pkg/server/init.go
@@ -276,7 +276,7 @@ func (s *initServer) ServeAndWait(
 				// "connection" errors save for one above. If we're
 				// here, we failed to initialize our first store after a
 				// successful join attempt.
-				return nil, false, errors.NewAssertionErrorWithWrappedErrf(err, "unexpected error: %v", err)
+				return nil, false, errors.NewAssertionErrorWithWrappedErrf(err, "unexpected error")
 			}
 
 			state := result.state


### PR DESCRIPTION
Found while re-reviewing #61608

cc @cockroachdb/server for education

`NewAssertionErrorWithWrappedErrf` already includes the text of the
original error on the right of the wrapping message. No need to
include it a second time.

Release note: None