### PR TITLE
release-21.1: geo/geomfn: fix Node if the LineString is the same point

### DIFF
--- a/pkg/geo/geomfn/node.go
+++ b/pkg/geo/geomfn/node.go
@@ -65,6 +65,12 @@ func Node(g geo.Geometry) (geo.Geometry, error) {
 	switch t := glines.(type) {
 	case *geom.MultiLineString:
 		mllines = t
+	case *geom.GeometryCollection:
+		if t.Empty() {
+			t.SetSRID(int(g.SRID()))
+			return geo.MakeGeometryFromGeomT(t)
+		}
+		return geo.Geometry{}, errors.AssertionFailedf("unknown GEOMETRYCOLLECTION: %T", t)
 	default:
 		return geo.Geometry{}, errors.AssertionFailedf("unknown LineMerge result type: %T", t)
 	}

--- a/pkg/geo/geomfn/node_test.go
+++ b/pkg/geo/geomfn/node_test.go
@@ -31,6 +31,12 @@ func TestNode(t *testing.T) {
 			false,
 		},
 		{
+			"LineString, same point",
+			geo.MustParseGeometry("SRID=4326;LINESTRING (-0.06435 -0.06948, -0.06435 -0.06948)"),
+			geo.MustParseGeometry("SRID=4326;GEOMETRYCOLLECTION EMPTY"),
+			false,
+		},
+		{
 			"LineString, 4 nodes",
 			geo.MustParseGeometry("LINESTRING(0 0, 10 10, 0 10, 10 0, 10 10)"),
 			geo.MustParseGeometry("MULTILINESTRING((0 0,5 5),(5 5,10 10),(10 10,0 10,5 5),(5 5,10 0,10 10))"),


### PR DESCRIPTION
Backport 1/1 commits from #65686.

/cc @cockroachdb/release

---

Release note (bug fix): Fix a bug where ST_Node on a LineString with the
same repeated points results in an error.

Resolves #65682
