### PR TITLE
ui: fix jobs page crash [BACKPORT 21.1]

### DIFF
--- a/pkg/ui/src/views/jobs/index.tsx
+++ b/pkg/ui/src/views/jobs/index.tsx
@@ -111,8 +111,14 @@ export class JobsTable extends React.Component<JobsTableProps> {
     this.refresh();
   }
 
-  componentDidUpdate() {
-    this.refresh(this.props);
+  componentDidUpdate(prevProps: JobsTableProps) {
+    if (
+      prevProps.status !== this.props.status ||
+      prevProps.type !== this.props.type ||
+      prevProps.show !== this.props.show
+    ) {
+      this.refresh(this.props);
+    }
   }
 
   onStatusSelected = (selected: DropdownOption) => {

--- a/pkg/ui/src/views/jobs/jobDescriptionCell.tsx
+++ b/pkg/ui/src/views/jobs/jobDescriptionCell.tsx
@@ -25,26 +25,34 @@ export class JobDescriptionCell extends React.PureComponent<{ job: Job }> {
       job.description && job.description.length > 425
         ? `${job.description.slice(0, 425)}...`
         : job.description;
+
+    const cellContent = (
+      <div className="jobs-table__cell--description">
+        {job.statement || job.description || job.type}
+      </div>
+    );
     return (
       <Link className={`${additionalStyle}`} to={`jobs/${String(job.id)}`}>
         <div className="cl-table-link__tooltip">
-          <Tooltip
-            arrowPointAtCenter
-            placement="bottom"
-            title={
-              <pre
-                style={{ whiteSpace: "pre-wrap" }}
-                className="cl-table-link__description"
-              >
-                {description}
-              </pre>
-            }
-            overlayClassName="cl-table-link__statement-tooltip--fixed-width"
-          >
-            <div className="jobs-table__cell--description">
-              {job.statement || job.description}
-            </div>
-          </Tooltip>
+          {description ? (
+            <Tooltip
+              arrowPointAtCenter
+              placement="bottom"
+              title={
+                <pre
+                  style={{ whiteSpace: "pre-wrap" }}
+                  className="cl-table-link__description"
+                >
+                  {description}
+                </pre>
+              }
+              overlayClassName="cl-table-link__statement-tooltip--fixed-width"
+            >
+              {cellContent}
+            </Tooltip>
+          ) : (
+            cellContent
+          )}
         </div>
       </Link>
     );

--- a/pkg/ui/src/views/jobs/jobTable.tsx
+++ b/pkg/ui/src/views/jobs/jobTable.tsx
@@ -9,10 +9,7 @@
 // licenses/APL.txt.
 
 import React, { MouseEvent } from "react";
-import {
-  ColumnDescriptor,
-  SortedTable,
-} from "src/views/shared/components/sortedtable";
+import _ from "lodash";
 import { cockroach } from "src/js/protos";
 import { TimestampToMoment } from "src/util/convert";
 import { DATE_FORMAT } from "src/util/format";
@@ -23,40 +20,50 @@ import { isEqual, map } from "lodash";
 import { JobDescriptionCell } from "src/views/jobs/jobDescriptionCell";
 import Job = cockroach.server.serverpb.JobsResponse.IJob;
 import JobsResponse = cockroach.server.serverpb.JobsResponse;
-import { Pagination, ResultsPerPageLabel } from "@cockroachlabs/cluster-ui";
+import {
+  ColumnDescriptor,
+  Pagination,
+  ResultsPerPageLabel,
+} from "@cockroachlabs/cluster-ui";
 import { jobTable } from "src/util/docs";
 import { trackDocsLink } from "src/util/analytics";
 import { EmptyTable } from "@cockroachlabs/cluster-ui";
 import { Anchor } from "src/components";
 import emptyTableResultsIcon from "assets/emptyState/empty-table-results.svg";
 import magnifyingGlassIcon from "assets/emptyState/magnifying-glass.svg";
+import { SortedTable } from "../shared/components/sortedtable";
 
 class JobsSortedTable extends SortedTable<Job> {}
 
 const jobsTableColumns: ColumnDescriptor<Job>[] = [
   {
+    name: "description",
     title: "Description",
     className: "cl-table__col-query-text",
     cell: (job) => <JobDescriptionCell job={job} />,
-    sort: (job) => job.description,
+    sort: (job) => job.statement || job.description || job.type,
   },
   {
+    name: "jobId",
     title: "Job ID",
     titleAlign: "right",
     cell: (job) => String(job.id),
     sort: (job) => job.id,
   },
   {
+    name: "users",
     title: "Users",
     cell: (job) => job.username,
     sort: (job) => job.username,
   },
   {
+    name: "creationTime",
     title: "Creation Time",
-    cell: (job) => TimestampToMoment(job.created).format(DATE_FORMAT),
-    sort: (job) => TimestampToMoment(job.created).valueOf(),
+    cell: (job) => TimestampToMoment(job?.created).format(DATE_FORMAT),
+    sort: (job) => TimestampToMoment(job?.created).valueOf(),
   },
   {
+    name: "status",
     title: "Status",
     cell: (job) => <JobStatusCell job={job} compact />,
     sort: (job) => job.fraction_completed,

--- a/pkg/ui/src/views/shared/components/sortabletable/sortabletable.styl
+++ b/pkg/ui/src/views/shared/components/sortabletable/sortabletable.styl
@@ -127,11 +127,10 @@
 .cl-table-link__description
   font-size $font-size--small
   line-height 22px
-  color $colors--neutral-1
   white-space pre-wrap
   margin-bottom 0
   line-height 22px
-  color $colors--neutral-6
+  color $colors--neutral-0
   span
     margin-right 6px
   a


### PR DESCRIPTION
while flipping pages on jobs table user could encount page crash. in addition
to that there was a visible delay beetwen data changes that make no sence
since pagination itself is pure ui.
there were a compbination of issues that cause such behavior, this pr contains:
 - on my local setup I got jobs with empty `statement` and `description` for such
case I added fallback to `type` value, to at least leave some value in that column as
it works also as a link and so there should be some clickable value
 - fix for unneeded component rerenders
 - after removing extra rerenders another issue with table component become
visible, wrong use of reselect library, fixed
 - combination last 2 changes fixed issue with slow data refresh
 - in addition fixed font color on `description` value tooltips, it was wrong and barely
visible

Resolves: cockroachdb#62905

Release note (ui): fix jobs page crash while using pagination, improve performance