### PR TITLE
opt: prevent stack overflows from normalization rule cycles

### DIFF
--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -2428,6 +2428,11 @@ func (b *logicalPropsBuilder) buildFakeRelProps(fake *FakeRelExpr, rel *props.Re
 	*rel = *fake.Props
 }
 
+func (b *logicalPropsBuilder) buildNormCycleTestRelProps(
+	nc *NormCycleTestRelExpr, rel *props.Relational,
+) {
+}
+
 // WithUses returns the WithUsesMap for the given expression.
 func WithUses(r opt.Expr) props.WithUsesMap {
 	switch e := r.(type) {

--- a/pkg/sql/opt/norm/rules/cycle.opt
+++ b/pkg/sql/opt/norm/rules/cycle.opt
@@ -1,0 +1,16 @@
+# =============================================================================
+# cycle.opt contains normalization rules for the NormCycleTestRel expression.
+# =============================================================================
+
+# The following two rules create a normalization rule cycle for the
+# NormCycleTestRel expression. This rule cycle is used to test that the cycle
+# can be detected and a stack overflow does not occur. See the cycle test file.
+[NormCycleTestRelTrueToFalse, Normalize]
+(NormCycleTestRel (True))
+=>
+(NormCycleTestRel (False))
+
+[NormCycleTestRelFalseToTrue, Normalize]
+(NormCycleTestRel (False))
+=>
+(NormCycleTestRel (True))

--- a/pkg/sql/opt/norm/testdata/rules/cycle
+++ b/pkg/sql/opt/norm/testdata/rules/cycle
@@ -1,0 +1,6 @@
+# This test ensures that a rule cycle does not cause a stack overflow. In test
+# builds, a deep constructor call stack is detected and the Factory panics.
+exprnorm
+(NormCycleTestRel (True))
+----
+error: optimizer factory constructor call stack exceeded max depth of 10000

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -1207,3 +1207,13 @@ define FakeRel {
 define FakeRelPrivate {
     Props RelPropsPtr
 }
+
+# NormCycleTestRel is a relational operator for testing that normalization rule
+# cycles are detected by the Factory and a stack overflow is prevented. Two
+# rules for this expression, NormCycleTestRelTrueToFalse and
+# NormCycleTestRelFalseToTrue, create a normalization rule cycle. See the cycle
+# test file for tests that use this expression.
+[Relational]
+define NormCycleTestRel {
+    Scalar ScalarExpr
+}

--- a/pkg/sql/opt/optgen/cmd/optgen/factory_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/factory_gen.go
@@ -116,6 +116,14 @@ func (g *factoryGen) genConstructFuncs() {
 			}
 			g.w.writeIndent("return item\n")
 		} else {
+			g.w.writeIndent("_f.constructorStackDepth++\n")
+			g.w.nestIndent("if _f.constructorStackDepth > maxConstructorStackDepth {\n")
+			g.w.writeIndent("// If the constructor call stack depth exceeds the limit, call\n")
+			g.w.writeIndent("// onMaxConstructorStackDepthExceeded and skip all rules.\n")
+			g.w.writeIndent("_f.onMaxConstructorStackDepthExceeded()\n")
+			g.w.writeIndent("goto SKIP_RULES\n")
+			g.w.unnest("}\n\n")
+
 			// Only include normalization rules for the current define.
 			rules := g.compiled.LookupMatchingRules(string(define.Name)).WithTag("Normalize")
 			sortRulesByPriority(rules)
@@ -126,6 +134,8 @@ func (g *factoryGen) genConstructFuncs() {
 				g.w.newline()
 			}
 
+			g.w.writeIndent("SKIP_RULES:\n")
+
 			g.w.writeIndent("e := _f.mem.Memoize%s(", define.Name)
 			for i, field := range fields {
 				if i != 0 {
@@ -133,14 +143,15 @@ func (g *factoryGen) genConstructFuncs() {
 				}
 				g.w.write("%s", unTitle(g.md.fieldName(field)))
 			}
-
 			g.w.write(")\n")
 
 			if define.Tags.Contains("Relational") {
-				g.w.writeIndent("return _f.onConstructRelational(e)\n")
+				g.w.writeIndent("expr := _f.onConstructRelational(e)\n")
 			} else {
-				g.w.writeIndent("return _f.onConstructScalar(e)\n")
+				g.w.writeIndent("expr := _f.onConstructScalar(e)\n")
 			}
+			g.w.writeIndent("_f.constructorStackDepth--\n")
+			g.w.writeIndent("return expr\n")
 		}
 
 		g.w.unnest("}\n\n")

--- a/pkg/sql/opt/optgen/cmd/optgen/rule_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/rule_gen.go
@@ -724,6 +724,7 @@ func (g *newRuleGen) genNormalizeReplace(define *lang.DefineExpr, rule *lang.Rul
 	g.w.writeIndent("_f.appliedRule(opt.%s, nil, _expr)\n", rule.Name)
 	g.w.unnest("}\n")
 
+	g.w.writeIndent("_f.constructorStackDepth--\n")
 	g.w.writeIndent("return _expr\n")
 }
 

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/factory
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/factory
@@ -82,6 +82,14 @@ func (_f *Factory) ConstructSelect(
 	input memo.RelExpr,
 	filters memo.FiltersExpr,
 ) memo.RelExpr {
+	_f.constructorStackDepth++
+	if _f.constructorStackDepth > maxConstructorStackDepth {
+		// If the constructor call stack depth exceeds the limit, call
+		// onMaxConstructorStackDepthExceeded and skip all rules.
+		_f.onMaxConstructorStackDepthExceeded()
+		goto SKIP_RULES
+	}
+
 	// [PushSelectIntoJoinLeft]
 	{
 		if input.Op() == opt.InnerJoinOp || input.Op() == opt.InnerJoinApplyOp {
@@ -109,6 +117,7 @@ func (_f *Factory) ConstructSelect(
 						if _f.appliedRule != nil {
 							_f.appliedRule(opt.PushSelectIntoJoinLeft, nil, _expr)
 						}
+						_f.constructorStackDepth--
 						return _expr
 					}
 				}
@@ -116,8 +125,11 @@ func (_f *Factory) ConstructSelect(
 		}
 	}
 
+SKIP_RULES:
 	e := _f.mem.MemoizeSelect(input, filters)
-	return _f.onConstructRelational(e)
+	expr := _f.onConstructRelational(e)
+	_f.constructorStackDepth--
+	return expr
 }
 
 // ConstructInnerJoin constructs an expression for the InnerJoin operator.
@@ -126,8 +138,19 @@ func (_f *Factory) ConstructInnerJoin(
 	right memo.RelExpr,
 	on memo.FiltersExpr,
 ) memo.RelExpr {
+	_f.constructorStackDepth++
+	if _f.constructorStackDepth > maxConstructorStackDepth {
+		// If the constructor call stack depth exceeds the limit, call
+		// onMaxConstructorStackDepthExceeded and skip all rules.
+		_f.onMaxConstructorStackDepthExceeded()
+		goto SKIP_RULES
+	}
+
+SKIP_RULES:
 	e := _f.mem.MemoizeInnerJoin(left, right, on)
-	return _f.onConstructRelational(e)
+	expr := _f.onConstructRelational(e)
+	_f.constructorStackDepth--
+	return expr
 }
 
 // ConstructInnerJoinApply constructs an expression for the InnerJoinApply operator.
@@ -136,8 +159,19 @@ func (_f *Factory) ConstructInnerJoinApply(
 	right memo.RelExpr,
 	on memo.FiltersExpr,
 ) memo.RelExpr {
+	_f.constructorStackDepth++
+	if _f.constructorStackDepth > maxConstructorStackDepth {
+		// If the constructor call stack depth exceeds the limit, call
+		// onMaxConstructorStackDepthExceeded and skip all rules.
+		_f.onMaxConstructorStackDepthExceeded()
+		goto SKIP_RULES
+	}
+
+SKIP_RULES:
 	e := _f.mem.MemoizeInnerJoinApply(left, right, on)
-	return _f.onConstructRelational(e)
+	expr := _f.onConstructRelational(e)
+	_f.constructorStackDepth--
+	return expr
 }
 
 // ConstructFiltersItem constructs an expression for the FiltersItem operator.
@@ -383,30 +417,71 @@ import (
 func (_f *Factory) ConstructVariable(
 	col opt.ColumnID,
 ) opt.ScalarExpr {
+	_f.constructorStackDepth++
+	if _f.constructorStackDepth > maxConstructorStackDepth {
+		// If the constructor call stack depth exceeds the limit, call
+		// onMaxConstructorStackDepthExceeded and skip all rules.
+		_f.onMaxConstructorStackDepthExceeded()
+		goto SKIP_RULES
+	}
+
+SKIP_RULES:
 	e := _f.mem.MemoizeVariable(col)
-	return _f.onConstructScalar(e)
+	expr := _f.onConstructScalar(e)
+	_f.constructorStackDepth--
+	return expr
 }
 
 // ConstructMin constructs an expression for the Min operator.
 func (_f *Factory) ConstructMin(
 	input *memo.VariableExpr,
 ) opt.ScalarExpr {
+	_f.constructorStackDepth++
+	if _f.constructorStackDepth > maxConstructorStackDepth {
+		// If the constructor call stack depth exceeds the limit, call
+		// onMaxConstructorStackDepthExceeded and skip all rules.
+		_f.onMaxConstructorStackDepthExceeded()
+		goto SKIP_RULES
+	}
+
+SKIP_RULES:
 	e := _f.mem.MemoizeMin(input)
-	return _f.onConstructScalar(e)
+	expr := _f.onConstructScalar(e)
+	_f.constructorStackDepth--
+	return expr
 }
 
 // ConstructMax constructs an expression for the Max operator.
 func (_f *Factory) ConstructMax(
 	input *memo.VariableExpr,
 ) opt.ScalarExpr {
+	_f.constructorStackDepth++
+	if _f.constructorStackDepth > maxConstructorStackDepth {
+		// If the constructor call stack depth exceeds the limit, call
+		// onMaxConstructorStackDepthExceeded and skip all rules.
+		_f.onMaxConstructorStackDepthExceeded()
+		goto SKIP_RULES
+	}
+
+SKIP_RULES:
 	e := _f.mem.MemoizeMax(input)
-	return _f.onConstructScalar(e)
+	expr := _f.onConstructScalar(e)
+	_f.constructorStackDepth--
+	return expr
 }
 
 // ConstructAggDistinct constructs an expression for the AggDistinct operator.
 func (_f *Factory) ConstructAggDistinct(
 	input opt.ScalarExpr,
 ) opt.ScalarExpr {
+	_f.constructorStackDepth++
+	if _f.constructorStackDepth > maxConstructorStackDepth {
+		// If the constructor call stack depth exceeds the limit, call
+		// onMaxConstructorStackDepthExceeded and skip all rules.
+		_f.onMaxConstructorStackDepthExceeded()
+		goto SKIP_RULES
+	}
+
 	// [EliminateAggDistinct1]
 	{
 		if input.Op() == opt.MinOp || input.Op() == opt.MaxOp {
@@ -415,6 +490,7 @@ func (_f *Factory) ConstructAggDistinct(
 				if _f.appliedRule != nil {
 					_f.appliedRule(opt.EliminateAggDistinct1, nil, _expr)
 				}
+				_f.constructorStackDepth--
 				return _expr
 			}
 		}
@@ -432,6 +508,7 @@ func (_f *Factory) ConstructAggDistinct(
 				if _f.appliedRule != nil {
 					_f.appliedRule(opt.EliminateAggDistinct2, nil, _expr)
 				}
+				_f.constructorStackDepth--
 				return _expr
 			}
 		}
@@ -449,13 +526,17 @@ func (_f *Factory) ConstructAggDistinct(
 				if _f.appliedRule != nil {
 					_f.appliedRule(opt.EliminateAggDistinct3, nil, _expr)
 				}
+				_f.constructorStackDepth--
 				return _expr
 			}
 		}
 	}
 
+SKIP_RULES:
 	e := _f.mem.MemoizeAggDistinct(input)
-	return _f.onConstructScalar(e)
+	expr := _f.onConstructScalar(e)
+	_f.constructorStackDepth--
+	return expr
 }
 
 // Replace enables an expression subtree to be rewritten under the control of
@@ -600,8 +681,19 @@ func (_f *Factory) ConstructWith(
 	binding memo.RelExpr,
 	main memo.RelExpr,
 ) memo.RelExpr {
+	_f.constructorStackDepth++
+	if _f.constructorStackDepth > maxConstructorStackDepth {
+		// If the constructor call stack depth exceeds the limit, call
+		// onMaxConstructorStackDepthExceeded and skip all rules.
+		_f.onMaxConstructorStackDepthExceeded()
+		goto SKIP_RULES
+	}
+
+SKIP_RULES:
 	e := _f.mem.MemoizeWith(binding, main)
-	return _f.onConstructRelational(e)
+	expr := _f.onConstructRelational(e)
+	_f.constructorStackDepth--
+	return expr
 }
 
 // Replace enables an expression subtree to be rewritten under the control of
@@ -742,6 +834,14 @@ func (_f *Factory) ConstructProject(
 	projections memo.ProjectionsExpr,
 	passthrough opt.ColSet,
 ) memo.RelExpr {
+	_f.constructorStackDepth++
+	if _f.constructorStackDepth > maxConstructorStackDepth {
+		// If the constructor call stack depth exceeds the limit, call
+		// onMaxConstructorStackDepthExceeded and skip all rules.
+		_f.onMaxConstructorStackDepthExceeded()
+		goto SKIP_RULES
+	}
+
 	// [PruneValuesCols]
 	{
 		_values, _ := input.(*memo.ValuesExpr)
@@ -757,22 +857,37 @@ func (_f *Factory) ConstructProject(
 					if _f.appliedRule != nil {
 						_f.appliedRule(opt.PruneValuesCols, nil, _expr)
 					}
+					_f.constructorStackDepth--
 					return _expr
 				}
 			}
 		}
 	}
 
+SKIP_RULES:
 	e := _f.mem.MemoizeProject(input, projections, passthrough)
-	return _f.onConstructRelational(e)
+	expr := _f.onConstructRelational(e)
+	_f.constructorStackDepth--
+	return expr
 }
 
 // ConstructValues constructs an expression for the Values operator.
 func (_f *Factory) ConstructValues(
 	rows memo.ScalarListExpr,
 ) opt.ScalarExpr {
+	_f.constructorStackDepth++
+	if _f.constructorStackDepth > maxConstructorStackDepth {
+		// If the constructor call stack depth exceeds the limit, call
+		// onMaxConstructorStackDepthExceeded and skip all rules.
+		_f.onMaxConstructorStackDepthExceeded()
+		goto SKIP_RULES
+	}
+
+SKIP_RULES:
 	e := _f.mem.MemoizeValues(rows)
-	return _f.onConstructScalar(e)
+	expr := _f.onConstructScalar(e)
+	_f.constructorStackDepth--
+	return expr
 }
 
 // Replace enables an expression subtree to be rewritten under the control of
@@ -985,14 +1100,33 @@ func (_f *Factory) ConstructAnd(
 	left opt.ScalarExpr,
 	right opt.ScalarExpr,
 ) opt.ScalarExpr {
+	_f.constructorStackDepth++
+	if _f.constructorStackDepth > maxConstructorStackDepth {
+		// If the constructor call stack depth exceeds the limit, call
+		// onMaxConstructorStackDepthExceeded and skip all rules.
+		_f.onMaxConstructorStackDepthExceeded()
+		goto SKIP_RULES
+	}
+
+SKIP_RULES:
 	e := _f.mem.MemoizeAnd(left, right)
-	return _f.onConstructScalar(e)
+	expr := _f.onConstructScalar(e)
+	_f.constructorStackDepth--
+	return expr
 }
 
 // ConstructRange constructs an expression for the Range operator.
 func (_f *Factory) ConstructRange(
 	and opt.ScalarExpr,
 ) opt.ScalarExpr {
+	_f.constructorStackDepth++
+	if _f.constructorStackDepth > maxConstructorStackDepth {
+		// If the constructor call stack depth exceeds the limit, call
+		// onMaxConstructorStackDepthExceeded and skip all rules.
+		_f.onMaxConstructorStackDepthExceeded()
+		goto SKIP_RULES
+	}
+
 	// [SimplifyRange]
 	{
 		input := and
@@ -1003,13 +1137,17 @@ func (_f *Factory) ConstructRange(
 				if _f.appliedRule != nil {
 					_f.appliedRule(opt.SimplifyRange, nil, _expr)
 				}
+				_f.constructorStackDepth--
 				return _expr
 			}
 		}
 	}
 
+SKIP_RULES:
 	e := _f.mem.MemoizeRange(and)
-	return _f.onConstructScalar(e)
+	expr := _f.onConstructScalar(e)
+	_f.constructorStackDepth--
+	return expr
 }
 
 // Replace enables an expression subtree to be rewritten under the control of
@@ -1193,6 +1331,14 @@ func (_f *Factory) ConstructUnion(
 	left memo.RelExpr,
 	right memo.RelExpr,
 ) memo.RelExpr {
+	_f.constructorStackDepth++
+	if _f.constructorStackDepth > maxConstructorStackDepth {
+		// If the constructor call stack depth exceeds the limit, call
+		// onMaxConstructorStackDepthExceeded and skip all rules.
+		_f.onMaxConstructorStackDepthExceeded()
+		goto SKIP_RULES
+	}
+
 	// [Let]
 	{
 		a, b, ok := _f.funcs.Split(left, right)
@@ -1205,6 +1351,7 @@ func (_f *Factory) ConstructUnion(
 				if _f.appliedRule != nil {
 					_f.appliedRule(opt.Let, nil, _expr)
 				}
+				_f.constructorStackDepth--
 				return _expr
 			}
 		}
@@ -1223,6 +1370,7 @@ func (_f *Factory) ConstructUnion(
 					if _f.appliedRule != nil {
 						_f.appliedRule(opt.LetNestedInFunction, nil, _expr)
 					}
+					_f.constructorStackDepth--
 					return _expr
 				}
 			}
@@ -1243,6 +1391,7 @@ func (_f *Factory) ConstructUnion(
 					if _f.appliedRule != nil {
 						_f.appliedRule(opt.LetNestedInFunctionWithBinding, nil, _expr)
 					}
+					_f.constructorStackDepth--
 					return _expr
 				}
 			}
@@ -1269,6 +1418,7 @@ func (_f *Factory) ConstructUnion(
 						if _f.appliedRule != nil {
 							_f.appliedRule(opt.LetInNestedMatch, nil, _expr)
 						}
+						_f.constructorStackDepth--
 						return _expr
 					}
 				}
@@ -1290,6 +1440,7 @@ func (_f *Factory) ConstructUnion(
 					if _f.appliedRule != nil {
 						_f.appliedRule(opt.LetNestedInFunctionAndLet, nil, _expr)
 					}
+					_f.constructorStackDepth--
 					return _expr
 				}
 			}
@@ -1307,12 +1458,16 @@ func (_f *Factory) ConstructUnion(
 			if _f.appliedRule != nil {
 				_f.appliedRule(opt.LetInReplace, nil, _expr)
 			}
+			_f.constructorStackDepth--
 			return _expr
 		}
 	}
 
+SKIP_RULES:
 	e := _f.mem.MemoizeUnion(left, right)
-	return _f.onConstructRelational(e)
+	expr := _f.onConstructRelational(e)
+	_f.constructorStackDepth--
+	return expr
 }
 
 // Replace enables an expression subtree to be rewritten under the control of

--- a/pkg/sql/opt/optgen/exprgen/expr_gen.go
+++ b/pkg/sql/opt/optgen/exprgen/expr_gen.go
@@ -78,7 +78,7 @@ func Build(catalog cat.Catalog, factory *norm.Factory, input string) (_ opt.Expr
 			if e, ok := r.(exprGenErr); ok {
 				err = e.error
 			} else {
-				panic(r)
+				err = r.(error)
 			}
 		}
 	}()

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -656,7 +656,7 @@ func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 	case "exprnorm":
 		e, err := ot.ExprNorm()
 		if err != nil {
-			d.Fatalf(tb, "%+v", err)
+			return fmt.Sprintf("error: %s\n", err)
 		}
 		ot.postProcess(tb, d, e)
 		return ot.FormatExpr(e)

--- a/pkg/sql/opt/xform/optimizer.go
+++ b/pkg/sql/opt/xform/optimizer.go
@@ -239,6 +239,10 @@ func (o *Optimizer) Optimize() (_ opt.Expr, err error) {
 		)
 	}
 
+	// Validate that the factory's stack depth is zero after all optimizations
+	// have been applied.
+	o.f.CheckConstructorStackDepth()
+
 	return root, nil
 }
 


### PR DESCRIPTION
Occasionally, normalization rules can inadvertently create rule cycles.
These cycles result in stack overflows and crashed nodes.

The optimizer Factory now detects a rule cycle by tracking the call
stack depth of `Construct...` functions. A cycle is detected when the
call stack depth exceeds 10,000.

In test builds, the Factory panics when a cycle is detected. In release
builds, when a cycle is detected normalization rules are no longer
applied and the event is reported to Sentry. The Sentry report includes a
stack trace which should help to debug the rule cycle.

Example Sentry report:
https://sentry.io/organizations/cockroach-labs/issues/2433743169

Informs #42745

Release note: None