### PR TITLE
roachtest: don't post issues from non-release branches

### DIFF
--- a/pkg/cmd/internal/issues/issues.go
+++ b/pkg/cmd/internal/issues/issues.go
@@ -253,6 +253,12 @@ func (o *Options) CanPost() bool {
 	return o.Token != ""
 }
 
+// IsReleaseBranch returns true for branches that we want to treat as
+// "release" branches, including master and provisional branches.
+func (o *Options) IsReleaseBranch() bool {
+	return o.Branch == "master" || strings.HasPrefix(o.Branch, "release-") || strings.HasPrefix(o.Branch, "provisional_")
+}
+
 // TemplateData is the input on which an IssueFormatter operates. It has
 // everything known about the test failure in a predigested form.
 type TemplateData struct {

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -655,53 +655,7 @@ func (r *testRunner) runTest(
 			}
 
 			shout(ctx, l, stdout, "--- FAIL: %s (%s)\n%s", t.Name(), durationStr, output)
-			// NB: check NodeCount > 0 to avoid posting issues from this pkg's unit tests.
-			if issues.DefaultOptionsFromEnv().CanPost() && t.spec.Run != nil && t.spec.Cluster.NodeCount > 0 {
-				teams, err := team.DefaultLoadTeams()
-				if err != nil {
-					t.Fatalf("could not load teams: %v", err)
-				}
-				alias := ownerToAlias(t.spec.Owner)
-				owner := teams[ownerToAlias(t.spec.Owner)]
-
-				branch := "<unknown branch>"
-				if b := os.Getenv("TC_BUILD_BRANCH"); b != "" {
-					branch = b
-				}
-				msg := fmt.Sprintf("The test failed on branch=%s, cloud=%s:\n%s",
-					branch, cloud, output)
-				artifacts := fmt.Sprintf("/%s", t.Name())
-
-				// Issues posted from roachtest are identifiable as such and
-				// they are also release blockers (this label may be removed
-				// by a human upon closer investigation).
-				labels := []string{"O-roachtest"}
-				if !t.spec.NonReleaseBlocker {
-					labels = append(labels, "release-blocker")
-				}
-
-				req := issues.PostRequest{
-					AuthorEmail:     "", // intentionally unset - we add to the board and cc the team
-					Mention:         []string{"@" + string(alias)},
-					ProjectColumnID: owner.TriageColumnID,
-					PackageName:     "roachtest",
-					TestName:        t.Name(),
-					Message:         msg,
-					Artifacts:       artifacts,
-					ExtraLabels:     labels,
-					ReproductionCommand: fmt.Sprintf(
-						`# From https://go.crdb.dev/p/roachstress, perhaps edited lightly.
-caffeinate ./roachstress.sh %s
-`, t.Name()),
-				}
-				if err := issues.Post(
-					context.Background(),
-					issues.UnitTestFormatter,
-					req,
-				); err != nil {
-					shout(ctx, l, stdout, "failed to post issue: %s", err)
-				}
-			}
+			r.maybePostGithubIssue(ctx, l, t, stdout, output)
 		} else {
 			shout(ctx, l, stdout, "--- PASS: %s (%s)", t.Name(), durationStr)
 			// If `##teamcity[testFailed ...]` is not present before `##teamCity[testFinished ...]`,
@@ -901,6 +855,65 @@ caffeinate ./roachstress.sh %s
 		return false, nil
 	}
 	return true, nil
+}
+
+func (r *testRunner) shouldPostGithubIssue(t *test) bool {
+	// NB: check NodeCount > 0 to avoid posting issues from this pkg's unit tests.
+	opts := issues.DefaultOptionsFromEnv()
+	return opts.CanPost() && opts.IsReleaseBranch() && t.spec.Run != nil && t.spec.Cluster.NodeCount > 0
+}
+
+func (r *testRunner) maybePostGithubIssue(
+	ctx context.Context, l *logger, t *test, stdout io.Writer, output string,
+) {
+	if !r.shouldPostGithubIssue(t) {
+		return
+	}
+
+	teams, err := team.DefaultLoadTeams()
+	if err != nil {
+		t.Fatalf("could not load teams: %v", err)
+	}
+	alias := ownerToAlias(t.spec.Owner)
+	owner := teams[ownerToAlias(t.spec.Owner)]
+
+	branch := "<unknown branch>"
+	if b := os.Getenv("TC_BUILD_BRANCH"); b != "" {
+		branch = b
+	}
+	msg := fmt.Sprintf("The test failed on branch=%s, cloud=%s:\n%s",
+		branch, cloud, output)
+	artifacts := fmt.Sprintf("/%s", t.Name())
+
+	// Issues posted from roachtest are identifiable as such and
+	// they are also release blockers (this label may be removed
+	// by a human upon closer investigation).
+	labels := []string{"O-roachtest"}
+	if !t.spec.NonReleaseBlocker {
+		labels = append(labels, "release-blocker")
+	}
+
+	req := issues.PostRequest{
+		AuthorEmail:     "", // intentionally unset - we add to the board and cc the team
+		Mention:         []string{"@" + string(alias)},
+		ProjectColumnID: owner.TriageColumnID,
+		PackageName:     "roachtest",
+		TestName:        t.Name(),
+		Message:         msg,
+		Artifacts:       artifacts,
+		ExtraLabels:     labels,
+		ReproductionCommand: fmt.Sprintf(
+			`# From https://go.crdb.dev/p/roachstress, perhaps edited lightly.
+caffeinate ./roachstress.sh %s
+`, t.Name()),
+	}
+	if err := issues.Post(
+		context.Background(),
+		issues.UnitTestFormatter,
+		req,
+	); err != nil {
+		shout(ctx, l, stdout, "failed to post issue: %s", err)
+	}
 }
 
 func (r *testRunner) collectClusterLogs(ctx context.Context, c *cluster, l *logger) {


### PR DESCRIPTION
Our build support scripts guard most calls to github-post with a
conditional based on the branch name.

Roachtest, however, knows how to post github issues directly. This
change uses the same branch-named based conditional to prevent github
issues being opened for development branches.

It looks like build/teamcity-nightly-pebble-metamorphic.sh and
build/teamcity-stress.sh call github-post without any branch checking,
so it may be worth adding this feature as an option to the github-post
tool itself.

Release note: None