### PR TITLE
sql: support expression-based indexes in CREATE TABLE

### DIFF
--- a/pkg/sql/catalog/descpb/column.go
+++ b/pkg/sql/catalog/descpb/column.go
@@ -50,6 +50,13 @@ func (desc *ColumnDescriptor) ColName() tree.Name {
 // CheckCanBeOutboundFKRef returns whether the given column can be on the
 // referencing (origin) side of a foreign key relation.
 func (desc *ColumnDescriptor) CheckCanBeOutboundFKRef() error {
+	if desc.Inaccessible {
+		return pgerror.Newf(
+			pgcode.UndefinedColumn,
+			"column %q is inaccessible and cannot reference a foreign key",
+			desc.Name,
+		)
+	}
 	if desc.Virtual {
 		return unimplemented.NewWithIssuef(
 			59671, "virtual column %q cannot reference a foreign key",

--- a/pkg/sql/catalog/descpb/index.go
+++ b/pkg/sql/catalog/descpb/index.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/errors"
 )
 
@@ -50,7 +49,7 @@ func (desc *IndexDescriptor) FillColumns(elems tree.IndexElemList) error {
 	desc.KeyColumnDirections = make([]IndexDescriptor_Direction, 0, len(elems))
 	for _, c := range elems {
 		if c.Expr != nil {
-			return unimplemented.NewWithIssuef(9682, "only simple columns are supported as index elements")
+			return errors.AssertionFailedf("index elem expression should have been replaced with a column")
 		}
 		desc.KeyColumnNames = append(desc.KeyColumnNames, string(c.Column))
 		switch c.Direction {

--- a/pkg/sql/catalog/schemaexpr/computed_column.go
+++ b/pkg/sql/catalog/schemaexpr/computed_column.go
@@ -106,9 +106,9 @@ func ValidateComputedColumnExpression(
 	}
 
 	// Virtual computed columns must not refer to mutation columns because it
-	// would not be safe in the case that the mutation column was being backfilled
-	// and the virtual computed column value needed to be computed for the purpose
-	// of writing to a secondary index.
+	// would not be safe in the case that the mutation column was being
+	// backfilled and the virtual computed column value needed to be computed
+	// for the purpose of writing to a secondary index.
 	if d.IsVirtual() {
 		var mutationColumnNames []string
 		var err error
@@ -136,6 +136,7 @@ func ValidateComputedColumnExpression(
 					"current transaction", d.Name, strings.Join(mutationColumnNames, ", "))
 		}
 	}
+
 	return expr, typ, nil
 }
 

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1867,6 +1867,27 @@ func NewTableDesc(
 		return newColumns, nil
 	}
 
+	// Now that we have all the other columns set up, we can validate
+	// any computed columns.
+	for _, def := range n.Defs {
+		switch d := def.(type) {
+		case *tree.ColumnTableDef:
+			if d.IsComputed() {
+				serializedExpr, _, err := schemaexpr.ValidateComputedColumnExpression(
+					ctx, &desc, d, &n.Table, "computed column", semaCtx,
+				)
+				if err != nil {
+					return nil, err
+				}
+				col, err := desc.FindColumnWithName(d.Name)
+				if err != nil {
+					return nil, err
+				}
+				col.ColumnDesc().ComputeExpr = &serializedExpr
+			}
+		}
+	}
+
 	for _, def := range n.Defs {
 		switch d := def.(type) {
 		case *tree.ColumnTableDef, *tree.LikeTableDef:
@@ -1878,6 +1899,22 @@ func NewTableDesc(
 			// AllocateIDs is called.
 			if d.Name != "" && desc.ValidateIndexNameIsUnique(d.Name.String()) != nil {
 				return nil, pgerror.Newf(pgcode.DuplicateRelation, "duplicate index name: %q", d.Name)
+			}
+			if err := validateColumnsAreAccessible(&desc, d.Columns); err != nil {
+				return nil, err
+			}
+			if err := replaceExpressionElemsWithVirtualCols(
+				ctx,
+				&desc,
+				&n.Table,
+				d.Columns,
+				d.Inverted,
+				true, /* isNewTable */
+				semaCtx,
+				evalCtx,
+				sessionData,
+			); err != nil {
+				return nil, err
 			}
 			idx := descpb.IndexDescriptor{
 				Name:             string(d.Name),
@@ -1986,6 +2023,22 @@ func NewTableDesc(
 			// AllocateIDs is called.
 			if d.Name != "" && desc.ValidateIndexNameIsUnique(d.Name.String()) != nil {
 				return nil, pgerror.Newf(pgcode.DuplicateRelation, "duplicate index name: %q", d.Name)
+			}
+			if err := validateColumnsAreAccessible(&desc, d.Columns); err != nil {
+				return nil, err
+			}
+			if err := replaceExpressionElemsWithVirtualCols(
+				ctx,
+				&desc,
+				&n.Table,
+				d.Columns,
+				false, /* isInverted */
+				true,  /* isNewTable */
+				semaCtx,
+				evalCtx,
+				sessionData,
+			); err != nil {
+				return nil, err
 			}
 			idx := descpb.IndexDescriptor{
 				Name:             string(d.Name),
@@ -2291,27 +2344,6 @@ func NewTableDesc(
 
 		default:
 			return nil, errors.Errorf("unsupported table def: %T", def)
-		}
-	}
-
-	// Now that we have all the other columns set up, we can validate
-	// any computed columns.
-	for _, def := range n.Defs {
-		switch d := def.(type) {
-		case *tree.ColumnTableDef:
-			if d.IsComputed() {
-				serializedExpr, _, err := schemaexpr.ValidateComputedColumnExpression(
-					ctx, &desc, d, &n.Table, "computed column", semaCtx,
-				)
-				if err != nil {
-					return nil, err
-				}
-				col, err := desc.FindColumnWithName(d.Name)
-				if err != nil {
-					return nil, err
-				}
-				col.ColumnDesc().ComputeExpr = &serializedExpr
-			}
 		}
 	}
 

--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -299,6 +299,17 @@ CREATE TABLE y (
   b INT AS (a) STORED
 )
 
+statement ok
+CREATE TABLE x (
+  a INT
+)
+
+statement error expected computed column expression to have type string, but .* has type int
+ALTER TABLE x ADD COLUMN err STRING AS (10::INT) STORED
+
+statement ok
+DROP TABLE x
+
 statement error context-dependent operators are not allowed in computed column
 CREATE TABLE y (
   a TIMESTAMP AS (now()) STORED

--- a/pkg/sql/logictest/testdata/logic_test/expression_index
+++ b/pkg/sql/logictest/testdata/logic_test/expression_index
@@ -1,3 +1,137 @@
+statement error unimplemented: only simple columns are supported as index elements
+CREATE TABLE err (
+  k INT PRIMARY KEY,
+  a INT,
+  b INT,
+  INDEX ((a + b))
+)
+
+statement ok
+CREATE TABLE t (
+  k INT PRIMARY KEY,
+  a INT,
+  b INT
+)
+
+statement error unimplemented: only simple columns are supported as index elements
+CREATE INDEX err ON t ((a + b))
+
+statement ok
+DROP TABLE t
+
+statement ok
+SET experimental_enable_expression_indexes=true
+
+statement ok
+CREATE TABLE t (
+  k INT PRIMARY KEY,
+  a INT,
+  b INT,
+  c STRING,
+  j JSON,
+  comp INT AS (a + 10) VIRTUAL,
+  INDEX t_a_plus_b_idx ((a + b)),
+  INDEX t_lower_c_a_plus_b_idx (lower(c), (a + b)),
+  FAMILY (k, a, b, c, j)
+)
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE t]
+----
+CREATE TABLE public.t (
+   k INT8 NOT NULL,
+   a INT8 NULL,
+   b INT8 NULL,
+   c STRING NULL,
+   j JSONB NULL,
+   comp INT8 NULL AS (a + 10:::INT8) VIRTUAL,
+   CONSTRAINT "primary" PRIMARY KEY (k ASC),
+   INDEX t_a_plus_b_idx ((a + b) ASC),
+   INDEX t_lower_c_a_plus_b_idx (lower(c) ASC, (a + b) ASC),
+   FAMILY fam_0_k_a_b_c_j (k, a, b, c, j)
+)
+
+# Referencing an inaccessible column in a CHECK constraint is not allowed.
+statement error column \"crdb_internal_idx_expr\" is inaccessible and cannot be referenced
+CREATE TABLE err (a INT, INDEX ((a + 10)), CHECK (crdb_internal_idx_expr > 0))
+
+# Referencing an inaccessible column in a UNIQUE constraint is not allowed.
+statement error column \"crdb_internal_idx_expr\" is inaccessible and cannot be referenced
+CREATE TABLE err (a INT, INDEX ((a + 10)), UNIQUE (crdb_internal_idx_expr))
+
+# Referencing an inaccessible column in a computed column expression is not
+# allowed.
+statement error column \"crdb_internal_idx_expr\" does not exist
+CREATE TABLE err (a INT, INDEX ((a + 10)), comp INT AS (crdb_internal_idx_expr + 10) STORED)
+
+# Referencing an inaccessible column in an index is not allowed.
+statement error column \"crdb_internal_idx_expr\" is inaccessible and cannot be referenced
+CREATE TABLE err (a INT, INDEX ((a + 10)), INDEX (crdb_internal_idx_expr))
+
+# Referencing an inaccessible column in a partial index predicate expression is
+# not allowed.
+statement error column \"crdb_internal_idx_expr\" is inaccessible and cannot be referenced
+CREATE TABLE err (a INT, INDEX ((a + 10)), INDEX (a) WHERE crdb_internal_idx_expr > 0)
+
+# Referencing an inaccessible column in a FK on the child side is not allowed.
+statement error column \"crdb_internal_idx_expr\" is inaccessible and cannot reference a foreign key
+CREATE TABLE err (a INT, INDEX ((a + 10)), FOREIGN KEY (crdb_internal_idx_expr) REFERENCES t(a))
+
+# A unique column name will be selected for expression index columns.
+statement ok
+CREATE TABLE name_collision (a INT, INDEX ((a + 10)), crdb_internal_idx_expr INT)
+
+query T
+SELECT * FROM (
+  SELECT json_array_elements(
+    crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', descriptor, false)->'table'->'columns'
+  ) AS desc FROM system.descriptor WHERE id = 'name_collision'::REGCLASS
+) AS cols WHERE cols.desc->'name' = '"crdb_internal_idx_expr_1"'
+----
+{"computeExpr": "a + 10:::INT8", "id": 3, "inaccessible": true, "name": "crdb_internal_idx_expr_1", "nullable": true, "type": {"family": "IntFamily", "oid": 20, "width": 64}, "virtual": true}
+
+statement error volatile functions are not allowed in index element
+CREATE TABLE err (a INT, INDEX ((a + random()::INT)))
+
+statement error column \"z\" does not exist
+CREATE TABLE err (a INT, INDEX ((a + z)))
+
+statement error index element expression cannot reference computed columns
+CREATE TABLE err (a INT, comp INT AS (a + 10) STORED, INDEX ((comp + 100)))
+
+statement error type of index element NULL is ambiguous.*\nHINT: consider adding a type cast to the expression
+CREATE TABLE err (a INT, INDEX (a, (NULL)))
+
+statement ok
+CREATE TABLE t_null_cast (a INT, INDEX (a, (NULL::TEXT)))
+
+statement error index element j->'a' of type jsonb is not indexable
+CREATE TABLE err (a INT, j JSON, INDEX (a, (j->'a')))
+
+statement error index element \(a, b\) of type record is not indexable
+CREATE TABLE err (a INT, b INT, INDEX (a, (row(a, b))))
+
+statement error index element j->'a' of type jsonb is not allowed as a prefix column in an inverted index.*\nHINT: see the documentation for more information about inverted indexes: https://www.cockroachlabs.com/docs/.*/inverted-indexes.html
+CREATE TABLE err (a INT, j JSON, INVERTED INDEX ((j->'a'), j))
+
+statement error index element a \+ b of type int is not allowed as the last column in an inverted index.*\nHINT: see the documentation for more information about inverted indexes: https://www.cockroachlabs.com/docs/.*/inverted-indexes.html
+CREATE TABLE err (a INT, b INT, INVERTED INDEX (a, (a + b)))
+
+statement error index element \(a, b\) of type record is not allowed as the last column in an inverted index.*\nHINT: see the documentation for more information about inverted indexes: https://www.cockroachlabs.com/docs/.*/inverted-indexes.html
+CREATE TABLE err (a INT, b INT, INVERTED INDEX (a, (row(a, b))))
+
+statement error volatile functions are not allowed in index element
+CREATE TABLE err (a INT, INDEX ((a + random()::INT)))
+
+statement error column \"z\" does not exist
+CREATE TABLE err (a INT, INDEX ((a + z)))
+
+statement error index element expression cannot reference computed columns
+CREATE TABLE err (a INT, comp INT AS (a + 10) STORED, INDEX ((comp + 10)))
+
+statement ok
+DROP TABLE t
+
 statement ok
 CREATE TABLE t (
   k INT PRIMARY KEY,
@@ -8,12 +142,6 @@ CREATE TABLE t (
   comp INT AS (a + 10) VIRTUAL,
   FAMILY (k, a, b, c, j)
 )
-
-statement error unimplemented: only simple columns are supported as index elements
-CREATE INDEX err ON t ((a + b))
-
-statement ok
-SET experimental_enable_expression_indexes=true
 
 statement ok
 CREATE INDEX t_a_plus_b_idx ON t ((a + b))
@@ -63,7 +191,7 @@ statement error column \"crdb_internal_idx_expr_4\" is inaccessible and cannot b
 ALTER TABLE t ADD COLUMN err INT AS (crdb_internal_idx_expr_4 + 10) STORED
 
 # Referencing an inaccessible column in an index is not allowed.
-statement error column \"crdb_internal_idx_expr_4\" is inaccessible and cannot be indexed
+statement error column \"crdb_internal_idx_expr_4\" is inaccessible and cannot be referenced
 CREATE INDEX err ON t (crdb_internal_idx_expr_4)
 
 # Referencing an inaccessible column in a partial index predicate expression is
@@ -80,6 +208,9 @@ CREATE TABLE child (a INT)
 
 statement error column \"crdb_internal_idx_expr_4\" is inaccessible and cannot be referenced by a foreign key
 ALTER TABLE child ADD CONSTRAINT err FOREIGN KEY (a) REFERENCES t(crdb_internal_idx_expr_4)
+
+statement error column \"crdb_internal_idx_expr_4\" is inaccessible and cannot reference a foreign key
+ALTER TABLE t ADD CONSTRAINT err FOREIGN KEY (crdb_internal_idx_expr_4) REFERENCES child(a)
 
 # Adding a column with the same name as one of the inaccessible columns created
 # for an expression index is not allowed.
@@ -185,6 +316,38 @@ CREATE INDEX ON anon ((a + 10), b);
 CREATE UNIQUE INDEX ON anon (lower(c), b);
 CREATE INDEX ON anon ((a + 10), b, lower(c));
 CREATE INDEX ON anon ((a + 10), (b + 100), lower(c));
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE anon]
+----
+CREATE TABLE public.anon (
+   k INT8 NOT NULL,
+   a INT8 NULL,
+   b INT8 NULL,
+   c STRING NULL,
+   CONSTRAINT "primary" PRIMARY KEY (k ASC),
+   INDEX anon_expr_idx ((a + b) ASC),
+   INDEX anon_expr_b_idx ((a + 10:::INT8) ASC, b ASC),
+   UNIQUE INDEX anon_expr_b_key (lower(c) ASC, b ASC),
+   INDEX anon_expr_b_expr1_idx ((a + 10:::INT8) ASC, b ASC, lower(c) ASC),
+   INDEX anon_expr_expr1_expr2_idx ((a + 10:::INT8) ASC, (b + 100:::INT8) ASC, lower(c) ASC),
+   FAMILY fam_0_k_a_b_c (k, a, b, c)
+)
+
+statement ok
+DROP TABLE anon;
+CREATE TABLE anon (
+  k INT PRIMARY KEY,
+  a INT,
+  b INT,
+  c STRING,
+  INDEX ((a + b)),
+  INDEX ((a + 10), b),
+  UNIQUE INDEX (lower(c), b),
+  INDEX ((a + 10), b, lower(c)),
+  INDEX ((a + 10), (b + 100), lower(c)),
+  FAMILY (k, a, b, c)
+)
 
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE anon]

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -330,9 +330,9 @@ statement ok
 CREATE TABLE constraint_db.t6 (
   a INT,
   b INT,
-  c STRING
+  c STRING,
+  INDEX ((a + b))
 );
-CREATE INDEX ON constraint_db.t6 ((a + b));
 CREATE INDEX ON constraint_db.t6 (lower(c), (a + b));
 CREATE UNIQUE INDEX ON constraint_db.t6 (lower(c));
 
@@ -620,9 +620,9 @@ attrelid    relname            attname                   atttypid  attstattarget
 61          t6                 a                         20        0              8       1       0         -1
 61          t6                 b                         20        0              8       2       0         -1
 61          t6                 c                         25        0              -1      3       0         -1
-61          t6                 rowid                     20        0              8       4       0         -1
-4179599057  primary            rowid                     20        0              8       4       0         -1
-4179599058  t6_expr_idx        crdb_internal_idx_expr    20        0              8       5       0         -1
+61          t6                 rowid                     20        0              8       5       0         -1
+4179599057  primary            rowid                     20        0              8       5       0         -1
+4179599058  t6_expr_idx        crdb_internal_idx_expr    20        0              8       4       0         -1
 4179599059  t6_expr_expr1_idx  crdb_internal_idx_expr_1  25        0              -1      6       0         -1
 4179599059  t6_expr_expr1_idx  crdb_internal_idx_expr_2  20        0              8       7       0         -1
 4179599060  t6_expr_key        crdb_internal_idx_expr_3  25        0              -1      8       0         -1
@@ -849,7 +849,7 @@ oid         relname  adrelid  adnum  adbin           adsrc           pg_get_expr
 2186255409  t3       57       4      unique_rowid()  unique_rowid()  unique_rowid()
 581442131   t4       59       4      unique_rowid()  unique_rowid()  unique_rowid()
 4050804964  t5       60       4      unique_rowid()  unique_rowid()  unique_rowid()
-1100914677  t6       61       4      unique_rowid()  unique_rowid()  unique_rowid()
+1100914676  t6       61       5      unique_rowid()  unique_rowid()  unique_rowid()
 2445991680  mv1      62       2      unique_rowid()  unique_rowid()  unique_rowid()
 
 ## pg_catalog.pg_indexes
@@ -3675,7 +3675,7 @@ WHERE n.nspname = 'public'
 2186255409  t3   unique_rowid()
 581442131   t4   unique_rowid()
 4050804964  t5   unique_rowid()
-1100914677  t6   unique_rowid()
+1100914676  t6   unique_rowid()
 2445991680  mv1  unique_rowid()
 
 # Verify that a set database shows tables from that database for a non-root


### PR DESCRIPTION
This commit adds support for creating expression-based indexes in
`CREATE TABLE` statements.

There is no release note because expression-based indexes are not
enabled by default. They require the
experimental_enable_expression_indexes session setting until they are
fully supported.

Release note: None
