### PR TITLE
sql: fix a bug which prevented self referencing NOT VALID foreign keys

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -1812,3 +1812,19 @@ CREATE TABLE duplicate_index_test (k INT PRIMARY KEY, v INT, INDEX idx (v));
 
 statement error pgcode 42P07 duplicate index name: \"idx\"
 ALTER TABLE duplicate_index_test ADD CONSTRAINT idx UNIQUE (v)
+
+# Regression test for a bug which occurred when adding a foreign key
+# constraint which is marked NOT VALID and is self-referencing.
+subtest self_reference_fk_not_valid
+
+statement ok
+DROP TABLE IF EXISTS t;
+CREATE TABLE t (i INT PRIMARY KEY, j INT);
+ALTER TABLE t ADD CONSTRAINT fk FOREIGN KEY (j) REFERENCES t(i) NOT VALID;
+
+# Demonstrate that the constraint is enforced.
+statement error pgcode 23503 insert on table "t" violates foreign key constraint "fk"
+INSERT INTO t VALUES (1, 0)
+
+statement ok
+DROP TABLE t;

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1124,8 +1124,10 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 						return err
 					}
 					backrefTable.InboundFKs = append(backrefTable.InboundFKs, constraint.ForeignKey())
-					if err := descsCol.WriteDescToBatch(ctx, kvTrace, backrefTable, b); err != nil {
-						return err
+					if backrefTable != scTable {
+						if err := descsCol.WriteDescToBatch(ctx, kvTrace, backrefTable, b); err != nil {
+							return err
+						}
 					}
 				}
 			}


### PR DESCRIPTION
This bug is due to both using the same object in descs.Txn (sort of) and the
fact the fact that MakeMutationComplete does not remove the mutation any
longer. I have a feeling, but have not checked, that we lost this back-
reference in older versions.

Release note (bug fix): Fixed a bug which prevented adding self-referencing
FOREIGN KEY constraints in the NOT VALID state.