### PR TITLE
release-20.2: sql: fix schema privileges on descriptor read

### DIFF
--- a/pkg/sql/catalog/catalogkv/catalogkv.go
+++ b/pkg/sql/catalog/catalogkv/catalogkv.go
@@ -290,7 +290,7 @@ func validateDescriptor(ctx context.Context, dg catalog.DescGetter, desc catalog
 		// TODO(ajwerner): Validate type descriptor.
 		return nil
 	case catalog.SchemaDescriptor:
-		return nil
+		return desc.Validate()
 	default:
 		return errors.AssertionFailedf("unknown descriptor type %T", desc)
 	}
@@ -363,7 +363,11 @@ func unwrapDescriptorMutable(
 	case typ != nil:
 		return typedesc.NewExistingMutable(*typ), nil
 	case schema != nil:
-		return schemadesc.NewMutableExisting(*schema), nil
+		schemaDesc := schemadesc.NewMutableExisting(*schema)
+		if err := schemaDesc.Validate(); err != nil {
+			return nil, err
+		}
+		return schemaDesc, nil
 	default:
 		return nil, nil
 	}

--- a/pkg/sql/catalog/descpb/privilege.go
+++ b/pkg/sql/catalog/descpb/privilege.go
@@ -235,6 +235,25 @@ func MaybeFixUsagePrivForTablesAndDBs(ptr **PrivilegeDescriptor) bool {
 	return modified
 }
 
+// MaybeFixSchemaPrivileges removes all invalid bits set on a schema's
+// PrivilegeDescriptor.
+// This is necessary due to ALTER DATABASE ... CONVERT TO SCHEMA originally
+// copying all database privileges to the schema. Not all database privileges
+// are valid for schemas thus after running ALTER DATABASE ... CONVERT TO SCHEMA,
+// the schema may become unusable.
+func MaybeFixSchemaPrivileges(ptr **PrivilegeDescriptor) {
+	if *ptr == nil {
+		*ptr = &PrivilegeDescriptor{}
+	}
+	p := *ptr
+
+	validPrivs := privilege.GetValidPrivilegesForObject(privilege.Schema).ToBitField()
+
+	for i := range p.Users {
+		p.Users[i].Privileges &= validPrivs
+	}
+}
+
 // MaybeFixPrivileges fixes the privilege descriptor if needed, including:
 // * adding default privileges for the "admin" role
 // * fixing default privileges for the "root" user

--- a/pkg/sql/catalog/descpb/privilege_test.go
+++ b/pkg/sql/catalog/descpb/privilege_test.go
@@ -858,3 +858,105 @@ func TestMaybeFixUsageAndZoneConfigPrivilege(t *testing.T) {
 	}
 
 }
+
+// TestMaybeFixSchemaPrivileges ensures that invalid privileges are removed
+// from a schema's privilege descriptor.
+func TestMaybeFixSchemaPrivileges(t *testing.T) {
+	fooUser := "foo"
+	barUser := "bar"
+
+	type userPrivileges map[string]privilege.List
+
+	testCases := []struct {
+		input  userPrivileges
+		output userPrivileges
+	}{
+		{
+			userPrivileges{
+				fooUser: privilege.List{
+					privilege.ALL,
+					privilege.CREATE,
+					privilege.DROP,
+					privilege.GRANT,
+					privilege.SELECT,
+					privilege.INSERT,
+					privilege.DELETE,
+					privilege.UPDATE,
+					privilege.USAGE,
+					privilege.ZONECONFIG,
+				},
+				barUser: privilege.List{
+					privilege.CREATE,
+					privilege.DROP,
+					privilege.GRANT,
+					privilege.SELECT,
+					privilege.INSERT,
+					privilege.DELETE,
+					privilege.UPDATE,
+					privilege.USAGE,
+					privilege.ZONECONFIG,
+				},
+			},
+			userPrivileges{
+				fooUser: privilege.List{privilege.ALL},
+				barUser: privilege.List{
+					privilege.GRANT,
+					privilege.CREATE,
+					privilege.USAGE,
+				},
+			},
+		},
+		{
+			userPrivileges{
+				fooUser: privilege.List{privilege.GRANT},
+			},
+			userPrivileges{
+				fooUser: privilege.List{privilege.GRANT},
+			},
+		},
+		{
+			userPrivileges{
+				fooUser: privilege.List{privilege.CREATE},
+			},
+			userPrivileges{
+				fooUser: privilege.List{privilege.CREATE},
+			},
+		},
+		{
+			userPrivileges{
+				fooUser: privilege.List{privilege.USAGE},
+			},
+			userPrivileges{
+				fooUser: privilege.List{privilege.USAGE},
+			},
+		},
+	}
+
+	for num, tc := range testCases {
+		desc := &PrivilegeDescriptor{}
+		for u, p := range tc.input {
+			desc.Grant(u, p)
+		}
+		MaybeFixSchemaPrivileges(&desc)
+
+		for u, p := range tc.output {
+			outputUser, ok := desc.findUser(u)
+			if !ok {
+				t.Errorf("#%d: expected user %s in output, but not found (%v)",
+					num, u, desc.Users,
+				)
+			}
+			if a, e := privilege.ListFromBitField(outputUser.Privileges, privilege.Any), p; a.ToBitField() != e.ToBitField() {
+				t.Errorf("#%d: user %s: expected privileges %v, got %v",
+					num, u, e, a,
+				)
+			}
+
+			err := privilege.ValidatePrivileges(p, privilege.Schema)
+			if err != nil {
+				t.Errorf("%s\n", err.Error())
+			}
+		}
+
+	}
+}

--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -109,6 +109,8 @@ type DatabaseDescriptor interface {
 type SchemaDescriptor interface {
 	Descriptor
 	SchemaDesc() *descpb.SchemaDescriptor
+
+	Validate() error
 }
 
 // TableDescriptor is an interface around the table descriptor types.

--- a/pkg/sql/catalog/descs/collection_test.go
+++ b/pkg/sql/catalog/descs/collection_test.go
@@ -15,17 +15,23 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemadesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
+	"github.com/cockroachdb/cockroach/pkg/sql/tests"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -191,4 +197,72 @@ func TestDistSQLTypeResolver_GetTypeDescriptor_WrongType(t *testing.T) {
 		})
 	require.Regexp(t, `descriptor \d+ is a relation not a type`, err)
 	require.Equal(t, pgcode.WrongObjectType, pgerror.GetPGCode(err))
+}
+
+// TestMaybeFixSchemaPrivilegesIntegration ensures that schemas that have
+// invalid privileges have their privilege descriptors fixed on read-time when
+// grabbing the descriptor.
+func TestMaybeFixSchemaPrivilegesIntegration(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	params, _ := tests.CreateTestServerParams()
+	s, db, kvDB := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(ctx)
+
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+
+	_, err = conn.ExecContext(ctx, `
+CREATE DATABASE test;
+USE test;
+CREATE SCHEMA schema;
+CREATE USER testuser;
+GRANT CREATE ON SCHEMA schema TO testuser;
+CREATE TABLE schema.t(x INT);
+`)
+	require.NoError(t, err)
+
+	require.NoError(
+		t,
+		descs.Txn(
+			ctx,
+			s.ClusterSettings(),
+			s.LeaseManager().(*lease.Manager),
+			s.InternalExecutor().(sqlutil.InternalExecutor),
+			kvDB,
+			func(ctx context.Context, txn *kv.Txn, descsCol *descs.Collection) error {
+				// descCols.GetMutableDatabaseDescriptor sometimes cannot
+				// resolve the MutableDesc from the ImmutableDesc.
+				dbDesc := catalogkv.TestingGetDatabaseDescriptor(kvDB, keys.SystemSQLCodec, "test")
+
+				_, schemaDesc, err := descsCol.ResolveSchema(
+					ctx, txn, dbDesc.GetID(), "schema", tree.SchemaLookupFlags{Required: true},
+				)
+				if err != nil {
+					return err
+				}
+				// Write garbage privileges into the schema desc.
+				privs := schemaDesc.Desc.GetPrivileges()
+				for i := range privs.Users {
+					// SELECT is valid on a database but not a schema, however
+					// due to issue #65697, after running ALTER DATABASE ...
+					// CONVERT TO SCHEMA, schemas could end up with
+					// SELECT on it's privilege descriptor. This test
+					// mimics a schema that was originally a database.
+					// We want to ensure the schema's privileges are fixed
+					// on read.
+					privs.Users[i].Privileges |= privilege.SELECT.Mask()
+				}
+
+				mut := schemadesc.NewMutableExisting(*schemaDesc.Desc.SchemaDesc())
+				return descsCol.WriteDesc(ctx, false, mut, txn)
+			}),
+	)
+
+	// Make sure using the schema is fine and we don't encounter a
+	// privilege validation error.
+	_, err = db.Query("USE test; GRANT USAGE ON SCHEMA schema TO testuser;")
+	require.NoError(t, err)
 }

--- a/pkg/sql/catalog/schemadesc/schema_desc.go
+++ b/pkg/sql/catalog/schemadesc/schema_desc.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -260,4 +261,11 @@ func IsSchemaNameValid(name string) error {
 		return err
 	}
 	return nil
+}
+
+// Validate validates that the schema descriptor is well formed.
+// This only checks that the privileges for the schema are valid.
+func (desc *Immutable) Validate() error {
+	descpb.MaybeFixSchemaPrivileges(&desc.Privileges)
+	return desc.Privileges.Validate(desc.GetID(), privilege.Schema)
 }

--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -182,6 +182,9 @@ func (p *planner) createDescriptorWithID(
 			}
 		}
 	case *schemadesc.Mutable:
+		if err := desc.Validate(); err != nil {
+			return err
+		}
 		if err := p.Descriptors().AddUncommittedDescriptor(mutDesc); err != nil {
 			return err
 		}

--- a/pkg/sql/doctor/doctor_test.go
+++ b/pkg/sql/doctor/doctor_test.go
@@ -162,17 +162,17 @@ Database   1: ParentID   0, ParentSchemaID  0, Name 'db': not being dropped but 
 		{
 			descTable: doctor.DescriptorTable{
 				{
-					ID: 1,
+					ID: 51,
 					DescBytes: toBytes(t, &descpb.Descriptor{Union: &descpb.Descriptor_Schema{
-						Schema: &descpb.SchemaDescriptor{Name: "schema", ID: 1, ParentID: 2},
+						Schema: &descpb.SchemaDescriptor{Name: "schema", ID: 51, ParentID: 2},
 					}}),
 				},
 			},
 			namespaceTable: doctor.NamespaceTable{
-				{NameInfo: descpb.NameInfo{ParentID: 2, Name: "schema"}, ID: 1},
+				{NameInfo: descpb.NameInfo{ParentID: 2, Name: "schema"}, ID: 51},
 			},
 			expected: `Examining 1 descriptors and 1 namespace entries...
-  Schema   1: ParentID   2, ParentSchemaID  0, Name 'schema': invalid parent id 2
+  Schema  51: ParentID   2, ParentSchemaID  0, Name 'schema': invalid parent id 2
 `,
 		},
 		{

--- a/pkg/sql/schema.go
+++ b/pkg/sql/schema.go
@@ -56,6 +56,9 @@ func (p *planner) writeSchemaDesc(ctx context.Context, desc *schemadesc.Mutable)
 func (p *planner) writeSchemaDescChange(
 	ctx context.Context, desc *schemadesc.Mutable, jobDesc string,
 ) error {
+	if err := desc.Validate(); err != nil {
+		return err
+	}
 	job, jobExists := p.extendedEvalCtx.SchemaChangeJobCache[desc.ID]
 	if jobExists {
 		// Update it.


### PR DESCRIPTION
Backport 1/1 commits from #65750.

/cc @cockroachdb/release

---

Release note (bug fix): Previously a schema's privilege descriptor
could become corrupted upon executing ALTER DATABASE ...
CONVERT TO SCHEMA due to privileges that are invalid on a schema
being copied over to the schema rendering the schema inusable due
to invalid privileges.

Fixes #65697
