### PR TITLE
release-21.1: sql: Fix TestTelemetry in cases where retries occur

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region
@@ -1557,3 +1557,125 @@ DROP TYPE db_enum_name_clash.crdb_internal_region;
 ALTER DATABASE db_enum_name_clash SET PRIMARY REGION "us-east-1"
 
 
+# Verify that we can use CREATE TABLE AS from a REGIONAL BY ROW table, and
+# end up with something that resembles a REGIONAL BY ROW table.  Note that
+# this is not simple, as we need to explicitly select the crdb_region
+# column, and then convert that column to be generated and hidden.
+subtest create_table_as_regional_by_row
+
+statement ok
+CREATE DATABASE "mr-create-table-as" PRIMARY REGION "ap-southeast-2" REGIONS "ap-southeast-2", "ca-central-1", "us-east-1";
+USE "mr-create-table-as"
+
+statement ok
+CREATE TABLE t (i int PRIMARY KEY) LOCALITY REGIONAL BY ROW
+
+statement ok
+INSERT INTO t VALUES (1),(2),(3)
+
+statement ok
+CREATE TABLE t_as AS SELECT i, crdb_region FROM t
+
+query T colnames
+SELECT create_statement from [SHOW CREATE TABLE t_as]
+----
+create_statement
+CREATE TABLE public.t_as (
+                                                i INT8 NULL,
+                                                crdb_region public.crdb_internal_region NULL,
+                                                rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                                                CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
+                                                FAMILY "primary" (i, crdb_region, rowid)
+) LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
+
+
+statement error cannot use column crdb_region for REGIONAL BY ROW table as it may contain NULL values
+ALTER TABLE t_as SET LOCALITY REGIONAL BY ROW AS crdb_region
+
+statement ok
+ALTER TABLE t_as ALTER COLUMN crdb_region SET NOT NULL
+
+statement ok
+ALTER TABLE t_as ALTER COLUMN crdb_region SET NOT VISIBLE
+
+statement ok
+ALTER TABLE t_as ALTER COLUMN crdb_region SET DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region
+
+statement ok
+ALTER TABLE t_as SET LOCALITY REGIONAL BY ROW AS crdb_region
+
+query T colnames
+SELECT create_statement from [SHOW CREATE TABLE t_as]
+----
+create_statement
+CREATE TABLE public.t_as (
+                                           i INT8 NULL,
+                                           crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
+                                           rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                                           CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
+                                           FAMILY "primary" (i, crdb_region, rowid)
+) LOCALITY REGIONAL BY ROW AS crdb_region
+
+query TI colnames
+SELECT crdb_region, i FROM t_as
+----
+crdb_region     i
+ap-southeast-2  1
+ap-southeast-2  2
+ap-southeast-2  3
+
+statement ok
+INSERT INTO t_as VALUES (4)
+
+# Validate that hidden column works
+query TI colnames
+SELECT crdb_region, i FROM t_as
+----
+crdb_region     i
+ap-southeast-2  1
+ap-southeast-2  2
+ap-southeast-2  3
+ap-southeast-2  4
+
+statement ok
+ALTER TABLE t_as ALTER COLUMN i SET NOT NULL
+
+statement ok
+ALTER TABLE t_as ALTER PRIMARY KEY USING COLUMNS (i)
+
+statement ok
+SET sql_safe_updates = false;
+ALTER TABLE t_as DROP COLUMN rowid;
+SET sql_safe_updates = true
+
+query T colnames
+SELECT create_statement from [SHOW CREATE TABLE t_as]
+----
+create_statement
+CREATE TABLE public.t_as (
+                                           i INT8 NOT NULL,
+                                           crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
+                                           CONSTRAINT "primary" PRIMARY KEY (i ASC),
+                                           FAMILY "primary" (i, crdb_region)
+) LOCALITY REGIONAL BY ROW AS crdb_region
+
+query T colnames
+SELECT create_statement from [SHOW CREATE TABLE t]
+----
+create_statement
+CREATE TABLE public.t (
+                            i INT8 NOT NULL,
+                            crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
+                            CONSTRAINT "primary" PRIMARY KEY (i ASC),
+                            FAMILY "primary" (i, crdb_region)
+) LOCALITY REGIONAL BY ROW
+
+# Declare victory, as this is the closest we can get.
+statement ok
+DROP TABLE t;
+DROP TABLE t_as
+
+statement ok
+SET sql_safe_updates = false;
+DROP DATABASE "mr-create-table-as";
+SET sql_safe_updates = true

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
@@ -657,13 +657,8 @@ RANGE default  ALTER RANGE default CONFIGURE ZONE USING
                constraints = '[]',
                lease_preferences = '[]'
 
-statement error attempting to discard the zone configuration of a multi-region entity
-ALTER INDEX regional_by_row@primary CONFIGURE ZONE DISCARD
-
 statement ok
-SET override_multi_region_zone_config = true;
-ALTER INDEX regional_by_row@primary CONFIGURE ZONE DISCARD;
-SET override_multi_region_zone_config = false
+ALTER INDEX regional_by_row@primary CONFIGURE ZONE DISCARD
 
 statement error attempting to discard the zone configuration of a multi-region entity
 ALTER PARTITION "ca-central-1" OF INDEX regional_by_row@primary CONFIGURE ZONE DISCARD
@@ -922,3 +917,431 @@ SET override_multi_region_zone_config = false
 
 statement ok
 ALTER TABLE tbl2 SET LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
+
+statement ok
+DROP TABLE tbl2
+
+# Test all cases where DISCARD is used to remove a zone configuration from a
+# REGIONAL BY ROW table.
+subtest discard_regional_by_row
+
+statement ok
+CREATE TABLE tbl3 (
+  pk INT PRIMARY KEY,
+  i INT,
+  INDEX(i)
+) LOCALITY REGIONAL BY ROW
+
+statement ok
+ALTER INDEX tbl3@tbl3_i_idx CONFIGURE ZONE USING gc.ttlseconds=10
+
+statement error attempting to modify protected field "num_replicas" of a multi-region zone configuration
+ALTER INDEX tbl3@tbl3_i_idx CONFIGURE ZONE USING num_replicas=10
+
+statement ok
+SET override_multi_region_zone_config = true;
+ALTER INDEX tbl3@tbl3_i_idx CONFIGURE ZONE USING num_replicas=10;
+SET override_multi_region_zone_config = false
+
+query TT
+SHOW ZONE CONFIGURATION FOR INDEX tbl3@tbl3_i_idx
+----
+INDEX tbl3@tbl3_i_idx  ALTER INDEX tbl3@tbl3_i_idx CONFIGURE ZONE USING
+                       range_min_bytes = 134217728,
+                       range_max_bytes = 536870912,
+                       gc.ttlseconds = 10,
+                       num_replicas = 10,
+                       num_voters = 3,
+                       constraints = '{+region=us-east-1: 1}',
+                       voter_constraints = '[+region=us-east-1]',
+                       lease_preferences = '[[+region=us-east-1]]'
+
+# DISCARD of an index zone config on a RBR table should succeed without override.
+statement ok
+ALTER INDEX tbl3@tbl3_i_idx CONFIGURE ZONE DISCARD
+
+query TT
+SHOW ZONE CONFIGURATION FOR INDEX tbl3@tbl3_i_idx
+----
+DATABASE initial_multiregion_db  ALTER DATABASE initial_multiregion_db CONFIGURE ZONE USING
+                                 range_min_bytes = 134217728,
+                                 range_max_bytes = 536870912,
+                                 gc.ttlseconds = 90000,
+                                 num_replicas = 3,
+                                 num_voters = 3,
+                                 constraints = '{+region=us-east-1: 1}',
+                                 voter_constraints = '[+region=us-east-1]',
+                                 lease_preferences = '[[+region=us-east-1]]'
+
+# DISCARDing a partition's zone configuration on a RBR table should fail.
+statement error attempting to discard the zone configuration of a multi-region entity
+ALTER partition "us-east-1" of index tbl3@tbl3_i_idx CONFIGURE ZONE DISCARD
+
+# ...but we should be able to override.
+statement ok
+SET override_multi_region_zone_config = true;
+ALTER partition "us-east-1" of index tbl3@tbl3_i_idx CONFIGURE ZONE DISCARD;
+SET override_multi_region_zone_config = false
+
+# Try a similar test but on the table zone configuration.
+statement ok
+ALTER TABLE tbl3 CONFIGURE ZONE USING gc.ttlseconds=10
+
+statement error attempting to modify protected field "num_replicas" of a multi-region zone configuration
+ALTER TABLE tbl3 CONFIGURE ZONE USING num_replicas=10
+
+statement ok
+SET override_multi_region_zone_config = true;
+ALTER TABLE tbl3 CONFIGURE ZONE USING num_replicas=10;
+SET override_multi_region_zone_config = false
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE tbl3
+----
+TABLE tbl3  ALTER TABLE tbl3 CONFIGURE ZONE USING
+            range_min_bytes = 134217728,
+            range_max_bytes = 536870912,
+            gc.ttlseconds = 10,
+            num_replicas = 10,
+            num_voters = 3,
+            constraints = '{+region=us-east-1: 1}',
+            voter_constraints = '[+region=us-east-1]',
+            lease_preferences = '[[+region=us-east-1]]'
+
+# DISCARD of an table zone config on a RBR table should succeed without override.
+statement ok
+ALTER TABLE tbl3 CONFIGURE ZONE DISCARD
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE tbl3
+----
+DATABASE initial_multiregion_db  ALTER DATABASE initial_multiregion_db CONFIGURE ZONE USING
+                                 range_min_bytes = 134217728,
+                                 range_max_bytes = 536870912,
+                                 gc.ttlseconds = 90000,
+                                 num_replicas = 3,
+                                 num_voters = 3,
+                                 constraints = '{+region=us-east-1: 1}',
+                                 voter_constraints = '[+region=us-east-1]',
+                                 lease_preferences = '[[+region=us-east-1]]'
+
+statement ok
+DROP TABLE tbl3
+
+# Test all cases where DISCARD is used to remove a zone configuration from a
+# REGIONAL BY TABLE IN PRIMARY REGION table.
+subtest discard_regional_by_table_in_primary_region
+
+statement ok
+CREATE TABLE tbl4 (
+  pk INT PRIMARY KEY,
+  i INT,
+  INDEX(i)
+) LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
+
+statement ok
+ALTER INDEX tbl4@tbl4_i_idx CONFIGURE ZONE USING gc.ttlseconds=10
+
+statement error attempting to modify protected field "num_replicas" of a multi-region zone configuration
+ALTER INDEX tbl4@tbl4_i_idx CONFIGURE ZONE USING num_replicas=10
+
+statement ok
+SET override_multi_region_zone_config = true;
+ALTER INDEX tbl4@tbl4_i_idx CONFIGURE ZONE USING num_replicas=10;
+SET override_multi_region_zone_config = false
+
+query TT
+SHOW ZONE CONFIGURATION FOR INDEX tbl4@tbl4_i_idx
+----
+INDEX tbl4@tbl4_i_idx  ALTER INDEX tbl4@tbl4_i_idx CONFIGURE ZONE USING
+                       range_min_bytes = 134217728,
+                       range_max_bytes = 536870912,
+                       gc.ttlseconds = 10,
+                       num_replicas = 10,
+                       num_voters = 3,
+                       constraints = '{+region=us-east-1: 1}',
+                       voter_constraints = '[+region=us-east-1]',
+                       lease_preferences = '[[+region=us-east-1]]'
+
+# DISCARD of an index zone config on a RBT table should succeed without override.
+statement ok
+ALTER INDEX tbl4@tbl4_i_idx CONFIGURE ZONE DISCARD
+
+query TT
+SHOW ZONE CONFIGURATION FOR INDEX tbl4@tbl4_i_idx
+----
+DATABASE initial_multiregion_db  ALTER DATABASE initial_multiregion_db CONFIGURE ZONE USING
+                                 range_min_bytes = 134217728,
+                                 range_max_bytes = 536870912,
+                                 gc.ttlseconds = 90000,
+                                 num_replicas = 3,
+                                 num_voters = 3,
+                                 constraints = '{+region=us-east-1: 1}',
+                                 voter_constraints = '[+region=us-east-1]',
+                                 lease_preferences = '[[+region=us-east-1]]'
+
+statement ok
+ALTER TABLE tbl4 CONFIGURE ZONE USING gc.ttlseconds=10
+
+statement error attempting to modify protected field "num_replicas" of a multi-region zone configuration
+ALTER TABLE tbl4 CONFIGURE ZONE USING num_replicas=10
+
+statement ok
+SET override_multi_region_zone_config = true;
+ALTER TABLE tbl4 CONFIGURE ZONE USING num_replicas=10;
+SET override_multi_region_zone_config = false
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE tbl4
+----
+TABLE tbl4  ALTER TABLE tbl4 CONFIGURE ZONE USING
+            range_min_bytes = 134217728,
+            range_max_bytes = 536870912,
+            gc.ttlseconds = 10,
+            num_replicas = 10,
+            num_voters = 3,
+            constraints = '{+region=us-east-1: 1}',
+            voter_constraints = '[+region=us-east-1]',
+            lease_preferences = '[[+region=us-east-1]]'
+
+# DISCARD of an table zone config on a RBT table should succeed without override.
+statement ok
+ALTER TABLE tbl4 CONFIGURE ZONE DISCARD
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE tbl4
+----
+DATABASE initial_multiregion_db  ALTER DATABASE initial_multiregion_db CONFIGURE ZONE USING
+                                 range_min_bytes = 134217728,
+                                 range_max_bytes = 536870912,
+                                 gc.ttlseconds = 90000,
+                                 num_replicas = 3,
+                                 num_voters = 3,
+                                 constraints = '{+region=us-east-1: 1}',
+                                 voter_constraints = '[+region=us-east-1]',
+                                 lease_preferences = '[[+region=us-east-1]]'
+
+# Test all cases where DISCARD is used to remove a zone configuration from a
+# REGIONAL BY TABLE IN REGION <region> table.
+subtest discard_regional_by_table_in_region
+
+statement ok
+CREATE TABLE tbl5 (
+  pk INT PRIMARY KEY,
+  i INT,
+  INDEX(i)
+) LOCALITY REGIONAL BY TABLE IN "us-east-1"
+
+statement ok
+ALTER INDEX tbl5@tbl5_i_idx CONFIGURE ZONE USING gc.ttlseconds=10
+
+statement error attempting to modify protected field "num_replicas" of a multi-region zone configuration
+ALTER INDEX tbl5@tbl5_i_idx CONFIGURE ZONE USING num_replicas=10
+
+statement ok
+SET override_multi_region_zone_config = true;
+ALTER INDEX tbl5@tbl5_i_idx CONFIGURE ZONE USING num_replicas=10;
+SET override_multi_region_zone_config = false
+
+query TT
+SHOW ZONE CONFIGURATION FOR INDEX tbl5@tbl5_i_idx
+----
+INDEX tbl5@tbl5_i_idx  ALTER INDEX tbl5@tbl5_i_idx CONFIGURE ZONE USING
+                       range_min_bytes = 134217728,
+                       range_max_bytes = 536870912,
+                       gc.ttlseconds = 10,
+                       num_replicas = 10,
+                       num_voters = 3,
+                       constraints = '{+region=us-east-1: 1}',
+                       voter_constraints = '[+region=us-east-1]',
+                       lease_preferences = '[[+region=us-east-1]]'
+
+# DISCARD of an index zone config on a RBT table should succeed without override.
+statement ok
+ALTER INDEX tbl5@tbl5_i_idx CONFIGURE ZONE DISCARD
+
+query TT
+SHOW ZONE CONFIGURATION FOR INDEX tbl5@tbl5_i_idx
+----
+TABLE tbl5  ALTER TABLE tbl5 CONFIGURE ZONE USING
+            range_min_bytes = 134217728,
+            range_max_bytes = 536870912,
+            gc.ttlseconds = 90000,
+            num_replicas = 3,
+            num_voters = 3,
+            constraints = '{+region=us-east-1: 1}',
+            voter_constraints = '[+region=us-east-1]',
+            lease_preferences = '[[+region=us-east-1]]'
+
+statement ok
+ALTER TABLE tbl5 CONFIGURE ZONE USING gc.ttlseconds=10
+
+statement error attempting to modify protected field "num_replicas" of a multi-region zone configuration
+ALTER TABLE tbl5 CONFIGURE ZONE USING num_replicas=10
+
+statement ok
+SET override_multi_region_zone_config = true;
+ALTER TABLE tbl5 CONFIGURE ZONE USING num_replicas=10;
+SET override_multi_region_zone_config = false
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE tbl5
+----
+TABLE tbl5  ALTER TABLE tbl5 CONFIGURE ZONE USING
+            range_min_bytes = 134217728,
+            range_max_bytes = 536870912,
+            gc.ttlseconds = 10,
+            num_replicas = 10,
+            num_voters = 3,
+            constraints = '{+region=us-east-1: 1}',
+            voter_constraints = '[+region=us-east-1]',
+            lease_preferences = '[[+region=us-east-1]]'
+
+# DISCARD of an table zone config on a RBT table should fail without override.
+statement error attempting to discard the zone configuration of a multi-region entity
+ALTER TABLE tbl5 CONFIGURE ZONE DISCARD
+
+statement ok
+SET override_multi_region_zone_config = true;
+ALTER TABLE tbl5 CONFIGURE ZONE DISCARD;
+SET override_multi_region_zone_config = false
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE tbl5
+----
+DATABASE initial_multiregion_db  ALTER DATABASE initial_multiregion_db CONFIGURE ZONE USING
+                                 range_min_bytes = 134217728,
+                                 range_max_bytes = 536870912,
+                                 gc.ttlseconds = 90000,
+                                 num_replicas = 3,
+                                 num_voters = 3,
+                                 constraints = '{+region=us-east-1: 1}',
+                                 voter_constraints = '[+region=us-east-1]',
+                                 lease_preferences = '[[+region=us-east-1]]'
+
+statement ok
+DROP TABLE tbl5
+
+# Test all cases where DISCARD is used to remove a zone configuration from a
+# GLOBAL table.
+subtest discard_global
+
+statement ok
+CREATE TABLE tbl6 (
+  pk INT PRIMARY KEY,
+  i INT,
+  INDEX(i)
+) LOCALITY GLOBAL
+
+statement ok
+ALTER INDEX tbl6@tbl6_i_idx CONFIGURE ZONE USING gc.ttlseconds=10
+
+statement error attempting to modify protected field "num_replicas" of a multi-region zone configuration
+ALTER INDEX tbl6@tbl6_i_idx CONFIGURE ZONE USING num_replicas=10
+
+statement ok
+SET override_multi_region_zone_config = true;
+ALTER INDEX tbl6@tbl6_i_idx CONFIGURE ZONE USING num_replicas=10;
+SET override_multi_region_zone_config = false
+
+query TT
+SHOW ZONE CONFIGURATION FOR INDEX tbl6@tbl6_i_idx
+----
+INDEX tbl6@tbl6_i_idx  ALTER INDEX tbl6@tbl6_i_idx CONFIGURE ZONE USING
+                       range_min_bytes = 134217728,
+                       range_max_bytes = 536870912,
+                       gc.ttlseconds = 10,
+                       num_replicas = 10,
+                       num_voters = 3,
+                       constraints = '{+region=us-east-1: 1}',
+                       voter_constraints = '[+region=us-east-1]',
+                       lease_preferences = '[[+region=us-east-1]]'
+
+# DISCARD of an index zone config on a GLOBAL table should succeed without
+# override.
+statement ok
+ALTER INDEX tbl6@tbl6_i_idx CONFIGURE ZONE DISCARD
+
+query TT
+SHOW ZONE CONFIGURATION FOR INDEX tbl6@tbl6_i_idx
+----
+TABLE tbl6  ALTER TABLE tbl6 CONFIGURE ZONE USING
+            range_min_bytes = 134217728,
+            range_max_bytes = 536870912,
+            gc.ttlseconds = 90000,
+            global_reads = true,
+            num_replicas = 3,
+            num_voters = 3,
+            constraints = '{+region=us-east-1: 1}',
+            voter_constraints = '[+region=us-east-1]',
+            lease_preferences = '[[+region=us-east-1]]'
+
+statement ok
+ALTER TABLE tbl6 CONFIGURE ZONE USING gc.ttlseconds=10
+
+statement error attempting to modify protected field "num_replicas" of a multi-region zone configuration
+ALTER TABLE tbl6 CONFIGURE ZONE USING num_replicas=10
+
+statement ok
+SET override_multi_region_zone_config = true;
+ALTER TABLE tbl6 CONFIGURE ZONE USING num_replicas=10;
+SET override_multi_region_zone_config = false
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE tbl6
+----
+TABLE tbl6  ALTER TABLE tbl6 CONFIGURE ZONE USING
+            range_min_bytes = 134217728,
+            range_max_bytes = 536870912,
+            gc.ttlseconds = 10,
+            global_reads = true,
+            num_replicas = 10,
+            num_voters = 3,
+            constraints = '{+region=us-east-1: 1}',
+            voter_constraints = '[+region=us-east-1]',
+            lease_preferences = '[[+region=us-east-1]]'
+
+# DISCARD of an table zone config on a GLOBAL table should fail without
+# override.
+statement error attempting to discard the zone configuration of a multi-region entity
+ALTER TABLE tbl6 CONFIGURE ZONE DISCARD
+
+statement ok
+SET override_multi_region_zone_config = true;
+ALTER TABLE tbl6 CONFIGURE ZONE DISCARD;
+SET override_multi_region_zone_config = false
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE tbl6
+----
+DATABASE initial_multiregion_db  ALTER DATABASE initial_multiregion_db CONFIGURE ZONE USING
+                                 range_min_bytes = 134217728,
+                                 range_max_bytes = 536870912,
+                                 gc.ttlseconds = 90000,
+                                 num_replicas = 3,
+                                 num_voters = 3,
+                                 constraints = '{+region=us-east-1: 1}',
+                                 voter_constraints = '[+region=us-east-1]',
+                                 lease_preferences = '[[+region=us-east-1]]'
+
+statement ok
+DROP TABLE tbl6
+
+# Ensure that when using INHERIT FROM PARENT, blocks still apply.
+subtest inherit_from_parent
+
+statement ok
+CREATE TABLE tbl7 (
+  pk INT PRIMARY KEY,
+  i INT,
+  INDEX(i)
+) LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
+
+statement error attempting to modify protected field "num_replicas" of a multi-region zone configuration
+ALTER TABLE tbl7 CONFIGURE ZONE USING num_replicas = COPY FROM PARENT
+
+statement error attempting to modify protected field "num_replicas" of a multi-region zone configuration
+ALTER INDEX tbl7@tbl7_i_idx CONFIGURE ZONE USING num_replicas = COPY FROM PARENT
+
+statement error attempting to modify protected field "num_replicas" of a multi-region zone configuration
+ALTER PARTITION "us-east-1" OF INDEX tbl7@tbl7_i_idx CONFIGURE ZONE USING num_replicas = COPY FROM PARENT

--- a/pkg/ccl/telemetryccl/testdata/telemetry/multiregion
+++ b/pkg/ccl/telemetryccl/testdata/telemetry/multiregion
@@ -346,10 +346,10 @@ INSERT INTO t7 VALUES (1),(2),(3);
 EXPORT INTO CSV 'nodelocal://0/t7' FROM TABLE t7;
 ----
 
-feature-counters
+feature-usage
 IMPORT INTO t7 CSV DATA ('nodelocal://0/t7/export*.csv')
 ----
-sql.multiregion.import  1
+sql.multiregion.import
 
 # Test for locality optimized search counter.
 feature-allowlist
@@ -375,63 +375,63 @@ feature-allowlist
 sql.multiregion.zone_configuration.override.*
 ----
 
-feature-counters
+feature-usage
 SET override_multi_region_zone_config = true;
 ALTER TABLE t9 CONFIGURE ZONE USING num_replicas=10;
 SET override_multi_region_zone_config = false
 ----
-sql.multiregion.zone_configuration.override.user  1
+sql.multiregion.zone_configuration.override.user
 
 # Note that this case illustrates that once the session variable is set, we'll
 # count all instances where a zone configuration is modified, even if that
 # modification didn't strictly require overriding.
-feature-counters
+feature-usage
 SET override_multi_region_zone_config = true;
 ALTER TABLE t9 CONFIGURE ZONE USING gc.ttlseconds=10;
 SET override_multi_region_zone_config = false
 ----
-sql.multiregion.zone_configuration.override.user  1
+sql.multiregion.zone_configuration.override.user
 
-feature-counters
+feature-usage
 ALTER TABLE t9 CONFIGURE ZONE USING gc.ttlseconds=5
 ----
 
-feature-counters
+feature-usage
 SET override_multi_region_zone_config = true;
 ALTER TABLE t9 SET LOCALITY GLOBAL;
 SET override_multi_region_zone_config = false
 ----
-sql.multiregion.zone_configuration.override.system.table  1
+sql.multiregion.zone_configuration.override.system.table
 
 # Ensure that no counters are set in the case where we're not overriding
-feature-counters
+feature-usage
 ALTER TABLE t9 SET LOCALITY REGIONAL BY TABLE IN PRIMARY REGION;
 ----
 
 # Note that this case illustrates that once the session variable is set, we'll
 # count all instances where a table's zone configuration is modified, even if
 # that modification didn't strictly require overriding.
-feature-counters
+feature-usage
 SET override_multi_region_zone_config = true;
 ALTER TABLE t9 SET LOCALITY GLOBAL;
 SET override_multi_region_zone_config = false
 ----
-sql.multiregion.zone_configuration.override.system.table  1
+sql.multiregion.zone_configuration.override.system.table
 
-feature-counters
+feature-usage
 SET override_multi_region_zone_config = true;
 ALTER DATABASE d CONFIGURE ZONE USING num_replicas=10;
 SET override_multi_region_zone_config = false
 ----
-sql.multiregion.zone_configuration.override.user  1
+sql.multiregion.zone_configuration.override.user
 
-feature-counters
+feature-usage
 ALTER DATABASE d CONFIGURE ZONE USING gc.ttlseconds=5;
 ----
 
-feature-counters
+feature-usage
 SET override_multi_region_zone_config = true;
 ALTER DATABASE d ADD REGION "us-east-1";
 SET override_multi_region_zone_config = false
 ----
-sql.multiregion.zone_configuration.override.system.database  1
+sql.multiregion.zone_configuration.override.system.database

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -1034,6 +1034,57 @@ func SynthesizeRegionConfig(
 	return regionConfig, nil
 }
 
+// blockDiscardOfZoneConfigForMultiRegionObject determines if discarding the
+// zone configuration of a multi-region table, index or partition should be
+// blocked. We only block the discard if the multi-region abstractions have
+// created the zone configuration. Note that this function relies on internal
+// knowledge of which table locality patterns write zone configurations. We do
+// things this way to avoid having to read the zone configurations directly and
+// do a more explicit comparison (with a generated zone configuration). If, down
+// the road, the rules around writing zone configurations change, the tests in
+// multi_region_zone_configs will fail and this function will need updating.
+func blockDiscardOfZoneConfigForMultiRegionObject(
+	zs tree.ZoneSpecifier, tblDesc catalog.TableDescriptor,
+) (bool, error) {
+	isIndex := zs.TableOrIndex.Index != ""
+	isPartition := zs.Partition != ""
+
+	if isPartition {
+		// Multi-region abstractions only set partition-level zone configs for
+		// REGIONAL BY ROW tables.
+		if tblDesc.IsLocalityRegionalByRow() {
+			return true, nil
+		}
+	} else if isIndex {
+		// Multi-region will never set a zone config on an index, so no need to
+		// error if the user wants to drop the index zone config.
+		return false, nil
+	} else {
+		// It's a table zone config that the user is trying to discard. This
+		// should only be present on GLOBAL and REGIONAL BY TABLE tables in a
+		// specified region.
+		if tblDesc.IsLocalityGlobal() {
+			return true, nil
+		} else if tblDesc.IsLocalityRegionalByTable() {
+			if tblDesc.GetLocalityConfig().GetRegionalByTable().Region != nil &&
+				tree.Name(*tblDesc.GetLocalityConfig().GetRegionalByTable().Region) !=
+					tree.PrimaryRegionNotSpecifiedName {
+				return true, nil
+			}
+		} else if tblDesc.IsLocalityRegionalByRow() {
+			// For REGIONAL BY ROW tables, no need to error if we're setting a
+			// table level zone config.
+			return false, nil
+		} else {
+			return false, errors.AssertionFailedf(
+				"unknown table locality: %v",
+				tblDesc.GetLocalityConfig(),
+			)
+		}
+	}
+	return false, nil
+}
+
 // CheckZoneConfigChangePermittedForMultiRegion checks if a zone config
 // change is permitted for a multi-region database, table, index or partition.
 // The change is permitted iff it is not modifying a protected multi-region
@@ -1055,8 +1106,12 @@ func (p *planner) CheckZoneConfigChangePermittedForMultiRegion(
 		return nil
 	}
 
+	var err error
+	var tblDesc catalog.TableDescriptor
+	isDB := false
 	// Check if what we're altering is a multi-region entity.
 	if zs.Database != "" {
+		isDB = true
 		_, dbDesc, err := p.Descriptors().GetImmutableDatabaseByName(
 			ctx,
 			p.txn,
@@ -1074,11 +1129,11 @@ func (p *planner) CheckZoneConfigChangePermittedForMultiRegion(
 		// We're dealing with a table, index, or partition zone configuration
 		// change.  Get the table descriptor so we can determine if this is a
 		// multi-region table/index/partition.
-		table, err := p.resolveTableForZone(ctx, &zs)
+		tblDesc, err = p.resolveTableForZone(ctx, &zs)
 		if err != nil {
 			return err
 		}
-		if table == nil || table.GetLocalityConfig() == nil {
+		if tblDesc == nil || tblDesc.GetLocalityConfig() == nil {
 			// Not a multi-region table, we're done here.
 			return nil
 		}
@@ -1090,13 +1145,27 @@ func (p *planner) CheckZoneConfigChangePermittedForMultiRegion(
 	// the zone configuration being discarded was created by the multi-region
 	// abstractions.
 	if options == nil {
-		// User is trying to update a zone config value that's protected for
-		// multi-region databases. Return the constructed error.
-		err := errors.WithDetail(errors.Newf(
-			"attempting to discard the zone configuration of a multi-region entity"),
-			"discarding a multi-region zone configuration may result in sub-optimal performance or behavior",
-		)
-		return errors.WithHint(err, hint)
+		needToError := false
+		// Determine if this zone config that we're trying to discard is
+		// supposed to be there.
+		if isDB {
+			needToError = true
+		} else {
+			needToError, err = blockDiscardOfZoneConfigForMultiRegionObject(zs, tblDesc)
+			if err != nil {
+				return err
+			}
+		}
+
+		if needToError {
+			// User is trying to update a zone config value that's protected for
+			// multi-region databases. Return the constructed error.
+			err := errors.WithDetail(errors.Newf(
+				"attempting to discard the zone configuration of a multi-region entity"),
+				"discarding a multi-region zone configuration may result in sub-optimal performance or behavior",
+			)
+			return errors.WithHint(err, hint)
+		}
 	}
 
 	// This is clearly an n^2 operation, but since there are only a single


### PR DESCRIPTION
Backport 1/1 commits from #64991.

/cc @cockroachdb/release

---

In cases where transactions retry, the feature-counters tests in
TestTelemetry could report incorrect usage counts. Changing all tests to
use feature-usage instead of feature-counters.

Release note: None

Resolves #64863 
