### PR TITLE
colexecbase: add casts from decimals to ints and floats

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/dist_vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/dist_vectorize
@@ -489,19 +489,19 @@ NULL
 # width of an integer column during a cast and the vectorized engine not
 # performing the cast to the integer of the desired width (#66306).
 statement ok
-CREATE TABLE t66306 (k DECIMAL PRIMARY KEY);
-INSERT INTO t66306 VALUES (1);
+CREATE TABLE t66306 (s STRING);
+INSERT INTO t66306 VALUES ('foo');
 ALTER TABLE t66306 EXPERIMENTAL_RELOCATE VALUES (ARRAY[2], 1);
 
-query II
-SELECT 1::INT2, k::INT8 FROM t66306;
+query IT
+SELECT 1::INT2, s COLLATE en FROM t66306;
 ----
-1 1
+1  foo
 
 # Sanity check that the wrapped processor is planned for the query above. If it
 # no longer is, we should adjust the query here and above.
 query T
-EXPLAIN (VEC) SELECT 1::INT2, k::INT8 FROM t66306;
+EXPLAIN (VEC) SELECT 1::INT2, s COLLATE en FROM t66306;
 ----
 │
 ├ Node 1

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -191,8 +191,10 @@ SELECT a, b, (a + 1) * (b + 2) FROM a WHERE a < 3
 2  4  18
 2  5  21
 
-statement error .* unhandled cast decimal -> int
+query I
 SELECT (a + 1.0::DECIMAL)::INT FROM a LIMIT 1
+----
+1
 
 # Operations with constants on the left work.
 query I
@@ -223,8 +225,10 @@ statement ok
 CREATE TABLE intdecfloat (a INT, b DECIMAL, c INT4, d INT2, e FLOAT8);
 INSERT INTO intdecfloat VALUES (1, 2.0, 3, 4, 3.5);
 
-statement error .* unhandled cast decimal -> int
+query I
 SELECT (a + b)::INT FROM intdecfloat
+----
+3
 
 query BB
 SELECT b > a, e < b FROM intdecfloat


### PR DESCRIPTION
This commit adds vectorized casts from decimals to ints (of all widths)
and floats.

Addresses: #48135.

Release note: None