### PR TITLE
storage: use Pebble incremental stats for disk usage calculation

### DIFF
--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -924,7 +924,7 @@ func (p *Pebble) Attrs() roachpb.Attributes {
 
 // Capacity implements the Engine interface.
 func (p *Pebble) Capacity() (roachpb.StoreCapacity, error) {
-	return computeCapacity(p.path, p.maxSize)
+	return computeCapacity(p.db.Metrics(), p.path, p.maxSize, p.auxDir)
 }
 
 // Flush implements the Engine interface.


### PR DESCRIPTION
When calculating capacity, use Pebble's incrementally computed
statistics rather than walking the entire store directory.

Fix #56620.

Release note: None