### PR TITLE
release-21.1: kvserver: change Migrate evaluation to wait for laxer LAI

### DIFF
--- a/pkg/kv/kvserver/replica_write.go
+++ b/pkg/kv/kvserver/replica_write.go
@@ -274,7 +274,8 @@ func (r *Replica) executeWriteBatch(
 				// NB: waitForApplication already has a timeout.
 				applicationErr := waitForApplication(
 					ctx, r.store.cfg.NodeDialer, desc.RangeID, desc.Replicas().Descriptors(),
-					uint64(maxLeaseIndex))
+					// We wait for an index >= that of the migration command.
+					r.GetLeaseAppliedIndex())
 				propResult.Err = roachpb.NewError(applicationErr)
 			}
 			return propResult.Reply, nil, propResult.Err


### PR DESCRIPTION
Backport 1/1 commits from #65790.

/cc @cockroachdb/release

---

The Migrate request blocks until all the replicas applied the command
it's evaluation results in. Before this patch, it was doing this waiting
by blocking until each replica has applied the MLAI of the respective
command, as returned by the request's evaluation. This patch changes it
to wait for an LAI that is read from the local replica after the
respective command applies locally. This LAI might be higher than the
migration command's MLAI, but it definitely won't be smaller.

There's two reasons for this change:
1) I think the code is currently broken because the MLAI returned by the
request evaluation is the one assigned to the respective command when
the command is inserted into the proposal buffer. However, the command
might end up being proposed and applied with a higher MLAI (see
tryReproposeWithNewLeaseIndex). So, the waiting that we currently do
might not actually wait for what it wants to wait for.

2) I'm moving MLAI assignment out of the evaluation path, deferring it
to proposal buffer flushing time.

Release note: None
