### PR TITLE
roachtest: use an interface instead of direct access to *cluster

### DIFF
--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "clock_util.go",
         "cluster.go",
         "cluster_init.go",
+        "cluster_interface.go",
         "connection_latency.go",
         "copy.go",
         "decommission.go",

--- a/pkg/cmd/roachtest/acceptance.go
+++ b/pkg/cmd/roachtest/acceptance.go
@@ -18,7 +18,7 @@ import (
 func registerAcceptance(r *testRegistry) {
 	testCases := map[Owner][]struct {
 		name       string
-		fn         func(ctx context.Context, t *test, c *cluster)
+		fn         func(ctx context.Context, t *test, c clusterI)
 		skip       string
 		minVersion string
 		numNodes   int
@@ -43,7 +43,7 @@ func registerAcceptance(r *testRegistry) {
 			},
 			{
 				name: "version-upgrade",
-				fn: func(ctx context.Context, t *test, c *cluster) {
+				fn: func(ctx context.Context, t *test, c clusterI) {
 					runVersionUpgrade(ctx, t, c, r.buildVersion)
 				},
 				// This test doesn't like running on old versions because it upgrades to

--- a/pkg/cmd/roachtest/acceptance.go
+++ b/pkg/cmd/roachtest/acceptance.go
@@ -97,7 +97,7 @@ func registerAcceptance(r *testRegistry) {
 			if tc.timeout != 0 {
 				spec.Timeout = tc.timeout
 			}
-			spec.Run = func(ctx context.Context, t *test, c *cluster) {
+			spec.Run = func(ctx context.Context, t *test, c clusterI) {
 				tc.fn(ctx, t, c)
 			}
 			r.Add(spec)

--- a/pkg/cmd/roachtest/activerecord.go
+++ b/pkg/cmd/roachtest/activerecord.go
@@ -241,8 +241,6 @@ func registerActiveRecord(r *testRegistry) {
 		Owner:      OwnerSQLExperience,
 		Cluster:    makeClusterSpec(1),
 		Tags:       []string{`default`, `orm`},
-		Run: func(ctx context.Context, t *test, c *cluster) {
-			runActiveRecord(ctx, t, c)
-		},
+		Run:        runActiveRecord,
 	})
 }

--- a/pkg/cmd/roachtest/allocator.go
+++ b/pkg/cmd/roachtest/allocator.go
@@ -22,7 +22,7 @@ import (
 )
 
 func registerAllocator(r *testRegistry) {
-	runAllocator := func(ctx context.Context, t *test, c *cluster, start int, maxStdDev float64) {
+	runAllocator := func(ctx context.Context, t *test, c clusterI, start int, maxStdDev float64) {
 		c.Put(ctx, cockroach, "./cockroach")
 
 		// Start the first `start` nodes and restore a tpch fixture.
@@ -44,10 +44,10 @@ func registerAllocator(r *testRegistry) {
 		m.Wait()
 
 		// Start the remaining nodes to kick off upreplication/rebalancing.
-		c.Start(ctx, t, c.Range(start+1, c.spec.NodeCount), args)
+		c.Start(ctx, t, c.Range(start+1, c.Spec().NodeCount), args)
 
 		c.Run(ctx, c.Node(1), `./cockroach workload init kv --drop`)
-		for node := 1; node <= c.spec.NodeCount; node++ {
+		for node := 1; node <= c.Spec().NodeCount; node++ {
 			node := node
 			// TODO(dan): Ideally, the test would fail if this queryload failed,
 			// but we can't put it in monitor as-is because the test deadlocks.

--- a/pkg/cmd/roachtest/allocator.go
+++ b/pkg/cmd/roachtest/allocator.go
@@ -74,7 +74,7 @@ func registerAllocator(r *testRegistry) {
 		Name:    `replicate/up/1to3`,
 		Owner:   OwnerKV,
 		Cluster: makeClusterSpec(3),
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			runAllocator(ctx, t, c, 1, 10.0)
 		},
 	})
@@ -82,7 +82,7 @@ func registerAllocator(r *testRegistry) {
 		Name:    `replicate/rebalance/3to5`,
 		Owner:   OwnerKV,
 		Cluster: makeClusterSpec(5),
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			runAllocator(ctx, t, c, 3, 42.0)
 		},
 	})
@@ -250,8 +250,8 @@ func waitForRebalance(ctx context.Context, l *logger, db *gosql.DB, maxStdDev fl
 	}
 }
 
-func runWideReplication(ctx context.Context, t *test, c *cluster) {
-	nodes := c.spec.NodeCount
+func runWideReplication(ctx context.Context, t *test, c clusterI) {
+	nodes := c.Spec().NodeCount
 	if nodes != 9 {
 		t.Fatalf("9-node cluster required")
 	}

--- a/pkg/cmd/roachtest/alterpk.go
+++ b/pkg/cmd/roachtest/alterpk.go
@@ -21,8 +21,8 @@ import (
 func registerAlterPK(r *testRegistry) {
 
 	setupTest := func(ctx context.Context, t *test, c *cluster) (nodeListOption, nodeListOption) {
-		roachNodes := c.Range(1, c.spec.NodeCount-1)
-		loadNode := c.Node(c.spec.NodeCount)
+		roachNodes := c.Range(1, c.Spec().NodeCount-1)
+		loadNode := c.Node(c.Spec().NodeCount)
 		t.Status("copying binaries")
 		c.Put(ctx, cockroach, "./cockroach", roachNodes)
 		c.Put(ctx, workload, "./workload", loadNode)

--- a/pkg/cmd/roachtest/alterpk.go
+++ b/pkg/cmd/roachtest/alterpk.go
@@ -20,7 +20,7 @@ import (
 
 func registerAlterPK(r *testRegistry) {
 
-	setupTest := func(ctx context.Context, t *test, c *cluster) (nodeListOption, nodeListOption) {
+	setupTest := func(ctx context.Context, t *test, c clusterI) (nodeListOption, nodeListOption) {
 		roachNodes := c.Range(1, c.Spec().NodeCount-1)
 		loadNode := c.Node(c.Spec().NodeCount)
 		t.Status("copying binaries")
@@ -33,7 +33,7 @@ func registerAlterPK(r *testRegistry) {
 	}
 
 	// runAlterPKBank runs a primary key change while the bank workload runs.
-	runAlterPKBank := func(ctx context.Context, t *test, c *cluster) {
+	runAlterPKBank := func(ctx context.Context, t *test, c clusterI) {
 		const numRows = 1000000
 		const duration = 1 * time.Minute
 
@@ -88,7 +88,7 @@ func registerAlterPK(r *testRegistry) {
 	}
 
 	// runAlterPKTPCC runs a primary key change while the TPCC workload runs.
-	runAlterPKTPCC := func(ctx context.Context, t *test, c *cluster, warehouses int, expensiveChecks bool) {
+	runAlterPKTPCC := func(ctx context.Context, t *test, c clusterI, warehouses int, expensiveChecks bool) {
 		const duration = 10 * time.Minute
 
 		roachNodes, loadNode := setupTest(ctx, t, c)
@@ -180,7 +180,7 @@ func registerAlterPK(r *testRegistry) {
 		// workload driver node.
 		MinVersion: "v20.1.0",
 		Cluster:    makeClusterSpec(4, cpu(32)),
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			runAlterPKTPCC(ctx, t, c, 250 /* warehouses */, true /* expensiveChecks */)
 		},
 	})
@@ -191,7 +191,7 @@ func registerAlterPK(r *testRegistry) {
 		// workload driver node.
 		MinVersion: "v20.1.0",
 		Cluster:    makeClusterSpec(4, cpu(16)),
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			runAlterPKTPCC(ctx, t, c, 500 /* warehouses */, false /* expensiveChecks */)
 		},
 	})

--- a/pkg/cmd/roachtest/autoupgrade.go
+++ b/pkg/cmd/roachtest/autoupgrade.go
@@ -29,10 +29,10 @@ import (
 // You want to look at versionupgrade.go, which has a test harness you
 // can use.
 func registerAutoUpgrade(r *testRegistry) {
-	runAutoUpgrade := func(ctx context.Context, t *test, c *cluster, oldVersion string) {
+	runAutoUpgrade := func(ctx context.Context, t *test, c clusterI, oldVersion string) {
 		nodes := c.Spec().NodeCount
 
-		if err := c.Stage(ctx, c.l, "release", "v"+oldVersion, "", c.Range(1, nodes)); err != nil {
+		if err := c.Stage(ctx, t.l, "release", "v"+oldVersion, "", c.Range(1, nodes)); err != nil {
 			t.Fatal(err)
 		}
 
@@ -246,7 +246,7 @@ func registerAutoUpgrade(r *testRegistry) {
 		Owner:      OwnerKV,
 		MinVersion: "v19.1.0",
 		Cluster:    makeClusterSpec(5),
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			pred, err := PredecessorVersion(r.buildVersion)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/cmd/roachtest/autoupgrade.go
+++ b/pkg/cmd/roachtest/autoupgrade.go
@@ -30,7 +30,7 @@ import (
 // can use.
 func registerAutoUpgrade(r *testRegistry) {
 	runAutoUpgrade := func(ctx context.Context, t *test, c *cluster, oldVersion string) {
-		nodes := c.spec.NodeCount
+		nodes := c.Spec().NodeCount
 
 		if err := c.Stage(ctx, c.l, "release", "v"+oldVersion, "", c.Range(1, nodes)); err != nil {
 			t.Fatal(err)

--- a/pkg/cmd/roachtest/backup.go
+++ b/pkg/cmd/roachtest/backup.go
@@ -48,10 +48,10 @@ const (
 	rows3GiB   = rows30GiB / 10
 )
 
-func importBankDataSplit(ctx context.Context, rows, ranges int, t *test, c *cluster) string {
-	dest := c.name
+func importBankDataSplit(ctx context.Context, rows, ranges int, t *test, c clusterI) string {
+	dest := c.Name()
 	// Randomize starting with encryption-at-rest enabled.
-	c.encryptAtRandom = true
+	c.EncryptAtRandom(true)
 
 	if local {
 		dest += fmt.Sprintf("%d", timeutil.Now().UnixNano())
@@ -76,7 +76,7 @@ func importBankDataSplit(ctx context.Context, rows, ranges int, t *test, c *clus
 	return dest
 }
 
-func importBankData(ctx context.Context, rows int, t *test, c *cluster) string {
+func importBankData(ctx context.Context, rows int, t *test, c clusterI) string {
 	return importBankDataSplit(ctx, rows, 0 /* ranges */, t, c)
 }
 
@@ -84,7 +84,7 @@ func registerBackupNodeShutdown(r *testRegistry) {
 	// backupNodeRestartSpec runs a backup and randomly shuts down a node during
 	// the backup.
 	backupNodeRestartSpec := makeClusterSpec(4)
-	loadBackupData := func(ctx context.Context, t *test, c *cluster) string {
+	loadBackupData := func(ctx context.Context, t *test, c clusterI) string {
 		// This aught to be enough since this isn't a performance test.
 		rows := rows15GiB
 		if local {
@@ -100,12 +100,12 @@ func registerBackupNodeShutdown(r *testRegistry) {
 		Owner:      OwnerBulkIO,
 		Cluster:    backupNodeRestartSpec,
 		MinVersion: "v21.1.0",
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			gatewayNode := 2
 			nodeToShutdown := 3
 			dest := loadBackupData(ctx, t, c)
 			backupQuery := `BACKUP bank.bank TO 'nodelocal://1/` + dest + `' WITH DETACHED`
-			startBackup := func(c *cluster) (jobID string, err error) {
+			startBackup := func(c clusterI) (jobID string, err error) {
 				gatewayDB := c.Conn(ctx, gatewayNode)
 				defer gatewayDB.Close()
 
@@ -121,12 +121,12 @@ func registerBackupNodeShutdown(r *testRegistry) {
 		Owner:      OwnerBulkIO,
 		Cluster:    backupNodeRestartSpec,
 		MinVersion: "v21.1.0",
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			gatewayNode := 2
 			nodeToShutdown := 2
 			dest := loadBackupData(ctx, t, c)
 			backupQuery := `BACKUP bank.bank TO 'nodelocal://1/` + dest + `' WITH DETACHED`
-			startBackup := func(c *cluster) (jobID string, err error) {
+			startBackup := func(c clusterI) (jobID string, err error) {
 				gatewayDB := c.Conn(ctx, gatewayNode)
 				defer gatewayDB.Close()
 
@@ -180,7 +180,7 @@ func registerBackup(r *testRegistry) {
 		Owner:      OwnerBulkIO,
 		Cluster:    backup2TBSpec,
 		MinVersion: "v2.1.0",
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			rows := rows2TiB
 			if local {
 				rows = 100
@@ -201,7 +201,7 @@ func registerBackup(r *testRegistry) {
 
 				// Upload the perf artifacts to any one of the nodes so that the test
 				// runner copies it into an appropriate directory path.
-				if err := c.PutE(ctx, c.l, perfArtifactsDir, perfArtifactsDir, c.Node(1)); err != nil {
+				if err := c.PutE(ctx, t.l, perfArtifactsDir, perfArtifactsDir, c.Node(1)); err != nil {
 					log.Errorf(ctx, "failed to upload perf artifacts to node: %s", err.Error())
 				}
 				return nil
@@ -216,7 +216,7 @@ func registerBackup(r *testRegistry) {
 		Owner:      OwnerBulkIO,
 		Cluster:    KMSSpec,
 		MinVersion: "v20.2.0",
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			if cloud == gce {
 				t.Skip("backupKMS roachtest is only configured to run on AWS", "")
 			}
@@ -335,9 +335,9 @@ func registerBackup(r *testRegistry) {
 		Owner:   OwnerBulkIO,
 		Cluster: makeClusterSpec(3),
 		Timeout: 1 * time.Hour,
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			// Randomize starting with encryption-at-rest enabled.
-			c.encryptAtRandom = true
+			c.EncryptAtRandom(true)
 			c.Put(ctx, cockroach, "./cockroach")
 			c.Put(ctx, workload, "./workload")
 			c.Start(ctx, t)
@@ -349,10 +349,10 @@ func registerBackup(r *testRegistry) {
 			}
 			warehouses := 10
 
-			backupDir := "gs://cockroachdb-backup-testing/" + c.name + "?AUTH=implicit"
+			backupDir := "gs://cockroachdb-backup-testing/" + c.Name() + "?AUTH=implicit"
 			// Use inter-node file sharing on 20.1+.
 			if r.buildVersion.AtLeast(version.MustParse(`v20.1.0-0`)) {
-				backupDir = "nodelocal://1/" + c.name
+				backupDir = "nodelocal://1/" + c.Name()
 			}
 			fullDir := backupDir + "/full"
 			incDir := backupDir + "/inc"
@@ -360,7 +360,7 @@ func registerBackup(r *testRegistry) {
 			t.Status(`workload initialization`)
 			cmd := []string{fmt.Sprintf(
 				"./workload init tpcc --warehouses=%d {pgurl:1-%d}",
-				warehouses, c.spec.NodeCount,
+				warehouses, c.Spec().NodeCount,
 			)}
 			if !t.buildVersion.AtLeast(version.MustParse("v20.2.0")) {
 				cmd = append(cmd, "--deprecated-fk-indexes")
@@ -385,7 +385,7 @@ func registerBackup(r *testRegistry) {
 			go func() {
 				cmd := fmt.Sprintf(
 					"./workload run tpcc --warehouses=%d {pgurl:1-%d}",
-					warehouses, c.spec.NodeCount,
+					warehouses, c.Spec().NodeCount,
 				)
 
 				cmdDone <- c.RunE(ctx, c.Node(1), cmd)

--- a/pkg/cmd/roachtest/build_info.go
+++ b/pkg/cmd/roachtest/build_info.go
@@ -19,7 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 )
 
-func runBuildInfo(ctx context.Context, t *test, c *cluster) {
+func runBuildInfo(ctx context.Context, t *test, c clusterI) {
 	c.Put(ctx, cockroach, "./cockroach")
 	c.Start(ctx, t)
 
@@ -50,7 +50,7 @@ func runBuildInfo(ctx context.Context, t *test, c *cluster) {
 
 // runBuildAnalyze performs static analysis on the built binary to
 // ensure it's built as expected.
-func runBuildAnalyze(ctx context.Context, t *test, c *cluster) {
+func runBuildAnalyze(ctx context.Context, t *test, c clusterI) {
 
 	if c.isLocal() {
 		// This test is linux-specific and needs to be able to install apt

--- a/pkg/cmd/roachtest/canary.go
+++ b/pkg/cmd/roachtest/canary.go
@@ -163,7 +163,7 @@ func repeatRunE(
 // repeatRunWithBuffer is the same function as c.RunWithBuffer but with an
 // automatic retry loop.
 func repeatRunWithBuffer(
-	ctx context.Context, c *cluster, l *logger, node nodeListOption, operation string, args ...string,
+	ctx context.Context, c clusterI, t *test, node nodeListOption, operation string, args ...string,
 ) ([]byte, error) {
 	var (
 		lastResult []byte
@@ -173,14 +173,14 @@ func repeatRunWithBuffer(
 		if ctx.Err() != nil {
 			return nil, ctx.Err()
 		}
-		if c.t.Failed() {
+		if t.Failed() {
 			return nil, fmt.Errorf("test has failed")
 		}
 		attempt++
-		c.l.Printf("attempt %d - %s", attempt, operation)
-		lastResult, lastError = c.RunWithBuffer(ctx, l, node, args...)
+		t.l.Printf("attempt %d - %s", attempt, operation)
+		lastResult, lastError = c.RunWithBuffer(ctx, t.l, node, args...)
 		if lastError != nil {
-			c.l.Printf("error - retrying: %s\n%s", lastError, string(lastResult))
+			t.l.Printf("error - retrying: %s\n%s", lastError, string(lastResult))
 			continue
 		}
 		return lastResult, nil

--- a/pkg/cmd/roachtest/canary.go
+++ b/pkg/cmd/roachtest/canary.go
@@ -84,7 +84,7 @@ func (b blocklistsForVersion) getLists(version string) (string, blocklist, strin
 }
 
 func fetchCockroachVersion(
-	ctx context.Context, c *cluster, nodeIndex int, dbConnectionParams *SecureDBConnectionParams,
+	ctx context.Context, c clusterI, nodeIndex int, dbConnectionParams *SecureDBConnectionParams,
 ) (string, error) {
 	var db *gosql.DB
 	var err error
@@ -138,21 +138,21 @@ var canaryRetryOptions = retry.Options{
 
 // repeatRunE is the same function as c.RunE but with an automatic retry loop.
 func repeatRunE(
-	ctx context.Context, c *cluster, node nodeListOption, operation string, args ...string,
+	ctx context.Context, t *test, c clusterI, node nodeListOption, operation string, args ...string,
 ) error {
 	var lastError error
 	for attempt, r := 0, retry.StartWithCtx(ctx, canaryRetryOptions); r.Next(); {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
-		if c.t.Failed() {
+		if t.Failed() {
 			return fmt.Errorf("test has failed")
 		}
 		attempt++
-		c.l.Printf("attempt %d - %s", attempt, operation)
+		t.l.Printf("attempt %d - %s", attempt, operation)
 		lastError = c.RunE(ctx, node, args...)
 		if lastError != nil {
-			c.l.Printf("error - retrying: %s", lastError)
+			t.l.Printf("error - retrying: %s", lastError)
 			continue
 		}
 		return nil
@@ -191,21 +191,21 @@ func repeatRunWithBuffer(
 // repeatGitCloneE is the same function as c.GitCloneE but with an automatic
 // retry loop.
 func repeatGitCloneE(
-	ctx context.Context, l *logger, c *cluster, src, dest, branch string, node nodeListOption,
+	ctx context.Context, t *test, c clusterI, src, dest, branch string, node nodeListOption,
 ) error {
 	var lastError error
 	for attempt, r := 0, retry.StartWithCtx(ctx, canaryRetryOptions); r.Next(); {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
-		if c.t.Failed() {
+		if t.Failed() {
 			return fmt.Errorf("test has failed")
 		}
 		attempt++
-		l.Printf("attempt %d - clone %s", attempt, src)
-		lastError = c.GitClone(ctx, l, src, dest, branch, node)
+		t.l.Printf("attempt %d - clone %s", attempt, src)
+		lastError = c.GitClone(ctx, t.l, src, dest, branch, node)
 		if lastError != nil {
-			c.l.Printf("error - retrying: %s", lastError)
+			t.l.Printf("error - retrying: %s", lastError)
 			continue
 		}
 		return nil
@@ -220,7 +220,7 @@ func repeatGitCloneE(
 // may contain "minor", "point" and "subpoint" in order of decreasing importance
 // for sorting purposes.
 func repeatGetLatestTag(
-	ctx context.Context, c *cluster, user string, repo string, releaseRegex *regexp.Regexp,
+	ctx context.Context, t *test, user string, repo string, releaseRegex *regexp.Regexp,
 ) (string, error) {
 	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/tags", user, repo)
 	httpClient := &http.Client{Timeout: 10 * time.Second}
@@ -251,16 +251,16 @@ func repeatGetLatestTag(
 		if ctx.Err() != nil {
 			return "", ctx.Err()
 		}
-		if c.t.Failed() {
+		if t.Failed() {
 			return "", fmt.Errorf("test has failed")
 		}
 		attempt++
 
-		c.l.Printf("attempt %d - fetching %s", attempt, url)
+		t.l.Printf("attempt %d - fetching %s", attempt, url)
 		var resp *http.Response
 		resp, lastError = httpClient.Get(url)
 		if lastError != nil {
-			c.l.Printf("error fetching - retrying: %s", lastError)
+			t.l.Printf("error fetching - retrying: %s", lastError)
 			continue
 		}
 		defer resp.Body.Close()
@@ -268,7 +268,7 @@ func repeatGetLatestTag(
 		var tags Tags
 		lastError = json.NewDecoder(resp.Body).Decode(&tags)
 		if lastError != nil {
-			c.l.Printf("error decoding - retrying: %s", lastError)
+			t.l.Printf("error decoding - retrying: %s", lastError)
 			continue
 		}
 		if len(tags) == 0 {

--- a/pkg/cmd/roachtest/cancel.go
+++ b/pkg/cmd/roachtest/cancel.go
@@ -37,7 +37,7 @@ import (
 // Once DistSQL queries provide more testing knobs, these tests can likely be
 // replaced with unit tests.
 func registerCancel(r *testRegistry) {
-	runCancel := func(ctx context.Context, t *test, c *cluster, tpchQueriesToRun []int, useDistsql bool) {
+	runCancel := func(ctx context.Context, t *test, c clusterI, tpchQueriesToRun []int, useDistsql bool) {
 		c.Put(ctx, cockroach, "./cockroach", c.All())
 		c.Start(ctx, t, c.All())
 
@@ -131,7 +131,7 @@ func registerCancel(r *testRegistry) {
 		Name:    fmt.Sprintf("cancel/tpch/distsql/queries=%s,nodes=%d", queries, numNodes),
 		Owner:   OwnerSQLQueries,
 		Cluster: makeClusterSpec(numNodes),
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			runCancel(ctx, t, c, tpchQueriesToRun, true /* useDistsql */)
 		},
 	})
@@ -140,7 +140,7 @@ func registerCancel(r *testRegistry) {
 		Name:    fmt.Sprintf("cancel/tpch/local/queries=%s,nodes=%d", queries, numNodes),
 		Owner:   OwnerSQLQueries,
 		Cluster: makeClusterSpec(numNodes),
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			runCancel(ctx, t, c, tpchQueriesToRun, false /* useDistsql */)
 		},
 	})

--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -63,9 +63,9 @@ type cdcTestArgs struct {
 }
 
 func cdcBasicTest(ctx context.Context, t *test, c *cluster, args cdcTestArgs) {
-	crdbNodes := c.Range(1, c.spec.NodeCount-1)
-	workloadNode := c.Node(c.spec.NodeCount)
-	kafkaNode := c.Node(c.spec.NodeCount)
+	crdbNodes := c.Range(1, c.Spec().NodeCount-1)
+	workloadNode := c.Node(c.Spec().NodeCount)
+	kafkaNode := c.Node(c.Spec().NodeCount)
 	c.Put(ctx, cockroach, "./cockroach")
 	c.Put(ctx, workload, "./workload", workloadNode)
 	c.Start(ctx, t, crdbNodes)
@@ -237,7 +237,7 @@ func runCDCBank(ctx context.Context, t *test, c *cluster) {
 	// spam.
 	c.Run(ctx, c.All(), `mkdir -p logs`)
 
-	crdbNodes, workloadNode, kafkaNode := c.Range(1, c.spec.NodeCount-1), c.Node(c.spec.NodeCount), c.Node(c.spec.NodeCount)
+	crdbNodes, workloadNode, kafkaNode := c.Range(1, c.Spec().NodeCount-1), c.Node(c.Spec().NodeCount), c.Node(c.Spec().NodeCount)
 	c.Put(ctx, cockroach, "./cockroach", crdbNodes)
 	c.Put(ctx, workload, "./workload", workloadNode)
 	c.Start(ctx, t, crdbNodes)
@@ -514,12 +514,12 @@ func runCDCSchemaRegistry(ctx context.Context, t *test, c *cluster) {
 }
 
 func runCDCKafkaAuth(ctx context.Context, t *test, c *cluster) {
-	lastCrdbNode := c.spec.NodeCount - 1
+	lastCrdbNode := c.Spec().NodeCount - 1
 	if lastCrdbNode == 0 {
 		lastCrdbNode = 1
 	}
 
-	crdbNodes, kafkaNode := c.Range(1, lastCrdbNode), c.Node(c.spec.NodeCount)
+	crdbNodes, kafkaNode := c.Range(1, lastCrdbNode), c.Node(c.Spec().NodeCount)
 	c.Put(ctx, cockroach, "./cockroach", crdbNodes)
 	c.Start(ctx, t, crdbNodes)
 

--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -62,7 +62,7 @@ type cdcTestArgs struct {
 	targetTxnPerSecond       float64
 }
 
-func cdcBasicTest(ctx context.Context, t *test, c *cluster, args cdcTestArgs) {
+func cdcBasicTest(ctx context.Context, t *test, c clusterI, args cdcTestArgs) {
 	crdbNodes := c.Range(1, c.Spec().NodeCount-1)
 	workloadNode := c.Node(c.Spec().NodeCount)
 	kafkaNode := c.Node(c.Spec().NodeCount)
@@ -76,6 +76,7 @@ func cdcBasicTest(ctx context.Context, t *test, c *cluster, args cdcTestArgs) {
 		t.Fatal(err)
 	}
 	kafka := kafkaManager{
+		t:     t,
 		c:     c,
 		nodes: kafkaNode,
 	}
@@ -231,7 +232,7 @@ func cdcBasicTest(ctx context.Context, t *test, c *cluster, args cdcTestArgs) {
 	}
 }
 
-func runCDCBank(ctx context.Context, t *test, c *cluster) {
+func runCDCBank(ctx context.Context, t *test, c clusterI) {
 
 	// Make the logs dir on every node to work around the `roachprod get logs`
 	// spam.
@@ -242,6 +243,7 @@ func runCDCBank(ctx context.Context, t *test, c *cluster) {
 	c.Put(ctx, workload, "./workload", workloadNode)
 	c.Start(ctx, t, crdbNodes)
 	kafka := kafkaManager{
+		t:     t,
 		c:     c,
 		nodes: kafkaNode,
 	}
@@ -387,12 +389,13 @@ func runCDCBank(ctx context.Context, t *test, c *cluster) {
 // This test verifies that the changefeed avro + confluent schema registry works
 // end-to-end (including the schema registry default of requiring backward
 // compatibility within a topic).
-func runCDCSchemaRegistry(ctx context.Context, t *test, c *cluster) {
+func runCDCSchemaRegistry(ctx context.Context, t *test, c clusterI) {
 
 	crdbNodes, kafkaNode := c.Node(1), c.Node(1)
 	c.Put(ctx, cockroach, "./cockroach", crdbNodes)
 	c.Start(ctx, t, crdbNodes)
 	kafka := kafkaManager{
+		t:     t,
 		c:     c,
 		nodes: kafkaNode,
 	}
@@ -513,7 +516,7 @@ func runCDCSchemaRegistry(ctx context.Context, t *test, c *cluster) {
 	}
 }
 
-func runCDCKafkaAuth(ctx context.Context, t *test, c *cluster) {
+func runCDCKafkaAuth(ctx context.Context, t *test, c clusterI) {
 	lastCrdbNode := c.Spec().NodeCount - 1
 	if lastCrdbNode == 0 {
 		lastCrdbNode = 1
@@ -524,6 +527,7 @@ func runCDCKafkaAuth(ctx context.Context, t *test, c *cluster) {
 	c.Start(ctx, t, crdbNodes)
 
 	kafka := kafkaManager{
+		t:     t,
 		c:     c,
 		nodes: kafkaNode,
 	}
@@ -603,7 +607,7 @@ func registerCDC(r *testRegistry) {
 		Owner:           OwnerCDC,
 		Cluster:         makeClusterSpec(4, cpu(16)),
 		RequiresLicense: true,
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType:             tpccWorkloadType,
 				tpccWarehouseCount:       1000,
@@ -619,7 +623,7 @@ func registerCDC(r *testRegistry) {
 		Cluster:         makeClusterSpec(4, cpu(16)),
 		Tags:            []string{"manual"},
 		RequiresLicense: true,
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType:             tpccWorkloadType,
 				tpccWarehouseCount:       1000,
@@ -635,7 +639,7 @@ func registerCDC(r *testRegistry) {
 		Owner:           OwnerCDC,
 		Cluster:         makeClusterSpec(4, cpu(16)),
 		RequiresLicense: true,
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType:             tpccWorkloadType,
 				tpccWarehouseCount:       100,
@@ -651,7 +655,7 @@ func registerCDC(r *testRegistry) {
 		Owner:           `cdc`,
 		Cluster:         makeClusterSpec(4, cpu(16)),
 		RequiresLicense: true,
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType:             tpccWorkloadType,
 				tpccWarehouseCount:       100,
@@ -667,7 +671,7 @@ func registerCDC(r *testRegistry) {
 		Owner:           `cdc`,
 		Cluster:         makeClusterSpec(4, cpu(16)),
 		RequiresLicense: true,
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType:             tpccWorkloadType,
 				tpccWarehouseCount:       100,
@@ -688,7 +692,7 @@ func registerCDC(r *testRegistry) {
 		// of this test. Look into it.
 		Cluster:         makeClusterSpec(4, cpu(16)),
 		RequiresLicense: true,
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType:             ledgerWorkloadType,
 				workloadDuration:         "30m",
@@ -704,7 +708,7 @@ func registerCDC(r *testRegistry) {
 		Owner:           `cdc`,
 		Cluster:         makeClusterSpec(4, cpu(16)),
 		RequiresLicense: true,
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType: tpccWorkloadType,
 				// Sending data to Google Cloud Storage is a bit slower than sending to
@@ -725,7 +729,7 @@ func registerCDC(r *testRegistry) {
 		Owner:           `cdc`,
 		Cluster:         makeClusterSpec(1),
 		RequiresLicense: true,
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			runCDCKafkaAuth(ctx, t, c)
 		},
 	})
@@ -734,7 +738,7 @@ func registerCDC(r *testRegistry) {
 		Owner:           `cdc`,
 		Cluster:         makeClusterSpec(4),
 		RequiresLicense: true,
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			runCDCBank(ctx, t, c)
 		},
 	})
@@ -743,7 +747,7 @@ func registerCDC(r *testRegistry) {
 		Owner:           `cdc`,
 		Cluster:         makeClusterSpec(1),
 		RequiresLicense: true,
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			runCDCSchemaRegistry(ctx, t, c)
 		},
 	})
@@ -1078,7 +1082,8 @@ confluent.support.customer.id=anonymous
 )
 
 type kafkaManager struct {
-	c     *cluster
+	t     *test
+	c     clusterI
 	nodes nodeListOption
 }
 
@@ -1110,7 +1115,7 @@ func (k kafkaManager) serverJAASConfig() string {
 }
 
 func (k kafkaManager) install(ctx context.Context) {
-	k.c.status("installing kafka")
+	k.t.Status("installing kafka")
 	folder := k.basePath()
 
 	k.c.Run(ctx, k.nodes, `mkdir -p `+folder)
@@ -1118,7 +1123,7 @@ func (k kafkaManager) install(ctx context.Context) {
 	downloadScriptPath := filepath.Join(folder, "install.sh")
 	err := k.c.PutString(ctx, confluentDownloadScript, downloadScriptPath, 0700, k.nodes)
 	if err != nil {
-		k.c.t.Fatal(err)
+		k.t.Fatal(err)
 	}
 	k.c.Run(ctx, k.nodes, downloadScriptPath, folder)
 	if !k.c.isLocal() {
@@ -1129,16 +1134,16 @@ func (k kafkaManager) install(ctx context.Context) {
 }
 
 func (k kafkaManager) configureAuth(ctx context.Context) *testCerts {
-	k.c.status("generating TLS certificates")
+	k.t.Status("generating TLS certificates")
 	ips, err := k.c.InternalIP(ctx, k.nodes)
 	if err != nil {
-		k.c.t.Fatal(err)
+		k.t.Fatal(err)
 	}
 	kafkaIP := ips[0]
 
 	testCerts, err := makeTestCerts(kafkaIP)
 	if err != nil {
-		k.c.t.Fatal(err)
+		k.t.Fatal(err)
 	}
 
 	configDir := k.configDir()
@@ -1161,7 +1166,7 @@ func (k kafkaManager) configureAuth(ctx context.Context) *testCerts {
 	kafkaConfigPath := filepath.Join(configDir, "server.properties")
 	kafkaJAASPath := filepath.Join(configDir, "server_jaas.conf")
 
-	k.c.status("writing kafka configuration files")
+	k.t.Status("writing kafka configuration files")
 	kafkaConfig := fmt.Sprintf(kafkaConfigTmpl,
 		truststorePath,
 		keystorePassword,
@@ -1176,7 +1181,7 @@ func (k kafkaManager) configureAuth(ctx context.Context) *testCerts {
 	k.PutConfigContent(ctx, kafkaConfig, kafkaConfigPath)
 	k.PutConfigContent(ctx, kafkaJAASConfig, kafkaJAASPath)
 
-	k.c.status("constructing java keystores")
+	k.t.Status("constructing java keystores")
 	// Convert PEM cert and key into pkcs12 bundle so that it can be imported into a java keystore.
 	k.c.Run(ctx, k.nodes,
 		fmt.Sprintf("openssl pkcs12 -export -in %s -inkey %s -name kafka -out %s -password pass:%s",
@@ -1211,12 +1216,12 @@ func (k kafkaManager) configureAuth(ctx context.Context) *testCerts {
 func (k kafkaManager) PutConfigContent(ctx context.Context, data string, path string) {
 	err := k.c.PutString(ctx, data, path, 0600, k.nodes)
 	if err != nil {
-		k.c.t.Fatal(err)
+		k.t.Fatal(err)
 	}
 }
 
 func (k kafkaManager) addSCRAMUsers(ctx context.Context) {
-	k.c.status("adding entries for SASL/SCRAM users")
+	k.t.Status("adding entries for SASL/SCRAM users")
 	k.c.Run(ctx, k.nodes, filepath.Join(k.binDir(), "kafka-configs"),
 		"--zookeeper", "localhost:2181",
 		"--alter",
@@ -1301,7 +1306,7 @@ func (k kafkaManager) chaosLoop(
 func (k kafkaManager) sinkURL(ctx context.Context) string {
 	ips, err := k.c.InternalIP(ctx, k.nodes)
 	if err != nil {
-		k.c.t.Fatal(err)
+		k.t.Fatal(err)
 	}
 	return `kafka://` + ips[0] + `:9092`
 }
@@ -1309,7 +1314,7 @@ func (k kafkaManager) sinkURL(ctx context.Context) string {
 func (k kafkaManager) sinkURLTLS(ctx context.Context) string {
 	ips, err := k.c.InternalIP(ctx, k.nodes)
 	if err != nil {
-		k.c.t.Fatal(err)
+		k.t.Fatal(err)
 	}
 	return `kafka://` + ips[0] + `:9093`
 }
@@ -1317,7 +1322,7 @@ func (k kafkaManager) sinkURLTLS(ctx context.Context) string {
 func (k kafkaManager) sinkURLSASL(ctx context.Context) string {
 	ips, err := k.c.InternalIP(ctx, k.nodes)
 	if err != nil {
-		k.c.t.Fatal(err)
+		k.t.Fatal(err)
 	}
 	return `kafka://` + ips[0] + `:9094`
 }
@@ -1325,7 +1330,7 @@ func (k kafkaManager) sinkURLSASL(ctx context.Context) string {
 func (k kafkaManager) consumerURL(ctx context.Context) string {
 	ips, err := k.c.ExternalIP(ctx, k.nodes)
 	if err != nil {
-		k.c.t.Fatal(err)
+		k.t.Fatal(err)
 	}
 	return ips[0] + `:9092`
 }
@@ -1333,7 +1338,7 @@ func (k kafkaManager) consumerURL(ctx context.Context) string {
 func (k kafkaManager) schemaRegistryURL(ctx context.Context) string {
 	ips, err := k.c.InternalIP(ctx, k.nodes)
 	if err != nil {
-		k.c.t.Fatal(err)
+		k.t.Fatal(err)
 	}
 	return `http://` + ips[0] + `:8081`
 }
@@ -1380,7 +1385,7 @@ type tpccWorkload struct {
 	tolerateErrors     bool
 }
 
-func (tw *tpccWorkload) install(ctx context.Context, c *cluster) {
+func (tw *tpccWorkload) install(ctx context.Context, c clusterI) {
 	// For fixtures import, use the version built into the cockroach binary so
 	// the tpcc workload-versions match on release branches.
 	c.Run(ctx, tw.workloadNodes, fmt.Sprintf(
@@ -1390,7 +1395,7 @@ func (tw *tpccWorkload) install(ctx context.Context, c *cluster) {
 	))
 }
 
-func (tw *tpccWorkload) run(ctx context.Context, c *cluster, workloadDuration string) {
+func (tw *tpccWorkload) run(ctx context.Context, c clusterI, workloadDuration string) {
 	tolerateErrors := ""
 	if tw.tolerateErrors {
 		tolerateErrors = "--tolerate-errors"
@@ -1406,14 +1411,14 @@ type ledgerWorkload struct {
 	sqlNodes      nodeListOption
 }
 
-func (lw *ledgerWorkload) install(ctx context.Context, c *cluster) {
+func (lw *ledgerWorkload) install(ctx context.Context, c clusterI) {
 	c.Run(ctx, lw.workloadNodes.randNode(), fmt.Sprintf(
 		`./workload init ledger {pgurl%s}`,
 		lw.sqlNodes.randNode(),
 	))
 }
 
-func (lw *ledgerWorkload) run(ctx context.Context, c *cluster, workloadDuration string) {
+func (lw *ledgerWorkload) run(ctx context.Context, c clusterI, workloadDuration string) {
 	c.Run(ctx, lw.workloadNodes, fmt.Sprintf(
 		`./workload run ledger --mix=balance=0,withdrawal=50,deposit=50,reversal=0 {pgurl%s} --duration=%s`,
 		lw.sqlNodes,

--- a/pkg/cmd/roachtest/chaos.go
+++ b/pkg/cmd/roachtest/chaos.go
@@ -52,9 +52,9 @@ type Chaos struct {
 // Runner returns a closure that runs chaos against the given cluster without
 // setting off the monitor. The process returns without an error after the chaos
 // duration.
-func (ch *Chaos) Runner(c *cluster, m *monitor) func(context.Context) error {
+func (ch *Chaos) Runner(c clusterI, m *monitor) func(context.Context) error {
 	return func(ctx context.Context) (err error) {
-		l, err := c.l.ChildLogger("CHAOS")
+		l, err := m.l.ChildLogger("CHAOS")
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/roachtest/clearrange.go
+++ b/pkg/cmd/roachtest/clearrange.go
@@ -30,16 +30,16 @@ func registerClearRange(r *testRegistry) {
 			Timeout:    5*time.Hour + 90*time.Minute,
 			MinVersion: "v19.1.0",
 			Cluster:    makeClusterSpec(10, cpu(16)),
-			Run: func(ctx context.Context, t *test, c *cluster) {
+			Run: func(ctx context.Context, t *test, c clusterI) {
 				runClearRange(ctx, t, c, checks)
 			},
 		})
 	}
 }
 
-func runClearRange(ctx context.Context, t *test, c *cluster, aggressiveChecks bool) {
+func runClearRange(ctx context.Context, t *test, c clusterI, aggressiveChecks bool) {
 	// Randomize starting with encryption-at-rest enabled.
-	c.encryptAtRandom = true
+	c.EncryptAtRandom(true)
 	c.Put(ctx, cockroach, "./cockroach")
 
 	t.Status("restoring fixture")
@@ -49,7 +49,7 @@ func runClearRange(ctx context.Context, t *test, c *cluster, aggressiveChecks bo
 	tBegin := timeutil.Now()
 	c.Run(ctx, c.Node(1), "./cockroach", "workload", "fixtures", "import", "bank",
 		"--payload-bytes=10240", "--ranges=10", "--rows=65104166", "--seed=4", "--db=bigbank")
-	c.l.Printf("import took %.2fs", timeutil.Since(tBegin).Seconds())
+	t.l.Printf("import took %.2fs", timeutil.Since(tBegin).Seconds())
 	c.Stop(ctx)
 	t.Status()
 

--- a/pkg/cmd/roachtest/cli.go
+++ b/pkg/cmd/roachtest/cli.go
@@ -19,7 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cli"
 )
 
-func runCLINodeStatus(ctx context.Context, t *test, c *cluster) {
+func runCLINodeStatus(ctx context.Context, t *test, c clusterI) {
 	c.Put(ctx, cockroach, "./cockroach")
 	c.Start(ctx, t, c.Range(1, 3))
 

--- a/pkg/cmd/roachtest/clock_jump_crash.go
+++ b/pkg/cmd/roachtest/clock_jump_crash.go
@@ -21,8 +21,8 @@ import (
 func runClockJump(ctx context.Context, t *test, c *cluster, tc clockJumpTestCase) {
 	// Test with a single node so that the node does not crash due to MaxOffset
 	// violation when injecting offset
-	if c.spec.NodeCount != 1 {
-		t.Fatalf("Expected num nodes to be 1, got: %d", c.spec.NodeCount)
+	if c.Spec().NodeCount != 1 {
+		t.Fatalf("Expected num nodes to be 1, got: %d", c.Spec().NodeCount)
 	}
 
 	t.Status("deploying offset injector")
@@ -37,7 +37,7 @@ func runClockJump(ctx context.Context, t *test, c *cluster, tc clockJumpTestCase
 	c.Wipe(ctx)
 	c.Start(ctx, t)
 
-	db := c.Conn(ctx, c.spec.NodeCount)
+	db := c.Conn(ctx, c.Spec().NodeCount)
 	defer db.Close()
 	if _, err := db.Exec(
 		fmt.Sprintf(
@@ -59,7 +59,7 @@ func runClockJump(ctx context.Context, t *test, c *cluster, tc clockJumpTestCase
 	// clock offset is reset or the node will crash again.
 	var aliveAfterOffset bool
 	defer func() {
-		offsetInjector.recover(ctx, c.spec.NodeCount)
+		offsetInjector.recover(ctx, c.Spec().NodeCount)
 		// Resetting the clock is a jump in the opposite direction which
 		// can cause a crash even if the original jump didn't. Wait a few
 		// seconds before checking whether the node is alive and
@@ -69,8 +69,8 @@ func runClockJump(ctx context.Context, t *test, c *cluster, tc clockJumpTestCase
 			c.Start(ctx, t, c.Node(1))
 		}
 	}()
-	defer offsetInjector.recover(ctx, c.spec.NodeCount)
-	offsetInjector.offset(ctx, c.spec.NodeCount, tc.offset)
+	defer offsetInjector.recover(ctx, c.Spec().NodeCount)
+	offsetInjector.offset(ctx, c.Spec().NodeCount, tc.offset)
 
 	// Wait a few seconds to let it crash if it's going to crash.
 	time.Sleep(3 * time.Second)

--- a/pkg/cmd/roachtest/clock_monotonic.go
+++ b/pkg/cmd/roachtest/clock_monotonic.go
@@ -18,7 +18,7 @@ import (
 	_ "github.com/lib/pq"
 )
 
-func runClockMonotonicity(ctx context.Context, t *test, c *cluster, tc clockMonotonicityTestCase) {
+func runClockMonotonicity(ctx context.Context, t *test, c clusterI, tc clockMonotonicityTestCase) {
 	// Test with a single node so that the node does not crash due to MaxOffset
 	// violation when introducing offset
 	if c.Spec().NodeCount != 1 {
@@ -26,7 +26,7 @@ func runClockMonotonicity(ctx context.Context, t *test, c *cluster, tc clockMono
 	}
 
 	t.Status("deploying offset injector")
-	offsetInjector := newOffsetInjector(c)
+	offsetInjector := newOffsetInjector(t, c)
 	if err := offsetInjector.deploy(ctx); err != nil {
 		t.Fatal(err)
 	}
@@ -48,7 +48,7 @@ func runClockMonotonicity(ctx context.Context, t *test, c *cluster, tc clockMono
 	// Wait for Cockroach to process the above cluster setting
 	time.Sleep(10 * time.Second)
 
-	if !isAlive(db, c.l) {
+	if !isAlive(db, t.l) {
 		t.Fatal("Node unexpectedly crashed")
 	}
 
@@ -59,7 +59,7 @@ func runClockMonotonicity(ctx context.Context, t *test, c *cluster, tc clockMono
 
 	// Recover from the injected clock offset after validation completes.
 	defer func() {
-		if !isAlive(db, c.l) {
+		if !isAlive(db, t.l) {
 			t.Fatal("Node unexpectedly crashed")
 		}
 		// Stop cockroach node before recovering from clock offset as this clock
@@ -70,7 +70,7 @@ func runClockMonotonicity(ctx context.Context, t *test, c *cluster, tc clockMono
 		offsetInjector.recover(ctx, c.Spec().NodeCount)
 
 		c.Start(ctx, t, c.Node(c.Spec().NodeCount))
-		if !isAlive(db, c.l) {
+		if !isAlive(db, t.l) {
 			t.Fatal("Node unexpectedly crashed")
 		}
 	}()
@@ -83,7 +83,7 @@ func runClockMonotonicity(ctx context.Context, t *test, c *cluster, tc clockMono
 	t.Status("starting cockroach post offset")
 	c.Start(ctx, t, c.Node(c.Spec().NodeCount))
 
-	if !isAlive(db, c.l) {
+	if !isAlive(db, t.l) {
 		t.Fatal("Node unexpectedly crashed")
 	}
 
@@ -134,7 +134,7 @@ func registerClockMonotonicTests(r *testRegistry) {
 			// These tests muck with NTP, therefor we don't want the cluster reused by
 			// others.
 			Cluster: makeClusterSpec(1, reuseTagged("offset-injector")),
-			Run: func(ctx context.Context, t *test, c *cluster) {
+			Run: func(ctx context.Context, t *test, c clusterI) {
 				runClockMonotonicity(ctx, t, c, tc)
 			},
 		}

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1160,6 +1160,17 @@ type cluster struct {
 	destroyState destroyState
 }
 
+// EncryptAtRandom sets whether the cluster will start new nodes with
+// encryption enabled.
+func (c *cluster) EncryptAtRandom(b bool) {
+	c.encryptAtRandom = true
+}
+
+// Spec returns the spec underlying the cluster.
+func (c *cluster) Spec() clusterSpec {
+	return c.spec
+}
+
 // status is used to communicate the test's status. It's a no-op until the
 // cluster is passed to a test, at which point it's hooked up to test.Status().
 func (c *cluster) status(args ...interface{}) {
@@ -2816,7 +2827,8 @@ type monitor struct {
 	expDeaths int32 // atomically
 }
 
-func newMonitor(ctx context.Context, c *cluster, opts ...option) *monitor {
+func newMonitor(ctx context.Context, ci clusterI, opts ...option) *monitor {
+	c := ci.(*cluster) // TODO(tbg): pass `t` to `newMonitor` and avoid need for `makeNodes`
 	m := &monitor{
 		t:     c.t,
 		l:     c.l,

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1166,6 +1166,12 @@ func (c *cluster) EncryptAtRandom(b bool) {
 	c.encryptAtRandom = true
 }
 
+// EncryptDefault sets the default for encryption-at-rest. This can be overridden
+// by options passed to `c.Start`.
+func (c *cluster) EncryptDefault(b bool) {
+	c.encryptDefault = b
+}
+
 // Spec returns the spec underlying the cluster.
 func (c *cluster) Spec() clusterSpec {
 	return c.spec
@@ -1187,7 +1193,7 @@ func (c *cluster) workerStatus(args ...interface{}) {
 }
 
 func (c *cluster) String() string {
-	return fmt.Sprintf("%s [tag:%s] (%d nodes)", c.name, c.tag, c.spec.NodeCount)
+	return fmt.Sprintf("%s [tag:%s] (%d nodes)", c.name, c.tag, c.Spec().NodeCount)
 }
 
 type destroyState struct {

--- a/pkg/cmd/roachtest/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster_interface.go
@@ -16,6 +16,7 @@ import (
 )
 
 type clusterI interface {
+	makeNodes(opts ...option) string // TODO(tbg): this should go away
 	isLocal() bool
 	EncryptAtRandom(on bool)
 	Spec() clusterSpec

--- a/pkg/cmd/roachtest/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster_interface.go
@@ -1,0 +1,74 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+package main
+
+import (
+	"context"
+	gosql "database/sql"
+	"os"
+)
+
+type clusterI interface {
+	isLocal() bool
+	EncryptAtRandom(on bool)
+	Spec() clusterSpec
+	StopCockroachGracefullyOnNode(ctx context.Context, node int) error
+	All() nodeListOption
+	Range(begin, end int) nodeListOption
+	Nodes(ns ...int) nodeListOption
+	Node(i int) nodeListOption
+	FetchDiskUsage(ctx context.Context) error
+	Put(ctx context.Context, src, dest string, opts ...option)
+	PutE(ctx context.Context, l *logger, src, dest string, opts ...option) error
+	PutLibraries(ctx context.Context, libraryDir string) error
+	Stage(
+		ctx context.Context, l *logger, application, versionOrSHA, dir string, opts ...option,
+	) error
+	Get(ctx context.Context, l *logger, src, dest string, opts ...option) error
+	PutString(
+		ctx context.Context, content, dest string, mode os.FileMode, opts ...option,
+	) error
+	GitClone(
+		ctx context.Context, l *logger, src, dest, branch string, node nodeListOption,
+	) error
+	StartE(ctx context.Context, opts ...option) error
+	Start(ctx context.Context, t *test, opts ...option)
+	StopE(ctx context.Context, opts ...option) error
+	Stop(ctx context.Context, opts ...option)
+	Reset(ctx context.Context) error
+	WipeE(ctx context.Context, l *logger, opts ...option) error
+	Wipe(ctx context.Context, opts ...option)
+	Run(ctx context.Context, node nodeListOption, args ...string)
+	Reformat(ctx context.Context, node nodeListOption, args ...string)
+	Install(
+		ctx context.Context, l *logger, node nodeListOption, args ...string,
+	) error
+	RunE(ctx context.Context, node nodeListOption, args ...string) error
+	RunL(ctx context.Context, l *logger, node nodeListOption, args ...string) error
+	RunWithBuffer(
+		ctx context.Context, l *logger, node nodeListOption, args ...string,
+	) ([]byte, error)
+	InternalPGUrl(ctx context.Context, node nodeListOption) ([]string, error)
+	ExternalPGUrl(ctx context.Context, node nodeListOption) ([]string, error)
+	ExternalPGUrlSecure(
+		ctx context.Context, node nodeListOption, user string, certsDir string, port int,
+	) ([]string, error)
+	InternalAdminUIAddr(ctx context.Context, node nodeListOption) ([]string, error)
+	ExternalAdminUIAddr(ctx context.Context, node nodeListOption) ([]string, error)
+	InternalAddr(ctx context.Context, node nodeListOption) ([]string, error)
+	InternalIP(ctx context.Context, node nodeListOption) ([]string, error)
+	ExternalAddr(ctx context.Context, node nodeListOption) ([]string, error)
+	ExternalIP(ctx context.Context, node nodeListOption) ([]string, error)
+	Conn(ctx context.Context, node int) *gosql.DB
+	ConnE(ctx context.Context, node int) (*gosql.DB, error)
+	ConnSecure(
+		ctx context.Context, node int, user string, certsDir string, port int,
+	) (*gosql.DB, error)
+}

--- a/pkg/cmd/roachtest/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster_interface.go
@@ -19,6 +19,7 @@ type clusterI interface {
 	makeNodes(opts ...option) string // TODO(tbg): this should go away
 	isLocal() bool
 	EncryptAtRandom(on bool)
+	EncryptDefault(on bool)
 	Spec() clusterSpec
 	StopCockroachGracefullyOnNode(ctx context.Context, node int) error
 	All() nodeListOption

--- a/pkg/cmd/roachtest/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster_interface.go
@@ -15,62 +15,108 @@ import (
 	"os"
 )
 
+// clusterI is the interface through which a given roachtest interacts with the
+// provisioned cloud hardware for a given test.
+//
+// This interface is currently crufty and unprincipled as it was extracted from
+// code in which tests had direct access to the `cluster` type.
 type clusterI interface {
-	makeNodes(opts ...option) string // TODO(tbg): this should go away
-	isLocal() bool
-	EncryptAtRandom(on bool)
-	EncryptDefault(on bool)
-	Spec() clusterSpec
-	StopCockroachGracefullyOnNode(ctx context.Context, node int) error
+	// Selecting nodes.
+
 	All() nodeListOption
 	Range(begin, end int) nodeListOption
 	Nodes(ns ...int) nodeListOption
 	Node(i int) nodeListOption
-	FetchDiskUsage(ctx context.Context) error
+
+	// Uploading and downloading from/to nodes.
+
+	Get(ctx context.Context, l *logger, src, dest string, opts ...option) error
 	Put(ctx context.Context, src, dest string, opts ...option)
 	PutE(ctx context.Context, l *logger, src, dest string, opts ...option) error
 	PutLibraries(ctx context.Context, libraryDir string) error
 	Stage(
 		ctx context.Context, l *logger, application, versionOrSHA, dir string, opts ...option,
 	) error
-	Get(ctx context.Context, l *logger, src, dest string, opts ...option) error
 	PutString(
 		ctx context.Context, content, dest string, mode os.FileMode, opts ...option,
 	) error
-	GitClone(
-		ctx context.Context, l *logger, src, dest, branch string, node nodeListOption,
-	) error
+
+	// Starting and stopping CockroachDB.
+
 	StartE(ctx context.Context, opts ...option) error
 	Start(ctx context.Context, t *test, opts ...option)
 	StopE(ctx context.Context, opts ...option) error
 	Stop(ctx context.Context, opts ...option)
-	Reset(ctx context.Context) error
-	WipeE(ctx context.Context, l *logger, opts ...option) error
-	Wipe(ctx context.Context, opts ...option)
-	Run(ctx context.Context, node nodeListOption, args ...string)
-	Reformat(ctx context.Context, node nodeListOption, args ...string)
-	Install(
-		ctx context.Context, l *logger, node nodeListOption, args ...string,
-	) error
-	RunE(ctx context.Context, node nodeListOption, args ...string) error
-	RunL(ctx context.Context, l *logger, node nodeListOption, args ...string) error
-	RunWithBuffer(
-		ctx context.Context, l *logger, node nodeListOption, args ...string,
-	) ([]byte, error)
+	StopCockroachGracefullyOnNode(ctx context.Context, node int) error
+
+	// Hostnames and IP addresses of the nodes.
+
+	InternalAddr(ctx context.Context, node nodeListOption) ([]string, error)
+	InternalIP(ctx context.Context, node nodeListOption) ([]string, error)
+	ExternalAddr(ctx context.Context, node nodeListOption) ([]string, error)
+	ExternalIP(ctx context.Context, node nodeListOption) ([]string, error)
+
+	// SQL connection strings.
+
 	InternalPGUrl(ctx context.Context, node nodeListOption) ([]string, error)
 	ExternalPGUrl(ctx context.Context, node nodeListOption) ([]string, error)
 	ExternalPGUrlSecure(
 		ctx context.Context, node nodeListOption, user string, certsDir string, port int,
 	) ([]string, error)
-	InternalAdminUIAddr(ctx context.Context, node nodeListOption) ([]string, error)
-	ExternalAdminUIAddr(ctx context.Context, node nodeListOption) ([]string, error)
-	InternalAddr(ctx context.Context, node nodeListOption) ([]string, error)
-	InternalIP(ctx context.Context, node nodeListOption) ([]string, error)
-	ExternalAddr(ctx context.Context, node nodeListOption) ([]string, error)
-	ExternalIP(ctx context.Context, node nodeListOption) ([]string, error)
+
+	// SQL clients to nodes.
+
 	Conn(ctx context.Context, node int) *gosql.DB
 	ConnE(ctx context.Context, node int) (*gosql.DB, error)
 	ConnSecure(
 		ctx context.Context, node int, user string, certsDir string, port int,
 	) (*gosql.DB, error)
+
+	// URLs for the Admin UI.
+
+	InternalAdminUIAddr(ctx context.Context, node nodeListOption) ([]string, error)
+	ExternalAdminUIAddr(ctx context.Context, node nodeListOption) ([]string, error)
+
+	// Running commands on nodes.
+
+	Run(ctx context.Context, node nodeListOption, args ...string)
+	RunE(ctx context.Context, node nodeListOption, args ...string) error
+	RunL(ctx context.Context, l *logger, node nodeListOption, args ...string) error
+	RunWithBuffer(
+		ctx context.Context, l *logger, node nodeListOption, args ...string,
+	) ([]byte, error)
+
+	// Metadata about the provisioned nodes.
+
+	Spec() clusterSpec
+	Name() string
+	isLocal() bool
+
+	// Deleting CockroachDB data and logs on nodes.
+
+	WipeE(ctx context.Context, l *logger, opts ...option) error
+	Wipe(ctx context.Context, opts ...option)
+
+	// Toggling encryption-at-rest settings for starting CockroachDB.
+
+	EncryptAtRandom(on bool)
+	EncryptDefault(on bool)
+
+	// Internal niche tools.
+
+	Reset(ctx context.Context) error
+	Reformat(ctx context.Context, node nodeListOption, args ...string)
+	Install(
+		ctx context.Context, l *logger, node nodeListOption, args ...string,
+	) error
+
+	// Methods whose inclusion on this interface is purely historical.
+	// These should be removed over time.
+
+	makeNodes(opts ...option) string
+	CheckReplicaDivergenceOnDB(context.Context, *test, *gosql.DB) error
+	FetchDiskUsage(ctx context.Context, t *test) error
+	GitClone(
+		ctx context.Context, l *logger, src, dest, branch string, node nodeListOption,
+	) error
 }

--- a/pkg/cmd/roachtest/connection_latency.go
+++ b/pkg/cmd/roachtest/connection_latency.go
@@ -25,7 +25,7 @@ const (
 )
 
 func runConnectionLatencyTest(
-	ctx context.Context, t *test, c *cluster, numNodes int, numZones int,
+	ctx context.Context, t *test, c clusterI, numNodes int, numZones int,
 ) {
 	err := c.PutE(ctx, t.l, cockroach, "./cockroach")
 	require.NoError(t, err)
@@ -95,7 +95,7 @@ func registerConnectionLatencyTest(r *testRegistry) {
 		Name:       fmt.Sprintf("connection_latency/nodes=%d", numNodes),
 		Owner:      OwnerSQLExperience,
 		Cluster:    makeClusterSpec(numNodes + 1), // Add one for load node.
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			runConnectionLatencyTest(ctx, t, c, numNodes, 1)
 		},
 	})
@@ -110,7 +110,7 @@ func registerConnectionLatencyTest(r *testRegistry) {
 		Name:       fmt.Sprintf("connection_latency/nodes=%d/multiregion", numMultiRegionNodes),
 		Owner:      OwnerSQLExperience,
 		Cluster:    makeClusterSpec(numMultiRegionNodes+loadNodes, geo(), zones(geoZonesStr)),
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			runConnectionLatencyTest(ctx, t, c, numMultiRegionNodes, numZones)
 		},
 	})

--- a/pkg/cmd/roachtest/copy.go
+++ b/pkg/cmd/roachtest/copy.go
@@ -27,7 +27,7 @@ func registerCopy(r *testRegistry) {
 	// This test imports a fully-populated Bank table. It then creates an empty
 	// Bank schema. Finally, it performs a series of `INSERT ... SELECT ...`
 	// statements to copy all data from the first table into the second table.
-	runCopy := func(ctx context.Context, t *test, c *cluster, rows int, inTxn bool) {
+	runCopy := func(ctx context.Context, t *test, c clusterI, rows int, inTxn bool) {
 		// payload is the size of the payload column for each row in the Bank
 		// table. If this is adjusted, a new fixture may need to be generated.
 		const payload = 100
@@ -174,7 +174,7 @@ func registerCopy(r *testRegistry) {
 			Name:    fmt.Sprintf("copy/bank/rows=%d,nodes=%d,txn=%t", tc.rows, tc.nodes, tc.txn),
 			Owner:   OwnerKV,
 			Cluster: makeClusterSpec(tc.nodes),
-			Run: func(ctx context.Context, t *test, c *cluster) {
+			Run: func(ctx context.Context, t *test, c clusterI) {
 				runCopy(ctx, t, c, tc.rows, tc.txn)
 			},
 		})

--- a/pkg/cmd/roachtest/decommission.go
+++ b/pkg/cmd/roachtest/decommission.go
@@ -352,7 +352,7 @@ func runDecommissionRandomized(ctx context.Context, t *test, c *cluster) {
 			numCols, err := cli.GetCsvNumCols(o)
 			require.NoError(t, err)
 			exp := h.expectCell(targetNode-1, /* node IDs are 1-indexed */
-				statusHeaderMembershipColumnIdx, `decommissioning`, c.spec.NodeCount, numCols)
+				statusHeaderMembershipColumnIdx, `decommissioning`, c.Spec().NodeCount, numCols)
 			if err := cli.MatchCSV(o, exp); err != nil {
 				t.Fatal(err)
 			}
@@ -382,7 +382,7 @@ func runDecommissionRandomized(ctx context.Context, t *test, c *cluster) {
 			numCols, err := cli.GetCsvNumCols(o)
 			require.NoError(t, err)
 			exp := h.expectCell(targetNode-1, /* node IDs are 1-indexed */
-				statusHeaderMembershipColumnIdx, `active`, c.spec.NodeCount, numCols)
+				statusHeaderMembershipColumnIdx, `active`, c.Spec().NodeCount, numCols)
 			if err := cli.MatchCSV(o, exp); err != nil {
 				t.Fatal(err)
 			}
@@ -411,7 +411,7 @@ func runDecommissionRandomized(ctx context.Context, t *test, c *cluster) {
 				}
 
 				exp := [][]string{decommissionHeader}
-				for i := 1; i <= c.spec.NodeCount; i++ {
+				for i := 1; i <= c.Spec().NodeCount; i++ {
 					rowRegex := []string{strconv.Itoa(i), "true", `\d+`, "true", "decommissioning", "false"}
 					exp = append(exp, rowRegex)
 				}
@@ -437,10 +437,10 @@ func runDecommissionRandomized(ctx context.Context, t *test, c *cluster) {
 			numCols, err := cli.GetCsvNumCols(o)
 			require.NoError(t, err)
 			var colRegex []string
-			for i := 1; i <= c.spec.NodeCount; i++ {
+			for i := 1; i <= c.Spec().NodeCount; i++ {
 				colRegex = append(colRegex, `decommissioning`)
 			}
-			exp := h.expectColumn(statusHeaderMembershipColumnIdx, colRegex, c.spec.NodeCount, numCols)
+			exp := h.expectColumn(statusHeaderMembershipColumnIdx, colRegex, c.Spec().NodeCount, numCols)
 			if err := cli.MatchCSV(o, exp); err != nil {
 				t.Fatal(err)
 			}
@@ -482,10 +482,10 @@ func runDecommissionRandomized(ctx context.Context, t *test, c *cluster) {
 			numCols, err := cli.GetCsvNumCols(o)
 			require.NoError(t, err)
 			var colRegex []string
-			for i := 1; i <= c.spec.NodeCount; i++ {
+			for i := 1; i <= c.Spec().NodeCount; i++ {
 				colRegex = append(colRegex, `active`)
 			}
-			exp := h.expectColumn(statusHeaderMembershipColumnIdx, colRegex, c.spec.NodeCount, numCols)
+			exp := h.expectColumn(statusHeaderMembershipColumnIdx, colRegex, c.Spec().NodeCount, numCols)
 			if err := cli.MatchCSV(o, exp); err != nil {
 				t.Fatal(err)
 			}
@@ -553,7 +553,7 @@ func runDecommissionRandomized(ctx context.Context, t *test, c *cluster) {
 					t.Fatalf("node-ls failed: %v", err)
 				}
 				exp := [][]string{{"id"}}
-				for i := 1; i <= c.spec.NodeCount; i++ {
+				for i := 1; i <= c.Spec().NodeCount; i++ {
 					if _, ok := h.randNodeBlocklist[i]; ok {
 						// Decommissioned, so should go away in due time.
 						continue
@@ -580,7 +580,7 @@ func runDecommissionRandomized(ctx context.Context, t *test, c *cluster) {
 				require.NoError(t, err)
 
 				colRegex := []string{}
-				for i := 1; i <= c.spec.NodeCount; i++ {
+				for i := 1; i <= c.Spec().NodeCount; i++ {
 					if _, ok := h.randNodeBlocklist[i]; ok {
 						continue // decommissioned
 					}
@@ -731,7 +731,7 @@ func runDecommissionRandomized(ctx context.Context, t *test, c *cluster) {
 
 				var exp [][]string
 				// We expect an entry for every node we haven't decommissioned yet.
-				for i := 1; i <= c.spec.NodeCount-len(h.randNodeBlocklist); i++ {
+				for i := 1; i <= c.Spec().NodeCount-len(h.randNodeBlocklist); i++ {
 					exp = append(exp, []string{fmt.Sprintf("[^%d]", targetNode)})
 				}
 
@@ -751,7 +751,7 @@ func runDecommissionRandomized(ctx context.Context, t *test, c *cluster) {
 				numCols, err := cli.GetCsvNumCols(o)
 				require.NoError(t, err)
 				var expC []string
-				for i := 1; i <= c.spec.NodeCount-len(h.randNodeBlocklist); i++ {
+				for i := 1; i <= c.Spec().NodeCount-len(h.randNodeBlocklist); i++ {
 					expC = append(expC, fmt.Sprintf("[^%d].*", targetNode))
 				}
 				exp := h.expectIDsInStatusOut(expC, numCols)
@@ -795,7 +795,7 @@ func runDecommissionRandomized(ctx context.Context, t *test, c *cluster) {
 			re += `].*`
 			// We expect to all the decommissioned nodes to
 			// disappear, but we let one rejoin as a fresh node.
-			for i := 1; i <= c.spec.NodeCount-len(h.randNodeBlocklist)+1; i++ {
+			for i := 1; i <= c.Spec().NodeCount-len(h.randNodeBlocklist)+1; i++ {
 				expC = append(expC, re)
 			}
 			exp := h.expectIDsInStatusOut(expC, numCols)
@@ -906,7 +906,7 @@ type decommTestHelper struct {
 
 func newDecommTestHelper(t *test, c *cluster) *decommTestHelper {
 	var nodeIDs []int
-	for i := 1; i <= c.spec.NodeCount; i++ {
+	for i := 1; i <= c.Spec().NodeCount; i++ {
 		nodeIDs = append(nodeIDs, i)
 	}
 	return &decommTestHelper{

--- a/pkg/cmd/roachtest/decommission.go
+++ b/pkg/cmd/roachtest/decommission.go
@@ -38,7 +38,7 @@ func registerDecommission(r *testRegistry) {
 			Owner:      OwnerKV,
 			MinVersion: "v20.2.0",
 			Cluster:    makeClusterSpec(4),
-			Run: func(ctx context.Context, t *test, c *cluster) {
+			Run: func(ctx context.Context, t *test, c clusterI) {
 				if local {
 					duration = 5 * time.Minute
 					t.l.Printf("running with duration=%s in local mode\n", duration)
@@ -55,7 +55,7 @@ func registerDecommission(r *testRegistry) {
 			MinVersion: "v20.2.0",
 			Timeout:    10 * time.Minute,
 			Cluster:    makeClusterSpec(numNodes),
-			Run: func(ctx context.Context, t *test, c *cluster) {
+			Run: func(ctx context.Context, t *test, c clusterI) {
 				runDecommissionRandomized(ctx, t, c)
 			},
 		})
@@ -67,7 +67,7 @@ func registerDecommission(r *testRegistry) {
 			Owner:      OwnerKV,
 			MinVersion: "v20.2.0",
 			Cluster:    makeClusterSpec(numNodes),
-			Run: func(ctx context.Context, t *test, c *cluster) {
+			Run: func(ctx context.Context, t *test, c clusterI) {
 				runDecommissionMixedVersions(ctx, t, c, r.buildVersion)
 			},
 		})
@@ -83,7 +83,7 @@ func registerDecommission(r *testRegistry) {
 // that would spam the log before #23605. I wonder if we should really
 // start grepping the logs. An alternative is to introduce a metric
 // that would have signaled this and check that instead.
-func runDecommission(ctx context.Context, t *test, c *cluster, nodes int, duration time.Duration) {
+func runDecommission(ctx context.Context, t *test, c clusterI, nodes int, duration time.Duration) {
 	const defaultReplicationFactor = 3
 	if defaultReplicationFactor > nodes {
 		t.Fatal("improper configuration: replication factor greater than number of nodes in the test")
@@ -297,7 +297,7 @@ func runDecommission(ctx context.Context, t *test, c *cluster, nodes int, durati
 // through partial decommissioning of random nodes, ensuring we're able to undo
 // those operations. We then fully decommission nodes, verifying it's an
 // irreversible operation.
-func runDecommissionRandomized(ctx context.Context, t *test, c *cluster) {
+func runDecommissionRandomized(ctx context.Context, t *test, c clusterI) {
 	args := startArgs("--env=COCKROACH_SCAN_MAX_IDLE_TIME=5ms")
 	c.Put(ctx, cockroach, "./cockroach")
 	c.Start(ctx, t, args)
@@ -897,14 +897,14 @@ const statusHeaderMembershipColumnIdx = 11
 
 type decommTestHelper struct {
 	t       *test
-	c       *cluster
+	c       clusterI
 	nodeIDs []int
 	// randNodeBlocklist are the nodes that won't be returned from randNode().
 	// populated via blockFromRandNode().
 	randNodeBlocklist map[int]struct{}
 }
 
-func newDecommTestHelper(t *test, c *cluster) *decommTestHelper {
+func newDecommTestHelper(t *test, c clusterI) *decommTestHelper {
 	var nodeIDs []int
 	for i := 1; i <= c.Spec().NodeCount; i++ {
 		nodeIDs = append(nodeIDs, i)
@@ -1055,7 +1055,7 @@ func (h *decommTestHelper) getRandNodeOtherThan(ids ...int) int {
 }
 
 func execCLI(
-	ctx context.Context, t *test, c *cluster, runNode int, extraArgs ...string,
+	ctx context.Context, t *test, c clusterI, runNode int, extraArgs ...string,
 ) (string, error) {
 	args := []string{"./cockroach"}
 	args = append(args, extraArgs...)

--- a/pkg/cmd/roachtest/decommission_self.go
+++ b/pkg/cmd/roachtest/decommission_self.go
@@ -15,7 +15,7 @@ import "context"
 // runDecommissionSelf decommissions n2 through n2. This is an acceptance test.
 //
 // See https://github.com/cockroachdb/cockroach/issues/56718
-func runDecommissionSelf(ctx context.Context, t *test, c *cluster) {
+func runDecommissionSelf(ctx context.Context, t *test, c clusterI) {
 	// An empty string means that the cockroach binary specified by flag
 	// `cockroach` will be used.
 	const mainVersion = ""

--- a/pkg/cmd/roachtest/disk_full.go
+++ b/pkg/cmd/roachtest/disk_full.go
@@ -31,7 +31,7 @@ func registerDiskFull(r *testRegistry) {
 				return
 			}
 
-			nodes := c.spec.NodeCount - 1
+			nodes := c.Spec().NodeCount - 1
 			c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 			c.Put(ctx, workload, "./workload", c.Node(nodes+1))
 			c.Start(ctx, t, c.Range(1, nodes))

--- a/pkg/cmd/roachtest/disk_full.go
+++ b/pkg/cmd/roachtest/disk_full.go
@@ -25,7 +25,7 @@ func registerDiskFull(r *testRegistry) {
 		Owner:      OwnerStorage,
 		MinVersion: `v20.2.0`,
 		Cluster:    makeClusterSpec(5),
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			if c.isLocal() {
 				t.spec.Skip = "you probably don't want to fill your local disk"
 				return

--- a/pkg/cmd/roachtest/disk_stall.go
+++ b/pkg/cmd/roachtest/disk_stall.go
@@ -36,7 +36,7 @@ func registerDiskStalledDetection(r *testRegistry) {
 				Owner:      OwnerStorage,
 				MinVersion: "v19.2.0",
 				Cluster:    makeClusterSpec(1),
-				Run: func(ctx context.Context, t *test, c *cluster) {
+				Run: func(ctx context.Context, t *test, c clusterI) {
 					runDiskStalledDetection(ctx, t, c, affectsLogDir, affectsDataDir)
 				},
 			})
@@ -45,7 +45,7 @@ func registerDiskStalledDetection(r *testRegistry) {
 }
 
 func runDiskStalledDetection(
-	ctx context.Context, t *test, c *cluster, affectsLogDir bool, affectsDataDir bool,
+	ctx context.Context, t *test, c clusterI, affectsLogDir bool, affectsDataDir bool,
 ) {
 	if local && runtime.GOOS != "linux" {
 		t.Fatalf("must run on linux os, found %s", runtime.GOOS)

--- a/pkg/cmd/roachtest/django.go
+++ b/pkg/cmd/roachtest/django.go
@@ -51,7 +51,7 @@ func registerDjango(r *testRegistry) {
 		t.Status("cloning django and installing prerequisites")
 
 		if err := repeatRunE(
-			ctx, c, node, "update apt-get",
+			ctx, t, c, node, "update apt-get",
 			`
 				sudo add-apt-repository ppa:deadsnakes/ppa &&
 				sudo apt-get -qq update`,
@@ -61,6 +61,7 @@ func registerDjango(r *testRegistry) {
 
 		if err := repeatRunE(
 			ctx,
+			t,
 			c,
 			node,
 			"install dependencies",
@@ -70,7 +71,7 @@ func registerDjango(r *testRegistry) {
 		}
 
 		if err := repeatRunE(
-			ctx, c, node, "set python3.7 as default", `
+			ctx, t, c, node, "set python3.7 as default", `
     		sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.5 1
     		sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 2
     		sudo update-alternatives --config python3`,
@@ -79,7 +80,7 @@ func registerDjango(r *testRegistry) {
 		}
 
 		if err := repeatRunE(
-			ctx, c, node, "install pip",
+			ctx, t, c, node, "install pip",
 			`curl https://bootstrap.pypa.io/get-pip.py | sudo -H python3.7`,
 		); err != nil {
 			t.Fatal(err)
@@ -87,6 +88,7 @@ func registerDjango(r *testRegistry) {
 
 		if err := repeatRunE(
 			ctx,
+			t,
 			c,
 			node,
 			"install pytest",
@@ -96,13 +98,13 @@ func registerDjango(r *testRegistry) {
 		}
 
 		if err := repeatRunE(
-			ctx, c, node, "remove old django", `rm -rf /mnt/data1/django`,
+			ctx, t, c, node, "remove old django", `rm -rf /mnt/data1/django`,
 		); err != nil {
 			t.Fatal(err)
 		}
 
 		djangoLatestTag, err := repeatGetLatestTag(
-			ctx, c, "django", "django", djangoReleaseTagRegex,
+			ctx, t, "django", "django", djangoReleaseTagRegex,
 		)
 		if err != nil {
 			t.Fatal(err)
@@ -112,7 +114,7 @@ func registerDjango(r *testRegistry) {
 
 		if err := repeatGitCloneE(
 			ctx,
-			t.l,
+			t,
 			c,
 			"https://github.com/timgraham/django/",
 			"/mnt/data1/django",
@@ -123,7 +125,7 @@ func registerDjango(r *testRegistry) {
 		}
 
 		djangoCockroachDBLatestTag, err := repeatGetLatestTag(
-			ctx, c, "cockroachdb", "django-cockroachdb", djangoCockroachDBReleaseTagRegex,
+			ctx, t, "cockroachdb", "django-cockroachdb", djangoCockroachDBReleaseTagRegex,
 		)
 		if err != nil {
 			t.Fatal(err)
@@ -133,7 +135,7 @@ func registerDjango(r *testRegistry) {
 
 		if err := repeatGitCloneE(
 			ctx,
-			t.l,
+			t,
 			c,
 			"https://github.com/cockroachdb/django-cockroachdb",
 			"/mnt/data1/django/tests/django-cockroachdb",
@@ -144,7 +146,7 @@ func registerDjango(r *testRegistry) {
 		}
 
 		if err := repeatRunE(
-			ctx, c, node, "install django's dependencies", `
+			ctx, t, c, node, "install django's dependencies", `
 				cd /mnt/data1/django/tests &&
 				sudo pip3 install -e .. &&
 				sudo pip3 install -r requirements/py3.txt &&
@@ -154,7 +156,7 @@ func registerDjango(r *testRegistry) {
 		}
 
 		if err := repeatRunE(
-			ctx, c, node, "install django-cockroachdb", `
+			ctx, t, c, node, "install django-cockroachdb", `
 					cd /mnt/data1/django/tests/django-cockroachdb/ &&
 					sudo pip3 install .`,
 		); err != nil {
@@ -163,7 +165,7 @@ func registerDjango(r *testRegistry) {
 
 		// Write the cockroach config into the test suite to use.
 		if err := repeatRunE(
-			ctx, c, node, "configuring tests to use cockroach",
+			ctx, t, c, node, "configuring tests to use cockroach",
 			fmt.Sprintf(
 				"echo \"%s\" > /mnt/data1/django/tests/cockroach_settings.py",
 				cockroachDjangoSettings,

--- a/pkg/cmd/roachtest/django.go
+++ b/pkg/cmd/roachtest/django.go
@@ -26,7 +26,7 @@ func registerDjango(r *testRegistry) {
 	runDjango := func(
 		ctx context.Context,
 		t *test,
-		c *cluster,
+		c clusterI,
 	) {
 		if c.isLocal() {
 			t.Fatal("cannot be run in local mode")
@@ -109,8 +109,8 @@ func registerDjango(r *testRegistry) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		c.l.Printf("Latest Django release is %s.", djangoLatestTag)
-		c.l.Printf("Supported Django release is %s.", djangoSupportedTag)
+		t.l.Printf("Latest Django release is %s.", djangoLatestTag)
+		t.l.Printf("Supported Django release is %s.", djangoSupportedTag)
 
 		if err := repeatGitCloneE(
 			ctx,
@@ -130,8 +130,8 @@ func registerDjango(r *testRegistry) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		c.l.Printf("Latest django-cockroachdb release is %s.", djangoCockroachDBLatestTag)
-		c.l.Printf("Supported django-cockroachdb release is %s.", djangoCockroachDBSupportedTag)
+		t.l.Printf("Latest django-cockroachdb release is %s.", djangoCockroachDBLatestTag)
+		t.l.Printf("Supported django-cockroachdb release is %s.", djangoCockroachDBSupportedTag)
 
 		if err := repeatGitCloneE(
 			ctx,
@@ -181,7 +181,7 @@ func registerDjango(r *testRegistry) {
 		if ignoredlist == nil {
 			t.Fatalf("No django ignorelist defined for cockroach version %s", version)
 		}
-		c.l.Printf("Running cockroach version %s, using blocklist %s, using ignoredlist %s",
+		t.l.Printf("Running cockroach version %s, using blocklist %s, using ignoredlist %s",
 			version, blocklistName, ignoredlistName)
 
 		// TODO (rohany): move this to a file backed buffer if the output becomes
@@ -193,8 +193,8 @@ func registerDjango(r *testRegistry) {
 			rawResults, _ := c.RunWithBuffer(
 				ctx, t.l, node, fmt.Sprintf(djangoRunTestCmd, testName))
 			fullTestResults = append(fullTestResults, rawResults...)
-			c.l.Printf("Test results for app %s: %s", testName, rawResults)
-			c.l.Printf("Test stdout for app %s:", testName)
+			t.l.Printf("Test results for app %s: %s", testName, rawResults)
+			t.l.Printf("Test stdout for app %s:", testName)
 			if err := c.RunL(
 				ctx, t.l, node, fmt.Sprintf("cd /mnt/data1/django/tests && cat %s.stdout", testName),
 			); err != nil {
@@ -216,7 +216,7 @@ func registerDjango(r *testRegistry) {
 		Owner:      OwnerSQLExperience,
 		Cluster:    makeClusterSpec(1, cpu(16)),
 		Tags:       []string{`default`, `orm`},
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			runDjango(ctx, t, c)
 		},
 	})

--- a/pkg/cmd/roachtest/drop.go
+++ b/pkg/cmd/roachtest/drop.go
@@ -29,7 +29,7 @@ func registerDrop(r *testRegistry) {
 	// by a truncation for the `stock` table (which contains warehouses*100k
 	// rows). Next, it issues a `DROP` for the whole database, and sets the GC TTL
 	// to one second.
-	runDrop := func(ctx context.Context, t *test, c *cluster, warehouses, nodes int) {
+	runDrop := func(ctx context.Context, t *test, c clusterI, warehouses, nodes int) {
 		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 		c.Put(ctx, workload, "./workload", c.Range(1, nodes))
 		c.Start(ctx, t, c.Range(1, nodes), startArgs("-e", "COCKROACH_MEMPROF_INTERVAL=15s"))
@@ -94,7 +94,7 @@ func registerDrop(r *testRegistry) {
 				run(false, "DELETE FROM tpcc.stock WHERE s_w_id = $1", i)
 				elapsed := timeutil.Since(tBegin)
 				// TODO(tschottdorf): check what's reasonable here and make sure we don't drop below it.
-				c.l.Printf("deleted from tpcc.stock for warehouse %d (100k rows) in %s (%.2f rows/sec)\n", i, elapsed, 100000.0/elapsed.Seconds())
+				t.l.Printf("deleted from tpcc.stock for warehouse %d (100k rows) in %s (%.2f rows/sec)\n", i, elapsed, 100000.0/elapsed.Seconds())
 			}
 
 			const stmtTruncate = "TRUNCATE TABLE tpcc.stock"
@@ -159,7 +159,7 @@ func registerDrop(r *testRegistry) {
 		Owner:      OwnerKV,
 		MinVersion: `v2.1.0`,
 		Cluster:    makeClusterSpec(numNodes),
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			// NB: this is likely not going to work out in `-local` mode. Edit the
 			// numbers during iteration.
 			if local {

--- a/pkg/cmd/roachtest/encryption.go
+++ b/pkg/cmd/roachtest/encryption.go
@@ -21,8 +21,8 @@ func registerEncryption(r *testRegistry) {
 	// Note that no workload is run in this roachtest because kv roachtest
 	// ideally runs with encryption turned on to see the performance impact and
 	// to test the correctness of encryption at rest.
-	runEncryption := func(ctx context.Context, t *test, c *cluster) {
-		nodes := c.spec.NodeCount
+	runEncryption := func(ctx context.Context, t *test, c clusterI) {
+		nodes := c.Spec().NodeCount
 		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 		c.Start(ctx, t, c.Range(1, nodes), startArgs("--encrypt"))
 
@@ -83,7 +83,7 @@ func registerEncryption(r *testRegistry) {
 			Owner:      OwnerStorage,
 			MinVersion: "v2.1.0",
 			Cluster:    makeClusterSpec(n),
-			Run: func(ctx context.Context, t *test, c *cluster) {
+			Run: func(ctx context.Context, t *test, c clusterI) {
 				runEncryption(ctx, t, c)
 			},
 		})

--- a/pkg/cmd/roachtest/engine_switch.go
+++ b/pkg/cmd/roachtest/engine_switch.go
@@ -24,8 +24,8 @@ import (
 
 func registerEngineSwitch(r *testRegistry) {
 	runEngineSwitch := func(ctx context.Context, t *test, c *cluster, additionalArgs ...string) {
-		roachNodes := c.Range(1, c.spec.NodeCount-1)
-		loadNode := c.Node(c.spec.NodeCount)
+		roachNodes := c.Range(1, c.Spec().NodeCount-1)
+		loadNode := c.Node(c.Spec().NodeCount)
 		c.Put(ctx, workload, "./workload", loadNode)
 		c.Put(ctx, cockroach, "./cockroach", roachNodes)
 		pebbleArgs := startArgs(append(additionalArgs, "--args=--storage-engine=pebble")...)

--- a/pkg/cmd/roachtest/engine_switch.go
+++ b/pkg/cmd/roachtest/engine_switch.go
@@ -23,7 +23,7 @@ import (
 )
 
 func registerEngineSwitch(r *testRegistry) {
-	runEngineSwitch := func(ctx context.Context, t *test, c *cluster, additionalArgs ...string) {
+	runEngineSwitch := func(ctx context.Context, t *test, c clusterI, additionalArgs ...string) {
 		roachNodes := c.Range(1, c.Spec().NodeCount-1)
 		loadNode := c.Node(c.Spec().NodeCount)
 		c.Put(ctx, workload, "./workload", loadNode)
@@ -88,7 +88,7 @@ func registerEngineSwitch(r *testRegistry) {
 					if err := rows.Close(); err != nil {
 						return err
 					}
-					if err := c.CheckReplicaDivergenceOnDB(ctx, db); err != nil {
+					if err := c.CheckReplicaDivergenceOnDB(ctx, t, db); err != nil {
 						return errors.Wrapf(err, "node %d", i)
 					}
 				}
@@ -143,7 +143,7 @@ func registerEngineSwitch(r *testRegistry) {
 		Skip:       "rocksdb removed in 21.1",
 		MinVersion: "v20.1.0",
 		Cluster:    makeClusterSpec(n + 1),
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			runEngineSwitch(ctx, t, c)
 		},
 	})
@@ -153,7 +153,7 @@ func registerEngineSwitch(r *testRegistry) {
 		Skip:       "rocksdb removed in 21.1",
 		MinVersion: "v20.1.0",
 		Cluster:    makeClusterSpec(n + 1),
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			runEngineSwitch(ctx, t, c, "--encrypt=true")
 		},
 	})

--- a/pkg/cmd/roachtest/event_log.go
+++ b/pkg/cmd/roachtest/event_log.go
@@ -21,7 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 )
 
-func runEventLog(ctx context.Context, t *test, c *cluster) {
+func runEventLog(ctx context.Context, t *test, c clusterI) {
 	type nodeEventInfo struct {
 		NodeID roachpb.NodeID
 	}
@@ -71,9 +71,9 @@ func runEventLog(ctx context.Context, t *test, c *cluster) {
 		if err := rows.Err(); err != nil {
 			t.Fatal(err)
 		}
-		if c.spec.NodeCount != len(seenIds) {
+		if c.Spec().NodeCount != len(seenIds) {
 			return fmt.Errorf("expected %d node join messages, found %d: %v",
-				c.spec.NodeCount, len(seenIds), seenIds)
+				c.Spec().NodeCount, len(seenIds), seenIds)
 		}
 		return nil
 	})

--- a/pkg/cmd/roachtest/flowable.go
+++ b/pkg/cmd/roachtest/flowable.go
@@ -23,7 +23,7 @@ func registerFlowable(r *testRegistry) {
 	runFlowable := func(
 		ctx context.Context,
 		t *test,
-		c *cluster,
+		c clusterI,
 	) {
 		if c.isLocal() {
 			t.Fatal("cannot be run in local mode")
@@ -101,7 +101,7 @@ func registerFlowable(r *testRegistry) {
 		Owner:      OwnerSQLExperience,
 		Cluster:    makeClusterSpec(1),
 		MinVersion: "v19.1.0",
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			runFlowable(ctx, t, c)
 		},
 	})

--- a/pkg/cmd/roachtest/flowable.go
+++ b/pkg/cmd/roachtest/flowable.go
@@ -35,7 +35,7 @@ func registerFlowable(r *testRegistry) {
 
 		t.Status("cloning flowable and installing prerequisites")
 		latestTag, err := repeatGetLatestTag(
-			ctx, c, "flowable", "flowable-engine", flowableReleaseTagRegex,
+			ctx, t, "flowable", "flowable-engine", flowableReleaseTagRegex,
 		)
 		if err != nil {
 			t.Fatal(err)
@@ -43,13 +43,14 @@ func registerFlowable(r *testRegistry) {
 		t.l.Printf("Latest Flowable release is %s.", latestTag)
 
 		if err := repeatRunE(
-			ctx, c, node, "update apt-get", `sudo apt-get -qq update`,
+			ctx, t, c, node, "update apt-get", `sudo apt-get -qq update`,
 		); err != nil {
 			t.Fatal(err)
 		}
 
 		if err := repeatRunE(
 			ctx,
+			t,
 			c,
 			node,
 			"install dependencies",
@@ -59,14 +60,14 @@ func registerFlowable(r *testRegistry) {
 		}
 
 		if err := repeatRunE(
-			ctx, c, node, "remove old Flowable", `rm -rf /mnt/data1/flowable-engine`,
+			ctx, t, c, node, "remove old Flowable", `rm -rf /mnt/data1/flowable-engine`,
 		); err != nil {
 			t.Fatal(err)
 		}
 
 		if err := repeatGitCloneE(
 			ctx,
-			t.l,
+			t,
 			c,
 			"https://github.com/flowable/flowable-engine.git",
 			"/mnt/data1/flowable-engine",
@@ -79,6 +80,7 @@ func registerFlowable(r *testRegistry) {
 		t.Status("building Flowable")
 		if err := repeatRunE(
 			ctx,
+			t,
 			c,
 			node,
 			"building Flowable",

--- a/pkg/cmd/roachtest/follower_reads.go
+++ b/pkg/cmd/roachtest/follower_reads.go
@@ -51,7 +51,7 @@ func registerFollowerReads(r *testRegistry) {
 				// us-west1, and 1 (or 2) in europe-west2.
 				zones("us-east1-b,us-east1-b,us-east1-b,us-west1-b,us-west1-b,europe-west2-b"),
 			),
-			Run: func(ctx context.Context, t *test, c *cluster) {
+			Run: func(ctx context.Context, t *test, c clusterI) {
 				runFollowerReadsTest(ctx, t, c, survival, locality)
 			},
 		})
@@ -99,7 +99,7 @@ const (
 //    time are under 10ms which implies that no WAN RPCs occurred.
 //
 func runFollowerReadsTest(
-	ctx context.Context, t *test, c *cluster, survival survivalGoal, locality localitySetting,
+	ctx context.Context, t *test, c clusterI, survival survivalGoal, locality localitySetting,
 ) {
 	c.Put(ctx, cockroach, "./cockroach")
 	c.Wipe(ctx)
@@ -396,7 +396,7 @@ func computeFollowerReadDuration(ctx context.Context, db *gosql.DB) (time.Durati
 // ignoring the first 20s.
 func verifySQLLatency(
 	ctx context.Context,
-	c *cluster,
+	c clusterI,
 	t *test,
 	adminNode nodeListOption,
 	start, end time.Time,
@@ -445,7 +445,7 @@ const followerReadsMetric = "follower_reads_success_count"
 
 // getFollowerReadCounts returns a slice from node to follower read count
 // according to the metric.
-func getFollowerReadCounts(ctx context.Context, c *cluster) ([]int, error) {
+func getFollowerReadCounts(ctx context.Context, c clusterI) ([]int, error) {
 	followerReadCounts := make([]int, c.Spec().NodeCount)
 	getFollowerReadCount := func(ctx context.Context, node int) func() error {
 		return func() error {

--- a/pkg/cmd/roachtest/follower_reads.go
+++ b/pkg/cmd/roachtest/follower_reads.go
@@ -106,7 +106,7 @@ func runFollowerReadsTest(
 	c.Start(ctx, t)
 
 	var conns []*gosql.DB
-	for i := 0; i < c.spec.NodeCount; i++ {
+	for i := 0; i < c.Spec().NodeCount; i++ {
 		conns = append(conns, c.Conn(ctx, i+1))
 		defer conns[i].Close()
 	}
@@ -321,7 +321,7 @@ func runFollowerReadsTest(
 	// few times on each follower to give caches time to warm up.
 	g, gCtx = errgroup.WithContext(ctx)
 	k, v := chooseKV()
-	for i := 1; i <= c.spec.NodeCount; i++ {
+	for i := 1; i <= c.Spec().NodeCount; i++ {
 		fn := verifySelect(gCtx, i, k, v)
 		g.Go(func() error {
 			for j := 0; j < 100; j++ {
@@ -359,7 +359,7 @@ func runFollowerReadsTest(
 	defer cancel()
 	g, gCtx = errgroup.WithContext(timeoutCtx)
 	for i := 0; i < concurrency; i++ {
-		g.Go(doSelects(gCtx, rand.Intn(c.spec.NodeCount)+1))
+		g.Go(doSelects(gCtx, rand.Intn(c.Spec().NodeCount)+1))
 	}
 	start := timeutil.Now()
 	if err := g.Wait(); err != nil && timeoutCtx.Err() == nil {
@@ -446,7 +446,7 @@ const followerReadsMetric = "follower_reads_success_count"
 // getFollowerReadCounts returns a slice from node to follower read count
 // according to the metric.
 func getFollowerReadCounts(ctx context.Context, c *cluster) ([]int, error) {
-	followerReadCounts := make([]int, c.spec.NodeCount)
+	followerReadCounts := make([]int, c.Spec().NodeCount)
 	getFollowerReadCount := func(ctx context.Context, node int) func() error {
 		return func() error {
 			adminUIAddrs, err := c.ExternalAdminUIAddr(ctx, c.Node(node))
@@ -479,7 +479,7 @@ func getFollowerReadCounts(ctx context.Context, c *cluster) ([]int, error) {
 		}
 	}
 	g, gCtx := errgroup.WithContext(ctx)
-	for i := 1; i <= c.spec.NodeCount; i++ {
+	for i := 1; i <= c.Spec().NodeCount; i++ {
 		g.Go(getFollowerReadCount(gCtx, i))
 	}
 	if err := g.Wait(); err != nil {

--- a/pkg/cmd/roachtest/go_helpers.go
+++ b/pkg/cmd/roachtest/go_helpers.go
@@ -16,7 +16,7 @@ const goPath = `/mnt/data1/go`
 
 // installGolang installs a specific version of Go on all nodes in
 // "node".
-func installGolang(ctx context.Context, t *test, c *cluster, node nodeListOption) {
+func installGolang(ctx context.Context, t *test, c clusterI, node nodeListOption) {
 	if err := repeatRunE(
 		ctx, t, c, node, "update apt-get", `sudo apt-get -qq update`,
 	); err != nil {

--- a/pkg/cmd/roachtest/go_helpers.go
+++ b/pkg/cmd/roachtest/go_helpers.go
@@ -18,13 +18,14 @@ const goPath = `/mnt/data1/go`
 // "node".
 func installGolang(ctx context.Context, t *test, c *cluster, node nodeListOption) {
 	if err := repeatRunE(
-		ctx, c, node, "update apt-get", `sudo apt-get -qq update`,
+		ctx, t, c, node, "update apt-get", `sudo apt-get -qq update`,
 	); err != nil {
 		t.Fatal(err)
 	}
 
 	if err := repeatRunE(
 		ctx,
+		t,
 		c,
 		node,
 		"install dependencies (go uses C bindings)",
@@ -34,24 +35,24 @@ func installGolang(ctx context.Context, t *test, c *cluster, node nodeListOption
 	}
 
 	if err := repeatRunE(
-		ctx, c, node, "download go", `curl -fsSL https://dl.google.com/go/go1.15.11.linux-amd64.tar.gz > /tmp/go.tgz`,
+		ctx, t, c, node, "download go", `curl -fsSL https://dl.google.com/go/go1.15.11.linux-amd64.tar.gz > /tmp/go.tgz`,
 	); err != nil {
 		t.Fatal(err)
 	}
 	if err := repeatRunE(
-		ctx, c, node, "verify tarball", `sha256sum -c - <<EOF
+		ctx, t, c, node, "verify tarball", `sha256sum -c - <<EOF
 8825b72d74b14e82b54ba3697813772eb94add3abf70f021b6bdebe193ed01ec /tmp/go.tgz
 EOF`,
 	); err != nil {
 		t.Fatal(err)
 	}
 	if err := repeatRunE(
-		ctx, c, node, "extract go", `sudo tar -C /usr/local -zxf /tmp/go.tgz && rm /tmp/go.tgz`,
+		ctx, t, c, node, "extract go", `sudo tar -C /usr/local -zxf /tmp/go.tgz && rm /tmp/go.tgz`,
 	); err != nil {
 		t.Fatal(err)
 	}
 	if err := repeatRunE(
-		ctx, c, node, "force symlink go", "sudo ln -sf /usr/local/go/bin/go /usr/bin",
+		ctx, t, c, node, "force symlink go", "sudo ln -sf /usr/local/go/bin/go /usr/bin",
 	); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/cmd/roachtest/gopg.go
+++ b/pkg/cmd/roachtest/gopg.go
@@ -58,7 +58,7 @@ func registerGopg(r *testRegistry) {
 		}
 
 		t.Status("cloning gopg and installing prerequisites")
-		gopgLatestTag, err := repeatGetLatestTag(ctx, c, "go-pg", "pg", gopgReleaseTagRegex)
+		gopgLatestTag, err := repeatGetLatestTag(ctx, t, "go-pg", "pg", gopgReleaseTagRegex)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -68,7 +68,7 @@ func registerGopg(r *testRegistry) {
 		installGolang(ctx, t, c, node)
 
 		if err := repeatRunE(
-			ctx, c, node, "remove old gopg",
+			ctx, t, c, node, "remove old gopg",
 			fmt.Sprintf(`sudo rm -rf %s`, destPath),
 		); err != nil {
 			t.Fatal(err)
@@ -76,7 +76,7 @@ func registerGopg(r *testRegistry) {
 
 		if err := repeatGitCloneE(
 			ctx,
-			t.l,
+			t,
 			c,
 			"https://github.com/go-pg/pg.git",
 			destPath,

--- a/pkg/cmd/roachtest/gopg.go
+++ b/pkg/cmd/roachtest/gopg.go
@@ -37,7 +37,7 @@ func registerGopg(r *testRegistry) {
 	runGopg := func(
 		ctx context.Context,
 		t *test,
-		c *cluster,
+		c clusterI,
 	) {
 		if c.isLocal() {
 			t.Fatal("cannot be run in local mode")
@@ -62,8 +62,8 @@ func registerGopg(r *testRegistry) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		c.l.Printf("Latest gopg release is %s.", gopgLatestTag)
-		c.l.Printf("Supported gopg release is %s.", gopgSupportedTag)
+		t.l.Printf("Latest gopg release is %s.", gopgLatestTag)
+		t.l.Printf("Supported gopg release is %s.", gopgSupportedTag)
 
 		installGolang(ctx, t, c, node)
 
@@ -93,7 +93,7 @@ func registerGopg(r *testRegistry) {
 		if ignorelist == nil {
 			t.Fatalf("No gopg ignorelist defined for cockroach version %s", version)
 		}
-		c.l.Printf("Running cockroach version %s, using blocklist %s, using ignorelist %s",
+		t.l.Printf("Running cockroach version %s, using blocklist %s, using ignorelist %s",
 			version, blocklistName, ignorelistName)
 
 		_ = c.RunE(ctx, node, fmt.Sprintf("mkdir -p %s", resultsDirPath))
@@ -112,7 +112,7 @@ func registerGopg(r *testRegistry) {
 		)
 
 		t.Status("collating the test results")
-		c.l.Printf("Test Results: %s", rawResults)
+		t.l.Printf("Test Results: %s", rawResults)
 		results := newORMTestsResults()
 
 		// gopg test suite consists of multiple tests, some of them being a full
@@ -150,7 +150,7 @@ func registerGopg(r *testRegistry) {
 		Cluster:    makeClusterSpec(1),
 		MinVersion: "v20.2.0",
 		Tags:       []string{`default`, `orm`},
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			runGopg(ctx, t, c)
 		},
 	})

--- a/pkg/cmd/roachtest/gorm.go
+++ b/pkg/cmd/roachtest/gorm.go
@@ -40,7 +40,7 @@ func registerGORM(r *testRegistry) {
 
 		t.Status("cloning gorm and installing prerequisites")
 		latestTag, err := repeatGetLatestTag(
-			ctx, c, "go-gorm", "gorm", gormReleaseTag)
+			ctx, t, "go-gorm", "gorm", gormReleaseTag)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -59,7 +59,7 @@ func registerGORM(r *testRegistry) {
 
 		// Remove any old gorm installations
 		if err := repeatRunE(
-			ctx, c, node, "remove old gorm", fmt.Sprintf("rm -rf %s", gormPath),
+			ctx, t, c, node, "remove old gorm", fmt.Sprintf("rm -rf %s", gormPath),
 		); err != nil {
 			t.Fatal(err)
 		}
@@ -67,14 +67,14 @@ func registerGORM(r *testRegistry) {
 		// Install go-junit-report to convert test results to .xml format we know
 		// how to work with.
 		if err := repeatRunE(
-			ctx, c, node, "install go-junit-report", fmt.Sprintf("GOPATH=%s go get -u github.com/jstemmer/go-junit-report", goPath),
+			ctx, t, c, node, "install go-junit-report", fmt.Sprintf("GOPATH=%s go get -u github.com/jstemmer/go-junit-report", goPath),
 		); err != nil {
 			t.Fatal(err)
 		}
 
 		if err := repeatGitCloneE(
 			ctx,
-			t.l,
+			t,
 			c,
 			fmt.Sprintf("https://%s.git", gormRepo),
 			gormPath,
@@ -94,7 +94,7 @@ func registerGORM(r *testRegistry) {
 
 		// Write the cockroach config into the test suite to use.
 		if err := repeatRunE(
-			ctx, c, node, fmt.Sprintf(`echo "%s" > %s/tests_test.go`, gormTestHelperGoFile, gormTestPath),
+			ctx, t, c, node, fmt.Sprintf(`echo "%s" > %s/tests_test.go`, gormTestHelperGoFile, gormTestPath),
 		); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/cmd/roachtest/gorm.go
+++ b/pkg/cmd/roachtest/gorm.go
@@ -22,7 +22,7 @@ var gormReleaseTag = regexp.MustCompile(`^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<p
 var gormSupportedTag = "v1.21.8"
 
 func registerGORM(r *testRegistry) {
-	runGORM := func(ctx context.Context, t *test, c *cluster) {
+	runGORM := func(ctx context.Context, t *test, c clusterI) {
 		if c.isLocal() {
 			t.Fatal("cannot be run in local mode")
 		}
@@ -44,8 +44,8 @@ func registerGORM(r *testRegistry) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		c.l.Printf("Latest gorm release is %s.", latestTag)
-		c.l.Printf("Supported gorm release is %s.", gormSupportedTag)
+		t.l.Printf("Latest gorm release is %s.", latestTag)
+		t.l.Printf("Supported gorm release is %s.", gormSupportedTag)
 
 		installGolang(ctx, t, c, node)
 
@@ -90,7 +90,7 @@ func registerGORM(r *testRegistry) {
 		if expectedFailures == nil {
 			t.Fatalf("No gorm blocklist defined for cockroach version %s", version)
 		}
-		c.l.Printf("Running cockroach version %s, using blocklist %s, using ignorelist %s", version, blocklistName, ignorelistName)
+		t.l.Printf("Running cockroach version %s, using blocklist %s, using ignorelist %s", version, blocklistName, ignorelistName)
 
 		// Write the cockroach config into the test suite to use.
 		if err := repeatRunE(

--- a/pkg/cmd/roachtest/gossip.go
+++ b/pkg/cmd/roachtest/gossip.go
@@ -85,7 +85,7 @@ SELECT string_agg(source_id::TEXT || ':' || target_id::TEXT, ',')
 			var expLiveNodes []int
 			var expGossipNetwork string
 
-			for i := 1; i <= c.spec.NodeCount; i++ {
+			for i := 1; i <= c.Spec().NodeCount; i++ {
 				if elapsed := timeutil.Since(start); elapsed >= 20*time.Second {
 					t.Fatalf("gossip did not stabilize in %.1fs", deadNode, elapsed.Seconds())
 				}
@@ -165,11 +165,11 @@ type gossipUtil struct {
 	conn     func(ctx context.Context, i int) *gosql.DB
 }
 
-func newGossipUtil(ctx context.Context, c *cluster) *gossipUtil {
+func newGossipUtil(ctx context.Context, t *test, c clusterI) *gossipUtil {
 	urlMap := make(map[int]string)
 	adminUIAddrs, err := c.ExternalAdminUIAddr(ctx, c.All())
 	if err != nil {
-		c.t.Fatal(err)
+		t.Fatal(err)
 	}
 	for i, addr := range adminUIAddrs {
 		urlMap[i+1] = `http://` + addr
@@ -186,10 +186,10 @@ type checkGossipFunc func(map[string]gossip.Info) error
 // checkGossip fetches the gossip infoStore from each node and invokes the
 // given function. The test passes if the function returns 0 for every node,
 // retrying for up to the given duration.
-func (g *gossipUtil) check(ctx context.Context, c *cluster, f checkGossipFunc) error {
+func (g *gossipUtil) check(ctx context.Context, c clusterI, f checkGossipFunc) error {
 	return retry.ForDuration(g.waitTime, func() error {
 		var infoStatus gossip.InfoStatus
-		for i := 1; i <= c.spec.NodeCount; i++ {
+		for i := 1; i <= c.Spec().NodeCount; i++ {
 			url := g.urlMap[i] + `/_status/gossip/local`
 			if err := httputil.GetJSON(http.Client{}, url, &infoStatus); err != nil {
 				return errors.Wrapf(err, "failed to get gossip status from node %d", i)
@@ -236,9 +236,9 @@ func (gossipUtil) hasClusterID(infos map[string]gossip.Info) error {
 	return nil
 }
 
-func (g *gossipUtil) checkConnectedAndFunctional(ctx context.Context, t *test, c *cluster) {
+func (g *gossipUtil) checkConnectedAndFunctional(ctx context.Context, t *test, c clusterI) {
 	t.l.Printf("waiting for gossip to be connected\n")
-	if err := g.check(ctx, c, g.hasPeers(c.spec.NodeCount)); err != nil {
+	if err := g.check(ctx, c, g.hasPeers(c.Spec().NodeCount)); err != nil {
 		t.Fatal(err)
 	}
 	if err := g.check(ctx, c, g.hasClusterID); err != nil {
@@ -248,7 +248,7 @@ func (g *gossipUtil) checkConnectedAndFunctional(ctx context.Context, t *test, c
 		t.Fatal(err)
 	}
 
-	for i := 1; i <= c.spec.NodeCount; i++ {
+	for i := 1; i <= c.Spec().NodeCount; i++ {
 		db := g.conn(ctx, i)
 		defer db.Close()
 		if i == 1 {
@@ -281,18 +281,18 @@ func (g *gossipUtil) checkConnectedAndFunctional(ctx context.Context, t *test, c
 	}
 }
 
-func runGossipPeerings(ctx context.Context, t *test, c *cluster) {
+func runGossipPeerings(ctx context.Context, t *test, c clusterI) {
 	c.Put(ctx, cockroach, "./cockroach")
 	c.Start(ctx, t)
 
 	// Repeatedly restart a random node and verify that all of the nodes are
 	// seeing the gossiped values.
 
-	g := newGossipUtil(ctx, c)
+	g := newGossipUtil(ctx, t, c)
 	deadline := timeutil.Now().Add(time.Minute)
 
 	for i := 1; timeutil.Now().Before(deadline); i++ {
-		if err := g.check(ctx, c, g.hasPeers(c.spec.NodeCount)); err != nil {
+		if err := g.check(ctx, c, g.hasPeers(c.Spec().NodeCount)); err != nil {
 			t.Fatal(err)
 		}
 		if err := g.check(ctx, c, g.hasClusterID); err != nil {
@@ -314,7 +314,7 @@ func runGossipPeerings(ctx context.Context, t *test, c *cluster) {
 	}
 }
 
-func runGossipRestart(ctx context.Context, t *test, c *cluster) {
+func runGossipRestart(ctx context.Context, t *test, c clusterI) {
 	t.Skip("skipping flaky acceptance/gossip/restart", "https://github.com/cockroachdb/cockroach/issues/48423")
 
 	c.Put(ctx, cockroach, "./cockroach")
@@ -325,7 +325,7 @@ func runGossipRestart(ctx context.Context, t *test, c *cluster) {
 	// which is required for any node to be able do even the most basic
 	// operations on a cluster.
 
-	g := newGossipUtil(ctx, c)
+	g := newGossipUtil(ctx, t, c)
 	deadline := timeutil.Now().Add(time.Minute)
 
 	for i := 1; timeutil.Now().Before(deadline); i++ {
@@ -340,11 +340,11 @@ func runGossipRestart(ctx context.Context, t *test, c *cluster) {
 	}
 }
 
-func runGossipRestartNodeOne(ctx context.Context, t *test, c *cluster) {
+func runGossipRestartNodeOne(ctx context.Context, t *test, c clusterI) {
 	args := startArgs("--env=COCKROACH_SCAN_MAX_IDLE_TIME=5ms", "--encrypt=false")
 	c.Put(ctx, cockroach, "./cockroach")
 	// Reduce the scan max idle time to speed up evacuation of node 1.
-	c.Start(ctx, t, racks(c.spec.NodeCount), args)
+	c.Start(ctx, t, racks(c.Spec().NodeCount), args)
 
 	db := c.Conn(ctx, 1)
 	defer db.Close()
@@ -448,13 +448,13 @@ SELECT count(replicas)
 	// Restart the other nodes. These nodes won't be able to talk to node 1 until
 	// node 1 talks to it (they have out of date address info). Node 1 needs
 	// incoming gossip info in order to determine where range 1 is.
-	c.Start(ctx, t, c.Range(2, c.spec.NodeCount), args)
+	c.Start(ctx, t, c.Range(2, c.Spec().NodeCount), args)
 
 	// We need to override DB connection creation to use the correct port for
 	// node 1. This is more complicated than it should be and a limitation of the
 	// current infrastructure which doesn't know about cockroach nodes started on
 	// non-standard ports.
-	g := newGossipUtil(ctx, c)
+	g := newGossipUtil(ctx, t, c)
 	g.conn = func(ctx context.Context, i int) *gosql.DB {
 		if i != 1 {
 			return c.Conn(ctx, i)
@@ -491,15 +491,15 @@ SELECT count(replicas)
 	c.Start(ctx, t, c.Node(1))
 }
 
-func runCheckLocalityIPAddress(ctx context.Context, t *test, c *cluster) {
+func runCheckLocalityIPAddress(ctx context.Context, t *test, c clusterI) {
 	c.Put(ctx, cockroach, "./cockroach")
 
-	externalIP, err := c.ExternalIP(ctx, c.Range(1, c.spec.NodeCount))
+	externalIP, err := c.ExternalIP(ctx, c.Range(1, c.Spec().NodeCount))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	for i := 1; i <= c.spec.NodeCount; i++ {
+	for i := 1; i <= c.Spec().NodeCount; i++ {
 		if local {
 			externalIP[i-1] = "localhost"
 		}
@@ -511,7 +511,7 @@ func runCheckLocalityIPAddress(ctx context.Context, t *test, c *cluster) {
 
 	rowCount := 0
 
-	for i := 1; i <= c.spec.NodeCount; i++ {
+	for i := 1; i <= c.Spec().NodeCount; i++ {
 		db := c.Conn(ctx, 1)
 		defer db.Close()
 

--- a/pkg/cmd/roachtest/hibernate.go
+++ b/pkg/cmd/roachtest/hibernate.go
@@ -96,7 +96,7 @@ func registerHibernate(r *testRegistry, opt hibernateOptions) {
 
 		t.Status("cloning hibernate and installing prerequisites")
 		latestTag, err := repeatGetLatestTag(
-			ctx, c, "hibernate", "hibernate-orm", hibernateReleaseTagRegex,
+			ctx, t, "hibernate", "hibernate-orm", hibernateReleaseTagRegex,
 		)
 		if err != nil {
 			t.Fatal(err)
@@ -105,7 +105,7 @@ func registerHibernate(r *testRegistry, opt hibernateOptions) {
 		c.l.Printf("Supported Hibernate release is %s.", supportedHibernateTag)
 
 		if err := repeatRunE(
-			ctx, c, node, "update apt-get", `sudo apt-get -qq update`,
+			ctx, t, c, node, "update apt-get", `sudo apt-get -qq update`,
 		); err != nil {
 			t.Fatal(err)
 		}
@@ -113,6 +113,7 @@ func registerHibernate(r *testRegistry, opt hibernateOptions) {
 		// TODO(rafi): use openjdk-11-jdk-headless once we are off of Ubuntu 16.
 		if err := repeatRunE(
 			ctx,
+			t,
 			c,
 			node,
 			"install dependencies",
@@ -122,14 +123,14 @@ func registerHibernate(r *testRegistry, opt hibernateOptions) {
 		}
 
 		if err := repeatRunE(
-			ctx, c, node, "remove old Hibernate", `rm -rf /mnt/data1/hibernate`,
+			ctx, t, c, node, "remove old Hibernate", `rm -rf /mnt/data1/hibernate`,
 		); err != nil {
 			t.Fatal(err)
 		}
 
 		if err := repeatGitCloneE(
 			ctx,
-			t.l,
+			t,
 			c,
 			"https://github.com/hibernate/hibernate-orm.git",
 			"/mnt/data1/hibernate",
@@ -146,6 +147,7 @@ func registerHibernate(r *testRegistry, opt hibernateOptions) {
 		// single test is invoked.
 		if err := repeatRunE(
 			ctx,
+			t,
 			c,
 			node,
 			"building hibernate (without tests)",
@@ -157,6 +159,7 @@ func registerHibernate(r *testRegistry, opt hibernateOptions) {
 		// Delete the test result; the test will be executed again later.
 		if err := repeatRunE(
 			ctx,
+			t,
 			c,
 			node,
 			"delete test result from build output",
@@ -184,6 +187,7 @@ func registerHibernate(r *testRegistry, opt hibernateOptions) {
 		// Copy the html report for the test.
 		if err := repeatRunE(
 			ctx,
+			t,
 			c,
 			node,
 			"copy html report",
@@ -195,6 +199,7 @@ func registerHibernate(r *testRegistry, opt hibernateOptions) {
 		// Copy the individual test result files.
 		if err := repeatRunE(
 			ctx,
+			t,
 			c,
 			node,
 			"copy test result files",

--- a/pkg/cmd/roachtest/hotspotsplits.go
+++ b/pkg/cmd/roachtest/hotspotsplits.go
@@ -27,8 +27,8 @@ func registerHotSpotSplits(r *testRegistry) {
 	// to force a large range. We then make sure that the largest range isn't larger than a threshold and
 	// that backpressure is working correctly.
 	runHotSpot := func(ctx context.Context, t *test, c *cluster, duration time.Duration, concurrency int) {
-		roachNodes := c.Range(1, c.spec.NodeCount-1)
-		appNode := c.Node(c.spec.NodeCount)
+		roachNodes := c.Range(1, c.Spec().NodeCount-1)
+		appNode := c.Node(c.Spec().NodeCount)
 
 		c.Put(ctx, cockroach, "./cockroach", roachNodes)
 		c.Start(ctx, t, roachNodes)

--- a/pkg/cmd/roachtest/hotspotsplits.go
+++ b/pkg/cmd/roachtest/hotspotsplits.go
@@ -26,7 +26,7 @@ func registerHotSpotSplits(r *testRegistry) {
 	// This test sets up a cluster and runs kv on it with high concurrency and a large block size
 	// to force a large range. We then make sure that the largest range isn't larger than a threshold and
 	// that backpressure is working correctly.
-	runHotSpot := func(ctx context.Context, t *test, c *cluster, duration time.Duration, concurrency int) {
+	runHotSpot := func(ctx context.Context, t *test, c clusterI, duration time.Duration, concurrency int) {
 		roachNodes := c.Range(1, c.Spec().NodeCount-1)
 		appNode := c.Node(c.Spec().NodeCount)
 
@@ -96,7 +96,7 @@ func registerHotSpotSplits(r *testRegistry) {
 		// https://github.com/cockroachdb/cockroach/pull/45323.
 		MinVersion: "v20.1.0",
 		Cluster:    makeClusterSpec(numNodes),
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			if local {
 				concurrency = 32
 				fmt.Printf("lowering concurrency to %d in local testing\n", concurrency)

--- a/pkg/cmd/roachtest/inconsistency.go
+++ b/pkg/cmd/roachtest/inconsistency.go
@@ -27,10 +27,10 @@ func registerInconsistency(r *testRegistry) {
 	})
 }
 
-func runInconsistency(ctx context.Context, t *test, c *cluster) {
+func runInconsistency(ctx context.Context, t *test, c clusterI) {
 	// With encryption on, our attempt below to manually introduce an inconsistency
 	// will fail.
-	c.encryptDefault = false
+	c.EncryptDefault(false)
 
 	nodes := c.Range(1, 3)
 	c.Put(ctx, cockroach, "./cockroach", nodes)

--- a/pkg/cmd/roachtest/indexes.go
+++ b/pkg/cmd/roachtest/indexes.go
@@ -33,7 +33,7 @@ func registerNIndexes(r *testRegistry, secondaryIndexes int) {
 		Cluster: makeClusterSpec(nodes+1, cpu(16), geo(), zones(geoZonesStr)),
 		// Uses CONFIGURE ZONE USING ... COPY FROM PARENT syntax.
 		MinVersion: `v19.1.0`,
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			firstAZ := geoZones[0]
 			roachNodes := c.Range(1, nodes)
 			gatewayNodes := c.Range(1, nodes/3)

--- a/pkg/cmd/roachtest/interleavedpartitioned.go
+++ b/pkg/cmd/roachtest/interleavedpartitioned.go
@@ -31,7 +31,7 @@ func registerInterleaved(r *testRegistry) {
 	runInterleaved := func(
 		ctx context.Context,
 		t *test,
-		c *cluster,
+		c clusterI,
 		config config,
 	) {
 		numZones, numRoachNodes, numLoadNodes := 3, 9, 3
@@ -45,8 +45,8 @@ func registerInterleaved(r *testRegistry) {
 		cockroachNodes := loadGroups.roachNodes()
 		workloadNodes := loadGroups.loadNodes()
 
-		c.l.Printf("cockroach nodes: %s", cockroachNodes.String()[1:])
-		c.l.Printf("workload nodes: %s", workloadNodes.String()[1:])
+		t.l.Printf("cockroach nodes: %s", cockroachNodes.String()[1:])
+		t.l.Printf("workload nodes: %s", workloadNodes.String()[1:])
 
 		c.Put(ctx, cockroach, "./cockroach", c.All())
 		c.Put(ctx, workload, "./workload", c.All())
@@ -121,7 +121,7 @@ func registerInterleaved(r *testRegistry) {
 		Name:    "interleavedpartitioned",
 		Owner:   OwnerKV,
 		Cluster: makeClusterSpec(12, geo(), zones("us-east1-b,us-west1-b,europe-west2-b")),
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			runInterleaved(ctx, t, c,
 				config{
 					eastName:        `europe-west2-b`,

--- a/pkg/cmd/roachtest/inverted_index.go
+++ b/pkg/cmd/roachtest/inverted_index.go
@@ -23,7 +23,7 @@ func registerSchemaChangeInvertedIndex(r *testRegistry) {
 		Name:    "schemachange/invertedindex",
 		Owner:   OwnerSQLSchema,
 		Cluster: makeClusterSpec(5),
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			runSchemaChangeInvertedIndex(ctx, t, c)
 		},
 	})
@@ -31,7 +31,7 @@ func registerSchemaChangeInvertedIndex(r *testRegistry) {
 
 // runInvertedIndex tests the correctness and performance of building an
 // inverted index on randomly generated JSON data (from the JSON workload).
-func runSchemaChangeInvertedIndex(ctx context.Context, t *test, c *cluster) {
+func runSchemaChangeInvertedIndex(ctx context.Context, t *test, c clusterI) {
 	crdbNodes := c.Range(1, c.Spec().NodeCount-1)
 	workloadNode := c.Node(c.Spec().NodeCount)
 

--- a/pkg/cmd/roachtest/inverted_index.go
+++ b/pkg/cmd/roachtest/inverted_index.go
@@ -32,8 +32,8 @@ func registerSchemaChangeInvertedIndex(r *testRegistry) {
 // runInvertedIndex tests the correctness and performance of building an
 // inverted index on randomly generated JSON data (from the JSON workload).
 func runSchemaChangeInvertedIndex(ctx context.Context, t *test, c *cluster) {
-	crdbNodes := c.Range(1, c.spec.NodeCount-1)
-	workloadNode := c.Node(c.spec.NodeCount)
+	crdbNodes := c.Range(1, c.Spec().NodeCount-1)
+	workloadNode := c.Node(c.Spec().NodeCount)
 
 	c.Put(ctx, cockroach, "./cockroach", crdbNodes)
 	c.Put(ctx, workload, "./workload", workloadNode)
@@ -56,7 +56,7 @@ func runSchemaChangeInvertedIndex(ctx context.Context, t *test, c *cluster) {
 
 	cmdWrite := fmt.Sprintf(
 		"./workload run json --read-percent=0 --duration %s {pgurl:1-%d} --batch 1000 --sequential",
-		initialDataDuration.String(), c.spec.NodeCount-1,
+		initialDataDuration.String(), c.Spec().NodeCount-1,
 	)
 	m.Go(func(ctx context.Context) error {
 		c.Run(ctx, workloadNode, cmdWrite)
@@ -80,7 +80,7 @@ func runSchemaChangeInvertedIndex(ctx context.Context, t *test, c *cluster) {
 
 	cmdWriteAndRead := fmt.Sprintf(
 		"./workload run json --read-percent=50 --duration %s {pgurl:1-%d} --sequential",
-		indexDuration.String(), c.spec.NodeCount-1,
+		indexDuration.String(), c.Spec().NodeCount-1,
 	)
 	m.Go(func(ctx context.Context) error {
 		c.Run(ctx, workloadNode, cmdWriteAndRead)

--- a/pkg/cmd/roachtest/java_helpers.go
+++ b/pkg/cmd/roachtest/java_helpers.go
@@ -174,7 +174,7 @@ func (r *ormTestsResults) parseJUnitXML(
 func parseAndSummarizeJavaORMTestsResults(
 	ctx context.Context,
 	t *test,
-	c *cluster,
+	c clusterI,
 	node nodeListOption,
 	ormName string,
 	testOutput []byte,
@@ -201,7 +201,7 @@ func parseAndSummarizeJavaORMTestsResults(
 		fileOutput, err := repeatRunWithBuffer(
 			ctx,
 			c,
-			t.l,
+			t,
 			node,
 			fmt.Sprintf("fetching results file %s", file),
 			fmt.Sprintf("cat %s", file),

--- a/pkg/cmd/roachtest/jepsen.go
+++ b/pkg/cmd/roachtest/jepsen.go
@@ -52,8 +52,8 @@ func initJepsen(ctx context.Context, t *test, c *cluster) {
 		return
 	}
 
-	controller := c.Node(c.spec.NodeCount)
-	workers := c.Range(1, c.spec.NodeCount-1)
+	controller := c.Node(c.Spec().NodeCount)
+	workers := c.Range(1, c.Spec().NodeCount-1)
 
 	// Install jepsen. This part is fast if the repo is already there,
 	// so do it before the initialization check for ease of iteration.
@@ -142,11 +142,11 @@ func initJepsen(ctx context.Context, t *test, c *cluster) {
 func runJepsen(ctx context.Context, t *test, c *cluster, testName, nemesis string) {
 	initJepsen(ctx, t, c)
 
-	controller := c.Node(c.spec.NodeCount)
+	controller := c.Node(c.Spec().NodeCount)
 
 	// Get the IP addresses for all our workers.
 	var nodeFlags []string
-	ips, err := c.InternalIP(ctx, c.Range(1, c.spec.NodeCount-1))
+	ips, err := c.InternalIP(ctx, c.Range(1, c.Spec().NodeCount-1))
 	if err != nil {
 		c.t.Fatal(err)
 	}

--- a/pkg/cmd/roachtest/jobs.go
+++ b/pkg/cmd/roachtest/jobs.go
@@ -20,7 +20,7 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-type jobStarter func(c *cluster) (string, error)
+type jobStarter func(c clusterI) (string, error)
 
 // jobSurvivesNodeShutdown is a helper that tests that a given job,
 // running on the specified gatewayNode will still complete successfully
@@ -32,9 +32,9 @@ type jobStarter func(c *cluster) (string, error)
 // - That the statement running the job is a detached statement, and does not
 // block until the job completes.
 func jobSurvivesNodeShutdown(
-	ctx context.Context, t *test, c *cluster, nodeToShutdown int, startJob jobStarter,
+	ctx context.Context, t *test, c clusterI, nodeToShutdown int, startJob jobStarter,
 ) {
-	watcherNode := 1 + (nodeToShutdown)%c.spec.NodeCount
+	watcherNode := 1 + (nodeToShutdown)%c.Spec().NodeCount
 	target := c.Node(nodeToShutdown)
 	t.l.Printf("test has chosen shutdown target node %d, and watcher node %d",
 		nodeToShutdown, watcherNode)

--- a/pkg/cmd/roachtest/kv.go
+++ b/pkg/cmd/roachtest/kv.go
@@ -61,7 +61,7 @@ func registerKV(r *testRegistry) {
 			return opts.splits
 		}
 	}
-	runKV := func(ctx context.Context, t *test, c *cluster, opts kvOptions) {
+	runKV := func(ctx context.Context, t *test, c clusterI, opts kvOptions) {
 		nodes := c.Spec().NodeCount - 1
 		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 		c.Put(ctx, workload, "./workload", c.Node(nodes+1))
@@ -227,7 +227,7 @@ func registerKV(r *testRegistry) {
 			Owner:      OwnerKV,
 			MinVersion: minVersion,
 			Cluster:    makeClusterSpec(opts.nodes+1, cpu(opts.cpus)),
-			Run: func(ctx context.Context, t *test, c *cluster) {
+			Run: func(ctx context.Context, t *test, c clusterI) {
 				runKV(ctx, t, c, opts)
 			},
 			Tags: opts.tags,
@@ -242,7 +242,7 @@ func registerKVContention(r *testRegistry) {
 		Owner:      OwnerKV,
 		MinVersion: "v20.1.0",
 		Cluster:    makeClusterSpec(nodes + 1),
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 			c.Put(ctx, workload, "./workload", c.Node(nodes+1))
 
@@ -311,7 +311,7 @@ func registerKVQuiescenceDead(r *testRegistry) {
 		Owner:      OwnerKV,
 		Cluster:    makeClusterSpec(4),
 		MinVersion: "v2.1.0",
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			nodes := c.Spec().NodeCount - 1
 			c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 			c.Put(ctx, workload, "./workload", c.Node(nodes+1))
@@ -392,7 +392,7 @@ func registerKVGracefulDraining(r *testRegistry) {
 		Name:    "kv/gracefuldraining/nodes=3",
 		Owner:   OwnerKV,
 		Cluster: makeClusterSpec(4),
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			nodes := c.Spec().NodeCount - 1
 			c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 			c.Put(ctx, workload, "./workload", c.Node(nodes+1))
@@ -609,7 +609,7 @@ func registerKVSplits(r *testRegistry) {
 			Owner:   OwnerKV,
 			Timeout: item.timeout,
 			Cluster: makeClusterSpec(4),
-			Run: func(ctx context.Context, t *test, c *cluster) {
+			Run: func(ctx context.Context, t *test, c clusterI) {
 				nodes := c.Spec().NodeCount - 1
 				c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 				c.Put(ctx, workload, "./workload", c.Node(nodes+1))
@@ -641,7 +641,7 @@ func registerKVSplits(r *testRegistry) {
 }
 
 func registerKVScalability(r *testRegistry) {
-	runScalability := func(ctx context.Context, t *test, c *cluster, percent int) {
+	runScalability := func(ctx context.Context, t *test, c clusterI, percent int) {
 		nodes := c.Spec().NodeCount - 1
 
 		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
@@ -674,7 +674,7 @@ func registerKVScalability(r *testRegistry) {
 				Name:    fmt.Sprintf("kv%d/scale/nodes=6", p),
 				Owner:   OwnerKV,
 				Cluster: makeClusterSpec(7, cpu(8)),
-				Run: func(ctx context.Context, t *test, c *cluster) {
+				Run: func(ctx context.Context, t *test, c clusterI) {
 					runScalability(ctx, t, c, p)
 				},
 			})
@@ -694,7 +694,7 @@ func registerKVRangeLookups(r *testRegistry) {
 		cpus  = 8
 	)
 
-	runRangeLookups := func(ctx context.Context, t *test, c *cluster, workers int, workloadType rangeLookupWorkloadType, maximumRangeLookupsPerSec float64) {
+	runRangeLookups := func(ctx context.Context, t *test, c clusterI, workers int, workloadType rangeLookupWorkloadType, maximumRangeLookupsPerSec float64) {
 		nodes := c.Spec().NodeCount - 1
 		doneInit := make(chan struct{})
 		doneWorkload := make(chan struct{})
@@ -809,7 +809,7 @@ func registerKVRangeLookups(r *testRegistry) {
 			Owner:      OwnerKV,
 			MinVersion: "v19.2.0",
 			Cluster:    makeClusterSpec(nodes+1, cpu(cpus)),
-			Run: func(ctx context.Context, t *test, c *cluster) {
+			Run: func(ctx context.Context, t *test, c clusterI) {
 				runRangeLookups(ctx, t, c, item.workers, item.workloadType, item.maximumRangeLookupsPerSec)
 			},
 		})

--- a/pkg/cmd/roachtest/kv.go
+++ b/pkg/cmd/roachtest/kv.go
@@ -62,7 +62,7 @@ func registerKV(r *testRegistry) {
 		}
 	}
 	runKV := func(ctx context.Context, t *test, c *cluster, opts kvOptions) {
-		nodes := c.spec.NodeCount - 1
+		nodes := c.Spec().NodeCount - 1
 		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 		c.Put(ctx, workload, "./workload", c.Node(nodes+1))
 		c.Start(ctx, t, c.Range(1, nodes), startArgs(fmt.Sprintf("--encrypt=%t", opts.encryption)))
@@ -312,7 +312,7 @@ func registerKVQuiescenceDead(r *testRegistry) {
 		Cluster:    makeClusterSpec(4),
 		MinVersion: "v2.1.0",
 		Run: func(ctx context.Context, t *test, c *cluster) {
-			nodes := c.spec.NodeCount - 1
+			nodes := c.Spec().NodeCount - 1
 			c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 			c.Put(ctx, workload, "./workload", c.Node(nodes+1))
 			c.Start(ctx, t, c.Range(1, nodes))
@@ -393,7 +393,7 @@ func registerKVGracefulDraining(r *testRegistry) {
 		Owner:   OwnerKV,
 		Cluster: makeClusterSpec(4),
 		Run: func(ctx context.Context, t *test, c *cluster) {
-			nodes := c.spec.NodeCount - 1
+			nodes := c.Spec().NodeCount - 1
 			c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 			c.Put(ctx, workload, "./workload", c.Node(nodes+1))
 
@@ -610,7 +610,7 @@ func registerKVSplits(r *testRegistry) {
 			Timeout: item.timeout,
 			Cluster: makeClusterSpec(4),
 			Run: func(ctx context.Context, t *test, c *cluster) {
-				nodes := c.spec.NodeCount - 1
+				nodes := c.Spec().NodeCount - 1
 				c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 				c.Put(ctx, workload, "./workload", c.Node(nodes+1))
 				c.Start(ctx, t, c.Range(1, nodes),
@@ -642,7 +642,7 @@ func registerKVSplits(r *testRegistry) {
 
 func registerKVScalability(r *testRegistry) {
 	runScalability := func(ctx context.Context, t *test, c *cluster, percent int) {
-		nodes := c.spec.NodeCount - 1
+		nodes := c.Spec().NodeCount - 1
 
 		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 		c.Put(ctx, workload, "./workload", c.Node(nodes+1))
@@ -695,7 +695,7 @@ func registerKVRangeLookups(r *testRegistry) {
 	)
 
 	runRangeLookups := func(ctx context.Context, t *test, c *cluster, workers int, workloadType rangeLookupWorkloadType, maximumRangeLookupsPerSec float64) {
-		nodes := c.spec.NodeCount - 1
+		nodes := c.Spec().NodeCount - 1
 		doneInit := make(chan struct{})
 		doneWorkload := make(chan struct{})
 		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))

--- a/pkg/cmd/roachtest/kvbench.go
+++ b/pkg/cmd/roachtest/kvbench.go
@@ -89,7 +89,7 @@ func registerKVBenchSpec(r *testRegistry, b kvBenchSpec) {
 		Tags:    []string{"manual"},
 		Owner:   OwnerKV,
 		Cluster: nodes,
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			runKVBench(ctx, t, c, b)
 		},
 	})

--- a/pkg/cmd/roachtest/kvbench.go
+++ b/pkg/cmd/roachtest/kvbench.go
@@ -176,7 +176,7 @@ func registerKVBench(r *testRegistry) {
 	}
 }
 
-func makeKVLoadGroup(c *cluster, numRoachNodes, numLoadNodes int) loadGroup {
+func makeKVLoadGroup(c clusterI, numRoachNodes, numLoadNodes int) loadGroup {
 	return loadGroup{
 		roachNodes: c.Range(1, numRoachNodes),
 		loadNodes:  c.Range(numRoachNodes+1, numRoachNodes+numLoadNodes),
@@ -191,7 +191,7 @@ func makeKVLoadGroup(c *cluster, numRoachNodes, numLoadNodes int) loadGroup {
 // This tool was primarily written with the objective of demonstrating the write
 // performance characteristics of using hash sharded indexes, for sequential workloads
 // which would've otherwise created a single-range hotspot.
-func runKVBench(ctx context.Context, t *test, c *cluster, b kvBenchSpec) {
+func runKVBench(ctx context.Context, t *test, c clusterI, b kvBenchSpec) {
 	loadGroup := makeKVLoadGroup(c, b.Nodes, 1)
 	roachNodes := loadGroup.roachNodes
 	loadNodes := loadGroup.loadNodes

--- a/pkg/cmd/roachtest/ledger.go
+++ b/pkg/cmd/roachtest/ledger.go
@@ -22,7 +22,7 @@ func registerLedger(r *testRegistry) {
 		Name:    fmt.Sprintf("ledger/nodes=%d/multi-az", nodes),
 		Owner:   OwnerKV,
 		Cluster: makeClusterSpec(nodes+1, cpu(16), geo(), zones(azs)),
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			roachNodes := c.Range(1, nodes)
 			gatewayNodes := c.Range(1, nodes/3)
 			loadNode := c.Node(nodes + 1)

--- a/pkg/cmd/roachtest/libpq.go
+++ b/pkg/cmd/roachtest/libpq.go
@@ -44,7 +44,7 @@ func registerLibPQ(r *testRegistry) {
 
 		t.Status("cloning lib/pq and installing prerequisites")
 		latestTag, err := repeatGetLatestTag(
-			ctx, c, "lib", "pq", libPQReleaseTagRegex)
+			ctx, t, "lib", "pq", libPQReleaseTagRegex)
 		require.NoError(t, err)
 		c.l.Printf("Latest lib/pq release is %s.", latestTag)
 		c.l.Printf("Supported lib/pq release is %s.", libPQSupportedTag)
@@ -60,20 +60,20 @@ func registerLibPQ(r *testRegistry) {
 
 		// Remove any old lib/pq installations
 		err = repeatRunE(
-			ctx, c, node, "remove old lib/pq", fmt.Sprintf("rm -rf %s", libPQPath),
+			ctx, t, c, node, "remove old lib/pq", fmt.Sprintf("rm -rf %s", libPQPath),
 		)
 		require.NoError(t, err)
 
 		// Install go-junit-report to convert test results to .xml format we know
 		// how to work with.
-		err = repeatRunE(ctx, c, node, "install go-junit-report",
+		err = repeatRunE(ctx, t, c, node, "install go-junit-report",
 			fmt.Sprintf("GOPATH=%s go get -u github.com/jstemmer/go-junit-report", goPath),
 		)
 		require.NoError(t, err)
 
 		err = repeatGitCloneE(
 			ctx,
-			t.l,
+			t,
 			c,
 			fmt.Sprintf("https://%s.git", libPQRepo),
 			libPQPath,

--- a/pkg/cmd/roachtest/libpq.go
+++ b/pkg/cmd/roachtest/libpq.go
@@ -23,7 +23,7 @@ var libPQReleaseTagRegex = regexp.MustCompile(`^v(?P<major>\d+)\.(?P<minor>\d+)\
 var libPQSupportedTag = "v1.10.0"
 
 func registerLibPQ(r *testRegistry) {
-	runLibPQ := func(ctx context.Context, t *test, c *cluster) {
+	runLibPQ := func(ctx context.Context, t *test, c clusterI) {
 		if c.isLocal() {
 			t.Fatal("cannot be run in local mode")
 		}
@@ -46,8 +46,8 @@ func registerLibPQ(r *testRegistry) {
 		latestTag, err := repeatGetLatestTag(
 			ctx, t, "lib", "pq", libPQReleaseTagRegex)
 		require.NoError(t, err)
-		c.l.Printf("Latest lib/pq release is %s.", latestTag)
-		c.l.Printf("Supported lib/pq release is %s.", libPQSupportedTag)
+		t.l.Printf("Latest lib/pq release is %s.", latestTag)
+		t.l.Printf("Supported lib/pq release is %s.", libPQSupportedTag)
 
 		installGolang(ctx, t, c, node)
 
@@ -87,7 +87,7 @@ func registerLibPQ(r *testRegistry) {
 		if expectedFailures == nil {
 			t.Fatalf("No lib/pq blocklist defined for cockroach version %s", version)
 		}
-		c.l.Printf("Running cockroach version %s, using blocklist %s, using ignorelist %s", version, blocklistName, ignorelistName)
+		t.l.Printf("Running cockroach version %s, using blocklist %s, using ignorelist %s", version, blocklistName, ignorelistName)
 
 		t.Status("running lib/pq test suite and collecting results")
 

--- a/pkg/cmd/roachtest/liquibase.go
+++ b/pkg/cmd/roachtest/liquibase.go
@@ -39,14 +39,14 @@ func registerLiquibase(r *testRegistry) {
 		}
 
 		if err := repeatRunE(
-			ctx, c, node, "update apt-get", `sudo apt-get -qq update`,
+			ctx, t, c, node, "update apt-get", `sudo apt-get -qq update`,
 		); err != nil {
 			t.Fatal(err)
 		}
 
 		t.Status("cloning liquibase test harness and installing prerequisites")
 		if err := repeatRunE(
-			ctx, c, node, "update apt-get", `sudo apt-get -qq update`,
+			ctx, t, c, node, "update apt-get", `sudo apt-get -qq update`,
 		); err != nil {
 			t.Fatal(err)
 		}
@@ -54,6 +54,7 @@ func registerLiquibase(r *testRegistry) {
 		// TODO(rafi): use openjdk-11-jdk-headless once we are off of Ubuntu 16.
 		if err := repeatRunE(
 			ctx,
+			t,
 			c,
 			node,
 			"install dependencies",
@@ -63,7 +64,7 @@ func registerLiquibase(r *testRegistry) {
 		}
 
 		if err := repeatRunE(
-			ctx, c, node, "remove old liquibase test harness",
+			ctx, t, c, node, "remove old liquibase test harness",
 			`rm -rf /mnt/data1/liquibase-test-harness`,
 		); err != nil {
 			t.Fatal(err)
@@ -71,7 +72,7 @@ func registerLiquibase(r *testRegistry) {
 
 		if err := repeatGitCloneE(
 			ctx,
-			t.l,
+			t,
 			c,
 			"https://github.com/liquibase/liquibase-test-harness.git",
 			"/mnt/data1/liquibase-test-harness",

--- a/pkg/cmd/roachtest/liquibase.go
+++ b/pkg/cmd/roachtest/liquibase.go
@@ -19,7 +19,7 @@ func registerLiquibase(r *testRegistry) {
 	runLiquibase := func(
 		ctx context.Context,
 		t *test,
-		c *cluster,
+		c clusterI,
 	) {
 		if c.isLocal() {
 			t.Fatal("cannot be run in local mode")
@@ -106,7 +106,7 @@ func registerLiquibase(r *testRegistry) {
 		Owner:      OwnerSQLExperience,
 		Cluster:    makeClusterSpec(1),
 		Tags:       []string{`default`, `tool`},
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			runLiquibase(ctx, t, c)
 		},
 	})

--- a/pkg/cmd/roachtest/many_splits.go
+++ b/pkg/cmd/roachtest/many_splits.go
@@ -17,9 +17,9 @@ import (
 
 // runManySplits attempts to create 2000 tiny ranges on a 4-node cluster using
 // left-to-right splits and check the cluster is still live afterwards.
-func runManySplits(ctx context.Context, t *test, c *cluster) {
+func runManySplits(ctx context.Context, t *test, c clusterI) {
 	// Randomize starting with encryption-at-rest enabled.
-	c.encryptAtRandom = true
+	c.EncryptAtRandom(true)
 	args := startArgs("--env=COCKROACH_SCAN_MAX_IDLE_TIME=5ms")
 	c.Put(ctx, cockroach, "./cockroach")
 	c.Start(ctx, t, args)

--- a/pkg/cmd/roachtest/mixed_version_decommission.go
+++ b/pkg/cmd/roachtest/mixed_version_decommission.go
@@ -24,7 +24,7 @@ import (
 // runDecommissionMixedVersions runs through randomized
 // decommission/recommission processes in mixed-version clusters.
 func runDecommissionMixedVersions(
-	ctx context.Context, t *test, c *cluster, buildVersion version.Version,
+	ctx context.Context, t *test, c clusterI, buildVersion version.Version,
 ) {
 	predecessorVersion, err := PredecessorVersion(buildVersion)
 	if err != nil {

--- a/pkg/cmd/roachtest/mixed_version_jobs.go
+++ b/pkg/cmd/roachtest/mixed_version_jobs.go
@@ -224,7 +224,7 @@ FROM [SHOW JOBS] WHERE status = $1 OR status = $2`,
 }
 
 func runJobsMixedVersions(
-	ctx context.Context, t *test, c *cluster, warehouses int, predecessorVersion string,
+	ctx context.Context, t *test, c clusterI, warehouses int, predecessorVersion string,
 ) {
 	// An empty string means that the cockroach binary specified by flag
 	// `cockroach` will be used.
@@ -333,7 +333,7 @@ func registerJobsMixedVersions(r *testRegistry) {
 		MinVersion: "v20.1.0",
 		Skip:       "https://github.com/cockroachdb/cockroach/issues/57230",
 		Cluster:    makeClusterSpec(4),
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			predV, err := PredecessorVersion(r.buildVersion)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/cmd/roachtest/mixed_version_schemachange.go
+++ b/pkg/cmd/roachtest/mixed_version_schemachange.go
@@ -26,7 +26,7 @@ func registerSchemaChangeMixedVersions(r *testRegistry) {
 		// order to prevent bugs during upgrades.
 		MinVersion: "v20.1.0",
 		Cluster:    makeClusterSpec(4),
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			maxOps := 100
 			concurrency := 5
 			if local {
@@ -71,7 +71,7 @@ func runSchemaChangeWorkloadStep(loadNode, maxOps, concurrency int) versionStep 
 func runSchemaChangeMixedVersions(
 	ctx context.Context,
 	t *test,
-	c *cluster,
+	c clusterI,
 	maxOps int,
 	concurrency int,
 	buildVersion version.Version,

--- a/pkg/cmd/roachtest/mixed_version_schemachange.go
+++ b/pkg/cmd/roachtest/mixed_version_schemachange.go
@@ -62,7 +62,7 @@ func runSchemaChangeWorkloadStep(loadNode, maxOps, concurrency int) versionStep 
 			"--tolerate-errors=true",
 			fmt.Sprintf("--max-ops %d", maxOps),
 			fmt.Sprintf("--concurrency %d", concurrency),
-			fmt.Sprintf("{pgurl:1-%d}", u.c.spec.NodeCount),
+			fmt.Sprintf("{pgurl:1-%d}", u.c.Spec().NodeCount),
 		}
 		u.c.Run(ctx, u.c.Node(loadNode), runCmd...)
 	}

--- a/pkg/cmd/roachtest/multitenant.go
+++ b/pkg/cmd/roachtest/multitenant.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func runAcceptanceMultitenant(ctx context.Context, t *test, c *cluster) {
+func runAcceptanceMultitenant(ctx context.Context, t *test, c clusterI) {
 	c.Put(ctx, cockroach, "./cockroach")
 
 	c.Start(ctx, t, c.All())

--- a/pkg/cmd/roachtest/multitenant_upgrade.go
+++ b/pkg/cmd/roachtest/multitenant_upgrade.go
@@ -53,7 +53,7 @@ type tenantNode struct {
 func createTenantNode(
 	ctx context.Context,
 	t *test,
-	c *cluster,
+	c clusterI,
 	binary string,
 	kvAddrs []string,
 	tenantID int,
@@ -72,7 +72,7 @@ func createTenantNode(
 	return tn
 }
 
-func (tn *tenantNode) stop(ctx context.Context, t *test, c *cluster) {
+func (tn *tenantNode) stop(ctx context.Context, t *test, c clusterI) {
 	if tn.errCh == nil {
 		return
 	}
@@ -88,7 +88,7 @@ func (tn *tenantNode) logDir() string {
 	return fmt.Sprintf("logs/mt-%d", tn.tenantID)
 }
 
-func (tn *tenantNode) start(ctx context.Context, t *test, c *cluster, binary string) {
+func (tn *tenantNode) start(ctx context.Context, t *test, c clusterI, binary string) {
 	tn.binary = binary
 	tn.errCh = startTenantServer(
 		ctx, c, c.Node(tn.node), binary, tn.kvAddrs, tn.tenantID,
@@ -128,7 +128,7 @@ func (tn *tenantNode) start(ctx context.Context, t *test, c *cluster, binary str
 		t.Fatal(err)
 	}
 
-	c.l.Printf("sql server for tenant %d running at %s", tn.tenantID, tn.pgURL)
+	t.l.Printf("sql server for tenant %d running at %s", tn.tenantID, tn.pgURL)
 }
 
 // runMultiTenantUpgrade exercises upgrading tenants and their host cluster.
@@ -406,7 +406,7 @@ func runMultiTenantUpgrade(ctx context.Context, t *test, c *cluster, v version.V
 
 func startTenantServer(
 	tenantCtx context.Context,
-	c *cluster,
+	c clusterI,
 	node nodeListOption,
 	binary string,
 	kvAddrs []string,

--- a/pkg/cmd/roachtest/multitenant_upgrade.go
+++ b/pkg/cmd/roachtest/multitenant_upgrade.go
@@ -32,7 +32,7 @@ func registerMultiTenantUpgrade(r *testRegistry) {
 		Cluster:           makeClusterSpec(2),
 		Owner:             OwnerKV,
 		NonReleaseBlocker: false,
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			runMultiTenantUpgrade(ctx, t, c, r.buildVersion)
 		},
 	})
@@ -154,7 +154,7 @@ func (tn *tenantNode) start(ctx context.Context, t *test, c clusterI, binary str
 //  * Tenant12{Binary: Cur, Cluster: Cur}: Restart tenant 13 and make sure it still works.
 //  * Tenant14{Binary: Cur, Cluster: Cur}: Create tenant 14 and verify it works.
 //  * Tenant12{Binary: Cur, Cluster: Cur}: Restart tenant 14 and make sure it still works.
-func runMultiTenantUpgrade(ctx context.Context, t *test, c *cluster, v version.Version) {
+func runMultiTenantUpgrade(ctx context.Context, t *test, c clusterI, v version.Version) {
 	predecessor, err := PredecessorVersion(v)
 	require.NoError(t, err)
 

--- a/pkg/cmd/roachtest/network.go
+++ b/pkg/cmd/roachtest/network.go
@@ -25,9 +25,9 @@ import (
 // runNetworkSanity is just a sanity check to make sure we're setting up toxiproxy
 // correctly. It injects latency between the nodes and verifies that we're not
 // seeing the latency on the client connection running `SELECT 1` on each node.
-func runNetworkSanity(ctx context.Context, t *test, origC *cluster, nodes int) {
+func runNetworkSanity(ctx context.Context, t *test, origC clusterI, nodes int) {
 	origC.Put(ctx, cockroach, "./cockroach", origC.All())
-	c, err := Toxify(ctx, origC, origC.All())
+	c, err := Toxify(ctx, t, origC, origC.All())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -63,7 +63,7 @@ func runNetworkSanity(ctx context.Context, t *test, origC *cluster, nodes int) {
 		}
 	}
 
-	m := newMonitor(ctx, c.cluster, c.All())
+	m := newMonitor(ctx, c.clusterI, c.All())
 	m.Go(func(ctx context.Context) error {
 		c.Measure(ctx, 1, `SET CLUSTER SETTING trace.debug.enable = true`)
 		c.Measure(ctx, 1, "CREATE DATABASE test")
@@ -74,7 +74,7 @@ func runNetworkSanity(ctx context.Context, t *test, origC *cluster, nodes int) {
 				"BEGIN; INSERT INTO test.commit VALUES (2, %[1]d), (1, %[1]d), (3, %[1]d); COMMIT",
 				i,
 			))
-			c.l.Printf("%s\n", duration)
+			t.l.Printf("%s\n", duration)
 		}
 
 		c.Measure(ctx, 1, `
@@ -83,7 +83,7 @@ insert into test.commit values(3,1000), (1,1000), (2,1000);
 select age, message from [ show trace for session ];
 `)
 
-		for i := 1; i <= origC.spec.NodeCount; i++ {
+		for i := 1; i <= origC.Spec().NodeCount; i++ {
 			if dur := c.Measure(ctx, i, `SELECT 1`); dur > latency {
 				t.Fatalf("node %d unexpectedly affected by latency: select 1 took %.2fs", i, dur.Seconds())
 			}
@@ -95,13 +95,13 @@ select age, message from [ show trace for session ];
 	m.Wait()
 }
 
-func runNetworkTPCC(ctx context.Context, t *test, origC *cluster, nodes int) {
-	n := origC.spec.NodeCount
+func runNetworkTPCC(ctx context.Context, t *test, origC clusterI, nodes int) {
+	n := origC.Spec().NodeCount
 	serverNodes, workerNode := origC.Range(1, n-1), origC.Node(n)
 	origC.Put(ctx, cockroach, "./cockroach", origC.All())
 	origC.Put(ctx, workload, "./workload", origC.All())
 
-	c, err := Toxify(ctx, origC, serverNodes)
+	c, err := Toxify(ctx, t, origC, serverNodes)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -122,7 +122,7 @@ func runNetworkTPCC(ctx context.Context, t *test, origC *cluster, nodes int) {
 	}
 
 	// Run TPCC, but don't give it the first node (or it basically won't do anything).
-	m := newMonitor(ctx, c.cluster, serverNodes)
+	m := newMonitor(ctx, c.clusterI, serverNodes)
 
 	m.Go(func(ctx context.Context) error {
 		t.WorkerStatus("running tpcc")
@@ -131,7 +131,7 @@ func runNetworkTPCC(ctx context.Context, t *test, origC *cluster, nodes int) {
 			"./workload run tpcc --warehouses=%d --wait=false"+
 				" --histograms="+perfArtifactsDir+"/stats.json"+
 				" --duration=%s {pgurl:2-%d}",
-			warehouses, duration, c.spec.NodeCount-1)
+			warehouses, duration, c.Spec().NodeCount-1)
 		return c.RunE(ctx, workerNode, cmd)
 	})
 
@@ -180,7 +180,7 @@ func runNetworkTPCC(ctx context.Context, t *test, origC *cluster, nodes int) {
 		// both the "upstream" and "downstream" directions, this is in fact an asymmetric partition since
 		// it only affects connections *to* the node. n1 itself can connect to the cluster just fine.
 		proxy := c.Proxy(1)
-		c.l.Printf("letting inbound traffic to first node time out")
+		t.l.Printf("letting inbound traffic to first node time out")
 		for _, direction := range []string{"upstream", "downstream"} {
 			if _, err := proxy.AddToxic("", "timeout", direction, 1, toxiproxy.Attributes{
 				"timeout": 0, // forever
@@ -195,13 +195,13 @@ func runNetworkTPCC(ctx context.Context, t *test, origC *cluster, nodes int) {
 		for {
 			cur := checkGoroutines(ctx)
 			if maxSeen < cur {
-				c.l.Printf("new goroutine peak: %d", cur)
+				t.l.Printf("new goroutine peak: %d", cur)
 				maxSeen = cur
 			}
 
 			select {
 			case <-done:
-				c.l.Printf("done checking goroutines, repairing network")
+				t.l.Printf("done checking goroutines, repairing network")
 				// Repair the network. Note that the TPCC workload would never
 				// finish (despite the duration) without this. In particular,
 				// we don't want to m.Wait() before we do this.
@@ -214,12 +214,12 @@ func runNetworkTPCC(ctx context.Context, t *test, origC *cluster, nodes int) {
 						t.Fatal(err)
 					}
 				}
-				c.l.Printf("network is repaired")
+				t.l.Printf("network is repaired")
 
 				// Verify that goroutine count doesn't spike.
 				for i := 0; i < 20; i++ {
 					nowGoroutines := checkGoroutines(ctx)
-					c.l.Printf("currently at most %d goroutines per node", nowGoroutines)
+					t.l.Printf("currently at most %d goroutines per node", nowGoroutines)
 					time.Sleep(time.Second)
 				}
 
@@ -240,7 +240,7 @@ func registerNetwork(r *testRegistry) {
 		Name:    fmt.Sprintf("network/sanity/nodes=%d", numNodes),
 		Owner:   OwnerKV,
 		Cluster: makeClusterSpec(numNodes),
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			runNetworkSanity(ctx, t, c, numNodes)
 		},
 	})
@@ -270,7 +270,7 @@ there to resolve the partition when the test aborts prematurely. (And the
 command to resolve the partition should not be sensitive to the test
 context's Done() channel, because during a tear-down that is closed already)
 `,
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			runNetworkTPCC(ctx, t, c, numNodes)
 		},
 	})

--- a/pkg/cmd/roachtest/nodejs_postgres.go
+++ b/pkg/cmd/roachtest/nodejs_postgres.go
@@ -30,7 +30,7 @@ func registerNodeJSPostgres(r *testRegistry) {
 	runNodeJSPostgres := func(
 		ctx context.Context,
 		t *test,
-		c *cluster,
+		c clusterI,
 	) {
 		if c.isLocal() {
 			t.Fatal("cannot be run in local mode")
@@ -161,7 +161,7 @@ PGSSLCERT=%s/client.%s.crt PGSSLKEY=%s/client.%s.key PGSSLROOTCERT=%s/ca.crt yar
 			),
 		)
 		rawResultsStr := string(rawResults)
-		c.l.Printf("Test Results: %s", rawResultsStr)
+		t.l.Printf("Test Results: %s", rawResultsStr)
 		if err != nil {
 			// The one failing test is `pool size of 1` which
 			// fails because it does SELECT count(*) FROM pg_stat_activity which is
@@ -184,7 +184,7 @@ PGSSLCERT=%s/client.%s.crt PGSSLKEY=%s/client.%s.key PGSSLROOTCERT=%s/ca.crt yar
 		Cluster:    makeClusterSpec(1),
 		MinVersion: "v20.1.0",
 		Tags:       []string{`default`, `driver`},
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			runNodeJSPostgres(ctx, t, c)
 		},
 	})

--- a/pkg/cmd/roachtest/nodejs_postgres.go
+++ b/pkg/cmd/roachtest/nodejs_postgres.go
@@ -47,19 +47,19 @@ func registerNodeJSPostgres(r *testRegistry) {
 		localCertsDir, err := filepathAbs("./certs")
 		require.NoError(t, err)
 
-		err = repeatRunE(ctx, c, node, "create sql user",
+		err = repeatRunE(ctx, t, c, node, "create sql user",
 			fmt.Sprintf(
 				`./cockroach sql --certs-dir %s -e "CREATE USER %s CREATEDB"`,
 				certsDir, user,
 			))
 		require.NoError(t, err)
 
-		err = repeatRunE(ctx, c, c.All(), "create user certs",
+		err = repeatRunE(ctx, t, c, c.All(), "create user certs",
 			fmt.Sprintf(`./cockroach cert create-client testuser --certs-dir %s --ca-key=%s/ca.key`,
 				certsDir, certsDir))
 		require.NoError(t, err)
 
-		err = repeatRunE(ctx, c, node, "create test database",
+		err = repeatRunE(ctx, t, c, node, "create test database",
 			fmt.Sprintf(`./cockroach sql --certs-dir %s -e "CREATE DATABASE postgres_node_test"`, certsDir),
 		)
 		require.NoError(t, err)
@@ -96,6 +96,7 @@ func registerNodeJSPostgres(r *testRegistry) {
 
 		err = repeatRunE(
 			ctx,
+			t,
 			c,
 			node,
 			"add nodesource repository",
@@ -104,33 +105,33 @@ func registerNodeJSPostgres(r *testRegistry) {
 		require.NoError(t, err)
 
 		err = repeatRunE(
-			ctx, c, node, "install nodejs and npm", `sudo apt-get -qq install nodejs`,
+			ctx, t, c, node, "install nodejs and npm", `sudo apt-get -qq install nodejs`,
 		)
 		require.NoError(t, err)
 
 		err = repeatRunE(
-			ctx, c, node, "update npm", `sudo npm i -g npm`,
+			ctx, t, c, node, "update npm", `sudo npm i -g npm`,
 		)
 		require.NoError(t, err)
 
 		err = repeatRunE(
-			ctx, c, node, "install yarn", `sudo npm i -g yarn`,
+			ctx, t, c, node, "install yarn", `sudo npm i -g yarn`,
 		)
 		require.NoError(t, err)
 
 		err = repeatRunE(
-			ctx, c, node, "install lerna", `sudo npm i --g lerna`,
+			ctx, t, c, node, "install lerna", `sudo npm i --g lerna`,
 		)
 		require.NoError(t, err)
 
 		err = repeatRunE(
-			ctx, c, node, "remove old node-postgres", `sudo rm -rf /mnt/data1/node-postgres`,
+			ctx, t, c, node, "remove old node-postgres", `sudo rm -rf /mnt/data1/node-postgres`,
 		)
 		require.NoError(t, err)
 
 		err = repeatGitCloneE(
 			ctx,
-			t.l,
+			t,
 			c,
 			fmt.Sprintf("https://github.com/%s/node-postgres.git", repoOwner),
 			"/mnt/data1/node-postgres",
@@ -141,6 +142,7 @@ func registerNodeJSPostgres(r *testRegistry) {
 
 		err = repeatRunE(
 			ctx,
+			t,
 			c,
 			node,
 			"building node-postgres",

--- a/pkg/cmd/roachtest/orm_helpers.go
+++ b/pkg/cmd/roachtest/orm_helpers.go
@@ -26,7 +26,7 @@ import (
 func alterZoneConfigAndClusterSettings(
 	ctx context.Context,
 	version string,
-	c *cluster,
+	c clusterI,
 	nodeIdx int,
 	dbConnectionParams *SecureDBConnectionParams,
 ) error {

--- a/pkg/cmd/roachtest/overload_tpcc_olap.go
+++ b/pkg/cmd/roachtest/overload_tpcc_olap.go
@@ -64,7 +64,7 @@ func (s tpccOLAPSpec) run(ctx context.Context, t *test, c *cluster) {
 				" --query-file %s"+
 				" --histograms="+perfArtifactsDir+"/stats.json "+
 				" --ramp=%s --duration=%s {pgurl:1-%d}",
-			s.Concurrency, queryFileName, rampDuration, duration, c.spec.NodeCount-1)
+			s.Concurrency, queryFileName, rampDuration, duration, c.Spec().NodeCount-1)
 		c.Run(ctx, workloadNode, cmd)
 		return nil
 	})

--- a/pkg/cmd/roachtest/overload_tpcc_olap.go
+++ b/pkg/cmd/roachtest/overload_tpcc_olap.go
@@ -42,7 +42,7 @@ type tpccOLAPSpec struct {
 	Concurrency int
 }
 
-func (s tpccOLAPSpec) run(ctx context.Context, t *test, c *cluster) {
+func (s tpccOLAPSpec) run(ctx context.Context, t *test, c clusterI) {
 	crdbNodes, workloadNode := setupTPCC(
 		ctx, t, c, tpccOptions{
 			Warehouses: s.Warehouses, SetupType: usingImport,
@@ -74,7 +74,7 @@ func (s tpccOLAPSpec) run(ctx context.Context, t *test, c *cluster) {
 
 // Check that node liveness did not fail more than maxFailures times across
 // all of the nodes.
-func verifyNodeLiveness(ctx context.Context, c *cluster, t *test, runDuration time.Duration) {
+func verifyNodeLiveness(ctx context.Context, c clusterI, t *test, runDuration time.Duration) {
 	const maxFailures = 10
 	adminURLs, err := c.ExternalAdminUIAddr(ctx, c.Node(1))
 	if err != nil {

--- a/pkg/cmd/roachtest/pebble.go
+++ b/pkg/cmd/roachtest/pebble.go
@@ -24,7 +24,7 @@ func registerPebble(r *testRegistry) {
 		pebble = "./pebble.linux"
 	}
 
-	run := func(ctx context.Context, t *test, c *cluster, size int) {
+	run := func(ctx context.Context, t *test, c clusterI, size int) {
 		c.Put(ctx, pebble, "./pebble")
 
 		const initialKeys = 10_000_000
@@ -35,11 +35,11 @@ func registerPebble(r *testRegistry) {
 		const benchDir = dataDir + "/bench"
 
 		runCmd := func(cmd string) {
-			c.l.PrintfCtx(ctx, "> %s", cmd)
-			err := c.RunL(ctx, c.l, c.All(), cmd)
-			c.l.Printf("> result: %+v", err)
+			t.l.PrintfCtx(ctx, "> %s", cmd)
+			err := c.RunL(ctx, t.l, c.All(), cmd)
+			t.l.Printf("> result: %+v", err)
 			if err := ctx.Err(); err != nil {
-				c.l.Printf("(note: incoming context was canceled: %s", err)
+				t.l.Printf("(note: incoming context was canceled: %s", err)
 			}
 			if err != nil {
 				t.Fatal(err)
@@ -84,13 +84,13 @@ func registerPebble(r *testRegistry) {
 			runCmd(fmt.Sprintf("tar cvPf profiles_%s.tar *.prof", workload))
 
 			dest := filepath.Join(t.artifactsDir, fmt.Sprintf("ycsb_%s.log", workload))
-			if err := c.Get(ctx, c.l, "ycsb.log", dest, c.All()); err != nil {
+			if err := c.Get(ctx, t.l, "ycsb.log", dest, c.All()); err != nil {
 				t.Fatal(err)
 			}
 
 			profilesName := fmt.Sprintf("profiles_%s.tar", workload)
 			dest = filepath.Join(t.artifactsDir, profilesName)
-			if err := c.Get(ctx, c.l, profilesName, dest, c.All()); err != nil {
+			if err := c.Get(ctx, t.l, profilesName, dest, c.All()); err != nil {
 				t.Fatal(err)
 			}
 
@@ -107,7 +107,7 @@ func registerPebble(r *testRegistry) {
 			MinVersion: "v20.1.0",
 			Cluster:    makeClusterSpec(5, cpu(16)),
 			Tags:       []string{"pebble"},
-			Run: func(ctx context.Context, t *test, c *cluster) {
+			Run: func(ctx context.Context, t *test, c clusterI) {
 				run(ctx, t, c, size)
 			},
 		})

--- a/pkg/cmd/roachtest/pgjdbc.go
+++ b/pkg/cmd/roachtest/pgjdbc.go
@@ -25,7 +25,7 @@ func registerPgjdbc(r *testRegistry) {
 	runPgjdbc := func(
 		ctx context.Context,
 		t *test,
-		c *cluster,
+		c clusterI,
 	) {
 		if c.isLocal() {
 			t.Fatal("cannot be run in local mode")
@@ -55,8 +55,8 @@ func registerPgjdbc(r *testRegistry) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		c.l.Printf("Latest pgjdbc release is %s.", latestTag)
-		c.l.Printf("Supported pgjdbc release is %s.", supportedPGJDBCTag)
+		t.l.Printf("Latest pgjdbc release is %s.", latestTag)
+		t.l.Printf("Supported pgjdbc release is %s.", supportedPGJDBCTag)
 
 		if err := repeatRunE(
 			ctx, t, c, node, "update apt-get", `sudo apt-get -qq update`,
@@ -134,7 +134,7 @@ func registerPgjdbc(r *testRegistry) {
 			status = fmt.Sprintf("Running cockroach version %s, using blocklist %s, using ignorelist %s",
 				version, blocklistName, ignorelistName)
 		}
-		c.l.Printf("%s", status)
+		t.l.Printf("%s", status)
 
 		t.Status("running pgjdbc test suite")
 		// Note that this is expected to return an error, since the test suite
@@ -168,7 +168,7 @@ func registerPgjdbc(r *testRegistry) {
 		output, err := repeatRunWithBuffer(
 			ctx,
 			c,
-			t.l,
+			t,
 			node,
 			"get list of test files",
 			`ls /mnt/data1/pgjdbc/pgjdbc/build/test-results/test/*.xml`,
@@ -192,7 +192,7 @@ func registerPgjdbc(r *testRegistry) {
 		Owner:      OwnerSQLExperience,
 		Cluster:    makeClusterSpec(1),
 		Tags:       []string{`default`, `driver`},
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			runPgjdbc(ctx, t, c)
 		},
 	})

--- a/pkg/cmd/roachtest/pgjdbc.go
+++ b/pkg/cmd/roachtest/pgjdbc.go
@@ -50,7 +50,7 @@ func registerPgjdbc(r *testRegistry) {
 		// Report the latest tag, but do not use it. The newest versions produces output that breaks our xml parser,
 		// and we want to pin to the working version for now.
 		latestTag, err := repeatGetLatestTag(
-			ctx, c, "pgjdbc", "pgjdbc", pgjdbcReleaseTagRegex,
+			ctx, t, "pgjdbc", "pgjdbc", pgjdbcReleaseTagRegex,
 		)
 		if err != nil {
 			t.Fatal(err)
@@ -59,7 +59,7 @@ func registerPgjdbc(r *testRegistry) {
 		c.l.Printf("Supported pgjdbc release is %s.", supportedPGJDBCTag)
 
 		if err := repeatRunE(
-			ctx, c, node, "update apt-get", `sudo apt-get -qq update`,
+			ctx, t, c, node, "update apt-get", `sudo apt-get -qq update`,
 		); err != nil {
 			t.Fatal(err)
 		}
@@ -67,6 +67,7 @@ func registerPgjdbc(r *testRegistry) {
 		// TODO(rafi): use openjdk-11-jdk-headless once we are off of Ubuntu 16.
 		if err := repeatRunE(
 			ctx,
+			t,
 			c,
 			node,
 			"install dependencies",
@@ -76,14 +77,14 @@ func registerPgjdbc(r *testRegistry) {
 		}
 
 		if err := repeatRunE(
-			ctx, c, node, "remove old pgjdbc", `rm -rf /mnt/data1/pgjdbc`,
+			ctx, t, c, node, "remove old pgjdbc", `rm -rf /mnt/data1/pgjdbc`,
 		); err != nil {
 			t.Fatal(err)
 		}
 
 		if err := repeatGitCloneE(
 			ctx,
-			t.l,
+			t,
 			c,
 			"https://github.com/pgjdbc/pgjdbc.git",
 			"/mnt/data1/pgjdbc",
@@ -97,6 +98,7 @@ func registerPgjdbc(r *testRegistry) {
 		// to override settings in build.local.properties
 		if err := repeatRunE(
 			ctx,
+			t,
 			c,
 			node,
 			"configuring tests for cockroach only",
@@ -114,6 +116,7 @@ func registerPgjdbc(r *testRegistry) {
 		// single test is invoked.
 		if err := repeatRunE(
 			ctx,
+			t,
 			c,
 			node,
 			"building pgjdbc (without tests)",
@@ -151,6 +154,7 @@ func registerPgjdbc(r *testRegistry) {
 		// Copy the individual test result files.
 		if err := repeatRunE(
 			ctx,
+			t,
 			c,
 			node,
 			"copy test result files",

--- a/pkg/cmd/roachtest/pgx.go
+++ b/pkg/cmd/roachtest/pgx.go
@@ -52,7 +52,7 @@ func registerPgx(r *testRegistry) {
 		t.Status("getting pgx")
 		if err := repeatGitCloneE(
 			ctx,
-			t.l,
+			t,
 			c,
 			"https://github.com/jackc/pgx.git",
 			"/mnt/data1/pgx",
@@ -62,7 +62,7 @@ func registerPgx(r *testRegistry) {
 			t.Fatal(err)
 		}
 
-		latestTag, err := repeatGetLatestTag(ctx, c, "jackc", "pgx", pgxReleaseTagRegex)
+		latestTag, err := repeatGetLatestTag(ctx, t, "jackc", "pgx", pgxReleaseTagRegex)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -71,7 +71,7 @@ func registerPgx(r *testRegistry) {
 
 		t.Status("installing go-junit-report")
 		if err := repeatRunE(
-			ctx, c, node, "install go-junit-report", "go get -u github.com/jstemmer/go-junit-report",
+			ctx, t, c, node, "install go-junit-report", "go get -u github.com/jstemmer/go-junit-report",
 		); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/cmd/roachtest/pgx.go
+++ b/pkg/cmd/roachtest/pgx.go
@@ -25,7 +25,7 @@ func registerPgx(r *testRegistry) {
 	runPgx := func(
 		ctx context.Context,
 		t *test,
-		c *cluster,
+		c clusterI,
 	) {
 		if c.isLocal() {
 			t.Fatal("cannot be run in local mode")
@@ -66,8 +66,8 @@ func registerPgx(r *testRegistry) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		c.l.Printf("Latest jackc/pgx release is %s.", latestTag)
-		c.l.Printf("Supported release is %s.", supportedPGXTag)
+		t.l.Printf("Latest jackc/pgx release is %s.", latestTag)
+		t.l.Printf("Supported release is %s.", supportedPGXTag)
 
 		t.Status("installing go-junit-report")
 		if err := repeatRunE(
@@ -86,7 +86,7 @@ func registerPgx(r *testRegistry) {
 			status = fmt.Sprintf("Running cockroach version %s, using blocklist %s, using ignorelist %s",
 				version, blocklistName, ignorelistName)
 		}
-		c.l.Printf("%s", status)
+		t.l.Printf("%s", status)
 
 		t.Status("setting up test db")
 		db, err := c.ConnE(ctx, node[0])
@@ -109,7 +109,7 @@ func registerPgx(r *testRegistry) {
 		t.Status("running pgx test suite")
 		// Running the test suite is expected to error out, so swallow the error.
 		xmlResults, _ := repeatRunWithBuffer(
-			ctx, c, t.l, node,
+			ctx, c, t, node,
 			"run pgx test suite",
 			"cd /mnt/data1/pgx && "+
 				"PGX_TEST_DATABASE='postgresql://root:@localhost:26257/pgx_test' go test -v 2>&1 | "+
@@ -129,7 +129,7 @@ func registerPgx(r *testRegistry) {
 		Cluster:    makeClusterSpec(1),
 		MinVersion: "v20.2.0",
 		Tags:       []string{`default`, `driver`},
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			runPgx(ctx, t, c)
 		},
 	})

--- a/pkg/cmd/roachtest/pop.go
+++ b/pkg/cmd/roachtest/pop.go
@@ -22,7 +22,7 @@ var popReleaseTag = regexp.MustCompile(`^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<po
 var popSupportedTag = "v5.3.3"
 
 func registerPop(r *testRegistry) {
-	runPop := func(ctx context.Context, t *test, c *cluster) {
+	runPop := func(ctx context.Context, t *test, c clusterI) {
 		if c.isLocal() {
 			t.Fatal("cannot be run in local mode")
 		}
@@ -44,8 +44,8 @@ func registerPop(r *testRegistry) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		c.l.Printf("Latest pop release is %s.", latestTag)
-		c.l.Printf("Supported pop release is %s.", popSupportedTag)
+		t.l.Printf("Latest pop release is %s.", latestTag)
+		t.l.Printf("Supported pop release is %s.", popSupportedTag)
 
 		installGolang(ctx, t, c, node)
 

--- a/pkg/cmd/roachtest/pop.go
+++ b/pkg/cmd/roachtest/pop.go
@@ -40,7 +40,7 @@ func registerPop(r *testRegistry) {
 
 		t.Status("cloning pop and installing prerequisites")
 		latestTag, err := repeatGetLatestTag(
-			ctx, c, "gobuffalo", "pop", popReleaseTag)
+			ctx, t, "gobuffalo", "pop", popReleaseTag)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -55,14 +55,14 @@ func registerPop(r *testRegistry) {
 
 		// Remove any old pop installations
 		if err := repeatRunE(
-			ctx, c, node, "remove old pop", fmt.Sprintf("rm -rf %s", popPath),
+			ctx, t, c, node, "remove old pop", fmt.Sprintf("rm -rf %s", popPath),
 		); err != nil {
 			t.Fatal(err)
 		}
 
 		if err := repeatGitCloneE(
 			ctx,
-			t.l,
+			t,
 			c,
 			"https://github.com/gobuffalo/pop.git",
 			popPath,

--- a/pkg/cmd/roachtest/psycopg.go
+++ b/pkg/cmd/roachtest/psycopg.go
@@ -45,7 +45,7 @@ func registerPsycopg(r *testRegistry) {
 		}
 
 		t.Status("cloning psycopg and installing prerequisites")
-		latestTag, err := repeatGetLatestTag(ctx, c, "psycopg", "psycopg2", psycopgReleaseTagRegex)
+		latestTag, err := repeatGetLatestTag(ctx, t, "psycopg", "psycopg2", psycopgReleaseTagRegex)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -53,13 +53,14 @@ func registerPsycopg(r *testRegistry) {
 		c.l.Printf("Supported Psycopg release is %s.", supportedPsycopgTag)
 
 		if err := repeatRunE(
-			ctx, c, node, "update apt-get", `sudo apt-get -qq update`,
+			ctx, t, c, node, "update apt-get", `sudo apt-get -qq update`,
 		); err != nil {
 			t.Fatal(err)
 		}
 
 		if err := repeatRunE(
 			ctx,
+			t,
 			c,
 			node,
 			"install dependencies",
@@ -69,14 +70,14 @@ func registerPsycopg(r *testRegistry) {
 		}
 
 		if err := repeatRunE(
-			ctx, c, node, "remove old Psycopg", `sudo rm -rf /mnt/data1/psycopg`,
+			ctx, t, c, node, "remove old Psycopg", `sudo rm -rf /mnt/data1/psycopg`,
 		); err != nil {
 			t.Fatal(err)
 		}
 
 		if err := repeatGitCloneE(
 			ctx,
-			t.l,
+			t,
 			c,
 			"https://github.com/psycopg/psycopg2.git",
 			"/mnt/data1/psycopg",
@@ -88,7 +89,7 @@ func registerPsycopg(r *testRegistry) {
 
 		t.Status("building Psycopg")
 		if err := repeatRunE(
-			ctx, c, node, "building Psycopg", `cd /mnt/data1/psycopg/ && make`,
+			ctx, t, c, node, "building Psycopg", `cd /mnt/data1/psycopg/ && make`,
 		); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/cmd/roachtest/psycopg.go
+++ b/pkg/cmd/roachtest/psycopg.go
@@ -23,7 +23,7 @@ func registerPsycopg(r *testRegistry) {
 	runPsycopg := func(
 		ctx context.Context,
 		t *test,
-		c *cluster,
+		c clusterI,
 	) {
 		if c.isLocal() {
 			t.Fatal("cannot be run in local mode")
@@ -49,8 +49,8 @@ func registerPsycopg(r *testRegistry) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		c.l.Printf("Latest Psycopg release is %s.", latestTag)
-		c.l.Printf("Supported Psycopg release is %s.", supportedPsycopgTag)
+		t.l.Printf("Latest Psycopg release is %s.", latestTag)
+		t.l.Printf("Supported Psycopg release is %s.", supportedPsycopgTag)
 
 		if err := repeatRunE(
 			ctx, t, c, node, "update apt-get", `sudo apt-get -qq update`,
@@ -101,7 +101,7 @@ func registerPsycopg(r *testRegistry) {
 		if ignoredlist == nil {
 			t.Fatalf("No psycopg ignorelist defined for cockroach version %s", version)
 		}
-		c.l.Printf("Running cockroach version %s, using blocklist %s, using ignoredlist %s",
+		t.l.Printf("Running cockroach version %s, using blocklist %s, using ignoredlist %s",
 			version, blocklistName, ignoredlistName)
 
 		t.Status("running psycopg test suite")
@@ -117,7 +117,7 @@ func registerPsycopg(r *testRegistry) {
 		)
 
 		t.Status("collating the test results")
-		c.l.Printf("Test Results: %s", rawResults)
+		t.l.Printf("Test Results: %s", rawResults)
 
 		// Find all the failed and errored tests.
 		results := newORMTestsResults()
@@ -134,7 +134,7 @@ func registerPsycopg(r *testRegistry) {
 		Cluster:    makeClusterSpec(1),
 		MinVersion: "v20.2.0",
 		Tags:       []string{`default`, `driver`},
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			runPsycopg(ctx, t, c)
 		},
 	})

--- a/pkg/cmd/roachtest/queue.go
+++ b/pkg/cmd/roachtest/queue.go
@@ -34,8 +34,8 @@ func registerQueue(r *testRegistry) {
 }
 
 func runQueue(ctx context.Context, t *test, c *cluster) {
-	dbNodeCount := c.spec.NodeCount - 1
-	workloadNode := c.spec.NodeCount
+	dbNodeCount := c.Spec().NodeCount - 1
+	workloadNode := c.Spec().NodeCount
 
 	// Distribute programs to the correct nodes and start CockroachDB.
 	c.Put(ctx, cockroach, "./cockroach", c.Range(1, dbNodeCount))

--- a/pkg/cmd/roachtest/queue.go
+++ b/pkg/cmd/roachtest/queue.go
@@ -27,13 +27,13 @@ func registerQueue(r *testRegistry) {
 		Name:    fmt.Sprintf("queue/nodes=%d", numNodes-1),
 		Owner:   OwnerKV,
 		Cluster: makeClusterSpec(numNodes),
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			runQueue(ctx, t, c)
 		},
 	})
 }
 
-func runQueue(ctx context.Context, t *test, c *cluster) {
+func runQueue(ctx context.Context, t *test, c clusterI) {
 	dbNodeCount := c.Spec().NodeCount - 1
 	workloadNode := c.Spec().NodeCount
 

--- a/pkg/cmd/roachtest/quit.go
+++ b/pkg/cmd/roachtest/quit.go
@@ -80,7 +80,7 @@ func (q *quitTest) runTest(
 	q.t.l.Printf("now running restart loop\n")
 	for i := 0; i < 3; i++ {
 		q.t.l.Printf("iteration %d\n", i)
-		for nodeID := 1; nodeID <= q.c.spec.NodeCount; nodeID++ {
+		for nodeID := 1; nodeID <= q.c.Spec().NodeCount; nodeID++ {
 			q.t.l.Printf("stopping node %d\n", nodeID)
 			q.runWithTimeout(ctx, func(ctx context.Context) { method(ctx, q.t, q.c, nodeID) })
 			q.runWithTimeout(ctx, func(ctx context.Context) { q.checkNoLeases(ctx, nodeID) })
@@ -192,7 +192,7 @@ ALTER TABLE t SPLIT AT TABLE generate_series(%[1]d,%[1]d-99,-1)`, i)); err != ni
 func (q *quitTest) checkNoLeases(ctx context.Context, nodeID int) {
 	// We need to use SQL against a node that's not the one we're
 	// shutting down.
-	otherNodeID := 1 + nodeID%q.c.spec.NodeCount
+	otherNodeID := 1 + nodeID%q.c.Spec().NodeCount
 
 	// Now we're going to check two things:
 	//
@@ -226,7 +226,7 @@ func (q *quitTest) checkNoLeases(ctx context.Context, nodeID int) {
 		// For condition (2) we accumulate the unwanted leases in
 		// invLeaseMap, then check at the end that the map is empty.
 		invLeaseMap := map[int][]string{}
-		for i := 1; i <= q.c.spec.NodeCount; i++ {
+		for i := 1; i <= q.c.Spec().NodeCount; i++ {
 			if i == nodeID {
 				// Can't request this node. Ignore.
 				continue

--- a/pkg/cmd/roachtest/quit.go
+++ b/pkg/cmd/roachtest/quit.go
@@ -26,7 +26,7 @@ import (
 
 type quitTest struct {
 	t    *test
-	c    *cluster
+	c    clusterI
 	args option
 }
 
@@ -37,9 +37,9 @@ type quitTest struct {
 func runQuitTransfersLeases(
 	ctx context.Context,
 	t *test,
-	c *cluster,
+	c clusterI,
 	methodName string,
-	method func(ctx context.Context, t *test, c *cluster, nodeID int),
+	method func(ctx context.Context, t *test, c clusterI, nodeID int),
 ) {
 	q := quitTest{t: t, c: c}
 	q.init(ctx)
@@ -64,7 +64,7 @@ func (q *quitTest) Fatalf(format string, args ...interface{}) {
 }
 
 func (q *quitTest) runTest(
-	ctx context.Context, method func(ctx context.Context, t *test, c *cluster, nodeID int),
+	ctx context.Context, method func(ctx context.Context, t *test, c clusterI, nodeID int),
 ) {
 	q.waitForUpReplication(ctx)
 	q.createRanges(ctx)
@@ -334,13 +334,13 @@ func (q *quitTest) checkNoLeases(ctx context.Context, nodeID int) {
 }
 
 func registerQuitTransfersLeases(r *testRegistry) {
-	registerTest := func(name, minver string, method func(context.Context, *test, *cluster, int)) {
+	registerTest := func(name, minver string, method func(context.Context, *test, clusterI, int)) {
 		r.Add(testSpec{
 			Name:       fmt.Sprintf("transfer-leases/%s", name),
 			Owner:      OwnerKV,
 			Cluster:    makeClusterSpec(3),
 			MinVersion: minver,
-			Run: func(ctx context.Context, t *test, c *cluster) {
+			Run: func(ctx context.Context, t *test, c clusterI) {
 				runQuitTransfersLeases(ctx, t, c, name, method)
 			},
 		})
@@ -348,7 +348,7 @@ func registerQuitTransfersLeases(r *testRegistry) {
 
 	// Uses 'roachprod stop --sig 15 --wait', ie send SIGTERM and wait
 	// until the process exits.
-	registerTest("signal", "v19.2.0", func(ctx context.Context, t *test, c *cluster, nodeID int) {
+	registerTest("signal", "v19.2.0", func(ctx context.Context, t *test, c clusterI, nodeID int) {
 		c.Stop(ctx, c.Node(nodeID),
 			roachprodArgOption{"--sig", "15", "--wait"}, // graceful shutdown
 		)
@@ -356,14 +356,14 @@ func registerQuitTransfersLeases(r *testRegistry) {
 
 	// Uses 'cockroach quit' which should drain and then request a
 	// shutdown. It then waits for the process to self-exit.
-	registerTest("quit", "v19.2.0", func(ctx context.Context, t *test, c *cluster, nodeID int) {
+	registerTest("quit", "v19.2.0", func(ctx context.Context, t *test, c clusterI, nodeID int) {
 		_ = runQuit(ctx, t, c, nodeID)
 	})
 
 	// Uses 'cockroach drain', followed by a non-graceful process
 	// kill. If the drain is successful, the leases are transferred
 	// successfully even if if the process terminates non-gracefully.
-	registerTest("drain", "v20.1.0", func(ctx context.Context, t *test, c *cluster, nodeID int) {
+	registerTest("drain", "v20.1.0", func(ctx context.Context, t *test, c clusterI, nodeID int) {
 		buf, err := c.RunWithBuffer(ctx, t.l, c.Node(nodeID),
 			"./cockroach", "node", "drain", "--insecure", "--logtostderr=INFO",
 			fmt.Sprintf("--port={pgport:%d}", nodeID),
@@ -395,7 +395,7 @@ func registerQuitTransfersLeases(r *testRegistry) {
 	})
 }
 
-func runQuit(ctx context.Context, t *test, c *cluster, nodeID int, extraArgs ...string) []byte {
+func runQuit(ctx context.Context, t *test, c clusterI, nodeID int, extraArgs ...string) []byte {
 	args := append([]string{
 		"./cockroach", "quit", "--insecure", "--logtostderr=INFO",
 		fmt.Sprintf("--port={pgport:%d}", nodeID)},
@@ -420,7 +420,7 @@ func registerQuitAllNodes(r *testRegistry) {
 		Owner:      OwnerServer,
 		Cluster:    makeClusterSpec(5),
 		MinVersion: "v20.1.0",
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			q := quitTest{t: t, c: c}
 
 			// Start the cluster.

--- a/pkg/cmd/roachtest/rapid_restart.go
+++ b/pkg/cmd/roachtest/rapid_restart.go
@@ -23,7 +23,7 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-func runRapidRestart(ctx context.Context, t *test, c *cluster) {
+func runRapidRestart(ctx context.Context, t *test, c clusterI) {
 	// Use a single-node cluster which speeds the stop/start cycle.
 	nodes := c.Node(1)
 	c.Put(ctx, cockroach, "./cockroach", nodes)

--- a/pkg/cmd/roachtest/rebalance_load.go
+++ b/pkg/cmd/roachtest/rebalance_load.go
@@ -42,7 +42,7 @@ func registerRebalanceLoad(r *testRegistry) {
 	rebalanceLoadRun := func(
 		ctx context.Context,
 		t *test,
-		c *cluster,
+		c clusterI,
 		rebalanceMode string,
 		maxDuration time.Duration,
 		concurrency int,
@@ -130,7 +130,7 @@ func registerRebalanceLoad(r *testRegistry) {
 		Owner:      OwnerKV,
 		Cluster:    makeClusterSpec(4), // the last node is just used to generate load
 		MinVersion: "v2.1.0",
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			if local {
 				concurrency = 32
 				fmt.Printf("lowering concurrency to %d in local testing\n", concurrency)
@@ -143,7 +143,7 @@ func registerRebalanceLoad(r *testRegistry) {
 		Owner:      OwnerKV,
 		Cluster:    makeClusterSpec(7), // the last node is just used to generate load
 		MinVersion: "v2.1.0",
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			if local {
 				concurrency = 32
 				fmt.Printf("lowering concurrency to %d in local testing\n", concurrency)

--- a/pkg/cmd/roachtest/rebalance_load.go
+++ b/pkg/cmd/roachtest/rebalance_load.go
@@ -47,8 +47,8 @@ func registerRebalanceLoad(r *testRegistry) {
 		maxDuration time.Duration,
 		concurrency int,
 	) {
-		roachNodes := c.Range(1, c.spec.NodeCount-1)
-		appNode := c.Node(c.spec.NodeCount)
+		roachNodes := c.Range(1, c.Spec().NodeCount-1)
+		appNode := c.Node(c.Spec().NodeCount)
 		splits := len(roachNodes) - 1 // n-1 splits => n ranges => 1 lease per node
 
 		c.Put(ctx, cockroach, "./cockroach", roachNodes)

--- a/pkg/cmd/roachtest/replicagc.go
+++ b/pkg/cmd/roachtest/replicagc.go
@@ -26,7 +26,7 @@ func registerReplicaGC(r *testRegistry) {
 			Name:    fmt.Sprintf("replicagc-changed-peers/restart=%t", restart),
 			Owner:   OwnerKV,
 			Cluster: makeClusterSpec(6),
-			Run: func(ctx context.Context, t *test, c *cluster) {
+			Run: func(ctx context.Context, t *test, c clusterI) {
 				runReplicaGCChangedPeers(ctx, t, c, restart)
 			},
 		})
@@ -46,7 +46,7 @@ var deadNodeAttr = "deadnode"
 // replicas off of them, and after having done so, it recommissions the downed
 // node. It expects the downed node to discover the new replica placement and gc
 // its replicas.
-func runReplicaGCChangedPeers(ctx context.Context, t *test, c *cluster, withRestart bool) {
+func runReplicaGCChangedPeers(ctx context.Context, t *test, c clusterI, withRestart bool) {
 	if c.Spec().NodeCount != 6 {
 		t.Fatal("test needs to be run with 6 nodes")
 	}
@@ -138,7 +138,7 @@ func runReplicaGCChangedPeers(ctx context.Context, t *test, c *cluster, withRest
 
 type replicagcTestHelper struct {
 	t *test
-	c *cluster
+	c clusterI
 }
 
 func (h *replicagcTestHelper) waitForFullReplication(ctx context.Context) {
@@ -190,7 +190,7 @@ func (h *replicagcTestHelper) numReplicas(ctx context.Context, db *gosql.DB, tar
 	).Scan(&n); err != nil {
 		h.t.Fatal(err)
 	}
-	h.c.l.Printf("found %d replicas found on n%d\n", n, targetNode)
+	h.t.l.Printf("found %d replicas found on n%d\n", n, targetNode)
 	return n
 }
 
@@ -236,7 +236,7 @@ func (h *replicagcTestHelper) isolateDeadNodes(ctx context.Context, runNode int)
 		"RANGE default", "RANGE meta", "RANGE system", "RANGE liveness", "DATABASE system", "TABLE system.jobs",
 	} {
 		stmt := `ALTER ` + change + ` CONFIGURE ZONE = 'constraints: {"-` + deadNodeAttr + `"}'`
-		h.c.l.Printf(stmt + "\n")
+		h.t.l.Printf(stmt + "\n")
 		if _, err := db.ExecContext(ctx, stmt); err != nil {
 			h.t.Fatal(err)
 		}

--- a/pkg/cmd/roachtest/replicagc.go
+++ b/pkg/cmd/roachtest/replicagc.go
@@ -47,7 +47,7 @@ var deadNodeAttr = "deadnode"
 // node. It expects the downed node to discover the new replica placement and gc
 // its replicas.
 func runReplicaGCChangedPeers(ctx context.Context, t *test, c *cluster, withRestart bool) {
-	if c.spec.NodeCount != 6 {
+	if c.Spec().NodeCount != 6 {
 		t.Fatal("test needs to be run with 6 nodes")
 	}
 

--- a/pkg/cmd/roachtest/reset_quorum.go
+++ b/pkg/cmd/roachtest/reset_quorum.go
@@ -20,7 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func runResetQuorum(ctx context.Context, t *test, c *cluster) {
+func runResetQuorum(ctx context.Context, t *test, c clusterI) {
 	skip.WithIssue(t, 58165)
 	args := func(attr string) option {
 		return startArgs(
@@ -90,7 +90,7 @@ OR
 		if buf.Len() == 0 {
 			break
 		}
-		c.l.Printf("still waiting:\n" + buf.String())
+		t.l.Printf("still waiting:\n" + buf.String())
 		time.Sleep(5 * time.Second)
 	}
 
@@ -105,7 +105,7 @@ OR
 	// Should not be able to read from it even (generously) after a lease timeout.
 	_, err = db.QueryContext(ctx, `SET statement_timeout = '15s'; SELECT * FROM lostrange;`)
 	require.Error(t, err)
-	c.l.Printf("table is now unavailable, as planned")
+	t.l.Printf("table is now unavailable, as planned")
 
 	const nodeID = 1 // where to put the replica, matches node number in roachtest
 	for rangeID := range lostRangeIDs {

--- a/pkg/cmd/roachtest/restart.go
+++ b/pkg/cmd/roachtest/restart.go
@@ -19,7 +19,7 @@ import (
 )
 
 func runRestart(ctx context.Context, t *test, c *cluster, downDuration time.Duration) {
-	crdbNodes := c.Range(1, c.spec.NodeCount)
+	crdbNodes := c.Range(1, c.Spec().NodeCount)
 	workloadNode := c.Node(1)
 	const restartNode = 3
 

--- a/pkg/cmd/roachtest/restart.go
+++ b/pkg/cmd/roachtest/restart.go
@@ -18,7 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
-func runRestart(ctx context.Context, t *test, c *cluster, downDuration time.Duration) {
+func runRestart(ctx context.Context, t *test, c clusterI, downDuration time.Duration) {
 	crdbNodes := c.Range(1, c.Spec().NodeCount)
 	workloadNode := c.Node(1)
 	const restartNode = 3
@@ -78,7 +78,7 @@ func runRestart(ctx context.Context, t *test, c *cluster, downDuration time.Dura
 	if took := timeutil.Since(start); took > downDuration {
 		t.Fatalf(`expected to recover within %s took %s`, downDuration, took)
 	} else {
-		c.l.Printf(`connecting and query finished in %s`, took)
+		t.l.Printf(`connecting and query finished in %s`, took)
 	}
 }
 
@@ -89,7 +89,7 @@ func registerRestart(r *testRegistry) {
 		Cluster: makeClusterSpec(3),
 		// "cockroach workload is only in 19.1+"
 		MinVersion: "v19.1.0",
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			runRestart(ctx, t, c, 2*time.Minute)
 		},
 	})

--- a/pkg/cmd/roachtest/restore.go
+++ b/pkg/cmd/roachtest/restore.go
@@ -188,7 +188,7 @@ func (dul *DiskUsageLogger) Runner(ctx context.Context) error {
 		}
 
 		var bytesUsed []usage
-		for i := 1; i <= dul.c.spec.NodeCount; i++ {
+		for i := 1; i <= dul.c.Spec().NodeCount; i++ {
 			cur, err := getDiskUsageInBytes(ctx, dul.c, quietLogger, i)
 			if err != nil {
 				// This can trigger spuriously as compactions remove files out from under `du`.

--- a/pkg/cmd/roachtest/roachmart.go
+++ b/pkg/cmd/roachtest/roachmart.go
@@ -16,7 +16,7 @@ import (
 )
 
 func registerRoachmart(r *testRegistry) {
-	runRoachmart := func(ctx context.Context, t *test, c *cluster, partition bool) {
+	runRoachmart := func(ctx context.Context, t *test, c clusterI, partition bool) {
 		c.Put(ctx, cockroach, "./cockroach")
 		c.Put(ctx, workload, "./workload")
 		c.Start(ctx, t)
@@ -67,7 +67,7 @@ func registerRoachmart(r *testRegistry) {
 			Name:    fmt.Sprintf("roachmart/partition=%v", v),
 			Owner:   OwnerKV,
 			Cluster: makeClusterSpec(9, geo(), zones("us-central1-b,us-west1-b,europe-west2-b")),
-			Run: func(ctx context.Context, t *test, c *cluster) {
+			Run: func(ctx context.Context, t *test, c clusterI) {
 				runRoachmart(ctx, t, c, v)
 			},
 		})

--- a/pkg/cmd/roachtest/ruby_pg.go
+++ b/pkg/cmd/roachtest/ruby_pg.go
@@ -56,13 +56,14 @@ func registerRubyPG(r *testRegistry) {
 		c.l.Printf("Supported ruby-pg version is %s.", rubyPGVersion)
 
 		if err := repeatRunE(
-			ctx, c, node, "update apt-get", `sudo apt-get -qq update`,
+			ctx, t, c, node, "update apt-get", `sudo apt-get -qq update`,
 		); err != nil {
 			t.Fatal(err)
 		}
 
 		if err := repeatRunE(
 			ctx,
+			t,
 			c,
 			node,
 			"install dependencies",
@@ -73,6 +74,7 @@ func registerRubyPG(r *testRegistry) {
 
 		if err := repeatRunE(
 			ctx,
+			t,
 			c,
 			node,
 			"install ruby 2.7",
@@ -86,14 +88,14 @@ func registerRubyPG(r *testRegistry) {
 		}
 
 		if err := repeatRunE(
-			ctx, c, node, "remove old ruby-pg", `sudo rm -rf /mnt/data1/ruby-pg`,
+			ctx, t, c, node, "remove old ruby-pg", `sudo rm -rf /mnt/data1/ruby-pg`,
 		); err != nil {
 			t.Fatal(err)
 		}
 
 		if err := repeatGitCloneE(
 			ctx,
-			t.l,
+			t,
 			c,
 			"https://github.com/ged/ruby-pg.git",
 			"/mnt/data1/ruby-pg",
@@ -106,6 +108,7 @@ func registerRubyPG(r *testRegistry) {
 		t.Status("installing bundler")
 		if err := repeatRunE(
 			ctx,
+			t,
 			c,
 			node,
 			"installing bundler",
@@ -117,6 +120,7 @@ func registerRubyPG(r *testRegistry) {
 		t.Status("installing gems")
 		if err := repeatRunE(
 			ctx,
+			t,
 			c,
 			node,
 			"installing gems",
@@ -126,7 +130,7 @@ func registerRubyPG(r *testRegistry) {
 		}
 
 		if err := repeatRunE(
-			ctx, c, node, "remove old ruby-pg helpers.rb", `sudo rm /mnt/data1/ruby-pg/spec/helpers.rb`,
+			ctx, t, c, node, "remove old ruby-pg helpers.rb", `sudo rm /mnt/data1/ruby-pg/spec/helpers.rb`,
 		); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/cmd/roachtest/ruby_pg.go
+++ b/pkg/cmd/roachtest/ruby_pg.go
@@ -29,7 +29,7 @@ func registerRubyPG(r *testRegistry) {
 	runRubyPGTest := func(
 		ctx context.Context,
 		t *test,
-		c *cluster,
+		c clusterI,
 	) {
 		if c.isLocal() {
 			t.Fatal("cannot be run in local mode")
@@ -53,7 +53,7 @@ func registerRubyPG(r *testRegistry) {
 
 		t.Status("cloning rails and installing prerequisites")
 
-		c.l.Printf("Supported ruby-pg version is %s.", rubyPGVersion)
+		t.l.Printf("Supported ruby-pg version is %s.", rubyPGVersion)
 
 		if err := repeatRunE(
 			ctx, t, c, node, "update apt-get", `sudo apt-get -qq update`,
@@ -136,7 +136,7 @@ func registerRubyPG(r *testRegistry) {
 		}
 
 		// Write the cockroach config into the test suite to use.
-		err = c.PutE(ctx, c.l, "./pkg/cmd/roachtest/ruby_pg_helpers.rb", "/mnt/data1/ruby-pg/spec/helpers.rb", c.All())
+		err = c.PutE(ctx, t.l, "./pkg/cmd/roachtest/ruby_pg_helpers.rb", "/mnt/data1/ruby-pg/spec/helpers.rb", c.All())
 		require.NoError(t, err)
 
 		t.Status("running ruby-pg test suite")
@@ -146,7 +146,7 @@ func registerRubyPG(r *testRegistry) {
 			`cd /mnt/data1/ruby-pg/ && sudo rake`,
 		)
 
-		c.l.Printf("Test Results:\n%s", rawResults)
+		t.l.Printf("Test Results:\n%s", rawResults)
 
 		// Find all the failed and errored tests.
 		results := newORMTestsResults()
@@ -202,7 +202,7 @@ func registerRubyPG(r *testRegistry) {
 		Owner:      OwnerSQLExperience,
 		Cluster:    makeClusterSpec(1),
 		Tags:       []string{`default`, `orm`},
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			runRubyPGTest(ctx, t, c)
 		},
 	})

--- a/pkg/cmd/roachtest/schema_change_database_version_upgrade.go
+++ b/pkg/cmd/roachtest/schema_change_database_version_upgrade.go
@@ -34,7 +34,7 @@ func registerSchemaChangeDatabaseVersionUpgrade(r *testRegistry) {
 		Owner:      OwnerSQLSchema,
 		MinVersion: "v20.2.0",
 		Cluster:    makeClusterSpec(3),
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			runSchemaChangeDatabaseVersionUpgrade(ctx, t, c, r.buildVersion)
 		},
 	})
@@ -61,7 +61,7 @@ func uploadAndStart(nodes nodeListOption, v string) versionStep {
 }
 
 func runSchemaChangeDatabaseVersionUpgrade(
-	ctx context.Context, t *test, c *cluster, buildVersion version.Version,
+	ctx context.Context, t *test, c clusterI, buildVersion version.Version,
 ) {
 	// An empty string means that the cockroach binary specified by flag
 	// `cockroach` will be used.

--- a/pkg/cmd/roachtest/schemachange_random_load.go
+++ b/pkg/cmd/roachtest/schemachange_random_load.go
@@ -124,7 +124,7 @@ func runSchemaChangeRandomLoad(ctx context.Context, t *test, c *cluster, maxOps,
 	}
 
 	loadNode := c.Node(1)
-	roachNodes := c.Range(1, c.spec.NodeCount)
+	roachNodes := c.Range(1, c.Spec().NodeCount)
 	t.Status("copying binaries")
 	c.Put(ctx, cockroach, "./cockroach", roachNodes)
 	c.Put(ctx, workload, "./workload", loadNode)

--- a/pkg/cmd/roachtest/scrub.go
+++ b/pkg/cmd/roachtest/scrub.go
@@ -50,7 +50,7 @@ func makeScrubTPCCTest(
 		Name:    fmt.Sprintf("scrub/%s/tpcc/w=%d", optionName, warehouses),
 		Owner:   OwnerSQLQueries,
 		Cluster: makeClusterSpec(numNodes),
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			runTPCC(ctx, t, c, tpccOptions{
 				Warehouses:   warehouses,
 				ExtraRunArgs: "--wait=false --tolerate-errors",
@@ -68,12 +68,12 @@ func makeScrubTPCCTest(
 					conn := c.Conn(ctx, 1)
 					defer conn.Close()
 
-					c.l.Printf("Starting %d SCRUB checks", numScrubRuns)
+					t.l.Printf("Starting %d SCRUB checks", numScrubRuns)
 					for i := 0; i < numScrubRuns; i++ {
-						c.l.Printf("Running SCRUB check %d\n", i+1)
+						t.l.Printf("Running SCRUB check %d\n", i+1)
 						before := timeutil.Now()
 						err := sqlutils.RunScrubWithOptions(conn, "tpcc", "order", stmtOptions)
-						c.l.Printf("SCRUB check %d took %v\n", i+1, timeutil.Since(before))
+						t.l.Printf("SCRUB check %d took %v\n", i+1, timeutil.Since(before))
 
 						if err != nil {
 							t.Fatal(err)

--- a/pkg/cmd/roachtest/secondary_indexes.go
+++ b/pkg/cmd/roachtest/secondary_indexes.go
@@ -19,7 +19,7 @@ import (
 // runIndexUpgrade runs a test that creates an index before a version upgrade,
 // and modifies it in a mixed version setting. It aims to test the changes made
 // to index encodings done to allow secondary indexes to respect column families.
-func runIndexUpgrade(ctx context.Context, t *test, c *cluster, predecessorVersion string) {
+func runIndexUpgrade(ctx context.Context, t *test, c clusterI, predecessorVersion string) {
 	firstExpected := [][]int{
 		{2, 3, 4},
 		{6, 7, 8},
@@ -135,7 +135,7 @@ func registerSecondaryIndexesMultiVersionCluster(r *testRegistry) {
 		Owner:      OwnerSQLSchema,
 		Cluster:    makeClusterSpec(3),
 		MinVersion: "v20.1.0",
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			predV, err := PredecessorVersion(r.buildVersion)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/cmd/roachtest/sequelize.go
+++ b/pkg/cmd/roachtest/sequelize.go
@@ -23,7 +23,7 @@ func registerSequelize(r *testRegistry) {
 	runSequelize := func(
 		ctx context.Context,
 		t *test,
-		c *cluster,
+		c clusterI,
 	) {
 		if c.isLocal() {
 			t.Fatal("cannot be run in local mode")
@@ -64,8 +64,8 @@ func registerSequelize(r *testRegistry) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		c.l.Printf("Latest Sequelize release is %s.", latestTag)
-		c.l.Printf("Supported Sequelize release is %s.", supportedSequelizeRelease)
+		t.l.Printf("Latest Sequelize release is %s.", latestTag)
+		t.l.Printf("Supported Sequelize release is %s.", supportedSequelizeRelease)
 
 		if err := repeatRunE(
 			ctx, t, c, node, "update apt-get", `sudo apt-get -qq update`,
@@ -137,7 +137,7 @@ func registerSequelize(r *testRegistry) {
 			`cd /mnt/data1/sequelize/ && npm test`,
 		)
 		rawResultsStr := string(rawResults)
-		c.l.Printf("Test Results: %s", rawResultsStr)
+		t.l.Printf("Test Results: %s", rawResultsStr)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -149,7 +149,7 @@ func registerSequelize(r *testRegistry) {
 		Owner:      OwnerSQLExperience,
 		Cluster:    makeClusterSpec(1),
 		Tags:       []string{`default`, `orm`},
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			runSequelize(ctx, t, c)
 		},
 	})

--- a/pkg/cmd/roachtest/sequelize.go
+++ b/pkg/cmd/roachtest/sequelize.go
@@ -60,7 +60,7 @@ func registerSequelize(r *testRegistry) {
 		}
 
 		t.Status("cloning Sequelize and installing prerequisites")
-		latestTag, err := repeatGetLatestTag(ctx, c, "cockroachdb", "sequelize-cockroachdb", sequelizeReleaseTagRegex)
+		latestTag, err := repeatGetLatestTag(ctx, t, "cockroachdb", "sequelize-cockroachdb", sequelizeReleaseTagRegex)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -68,13 +68,14 @@ func registerSequelize(r *testRegistry) {
 		c.l.Printf("Supported Sequelize release is %s.", supportedSequelizeRelease)
 
 		if err := repeatRunE(
-			ctx, c, node, "update apt-get", `sudo apt-get -qq update`,
+			ctx, t, c, node, "update apt-get", `sudo apt-get -qq update`,
 		); err != nil {
 			t.Fatal(err)
 		}
 
 		if err := repeatRunE(
 			ctx,
+			t,
 			c,
 			node,
 			"install dependencies",
@@ -86,6 +87,7 @@ func registerSequelize(r *testRegistry) {
 
 		if err := repeatRunE(
 			ctx,
+			t,
 			c,
 			node,
 			"add nodesource repository",
@@ -95,26 +97,26 @@ func registerSequelize(r *testRegistry) {
 		}
 
 		if err := repeatRunE(
-			ctx, c, node, "install nodejs and npm", `sudo apt-get -qq install nodejs`,
+			ctx, t, c, node, "install nodejs and npm", `sudo apt-get -qq install nodejs`,
 		); err != nil {
 			t.Fatal(err)
 		}
 
 		if err := repeatRunE(
-			ctx, c, node, "update npm", `sudo npm i -g npm`,
+			ctx, t, c, node, "update npm", `sudo npm i -g npm`,
 		); err != nil {
 			t.Fatal(err)
 		}
 
 		if err := repeatRunE(
-			ctx, c, node, "remove old sequelize", `sudo rm -rf /mnt/data1/sequelize`,
+			ctx, t, c, node, "remove old sequelize", `sudo rm -rf /mnt/data1/sequelize`,
 		); err != nil {
 			t.Fatal(err)
 		}
 
 		if err := repeatGitCloneE(
 			ctx,
-			t.l,
+			t,
 			c,
 			"https://github.com/cockroachdb/sequelize-cockroachdb.git",
 			"/mnt/data1/sequelize",
@@ -125,7 +127,7 @@ func registerSequelize(r *testRegistry) {
 		}
 
 		if err := repeatRunE(
-			ctx, c, node, "install dependencies", `cd /mnt/data1/sequelize && sudo npm i`,
+			ctx, t, c, node, "install dependencies", `cd /mnt/data1/sequelize && sudo npm i`,
 		); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/cmd/roachtest/sequence_upgrade.go
+++ b/pkg/cmd/roachtest/sequence_upgrade.go
@@ -21,7 +21,7 @@ func registerSequenceUpgrade(r *testRegistry) {
 		Owner:      OwnerSQLSchema,
 		MinVersion: "v21.1.0",
 		Cluster:    makeClusterSpec(1),
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			runSequenceUpgradeMigration(ctx, t, c)
 		},
 	})
@@ -78,7 +78,7 @@ func verifySequences(node int) versionStep {
 	}
 }
 
-func runSequenceUpgradeMigration(ctx context.Context, t *test, c *cluster) {
+func runSequenceUpgradeMigration(ctx context.Context, t *test, c clusterI) {
 	const (
 		v20_2 = "20.2.4"
 		// An empty string means that the cockroach binary specified by flag

--- a/pkg/cmd/roachtest/split.go
+++ b/pkg/cmd/roachtest/split.go
@@ -158,7 +158,7 @@ func runLoadSplits(ctx context.Context, t *test, c *cluster, params splitParams)
 		setRangeMaxBytes(params.maxSize)
 
 		t.Status("running uniform kv workload")
-		c.Run(ctx, c.Node(1), fmt.Sprintf("./workload init kv {pgurl:1-%d}", c.spec.NodeCount))
+		c.Run(ctx, c.Node(1), fmt.Sprintf("./workload init kv {pgurl:1-%d}", c.Spec().NodeCount))
 
 		t.Status("checking initial range count")
 		rangeCount := func() int {
@@ -195,7 +195,7 @@ func runLoadSplits(ctx context.Context, t *test, c *cluster, params splitParams)
 		}
 		c.Run(ctx, c.Node(1), fmt.Sprintf("./workload run kv "+
 			"--init --concurrency=%d --read-percent=%d --span-percent=%d %s {pgurl:1-%d} --duration='%s'",
-			params.concurrency, params.readPercent, params.spanPercent, extraFlags, c.spec.NodeCount,
+			params.concurrency, params.readPercent, params.spanPercent, extraFlags, c.Spec().NodeCount,
 			params.waitDuration.String()))
 
 		t.Status("waiting for splits")
@@ -290,7 +290,7 @@ func runLargeRangeSplits(ctx context.Context, t *test, c *cluster, size int) {
 		// schema but before populating it. This is ok because upreplication
 		// occurs much faster than we can actually create a large range.
 		c.Run(ctx, c.Node(1), fmt.Sprintf("./workload init bank "+
-			"--rows=%d --payload-bytes=%d --ranges=1 {pgurl:1-%d}", rows, payload, c.spec.NodeCount))
+			"--rows=%d --payload-bytes=%d --ranges=1 {pgurl:1-%d}", rows, payload, c.Spec().NodeCount))
 
 		t.Status("checking for single range")
 		rangeCount := func() int {

--- a/pkg/cmd/roachtest/split.go
+++ b/pkg/cmd/roachtest/split.go
@@ -44,7 +44,7 @@ func registerLoadSplits(r *testRegistry) {
 		Owner:      OwnerKV,
 		MinVersion: "v19.1.0",
 		Cluster:    makeClusterSpec(numNodes),
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			// This number was determined experimentally. Often, but not always,
 			// more splits will happen.
 			expSplits := 10
@@ -88,7 +88,7 @@ func registerLoadSplits(r *testRegistry) {
 		Owner:      OwnerKV,
 		MinVersion: "v19.1.0",
 		Cluster:    makeClusterSpec(numNodes),
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			runLoadSplits(ctx, t, c, splitParams{
 				maxSize:       10 << 30, // 10 GB
 				concurrency:   64,       // 64 concurrent workers
@@ -109,7 +109,7 @@ func registerLoadSplits(r *testRegistry) {
 		Owner:      OwnerKV,
 		MinVersion: "v19.1.0",
 		Cluster:    makeClusterSpec(numNodes),
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			runLoadSplits(ctx, t, c, splitParams{
 				maxSize:       10 << 30, // 10 GB
 				concurrency:   64,       // 64 concurrent workers
@@ -127,7 +127,7 @@ func registerLoadSplits(r *testRegistry) {
 // runLoadSplits tests behavior of load based splitting under
 // conditions defined by the params. It checks whether certain number of
 // splits occur in different workload scenarios.
-func runLoadSplits(ctx context.Context, t *test, c *cluster, params splitParams) {
+func runLoadSplits(ctx context.Context, t *test, c clusterI, params splitParams) {
 	c.Put(ctx, cockroach, "./cockroach", c.All())
 	c.Put(ctx, workload, "./workload", c.Node(1))
 	c.Start(ctx, t, c.All())
@@ -216,7 +216,7 @@ func registerLargeRange(r *testRegistry) {
 		Owner:   OwnerKV,
 		Cluster: makeClusterSpec(numNodes),
 		Timeout: 5 * time.Hour,
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			runLargeRangeSplits(ctx, t, c, size)
 		},
 	})
@@ -230,7 +230,7 @@ func bytesStr(size uint64) string {
 // so by setting the max range size to a huge number before populating the
 // table. It then drops the range size back down to normal and watches as
 // the large range splits apart.
-func runLargeRangeSplits(ctx context.Context, t *test, c *cluster, size int) {
+func runLargeRangeSplits(ctx context.Context, t *test, c clusterI, size int) {
 	// payload is the size of the payload column for each row in the Bank
 	// table.
 	const payload = 100

--- a/pkg/cmd/roachtest/sqlalchemy.go
+++ b/pkg/cmd/roachtest/sqlalchemy.go
@@ -34,13 +34,13 @@ func registerSQLAlchemy(r *testRegistry) {
 		Cluster:    makeClusterSpec(1),
 		MinVersion: "v20.2.0",
 		Tags:       []string{`default`, `orm`},
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			runSQLAlchemy(ctx, t, c)
 		},
 	})
 }
 
-func runSQLAlchemy(ctx context.Context, t *test, c *cluster) {
+func runSQLAlchemy(ctx context.Context, t *test, c clusterI) {
 	if c.isLocal() {
 		t.Fatal("cannot be run in local mode")
 	}
@@ -52,8 +52,8 @@ func runSQLAlchemy(ctx context.Context, t *test, c *cluster) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	c.l.Printf("Latest sqlalchemy release is %s.", latestTag)
-	c.l.Printf("Supported sqlalchemy release is %s.", supportedSQLAlchemyTag)
+	t.l.Printf("Latest sqlalchemy release is %s.", latestTag)
+	t.l.Printf("Supported sqlalchemy release is %s.", supportedSQLAlchemyTag)
 
 	if err := repeatRunE(ctx, t, c, node, "update apt-get", `
 		sudo add-apt-repository ppa:deadsnakes/ppa &&
@@ -147,7 +147,7 @@ func runSQLAlchemy(ctx context.Context, t *test, c *cluster) {
 	if expectedFailures == nil {
 		t.Fatalf("No sqlalchemy blocklist defined for cockroach version %s", version)
 	}
-	c.l.Printf("Running cockroach version %s, using blocklist %s, using ignoredlist %s",
+	t.l.Printf("Running cockroach version %s, using blocklist %s, using ignoredlist %s",
 		version, blocklistName, ignoredlistName)
 
 	t.Status("running sqlalchemy test suite")
@@ -161,7 +161,7 @@ func runSQLAlchemy(ctx context.Context, t *test, c *cluster) {
 	`)
 
 	t.Status("collating the test results")
-	c.l.Printf("Test Results: %s", rawResults)
+	t.l.Printf("Test Results: %s", rawResults)
 
 	// Find all the failed and errored tests.
 	results := newORMTestsResults()

--- a/pkg/cmd/roachtest/sqlalchemy.go
+++ b/pkg/cmd/roachtest/sqlalchemy.go
@@ -48,27 +48,27 @@ func runSQLAlchemy(ctx context.Context, t *test, c *cluster) {
 	node := c.Node(1)
 
 	t.Status("cloning sqlalchemy and installing prerequisites")
-	latestTag, err := repeatGetLatestTag(ctx, c, "sqlalchemy", "sqlalchemy", sqlAlchemyReleaseTagRegex)
+	latestTag, err := repeatGetLatestTag(ctx, t, "sqlalchemy", "sqlalchemy", sqlAlchemyReleaseTagRegex)
 	if err != nil {
 		t.Fatal(err)
 	}
 	c.l.Printf("Latest sqlalchemy release is %s.", latestTag)
 	c.l.Printf("Supported sqlalchemy release is %s.", supportedSQLAlchemyTag)
 
-	if err := repeatRunE(ctx, c, node, "update apt-get", `
+	if err := repeatRunE(ctx, t, c, node, "update apt-get", `
 		sudo add-apt-repository ppa:deadsnakes/ppa &&
 		sudo apt-get -qq update
 	`); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := repeatRunE(ctx, c, node, "install dependencies", `
+	if err := repeatRunE(ctx, t, c, node, "install dependencies", `
 		sudo apt-get -qq install make python3.7 libpq-dev python3.7-dev gcc python3-setuptools python-setuptools build-essential
 	`); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := repeatRunE(ctx, c, node, "set python3.7 as default", `
+	if err := repeatRunE(ctx, t, c, node, "set python3.7 as default", `
 		sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.5 1
 		sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 2
 		sudo update-alternatives --config python3
@@ -76,51 +76,51 @@ func runSQLAlchemy(ctx context.Context, t *test, c *cluster) {
 		t.Fatal(err)
 	}
 
-	if err := repeatRunE(ctx, c, node, "install pip", `
+	if err := repeatRunE(ctx, t, c, node, "install pip", `
 		curl https://bootstrap.pypa.io/get-pip.py | sudo -H python3.7
 	`); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := repeatRunE(ctx, c, node, "install pytest", `
+	if err := repeatRunE(ctx, t, c, node, "install pytest", `
 		sudo pip3 install --upgrade --force-reinstall setuptools pytest==6.0.1 pytest-xdist psycopg2
 	`); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := repeatRunE(ctx, c, node, "remove old sqlalchemy-cockroachdb", `
+	if err := repeatRunE(ctx, t, c, node, "remove old sqlalchemy-cockroachdb", `
 		sudo rm -rf /mnt/data1/sqlalchemy-cockroachdb
 	`); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := repeatGitCloneE(ctx, t.l, c,
+	if err := repeatGitCloneE(ctx, t, c,
 		"https://github.com/cockroachdb/sqlalchemy-cockroachdb.git", "/mnt/data1/sqlalchemy-cockroachdb",
 		"master", node); err != nil {
 		t.Fatal(err)
 	}
 
 	t.Status("installing sqlalchemy-cockroachdb")
-	if err := repeatRunE(ctx, c, node, "installing sqlalchemy=cockroachdb", `
+	if err := repeatRunE(ctx, t, c, node, "installing sqlalchemy=cockroachdb", `
 		cd /mnt/data1/sqlalchemy-cockroachdb && sudo pip3 install .
 	`); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := repeatRunE(ctx, c, node, "remove old sqlalchemy", `
+	if err := repeatRunE(ctx, t, c, node, "remove old sqlalchemy", `
 		sudo rm -rf /mnt/data1/sqlalchemy
 	`); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := repeatGitCloneE(ctx, t.l, c,
+	if err := repeatGitCloneE(ctx, t, c,
 		"https://github.com/sqlalchemy/sqlalchemy.git", "/mnt/data1/sqlalchemy",
 		supportedSQLAlchemyTag, node); err != nil {
 		t.Fatal(err)
 	}
 
 	t.Status("building sqlalchemy")
-	if err := repeatRunE(ctx, c, node, "building sqlalchemy", `
+	if err := repeatRunE(ctx, t, c, node, "building sqlalchemy", `
 		cd /mnt/data1/sqlalchemy && python3 setup.py build
 	`); err != nil {
 		t.Fatal(err)

--- a/pkg/cmd/roachtest/sqlsmith.go
+++ b/pkg/cmd/roachtest/sqlsmith.go
@@ -57,7 +57,7 @@ func registerSQLSmith(r *testRegistry) {
 		"no-ddl":       sqlsmith.Settings["no-ddl"],
 	}
 
-	runSQLSmith := func(ctx context.Context, t *test, c *cluster, setupName, settingName string) {
+	runSQLSmith := func(ctx context.Context, t *test, c clusterI, setupName, settingName string) {
 		// Set up a statement logger for easy reproduction. We only
 		// want to log successful statements and statements that
 		// produced a final error or panic.
@@ -79,7 +79,7 @@ func registerSQLSmith(r *testRegistry) {
 		}
 
 		rng, seed := randutil.NewPseudoRand()
-		c.l.Printf("seed: %d", seed)
+		t.l.Printf("seed: %d", seed)
 
 		c.Put(ctx, cockroach, "./cockroach")
 		if err := c.PutLibraries(ctx, "./lib"); err != nil {
@@ -101,7 +101,7 @@ func registerSQLSmith(r *testRegistry) {
 
 		conn := c.Conn(ctx, 1)
 		t.Status("executing setup")
-		c.l.Printf("setup:\n%s", setup)
+		t.l.Printf("setup:\n%s", setup)
 		if _, err := conn.Exec(setup); err != nil {
 			t.Fatal(err)
 		} else {
@@ -111,7 +111,7 @@ func registerSQLSmith(r *testRegistry) {
 		const timeout = time.Minute
 		setStmtTimeout := fmt.Sprintf("SET statement_timeout='%s';", timeout.String())
 		t.Status("setting statement_timeout")
-		c.l.Printf("statement timeout:\n%s", setStmtTimeout)
+		t.l.Printf("statement timeout:\n%s", setStmtTimeout)
 		if _, err := conn.Exec(setStmtTimeout); err != nil {
 			t.Fatal(err)
 		}
@@ -192,7 +192,7 @@ func registerSQLSmith(r *testRegistry) {
 					// just timing out.
 					// TODO (rohany): once #45463 and #45461 have been resolved, return
 					//  to calling t.Fatalf here.
-					c.l.Printf("query timed out, but did not cancel execution:\n%s;", stmt)
+					t.l.Printf("query timed out, but did not cancel execution:\n%s;", stmt)
 					return nil
 				case err := <-done:
 					return err
@@ -247,7 +247,7 @@ func registerSQLSmith(r *testRegistry) {
 			Cluster:    makeClusterSpec(4),
 			MinVersion: "v20.2.0",
 			Timeout:    time.Minute * 20,
-			Run: func(ctx context.Context, t *test, c *cluster) {
+			Run: func(ctx context.Context, t *test, c clusterI) {
 				runSQLSmith(ctx, t, c, setup, setting)
 			},
 		})

--- a/pkg/cmd/roachtest/status_server.go
+++ b/pkg/cmd/roachtest/status_server.go
@@ -23,7 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 )
 
-func runStatusServer(ctx context.Context, t *test, c *cluster) {
+func runStatusServer(ctx context.Context, t *test, c clusterI) {
 	c.Put(ctx, cockroach, "./cockroach")
 	c.Start(ctx, t)
 
@@ -101,7 +101,7 @@ func runStatusServer(ctx context.Context, t *test, c *cluster) {
 	}
 
 	// Check local response for the every node.
-	for i := 1; i <= c.spec.NodeCount; i++ {
+	for i := 1; i <= c.Spec().NodeCount; i++ {
 		id := idMap[i]
 		checkNode(urlMap[i], id, id, id)
 		get(urlMap[i], "/_status/nodes")
@@ -109,7 +109,7 @@ func runStatusServer(ctx context.Context, t *test, c *cluster) {
 
 	// Proxy from the first node to the last node.
 	firstNode := 1
-	lastNode := c.spec.NodeCount
+	lastNode := c.Spec().NodeCount
 	firstID := idMap[firstNode]
 	lastID := idMap[lastNode]
 	checkNode(urlMap[firstNode], firstID, lastID, lastID)

--- a/pkg/cmd/roachtest/synctest.go
+++ b/pkg/cmd/roachtest/synctest.go
@@ -34,7 +34,7 @@ fi
 		MinVersion: "v19.1.0",
 		// This test sets up a custom file system; we don't want the cluster reused.
 		Cluster: makeClusterSpec(1, reuseNone()),
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			n := c.Node(1)
 			tmpDir, err := ioutil.TempDir("", "synctest")
 			if err != nil {

--- a/pkg/cmd/roachtest/sysbench.go
+++ b/pkg/cmd/roachtest/sysbench.go
@@ -84,9 +84,9 @@ func (o *sysbenchOptions) cmd(haproxy bool) string {
 }
 
 func runSysbench(ctx context.Context, t *test, c *cluster, opts sysbenchOptions) {
-	allNodes := c.Range(1, c.spec.NodeCount)
-	roachNodes := c.Range(1, c.spec.NodeCount-1)
-	loadNode := c.Node(c.spec.NodeCount)
+	allNodes := c.Range(1, c.Spec().NodeCount)
+	roachNodes := c.Range(1, c.Spec().NodeCount-1)
+	loadNode := c.Node(c.Spec().NodeCount)
 
 	t.Status("installing cockroach")
 	c.Put(ctx, cockroach, "./cockroach", allNodes)

--- a/pkg/cmd/roachtest/sysbench.go
+++ b/pkg/cmd/roachtest/sysbench.go
@@ -83,7 +83,7 @@ func (o *sysbenchOptions) cmd(haproxy bool) string {
 	)
 }
 
-func runSysbench(ctx context.Context, t *test, c *cluster, opts sysbenchOptions) {
+func runSysbench(ctx context.Context, t *test, c clusterI, opts sysbenchOptions) {
 	allNodes := c.Range(1, c.Spec().NodeCount)
 	roachNodes := c.Range(1, c.Spec().NodeCount-1)
 	loadNode := c.Node(c.Spec().NodeCount)
@@ -118,7 +118,7 @@ func runSysbench(ctx context.Context, t *test, c *cluster, opts sysbenchOptions)
 		if err != nil && !strings.Contains(err.Error(), "Segmentation fault") {
 			return err
 		}
-		c.l.Printf("sysbench segfaulted; passing test anyway")
+		t.l.Printf("sysbench segfaulted; passing test anyway")
 		return nil
 	})
 	m.Wait()
@@ -141,7 +141,7 @@ func registerSysbench(r *testRegistry) {
 			Name:    fmt.Sprintf("sysbench/%s/nodes=%d/cpu=%d/conc=%d", w, n, cpus, conc),
 			Owner:   OwnerKV,
 			Cluster: makeClusterSpec(n+1, cpu(cpus)),
-			Run: func(ctx context.Context, t *test, c *cluster) {
+			Run: func(ctx context.Context, t *test, c clusterI) {
 				runSysbench(ctx, t, c, opts)
 			},
 		})

--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -81,7 +81,7 @@ type testSpec struct {
 	RequiresLicense bool
 
 	// Run is the test function.
-	Run func(ctx context.Context, t *test, c *cluster)
+	Run func(ctx context.Context, t *test, c clusterI)
 }
 
 // perfArtifactsDir is the directory on cluster nodes in which perf artifacts

--- a/pkg/cmd/roachtest/test_test.go
+++ b/pkg/cmd/roachtest/test_test.go
@@ -85,13 +85,13 @@ func TestRunnerRun(t *testing.T) {
 	r.Add(testSpec{
 		Name:    "pass",
 		Owner:   OwnerUnitTest,
-		Run:     func(ctx context.Context, t *test, c *cluster) {},
+		Run:     func(ctx context.Context, t *test, c clusterI) {},
 		Cluster: makeClusterSpec(0),
 	})
 	r.Add(testSpec{
 		Name:  "fail",
 		Owner: OwnerUnitTest,
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			t.Fatal("failed")
 		},
 		Cluster: makeClusterSpec(0),
@@ -179,7 +179,7 @@ func TestRunnerTestTimeout(t *testing.T) {
 		Owner:   OwnerUnitTest,
 		Timeout: 10 * time.Millisecond,
 		Cluster: makeClusterSpec(0),
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			<-ctx.Done()
 		},
 	}
@@ -197,7 +197,7 @@ func TestRunnerTestTimeout(t *testing.T) {
 }
 
 func TestRegistryPrepareSpec(t *testing.T) {
-	dummyRun := func(context.Context, *test, *cluster) {}
+	dummyRun := func(context.Context, *test, clusterI) {}
 
 	var listTests = func(t *testSpec) []string {
 		return []string{t.Name}
@@ -286,7 +286,7 @@ func TestRegistryMinVersion(t *testing.T) {
 				Owner:      OwnerUnitTest,
 				MinVersion: "v2.0.0",
 				Cluster:    makeClusterSpec(0),
-				Run: func(ctx context.Context, t *test, c *cluster) {
+				Run: func(ctx context.Context, t *test, c clusterI) {
 					runA = true
 				},
 			})
@@ -295,7 +295,7 @@ func TestRegistryMinVersion(t *testing.T) {
 				Owner:      OwnerUnitTest,
 				MinVersion: "v2.1.0",
 				Cluster:    makeClusterSpec(0),
-				Run: func(ctx context.Context, t *test, c *cluster) {
+				Run: func(ctx context.Context, t *test, c clusterI) {
 					runB = true
 				},
 			})
@@ -345,7 +345,7 @@ func runExitCodeTest(t *testing.T, injectedError error) error {
 		Name:    "boom",
 		Owner:   OwnerUnitTest,
 		Cluster: makeClusterSpec(0),
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			if injectedError != nil {
 				t.Fatal(injectedError)
 			}

--- a/pkg/cmd/roachtest/tlp.go
+++ b/pkg/cmd/roachtest/tlp.go
@@ -37,7 +37,7 @@ func registerTLP(r *testRegistry) {
 	})
 }
 
-func runTLP(ctx context.Context, t *test, c *cluster) {
+func runTLP(ctx context.Context, t *test, c clusterI) {
 	// Set up a statement logger for easy reproduction. We only
 	// want to log successful statements and statements that
 	// produced a TLP error.
@@ -61,7 +61,7 @@ func runTLP(ctx context.Context, t *test, c *cluster) {
 	conn := c.Conn(ctx, 1)
 
 	rnd, seed := randutil.NewPseudoRand()
-	c.l.Printf("seed: %d", seed)
+	t.l.Printf("seed: %d", seed)
 
 	c.Put(ctx, cockroach, "./cockroach")
 	if err := c.PutLibraries(ctx, "./lib"); err != nil {
@@ -72,7 +72,7 @@ func runTLP(ctx context.Context, t *test, c *cluster) {
 	setup := sqlsmith.Setups["rand-tables"](rnd)
 
 	t.Status("executing setup")
-	c.l.Printf("setup:\n%s", setup)
+	t.l.Printf("setup:\n%s", setup)
 	if _, err := conn.Exec(setup); err != nil {
 		t.Fatal(err)
 	} else {
@@ -81,7 +81,7 @@ func runTLP(ctx context.Context, t *test, c *cluster) {
 
 	setStmtTimeout := fmt.Sprintf("SET statement_timeout='%s';", statementTimeout.String())
 	t.Status("setting statement_timeout")
-	c.l.Printf("statement timeout:\n%s", setStmtTimeout)
+	t.l.Printf("statement timeout:\n%s", setStmtTimeout)
 	if _, err := conn.Exec(setStmtTimeout); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/cmd/roachtest/tpc_utils.go
+++ b/pkg/cmd/roachtest/tpc_utils.go
@@ -26,7 +26,7 @@ import (
 // scale factor at least as large as the provided scale factor), performing an
 // expensive dataset restore only if it doesn't.
 func loadTPCHDataset(
-	ctx context.Context, t *test, c *cluster, sf int, m *monitor, roachNodes nodeListOption,
+	ctx context.Context, t *test, c clusterI, sf int, m *monitor, roachNodes nodeListOption,
 ) error {
 	db := c.Conn(ctx, roachNodes[0])
 	defer db.Close()
@@ -57,7 +57,7 @@ func loadTPCHDataset(
 
 		// If the scale factor was smaller than the required scale factor, wipe the
 		// cluster and restore.
-		m.ExpectDeaths(int32(c.spec.NodeCount))
+		m.ExpectDeaths(int32(c.Spec().NodeCount))
 		c.Wipe(ctx, roachNodes)
 		c.Start(ctx, t, roachNodes)
 		m.ResetDeaths()

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -385,7 +385,7 @@ func registerTPCC(r *testRegistry) {
 								Period:   300 * time.Second,
 								DownTime: 300 * time.Second,
 							},
-							Target:       func() nodeListOption { return c.Node(1 + rand.Intn(c.spec.NodeCount-1)) },
+							Target:       func() nodeListOption { return c.Node(1 + rand.Intn(c.Spec().NodeCount-1)) },
 							Stopper:      time.After(duration),
 							DrainAndQuit: false,
 						}
@@ -415,7 +415,7 @@ func registerTPCC(r *testRegistry) {
 							Period:   45 * time.Second,
 							DownTime: 10 * time.Second,
 						},
-						Target:       func() nodeListOption { return c.Node(1 + rand.Intn(c.spec.NodeCount-1)) },
+						Target:       func() nodeListOption { return c.Node(1 + rand.Intn(c.Spec().NodeCount-1)) },
 						Stopper:      time.After(duration),
 						DrainAndQuit: false,
 					}

--- a/pkg/cmd/roachtest/tpcdsvec.go
+++ b/pkg/cmd/roachtest/tpcdsvec.go
@@ -51,7 +51,7 @@ func registerTPCDSVec(r *testRegistry) {
 		`web_sales`, `web_site`,
 	}
 
-	runTPCDSVec := func(ctx context.Context, t *test, c *cluster) {
+	runTPCDSVec := func(ctx context.Context, t *test, c clusterI) {
 		c.Put(ctx, cockroach, "./cockroach", c.All())
 		c.Start(ctx, t)
 
@@ -174,7 +174,7 @@ func registerTPCDSVec(r *testRegistry) {
 		Owner:      OwnerSQLQueries,
 		Cluster:    makeClusterSpec(3),
 		MinVersion: "v20.1.0",
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			runTPCDSVec(ctx, t, c)
 		},
 	})

--- a/pkg/cmd/roachtest/tpce.go
+++ b/pkg/cmd/roachtest/tpce.go
@@ -30,7 +30,7 @@ func registerTPCE(r *testRegistry) {
 		timeout time.Duration
 	}
 
-	runTPCE := func(ctx context.Context, t *test, c *cluster, opts tpceOptions) {
+	runTPCE := func(ctx context.Context, t *test, c clusterI, opts tpceOptions) {
 		roachNodes := c.Range(1, opts.nodes)
 		loadNode := c.Node(opts.nodes + 1)
 		racks := opts.nodes
@@ -112,7 +112,7 @@ func registerTPCE(r *testRegistry) {
 			Tags:    opts.tags,
 			Timeout: opts.timeout,
 			Cluster: makeClusterSpec(opts.nodes+1, cpu(opts.cpus), ssd(opts.ssds)),
-			Run: func(ctx context.Context, t *test, c *cluster) {
+			Run: func(ctx context.Context, t *test, c clusterI) {
 				runTPCE(ctx, t, c, opts)
 			},
 		})

--- a/pkg/cmd/roachtest/tpchbench.go
+++ b/pkg/cmd/roachtest/tpchbench.go
@@ -49,8 +49,8 @@ type tpchBenchSpec struct {
 // This benchmark runs with a single load generator node running a single
 // worker.
 func runTPCHBench(ctx context.Context, t *test, c *cluster, b tpchBenchSpec) {
-	roachNodes := c.Range(1, c.spec.NodeCount-1)
-	loadNode := c.Node(c.spec.NodeCount)
+	roachNodes := c.Range(1, c.Spec().NodeCount-1)
+	loadNode := c.Node(c.Spec().NodeCount)
 
 	t.Status("copying binaries")
 	c.Put(ctx, cockroach, "./cockroach", roachNodes)

--- a/pkg/cmd/roachtest/tpchbench.go
+++ b/pkg/cmd/roachtest/tpchbench.go
@@ -48,7 +48,7 @@ type tpchBenchSpec struct {
 //
 // This benchmark runs with a single load generator node running a single
 // worker.
-func runTPCHBench(ctx context.Context, t *test, c *cluster, b tpchBenchSpec) {
+func runTPCHBench(ctx context.Context, t *test, c clusterI, b tpchBenchSpec) {
 	roachNodes := c.Range(1, c.Spec().NodeCount-1)
 	loadNode := c.Node(c.Spec().NodeCount)
 
@@ -167,7 +167,7 @@ func registerTPCHBenchSpec(r *testRegistry, b tpchBenchSpec) {
 		Owner:      OwnerSQLQueries,
 		Cluster:    makeClusterSpec(numNodes),
 		MinVersion: minVersion,
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			runTPCHBench(ctx, t, c, b)
 		},
 	})

--- a/pkg/cmd/roachtest/tpchvec.go
+++ b/pkg/cmd/roachtest/tpchvec.go
@@ -70,13 +70,13 @@ type tpchVecTestCase interface {
 	// preTestRunHook is called before any tpch query is run. Can be used to
 	// perform any setup that cannot be expressed as a modification to
 	// cluster-wide settings (those should go into tpchVecTestRunConfig).
-	preTestRunHook(ctx context.Context, t *test, c *cluster, conn *gosql.DB, clusterSetup []string)
+	preTestRunHook(ctx context.Context, t *test, c clusterI, conn *gosql.DB, clusterSetup []string)
 	// postQueryRunHook is called after each tpch query is run with the output and
 	// the index of the setup it was run in.
 	postQueryRunHook(t *test, output []byte, setupIdx int)
 	// postTestRunHook is called after all tpch queries are run. Can be used to
 	// perform teardown or general validation.
-	postTestRunHook(ctx context.Context, t *test, c *cluster, conn *gosql.DB)
+	postTestRunHook(ctx context.Context, t *test, c clusterI, conn *gosql.DB)
 }
 
 // tpchVecTestCaseBase is a default tpchVecTestCase implementation that can be
@@ -109,7 +109,7 @@ func (b tpchVecTestCaseBase) preTestRunHook(
 
 func (b tpchVecTestCaseBase) postQueryRunHook(*test, []byte, int) {}
 
-func (b tpchVecTestCaseBase) postTestRunHook(context.Context, *test, *cluster, *gosql.DB) {
+func (b tpchVecTestCaseBase) postTestRunHook(context.Context, *test, clusterI, *gosql.DB) {
 }
 
 type tpchVecPerfHelper struct {
@@ -192,7 +192,7 @@ func (p tpchVecPerfTest) getRunConfig() tpchVecTestRunConfig {
 }
 
 func (p tpchVecPerfTest) preTestRunHook(
-	ctx context.Context, t *test, c *cluster, conn *gosql.DB, clusterSetup []string,
+	ctx context.Context, t *test, c clusterI, conn *gosql.DB, clusterSetup []string,
 ) {
 	p.tpchVecTestCaseBase.preTestRunHook(t, conn, clusterSetup, !p.disableStatsCreation /* createStats */)
 }
@@ -202,7 +202,7 @@ func (p *tpchVecPerfTest) postQueryRunHook(t *test, output []byte, setupIdx int)
 }
 
 func (p *tpchVecPerfTest) postTestRunHook(
-	ctx context.Context, t *test, c *cluster, conn *gosql.DB,
+	ctx context.Context, t *test, c clusterI, conn *gosql.DB,
 ) {
 	runConfig := p.getRunConfig()
 	t.Status("comparing the runtimes (only median values for each query are compared)")
@@ -356,7 +356,7 @@ func (b tpchVecBenchTest) getRunConfig() tpchVecTestRunConfig {
 }
 
 func (b tpchVecBenchTest) preTestRunHook(
-	_ context.Context, t *test, _ *cluster, conn *gosql.DB, clusterSetup []string,
+	_ context.Context, t *test, _ clusterI, conn *gosql.DB, clusterSetup []string,
 ) {
 	b.tpchVecTestCaseBase.preTestRunHook(t, conn, clusterSetup, true /* createStats */)
 }
@@ -366,7 +366,7 @@ func (b *tpchVecBenchTest) postQueryRunHook(t *test, output []byte, setupIdx int
 }
 
 func (b *tpchVecBenchTest) postTestRunHook(
-	ctx context.Context, t *test, c *cluster, conn *gosql.DB,
+	ctx context.Context, t *test, c clusterI, conn *gosql.DB,
 ) {
 	runConfig := b.getRunConfig()
 	t.Status("comparing the runtimes (average of values (excluding best and worst) for each query are compared)")
@@ -425,7 +425,7 @@ type tpchVecDiskTest struct {
 }
 
 func (d tpchVecDiskTest) preTestRunHook(
-	ctx context.Context, t *test, c *cluster, conn *gosql.DB, clusterSetup []string,
+	ctx context.Context, t *test, c clusterI, conn *gosql.DB, clusterSetup []string,
 ) {
 	d.tpchVecTestCaseBase.preTestRunHook(t, conn, clusterSetup, true /* createStats */)
 	// In order to stress the disk spilling of the vectorized engine, we will
@@ -448,7 +448,7 @@ func (d tpchVecDiskTest) preTestRunHook(
 	}
 }
 
-func baseTestRun(ctx context.Context, t *test, c *cluster, conn *gosql.DB, tc tpchVecTestCase) {
+func baseTestRun(ctx context.Context, t *test, c clusterI, conn *gosql.DB, tc tpchVecTestCase) {
 	firstNode := c.Node(1)
 	runConfig := tc.getRunConfig()
 	for setupIdx, setup := range runConfig.clusterSetups {
@@ -481,7 +481,7 @@ type tpchVecSmithcmpTest struct {
 const tpchVecSmithcmp = "smithcmp"
 
 func (s tpchVecSmithcmpTest) preTestRunHook(
-	ctx context.Context, t *test, c *cluster, conn *gosql.DB, clusterSetup []string,
+	ctx context.Context, t *test, c clusterI, conn *gosql.DB, clusterSetup []string,
 ) {
 	s.tpchVecTestCaseBase.preTestRunHook(t, conn, clusterSetup, true /* createStats */)
 	const smithcmpSHA = "a3f41f5ba9273249c5ecfa6348ea8ee3ac4b77e3"
@@ -506,7 +506,7 @@ func (s tpchVecSmithcmpTest) preTestRunHook(
 	c.Put(ctx, smithcmp, "./"+tpchVecSmithcmp, node)
 }
 
-func smithcmpTestRun(ctx context.Context, t *test, c *cluster, conn *gosql.DB, tc tpchVecTestCase) {
+func smithcmpTestRun(ctx context.Context, t *test, c clusterI, conn *gosql.DB, tc tpchVecTestCase) {
 	runConfig := tc.getRunConfig()
 	tc.preTestRunHook(ctx, t, c, conn, runConfig.clusterSetups[0])
 	const (
@@ -526,9 +526,9 @@ func smithcmpTestRun(ctx context.Context, t *test, c *cluster, conn *gosql.DB, t
 func runTPCHVec(
 	ctx context.Context,
 	t *test,
-	c *cluster,
+	c clusterI,
 	testCase tpchVecTestCase,
-	testRun func(ctx context.Context, t *test, c *cluster, conn *gosql.DB, tc tpchVecTestCase),
+	testRun func(ctx context.Context, t *test, c clusterI, conn *gosql.DB, tc tpchVecTestCase),
 ) {
 	firstNode := c.Node(1)
 	c.Put(ctx, cockroach, "./cockroach", c.All())
@@ -561,7 +561,7 @@ func registerTPCHVec(r *testRegistry) {
 		Owner:      OwnerSQLQueries,
 		Cluster:    makeClusterSpec(tpchVecNodeCount),
 		MinVersion: "v19.2.0",
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			runTPCHVec(ctx, t, c, newTpchVecPerfTest(false /* disableStatsCreation */), baseTestRun)
 		},
 	})
@@ -573,7 +573,7 @@ func registerTPCHVec(r *testRegistry) {
 		// 19.2 version doesn't have disk spilling nor memory monitoring, so
 		// there is no point in running this config on that version.
 		MinVersion: "v20.1.0",
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			runTPCHVec(ctx, t, c, tpchVecDiskTest{}, baseTestRun)
 		},
 	})
@@ -583,7 +583,7 @@ func registerTPCHVec(r *testRegistry) {
 		Owner:      OwnerSQLQueries,
 		Cluster:    makeClusterSpec(tpchVecNodeCount),
 		MinVersion: "v20.1.0",
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			runTPCHVec(ctx, t, c, tpchVecSmithcmpTest{}, smithcmpTestRun)
 		},
 	})
@@ -593,7 +593,7 @@ func registerTPCHVec(r *testRegistry) {
 		Owner:      OwnerSQLQueries,
 		Cluster:    makeClusterSpec(tpchVecNodeCount),
 		MinVersion: "v20.2.0",
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			runTPCHVec(ctx, t, c, newTpchVecPerfTest(true /* disableStatsCreation */), baseTestRun)
 		},
 	})
@@ -605,7 +605,7 @@ func registerTPCHVec(r *testRegistry) {
 		MinVersion: "v20.2.0",
 		Skip: "This config can be used to perform some benchmarking and is not " +
 			"meant to be run on a nightly basis",
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			// In order to use this test for benchmarking, include the queries
 			// that modify the cluster settings for all configs to benchmark
 			// like in the example below. The example benchmarks three values

--- a/pkg/cmd/roachtest/ts_util.go
+++ b/pkg/cmd/roachtest/ts_util.go
@@ -91,7 +91,7 @@ func getMetrics(
 
 func verifyTxnPerSecond(
 	ctx context.Context,
-	c *cluster,
+	c clusterI,
 	t *test,
 	adminNode nodeListOption,
 	start, end time.Time,
@@ -142,7 +142,7 @@ func verifyTxnPerSecond(
 
 func verifyLookupsPerSec(
 	ctx context.Context,
-	c *cluster,
+	c clusterI,
 	t *test,
 	adminNode nodeListOption,
 	start, end time.Time,

--- a/pkg/cmd/roachtest/typeorm.go
+++ b/pkg/cmd/roachtest/typeorm.go
@@ -47,7 +47,7 @@ func registerTypeORM(r *testRegistry) {
 		}
 
 		t.Status("cloning TypeORM and installing prerequisites")
-		latestTag, err := repeatGetLatestTag(ctx, c, "typeorm", "typeorm", typeORMReleaseTagRegex)
+		latestTag, err := repeatGetLatestTag(ctx, t, "typeorm", "typeorm", typeORMReleaseTagRegex)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -55,13 +55,14 @@ func registerTypeORM(r *testRegistry) {
 		c.l.Printf("Supported TypeORM release is %s.", supportedTypeORMRelease)
 
 		if err := repeatRunE(
-			ctx, c, node, "update apt-get", `sudo apt-get -qq update`,
+			ctx, t, c, node, "update apt-get", `sudo apt-get -qq update`,
 		); err != nil {
 			t.Fatal(err)
 		}
 
 		if err := repeatRunE(
 			ctx,
+			t,
 			c,
 			node,
 			"install dependencies",
@@ -73,6 +74,7 @@ func registerTypeORM(r *testRegistry) {
 
 		if err := repeatRunE(
 			ctx,
+			t,
 			c,
 			node,
 			"add nodesource repository",
@@ -82,26 +84,26 @@ func registerTypeORM(r *testRegistry) {
 		}
 
 		if err := repeatRunE(
-			ctx, c, node, "install nodejs and npm", `sudo apt-get -qq install nodejs`,
+			ctx, t, c, node, "install nodejs and npm", `sudo apt-get -qq install nodejs`,
 		); err != nil {
 			t.Fatal(err)
 		}
 
 		if err := repeatRunE(
-			ctx, c, node, "update npm", `sudo npm i -g npm`,
+			ctx, t, c, node, "update npm", `sudo npm i -g npm`,
 		); err != nil {
 			t.Fatal(err)
 		}
 
 		if err := repeatRunE(
-			ctx, c, node, "remove old TypeORM", `sudo rm -rf /mnt/data1/typeorm`,
+			ctx, t, c, node, "remove old TypeORM", `sudo rm -rf /mnt/data1/typeorm`,
 		); err != nil {
 			t.Fatal(err)
 		}
 
 		if err := repeatGitCloneE(
 			ctx,
-			t.l,
+			t,
 			c,
 			"https://github.com/typeorm/typeorm.git",
 			"/mnt/data1/typeorm",
@@ -115,6 +117,7 @@ func registerTypeORM(r *testRegistry) {
 		// it will return a file not found error.
 		if err := repeatRunE(
 			ctx,
+			t,
 			c,
 			node,
 			"configuring tests for cockroach only",
@@ -125,6 +128,7 @@ func registerTypeORM(r *testRegistry) {
 
 		if err := repeatRunE(
 			ctx,
+			t,
 			c,
 			node,
 			"patch TypeORM test script to run all tests even on failure",
@@ -135,6 +139,7 @@ func registerTypeORM(r *testRegistry) {
 
 		if err := repeatRunE(
 			ctx,
+			t,
 			c,
 			node,
 			"building TypeORM",

--- a/pkg/cmd/roachtest/typeorm.go
+++ b/pkg/cmd/roachtest/typeorm.go
@@ -25,7 +25,7 @@ func registerTypeORM(r *testRegistry) {
 	runTypeORM := func(
 		ctx context.Context,
 		t *test,
-		c *cluster,
+		c clusterI,
 	) {
 		if c.isLocal() {
 			t.Fatal("cannot be run in local mode")
@@ -51,8 +51,8 @@ func registerTypeORM(r *testRegistry) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		c.l.Printf("Latest TypeORM release is %s.", latestTag)
-		c.l.Printf("Supported TypeORM release is %s.", supportedTypeORMRelease)
+		t.l.Printf("Latest TypeORM release is %s.", latestTag)
+		t.l.Printf("Supported TypeORM release is %s.", supportedTypeORMRelease)
 
 		if err := repeatRunE(
 			ctx, t, c, node, "update apt-get", `sudo apt-get -qq update`,
@@ -153,7 +153,7 @@ func registerTypeORM(r *testRegistry) {
 			`cd /mnt/data1/typeorm/ && sudo npm test --unsafe-perm=true --allow-root`,
 		)
 		rawResultsStr := string(rawResults)
-		c.l.Printf("Test Results: %s", rawResultsStr)
+		t.l.Printf("Test Results: %s", rawResultsStr)
 		if err != nil {
 			// Ignore the failure discussed in #38180 and in
 			// https://github.com/typeorm/typeorm/pull/4298.
@@ -175,7 +175,7 @@ func registerTypeORM(r *testRegistry) {
 		Cluster:    makeClusterSpec(1),
 		MinVersion: "v20.2.0",
 		Tags:       []string{`default`, `orm`},
-		Run: func(ctx context.Context, t *test, c *cluster) {
+		Run: func(ctx context.Context, t *test, c clusterI) {
 			runTypeORM(ctx, t, c)
 		},
 	})

--- a/pkg/cmd/roachtest/version.go
+++ b/pkg/cmd/roachtest/version.go
@@ -24,10 +24,10 @@ import (
 // TODO(tbg): remove this test. Use the harness in versionupgrade.go
 // to make a much better one, much more easily.
 func registerVersion(r *testRegistry) {
-	runVersion := func(ctx context.Context, t *test, c *cluster, binaryVersion string) {
+	runVersion := func(ctx context.Context, t *test, c clusterI, binaryVersion string) {
 		nodes := c.Spec().NodeCount - 1
 
-		if err := c.Stage(ctx, c.l, "release", "v"+binaryVersion, "", c.Range(1, nodes)); err != nil {
+		if err := c.Stage(ctx, t.l, "release", "v"+binaryVersion, "", c.Range(1, nodes)); err != nil {
 			t.Fatal(err)
 		}
 
@@ -98,7 +98,7 @@ func registerVersion(r *testRegistry) {
 					//
 					// https://github.com/cockroachdb/cockroach/issues/37737#issuecomment-496026918
 					if !strings.HasPrefix(binaryVersion, "2.") {
-						if err := c.CheckReplicaDivergenceOnDB(ctx, db); err != nil {
+						if err := c.CheckReplicaDivergenceOnDB(ctx, t, db); err != nil {
 							return errors.Wrapf(err, "node %d", i)
 						}
 					}
@@ -172,7 +172,7 @@ func registerVersion(r *testRegistry) {
 				if err := stop(i); err != nil {
 					return err
 				}
-				if err := c.Stage(ctx, c.l, "release", "v"+binaryVersion, "", c.Node(i)); err != nil {
+				if err := c.Stage(ctx, t.l, "release", "v"+binaryVersion, "", c.Node(i)); err != nil {
 					t.Fatal(err)
 				}
 				c.Start(ctx, t, c.Node(i), startArgsDontEncrypt)
@@ -214,7 +214,7 @@ func registerVersion(r *testRegistry) {
 			Owner:      OwnerKV,
 			MinVersion: "v2.1.0",
 			Cluster:    makeClusterSpec(n + 1),
-			Run: func(ctx context.Context, t *test, c *cluster) {
+			Run: func(ctx context.Context, t *test, c clusterI) {
 				pred, err := PredecessorVersion(r.buildVersion)
 				if err != nil {
 					t.Fatal(err)

--- a/pkg/cmd/roachtest/version.go
+++ b/pkg/cmd/roachtest/version.go
@@ -25,7 +25,7 @@ import (
 // to make a much better one, much more easily.
 func registerVersion(r *testRegistry) {
 	runVersion := func(ctx context.Context, t *test, c *cluster, binaryVersion string) {
-		nodes := c.spec.NodeCount - 1
+		nodes := c.Spec().NodeCount - 1
 
 		if err := c.Stage(ctx, c.l, "release", "v"+binaryVersion, "", c.Range(1, nodes)); err != nil {
 			t.Fatal(err)

--- a/pkg/cmd/roachtest/ycsb.go
+++ b/pkg/cmd/roachtest/ycsb.go
@@ -33,7 +33,7 @@ func registerYCSB(r *testRegistry) {
 	}
 
 	runYCSB := func(ctx context.Context, t *test, c *cluster, wl string, cpus int) {
-		nodes := c.spec.NodeCount - 1
+		nodes := c.Spec().NodeCount - 1
 
 		conc, ok := concurrencyConfigs[wl][cpus]
 		if !ok {

--- a/pkg/cmd/roachtest/ycsb.go
+++ b/pkg/cmd/roachtest/ycsb.go
@@ -32,7 +32,7 @@ func registerYCSB(r *testRegistry) {
 		"F": {8: 96, 32: 144},
 	}
 
-	runYCSB := func(ctx context.Context, t *test, c *cluster, wl string, cpus int) {
+	runYCSB := func(ctx context.Context, t *test, c clusterI, wl string, cpus int) {
 		nodes := c.Spec().NodeCount - 1
 
 		conc, ok := concurrencyConfigs[wl][cpus]
@@ -75,7 +75,7 @@ func registerYCSB(r *testRegistry) {
 				Name:    name,
 				Owner:   OwnerKV,
 				Cluster: makeClusterSpec(4, cpu(cpus)),
-				Run: func(ctx context.Context, t *test, c *cluster) {
+				Run: func(ctx context.Context, t *test, c clusterI) {
 					runYCSB(ctx, t, c, wl, cpus)
 				},
 			})


### PR DESCRIPTION
a.k.a "boiling the ocean". Roachtests now use `clusterI` instead of
`cluster`. The immediate benefit of this is that there is an interface
to look at that at least gives a basic idea of what `*cluster` can do,
without seeing all of the internals.

A second benefit is that this addresses a long-standing TODO, namely to
phase out `*cluster.{t,l}` (in favor of using the test's `t *test`).
These aren't quite removed yet - internals still touch them all over
the place - but the tests now don't have access to either any more.

- roachtest: extract an interface from `cluster`
- roachtest: use clusterI in runKVBench
- roachtest: use clusterI in allocator test
- roachtest: use clusterI in acceptance/*
- roachtest: use clusterI in ORM tests
- roachtest: take clusterI in `testSpec.Run`

Release note: None
