### PR TITLE
release-20.2: kvserver: fix deadlock in Store.removeInitializedReplicaRaftMuLocked

### DIFF
--- a/pkg/kv/kvserver/scanner.go
+++ b/pkg/kv/kvserver/scanner.go
@@ -121,10 +121,9 @@ func (rs *replicaScanner) AddQueues(queues ...replicaQueue) {
 }
 
 // Start spins up the scanning loop.
-func (rs *replicaScanner) Start(stopper *stop.Stopper) {
-	rs.stopper = stopper
+func (rs *replicaScanner) Start() {
 	for _, queue := range rs.queues {
-		queue.Start(stopper)
+		queue.Start(rs.stopper)
 	}
 	rs.scanLoop()
 }

--- a/pkg/kv/kvserver/scanner.go
+++ b/pkg/kv/kvserver/scanner.go
@@ -62,7 +62,8 @@ type replicaSet interface {
 // prioritized replica queues.
 type replicaScanner struct {
 	log.AmbientContext
-	clock *hlc.Clock
+	clock   *hlc.Clock
+	stopper *stop.Stopper
 
 	targetInterval time.Duration  // Target duration interval for scan loop
 	minIdleTime    time.Duration  // Min idle time for scan loop
@@ -104,7 +105,7 @@ func newReplicaScanner(
 		minIdleTime:    minIdleTime,
 		maxIdleTime:    maxIdleTime,
 		replicas:       replicas,
-		removed:        make(chan *Replica, 10),
+		removed:        make(chan *Replica),
 		setDisabledCh:  make(chan struct{}, 1),
 	}
 	if targetInterval == 0 {
@@ -121,10 +122,11 @@ func (rs *replicaScanner) AddQueues(queues ...replicaQueue) {
 
 // Start spins up the scanning loop.
 func (rs *replicaScanner) Start(stopper *stop.Stopper) {
+	rs.stopper = stopper
 	for _, queue := range rs.queues {
 		queue.Start(stopper)
 	}
-	rs.scanLoop(stopper)
+	rs.scanLoop()
 }
 
 // scanCount returns the number of times the scanner has cycled through
@@ -176,7 +178,10 @@ func (rs *replicaScanner) avgScan() time.Duration {
 // have placed it in. This method should be called by the Store
 // when a replica is removed (e.g. rebalanced or merged).
 func (rs *replicaScanner) RemoveReplica(repl *Replica) {
-	rs.removed <- repl
+	select {
+	case rs.removed <- repl:
+	case <-rs.stopper.ShouldStop():
+	}
 }
 
 // paceInterval returns a duration between iterations to allow us to pace
@@ -205,9 +210,7 @@ func (rs *replicaScanner) paceInterval(start, now time.Time) time.Duration {
 // if repl is not nil. The method returns true when the scanner needs
 // to be stopped. The method also removes a replica from queues when it
 // is signaled via the removed channel.
-func (rs *replicaScanner) waitAndProcess(
-	ctx context.Context, stopper *stop.Stopper, start time.Time, repl *Replica,
-) bool {
+func (rs *replicaScanner) waitAndProcess(ctx context.Context, start time.Time, repl *Replica) bool {
 	waitInterval := rs.paceInterval(start, timeutil.Now())
 	rs.waitTimer.Reset(waitInterval)
 	if log.V(6) {
@@ -235,7 +238,7 @@ func (rs *replicaScanner) waitAndProcess(
 		case repl := <-rs.removed:
 			rs.removeReplica(repl)
 
-		case <-stopper.ShouldStop():
+		case <-rs.stopper.ShouldStop():
 			return true
 		}
 	}
@@ -257,9 +260,9 @@ func (rs *replicaScanner) removeReplica(repl *Replica) {
 // scanLoop loops endlessly, scanning through replicas available via
 // the replica set, or until the scanner is stopped. The iteration
 // is paced to complete a full scan in approximately the scan interval.
-func (rs *replicaScanner) scanLoop(stopper *stop.Stopper) {
+func (rs *replicaScanner) scanLoop() {
 	ctx := rs.AnnotateCtx(context.Background())
-	stopper.RunWorker(ctx, func(ctx context.Context) {
+	rs.stopper.RunWorker(ctx, func(ctx context.Context) {
 		start := timeutil.Now()
 
 		// waitTimer is reset in each call to waitAndProcess.
@@ -267,7 +270,7 @@ func (rs *replicaScanner) scanLoop(stopper *stop.Stopper) {
 
 		for {
 			if rs.GetDisabled() {
-				if done := rs.waitEnabled(stopper); done {
+				if done := rs.waitEnabled(); done {
 					return
 				}
 				continue
@@ -276,12 +279,12 @@ func (rs *replicaScanner) scanLoop(stopper *stop.Stopper) {
 			count := 0
 			rs.replicas.Visit(func(repl *Replica) bool {
 				count++
-				shouldStop = rs.waitAndProcess(ctx, stopper, start, repl)
+				shouldStop = rs.waitAndProcess(ctx, start, repl)
 				return !shouldStop
 			})
 			if count == 0 {
 				// No replicas processed, just wait.
-				shouldStop = rs.waitAndProcess(ctx, stopper, start, nil)
+				shouldStop = rs.waitAndProcess(ctx, start, nil)
 			}
 
 			// waitAndProcess returns true when the system is stopping. Note that this
@@ -309,7 +312,7 @@ func (rs *replicaScanner) scanLoop(stopper *stop.Stopper) {
 
 // waitEnabled loops, removing replicas from the scanner's queues,
 // until scanning is enabled or the stopper signals shutdown,
-func (rs *replicaScanner) waitEnabled(stopper *stop.Stopper) bool {
+func (rs *replicaScanner) waitEnabled() bool {
 	rs.mu.Lock()
 	rs.mu.waitEnabledCount++
 	rs.mu.Unlock()
@@ -324,7 +327,7 @@ func (rs *replicaScanner) waitEnabled(stopper *stop.Stopper) bool {
 		case repl := <-rs.removed:
 			rs.removeReplica(repl)
 
-		case <-stopper.ShouldStop():
+		case <-rs.stopper.ShouldStop():
 			return true
 		}
 	}

--- a/pkg/kv/kvserver/scanner_test.go
+++ b/pkg/kv/kvserver/scanner_test.go
@@ -203,10 +203,10 @@ func TestScannerAddToQueues(t *testing.T) {
 	clock := hlc.NewClock(mc.UnixNano, time.Nanosecond)
 	s := newReplicaScanner(makeAmbCtx(), clock, 1*time.Millisecond, 0, 0, ranges)
 	s.AddQueues(q1, q2)
-	stopper := stop.NewStopper()
+	s.stopper = stop.NewStopper()
 
 	// Start scanner and verify that all ranges are added to both queues.
-	s.Start(stopper)
+	s.Start()
 	testutils.SucceedsSoon(t, func() error {
 		if q1.count() != count || q2.count() != count {
 			return errors.Errorf("q1 or q2 count != %d; got %d, %d", count, q1.count(), q2.count())
@@ -230,7 +230,7 @@ func TestScannerAddToQueues(t *testing.T) {
 	})
 
 	// Stop scanner and verify both queues are stopped.
-	stopper.Stop(context.Background())
+	s.stopper.Stop(context.Background())
 	if !q1.isDone() || !q2.isDone() {
 		t.Errorf("expected all queues to stop; got %t, %t", q1.isDone(), q2.isDone())
 	}
@@ -256,10 +256,10 @@ func TestScannerTiming(t *testing.T) {
 			clock := hlc.NewClock(mc.UnixNano, time.Nanosecond)
 			s := newReplicaScanner(makeAmbCtx(), clock, duration, 0, 0, ranges)
 			s.AddQueues(q)
-			stopper := stop.NewStopper()
-			s.Start(stopper)
+			s.stopper = stop.NewStopper()
+			s.Start()
 			time.Sleep(runTime)
-			stopper.Stop(context.Background())
+			s.stopper.Stop(context.Background())
 
 			avg := s.avgScan()
 			log.Infof(context.Background(), "%d: average scan: %s", i, avg)
@@ -340,9 +340,9 @@ func TestScannerDisabled(t *testing.T) {
 	clock := hlc.NewClock(mc.UnixNano, time.Nanosecond)
 	s := newReplicaScanner(makeAmbCtx(), clock, 1*time.Millisecond, 0, 0, ranges)
 	s.AddQueues(q)
-	stopper := stop.NewStopper()
-	defer stopper.Stop(context.Background())
-	s.Start(stopper)
+	s.stopper = stop.NewStopper()
+	defer s.stopper.Stop(context.Background())
+	s.Start()
 
 	// Verify queue gets all ranges.
 	testutils.SucceedsSoon(t, func() error {
@@ -405,9 +405,9 @@ func TestScannerEmptyRangeSet(t *testing.T) {
 	clock := hlc.NewClock(mc.UnixNano, time.Nanosecond)
 	s := newReplicaScanner(makeAmbCtx(), clock, time.Hour, 0, 0, ranges)
 	s.AddQueues(q)
-	stopper := stop.NewStopper()
-	defer stopper.Stop(context.Background())
-	s.Start(stopper)
+	s.stopper = stop.NewStopper()
+	defer s.stopper.Stop(context.Background())
+	s.Start()
 	time.Sleep(time.Millisecond) // give it some time to (not) busy loop
 	if count := s.scanCount(); count > 1 {
 		t.Errorf("expected at most one loop, but got %d", count)

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1427,6 +1427,12 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 	// depends on the scanner not having added its own log tag.
 	if s.scanner != nil {
 		s.scanner.AmbientContext.AddLogTag("s", s.StoreID())
+
+		// We have to set the stopper here to avoid races, since scanner.Start() is
+		// called async and the stopper is not available when the scanner is
+		// created. This is a hack, the scanner/queue construction should be
+		// refactored.
+		s.scanner.stopper = s.stopper
 	}
 
 	// If the nodeID is 0, it has not be assigned yet.
@@ -1594,7 +1600,7 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 		s.stopper.RunWorker(ctx, func(context.Context) {
 			select {
 			case <-s.cfg.Gossip.Connected:
-				s.scanner.Start(s.stopper)
+				s.scanner.Start()
 			case <-s.stopper.ShouldStop():
 				return
 			}


### PR DESCRIPTION
Backport 1/1 commits from #65781.
Backport 1/1 commits from #67006.

We should let this bake on master for a little bit, in case removing the channel buffer causes any trouble.

/cc @cockroachdb/release @cockroachdb/kv

---

When `Store.removeInitializedReplicaRaftMuLocked()` is finishing up
replica removal, it calls `replicaScanner.RemoveReplica()` to remove it
from the queue, which happens via a buffered channel. However, this call
(and thus the channel send) was done while still holding `Store.mu`,
which could deadlock if the channel buffer filled up and the
`replicaScanner` also needed to grab `Store.mu`.

Since there is no need for `Store.mu` to be held when calling
`replicaScanner.RemoveReplica()`, this patch unlocks it first. It also
removes the `replicaScanner.removed` channel buffer, to avoid hiding
these sorts of deadlocks in the first place.

Release note (bug fix): Fixed a deadlock that could occur when many
replicas were rapidly queued for removal.