### PR TITLE
ui: remove custom charts extra padding

### DIFF
--- a/pkg/ui/src/views/cluster/components/visualization/visualizations.styl
+++ b/pkg/ui/src/views/cluster/components/visualization/visualizations.styl
@@ -55,13 +55,6 @@ $viz-sides = 62px
   .icon-warning
     color $warning-color
 
-// TODO(davidh): Remove this rule once the legend display
-// is redesign for uPlot. Currently it takes up a lot of
-// space below the graph so the last graph needs to make
-// extra room for it.
-.visualization:last-child
-  margin-bottom: 600px
-
 .linegraph
   height 100%
 

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/index.tsx
@@ -65,7 +65,6 @@ import {
   TimeWindow,
   TimeScale,
 } from "src/redux/timewindow";
-
 interface GraphDashboard {
   label: string;
   component: (props: GraphDashboardProps) => React.ReactElement<any>[];
@@ -246,8 +245,17 @@ export class NodeGraphs extends React.Component<NodeGraphsProps> {
       );
     });
 
+    // add pading to have last chart tooltip visible
+    // tooltip layout with header and paddings take up
+    // somewhere around 50px, after it have more than
+    // 9 nodes it switch to multicolumn layout that take
+    // somewhere around 90px height + 10px for per node
+    // as we have 3 columns, we divide node amount on 3
+    const paddingBottom =
+      nodeIDs.length > 8 ? 90 + Math.ceil(nodeIDs.length / 3) * 10 : 50;
+
     return (
-      <div>
+      <div style={{ paddingBottom }}>
         <Helmet title={title} />
         <section className="section">
           <h1 className="base-heading">{title}</h1>


### PR DESCRIPTION
before: 900px padding was added to provide space for chart
legend in the end of metrics page, but this rule corrupt a view
of custom chart page

after: made this padding specific to metric page, calculate it
dynamicly based on node number, this removed mentioned
issue with custom chart page.

Resolves: #64791

Release note(ui): fix custom charts page layout