### PR TITLE
release-21.1: cloud/amazon: CredentialsChainVerboseErrors

### DIFF
--- a/pkg/storage/cloudimpl/s3_storage.go
+++ b/pkg/storage/cloudimpl/s3_storage.go
@@ -145,9 +145,11 @@ func MakeS3Storage(
 	if conf.Endpoint != "" {
 		opts.Config.S3ForcePathStyle = aws.Bool(true)
 	}
+
+	opts.Config.CredentialsChainVerboseErrors = aws.Bool(true)
+
 	if log.V(2) {
 		opts.Config.LogLevel = aws.LogLevel(aws.LogDebugWithRequestRetries | aws.LogDebugWithRequestErrors)
-		opts.Config.CredentialsChainVerboseErrors = aws.Bool(true)
 	}
 
 	// Ensure that a KMS ID is specified if server side encryption is set to use


### PR DESCRIPTION
Backport 1/1 commits from #66062.

/cc @cockroachdb/release

---

This makes the error message returned when the AWS SDK cannot find valid credentials
in the chain (env, file, ec2 role) actually include the errors returned by each
step of the chain that was tried. This should make it easier to determine why the
step which we _expected_ to return valid credentials did not do so.

Release note: none.
