### PR TITLE
release-21.1: sql: fix statement diagnostics for EXECUTE

### DIFF
--- a/pkg/sql/stmtdiagnostics/statement_diagnostics_test.go
+++ b/pkg/sql/stmtdiagnostics/statement_diagnostics_test.go
@@ -86,6 +86,15 @@ func TestDiagnosticsRequest(t *testing.T) {
 	_, err = db.Exec("INSERT INTO test VALUES (2)")
 	require.NoError(t, err)
 	checkCompleted(id1)
+
+	// Verify that EXECUTE triggers diagnostics collection (#66048).
+	id4, err := registry.InsertRequestInternal(ctx, "SELECT x + $1 FROM test")
+	require.NoError(t, err)
+	_, err = db.Exec("PREPARE stmt AS SELECT x + $1 FROM test")
+	require.NoError(t, err)
+	_, err = db.Exec("EXECUTE stmt(1)")
+	require.NoError(t, err)
+	checkCompleted(id4)
 }
 
 // Test that a different node can service a diagnostics request.


### PR DESCRIPTION
Backport 1/1 commits from #66074.

/cc @cockroachdb/release

---

Previously, prepared statements ran through the EXECUTE statements
could not trigger collection of statement diagnostics. This is because
we consider the fingerprint of the EXECUTE statement instead of the
one from the prepared statement.

The fix is to move up the special handling code in the executor, and
replace the AST and fingerprint before setting up the instrumentation
helper.

Release note (bug fix): queries ran through the EXECUTE statement can
now generate statement diagnostic bundles as expected.

Fixes #66048.
