### PR TITLE
release-20.2: Avro and Kafka namespacing changefeed options

### DIFF
--- a/pkg/ccl/changefeedccl/avro.go
+++ b/pkg/ccl/changefeedccl/avro.go
@@ -389,11 +389,11 @@ func columnDescToAvroSchema(colDesc *descpb.ColumnDescriptor) (*avroSchemaField,
 // indexToAvroSchema converts a column descriptor into its corresponding avro
 // record schema. The fields are kept in the same order as columns in the index.
 func indexToAvroSchema(
-	tableDesc catalog.TableDescriptor, indexDesc *descpb.IndexDescriptor,
+	tableDesc catalog.TableDescriptor, indexDesc *descpb.IndexDescriptor, name string,
 ) (*avroDataRecord, error) {
 	schema := &avroDataRecord{
 		avroRecord: avroRecord{
-			Name:       SQLNameToAvroName(tableDesc.GetName()),
+			Name:       SQLNameToAvroName(name),
 			SchemaType: `record`,
 		},
 		fieldIdxByName:   make(map[string]int),

--- a/pkg/ccl/changefeedccl/avro.go
+++ b/pkg/ccl/changefeedccl/avro.go
@@ -83,7 +83,10 @@ func avroUnionKey(t avroSchemaType) string {
 	case avroLogicalType:
 		return avroUnionKey(s.SchemaType) + `.` + s.LogicalType
 	case *avroRecord:
-		return s.Name
+		if s.Namespace == "" {
+			return s.Name
+		}
+		return s.Namespace + `.` + s.Name
 	default:
 		panic(errors.AssertionFailedf(`unsupported type %T %v`, t, t))
 	}
@@ -96,6 +99,7 @@ type avroSchemaField struct {
 	Name       string         `json:"name"`
 	Default    *string        `json:"default"`
 	Metadata   string         `json:"__crdb__,omitempty"`
+	Namespace  string         `json:"namespace,omitempty"`
 
 	typ *types.T
 
@@ -109,6 +113,7 @@ type avroRecord struct {
 	SchemaType string             `json:"type"`
 	Name       string             `json:"name"`
 	Fields     []*avroSchemaField `json:"fields"`
+	Namespace  string             `json:"namespace,omitempty"`
 	codec      *goavro.Codec
 }
 
@@ -390,12 +395,16 @@ func columnDescToAvroSchema(colDesc *descpb.ColumnDescriptor) (*avroSchemaField,
 // record schema. The fields are kept in the same order as columns in the index.
 // sqlName can be any string but should uniquely identify a schema.
 func indexToAvroSchema(
-	tableDesc catalog.TableDescriptor, indexDesc *descpb.IndexDescriptor, sqlName string,
+	tableDesc catalog.TableDescriptor,
+	indexDesc *descpb.IndexDescriptor,
+	sqlName string,
+	namespace string,
 ) (*avroDataRecord, error) {
 	schema := &avroDataRecord{
 		avroRecord: avroRecord{
 			Name:       SQLNameToAvroName(sqlName),
 			SchemaType: `record`,
+			Namespace:  namespace,
 		},
 		fieldIdxByName:   make(map[string]int),
 		colIdxByFieldIdx: make(map[int]int),
@@ -437,7 +446,7 @@ const (
 // If a name suffix is provided (as opposed to avroSchemaNoSuffix), it will be
 // appended to the end of the avro record's name.
 func tableToAvroSchema(
-	tableDesc catalog.TableDescriptor, nameSuffix string,
+	tableDesc catalog.TableDescriptor, nameSuffix string, namespace string,
 ) (*avroDataRecord, error) {
 	name := SQLNameToAvroName(tableDesc.GetName())
 	if nameSuffix != avroSchemaNoSuffix {
@@ -447,6 +456,7 @@ func tableToAvroSchema(
 		avroRecord: avroRecord{
 			Name:       name,
 			SchemaType: `record`,
+			Namespace:  namespace,
 		},
 		fieldIdxByName:   make(map[string]int),
 		colIdxByFieldIdx: make(map[int]int),
@@ -554,12 +564,13 @@ func (r *avroDataRecord) rowFromNative(native interface{}) (rowenc.EncDatumRow, 
 // envelopeToAvroSchema creates an avro record schema for an envelope containing
 // before and after versions of a row change and metadata about that row change.
 func envelopeToAvroSchema(
-	topic string, opts avroEnvelopeOpts, before, after *avroDataRecord,
+	topic string, opts avroEnvelopeOpts, before, after *avroDataRecord, namespace string,
 ) (*avroEnvelopeRecord, error) {
 	schema := &avroEnvelopeRecord{
 		avroRecord: avroRecord{
 			Name:       SQLNameToAvroName(topic) + `_envelope`,
 			SchemaType: `record`,
+			Namespace:  namespace,
 		},
 		opts: opts,
 	}

--- a/pkg/ccl/changefeedccl/avro.go
+++ b/pkg/ccl/changefeedccl/avro.go
@@ -388,12 +388,13 @@ func columnDescToAvroSchema(colDesc *descpb.ColumnDescriptor) (*avroSchemaField,
 
 // indexToAvroSchema converts a column descriptor into its corresponding avro
 // record schema. The fields are kept in the same order as columns in the index.
+// sqlName can be any string but should uniquely identify a schema.
 func indexToAvroSchema(
-	tableDesc catalog.TableDescriptor, indexDesc *descpb.IndexDescriptor, name string,
+	tableDesc catalog.TableDescriptor, indexDesc *descpb.IndexDescriptor, sqlName string,
 ) (*avroDataRecord, error) {
 	schema := &avroDataRecord{
 		avroRecord: avroRecord{
-			Name:       SQLNameToAvroName(name),
+			Name:       SQLNameToAvroName(sqlName),
 			SchemaType: `record`,
 		},
 		fieldIdxByName:   make(map[string]int),

--- a/pkg/ccl/changefeedccl/avro_test.go
+++ b/pkg/ccl/changefeedccl/avro_test.go
@@ -123,7 +123,7 @@ func parseAvroSchema(j string) (*avroDataRecord, error) {
 		}
 		tableDesc.Columns = append(tableDesc.Columns, *colDesc)
 	}
-	return tableToAvroSchema(tabledesc.NewImmutable(tableDesc), avroSchemaNoSuffix)
+	return tableToAvroSchema(tabledesc.NewImmutable(tableDesc), avroSchemaNoSuffix, "")
 }
 
 func avroFieldMetadataToColDesc(metadata string) (*descpb.ColumnDescriptor, error) {
@@ -244,7 +244,7 @@ func TestAvroSchema(t *testing.T) {
 			tableDesc, err := parseTableDesc(
 				fmt.Sprintf(`CREATE TABLE "%s" %s`, test.name, test.schema))
 			require.NoError(t, err)
-			origSchema, err := tableToAvroSchema(tableDesc, avroSchemaNoSuffix)
+			origSchema, err := tableToAvroSchema(tableDesc, avroSchemaNoSuffix, "")
 			require.NoError(t, err)
 			jsonSchema := origSchema.codec.Schema()
 			roundtrippedSchema, err := parseAvroSchema(jsonSchema)
@@ -278,7 +278,7 @@ func TestAvroSchema(t *testing.T) {
 	t.Run("escaping", func(t *testing.T) {
 		tableDesc, err := parseTableDesc(`CREATE TABLE "☃" (🍦 INT PRIMARY KEY)`)
 		require.NoError(t, err)
-		tableSchema, err := tableToAvroSchema(tableDesc, avroSchemaNoSuffix)
+		tableSchema, err := tableToAvroSchema(tableDesc, avroSchemaNoSuffix, "")
 		require.NoError(t, err)
 		require.Equal(t,
 			`{"type":"record","name":"_u2603_","fields":[`+
@@ -286,7 +286,8 @@ func TestAvroSchema(t *testing.T) {
 				`"__crdb__":"🍦 INT8 NOT NULL"}]}`,
 			tableSchema.codec.Schema())
 
-		indexSchema, err := indexToAvroSchema(tableDesc, tableDesc.GetPrimaryIndex(), tableDesc.GetName())
+		indexSchema, err := indexToAvroSchema(tableDesc, tableDesc.GetPrimaryIndex(), tableDesc.GetName(), "")
+
 		require.NoError(t, err)
 		require.Equal(t,
 			`{"type":"record","name":"_u2603_","fields":[`+
@@ -451,7 +452,7 @@ func TestAvroSchema(t *testing.T) {
 			rows, err := parseValues(tableDesc, `VALUES (1, `+test.sql+`)`)
 			require.NoError(t, err)
 
-			schema, err := tableToAvroSchema(tableDesc, avroSchemaNoSuffix)
+			schema, err := tableToAvroSchema(tableDesc, avroSchemaNoSuffix, "")
 			require.NoError(t, err)
 			textual, err := schema.textualFromRow(rows[0])
 			require.NoError(t, err)
@@ -554,12 +555,12 @@ func TestAvroMigration(t *testing.T) {
 			writerDesc, err := parseTableDesc(
 				fmt.Sprintf(`CREATE TABLE "%s" %s`, test.name, test.writerSchema))
 			require.NoError(t, err)
-			writerSchema, err := tableToAvroSchema(writerDesc, avroSchemaNoSuffix)
+			writerSchema, err := tableToAvroSchema(writerDesc, avroSchemaNoSuffix, "")
 			require.NoError(t, err)
 			readerDesc, err := parseTableDesc(
 				fmt.Sprintf(`CREATE TABLE "%s" %s`, test.name, test.readerSchema))
 			require.NoError(t, err)
-			readerSchema, err := tableToAvroSchema(readerDesc, avroSchemaNoSuffix)
+			readerSchema, err := tableToAvroSchema(readerDesc, avroSchemaNoSuffix, "")
 			require.NoError(t, err)
 
 			writerRows, err := parseValues(writerDesc, `VALUES `+test.writerValues)

--- a/pkg/ccl/changefeedccl/avro_test.go
+++ b/pkg/ccl/changefeedccl/avro_test.go
@@ -285,7 +285,8 @@ func TestAvroSchema(t *testing.T) {
 				`{"type":["null","long"],"name":"_u0001f366_","default":null,`+
 				`"__crdb__":"🍦 INT8 NOT NULL"}]}`,
 			tableSchema.codec.Schema())
-		indexSchema, err := indexToAvroSchema(tableDesc, tableDesc.GetPrimaryIndex())
+
+		indexSchema, err := indexToAvroSchema(tableDesc, tableDesc.GetPrimaryIndex(), tableDesc.GetName())
 		require.NoError(t, err)
 		require.Equal(t,
 			`{"type":"record","name":"_u2603_","fields":[`+

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -136,7 +136,7 @@ func newChangeAggregatorProcessor(
 	}
 
 	var err error
-	if ca.encoder, err = getEncoder(ca.spec.Feed.Opts); err != nil {
+	if ca.encoder, err = getEncoder(ca.spec.Feed.Opts, ca.spec.Feed.Targets); err != nil {
 		return nil, err
 	}
 
@@ -529,7 +529,7 @@ func newChangeFrontierProcessor(
 	}
 
 	var err error
-	if cf.encoder, err = getEncoder(spec.Feed.Opts); err != nil {
+	if cf.encoder, err = getEncoder(spec.Feed.Opts, spec.Feed.Targets); err != nil {
 		return nil, err
 	}
 

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -185,7 +185,7 @@ func changefeedPlanHook(
 					return err
 				}
 				_, qualified := opts[changefeedbase.OptFullTableName]
-				name, err := getMaybeQualifiedTableName(ctx, table, *p.ExecCfg(), p.Txn(), qualified)
+				name, err := getChangefeedTargetName(ctx, table, *p.ExecCfg(), p.Txn(), qualified)
 				if err != nil {
 					return err
 				}
@@ -727,30 +727,29 @@ func (b *changefeedResumer) OnPauseRequest(
 }
 
 // getQualifiedTableName returns the database-qualified name of the table
-// or view represented by the provided descriptor. It is a sort of
-// reverse of the Resolve() functions.
+// or view represented by the provided descriptor.
 func getQualifiedTableName(
 	ctx context.Context, execCfg sql.ExecutorConfig, txn *kv.Txn, desc catalog.TableDescriptor,
-) (*tree.TableName, error) {
+) (string, error) {
 	dbDesc, err := catalogkv.MustGetDatabaseDescByID(ctx, txn, execCfg.Codec, desc.GetParentID())
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 	schemaID := desc.GetParentSchemaID()
 	schemaName, err := resolver.ResolveSchemaNameByID(ctx, txn, execCfg.Codec, desc.GetParentID(), schemaID)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 	tbName := tree.MakeTableNameWithSchema(
 		tree.Name(dbDesc.GetName()),
 		tree.Name(schemaName),
 		tree.Name(desc.GetName()),
 	)
-	return &tbName, nil
+	return tbName.String(), nil
 }
 
-// getMaybeQualifiedTableName gets a table name with or without the dots
-func getMaybeQualifiedTableName(
+// getChangefeedTargetName gets a table name with or without the dots
+func getChangefeedTargetName(
 	ctx context.Context,
 	desc catalog.TableDescriptor,
 	execCfg sql.ExecutorConfig,
@@ -758,11 +757,7 @@ func getMaybeQualifiedTableName(
 	qualified bool,
 ) (string, error) {
 	if qualified {
-		tbl, err := getQualifiedTableName(ctx, execCfg, txn, desc)
-		if err != nil {
-			return "", err
-		}
-		return tbl.String(), err
+		return getQualifiedTableName(ctx, execCfg, txn, desc)
 	}
 	return desc.GetName(), nil
 }

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -244,7 +244,7 @@ func changefeedPlanHook(
 			return err
 		}
 
-		if _, err := getEncoder(details.Opts); err != nil {
+		if _, err := getEncoder(details.Opts, details.Targets); err != nil {
 			return err
 		}
 		if isCloudStorageSink(parsedSink) {
@@ -537,9 +537,6 @@ func validateChangefeedTable(
 
 	if tableDesc.GetState() == descpb.DescriptorState_DROP {
 		return errors.Errorf(`"%s" was dropped or truncated`, t.StatementTimeName)
-	}
-	if tableDesc.GetName() != t.StatementTimeName {
-		return errors.Errorf(`"%s" was renamed to "%s"`, t.StatementTimeName, tableDesc.GetName())
 	}
 
 	// TODO(mrtracy): re-enable this when allow-backfill option is added.

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -199,6 +199,26 @@ func TestChangefeedEnvelope(t *testing.T) {
 	t.Run(`enterprise`, enterpriseTest(testFn))
 }
 
+func TestChangefeedFullTableName(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING)`)
+		sqlDB.Exec(t, `INSERT INTO foo VALUES (1, 'a')`)
+
+		t.Run(`envelope=row`, func(t *testing.T) {
+			foo := feed(t, f, `CREATE CHANGEFEED FOR foo WITH full_table_name`)
+			defer closeFeed(t, foo)
+			assertPayloads(t, foo, []string{`d.public.foo: [1]->{"after": {"a": 1, "b": "a"}}`})
+		})
+	}
+	//TODO(zinger): No reason in principle this shouldn't be honored here
+	//t.Run(`sinkless`, sinklessTest(testFn))
+	t.Run(`enterprise`, enterpriseTest(testFn))
+}
+
 func TestChangefeedMultiTable(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1425,7 +1445,7 @@ func TestChangefeedUpdatePrimaryKey(t *testing.T) {
 	t.Run(`enterprise`, enterpriseTest(testFn))
 }
 
-func TestChangefeedTruncateRenameDrop(t *testing.T) {
+func TestChangefeedTruncateOrDrop(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
@@ -1471,18 +1491,6 @@ func TestChangefeedTruncateRenameDrop(t *testing.T) {
 		}
 		assertFailuresCounter(t, metrics, 2)
 
-		sqlDB.Exec(t, `CREATE TABLE rename (a INT PRIMARY KEY)`)
-		sqlDB.Exec(t, `INSERT INTO rename VALUES (1)`)
-		rename := feed(t, f, `CREATE CHANGEFEED FOR rename`)
-		defer closeFeed(t, rename)
-		assertPayloads(t, rename, []string{`rename: [1]->{"after": {"a": 1}}`})
-		sqlDB.Exec(t, `ALTER TABLE rename RENAME TO renamed`)
-		sqlDB.Exec(t, `INSERT INTO renamed VALUES (2)`)
-		if _, err := rename.Next(); !testutils.IsError(err, `"rename" was renamed to "renamed"`) {
-			t.Errorf(`expected ""rename" was renamed to "renamed"" error got: %+v`, err)
-		}
-		assertFailuresCounter(t, metrics, 3)
-
 		sqlDB.Exec(t, `CREATE TABLE drop (a INT PRIMARY KEY)`)
 		sqlDB.Exec(t, `INSERT INTO drop VALUES (1)`)
 		drop := feed(t, f, `CREATE CHANGEFEED FOR drop`)
@@ -1492,7 +1500,7 @@ func TestChangefeedTruncateRenameDrop(t *testing.T) {
 		if _, err := drop.Next(); !testutils.IsError(err, `"drop" was dropped or truncated`) {
 			t.Errorf(`expected ""drop" was dropped or truncated" error got: %+v`, err)
 		}
-		assertFailuresCounter(t, metrics, 4)
+		assertFailuresCounter(t, metrics, 3)
 	}
 
 	t.Run(`sinkless`, sinklessTest(testFn))

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -214,7 +214,7 @@ func TestChangefeedFullTableName(t *testing.T) {
 			assertPayloads(t, foo, []string{`d.public.foo: [1]->{"after": {"a": 1, "b": "a"}}`})
 		})
 	}
-	//TODO(zinger): No reason in principle this shouldn't be honored here
+	//TODO(zinger): Plumb this option through to all encoders so it works in sinkless mode
 	//t.Run(`sinkless`, sinklessTest(testFn))
 	t.Run(`enterprise`, enterpriseTest(testFn))
 }

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -1990,6 +1990,7 @@ func TestChangefeedErrors(t *testing.T) {
 	)
 
 	// Check that confluent_schema_registry is only accepted if format is avro.
+	// TODO: This should be testing it as a WITH option and check avro_schema_prefix too
 	sqlDB.ExpectErr(
 		t, `unknown sink query parameter: confluent_schema_registry`,
 		`CREATE CHANGEFEED FOR foo INTO $1`, `experimental-sql://d/?confluent_schema_registry=foo`,

--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -30,6 +30,7 @@ const (
 	OptCursor                   = `cursor`
 	OptEnvelope                 = `envelope`
 	OptFormat                   = `format`
+	OptFullTableName            = `full_table_name`
 	OptKeyInValue               = `key_in_value`
 	OptResolvedTimestamps       = `resolved`
 	OptUpdatedTimestamps        = `updated`
@@ -103,6 +104,7 @@ var ChangefeedOptionExpectValues = map[string]sql.KVStringOptValidate{
 	OptCursor:                   sql.KVStringOptRequireValue,
 	OptEnvelope:                 sql.KVStringOptRequireValue,
 	OptFormat:                   sql.KVStringOptRequireValue,
+	OptFullTableName:            sql.KVStringOptRequireNoValue,
 	OptKeyInValue:               sql.KVStringOptRequireNoValue,
 	OptResolvedTimestamps:       sql.KVStringOptAny,
 	OptUpdatedTimestamps:        sql.KVStringOptRequireNoValue,

--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -26,6 +26,7 @@ type SchemaChangePolicy string
 
 // Constants for the options.
 const (
+	OptAvroSchemaPrefix         = `avro_schema_prefix`
 	OptConfluentSchemaRegistry  = `confluent_schema_registry`
 	OptCursor                   = `cursor`
 	OptEnvelope                 = `envelope`
@@ -100,6 +101,7 @@ const (
 // ChangefeedOptionExpectValues is used to parse changefeed options using
 // PlanHookState.TypeAsStringOpts().
 var ChangefeedOptionExpectValues = map[string]sql.KVStringOptValidate{
+	OptAvroSchemaPrefix:         sql.KVStringOptRequireValue,
 	OptConfluentSchemaRegistry:  sql.KVStringOptRequireValue,
 	OptCursor:                   sql.KVStringOptRequireValue,
 	OptEnvelope:                 sql.KVStringOptRequireValue,

--- a/pkg/ccl/changefeedccl/changefeedbase/validate.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/validate.go
@@ -49,9 +49,6 @@ func ValidateTable(targets jobspb.ChangefeedTargets, tableDesc *tabledesc.Immuta
 	if tableDesc.State == descpb.DescriptorState_DROP {
 		return errors.Errorf(`"%s" was dropped or truncated`, t.StatementTimeName)
 	}
-	if tableDesc.Name != t.StatementTimeName {
-		return errors.Errorf(`"%s" was renamed to "%s"`, t.StatementTimeName, tableDesc.Name)
-	}
 
 	// TODO(mrtracy): re-enable this when allow-backfill option is added.
 	// if tableDesc.HasColumnBackfillMutation() {

--- a/pkg/ccl/changefeedccl/encoder.go
+++ b/pkg/ccl/changefeedccl/encoder.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"encoding/binary"
 	gojson "encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/url"
 	"path/filepath"
@@ -21,6 +20,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
@@ -83,12 +83,12 @@ type Encoder interface {
 	EncodeResolvedTimestamp(context.Context, string, hlc.Timestamp) ([]byte, error)
 }
 
-func getEncoder(opts map[string]string) (Encoder, error) {
+func getEncoder(opts map[string]string, targets jobspb.ChangefeedTargets) (Encoder, error) {
 	switch changefeedbase.FormatType(opts[changefeedbase.OptFormat]) {
 	case ``, changefeedbase.OptFormatJSON:
 		return makeJSONEncoder(opts)
 	case changefeedbase.OptFormatAvro:
-		return newConfluentAvroEncoder(opts)
+		return newConfluentAvroEncoder(opts, targets)
 	default:
 		return nil, errors.Errorf(`unknown %s: %s`, changefeedbase.OptFormat, opts[changefeedbase.OptFormat])
 	}
@@ -272,9 +272,10 @@ func (e *jsonEncoder) EncodeResolvedTimestamp(
 // JSON format. Keys are the primary key columns in a record. Values are all
 // columns in a record.
 type confluentAvroEncoder struct {
-	registryURL                                          string
-	schemaPrefix                                         string
-	updatedField, beforeField, keyOnly, useFullTableName bool
+	registryURL                        string
+	schemaPrefix                       string
+	updatedField, beforeField, keyOnly bool
+	targets                            jobspb.ChangefeedTargets
 
 	keyCache      map[tableIDAndVersion]confluentRegisteredKeySchema
 	valueCache    map[tableIDAndVersionPair]confluentRegisteredEnvelopeSchema
@@ -300,10 +301,13 @@ type confluentRegisteredEnvelopeSchema struct {
 
 var _ Encoder = &confluentAvroEncoder{}
 
-func newConfluentAvroEncoder(opts map[string]string) (*confluentAvroEncoder, error) {
+func newConfluentAvroEncoder(
+	opts map[string]string, targets jobspb.ChangefeedTargets,
+) (*confluentAvroEncoder, error) {
 	e := &confluentAvroEncoder{registryURL: opts[changefeedbase.OptConfluentSchemaRegistry]}
 
 	e.schemaPrefix = opts[changefeedbase.OptAvroSchemaPrefix]
+	e.targets = targets
 
 	switch opts[changefeedbase.OptEnvelope] {
 	case string(changefeedbase.OptEnvelopeKeyOnly):
@@ -328,7 +332,6 @@ func newConfluentAvroEncoder(opts map[string]string) (*confluentAvroEncoder, err
 		return nil, errors.Errorf(`%s is not supported with %s=%s`,
 			changefeedbase.OptKeyInValue, changefeedbase.OptFormat, changefeedbase.OptFormatAvro)
 	}
-	_, e.useFullTableName = opts[changefeedbase.OptFullTableName]
 
 	if len(e.registryURL) == 0 {
 		return nil, errors.Errorf(`WITH option %s is required for %s=%s`,
@@ -343,18 +346,7 @@ func newConfluentAvroEncoder(opts map[string]string) (*confluentAvroEncoder, err
 // Get the raw SQL-formatted string for a table name
 // and apply full_table_name and avro_schema_prefix options
 func (e *confluentAvroEncoder) rawTableName(desc catalog.TableDescriptor) string {
-	tableName := desc.GetName()
-	if e.useFullTableName {
-		//We can't use the statement time name here because schemas are version specific
-		//And the fully-qualified table name is either hard to get or undefined
-		//without a current transaction and execution context.
-		//But this just needs to avoid collisions, so we can use ids in place of names.
-		tableName = fmt.Sprintf("db%d.schema%d.%s",
-			desc.GetParentID(),
-			desc.GetParentSchemaID(),
-			tableName)
-	}
-	return e.schemaPrefix + tableName
+	return e.schemaPrefix + e.targets[desc.GetID()].StatementTimeName
 }
 
 // EncodeKey implements the Encoder interface.

--- a/pkg/ccl/changefeedccl/encoder.go
+++ b/pkg/ccl/changefeedccl/encoder.go
@@ -411,7 +411,7 @@ func (e *confluentAvroEncoder) EncodeValue(ctx context.Context, row encodeRow) (
 		}
 
 		opts := avroEnvelopeOpts{afterField: true, beforeField: e.beforeField, updatedField: e.updatedField}
-		registered.schema, err = envelopeToAvroSchema(row.tableDesc.GetName(), opts, beforeDataSchema, afterDataSchema)
+		registered.schema, err = envelopeToAvroSchema(e.rawTableName(row.tableDesc), opts, beforeDataSchema, afterDataSchema)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/ccl/changefeedccl/encoder.go
+++ b/pkg/ccl/changefeedccl/encoder.go
@@ -273,6 +273,7 @@ func (e *jsonEncoder) EncodeResolvedTimestamp(
 // columns in a record.
 type confluentAvroEncoder struct {
 	registryURL                                          string
+	schemaPrefix                                         string
 	updatedField, beforeField, keyOnly, useFullTableName bool
 
 	keyCache      map[tableIDAndVersion]confluentRegisteredKeySchema
@@ -301,6 +302,8 @@ var _ Encoder = &confluentAvroEncoder{}
 
 func newConfluentAvroEncoder(opts map[string]string) (*confluentAvroEncoder, error) {
 	e := &confluentAvroEncoder{registryURL: opts[changefeedbase.OptConfluentSchemaRegistry]}
+
+	e.schemaPrefix = opts[changefeedbase.OptAvroSchemaPrefix]
 
 	switch opts[changefeedbase.OptEnvelope] {
 	case string(changefeedbase.OptEnvelopeKeyOnly):
@@ -337,7 +340,8 @@ func newConfluentAvroEncoder(opts map[string]string) (*confluentAvroEncoder, err
 	return e, nil
 }
 
-//Get the raw SQL-formatted string for a table name and apply full_table_name option
+// Get the raw SQL-formatted string for a table name
+// and apply full_table_name and avro_schema_prefix options
 func (e *confluentAvroEncoder) rawTableName(desc catalog.TableDescriptor) string {
 	tableName := desc.GetName()
 	if e.useFullTableName {
@@ -350,7 +354,7 @@ func (e *confluentAvroEncoder) rawTableName(desc catalog.TableDescriptor) string
 			desc.GetParentSchemaID(),
 			tableName)
 	}
-	return tableName
+	return e.schemaPrefix + tableName
 }
 
 // EncodeKey implements the Encoder interface.

--- a/pkg/ccl/changefeedccl/encoder.go
+++ b/pkg/ccl/changefeedccl/encoder.go
@@ -358,7 +358,8 @@ func (e *confluentAvroEncoder) EncodeKey(ctx context.Context, row encodeRow) ([]
 		var err error
 
 		tableName := e.rawTableName(row.tableDesc)
-		registered.schema, err = indexToAvroSchema(row.tableDesc, row.tableDesc.GetPrimaryIndex(), tableName)
+		registered.schema, err = indexToAvroSchema(row.tableDesc, row.tableDesc.GetPrimaryIndex(), tableName, e.schemaPrefix)
+
 		if err != nil {
 			return nil, err
 		}
@@ -399,19 +400,20 @@ func (e *confluentAvroEncoder) EncodeValue(ctx context.Context, row encodeRow) (
 		var beforeDataSchema *avroDataRecord
 		if e.beforeField && row.prevTableDesc != nil {
 			var err error
-			beforeDataSchema, err = tableToAvroSchema(row.prevTableDesc, `before`)
+			beforeDataSchema, err = tableToAvroSchema(row.prevTableDesc, `before`, e.schemaPrefix)
 			if err != nil {
 				return nil, err
 			}
 		}
 
-		afterDataSchema, err := tableToAvroSchema(row.tableDesc, avroSchemaNoSuffix)
+		afterDataSchema, err := tableToAvroSchema(row.tableDesc, avroSchemaNoSuffix, e.schemaPrefix)
 		if err != nil {
 			return nil, err
 		}
 
 		opts := avroEnvelopeOpts{afterField: true, beforeField: e.beforeField, updatedField: e.updatedField}
-		registered.schema, err = envelopeToAvroSchema(e.rawTableName(row.tableDesc), opts, beforeDataSchema, afterDataSchema)
+		registered.schema, err = envelopeToAvroSchema(e.rawTableName(row.tableDesc), opts, beforeDataSchema, afterDataSchema, e.schemaPrefix)
+
 		if err != nil {
 			return nil, err
 		}
@@ -456,7 +458,7 @@ func (e *confluentAvroEncoder) EncodeResolvedTimestamp(
 	if !ok {
 		opts := avroEnvelopeOpts{resolvedField: true}
 		var err error
-		registered.schema, err = envelopeToAvroSchema(topic, opts, nil /* before */, nil /* after */)
+		registered.schema, err = envelopeToAvroSchema(topic, opts, nil /* before */, nil /* after */, e.schemaPrefix /* namespace */)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/ccl/changefeedccl/encoder.go
+++ b/pkg/ccl/changefeedccl/encoder.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"encoding/binary"
 	gojson "encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/url"
 	"path/filepath"
@@ -271,8 +272,8 @@ func (e *jsonEncoder) EncodeResolvedTimestamp(
 // JSON format. Keys are the primary key columns in a record. Values are all
 // columns in a record.
 type confluentAvroEncoder struct {
-	registryURL                                       string
-	updatedField, beforeField, keyOnly, fullTableName bool
+	registryURL                                          string
+	updatedField, beforeField, keyOnly, useFullTableName bool
 
 	keyCache      map[tableIDAndVersion]confluentRegisteredKeySchema
 	valueCache    map[tableIDAndVersionPair]confluentRegisteredEnvelopeSchema
@@ -324,7 +325,7 @@ func newConfluentAvroEncoder(opts map[string]string) (*confluentAvroEncoder, err
 		return nil, errors.Errorf(`%s is not supported with %s=%s`,
 			changefeedbase.OptKeyInValue, changefeedbase.OptFormat, changefeedbase.OptFormatAvro)
 	}
-	_, e.fullTableName = opts[changefeedbase.OptFullTableName]
+	_, e.useFullTableName = opts[changefeedbase.OptFullTableName]
 
 	if len(e.registryURL) == 0 {
 		return nil, errors.Errorf(`WITH option %s is required for %s=%s`,
@@ -336,6 +337,22 @@ func newConfluentAvroEncoder(opts map[string]string) (*confluentAvroEncoder, err
 	return e, nil
 }
 
+//Get the raw SQL-formatted string for a table name and apply full_table_name option
+func (e *confluentAvroEncoder) rawTableName(desc catalog.TableDescriptor) string {
+	tableName := desc.GetName()
+	if e.useFullTableName {
+		//We can't use the statement time name here because schemas are version specific
+		//And the fully-qualified table name is either hard to get or undefined
+		//without a current transaction and execution context.
+		//But this just needs to avoid collisions, so we can use ids in place of names.
+		tableName = fmt.Sprintf("db%d.schema%d.%s",
+			desc.GetParentID(),
+			desc.GetParentSchemaID(),
+			tableName)
+	}
+	return tableName
+}
+
 // EncodeKey implements the Encoder interface.
 func (e *confluentAvroEncoder) EncodeKey(ctx context.Context, row encodeRow) ([]byte, error) {
 	cacheKey := makeTableIDAndVersion(row.tableDesc.GetID(), row.tableDesc.GetVersion())
@@ -344,14 +361,15 @@ func (e *confluentAvroEncoder) EncodeKey(ctx context.Context, row encodeRow) ([]
 	if !ok {
 		var err error
 
-		registered.schema, err = indexToAvroSchema(row.tableDesc, row.tableDesc.GetPrimaryIndex(), row.tableDesc.GetName())
+		tableName := e.rawTableName(row.tableDesc)
+		registered.schema, err = indexToAvroSchema(row.tableDesc, row.tableDesc.GetPrimaryIndex(), tableName)
 		if err != nil {
 			return nil, err
 		}
 
 		// NB: This uses the kafka name escaper because it has to match the name
 		// of the kafka topic.
-		subject := SQLNameToKafkaName(row.tableDesc.GetName()) + confluentSubjectSuffixKey
+		subject := SQLNameToKafkaName(tableName) + confluentSubjectSuffixKey
 		registered.registryID, err = e.register(ctx, &registered.schema.avroRecord, subject)
 		if err != nil {
 			return nil, err
@@ -404,7 +422,7 @@ func (e *confluentAvroEncoder) EncodeValue(ctx context.Context, row encodeRow) (
 
 		// NB: This uses the kafka name escaper because it has to match the name
 		// of the kafka topic.
-		subject := SQLNameToKafkaName(row.tableDesc.GetName()) + confluentSubjectSuffixValue
+		subject := SQLNameToKafkaName(e.rawTableName(row.tableDesc)) + confluentSubjectSuffixValue
 		registered.registryID, err = e.register(ctx, &registered.schema.avroRecord, subject)
 		if err != nil {
 			return nil, err

--- a/pkg/ccl/changefeedccl/encoder_test.go
+++ b/pkg/ccl/changefeedccl/encoder_test.go
@@ -482,6 +482,10 @@ func TestAvroSchemaNaming(t *testing.T) {
 			`supermovr.public.drivers-key`,
 			`supermovr.public.drivers-value`,
 		})
+
+		//Both changes to the subject are also reflected in the schema name in the posted schemas
+		require.Contains(t, reg.mu.schemas[reg.mu.subjects[`supermovr.public.drivers-key`]], `supermovr`)
+		require.Contains(t, reg.mu.schemas[reg.mu.subjects[`supermovr.public.drivers-value`]], `supermovr`)
 	}
 
 	t.Run(`enterprise`, enterpriseTest(testFn))

--- a/pkg/ccl/changefeedccl/encoder_test.go
+++ b/pkg/ccl/changefeedccl/encoder_test.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach-go/crdb"
@@ -261,14 +262,16 @@ type testSchemaRegistry struct {
 	server *httptest.Server
 	mu     struct {
 		syncutil.Mutex
-		idAlloc int32
-		schemas map[int32]string
+		idAlloc  int32
+		schemas  map[int32]string
+		subjects map[string]int32
 	}
 }
 
 func makeTestSchemaRegistry() *testSchemaRegistry {
 	r := &testSchemaRegistry{}
 	r.mu.schemas = make(map[int32]string)
+	r.mu.subjects = make(map[string]int32)
 	r.server = httptest.NewServer(http.HandlerFunc(r.Register))
 	return r
 }
@@ -292,9 +295,11 @@ func (r *testSchemaRegistry) Register(hw http.ResponseWriter, hr *http.Request) 
 		}
 
 		r.mu.Lock()
+		subject := strings.Split(hr.URL.Path, "/")[2]
 		id := r.mu.idAlloc
 		r.mu.idAlloc++
 		r.mu.schemas[id] = req.Schema
+		r.mu.subjects[subject] = id
 		r.mu.Unlock()
 
 		res, err := gojson.Marshal(confluentSchemaVersionResponse{ID: id})
@@ -385,6 +390,93 @@ func TestAvroEncoder(t *testing.T) {
 	}
 
 	t.Run(`sinkless`, sinklessTest(testFn))
+	t.Run(`enterprise`, enterpriseTest(testFn))
+}
+
+func TestAvroSchemaNaming(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
+		reg := makeTestSchemaRegistry()
+		defer reg.Close()
+
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		sqlDB.Exec(t, `CREATE DATABASE movr`)
+		sqlDB.Exec(t, `CREATE TABLE movr.drivers (id INT PRIMARY KEY, name STRING)`)
+		sqlDB.Exec(t,
+			`INSERT INTO movr.drivers VALUES (1, 'Alice')`,
+		)
+
+		movrFeed := feed(t, f, `CREATE CHANGEFEED FOR movr.drivers `+
+			`WITH format=$1, confluent_schema_registry=$2`,
+			changefeedbase.OptFormatAvro, reg.server.URL)
+		defer closeFeed(t, movrFeed)
+
+		assertPayloadsAvro(t, reg, movrFeed, []string{
+			`drivers: {"id":{"long":1}}->{"after":{"drivers":{"id":{"long":1},"name":{"string":"Alice"}}}}`,
+		})
+
+		assertRegisteredSubjects(t, reg, []string{
+			`drivers-key`,
+			`drivers-value`,
+		})
+
+		fqnFeed := feed(t, f, `CREATE CHANGEFEED FOR movr.drivers `+
+			`WITH format=$1, confluent_schema_registry=$2, full_table_name`,
+			changefeedbase.OptFormatAvro, reg.server.URL)
+		defer closeFeed(t, fqnFeed)
+
+		assertPayloadsAvro(t, reg, fqnFeed, []string{
+			`movr.public.drivers: {"id":{"long":1}}->{"after":{"drivers":{"id":{"long":1},"name":{"string":"Alice"}}}}`,
+		})
+
+		assertRegisteredSubjects(t, reg, []string{
+			`drivers-key`,
+			`drivers-value`,
+			`db#.schema#.drivers-key`,
+			`db#.schema#.drivers-value`,
+		})
+
+		prefixFeed := feed(t, f, `CREATE CHANGEFEED FOR movr.drivers `+
+			`WITH format=$1, confluent_schema_registry=$2, avro_schema_prefix=super`,
+			changefeedbase.OptFormatAvro, reg.server.URL)
+		defer closeFeed(t, prefixFeed)
+
+		assertPayloadsAvro(t, reg, prefixFeed, []string{
+			`drivers: {"id":{"long":1}}->{"after":{"drivers":{"id":{"long":1},"name":{"string":"Alice"}}}}`,
+		})
+
+		assertRegisteredSubjects(t, reg, []string{
+			`drivers-key`,
+			`drivers-value`,
+			`db#.schema#.drivers-key`,
+			`db#.schema#.drivers-value`,
+			`superdrivers-key`,
+			`superdrivers-value`,
+		})
+
+		prefixFQNFeed := feed(t, f, `CREATE CHANGEFEED FOR movr.drivers `+
+			`WITH format=$1, confluent_schema_registry=$2, avro_schema_prefix=super, full_table_name`,
+			changefeedbase.OptFormatAvro, reg.server.URL)
+		defer closeFeed(t, prefixFQNFeed)
+
+		assertPayloadsAvro(t, reg, prefixFQNFeed, []string{
+			`movr.public.drivers: {"id":{"long":1}}->{"after":{"drivers":{"id":{"long":1},"name":{"string":"Alice"}}}}`,
+		})
+
+		assertRegisteredSubjects(t, reg, []string{
+			`drivers-key`,
+			`drivers-value`,
+			`db#.schema#.drivers-key`,
+			`db#.schema#.drivers-value`,
+			`superdrivers-key`,
+			`superdrivers-value`,
+			`superdb#.schema#.drivers-key`,
+			`superdb#.schema#.drivers-value`,
+		})
+	}
+
 	t.Run(`enterprise`, enterpriseTest(testFn))
 }
 

--- a/pkg/ccl/changefeedccl/encoder_test.go
+++ b/pkg/ccl/changefeedccl/encoder_test.go
@@ -451,7 +451,7 @@ func TestAvroSchemaNaming(t *testing.T) {
 		defer closeFeed(t, prefixFeed)
 
 		assertPayloadsAvro(t, reg, prefixFeed, []string{
-			`drivers: {"id":{"long":1}}->{"after":{"drivers":{"id":{"long":1},"name":{"string":"Alice"}}}}`,
+			`drivers: {"id":{"long":1}}->{"after":{"super.drivers":{"id":{"long":1},"name":{"string":"Alice"}}}}`,
 		})
 
 		assertRegisteredSubjects(t, reg, []string{
@@ -469,7 +469,7 @@ func TestAvroSchemaNaming(t *testing.T) {
 		defer closeFeed(t, prefixFQNFeed)
 
 		assertPayloadsAvro(t, reg, prefixFQNFeed, []string{
-			`movr.public.drivers: {"id":{"long":1}}->{"after":{"drivers":{"id":{"long":1},"name":{"string":"Alice"}}}}`,
+			`movr.public.drivers: {"id":{"long":1}}->{"after":{"super.drivers":{"id":{"long":1},"name":{"string":"Alice"}}}}`,
 		})
 
 		assertRegisteredSubjects(t, reg, []string{
@@ -486,6 +486,48 @@ func TestAvroSchemaNaming(t *testing.T) {
 		//Both changes to the subject are also reflected in the schema name in the posted schemas
 		require.Contains(t, reg.mu.schemas[reg.mu.subjects[`supermovr.public.drivers-key`]], `supermovr`)
 		require.Contains(t, reg.mu.schemas[reg.mu.subjects[`supermovr.public.drivers-value`]], `supermovr`)
+	}
+
+	t.Run(`enterprise`, enterpriseTest(testFn))
+}
+
+func TestAvroSchemaNamespace(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
+		reg := makeTestSchemaRegistry()
+		defer reg.Close()
+
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		sqlDB.Exec(t, `CREATE DATABASE movr`)
+		sqlDB.Exec(t, `CREATE TABLE movr.drivers (id INT PRIMARY KEY, name STRING)`)
+		sqlDB.Exec(t,
+			`INSERT INTO movr.drivers VALUES (1, 'Alice')`,
+		)
+
+		noNamespaceFeed := feed(t, f, `CREATE CHANGEFEED FOR movr.drivers `+
+			`WITH format=$1, confluent_schema_registry=$2`,
+			changefeedbase.OptFormatAvro, reg.server.URL)
+		defer closeFeed(t, noNamespaceFeed)
+
+		assertPayloadsAvro(t, reg, noNamespaceFeed, []string{
+			`drivers: {"id":{"long":1}}->{"after":{"drivers":{"id":{"long":1},"name":{"string":"Alice"}}}}`,
+		})
+
+		namespaceFeed := feed(t, f, `CREATE CHANGEFEED FOR movr.drivers `+
+			`WITH format=$1, confluent_schema_registry=$2, avro_schema_prefix=super`,
+			changefeedbase.OptFormatAvro, reg.server.URL)
+		defer closeFeed(t, namespaceFeed)
+
+		assertPayloadsAvro(t, reg, namespaceFeed, []string{
+			`drivers: {"id":{"long":1}}->{"after":{"super.drivers":{"id":{"long":1},"name":{"string":"Alice"}}}}`,
+		})
+
+		require.NotContains(t, reg.mu.schemas[reg.mu.subjects[`drivers-key`]], `namespace`)
+		require.NotContains(t, reg.mu.schemas[reg.mu.subjects[`drivers-value`]], `namespace`)
+		require.Contains(t, reg.mu.schemas[reg.mu.subjects[`superdrivers-key`]], `"namespace":"super"`)
+		require.Contains(t, reg.mu.schemas[reg.mu.subjects[`superdrivers-value`]], `"namespace":"super"`)
 	}
 
 	t.Run(`enterprise`, enterpriseTest(testFn))

--- a/pkg/ccl/changefeedccl/encoder_test.go
+++ b/pkg/ccl/changefeedccl/encoder_test.go
@@ -441,7 +441,6 @@ func TestTableNameCollision(t *testing.T) {
 		})
 	}
 
-	//t.Run(`sinkless`, sinklessTest(testFn))
 	t.Run(`enterprise`, enterpriseTest(testFn))
 }
 

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 	"net/url"
 	"reflect"
-	"regexp"
 	"sort"
 	"strings"
 	"testing"
@@ -156,12 +155,10 @@ func assertPayloadsAvro(
 func assertRegisteredSubjects(t testing.TB, reg *testSchemaRegistry, expected []string) {
 	t.Helper()
 
-	scrubIds := regexp.MustCompile(`\d+`)
-
 	actual := make([]string, 0, len(reg.mu.subjects))
 
 	for subject := range reg.mu.subjects {
-		actual = append(actual, scrubIds.ReplaceAllString(subject, "#"))
+		actual = append(actual, subject)
 	}
 
 	sort.Strings(expected)

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"net/url"
 	"reflect"
+	"regexp"
 	"sort"
 	"strings"
 	"testing"
@@ -144,6 +145,25 @@ func assertPayloadsAvro(
 
 	// The tests that use this aren't concerned with order, just that these are
 	// the next len(expected) messages.
+	sort.Strings(expected)
+	sort.Strings(actual)
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("expected\n  %s\ngot\n  %s",
+			strings.Join(expected, "\n  "), strings.Join(actual, "\n  "))
+	}
+}
+
+func assertRegisteredSubjects(t testing.TB, reg *testSchemaRegistry, expected []string) {
+	t.Helper()
+
+	scrubIds := regexp.MustCompile(`\d+`)
+
+	actual := make([]string, 0, len(reg.mu.subjects))
+
+	for subject := range reg.mu.subjects {
+		actual = append(actual, scrubIds.ReplaceAllString(subject, "#"))
+	}
+
 	sort.Strings(expected)
 	sort.Strings(actual)
 	if !reflect.DeepEqual(expected, actual) {

--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
@@ -307,6 +308,7 @@ type kafkaSinkConfig struct {
 	saslHandshake    bool
 	saslUser         string
 	saslPassword     string
+	targetNames      map[descpb.ID]string
 }
 
 // kafkaSink emits to Kafka asynchronously. It is not concurrency-safe; all
@@ -420,6 +422,13 @@ func getSaramaConfig(opts map[string]string) (config *saramaConfig, err error) {
 		config = defaultSaramaConfig
 	}
 	return
+func (s *kafkaSink) setTargets(targets jobspb.ChangefeedTargets) {
+	s.topics = make(map[string]struct{})
+	s.cfg.targetNames = make(map[descpb.ID]string)
+	for id, t := range targets {
+		s.cfg.targetNames[id] = t.StatementTimeName
+		s.topics[s.cfg.kafkaTopicPrefix+SQLNameToKafkaName(t.StatementTimeName)] = struct{}{}
+	}
 }
 
 func makeKafkaSink(
@@ -430,15 +439,14 @@ func makeKafkaSink(
 	opts map[string]string,
 	acc mon.BoundAccount,
 ) (Sink, error) {
+
 	sink := &kafkaSink{
 		ctx: ctx,
 		cfg: cfg,
 	}
-	sink.topics = make(map[string]struct{})
-	for _, t := range targets {
-		sink.topics[cfg.kafkaTopicPrefix+SQLNameToKafkaName(t.StatementTimeName)] = struct{}{}
-	}
+
 	sink.mu.mem = acc
+	sink.setTargets(targets)
 
 	config := sarama.NewConfig()
 	config.ClientID = `CockroachDB`
@@ -542,7 +550,7 @@ func (s *kafkaSink) Close() error {
 func (s *kafkaSink) EmitRow(
 	ctx context.Context, table catalog.TableDescriptor, key, value []byte, updated hlc.Timestamp,
 ) error {
-	topic := s.cfg.kafkaTopicPrefix + SQLNameToKafkaName(table.GetName())
+	topic := s.cfg.kafkaTopicPrefix + SQLNameToKafkaName(s.cfg.targetNames[table.GetID()])
 	if _, ok := s.topics[topic]; !ok {
 		return errors.Errorf(`cannot emit to undeclared topic: %s`, topic)
 	}
@@ -769,6 +777,8 @@ type sqlSink struct {
 
 	rowBuf  []interface{}
 	scratch bufalloc.ByteAllocator
+
+	targetNames map[descpb.ID]string
 }
 
 func makeSQLSink(uri, tableName string, targets jobspb.ChangefeedTargets) (*sqlSink, error) {
@@ -787,13 +797,15 @@ func makeSQLSink(uri, tableName string, targets jobspb.ChangefeedTargets) (*sqlS
 	}
 
 	s := &sqlSink{
-		db:        db,
-		tableName: tableName,
-		topics:    make(map[string]struct{}),
-		hasher:    fnv.New32a(),
+		db:          db,
+		tableName:   tableName,
+		topics:      make(map[string]struct{}),
+		hasher:      fnv.New32a(),
+		targetNames: make(map[descpb.ID]string),
 	}
-	for _, t := range targets {
+	for id, t := range targets {
 		s.topics[t.StatementTimeName] = struct{}{}
+		s.targetNames[id] = t.StatementTimeName
 	}
 	return s, nil
 }
@@ -802,7 +814,7 @@ func makeSQLSink(uri, tableName string, targets jobspb.ChangefeedTargets) (*sqlS
 func (s *sqlSink) EmitRow(
 	ctx context.Context, table catalog.TableDescriptor, key, value []byte, updated hlc.Timestamp,
 ) error {
-	topic := table.GetName()
+	topic := s.targetNames[table.GetID()]
 	if _, ok := s.topics[topic]; !ok {
 		return errors.Errorf(`cannot emit to undeclared topic: %s`, topic)
 	}

--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -422,6 +422,8 @@ func getSaramaConfig(opts map[string]string) (config *saramaConfig, err error) {
 		config = defaultSaramaConfig
 	}
 	return
+}
+
 func (s *kafkaSink) setTargets(targets jobspb.ChangefeedTargets) {
 	s.topics = make(map[string]struct{})
 	s.cfg.targetNames = make(map[descpb.ID]string)

--- a/pkg/ccl/changefeedccl/sink_test.go
+++ b/pkg/ccl/changefeedccl/sink_test.go
@@ -180,6 +180,10 @@ func TestKafkaSink(t *testing.T) {
 	sink, cleanup := makeTestKafkaSink(t, p, memoryUnlimited, "t")
 	defer cleanup()
 
+	targets := make(jobspb.ChangefeedTargets, 1)
+	targets[0] = jobspb.ChangefeedTarget{StatementTimeName: `t`}
+	sink.setTargets(targets)
+
 	// No inflight
 	if err := sink.Flush(ctx); err != nil {
 		t.Fatal(err)
@@ -259,6 +263,10 @@ func TestKafkaSinkEscaping(t *testing.T) {
 	sink, cleanup := makeTestKafkaSink(t, p, memoryUnlimited, `☃`)
 	defer cleanup()
 
+	targets := make(jobspb.ChangefeedTargets, 1)
+	targets[0] = jobspb.ChangefeedTarget{StatementTimeName: `☃`}
+	sink.setTargets(targets)
+
 	if err := sink.EmitRow(ctx, table(`☃`), []byte(`k☃`), []byte(`v☃`), zeroTS); err != nil {
 		t.Fatal(err)
 	}
@@ -283,7 +291,8 @@ func TestSQLSink(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	table := func(name string) *tabledesc.Immutable {
-		return tabledesc.NewImmutable(descpb.TableDescriptor{Name: name})
+		id, _ := strconv.ParseUint(name, 36, 64)
+		return tabledesc.NewImmutable(descpb.TableDescriptor{Name: name, ID: descpb.ID(id)})
 	}
 
 	ctx := context.Background()
@@ -297,8 +306,8 @@ func TestSQLSink(t *testing.T) {
 	sinkURL.Path = `d`
 
 	targets := jobspb.ChangefeedTargets{
-		0: jobspb.ChangefeedTarget{StatementTimeName: `foo`},
-		1: jobspb.ChangefeedTarget{StatementTimeName: `bar`},
+		table(`foo`).GetID(): jobspb.ChangefeedTarget{StatementTimeName: `foo`},
+		table(`bar`).GetID(): jobspb.ChangefeedTarget{StatementTimeName: `bar`},
 	}
 	sink, err := makeSQLSink(sinkURL.String(), `sink`, targets)
 	require.NoError(t, err)
@@ -309,7 +318,7 @@ func TestSQLSink(t *testing.T) {
 
 	// Undeclared topic
 	require.EqualError(t,
-		sink.EmitRow(ctx, table(`nope`), nil, nil, zeroTS), `cannot emit to undeclared topic: nope`)
+		sink.EmitRow(ctx, table(`nope`), nil, nil, zeroTS), `cannot emit to undeclared topic: `)
 
 	// With one row, nothing flushes until Flush is called.
 	require.NoError(t, sink.EmitRow(ctx, table(`foo`), []byte(`k1`), []byte(`v0`), zeroTS))

--- a/pkg/ccl/changefeedccl/sink_test.go
+++ b/pkg/ccl/changefeedccl/sink_test.go
@@ -441,6 +441,10 @@ func TestKafkaSinkTracksMemory(t *testing.T) {
 		cleanup()
 	}()
 
+	targets := make(jobspb.ChangefeedTargets, 1)
+	targets[0] = jobspb.ChangefeedTarget{StatementTimeName: `t`}
+	sink.setTargets(targets)
+
 	// No inflight
 	require.NoError(t, sink.Flush(ctx))
 
@@ -478,7 +482,7 @@ func TestKafkaSinkTracksMemory(t *testing.T) {
 		changefeedbase.OptEnvelope:                string(changefeedbase.OptEnvelopeWrapped),
 		changefeedbase.OptConfluentSchemaRegistry: reg.server.URL,
 	}
-	encoder, err := newConfluentAvroEncoder(opts)
+	encoder, err := newConfluentAvroEncoder(opts, jobspb.ChangefeedTargets{})
 	require.NoError(t, err)
 	payload, err := encoder.EncodeResolvedTimestamp(ctx, "t", hlc.Timestamp{})
 	require.NoError(t, err)


### PR DESCRIPTION
Backport of two new features as discussed here: https://github.com/cockroachdb/cockroach/issues/64851

Per some out-of-band discussion, we're tentatively okay with a slight behavior change for users not using the new flags: changing the table name of a targeted table will no longer cause the changefeed to fail.