### PR TITLE
release-21.1: roachtest: deflake gossip/chaos

### DIFF
--- a/_bazel/bin
+++ b/_bazel/bin
@@ -1,0 +1,1 @@
+/private/var/tmp/_bazel_irfansharif/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin

--- a/_bazel/cockroach
+++ b/_bazel/cockroach
@@ -1,0 +1,1 @@
+/private/var/tmp/_bazel_irfansharif/99e666e4e674209ecdb66b46371278df/execroot/cockroach

--- a/_bazel/out
+++ b/_bazel/out
@@ -1,0 +1,1 @@
+/private/var/tmp/_bazel_irfansharif/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out

--- a/_bazel/testlogs
+++ b/_bazel/testlogs
@@ -1,0 +1,1 @@
+/private/var/tmp/_bazel_irfansharif/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/testlogs

--- a/pkg/cmd/roachtest/gossip.go
+++ b/pkg/cmd/roachtest/gossip.go
@@ -17,6 +17,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -37,7 +38,11 @@ func registerGossip(r *testRegistry) {
 		c.Start(ctx, t, c.All(), args)
 		waitForFullReplication(t, c.Conn(ctx, 1))
 
-		gossipNetwork := func(node int) string {
+		// TODO(irfansharif): We could also look at gossip_liveness to determine
+		// cluster membership as seen by each gossip module, and ensure each
+		// node's gossip excludes the dead node and includes all other live
+		// ones.
+		gossipNetworkAccordingTo := func(node int) (network string) {
 			const query = `
 SELECT string_agg(source_id::TEXT || ':' || target_id::TEXT, ',')
   FROM (SELECT * FROM crdb_internal.gossip_network ORDER BY source_id, target_id)
@@ -55,63 +60,91 @@ SELECT string_agg(source_id::TEXT || ':' || target_id::TEXT, ',')
 			return ""
 		}
 
-		var deadNode int
-		gossipOK := func(start time.Time) bool {
-			var expected string
-			var initialized bool
+		nodesInNetworkAccordingTo := func(node int) (nodes []int, network string) {
+			split := func(c rune) bool {
+				return !unicode.IsNumber(c)
+			}
+
+			uniqueNodes := make(map[int]struct{})
+			network = gossipNetworkAccordingTo(node)
+			for _, idStr := range strings.FieldsFunc(network, split) {
+				nodeID, err := strconv.Atoi(idStr)
+				if err != nil {
+					t.Fatal(err)
+				}
+				uniqueNodes[nodeID] = struct{}{}
+			}
+			for node := range uniqueNodes {
+				nodes = append(nodes, node)
+			}
+			sort.Ints(nodes)
+			return nodes, network
+		}
+
+		gossipOK := func(start time.Time, deadNode int) bool {
+			var expLiveNodes []int
+			var expGossipNetwork string
+
 			for i := 1; i <= c.spec.NodeCount; i++ {
 				if elapsed := timeutil.Since(start); elapsed >= 20*time.Second {
-					t.Fatalf("gossip did not stabilize in %.1fs", elapsed.Seconds())
+					t.Fatalf("(dead node %d) gossip did not stabilize in %.1fs", deadNode, elapsed.Seconds())
 				}
 
 				if i == deadNode {
 					continue
 				}
+
 				c.l.Printf("%d: checking gossip\n", i)
-				s := gossipNetwork(i)
-				if !initialized {
-					deadNodeStr := fmt.Sprint(deadNode)
-					split := func(c rune) bool {
-						return !unicode.IsNumber(c)
+				liveNodes, gossipNetwork := nodesInNetworkAccordingTo(i)
+				for _, id := range liveNodes {
+					if id == deadNode {
+						c.l.Printf("%d: gossip not ok (dead node %d present): %s (%.0fs)\n",
+							i, deadNode, gossipNetwork, timeutil.Since(start).Seconds())
+						return false
 					}
-					for _, id := range strings.FieldsFunc(s, split) {
-						if id == deadNodeStr {
-							c.l.Printf("%d: gossip not ok (dead node %d present): %s (%.0fs)\n",
-								i, deadNode, s, timeutil.Since(start).Seconds())
-							return false
-						}
-					}
-					initialized = true
-					expected = s
+				}
+
+				if len(expLiveNodes) == 0 {
+					expLiveNodes = liveNodes
+					expGossipNetwork = gossipNetwork
 					continue
 				}
-				if expected != s {
-					c.l.Printf("%d: gossip not ok: %s != %s (%.0fs)\n",
-						i, expected, s, timeutil.Since(start).Seconds())
+
+				if len(liveNodes) != len(expLiveNodes) {
+					c.l.Printf("%d: gossip not ok (mismatched size of network: %s); expected %d, got %d (%.0fs)\n",
+						i, gossipNetwork, len(expLiveNodes), len(liveNodes), timeutil.Since(start).Seconds())
 					return false
 				}
+
+				for i := range liveNodes {
+					if liveNodes[i] != expLiveNodes[i] {
+						c.l.Printf("%d: gossip not ok (mismatched view of live nodes); expected %s, got %s (%.0fs)\n",
+							i, gossipNetwork, expLiveNodes, liveNodes, timeutil.Since(start).Seconds())
+						return false
+					}
+				}
 			}
-			c.l.Printf("gossip ok: %s (%0.0fs)\n", expected, timeutil.Since(start).Seconds())
+			c.l.Printf("gossip ok: %s (size: %d) (%0.0fs)\n", expGossipNetwork, len(expLiveNodes), timeutil.Since(start).Seconds())
 			return true
 		}
 
-		waitForGossip := func() {
-			t.Status("waiting for gossip to stabilize")
+		waitForGossip := func(deadNode int) {
+			t.Status("waiting for gossip to exclude dead node")
 			start := timeutil.Now()
 			for {
-				if gossipOK(start) {
+				if gossipOK(start, deadNode) {
 					return
 				}
 				time.Sleep(time.Second)
 			}
 		}
 
-		waitForGossip()
+		waitForGossip(0)
 		nodes := c.All()
-		for j := 0; j < 100; j++ {
-			deadNode = nodes.randNode()[0]
+		for j := 0; j < 10; j++ {
+			deadNode := nodes.randNode()[0]
 			c.Stop(ctx, c.Node(deadNode))
-			waitForGossip()
+			waitForGossip(deadNode)
 			c.Start(ctx, t, c.Node(deadNode), args)
 		}
 	}

--- a/pkg/gossip/client.go
+++ b/pkg/gossip/client.go
@@ -121,7 +121,7 @@ func (c *client) startLocked(
 		}
 
 		// Start gossiping.
-		log.Infof(ctx, "started gossip client to %s", c.addr)
+		log.Infof(ctx, "started gossip client to n%d (%s)", c.peerID, c.addr)
 		if err := c.gossip(ctx, g, stream, stopper, &wg); err != nil {
 			if !grpcutil.IsClosedConnection(err) {
 				g.mu.RLock()
@@ -267,7 +267,7 @@ func (c *client) handleResponse(ctx context.Context, g *Gossip, reply *Response)
 				reply.AlternateAddr, reply.AlternateNodeID, err)
 		}
 		c.forwardAddr = reply.AlternateAddr
-		return errors.Errorf("received forward from n%d to %d (%s)",
+		return errors.Errorf("received forward from n%d to n%d (%s)",
 			reply.NodeID, reply.AlternateNodeID, reply.AlternateAddr)
 	}
 

--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -1396,7 +1396,7 @@ func (g *Gossip) manage() {
 							if log.V(1) {
 								log.Health.Infof(ctx, "closing least useful client %+v to tighten network graph", c)
 							}
-							log.Eventf(ctx, "culling %s", c.addr)
+							log.VEventf(ctx, 1, "culling n%d %s", c.peerID, c.addr)
 							c.close()
 
 							// After releasing the lock, block until the client disconnects.
@@ -1548,7 +1548,7 @@ func (g *Gossip) startClientLocked(addr net.Addr) {
 		g.clientsMu.breakers[addr.String()] = breaker
 	}
 	ctx := g.AnnotateCtx(context.TODO())
-	log.Eventf(ctx, "starting new client to %s", addr)
+	log.VEventf(ctx, 1, "starting new client to %s", addr)
 	c := newClient(g.server.AmbientContext, addr, g.serverMetrics)
 	g.clientsMu.clients = append(g.clientsMu.clients, c)
 	c.startLocked(g, g.disconnected, g.rpcContext, g.server.stopper, breaker)
@@ -1562,7 +1562,7 @@ func (g *Gossip) removeClientLocked(target *client) {
 	for i, candidate := range g.clientsMu.clients {
 		if candidate == target {
 			ctx := g.AnnotateCtx(context.TODO())
-			log.Eventf(ctx, "client %s disconnected", candidate.addr)
+			log.VEventf(ctx, 1, "client %s disconnected", candidate.addr)
 			g.clientsMu.clients = append(g.clientsMu.clients[:i], g.clientsMu.clients[i+1:]...)
 			delete(g.bootstrapping, candidate.addr.String())
 			g.outgoing.removeNode(candidate.peerID)


### PR DESCRIPTION
Backport 1/1 commits from #65817.

/cc @cockroachdb/release

---

Fixes #64292. Gossip, as written, periodic culls intra-node connections
to reduce the likelihood of stagnant links degrading the gossip
topology. This happens ever 60s on each node, where each node drops 1/3
connections.

This gossip/chaos test checked for two things:
1. the downed node was no longer part of the gossip network
2. the gossip network, as seen by each node, converged within 20s

With periodic culling, the network is seeing continual change, and it
makes (2) less likely to occur. When investigating #64292, we observed
that we were always able to achieve (1), but the periodic culling got
in the way of achieving (2). This PR updates this test to avoid trying
for (2) altogether.

Release note: None
Release justification: Non-production code change