### PR TITLE
release-21.1: sql: use column attrnum as sub_id

### DIFF
--- a/pkg/sql/comment_on_column.go
+++ b/pkg/sql/comment_on_column.go
@@ -69,7 +69,7 @@ func (n *commentOnColumnNode) startExec(params runParams) error {
 			"UPSERT INTO system.comments VALUES ($1, $2, $3, $4)",
 			keys.ColumnCommentType,
 			n.tableDesc.GetID(),
-			col.GetID(),
+			col.GetPGAttributeNum(),
 			*n.n.Comment)
 		if err != nil {
 			return err
@@ -83,7 +83,7 @@ func (n *commentOnColumnNode) startExec(params runParams) error {
 			"DELETE FROM system.comments WHERE type=$1 AND object_id=$2 AND sub_id=$3",
 			keys.ColumnCommentType,
 			n.tableDesc.GetID(),
-			col.GetID())
+			col.GetPGAttributeNum())
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Backport 1/1 commits from #65597.

/cc @cockroachdb/release

---

sql: use column attrnum as sub_id

Fixes #65568

Previously, CRDB used a column id as objsubid in system.comments and
pg_catalog.pg_description. A column type change creates a new column with a new
column id, so these tables contained comments for old and new columns.

This patch changes column attnum to be used as objsubid instead, to prevent
creation of new entries for altered columns.

Release note (bug fix): It is now possible to change the COMMENT on a column after using ALTER TYPE on that column.
