### PR TITLE
[DNM] sql/opt: demonstrate incorrect implicit locking in mutation "set clause" projections

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -791,6 +791,11 @@ func (b *Builder) buildProject(prj *memo.ProjectExpr) (execPlan, error) {
 		return execPlan{}, err
 	}
 
+	if b.forceForUpdateLocking {
+		b.forceForUpdateLocking = false
+		defer func() { b.forceForUpdateLocking = true }()
+	}
+
 	projections := prj.Projections
 	if len(projections) == 0 {
 		// We have only pass-through columns.

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -518,6 +518,74 @@ vectorized: true
           spans: [/2 - /9]
           locking strength: for update
 
+query T
+EXPLAIN UPDATE kv3 SET v = (SELECT count(*) FROM kv2) WHERE k = 1
+----
+distribution: local
+vectorized: true
+·
+• root
+│
+├── • update
+│   │ table: kv3
+│   │ set: v
+│   │ auto commit
+│   │
+│   └── • render
+│       │
+│       └── • scan
+│             missing stats
+│             table: kv3@primary
+│             spans: [/1 - /1]
+│             locking strength: for update
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: (SELECT count(*) FROM kv2)
+    │ exec mode: one row
+    │
+    └── • group (scalar)
+        │
+        └── • scan
+              missing stats
+              table: kv2@primary
+              spans: FULL SCAN
+              locking strength: for update
+
+query T
+EXPLAIN UPDATE kv3 SET v = (SELECT count(*) FROM kv3) WHERE k = 1
+----
+distribution: local
+vectorized: true
+·
+• root
+│
+├── • update
+│   │ table: kv3
+│   │ set: v
+│   │ auto commit
+│   │
+│   └── • render
+│       │
+│       └── • scan
+│             missing stats
+│             table: kv3@primary
+│             spans: [/1 - /1]
+│             locking strength: for update
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: (SELECT count(*) FROM kv3)
+    │ exec mode: one row
+    │
+    └── • group (scalar)
+        │
+        └── • scan
+              missing stats
+              table: kv3@kv3_v_idx
+              spans: FULL SCAN
+              locking strength: for update
+
 statement ok
 SET enable_implicit_select_for_update = false
 
@@ -659,6 +727,70 @@ vectorized: true
           missing stats
           table: kv3@kv3_v_idx
           spans: [/2 - /9]
+
+query T
+EXPLAIN UPDATE kv3 SET v = (SELECT count(*) FROM kv2) WHERE k = 1
+----
+distribution: local
+vectorized: true
+·
+• root
+│
+├── • update
+│   │ table: kv3
+│   │ set: v
+│   │ auto commit
+│   │
+│   └── • render
+│       │
+│       └── • scan
+│             missing stats
+│             table: kv3@primary
+│             spans: [/1 - /1]
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: (SELECT count(*) FROM kv2)
+    │ exec mode: one row
+    │
+    └── • group (scalar)
+        │
+        └── • scan
+              missing stats
+              table: kv2@primary
+              spans: FULL SCAN
+
+query T
+EXPLAIN UPDATE kv3 SET v = (SELECT count(*) FROM kv3) WHERE k = 1
+----
+distribution: local
+vectorized: true
+·
+• root
+│
+├── • update
+│   │ table: kv3
+│   │ set: v
+│   │ auto commit
+│   │
+│   └── • render
+│       │
+│       └── • scan
+│             missing stats
+│             table: kv3@primary
+│             spans: [/1 - /1]
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: (SELECT count(*) FROM kv3)
+    │ exec mode: one row
+    │
+    └── • group (scalar)
+        │
+        └── • scan
+              missing stats
+              table: kv3@kv3_v_idx
+              spans: FULL SCAN
 
 # Reset for rest of test.
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -550,7 +550,6 @@ vectorized: true
               missing stats
               table: kv2@primary
               spans: FULL SCAN
-              locking strength: for update
 
 query T
 EXPLAIN UPDATE kv3 SET v = (SELECT count(*) FROM kv3) WHERE k = 1
@@ -584,7 +583,6 @@ vectorized: true
               missing stats
               table: kv3@kv3_v_idx
               spans: FULL SCAN
-              locking strength: for update
 
 statement ok
 SET enable_implicit_select_for_update = false


### PR DESCRIPTION
This PR adds a few tests that demonstrate incorrect behavior in the propagation of implicit SELECT FOR UPDATE locking in mutations. Only tables/rows in the mutation's initial row-scan should use SFU locking, not tables/rows in the mutation's projection list. This is going wrong due to the way that we propagate implicit locking decisions through the `(*execbuilder.Builder).forceForUpdateLocking` flag.

The PR then adds a hacky fix for the bug revealed in the previous commit. I'm pretty confident that we will not want to actually merge this, but I wanted to use this to demonstrate what's going wrong.

I'd like to solicit input from people who know this code better about how we should handle this and whether the current approach to propagating implicit locking decisions through the `(*execbuilder.Builder).forceForUpdateLocking` flag is a good idea.