### PR TITLE
bazel: exclude `_bazel` from consideration by gazelle

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -68,9 +68,11 @@ load("@bazel_gazelle//:def.bzl", "gazelle")
 # - The vendor directory. We're using external targets for go dependencies,
 #   generated without actually looking at vendor. See #58229.
 #
+# gazelle:exclude _bazel
 # gazelle:exclude c-deps/krb5
 # gazelle:exclude c-deps/protobuf
 # gazelle:exclude artifacts
+# gazelle:exclude vendor
 # gazelle:exclude **/zcgo_flags.go
 # gazelle:exclude **/zcgo_flags_*.go
 # gazelle:exclude **/*.og.go
@@ -87,7 +89,6 @@ load("@bazel_gazelle//:def.bzl", "gazelle")
 # gazelle:exclude pkg/sql/lexbase/reserved_keywords.go
 # gazelle:exclude pkg/cmd/prereqs/testdata
 # gazelle:exclude pkg/testutils/**/testdata/**
-# gazelle:exclude vendor
 # gazelle:exclude pkg/security/securitytest/embedded.go
 # gazelle:exclude pkg/cmd/roachprod/vm/aws/embedded.go
 # gazelle:exclude pkg/**/*_string.go


### PR DESCRIPTION
tests. Since then, we've seen `gazelle` occasionally time out lint jobs
in CI (see #65715). The error messages don't make a great deal of sense;
a bunch of them look like this:

    gazelle: found packages exports (exports.go) and p (issue20046.go) in /go/src/github.com/cockroachdb/cockroach/_bazel/bin/pkg/testutils/lint/passes/forbiddenmethod/forbiddenmethod_test_/forbiddenmethod_test.runfiles/go_sdk/src/go/internal/gcimporter/testdata

i.e., Gazelle is looking in `_bazel/bin`, finding `testdata` for the
`go/internal/gcimporter` package in the `go_sdk`, and complaining about
the results. So we add `_bazel` to the list of `exclude`s to prevent
this. This is necessary according to
https://github.com/bazelbuild/bazel-gazelle/issues/168.

Release note: None