### PR TITLE
workflow: extends the time between when an issue is considered stale …

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,7 +20,7 @@ jobs:
            We have marked this issue as stale because it has been inactive for
            18 months. If this issue is still relevant, removing the stale label
            or adding a comment will keep it active. Otherwise, we'll close it in
-           5 days to keep the issue queue tidy. Thank you for your contribution
+           10 days to keep the issue queue tidy. Thank you for your contribution
            to CockroachDB!
         stale-pr-message: 'Stale pull request message'
         stale-issue-label: 'no-issue-activity'
@@ -30,5 +30,5 @@ jobs:
         # Disable this for PR's, by setting a very high bar
         days-before-pr-stale: 99999
         days-before-issue-stale: 540
-        days-before-close: 5
+        days-before-close: 10
         exempt-issue-labels: 'X-anchored-telemetry,X-nostale'


### PR DESCRIPTION
…and closed

Last week we rolled out the stale issue bot for this repo. The
bot was set to close a stale issue 5 days after marking it. if the
bot marks an issue on Friday and it's a long weekend to does not leave
a lot of time for someone to respond. To avoid these issues we extend the
time between these two events to 10 days.

Release note: None