### PR TITLE
cli/demo: clarify the details printed upon startup

### DIFF
--- a/pkg/cli/demo.go
+++ b/pkg/cli/demo.go
@@ -350,17 +350,21 @@ func runDemo(cmd *cobra.Command, gen workload.Generator) (err error) {
 			// if embedded, the embedding platform owns the network
 			// configuration.
 			`#
-# Connection parameters:
-#`,
-			strings.ReplaceAll(strings.TrimSuffix(nodeList.String(), "\n"), "\n", "\n# "))
+# If you wish to access this demo cluster using another tool, you will need
+# the following details:
+#
+#   - Connection parameters:
+#  `,
+			strings.ReplaceAll(strings.TrimSuffix(nodeList.String(), "\n"), "\n", "\n#   "))
 
 		if !demoCtx.insecure {
-			fmt.Printf(`#
-# The user %q with password %q has been created. Use it to access the Web UI!
+			fmt.Printf(`#   - Username: %q, password: %q
+#   - Directory with certificate files (for certain SQL drivers/tools): %s
 #
 `,
 				c.adminUser,
 				c.adminPassword,
+				c.demoDir,
 			)
 		}
 

--- a/pkg/cli/interactive_tests/test_demo.tcl
+++ b/pkg/cli/interactive_tests/test_demo.tcl
@@ -78,8 +78,8 @@ start_test "Check that demo secure says hello properly"
 set ::env(COCKROACH_INSECURE) "false"
 spawn $argv demo --no-example-database
 eexpect "Welcome"
-eexpect "The user \"demo\" with password"
-eexpect "has been created."
+eexpect "Username: \"demo\", password"
+eexpect "Directory with certificate files"
 eexpect "defaultdb>"
 
 # Show the URLs.
@@ -104,8 +104,7 @@ eexpect eof
 set ::env(COCKROACH_INSECURE) "true"
 spawn $argv demo --insecure=false --no-example-database
 eexpect "Welcome"
-eexpect "The user \"demo\" with password"
-eexpect "has been created."
+eexpect "Username: \"demo\", password"
 eexpect "defaultdb>"
 
 # Show the URLs.


### PR DESCRIPTION
Fixes #65337.
Requested by @ianjevans 

Before:

```
Connection parameters:
  (webui)    http://...
  (sql)      postgres://...
  (sql/unix) postgres://...

The user "demo" with password "..." has been created. Use it to access the Web UI!
```

After:

```
If you wish to access this demo cluster using another tool, you will need
the following details:

  - Connection parameters:
    (webui)    http://...
    (sql)      postgres://...
    (sql/unix) postgres://...

  - Username: "demo", password: "..."
  - Directory with certificate files (for SQL drivers/tools): /tmp/demo...
```

Release note (cli change): The informational messages printed out
when `cockroach demo` starts have been updated to clarify that
certain information is only needed when accessing the demo cluster
from another tool.