### PR TITLE
security: protect calls to bcrypt hashes by a semaphore

### DIFF
--- a/pkg/ccl/gssapiccl/gssapi.go
+++ b/pkg/ccl/gssapiccl/gssapi.go
@@ -50,7 +50,7 @@ func authGSS(
 	execCfg *sql.ExecutorConfig,
 	entry *hba.Entry,
 ) (security.UserAuthHook, error) {
-	return func(requestedUser security.SQLUsername, clientConnection bool) (func(), error) {
+	return func(ctx context.Context, requestedUser security.SQLUsername, clientConnection bool) (func(), error) {
 		var (
 			majStat, minStat, lminS, gflags C.OM_uint32
 			gbuf                            C.gss_buffer_desc

--- a/pkg/ccl/serverccl/role_authentication_test.go
+++ b/pkg/ccl/serverccl/role_authentication_test.go
@@ -142,7 +142,7 @@ func TestVerifyPassword(t *testing.T) {
 				)
 			}
 
-			err = security.CompareHashAndPassword(hashedPassword, tc.password)
+			err = security.CompareHashAndPassword(ctx, hashedPassword, tc.password)
 			if err != nil {
 				valid = false
 			}

--- a/pkg/security/BUILD.bazel
+++ b/pkg/security/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
         "//pkg/util/log",
         "//pkg/util/log/eventpb",
         "//pkg/util/metric",
+        "//pkg/util/quotapool",
         "//pkg/util/randutil",
         "//pkg/util/stop",
         "//pkg/util/syncutil",

--- a/pkg/security/auth_test.go
+++ b/pkg/security/auth_test.go
@@ -11,6 +11,7 @@
 package security_test
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -204,6 +205,8 @@ func TestAuthenticationHook(t *testing.T) {
 		{false, "foo,bar", blahUser, "bar:blah", true, true, false},
 	}
 
+	ctx := context.Background()
+
 	for _, tc := range testCases {
 		t.Run("", func(t *testing.T) {
 			err := security.SetCertPrincipalMap(strings.Split(tc.principalMap, ","))
@@ -217,11 +220,11 @@ func TestAuthenticationHook(t *testing.T) {
 			if err != nil {
 				return
 			}
-			_, err = hook(tc.username, true /* clientConnection */)
+			_, err = hook(ctx, tc.username, true /* clientConnection */)
 			if (err == nil) != tc.publicHookSuccess {
 				t.Fatalf("expected success=%t, got err=%v", tc.publicHookSuccess, err)
 			}
-			_, err = hook(tc.username, false /* clientConnection */)
+			_, err = hook(ctx, tc.username, false /* clientConnection */)
 			if (err == nil) != tc.privateHookSuccess {
 				t.Fatalf("expected success=%t, got err=%v", tc.privateHookSuccess, err)
 			}

--- a/pkg/security/password.go
+++ b/pkg/security/password.go
@@ -11,11 +11,17 @@
 package security
 
 import (
+	"context"
 	"crypto/sha256"
 	"fmt"
 	"os"
+	"runtime"
+	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
 	"github.com/cockroachdb/errors"
 	"golang.org/x/crypto/bcrypt"
 	"golang.org/x/term"
@@ -56,12 +62,24 @@ func appendEmptySha256(password string) []byte {
 // CompareHashAndPassword tests that the provided bytes are equivalent to the
 // hash of the supplied password. If they are not equivalent, returns an
 // error.
-func CompareHashAndPassword(hashedPassword []byte, password string) error {
+func CompareHashAndPassword(ctx context.Context, hashedPassword []byte, password string) error {
+	sem := getBcryptSem(ctx)
+	alloc, err := sem.Acquire(ctx, 1)
+	if err != nil {
+		return err
+	}
+	defer alloc.Release()
 	return bcrypt.CompareHashAndPassword(hashedPassword, appendEmptySha256(password))
 }
 
 // HashPassword takes a raw password and returns a bcrypt hashed password.
-func HashPassword(password string) ([]byte, error) {
+func HashPassword(ctx context.Context, password string) ([]byte, error) {
+	sem := getBcryptSem(ctx)
+	alloc, err := sem.Acquire(ctx, 1)
+	if err != nil {
+		return nil, err
+	}
+	defer alloc.Release()
 	return bcrypt.GenerateFromPassword(appendEmptySha256(password), BcryptCost)
 }
 
@@ -88,3 +106,45 @@ var MinPasswordLength = settings.RegisterIntSetting(
 	1,
 	settings.NonNegativeInt,
 )
+
+// bcryptSemOnce wraps a semaphore that limits the number of concurrent calls
+// to the bcrypt hash functions. This is needed to avoid the risk of a
+// DoS attacks by malicious users or broken client apps that would
+// starve the server of CPU resources just by computing bcrypt hashes.
+//
+// We use a sync.Once to delay the creation of the semaphore to the
+// first time the password functions are used. This gives a chance to
+// the server process to update GOMAXPROCS before we compute the
+// maximum amount of concurrency for the semaphore.
+var bcryptSemOnce struct {
+	sem  *quotapool.IntPool
+	once sync.Once
+}
+
+// envMaxBcryptConcurrency allows a user to override the semaphore
+// configuration using an environment variable.
+// If the env var is set to a value >= 1, that value is used.
+// Otherwise, a default is computed from the configure GOMAXPROCS.
+var envMaxBcryptConcurrency = envutil.EnvOrDefaultInt("COCKROACH_MAX_BCRYPT_CONCURRENCY", 0)
+
+// getBcryptSem retrieves the bcrypt semaphore.
+func getBcryptSem(ctx context.Context) *quotapool.IntPool {
+	bcryptSemOnce.once.Do(func() {
+		var n int
+		if envMaxBcryptConcurrency >= 1 {
+			// The operator knows better. Use what they tell us to use.
+			n = envMaxBcryptConcurrency
+		} else {
+			// We divide by 8 so that the max CPU usage of bcrypt checks
+			// never exceeds ~10% of total CPU resources allocated to this
+			// process.
+			n = runtime.GOMAXPROCS(-1) / 8
+		}
+		if n < 1 {
+			n = 1
+		}
+		log.VInfof(ctx, 1, "configured maximum bcrypt concurrency: %d", n)
+		bcryptSemOnce.sem = quotapool.NewIntPool("bcrypt", uint64(n))
+	})
+	return bcryptSemOnce.sem
+}

--- a/pkg/server/authentication.go
+++ b/pkg/server/authentication.go
@@ -437,7 +437,7 @@ func (s *authenticationServer) verifyPassword(
 		}
 	}
 
-	return security.CompareHashAndPassword(hashedPassword, password) == nil, false, nil
+	return security.CompareHashAndPassword(ctx, hashedPassword, password) == nil, false, nil
 }
 
 // CreateAuthSecret creates a secret, hash pair to populate a session auth token.

--- a/pkg/sql/create_role.go
+++ b/pkg/sql/create_role.go
@@ -322,7 +322,7 @@ func (p *planner) checkPasswordAndGetHash(
 		}
 	}
 
-	hashedPassword, err = security.HashPassword(password)
+	hashedPassword, err = security.HashPassword(ctx, password)
 	if err != nil {
 		return hashedPassword, err
 	}

--- a/pkg/sql/pgwire/auth.go
+++ b/pkg/sql/pgwire/auth.go
@@ -127,7 +127,7 @@ func (c *conn) handleAuthentication(
 		return nil, sendError(err)
 	}
 
-	if connClose, err = authenticationHook(c.sessionArgs.User, true /* public */); err != nil {
+	if connClose, err = authenticationHook(ctx, c.sessionArgs.User, true /* public */); err != nil {
 		ac.LogAuthFailed(ctx, eventpb.AuthFailReason_CREDENTIALS_INVALID, err)
 		return connClose, sendError(err)
 	}

--- a/pkg/sql/pgwire/auth_methods.go
+++ b/pkg/sql/pgwire/auth_methods.go
@@ -182,7 +182,7 @@ func authTrust(
 	_ *sql.ExecutorConfig,
 	_ *hba.Entry,
 ) (security.UserAuthHook, error) {
-	return func(_ security.SQLUsername, _ bool) (func(), error) { return nil, nil }, nil
+	return func(_ context.Context, _ security.SQLUsername, _ bool) (func(), error) { return nil, nil }, nil
 }
 
 func authReject(
@@ -194,7 +194,7 @@ func authReject(
 	_ *sql.ExecutorConfig,
 	_ *hba.Entry,
 ) (security.UserAuthHook, error) {
-	return func(_ security.SQLUsername, _ bool) (func(), error) {
+	return func(_ context.Context, _ security.SQLUsername, _ bool) (func(), error) {
 		return nil, errors.New("authentication rejected by configuration")
 	}, nil
 }


### PR DESCRIPTION
Informs #47602.
(It does not *solve* the issue because a DoS is still possible due to the SQL username/password lookups in KV ahead of the bcrypt calls)

Prior to this patch, it was possible to starve a server of CPU
resources by forcing it to compute bcrypt hashes, for example by
quickly opening SQL sessions, authenticating them and closing them in
parallel.

This patch addresses this by wrapping the bcrypt calls under
a semaphore.

Release note (security update): CockroachDB now configures a maximum
number of concurrent password verifications in the server process,
across UI and SQL clients. This limit reduces the risk of DoS attacks
or accidents due to misbehaving clients.

By default, the maximum amount of concurrency is 10% of the number of
allocated CPU cores (as per `GOMAXPROCS`), with a minimum of 1
core. This default can be overridden using the environment variable
`COCKROACH_MAX_BCRYPT_CONCURRENCY`.