### PR TITLE
roachprod: added capability to set OS disk size for AWS, GCP

### DIFF
--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -1857,6 +1857,10 @@ func main() {
 			`Ignored if --local-ssd=false is specified.`)
 	createCmd.Flags().IntVarP(&numNodes,
 		"nodes", "n", 4, "Total number of nodes, distributed across all clouds")
+
+	createCmd.Flags().IntVarP(&createVMOpts.OsVolumeSize,
+		"os-volume-size", "", 10, "OS disk volume size in GB")
+
 	createCmd.Flags().StringSliceVarP(&createVMOpts.VMProviders,
 		"clouds", "c", []string{gce.ProviderName},
 		fmt.Sprintf("The cloud provider(s) to use when creating new vm instances: %s", vm.AllProviderNames()))

--- a/pkg/cmd/roachprod/vm/azure/azure.go
+++ b/pkg/cmd/roachprod/vm/azure/azure.go
@@ -498,6 +498,11 @@ func (p *Provider) createVM(
 	tags[tagLifetime] = to.StringPtr(opts.Lifetime.String())
 	tags[tagRoachprod] = to.StringPtr("true")
 
+	osVolumeSize := int32(opts.OsVolumeSize)
+	if osVolumeSize < 32 {
+		log.Print("WARNING: increasing the OS volume size to minimally allowed 32GB")
+		osVolumeSize = 32
+	}
 	// Derived from
 	// https://github.com/Azure-Samples/azure-sdk-for-go-samples/blob/79e3f3af791c3873d810efe094f9d61e93a6ccaa/compute/vm.go#L41
 	vm = compute.VirtualMachine{
@@ -520,6 +525,7 @@ func (p *Provider) createVM(
 					ManagedDisk: &compute.ManagedDiskParameters{
 						StorageAccountType: compute.StorageAccountTypesStandardSSDLRS,
 					},
+					DiskSizeGB: to.Int32Ptr(osVolumeSize),
 				},
 			},
 			OsProfile: &compute.OSProfile{

--- a/pkg/cmd/roachprod/vm/gce/gcloud.go
+++ b/pkg/cmd/roachprod/vm/gce/gcloud.go
@@ -277,7 +277,7 @@ func (o *providerOpts) ConfigureCreateFlags(flags *pflag.FlagSet) {
 		"Image to use to create the vm, "+
 			"use `gcloud compute images list --filter=\"family=ubuntu-2004-lts\"` to list available images")
 
-	flags.IntVar(&o.SSDCount, ProviderName+"-local-ssd-count", 1,
+	flags.IntVar(&o.SSDCount, ProviderName+"-local-ssd-count", 0,
 		"Number of local SSDs to create, only used if local-ssd=true")
 	flags.StringVar(&o.PDVolumeType, ProviderName+"-pd-volume-type", "pd-ssd",
 		"Type of the persistent disk volume, only used if local-ssd=false")
@@ -385,7 +385,6 @@ func (p *Provider) Create(names []string, opts vm.CreateOpts) error {
 		"--scopes", "default,storage-rw",
 		"--image", p.opts.Image,
 		"--image-project", "ubuntu-os-cloud",
-		"--boot-disk-size", "10",
 		"--boot-disk-type", "pd-ssd",
 	}
 
@@ -405,7 +404,7 @@ func (p *Provider) Create(names []string, opts vm.CreateOpts) error {
 		// come in different sizes.
 		// See: https://cloud.google.com/compute/docs/disks/
 		n2MachineTypes := regexp.MustCompile("^[cn]2-.+-16")
-		if n2MachineTypes.MatchString(p.opts.MachineType) && p.opts.SSDCount < 2 {
+		if n2MachineTypes.MatchString(p.opts.MachineType) && p.opts.SSDCount == 1 {
 			fmt.Fprint(os.Stderr, "WARNING: SSD count must be at least 2 for n2 and c2 machine types with 16vCPU. Setting --gce-local-ssd-count to 2.\n")
 			p.opts.SSDCount = 2
 		}
@@ -444,7 +443,7 @@ func (p *Provider) Create(names []string, opts vm.CreateOpts) error {
 
 	args = append(args, "--metadata-from-file", fmt.Sprintf("startup-script=%s", filename))
 	args = append(args, "--project", project)
-
+	args = append(args, fmt.Sprintf("--boot-disk-size=%dGB", opts.OsVolumeSize))
 	var g errgroup.Group
 
 	nodeZones := vm.ZonePlacement(len(zones), len(names))

--- a/pkg/cmd/roachprod/vm/vm.go
+++ b/pkg/cmd/roachprod/vm/vm.go
@@ -140,6 +140,7 @@ type CreateOpts struct {
 		// mounting the SSD. Ignored if UseLocalSSD is not set.
 		NoExt4Barrier bool
 	}
+	OsVolumeSize int
 }
 
 // MultipleProjectsOption is used to specify whether a command accepts multiple


### PR DESCRIPTION
Added capability in `roachprod` to set the OS/root disk volume size in GB for AWS and GCP.

The global flag is `--os-volume-size`. 

At times you might want to install additional software, or run some simple tests that do not require additional disks.

Usage example:

```
bin/roachprod create fabio-test -n=1 -c aws|gce --os-volume-size=100
```
