### PR TITLE
monitoring: add docker compose dev env for grafana dashboards

### DIFF
--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,0 +1,50 @@
+# Monitoring
+
+This directory contains various sample configurations related to third party monitoring in CockroachDB.
+
+## Developing Grafana Dashboards
+
+### Bootstrap
+
+Inside the `demo` directory lives a docker compose file used to bootstrap a three node cockroachdb cluster hooked up to
+an instance of prometheus and grafana. This will allow for spinning up a quick dev environment for performing manual QA
+or making any modifications on the grafana dashboards.
+
+To get started, run this command to launch the containers:  
+`$ cd demo && docker compose up`
+
+The output of `$ docker ps` should resemble what is shown below:
+
+```bash
+CONTAINER ID   IMAGE          COMMAND                  CREATED          STATUS         PORTS                                                                                      NAMES
+0f0f35180a8b   bc8c9ea5532e   "/run.sh"                18 minutes ago   Up 5 minutes   0.0.0.0:3000->3000/tcp, :::3000->3000/tcp                                                  demo_grafana_1
+aba0ebd929ef   49cce1dff0e5   "/bin/prometheus --c…"   18 minutes ago   Up 5 minutes   0.0.0.0:9090->9090/tcp, :::9090->9090/tcp                                                  demo_prometheus_1
+043bc21a74a0   bb9ac5c2ae52   "/cockroach/cockroac…"   18 minutes ago   Up 5 minutes   0.0.0.0:8080->8080/tcp, :::8080->8080/tcp, 0.0.0.0:26257->26257/tcp, :::26257->26257/tcp   demo_roach1_1
+15c6e9c2167e   bb9ac5c2ae52   "/cockroach/cockroac…"   18 minutes ago   Up 5 minutes   8080/tcp, 26257/tcp                                                                        demo_roach2_1
+0adb9e3b2c50   bb9ac5c2ae52   "/cockroach/cockroac…"   18 minutes ago   Up 5 minutes   8080/tcp, 26257/tcp                                                                        demo_roach3_1
+```
+
+Now that each container is up and running, we can access the web interface of each service.
+
+- `localhost:8080`: cockroachdb console
+- `localhost:9090`: prometheus web ui
+- `localhost:3000`: grafana (dashboards located at `/dashboards`)
+
+In addition, `localhost:26257` is accessible for sql connections targeting the first node.
+
+### Making dashboard changes
+
+Dashboard modifications happen in the Grafana web interface. To save changes, click on the "Save dashboard" icon in the
+top right menu. Then proceed to export the dashboard as a JSON file by clicking the "Save JSON to file" button. Lastly,
+move this file to the `grafana-dashboards` folder.
+
+### Running a workload
+
+Workloads can be used to generate activity and provide time series data for visualization. For example:  
+`$ cockroach workload init movr`  
+`$ cockroach workload run movr`
+
+### Cleanup
+
+`CTRL+C` will stop the running containers.  
+`$ docker compose down` will remove all data from previous runs.

--- a/monitoring/demo/config/grafana/provisioning/dashboards/cockroachdb.yaml
+++ b/monitoring/demo/config/grafana/provisioning/dashboards/cockroachdb.yaml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+providers:
+  - name: 'cockroachdb'
+    orgId: 1
+    folder: ''
+    folderUid: ''
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    allowUiUpdates: false
+    options:
+      path: /var/lib/grafana/dashboards

--- a/monitoring/demo/config/grafana/provisioning/datasources/prometheus.yaml
+++ b/monitoring/demo/config/grafana/provisioning/datasources/prometheus.yaml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    httpMethod: POST
+    url: http://prometheus:9090
+    isDefault: true

--- a/monitoring/demo/config/prometheus.yml
+++ b/monitoring/demo/config/prometheus.yml
@@ -1,0 +1,15 @@
+global:
+  scrape_interval: 10s
+  evaluation_interval: 10s
+
+scrape_configs:
+  - job_name: 'cockroachdb'
+    metrics_path: '/_status/vars'
+    scheme: 'http'
+    tls_config:
+      insecure_skip_verify: true
+
+    static_configs:
+    - targets: ['roach1:8080', 'roach2:8080', 'roach3:8080']
+      labels:
+        cluster: 'my-cockroachdb-cluster'

--- a/monitoring/demo/config/roach-init.sh
+++ b/monitoring/demo/config/roach-init.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# curl health endpoint
+while ! health=$(curl -s "http://roach1:8080/health?ready=1"); do
+  sleep 0.1
+done
+
+# check if health check shows uninitialized cluster
+error='"error": "node is waiting for cluster initialization"'
+if [[ $health =~ $error ]]; then
+  ./cockroach init --insecure --host=roach1:26257
+else
+  echo "Cluster is up!"
+fi

--- a/monitoring/demo/docker-compose.yaml
+++ b/monitoring/demo/docker-compose.yaml
@@ -1,0 +1,38 @@
+version: "3.9"
+services:
+  grafana:
+    image: grafana/grafana
+    environment:
+      - "GF_AUTH_ANONYMOUS_ENABLED=true"
+      - "GF_AUTH_ANONYMOUS_ORG_ROLE=Admin"
+      - "GF_AUTH_ANONYMOUS_HIDE_VERSION=true"
+    volumes:
+      # Mount provisioning configuration
+      - "./config/grafana/provisioning:/etc/grafana/provisioning"
+      # Mount dashboards
+      - "../grafana-dashboards:/var/lib/grafana/dashboards"
+    ports: [ "3000:3000" ]
+  prometheus:
+    image: prom/prometheus
+    # Mount prometheus configuration
+    volumes: [ "./config/prometheus.yml:/etc/prometheus/prometheus.yml" ]
+    ports: [ "9090:9090" ]
+  roach1:
+    hostname: roach1
+    image: cockroachdb/cockroach
+    command: [ "start", "--insecure", "--accept-sql-without-tls", "--join=roach1,roach2,roach3" ]
+    ports: [ "8080:8080", "26257:26257" ]
+  roach2:
+    hostname: roach2
+    image: cockroachdb/cockroach
+    command: [ "start", "--insecure", "--accept-sql-without-tls", "--join=roach1,roach2,roach3" ]
+  roach3:
+    hostname: roach3
+    image: cockroachdb/cockroach
+    command: [ "start", "--insecure",  "--accept-sql-without-tls", "--join=roach1,roach2,roach3" ]
+  # Initialize the cluster
+  roach-init:
+    image: cockroachdb/cockroach
+    depends_on: [ roach1 ]
+    volumes: [ "./config/roach-init.sh:/cockroach/init.sh" ]
+    command: [ "shell", "/cockroach/init.sh" ]

--- a/monitoring/grafana-dashboards/replicas.json
+++ b/monitoring/grafana-dashboards/replicas.json
@@ -1,14 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_PROMETHEUS",
-      "label": "Prometheus",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
   "__requires": [
     {
       "type": "grafana",
@@ -1698,6 +1688,16 @@
   ],
   "templating": {
     "list": [
+      {
+        "hide": 0,
+        "label": "datasource",
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
       {
         "allValue": null,
         "current": {},

--- a/monitoring/grafana-dashboards/runtime.json
+++ b/monitoring/grafana-dashboards/runtime.json
@@ -1,14 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_PROMETHEUS",
-      "label": "Prometheus",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
   "__requires": [
     {
       "type": "grafana",
@@ -1847,6 +1837,16 @@
   ],
   "templating": {
     "list": [
+      {
+        "hide": 0,
+        "label": "datasource",
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
       {
         "allValue": null,
         "current": {},

--- a/monitoring/grafana-dashboards/sql.json
+++ b/monitoring/grafana-dashboards/sql.json
@@ -1,14 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_PROMETHEUS",
-      "label": "Prometheus",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
   "__requires": [
     {
       "type": "grafana",
@@ -1131,6 +1121,16 @@
   ],
   "templating": {
     "list": [
+      {
+        "hide": 0,
+        "label": "datasource",
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
       {
         "allValue": null,
         "current": {},

--- a/monitoring/grafana-dashboards/storage.json
+++ b/monitoring/grafana-dashboards/storage.json
@@ -1,14 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_PROMETHEUS",
-      "label": "Prometheus",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
   "__requires": [
     {
       "type": "grafana",
@@ -1545,6 +1535,16 @@
   ],
   "templating": {
     "list": [
+      {
+        "hide": 0,
+        "label": "datasource",
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
       {
         "allValue": null,
         "current": {},


### PR DESCRIPTION
This PR adds in a docker compose file used to bootstrap a three node
cockroachdb cluster hooked onto a prometheus instance and a grafana instance.
This is intended to be used for spinning up a quick dev environment for
performing manual QA on the grafana dashboards.

This PR also tweaks the existing grafana dashboards such that they
are compatible with dashboard provisioning in grafana.

See:
grafana/grafana#10786 (comment)

Release note: None