### PR TITLE
release-21.1: fix intra-query memory leaks

### DIFF
--- a/pkg/sql/colcontainer/diskqueue.go
+++ b/pkg/sql/colcontainer/diskqueue.go
@@ -410,6 +410,13 @@ func (d *diskQueue) closeFileDeserializer() error {
 }
 
 func (d *diskQueue) Close(ctx context.Context) error {
+	defer func() {
+		// Zero out the structure completely upon return. If users of this diskQueue
+		// retain a pointer to it, and we don't remove all references to large
+		// backing slices (various scratch spaces in this struct and children),
+		// we'll be "leaking memory" until users remove their references.
+		*d = diskQueue{}
+	}()
 	if d.serializer != nil {
 		if err := d.writeFooterAndFlush(ctx); err != nil {
 			return err

--- a/pkg/sql/row/kv_batch_fetcher.go
+++ b/pkg/sql/row/kv_batch_fetcher.go
@@ -441,35 +441,42 @@ func (f *txnKVFetcher) fetch(ctx context.Context) error {
 	return nil
 }
 
+// popBatch returns the 0th byte slice in a slice of byte slices, as well as
+// the rest of the slice of the byte slices. It nils the pointer to the 0th
+// element before reslicing the outer slice.
+func popBatch(batches [][]byte) (batch []byte, remainingBatches [][]byte) {
+	batch, remainingBatches = batches[0], batches[1:]
+	batches[0] = nil
+	return batch, remainingBatches
+}
+
 // nextBatch returns the next batch of key/value pairs. If there are none
 // available, a fetch is initiated. When there are no more keys, ok is false.
 // origSpan returns the span that batch was fetched from, and bounds all of the
 // keys returned.
 func (f *txnKVFetcher) nextBatch(
 	ctx context.Context,
-) (ok bool, kvs []roachpb.KeyValue, batchResponse []byte, origSpan roachpb.Span, err error) {
+) (ok bool, kvs []roachpb.KeyValue, batchResp []byte, origSpan roachpb.Span, err error) {
 	if len(f.remainingBatches) > 0 {
-		batch := f.remainingBatches[0]
-		f.remainingBatches = f.remainingBatches[1:]
-		return true, nil, batch, f.origSpan, nil
+		batchResp, f.remainingBatches = popBatch(f.remainingBatches)
+		return true, nil, batchResp, f.origSpan, nil
 	}
 	if len(f.responses) > 0 {
 		reply := f.responses[0].GetInner()
+		f.responses[0] = roachpb.ResponseUnion{}
 		f.responses = f.responses[1:]
 		origSpan := f.requestSpans[0]
+		f.requestSpans[0] = roachpb.Span{}
 		f.requestSpans = f.requestSpans[1:]
-		var batchResp []byte
 		switch t := reply.(type) {
 		case *roachpb.ScanResponse:
 			if len(t.BatchResponses) > 0 {
-				batchResp = t.BatchResponses[0]
-				f.remainingBatches = t.BatchResponses[1:]
+				batchResp, f.remainingBatches = popBatch(t.BatchResponses)
 			}
 			return true, t.Rows, batchResp, origSpan, nil
 		case *roachpb.ReverseScanResponse:
 			if len(t.BatchResponses) > 0 {
-				batchResp = t.BatchResponses[0]
-				f.remainingBatches = t.BatchResponses[1:]
+				batchResp, f.remainingBatches = popBatch(t.BatchResponses)
 			}
 			return true, t.Rows, batchResp, origSpan, nil
 		}
@@ -485,5 +492,7 @@ func (f *txnKVFetcher) nextBatch(
 
 // close releases the resources of this txnKVFetcher.
 func (f *txnKVFetcher) close(ctx context.Context) {
+	f.responses = nil
+	f.remainingBatches = nil
 	f.acc.Close(ctx)
 }

--- a/pkg/sql/row/kv_fetcher.go
+++ b/pkg/sql/row/kv_fetcher.go
@@ -117,6 +117,11 @@ func (f *KVFetcher) NextKV(
 			if err != nil {
 				return false, kv, false, err
 			}
+			// If we're finished decoding the batch response, nil our reference to it
+			// so that the garbage collector can reclaim the backing memory.
+			if len(f.batchResponse) == 0 {
+				f.batchResponse = nil
+			}
 			return true, roachpb.KeyValue{
 				Key: key,
 				Value: roachpb.Value{


### PR DESCRIPTION
Backport:
  * 2/2 commits from "row: fix intra-query memory leaks in kvFetcher and txnKVFetcher" (#65881)
  * 1/1 commits from "colcontainer: fix intra-query memory leak" (#66106)

Please see individual PRs for details.

/cc @cockroachdb/release
