### PR TITLE
release-21.1: colexecutils: make closure of nil spilling queue a no-op

### DIFF
--- a/pkg/sql/colexec/colexecutils/spilling_queue.go
+++ b/pkg/sql/colexec/colexecutils/spilling_queue.go
@@ -513,7 +513,7 @@ func (q *SpillingQueue) MemoryUsage() int64 {
 
 // Close closes the spilling queue.
 func (q *SpillingQueue) Close(ctx context.Context) error {
-	if q.closed {
+	if q == nil || q.closed {
 		return nil
 	}
 	if q.diskQueue != nil {


### PR DESCRIPTION
Backport 1/2 commits from #65819.

/cc @cockroachdb/release

---

**colexecutils: make closure of nil spilling queue a no-op**

In some edge cases (shown by the follow-up commit) we might attempt to
close a nil spilling queue. Previously, this would lead to a NPE
(converted to an internal error). Now we make such operation a no-op.

Informs: #65763.

Release note: None (it is extremely unlikely that someone would run into
this bug)
