### PR TITLE
settings: add `backup.table_statistics.enabled` to retired settings

### DIFF
--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -72,6 +72,7 @@ var retiredSettings = map[string]struct{}{
 	"sql.defaults.optimizer_foreign_keys.enabled":                      {},
 	"sql.defaults.experimental_optimizer_foreign_key_cascades.enabled": {},
 	"sql.parallel_scans.enabled":                                       {},
+	"backup.table_statistics.enabled":                                  {},
 	// removed as of 21.1.
 	"sql.distsql.interleaved_joins.enabled": {},
 	"sql.testing.vectorize.batch_size":      {},


### PR DESCRIPTION
This setting has been retired since 20.2 as we no longer
store the backed up stats in the BACKUP manifest. This
settings was added in 20.1.

Release note: None