### PR TITLE
release-20.2: kvcoord: prevent concurrent EndTxn requests

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_heartbeater.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_heartbeater.go
@@ -16,11 +16,20 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	opentracing "github.com/opentracing/opentracing-go"
 )
+
+// abortTxnAsyncTimeout is the context timeout for abortTxnAsyncLocked()
+// rollbacks. If the intent resolver has spare async task capacity, this timeout
+// only needs to be long enough for the EndTxn request to make it through Raft,
+// but if the cleanup task is synchronous (to backpressure clients) then cleanup
+// will be abandoned when the timeout expires. We generally want to clean up if
+// possible, but not at any cost, so we set it high at 1 minute.
+const abortTxnAsyncTimeout = time.Minute
 
 // txnHeartbeater is a txnInterceptor in charge of a transaction's heartbeat
 // loop. Transaction coordinators heartbeat their transaction record
@@ -104,7 +113,35 @@ type txnHeartbeater struct {
 		// future requests sent though it (which indicates that the heartbeat
 		// loop did not race with an EndTxn request).
 		finalObservedStatus roachpb.TransactionStatus
+
+		// ifReqs tracks the number of in-flight requests. This is expected to
+		// be either 0 or 1, but we let the txnLockGatekeeper enforce that.
+		//
+		// This is used to make sure we don't send EndTxn(commit=false) from
+		// abortTxnAsyncLocked() concurrently with another in-flight request.
+		// The TxnCoordSender assumes synchronous operation; in particular,
+		// the txnPipeliner must update its lock spans with pending responses
+		// before attaching the final lock spans to the EndTxn request.
+		ifReqs uint8
+
+		// abortTxnAsyncPending, if true, signals that an abortTxnAsyncLocked()
+		// call is waiting for in-flight requests to complete. Once the last
+		// request returns (setting ifReqs=0), it calls abortTxnAsyncLocked().
+		abortTxnAsyncPending bool
+
+		// abortTxnAsyncResultC is non-nil when an abortTxnAsyncLocked()
+		// rollback is in-flight. If a client rollback arrives concurrently, it
+		// will wait for the result on this channel, collapsing the requests to
+		// prevent concurrent rollbacks. Only EndTxn(commit=false) requests can
+		// arrive during rollback, the TxnCoordSender blocks any others due to
+		// finalObservedStatus.
+		abortTxnAsyncResultC chan abortTxnAsyncResult
 	}
+}
+
+type abortTxnAsyncResult struct {
+	br   *roachpb.BatchResponse
+	pErr *roachpb.Error
 }
 
 // init initializes the txnHeartbeater. This method exists instead of a
@@ -165,10 +202,46 @@ func (h *txnHeartbeater) SendLocked(
 	if hasET {
 		et := etArg.(*roachpb.EndTxnRequest)
 		et.TxnHeartbeating = h.mu.loopStarted
+
+		if !et.Commit {
+			// If an abortTxnAsyncLocked() rollback is in flight, we'll wait for
+			// its result here to avoid sending a concurrent rollback.
+			// Otherwise, txnLockGatekeeper would error since it does not allow
+			// concurrent requests (to enforce a synchronous client protocol).
+			if resultC := h.mu.abortTxnAsyncResultC; resultC != nil {
+				// We have to unlock the mutex while waiting, to allow the
+				// txnLockGatekeeper to acquire the mutex when receiving the
+				// async abort response. Once we receive our copy of the
+				// response, we re-acquire the lock to return it to the client.
+				h.mu.Unlock()
+				defer h.mu.Lock()
+				select {
+				case res := <-resultC:
+					return res.br, res.pErr
+				case <-ctx.Done():
+					return nil, roachpb.NewError(ctx.Err())
+				}
+			}
+		}
 	}
 
-	// Forward the batch through the wrapped lockedSender.
-	return h.wrapped.SendLocked(ctx, ba)
+	// Forward the batch through the wrapped lockedSender, recording the
+	// in-flight request to coordinate with abortTxnAsyncLocked(). Recall that
+	// the mutex is unlocked for the duration of the SendLocked() call.
+	h.mu.ifReqs++
+	br, pErr := h.wrapped.SendLocked(ctx, ba)
+	h.mu.ifReqs--
+
+	// If an abortTxnAsyncLocked() call is waiting for this in-flight
+	// request to complete, call it. At this point, finalObservedStatus has
+	// already been set, so we don't have to worry about additional incoming
+	// requests (except rollbacks) -- the TxnCoordSender will block them.
+	if h.mu.abortTxnAsyncPending && h.mu.ifReqs == 0 {
+		h.abortTxnAsyncLocked(ctx)
+		h.mu.abortTxnAsyncPending = false
+	}
+
+	return br, pErr
 }
 
 // setWrapped is part of the txnInterceptor interface.
@@ -321,7 +394,7 @@ func (h *txnHeartbeater) heartbeat(ctx context.Context) bool {
 
 	var respTxn *roachpb.Transaction
 	if pErr != nil {
-		log.VEventf(ctx, 2, "heartbeat failed: %s", pErr)
+		log.VEventf(ctx, 2, "heartbeat failed for %s: %s", h.mu.txn, pErr)
 
 		// We need to be prepared here to handle the case of a
 		// TransactionAbortedError with no transaction proto in it.
@@ -337,6 +410,7 @@ func (h *txnHeartbeater) heartbeat(ctx context.Context) bool {
 			// its commit or an ambiguous one and we have nothing to offer that
 			// provides more clarity. We do however prevent it from running more
 			// requests in case it isn't aware that the transaction is over.
+			log.VEventf(ctx, 1, "Heartbeat detected aborted txn, cleaning up for %s", h.mu.txn)
 			h.abortTxnAsyncLocked(ctx)
 			h.mu.finalObservedStatus = roachpb.ABORTED
 			return false
@@ -356,6 +430,7 @@ func (h *txnHeartbeater) heartbeat(ctx context.Context) bool {
 		case roachpb.ABORTED:
 			// Roll back the transaction record to clean up intents and
 			// then shut down the heartbeat loop.
+			log.VEventf(ctx, 1, "Heartbeat detected aborted txn, cleaning up for %s", h.mu.txn)
 			h.abortTxnAsyncLocked(ctx)
 		}
 		h.mu.finalObservedStatus = respTxn.Status
@@ -364,15 +439,19 @@ func (h *txnHeartbeater) heartbeat(ctx context.Context) bool {
 	return true
 }
 
-// abortTxnAsyncLocked send an EndTxn(commmit=false) asynchronously.
+// abortTxnAsyncLocked sends an EndTxn(commmit=false) asynchronously.
 // The purpose of the async cleanup is to resolve transaction intents as soon
 // as possible when a transaction coordinator observes an ABORTED transaction.
 func (h *txnHeartbeater) abortTxnAsyncLocked(ctx context.Context) {
-	log.VEventf(ctx, 1, "Heartbeat detected aborted txn. Cleaning up.")
 
-	// NB: We use context.Background() here because we don't want a canceled
-	// context to interrupt the aborting.
-	ctx = h.AnnotateCtx(context.Background())
+	// If a request is in flight, we must wait for it to complete first such
+	// that txnPipeliner can record its lock spans and attach them to the EndTxn
+	// request we'll send.
+	if h.mu.ifReqs > 0 {
+		h.mu.abortTxnAsyncPending = true
+		log.VEventf(ctx, 2, "async abort waiting for in-flight request for txn %s", h.mu.txn)
+		return
+	}
 
 	// Construct a batch with an EndTxn request.
 	txn := h.mu.txn.Clone()
@@ -386,17 +465,62 @@ func (h *txnHeartbeater) abortTxnAsyncLocked(ctx context.Context) {
 		TxnHeartbeating: true,
 	})
 
+	const taskName = "txnHeartbeater: aborting txn"
 	log.VEventf(ctx, 2, "async abort for txn: %s", txn)
-	if err := h.stopper.RunAsyncTask(
-		ctx, "txnHeartbeater: aborting txn", func(ctx context.Context) {
-			// Send the abort request through the interceptor stack. This is
-			// important because we need the txnPipeliner to append lock spans
-			// to the EndTxn request.
-			h.mu.Lock()
-			defer h.mu.Unlock()
-			_, pErr := h.wrapped.SendLocked(ctx, ba)
-			if pErr != nil {
-				log.VErrEventf(ctx, 1, "async abort failed for %s: %s ", txn, pErr)
+	if err := h.stopper.RunAsyncTask(h.AnnotateCtx(context.Background()), taskName,
+		func(ctx context.Context) {
+			if err := contextutil.RunWithTimeout(ctx, taskName, abortTxnAsyncTimeout,
+				func(ctx context.Context) error {
+					h.mu.Lock()
+					defer h.mu.Unlock()
+
+					// If we find an abortTxnAsyncResultC, that means an async
+					// rollback request is already in flight, so there's no
+					// point in us running another. This can happen because the
+					// TxnCoordSender also calls abortTxnAsyncLocked()
+					// independently of the heartbeat loop.
+					if h.mu.abortTxnAsyncResultC != nil {
+						log.VEventf(ctx, 2,
+							"skipping async abort due to concurrent async abort for %s", txn)
+						return nil
+					}
+
+					// TxnCoordSender allows EndTxn(commit=false) through even
+					// after we set finalObservedStatus, and that request can
+					// race with us for the mutex. Thus, if we find an in-flight
+					// request here, after checking ifReqs=0 before being spawned,
+					// we deduce that it must have been a rollback and there's no
+					// point in sending another rollback.
+					if h.mu.ifReqs > 0 {
+						log.VEventf(ctx, 2,
+							"skipping async abort due to client rollback for %s", txn)
+						return nil
+					}
+
+					// Set up a result channel to signal to an incoming client
+					// rollback that an async rollback is already in progress,
+					// and pass it the result. The buffer allows storing the
+					// result even when no client rollback arrives. Recall that
+					// the SendLocked() call below releases the mutex while
+					// running, allowing concurrent incoming requests.
+					h.mu.abortTxnAsyncResultC = make(chan abortTxnAsyncResult, 1)
+
+					// Send the abort request through the interceptor stack. This is
+					// important because we need the txnPipeliner to append lock spans
+					// to the EndTxn request.
+					br, pErr := h.wrapped.SendLocked(ctx, ba)
+					if pErr != nil {
+						log.VErrEventf(ctx, 1, "async abort failed for %s: %s ", txn, pErr)
+					}
+
+					// Pass the result to a waiting client rollback, if any, and
+					// remove the channel since we're no longer in flight.
+					h.mu.abortTxnAsyncResultC <- abortTxnAsyncResult{br: br, pErr: pErr}
+					h.mu.abortTxnAsyncResultC = nil
+					return nil
+				},
+			); err != nil {
+				log.VEventf(ctx, 1, "async abort failed for %s: %s", txn, err)
 			}
 		},
 	); err != nil {

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_heartbeater_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_heartbeater_test.go
@@ -415,3 +415,200 @@ func TestTxnHeartbeaterAsyncAbort(t *testing.T) {
 		require.Equal(t, roachpb.ABORTED, th.mu.finalObservedStatus)
 	})
 }
+
+// TestTxnHeartbeaterAsyncAbortWaitsForInFlight tests that the txnHeartbeater
+// will wait for an in-flight request to complete before sending the
+// EndTxn rollback request.
+func TestTxnHeartbeaterAsyncAbortWaitsForInFlight(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	txn := makeTxnProto()
+	th, mockSender, mockGatekeeper := makeMockTxnHeartbeater(&txn)
+	defer th.stopper.Stop(ctx)
+
+	// Mock the heartbeat request, which should wait for an in-flight put via
+	// putReady then return an aborted txn and signal hbAborted.
+	putReady := make(chan struct{})
+	hbAborted := make(chan struct{})
+	mockGatekeeper.MockSend(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+		<-putReady
+		defer close(hbAborted)
+
+		require.Len(t, ba.Requests, 1)
+		require.IsType(t, &roachpb.HeartbeatTxnRequest{}, ba.Requests[0].GetInner())
+
+		br := ba.CreateReply()
+		br.Txn = ba.Txn
+		br.Txn.Status = roachpb.ABORTED
+		return br, nil
+	})
+
+	putResume := make(chan struct{})
+	rollbackSent := make(chan struct{})
+	mockSender.ChainMockSend(
+		// Mock a Put, which signals putReady and then waits for putResume
+		// before returning a response.
+		func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+			th.mu.Unlock() // without txnLockGatekeeper, we must unlock manually
+			defer th.mu.Lock()
+			close(putReady)
+			require.Len(t, ba.Requests, 1)
+			require.IsType(t, &roachpb.PutRequest{}, ba.Requests[0].GetInner())
+
+			<-putResume
+
+			br := ba.CreateReply()
+			br.Txn = ba.Txn
+			return br, nil
+		},
+		// Mock an EndTxn, which signals rollbackSent.
+		func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+			defer close(rollbackSent)
+			require.Len(t, ba.Requests, 1)
+			require.IsType(t, &roachpb.EndTxnRequest{}, ba.Requests[0].GetInner())
+
+			etReq := ba.Requests[0].GetInner().(*roachpb.EndTxnRequest)
+			require.Equal(t, &txn, ba.Txn)
+			require.False(t, etReq.Commit)
+			require.True(t, etReq.Poison)
+			require.True(t, etReq.TxnHeartbeating)
+
+			br := ba.CreateReply()
+			br.Txn = ba.Txn
+			br.Txn.Status = roachpb.ABORTED
+			return br, nil
+		},
+	)
+
+	// Spawn a goroutine to send the Put.
+	require.NoError(t, th.stopper.RunAsyncTask(ctx, "put", func(ctx context.Context) {
+		var ba roachpb.BatchRequest
+		ba.Header = roachpb.Header{Txn: txn.Clone()}
+		ba.Add(&roachpb.PutRequest{RequestHeader: roachpb.RequestHeader{Key: roachpb.Key("a")}})
+
+		th.mu.Lock() // without TxnCoordSender, we must lock manually
+		defer th.mu.Unlock()
+		br, pErr := th.SendLocked(ctx, ba)
+		require.Nil(t, pErr)
+		require.NotNil(t, br)
+	}))
+
+	<-putReady  // wait for put
+	<-hbAborted // wait for heartbeat abort
+	select {
+	case <-rollbackSent: // we don't expect a rollback yet
+		require.Fail(t, "received unexpected EndTxn")
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(putResume) // make put return
+	<-rollbackSent   // we now expect the rollback
+
+	// The heartbeat loop should eventually close.
+	waitForHeartbeatLoopToStop(t, &th)
+}
+
+// TestTxnHeartbeaterAsyncAbortCollapsesRequests tests that when the
+// txnHeartbeater has an async abort rollback in flight, any client
+// rollbacks will wait for the async rollback to complete and return
+// its result.
+func TestTxnHeartbeaterAsyncAbortCollapsesRequests(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	txn := makeTxnProto()
+	th, mockSender, mockGatekeeper := makeMockTxnHeartbeater(&txn)
+	defer th.stopper.Stop(ctx)
+
+	// Mock the heartbeat request, which simply aborts and signals hbAborted.
+	hbAborted := make(chan struct{})
+	mockGatekeeper.MockSend(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+		defer close(hbAborted)
+
+		require.Len(t, ba.Requests, 1)
+		require.IsType(t, &roachpb.HeartbeatTxnRequest{}, ba.Requests[0].GetInner())
+
+		br := ba.CreateReply()
+		br.Txn = ba.Txn
+		br.Txn.Status = roachpb.ABORTED
+		return br, nil
+	})
+
+	// Mock an EndTxn response, which signals rollbackReady and blocks
+	// until rollbackUnblock is closed.
+	rollbackReady := make(chan struct{})
+	rollbackUnblock := make(chan struct{})
+	mockSender.ChainMockSend(
+		// The first Put request is expected and should just return.
+		func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+			require.Len(t, ba.Requests, 1)
+			require.IsType(t, &roachpb.PutRequest{}, ba.Requests[0].GetInner())
+
+			br := ba.CreateReply()
+			br.Txn = ba.Txn
+			return br, nil
+		},
+		// The first EndTxn request from the heartbeater is expected, so block and return.
+		func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+			th.mu.Unlock() // manually unlock for concurrency, no txnLockGatekeeper
+			defer th.mu.Lock()
+			close(rollbackReady)
+			require.Len(t, ba.Requests, 1)
+			require.IsType(t, &roachpb.EndTxnRequest{}, ba.Requests[0].GetInner())
+
+			<-rollbackUnblock
+
+			etReq := ba.Requests[0].GetInner().(*roachpb.EndTxnRequest)
+			require.Equal(t, &txn, ba.Txn)
+			require.False(t, etReq.Commit)
+			require.True(t, etReq.Poison)
+			require.True(t, etReq.TxnHeartbeating)
+
+			br := ba.CreateReply()
+			br.Txn = ba.Txn
+			br.Txn.Status = roachpb.ABORTED
+			return br, nil
+		},
+		// The second EndTxn request from the client is unexpected, so
+		// return an error response.
+		func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+			return nil, roachpb.NewError(errors.Errorf("unexpected request: %v", ba))
+		},
+	)
+
+	// Kick off the heartbeat loop.
+	var ba roachpb.BatchRequest
+	ba.Header = roachpb.Header{Txn: txn.Clone()}
+	ba.Add(&roachpb.PutRequest{RequestHeader: roachpb.RequestHeader{Key: roachpb.Key("a")}})
+
+	th.mu.Lock() // manually lock, there's no TxnCoordSender
+	br, pErr := th.SendLocked(ctx, ba)
+	th.mu.Unlock()
+	require.Nil(t, pErr)
+	require.NotNil(t, br)
+
+	// Wait for the heartbeater to abort and send an EndTxn.
+	<-hbAborted
+	<-rollbackReady
+
+	// Send a rollback from the client. This should be collapsed together
+	// with the heartbeat abort, and block until it returns. We spawn
+	// a goroutine to unblock the rollback.
+	require.NoError(t, th.stopper.RunAsyncTask(ctx, "put", func(ctx context.Context) {
+		time.Sleep(100 * time.Millisecond)
+		close(rollbackUnblock)
+	}))
+
+	ba = roachpb.BatchRequest{}
+	ba.Header = roachpb.Header{Txn: txn.Clone()}
+	ba.Add(&roachpb.EndTxnRequest{Commit: false})
+
+	th.mu.Lock() // manually lock, there's no TxnCoordSender
+	br, pErr = th.SendLocked(ctx, ba)
+	th.mu.Unlock()
+	require.Nil(t, pErr)
+	require.NotNil(t, br)
+
+	// The heartbeat loop should eventually close.
+	waitForHeartbeatLoopToStop(t, &th)
+}

--- a/pkg/kv/kvserver/intent_resolver_integration_test.go
+++ b/pkg/kv/kvserver/intent_resolver_integration_test.go
@@ -11,9 +11,11 @@
 package kvserver
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"math/rand"
+	"sync"
 	"testing"
 	"time"
 
@@ -183,18 +185,114 @@ func TestContendedIntentWithDependencyCycle(t *testing.T) {
 func TestReliableIntentCleanup(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.WithIssue(t, 65447, "fixing the flake uncovered additional bugs in #65458")
+	skip.UnderShort(t) // takes 294s
 	skip.UnderRace(t, "timing-sensitive test")
-	skip.UnderStress(t, "multi-node test")
+	skip.UnderStress(t, "memory-hungry test")
 
-	testutils.RunTrueAndFalse(t, "ForceSyncIntentResolution", func(t *testing.T, sync bool) {
+	prefix := roachpb.Key([]byte("key\x00"))
+
+	testutils.RunTrueAndFalse(t, "ForceSyncIntentResolution", func(t *testing.T, forceSync bool) {
+		// abortHeartbeats is used to abort txn heartbeats, returning
+		// TransactionAbortedError. Key is txn anchor key, value is a chan
+		// struct{} that will be closed when the next heartbeat aborts.
+		var abortHeartbeats sync.Map
+
+		abortHeartbeat := func(t *testing.T, txnKey roachpb.Key) <-chan struct{} {
+			abortedC := make(chan struct{})
+			abortHeartbeats.Store(string(txnKey), abortedC)
+			return abortedC
+		}
+
+		// blockPuts is used to block Put responses for a given txn. The key is
+		// a txn anchor key, and the value is a chan chan<- struct{} that, when
+		// the Put is ready, will be used to send an unblock channel. The
+		// unblock channel can be closed to unblock the Put.
+		var blockPuts sync.Map
+
+		blockPut := func(t *testing.T, txnKey roachpb.Key) <-chan chan<- struct{} {
+			readyC := make(chan chan<- struct{})
+			blockPuts.Store(string(txnKey), readyC)
+			return readyC
+		}
+
+		// blockPutEvals is used to block Put command evaluation in Raft for a
+		// given txn. The key is a txn anchor key, and the value is a chan
+		// chan<- struct{} that, when the Put is ready, will be used to send an
+		// unblock channel. The unblock channel can be closed to unblock the
+		// Put.
+		var blockPutEvals sync.Map
+
+		blockPutEval := func(t *testing.T, txnKey roachpb.Key) <-chan chan<- struct{} {
+			readyC := make(chan chan<- struct{})
+			blockPutEvals.Store(string(txnKey), readyC)
+			return readyC
+		}
+
+		requestFilter := func(ctx context.Context, ba roachpb.BatchRequest) *roachpb.Error {
+			// If we receive a heartbeat from a txn in abortHeartbeats,
+			// close the aborted channel and return an error response.
+			if _, ok := ba.GetArg(roachpb.HeartbeatTxn); ok && ba.Txn != nil {
+				if abortedC, ok := abortHeartbeats.Load(string(ba.Txn.Key)); ok {
+					abortHeartbeats.Delete(string(ba.Txn.Key))
+					close(abortedC.(chan struct{}))
+					return roachpb.NewError(roachpb.NewTransactionAbortedError(
+						roachpb.ABORT_REASON_NEW_LEASE_PREVENTS_TXN))
+				}
+			}
+			return nil
+		}
+
+		evalFilter := func(args kvserverbase.FilterArgs) *roachpb.Error {
+			// If we receive a Put request from a txn in blockPutEvals, signal
+			// the caller that the Put is ready to block by passing it an
+			// unblock channel, and wait for it to close.
+			if put, ok := args.Req.(*roachpb.PutRequest); ok && args.Hdr.Txn != nil {
+				if bytes.HasPrefix(put.Key, prefix) {
+					if ch, ok := blockPutEvals.Load(string(args.Hdr.Txn.Key)); ok {
+						blockPutEvals.Delete(string(args.Hdr.Txn.Key))
+						readyC := ch.(chan chan<- struct{})
+						unblockC := make(chan struct{})
+						readyC <- unblockC
+						close(readyC)
+						<-unblockC
+					}
+				}
+			}
+			return nil
+		}
+
+		responseFilter := func(ctx context.Context, ba roachpb.BatchRequest, br *roachpb.BatchResponse) *roachpb.Error {
+			// If we receive a Put request from a txn in blockPuts, signal
+			// the caller that the Put is ready to block by passing it an
+			// unblock channel, and wait for it to close.
+			if arg, ok := ba.GetArg(roachpb.Put); ok && ba.Txn != nil {
+				if bytes.HasPrefix(arg.(*roachpb.PutRequest).Key, prefix) {
+					if ch, ok := blockPuts.Load(string(ba.Txn.Key)); ok {
+						blockPuts.Delete(string(ba.Txn.Key))
+						readyC := ch.(chan chan<- struct{})
+						unblockC := make(chan struct{})
+						readyC <- unblockC
+						close(readyC)
+						<-unblockC
+					}
+				}
+			}
+			return nil
+		}
+
+		// Set up three-node cluster, which will be shared by subtests.
 		ctx := context.Background()
 		clusterArgs := base.TestClusterArgs{
 			ServerArgs: base.TestServerArgs{
 				Knobs: base.TestingKnobs{
 					Store: &StoreTestingKnobs{
 						IntentResolverKnobs: kvserverbase.IntentResolverTestingKnobs{
-							ForceSyncIntentResolution: sync,
+							ForceSyncIntentResolution: forceSync,
+						},
+						TestingRequestFilter:  requestFilter,
+						TestingResponseFilter: responseFilter,
+						EvalKnobs: kvserverbase.BatchEvalTestingKnobs{
+							TestingPostEvalFilter: evalFilter,
 						},
 					},
 				},
@@ -207,12 +305,9 @@ func TestReliableIntentCleanup(t *testing.T) {
 		db := srv.DB()
 		store, err := srv.GetStores().(*Stores).GetStore(srv.GetFirstStoreID())
 		require.NoError(t, err)
-		engine := store.Engine()
-		clock := srv.Clock()
 
-		// Set up a key prefix, and split off 16 ranges by the first hex digit (4
-		// bits) following the prefix: key\x00\x00 key\x00\x10 key\x00\x20 ...
-		prefix := roachpb.Key([]byte("key\x00"))
+		// Split off 16 ranges by the first hex digit (4 bits) after prefix:
+		// key\x00\x00 key\x00\x10 key\x00\x20 key\x00\x30 ...
 		for i := 0; i < 16; i++ {
 			require.NoError(t, db.AdminSplit(ctx, append(prefix, byte(i<<4)), hlc.MaxTimestamp))
 		}
@@ -241,12 +336,13 @@ func TestReliableIntentCleanup(t *testing.T) {
 			t.Helper()
 			var result storage.MVCCScanResult
 			if !assert.Eventually(t, func() bool {
-				result, err = storage.MVCCScan(ctx, engine, prefix, prefix.PrefixEnd(),
+				result, err = storage.MVCCScan(ctx, store.Engine(), prefix, prefix.PrefixEnd(),
 					hlc.MaxTimestamp, storage.MVCCScanOptions{Inconsistent: true})
 				require.NoError(t, err)
 				return len(result.Intents) == 0
-			}, 30*time.Second, 200*time.Millisecond, "intent cleanup timed out") {
-				require.Fail(t, "found stale intents", "%v intents", len(result.Intents))
+			}, time.Minute, 200*time.Millisecond, "intent cleanup timed out") {
+				require.Fail(t, "found stale intents", "count=%v first=%v last=%v",
+					len(result.Intents), result.Intents[0], result.Intents[len(result.Intents)-1])
 			}
 		}
 
@@ -257,12 +353,12 @@ func TestReliableIntentCleanup(t *testing.T) {
 			var txnEntry roachpb.Transaction
 			if !assert.Eventually(t, func() bool {
 				key := keys.TransactionKey(txnKey, txnID)
-				ok, err := storage.MVCCGetProto(ctx, engine, key, hlc.MaxTimestamp, &txnEntry,
+				ok, err := storage.MVCCGetProto(ctx, store.Engine(), key, hlc.MaxTimestamp, &txnEntry,
 					storage.MVCCGetOptions{})
 				require.NoError(t, err)
 				return !ok
-			}, 10*time.Second, 100*time.Millisecond, "txn entry cleanup timed out") {
-				require.Fail(t, "found stale txn entry", "%v", txnEntry)
+			}, 10*time.Second, 100*time.Millisecond, "txn record cleanup timed out") {
+				require.Fail(t, "found stale txn record", "%v", txnEntry)
 			}
 		}
 
@@ -280,76 +376,184 @@ func TestReliableIntentCleanup(t *testing.T) {
 			genKeySeen = map[string]bool{} // reset random key generator
 		}
 
-		// testTxn runs an intent cleanup test using a transaction.
+		// testTxnSpec specifies a testTxn test.
 		type testTxnSpec struct {
 			numKeys     int    // number of keys per transaction
 			singleRange bool   // if true, put intents in a single range at key\x00\x00
-			finalize    string // commit, rollback, cancel, abort (via push)
+			finalize    string // commit, rollback, cancel, cancelAsync
+			abort       string // heartbeat, push
 		}
-		testTxn := func(t *testing.T, spec testTxnSpec) {
-			t.Helper()
-			defer removeKeys(t)
-			const batchSize = 10000
+
+		// testTxnExecute executes a transaction for testTxn. It is a separate function
+		// so that any transaction errors can be retried as appropriate.
+		testTxnExecute := func(t *testing.T, ctx context.Context, spec testTxnSpec, txn *kv.Txn, txnKey roachpb.Key) error {
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			if spec.finalize == "cancelAsync" && spec.abort != "" {
+				// This would require coordinating the abort, cancel, and put
+				// goroutines. Doesn't seem worth the complexity.
+				require.Fail(t, "Can't combine finalize=cancelAsync and abort")
+			}
+
+			// If requested, spin off txn aborter goroutines, returning errors
+			// (if any) via abortErrC.
+			//
+			// We execute aborts while a Put request is in-flight, by blocking
+			// the put response until the abort completes, as a regression test:
+			// https://github.com/cockroachdb/cockroach/issues/65458
+			abortErrC := make(chan error, 1)
+			switch spec.abort {
+			case "heartbeat":
+				// Waits for a heartbeat and returns an abort error. Blocks put
+				// meanwhile, returning when heartbeat was aborted.
+				abortedC := abortHeartbeat(t, txnKey)
+				readyC := blockPut(t, txnKey)
+				require.NoError(t, tc.Stopper().RunAsyncTask(ctx, "unblock", func(ctx context.Context) {
+					<-abortedC
+					unblockC := <-readyC
+					time.Sleep(100 * time.Millisecond)
+					close(unblockC)
+				}))
+				close(abortErrC) // can't error
+
+			case "push":
+				// Push txn with a high-priority write once put is blocked.
+				readyC := blockPut(t, txnKey)
+				require.NoError(t, tc.Stopper().RunAsyncTask(ctx, "push", func(ctx context.Context) {
+					unblockC := <-readyC
+					defer close(unblockC)
+					defer close(abortErrC)
+
+					now := srv.Clock().Now()
+					pusherProto := roachpb.MakeTransaction(
+						"pusher",
+						nil, // baseKey
+						roachpb.MaxUserPriority,
+						now,
+						srv.Clock().MaxOffset().Nanoseconds(),
+					)
+					pusher := kv.NewTxnFromProto(ctx, db, srv.NodeID(), now, kv.RootTxn, &pusherProto)
+					if err := pusher.Put(ctx, txnKey, []byte("pushit")); err != nil {
+						abortErrC <- err
+						return
+					}
+					if err := pusher.Rollback(ctx); err != nil {
+						abortErrC <- err
+						return
+					}
+					time.Sleep(100 * time.Millisecond)
+				}))
+
+			case "":
+				close(abortErrC)
+
+			default:
+				require.Fail(t, "invalid abort type", "abort=%v", spec.abort)
+			}
+
+			// If requested, cancel the context while the put is being
+			// evaluated in Raft.
+			if spec.finalize == "cancelAsync" {
+				readyC := blockPutEval(t, txnKey)
+				require.NoError(t, tc.Stopper().RunAsyncTask(ctx, "cancel", func(ctx context.Context) {
+					unblockC := <-readyC
+					defer close(unblockC)
+					cancel()
+					time.Sleep(100 * time.Millisecond)
+				}))
+			}
 
 			// Write numKeys KV pairs in batches of batchSize as a single txn.
-			var txnKey roachpb.Key
-			txn := db.NewTxn(ctx, "test")
-			batch := txn.NewBatch()
-			for i := 0; i < spec.numKeys; i++ {
-				key := genKey(spec.singleRange)
-				batch.Put(key, []byte("value"))
-				if (i > 0 && i%batchSize == 0) || i == spec.numKeys-1 {
-					require.NoError(t, txn.Run(ctx, batch))
-					batch = txn.NewBatch()
+			const batchSize = 10000
+			for b := 0; b*batchSize < spec.numKeys; b++ {
+				batch := txn.NewBatch()
+				for i := 0; i < batchSize && b*batchSize+i < spec.numKeys; i++ {
+					key := genKey(spec.singleRange)
+					if b == 0 && i == 0 {
+						copy(key, txnKey) // txnKey must be the first written key
+					}
+					batch.Put(key, []byte("value"))
 				}
-				if i == 0 {
-					txnKey = make([]byte, len(key))
-					copy(txnKey, key)
+				err := txn.Run(ctx, batch)
+				if ctx.Err() != nil {
+					// If context was canceled (see cancelAsync), we just bail
+					// out and ignore the error (as the client would).
+					break
+				} else if err != nil {
+					return err
 				}
+			}
+
+			// Make sure the abort didn't error.
+			if err := <-abortErrC; err != nil {
+				return err
 			}
 
 			// Finalize the txn according to the spec.
 			switch spec.finalize {
 			case "commit":
-				require.NoError(t, txn.Commit(ctx))
-
+				return txn.Commit(ctx)
 			case "rollback":
-				require.NoError(t, txn.Rollback(ctx))
-
-			case "cancel":
-				rollbackCtx, cancel := context.WithCancel(ctx)
+				return txn.Rollback(ctx)
+			case "cancel", "cancelAsync":
+				// Rollback with canceled context, as the SQL connection would.
 				cancel()
-				if err := txn.Rollback(rollbackCtx); !errors.Is(err, context.Canceled) {
-					require.NoError(t, err)
+				if err := txn.Rollback(ctx); err != nil && !errors.Is(err, context.Canceled) {
+					return err
 				}
-
-			case "abort":
-				now := clock.Now()
-				pusherProto := roachpb.MakeTransaction(
-					"pusher",
-					nil, // baseKey
-					roachpb.MaxUserPriority,
-					now,
-					clock.MaxOffset().Nanoseconds(),
-				)
-				pusher := kv.NewTxnFromProto(ctx, db, srv.NodeID(), now, kv.RootTxn, &pusherProto)
-				require.NoError(t, pusher.Put(ctx, txnKey, []byte("pushit")))
-
-				err := txn.Commit(ctx)
-				require.Error(t, err)
-				require.IsType(t, &roachpb.TransactionRetryWithProtoRefreshError{}, err)
-				// if is required by linter, even though we know it will always succeed.
-				if retryErr := (*roachpb.TransactionRetryWithProtoRefreshError)(nil); errors.As(err, &retryErr) {
-					require.True(t, retryErr.PrevTxnAborted())
-				}
-				require.NoError(t, pusher.Rollback(ctx))
-
 			default:
-				require.Fail(t, "invalid finalize value %q", spec.finalize)
+				require.Fail(t, "invalid finalize type", "finalize=%v", spec.finalize)
+			}
+			return nil
+		}
+
+		// testTxn runs an intent cleanup test using a transaction.
+		testTxn := func(t *testing.T, spec testTxnSpec) {
+			defer removeKeys(t)
+
+			// Execute the transaction and retry any transaction errors (unless
+			// the test expects an error). These errors can be caused by async
+			// processes such as lease transfers, range merges/splits, or
+			// stats jobs).
+			txns := map[uuid.UUID]roachpb.Key{}
+			txn := db.NewTxn(ctx, "test") // reuse *kv.Txn across retries, will be updated
+			for attempt := 1; ; attempt++ {
+				txnKey := genKey(spec.singleRange)
+				txns[txn.ID()] = txnKey // before testTxnExecute, id may change on errors
+
+				err := testTxnExecute(t, ctx, spec, txn, txnKey)
+				if err == nil {
+					break
+				} else if spec.abort != "" {
+					require.Error(t, err)
+					require.IsType(t, &roachpb.TransactionRetryWithProtoRefreshError{}, err, "err: %v", err)
+					// if is required by linter, even though we know it will always succeed.
+					if retryErr := (*roachpb.TransactionRetryWithProtoRefreshError)(nil); errors.As(err, &retryErr) {
+						require.True(t, retryErr.PrevTxnAborted())
+					}
+					break
+				} else if retryErr := (*roachpb.TransactionRetryWithProtoRefreshError)(nil); !errors.As(err, &retryErr) {
+					require.NoError(t, err)
+				} else if attempt >= 3 {
+					require.Fail(t, "too many txn retries", "attempt %v errored: %v", attempt, err)
+				} else {
+					t.Logf("retrying unexpected txn error: %v", err)
+					require.True(t, txn.IsRetryableErrMeantForTxn(*retryErr))
+				}
 			}
 
 			assertIntentCleanup(t)
-			assertTxnCleanup(t, txnKey, txn.ID())
+			for txnID, txnKey := range txns {
+				// TODO(erikgrinaker): this occasionally fails in CI with
+				// finalize=cancelAsync, but the reason hasn't been found. We're
+				// mostly concerned with intent cleanup, so skip the txn record
+				// assertion in these cases.
+				if spec.finalize == "cancelAsync" {
+					break
+				}
+				assertTxnCleanup(t, txnKey, txnID)
+			}
 		}
 
 		// testNonTxn runs an intent cleanup test without an explicit transaction.
@@ -358,7 +562,6 @@ func TestReliableIntentCleanup(t *testing.T) {
 			singleRange bool // if true, put intents in a single range at key\x00\x00
 		}
 		testNonTxn := func(t *testing.T, spec testNonTxnSpec) {
-			t.Helper()
 			defer removeKeys(t)
 
 			batch := &kv.Batch{}
@@ -370,24 +573,41 @@ func TestReliableIntentCleanup(t *testing.T) {
 			assertIntentCleanup(t)
 		}
 
+		// The actual tests are run here, using all combinations of parameters.
 		testutils.RunValues(t, "numKeys", []interface{}{1, 100, 100000}, func(t *testing.T, numKeys interface{}) {
 			testutils.RunTrueAndFalse(t, "singleRange", func(t *testing.T, singleRange bool) {
 				testutils.RunTrueAndFalse(t, "txn", func(t *testing.T, txn bool) {
-					if txn {
-						finalize := []interface{}{"commit", "rollback", "cancel", "abort"}
-						testutils.RunValues(t, "finalize", finalize, func(t *testing.T, finalize interface{}) {
+					if !txn {
+						testNonTxn(t, testNonTxnSpec{
+							numKeys:     numKeys.(int),
+							singleRange: singleRange,
+						})
+						return
+					}
+					finalize := []interface{}{"commit", "rollback", "cancel", "cancelAsync"}
+					testutils.RunValues(t, "finalize", finalize, func(t *testing.T, finalize interface{}) {
+						if finalize == "cancelAsync" {
+							// cancelAsync can't run together with abort.
 							testTxn(t, testTxnSpec{
 								numKeys:     numKeys.(int),
 								singleRange: singleRange,
 								finalize:    finalize.(string),
 							})
+							return
+						}
+						abort := []interface{}{"no", "push", "heartbeat"}
+						testutils.RunValues(t, "abort", abort, func(t *testing.T, abort interface{}) {
+							if abort.(string) == "no" {
+								abort = "" // "no" just makes the test output better
+							}
+							testTxn(t, testTxnSpec{
+								numKeys:     numKeys.(int),
+								singleRange: singleRange,
+								finalize:    finalize.(string),
+								abort:       abort.(string),
+							})
 						})
-					} else {
-						testNonTxn(t, testNonTxnSpec{
-							numKeys:     numKeys.(int),
-							singleRange: singleRange,
-						})
-					}
+					})
 				})
 			})
 		})


### PR DESCRIPTION
Backport 1/1 commits from #65592.

This should bake on master for a while, in case there are unexpected async requests being sent.

/cc @cockroachdb/release @cockroachdb/kv

---

`TxnCoordSender` generally operates synchronously (i.e. the client waits
for the previous response before sending the next request). However, the
`txnHeartbeater` sends asynchronous `EndTxn(commit=false)` rollbacks
when it discovers an aborted transaction record. Unfortunately, some code
assumes synchrony, which caused race conditions with txn rollbacks.

In particular, the `txnPipeliner` attaches lock spans and in-flight
writes to the `EndTxn` request for e.g. intent cleanup, but it only
records this information when it receives responses. Thus, if an
`EndTxn(commit=false)` is sent concurrently with a write request, the
lock spans and in-flight writes of that write request will not get
attached to the `EndTxn` request and the intents will not get cleaned
up.

This patch makes the `txnHeartbeater` wait for any in-flight requests to
complete before sending asynchronous rollbacks, and collapses incoming
client rollbacks with in-flight async rollbacks.

Resolves #65458.
Resolves #65587.
Resolves #65447.

Release note (bug fix): Fixed a race condition where transaction cleanup
would fail to take into account ongoing writes and clean up their
intents.
