### PR TITLE
storage/cloud,backup: use delimiters when listing to find backup

### DIFF
--- a/pkg/blobs/local_storage.go
+++ b/pkg/blobs/local_storage.go
@@ -16,6 +16,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/blobs/blobspb"
@@ -178,6 +179,7 @@ func (l *LocalStorage) List(pattern string) ([]string, error) {
 	for _, file := range matches {
 		fileList = append(fileList, strings.TrimPrefix(file, l.externalIODir))
 	}
+	sort.Strings(fileList)
 	return fileList, nil
 }
 

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -807,7 +807,7 @@ func TestBackupRestoreAppend(t *testing.T) {
 				tc.Servers[0].InternalExecutor().(*sql.InternalExecutor), tc.Servers[0].DB())
 			require.NoError(t, err)
 			defer store.Close()
-			files, err := store.ListFiles(ctx, "*/*/*/"+backupManifestName)
+			files, err := store.ListFiles(ctx, "*/*/*/"+backupManifestName, cloud.NoDelimiter)
 			require.NoError(t, err)
 			full1 = strings.TrimSuffix(files[0], backupManifestName)
 			full2 = strings.TrimSuffix(files[1], backupManifestName)
@@ -816,7 +816,7 @@ func TestBackupRestoreAppend(t *testing.T) {
 			// each also check if we can restore to individual times captured with
 			// incremental backups that were appended to that backup.
 			subdirFiles, err := store.ListFiles(ctx, path.Join("foo", fmt.Sprintf("%s*",
-				specifiedSubdir), backupManifestName))
+				specifiedSubdir), backupManifestName), cloud.NoDelimiter)
 			require.NoError(t, err)
 			subdirFull1 = strings.TrimSuffix(strings.TrimPrefix(subdirFiles[0], "foo"),
 				backupManifestName)

--- a/pkg/ccl/backupccl/manifest_handling.go
+++ b/pkg/ccl/backupccl/manifest_handling.go
@@ -593,11 +593,13 @@ func getLocalityInfo(
 
 const incBackupSubdirGlob = "[0-9]*/[0-9]*.[0-9][0-9]/"
 
+const sstSubdir = "data"
+
 // findPriorBackupNames finds "appended" incremental backups, as done by
 // findPriorBackupLocations and appends the backup manifest file name to
 // the URI.
 func findPriorBackupNames(ctx context.Context, store cloud.ExternalStorage) ([]string, error) {
-	prev, err := store.ListFiles(ctx, incBackupSubdirGlob+backupManifestName)
+	prev, err := store.ListFiles(ctx, incBackupSubdirGlob+backupManifestName, sstSubdir)
 	if err != nil {
 		return nil, errors.Wrap(err, "reading previous backup layers")
 	}
@@ -612,7 +614,7 @@ func findPriorBackupNames(ctx context.Context, store cloud.ExternalStorage) ([]s
 // said list.
 func FindPriorBackupLocations(ctx context.Context, store cloud.ExternalStorage) ([]string, error) {
 	backupManifestSuffix := backupManifestName
-	prev, err := store.ListFiles(ctx, incBackupSubdirGlob+backupManifestSuffix)
+	prev, err := store.ListFiles(ctx, incBackupSubdirGlob+backupManifestSuffix, sstSubdir)
 	if err != nil {
 		return nil, errors.Wrap(err, "reading previous backup layers")
 	}
@@ -621,7 +623,7 @@ func FindPriorBackupLocations(ctx context.Context, store cloud.ExternalStorage) 
 		// 20.1 nodes and earlier will have an oldBackupManifestName so we check for
 		// that too.
 		backupManifestSuffix = backupOldManifestName
-		prev, err = store.ListFiles(ctx, incBackupSubdirGlob+backupManifestSuffix)
+		prev, err = store.ListFiles(ctx, incBackupSubdirGlob+backupManifestSuffix, sstSubdir)
 		if err != nil {
 			return nil, errors.Wrap(err, "reading previous backup layers")
 		}
@@ -1016,7 +1018,7 @@ func tempCheckpointFileNameForJob(jobID jobspb.JobID) string {
 func ListFullBackupsInCollection(
 	ctx context.Context, store cloud.ExternalStorage,
 ) ([]string, error) {
-	backupPaths, err := store.ListFiles(ctx, "/*/*/*/"+backupManifestName)
+	backupPaths, err := store.ListFiles(ctx, "/*/*/*/"+backupManifestName, sstSubdir)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -382,7 +382,7 @@ func importPlanHook(
 					if err != nil {
 						return err
 					}
-					expandedFiles, err := s.ListFiles(ctx, "")
+					expandedFiles, err := s.ListFiles(ctx, "", cloud.NoDelimiter)
 					if err != nil {
 						return err
 					}

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -5878,7 +5878,7 @@ func TestImportPgDumpIgnoredStmts(t *testing.T) {
 		// We expect there to be two log files since we have 13 unsupported statements.
 		dirName := fmt.Sprintf("import%d", importJobID)
 		checkFiles := func(expectedFileContent []string, logSubdir string) {
-			files, err := store.ListFiles(ctx, fmt.Sprintf("*/%s/*", logSubdir))
+			files, err := store.ListFiles(ctx, fmt.Sprintf("*/%s/*", logSubdir), cloud.NoDelimiter)
 			require.NoError(t, err)
 			for i, file := range files {
 				require.Equal(t, file, path.Join(dirName, logSubdir, fmt.Sprintf("%d.log", i)))

--- a/pkg/ccl/importccl/testutils_test.go
+++ b/pkg/ccl/importccl/testutils_test.go
@@ -277,7 +277,7 @@ func (es *generatorExternalStorage) Writer(
 	return nil, errors.New("unsupported")
 }
 
-func (es *generatorExternalStorage) ListFiles(ctx context.Context, _ string) ([]string, error) {
+func (es *generatorExternalStorage) ListFiles(ctx context.Context, _, _ string) ([]string, error) {
 	return nil, errors.New("unsupported")
 }
 

--- a/pkg/cli/userfile.go
+++ b/pkg/cli/userfile.go
@@ -192,7 +192,7 @@ func runUserFileGet(cmd *cobra.Command, args []string) error {
 	}
 	defer f.Close()
 
-	files, err := f.ListFiles(ctx, glob)
+	files, err := f.ListFiles(ctx, glob, cloud.NoDelimiter)
 	if err != nil {
 		return err
 	}
@@ -388,7 +388,7 @@ func listUserFile(ctx context.Context, conn *sqlConn, glob string) ([]string, er
 	}
 	defer f.Close()
 
-	return f.ListFiles(ctx, prefix)
+	return f.ListFiles(ctx, prefix, cloud.NoDelimiter)
 }
 
 func downloadUserfile(
@@ -453,7 +453,7 @@ func deleteUserFile(ctx context.Context, conn *sqlConn, glob string) ([]string, 
 		return nil, err
 	}
 
-	files, err := f.ListFiles(ctx, userfileParsedURL.Path)
+	files, err := f.ListFiles(ctx, userfileParsedURL.Path, cloud.NoDelimiter)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/cloud/azure/azure_storage.go
+++ b/pkg/storage/cloud/azure/azure_storage.go
@@ -175,7 +175,9 @@ func (s *azureStorage) ReadFileAt(
 	return reader, size, nil
 }
 
-func (s *azureStorage) ListFiles(ctx context.Context, patternSuffix string) ([]string, error) {
+func (s *azureStorage) ListFiles(
+	ctx context.Context, patternSuffix, delimiter string,
+) ([]string, error) {
 	pattern := s.prefix
 	if patternSuffix != "" {
 		if cloud.ContainsGlob(s.prefix) {
@@ -184,38 +186,66 @@ func (s *azureStorage) ListFiles(ctx context.Context, patternSuffix string) ([]s
 		pattern = path.Join(pattern, patternSuffix)
 	}
 	var fileList []string
-	response, err := s.container.ListBlobsFlatSegment(ctx,
-		azblob.Marker{},
-		azblob.ListBlobsSegmentOptions{Prefix: cloud.GetPrefixBeforeWildcard(s.prefix)},
-	)
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to list files for specified blob")
-	}
-
-	for _, blob := range response.Segment.BlobItems {
-		matches, err := path.Match(pattern, blob.Name)
+	acc := func(key string) error {
+		matches, err := path.Match(pattern, key)
 		if err != nil {
-			continue
+			return err
 		}
 		if matches {
 			if patternSuffix != "" {
-				if !strings.HasPrefix(blob.Name, s.prefix) {
+				if !strings.HasPrefix(key, s.prefix) {
 					// TODO(dt): return a nice rel-path instead of erroring out.
-					return nil, errors.New("pattern matched file outside of path")
+					return errors.New("pattern matched file outside of path")
 				}
-				fileList = append(fileList, strings.TrimPrefix(strings.TrimPrefix(blob.Name, s.prefix), "/"))
+				fileList = append(fileList, strings.TrimPrefix(strings.TrimPrefix(key, s.prefix), "/"))
 			} else {
 				azureURL := url.URL{
 					Scheme:   "azure",
 					Host:     strings.TrimPrefix(s.container.URL().Path, "/"),
-					Path:     blob.Name,
+					Path:     key,
 					RawQuery: azureQueryParams(s.conf),
 				}
 				fileList = append(fileList, azureURL.String())
 			}
 		}
+		return nil
 	}
 
+	if delimiter != cloud.NoDelimiter {
+		response, err := s.container.ListBlobsHierarchySegment(ctx,
+			azblob.Marker{},
+			delimiter,
+			azblob.ListBlobsSegmentOptions{Prefix: cloud.GetPrefixBeforeWildcard(s.prefix)},
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to list files for specified blob")
+		}
+
+		for _, blob := range response.Segment.BlobPrefixes {
+			if err := acc(blob.Name); err != nil {
+				return nil, err
+			}
+		}
+		for _, blob := range response.Segment.BlobItems {
+			if err := acc(blob.Name); err != nil {
+				return nil, err
+			}
+		}
+	} else {
+		response, err := s.container.ListBlobsFlatSegment(ctx,
+			azblob.Marker{},
+			azblob.ListBlobsSegmentOptions{Prefix: cloud.GetPrefixBeforeWildcard(s.prefix)},
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to list files for specified blob")
+		}
+
+		for _, blob := range response.Segment.BlobItems {
+			if err := acc(blob.Name); err != nil {
+				return nil, err
+			}
+		}
+	}
 	return fileList, nil
 }
 

--- a/pkg/storage/cloud/cloudtestutils/cloud_test_helpers.go
+++ b/pkg/storage/cloud/cloudtestutils/cloud_test_helpers.go
@@ -506,7 +506,7 @@ func CheckListFilesCanonical(
 		} {
 			t.Run(tc.name, func(t *testing.T) {
 				s := storeFromURI(ctx, t, tc.URI, clientFactory, user, ie, kvDB, testSettings)
-				filesList, err := s.ListFiles(ctx, tc.suffix)
+				filesList, err := s.ListFiles(ctx, tc.suffix, cloud.NoDelimiter)
 				require.NoError(t, err)
 				require.Equal(t, filesList, tc.resultList)
 			})

--- a/pkg/storage/cloud/httpsink/http_storage.go
+++ b/pkg/storage/cloud/httpsink/http_storage.go
@@ -182,7 +182,7 @@ func (h *httpStorage) Writer(ctx context.Context, basename string) (io.WriteClos
 	}), nil
 }
 
-func (h *httpStorage) ListFiles(_ context.Context, _ string) ([]string, error) {
+func (h *httpStorage) ListFiles(_ context.Context, _, _ string) ([]string, error) {
 	return nil, errors.Mark(errors.New("http storage does not support listing"), cloud.ErrListingUnsupported)
 }
 

--- a/pkg/storage/cloud/nodelocal/nodelocal_storage.go
+++ b/pkg/storage/cloud/nodelocal/nodelocal_storage.go
@@ -155,7 +155,9 @@ func (l *localFileStorage) ReadFileAt(
 	return reader, size, nil
 }
 
-func (l *localFileStorage) ListFiles(ctx context.Context, patternSuffix string) ([]string, error) {
+func (l *localFileStorage) ListFiles(
+	ctx context.Context, patternSuffix, delimiter string,
+) ([]string, error) {
 
 	pattern := l.base
 	if patternSuffix != "" {
@@ -165,13 +167,27 @@ func (l *localFileStorage) ListFiles(ctx context.Context, patternSuffix string) 
 		pattern = joinRelativePath(pattern, patternSuffix)
 	}
 
+	// TODO(dt): push delimiter down.
 	var fileList []string
 	matches, err := l.blobClient.List(ctx, pattern)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to match pattern provided")
 	}
 
+	constPrefix := cloud.GetPrefixBeforeWildcard(pattern)
+	var prevGroup string
+
 	for _, fileName := range matches {
+		if delimiter != "" {
+			suffix := strings.TrimPrefix(fileName, constPrefix)
+			if idx := strings.Index(suffix, delimiter); idx != -1 {
+				if prevGroup == suffix[0:idx] {
+					continue
+				}
+				prevGroup = suffix[0:idx]
+				fileName = constPrefix + suffix[0:idx]
+			}
+		}
 		if patternSuffix != "" {
 			if !strings.HasPrefix(fileName, l.base) {
 				// TODO(dt): return a nice rel-path instead of erroring out.

--- a/pkg/storage/cloud/nodelocal/nodelocal_storage_test.go
+++ b/pkg/storage/cloud/nodelocal/nodelocal_storage_test.go
@@ -67,10 +67,10 @@ func TestLocalIOLimits(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if _, err = e.ListFiles(ctx, ""); !testutils.IsError(err, expected) {
+		if _, err = e.ListFiles(ctx, "", cloud.NoDelimiter); !testutils.IsError(err, expected) {
 			t.Fatal(err)
 		}
-		if _, err = baseDir.ListFiles(ctx, dest); !testutils.IsError(err, expected) {
+		if _, err = baseDir.ListFiles(ctx, dest, cloud.NoDelimiter); !testutils.IsError(err, expected) {
 			t.Fatal(err)
 		}
 	}

--- a/pkg/storage/cloud/nullsink/nullsink_storage.go
+++ b/pkg/storage/cloud/nullsink/nullsink_storage.go
@@ -80,7 +80,7 @@ func (n *nullSinkStorage) Writer(_ context.Context, _ string) (io.WriteCloser, e
 	return nullWriter{}, nil
 }
 
-func (n *nullSinkStorage) ListFiles(_ context.Context, _ string) ([]string, error) {
+func (n *nullSinkStorage) ListFiles(_ context.Context, _, _ string) ([]string, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
This changes the ListFiles API of pkg/cloud to take an additional delimiter string.
This string is then passed to the various cloud storage providers in the different
implementations of ExternalStorage, so that all results that have a common prefix
before that delimiter are grouped into one result.

This in turn is utilized in BACKUP's listing of backup directories to find prior
backups, by using the string data as the delimiter, grouping all SST files, which
since #66094 are written in data/, into a single result.

Release note (bug fix): Improve how BACKUP finds prior incremental backups to avoid timing out in larger backup buckets.