### PR TITLE
kv: add new kv.lock_table.wait_queue.waiting metric

### DIFF
--- a/pkg/kv/kvserver/concurrency/BUILD.bazel
+++ b/pkg/kv/kvserver/concurrency/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "latch_manager.go",
         "lock_table.go",
         "lock_table_waiter.go",
+        "metrics.go",
         ":lockstate_interval_btree.go",  # keep
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency",

--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -73,6 +73,7 @@ type Config struct {
 	Stopper        *stop.Stopper
 	IntentResolver IntentResolver
 	// Metrics.
+	ConcurrencyMetrics                 *Metrics
 	TxnWaitMetrics                     *txnwait.Metrics
 	SlowLatchGauge                     *metric.Gauge
 	ConflictingIntentCleanupRejections *metric.Counter
@@ -114,6 +115,7 @@ func NewManager(cfg Config) Manager {
 			lt:                                  lt,
 			disableTxnPushing:                   cfg.DisableTxnPushing,
 			onContentionEvent:                   cfg.OnContentionEvent,
+			lockWaitQueueWaiters:                cfg.ConcurrencyMetrics.LockWaitQueueWaiters,
 			conflictingIntentsResolveRejections: cfg.ConflictingIntentCleanupRejections,
 		},
 		// TODO(nvanbenschoten): move pkg/storage/txnwait to a new

--- a/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
@@ -605,6 +605,7 @@ func (c *cluster) makeConfig() concurrency.Config {
 		OnContentionEvent: func(ev *roachpb.ContentionEvent) {
 			ev.Duration = 1234 * time.Millisecond // for determinism
 		},
+		ConcurrencyMetrics:                 concurrency.NewMetrics(),
 		TxnWaitMetrics:                     txnwait.NewMetrics(time.Minute),
 		ConflictingIntentCleanupRejections: metric.NewCounter(metric.Metadata{}),
 	}

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter.go
@@ -108,7 +108,8 @@ type lockTableWaiterImpl struct {
 	// Is allowed to mutate the event.
 	onContentionEvent func(ev *roachpb.ContentionEvent)
 
-	// Metric reporting intent resolution failures.
+	// Metrics.
+	lockWaitQueueWaiters                *metric.Gauge
 	conflictingIntentsResolveRejections *metric.Counter
 }
 
@@ -142,6 +143,9 @@ func (w *lockTableWaiterImpl) WaitOn(
 	var timer *timeutil.Timer
 	var timerC <-chan time.Time
 	var timerWaitingState waitingState
+
+	w.lockWaitQueueWaiters.Inc(1)
+	defer w.lockWaitQueueWaiters.Dec(1)
 
 	h := contentionEventHelper{
 		sp:      tracing.SpanFromContext(ctx),

--- a/pkg/kv/kvserver/concurrency/metrics.go
+++ b/pkg/kv/kvserver/concurrency/metrics.go
@@ -1,0 +1,32 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package concurrency
+
+import "github.com/cockroachdb/cockroach/pkg/util/metric"
+
+// Metrics contains concurrency related metrics.
+type Metrics struct {
+	LockWaitQueueWaiters *metric.Gauge
+}
+
+// NewMetrics creates a new Metrics instance with all related metric fields.
+func NewMetrics() *Metrics {
+	return &Metrics{
+		LockWaitQueueWaiters: metric.NewGauge(
+			metric.Metadata{
+				Name:        "kv.lock_table.wait_queue.waiting",
+				Help:        "Number of requests waiting in lock wait-queues in the lock table",
+				Measurement: "Waiting Requests",
+				Unit:        metric.Unit_COUNT,
+			},
+		),
+	}
+}

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -80,6 +80,7 @@ func newUnloadedReplica(
 			Clock:                              store.Clock(),
 			Stopper:                            store.Stopper(),
 			IntentResolver:                     store.intentResolver,
+			ConcurrencyMetrics:                 store.concurrencyMetrics,
 			TxnWaitMetrics:                     store.txnWaitMetrics,
 			SlowLatchGauge:                     store.metrics.SlowLatchRequests,
 			ConflictingIntentCleanupRejections: store.metrics.ConflictingIntentsResolveRejected,

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts/container"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts/ctpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts/sidetransport"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/idalloc"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/intentresolver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
@@ -411,6 +412,7 @@ type Store struct {
 	recoveryMgr        txnrecovery.Manager
 	raftEntryCache     *raftentry.Cache
 	limiters           batcheval.Limiters
+	concurrencyMetrics *concurrency.Metrics
 	txnWaitMetrics     *txnwait.Metrics
 	sstSnapshotStorage SSTSnapshotStorage
 	protectedtsCache   protectedts.Cache
@@ -841,6 +843,8 @@ func NewStore(
 	s.tsCache = tscache.New(cfg.Clock)
 	s.metrics.registry.AddMetricStruct(s.tsCache.Metrics())
 
+	s.concurrencyMetrics = concurrency.NewMetrics()
+	s.metrics.registry.AddMetricStruct(s.concurrencyMetrics)
 	s.txnWaitMetrics = txnwait.NewMetrics(cfg.HistogramWindowInterval)
 	s.metrics.registry.AddMetricStruct(s.txnWaitMetrics)
 	s.snapshotApplySem = make(chan struct{}, cfg.concurrentSnapshotApplyLimit)

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -911,6 +911,17 @@ var charts = []sectionDescription{
 		},
 	},
 	{
+		Organization: [][]string{{KVTransactionLayer, "Transactions", "LockTable"}},
+		Charts: []chartDescription{
+			{
+				Title: "Waiting",
+				Metrics: []string{
+					"kv.lock_table.wait_queue.waiting",
+				},
+			},
+		},
+	},
+	{
 		Organization: [][]string{{KVTransactionLayer, "Transactions", "TxnWaitQueue"}},
 		Charts: []chartDescription{
 			{


### PR DESCRIPTION
This metric tracks the number of requests waiting in lock wait-queues in the
lock table. It would have been helpful to have during a recent customer
investigation, because not all requests that wait in lock wait-queues will
eventually push and end up in a txn wait-queue.