### PR TITLE
sql: add time & contention time to EXPLAIN ANALYZE.

### DIFF
--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -559,6 +559,8 @@ func (m execNodeTraceMetadata) annotateExplain(
 					break
 				}
 				nodeStats.RowCount.MaybeAdd(stats.Output.NumTuples)
+				nodeStats.KVTime.MaybeAdd(stats.KV.KVTime)
+				nodeStats.KVContentionTime.MaybeAdd(stats.KV.ContentionTime)
 				nodeStats.KVBytesRead.MaybeAdd(stats.KV.BytesRead)
 				nodeStats.KVRowsRead.MaybeAdd(stats.KV.TuplesRead)
 				nodeStats.VectorizedBatchCount.MaybeAdd(stats.Output.NumBatches)

--- a/pkg/sql/logictest/testdata/logic_test/dist_vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/dist_vectorize
@@ -69,6 +69,8 @@ cluster regions: <hidden>
       cluster nodes: <hidden>
       cluster regions: <hidden>
       actual row count: 5
+      KV time: 0µs
+      KV contention time: 0µs
       KV rows read: 5
       KV bytes read: 40 B
       missing stats
@@ -101,6 +103,8 @@ cluster regions: <hidden>
 │     cluster nodes: <hidden>
 │     cluster regions: <hidden>
 │     actual row count: 5
+│     KV time: 0µs
+│     KV contention time: 0µs
 │     KV rows read: 5
 │     KV bytes read: 40 B
 │     missing stats
@@ -111,6 +115,8 @@ cluster regions: <hidden>
       cluster nodes: <hidden>
       cluster regions: <hidden>
       actual row count: 5
+      KV time: 0µs
+      KV contention time: 0µs
       KV rows read: 5
       KV bytes read: 40 B
       missing stats

--- a/pkg/sql/logictest/testdata/logic_test/explain_analyze
+++ b/pkg/sql/logictest/testdata/logic_test/explain_analyze
@@ -24,6 +24,8 @@ cluster regions: <hidden>
   cluster nodes: <hidden>
   cluster regions: <hidden>
   actual row count: 0
+  KV time: 0µs
+  KV contention time: 0µs
   KV rows read: 0
   KV bytes read: 0 B
   missing stats
@@ -49,6 +51,8 @@ cluster regions: <hidden>
   cluster nodes: <hidden>
   cluster regions: <hidden>
   actual row count: 3
+  KV time: 0µs
+  KV contention time: 0µs
   KV rows read: 3
   KV bytes read: 24 B
   missing stats
@@ -87,6 +91,8 @@ cluster regions: <hidden>
 │     cluster regions: <hidden>
 │     actual row count: 4
 │     vectorized batch count: 0
+│     KV time: 0µs
+│     KV contention time: 0µs
 │     KV rows read: 4
 │     KV bytes read: 32 B
 │     estimated row count: 1,000 (missing stats)
@@ -99,6 +105,8 @@ cluster regions: <hidden>
       cluster regions: <hidden>
       actual row count: 3
       vectorized batch count: 0
+      KV time: 0µs
+      KV contention time: 0µs
       KV rows read: 3
       KV bytes read: 24 B
       estimated row count: 1,000 (missing stats)

--- a/pkg/sql/logictest/testdata/logic_test/explain_analyze_plans
+++ b/pkg/sql/logictest/testdata/logic_test/explain_analyze_plans
@@ -88,6 +88,8 @@ cluster regions: <hidden>
     │     cluster nodes: <hidden>
     │     cluster regions: <hidden>
     │     actual row count: 5
+    │     KV time: 0µs
+    │     KV contention time: 0µs
     │     KV rows read: 5
     │     KV bytes read: 40 B
     │     missing stats
@@ -98,6 +100,8 @@ cluster regions: <hidden>
           cluster nodes: <hidden>
           cluster regions: <hidden>
           actual row count: 5
+          KV time: 0µs
+          KV contention time: 0µs
           KV rows read: 5
           KV bytes read: 40 B
           missing stats
@@ -142,6 +146,8 @@ cluster regions: <hidden>
         │     cluster nodes: <hidden>
         │     cluster regions: <hidden>
         │     actual row count: 5
+        │     KV time: 0µs
+        │     KV contention time: 0µs
         │     KV rows read: 5
         │     KV bytes read: 40 B
         │     missing stats
@@ -152,6 +158,8 @@ cluster regions: <hidden>
               cluster nodes: <hidden>
               cluster regions: <hidden>
               actual row count: 5
+              KV time: 0µs
+              KV contention time: 0µs
               KV rows read: 5
               KV bytes read: 40 B
               missing stats
@@ -187,6 +195,8 @@ cluster regions: <hidden>
 │         cluster nodes: <hidden>
 │         cluster regions: <hidden>
 │         actual row count: 5
+│         KV time: 0µs
+│         KV contention time: 0µs
 │         KV rows read: 5
 │         KV bytes read: 40 B
 │         missing stats
@@ -202,6 +212,8 @@ cluster regions: <hidden>
           cluster nodes: <hidden>
           cluster regions: <hidden>
           actual row count: 5
+          KV time: 0µs
+          KV contention time: 0µs
           KV rows read: 5
           KV bytes read: 40 B
           missing stats
@@ -253,6 +265,8 @@ cluster regions: <hidden>
       cluster nodes: <hidden>
       cluster regions: <hidden>
       actual row count: 5
+      KV time: 0µs
+      KV contention time: 0µs
       KV rows read: 5
       KV bytes read: 40 B
       missing stats
@@ -278,6 +292,8 @@ cluster regions: <hidden>
   cluster nodes: <hidden>
   cluster regions: <hidden>
   actual row count: 0
+  KV time: 0µs
+  KV contention time: 0µs
   KV rows read: 0
   KV bytes read: 0 B
   missing stats
@@ -332,6 +348,8 @@ cluster regions: <hidden>
 │             cluster nodes: <hidden>
 │             cluster regions: <hidden>
 │             actual row count: 1
+│             KV time: 0µs
+│             KV contention time: 0µs
 │             KV rows read: 1
 │             KV bytes read: 8 B
 │             missing stats
@@ -350,6 +368,8 @@ cluster regions: <hidden>
             │ cluster nodes: <hidden>
             │ cluster regions: <hidden>
             │ actual row count: 0
+            │ KV time: 0µs
+            │ KV contention time: 0µs
             │ KV rows read: 1
             │ KV bytes read: 8 B
             │ table: parent@primary

--- a/pkg/sql/logictest/testdata/logic_test/inverted_index_geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index_geospatial
@@ -53,6 +53,8 @@ cluster regions: <hidden>
         │ cluster nodes: <hidden>
         │ cluster regions: <hidden>
         │ actual row count: 2
+        │ KV time: 0µs
+        │ KV contention time: 0µs
         │ KV rows read: 2
         │ KV bytes read: 16 B
         │ table: geo_table@primary
@@ -68,6 +70,8 @@ cluster regions: <hidden>
                   cluster nodes: <hidden>
                   cluster regions: <hidden>
                   actual row count: 4
+                  KV time: 0µs
+                  KV contention time: 0µs
                   KV rows read: 4
                   KV bytes read: 32 B
                   missing stats
@@ -135,6 +139,8 @@ cluster regions: <hidden>
         │ cluster nodes: <hidden>
         │ cluster regions: <hidden>
         │ actual row count: 2
+        │ KV time: 0µs
+        │ KV contention time: 0µs
         │ KV rows read: 2
         │ KV bytes read: 16 B
         │ table: geo_table@primary
@@ -150,6 +156,8 @@ cluster regions: <hidden>
                   cluster nodes: <hidden>
                   cluster regions: <hidden>
                   actual row count: 2
+                  KV time: 0µs
+                  KV contention time: 0µs
                   KV rows read: 2
                   KV bytes read: 16 B
                   missing stats
@@ -193,6 +201,8 @@ cluster regions: <hidden>
         │ cluster nodes: <hidden>
         │ cluster regions: <hidden>
         │ actual row count: 2
+        │ KV time: 0µs
+        │ KV contention time: 0µs
         │ KV rows read: 2
         │ KV bytes read: 16 B
         │ table: geo_table@primary
@@ -208,6 +218,8 @@ cluster regions: <hidden>
                   cluster nodes: <hidden>
                   cluster regions: <hidden>
                   actual row count: 2
+                  KV time: 0µs
+                  KV contention time: 0µs
                   KV rows read: 2
                   KV bytes read: 16 B
                   missing stats

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_local
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_local
@@ -51,6 +51,8 @@ cluster regions: <hidden>
   cluster nodes: <hidden>
   cluster regions: <hidden>
   actual row count: 2,001
+  KV time: 0µs
+  KV contention time: 0µs
   KV rows read: 2,001
   KV bytes read: 16 KiB
   missing stats
@@ -75,6 +77,8 @@ cluster regions: <hidden>
 │ cluster nodes: <hidden>
 │ cluster regions: <hidden>
 │ actual row count: 2
+│ KV time: 0µs
+│ KV contention time: 0µs
 │ KV rows read: 1
 │ KV bytes read: 8 B
 │ table: d@primary
@@ -84,6 +88,8 @@ cluster regions: <hidden>
       cluster nodes: <hidden>
       cluster regions: <hidden>
       actual row count: 2
+      KV time: 0µs
+      KV contention time: 0µs
       KV rows read: 2
       KV bytes read: 16 B
       estimated row count: 1 (100% of the table; stats collected <hidden> ago)
@@ -162,6 +168,8 @@ cluster regions: <hidden>
 │         cluster nodes: <hidden>
 │         cluster regions: <hidden>
 │         actual row count: 2
+│         KV time: 0µs
+│         KV contention time: 0µs
 │         KV rows read: 2
 │         KV bytes read: 16 B
 │         estimated row count: 1 (100% of the table; stats collected <hidden> ago)
@@ -172,6 +180,8 @@ cluster regions: <hidden>
       cluster nodes: <hidden>
       cluster regions: <hidden>
       actual row count: 2
+      KV time: 0µs
+      KV contention time: 0µs
       KV rows read: 2
       KV bytes read: 16 B
       missing stats

--- a/pkg/sql/opt/exec/execbuilder/testdata/prepare
+++ b/pkg/sql/opt/exec/execbuilder/testdata/prepare
@@ -124,6 +124,8 @@ cluster regions: <hidden>
   cluster nodes: <hidden>
   cluster regions: <hidden>
   actual row count: 1
+  KV time: 0µs
+  KV contention time: 0µs
   KV rows read: 1
   KV bytes read: 8 B
   estimated row count: 0
@@ -145,6 +147,8 @@ cluster regions: <hidden>
   cluster nodes: <hidden>
   cluster regions: <hidden>
   actual row count: 0
+  KV time: 0µs
+  KV contention time: 0µs
   KV rows read: 0
   KV bytes read: 0 B
   estimated row count: 0

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -347,6 +347,12 @@ func (e *emitter) emitNodeAttributes(n *Node) error {
 				e.ob.AddField("vectorized batch count", humanizeutil.Count(s.VectorizedBatchCount.Value()))
 			}
 		}
+		if s.KVTime.HasValue() {
+			e.ob.AddField("KV time", humanizeutil.Duration(s.KVTime.Value()))
+		}
+		if s.KVContentionTime.HasValue() {
+			e.ob.AddField("KV contention time", humanizeutil.Duration(s.KVContentionTime.Value()))
+		}
 		if s.KVRowsRead.HasValue() {
 			e.ob.AddField("KV rows read", humanizeutil.Count(s.KVRowsRead.Value()))
 		}

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -315,8 +315,10 @@ type ExecutionStats struct {
 	// operator.
 	VectorizedBatchCount optional.Uint
 
-	KVBytesRead optional.Uint
-	KVRowsRead  optional.Uint
+	KVTime           optional.Duration
+	KVContentionTime optional.Duration
+	KVBytesRead      optional.Uint
+	KVRowsRead       optional.Uint
 
 	// Nodes on which this operator was executed.
 	Nodes []string


### PR DESCRIPTION
The new fields are labeled `KV time` and `KV contention time`:

```
 > EXPLAIN ANALYZE
-> UPDATE users SET name = 'Bob Loblaw'
-> WHERE id = '32a962b7-8440-4b81-97cd-a7d7757d6eac';
                                            info
--------------------------------------------------------------------------------------------
  planning time: 353µs
  execution time: 3ms
  distribution: local
  vectorized: true
  rows read from KV: 52 (5.8 KiB)
  cumulative time spent in KV: 2ms
  maximum memory usage: 60 KiB
  network usage: 0 B (0 messages)
  cluster regions: us-east1

  • update
  │ cluster nodes: n1
  │ cluster regions: us-east1
  │ actual row count: 1
  │ table: users
  │ set: name
  │ auto commit
  │
  └── • render
      │ cluster nodes: n1
      │ cluster regions: us-east1
      │ actual row count: 1
      │ estimated row count: 0
      │
      └── • filter
          │ cluster nodes: n1
          │ cluster regions: us-east1
          │ actual row count: 1
          │ estimated row count: 0
          │ filter: id = '32a962b7-8440-4b81-97cd-a7d7757d6eac'
          │
          └── • scan
                cluster nodes: n1
                cluster regions: us-east1
                actual row count: 52
                KV time: 2ms
                KV contention time: 0µs
                KV rows read: 52
                KV bytes read: 5.8 KiB
                estimated row count: 50 (100% of the table; stats collected 3 minutes ago)
                table: users@primary
                spans: FULL SCAN
(42 rows)

Time: 4ms total (execution 4ms / network 0ms)
```

Resolves #64200

Release note (sql change): EXPLAIN ANALYZE output now includes, for each plan step, the total time spent waiting for KV requests as well as the total time those KV requests spent contending with other transactions.