### PR TITLE
tabledesc: promote index format more aggressively

### DIFF
--- a/pkg/sql/catalog/tabledesc/index_test.go
+++ b/pkg/sql/catalog/tabledesc/index_test.go
@@ -345,7 +345,7 @@ func TestIndexStrictColumnIDs(t *testing.T) {
 	idx := &mut.Indexes[0]
 	id := idx.KeyColumnIDs[0]
 	name := idx.KeyColumnNames[0]
-	idx.Version = descpb.EmptyArraysInInvertedIndexesVersion
+	idx.Version = descpb.SecondaryIndexFamilyFormatVersion
 	idx.StoreColumnIDs = append([]descpb.ColumnID{}, id, id, id, id)
 	idx.StoreColumnNames = append([]string{}, name, name, name, name)
 	idx.KeySuffixColumnIDs = append([]descpb.ColumnID{}, id, id, id, id)
@@ -376,13 +376,14 @@ func TestIndexStrictColumnIDs(t *testing.T) {
 	var msg string
 	err = rows.Scan(&msg)
 	require.NoError(t, err)
-	require.Equal(t, `InitPut /Table/53/2/0/0/0/0/0/0 -> /BYTES/0x2300030003000300`, msg)
+	expected := fmt.Sprintf(`InitPut /Table/%d/2/0/0/0/0/0/0 -> /BYTES/0x2300030003000300`, mut.GetID())
+	require.Equal(t, expected, msg)
 
 	// Test that with the strict guarantees, this table descriptor would have been
 	// considered invalid.
 	idx.Version = descpb.StrictIndexColumnIDGuaranteesVersion
-	require.EqualError(t, catalog.ValidateSelf(mut),
-		`relation "t" (53): index "sec" has duplicates in KeySuffixColumnIDs: [2 2 2 2]`)
+	expected = fmt.Sprintf(`relation "t" (%d): index "sec" has duplicates in KeySuffixColumnIDs: [2 2 2 2]`, mut.GetID())
+	require.EqualError(t, catalog.ValidateSelf(mut), expected)
 
 	_, err = conn.Exec(`ALTER TABLE d.t DROP COLUMN c2`)
 	require.NoError(t, err)

--- a/pkg/sql/catalog/tabledesc/table_desc_builder.go
+++ b/pkg/sql/catalog/tabledesc/table_desc_builder.go
@@ -465,7 +465,14 @@ func maybeUpgradeToFamilyFormatVersion(desc *descpb.TableDescriptor) bool {
 // maybeUpgradeIndexFormatVersion tries to promote an index to version
 // descpb.StrictIndexColumnIDGuaranteesVersion whenever possible.
 func maybeUpgradeIndexFormatVersion(idx *descpb.IndexDescriptor) (hasChanged bool) {
-	if idx.Version != descpb.EmptyArraysInInvertedIndexesVersion {
+	switch idx.Version {
+	case descpb.SecondaryIndexFamilyFormatVersion:
+		if idx.Type == descpb.IndexDescriptor_INVERTED {
+			return false
+		}
+	case descpb.EmptyArraysInInvertedIndexesVersion:
+		break
+	default:
 		return false
 	}
 	slice := make([]descpb.ColumnID, 0, len(idx.KeyColumnIDs)+len(idx.KeySuffixColumnIDs)+len(idx.StoreColumnIDs))


### PR DESCRIPTION
We recently introduced a change which promotes the `version` of a
descpb.IndexDescriptor from EmptyArraysInInvertedIndexesVersion to
StrictIndexColumnIDGuaranteesVersion.

This commit extends that promotion mechanism to
SecondaryIndexFamilyFormatVersion for non-inverted indexes.

Release note: None