### PR TITLE
importccl: fix import benchmarks

### DIFF
--- a/pkg/ccl/importccl/bench_test.go
+++ b/pkg/ccl/importccl/bench_test.go
@@ -43,6 +43,8 @@ type tableSSTable struct {
 	sstData []byte
 }
 
+//BenchmarkImportWorkload/tpcc/warehouses=1/WriteAndLink-8         18        74032204 ns/op     324.94 MB/s
+//BenchmarkImportWorkload/tpcc/warehouses=1/AddSStable-8           1       2230451598 ns/op      10.79 MB/s
 func BenchmarkImportWorkload(b *testing.B) {
 	skip.UnderShort(b, "skipping long benchmark")
 
@@ -149,6 +151,7 @@ func benchmarkAddSSTable(b *testing.B, dir string, tables []tableSSTable) {
 	b.SetBytes(totalBytes / int64(b.N))
 }
 
+//BenchmarkConvertToKVs/tpcc/warehouses=1-8         1        3558824936 ns/op          22.46 MB/s
 func BenchmarkConvertToKVs(b *testing.B) {
 	skip.UnderShort(b, "skipping long benchmark")
 

--- a/pkg/ccl/importccl/bench_test.go
+++ b/pkg/ccl/importccl/bench_test.go
@@ -196,31 +196,3 @@ func benchmarkConvertToKVs(b *testing.B, g workload.Generator) {
 	b.StopTimer()
 	b.SetBytes(bytes)
 }
-
-func BenchmarkConvertToSSTable(b *testing.B) {
-	skip.UnderShort(b, "skipping long benchmark")
-	//
-	tpccGen := tpcc.FromWarehouses(1)
-	b.Run(`tpcc/warehouses=1`, func(b *testing.B) {
-		benchmarkConvertToSSTable(b, tpccGen)
-	})
-}
-
-func benchmarkConvertToSSTable(b *testing.B, g workload.Generator) {
-	const tableID = descpb.ID(keys.MinUserDescID)
-	now := timeutil.Now()
-
-	var totalBytes int64
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		for _, table := range g.Tables() {
-			sst, err := format.ToSSTable(table, tableID, now)
-			if err != nil {
-				b.Fatal(err)
-			}
-			totalBytes += int64(len(sst))
-		}
-	}
-	b.StopTimer()
-	b.SetBytes(totalBytes / int64(b.N))
-}

--- a/pkg/ccl/workloadccl/format/BUILD.bazel
+++ b/pkg/ccl/workloadccl/format/BUILD.bazel
@@ -8,6 +8,8 @@ go_library(
     deps = [
         "//pkg/ccl/importccl",
         "//pkg/keys",
+        "//pkg/roachpb",
+        "//pkg/settings/cluster",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/parser",

--- a/pkg/ccl/workloadccl/format/sstable.go
+++ b/pkg/ccl/workloadccl/format/sstable.go
@@ -11,10 +11,13 @@ package format
 import (
 	"context"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/importccl"
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
@@ -44,13 +47,20 @@ func ToTableDescriptor(
 		return nil, errors.Errorf("expected *tree.CreateTable got %T", stmt)
 	}
 	const parentID descpb.ID = keys.MaxReservedDescID
+	testSettings := cluster.MakeTestingClusterSettings()
 	tableDesc, err := importccl.MakeSimpleTableDescriptor(
-		ctx, &semaCtx, nil /* settings */, createTable, parentID, keys.PublicSchemaID, tableID, importccl.NoFKs, ts.UnixNano())
+		ctx, &semaCtx, testSettings, createTable, parentID, keys.PublicSchemaID, tableID, importccl.NoFKs, ts.UnixNano())
 	if err != nil {
 		return nil, err
 	}
 	return tableDesc.ImmutableCopy().(catalog.TableDescriptor), nil
 }
+
+type sortableKVs []roachpb.KeyValue
+
+func (s sortableKVs) Len() int           { return len(s) }
+func (s sortableKVs) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s sortableKVs) Less(i, j int) bool { return s[i].Key.Compare(s[j].Key) == -1 }
 
 // ToSSTable constructs a single sstable with the kvs necessary to represent a
 // workload.Table as a CockroachDB SQL table. This sstable is suitable for
@@ -71,30 +81,44 @@ func ToSSTable(t workload.Table, tableID descpb.ID, ts time.Time) ([]byte, error
 	g := ctxgroup.WithContext(ctx)
 	g.GoCtx(func(ctx context.Context) error {
 		defer close(kvCh)
-		evalCtx := &tree.EvalContext{SessionData: &sessiondata.SessionData{}}
+		evalCtx := &tree.EvalContext{
+			SessionData: &sessiondata.SessionData{},
+			Codec:       keys.SystemSQLCodec,
+		}
 		return wc.Worker(ctx, evalCtx)
 	})
 	var sst []byte
+	var kvs sortableKVs
 	g.GoCtx(func(ctx context.Context) error {
-		sstTS := hlc.Timestamp{WallTime: ts.UnixNano()}
-		sstFile := &storage.MemFile{}
-		sw := storage.MakeIngestionSSTWriter(sstFile)
-		defer sw.Close()
 		for kvBatch := range kvCh {
 			for _, kv := range kvBatch.KVs {
-				mvccKey := storage.MVCCKey{Timestamp: sstTS, Key: kv.Key}
-				if err := sw.PutMVCC(mvccKey, kv.Value.RawBytes); err != nil {
-					return err
-				}
+				// Workload produces KVs out of order, so we buffer and sort
+				// them all here. We shouldn't be concerned with the performance
+				// of this
+				kvs = append(kvs, kv)
 			}
 		}
-		err = sw.Finish()
-		sst = sstFile.Data()
 		return err
 	})
 	if err := g.Wait(); err != nil {
 		return nil, err
 	}
+
+	sstTS := hlc.Timestamp{WallTime: ts.UnixNano()}
+	sstFile := &storage.MemFile{}
+	sw := storage.MakeIngestionSSTWriter(sstFile)
+	defer sw.Close()
+
+	sort.Sort(kvs)
+	for _, kv := range kvs {
+		mvccKey := storage.MVCCKey{Timestamp: sstTS, Key: kv.Key}
+		if err := sw.PutMVCC(mvccKey, kv.Value.RawBytes); err != nil {
+			return nil, err
+		}
+	}
+
+	err = sw.Finish()
+	sst = sstFile.Data()
 
 	return sst, nil
 }


### PR DESCRIPTION
Import's benchmarks were not run in a while and have rotted. This commit
spruces them up to be able to run again. This is setting up work to be
able to add more microbenchmarks to RESTORE.

The main change here is updating the ToSSTable to buffer the KVs it
receives. It appears that the KVs being ingested here were never
produced in order... In any case, this method should only be used as a
helper in benchmarks to generate SSTables.

It also unskips a benchmark that has been skipped for a long time.

Fixes https://github.com/cockroachdb/cockroach/issues/41932.

Release note: None
