### PR TITLE
kv/kvserver: skip TestReplicateQueueDeadNonVoters under race

### DIFF
--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -511,6 +511,7 @@ func TestReplicateQueueDecommissioningNonVoters(t *testing.T) {
 // non-voting replicas on dead nodes are replaced or removed.
 func TestReplicateQueueDeadNonVoters(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.UnderRaceWithIssue(t, 65932, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()


### PR DESCRIPTION
Refs: #65932

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None