### PR TITLE
cloud: use (*http.Transport).Clone() to create http Transport

### DIFF
--- a/pkg/storage/cloud/cloud_io.go
+++ b/pkg/storage/cloud/cloud_io.go
@@ -66,22 +66,10 @@ func MakeHTTPClient(settings *cluster.Settings) (*http.Client, error) {
 		}
 		tlsConf = &tls.Config{RootCAs: roots}
 	}
-	// Copy the defaults from http.DefaultTransport. We cannot just copy the
-	// entire struct because it has a sync Mutex. This has the unfortunate problem
-	// that if Go adds fields to DefaultTransport they won't be copied here,
-	// but this is ok for now.
-	t := http.DefaultTransport.(*http.Transport)
-	return &http.Client{Transport: &http.Transport{
-		Proxy:                 t.Proxy,
-		DialContext:           t.DialContext,
-		MaxIdleConns:          t.MaxIdleConns,
-		IdleConnTimeout:       t.IdleConnTimeout,
-		TLSHandshakeTimeout:   t.TLSHandshakeTimeout,
-		ExpectContinueTimeout: t.ExpectContinueTimeout,
-
-		// Add our custom CA.
-		TLSClientConfig: tlsConf,
-	}}, nil
+	t := http.DefaultTransport.(*http.Transport).Clone()
+	// Add our custom CA.
+	t.TLSClientConfig = tlsConf
+	return &http.Client{Transport: t}, nil
 }
 
 // MaxDelayedRetryAttempts is the number of times the delayedRetry method will


### PR DESCRIPTION
(*http.Transport).Clone() was added in Go 1.13 to solve the problem
called out in this comment.

The main thing we'll pick up here is the new preference for HTTP/2 if
it is available.

Release note: None