### PR TITLE
backupccl: fix bug in failing backups

### DIFF
--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -183,7 +183,6 @@ func backup(
 	spans := filterSpans(backupManifest.Spans, completedSpans)
 	introducedSpans := filterSpans(backupManifest.IntroducedSpans, completedIntroducedSpans)
 
-	g := ctxgroup.WithContext(ctx)
 	pkIDs := make(map[uint64]bool)
 	for i := range backupManifest.Descriptors {
 		if t, _, _, _ := descpb.FromDescriptor(&backupManifest.Descriptors[i]); t != nil {
@@ -227,17 +226,18 @@ func backup(
 	progressLogger := jobs.NewChunkProgressLogger(job, numTotalSpans, job.FractionCompleted(), jobs.ProgressUpdateOnly)
 
 	requestFinishedCh := make(chan struct{}, numTotalSpans) // enough buffer to never block
+	var jobProgressLoop func(ctx context.Context) error
 	if numTotalSpans > 0 {
-		g.GoCtx(func(ctx context.Context) error {
+		jobProgressLoop = func(ctx context.Context) error {
 			// Currently the granularity of backup progress is the % of spans
 			// exported. Would improve accuracy if we tracked the actual size of each
 			// file.
 			return progressLogger.Loop(ctx, requestFinishedCh)
-		})
+		}
 	}
 
 	progCh := make(chan *execinfrapb.RemoteProducerMetadata_BulkProcessorProgress)
-	g.GoCtx(func(ctx context.Context) error {
+	checkpointLoop := func(ctx context.Context) error {
 		// When a processor is done exporting a span, it will send a progress update
 		// to progCh.
 		for progress := range progCh {
@@ -267,20 +267,20 @@ func backup(
 			}
 		}
 		return nil
-	})
-
-	if err := distBackup(
-		ctx,
-		execCtx,
-		planCtx,
-		dsp,
-		progCh,
-		backupSpecs,
-	); err != nil {
-		return RowCount{}, err
 	}
 
-	if err := g.Wait(); err != nil {
+	runBackup := func(ctx context.Context) error {
+		return distBackup(
+			ctx,
+			execCtx,
+			planCtx,
+			dsp,
+			progCh,
+			backupSpecs,
+		)
+	}
+
+	if err := ctxgroup.GoAndWait(ctx, jobProgressLoop, checkpointLoop, runBackup); err != nil {
 		return RowCount{}, errors.Wrapf(err, "exporting %d ranges", errors.Safe(numTotalSpans))
 	}
 

--- a/pkg/util/ctxgroup/ctxgroup.go
+++ b/pkg/util/ctxgroup/ctxgroup.go
@@ -176,3 +176,16 @@ func GroupWorkers(ctx context.Context, num int, f func(context.Context, int) err
 	}
 	return group.Wait()
 }
+
+// GoAndWait calls the given functions each in a new goroutine. It then Waits
+// for them to finish. This is intended to help prevent bugs caused by returning
+// early after running some goroutines but before Waiting for them to complete.
+func GoAndWait(ctx context.Context, fs ...func(ctx context.Context) error) error {
+	group := WithContext(ctx)
+	for _, f := range fs {
+		if f != nil {
+			group.GoCtx(f)
+		}
+	}
+	return group.Wait()
+}


### PR DESCRIPTION
Fixes a bug where backups progress updating goroutine may continue
running even after the backup command itself fails. At worst, this results
in a panic inside Google Cloud Storage's SDK since we attempt to write
to a destination that was previously closed upon the backup failure.

Release note (bug fix): fix a bug that could cause a node to crash in rare
cases if a BACKUP writing to Google Cloud Storage failed