### PR TITLE
kv: don't recompute raft.enqueued.pending on each Raft message

### DIFF
--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -1332,11 +1332,7 @@ func (r *Replica) sendRaftMessageRequest(ctx context.Context, req *RaftMessageRe
 	if log.V(4) {
 		log.Infof(ctx, "sending raft request %+v", req)
 	}
-	ok := r.store.cfg.Transport.SendAsync(req, r.connectionClass.get())
-	// TODO(peter): Looping over all of the outgoing Raft message queues to
-	// update this stat on every send is a bit expensive.
-	r.store.metrics.RaftEnqueuedPending.Update(r.store.cfg.Transport.queuedMessageCount())
-	return ok
+	return r.store.cfg.Transport.SendAsync(req, r.connectionClass.get())
 }
 
 func (r *Replica) reportSnapshotStatus(ctx context.Context, to roachpb.ReplicaID, snapErr error) {

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2606,6 +2606,8 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 		s.cfg.ClosedTimestamp.Tracker.FailedCloseAttempts(),
 	)
 
+	s.metrics.RaftEnqueuedPending.Update(s.cfg.Transport.queuedMessageCount())
+
 	return nil
 }
 


### PR DESCRIPTION
This commit replaces the call to `(*RaftTransport).queuedMessageCount` on each Raft message with a call to the function once every 10 seconds from the Node's `compute-metrics` loop. This is a sizable win because the TODO here was right - calling this function on each Raft message is quite expensive. Specifically, its cost is linear with respect to the size of the cluster, so it really starts to hurt on larger clusters.

On a 96-node cluster running TPC-E, this call showed up prominently in CPU profiles, accounting for **2.21%** of CPU utilization on 30 vCPU machines!

<img width="1656" alt="Screen Shot 2021-06-08 at 11 56 23 PM" src="https://user-images.githubusercontent.com/5438456/121292794-87a1d600-c8b8-11eb-856e-d7074e190b99.png">
