### PR TITLE
release-21.1: sql: Don't clear zone configs on indexes during a RBR transition

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
@@ -870,9 +870,39 @@ statement error attempting to update zone config which contains an extra zone co
 ALTER TABLE tbl2 SET LOCALITY GLOBAL
 
 statement ok
+ALTER INDEX tbl2@tbl2_i_idx CONFIGURE ZONE USING gc.ttlseconds=10
+
+query TT
+SHOW ZONE CONFIGURATION FOR INDEX tbl2@tbl2_i_idx
+----
+INDEX tbl2@tbl2_i_idx  ALTER INDEX tbl2@tbl2_i_idx CONFIGURE ZONE USING
+                       range_min_bytes = 134217728,
+                       range_max_bytes = 536870912,
+                       gc.ttlseconds = 10,
+                       num_replicas = 10,
+                       num_voters = 3,
+                       constraints = '{+region=us-east-1: 1}',
+                       voter_constraints = '[+region=us-east-1]',
+                       lease_preferences = '[[+region=us-east-1]]'
+
+statement ok
 SET override_multi_region_zone_config = true;
 ALTER TABLE tbl2 SET LOCALITY GLOBAL;
 SET override_multi_region_zone_config = false
+
+# Validate that we don't overwrite gc.ttlseconds
+query TT
+SHOW ZONE CONFIGURATION FOR INDEX tbl2@tbl2_i_idx
+----
+INDEX tbl2@tbl2_i_idx  ALTER INDEX tbl2@tbl2_i_idx CONFIGURE ZONE USING
+                       range_min_bytes = 134217728,
+                       range_max_bytes = 536870912,
+                       gc.ttlseconds = 10,
+                       num_replicas = 3,
+                       num_voters = 3,
+                       constraints = '{+region=us-east-1: 1}',
+                       voter_constraints = '[+region=us-east-1]',
+                       lease_preferences = '[[+region=us-east-1]]'
 
 statement ok
 ALTER TABLE tbl2 SET LOCALITY REGIONAL BY ROW

--- a/pkg/config/zonepb/zone.go
+++ b/pkg/config/zonepb/zone.go
@@ -849,6 +849,23 @@ func (z *ZoneConfig) DiffWithZone(
 	return true, DiffWithZoneMismatch{}, nil
 }
 
+// ClearFieldsOfAllSubzones uses the supplied fieldList and clears those fields
+// from all of the zone config's subzones.
+func (z *ZoneConfig) ClearFieldsOfAllSubzones(fieldList []tree.Name) {
+	newSubzones := z.Subzones[:0]
+	emptyZone := NewZoneConfig()
+	for _, sz := range z.Subzones {
+		// By copying from an empty zone, we'll end up clearing out all of the
+		// fields in the fieldList.
+		sz.Config.CopyFromZone(*emptyZone, fieldList)
+		// If we haven't emptied out the subzone, append it to the new slice.
+		if !sz.Config.Equal(emptyZone) {
+			newSubzones = append(newSubzones, sz)
+		}
+	}
+	z.Subzones = newSubzones
+}
+
 // StoreSatisfiesConstraint checks whether a store satisfies the given constraint.
 // If the constraint is of the PROHIBITED type, satisfying it means the store
 // not matching the constraint's spec.

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -2525,19 +2525,21 @@ func (sc *SchemaChanger) applyZoneConfigChangeForMutation(
 			if err != nil {
 				return err
 			}
-			return ApplyZoneConfigForMultiRegionTable(
+			if err := ApplyZoneConfigForMultiRegionTable(
 				ctx,
 				txn,
 				sc.execCfg,
 				regionConfig,
 				tableDesc,
 				opts...,
-			)
+			); err != nil {
+				return err
+			}
 		}
 
-		// For the plain ALTER PRIMARY KEY case, copy the zone configs over
-		// for any new indexes.
-		// Note this is done even for isDone = true, though not strictly necessary.
+		// In all cases, we now copy the zone configs over for any new indexes.
+		// Note this is done even for isDone = true, though not strictly
+		// necessary.
 		return maybeUpdateZoneConfigsForPKChange(
 			ctx, txn, sc.execCfg, tableDesc, pkSwap,
 		)


### PR DESCRIPTION
Backport 1/1 commits from #63665.

/cc @cockroachdb/release

---

Previously we were wiping out the zone configs for all indexes when
transitioning from REGIONAL BY ROW to either GLOBAL or REGIONAL BY
TABLE. This was problematic because there could have been zone configs
which were setup by the user and didn't have any multi-region zone
config fields set. This fix ensures that we don't wipe out the zone
configs for indexes, provided that they contain at least one field set
that isn't governed by the multi-region syntax.

Release note (sql change): Fixes a bug where transitioning from locality
REGIONAL BY ROW to GLOBAL or REGIONAL BY TABLE could mistakenly remove a
zone configuration on an index which has no multi-region fields set.

Resolves: #63614.
