### PR TITLE
release-20.2: cloud/amazon: reuse s3 client sessions

### DIFF
--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -14,8 +14,6 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
@@ -1322,13 +1320,6 @@ func (*RangeStatsRequest) flags() int { return isRead }
 // parallel commits.
 func (etr *EndTxnRequest) IsParallelCommit() bool {
 	return etr.Commit && len(etr.InFlightWrites) > 0
-}
-
-// Keys returns credentials in an aws.Config.
-func (b *ExternalStorage_S3) Keys() *aws.Config {
-	return &aws.Config{
-		Credentials: credentials.NewStaticCredentials(b.AccessKey, b.Secret, b.TempToken),
-	}
 }
 
 // BulkOpSummaryID returns the key within a BulkOpSummary's EntryCounts map for


### PR DESCRIPTION
Backport 1/1 commits from #66172.

/cc @cockroachdb/release

---

This changes the s3 client wrapper to optionally cache the last S3 client opened based
on the arguments and then re-use that client for subsequent client opening to the same
bucket with the same session parameters.

This should avoid issues that arise from opening many sessions at once, like hammering
the EC2 metadata server which can then result in it rejecting some requests and the SDK
returning an error like 'NoCredentialProviders: no valid providers in chain'. This is a
particular concern when loading a long chain of incremental backups which, since #47158,
is done in parallel. That parallel loading can generate a flood of new S3 sessions at once
and quickly hit the metadata server's rate limit. With this session the first will establish
a new session, including loading credentials from the metadata server, and subsequent sessions
will reuse it.

Release note (bug fix): Operations like BACKUP can now reuse a previously created S3 client
session when operating on the same bucket, which can avoid NoCredentialProviders errors on
EC2 when interating with large incremental backups.
