### PR TITLE
opt: simplify and eliminate set operators

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/dist_union
+++ b/pkg/sql/opt/exec/execbuilder/testdata/dist_union
@@ -126,7 +126,7 @@ vectorized: true
 
 query T
 EXPLAIN (VERBOSE) ((SELECT '', '', 'x' WHERE false))
-UNION ALL ((SELECT '', '', 'x') EXCEPT (VALUES ('', '', 'x')))
+UNION ALL ((SELECT * FROM (VALUES ('', '', 'x'), ('', '', 'x'))) EXCEPT (VALUES ('', '', 'x')))
 ----
 distribution: full
 vectorized: true
@@ -134,22 +134,23 @@ vectorized: true
 • render
 │ columns: ("?column?", "?column?", "?column?")
 │ estimated row count: 1
-│ render ?column?: "?column?"
-│ render ?column?: "?column?"
-│ render ?column?: "?column?"
+│ render ?column?: column1
+│ render ?column?: column2
+│ render ?column?: column3
 │
 └── • except
-    │ columns: ("?column?", "?column?", "?column?")
+    │ columns: (column1, column2, column3)
     │ estimated row count: 1
     │
-    ├── • project
-    │   │ columns: ("?column?", "?column?", "?column?")
-    │   │
-    │   └── • values
-    │         columns: ("?column?", "?column?")
-    │         size: 2 columns, 1 row
-    │         row 0, expr 0: ''
-    │         row 0, expr 1: 'x'
+    ├── • values
+    │     columns: (column1, column2, column3)
+    │     size: 3 columns, 2 rows
+    │     row 0, expr 0: ''
+    │     row 0, expr 1: ''
+    │     row 0, expr 2: 'x'
+    │     row 1, expr 0: ''
+    │     row 1, expr 1: ''
+    │     row 1, expr 2: 'x'
     │
     └── • values
           columns: (column1, column2, column3)

--- a/pkg/sql/opt/exec/execbuilder/testdata/fk
+++ b/pkg/sql/opt/exec/execbuilder/testdata/fk
@@ -487,10 +487,9 @@ vectorized: true
 │       │
 │       └── • hash join
 │           │ equality: (p) = (p)
-│           │ left cols are key
 │           │ right cols are key
 │           │
-│           ├── • except
+│           ├── • except all
 │           │   │
 │           │   ├── • scan buffer
 │           │   │     label: buffer 1
@@ -513,10 +512,9 @@ vectorized: true
         │
         └── • hash join
             │ equality: (p) = (p)
-            │ left cols are key
             │ right cols are key
             │
-            ├── • except
+            ├── • except all
             │   │
             │   ├── • scan buffer
             │   │     label: buffer 1
@@ -564,7 +562,7 @@ vectorized: true
 │           │ table: child@child_p_idx
 │           │ equality: (p) = (p)
 │           │
-│           └── • except
+│           └── • except all
 │               │
 │               ├── • scan buffer
 │               │     label: buffer 1
@@ -580,7 +578,7 @@ vectorized: true
             │ table: child_nullable@child_nullable_p_idx
             │ equality: (p) = (p)
             │
-            └── • except
+            └── • except all
                 │
                 ├── • scan buffer
                 │     label: buffer 1
@@ -620,10 +618,9 @@ vectorized: true
         │
         └── • hash join
             │ equality: (c) = (c)
-            │ left cols are key
             │ right cols are key
             │
-            ├── • except
+            ├── • except all
             │   │
             │   ├── • scan buffer
             │   │     label: buffer 1
@@ -761,10 +758,9 @@ vectorized: true
         │
         └── • hash join
             │ equality: (c) = (c)
-            │ left cols are key
             │ right cols are key
             │
-            ├── • except
+            ├── • except all
             │   │
             │   ├── • scan buffer
             │   │     label: buffer 1
@@ -894,10 +890,9 @@ vectorized: true
         │
         └── • hash join
             │ equality: (x) = (y)
-            │ left cols are key
             │ right cols are key
             │
-            ├── • except
+            ├── • except all
             │   │
             │   ├── • scan buffer
             │   │     label: buffer 1
@@ -1543,7 +1538,7 @@ vectorized: true
             │ table: partial_child@partial_idx (partial index)
             │ equality: (id) = (parent_id)
             │
-            └── • except
+            └── • except all
                 │
                 ├── • scan buffer
                 │     label: buffer 1

--- a/pkg/sql/opt/exec/execbuilder/testdata/union
+++ b/pkg/sql/opt/exec/execbuilder/testdata/union
@@ -126,7 +126,7 @@ vectorized: true
 
 query T
 EXPLAIN (VERBOSE) ((SELECT '', '', 'x' WHERE false))
-UNION ALL ((SELECT '', '', 'x') EXCEPT (VALUES ('', '', 'x')))
+UNION ALL ((SELECT * FROM (VALUES ('', '', 'x'), ('', '', 'x'))) EXCEPT (VALUES ('', '', 'x')))
 ----
 distribution: local
 vectorized: true
@@ -134,22 +134,23 @@ vectorized: true
 • render
 │ columns: ("?column?", "?column?", "?column?")
 │ estimated row count: 1
-│ render ?column?: "?column?"
-│ render ?column?: "?column?"
-│ render ?column?: "?column?"
+│ render ?column?: column1
+│ render ?column?: column2
+│ render ?column?: column3
 │
 └── • except
-    │ columns: ("?column?", "?column?", "?column?")
+    │ columns: (column1, column2, column3)
     │ estimated row count: 1
     │
-    ├── • project
-    │   │ columns: ("?column?", "?column?", "?column?")
-    │   │
-    │   └── • values
-    │         columns: ("?column?", "?column?")
-    │         size: 2 columns, 1 row
-    │         row 0, expr 0: ''
-    │         row 0, expr 1: 'x'
+    ├── • values
+    │     columns: (column1, column2, column3)
+    │     size: 3 columns, 2 rows
+    │     row 0, expr 0: ''
+    │     row 0, expr 1: ''
+    │     row 0, expr 2: 'x'
+    │     row 1, expr 0: ''
+    │     row 1, expr 1: ''
+    │     row 1, expr 2: 'x'
     │
     └── • values
           columns: (column1, column2, column3)
@@ -196,10 +197,10 @@ vectorized: true
           spans: FULL SCAN
 
 statement ok
-CREATE TABLE ab (a INT PRIMARY KEY, b INT, INDEX (b, a))
+CREATE TABLE ab (a INT NOT NULL, b INT, INDEX(a, b), INDEX (b, a))
 
 statement ok
-CREATE TABLE xy (x INT PRIMARY KEY, y INT, INDEX (y, x))
+CREATE TABLE xy (x INT NOT NULL, y INT, INDEX(x, y), INDEX (y, x))
 
 # Regression tests for #41245, #40797. Ensure we can plan ordered set ops
 # without a sort.
@@ -212,23 +213,23 @@ vectorized: true
 • union
 │ columns: (a)
 │ ordering: +a
-│ estimated row count: 2,000 (missing stats)
+│ estimated row count: 200 (missing stats)
 │
 ├── • scan
 │     columns: (a)
 │     ordering: +a
 │     estimated row count: 1,000 (missing stats)
-│     table: ab@primary
+│     table: ab@ab_a_b_idx
 │     spans: FULL SCAN
 │
 └── • scan
       columns: (x)
       ordering: +x
       estimated row count: 1,000 (missing stats)
-      table: xy@primary
+      table: xy@xy_x_y_idx
       spans: FULL SCAN
 ·
-Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJykkVFLwzAUhd_9FZf7pBhZ273laZurUJjtbKco0oesuYxC19QkhY7R_y5rGbPiBOfjPTfnfCfJHs1HgRz91-ViGoRwPQ-SVfK0YPDix7Mo8W8g8Rf-_QoEPMTRI4g1PIdBFB7lBqbJcdfsIIrnfgyzNxDIsFSSQrElg_wdXUwZVlplZIzSB2nfHQhkg9xhmJdVbQ9yyjBTmpDv0ea2IOS4EuuCYhKS9MhBhpKsyIsuttlNKp1vhd4hw6QSpeFwhwyj2nKYuJi2DFVtT9nGig0hd1t2Gd8d8sX6Mr53ln_CKi1JkxwCJ-4tpu0PJee5sXmZ2ZH33XC2xPgvjxCTqVRpaJB-Ltk5NCS5of5GRtU6o6VWWYfpx6jzdYIkY_ut1w9B2a26X_pqdv9j9n41jwdmp03bq88AAAD__9FnAD0=
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJykkVFruzAUxd__nyLcp_9YRtW-5cl2dSB02mk3NoZINJciOOOSCErxu48qpXOsg26P99ycc35J9qDfS2DgPW_WCz8g_1d-vI0f1pQ8edEyjL0rEntr73ZLOLmLwnvCM_IY-GFwlFuyiI-7tiNhtPIisnwhHChUUmDA31ADewUbEgq1kjlqLdVB2g8HfNECsygUVd2Yg5xQyKVCYHswhSkRGGx5VmKEXKCaWUBBoOFFOcS2ndt2aZt2aSFaoBDXvNKM3ACFsDGMuDYkPQXZmFO8NnyHwOye_g7BniLwzOVZytPscgTnLMKpWSqBCsW007WvIem_4VwV2hRVbmbOV8NZiPkl7xChrmWlcZJ-Ltk6EKLY4XgjLRuV40bJfKgZx3DwDYJAbcatMw5-NayGj_pstv9idn40zydmq0_6fx8BAAD__07uAmE=
 
 query T
 EXPLAIN (DISTSQL,VERBOSE) SELECT a, b FROM ab UNION SELECT x AS a, y AS b FROM xy ORDER BY a
@@ -243,19 +244,19 @@ vectorized: true
 │
 ├── • scan
 │     columns: (a, b)
-│     ordering: +a
+│     ordering: +a,+b
 │     estimated row count: 1,000 (missing stats)
-│     table: ab@primary
+│     table: ab@ab_a_b_idx
 │     spans: FULL SCAN
 │
 └── • scan
       columns: (x, y)
-      ordering: +x
+      ordering: +x,+y
       estimated row count: 1,000 (missing stats)
-      table: xy@primary
+      table: xy@xy_x_y_idx
       spans: FULL SCAN
 ·
-Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJykkUFr4zAQhe_7K8ScdomW2M5NJycbLxhSO7XT0lJ8kK0hGBzLlRSwCf7vxXJL6tIU0p7EzJs335N0Av1cAYPgYbtZhhH5vQ7TXXq7oeQ-SFZxGvwhabAJ_u0IpyQn_5P4hvCc3EVhHL0pLVmmg9wN5-tM25E4WQcJWT0SDhRqKTDiB9TAnsCFjEKjZIFaSzW0TnYgFC0wh0JZN0cztDMKhVQI7ASmNBUCgx3PK0yQC1RzBygINLys7Nq28xtVHrjqgELa8Foz8heynoI8mvNGbfgegbk9_R7VnVJ5fg3Vu0g9w6QSqFBMMb47o743g6z_JN661KasCzP3Ppqo713MsrjmBRLUjaw1TgCXNjtDSBR7HC-m5VEVuFWysJixjK3PNgRqM6reWIS1lewXvTe7PzF7X5oXE7PTZ_2vlwAAAP__UP__WA==
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJykkdFro0AQxt_vr1jm6Y7sETVv-2Ry8UDIaU5zR0sRWd0hCNa1uysowf-9qC2ppQk0fVpmvvnm--3uCfRTCQy8u_1u7Qfk-9aPD_HfHSX_vWgTxt4PEns779eBcEoy8jsK_xCekX-BHwavSkvW8SB3w_ky03YkjLZeRDb3hAOFSgoM-CNqYA9gQ0KhVjJHraUaWqdxwBctMItCUdWNGdoJhVwqBHYCU5gSgcGBZyVGyAWqpQUUBBpelOPatnPbLm3TLi1ECxTimleakZ9AIWwMI65NXQeSnoJszDlBG35EYHZPb6Ow5xQ8c3mW8jS7icK5SHEOl0qgQjGPde0FdZ0FJP0HuNtCm6LKzdJ5b7rGsvrMi0Soa1lpnAVc2mwNkCiOOF1My0bluFcyH2OmMhx9Y0OgNpPqTIVfjdL4ZW_N9lfMzlXzama2-qT_9hwAAP__ZggHrQ==
 
 query T
 EXPLAIN (DISTSQL,VERBOSE) SELECT a, b FROM ab UNION ALL SELECT x AS a, y AS b FROM xy ORDER BY a
@@ -272,17 +273,17 @@ vectorized: true
 │     columns: (a, b)
 │     ordering: +a
 │     estimated row count: 1,000 (missing stats)
-│     table: ab@primary
+│     table: ab@ab_a_b_idx
 │     spans: FULL SCAN
 │
 └── • scan
       columns: (x, y)
       ordering: +x
       estimated row count: 1,000 (missing stats)
-      table: xy@primary
+      table: xy@xy_x_y_idx
       spans: FULL SCAN
 ·
-Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJykkc9rq0AQx-_vrxjm9B5vQ9TePCVpLAhWU01LS_GwukMQjGt3DSjB_724tqRCU5r2JDPfHx-HPaJ-KdFF73ETLP0Q_q79ZJvcBQwevHgVJd4_SLzAu94CZ5DBTRzdAs_gPvSjEJZB8K62sEwGSzd833xtB1G89mJYPQFHhpUUFPI9aXSf0caUYa1kTlpLNayOxuCLFl2LYVHVh2ZYpwxzqQjdIzZFUxK6uOVZSTFxQWpuIUNBDS9KU9t2i1oVe646ZJjUvNIuzDDtGcpDc2rUDd8RunbPfka1p1SeXUJ1zlJPMKkEKRJTzML-j2n_ya-FcibruTNxn6Nbl9wck65lpembzSlDEjsaT9HyoHLaKJkbzDhGJmcWgnQzqs44-JWRzKN8DNu_CTtfhq8mYatP-z-vAQAA___WJ_y5
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJykUV1rpDAUfd9fEe7TLpth1H3LkzM7LgiuzupsaSki0VwGwRqbRFAG_3tRW6ZCp7TTp3DPxz0nyQn0YwUMvNt9sPFD8n3nJ4fkX0DJjRdvo8T7QRIv8H4fCKckJ3_i6C_hOfkf-lFINkHwwnZkk4ySfjyfdV1PonjnxWR7RzhQqKXAkD-gBnYPNqQUGiUL1FqqETpNAl90wCwKZd20ZoRTCoVUCOwEpjQVAoMDzyuMkQtUawsoCDS8rKa1Xe92fdZlfVaKDigkDa81IyugELWGEdemrgPpQEG25pygDT8iMHug17Wwly147vI841l-VQvnYotzuFQCFYplrGv_hHR4o2ooV7JZOwv1pXTrM28Qo25krfGDm1MKKI44X0XLVhW4V7KYYuYxmnwTIFCbmXXmwa8navqk12b7K2bnXfOvhdka0uHbUwAAAP__lnwFDg==
 
 # TODO(yuzefovich): The synchronizers in the below DistSQL plans are all
 # unordered. This is not a problem, but we shouldn't need an input synchronizer
@@ -313,7 +314,7 @@ vectorized: true
       table: xy@xy_y_x_idx
       spans: FULL SCAN
 ·
-Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJykkl-Lm0AQwN_7KZZ5uuO2JJrcy0LBXGMh4MWrSmkpIqs7TQXr2t0VlJDvXlYPcoZL2lyfZP785jezuAf9uwIG_tenYLXZkpv1Jk7izwElX_zoIYz9WxL7gf8xIZySnHyKwkfCc7LZJn4U2_RztSOr2Lb09vvc1_UkjNZ-RB6-kZwSDhRqKXDLf6EG9h0cSCk0ShaotVQ2tR8aNqIDNqdQ1k1rbDqlUEiFwPZgSlMhMEh4XmGEXKCazYGCQMPLahjb9V7XZ33WZaXogELc8Foz8h7SAwXZmuNQbfgOgTkH-jaxMxXz3ON5lmf8X8XuNeJ1qU1ZF2bmTq2eQz2bCpVAhYIRz6Wec9a5eJNz8V_O5VnnUdXWchw2MaWW_FvLK4s_otphjCZsZsvp6knfIHvx_66CAChU-MPceO4d9Zy72w-q3P08hvbO1jAyHn3uxvtr3jVC3cha4-mtr06e2wNR7HB8MC1bVeCTksWgGcNw4IaEQG3G6mIMNvVYsgu-hJ2LsHsZdi_CywnsnMKLK2D3FF5ehO9P1k4P7_4EAAD__60NkI0=
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJykktGLm0AQxt_7VyzzdMdtSTS5l4WCucaC4MWrSmkpIqs7TQXr2t0VlJD_vagHOcOdbdInmZnvN9-36x5A_y6Bgfv1yd94O3Kz9aI4-uxT8sUNH4LIvSWR67sfY8IpycinMHgkPCPeLnbDqG8_T1uyiXpJ13-fdW1HgnDrhuThG8ko4UChkgJ3_BdqYN_BgoRCrWSOWkvVtw6DwBMtsCWFoqob07cTCrlUCOwApjAlAoOYZyWGyAWqxRIoCDS8KIe1bee0XdqlbVqIFihENa80I--BQtAYRhyLOjYkRwqyMScHbfgegVlHel0Ka5qCZw7P0izlV6WwL0mxLbQpqtws7GmE0YJCoAQqFIw4NnWsNz1XV3mu_stz_abnyaqp5Lhs4pT05N8krwR_RLXHCE1QL9bT6HFXI3vxsje-DxRK_GFuHPuOOtbd7QdV7H-eyn_7l_eX3GuIupaVxvOzvrp52R8QxR7HC9OyUTk-KZkPNmMZDNzQEKjNOF2NhVeNoz7gS9iahe152J6F1xPYOodXF8D2Obyehe_PYifHd38CAAD__xYClq8=
 
 query T
 EXPLAIN (DISTSQL,VERBOSE) SELECT b FROM ab INTERSECT ALL SELECT x AS b FROM xy ORDER BY b
@@ -337,10 +338,10 @@ vectorized: true
       columns: (x)
       ordering: +x
       estimated row count: 1,000 (missing stats)
-      table: xy@primary
+      table: xy@xy_x_y_idx
       spans: FULL SCAN
 ·
-Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJycUWGLnDAQ_d5fEebTHU059b4FCu71LAjeejVSWoos0Uyt4BqbRFAW_3tRWbYuu2233zJv5s2b93IA87MGBsGX12gTbsndc8hT_imi5HOQPMU8uCc8iIIPKcnJxyR-ISIn4TYNEj5hmyg6tnuy4ceZfiBx8hwk5OkryYFCoyRuxR4NsG_gQkah1apAY5SeoMM8EMoemEOhatrOTnBGoVAagR3AVrZGYJCKvMYEhUT94AAFiVZU9by2H_xWV3uhB6DAW9EYRt4BhbizjPguZCMF1dnTbmNFicDckf6fvrvWF7kv8l2-E7tK9pdO8K6e4F094aTcNUpL1ChXqtnE_NvIBR8vqEvkaOP2wVvbSIcW2fqHgUKN3-2d7769f6-r8sfy_IdsH2_JNkHTqsbgucGLm53JFcoSl5SM6nSBr1oVs8xSxjNvBiQau3S9pQibuTUn_zvZvYHsnpO9P5IfV2RnzMY3vwIAAP__7D8d8w==
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJycUWGLnDAQ_d5fEebTHU059b4FCu71LAjeejVSWopINFMrWGOTCMrify8qx9Zlt-3et8ybeTPvvRzA_GqAQfDlOdqFe3LzGPKUf4oo-RwkDzEPbgkPouBDSgryMYmfiChIuE-DhM_YLope2gPZ8ZeZYSRx8hgk5OErKYBCqyTuxU80wL6BCxmFTqsSjVF6hg7LQCgHYA6Fuu16O8MZhVJpBHYAW9sGgUEqigYTFBL1nQMUJFpRN8vaYfSHMR_yMa_lABR4J1rDyDugEPeWEd-FbKKgentcb6yoEJg70ddJcLcSROGLIi9ycUmCd1GCd1HC8XLfKi1Ro9xczWbmv0bO-HhCXSFHG3d33tZGOnbItp8MFBr8bm989-3te11XP9bnf2R7f022CZpOtQZPDZ7d7MyuUFa4pmRUr0t81qpczqxlvPAWQKKxa9dbi7BdWkvyf5LdK8juKdn7K_l-Q3ambHrzOwAA__8EXx8z
 
 query T
 EXPLAIN (DISTSQL,VERBOSE) SELECT b, a FROM ab INTERSECT ALL SELECT y AS b, x AS a FROM xy ORDER BY b
@@ -421,7 +422,7 @@ vectorized: true
       table: xy@xy_y_x_idx
       spans: FULL SCAN
 ·
-Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyckVFrnEAQx9_7KYZ5SsiWnOZtoeAl2cKBiVeVklJE1tupFaxrd1dQDr97UVsuhqRt8rTMzP8_v52ZI9qfNXIUD_twu7uHs9tdkiafQgafRXwdJeIcEhGKmxQkgwI-xtEdyALEw43Yp7ANwz_lHrbJpBmm97ewHyCKb0UM11-gYCCRYaMV3csfZJF_RQ8zhq3RB7JWmyl1nAU71SPfMKyatnNTOmN40IaQH9FVribkmMqippikInO5QYaKnKzqua0sAlnkRS7zSvXIMGllYzm8x2xkqDt3amqdLAm5N7K3gb01uB-CfsiHvP9fsP8i-MTrGm0UGVIrVjY5_yV55vd3ZEpKyEXtpb_-fDq0xB8dFhnW9M2dBf4FC7yL8w-mKr-fQmQYdY5D4LHAf3HAq9dsNibb6sbS00Gf7byZpiNV0rItqztzoL3RhxmzhNHsmxOKrFuq_hLsmrk0n_6x2XuF2X9q9v9qvlqZN2M2vvsVAAD__wSzHgA=
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJycUmFrnEAQ_d5fMcynhGzJab4tFLwkWzgw8apSUorIeju1gnXt7grK4X8vasvFkLZJPsnMvDfvvXGPaH_WyFE87MPt7h7ObndJmnwKGXwW8XWUiHNIRChuUpAMCvgYR3cgCxAPN2KfwjYM_4x72CYTZpi-v4H9AFF8K2K4_gIFA4kMG63oXv4gi_wrepgxbI0-kLXaTK3jDNipHvmGYdW0nZvaGcODNoT8iK5yNSHHVBY1xSQVmcsNMlTkZFXPa2URyCIvcplXqkeGSSsby-E9Mow6xyHwWOBjNjLUnTspWCdLQu6N7G0uvLWLfgj6IR_y_k0u_L-6OIl3jTaKDKmVcDYx_wd5JsodmZISclF76a-TpENL_NEvR4Y1fXNngX_BAu_i_IOpyu-n8mUBr15z5phsqxtLT4M-u3kzpSNV0nItqztzoL3Rh1lmKaOZNzcUWbdM_aXYNfNofgePyd4ryP5Tsv9P8tWKvBmz8d2vAAAA___aYCQi
 
 statement ok
 CREATE TABLE abcde (a INT PRIMARY KEY, b INT, c INT, d INT, e INT, INDEX (b, c, d, e))
@@ -587,82 +588,82 @@ vectorized: true
 Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyskG9rm1AUxt_vUxzOq7ickhgtjAsB08UywWmn2T-GiPEeiuC87l4DhZDvPqKD1tKEdu0b4TzH5zy_--zR_KlRoP_jJlwFEUzWQbpJv4QE3_zkKk59C1I_9D9u4D1cJ_FnmIzHYltKhq9REEewCkN4YmvB909-4sOkhCXYFqyiNUwkLIEtiJO1n8DVT9gSlASSgAkKJGyU5Kj4zQbFL7QxI2y1KtkYpY_Svv8hkHco5oRV0-66o5wRlkozij12VVczCtwU25oTLiTr2RwJJXdFVfdnezqv_-bbvMxlznkl75AwbYvGCLjA7ECodt39edMVt4zCPtDzEa6rumPNemaP8wddwMRzjs0IIYJo8-FfQZ4LS_AurZMIi5cgPGxh8WYtOP_VgvOWLbgnEe6TlZasWY5jvcWUPGdKnjslz55idniCOVIXqp25I-cpkvlLykjYtKox_MzLGSHLWx6eZdROl3yjVdnHDGPc-3pBsumGrT0MQTOsjoAPzfZZszsy24_Ni7Nm53yy85pk96z58lFydnj3NwAA__-m3oqG
 
 query T
-EXPLAIN (DISTSQL,VERBOSE) SELECT * FROM (SELECT * FROM abcde INTERSECT SELECT * FROM abcde) WHERE c = 1 AND d = e ORDER BY a
+EXPLAIN (DISTSQL,VERBOSE) SELECT b, c, d, e FROM (SELECT b, c, d, e FROM abcde INTERSECT SELECT b, c, d, e FROM abcde) WHERE c = 1 AND d = e ORDER BY b
 ----
 distribution: local
 vectorized: true
 ·
 • intersect
-│ columns: (a, b, c, d, e)
-│ ordering: +a,+b,+c,+d,+e
+│ columns: (b, c, d, e)
+│ ordering: +b,+c,+d,+e
 │ estimated row count: 1 (missing stats)
 │
 ├── • filter
-│   │ columns: (a, b, c, d, e)
-│   │ ordering: +a
+│   │ columns: (b, c, d, e)
+│   │ ordering: +b,+d
 │   │ estimated row count: 1 (missing stats)
 │   │ filter: (c = 1) AND (d = e)
 │   │
 │   └── • scan
-│         columns: (a, b, c, d, e)
-│         ordering: +a
-│         estimated row count: 1,000 (missing stats)
-│         table: abcde@primary
-│         spans: FULL SCAN
-│
-└── • filter
-    │ columns: (a, b, c, d, e)
-    │ ordering: +a
-    │ estimated row count: 1 (missing stats)
-    │ filter: (c = 1) AND (d = e)
-    │
-    └── • scan
-          columns: (a, b, c, d, e)
-          ordering: +a
-          estimated row count: 1,000 (missing stats)
-          table: abcde@primary
-          spans: FULL SCAN
-·
-Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJysk1uLm0AUx9_7KQ7nSZspibdsGQhMtnGpkI1blV4oeXD1NBVcteMEuoR896IWNobENrv7OOf4O_8LuMP6V44c3a93y7m3Am3hhVH4acngsxtc-6GrQ-gu3Q8RvIWbwL8Frf-M75OUwFtFbhA24xNbHb58dAMXtARmYOgwXy1AS2EGpIMfLNwArr9BjAyLMqVV_EA18u9o4JphJcuE6rqUzWjXfuClv5FPGGZFtVXNeM0wKSUh36HKVE7IMYrvcwooTkmOJ8gwJRVneXu2dSQqmT3E8hEZhlVc1Bze4XrPsNyqp6O1ijeE3Niz_xe-yXJFkuTY6Kt2cw6asJoOOOfeKnr_twphwwyEo5-1YF5i4TC7-cLs1rOyW6-Z3b7EwiKrVVYkamz3LQiDCZMJiwmbCQcZ-jIlSSkHYZxVdp6l7LyC8vSs8pPgtii7Sz29dUP-65MT9m9Jbigk5VfjaT9A9FgRP_i_58slMszph9KEMWLCHDFhjZiwR0w4I30ms83P06sm_FY1wXuVnCvh6pL6A6qrsqjpuIyTlydNA5RuqGu0LrcyoTtZJq1M9_Rbrh2kVKtua3QPr-hWjcFD2BiEnWHYHIStYdgahO1h2B6Epz3YOIadC2DzGJ4OwldHttf7N38CAAD__8p2GHI=
-
-query T
-EXPLAIN (DISTSQL,VERBOSE) SELECT * FROM (SELECT * FROM abcde EXCEPT SELECT * FROM abcde) WHERE c = 1 AND d = e ORDER BY b, c, d, e, a
-----
-distribution: local
-vectorized: true
-·
-• except
-│ columns: (a, b, c, d, e)
-│ ordering: +b,+c,+d,+a,+e
-│ estimated row count: 1 (missing stats)
-│
-├── • filter
-│   │ columns: (a, b, c, d, e)
-│   │ ordering: +b,+d,+a
-│   │ estimated row count: 1 (missing stats)
-│   │ filter: (c = 1) AND (d = e)
-│   │
-│   └── • scan
-│         columns: (a, b, c, d, e)
-│         ordering: +b,+c,+d,+e,+a
+│         columns: (b, c, d, e)
+│         ordering: +b,+c,+d
 │         estimated row count: 1,000 (missing stats)
 │         table: abcde@abcde_b_c_d_e_idx
 │         spans: FULL SCAN
 │
 └── • filter
-    │ columns: (a, b, c, d, e)
-    │ ordering: +b,+d,+a
+    │ columns: (b, c, d, e)
+    │ ordering: +b,+d
     │ estimated row count: 1 (missing stats)
     │ filter: (c = 1) AND (d = e)
     │
     └── • scan
-          columns: (a, b, c, d, e)
-          ordering: +b,+c,+d,+e,+a
+          columns: (b, c, d, e)
+          ordering: +b,+c,+d
           estimated row count: 1,000 (missing stats)
           table: abcde@abcde_b_c_d_e_idx
           spans: FULL SCAN
 ·
-Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyslNFr20AMxt_3Vwg9JYtG6thOx0Hg2sZlgTTpbLN1jBAcn5YZPNs7X6Cj9H8ftjdah8RbSl8Cku6n79MX8AOWP1MU6N3dzi9mC-hNZ0EYfJwTfPL8y2Xg9SHw5t5VCG_h2l_eQK9dRptYMXh3V95tCAdGffj8wfM96MUwAasPF4sp9BRMgPuw9KeeD5dfYEMQEygCJoiQMMsVL6IfXKL4ihauCAudx1yWua5aD_WDmbpHcUaYZMXOVO0VYZxrRvGAJjEpo8Aw2qTsc6RYD8-QULGJkrReW7uT9e96s47Xas3rRN0jYVBEWSngHa4eCfOdeVpfmmjLKKxH-n8L10lqWLMeWm39pi-gJ-0qGSHEbBG-_xOQdGAC0u0ftTA6xcLzFEavloL9ohTs10zBOcXCNClNksVm6LQtSIvkiKRN0iHpIuFSK9asBFRth6R1VN99kb77avrjo_pPsrssb_a1VFcV-a8nB464Yb3lgM2yGI7bZ4S_ChZ_PwQX8zkSpvzN9ORoQNIekHQGJK0BSXfQn-hk-_3wqLp_ZwTspXIsgfNT_gGfyyLPSt5P4uDms-p8Vltu4izznY75VudxLdOUy5qrG4pL00ytpphlzagy-By2OmGnGx51wnY3bHfCbjfsdMLjFmztw-4J8GgfHnfC53u2V49vfgcAAP__jLsjDg==
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJy0lF-L2kAUxd_7KS73KcEpbv7olgFhdmuWBlyzTUL_UERi5tYG0iSdjLBF_O4lSdtVu6Z12b4Ic2Z-95x7kGyx_pYjR-_D3ezKn4Mx9aM4ejtj8M4Lr4PIMyHyZt7rGFYMUgaSAcFNGNyCcUJPVqkk8OexF0bNfd8zE96_8UIPjBQmYJlwNZ-CIWECZEIQTr0Qrj_CChkWpaR58pVq5J_QwgXDSpUp1XWpGmnbPvDlPfILhllRbXQjLximpSLkW9SZzgk5xskqp5ASSWp4gQwl6STL27FtItH-LlfLdCmXtMzkPTKMqqSoObxEhsFGcxA2Ew4TLhMjXOwYlhv94FjrZE3IrR3791Q3Wa5JkRpah5E6nYMh7KYgzrk_j1_97Ek4MAHhmicj2OdE2C_G_p_FOE8qxnnOYtxzIkyzWmdFqofuYQRhsV_rNusrSYokh0Z2TjqPnuQ8egbn8UnnB8NNUXbDDvwWDfm3J4_EvyW1poh0UA3HhwvE3yvie5-Iq9kMGeb0WRvCGjBhD5hwBky4A3OisvWXP-Xff7i9Kk5tfnlO5yHVVVnUdNzAo5MvmrVJrqmrsS43KqU7VaatTXcMWq4VJNW6u7W6g190V03AfdjqhUf9sN0LO_2w0wu7_bDbC48PYOsYHp0B28fwuBe-PIq92L34EQAA___K-yzi
+
+query T
+EXPLAIN (DISTSQL,VERBOSE) SELECT b, c, d, e FROM (SELECT b, c, d, e FROM abcde EXCEPT SELECT b, c, d, e FROM abcde) WHERE c = 1 AND d = e ORDER BY b, c, d, e
+----
+distribution: local
+vectorized: true
+·
+• except
+│ columns: (b, c, d, e)
+│ ordering: +b,+c,+d,+e
+│ estimated row count: 1 (missing stats)
+│
+├── • filter
+│   │ columns: (b, c, d, e)
+│   │ ordering: +b,+d
+│   │ estimated row count: 1 (missing stats)
+│   │ filter: (c = 1) AND (d = e)
+│   │
+│   └── • scan
+│         columns: (b, c, d, e)
+│         ordering: +b,+c,+d
+│         estimated row count: 1,000 (missing stats)
+│         table: abcde@abcde_b_c_d_e_idx
+│         spans: FULL SCAN
+│
+└── • filter
+    │ columns: (b, c, d, e)
+    │ ordering: +b,+d
+    │ estimated row count: 1 (missing stats)
+    │ filter: (c = 1) AND (d = e)
+    │
+    └── • scan
+          columns: (b, c, d, e)
+          ordering: +b,+c,+d
+          estimated row count: 1,000 (missing stats)
+          table: abcde@abcde_b_c_d_e_idx
+          spans: FULL SCAN
+·
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJy0lN9q20wQxe-_pxjmSsL74eiPnbJg2CRWqMGxUkm0KcUYWTt1BaqkrtaQEvzuRVLT2G6k1iG9MezZ_c05czB6wOpbhhy9u9v5xWwBxnQWRuG7OYP3XnDph54JoTf3riJYM0gYSAYE14F_A0aHHq8TSeDdXXm3URfbvDHhw1sv8MBIYAKWCReLKRgSJkAm-MHUC-Dy4x6JDPNC0iL-ShXyT2jhkmGpioSqqlC19NA8mMl75GcM07zc6lpeMkwKRcgfUKc6I-QYxeuMAoolqeEZMpSk4zRrxjbRRPO7Wq-SlVzRKpX3yDAs47zi8D8y9Leag7CZcJhwmRjhcsew2Oonx0rHG0Ju7djfp7pOM02K1NA6jNTqHAxh101xzmeL6M3PwoQDExCu2RnBPiXCfjH2vyzGeVExzmsW454SYZpWOs0TPXQPIwiLPa5br68kKZIcatnpdB69yHn0Cs7jTucnw21etMMO_JY1-acnz8S_IbWhkLRfDseHC0TfS-KPH4qL-RwZZvRZG8IaMGEPmHAGTLgDc6LSzZff5V__tr0eutY-P6XwgKqyyCs6Xv_ZyWf1ziQ31HZYFVuV0K0qksamPfoN1wiSKt3eWu1hlrdXdcB92OqF3X7Y7oWdftjphUf9sNsLjw9g6xgenQDbx_C4Fz4_ir3c_fcjAAD__7UbLSI=
 
 query T
 EXPLAIN (DISTSQL,VERBOSE) SELECT * FROM (SELECT * FROM abcde EXCEPT ALL SELECT * FROM abcde) WHERE c = 1 AND d = e ORDER BY a

--- a/pkg/sql/opt/memo/testdata/logprops/set
+++ b/pkg/sql/opt/memo/testdata/logprops/set
@@ -485,11 +485,10 @@ SELECT a, b, c FROM abc WHERE a > 0 AND a = c
 INTERSECT
 SELECT a, b, c FROM abc WHERE a > 10 AND a = b
 ----
-intersect
+intersect-all
  ├── columns: a:1(int!null) b:2(int) c:3(int)
  ├── left columns: a:1(int!null) b:2(int) c:3(int)
  ├── right columns: a:6(int) b:7(int) c:8(int)
- ├── key: (2,3)
  ├── fd: (1)==(3), (3)==(1)
  ├── interesting orderings: (+1)
  ├── select
@@ -538,11 +537,10 @@ SELECT a, b, c FROM abc WHERE a > 0 AND a = c
 EXCEPT
 SELECT a, b, c FROM abc WHERE a > 10 AND a = b
 ----
-except
+except-all
  ├── columns: a:1(int!null) b:2(int) c:3(int)
  ├── left columns: a:1(int!null) b:2(int) c:3(int)
  ├── right columns: a:6(int) b:7(int) c:8(int)
- ├── key: (2,3)
  ├── fd: (1)==(3), (3)==(1)
  ├── interesting orderings: (+1)
  ├── select

--- a/pkg/sql/opt/memo/testdata/stats/set
+++ b/pkg/sql/opt/memo/testdata/stats/set
@@ -871,29 +871,44 @@ except-all
 # Regression test for #35715.
 opt colstat=(5,2)
 SELECT * FROM
-((VALUES (NULL, true) EXCEPT (VALUES (1, NULL)))) AS t(a, b)
+(((VALUES (NULL, true), (2, true)) EXCEPT (VALUES (1, NULL), (1, NULL)))) AS t(a, b)
 WHERE a IS NULL and b
 ----
 except
- ├── columns: a:5(int) b:2(bool!null)
- ├── left columns: column1:5(int) column2:2(bool!null)
+ ├── columns: a:1(int) b:2(bool!null)
+ ├── left columns: column1:1(int) column2:2(bool!null)
  ├── right columns: column1:3(int) column2:4(bool)
- ├── cardinality: [1 - 1]
- ├── stats: [rows=1, distinct(2,5)=1, null(2,5)=0]
- ├── key: (2,5)
- ├── values
- │    ├── columns: column2:2(bool!null) column1:5(int)
- │    ├── cardinality: [1 - 1]
- │    ├── stats: [rows=1, distinct(2,5)=1, null(2,5)=0]
- │    ├── key: ()
- │    ├── fd: ()-->(2,5)
- │    └── (true, NULL) [type=tuple{bool, int}]
- └── values
+ ├── cardinality: [0 - 2]
+ ├── stats: [rows=1, distinct(1,2)=1, null(1,2)=0, distinct(2,5)=1, null(2,5)=0]
+ ├── key: (1,2)
+ ├── select
+ │    ├── columns: column1:1(int) column2:2(bool!null)
+ │    ├── cardinality: [0 - 2]
+ │    ├── stats: [rows=1, distinct(1)=1, null(1)=1, distinct(2)=1, null(2)=0, distinct(1,2)=1, null(1,2)=0]
+ │    ├── fd: ()-->(1,2)
+ │    ├── values
+ │    │    ├── columns: column1:1(int) column2:2(bool!null)
+ │    │    ├── cardinality: [2 - 2]
+ │    │    ├── stats: [rows=2, distinct(1)=2, null(1)=1, distinct(2)=1, null(2)=0, distinct(1,2)=2, null(1,2)=0]
+ │    │    ├── (NULL, true) [type=tuple{int, bool}]
+ │    │    └── (2, true) [type=tuple{int, bool}]
+ │    └── filters
+ │         ├── column1:1 IS NULL [type=bool, outer=(1), constraints=(/1: [/NULL - /NULL]; tight), fd=()-->(1)]
+ │         └── column2:2 [type=bool, outer=(2), constraints=(/2: [/true - /true]; tight), fd=()-->(2)]
+ └── select
       ├── columns: column1:3(int!null) column2:4(bool!null)
-      ├── cardinality: [0 - 0]
-      ├── stats: [rows=0, distinct(3,4)=0, null(3,4)=0]
-      ├── key: ()
-      └── fd: ()-->(3,4)
+      ├── cardinality: [0 - 2]
+      ├── stats: [rows=2e-10, distinct(3)=2e-10, null(3)=0, distinct(4)=2e-10, null(4)=0, distinct(3,4)=2e-10, null(3,4)=0]
+      ├── fd: ()-->(3,4)
+      ├── values
+      │    ├── columns: column1:3(int!null) column2:4(bool)
+      │    ├── cardinality: [2 - 2]
+      │    ├── stats: [rows=2, distinct(3)=1, null(3)=0, distinct(4)=1, null(4)=2, distinct(3,4)=1, null(3,4)=0]
+      │    ├── (1, NULL) [type=tuple{int, bool}]
+      │    └── (1, NULL) [type=tuple{int, bool}]
+      └── filters
+           ├── column1:3 IS NULL [type=bool, outer=(3), constraints=(/3: [/NULL - /NULL]; tight), fd=()-->(3)]
+           └── column2:4 [type=bool, outer=(4), constraints=(/4: [/true - /true]; tight), fd=()-->(4)]
 
 # Regression test for #36147 and #36157.
 opt
@@ -938,28 +953,32 @@ except
            └── column1:3 IS NULL [type=bool, outer=(3), constraints=(/3: [/NULL - /NULL]; tight), fd=()-->(3)]
 
 # Make sure that we estimate at least 1 row for the intersect.
-opt
-VALUES (1) INTERSECT VALUES (NULL) ORDER BY 1
+opt disable=SimplifyIntersectRight
+VALUES (1), (2) INTERSECT VALUES (NULL) ORDER BY 1
 ----
-intersect
+sort
  ├── columns: column1:1(int)
- ├── left columns: column1:1(int)
- ├── right columns: column1:2(int)
  ├── cardinality: [0 - 1]
  ├── stats: [rows=1, distinct(1)=1, null(1)=0]
  ├── key: (1)
  ├── ordering: +1
- ├── values
- │    ├── columns: column1:1(int!null)
- │    ├── cardinality: [1 - 1]
- │    ├── stats: [rows=1, distinct(1)=1, null(1)=0]
- │    ├── key: ()
- │    ├── fd: ()-->(1)
- │    └── (1,) [type=tuple{int}]
- └── values
-      ├── columns: column1:2(int)
-      ├── cardinality: [1 - 1]
-      ├── stats: [rows=1, distinct(2)=1, null(2)=1]
-      ├── key: ()
-      ├── fd: ()-->(2)
-      └── (NULL,) [type=tuple{int}]
+ └── intersect
+      ├── columns: column1:1(int)
+      ├── left columns: column1:1(int)
+      ├── right columns: column1:2(int)
+      ├── cardinality: [0 - 1]
+      ├── stats: [rows=1, distinct(1)=1, null(1)=0]
+      ├── key: (1)
+      ├── values
+      │    ├── columns: column1:1(int!null)
+      │    ├── cardinality: [2 - 2]
+      │    ├── stats: [rows=2, distinct(1)=2, null(1)=0]
+      │    ├── (1,) [type=tuple{int}]
+      │    └── (2,) [type=tuple{int}]
+      └── values
+           ├── columns: column1:2(int)
+           ├── cardinality: [1 - 1]
+           ├── stats: [rows=1, distinct(2)=1, null(2)=1]
+           ├── key: ()
+           ├── fd: ()-->(2)
+           └── (NULL,) [type=tuple{int}]

--- a/pkg/sql/opt/norm/rules/set.opt
+++ b/pkg/sql/opt/norm/rules/set.opt
@@ -2,16 +2,20 @@
 # set.opt contains normalization rules for set operators.
 # =============================================================================
 
-# EliminateUnionAllLeft replaces a union all with a right side having a
-# cardinality of zero, with just the left side operand.
+# EliminateSetLeft replaces a UnionAll or ExceptAll operator with a right side
+# having a cardinality of zero, with just the left side operand.
 #
-# It is possible for the left and right sides of the UnionAll to have column
-# IDs that are also present in the output columns of the UnionAll, e.g. after
+# It is possible for the left and right sides of the set operator to have column
+# IDs that are also present in the output columns of the operator, e.g. after
 # the SplitDisjunction exploration rule has been applied. These columns are
 # included as passthrough columns in the generated Project because they do not
 # need to be projected. All other column IDs are added to the ProjectionsExpr.
-[EliminateUnionAllLeft, Normalize]
-(UnionAll $left:* $right:* & (HasZeroRows $right) $colmap:*)
+[EliminateSetLeft, Normalize]
+(UnionAll | ExceptAll
+    $left:*
+    $right:* & (HasZeroRows $right)
+    $colmap:*
+)
 =>
 (Project
     $left
@@ -19,12 +23,14 @@
     (ProjectPassthroughLeft $colmap)
 )
 
-# EliminateUnionAllRight replaces a union all with a left side having a
-# cardinality of zero, with just the right side operand.
+# EliminateSetRight replaces a UnionAll operator with a left side having a
+# cardinality of zero, with just the right side operand. Note that it only
+# applies to UnionAll operators because Except operators only output left input
+# rows.
 #
-# See the comment above EliminateUnionAllLeft which describes when columns are
+# See the comment above EliminateSetLeft which describes when columns are
 # projected vs. passed-through.
-[EliminateUnionAllRight, Normalize]
+[EliminateSetRight, Normalize]
 (UnionAll $left:* & (HasZeroRows $left) $right:* $colmap:*)
 =>
 (Project
@@ -33,10 +39,14 @@
     (ProjectPassthroughRight $colmap)
 )
 
-# EliminateUnionLeft replaces a union with a right side having a cardinality of
-# zero, with a Distinct on just the left side operand.
-[EliminateUnionLeft, Normalize]
-(Union $left:* $right:* & (HasZeroRows $right) $colMap:*)
+# EliminateDistinctSetLeft replaces a Union or Except operator with a right side
+# having a cardinality of zero, with a Distinct on just the left side operand.
+[EliminateDistinctSetLeft, Normalize]
+(Union | Except
+    $left:*
+    $right:* & (HasZeroRows $right)
+    $colMap:*
+)
 =>
 (DistinctOn
     $project:(Project
@@ -48,8 +58,9 @@
     (MakeGrouping (OutputCols $project) (EmptyOrdering))
 )
 
-# EliminateUnionRight mirrors EliminateUnionLeft.
-[EliminateUnionRight, Normalize]
+# EliminateDistinctSetRight mirrors EliminateDistinctSetLeft. Note that it only
+# applies to Union because Except operators only output left input rows.
+[EliminateDistinctSetRight, Normalize]
 (Union $left:* & (HasZeroRows $left) $right:* $colMap:*)
 =>
 (DistinctOn
@@ -61,6 +72,34 @@
     []
     (MakeGrouping (OutputCols $project) (EmptyOrdering))
 )
+
+# SimplifyExcept converts an Except operator into an ExceptAll operator when the
+# left input has a key. This avoids the de-duplication step.
+[SimplifyExcept, Normalize]
+(Except $left:* & (HasStrictKey $left) $right:* $colMap:*)
+=>
+(ExceptAll $left $right $colMap)
+
+# SimplifyIntersectLeft converts an Intersect operator into an IntersectAll
+# operator when the left input has a key. This avoids the de-duplication step.
+[SimplifyIntersectLeft, Normalize]
+(Intersect $left:* & (HasStrictKey $left) $right:* $colMap:*)
+=>
+(IntersectAll $left $right $colMap)
+
+# SimplifyIntersectRight converts an Intersect operator into an IntersectAll
+# operator when the right input has a key. This avoids the de-duplication step.
+#
+# This works because IntersectAll creates a one-to-one mapping between left and
+# right rows. If there is more than one row with a particular value on the
+# left side, then there must be at least that many rows with the same value on
+# the right side in order for the left rows to be preserved in the output.
+# Therefore, if the right input has a strict key, the output rows will be
+# de-duplicated for 'free', and an IntersectAll can safely be used.
+[SimplifyIntersectRight, Normalize]
+(Intersect $left:* $right:* & (HasStrictKey $right) $colMap:*)
+=>
+(IntersectAll $left $right $colMap)
 
 # ConvertUnionToDistinctUnionAll replaces a Union with a DistinctOn on top of a
 # UnionAll when the left and right inputs satisfy the following conditions:

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -1520,12 +1520,11 @@ SELECT k FROM
   (SELECT i FROM a))
 WHERE k < 10 AND k > 1
 ----
-except
+except-all
  ├── columns: k:1!null
  ├── left columns: b.k:1!null
  ├── right columns: a.i:9
  ├── cardinality: [0 - 8]
- ├── key: (1)
  ├── select
  │    ├── columns: b.k:1!null
  │    ├── cardinality: [0 - 8]
@@ -1577,12 +1576,11 @@ SELECT k FROM
   (SELECT i FROM a))
 WHERE k < 10 AND k > 1
 ----
-intersect
+intersect-all
  ├── columns: k:1!null
  ├── left columns: b.k:1!null
  ├── right columns: a.i:9
  ├── cardinality: [0 - 8]
- ├── key: (1)
  ├── select
  │    ├── columns: b.k:1!null
  │    ├── cardinality: [0 - 8]
@@ -1867,13 +1865,12 @@ SELECT * FROM ((values (1,2))
   EXCEPT (values (0,1)))
 WHERE 1 / column1 > 0
 ----
-except
+except-all
  ├── columns: column1:1!null column2:2!null
  ├── left columns: column1:1!null column2:2!null
  ├── right columns: column1:3 column2:4
  ├── cardinality: [0 - 1]
  ├── immutable
- ├── key: (1,2)
  ├── values
  │    ├── columns: column1:1!null column2:2!null
  │    ├── cardinality: [1 - 1]
@@ -1903,13 +1900,11 @@ select
  ├── columns: column1:1!null
  ├── cardinality: [0 - 1]
  ├── immutable
- ├── key: (1)
- ├── except
+ ├── except-all
  │    ├── columns: column1:1!null
  │    ├── left columns: column1:1!null
  │    ├── right columns: column1:2
  │    ├── cardinality: [0 - 1]
- │    ├── key: (1)
  │    ├── values
  │    │    ├── columns: column1:1!null
  │    │    ├── cardinality: [1 - 1]
@@ -1929,12 +1924,11 @@ select
 norm expect=PushFilterIntoSetOp
 SELECT * FROM ((VALUES (1.0::DECIMAL)) EXCEPT (VALUES (1.00::DECIMAL))) WHERE column1 > 0;
 ----
-except
+except-all
  ├── columns: column1:1!null
  ├── left columns: column1:1!null
  ├── right columns: column1:2
  ├── cardinality: [0 - 1]
- ├── key: (1)
  ├── values
  │    ├── columns: column1:1!null
  │    ├── cardinality: [1 - 1]

--- a/pkg/sql/opt/norm/testdata/rules/set
+++ b/pkg/sql/opt/norm/testdata/rules/set
@@ -23,10 +23,10 @@ CREATE TABLE t2 (
 ----
 
 # --------------------------------------------------
-# EliminateUnionAllLeft
+# EliminateSetLeft
 # --------------------------------------------------
 
-norm expect=EliminateUnionAllLeft
+norm expect=EliminateSetLeft
 SELECT k FROM
   (SELECT k FROM b)
   UNION ALL
@@ -41,11 +41,21 @@ project
  └── projections
       └── b.k:1 [as=k:15, outer=(1)]
 
+norm expect=EliminateSetLeft
+SELECT k FROM
+  (SELECT k FROM b)
+  EXCEPT ALL
+  (SELECT k FROM b WHERE k IN ())
+----
+scan b
+ ├── columns: k:1!null
+ └── key: (1)
+
 # --------------------------------------------------
-# EliminateUnionAllRight
+# EliminateSetRight
 # --------------------------------------------------
 
-norm expect=EliminateUnionAllRight
+norm expect=EliminateSetRight
 SELECT k FROM
   (SELECT k FROM b WHERE Null)
   UNION ALL
@@ -60,6 +70,19 @@ project
  └── projections
       └── b.k:8 [as=k:15, outer=(8)]
 
+# No-op case because EXCEPT ALL outputs left rows.
+norm expect-not=EliminateSetLeft
+SELECT k FROM
+  (SELECT k FROM b WHERE k IN ())
+  EXCEPT ALL
+  (SELECT k FROM b)
+----
+values
+ ├── columns: k:1!null
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(1)
+
 norm
 SELECT k FROM
   (SELECT k FROM b WHERE False)
@@ -73,10 +96,10 @@ values
  └── fd: ()-->(15)
 
 # --------------------------------------------------
-# EliminateUnionLeft
+# EliminateDistinctSetLeft
 # --------------------------------------------------
 
-norm expect=EliminateUnionLeft
+norm expect=EliminateDistinctSetLeft
 SELECT k FROM
   (SELECT k FROM b)
   UNION
@@ -91,11 +114,24 @@ project
  └── projections
       └── b.k:1 [as=k:15, outer=(1)]
 
+norm expect=EliminateDistinctSetLeft
+SELECT i FROM
+  (SELECT i FROM b)
+  EXCEPT
+  (SELECT i FROM b WHERE k IN ())
+----
+distinct-on
+ ├── columns: i:2
+ ├── grouping columns: i:2
+ ├── key: (2)
+ └── scan b
+      └── columns: i:2
+
 # --------------------------------------------------
-# EliminateUnionRight
+# EliminateDistinctSetRight
 # --------------------------------------------------
 
-norm expect=EliminateUnionRight
+norm expect=EliminateDistinctSetRight
 SELECT k FROM
   (SELECT k FROM b WHERE Null)
   UNION
@@ -110,6 +146,19 @@ project
  └── projections
       └── b.k:8 [as=k:15, outer=(8)]
 
+# No-op case because EXCEPT outputs left rows.
+norm expect-not=EliminateDistinctSetLeft
+SELECT i FROM
+  (SELECT i FROM b WHERE k IN ())
+  EXCEPT
+  (SELECT i FROM b)
+----
+values
+ ├── columns: i:2!null
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(2)
+
 norm
 SELECT k FROM
   (SELECT k FROM b WHERE False)
@@ -121,6 +170,114 @@ values
  ├── cardinality: [0 - 0]
  ├── key: ()
  └── fd: ()-->(15)
+
+# -------------------------------------------------
+# SimplifyExcept
+# -------------------------------------------------
+
+norm expect=SimplifyExcept
+SELECT k FROM
+  (SELECT k FROM b)
+  EXCEPT
+  (SELECT i FROM b)
+----
+except-all
+ ├── columns: k:1
+ ├── left columns: k:1
+ ├── right columns: i:9
+ ├── scan b
+ │    ├── columns: k:1!null
+ │    └── key: (1)
+ └── scan b
+      └── columns: i:9
+
+# No-op case because the left side does not have a key.
+norm expect-not=SimplifyExcept
+SELECT i FROM
+  (SELECT i FROM b)
+  EXCEPT
+  (SELECT k FROM b)
+----
+except
+ ├── columns: i:2
+ ├── left columns: i:2
+ ├── right columns: k:8
+ ├── key: (2)
+ ├── scan b
+ │    └── columns: i:2
+ └── scan b
+      ├── columns: k:8!null
+      └── key: (8)
+
+# -------------------------------------------------
+# SimplifyIntersect
+# -------------------------------------------------
+
+norm expect=SimplifyIntersectLeft expect-not=SimplifyIntersectRight
+SELECT k FROM
+  (SELECT k FROM b)
+  Intersect
+  (SELECT i FROM b)
+----
+intersect-all
+ ├── columns: k:1
+ ├── left columns: k:1
+ ├── right columns: i:9
+ ├── scan b
+ │    ├── columns: k:1!null
+ │    └── key: (1)
+ └── scan b
+      └── columns: i:9
+
+norm expect=SimplifyIntersectRight expect-not=SimplifyIntersectLeft
+SELECT i FROM
+  (SELECT i FROM b)
+  Intersect
+  (SELECT k FROM b)
+----
+intersect-all
+ ├── columns: i:2
+ ├── left columns: i:2
+ ├── right columns: k:8
+ ├── scan b
+ │    └── columns: i:2
+ └── scan b
+      ├── columns: k:8!null
+      └── key: (8)
+
+norm
+SELECT k FROM
+  (SELECT k FROM b)
+  Intersect
+  (SELECT k FROM b)
+----
+intersect-all
+ ├── columns: k:1!null
+ ├── left columns: k:1!null
+ ├── right columns: k:8
+ ├── scan b
+ │    ├── columns: k:1!null
+ │    └── key: (1)
+ └── scan b
+      ├── columns: k:8!null
+      └── key: (8)
+
+# No-op case because neither side has a key.
+norm expect-not=(SimplifyIntersectLeft, SimplifyIntersectRight)
+SELECT i FROM
+  (SELECT i FROM b)
+  Intersect
+  (SELECT i FROM b)
+----
+intersect
+ ├── columns: i:2
+ ├── left columns: i:2
+ ├── right columns: i:9
+ ├── key: (2)
+ ├── scan b
+ │    └── columns: i:2
+ └── scan b
+      └── columns: i:9
 
 # -------------------------------------------------
 # ConvertUnionToDistinctUnionAll

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -845,6 +845,9 @@ define SetPrivate {
 # The SetPrivate field matches columns from the Left and Right inputs of the
 # Intersect with the output columns. See the comment above SetPrivate for more
 # details.
+# Note that Intersect is symmetric in most cases, but there are exceptions:
+# some types allow values that are equal but not identical (e.g. collated
+# strings) in which case it could be visible which side a row is coming from.
 [Relational, Set]
 define Intersect {
     Left RelExpr
@@ -907,6 +910,9 @@ define UnionAll {
 # The SetPrivate field matches columns from the Left and Right inputs of the
 # IntersectAll with the output columns. See the comment above SetPrivate for more
 # details.
+# Note that IntersectAll is symmetric in most cases, but there are exceptions:
+# some types allow values that are equal but not identical (e.g. collated
+# strings) in which case it could be visible which side a row is coming from.
 [Relational, Set]
 define IntersectAll {
     Left RelExpr

--- a/pkg/sql/opt/xform/testdata/coster/set
+++ b/pkg/sql/opt/xform/testdata/coster/set
@@ -50,22 +50,21 @@ union-all
 opt
 SELECT k, i FROM a INTERSECT SELECT * FROM b
 ----
-intersect
+intersect-all
  ├── columns: k:1 i:2
  ├── left columns: k:1 i:2
  ├── right columns: x:7 z:8
- ├── stats: [rows=1000, distinct(1,2)=1000, null(1,2)=0]
+ ├── stats: [rows=1000]
  ├── cost: 2169.13
- ├── key: (1,2)
  ├── scan a
  │    ├── columns: k:1!null i:2
- │    ├── stats: [rows=1000, distinct(1,2)=1000, null(1,2)=0]
+ │    ├── stats: [rows=1000]
  │    ├── cost: 1074.61
  │    ├── key: (1)
  │    └── fd: (1)-->(2)
  └── scan b
       ├── columns: x:7 z:8!null
-      ├── stats: [rows=1000, distinct(7,8)=1000, null(7,8)=0]
+      ├── stats: [rows=1000]
       └── cost: 1064.51
 
 opt
@@ -91,22 +90,21 @@ intersect-all
 opt
 SELECT k, i FROM a EXCEPT SELECT * FROM b
 ----
-except
+except-all
  ├── columns: k:1 i:2
  ├── left columns: k:1 i:2
  ├── right columns: x:7 z:8
- ├── stats: [rows=1000, distinct(1,2)=1000, null(1,2)=0]
+ ├── stats: [rows=1000]
  ├── cost: 2169.13
- ├── key: (1,2)
  ├── scan a
  │    ├── columns: k:1!null i:2
- │    ├── stats: [rows=1000, distinct(1,2)=1000, null(1,2)=0]
+ │    ├── stats: [rows=1000]
  │    ├── cost: 1074.61
  │    ├── key: (1)
  │    └── fd: (1)-->(2)
  └── scan b
       ├── columns: x:7 z:8!null
-      ├── stats: [rows=1000, distinct(7,8)=1000, null(7,8)=0]
+      ├── stats: [rows=1000]
       └── cost: 1064.51
 
 opt

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -1584,37 +1584,33 @@ intersect-all
            └── y:7 = x:6 [outer=(6,7), fd=(6)==(7), (7)==(6)]
 
 opt
-SELECT * FROM (SELECT a, b, c FROM abc EXCEPT SELECT z, y, x FROM xyz) WHERE a = c ORDER BY a, b
+SELECT * FROM (SELECT b, c FROM abc EXCEPT SELECT y, x FROM xyz) WHERE b = c ORDER BY c, b
 ----
-except
- ├── columns: a:1!null b:2!null c:3!null
- ├── left columns: a:1!null b:2!null c:3!null
- ├── right columns: z:8 y:7 x:6
- ├── key: (2,3)
- ├── fd: (1)==(3), (3)==(1)
- ├── ordering: +(1|3),+2 [actual: +1,+2]
- ├── select
- │    ├── columns: a:1!null b:2!null c:3!null
- │    ├── key: (2,3)
- │    ├── fd: (1)==(3), (3)==(1)
- │    ├── ordering: +(1|3),+2 [actual: +1,+2]
- │    ├── scan abc
- │    │    ├── columns: a:1!null b:2!null c:3!null
- │    │    ├── key: (1-3)
- │    │    └── ordering: +1,+2
- │    └── filters
- │         └── a:1 = c:3 [outer=(1,3), fd=(1)==(3), (3)==(1)]
- └── select
-      ├── columns: x:6!null y:7!null z:8!null
-      ├── key: (7,8)
-      ├── fd: (6)==(8), (8)==(6)
-      ├── ordering: +(6|8),+7 [actual: +6,+7]
-      ├── scan xyz
-      │    ├── columns: x:6!null y:7!null z:8!null
-      │    ├── key: (6-8)
-      │    └── ordering: +6,+7
-      └── filters
-           └── z:8 = x:6 [outer=(6,8), fd=(6)==(8), (8)==(6)]
+sort
+ ├── columns: b:2!null c:3!null
+ ├── key: (3)
+ ├── fd: (2)==(3), (3)==(2)
+ ├── ordering: +(2|3) [actual: +2]
+ └── except
+      ├── columns: b:2!null c:3!null
+      ├── left columns: b:2!null c:3!null
+      ├── right columns: y:7 x:6
+      ├── key: (3)
+      ├── fd: (2)==(3), (3)==(2)
+      ├── select
+      │    ├── columns: b:2!null c:3!null
+      │    ├── fd: (2)==(3), (3)==(2)
+      │    ├── scan abc
+      │    │    └── columns: b:2!null c:3!null
+      │    └── filters
+      │         └── b:2 = c:3 [outer=(2,3), fd=(2)==(3), (3)==(2)]
+      └── select
+           ├── columns: x:6!null y:7!null
+           ├── fd: (6)==(7), (7)==(6)
+           ├── scan xyz
+           │    └── columns: x:6!null y:7!null
+           └── filters
+                └── y:7 = x:6 [outer=(6,7), fd=(6)==(7), (7)==(6)]
 
 opt
 SELECT * FROM (SELECT a, b, c, d FROM abcd EXCEPT ALL SELECT c, d, a, b FROM abcd) ORDER BY a, b
@@ -1665,12 +1661,11 @@ union-all
 opt
 VALUES (1) INTERSECT VALUES (1) ORDER BY 1
 ----
-intersect
+intersect-all
  ├── columns: column1:1!null
  ├── left columns: column1:1!null
  ├── right columns: column1:2
  ├── cardinality: [0 - 1]
- ├── key: (1)
  ├── ordering: +1
  ├── values
  │    ├── columns: column1:1!null


### PR DESCRIPTION
This patch adds rules to simplify and eliminate the `Except` and
`Intersect` set operators.

The `EliminateSetLeft` and `EliminateDistinctSetLeft` rules
(previously `EliminateUnionAllLeft` and `EliminateUnionLeft`) now apply
to `ExceptAll` and `Except` operators respectively. This means that
`Except` and `ExceptAll` will be eliminated when the right input has
no rows.

In addition, the `SimplifyExcept` and `SimplifyIntersect` rules will
replace `Except` and `Intersect` with the non de-duplicating variants
when the left input has a strict key. This allows the execution engine
to skip the relatively expensive de-duplication step.

Release note: None