### PR TITLE
release-21.1: execbuilder: fix column mapping for insert fast path FK violations

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -702,7 +702,7 @@ DROP TABLE parent CASCADE
 statement ok
 INSERT INTO child VALUES (2, 2)
 
-statement error pgcode 23503 foreign key 
+statement error pgcode 23503 foreign key
 INSERT INTO grandchild VALUES (1, 1)
 
 statement ok
@@ -3662,3 +3662,64 @@ ALTER TABLE child_59582 ADD FOREIGN KEY (i) REFERENCES child_59582(rowid)
 
 statement ok
 DROP TABLE parent_59582, child_59582
+
+# Regression test for #65890. Duplicate column IDs in the input of an insert
+# fast path should not cause internal errors when shuffling columns during FK
+# violations.
+subtest 65890
+
+statement ok
+SET enable_insert_fast_path = true
+
+# TODO(mgartner): We can remove ab_idx once we lift the restriction that FK
+# column ordering must match the column ordering of a UNIQUE constraint in the
+# reference table.
+statement ok
+CREATE TABLE t65890_p (
+  k INT PRIMARY KEY,
+  a INT,
+  b INT,
+  UNIQUE (a),
+  UNIQUE INDEX ba_idx (b, a),
+  UNIQUE INDEX ab_idx (a, b),
+  FAMILY (k, a, b)
+)
+
+statement ok
+CREATE TABLE t65890_c (
+  k INT PRIMARY KEY,
+  b INT,
+  a INT,
+  FAMILY (k, b, a)
+)
+
+statement ok
+ALTER TABLE t65890_c ADD CONSTRAINT fk FOREIGN KEY (a) REFERENCES t65890_p(a)
+
+statement error insert on table "t65890_c" violates foreign key constraint "fk"\nDETAIL: Key \(a\)=\(1\) is not present in table "t65890_p"\.
+INSERT INTO t65890_c SELECT 1, 1, 1
+
+statement ok
+ALTER TABLE t65890_c DROP CONSTRAINT fk
+
+statement ok
+ALTER TABLE t65890_c ADD CONSTRAINT fk FOREIGN KEY (a, b) REFERENCES t65890_p(a, b)
+
+# Ensure that a fast path on ba_idx is used.
+query T
+SELECT * FROM [EXPLAIN INSERT INTO t65890_c (k, b, a) VALUES (1, 2, 3)] OFFSET 3
+----
+• insert fast path
+  into: t65890_c(k, b, a)
+  auto commit
+  FK check: t65890_p@ba_idx
+  size: 3 columns, 1 row
+
+statement error insert on table "t65890_c" violates foreign key constraint "fk"\nDETAIL: Key \(a, b\)=\(3, 2\) is not present in table "t65890_p"\.
+INSERT INTO t65890_c (k, b, a) VALUES (1, 2, 3)
+
+statement error insert on table "t65890_c" violates foreign key constraint "fk"\nDETAIL: Key \(a, b\)=\(2, 2\) is not present in table "t65890_p"\.
+INSERT INTO t65890_c SELECT 1, 2, 2
+
+statement ok
+SET enable_insert_fast_path = $enable_insert_fast_path

--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -222,15 +222,14 @@ func (b *Builder) tryBuildFastPathInsert(ins *memo.InsertExpr) (_ execPlan, ok b
 			// the FK reference and the index we're looking up. We have to reshuffle
 			// the values to fix that.
 			fkVals := make(tree.Datums, len(values))
-			for i, ordinal := range out.InsertCols {
-				for j := range out.InsertCols {
-					if fk.OriginColumnOrdinal(tab, j) == int(ordinal) {
-						fkVals[j] = values[i]
+			for i := range fkVals {
+				parentOrd := fk.ReferencedColumnOrdinal(out.ReferencedTable, i)
+				for j := 0; j < out.ReferencedIndex.KeyColumnCount(); j++ {
+					if out.ReferencedIndex.Column(j).Ordinal() == parentOrd {
+						fkVals[i] = values[j]
 						break
 					}
 				}
-			}
-			for i := range fkVals {
 				if fkVals[i] == nil {
 					return errors.AssertionFailedf("invalid column mapping")
 				}


### PR DESCRIPTION
Backport 1/1 commits from #66270.

/cc @cockroachdb/release

---

An insert fast path is built in `execbuilder` when FK checks are
performed with WithScan and a simple LookupJoin. It is possible that the
LookupJoin is planned on a unique index with columns in a different
order than the FK columns. When an FK violation is detected during
execution, the LookupJoin key values must be shuffled to match the FK
column ordering to produce the correct error message.

Previously, this shuffling would produce an internal error when the
mutation's input contained duplicate column IDs. The shuffling relied on
the Insert and WithScan column mappings. A duplicate column ID in these
mappings created ambiguity which caused the shuffle to fail.

For example, consider:

    CREATE TABLE p (x INT PRIMARY KEY)
    CREATE TABLE c (a INT, b INT REFERENCES p(x))
    INSERT INTO c (a, b) SELECT 1, 1

    FK Cols:              (b)
    Insert Mapping:       (i, i) => (a, b)
    WithScan Mapping:     (i) => (x)
    Lookup Join Key Cols: (x)

By considering just these mappings, it is impossible to determine if the
LookupJoin key column `x` corresponds to `a` or `b`, because `i`
corresponds to both `a` and `b` in the insert mappings.

As another example, consider:

    CREATE TABLE p (x INT, y INT, PRIMARY KEY (x, y))
    CREATE TABLE c (a INT, b INT, FOREIGN KEY (b, a) REFERENCES p(x, y))
    INSERT INTO c (a, b) SELECT 1, 1

    FK Cols:              (b, a)
    Insert Mapping:       (i, i) => (a, b)
    WithScan Mapping:     (i, i) => (x, y)
    Lookup Join Key Cols: (x, y)

With these mappings, we cannot determine whether `(a, b)` corresponds to
`(x, y)` or `(b, a)` corresponds to `(x, y)`.

This issue is fixed by using the FK and unique index column ordinals to
perform the shuffling, rather than the Insert and WithScan column
mappings. This more detailed information eliminates any ambiguity and
prevents the shuffling from failing.

Fixes #65890

Release note (bug fix): Previously, an INSERT causing a foreign key
violation could result in an internal error in rare cases. The bug only
affected the error response; any affected INSERTs, which must have been
FK violations, did not succeeded. This bug, which was present since
version 21.1.0, has been fixed.
