### PR TITLE
release-21.1: release: configure ssh key before using git

### DIFF
--- a/build/release/teamcity-publish-release.sh
+++ b/build/release/teamcity-publish-release.sh
@@ -60,6 +60,8 @@ tc_end_block "Variable Setup"
 
 
 tc_start_block "Check remote tag"
+github_ssh_key="${GITHUB_COCKROACH_TEAMCITY_PRIVATE_SSH_KEY}"
+configure_git_ssh_key
 if git_wrapped ls-remote --exit-code --tags "ssh://git@github.com/${git_repo_for_tag}.git" "${build_name}"; then
   echo "Tag ${build_name} already exists"
   exit 1
@@ -111,8 +113,6 @@ tc_end_block "Make and push docker images"
 
 
 tc_start_block "Push release tag to GitHub"
-github_ssh_key="${GITHUB_COCKROACH_TEAMCITY_PRIVATE_SSH_KEY}"
-configure_git_ssh_key
 git_wrapped push "ssh://git@github.com/${git_repo_for_tag}.git" "$build_name"
 tc_end_block "Push release tag to GitHub"
 


### PR DESCRIPTION
Backport 1/1 commits from #65943.

/cc @cockroachdb/release

---

In #65555 we added check to make sure we don't try to push the same tag
twice. The `git ls-remote` command, which uses `ssh://` was missing a
step that configures the SSH key.

This patch configures SSH earlier in the process.

Release note: None
