### PR TITLE
cloud: uncomment and fix default CPU resources in K8s configs

### DIFF
--- a/cloud/kubernetes/bring-your-own-certs/cockroachdb-statefulset.yaml
+++ b/cloud/kubernetes/bring-your-own-certs/cockroachdb-statefulset.yaml
@@ -158,13 +158,13 @@ spec:
         # the resources that can be allocated on each of your Kubernetes nodes by running:
         #   kubectl describe nodes
         # Note that requests and limits should have identical values.
-        # resources:
-        #   requests:
-        #     cpu: "16"
-        #     memory: "8Gi"
-        #   limits:
-        #     cpu: "16"
-        #     memory: "8Gi" 
+        resources:
+          requests:
+            cpu: "2"
+            memory: "8Gi"
+          limits:
+            cpu: "2"
+            memory: "8Gi" 
         ports:
         - containerPort: 26257
           name: grpc

--- a/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
@@ -200,13 +200,13 @@ spec:
         # the resources that can be allocated on each of your Kubernetes nodes by running:
         #   kubectl describe nodes
         # Note that requests and limits should have identical values.
-        # resources:
-        #   requests:
-        #     cpu: "16"
-        #     memory: "8Gi"
-        #   limits:
-        #     cpu: "16"
-        #     memory: "8Gi" 
+        resources:
+          requests:
+            cpu: "2"
+            memory: "8Gi"
+          limits:
+            cpu: "2"
+            memory: "8Gi" 
         ports:
         - containerPort: 26257
           name: grpc

--- a/cloud/kubernetes/cockroachdb-statefulset.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset.yaml
@@ -103,13 +103,13 @@ spec:
         # the resources that can be allocated on each of your Kubernetes nodes by running:
         #   kubectl describe nodes
         # Note that requests and limits should have identical values.
-        # resources:
-        #   requests:
-        #     cpu: "16"
-        #     memory: "8Gi"
-        #   limits:
-        #     cpu: "16"
-        #     memory: "8Gi" 
+        resources:
+          requests:
+            cpu: "2"
+            memory: "8Gi"
+          limits:
+            cpu: "2"
+            memory: "8Gi" 
         ports:
         - containerPort: 26257
           name: grpc

--- a/cloud/kubernetes/multiregion/eks/cockroachdb-statefulset-secure-eks.yaml
+++ b/cloud/kubernetes/multiregion/eks/cockroachdb-statefulset-secure-eks.yaml
@@ -190,13 +190,13 @@ spec:
         # the resources that can be allocated on each of your Kubernetes nodes by running:
         #   kubectl describe nodes
         # Note that requests and limits should have identical values.
-        # resources:
-        #   requests:
-        #     cpu: "16"
-        #     memory: "8Gi"
-        #   limits:
-        #     cpu: "16"
-        #     memory: "8Gi" 
+        resources:
+          requests:
+            cpu: "2"
+            memory: "8Gi"
+          limits:
+            cpu: "2"
+            memory: "8Gi" 
         ports:
         - containerPort: 26257
           name: grpc

--- a/cloud/kubernetes/performance/cockroachdb-statefulset-insecure.yaml
+++ b/cloud/kubernetes/performance/cockroachdb-statefulset-insecure.yaml
@@ -146,13 +146,13 @@ spec:
         # the resources that can be allocated on each of your Kubernetes nodes by running:
         #   kubectl describe nodes
         # Note that requests and limits should have identical values.
-        # resources:
-        #   requests:
-        #     cpu: "16"
-        #     memory: "8Gi"
-        #   limits:
-        #     cpu: "16"
-        #     memory: "8Gi" 
+        resources:
+          requests:
+            cpu: "2"
+            memory: "8Gi"
+          limits:
+            cpu: "2"
+            memory: "8Gi" 
         ports:
         - containerPort: 26257
           name: grpc

--- a/cloud/kubernetes/performance/cockroachdb-statefulset-secure.yaml
+++ b/cloud/kubernetes/performance/cockroachdb-statefulset-secure.yaml
@@ -237,13 +237,13 @@ spec:
         # the resources that can be allocated on each of your Kubernetes nodes by running:
         #   kubectl describe nodes
         # Note that requests and limits should have identical values.
-        # resources:
-        #   requests:
-        #     cpu: "16"
-        #     memory: "8Gi"
-        #   limits:
-        #     cpu: "16"
-        #     memory: "8Gi" 
+        resources:
+          requests:
+            cpu: "2"
+            memory: "8Gi"
+          limits:
+            cpu: "2"
+            memory: "8Gi" 
         ports:
         - containerPort: 26257
           name: grpc


### PR DESCRIPTION
Relates to https://github.com/cockroachdb/docs/pull/10578.

The default CPU resource limit/request was too large in the StatefulSet configs (I think I introduced this error previously). The updated value makes sense for the `n2-standard-4` machines we use in our deployment tutorials, and the CPU/memory ratio is consistent with our recommendation in the [Production Checklist](https://www.cockroachlabs.com/docs/stable/recommended-production-settings.html).

Also uncommented the `resources` object, since we recommend always defining resource requests/limits explicitly. The updated docs in https://github.com/cockroachdb/docs/pull/10578 make it clear that these values should be tailored to a production deployment.

cc @udnay 