### PR TITLE
release-21.1: kvserver: deflake TestMergeQueue

### DIFF
--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -4091,7 +4091,6 @@ func TestMergeQueue(t *testing.T) {
 	zoneConfig.RangeMinBytes = &rangeMinBytes
 	settings := cluster.MakeTestingClusterSettings()
 	sv := &settings.SV
-	kvserverbase.MergeQueueEnabled.Override(sv, true)
 	kvserver.MergeQueueInterval.Override(sv, 0) // process greedily
 
 	tc := testcluster.StartTestCluster(t, 2,
@@ -4114,7 +4113,8 @@ func TestMergeQueue(t *testing.T) {
 	store := tc.GetFirstStoreFromServer(t, 0)
 	// The cluster with manual replication disables the merge queue,
 	// so we need to re-enable.
-	kvserverbase.MergeQueueEnabled.Override(sv, true)
+	_, err := tc.ServerConn(0).Exec(`SET CLUSTER SETTING kv.range_merge.queue_enabled = true`)
+	require.NoError(t, err)
 	store.SetMergeQueueActive(true)
 
 	split := func(t *testing.T, key roachpb.Key, expirationTime hlc.Timestamp) {
@@ -4216,20 +4216,13 @@ func TestMergeQueue(t *testing.T) {
 
 	t.Run("non-collocated", func(t *testing.T) {
 		reset(t)
-		rangeID := rhs().RangeID
 		verifyUnmerged(t, store, lhsStartKey, rhsStartKey)
 		tc.AddVotersOrFatal(t, rhs().Desc().StartKey.AsRawKey(), tc.Target(1))
 		tc.TransferRangeLeaseOrFatal(t, *rhs().Desc(), tc.Target(1))
+		// NB: We're running on a 2 node `TestCluster` so we can count on the
+		// replica being removed to learn about the removal synchronously.
+		require.Equal(t, tc.NumServers(), 2)
 		tc.RemoveVotersOrFatal(t, rhs().Desc().StartKey.AsRawKey(), tc.Target(0))
-		testutils.SucceedsSoon(t, func() error {
-			_, err := tc.GetFirstStoreFromServer(t, 0).GetReplica(rangeID)
-			if err == nil {
-				return fmt.Errorf("replica still exists on dest %d", tc.Target(0))
-			} else if errors.HasType(err, (*roachpb.RangeNotFoundError)(nil)) {
-				return nil
-			}
-			return err
-		})
 
 		clearRange(t, lhsStartKey, rhsEndKey)
 		store.MustForceMergeScanAndProcess()


### PR DESCRIPTION
The test started flaking after ce73bc1. The issue was that there was a race
between when the merge queue was enabled via an `Override()` call and when
these tests assert that a given range actually got merged away. In other words,
these tests were sometime getting to their assertion before the relevant server
learned that the merge queue was enabled.

This patch modifies the test to instead enable the merge queue via SQL and not
through the `Override()` call.

Resolves #64866
Resolves #64056
Resolves #63009

Release note: None