### PR TITLE
sql: enhance readability of builder tests in new schema changer

### DIFF
--- a/pkg/sql/schemachanger/scbuild/testdata/alter_table
+++ b/pkg/sql/schemachanger/scbuild/testdata/alter_table
@@ -5,300 +5,274 @@ CREATE TABLE defaultdb.foo (i INT PRIMARY KEY)
 build
 ALTER TABLE defaultdb.foo ADD COLUMN j INT
 ----
-- target:
-    direction: ADD
-    elementProto:
-      column:
-        column:
-          id: 2
-          name: j
-          nullable: true
-          type:
-            family: IntFamily
-            oid: 20
-            width: 64
-        familyName: primary
-        tableId: 52
+- ADD Column:{DescID: 52, ColumnID: 2, ElementName: "j"}
   state: ABSENT
-- target:
-    direction: ADD
-    elementProto:
-      primaryIndex:
-        index:
-          foreignKey: {}
-          geoConfig: {}
-          id: 2
-          interleave: {}
-          keyColumnDirections:
-          - ASC
-          keyColumnIds:
-          - 1
-          keyColumnNames:
-          - i
-          name: new_primary_key
-          partitioning: {}
-          sharded: {}
-          unique: true
-          version: 3
-        otherPrimaryIndexId: 1
-        storeColumnIds:
-        - 2
-        storeColumnNames:
-        - j
-        tableId: 52
+  details:
+    column:
+      id: 2
+      name: j
+      nullable: true
+      type:
+        family: IntFamily
+        oid: 20
+        width: 64
+    familyName: primary
+    tableId: 52
+- ADD PrimaryIndex:{DescID: 52, ElementName: "new_primary_key", IndexID: 2}
   state: ABSENT
-- target:
-    direction: DROP
-    elementProto:
-      primaryIndex:
-        index:
-          foreignKey: {}
-          geoConfig: {}
-          id: 1
-          interleave: {}
-          keyColumnDirections:
-          - ASC
-          keyColumnIds:
-          - 1
-          keyColumnNames:
-          - i
-          name: primary
-          partitioning: {}
-          sharded: {}
-          unique: true
-          version: 3
-        otherPrimaryIndexId: 2
-        tableId: 52
+  details:
+    index:
+      foreignKey: {}
+      geoConfig: {}
+      id: 2
+      interleave: {}
+      keyColumnDirections:
+      - ASC
+      keyColumnIds:
+      - 1
+      keyColumnNames:
+      - i
+      name: new_primary_key
+      partitioning: {}
+      sharded: {}
+      unique: true
+      version: 3
+    otherPrimaryIndexId: 1
+    storeColumnIds:
+    - 2
+    storeColumnNames:
+    - j
+    tableId: 52
+- DROP PrimaryIndex:{DescID: 52, ElementName: "primary", IndexID: 1}
   state: PUBLIC
+  details:
+    index:
+      foreignKey: {}
+      geoConfig: {}
+      id: 1
+      interleave: {}
+      keyColumnDirections:
+      - ASC
+      keyColumnIds:
+      - 1
+      keyColumnNames:
+      - i
+      name: primary
+      partitioning: {}
+      sharded: {}
+      unique: true
+      version: 3
+    otherPrimaryIndexId: 2
+    tableId: 52
 
 build
 ALTER TABLE defaultdb.foo ADD COLUMN j INT DEFAULT 123
 ----
-- target:
-    direction: ADD
-    elementProto:
-      column:
-        column:
-          defaultExpr: 123:::INT8
-          id: 2
-          name: j
-          nullable: true
-          type:
-            family: IntFamily
-            oid: 20
-            width: 64
-        familyName: primary
-        tableId: 52
+- ADD Column:{DescID: 52, ColumnID: 2, ElementName: "j"}
   state: ABSENT
-- target:
-    direction: ADD
-    elementProto:
-      primaryIndex:
-        index:
-          foreignKey: {}
-          geoConfig: {}
-          id: 2
-          interleave: {}
-          keyColumnDirections:
-          - ASC
-          keyColumnIds:
-          - 1
-          keyColumnNames:
-          - i
-          name: new_primary_key
-          partitioning: {}
-          sharded: {}
-          unique: true
-          version: 3
-        otherPrimaryIndexId: 1
-        storeColumnIds:
-        - 2
-        storeColumnNames:
-        - j
-        tableId: 52
+  details:
+    column:
+      defaultExpr: 123:::INT8
+      id: 2
+      name: j
+      nullable: true
+      type:
+        family: IntFamily
+        oid: 20
+        width: 64
+    familyName: primary
+    tableId: 52
+- ADD PrimaryIndex:{DescID: 52, ElementName: "new_primary_key", IndexID: 2}
   state: ABSENT
-- target:
-    direction: DROP
-    elementProto:
-      primaryIndex:
-        index:
-          foreignKey: {}
-          geoConfig: {}
-          id: 1
-          interleave: {}
-          keyColumnDirections:
-          - ASC
-          keyColumnIds:
-          - 1
-          keyColumnNames:
-          - i
-          name: primary
-          partitioning: {}
-          sharded: {}
-          unique: true
-          version: 3
-        otherPrimaryIndexId: 2
-        tableId: 52
+  details:
+    index:
+      foreignKey: {}
+      geoConfig: {}
+      id: 2
+      interleave: {}
+      keyColumnDirections:
+      - ASC
+      keyColumnIds:
+      - 1
+      keyColumnNames:
+      - i
+      name: new_primary_key
+      partitioning: {}
+      sharded: {}
+      unique: true
+      version: 3
+    otherPrimaryIndexId: 1
+    storeColumnIds:
+    - 2
+    storeColumnNames:
+    - j
+    tableId: 52
+- DROP PrimaryIndex:{DescID: 52, ElementName: "primary", IndexID: 1}
   state: PUBLIC
+  details:
+    index:
+      foreignKey: {}
+      geoConfig: {}
+      id: 1
+      interleave: {}
+      keyColumnDirections:
+      - ASC
+      keyColumnIds:
+      - 1
+      keyColumnNames:
+      - i
+      name: primary
+      partitioning: {}
+      sharded: {}
+      unique: true
+      version: 3
+    otherPrimaryIndexId: 2
+    tableId: 52
 
 build
 ALTER TABLE defaultdb.foo ADD COLUMN j INT DEFAULT 123;
 ALTER TABLE defaultdb.foo ADD COLUMN k INT DEFAULT 456;
 ----
-- target:
-    direction: ADD
-    elementProto:
-      column:
-        column:
-          defaultExpr: 123:::INT8
-          id: 2
-          name: j
-          nullable: true
-          type:
-            family: IntFamily
-            oid: 20
-            width: 64
-        familyName: primary
-        tableId: 52
+- ADD Column:{DescID: 52, ColumnID: 2, ElementName: "j"}
   state: ABSENT
-- target:
-    direction: ADD
-    elementProto:
-      primaryIndex:
-        index:
-          foreignKey: {}
-          geoConfig: {}
-          id: 2
-          interleave: {}
-          keyColumnDirections:
-          - ASC
-          keyColumnIds:
-          - 1
-          keyColumnNames:
-          - i
-          name: new_primary_key
-          partitioning: {}
-          sharded: {}
-          unique: true
-          version: 3
-        otherPrimaryIndexId: 1
-        storeColumnIds:
-        - 2
-        - 3
-        storeColumnNames:
-        - j
-        - k
-        tableId: 52
+  details:
+    column:
+      defaultExpr: 123:::INT8
+      id: 2
+      name: j
+      nullable: true
+      type:
+        family: IntFamily
+        oid: 20
+        width: 64
+    familyName: primary
+    tableId: 52
+- ADD PrimaryIndex:{DescID: 52, ElementName: "new_primary_key", IndexID: 2}
   state: ABSENT
-- target:
-    direction: DROP
-    elementProto:
-      primaryIndex:
-        index:
-          foreignKey: {}
-          geoConfig: {}
-          id: 1
-          interleave: {}
-          keyColumnDirections:
-          - ASC
-          keyColumnIds:
-          - 1
-          keyColumnNames:
-          - i
-          name: primary
-          partitioning: {}
-          sharded: {}
-          unique: true
-          version: 3
-        otherPrimaryIndexId: 2
-        tableId: 52
+  details:
+    index:
+      foreignKey: {}
+      geoConfig: {}
+      id: 2
+      interleave: {}
+      keyColumnDirections:
+      - ASC
+      keyColumnIds:
+      - 1
+      keyColumnNames:
+      - i
+      name: new_primary_key
+      partitioning: {}
+      sharded: {}
+      unique: true
+      version: 3
+    otherPrimaryIndexId: 1
+    storeColumnIds:
+    - 2
+    - 3
+    storeColumnNames:
+    - j
+    - k
+    tableId: 52
+- DROP PrimaryIndex:{DescID: 52, ElementName: "primary", IndexID: 1}
   state: PUBLIC
-- target:
-    direction: ADD
-    elementProto:
-      column:
-        column:
-          defaultExpr: 456:::INT8
-          id: 3
-          name: k
-          nullable: true
-          type:
-            family: IntFamily
-            oid: 20
-            width: 64
-        familyName: primary
-        tableId: 52
+  details:
+    index:
+      foreignKey: {}
+      geoConfig: {}
+      id: 1
+      interleave: {}
+      keyColumnDirections:
+      - ASC
+      keyColumnIds:
+      - 1
+      keyColumnNames:
+      - i
+      name: primary
+      partitioning: {}
+      sharded: {}
+      unique: true
+      version: 3
+    otherPrimaryIndexId: 2
+    tableId: 52
+- ADD Column:{DescID: 52, ColumnID: 3, ElementName: "k"}
   state: ABSENT
+  details:
+    column:
+      defaultExpr: 456:::INT8
+      id: 3
+      name: k
+      nullable: true
+      type:
+        family: IntFamily
+        oid: 20
+        width: 64
+    familyName: primary
+    tableId: 52
 
 build
 ALTER TABLE defaultdb.foo ADD COLUMN a INT AS (i+1) STORED
 ----
-- target:
-    direction: ADD
-    elementProto:
-      column:
-        column:
-          computeExpr: i + 1:::INT8
-          id: 2
-          name: a
-          nullable: true
-          type:
-            family: IntFamily
-            oid: 20
-            width: 64
-        familyName: primary
-        tableId: 52
+- ADD Column:{DescID: 52, ColumnID: 2, ElementName: "a"}
   state: ABSENT
-- target:
-    direction: ADD
-    elementProto:
-      primaryIndex:
-        index:
-          foreignKey: {}
-          geoConfig: {}
-          id: 2
-          interleave: {}
-          keyColumnDirections:
-          - ASC
-          keyColumnIds:
-          - 1
-          keyColumnNames:
-          - i
-          name: new_primary_key
-          partitioning: {}
-          sharded: {}
-          unique: true
-          version: 3
-        otherPrimaryIndexId: 1
-        storeColumnIds:
-        - 2
-        storeColumnNames:
-        - a
-        tableId: 52
+  details:
+    column:
+      computeExpr: i + 1:::INT8
+      id: 2
+      name: a
+      nullable: true
+      type:
+        family: IntFamily
+        oid: 20
+        width: 64
+    familyName: primary
+    tableId: 52
+- ADD PrimaryIndex:{DescID: 52, ElementName: "new_primary_key", IndexID: 2}
   state: ABSENT
-- target:
-    direction: DROP
-    elementProto:
-      primaryIndex:
-        index:
-          foreignKey: {}
-          geoConfig: {}
-          id: 1
-          interleave: {}
-          keyColumnDirections:
-          - ASC
-          keyColumnIds:
-          - 1
-          keyColumnNames:
-          - i
-          name: primary
-          partitioning: {}
-          sharded: {}
-          unique: true
-          version: 3
-        otherPrimaryIndexId: 2
-        tableId: 52
+  details:
+    index:
+      foreignKey: {}
+      geoConfig: {}
+      id: 2
+      interleave: {}
+      keyColumnDirections:
+      - ASC
+      keyColumnIds:
+      - 1
+      keyColumnNames:
+      - i
+      name: new_primary_key
+      partitioning: {}
+      sharded: {}
+      unique: true
+      version: 3
+    otherPrimaryIndexId: 1
+    storeColumnIds:
+    - 2
+    storeColumnNames:
+    - a
+    tableId: 52
+- DROP PrimaryIndex:{DescID: 52, ElementName: "primary", IndexID: 1}
   state: PUBLIC
+  details:
+    index:
+      foreignKey: {}
+      geoConfig: {}
+      id: 1
+      interleave: {}
+      keyColumnDirections:
+      - ASC
+      keyColumnIds:
+      - 1
+      keyColumnNames:
+      - i
+      name: primary
+      partitioning: {}
+      sharded: {}
+      unique: true
+      version: 3
+    otherPrimaryIndexId: 2
+    tableId: 52
 
 create-table
 CREATE TABLE defaultdb.bar (j INT);
@@ -308,137 +282,125 @@ build
 ALTER TABLE defaultdb.foo ADD COLUMN a INT;
 ALTER TABLE defaultdb.bar ADD COLUMN b INT;
 ----
-- target:
-    direction: ADD
-    elementProto:
-      column:
-        column:
-          id: 2
-          name: a
-          nullable: true
-          type:
-            family: IntFamily
-            oid: 20
-            width: 64
-        familyName: primary
-        tableId: 52
+- ADD Column:{DescID: 52, ColumnID: 2, ElementName: "a"}
   state: ABSENT
-- target:
-    direction: ADD
-    elementProto:
-      primaryIndex:
-        index:
-          foreignKey: {}
-          geoConfig: {}
-          id: 2
-          interleave: {}
-          keyColumnDirections:
-          - ASC
-          keyColumnIds:
-          - 1
-          keyColumnNames:
-          - i
-          name: new_primary_key
-          partitioning: {}
-          sharded: {}
-          unique: true
-          version: 3
-        otherPrimaryIndexId: 1
-        storeColumnIds:
-        - 2
-        storeColumnNames:
-        - a
-        tableId: 52
+  details:
+    column:
+      id: 2
+      name: a
+      nullable: true
+      type:
+        family: IntFamily
+        oid: 20
+        width: 64
+    familyName: primary
+    tableId: 52
+- ADD PrimaryIndex:{DescID: 52, ElementName: "new_primary_key", IndexID: 2}
   state: ABSENT
-- target:
-    direction: DROP
-    elementProto:
-      primaryIndex:
-        index:
-          foreignKey: {}
-          geoConfig: {}
-          id: 1
-          interleave: {}
-          keyColumnDirections:
-          - ASC
-          keyColumnIds:
-          - 1
-          keyColumnNames:
-          - i
-          name: primary
-          partitioning: {}
-          sharded: {}
-          unique: true
-          version: 3
-        otherPrimaryIndexId: 2
-        tableId: 52
+  details:
+    index:
+      foreignKey: {}
+      geoConfig: {}
+      id: 2
+      interleave: {}
+      keyColumnDirections:
+      - ASC
+      keyColumnIds:
+      - 1
+      keyColumnNames:
+      - i
+      name: new_primary_key
+      partitioning: {}
+      sharded: {}
+      unique: true
+      version: 3
+    otherPrimaryIndexId: 1
+    storeColumnIds:
+    - 2
+    storeColumnNames:
+    - a
+    tableId: 52
+- DROP PrimaryIndex:{DescID: 52, ElementName: "primary", IndexID: 1}
   state: PUBLIC
-- target:
-    direction: ADD
-    elementProto:
-      column:
-        column:
-          id: 3
-          name: b
-          nullable: true
-          type:
-            family: IntFamily
-            oid: 20
-            width: 64
-        familyName: primary
-        tableId: 53
+  details:
+    index:
+      foreignKey: {}
+      geoConfig: {}
+      id: 1
+      interleave: {}
+      keyColumnDirections:
+      - ASC
+      keyColumnIds:
+      - 1
+      keyColumnNames:
+      - i
+      name: primary
+      partitioning: {}
+      sharded: {}
+      unique: true
+      version: 3
+    otherPrimaryIndexId: 2
+    tableId: 52
+- ADD Column:{DescID: 53, ColumnID: 3, ElementName: "b"}
   state: ABSENT
-- target:
-    direction: ADD
-    elementProto:
-      primaryIndex:
-        index:
-          foreignKey: {}
-          geoConfig: {}
-          id: 2
-          interleave: {}
-          keyColumnDirections:
-          - ASC
-          keyColumnIds:
-          - 2
-          keyColumnNames:
-          - rowid
-          name: new_primary_key
-          partitioning: {}
-          sharded: {}
-          unique: true
-        otherPrimaryIndexId: 1
-        storeColumnIds:
-        - 1
-        - 3
-        storeColumnNames:
-        - j
-        - b
-        tableId: 53
+  details:
+    column:
+      id: 3
+      name: b
+      nullable: true
+      type:
+        family: IntFamily
+        oid: 20
+        width: 64
+    familyName: primary
+    tableId: 53
+- ADD PrimaryIndex:{DescID: 53, ElementName: "new_primary_key", IndexID: 2}
   state: ABSENT
-- target:
-    direction: DROP
-    elementProto:
-      primaryIndex:
-        index:
-          foreignKey: {}
-          geoConfig: {}
-          id: 1
-          interleave: {}
-          keyColumnDirections:
-          - ASC
-          keyColumnIds:
-          - 2
-          keyColumnNames:
-          - rowid
-          name: primary
-          partitioning: {}
-          sharded: {}
-          unique: true
-        otherPrimaryIndexId: 2
-        storeColumnIds:
-        - 1
-        storeColumnNames:
-        - j
-        tableId: 53
+  details:
+    index:
+      foreignKey: {}
+      geoConfig: {}
+      id: 2
+      interleave: {}
+      keyColumnDirections:
+      - ASC
+      keyColumnIds:
+      - 2
+      keyColumnNames:
+      - rowid
+      name: new_primary_key
+      partitioning: {}
+      sharded: {}
+      unique: true
+    otherPrimaryIndexId: 1
+    storeColumnIds:
+    - 1
+    - 3
+    storeColumnNames:
+    - j
+    - b
+    tableId: 53
+- DROP PrimaryIndex:{DescID: 53, ElementName: "primary", IndexID: 1}
   state: PUBLIC
+  details:
+    index:
+      foreignKey: {}
+      geoConfig: {}
+      id: 1
+      interleave: {}
+      keyColumnDirections:
+      - ASC
+      keyColumnIds:
+      - 2
+      keyColumnNames:
+      - rowid
+      name: primary
+      partitioning: {}
+      sharded: {}
+      unique: true
+    otherPrimaryIndexId: 2
+    storeColumnIds:
+    - 1
+    storeColumnNames:
+    - j
+    tableId: 53

--- a/pkg/sql/schemachanger/scbuild/testdata/drop_sequence
+++ b/pkg/sql/schemachanger/scbuild/testdata/drop_sequence
@@ -5,12 +5,10 @@ CREATE SEQUENCE defaultdb.SQ1
 build
 DROP SEQUENCE defaultdb.SQ1 CASCADE
 ----
-- target:
-    direction: DROP
-    elementProto:
-      sequence:
-        sequenceId: 52
+- DROP Sequence:{DescID: 52}
   state: PUBLIC
+  details:
+    sequenceId: 52
 
 create-table
 CREATE TABLE defaultdb.blog_posts (id INT PRIMARY KEY, val int DEFAULT nextval('defaultdb.sq1'), title text)
@@ -23,27 +21,21 @@ CREATE TABLE defaultdb.blog_posts2 (id INT PRIMARY KEY, val int DEFAULT nextval(
 build
 DROP SEQUENCE defaultdb.SQ1 CASCADE
 ----
-- target:
-    direction: DROP
-    elementProto:
-      defaultExpression:
-        columnId: 2
-        tableId: 53
-        usesSequenceIDs:
-        - 52
+- DROP DefaultExpression:{DescID: 53, ColumnID: 2}
   state: PUBLIC
-- target:
-    direction: DROP
-    elementProto:
-      defaultExpression:
-        columnId: 2
-        tableId: 54
-        usesSequenceIDs:
-        - 52
+  details:
+    columnId: 2
+    tableId: 53
+    usesSequenceIDs:
+    - 52
+- DROP DefaultExpression:{DescID: 54, ColumnID: 2}
   state: PUBLIC
-- target:
-    direction: DROP
-    elementProto:
-      sequence:
-        sequenceId: 52
+  details:
+    columnId: 2
+    tableId: 54
+    usesSequenceIDs:
+    - 52
+- DROP Sequence:{DescID: 52}
   state: PUBLIC
+  details:
+    sequenceId: 52

--- a/pkg/sql/schemachanger/scbuild/testdata/drop_table
+++ b/pkg/sql/schemachanger/scbuild/testdata/drop_table
@@ -38,96 +38,76 @@ CREATE VIEW v1 as (select customer_id, carrier from defaultdb.shipments);
 build
 DROP TABLE defaultdb.shipments CASCADE;
 ----
-- target:
-    direction: DROP
-    elementProto:
-      view:
-        dependedOnBy: []
-        dependsOn:
-        - 55
-        tableId: 57
+- DROP View:{DescID: 57}
   state: PUBLIC
-- target:
-    direction: DROP
-    elementProto:
-      outForeignKey:
-        name: fk_customers
-        originColumns:
-        - 4
-        originId: 55
-        referenceColumns:
-        - 1
-        referenceId: 52
+  details:
+    dependedOnBy: []
+    dependsOn:
+    - 55
+    tableId: 57
+- DROP OutboundForeignKey:{DescID: 55, DepID: 52, ElementName: "fk_customers"}
   state: PUBLIC
-- target:
-    direction: DROP
-    elementProto:
-      inForeignKey:
-        name: fk_customers
-        originColumns:
-        - 1
-        originId: 52
-        referenceColumns:
-        - 4
-        referenceId: 55
+  details:
+    name: fk_customers
+    originColumns:
+    - 4
+    originId: 55
+    referenceColumns:
+    - 1
+    referenceId: 52
+- DROP InboundForeignKey:{DescID: 52, DepID: 55, ElementName: "fk_customers"}
   state: PUBLIC
-- target:
-    direction: DROP
-    elementProto:
-      outForeignKey:
-        name: fk_orders
-        originColumns:
-        - 4
-        originId: 55
-        referenceColumns:
-        - 2
-        referenceId: 53
+  details:
+    name: fk_customers
+    originColumns:
+    - 1
+    originId: 52
+    referenceColumns:
+    - 4
+    referenceId: 55
+- DROP OutboundForeignKey:{DescID: 55, DepID: 53, ElementName: "fk_orders"}
   state: PUBLIC
-- target:
-    direction: DROP
-    elementProto:
-      inForeignKey:
-        name: fk_orders
-        originColumns:
-        - 2
-        originId: 53
-        referenceColumns:
-        - 4
-        referenceId: 55
+  details:
+    name: fk_orders
+    originColumns:
+    - 4
+    originId: 55
+    referenceColumns:
+    - 2
+    referenceId: 53
+- DROP InboundForeignKey:{DescID: 53, DepID: 55, ElementName: "fk_orders"}
   state: PUBLIC
-- target:
-    direction: DROP
-    elementProto:
-      sequence:
-        sequenceId: 56
+  details:
+    name: fk_orders
+    originColumns:
+    - 2
+    originId: 53
+    referenceColumns:
+    - 4
+    referenceId: 55
+- DROP Sequence:{DescID: 56}
   state: PUBLIC
-- target:
-    direction: DROP
-    elementProto:
-      sequenceOwner:
-        ownerTableId: 55
-        sequenceId: 56
+  details:
+    sequenceId: 56
+- DROP SequenceOwnedBy:{DescID: 56, DepID: 55}
   state: PUBLIC
-- target:
-    direction: DROP
-    elementProto:
-      defaultExpression:
-        columnId: 5
-        defaultExpr: nextval(54:::REGCLASS)
-        tableId: 55
-        usesSequenceIDs:
-        - 54
+  details:
+    ownerTableId: 55
+    sequenceId: 56
+- DROP DefaultExpression:{DescID: 55, ColumnID: 5}
   state: PUBLIC
-- target:
-    direction: DROP
-    elementProto:
-      relationDependedOnBy:
-        dependedOn: 55
-        tableId: 54
+  details:
+    columnId: 5
+    defaultExpr: nextval(54:::REGCLASS)
+    tableId: 55
+    usesSequenceIDs:
+    - 54
+- DROP RelationDependedOnBy:{DescID: 54, DepID: 55}
   state: PUBLIC
-- target:
-    direction: DROP
-    elementProto:
-      table:
-        tableId: 55
+  details:
+    dependedOn: 55
+    tableId: 54
+- DROP Table:{DescID: 55}
   state: PUBLIC
+  details:
+    tableId: 55

--- a/pkg/sql/schemachanger/scbuild/testdata/drop_view
+++ b/pkg/sql/schemachanger/scbuild/testdata/drop_view
@@ -9,15 +9,13 @@ CREATE VIEW defaultdb.v1 AS (SELECT name FROM defaultdb.t1)
 build
 DROP VIEW defaultdb.v1
 ----
-- target:
-    direction: DROP
-    elementProto:
-      view:
-        dependedOnBy: []
-        dependsOn:
-        - 52
-        tableId: 53
+- DROP View:{DescID: 53}
   state: PUBLIC
+  details:
+    dependedOnBy: []
+    dependsOn:
+    - 52
+    tableId: 53
 
 create-view
 CREATE VIEW defaultdb.v2 AS (SELECT name AS n1, name AS n2 FROM v1)
@@ -42,68 +40,54 @@ CREATE VIEW v5 AS (SELECT 'a'::defaultdb.typ::string AS k, n2, n1 from defaultdb
 build
 DROP VIEW defaultdb.v1 CASCADE
 ----
-- target:
-    direction: DROP
-    elementProto:
-      view:
-        dependedOnBy:
-        - 54
-        - 55
-        dependsOn:
-        - 52
-        tableId: 53
+- DROP View:{DescID: 53}
   state: PUBLIC
-- target:
-    direction: DROP
-    elementProto:
-      view:
-        dependedOnBy:
-        - 55
-        - 56
-        dependsOn:
-        - 53
-        tableId: 54
+  details:
+    dependedOnBy:
+    - 54
+    - 55
+    dependsOn:
+    - 52
+    tableId: 53
+- DROP View:{DescID: 54}
   state: PUBLIC
-- target:
-    direction: DROP
-    elementProto:
-      view:
-        dependedOnBy: []
-        dependsOn:
-        - 53
-        - 54
-        tableId: 55
+  details:
+    dependedOnBy:
+    - 55
+    - 56
+    dependsOn:
+    - 53
+    tableId: 54
+- DROP View:{DescID: 55}
   state: PUBLIC
-- target:
-    direction: DROP
-    elementProto:
-      view:
-        dependedOnBy:
-        - 59
-        dependsOn:
-        - 54
-        tableId: 56
+  details:
+    dependedOnBy: []
+    dependsOn:
+    - 53
+    - 54
+    tableId: 55
+- DROP View:{DescID: 56}
   state: PUBLIC
-- target:
-    direction: DROP
-    elementProto:
-      view:
-        dependedOnBy: []
-        dependsOn:
-        - 56
-        tableId: 59
+  details:
+    dependedOnBy:
+    - 59
+    dependsOn:
+    - 54
+    tableId: 56
+- DROP View:{DescID: 59}
   state: PUBLIC
-- target:
-    direction: DROP
-    elementProto:
-      typeRef:
-        descriptorId: 59
-        typeId: 57
+  details:
+    dependedOnBy: []
+    dependsOn:
+    - 56
+    tableId: 59
+- DROP TypeReference:{DescID: 57, DepID: 59}
   state: PUBLIC
-- target:
-    direction: DROP
-    elementProto:
-      typeRef:
-        descriptorId: 59
-        typeId: 58
+  details:
+    descriptorId: 59
+    typeId: 57
+- DROP TypeReference:{DescID: 58, DepID: 59}
   state: PUBLIC
+  details:
+    descriptorId: 59
+    typeId: 58

--- a/pkg/sql/schemachanger/scplan/plan_test.go
+++ b/pkg/sql/schemachanger/scplan/plan_test.go
@@ -11,6 +11,7 @@
 package scplan_test
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"path/filepath"
@@ -129,18 +130,20 @@ func TestPlanAlterTable(t *testing.T) {
 }
 
 // indentText indents text for formatting out marshaled data.
-func indentText(input string, tab string) (final string) {
-	split := strings.Split(input, "\n")
-	for idx, line := range split {
+func indentText(input string, tab string) string {
+	result := strings.Builder{}
+	scanner := bufio.NewScanner(strings.NewReader(input))
+	scanner.Split(bufio.ScanLines)
+	for scanner.Scan() {
+		line := scanner.Text()
 		if len(line) == 0 {
 			continue
 		}
-		final += tab + line
-		if idx != len(split)-1 {
-			final = final + "\n"
-		}
+		result.WriteString(tab)
+		result.WriteString(line)
+		result.WriteString("\n")
 	}
-	return final
+	return result.String()
 }
 
 // marshalDeps marshals dependencies in scplan.Plan to a string.


### PR DESCRIPTION
Previously, the new schema changer builder tests had readability
issues trying to figure out the elements getting made. This was
inadequate because the builder tests results were hard to read.
To address this, this patch changes the format for the builder
tests to be easier to read.

Release note: None