### PR TITLE
tenantrate: add old settings to retiredSettings

### DIFF
--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -79,6 +79,15 @@ var retiredSettings = map[string]struct{}{
 	"sql.testing.mutations.max_batch_size":  {},
 	"sql.testing.mock_contention.enabled":   {},
 	"kv.atomic_replication_changes.enabled": {},
+	// removed as of 21.1.2.
+	"kv.tenant_rate_limiter.read_requests.rate_limit":   {},
+	"kv.tenant_rate_limiter.read_requests.burst_limit":  {},
+	"kv.tenant_rate_limiter.write_requests.rate_limit":  {},
+	"kv.tenant_rate_limiter.write_requests.burst_limit": {},
+	"kv.tenant_rate_limiter.read_bytes.rate_limit":      {},
+	"kv.tenant_rate_limiter.read_bytes.burst_limit":     {},
+	"kv.tenant_rate_limiter.write_bytes.rate_limit":     {},
+	"kv.tenant_rate_limiter.write_bytes.burst_limit":    {},
 	// removed as of 21.2.
 	"sql.defaults.vectorize_row_count_threshold": {},
 	"cloudstorage.gs.default.key":                {},


### PR DESCRIPTION
These settings were removed in a previous change but were not added to
retiredSettings.

Release note: None