### PR TITLE
colexecutils: make closure of nil spilling queue a no-op

### DIFF
--- a/pkg/sql/colexec/colexecutils/spilling_queue.go
+++ b/pkg/sql/colexec/colexecutils/spilling_queue.go
@@ -513,7 +513,7 @@ func (q *SpillingQueue) MemoryUsage() int64 {
 
 // Close closes the spilling queue.
 func (q *SpillingQueue) Close(ctx context.Context) error {
-	if q.closed {
+	if q == nil || q.closed {
 		return nil
 	}
 	if q.diskQueue != nil {

--- a/pkg/sql/colexec/colexecwindow/buffered_window.go
+++ b/pkg/sql/colexec/colexecwindow/buffered_window.go
@@ -343,7 +343,9 @@ func (b *bufferedWindowOp) Next() coldata.Batch {
 }
 
 func (b *bufferedWindowOp) Close() error {
-	if !b.CloserHelper.Close() {
+	if !b.CloserHelper.Close() || b.Ctx == nil {
+		// Either Close() has already been called or Init() was never called. In
+		// both cases there is nothing to do.
 		return nil
 	}
 	var err error

--- a/pkg/sql/colexec/colexecwindow/relative_rank.eg.go
+++ b/pkg/sql/colexec/colexecwindow/relative_rank.eg.go
@@ -352,12 +352,13 @@ func (r *percentRankNoPartitionOp) Next() coldata.Batch {
 }
 
 func (r *percentRankNoPartitionOp) Close() error {
-	if !r.CloserHelper.Close() {
+	if !r.CloserHelper.Close() || r.Ctx == nil {
+		// Either Close() has already been called or Init() was never called. In
+		// both cases there is nothing to do.
 		return nil
 	}
-	ctx := r.EnsureCtx()
 	var lastErr error
-	if err := r.bufferedTuples.Close(ctx); err != nil {
+	if err := r.bufferedTuples.Close(r.Ctx); err != nil {
 		lastErr = err
 	}
 	return lastErr
@@ -647,15 +648,16 @@ func (r *percentRankWithPartitionOp) Next() coldata.Batch {
 }
 
 func (r *percentRankWithPartitionOp) Close() error {
-	if !r.CloserHelper.Close() {
+	if !r.CloserHelper.Close() || r.Ctx == nil {
+		// Either Close() has already been called or Init() was never called. In
+		// both cases there is nothing to do.
 		return nil
 	}
-	ctx := r.EnsureCtx()
 	var lastErr error
-	if err := r.bufferedTuples.Close(ctx); err != nil {
+	if err := r.bufferedTuples.Close(r.Ctx); err != nil {
 		lastErr = err
 	}
-	if err := r.partitionsState.Close(ctx); err != nil {
+	if err := r.partitionsState.Close(r.Ctx); err != nil {
 		lastErr = err
 	}
 	return lastErr
@@ -930,15 +932,16 @@ func (r *cumeDistNoPartitionOp) Next() coldata.Batch {
 }
 
 func (r *cumeDistNoPartitionOp) Close() error {
-	if !r.CloserHelper.Close() {
+	if !r.CloserHelper.Close() || r.Ctx == nil {
+		// Either Close() has already been called or Init() was never called. In
+		// both cases there is nothing to do.
 		return nil
 	}
-	ctx := r.EnsureCtx()
 	var lastErr error
-	if err := r.bufferedTuples.Close(ctx); err != nil {
+	if err := r.bufferedTuples.Close(r.Ctx); err != nil {
 		lastErr = err
 	}
-	if err := r.peerGroupsState.Close(ctx); err != nil {
+	if err := r.peerGroupsState.Close(r.Ctx); err != nil {
 		lastErr = err
 	}
 	return lastErr
@@ -1307,18 +1310,19 @@ func (r *cumeDistWithPartitionOp) Next() coldata.Batch {
 }
 
 func (r *cumeDistWithPartitionOp) Close() error {
-	if !r.CloserHelper.Close() {
+	if !r.CloserHelper.Close() || r.Ctx == nil {
+		// Either Close() has already been called or Init() was never called. In
+		// both cases there is nothing to do.
 		return nil
 	}
-	ctx := r.EnsureCtx()
 	var lastErr error
-	if err := r.bufferedTuples.Close(ctx); err != nil {
+	if err := r.bufferedTuples.Close(r.Ctx); err != nil {
 		lastErr = err
 	}
-	if err := r.partitionsState.Close(ctx); err != nil {
+	if err := r.partitionsState.Close(r.Ctx); err != nil {
 		lastErr = err
 	}
-	if err := r.peerGroupsState.Close(ctx); err != nil {
+	if err := r.peerGroupsState.Close(r.Ctx); err != nil {
 		lastErr = err
 	}
 	return lastErr

--- a/pkg/sql/colexec/colexecwindow/relative_rank_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/relative_rank_tmpl.go
@@ -612,21 +612,22 @@ func (r *_RELATIVE_RANK_STRINGOp) Next() coldata.Batch {
 }
 
 func (r *_RELATIVE_RANK_STRINGOp) Close() error {
-	if !r.CloserHelper.Close() {
+	if !r.CloserHelper.Close() || r.Ctx == nil {
+		// Either Close() has already been called or Init() was never called. In
+		// both cases there is nothing to do.
 		return nil
 	}
-	ctx := r.EnsureCtx()
 	var lastErr error
-	if err := r.bufferedTuples.Close(ctx); err != nil {
+	if err := r.bufferedTuples.Close(r.Ctx); err != nil {
 		lastErr = err
 	}
 	// {{if .HasPartition}}
-	if err := r.partitionsState.Close(ctx); err != nil {
+	if err := r.partitionsState.Close(r.Ctx); err != nil {
 		lastErr = err
 	}
 	// {{end}}
 	// {{if .IsCumeDist}}
-	if err := r.peerGroupsState.Close(ctx); err != nil {
+	if err := r.peerGroupsState.Close(r.Ctx); err != nil {
 		lastErr = err
 	}
 	// {{end}}


### PR DESCRIPTION
**colexecutils: make closure of nil spilling queue a no-op**

In some edge cases (shown by the follow-up commit) we might attempt to
close a nil spilling queue. Previously, this would lead to a NPE
(converted to an internal error). Now we make such operation a no-op.

Informs: #65763.

Release note: None (it is extremely unlikely that someone would run into
this bug)

**colexecwindow: fix closing of operators in an edge case**

The contract of `Close` method is such that it must be safe to call even
if `Init` was never called on the operator. This commit fixes a couple
of places where this contract was broken: namely, several window
functions tried to close nil spilling queue that would lead to a NPE.
This is now fixed.

Fixes: #65763.

Release note: None