### PR TITLE
release-20.2: contextutil: preserve contextutil.TimeoutError details across the network

### DIFF
--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1028,6 +1028,7 @@ func TestLint(t *testing.T) {
 			":!sql/pgwire/pgerror/with_candidate_code.go",
 			":!sql/pgwire/pgwirebase/too_big_error.go",
 			":!sql/colexecbase/colexecerror/error.go",
+			":!util/contextutil/timeout_error.go",
 			":!util/protoutil/jsonpb_marshal.go",
 			":!util/protoutil/marshal.go",
 			":!util/protoutil/marshaler.go",
@@ -1913,6 +1914,8 @@ func TestLint(t *testing.T) {
 			// own redact code.
 			stream.GrepNot(`pkg/util/log/crash_reporting\.go:.*invalid direct cast on error object`),
 			stream.GrepNot(`pkg/util/log/crash_reporting\.go:.*invalid direct comparison of error object`),
+			// Cast in decode handler.
+			stream.GrepNot(`pkg/util/contextutil/timeout_error\.go:.*invalid direct cast on error object`),
 			// The logging package translates log.Fatal calls into errors.
 			// We can't use the regular exception mechanism via functions.go
 			// because addStructured takes its positional argument as []interface{},

--- a/pkg/util/contextutil/context.go
+++ b/pkg/util/contextutil/context.go
@@ -12,8 +12,6 @@ package contextutil
 
 import (
 	"context"
-	"fmt"
-	"net"
 	"runtime/debug"
 	"sync/atomic"
 	"time"
@@ -78,50 +76,6 @@ func wrap(ctx context.Context, cancel context.CancelFunc) (context.Context, cont
 		}
 		cancel()
 	}
-}
-
-// TimeoutError is a wrapped ContextDeadlineExceeded error. It indicates that
-// an operation didn't complete within its designated timeout.
-type TimeoutError struct {
-	operation string
-	duration  time.Duration
-	cause     error
-}
-
-var _ error = (*TimeoutError)(nil)
-var _ fmt.Formatter = (*TimeoutError)(nil)
-var _ errors.Formatter = (*TimeoutError)(nil)
-
-// We implement net.Error the same way that context.DeadlineExceeded does, so
-// that people looking for net.Error attributes will still find them.
-var _ net.Error = (*TimeoutError)(nil)
-
-func (t *TimeoutError) Error() string { return fmt.Sprintf("%v", t) }
-
-// Format implements fmt.Formatter.
-func (t *TimeoutError) Format(s fmt.State, verb rune) { errors.FormatError(t, s, verb) }
-
-// FormatError implements errors.Formatter.
-func (t *TimeoutError) FormatError(p errors.Printer) error {
-	p.Printf("operation %q timed out after %s", t.operation, t.duration)
-	if errors.UnwrapOnce(t.cause) != nil {
-		// If there were details (wrappers, stack trace etc.) ensure
-		// they get printed.
-		return t.cause
-	}
-	// We omit the "context deadline exceeded" suffix in the common case.
-	return nil
-}
-
-// Timeout implements net.Error.
-func (*TimeoutError) Timeout() bool { return true }
-
-// Temporary implements net.Error.
-func (*TimeoutError) Temporary() bool { return true }
-
-// Cause implements Causer.
-func (t *TimeoutError) Cause() error {
-	return t.cause
 }
 
 // RunWithTimeout runs a function with a timeout, the same way you'd do with

--- a/pkg/util/contextutil/context_test.go
+++ b/pkg/util/contextutil/context_test.go
@@ -34,7 +34,8 @@ func TestRunWithTimeout(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 		return ctx.Err()
 	})
-	expectedMsg := "operation \"foo\" timed out after 1ns"
+	baseExpectedMsg := "operation \"foo\" timed out after 1ns"
+	expectedMsg := baseExpectedMsg + ": context deadline exceeded"
 	if err.Error() != expectedMsg {
 		t.Fatalf("expected %s, actual %s", expectedMsg, err.Error())
 	}
@@ -53,7 +54,7 @@ func TestRunWithTimeout(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 		return errors.Wrap(ctx.Err(), "custom error")
 	})
-	expExtended := expectedMsg + ": custom error: context deadline exceeded"
+	expExtended := baseExpectedMsg + ": custom error: context deadline exceeded"
 	if err.Error() != expExtended {
 		t.Fatalf("expected %q, actual %q", expExtended, err.Error())
 	}

--- a/pkg/util/contextutil/timeout_error.go
+++ b/pkg/util/contextutil/timeout_error.go
@@ -1,0 +1,110 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package contextutil
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/errors/errorspb"
+	"github.com/gogo/protobuf/proto"
+)
+
+// TimeoutError is a wrapped ContextDeadlineExceeded error. It indicates that
+// an operation didn't complete within its designated timeout.
+type TimeoutError struct {
+	operation string
+	duration  time.Duration
+	cause     error
+}
+
+var _ error = (*TimeoutError)(nil)
+var _ fmt.Formatter = (*TimeoutError)(nil)
+var _ errors.Formatter = (*TimeoutError)(nil)
+
+// We implement net.Error the same way that context.DeadlineExceeded does, so
+// that people looking for net.Error attributes will still find them.
+var _ net.Error = (*TimeoutError)(nil)
+
+// Operation returns the name of the operation that timed out.
+func (t *TimeoutError) Operation() string {
+	return t.operation
+}
+
+func (t *TimeoutError) Error() string { return fmt.Sprintf("%v", t) }
+
+// Format implements fmt.Formatter.
+func (t *TimeoutError) Format(s fmt.State, verb rune) { errors.FormatError(t, s, verb) }
+
+// FormatError implements errors.Formatter.
+func (t *TimeoutError) FormatError(p errors.Printer) error {
+	p.Printf("operation %q timed out after %s", t.operation, t.duration)
+	return t.cause
+}
+
+// Timeout implements net.Error.
+func (*TimeoutError) Timeout() bool { return true }
+
+// Temporary implements net.Error.
+func (*TimeoutError) Temporary() bool { return true }
+
+// Cause implements Causer.
+func (t *TimeoutError) Cause() error {
+	return t.cause
+}
+
+// encodeTimeoutError serializes a TimeoutError.
+// We cannot include the operation in the safe strings because
+// we currently have plenty of uses where the operation is constructed
+// from unsafe/sensitive data.
+func encodeTimeoutError(
+	_ context.Context, err error,
+) (msgPrefix string, safe []string, details proto.Message) {
+	t := err.(*TimeoutError)
+	details = &errorspb.StringsPayload{
+		Details: []string{t.operation, t.duration.String()},
+	}
+	msgPrefix = fmt.Sprintf("operation %q timed out after %s", t.operation, t.duration)
+	return msgPrefix, nil, details
+}
+
+func decodeTimeoutError(
+	ctx context.Context, cause error, msgPrefix string, safeDetails []string, payload proto.Message,
+) error {
+	m, ok := payload.(*errorspb.StringsPayload)
+	if !ok || len(m.Details) < 2 {
+		// If this ever happens, this means some version of the library
+		// (presumably future) changed the payload type, and we're
+		// receiving this here. In this case, give up and let
+		// DecodeError use the opaque type.
+		return nil
+	}
+	op := m.Details[0]
+	dur, decodeErr := time.ParseDuration(m.Details[1])
+	if decodeErr != nil {
+		// Not encoded by our encode function. Bail out.
+		return nil //nolint:returnerrcheck
+	}
+	return &TimeoutError{
+		operation: op,
+		duration:  dur,
+		cause:     cause,
+	}
+}
+
+func init() {
+	pKey := errors.GetTypeKey(&TimeoutError{})
+	errors.RegisterWrapperEncoder(pKey, encodeTimeoutError)
+	errors.RegisterWrapperDecoder(pKey, decodeTimeoutError)
+}

--- a/pkg/util/contextutil/timeout_error_test.go
+++ b/pkg/util/contextutil/timeout_error_test.go
@@ -1,0 +1,33 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package contextutil
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/errors/errbase"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEncodeDecode(t *testing.T) {
+	origErr := &TimeoutError{
+		operation: "hello",
+		duration:  3 * time.Minute,
+		cause:     fmt.Errorf("woo")}
+	enc := errbase.EncodeError(context.Background(), origErr)
+	newErr := errbase.DecodeError(context.Background(), enc)
+
+	assert.Equal(t, origErr.Error(), newErr.Error())
+	assert.Equal(t, origErr, newErr)
+}


### PR DESCRIPTION
Backport 1/1 commits from #66357.

/cc @cockroachdb/release

---