### PR TITLE
TEAMS: update KV triage column ID

### DIFF
--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -31,7 +31,7 @@ cockroachdb/sql-observability:
   triage_column_id: 12618343
 cockroachdb/kv:
   aliases: [cockroachdb/kv-triage]
-  triage_column_id: 3550674
+  triage_column_id: 14242655
 cockroachdb/geospatial:
   triage_column_id: 9487269
 cockroachdb/dev-inf:


### PR DESCRIPTION
This sets the column ID to that of the "Roachtest/Unit Test Backlog"
column, which is where we want all test flakes to end up.

Release note: None
