### PR TITLE
ccl/importccl: skip TestImportPgDumpSchemas/inject-error-ensure-cleanup

### DIFF
--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -6190,6 +6190,7 @@ table_name FROM [SHOW TABLES] ORDER BY (schema_name, table_name)`,
 	})
 
 	t.Run("inject-error-ensure-cleanup", func(t *testing.T) {
+		skip.WithIssue(t, 65878, "flaky test")
 		defer gcjob.SetSmallMaxGCIntervalForTest()()
 		tc := testcluster.StartTestCluster(t, nodes, base.TestClusterArgs{ServerArgs: args})
 		defer tc.Stopper().Stop(ctx)


### PR DESCRIPTION
Refs: #65878

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None