### PR TITLE
docgen: fix collated string links in auto-gen functions doc

### DIFF
--- a/docs/generated/sql/operators.md
+++ b/docs/generated/sql/operators.md
@@ -156,7 +156,7 @@
 <tr><td>box2d <code><</code> box2d</td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="bytes.html">bytes</a> <code><</code> <a href="bytes.html">bytes</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="bytes.html">bytes[]</a> <code><</code> <a href="bytes.html">bytes[]</a></td><td><a href="bool.html">bool</a></td></tr>
-<tr><td><a href="collatedstring.html">collatedstring</a> <code><</code> <a href="collatedstring.html">collatedstring</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="collate.html">collatedstring</a> <code><</code> <a href="collate.html">collatedstring</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="date.html">date</a> <code><</code> <a href="date.html">date</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="date.html">date</a> <code><</code> <a href="timestamp.html">timestamp</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="date.html">date</a> <code><</code> <a href="timestamp.html">timestamptz</a></td><td><a href="bool.html">bool</a></td></tr>
@@ -219,7 +219,7 @@
 <tr><td>box2d <code><=</code> box2d</td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="bytes.html">bytes</a> <code><=</code> <a href="bytes.html">bytes</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="bytes.html">bytes[]</a> <code><=</code> <a href="bytes.html">bytes[]</a></td><td><a href="bool.html">bool</a></td></tr>
-<tr><td><a href="collatedstring.html">collatedstring</a> <code><=</code> <a href="collatedstring.html">collatedstring</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="collate.html">collatedstring</a> <code><=</code> <a href="collate.html">collatedstring</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="date.html">date</a> <code><=</code> <a href="date.html">date</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="date.html">date</a> <code><=</code> <a href="timestamp.html">timestamp</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="date.html">date</a> <code><=</code> <a href="timestamp.html">timestamptz</a></td><td><a href="bool.html">bool</a></td></tr>
@@ -281,7 +281,7 @@
 <tr><td>box2d <code>=</code> box2d</td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="bytes.html">bytes</a> <code>=</code> <a href="bytes.html">bytes</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="bytes.html">bytes[]</a> <code>=</code> <a href="bytes.html">bytes[]</a></td><td><a href="bool.html">bool</a></td></tr>
-<tr><td><a href="collatedstring.html">collatedstring</a> <code>=</code> <a href="collatedstring.html">collatedstring</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="collate.html">collatedstring</a> <code>=</code> <a href="collate.html">collatedstring</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="date.html">date</a> <code>=</code> <a href="date.html">date</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="date.html">date</a> <code>=</code> <a href="timestamp.html">timestamp</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="date.html">date</a> <code>=</code> <a href="timestamp.html">timestamptz</a></td><td><a href="bool.html">bool</a></td></tr>
@@ -368,7 +368,7 @@
 <tr><td><a href="bool.html">bool</a> <code>IN</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
 <tr><td>box2d <code>IN</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="bytes.html">bytes</a> <code>IN</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
-<tr><td><a href="collatedstring.html">collatedstring</a> <code>IN</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="collate.html">collatedstring</a> <code>IN</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="date.html">date</a> <code>IN</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="decimal.html">decimal</a> <code>IN</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="float.html">float</a> <code>IN</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
@@ -397,7 +397,7 @@
 <tr><td>box2d <code>IS NOT DISTINCT FROM</code> box2d</td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="bytes.html">bytes</a> <code>IS NOT DISTINCT FROM</code> <a href="bytes.html">bytes</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="bytes.html">bytes[]</a> <code>IS NOT DISTINCT FROM</code> <a href="bytes.html">bytes[]</a></td><td><a href="bool.html">bool</a></td></tr>
-<tr><td><a href="collatedstring.html">collatedstring</a> <code>IS NOT DISTINCT FROM</code> <a href="collatedstring.html">collatedstring</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="collate.html">collatedstring</a> <code>IS NOT DISTINCT FROM</code> <a href="collate.html">collatedstring</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="date.html">date</a> <code>IS NOT DISTINCT FROM</code> <a href="date.html">date</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="date.html">date</a> <code>IS NOT DISTINCT FROM</code> <a href="timestamp.html">timestamp</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="date.html">date</a> <code>IS NOT DISTINCT FROM</code> <a href="timestamp.html">timestamptz</a></td><td><a href="bool.html">bool</a></td></tr>

--- a/pkg/cmd/docgen/funcs.go
+++ b/pkg/cmd/docgen/funcs.go
@@ -268,12 +268,14 @@ func linkTypeName(s string) string {
 	switch s {
 	case "timestamptz":
 		s = "timestamp"
+	case "collatedstring":
+		s = "collate"
 	}
 	s = strings.TrimSuffix(s, "[]")
 	s = strings.TrimSuffix(s, "*")
 	switch s {
 	case "int", "decimal", "float", "bool", "date", "timestamp", "interval", "string", "bytes",
-		"inet", "uuid", "collatedstring", "time":
+		"inet", "uuid", "collate", "time":
 		s = fmt.Sprintf("<a href=\"%s.html\">%s</a>", s, name)
 	}
 	return s


### PR DESCRIPTION
Previously, many instances of collatedstring in the auto-generated
functions doc would try to reach collatedstring.html. This isn't
a page in our docs.

To address this, this patch alters the collatedstring links
to point to collate.html, which is a page in our docs.

Release note: None