### PR TITLE
sql: fix slow TestTypeChangeJobCancelSemantics

### DIFF
--- a/pkg/sql/type_change_test.go
+++ b/pkg/sql/type_change_test.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -481,6 +482,10 @@ CREATE TYPE ab AS ENUM ('a', 'b')`,
 func TestTypeChangeJobCancelSemantics(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	defer jobs.TestingSetAdoptAndCancelIntervals(
+		100*time.Millisecond, 100*time.Millisecond,
+	)()
 
 	testCases := []struct {
 		desc       string


### PR DESCRIPTION
Before:
```
--- PASS: TestTypeChangeJobCancelSemantics (92.91s)
    --- PASS: TestTypeChangeJobCancelSemantics/simple_drop (30.47s)
    --- PASS: TestTypeChangeJobCancelSemantics/txn_add_drop (30.98s)
    --- PASS: TestTypeChangeJobCancelSemantics/txn_drop_drop (31.04s)
```

After:
```
--- PASS: TestTypeChangeJobCancelSemantics (1.72s)
    --- PASS: TestTypeChangeJobCancelSemantics/simple_drop (0.51s)
    --- PASS: TestTypeChangeJobCancelSemantics/simple_add (0.19s)
    --- PASS: TestTypeChangeJobCancelSemantics/txn_add_drop (0.42s)
    --- PASS: TestTypeChangeJobCancelSemantics/txn_add_add (0.19s)
    --- PASS: TestTypeChangeJobCancelSemantics/txn_drop_drop (0.38s)
```

cc @sajjadrizvi 

Release note: None