### PR TITLE
sql: fix bug in column backfill with virtual NOT NULL columns

### DIFF
--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -108,9 +108,13 @@ func (cb *ColumnBackfiller) init(
 		cb.updateExprs[j+len(cb.added)] = tree.DNull
 	}
 
-	// We need all the columns.
+	// We need all the non-virtual columns.
 	var valNeededForCol util.FastIntSet
-	valNeededForCol.AddRange(0, len(desc.PublicColumns())-1)
+	for i, c := range desc.PublicColumns() {
+		if !c.IsVirtual() {
+			valNeededForCol.Add(i)
+		}
+	}
 
 	tableArgs := row.FetcherTableArgs{
 		Desc:            desc,

--- a/pkg/sql/logictest/testdata/logic_test/virtual_columns
+++ b/pkg/sql/logictest/testdata/logic_test/virtual_columns
@@ -1109,3 +1109,21 @@ CREATE TABLE public.t63167_b (
    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
    FAMILY "primary" (a, rowid)
 )
+
+# Test that columns backfills to tables with virtual columns work.
+subtest column_backfill
+
+statement ok
+CREATE TABLE t_65915 (i INT PRIMARY KEY, j INT AS (i + 1) VIRTUAL NOT NULL);
+INSERT INTO t_65915 VALUES (1)
+
+statement ok
+ALTER TABLE t_65915 ADD COLUMN k INT DEFAULT 42;
+
+query III
+SELECT * FROM t_65915;
+----
+1  2  42
+
+statement ok
+DROP TABLE t_65915


### PR DESCRIPTION
Prior to this change we'd inform the column backfiller that it needed to read
the virtual columns. These virtual columns don't exist and thus won't be read.
If the columns are marked as NOT NULL, then an assertion will fire from inside
the row fetcher. This PR fixes the bug by not requesting the virtual columns.

Fixes #65915.

Release note (bug fix): Fixed a bug which prevented adding columns to tables
which contain data and use NOT NULL virtual columns