### PR TITLE
sql/pgwire: add telemetry for pgwire extended protcol

### DIFF
--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -22,6 +22,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
@@ -793,6 +794,7 @@ func (c *conn) handleSimpleQuery(
 func (c *conn) handleParse(
 	ctx context.Context, buf *pgwirebase.ReadBuffer, nakedIntSize *types.T,
 ) error {
+	telemetry.Inc(sqltelemetry.ParseRequestCounter)
 	name, err := buf.GetString()
 	if err != nil {
 		return c.stmtBuf.Push(ctx, sql.SendError{Err: err})
@@ -889,6 +891,7 @@ func (c *conn) handleParse(
 // An error is returned iff the statement buffer has been closed. In that case,
 // the connection should be considered toast.
 func (c *conn) handleDescribe(ctx context.Context, buf *pgwirebase.ReadBuffer) error {
+	telemetry.Inc(sqltelemetry.DescribeRequestCounter)
 	typ, err := buf.GetPrepareType()
 	if err != nil {
 		return c.stmtBuf.Push(ctx, sql.SendError{Err: err})
@@ -908,6 +911,7 @@ func (c *conn) handleDescribe(ctx context.Context, buf *pgwirebase.ReadBuffer) e
 // An error is returned iff the statement buffer has been closed. In that case,
 // the connection should be considered toast.
 func (c *conn) handleClose(ctx context.Context, buf *pgwirebase.ReadBuffer) error {
+	telemetry.Inc(sqltelemetry.CloseRequestCounter)
 	typ, err := buf.GetPrepareType()
 	if err != nil {
 		return c.stmtBuf.Push(ctx, sql.SendError{Err: err})
@@ -933,6 +937,7 @@ var formatCodesAllText = []pgwirebase.FormatCode{pgwirebase.FormatText}
 // An error is returned iff the statement buffer has been closed. In that case,
 // the connection should be considered toast.
 func (c *conn) handleBind(ctx context.Context, buf *pgwirebase.ReadBuffer) error {
+	telemetry.Inc(sqltelemetry.BindRequestCounter)
 	portalName, err := buf.GetString()
 	if err != nil {
 		return c.stmtBuf.Push(ctx, sql.SendError{Err: err})
@@ -1058,6 +1063,7 @@ func (c *conn) handleBind(ctx context.Context, buf *pgwirebase.ReadBuffer) error
 func (c *conn) handleExecute(
 	ctx context.Context, buf *pgwirebase.ReadBuffer, timeReceived time.Time,
 ) error {
+	telemetry.Inc(sqltelemetry.ExecuteRequestCounter)
 	portalName, err := buf.GetString()
 	if err != nil {
 		return c.stmtBuf.Push(ctx, sql.SendError{Err: err})
@@ -1074,6 +1080,7 @@ func (c *conn) handleExecute(
 }
 
 func (c *conn) handleFlush(ctx context.Context) error {
+	telemetry.Inc(sqltelemetry.FlushRequestCounter)
 	return c.stmtBuf.Push(ctx, sql.Flush{})
 }
 

--- a/pkg/sql/sqltelemetry/pgwire.go
+++ b/pkg/sql/sqltelemetry/pgwire.go
@@ -44,3 +44,27 @@ var InterleavedPortalRequestCounter = telemetry.GetCounterOnce("pgwire.#40195.in
 // PortalWithLimitRequestCounter is to be incremented every time a portal request is
 // made.
 var PortalWithLimitRequestCounter = telemetry.GetCounterOnce("pgwire.portal_with_limit_request")
+
+// ParseRequestCounter is to be incremented every time a parse request
+// is made.
+var ParseRequestCounter = telemetry.GetCounterOnce("pgwire.command.parse")
+
+// BindRequestCounter is to be incremented every time a bind request
+// is made.
+var BindRequestCounter = telemetry.GetCounterOnce("pgwire.command.bind")
+
+// DescribeRequestCounter is to be incremented every time a describe request
+// is made.
+var DescribeRequestCounter = telemetry.GetCounterOnce("pgwire.command.describe")
+
+// ExecuteRequestCounter is to be incremented every time a execute request
+// is made.
+var ExecuteRequestCounter = telemetry.GetCounterOnce("pgwire.command.execute")
+
+// CloseRequestCounter is to be incremented every time a close request
+// is made.
+var CloseRequestCounter = telemetry.GetCounterOnce("pgwire.command.close")
+
+// FlushRequestCounter is to be incremented every time a flush request
+// is made.
+var FlushRequestCounter = telemetry.GetCounterOnce("pgwire.command.flush")


### PR DESCRIPTION
sql/pgwire: add telemetry for pgwire extended protcol

Fixes #65622

This PR adds telemetry counters for parse, bind, describe, and execute commands.

Release note: None