### PR TITLE
kvserver: remove tscache.SetLowWater

### DIFF
--- a/pkg/kv/kvserver/replica_tscache.go
+++ b/pkg/kv/kvserver/replica_tscache.go
@@ -600,14 +600,16 @@ func collectReadSummaryFromTimestampCache(
 func applyReadSummaryToTimestampCache(
 	tc tscache.Cache, desc *roachpb.RangeDescriptor, s rspb.ReadSummary,
 ) {
-	tc.SetLowWater(
+	tc.Add(
 		keys.MakeRangeKeyPrefix(desc.StartKey),
 		keys.MakeRangeKeyPrefix(desc.EndKey),
 		s.Local.LowWater,
+		uuid.Nil, /* txnID */
 	)
-	tc.SetLowWater(
+	tc.Add(
 		desc.StartKey.AsRawKey(),
 		desc.EndKey.AsRawKey(),
 		s.Global.LowWater,
+		uuid.Nil, /* txnID */
 	)
 }

--- a/pkg/kv/kvserver/tscache/cache.go
+++ b/pkg/kv/kvserver/tscache/cache.go
@@ -53,11 +53,9 @@ const MinRetentionWindow = 10 * time.Second
 type Cache interface {
 	// Add adds the specified timestamp to the cache covering the range of keys
 	// from start to end. If end is nil, the range covers the start key only.
-	// txnID is nil for no transaction.
+	// An empty txnID can be passed when the operation is not done on behalf of a
+	// particular txn.
 	Add(start, end roachpb.Key, ts hlc.Timestamp, txnID uuid.UUID)
-	// SetLowWater sets the low water mark of the cache for the specified span
-	// to the provided timestamp.
-	SetLowWater(start, end roachpb.Key, ts hlc.Timestamp)
 
 	// GetMax returns the maximum timestamp which overlaps the interval spanning
 	// from start to end. If that maximum timestamp belongs to a single

--- a/pkg/kv/kvserver/tscache/skl_impl.go
+++ b/pkg/kv/kvserver/tscache/skl_impl.go
@@ -58,11 +58,6 @@ func (tc *sklImpl) Add(start, end roachpb.Key, ts hlc.Timestamp, txnID uuid.UUID
 	}
 }
 
-// SetLowWater implements the Cache interface.
-func (tc *sklImpl) SetLowWater(start, end roachpb.Key, ts hlc.Timestamp) {
-	tc.Add(start, end, ts, noTxnID)
-}
-
 // getLowWater implements the Cache interface.
 func (tc *sklImpl) getLowWater() hlc.Timestamp {
 	return tc.cache.FloorTS()

--- a/pkg/kv/kvserver/tscache/tree_impl.go
+++ b/pkg/kv/kvserver/tscache/tree_impl.go
@@ -446,11 +446,6 @@ func (tc *treeImpl) Add(start, end roachpb.Key, ts hlc.Timestamp, txnID uuid.UUI
 	}
 }
 
-// SetLowWater implements the Cache interface.
-func (tc *treeImpl) SetLowWater(start, end roachpb.Key, ts hlc.Timestamp) {
-	tc.Add(start, end, ts, noTxnID)
-}
-
 // getLowWater implements the Cache interface.
 func (tc *treeImpl) getLowWater() hlc.Timestamp {
 	tc.RLock()


### PR DESCRIPTION
The low-watermark is not a prominent concept of the ts cache any more,
and setting it is no different from adding a span. This method was not
necessary.

Release note: None