### PR TITLE
makefile: remove bnf files before regenerating

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1538,6 +1538,7 @@ pkg/sql/parser/help_messages.go: pkg/sql/parser/sql.y pkg/sql/parser/help.awk | 
 	gofmt -s -w $@
 
 bin/.docgen_bnfs: bin/docgen
+	rm -f docs/generated/sql/bnf/*.bnf
 	docgen grammar bnf docs/generated/sql/bnf --quiet
 	touch $@
 


### PR DESCRIPTION
This forces us to remove bnf files that are no longer
applicable.

Release note: None