### PR TITLE
sql: surface sampled query plan, database name, and execution nodes to internal node statement statistics table

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -846,6 +846,28 @@ func getSQLStats(p *planner, virtualTableName string) (*sqlStats, error) {
 	return p.extendedEvalCtx.sqlStatsCollector.sqlStats, nil
 }
 
+// ExplainTreePlanNodeToJSON builds a formatted JSON object from the explain tree nodes.
+func ExplainTreePlanNodeToJSON(node *roachpb.ExplainTreePlanNode) json.JSON {
+
+	// Create a new json.ObjectBuilder with key-value pairs for the node's name (1),
+	// node's attributes (len(node.Attrs)), and the node's children (1).
+	nodePlan := json.NewObjectBuilder(len(node.Attrs) + 2 /* numAddsHint */)
+	nodeChildren := json.NewArrayBuilder(len(node.Children))
+
+	nodePlan.Add("Name", json.FromString(node.Name))
+
+	for _, attr := range node.Attrs {
+		nodePlan.Add(strings.Title(attr.Key), json.FromString(attr.Value))
+	}
+
+	for _, childNode := range node.Children {
+		nodeChildren.Add(ExplainTreePlanNodeToJSON(childNode))
+	}
+
+	nodePlan.Add("Children", nodeChildren.Build())
+	return nodePlan.Build()
+}
+
 var crdbInternalStmtStatsTable = virtualSchemaTable{
 	comment: `statement statistics (in-memory, not durable; local node only). ` +
 		`This table is wiped periodically (by default, at least every two hours)`,
@@ -888,7 +910,10 @@ CREATE TABLE crdb_internal.node_statement_statistics (
   contention_time_avg FLOAT,
   contention_time_var FLOAT,
   implicit_txn        BOOL NOT NULL,
-  full_scan           BOOL NOT NULL
+  full_scan           BOOL NOT NULL,
+  sample_plan         JSONB,
+  database_name       STRING NOT NULL,
+  exec_node_ids       INT[] NOT NULL
 )`,
 	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		hasViewActivity, err := p.HasRoleOption(ctx, roleoption.VIEWACTIVITY)
@@ -961,6 +986,16 @@ CREATE TABLE crdb_internal.node_statement_statistics (
 				if stmtKey.failed {
 					flags = "!" + flags
 				}
+
+				samplePlan := ExplainTreePlanNodeToJSON(&s.mu.data.SensitiveInfo.MostRecentPlanDescription)
+
+				execNodeIDs := tree.NewDArray(types.Int)
+				for _, nodeID := range s.mu.data.Nodes {
+					if err := execNodeIDs.Append(tree.NewDInt(tree.DInt(nodeID))); err != nil {
+						return err
+					}
+				}
+
 				err := addRow(
 					tree.NewDInt(tree.DInt(nodeID)),                         // node_id
 					tree.NewDString(appName),                                // application_name
@@ -1000,6 +1035,9 @@ CREATE TABLE crdb_internal.node_statement_statistics (
 					execStatVar(s.mu.data.ExecStats.Count, s.mu.data.ExecStats.ContentionTime),      // contention_time_var
 					tree.MakeDBool(tree.DBool(stmtKey.implicitTxn)),                                 // implicit_txn
 					tree.MakeDBool(tree.DBool(s.mu.fullScan)),                                       // full_scan
+					tree.NewDJSON(samplePlan),         // sample_plan
+					tree.NewDString(stmtKey.database), // database_name
+					execNodeIDs,                       // exec_node_ids
 				)
 				s.mu.Unlock()
 				if err != nil {

--- a/pkg/sql/crdb_internal_test.go
+++ b/pkg/sql/crdb_internal_test.go
@@ -487,3 +487,128 @@ UPDATE system.namespace SET id = 12345 WHERE id = 53;
 
 	require.False(t, rows.Next())
 }
+
+// TestExplainTreePlanNodeToJSON tests whether the ExplainTreePlanNode function
+// correctly builds a JSON object from an ExplainTreePlanNode.
+func TestExplainTreePlanNodeToJSON(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testDataArr := []struct {
+		explainTree roachpb.ExplainTreePlanNode
+		expected    string
+	}{
+		// Test data using a node with multiple inner children.
+		{
+			roachpb.ExplainTreePlanNode{
+				Name: "root",
+				Attrs: []*roachpb.ExplainTreePlanNode_Attr{
+					{
+						Key:   "rootKey",
+						Value: "rootValue",
+					},
+				},
+				Children: []*roachpb.ExplainTreePlanNode{
+					{
+						Name: "child",
+						Attrs: []*roachpb.ExplainTreePlanNode_Attr{
+							{
+								Key:   "childKey",
+								Value: "childValue",
+							},
+						},
+						Children: []*roachpb.ExplainTreePlanNode{
+							{
+								Name: "innerChild",
+								Attrs: []*roachpb.ExplainTreePlanNode_Attr{
+									{
+										Key:   "innerChildKey",
+										Value: "innerChildValue",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			`{"Children": [{"ChildKey": "childValue", "Children": [{"Children": [], "InnerChildKey": "innerChildValue", "Name": "innerChild"}], "Name": "child"}], "Name": "root", "RootKey": "rootValue"}`,
+		},
+		// Test using a node with multiple attributes.
+		{
+			roachpb.ExplainTreePlanNode{
+				Name: "root",
+				Attrs: []*roachpb.ExplainTreePlanNode_Attr{
+					{
+						Key:   "rootFirstKey",
+						Value: "rootFirstValue",
+					},
+					{
+						Key:   "rootSecondKey",
+						Value: "rootSecondValue",
+					},
+				},
+				Children: []*roachpb.ExplainTreePlanNode{
+					{
+						Name: "child",
+						Attrs: []*roachpb.ExplainTreePlanNode_Attr{
+							{
+								Key:   "childKey",
+								Value: "childValue",
+							},
+						},
+					},
+				},
+			},
+			`{"Children": [{"ChildKey": "childValue", "Children": [], "Name": "child"}], "Name": "root", "RootFirstKey": "rootFirstValue", "RootSecondKey": "rootSecondValue"}`,
+		},
+		// Test using a node with multiple children and multiple inner children.
+		{
+			roachpb.ExplainTreePlanNode{
+				Name: "root",
+				Attrs: []*roachpb.ExplainTreePlanNode_Attr{
+					{
+						Key:   "rootKey",
+						Value: "rootValue",
+					},
+				},
+				Children: []*roachpb.ExplainTreePlanNode{
+					{
+						Name: "firstChild",
+						Attrs: []*roachpb.ExplainTreePlanNode_Attr{
+							{
+								Key:   "firstChildKey",
+								Value: "firstChildValue",
+							},
+						},
+						Children: []*roachpb.ExplainTreePlanNode{
+							{
+								Name: "innerChild",
+								Attrs: []*roachpb.ExplainTreePlanNode_Attr{
+									{
+										Key:   "innerChildKey",
+										Value: "innerChildValue",
+									},
+								},
+							},
+						},
+					},
+					{
+						Name: "secondChild",
+						Attrs: []*roachpb.ExplainTreePlanNode_Attr{
+							{
+								Key:   "secondChildKey",
+								Value: "secondChildValue",
+							},
+						},
+					},
+				},
+			},
+			`{"Children": [{"Children": [{"Children": [], "InnerChildKey": "innerChildValue", "Name": "innerChild"}], "FirstChildKey": "firstChildValue", "Name": "firstChild"}, {"Children": [], "Name": "secondChild", "SecondChildKey": "secondChildValue"}], "Name": "root", "RootKey": "rootValue"}`,
+		},
+	}
+
+	for _, testData := range testDataArr {
+		explainTreeJSON := sql.ExplainTreePlanNodeToJSON(&testData.explainTree)
+		require.Equal(t, testData.expected, explainTreeJSON.String())
+	}
+
+}

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -154,10 +154,10 @@ SELECT * FROM crdb_internal.leases WHERE node_id < 0
 ----
 node_id  table_id  name  parent_id  expiration  deleted
 
-query ITTTTTIIITRRRRRRRRRRRRRRRRRRRRRRRRRRBB colnames
+query ITTTTTIIITRRRRRRRRRRRRRRRRRRRRRRRRRRBBTTT colnames
 SELECT * FROM crdb_internal.node_statement_statistics WHERE node_id < 0
 ----
-node_id  application_name  flags  statement_id  key  anonymized  count  first_attempt_count  max_retries  last_error  rows_avg  rows_var  parse_lat_avg  parse_lat_var  plan_lat_avg  plan_lat_var  run_lat_avg  run_lat_var  service_lat_avg  service_lat_var  overhead_lat_avg  overhead_lat_var  bytes_read_avg  bytes_read_var  rows_read_avg  rows_read_var  network_bytes_avg  network_bytes_var  network_msgs_avg  network_msgs_var  max_mem_usage_avg  max_mem_usage_var  max_disk_usage_avg  max_disk_usage_var  contention_time_avg  contention_time_var  implicit_txn  full_scan
+node_id  application_name  flags  statement_id  key  anonymized  count  first_attempt_count  max_retries  last_error  rows_avg  rows_var  parse_lat_avg  parse_lat_var  plan_lat_avg  plan_lat_var  run_lat_avg  run_lat_var  service_lat_avg  service_lat_var  overhead_lat_avg  overhead_lat_var  bytes_read_avg  bytes_read_var  rows_read_avg  rows_read_var  network_bytes_avg  network_bytes_var  network_msgs_avg  network_msgs_var  max_mem_usage_avg  max_mem_usage_var  max_disk_usage_avg  max_disk_usage_var  contention_time_avg  contention_time_var  implicit_txn  full_scan sample_plan database_name exec_node_ids
 
 query ITTTIIRRRRRRRRRRRRRRRRRR colnames
 SELECT * FROM crdb_internal.node_transaction_statistics WHERE node_id < 0
@@ -572,6 +572,10 @@ SELECT IF(nextval(_) < _, crdb_internal.force_retry(_), _)            1  true
 SELECT IF(nextval(_) < _, crdb_internal.force_retry(_::INTERVAL), _)  0  true
 SET application_name = DEFAULT                                        0  false
 
+query T
+SELECT database_name FROM crdb_internal.node_statement_statistics limit 1
+----
+test
 
 # Testing split_enforced_until when truncating and dropping.
 statement ok
@@ -879,3 +883,4 @@ query B
 SELECT is_temporary FROM crdb_internal.create_statements WHERE descriptor_name = 'temp'
 ----
 true
+

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal_tenant
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal_tenant
@@ -168,10 +168,10 @@ SELECT * FROM crdb_internal.leases WHERE node_id < 0
 ----
 node_id  table_id  name  parent_id  expiration  deleted
 
-query ITTTTTIIITRRRRRRRRRRRRRRRRRRRRRRRRRRBB colnames
+query ITTTTTIIITRRRRRRRRRRRRRRRRRRRRRRRRRRBBTTT colnames
 SELECT * FROM crdb_internal.node_statement_statistics WHERE node_id < 0
 ----
-node_id  application_name  flags  statement_id  key  anonymized  count  first_attempt_count  max_retries  last_error  rows_avg  rows_var  parse_lat_avg  parse_lat_var  plan_lat_avg  plan_lat_var  run_lat_avg  run_lat_var  service_lat_avg  service_lat_var  overhead_lat_avg  overhead_lat_var  bytes_read_avg  bytes_read_var  rows_read_avg  rows_read_var  network_bytes_avg  network_bytes_var  network_msgs_avg  network_msgs_var  max_mem_usage_avg  max_mem_usage_var  max_disk_usage_avg  max_disk_usage_var  contention_time_avg  contention_time_var  implicit_txn  full_scan
+node_id  application_name  flags  statement_id  key  anonymized  count  first_attempt_count  max_retries  last_error  rows_avg  rows_var  parse_lat_avg  parse_lat_var  plan_lat_avg  plan_lat_var  run_lat_avg  run_lat_var  service_lat_avg  service_lat_var  overhead_lat_avg  overhead_lat_var  bytes_read_avg  bytes_read_var  rows_read_avg  rows_read_var  network_bytes_avg  network_bytes_var  network_msgs_avg  network_msgs_var  max_mem_usage_avg  max_mem_usage_var  max_disk_usage_avg  max_disk_usage_var  contention_time_avg  contention_time_var  implicit_txn  full_scan sample_plan database_name exec_node_ids
 
 query ITTTIIRRRRRRRRRRRRRRRRRR colnames
 SELECT * FROM crdb_internal.node_transaction_statistics WHERE node_id < 0

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -697,7 +697,10 @@ CREATE TABLE crdb_internal.node_statement_statistics (
    contention_time_avg FLOAT8 NULL,
    contention_time_var FLOAT8 NULL,
    implicit_txn BOOL NOT NULL,
-   full_scan BOOL NOT NULL
+   full_scan BOOL NOT NULL,
+   sample_plan         JSONB NULL,
+   database_name       STRING NOT NULL,
+   exec_node_ids       INT8[] NOT NULL
 )  CREATE TABLE crdb_internal.node_statement_statistics (
    node_id INT8 NOT NULL,
    application_name STRING NOT NULL,
@@ -736,7 +739,10 @@ CREATE TABLE crdb_internal.node_statement_statistics (
    contention_time_avg FLOAT8 NULL,
    contention_time_var FLOAT8 NULL,
    implicit_txn BOOL NOT NULL,
-   full_scan BOOL NOT NULL
+   full_scan BOOL NOT NULL,
+   sample_plan         JSONB NULL,
+   database_name       STRING NOT NULL,
+   exec_node_ids       INT8[] NOT NULL
 )  {}  {}
 CREATE TABLE crdb_internal.node_transaction_statistics (
    node_id INT8 NOT NULL,


### PR DESCRIPTION
This change adds the database name, sampled query plan, and execution nodes of a query statement to the crdb_internal.node_statement_statistics table.

Example of result:
```
demo@127.0.0.1:26257/movr> select sample_plan, database_name, exec_node_ids from crdb_internal.node_statement_statistics where key = 'SELECT city, revenue FROM rides LIMIT _';
                                                                                      sample_plan                                                                                     | database_name | exec_node_ids
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------+----------------
  {"Children": [], "Estimated Row Count": "10 (2.0% of the table; stats collected 36 seconds ago)", "Limit": "10", "Name": "scan", "Spans": "LIMITED SCAN", "Table": "rides@primary"} | movr          | {1}
(1 row)

Time: 9ms total (execution 8ms / network 0ms)
```

Example sample plan JSON formatted:
```
{
   "Children":[],
   "Estimated Row Count":"10 (2.0% of the table; stats collected 36 seconds ago)",
   "Limit":"10",
   "Name":"scan",
   "Spans":"LIMITED SCAN",
   "Table":"rides@primary"
}
```

Through this change, 3rd party tools and partners are now able to consume this information for their use.

Resolves #65013
Resolves #65285

Release note (sql change): Added sample_plan, database_name, and exec_node_ids columns to crdb_internal.node_statement_statistics table. Allows for 3rd party and partner consumption of this data.