### PR TITLE
release-20.2: sql: fix lease_holder_locality in SHOW RANGES

### DIFF
--- a/pkg/sql/delegate/show_range_for_row.go
+++ b/pkg/sql/delegate/show_range_for_row.go
@@ -64,11 +64,10 @@ SELECT
 	CASE WHEN r.end_key >= x'%[6]s' THEN NULL ELSE crdb_internal.pretty_key(r.end_key, 2) END AS end_key,
 	range_id,
 	lease_holder,
-	gossip_nodes.locality as lease_holder_locality,
+	replica_localities[array_position(replicas, lease_holder)] as lease_holder_locality,
 	replicas,
 	replica_localities
 FROM %[4]s.crdb_internal.ranges AS r
-LEFT JOIN %[4]s.crdb_internal.gossip_nodes ON lease_holder = node_id
 WHERE (r.start_key <= crdb_internal.encode_key(%[1]d, %[2]d, %[3]s))
   AND (r.end_key   >  crdb_internal.encode_key(%[1]d, %[2]d, %[3]s)) ORDER BY r.start_key
 	`
@@ -84,5 +83,4 @@ WHERE (r.start_key <= crdb_internal.encode_key(%[1]d, %[2]d, %[3]s))
 			idxSpanEnd,
 		),
 	)
-
 }

--- a/pkg/sql/show_ranges_test.go
+++ b/pkg/sql/show_ranges_test.go
@@ -17,10 +17,12 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestShowRangesWithLocality(t *testing.T) {
@@ -71,5 +73,65 @@ func TestShowRangesWithLocality(t *testing.T) {
 		if row[localitiesColIdx] != expected {
 			t.Fatalf("expected %s found %s", expected, row[localitiesColIdx])
 		}
+	}
+}
+
+// TestRangeLocalityBasedOnNodeIDs tests that the leaseholder_locality shown in
+// SHOW RANGES works correctly.
+func TestShowRangesMultipleStores(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	// NodeID=1, StoreID=1,2
+	tc := testcluster.StartTestCluster(t, 1,
+		base.TestClusterArgs{
+			ServerArgs: base.TestServerArgs{
+				Locality:   roachpb.Locality{Tiers: []roachpb.Tier{{Key: "node", Value: "1"}}},
+				StoreSpecs: []base.StoreSpec{base.DefaultTestStoreSpec, base.DefaultTestStoreSpec},
+			},
+
+			ReplicationMode: base.ReplicationAuto,
+		},
+	)
+	defer tc.Stopper().Stop(ctx)
+	// NodeID=2, StoreID=3,4
+	tc.AddAndStartServer(t,
+		base.TestServerArgs{
+			Locality:   roachpb.Locality{Tiers: []roachpb.Tier{{Key: "node", Value: "2"}}},
+			StoreSpecs: []base.StoreSpec{base.DefaultTestStoreSpec, base.DefaultTestStoreSpec},
+		},
+	)
+	// NodeID=3, StoreID=5,6
+	tc.AddAndStartServer(t,
+		base.TestServerArgs{
+			Locality:   roachpb.Locality{Tiers: []roachpb.Tier{{Key: "node", Value: "3"}}},
+			StoreSpecs: []base.StoreSpec{base.DefaultTestStoreSpec, base.DefaultTestStoreSpec},
+		},
+	)
+	assert.NoError(t, tc.WaitForFullReplication())
+
+	// Scatter a system table so that the lease is unlike to be on node 1.
+	sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
+	sqlDB.Exec(t, "ALTER TABLE system.jobs SCATTER")
+	// Ensure that the localities line up.
+	for _, q := range []string{
+		"SHOW RANGES FROM DATABASE system",
+		"SHOW RANGES FROM TABLE system.jobs",
+		"SHOW RANGES FROM INDEX system.jobs@jobs_status_created_idx",
+		"SHOW RANGE FROM TABLE system.jobs FOR ROW (0)",
+		"SHOW RANGE FROM INDEX system.jobs@jobs_status_created_idx FOR ROW ('running', now(), 0)",
+	} {
+		t.Run(q, func(t *testing.T) {
+			sqlDB.CheckQueryResults(t,
+				fmt.Sprintf(`
+SELECT DISTINCT
+		(
+		array_position(replica_localities, lease_holder_locality)
+		= array_position(replicas, lease_holder)
+		)
+	FROM [%s]`, q), [][]string{{"true"}})
+		})
 	}
 }


### PR DESCRIPTION
Backport 1/1 commits from #65994.

/cc @cockroachdb/release

---

Before this change we would match replicas up with localities by node id rather
thank store id. This was wrong and would lead to weird results.

Fixes #65990.

Release note (bug fix): Fix a bug in `SHOW RANGES` which misattributed
localities to nodes when using multiple stores.
