### PR TITLE
backupccl: fixing flaky TestCleanupIntentsDuringBackupPerformanceRegression test

### DIFF
--- a/pkg/ccl/backupccl/backup_intents_test.go
+++ b/pkg/ccl/backupccl/backup_intents_test.go
@@ -36,7 +36,7 @@ func TestCleanupIntentsDuringBackupPerformanceRegression(t *testing.T) {
 	// Time to create backup in presence of intents differs roughly 10x so some
 	// arbitrary number is picked which is 2x higher than current backup time on
 	// current (laptop) hardware.
-	const backupTimeout = time.Second * 10
+	const backupTimeout = time.Second * 20
 
 	const totalRowCount = 10000
 	const perTransactionRowCount = 10


### PR DESCRIPTION
Increasing test timeout from 10 to 20 sec to stop CI failing. This
value is safe as regressions take 60 sec when they start showing
quadratic behaviours.

Release note: None