### PR TITLE
sql: add support for show create database

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_show
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_show
@@ -1,0 +1,49 @@
+# LogicTest: multiregion-9node-3region-3azs
+
+statement ok
+CREATE DATABASE test_local_db
+
+query TT colnames
+SHOW CREATE DATABASE test_local_db
+----
+database_name                create_statement
+test_local_db                CREATE DATABASE test_local_db
+
+statement ok
+CREATE DATABASE """test_escaping""""''b""";
+
+query TT colnames
+SHOW CREATE DATABASE """test_escaping""""''b""";
+----
+database_name                create_statement
+"test_escaping""''b"         CREATE DATABASE """test_escaping""""''b"""
+
+statement ok
+CREATE DATABASE region_test_db PRIMARY REGION "ap-southeast-2"
+
+query TT colnames
+SHOW CREATE DATABASE region_test_db
+----
+database_name              create_statement
+region_test_db             CREATE DATABASE region_test_db PRIMARY REGION "ap-southeast-2" REGIONS = "ap-southeast-2" SURVIVE ZONE FAILURE
+
+statement ok
+CREATE DATABASE multi_region_test_db PRIMARY REGION "ca-central-1" REGIONS "ap-southeast-2", "us-east-1" SURVIVE REGION FAILURE
+
+query TT colnames
+SHOW CREATE DATABASE multi_region_test_db
+----
+database_name              create_statement
+multi_region_test_db       CREATE DATABASE multi_region_test_db PRIMARY REGION "ca-central-1" REGIONS = "ap-southeast-2", "ca-central-1", "us-east-1" SURVIVE REGION FAILURE
+
+statement ok
+CREATE DATABASE multi_region_test_explicit_primary_region_db PRIMARY REGION "ap-southeast-2" REGIONS "ap-southeast-2", "ca-central-1", "us-east-1" SURVIVE REGION FAILURE
+
+query TT colnames
+SHOW CREATE DATABASE multi_region_test_explicit_primary_region_db
+----
+database_name                                     create_statement
+multi_region_test_explicit_primary_region_db      CREATE DATABASE multi_region_test_explicit_primary_region_db PRIMARY REGION "ap-southeast-2" REGIONS = "ap-southeast-2", "ca-central-1", "us-east-1" SURVIVE REGION FAILURE
+
+statement error target database or schema does not exist
+SHOW CREATE DATABASE foo

--- a/pkg/sql/delegate/show_table.go
+++ b/pkg/sql/delegate/show_table.go
@@ -17,11 +17,42 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
+	"github.com/cockroachdb/errors"
 )
 
 func (d *delegator) delegateShowCreate(n *tree.ShowCreate) (tree.Statement, error) {
 	sqltelemetry.IncrementShowCounter(sqltelemetry.Create)
 
+	switch n.Mode {
+	case tree.ShowCreateModeTable, tree.ShowCreateModeView, tree.ShowCreateModeSequence:
+		return d.delegateShowCreateTable(n)
+	case tree.ShowCreateModeDatabase:
+		return d.delegateShowCreateDatabase(n)
+	default:
+		return nil, errors.Newf("unknown show create mode: %d", n.Mode)
+	}
+}
+
+func (d *delegator) delegateShowCreateDatabase(n *tree.ShowCreate) (tree.Statement, error) {
+	const showCreateQuery = `
+SELECT
+	name AS database_name,
+	create_statement
+FROM crdb_internal.databases
+WHERE name = %s
+;
+`
+
+	// Checking if the database exists before running the sql.
+	_, err := d.getSpecifiedOrCurrentDatabase(tree.Name(n.Name.Object()))
+	if err != nil {
+		return nil, err
+	}
+
+	return parse(fmt.Sprintf(showCreateQuery, lex.EscapeSQLString(n.Name.Object())))
+}
+
+func (d *delegator) delegateShowCreateTable(n *tree.ShowCreate) (tree.Statement, error) {
 	const showCreateQuery = `
 WITH zone_configs AS (
 		SELECT

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -253,14 +253,16 @@ CREATE TABLE crdb_internal.databases (
    owner NAME NOT NULL,
    primary_region STRING NULL,
    regions STRING[] NULL,
-   survival_goal STRING NULL
+   survival_goal STRING NULL,
+   create_statement STRING NOT NULL
 )  CREATE TABLE crdb_internal.databases (
    id INT8 NOT NULL,
    name STRING NOT NULL,
    owner NAME NOT NULL,
    primary_region STRING NULL,
    regions STRING[] NULL,
-   survival_goal STRING NULL
+   survival_goal STRING NULL,
+   create_statement STRING NOT NULL
 )  {}  {}
 CREATE TABLE crdb_internal.feature_usage (
    feature_name STRING NOT NULL,

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -1057,7 +1057,7 @@ func (u *sqlSymUnion) objectNamePrefixList() tree.ObjectNamePrefixList {
 %type <str> cursor_name database_name index_name opt_index_name column_name insert_column_item statistics_name window_name
 %type <str> family_name opt_family_name table_alias_name constraint_name target_name zone_name partition_name collation_name
 %type <str> db_object_name_component
-%type <*tree.UnresolvedObjectName> table_name standalone_index_name sequence_name type_name view_name db_object_name simple_db_object_name complex_db_object_name
+%type <*tree.UnresolvedObjectName> table_name db_name standalone_index_name sequence_name type_name view_name db_object_name simple_db_object_name complex_db_object_name
 %type <[]*tree.UnresolvedObjectName> type_name_list
 %type <str> schema_name
 %type <tree.ObjectNamePrefix>  qualifiable_schema_name opt_schema_name
@@ -5343,10 +5343,10 @@ show_transaction_stmt:
   }
 | SHOW TRANSACTION error // SHOW HELP: SHOW TRANSACTION
 
-// %Help: SHOW CREATE - display the CREATE statement for a table, sequence or view
+// %Help: SHOW CREATE - display the CREATE statement for a table, sequence, view, or database
 // %Category: DDL
 // %Text:
-// SHOW CREATE [ TABLE | SEQUENCE | VIEW ] <tablename>
+// SHOW CREATE [ TABLE | SEQUENCE | VIEW | DATABASE ] <object_name>
 // SHOW CREATE ALL TABLES
 // %SeeAlso: WEBDOCS/show-create-table.html
 show_create_stmt:
@@ -5354,21 +5354,31 @@ show_create_stmt:
   {
     $$.val = &tree.ShowCreate{Name: $3.unresolvedObjectName()}
   }
-| SHOW CREATE create_kw table_name
-  {
+| SHOW CREATE TABLE table_name
+	{
     /* SKIP DOC */
-    $$.val = &tree.ShowCreate{Name: $4.unresolvedObjectName()}
-  }
+    $$.val = &tree.ShowCreate{Mode: tree.ShowCreateModeTable, Name: $4.unresolvedObjectName()}
+	}
+| SHOW CREATE VIEW table_name
+	{
+    /* SKIP DOC */
+    $$.val = &tree.ShowCreate{Mode: tree.ShowCreateModeView, Name: $4.unresolvedObjectName()}
+	}
+| SHOW CREATE SEQUENCE table_name
+	{
+    /* SKIP DOC */
+    $$.val = &tree.ShowCreate{Mode: tree.ShowCreateModeSequence, Name: $4.unresolvedObjectName()}
+	}
+| SHOW CREATE DATABASE db_name
+	{
+    /* SKIP DOC */
+    $$.val = &tree.ShowCreate{Mode: tree.ShowCreateModeDatabase, Name: $4.unresolvedObjectName()}
+	}
 | SHOW CREATE ALL TABLES
   {
     $$.val = &tree.ShowCreateAllTables{}
   }
 | SHOW CREATE error // SHOW HELP: SHOW CREATE
-
-create_kw:
-  TABLE
-| VIEW
-| SEQUENCE
 
 // %Help: SHOW USERS - list defined users
 // %Category: Priv
@@ -12310,6 +12320,8 @@ opt_schema_name:
 	}
 
 table_name:            db_object_name
+
+db_name:               db_object_name
 
 standalone_index_name: db_object_name
 

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -492,14 +492,34 @@ func (node *ShowRoleGrants) Format(ctx *FmtCtx) {
 	}
 }
 
+// ShowCreateMode denotes what kind of SHOW CREATE should be used
+type ShowCreateMode int
+
+const (
+	// ShowCreateModeTable represents SHOW CREATE TABLE
+	ShowCreateModeTable ShowCreateMode = iota
+	// ShowCreateModeView represents SHOW CREATE VIEW
+	ShowCreateModeView
+	// ShowCreateModeSequence represents SHOW CREATE SEQUENCE
+	ShowCreateModeSequence
+	// ShowCreateModeDatabase represents SHOW CREATE DATABASE
+	ShowCreateModeDatabase
+)
+
 // ShowCreate represents a SHOW CREATE statement.
 type ShowCreate struct {
+	Mode ShowCreateMode
 	Name *UnresolvedObjectName
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowCreate) Format(ctx *FmtCtx) {
 	ctx.WriteString("SHOW CREATE ")
+
+	switch node.Mode {
+	case ShowCreateModeDatabase:
+		ctx.WriteString("DATABASE ")
+	}
 	ctx.FormatNode(node.Name)
 }
 


### PR DESCRIPTION
Previously, this was not supported as databases did not have
attributes.
With the addition of region attributes, this patch adds SHOW CREATE
DATABASE to get database details.

Release note (sql change): The SHOW CREATE DATABASE command was added to
get database metadata.