### PR TITLE
bazel: add lint to ensure new broken tests aren't added

### DIFF
--- a/build/teamcity-check.sh
+++ b/build/teamcity-check.sh
@@ -38,7 +38,7 @@ fi
 
 tc_start_block "Ensure generated code is up-to-date"
 # Buffer noisy output and only print it on failure.
-if ! run run_bazel build/bazelutil/check-genfiles.sh &> artifacts/buildshort.log || (cat artifacts/buildshort.log && false); then
+if ! run run_bazel build/bazelutil/check.sh &> artifacts/buildshort.log || (cat artifacts/buildshort.log && false); then
     # The command will output instructions on how to fix the error.
     exit 1
 fi

--- a/pkg/ccl/sqlproxyccl/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/BUILD.bazel
@@ -45,7 +45,6 @@ go_test(
         ":testserver_config.cnf",
     ],
     embed = [":sqlproxyccl"],
-    tags = ["broken_in_bazel"],
     deps = [
         "//pkg/base",
         "//pkg/ccl/utilccl",

--- a/pkg/sql/colflow/BUILD.bazel
+++ b/pkg/sql/colflow/BUILD.bazel
@@ -68,7 +68,6 @@ go_test(
         "vectorized_panic_propagation_test.go",
     ],
     embed = [":colflow"],
-    tags = ["broken_in_bazel"],
     deps = [
         "//pkg/base",
         "//pkg/col/coldata",


### PR DESCRIPTION
Also remove the `broken_in_bazel` tag from some working tests.

Release note: None