### PR TITLE
backupccl: change import to ingest where relevant

### DIFF
--- a/pkg/ccl/backupccl/restore_data_processor.go
+++ b/pkg/ccl/backupccl/restore_data_processor.go
@@ -286,7 +286,7 @@ func (rd *restoreDataProcessor) processRestoreSpanEntry(
 	}
 
 	batcher, err := bulk.MakeSSTBatcher(ctx, db, evalCtx.Settings,
-		func() int64 { return storageccl.MaxImportBatchSize(evalCtx.Settings) })
+		func() int64 { return storageccl.MaxIngestBatchSize(evalCtx.Settings) })
 	if err != nil {
 		return summary, err
 	}

--- a/pkg/ccl/importccl/import_processor.go
+++ b/pkg/ccl/importccl/import_processor.go
@@ -312,7 +312,7 @@ func ingestKvs(
 
 	writeTS := hlc.Timestamp{WallTime: spec.WalltimeNanos}
 
-	flushSize := func() int64 { return storageccl.MaxImportBatchSize(flowCtx.Cfg.Settings) }
+	flushSize := func() int64 { return storageccl.MaxIngestBatchSize(flowCtx.Cfg.Settings) }
 
 	// We create two bulk adders so as to combat the excessive flushing of small
 	// SSTs which was observed when using a single adder for both primary and

--- a/pkg/ccl/storageccl/import.go
+++ b/pkg/ccl/storageccl/import.go
@@ -17,9 +17,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 )
 
-// ImportBatchSize is a cluster setting that controls the maximum size of the
+// IngestBatchSize is a cluster setting that controls the maximum size of the
 // payload in an AddSSTable request.
-var ImportBatchSize = func() *settings.ByteSizeSetting {
+var IngestBatchSize = func() *settings.ByteSizeSetting {
 	s := settings.RegisterByteSizeSetting(
 		"kv.bulk_ingest.batch_size",
 		"the maximum size of the payload in an AddSSTable request",
@@ -43,12 +43,12 @@ func init() {
 	}
 }
 
-// MaxImportBatchSize determines the maximum size of the payload in an
-// AddSSTable request. It uses the ImportBatchSize setting directly unless the
+// MaxIngestBatchSize determines the maximum size of the payload in an
+// AddSSTable request. It uses the IngestBatchSize setting directly unless the
 // specified value would exceed the maximum Raft command size, in which case it
 // returns the maximum batch size that will fit within a Raft command.
-func MaxImportBatchSize(st *cluster.Settings) int64 {
-	desiredSize := ImportBatchSize.Get(&st.SV)
+func MaxIngestBatchSize(st *cluster.Settings) int64 {
+	desiredSize := IngestBatchSize.Get(&st.SV)
 	maxCommandSize := kvserver.MaxCommandSize.Get(&st.SV)
 	if desiredSize+commandMetadataEstimate > maxCommandSize {
 		return maxCommandSize - commandMetadataEstimate

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
@@ -177,7 +177,7 @@ func (sip *streamIngestionProcessor) Start(ctx context.Context) {
 	db := sip.FlowCtx.Cfg.DB
 	var err error
 	sip.batcher, err = bulk.MakeStreamSSTBatcher(ctx, db, evalCtx.Settings,
-		func() int64 { return storageccl.MaxImportBatchSize(evalCtx.Settings) })
+		func() int64 { return storageccl.MaxIngestBatchSize(evalCtx.Settings) })
 	if err != nil {
 		sip.MoveToDraining(errors.Wrap(err, "creating stream sst batcher"))
 		return


### PR DESCRIPTION
Previously, with the existance of ImportRequest, there were several
usages of the term "import". One refers to the SQL feature, and the
other to generally ingesting data (which is used by IMPORT but also
RESTORE and cluster streaming). This renames a few tests and variables
that were referring to the general ingestion case, rather than import in
particular to help differentiate their usages.

Release note: None