### PR TITLE
changefeedccl: add mvcc_timestamp option

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -723,7 +723,7 @@ func (c *kvEventToRowConsumer) eventToRow(
 	var r encodeRow
 	schemaTimestamp := event.KV().Value.Timestamp
 	prevSchemaTimestamp := schemaTimestamp
-	nonLogicalTimestamp := event.LastNonlogicalWrite()
+	mvccTimestamp := event.MVCCTimestamp()
 
 	if backfillTs := event.BackfillTimestamp(); !backfillTs.IsEmpty() {
 		schemaTimestamp = backfillTs
@@ -767,7 +767,7 @@ func (c *kvEventToRowConsumer) eventToRow(
 	r.datums = append(rowenc.EncDatumRow(nil), r.datums...)
 	r.deleted = rf.RowIsDeleted()
 	r.updated = schemaTimestamp
-	r.nonLogicalUpdated = nonLogicalTimestamp
+	r.mvccTimestamp = mvccTimestamp
 
 	// Assert that we don't get a second row from the row.Fetcher. We
 	// fed it a single KV, so that would be surprising.

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -723,6 +723,7 @@ func (c *kvEventToRowConsumer) eventToRow(
 	var r encodeRow
 	schemaTimestamp := event.KV().Value.Timestamp
 	prevSchemaTimestamp := schemaTimestamp
+	nonLogicalTimestamp := event.LastNonlogicalWrite()
 
 	if backfillTs := event.BackfillTimestamp(); !backfillTs.IsEmpty() {
 		schemaTimestamp = backfillTs
@@ -766,6 +767,7 @@ func (c *kvEventToRowConsumer) eventToRow(
 	r.datums = append(rowenc.EncDatumRow(nil), r.datums...)
 	r.deleted = rf.RowIsDeleted()
 	r.updated = schemaTimestamp
+	r.nonLogicalUpdated = nonLogicalTimestamp
 
 	// Assert that we don't get a second row from the row.Fetcher. We
 	// fed it a single KV, so that would be surprising.

--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -35,7 +35,7 @@ const (
 	OptKeyInValue               = `key_in_value`
 	OptResolvedTimestamps       = `resolved`
 	OptUpdatedTimestamps        = `updated`
-	OptNonLogicalTimestamps     = `non_logical_updated`
+	OptMVCCTimestamps           = `mvcc_timestamp`
 	OptDiff                     = `diff`
 	OptCompression              = `compression`
 	OptSchemaChangeEvents       = `schema_change_events`
@@ -122,7 +122,7 @@ var ChangefeedOptionExpectValues = map[string]sql.KVStringOptValidate{
 	OptKeyInValue:               sql.KVStringOptRequireNoValue,
 	OptResolvedTimestamps:       sql.KVStringOptAny,
 	OptUpdatedTimestamps:        sql.KVStringOptRequireNoValue,
-	OptNonLogicalTimestamps:     sql.KVStringOptRequireNoValue,
+	OptMVCCTimestamps:           sql.KVStringOptRequireNoValue,
 	OptDiff:                     sql.KVStringOptRequireNoValue,
 	OptCompression:              sql.KVStringOptRequireValue,
 	OptSchemaChangeEvents:       sql.KVStringOptRequireValue,

--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -35,6 +35,7 @@ const (
 	OptKeyInValue               = `key_in_value`
 	OptResolvedTimestamps       = `resolved`
 	OptUpdatedTimestamps        = `updated`
+	OptNonLogicalTimestamps     = `non_logical_updated`
 	OptDiff                     = `diff`
 	OptCompression              = `compression`
 	OptSchemaChangeEvents       = `schema_change_events`
@@ -121,6 +122,7 @@ var ChangefeedOptionExpectValues = map[string]sql.KVStringOptValidate{
 	OptKeyInValue:               sql.KVStringOptRequireNoValue,
 	OptResolvedTimestamps:       sql.KVStringOptAny,
 	OptUpdatedTimestamps:        sql.KVStringOptRequireNoValue,
+	OptNonLogicalTimestamps:     sql.KVStringOptRequireNoValue,
 	OptDiff:                     sql.KVStringOptRequireNoValue,
 	OptCompression:              sql.KVStringOptRequireValue,
 	OptSchemaChangeEvents:       sql.KVStringOptRequireValue,

--- a/pkg/ccl/changefeedccl/encoder.go
+++ b/pkg/ccl/changefeedccl/encoder.go
@@ -45,10 +45,13 @@ const (
 type encodeRow struct {
 	// datums is the new value of a changed table row.
 	datums rowenc.EncDatumRow
-	// updated is the mvcc timestamp corresponding to the latest update in
-	// `datums`.
-	updated           hlc.Timestamp
-	nonLogicalUpdated hlc.Timestamp
+	// updated is the mvcc timestamp corresponding to the latest
+	// update in `datums` or, if the row is part of a backfill,
+	// the time at which the backfill was started.
+	updated hlc.Timestamp
+	// mvccTimestamp is the mvcc timestamp corresponding to the
+	// latest update in `datums`.
+	mvccTimestamp hlc.Timestamp
 	// deleted is true if row is a deletion. In this case, only the primary
 	// key columns are guaranteed to be set in `datums`.
 	deleted bool
@@ -102,7 +105,7 @@ func getEncoder(opts map[string]string, targets jobspb.ChangefeedTargets) (Encod
 // to its value. Updated timestamps in rows and resolved timestamp payloads are
 // stored in a sub-object under the `__crdb__` key in the top-level JSON object.
 type jsonEncoder struct {
-	updatedField, nonLogicalUpdatedField, beforeField, wrapped, keyOnly, keyInValue bool
+	updatedField, mvccTimestampField, beforeField, wrapped, keyOnly, keyInValue bool
 
 	alloc rowenc.DatumAlloc
 	buf   bytes.Buffer
@@ -116,7 +119,7 @@ func makeJSONEncoder(opts map[string]string) (*jsonEncoder, error) {
 		wrapped: changefeedbase.EnvelopeType(opts[changefeedbase.OptEnvelope]) == changefeedbase.OptEnvelopeWrapped,
 	}
 	_, e.updatedField = opts[changefeedbase.OptUpdatedTimestamps]
-	_, e.nonLogicalUpdatedField = opts[changefeedbase.OptNonLogicalTimestamps]
+	_, e.mvccTimestampField = opts[changefeedbase.OptMVCCTimestamps]
 	_, e.beforeField = opts[changefeedbase.OptDiff]
 	if e.beforeField && !e.wrapped {
 		return nil, errors.Errorf(`%s is only usable with %s=%s`,
@@ -234,7 +237,7 @@ func (e *jsonEncoder) EncodeValue(_ context.Context, row encodeRow) ([]byte, err
 		jsonEntries = after
 	}
 
-	if e.updatedField || e.nonLogicalUpdatedField {
+	if e.updatedField || e.mvccTimestampField {
 		var meta map[string]interface{}
 		if e.wrapped {
 			meta = jsonEntries
@@ -245,8 +248,8 @@ func (e *jsonEncoder) EncodeValue(_ context.Context, row encodeRow) ([]byte, err
 		if e.updatedField {
 			meta[`updated`] = row.updated.AsOfSystemTime()
 		}
-		if e.nonLogicalUpdatedField {
-			meta[`non_logical_updated`] = row.nonLogicalUpdated.AsOfSystemTime()
+		if e.mvccTimestampField {
+			meta[`mvcc_timestamp`] = row.mvccTimestamp.AsOfSystemTime()
 		}
 	}
 

--- a/pkg/ccl/changefeedccl/kvfeed/buffer.go
+++ b/pkg/ccl/changefeedccl/kvfeed/buffer.go
@@ -135,10 +135,10 @@ func (b *Event) Timestamp() hlc.Timestamp {
 	}
 }
 
-// LastNonlogicalWrite returns the Timestamp of the KV,
-// ignoring the backfillTimestamp if present. This helps
-// distinguish backfills from other events.
-func (b *Event) LastNonlogicalWrite() hlc.Timestamp {
+// MVCCTimestamp returns the Timestamp of the KV, ignoring the
+// backfillTimestamp if present. This helps distinguish backfills from
+// other events.
+func (b *Event) MVCCTimestamp() hlc.Timestamp {
 	switch b.Type() {
 	case ResolvedEvent:
 		return b.resolved.Timestamp

--- a/pkg/ccl/changefeedccl/kvfeed/buffer.go
+++ b/pkg/ccl/changefeedccl/kvfeed/buffer.go
@@ -135,6 +135,21 @@ func (b *Event) Timestamp() hlc.Timestamp {
 	}
 }
 
+// LastNonlogicalWrite returns the Timestamp of the KV,
+// ignoring the backfillTimestamp if present. This helps
+// distinguish backfills from other events.
+func (b *Event) LastNonlogicalWrite() hlc.Timestamp {
+	switch b.Type() {
+	case ResolvedEvent:
+		return b.resolved.Timestamp
+	case KVEvent:
+		return b.kv.Value.Timestamp
+	default:
+		log.Fatalf(context.TODO(), "unknown event type")
+		return hlc.Timestamp{} // unreachable
+	}
+}
+
 // chanBuffer mediates between the changed data KVFeed and the rest of the
 // changefeed pipeline (which is backpressured all the way to the sink).
 type chanBuffer struct {


### PR DESCRIPTION
This revives @HonoreDB's demo of a non_logical_updated option.

Overall, the point of this feature is to allow changefeed consumers to
take action based on row age during an initial backfill. Changefeed
consumers may want to ignore backfill'd rows older some pre-defined
timestamp.

Emitting this extra timestamp allows them to do this filtering at the
expense of sending more data over the wire when not backfilling rows.

In our discussion of this, no one was in love with the name
non_logical_updated. Thus, I've changed this field name to
mvcc_timestamp and added a small test.

* Alternatives

1. Provide an explicit, non-SQL means of limiting what gets emitted
   during backfills. This could be in the form of an option such as
   `backfill_max_age` which would drop any rows older than the provided
   timestamp.  This, however, would not allow the consumer to make
   more complicated decisions about the older data downstream (for
   example, perhaps they want to partially process old data). Further,
   it would add filtering based on mvcc_timestamp as a special case
   that we need to support even if we develop more sophisticated
   predicate filtering.

2. Provide a general way of filtering messages. For example, if the
   user could run:

       CREATE CHANGEFEED FOR foo WHERE crdb_internal_mvcc_timestamp >
       $1 INTO 'kafka://bar'

   This wouldn't allow for more dynamic downstream decisions, but would
   also avoid the special-case nature of alternative 1.

3. Provide a general way of selecting columns for emissions. For
   example, if the user could run something like:

       CREATE CHANGEFEED FOR (SELECT *, crdb_internal_mvcc_timestamp
       FROM foo) INTO 'kafka://bar'

   They could then make decisions based on the rows mvcc timestamp
   without the explicit new option added in this PR.

I think that in the long run we would like something like both 2 and
3. However, providing a means by which the user can get the actual
MVCC timestamp of rows in the near term will allow users to handle the
filtering they need downstream until we have the more sophisticated
features.

Release note (enterprise change): Changefeed's can now be started with
the `mvcc_timestamp` option to emit the mvcc timestamp of each row
being emitted. This option is similar to the `updated` option, but the
`mvcc_timestamp` will always contain the row's mvcc timestamp, even
during the changefeed's initial backfill.