### PR TITLE
ui: Adding TransactionsPageConnected for Cluster UI 20.2

### DIFF
--- a/pkg/ui/cluster-ui/src/store/reducers.ts
+++ b/pkg/ui/cluster-ui/src/store/reducers.ts
@@ -19,6 +19,7 @@ import {
 import { NodesState, reducer as nodes } from "./nodes";
 import { LivenessState, reducer as liveness } from "./liveness";
 import { SessionsState, reducer as sessions } from "./sessions";
+import { TransactionsState, reducer as transactions } from "./transactions";
 import {
   TerminateQueryState,
   reducer as terminateQuery,
@@ -33,6 +34,7 @@ export type AdminUiState = {
   nodes: NodesState;
   liveness: LivenessState;
   sessions: SessionsState;
+  transactions: TransactionsState;
   terminateQuery: TerminateQueryState;
   uiConfig: UIConfigState;
 };
@@ -48,6 +50,7 @@ export const reducers = combineReducers<AdminUiState>({
   nodes,
   liveness,
   sessions,
+  transactions,
   terminateQuery,
   uiConfig,
 });

--- a/pkg/ui/cluster-ui/src/store/sagas.ts
+++ b/pkg/ui/cluster-ui/src/store/sagas.ts
@@ -16,6 +16,7 @@ import { statementsSaga } from "./statements";
 import { nodesSaga } from "./nodes";
 import { livenessSaga } from "./liveness";
 import { sessionsSaga } from "./sessions";
+import { transactionsSaga } from "./transactions";
 import { terminateSaga } from "./terminateQuery";
 import { notifificationsSaga } from "./notifications";
 
@@ -27,6 +28,7 @@ export function* sagas(cacheInvalidationPeriod?: number) {
     fork(nodesSaga, cacheInvalidationPeriod),
     fork(livenessSaga, cacheInvalidationPeriod),
     fork(sessionsSaga),
+    fork(transactionsSaga),
     fork(terminateSaga),
     fork(notifificationsSaga),
   ]);

--- a/pkg/ui/cluster-ui/src/store/transactions/index.ts
+++ b/pkg/ui/cluster-ui/src/store/transactions/index.ts
@@ -8,5 +8,5 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-export * from "./transactionsPage";
-export * from "./transactionsPageConnected";
+export * from "./transactions.reducer";
+export * from "./transactions.sagas";

--- a/pkg/ui/cluster-ui/src/store/transactions/transactions.reducer.ts
+++ b/pkg/ui/cluster-ui/src/store/transactions/transactions.reducer.ts
@@ -1,0 +1,51 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+import { DOMAIN_NAME, noopReducer } from "../utils";
+
+type StatementsResponse = cockroach.server.serverpb.StatementsResponse;
+
+export type TransactionsState = {
+  data: StatementsResponse;
+  lastError: Error;
+  valid: boolean;
+};
+
+const initialState: TransactionsState = {
+  data: null,
+  lastError: null,
+  valid: true,
+};
+
+const transactionsSlice = createSlice({
+  name: `${DOMAIN_NAME}/transactions`,
+  initialState,
+  reducers: {
+    received: (state, action: PayloadAction<StatementsResponse>) => {
+      state.data = action.payload;
+      state.valid = true;
+      state.lastError = null;
+    },
+    failed: (state, action: PayloadAction<Error>) => {
+      state.valid = false;
+      state.lastError = action.payload;
+    },
+    invalidated: state => {
+      state.valid = false;
+    },
+    // Define actions that don't change state
+    refresh: noopReducer,
+    request: noopReducer,
+  },
+});
+
+export const { reducer, actions } = transactionsSlice;

--- a/pkg/ui/cluster-ui/src/store/transactions/transactions.sagas.spec.ts
+++ b/pkg/ui/cluster-ui/src/store/transactions/transactions.sagas.spec.ts
@@ -1,0 +1,87 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { expectSaga } from "redux-saga-test-plan";
+import { throwError } from "redux-saga-test-plan/providers";
+import * as matchers from "redux-saga-test-plan/matchers";
+import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+
+import { getStatements } from "src/api/statementsApi";
+
+import {
+  receivedTransactionsSaga,
+  refreshTransactionsSaga,
+  requestTransactionsSaga,
+} from "./transactions.sagas";
+import { actions, reducer, TransactionsState } from "./transactions.reducer";
+
+describe("TransactionsPage sagas", () => {
+  const statements = new cockroach.server.serverpb.StatementsResponse({
+    statements: [],
+    last_reset: null,
+  });
+
+  describe("refreshTransactionsSaga", () => {
+    it("dispatches request transactions action", () => {
+      expectSaga(refreshTransactionsSaga)
+        .put(actions.request())
+        .run();
+    });
+  });
+
+  describe("requestStatementsSaga", () => {
+    it("successfully requests statements list", () => {
+      expectSaga(requestTransactionsSaga)
+        .provide([[matchers.call.fn(getStatements), statements]])
+        .put(actions.received(statements))
+        .withReducer(reducer)
+        .hasFinalState<TransactionsState>({
+          data: statements,
+          lastError: null,
+          valid: true,
+        })
+        .run();
+    });
+
+    it("returns error on failed request", () => {
+      const error = new Error("Failed request");
+      expectSaga(requestTransactionsSaga)
+        .provide([[matchers.call.fn(getStatements), throwError(error)]])
+        .put(actions.failed(error))
+        .withReducer(reducer)
+        .hasFinalState<TransactionsState>({
+          data: null,
+          lastError: error,
+          valid: false,
+        })
+        .run();
+    });
+  });
+
+  describe("receivedStatementsSaga", () => {
+    it("sets valid status to false after specified period of time", () => {
+      const timeout = 500;
+      expectSaga(receivedTransactionsSaga, timeout)
+        .delay(timeout)
+        .put(actions.invalidated())
+        .withReducer(reducer, {
+          data: statements,
+          lastError: null,
+          valid: true,
+        })
+        .hasFinalState<TransactionsState>({
+          data: statements,
+          lastError: null,
+          valid: false,
+        })
+        .run(1000);
+    });
+  });
+});

--- a/pkg/ui/cluster-ui/src/store/transactions/transactions.sagas.ts
+++ b/pkg/ui/cluster-ui/src/store/transactions/transactions.sagas.ts
@@ -1,0 +1,53 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { all, call, put, delay, takeLatest } from "redux-saga/effects";
+import { getStatements } from "src/api/statementsApi";
+import { actions } from "./transactions.reducer";
+import { rootActions } from "../reducers";
+
+import { CACHE_INVALIDATION_PERIOD, throttleWithReset } from "src/store/utils";
+
+export function* refreshTransactionsSaga() {
+  yield put(actions.request());
+}
+
+export function* requestTransactionsSaga() {
+  try {
+    const result = yield call(getStatements);
+    yield put(actions.received(result));
+  } catch (e) {
+    yield put(actions.failed(e));
+  }
+}
+
+export function* receivedTransactionsSaga(delayMs: number) {
+  yield delay(delayMs);
+  yield put(actions.invalidated());
+}
+
+export function* transactionsSaga(
+  cacheInvalidationPeriod: number = CACHE_INVALIDATION_PERIOD,
+) {
+  yield all([
+    throttleWithReset(
+      cacheInvalidationPeriod,
+      actions.refresh,
+      [actions.invalidated, actions.failed, rootActions.resetState],
+      refreshTransactionsSaga,
+    ),
+    takeLatest(actions.request, requestTransactionsSaga),
+    takeLatest(
+      actions.received,
+      receivedTransactionsSaga,
+      cacheInvalidationPeriod,
+    ),
+  ]);
+}

--- a/pkg/ui/cluster-ui/src/transactionsPage/transactionsPage.selectors.ts
+++ b/pkg/ui/cluster-ui/src/transactionsPage/transactionsPage.selectors.ts
@@ -1,0 +1,28 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { createSelector } from "reselect";
+
+import { adminUISelector } from "../statementsPage/statementsPage.selectors";
+
+export const selectTransactionsSlice = createSelector(
+  adminUISelector,
+  adminUiState => adminUiState.transactions,
+);
+
+export const selectTransactionsData = createSelector(
+  selectTransactionsSlice,
+  transactionsState => transactionsState.data,
+);
+
+export const selectTransactionsLastError = createSelector(
+  selectTransactionsSlice,
+  state => state.lastError,
+);

--- a/pkg/ui/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -60,13 +60,19 @@ interface TState {
   statementIds: Long[] | null;
 }
 
-interface TransactionsPageProps {
+export interface TransactionsPageStateProps {
   data: IStatementsResponse;
-  refreshData: () => void;
   error?: Error | null;
   pageSize?: number;
 }
 
+export interface TransactionsPageDispatchProps {
+  refreshData: () => void;
+}
+
+export type TransactionsPageProps = TransactionsPageStateProps &
+  TransactionsPageDispatchProps &
+  RouteComponentProps;
 export class TransactionsPage extends React.Component<
   RouteComponentProps & TransactionsPageProps
 > {

--- a/pkg/ui/cluster-ui/src/transactionsPage/transactionsPageConnected.tsx
+++ b/pkg/ui/cluster-ui/src/transactionsPage/transactionsPageConnected.tsx
@@ -1,0 +1,41 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { connect } from "react-redux";
+import { RouteComponentProps, withRouter } from "react-router-dom";
+import { Dispatch } from "redux";
+
+import { AppState } from "src/store";
+import { actions as transactionsActions } from "src/store/transactions";
+import { TransactionsPage } from "./transactionsPage";
+import {
+  TransactionsPageStateProps,
+  TransactionsPageDispatchProps,
+} from "./transactionsPage";
+import {
+  selectTransactionsData,
+  selectTransactionsLastError,
+} from "./transactionsPage.selectors";
+
+export const TransactionsPageConnected = withRouter(
+  connect<
+    TransactionsPageStateProps,
+    TransactionsPageDispatchProps,
+    RouteComponentProps
+  >(
+    (state: AppState) => ({
+      data: selectTransactionsData(state),
+      error: selectTransactionsLastError(state),
+    }),
+    (dispatch: Dispatch) => ({
+      refreshData: () => dispatch(transactionsActions.refresh()),
+    }),
+  )(TransactionsPage),
+);


### PR DESCRIPTION
Added a transactionsPageConnected to cluster-ui for use in the published
   package. Also added the associated reducer, sagas, and selectors to support
   the connection with a Redux store.