### PR TITLE
sql: add partial redactability to logs

### DIFF
--- a/pkg/ccl/importccl/BUILD.bazel
+++ b/pkg/ccl/importccl/BUILD.bazel
@@ -101,6 +101,7 @@ go_test(
         "csv_internal_test.go",
         "csv_testdata_helpers_test.go",
         "exportcsv_test.go",
+        "import_csv_mark_redaction_test.go",
         "import_into_test.go",
         "import_processor_test.go",
         "import_stmt_test.go",

--- a/pkg/ccl/importccl/import_csv_mark_redaction_test.go
+++ b/pkg/ccl/importccl/import_csv_mark_redaction_test.go
@@ -1,0 +1,45 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package importccl
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMarkRedactionCCLStatement verifies that the redactable parts
+// of CCL statements are marked correctly.
+func TestMarkRedactionCCLStatement(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	testCases := []struct {
+		query    string
+		expected string
+	}{
+		{
+			"IMPORT CSV 'file' WITH delimiter = 'foo'",
+			"IMPORT CSV ‹'file'› WITH delimiter = ‹'foo'›",
+		},
+	}
+
+	for _, test := range testCases {
+		stmt, err := parser.ParseOne(test.query)
+		require.NoError(t, err)
+		annotations := tree.MakeAnnotations(stmt.NumAnnotations)
+		f := tree.NewFmtCtx(tree.FmtAlwaysQualifyTableNames|tree.FmtMarkRedactionNode, tree.FmtAnnotations(&annotations))
+		f.FormatNode(stmt.AST)
+		redactedString := f.CloseAndGetString()
+		require.Equal(t, test.expected, redactedString)
+	}
+}

--- a/pkg/cli/interactive_tests/test_exec_log.tcl
+++ b/pkg/cli/interactive_tests/test_exec_log.tcl
@@ -100,20 +100,20 @@ flush_server_logs
 # previous statement is also in the log file after this check
 # succeeds.
 system "for i in `seq 1 3`; do
-  grep 'SELECT 660' $logfile && exit 0;
+  grep 'SELECT ..*660..* +' $logfile && exit 0;
   echo still waiting;
   sleep 1;
 done;
 echo 'not finding two separate txn counter values?';
-grep 'SELECT 660' $logfile;
+grep 'SELECT ..*660..* +' $logfile;
 exit 1;"
 
 # Two separate single-stmt txns.
-system "n=`grep 'SELECT 660' $logfile | sed -e 's/.*TxnCounter.:\\(\[0-9\]*\\)/\\1/g' | uniq | wc -l`; if test \$n -ne 2; then echo unexpected \$n; exit 1; fi"
+system "n=`grep 'SELECT ..*660..* +' $logfile | sed -e 's/.*TxnCounter.:\\(\[0-9\]*\\)/\\1/g' | uniq | wc -l`; if test \$n -ne 2; then echo unexpected \$n; exit 1; fi"
 # Same txns.
-system "n=`grep 'SELECT 770' $logfile | sed -e 's/.*TxnCounter.:\\(\[0-9\]*\\)/\\1/g' | uniq | wc -l`; if test \$n -ne 1; then echo unexpected \$n; exit 1; fi"
-system "n=`grep 'SELECT 880' $logfile | sed -e 's/.*TxnCounter.:\\(\[0-9\]*\\)/\\1/g' | uniq | wc -l`; if test \$n -ne 1; then echo unexpected \$n; exit 1; fi"
-system "n=`grep 'SELECT 990' $logfile | sed -e 's/.*TxnCounter.:\\(\[0-9\]*\\)/\\1/g' | uniq | wc -l`; if test \$n -ne 1; then echo unexpected \$n; exit 1; fi"
+system "n=`grep 'SELECT ..*770..* +' $logfile | sed -e 's/.*TxnCounter.:\\(\[0-9\]*\\)/\\1/g' | uniq | wc -l`; if test \$n -ne 1; then echo unexpected \$n; exit 1; fi"
+system "n=`grep 'SELECT ..*880..* +' $logfile | sed -e 's/.*TxnCounter.:\\(\[0-9\]*\\)/\\1/g' | uniq | wc -l`; if test \$n -ne 1; then echo unexpected \$n; exit 1; fi"
+system "n=`grep 'SELECT ..*990..* +' $logfile | sed -e 's/.*TxnCounter.:\\(\[0-9\]*\\)/\\1/g' | uniq | wc -l`; if test \$n -ne 1; then echo unexpected \$n; exit 1; fi"
 
 end_test
 

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -484,6 +484,7 @@ go_test(
         "sort_test.go",
         "span_builder_test.go",
         "split_test.go",
+        "statement_mark_redaction_test.go",
         "table_ref_test.go",
         "table_test.go",
         "telemetry_test.go",

--- a/pkg/sql/admin_audit_log_test.go
+++ b/pkg/sql/admin_audit_log_test.go
@@ -72,8 +72,7 @@ func TestAdminAuditLogBasic(t *testing.T) {
 	db.Exec(t, `SET CLUSTER SETTING sql.log.admin_audit.enabled = true;`)
 	db.Exec(t, `SELECT 1;`)
 
-	var selectAdminRe = regexp.MustCompile(`"EventType":"admin_query","Statement":"‹SELECT 1›","Tag":"SELECT","User":"root"`)
-
+	var selectAdminRe = regexp.MustCompile(`"EventType":"admin_query","Statement":"SELECT ‹1›","Tag":"SELECT","User":"root"`)
 	log.Flush()
 
 	entries, err := log.FetchEntriesFromFiles(0, math.MaxInt64, 10000, selectAdminRe,
@@ -169,15 +168,15 @@ COMMIT;
 	}{
 		{
 			"select-1-query",
-			`"EventType":"admin_query","Statement":"‹SELECT 1›"`,
+			`"EventType":"admin_query","Statement":"SELECT ‹1›"`,
 		},
 		{
 			"select-*-from-table-query",
-			`"EventType":"admin_query","Statement":"‹SELECT * FROM \"\".\"\".t›"`,
+			`"EventType":"admin_query","Statement":"SELECT * FROM ‹\"\"›.‹\"\"›.‹t›"`,
 		},
 		{
 			"create-table-query",
-			`"EventType":"admin_query","Statement":"‹CREATE TABLE defaultdb.public.t ()›"`,
+			`"EventType":"admin_query","Statement":"CREATE TABLE ‹defaultdb›.public.‹t› ()"`,
 		},
 	}
 
@@ -264,15 +263,15 @@ COMMIT;
 	}{
 		{
 			"select-1-query",
-			`"EventType":"admin_query","Statement":"‹SELECT 1›"`,
+			`"EventType":"admin_query","Statement":"SELECT ‹1›"`,
 		},
 		{
 			"select-*-from-table-query",
-			`"EventType":"admin_query","Statement":"‹SELECT * FROM \"\".\"\".t›"`,
+			`"EventType":"admin_query","Statement":"SELECT * FROM ‹\"\"›.‹\"\"›.‹t›"`,
 		},
 		{
 			"create-table-query",
-			`"EventType":"admin_query","Statement":"‹CREATE TABLE defaultdb.public.t ()›"`,
+			`"EventType":"admin_query","Statement":"CREATE TABLE ‹defaultdb›.public.‹t› ()"`,
 		},
 	}
 

--- a/pkg/sql/event_log.go
+++ b/pkg/sql/event_log.go
@@ -174,11 +174,8 @@ type eventLogOptions struct {
 func (p *planner) logEventsWithOptions(
 	ctx context.Context, depth int, opts eventLogOptions, entries ...eventLogEntry,
 ) error {
-	// TODO(thomas): place the redaction markers during the formatting
-	// and get rid of the call to redact.Sprint here.
-	// https://github.com/cockroachdb/cockroach/issues/65401
-	rawStmtString := tree.AsStringWithFQNames(p.stmt.AST, p.extendedEvalCtx.EvalContext.Annotations)
-	redactableStmt := redact.Sprint(rawStmtString)
+
+	redactableStmt := formatStmtKeyAsRedactableString(p.extendedEvalCtx.VirtualSchemas, p.stmt.AST, p.extendedEvalCtx.EvalContext.Annotations)
 
 	commonPayload := sqlEventCommonExecPayload{
 		user:         p.User(),
@@ -187,6 +184,7 @@ func (p *planner) logEventsWithOptions(
 		placeholders: p.extendedEvalCtx.EvalContext.Placeholders.Values,
 		appName:      p.SessionData().ApplicationName,
 	}
+
 	return logEventInternalForSQLStatements(ctx,
 		p.extendedEvalCtx.ExecCfg, p.txn,
 		1+depth,

--- a/pkg/sql/event_log_test.go
+++ b/pkg/sql/event_log_test.go
@@ -50,6 +50,7 @@ func TestStructuredEventLogging(t *testing.T) {
 	//   setting that does not otherwise impact the test's semantics
 	//   will do.
 	const setStmt = `SET CLUSTER SETTING "sql.defaults.default_int_size" = $1`
+	const expectedStmt = `SET CLUSTER SETTING "sql.defaults.default_int_size" = $1`
 	if _, err := conn.ExecContext(ctx,
 		`PREPARE a(INT) AS `+setStmt,
 	); err != nil {
@@ -85,8 +86,8 @@ func TestStructuredEventLogging(t *testing.T) {
 		if err := json.Unmarshal(jsonPayload, &ev); err != nil {
 			t.Errorf("unmarshalling %q: %v", e.Message, err)
 		}
-		if expected := redact.Sprint(setStmt); ev.Statement != expected {
-			t.Errorf("wrong statement: expected %q, got %q", expected, ev.Statement)
+		if ev.Statement != expectedStmt {
+			t.Errorf("wrong statement: expected %q, got %q", expectedStmt, ev.Statement)
 		}
 		if expected := []string{string(redact.Sprint("8"))}; !reflect.DeepEqual(expected, ev.PlaceholderValues) {
 			t.Errorf("wrong placeholders: expected %+v, got %+v", expected, ev.PlaceholderValues)

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -90,6 +90,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // ClusterOrganization is the organization name.
@@ -1624,8 +1625,33 @@ func truncateStatementStringForTelemetry(stmt string) string {
 func hideNonVirtualTableNameFunc(vt VirtualTabler) func(ctx *tree.FmtCtx, name *tree.TableName) {
 	reformatFn := func(ctx *tree.FmtCtx, tn *tree.TableName) {
 		virtual, err := vt.getVirtualTableEntry(tn)
+
 		if err != nil || virtual == nil {
-			ctx.WriteByte('_')
+			// Current table is non-virtual and therefore needs to be scrubbed (for statement stats) or redacted (for logs).
+			if ctx.HasFlags(tree.FmtMarkRedactionNode) {
+				// The redaction flag is set, redact the table name.
+
+				// Individually format the table name's fields for individual field redaction.
+				ctx.FormatNode(&tn.CatalogName)
+				ctx.WriteByte('.')
+
+				// Check if the table's schema name is 'public', we do not redact the 'public' schema.
+				if tn.ObjectNamePrefix.SchemaName == "public" {
+					ctx.WithFlags(tree.FmtParsable, func() {
+						ctx.FormatNode(&tn.ObjectNamePrefix.SchemaName)
+					})
+				} else {
+					// The table's schema name is not 'public', format schema name normally for redaction.
+					ctx.FormatNode(&tn.ObjectNamePrefix.SchemaName)
+				}
+
+				ctx.WriteByte('.')
+				ctx.FormatNode(&tn.ObjectName)
+			} else {
+				// The redaction flag is not set, this means that we are scrubbing the table for statement stats.
+				// Scrub the table name with '_'.
+				ctx.WriteByte('_')
+			}
 			return
 		}
 		// Virtual table: we want to keep the name; however
@@ -2560,6 +2586,18 @@ func scrubStmtStatKey(vt VirtualTabler, key string) (string, bool) {
 	)
 	f.FormatNode(stmt.AST)
 	return f.CloseAndGetString(), true
+}
+
+func formatStmtKeyAsRedactableString(
+	vt VirtualTabler, rootAST tree.Statement, ann *tree.Annotations,
+) redact.RedactableString {
+	f := tree.NewFmtCtx(
+		tree.FmtAlwaysQualifyTableNames|tree.FmtMarkRedactionNode,
+		tree.FmtAnnotations(ann),
+		tree.FmtReformatTableNames(hideNonVirtualTableNameFunc(vt)))
+	f.FormatNode(rootAST)
+	formattedRedactableStatementString := f.CloseAndGetString()
+	return redact.RedactableString(formattedRedactableStatementString)
 }
 
 // FailedHashedValue is used as a default return value for when HashForReporting

--- a/pkg/sql/sem/tree/BUILD.bazel
+++ b/pkg/sql/sem/tree/BUILD.bazel
@@ -159,6 +159,7 @@ go_library(
         "//pkg/util/uuid",
         "@com_github_cockroachdb_apd_v2//:apd",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_google_go_cmp//cmp",
         "@com_github_lib_pq//oid",
         "@org_golang_x_text//collate",

--- a/pkg/sql/sem/tree/backup.go
+++ b/pkg/sql/sem/tree/backup.go
@@ -176,7 +176,11 @@ func (o *KVOptions) Format(ctx *FmtCtx) {
 		if i > 0 {
 			ctx.WriteString(", ")
 		}
-		ctx.FormatNode(&n.Key)
+		// KVOption Key values never contain PII and should be distinguished
+		// for feature tracking purposes.
+		ctx.WithFlags(ctx.flags&^FmtMarkRedactionNode, func() {
+			ctx.FormatNode(&n.Key)
+		})
 		if n.Value != nil {
 			ctx.WriteString(` = `)
 			ctx.FormatNode(n.Value)

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -1498,9 +1498,11 @@ func (node *FuncExpr) Format(ctx *FmtCtx) {
 		typ = funcTypeName[node.Type] + " "
 	}
 
-	// We need to remove name anonymization for the function name in
+	// We need to remove name anonymization/redaction for the function name in
 	// particular. Do this by overriding the flags.
-	ctx.WithFlags(ctx.flags&^FmtAnonymize, func() {
+	// TODO(thomas): when function names are correctly typed as FunctionDefinition
+	// remove FmtMarkRedactionNode from being overridden.
+	ctx.WithFlags(ctx.flags&^FmtAnonymize&^FmtMarkRedactionNode, func() {
 		ctx.FormatNode(&node.Func)
 	})
 

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -35,7 +35,7 @@ func (node *ShowVar) Format(ctx *FmtCtx) {
 	ctx.WriteString("SHOW ")
 	// Session var names never contain PII and should be distinguished
 	// for feature tracking purposes.
-	ctx.WithFlags(ctx.flags & ^FmtAnonymize, func() {
+	ctx.WithFlags(ctx.flags & ^FmtAnonymize & ^FmtMarkRedactionNode, func() {
 		ctx.FormatNameP(&node.Name)
 	})
 }
@@ -50,7 +50,7 @@ func (node *ShowClusterSetting) Format(ctx *FmtCtx) {
 	ctx.WriteString("SHOW CLUSTER SETTING ")
 	// Cluster setting names never contain PII and should be distinguished
 	// for feature tracking purposes.
-	ctx.WithFlags(ctx.flags & ^FmtAnonymize, func() {
+	ctx.WithFlags(ctx.flags & ^FmtAnonymize & ^FmtMarkRedactionNode, func() {
 		ctx.FormatNameP(&node.Name)
 	})
 }

--- a/pkg/sql/statement_mark_redaction_test.go
+++ b/pkg/sql/statement_mark_redaction_test.go
@@ -1,0 +1,105 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	_ "github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMarkRedactionStatement verifies that the redactable parts
+// of statements are marked correctly.
+func TestMarkRedactionStatement(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	testCases := []struct {
+		query    string
+		expected string
+	}{
+		{
+			"SELECT 1",
+			"SELECT ‹1›",
+		},
+		{
+			"SELECT * FROM t",
+			"SELECT * FROM ‹\"\"›.‹\"\"›.‹t›",
+		},
+		{
+			"CREATE TABLE defaultdb.public.t()",
+			"CREATE TABLE ‹defaultdb›.public.‹t› ()",
+		},
+		// Note: this test only passes due to the overriding of the FmtMarkRedactionNode flag
+		// when formatting FuncExpr.Func. Although the overriding of the redaction flag
+		// is correct (function names do not hold PII and therefore do not need redaction),
+		// the incorrect typing of FuncExpr.Func as an UnresolvedName results in the
+		// function name being incorrectly redacted when logging statements. In this
+		// test case, that would be: SELECT ‹lower›(‹'foo'›).
+		// The intended functionality is for function names to be correctly typed as
+		// FunctionDefinition, which is logically identified as non-PII.
+		{
+			"SELECT lower('foo')",
+			"SELECT lower(‹'foo'›)",
+		},
+		{
+			"SELECT crdb_internal.node_executable_version()",
+			"SELECT crdb_internal.node_executable_version()",
+		},
+		{
+			"SHOW database",
+			"SHOW database",
+		},
+		{
+			"SET database = defaultdb",
+			"SET database = ‹defaultdb›",
+		},
+		{
+			"SET TRACING = off",
+			"SET TRACING = off",
+		},
+		{
+			"SHOW CLUSTER SETTING sql.log.admin_audit.enabled",
+			"SHOW CLUSTER SETTING \"sql.log.admin_audit.enabled\"",
+		},
+		{
+			"SET CLUSTER SETTING sql.log.admin_audit.enabled = true",
+			"SET CLUSTER SETTING \"sql.log.admin_audit.enabled\" = true",
+		},
+	}
+
+	s := cluster.MakeTestingClusterSettings()
+	vt, err := NewVirtualSchemaHolder(context.Background(), s)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range testCases {
+		stmt, err := parser.ParseOne(test.query)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ann := tree.MakeAnnotations(stmt.NumAnnotations)
+		f := tree.NewFmtCtx(
+			tree.FmtAlwaysQualifyTableNames|tree.FmtMarkRedactionNode,
+			tree.FmtAnnotations(&ann),
+			tree.FmtReformatTableNames(hideNonVirtualTableNameFunc(vt)))
+		f.FormatNode(stmt.AST)
+		redactedString := f.CloseAndGetString()
+		require.Equal(t, test.expected, redactedString)
+	}
+}


### PR DESCRIPTION
Prior to this change, enabling log redaction redacted entire SQL
statements. Consequently, troubleshooting efforts were hindered   by the
limited SQL statement information available in the redacted logs. This
change introduces partial redaction to log SQL statements, wherein only
sensitive information is redacted. As a result, more information is
available to those using redacted logs for troubleshooting.

Changes were introduced to the statement formatter. The formatter now
checks where the redaction flag is set. If so, redaction markers are
placed are specific node types in the statement's AST (namely, the
Datum, Constant, Name, and Unrestricted Name types).

Virtual schemas/tables are not redacted. The `public` schema is also not
redacted.

Note: redaction markers are ‹ and ›. Terms between the redaction markers are redacted.

**Redaction Marker Examples:**

```
1) SELECT city, revenue FROM rides LIMIT 10;

Before: ‹SELECT city, revenue FROM rides LIMIT 10›
After: SELECT ‹city›, ‹revenue› FROM ‹\"\"›.‹\"\"›.‹rides› LIMIT ‹10›
```

```
2) SELECT key FROM crdb_internal.node_statement_statistics LIMIT 10;

Before: ‹SELECT key FROM crdb_internal.node_statement_statistics LIMIT 10›
After: SELECT ‹key› FROM crdb_internal.node_statement_statistics LIMIT ‹10›
```

**Redaction Examples:**
```
1) SELECT city, revenue FROM rides LIMIT 10;

Before: ‹×›
After: SELECT ‹×›, ‹×› FROM ‹×›.‹×›.‹×› LIMIT ‹×›
```

```
2) SELECT key FROM crdb_internal.node_statement_statistics LIMIT 10;

Before: ‹×›
After: SELECT ‹×› FROM crdb_internal.node_statement_statistics LIMIT ‹×›
```

Resolves: #65401

Release note (bug fix): Added partial redactability to log SQL
statements. This change provides greater visibility to SQL usage in the
logs, enabling greater ability to troubleshoot.