### PR TITLE
ui: style fix of login password input

### DIFF
--- a/pkg/ui/src/views/login/loginPage.styl
+++ b/pkg/ui/src/views/login/loginPage.styl
@@ -74,6 +74,9 @@
     margin 12px 0
     color $body-color
     display block
+    
+    &[type="password"]
+      font-family system-ui
 
     &::placeholder
       color lightgrey


### PR DESCRIPTION
before: on login screen on Safari is displaying Yen symbols
insteas of dots
after: fixed issue above

Resolves: #49386

Release note (ui): style fix of password input field for Safari