### PR TITLE
github: update codeowner for storage/cloud

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -73,6 +73,7 @@
 /pkg/kv/                     @cockroachdb/kv
 
 /pkg/storage/                @cockroachdb/storage
+/pkg/storage/cloud           @cockroachdb/bulk-prs
 
 /pkg/ui/                     @cockroachdb/cluster-ui-prs
 /pkg/ui/embedded.go          @cockroachdb/cluster-ui-prs


### PR DESCRIPTION
Updates the code owner for the cloud storage package to Bulk IO.

Release note: None