### PR TITLE
colcontainer: fix intra-query memory leak

### DIFF
--- a/pkg/sql/colcontainer/diskqueue.go
+++ b/pkg/sql/colcontainer/diskqueue.go
@@ -433,6 +433,13 @@ func (d *diskQueue) closeFileDeserializer() error {
 }
 
 func (d *diskQueue) Close(ctx context.Context) error {
+	defer func() {
+		// Zero out the structure completely upon return. If users of this diskQueue
+		// retain a pointer to it, and we don't remove all references to large
+		// backing slices (various scratch spaces in this struct and children),
+		// we'll be "leaking memory" until users remove their references.
+		*d = diskQueue{}
+	}()
 	if d.serializer != nil {
 		if err := d.writeFooterAndFlush(ctx); err != nil {
 			return err


### PR DESCRIPTION
Closes #66107.

Previously, when closing a diskQueue (the structure that's used to
implement disk spilling), we failed to properly allow all scratch memory
to be reclaimed by the garbage collector.

Release note (sql change): prevent intra-query leak during disk spilling
that could cause the database to run out of memory, especially during
disk spilling operations on tables with wide rows.