### PR TITLE
sql: fix non-round-trippable SHOW CHANGEFEED JOB formatting

### DIFF
--- a/docs/generated/sql/bnf/show_jobs.bnf
+++ b/docs/generated/sql/bnf/show_jobs.bnf
@@ -5,6 +5,7 @@ show_jobs_stmt ::=
 	| 'SHOW' 'JOBS' select_stmt
 	| 'SHOW' 'JOBS' 'WHEN' 'COMPLETE' select_stmt
 	| 'SHOW' 'JOBS' for_schedules_clause
+	| 'SHOW' 'CHANGEFEED' 'JOBS' select_stmt
 	| 'SHOW' 'JOB' job_id
 	| 'SHOW' 'CHANGEFEED' 'JOB' job_id
 	| 'SHOW' 'JOB' 'WHEN' 'COMPLETE' job_id

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -657,6 +657,7 @@ show_jobs_stmt ::=
 	| 'SHOW' 'JOBS' select_stmt
 	| 'SHOW' 'JOBS' 'WHEN' 'COMPLETE' select_stmt
 	| 'SHOW' 'JOBS' for_schedules_clause
+	| 'SHOW' 'CHANGEFEED' 'JOBS' select_stmt
 	| 'SHOW' 'JOB' a_expr
 	| 'SHOW' 'CHANGEFEED' 'JOB' a_expr
 	| 'SHOW' 'JOB' 'WHEN' 'COMPLETE' a_expr

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -5091,6 +5091,10 @@ show_jobs_stmt:
   {
     $$.val = &tree.ShowJobs{Schedules: $3.slct()}
   }
+| SHOW CHANGEFEED JOBS select_stmt
+  {
+    $$.val = &tree.ShowChangefeedJobs{Jobs: $4.slct()}
+  }
 | SHOW JOBS select_stmt error // SHOW HELP: SHOW JOBS
 | SHOW JOB a_expr
   {

--- a/pkg/sql/parser/testdata/show
+++ b/pkg/sql/parser/testdata/show
@@ -466,6 +466,22 @@ EXPLAIN SHOW USERS -- literals removed
 EXPLAIN SHOW USERS -- identifiers removed
 
 parse
+SHOW JOB 1234
+----
+SHOW JOBS VALUES (1234) -- normalized!
+SHOW JOBS VALUES ((1234)) -- fully parenthesized
+SHOW JOBS VALUES (_) -- literals removed
+SHOW JOBS VALUES (1234) -- identifiers removed
+
+parse
+EXPLAIN SHOW JOB 1234
+----
+EXPLAIN SHOW JOBS VALUES (1234) -- normalized!
+EXPLAIN SHOW JOBS VALUES ((1234)) -- fully parenthesized
+EXPLAIN SHOW JOBS VALUES (_) -- literals removed
+EXPLAIN SHOW JOBS VALUES (1234) -- identifiers removed
+
+parse
 SHOW JOBS
 ----
 SHOW JOBS
@@ -496,6 +512,22 @@ EXPLAIN SHOW AUTOMATIC JOBS
 EXPLAIN SHOW AUTOMATIC JOBS -- fully parenthesized
 EXPLAIN SHOW AUTOMATIC JOBS -- literals removed
 EXPLAIN SHOW AUTOMATIC JOBS -- identifiers removed
+
+parse
+SHOW CHANGEFEED JOB 1234
+----
+SHOW CHANGEFEED JOBS VALUES (1234) -- normalized!
+SHOW CHANGEFEED JOBS VALUES ((1234)) -- fully parenthesized
+SHOW CHANGEFEED JOBS VALUES (_) -- literals removed
+SHOW CHANGEFEED JOBS VALUES (1234) -- identifiers removed
+
+parse
+EXPLAIN SHOW CHANGEFEED JOB 1234
+----
+EXPLAIN SHOW CHANGEFEED JOBS VALUES (1234) -- normalized!
+EXPLAIN SHOW CHANGEFEED JOBS VALUES ((1234)) -- fully parenthesized
+EXPLAIN SHOW CHANGEFEED JOBS VALUES (_) -- literals removed
+EXPLAIN SHOW CHANGEFEED JOBS VALUES (1234) -- identifiers removed
 
 parse
 SHOW CHANGEFEED JOBS

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -294,12 +294,10 @@ type ShowChangefeedJobs struct {
 
 // Format implements the NodeFormatter interface.
 func (node *ShowChangefeedJobs) Format(ctx *FmtCtx) {
-	ctx.WriteString("SHOW CHANGEFEED")
+	ctx.WriteString("SHOW CHANGEFEED JOBS")
 	if node.Jobs != nil {
-		ctx.WriteString(" JOB")
+		ctx.WriteString(" ")
 		ctx.FormatNode(node.Jobs)
-	} else {
-		ctx.WriteString(" JOBS")
 	}
 }
 


### PR DESCRIPTION
Previously, we would incorrectly format `SHOW CHANGEFEED JOB` AST
nodes. For example,

    SHOW CHANGEFEED JOB 665152927024873473;

would get pretty-printed as:

    SHOW CHANGEFEED JOBVALUES (665152927024873473)

There are a couple of problems here. The lack of a space between `JOB`
and `VALUES` and the fact that `SHOW CHANGEFEED JOB` doesn't take a
select statement as an argument, so even if the space were there, the
generated SQL would not parse.

In the fix here, I've gone with consistency with how we currently
format `SHOW JOB <ID>`. That is, I've added support for a select statement
argument to `SHOW CHANGEFEED JOBS` so that we can pretty print

    SHOW CHANGEFEED JOB 665152927024873473

as

    SHOW CHANGEFEED JOBS VALUES (665152927024873473);

We could alternatively dig into the Select node and pull out the value
in order to generate a terser representation; however, I think
consistency with the other jobs commands makes the most sense for now.

Fixes #65759

Release note: None