### PR TITLE
release-20.2: ui: fix metric rendering when node data is missing

### DIFF
--- a/pkg/ui/src/views/cluster/util/graphs.ts
+++ b/pkg/ui/src/views/cluster/util/graphs.ts
@@ -293,7 +293,7 @@ export type formattedSeries = {
   fillOpacity: number,
 };
 
-function formatMetricData(
+export function formatMetricData(
   metrics: React.ReactElement<MetricProps>[],
   data: TSResponse,
 ): formattedSeries[] {
@@ -571,8 +571,6 @@ export function configureUPlotLineChart(
           width: 1,
           label: result.key,
           stroke: color,
-          // Adds transparency to the fill color
-          fill: color + "10",
           points: {
             show: false,
           },


### PR DESCRIPTION
Backport 1/1 commits from #66027.

/cc @cockroachdb/release

---

Previously, the logic for deciding how to render
changes to data did not account for the fact that
a new dataset could contain a different set of
series than the one the graph was initially created
with. The update logic would try to push the new 
dataset into an existing uPlot instance and if the
dimensions didn't match, we'd see errors, or worse
if the dimensions *did* match but this series were
different, we'd show incorrect data. This arose in
particular when customers had decommissioned nodes
in their clusters which can have historical data
available in the cluster that stops at a certain
point in time.

This change now routes all uPlot data through the
`formatMetricData` function which accounts for
empty series. In addition, we check the set of keys
for all the series in the data when deciding whether
to render a new graph or update an existing one.

This commit also contains two single-line changes
to resolve some additional requests:
- permitting selection of time ranges under 10m
- removing translucent shading on plots

Resolves: #65089
Resolves: #64998
Resolves: #65034
Resolves: #65026

Release note (ui change): Fixed bug where empty
series would show up in metrics graphs and legend
and when data was incorrectly attributed to the 
wrong nodes on graphs for clusters with 
decommissioned nodes.

Release note (ui change): Removed shading on line
graphs which improves legibility when viewing more
than a few series on the same plot.

Release note (ui change): Drag to zoom on metrics
graphs now supports time ranges under 10 minutes.
