### PR TITLE
cli: `import pgdump`: support db in `--url` + new flag `--database`

### DIFF
--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -857,6 +857,7 @@ func init() {
 		intFlag(d, &importCtx.rowLimit, cliflags.ImportRowLimit)
 		boolFlag(d, &importCtx.ignoreUnsupported, cliflags.ImportIgnoreUnsupportedStatements)
 		stringFlag(d, &importCtx.ignoreUnsupportedLog, cliflags.ImportLogIgnoredStatements)
+		stringFlag(d, &cliCtx.sqlConnDBName, cliflags.Database)
 
 		t := importDumpTableCmd.Flags()
 		boolFlag(t, &importCtx.skipForeignKeys, cliflags.ImportSkipForeignKeys)
@@ -864,6 +865,7 @@ func init() {
 		intFlag(t, &importCtx.rowLimit, cliflags.ImportRowLimit)
 		boolFlag(t, &importCtx.ignoreUnsupported, cliflags.ImportIgnoreUnsupportedStatements)
 		stringFlag(t, &importCtx.ignoreUnsupportedLog, cliflags.ImportLogIgnoredStatements)
+		stringFlag(t, &cliCtx.sqlConnDBName, cliflags.Database)
 	}
 
 	// sqlfmt command.

--- a/pkg/cli/import.go
+++ b/pkg/cli/import.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/server/pgurl"
 	"github.com/cockroachdb/errors"
 	"github.com/spf13/cobra"
 )
@@ -206,8 +207,14 @@ func runImport(
 		return errors.New("unsupported import format")
 	}
 
+	purl, err := pgurl.Parse(conn.url)
+	if err != nil {
+		return err
+	}
+
 	if importCLIKnobs.returnQuery {
-		fmt.Print(importQuery)
+		fmt.Print(importQuery + "\n")
+		fmt.Print(purl.GetDatabase())
 		return nil
 	}
 


### PR DESCRIPTION
Prior to this commit, any custom database specified via the `--url` flag
for `import pgdump` was ignored, and so it was not possible
for the user to customize the target database of an import.

The reason why the database was ignored is because the URL parser
in `cli/client_url.go` has separate logic for SQL-related commands
and RPC-related commands; in particular, a non-SQL command
that does not supports database customizations gets a warning
and the database part of the URL is ignored.
The `import pgdump` command was not identified by the URL parser
as a SQL-related command and therefore was not served
any database customization served by the end-user via `--url`.

To solve this, this commit makes the
`import pgdump` command also recognize a `--database` flag.
This achieves to separate objectives:

- it makes the URL parser recognize the command as a SQL-related
  command and ensures the custom database name is retained.
- it also makes the command-line interface of this command more consistent
  with the other SQL commands that accept `--url`.

Resolves: #66131

Release note (cli change): The `cockroach import pgdump` command now
recognizes custom target database names inside the URL passed via `--url`.
Additionally, the command now also accepts a `--database` parameter.
Using this parameter is equivalent to customizing the database inside the `--url` flag.