### PR TITLE
[dnm] roachtest: check heap_profiler artifacts collection

### DIFF
--- a/pkg/cmd/roachtest/build_info.go
+++ b/pkg/cmd/roachtest/build_info.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"net/http"
 	"os/exec"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
@@ -46,6 +47,8 @@ func runBuildInfo(ctx context.Context, t *test, c *cluster) {
 			t.Fatalf("build info not set for \"%s\"", key)
 		}
 	}
+	time.Sleep(time.Minute)
+	t.Fatal("boom")
 }
 
 // runBuildAnalyze performs static analysis on the built binary to


### PR DESCRIPTION
We suspect, in #66176, that the `heap_profiler` artifacts are missing from the TC artifacts.
This commit investigates that by intentionally failing an acceptance roachtest in a way that
should result in heap profiles being collected.
