### PR TITLE
cli: clean up temp directories from other stores

### DIFF
--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -177,16 +177,6 @@ func initTempStorageConfig(
 		recordPath = filepath.Join(useStore.Path, server.TempDirsRecordFilename)
 	}
 
-	var err error
-	// Need to first clean up any abandoned temporary directories from
-	// the temporary directory record file before creating any new
-	// temporary directories in case the disk is completely full.
-	if recordPath != "" {
-		if err = storage.CleanupTempDirs(recordPath); err != nil {
-			return base.TempStorageConfig{}, errors.Wrap(err, "could not cleanup temporary directories from record file")
-		}
-	}
-
 	// The temp store size can depend on the location of the first regular store
 	// (if it's expressed as a percentage), so we resolve that flag here.
 	var tempStorePercentageResolver percentResolverFunc
@@ -194,9 +184,10 @@ func initTempStorageConfig(
 		dir := useStore.Path
 		// Create the store dir, if it doesn't exist. The dir is required to exist
 		// by diskPercentResolverFactory.
-		if err = os.MkdirAll(dir, 0755); err != nil {
+		if err := os.MkdirAll(dir, 0755); err != nil {
 			return base.TempStorageConfig{}, errors.Wrapf(err, "failed to create dir for first store: %s", dir)
 		}
+		var err error
 		tempStorePercentageResolver, err = diskPercentResolverFactory(dir)
 		if err != nil {
 			return base.TempStorageConfig{}, errors.Wrapf(err, "failed to create resolver for: %s", dir)
@@ -205,7 +196,7 @@ func initTempStorageConfig(
 		tempStorePercentageResolver = memoryPercentResolver
 	}
 	var tempStorageMaxSizeBytes int64
-	if err = diskTempStorageSizeValue.Resolve(
+	if err := diskTempStorageSizeValue.Resolve(
 		&tempStorageMaxSizeBytes, tempStorePercentageResolver,
 	); err != nil {
 		return base.TempStorageConfig{}, err
@@ -238,14 +229,17 @@ func initTempStorageConfig(
 		tempDir = useStore.Path
 	}
 	// Create the temporary subdirectory for the temp engine.
-	if tempStorageConfig.Path, err = storage.CreateTempDir(tempDir, server.TempDirPrefix, stopper); err != nil {
-		return base.TempStorageConfig{}, errors.Wrap(err, "could not create temporary directory for temp storage")
+	{
+		var err error
+		if tempStorageConfig.Path, err = storage.CreateTempDir(tempDir, server.TempDirPrefix, stopper); err != nil {
+			return base.TempStorageConfig{}, errors.Wrap(err, "could not create temporary directory for temp storage")
+		}
 	}
 
 	// We record the new temporary directory in the record file (if it
 	// exists) for cleanup in case the node crashes.
 	if recordPath != "" {
-		if err = storage.RecordTempDir(recordPath, tempStorageConfig.Path); err != nil {
+		if err := storage.RecordTempDir(recordPath, tempStorageConfig.Path); err != nil {
 			return base.TempStorageConfig{}, errors.Wrapf(
 				err,
 				"could not record temporary directory path to record file: %s",
@@ -409,10 +403,24 @@ func runStart(cmd *cobra.Command, args []string, startSingleNode bool) (returnEr
 	// storage to be encrypted too. To achieve this, we use
 	// the first encrypted store as temp dir target, if any.
 	// If we can't find one, we use the first StoreSpec in the list.
+	//
+	// While we look, we also clean up any abandoned temporary directories. We
+	// don't know which store spec was used previously—and it may change if
+	// encryption gets enabled after the fact—so we check each store.
 	var specIdx = 0
 	for i, spec := range serverCfg.Stores.Specs {
 		if spec.IsEncrypted() {
+			// TODO(jackson): One store's EncryptionOptions may say to encrypt
+			// with a real key, while another store's say to use key=plain.
+			// This provides no guarantee that we'll use the encrypted one's.
 			specIdx = i
+		}
+		if spec.InMemory {
+			continue
+		}
+		recordPath := filepath.Join(spec.Path, server.TempDirsRecordFilename)
+		if err := storage.CleanupTempDirs(recordPath); err != nil {
+			return errors.Wrap(err, "could not cleanup temporary directories from record file")
 		}
 	}
 


### PR DESCRIPTION
I stumbled upon this while reading the temporary directories code. If a
node has multiple stores, an arbitrary encrypted store is used. If no
store uses encryption, the first store is used.

Since encryption can change on startup, this meant that we could leave
temporary directories on a previous store if we were no longer using the
store for temporary storage. This commit ensures we'll clean up any
temporary directories across all stores during start.

Release note: None