### PR TITLE
release-21.1: add button to reset SQL stats

### DIFF
--- a/pkg/ui/cluster-ui/src/api/sqlStatsApi.ts
+++ b/pkg/ui/cluster-ui/src/api/sqlStatsApi.ts
@@ -1,0 +1,22 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+import { fetchData } from "src/api";
+
+const RESET_SQL_STATS_PATH = "/_status/resetsqlstats";
+
+export const resetSQLStats = (): Promise<cockroach.server.serverpb.ResetSQLStatsResponse> => {
+  return fetchData(
+    cockroach.server.serverpb.ResetSQLStatsResponse,
+    RESET_SQL_STATS_PATH,
+    cockroach.server.serverpb.ResetSQLStatsRequest,
+  );
+};

--- a/pkg/ui/cluster-ui/src/statementsPage/statementsPage.fixture.ts
+++ b/pkg/ui/cluster-ui/src/statementsPage/statementsPage.fixture.ts
@@ -511,6 +511,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
   dismissAlertMessage: noop,
   refreshStatementDiagnosticsRequests: noop,
   refreshStatements: noop,
+  resetSQLStats: noop,
   onActivateStatementDiagnostics: noop,
   onDiagnosticsModalOpen: noop,
   onSearchComplete: noop,

--- a/pkg/ui/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -57,6 +57,7 @@ const sortableTableCx = classNames.bind(sortableTableStyles);
 export interface StatementsPageDispatchProps {
   refreshStatements: () => void;
   refreshStatementDiagnosticsRequests: () => void;
+  resetSQLStats: () => void;
   dismissAlertMessage: () => void;
   onActivateStatementDiagnostics: (statement: string) => void;
   onDiagnosticsModalOpen?: (statement: string) => void;
@@ -296,6 +297,7 @@ export class StatementsPage extends React.Component<
       lastReset,
       onDiagnosticsReportDownload,
       onStatementClick,
+      resetSQLStats,
     } = this.props;
     const appAttrValue = getMatchParamByName(match, appAttr);
     const selectedApp = appAttrValue || "";
@@ -335,6 +337,7 @@ export class StatementsPage extends React.Component<
             arrayItemName="statements"
             activeFilters={activeFilters}
             onClearFilters={this.onClearFilters}
+            resetSQLStats={resetSQLStats}
           />
           <StatementsSortedTable
             className="statements-table"

--- a/pkg/ui/cluster-ui/src/statementsPage/statementsPageConnected.tsx
+++ b/pkg/ui/cluster-ui/src/statementsPage/statementsPageConnected.tsx
@@ -17,6 +17,7 @@ import { actions as statementActions } from "src/store/statements";
 import { actions as statementDiagnosticsActions } from "src/store/statementDiagnostics";
 import { actions as analyticsActions } from "src/store/analytics";
 import { actions as localStorageActions } from "src/store/localStorage";
+import { actions as resetSQLStatsActions } from "src/store/sqlStats";
 import {
   StatementsPage,
   StatementsPageDispatchProps,
@@ -49,6 +50,7 @@ export const ConnectedStatementsPage = withRouter(
       refreshStatements: () => dispatch(statementActions.refresh()),
       refreshStatementDiagnosticsRequests: () =>
         dispatch(statementDiagnosticsActions.refresh()),
+      resetSQLStats: () => dispatch(resetSQLStatsActions.request()),
       dismissAlertMessage: () =>
         dispatch(
           localStorageActions.update({

--- a/pkg/ui/cluster-ui/src/store/sagas.ts
+++ b/pkg/ui/cluster-ui/src/store/sagas.ts
@@ -18,6 +18,7 @@ import { livenessSaga } from "./liveness";
 import { sessionsSaga } from "./sessions";
 import { terminateSaga } from "./terminateQuery";
 import { notifificationsSaga } from "./notifications";
+import { sqlStatsSaga } from "./sqlStats";
 
 export function* sagas(cacheInvalidationPeriod?: number) {
   yield all([
@@ -29,5 +30,6 @@ export function* sagas(cacheInvalidationPeriod?: number) {
     fork(sessionsSaga),
     fork(terminateSaga),
     fork(notifificationsSaga),
+    fork(sqlStatsSaga),
   ]);
 }

--- a/pkg/ui/cluster-ui/src/store/sqlStats/index.ts
+++ b/pkg/ui/cluster-ui/src/store/sqlStats/index.ts
@@ -1,0 +1,12 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+export * from "./sqlStats.reducer";
+export * from "./sqlStats.sagas";

--- a/pkg/ui/cluster-ui/src/store/sqlStats/sqlStats.reducer.ts
+++ b/pkg/ui/cluster-ui/src/store/sqlStats/sqlStats.reducer.ts
@@ -1,0 +1,51 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+import { DOMAIN_NAME, noopReducer } from "../utils";
+
+type ResetSQLStatsResponse = cockroach.server.serverpb.ResetSQLStatsResponse;
+
+export type ResetSQLStatsState = {
+  data: ResetSQLStatsResponse;
+  lastError: Error;
+  valid: boolean;
+};
+
+const initialState: ResetSQLStatsState = {
+  data: null,
+  lastError: null,
+  valid: true,
+};
+
+const resetSQLStatsSlice = createSlice({
+  name: `${DOMAIN_NAME}/resetsqlstats`,
+  initialState,
+  reducers: {
+    received: (state, action: PayloadAction<ResetSQLStatsResponse>) => {
+      state.data = action.payload;
+      state.valid = true;
+      state.lastError = null;
+    },
+    failed: (state, action: PayloadAction<Error>) => {
+      state.valid = false;
+      state.lastError = action.payload;
+    },
+    invalidated: state => {
+      state.valid = false;
+    },
+    // Define actions that don't change state
+    refresh: noopReducer,
+    request: noopReducer,
+  },
+});
+
+export const { reducer, actions } = resetSQLStatsSlice;

--- a/pkg/ui/cluster-ui/src/store/sqlStats/sqlStats.sagas.spec.ts
+++ b/pkg/ui/cluster-ui/src/store/sqlStats/sqlStats.sagas.spec.ts
@@ -1,0 +1,58 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { expectSaga } from "redux-saga-test-plan";
+import { throwError } from "redux-saga-test-plan/providers";
+import * as matchers from "redux-saga-test-plan/matchers";
+import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+
+import { resetSQLStatsSaga } from "./sqlStats.sagas";
+import { resetSQLStats } from "../../api/sqlStatsApi";
+import {
+  actions as sqlStatsActions,
+  reducer as sqlStatsReducers,
+  ResetSQLStatsState,
+} from "./sqlStats.reducer";
+import { actions as statementActions } from "src/store/statements/statements.reducer";
+
+describe("SQL Stats sagas", () => {
+  describe("resetSQLStatsSaga", () => {
+    const resetSQLStatsResponse = new cockroach.server.serverpb.ResetSQLStatsResponse();
+
+    it("successfully resets SQL stats", () => {
+      expectSaga(resetSQLStatsSaga)
+        .provide([[matchers.call.fn(resetSQLStats), resetSQLStatsResponse]])
+        .put(sqlStatsActions.received(resetSQLStatsResponse))
+        .put(statementActions.invalidated())
+        .put(statementActions.refresh())
+        .withReducer(sqlStatsReducers)
+        .hasFinalState<ResetSQLStatsState>({
+          data: resetSQLStatsResponse,
+          lastError: null,
+          valid: true,
+        })
+        .run();
+    });
+
+    it("returns error on failed reset", () => {
+      const err = new Error("failed to reset");
+      expectSaga(resetSQLStatsSaga)
+        .provide([[matchers.call.fn(resetSQLStats), throwError(err)]])
+        .put(sqlStatsActions.failed(err))
+        .withReducer(sqlStatsReducers)
+        .hasFinalState<ResetSQLStatsState>({
+          data: null,
+          lastError: err,
+          valid: false,
+        })
+        .run();
+    });
+  });
+});

--- a/pkg/ui/cluster-ui/src/store/sqlStats/sqlStats.sagas.ts
+++ b/pkg/ui/cluster-ui/src/store/sqlStats/sqlStats.sagas.ts
@@ -1,0 +1,29 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { all, call, put, takeEvery } from "redux-saga/effects";
+import { resetSQLStats } from "src/api/sqlStatsApi";
+import { actions as statementActions } from "src/store/statements";
+import { actions as sqlStatsActions } from "./sqlStats.reducer";
+
+export function* resetSQLStatsSaga() {
+  try {
+    const response = yield call(resetSQLStats);
+    yield put(sqlStatsActions.received(response));
+    yield put(statementActions.invalidated());
+    yield put(statementActions.refresh());
+  } catch (e) {
+    yield put(sqlStatsActions.failed(e));
+  }
+}
+
+export function* sqlStatsSaga() {
+  yield all([takeEvery(sqlStatsActions.request, resetSQLStatsSaga)]);
+}

--- a/pkg/ui/cluster-ui/src/tableStatistics/tableStatistics.module.scss
+++ b/pkg/ui/cluster-ui/src/tableStatistics/tableStatistics.module.scss
@@ -1,0 +1,18 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+.flex-display {
+  display: flex;
+}
+
+.tooltip-hover-area {
+  padding-top: 3px;
+  padding-right: 10px;
+}

--- a/pkg/ui/cluster-ui/src/tableStatistics/tableStatistics.tsx
+++ b/pkg/ui/cluster-ui/src/tableStatistics/tableStatistics.tsx
@@ -15,8 +15,15 @@ import { statisticsClasses } from "../transactionsPage/transactionsPageClasses";
 import { ISortedTablePagination } from "../sortedtable";
 import { Button } from "src/button";
 import { ResultsPerPageLabel } from "src/pagination";
+import { Tooltip } from "@cockroachlabs/ui-components";
+import statementStyles from "src/statementDetails/statementDetails.module.scss";
+import tableStatsStyles from "./tableStatistics.module.scss";
+import classNames from "classnames/bind";
+import { Icon } from "@cockroachlabs/ui-components";
 
 const { statistic, countTitle, lastCleared } = statisticsClasses;
+const cxStmt = classNames.bind(statementStyles);
+const cxStats = classNames.bind(tableStatsStyles);
 
 interface TableStatistics {
   pagination: ISortedTablePagination;
@@ -26,7 +33,11 @@ interface TableStatistics {
   activeFilters: number;
   search?: string;
   onClearFilters?: () => void;
+  resetSQLStats: () => void;
 }
+
+const toolTipText = `Statement history is cleared once an hour by default, which can be configured with the cluster setting
+ diagnostics.reporting.interval. Clicking ‘Clear SQL stats’ will reset SQL stats on the statements and transactions pages.`;
 
 const renderLastCleared = (lastReset: string | Date) => {
   return `Last cleared ${moment.utc(lastReset).format(DATE_FORMAT)}`;
@@ -40,6 +51,7 @@ export const TableStatistics: React.FC<TableStatistics> = ({
   arrayItemName,
   onClearFilters,
   activeFilters,
+  resetSQLStats,
 }) => {
   const resultsPerPageLabel = (
     <ResultsPerPageLabel
@@ -64,7 +76,18 @@ export const TableStatistics: React.FC<TableStatistics> = ({
       <h4 className={countTitle}>
         {activeFilters ? resultsCountAndClear : resultsPerPageLabel}
       </h4>
-      <h4 className={lastCleared}>{renderLastCleared(lastReset)}</h4>
+      <div className={cxStats("flex-display")}>
+        <Tooltip content={toolTipText}>
+          <div className={cxStats("tooltip-hover-area")}>
+            <Icon iconName={"InfoCircle"} />
+          </div>
+        </Tooltip>
+        <div className={lastCleared}>
+          {renderLastCleared(lastReset)}
+          {"  "}-{"  "}
+          <a onClick={resetSQLStats}>Clear SQL Stats</a> {/*doesn't work!*/}
+        </div>
+      </div>
     </div>
   );
 };

--- a/pkg/ui/cluster-ui/src/transactionDetails/transactionDetails.stories.tsx
+++ b/pkg/ui/cluster-ui/src/transactionDetails/transactionDetails.stories.tsx
@@ -27,6 +27,7 @@ storiesOf("Transactions Details", module)
       statements={data.statements as any}
       lastReset={Date().toString()}
       handleDetails={() => {}}
+      resetSQLStats={() => {}}
     />
   ))
   .add("with loading indicator", () => (
@@ -34,6 +35,7 @@ storiesOf("Transactions Details", module)
       statements={undefined}
       lastReset={Date().toString()}
       handleDetails={() => {}}
+      resetSQLStats={() => {}}
     />
   ))
   .add("with error alert", () => (
@@ -42,5 +44,6 @@ storiesOf("Transactions Details", module)
       error={error}
       lastReset={Date().toString()}
       handleDetails={() => {}}
+      resetSQLStats={() => {}}
     />
   ));

--- a/pkg/ui/cluster-ui/src/transactionDetails/transactionDetails.tsx
+++ b/pkg/ui/cluster-ui/src/transactionDetails/transactionDetails.tsx
@@ -63,6 +63,7 @@ interface TransactionDetailsProps {
     transactionStats: TransactionStats | null,
   ) => void;
   error?: Error | null;
+  resetSQLStats: () => void;
 }
 
 interface TState {
@@ -98,7 +99,13 @@ export class TransactionDetails extends React.Component<
   };
 
   render() {
-    const { statements, transactionStats, handleDetails, error } = this.props;
+    const {
+      statements,
+      transactionStats,
+      handleDetails,
+      error,
+      resetSQLStats,
+    } = this.props;
     return (
       <div>
         <section className={baseHeadingClasses.wrapper}>
@@ -225,6 +232,7 @@ export class TransactionDetails extends React.Component<
                     lastReset={lastReset}
                     arrayItemName={"statements for this transaction"}
                     activeFilters={0}
+                    resetSQLStats={resetSQLStats}
                   />
                   <div className={cx("table-area")}>
                     <SortedTable

--- a/pkg/ui/cluster-ui/src/transactionsPage/transactionsPage.stories.tsx
+++ b/pkg/ui/cluster-ui/src/transactionsPage/transactionsPage.stories.tsx
@@ -26,7 +26,12 @@ storiesOf("Transactions Page", module)
     <div style={{ backgroundColor: "#F5F7FA" }}>{storyFn()}</div>
   ))
   .add("with data", () => (
-    <TransactionsPage {...routeProps} data={data} refreshData={noop} />
+    <TransactionsPage
+      {...routeProps}
+      data={data}
+      refreshData={noop}
+      resetSQLStats={noop}
+    />
   ))
   .add("without data", () => {
     return (
@@ -34,6 +39,7 @@ storiesOf("Transactions Page", module)
         {...routeProps}
         data={getEmptyData()}
         refreshData={noop}
+        resetSQLStats={noop}
       />
     );
   })
@@ -50,12 +56,18 @@ storiesOf("Transactions Page", module)
         data={getEmptyData()}
         refreshData={noop}
         history={history}
+        resetSQLStats={noop}
       />
     );
   })
   .add("with loading indicator", () => {
     return (
-      <TransactionsPage {...routeProps} data={undefined} refreshData={noop} />
+      <TransactionsPage
+        {...routeProps}
+        data={undefined}
+        refreshData={noop}
+        resetSQLStats={noop}
+      />
     );
   })
   .add("with error alert", () => {
@@ -71,6 +83,7 @@ storiesOf("Transactions Page", module)
           )
         }
         refreshData={noop}
+        resetSQLStats={noop}
       />
     );
   });

--- a/pkg/ui/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -59,6 +59,7 @@ interface TState {
 interface TransactionsPageProps {
   data: IStatementsResponse;
   refreshData: () => void;
+  resetSQLStats: () => void;
   error?: Error | null;
   pageSize?: number;
 }
@@ -201,7 +202,7 @@ export class TransactionsPage extends React.Component<
           loading={!this.props?.data}
           error={this.props?.error}
           render={() => {
-            const { data } = this.props;
+            const { data, resetSQLStats } = this.props;
             const { pagination, search, filters } = this.state;
             const { statements, internal_app_name_prefix } = data;
             const appNames = getTrxAppFilterOptions(
@@ -257,6 +258,7 @@ export class TransactionsPage extends React.Component<
                     arrayItemName="transactions"
                     activeFilters={activeFilters}
                     onClearFilters={this.onClearFilters}
+                    resetSQLStats={resetSQLStats}
                   />
                   <TransactionsTable
                     transactions={transactionsToDisplay}
@@ -300,6 +302,7 @@ export class TransactionsPage extends React.Component<
         lastReset={this.lastReset()}
         handleDetails={this.handleDetails}
         error={this.props.error}
+        resetSQLStats={this.props.resetSQLStats}
       />
     );
   }

--- a/pkg/ui/src/redux/apiReducers.ts
+++ b/pkg/ui/src/redux/apiReducers.ts
@@ -271,6 +271,7 @@ const queriesReducerObj = new CachedDataReducer(
   moment.duration(5, "m"),
   moment.duration(1, "m"),
 );
+export const invalidateStatements = queriesReducerObj.invalidateData;
 export const refreshStatements = queriesReducerObj.refresh;
 
 const statementDiagnosticsReportsReducerObj = new CachedDataReducer(

--- a/pkg/ui/src/redux/sagas.ts
+++ b/pkg/ui/src/redux/sagas.ts
@@ -16,6 +16,7 @@ import { customAnalyticsSaga } from "./customAnalytics";
 import { statementsSaga } from "./statements";
 import { analyticsSaga } from "./analyticsSagas";
 import { sessionsSaga } from "./sessions";
+import { sqlStatsSaga } from "./sqlStats";
 
 export default function* rootSaga() {
   yield all([
@@ -25,5 +26,6 @@ export default function* rootSaga() {
     fork(statementsSaga),
     fork(analyticsSaga),
     fork(sessionsSaga),
+    fork(sqlStatsSaga),
   ]);
 }

--- a/pkg/ui/src/redux/sqlStats/index.ts
+++ b/pkg/ui/src/redux/sqlStats/index.ts
@@ -1,0 +1,12 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+export * from "./sqlStatsActions";
+export * from "./sqlStatsSagas";

--- a/pkg/ui/src/redux/sqlStats/sqlStatsActions.ts
+++ b/pkg/ui/src/redux/sqlStats/sqlStatsActions.ts
@@ -1,0 +1,35 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { Action } from "redux";
+
+export const RESET_SQL_STATS = "cockroachui/sqlStats/RESET_SQL_STATS";
+export const RESET_SQL_STATS_COMPLETE =
+  "cockroachui/sqlStats/RESET_SQL_STATS_COMPLETE";
+export const RESET_SQL_STATS_FAILED =
+  "cockroachui/sqlStats/RESET_SQL_STATS_FAILED";
+
+export function resetSQLStatsAction(): Action {
+  return {
+    type: RESET_SQL_STATS,
+  };
+}
+
+export function resetSQLStatsCompleteAction(): Action {
+  return {
+    type: RESET_SQL_STATS_COMPLETE,
+  };
+}
+
+export function resetSQLStatsFailedAction(): Action {
+  return {
+    type: RESET_SQL_STATS_FAILED,
+  };
+}

--- a/pkg/ui/src/redux/sqlStats/sqlStatsSagas.spec.ts
+++ b/pkg/ui/src/redux/sqlStats/sqlStatsSagas.spec.ts
@@ -1,0 +1,46 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { expectSaga } from "redux-saga-test-plan";
+import { call } from "redux-saga-test-plan/matchers";
+
+import {
+  resetSQLStatsFailedAction,
+  resetSQLStatsCompleteAction,
+} from "./sqlStatsActions";
+import { resetSQLStatsSaga } from "./sqlStatsSagas";
+import { resetSQLStats } from "src/util/api";
+import { invalidateStatements, refreshStatements } from "src/redux/apiReducers";
+import { throwError } from "redux-saga-test-plan/providers";
+
+import { cockroach } from "src/js/protos";
+
+describe("SQL Stats sagas", () => {
+  describe("resetSQLStatsSaga", () => {
+    const resetSQLStatsResponse = new cockroach.server.serverpb.ResetSQLStatsResponse();
+
+    it("successfully resets SQL stats", () => {
+      expectSaga(resetSQLStatsSaga)
+        .provide([[call.fn(resetSQLStats), resetSQLStatsResponse]])
+        .put(resetSQLStatsCompleteAction())
+        .put(invalidateStatements())
+        .put(refreshStatements() as any)
+        .run();
+    });
+
+    it("returns error on failed reset", () => {
+      const err = new Error("failed to reset");
+      expectSaga(resetSQLStatsSaga)
+        .provide([[call.fn(resetSQLStats), throwError(err)]])
+        .put(resetSQLStatsFailedAction())
+        .run();
+    });
+  });
+});

--- a/pkg/ui/src/redux/sqlStats/sqlStatsSagas.ts
+++ b/pkg/ui/src/redux/sqlStats/sqlStatsSagas.ts
@@ -1,0 +1,37 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { cockroach } from "src/js/protos";
+import { resetSQLStats } from "src/util/api";
+import { all, call, put, takeEvery } from "redux-saga/effects";
+import {
+  RESET_SQL_STATS,
+  resetSQLStatsCompleteAction,
+  resetSQLStatsFailedAction,
+} from "./sqlStatsActions";
+import { invalidateStatements, refreshStatements } from "src/redux/apiReducers";
+
+import ResetSQLStatsRequest = cockroach.server.serverpb.ResetSQLStatsRequest;
+
+export function* resetSQLStatsSaga() {
+  const resetSQLStatsRequest = new ResetSQLStatsRequest();
+  try {
+    yield call(resetSQLStats, resetSQLStatsRequest);
+    yield put(resetSQLStatsCompleteAction());
+    yield put(invalidateStatements());
+    yield put(refreshStatements() as any);
+  } catch (e) {
+    yield put(resetSQLStatsFailedAction());
+  }
+}
+
+export function* sqlStatsSaga() {
+  yield all([takeEvery(RESET_SQL_STATS, resetSQLStatsSaga)]);
+}

--- a/pkg/ui/src/util/api.ts
+++ b/pkg/ui/src/util/api.ts
@@ -126,6 +126,9 @@ export type CreateStatementDiagnosticsReportResponseMessage = protos.cockroach.s
 export type StatementDiagnosticsRequestMessage = protos.cockroach.server.serverpb.StatementDiagnosticsRequest;
 export type StatementDiagnosticsResponseMessage = protos.cockroach.server.serverpb.StatementDiagnosticsResponse;
 
+export type ResetSQLStatsRequestMessage = protos.cockroach.server.serverpb.ResetSQLStatsRequest;
+export type ResetSQLStatsResponseMessage = protos.cockroach.server.serverpb.ResetSQLStatsResponse;
+
 // API constants
 
 export const API_PREFIX = "_admin/v1";
@@ -727,6 +730,18 @@ export function getAllMetricMetadata(
     serverpb.MetricMetadataResponse,
     `${API_PREFIX}/metricmetadata`,
     null,
+    timeout,
+  );
+}
+
+export function resetSQLStats(
+  req: ResetSQLStatsRequestMessage,
+  timeout?: moment.Duration,
+): Promise<ResetSQLStatsResponseMessage> {
+  return timeoutFetch(
+    serverpb.ResetSQLStatsResponse,
+    `${STATUS_PREFIX}/resetsqlstats`,
+    req as any,
     timeout,
   );
 }

--- a/pkg/ui/src/views/statements/statementsPage.fixture.ts
+++ b/pkg/ui/src/views/statements/statementsPage.fixture.ts
@@ -459,6 +459,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
   onActivateStatementDiagnostics: (_) => {},
   onDiagnosticsModalOpen: (_) => {},
   onPageChanged: (_) => {},
+  resetSQLStats: () => {},
 };
 
 export default statementsPagePropsFixture;

--- a/pkg/ui/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/src/views/statements/statementsPage.tsx
@@ -44,6 +44,7 @@ import {
   trackStatementsSearchAction,
   trackTableSortAction,
 } from "src/redux/analyticsActions";
+import { resetSQLStatsAction } from "src/redux/sqlStats";
 
 type ICollectedStatementStatistics = protos.cockroach.server.serverpb.StatementsResponse.ICollectedStatementStatistics;
 type IStatementDiagnosticsReport = protos.cockroach.server.serverpb.IStatementDiagnosticsReport;
@@ -194,6 +195,7 @@ export default withRouter(
     {
       refreshStatements,
       refreshStatementDiagnosticsRequests,
+      resetSQLStats: resetSQLStatsAction,
       dismissAlertMessage: () =>
         createStatementDiagnosticsAlertLocalSetting.set({ show: false }),
       onActivateStatementDiagnostics: createStatementDiagnosticsReportAction,

--- a/pkg/ui/src/views/transactions/transactionsPage.tsx
+++ b/pkg/ui/src/views/transactions/transactionsPage.tsx
@@ -12,6 +12,7 @@ import { connect } from "react-redux";
 import { createSelector } from "reselect";
 import { withRouter } from "react-router-dom";
 import { refreshStatements } from "src/redux/apiReducers";
+import { resetSQLStatsAction } from "src/redux/sqlStats";
 import { CachedDataReducerState } from "src/redux/cachedDataReducer";
 import { AdminUIState } from "src/redux/state";
 import { StatementsResponseMessage } from "src/util/api";
@@ -58,6 +59,7 @@ const TransactionsPageConnected = withRouter(
     }),
     {
       refreshData: refreshStatements,
+      resetSQLStats: resetSQLStatsAction,
     },
   )(TransactionsPage),
 );


### PR DESCRIPTION
Backport 1/1 commits from #63342
Backport 1/1 commits from https://github.com/cockroachdb/ui/pull/271

/cc @cockroachdb/release

---

add button to reset SQL stats 