### PR TITLE
release-21.1: settings: mark diagnostics.forced_stat_reset.interval as retired

### DIFF
--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -60,8 +60,9 @@ var retiredSettings = map[string]struct{}{
 	"sql.defaults.optimizer":                               {},
 	"kv.bulk_io_write.addsstable_max_rate":                 {},
 	// removed as of 20.1.
-	"schemachanger.lease.duration":       {},
-	"schemachanger.lease.renew_fraction": {},
+	"schemachanger.lease.duration":           {},
+	"schemachanger.lease.renew_fraction":     {},
+	"diagnostics.forced_stat_reset.interval": {},
 	// removed as of 20.2.
 	"rocksdb.ingest_backpressure.pending_compaction_threshold":         {},
 	"sql.distsql.temp_storage.joins":                                   {},


### PR DESCRIPTION
Backports #65705 

It was removed in ac3c72339b82d9f85fd8112977a542b87fb5e712 but was never
added to this list. This prevents noise in the logs when trying to read
the old setting name.

Release note: None