### PR TITLE
ccl/sqlproxyccl: use new denylist format in proxy handler

### DIFF
--- a/pkg/ccl/sqlproxyccl/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/BUILD.bazel
@@ -60,6 +60,7 @@ go_test(
     deps = [
         "//pkg/base",
         "//pkg/ccl/kvccl/kvtenantccl",
+        "//pkg/ccl/sqlproxyccl/denylist",
         "//pkg/ccl/sqlproxyccl/tenant",
         "//pkg/ccl/utilccl",
         "//pkg/roachpb",

--- a/pkg/ccl/sqlproxyccl/proxy_handler.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler.go
@@ -141,17 +141,14 @@ func newProxyHandler(
 		certManager:  certmgr.NewCertManager(ctx),
 	}
 
-	var err error
-	err = handler.setupIncomingCert()
+	err := handler.setupIncomingCert()
 	if err != nil {
 		return nil, err
 	}
 
 	ctx, _ = stopper.WithCancelOnQuiesce(ctx)
-	handler.denyListService, err = denylist.NewViperDenyListFromFile(ctx, options.Denylist, options.PollConfigInterval)
-	if err != nil {
-		return nil, err
-	}
+	handler.denyListService = denylist.NewDenylistWithFile(ctx, options.Denylist,
+		denylist.WithPollingInterval(options.PollConfigInterval))
 
 	handler.throttleService = throttler.NewLocalService(throttler.WithBaseDelay(options.RatelimitBaseDelay))
 	handler.connCache = cache.NewCappedConnCache(maxKnownConnCacheSize)


### PR DESCRIPTION
The new format was added in
https://github.com/cockroachdb/cockroach/pull/64957,
which supports expiration of denylist entries based on
timestamps.

Release note: None