### PR TITLE
release-21.1: multiregionccl: fix bazel build

### DIFF
--- a/pkg/ccl/multiregionccl/BUILD.bazel
+++ b/pkg/ccl/multiregionccl/BUILD.bazel
@@ -28,9 +28,9 @@ go_test(
         "regional_by_row_test.go",
         "show_test.go",
     ],
-    tags = ["broken_in_bazel"],
     deps = [
         "//pkg/base",
+        "//pkg/ccl",
         "//pkg/ccl/multiregionccl/multiregionccltestutils",
         "//pkg/ccl/partitionccl",
         "//pkg/ccl/testutilsccl",

--- a/pkg/ccl/multiregionccl/multiregion_test.go
+++ b/pkg/ccl/multiregionccl/multiregion_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	// Blank import ccl so that we have all CCL features enabled.
+	_ "github.com/cockroachdb/cockroach/pkg/ccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/multiregionccl/multiregionccltestutils"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"


### PR DESCRIPTION
Backport 1/1 commits from #62036.

/cc @cockroachdb/release

---

Needed CCL to work, so imported it.

Resolves https://github.com/cockroachdb/cockroach/issues/61921

Release note: None
