### PR TITLE
sql: fix very slow TestSchemaChangeRetryOnVersionChange

### DIFF
--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -39,12 +39,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/gcjob"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltestutils"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/sqlmigrations"
@@ -1385,23 +1383,30 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 
 	upTableVersion = func() {
 		leaseMgr := s.LeaseManager().(*lease.Manager)
-		ie := s.InternalExecutor().(sqlutil.InternalExecutor)
 		var version descpb.DescriptorVersion
-		if err := descs.Txn(ctx, s.ClusterSettings(), leaseMgr, ie, kvDB, func(
-			ctx context.Context, txn *kv.Txn, descsCol *descs.Collection,
-		) error {
-			table, err := descsCol.GetMutableTableVersionByID(ctx, id, txn)
+		if err := kvDB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+			table, err := catalogkv.MustGetMutableTableDescByID(
+				ctx, txn, keys.SystemSQLCodec, tableDesc.GetID())
 			if err != nil {
 				return err
 			}
-			return descsCol.WriteDesc(ctx, false /* kvTrace */, table, txn)
+			table.MaybeIncrementVersion()
+			ba := txn.NewBatch()
+			if err := catalogkv.WriteDescToBatch(
+				ctx, false /* kvTrace */, s.ClusterSettings(), ba,
+				keys.SystemSQLCodec, table.GetID(), table,
+			); err != nil {
+				return err
+			}
+			version = table.GetVersion()
+			return txn.Run(ctx, ba)
 		}); err != nil {
 			t.Error(err)
 		}
 
 		// Grab a lease at the latest version so that we are confident
 		// that all future leases will be taken at the latest version.
-		table, err := leaseMgr.TestingAcquireAndAssertMinVersion(ctx, s.Clock().Now(), id, version+1)
+		table, err := leaseMgr.TestingAcquireAndAssertMinVersion(ctx, s.Clock().Now(), id, version)
 		if err != nil {
 			t.Error(err)
 		}


### PR DESCRIPTION
See [here](https://teamcity.cockroachdb.com/project.html?projectId=Cockroach_UnitTests&testNameId=6532733632782929224&tab=testDetails).
This test was taking 10 minutes every time. This was happening because of the
change to wait for the version's leases to expire in #63725.

After:
```
--- PASS: TestSchemaChangeRetryOnVersionChange (1.70s)
```

Release note: None