### PR TITLE
storageccl: don't update file registry when creating unencrypted files

### DIFF
--- a/pkg/storage/pebble_file_registry.go
+++ b/pkg/storage/pebble_file_registry.go
@@ -102,6 +102,12 @@ func (r *PebbleFileRegistry) GetFileEntry(filename string) *enginepb.FileEntry {
 
 // SetFileEntry sets filename => entry in the registry map and persists the registry.
 func (r *PebbleFileRegistry) SetFileEntry(filename string, entry *enginepb.FileEntry) error {
+	// We choose not to store an entry for unencrypted files since the absence of
+	// a file in the file registry implies that it is unencrypted.
+	if entry != nil && entry.EnvType == enginepb.EnvType_Plaintext {
+		return r.MaybeDeleteEntry(filename)
+	}
+
 	filename = r.tryMakeRelativePath(filename)
 	newProto := &enginepb.FileRegistry{}
 


### PR DESCRIPTION
This patch changes PebbleFileRegistry to not store an entry
for an unencrypted file. This should lead to a performance
improvement since the file registry is rewritten every time
it is updated.

Fixes #65430.

Release note: None