### PR TITLE
release-21.1: acceptance: maybe deflake acceptance/multi-tenant

### DIFF
--- a/pkg/cli/mt_start_sql.go
+++ b/pkg/cli/mt_start_sql.go
@@ -137,5 +137,6 @@ func runStartSQL(cmd *cobra.Command, args []string) error {
 	ch := make(chan os.Signal, 1)
 	signal.Notify(ch, drainSignals...)
 	sig := <-ch
+	log.Flush()
 	return errors.Newf("received signal %v", sig)
 }

--- a/pkg/cmd/roachtest/multitenant.go
+++ b/pkg/cmd/roachtest/multitenant.go
@@ -52,8 +52,7 @@ func runAcceptanceMultitenant(ctx context.Context, t *test, c *cluster) {
 	t.Status("stopping the server ahead of checking for the tenant server")
 
 	// Stop the server, which also ensures that log files get flushed.
-	cancel()
-	<-tenant.errCh
+	tenant.stop(ctx, t, c)
 
 	t.Status("checking log file contents")
 

--- a/pkg/cmd/roachtest/multitenant_upgrade.go
+++ b/pkg/cmd/roachtest/multitenant_upgrade.go
@@ -100,7 +100,7 @@ func (tn *tenantNode) start(ctx context.Context, t *test, c *cluster, binary str
 	u.Host = c.ExternalIP(ctx, c.Node(tn.node))[0] + ":" + strconv.Itoa(tn.sqlPort)
 	tn.pgURL = u.String()
 
-	// The tenant is usually responsible ~right away, but it
+	// The tenant is usually responsive ~right away, but it
 	// has on occasions taken more than 3s for it to connect
 	// to the KV layer, and it won't open the SQL port until
 	// it has.


### PR DESCRIPTION
Backport 2/2 commits from #65386.

Closes #65526.

/cc @cockroachdb/release

---

Closes #65335.

Release note: None

