### PR TITLE
cli/sql: fix the handling of client-side commands

### DIFF
--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -243,6 +243,10 @@ var sqlCtx = struct {
 	// Only valid if inputFile is empty.
 	execStmts statementsValue
 
+	// quitAfterExecStmts tells the shell whether to quit
+	// after processing the execStmts.
+	quitAfterExecStmts bool
+
 	// inputFile is the file to read from.
 	// If empty, os.Stdin is used.
 	// Only valid if execStmts is empty.
@@ -300,6 +304,7 @@ var sqlCtx = struct {
 func setSQLContextDefaults() {
 	sqlCtx.setStmts = nil
 	sqlCtx.execStmts = nil
+	sqlCtx.quitAfterExecStmts = false
 	sqlCtx.inputFile = ""
 	sqlCtx.repeatDelay = 0
 	sqlCtx.safeUpdates = false

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -1464,7 +1464,12 @@ func (c *cliState) doRunShell(state cliStateEnum, cmdIn *os.File) (exitErr error
 			}
 			if len(sqlCtx.execStmts) > 0 {
 				// Single-line sql; run as simple as possible, without noise on stdout.
-				return c.runStatements(sqlCtx.execStmts)
+				if err := c.runStatements(sqlCtx.execStmts); err != nil {
+					return err
+				}
+				if sqlCtx.quitAfterExecStmts {
+					return nil
+				}
 			}
 
 			state = c.doStart(cliStartLine)
@@ -1603,13 +1608,18 @@ func (c *cliState) configurePreShellDefaults(cmdIn *os.File) (cleanupFn func(), 
 		}
 	}
 
-	// After all the local options have been computed/initialized above,
-	// process any overrides from the command line.
-	for i := range sqlCtx.setStmts {
-		if c.handleSet(sqlCtx.setStmts[i:i+1], cliStart, cliStop) == cliStop {
-			return cleanupFn, c.exitErr
+	// If any --set flags were set through the command line,
+	// synthetize '-e set=xxx' statements for them at the beginning.
+	sqlCtx.quitAfterExecStmts = len(sqlCtx.execStmts) > 0
+	if len(sqlCtx.setStmts) > 0 {
+		setStmts := make([]string, 0, len(sqlCtx.setStmts)+len(sqlCtx.execStmts))
+		for _, s := range sqlCtx.setStmts {
+			setStmts = append(setStmts, `\set `+s)
 		}
+		sqlCtx.setStmts = nil
+		sqlCtx.execStmts = append(setStmts, sqlCtx.execStmts...)
 	}
+
 	return cleanupFn, nil
 }
 
@@ -1622,7 +1632,17 @@ func (c *cliState) runStatements(stmts []string) error {
 			// because we need a different error handling mechanism:
 			// the error, if any, must not be printed to stderr if
 			// we are returning directly.
-			c.exitErr = runQueryAndFormatResults(c.conn, os.Stdout, makeQuery(stmt))
+			if strings.HasPrefix(stmt, `\`) {
+				// doHandleCliCmd takes its input from c.lastInputLine.
+				c.lastInputLine = stmt
+				if nextState := c.doHandleCliCmd(cliRunStatement, cliStop); nextState == cliStop && c.exitErr == nil {
+					// The client-side command failed with an error, but
+					// did not populate c.exitErr itself. Do it here.
+					c.exitErr = errors.New("error in client-side command")
+				}
+			} else {
+				c.exitErr = runQueryAndFormatResults(c.conn, os.Stdout, makeQuery(stmt))
+			}
 			if c.exitErr != nil {
 				if !sqlCtx.errExit && i < len(stmts)-1 {
 					// Print the error now because we don't get a chance later.

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -291,7 +291,8 @@ func (c *cliState) invalidOptSet(nextState cliStateEnum, args []string) cliState
 }
 
 func (c *cliState) invalidOptionChange(nextState cliStateEnum, opt string) cliStateEnum {
-	fmt.Fprintf(stderr, "cannot change option during multi-line editing: %s\n", opt)
+	c.exitErr = errors.Newf("cannot change option during multi-line editing: %s\n", opt)
+	fmt.Fprintln(stderr, c.exitErr)
 	return nextState
 }
 
@@ -496,6 +497,7 @@ func (c *cliState) handleSet(args []string, nextState, errState cliStateEnum) cl
 
 	if err != nil {
 		fmt.Fprintf(stderr, "\\set %s: %v\n", strings.Join(args, " "), err)
+		c.exitErr = err
 		return errState
 	}
 
@@ -516,6 +518,7 @@ func (c *cliState) handleUnset(args []string, nextState, errState cliStateEnum) 
 	}
 	if err := opt.reset(); err != nil {
 		fmt.Fprintf(stderr, "\\unset %s: %v\n", args[0], err)
+		c.exitErr = err
 		return errState
 	}
 	return nextState
@@ -630,6 +633,7 @@ func (c *cliState) handleHelp(cmd []string, nextState, errState cliStateEnum) cl
 		} else {
 			fmt.Fprintf(stderr,
 				"no help available for %q.\nTry \\h with no argument to see available help.\n", cmdrest)
+			c.exitErr = errors.New("no help available")
 			return errState
 		}
 	}
@@ -651,6 +655,7 @@ func (c *cliState) handleFunctionHelp(cmd []string, nextState, errState cliState
 		} else {
 			fmt.Fprintf(stderr,
 				"no help available for %q.\nTry \\hf with no argument to see available help.\n", funcName)
+			c.exitErr = errors.New("no help available")
 			return errState
 		}
 	}

--- a/pkg/cli/sql_test.go
+++ b/pkg/cli/sql_test.go
@@ -51,6 +51,7 @@ func Example_sql() {
 	c.RunWithArgs([]string{`sql`, `--set=errexit=0`, `-e`, `select nonexistent`, `-e`, `select 123 as "123"`})
 	c.RunWithArgs([]string{`sql`, `--set`, `echo=true`, `-e`, `select 123 as "123"`})
 	c.RunWithArgs([]string{`sql`, `--set`, `unknownoption`, `-e`, `select 123 as "123"`})
+	c.RunWithArgs([]string{`sql`, `--set`, `display_format=invalidvalue`, `-e`, `select 123 as "123"`})
 	// Check that partial results + error get reported together. The query will
 	// run via the vectorized execution engine which operates on the batches of
 	// growing capacity starting at 1 (the batch sizes will be 1, 2, 4, ...),
@@ -115,6 +116,9 @@ func Example_sql() {
 	// sql --set unknownoption -e select 123 as "123"
 	// invalid syntax: \set unknownoption. Try \? for help.
 	// ERROR: invalid syntax
+	// sql --set display_format=invalidvalue -e select 123 as "123"
+	// \set display_format invalidvalue: invalid table display format: invalidvalue (possible values: tsv, csv, table, records, sql, html, raw)
+	// ERROR: invalid table display format: invalidvalue (possible values: tsv, csv, table, records, sql, html, raw)
 	// sql -e select 1/(@1-2) from generate_series(1,3)
 	// ?column?
 	// -1


### PR DESCRIPTION
Planning to backport this.

Release note (bug fix): The command exit status of `cockroach demo`
and `cockroach sql` is now properly set to non-zero (error) after
an error was encountered in a client-side command.
Additionally, `cockroach sql` and `cockroach demo` now properly
stop upon encountering an invalid configuration with `--set`, instead
of starting to execute SQL statements after the invalid configuration.

Release note (cli change): `cockroach demo` and `cockroach sql` are
now able to run client-side commands via the `-e` command-line
flag. This makes it possible to use commands like `\dt` or `\hf` from
a shell script.