### PR TITLE
storage: expose pebble.IteratorStats through {MVCC,Engine}Iterator

### DIFF
--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -379,6 +379,11 @@ func (i *EngineIterator) GetRawIter() *pebble.Iterator {
 	return i.i.GetRawIter()
 }
 
+// Stats is part of the storage.EngineIterator interface.
+func (i *EngineIterator) Stats() storage.IteratorStats {
+	return i.i.Stats()
+}
+
 type spanSetReader struct {
 	r     storage.Reader
 	spans *SpanSet

--- a/pkg/storage/intent_interleaving_iter.go
+++ b/pkg/storage/intent_interleaving_iter.go
@@ -959,8 +959,17 @@ func (i *intentInterleavingIter) SetUpperBound(key roachpb.Key) {
 }
 
 func (i *intentInterleavingIter) Stats() IteratorStats {
-	// Only used in tests.
-	return i.iter.Stats()
+	stats := i.iter.Stats()
+	intentStats := i.intentIter.Stats()
+	stats.InternalDeleteSkippedCount += intentStats.InternalDeleteSkippedCount
+	stats.TimeBoundNumSSTs += intentStats.TimeBoundNumSSTs
+	for i := pebble.IteratorStatsKind(0); i < pebble.NumStatsKind; i++ {
+		stats.Stats.ForwardSeekCount[i] += intentStats.Stats.ForwardSeekCount[i]
+		stats.Stats.ReverseSeekCount[i] += intentStats.Stats.ReverseSeekCount[i]
+		stats.Stats.ForwardStepCount[i] += intentStats.Stats.ForwardStepCount[i]
+		stats.Stats.ReverseStepCount[i] += intentStats.Stats.ReverseStepCount[i]
+	}
+	return stats
 }
 
 func (i *intentInterleavingIter) SupportsPrev() bool {

--- a/pkg/storage/intent_interleaving_iter_test.go
+++ b/pkg/storage/intent_interleaving_iter_test.go
@@ -185,7 +185,7 @@ func checkAndOutputIter(iter MVCCIterator, b *strings.Builder) {
 // - iter: for iterating, is defined as
 //   iter [lower=<lower>] [upper=<upper>] [prefix=<true|false>]
 //   followed by newline separated sequence of operations:
-//     next, prev, seek-lt, seek-ge, set-upper, next-key
+//     next, prev, seek-lt, seek-ge, set-upper, next-key, stats
 //
 // Keys are interpreted as:
 // - starting with L is interpreted as a local-range key.
@@ -363,6 +363,9 @@ func TestIntentInterleavingIter(t *testing.T) {
 						k := scanRoachKey(t, d, "k")
 						iter.SetUpperBound(k)
 						fmt.Fprintf(&b, "set-upper %s\n", string(makePrintableKey(MVCCKey{Key: k}).Key))
+					case "stats":
+						stats := iter.Stats()
+						fmt.Fprintf(&b, "stats: %s\n", stats.Stats.String())
 					default:
 						fmt.Fprintf(&b, "unknown command: %s\n", d.Cmd)
 					}

--- a/pkg/storage/pebble_iterator.go
+++ b/pkg/storage/pebble_iterator.go
@@ -245,6 +245,7 @@ func (p *pebbleIterator) Close() {
 	p.inuse = false
 
 	if p.reusable {
+		p.iter.ResetStats()
 		return
 	}
 
@@ -761,10 +762,11 @@ func (p *pebbleIterator) SetUpperBound(upperBound roachpb.Key) {
 	}
 }
 
-// Stats implements the MVCCIterator interface.
+// Stats implements the {MVCCIterator,EngineIterator} interfaces.
 func (p *pebbleIterator) Stats() IteratorStats {
 	return IteratorStats{
 		TimeBoundNumSSTs: p.timeBoundNumSSTables,
+		Stats:            p.iter.Stats(),
 	}
 }
 

--- a/pkg/storage/testdata/intent_interleaving_iter/basic
+++ b/pkg/storage/testdata/intent_interleaving_iter/basic
@@ -12,6 +12,15 @@ value k=d ts=25 v=d25
 ----
 
 # Exercise basic forward and reverse iteration.
+# Stats:
+# - When the intent iterator is not exhausted we incur steps for both
+#   underlying iterators. Similarly, seeks will happen on both
+#   iterators.
+# - The second stats call below (after some prev steps) shows a higher value
+#   of interface reverse steps compared to internal reverse steps. This is
+#   because the intent iterator is being called with PrevWithLimit ans is
+#   already at the separated intent "a", so does not have to step the internal
+#   iterator.
 iter lower=a upper=f
 seek-ge k=a
 next
@@ -21,6 +30,7 @@ next
 next
 next
 next
+stats
 prev
 prev
 prev
@@ -29,14 +39,17 @@ prev
 prev
 prev
 prev
+stats
 set-upper k=c
 seek-ge k=b
+stats
 next
 next
 prev
 prev
 prev
 seek-lt k=b
+stats
 next
 prev
 prev
@@ -52,6 +65,7 @@ next: output: value k=b ts=30.000000000,0 v=b30
 next: output: meta k=c
 next: output: value k=d ts=25.000000000,0 v=d25
 next: output: .
+stats: (interface (dir, seek, step): (fwd, 2, 7), (rev, 0, 0)), (internal (dir, seek, step): (fwd, 2, 7), (rev, 0, 0))
 prev: output: value k=d ts=25.000000000,0 v=d25
 prev: output: meta k=c
 prev: output: value k=b ts=30.000000000,0 v=b30
@@ -60,14 +74,17 @@ prev: output: value k=a ts=10.000000000,0 v=a10
 prev: output: value k=a ts=20.000000000,0 v=a20
 prev: output: meta k=a ts=20.000000000,0 txn=1
 prev: output: .
+stats: (interface (dir, seek, step): (fwd, 2, 7), (rev, 0, 13)), (internal (dir, seek, step): (fwd, 2, 7), (rev, 2, 7))
 set-upper c
 seek-ge "b"/0,0: output: meta k=b ts=30.000000000,0 txn=2
+stats: (interface (dir, seek, step): (fwd, 4, 7), (rev, 0, 13)), (internal (dir, seek, step): (fwd, 4, 7), (rev, 2, 7))
 next: output: value k=b ts=30.000000000,0 v=b30
 next: output: .
 prev: output: value k=b ts=30.000000000,0 v=b30
 prev: output: meta k=b ts=30.000000000,0 txn=2
 prev: output: value k=a ts=10.000000000,0 v=a10
 seek-lt "b"/0,0: output: value k=a ts=10.000000000,0 v=a10
+stats: (interface (dir, seek, step): (fwd, 4, 9), (rev, 2, 19)), (internal (dir, seek, step): (fwd, 4, 9), (rev, 6, 13))
 next: output: meta k=b ts=30.000000000,0 txn=2
 prev: output: value k=a ts=10.000000000,0 v=a10
 prev: output: value k=a ts=20.000000000,0 v=a20


### PR DESCRIPTION
These will potentially be aggregated before exposing in trace
statements, EXPLAIN ANALYZE etc.

Release note: None