### PR TITLE
fetcher: don't hold batches across boundaries

### DIFF
--- a/pkg/sql/colfetcher/cfetcher.go
+++ b/pkg/sql/colfetcher/cfetcher.go
@@ -1354,7 +1354,7 @@ func (rf *cFetcher) processValueSingle(
 			if len(val.RawBytes) == 0 {
 				return prettyKey, "", nil
 			}
-			typ := table.cols[idx].GetType()
+			typ := rf.typs[idx]
 			err := colencoding.UnmarshalColumnValueToCol(
 				&table.da, rf.machine.colvecs[idx], rf.machine.rowIdx, typ, val,
 			)
@@ -1454,7 +1454,7 @@ func (rf *cFetcher) processValueBytes(
 
 		vec := rf.machine.colvecs[idx]
 
-		valTyp := table.cols[idx].GetType()
+		valTyp := rf.typs[idx]
 		valueBytes, err = colencoding.DecodeTableValueToCol(
 			&table.da, vec, rf.machine.rowIdx, typ, dataOffset, valTyp, valueBytes,
 		)

--- a/pkg/sql/colfetcher/cfetcher.go
+++ b/pkg/sql/colfetcher/cfetcher.go
@@ -275,8 +275,6 @@ type cFetcher struct {
 		// within the current batch. It's incremented as soon as we detect that a row
 		// is finished.
 		rowIdx int
-		// curSpan is the current span that the kv fetcher just returned data from.
-		curSpan roachpb.Span
 		// nextKV is the kv to process next.
 		nextKV roachpb.KeyValue
 		// seekPrefix is the prefix to seek to in stateSeekPrefix.
@@ -804,6 +802,29 @@ func (rf *cFetcher) nextAdapter() {
 	rf.adapter.batch, rf.adapter.err = rf.nextBatch(rf.adapter.ctx)
 }
 
+// setNextKV sets the next KV to process to the input KV. needsCopy, if true,
+// causes the input kv to be deep copied. needsCopy should be set to true if
+// the input KV is pointing to the last KV of a batch, so that the batch can
+// be garbage collected before fetching the next one.
+// gcassert:inline
+func (rf *cFetcher) setNextKV(kv roachpb.KeyValue, needsCopy bool) {
+	if !needsCopy {
+		rf.machine.nextKV = kv
+		return
+	}
+
+	// If we've made it to the very last key in the batch, copy out the key
+	// so that the GC can reclaim the large backing slice before we call
+	// NextKV() again.
+	kvCopy := roachpb.KeyValue{}
+	kvCopy.Key = make(roachpb.Key, len(kv.Key))
+	copy(kvCopy.Key, kv.Key)
+	kvCopy.Value.RawBytes = make([]byte, len(kv.Value.RawBytes))
+	copy(kvCopy.Value.RawBytes, kv.Value.RawBytes)
+	kvCopy.Value.Timestamp = kv.Value.Timestamp
+	rf.machine.nextKV = kvCopy
+}
+
 // nextBatch processes keys until we complete one batch of rows,
 // coldata.BatchSize() in length, which are returned in columnar format as a
 // coldata.Batch. The batch contains one Vec per table column, regardless of
@@ -819,38 +840,37 @@ func (rf *cFetcher) nextBatch(ctx context.Context) (coldata.Batch, error) {
 		case stateInvalid:
 			return nil, errors.New("invalid fetcher state")
 		case stateInitFetch:
-			moreKeys, kv, newSpan, err := rf.fetcher.NextKV(ctx, rf.mvccDecodeStrategy)
+			moreKVs, kv, finalReferenceToBatch, err := rf.fetcher.NextKV(ctx, rf.mvccDecodeStrategy)
 			if err != nil {
 				return nil, rf.convertFetchError(ctx, err)
 			}
-			if !moreKeys {
+			if !moreKVs {
 				rf.machine.state[0] = stateEmitLastBatch
 				continue
 			}
-			if newSpan {
-				rf.machine.curSpan = rf.fetcher.Span
-				// TODO(jordan): parse the logical longest common prefix of the span
-				// into a buffer. The logical longest common prefix is the longest
-				// common prefix that contains only full key components. For example,
-				// the keys /Table/53/1/foo/bar/10 and /Table/53/1/foo/bop/10 would
-				// have LLCS of /Table/53/1/foo, even though they share a b prefix of
-				// the next key, since that prefix isn't a complete key component.
-				/*
-					lcs := rf.fetcher.span.LongestCommonPrefix()
-					// parse lcs into stuff
-					key, matches, err := rowenc.DecodeIndexKeyWithoutTableIDIndexIDPrefix(
-						rf.table.desc, rf.table.info.index, rf.table.info.keyValTypes,
-						rf.table.keyVals, rf.table.info.indexColumnDirs, kv.Key[rf.table.info.knownPrefixLength:],
-					)
-					if err != nil {
-						// This is expected - the longest common prefix of the keyspan might
-						// end half way through a key. Suppress the error and set the actual
-						// LCS we'll use later to the decodable components of the key.
-					}
-				*/
-			}
+			// TODO(jordan): parse the logical longest common prefix of the span
+			// into a buffer. The logical longest common prefix is the longest
+			// common prefix that contains only full key components. For example,
+			// the keys /Table/53/1/foo/bar/10 and /Table/53/1/foo/bop/10 would
+			// have LLCS of /Table/53/1/foo, even though they share a b prefix of
+			// the next key, since that prefix isn't a complete key component.
+			/*
+				if newSpan {
+				lcs := rf.fetcher.span.LongestCommonPrefix()
+				// parse lcs into stuff
+				key, matches, err := rowenc.DecodeIndexKeyWithoutTableIDIndexIDPrefix(
+					rf.table.desc, rf.table.info.index, rf.table.info.keyValTypes,
+					rf.table.keyVals, rf.table.info.indexColumnDirs, kv.Key[rf.table.info.knownPrefixLength:],
+				)
+				if err != nil {
+					// This is expected - the longest common prefix of the keyspan might
+					// end half way through a key. Suppress the error and set the actual
+					// LCS we'll use later to the decodable components of the key.
+				}
+				}
+			*/
 
-			rf.machine.nextKV = kv
+			rf.setNextKV(kv, finalReferenceToBatch)
 			rf.machine.state[0] = stateDecodeFirstKVOfRow
 
 		case stateResetBatch:
@@ -976,15 +996,16 @@ func (rf *cFetcher) nextBatch(ctx context.Context) (coldata.Batch, error) {
 			}
 			rf.machine.state[0] = stateFetchNextKVWithUnfinishedRow
 		case stateSeekPrefix:
+			// Note: seekPrefix is only used for interleaved tables.
 			for {
-				moreRows, kv, _, err := rf.fetcher.NextKV(ctx, rf.mvccDecodeStrategy)
+				moreKVs, kv, finalReferenceToBatch, err := rf.fetcher.NextKV(ctx, rf.mvccDecodeStrategy)
 				if err != nil {
 					return nil, rf.convertFetchError(ctx, err)
 				}
 				if debugState {
 					log.Infof(ctx, "found kv %s, seeking to prefix %s", kv.Key, rf.machine.seekPrefix)
 				}
-				if !moreRows {
+				if !moreKVs {
 					// We ran out of data, so ignore whatever our next state was going to
 					// be and emit the final batch.
 					rf.machine.state[1] = stateEmitLastBatch
@@ -1002,14 +1023,14 @@ func (rf *cFetcher) nextBatch(ctx context.Context) (coldata.Batch, error) {
 				// TODO(jordan): if nextKV returns newSpan = true, set the new span
 				//  prefix and indicate that it needs decoding.
 				if comparison >= 0 {
-					rf.machine.nextKV = kv
+					rf.setNextKV(kv, finalReferenceToBatch)
 					break
 				}
 			}
 			rf.shiftState()
 
 		case stateFetchNextKVWithUnfinishedRow:
-			moreKVs, kv, _, err := rf.fetcher.NextKV(ctx, rf.mvccDecodeStrategy)
+			moreKVs, kv, finalReferenceToBatch, err := rf.fetcher.NextKV(ctx, rf.mvccDecodeStrategy)
 			if err != nil {
 				return nil, rf.convertFetchError(ctx, err)
 			}
@@ -1021,7 +1042,7 @@ func (rf *cFetcher) nextBatch(ctx context.Context) (coldata.Batch, error) {
 			}
 			// TODO(jordan): if nextKV returns newSpan = true, set the new span
 			// prefix and indicate that it needs decoding.
-			rf.machine.nextKV = kv
+			rf.setNextKV(kv, finalReferenceToBatch)
 			if debugState {
 				log.Infof(ctx, "decoding next key %s", rf.machine.nextKV.Key)
 			}

--- a/pkg/sql/row/errors.go
+++ b/pkg/sql/row/errors.go
@@ -36,13 +36,13 @@ type singleKVFetcher struct {
 
 // nextBatch implements the kvBatchFetcher interface.
 func (f *singleKVFetcher) nextBatch(
-	_ context.Context,
-) (ok bool, kvs []roachpb.KeyValue, batchResponse []byte, span roachpb.Span, err error) {
+	ctx context.Context,
+) (ok bool, kvs []roachpb.KeyValue, batchResponse []byte, err error) {
 	if f.done {
-		return false, nil, nil, roachpb.Span{}, nil
+		return false, nil, nil, nil
 	}
 	f.done = true
-	return true, f.kvs[:], nil, roachpb.Span{}, nil
+	return true, f.kvs[:], nil, nil
 }
 
 // ConvertBatchError returns a user friendly constraint violation error.

--- a/pkg/sql/row/kv_fetcher.go
+++ b/pkg/sql/row/kv_fetcher.go
@@ -32,7 +32,6 @@ type KVFetcher struct {
 	kvs []roachpb.KeyValue
 
 	batchResponse []byte
-	Span          roachpb.Span
 	newSpan       bool
 
 	// Observability fields.
@@ -94,16 +93,27 @@ const (
 // NextKV returns the next kv from this fetcher. Returns false if there are no
 // more kvs to fetch, the kv that was fetched, and any errors that may have
 // occurred.
+// finalReferenceToBatch is set to true if the returned KV's byte slices are
+// the last reference into a larger backing byte slice. This parameter allows
+// calling code to control its memory usage: if finalReferenceToBatch is true,
+// it means that the next call to NextKV might potentially allocate a big chunk
+// of new memory, so the returned KeyValue should be copied into a small slice
+// that the caller owns to avoid retaining two large backing byte slices at once
+// unexpectedly.
 func (f *KVFetcher) NextKV(
 	ctx context.Context, mvccDecodeStrategy MVCCDecodingStrategy,
-) (ok bool, kv roachpb.KeyValue, newSpan bool, err error) {
+) (moreKVs bool, kv roachpb.KeyValue, finalReferenceToBatch bool, err error) {
 	for {
-		newSpan = f.newSpan
-		f.newSpan = false
-		if len(f.kvs) != 0 {
+		// Only one of f.kvs or f.batchResponse will be set at a given time. Which
+		// one is set depends on the format returned by a given BatchRequest.
+		nKvs := len(f.kvs)
+		if nKvs != 0 {
 			kv = f.kvs[0]
 			f.kvs = f.kvs[1:]
-			return true, kv, newSpan, nil
+			// We always return "false" for finalReferenceToBatch when returning data in the
+			// KV format, because each of the KVs doesn't share any backing memory -
+			// they are all independently garbage collectable.
+			return true, kv, false, nil
 		}
 		if len(f.batchResponse) > 0 {
 			var key []byte
@@ -121,7 +131,8 @@ func (f *KVFetcher) NextKV(
 			}
 			// If we're finished decoding the batch response, nil our reference to it
 			// so that the garbage collector can reclaim the backing memory.
-			if len(f.batchResponse) == 0 {
+			lastKey := len(f.batchResponse) == 0
+			if lastKey {
 				f.batchResponse = nil
 			}
 			return true, roachpb.KeyValue{
@@ -130,14 +141,14 @@ func (f *KVFetcher) NextKV(
 					RawBytes:  rawBytes[:len(rawBytes):len(rawBytes)],
 					Timestamp: ts,
 				},
-			}, newSpan, nil
+			}, lastKey, nil
 		}
 
-		ok, f.kvs, f.batchResponse, f.Span, err = f.nextBatch(ctx)
+		moreKVs, f.kvs, f.batchResponse, err = f.nextBatch(ctx)
 		if err != nil {
-			return ok, kv, false, err
+			return moreKVs, kv, false, err
 		}
-		if !ok {
+		if !moreKVs {
 			return false, kv, false, nil
 		}
 		f.newSpan = true
@@ -161,14 +172,14 @@ type SpanKVFetcher struct {
 
 // nextBatch implements the kvBatchFetcher interface.
 func (f *SpanKVFetcher) nextBatch(
-	_ context.Context,
-) (ok bool, kvs []roachpb.KeyValue, batchResponse []byte, span roachpb.Span, err error) {
+	ctx context.Context,
+) (ok bool, kvs []roachpb.KeyValue, batchResponse []byte, err error) {
 	if len(f.KVs) == 0 {
-		return false, nil, nil, roachpb.Span{}, nil
+		return false, nil, nil, nil
 	}
 	res := f.KVs
 	f.KVs = nil
-	return true, res, nil, roachpb.Span{}, nil
+	return true, res, nil, nil
 }
 
 func (f *SpanKVFetcher) close(context.Context) {}
@@ -204,8 +215,8 @@ func MakeBackupSSTKVFetcher(
 }
 
 func (f *BackupSSTKVFetcher) nextBatch(
-	_ context.Context,
-) (ok bool, kvs []roachpb.KeyValue, batchResponse []byte, span roachpb.Span, err error) {
+	ctx context.Context,
+) (ok bool, kvs []roachpb.KeyValue, batchResponse []byte, err error) {
 	res := make([]roachpb.KeyValue, 0)
 
 	copyKV := func(mvccKey storage.MVCCKey, value []byte) roachpb.KeyValue {
@@ -223,7 +234,7 @@ func (f *BackupSSTKVFetcher) nextBatch(
 		valid, err := f.iter.Valid()
 		if err != nil {
 			err = errors.Wrapf(err, "iter key value of table data")
-			return false, nil, nil, roachpb.Span{}, err
+			return false, nil, nil, err
 		}
 
 		if !valid || !f.iter.UnsafeKey().Less(f.endKeyMVCC) {
@@ -266,9 +277,9 @@ func (f *BackupSSTKVFetcher) nextBatch(
 
 	}
 	if len(res) == 0 {
-		return false, nil, nil, roachpb.Span{}, err
+		return false, nil, nil, err
 	}
-	return true, res, nil, roachpb.Span{}, nil
+	return true, res, nil, nil
 }
 
 func (f *BackupSSTKVFetcher) close(context.Context) {

--- a/pkg/sql/row/kv_fetcher.go
+++ b/pkg/sql/row/kv_fetcher.go
@@ -125,9 +125,9 @@ func (f *KVFetcher) NextKV(
 				f.batchResponse = nil
 			}
 			return true, roachpb.KeyValue{
-				Key: key,
+				Key: key[:len(key):len(key)],
 				Value: roachpb.Value{
-					RawBytes:  rawBytes,
+					RawBytes:  rawBytes[:len(rawBytes):len(rawBytes)],
 					Timestamp: ts,
 				},
 			}, newSpan, nil

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1951,6 +1951,7 @@ func TestLint(t *testing.T) {
 			"../../sql/colexec/colexecsel",
 			"../../sql/colexec/colexecwindow",
 			"../../sql/colfetcher",
+			"../../sql/row",
 		); err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Updates #64906.

Previously, the cfetcher was completely blind to whether or not the keys
it retrieves from the kvfetcher lie on a batch boundary. This led to
the cfetcher retaining a pointer to 2 fetched batches at once during
fetches, since it doesn't deep copy key or value memory out of the
batches. The retained pointer is required, because the cfetcher needs to
keep the bytes of the last key and value it saw for various reasons.

Now, the kvfetcher and kvbatchfetcher participate by returning whether
or not the most recent returned key or batch lies on a *batch boundary*,
meaning that the next invocation to the fetcher would require sending a
BatchRequest to KV, getting more bytes back.

If this condition is true, the cFetcher will now deep copy its last-seen
KV instead of keeping a pointer into the most recent batch.

This improves memory usage by 2x for a brief moment, since before, the
cFetcher would always have a live pointer to both the last batch and the
next batch until it had a chance to decode the first key of the next
batch.

Commit 5c00812b5d495749133beb1e217639e03fd02246 improved this same
situation by drastically cutting down the window in which the last batch
was retained. But it wasn't quite enough. After this commit, there
should be no moment in time when the fetcher ever retains a pointer to
more than one batch at the same time.

Release note (sql change): reduce instantaneous memory usage during
scans by up to 2x.