### PR TITLE
sql: Add unit tests for planning inside the new schema changer

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -254,6 +254,7 @@ ALL_TESTS = [
     "//pkg/sql/schemachanger/scbuild:scbuild_test",
     "//pkg/sql/schemachanger/scexec:scexec_test",
     "//pkg/sql/schemachanger/scpb:scpb_test",
+    "//pkg/sql/schemachanger/scplan:scplan_test",
     "//pkg/sql/schemachanger:schemachanger_test",
     "//pkg/sql/sem/builtins:builtins_test",
     "//pkg/sql/sem/tree/eval_test:eval_test_test",

--- a/pkg/sql/schemachanger/scgraphviz/graphviz.go
+++ b/pkg/sql/schemachanger/scgraphviz/graphviz.go
@@ -161,11 +161,11 @@ func htmlLabel(o interface{}) dot.HTML {
 	return dot.HTML(buf.String())
 }
 
-// toMap converts a struct to a map, field by field. If at any point a protobuf
+// ToMap converts a struct to a map, field by field. If at any point a protobuf
 // message is encountered, it is converted to a map using jsonpb to marshal it
 // to json and then marshaling it back to a map. This approach allows zero
 // values to be effectively omitted.
-func toMap(v interface{}) (interface{}, error) {
+func ToMap(v interface{}) (interface{}, error) {
 	if v == nil {
 		return nil, nil
 	}
@@ -202,7 +202,7 @@ func toMap(v interface{}) (interface{}, error) {
 			continue
 		}
 		var err error
-		if m[vt.Field(i).Name], err = toMap(vvf.Interface()); err != nil {
+		if m[vt.Field(i).Name], err = ToMap(vvf.Interface()); err != nil {
 			return nil, err
 		}
 	}
@@ -235,7 +235,7 @@ var objectTemplate = template.Must(template.New("obj").Funcs(template.FuncMap{
 	"isStruct": func(v interface{}) bool {
 		return reflect.Indirect(reflect.ValueOf(v)).Kind() == reflect.Struct
 	},
-	"toMap": toMap,
+	"toMap": ToMap,
 }).Parse(`
 {{- define "key" -}}
 <td>

--- a/pkg/sql/schemachanger/scpb/attribute.go
+++ b/pkg/sql/schemachanger/scpb/attribute.go
@@ -61,7 +61,7 @@ func (id IndexID) String() string {
 
 // String implements AttributeValue.
 func (id ElementTypeID) String() string {
-	return strconv.Itoa(int(id))
+	return ElementIDToString(id)
 }
 
 // String implements AttributeValue.
@@ -146,8 +146,12 @@ func (a Attributes) Equal(other Attributes) bool {
 // String seralizes attribute into a string
 func (a Attributes) String() string {
 	result := strings.Builder{}
-	result.WriteString("[ ")
+	result.WriteString(a.Get(AttributeType).String())
+	result.WriteString(":{")
 	for attribIdx, attrib := range a.values {
+		if attrib.key == AttributeType {
+			continue
+		}
 		result.WriteString(attrib.key.String())
 		result.WriteString(": ")
 		result.WriteString(attrib.value.String())
@@ -155,7 +159,7 @@ func (a Attributes) String() string {
 			result.WriteString(", ")
 		}
 	}
-	result.WriteString(" ]")
+	result.WriteString("}")
 	return result.String()
 }
 

--- a/pkg/sql/schemachanger/scpb/attribute_test.go
+++ b/pkg/sql/schemachanger/scpb/attribute_test.go
@@ -30,7 +30,7 @@ func TestGetAttribute(t *testing.T) {
 
 	// Sanity: Validate basic string conversion, equality,
 	// and inequality.
-	expectedStr := `[ Type: 4, DescID: 3, DepID: 1, ColumnID: 2 ]`
+	expectedStr := `SequenceDependency:{DescID: 3, DepID: 1, ColumnID: 2}`
 	require.Equal(t, expectedStr, seqElem.GetAttributes().String(), "Attribute string conversion is broken.")
 	require.True(t, seqElem.GetAttributes().Equal(seqElem.GetAttributes()))
 	require.False(t, seqElem.GetAttributes().Equal(seqElemDiff.GetAttributes()))
@@ -38,7 +38,7 @@ func TestGetAttribute(t *testing.T) {
 	// Sanity: Validate type references, then check if type comparisons
 	// work.
 	typeBackRef := TypeReference{TypeID: 3, DescID: 1}
-	expectedStr = `[ Type: 10, DescID: 3, DepID: 1 ]`
+	expectedStr = `TypeReference:{DescID: 3, DepID: 1}`
 	require.Equal(t, expectedStr, typeBackRef.GetAttributes().String(), "Attribute string conversion is broken.")
 	require.False(t, seqElem.GetAttributes().Equal(typeBackRef.GetAttributes()))
 	require.False(t, typeBackRef.GetAttributes().Equal(seqElem.GetAttributes()))
@@ -46,6 +46,6 @@ func TestGetAttribute(t *testing.T) {
 	// Sanity: Validate attribute fetching for both types.
 	require.Equal(t, "1", typeBackRef.GetAttributes().Get(AttributeDepID).String())
 	require.Equal(t, "3", typeBackRef.GetAttributes().Get(AttributeDescID).String())
-	require.Equal(t, "10", typeBackRef.GetAttributes().Get(AttributeType).String())
+	require.Equal(t, "TypeReference", typeBackRef.GetAttributes().Get(AttributeType).String())
 	require.Equal(t, "4", seqElemDiff.GetAttributes().Get(AttributeColumnID).String())
 }

--- a/pkg/sql/schemachanger/scpb/elements.go
+++ b/pkg/sql/schemachanger/scpb/elements.go
@@ -63,10 +63,12 @@ func NewTarget(dir Target_Direction, elem Element) *Target {
 type ElementTypeID int
 
 var typeToElementID map[reflect.Type]ElementTypeID
+var elementIDToString map[ElementTypeID]string
 
 func init() {
 	typ := reflect.TypeOf((*ElementProto)(nil)).Elem()
 	typeToElementID = make(map[reflect.Type]ElementTypeID, typ.NumField())
+	elementIDToString = make(map[ElementTypeID]string, typ.NumField())
 	for i := 0; i < typ.NumField(); i++ {
 		f := typ.Field(i)
 		protoFlags := strings.Split(f.Tag.Get("protobuf"), ",")
@@ -75,12 +77,18 @@ func init() {
 			panic(errors.Wrapf(err, "failed to extract ID from protobuf tag: %q", protoFlags))
 		}
 		typeToElementID[f.Type] = ElementTypeID(id)
+		elementIDToString[ElementTypeID(id)] = strings.TrimPrefix(f.Type.String(), "*scpb.")
 	}
 }
 
 // ElementType determines the type ID of a element
 func ElementType(el Element) ElementTypeID {
 	return typeToElementID[reflect.TypeOf(el)]
+}
+
+// ElementIDToString determines the type ID of a element
+func ElementIDToString(id ElementTypeID) string {
+	return elementIDToString[id]
 }
 
 // DescriptorID implements the Element interface.

--- a/pkg/sql/schemachanger/scplan/BUILD.bazel
+++ b/pkg/sql/schemachanger/scplan/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "scplan",
@@ -19,5 +19,43 @@ go_library(
         "//pkg/util/iterutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
+    ],
+)
+
+go_test(
+    name = "scplan_test",
+    srcs = [
+        "main_test.go",
+        "plan_test.go",
+    ],
+    data = glob(["testdata/**"]),
+    deps = [
+        ":scplan",
+        "//pkg/base",
+        "//pkg/kv",
+        "//pkg/security",
+        "//pkg/security/securitytest",
+        "//pkg/server",
+        "//pkg/sql",
+        "//pkg/sql/catalog/descpb",
+        "//pkg/sql/catalog/descs",
+        "//pkg/sql/catalog/resolver",
+        "//pkg/sql/parser",
+        "//pkg/sql/schemachanger/scbuild",
+        "//pkg/sql/schemachanger/scgraph",
+        "//pkg/sql/schemachanger/scgraphviz",
+        "//pkg/sql/schemachanger/scpb",
+        "//pkg/sql/sem/tree",
+        "//pkg/sql/sessiondatapb",
+        "//pkg/testutils/serverutils",
+        "//pkg/testutils/sqlutils",
+        "//pkg/testutils/testcluster",
+        "//pkg/util/leaktest",
+        "//pkg/util/log",
+        "//pkg/util/randutil",
+        "@com_github_cockroachdb_datadriven//:datadriven",
+        "@com_github_cockroachdb_errors//:errors",
+        "@com_github_stretchr_testify//require",
+        "@in_gopkg_yaml_v2//:yaml_v2",
     ],
 )

--- a/pkg/sql/schemachanger/scplan/main_test.go
+++ b/pkg/sql/schemachanger/scplan/main_test.go
@@ -1,0 +1,31 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package scplan_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+func TestMain(m *testing.M) {
+	security.SetAssetLoader(securitytest.EmbeddedAssets)
+	randutil.SeedForTests()
+	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
+	os.Exit(m.Run())
+}

--- a/pkg/sql/schemachanger/scplan/plan_test.go
+++ b/pkg/sql/schemachanger/scplan/plan_test.go
@@ -1,0 +1,209 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package scplan_test
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/resolver"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scbuild"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scgraph"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scgraphviz"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+func TestPlanAlterTable(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	datadriven.Walk(t, filepath.Join("testdata"), func(t *testing.T, path string) {
+		s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+		defer s.Stopper().Stop(ctx)
+
+		tdb := sqlutils.MakeSQLRunner(sqlDB)
+		run := func(t *testing.T, d *datadriven.TestData) string {
+			switch d.Cmd {
+			case "create-view", "create-sequence", "create-table", "create-type":
+				stmts, err := parser.Parse(d.Input)
+				require.NoError(t, err)
+				require.Len(t, stmts, 1)
+				tableName := ""
+				switch node := stmts[0].AST.(type) {
+				case *tree.CreateTable:
+					tableName = node.Table.String()
+				case *tree.CreateSequence:
+					tableName = node.Name.String()
+				case *tree.CreateView:
+					tableName = node.Name.String()
+				case *tree.CreateType:
+					tableName = ""
+				default:
+					t.Fatal("not a CREATE TABLE/SEQUENCE/VIEW statement")
+				}
+				tdb.Exec(t, d.Input)
+
+				if len(tableName) > 0 {
+					var tableID descpb.ID
+					tdb.QueryRow(t, `SELECT $1::regclass::int`, tableName).Scan(&tableID)
+					if tableID == 0 {
+						t.Fatalf("failed to read ID of new table %s", tableName)
+					}
+					t.Logf("created relation with id %d", tableID)
+				}
+				return ""
+			case "ops", "deps":
+				deps, cleanup := newTestingPlanDeps(s)
+				defer cleanup()
+
+				stmts, err := parser.Parse(d.Input)
+				require.NoError(t, err)
+				var outputNodes []*scpb.Node
+				for i := range stmts {
+					outputNodes, err = scbuild.Build(ctx, stmts[i].AST, *deps, outputNodes)
+					require.NoError(t, err)
+				}
+
+				plan, err := scplan.MakePlan(outputNodes,
+					scplan.Params{
+						ExecutionPhase:         scplan.PostCommitPhase,
+						DisableOpRandomization: true,
+					})
+				require.NoError(t, err)
+
+				if d.Cmd == "ops" {
+					return marshalOps(t, &plan)
+				}
+				return marshalDeps(t, &plan)
+			case "unimplemented":
+				deps, cleanup := newTestingPlanDeps(s)
+				defer cleanup()
+
+				stmts, err := parser.Parse(d.Input)
+				require.NoError(t, err)
+				require.Len(t, stmts, 1)
+
+				stmt := stmts[0]
+				alter, ok := stmt.AST.(*tree.AlterTable)
+				require.Truef(t, ok, "not an ALTER TABLE statement: %s", stmt.SQL)
+				_, err = scbuild.Build(ctx, alter, *deps, nil)
+				require.Truef(t, scbuild.HasNotImplemented(err), "expected unimplemented, got %v", err)
+				return ""
+
+			default:
+				return fmt.Sprintf("unknown command: %s", d.Cmd)
+			}
+		}
+		datadriven.RunTest(t, path, run)
+	})
+}
+
+// indentText indents text for formatting out marshaled data.
+func indentText(input string, tab string) (final string) {
+	split := strings.Split(input, "\n")
+	for idx, line := range split {
+		if len(line) == 0 {
+			continue
+		}
+		final += tab + line
+		if idx != len(split)-1 {
+			final = final + "\n"
+		}
+	}
+	return final
+}
+
+// marshalDeps marshals dependencies in scplan.Plan to a string.
+func marshalDeps(t *testing.T, plan *scplan.Plan) string {
+	var stages strings.Builder
+	err := plan.Graph.ForEachNode(func(n *scpb.Node) error {
+		return plan.Graph.ForEachDepEdgeFrom(n, func(de *scgraph.DepEdge) error {
+			toAttr := de.To().Element().GetAttributes()
+			fromAttr := de.From().Element().GetAttributes()
+			fmt.Fprintf(&stages, "- from: [%s, %s]\n", fromAttr, de.From().State)
+			fmt.Fprintf(&stages, "  to:   [%s, %s]\n", toAttr, de.To().State)
+			return nil
+		})
+	})
+	if err != nil {
+		panic(errors.Wrap(err, "failed marshaling dependencies."))
+	}
+	return stages.String()
+}
+
+// marshalOps marshals operations in scplan.Plan to a string.
+func marshalOps(t *testing.T, plan *scplan.Plan) string {
+	stages := ""
+	for stageIdx, stage := range plan.Stages {
+		stages += fmt.Sprintf("Stage %d\n", stageIdx)
+		stageOps := ""
+		for _, op := range stage.Ops.Slice() {
+			opMap, err := scgraphviz.ToMap(op)
+			require.NoError(t, err)
+			data, err := yaml.Marshal(opMap)
+			require.NoError(t, err)
+			stageOps += fmt.Sprintf("%T\n%s", op, indentText(string(data), "  "))
+		}
+		stages += indentText(stageOps, "  ")
+	}
+	return stages
+}
+
+func newTestingPlanDeps(s serverutils.TestServerInterface) (*scbuild.Dependencies, func()) {
+	execCfg := s.ExecutorConfig().(sql.ExecutorConfig)
+	ip, cleanup := sql.NewInternalPlanner(
+		"test",
+		kv.NewTxn(context.Background(), s.DB(), s.NodeID()),
+		security.RootUserName(),
+		&sql.MemoryMetrics{},
+		&execCfg,
+		// Setting the database on the session data to "defaultdb" in the obvious
+		// way doesn't seem to do what we want.
+		sessiondatapb.SessionData{},
+	)
+	planner := ip.(interface {
+		resolver.SchemaResolver
+		SemaCtx() *tree.SemaContext
+		EvalContext() *tree.EvalContext
+		Descriptors() *descs.Collection
+		scbuild.AuthorizationAccessor
+	})
+	buildDeps := scbuild.Dependencies{
+		Res:          planner,
+		SemaCtx:      planner.SemaCtx(),
+		EvalCtx:      planner.EvalContext(),
+		Descs:        planner.Descriptors(),
+		AuthAccessor: planner,
+	}
+	return &buildDeps, cleanup
+}

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table
@@ -1,0 +1,559 @@
+create-table
+CREATE TABLE defaultdb.foo (i INT PRIMARY KEY)
+----
+
+ops
+ALTER TABLE defaultdb.foo ADD COLUMN j INT
+----
+Stage 0
+  *scop.MakeAddedColumnDeleteOnly
+    Column:
+      ID: 2
+      Name: j
+      Nullable: true
+      Type:
+        family: IntFamily
+        oid: 20
+        width: 64
+    FamilyName: primary
+    TableID: 52
+  *scop.MakeAddedIndexDeleteOnly
+    Index:
+      EncodingType: 1
+      ID: 2
+      KeyColumnDirections:
+      - 0
+      KeyColumnIDs:
+      - 1
+      KeyColumnNames:
+      - i
+      Name: new_primary_key
+      StoreColumnIDs:
+      - 2
+      StoreColumnNames:
+      - j
+      Unique: true
+      Version: 3
+    TableID: 52
+Stage 1
+  *scop.MakeAddedColumnDeleteAndWriteOnly
+    ColumnID: 2
+    TableID: 52
+  *scop.MakeAddedIndexDeleteAndWriteOnly
+    IndexID: 2
+    TableID: 52
+Stage 2
+  scop.BackfillIndex
+    IndexID: 2
+    TableID: 52
+Stage 3
+  scop.ValidateUniqueIndex
+    IndexID: 2
+    PrimaryIndexID: 1
+    TableID: 52
+Stage 4
+  *scop.MakeColumnPublic
+    ColumnID: 2
+    TableID: 52
+  *scop.MakeAddedPrimaryIndexPublic
+    Index:
+      ID: 2
+      KeyColumnDirections:
+      - 0
+      KeyColumnIDs:
+      - 1
+      KeyColumnNames:
+      - i
+      Name: new_primary_key
+      Unique: true
+      Version: 3
+    TableID: 52
+  *scop.MakeDroppedPrimaryIndexDeleteAndWriteOnly
+    Index:
+      EncodingType: 1
+      ID: 1
+      KeyColumnDirections:
+      - 0
+      KeyColumnIDs:
+      - 1
+      KeyColumnNames:
+      - i
+      Name: primary
+      Unique: true
+      Version: 3
+    TableID: 52
+Stage 5
+  *scop.MakeDroppedIndexDeleteOnly
+    IndexID: 1
+    TableID: 52
+Stage 6
+  *scop.MakeIndexAbsent
+    IndexID: 1
+    TableID: 52
+
+ops
+ALTER TABLE defaultdb.foo ADD COLUMN j INT DEFAULT 123
+----
+Stage 0
+  *scop.MakeAddedColumnDeleteOnly
+    Column:
+      DefaultExpr: 123:::INT8
+      ID: 2
+      Name: j
+      Nullable: true
+      Type:
+        family: IntFamily
+        oid: 20
+        width: 64
+    FamilyName: primary
+    TableID: 52
+  *scop.MakeAddedIndexDeleteOnly
+    Index:
+      EncodingType: 1
+      ID: 2
+      KeyColumnDirections:
+      - 0
+      KeyColumnIDs:
+      - 1
+      KeyColumnNames:
+      - i
+      Name: new_primary_key
+      StoreColumnIDs:
+      - 2
+      StoreColumnNames:
+      - j
+      Unique: true
+      Version: 3
+    TableID: 52
+Stage 1
+  *scop.MakeAddedColumnDeleteAndWriteOnly
+    ColumnID: 2
+    TableID: 52
+  *scop.MakeAddedIndexDeleteAndWriteOnly
+    IndexID: 2
+    TableID: 52
+Stage 2
+  scop.BackfillIndex
+    IndexID: 2
+    TableID: 52
+Stage 3
+  scop.ValidateUniqueIndex
+    IndexID: 2
+    PrimaryIndexID: 1
+    TableID: 52
+Stage 4
+  *scop.MakeColumnPublic
+    ColumnID: 2
+    TableID: 52
+  *scop.MakeAddedPrimaryIndexPublic
+    Index:
+      ID: 2
+      KeyColumnDirections:
+      - 0
+      KeyColumnIDs:
+      - 1
+      KeyColumnNames:
+      - i
+      Name: new_primary_key
+      Unique: true
+      Version: 3
+    TableID: 52
+  *scop.MakeDroppedPrimaryIndexDeleteAndWriteOnly
+    Index:
+      EncodingType: 1
+      ID: 1
+      KeyColumnDirections:
+      - 0
+      KeyColumnIDs:
+      - 1
+      KeyColumnNames:
+      - i
+      Name: primary
+      Unique: true
+      Version: 3
+    TableID: 52
+Stage 5
+  *scop.MakeDroppedIndexDeleteOnly
+    IndexID: 1
+    TableID: 52
+Stage 6
+  *scop.MakeIndexAbsent
+    IndexID: 1
+    TableID: 52
+
+ops
+ALTER TABLE defaultdb.foo ADD COLUMN j INT DEFAULT 123;
+ALTER TABLE defaultdb.foo ADD COLUMN k INT DEFAULT 456;
+----
+Stage 0
+  *scop.MakeAddedColumnDeleteOnly
+    Column:
+      DefaultExpr: 123:::INT8
+      ID: 2
+      Name: j
+      Nullable: true
+      Type:
+        family: IntFamily
+        oid: 20
+        width: 64
+    FamilyName: primary
+    TableID: 52
+  *scop.MakeAddedIndexDeleteOnly
+    Index:
+      EncodingType: 1
+      ID: 2
+      KeyColumnDirections:
+      - 0
+      KeyColumnIDs:
+      - 1
+      KeyColumnNames:
+      - i
+      Name: new_primary_key
+      StoreColumnIDs:
+      - 2
+      - 3
+      StoreColumnNames:
+      - j
+      - k
+      Unique: true
+      Version: 3
+    TableID: 52
+  *scop.MakeAddedColumnDeleteOnly
+    Column:
+      DefaultExpr: 456:::INT8
+      ID: 3
+      Name: k
+      Nullable: true
+      Type:
+        family: IntFamily
+        oid: 20
+        width: 64
+    FamilyName: primary
+    TableID: 52
+Stage 1
+  *scop.MakeAddedColumnDeleteAndWriteOnly
+    ColumnID: 2
+    TableID: 52
+  *scop.MakeAddedIndexDeleteAndWriteOnly
+    IndexID: 2
+    TableID: 52
+  *scop.MakeAddedColumnDeleteAndWriteOnly
+    ColumnID: 3
+    TableID: 52
+Stage 2
+  scop.BackfillIndex
+    IndexID: 2
+    TableID: 52
+Stage 3
+  scop.ValidateUniqueIndex
+    IndexID: 2
+    PrimaryIndexID: 1
+    TableID: 52
+Stage 4
+  *scop.MakeColumnPublic
+    ColumnID: 2
+    TableID: 52
+  *scop.MakeAddedPrimaryIndexPublic
+    Index:
+      ID: 2
+      KeyColumnDirections:
+      - 0
+      KeyColumnIDs:
+      - 1
+      KeyColumnNames:
+      - i
+      Name: new_primary_key
+      Unique: true
+      Version: 3
+    TableID: 52
+  *scop.MakeDroppedPrimaryIndexDeleteAndWriteOnly
+    Index:
+      EncodingType: 1
+      ID: 1
+      KeyColumnDirections:
+      - 0
+      KeyColumnIDs:
+      - 1
+      KeyColumnNames:
+      - i
+      Name: primary
+      Unique: true
+      Version: 3
+    TableID: 52
+  *scop.MakeColumnPublic
+    ColumnID: 3
+    TableID: 52
+Stage 5
+  *scop.MakeDroppedIndexDeleteOnly
+    IndexID: 1
+    TableID: 52
+Stage 6
+  *scop.MakeIndexAbsent
+    IndexID: 1
+    TableID: 52
+
+ops
+ALTER TABLE defaultdb.foo ADD COLUMN a INT AS (i+1) STORED
+----
+Stage 0
+  *scop.MakeAddedColumnDeleteOnly
+    Column:
+      ComputeExpr: i + 1:::INT8
+      ID: 2
+      Name: a
+      Nullable: true
+      Type:
+        family: IntFamily
+        oid: 20
+        width: 64
+    FamilyName: primary
+    TableID: 52
+  *scop.MakeAddedIndexDeleteOnly
+    Index:
+      EncodingType: 1
+      ID: 2
+      KeyColumnDirections:
+      - 0
+      KeyColumnIDs:
+      - 1
+      KeyColumnNames:
+      - i
+      Name: new_primary_key
+      StoreColumnIDs:
+      - 2
+      StoreColumnNames:
+      - a
+      Unique: true
+      Version: 3
+    TableID: 52
+Stage 1
+  *scop.MakeAddedColumnDeleteAndWriteOnly
+    ColumnID: 2
+    TableID: 52
+  *scop.MakeAddedIndexDeleteAndWriteOnly
+    IndexID: 2
+    TableID: 52
+Stage 2
+  scop.BackfillIndex
+    IndexID: 2
+    TableID: 52
+Stage 3
+  scop.ValidateUniqueIndex
+    IndexID: 2
+    PrimaryIndexID: 1
+    TableID: 52
+Stage 4
+  *scop.MakeColumnPublic
+    ColumnID: 2
+    TableID: 52
+  *scop.MakeAddedPrimaryIndexPublic
+    Index:
+      ID: 2
+      KeyColumnDirections:
+      - 0
+      KeyColumnIDs:
+      - 1
+      KeyColumnNames:
+      - i
+      Name: new_primary_key
+      Unique: true
+      Version: 3
+    TableID: 52
+  *scop.MakeDroppedPrimaryIndexDeleteAndWriteOnly
+    Index:
+      EncodingType: 1
+      ID: 1
+      KeyColumnDirections:
+      - 0
+      KeyColumnIDs:
+      - 1
+      KeyColumnNames:
+      - i
+      Name: primary
+      Unique: true
+      Version: 3
+    TableID: 52
+Stage 5
+  *scop.MakeDroppedIndexDeleteOnly
+    IndexID: 1
+    TableID: 52
+Stage 6
+  *scop.MakeIndexAbsent
+    IndexID: 1
+    TableID: 52
+
+
+create-table
+CREATE TABLE defaultdb.bar (j INT);
+----
+
+ops
+ALTER TABLE defaultdb.foo ADD COLUMN a INT;
+ALTER TABLE defaultdb.bar ADD COLUMN b INT;
+----
+Stage 0
+  *scop.MakeAddedColumnDeleteOnly
+    Column:
+      ID: 2
+      Name: a
+      Nullable: true
+      Type:
+        family: IntFamily
+        oid: 20
+        width: 64
+    FamilyName: primary
+    TableID: 52
+  *scop.MakeAddedIndexDeleteOnly
+    Index:
+      EncodingType: 1
+      ID: 2
+      KeyColumnDirections:
+      - 0
+      KeyColumnIDs:
+      - 1
+      KeyColumnNames:
+      - i
+      Name: new_primary_key
+      StoreColumnIDs:
+      - 2
+      StoreColumnNames:
+      - a
+      Unique: true
+      Version: 3
+    TableID: 52
+  *scop.MakeAddedColumnDeleteOnly
+    Column:
+      ID: 3
+      Name: b
+      Nullable: true
+      Type:
+        family: IntFamily
+        oid: 20
+        width: 64
+    FamilyName: primary
+    TableID: 53
+  *scop.MakeAddedIndexDeleteOnly
+    Index:
+      EncodingType: 1
+      ID: 2
+      KeyColumnDirections:
+      - 0
+      KeyColumnIDs:
+      - 2
+      KeyColumnNames:
+      - rowid
+      Name: new_primary_key
+      StoreColumnIDs:
+      - 1
+      - 3
+      StoreColumnNames:
+      - j
+      - b
+      Unique: true
+    TableID: 53
+Stage 1
+  *scop.MakeAddedColumnDeleteAndWriteOnly
+    ColumnID: 2
+    TableID: 52
+  *scop.MakeAddedIndexDeleteAndWriteOnly
+    IndexID: 2
+    TableID: 52
+  *scop.MakeAddedColumnDeleteAndWriteOnly
+    ColumnID: 3
+    TableID: 53
+  *scop.MakeAddedIndexDeleteAndWriteOnly
+    IndexID: 2
+    TableID: 53
+Stage 2
+  scop.BackfillIndex
+    IndexID: 2
+    TableID: 52
+  scop.BackfillIndex
+    IndexID: 2
+    TableID: 53
+Stage 3
+  scop.ValidateUniqueIndex
+    IndexID: 2
+    PrimaryIndexID: 1
+    TableID: 52
+  scop.ValidateUniqueIndex
+    IndexID: 2
+    PrimaryIndexID: 1
+    TableID: 53
+Stage 4
+  *scop.MakeColumnPublic
+    ColumnID: 2
+    TableID: 52
+  *scop.MakeAddedPrimaryIndexPublic
+    Index:
+      ID: 2
+      KeyColumnDirections:
+      - 0
+      KeyColumnIDs:
+      - 1
+      KeyColumnNames:
+      - i
+      Name: new_primary_key
+      Unique: true
+      Version: 3
+    TableID: 52
+  *scop.MakeDroppedPrimaryIndexDeleteAndWriteOnly
+    Index:
+      EncodingType: 1
+      ID: 1
+      KeyColumnDirections:
+      - 0
+      KeyColumnIDs:
+      - 1
+      KeyColumnNames:
+      - i
+      Name: primary
+      Unique: true
+      Version: 3
+    TableID: 52
+  *scop.MakeColumnPublic
+    ColumnID: 3
+    TableID: 53
+  *scop.MakeAddedPrimaryIndexPublic
+    Index:
+      ID: 2
+      KeyColumnDirections:
+      - 0
+      KeyColumnIDs:
+      - 2
+      KeyColumnNames:
+      - rowid
+      Name: new_primary_key
+      Unique: true
+    TableID: 53
+  *scop.MakeDroppedPrimaryIndexDeleteAndWriteOnly
+    Index:
+      EncodingType: 1
+      ID: 1
+      KeyColumnDirections:
+      - 0
+      KeyColumnIDs:
+      - 2
+      KeyColumnNames:
+      - rowid
+      Name: primary
+      StoreColumnIDs:
+      - 1
+      StoreColumnNames:
+      - j
+      Unique: true
+    TableID: 53
+Stage 5
+  *scop.MakeDroppedIndexDeleteOnly
+    IndexID: 1
+    TableID: 52
+  *scop.MakeDroppedIndexDeleteOnly
+    IndexID: 1
+    TableID: 53
+Stage 6
+  *scop.MakeIndexAbsent
+    IndexID: 1
+    TableID: 52
+  *scop.MakeIndexAbsent
+    IndexID: 1
+    TableID: 53

--- a/pkg/sql/schemachanger/scplan/testdata/drop_sequence
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_sequence
@@ -1,0 +1,58 @@
+create-sequence
+CREATE SEQUENCE defaultdb.SQ1
+----
+
+ops
+DROP SEQUENCE defaultdb.SQ1 CASCADE
+----
+Stage 0
+  *scop.CreateGcJobForDescriptor
+    DescID: 52
+  *scop.MarkDescriptorAsDropped
+    TableID: 52
+Stage 1
+  *scop.CreateGcJobForDescriptor
+    DescID: 52
+  *scop.DrainDescriptorName
+    TableID: 52
+
+create-table
+CREATE TABLE defaultdb.blog_posts (id INT PRIMARY KEY, val int DEFAULT nextval('defaultdb.sq1'), title text)
+----
+
+create-table
+CREATE TABLE defaultdb.blog_posts2 (id INT PRIMARY KEY, val int DEFAULT nextval('defaultdb.sq1'), title text)
+----
+
+ops
+DROP SEQUENCE defaultdb.SQ1 CASCADE
+----
+Stage 0
+  *scop.RemoveColumnDefaultExpression
+    ColumnID: 2
+    TableID: 53
+  *scop.UpdateRelationDeps
+    TableID: 53
+  *scop.RemoveColumnDefaultExpression
+    ColumnID: 2
+    TableID: 54
+  *scop.UpdateRelationDeps
+    TableID: 54
+  *scop.CreateGcJobForDescriptor
+    DescID: 52
+  *scop.MarkDescriptorAsDropped
+    TableID: 52
+Stage 1
+  *scop.CreateGcJobForDescriptor
+    DescID: 52
+  *scop.DrainDescriptorName
+    TableID: 52
+
+
+deps
+DROP SEQUENCE defaultdb.SQ1 CASCADE
+----
+- from: [Sequence:{DescID: 52}, DELETE_ONLY]
+  to:   [DefaultExpression:{DescID: 53, ColumnID: 2}, ABSENT]
+- from: [Sequence:{DescID: 52}, DELETE_ONLY]
+  to:   [DefaultExpression:{DescID: 54, ColumnID: 2}, ABSENT]

--- a/pkg/sql/schemachanger/scplan/testdata/drop_view
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_view
@@ -1,0 +1,103 @@
+create-table
+CREATE TABLE defaultdb.t1 (id INT PRIMARY KEY, name varchar(256))
+----
+
+create-view
+CREATE VIEW defaultdb.v1 AS (SELECT name FROM defaultdb.t1)
+----
+
+ops
+DROP VIEW defaultdb.v1
+----
+Stage 0
+  *scop.MarkDescriptorAsDropped
+    TableID: 53
+Stage 1
+  *scop.CreateGcJobForDescriptor
+    DescID: 53
+  *scop.DrainDescriptorName
+    TableID: 53
+
+deps
+DROP VIEW defaultdb.v1
+----
+
+create-view
+CREATE VIEW defaultdb.v2 AS (SELECT name AS n1, name AS n2 FROM v1)
+----
+
+create-view
+CREATE VIEW defaultdb.v3 AS (SELECT name, n1 FROM v1, v2);
+----
+
+create-view
+CREATE VIEW defaultdb.v4 AS (SELECT n2, n1 FROM v2);
+----
+
+create-type
+CREATE TYPE defaultdb.typ AS ENUM('a')
+----
+
+create-view
+CREATE VIEW v5 AS (SELECT 'a'::defaultdb.typ::string AS k, n2, n1 from defaultdb.v4)
+----
+
+ops
+DROP VIEW defaultdb.v1 CASCADE
+----
+Stage 0
+  *scop.RemoveTypeBackRef
+    DescID: 59
+    TypeID: 57
+  *scop.RemoveTypeBackRef
+    DescID: 59
+    TypeID: 58
+  *scop.MarkDescriptorAsDropped
+    TableID: 53
+  *scop.MarkDescriptorAsDropped
+    TableID: 54
+  *scop.MarkDescriptorAsDropped
+    TableID: 55
+  *scop.MarkDescriptorAsDropped
+    TableID: 56
+  *scop.MarkDescriptorAsDropped
+    TableID: 59
+Stage 1
+  *scop.CreateGcJobForDescriptor
+    DescID: 53
+  *scop.CreateGcJobForDescriptor
+    DescID: 54
+  *scop.CreateGcJobForDescriptor
+    DescID: 55
+  *scop.CreateGcJobForDescriptor
+    DescID: 56
+  *scop.CreateGcJobForDescriptor
+    DescID: 59
+  *scop.DrainDescriptorName
+    TableID: 53
+  *scop.DrainDescriptorName
+    TableID: 54
+  *scop.DrainDescriptorName
+    TableID: 55
+  *scop.DrainDescriptorName
+    TableID: 56
+  *scop.DrainDescriptorName
+    TableID: 59
+
+deps
+DROP VIEW defaultdb.v1 CASCADE
+----
+- from: [View:{DescID: 53}, DELETE_ONLY]
+  to:   [View:{DescID: 54}, DELETE_ONLY]
+- from: [View:{DescID: 53}, DELETE_ONLY]
+  to:   [View:{DescID: 55}, DELETE_ONLY]
+- from: [View:{DescID: 54}, DELETE_ONLY]
+  to:   [View:{DescID: 55}, DELETE_ONLY]
+- from: [View:{DescID: 54}, DELETE_ONLY]
+  to:   [View:{DescID: 56}, DELETE_ONLY]
+- from: [View:{DescID: 56}, DELETE_ONLY]
+  to:   [View:{DescID: 59}, DELETE_ONLY]
+- from: [View:{DescID: 59}, DELETE_ONLY]
+  to:   [TypeReference:{DescID: 57, DepID: 59}, ABSENT]
+- from: [View:{DescID: 59}, DELETE_ONLY]
+  to:   [TypeReference:{DescID: 58, DepID: 59}, ABSENT]


### PR DESCRIPTION
Previously, the new schema changer did not have any unit
tests covering the planning capability. This was inadequate,
because we had no way of detect if plans were regressing with
changes or enhancements. To address this, this patch adds
basic tests to see if the operators/dependencies for a given
command are sane.

Release note: None