### PR TITLE
cli/interactive_tests: re-enable test_demo_partitioning.tcl

### DIFF
--- a/pkg/cli/interactive_tests/test_demo_partitioning.tcl
+++ b/pkg/cli/interactive_tests/test_demo_partitioning.tcl
@@ -2,6 +2,9 @@
 
 source [file join [file dirname $argv0] common.tcl]
 
+# Set a larger timeout as partitioning can be slow.
+set timeout 300
+
 # The following tests want to access the licensing server.
 set env(COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING) "false"
 


### PR DESCRIPTION
This seemed to always time out in earlier runs, so give it a slightly
beefier timeout.

Release note: None