### PR TITLE
kv: massage IsExpectedRebalanceError

### DIFF
--- a/pkg/kv/test_utils.go
+++ b/pkg/kv/test_utils.go
@@ -52,12 +52,13 @@ func IsExpectedRelocateError(err error) bool {
 		"unable to remove replica .* which is not present",
 		"unable to add replica .* which is already present",
 		"received invalid ChangeReplicasTrigger .* to remove self",
-		"failed to apply snapshot: raft group deleted",
+		"raft group deleted",
 		"snapshot failed",
 		"breaker open",
 		"unable to select removal target", // https://github.com/cockroachdb/cockroach/issues/49513
 		"cannot up-replicate to .*; missing gossiped StoreDescriptor",
 		"remote couldn't accept .* snapshot",
+		"cannot add placeholder",
 	}
 	pattern := "(" + strings.Join(allowlist, "|") + ")"
 	return testutils.IsError(err, pattern)


### PR DESCRIPTION
The error that would bubble up when a raft group got deleted has changed
slightly, likely as a result of #62719.

Fixes #65546.

Release note: None
