### PR TITLE
teamcity-support: make github-post best effort

### DIFF
--- a/build/teamcity-support.sh
+++ b/build/teamcity-support.sh
@@ -77,7 +77,7 @@ function run_json_test() {
       exit 1
     else
       tc_start_block "post issues"
-      github-post < "${tmpfile}"
+      (github-post < "${tmpfile}") || (echo "failed to post github issue")
       tc_end_block "post issues"
     fi
   fi


### PR DESCRIPTION
CI is currently broken and seemingly at this step:
```
[17:02:05][Run ./pkg/... under race detector] post issues
[17:02:05][post issues] Process exited with code 143`
```

Not sure what the error is, but this should confirm whether
it is the posting script which is broken.

Release note: None

