### PR TITLE
opt: improve performance for tables with many columns and indexes

### DIFF
--- a/pkg/sql/opt/xform/select_funcs.go
+++ b/pkg/sql/opt/xform/select_funcs.go
@@ -916,8 +916,8 @@ func (c *CustomFuncs) GenerateZigzagJoins(
 
 	fixedCols := memo.ExtractConstColumns(filters, c.e.evalCtx)
 
-	if fixedCols.Len() == 0 {
-		// Zigzagging isn't helpful in the absence of fixed columns.
+	if fixedCols.Len() < 2 {
+		// Zigzagging requires at least 2 columns to have fixed values.
 		return
 	}
 

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -1143,6 +1143,9 @@ type optIndex struct {
 	idx  catalog.Index
 	zone *zonepb.ZoneConfig
 
+	// columnOrds maps the index columns to table column ordinals.
+	columnOrds []int
+
 	// storedCols is the set of non-PK columns if this is the primary index,
 	// otherwise it is desc.StoreColumnIDs.
 	storedCols []descpb.ColumnID
@@ -1268,6 +1271,26 @@ func (oi *optIndex) init(
 		oi.numLaxKeyCols = idx.NumKeyColumns() + idx.NumKeySuffixColumns()
 		oi.numKeyCols = oi.numLaxKeyCols
 	}
+
+	// Populate columnOrds.
+	inverted := oi.IsInverted()
+	numKeyCols := idx.NumKeyColumns()
+	numKeySuffixCols := idx.NumKeySuffixColumns()
+	oi.columnOrds = make([]int, oi.numCols)
+	for i := 0; i < oi.numCols; i++ {
+		var ord int
+		switch {
+		case inverted && i == numKeyCols-1:
+			ord = oi.invertedVirtualColOrd
+		case i < numKeyCols:
+			ord, _ = oi.tab.lookupColumnOrdinal(oi.idx.GetKeyColumnID(i))
+		case i < numKeyCols+numKeySuffixCols:
+			ord, _ = oi.tab.lookupColumnOrdinal(oi.idx.GetKeySuffixColumnID(i - numKeyCols))
+		default:
+			ord, _ = oi.tab.lookupColumnOrdinal(oi.storedCols[i-numKeyCols-numKeySuffixCols])
+		}
+		oi.columnOrds[i] = ord
+	}
 }
 
 // ID is part of the cat.Index interface.
@@ -1315,30 +1338,13 @@ func (oi *optIndex) NonInvertedPrefixColumnCount() int {
 
 // Column is part of the cat.Index interface.
 func (oi *optIndex) Column(i int) cat.IndexColumn {
-	length := oi.idx.NumKeyColumns()
-	if i < length {
-		ord := 0
-		if oi.IsInverted() && i == length-1 {
-			ord = oi.invertedVirtualColOrd
-		} else {
-			ord, _ = oi.tab.lookupColumnOrdinal(oi.idx.GetKeyColumnID(i))
-		}
-		return cat.IndexColumn{
-			Column:     oi.tab.Column(ord),
-			Descending: oi.idx.GetKeyColumnDirection(i) == descpb.IndexDescriptor_DESC,
-		}
+	ord := oi.columnOrds[i]
+	// Only key columns have a direction.
+	descending := i < oi.idx.NumKeyColumns() && oi.idx.GetKeyColumnDirection(i) == descpb.IndexDescriptor_DESC
+	return cat.IndexColumn{
+		Column:     oi.tab.Column(ord),
+		Descending: descending,
 	}
-
-	i -= length
-	length = oi.idx.NumKeySuffixColumns()
-	if i < length {
-		ord, _ := oi.tab.lookupColumnOrdinal(oi.idx.GetKeySuffixColumnID(i))
-		return cat.IndexColumn{Column: oi.tab.Column(ord), Descending: false}
-	}
-
-	i -= length
-	ord, _ := oi.tab.lookupColumnOrdinal(oi.storedCols[i])
-	return cat.IndexColumn{Column: oi.tab.Column(ord), Descending: false}
 }
 
 // VirtualInvertedColumn is part of the cat.Index interface.


### PR DESCRIPTION
#### opt: add benchmark for a table with many columns and indexes

Release note: None

#### sql: optimize optIndex.Column

During optimization, many calls are made to the catalog to get
information about index columns. The `optIndex.Column` function
previously made a call to `optTable.lookupColumnOrdinal` which looks up
a table's column ordinal from a column ID using a `util.FastIntMap`.
This was a bottleneck on tables with more than ~16 columns because
`util.FastIntMap` degrades to a normal, less efficient Go map when a
table has ~16 or more columns (`util.FastIntMap` currently supports the
fast path when the keys are in `[0, 31]` and the values are in
`[0, 14]`).

The bottleneck was most evident on tables with many indexes. Each index
incurs additional calls to `optIndex.Column` while the optimizer
explores the possibility of using the index to satisfy a query.

This commit mitigates the bottleneck by storing a mapping of an index's
columns to their table ordinals in a new field `optIndex.columnOrds`.
`optIndex.Column` can use this map as a replacement for calling
`optTable.lookupColumnOrdinal`.

The end-to-end benchmark highlights the improvement:

    name                                          old time/op  new time/op  delta
    EndToEnd/kv-read/Simple                        245µs ±10%   226µs ± 2%   -7.63%  (p=0.016 n=5+5)
    EndToEnd/kv-read/Prepared                      145µs ± 9%   139µs ± 2%     ~     (p=0.222 n=5+5)
    EndToEnd/kv-read-const/Simple                  162µs ± 4%   163µs ± 1%     ~     (p=0.310 n=5+5)
    EndToEnd/kv-read-const/Prepared                141µs ± 1%   139µs ± 2%     ~     (p=0.095 n=5+5)
    EndToEnd/tpcc-new-order/Simple                 283µs ± 6%   274µs ± 6%     ~     (p=0.151 n=5+5)
    EndToEnd/tpcc-new-order/Prepared               189µs ± 4%   169µs ± 5%  -10.81%  (p=0.008 n=5+5)
    EndToEnd/tpcc-delivery/Simple                  347µs ± 8%   343µs ±12%     ~     (p=0.690 n=5+5)
    EndToEnd/tpcc-delivery/Prepared                223µs ± 2%   217µs ± 3%     ~     (p=0.056 n=5+5)
    EndToEnd/tpcc-stock-level/Simple               715µs ±10%   670µs ± 3%   -6.37%  (p=0.032 n=5+5)
    EndToEnd/tpcc-stock-level/Prepared             583µs ± 3%   577µs ±23%     ~     (p=0.190 n=4+5)
    EndToEnd/many-columns-and-indexes-a/Simple    2.27ms ± 2%  1.40ms ± 2%  -38.58%  (p=0.008 n=5+5)
    EndToEnd/many-columns-and-indexes-a/Prepared  2.26ms ±24%  1.30ms ± 1%  -42.63%  (p=0.008 n=5+5)
    EndToEnd/many-columns-and-indexes-b/Simple    2.34ms ±10%  1.42ms ± 1%  -39.28%  (p=0.008 n=5+5)
    EndToEnd/many-columns-and-indexes-b/Prepared  2.17ms ± 5%  1.33ms ± 5%  -38.57%  (p=0.008 n=5+5)

Informs #66226

Release note (performance improvement): The optimizer is now more efficient
when planning queries on tables that have many columns and indexes.

#### opt: only explore zig zag joins with two or more fixed columns

`GenerateZigzagJoins` requires at least two fixed columns to generate a
zigzag join. This commit adds a check early in the function to ensure
there are enough fixed columns. This prevents doing unnecessary work in
some cases.

The end-to-end benchmarks highlight the improvement for a simple query:

    name                                          old time/op  new time/op  delta
    EndToEnd/kv-read/Simple                        226µs ± 2%   226µs ± 4%    ~     (p=0.841 n=5+5)
    EndToEnd/kv-read/Prepared                      139µs ± 2%   140µs ± 2%    ~     (p=1.000 n=5+5)
    EndToEnd/kv-read-const/Simple                  163µs ± 1%   162µs ± 2%    ~     (p=0.310 n=5+5)
    EndToEnd/kv-read-const/Prepared                139µs ± 2%   140µs ± 3%    ~     (p=0.548 n=5+5)
    EndToEnd/tpcc-new-order/Simple                 274µs ± 6%   273µs ± 5%    ~     (p=1.000 n=5+5)
    EndToEnd/tpcc-new-order/Prepared               169µs ± 5%   164µs ± 1%    ~     (p=0.056 n=5+5)
    EndToEnd/tpcc-delivery/Simple                  343µs ±12%   326µs ± 4%    ~     (p=0.095 n=5+5)
    EndToEnd/tpcc-delivery/Prepared                217µs ± 3%   216µs ± 1%    ~     (p=0.841 n=5+5)
    EndToEnd/tpcc-stock-level/Simple               670µs ± 3%   674µs ± 3%    ~     (p=0.095 n=5+5)
    EndToEnd/tpcc-stock-level/Prepared             577µs ±23%   573µs ±19%    ~     (p=1.000 n=5+5)
    EndToEnd/many-columns-and-indexes-a/Simple    1.40ms ± 2%  1.30ms ± 0%  -6.87%  (p=0.016 n=5+4)
    EndToEnd/many-columns-and-indexes-a/Prepared  1.30ms ± 1%  1.23ms ± 1%  -5.43%  (p=0.008 n=5+5)
    EndToEnd/many-columns-and-indexes-b/Simple    1.42ms ± 1%  1.42ms ± 3%    ~     (p=1.000 n=5+5)
    EndToEnd/many-columns-and-indexes-b/Prepared  1.33ms ± 5%  1.33ms ± 3%    ~     (p=0.841 n=5+5)

Informs #66226

Release note (performance improvement): The optimizer is now more
efficient when planning simple queries on tables that have many columns
and indexes.
