### PR TITLE
opt: fix qualified star expansion after joins

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/join
+++ b/pkg/sql/logictest/testdata/logic_test/join
@@ -1112,3 +1112,39 @@ statement ok
 DROP TABLE empty;
 DROP TABLE fk_ref;
 DROP TABLE xy;
+
+statement ok
+CREATE TABLE abcd (a INT, b INT, c INT, d INT)
+
+statement ok
+INSERT INTO abcd VALUES (1, 1, 1, 1), (2, 2, 2, 2)
+
+statement ok
+CREATE TABLE dxby (d INT, x INT, b INT, y INT)
+
+statement ok
+INSERT INTO dxby VALUES (2, 2, 2, 2), (3, 3, 3, 3)
+
+query IIIIII colnames,rowsort
+SELECT * FROM abcd NATURAL FULL OUTER JOIN dxby
+----
+b  d  a     c     x     y
+1  1  1     1     NULL  NULL
+2  2  2     2     2     2
+3  3  NULL  NULL  3     3
+
+# Test that qualified stars expand to all table columns (even those that aren't
+# directly visible); see #66123.
+query IIIIIIII colnames,rowsort
+SELECT abcd.*, dxby.* FROM abcd NATURAL FULL OUTER JOIN dxby
+----
+a     b     c     d     d     x     b     y
+1     1     1     1     NULL  NULL  NULL  NULL
+2     2     2     2     2     2     2     2
+NULL  NULL  NULL  NULL  3     3     3     3
+
+query IIIIIIII colnames,rowsort
+SELECT abcd.*, dxby.* FROM abcd INNER JOIN dxby USING (d, b)
+----
+a  b  c  d  d  x  b  y
+2  2  2  2  2  2  2  2

--- a/pkg/sql/opt/optbuilder/BUILD.bazel
+++ b/pkg/sql/opt/optbuilder/BUILD.bazel
@@ -95,7 +95,6 @@ go_test(
         "//pkg/settings/cluster",
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/colinfo/colinfotestutils",
-        "//pkg/sql/opt/cat",
         "//pkg/sql/opt/memo",
         "//pkg/sql/opt/testutils",
         "//pkg/sql/opt/testutils/opttester",

--- a/pkg/sql/opt/optbuilder/distinct.go
+++ b/pkg/sql/opt/optbuilder/distinct.go
@@ -12,7 +12,6 @@ package optbuilder
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -25,7 +24,7 @@ func (b *Builder) constructDistinct(inScope *scope) memo.RelExpr {
 	// We are doing a distinct along all the projected columns.
 	var private memo.GroupingPrivate
 	for i := range inScope.cols {
-		if inScope.cols[i].visibility == cat.Visible {
+		if inScope.cols[i].visibility == visible {
 			private.GroupingCols.Add(inScope.cols[i].id)
 		}
 	}

--- a/pkg/sql/opt/optbuilder/join.go
+++ b/pkg/sql/opt/optbuilder/join.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -375,7 +374,7 @@ func (jb *usingJoinBuilder) buildNaturalJoin(natural tree.NaturalJoinCond) {
 	var seenCols opt.ColSet
 	for i := range jb.leftScope.cols {
 		leftCol := &jb.leftScope.cols[i]
-		if leftCol.visibility != cat.Visible {
+		if leftCol.visibility != visible {
 			continue
 		}
 		if seenCols.Contains(leftCol.id) {
@@ -444,7 +443,7 @@ func (jb *usingJoinBuilder) addRemainingCols(cols []scopeColumn) {
 		col := &cols[i]
 		if _, ok := jb.hideCols[col]; ok {
 			jb.outScope.cols = append(jb.outScope.cols, *col)
-			jb.outScope.cols[len(jb.outScope.cols)-1].visibility = cat.Hidden
+			jb.outScope.cols[len(jb.outScope.cols)-1].visibility = accessibleByName
 		} else if _, ok := jb.showCols[col]; !ok {
 			jb.outScope.cols = append(jb.outScope.cols, *col)
 		}
@@ -461,7 +460,7 @@ func (jb *usingJoinBuilder) findUsingColumn(
 	var foundCol *scopeColumn
 	for i := range cols {
 		col := &cols[i]
-		if col.visibility == cat.Visible && col.name.MatchesReferenceName(name) {
+		if col.visibility == visible && col.name.MatchesReferenceName(name) {
 			if foundCol != nil {
 				jb.raiseDuplicateColError(name, context)
 			}

--- a/pkg/sql/opt/optbuilder/join.go
+++ b/pkg/sql/opt/optbuilder/join.go
@@ -306,11 +306,6 @@ type usingJoinBuilder struct {
 	// same column may be used multiple times with different aliases.
 	hideCols map[*scopeColumn]struct{}
 
-	// showCols contains the join columns which are not hidden in the result
-	// expression. Note that we cannot simply store the column ids since the
-	// same column may be used multiple times with different aliases.
-	showCols map[*scopeColumn]struct{}
-
 	// ifNullCols contains the ids of each synthesized column which performs the
 	// IFNULL check for a pair of join columns.
 	ifNullCols opt.ColSet
@@ -332,7 +327,6 @@ func (jb *usingJoinBuilder) init(
 		rightScope: rightScope,
 		outScope:   outScope,
 		hideCols:   make(map[*scopeColumn]struct{}),
-		showCols:   make(map[*scopeColumn]struct{}),
 	}
 }
 
@@ -403,8 +397,8 @@ func (jb *usingJoinBuilder) buildNaturalJoin(natural tree.NaturalJoinCond) {
 // the Join operator. If at least one "if null" column exists, the join must be
 // wrapped in a Project operator that performs the required IFNULL checks.
 func (jb *usingJoinBuilder) finishBuild() {
-	jb.addRemainingCols(jb.leftScope.cols)
-	jb.addRemainingCols(jb.rightScope.cols)
+	jb.addCols(jb.leftScope.cols)
+	jb.addCols(jb.rightScope.cols)
 
 	jb.outScope.expr = jb.b.constructJoin(
 		jb.joinType,
@@ -430,22 +424,14 @@ func (jb *usingJoinBuilder) finishBuild() {
 	}
 }
 
-// addRemainingCols iterates through each of the columns in cols and performs
-// one of the following actions:
-// (1) If the column is part of the hideCols set, then it is a join column that
-//     needs to be added to output scope, with the hidden attribute set to true.
-// (2) If the column is part of the showCols set, then it is a join column that
-//     has already been added to the output scope by addEqualityCondition, so
-//     skip it now.
-// (3) All other columns are added to the scope without modification.
-func (jb *usingJoinBuilder) addRemainingCols(cols []scopeColumn) {
+// addCols appends all columns from the given scope. Any columns that are in the
+// hideCols set are marked as accessibleByQualifiedStar.
+func (jb *usingJoinBuilder) addCols(cols []scopeColumn) {
 	for i := range cols {
 		col := &cols[i]
+		jb.outScope.cols = append(jb.outScope.cols, *col)
 		if _, ok := jb.hideCols[col]; ok {
-			jb.outScope.cols = append(jb.outScope.cols, *col)
-			jb.outScope.cols[len(jb.outScope.cols)-1].visibility = accessibleByName
-		} else if _, ok := jb.showCols[col]; !ok {
-			jb.outScope.cols = append(jb.outScope.cols, *col)
+			jb.outScope.cols[len(jb.outScope.cols)-1].visibility = accessibleByQualifiedStar
 		}
 	}
 }
@@ -486,6 +472,10 @@ func (jb *usingJoinBuilder) addEqualityCondition(leftCol, rightCol *scopeColumn)
 		}
 	}
 
+	// We will create a new "merged" column and hide the original columns.
+	jb.hideCols[leftCol] = struct{}{}
+	jb.hideCols[rightCol] = struct{}{}
+
 	// Construct the predicate.
 	leftVar := jb.b.factory.ConstructVariable(leftCol.id)
 	rightVar := jb.b.factory.ConstructVariable(rightCol.id)
@@ -496,16 +486,16 @@ func (jb *usingJoinBuilder) addEqualityCondition(leftCol, rightCol *scopeColumn)
 	if jb.joinType == descpb.InnerJoin || jb.joinType == descpb.LeftOuterJoin {
 		// The merged column is the same as the corresponding column from the
 		// left side.
-		jb.outScope.cols = append(jb.outScope.cols, *leftCol)
-		jb.showCols[leftCol] = struct{}{}
-		jb.hideCols[rightCol] = struct{}{}
+		col := *leftCol
+		col.table = tree.TableName{}
+		jb.outScope.cols = append(jb.outScope.cols, col)
 	} else if jb.joinType == descpb.RightOuterJoin &&
 		!colinfo.HasCompositeKeyEncoding(leftCol.typ) {
 		// The merged column is the same as the corresponding column from the
 		// right side.
-		jb.outScope.cols = append(jb.outScope.cols, *rightCol)
-		jb.showCols[rightCol] = struct{}{}
-		jb.hideCols[leftCol] = struct{}{}
+		col := *rightCol
+		col.table = tree.TableName{}
+		jb.outScope.cols = append(jb.outScope.cols, col)
 	} else {
 		// Construct a new merged column to represent IFNULL(left, right).
 		var typ *types.T
@@ -518,8 +508,6 @@ func (jb *usingJoinBuilder) addEqualityCondition(leftCol, rightCol *scopeColumn)
 		merged := jb.b.factory.ConstructCoalesce(memo.ScalarListExpr{leftVar, rightVar})
 		col := jb.b.synthesizeColumn(jb.outScope, leftCol.name, typ, texpr, merged)
 		jb.ifNullCols.Add(col.id)
-		jb.hideCols[leftCol] = struct{}{}
-		jb.hideCols[rightCol] = struct{}{}
 	}
 }
 

--- a/pkg/sql/opt/optbuilder/name_resolution_test.go
+++ b/pkg/sql/opt/optbuilder/name_resolution_test.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo/colinfotestutils"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
@@ -47,7 +46,7 @@ func (s *scope) ResolveQualifiedStarTestResults(
 	nl := make(tree.NameList, 0, len(s.cols))
 	for i := range s.cols {
 		col := s.cols[i]
-		if col.table == *srcName && col.visibility == cat.Visible {
+		if col.table == *srcName && col.visibility == visible {
 			nl = append(nl, col.name.ReferenceName())
 		}
 	}

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -223,7 +223,7 @@ func (s *scope) appendOrdinaryColumnsFromTable(tabMeta *opt.TableMeta, alias *tr
 			table:      *alias,
 			typ:        tabCol.DatumType(),
 			id:         tabMeta.MetaID.ColumnID(i),
-			visibility: tabCol.Visibility(),
+			visibility: columnVisibility(tabCol.Visibility()),
 		})
 	}
 }
@@ -358,7 +358,7 @@ func (s *scope) makePresentation() physical.Presentation {
 	presentation := make(physical.Presentation, 0, len(s.cols))
 	for i := range s.cols {
 		col := &s.cols[i]
-		if col.visibility == cat.Visible {
+		if col.visibility == visible {
 			presentation = append(presentation, opt.AliasedColumn{
 				Alias: string(col.name.ReferenceName()),
 				ID:    col.id,
@@ -539,7 +539,7 @@ func (s *scope) hasSameColumns(other *scope) bool {
 func (s *scope) removeHiddenCols() {
 	n := 0
 	for i := range s.cols {
-		if s.cols[i].visibility != cat.Visible {
+		if s.cols[i].visibility != visible {
 			s.extraCols = append(s.extraCols, s.cols[i])
 		} else {
 			if n != i {
@@ -696,27 +696,64 @@ func (*scopeColumn) ColumnSourceMeta() {}
 // ColumnResolutionResult implements the tree.ColumnResolutionResult interface.
 func (*scopeColumn) ColumnResolutionResult() {}
 
+// columnMatchClass identifies a class of column matches.
+//
+// We have three classes of column matches:
+//  1. Anonymous source columns
+//  2. Qualified source columns
+//  3. Hidden columns
+//
+// The classes have strict precedence; within a given scope, the resolution
+// outcome is determined by the first class that has at least one match. If
+// there is exactly one match in that class, resolution is successful. If there
+// are more matches, it is an ambiguity error.
+type columnMatchClass int8
+
+const (
+	anonymousSourceMatch columnMatchClass = iota
+	qualifiedSourceMatch
+	hiddenMatch
+)
+
+// candidateTracker keeps track of a candidate *scopeColumn, its match class,
+// and whether there is an ambiguity within that match class. Only information
+// relevant to the "best" match class encountered is retained.
+type candidateTracker struct {
+	col        *scopeColumn
+	ambiguous  bool
+	matchClass columnMatchClass
+}
+
+// Add a potential candidate.
+func (c *candidateTracker) Add(col *scopeColumn, matchClass columnMatchClass) {
+	if c.col == nil || c.matchClass > matchClass {
+		c.col = col
+		c.ambiguous = false
+		c.matchClass = matchClass
+	} else if c.matchClass == matchClass {
+		c.ambiguous = true
+	}
+}
+
 // FindSourceProvidingColumn is part of the tree.ColumnItemResolver interface.
 func (s *scope) FindSourceProvidingColumn(
 	_ context.Context, colName tree.Name,
 ) (prefix *tree.TableName, srcMeta colinfo.ColumnSourceMeta, colHint int, err error) {
-	var candidateFromAnonSource *scopeColumn
-	var candidateWithPrefix *scopeColumn
-	var hiddenCandidate *scopeColumn
-	var moreThanOneCandidateFromAnonSource bool
-	var moreThanOneCandidateWithPrefix bool
-	var moreThanOneHiddenCandidate bool
+	// We start from the current scope; if we find at least one match we are done
+	// (either with a result or an ambiguity error). Otherwise, we search the
+	// parent scope.
+
+	// In case we find no matches anywhere, we remember if we saw an inaccessible
+	// mutation column on the way, in which case we can present a more useful
+	// error.
+	reportBackfillError := false
 
 	// We only allow hidden columns in the current scope. Hidden columns
 	// in parent scopes are not accessible.
 	allowHidden := true
-
-	// If multiple columns match c in the same scope, we return an error
-	// due to ambiguity. If no columns match in the current scope, we
-	// search the parent scope. If the column is not found in any of the
-	// ancestor scopes, we return an error.
-	reportBackfillError := false
 	for ; s != nil; s, allowHidden = s.parent, false {
+		var candidate candidateTracker
+
 		for i := range s.cols {
 			col := &s.cols[i]
 			if !col.name.MatchesReferenceName(colName) {
@@ -724,65 +761,32 @@ func (s *scope) FindSourceProvidingColumn(
 			}
 
 			switch col.visibility {
-			case cat.Inaccessible:
-				// Act as if this column is not present so that matches in higher scopes
-				// can be found. However, if no match is found in higher scopes and this
-				// is a mutation column, report a backfill error rather than a "not
-				// found" error.
+			case inaccessible:
 				if col.mutation {
 					reportBackfillError = true
 				}
 
-			case cat.Visible:
+			case visible:
 				if col.table.ObjectName == "" {
-					if candidateFromAnonSource != nil {
-						moreThanOneCandidateFromAnonSource = true
-					}
-					candidateFromAnonSource = col
+					candidate.Add(col, anonymousSourceMatch)
 				} else {
-					if candidateWithPrefix != nil {
-						moreThanOneCandidateWithPrefix = true
-					}
-					candidateWithPrefix = col
+					candidate.Add(col, qualifiedSourceMatch)
 				}
 
-			case cat.Hidden:
+			case accessibleByName, accessibleByQualifiedStar:
 				if allowHidden {
-					if hiddenCandidate != nil {
-						moreThanOneHiddenCandidate = true
-					}
-					hiddenCandidate = col
+					candidate.Add(col, hiddenMatch)
 				}
 			}
 		}
 
-		// The table name was unqualified, so if a single anonymous source exists
-		// with a matching non-hidden column, use that.
-		if moreThanOneCandidateFromAnonSource {
-			return nil, nil, -1, s.newAmbiguousColumnError(
-				colName, allowHidden, moreThanOneCandidateFromAnonSource, moreThanOneCandidateWithPrefix, moreThanOneHiddenCandidate,
-			)
+		if col := candidate.col; col != nil {
+			if candidate.ambiguous {
+				return nil, nil, -1, s.newAmbiguousColumnError(colName, candidate.matchClass)
+			}
+			return &col.table, col, int(col.id), nil
 		}
-		if candidateFromAnonSource != nil {
-			return &candidateFromAnonSource.table, candidateFromAnonSource, int(candidateFromAnonSource.id), nil
-		}
-
-		// Else if a single named source exists with a matching non-hidden column,
-		// use that.
-		if candidateWithPrefix != nil && !moreThanOneCandidateWithPrefix {
-			return &candidateWithPrefix.table, candidateWithPrefix, int(candidateWithPrefix.id), nil
-		}
-		if moreThanOneCandidateWithPrefix || moreThanOneHiddenCandidate {
-			return nil, nil, -1, s.newAmbiguousColumnError(
-				colName, allowHidden, moreThanOneCandidateFromAnonSource, moreThanOneCandidateWithPrefix, moreThanOneHiddenCandidate,
-			)
-		}
-
-		// One last option: if a single source exists with a matching hidden
-		// column, use that.
-		if hiddenCandidate != nil {
-			return &hiddenCandidate.table, hiddenCandidate, int(hiddenCandidate.id), nil
-		}
+		// No matches in this scope; proceed to the parent scope.
 	}
 
 	// Make a copy of colName so that passing a reference to tree.ErrString does
@@ -793,6 +797,51 @@ func (s *scope) FindSourceProvidingColumn(
 		return nil, nil, -1, makeBackfillError(tmpName)
 	}
 	return nil, nil, -1, colinfo.NewUndefinedColumnError(tree.ErrString(&tmpName))
+}
+
+// newAmbiguousColumnError returns an error with a helpful error message to be
+// used in case of an ambiguous column reference.
+func (s *scope) newAmbiguousColumnError(n tree.Name, matchClass columnMatchClass) error {
+	colString := tree.ErrString(&n)
+	var msgBuf bytes.Buffer
+	// Search the scope for columns that match our column name and the match
+	// class.
+	for i := range s.cols {
+		col := &s.cols[i]
+		if !col.name.MatchesReferenceName(n) {
+			continue
+		}
+		var match bool
+		switch matchClass {
+		case anonymousSourceMatch:
+			match = (col.visibility == visible && col.table.ObjectName == "")
+
+		case qualifiedSourceMatch:
+			match = (col.visibility == visible && col.table.ObjectName != "")
+
+		case hiddenMatch:
+			match = (col.visibility == accessibleByName || col.visibility == accessibleByQualifiedStar)
+		}
+
+		if match {
+			srcName := tree.ErrString(&col.table)
+			if len(srcName) == 0 {
+				srcName = "<anonymous>"
+			}
+			if msgBuf.Len() > 0 {
+				msgBuf.WriteString(", ")
+			}
+			fmt.Fprintf(&msgBuf, "%s.%s", srcName, colString)
+			if matchClass == anonymousSourceMatch {
+				// All anonymous sources are identical; only print the first one.
+				break
+			}
+		}
+	}
+
+	return pgerror.Newf(pgcode.AmbiguousColumn,
+		"column reference %q is ambiguous (candidates: %s)", colString, msgBuf.String(),
+	)
 }
 
 // FindSourceMatchingName is part of the tree.ColumnItemResolver interface.
@@ -1517,49 +1566,6 @@ func (s *scope) IndexedVarResolvedType(idx int) *types.T {
 // IndexedVarNodeFormatter is part of the IndexedVarContainer interface.
 func (s *scope) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
 	panic(errors.AssertionFailedf("unimplemented: scope.IndexedVarNodeFormatter"))
-}
-
-// newAmbiguousColumnError returns an error with a helpful error message to be
-// used in case of an ambiguous column reference.
-func (s *scope) newAmbiguousColumnError(
-	n tree.Name,
-	allowHidden, moreThanOneCandidateFromAnonSource, moreThanOneCandidateWithPrefix, moreThanOneHiddenCandidate bool,
-) error {
-	colString := tree.ErrString(&n)
-	var msgBuf bytes.Buffer
-	sep := ""
-	fmtCandidate := func(tn tree.TableName) {
-		name := tree.ErrString(&tn)
-		if len(name) == 0 {
-			name = "<anonymous>"
-		}
-		fmt.Fprintf(&msgBuf, "%s%s.%s", sep, name, colString)
-		sep = ", "
-	}
-	for i := range s.cols {
-		col := &s.cols[i]
-		if col.name.MatchesReferenceName(n) && (col.visibility == cat.Visible || (col.visibility == cat.Hidden && allowHidden)) {
-			if col.table.ObjectName == "" && col.visibility == cat.Visible {
-				if moreThanOneCandidateFromAnonSource {
-					// Only print first anonymous source, since other(s) are identical.
-					fmtCandidate(col.table)
-					break
-				}
-			} else if col.visibility == cat.Visible {
-				if moreThanOneCandidateWithPrefix && !moreThanOneCandidateFromAnonSource {
-					fmtCandidate(col.table)
-				}
-			} else {
-				if moreThanOneHiddenCandidate && !moreThanOneCandidateWithPrefix && !moreThanOneCandidateFromAnonSource {
-					fmtCandidate(col.table)
-				}
-			}
-		}
-	}
-
-	return pgerror.Newf(pgcode.AmbiguousColumn,
-		"column reference %q is ambiguous (candidates: %s)", colString, msgBuf.String(),
-	)
 }
 
 // newAmbiguousSourceError returns an error with a helpful error message to be

--- a/pkg/sql/opt/optbuilder/scope_column.go
+++ b/pkg/sql/opt/optbuilder/scope_column.go
@@ -37,7 +37,7 @@ type scopeColumn struct {
 	// columns in the query.
 	id opt.ColumnID
 
-	visibility cat.ColumnVisibility
+	visibility columnVisibility
 
 	// tableOrdinal is set to the table ordinal corresponding to this column, if
 	// this is a column from a scan.
@@ -65,6 +65,45 @@ type scopeColumn struct {
 	// exprStr contains a stringified representation of expr, or the original
 	// column name if expr is nil. It is populated lazily inside getExprStr().
 	exprStr string
+}
+
+// columnVisibility is an extension of cat.ColumnVisibility.
+// cat.ColumnVisibility values can be converted directly.
+type columnVisibility uint8
+
+const (
+	// visible columns are part of the presentation of a query. Visible columns
+	// contribute to star expansions.
+	visible = columnVisibility(cat.Visible)
+
+	// accessibleByQualifiedStar columns are accessible by name or by a qualified
+	// star "<table>.*". This is a rare case, occurring in joins:
+	//   ab NATURAL LEFT JOIN ac
+	// Here ac.a is not visible (or part of the unqualified star expansion) but it
+	// is accessible via ac.*.
+	accessibleByQualifiedStar = columnVisibility(10)
+
+	// accessibleByName columns are accessible by name but are otherwise not
+	// visible; they do not contribute to star expansions.
+	accessibleByName = columnVisibility(cat.Hidden)
+
+	// inaccessible columns cannot be referred to by name (or any other means).
+	inaccessible = columnVisibility(cat.Inaccessible)
+)
+
+func (cv columnVisibility) String() string {
+	switch cv {
+	case visible:
+		return "visible"
+	case accessibleByQualifiedStar:
+		return "accessible-by-qualified-star"
+	case accessibleByName:
+		return "accessible-by-name"
+	case inaccessible:
+		return "inaccessible"
+	default:
+		return "invalid-column-visibility"
+	}
 }
 
 // clearName sets the empty table and column name. This is used to make the

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -357,7 +357,7 @@ func (b *Builder) renameSource(as tree.AliasClause, scope *scope) {
 					))
 				}
 				col := &scope.cols[colIdx]
-				if col.visibility != cat.Visible {
+				if col.visibility != visible {
 					continue
 				}
 				col.name = scopeColName(colAlias[aliasIdx])
@@ -484,7 +484,7 @@ func (b *Builder) buildScan(
 			name:         scopeColName(name),
 			table:        tabMeta.Alias,
 			typ:          col.DatumType(),
-			visibility:   col.Visibility(),
+			visibility:   columnVisibility(col.Visibility()),
 			kind:         kind,
 			mutation:     kind == cat.WriteOnly || kind == cat.DeleteOnly,
 			tableOrdinal: ord,

--- a/pkg/sql/opt/optbuilder/testdata/join
+++ b/pkg/sql/opt/optbuilder/testdata/join
@@ -1391,7 +1391,7 @@ build
 SELECT t1.*, t2.* FROM t1 NATURAL JOIN t2
 ----
 project
- ├── columns: x:2!null y:4!null col1:1 col2:3 col3:8 col4:11
+ ├── columns: col1:1 x:2!null col2:3 y:4!null col3:8 y:9!null x:10!null col4:11
  └── inner-join (hash)
       ├── columns: col1:1 t1.x:2!null col2:3 t1.y:4!null t1.rowid:5!null t1.crdb_internal_mvcc_timestamp:6 t1.tableoid:7 col3:8 t2.y:9!null t2.x:10!null col4:11 t2.rowid:12!null t2.crdb_internal_mvcc_timestamp:13 t2.tableoid:14
       ├── scan t1
@@ -2670,3 +2670,158 @@ inner-join (hash)
  │              └── columns: c0:5 rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
  └── filters
       └── c0:1 = c0:5
+
+exec-ddl
+CREATE TABLE abcd (a INT, b INT, c INT, d INT)
+----
+
+exec-ddl
+CREATE TABLE dxby (d INT, x INT, b INT, y INT)
+----
+
+build
+SELECT * FROM abcd NATURAL FULL OUTER JOIN dxby
+----
+project
+ ├── columns: b:15 d:16 a:1 c:3 x:9 y:11
+ └── project
+      ├── columns: b:15 d:16 a:1 abcd.b:2 c:3 abcd.d:4 abcd.rowid:5 abcd.crdb_internal_mvcc_timestamp:6 abcd.tableoid:7 dxby.d:8 x:9 dxby.b:10 y:11 dxby.rowid:12 dxby.crdb_internal_mvcc_timestamp:13 dxby.tableoid:14
+      ├── full-join (hash)
+      │    ├── columns: a:1 abcd.b:2 c:3 abcd.d:4 abcd.rowid:5 abcd.crdb_internal_mvcc_timestamp:6 abcd.tableoid:7 dxby.d:8 x:9 dxby.b:10 y:11 dxby.rowid:12 dxby.crdb_internal_mvcc_timestamp:13 dxby.tableoid:14
+      │    ├── scan abcd
+      │    │    └── columns: a:1 abcd.b:2 c:3 abcd.d:4 abcd.rowid:5!null abcd.crdb_internal_mvcc_timestamp:6 abcd.tableoid:7
+      │    ├── scan dxby
+      │    │    └── columns: dxby.d:8 x:9 dxby.b:10 y:11 dxby.rowid:12!null dxby.crdb_internal_mvcc_timestamp:13 dxby.tableoid:14
+      │    └── filters
+      │         ├── abcd.b:2 = dxby.b:10
+      │         └── abcd.d:4 = dxby.d:8
+      └── projections
+           ├── COALESCE(abcd.b:2, dxby.b:10) [as=b:15]
+           └── COALESCE(abcd.d:4, dxby.d:8) [as=d:16]
+
+# Test that qualified stars expand to all table columns (even those that aren't
+# directly visible); see #66123.
+build
+SELECT abcd.*, dxby.* FROM abcd NATURAL INNER JOIN dxby
+----
+project
+ ├── columns: a:1 b:2!null c:3 d:4!null d:8!null x:9 b:10!null y:11
+ └── inner-join (hash)
+      ├── columns: a:1 abcd.b:2!null c:3 abcd.d:4!null abcd.rowid:5!null abcd.crdb_internal_mvcc_timestamp:6 abcd.tableoid:7 dxby.d:8!null x:9 dxby.b:10!null y:11 dxby.rowid:12!null dxby.crdb_internal_mvcc_timestamp:13 dxby.tableoid:14
+      ├── scan abcd
+      │    └── columns: a:1 abcd.b:2 c:3 abcd.d:4 abcd.rowid:5!null abcd.crdb_internal_mvcc_timestamp:6 abcd.tableoid:7
+      ├── scan dxby
+      │    └── columns: dxby.d:8 x:9 dxby.b:10 y:11 dxby.rowid:12!null dxby.crdb_internal_mvcc_timestamp:13 dxby.tableoid:14
+      └── filters
+           ├── abcd.b:2 = dxby.b:10
+           └── abcd.d:4 = dxby.d:8
+
+build
+SELECT abcd.*, dxby.* FROM abcd NATURAL LEFT OUTER JOIN dxby
+----
+project
+ ├── columns: a:1 b:2 c:3 d:4 d:8 x:9 b:10 y:11
+ └── left-join (hash)
+      ├── columns: a:1 abcd.b:2 c:3 abcd.d:4 abcd.rowid:5!null abcd.crdb_internal_mvcc_timestamp:6 abcd.tableoid:7 dxby.d:8 x:9 dxby.b:10 y:11 dxby.rowid:12 dxby.crdb_internal_mvcc_timestamp:13 dxby.tableoid:14
+      ├── scan abcd
+      │    └── columns: a:1 abcd.b:2 c:3 abcd.d:4 abcd.rowid:5!null abcd.crdb_internal_mvcc_timestamp:6 abcd.tableoid:7
+      ├── scan dxby
+      │    └── columns: dxby.d:8 x:9 dxby.b:10 y:11 dxby.rowid:12!null dxby.crdb_internal_mvcc_timestamp:13 dxby.tableoid:14
+      └── filters
+           ├── abcd.b:2 = dxby.b:10
+           └── abcd.d:4 = dxby.d:8
+
+build
+SELECT abcd.*, dxby.* FROM abcd NATURAL RIGHT OUTER JOIN dxby
+----
+project
+ ├── columns: a:1 b:2 c:3 d:4 d:8 x:9 b:10 y:11
+ └── right-join (hash)
+      ├── columns: a:1 abcd.b:2 c:3 abcd.d:4 abcd.rowid:5 abcd.crdb_internal_mvcc_timestamp:6 abcd.tableoid:7 dxby.d:8 x:9 dxby.b:10 y:11 dxby.rowid:12!null dxby.crdb_internal_mvcc_timestamp:13 dxby.tableoid:14
+      ├── scan abcd
+      │    └── columns: a:1 abcd.b:2 c:3 abcd.d:4 abcd.rowid:5!null abcd.crdb_internal_mvcc_timestamp:6 abcd.tableoid:7
+      ├── scan dxby
+      │    └── columns: dxby.d:8 x:9 dxby.b:10 y:11 dxby.rowid:12!null dxby.crdb_internal_mvcc_timestamp:13 dxby.tableoid:14
+      └── filters
+           ├── abcd.b:2 = dxby.b:10
+           └── abcd.d:4 = dxby.d:8
+
+build
+SELECT abcd.*, dxby.* FROM abcd NATURAL FULL OUTER JOIN dxby
+----
+project
+ ├── columns: a:1 b:2 c:3 d:4 d:8 x:9 b:10 y:11
+ └── project
+      ├── columns: b:15 d:16 a:1 abcd.b:2 c:3 abcd.d:4 abcd.rowid:5 abcd.crdb_internal_mvcc_timestamp:6 abcd.tableoid:7 dxby.d:8 x:9 dxby.b:10 y:11 dxby.rowid:12 dxby.crdb_internal_mvcc_timestamp:13 dxby.tableoid:14
+      ├── full-join (hash)
+      │    ├── columns: a:1 abcd.b:2 c:3 abcd.d:4 abcd.rowid:5 abcd.crdb_internal_mvcc_timestamp:6 abcd.tableoid:7 dxby.d:8 x:9 dxby.b:10 y:11 dxby.rowid:12 dxby.crdb_internal_mvcc_timestamp:13 dxby.tableoid:14
+      │    ├── scan abcd
+      │    │    └── columns: a:1 abcd.b:2 c:3 abcd.d:4 abcd.rowid:5!null abcd.crdb_internal_mvcc_timestamp:6 abcd.tableoid:7
+      │    ├── scan dxby
+      │    │    └── columns: dxby.d:8 x:9 dxby.b:10 y:11 dxby.rowid:12!null dxby.crdb_internal_mvcc_timestamp:13 dxby.tableoid:14
+      │    └── filters
+      │         ├── abcd.b:2 = dxby.b:10
+      │         └── abcd.d:4 = dxby.d:8
+      └── projections
+           ├── COALESCE(abcd.b:2, dxby.b:10) [as=b:15]
+           └── COALESCE(abcd.d:4, dxby.d:8) [as=d:16]
+
+build
+SELECT abcd.*, dxby.* FROM abcd FULL OUTER JOIN dxby USING (d, b)
+----
+project
+ ├── columns: a:1 b:2 c:3 d:4 d:8 x:9 b:10 y:11
+ └── project
+      ├── columns: d:15 b:16 a:1 abcd.b:2 c:3 abcd.d:4 abcd.rowid:5 abcd.crdb_internal_mvcc_timestamp:6 abcd.tableoid:7 dxby.d:8 x:9 dxby.b:10 y:11 dxby.rowid:12 dxby.crdb_internal_mvcc_timestamp:13 dxby.tableoid:14
+      ├── full-join (hash)
+      │    ├── columns: a:1 abcd.b:2 c:3 abcd.d:4 abcd.rowid:5 abcd.crdb_internal_mvcc_timestamp:6 abcd.tableoid:7 dxby.d:8 x:9 dxby.b:10 y:11 dxby.rowid:12 dxby.crdb_internal_mvcc_timestamp:13 dxby.tableoid:14
+      │    ├── scan abcd
+      │    │    └── columns: a:1 abcd.b:2 c:3 abcd.d:4 abcd.rowid:5!null abcd.crdb_internal_mvcc_timestamp:6 abcd.tableoid:7
+      │    ├── scan dxby
+      │    │    └── columns: dxby.d:8 x:9 dxby.b:10 y:11 dxby.rowid:12!null dxby.crdb_internal_mvcc_timestamp:13 dxby.tableoid:14
+      │    └── filters
+      │         ├── abcd.d:4 = dxby.d:8
+      │         └── abcd.b:2 = dxby.b:10
+      └── projections
+           ├── COALESCE(abcd.d:4, dxby.d:8) [as=d:15]
+           └── COALESCE(abcd.b:2, dxby.b:10) [as=b:16]
+
+build
+SELECT abcd.a, abcd.b, abcd.c, abcd.d, dxby.d, dxby.x, dxby.b, dxby.y FROM abcd NATURAL FULL OUTER JOIN dxby
+----
+project
+ ├── columns: a:1 b:2 c:3 d:4 d:8 x:9 b:10 y:11
+ └── project
+      ├── columns: b:15 d:16 a:1 abcd.b:2 c:3 abcd.d:4 abcd.rowid:5 abcd.crdb_internal_mvcc_timestamp:6 abcd.tableoid:7 dxby.d:8 x:9 dxby.b:10 y:11 dxby.rowid:12 dxby.crdb_internal_mvcc_timestamp:13 dxby.tableoid:14
+      ├── full-join (hash)
+      │    ├── columns: a:1 abcd.b:2 c:3 abcd.d:4 abcd.rowid:5 abcd.crdb_internal_mvcc_timestamp:6 abcd.tableoid:7 dxby.d:8 x:9 dxby.b:10 y:11 dxby.rowid:12 dxby.crdb_internal_mvcc_timestamp:13 dxby.tableoid:14
+      │    ├── scan abcd
+      │    │    └── columns: a:1 abcd.b:2 c:3 abcd.d:4 abcd.rowid:5!null abcd.crdb_internal_mvcc_timestamp:6 abcd.tableoid:7
+      │    ├── scan dxby
+      │    │    └── columns: dxby.d:8 x:9 dxby.b:10 y:11 dxby.rowid:12!null dxby.crdb_internal_mvcc_timestamp:13 dxby.tableoid:14
+      │    └── filters
+      │         ├── abcd.b:2 = dxby.b:10
+      │         └── abcd.d:4 = dxby.d:8
+      └── projections
+           ├── COALESCE(abcd.b:2, dxby.b:10) [as=b:15]
+           └── COALESCE(abcd.d:4, dxby.d:8) [as=d:16]
+
+build
+SELECT abcd.a, abcd.b, abcd.c, abcd.d, dxby.d, dxby.x, dxby.b, dxby.y FROM abcd FULL OUTER JOIN dxby USING (d, b)
+----
+project
+ ├── columns: a:1 b:2 c:3 d:4 d:8 x:9 b:10 y:11
+ └── project
+      ├── columns: d:15 b:16 a:1 abcd.b:2 c:3 abcd.d:4 abcd.rowid:5 abcd.crdb_internal_mvcc_timestamp:6 abcd.tableoid:7 dxby.d:8 x:9 dxby.b:10 y:11 dxby.rowid:12 dxby.crdb_internal_mvcc_timestamp:13 dxby.tableoid:14
+      ├── full-join (hash)
+      │    ├── columns: a:1 abcd.b:2 c:3 abcd.d:4 abcd.rowid:5 abcd.crdb_internal_mvcc_timestamp:6 abcd.tableoid:7 dxby.d:8 x:9 dxby.b:10 y:11 dxby.rowid:12 dxby.crdb_internal_mvcc_timestamp:13 dxby.tableoid:14
+      │    ├── scan abcd
+      │    │    └── columns: a:1 abcd.b:2 c:3 abcd.d:4 abcd.rowid:5!null abcd.crdb_internal_mvcc_timestamp:6 abcd.tableoid:7
+      │    ├── scan dxby
+      │    │    └── columns: dxby.d:8 x:9 dxby.b:10 y:11 dxby.rowid:12!null dxby.crdb_internal_mvcc_timestamp:13 dxby.tableoid:14
+      │    └── filters
+      │         ├── abcd.d:4 = dxby.d:8
+      │         └── abcd.b:2 = dxby.b:10
+      └── projections
+           ├── COALESCE(abcd.d:4, dxby.d:8) [as=d:15]
+           └── COALESCE(abcd.b:2, dxby.b:10) [as=b:16]

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -119,7 +119,7 @@ func (b *Builder) expandStar(
 		aliases = make([]string, 0, len(refScope.cols))
 		for i := range refScope.cols {
 			col := &refScope.cols[i]
-			if col.table == *src && col.visibility == cat.Visible {
+			if col.table == *src && (col.visibility == visible || col.visibility == accessibleByQualifiedStar) {
 				exprs = append(exprs, col)
 				aliases = append(aliases, string(col.name.ReferenceName()))
 			}
@@ -134,7 +134,7 @@ func (b *Builder) expandStar(
 		aliases = make([]string, 0, len(inScope.cols))
 		for i := range inScope.cols {
 			col := &inScope.cols[i]
-			if col.visibility == cat.Visible {
+			if col.visibility == visible {
 				exprs = append(exprs, col)
 				aliases = append(aliases, string(col.name.ReferenceName()))
 			}
@@ -247,7 +247,7 @@ func (b *Builder) synthesizeResultColumns(scope *scope, cols colinfo.ResultColum
 	for i := range cols {
 		c := b.synthesizeColumn(scope, scopeColName(tree.Name(cols[i].Name)), cols[i].Typ, nil /* expr */, nil /* scalar */)
 		if cols[i].Hidden {
-			c.visibility = cat.Hidden
+			c.visibility = accessibleByName
 		}
 	}
 }


### PR DESCRIPTION
#### opt: introduce "accessible by qualified star" column visibility in optbuilder

This commit extends `cat.Visibility` into a new `columnVisibility`
type and adds a new value for columns which are not visible by default
but are part of qualified star expansions (`<table_name>.*` aka "all
columns selector").

Release note: None

#### opt: fix qualified star expansion after joins

When using JOIN NATURAL/USING, the equality columns are visible in the
result only once. However, the original table columns are still
accessible by qualified star ("<table_name>.*"). These columns are
currently missing from the qualified star expansion.

This commit fixes this problem by making use of the new
`accessibleByQualifiedStar` visibility.

Fixes #66123.