### PR TITLE
cli: order span payloads by start_time for readability

### DIFF
--- a/pkg/cli/debug_job_trace.go
+++ b/pkg/cli/debug_job_trace.go
@@ -100,7 +100,7 @@ SELECT span_id, goroutine_id, operation, start_time, duration
 FROM crdb_internal.node_inflight_trace_spans 
 WHERE trace_id=$1
 ) SELECT *
-FROM spans, LATERAL crdb_internal.payloads_for_span(spans.span_id)`
+FROM spans, LATERAL crdb_internal.payloads_for_span(spans.span_id) ORDER BY spans.start_time`
 
 	var f *os.File
 	if f, err = os.Create(traceFilePath); err != nil {


### PR DESCRIPTION
During job execution, there can be several root spans on a node.
Egs: resumer, processor

While the recordings within a span are sorted by start time,
since the root spans are stored in an unordered map, the recordings
across root spans might not be sorted by start_time. When viewing
the output files for a job this results in the processor span printing
its payload before the job payload which is not intuitive.

We might change how we display recordings in the future, but for the
time being this fix makes the "ordering" of events deterministic.

Informs: https://github.com/cockroachdb/cockroach/issues/64992

Release note: None