### PR TITLE
util/stop: a better async task interface

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -1342,9 +1343,13 @@ func (ds *DistSender) sendPartialBatchAsync(
 	batchIdx int,
 	responseCh chan response,
 ) bool {
-	if err := ds.rpcContext.Stopper.RunLimitedAsyncTask(
-		ctx, "kv.DistSender: sending partial batch",
-		ds.asyncSenderSem, false, /* wait */
+	if err := ds.rpcContext.Stopper.RunAsyncTaskEx(
+		ctx,
+		stop.TaskOpts{
+			TaskName:   "kv.DistSender: sending partial batch",
+			Sem:        ds.asyncSenderSem,
+			WaitForSem: false,
+		},
 		func(ctx context.Context) {
 			ds.metrics.AsyncSentCount.Inc(1)
 			responseCh <- ds.sendPartialBatch(

--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -1347,6 +1347,7 @@ func (ds *DistSender) sendPartialBatchAsync(
 		ctx,
 		stop.TaskOpts{
 			TaskName:   "kv.DistSender: sending partial batch",
+			ChildSpan:  true,
 			Sem:        ds.asyncSenderSem,
 			WaitForSem: false,
 		},

--- a/pkg/kv/kvserver/queue.go
+++ b/pkg/kv/kvserver/queue.go
@@ -576,7 +576,12 @@ func (bq *baseQueue) Async(
 		log.InfofDepth(ctx, 2, "%s", log.Safe(opName))
 	}
 	opName += " (" + bq.name + ")"
-	if err := bq.store.stopper.RunLimitedAsyncTask(context.Background(), opName, bq.addOrMaybeAddSem, wait,
+	if err := bq.store.stopper.RunAsyncTaskEx(context.Background(),
+		stop.TaskOpts{
+			TaskName:   opName,
+			Sem:        bq.addOrMaybeAddSem,
+			WaitForSem: wait,
+		},
 		func(ctx context.Context) {
 			fn(ctx, baseQueueHelper{bq})
 		}); err != nil && bq.addLogN.ShouldLog() {

--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -785,33 +786,37 @@ func (txn *Txn) rollback(ctx context.Context) *roachpb.Error {
 	// through Raft, and the intent resolver has free async task capacity, the
 	// actual cleanup will be independent of this context.
 	stopper := txn.db.ctx.Stopper
-	ctx, cancel := stopper.WithCancelOnQuiesce(contextutil.WithoutCancel(ctx))
-	if err := stopper.RunAsyncTask(ctx, "async-rollback", func(ctx context.Context) {
-		defer cancel()
-		// A batch with only endTxnReq is not subject to admission control, in
-		// order to reduce contention by releasing locks. In multi-tenant
-		// settings, it will be subject to admission control, and the zero
-		// CreateTime will give it preference within the tenant.
-		var ba roachpb.BatchRequest
-		ba.Add(endTxnReq(false /* commit */, nil /* deadline */, false /* systemConfigTrigger */))
-		_ = contextutil.RunWithTimeout(ctx, "async txn rollback", asyncRollbackTimeout,
-			func(ctx context.Context) error {
-				if _, pErr := txn.Send(ctx, ba); pErr != nil {
-					if statusErr, ok := pErr.GetDetail().(*roachpb.TransactionStatusError); ok &&
-						statusErr.Reason == roachpb.TransactionStatusError_REASON_TXN_COMMITTED {
-						// A common cause of these async rollbacks failing is when they're
-						// triggered by a ctx canceled while a commit is in-flight (and it's too
-						// late for it to be canceled), and so the rollback finds the txn to be
-						// already committed. We don't spam the logs with those.
-						log.VEventf(ctx, 2, "async rollback failed: %s", pErr)
-					} else {
-						log.Infof(ctx, "async rollback failed: %s", pErr)
+	if err := stopper.RunAsyncTaskEx(ctx,
+		stop.TaskOpts{
+			TaskName:                "aync-rollback",
+			DontInheritCancellation: true,
+			CancelOnQuiesce:         true,
+			ChildSpan:               false,
+		},
+		func(ctx context.Context) {
+			// A batch with only endTxnReq is not subject to admission control, in
+			// order to reduce contention by releasing locks. In multi-tenant
+			// settings, it will be subject to admission control, and the zero
+			// CreateTime will give it preference within the tenant.
+			var ba roachpb.BatchRequest
+			ba.Add(endTxnReq(false /* commit */, nil /* deadline */, false /* systemConfigTrigger */))
+			_ = contextutil.RunWithTimeout(ctx, "async txn rollback", asyncRollbackTimeout,
+				func(ctx context.Context) error {
+					if _, pErr := txn.Send(ctx, ba); pErr != nil {
+						if statusErr, ok := pErr.GetDetail().(*roachpb.TransactionStatusError); ok &&
+							statusErr.Reason == roachpb.TransactionStatusError_REASON_TXN_COMMITTED {
+							// A common cause of these async rollbacks failing is when they're
+							// triggered by a ctx canceled while a commit is in-flight (and it's too
+							// late for it to be canceled), and so the rollback finds the txn to be
+							// already committed. We don't spam the logs with those.
+							log.VEventf(ctx, 2, "async rollback failed: %s", pErr)
+						} else {
+							log.Infof(ctx, "async rollback failed: %s", pErr)
+						}
 					}
-				}
-				return nil
-			})
-	}); err != nil {
-		cancel()
+					return nil
+				})
+		}); err != nil {
 		return roachpb.NewError(err)
 	}
 	return nil

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -1955,9 +1955,13 @@ func (s *statusServer) iterateNodes(
 	defer cancel()
 	for nodeID := range nodeStatuses {
 		nodeID := nodeID // needed to ensure the closure below captures a copy.
-		if err := s.stopper.RunLimitedAsyncTask(
-			ctx, fmt.Sprintf("server.statusServer: requesting %s", errorCtx),
-			sem, true, /* wait */
+		if err := s.stopper.RunAsyncTaskEx(
+			ctx,
+			stop.TaskOpts{
+				TaskName:   fmt.Sprintf("server.statusServer: requesting %s", errorCtx),
+				Sem:        sem,
+				WaitForSem: true,
+			},
 			func(ctx context.Context) { nodeQuery(ctx, nodeID) },
 		); err != nil {
 			return err
@@ -2046,9 +2050,13 @@ func (s *statusServer) paginatedIterateNodes(
 	for idx, nodeID := range nodeIDs {
 		nodeID := nodeID // needed to ensure the closure below captures a copy.
 		idx := idx
-		if err := s.stopper.RunLimitedAsyncTask(
-			ctx, fmt.Sprintf("server.statusServer: requesting %s", errorCtx),
-			sem, true, /* wait */
+		if err := s.stopper.RunAsyncTaskEx(
+			ctx,
+			stop.TaskOpts{
+				TaskName:   fmt.Sprintf("server.statusServer: requesting %s", errorCtx),
+				Sem:        sem,
+				WaitForSem: true,
+			},
 			func(ctx context.Context) { paginator.queryNode(ctx, nodeID, idx) },
 		); err != nil {
 			return pagState, err

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -1932,8 +1932,14 @@ func (m *Manager) refreshSomeLeases(ctx context.Context) {
 	for i := range ids {
 		id := ids[i]
 		wg.Add(1)
-		if err := m.stopper.RunLimitedAsyncTask(
-			ctx, fmt.Sprintf("refresh descriptor: %d lease", id), m.sem, true /*wait*/, func(ctx context.Context) {
+		if err := m.stopper.RunAsyncTaskEx(
+			ctx,
+			stop.TaskOpts{
+				TaskName:   fmt.Sprintf("refresh descriptor: %d lease", id),
+				Sem:        m.sem,
+				WaitForSem: true,
+			},
+			func(ctx context.Context) {
 				defer wg.Done()
 				if _, err := acquireNodeLease(ctx, m, id); err != nil {
 					log.Infof(ctx, "refreshing descriptor: %d lease failed: %s", id, err)
@@ -1996,8 +2002,14 @@ SELECT "descID", version, expiration FROM system.public.lease AS OF SYSTEM TIME 
 				version:    int(tree.MustBeDInt(row[1])),
 				expiration: tree.MustBeDTimestamp(row[2]),
 			}
-			if err := m.stopper.RunLimitedAsyncTask(
-				ctx, fmt.Sprintf("release lease %+v", lease), m.sem, true /*wait*/, func(ctx context.Context) {
+			if err := m.stopper.RunAsyncTaskEx(
+				ctx,
+				stop.TaskOpts{
+					TaskName:   fmt.Sprintf("release lease %+v", lease),
+					Sem:        m.sem,
+					WaitForSem: true,
+				},
+				func(ctx context.Context) {
 					m.storage.release(ctx, m.stopper, &lease)
 					log.Infof(ctx, "released orphaned lease: %+v", lease)
 					wg.Done()

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -1772,6 +1772,7 @@ WHERE message LIKE 'querying next range at /Table/74/1%' OR
       message = '=== SPAN START: kv.DistSender: sending partial batch ==='
 ----
 querying next range at /Table/74/1/0/0
+=== SPAN START: kv.DistSender: sending partial batch ===
 querying next range at /Table/74/1/10/0
 
 # Test for 42202 -- ensure filters can get pushed down through project-set.

--- a/pkg/sql/opt/exec/execbuilder/testdata/show_trace_nonmetamorphic
+++ b/pkg/sql/opt/exec/execbuilder/testdata/show_trace_nonmetamorphic
@@ -73,7 +73,7 @@ SET tracing = on,kv,results; INSERT INTO t.kv(k, v) VALUES (1,2); SET tracing = 
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
- WHERE operation != 'dist sender send'
+ WHERE operation != 'dist sender send' AND operation != 'kv.DistSender: sending partial batch'
 ----
 batch flow coordinator  CPut /Table/54/1/1/0 -> /TUPLE/2:2:Int/2
 batch flow coordinator  InitPut /Table/54/2/2/0 -> /BYTES/0x89
@@ -87,7 +87,7 @@ SET tracing = on,kv,results; INSERT INTO t.kv(k, v) VALUES (1,2); SET tracing = 
 query TT
 set tracing=off;
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
- WHERE operation != 'dist sender send'
+ WHERE operation != 'dist sender send' AND operation != 'kv.DistSender: sending partial batch'
 ----
 batch flow coordinator  CPut /Table/54/1/1/0 -> /TUPLE/2:2:Int/2
 batch flow coordinator  InitPut /Table/54/2/2/0 -> /BYTES/0x89
@@ -99,7 +99,7 @@ SET tracing = on,kv,results; INSERT INTO t.kv(k, v) VALUES (2,2); SET tracing = 
 query TT
 set tracing=off;
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
- WHERE operation != 'dist sender send'
+ WHERE operation != 'dist sender send' AND operation != 'kv.DistSender: sending partial batch'
 ----
 batch flow coordinator  CPut /Table/54/1/2/0 -> /TUPLE/2:2:Int/2
 batch flow coordinator  InitPut /Table/54/2/2/0 -> /BYTES/0x8a
@@ -176,7 +176,7 @@ SET tracing = on,kv,results; DELETE FROM t.kv; SET tracing = off
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
- WHERE operation != 'dist sender send'
+ WHERE operation != 'dist sender send' AND operation != 'kv.DistSender: sending partial batch'
 ----
 colbatchscan            Scan /Table/54/{1-2}
 colbatchscan            fetched: /kv/primary/1/v -> /2

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert_nonmetamorphic
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert_nonmetamorphic
@@ -36,7 +36,7 @@ SET tracing = on,kv,results; UPSERT INTO t.kv(k, v) VALUES (2,3); SET tracing = 
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
- WHERE operation != 'dist sender send'
+ WHERE operation != 'dist sender send' AND operation != 'kv.DistSender: sending partial batch'
 ----
 colbatchscan            Scan /Table/55/1/2/0
 batch flow coordinator  CPut /Table/55/1/2/0 -> /TUPLE/2:2:Int/3
@@ -49,7 +49,7 @@ SET tracing = on,kv,results; UPSERT INTO t.kv(k, v) VALUES (1,2); SET tracing = 
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
- WHERE operation != 'dist sender send'
+ WHERE operation != 'dist sender send' AND operation != 'kv.DistSender: sending partial batch'
 ----
 colbatchscan            Scan /Table/55/1/1/0
 batch flow coordinator  CPut /Table/55/1/1/0 -> /TUPLE/2:2:Int/2
@@ -63,7 +63,7 @@ SET tracing = on,kv,results; UPSERT INTO t.kv(k, v) VALUES (2,2); SET tracing = 
 query TT
 set tracing=off;
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
- WHERE operation != 'dist sender send'
+ WHERE operation != 'dist sender send' AND operation != 'kv.DistSender: sending partial batch'
 ----
 colbatchscan            Scan /Table/55/1/2/0
 colbatchscan            fetched: /kv/primary/2/v -> /3

--- a/pkg/sql/trace_test.go
+++ b/pkg/sql/trace_test.go
@@ -41,9 +41,9 @@ func TestTrace(t *testing.T) {
 
 	// These are always appended, even without the test specifying it.
 	alwaysOptionalSpans := []string{
-		"[async] drain",
-		"[async] storage.pendingLeaseRequest: requesting lease",
-		"[async] storage.Store: gossip on capacity change",
+		"drain",
+		"storage.pendingLeaseRequest: requesting lease",
+		"storage.Store: gossip on capacity change",
 		"outbox",
 		"request range lease",
 		"range lookup",

--- a/pkg/util/contextutil/BUILD.bazel
+++ b/pkg/util/contextutil/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "context.go",
         "timeout_error.go",
+        "uncanceled_context.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/util/contextutil",
     visibility = ["//visibility:public"],

--- a/pkg/util/contextutil/BUILD.bazel
+++ b/pkg/util/contextutil/BUILD.bazel
@@ -23,11 +23,14 @@ go_test(
     srcs = [
         "context_test.go",
         "timeout_error_test.go",
+        "uncanceled_context_test.go",
     ],
     embed = [":contextutil"],
     deps = [
+        "//pkg/util/leaktest",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//errbase",
         "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/util/contextutil/uncanceled_context.go
+++ b/pkg/util/contextutil/uncanceled_context.go
@@ -1,0 +1,50 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package contextutil
+
+import (
+	"context"
+	"time"
+)
+
+// WithoutCancel returns a context that doesn't inherit the cancellation of its
+// parent, and so it can never be canceled. Aside from the cancellation, the
+// returned context inherits all values from the parent.
+func WithoutCancel(ctx context.Context) context.Context {
+	if ctx.Done() == nil {
+		// If ctx can't be canceled, there's no reason to allocate a new context.
+		return ctx
+	}
+	return &uncanceledContext{Context: ctx}
+}
+
+// uncanceledContext is an implementation of context.Context that ignores the
+// cancellation of the parent.
+type uncanceledContext struct {
+	context.Context
+}
+
+var _ context.Context = &uncanceledContext{}
+
+// Done overrides the Context method, clearing any cancellation channel. Always return nil.
+func (*uncanceledContext) Done() <-chan struct{} {
+	return nil
+}
+
+// Err overrides the Context method. Always returns nil
+func (*uncanceledContext) Err() error {
+	return nil
+}
+
+// Deadline overrides the Context method. Always returns false.
+func (*uncanceledContext) Deadline() (deadline time.Time, ok bool) {
+	return time.Time{}, false
+}

--- a/pkg/util/contextutil/uncanceled_context.go
+++ b/pkg/util/contextutil/uncanceled_context.go
@@ -23,28 +23,89 @@ func WithoutCancel(ctx context.Context) context.Context {
 		// If ctx can't be canceled, there's no reason to allocate a new context.
 		return ctx
 	}
-	return &uncanceledContext{Context: ctx}
+	return &uncanceledContext{ctx: ctx}
+}
+
+// InheritsCancellation returns true if child inherits the cancellation of
+// parent.
+//
+// child is assumed to be derived directly or indirectly from parent. It's
+// illegal to call InheritsCancellation with unrelated contexts.
+//
+// If parent is not a cancelable context, InheritsCancellation might return true
+// even if there is a WithoutCancel context in between child and parent. This is
+// because WithoutCancel is a no-op when called on a non-cancelable context.
+//
+// It is assumed that the only way for a child to not inherit a parent's
+// cancellation is when there's a context produced by WithoutCancel() in the
+// chain, between child and parent. In other words, we're assuming that there's
+// no other types other than uncanceledCtx which override Done().
+func InheritsCancellation(child, parent context.Context) bool {
+	barrier1 := getUncanceledParent(child)
+	if barrier1 == nil {
+		// There's no barriers anywhere, so the child must be inheriting from the
+		// parent.
+		return true
+	}
+	barrier2 := getUncanceledParent(parent)
+	// There's two cases to consider:
+	// 1. barrier -> parent -> child
+	// 2. [other barrier] -> parent -> barrier -> child
+	// In case 1, the child inherits from the parent. In case 2, it doesn't.
+	return barrier1 == barrier2
 }
 
 // uncanceledContext is an implementation of context.Context that ignores the
 // cancellation of the parent.
 type uncanceledContext struct {
-	context.Context
+	ctx context.Context
 }
 
 var _ context.Context = &uncanceledContext{}
 
-// Done overrides the Context method, clearing any cancellation channel. Always return nil.
+// Value is part of the Context interface.
+//
+// Value recognizes cancellationBarrierKey and returns the receiver. This is so
+// that children contexts can get a reference to a parent uncanceledContext, for
+// the purposes of InheritsCancelation. Since we want to integrate with any
+// implementation con context.Context, the only way for a parent to provide
+// information to a child is through the Value method.
+func (c *uncanceledContext) Value(key interface{}) interface{} {
+	if key == cancellationBarrierKey {
+		return c
+	}
+	return c.ctx.Value(key)
+}
+
+// Done is part of the Context interface. Always returns nil.
+//
+// NB: uncanceledContext has to remain the only Context implementation in the
+// codebase to override Done() because InheritsCancellation relies on there not
+// being other cancellation "barriers".
 func (*uncanceledContext) Done() <-chan struct{} {
 	return nil
 }
 
-// Err overrides the Context method. Always returns nil
+// Err is part the Context interface. Always returns nil.
 func (*uncanceledContext) Err() error {
 	return nil
 }
 
-// Deadline overrides the Context method. Always returns false.
+// Deadline overrides the Context method.  Always returns false.
 func (*uncanceledContext) Deadline() (deadline time.Time, ok bool) {
 	return time.Time{}, false
+}
+
+// cancellationBarrierKey is the key for which a uncanceledContext returns
+// itself.
+var cancellationBarrierKey = new(int)
+
+// getUncanceledParent returns the innermost uncanceledContext amongst ctx's
+// parents. Returns nil if there's no such context on the chain.
+func getUncanceledParent(ctx context.Context) *uncanceledContext {
+	c := ctx.Value(cancellationBarrierKey)
+	if c == nil {
+		return nil
+	}
+	return c.(*uncanceledContext)
 }

--- a/pkg/util/contextutil/uncanceled_context_test.go
+++ b/pkg/util/contextutil/uncanceled_context_test.go
@@ -1,0 +1,52 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package contextutil
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithoutCancel(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	child := WithoutCancel(ctx)
+	require.Nil(t, child.Done())
+
+	cancel()
+	require.NotNil(t, ctx.Err())
+	require.Nil(t, child.Err())
+}
+
+func TestInheritsCancellation(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	type myKey string
+
+	c1, _ := context.WithCancel(context.Background())
+	c2 := context.WithValue(c1, myKey("a"), nil)
+	c3 := WithoutCancel(c2)
+	c4, _ := context.WithCancel(c3)
+	c5, _ := context.WithCancel(c4)
+	c6 := WithoutCancel(c5)
+	c7 := context.WithValue(c6, myKey("a"), nil)
+
+	require.True(t, InheritsCancellation(c2, c1))
+	require.False(t, InheritsCancellation(c3, c2))
+	require.False(t, InheritsCancellation(c7, c2))
+	require.True(t, InheritsCancellation(c5, c4))
+	require.False(t, InheritsCancellation(c6, c5))
+	require.False(t, InheritsCancellation(c7, c5))
+}

--- a/pkg/util/stop/BUILD.bazel
+++ b/pkg/util/stop/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
         "//pkg/util/log",
         "//pkg/util/quotapool",
         "//pkg/util/syncutil",
+        "//pkg/util/tracing",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/util/stop/BUILD.bazel
+++ b/pkg/util/stop/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/roachpb",
         "//pkg/settings",
+        "//pkg/util/contextutil",
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/log/logcrash",

--- a/pkg/util/stop/BUILD.bazel
+++ b/pkg/util/stop/BUILD.bazel
@@ -30,6 +30,7 @@ go_test(
         ":stop",
         "//pkg/roachpb",
         "//pkg/testutils",
+        "//pkg/util/contextutil",
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/quotapool",

--- a/pkg/util/stop/stopper.go
+++ b/pkg/util/stop/stopper.go
@@ -334,6 +334,7 @@ func (s *Stopper) RunAsyncTask(
 	return s.RunAsyncTaskEx(ctx,
 		TaskOpts{
 			TaskName:   taskName,
+			ChildSpan:  false,
 			Sem:        nil,
 			WaitForSem: false,
 		},
@@ -345,6 +346,26 @@ type TaskOpts struct {
 	// TaskName is a human-readable name for the operation. Used as the name of
 	// the tracing span.
 	TaskName string
+
+	// ChildSpan, if set, creates the tracing span for the task via
+	// tracing.ChildSpan() instead of tracing.ForkSpan. This makes the task's span
+	// be part of the parent span's recording (it is created with the
+	// WithParentAndAutoCollection option instead of
+	// WithParentAndManualCollection). It also leads to a ChildOf relationship
+	// instead of a FollowsFrom relationship to be used for the task's span, which
+	// typically implies a non-binding expectation that the parent span will
+	// outlive the task's span, i.e. that the parent will wait for the task to
+	// complete.
+	//
+	// Regardless of this setting, if the caller doesn't have a span, the task
+	// doesn't get a span either.
+	//
+	// Setting ChildSpan can have consequences on memory usage. The lifetime of
+	// the task's span becomes tied to the lifetime of the parent. Generally
+	// ChildSpan should be used when the parent waits for the task to complete,
+	// and the parent is not a long-running process.
+	ChildSpan bool
+
 	// If set, Sem is used as a semaphore limiting the concurrency (each task has
 	// weight 1).
 	//
@@ -400,7 +421,13 @@ func (s *Stopper) RunAsyncTaskEx(ctx context.Context, opt TaskOpts, f func(conte
 		return ErrUnavailable
 	}
 
-	ctx, span := tracing.ForkSpan(ctx, opt.TaskName)
+	// If the caller has a span, the task gets a child span.
+	var span *tracing.Span
+	if opt.ChildSpan {
+		ctx, span = tracing.ChildSpan(ctx, opt.TaskName)
+	} else {
+		ctx, span = tracing.ForkSpan(ctx, opt.TaskName)
+	}
 
 	// Call f on another goroutine.
 	taskStarted = true // Another goroutine now takes ownership of the alloc, if any.

--- a/pkg/util/stop/stopper.go
+++ b/pkg/util/stop/stopper.go
@@ -35,9 +35,7 @@ func init() {
 	leaktest.PrintLeakedStoppers = PrintLeakedStoppers
 }
 
-const asyncTaskNamePrefix = "[async] "
-
-// ErrThrottled is returned from RunLimitedAsyncTask in the event that there
+// ErrThrottled is returned from RunAsyncTaskEx in the event that there
 // is no more capacity for async tasks, as limited by the semaphore.
 var ErrThrottled = errors.New("throttled on async limiting semaphore")
 
@@ -328,77 +326,94 @@ func (s *Stopper) RunTaskWithErr(
 
 // RunAsyncTask is like RunTask, except the callback is run in a goroutine. The
 // method doesn't block for the callback to finish execution.
+//
+// See also RunAsyncTaskEx for a version with more options.
 func (s *Stopper) RunAsyncTask(
 	ctx context.Context, taskName string, f func(context.Context),
 ) error {
-	taskName = asyncTaskNamePrefix + taskName
+	return s.RunAsyncTaskEx(ctx,
+		TaskOpts{
+			TaskName:   taskName,
+			Sem:        nil,
+			WaitForSem: false,
+		},
+		f)
+}
+
+// TaskOpts groups the task execution options for RunAsyncTaskEx.
+type TaskOpts struct {
+	// TaskName is a human-readable name for the operation. Used as the name of
+	// the tracing span.
+	TaskName string
+	// If set, Sem is used as a semaphore limiting the concurrency (each task has
+	// weight 1).
+	//
+	// It is the caller's responsibility to ensure that Sem is closed when the
+	// stopper is quiesced. For quotapools which live for the lifetime of the
+	// stopper, it is generally best to register the sem with the stopper using
+	// AddCloser.
+	Sem *quotapool.IntPool
+	// If Sem is not nil, WaitForSem specifies whether the call blocks or not when
+	// the semaphore is full. If true, the call blocks until the semaphore is
+	// available in order to push back on callers that may be trying to create
+	// many tasks. If false, returns immediately with an error if the semaphore is
+	// not available.
+	WaitForSem bool
+}
+
+// RunAsyncTaskEx is like RunTask, except the callback f is run in a goroutine.
+// The call doesn't block for the callback to finish execution.
+func (s *Stopper) RunAsyncTaskEx(ctx context.Context, opt TaskOpts, f func(context.Context)) error {
+	var alloc *quotapool.IntAlloc
+	taskStarted := false
+	if opt.Sem != nil {
+		// Wait for permission to run from the semaphore.
+		var err error
+		if opt.WaitForSem {
+			alloc, err = opt.Sem.Acquire(ctx, 1)
+		} else {
+			alloc, err = opt.Sem.TryAcquire(ctx, 1)
+		}
+		if errors.Is(err, quotapool.ErrNotEnoughQuota) {
+			err = ErrThrottled
+		} else if quotapool.HasErrClosed(err) {
+			err = ErrUnavailable
+		}
+		if err != nil {
+			return err
+		}
+		defer func() {
+			// If the task is started, the alloc will be released async.
+			if !taskStarted {
+				alloc.Release()
+			}
+		}()
+
+		// Check for canceled context: it's possible to get the semaphore even
+		// if the context is canceled.
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+	}
+
 	if !s.runPrelude() {
 		return ErrUnavailable
 	}
 
-	ctx, span := tracing.ForkSpan(ctx, taskName)
+	ctx, span := tracing.ForkSpan(ctx, opt.TaskName)
 
-	// Call f.
+	// Call f on another goroutine.
+	taskStarted = true // Another goroutine now takes ownership of the alloc, if any.
 	go func() {
 		defer s.Recover(ctx)
 		defer s.runPostlude()
 		defer span.Finish()
-
-		f(ctx)
-	}()
-	return nil
-}
-
-// RunLimitedAsyncTask runs function f in a goroutine, using the given
-// channel as a semaphore to limit the number of tasks that are run
-// concurrently to the channel's capacity. If wait is true, blocks
-// until the semaphore is available in order to push back on callers
-// that may be trying to create many tasks. If wait is false, returns
-// immediately with an error if the semaphore is not
-// available. It is the caller's responsibility to ensure that sem is
-// closed when the stopper is quiesced. For quotapools which live for the
-// lifetime of the stopper, it is generally best to register the sem with the
-// stopper using AddCloser.
-func (s *Stopper) RunLimitedAsyncTask(
-	ctx context.Context, taskName string, sem *quotapool.IntPool, wait bool, f func(context.Context),
-) error {
-	// Wait for permission to run from the semaphore.
-	var alloc *quotapool.IntAlloc
-	var err error
-	if wait {
-		alloc, err = sem.Acquire(ctx, 1)
-	} else {
-		alloc, err = sem.TryAcquire(ctx, 1)
-	}
-	if errors.Is(err, quotapool.ErrNotEnoughQuota) {
-		err = ErrThrottled
-	} else if quotapool.HasErrClosed(err) {
-		err = ErrUnavailable
-	}
-	if err != nil {
-		return err
-	}
-	taskStarted := false
-	defer func() {
-		// If the task is started, the alloc will be released async.
-		if !taskStarted {
-			alloc.Release()
+		if alloc != nil {
+			defer alloc.Release()
 		}
-	}()
 
-	// Check for canceled context: it's possible to get the semaphore even
-	// if the context is canceled.
-	if ctx.Err() != nil {
-		return ctx.Err()
-	}
-
-	if err := s.RunAsyncTask(ctx, taskName, func(ctx context.Context) {
-		defer alloc.Release()
 		f(ctx)
-	}); err != nil {
-		return err
-	}
-	taskStarted = true
+	}()
 	return nil
 }
 

--- a/pkg/util/stop/stopper_test.go
+++ b/pkg/util/stop/stopper_test.go
@@ -718,3 +718,55 @@ func TestStopperRunAsyncTaskTracing(t *testing.T) {
 			span: async child same trace
 				event: async 2`))
 }
+
+func TestStopperRunAsyncTaskCancel(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	testutils.RunTrueAndFalse(t, "inherit cancel", func(t *testing.T, inheritCancel bool) {
+		s := stop.NewStopper()
+		ctx, cancel := context.WithCancel(context.Background())
+		var taskFinished bool
+		ch := make(chan struct{})
+		require.NoError(t, s.RunAsyncTaskEx(ctx, stop.TaskOpts{
+			TaskName:                "test",
+			DontInheritCancellation: !inheritCancel,
+		}, func(ctx context.Context) {
+			<-ch
+			if ctx.Err() != nil {
+				return
+			}
+			taskFinished = true
+		}))
+
+		cancel()
+		close(ch)
+		s.Stop(context.Background())
+		require.Equal(t, !inheritCancel, taskFinished)
+	})
+}
+
+func TestStopperRunAsyncTaskCancelOnQuiesce(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	// To cover more surface, we test in conjunction with the
+	// DontInheritCancellation option. We always set that option, and we test with
+	// both a canceled parent and non-canceled one. Because we set
+	// DontInheritCancellation, the parent shouldn't matter.
+	testutils.RunTrueAndFalse(t, "canceled parent", func(t *testing.T, canceledParent bool) {
+		s := stop.NewStopper()
+		ctx := context.Background()
+		if canceledParent {
+			var cancel func()
+			ctx, cancel = context.WithCancel(context.Background())
+			cancel()
+		}
+		require.NoError(t, s.RunAsyncTaskEx(ctx, stop.TaskOpts{
+			TaskName:                "test",
+			CancelOnQuiesce:         true,
+			DontInheritCancellation: true,
+		}, func(ctx context.Context) {
+			<-ctx.Done()
+		}))
+		// We check that the test doesn't time out, meaning that the task was
+		// signaled by the quiescence.
+		s.Stop(context.Background())
+	})
+}


### PR DESCRIPTION
See individual commits. They all improve the stopper.RunAsyncTask() interface. The only behavior change is that the DistSender's partial batches are not included in the parent's trace.