### PR TITLE
cli/sql: support the `border` parameter like `psql`

### DIFF
--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -145,6 +145,11 @@ type cliContext struct {
 	// tableDisplayFormat indicates how to format result tables.
 	tableDisplayFormat tableDisplayFormat
 
+	// tableBorderMode indicates how to format tables when the display
+	// format is 'table'. This exists for compatibility
+	// with psql: https://www.postgresql.org/docs/12/app-psql.html
+	tableBorderMode int
+
 	// cmdTimeout sets the maximum run time for the command.
 	// Commands that wish to use this must use cmdTimeoutContext().
 	cmdTimeout time.Duration
@@ -211,6 +216,7 @@ func setCliContextDefaults() {
 	// See also setCLIDefaultForTests() in cli_test.go.
 	cliCtx.terminalOutput = isatty.IsTerminal(os.Stdout.Fd())
 	cliCtx.tableDisplayFormat = tableDisplayTSV
+	cliCtx.tableBorderMode = 0 /* no outer lines + no inside row lines */
 	if cliCtx.terminalOutput {
 		// See also setCLIDefaultForTests() in cli_test.go.
 		cliCtx.tableDisplayFormat = tableDisplayTable

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -337,6 +337,23 @@ var options = map[string]struct {
 			return sqlCtx.autoTrace
 		},
 	},
+	`border`: {
+		description:               "the border style for the display format 'table'",
+		isBoolean:                 false,
+		validDuringMultilineEntry: true,
+		set: func(val string) error {
+			v, err := strconv.Atoi(val)
+			if err != nil {
+				return err
+			}
+			if v < 0 || v > 3 {
+				return errors.New("only values between 0 and 4 are supported")
+			}
+			cliCtx.tableBorderMode = v
+			return nil
+		},
+		display: func() string { return strconv.Itoa(cliCtx.tableBorderMode) },
+	},
 	`display_format`: {
 		description:               "the output format for tabular data (table, csv, tsv, html, sql, records, raw)",
 		isBoolean:                 false,

--- a/pkg/cli/sql_format_table.go
+++ b/pkg/cli/sql_format_table.go
@@ -275,7 +275,21 @@ func (p *asciiTableReporter) describe(w io.Writer, cols []string) error {
 		p.table = tablewriter.NewWriter(w)
 		p.table.SetAutoFormatHeaders(false)
 		p.table.SetAutoWrapText(false)
-		p.table.SetBorder(false)
+		var outsideBorders, insideLines bool
+		// The following table border modes are taken from psql.
+		// https://www.postgresql.org/docs/12/app-psql.html
+		switch cliCtx.tableBorderMode {
+		case 0:
+			outsideBorders, insideLines = false, false
+		case 1:
+			outsideBorders, insideLines = false, true
+		case 2:
+			outsideBorders, insideLines = true, false
+		case 3:
+			outsideBorders, insideLines = true, true
+		}
+		p.table.SetBorder(outsideBorders)
+		p.table.SetRowLine(insideLines)
 		p.table.SetReflowDuringAutoWrap(false)
 		p.table.SetHeader(expandedCols)
 		p.table.SetTrimWhiteSpaceAtEOL(true)

--- a/pkg/cli/sql_format_table_test.go
+++ b/pkg/cli/sql_format_table_test.go
@@ -13,6 +13,7 @@ package cli
 import (
 	"bytes"
 	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -656,6 +657,53 @@ func Example_sql_table() {
 	// ## 4
 	// tabs
 	// # 9 rows
+}
+
+func Example_sql_table_border() {
+	c := NewCLITest(TestCLIParams{})
+	defer c.Cleanup()
+
+	for i := 0; i < 4; i++ {
+		c.RunWithArgs([]string{`sql`, `--format=table`, `--set`, `border=` + strconv.Itoa(i),
+			`-e`, `values (123, '123'), (456, e'456\nfoobar')`})
+	}
+
+	// Output:
+	// sql --format=table --set border=0 -e values (123, '123'), (456, e'456\nfoobar')
+	//   column1 | column2
+	// ----------+----------
+	//       123 | 123
+	//       456 | 456
+	//           | foobar
+	// (2 rows)
+	// sql --format=table --set border=1 -e values (123, '123'), (456, e'456\nfoobar')
+	//   column1 | column2
+	// ----------+----------
+	//       123 | 123
+	// ----------+----------
+	//       456 | 456
+	//           | foobar
+	// ----------+----------
+	// (2 rows)
+	// sql --format=table --set border=2 -e values (123, '123'), (456, e'456\nfoobar')
+	// +---------+---------+
+	// | column1 | column2 |
+	// +---------+---------+
+	// |     123 | 123     |
+	// |     456 | 456     |
+	// |         | foobar  |
+	// +---------+---------+
+	// (2 rows)
+	// sql --format=table --set border=3 -e values (123, '123'), (456, e'456\nfoobar')
+	// +---------+---------+
+	// | column1 | column2 |
+	// +---------+---------+
+	// |     123 | 123     |
+	// +---------+---------+
+	// |     456 | 456     |
+	// |         | foobar  |
+	// +---------+---------+
+	// (2 rows)
 }
 
 func TestRenderHTML(t *testing.T) {


### PR DESCRIPTION
Fixes #30851.
Requested by @rmloveland 

Example:

```
sql --format=table --set border=0 -e values (123, '123'), (456, e'456\nfoobar')
  column1 | column2
----------+----------
      123 | 123
      456 | 456
          | foobar
(2 rows)

sql --format=table --set border=1 -e values (123, '123'), (456, e'456\nfoobar')
  column1 | column2
----------+----------
      123 | 123
----------+----------
      456 | 456
          | foobar
----------+----------
(2 rows)

sql --format=table --set border=2 -e values (123, '123'), (456, e'456\nfoobar')
+---------+---------+
| column1 | column2 |
+---------+---------+
|     123 | 123     |
|     456 | 456     |
|         | foobar  |
+---------+---------+
(2 rows)

sql --format=table --set border=3 -e values (123, '123'), (456, e'456\nfoobar')
+---------+---------+
| column1 | column2 |
+---------+---------+
|     123 | 123     |
+---------+---------+
|     456 | 456     |
|         | foobar  |
+---------+---------+
(2 rows)
```

Release note (cli change): `cockroach sql` and `cockroach demo`
now support the client-side parameter `border` like `psql`.