### PR TITLE
sql: add `http_addr` column to `sqlliveness` table

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1839,6 +1839,7 @@ func (s *Server) PreStart(ctx context.Context) error {
 		pgL,
 		s.cfg.SocketFile,
 		orphanedLeasesTimeThresholdNanos,
+		s.cfg.HTTPAdvertiseAddr,
 	); err != nil {
 		return err
 	}

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -753,6 +753,7 @@ func (s *SQLServer) preStart(
 	pgL net.Listener,
 	socketFile string,
 	orphanedLeasesTimeThresholdNanos int64,
+	httpAddr string,
 ) error {
 	// If necessary, start the tenant proxy first, to ensure all other
 	// components can properly route to KV nodes. The Start method will block
@@ -790,7 +791,7 @@ func (s *SQLServer) preStart(
 	// version which relies on it.
 	sqllivenessActive := sqlliveness.IsActive(ctx, s.execCfg.Settings)
 	if sqllivenessActive {
-		s.sqlLivenessProvider.Start(ctx)
+		s.sqlLivenessProvider.Start(ctx, httpAddr)
 	}
 
 	migrationsExecutor := sql.MakeInternalExecutor(
@@ -878,7 +879,7 @@ func (s *SQLServer) preStart(
 		// migration. In this case we won't start the sqlliveness subsystem.
 		(!s.execCfg.Settings.Version.BinaryVersion().Less(clusterversion.ByKey(
 			clusterversion.AlterSystemJobsAddSqllivenessColumnsAddNewSystemSqllivenessTable))) {
-		s.sqlLivenessProvider.Start(ctx)
+		s.sqlLivenessProvider.Start(ctx, httpAddr)
 	}
 
 	// Delete all orphaned table leases created by a prior instance of this

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -156,6 +156,7 @@ func StartTenant(
 		pgL,
 		socketFile,
 		orphanedLeasesTimeThresholdNanos,
+		httpLAddr,
 	); err != nil {
 		return nil, "", "", err
 	}

--- a/pkg/sql/catalog/systemschema/system.go
+++ b/pkg/sql/catalog/systemschema/system.go
@@ -344,7 +344,8 @@ CREATE TABLE system.scheduled_jobs (
 CREATE TABLE system.sqlliveness (
     session_id       BYTES PRIMARY KEY NOT NULL,
     expiration       DECIMAL NOT NULL,
-  	FAMILY fam0_session_id_expiration (session_id, expiration)
+    http_addr        STRING,
+  	FAMILY fam0_session_id_expiration_http_addr (session_id, expiration, http_addr)
 )`
 
 	MigrationsTableSchema = `
@@ -1697,14 +1698,15 @@ var (
 		Columns: []descpb.ColumnDescriptor{
 			{Name: "session_id", ID: 1, Type: types.Bytes, Nullable: false},
 			{Name: "expiration", ID: 2, Type: types.Decimal, Nullable: false},
+			{Name: "http_addr", ID: 3, Type: types.String, Nullable: false},
 		},
-		NextColumnID: 3,
+		NextColumnID: 4,
 		Families: []descpb.ColumnFamilyDescriptor{
 			{
-				Name:            "fam0_session_id_expiration",
+				Name:            "fam0_session_id_expiration_http_addr",
 				ID:              0,
-				ColumnNames:     []string{"session_id", "expiration"},
-				ColumnIDs:       []descpb.ColumnID{1, 2},
+				ColumnNames:     []string{"session_id", "expiration", "http_addr"},
+				ColumnIDs:       []descpb.ColumnID{1, 2, 3},
 				DefaultColumnID: 2,
 			},
 		},

--- a/pkg/sql/sqlliveness/slinstance/slinstance_test.go
+++ b/pkg/sql/sqlliveness/slinstance/slinstance_test.go
@@ -45,11 +45,11 @@ func TestSQLInstance(t *testing.T) {
 
 	fakeStorage := slstorage.NewFakeStorage()
 	sqlInstance := slinstance.NewSQLInstance(stopper, clock, fakeStorage, settings)
-	sqlInstance.Start(ctx)
+	sqlInstance.Start(ctx, "")
 
 	// Add one more instance to introduce concurrent access to storage.
 	dummy := slinstance.NewSQLInstance(stopper, clock, fakeStorage, settings)
-	dummy.Start(ctx)
+	dummy.Start(ctx, "")
 
 	s1, err := sqlInstance.Session(ctx)
 	require.NoError(t, err)

--- a/pkg/sql/sqlliveness/slprovider/slprovider.go
+++ b/pkg/sql/sqlliveness/slprovider/slprovider.go
@@ -42,9 +42,9 @@ func New(
 	}
 }
 
-func (p *provider) Start(ctx context.Context) {
+func (p *provider) Start(ctx context.Context, httpAddr string) {
 	p.Storage.Start(ctx)
-	p.Instance.Start(ctx)
+	p.Instance.Start(ctx, httpAddr)
 }
 
 func (p *provider) Metrics() metric.Struct {

--- a/pkg/sql/sqlliveness/slstorage/slstorage.go
+++ b/pkg/sql/sqlliveness/slstorage/slstorage.go
@@ -336,13 +336,13 @@ func (s *Storage) deleteExpiredSessions(ctx context.Context) {
 // used! The contract of IsAlive is that once a session becomes not alive, it
 // must never become alive again.
 func (s *Storage) Insert(
-	ctx context.Context, sid sqlliveness.SessionID, expiration hlc.Timestamp,
+	ctx context.Context, sid sqlliveness.SessionID, expiration hlc.Timestamp, httpAddr string,
 ) (err error) {
 	if err := s.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 		_, err := s.ex.QueryRowEx(
 			ctx, "insert-session", txn, s.sd,
-			`INSERT INTO sqlliveness VALUES ($1, $2)`,
-			sid.UnsafeBytes(), tree.TimestampToDecimalDatum(expiration),
+			`INSERT INTO sqlliveness VALUES ($1, $2, $3)`,
+			sid.UnsafeBytes(), tree.TimestampToDecimalDatum(expiration), httpAddr,
 		)
 		return err
 	}); err != nil {

--- a/pkg/sql/sqlliveness/slstorage/test_helpers.go
+++ b/pkg/sql/sqlliveness/slstorage/test_helpers.go
@@ -46,7 +46,7 @@ func (s *FakeStorage) IsAlive(
 
 // Insert implements the sqlliveness.Storage interface.
 func (s *FakeStorage) Insert(
-	_ context.Context, sid sqlliveness.SessionID, expiration hlc.Timestamp,
+	_ context.Context, sid sqlliveness.SessionID, expiration hlc.Timestamp, httpAddr string,
 ) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/pkg/sql/sqlliveness/sqlliveness.go
+++ b/pkg/sql/sqlliveness/sqlliveness.go
@@ -35,7 +35,7 @@ type SessionID string
 // Provider is a wrapper around the sqllivness subsystem for external
 // consumption.
 type Provider interface {
-	Start(ctx context.Context)
+	Start(ctx context.Context, httpAddr string)
 	Metrics() metric.Struct
 	Reader
 	Instance

--- a/pkg/sqlmigrations/migrations.go
+++ b/pkg/sqlmigrations/migrations.go
@@ -328,6 +328,10 @@ var backwardCompatibleMigrations = []migrationDescriptor{
 		// Introduced in v20.2.
 		name: "mark non-terminal schema change jobs with a pre-20.1 format version as failed",
 	},
+	{
+		name:   "alter sqlliveness to include httpAddr",
+		workFn: alterSqllivenessColumnsAddHttpAddr,
+	},
 }
 
 func staticIDs(
@@ -1098,5 +1102,16 @@ ALTER COLUMN owner SET NOT NULL,
 DROP COLUMN IF EXISTS schedule_changes
 `
 	_, err := r.sqlExecutor.ExecEx(ctx, "alter-scheduled-jobs", nil, asNode, alterSchedules)
+	return err
+}
+
+func alterSqllivenessColumnsAddHttpAddr(ctx context.Context, r runner) error {
+	asNode := sessiondata.InternalExecutorOverride{User: security.NodeUserName()}
+
+	addSqlLivenessHttpAddr := `
+ALTER TABLE system.sqlliveness
+ADD COLUMN IF NOT EXISTS http_addr STRING FAMILY fam0_session_id_expiration,
+`
+	_, err := r.sqlExecutor.ExecEx(ctx, "add-sql-liveness-httpaddr", nil, asNode, addSqlLivenessHttpAddr)
 	return err
 }


### PR DESCRIPTION
In order to implement fan out requests between
SQL pods, we need a place to store their HTTP
addresses so the pods can independently know how 
to talk to other tenants.

This commit adds a column `http_addr` to the
`system.sqlliveness` table and populates it with
the HTTP listening address of the tenant pod on
startup.

Resolves #64475

Release note: None