### PR TITLE
sql: stop creating superfluous indexes after primary key change

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -732,7 +732,6 @@ t2  CREATE TABLE public.t2 (
     x INT8 NOT NULL,
     y INT8 NOT NULL,
     CONSTRAINT "primary" PRIMARY KEY (x ASC, y ASC),
-    UNIQUE INDEX t2_x_y_key (x ASC, y ASC),
     FAMILY fam_0_x_y (x, y)
 )
 
@@ -1427,8 +1426,6 @@ child3_x_key      y  ASC
 child3_x_y_z_key  x  ASC
 child3_x_y_z_key  y  ASC
 child3_x_y_z_key  z  ASC
-child3_x_y_key    x  ASC
-child3_x_y_key    y  ASC
 
 statement ok
 drop table t1;
@@ -1459,3 +1456,66 @@ table_with_virtual_cols  CREATE TABLE public.table_with_virtual_cols (
                          UNIQUE INDEX table_with_virtual_cols_id_key (id ASC),
                          FAMILY fam_0_id_new_pk (id, new_pk)
 )
+
+# Test that we do not create new indexes for the old primary key when going
+# from sharded to non-sharded and back.
+subtest toggle_sharded_no_new_index
+
+statement ok
+DROP TABLE IF EXISTS t;
+CREATE TABLE t (i INT PRIMARY KEY)
+
+query TTT
+SELECT index_name,column_name,direction FROM [SHOW INDEXES FROM t]
+----
+primary  i  ASC
+
+statement ok
+ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (i) USING HASH WITH BUCKET_COUNT = 2
+
+query TTT
+SELECT index_name,column_name,direction FROM [SHOW INDEXES FROM t]
+----
+primary  crdb_internal_i_shard_2  ASC
+primary  i                        ASC
+
+statement ok
+ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (i);
+
+query TTT
+SELECT index_name,column_name,direction FROM [SHOW INDEXES FROM t]
+----
+primary  i  ASC
+
+# Test that we do not create new indexes for the old primary key when going
+# from interleaved to non-interleaved and back.
+subtest toggle_interleaved_no_new_index
+
+statement ok
+DROP TABLE IF EXISTS parent, child;
+CREATE TABLE parent (i INT PRIMARY KEY);
+CREATE TABLE child (i INT REFERENCES "parent" (i), j INT, PRIMARY KEY (i, j))
+
+query TTT
+SELECT index_name,column_name,direction FROM [SHOW INDEXES FROM child]
+----
+primary  i  ASC
+primary  j  ASC
+
+statement ok
+ALTER TABLE child ALTER PRIMARY KEY USING COLUMNS (i, j) INTERLEAVE IN PARENT "parent" (i)
+
+query TTT
+SELECT index_name,column_name,direction FROM [SHOW INDEXES FROM child]
+----
+primary  i  ASC
+primary  j  ASC
+
+statement ok
+ALTER TABLE child ALTER PRIMARY KEY USING COLUMNS (i, j);
+
+query TTT
+SELECT index_name,column_name,direction FROM [SHOW INDEXES FROM child]
+----
+primary  i  ASC
+primary  j  ASC

--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -725,6 +725,17 @@ CREATE TABLE t2 (x INT, y INT, PRIMARY KEY (x, y), FAMILY (x, y)) INTERLEAVE IN 
 ALTER TABLE t2 ALTER PRIMARY KEY USING COLUMNS (x, y);
 DROP TABLE t1
 
+query TT
+SHOW CREATE t2
+----
+t2  CREATE TABLE public.t2 (
+    x INT8 NOT NULL,
+    y INT8 NOT NULL,
+    CONSTRAINT "primary" PRIMARY KEY (x ASC, y ASC),
+    UNIQUE INDEX t2_x_y_key (x ASC, y ASC),
+    FAMILY fam_0_x_y (x, y)
+)
+
 statement ok
 DROP TABLE IF EXISTS t;
 CREATE TABLE t (x INT NOT NULL);
@@ -1312,10 +1323,10 @@ alter table t1 alter primary key using columns(id desc);
 query TTT
 select index_name,column_name,direction from [show indexes from t1];
 ----
-primary  id  DESC
-t1_id_id2_key  id  ASC
+primary        id   DESC
+t1_id_id2_key  id   ASC
 t1_id_id2_key  id2  ASC
-t1_id_key id  ASC
+t1_id_key      id   ASC
 
 statement ok
 alter table t1 alter primary key using columns(id desc);
@@ -1323,10 +1334,10 @@ alter table t1 alter primary key using columns(id desc);
 query TTT
 select index_name,column_name,direction from [show indexes from t1];
 ----
-primary  id  DESC
-t1_id_id2_key  id  ASC
+primary        id   DESC
+t1_id_id2_key  id   ASC
 t1_id_id2_key  id2  ASC
-t1_id_key id  ASC
+t1_id_key      id   ASC
 
 statement ok
 alter table t1 alter primary key using columns(id) USING HASH WITH BUCKET_COUNT = 10
@@ -1349,6 +1360,11 @@ CREATE TABLE parent3 (x INT, y INT, PRIMARY KEY (x, y), FAMILY (x, y));
 
 statement ok
 CREATE TABLE child3 (x INT PRIMARY KEY, y INT NOT NULL, z INT NOT NULL, FAMILY (x, y, z));
+
+query TTT
+select index_name,column_name,direction from [show indexes from child3];
+----
+primary  x  ASC
 
 statement ok
 INSERT INTO parent3 VALUES (1, 2), (4, 5);
@@ -1395,6 +1411,24 @@ child3_x_key      y  ASC
 child3_x_y_z_key  x  ASC
 child3_x_y_z_key  y  ASC
 child3_x_y_z_key  z  ASC
+
+# De-interleave the table and show that the indexes are dropped.
+
+statement ok
+ALTER TABLE child3 ALTER PRIMARY KEY USING COLUMNS (x, y)
+
+query TTT
+select index_name,column_name,direction from [show indexes from child3];
+----
+primary           x  ASC
+primary           y  ASC
+child3_x_key      x  ASC
+child3_x_key      y  ASC
+child3_x_y_z_key  x  ASC
+child3_x_y_z_key  y  ASC
+child3_x_y_z_key  z  ASC
+child3_x_y_key    x  ASC
+child3_x_y_key    y  ASC
 
 statement ok
 drop table t1;


### PR DESCRIPTION
The logic prior to this change would maintain the old primary index as a new
unique constraint even in cases where the key columns and directions remain
the same between the new and old index. This meaningfully happens when moving
from or to hash sharding from not or from or two interleaving from not.
    
Fixes #64838.

Release note (bug fix): Fixes a bug where a superfluous unique constraint would
be added to a table during a primary key change when the primary key change
specifies a new primary key constraint that involves the same columns in the
same directions.