### PR TITLE
kv: pool SpanSet objects and inner slices, avoid related heap allocs

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -390,7 +390,7 @@ func spansForAllTableIndexes(
 	// Attempt to merge any contiguous spans generated from the tables and revs.
 	// No need to check if the spans are distinct, since some of the merged
 	// indexes may overlap between different revisions of the same descriptor.
-	mergedSpans, _ := roachpb.MergeSpans(spans)
+	mergedSpans, _ := roachpb.MergeSpans(&spans)
 
 	knobs := execCfg.BackupRestoreTestingKnobs
 	if knobs != nil && knobs.CaptureResolvedTableDescSpans != nil {

--- a/pkg/ccl/backupccl/helpers_test.go
+++ b/pkg/ccl/backupccl/helpers_test.go
@@ -423,11 +423,11 @@ func getSpansFromManifest(t *testing.T, backupPath string) roachpb.Spans {
 	decompressedBytes, err := decompressData(backupManifestBytes)
 	require.NoError(t, err)
 	require.NoError(t, protoutil.Unmarshal(decompressedBytes, &backupManifest))
-	spans := make(roachpb.Spans, 0, len(backupManifest.Files))
+	spans := make([]roachpb.Span, 0, len(backupManifest.Files))
 	for _, file := range backupManifest.Files {
 		spans = append(spans, file.Span)
 	}
-	mergedSpans, _ := roachpb.MergeSpans(spans)
+	mergedSpans, _ := roachpb.MergeSpans(&spans)
 	return mergedSpans
 }
 

--- a/pkg/kv/kvclient/kvcoord/condensable_span_set.go
+++ b/pkg/kv/kvclient/kvcoord/condensable_span_set.go
@@ -54,7 +54,7 @@ func (s *condensableSpanSet) insert(spans ...roachpb.Span) {
 // The method has the side effect of sorting the stable write set.
 func (s *condensableSpanSet) mergeAndSort() {
 	oldLen := len(s.s)
-	s.s, _ = roachpb.MergeSpans(s.s)
+	s.s, _ = roachpb.MergeSpans(&s.s)
 	// Recompute the size if anything has changed.
 	if oldLen != len(s.s) {
 		s.bytes = 0

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_committer.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_committer.go
@@ -417,7 +417,7 @@ func mergeIntoSpans(s []roachpb.Span, ws []roachpb.SequencedWrite) ([]roachpb.Sp
 	for i, w := range ws {
 		m[len(s)+i] = roachpb.Span{Key: w.Key}
 	}
-	return roachpb.MergeSpans(m)
+	return roachpb.MergeSpans(&m)
 }
 
 // needTxnRetryAfterStaging determines whether the transaction needs to refresh

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner.go
@@ -318,7 +318,7 @@ func (tp *txnPipeliner) attachLocksToEndTxn(
 	}
 
 	// Sort both sets and condense the lock spans.
-	et.LockSpans, _ = roachpb.MergeSpans(et.LockSpans)
+	et.LockSpans, _ = roachpb.MergeSpans(&et.LockSpans)
 	sort.Sort(roachpb.SequencedWriteBySeq(et.InFlightWrites))
 
 	if log.V(3) {

--- a/pkg/kv/kvserver/batcheval/cmd_recover_txn.go
+++ b/pkg/kv/kvserver/batcheval/cmd_recover_txn.go
@@ -201,7 +201,7 @@ func RecoverTxn(
 		sp := roachpb.Span{Key: w.Key}
 		reply.RecoveredTxn.LockSpans = append(reply.RecoveredTxn.LockSpans, sp)
 	}
-	reply.RecoveredTxn.LockSpans, _ = roachpb.MergeSpans(reply.RecoveredTxn.LockSpans)
+	reply.RecoveredTxn.LockSpans, _ = roachpb.MergeSpans(&reply.RecoveredTxn.LockSpans)
 	reply.RecoveredTxn.InFlightWrites = nil
 
 	// Recover the transaction based on whether or not all of its writes

--- a/pkg/kv/kvserver/concurrency/concurrency_control.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_control.go
@@ -372,7 +372,10 @@ type Request struct {
 
 	// The maximal set of spans that the request will access. Latches
 	// will be acquired for these spans.
-	// TODO(nvanbenschoten): don't allocate these SpanSet objects.
+	//
+	// Note: ownership of the SpanSet is assumed by the Request once it is
+	// passed to SequenceReq. Only supplied to SequenceReq if the method is
+	// not also passed an exiting Guard.
 	LatchSpans *spanset.SpanSet
 
 	// The maximal set of spans within which the request expects to have
@@ -386,6 +389,10 @@ type Request struct {
 	// timestamp (Txn.WriteTimestamp). If the request is non-transactional
 	// (Txn == nil), all reads and writes are considered to take place at
 	// Timestamp.
+	//
+	// Note: ownership of the SpanSet is assumed by the Request once it is
+	// passed to SequenceReq. Only supplied to SequenceReq if the method is
+	// not also passed an exiting Guard.
 	LockSpans *spanset.SpanSet
 }
 

--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -154,14 +154,14 @@ func (m *managerImpl) SequenceReq(
 		case OptimisticEval:
 			panic("optimistic eval cannot happen when re-sequencing")
 		case PessimisticAfterFailedOptimisticEval:
-			if shouldAcquireLatches(req) {
+			if shouldAcquireLatches(g.Req) {
 				g.AssertLatches()
 			}
 			log.Event(ctx, "re-sequencing request after optimistic sequencing failed")
 		}
 	}
 	g.EvalKind = evalKind
-	resp, err := m.sequenceReqWithGuard(ctx, g, req)
+	resp, err := m.sequenceReqWithGuard(ctx, g)
 	if resp != nil || err != nil {
 		// Ensure that we release the guard if we return a response or an error.
 		m.FinishReq(g)
@@ -170,13 +170,9 @@ func (m *managerImpl) SequenceReq(
 	return g, nil, nil
 }
 
-// TODO(sumeer): we are using both g.Req and req, when the former should
-// suffice. Remove the req parameter.
-func (m *managerImpl) sequenceReqWithGuard(
-	ctx context.Context, g *Guard, req Request,
-) (Response, *Error) {
+func (m *managerImpl) sequenceReqWithGuard(ctx context.Context, g *Guard) (Response, *Error) {
 	// Some requests don't need to acquire latches at all.
-	if !shouldAcquireLatches(req) {
+	if !shouldAcquireLatches(g.Req) {
 		log.Event(ctx, "not acquiring latches")
 		return nil, nil
 	}
@@ -184,7 +180,7 @@ func (m *managerImpl) sequenceReqWithGuard(
 	// Provide the manager with an opportunity to intercept the request. It
 	// may be able to serve the request directly, and even if not, it may be
 	// able to update its internal state based on the request.
-	resp, err := m.maybeInterceptReq(ctx, req)
+	resp, err := m.maybeInterceptReq(ctx, g.Req)
 	if resp != nil || err != nil {
 		return resp, err
 	}
@@ -202,13 +198,13 @@ func (m *managerImpl) sequenceReqWithGuard(
 					panic("optimistic eval should not loop in sequenceReqWithGuard")
 				}
 				log.Event(ctx, "optimistically acquiring latches")
-				g.lg = m.lm.AcquireOptimistic(req)
+				g.lg = m.lm.AcquireOptimistic(g.Req)
 				g.lm = m.lm
 			} else {
 				// Acquire latches for the request. This synchronizes the request
 				// with all conflicting in-flight requests.
 				log.Event(ctx, "acquiring latches")
-				g.lg, err = m.lm.Acquire(ctx, req)
+				g.lg, err = m.lm.Acquire(ctx, g.Req)
 				if err != nil {
 					return nil, err
 				}
@@ -230,7 +226,7 @@ func (m *managerImpl) sequenceReqWithGuard(
 		firstIteration = false
 
 		// Some requests don't want the wait on locks.
-		if req.LockSpans.Empty() {
+		if g.Req.LockSpans.Empty() {
 			return nil, nil
 		}
 
@@ -535,18 +531,36 @@ func newGuard(req Request) *Guard {
 }
 
 func releaseGuard(g *Guard) {
+	if g.Req.LatchSpans != nil {
+		g.Req.LatchSpans.Release()
+	}
+	if g.Req.LockSpans != nil {
+		g.Req.LockSpans.Release()
+	}
 	*g = Guard{}
 	guardPool.Put(g)
 }
 
 // LatchSpans returns the maximal set of spans that the request will access.
+// The returned spanset is not safe for use after the guard has been finished.
 func (g *Guard) LatchSpans() *spanset.SpanSet {
 	return g.Req.LatchSpans
 }
 
 // LockSpans returns the maximal set of lock spans that the request will access.
+// The returned spanset is not safe for use after the guard has been finished.
 func (g *Guard) LockSpans() *spanset.SpanSet {
 	return g.Req.LockSpans
+}
+
+// TakeSpanSets transfers ownership of the Guard's LatchSpans and LockSpans
+// SpanSets to the caller, ensuring that the SpanSets are not destroyed with the
+// Guard. The method is only safe if called immediately before passing the Guard
+// to FinishReq.
+func (g *Guard) TakeSpanSets() (*spanset.SpanSet, *spanset.SpanSet) {
+	la, lo := g.Req.LatchSpans, g.Req.LockSpans
+	g.Req.LatchSpans, g.Req.LockSpans = nil, nil
+	return la, lo
 }
 
 // HoldingLatches returned whether the guard is holding latches or not.

--- a/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
@@ -193,6 +193,13 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 						d.Fatalf(t, "unknown eval-kind: %s", kind)
 					}
 				}
+
+				// Copy the request's latch and lock spans before handing them to
+				// SequenceReq, because they may be destroyed once handed to the
+				// concurrency manager.
+				req.LatchSpans = req.LatchSpans.Copy()
+				req.LockSpans = req.LockSpans.Copy()
+
 				c.mu.Lock()
 				prev := c.guardsByReqName[reqName]
 				delete(c.guardsByReqName, reqName)

--- a/pkg/kv/kvserver/protectedts/ptverifier/verifier.go
+++ b/pkg/kv/kvserver/protectedts/ptverifier/verifier.go
@@ -81,7 +81,7 @@ func getRecordWithTimestamp(
 
 func makeVerificationBatch(r *ptpb.Record, aliveAt hlc.Timestamp) kv.Batch {
 	// Need to perform validation, build a batch and run it.
-	mergedSpans, _ := roachpb.MergeSpans(r.Spans)
+	mergedSpans, _ := roachpb.MergeSpans(&r.Spans)
 	var b kv.Batch
 	for _, s := range mergedSpans {
 		var req roachpb.AdminVerifyProtectedTimestampRequest

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -39,7 +39,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/cloud"
-	enginepb "github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"

--- a/pkg/kv/kvserver/replica_batch_updates.go
+++ b/pkg/kv/kvserver/replica_batch_updates.go
@@ -89,7 +89,7 @@ func maybeStripInFlightWrites(ba *roachpb.BatchRequest) (*roachpb.BatchRequest, 
 				et.LockSpans[len(origET.LockSpans)+i] = roachpb.Span{Key: w.Key}
 			}
 			// See below for why we set Header.DistinctSpans here.
-			et.LockSpans, ba.Header.DistinctSpans = roachpb.MergeSpans(et.LockSpans)
+			et.LockSpans, ba.Header.DistinctSpans = roachpb.MergeSpans(&et.LockSpans)
 			return ba, nil
 		}
 	}
@@ -161,7 +161,7 @@ func maybeStripInFlightWrites(ba *roachpb.BatchRequest) (*roachpb.BatchRequest, 
 		// batch overlap with each other. This will have (rare) false negatives
 		// when the in-flight writes overlap with existing lock spans, but never
 		// false positives.
-		et.LockSpans, ba.Header.DistinctSpans = roachpb.MergeSpans(et.LockSpans)
+		et.LockSpans, ba.Header.DistinctSpans = roachpb.MergeSpans(&et.LockSpans)
 	}
 	return ba, nil
 }

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -361,8 +361,8 @@ func (r *Replica) executeBatchWithConcurrencyRetries(
 			ReadConsistency: ba.ReadConsistency,
 			WaitPolicy:      ba.WaitPolicy,
 			Requests:        ba.Requests,
-			LatchSpans:      latchSpans,
-			LockSpans:       lockSpans,
+			LatchSpans:      latchSpans, // nil if g != nil
+			LockSpans:       lockSpans,  // nil if g != nil
 		}, requestEvalKind)
 		if pErr != nil {
 			return nil, pErr
@@ -371,6 +371,7 @@ func (r *Replica) executeBatchWithConcurrencyRetries(
 			br.Responses = resp
 			return br, nil
 		}
+		latchSpans, lockSpans = nil, nil // ownership released
 
 		br, g, pErr = fn(r, ctx, ba, g)
 		if pErr == nil {
@@ -409,6 +410,7 @@ func (r *Replica) executeBatchWithConcurrencyRetries(
 			}
 		case *roachpb.IndeterminateCommitError:
 			// Drop latches and lock wait-queues.
+			latchSpans, lockSpans = g.TakeSpanSets()
 			r.concMgr.FinishReq(g)
 			g = nil
 			// Then launch a task to handle the indeterminate commit error.
@@ -417,6 +419,7 @@ func (r *Replica) executeBatchWithConcurrencyRetries(
 			}
 		case *roachpb.InvalidLeaseError:
 			// Drop latches and lock wait-queues.
+			latchSpans, lockSpans = g.TakeSpanSets()
 			r.concMgr.FinishReq(g)
 			g = nil
 			// Then attempt to acquire the lease if not currently held by any
@@ -427,6 +430,7 @@ func (r *Replica) executeBatchWithConcurrencyRetries(
 			}
 		case *roachpb.MergeInProgressError:
 			// Drop latches and lock wait-queues.
+			latchSpans, lockSpans = g.TakeSpanSets()
 			r.concMgr.FinishReq(g)
 			g = nil
 			// Then listen for the merge to complete.
@@ -781,12 +785,11 @@ func (r *Replica) checkBatchRequest(ba *roachpb.BatchRequest, isReadOnly bool) e
 func (r *Replica) collectSpans(
 	ba *roachpb.BatchRequest,
 ) (latchSpans, lockSpans *spanset.SpanSet, requestEvalKind concurrency.RequestEvalKind, _ error) {
-	latchSpans, lockSpans = new(spanset.SpanSet), new(spanset.SpanSet)
+	latchSpans, lockSpans = spanset.New(), spanset.New()
 	r.mu.RLock()
 	desc := r.descRLocked()
 	liveCount := r.mu.state.Stats.LiveCount
 	r.mu.RUnlock()
-
 	// TODO(bdarnell): need to make this less global when local
 	// latches are used more heavily. For example, a split will
 	// have a large read-only span but also a write (see #10084).

--- a/pkg/kv/kvserver/spanset/merge.go
+++ b/pkg/kv/kvserver/spanset/merge.go
@@ -14,23 +14,23 @@ import "sort"
 
 type sortedSpans []Span
 
-func (s sortedSpans) Less(i, j int) bool {
+func (s *sortedSpans) Less(i, j int) bool {
 	// Sort first on the start key and second on the end key. Note that we're
 	// relying on EndKey = nil (and len(EndKey) == 0) sorting before other
 	// EndKeys.
-	c := s[i].Key.Compare(s[j].Key)
+	c := (*s)[i].Key.Compare((*s)[j].Key)
 	if c != 0 {
 		return c < 0
 	}
-	return s[i].EndKey.Compare(s[j].EndKey) < 0
+	return (*s)[i].EndKey.Compare((*s)[j].EndKey) < 0
 }
 
-func (s sortedSpans) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
+func (s *sortedSpans) Swap(i, j int) {
+	(*s)[i], (*s)[j] = (*s)[j], (*s)[i]
 }
 
-func (s sortedSpans) Len() int {
-	return len(s)
+func (s *sortedSpans) Len() int {
+	return len(*s)
 }
 
 // mergeSpans sorts the given spans and merges ones with overlapping
@@ -39,20 +39,20 @@ func (s sortedSpans) Len() int {
 //
 // Returns true iff all of the spans are distinct.
 // The input spans are not safe for re-use.
-func mergeSpans(latches []Span) ([]Span, bool) {
-	if len(latches) == 0 {
-		return latches, true
+func mergeSpans(latches *[]Span) ([]Span, bool) {
+	if len(*latches) == 0 {
+		return *latches, true
 	}
 
-	sort.Sort(sortedSpans(latches))
+	sort.Sort((*sortedSpans)(latches))
 
 	// We build up the resulting slice of merged spans in place. This is safe
 	// because "r" grows by at most 1 element on each iteration, staying abreast
 	// or behind the iteration over "latches".
-	r := latches[:1]
+	r := (*latches)[:1]
 	distinct := true
 
-	for _, cur := range latches[1:] {
+	for _, cur := range (*latches)[1:] {
 		prev := &r[len(r)-1]
 		if len(cur.EndKey) == 0 && len(prev.EndKey) == 0 {
 			if cur.Key.Compare(prev.Key) != 0 {

--- a/pkg/kv/kvserver/spanset/spanset.go
+++ b/pkg/kv/kvserver/spanset/spanset.go
@@ -211,7 +211,7 @@ func (s *SpanSet) Merge(s2 *SpanSet) {
 func (s *SpanSet) SortAndDedup() {
 	for sa := SpanAccess(0); sa < NumSpanAccess; sa++ {
 		for ss := SpanScope(0); ss < NumSpanScope; ss++ {
-			s.spans[sa][ss], _ /* distinct */ = mergeSpans(s.spans[sa][ss])
+			s.spans[sa][ss], _ /* distinct */ = mergeSpans(&s.spans[sa][ss])
 		}
 	}
 }

--- a/pkg/roachpb/merge_spans.go
+++ b/pkg/roachpb/merge_spans.go
@@ -14,23 +14,23 @@ import "sort"
 
 type sortedSpans []Span
 
-func (s sortedSpans) Less(i, j int) bool {
+func (s *sortedSpans) Less(i, j int) bool {
 	// Sort first on the start key and second on the end key. Note that we're
 	// relying on EndKey = nil (and len(EndKey) == 0) sorting before other
 	// EndKeys.
-	c := s[i].Key.Compare(s[j].Key)
+	c := (*s)[i].Key.Compare((*s)[j].Key)
 	if c != 0 {
 		return c < 0
 	}
-	return s[i].EndKey.Compare(s[j].EndKey) < 0
+	return (*s)[i].EndKey.Compare((*s)[j].EndKey) < 0
 }
 
-func (s sortedSpans) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
+func (s *sortedSpans) Swap(i, j int) {
+	(*s)[i], (*s)[j] = (*s)[j], (*s)[i]
 }
 
-func (s sortedSpans) Len() int {
-	return len(s)
+func (s *sortedSpans) Len() int {
+	return len(*s)
 }
 
 // MergeSpans sorts the incoming spans and merges overlapping spans. Returns
@@ -39,20 +39,20 @@ func (s sortedSpans) Len() int {
 // but the two are still merged.
 //
 // The input spans are not safe for re-use.
-func MergeSpans(spans []Span) ([]Span, bool) {
-	if len(spans) == 0 {
-		return spans, true
+func MergeSpans(spans *[]Span) ([]Span, bool) {
+	if len(*spans) == 0 {
+		return *spans, true
 	}
 
-	sort.Sort(sortedSpans(spans))
+	sort.Sort((*sortedSpans)(spans))
 
 	// We build up the resulting slice of merged spans in place. This is safe
 	// because "r" grows by at most 1 element on each iteration, staying abreast
 	// or behind the iteration over "spans".
-	r := spans[:1]
+	r := (*spans)[:1]
 	distinct := true
 
-	for _, cur := range spans[1:] {
+	for _, cur := range (*spans)[1:] {
 		prev := &r[len(r)-1]
 		if len(cur.EndKey) == 0 && len(prev.EndKey) == 0 {
 			if cur.Key.Compare(prev.Key) != 0 {

--- a/pkg/roachpb/merge_spans_test.go
+++ b/pkg/roachpb/merge_spans_test.go
@@ -12,7 +12,6 @@ package roachpb
 
 import (
 	"math/rand"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -60,15 +59,12 @@ func TestMergeSpans(t *testing.T) {
 		{"a-c,b-bb", "a-c", false},
 		{"a-c,b-c", "a-c", false},
 	}
-	for i, c := range testCases {
-		spans, distinct := MergeSpans(makeSpans(c.spans))
+	for _, c := range testCases {
+		spans := makeSpans(c.spans)
+		spans, distinct := MergeSpans((*[]Span)(&spans))
 		expected := makeSpans(c.expected)
-		if (len(expected) != 0 || len(spans) != 0) && reflect.DeepEqual(expected, spans) {
-			t.Fatalf("%d: expected\n%s\n, but found:\n%s", i, expected, spans)
-		}
-		if c.distinct != distinct {
-			t.Fatalf("%d: expected %t, but found %t", i, c.distinct, distinct)
-		}
+		require.Equal(t, expected, spans)
+		require.Equal(t, c.distinct, distinct)
 	}
 }
 

--- a/pkg/sql/row/fetcher_test.go
+++ b/pkg/sql/row/fetcher_test.go
@@ -998,7 +998,7 @@ func TestNextRowInterleaved(t *testing.T) {
 				}
 			}
 
-			lookupSpans, _ = roachpb.MergeSpans(lookupSpans)
+			lookupSpans, _ = roachpb.MergeSpans(&lookupSpans)
 
 			rf, err := initFetcher(args, false /*reverseScan*/, alloc, nil /*memMon*/)
 			if err != nil {


### PR DESCRIPTION
This PR contains a series of changes to avoid heap allocations in the hot path of KV processing.

### kv: pool SpanSet objects and inner slices

This commit adds a `sync.Pool` for `spanset.SpanSet` objects. This allows us to avoid heap allocations when declaring latch and lock spans in `collectSpans`. The commit also preserves inner slices in the `spanset.SpanSet` objects when possible, avoiding further heap allocations upon re-use.

This is something @jordanlewis has been rightfully pointing to as an area for optimization for a while.

To get this working near the concurrency package boundary, we have to be careful around object ownership. This is because it is possible for the request to outlive a concurrency guard and for a concurrency guard to outlive a request. I think this commit makes the contracts clean and understandable, but I'm open to suggestions.

### kv: avoid heap allocation in spanset.SortAndDedup

By implementing `sort.Interface` on a pointer type that's already on the heap, we avoid a heap allocation when sorting the spans.

### kv: avoid heap allocation in roachpb.MergeSpans

This commit is similar to the previous one, except it makes the change to the more widely used `roachpb.MergeSpans`, which was specialized in 15d0c2d for the `spanset` package. By implementing `sort.Interface` on a pointer type that's already on the heap, we avoid a heap allocation when sorting the spans.

----

These changes combine to have the following impact.

```
name                            old time/op    new time/op    delta
KV/Delete/Native/rows=10000-16    49.6ms ± 4%    48.0ms ± 2%   -3.28%  (p=0.000 n=19+16)
KV/Delete/Native/rows=1-16        95.5µs ± 7%    93.8µs ± 2%   -1.85%  (p=0.000 n=18+19)
KV/Update/Native/rows=1000-16     15.3ms ± 3%    15.0ms ± 7%   -1.59%  (p=0.026 n=17+20)
KV/Scan/Native/rows=10-16         32.5µs ± 3%    32.0µs ± 3%   -1.54%  (p=0.006 n=18+19)
KV/Insert/Native/rows=1000-16     3.72ms ± 3%    3.64ms ± 5%   -1.54%  (p=0.026 n=17+20)
KV/Insert/Native/rows=1-16        94.7µs ± 6%    95.1µs ± 9%     ~     (p=0.426 n=18+20)
KV/Insert/Native/rows=10-16        135µs ± 8%     132µs ± 3%     ~     (p=0.183 n=20+20)
KV/Insert/Native/rows=100-16       480µs ± 6%     475µs ± 4%     ~     (p=0.339 n=19+19)
KV/Insert/Native/rows=10000-16    39.3ms ± 3%    39.6ms ± 7%     ~     (p=0.813 n=19+20)
KV/Update/Native/rows=1-16         149µs ± 5%     149µs ± 5%     ~     (p=0.698 n=20+20)
KV/Update/Native/rows=10-16        324µs ± 2%     323µs ± 3%     ~     (p=0.358 n=18+19)
KV/Update/Native/rows=100-16      1.78ms ± 1%    1.78ms ± 4%     ~     (p=0.684 n=17+20)
KV/Update/Native/rows=10000-16     128ms ± 4%     127ms ± 3%     ~     (p=0.165 n=17+19)
KV/Delete/Native/rows=10-16        149µs ± 7%     147µs ± 3%     ~     (p=0.327 n=20+20)
KV/Delete/Native/rows=100-16       585µs ± 7%     572µs ± 5%     ~     (p=0.087 n=20+18)
KV/Delete/Native/rows=1000-16     4.71ms ± 8%    4.68ms ± 4%     ~     (p=0.879 n=20+19)
KV/Scan/Native/rows=1-16          29.4µs ± 4%    29.4µs ± 4%     ~     (p=0.713 n=19+19)
KV/Scan/Native/rows=100-16        52.6µs ± 4%    51.9µs ± 2%     ~     (p=0.079 n=20+19)
KV/Scan/Native/rows=1000-16        245µs ± 5%     244µs ± 2%     ~     (p=0.789 n=20+16)
KV/Scan/Native/rows=10000-16      2.05ms ± 3%    2.05ms ± 3%     ~     (p=0.171 n=18+18)

name                            old alloc/op   new alloc/op   delta
KV/Delete/Native/rows=1-16        15.5kB ± 1%    14.3kB ± 1%   -7.27%  (p=0.000 n=18+19)
KV/Update/Native/rows=1-16        23.2kB ± 1%    21.6kB ± 0%   -6.90%  (p=0.000 n=18+20)
KV/Insert/Native/rows=1-16        15.7kB ± 0%    14.6kB ± 1%   -6.89%  (p=0.000 n=16+20)
KV/Scan/Native/rows=1-16          7.60kB ± 0%    7.15kB ± 0%   -6.01%  (p=0.000 n=17+20)
KV/Scan/Native/rows=10-16         9.01kB ± 0%    8.55kB ± 0%   -5.07%  (p=0.000 n=19+19)
KV/Delete/Native/rows=10-16       36.0kB ± 1%    35.2kB ± 1%   -2.35%  (p=0.000 n=19+20)
KV/Scan/Native/rows=100-16        21.6kB ± 0%    21.1kB ± 0%   -2.14%  (p=0.000 n=20+19)
KV/Update/Native/rows=10-16       66.4kB ± 1%    65.1kB ± 1%   -2.00%  (p=0.000 n=20+20)
KV/Insert/Native/rows=10-16       39.6kB ± 2%    38.9kB ± 1%   -1.95%  (p=0.000 n=20+20)
KV/Delete/Native/rows=10000-16    30.2MB ± 2%    29.9MB ± 2%   -0.84%  (p=0.028 n=20+20)
KV/Insert/Native/rows=100-16       278kB ± 1%     277kB ± 1%   -0.53%  (p=0.000 n=18+20)
KV/Insert/Native/rows=1000-16     2.54MB ± 1%    2.53MB ± 1%   -0.30%  (p=0.017 n=20+20)
KV/Delete/Native/rows=100-16       242kB ± 1%     241kB ± 1%   -0.28%  (p=0.035 n=20+20)
KV/Scan/Native/rows=1000-16        173kB ± 0%     172kB ± 0%   -0.26%  (p=0.000 n=20+20)
KV/Update/Native/rows=100-16       486kB ± 0%     485kB ± 1%   -0.19%  (p=0.014 n=19+20)
KV/Scan/Native/rows=10000-16      1.51MB ± 0%    1.51MB ± 0%   -0.02%  (p=0.009 n=17+20)
KV/Insert/Native/rows=10000-16    34.2MB ± 3%    34.2MB ± 3%     ~     (p=0.904 n=20+20)
KV/Update/Native/rows=1000-16     4.56MB ± 1%    4.56MB ± 1%     ~     (p=0.478 n=19+20)
KV/Update/Native/rows=10000-16    64.8MB ± 2%    64.6MB ± 1%     ~     (p=0.251 n=20+18)
KV/Delete/Native/rows=1000-16     2.22MB ± 1%    2.21MB ± 1%     ~     (p=0.428 n=20+19)

name                            old allocs/op  new allocs/op  delta
KV/Scan/Native/rows=1-16            60.0 ± 0%      52.0 ± 0%  -13.33%  (p=0.000 n=18+20)
KV/Scan/Native/rows=10-16           64.0 ± 0%      56.0 ± 0%  -12.50%  (p=0.000 n=19+20)
KV/Scan/Native/rows=100-16          68.0 ± 0%      60.0 ± 0%  -11.76%  (p=0.000 n=20+19)
KV/Update/Native/rows=1-16           203 ± 0%       181 ± 0%  -10.84%  (p=0.000 n=18+20)
KV/Scan/Native/rows=1000-16         77.0 ± 0%      69.0 ± 0%  -10.39%  (p=0.000 n=20+18)
KV/Delete/Native/rows=1-16           129 ± 0%       116 ± 0%  -10.08%  (p=0.000 n=19+20)
KV/Insert/Native/rows=1-16           130 ± 0%       117 ± 0%  -10.00%  (p=0.000 n=16+18)
KV/Scan/Native/rows=10000-16         103 ± 2%        95 ± 1%   -7.77%  (p=0.000 n=18+19)
KV/Delete/Native/rows=10-16          246 ± 0%       235 ± 0%   -4.47%  (p=0.000 n=19+20)
KV/Insert/Native/rows=10-16          275 ± 0%       264 ± 0%   -4.00%  (p=0.000 n=18+20)
KV/Update/Native/rows=10-16          460 ± 0%       442 ± 0%   -3.92%  (p=0.000 n=20+19)
KV/Delete/Native/rows=100-16       1.27k ± 0%     1.26k ± 0%   -0.91%  (p=0.000 n=20+14)
KV/Insert/Native/rows=100-16       1.57k ± 0%     1.56k ± 0%   -0.71%  (p=0.000 n=20+18)
KV/Update/Native/rows=100-16       2.67k ± 0%     2.65k ± 0%   -0.68%  (p=0.000 n=19+19)
KV/Delete/Native/rows=1000-16      11.3k ± 0%     11.3k ± 0%   -0.11%  (p=0.000 n=19+18)
KV/Insert/Native/rows=1000-16      14.3k ± 0%     14.3k ± 0%   -0.11%  (p=0.000 n=19+20)
KV/Update/Native/rows=1000-16      25.9k ± 0%     25.9k ± 0%   -0.08%  (p=0.000 n=16+18)
KV/Delete/Native/rows=10000-16      111k ± 0%      111k ± 0%   -0.05%  (p=0.000 n=20+20)
KV/Update/Native/rows=10000-16      263k ± 0%      262k ± 0%   -0.03%  (p=0.003 n=16+20)
KV/Insert/Native/rows=10000-16      141k ± 0%      141k ± 0%     ~     (p=0.683 n=20+20)
```