### PR TITLE
tree: fix type checking of tuples with collated strings and NULLs

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/collatedstring
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring
@@ -507,3 +507,18 @@ query T
 SELECT s FROM nocase_strings2 WHERE s = ('bbb' COLLATE "en_US_u_ks_level2")
 ----
 Bbb
+
+subtest regression_45142
+
+statement ok
+CREATE TABLE t45142(c STRING COLLATE en);
+
+query error unsupported comparison operator
+SELECT * FROM t45142 WHERE c < SOME ('' COLLATE de, '' COLLATE en);
+
+query error unsupported comparison operator
+SELECT * FROM t45142 WHERE c < SOME ('' COLLATE en, '' COLLATE de);
+
+statement ok
+SELECT * FROM t45142 WHERE c < SOME (CASE WHEN true THEN NULL END, '' COLLATE en);
+SELECT * FROM t45142 WHERE c < SOME ('' COLLATE en, CASE WHEN true THEN NULL END);

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2170,10 +2170,10 @@ var CmpOps = cmpOpFixups(map[ComparisonOperator]cmpOpOverload{
 		makeLtFn(types.Bytes, types.Bytes, VolatilityLeakProof),
 		makeLtFn(types.Date, types.Date, VolatilityLeakProof),
 		makeLtFn(types.Decimal, types.Decimal, VolatilityImmutable),
-		makeLtFn(types.AnyCollatedString, types.AnyCollatedString, VolatilityLeakProof),
 		// Note: it is an error to compare two strings with different collations;
 		// the operator is leak proof under the assumption that these cases will be
 		// detected during type checking.
+		makeLtFn(types.AnyCollatedString, types.AnyCollatedString, VolatilityLeakProof),
 		makeLtFn(types.Float, types.Float, VolatilityLeakProof),
 		makeLtFn(types.Box2D, types.Box2D, VolatilityLeakProof),
 		makeLtFn(types.Geography, types.Geography, VolatilityLeakProof),


### PR DESCRIPTION
This commit adds a special case for type-checking tuples containing
collated strings in order to propagate the non-empty locale to all
elements of the tuples. I believe this matters only if we have
a combination of collated strings and NULLs (the latter might have
a default empty locale set).

Fixes: #45142.

Release note (bug fix): CockroachDB could previously error out when
a query involving tuples with collated strings and NULLs was executed in
a distributed manner.