### PR TITLE
bazel: in `dev` toolchain, don't include unnecessary directory

### DIFF
--- a/build/toolchains/dev/darwin-x86_64/cc_toolchain_config.bzl.tmpl
+++ b/build/toolchains/dev/darwin-x86_64/cc_toolchain_config.bzl.tmpl
@@ -78,7 +78,6 @@ def _impl(ctx):
                         flags = [
                             "-g1",
                             "-Wall",
-                            "-I%{repo_path}/include/c++/v1",
                         ],
                     ),
                 ]),
@@ -128,7 +127,6 @@ def _impl(ctx):
         cxx_builtin_include_directories = [
             "%sysroot%/usr/include",
             "%{repo_path}/lib/clang/10.0.0/include",
-            "%{repo_path}/include/c++/v1",
         ],
         builtin_sysroot = "%{sdk_path}",
     )


### PR DESCRIPTION
After a macOS update, including the additional directory in the include
search path breaks as the same file is included in two different
locations, leading to some missing declarations.

Closes #64296.

Release note: None