### PR TITLE
build: add `dev-inf` as a code owner of the `Makefile`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,6 +21,8 @@
 
 /docs/RFCS/                  @cockroachdb/rfc-prs
 
+/Makefile                    @cockroachdb/dev-inf
+
 /pkg/sql/opt/                @cockroachdb/sql-opt-prs
 /pkg/sql/stats/              @cockroachdb/sql-opt-prs
 


### PR DESCRIPTION
This will help prevent un-bazelfied steps being added to the build.

Release note: None