### PR TITLE
release-21.1: tenantrate: add old settings to retiredSettings

### DIFF
--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -80,6 +80,15 @@ var retiredSettings = map[string]struct{}{
 	"sql.testing.mock_contention.enabled":      {},
 	"kv.atomic_replication_changes.enabled":    {},
 	"storage.sst_export.max_intents_per_error": {},
+	// removed as of 21.1.2.
+	"kv.tenant_rate_limiter.read_requests.rate_limit":   {},
+	"kv.tenant_rate_limiter.read_requests.burst_limit":  {},
+	"kv.tenant_rate_limiter.write_requests.rate_limit":  {},
+	"kv.tenant_rate_limiter.write_requests.burst_limit": {},
+	"kv.tenant_rate_limiter.read_bytes.rate_limit":      {},
+	"kv.tenant_rate_limiter.read_bytes.burst_limit":     {},
+	"kv.tenant_rate_limiter.write_bytes.rate_limit":     {},
+	"kv.tenant_rate_limiter.write_bytes.burst_limit":    {},
 }
 
 // register adds a setting to the registry.


### PR DESCRIPTION
Backport 1/1 commits from #66200.

/cc @cockroachdb/release

---

These settings were removed in a previous change but were not added to
retiredSettings.

Release note: None
