### PR TITLE
catalogkeys: clean up namespace keys

### DIFF
--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -267,20 +267,20 @@ func synthesizePGTempSchema(
 			return err
 		}
 
-		sKey := catalogkeys.NewSchemaKey(defaultDBID, schemaName)
+		sKey := catalogkeys.NewNameKeyComponents(defaultDBID, keys.RootNamespaceID, schemaName)
 		schemaID, err := catalogkv.GetDescriptorID(ctx, txn, p.ExecCfg().Codec, sKey)
 		if err != nil {
 			return err
 		}
 		if schemaID != descpb.InvalidID {
 			return errors.Newf("attempted to synthesize temp schema during RESTORE but found"+
-				" another schema already using the same schema key %s", sKey.Name())
+				" another schema already using the same schema key %s", sKey.GetName())
 		}
 		synthesizedSchemaID, err = catalogkv.GenerateUniqueDescID(ctx, p.ExecCfg().DB, p.ExecCfg().Codec)
 		if err != nil {
 			return err
 		}
-		return p.CreateSchemaNamespaceEntry(ctx, sKey.Key(p.ExecCfg().Codec), synthesizedSchemaID)
+		return p.CreateSchemaNamespaceEntry(ctx, catalogkeys.EncodeNameKey(p.ExecCfg().Codec, sKey), synthesizedSchemaID)
 	})
 
 	return synthesizedSchemaID, defaultDBID, err

--- a/pkg/ccl/streamingccl/streamclient/random_stream_client.go
+++ b/pkg/ccl/streamingccl/streamclient/random_stream_client.go
@@ -250,8 +250,8 @@ func (m *randomStreamClient) getDescriptorAndNamespaceKVForTableID(
 	}
 
 	// Generate namespace entry.
-	key := catalogkeys.NewTableKey(50, keys.PublicSchemaID, testTable.Name)
-	k := rekey(m.config.tenantID, key.Key(keys.TODOSQLCodec))
+	key := catalogkeys.MakePublicObjectNameKey(keys.TODOSQLCodec, 50, testTable.Name)
+	k := rekey(m.config.tenantID, key)
 	var value roachpb.Value
 	value.SetInt(int64(testTable.GetID()))
 	value.InitChecksum(k)

--- a/pkg/migration/migrations/delete_deprecated_namespace_tabledesc.go
+++ b/pkg/migration/migrations/delete_deprecated_namespace_tabledesc.go
@@ -31,10 +31,8 @@ func deleteDeprecatedNamespaceTableDescriptorMigration(
 	const pageSize = 1000
 	deprecatedTablePrefix := d.Codec.TablePrefix(uint32(keys.DeprecatedNamespaceTableID))
 	deprecatedTableDescKey := d.Codec.DescMetadataKey(keys.DeprecatedNamespaceTableID)
-	namespaceNameKey := catalogkeys.MakeNameMetadataKey(
-		d.Codec, keys.SystemDatabaseID, keys.PublicSchemaID, `namespace`)
-	namespace2NameKey := catalogkeys.MakeNameMetadataKey(
-		d.Codec, keys.SystemDatabaseID, keys.PublicSchemaID, `namespace2`)
+	namespaceNameKey := catalogkeys.MakePublicObjectNameKey(d.Codec, keys.SystemDatabaseID, `namespace`)
+	namespace2NameKey := catalogkeys.MakePublicObjectNameKey(d.Codec, keys.SystemDatabaseID, `namespace2`)
 
 	log.Info(ctx, "removing references to deprecated system.namespace table descriptor")
 	return d.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
@@ -77,10 +75,10 @@ func checkDeprecatedEntries(
 		var newKey roachpb.Key
 		if parentID == keys.RootNamespaceID {
 			// This is a database key, look for it in the new namespace table.
-			newKey = catalogkeys.NewDatabaseKey(name).Key(codec)
+			newKey = catalogkeys.MakeDatabaseNameKey(codec, name)
 		} else {
 			// This is a table key, look for it in the new namespace table.
-			newKey = catalogkeys.NewPublicTableKey(parentID, name).Key(codec)
+			newKey = catalogkeys.MakePublicObjectNameKey(codec, parentID, name)
 		}
 		b.Get(newKey)
 	}

--- a/pkg/migration/migrations/delete_deprecated_namespace_tabledesc_external_test.go
+++ b/pkg/migration/migrations/delete_deprecated_namespace_tabledesc_external_test.go
@@ -51,8 +51,10 @@ func TestDeleteDeprecatedNamespaceDescriptorMigration(t *testing.T) {
 		descProto := &descpb.Descriptor{Union: &descpb.Descriptor_Table{Table: &deprecated}}
 		b := txn.NewBatch()
 		b.Put(catalogkeys.MakeDescMetadataKey(codec, keys.DeprecatedNamespaceTableID), descProto)
-		b.Put(catalogkeys.NewPublicTableKey(keys.SystemDatabaseID, `namespace`).Key(codec), keys.DeprecatedNamespaceTableID)
-		b.Put(catalogkeys.NewPublicTableKey(keys.SystemDatabaseID, `namespace2`).Key(codec), keys.NamespaceTableID)
+		namespaceKey := catalogkeys.MakePublicObjectNameKey(codec, keys.SystemDatabaseID, `namespace`)
+		b.Put(namespaceKey, keys.DeprecatedNamespaceTableID)
+		namespace2Key := catalogkeys.MakePublicObjectNameKey(codec, keys.SystemDatabaseID, `namespace2`)
+		b.Put(namespace2Key, keys.NamespaceTableID)
 		return txn.Run(ctx, b)
 	})
 	require.NoError(t, err)
@@ -90,8 +92,8 @@ func TestDeleteDeprecatedNamespaceDescriptorMigrationOnlyNamespace2(t *testing.T
 		descProto := &descpb.Descriptor{Union: &descpb.Descriptor_Table{Table: &deprecated}}
 		b := txn.NewBatch()
 		b.Put(catalogkeys.MakeDescMetadataKey(codec, keys.DeprecatedNamespaceTableID), descProto)
-		b.Del(catalogkeys.NewPublicTableKey(keys.SystemDatabaseID, `namespace`).Key(codec))
-		b.Put(catalogkeys.NewPublicTableKey(keys.SystemDatabaseID, `namespace2`).Key(codec), keys.NamespaceTableID)
+		b.Del(catalogkeys.MakePublicObjectNameKey(codec, keys.SystemDatabaseID, `namespace`))
+		b.Put(catalogkeys.MakePublicObjectNameKey(codec, keys.SystemDatabaseID, `namespace2`), keys.NamespaceTableID)
 		return txn.Run(ctx, b)
 	})
 	require.NoError(t, err)

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -756,7 +756,7 @@ func maybeCheckTenantExists(ctx context.Context, codec keys.SQLCodec, db *kv.DB)
 		// Skip check for system tenant and return early.
 		return nil
 	}
-	key := catalogkeys.NewDatabaseKey(systemschema.SystemDatabaseName).Key(codec)
+	key := catalogkeys.MakeDatabaseNameKey(codec, systemschema.SystemDatabaseName)
 	result, err := db.Get(ctx, key)
 	if err != nil {
 		return err

--- a/pkg/sql/alter_schema.go
+++ b/pkg/sql/alter_schema.go
@@ -204,7 +204,7 @@ func (p *planner) renameSchema(
 	desc.SetName(newName)
 
 	// Write a new namespace entry for the new name.
-	nameKey := catalogkeys.NewSchemaKey(desc.ParentID, newName).Key(p.execCfg.Codec)
+	nameKey := catalogkeys.MakeSchemaNameKey(p.execCfg.Codec, desc.ParentID, newName)
 	b := p.txn.NewBatch()
 	if p.ExtendedEvalContext().Tracing.KVTracingEnabled() {
 		log.VEventf(ctx, 2, "CPut %s -> %d", nameKey, desc.ID)

--- a/pkg/sql/alter_table_set_schema.go
+++ b/pkg/sql/alter_table_set_schema.go
@@ -144,9 +144,7 @@ func (n *alterTableSetSchemaNode) startExec(params runParams) error {
 		return err
 	}
 
-	newTbKey := catalogkv.MakeObjectNameKey(databaseID, desiredSchemaID, tableDesc.Name)
-
-	if err := p.writeNameKey(ctx, newTbKey, tableDesc.ID); err != nil {
+	if err := p.writeNameKey(ctx, tableDesc, tableDesc.ID); err != nil {
 		return err
 	}
 

--- a/pkg/sql/alter_type.go
+++ b/pkg/sql/alter_type.go
@@ -288,10 +288,8 @@ func (p *planner) performRenameTypeDesc(
 	if err := p.writeTypeSchemaChange(ctx, desc, jobDesc); err != nil {
 		return err
 	}
-	// Construct the new namespace key.
-	key := catalogkv.MakeObjectNameKey(desc.ParentID, desc.ParentSchemaID, newName)
-
-	return p.writeNameKey(ctx, key, desc.ID)
+	// Write the new namespace key.
+	return p.writeNameKey(ctx, desc, desc.ID)
 }
 
 func (p *planner) renameTypeValue(

--- a/pkg/sql/catalog/bootstrap/metadata.go
+++ b/pkg/sql/catalog/bootstrap/metadata.go
@@ -112,7 +112,7 @@ func (ms MetadataSchema) GetInitialValues() ([]roachpb.KeyValue, []roachpb.RKey)
 		value.SetInt(int64(desc.GetID()))
 		if parentID != keys.RootNamespaceID {
 			ret = append(ret, roachpb.KeyValue{
-				Key:   catalogkeys.NewPublicTableKey(parentID, desc.GetName()).Key(ms.codec),
+				Key:   catalogkeys.MakePublicObjectNameKey(ms.codec, parentID, desc.GetName()),
 				Value: value,
 			})
 		} else {
@@ -123,11 +123,11 @@ func (ms MetadataSchema) GetInitialValues() ([]roachpb.KeyValue, []roachpb.RKey)
 			ret = append(
 				ret,
 				roachpb.KeyValue{
-					Key:   catalogkeys.NewDatabaseKey(desc.GetName()).Key(ms.codec),
+					Key:   catalogkeys.MakeDatabaseNameKey(ms.codec, desc.GetName()),
 					Value: value,
 				},
 				roachpb.KeyValue{
-					Key:   catalogkeys.NewPublicSchemaKey(desc.GetID()).Key(ms.codec),
+					Key:   catalogkeys.MakePublicSchemaNameKey(ms.codec, desc.GetID()),
 					Value: publicSchemaValue,
 				})
 		}

--- a/pkg/sql/catalog/catalogkeys/keys_test.go
+++ b/pkg/sql/catalog/catalogkeys/keys_test.go
@@ -27,16 +27,16 @@ func TestKeyAddress(t *testing.T) {
 	}{
 		{MakeDescMetadataKey(tenSysCodec, 123)},
 		{MakeDescMetadataKey(tenSysCodec, 124)},
-		{NewPublicTableKey(0, "BAR").Key(tenSysCodec)},
-		{NewPublicTableKey(1, "BAR").Key(tenSysCodec)},
-		{NewPublicTableKey(1, "foo").Key(tenSysCodec)},
-		{NewPublicTableKey(2, "foo").Key(tenSysCodec)},
+		{MakePublicObjectNameKey(tenSysCodec, 0, "BAR")},
+		{MakePublicObjectNameKey(tenSysCodec, 1, "BAR")},
+		{MakePublicObjectNameKey(tenSysCodec, 1, "foo")},
+		{MakePublicObjectNameKey(tenSysCodec, 2, "foo")},
 		{MakeDescMetadataKey(ten5Codec, 123)},
 		{MakeDescMetadataKey(ten5Codec, 124)},
-		{NewPublicTableKey(0, "BAR").Key(ten5Codec)},
-		{NewPublicTableKey(1, "BAR").Key(ten5Codec)},
-		{NewPublicTableKey(1, "foo").Key(ten5Codec)},
-		{NewPublicTableKey(2, "foo").Key(ten5Codec)},
+		{MakePublicObjectNameKey(ten5Codec, 0, "BAR")},
+		{MakePublicObjectNameKey(ten5Codec, 1, "BAR")},
+		{MakePublicObjectNameKey(ten5Codec, 1, "foo")},
+		{MakePublicObjectNameKey(ten5Codec, 2, "foo")},
 	}
 	var lastKey roachpb.Key
 	for i, test := range testCases {

--- a/pkg/sql/catalog/catalogkv/desc_getter.go
+++ b/pkg/sql/catalog/catalogkv/desc_getter.go
@@ -125,8 +125,7 @@ func (t *oneLevelUncachedDescGetter) GetNamespaceEntries(
 			// Ignore nameless requests.
 			continue
 		}
-		key := catalogkeys.MakeNameMetadataKey(t.codec, r.ParentID, r.ParentSchemaID, r.Name)
-		b.Get(key)
+		b.Get(catalogkeys.EncodeNameKey(t.codec, r))
 		isBatchEmpty = false
 	}
 	ret := make([]descpb.ID, len(requests))

--- a/pkg/sql/catalog/catalogkv/namespace.go
+++ b/pkg/sql/catalog/catalogkv/namespace.go
@@ -24,62 +24,6 @@ import (
 // system.namespace are never modified. We only write new entries or delete
 // existing entries.
 
-// WriteObjectNamespaceEntryRemovalToBatch writes Del operations to b for
-// both the deprecated and new system.namespace table (if one exists).
-func WriteObjectNamespaceEntryRemovalToBatch(
-	ctx context.Context,
-	b *kv.Batch,
-	codec keys.SQLCodec,
-	parentID descpb.ID,
-	parentSchemaID descpb.ID,
-	name string,
-	KVTrace bool,
-) {
-	delKey := MakeObjectNameKey(parentID, parentSchemaID, name)
-	if KVTrace {
-		log.VEventf(ctx, 2, "Del %s", delKey)
-	}
-	b.Del(delKey.Key(codec))
-}
-
-// RemoveObjectNamespaceEntry removes entries from both the deprecated and
-// new system.namespace table (if one exists).
-func RemoveObjectNamespaceEntry(
-	ctx context.Context,
-	txn *kv.Txn,
-	codec keys.SQLCodec,
-	parentID descpb.ID,
-	parentSchemaID descpb.ID,
-	name string,
-	KVTrace bool,
-) error {
-	b := txn.NewBatch()
-	WriteObjectNamespaceEntryRemovalToBatch(ctx, b, codec, parentID, parentSchemaID, name, KVTrace)
-	return txn.Run(ctx, b)
-}
-
-// RemoveSchemaNamespaceEntry is a wrapper around RemoveObjectNamespaceEntry
-// for schemas.
-func RemoveSchemaNamespaceEntry(
-	ctx context.Context, txn *kv.Txn, codec keys.SQLCodec, parentID descpb.ID, name string,
-) error {
-	return RemoveObjectNamespaceEntry(ctx, txn, codec, parentID, keys.RootNamespaceID, name, false /* KVTrace */)
-}
-
-// MakeObjectNameKey returns a key in the system.namespace table for
-// a given parentID, parentSchemaID and name.
-func MakeObjectNameKey(
-	parentID descpb.ID, parentSchemaID descpb.ID, name string,
-) catalogkeys.DescriptorKey {
-	if parentID == keys.RootNamespaceID {
-		return catalogkeys.NewDatabaseKey(name)
-	}
-	if parentSchemaID == keys.RootNamespaceID {
-		return catalogkeys.NewSchemaKey(parentID, name)
-	}
-	return catalogkeys.NewTableKey(parentID, parentSchemaID, name)
-}
-
 // LookupObjectID returns the ObjectID for the given
 // (parentID, parentSchemaID, name) supplied.
 func LookupObjectID(
@@ -95,9 +39,9 @@ func LookupObjectID(
 	if name == "" {
 		return false, descpb.InvalidID, nil
 	}
-	key := MakeObjectNameKey(parentID, parentSchemaID, name).Key(codec)
+	key := catalogkeys.NewNameKeyComponents(parentID, parentSchemaID, name)
 	log.Eventf(ctx, "looking up descriptor ID for name key %q", key)
-	res, err := txn.Get(ctx, key)
+	res, err := txn.Get(ctx, catalogkeys.EncodeNameKey(codec, key))
 	if err != nil || !res.Exists() {
 		return false, descpb.InvalidID, err
 	}

--- a/pkg/sql/catalog/descpb/structured.go
+++ b/pkg/sql/catalog/descpb/structured.go
@@ -356,3 +356,18 @@ func (u *UniqueWithoutIndexConstraint) GetName() string {
 func (u *UniqueWithoutIndexConstraint) IsPartial() bool {
 	return u.Predicate != ""
 }
+
+// GetParentID implements the catalog.NameKeyHaver interface.
+func (ni NameInfo) GetParentID() ID {
+	return ni.ParentID
+}
+
+// GetParentSchemaID implements the catalog.NameKeyHaver interface.
+func (ni NameInfo) GetParentSchemaID() ID {
+	return ni.ParentSchemaID
+}
+
+// GetName implements the catalog.NameKeyHaver interface.
+func (ni NameInfo) GetName() string {
+	return ni.Name
+}

--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -103,13 +103,23 @@ type IndexOpts struct {
 	AddMutations bool
 }
 
+// NameKeyComponents is an interface for objects which have all the components
+// of their corresponding namespace table entry.
+// Typically these objects are either Descriptor implementations or
+// descpb.NameInfo structs.
+type NameKeyComponents interface {
+	GetName() string
+	GetParentID() descpb.ID
+	GetParentSchemaID() descpb.ID
+}
+
+var _ NameKeyComponents = descpb.NameInfo{}
+
 // Descriptor is an interface to be shared by individual descriptor
 // types.
 type Descriptor interface {
 	GetID() descpb.ID
-	GetName() string
-	GetParentID() descpb.ID
-	GetParentSchemaID() descpb.ID
+	NameKeyComponents
 
 	// IsUncommittedVersion returns true if this descriptor represent a version
 	// which is not the currently committed version. Implementations may return

--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -1984,7 +1984,7 @@ func (tc *Collection) GetObjectNamesAndIDs(
 	}
 
 	log.Eventf(ctx, "fetching list of objects for %q", dbDesc.GetName())
-	prefix := catalogkeys.NewTableKey(dbDesc.GetID(), schema.GetID(), "").Key(tc.codec())
+	prefix := catalogkeys.MakeObjectNameKey(tc.codec(), dbDesc.GetID(), schema.GetID(), "")
 	sr, err := txn.Scan(ctx, prefix, prefix.PrefixEnd(), 0)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/sql/catalog/descs/collection_test.go
+++ b/pkg/sql/catalog/descs/collection_test.go
@@ -258,7 +258,7 @@ func TestAddUncommittedDescriptorAndMutableResolution(t *testing.T) {
 			}})
 
 			b := &kv.Batch{}
-			b.CPut(catalogkeys.NewDatabaseKey(mut.Name).Key(lm.Codec()), mut.GetID(), nil)
+			b.CPut(catalogkeys.MakeDatabaseNameKey(lm.Codec(), mut.Name), mut.GetID(), nil)
 			err = txn.Run(ctx, b)
 			require.NoError(t, err)
 

--- a/pkg/sql/catalog/resolver/resolver.go
+++ b/pkg/sql/catalog/resolver/resolver.go
@@ -289,7 +289,7 @@ func GetForDatabase(
 ) (map[descpb.ID]string, error) {
 	log.Eventf(ctx, "fetching all schema descriptor IDs for %d", dbID)
 
-	nameKey := catalogkeys.NewSchemaKey(dbID, "" /* name */).Key(codec)
+	nameKey := catalogkeys.MakeSchemaNameKey(codec, dbID, "" /* name */)
 	kvs, err := txn.Scan(ctx, nameKey, nameKey.PrefixEnd(), 0 /* maxRows */)
 	if err != nil {
 		return nil, err
@@ -306,11 +306,11 @@ func GetForDatabase(
 		if _, ok := ret[id]; ok {
 			continue
 		}
-		_, _, name, err := catalogkeys.DecodeNameMetadataKey(codec, kv.Key)
+		k, err := catalogkeys.DecodeNameMetadataKey(codec, kv.Key)
 		if err != nil {
 			return nil, err
 		}
-		ret[id] = name
+		ret[id] = k.GetName()
 	}
 	return ret, nil
 }

--- a/pkg/sql/create_schema.go
+++ b/pkg/sql/create_schema.go
@@ -213,7 +213,7 @@ func (p *planner) createUserDefinedSchema(params runParams, n *tree.CreateSchema
 	// Finally create the schema on disk.
 	if err := p.createDescriptorWithID(
 		params.ctx,
-		catalogkeys.NewSchemaKey(db.ID, desc.Name).Key(p.ExecCfg().Codec),
+		catalogkeys.MakeSchemaNameKey(p.ExecCfg().Codec, db.ID, desc.Name),
 		desc.ID,
 		desc,
 		params.ExecCfg().Settings,

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -124,19 +124,19 @@ func getTableCreateParams(
 	tableName *tree.TableName,
 	kind tree.RequiredTableKind,
 	ifNotExists bool,
-) (tKey catalogkeys.DescriptorKey, schemaID descpb.ID, err error) {
+) (schemaID descpb.ID, err error) {
 	// Check we are not creating a table which conflicts with an alias available
 	// as a built-in type in CockroachDB but an extension type on the public
 	// schema for PostgreSQL.
 	if tableName.Schema() == tree.PublicSchema {
 		if _, ok := types.PublicSchemaAliases[tableName.Object()]; ok {
-			return nil, 0, sqlerrors.NewTypeAlreadyExistsError(tableName.String())
+			return descpb.InvalidID, sqlerrors.NewTypeAlreadyExistsError(tableName.String())
 		}
 	}
 
 	if persistence.IsTemporary() {
 		if !params.SessionData().TempTablesEnabled {
-			return nil, 0, errors.WithTelemetry(
+			return descpb.InvalidID, errors.WithTelemetry(
 				pgerror.WithCandidateCode(
 					errors.WithHint(
 						errors.WithIssueLink(
@@ -155,20 +155,18 @@ func getTableCreateParams(
 		var err error
 		schemaID, err = params.p.getOrCreateTemporarySchema(params.ctx, dbID)
 		if err != nil {
-			return nil, 0, err
+			return descpb.InvalidID, err
 		}
-		tKey = catalogkeys.NewTableKey(dbID, schemaID, tableName.Table())
 	} else {
 		// Otherwise, find the ID of the schema to create the table within.
 		var err error
 		schemaID, err = params.p.getSchemaIDForCreate(params.ctx, params.ExecCfg().Codec, dbID, tableName.Schema())
 		if err != nil {
-			return nil, 0, err
+			return descpb.InvalidID, err
 		}
 		if schemaID != keys.PublicSchemaID {
 			sqltelemetry.IncrementUserDefinedSchemaCounter(sqltelemetry.UserDefinedSchemaUsedByObject)
 		}
-		tKey = catalogkv.MakeObjectNameKey(dbID, schemaID, tableName.Table())
 	}
 
 	if persistence.IsUnlogged() {
@@ -182,7 +180,7 @@ func getTableCreateParams(
 	// Check permissions on the schema.
 	if err := params.p.canCreateOnSchema(
 		params.ctx, schemaID, dbID, params.p.User(), skipCheckPublicSchema); err != nil {
-		return nil, 0, err
+		return descpb.InvalidID, err
 	}
 
 	desc, err := catalogkv.GetDescriptorCollidingWithObject(
@@ -194,7 +192,7 @@ func getTableCreateParams(
 		tableName.Table(),
 	)
 	if err != nil {
-		return nil, descpb.InvalidID, err
+		return descpb.InvalidID, err
 	}
 	if desc != nil {
 		// Ensure that the descriptor that does exist has the appropriate type.
@@ -216,7 +214,7 @@ func getTableCreateParams(
 			// Only complain about mismatched types for
 			// if not exists clauses.
 			if mismatchedType && ifNotExists {
-				return nil, descpb.InvalidID, pgerror.Newf(pgcode.WrongObjectType,
+				return descpb.InvalidID, pgerror.Newf(pgcode.WrongObjectType,
 					"%q is not a %s",
 					tableName.Table(),
 					kind)
@@ -225,23 +223,23 @@ func getTableCreateParams(
 
 		// Check if the object already exists in a dropped state
 		if desc.Dropped() {
-			return nil, descpb.InvalidID, pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
+			return descpb.InvalidID, pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
 				"%s %q is being dropped, try again later",
 				kind,
 				tableName.Table())
 		}
 
 		// Still return data in this case.
-		return tKey, schemaID, sqlerrors.MakeObjectAlreadyExistsError(desc.DescriptorProto(), tableName.FQString())
+		return schemaID, sqlerrors.MakeObjectAlreadyExistsError(desc.DescriptorProto(), tableName.FQString())
 	}
 
-	return tKey, schemaID, nil
+	return schemaID, nil
 }
 
 func (n *createTableNode) startExec(params runParams) error {
 	telemetry.Inc(sqltelemetry.SchemaChangeCreateCounter("table"))
 
-	tKey, schemaID, err := getTableCreateParams(params, n.dbDesc.GetID(), n.n.Persistence, &n.n.Table,
+	schemaID, err := getTableCreateParams(params, n.dbDesc.GetID(), n.n.Persistence, &n.n.Table,
 		tree.ResolveRequireTableDesc, n.n.IfNotExists)
 	if err != nil {
 		if sqlerrors.IsRelationAlreadyExistsError(err) && n.n.IfNotExists {
@@ -364,7 +362,11 @@ func (n *createTableNode) startExec(params runParams) error {
 
 	// Descriptor written to store here.
 	if err := params.p.createDescriptorWithID(
-		params.ctx, tKey.Key(params.ExecCfg().Codec), id, desc, params.EvalContext().Settings,
+		params.ctx,
+		catalogkeys.MakeObjectNameKey(params.ExecCfg().Codec, n.dbDesc.GetID(), schemaID, n.n.Table.Table()),
+		id,
+		desc,
+		params.EvalContext().Settings,
 		tree.AsStringWithFQNames(n.n, params.Ann()),
 	); err != nil {
 		return err

--- a/pkg/sql/create_test.go
+++ b/pkg/sql/create_test.go
@@ -55,7 +55,7 @@ func TestDatabaseDescriptor(t *testing.T) {
 	}
 
 	// Database name.
-	nameKey := catalogkeys.NewDatabaseKey("test").Key(codec)
+	nameKey := catalogkeys.MakeDatabaseNameKey(codec, "test")
 	if gr, err := kvDB.Get(ctx, nameKey); err != nil {
 		t.Fatal(err)
 	} else if gr.Exists() {

--- a/pkg/sql/database.go
+++ b/pkg/sql/database.go
@@ -49,7 +49,7 @@ func (p *planner) renameDatabase(
 	}
 
 	b := &kv.Batch{}
-	newKey := catalogkeys.NewDatabaseKey(newName).Key(p.ExecCfg().Codec)
+	newKey := catalogkeys.MakeDatabaseNameKey(p.ExecCfg().Codec, newName)
 	descID := desc.GetID()
 	if p.ExtendedEvalContext().Tracing.KVTracingEnabled() {
 		log.VEventf(ctx, 2, "CPut %s -> %d", newKey, descID)

--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -64,7 +64,7 @@ func (p *planner) createDatabase(
 ) (*dbdesc.Mutable, bool, error) {
 
 	dbName := string(database.Name)
-	dKey := catalogkeys.NewDatabaseKey(dbName)
+	dKey := catalogkeys.MakeDatabaseNameKey(p.ExecCfg().Codec, dbName)
 
 	if exists, databaseID, err := catalogkv.LookupDatabaseID(ctx, p.txn, p.ExecCfg().Codec, dbName); err == nil && exists {
 		if database.IfNotExists {
@@ -117,7 +117,7 @@ func (p *planner) createDatabase(
 		dbdesc.MaybeWithDatabaseRegionConfig(regionConfig),
 	)
 
-	if err := p.createDescriptorWithID(ctx, dKey.Key(p.ExecCfg().Codec), id, desc, nil, jobDesc); err != nil {
+	if err := p.createDescriptorWithID(ctx, dKey, id, desc, nil, jobDesc); err != nil {
 		return nil, true, err
 	}
 
@@ -129,8 +129,8 @@ func (p *planner) createDatabase(
 	}
 
 	// Every database must be initialized with the public schema.
-	if err := p.CreateSchemaNamespaceEntry(ctx,
-		catalogkeys.NewPublicSchemaKey(id).Key(p.ExecCfg().Codec), keys.PublicSchemaID); err != nil {
+	key := catalogkeys.MakePublicSchemaNameKey(p.ExecCfg().Codec, id)
+	if err := p.CreateSchemaNamespaceEntry(ctx, key, keys.PublicSchemaID); err != nil {
 		return nil, true, err
 	}
 

--- a/pkg/sql/drop_test.go
+++ b/pkg/sql/drop_test.go
@@ -164,8 +164,7 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 	if err := descExists(sqlDB, true, tbDesc.GetID()); err != nil {
 		t.Fatal(err)
 	}
-	tbNameKey := catalogkeys.MakeNameMetadataKey(keys.SystemSQLCodec,
-		tbDesc.GetParentID(), keys.PublicSchemaID, tbDesc.GetName())
+	tbNameKey := catalogkeys.EncodeNameKey(keys.SystemSQLCodec, tbDesc)
 	if gr, err := kvDB.Get(ctx, tbNameKey); err != nil {
 		t.Fatal(err)
 	} else if gr.Exists() {
@@ -180,7 +179,7 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 		t.Fatal(err)
 	}
 
-	dbNameKey := catalogkeys.MakeNameMetadataKey(keys.SystemSQLCodec, 0, 0, dbDesc.GetName())
+	dbNameKey := catalogkeys.EncodeNameKey(keys.SystemSQLCodec, dbDesc)
 	if gr, err := kvDB.Get(ctx, dbNameKey); err != nil {
 		t.Fatal(err)
 	} else if gr.Exists() {
@@ -226,8 +225,8 @@ CREATE DATABASE t;
 		t.Fatal(err)
 	}
 
-	dKey := catalogkeys.NewDatabaseKey("t")
-	r, err := kvDB.Get(ctx, dKey.Key(keys.SystemSQLCodec))
+	dKey := catalogkeys.MakeDatabaseNameKey(keys.SystemSQLCodec, "t")
+	r, err := kvDB.Get(ctx, dKey)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -619,7 +618,7 @@ func TestDropTable(t *testing.T) {
 	}
 
 	tableDesc := catalogkv.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "t", "kv")
-	nameKey := catalogkeys.NewPublicTableKey(keys.MinNonPredefinedUserDescID, "kv").Key(keys.SystemSQLCodec)
+	nameKey := catalogkeys.MakePublicObjectNameKey(keys.SystemSQLCodec, keys.MinNonPredefinedUserDescID, "kv")
 	gr, err := kvDB.Get(ctx, nameKey)
 
 	if err != nil {
@@ -719,7 +718,7 @@ func TestDropTableDeleteData(t *testing.T) {
 
 		descs = append(descs, catalogkv.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "t", tableName))
 
-		nameKey := catalogkeys.NewPublicTableKey(keys.MinNonPredefinedUserDescID, tableName).Key(keys.SystemSQLCodec)
+		nameKey := catalogkeys.MakePublicObjectNameKey(keys.SystemSQLCodec, keys.MinNonPredefinedUserDescID, tableName)
 		gr, err := kvDB.Get(ctx, nameKey)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/sql/gcjob_test/gc_job_test.go
+++ b/pkg/sql/gcjob_test/gc_job_test.go
@@ -303,7 +303,7 @@ SELECT job_id, status, running_status
 
 	// Manually delete the table.
 	require.NoError(t, kvDB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-		nameKey := catalogkeys.MakeNameMetadataKey(keys.SystemSQLCodec, dbID, keys.PublicSchemaID, "foo")
+		nameKey := catalogkeys.MakePublicObjectNameKey(keys.SystemSQLCodec, dbID, "foo")
 		if err := txn.Del(ctx, nameKey); err != nil {
 			return err
 		}

--- a/pkg/sql/privileged_accessor_test.go
+++ b/pkg/sql/privileged_accessor_test.go
@@ -38,7 +38,7 @@ func TestLookupNamespaceID(t *testing.T) {
 	err := kvDB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 		return txn.Put(
 			ctx,
-			catalogkeys.NewPublicTableKey(999, "bob").Key(keys.SystemSQLCodec),
+			catalogkeys.MakePublicObjectNameKey(keys.SystemSQLCodec, 999, "bob"),
 			9999,
 		)
 	})

--- a/pkg/sql/rename_table.go
+++ b/pkg/sql/rename_table.go
@@ -247,7 +247,7 @@ func (n *renameTableNode) startExec(params runParams) error {
 		return err
 	}
 
-	newTbKey := catalogkv.MakeObjectNameKey(targetDbDesc.GetID(), tableDesc.GetParentSchemaID(), newTn.Table())
+	newTbKey := catalogkeys.NewNameKeyComponents(targetDbDesc.GetID(), tableDesc.GetParentSchemaID(), newTn.Table())
 
 	if err := p.writeNameKey(ctx, newTbKey, descID); err != nil {
 		return err
@@ -496,9 +496,9 @@ func (n *renameTableNode) checkForCrossDbReferences(
 
 // writeNameKey writes a name key to a batch and runs the batch.
 func (p *planner) writeNameKey(
-	ctx context.Context, key catalogkeys.DescriptorKey, ID descpb.ID,
+	ctx context.Context, nameKey catalog.NameKeyComponents, ID descpb.ID,
 ) error {
-	marshalledKey := key.Key(p.ExecCfg().Codec)
+	marshalledKey := catalogkeys.EncodeNameKey(p.ExecCfg().Codec, nameKey)
 	b := &kv.Batch{}
 	if p.extendedEvalCtx.Tracing.KVTracingEnabled() {
 		log.VEventf(ctx, 2, "CPut %s -> %d", marshalledKey, ID)

--- a/pkg/sql/repair.go
+++ b/pkg/sql/repair.go
@@ -385,7 +385,7 @@ func (p *planner) UnsafeUpsertNamespaceEntry(
 		return err
 	}
 	parentID, parentSchemaID, descID := descpb.ID(parentIDInt), descpb.ID(parentSchemaIDInt), descpb.ID(descIDInt)
-	key := catalogkeys.MakeNameMetadataKey(p.execCfg.Codec, parentID, parentSchemaID, name)
+	key := catalogkeys.MakeObjectNameKey(p.execCfg.Codec, parentID, parentSchemaID, name)
 	val, err := p.txn.Get(ctx, key)
 	if err != nil {
 		return errors.Wrapf(err, "failed to read namespace entry (%d, %d, %s)",
@@ -512,7 +512,7 @@ func (p *planner) UnsafeDeleteNamespaceEntry(
 		return err
 	}
 	parentID, parentSchemaID, descID := descpb.ID(parentIDInt), descpb.ID(parentSchemaIDInt), descpb.ID(descIDInt)
-	key := catalogkeys.MakeNameMetadataKey(p.execCfg.Codec, parentID, parentSchemaID, name)
+	key := catalogkeys.MakeObjectNameKey(p.execCfg.Codec, parentID, parentSchemaID, name)
 	val, err := p.txn.Get(ctx, key)
 	if err != nil {
 		return errors.Wrapf(err, "failed to read namespace entry (%d, %d, %s)",

--- a/pkg/sql/schemachanger/scexec/BUILD.bazel
+++ b/pkg/sql/schemachanger/scexec/BUILD.bazel
@@ -17,7 +17,7 @@ go_library(
         "//pkg/roachpb",
         "//pkg/security",
         "//pkg/sql/catalog",
-        "//pkg/sql/catalog/catalogkv",
+        "//pkg/sql/catalog/catalogkeys",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/descs",
         "//pkg/sql/catalog/tabledesc",

--- a/pkg/sql/schemachanger/scexec/mutation_desc_getter.go
+++ b/pkg/sql/schemachanger/scexec/mutation_desc_getter.go
@@ -17,7 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
@@ -91,8 +91,7 @@ func (m *mutationDescGetter) SubmitDrainedNames(
 ) error {
 	for _, drainedNames := range m.drainedNames {
 		for _, drain := range drainedNames {
-			catalogkv.WriteObjectNamespaceEntryRemovalToBatch(
-				ctx, ba, codec, drain.ParentID, drain.ParentSchemaID, drain.Name, false /* KVTrace */)
+			ba.Del(catalogkeys.EncodeNameKey(codec, drain))
 		}
 	}
 	return nil

--- a/pkg/sqlmigrations/migrations.go
+++ b/pkg/sqlmigrations/migrations.go
@@ -327,7 +327,7 @@ func databaseIDs(
 	return func(ctx context.Context, db DB, codec keys.SQLCodec) ([]descpb.ID, error) {
 		var ids []descpb.ID
 		for _, name := range names {
-			kv, err := db.Get(ctx, catalogkeys.NewDatabaseKey(name).Key(codec))
+			kv, err := db.Get(ctx, catalogkeys.MakeDatabaseNameKey(codec, name))
 			if err != nil {
 				return nil, err
 			}
@@ -715,8 +715,8 @@ func CreateSystemTable(
 	// the reserved ID space. (The SQL layer doesn't allow this.)
 	err := db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 		b := txn.NewBatch()
-		tKey := catalogkeys.NewPublicTableKey(desc.GetParentID(), desc.GetName())
-		b.CPut(tKey.Key(codec), desc.GetID(), nil)
+		tKey := catalogkeys.MakePublicObjectNameKey(codec, desc.GetParentID(), desc.GetName())
+		b.CPut(tKey, desc.GetID(), nil)
 		b.CPut(catalogkeys.MakeDescMetadataKey(codec, desc.GetID()), desc.DescriptorProto(), nil)
 		if err := txn.SetSystemConfigTrigger(codec.ForSystemTenant()); err != nil {
 			return err

--- a/pkg/sqlmigrations/migrations_test.go
+++ b/pkg/sqlmigrations/migrations_test.go
@@ -560,7 +560,7 @@ func TestCreateSystemTable(t *testing.T) {
 	descpb.SystemAllowedPrivileges[table.ID] = descpb.SystemAllowedPrivileges[keys.NamespaceTableID]
 
 	table.Name = "dummy"
-	nameKey := catalogkeys.NewPublicTableKey(table.ParentID, table.Name).Key(keys.SystemSQLCodec)
+	nameKey := catalogkeys.MakePublicObjectNameKey(keys.SystemSQLCodec, table.ParentID, table.Name)
 	descKey := catalogkeys.MakeDescMetadataKey(keys.SystemSQLCodec, table.ID)
 	descVal := table.DescriptorProto()
 


### PR DESCRIPTION
    catalogkeys: clean up namespace keys
    
    The recently-added final namespace table migration allowed us to remove
    a substantial amount of dead code pertaining to the deprecated table and
    the rows in it. This commit is a refactor that goes further in that
    direction and refactors the namespace row key functions in catalogkeys,
    yielding more consistent calling patterns.
    
    This commit notably introduces a catalog.NameKeyComponents interface
    which is implemented by any object which has a matching namespace entry,
    like a catalog.Descriptor for instance.
    
    Release note: None
