### PR TITLE
sql/catalog/tabledesc,migrations: fix namespace migration for upgraded clusters

### DIFF
--- a/pkg/migration/migrations/BUILD.bazel
+++ b/pkg/migration/migrations/BUILD.bazel
@@ -54,6 +54,7 @@ go_test(
         "//pkg/security",
         "//pkg/security/securitytest",
         "//pkg/server",
+        "//pkg/settings/cluster",
         "//pkg/sql/catalog/catalogkeys",
         "//pkg/sql/catalog/catalogkv",
         "//pkg/sql/catalog/descpb",

--- a/pkg/migration/migrations/BUILD.bazel
+++ b/pkg/migration/migrations/BUILD.bazel
@@ -62,6 +62,7 @@ go_test(
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",
+        "//pkg/util/log",
         "//pkg/util/protoutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",

--- a/pkg/sql/catalog/catconstants/namespace.go
+++ b/pkg/sql/catalog/catconstants/namespace.go
@@ -18,4 +18,12 @@ const (
 	// NamespaceTablePrimaryIndexID is the id of the primary index of the
 	// namespace table.
 	NamespaceTablePrimaryIndexID = 1
+
+	// NamespaceTableName is the name of the namespace table.
+	NamespaceTableName = "namespace"
+
+	// PreMigrationNamespaceTableName is the name that was used on the descriptor
+	// of the current namespace table before the DeprecatedNamespaceTable was
+	// migrated away.
+	PreMigrationNamespaceTableName = "namespace2"
 )

--- a/pkg/sql/catalog/systemschema/system.go
+++ b/pkg/sql/catalog/systemschema/system.go
@@ -419,7 +419,7 @@ var (
 	// code assumes that it only has KV entries for column family 4, not the
 	// "sentinel" column family 0 which would be written by SQL.
 	NamespaceTable = makeTable(descpb.TableDescriptor{
-		Name:                    "namespace",
+		Name:                    catconstants.NamespaceTableName,
 		ID:                      keys.NamespaceTableID,
 		ParentID:                keys.SystemDatabaseID,
 		UnexposedParentSchemaID: keys.PublicSchemaID,

--- a/pkg/sql/catalog/tabledesc/BUILD.bazel
+++ b/pkg/sql/catalog/tabledesc/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//pkg/roachpb",
         "//pkg/settings/cluster",
         "//pkg/sql/catalog",
+        "//pkg/sql/catalog/catconstants",
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/schemaexpr",

--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -90,6 +90,9 @@ type PostDeserializationTableDescriptorChanges struct {
 
 	// UpgradedNamespaceName indicates that the table was system.namespace
 	// and it had its name upgraded from "namespace2".
+	//
+	// TODO(ajwerner): Remove this and the associated migration in 22.1 as
+	// this will never be true due to the corresponding long-running migration.
 	UpgradedNamespaceName bool
 }
 

--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -87,6 +87,10 @@ type PostDeserializationTableDescriptorChanges struct {
 	// UpgradedForeignKeyRepresentation indicates that the foreign key
 	// representation was upgraded.
 	UpgradedForeignKeyRepresentation bool
+
+	// UpgradedNamespaceName indicates that the table was system.namespace
+	// and it had its name upgraded from "namespace2".
+	UpgradedNamespaceName bool
 }
 
 // DescriptorType returns the type of this descriptor.


### PR DESCRIPTION
See individual commits. 