### PR TITLE
backupccl: add cluster setting to disable GCS chunking

### DIFF
--- a/pkg/storage/cloud/gcp/BUILD.bazel
+++ b/pkg/storage/cloud/gcp/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//pkg/base",
         "//pkg/roachpb",
         "//pkg/server/telemetry",
+        "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/storage/cloud",
         "//pkg/util/contextutil",

--- a/pkg/storage/cloud/gcp/gcs_storage.go
+++ b/pkg/storage/cloud/gcp/gcs_storage.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/cloud"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
@@ -38,6 +39,14 @@ const (
 	// CredentialsParam is the query parameter for the base64-encoded contents of
 	// the Google Application Credentials JSON file.
 	CredentialsParam = "CREDENTIALS"
+)
+
+// gcsChunkingEnabled is used to enable and disable chunking of file upload to
+// Google Cloud Storage.
+var gcsChunkingEnabled = settings.RegisterBoolSetting(
+	"cloudstorage.gs.chunking.enabled",
+	"enable chunking of file upload to Google Cloud Storage",
+	true, /* default */
 )
 
 func parseGSURL(_ cloud.ExternalStorageURIContext, uri *url.URL) (roachpb.ExternalStorage, error) {
@@ -158,6 +167,9 @@ func makeGCSStorage(
 
 func (g *gcsStorage) Writer(ctx context.Context, basename string) (io.WriteCloser, error) {
 	w := g.bucket.Object(path.Join(g.prefix, basename)).NewWriter(ctx)
+	if !gcsChunkingEnabled.Get(&g.settings.SV) {
+		w.ChunkSize = 0
+	}
 	return w, nil
 }
 


### PR DESCRIPTION
Adds a cluster setting that can disable GCS chunking during file upload.
This might be desirable if writing to GCS is stuck trying in the SDK.
See googleapis/google-cloud-go#1507 for details.

Encountering this retry is quite rare and so this cluster setting is not
public since it's not expected to be set most of the time, but could
serve as a useful escape-hatch.

Release note: None