### PR TITLE
colexec: minor fixes around the spilling queue

### DIFF
--- a/pkg/sql/colexec/colexecutils/spilling_queue.go
+++ b/pkg/sql/colexec/colexecutils/spilling_queue.go
@@ -81,6 +81,13 @@ type SpillingQueue struct {
 		maxNumBatchesEnqueuedInMemory int
 	}
 
+	// testingObservability stores some observability information about the
+	// state of the spilling queue when it was closed.
+	testingObservability struct {
+		spilled     bool
+		memoryUsage int64
+	}
+
 	diskAcc *mon.BoundAccount
 }
 
@@ -501,13 +508,23 @@ func (q *SpillingQueue) Empty() bool {
 	return q.numInMemoryItems == 0 && q.numOnDiskItems == 0
 }
 
-// Spilled returns whether the spilling queue has spilled to disk.
+// Spilled returns whether the spilling queue has spilled to disk. Note that if
+// the spilling queue has been closed, then it returns whether the queue spilled
+// before being closed.
 func (q *SpillingQueue) Spilled() bool {
+	if q.closed {
+		return q.testingObservability.spilled
+	}
 	return q.diskQueue != nil
 }
 
 // MemoryUsage reports the current memory usage of the spilling queue in bytes.
+// Note that if the spilling queue has been closed, then it returns the memory
+// usage of the queue before its closure.
 func (q *SpillingQueue) MemoryUsage() int64 {
+	if q.closed {
+		return q.testingObservability.memoryUsage
+	}
 	return q.unlimitedAllocator.Used()
 }
 
@@ -516,16 +533,27 @@ func (q *SpillingQueue) Close(ctx context.Context) error {
 	if q.closed {
 		return nil
 	}
+	q.closed = true
+	q.testingObservability.spilled = q.diskQueue != nil
+	q.testingObservability.memoryUsage = q.unlimitedAllocator.Used()
+	q.unlimitedAllocator.ReleaseMemory(q.unlimitedAllocator.Used())
+	// Eagerly release references to the in-memory items and scratch batches.
+	// Note that we don't lose the reference to 'items' slice itself so that it
+	// can be reused in case Close() is called by Reset().
+	for i := range q.items {
+		q.items[i] = nil
+	}
+	q.diskQueueDeselectionScratch = nil
+	q.dequeueScratch = nil
 	if q.diskQueue != nil {
 		if err := q.diskQueue.Close(ctx); err != nil {
 			return err
 		}
+		q.diskQueue = nil
 		if q.fdSemaphore != nil {
 			q.fdSemaphore.Release(q.numFDsOpenAtAnyGivenTime())
 		}
 		q.maxMemoryLimit += int64(q.diskQueueCfg.BufferSizeBytes)
-		q.closed = true
-		return nil
 	}
 	return nil
 }
@@ -551,7 +579,6 @@ func (q *SpillingQueue) Reset(ctx context.Context) {
 	if err := q.Close(ctx); err != nil {
 		colexecerror.InternalError(err)
 	}
-	q.diskQueue = nil
 	q.closed = false
 	q.numInMemoryItems = 0
 	q.numOnDiskItems = 0

--- a/pkg/sql/colexec/hash_aggregator.go
+++ b/pkg/sql/colexec/hash_aggregator.go
@@ -530,9 +530,7 @@ func (op *hashAggregator) Reset(ctx context.Context) {
 	op.buckets = op.buckets[:0]
 	op.ht.Reset(ctx)
 	if op.inputTrackingState.tuples != nil {
-		if err := op.inputTrackingState.tuples.Close(ctx); err != nil {
-			colexecerror.InternalError(err)
-		}
+		op.inputTrackingState.tuples.Reset(ctx)
 		op.inputTrackingState.zeroBatchEnqueued = false
 	}
 	op.curOutputBucketIdx = 0


### PR DESCRIPTION
**colexecutils: fix and improve closing of the spilling queue**

Previously, we forgot to release the memory registered with the
allocator of the spilling queue in `Close`. That method is called by
`Reset`, so the previous behavior could result in the increased reported
(not actual) memory usage which is suboptimal. This commit fixes that
issue as well as makes minor improvements to release some references
eagerly.

Release note: None

**colexec: fix resetting of the hash aggregator in an edge case**

Previously, when resetting the hash aggregator, we would close the
spilling queue in case the input tuples tracking is needed. This is
incorrect (`Close` is assumed to be called only once the spilling queue
will no longer be used), so this commit switches to using `Reset`.

This bug, however, doesn't pose any real danger because currently we
would never reset the hash aggregator in case the input tuples tracking
is needed (which is the case only when the hash aggregator is used as
the in-memory operator of the disk spiller, and the in-memory operators
never get reset to be reused later). So this commit fixes more of
a philosophical bug and, thus, won't be backported (and doesn't have
a regression test).

Release note: None