### PR TITLE
kvserver: skip some long tests under short

### DIFF
--- a/pkg/kv/kvserver/intent_resolver_integration_test.go
+++ b/pkg/kv/kvserver/intent_resolver_integration_test.go
@@ -219,6 +219,7 @@ func TestReliableIntentCleanup(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	skip.WithIssue(t, 65447, "fixing the flake uncovered additional bugs in #65458")
+	skip.UnderShort(t) // takes 85s
 	skip.UnderRace(t, "timing-sensitive test")
 	skip.UnderStress(t, "multi-node test")
 

--- a/pkg/kv/kvserver/replica_learner_test.go
+++ b/pkg/kv/kvserver/replica_learner_test.go
@@ -309,6 +309,8 @@ func TestLearnerSnapshotFailsRollback(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	skip.UnderShort(t) // Takes 90s.
+
 	runTest := func(t *testing.T, replicaType roachpb.ReplicaType) {
 		var rejectSnapshots int64
 		knobs, ltk := makeReplicationTestKnobs()

--- a/pkg/kv/kvserver/reset_quorum_test.go
+++ b/pkg/kv/kvserver/reset_quorum_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
@@ -51,9 +52,11 @@ import (
 // 6. A meta range (error expected).
 func TestResetQuorum(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	skip.UnderStress(t, "too many nodes")
 	skip.UnderRace(t, "takes >1m under race")
+	skip.UnderShort(t)
 
 	ctx := context.Background()
 	livenessDuration := 3000 * time.Millisecond


### PR DESCRIPTION
TestResetQuorum - 33s
TestLearnerSnapshotFailsRollback - 90s
TestReliableIntentCleanup - 80s

Release note: None