### PR TITLE
release-21.1: sql: allow computed columns to reference foreign key columns

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -350,21 +350,8 @@ CREATE TABLE y (
   a INT AS (3) STORED DEFAULT 4
 )
 
-# TODO(justin,bram): this should be allowed.
 statement ok
 CREATE TABLE x (a INT PRIMARY KEY)
-
-statement error computed columns cannot reference non-restricted FK columns
-CREATE TABLE y (
-  q INT REFERENCES x (a) ON UPDATE CASCADE,
-  r INT AS (q) STORED
-)
-
-statement error computed columns cannot reference non-restricted FK columns
-CREATE TABLE y (
-  q INT REFERENCES x (a) ON DELETE CASCADE,
-  r INT AS (q) STORED
-)
 
 statement error computed column "r" cannot reference a foreign key
 CREATE TABLE y (
@@ -381,6 +368,72 @@ CREATE TABLE y (
   a INT,
   r INT AS (1) STORED REFERENCES x
 )
+
+# Tests for computed columns that reference foreign key columns.
+subtest referencing_fks
+
+statement ok
+CREATE TABLE p (p INT PRIMARY KEY)
+
+statement ok
+CREATE TABLE c_update (
+  p_cascade INT REFERENCES p (p) ON UPDATE CASCADE,
+  p_default INT DEFAULT 0 REFERENCES p (p) ON UPDATE SET DEFAULT,
+  p_null INT REFERENCES p (p) ON UPDATE SET NULL,
+  c_cascade INT AS (p_cascade + 100) STORED,
+  c_default INT AS (p_default) STORED,
+  c_null INT AS (p_null + 100) STORED
+)
+
+statement ok
+CREATE TABLE c_delete_cascade (
+  p_cascade INT REFERENCES p (p) ON DELETE CASCADE,
+  c_cascade INT AS (p_cascade + 100) STORED
+)
+
+statement ok
+CREATE TABLE c_delete_set (
+  p_default INT DEFAULT 0 REFERENCES p (p) ON DELETE SET DEFAULT,
+  p_null INT REFERENCES p (p) ON DELETE SET NULL,
+  c_default INT AS (p_default) STORED,
+  c_null INT AS (p_null + 100) STORED
+)
+
+statement ok
+INSERT INTO p VALUES (0), (1), (2), (3)
+
+statement ok
+INSERT INTO c_update VALUES (1, 1, 1), (2, 2, 2)
+
+statement ok
+UPDATE p SET p = 10 WHERE p = 1
+
+query IIIIII colnames,rowsort
+SELECT * FROM c_update
+----
+p_cascade  p_default  p_null  c_cascade  c_default  c_null
+2          2          2       102        2          102
+10         0          NULL    110        0          NULL
+
+statement ok
+INSERT INTO c_delete_cascade VALUES (2), (3);
+INSERT INTO c_delete_set VALUES (2, 2), (3, 3);
+
+statement ok
+DELETE FROM p WHERE p = 3
+
+query II colnames,rowsort
+SELECT * FROM c_delete_cascade
+----
+p_cascade  c_cascade
+2          102
+
+query IIII colnames,rowsort
+SELECT * FROM c_delete_set
+----
+p_default  p_null  c_default  c_null
+0          NULL    0          NULL
+2          2       2          102
 
 # Regression test for #36036.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/virtual_columns
+++ b/pkg/sql/logictest/testdata/logic_test/virtual_columns
@@ -1093,6 +1093,72 @@ COMMIT;
 statement ok
 DROP TABLE t_ref;
 
+# Tests for virtual computed columns that reference foreign key columns.
+subtest referencing_fks
+
+statement ok
+CREATE TABLE p (p INT PRIMARY KEY)
+
+statement ok
+CREATE TABLE c_update (
+  p_cascade INT REFERENCES p (p) ON UPDATE CASCADE,
+  p_default INT DEFAULT 0 REFERENCES p (p) ON UPDATE SET DEFAULT,
+  p_null INT REFERENCES p (p) ON UPDATE SET NULL,
+  v_cascade INT AS (p_cascade + 100) VIRTUAL,
+  v_default INT AS (p_default) VIRTUAL,
+  v_null INT AS (p_null + 100) VIRTUAL
+)
+
+statement ok
+CREATE TABLE c_delete_cascade (
+  p_cascade INT REFERENCES p (p) ON DELETE CASCADE,
+  v_cascade INT AS (p_cascade + 100) VIRTUAL
+)
+
+statement ok
+CREATE TABLE c_delete_set (
+  p_default INT DEFAULT 0 REFERENCES p (p) ON DELETE SET DEFAULT,
+  p_null INT REFERENCES p (p) ON DELETE SET NULL,
+  v_default INT AS (p_default) VIRTUAL,
+  v_null INT AS (p_null + 100) VIRTUAL
+)
+
+statement ok
+INSERT INTO p VALUES (0), (1), (2), (3)
+
+statement ok
+INSERT INTO c_update VALUES (1, 1, 1), (2, 2, 2)
+
+statement ok
+UPDATE p SET p = 10 WHERE p = 1
+
+query IIIIII colnames,rowsort
+SELECT * FROM c_update
+----
+p_cascade  p_default  p_null  v_cascade  v_default  v_null
+2          2          2       102        2          102
+10         0          NULL    110        0          NULL
+
+statement ok
+INSERT INTO c_delete_cascade VALUES (2), (3);
+INSERT INTO c_delete_set VALUES (2, 2), (3, 3);
+
+statement ok
+DELETE FROM p WHERE p = 3
+
+query II colnames,rowsort
+SELECT * FROM c_delete_cascade
+----
+p_cascade  v_cascade
+2          102
+
+query IIII colnames,rowsort
+SELECT * FROM c_delete_set
+----
+p_default  p_null  v_default  v_null
+0          NULL    0          NULL
+2          2       2          102
+
 # Regression test for #63167. CREATE TABLE LIKE should copy VIRTUAL columns as
 # VIRTUAL, not STORED.
 statement ok

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-delete-cascade
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-delete-cascade
@@ -995,3 +995,82 @@ root
                 └── projections
                      ├── i:11 > 0 [as=partial_index_del1:13]
                      └── child_partial.p:10 > 0 [as=partial_index_del2:14]
+
+# Test cascade to a child with a virtual column that references the FK.
+exec-ddl
+CREATE TABLE parent_virt (p INT PRIMARY KEY)
+----
+
+exec-ddl
+CREATE TABLE child_virt (
+  c INT PRIMARY KEY,
+  p INT REFERENCES parent_virt(p) ON DELETE CASCADE,
+  v INT AS (p) VIRTUAL
+)
+----
+
+# Fast path.
+build-cascades
+DELETE FROM parent_virt WHERE p > 1
+----
+root
+ ├── delete parent_virt
+ │    ├── columns: <none>
+ │    ├── fetch columns: p:3
+ │    ├── cascades
+ │    │    └── fk_p_ref_parent_virt
+ │    └── select
+ │         ├── columns: p:3!null crdb_internal_mvcc_timestamp:4
+ │         ├── scan parent_virt
+ │         │    └── columns: p:3!null crdb_internal_mvcc_timestamp:4
+ │         └── filters
+ │              └── p:3 > 1
+ └── cascade
+      └── delete child_virt
+           ├── columns: <none>
+           ├── fetch columns: c:9 child_virt.p:10
+           └── select
+                ├── columns: c:9!null child_virt.p:10!null
+                ├── scan child_virt
+                │    ├── columns: c:9!null child_virt.p:10
+                │    └── computed column expressions
+                │         └── v:11
+                │              └── child_virt.p:10
+                └── filters
+                     ├── child_virt.p:10 > 1
+                     └── child_virt.p:10 IS DISTINCT FROM CAST(NULL AS INT8)
+
+# No fast path.
+build-cascades
+DELETE FROM parent_virt WHERE p > 1 AND random() < 0.5
+----
+root
+ ├── delete parent_virt
+ │    ├── columns: <none>
+ │    ├── fetch columns: p:3
+ │    ├── input binding: &1
+ │    ├── cascades
+ │    │    └── fk_p_ref_parent_virt
+ │    └── select
+ │         ├── columns: p:3!null crdb_internal_mvcc_timestamp:4
+ │         ├── scan parent_virt
+ │         │    └── columns: p:3!null crdb_internal_mvcc_timestamp:4
+ │         └── filters
+ │              └── (p:3 > 1) AND (random() < 0.5)
+ └── cascade
+      └── delete child_virt
+           ├── columns: <none>
+           ├── fetch columns: c:9 child_virt.p:10
+           └── semi-join (hash)
+                ├── columns: c:9!null child_virt.p:10
+                ├── scan child_virt
+                │    ├── columns: c:9!null child_virt.p:10
+                │    └── computed column expressions
+                │         └── v:11
+                │              └── child_virt.p:10
+                ├── with-scan &1
+                │    ├── columns: p:13!null
+                │    └── mapping:
+                │         └──  parent_virt.p:3 => p:13
+                └── filters
+                     └── child_virt.p:10 = p:13

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-delete-set-default
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-delete-set-default
@@ -278,3 +278,74 @@ root
                           │    └── columns: parent_partial.p:19!null
                           └── filters
                                └── p:18 = parent_partial.p:19
+
+# Test cascades to a child with a virtual column that references the FK.
+exec-ddl
+CREATE TABLE parent_virt (p INT PRIMARY KEY)
+----
+
+exec-ddl
+CREATE TABLE child_virt (
+  c INT PRIMARY KEY,
+  p INT DEFAULT 0 REFERENCES parent_virt(p) ON DELETE SET DEFAULT,
+  v INT AS (p) VIRTUAL
+)
+----
+
+build-cascades
+DELETE FROM parent_virt WHERE p > 1
+----
+root
+ ├── delete parent_virt
+ │    ├── columns: <none>
+ │    ├── fetch columns: p:3
+ │    ├── input binding: &1
+ │    ├── cascades
+ │    │    └── fk_p_ref_parent_virt
+ │    └── select
+ │         ├── columns: p:3!null crdb_internal_mvcc_timestamp:4
+ │         ├── scan parent_virt
+ │         │    └── columns: p:3!null crdb_internal_mvcc_timestamp:4
+ │         └── filters
+ │              └── p:3 > 1
+ └── cascade
+      └── update child_virt
+           ├── columns: <none>
+           ├── fetch columns: c:9 child_virt.p:10 v:11
+           ├── update-mapping:
+           │    ├── p_new:14 => child_virt.p:6
+           │    └── p_new:14 => v:7
+           ├── input binding: &2
+           ├── project
+           │    ├── columns: p_new:14!null c:9!null child_virt.p:10 v:11
+           │    ├── semi-join (hash)
+           │    │    ├── columns: c:9!null child_virt.p:10 v:11
+           │    │    ├── project
+           │    │    │    ├── columns: v:11 c:9!null child_virt.p:10
+           │    │    │    ├── scan child_virt
+           │    │    │    │    ├── columns: c:9!null child_virt.p:10
+           │    │    │    │    └── computed column expressions
+           │    │    │    │         └── v:11
+           │    │    │    │              └── child_virt.p:10
+           │    │    │    └── projections
+           │    │    │         └── child_virt.p:10 [as=v:11]
+           │    │    ├── with-scan &1
+           │    │    │    ├── columns: p:13!null
+           │    │    │    └── mapping:
+           │    │    │         └──  parent_virt.p:3 => p:13
+           │    │    └── filters
+           │    │         └── child_virt.p:10 = p:13
+           │    └── projections
+           │         └── 0 [as=p_new:14]
+           └── f-k-checks
+                └── f-k-checks-item: child_virt(p) -> parent_virt(p)
+                     └── anti-join (hash)
+                          ├── columns: p:15!null
+                          ├── with-scan &2
+                          │    ├── columns: p:15!null
+                          │    └── mapping:
+                          │         └──  p_new:14 => p:15
+                          ├── scan parent_virt
+                          │    └── columns: parent_virt.p:16!null
+                          └── filters
+                               └── p:15 = parent_virt.p:16

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-delete-set-null
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-delete-set-null
@@ -183,3 +183,61 @@ root
                      ├── i:11 > 0 [as=partial_index_put1:15]
                      ├── p_new:14 > 0 [as=partial_index_put2:16]
                      └── child_partial.p:10 > 0 [as=partial_index_del2:17]
+
+# Test cascades to a child with a virtual column that references the FK.
+exec-ddl
+CREATE TABLE parent_virt (p INT PRIMARY KEY)
+----
+
+exec-ddl
+CREATE TABLE child_virt (
+  c INT PRIMARY KEY,
+  p INT REFERENCES parent_virt(p) ON DELETE SET NULL,
+  v INT AS (p) VIRTUAL
+)
+----
+
+build-cascades
+DELETE FROM parent_virt WHERE p > 1
+----
+root
+ ├── delete parent_virt
+ │    ├── columns: <none>
+ │    ├── fetch columns: p:3
+ │    ├── input binding: &1
+ │    ├── cascades
+ │    │    └── fk_p_ref_parent_virt
+ │    └── select
+ │         ├── columns: p:3!null crdb_internal_mvcc_timestamp:4
+ │         ├── scan parent_virt
+ │         │    └── columns: p:3!null crdb_internal_mvcc_timestamp:4
+ │         └── filters
+ │              └── p:3 > 1
+ └── cascade
+      └── update child_virt
+           ├── columns: <none>
+           ├── fetch columns: c:9 child_virt.p:10 v:11
+           ├── update-mapping:
+           │    ├── p_new:14 => child_virt.p:6
+           │    └── p_new:14 => v:7
+           └── project
+                ├── columns: p_new:14 c:9!null child_virt.p:10 v:11
+                ├── semi-join (hash)
+                │    ├── columns: c:9!null child_virt.p:10 v:11
+                │    ├── project
+                │    │    ├── columns: v:11 c:9!null child_virt.p:10
+                │    │    ├── scan child_virt
+                │    │    │    ├── columns: c:9!null child_virt.p:10
+                │    │    │    └── computed column expressions
+                │    │    │         └── v:11
+                │    │    │              └── child_virt.p:10
+                │    │    └── projections
+                │    │         └── child_virt.p:10 [as=v:11]
+                │    ├── with-scan &1
+                │    │    ├── columns: p:13!null
+                │    │    └── mapping:
+                │    │         └──  parent_virt.p:3 => p:13
+                │    └── filters
+                │         └── child_virt.p:10 = p:13
+                └── projections
+                     └── NULL::INT8 [as=p_new:14]

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-update-cascade
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-update-cascade
@@ -1110,3 +1110,81 @@ root
                           │    └── columns: parent_check_ambig.p:19!null
                           └── filters
                                └── p_new:18 = parent_check_ambig.p:19
+
+# Test cascade to a child with a virtual column that references the FK.
+exec-ddl
+CREATE TABLE parent_virt (p INT PRIMARY KEY)
+----
+
+exec-ddl
+CREATE TABLE child_virt (
+  c INT PRIMARY KEY,
+  p INT REFERENCES parent_virt(p) ON UPDATE CASCADE,
+  v INT AS (p) VIRTUAL
+)
+----
+
+build-cascades
+UPDATE parent_virt SET p = p * 10 WHERE p > 1
+----
+root
+ ├── update parent_virt
+ │    ├── columns: <none>
+ │    ├── fetch columns: p:3
+ │    ├── update-mapping:
+ │    │    └── p_new:5 => p:1
+ │    ├── input binding: &1
+ │    ├── cascades
+ │    │    └── fk_p_ref_parent_virt
+ │    └── project
+ │         ├── columns: p_new:5!null p:3!null crdb_internal_mvcc_timestamp:4
+ │         ├── select
+ │         │    ├── columns: p:3!null crdb_internal_mvcc_timestamp:4
+ │         │    ├── scan parent_virt
+ │         │    │    └── columns: p:3!null crdb_internal_mvcc_timestamp:4
+ │         │    └── filters
+ │         │         └── p:3 > 1
+ │         └── projections
+ │              └── p:3 * 10 [as=p_new:5]
+ └── cascade
+      └── update child_virt
+           ├── columns: <none>
+           ├── fetch columns: c:10 child_virt.p:11 v:12
+           ├── update-mapping:
+           │    ├── p_new:15 => child_virt.p:7
+           │    └── p_new:15 => v:8
+           ├── input binding: &2
+           ├── inner-join (hash)
+           │    ├── columns: c:10!null child_virt.p:11!null v:12 p:14!null p_new:15!null
+           │    ├── project
+           │    │    ├── columns: v:12 c:10!null child_virt.p:11
+           │    │    ├── scan child_virt
+           │    │    │    ├── columns: c:10!null child_virt.p:11
+           │    │    │    └── computed column expressions
+           │    │    │         └── v:12
+           │    │    │              └── child_virt.p:11
+           │    │    └── projections
+           │    │         └── child_virt.p:11 [as=v:12]
+           │    ├── select
+           │    │    ├── columns: p:14!null p_new:15!null
+           │    │    ├── with-scan &1
+           │    │    │    ├── columns: p:14!null p_new:15!null
+           │    │    │    └── mapping:
+           │    │    │         ├──  parent_virt.p:3 => p:14
+           │    │    │         └──  p_new:5 => p_new:15
+           │    │    └── filters
+           │    │         └── p:14 IS DISTINCT FROM p_new:15
+           │    └── filters
+           │         └── child_virt.p:11 = p:14
+           └── f-k-checks
+                └── f-k-checks-item: child_virt(p) -> parent_virt(p)
+                     └── anti-join (hash)
+                          ├── columns: p:16!null
+                          ├── with-scan &2
+                          │    ├── columns: p:16!null
+                          │    └── mapping:
+                          │         └──  p_new:15 => p:16
+                          ├── scan parent_virt
+                          │    └── columns: parent_virt.p:17!null
+                          └── filters
+                               └── p:16 = parent_virt.p:17

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-update-set-default
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-update-set-default
@@ -851,3 +851,85 @@ root
                           │    └── columns: parent_partial.p:21!null
                           └── filters
                                └── p:20 = parent_partial.p:21
+
+# Test cascade to a child with a virtual column that references the FK.
+exec-ddl
+CREATE TABLE parent_virt (p INT PRIMARY KEY)
+----
+
+exec-ddl
+CREATE TABLE child_virt (
+  c INT PRIMARY KEY,
+  p INT DEFAULT 0 NOT NULL REFERENCES parent_virt(p) ON UPDATE SET DEFAULT,
+  v INT AS (p) VIRTUAL
+)
+----
+
+build-cascades
+UPDATE parent_virt SET p = p * 10 WHERE p > 1
+----
+root
+ ├── update parent_virt
+ │    ├── columns: <none>
+ │    ├── fetch columns: p:3
+ │    ├── update-mapping:
+ │    │    └── p_new:5 => p:1
+ │    ├── input binding: &1
+ │    ├── cascades
+ │    │    └── fk_p_ref_parent_virt
+ │    └── project
+ │         ├── columns: p_new:5!null p:3!null crdb_internal_mvcc_timestamp:4
+ │         ├── select
+ │         │    ├── columns: p:3!null crdb_internal_mvcc_timestamp:4
+ │         │    ├── scan parent_virt
+ │         │    │    └── columns: p:3!null crdb_internal_mvcc_timestamp:4
+ │         │    └── filters
+ │         │         └── p:3 > 1
+ │         └── projections
+ │              └── p:3 * 10 [as=p_new:5]
+ └── cascade
+      └── update child_virt
+           ├── columns: <none>
+           ├── fetch columns: c:10 child_virt.p:11 v:12
+           ├── update-mapping:
+           │    ├── p_new:16 => child_virt.p:7
+           │    └── p_new:16 => v:8
+           ├── input binding: &2
+           ├── project
+           │    ├── columns: p_new:16!null c:10!null child_virt.p:11!null v:12!null p:14!null p_new:15!null
+           │    ├── inner-join (hash)
+           │    │    ├── columns: c:10!null child_virt.p:11!null v:12!null p:14!null p_new:15!null
+           │    │    ├── project
+           │    │    │    ├── columns: v:12!null c:10!null child_virt.p:11!null
+           │    │    │    ├── scan child_virt
+           │    │    │    │    ├── columns: c:10!null child_virt.p:11!null
+           │    │    │    │    └── computed column expressions
+           │    │    │    │         └── v:12
+           │    │    │    │              └── child_virt.p:11
+           │    │    │    └── projections
+           │    │    │         └── child_virt.p:11 [as=v:12]
+           │    │    ├── select
+           │    │    │    ├── columns: p:14!null p_new:15!null
+           │    │    │    ├── with-scan &1
+           │    │    │    │    ├── columns: p:14!null p_new:15!null
+           │    │    │    │    └── mapping:
+           │    │    │    │         ├──  parent_virt.p:3 => p:14
+           │    │    │    │         └──  p_new:5 => p_new:15
+           │    │    │    └── filters
+           │    │    │         └── p:14 IS DISTINCT FROM p_new:15
+           │    │    └── filters
+           │    │         └── child_virt.p:11 = p:14
+           │    └── projections
+           │         └── 0 [as=p_new:16]
+           └── f-k-checks
+                └── f-k-checks-item: child_virt(p) -> parent_virt(p)
+                     └── anti-join (hash)
+                          ├── columns: p:17!null
+                          ├── with-scan &2
+                          │    ├── columns: p:17!null
+                          │    └── mapping:
+                          │         └──  p_new:16 => p:17
+                          ├── scan parent_virt
+                          │    └── columns: parent_virt.p:18!null
+                          └── filters
+                               └── p:17 = parent_virt.p:18

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-update-set-null
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-update-set-null
@@ -667,3 +667,72 @@ root
                      ├── i:12 > 0 [as=partial_index_put1:17]
                      ├── p_new:16 > 0 [as=partial_index_put2:18]
                      └── child_partial.p:11 > 0 [as=partial_index_del2:19]
+
+# Test cascade to a child with a virtual column that references the FK.
+exec-ddl
+CREATE TABLE parent_virt (p INT PRIMARY KEY)
+----
+
+exec-ddl
+CREATE TABLE child_virt (
+  c INT PRIMARY KEY,
+  p INT NOT NULL REFERENCES parent_virt(p) ON UPDATE SET NULL,
+  v INT AS (p) VIRTUAL
+)
+----
+
+build-cascades
+UPDATE parent_virt SET p = p * 10 WHERE p > 1
+----
+root
+ ├── update parent_virt
+ │    ├── columns: <none>
+ │    ├── fetch columns: p:3
+ │    ├── update-mapping:
+ │    │    └── p_new:5 => p:1
+ │    ├── input binding: &1
+ │    ├── cascades
+ │    │    └── fk_p_ref_parent_virt
+ │    └── project
+ │         ├── columns: p_new:5!null p:3!null crdb_internal_mvcc_timestamp:4
+ │         ├── select
+ │         │    ├── columns: p:3!null crdb_internal_mvcc_timestamp:4
+ │         │    ├── scan parent_virt
+ │         │    │    └── columns: p:3!null crdb_internal_mvcc_timestamp:4
+ │         │    └── filters
+ │         │         └── p:3 > 1
+ │         └── projections
+ │              └── p:3 * 10 [as=p_new:5]
+ └── cascade
+      └── update child_virt
+           ├── columns: <none>
+           ├── fetch columns: c:10 child_virt.p:11 v:12
+           ├── update-mapping:
+           │    ├── p_new:16 => child_virt.p:7
+           │    └── p_new:16 => v:8
+           └── project
+                ├── columns: p_new:16 c:10!null child_virt.p:11!null v:12!null p:14!null p_new:15!null
+                ├── inner-join (hash)
+                │    ├── columns: c:10!null child_virt.p:11!null v:12!null p:14!null p_new:15!null
+                │    ├── project
+                │    │    ├── columns: v:12!null c:10!null child_virt.p:11!null
+                │    │    ├── scan child_virt
+                │    │    │    ├── columns: c:10!null child_virt.p:11!null
+                │    │    │    └── computed column expressions
+                │    │    │         └── v:12
+                │    │    │              └── child_virt.p:11
+                │    │    └── projections
+                │    │         └── child_virt.p:11 [as=v:12]
+                │    ├── select
+                │    │    ├── columns: p:14!null p_new:15!null
+                │    │    ├── with-scan &1
+                │    │    │    ├── columns: p:14!null p_new:15!null
+                │    │    │    └── mapping:
+                │    │    │         ├──  parent_virt.p:3 => p:14
+                │    │    │         └──  p_new:5 => p_new:15
+                │    │    └── filters
+                │    │         └── p:14 IS DISTINCT FROM p_new:15
+                │    └── filters
+                │         └── child_virt.p:11 = p:14
+                └── projections
+                     └── NULL::INT8 [as=p_new:16]


### PR DESCRIPTION
Backport 1/1 commits from #65690.

/cc @cockroachdb/release

---

This commit lifts a restriction that prevented creating computed columns
with expressions that referenced foreign key columns. This limitation
has existed since computed columns were first added in #21586. Removing
it improves the user experience, as it would come as a surprise to many.

This will also reduce the complexity required to implement
expression-based indexes. Enforcing the restriction would require
validating and serializing computed column expressions both (1) before
and (2) after indexes are added to a new table descriptor. (1) would be
required to reuse existing virtual computed columns for expression-based
indexes. String equality of serialized expressions is used to find
matching computed columns. (2) would be required to uphold this
restriction because enforcement requires that FKs and their associated
indexes have been added to the table descriptor. With the restriction
removed, only (1) is required.

Some minor changes were required in order to support virtual computed
column expressions that reference foreign key columns. The execution
engine requires fetch columns to be a superset of update columns.
Virtual columns are included in update columns in order to update
secondary indexes on those columns. Therefore, any cascade that updates
a child table must fetch virtual computed columns.

Release note (sql change): Creating STORED or VIRTUAL computed columns
with expressions that reference foreign key columns is now allowed.
