### PR TITLE
ui: format missing event types in the events page

### DIFF
--- a/pkg/ui/src/util/eventTypes.ts
+++ b/pkg/ui/src/util/eventTypes.ts
@@ -32,6 +32,8 @@ export const ALTER_DATABASE_DROP_REGION = "alter_database_drop_region";
 export const ALTER_DATABASE_PRIMARY_REGION = "alter_database_primary_region";
 // Recorded when the survival goal of a database is altered.
 export const ALTER_DATABASE_SURVIVAL_GOAL = "alter_database_survival_goal";
+// Recorded when a table's owner is changed.
+export const ALTER_TABLE_OWNER = "alter_table_owner";
 // Recorded when a table is created.
 export const CREATE_TABLE = "create_table";
 // Recorded when a table is dropped.
@@ -56,8 +58,20 @@ export const DROP_VIEW = "drop_view";
 export const CREATE_TYPE = "create_type";
 // Recorded when a type is altered.
 export const ALTER_TYPE = "alter_type";
+// Recorded when a type's owner is changed.
+export const ALTER_TYPE_OWNER = "alter_type_owner";
+// Recorded when a database's comment is changed.
+export const COMMENT_ON_DATABASE = "comment_on_database";
+// Recorded when a table's comment is changed.
+export const COMMENT_ON_TABLE = "comment_on_table";
+// Recorded when a index's comment is changed.
+export const COMMENT_ON_INDEX = "comment_on_index";
+// Recorded when a column's comment is changed.
+export const COMMENT_ON_COLUMN = "comment_on_column";
 // Recorded when a type is dropped.
 export const DROP_TYPE = "drop_type";
+// Recorded when a type is renamed.
+export const RENAME_TYPE = "rename_type";
 // Recorded when a sequence is created.
 export const CREATE_SEQUENCE = "create_sequence";
 // Recorded when a sequence is altered.
@@ -97,6 +111,8 @@ export const CHANGE_TABLE_PRIVILEGE = "change_table_privilege";
 export const CHANGE_SCHEMA_PRIVILEGE = "change_schema_privilege";
 // Recorded when privileges are added to a user.
 export const CHANGE_TYPE_PRIVILEGE = "change_type_privilege";
+// Recorded when a schema is set.
+export const SET_SCHEMA = "set_schema";
 // Recorded when a schema is created.
 export const CREATE_SCHEMA = "create_schema";
 // Recorded when a schema is dropped.
@@ -117,6 +133,14 @@ export const ALTER_ROLE = "alter_role";
 export const IMPORT = "import";
 // Recorded when a restore job is in different stages of execution.
 export const RESTORE = "restore";
+// Recorded when crdb_internal.unsafe_delete_descriptor is executed.
+export const UNSAFE_DELETE_DESCRIPTOR = "unsafe_delete_descriptor";
+// Recorded when crdb_internal.unsafe_delete_namespace_entry is executed.
+export const UNSAFE_DELETE_NAMESPACE_ENTRY = "unsafe_delete_namespace_entry";
+// Recorded when crdb_internal.unsafe_upsert_descriptor is executed.
+export const UNSAFE_UPSERT_DESCRIPTOR = "unsafe_upsert_descriptor";
+// Recorded when crdb_internal.unsafe_upsert_namespace_entry is executed.
+export const UNSAFE_UPSERT_NAMESPACE_ENTRY = "unsafe_upsert_namespace_entry";
 
 // Node Event Types
 export const nodeEvents = [

--- a/pkg/ui/src/util/events.ts
+++ b/pkg/ui/src/util/events.ts
@@ -23,6 +23,7 @@ export function getEventDescription(e: Event$Properties): string {
     ? JSON.parse(e.info)
     : {};
   let privs = "";
+  let comment = "";
 
   switch (e.event_type) {
     case eventTypes.CREATE_DATABASE:
@@ -35,6 +36,36 @@ export function getEventDescription(e: Event$Properties): string {
       return `Database Renamed: User ${info.User} renamed database ${info.DatabaseName} to ${info.NewDatabaseName}`;
     case eventTypes.ALTER_DATABASE_OWNER:
       return `Database Owner Altered: User ${info.User} altered the owner of database ${info.DatabaseName} to ${info.Owner}`;
+    case eventTypes.ALTER_TABLE_OWNER:
+      return `Table Owner Altered: User ${info.User} altered the owner of the table ${info.TableName} to ${info.Owner}`;
+    case eventTypes.COMMENT_ON_DATABASE:
+      if (info.NullComment) {
+        comment += " removed the comment ";
+      } else {
+        comment += ' commented "' + info.Comment + '" ';
+      }
+      return `Comment: User ${info.User}${comment} on database ${info.DatabaseName}`;
+    case eventTypes.COMMENT_ON_TABLE:
+      if (info.NullComment) {
+        comment += " removed the comment ";
+      } else {
+        comment += ' commented "' + info.Comment + '" ';
+      }
+      return `Comment: User ${info.User}${comment} on table ${info.TableName}`;
+    case eventTypes.COMMENT_ON_INDEX:
+      if (info.NullComment) {
+        comment += " removed the comment ";
+      } else {
+        comment += ' commented "' + info.Comment + '" ';
+      }
+      return `Comment: User ${info.User}${comment} on index ${info.IndexName} of table ${info.TableName}`;
+    case eventTypes.COMMENT_ON_COLUMN:
+      if (info.NullComment) {
+        comment += " removed the comment ";
+      } else {
+        comment += ' commented "' + info.Comment + '" ';
+      }
+      return `Comment: User ${info.User}${comment} on column ${info.ColumnName} of table ${info.TableName}`;
     case eventTypes.CREATE_TABLE:
       return `Table Created: User ${info.User} created table ${info.TableName}`;
     case eventTypes.DROP_TABLE:
@@ -59,8 +90,12 @@ export function getEventDescription(e: Event$Properties): string {
       return `Type Created: User ${info.User} created type ${info.TypeName}`;
     case eventTypes.ALTER_TYPE:
       return `Type Altered: User ${info.User} altered type ${info.TypeName}`;
+    case eventTypes.ALTER_TYPE_OWNER:
+      return `Type Owner Altered: User ${info.User} altered the owner of the type ${info.TypeName} to ${info.Owner}`;
     case eventTypes.DROP_TYPE:
       return `Type Dropped: User ${info.User} dropped type ${info.TypeName}`;
+    case eventTypes.RENAME_TYPE:
+      return `Type Renamed: User ${info.User} renamed type ${info.TypeName} to ${info.NewTypeName}`;
     case eventTypes.CREATE_SEQUENCE:
       return `Sequence Created: User ${info.User} created sequence ${info.SequenceName}`;
     case eventTypes.ALTER_SEQUENCE:
@@ -126,6 +161,8 @@ export function getEventDescription(e: Event$Properties): string {
         privs += " revoked " + info.GrantedPrivileges;
       }
       return `Privilege change: User ${info.User}${privs} to ${info.Grantee} on type ${info.TypeName}`;
+    case eventTypes.SET_SCHEMA:
+      return `Schema Change: User ${info.User} set the schema of ${info.DescriptorType} ${info.DescriptorName} to ${info.NewDescriptorName}`;
     case eventTypes.CREATE_SCHEMA:
       return `Schema Created: User ${info.User} created schema ${info.SchemaName} with owner ${info.Owner}`;
     case eventTypes.DROP_SCHEMA:
@@ -154,8 +191,15 @@ export function getEventDescription(e: Event$Properties): string {
       return `Primary Region Changed: User ${info.User} changed primary region of database ${info.DatabaseName} to ${info.PrimaryRegionName}`;
     case eventTypes.ALTER_DATABASE_SURVIVAL_GOAL:
       return `Survival Goal Changed: User ${info.User} changed survival goal of database ${info.DatabaseName} to ${info.SurvivalGoal}`;
+    case (eventTypes.UNSAFE_UPSERT_NAMESPACE_ENTRY,
+    eventTypes.UNSAFE_DELETE_NAMESPACE_ENTRY,
+    eventTypes.UNSAFE_UPSERT_DESCRIPTOR,
+    eventTypes.UNSAFE_DELETE_DESCRIPTOR):
+      return `Unsafe: User ${info.User} executed crdb_internal.${
+        e.event_type
+      }, Info: ${JSON.stringify(info, null, 2)}`;
     default:
-      return `Unknown Event Type: ${e.event_type}, content: ${JSON.stringify(
+      return `Event: ${e.event_type}, content: ${JSON.stringify(
         info,
         null,
         2,
@@ -169,17 +213,23 @@ export interface EventInfo {
   CascadeDroppedViews?: string[];
   Config?: string;
   DatabaseName?: string;
+  DescriptorType?: string;
+  DescriptorName?: string;
+  NewDescriptorName?: string;
   DescriptorID?: string;
   Grantee?: string;
   GrantedPrivileges?: string[];
   IndexName?: string;
   MutationID?: string;
   NewDatabaseName?: string;
+  NewTypeName?: string;
   NewSchemaName?: string;
   NewTableName?: string;
   NodeID?: string;
   Options?: string[];
   Owner?: string;
+  Comment?: string;
+  NullComment?: string;
   RevokedPrivileges?: string[];
   RoleName?: string;
   SchemaName?: string;
@@ -187,6 +237,7 @@ export interface EventInfo {
   SettingName?: string;
   Statement?: string;
   TableName?: string;
+  ColumnName?: string;
   Target?: string;
   TargetNodeID?: string;
   TypeName?: string;
@@ -205,6 +256,13 @@ export interface EventInfo {
   RegionName?: string;
   PrimaryRegionName?: string;
   SurvivalGoal?: string;
+  ParentID?: string;
+  ParentSchemaID?: string;
+  Name?: string;
+  Force?: string;
+  ForceNotice?: string;
+  PreviousDescriptor?: string;
+  NewDescriptor?: string;
 }
 
 export function getDroppedObjectsText(eventInfo: EventInfo): string {


### PR DESCRIPTION
ui: format missing event types in the events page

This commit adds in missing formatting for events
that were previously rendered as raw json on the events page.

The events affected are listed below:
- alter_table_owner
- alter_type_owner
- comment_on_column
- comment_on_database
- comment_on_index
- comment_on_table
- rename_type
- set_schema
- unsafe_delete_descriptor
- unsafe_delete_namespace_entry
- unsafe_upsert_descriptor
- unsafe_upsert_namespace_entry

In addition, this commit changes the default event formatting (used when an event
is missing from the formatter) to be less alarming and more user friendly by replacing
the existing prefix "Unknown Event Type:" with "Event". This should lead to fewer cases
of users mistaking the missing event type messages as errors despite being harmless.

Resolves: #61332

Release note (ui change): Added missing formatting for a couple event types displayed on the events page
Release note (ui change): Changed default event formatting to appear less alarming to users.