### PR TITLE
build: quash remaining references to `msan`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -491,7 +491,6 @@ KRB5_SRC_DIR     := $(C_DEPS_DIR)/krb5
 
 # Derived build variants.
 use-stdmalloc          := $(findstring stdmalloc,$(TAGS))
-use-msan               := $(findstring msan,$(GOFLAGS))
 
 # User-requested build variants.
 ENABLE_LIBROACH_ASSERTIONS ?=
@@ -507,13 +506,13 @@ ifdef host-is-mingw
 BUILD_DIR := $(shell cygpath -m $(BUILD_DIR))
 endif
 
-JEMALLOC_DIR := $(BUILD_DIR)/jemalloc$(if $(use-msan),_msan)
-PROTOBUF_DIR := $(BUILD_DIR)/protobuf$(if $(use-msan),_msan)
-GEOS_DIR     := $(BUILD_DIR)/geos$(if $(use-msan),_msan)
-PROJ_DIR     := $(BUILD_DIR)/proj$(if $(use-msan),_msan)
-LIBEDIT_DIR  := $(BUILD_DIR)/libedit$(if $(use-msan),_msan)
-LIBROACH_DIR := $(BUILD_DIR)/libroach$(if $(use-msan),_msan)$(if $(ENABLE_LIBROACH_ASSERTIONS),_assert)
-KRB5_DIR     := $(BUILD_DIR)/krb5$(if $(use-msan),_msan)
+JEMALLOC_DIR := $(BUILD_DIR)/jemalloc
+PROTOBUF_DIR := $(BUILD_DIR)/protobuf
+GEOS_DIR     := $(BUILD_DIR)/geos
+PROJ_DIR     := $(BUILD_DIR)/proj
+LIBEDIT_DIR  := $(BUILD_DIR)/libedit
+LIBROACH_DIR := $(BUILD_DIR)/libroach$(if $(ENABLE_LIBROACH_ASSERTIONS),_assert)
+KRB5_DIR     := $(BUILD_DIR)/krb5
 # Can't share with protobuf because protoc is always built for the host.
 PROTOC_DIR := $(GOPATH)/native/$(HOST_TRIPLE)/protobuf
 
@@ -555,7 +554,7 @@ override TAGS += gss
 endif
 
 # Go does not permit dashes in build tags. This is undocumented.
-native-tag := $(subst -,_,$(TARGET_TRIPLE))$(if $(use-stdmalloc),_stdmalloc)$(if $(use-msan),_msan)
+native-tag := $(subst -,_,$(TARGET_TRIPLE))$(if $(use-stdmalloc),_stdmalloc)
 
 # In each package that uses cgo, we inject include and library search paths into
 # files named zcgo_flags_{native-tag}.go. The logic for this is complicated so

--- a/build/builder/Dockerfile
+++ b/build/builder/Dockerfile
@@ -10,7 +10,7 @@ FROM ubuntu:focal-20210119
 # autopoint - sed build
 # bison - CRDB build system
 # clang-10 - compiler
-# cmake - msan / c-deps: libroach, protobuf, et al.
+# cmake - c-deps: libroach, protobuf, et al.
 # gcc/g++ - host builds
 # gettext - sed build
 # gnupg2 - for apt
@@ -48,8 +48,6 @@ RUN apt-get update \
 
 RUN curl -fsSL https://storage.googleapis.com/public-bazel-artifacts/toolchains/crosstool-ng/20210601-231954/aarch64-unknown-linux-gnu.tar.gz -o aarch64-unknown-linux-gnu.tar.gz \
  && echo 'ed7ebe618794c0a64aec742d1bf9274302f86a8a81505758c97dc99dab5fd6ab aarch64-unknown-linux-gnu.tar.gz' | sha256sum -c - \
- && curl -fsSL https://storage.googleapis.com/public-bazel-artifacts/toolchains/crosstool-ng/20210601-231954/libcxx_msan.tar.gz -o libcxx_msan.tar.gz \
- && echo '6a0991c6ed14315fdc525226e96d5908cf8d75177144d600bb6fdac0fd4110f4 libcxx_msan.tar.gz' | sha256sum -c - \
  && curl -fsSL https://storage.googleapis.com/public-bazel-artifacts/toolchains/crosstool-ng/20210601-231954/s390x-ibm-linux-gnu.tar.gz -o s390x-ibm-linux-gnu.tar.gz \
  && echo '93c34d3111e38882fd88f38df33243c52466f703d78e7dd8ac0260c9e1ca35c6 s390x-ibm-linux-gnu.tar.gz' | sha256sum -c - \
  && curl -fsSL https://storage.googleapis.com/public-bazel-artifacts/toolchains/crosstool-ng/20210601-231954/x86_64-apple-darwin19.tar.gz -o x86_64-apple-darwin19.tar.gz \

--- a/build/builder/mkrelease.sh
+++ b/build/builder/mkrelease.sh
@@ -9,7 +9,6 @@
 # Possible configurations:
 #
 #   - amd64-linux-gnu:      amd64, Linux 2.6.32, dynamically link glibc 2.12.2
-#   - amd64-linux-msan:     amd64, recent Linux, enable Clang's memory sanitizer
 #   - arm64-linux-gnueabi:  arm64, Linux 3.7.10, dynamically link glibc 2.12.2
 #   - amd64-darwin:         amd64, macOS 10.9
 #   - amd64-windows:        amd64, Windows 8, statically link all non-Windows libraries
@@ -62,16 +61,6 @@ case "${1-}" in
       TARGET_TRIPLE=aarch64-unknown-linux-gnueabi
       LDFLAGS="-static-libgcc -static-libstdc++"
       SUFFIX=-linux-3.7.10-gnu-aarch64
-    ) ;;
-
-  ?(amd64-)linux-msan)
-    flags="-fsanitize=memory -fsanitize-memory-track-origins -fno-omit-frame-pointer -I/libcxx_msan/include -I/libcxx_msan/include/c++/v1"
-    args=(
-      CFLAGS="$flags"
-      CXXFLAGS="$flags"
-      LDFLAGS="-fsanitize=memory -stdlib=libc++ -L/libcxx_msan/lib -lc++abi -Wl,-rpath,/libcxx_msan/lib"
-      GOFLAGS=-msan
-      TAGS=stdmalloc
     ) ;;
 
   ?(amd64-)darwin)

--- a/build/toolchains/toolchainbuild/perform-build.sh
+++ b/build/toolchains/toolchainbuild/perform-build.sh
@@ -101,15 +101,6 @@ apt-get update \
   && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-10 100 \
     --slave /usr/bin/clang++ clang++ /usr/bin/clang++-10
 
-# Build an msan-enabled build of libc++, following instructions from
-# https://github.com/google/sanitizers/wiki/MemorySanitizerLibcxxHowTo
-mkdir llvm \
- && curl -sfSL https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/llvm-10.0.0.src.tar.xz      | tar --strip-components=1 -C llvm -xJ \
- && mkdir libcxx    && curl -sfSL https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/libcxx-10.0.0.src.tar.xz    | tar --strip-components=1 -C libcxx -xJ \
- && mkdir libcxxabi && curl -sfSL https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/libcxxabi-10.0.0.src.tar.xz | tar --strip-components=1 -C libcxxabi -xJ \
- && mkdir libcxx_msan && (cd libcxx_msan && cmake ../llvm -DCMAKE_BUILD_TYPE=Release -DLLVM_USE_SANITIZER=Memory -DLLVM_ENABLE_PROJECTS="libcxx;libcxxabi" && make cxx -j$(nproc)) \
- && rm -rf llvm libcxx libcxxabi
-
 # libtapi is required for later versions of MacOSX.
 git clone https://github.com/tpoechtrager/apple-libtapi.git \
     && cd apple-libtapi \
@@ -150,4 +141,3 @@ bundle /x-tools/aarch64-unknown-linux-gnu
 bundle /x-tools/s390x-ibm-linux-gnu
 bundle /x-tools/x86_64-w64-mingw32
 bundle /x-tools/x86_64-apple-darwin19
-bundle /libcxx_msan


### PR DESCRIPTION
This is no longer supported.

Release note: None