### PR TITLE
changefeedccl: Refactor errors and error wrapper event buffer.

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -10,7 +10,6 @@ go_library(
         "changefeed_stmt.go",
         "doc.go",
         "encoder.go",
-        "errors.go",
         "metrics.go",
         "name.go",
         "rowfetcher_cache.go",

--- a/pkg/ccl/changefeedccl/bench_test.go
+++ b/pkg/ccl/changefeedccl/bench_test.go
@@ -216,16 +216,15 @@ func createBenchmarkChangefeed(
 	}
 	_, withDiff := details.Opts[changefeedbase.OptDiff]
 	kvfeedCfg := kvfeed.Config{
-		Settings: settings,
-		DB:       s.DB(),
-		Clock:    feedClock,
-		Gossip:   gossip.MakeOptionalGossip(s.GossipI().(*gossip.Gossip)),
-		Spans:    spans,
-		Targets:  details.Targets,
-		Sink:     buf,
-		EventBufferFactory: func() kvfeed.EventBuffer {
-			return kvfeed.MakeMemBuffer(mm.MakeBoundAccount(), &metrics.KVFeedMetrics)
-		},
+		Settings:         settings,
+		DB:               s.DB(),
+		Clock:            feedClock,
+		Gossip:           gossip.MakeOptionalGossip(s.GossipI().(*gossip.Gossip)),
+		Spans:            spans,
+		Targets:          details.Targets,
+		Sink:             buf,
+		Metrics:          &metrics.KVFeedMetrics,
+		MM:               mm,
 		InitialHighWater: initialHighWater,
 		WithDiff:         withDiff,
 		NeedsInitialScan: needsInitialScan,

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -293,7 +293,7 @@ func changefeedPlanHook(
 			if err != nil {
 				telemetry.Count(`changefeed.core.error`)
 			}
-			return MaybeStripRetryableErrorMarker(err)
+			return changefeedbase.MaybeStripRetryableErrorMarker(err)
 		}
 
 		// Changefeeds are based on the Rangefeed abstraction, which requires the
@@ -322,7 +322,7 @@ func changefeedPlanHook(
 				jobspb.InvalidJobID,
 			)
 			if err != nil {
-				return MaybeStripRetryableErrorMarker(err)
+				return changefeedbase.MaybeStripRetryableErrorMarker(err)
 			}
 			if err := canarySink.Close(); err != nil {
 				return err
@@ -607,7 +607,7 @@ func (b *changefeedResumer) Resume(ctx context.Context, execCtx interface{}) err
 			}
 		}
 
-		if !IsRetryableError(err) {
+		if !changefeedbase.IsRetryableError(err) {
 			if ctx.Err() != nil {
 				return ctx.Err()
 			}

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -2009,7 +2009,7 @@ func TestChangefeedRetryableError(t *testing.T) {
 		knobs.BeforeEmitRow = func(_ context.Context) error {
 			switch atomic.LoadInt64(&failEmit) {
 			case 1:
-				return MarkRetryableError(fmt.Errorf("synthetic retryable error"))
+				return changefeedbase.MarkRetryableError(fmt.Errorf("synthetic retryable error"))
 			case 2:
 				return fmt.Errorf("synthetic terminal error")
 			default:
@@ -3295,7 +3295,7 @@ func TestChangefeedMemBufferCapacityErrorRetryable(t *testing.T) {
 				// This function is invoked form a different go routine -- and calling
 				// t.Fatal will likely deadlock the test.
 				distErrCh <- err
-				return MaybeStripRetryableErrorMarker(err)
+				return changefeedbase.MaybeStripRetryableErrorMarker(err)
 			}
 
 			sqlDB := sqlutils.MakeSQLRunner(db)
@@ -3343,7 +3343,7 @@ func TestChangefeedMemBufferCapacityErrorRetryable(t *testing.T) {
 
 			err := <-distErrCh
 			require.Regexp(t, `memory budget exceeded`, err)
-			require.True(t, IsRetryableError(err))
+			require.True(t, changefeedbase.IsRetryableError(err))
 		}
 	}
 
@@ -3436,7 +3436,7 @@ func TestChangefeedRestartDuringBackfill(t *testing.T) {
 		require.NoError(t, feedJob.Pause())
 
 		// Make extra sure that the zombie changefeed can't write any more data.
-		beforeEmitRowCh <- MarkRetryableError(errors.New(`nope don't write it`))
+		beforeEmitRowCh <- changefeedbase.MarkRetryableError(errors.New(`nope don't write it`))
 
 		// Insert some data that we should only see out of the changefeed after it
 		// re-runs the backfill.

--- a/pkg/ccl/changefeedccl/changefeedbase/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/changefeedbase/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "changefeedbase",
     srcs = [
         "avro.go",
+        "errors.go",
         "options.go",
         "settings.go",
         "validate.go",
@@ -11,6 +12,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/ccl/utilccl",
         "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/settings",

--- a/pkg/ccl/changefeedccl/changefeedbase/errors.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/errors.go
@@ -6,7 +6,7 @@
 //
 //     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
 
-package changefeedccl
+package changefeedbase
 
 import (
 	"fmt"

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed_test.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed_test.go
@@ -98,7 +98,7 @@ func TestKVFeed(t *testing.T) {
 		)
 		metrics := MakeMetrics(time.Minute)
 		bufferFactory := func() EventBuffer {
-			return MakeMemBuffer(mm.MakeBoundAccount(), &metrics)
+			return makeMemBuffer(mm.MakeBoundAccount(), &metrics)
 		}
 		scans := make(chan physicalConfig)
 		sf := scannerFunc(func(ctx context.Context, sink EventBufferWriter, cfg physicalConfig) error {

--- a/pkg/ccl/changefeedccl/rowfetcher_cache.go
+++ b/pkg/ccl/changefeedccl/rowfetcher_cache.go
@@ -11,6 +11,7 @@ package changefeedccl
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -86,7 +87,7 @@ func (c *rowFetcherCache) TableDescForKey(
 		if err != nil {
 			// Manager can return all kinds of errors during chaos, but based on
 			// its usage, none of them should ever be terminal.
-			return nil, MarkRetryableError(err)
+			return nil, changefeedbase.MarkRetryableError(err)
 		}
 		tableDesc = desc.Desc().(catalog.TableDescriptor)
 		// Immediately release the lease, since we only need it for the exact
@@ -110,7 +111,7 @@ func (c *rowFetcherCache) TableDescForKey(
 			}); err != nil {
 				// Manager can return all kinds of errors during chaos, but based on
 				// its usage, none of them should ever be terminal.
-				return nil, MarkRetryableError(err)
+				return nil, changefeedbase.MarkRetryableError(err)
 			}
 			// Immediately release the lease, since we only need it for the exact
 			// timestamp requested.

--- a/pkg/ccl/changefeedccl/schema_registry.go
+++ b/pkg/ccl/changefeedccl/schema_registry.go
@@ -197,7 +197,7 @@ func (r *confluentSchemaRegistry) doWithRetry(ctx context.Context, fn func() err
 		}
 		log.VInfof(ctx, 2, "retrying schema registry operation: %s", err.Error())
 	}
-	return MarkRetryableError(err)
+	return changefeedbase.MarkRetryableError(err)
 }
 
 func gracefulClose(ctx context.Context, toClose io.ReadCloser) {

--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -154,7 +154,7 @@ func (s errorWrapperSink) EmitRow(
 	ctx context.Context, topicDescr TopicDescriptor, key, value []byte, updated hlc.Timestamp,
 ) error {
 	if err := s.wrapped.EmitRow(ctx, topicDescr, key, value, updated); err != nil {
-		return MarkRetryableError(err)
+		return changefeedbase.MarkRetryableError(err)
 	}
 	return nil
 }
@@ -164,7 +164,7 @@ func (s errorWrapperSink) EmitResolvedTimestamp(
 	ctx context.Context, encoder Encoder, resolved hlc.Timestamp,
 ) error {
 	if err := s.wrapped.EmitResolvedTimestamp(ctx, encoder, resolved); err != nil {
-		return MarkRetryableError(err)
+		return changefeedbase.MarkRetryableError(err)
 	}
 	return nil
 }
@@ -172,7 +172,7 @@ func (s errorWrapperSink) EmitResolvedTimestamp(
 // Flush implements Sink interface.
 func (s errorWrapperSink) Flush(ctx context.Context) error {
 	if err := s.wrapped.Flush(ctx); err != nil {
-		return MarkRetryableError(err)
+		return changefeedbase.MarkRetryableError(err)
 	}
 	return nil
 }
@@ -180,7 +180,7 @@ func (s errorWrapperSink) Flush(ctx context.Context) error {
 // Close implements Sink interface.
 func (s errorWrapperSink) Close() error {
 	if err := s.wrapped.Close(); err != nil {
-		return MarkRetryableError(err)
+		return changefeedbase.MarkRetryableError(err)
 	}
 	return nil
 }


### PR DESCRIPTION
This is a pure code move/refactoring to address comments from #65746:
  * Move errors to changefeedbase so that they are accessible.
  * Move error wrapper buffer to buffer.go
  * Unexport mem buffer.

Release Notes: None