### PR TITLE
cli/sql: support the `\c` / `\connect` client-side command

### DIFF
--- a/pkg/cli/clisqlshell/BUILD.bazel
+++ b/pkg/cli/clisqlshell/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/cli/clisqlexec",
         "//pkg/cli/democluster/api",
         "//pkg/docs",
+        "//pkg/server/pgurl",
         "//pkg/sql/lexbase",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",

--- a/pkg/cli/clisqlshell/api.go
+++ b/pkg/cli/clisqlshell/api.go
@@ -10,10 +10,18 @@
 
 package clisqlshell
 
-import "os"
+import (
+	"os"
+
+	"github.com/cockroachdb/cockroach/pkg/server/pgurl"
+)
 
 // Shell represents an interactive shell
 type Shell interface {
 	// RunInteractive runs the shell.
 	RunInteractive(cmdIn, cmdOut, cmdErr *os.File) (exitErr error)
 }
+
+// URLParser represents a function able to convert user-supplied
+// strings to a URL object.
+type URLParser = func(url string) (*pgurl.URL, error)

--- a/pkg/cli/clisqlshell/context.go
+++ b/pkg/cli/clisqlshell/context.go
@@ -35,6 +35,13 @@ type Context struct {
 	// DemoCluster is the interface to the in-memory cluster for the
 	// `demo` command, if that is the command being run.
 	DemoCluster democlusterapi.DemoCluster
+
+	// ParseURL is a custom URL parser.
+	//
+	// When left undefined, the code defaults to pgurl.Parse.
+	// CockroachDB's own CLI package has a more advanced URL
+	// parser that is used instead.
+	ParseURL URLParser
 }
 
 // internalContext represents the internal configuration state of the
@@ -61,4 +68,7 @@ type internalContext struct {
 
 	// The string used to produce the value of fullPrompt.
 	customPromptPattern string
+
+	// current database name, if known. This is maintained on a best-effort basis.
+	dbName string
 }

--- a/pkg/cli/demo.go
+++ b/pkg/cli/demo.go
@@ -342,6 +342,7 @@ func runDemo(cmd *cobra.Command, gen workload.Generator) (resErr error) {
 	}
 	defer func() { resErr = errors.CombineErrors(resErr, conn.Close()) }()
 
+	sqlCtx.ShellCtx.ParseURL = makeURLParser(cmd)
 	return sqlCtx.Run(conn)
 }
 

--- a/pkg/cli/interactive_tests/test_connect_cmd.tcl
+++ b/pkg/cli/interactive_tests/test_connect_cmd.tcl
@@ -1,0 +1,143 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+set certs_dir "/certs"
+set ::env(COCKROACH_INSECURE) "false"
+set ::env(COCKROACH_HOST) "localhost"
+
+proc start_secure_server {argv certs_dir extra} {
+    report "BEGIN START SECURE SERVER"
+    system "$argv start-single-node --host=localhost --socket-dir=. --certs-dir=$certs_dir --pid-file=server_pid -s=path=logs/db --background $extra >>expect-cmd.log 2>&1;
+            $argv sql --certs-dir=$certs_dir -e 'select 1'"
+    report "END START SECURE SERVER"
+}
+
+proc stop_secure_server {argv certs_dir} {
+    report "BEGIN STOP SECURE SERVER"
+    system "$argv quit --certs-dir=$certs_dir"
+    report "END STOP SECURE SERVER"
+}
+
+start_secure_server $argv $certs_dir ""
+
+spawn $argv sql --certs-dir=$certs_dir
+eexpect root@
+
+start_test "Test initialization"
+send "create database t; set database = t;\r"
+eexpect root@
+eexpect "/t>"
+
+start_test "Check that the client-side connect cmd prints the current conn details"
+send "\\c\r"
+eexpect "Connection string:"
+eexpect "You are connected to database \"t\" as user \"root\""
+eexpect root@
+eexpect "/t>"
+
+start_test "Check that the client-side connect cmd changes databases using a SET statement"
+send "\\c invaliddb\r"
+eexpect database
+eexpect "does not exist"
+eexpect root@
+eexpect "/t>"
+
+send "\\c system\r"
+eexpect SET
+eexpect root@
+eexpect "/system>"
+end_test
+
+start_test "Check that the client-side connect cmd can change users using a password"
+send "create user foo with password 'abc';\r"
+eexpect "CREATE ROLE"
+eexpect root@
+
+send "\\c - foo\r"
+eexpect "using new connection URL"
+eexpect "Connecting to server"
+eexpect "as user \"foo\""
+eexpect "Enter password:"
+send "foo\r"
+eexpect "password authentication failed"
+eexpect foo@
+eexpect "?>"
+
+send "\\c -\r"
+eexpect "Enter password:"
+send "abc\r"
+eexpect foo@
+eexpect "/system>"
+end_test
+
+start_test "Check that the user can recover from an invalid database"
+send "\\c invaliddb -\r"
+eexpect "Enter password:"
+send "abc\r"
+eexpect "error retrieving the database name"
+eexpect foo@
+eexpect "?>"
+
+send "\\c system -\r"
+eexpect "Enter password:"
+send "abc\r"
+eexpect foo@
+eexpect "/system>"
+end_test
+
+start_test "Check that the client-side connect cmd can change hosts"
+send "\\c - - localhost\r"
+eexpect "using new connection URL"
+eexpect "Connecting to server"
+eexpect "as user \"foo\""
+eexpect "Enter password:"
+send "abc\r"
+eexpect foo@
+eexpect "/system>"
+end_test
+
+start_test "Check that the client-side connect cmd can change ports"
+send "\\c - - - 26257\r"
+eexpect "using new connection URL"
+eexpect "Connecting to server"
+eexpect "as user \"foo\""
+eexpect "Enter password:"
+send "abc\r"
+eexpect foo@
+eexpect "/system>"
+end_test
+
+start_test "Check that the client-side connect cmd can detect syntax errors"
+send "\\c - - - - abc\r"
+eexpect "unknown syntax"
+eexpect foo@
+eexpect "/system>"
+end_test
+
+start_test "Check that the client-side connect cmd recognizes invalid URLs"
+send "\\c postgres://root@localhost:26257/defaultdb?sslmode=invalid&sslcert=$certs_dir%2Fclient.root.crt&sslkey=$certs_dir%2Fclient.root.key&sslrootcert=$certs_dir%2Fca.crt\r"
+eexpect "unrecognized sslmode parameter"
+eexpect foo@
+eexpect "/system>"
+end_test
+
+start_test "Check that the client-side connect cmd can change users with certs using a URL"
+# first test that it can recover from an invalid database
+send "\\c postgres://root@localhost:26257/invaliddb?sslmode=require&sslcert=$certs_dir%2Fclient.root.crt&sslkey=$certs_dir%2Fclient.root.key&sslrootcert=$certs_dir%2Fca.crt\r"
+eexpect "using new connection URL"
+eexpect "error retrieving the database name"
+eexpect root@
+eexpect "?>"
+
+send "\\c postgres://root@localhost:26257/defaultdb?sslmode=require&sslcert=$certs_dir%2Fclient.root.crt&sslkey=$certs_dir%2Fclient.root.key&sslrootcert=$certs_dir%2Fca.crt\r"
+eexpect "using new connection URL"
+eexpect root@
+eexpect "/defaultdb>"
+end_test
+
+send "\\q\r"
+eexpect eof
+
+
+stop_secure_server $argv $certs_dir

--- a/pkg/cli/sql_shell_cmd.go
+++ b/pkg/cli/sql_shell_cmd.go
@@ -14,6 +14,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/cockroachdb/cockroach/pkg/cli/clisqlshell"
+	"github.com/cockroachdb/cockroach/pkg/server/pgurl"
 	"github.com/cockroachdb/errors"
 	"github.com/spf13/cobra"
 )
@@ -55,5 +57,17 @@ func runTerm(cmd *cobra.Command, args []string) (resErr error) {
 	}
 	defer func() { resErr = errors.CombineErrors(resErr, conn.Close()) }()
 
+	sqlCtx.ShellCtx.ParseURL = makeURLParser(cmd)
 	return sqlCtx.Run(conn)
+}
+
+func makeURLParser(cmd *cobra.Command) clisqlshell.URLParser {
+	return func(url string) (*pgurl.URL, error) {
+		// Parse it as if --url was specified.
+		up := urlParser{cmd: cmd, cliCtx: &cliCtx}
+		if err := up.setInternal(url, false /* warn */); err != nil {
+			return nil, err
+		}
+		return cliCtx.sqlConnURL, nil
+	}
 }

--- a/pkg/server/pgurl/parse.go
+++ b/pkg/server/pgurl/parse.go
@@ -81,6 +81,10 @@ func (u *URL) parseOptions(extra url.Values) error {
 		}
 	}
 
+	if _, hasDbOpt := q["database"]; hasDbOpt {
+		u.database = getVal(q, "database")
+		delete(q, "database")
+	}
 	if _, hasUserOpt := q["user"]; hasUserOpt {
 		u.username = getVal(q, "user")
 		delete(q, "user")

--- a/pkg/server/pgurl/pgurl_test.go
+++ b/pkg/server/pgurl/pgurl_test.go
@@ -68,10 +68,13 @@ func TestOptions(t *testing.T) {
 	u := New()
 
 	// Check that AddOptions processes the options as per Parse().
-	err := u.AddOptions(url.Values{"user": []string{"foo"}})
+	err := u.AddOptions(url.Values{"user": []string{"foo"}, "database": []string{"bar"}})
 	require.NoError(t, err)
 	require.Equal(t, u.GetUsername(), "foo")
+	require.Equal(t, u.GetDatabase(), "bar")
 	_, ok := u.extraOptions["user"]
+	require.Equal(t, ok, false)
+	_, ok = u.extraOptions["database"]
 	require.Equal(t, ok, false)
 
 	// Check that non-special options remain in extraOptions.


### PR DESCRIPTION
Fixes #65676.

Release note (cli change): `cockroach sql` and `cockroach demo`
now support the `\c` / `\connect` client-side command, in a way
similar to `psql`:

- `\c` without arguments: display the current connection parameters.
- `\c [DB] [USER] [HOST] [PORT]` connect using the specified
  parameters. Specify '-' to omit one parameter.
- `\c URL` connect using the specified URL.

For example: `\c - myuser` to reconnect to the same server/db as `myuser`.

This feature is intended to ease switching across simulate nodes in
`cockroach demo`.

Note: `\c <dbname>` reuses the existing server connection to
change the current database, using a SET statement. To force a
network reconnect, use `\c -` then `\c <dbname>`, or use `\c <dbname> -`.

Note: When using the syntax with discrete parameters, the generated
URL reuses the same TLS parameters as the original connection,
including the CA certificate used to validate the server. To use
different TLS settings, use `\c <URL>` instead.