### PR TITLE
release-20.2: release: check remote tag before pushing

### DIFF
--- a/build/release/teamcity-make-and-publish-build.sh
+++ b/build/release/teamcity-make-and-publish-build.sh
@@ -78,7 +78,7 @@ tc_end_block "Make and push docker image"
 tc_start_block "Push release tag to github.com/cockroachdb/cockroach"
 github_ssh_key="${GITHUB_COCKROACH_TEAMCITY_PRIVATE_SSH_KEY}"
 configure_git_ssh_key
-push_to_git ssh://git@github.com/cockroachlabs/release-staging.git "${build_name}"
+git_wrapped push ssh://git@github.com/cockroachlabs/release-staging.git "${build_name}"
 tc_end_block "Push release tag to github.com/cockroachdb/cockroach"
 
 
@@ -104,6 +104,6 @@ EOF
 
 if [[ -n "${is_custom_build}" ]] ; then
   tc_start_block "Delete custombuild tag"
-  push_to_git ssh://git@github.com/cockroachdb/cockroach.git --delete "${TC_BUILD_BRANCH}"
+  git_wrapped push ssh://git@github.com/cockroachdb/cockroach.git --delete "${TC_BUILD_BRANCH}"
   tc_end_block "Delete custombuild tag"
 fi

--- a/build/release/teamcity-publish-release.sh
+++ b/build/release/teamcity-publish-release.sh
@@ -65,6 +65,14 @@ gcr_hostname="us.gcr.io"
 tc_end_block "Variable Setup"
 
 
+tc_start_block "Check remote tag"
+if git_wrapped ls-remote --exit-code --tags "ssh://git@github.com/${git_repo_for_tag}.git" "${build_name}"; then
+  echo "Tag ${build_name} already exists"
+  exit 1
+fi
+tc_end_block "Check remote tag"
+
+
 tc_start_block "Tag the release"
 git tag "${build_name}"
 tc_end_block "Tag the release"
@@ -111,7 +119,7 @@ tc_end_block "Make and push docker images"
 tc_start_block "Push release tag to GitHub"
 github_ssh_key="${GITHUB_COCKROACH_TEAMCITY_PRIVATE_SSH_KEY}"
 configure_git_ssh_key
-push_to_git "ssh://git@github.com/${git_repo_for_tag}.git" "$build_name"
+git_wrapped push "ssh://git@github.com/${git_repo_for_tag}.git" "$build_name"
 tc_end_block "Push release tag to GitHub"
 
 

--- a/build/teamcity-common-support.sh
+++ b/build/teamcity-common-support.sh
@@ -25,7 +25,7 @@ configure_git_ssh_key() {
   ssh-keyscan github.com > "$HOME/.ssh/known_hosts"
 }
 
-push_to_git() {
+git_wrapped() {
   # $@ passes all arguments to this function to the command
-  GIT_SSH_COMMAND="ssh -i .cockroach-teamcity-key" git push "$@"
+  GIT_SSH_COMMAND="ssh -i .cockroach-teamcity-key" git "$@"
 }

--- a/build/teamcity-diagram-generation.sh
+++ b/build/teamcity-diagram-generation.sh
@@ -47,5 +47,5 @@ git commit -m "Snapshot $cockroach_ref"
 github_ssh_key="${PRIVATE_DEPLOY_KEY_FOR_GENERATED_DIAGRAMS}"
 configure_git_ssh_key
 
-push_to_git -f ssh://git@github.com/cockroachdb/generated-diagrams.git
+git_wrapped push -f ssh://git@github.com/cockroachdb/generated-diagrams.git
 tc_end_block "Push Diagrams to Git"


### PR DESCRIPTION
Backport 1/1 commits from #65555.

/cc @cockroachdb/release

---

Previously, prior to pushing the release git tag, we created and pushed
most of the release artifacts (docker images, s3). If we run the script
multiple times against the same version, it may rewrite the artifacts
and will fail pushing the exiting git tag, leaving the release process
in a partially released state.

This patch adds a check if the release git tag already pushed to the
GitHub repo and fails before any artifacts are created.

Fixes #54814

Release note: None
