### PR TITLE
release-21.1: colbuilder: optimize casting in some cases

### DIFF
--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -1347,9 +1347,9 @@ func NewColOperator(
 				post := &execinfrapb.PostProcessSpec{}
 				post.RenderExprs = make([]execinfrapb.Expression, castedIdx+1)
 				for j := 0; j < castedIdx; j++ {
-					post.RenderExprs[j].Expr = fmt.Sprintf("@%d", j+1)
+					post.RenderExprs[j].LocalExpr = tree.NewTypedOrdinalReference(j, r.ColumnTypes[j])
 				}
-				post.RenderExprs[castedIdx].Expr = fmt.Sprintf("@%d::%s", i+1, expected.SQLStandardName())
+				post.RenderExprs[castedIdx].LocalExpr = tree.NewTypedCastExpr(tree.NewTypedOrdinalReference(i, r.ColumnTypes[i]), expected)
 				result.Op = input
 				if err = result.wrapPostProcessSpec(ctx, flowCtx, args, post, resultTypes, factory, err); err != nil {
 					return r, err


### PR DESCRIPTION
Backport 1/1 commits from #65857.

/cc @cockroachdb/release

---

If the operator chain produces type schema that doesn't exactly match
the expected type schema, we plan a stage of cast operators. However, if
a particular cast isn't supported natively, we fallback to the row
engine by wrapping a noop processor with such a post-processing spec
that passes through all input columns and appends a result of the
desired cast.

Previously, that post-processing spec was populated very inefficiently -
by using the serialized representation of the relevant expressions.
This is a poor choice because we have to deserialize it right away. This
commit switches to using the typed expressions directly which should
speed things up, especially in the case of point queries.

Release note: None