### PR TITLE
pgwire: remove some allocations when working with strings

### DIFF
--- a/pkg/cli/sql_util.go
+++ b/pkg/cli/sql_util.go
@@ -1202,8 +1202,9 @@ func formatVal(
 		// not interpret the bytes and for us here to print that as-is, so
 		// that we can let the user see and control the result using
 		// `bytea_output`.
-		return lex.EncodeByteArrayToRawBytes(string(t),
-			sessiondatapb.BytesEncodeEscape, false /* skipHexPrefix */)
+		return string(lex.EncodeByteArrayToRawBytes(
+			t, sessiondatapb.BytesEncodeEscape, false /* skipHexPrefix */),
+		)
 
 	case time.Time:
 		tfmt, ok := timeOutputFormats[colType]

--- a/pkg/sql/lex/encode_test.go
+++ b/pkg/sql/lex/encode_test.go
@@ -135,7 +135,7 @@ func TestByteArrayDecoding(t *testing.T) {
 			if s.auto {
 				dec, err = lex.DecodeRawBytesToByteArrayAuto([]byte(s.in))
 			} else {
-				dec, err = lex.DecodeRawBytesToByteArray(s.in, s.inFmt)
+				dec, err = lex.DecodeRawBytesToByteArray([]byte(s.in), s.inFmt)
 			}
 			if s.err != "" {
 				if err == nil {
@@ -179,17 +179,17 @@ func TestByteArrayEncoding(t *testing.T) {
 				sessiondatapb.BytesEncodeBase64,
 			} {
 				t.Run(format.String(), func(t *testing.T) {
-					enc := lex.EncodeByteArrayToRawBytes(s.in, format, false)
+					enc := lex.EncodeByteArrayToRawBytes([]byte(s.in), format, false)
 
 					expEnc := s.out[int(format)]
-					if enc != expEnc {
+					if string(enc) != expEnc {
 						t.Fatalf("encoded %q, expected %q", enc, expEnc)
 					}
 
 					if format == sessiondatapb.BytesEncodeHex {
 						// Check that the \x also can be skipped.
-						enc2 := lex.EncodeByteArrayToRawBytes(s.in, format, true)
-						if enc[2:] != enc2 {
+						enc2 := lex.EncodeByteArrayToRawBytes([]byte(s.in), format, true)
+						if string(enc[2:]) != string(enc2) {
 							t.Fatal("can't skip prefix")
 						}
 						enc = enc[2:]

--- a/pkg/sql/pgwire/types.go
+++ b/pkg/sql/pgwire/types.go
@@ -112,8 +112,8 @@ func writeTextUUID(b *writeBuffer, v uuid.UUID) {
 	b.write(s)
 }
 
-func writeTextString(b *writeBuffer, v string, t *types.T) {
-	b.writeLengthPrefixedString(tree.ResolveBlankPaddedChar(v, t))
+func writeTextString(b *writeBuffer, v []byte, t *types.T) {
+	b.writeLengthPrefixedByteSlice(tree.ResolveBlankPaddedChar(v, t))
 }
 
 func writeTextTimestamp(b *writeBuffer, v time.Time) {
@@ -190,10 +190,10 @@ func writeTextDatumNotNull(
 		b.writeLengthPrefixedString(v.IPAddr.String())
 
 	case *tree.DString:
-		writeTextString(b, string(*v), t)
+		writeTextString(b, []byte(*v), t)
 
 	case *tree.DCollatedString:
-		b.writeLengthPrefixedString(tree.ResolveBlankPaddedChar(v.Contents, t))
+		b.writeLengthPrefixedByteSlice(tree.ResolveBlankPaddedChar([]byte(v.Contents), t))
 
 	case *tree.DDate:
 		b.textFormatter.FormatNode(v)
@@ -316,7 +316,7 @@ func (b *writeBuffer) writeTextColumnarElement(
 		writeTextUUID(b, id)
 
 	case types.StringFamily:
-		writeTextString(b, string(vec.Bytes().Get(idx)), vec.Type())
+		writeTextString(b, vec.Bytes().Get(idx), vec.Type())
 
 	case types.DateFamily:
 		tree.FormatDate(pgdate.MakeCompatibleDateFromDisk(vec.Int64().Get(idx)), b.textFormatter)
@@ -474,8 +474,8 @@ func writeBinaryBytes(b *writeBuffer, v []byte) {
 	b.write(v)
 }
 
-func writeBinaryString(b *writeBuffer, v string, t *types.T) {
-	b.writeLengthPrefixedString(tree.ResolveBlankPaddedChar(v, t))
+func writeBinaryString(b *writeBuffer, v []byte, t *types.T) {
+	b.writeLengthPrefixedByteSlice(tree.ResolveBlankPaddedChar(v, t))
 }
 
 func writeBinaryTimestamp(b *writeBuffer, v time.Time) {
@@ -621,10 +621,10 @@ func writeBinaryDatumNotNull(
 		b.writeLengthPrefixedString(v.LogicalRep)
 
 	case *tree.DString:
-		writeBinaryString(b, string(*v), t)
+		writeBinaryString(b, []byte(*v), t)
 
 	case *tree.DCollatedString:
-		b.writeLengthPrefixedString(tree.ResolveBlankPaddedChar(v.Contents, t))
+		b.writeLengthPrefixedByteSlice(tree.ResolveBlankPaddedChar([]byte(v.Contents), t))
 
 	case *tree.DTimestamp:
 		writeBinaryTimestamp(b, v.Time)
@@ -751,7 +751,7 @@ func (b *writeBuffer) writeBinaryColumnarElement(
 		writeBinaryBytes(b, vec.Bytes().Get(idx))
 
 	case types.StringFamily:
-		writeBinaryString(b, string(vec.Bytes().Get(idx)), vec.Type())
+		writeBinaryString(b, vec.Bytes().Get(idx), vec.Type())
 
 	case types.TimestampFamily:
 		writeBinaryTimestamp(b, vec.Timestamp().Get(idx))

--- a/pkg/sql/pgwire/types.go
+++ b/pkg/sql/pgwire/types.go
@@ -98,10 +98,10 @@ func writeTextFloat64(b *writeBuffer, fl float64, conv sessiondatapb.DataConvers
 	b.write(s)
 }
 
-func writeTextBytes(b *writeBuffer, v string, conv sessiondatapb.DataConversionConfig) {
+func writeTextBytes(b *writeBuffer, v []byte, conv sessiondatapb.DataConversionConfig) {
 	result := lex.EncodeByteArrayToRawBytes(v, conv.BytesEncodeFormat, false /* skipHexPrefix */)
 	b.putInt32(int32(len(result)))
-	b.write([]byte(result))
+	b.write(result)
 }
 
 func writeTextUUID(b *writeBuffer, v uuid.UUID) {
@@ -181,7 +181,7 @@ func writeTextDatumNotNull(
 		b.writeLengthPrefixedDatum(v)
 
 	case *tree.DBytes:
-		writeTextBytes(b, string(*v), conv)
+		writeTextBytes(b, []byte(*v), conv)
 
 	case *tree.DUuid:
 		writeTextUUID(b, v.UUID)
@@ -306,7 +306,7 @@ func (b *writeBuffer) writeTextColumnarElement(
 		b.writeLengthPrefixedString(d.String())
 
 	case types.BytesFamily:
-		writeTextBytes(b, string(vec.Bytes().Get(idx)), conv)
+		writeTextBytes(b, vec.Bytes().Get(idx), conv)
 
 	case types.UuidFamily:
 		id, err := uuid.FromBytes(vec.Bytes().Get(idx))

--- a/pkg/sql/pgwire/write_buffer.go
+++ b/pkg/sql/pgwire/write_buffer.go
@@ -108,6 +108,13 @@ func (b *writeBuffer) writeLengthPrefixedBuffer(buf *bytes.Buffer) {
 	}
 }
 
+// writeLengthPrefixedByteSlice writes a length-prefixed []byte. The length is
+// encoded as an int32.
+func (b *writeBuffer) writeLengthPrefixedByteSlice(v []byte) {
+	b.putInt32(int32(len(v)))
+	b.write(v)
+}
+
 // writeLengthPrefixedString writes a length-prefixed string. The
 // length is encoded as an int32.
 func (b *writeBuffer) writeLengthPrefixedString(s string) {

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -1043,8 +1043,9 @@ var builtins = map[string]builtinDefinition{
 					return nil, pgerror.New(pgcode.InvalidParameterValue,
 						"only 'hex', 'escape', and 'base64' formats are supported for encode()")
 				}
-				return tree.NewDString(lex.EncodeByteArrayToRawBytes(
-					string(data), be, true /* skipHexPrefix */)), nil
+				return tree.NewDString(string(lex.EncodeByteArrayToRawBytes(
+					[]byte(data), be, true /* skipHexPrefix */),
+				)), nil
 			},
 			Info:       "Encodes `data` using `format` (`hex` / `escape` / `base64`).",
 			Volatility: tree.VolatilityImmutable,
@@ -1062,7 +1063,7 @@ var builtins = map[string]builtinDefinition{
 					return nil, pgerror.New(pgcode.InvalidParameterValue,
 						"only 'hex', 'escape', and 'base64' formats are supported for decode()")
 				}
-				res, err := lex.DecodeRawBytesToByteArray(data, be)
+				res, err := lex.DecodeRawBytesToByteArray([]byte(data), be)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/sql/sem/tree/casts.go
+++ b/pkg/sql/sem/tree/casts.go
@@ -880,11 +880,11 @@ func performCastWithoutPrecisionTruncation(ctx *EvalContext, d Datum, t *types.T
 		case *DCollatedString:
 			s = t.Contents
 		case *DBytes:
-			s = lex.EncodeByteArrayToRawBytes(
-				string(*t),
+			s = string(lex.EncodeByteArrayToRawBytes(
+				[]byte(*t),
 				ctx.SessionData.DataConversionConfig.BytesEncodeFormat,
 				false, /* skipHexPrefix */
-			)
+			))
 		case *DOid:
 			s = t.String()
 		case *DJSON:


### PR DESCRIPTION
**sql/lex: operate on byte slices when encoding byte arrays**

Previously, encode/decode pair methods of operating on byte arrays was
taking in a `string` as an input although the underlying datum is of
`[]byte` type. That conversion required a deep copy and isn't needed in
most cases AFAICT. This commit removes that redundant allocation in
favor of operating on the byte slices directly.

Release note: None

**pgwire,tree: remove redundant string allocation**

Previously, whenever we were encoding a columnar element of string
family, we would redundantly convert the underlying byte slice into
a string (incurring an allocation) in order to discard it later. This
commit removes that redundancy.

Release note: None