### PR TITLE
release-20.1: row: fix intra-query memory leaks in kvFetcher and txnKVFetcher

### DIFF
--- a/pkg/sql/row/kv_batch_fetcher.go
+++ b/pkg/sql/row/kv_batch_fetcher.go
@@ -360,35 +360,42 @@ func (f *txnKVFetcher) fetch(ctx context.Context) error {
 	return nil
 }
 
+// popBatch returns the 0th byte slice in a slice of byte slices, as well as
+// the rest of the slice of the byte slices. It nils the pointer to the 0th
+// element before reslicing the outer slice.
+func popBatch(batches [][]byte) (batch []byte, remainingBatches [][]byte) {
+	batch, remainingBatches = batches[0], batches[1:]
+	batches[0] = nil
+	return batch, remainingBatches
+}
+
 // nextBatch returns the next batch of key/value pairs. If there are none
 // available, a fetch is initiated. When there are no more keys, ok is false.
 // origSpan returns the span that batch was fetched from, and bounds all of the
 // keys returned.
 func (f *txnKVFetcher) nextBatch(
 	ctx context.Context,
-) (ok bool, kvs []roachpb.KeyValue, batchResponse []byte, origSpan roachpb.Span, err error) {
+) (ok bool, kvs []roachpb.KeyValue, batchResp []byte, origSpan roachpb.Span, err error) {
 	if len(f.remainingBatches) > 0 {
-		batch := f.remainingBatches[0]
-		f.remainingBatches = f.remainingBatches[1:]
-		return true, nil, batch, f.origSpan, nil
+		batchResp, f.remainingBatches = popBatch(f.remainingBatches)
+		return true, nil, batchResp, f.origSpan, nil
 	}
 	if len(f.responses) > 0 {
 		reply := f.responses[0].GetInner()
+		f.responses[0] = roachpb.ResponseUnion{}
 		f.responses = f.responses[1:]
 		origSpan := f.requestSpans[0]
+		f.requestSpans[0] = roachpb.Span{}
 		f.requestSpans = f.requestSpans[1:]
-		var batchResp []byte
 		switch t := reply.(type) {
 		case *roachpb.ScanResponse:
 			if len(t.BatchResponses) > 0 {
-				batchResp = t.BatchResponses[0]
-				f.remainingBatches = t.BatchResponses[1:]
+				batchResp, f.remainingBatches = popBatch(t.BatchResponses)
 			}
 			return true, t.Rows, batchResp, origSpan, nil
 		case *roachpb.ReverseScanResponse:
 			if len(t.BatchResponses) > 0 {
-				batchResp = t.BatchResponses[0]
-				f.remainingBatches = t.BatchResponses[1:]
+				batchResp, f.remainingBatches = popBatch(t.BatchResponses)
 			}
 			return true, t.Rows, batchResp, origSpan, nil
 		}

--- a/pkg/sql/row/kv_fetcher.go
+++ b/pkg/sql/row/kv_fetcher.go
@@ -76,6 +76,11 @@ func (f *KVFetcher) NextKV(
 			if err != nil {
 				return false, kv, false, err
 			}
+			// If we're finished decoding the batch response, nil our reference to it
+			// so that the garbage collector can reclaim the backing memory.
+			if len(f.batchResponse) == 0 {
+				f.batchResponse = nil
+			}
 			return true, roachpb.KeyValue{
 				Key: key,
 				Value: roachpb.Value{


### PR DESCRIPTION
Backport 2/2 commits from #65881.

/cc @cockroachdb/release

---

Updates #64906. The critical change is the first patch, the kvfetcher one.
The kvbatchfetcher one is theoretically good but I haven't found it to make
as large of a difference as the first patch.

With the first patch applied alone, I can no longer cause OOM conditions with
1024 concurrent TPCH query 18s sent at a single machine, which is a major
improvement. Prior to that patch, such a workload would overwhelm the machine
within 1-2 minutes.

This bug was found with help of the new tooling I've been adding to `viewcore`,
mostly the new `pprof` output format, the existing html object explorer, and the
new type explorer. You can see these updates at
https://github.com/jordanlewis/debug/tree/crl-stuff.

----

The KVFetcher is the piece of code that does the first level of decoding
of a KV batch response, doling out slices of keys and values to higher
level code that further decodes the key values into formats that the SQL
engine can operate on.

The KVFetcher uses a slice into the batch response to keep track of
where it is during the decoding process. Once the slice is empty, it's
finished until someone asks it for a new batch.

However, the KVFetcher used to keep around that empty slice pointer for
its lifetime, or until it was asked for a new batch. This causes the
batch response to be un-garbage-collectable, since there is still a
slice pointing at it, even though the slice is empty.

This causes queries to use up to 2x their accounted-for batch memory,
since the memory accounting system assumes that once data is transfered
out of the batch response into the SQL representation, the batch
response is freed - it assumes there's just 1 "copy" of this batch
response memory.

This is especially problematic for long queries (since they will not
allow that KVFetcher memory to be freed until they're finished).

In effect, this causes 1 extra batch per KVFetcher per query to be
retained in memory. This doesn't sound too bad, since a batch is of
fixed size. But the max batch size is 1 megabyte, so with 1024
concurrent queries, each with 3 KVFetchers, like we see in a TPCH
workload with 1024 concurrent query 18s, that's 1024 * 1MB * 3 = 3GB of
unaccounted for memory. This is easily enough memory to push a node over
and cause it to OOM.

This patch nils the batch response pointer once the KVFetcher is
finished decoding it, which allows it to be garbage collected as soon as
possible. In practice, this seems to allow at least a single-node
concurrency-1024 query18 TPCH workload to survive indefinitely (all
queries return out of budget errors) without OOMing.

Release note (bug fix): queries use up to 1MB less actual system memory
per scan, lookup join, index join, zigzag join, or inverted join in
their query plans. This will result in improved memory performance for
workloads with concurrent OLAP-style queries.

----

Previously, we could leave some dangling references to batch responses
around in the txnKVFetcher when we were fetching more than one batch at
a time. This would cause a delay in reclamation of memory for the
lifetime of a given query.

Release note (bug fix): use less memory in some queries, primarily
lookup joins.
