### PR TITLE
release-21.1: cli: stop attributing time spent running schema changes to network lat 

### DIFF
--- a/pkg/sql/catalog/colinfo/result_columns.go
+++ b/pkg/sql/catalog/colinfo/result_columns.go
@@ -210,6 +210,7 @@ var ShowLastQueryStatisticsColumns = ResultColumns{
 	{Name: "plan_latency", Typ: types.Interval},
 	{Name: "exec_latency", Typ: types.Interval},
 	{Name: "service_latency", Typ: types.Interval},
+	{Name: "post_commit_jobs_latency", Typ: types.Interval},
 }
 
 // ShowFingerprintsColumns are the result columns of a

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -2389,12 +2389,14 @@ func (ex *connExecutor) txnStateTransitionsApplyWrapper(
 		}
 		ex.notifyStatsRefresherOfNewTables(ex.Ctx())
 
+		ex.statsCollector.phaseTimes[sessionStartPostCommitJob] = timeutil.Now()
 		if err := ex.server.cfg.JobRegistry.Run(
 			ex.ctxHolder.connCtx,
 			ex.server.cfg.InternalExecutor,
 			ex.extraTxnState.jobs); err != nil {
 			handleErr(err)
 		}
+		ex.statsCollector.phaseTimes[sessionEndPostCommitJob] = timeutil.Now()
 
 		fallthrough
 	case txnRestart, txnRollback:

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1338,6 +1338,7 @@ func (ex *connExecutor) runShowLastQueryStatistics(
 	// Since the last query has already finished, it is safe to retrieve its
 	// total service latency.
 	svcLat := phaseTimes.getServiceLatencyTotal().Seconds()
+	postCommitJobsLat := phaseTimes.getPostCommitJobsLatency().Seconds()
 
 	return res.AddRow(ctx,
 		tree.Datums{
@@ -1345,6 +1346,7 @@ func (ex *connExecutor) runShowLastQueryStatistics(
 			tree.NewDInterval(duration.FromFloat64(planLat), types.DefaultIntervalTypeMetadata),
 			tree.NewDInterval(duration.FromFloat64(runLat), types.DefaultIntervalTypeMetadata),
 			tree.NewDInterval(duration.FromFloat64(svcLat), types.DefaultIntervalTypeMetadata),
+			tree.NewDInterval(duration.FromFloat64(postCommitJobsLat), types.DefaultIntervalTypeMetadata),
 		})
 }
 

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -56,6 +56,8 @@ const (
 	sessionEndExecTransaction             // Transaction is committed/rolled back.
 	sessionStartTransactionCommit         // Transaction `COMMIT` starts.
 	sessionEndTransactionCommit           // Transaction `COMMIT` ends.
+	sessionStartPostCommitJob             // Post transaction `COMMIT` jobs start.
+	sessionEndPostCommitJob               // Post transaction `COMMIT` jobs end.
 
 	// sessionNumPhases must be listed last so that it can be used to
 	// define arrays sufficiently large to hold all the other values.
@@ -113,6 +115,12 @@ func (p *phaseTimes) getPlanningLatency() time.Duration {
 // getParsingLatency returns the time it takes for a query to be parsed.
 func (p *phaseTimes) getParsingLatency() time.Duration {
 	return p[sessionEndParse].Sub(p[sessionStartParse])
+}
+
+// getPostCommitJobsLatency returns the time spent running the post transaction
+// commit jobs, such as schema changes.
+func (p *phaseTimes) getPostCommitJobsLatency() time.Duration {
+	return p[sessionEndPostCommitJob].Sub(p[sessionStartPostCommitJob])
 }
 
 func (p *phaseTimes) getTransactionRetryLatency() time.Duration {


### PR DESCRIPTION
Backport 3/3 commits from #65530.

/cc @cockroachdb/release

---

See individual commits for details.
