### PR TITLE
changefeedccl: set sarama's flush frequency to 0 by default.

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -2536,7 +2536,7 @@ func TestChangefeedErrors(t *testing.T) {
 	)
 	sqlDB.ExpectErr(
 		t, `client has run out of available brokers`,
-		`CREATE CHANGEFEED FOR foo INTO 'kafka://nope/' WITH kafka_sink_config='{"Flush": {"Messages": 100}}'`,
+		`CREATE CHANGEFEED FOR foo INTO 'kafka://nope/' WITH kafka_sink_config='{"Flush": {"Messages": 100, "Frequency": "1s"}}'`,
 	)
 	// The avro format doesn't support key_in_value yet.
 	sqlDB.ExpectErr(

--- a/pkg/ccl/changefeedccl/sink_kafka.go
+++ b/pkg/ccl/changefeedccl/sink_kafka.go
@@ -144,9 +144,14 @@ func defaultSaramaConfig() *saramaConfig {
 	// to test this one more before changing it.
 	config.Flush.MaxMessages = 1000
 
-	// config.Producer.Flush.Messages is set to 1 so we don't need this, but
-	// sarama prints scary things to the logs if we don't.
-	config.Flush.Frequency = jsonDuration(time.Hour)
+	// Setting Frequency to 0 disables time-based flushes. This is
+	// OK because we set Flush.Messages = 1, which should mean
+	// that sarama will always try to flush its buffer if it has
+	// at least 1 message in it.
+	//
+	// This will produce a warning at the start of a changefeed
+	// that may alarm some users.
+	config.Flush.Frequency = jsonDuration(0)
 
 	return config
 }

--- a/pkg/ccl/changefeedccl/sink_kafka.go
+++ b/pkg/ccl/changefeedccl/sink_kafka.go
@@ -110,27 +110,36 @@ type saramaConfig struct {
 	Version string `json:",omitempty"`
 }
 
+func (c saramaConfig) Validate() error {
+	// If Flush.Bytes > 0 or Flush.Messages > 1 without
+	// Flush.Frequency, sarama may wait forever to flush the
+	// messages to Kafka.  We want to guard against such
+	// configurations to ensure that we don't get into a situation
+	// where our call to Flush() would block forever.
+	if (c.Flush.Bytes > 0 || c.Flush.Messages > 1) && c.Flush.Frequency == 0 {
+		return errors.New("Flush.Frequency must be > 0 when Flush.Bytes > 0 or Flush.Messages > 1")
+	}
+	return nil
+}
+
 func defaultSaramaConfig() *saramaConfig {
 	config := &saramaConfig{}
 
-	// When we emit messages to sarama, they're placed in a queue (as does any
-	// reasonable kafka producer client). When our sink's Flush is called, we
-	// have to wait for all buffered and inflight requests to be sent and then
-	// acknowledged. Quite unfortunately, we have no way to hint to the producer
-	// that it should immediately send out whatever is buffered. This
-	// configuration can have a dramatic impact on how quickly this happens
-	// naturally (and some configurations will block forever!).
+	// When we emit messages to sarama, they're placed in a queue
+	// (as does any reasonable kafka producer client). When our
+	// sink's Flush is called, we have to wait for all buffered
+	// and inflight requests to be sent and then
+	// acknowledged. Quite unfortunately, we have no way to hint
+	// to the producer that it should immediately send out
+	// whatever is buffered. This configuration can have a
+	// dramatic impact on how quickly this happens naturally (and
+	// some configurations will block forever!).
 	//
-	// We can configure the producer to send out its batches based on number of
-	// messages and/or total buffered message size and/or time. If none of them
-	// are set, it uses some defaults, but if any of the three are set, it does
-	// no defaulting. Which means that if `Flush.Messages` is set to 10 and
-	// nothing else is set, then 9/10 times `Flush` will block forever. We can
-	// work around this by also setting `Flush.Frequency` but a cleaner way is
-	// to set `Flush.Messages` to 1. In the steady state, this sends a request
-	// with some messages, buffers any messages that come in while it is in
-	// flight, then sends those out.
-	config.Flush.Messages = 1
+	// The default configuration of all 0 values will send
+	// messages as quickly as possible.
+	config.Flush.Messages = 0
+	config.Flush.Frequency = jsonDuration(0)
+	config.Flush.Bytes = 0
 
 	// This works around what seems to be a bug in sarama where it isn't
 	// computing the right value to compare against `Producer.MaxMessageBytes`
@@ -143,15 +152,6 @@ func defaultSaramaConfig() *saramaConfig {
 	// this workaround is the one that's been running in roachtests and I'd want
 	// to test this one more before changing it.
 	config.Flush.MaxMessages = 1000
-
-	// Setting Frequency to 0 disables time-based flushes. This is
-	// OK because we set Flush.Messages = 1, which should mean
-	// that sarama will always try to flush its buffer if it has
-	// at least 1 message in it.
-	//
-	// This will produce a warning at the start of a changefeed
-	// that may alarm some users.
-	config.Flush.Frequency = jsonDuration(0)
 
 	return config
 }
@@ -614,6 +614,11 @@ func buildKafkaConfig(u sinkURL, opts map[string]string) (*sarama.Config, error)
 		return nil, errors.Wrapf(err,
 			"failed to parse sarama config; check %s option", changefeedbase.OptKafkaSinkConfig)
 	}
+
+	if err := saramaCfg.Validate(); err != nil {
+		return nil, errors.Wrap(err, "invalid sarama configuration")
+	}
+
 	if err := saramaCfg.Apply(config); err != nil {
 		return nil, errors.Wrap(err, "failed to apply kafka client configuration")
 	}

--- a/pkg/ccl/changefeedccl/sink_test.go
+++ b/pkg/ccl/changefeedccl/sink_test.go
@@ -514,6 +514,32 @@ func TestSaramaConfigOptionParsing(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, expected, cfg)
 	})
+	t.Run("validate returns nil for valid flush configuration", func(t *testing.T) {
+		opts := make(map[string]string)
+
+		opts[changefeedbase.OptKafkaSinkConfig] = `{"Flush": {"Messages": 1000, "Frequency": "1s"}}`
+		cfg, err := getSaramaConfig(opts)
+		require.NoError(t, err)
+		require.NoError(t, cfg.Validate())
+
+		opts[changefeedbase.OptKafkaSinkConfig] = `{"Flush": {"Messages": 1}}`
+		cfg, err = getSaramaConfig(opts)
+		require.NoError(t, err)
+		require.NoError(t, cfg.Validate())
+	})
+	t.Run("validate returns error for bad flush configurationg", func(t *testing.T) {
+		opts := make(map[string]string)
+		opts[changefeedbase.OptKafkaSinkConfig] = `{"Flush": {"Messages": 1000}}`
+
+		cfg, err := getSaramaConfig(opts)
+		require.NoError(t, err)
+		require.Error(t, cfg.Validate())
+
+		opts[changefeedbase.OptKafkaSinkConfig] = `{"Flush": {"Bytes": 10}}`
+		cfg, err = getSaramaConfig(opts)
+		require.NoError(t, err)
+		require.Error(t, cfg.Validate())
+	})
 	t.Run("apply parses valid version", func(t *testing.T) {
 		opts := make(map[string]string)
 		opts[changefeedbase.OptKafkaSinkConfig] = `{"version": "0.8.2.0"}`


### PR DESCRIPTION
The default of 1 hours was added to avoid a warning that sarama
produces when you set flush.Messages but not flush.Frequency. When
flush.Messages is 1, we believe this warning is incorrect since Sarama
will always try to flush its buffer when it has a message and
flush.Messages = 1.

Unfortunately, sarama creates a new timer after every flush. Under
constant load, we will flush very frequently. The timers it creates
are kept alive by the Go runtime until they expire. This means we can
accumulate 1 hours worth of timers.

During a 1 hour run of the cdc/ledger roachtest, these times grew to
two hundred MBs of inuse space. By setting the timer to 0, we avoid
this accumulation.

Because of this changes, users will occasionally see the following
error message:

    [kafka-producer] 202 ‹Producer.Flush: Bytes or Messages are set,
    but Frequency is not; messages may not get flushed.›

This warning can be ignored for our default configuration.

Release note: None