### PR TITLE
roachprod: fix local SSD setup on GCE

### DIFF
--- a/pkg/cmd/roachprod/vm/gce/gcloud.go
+++ b/pkg/cmd/roachprod/vm/gce/gcloud.go
@@ -277,7 +277,7 @@ func (o *providerOpts) ConfigureCreateFlags(flags *pflag.FlagSet) {
 		"Image to use to create the vm, "+
 			"use `gcloud compute images list --filter=\"family=ubuntu-2004-lts\"` to list available images")
 
-	flags.IntVar(&o.SSDCount, ProviderName+"-local-ssd-count", 0,
+	flags.IntVar(&o.SSDCount, ProviderName+"-local-ssd-count", 1,
 		"Number of local SSDs to create, only used if local-ssd=true")
 	flags.StringVar(&o.PDVolumeType, ProviderName+"-pd-volume-type", "pd-ssd",
 		"Type of the persistent disk volume, only used if local-ssd=false")


### PR DESCRIPTION
In #65941, local SSDs were disabled on GCE even when `--local-ssd=true`.
This patch reverts that change, since it broke a bunch of roachtests that
relied on having the 375 GB SSDs available.

Resolves #66230.
Resolves #66231.
Resolves #66232.
Resolves #66234.
Resolves #66235.
Resolves #66237.
Resolves #66238.
Resolves #66240.
Resolves #66241.
Resolves #66242.
Resolves #66243.
Resolves #66244.
Resolves #66247.
Resolves #66248.
Resolves #66249.
Resolves #66250.
Resolves #66251.

Release note: None