### PR TITLE
bazel: bazel builder image doesn't run builds as root

### DIFF
--- a/build/bazelbuilder/Dockerfile
+++ b/build/bazelbuilder/Dockerfile
@@ -60,6 +60,9 @@ RUN rm -rf /tmp/* /var/lib/apt/lists/*
 
 RUN ln -s /usr/bin/bazel-4.0.0 /usr/bin/bazel
 
-COPY entrypoint.sh /usr/bin
-ENTRYPOINT ["/usr/bin/entrypoint.sh"]
-CMD ["/usr/bin/bash"]
+RUN curl -fsSL https://github.com/benesch/autouseradd/releases/download/1.2.0/autouseradd-1.2.0-amd64.tar.gz -o autouseradd.tar.gz \
+  && echo 'f7b0cf67564044c31ffc5e84c961726098b88b0296a57c84421659d56434a365 autouseradd.tar.gz' | sha256sum -c - \
+  && tar xzf autouseradd.tar.gz --strip-components 1 \
+  && rm autouseradd.tar.gz
+
+ENTRYPOINT ["autouseradd", "--user", "roach", "--no-create-home"]

--- a/build/bazelbuilder/entrypoint.sh
+++ b/build/bazelbuilder/entrypoint.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/bash
-# Without this `umask`, the image will create build artifacts that the host
-# won't have permission to delete (which can pollute the workspace with files
-# that can't be cleaned up).
-umask 0000
-exec "$@"

--- a/build/builder/Dockerfile
+++ b/build/builder/Dockerfile
@@ -200,10 +200,12 @@ RUN apt-get purge -y \
 RUN rm -rf /tmp/* /var/lib/apt/lists/*
 
 RUN ln -s /go/src/github.com/cockroachdb/cockroach/build/builder/mkrelease.sh /usr/local/bin/mkrelease \
-    && ln -s /usr/bin/bazel-3.6.0 /usr/bin/bazel
+  && ln -s /usr/bin/bazel-3.6.0 /usr/bin/bazel
 
-RUN curl -fsSL https://github.com/benesch/autouseradd/releases/download/1.2.0/autouseradd-1.2.0-amd64.tar.gz \
-    | tar xz -C / --strip-components 1
+RUN curl -fsSL https://github.com/benesch/autouseradd/releases/download/1.2.0/autouseradd-1.2.0-amd64.tar.gz -o autouseradd.tar.gz \
+  && echo 'f7b0cf67564044c31ffc5e84c961726098b88b0296a57c84421659d56434a365 autouseradd.tar.gz' | sha256sum -c - \
+  && tar xzf autouseradd.tar.gz --strip-components 1 \
+  && rm autouseradd.tar.gz
 
 COPY entrypoint.sh /usr/local/bin
 

--- a/build/teamcity-bazel-support.sh
+++ b/build/teamcity-bazel-support.sh
@@ -1,4 +1,4 @@
-BAZEL_IMAGE=cockroachdb/bazel:20210528-135020
+BAZEL_IMAGE=cockroachdb/bazel:20210608-131711
 
 # Call `run_bazel $NAME_OF_SCRIPT` to start an appropriately-configured Docker
 # container with the `cockroachdb/bazel` image running the given script.
@@ -17,7 +17,9 @@ run_bazel() {
     cp $root/.bazelrc.ci $root/.bazelrc.user
 
     # Set up volumes.
-    vols="--volume /home/agent/.bazelcache:/root/.cache/bazel"
+    cache=/home/agent/.bzlhome
+    mkdir -p $cache
+    vols="--volume ${cache}:/home/roach"
 
     workspace_vol="--volume ${root}:/go/src/github.com/cockroachdb/cockroach"
     if [ -z "${TEAMCITY_BAZEL_SUPPORT_LINT:-}" ]
@@ -32,6 +34,7 @@ run_bazel() {
     fi
 
     docker run -i ${tty-} --rm --init \
+        -u "$(id -u):$(id -g)" \
         --workdir="/go/src/github.com/cockroachdb/cockroach" \
         ${vols} \
         $BAZEL_IMAGE "$@"

--- a/pkg/cmd/bazci/watch.go
+++ b/pkg/cmd/bazci/watch.go
@@ -142,7 +142,7 @@ func (w watcher) stageTestArtifacts(phase Phase) error {
 			{path.Join(relDir, "test.xml"), mungeTestXML},
 			{path.Join(relDir, "*", "test.xml"), mungeTestXML},
 		} {
-			err := w.maybeStageArtifact(testlogsSourceDir, tup.relPath, 0666, phase,
+			err := w.maybeStageArtifact(testlogsSourceDir, tup.relPath, 0644, phase,
 				tup.stagefn)
 			if err != nil {
 				return err
@@ -197,7 +197,7 @@ func (w watcher) stageBinaryArtifacts() error {
 		head := strings.ReplaceAll(strings.TrimPrefix(bin, "//"), ":", "/")
 		components := strings.Split(bin, ":")
 		relBinPath := path.Join(head+"_", components[len(components)-1])
-		err := w.maybeStageArtifact(binSourceDir, relBinPath, 0777, finalizePhase,
+		err := w.maybeStageArtifact(binSourceDir, relBinPath, 0755, finalizePhase,
 			copyContentTo)
 		if err != nil {
 			return err
@@ -269,7 +269,7 @@ func (w *cancelableWriter) Write(p []byte) (n int, err error) {
 
 func (w *cancelableWriter) Close() error {
 	if !w.Canceled {
-		err := os.MkdirAll(path.Dir(w.filename), 0777)
+		err := os.MkdirAll(path.Dir(w.filename), 0755)
 		if err != nil {
 			return err
 		}
@@ -315,7 +315,7 @@ func (w *cancelableWriter) Close() error {
 //
 // For example, one might stage a set of log files with a call like:
 // w.maybeStageArtifact(testlogsSourceDir, "pkg/server/server_test/*/test.log",
-//                      0666, incrementalUpdatePhase, copycontentTo)
+//                      0644, incrementalUpdatePhase, copycontentTo)
 func (w watcher) maybeStageArtifact(
 	root SourceDir,
 	pattern string,


### PR DESCRIPTION
Adopt the same `autouseradd` script that we use in `cockroachdb/builder`
to avoid creating these files as `root`. Also step down the permissions
on some files that `bazci` creates -- they don't need to be so
permissive any more.

Consuming this for dev scenarios is a follow-up task -- I plan to
integrate it with the `dev` helper tool.

Closes #66162

Release note: None