### PR TITLE
sql: move OID resolution under an interface from tree

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -154,6 +154,7 @@ go_library(
         "render.go",
         "repair.go",
         "reparent_database.go",
+        "resolve_oid.go",
         "resolver.go",
         "revert.go",
         "revoke_role.go",

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -139,6 +139,20 @@ func (so *DummySequenceOperators) SetSequenceValueByID(
 // errors.
 type DummyEvalPlanner struct{}
 
+// ResolveOIDFromString is part of the EvalPlanner interface.
+func (ep *DummyEvalPlanner) ResolveOIDFromString(
+	ctx context.Context, resultType *types.T, toResolve *tree.DString,
+) (*tree.DOid, error) {
+	return nil, errors.WithStack(errEvalPlanner)
+}
+
+// ResolveOIDFromOID is part of the EvalPlanner interface.
+func (ep *DummyEvalPlanner) ResolveOIDFromOID(
+	ctx context.Context, resultType *types.T, toResolve *tree.DOid,
+) (*tree.DOid, error) {
+	return nil, errors.WithStack(errEvalPlanner)
+}
+
 // UnsafeUpsertDescriptor is part of the EvalPlanner interface.
 func (ep *DummyEvalPlanner) UnsafeUpsertDescriptor(
 	ctx context.Context, descID int64, encodedDescriptor []byte, force bool,

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -587,7 +587,7 @@ ALTER TABLE add_default ADD g INT DEFAULT nextval('initial_seq')
 statement error pgcode 22C01 cannot evaluate scalar expressions using table lookups in this context
 ALTER TABLE add_default ADD g OID DEFAULT 'foo'::regclass::oid
 
-statement error cannot access virtual schema in anonymous database
+statement error pgcode 22C01 cannot evaluate scalar expressions using table lookups in this context
 ALTER TABLE add_default ADD g INT DEFAULT 'foo'::regtype::INT
 
 subtest 26422

--- a/pkg/sql/resolve_oid.go
+++ b/pkg/sql/resolve_oid.go
@@ -1,0 +1,106 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/errors"
+	"github.com/lib/pq/oid"
+)
+
+// ResolveOIDFromString is part of tree.TypeResolver.
+func (p *planner) ResolveOIDFromString(
+	ctx context.Context, resultType *types.T, toResolve *tree.DString,
+) (*tree.DOid, error) {
+	return resolveOID(
+		ctx, p.Txn(),
+		p.extendedEvalCtx.InternalExecutor.(sqlutil.InternalExecutor),
+		resultType, toResolve,
+	)
+}
+
+// ResolveOIDFromOID is part of tree.TypeResolver.
+func (p *planner) ResolveOIDFromOID(
+	ctx context.Context, resultType *types.T, toResolve *tree.DOid,
+) (*tree.DOid, error) {
+	return resolveOID(
+		ctx, p.Txn(),
+		p.extendedEvalCtx.InternalExecutor.(sqlutil.InternalExecutor),
+		resultType, toResolve,
+	)
+}
+
+func resolveOID(
+	ctx context.Context,
+	txn *kv.Txn,
+	ie sqlutil.InternalExecutor,
+	resultType *types.T,
+	toResolve tree.Datum,
+) (*tree.DOid, error) {
+	info, ok := regTypeInfos[resultType.Oid()]
+	if !ok {
+		return nil, errors.AssertionFailedf("illegal oid type %v", resultType)
+	}
+	queryCol := info.nameCol
+	if _, isOid := toResolve.(*tree.DOid); isOid {
+		queryCol = "oid"
+	}
+	q := fmt.Sprintf(
+		"SELECT %s.oid, %s FROM pg_catalog.%s WHERE %s = $1",
+		info.tableName, info.nameCol, info.tableName, queryCol,
+	)
+	results, err := ie.QueryRow(ctx, "queryOid", txn, q, toResolve)
+	if err != nil {
+		if errors.HasType(err, (*tree.MultipleResultsError)(nil)) {
+			return nil, pgerror.Newf(pgcode.AmbiguousAlias,
+				"more than one %s named %s", info.objName, toResolve)
+		}
+		return nil, err
+	}
+	if results.Len() == 0 {
+		return nil, pgerror.Newf(info.errType,
+			"%s %s does not exist", info.objName, toResolve)
+	}
+	return tree.NewDOidWithName(
+		results[0].(*tree.DOid).DInt,
+		resultType,
+		tree.AsStringWithFlags(results[1], tree.FmtBareStrings),
+	), nil
+}
+
+// regTypeInfo contains details on a pg_catalog table that has a reg* type.
+type regTypeInfo struct {
+	tableName string
+	// nameCol is the name of the column that contains the table's entity name.
+	nameCol string
+	// objName is a human-readable name describing the objects in the table.
+	objName string
+	// errType is the pg error code in case the object does not exist.
+	errType pgcode.Code
+}
+
+// regTypeInfos maps an oid.Oid to a regTypeInfo that describes the pg_catalog
+// table that contains the entities of the type of the key.
+var regTypeInfos = map[oid.Oid]regTypeInfo{
+	oid.T_regclass:     {"pg_class", "relname", "relation", pgcode.UndefinedTable},
+	oid.T_regtype:      {"pg_type", "typname", "type", pgcode.UndefinedObject},
+	oid.T_regproc:      {"pg_proc", "proname", "function", pgcode.UndefinedFunction},
+	oid.T_regprocedure: {"pg_proc", "proname", "function", pgcode.UndefinedFunction},
+	oid.T_regnamespace: {"pg_namespace", "nspname", "namespace", pgcode.UndefinedObject},
+}

--- a/pkg/sql/sem/tree/casts.go
+++ b/pkg/sql/sem/tree/casts.go
@@ -1322,7 +1322,7 @@ func performIntToOidCast(ctx *EvalContext, t *types.T, v DInt) (Datum, error) {
 		return ret, nil
 
 	default:
-		oid, err := queryOid(ctx, t, NewDOid(v))
+		oid, err := ctx.Planner.ResolveOIDFromOID(ctx.Ctx(), t, NewDOid(v))
 		if err != nil {
 			oid = NewDOid(v)
 			oid.semanticType = t

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -4297,7 +4297,7 @@ func ParseDOid(ctx *EvalContext, s string, t *types.T) (*DOid, error) {
 	// If it is an integer in string form, convert it as an int.
 	if val, err := ParseDInt(strings.TrimSpace(s)); err == nil {
 		tmpOid := NewDOid(*val)
-		oid, err := queryOid(ctx, t, tmpOid)
+		oid, err := ctx.Planner.ResolveOIDFromOID(ctx.Ctx(), t, tmpOid)
 		if err != nil {
 			oid = tmpOid
 			oid.semanticType = t
@@ -4368,7 +4368,7 @@ func ParseDOid(ctx *EvalContext, s string, t *types.T) (*DOid, error) {
 		// Trim type modifiers, e.g. `numeric(10,3)` becomes `numeric`.
 		s = pgSignatureRegexp.ReplaceAllString(s, "$1")
 
-		dOid, missingTypeErr := queryOid(ctx, t, NewDString(Name(s).Normalize()))
+		dOid, missingTypeErr := ctx.Planner.ResolveOIDFromString(ctx.Ctx(), t, NewDString(Name(s).Normalize()))
 		if missingTypeErr == nil {
 			return dOid, missingTypeErr
 		}
@@ -4407,7 +4407,7 @@ func ParseDOid(ctx *EvalContext, s string, t *types.T) (*DOid, error) {
 			name:         tn.ObjectName.String(),
 		}, nil
 	default:
-		return queryOid(ctx, t, NewDString(s))
+		return ctx.Planner.ResolveOIDFromString(ctx.Ctx(), t, NewDString(s))
 	}
 }
 

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3065,10 +3065,35 @@ type EvalDatabase interface {
 	) (isVisible bool, exists bool, err error)
 }
 
+// TypeResolver is an interface for resolving types and type OIDs.
+type TypeResolver interface {
+	TypeReferenceResolver
+
+	// ResolveOIDFromString looks up the populated value of the OID with the
+	// desired resultType which matches the provided name.
+	//
+	// The return value is a fresh DOid of the input oid.Oid with name and OID
+	// set to the result of the query. If there was not exactly one result to the
+	// query, an error will be returned.
+	ResolveOIDFromString(
+		ctx context.Context, resultType *types.T, toResolve *DString,
+	) (*DOid, error)
+
+	// ResolveOIDFromOID looks up the populated value of the oid with the
+	// desired resultType which matches the provided oid.
+	//
+	// The return value is a fresh DOid of the input oid.Oid with name and OID
+	// set to the result of the query. If there was not exactly one result to the
+	// query, an error will be returned.
+	ResolveOIDFromOID(
+		ctx context.Context, resultType *types.T, toResolve *DOid,
+	) (*DOid, error)
+}
+
 // EvalPlanner is a limited planner that can be used from EvalContext.
 type EvalPlanner interface {
 	EvalDatabase
-	TypeReferenceResolver
+	TypeResolver
 
 	// GetImmutableTableInterfaceByID returns an interface{} with
 	// catalog.TableDescriptor to avoid a circular dependency.
@@ -3786,75 +3811,6 @@ func (expr *CaseExpr) Eval(ctx *EvalContext) (Datum, error) {
 // name of the function into group 1.
 // e.g. function(a, b, c) or function( a )
 var pgSignatureRegexp = regexp.MustCompile(`^\s*([\w\."]+)\s*\((?:(?:\s*[\w"]+\s*,)*\s*[\w"]+)?\s*\)\s*$`)
-
-// regTypeInfo contains details on a pg_catalog table that has a reg* type.
-type regTypeInfo struct {
-	tableName string
-	// nameCol is the name of the column that contains the table's entity name.
-	nameCol string
-	// objName is a human-readable name describing the objects in the table.
-	objName string
-	// errType is the pg error code in case the object does not exist.
-	errType pgcode.Code
-}
-
-// regTypeInfos maps an oid.Oid to a regTypeInfo that describes the pg_catalog
-// table that contains the entities of the type of the key.
-var regTypeInfos = map[oid.Oid]regTypeInfo{
-	oid.T_regclass:     {"pg_class", "relname", "relation", pgcode.UndefinedTable},
-	oid.T_regtype:      {"pg_type", "typname", "type", pgcode.UndefinedObject},
-	oid.T_regproc:      {"pg_proc", "proname", "function", pgcode.UndefinedFunction},
-	oid.T_regprocedure: {"pg_proc", "proname", "function", pgcode.UndefinedFunction},
-	oid.T_regnamespace: {"pg_namespace", "nspname", "namespace", pgcode.UndefinedObject},
-}
-
-// queryOidWithJoin looks up the name or OID of an input OID or string in the
-// pg_catalog table that the input oid.Oid belongs to. If the input Datum
-// is a DOid, the relevant table will be queried by OID; if the input is a
-// DString, the table will be queried by its name column.
-//
-// The return value is a fresh DOid of the input oid.Oid with name and OID
-// set to the result of the query. If there was not exactly one result to the
-// query, an error will be returned.
-func queryOidWithJoin(
-	ctx *EvalContext, typ *types.T, d Datum, joinClause string, additionalWhere string,
-) (*DOid, error) {
-	ret := &DOid{semanticType: typ}
-	info := regTypeInfos[typ.Oid()]
-	var queryCol string
-	switch d.(type) {
-	case *DOid:
-		queryCol = "oid"
-	case *DString:
-		queryCol = info.nameCol
-	default:
-		return nil, errors.AssertionFailedf("invalid argument to OID cast: %s", d)
-	}
-	results, err := ctx.InternalExecutor.QueryRow(
-		ctx.Ctx(), "queryOidWithJoin",
-		ctx.Txn,
-		fmt.Sprintf(
-			"SELECT %s.oid, %s FROM pg_catalog.%s %s WHERE %s = $1 %s",
-			info.tableName, info.nameCol, info.tableName, joinClause, queryCol, additionalWhere),
-		d)
-	if err != nil {
-		if errors.HasType(err, (*MultipleResultsError)(nil)) {
-			return nil, pgerror.Newf(pgcode.AmbiguousAlias,
-				"more than one %s named %s", info.objName, d)
-		}
-		return nil, err
-	}
-	if results.Len() == 0 {
-		return nil, pgerror.Newf(info.errType, "%s %s does not exist", info.objName, d)
-	}
-	ret.DInt = results[0].(*DOid).DInt
-	ret.name = AsStringWithFlags(results[1], FmtBareStrings)
-	return ret, nil
-}
-
-func queryOid(ctx *EvalContext, typ *types.T, d Datum) (*DOid, error) {
-	return queryOidWithJoin(ctx, typ, d, "", "")
-}
 
 // Eval implements the TypedExpr interface.
 func (expr *CastExpr) Eval(ctx *EvalContext) (Datum, error) {


### PR DESCRIPTION
This is part of a longer journey to unhook the InternalExecutor from the
tree.EvalContext.

Release note: None