### PR TITLE
backupccl: avoid panic if not collecting prior IDs

### DIFF
--- a/pkg/ccl/backupccl/targets.go
+++ b/pkg/ccl/backupccl/targets.go
@@ -206,7 +206,7 @@ func getAllDescChanges(
 				// Note that the modification time of descriptors on disk is usually 0.
 				// See the comment on MaybeSetDescriptorModificationTime... for more.
 				t, _, _, _ := descpb.FromDescriptorWithMVCCTimestamp(r.Desc, rev.Timestamp)
-				if t != nil && t.ReplacementOf.ID != descpb.InvalidID {
+				if priorIDs != nil && t != nil && t.ReplacementOf.ID != descpb.InvalidID {
 					priorIDs[t.ID] = t.ReplacementOf.ID
 				}
 			}


### PR DESCRIPTION
We pass priorIDs nil on some paths, when we do not need them.
However that can cause a panic.

Note: we could rip out priorIDs entirely because ReplacementOf
has not been set since <20.2, but that is left for a future change.

Release note (bug fix): fix a crash when performing a cluster BACKUP with revision history of a cluster upgraded from 20.1 to 20.2 to 21.1 which contains tables that were truncated by 20.1.