### PR TITLE
backupccl: fix a bug when backing up mutated views

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -199,6 +199,9 @@ func spansForAllTableIndexes(
 		rawTbl := descpb.TableFromDescriptor(rev.Desc, hlc.Timestamp{})
 		if rawTbl != nil && rawTbl.State == descpb.DescriptorState_PUBLIC {
 			tbl := tabledesc.NewImmutable(*rawTbl)
+			if !tbl.IsPhysicalTable() {
+				continue
+			}
 
 			if index := tbl.GetPrimaryIndex(); index != nil {
 				addIndexToTree(tbl, *index)


### PR DESCRIPTION
A bug was introduced where backups may sometimes fail claiming that a
span (covered by a view) was not covered by previous backups. This span
should not have been requested by the backup in the first place.

Release note (bug fix): Fix a bug where incremental backups with
revision history would sometimes fail if a view was altered between
incremental backups.