### PR TITLE
sql: add regions to EXPLAIN ANALYZE

### DIFF
--- a/pkg/roachpb/app_stats.go
+++ b/pkg/roachpb/app_stats.go
@@ -139,7 +139,7 @@ func (s *StatementStatistics) Add(other *StatementStatistics) {
 	s.OverheadLat.Add(other.OverheadLat, s.Count, other.Count)
 	s.BytesRead.Add(other.BytesRead, s.Count, other.Count)
 	s.RowsRead.Add(other.RowsRead, s.Count, other.Count)
-	s.Nodes = util.CombinesUniqueInt64(s.Nodes, other.Nodes)
+	s.Nodes = util.CombineUniqueInt64(s.Nodes, other.Nodes)
 
 	s.ExecStats.Add(other.ExecStats)
 

--- a/pkg/sql/app_stats.go
+++ b/pkg/sql/app_stats.go
@@ -352,7 +352,7 @@ func (a *appStats) recordStatement(
 	s.mu.data.BytesRead.Record(s.mu.data.Count, float64(stats.bytesRead))
 	s.mu.data.RowsRead.Record(s.mu.data.Count, float64(stats.rowsRead))
 	s.mu.data.LastExecTimestamp = timeutil.Now()
-	s.mu.data.Nodes = util.CombinesUniqueInt64(s.mu.data.Nodes, nodes)
+	s.mu.data.Nodes = util.CombineUniqueInt64(s.mu.data.Nodes, nodes)
 	// Note that some fields derived from tracing statements (such as
 	// BytesSentOverNetwork) are not updated here because they are collected
 	// on-demand.

--- a/pkg/sql/execstats/traceanalyzer.go
+++ b/pkg/sql/execstats/traceanalyzer.go
@@ -125,6 +125,7 @@ type QueryLevelStats struct {
 	KVTime           time.Duration
 	NetworkMessages  int64
 	ContentionTime   time.Duration
+	Regions          []string
 }
 
 // Accumulate accumulates other's stats into the receiver.
@@ -141,6 +142,7 @@ func (s *QueryLevelStats) Accumulate(other QueryLevelStats) {
 	s.KVTime += other.KVTime
 	s.NetworkMessages += other.NetworkMessages
 	s.ContentionTime += other.ContentionTime
+	s.Regions = util.CombineUniqueString(s.Regions, other.Regions)
 }
 
 // TraceAnalyzer is a struct that helps calculate top-level statistics from a

--- a/pkg/sql/execstats/traceanalyzer_test.go
+++ b/pkg/sql/execstats/traceanalyzer_test.go
@@ -253,6 +253,7 @@ func TestQueryLevelStatsAccumulate(t *testing.T) {
 		NetworkMessages:  6,
 		ContentionTime:   7 * time.Second,
 		MaxDiskUsage:     8,
+		Regions:          []string{"gcp-us-east1"},
 	}
 	b := execstats.QueryLevelStats{
 		NetworkBytesSent: 8,
@@ -263,6 +264,7 @@ func TestQueryLevelStatsAccumulate(t *testing.T) {
 		NetworkMessages:  13,
 		ContentionTime:   14 * time.Second,
 		MaxDiskUsage:     15,
+		Regions:          []string{"gcp-us-west1"},
 	}
 	expected := execstats.QueryLevelStats{
 		NetworkBytesSent: 9,
@@ -273,6 +275,7 @@ func TestQueryLevelStatsAccumulate(t *testing.T) {
 		NetworkMessages:  19,
 		ContentionTime:   21 * time.Second,
 		MaxDiskUsage:     15,
+		Regions:          []string{"gcp-us-east1", "gcp-us-west1"},
 	}
 
 	aCopy := a

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -14,6 +14,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"sort"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -105,6 +106,9 @@ type instrumentationHelper struct {
 	vectorized   bool
 
 	traceMetadata execNodeTraceMetadata
+
+	// regions used only on EXPLAIN ANALYZE to be displayed as top-level stat.
+	regions []string
 }
 
 // outputMode indicates how the statement output needs to be populated (for
@@ -240,11 +244,11 @@ func (ih *instrumentationHelper) Finish(
 	}
 
 	if ih.traceMetadata != nil && ih.explainPlan != nil {
-		ih.traceMetadata.annotateExplain(
+		ih.regions = ih.traceMetadata.annotateExplain(
 			ih.explainPlan,
-			p.curPlan.distSQLFlowInfos,
 			trace,
 			cfg.TestingKnobs.DeterministicExplain,
+			p,
 		)
 	}
 
@@ -434,6 +438,10 @@ func (ih *instrumentationHelper) buildExplainAnalyzePlan(
 	ob.AddNetworkStats(queryStats.NetworkMessages, queryStats.NetworkBytesSent)
 	ob.AddMaxDiskUsage(queryStats.MaxDiskUsage)
 
+	if len(ih.regions) > 0 {
+		ob.AddRegionsStats(ih.regions)
+	}
+
 	if err := emitExplain(ob, ih.evalCtx, ih.codec, ih.explainPlan); err != nil {
 		ob.AddTopLevelField("error emitting plan", fmt.Sprint(err))
 	}
@@ -511,10 +519,24 @@ func (m execNodeTraceMetadata) associateNodeWithComponents(
 
 // annotateExplain aggregates the statistics in the trace and annotates
 // explain.Nodes with execution stats.
+// It returns a list of all regions on which any of the statements
+// where executed on.
 func (m execNodeTraceMetadata) annotateExplain(
-	plan *explain.Plan, flowInfos []flowInfo, spans []tracingpb.RecordedSpan, makeDeterministic bool,
-) {
+	plan *explain.Plan, spans []tracingpb.RecordedSpan, makeDeterministic bool, p *planner,
+) []string {
 	statsMap := execinfrapb.ExtractStatsFromSpans(spans, makeDeterministic)
+	var allRegions []string
+
+	// Retrieve which region each node is on.
+	regionsInfo := make(map[int64]string)
+	descriptors, _ := getAllNodeDescriptors(p)
+	for _, descriptor := range descriptors {
+		for _, tier := range descriptor.Locality.Tiers {
+			if tier.Key == "region" {
+				regionsInfo[int64(descriptor.NodeID)] = tier.Value
+			}
+		}
+	}
 
 	var walk func(n *explain.Node)
 	walk = func(n *explain.Node) {
@@ -524,9 +546,11 @@ func (m execNodeTraceMetadata) annotateExplain(
 
 			incomplete := false
 			var nodes util.FastIntSet
+			regionsMap := make(map[string]struct{})
 			for _, c := range components {
 				if c.Type == execinfrapb.ComponentID_PROCESSOR {
 					nodes.Add(int(c.SQLInstanceID))
+					regionsMap[regionsInfo[int64(c.SQLInstanceID)]] = struct{}{}
 				}
 				stats := statsMap[c]
 				if stats == nil {
@@ -545,6 +569,17 @@ func (m execNodeTraceMetadata) annotateExplain(
 				for i, ok := nodes.Next(0); ok; i, ok = nodes.Next(i + 1) {
 					nodeStats.Nodes = append(nodeStats.Nodes, fmt.Sprintf("n%d", i))
 				}
+				regions := make([]string, 0, len(regionsMap))
+				for r := range regionsMap {
+					// Add only if the region is not an empty string (it will be an
+					// empty string if the region is not setup).
+					if r != "" {
+						regions = append(regions, r)
+					}
+				}
+				sort.Strings(regions)
+				nodeStats.Regions = regions
+				allRegions = util.CombineUniqueString(allRegions, regions)
 				n.Annotate(exec.ExecutionStatsID, &nodeStats)
 			}
 		}
@@ -561,4 +596,6 @@ func (m execNodeTraceMetadata) annotateExplain(
 	for i := range plan.Checks {
 		walk(plan.Checks[i])
 	}
+
+	return allRegions
 }

--- a/pkg/sql/logictest/testdata/logic_test/dist_vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/dist_vectorize
@@ -58,13 +58,16 @@ vectorized: <hidden>
 rows read from KV: 5 (40 B)
 maximum memory usage: <hidden>
 network usage: <hidden>
+cluster regions: <hidden>
 ·
 • group (scalar)
 │ cluster nodes: <hidden>
+│ cluster regions: <hidden>
 │ actual row count: 1
 │
 └── • scan
       cluster nodes: <hidden>
+      cluster regions: <hidden>
       actual row count: 5
       KV rows read: 5
       KV bytes read: 40 B
@@ -84,9 +87,11 @@ vectorized: <hidden>
 rows read from KV: 10 (80 B)
 maximum memory usage: <hidden>
 network usage: <hidden>
+cluster regions: <hidden>
 ·
 • merge join
 │ cluster nodes: <hidden>
+│ cluster regions: <hidden>
 │ actual row count: 5
 │ equality: (k) = (k)
 │ left cols are key
@@ -94,6 +99,7 @@ network usage: <hidden>
 │
 ├── • scan
 │     cluster nodes: <hidden>
+│     cluster regions: <hidden>
 │     actual row count: 5
 │     KV rows read: 5
 │     KV bytes read: 40 B
@@ -103,6 +109,7 @@ network usage: <hidden>
 │
 └── • scan
       cluster nodes: <hidden>
+      cluster regions: <hidden>
       actual row count: 5
       KV rows read: 5
       KV bytes read: 40 B

--- a/pkg/sql/logictest/testdata/logic_test/explain_analyze
+++ b/pkg/sql/logictest/testdata/logic_test/explain_analyze
@@ -18,9 +18,11 @@ distribution: <hidden>
 vectorized: <hidden>
 maximum memory usage: <hidden>
 network usage: <hidden>
+cluster regions: <hidden>
 ·
 • scan
   cluster nodes: <hidden>
+  cluster regions: <hidden>
   actual row count: 0
   KV rows read: 0
   KV bytes read: 0 B
@@ -41,9 +43,11 @@ vectorized: <hidden>
 rows read from KV: 3 (24 B)
 maximum memory usage: <hidden>
 network usage: <hidden>
+cluster regions: <hidden>
 ·
 • scan
   cluster nodes: <hidden>
+  cluster regions: <hidden>
   actual row count: 3
   KV rows read: 3
   KV bytes read: 24 B
@@ -65,10 +69,12 @@ vectorized: <hidden>
 rows read from KV: 7 (56 B)
 maximum memory usage: <hidden>
 network usage: <hidden>
+cluster regions: <hidden>
 ·
 • hash join (inner)
 │ columns: (k, v, a, b)
 │ cluster nodes: <hidden>
+│ cluster regions: <hidden>
 │ actual row count: 2
 │ vectorized batch count: 0
 │ estimated row count: 990 (missing stats)
@@ -78,6 +84,7 @@ network usage: <hidden>
 ├── • scan
 │     columns: (k, v)
 │     cluster nodes: <hidden>
+│     cluster regions: <hidden>
 │     actual row count: 4
 │     vectorized batch count: 0
 │     KV rows read: 4
@@ -89,6 +96,7 @@ network usage: <hidden>
 └── • scan
       columns: (a, b)
       cluster nodes: <hidden>
+      cluster regions: <hidden>
       actual row count: 3
       vectorized batch count: 0
       KV rows read: 3

--- a/pkg/sql/logictest/testdata/logic_test/explain_analyze_plans
+++ b/pkg/sql/logictest/testdata/logic_test/explain_analyze_plans
@@ -67,15 +67,18 @@ vectorized: <hidden>
 rows read from KV: 10 (80 B)
 maximum memory usage: <hidden>
 network usage: <hidden>
+cluster regions: <hidden>
 ·
 • group
 │ cluster nodes: <hidden>
+│ cluster regions: <hidden>
 │ actual row count: 5
 │ group by: k
 │ ordered: +k
 │
 └── • merge join
     │ cluster nodes: <hidden>
+    │ cluster regions: <hidden>
     │ actual row count: 5
     │ equality: (k) = (k)
     │ left cols are key
@@ -83,6 +86,7 @@ network usage: <hidden>
     │
     ├── • scan
     │     cluster nodes: <hidden>
+    │     cluster regions: <hidden>
     │     actual row count: 5
     │     KV rows read: 5
     │     KV bytes read: 40 B
@@ -92,6 +96,7 @@ network usage: <hidden>
     │
     └── • scan
           cluster nodes: <hidden>
+          cluster regions: <hidden>
           actual row count: 5
           KV rows read: 5
           KV bytes read: 40 B
@@ -112,25 +117,30 @@ vectorized: <hidden>
 rows read from KV: 10 (80 B)
 maximum memory usage: <hidden>
 network usage: <hidden>
+cluster regions: <hidden>
 ·
 • sort
 │ cluster nodes: <hidden>
+│ cluster regions: <hidden>
 │ actual row count: 5
 │ order: +w
 │
 └── • distinct
     │ cluster nodes: <hidden>
+    │ cluster regions: <hidden>
     │ actual row count: 5
     │ distinct on: w
     │
     └── • hash join
         │ cluster nodes: <hidden>
+        │ cluster regions: <hidden>
         │ actual row count: 5
         │ equality: (k) = (w)
         │ left cols are key
         │
         ├── • scan
         │     cluster nodes: <hidden>
+        │     cluster regions: <hidden>
         │     actual row count: 5
         │     KV rows read: 5
         │     KV bytes read: 40 B
@@ -140,6 +150,7 @@ network usage: <hidden>
         │
         └── • scan
               cluster nodes: <hidden>
+              cluster regions: <hidden>
               actual row count: 5
               KV rows read: 5
               KV bytes read: 40 B
@@ -160,17 +171,21 @@ vectorized: <hidden>
 rows read from KV: 10 (80 B)
 maximum memory usage: <hidden>
 network usage: <hidden>
+cluster regions: <hidden>
 ·
 • cross join
 │ cluster nodes: <hidden>
+│ cluster regions: <hidden>
 │ actual row count: 25
 │
 ├── • ordinality
 │   │ cluster nodes: <hidden>
+│   │ cluster regions: <hidden>
 │   │ actual row count: 5
 │   │
 │   └── • scan
 │         cluster nodes: <hidden>
+│         cluster regions: <hidden>
 │         actual row count: 5
 │         KV rows read: 5
 │         KV bytes read: 40 B
@@ -180,10 +195,12 @@ network usage: <hidden>
 │
 └── • ordinality
     │ cluster nodes: <hidden>
+    │ cluster regions: <hidden>
     │ actual row count: 5
     │
     └── • scan
           cluster nodes: <hidden>
+          cluster regions: <hidden>
           actual row count: 5
           KV rows read: 5
           KV bytes read: 40 B
@@ -225,13 +242,16 @@ vectorized: <hidden>
 rows read from KV: 5 (40 B)
 maximum memory usage: <hidden>
 network usage: <hidden>
+cluster regions: <hidden>
 ·
 • window
 │ cluster nodes: <hidden>
+│ cluster regions: <hidden>
 │ actual row count: 5
 │
 └── • scan
       cluster nodes: <hidden>
+      cluster regions: <hidden>
       actual row count: 5
       KV rows read: 5
       KV bytes read: 40 B
@@ -252,9 +272,11 @@ distribution: <hidden>
 vectorized: <hidden>
 maximum memory usage: <hidden>
 network usage: <hidden>
+cluster regions: <hidden>
 ·
 • scan
   cluster nodes: <hidden>
+  cluster regions: <hidden>
   actual row count: 0
   KV rows read: 0
   KV bytes read: 0 B
@@ -280,11 +302,13 @@ vectorized: <hidden>
 rows read from KV: 2 (16 B)
 maximum memory usage: <hidden>
 network usage: <hidden>
+cluster regions: <hidden>
 ·
 • root
 │
 ├── • insert
 │   │ cluster nodes: <hidden>
+│   │ cluster regions: <hidden>
 │   │ actual row count: 1
 │   │ into: child(c, p)
 │   │
@@ -301,10 +325,12 @@ network usage: <hidden>
 │   │
 │   └── • group (scalar)
 │       │ cluster nodes: <hidden>
+│       │ cluster regions: <hidden>
 │       │ actual row count: 1
 │       │
 │       └── • scan
 │             cluster nodes: <hidden>
+│             cluster regions: <hidden>
 │             actual row count: 1
 │             KV rows read: 1
 │             KV bytes read: 8 B
@@ -317,10 +343,12 @@ network usage: <hidden>
     │
     └── • error if rows
         │ cluster nodes: <hidden>
+        │ cluster regions: <hidden>
         │ actual row count: 0
         │
         └── • lookup join (anti)
             │ cluster nodes: <hidden>
+            │ cluster regions: <hidden>
             │ actual row count: 0
             │ KV rows read: 1
             │ KV bytes read: 8 B
@@ -330,12 +358,14 @@ network usage: <hidden>
             │
             └── • filter
                 │ cluster nodes: <hidden>
+                │ cluster regions: <hidden>
                 │ actual row count: 1
                 │ estimated row count: 1
                 │ filter: column2 IS NOT NULL
                 │
                 └── • scan buffer
                       cluster nodes: <hidden>
+                      cluster regions: <hidden>
                       actual row count: 1
                       label: buffer 1
 ·

--- a/pkg/sql/logictest/testdata/logic_test/inverted_index_geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index_geospatial
@@ -35,19 +35,23 @@ vectorized: <hidden>
 rows read from KV: 6 (48 B)
 maximum memory usage: <hidden>
 network usage: <hidden>
+cluster regions: <hidden>
 ·
 • sort
 │ cluster nodes: <hidden>
+│ cluster regions: <hidden>
 │ actual row count: 2
 │ order: +k
 │
 └── • filter
     │ cluster nodes: <hidden>
+    │ cluster regions: <hidden>
     │ actual row count: 2
     │ filter: st_intersects('010100002026690000000000000C6A18410000008081844E41', geom)
     │
     └── • index join
         │ cluster nodes: <hidden>
+        │ cluster regions: <hidden>
         │ actual row count: 2
         │ KV rows read: 2
         │ KV bytes read: 16 B
@@ -55,12 +59,14 @@ network usage: <hidden>
         │
         └── • inverted filter
             │ cluster nodes: <hidden>
+            │ cluster regions: <hidden>
             │ actual row count: 2
             │ inverted column: geom_inverted_key
             │ num spans: 31
             │
             └── • scan
                   cluster nodes: <hidden>
+                  cluster regions: <hidden>
                   actual row count: 4
                   KV rows read: 4
                   KV bytes read: 32 B
@@ -111,19 +117,23 @@ vectorized: <hidden>
 rows read from KV: 4 (32 B)
 maximum memory usage: <hidden>
 network usage: <hidden>
+cluster regions: <hidden>
 ·
 • sort
 │ cluster nodes: <hidden>
+│ cluster regions: <hidden>
 │ actual row count: 2
 │ order: +k
 │
 └── • filter
     │ cluster nodes: <hidden>
+    │ cluster regions: <hidden>
     │ actual row count: 2
     │ filter: st_intersects('010100002026690000000000000C6A18410000008081844E41', geom)
     │
     └── • index join
         │ cluster nodes: <hidden>
+        │ cluster regions: <hidden>
         │ actual row count: 2
         │ KV rows read: 2
         │ KV bytes read: 16 B
@@ -131,12 +141,14 @@ network usage: <hidden>
         │
         └── • inverted filter
             │ cluster nodes: <hidden>
+            │ cluster regions: <hidden>
             │ actual row count: 2
             │ inverted column: geom_inverted_key
             │ num spans: 31
             │
             └── • scan
                   cluster nodes: <hidden>
+                  cluster regions: <hidden>
                   actual row count: 2
                   KV rows read: 2
                   KV bytes read: 16 B
@@ -163,19 +175,23 @@ vectorized: <hidden>
 rows read from KV: 4 (32 B)
 maximum memory usage: <hidden>
 network usage: <hidden>
+cluster regions: <hidden>
 ·
 • sort
 │ cluster nodes: <hidden>
+│ cluster regions: <hidden>
 │ actual row count: 2
 │ order: +k
 │
 └── • filter
     │ cluster nodes: <hidden>
+    │ cluster regions: <hidden>
     │ actual row count: 2
     │ filter: st_intersects('010100002026690000000000000C6A18410000008081844E41', geom)
     │
     └── • index join
         │ cluster nodes: <hidden>
+        │ cluster regions: <hidden>
         │ actual row count: 2
         │ KV rows read: 2
         │ KV bytes read: 16 B
@@ -183,12 +199,14 @@ network usage: <hidden>
         │
         └── • inverted filter
             │ cluster nodes: <hidden>
+            │ cluster regions: <hidden>
             │ actual row count: 2
             │ inverted column: geom_inverted_key
             │ num spans: 31
             │
             └── • scan
                   cluster nodes: <hidden>
+                  cluster regions: <hidden>
                   actual row count: 2
                   KV rows read: 2
                   KV bytes read: 16 B

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_local
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_local
@@ -45,9 +45,11 @@ vectorized: <hidden>
 rows read from KV: 2,001 (16 KiB)
 maximum memory usage: <hidden>
 network usage: <hidden>
+cluster regions: <hidden>
 ·
 • scan
   cluster nodes: <hidden>
+  cluster regions: <hidden>
   actual row count: 2,001
   KV rows read: 2,001
   KV bytes read: 16 KiB
@@ -67,9 +69,11 @@ vectorized: <hidden>
 rows read from KV: 3 (24 B)
 maximum memory usage: <hidden>
 network usage: <hidden>
+cluster regions: <hidden>
 ·
 • lookup join
 │ cluster nodes: <hidden>
+│ cluster regions: <hidden>
 │ actual row count: 2
 │ KV rows read: 1
 │ KV bytes read: 8 B
@@ -78,6 +82,7 @@ network usage: <hidden>
 │
 └── • scan
       cluster nodes: <hidden>
+      cluster regions: <hidden>
       actual row count: 2
       KV rows read: 2
       KV bytes read: 16 B
@@ -138,20 +143,24 @@ vectorized: <hidden>
 rows read from KV: 4 (32 B)
 maximum memory usage: <hidden>
 network usage: <hidden>
+cluster regions: <hidden>
 ·
 • merge join
 │ cluster nodes: <hidden>
+│ cluster regions: <hidden>
 │ actual row count: 2
 │ equality: (a) = (b)
 │
 ├── • sort
 │   │ cluster nodes: <hidden>
+│   │ cluster regions: <hidden>
 │   │ actual row count: 2
 │   │ estimated row count: 1
 │   │ order: +a
 │   │
 │   └── • scan
 │         cluster nodes: <hidden>
+│         cluster regions: <hidden>
 │         actual row count: 2
 │         KV rows read: 2
 │         KV bytes read: 16 B
@@ -161,6 +170,7 @@ network usage: <hidden>
 │
 └── • scan
       cluster nodes: <hidden>
+      cluster regions: <hidden>
       actual row count: 2
       KV rows read: 2
       KV bytes read: 16 B

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -1582,8 +1582,10 @@ distribution: <hidden>
 vectorized: <hidden>
 maximum memory usage: <hidden>
 network usage: <hidden>
+cluster regions: <hidden>
 ·
 • values
   cluster nodes: <hidden>
+  cluster regions: <hidden>
   actual row count: 1
   size: 1 column, 1 row

--- a/pkg/sql/opt/exec/execbuilder/testdata/prepare
+++ b/pkg/sql/opt/exec/execbuilder/testdata/prepare
@@ -118,9 +118,11 @@ vectorized: <hidden>
 rows read from KV: 1 (8 B)
 maximum memory usage: <hidden>
 network usage: <hidden>
+cluster regions: <hidden>
 ·
 • scan
   cluster nodes: <hidden>
+  cluster regions: <hidden>
   actual row count: 1
   KV rows read: 1
   KV bytes read: 8 B
@@ -137,9 +139,11 @@ distribution: <hidden>
 vectorized: <hidden>
 maximum memory usage: <hidden>
 network usage: <hidden>
+cluster regions: <hidden>
 ·
 • scan
   cluster nodes: <hidden>
+  cluster regions: <hidden>
   actual row count: 0
   KV rows read: 0
   KV bytes read: 0 B

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -335,6 +335,9 @@ func (e *emitter) emitNodeAttributes(n *Node) error {
 		if len(s.Nodes) > 0 {
 			e.ob.AddRedactableField(RedactNodes, "cluster nodes", strings.Join(s.Nodes, ", "))
 		}
+		if len(s.Regions) > 0 {
+			e.ob.AddRedactableField(RedactNodes, "cluster regions", strings.Join(s.Regions, ", "))
+		}
 		if s.RowCount.HasValue() {
 			e.ob.AddField("actual row count", humanizeutil.Count(s.RowCount.Value()))
 		}

--- a/pkg/sql/opt/exec/explain/output.go
+++ b/pkg/sql/opt/exec/explain/output.go
@@ -13,6 +13,7 @@ package explain
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -408,4 +409,13 @@ func (ob *OutputBuilder) AddMaxDiskUsage(bytes int64) {
 		ob.AddTopLevelField("max sql temp disk usage",
 			humanizeutil.IBytes(bytes))
 	}
+}
+
+// AddRegionsStats adds a top-level field for regions executed on statistics.
+func (ob *OutputBuilder) AddRegionsStats(regions []string) {
+	ob.AddRedactableTopLevelField(
+		RedactNodes,
+		"cluster regions",
+		strings.Join(regions, ", "),
+	)
 }

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -320,6 +320,10 @@ type ExecutionStats struct {
 
 	// Nodes on which this operator was executed.
 	Nodes []string
+
+	// Regions on which this operator was executed.
+	// Only being generated on EXPLAIN ANALYZE.
+	Regions []string
 }
 
 // BuildPlanForExplainFn builds an execution plan against the given

--- a/pkg/util/slices.go
+++ b/pkg/util/slices.go
@@ -10,10 +10,37 @@
 
 package util
 
-// CombinesUniqueInt64 combine two ordered int64 slices and return the result without
-// duplicates.
-func CombinesUniqueInt64(a []int64, b []int64) []int64 {
+// CombineUniqueInt64 combines two ordered int64 slices and returns
+// the result without duplicates.
+func CombineUniqueInt64(a []int64, b []int64) []int64 {
 	res := make([]int64, 0, len(a))
+	aIter, bIter := 0, 0
+	for aIter < len(a) && bIter < len(b) {
+		if a[aIter] == b[bIter] {
+			res = append(res, a[aIter])
+			aIter++
+			bIter++
+		} else if a[aIter] < b[bIter] {
+			res = append(res, a[aIter])
+			aIter++
+		} else {
+			res = append(res, b[bIter])
+			bIter++
+		}
+	}
+	if aIter < len(a) {
+		res = append(res, a[aIter:]...)
+	}
+	if bIter < len(b) {
+		res = append(res, b[bIter:]...)
+	}
+	return res
+}
+
+// CombineUniqueString combines two ordered string slices and returns
+// the result without duplicates.
+func CombineUniqueString(a []string, b []string) []string {
+	res := make([]string, 0, len(a))
 	aIter, bIter := 0, 0
 	for aIter < len(a) && bIter < len(b) {
 		if a[aIter] == b[bIter] {

--- a/pkg/util/slices_test.go
+++ b/pkg/util/slices_test.go
@@ -39,7 +39,7 @@ func TestCombinesUniqueInt64(t *testing.T) {
 			expected: []int64{1, 3},
 		},
 	} {
-		output := CombinesUniqueInt64(tc.inputA, tc.inputB)
+		output := CombineUniqueInt64(tc.inputA, tc.inputB)
 		require.Equal(t, tc.expected, output)
 	}
 }


### PR DESCRIPTION
Add to EXPLAIN ANALYZE which regions a statement was executed on (added to both children and top levels).

Example of result:
```
> explain analyze select count(*) from users;
                             info
---------------------------------------------------------------
  planning time: 240µs
  execution time: 6ms
  distribution: full
  vectorized: true
  rows read from KV: 50 (5.7 KiB)
  cumulative time spent in KV: 7ms
  maximum memory usage: 70 KiB
  network usage: 608 B (12 messages)
  cluster regions: gcp-europe-west1, gcp-us-east1, gcp-us-west1

  • group (scalar)
  │ cluster nodes: n1
  │ cluster regions: gcp-us-east1
  │ actual row count: 1
  │
  └── • scan
        cluster nodes: n1, n5, n6, n7, n8
        cluster regions: gcp-europe-west1, gcp-us-east1, gcp-us-west1
        actual row count: 50
        KV rows read: 50
        KV bytes read: 5.7 KiB
        missing stats
        table: users@primary
        spans: FULL SCAN
(23 rows)
```

Resolves https://github.com/cockroachdb/cockroach/issues/64607

Release note (sql change): Surface on EXLAIN ANALYZE information
about which regions a statement was executed on.