### PR TITLE
cloud: fix gcs to resuming reader

### DIFF
--- a/pkg/storage/cloud/cloud_io.go
+++ b/pkg/storage/cloud/cloud_io.go
@@ -120,7 +120,7 @@ func DelayedRetry(
 	})
 }
 
-// isResumableHTTPError returns true if we can
+// IsResumableHTTPError returns true if we can
 // resume download after receiving an error 'err'.
 // We can attempt to resume download if the error is ErrUnexpectedEOF.
 // In particular, we should not worry about a case when error is io.EOF.
@@ -135,7 +135,7 @@ func DelayedRetry(
 // In addition, we treat connection reset by peer errors (which can
 // happen if we didn't read from the connection too long due to e.g. load),
 // the same as unexpected eof errors.
-func isResumableHTTPError(err error) bool {
+func IsResumableHTTPError(err error) bool {
 	return errors.Is(err, io.ErrUnexpectedEOF) ||
 		sysutil.IsErrConnectionReset(err) ||
 		sysutil.IsErrConnectionRefused(err)
@@ -151,14 +151,39 @@ type ReaderOpenerAt func(ctx context.Context, pos int64) (io.ReadCloser, error)
 
 // ResumingReader is a reader which retries reads in case of a transient errors.
 type ResumingReader struct {
-	Ctx    context.Context           // Reader context
-	Opener ReaderOpenerAt            // Get additional content
-	Reader io.ReadCloser             // Currently opened reader
-	Pos    int64                     // How much data was received so far
-	ErrFn  func(error) time.Duration // custom error delay picker
+	Ctx          context.Context           // Reader context
+	Opener       ReaderOpenerAt            // Get additional content
+	Reader       io.ReadCloser             // Currently opened reader
+	Pos          int64                     // How much data was received so far
+	RetryOnErrFn func(error) bool          // custom retry-on-error function
+	ErrFn        func(error) time.Duration // custom error delay picker
 }
 
 var _ io.ReadCloser = &ResumingReader{}
+
+// NewResumingReader returns a ResumingReader instance.
+func NewResumingReader(
+	ctx context.Context,
+	opener ReaderOpenerAt,
+	reader io.ReadCloser,
+	pos int64,
+	retryOnErrFn func(error) bool,
+	errFn func(error) time.Duration,
+) *ResumingReader {
+	r := &ResumingReader{
+		Ctx:          ctx,
+		Opener:       opener,
+		Reader:       reader,
+		Pos:          pos,
+		RetryOnErrFn: retryOnErrFn,
+		ErrFn:        errFn,
+	}
+	if r.RetryOnErrFn == nil {
+		log.Warning(ctx, "no RetryOnErrFn specified when configuring ResumingReader, setting to default value")
+		r.RetryOnErrFn = sysutil.IsErrConnectionReset
+	}
+	return r
+}
 
 // Open opens the reader at its current offset.
 func (r *ResumingReader) Open() error {
@@ -190,7 +215,8 @@ func (r *ResumingReader) Read(p []byte) (int, error) {
 			log.Errorf(r.Ctx, "Read err: %s", lastErr)
 		}
 
-		if isResumableHTTPError(lastErr) {
+		// Use the configured retry-on-error decider to check for a resumable error.
+		if r.RetryOnErrFn(lastErr) {
 			if retries >= maxNoProgressReads {
 				return 0, errors.Wrap(lastErr, "multiple Read calls return no data")
 			}

--- a/pkg/storage/cloud/cloudtestutils/cloud_test_helpers.go
+++ b/pkg/storage/cloud/cloudtestutils/cloud_test_helpers.go
@@ -536,9 +536,9 @@ func uploadData(
 		ctx, dest, base.ExternalIODirConfig{}, testSettings,
 		nil, nil, nil)
 	require.NoError(t, err)
-	defer s.Close()
 	require.NoError(t, cloud.WriteFile(ctx, s, basename, bytes.NewReader(data)))
 	return data, func() {
+		defer s.Close()
 		_ = s.Delete(ctx, basename)
 	}
 }

--- a/pkg/storage/cloud/gcp/gcs_storage.go
+++ b/pkg/storage/cloud/gcp/gcs_storage.go
@@ -176,7 +176,8 @@ func (g *gcsStorage) ReadFileAt(
 		Opener: func(ctx context.Context, pos int64) (io.ReadCloser, error) {
 			return g.bucket.Object(object).NewRangeReader(ctx, pos, -1)
 		},
-		Pos: offset,
+		RetryOnErrFn: cloud.IsResumableHTTPError,
+		Pos:          offset,
 	}
 
 	if err := r.Open(); err != nil {
@@ -189,7 +190,7 @@ func (g *gcsStorage) ReadFileAt(
 		}
 		return nil, 0, err
 	}
-	return r.Reader, r.Reader.(*gcs.Reader).Attrs.Size, nil
+	return r, r.Reader.(*gcs.Reader).Attrs.Size, nil
 }
 
 func (g *gcsStorage) ListFiles(ctx context.Context, patternSuffix string) ([]string, error) {


### PR DESCRIPTION
This change does a few things:

1. gcs_storage was not returning a resuming reader as a result of
which the Read method of the resuming reader that contains logic
to retry on certain kinds of errors was not being invoked.

2, Changes the resuming reader to take a storage specific function
that can define what errors are retryable in the resuming reader.
All storage providers use the same deciding function at the moment
and so behavior is unchanged.

Release note: None