### PR TITLE
release-20.2: fix intra-query memory leaks

### DIFF
--- a/pkg/sql/colcontainer/diskqueue.go
+++ b/pkg/sql/colcontainer/diskqueue.go
@@ -394,6 +394,13 @@ func (d *diskQueue) closeFileDeserializer() error {
 }
 
 func (d *diskQueue) Close(ctx context.Context) error {
+	defer func() {
+		// Zero out the structure completely upon return. If users of this diskQueue
+		// retain a pointer to it, and we don't remove all references to large
+		// backing slices (various scratch spaces in this struct and children),
+		// we'll be "leaking memory" until users remove their references.
+		*d = diskQueue{}
+	}()
 	if d.serializer != nil {
 		if err := d.writeFooterAndFlush(ctx); err != nil {
 			return err

--- a/pkg/sql/row/kv_fetcher.go
+++ b/pkg/sql/row/kv_fetcher.go
@@ -106,6 +106,11 @@ func (f *KVFetcher) NextKV(
 			if err != nil {
 				return false, kv, false, err
 			}
+			// If we're finished decoding the batch response, nil our reference to it
+			// so that the garbage collector can reclaim the backing memory.
+			if len(f.batchResponse) == 0 {
+				f.batchResponse = nil
+			}
 			return true, roachpb.KeyValue{
 				Key: key,
 				Value: roachpb.Value{


### PR DESCRIPTION
Backport:
  * 2/2 commits from "row: fix intra-query memory leaks in kvFetcher and txnKVFetcher" (#65881)
  * 1/1 commits from "colcontainer: fix intra-query memory leak" (#66106)

Please see individual PRs for details.

/cc @cockroachdb/release
