### PR TITLE
bazel: sketch out cross toolchains for all platforms except darwin

### DIFF
--- a/build/toolchains/REPOSITORIES.bzl
+++ b/build/toolchains/REPOSITORIES.bzl
@@ -1,5 +1,27 @@
 load("//build:toolchains/dev/darwin-x86_64/toolchain.bzl",
      _dev_darwin_x86_repo = "dev_darwin_x86_repo")
+load("//build:toolchains/crosstool-ng/toolchain.bzl",
+     _crosstool_toolchain_repo = "crosstool_toolchain_repo")
 
 def toolchain_dependencies():
     _dev_darwin_x86_repo(name = "toolchain_dev_darwin_x86-64")
+    _crosstool_toolchain_repo(
+        name = "toolchain_cross_aarch64-unknown-linux-gnu",
+        target = "aarch64-unknown-linux-gnu",
+        tarball_sha256 = "ed7ebe618794c0a64aec742d1bf9274302f86a8a81505758c97dc99dab5fd6ab",
+    )
+    _crosstool_toolchain_repo(
+        name = "toolchain_cross_s390x-ibm-linux-gnu",
+        target = "s390x-ibm-linux-gnu",
+        tarball_sha256 = "93c34d3111e38882fd88f38df33243c52466f703d78e7dd8ac0260c9e1ca35c6",
+    )
+    _crosstool_toolchain_repo(
+        name = "toolchain_cross_x86_64-unknown-linux-gnu",
+        target = "x86_64-unknown-linux-gnu",
+        tarball_sha256 = "38f06a929fcc3d1405fe229aa8bc30e57ca78312f4e07e10a68cd3568a64412e",
+    )
+    _crosstool_toolchain_repo(
+        name = "toolchain_cross_x86_64-w64-mingw32",
+        target = "x86_64-w64-mingw32",
+        tarball_sha256 = "6900b96f7bbd86ba96c4c9704eab6fcb2241fdb5df0a8b9cb3416505a6ef19f7",
+    )

--- a/build/toolchains/crosstool-ng/BUILD.tmpl
+++ b/build/toolchains/crosstool-ng/BUILD.tmpl
@@ -1,0 +1,75 @@
+package(default_visibility = ["//visibility:public"])
+
+load(":cc_toolchain_config.bzl", "cc_toolchain_config")
+
+cc_toolchain_suite(
+    name = "suite",
+    toolchains = {
+        "k8": ":toolchain",
+    },
+)
+
+cc_toolchain_config(name = "toolchain_config")
+
+filegroup(name = "empty")
+
+filegroup(
+    name = "all_files",
+    srcs = [
+        ":ar_files",
+        ":compiler_files",
+        ":linker_files",
+        ":objcopy_files",
+        ":strip_files",
+    ],
+)
+
+filegroup(
+    name = "compiler_files",
+    srcs = [
+        "bin/%{target}-gcc",
+        "bin/%{target}-g++",
+    ],
+)
+
+filegroup(
+    name = "ar_files",
+    srcs = [
+        "bin/%{target}-ar",
+    ],
+)
+
+filegroup(
+    name = "linker_files",
+    srcs = [
+        "bin/%{target}-gcc",
+    ],
+)
+
+filegroup(
+    name = "objcopy_files",
+    srcs = [
+        "bin/%{target}-objcopy",
+    ],
+)
+
+filegroup(
+    name = "strip_files",
+    srcs = [
+        "bin/%{target}-strip",
+    ],
+)
+
+cc_toolchain(
+    name = "toolchain",
+    toolchain_identifier = "%{target}-cross-toolchain",
+    toolchain_config = ":toolchain_config",
+    all_files = ":all_files",
+    ar_files = ":ar_files",
+    compiler_files = ":compiler_files",
+    dwp_files = ":empty",
+    linker_files = ":linker_files",
+    objcopy_files = ":objcopy_files",
+    strip_files = ":strip_files",
+    supports_param_files = 0,
+)

--- a/build/toolchains/crosstool-ng/cc_toolchain_config.bzl.tmpl
+++ b/build/toolchains/crosstool-ng/cc_toolchain_config.bzl.tmpl
@@ -1,0 +1,167 @@
+load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
+load("@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl",
+     "feature",
+     "flag_group",
+     "flag_set",
+     "tool_path")
+
+all_compile_actions = [
+    ACTION_NAMES.c_compile,
+    ACTION_NAMES.cpp_compile,
+    ACTION_NAMES.linkstamp_compile,
+    ACTION_NAMES.assemble,
+    ACTION_NAMES.preprocess_assemble,
+    ACTION_NAMES.cpp_header_parsing,
+    ACTION_NAMES.cpp_module_compile,
+    ACTION_NAMES.cpp_module_codegen,
+    ACTION_NAMES.clif_match,
+    ACTION_NAMES.lto_backend,
+]
+
+all_link_actions = [
+    ACTION_NAMES.cpp_link_executable,
+    ACTION_NAMES.cpp_link_dynamic_library,
+    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+]
+
+def _impl(ctx):
+    tool_paths = [
+        tool_path(
+            name = "gcc",
+            path = "bin/%{target}-gcc",
+        ),
+        tool_path(
+            name = "ld",
+            path = "bin/%{target}-ld",
+        ),
+        tool_path(
+            name = "cpp",
+            path = "bin/%{target}-g++",
+        ),
+        tool_path(
+            name = "gcov",
+            path = "bin/%{target}-gcov",
+        ),
+        tool_path(
+            name = "nm",
+            path = "bin/%{target}-nm",
+        ),
+        tool_path(
+            name = "objdump",
+            path = "bin/%{target}-objdump",
+        ),
+        tool_path(
+            name = "strip",
+            path = "bin/%{target}-strip",
+        ),
+        tool_path(
+            name = "ar",
+            path = "bin/%{target}-ar",
+        ),
+    ]
+
+    opt_feature = feature(
+        name = "opt",
+        flag_sets = [
+            flag_set(
+                actions = all_compile_actions,
+                flag_groups = ([
+                    flag_group(
+                        flags = [
+                            "-O3",
+                        ]
+                    ),
+                ]),
+            ),
+        ],
+    )
+    fastbuild_feature = feature(name = "fastbuild")
+    dbg_feature = feature(
+        name = "dbg",
+        flag_sets = [
+            flag_set(
+                actions = all_compile_actions,
+                flag_groups = ([
+                    flag_group(
+                        flags = [
+                            "-g3",
+                        ]
+                    ),
+                ]),
+            ),
+        ],
+    )
+
+    supports_pic_feature = feature(name = "supports_pic", enabled = True)
+    supports_dynamic_linker_feature = feature(name = "supports_dynamic_linker", enabled = False)
+
+    default_compile_flags = feature(
+        name = "default_compile_flags",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_compile_actions,
+                flag_groups = ([
+                    flag_group(
+                        flags = [
+                            "-g1",
+                            "-Wall",
+                            "-I%{repo_path}/%{target}/include/c++/6.5.0",
+                        ],
+                    ),
+                ]),
+            ),
+        ],
+    )
+
+    linker_flags = ["-lstdc++"]
+    if "%{target}" == "x86_64-unknown-linux-gnu":
+        linker_flags.append("-lrt")
+
+    default_linker_flags = feature(
+        name = "default_linker_flags",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_link_actions,
+                flag_groups = ([flag_group(flags = linker_flags)]),
+            ),
+        ],
+    )
+
+    features = [
+        opt_feature,
+        fastbuild_feature,
+        dbg_feature,
+        supports_pic_feature,
+        supports_dynamic_linker_feature,
+        default_compile_flags,
+        default_linker_flags,
+    ]
+
+    return cc_common.create_cc_toolchain_config_info(
+        ctx = ctx,
+        features = features,
+        toolchain_identifier = "%{target}-cross-toolchain",
+        host_system_name = "%{target}",
+        target_system_name = "%{target}",
+        target_cpu = "%{target}",
+        target_libc = "glibc-2.14",
+        compiler = "clang",
+        abi_version = "clang-10.0.0",
+        abi_libc_version = "%{target}",
+        tool_paths = tool_paths,
+        cxx_builtin_include_directories = [
+            "%sysroot%/usr/include",
+            "%{repo_path}/%{target}/include/c++/6.5.0",
+            "%{repo_path}/lib/gcc/%{target}/6.5.0/include",
+            "%{repo_path}/lib/gcc/%{target}/6.5.0/include-fixed",
+        ],
+        builtin_sysroot = "%{repo_path}/%{target}/sysroot",
+    )
+
+cc_toolchain_config = rule(
+    implementation = _impl,
+    attrs = {},
+    provides = [CcToolchainConfigInfo],
+)

--- a/build/toolchains/crosstool-ng/toolchain.bzl
+++ b/build/toolchains/crosstool-ng/toolchain.bzl
@@ -1,0 +1,33 @@
+def _impl(rctx):
+    rctx.download_and_extract(
+        url = [
+            "https://storage.googleapis.com/public-bazel-artifacts/toolchains/crosstool-ng/20210601-231954/{}.tar.gz".format(
+                rctx.attr.target),
+        ],
+        sha256 = rctx.attr.tarball_sha256,
+        stripPrefix = "x-tools/{}/".format(rctx.attr.target),
+    )
+
+    repo_path = str(rctx.path(""))
+
+    rctx.template("BUILD",
+                  Label("@cockroach//build:toolchains/crosstool-ng/BUILD.tmpl"),
+                  substitutions = {
+                      "%{target}": rctx.attr.target,
+                  },
+                  executable = False)
+    rctx.template("cc_toolchain_config.bzl",
+                  Label("@cockroach//build:toolchains/crosstool-ng/cc_toolchain_config.bzl.tmpl"),
+                  substitutions = {
+                      "%{target}": rctx.attr.target,
+                      "%{repo_path}": repo_path,
+                  },
+                  executable = False)
+
+crosstool_toolchain_repo = repository_rule(
+    implementation = _impl,
+    attrs = {
+        "target": attr.string(mandatory = True),
+        "tarball_sha256": attr.string(mandatory = True),
+    },
+)


### PR DESCRIPTION
In #65966, we published these toolchains to a storage bucket in GCP.
This demonstrates how we can consume these same toolchains in Bazel for
cross-compilation.

These can be activated with:

    build --crosstool_top=@toolchain_cross_x86_64-unknown-linux-gnu//:suite

... or substitute `x86_64-unknown-linux-gnu` for another target name.

I've verified the Linux toolchain works. The others break during
compilation for various reasons that I haven't looked at closely, but I
wanted to get this landed so we can iterate on those/maybe parallelize
across a couple different people.

The Darwin toolchain isn't generated by `crosstool-ng`, so it's
structured a little differently than the others. I'll add that in a
follow-up PR.

See #56072

Release note: None