### PR TITLE
Revert "teamcity-support: make github-post best effort"

### DIFF
--- a/build/teamcity-support.sh
+++ b/build/teamcity-support.sh
@@ -77,7 +77,7 @@ function run_json_test() {
       exit 1
     else
       tc_start_block "post issues"
-      (github-post < "${tmpfile}") || (echo "failed to post github issue")
+      github-post < "${tmpfile}"
       tc_end_block "post issues"
     fi
   fi


### PR DESCRIPTION
don't think it was the problem, reverting back to old behaviour as i think
CI should be red if we had no corresponding github issue for it.

----

This reverts commit 8bfad1d214ceeb5565dc26a70d8e78119c1c97da.

Release note: None