### PR TITLE
release-21.1: sql: Fix TestTelemetry in cases where retries occur

### DIFF
--- a/pkg/ccl/telemetryccl/testdata/telemetry/multiregion
+++ b/pkg/ccl/telemetryccl/testdata/telemetry/multiregion
@@ -346,10 +346,10 @@ INSERT INTO t7 VALUES (1),(2),(3);
 EXPORT INTO CSV 'nodelocal://0/t7' FROM TABLE t7;
 ----
 
-feature-counters
+feature-usage
 IMPORT INTO t7 CSV DATA ('nodelocal://0/t7/export*.csv')
 ----
-sql.multiregion.import  1
+sql.multiregion.import
 
 # Test for locality optimized search counter.
 feature-allowlist
@@ -375,63 +375,63 @@ feature-allowlist
 sql.multiregion.zone_configuration.override.*
 ----
 
-feature-counters
+feature-usage
 SET override_multi_region_zone_config = true;
 ALTER TABLE t9 CONFIGURE ZONE USING num_replicas=10;
 SET override_multi_region_zone_config = false
 ----
-sql.multiregion.zone_configuration.override.user  1
+sql.multiregion.zone_configuration.override.user
 
 # Note that this case illustrates that once the session variable is set, we'll
 # count all instances where a zone configuration is modified, even if that
 # modification didn't strictly require overriding.
-feature-counters
+feature-usage
 SET override_multi_region_zone_config = true;
 ALTER TABLE t9 CONFIGURE ZONE USING gc.ttlseconds=10;
 SET override_multi_region_zone_config = false
 ----
-sql.multiregion.zone_configuration.override.user  1
+sql.multiregion.zone_configuration.override.user
 
-feature-counters
+feature-usage
 ALTER TABLE t9 CONFIGURE ZONE USING gc.ttlseconds=5
 ----
 
-feature-counters
+feature-usage
 SET override_multi_region_zone_config = true;
 ALTER TABLE t9 SET LOCALITY GLOBAL;
 SET override_multi_region_zone_config = false
 ----
-sql.multiregion.zone_configuration.override.system.table  1
+sql.multiregion.zone_configuration.override.system.table
 
 # Ensure that no counters are set in the case where we're not overriding
-feature-counters
+feature-usage
 ALTER TABLE t9 SET LOCALITY REGIONAL BY TABLE IN PRIMARY REGION;
 ----
 
 # Note that this case illustrates that once the session variable is set, we'll
 # count all instances where a table's zone configuration is modified, even if
 # that modification didn't strictly require overriding.
-feature-counters
+feature-usage
 SET override_multi_region_zone_config = true;
 ALTER TABLE t9 SET LOCALITY GLOBAL;
 SET override_multi_region_zone_config = false
 ----
-sql.multiregion.zone_configuration.override.system.table  1
+sql.multiregion.zone_configuration.override.system.table
 
-feature-counters
+feature-usage
 SET override_multi_region_zone_config = true;
 ALTER DATABASE d CONFIGURE ZONE USING num_replicas=10;
 SET override_multi_region_zone_config = false
 ----
-sql.multiregion.zone_configuration.override.user  1
+sql.multiregion.zone_configuration.override.user
 
-feature-counters
+feature-usage
 ALTER DATABASE d CONFIGURE ZONE USING gc.ttlseconds=5;
 ----
 
-feature-counters
+feature-usage
 SET override_multi_region_zone_config = true;
 ALTER DATABASE d ADD REGION "us-east-1";
 SET override_multi_region_zone_config = false
 ----
-sql.multiregion.zone_configuration.override.system.database  1
+sql.multiregion.zone_configuration.override.system.database


### PR DESCRIPTION
Backport 1/1 commits from #64991.

/cc @cockroachdb/release

---

In cases where transactions retry, the feature-counters tests in
TestTelemetry could report incorrect usage counts. Changing all tests to
use feature-usage instead of feature-counters.

Release note: None

Resolves #64863 
