### PR TITLE
storage/cloud: remove CloseWithError

### DIFF
--- a/pkg/blobs/bench_test.go
+++ b/pkg/blobs/bench_test.go
@@ -90,12 +90,12 @@ func benchmarkStreamingReadFile(b *testing.B, tc *benchmarkTestCase) {
 		if err != nil {
 			b.Fatal(err)
 		}
-		w, err := writeTo.Writer(tc.fileName)
+		w, err := writeTo.Writer(context.Background(), tc.fileName)
 		if err != nil {
 			b.Fatal(err)
 		}
 		if _, err := io.Copy(w, reader); err != nil {
-			b.Fatal(errors.CombineErrors(err, w.CloseWithError(err)))
+			b.Fatal(errors.CombineErrors(err, w.Close()))
 		}
 		if err := w.Close(); err != nil {
 			b.Fatal(err)
@@ -147,7 +147,7 @@ func benchmarkStreamingWriteFile(b *testing.B, tc *benchmarkTestCase) {
 			b.Fatal(err)
 		}
 		if _, err := io.Copy(w, bytes.NewReader(content)); err != nil {
-			b.Fatal(errors.CombineErrors(err, w.CloseWithError(err)))
+			b.Fatal(errors.CombineErrors(w.Close(), err))
 		}
 		if err := w.Close(); err != nil {
 			b.Fatal(err)

--- a/pkg/blobs/client_test.go
+++ b/pkg/blobs/client_test.go
@@ -258,7 +258,7 @@ func TestBlobClientWriteFile(t *testing.T) {
 					return err
 				}
 				if _, err := io.Copy(w, bytes.NewReader(byteContent)); err != nil {
-					return errors.CombineErrors(w.CloseWithError(err), err)
+					return errors.CombineErrors(w.Close(), err)
 				}
 				return w.Close()
 			}()

--- a/pkg/ccl/importccl/testutils_test.go
+++ b/pkg/ccl/importccl/testutils_test.go
@@ -273,7 +273,7 @@ func (es *generatorExternalStorage) Size(ctx context.Context, basename string) (
 
 func (es *generatorExternalStorage) Writer(
 	ctx context.Context, basename string,
-) (cloud.WriteCloserWithError, error) {
+) (io.WriteCloser, error) {
 	return nil, errors.New("unsupported")
 }
 

--- a/pkg/storage/cloud/amazon/s3_storage.go
+++ b/pkg/storage/cloud/amazon/s3_storage.go
@@ -285,9 +285,7 @@ func (s *s3Storage) Settings() *cluster.Settings {
 	return s.settings
 }
 
-func (s *s3Storage) Writer(
-	ctx context.Context, basename string,
-) (cloud.WriteCloserWithError, error) {
+func (s *s3Storage) Writer(ctx context.Context, basename string) (io.WriteCloser, error) {
 	sess, err := s.newSession(ctx)
 	if err != nil {
 		return nil, err

--- a/pkg/storage/cloud/azure/azure_storage.go
+++ b/pkg/storage/cloud/azure/azure_storage.go
@@ -125,9 +125,7 @@ func (s *azureStorage) Settings() *cluster.Settings {
 	return s.settings
 }
 
-func (s *azureStorage) Writer(
-	ctx context.Context, basename string,
-) (cloud.WriteCloserWithError, error) {
+func (s *azureStorage) Writer(ctx context.Context, basename string) (io.WriteCloser, error) {
 	blob := s.getBlob(basename)
 	return cloud.BackgroundPipe(ctx, func(ctx context.Context, r io.Reader) error {
 		_, err := azblob.UploadStreamToBlockBlob(

--- a/pkg/storage/cloud/gcp/gcs_storage.go
+++ b/pkg/storage/cloud/gcp/gcs_storage.go
@@ -156,9 +156,7 @@ func makeGCSStorage(
 	}, nil
 }
 
-func (g *gcsStorage) Writer(
-	ctx context.Context, basename string,
-) (cloud.WriteCloserWithError, error) {
+func (g *gcsStorage) Writer(ctx context.Context, basename string) (io.WriteCloser, error) {
 	w := g.bucket.Object(path.Join(g.prefix, basename)).NewWriter(ctx)
 	return w, nil
 }

--- a/pkg/storage/cloud/httpsink/http_storage.go
+++ b/pkg/storage/cloud/httpsink/http_storage.go
@@ -175,9 +175,7 @@ func (h *httpStorage) ReadFileAt(
 	return stream.Body, size, nil
 }
 
-func (h *httpStorage) Writer(
-	ctx context.Context, basename string,
-) (cloud.WriteCloserWithError, error) {
+func (h *httpStorage) Writer(ctx context.Context, basename string) (io.WriteCloser, error) {
 	return cloud.BackgroundPipe(ctx, func(ctx context.Context, r io.Reader) error {
 		_, err := h.reqNoBody(ctx, "PUT", basename, r)
 		return err

--- a/pkg/storage/cloud/nodelocal/nodelocal_storage.go
+++ b/pkg/storage/cloud/nodelocal/nodelocal_storage.go
@@ -128,9 +128,7 @@ func joinRelativePath(filePath string, file string) string {
 	return path.Join(".", filePath, file)
 }
 
-func (l *localFileStorage) Writer(
-	ctx context.Context, basename string,
-) (cloud.WriteCloserWithError, error) {
+func (l *localFileStorage) Writer(ctx context.Context, basename string) (io.WriteCloser, error) {
 	return l.blobClient.Writer(ctx, joinRelativePath(l.base, basename))
 }
 

--- a/pkg/storage/cloud/nullsink/nullsink_storage.go
+++ b/pkg/storage/cloud/nullsink/nullsink_storage.go
@@ -73,11 +73,10 @@ func (n *nullSinkStorage) ReadFileAt(
 
 type nullWriter struct{}
 
-func (nullWriter) Write(p []byte) (int, error)  { return len(p), nil }
-func (nullWriter) Close() error                 { return nil }
-func (nullWriter) CloseWithError(_ error) error { return nil }
+func (nullWriter) Write(p []byte) (int, error) { return len(p), nil }
+func (nullWriter) Close() error                { return nil }
 
-func (n *nullSinkStorage) Writer(_ context.Context, _ string) (cloud.WriteCloserWithError, error) {
+func (n *nullSinkStorage) Writer(_ context.Context, _ string) (io.WriteCloser, error) {
 	return nullWriter{}, nil
 }
 

--- a/pkg/storage/cloud/userfile/file_table_storage.go
+++ b/pkg/storage/cloud/userfile/file_table_storage.go
@@ -241,9 +241,7 @@ func (f *fileTableStorage) ReadFileAt(
 
 // Writer implements the ExternalStorage interface and writes the file to the
 // user scoped FileToTableSystem.
-func (f *fileTableStorage) Writer(
-	ctx context.Context, basename string,
-) (cloud.WriteCloserWithError, error) {
+func (f *fileTableStorage) Writer(ctx context.Context, basename string) (io.WriteCloser, error) {
 	filepath, err := checkBaseAndJoinFilePath(f.prefix, basename)
 	if err != nil {
 		return nil, err

--- a/pkg/storage/cloudimpl/filetable/file_table_read_writer.go
+++ b/pkg/storage/cloudimpl/filetable/file_table_read_writer.go
@@ -597,10 +597,6 @@ func (w *chunkWriter) Write(buf []byte) (int, error) {
 	return bufLen, nil
 }
 
-func (w *chunkWriter) CloseWithError(err error) error {
-	return w.Close()
-}
-
 // Close implements the io.Closer interface by flushing the underlying writer
 // thereby writing remaining data to the Payload table. It also updates the file
 // metadata entry in the File table with the number of bytes written.
@@ -922,7 +918,7 @@ users WHERE NOT "username" = 'root' AND NOT "username" = 'admin' AND NOT "userna
 // the last chunk and commit the txn within which all writes occur.
 func (f *FileToTableSystem) NewFileWriter(
 	ctx context.Context, filename string, chunkSize int,
-) (cloud.WriteCloserWithError, error) {
+) (io.WriteCloser, error) {
 	e, err := resolveInternalFileToTableExecutor(f.executor)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Context cancellation is typically how operations are aborted.
When we open a new Writer, we pass a context, so we must assume
that that context can be cancelled, which should cancel the write
operation. Having an extra CloseWithError method in the API that
also cancels the operation is duplicative.

Release note: none.