### PR TITLE
changefeedccl: stricter URL matching in TestSchemaRegistry

### DIFF
--- a/pkg/ccl/changefeedccl/cdctest/schema_registry.go
+++ b/pkg/ccl/changefeedccl/cdctest/schema_registry.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
@@ -33,21 +34,18 @@ type SchemaRegistry struct {
 	}
 }
 
-// MakeTestSchemaRegistry creates and starts schema registry for tests.
-func MakeTestSchemaRegistry() *SchemaRegistry {
-	r := &SchemaRegistry{}
-	r.mu.schemas = make(map[int32]string)
-	r.mu.subjects = make(map[string]int32)
-	r.server = httptest.NewServer(http.HandlerFunc(r.register))
+// StartTestSchemaRegistry creates and starts schema registry for
+// tests.
+func StartTestSchemaRegistry() *SchemaRegistry {
+	r := makeTestSchemaRegistry()
+	r.server.Start()
 	return r
 }
 
-// MakeTestSchemaRegistryWithTLS creates and starts schema registry for tests with TLS enabled.
-func MakeTestSchemaRegistryWithTLS(certificate *tls.Certificate) (*SchemaRegistry, error) {
-	r := &SchemaRegistry{}
-	r.mu.schemas = make(map[int32]string)
-	r.mu.subjects = make(map[string]int32)
-	r.server = httptest.NewUnstartedServer(http.HandlerFunc(r.register))
+// StartTestSchemaRegistryWithTLS creates and starts schema registry
+// for tests with TLS enabled.
+func StartTestSchemaRegistryWithTLS(certificate *tls.Certificate) (*SchemaRegistry, error) {
+	r := makeTestSchemaRegistry()
 	if certificate != nil {
 		r.server.TLS = &tls.Config{
 			Certificates: []tls.Certificate{*certificate},
@@ -55,6 +53,14 @@ func MakeTestSchemaRegistryWithTLS(certificate *tls.Certificate) (*SchemaRegistr
 	}
 	r.server.StartTLS()
 	return r, nil
+}
+
+func makeTestSchemaRegistry() *SchemaRegistry {
+	r := &SchemaRegistry{}
+	r.mu.schemas = make(map[int32]string)
+	r.mu.subjects = make(map[string]int32)
+	r.server = httptest.NewUnstartedServer(http.HandlerFunc(r.requestHandler))
+	return r
 }
 
 // Close closes this schema registry.
@@ -84,43 +90,69 @@ func (r *SchemaRegistry) SchemaForSubject(subject string) string {
 	return r.mu.schemas[r.mu.subjects[subject]]
 }
 
+func (r *SchemaRegistry) registerSchema(subject string, schema string) int32 {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	id := r.mu.idAlloc
+	r.mu.idAlloc++
+	r.mu.schemas[id] = schema
+	r.mu.subjects[subject] = id
+	return id
+}
+
+var (
+	// We are slightly stricter than confluent here as they allow
+	// a trailing slash.
+	subjectVersionsRegexp = regexp.MustCompile("^/subjects/[^/]+/versions$")
+)
+
+// requestHandler routes requests based on the Method and Path of the request.
+func (r *SchemaRegistry) requestHandler(hw http.ResponseWriter, hr *http.Request) {
+	path := hr.URL.Path
+	method := hr.Method
+
+	var err error
+	switch {
+	case method == http.MethodPost && subjectVersionsRegexp.MatchString(path):
+		err = r.register(hw, hr)
+	default:
+		hw.WriteHeader(http.StatusNotFound)
+		return
+	}
+	if err != nil {
+		http.Error(hw, err.Error(), http.StatusInternalServerError)
+	}
+}
+
 // register is an http hander for the underlying server which registers schemas.
-func (r *SchemaRegistry) register(hw http.ResponseWriter, hr *http.Request) {
+func (r *SchemaRegistry) register(hw http.ResponseWriter, hr *http.Request) (err error) {
 	type confluentSchemaVersionRequest struct {
 		Schema string `json:"schema"`
 	}
 	type confluentSchemaVersionResponse struct {
 		ID int32 `json:"id"`
 	}
-	if err := func() (err error) {
-		defer func() {
-			err = hr.Body.Close()
-		}()
 
-		var req confluentSchemaVersionRequest
-		if err := json.NewDecoder(hr.Body).Decode(&req); err != nil {
-			return err
-		}
+	defer func() {
+		err = hr.Body.Close()
+	}()
 
-		r.mu.Lock()
-		subject := strings.Split(hr.URL.Path, "/")[2]
-		id := r.mu.idAlloc
-		r.mu.idAlloc++
-		r.mu.schemas[id] = req.Schema
-		r.mu.subjects[subject] = id
-		r.mu.Unlock()
-
-		res, err := json.Marshal(confluentSchemaVersionResponse{ID: id})
-		if err != nil {
-			return err
-		}
-
-		hw.Header().Set(`Content-type`, `application/json`)
-		_, _ = hw.Write(res)
-		return nil
-	}(); err != nil {
-		http.Error(hw, err.Error(), http.StatusInternalServerError)
+	var req confluentSchemaVersionRequest
+	if err := json.NewDecoder(hr.Body).Decode(&req); err != nil {
+		return err
 	}
+
+	subject := strings.Split(hr.URL.Path, "/")[2]
+	id := r.registerSchema(subject, req.Schema)
+	res, err := json.Marshal(confluentSchemaVersionResponse{ID: id})
+	if err != nil {
+		return err
+	}
+
+	hw.Header().Set(`Content-type`, `application/json`)
+	_, err = hw.Write(res)
+	return err
 }
 
 // EncodedAvroToNative decodes bytes that were previously encoded by

--- a/pkg/ccl/changefeedccl/encoder.go
+++ b/pkg/ccl/changefeedccl/encoder.go
@@ -15,7 +15,7 @@ import (
 	gojson "encoding/json"
 	"io/ioutil"
 	"net/url"
-	"path/filepath"
+	"path"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -553,7 +553,7 @@ func (e *confluentAvroEncoder) register(
 	if err != nil {
 		return 0, err
 	}
-	url.Path = filepath.Join(url.EscapedPath(), `subjects`, subject, `versions`)
+	url.Path = path.Join(url.EscapedPath(), `subjects`, subject, `versions`)
 
 	schemaStr := schema.codec.Schema()
 	if log.V(1) {

--- a/pkg/ccl/changefeedccl/encoder_test.go
+++ b/pkg/ccl/changefeedccl/encoder_test.go
@@ -199,7 +199,7 @@ func TestEncoders(t *testing.T) {
 				rowStringFn = func(k, v []byte) string { return fmt.Sprintf(`%s->%s`, k, v) }
 				resolvedStringFn = func(r []byte) string { return string(r) }
 			case string(changefeedbase.OptFormatAvro):
-				reg := cdctest.MakeTestSchemaRegistry()
+				reg := cdctest.StartTestSchemaRegistry()
 				defer reg.Close()
 				o[changefeedbase.OptConfluentSchemaRegistry] = reg.URL()
 				rowStringFn = func(k, v []byte) string {
@@ -268,7 +268,7 @@ func TestAvroEncoder(t *testing.T) {
 
 	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
 		ctx := context.Background()
-		reg := cdctest.MakeTestSchemaRegistry()
+		reg := cdctest.StartTestSchemaRegistry()
 		defer reg.Close()
 
 		sqlDB := sqlutils.MakeSQLRunner(db)
@@ -384,7 +384,7 @@ func TestAvroEncoderWithTLS(t *testing.T) {
 
 		var rowStringFn func([]byte, []byte) string
 		var resolvedStringFn func([]byte) string
-		reg, err := cdctest.MakeTestSchemaRegistryWithTLS(cert)
+		reg, err := cdctest.StartTestSchemaRegistryWithTLS(cert)
 		require.NoError(t, err)
 		defer reg.Close()
 
@@ -445,7 +445,7 @@ func TestAvroEncoderWithTLS(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, expected.resolved, resolvedStringFn(resolved))
 
-		noCertReg, err := cdctest.MakeTestSchemaRegistryWithTLS(nil)
+		noCertReg, err := cdctest.StartTestSchemaRegistryWithTLS(nil)
 		require.NoError(t, err)
 		defer noCertReg.Close()
 		opts[changefeedbase.OptConfluentSchemaRegistry] = noCertReg.URL()
@@ -461,7 +461,7 @@ func TestAvroEncoderWithTLS(t *testing.T) {
 		wrongCert, _, err := newCACertBase64Encoded()
 		require.NoError(t, err)
 
-		wrongCertReg, err := cdctest.MakeTestSchemaRegistryWithTLS(wrongCert)
+		wrongCertReg, err := cdctest.StartTestSchemaRegistryWithTLS(wrongCert)
 		require.NoError(t, err)
 		defer wrongCertReg.Close()
 		opts[changefeedbase.OptConfluentSchemaRegistry] = wrongCertReg.URL()
@@ -481,15 +481,15 @@ func TestAvroArray(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
-		reg := cdctest.MakeTestSchemaRegistry()
+		reg := cdctest.StartTestSchemaRegistry()
 		defer reg.Close()
 
 		sqlDB := sqlutils.MakeSQLRunner(db)
 		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b INT[])`)
 		sqlDB.Exec(t,
-			`INSERT INTO foo VALUES 
-			(1, ARRAY[10,20,30]), 
-			(2, NULL), 
+			`INSERT INTO foo VALUES
+			(1, ARRAY[10,20,30]),
+			(2, NULL),
 			(3, ARRAY[42, NULL, 42, 43]),
 			(4, ARRAY[])`,
 		)
@@ -515,7 +515,7 @@ func TestAvroCollatedString(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
-		reg := cdctest.MakeTestSchemaRegistry()
+		reg := cdctest.StartTestSchemaRegistry()
 		defer reg.Close()
 
 		sqlDB := sqlutils.MakeSQLRunner(db)
@@ -540,7 +540,7 @@ func TestAvroSchemaNaming(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
-		reg := cdctest.MakeTestSchemaRegistry()
+		reg := cdctest.StartTestSchemaRegistry()
 		defer reg.Close()
 
 		sqlDB := sqlutils.MakeSQLRunner(db)
@@ -631,7 +631,7 @@ func TestAvroSchemaNamespace(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
-		reg := cdctest.MakeTestSchemaRegistry()
+		reg := cdctest.StartTestSchemaRegistry()
 		defer reg.Close()
 
 		sqlDB := sqlutils.MakeSQLRunner(db)
@@ -673,7 +673,7 @@ func TestTableNameCollision(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
-		reg := cdctest.MakeTestSchemaRegistry()
+		reg := cdctest.StartTestSchemaRegistry()
 		defer reg.Close()
 
 		sqlDB := sqlutils.MakeSQLRunner(db)
@@ -729,7 +729,7 @@ func TestAvroMigrateToUnsupportedColumn(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
-		reg := cdctest.MakeTestSchemaRegistry()
+		reg := cdctest.StartTestSchemaRegistry()
 		defer reg.Close()
 
 		sqlDB := sqlutils.MakeSQLRunner(db)
@@ -760,7 +760,7 @@ func TestAvroLedger(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
-		reg := cdctest.MakeTestSchemaRegistry()
+		reg := cdctest.StartTestSchemaRegistry()
 		defer reg.Close()
 
 		ctx := context.Background()

--- a/pkg/ccl/changefeedccl/sink_test.go
+++ b/pkg/ccl/changefeedccl/sink_test.go
@@ -600,7 +600,7 @@ func TestKafkaSinkTracksMemory(t *testing.T) {
 	// regular messages since it doesn't have Key set.
 	// We bypass majority of EmitResolvedTimestamp logic since we don't have
 	// a real kafka client instantiated.  Instead, we call emitMessage directly.
-	reg := cdctest.MakeTestSchemaRegistry()
+	reg := cdctest.StartTestSchemaRegistry()
 	defer reg.Close()
 	opts := map[string]string{
 		changefeedbase.OptEnvelope:                string(changefeedbase.OptEnvelopeWrapped),

--- a/pkg/ccl/changefeedccl/testfeed_test.go
+++ b/pkg/ccl/changefeedccl/testfeed_test.go
@@ -1072,7 +1072,7 @@ func (k *kafkaFeedFactory) Feed(create string, args ...interface{}) (cdctest.Tes
 			if format == string(changefeedbase.OptFormatAvro) {
 				// Must use confluent schema registry so that we register our schema
 				// in order to be able to decode kafka messages.
-				registry = cdctest.MakeTestSchemaRegistry()
+				registry = cdctest.StartTestSchemaRegistry()
 				registryOption := tree.KVOption{
 					Key:   changefeedbase.OptConfluentSchemaRegistry,
 					Value: tree.NewStrVal(registry.URL()),


### PR DESCRIPTION
The test schema registry previously accepted any URL you passed to
it. Now it expects the URLs in the actual schema registry API.

Release note: None