### PR TITLE
release-21.1: TRUNCATE preserves split points of indexes

### DIFF
--- a/pkg/bench/ddl_analysis/ddl_analysis_bench_test.go
+++ b/pkg/bench/ddl_analysis/ddl_analysis_bench_test.go
@@ -109,7 +109,10 @@ func RunRoundTripBenchmark(b *testing.B, tests []RoundTripBenchTestCase) {
 
 			res := float64(roundTrips) / float64(b.N)
 			if haveExp && !exp.matches(int(res)) && *rewriteFlag == "" {
-				b.Fatalf("got %v, expected %v. trace: \n%v", res, exp, r)
+				b.Fatalf(`got %v, expected %v. trace:
+%v
+(above trace from test %s. got %v, expected %v)
+`, res, exp, r, b.Name(), res, exp)
 			}
 			b.ReportMetric(res, "roundtrips")
 		})

--- a/pkg/bench/ddl_analysis/testdata/benchmark_expectations
+++ b/pkg/bench/ddl_analysis/testdata/benchmark_expectations
@@ -68,11 +68,11 @@ exp,benchmark
 1,SystemDatabaseQueries/select_system.users_with_empty_database_name
 1,SystemDatabaseQueries/select_system.users_with_schema_name
 2,SystemDatabaseQueries/select_system.users_without_schema_name
-30,Truncate/truncate_1_column_0_rows
-30,Truncate/truncate_1_column_1_row
-30,Truncate/truncate_1_column_2_rows
-30,Truncate/truncate_2_column_0_rows
-30,Truncate/truncate_2_column_1_rows
-30,Truncate/truncate_2_column_2_rows
+30-34,Truncate/truncate_1_column_0_rows
+30-34,Truncate/truncate_1_column_1_row
+30-34,Truncate/truncate_1_column_2_rows
+30-34,Truncate/truncate_2_column_0_rows
+30-34,Truncate/truncate_2_column_1_rows
+30-34,Truncate/truncate_2_column_2_rows
 1,VirtualTableQueries/select_crdb_internal.invalid_objects_with_1_fk
 1,VirtualTableQueries/select_crdb_internal.tables_with_1_fk

--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -479,7 +479,8 @@ func (p *planner) dropIndexByName(
 	// the meta ranges directly.
 	if p.ExecCfg().Codec.ForSystemTenant() {
 		span := tableDesc.IndexSpan(p.ExecCfg().Codec, idxEntry.ID)
-		ranges, err := kvclient.ScanMetaKVs(ctx, p.txn, span)
+		txn := p.ExecCfg().DB.NewTxn(ctx, "scan-ranges-for-index-drop")
+		ranges, err := kvclient.ScanMetaKVs(ctx, txn, span)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -393,7 +393,7 @@ func (p *planner) unsplitRangesForTable(ctx context.Context, tableDesc *tabledes
 	// allowed to scan the meta ranges directly.
 	if p.ExecCfg().Codec.ForSystemTenant() {
 		span := tableDesc.TableSpan(p.ExecCfg().Codec)
-		ranges, err := kvclient.ScanMetaKVs(ctx, p.txn, span)
+		ranges, err := kvclient.ScanMetaKVs(ctx, p.execCfg.DB.NewTxn(ctx, "unsplit-ranges-for-table"), span)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -579,10 +579,14 @@ start_pretty   end_pretty
 statement ok
 TRUNCATE TABLE foo
 
-query TT colnames
-SELECT start_pretty, end_pretty FROM crdb_internal.ranges WHERE split_enforced_until IS NOT NULL
+# Ensure that there are no longer any splits left over on the original indexes.
+# TRUNCATE will have created equivalent splits points on the new indexes, so
+# this test just checks that there are no more on the old indexes.
+query TT
+SELECT start_pretty, end_pretty FROM crdb_internal.ranges
+WHERE split_enforced_until IS NOT NULL
+AND (start_pretty LIKE '/Table/58/1%' OR start_pretty LIKE '/Table/58/2%')
 ----
-start_pretty   end_pretty
 
 statement ok
 ALTER TABLE foo SPLIT AT VALUES (1), (2), (3)

--- a/pkg/sql/pgwire/testdata/pgtest/notice
+++ b/pkg/sql/pgwire/testdata/pgtest/notice
@@ -55,7 +55,7 @@ Query {"String": "DROP INDEX t_x_idx"}
 until crdb_only
 CommandComplete
 ----
-{"Severity":"NOTICE","SeverityUnlocalized":"","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":529,"Routine":"dropIndexByName","UnknownFields":null}
+{"Severity":"NOTICE","SeverityUnlocalized":"","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":530,"Routine":"dropIndexByName","UnknownFields":null}
 {"Type":"CommandComplete","CommandTag":"DROP INDEX"}
 
 until noncrdb_only

--- a/pkg/sql/tests/BUILD.bazel
+++ b/pkg/sql/tests/BUILD.bazel
@@ -61,6 +61,7 @@ go_test(
         "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/kv",
+        "//pkg/kv/kvserver",
         "//pkg/kv/kvserver/concurrency",
         "//pkg/roachpb",
         "//pkg/security",

--- a/pkg/sql/tests/truncate_test.go
+++ b/pkg/sql/tests/truncate_test.go
@@ -12,13 +12,16 @@ package tests
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -350,5 +353,71 @@ func TestTruncateWithConcurrentMutations(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) { run(t, tc) })
+	}
+}
+
+func TestTruncatePreservesSplitPoints(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	skip.UnderRace(t)
+
+	ctx := context.Background()
+
+	testCases := []struct {
+		nodes int
+	}{
+		{
+			nodes: 1,
+		},
+		{
+			nodes: 3,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(fmt.Sprintf("nodes=%d", testCase.nodes), func(t *testing.T) {
+			tc := testcluster.StartTestCluster(t, testCase.nodes, base.TestClusterArgs{
+				ServerArgs: base.TestServerArgs{
+					Knobs: base.TestingKnobs{
+						Store: &kvserver.StoreTestingKnobs{
+							DisableMergeQueue: true,
+						},
+					},
+				},
+			})
+			defer tc.Stopper().Stop(ctx)
+
+			var err error
+			_, err = tc.Conns[0].ExecContext(ctx, `
+CREATE TABLE a(a INT PRIMARY KEY, b INT, INDEX(b));
+INSERT INTO a SELECT g,g FROM generate_series(1,10000) g(g);
+ALTER TABLE a SPLIT AT VALUES(1000), (2000), (3000), (4000), (5000), (6000), (7000), (8000), (9000);
+ALTER INDEX a_b_idx SPLIT AT VALUES(1000), (2000), (3000), (4000), (5000), (6000), (7000), (8000), (9000);
+`)
+			assert.NoError(t, err)
+
+			row := tc.Conns[0].QueryRowContext(ctx, `
+SELECT count(*) FROM crdb_internal.ranges_no_leases WHERE table_id = 'a'::regclass`)
+			assert.NoError(t, row.Err())
+			var nRanges int
+			assert.NoError(t, row.Scan(&nRanges))
+
+			const origNRanges = 19
+			assert.Equal(t, origNRanges, nRanges)
+
+			_, err = tc.Conns[0].ExecContext(ctx, `TRUNCATE a`)
+			assert.NoError(t, err)
+
+			row = tc.Conns[0].QueryRowContext(ctx, `
+SELECT count(*) FROM crdb_internal.ranges_no_leases WHERE table_id = 'a'::regclass`)
+			assert.NoError(t, row.Err())
+			assert.NoError(t, row.Scan(&nRanges))
+
+			// We subtract 1 from the original n ranges because the first range can't
+			// be migrated to the new keyspace, as its prefix doesn't include an
+			// index ID.
+			assert.Equal(t, origNRanges+testCase.nodes*int(sql.PreservedSplitCountMultiple.Get(&tc.Servers[0].Cfg.
+				Settings.SV)),
+				nRanges)
+		})
 	}
 }

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -518,7 +518,7 @@ func (p *planner) copySplitPointsToNewIndexes(
 	tablePrefix := p.execCfg.Codec.TablePrefix(uint32(tableID))
 
 	// Fetch all of the range descriptors for this index.
-	ranges, err := kvclient.ScanMetaKVs(ctx, p.txn, roachpb.Span{
+	ranges, err := kvclient.ScanMetaKVs(ctx, p.execCfg.DB.NewTxn(ctx, "truncate-copy-splits"), roachpb.Span{
 		Key:    tablePrefix,
 		EndKey: tablePrefix.PrefixEnd(),
 	})

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -12,12 +12,16 @@ package sql
 
 import (
 	"context"
+	"math/rand"
 
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvclient"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
@@ -170,6 +174,17 @@ func (t *truncateNode) Next(runParams) (bool, error) { return false, nil }
 func (t *truncateNode) Values() tree.Datums          { return tree.Datums{} }
 func (t *truncateNode) Close(context.Context)        {}
 
+// PreservedSplitCountMultiple is the setting that configures the number of
+// split points that we re-create on a table after a truncate. It's scaled by
+// the number of nodes in the cluster.
+var PreservedSplitCountMultiple = settings.RegisterIntSetting(
+	"sql.truncate.preserved_split_count_multiple",
+	"set to non-zero to cause TRUNCATE to preserve range splits from the "+
+		"table's indexes. The multiple given will be multiplied with the number of "+
+		"nodes in the cluster to produce the number of preserved range splits. This "+
+		"can improve performance when truncating a table with significant write traffic.",
+	4)
+
 // truncateTable truncates the data of a table in a single transaction. It does
 // so by dropping all existing indexes on the table and creating new ones without
 // backfilling any data into the new indexes. The old indexes are cleaned up
@@ -270,6 +285,24 @@ func (p *planner) truncateTable(
 		return err
 	}
 
+	oldIndexIDs := make([]descpb.IndexID, len(oldIndexes))
+	for i := range oldIndexIDs {
+		oldIndexIDs[i] = oldIndexes[i].ID
+	}
+	newIndexIDs := make([]descpb.IndexID, len(tableDesc.ActiveIndexes()))
+	newIndexes := tableDesc.ActiveIndexes()
+	for i := range newIndexIDs {
+		newIndexIDs[i] = newIndexes[i].GetID()
+	}
+
+	// Move existing range split points in the pre-truncated table's indexes to
+	// the new indexes we're creating, to avoid a thundering herd effect where
+	// any existing traffic on the table will slam into a single range after the
+	// truncate is completed.
+	if err := p.copySplitPointsToNewIndexes(ctx, id, oldIndexIDs, newIndexIDs); err != nil {
+		return err
+	}
+
 	// Reassign any referenced index ID's from other tables.
 	if err := p.reassignInterleaveIndexReferences(ctx, allRefs, tableDesc.ID, indexIDMapping); err != nil {
 		return err
@@ -285,19 +318,11 @@ func (p *planner) truncateTable(
 	}
 
 	// Move any zone configs on indexes over to the new set of indexes.
-	oldIndexIDs := make([]descpb.IndexID, len(oldIndexes)-1)
-	for i := range oldIndexIDs {
-		oldIndexIDs[i] = oldIndexes[i+1].ID
-	}
-	newIndexIDs := make([]descpb.IndexID, len(tableDesc.PublicNonPrimaryIndexes()))
-	for i := range newIndexIDs {
-		newIndexIDs[i] = tableDesc.PublicNonPrimaryIndexes()[i].GetID()
-	}
 	swapInfo := &descpb.PrimaryKeySwap{
-		OldPrimaryIndexId: oldIndexes[0].ID,
-		OldIndexes:        oldIndexIDs,
-		NewPrimaryIndexId: tableDesc.GetPrimaryIndexID(),
-		NewIndexes:        newIndexIDs,
+		OldPrimaryIndexId: oldIndexIDs[0],
+		OldIndexes:        oldIndexIDs[1:],
+		NewPrimaryIndexId: newIndexIDs[0],
+		NewIndexes:        newIndexIDs[1:],
 	}
 	if err := maybeUpdateZoneConfigsForPKChange(ctx, p.txn, p.ExecCfg(), tableDesc, swapInfo); err != nil {
 		return err
@@ -454,6 +479,155 @@ func (p *planner) findAllReferencingInterleaves(
 	}
 
 	return tables, nil
+}
+
+// copySplitPointsToNewIndexes copies any range split points from the indexes
+// given by the oldIndexIDs slice to the indexes given by the newIndexIDs slice
+// on the table given by the tableID.
+// oldIndexIDs and newIndexIDs must be in the same order and be the same length.
+func (p *planner) copySplitPointsToNewIndexes(
+	ctx context.Context,
+	tableID descpb.ID,
+	oldIndexIDs []descpb.IndexID,
+	newIndexIDs []descpb.IndexID,
+) error {
+	if !p.EvalContext().Codec.ForSystemTenant() {
+		// Can't do any of this direct manipulation of ranges in multi-tenant mode.
+		return nil
+	}
+
+	preservedSplitsMultiple := int(PreservedSplitCountMultiple.Get(p.execCfg.SV()))
+	if preservedSplitsMultiple <= 0 {
+		return nil
+	}
+	row, err := p.execCfg.InternalExecutor.QueryRowEx(
+		// Run as Root, since ordinary users can't select from this table.
+		ctx, "count-active-nodes", nil, sessiondata.InternalExecutorOverride{User: security.RootUserName()},
+		"SELECT count(*) FROM crdb_internal.kv_node_status")
+	if err != nil || row == nil {
+		return err
+	}
+	nNodes := int(tree.MustBeDInt(row[0]))
+	nSplits := preservedSplitsMultiple * nNodes
+
+	log.Infof(ctx, "making %d new truncate split points (%d * %d)", nSplits, preservedSplitsMultiple, nNodes)
+
+	// Re-split the new set of indexes along the same split points as the old
+	// indexes.
+	var b kv.Batch
+	tablePrefix := p.execCfg.Codec.TablePrefix(uint32(tableID))
+
+	// Fetch all of the range descriptors for this index.
+	ranges, err := kvclient.ScanMetaKVs(ctx, p.txn, roachpb.Span{
+		Key:    tablePrefix,
+		EndKey: tablePrefix.PrefixEnd(),
+	})
+	if err != nil {
+		return err
+	}
+
+	// Shift the range split points from the old keyspace into the new keyspace,
+	// filtering out any ranges that we can't translate.
+	var desc roachpb.RangeDescriptor
+	splitPoints := make([][]byte, 0, len(ranges))
+	for i := range ranges {
+		if err := ranges[i].ValueProto(&desc); err != nil {
+			return err
+		}
+		// For every range's start key, translate the start key into the keyspace
+		// of the replacement index. We'll split the replacement index along this
+		// same boundary later.
+		startKey := desc.StartKey
+
+		restOfKey, foundTable, foundIndex, err := p.execCfg.Codec.DecodeIndexPrefix(roachpb.Key(startKey))
+		if err != nil {
+			// If we get an error here, it means that either our key didn't contain
+			// an index ID (because it was the first range in a table) or the key
+			// didn't contain a table ID (because it's still the first range in the
+			// system that hasn't split off yet).
+			// In this case, we can't translate this range into the new keyspace,
+			// so we just have to continue along.
+			continue
+		}
+		if foundTable != uint32(tableID) {
+			// We found a split point that started somewhere else in the database,
+			// so we can't translate it to the new keyspace. Don't bother with this
+			// range.
+			continue
+		}
+		var newIndexID descpb.IndexID
+		var found bool
+		for k := range oldIndexIDs {
+			if oldIndexIDs[k] == descpb.IndexID(foundIndex) {
+				newIndexID = newIndexIDs[k]
+				found = true
+			}
+		}
+		if !found {
+			// We found a split point that is on an index that no longer exists.
+			// This can happen if the table was truncated more than once in a row,
+			// and there are old split points sitting around in the ranges. In this
+			// case, we can't translate the range into the new keyspace, so we don't
+			// bother with this range.
+			continue
+		}
+
+		newStartKey := append(p.execCfg.Codec.IndexPrefix(uint32(tableID), uint32(newIndexID)), restOfKey...)
+		splitPoints = append(splitPoints, newStartKey)
+	}
+
+	if len(splitPoints) == 0 {
+		// No split points to carry over. We can leave early.
+		return nil
+	}
+
+	// Finally, downsample the split points - choose just nSplits of them to keep.
+	step := float64(len(splitPoints)) / float64(nSplits)
+	if step < 1 {
+		step = 1
+	}
+	expirationTime := kvserver.SplitByLoadMergeDelay.Get(p.execCfg.SV()).Nanoseconds()
+	for i := 0; i < nSplits; i++ {
+		// Evenly space out the ranges that we select from the ranges that are
+		// returned.
+		idx := int(step * float64(i))
+		if idx >= len(splitPoints) {
+			break
+		}
+		sp := splitPoints[idx]
+
+		// Jitter the expiration time by 20% up or down from the default.
+		maxJitter := expirationTime / 5
+		jitter := rand.Int63n(maxJitter*2) - maxJitter
+		expirationTime += jitter
+
+		log.Infof(ctx, "truncate sending split request for key %s", sp)
+		b.AddRawRequest(&roachpb.AdminSplitRequest{
+			RequestHeader: roachpb.RequestHeader{
+				Key: sp,
+			},
+			SplitKey:       sp,
+			ExpirationTime: p.execCfg.Clock.Now().Add(expirationTime, 0),
+		})
+	}
+
+	if err = p.txn.DB().Run(ctx, &b); err != nil {
+		return err
+	}
+
+	// Now scatter the ranges, after we've finished splitting them.
+	b = kv.Batch{}
+	b.AddRawRequest(&roachpb.AdminScatterRequest{
+		// Scatter all of the data between the start key of the first new index, and
+		// the PrefixEnd of the last new index.
+		RequestHeader: roachpb.RequestHeader{
+			Key:    p.execCfg.Codec.IndexPrefix(uint32(tableID), uint32(newIndexIDs[0])),
+			EndKey: p.execCfg.Codec.IndexPrefix(uint32(tableID), uint32(newIndexIDs[len(newIndexIDs)-1])).PrefixEnd(),
+		},
+		RandomizeLeases: true,
+	})
+
+	return p.txn.DB().Run(ctx, &b)
 }
 
 // reassignInterleaveIndexReferences reassigns all index ID's present in


### PR DESCRIPTION
Backport:
  * 1/1 commits from "sql: TRUNCATE preserves split points of indexes" (#63043)
  * 1/1 commits from "sql: remove transactional meta scan in TRUNCATE" (#65371)

Please see individual PRs for details.

/cc @cockroachdb/release
