### PR TITLE
build: force yarn to pick up protobuf changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -371,6 +371,8 @@ protobufjs-cli-fix-deps:
 .SECONDARY: pkg/ui/yarn.cluster-ui.installed
 pkg/ui/yarn.cluster-ui.installed: pkg/ui/cluster-ui/package.json pkg/ui/cluster-ui/yarn.lock pkg/ui/src/js/protos.js pkg/ui/src/js/protos.d.ts | bin/.submodules-initialized
 	$(NODE_RUN) -C pkg/ui/cluster-ui yarn install --offline
+	# This ensures that any update to the protobuf will be picked up by cluster-ui.
+	$(NODE_RUN) -C pkg/ui/cluster-ui yarn upgrade file:pkg/ui/src/js
 	$(NODE_RUN) -C pkg/ui/cluster-ui yarn build
 	touch $@
 


### PR DESCRIPTION
Previously, yarn does not properly upgrade crdb-protobuf-client
package after it's being changed. This cause the build to break
without force yarn to reinstall the package.
This commit introduces a fix to that issue to ensure the build
will succeed without manual yarn reinstalling.

Release note: None