### PR TITLE
release-21.1: ui: changing chart name to be compatible with other charts

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/overview.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/overview.tsx
@@ -36,7 +36,7 @@ export default function (props: GraphDashboardProps) {
 
   return [
     <LineGraph
-      title="SQL Queries"
+      title="SQL Statements"
       sources={nodeSources}
       tooltip={`A ten-second moving average of the # of SELECT, INSERT, UPDATE, and DELETE statements
         successfully executed per second ${tooltipSelection}.`}


### PR DESCRIPTION
Backport 1/1 commits from #64160.

/cc @cockroachdb/release

---

We use `SQL Statements` for the same chart under SQL Metrics, so
the title on Overview was changed to be compatible.

Release note (ui change): Overview metrics chart renamed from
`SQL Queries` to `SQL Statements` to be compatible with the same
chart on SQL metrics.
