### PR TITLE
util: Fix interval division with float rounds differently from PostgreSQL

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/datetime
+++ b/pkg/sql/logictest/testdata/logic_test/datetime
@@ -1522,8 +1522,8 @@ ORDER BY
 ----
 01:00:00               00:30:00          02:00:00                00:30:00          02:00:00                04:14:01.320914                 00:14:10.32
 1 day                  12:00:00          2 days                  12:00:00          2 days                  4 days 05:36:31.701948          05:40:07.68
-1 mon                  15 days           2 mons                  15 days           2 mons                  4 mons 7 days 00:15:51.058425   7 days 02:03:50.4
-1 mon 2 days 04:00:00  16 days 02:00:00  2 mons 4 days 08:00:00  16 days 02:00:00  2 mons 4 days 08:00:00  4 mons 15 days 28:24:59.745978  7 days 14:20:47.04
+1 mon                  15 days           2 mons                  15 days           2 mons                  4 mons 7 days 00:15:51.0912     7 days 02:03:50.4
+1 mon 2 days 04:00:00  16 days 02:00:00  2 mons 4 days 08:00:00  16 days 02:00:00  2 mons 4 days 08:00:00  4 mons 15 days 28:24:59.778753  7 days 14:20:47.04
 
 subtest tz_utc_normalization
 

--- a/pkg/sql/logictest/testdata/logic_test/interval
+++ b/pkg/sql/logictest/testdata/logic_test/interval
@@ -367,3 +367,28 @@ subtest regression_62369
 
 query error "10000000000000000000000000000000000": value out of range
 SELECT INTERVAL '10000000000000000000000000000000000 year'
+
+query T
+SELECT i / 2 FROM ( VALUES
+  ('0 days 0.253000 seconds'::interval),
+  (INTERVAL '0.000001'::interval),
+  (INTERVAL '0.000002'::interval),
+  (INTERVAL '0.000003'::interval),
+  (INTERVAL '0.000004'::interval),
+  (INTERVAL '0.000005'::interval),
+  (INTERVAL '0.000006'::interval),
+  (INTERVAL '0.000007'::interval),
+  (INTERVAL '0.000008'::interval),
+  (INTERVAL '0.000009'::interval)
+) regression_66118(i)
+----
+00:00:00.1265
+00:00:00
+00:00:00.000001
+00:00:00.000002
+00:00:00.000002
+00:00:00.000002
+00:00:00.000003
+00:00:00.000004
+00:00:00.000004
+00:00:00.000004

--- a/pkg/util/duration/duration_test.go
+++ b/pkg/util/duration/duration_test.go
@@ -498,6 +498,18 @@ func TestFloatMath(t *testing.T) {
 			Duration{Months: 2, Days: 34, nanos: nanosInHour * 4},
 			Duration{Days: 23, nanos: nanosInHour * 13},
 		},
+		{
+			Duration{Months: 0, Days: 0, nanos: nanosInSecond * 0.253000},
+			3.2,
+			Duration{Months: 0, Days: 0, nanos: nanosInSecond * 0.8096},
+			Duration{Months: 0, Days: 0, nanos: nanosInSecond * 0.079062},
+		},
+		{
+			Duration{Months: 0, Days: 0, nanos: nanosInSecond * 0.000001},
+			2.0,
+			Duration{Months: 0, Days: 0, nanos: nanosInSecond * 0.000002},
+			Duration{Months: 0, Days: 0, nanos: nanosInSecond * 0},
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
Before this commit, the nanos will be rounded in `MakeDuration`.
This commit round down nanos before `rounded` is called in the div of duration.

Fixes #66118

Release note (bug fix): Fixed a bug with PostgreSQL compatibility where
dividing an interval by a number would round to the nearest Microsecond
instead of always rounding down.
