### PR TITLE
roachtest: save timeseries dumps as artifacts

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1654,6 +1654,27 @@ func (c *cluster) CopyRoachprodState(ctx context.Context) error {
 	return errors.Wrapf(err, "command %q failed: output: %v", cmd.Args, string(output))
 }
 
+// FetchTimeseriesData downloads the timeseries from the cluster using
+// the first available node. They can be visualized via:
+//
+// `COCKROACH_DEBUG_TS_IMPORT_FILE=tsdump.gob ./cockroach start-single-node --insecure --store=$(mktemp -d)`
+func (c *cluster) FetchTimeseriesData(ctx context.Context) error {
+	return contextutil.RunWithTimeout(ctx, "debug zip", 5*time.Minute, func(ctx context.Context) error {
+		var err error
+		for i := 1; i <= c.spec.NodeCount; i++ {
+			err = c.RunE(ctx, c.Node(i), "./cockroach debug tsdump --insecure --format=raw > tsdump.gob")
+			if err == nil {
+				err = c.Get(ctx, c.l, "tsdump.gob", filepath.Join(c.t.ArtifactsDir(), "tsdump.gob"), c.Node(i))
+			}
+			if err == nil {
+				return nil
+			}
+			c.l.Printf("while fetching timeseries: %s", err)
+		}
+		return err
+	})
+}
+
 // FetchDebugZip downloads the debug zip from the cluster using `roachprod ssh`.
 // The logs will be placed in the test's artifacts dir.
 func (c *cluster) FetchDebugZip(ctx context.Context) error {

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1582,14 +1582,14 @@ func (c *cluster) FetchLogs(ctx context.Context) error {
 		}
 
 		if err := execCmd(ctx, c.l, roachprod, "get", c.name, "logs" /* src */, path /* dest */); err != nil {
-			log.Infof(ctx, "failed to fetch logs: %v", err)
+			c.l.Printf("failed to fetch logs: %v", err)
 			if ctx.Err() != nil {
 				return err
 			}
 		}
 
 		if err := c.RunE(ctx, c.All(), "mkdir -p logs/redacted && ./cockroach debug merge-logs --redact logs/*.log > logs/redacted/combined.log"); err != nil {
-			log.Infof(ctx, "failed to redact logs: %v", err)
+			c.l.Printf("failed to redact logs: %v", err)
 			if ctx.Err() != nil {
 				return err
 			}

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -299,7 +299,7 @@ func (r *testRunner) Run(
 				l,
 			); err != nil {
 				// A worker returned an error. Let's shut down.
-				msg := fmt.Sprintf("Worker %d returned with error. Quiescing. Error: %+v", i, err)
+				msg := fmt.Sprintf("Worker %d returned with error. Quiescing. Error: %v", i, err)
 				shout(ctx, l, lopt.stdout, msg)
 				errs.AddErr(err)
 				// Stop the stopper. This will cause all workers to not pick up more

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -922,6 +922,9 @@ func (r *testRunner) collectClusterLogs(ctx context.Context, c *cluster, l *logg
 	if err := c.FetchDiskUsage(ctx); err != nil {
 		l.Printf("failed to fetch disk uage summary: %s", err)
 	}
+	if err := c.FetchTimeseriesData(ctx); err != nil {
+		l.Printf("failed to fetch timeseries data: %s", err)
+	}
 	if err := c.FetchDebugZip(ctx); err != nil {
 		l.Printf("failed to collect zip: %s", err)
 	}


### PR DESCRIPTION
- roachtest: minor logging improvements
- roachtest: fetch timeseries dump on failed tests
