### PR TITLE
release-21.1: cloudimpl: fix GCS storage to use the resuming reader

### DIFF
--- a/pkg/storage/cloudimpl/gcs_storage.go
+++ b/pkg/storage/cloudimpl/gcs_storage.go
@@ -199,7 +199,7 @@ func (g *gcsStorage) ReadFileAt(
 		}
 		return nil, 0, err
 	}
-	return r.reader, r.reader.(*gcs.Reader).Attrs.Size, nil
+	return r, r.reader.(*gcs.Reader).Attrs.Size, nil
 }
 
 func (g *gcsStorage) ListFiles(ctx context.Context, patternSuffix string) ([]string, error) {


### PR DESCRIPTION
This change is a minimal backport of #66149. It fixes a bug
where GCS was not using the resuming reader on Read().

Release note (bug fix): Fixes a bug where google cloud storage
was not using the resuming reader, as a result of which some
retryable errors were not being treated as such, and the
Read would fail.