### PR TITLE
release-21.1: tabledesc: promote index format more aggressively

### DIFF
--- a/pkg/sql/catalog/tabledesc/table_desc_builder.go
+++ b/pkg/sql/catalog/tabledesc/table_desc_builder.go
@@ -465,7 +465,14 @@ func maybeUpgradeToFamilyFormatVersion(desc *descpb.TableDescriptor) bool {
 // maybeUpgradeIndexFormatVersion tries to promote an index to version
 // descpb.StrictIndexColumnIDGuaranteesVersion whenever possible.
 func maybeUpgradeIndexFormatVersion(idx *descpb.IndexDescriptor) (hasChanged bool) {
-	if idx.Version != descpb.EmptyArraysInInvertedIndexesVersion {
+	switch idx.Version {
+	case descpb.SecondaryIndexFamilyFormatVersion:
+		if idx.Type == descpb.IndexDescriptor_INVERTED {
+			return false
+		}
+	case descpb.EmptyArraysInInvertedIndexesVersion:
+		break
+	default:
 		return false
 	}
 	slice := make([]descpb.ColumnID, 0, len(idx.ColumnIDs)+len(idx.ExtraColumnIDs)+len(idx.StoreColumnIDs))


### PR DESCRIPTION
Backport 1/1 commits from #65718.

/cc @cockroachdb/release

---

We recently introduced a change which promotes the `version` of a
descpb.IndexDescriptor from EmptyArraysInInvertedIndexesVersion to
StrictIndexColumnIDGuaranteesVersion.

This commit extends that promotion mechanism to
SecondaryIndexFamilyFormatVersion for non-inverted indexes.

Release note: None
