### PR TITLE
wip: sql: Opportunistically ignore USING clause for ALTER COLUMN TYPE

### DIFF
--- a/pkg/sql/sem/tree/alter_table.go
+++ b/pkg/sql/sem/tree/alter_table.go
@@ -252,6 +252,11 @@ func (node *AlterTableAlterColumnType) GetColumn() Name {
 	return node.Column
 }
 
+// GetFullyQualifiedColumn
+func (node *AlterTableAlterColumnType) GetFullyQualifiedColumn() Name {
+	return node.Column
+}
+
 // AlterTableAlterPrimaryKey represents an ALTER TABLE ALTER PRIMARY KEY command.
 type AlterTableAlterPrimaryKey struct {
 	Columns    IndexElemList

--- a/pkg/sql/sem/tree/table_name.go
+++ b/pkg/sql/sem/tree/table_name.go
@@ -65,6 +65,22 @@ func (t *TableName) Equals(other *TableName) bool {
 	return *t == *other
 }
 
+// EqualsIgnoreExplicit returns true if the two table names matches,
+// the CatalogName and SchemaNames fields are only compared if
+// ExplicitSchema and ExplicitCatalog are set for both TableNames.
+func (t *TableName) EqualsIgnoreExplicit(other *TableName) bool {
+	if t.ExplicitCatalog && other.ExplicitCatalog &&
+		t.ExplicitSchema && other.ExplicitSchema {
+		return t.Equals(other)
+	} else if t.ExplicitCatalog && other.ExplicitCatalog {
+		return t.Catalog() == other.Catalog() && t.Table() == other.Table()
+	} else if t.ExplicitSchema && other.ExplicitSchema {
+		return t.Schema() == other.Schema() && t.Table() == other.Table()
+	}
+
+	return t.Table() == other.Table()
+}
+
 // tableExpr implements the TableExpr interface.
 func (*TableName) tableExpr() {}
 


### PR DESCRIPTION
If the USING clause for ALTER TABLE t ALTER COLUMN x TYPE t USING EXPR
follows the case where EXPR exactly matches a cast t::x, then we
can ignore the USING clause allowing us to possibly no-op in some cases.

Release note: None

Resolves #65853