### PR TITLE
sqlproxyccl: do not inject error frame after connection hand off

### DIFF
--- a/pkg/ccl/sqlproxyccl/proxy_handler.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler.go
@@ -343,7 +343,7 @@ func (handler *proxyHandler) handle(ctx context.Context, proxyConn *conn) error 
 
 	select {
 	case err := <-errConnectionCopy:
-		updateMetricsAndSendErrToClient(err, conn, handler.metrics)
+		handler.metrics.updateForError(err)
 		return err
 	case err := <-errExpired:
 		if err != nil {
@@ -351,7 +351,7 @@ func (handler *proxyHandler) handle(ctx context.Context, proxyConn *conn) error 
 			codeErr := newErrorf(
 				codeExpiredClientConnection, "expired client conn: %v", err,
 			)
-			updateMetricsAndSendErrToClient(codeErr, conn, handler.metrics)
+			handler.metrics.updateForError(codeErr)
 			return codeErr
 		}
 		return nil


### PR DESCRIPTION
Fixes #66156

Previously, deny list and idle errors were communicated using error frames. This
causes wire protocol corruption if the proxy is in the middle of proxying a reply
frame. Now, the sqlproxy closes the connection without injecting an error frame.

Communicating errors to the client after connection handoff could be done if the
proxy inspects the reply stream and tracks the start/end of database reply frames.

Release note: None