### PR TITLE
kvclient: protect agaist DelRange with limit running as 1PC

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
@@ -319,6 +319,65 @@ func checkReverseScanResults(
 	checkResumeSpanReverseScanResults(t, spans, results, expResults, expSatisfied, opt)
 }
 
+// Tests limited scan requests across many ranges with multiple bounds.
+func TestMultiRangeBoundedBatchScanSimple(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	s, _ := startNoSplitMergeServer(t)
+	ctx := context.Background()
+	defer s.Stopper().Stop(ctx)
+
+	db := s.DB()
+	if err := setupMultipleRanges(ctx, db, "a", "b", "c", "d", "e", "f", "g", "h"); err != nil {
+		t.Fatal(err)
+	}
+
+	expResultsWithoutBound := [][]string{
+		{"a1", "a2", "a3", "b1", "b2"},
+		{"c1", "c2", "d1"},
+		{"g1", "g2"},
+	}
+
+	for _, key := range []string{"a1", "a2", "a3", "b1", "b2", "c1", "c2", "d1", "f1", "f2", "f3", "g1", "g2", "h1"} {
+		require.NoError(t, db.Put(ctx, key, "value"))
+	}
+
+	for bound := 1; bound <= 20; bound++ {
+		t.Run(fmt.Sprintf("bound=%d", bound), func(t *testing.T) {
+
+			b := &kv.Batch{}
+			b.Header.MaxSpanRequestKeys = int64(bound)
+			spans := [][]string{{"a", "c"}, {"c", "e"}, {"g", "h"}}
+			for _, span := range spans {
+				b.Scan(span[0], span[1])
+			}
+			if err := db.Run(ctx, b); err != nil {
+				t.Fatal(err)
+			}
+
+			require.Equal(t, len(expResultsWithoutBound), len(b.Results))
+
+			expResults := make([][]string, len(expResultsWithoutBound))
+			expSatisfied := make(map[int]struct{})
+			var count int
+		Loop:
+			for i, expRes := range expResultsWithoutBound {
+				for _, key := range expRes {
+					if count == bound {
+						break Loop
+					}
+					expResults[i] = append(expResults[i], key)
+					count++
+				}
+				// NB: only works because requests are sorted and non-overlapping.
+				expSatisfied[i] = struct{}{}
+			}
+
+			checkScanResults(t, spans, b.Results, expResults, expSatisfied, checkOptions{mode: Strict})
+		})
+	}
+}
+
 // Tests multiple scans, forward and reverse, across many ranges with multiple
 // bounds.
 func TestMultiRangeBoundedBatchScan(t *testing.T) {
@@ -698,318 +757,9 @@ func TestMultiRangeBoundedBatchScanPartialResponses(t *testing.T) {
 	}
 }
 
-// checks the results of a DelRange.
-func checkDelRangeResults(
-	t *testing.T,
-	spans [][]string,
-	results []kv.Result,
-	expResults [][]string,
-	expSatisfied map[int]struct{},
-) {
-	checkDelRangeSpanResults(t, results, expResults)
-	checkResumeSpanDelRangeResults(t, spans, results, expResults, expSatisfied)
-}
-
-// checks the keys returned from a DelRange.
-func checkDelRangeSpanResults(t *testing.T, results []kv.Result, expResults [][]string) {
-	t.Helper()
-	require.Equal(t, len(expResults), len(results))
-	for i, res := range results {
-		require.Equal(t, len(expResults[i]), len(res.Keys))
-		for j, key := range res.Keys {
-			require.Equal(t, expResults[i][j], string(key))
-		}
-	}
-}
-
-// checks the ResumeSpan in the DelRange results.
-func checkResumeSpanDelRangeResults(
-	t *testing.T,
-	spans [][]string,
-	results []kv.Result,
-	expResults [][]string,
-	expSatisfied map[int]struct{},
-) {
-	t.Helper()
-	for i, res := range results {
-		keyLen := len(res.Keys)
-		// Check that satisfied requests don't have resume spans.
-		if _, satisfied := expSatisfied[i]; satisfied {
-			require.Nil(t, res.ResumeSpan)
-			continue
-		}
-
-		// Check ResumeSpan when request has been processed.
-		require.NotNil(t, res.ResumeSpan)
-		require.Equal(t, roachpb.RESUME_KEY_LIMIT, res.ResumeReason)
-
-		// The key can be empty once the entire span has been deleted.
-		if keyLen == 0 {
-			// The request was not processed; the resume span key >= first seen key.
-			require.LessOrEqual(t, spans[i][0], string(res.ResumeSpan.Key), "ResumeSpan.Key")
-		} else {
-			// The next start key is always greater than the last key seen.
-			lastRes := expResults[i][keyLen-1]
-			require.Less(t, lastRes, string(res.ResumeSpan.Key), "ResumeSpan.Key")
-		}
-		// The EndKey is untouched.
-		require.Equal(t, spans[i][1], string(res.ResumeSpan.EndKey), "ResumeSpan.EndKey")
-	}
-}
-
-// Tests multiple delete range requests across many ranges with multiple bounds.
-func TestMultiRangeBoundedBatchDelRange(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-	s, _ := startNoSplitMergeServer(t)
-	ctx := context.Background()
-	defer s.Stopper().Stop(ctx)
-
-	db := s.DB()
-	if err := setupMultipleRanges(ctx, db, "a", "b", "c", "d", "e", "f", "g", "h"); err != nil {
-		t.Fatal(err)
-	}
-
-	expResultsWithoutBound := [][]string{
-		{"a1", "a2", "a3", "b1", "b2"},
-		{"c1", "c2", "d1"},
-		{"g1", "g2"},
-	}
-
-	for bound := 1; bound <= 20; bound++ {
-		t.Run(fmt.Sprintf("bound=%d", bound), func(t *testing.T) {
-			for _, key := range []string{"a1", "a2", "a3", "b1", "b2", "c1", "c2", "d1", "f1", "f2", "f3", "g1", "g2", "h1"} {
-				if err := db.Put(ctx, key, "value"); err != nil {
-					t.Fatal(err)
-				}
-			}
-
-			b := &kv.Batch{}
-			b.Header.MaxSpanRequestKeys = int64(bound)
-			spans := [][]string{{"a", "c"}, {"c", "e"}, {"g", "h"}}
-			for _, span := range spans {
-				b.DelRange(span[0], span[1], true /* returnKeys */)
-			}
-			if err := db.Run(ctx, b); err != nil {
-				t.Fatal(err)
-			}
-
-			require.Equal(t, len(expResultsWithoutBound), len(b.Results))
-
-			expResults := make([][]string, len(expResultsWithoutBound))
-			expSatisfied := make(map[int]struct{})
-			var count int
-		Loop:
-			for i, expRes := range expResultsWithoutBound {
-				for _, key := range expRes {
-					if count == bound {
-						break Loop
-					}
-					expResults[i] = append(expResults[i], key)
-					count++
-				}
-				// NB: only works because requests are sorted and non-overlapping.
-				expSatisfied[i] = struct{}{}
-			}
-
-			checkDelRangeResults(t, spans, b.Results, expResults, expSatisfied)
-		})
-	}
-}
-
-// TestMultiRangeBoundedBatchScanPartialResponses runs multiple delete range
-// requests either out-of-order or over overlapping key spans and shows how the
-// batch responses can contain partial responses.
-func TestMultiRangeBoundedBatchDelRangePartialResponses(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-	s, _ := startNoSplitMergeServer(t)
-	ctx := context.Background()
-	defer s.Stopper().Stop(ctx)
-
-	db := s.DB()
-	if err := setupMultipleRanges(ctx, db, "a", "b", "c", "d", "e", "f"); err != nil {
-		t.Fatal(err)
-	}
-
-	for _, tc := range []struct {
-		name         string
-		bound        int64
-		spans        [][]string
-		expResults   [][]string
-		expSatisfied []int
-	}{
-		{
-			name:  "unsorted, non-overlapping, neither satisfied",
-			bound: 6,
-			spans: [][]string{
-				{"b1", "d"}, {"a", "b1"},
-			},
-			expResults: [][]string{
-				{"b1", "b2", "b3"}, {"a1", "a2", "a3"},
-			},
-		},
-		{
-			name:  "unsorted, non-overlapping, first satisfied",
-			bound: 6,
-			spans: [][]string{
-				{"b1", "c"}, {"a", "b1"},
-			},
-			expResults: [][]string{
-				{"b1", "b2", "b3"}, {"a1", "a2", "a3"},
-			},
-			expSatisfied: []int{0},
-		},
-		{
-			name:  "unsorted, non-overlapping, second satisfied",
-			bound: 6,
-			spans: [][]string{
-				{"b1", "d"}, {"a", "b"},
-			},
-			expResults: [][]string{
-				{"b1", "b2", "b3"}, {"a1", "a2", "a3"},
-			},
-			expSatisfied: []int{1},
-		},
-		{
-			name:  "unsorted, non-overlapping, both satisfied",
-			bound: 6,
-			spans: [][]string{
-				{"b1", "c"}, {"a", "b"},
-			},
-			expResults: [][]string{
-				{"b1", "b2", "b3"}, {"a1", "a2", "a3"},
-			},
-			expSatisfied: []int{0, 1},
-		},
-		{
-			// NOTE: the first request will have already deleted the keys, so
-			// the second request has no keys to delete.
-			name:  "sorted, overlapping, neither satisfied",
-			bound: 7,
-			spans: [][]string{
-				{"a", "d"}, {"b", "g"},
-			},
-			expResults: [][]string{
-				{"a1", "a2", "a3", "b1", "b2", "b3", "c1"}, {},
-			},
-		},
-		{
-			name:  "sorted, overlapping, first satisfied",
-			bound: 7,
-			spans: [][]string{
-				{"a", "c"}, {"b", "g"},
-			},
-			expResults: [][]string{
-				{"a1", "a2", "a3", "b1", "b2", "b3"}, {"c1"},
-			},
-			expSatisfied: []int{0},
-		},
-		{
-			name:  "sorted, overlapping, second satisfied",
-			bound: 7,
-			spans: [][]string{
-				{"a", "d"}, {"b", "c"},
-			},
-			expResults: [][]string{
-				{"a1", "a2", "a3", "b1", "b2", "b3", "c1"}, {},
-			},
-			expSatisfied: []int{1},
-		},
-		{
-			name:  "sorted, overlapping, both satisfied",
-			bound: 7,
-			spans: [][]string{
-				{"a", "c"}, {"b", "c"},
-			},
-			expResults: [][]string{
-				{"a1", "a2", "a3", "b1", "b2", "b3"}, {},
-			},
-			expSatisfied: []int{0, 1},
-		},
-		{
-			name:  "unsorted, overlapping, neither satisfied",
-			bound: 7,
-			spans: [][]string{
-				{"b", "g"}, {"a", "d"},
-			},
-			expResults: [][]string{
-				{"b1", "b2", "b3", "c1"}, {"a1", "a2", "a3"},
-			},
-		},
-		{
-			name:  "unsorted, overlapping, first satisfied",
-			bound: 7,
-			spans: [][]string{
-				{"b", "c"}, {"a", "d"},
-			},
-			expResults: [][]string{
-				{"b1", "b2", "b3"}, {"a1", "a2", "a3", "c1"},
-			},
-			expSatisfied: []int{0},
-		},
-		{
-			name:  "unsorted, overlapping, second satisfied",
-			bound: 7,
-			spans: [][]string{
-				{"b", "g"}, {"a", "b2"},
-			},
-			expResults: [][]string{
-				{"b1", "b2", "b3", "c1"}, {"a1", "a2", "a3"},
-			},
-			expSatisfied: []int{1},
-		},
-		{
-			name:  "unsorted, overlapping, both satisfied",
-			bound: 7,
-			spans: [][]string{
-				{"b", "c"}, {"a", "b2"},
-			},
-			expResults: [][]string{
-				{"b1", "b2", "b3"}, {"a1", "a2", "a3"},
-			},
-			expSatisfied: []int{0, 1},
-		},
-		{
-			name:  "unsorted, overlapping, unreached",
-			bound: 6,
-			spans: [][]string{
-				{"b", "g"}, {"c", "f"}, {"a", "d"},
-			},
-			expResults: [][]string{
-				{"b1", "b2", "b3"}, {}, {"a1", "a2", "a3"},
-			},
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			// Re-write all keys before each subtest.
-			for _, key := range []string{"a1", "a2", "a3", "b1", "b2", "b3", "c1", "c2", "c3", "d1", "d2", "d3"} {
-				if err := db.Put(ctx, key, "value"); err != nil {
-					t.Fatal(err)
-				}
-			}
-
-			b := &kv.Batch{}
-			b.Header.MaxSpanRequestKeys = tc.bound
-			for _, span := range tc.spans {
-				b.DelRange(span[0], span[1], true /* returnKeys */)
-			}
-			if err := db.Run(ctx, b); err != nil {
-				t.Fatal(err)
-			}
-
-			expSatisfied := make(map[int]struct{})
-			for _, exp := range tc.expSatisfied {
-				expSatisfied[exp] = struct{}{}
-			}
-			checkDelRangeResults(t, tc.spans, b.Results, tc.expResults, expSatisfied)
-		})
-	}
-}
-
 // Test that a bounded range delete request that gets terminated at a range
 // boundary uses the range boundary as the start key in the response ResumeSpan.
-func TestMultiRangeBoundedBatchDelRangeBoundary(t *testing.T) {
+func TestMultiRangeBoundedBatchScanBoundary(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	s, _ := startNoSplitMergeServer(t)
@@ -1028,7 +778,7 @@ func TestMultiRangeBoundedBatchDelRangeBoundary(t *testing.T) {
 
 	b := &kv.Batch{}
 	b.Header.MaxSpanRequestKeys = 3
-	b.DelRange("a", "c", true /* returnKeys */)
+	b.Scan("a", "c")
 	if err := db.Run(ctx, b); err != nil {
 		t.Fatal(err)
 	}
@@ -1041,7 +791,7 @@ func TestMultiRangeBoundedBatchDelRangeBoundary(t *testing.T) {
 
 	b = &kv.Batch{}
 	b.Header.MaxSpanRequestKeys = 1
-	b.DelRange("b", "c", true /* returnKeys */)
+	b.Scan("b", "c")
 	if err := db.Run(ctx, b); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_committer.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_committer.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/errors"
 )
 
 var parallelCommitsEnabled = settings.RegisterBoolSetting(
@@ -126,6 +127,10 @@ func (tc *txnCommitter) SendLocked(
 		return tc.wrapped.SendLocked(ctx, ba)
 	}
 	et := rArgs.(*roachpb.EndTxnRequest)
+
+	if err := tc.validateEndTxnBatch(ba); err != nil {
+		return nil, roachpb.NewError(err)
+	}
 
 	// Determine whether we can elide the EndTxn entirely. We can do so if the
 	// transaction is read-only, which we determine based on whether the EndTxn
@@ -253,6 +258,28 @@ func (tc *txnCommitter) SendLocked(
 	// transaction proto in the STAGING state.
 	br.Txn = cloneWithStatus(br.Txn, roachpb.COMMITTED)
 	return br, nil
+}
+
+// validateEndTxnBatch runs sanity checks on a commit or rollback request.
+func (tc *txnCommitter) validateEndTxnBatch(ba roachpb.BatchRequest) error {
+	// Check that we don't combine a limited DeleteRange with a commit. We cannot
+	// attempt to run such a batch as a 1PC because, if it gets split and thus
+	// doesn't run as a 1PC, resolving the intents will be very expensive.
+	// Resolving the intents would require scanning the whole key span, which
+	// might be much larger than the span of keys deleted before the limit was
+	// hit. Requests that actually run as 1PC don't have this problem, as they
+	// don't write and resolve intents. So, we make an exception and allow batches
+	// that set Require1PC - those are guaranteed to either execute as 1PC or
+	// fail. See also #37457.
+	if ba.Header.MaxSpanRequestKeys == 0 {
+		return nil
+	}
+	e, endTxn := ba.GetArg(roachpb.EndTxn)
+	_, delRange := ba.GetArg(roachpb.DeleteRange)
+	if delRange && endTxn && !e.(*roachpb.EndTxnRequest).Require1PC {
+		return errors.Errorf("possible 1PC batch cannot contain EndTxn without setting Require1PC; see #37457")
+	}
+	return nil
 }
 
 // sendLockedWithElidedEndTxn sends the provided batch without its EndTxn

--- a/pkg/roachpb/api.pb.go
+++ b/pkg/roachpb/api.pb.go
@@ -6220,7 +6220,7 @@ type Header struct {
 	// request types:
 	// - ScanRequest
 	// - ReverseScanRequest
-	// - DeleteRangeRequest
+	// - DeleteRangeRequest(*)
 	// - GetRequest
 	// - RevertRangeRequest
 	// - ResolveIntentRangeRequest
@@ -6229,6 +6229,9 @@ type Header struct {
 	// the limit has no effect on them:
 	// - QueryIntentRequest
 	// - EndTxnRequest
+	//
+	// [*] DeleteRangeRequests are generally not allowed to be batched together
+	// with a commit (i.e. 1PC), except if Require1PC is also set. See #37457.
 	//
 	// Forward requests and reverse requests cannot be mixed in the same batch if
 	// a limit is set. There doesn't seem to be a fundamental reason for this

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -1931,7 +1931,7 @@ message Header {
   // request types:
   // - ScanRequest
   // - ReverseScanRequest
-  // - DeleteRangeRequest
+  // - DeleteRangeRequest(*)
   // - GetRequest
   // - RevertRangeRequest
   // - ResolveIntentRangeRequest
@@ -1940,6 +1940,9 @@ message Header {
   // the limit has no effect on them:
   // - QueryIntentRequest
   // - EndTxnRequest
+  //
+  // [*] DeleteRangeRequests are generally not allowed to be batched together
+  // with a commit (i.e. 1PC), except if Require1PC is also set. See #37457.
   //
   // Forward requests and reverse requests cannot be mixed in the same batch if
   // a limit is set. There doesn't seem to be a fundamental reason for this


### PR DESCRIPTION
Such a request is dangerous because it can be very expensive. Because of
how our "intent span" collection works, for requests from the
EndTransaction batch, the intents they've laid down are inferred from
the request, not from the response (since there's no opportunity to get
a response before the intents need to be attached to the ET).  This has
potentially catastrophic consequences for DeleteRanges with limits in
the ET batch - the limit is ignored for the purposes of tracking the
intents.  If the batch happens to also have a BeginTransaction, and if
we manage to execute it as a 1PC (so, the DistSender doesn't need to
split it and the store manages to execute it as 1PC), then I think we're
fine - there's no intents to speak of and the ET is ignored.  If it's
not executed as a 1PC, however, the cleanup process is going to scan the
whole key span specified in the DeleteRange, with no respect for the
limit.

This patch has the DistSender check for and reject such requests.

Touches #37457

Release note: None