### PR TITLE
bazel: remove `log`, `caller` packages from `broken_in_bazel` allowlist

### DIFF
--- a/build/bazelutil/check.sh
+++ b/build/bazelutil/check.sh
@@ -42,8 +42,6 @@ pkg/cmd/prereqs/BUILD.bazel
 pkg/cmd/publish-artifacts/BUILD.bazel
 pkg/cmd/roachtest/BUILD.bazel
 pkg/cmd/teamcity-trigger/BUILD.bazel
-pkg/util/caller/BUILD.bazel
-pkg/util/log/BUILD.bazel
 "
 
 git grep 'go:generate stringer' pkg | while read LINE; do


### PR DESCRIPTION
Release note: None