### PR TITLE
CODEOWNERS: add dev-inf as owner of `.github`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,6 +17,8 @@
 # [2]: https://help.github.com/articles/about-codeowners/
 # [3]: pkg/internal/codeowners
 
+/.github/                    @cockroachdb/dev-inf
+
 /docs/RFCS/                  @cockroachdb/rfc-prs
 
 /pkg/sql/opt/                @cockroachdb/sql-opt-prs


### PR DESCRIPTION
Keep the Developer Infrastructure team aware of the changes to the
`.github` directory, which may contain CI-related changes.

Release note: None