### PR TITLE
release-21.1: sql: add ADD REGION IF NOT EXISTS / DROP REGION IF EXISTS

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1745,6 +1745,7 @@ alter_database_add_region_stmt ::=
 
 alter_database_drop_region_stmt ::=
 	'ALTER' 'DATABASE' database_name 'DROP' 'REGION' region_name
+	| 'ALTER' 'DATABASE' database_name 'DROP' 'REGION' 'IF' 'EXISTS' region_name
 
 alter_database_survival_goal_stmt ::=
 	'ALTER' 'DATABASE' database_name survival_goal_clause

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1741,6 +1741,7 @@ alter_database_to_schema_stmt ::=
 
 alter_database_add_region_stmt ::=
 	'ALTER' 'DATABASE' database_name 'ADD' 'REGION' region_name
+	| 'ALTER' 'DATABASE' database_name 'ADD' 'REGION' 'IF' 'NOT' 'EXISTS' region_name
 
 alter_database_drop_region_stmt ::=
 	'ALTER' 'DATABASE' database_name 'DROP' 'REGION' region_name

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region
@@ -1025,6 +1025,11 @@ CREATE DATABASE non_multi_region_db
 statement error pq: database has no regions to drop
 ALTER DATABASE non_multi_region_db DROP REGION "ca-central-1"
 
+query T noticetrace
+ALTER DATABASE non_multi_region_db DROP REGION IF EXISTS "ca-central-1"
+----
+NOTICE: region "ca-central-1" is not defined on the database; skipping
+
 statement ok
 CREATE DATABASE drop_region_db PRIMARY REGION "ca-central-1" REGIONS "ap-southeast-2", "us-east-1";
 USE drop_region_db
@@ -1032,8 +1037,9 @@ USE drop_region_db
 statement error pgcode 42P12 cannot drop region "ca-central-1"\nHINT: You must designate another region as the primary region using ALTER DATABASE drop_region_db PRIMARY REGION <region name> or remove all other regions before attempting to drop region "ca-central-1"
 ALTER DATABASE drop_region_db DROP REGION "ca-central-1"
 
-statement ok
-ALTER DATABASE drop_region_db DROP REGION "us-east-1"
+query T noticetrace
+ALTER DATABASE drop_region_db DROP REGION IF EXISTS "us-east-1"
+----
 
 # Ensure that events are generated for dropping the region
 query IT
@@ -1041,7 +1047,12 @@ SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
 FROM system.eventlog
 WHERE "eventType" = 'alter_database_drop_region'
 ----
-1  {"DatabaseName": "drop_region_db", "EventType": "alter_database_drop_region", "RegionName": "\"us-east-1\"", "Statement": "ALTER DATABASE drop_region_db DROP REGION \"us-east-1\"", "Tag": "ALTER DATABASE DROP REGION", "User": "root"}
+1  {"DatabaseName": "drop_region_db", "EventType": "alter_database_drop_region", "RegionName": "\"us-east-1\"", "Statement": "ALTER DATABASE drop_region_db DROP REGION IF EXISTS \"us-east-1\"", "Tag": "ALTER DATABASE DROP REGION", "User": "root"}
+
+query T noticetrace
+ALTER DATABASE drop_region_db DROP REGION IF EXISTS "us-east-1"
+----
+NOTICE: region "us-east-1" is not defined on the database; skipping
 
 statement error pgcode 42704 region "non-existent-region" has not been added to the database
 ALTER DATABASE drop_region_db DROP REGION "non-existent-region"

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region
@@ -554,8 +554,9 @@ DATABASE alter_test_db  ALTER DATABASE alter_test_db CONFIGURE ZONE USING
                         lease_preferences = '[[+region=ca-central-1]]'
 
 # Test adding a region after first region.
-statement ok
-ALTER DATABASE alter_test_db ADD REGION "us-east-1"
+query T noticetrace
+ALTER DATABASE alter_test_db ADD REGION IF NOT EXISTS "us-east-1"
+----
 
 query TTBT colnames
 show regions from database alter_test_db
@@ -591,11 +592,24 @@ ALTER DATABASE alter_test_db ADD REGION "test"
 statement error pgcode 42710 region "ap-southeast-2" already added to database
 ALTER DATABASE alter_test_db ADD REGION "ap-southeast-2"
 
+query T noticetrace
+ALTER DATABASE alter_test_db ADD REGION IF NOT EXISTS "ap-southeast-2"
+----
+NOTICE: region "ap-southeast-2" already exists; skipping
+
 statement error cannot add region
 ALTER DATABASE new_db ADD REGION "us-west-1"
 
 statement error pq: database has no regions to drop
 ALTER DATABASE new_db DROP REGION "us-west-1"
+
+query TTBT colnames
+show regions from database alter_test_db
+----
+database       region          primary  zones
+alter_test_db  ca-central-1    true     {ca-az1,ca-az2,ca-az3}
+alter_test_db  ap-southeast-2  false    {ap-az1,ap-az2,ap-az3}
+alter_test_db  us-east-1       false    {us-az1,us-az2,us-az3}
 
 statement ok
 CREATE DATABASE alter_primary_region_db

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region
@@ -1043,6 +1043,9 @@ WHERE "eventType" = 'alter_database_drop_region'
 ----
 1  {"DatabaseName": "drop_region_db", "EventType": "alter_database_drop_region", "RegionName": "\"us-east-1\"", "Statement": "ALTER DATABASE drop_region_db DROP REGION \"us-east-1\"", "Tag": "ALTER DATABASE DROP REGION", "User": "root"}
 
+statement error pgcode 42704 region "non-existent-region" has not been added to the database
+ALTER DATABASE drop_region_db DROP REGION "non-existent-region"
+
 query TTBT colnames
 SHOW REGIONS FROM DATABASE drop_region_db
 ----

--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -576,6 +576,13 @@ func (n *alterDatabaseDropRegionNode) startExec(params runParams) error {
 		// ROW table is homed in that region. The type schema changer is responsible
 		// for all the requisite validation.
 		if err := params.p.dropEnumValue(params.ctx, typeDesc, tree.EnumValue(n.n.Region)); err != nil {
+			if pgerror.GetPGCode(err) == pgcode.UndefinedObject {
+				return pgerror.Newf(
+					pgcode.UndefinedObject,
+					"region %q has not been added to the database",
+					n.n.Region,
+				)
+			}
 			return err
 		}
 	}

--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -299,6 +299,13 @@ func (p *planner) AlterDatabaseDropRegion(
 	}
 
 	if !dbDesc.IsMultiRegion() {
+		if n.IfExists {
+			p.BufferClientNotice(
+				ctx,
+				pgnotice.Newf("region %q is not defined on the database; skipping", n.Region),
+			)
+			return &alterDatabaseDropRegionNode{}, nil
+		}
 		return nil, pgerror.New(pgcode.InvalidDatabaseDefinition, "database has no regions to drop")
 	}
 
@@ -534,6 +541,9 @@ func removeLocalityConfigFromAllTablesInDB(
 }
 
 func (n *alterDatabaseDropRegionNode) startExec(params runParams) error {
+	if n.n == nil {
+		return nil
+	}
 	typeDesc, err := params.p.Descriptors().GetMutableTypeVersionByID(
 		params.ctx,
 		params.p.txn,
@@ -577,6 +587,13 @@ func (n *alterDatabaseDropRegionNode) startExec(params runParams) error {
 		// for all the requisite validation.
 		if err := params.p.dropEnumValue(params.ctx, typeDesc, tree.EnumValue(n.n.Region)); err != nil {
 			if pgerror.GetPGCode(err) == pgcode.UndefinedObject {
+				if n.n.IfExists {
+					params.p.BufferClientNotice(
+						params.ctx,
+						pgnotice.Newf("region %q is not defined on the database; skipping", n.n.Region),
+					)
+					return nil
+				}
 				return pgerror.Newf(
 					pgcode.UndefinedObject,
 					"region %q has not been added to the database",

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -1534,6 +1534,14 @@ alter_database_drop_region_stmt:
       Region: tree.Name($6),
     }
   }
+| ALTER DATABASE database_name DROP REGION IF EXISTS region_name
+  {
+    $$.val = &tree.AlterDatabaseDropRegion{
+      Name: tree.Name($3),
+      Region: tree.Name($8),
+      IfExists: true,
+    }
+  }
 
 alter_database_survival_goal_stmt:
   ALTER DATABASE database_name survival_goal_clause

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -1517,6 +1517,14 @@ alter_database_add_region_stmt:
       Region: tree.Name($6),
     }
   }
+| ALTER DATABASE database_name ADD REGION IF NOT EXISTS region_name
+  {
+    $$.val = &tree.AlterDatabaseAddRegion{
+      Name: tree.Name($3),
+      Region: tree.Name($9),
+      IfNotExists: true,
+    }
+  }
 
 alter_database_drop_region_stmt:
   ALTER DATABASE database_name DROP REGION region_name

--- a/pkg/sql/parser/testdata/parse/alter_database
+++ b/pkg/sql/parser/testdata/parse/alter_database
@@ -31,6 +31,14 @@ ALTER DATABASE a DROP REGION "us-west-1" -- literals removed
 ALTER DATABASE _ DROP REGION _ -- identifiers removed
 
 parse
+ALTER DATABASE a DROP REGION IF EXISTS "us-west-1"
+----
+ALTER DATABASE a DROP REGION IF EXISTS "us-west-1"
+ALTER DATABASE a DROP REGION IF EXISTS "us-west-1" -- fully parenthetized
+ALTER DATABASE a DROP REGION IF EXISTS "us-west-1" -- literals removed
+ALTER DATABASE _ DROP REGION IF EXISTS _ -- identifiers removed
+
+parse
 ALTER DATABASE a SURVIVE REGION FAILURE
 ----
 ALTER DATABASE a SURVIVE REGION FAILURE

--- a/pkg/sql/parser/testdata/parse/alter_database
+++ b/pkg/sql/parser/testdata/parse/alter_database
@@ -15,6 +15,14 @@ ALTER DATABASE a ADD REGION "us-west-1" -- literals removed
 ALTER DATABASE _ ADD REGION _ -- identifiers removed
 
 parse
+ALTER DATABASE a ADD REGION IF NOT EXISTS "us-west-1"
+----
+ALTER DATABASE a ADD REGION IF NOT EXISTS "us-west-1"
+ALTER DATABASE a ADD REGION IF NOT EXISTS "us-west-1" -- fully parenthetized
+ALTER DATABASE a ADD REGION IF NOT EXISTS "us-west-1" -- literals removed
+ALTER DATABASE _ ADD REGION IF NOT EXISTS _ -- identifiers removed
+
+parse
 ALTER DATABASE a DROP REGION "us-west-1"
 ----
 ALTER DATABASE a DROP REGION "us-west-1"

--- a/pkg/sql/sem/tree/alter_database.go
+++ b/pkg/sql/sem/tree/alter_database.go
@@ -30,8 +30,9 @@ func (node *AlterDatabaseOwner) Format(ctx *FmtCtx) {
 
 // AlterDatabaseAddRegion represents a ALTER DATABASE ADD REGION statement.
 type AlterDatabaseAddRegion struct {
-	Name   Name
-	Region Name
+	Name        Name
+	Region      Name
+	IfNotExists bool
 }
 
 var _ Statement = &AlterDatabaseAddRegion{}
@@ -41,6 +42,9 @@ func (node *AlterDatabaseAddRegion) Format(ctx *FmtCtx) {
 	ctx.WriteString("ALTER DATABASE ")
 	ctx.FormatNode(&node.Name)
 	ctx.WriteString(" ADD REGION ")
+	if node.IfNotExists {
+		ctx.WriteString("IF NOT EXISTS ")
+	}
 	ctx.FormatNode(&node.Region)
 }
 

--- a/pkg/sql/sem/tree/alter_database.go
+++ b/pkg/sql/sem/tree/alter_database.go
@@ -50,8 +50,9 @@ func (node *AlterDatabaseAddRegion) Format(ctx *FmtCtx) {
 
 // AlterDatabaseDropRegion represents a ALTER DATABASE DROP REGION statement.
 type AlterDatabaseDropRegion struct {
-	Name   Name
-	Region Name
+	Name     Name
+	Region   Name
+	IfExists bool
 }
 
 var _ Statement = &AlterDatabaseDropRegion{}
@@ -61,6 +62,9 @@ func (node *AlterDatabaseDropRegion) Format(ctx *FmtCtx) {
 	ctx.WriteString("ALTER DATABASE ")
 	ctx.FormatNode(&node.Name)
 	ctx.WriteString(" DROP REGION ")
+	if node.IfExists {
+		ctx.WriteString("IF EXISTS ")
+	}
 	ctx.FormatNode(&node.Region)
 }
 


### PR DESCRIPTION
Backport 3/3 commits from #65641.

/cc @cockroachdb/release

---

See individual commits for details.

I'd be up for backporting this, it simplifies idempotent test setups for me a lot!
