### PR TITLE
bazel: bump size of `//pkg/sql:sql_test`

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -402,7 +402,7 @@ go_library(
 
 go_test(
     name = "sql_test",
-    size = "large",
+    size = "enormous",
     srcs = [
         "admin_audit_log_test.go",
         "alter_column_type_test.go",


### PR DESCRIPTION
This has been routinely timing out in CI.

Release note: None