### PR TITLE
release-20.2: sql: allow computed columns to reference foreign key columns

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -340,21 +340,8 @@ CREATE TABLE y (
   a INT AS (3) STORED DEFAULT 4
 )
 
-# TODO(justin,bram): this should be allowed.
 statement ok
 CREATE TABLE x (a INT PRIMARY KEY)
-
-statement error computed columns cannot reference non-restricted FK columns
-CREATE TABLE y (
-  q INT REFERENCES x (a) ON UPDATE CASCADE,
-  r INT AS (q) STORED
-)
-
-statement error computed columns cannot reference non-restricted FK columns
-CREATE TABLE y (
-  q INT REFERENCES x (a) ON DELETE CASCADE,
-  r INT AS (q) STORED
-)
 
 statement error computed column "r" cannot be a foreign key reference
 CREATE TABLE y (
@@ -371,6 +358,72 @@ CREATE TABLE y (
   a INT,
   r INT AS (1) STORED REFERENCES x
 )
+
+# Tests for computed columns that reference foreign key columns.
+subtest referencing_fks
+
+statement ok
+CREATE TABLE p (p INT PRIMARY KEY)
+
+statement ok
+CREATE TABLE c_update (
+  p_cascade INT REFERENCES p (p) ON UPDATE CASCADE,
+  p_default INT DEFAULT 0 REFERENCES p (p) ON UPDATE SET DEFAULT,
+  p_null INT REFERENCES p (p) ON UPDATE SET NULL,
+  c_cascade INT AS (p_cascade + 100) STORED,
+  c_default INT AS (p_default) STORED,
+  c_null INT AS (p_null + 100) STORED
+)
+
+statement ok
+CREATE TABLE c_delete_cascade (
+  p_cascade INT REFERENCES p (p) ON DELETE CASCADE,
+  c_cascade INT AS (p_cascade + 100) STORED
+)
+
+statement ok
+CREATE TABLE c_delete_set (
+  p_default INT DEFAULT 0 REFERENCES p (p) ON DELETE SET DEFAULT,
+  p_null INT REFERENCES p (p) ON DELETE SET NULL,
+  c_default INT AS (p_default) STORED,
+  c_null INT AS (p_null + 100) STORED
+)
+
+statement ok
+INSERT INTO p VALUES (0), (1), (2), (3)
+
+statement ok
+INSERT INTO c_update VALUES (1, 1, 1), (2, 2, 2)
+
+statement ok
+UPDATE p SET p = 10 WHERE p = 1
+
+query IIIIII colnames,rowsort
+SELECT * FROM c_update
+----
+p_cascade  p_default  p_null  c_cascade  c_default  c_null
+2          2          2       102        2          102
+10         0          NULL    110        0          NULL
+
+statement ok
+INSERT INTO c_delete_cascade VALUES (2), (3);
+INSERT INTO c_delete_set VALUES (2, 2), (3, 3);
+
+statement ok
+DELETE FROM p WHERE p = 3
+
+query II colnames,rowsort
+SELECT * FROM c_delete_cascade
+----
+p_cascade  c_cascade
+2          102
+
+query IIII colnames,rowsort
+SELECT * FROM c_delete_set
+----
+p_default  p_null  c_default  c_null
+0          NULL    0          NULL
+2          2       2          102
 
 # Regression test for #36036.
 statement ok

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-update-cascade
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-update-cascade
@@ -79,7 +79,7 @@ CREATE TABLE child_multi (
   c INT PRIMARY KEY,
   p INT, q INT,
   UNIQUE (c, q),
-  CONSTRAINT fk FOREIGN KEY (p, q) REFERENCES parent_multi(p, q) ON UPDATE CASCADE 
+  CONSTRAINT fk FOREIGN KEY (p, q) REFERENCES parent_multi(p, q) ON UPDATE CASCADE
 )
 ----
 

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-update-set-default
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-update-set-default
@@ -84,7 +84,7 @@ CREATE TABLE child_multi (
   p INT DEFAULT 0,
   q INT DEFAULT 1,
   UNIQUE (c, q),
-  CONSTRAINT fk FOREIGN KEY (p, q) REFERENCES parent_multi(p, q) ON UPDATE SET DEFAULT 
+  CONSTRAINT fk FOREIGN KEY (p, q) REFERENCES parent_multi(p, q) ON UPDATE SET DEFAULT
 )
 ----
 

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-update-set-null
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-update-set-null
@@ -70,7 +70,7 @@ CREATE TABLE child_multi (
   c INT PRIMARY KEY,
   p INT, q INT,
   UNIQUE (c, q),
-  CONSTRAINT fk FOREIGN KEY (p, q) REFERENCES parent_multi(p, q) ON UPDATE SET NULL 
+  CONSTRAINT fk FOREIGN KEY (p, q) REFERENCES parent_multi(p, q) ON UPDATE SET NULL
 )
 ----
 

--- a/pkg/sql/schemaexpr/computed_column.go
+++ b/pkg/sql/schemaexpr/computed_column.go
@@ -79,33 +79,6 @@ func (v *ComputedColumnValidator) Validate(d *tree.ColumnTableDef) error {
 		return err
 	}
 
-	// TODO(justin,bram): allow depending on columns like this. We disallow it
-	// for now because cascading changes must hook into the computed column
-	// update path.
-	if err := v.desc.ForeachOutboundFK(func(fk *descpb.ForeignKeyConstraint) error {
-		for _, id := range fk.OriginColumnIDs {
-			if !depColIDs.Contains(id) {
-				// We don't depend on this column.
-				return nil
-			}
-			for _, action := range []descpb.ForeignKeyReference_Action{
-				fk.OnDelete,
-				fk.OnUpdate,
-			} {
-				switch action {
-				case descpb.ForeignKeyReference_CASCADE,
-					descpb.ForeignKeyReference_SET_NULL,
-					descpb.ForeignKeyReference_SET_DEFAULT:
-					return pgerror.New(pgcode.InvalidTableDefinition,
-						"computed columns cannot reference non-restricted FK columns")
-				}
-			}
-		}
-		return nil
-	}); err != nil {
-		return err
-	}
-
 	// Resolve the type of the computed column expression.
 	defType, err := tree.ResolveType(v.ctx, d.Type, v.semaCtx.GetTypeResolver())
 	if err != nil {


### PR DESCRIPTION
Backport 1/1 commits from #65690.

/cc @cockroachdb/release

---

This commit lifts a restriction that prevented creating computed columns
with expressions that referenced foreign key columns. This limitation
has existed since computed columns were first added in #21586. Removing
it improves the user experience, as it would come as a surprise to many.

This will also reduce the complexity required to implement
expression-based indexes. Enforcing the restriction would require
validating and serializing computed column expressions both (1) before
and (2) after indexes are added to a new table descriptor. (1) would be
required to reuse existing virtual computed columns for expression-based
indexes. String equality of serialized expressions is used to find
matching computed columns. (2) would be required to uphold this
restriction because enforcement requires that FKs and their associated
indexes have been added to the table descriptor. With the restriction
removed, only (1) is required.

Some minor changes were required in order to support virtual computed
column expressions that reference foreign key columns. The execution
engine requires fetch columns to be a superset of update columns.
Virtual columns are included in update columns in order to update
secondary indexes on those columns. Therefore, any cascade that updates
a child table must fetch virtual computed columns.

Release note (sql change): Creating STORED computed columns with
expressions that reference foreign key columns is now allowed.
