### PR TITLE
events: change date time format to 24 hr utc

### DIFF
--- a/pkg/ui/src/util/format.ts
+++ b/pkg/ui/src/util/format.ts
@@ -152,3 +152,8 @@ export const DurationFitScale = (scale: string) => (nanoseconds: number) => {
 };
 
 export const DATE_FORMAT = "MMM DD, YYYY [at] h:mm A";
+
+/**
+ * Alternate 24 hour UTC format
+ */
+export const DATE_FORMAT_24_UTC = "MMM DD, YYYY [at] HH:mm UTC";

--- a/pkg/ui/src/views/cluster/containers/events/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/events/index.tsx
@@ -25,7 +25,7 @@ import { LocalSetting } from "src/redux/localsettings";
 import { AdminUIState } from "src/redux/state";
 import { TimestampToMoment } from "src/util/convert";
 import { getEventDescription } from "src/util/events";
-import { DATE_FORMAT } from "src/util/format";
+import { DATE_FORMAT_24_UTC } from "src/util/format";
 import { SortSetting } from "src/views/shared/components/sortabletable";
 import { SortedTable } from "src/views/shared/components/sortedtable";
 import { ToolTipWrapper } from "src/views/shared/components/toolTip";
@@ -58,7 +58,7 @@ export interface EventRowProps {
 export function getEventInfo(e: Event$Properties): SimplifiedEvent {
   return {
     fromNowString: TimestampToMoment(e.timestamp)
-      .format(DATE_FORMAT)
+      .format(DATE_FORMAT_24_UTC)
       .replace("second", "sec")
       .replace("minute", "min"),
     content: <span>{getEventDescription(e)}</span>,


### PR DESCRIPTION
**what was there before:** Previously, the date time on the events card had a 12 hour format with AM/PM
**why it needed to change:** This was inadequate because it was confusing as it was already UTC time but was displaying with AM/PM
**what you did about it:** To address this, this patch I added a new date time format for 24 hour utc and used this instead of the old date format
**Jira issue:** https://cockroachlabs.atlassian.net/browse/CC-1927