### PR TITLE
release-20.2: kafka client configuration improvements

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -2085,7 +2085,7 @@ func TestChangefeedErrors(t *testing.T) {
 	)
 	sqlDB.ExpectErr(
 		t, `client has run out of available brokers`,
-		`CREATE CHANGEFEED FOR foo INTO 'kafka://nope/' WITH kafka_sink_config='{"Flush": {"Messages": 100}}'`,
+		`CREATE CHANGEFEED FOR foo INTO 'kafka://nope/' WITH kafka_sink_config='{"Flush": {"Messages": 100, "Frequency": "1s"}}'`,
 	)
 	// The avro format doesn't support key_in_value yet.
 	sqlDB.ExpectErr(

--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -415,9 +415,14 @@ func defaultSaramaConfig() *saramaConfig {
 	// to test this one more before changing it.
 	config.Flush.MaxMessages = 1000
 
-	// config.Producer.Flush.Messages is set to 1 so we don't need this, but
-	// sarama prints scary things to the logs if we don't.
-	config.Flush.Frequency = jsonDuration(time.Hour)
+	// Setting Frequency to 0 disables time-based flushes. This is
+	// OK because we set Flush.Messages = 1, which should mean
+	// that sarama will always try to flush its buffer if it has
+	// at least 1 message in it.
+	//
+	// This will produce a warning at the start of a changefeed
+	// that may alarm some users.
+	config.Flush.Frequency = jsonDuration(0)
 
 	return config
 }

--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -360,18 +360,28 @@ type saramaConfig struct {
 		Frequency   jsonDuration `json:",omitempty"`
 		MaxMessages int          `json:",omitempty"`
 	}
+
+	Version string `json:",omitempty"`
 }
 
 // Configure configures provided kafka configuration struct based
 // on this config.
-func (c *saramaConfig) Apply(kafka *sarama.Config) {
+func (c *saramaConfig) Apply(kafka *sarama.Config) error {
 	kafka.Producer.Flush.Bytes = c.Flush.Bytes
 	kafka.Producer.Flush.Messages = c.Flush.Messages
 	kafka.Producer.Flush.Frequency = time.Duration(c.Flush.Frequency)
 	kafka.Producer.Flush.MaxMessages = c.Flush.MaxMessages
+	if c.Version != "" {
+		parsedVersion, err := sarama.ParseKafkaVersion(c.Version)
+		if err != nil {
+			return err
+		}
+		kafka.Version = parsedVersion
+	}
+	return nil
 }
 
-var defaultSaramaConfig = func() *saramaConfig {
+func defaultSaramaConfig() *saramaConfig {
 	config := &saramaConfig{}
 
 	// When we emit messages to sarama, they're placed in a queue (as does any
@@ -410,14 +420,13 @@ var defaultSaramaConfig = func() *saramaConfig {
 	config.Flush.Frequency = jsonDuration(time.Hour)
 
 	return config
-}()
+}
 
 func getSaramaConfig(opts map[string]string) (config *saramaConfig, err error) {
+	config = defaultSaramaConfig()
 	if configStr, haveOverride := opts[changefeedbase.OptKafkaSinkConfig]; haveOverride {
 		config = &saramaConfig{}
 		err = json.Unmarshal([]byte(configStr), config)
-	} else {
-		config = defaultSaramaConfig
 	}
 	return
 }
@@ -493,7 +502,9 @@ func makeKafkaSink(
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to parse sarama config; check changefeed.experimental_kafka_config setting")
 	}
-	saramaCfg.Apply(config)
+	if err := saramaCfg.Apply(config); err != nil {
+		return nil, errors.Wrap(err, "failed to apply kafka client configuration")
+	}
 
 	sink.client, err = sarama.NewClient(strings.Split(bootstrapServers, `,`), config)
 	if err != nil {

--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -381,27 +381,36 @@ func (c *saramaConfig) Apply(kafka *sarama.Config) error {
 	return nil
 }
 
+func (c saramaConfig) Validate() error {
+	// If Flush.Bytes > 0 or Flush.Messages > 1 without
+	// Flush.Frequency, sarama may wait forever to flush the
+	// messages to Kafka.  We want to guard against such
+	// configurations to ensure that we don't get into a situation
+	// where our call to Flush() would block forever.
+	if (c.Flush.Bytes > 0 || c.Flush.Messages > 1) && c.Flush.Frequency == 0 {
+		return errors.New("Flush.Frequency must be > 0 when Flush.Bytes > 0 or Flush.Messages > 1")
+	}
+	return nil
+}
+
 func defaultSaramaConfig() *saramaConfig {
 	config := &saramaConfig{}
 
-	// When we emit messages to sarama, they're placed in a queue (as does any
-	// reasonable kafka producer client). When our sink's Flush is called, we
-	// have to wait for all buffered and inflight requests to be sent and then
-	// acknowledged. Quite unfortunately, we have no way to hint to the producer
-	// that it should immediately send out whatever is buffered. This
-	// configuration can have a dramatic impact on how quickly this happens
-	// naturally (and some configurations will block forever!).
+	// When we emit messages to sarama, they're placed in a queue
+	// (as does any reasonable kafka producer client). When our
+	// sink's Flush is called, we have to wait for all buffered
+	// and inflight requests to be sent and then
+	// acknowledged. Quite unfortunately, we have no way to hint
+	// to the producer that it should immediately send out
+	// whatever is buffered. This configuration can have a
+	// dramatic impact on how quickly this happens naturally (and
+	// some configurations will block forever!).
 	//
-	// We can configure the producer to send out its batches based on number of
-	// messages and/or total buffered message size and/or time. If none of them
-	// are set, it uses some defaults, but if any of the three are set, it does
-	// no defaulting. Which means that if `Flush.Messages` is set to 10 and
-	// nothing else is set, then 9/10 times `Flush` will block forever. We can
-	// work around this by also setting `Flush.Frequency` but a cleaner way is
-	// to set `Flush.Messages` to 1. In the steady state, this sends a request
-	// with some messages, buffers any messages that come in while it is in
-	// flight, then sends those out.
-	config.Flush.Messages = 1
+	// The default configuration of all 0 values will send
+	// messages as quickly as possible.
+	config.Flush.Messages = 0
+	config.Flush.Frequency = jsonDuration(0)
+	config.Flush.Bytes = 0
 
 	// This works around what seems to be a bug in sarama where it isn't
 	// computing the right value to compare against `Producer.MaxMessageBytes`
@@ -414,15 +423,6 @@ func defaultSaramaConfig() *saramaConfig {
 	// this workaround is the one that's been running in roachtests and I'd want
 	// to test this one more before changing it.
 	config.Flush.MaxMessages = 1000
-
-	// Setting Frequency to 0 disables time-based flushes. This is
-	// OK because we set Flush.Messages = 1, which should mean
-	// that sarama will always try to flush its buffer if it has
-	// at least 1 message in it.
-	//
-	// This will produce a warning at the start of a changefeed
-	// that may alarm some users.
-	config.Flush.Frequency = jsonDuration(0)
 
 	return config
 }
@@ -507,6 +507,11 @@ func makeKafkaSink(
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to parse sarama config; check changefeed.experimental_kafka_config setting")
 	}
+
+	if err := saramaCfg.Validate(); err != nil {
+		return nil, errors.Wrap(err, "invalid sarama configuration")
+	}
+
 	if err := saramaCfg.Apply(config); err != nil {
 		return nil, errors.Wrap(err, "failed to apply kafka client configuration")
 	}

--- a/pkg/ccl/changefeedccl/sink_test.go
+++ b/pkg/ccl/changefeedccl/sink_test.go
@@ -399,19 +399,62 @@ func TestSaramaConfigOptionParsing(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	opts := make(map[string]string)
-	cfg, err := getSaramaConfig(opts)
-	require.NoError(t, err)
-	require.Equal(t, defaultSaramaConfig, cfg)
+	t.Run("defaults returned if not option set", func(t *testing.T) {
+		opts := make(map[string]string)
 
-	expected := &saramaConfig{}
-	expected.Flush.MaxMessages = 1000
-	expected.Flush.Frequency = jsonDuration(time.Second)
+		expected := defaultSaramaConfig()
 
-	opts[changefeedbase.OptKafkaSinkConfig] = `{"Flush": {"MaxMessages": 1000, "Frequency": "1s"}}`
-	cfg, err = getSaramaConfig(opts)
-	require.NoError(t, err)
-	require.Equal(t, expected, cfg)
+		cfg, err := getSaramaConfig(opts)
+		require.NoError(t, err)
+		require.Equal(t, expected, cfg)
+	})
+	t.Run("options overlay defaults", func(t *testing.T) {
+		opts := make(map[string]string)
+		opts[changefeedbase.OptKafkaSinkConfig] = `{"Flush": {"MaxMessages": 1000, "Frequency": "1s"}}`
+
+		expected := defaultSaramaConfig()
+		expected.Flush.MaxMessages = 1000
+		expected.Flush.Frequency = jsonDuration(time.Second)
+
+		cfg, err := getSaramaConfig(opts)
+		require.NoError(t, err)
+		require.Equal(t, expected, cfg)
+	})
+	t.Run("apply parses valid version", func(t *testing.T) {
+		opts := make(map[string]string)
+		opts[changefeedbase.OptKafkaSinkConfig] = `{"version": "0.8.2.0"}`
+
+		cfg, err := getSaramaConfig(opts)
+		require.NoError(t, err)
+
+		saramaCfg := &sarama.Config{}
+		err = cfg.Apply(saramaCfg)
+		require.NoError(t, err)
+		require.Equal(t, sarama.V0_8_2_0, saramaCfg.Version)
+	})
+	t.Run("apply allows for unset version", func(t *testing.T) {
+		opts := make(map[string]string)
+		opts[changefeedbase.OptKafkaSinkConfig] = `{}`
+
+		cfg, err := getSaramaConfig(opts)
+		require.NoError(t, err)
+
+		saramaCfg := &sarama.Config{}
+		err = cfg.Apply(saramaCfg)
+		require.NoError(t, err)
+		require.Equal(t, sarama.KafkaVersion{}, saramaCfg.Version)
+	})
+	t.Run("apply errors if version is invalid", func(t *testing.T) {
+		opts := make(map[string]string)
+		opts[changefeedbase.OptKafkaSinkConfig] = `{"version": "invalid"}`
+
+		cfg, err := getSaramaConfig(opts)
+		require.NoError(t, err)
+
+		saramaCfg := &sarama.Config{}
+		err = cfg.Apply(saramaCfg)
+		require.Error(t, err)
+	})
 }
 
 func TestKafkaSinkTracksMemory(t *testing.T) {

--- a/pkg/ccl/changefeedccl/sink_test.go
+++ b/pkg/ccl/changefeedccl/sink_test.go
@@ -420,6 +420,32 @@ func TestSaramaConfigOptionParsing(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, expected, cfg)
 	})
+	t.Run("validate returns nil for valid flush configuration", func(t *testing.T) {
+		opts := make(map[string]string)
+
+		opts[changefeedbase.OptKafkaSinkConfig] = `{"Flush": {"Messages": 1000, "Frequency": "1s"}}`
+		cfg, err := getSaramaConfig(opts)
+		require.NoError(t, err)
+		require.NoError(t, cfg.Validate())
+
+		opts[changefeedbase.OptKafkaSinkConfig] = `{"Flush": {"Messages": 1}}`
+		cfg, err = getSaramaConfig(opts)
+		require.NoError(t, err)
+		require.NoError(t, cfg.Validate())
+	})
+	t.Run("validate returns error for bad flush configurationg", func(t *testing.T) {
+		opts := make(map[string]string)
+		opts[changefeedbase.OptKafkaSinkConfig] = `{"Flush": {"Messages": 1000}}`
+
+		cfg, err := getSaramaConfig(opts)
+		require.NoError(t, err)
+		require.Error(t, cfg.Validate())
+
+		opts[changefeedbase.OptKafkaSinkConfig] = `{"Flush": {"Bytes": 10}}`
+		cfg, err = getSaramaConfig(opts)
+		require.NoError(t, err)
+		require.Error(t, cfg.Validate())
+	})
 	t.Run("apply parses valid version", func(t *testing.T) {
 		opts := make(map[string]string)
 		opts[changefeedbase.OptKafkaSinkConfig] = `{"version": "0.8.2.0"}`


### PR DESCRIPTION
Backport:
  * 1/1 commits from "changefeedccl: allow user to configure kafka server version" (#65389)
  * 2/2 commits from "changefeedccl: set sarama's flush frequency to 0 by default." (#66040)

Please see individual PRs for details.

The goal of backporting #65389 is to allow customers on 20.2 to get around issues
caused by the older version. It may also allow us to merge https://github.com/cockroachdb/cockroach/pull/64970 while still providing a solution for users still on EOL'd kafka.

Note this will slightly change behaviour for people using the undocumented kafka_sink_config
feature in that we now retain our default settings for anything unspecified and fail for known-bad
configuration.

/cc @cockroachdb/release
