### PR TITLE
release-20.2: sql: ensure schema only has valid privileges after reparent database is done

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/reparent_database
+++ b/pkg/sql/logictest/testdata/logic_test/reparent_database
@@ -69,3 +69,19 @@ CREATE VIEW with_views.v AS SELECT x FROM with_views.t
 
 statement error pq: could not convert database "with_views" into schema because "with_views.public.t" has dependent objects \[with_views.public.v\]
 ALTER DATABASE with_views CONVERT TO SCHEMA WITH PARENT pgdatabase
+
+# Ensure only valid privileges are copied over to the schema.
+statement ok
+CREATE DATABASE to_schema;
+GRANT CREATE, DROP, SELECT, INSERT, DELETE, UPDATE ON DATABASE to_schema TO testuser;
+CREATE DATABASE parent2;
+
+# No privilege validation error should occur.
+statement ok
+ALTER DATABASE to_schema CONVERT TO SCHEMA WITH PARENT parent2;
+
+statement ok
+USE parent2;
+
+statement ok
+GRANT USAGE ON SCHEMA to_schema TO testuser;

--- a/pkg/sql/reparent_database.go
+++ b/pkg/sql/reparent_database.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
@@ -103,6 +104,16 @@ func (n *reparentDatabaseNode) startExec(params runParams) error {
 	if err != nil {
 		return err
 	}
+
+	// Not all Privileges on databases are valid on schemas.
+	// Remove any privileges that are not valid for schemas.
+	schemaPrivs := privilege.GetValidPrivilegesForObject(privilege.Schema).ToBitField()
+	privs := n.db.GetPrivileges()
+	for i, u := range privs.Users {
+		// Remove privileges that are valid for databases but not for schemas.
+		privs.Users[i].Privileges = u.Privileges & schemaPrivs
+	}
+
 	schema := schemadesc.NewCreatedMutable(descpb.SchemaDescriptor{
 		ParentID:   n.newParent.ID,
 		Name:       n.db.Name,


### PR DESCRIPTION
Backport 1/1 commits from #65722.

/cc @cockroachdb/release

---

sql: ensure schema only has valid privileges after reparent database is done

Release note (bug fix): Previously, ALTER DATABASE ... CONVERT TO SCHEMA
could potentially leave the schema with invalid privileges thus causing the
privilege descriptor to be invalid.

Fixes #65697
