### PR TITLE
colbuilder: improve logging of planning for traces

### DIFF
--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -174,9 +174,7 @@ func (f *vectorizedFlow) Setup(
 	if err != nil {
 		return ctx, nil, err
 	}
-	if log.V(1) {
-		log.Infof(ctx, "setting up vectorize flow %s", f.ID.Short())
-	}
+	log.VEvent(ctx, 2, "setting up vectorized flow")
 	recordingStats := false
 	if execinfra.ShouldCollectStats(ctx, &f.FlowCtx) {
 		recordingStats = true
@@ -216,16 +214,12 @@ func (f *vectorizedFlow) Setup(
 		// clean that up.
 		f.creator.cleanup(ctx)
 		f.creator.Release()
-		if log.V(1) {
-			log.Infof(ctx, "failed to vectorize: %s", err)
-		}
+		log.VEventf(ctx, 1, "failed to vectorize: %v", err)
 		return ctx, nil, err
 	}
 	f.testingInfo.numClosers = f.creator.numClosers
 	f.testingInfo.numClosed = &f.creator.numClosed
-	if log.V(1) {
-		log.Info(ctx, "vectorized flow setup succeeded")
-	}
+	log.VEventf(ctx, 2, "vectorized flow setup succeeded")
 	if !f.IsLocal() {
 		// For distributed flows set opChains to nil, per the contract of
 		// flowinfra.Flow.Setup.
@@ -848,9 +842,7 @@ func (s *vectorizedFlowCreator) setupInput(
 				// 0, it is not included in the displayed stats for EXPLAIN ANALYZE
 				// diagrams.
 				latency = 0
-				if log.V(1) {
-					log.Infof(ctx, "an error occurred during vectorized planning while getting latency: %v", err)
-				}
+				log.VEventf(ctx, 1, "an error occurred during vectorized planning while getting latency: %v", err)
 			}
 
 			inbox, err := s.remoteComponentCreator.newInbox(colmem.NewAllocator(ctx, s.newStreamingMemAccount(flowCtx), factory), input.ColumnTypes, inputStream.StreamID)


### PR DESCRIPTION
All our logging around the vectorized planning has been hidden behind
the verbosity levels since 5fd5e829506d2a70bf520e39e17d2088fff59b5b.
I believe that commit was short-sighted because at the cost of
observability (in traces) we improved the performance. This commit tries
to get the best of both options: have logging in place that makes it
into traces but also is such that expensive allocations don't need to
occur if the verbosity level is not high enough (if the tracing is off).

This commit audits the planning code in order to unify it a bit with the
goal of providing visibility of why row-execution things are wrapped
into the vectorized flows. This commit also removes some not very
helpful messages (like that a particular operator was created) - I
believe those were interesting maybe like 2 years ago, when the
vectorized engine was immature.

Release note: None