### PR TITLE
sql: drop "cluster" from EXPLAIN ANALYZE to improve readability

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/dist_vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/dist_vectorize
@@ -58,16 +58,16 @@ vectorized: <hidden>
 rows read from KV: 5 (40 B)
 maximum memory usage: <hidden>
 network usage: <hidden>
-cluster regions: <hidden>
+regions: <hidden>
 ·
 • group (scalar)
-│ cluster nodes: <hidden>
-│ cluster regions: <hidden>
+│ nodes: <hidden>
+│ regions: <hidden>
 │ actual row count: 1
 │
 └── • scan
-      cluster nodes: <hidden>
-      cluster regions: <hidden>
+      nodes: <hidden>
+      regions: <hidden>
       actual row count: 5
       KV rows read: 5
       KV bytes read: 40 B
@@ -87,19 +87,19 @@ vectorized: <hidden>
 rows read from KV: 10 (80 B)
 maximum memory usage: <hidden>
 network usage: <hidden>
-cluster regions: <hidden>
+regions: <hidden>
 ·
 • merge join
-│ cluster nodes: <hidden>
-│ cluster regions: <hidden>
+│ nodes: <hidden>
+│ regions: <hidden>
 │ actual row count: 5
 │ equality: (k) = (k)
 │ left cols are key
 │ right cols are key
 │
 ├── • scan
-│     cluster nodes: <hidden>
-│     cluster regions: <hidden>
+│     nodes: <hidden>
+│     regions: <hidden>
 │     actual row count: 5
 │     KV rows read: 5
 │     KV bytes read: 40 B
@@ -108,8 +108,8 @@ cluster regions: <hidden>
 │     spans: FULL SCAN
 │
 └── • scan
-      cluster nodes: <hidden>
-      cluster regions: <hidden>
+      nodes: <hidden>
+      regions: <hidden>
       actual row count: 5
       KV rows read: 5
       KV bytes read: 40 B

--- a/pkg/sql/logictest/testdata/logic_test/explain_analyze
+++ b/pkg/sql/logictest/testdata/logic_test/explain_analyze
@@ -18,11 +18,11 @@ distribution: <hidden>
 vectorized: <hidden>
 maximum memory usage: <hidden>
 network usage: <hidden>
-cluster regions: <hidden>
+regions: <hidden>
 ·
 • scan
-  cluster nodes: <hidden>
-  cluster regions: <hidden>
+  nodes: <hidden>
+  regions: <hidden>
   actual row count: 0
   KV rows read: 0
   KV bytes read: 0 B
@@ -43,11 +43,11 @@ vectorized: <hidden>
 rows read from KV: 3 (24 B)
 maximum memory usage: <hidden>
 network usage: <hidden>
-cluster regions: <hidden>
+regions: <hidden>
 ·
 • scan
-  cluster nodes: <hidden>
-  cluster regions: <hidden>
+  nodes: <hidden>
+  regions: <hidden>
   actual row count: 3
   KV rows read: 3
   KV bytes read: 24 B
@@ -69,12 +69,12 @@ vectorized: <hidden>
 rows read from KV: 7 (56 B)
 maximum memory usage: <hidden>
 network usage: <hidden>
-cluster regions: <hidden>
+regions: <hidden>
 ·
 • hash join (inner)
 │ columns: (k, v, a, b)
-│ cluster nodes: <hidden>
-│ cluster regions: <hidden>
+│ nodes: <hidden>
+│ regions: <hidden>
 │ actual row count: 2
 │ vectorized batch count: 0
 │ estimated row count: 990 (missing stats)
@@ -83,8 +83,8 @@ cluster regions: <hidden>
 │
 ├── • scan
 │     columns: (k, v)
-│     cluster nodes: <hidden>
-│     cluster regions: <hidden>
+│     nodes: <hidden>
+│     regions: <hidden>
 │     actual row count: 4
 │     vectorized batch count: 0
 │     KV rows read: 4
@@ -95,8 +95,8 @@ cluster regions: <hidden>
 │
 └── • scan
       columns: (a, b)
-      cluster nodes: <hidden>
-      cluster regions: <hidden>
+      nodes: <hidden>
+      regions: <hidden>
       actual row count: 3
       vectorized batch count: 0
       KV rows read: 3

--- a/pkg/sql/logictest/testdata/logic_test/explain_analyze_plans
+++ b/pkg/sql/logictest/testdata/logic_test/explain_analyze_plans
@@ -67,26 +67,26 @@ vectorized: <hidden>
 rows read from KV: 10 (80 B)
 maximum memory usage: <hidden>
 network usage: <hidden>
-cluster regions: <hidden>
+regions: <hidden>
 ·
 • group
-│ cluster nodes: <hidden>
-│ cluster regions: <hidden>
+│ nodes: <hidden>
+│ regions: <hidden>
 │ actual row count: 5
 │ group by: k
 │ ordered: +k
 │
 └── • merge join
-    │ cluster nodes: <hidden>
-    │ cluster regions: <hidden>
+    │ nodes: <hidden>
+    │ regions: <hidden>
     │ actual row count: 5
     │ equality: (k) = (k)
     │ left cols are key
     │ right cols are key
     │
     ├── • scan
-    │     cluster nodes: <hidden>
-    │     cluster regions: <hidden>
+    │     nodes: <hidden>
+    │     regions: <hidden>
     │     actual row count: 5
     │     KV rows read: 5
     │     KV bytes read: 40 B
@@ -95,8 +95,8 @@ cluster regions: <hidden>
     │     spans: FULL SCAN
     │
     └── • scan
-          cluster nodes: <hidden>
-          cluster regions: <hidden>
+          nodes: <hidden>
+          regions: <hidden>
           actual row count: 5
           KV rows read: 5
           KV bytes read: 40 B
@@ -117,30 +117,30 @@ vectorized: <hidden>
 rows read from KV: 10 (80 B)
 maximum memory usage: <hidden>
 network usage: <hidden>
-cluster regions: <hidden>
+regions: <hidden>
 ·
 • sort
-│ cluster nodes: <hidden>
-│ cluster regions: <hidden>
+│ nodes: <hidden>
+│ regions: <hidden>
 │ actual row count: 5
 │ order: +w
 │
 └── • distinct
-    │ cluster nodes: <hidden>
-    │ cluster regions: <hidden>
+    │ nodes: <hidden>
+    │ regions: <hidden>
     │ actual row count: 5
     │ distinct on: w
     │
     └── • hash join
-        │ cluster nodes: <hidden>
-        │ cluster regions: <hidden>
+        │ nodes: <hidden>
+        │ regions: <hidden>
         │ actual row count: 5
         │ equality: (k) = (w)
         │ left cols are key
         │
         ├── • scan
-        │     cluster nodes: <hidden>
-        │     cluster regions: <hidden>
+        │     nodes: <hidden>
+        │     regions: <hidden>
         │     actual row count: 5
         │     KV rows read: 5
         │     KV bytes read: 40 B
@@ -149,8 +149,8 @@ cluster regions: <hidden>
         │     spans: FULL SCAN
         │
         └── • scan
-              cluster nodes: <hidden>
-              cluster regions: <hidden>
+              nodes: <hidden>
+              regions: <hidden>
               actual row count: 5
               KV rows read: 5
               KV bytes read: 40 B
@@ -171,21 +171,21 @@ vectorized: <hidden>
 rows read from KV: 10 (80 B)
 maximum memory usage: <hidden>
 network usage: <hidden>
-cluster regions: <hidden>
+regions: <hidden>
 ·
 • cross join
-│ cluster nodes: <hidden>
-│ cluster regions: <hidden>
+│ nodes: <hidden>
+│ regions: <hidden>
 │ actual row count: 25
 │
 ├── • ordinality
-│   │ cluster nodes: <hidden>
-│   │ cluster regions: <hidden>
+│   │ nodes: <hidden>
+│   │ regions: <hidden>
 │   │ actual row count: 5
 │   │
 │   └── • scan
-│         cluster nodes: <hidden>
-│         cluster regions: <hidden>
+│         nodes: <hidden>
+│         regions: <hidden>
 │         actual row count: 5
 │         KV rows read: 5
 │         KV bytes read: 40 B
@@ -194,13 +194,13 @@ cluster regions: <hidden>
 │         spans: FULL SCAN
 │
 └── • ordinality
-    │ cluster nodes: <hidden>
-    │ cluster regions: <hidden>
+    │ nodes: <hidden>
+    │ regions: <hidden>
     │ actual row count: 5
     │
     └── • scan
-          cluster nodes: <hidden>
-          cluster regions: <hidden>
+          nodes: <hidden>
+          regions: <hidden>
           actual row count: 5
           KV rows read: 5
           KV bytes read: 40 B
@@ -242,16 +242,16 @@ vectorized: <hidden>
 rows read from KV: 5 (40 B)
 maximum memory usage: <hidden>
 network usage: <hidden>
-cluster regions: <hidden>
+regions: <hidden>
 ·
 • window
-│ cluster nodes: <hidden>
-│ cluster regions: <hidden>
+│ nodes: <hidden>
+│ regions: <hidden>
 │ actual row count: 5
 │
 └── • scan
-      cluster nodes: <hidden>
-      cluster regions: <hidden>
+      nodes: <hidden>
+      regions: <hidden>
       actual row count: 5
       KV rows read: 5
       KV bytes read: 40 B
@@ -272,11 +272,11 @@ distribution: <hidden>
 vectorized: <hidden>
 maximum memory usage: <hidden>
 network usage: <hidden>
-cluster regions: <hidden>
+regions: <hidden>
 ·
 • scan
-  cluster nodes: <hidden>
-  cluster regions: <hidden>
+  nodes: <hidden>
+  regions: <hidden>
   actual row count: 0
   KV rows read: 0
   KV bytes read: 0 B
@@ -302,13 +302,13 @@ vectorized: <hidden>
 rows read from KV: 2 (16 B)
 maximum memory usage: <hidden>
 network usage: <hidden>
-cluster regions: <hidden>
+regions: <hidden>
 ·
 • root
 │
 ├── • insert
-│   │ cluster nodes: <hidden>
-│   │ cluster regions: <hidden>
+│   │ nodes: <hidden>
+│   │ regions: <hidden>
 │   │ actual row count: 1
 │   │ into: child(c, p)
 │   │
@@ -324,13 +324,13 @@ cluster regions: <hidden>
 │   │ exec mode: one row
 │   │
 │   └── • group (scalar)
-│       │ cluster nodes: <hidden>
-│       │ cluster regions: <hidden>
+│       │ nodes: <hidden>
+│       │ regions: <hidden>
 │       │ actual row count: 1
 │       │
 │       └── • scan
-│             cluster nodes: <hidden>
-│             cluster regions: <hidden>
+│             nodes: <hidden>
+│             regions: <hidden>
 │             actual row count: 1
 │             KV rows read: 1
 │             KV bytes read: 8 B
@@ -342,13 +342,13 @@ cluster regions: <hidden>
 └── • constraint-check
     │
     └── • error if rows
-        │ cluster nodes: <hidden>
-        │ cluster regions: <hidden>
+        │ nodes: <hidden>
+        │ regions: <hidden>
         │ actual row count: 0
         │
         └── • lookup join (anti)
-            │ cluster nodes: <hidden>
-            │ cluster regions: <hidden>
+            │ nodes: <hidden>
+            │ regions: <hidden>
             │ actual row count: 0
             │ KV rows read: 1
             │ KV bytes read: 8 B
@@ -357,15 +357,15 @@ cluster regions: <hidden>
             │ equality cols are key
             │
             └── • filter
-                │ cluster nodes: <hidden>
-                │ cluster regions: <hidden>
+                │ nodes: <hidden>
+                │ regions: <hidden>
                 │ actual row count: 1
                 │ estimated row count: 1
                 │ filter: column2 IS NOT NULL
                 │
                 └── • scan buffer
-                      cluster nodes: <hidden>
-                      cluster regions: <hidden>
+                      nodes: <hidden>
+                      regions: <hidden>
                       actual row count: 1
                       label: buffer 1
 ·

--- a/pkg/sql/logictest/testdata/logic_test/inverted_index_geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index_geospatial
@@ -35,38 +35,38 @@ vectorized: <hidden>
 rows read from KV: 6 (48 B)
 maximum memory usage: <hidden>
 network usage: <hidden>
-cluster regions: <hidden>
+regions: <hidden>
 ·
 • sort
-│ cluster nodes: <hidden>
-│ cluster regions: <hidden>
+│ nodes: <hidden>
+│ regions: <hidden>
 │ actual row count: 2
 │ order: +k
 │
 └── • filter
-    │ cluster nodes: <hidden>
-    │ cluster regions: <hidden>
+    │ nodes: <hidden>
+    │ regions: <hidden>
     │ actual row count: 2
     │ filter: st_intersects('010100002026690000000000000C6A18410000008081844E41', geom)
     │
     └── • index join
-        │ cluster nodes: <hidden>
-        │ cluster regions: <hidden>
+        │ nodes: <hidden>
+        │ regions: <hidden>
         │ actual row count: 2
         │ KV rows read: 2
         │ KV bytes read: 16 B
         │ table: geo_table@primary
         │
         └── • inverted filter
-            │ cluster nodes: <hidden>
-            │ cluster regions: <hidden>
+            │ nodes: <hidden>
+            │ regions: <hidden>
             │ actual row count: 2
             │ inverted column: geom_inverted_key
             │ num spans: 31
             │
             └── • scan
-                  cluster nodes: <hidden>
-                  cluster regions: <hidden>
+                  nodes: <hidden>
+                  regions: <hidden>
                   actual row count: 4
                   KV rows read: 4
                   KV bytes read: 32 B
@@ -117,38 +117,38 @@ vectorized: <hidden>
 rows read from KV: 4 (32 B)
 maximum memory usage: <hidden>
 network usage: <hidden>
-cluster regions: <hidden>
+regions: <hidden>
 ·
 • sort
-│ cluster nodes: <hidden>
-│ cluster regions: <hidden>
+│ nodes: <hidden>
+│ regions: <hidden>
 │ actual row count: 2
 │ order: +k
 │
 └── • filter
-    │ cluster nodes: <hidden>
-    │ cluster regions: <hidden>
+    │ nodes: <hidden>
+    │ regions: <hidden>
     │ actual row count: 2
     │ filter: st_intersects('010100002026690000000000000C6A18410000008081844E41', geom)
     │
     └── • index join
-        │ cluster nodes: <hidden>
-        │ cluster regions: <hidden>
+        │ nodes: <hidden>
+        │ regions: <hidden>
         │ actual row count: 2
         │ KV rows read: 2
         │ KV bytes read: 16 B
         │ table: geo_table@primary
         │
         └── • inverted filter
-            │ cluster nodes: <hidden>
-            │ cluster regions: <hidden>
+            │ nodes: <hidden>
+            │ regions: <hidden>
             │ actual row count: 2
             │ inverted column: geom_inverted_key
             │ num spans: 31
             │
             └── • scan
-                  cluster nodes: <hidden>
-                  cluster regions: <hidden>
+                  nodes: <hidden>
+                  regions: <hidden>
                   actual row count: 2
                   KV rows read: 2
                   KV bytes read: 16 B
@@ -175,38 +175,38 @@ vectorized: <hidden>
 rows read from KV: 4 (32 B)
 maximum memory usage: <hidden>
 network usage: <hidden>
-cluster regions: <hidden>
+regions: <hidden>
 ·
 • sort
-│ cluster nodes: <hidden>
-│ cluster regions: <hidden>
+│ nodes: <hidden>
+│ regions: <hidden>
 │ actual row count: 2
 │ order: +k
 │
 └── • filter
-    │ cluster nodes: <hidden>
-    │ cluster regions: <hidden>
+    │ nodes: <hidden>
+    │ regions: <hidden>
     │ actual row count: 2
     │ filter: st_intersects('010100002026690000000000000C6A18410000008081844E41', geom)
     │
     └── • index join
-        │ cluster nodes: <hidden>
-        │ cluster regions: <hidden>
+        │ nodes: <hidden>
+        │ regions: <hidden>
         │ actual row count: 2
         │ KV rows read: 2
         │ KV bytes read: 16 B
         │ table: geo_table@primary
         │
         └── • inverted filter
-            │ cluster nodes: <hidden>
-            │ cluster regions: <hidden>
+            │ nodes: <hidden>
+            │ regions: <hidden>
             │ actual row count: 2
             │ inverted column: geom_inverted_key
             │ num spans: 31
             │
             └── • scan
-                  cluster nodes: <hidden>
-                  cluster regions: <hidden>
+                  nodes: <hidden>
+                  regions: <hidden>
                   actual row count: 2
                   KV rows read: 2
                   KV bytes read: 16 B

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_local
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_local
@@ -45,11 +45,11 @@ vectorized: <hidden>
 rows read from KV: 2,001 (16 KiB)
 maximum memory usage: <hidden>
 network usage: <hidden>
-cluster regions: <hidden>
+regions: <hidden>
 ·
 • scan
-  cluster nodes: <hidden>
-  cluster regions: <hidden>
+  nodes: <hidden>
+  regions: <hidden>
   actual row count: 2,001
   KV rows read: 2,001
   KV bytes read: 16 KiB
@@ -69,11 +69,11 @@ vectorized: <hidden>
 rows read from KV: 3 (24 B)
 maximum memory usage: <hidden>
 network usage: <hidden>
-cluster regions: <hidden>
+regions: <hidden>
 ·
 • lookup join
-│ cluster nodes: <hidden>
-│ cluster regions: <hidden>
+│ nodes: <hidden>
+│ regions: <hidden>
 │ actual row count: 2
 │ KV rows read: 1
 │ KV bytes read: 8 B
@@ -81,8 +81,8 @@ cluster regions: <hidden>
 │ equality: (b) = (b)
 │
 └── • scan
-      cluster nodes: <hidden>
-      cluster regions: <hidden>
+      nodes: <hidden>
+      regions: <hidden>
       actual row count: 2
       KV rows read: 2
       KV bytes read: 16 B
@@ -143,24 +143,24 @@ vectorized: <hidden>
 rows read from KV: 4 (32 B)
 maximum memory usage: <hidden>
 network usage: <hidden>
-cluster regions: <hidden>
+regions: <hidden>
 ·
 • merge join
-│ cluster nodes: <hidden>
-│ cluster regions: <hidden>
+│ nodes: <hidden>
+│ regions: <hidden>
 │ actual row count: 2
 │ equality: (a) = (b)
 │
 ├── • sort
-│   │ cluster nodes: <hidden>
-│   │ cluster regions: <hidden>
+│   │ nodes: <hidden>
+│   │ regions: <hidden>
 │   │ actual row count: 2
 │   │ estimated row count: 1
 │   │ order: +a
 │   │
 │   └── • scan
-│         cluster nodes: <hidden>
-│         cluster regions: <hidden>
+│         nodes: <hidden>
+│         regions: <hidden>
 │         actual row count: 2
 │         KV rows read: 2
 │         KV bytes read: 16 B
@@ -169,8 +169,8 @@ cluster regions: <hidden>
 │         spans: FULL SCAN
 │
 └── • scan
-      cluster nodes: <hidden>
-      cluster regions: <hidden>
+      nodes: <hidden>
+      regions: <hidden>
       actual row count: 2
       KV rows read: 2
       KV bytes read: 16 B

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -1582,10 +1582,10 @@ distribution: <hidden>
 vectorized: <hidden>
 maximum memory usage: <hidden>
 network usage: <hidden>
-cluster regions: <hidden>
+regions: <hidden>
 ·
 • values
-  cluster nodes: <hidden>
-  cluster regions: <hidden>
+  nodes: <hidden>
+  regions: <hidden>
   actual row count: 1
   size: 1 column, 1 row

--- a/pkg/sql/opt/exec/execbuilder/testdata/prepare
+++ b/pkg/sql/opt/exec/execbuilder/testdata/prepare
@@ -118,11 +118,11 @@ vectorized: <hidden>
 rows read from KV: 1 (8 B)
 maximum memory usage: <hidden>
 network usage: <hidden>
-cluster regions: <hidden>
+regions: <hidden>
 ·
 • scan
-  cluster nodes: <hidden>
-  cluster regions: <hidden>
+  nodes: <hidden>
+  regions: <hidden>
   actual row count: 1
   KV rows read: 1
   KV bytes read: 8 B
@@ -139,11 +139,11 @@ distribution: <hidden>
 vectorized: <hidden>
 maximum memory usage: <hidden>
 network usage: <hidden>
-cluster regions: <hidden>
+regions: <hidden>
 ·
 • scan
-  cluster nodes: <hidden>
-  cluster regions: <hidden>
+  nodes: <hidden>
+  regions: <hidden>
   actual row count: 0
   KV rows read: 0
   KV bytes read: 0 B

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -333,10 +333,10 @@ func (e *emitter) emitNodeAttributes(n *Node) error {
 	if stats, ok := n.annotations[exec.ExecutionStatsID]; ok {
 		s := stats.(*exec.ExecutionStats)
 		if len(s.Nodes) > 0 {
-			e.ob.AddRedactableField(RedactNodes, "cluster nodes", strings.Join(s.Nodes, ", "))
+			e.ob.AddRedactableField(RedactNodes, "nodes", strings.Join(s.Nodes, ", "))
 		}
 		if len(s.Regions) > 0 {
-			e.ob.AddRedactableField(RedactNodes, "cluster regions", strings.Join(s.Regions, ", "))
+			e.ob.AddRedactableField(RedactNodes, "regions", strings.Join(s.Regions, ", "))
 		}
 		if s.RowCount.HasValue() {
 			e.ob.AddField("actual row count", humanizeutil.Count(s.RowCount.Value()))

--- a/pkg/sql/opt/exec/explain/output.go
+++ b/pkg/sql/opt/exec/explain/output.go
@@ -415,7 +415,7 @@ func (ob *OutputBuilder) AddMaxDiskUsage(bytes int64) {
 func (ob *OutputBuilder) AddRegionsStats(regions []string) {
 	ob.AddRedactableTopLevelField(
 		RedactNodes,
-		"cluster regions",
+		"regions",
 		strings.Join(regions, ", "),
 	)
 }


### PR DESCRIPTION
Remove the word "cluster" from "cluster nodes" and "cluster regions"
on EXPLAIN ANALYZE to improve readability.

Release note: None