### PR TITLE
logcrash: update non-release Sentry URL

### DIFF
--- a/pkg/util/log/logcrash/crash_reporting.go
+++ b/pkg/util/log/logcrash/crash_reporting.go
@@ -164,7 +164,7 @@ func PanicAsError(depth int, r interface{}) error {
 // Non-release builds wishing to use Sentry reports
 // are invited to use the following URL instead:
 //
-//   https://ignored@errors.cockroachdb.com/sentrydev/v2/1111
+//   https://ignored@errors.cockroachdb.com/api/sentrydev/v2/1111
 //
 // This can be set via e.g. the env var COCKROACH_CRASH_REPORTS.
 // Note that the special number "1111" is important as it


### PR DESCRIPTION
The documentation for creating Sentry reports in non-release builds
directed developers to set the COCKROACH_CRASH_REPORTS env var to an
incorrect URL. Sentry reports were not created when using this URL. The
documentation has been updated to refer to the correct URL.

Release note: None