### PR TITLE
release-21.1: storage: max number of intents in WriteIntentError during scan

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_reverse_scan.go
+++ b/pkg/kv/kvserver/batcheval/cmd_reverse_scan.go
@@ -43,6 +43,7 @@ func ReverseScan(
 		Inconsistent:     h.ReadConsistency != roachpb.CONSISTENT,
 		Txn:              h.Txn,
 		MaxKeys:          h.MaxSpanRequestKeys,
+		MaxIntents:       storage.MaxIntentsPerWriteIntentError.Get(&cArgs.EvalCtx.ClusterSettings().SV),
 		TargetBytes:      h.TargetBytes,
 		FailOnMoreRecent: args.KeyLocking != lock.None,
 		Reverse:          true,

--- a/pkg/kv/kvserver/batcheval/cmd_scan.go
+++ b/pkg/kv/kvserver/batcheval/cmd_scan.go
@@ -44,6 +44,7 @@ func Scan(
 		Txn:                   h.Txn,
 		LocalUncertaintyLimit: cArgs.LocalUncertaintyLimit,
 		MaxKeys:               h.MaxSpanRequestKeys,
+		MaxIntents:            storage.MaxIntentsPerWriteIntentError.Get(&cArgs.EvalCtx.ClusterSettings().SV),
 		TargetBytes:           h.TargetBytes,
 		FailOnMoreRecent:      args.KeyLocking != lock.None,
 		Reverse:               false,

--- a/pkg/kv/kvserver/batcheval/cmd_scan_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_scan_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -84,6 +85,7 @@ func testScanReverseScanInner(
 			Timestamp:   ts,
 			TargetBytes: tb,
 		},
+		EvalCtx: (&MockEvalCtx{ClusterSettings: cluster.MakeClusterSettings()}).EvalContext(),
 	}
 
 	if !reverse {

--- a/pkg/kv/kvserver/batcheval/intent_test.go
+++ b/pkg/kv/kvserver/batcheval/intent_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -56,6 +57,7 @@ func TestCollectIntentsUsesSameIterator(t *testing.T) {
 		Timestamp:       ts,
 		ReadConsistency: roachpb.READ_UNCOMMITTED,
 	}
+	evalCtx := (&MockEvalCtx{ClusterSettings: cluster.MakeClusterSettings()}).EvalContext()
 
 	testCases := []struct {
 		name              string
@@ -70,7 +72,7 @@ func TestCollectIntentsUsesSameIterator(t *testing.T) {
 					RequestHeader: roachpb.RequestHeader{Key: key},
 				}
 				var resp roachpb.GetResponse
-				if _, err := Get(ctx, db, CommandArgs{Args: req, Header: header}, &resp); err != nil {
+				if _, err := Get(ctx, db, CommandArgs{Args: req, Header: header, EvalCtx: evalCtx}, &resp); err != nil {
 					return nil, err
 				}
 				if resp.IntentValue == nil {
@@ -88,7 +90,7 @@ func TestCollectIntentsUsesSameIterator(t *testing.T) {
 					RequestHeader: roachpb.RequestHeader{Key: key, EndKey: key.Next()},
 				}
 				var resp roachpb.ScanResponse
-				if _, err := Scan(ctx, db, CommandArgs{Args: req, Header: header}, &resp); err != nil {
+				if _, err := Scan(ctx, db, CommandArgs{Args: req, Header: header, EvalCtx: evalCtx}, &resp); err != nil {
 					return nil, err
 				}
 				return resp.IntentRows, nil
@@ -103,7 +105,7 @@ func TestCollectIntentsUsesSameIterator(t *testing.T) {
 					RequestHeader: roachpb.RequestHeader{Key: key, EndKey: key.Next()},
 				}
 				var resp roachpb.ReverseScanResponse
-				if _, err := ReverseScan(ctx, db, CommandArgs{Args: req, Header: header}, &resp); err != nil {
+				if _, err := ReverseScan(ctx, db, CommandArgs{Args: req, Header: header, EvalCtx: evalCtx}, &resp); err != nil {
 					return nil, err
 				}
 				return resp.IntentRows, nil

--- a/pkg/kv/kvserver/replica_evaluate_test.go
+++ b/pkg/kv/kvserver/replica_evaluate_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -612,6 +613,7 @@ func TestEvaluateBatch(t *testing.T) {
 			}
 			d.AbortSpan = abortspan.New(1)
 			d.ba.Header.Timestamp = ts
+			d.ClusterSettings = cluster.MakeClusterSettings()
 
 			tc.setup(t, d)
 

--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -74,11 +74,12 @@ var retiredSettings = map[string]struct{}{
 	"sql.parallel_scans.enabled":                                       {},
 	"backup.table_statistics.enabled":                                  {},
 	// removed as of 21.1.
-	"sql.distsql.interleaved_joins.enabled": {},
-	"sql.testing.vectorize.batch_size":      {},
-	"sql.testing.mutations.max_batch_size":  {},
-	"sql.testing.mock_contention.enabled":   {},
-	"kv.atomic_replication_changes.enabled": {},
+	"sql.distsql.interleaved_joins.enabled":    {},
+	"sql.testing.vectorize.batch_size":         {},
+	"sql.testing.mutations.max_batch_size":     {},
+	"sql.testing.mock_contention.enabled":      {},
+	"kv.atomic_replication_changes.enabled":    {},
+	"storage.sst_export.max_intents_per_error": {},
 }
 
 // register adds a setting to the registry.

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -639,10 +639,16 @@ func TestMVCCScanWriteIntentError(t *testing.T) {
 			engine := engineImpl.create()
 			defer engine.Close()
 
-			ts := []hlc.Timestamp{{Logical: 1}, {Logical: 2}, {Logical: 3}, {Logical: 4}, {Logical: 5}, {Logical: 6}}
+			ts := []hlc.Timestamp{{Logical: 1}, {Logical: 2}, {Logical: 3}, {Logical: 4}, {Logical: 5}, {Logical: 6}, {Logical: 7}}
 
 			txn1ts := makeTxn(*txn1, ts[2])
 			txn2ts := makeTxn(*txn2, ts[5])
+			txnMap := map[int]*roachpb.Transaction{
+				2: txn1ts,
+				5: txn2ts,
+				6: txn2ts,
+				7: txn2ts,
+			}
 
 			fixtureKVs := []roachpb.KeyValue{
 				{Key: testKey1, Value: mkVal("testValue1 pre", ts[0])},
@@ -651,28 +657,26 @@ func TestMVCCScanWriteIntentError(t *testing.T) {
 				{Key: testKey2, Value: mkVal("testValue2", ts[3])},
 				{Key: testKey3, Value: mkVal("testValue3", ts[4])},
 				{Key: testKey4, Value: mkVal("testValue4", ts[5])},
+				{Key: testKey5, Value: mkVal("testValue5", ts[5])},
+				{Key: testKey6, Value: mkVal("testValue5", ts[5])},
 			}
 			for i, kv := range fixtureKVs {
-				var txn *roachpb.Transaction
-				if i == 2 {
-					txn = txn1ts
-				} else if i == 5 {
-					txn = txn2ts
-				}
 				v := *protoutil.Clone(&kv.Value).(*roachpb.Value)
 				v.Timestamp = hlc.Timestamp{}
-				if err := MVCCPut(ctx, engine, nil, kv.Key, kv.Value.Timestamp, v, txn); err != nil {
+				if err := MVCCPut(ctx, engine, nil, kv.Key, kv.Value.Timestamp, v, txnMap[i]); err != nil {
 					t.Fatal(err)
 				}
 			}
 
 			scanCases := []struct {
+				name       string
 				consistent bool
 				txn        *roachpb.Transaction
 				expIntents []roachpb.Intent
 				expValues  []roachpb.KeyValue
 			}{
 				{
+					name:       "consistent-all-keys",
 					consistent: true,
 					txn:        nil,
 					expIntents: []roachpb.Intent{
@@ -683,14 +687,17 @@ func TestMVCCScanWriteIntentError(t *testing.T) {
 					expValues: nil,
 				},
 				{
+					name:       "consistent-txn1",
 					consistent: true,
 					txn:        txn1ts,
 					expIntents: []roachpb.Intent{
 						roachpb.MakeIntent(&txn2ts.TxnMeta, testKey4),
+						roachpb.MakeIntent(&txn2ts.TxnMeta, testKey5),
 					},
 					expValues: nil, // []roachpb.KeyValue{fixtureKVs[2], fixtureKVs[3], fixtureKVs[4]},
 				},
 				{
+					name:       "consistent-txn2",
 					consistent: true,
 					txn:        txn2ts,
 					expIntents: []roachpb.Intent{
@@ -699,52 +706,51 @@ func TestMVCCScanWriteIntentError(t *testing.T) {
 					expValues: nil, // []roachpb.KeyValue{fixtureKVs[3], fixtureKVs[4], fixtureKVs[5]},
 				},
 				{
+					name:       "inconsistent-all-keys",
 					consistent: false,
 					txn:        nil,
 					expIntents: []roachpb.Intent{
 						roachpb.MakeIntent(&txn1ts.TxnMeta, testKey1),
 						roachpb.MakeIntent(&txn2ts.TxnMeta, testKey4),
+						roachpb.MakeIntent(&txn2ts.TxnMeta, testKey5),
+						roachpb.MakeIntent(&txn2ts.TxnMeta, testKey6),
 					},
 					expValues: []roachpb.KeyValue{fixtureKVs[0], fixtureKVs[3], fixtureKVs[4], fixtureKVs[1]},
 				},
 			}
 
-			for i, scan := range scanCases {
-				cStr := "inconsistent"
-				if scan.consistent {
-					cStr = "consistent"
-				}
-				res, err := MVCCScan(ctx, engine, testKey1, testKey4.Next(),
-					hlc.Timestamp{WallTime: 1}, MVCCScanOptions{Inconsistent: !scan.consistent, Txn: scan.txn})
-				var wiErr *roachpb.WriteIntentError
-				_ = errors.As(err, &wiErr)
-				if (err == nil) != (wiErr == nil) {
-					t.Errorf("%s(%d): unexpected error: %+v", cStr, i, err)
-				}
+			for _, scan := range scanCases {
+				t.Run(scan.name, func(t *testing.T) {
+					res, err := MVCCScan(ctx, engine, testKey1, testKey6.Next(),
+						hlc.Timestamp{WallTime: 1}, MVCCScanOptions{Inconsistent: !scan.consistent, Txn: scan.txn, MaxIntents: 2})
+					var wiErr *roachpb.WriteIntentError
+					_ = errors.As(err, &wiErr)
+					if (err == nil) != (wiErr == nil) {
+						t.Errorf("unexpected error: %+v", err)
+					}
 
-				if wiErr == nil != !scan.consistent {
-					t.Errorf("%s(%d): expected write intent error; got %s", cStr, i, err)
-					continue
-				}
+					if wiErr == nil != !scan.consistent {
+						t.Fatalf("expected write intent error; got %s", err)
+					}
 
-				intents := res.Intents
-				kvs := res.KVs
-				if len(intents) > 0 != !scan.consistent {
-					t.Errorf("%s(%d): expected different intents slice; got %+v", cStr, i, intents)
-					continue
-				}
+					intents := res.Intents
+					kvs := res.KVs
+					if len(intents) > 0 != !scan.consistent {
+						t.Fatalf("expected different intents slice; got %+v", intents)
+					}
 
-				if scan.consistent {
-					intents = wiErr.Intents
-				}
+					if scan.consistent {
+						intents = wiErr.Intents
+					}
 
-				if !reflect.DeepEqual(intents, scan.expIntents) {
-					t.Fatalf("%s(%d): expected intents:\n%+v;\n got\n%+v", cStr, i, scan.expIntents, intents)
-				}
+					if !reflect.DeepEqual(intents, scan.expIntents) {
+						t.Fatalf("expected intents:\n%+v;\n got\n%+v", scan.expIntents, intents)
+					}
 
-				if !reflect.DeepEqual(kvs, scan.expValues) {
-					t.Errorf("%s(%d): expected values %+v; got %+v", cStr, i, scan.expValues, kvs)
-				}
+					if !reflect.DeepEqual(kvs, scan.expValues) {
+						t.Fatalf("expected values %+v; got %+v", scan.expValues, kvs)
+					}
+				})
 			}
 		})
 	}

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -45,15 +45,7 @@ import (
 	"github.com/cockroachdb/redact"
 )
 
-const (
-	maxSyncDurationFatalOnExceededDefault = true
-
-	// Default value for maximum number of intents reported by ExportToSST
-	// in WriteIntentError is set to half of the maximum lock table size.
-	// This value is subject to tuning in real environment as we have more
-	// data available.
-	maxIntentsPerSstExportErrorDefault = 5000
-)
+const maxSyncDurationFatalOnExceededDefault = true
 
 // Default for MaxSyncDuration below.
 var maxSyncDurationDefault = envutil.EnvOrDefaultDuration("COCKROACH_ENGINE_MAX_SYNC_DURATION_DEFAULT", 60*time.Second)
@@ -74,11 +66,6 @@ var MaxSyncDurationFatalOnExceeded = settings.RegisterBoolSetting(
 	"if true, fatal the process when a disk operation exceeds storage.max_sync_duration",
 	maxSyncDurationFatalOnExceededDefault,
 )
-
-var maxIntentsPerSstExportError = settings.RegisterIntSetting(
-	"storage.sst_export.max_intents_per_error",
-	"maximum number of intents returned in error when sst export fails",
-	maxIntentsPerSstExportErrorDefault)
 
 // EngineKeyCompare compares cockroach keys, including the version (which
 // could be MVCC timestamps).
@@ -670,7 +657,7 @@ func (p *Pebble) ExportMVCCToSst(
 ) ([]byte, roachpb.BulkOpSummary, roachpb.Key, error) {
 	r := wrapReader(p)
 	// Doing defer r.Free() does not inline.
-	maxIntentCount := maxIntentsPerSstExportError.Get(&p.settings.SV)
+	maxIntentCount := MaxIntentsPerWriteIntentError.Get(&p.settings.SV)
 	b, summary, k, err := pebbleExportToSst(r, startKey, endKey, startTS, endTS, exportAllRevisions, targetSize,
 		maxSize, useTBI, maxIntentCount)
 	r.Free()
@@ -1341,7 +1328,7 @@ func (p *pebbleReadOnly) ExportMVCCToSst(
 ) ([]byte, roachpb.BulkOpSummary, roachpb.Key, error) {
 	r := wrapReader(p)
 	// Doing defer r.Free() does not inline.
-	maxIntentCount := maxIntentsPerSstExportError.Get(&p.parent.settings.SV)
+	maxIntentCount := MaxIntentsPerWriteIntentError.Get(&p.parent.settings.SV)
 	b, summary, k, err := pebbleExportToSst(
 		r, startKey, endKey, startTS, endTS, exportAllRevisions, targetSize, maxSize, useTBI, maxIntentCount)
 	r.Free()
@@ -1605,7 +1592,7 @@ func (p *pebbleSnapshot) ExportMVCCToSst(
 ) ([]byte, roachpb.BulkOpSummary, roachpb.Key, error) {
 	r := wrapReader(p)
 	// Doing defer r.Free() does not inline.
-	maxIntentCount := maxIntentsPerSstExportError.Get(&p.settings.SV)
+	maxIntentCount := MaxIntentsPerWriteIntentError.Get(&p.settings.SV)
 	b, summary, k, err := pebbleExportToSst(
 		r, startKey, endKey, startTS, endTS, exportAllRevisions, targetSize, maxSize, useTBI, maxIntentCount)
 	r.Free()

--- a/pkg/storage/pebble_mvcc_scanner.go
+++ b/pkg/storage/pebble_mvcc_scanner.go
@@ -114,6 +114,12 @@ type pebbleMVCCScanner struct {
 	// Stop adding keys once p.result.bytes matches or exceeds this threshold,
 	// if nonzero.
 	targetBytes int64
+	// Stop adding intents and abort scan once maxIntents threshold is reached.
+	// This limit is only applicable to consistent scans since they return
+	// intents as an error.
+	// Not used in inconsistent scans.
+	// Ignored if zero.
+	maxIntents int64
 	// Transaction epoch and sequence number.
 	txn               *roachpb.Transaction
 	txnEpoch          enginepb.TxnEpoch
@@ -442,6 +448,11 @@ func (p *pebbleMVCCScanner) getAndAdvance() bool {
 		// return the intent separately; the caller may want to resolve
 		// it.
 		if p.maxKeys > 0 && p.results.count == p.maxKeys {
+			// TODO(oleg): This check seems broken and it should never
+			// reach this point with results count reaching max. We
+			// always get out of getAndAdvance either by addAndAdvance or
+			// by seekVersion which is also calling addAndAdvance.
+			//
 			// We've already retrieved the desired number of keys and now
 			// we're adding the resume key. We don't want to add the
 			// intent here as the intents should only correspond to KVs
@@ -470,6 +481,10 @@ func (p *pebbleMVCCScanner) getAndAdvance() bool {
 		// in the scan range.
 		p.err = p.intents.Set(p.curRawKey, p.curValue, nil)
 		if p.err != nil {
+			return false
+		}
+		// Limit number of intents returned in write intent error.
+		if p.maxIntents > 0 && int64(p.intents.Count()) >= p.maxIntents {
 			return false
 		}
 		return p.advanceKey()

--- a/pkg/storage/pebble_test.go
+++ b/pkg/storage/pebble_test.go
@@ -626,7 +626,7 @@ func TestSstExportFailureIntentBatching(t *testing.T) {
 	}
 
 	// Export range is fixed to k:["00010", "10000"), ts:(999, 2000] for all tests.
-	testDataCount := int(maxIntentsPerSstExportError.Default() + 1)
+	testDataCount := int(MaxIntentsPerWriteIntentError.Default() + 1)
 	testData := make([]testValue, testDataCount*2)
 	expectedErrors := make([]int, testDataCount)
 	for i := 0; i < testDataCount; i++ {
@@ -634,5 +634,5 @@ func TestSstExportFailureIntentBatching(t *testing.T) {
 		testData[i*2+1] = intent(key(i*2+12), "intent", ts(1001))
 		expectedErrors[i] = i*2 + 1
 	}
-	t.Run("Receive no more than limit intents", checkReportedErrors(testData, expectedErrors[:maxIntentsPerSstExportError.Default()]))
+	t.Run("Receive no more than limit intents", checkReportedErrors(testData, expectedErrors[:MaxIntentsPerWriteIntentError.Default()]))
 }


### PR DESCRIPTION
Backport 1/1 commits from #65465.

/cc @cockroachdb/release

---

Previously consistent scan operation could return all encountered
intents from a range which could lead to process running out of memory.
This was the case when trying to cleanup built up intents by a high pri
query.

To address this, limit is added to the scan, to only return so much
intents before aborting.

This limit is controlled by cluster setting
storage.mvcc.max_intents_per_error which is replacing previously
available setting storage.sst_export.max_intents_per_error. New
setting will cover both scan and export commands.

Release note (ops change): Added limit to number of intents
collected by scan before aborting.
