### PR TITLE
kvnemesis: reduce frequency of splits and merges

### DIFF
--- a/pkg/kv/kvnemesis/generator.go
+++ b/pkg/kv/kvnemesis/generator.go
@@ -182,12 +182,12 @@ func newAllOperationsConfig() GeneratorConfig {
 			CommitBatchOps: clientOpConfig,
 		},
 		Split: SplitConfig{
-			SplitNew:   10,
+			SplitNew:   1,
 			SplitAgain: 1,
 		},
 		Merge: MergeConfig{
 			MergeNotSplit: 1,
-			MergeIsSplit:  10,
+			MergeIsSplit:  1,
 		},
 		ChangeReplicas: ChangeReplicasConfig{
 			AddReplica:        1,


### PR DESCRIPTION
These frequencies were accidentally left inflated by b025216.