### PR TITLE
release-21.1: sql: show full table scans query

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1048,6 +1048,7 @@ unreserved_keyword ::=
 	| 'SETTINGS'
 	| 'STATUS'
 	| 'SAVEPOINT'
+	| 'SCANS'
 	| 'SCATTER'
 	| 'SCHEMA'
 	| 'SCHEMAS'

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -883,7 +883,8 @@ CREATE TABLE crdb_internal.node_statement_statistics (
   max_disk_usage_var  FLOAT,
   contention_time_avg FLOAT,
   contention_time_var FLOAT,
-  implicit_txn        BOOL NOT NULL
+  implicit_txn        BOOL NOT NULL,
+  full_scan           BOOL NOT NULL
 )`,
 	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		hasViewActivity, err := p.HasRoleOption(ctx, roleoption.VIEWACTIVITY)
@@ -986,6 +987,7 @@ CREATE TABLE crdb_internal.node_statement_statistics (
 					execStatAvg(s.mu.data.ExecStats.Count, s.mu.data.ExecStats.ContentionTime),      // contention_time_avg
 					execStatVar(s.mu.data.ExecStats.Count, s.mu.data.ExecStats.ContentionTime),      // contention_time_var
 					tree.MakeDBool(tree.DBool(stmtKey.implicitTxn)),                                 // implicit_txn
+					tree.MakeDBool(tree.DBool(s.mu.fullScan)),                                       // full_scan
 				)
 				s.mu.Unlock()
 				if err != nil {

--- a/pkg/sql/delegate/BUILD.bazel
+++ b/pkg/sql/delegate/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "show_database_indexes.go",
         "show_databases.go",
         "show_enums.go",
+        "show_full_table_scans.go",
         "show_grants.go",
         "show_jobs.go",
         "show_partitions.go",

--- a/pkg/sql/delegate/delegate.go
+++ b/pkg/sql/delegate/delegate.go
@@ -133,6 +133,9 @@ func TryDelegate(
 	case *tree.ControlJobsForSchedules:
 		return d.delegateJobControl(t)
 
+	case *tree.ShowFullTableScans:
+		return d.delegateShowFullTableScans()
+
 	case *tree.ShowLastQueryStatistics:
 		return nil, unimplemented.New(
 			"show last query statistics",

--- a/pkg/sql/delegate/show_full_table_scans.go
+++ b/pkg/sql/delegate/show_full_table_scans.go
@@ -1,0 +1,25 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package delegate
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
+)
+
+func (d *delegator) delegateShowFullTableScans() (tree.Statement, error) {
+	sqltelemetry.IncrementShowCounter(sqltelemetry.FullTableScans)
+	const query = `
+  SELECT 
+    key AS query, count, rows_read_avg, bytes_read_avg, service_lat_avg, contention_time_avg, max_mem_usage_avg, network_bytes_avg, max_retries
+  FROM crdb_internal.node_statement_statistics WHERE full_scan = TRUE ORDER BY count DESC`
+	return parse(query)
+}

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -152,10 +152,10 @@ SELECT * FROM crdb_internal.leases WHERE node_id < 0
 ----
 node_id  table_id  name  parent_id  expiration  deleted
 
-query ITTTTIIITRRRRRRRRRRRRRRRRRRRRRRRRRRR colnames
+query ITTTTIIITRRRRRRRRRRRRRRRRRRRRRRRRRRBB colnames
 SELECT * FROM crdb_internal.node_statement_statistics WHERE node_id < 0
 ----
-node_id  application_name  flags  key  anonymized  count  first_attempt_count  max_retries  last_error  rows_avg  rows_var  parse_lat_avg  parse_lat_var  plan_lat_avg  plan_lat_var  run_lat_avg  run_lat_var  service_lat_avg  service_lat_var  overhead_lat_avg  overhead_lat_var  bytes_read_avg  bytes_read_var  rows_read_avg  rows_read_var  network_bytes_avg  network_bytes_var  network_msgs_avg  network_msgs_var  max_mem_usage_avg  max_mem_usage_var  max_disk_usage_avg  max_disk_usage_var  contention_time_avg  contention_time_var  implicit_txn
+node_id  application_name  flags  key  anonymized  count  first_attempt_count  max_retries  last_error  rows_avg  rows_var  parse_lat_avg  parse_lat_var  plan_lat_avg  plan_lat_var  run_lat_avg  run_lat_var  service_lat_avg  service_lat_var  overhead_lat_avg  overhead_lat_var  bytes_read_avg  bytes_read_var  rows_read_avg  rows_read_var  network_bytes_avg  network_bytes_var  network_msgs_avg  network_msgs_var  max_mem_usage_avg  max_mem_usage_var  max_disk_usage_avg  max_disk_usage_var  contention_time_avg  contention_time_var  implicit_txn  full_scan
 
 query ITTTIIRRRRRRRRRRRRRRRRRR colnames
 SELECT * FROM crdb_internal.node_transaction_statistics WHERE node_id < 0

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal_tenant
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal_tenant
@@ -164,10 +164,10 @@ SELECT * FROM crdb_internal.leases WHERE node_id < 0
 ----
 node_id  table_id  name  parent_id  expiration  deleted
 
-query ITTTTIIITRRRRRRRRRRRRRRRRRRRRRRRRRRR colnames
+query ITTTTIIITRRRRRRRRRRRRRRRRRRRRRRRRRRBB colnames
 SELECT * FROM crdb_internal.node_statement_statistics WHERE node_id < 0
 ----
-node_id  application_name  flags  key  anonymized  count  first_attempt_count  max_retries  last_error  rows_avg  rows_var  parse_lat_avg  parse_lat_var  plan_lat_avg  plan_lat_var  run_lat_avg  run_lat_var  service_lat_avg  service_lat_var  overhead_lat_avg  overhead_lat_var  bytes_read_avg  bytes_read_var  rows_read_avg  rows_read_var  network_bytes_avg  network_bytes_var  network_msgs_avg  network_msgs_var  max_mem_usage_avg  max_mem_usage_var  max_disk_usage_avg  max_disk_usage_var  contention_time_avg  contention_time_var  implicit_txn
+node_id  application_name  flags  key  anonymized  count  first_attempt_count  max_retries  last_error  rows_avg  rows_var  parse_lat_avg  parse_lat_var  plan_lat_avg  plan_lat_var  run_lat_avg  run_lat_var  service_lat_avg  service_lat_var  overhead_lat_avg  overhead_lat_var  bytes_read_avg  bytes_read_var  rows_read_avg  rows_read_var  network_bytes_avg  network_bytes_var  network_msgs_avg  network_msgs_var  max_mem_usage_avg  max_mem_usage_var  max_disk_usage_avg  max_disk_usage_var  contention_time_avg  contention_time_var  implicit_txn  full_scan
 
 query ITTTIIRRRRRRRRRRRRRRRRRR colnames
 SELECT * FROM crdb_internal.node_transaction_statistics WHERE node_id < 0

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -659,7 +659,8 @@ CREATE TABLE crdb_internal.node_statement_statistics (
    max_disk_usage_var FLOAT8 NULL,
    contention_time_avg FLOAT8 NULL,
    contention_time_var FLOAT8 NULL,
-   implicit_txn BOOL NOT NULL
+   implicit_txn BOOL NOT NULL,
+   full_scan BOOL NOT NULL
 )  CREATE TABLE crdb_internal.node_statement_statistics (
    node_id INT8 NOT NULL,
    application_name STRING NOT NULL,
@@ -696,7 +697,8 @@ CREATE TABLE crdb_internal.node_statement_statistics (
    max_disk_usage_var FLOAT8 NULL,
    contention_time_avg FLOAT8 NULL,
    contention_time_var FLOAT8 NULL,
-   implicit_txn BOOL NOT NULL
+   implicit_txn BOOL NOT NULL,
+   full_scan BOOL NOT NULL
 )  {}  {}
 CREATE TABLE crdb_internal.node_transaction_statistics (
    node_id INT8 NOT NULL,

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -684,7 +684,7 @@ func (u *sqlSymUnion) objectNamePrefixList() tree.ObjectNamePrefixList {
 %token <str> RELEASE RESET RESTORE RESTRICT RESUME RETURNING RETRY REVISION_HISTORY REVOKE RIGHT
 %token <str> ROLE ROLES ROLLBACK ROLLUP ROW ROWS RSHIFT RULE RUNNING
 
-%token <str> SAVEPOINT SCATTER SCHEDULE SCHEDULES SCHEMA SCHEMAS SCRUB SEARCH SECOND SELECT SEQUENCE SEQUENCES
+%token <str> SAVEPOINT SCANS SCATTER SCHEDULE SCHEDULES SCHEMA SCHEMAS SCRUB SEARCH SECOND SELECT SEQUENCE SEQUENCES
 %token <str> SERIALIZABLE SERVER SESSION SESSIONS SESSION_USER SET SETS SETTING SETTINGS
 %token <str> SHARE SHOW SIMILAR SIMPLE SKIP SKIP_MISSING_FOREIGN_KEYS
 %token <str> SKIP_MISSING_SEQUENCES SKIP_MISSING_SEQUENCE_OWNERS SKIP_MISSING_VIEWS SMALLINT SMALLSERIAL SNAPSHOT SOME SPLIT SQL
@@ -925,6 +925,7 @@ func (u *sqlSymUnion) objectNamePrefixList() tree.ObjectNamePrefixList {
 %type <tree.Statement> show_users_stmt
 %type <tree.Statement> show_zone_stmt
 %type <tree.Statement> show_schedules_stmt
+%type <tree.Statement> show_full_scans_stmt
 
 %type <str> statements_or_queries
 
@@ -4555,7 +4556,7 @@ zone_value:
 // SHOW ROLES, SHOW SCHEMAS, SHOW SEQUENCES, SHOW SESSION, SHOW SESSIONS,
 // SHOW STATISTICS, SHOW SYNTAX, SHOW TABLES, SHOW TRACE, SHOW TRANSACTION,
 // SHOW TRANSACTIONS, SHOW TYPES, SHOW USERS, SHOW LAST QUERY STATISTICS, SHOW SCHEDULES,
-// SHOW LOCALITY, SHOW ZONE CONFIGURATION
+// SHOW LOCALITY, SHOW ZONE CONFIGURATION, SHOW FULL TABLE SCANS
 show_stmt:
   show_backup_stmt          // EXTEND WITH HELP: SHOW BACKUP
 | show_columns_stmt         // EXTEND WITH HELP: SHOW COLUMNS
@@ -4594,6 +4595,7 @@ show_stmt:
 | show_zone_stmt            // EXTEND WITH HELP: SHOW ZONE CONFIGURATION
 | SHOW error                // SHOW HELP: SHOW
 | show_last_query_stats_stmt
+| show_full_scans_stmt
 
 // Cursors are not yet supported by CockroachDB. CLOSE ALL is safe to no-op
 // since there will be no open cursors.
@@ -5466,6 +5468,13 @@ show_fingerprints_stmt:
   {
     /* SKIP DOC */
     $$.val = &tree.ShowFingerprints{Table: $5.unresolvedObjectName()}
+  }
+
+show_full_scans_stmt:
+  SHOW FULL TABLE SCANS
+  {
+    /* SKIP DOC */
+    $$.val = &tree.ShowFullTableScans{}
   }
 
 opt_on_targets_roles:
@@ -12583,6 +12592,7 @@ unreserved_keyword:
 | SETTINGS
 | STATUS
 | SAVEPOINT
+| SCANS
 | SCATTER
 | SCHEMA
 | SCHEMAS
@@ -12777,7 +12787,7 @@ type_func_name_no_crdb_extra_keyword:
 type_func_name_crdb_extra_keyword:
   FAMILY
 
-// Reserved keyword --- these keywords are usable only as a unrestricted_name.
+// Reserved keyword --- these keywords are usable only as an unrestricted_name.
 //
 // Keywords appear here if they could not be distinguished from variable, type,
 // or function names in some contexts.

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -528,6 +528,15 @@ func (node *ShowLastQueryStatistics) Format(ctx *FmtCtx) {
 	ctx.WriteString("SHOW LAST QUERY STATISTICS")
 }
 
+// ShowFullTableScans represents a SHOW FULL TABLE SCANS statement.
+type ShowFullTableScans struct {
+}
+
+// Format implements the NodeFormatter interface.
+func (node *ShowFullTableScans) Format(ctx *FmtCtx) {
+	ctx.WriteString("SHOW FULL TABLE SCANS")
+}
+
 // ShowSavepointStatus represents a SHOW SAVEPOINT STATUS statement.
 type ShowSavepointStatus struct {
 }

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -971,6 +971,12 @@ func (*ShowUsers) StatementType() StatementType { return Rows }
 func (*ShowUsers) StatementTag() string { return "SHOW USERS" }
 
 // StatementType implements the Statement interface.
+func (*ShowFullTableScans) StatementType() StatementType { return Rows }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*ShowFullTableScans) StatementTag() string { return "SHOW FULL TABLE SCANS" }
+
+// StatementType implements the Statement interface.
 func (*ShowRoles) StatementType() StatementType { return Rows }
 
 // StatementTag returns a short string identifying the type of statement.
@@ -1198,16 +1204,17 @@ func (n *ShowCreateAllTables) String() string            { return AsString(n) }
 func (n *ShowDatabases) String() string                  { return AsString(n) }
 func (n *ShowDatabaseIndexes) String() string            { return AsString(n) }
 func (n *ShowEnums) String() string                      { return AsString(n) }
+func (n *ShowFullTableScans) String() string             { return AsString(n) }
 func (n *ShowGrants) String() string                     { return AsString(n) }
 func (n *ShowHistogram) String() string                  { return AsString(n) }
 func (n *ShowSchedules) String() string                  { return AsString(n) }
 func (n *ShowIndexes) String() string                    { return AsString(n) }
-func (n *ShowPartitions) String() string                 { return AsString(n) }
 func (n *ShowJobs) String() string                       { return AsString(n) }
+func (n *ShowLastQueryStatistics) String() string        { return AsString(n) }
+func (n *ShowPartitions) String() string                 { return AsString(n) }
 func (n *ShowQueries) String() string                    { return AsString(n) }
 func (n *ShowRanges) String() string                     { return AsString(n) }
 func (n *ShowRangeForRow) String() string                { return AsString(n) }
-func (n *ShowSurvivalGoal) String() string               { return AsString(n) }
 func (n *ShowRegions) String() string                    { return AsString(n) }
 func (n *ShowRoleGrants) String() string                 { return AsString(n) }
 func (n *ShowRoles) String() string                      { return AsString(n) }
@@ -1215,6 +1222,7 @@ func (n *ShowSavepointStatus) String() string            { return AsString(n) }
 func (n *ShowSchemas) String() string                    { return AsString(n) }
 func (n *ShowSequences) String() string                  { return AsString(n) }
 func (n *ShowSessions) String() string                   { return AsString(n) }
+func (n *ShowSurvivalGoal) String() string               { return AsString(n) }
 func (n *ShowSyntax) String() string                     { return AsString(n) }
 func (n *ShowTableStats) String() string                 { return AsString(n) }
 func (n *ShowTables) String() string                     { return AsString(n) }
@@ -1222,7 +1230,6 @@ func (n *ShowTypes) String() string                      { return AsString(n) }
 func (n *ShowTraceForSession) String() string            { return AsString(n) }
 func (n *ShowTransactionStatus) String() string          { return AsString(n) }
 func (n *ShowTransactions) String() string               { return AsString(n) }
-func (n *ShowLastQueryStatistics) String() string        { return AsString(n) }
 func (n *ShowUsers) String() string                      { return AsString(n) }
 func (n *ShowVar) String() string                        { return AsString(n) }
 func (n *ShowZoneConfig) String() string                 { return AsString(n) }

--- a/pkg/sql/sqltelemetry/show.go
+++ b/pkg/sql/sqltelemetry/show.go
@@ -54,6 +54,8 @@ const (
 	Roles
 	// Schedules represents the SHOW SCHEDULE command.
 	Schedules
+	// FullTableScans represents the SHOW FULL TABLE SCANS command.
+	FullTableScans
 )
 
 var showTelemetryNameMap = map[ShowTelemetryType]string{
@@ -73,6 +75,7 @@ var showTelemetryNameMap = map[ShowTelemetryType]string{
 	Jobs:                    "jobs",
 	Roles:                   "roles",
 	Schedules:               "schedules",
+	FullTableScans:          "full_table_scans",
 }
 
 func (s ShowTelemetryType) String() string {


### PR DESCRIPTION
Backport 1/1 commits from #63165.

/cc @cockroachdb/release

---

Show full table scans query shows queries that used a full table scan
within the past hour or two.

Fixes: #41340

Release note (sql change): SHOW FULL TABLE SCANS query added
