### PR TITLE
ui: add reset sql stats feature flag

### DIFF
--- a/pkg/ui/cluster-ui/src/statementsPage/statementsPage.spec.tsx
+++ b/pkg/ui/cluster-ui/src/statementsPage/statementsPage.spec.tsx
@@ -11,7 +11,6 @@
 import React from "react";
 import { assert } from "chai";
 import { ReactWrapper, mount } from "enzyme";
-import { MemoryRouter } from "react-router-dom";
 
 import {
   StatementsPage,
@@ -19,14 +18,15 @@ import {
   StatementsPageState,
 } from "src/statementsPage";
 import statementsPagePropsFixture from "./statementsPage.fixture";
+import { TestStoreProvider } from "../test-utils";
 
 describe("StatementsPage", () => {
   describe("Statements table", () => {
     it("sorts data by Execution Count DESC as default option", () => {
       const rootWrapper = mount(
-        <MemoryRouter>
+        <TestStoreProvider>
           <StatementsPage {...statementsPagePropsFixture} />
-        </MemoryRouter>,
+        </TestStoreProvider>,
       );
 
       const statementsPageWrapper: ReactWrapper<

--- a/pkg/ui/cluster-ui/src/statementsPage/statementsPage.stories.tsx
+++ b/pkg/ui/cluster-ui/src/statementsPage/statementsPage.stories.tsx
@@ -10,16 +10,16 @@
 
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import { MemoryRouter } from "react-router-dom";
 import { cloneDeep } from "lodash";
 
 import { StatementsPage } from "./statementsPage";
 import statementsPagePropsFixture, {
   statementsPagePropsWithRequestError,
 } from "./statementsPage.fixture";
+import { TestStoreProvider } from "../test-utils";
 
 storiesOf("StatementsPage", module)
-  .addDecorator(storyFn => <MemoryRouter>{storyFn()}</MemoryRouter>)
+  .addDecorator(storyFn => <TestStoreProvider>{storyFn()}</TestStoreProvider>)
   .addDecorator(storyFn => (
     <div style={{ backgroundColor: "#F5F7FA" }}>{storyFn()}</div>
   ))

--- a/pkg/ui/cluster-ui/src/store/uiConfig/index.ts
+++ b/pkg/ui/cluster-ui/src/store/uiConfig/index.ts
@@ -9,3 +9,4 @@
 // licenses/APL.txt.
 
 export * from "./uiConfig.reducer";
+export * from "./uiConfig.selectors";

--- a/pkg/ui/cluster-ui/src/store/uiConfig/uiConfig.reducer.ts
+++ b/pkg/ui/cluster-ui/src/store/uiConfig/uiConfig.reducer.ts
@@ -20,6 +20,9 @@ export type UIConfigState = {
     sessionDetails: {
       showGatewayNodeLink: boolean;
     };
+    statements?: {
+      enableSqlStatsReset?: boolean;
+    };
   };
 };
 
@@ -30,6 +33,9 @@ const initialState: UIConfigState = {
     },
     sessionDetails: {
       showGatewayNodeLink: false,
+    },
+    statements: {
+      enableSqlStatsReset: true,
     },
   },
 };

--- a/pkg/ui/cluster-ui/src/store/uiConfig/uiConfig.selectors.ts
+++ b/pkg/ui/cluster-ui/src/store/uiConfig/uiConfig.selectors.ts
@@ -1,0 +1,27 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { createSelector } from "reselect";
+import { AppState } from "../reducers";
+
+const uiConfigSelectors = createSelector(
+  (state: AppState) => state.adminUI,
+  state => state?.uiConfig,
+);
+
+export const enableSqlStatsResetSelector = createSelector(
+  uiConfigSelectors,
+  config => {
+    if (config?.pages?.statements?.enableSqlStatsReset === undefined) {
+      return true; // enable "reset sql stats" by default
+    }
+    return config?.pages?.statements?.enableSqlStatsReset;
+  },
+);

--- a/pkg/ui/cluster-ui/src/tableStatistics/tableStatistics.module.scss
+++ b/pkg/ui/cluster-ui/src/tableStatistics/tableStatistics.module.scss
@@ -13,6 +13,7 @@
 }
 
 .tooltip-hover-area {
-  padding-top: 3px;
   padding-right: 10px;
+  height: 100%;
+  display: flex;
 }

--- a/pkg/ui/cluster-ui/src/tableStatistics/tableStatistics.tsx
+++ b/pkg/ui/cluster-ui/src/tableStatistics/tableStatistics.tsx
@@ -20,6 +20,8 @@ import statementStyles from "src/statementDetails/statementDetails.module.scss";
 import tableStatsStyles from "./tableStatistics.module.scss";
 import classNames from "classnames/bind";
 import { Icon } from "@cockroachlabs/ui-components";
+import { useSelector } from "react-redux";
+import { enableSqlStatsResetSelector } from "../store/uiConfig";
 
 const { statistic, countTitle, lastCleared } = statisticsClasses;
 const cxStmt = classNames.bind(statementStyles);
@@ -53,6 +55,7 @@ export const TableStatistics: React.FC<TableStatistics> = ({
   activeFilters,
   resetSQLStats,
 }) => {
+  const enableSqlStatsReset = useSelector(enableSqlStatsResetSelector);
   const resultsPerPageLabel = (
     <ResultsPerPageLabel
       pagination={{ ...pagination, total: totalCount }}
@@ -76,18 +79,22 @@ export const TableStatistics: React.FC<TableStatistics> = ({
       <h4 className={countTitle}>
         {activeFilters ? resultsCountAndClear : resultsPerPageLabel}
       </h4>
-      <div className={cxStats("flex-display")}>
-        <Tooltip content={toolTipText}>
-          <div className={cxStats("tooltip-hover-area")}>
-            <Icon iconName={"InfoCircle"} />
+      {enableSqlStatsReset ? (
+        <div className={cxStats("flex-display")}>
+          <Tooltip content={toolTipText}>
+            <div className={cxStats("tooltip-hover-area")}>
+              <Icon iconName={"InfoCircle"} />
+            </div>
+          </Tooltip>
+          <div className={lastCleared}>
+            {renderLastCleared(lastReset)}
+            {"  "}-{"  "}
+            <a onClick={resetSQLStats}>Clear SQL Stats</a>
           </div>
-        </Tooltip>
-        <div className={lastCleared}>
-          {renderLastCleared(lastReset)}
-          {"  "}-{"  "}
-          <a onClick={resetSQLStats}>Clear SQL Stats</a> {/*doesn't work!*/}
         </div>
-      </div>
+      ) : (
+        <h4 className={lastCleared}>{renderLastCleared(lastReset)}</h4>
+      )}
     </div>
   );
 };

--- a/pkg/ui/cluster-ui/src/transactionsPage/transactionsPage.stories.tsx
+++ b/pkg/ui/cluster-ui/src/transactionsPage/transactionsPage.stories.tsx
@@ -10,18 +10,18 @@
 
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import { MemoryRouter } from "react-router-dom";
 import { cloneDeep, noop, extend } from "lodash";
 import { data, routeProps } from "./transactions.fixture";
 
 import { TransactionsPage } from ".";
 import { RequestError } from "../util";
+import { TestStoreProvider } from "../test-utils";
 
 const getEmptyData = () =>
   extend({}, data, { transactions: [], statements: [] });
 
 storiesOf("Transactions Page", module)
-  .addDecorator(storyFn => <MemoryRouter>{storyFn()}</MemoryRouter>)
+  .addDecorator(storyFn => <TestStoreProvider>{storyFn()}</TestStoreProvider>)
   .addDecorator(storyFn => (
     <div style={{ backgroundColor: "#F5F7FA" }}>{storyFn()}</div>
   ))


### PR DESCRIPTION
Statements page table contains a link to reset SQL stats that
was introduced recently is not backward compatible with previous
"patch" versions.
This change introduces dynamic configuration for this feature and
allows to disable this change to work as before.

Release note: None