### PR TITLE
release-20.2: sql: remove transactional meta scan in TRUNCATE

### DIFF
--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -458,7 +458,8 @@ func (p *planner) dropIndexByName(
 			// the meta ranges directly.
 			if p.ExecCfg().Codec.ForSystemTenant() {
 				span := tableDesc.IndexSpan(p.ExecCfg().Codec, idxEntry.ID)
-				ranges, err := ScanMetaKVs(ctx, p.txn, span)
+				txn := p.ExecCfg().DB.NewTxn(ctx, "scan-ranges-for-index-drop")
+				ranges, err := ScanMetaKVs(ctx, txn, span)
 				if err != nil {
 					return err
 				}

--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -372,7 +372,7 @@ func (p *planner) unsplitRangesForTable(ctx context.Context, tableDesc *tabledes
 	// allowed to scan the meta ranges directly.
 	if p.ExecCfg().Codec.ForSystemTenant() {
 		span := tableDesc.TableSpan(p.ExecCfg().Codec)
-		ranges, err := ScanMetaKVs(ctx, p.txn, span)
+		ranges, err := ScanMetaKVs(ctx, p.execCfg.DB.NewTxn(ctx, "unsplit-ranges-for-table"), span)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/pgwire/testdata/pgtest/notice
+++ b/pkg/sql/pgwire/testdata/pgtest/notice
@@ -55,7 +55,7 @@ Query {"String": "DROP INDEX t_x_idx"}
 until crdb_only
 CommandComplete
 ----
-{"Severity":"NOTICE","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":520,"Routine":"dropIndexByName","UnknownFields":null}
+{"Severity":"NOTICE","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":521,"Routine":"dropIndexByName","UnknownFields":null}
 {"Type":"CommandComplete","CommandTag":"DROP INDEX"}
 
 until noncrdb_only

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -517,7 +517,7 @@ func (p *planner) copySplitPointsToNewIndexes(
 	tablePrefix := p.execCfg.Codec.TablePrefix(uint32(tableID))
 
 	// Fetch all of the range descriptors for this index.
-	ranges, err := ScanMetaKVs(ctx, p.txn, roachpb.Span{
+	ranges, err := ScanMetaKVs(ctx, p.execCfg.DB.NewTxn(ctx, "truncate-copy-splits"), roachpb.Span{
 		Key:    tablePrefix,
 		EndKey: tablePrefix.PrefixEnd(),
 	})


### PR DESCRIPTION
Backport 1/1 commits from #65371.

/cc @cockroachdb/release

---

Previously, TRUNCATE transactionally scanned the meta range to find
ranges to unsplit. This was not necessary, and created unwanted
contention with TRUNCATE's new behavior of preserving splits.

Release note (bug fix): prevent contention during TRUNCATE operations
