### PR TITLE
bazel: add targets to generate cluster setting/functions documentation

### DIFF
--- a/docs/generated/settings/BUILD.bazel
+++ b/docs/generated/settings/BUILD.bazel
@@ -1,0 +1,13 @@
+genrule(
+    name = "settings",
+    outs = ["settings.html"],
+    cmd = "$(location //pkg/cmd/cockroach-short) gen settings-list --format=html > $@",
+    exec_tools = ["//pkg/cmd/cockroach-short"],
+)
+
+genrule(
+    name = "settings_for_tenants",
+    outs = ["settings-for-tenants.txt"],
+    cmd = "$(location //pkg/cmd/cockroach-short) gen settings-list --without-system-only > $@",
+    exec_tools = ["//pkg/cmd/cockroach-short"],
+)

--- a/docs/generated/sql/BUILD.bazel
+++ b/docs/generated/sql/BUILD.bazel
@@ -1,0 +1,17 @@
+genrule(
+    name = "sql",
+    outs = [
+        "aggregates.md",
+        "functions.md",
+        "operators.md",
+        "window_functions.md",
+    ],
+    cmd = """
+$(location //pkg/cmd/docgen) functions . --quiet
+mv aggregates.md $(location aggregates.md)
+mv functions.md $(location functions.md)
+mv operators.md $(location operators.md)
+mv window_functions.md $(location window_functions.md)
+""",
+    exec_tools = ["//pkg/cmd/docgen"],
+)


### PR DESCRIPTION
I validated that these work and have a clean `diff` with what's in tree.

Closes #65808.
Closes #65811.

Release note: None