### PR TITLE
release-20.2: kvserver: avoid bootstrapping closedTS state with the lease start time

### DIFF
--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -290,7 +290,7 @@ func (r *Replica) LastAssignedLeaseIndex() uint64 {
 
 // MaxClosed returns the maximum closed timestamp known to the Replica.
 func (r *Replica) MaxClosed(ctx context.Context) (_ hlc.Timestamp, ok bool) {
-	return r.maxClosed(ctx)
+	return r.maxClosed()
 }
 
 // SetQuotaPool allows the caller to set a replica's quota pool initialized to

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1025,7 +1025,7 @@ func (r *Replica) State() kvserverpb.RangeInfo {
 	// NB: this acquires an RLock(). Reentrant RLocks are deadlock prone, so do
 	// this first before RLocking below. Performance of this extra lock
 	// acquisition is not a concern.
-	ri.ActiveClosedTimestamp, _ = r.maxClosed(context.Background())
+	ri.ActiveClosedTimestamp, _ = r.maxClosed()
 
 	// NB: numRangefeedRegistrations doesn't require Replica.mu to be locked.
 	// However, it does require coordination between multiple goroutines, so

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -595,7 +595,7 @@ func (r *Replica) handleClosedTimestampUpdateRaftMuLocked(ctx context.Context) {
 	}
 
 	// Determine what the maximum closed timestamp is for this replica.
-	closedTS, _ := r.maxClosed(ctx)
+	closedTS, _ := r.maxClosed()
 
 	// If the closed timestamp is sufficiently stale, signal that we want an
 	// update to the leaseholder so that it will eventually begin to progress

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2550,7 +2550,7 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 		if wps, dur := rep.writeStats.avgQPS(); dur >= MinStatsDuration {
 			averageWritesPerSecond += wps
 		}
-		mc, ok := rep.maxClosed(ctx)
+		mc, ok := rep.maxClosed()
 		if ok && (minMaxClosedTS.IsEmpty() || mc.Less(minMaxClosedTS)) {
 			minMaxClosedTS = mc
 		}

--- a/pkg/kv/kvserver/store_split.go
+++ b/pkg/kv/kvserver/store_split.go
@@ -149,7 +149,7 @@ func splitPreApply(
 	// the hazard and ensures that no replica on the RHS is created with an
 	// initialMaxClosed that could be violated by a proposal on the RHS's
 	// initial leaseholder. See #44878.
-	initialMaxClosed, _ := r.maxClosed(ctx)
+	initialMaxClosed, _ := r.maxClosed()
 	rightRepl.mu.Lock()
 	rightRepl.mu.initialMaxClosed = initialMaxClosed
 	rightRepl.mu.Unlock()


### PR DESCRIPTION
This commit reverts the main change introduced in #35130. That change made it
such that each replica could bootstrap its `maxClosed` timestamp value with the
start time of the latest lease that it knew about. However, it doesn't consider
the fact that when the lease transfer occurred, the range may have been in a
subsumed state and thus, is not allowed to serve any requests past the
subsumption time. Bumping a replica's closed timestamp by the lease start time
allows for a bug where the closed timestamp of a replica may be advanced past
the subsumption time of a range, which would allow the range's non-leaseholder
replicas to serve follower reads past its subsumption time.

Such a sequence of events would in turn allow follower reads queries to serve
results that could be invalidated by future writes on the keyspan owned by the
subsumed range.

Release note (bug fix): A rare bug in 20.2 that manifested itself when a lease
change occured during a range merge has been resolved. This bug allowed `AS OF
SYSTEM TIME` queries to serve inconsistent results.

