### PR TITLE
kv: introduce setting for maximum lock wait-queue depth

### DIFF
--- a/pkg/kv/kvserver/concurrency/concurrency_control.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_control.go
@@ -371,6 +371,14 @@ type Request struct {
 	// transactions.
 	WaitPolicy lock.WaitPolicy
 
+	// The maximum length of a lock wait-queue that the request is willing
+	// to enter and wait in. Used to provide a release valve and ensure some
+	// level of quality-of-service under severe per-key contention. If set
+	// to a non-zero value and an existing lock wait-queue is already equal
+	// to or exceeding this length, the request will be rejected eagerly
+	// with a WriteIntentError instead of entering the queue and waiting.
+	MaxLockWaitQueueLength int
+
 	// The individual requests in the batch.
 	Requests []roachpb.RequestUnion
 

--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -31,6 +31,55 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+// MaxLockWaitQueueLength sets the maximum length of a lock wait-queue that a
+// read-write request is willing to enter and wait in. Used to provide a release
+// valve and ensure some level of quality-of-service under severe per-key
+// contention. If set to a non-zero value and an existing lock wait-queue is
+// already equal to or exceeding this length, the request will be rejected
+// eagerly instead of entering the queue and waiting.
+//
+// This is a fairly blunt mechanism to place an upper bound on resource
+// utilization per lock wait-queue and ensure some reasonable level of
+// quality-of-service for transactions that enter a lock wait-queue. More
+// sophisticated queueing alternatives exist that account for queueing time and
+// detect sustained queue growth before rejecting:
+// - https://queue.acm.org/detail.cfm?id=2209336
+// - https://queue.acm.org/detail.cfm?id=2839461
+//
+// We could explore these algorithms if this setting is too coarse grained and
+// not serving its purpose well enough.
+//
+// Alternatively, we could implement the lock_timeout session variable that
+// exists in Postgres (#67513) and use that to ensure quality-of-service for
+// requests that wait for locks. With that configuration, this cluster setting
+// would be relegated to a guardrail that protects against unbounded resource
+// utilization and runaway queuing for misbehaving clients, a role it is well
+// positioned to serve.
+var MaxLockWaitQueueLength = settings.RegisterIntSetting(
+	"kv.lock_table.maximum_lock_wait_queue_length",
+	"the maximum length of a lock wait-queue that read-write requests are willing "+
+		"to enter and wait in. The setting can be used to ensure some level of quality-of-service "+
+		"under severe per-key contention. If set to a non-zero value and an existing lock "+
+		"wait-queue is already equal to or exceeding this length, requests will be rejected "+
+		"eagerly instead of entering the queue and waiting. Set to 0 to disable.",
+	0,
+	func(v int64) error {
+		if v < 0 {
+			return errors.Errorf("cannot be set to a negative value: %d", v)
+		}
+		if v == 0 {
+			return nil // disabled
+		}
+		// Don't let the setting be dropped below a reasonable value that we don't
+		// expect to impact internal transaction processing.
+		const minSafeMaxLength = 3
+		if v < minSafeMaxLength {
+			return errors.Errorf("cannot be set below %d: %d", minSafeMaxLength, v)
+		}
+		return nil
+	},
+)
+
 // DiscoveredLocksThresholdToConsultFinalizedTxnCache sets a threshold as
 // mentioned in the description string. The default of 200 is somewhat
 // arbitrary but should suffice for small OLTP transactions. Given the default
@@ -225,6 +274,12 @@ func (m *managerImpl) sequenceReqWithGuard(ctx context.Context, g *Guard) (Respo
 		// Some requests don't want the wait on locks.
 		if g.Req.LockSpans.Empty() {
 			return nil, nil
+		}
+
+		// Set the request's MaxWaitQueueLength based on the cluster setting, if not
+		// already set.
+		if g.Req.MaxLockWaitQueueLength == 0 {
+			g.Req.MaxLockWaitQueueLength = int(MaxLockWaitQueueLength.Get(&m.st.SV))
 		}
 
 		if g.EvalKind == OptimisticEval {

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter.go
@@ -170,7 +170,7 @@ func (w *lockTableWaiterImpl) WaitOn(
 					if state.held {
 						err = w.pushLockTxn(ctx, req, state)
 					} else {
-						err = newWriteIntentErr(state)
+						err = newWriteIntentErr(req, state)
 					}
 					if err != nil {
 						return err
@@ -279,6 +279,12 @@ func (w *lockTableWaiterImpl) WaitOn(
 				// holder of this lock wait-queue. This can only happen when the
 				// request's transaction is sending multiple requests concurrently.
 				// Proceed with waiting without pushing anyone.
+
+			case waitQueueMaxLengthExceeded:
+				// The request attempted to wait in a lock wait-queue whose length was
+				// already equal to or exceeding the request's configured maximum. As a
+				// result, the request was rejected.
+				return newWriteIntentErr(req, state)
 
 			case doneWaiting:
 				// The request has waited for all conflicting locks to be released
@@ -390,7 +396,7 @@ func (w *lockTableWaiterImpl) pushLockTxn(
 	ctx context.Context, req Request, ws waitingState,
 ) *Error {
 	if w.disableTxnPushing {
-		return newWriteIntentErr(ws)
+		return newWriteIntentErr(req, ws)
 	}
 
 	// Construct the request header and determine which form of push to use.
@@ -432,7 +438,7 @@ func (w *lockTableWaiterImpl) pushLockTxn(
 		// If pushing with an Error WaitPolicy and the push fails, then the lock
 		// holder is still active. Transform the error into a WriteIntentError.
 		if _, ok := err.GetDetail().(*roachpb.TransactionPushError); ok && req.WaitPolicy == lock.WaitPolicy_Error {
-			err = newWriteIntentErr(ws)
+			err = newWriteIntentErr(req, ws)
 		}
 		return err
 	}
@@ -770,7 +776,7 @@ func (h *contentionEventHelper) emitAndInit(s waitingState) {
 			}
 			h.tBegin = timeutil.Now()
 		}
-	case waitElsewhere, doneWaiting:
+	case waitElsewhere, waitQueueMaxLengthExceeded, doneWaiting:
 		// If we have an event, emit it now and that's it - the case we're in
 		// does not give us a new transaction/key.
 		if h.ev != nil {
@@ -781,10 +787,22 @@ func (h *contentionEventHelper) emitAndInit(s waitingState) {
 	}
 }
 
-func newWriteIntentErr(ws waitingState) *Error {
-	return roachpb.NewError(&roachpb.WriteIntentError{
+func newWriteIntentErr(req Request, ws waitingState) *Error {
+	err := roachpb.NewError(&roachpb.WriteIntentError{
 		Intents: []roachpb.Intent{roachpb.MakeIntent(ws.txn, ws.key)},
 	})
+	// TODO(nvanbenschoten): setting an error index can assist the KV client in
+	// understanding which request hit an error. This is not necessary, but can
+	// improve error handling, leading to better error messages and performance
+	// optimizations in some cases. We don't have an easy way to associate a given
+	// conflict with a specific request in a batch because we don't retain a
+	// mapping from lock span to request. However, as a best-effort optimization,
+	// we set the error index to 0 if this is the only request in the batch (that
+	// landed on this range, from the client's perspective).
+	if len(req.Requests) == 1 {
+		err.SetErrorIndex(0)
+	}
+	return err
 }
 
 func hasMinPriority(txn *enginepb.TxnMeta) bool {

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/queue_length_exceeded
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/queue_length_exceeded
@@ -1,0 +1,223 @@
+new-txn name=txn1 ts=10,1 epoch=0
+----
+
+new-txn name=txn2 ts=11,1 epoch=0
+----
+
+new-txn name=txn3 ts=12,1 epoch=0
+----
+
+new-txn name=txn4 ts=13,1 epoch=0
+----
+
+# NOTE: txn5.ts < txn2.ts so that txn5's reads don't conflict with
+# txn2's writes. This helps make the test deterministic when txn1
+# releases its lock.
+new-txn name=txn5 ts=10,1 epoch=0
+----
+
+# -------------------------------------------------------------
+# Prep: Txn 1 acquire locks at key k
+#       Txns 2, 3, and 4 begin waiting in k's wait-queue
+# -------------------------------------------------------------
+
+new-request name=req1 txn=txn1 ts=10,0
+  put key=k value=v
+----
+
+sequence req=req1
+----
+[1] sequence req1: sequencing request
+[1] sequence req1: acquiring latches
+[1] sequence req1: scanning lock table for conflicting locks
+[1] sequence req1: sequencing complete, returned guard
+
+on-lock-acquired req=req1 key=k
+----
+[-] acquire lock: txn 00000001 @ k
+
+finish req=req1
+----
+[-] finish req1: finishing request
+
+new-request name=req2 txn=txn2 ts=11,0
+  put key=k value=v2
+----
+
+sequence req=req2
+----
+[2] sequence req2: sequencing request
+[2] sequence req2: acquiring latches
+[2] sequence req2: scanning lock table for conflicting locks
+[2] sequence req2: waiting in lock wait-queues
+[2] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 1, queuedReaders: 0)
+[2] sequence req2: pushing txn 00000001 to abort
+[2] sequence req2: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+new-request name=req3 txn=txn3 ts=12,0
+  put key=k value=v3
+----
+
+sequence req=req3
+----
+[3] sequence req3: sequencing request
+[3] sequence req3: acquiring latches
+[3] sequence req3: scanning lock table for conflicting locks
+[3] sequence req3: waiting in lock wait-queues
+[3] sequence req3: lock wait-queue event: wait for txn 00000001 holding lock @ key "k" (queuedWriters: 2, queuedReaders: 0)
+[3] sequence req3: pushing txn 00000001 to abort
+[3] sequence req3: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+new-request name=req4 txn=txn4 ts=13,0
+  put key=k value=v4
+----
+
+sequence req=req4
+----
+[4] sequence req4: sequencing request
+[4] sequence req4: acquiring latches
+[4] sequence req4: scanning lock table for conflicting locks
+[4] sequence req4: waiting in lock wait-queues
+[4] sequence req4: lock wait-queue event: wait for txn 00000001 holding lock @ key "k" (queuedWriters: 3, queuedReaders: 0)
+[4] sequence req4: pushing txn 00000001 to abort
+[4] sequence req4: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+debug-lock-table
+----
+global: num=1
+ lock: "k"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+   queued writers:
+    active: true req: 2, txn: 00000002-0000-0000-0000-000000000000
+    active: true req: 3, txn: 00000003-0000-0000-0000-000000000000
+    active: true req: 4, txn: 00000004-0000-0000-0000-000000000000
+   distinguished req: 2
+local: num=0
+
+# -------------------------------------------------------------
+# Read-only request runs into long lock wait-queue. Waits for
+# lock to be released, but not in queue. Proceeds as soon as
+# lock is released.
+# -------------------------------------------------------------
+
+new-request name=req5r txn=txn5 ts=10,0 max-lock-wait-queue-length=2
+  get key=k
+----
+
+sequence req=req5r
+----
+[5] sequence req5r: sequencing request
+[5] sequence req5r: acquiring latches
+[5] sequence req5r: scanning lock table for conflicting locks
+[5] sequence req5r: waiting in lock wait-queues
+[5] sequence req5r: lock wait-queue event: wait for txn 00000001 holding lock @ key "k" (queuedWriters: 3, queuedReaders: 1)
+[5] sequence req5r: pushing timestamp of txn 00000001 above 10.000000000,1
+[5] sequence req5r: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+on-txn-updated txn=txn1 status=committed
+----
+[-] update txn: committing txn1
+[2] sequence req2: resolving intent "k" for txn 00000001 with COMMITTED status
+[2] sequence req2: lock wait-queue event: done waiting
+[2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
+[2] sequence req2: acquiring latches
+[2] sequence req2: scanning lock table for conflicting locks
+[2] sequence req2: sequencing complete, returned guard
+[3] sequence req3: resolving intent "k" for txn 00000001 with COMMITTED status
+[3] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000002 running request @ key "k" (queuedWriters: 2, queuedReaders: 0)
+[3] sequence req3: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
+[3] sequence req3: pushing txn 00000002 to detect request deadlock
+[3] sequence req3: blocked on select in concurrency_test.(*cluster).PushTransaction
+[4] sequence req4: resolving intent "k" for txn 00000001 with COMMITTED status
+[4] sequence req4: lock wait-queue event: wait for txn 00000002 running request @ key "k" (queuedWriters: 2, queuedReaders: 0)
+[4] sequence req4: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
+[4] sequence req4: pushing txn 00000002 to detect request deadlock
+[4] sequence req4: blocked on select in concurrency_test.(*cluster).PushTransaction
+[5] sequence req5r: resolving intent "k" for txn 00000001 with COMMITTED status
+[5] sequence req5r: lock wait-queue event: done waiting
+[5] sequence req5r: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
+[5] sequence req5r: acquiring latches
+[5] sequence req5r: scanning lock table for conflicting locks
+[5] sequence req5r: sequencing complete, returned guard
+
+finish req=req5r
+----
+[-] finish req5r: finishing request
+
+on-lock-acquired req=req2 key=k
+----
+[-] acquire lock: txn 00000002 @ k
+[3] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "k" (queuedWriters: 2, queuedReaders: 0)
+[3] sequence req3: pushing txn 00000002 to abort
+[3] sequence req3: blocked on select in concurrency_test.(*cluster).PushTransaction
+[4] sequence req4: lock wait-queue event: wait for txn 00000002 holding lock @ key "k" (queuedWriters: 2, queuedReaders: 0)
+[4] sequence req4: pushing txn 00000002 to abort
+[4] sequence req4: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+finish req=req2
+----
+[-] finish req2: finishing request
+
+debug-lock-table
+----
+global: num=1
+ lock: "k"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 11.000000000,0, info: unrepl epoch: 0, seqs: [0]
+   queued writers:
+    active: true req: 3, txn: 00000003-0000-0000-0000-000000000000
+    active: true req: 4, txn: 00000004-0000-0000-0000-000000000000
+   distinguished req: 3
+local: num=0
+
+# -------------------------------------------------------------
+# Read-write request runs into long lock wait-queue. Instead of
+# waiting in the queue, the request raises an error.
+# -------------------------------------------------------------
+
+new-request name=req5w txn=txn5 ts=10,0 max-lock-wait-queue-length=2
+  put key=k value=v5
+----
+
+sequence req=req5w
+----
+[6] sequence req5w: sequencing request
+[6] sequence req5w: acquiring latches
+[6] sequence req5w: scanning lock table for conflicting locks
+[6] sequence req5w: waiting in lock wait-queues
+[6] sequence req5w: lock wait-queue event: wait-queue maximum length exceeded @ key "k" with length 2
+[6] sequence req5w: sequencing complete, returned error: conflicting intents on "k"
+
+# -------------------------------------------------------------
+# Cleanup.
+# -------------------------------------------------------------
+
+on-txn-updated txn=txn2 status=aborted
+----
+[-] update txn: aborting txn2
+[3] sequence req3: resolving intent "k" for txn 00000002 with ABORTED status
+[3] sequence req3: lock wait-queue event: done waiting
+[3] sequence req3: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 1.234s
+[3] sequence req3: acquiring latches
+[3] sequence req3: scanning lock table for conflicting locks
+[3] sequence req3: sequencing complete, returned guard
+[4] sequence req4: resolving intent "k" for txn 00000002 with ABORTED status
+[4] sequence req4: lock wait-queue event: wait for (distinguished) txn 00000003 running request @ key "k" (queuedWriters: 1, queuedReaders: 0)
+[4] sequence req4: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 1.234s
+[4] sequence req4: pushing txn 00000003 to detect request deadlock
+[4] sequence req4: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+finish req=req3
+----
+[-] finish req3: finishing request
+[4] sequence req4: lock wait-queue event: done waiting
+[4] sequence req4: conflicted with 00000003-0000-0000-0000-000000000000 on "k" for 1.234s
+[4] sequence req4: acquiring latches
+[4] sequence req4: scanning lock table for conflicting locks
+[4] sequence req4: sequencing complete, returned guard
+
+finish req=req4
+----
+[-] finish req4: finishing request
+
+reset
+----

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/queue_length_exceeded
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/queue_length_exceeded
@@ -1,0 +1,186 @@
+new-lock-table maxlocks=10000
+----
+
+new-txn txn=txn1 ts=10 epoch=0
+----
+
+new-txn txn=txn2 ts=10 epoch=0
+----
+
+new-txn txn=txn3 ts=10 epoch=0
+----
+
+new-request r=req1 txn=txn1 ts=10 spans=w@a
+----
+
+new-request r=req2 txn=txn2 ts=10 spans=w@a
+----
+
+new-request r=req3 txn=txn3 ts=10 spans=w@a
+----
+
+scan r=req1
+----
+start-waiting: false
+
+acquire r=req1 k=a durability=u
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+local: num=0
+
+scan r=req2
+----
+start-waiting: true
+
+scan r=req3
+----
+start-waiting: true
+
+print
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+   queued writers:
+    active: true req: 2, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
+   distinguished req: 2
+local: num=0
+
+# ---------------------------------------------------------------------------------
+# Read requests do not observe a queue length limit, because they don't wait in the
+# queuedWriters list.
+# ---------------------------------------------------------------------------------
+
+new-txn txn=txn4 ts=10 epoch=0
+----
+
+new-request r=req4 txn=txn4 ts=10 spans=r@a max-lock-wait-queue-length=2
+----
+
+scan r=req4
+----
+start-waiting: true
+
+guard-state r=req4
+----
+new: state=waitFor txn=txn1 key="a" held=true guard-access=read
+
+dequeue r=req4
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+   queued writers:
+    active: true req: 2, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
+   distinguished req: 2
+local: num=0
+
+# ---------------------------------------------------------------------------------
+# Write requests with a large enough MaxLockWaitQueueLength do not throw an error.
+# ---------------------------------------------------------------------------------
+
+new-txn txn=txn5 ts=10 epoch=0
+----
+
+new-request r=req5 txn=txn5 ts=10 spans=w@a max-lock-wait-queue-length=3
+----
+
+scan r=req5
+----
+start-waiting: true
+
+guard-state r=req5
+----
+new: state=waitFor txn=txn1 key="a" held=true guard-access=write
+
+dequeue r=req5
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+   queued writers:
+    active: true req: 2, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
+   distinguished req: 2
+local: num=0
+
+# ---------------------------------------------------------------------------------
+# Write requests with a sufficiently low MaxLockWaitQueueLength throw an error.
+# ---------------------------------------------------------------------------------
+
+new-txn txn=txn6 ts=10 epoch=0
+----
+
+new-request r=req6 txn=txn6 ts=10 spans=w@a max-lock-wait-queue-length=2
+----
+
+scan r=req6
+----
+start-waiting: true
+
+guard-state r=req6
+----
+new: state=waitQueueMaxLengthExceeded txn=txn1 key="a" held=true guard-access=write
+
+dequeue r=req6
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+   queued writers:
+    active: true req: 2, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
+   distinguished req: 2
+local: num=0
+
+# ---------------------------------------------------------------------------------
+# Same as previous two cases, but for non-transactional writes.
+# ---------------------------------------------------------------------------------
+
+new-request r=req7 txn=none ts=10 spans=w@a max-lock-wait-queue-length=3
+----
+
+scan r=req7
+----
+start-waiting: true
+
+guard-state r=req7
+----
+new: state=waitFor txn=txn1 key="a" held=true guard-access=write
+
+dequeue r=req7
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+   queued writers:
+    active: true req: 2, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
+   distinguished req: 2
+local: num=0
+
+new-request r=req8 txn=none ts=10 spans=w@a max-lock-wait-queue-length=2
+----
+
+scan r=req8
+----
+start-waiting: true
+
+guard-state r=req8
+----
+new: state=waitQueueMaxLengthExceeded txn=txn1 key="a" held=true guard-access=write
+
+dequeue r=req8
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+   queued writers:
+    active: true req: 2, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 3, txn: 00000000-0000-0000-0000-000000000003
+   distinguished req: 2
+local: num=0


### PR DESCRIPTION
Fixes #66017.
Related to #67513.

This PR introduces a new `kv.lock_table.maximum_lock_wait_queue_length` cluster setting, which controls the maximum length of a lock wait-queue that requests are willing to enter and wait in. The setting can be used to ensure some level of quality-of-service under severe per-key contention. If set to a non-zero value and an existing lock wait-queue is already equal to or exceeding this length, requests will be rejected eagerly instead of entering the queue and waiting.

Before this change, the lock-table's wait-queues had no limit on the number of writers that could be queued on a given key. This could lead to unbounded queueing and diminishing quality of service for all writers as the queues built up. It could also leave to starvation (i.e. zero throughput) when requests had a timeout that fires before any single request can get to the head of the queue. This was all especially bad with high replication latency in multi-region clusters, as locks are held for the duration of a consensus replication round. 

We can see this in the following experiment. Here, we run a multi-region (demo) cluster in three configurations: `default`, `timeout`, and `queue_limit`. Under the `default` configuration, we change nothing. Under the `timeout` configuration, we set `sql.defaults.statement_timeout='250ms'`. Under the `queue_limit` configuration, we set `kv.lock_table.maximum_lock_wait_queue_length=3`. We then run a single-row, update-only workload (workload "U", mocked out in this patch):
```
./cockroach demo --global --empty --nodes=9
./cockroach sql -e 'create database ycsb primary region "us-east1" regions "us-west1", "europe-west1" survive region failure'
./cockroach workload init ycsb --families=false --insert-count=1
./cockroach workload run  ycsb --families=false --insert-count=1 --workload=U --duration=30s --tolerate-errors --concurrency=?
```

This results in the following behavior:

| setting     | concurrency | qps  | errors | p50 (ms) | p95 (ms) |
|-------------|-------------|------|--------|----------|----------|
| default     | 1           | 13.7 | 0      | 67.1     | 71.3     |
| default     | 2           | 12.6 | 0      | 142.6    | 151.0    |
| default     | 4           | 12.3 | 0      | 302.0    | 385.9    |
| default     | 8           | 12.2 | 0      | 570.4    | 1610.6   |
| default     | 16          | 12.0 | 0      | 1208.0   | 2550.1   |
| default     | 32          | 8.0  | 0      | 4563.4   | 5637.1   |
| timeout     | 1           | 14.7 | 0      | 67.1     | 67.1     |
| timeout     | 2           | 12.8 | 17     | 142.6    | 142.6    |
| timeout     | 4           | 0.2  | 464    | 71.3     | 352.3    |
| timeout     | 8           | 0.2  | 913    | 67.1     | 335.5    |
| timeout     | 16          | 0    | -      | -        | -        |
| timeout     | 32          | 0    | -      | -        | -        |
| queue_limit | 1           | 14.5 | 0      | 67.1     | 71.3     |
| queue_limit | 2           | 14.2 | 0      | 134.2    | 176.2    |
| queue_limit | 4           | 13.3 | 0      | 285.2    | 369.1    |
| queue_limit | 8           | 13.0 | 1934   | 352.3    | 486.5    |
| queue_limit | 16          | 12.8 | 4290   | 352.3    | 486.5    |
| queue_limit | 32          | 11.6 | 9203   | 385.9    | 671.1    |

The first thing to note is that under the `default` config, throughput remains relatively steady as concurrency grows, but latency grows linearly with concurrency. Next, note that under the `timeout` config, throughput falls to 0 the moment the p50 latency exceeds the `statement_timeout`. Finally, note that under the `queue_limit` config, errors begin to build once the queue limit is exceeded. However, throughput and latency hold steady as concurrency grows, as desired. So some requests are rejected, but the ones that are not are provided a good quality-of-service.

/cc @cockroachdb/kv @sumeerbhola 