### PR TITLE
backupccl: fix cluster restore progress logging

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -659,25 +659,6 @@ func restore(
 	}
 	mu.requestsCompleted = make([]bool, len(importSpans))
 
-	progressLogger := jobs.NewChunkProgressLogger(job, len(importSpans), job.FractionCompleted(),
-		func(progressedCtx context.Context, details jobspb.ProgressDetails) {
-			switch d := details.(type) {
-			case *jobspb.Progress_Restore:
-				if !dataToRestore.isMainBundle() {
-					// We only update the progress for the primary data bundle (of which there
-					// can only be one).
-					return
-				}
-				mu.Lock()
-				if mu.highWaterMark >= 0 {
-					d.Restore.HighWater = importSpans[mu.highWaterMark].Span.Key
-				}
-				mu.Unlock()
-			default:
-				log.Errorf(progressedCtx, "job payload had unexpected type %T", d)
-			}
-		})
-
 	// TODO(pbardea): This not super principled. I just wanted something that
 	// wasn't a constant and grew slower than linear with the length of
 	// importSpans. It seems to be working well for BenchmarkRestore2TB but
@@ -701,13 +682,37 @@ func restore(
 	}
 
 	requestFinishedCh := make(chan struct{}, len(importSpans)) // enough buffer to never block
-	jobProgressLoop := func(ctx context.Context) error {
-		ctx, progressSpan := tracing.ChildSpan(ctx, "progress-log")
-		defer progressSpan.Finish()
-		return progressLogger.Loop(ctx, requestFinishedCh)
-	}
-
 	progCh := make(chan *execinfrapb.RemoteProducerMetadata_BulkProcessorProgress)
+
+	// tasks are the concurrent tasks that are run during the restore.
+	var tasks []func(ctx context.Context) error
+	if dataToRestore.isMainBundle() {
+		// Only update the job progress on the main data bundle. This should account
+		// for the bulk of the data to restore. Other data (e.g. zone configs in
+		// cluster restores) may be restored first. When restoring that data, we
+		// don't want to update the high-water mark key, so instead progress is just
+		// defined on the main data bundle (of which there should only be one).
+		progressLogger := jobs.NewChunkProgressLogger(job, len(importSpans), job.FractionCompleted(),
+			func(progressedCtx context.Context, details jobspb.ProgressDetails) {
+				switch d := details.(type) {
+				case *jobspb.Progress_Restore:
+					mu.Lock()
+					if mu.highWaterMark >= 0 {
+						d.Restore.HighWater = importSpans[mu.highWaterMark].Span.Key
+					}
+					mu.Unlock()
+				default:
+					log.Errorf(progressedCtx, "job payload had unexpected type %T", d)
+				}
+			})
+
+		jobProgressLoop := func(ctx context.Context) error {
+			ctx, progressSpan := tracing.ChildSpan(ctx, "progress-log")
+			defer progressSpan.Finish()
+			return progressLogger.Loop(ctx, requestFinishedCh)
+		}
+		tasks = append(tasks, jobProgressLoop)
+	}
 
 	jobCheckpointLoop := func(ctx context.Context) error {
 		// When a processor is done importing a span, it will send a progress update
@@ -741,6 +746,7 @@ func restore(
 		}
 		return nil
 	}
+	tasks = append(tasks, jobCheckpointLoop)
 
 	runRestore := func(ctx context.Context) error {
 		return distRestore(
@@ -754,8 +760,9 @@ func restore(
 			progCh,
 		)
 	}
+	tasks = append(tasks, runRestore)
 
-	if err := ctxgroup.GoAndWait(restoreCtx, jobProgressLoop, jobCheckpointLoop, runRestore); err != nil {
+	if err := ctxgroup.GoAndWait(restoreCtx, tasks...); err != nil {
 		// This leaves the data that did get imported in case the user wants to
 		// retry.
 		// TODO(dan): Build tooling to allow a user to restart a failed restore.


### PR DESCRIPTION
This commit fixes a bug in cluster RESTORE's progress logging. When
RESTORE was updated to support several phases, it made sure that the
highwatermark of the restore was only updated during the main portion of
the restore. However, there was a bug where the "fraction progressed"
metric was updated by the non-main bundle of data to restore.

This change makes is so that fraction progressed is only updated during
the main data bundle.

Unfortunately most backup progress tests are skipped since they're flaky.
This was tested manually and would be nice to get in for the upcoming 21.1
patch release. After the change:

<img width="1332" alt="Screen Shot 2021-05-27 at 16 17 46" src="https://user-images.githubusercontent.com/507390/119891792-667bd580-bf07-11eb-9ea7-be13375a75fe.png">


Release note (bug fix): Fixes a bug introduces in 21.1 where cluster
restores would report inaccurate progress, showing 100% progress
erroneously.