### PR TITLE
release-21.1: kvserver: add missing regexp to IsExpectedRelocateError

### DIFF
--- a/pkg/kv/test_utils.go
+++ b/pkg/kv/test_utils.go
@@ -53,6 +53,7 @@ func IsExpectedRelocateError(err error) bool {
 		"unable to add replica .* which is already present",
 		"received invalid ChangeReplicasTrigger .* to remove self",
 		"failed to apply snapshot: raft group deleted",
+		"failed to generate .* snapshot",
 		"snapshot failed",
 		"breaker open",
 		"unable to select removal target", // https://github.com/cockroachdb/cockroach/issues/49513


### PR DESCRIPTION
Fixes #66077.

Release note: None
