### PR TITLE
ui: style fix of login password input

### DIFF
--- a/pkg/ui/src/components/input/input.styl
+++ b/pkg/ui/src/components/input/input.styl
@@ -61,3 +61,10 @@
     &--error-message
       color $colors--functional-red-3
       position absolute
+  &__password
+    font-family sans-serif
+    &[type="text"]
+      font-family $font-family--base
+    &::-webkit-credentials-auto-fill-button
+      position absolute
+      right 45px


### PR DESCRIPTION
before: on login screen on Safari is displaying Yen symbols
instead of dots
after: fixed issue above and in addition fixed position of key
button overlap with "view password" button

Resolves: #49386

Release note (ui): style fix of password input field for Safari