### PR TITLE
opt: add rule to reduce a union with a zero-cardinality input

### DIFF
--- a/pkg/sql/opt/norm/rules/set.opt
+++ b/pkg/sql/opt/norm/rules/set.opt
@@ -32,3 +32,32 @@
     (ProjectColMapRight $colmap)
     (ProjectPassthroughRight $colmap)
 )
+
+# EliminateUnionLeft replaces a union with a right side having a cardinality of
+# zero, with a Distinct on just the left side operand.
+[EliminateUnionLeft, Normalize]
+(Union $left:* $right:* & (HasZeroRows $right) $colMap:*)
+=>
+(DistinctOn
+    $project:(Project
+        $left
+        (ProjectColMapLeft $colMap)
+        (ProjectPassthroughLeft $colMap)
+    )
+    []
+    (MakeGrouping (OutputCols $project) (EmptyOrdering))
+)
+
+# EliminateUnionRight mirrors EliminateUnionLeft.
+[EliminateUnionRight, Normalize]
+(Union $left:* & (HasZeroRows $left) $right:* $colMap:*)
+=>
+(DistinctOn
+    $project:(Project
+        $right
+        (ProjectColMapRight $colMap)
+        (ProjectPassthroughRight $colMap)
+    )
+    []
+    (MakeGrouping (OutputCols $project) (EmptyOrdering))
+)

--- a/pkg/sql/opt/norm/testdata/rules/set
+++ b/pkg/sql/opt/norm/testdata/rules/set
@@ -55,3 +55,53 @@ values
  ├── cardinality: [0 - 0]
  ├── key: ()
  └── fd: ()-->(13)
+
+# --------------------------------------------------
+# EliminateUnionLeft
+# --------------------------------------------------
+
+norm expect=EliminateUnionLeft
+SELECT k FROM
+  (SELECT k FROM b)
+  UNION
+  (SELECT k FROM b WHERE k IN ())
+----
+project
+ ├── columns: k:13!null
+ ├── key: (13)
+ ├── scan b
+ │    ├── columns: b.k:1!null
+ │    └── key: (1)
+ └── projections
+      └── b.k:1 [as=k:13, outer=(1)]
+
+# --------------------------------------------------
+# EliminateUnionRight
+# --------------------------------------------------
+
+norm expect=EliminateUnionRight
+SELECT k FROM
+  (SELECT k FROM b WHERE Null)
+  UNION
+  (SELECT k FROM b)
+----
+project
+ ├── columns: k:13!null
+ ├── key: (13)
+ ├── scan b
+ │    ├── columns: b.k:7!null
+ │    └── key: (7)
+ └── projections
+      └── b.k:7 [as=k:13, outer=(7)]
+
+norm
+SELECT k FROM
+  (SELECT k FROM b WHERE False)
+  UNION
+  (SELECT k FROM b WHERE i IN ())
+----
+values
+ ├── columns: k:13!null
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(13)


### PR DESCRIPTION
This patch adds two rules, `EliminateUnionLeft` and
`EliminateUnionRight`, that replace a `UNION` with a `DISTINCT`
on its left or right input respectively when the other input
has zero cardinality. The newly constructed `DISTINCT` groups
on all (left or right) input columns, but other rules may
reduce the grouping columns or eliminate the `DISTINCT` entirely.

Release note: None