### PR TITLE
jobs: provide cluster-settings for job-query frequencies

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -1680,12 +1680,15 @@ func createAndWaitForJob(
 func TestBackupRestoreResume(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	defer jobs.TestingSetAdoptAndCancelIntervals(100*time.Millisecond, 100*time.Millisecond)()
 
 	ctx := context.Background()
 
+	params := base.TestClusterArgs{ServerArgs: base.TestServerArgs{
+		Knobs: base.TestingKnobs{JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals()},
+	}}
+
 	const numAccounts = 1000
-	_, tc, outerDB, dir, cleanupFn := BackupRestoreTestSetup(t, MultiNode, numAccounts, InitManualReplication)
+	_, tc, outerDB, dir, cleanupFn := backupRestoreTestSetupWithParams(t, MultiNode, numAccounts, InitManualReplication, params)
 	defer cleanupFn()
 
 	backupTableDesc := catalogkv.TestingGetTableDescriptor(tc.Servers[0].DB(), keys.SystemSQLCodec, "data", "bank")
@@ -1818,9 +1821,8 @@ func TestBackupRestoreControlJob(t *testing.T) {
 
 	// force every call to update
 	defer jobs.TestingSetProgressThresholds()()
-	defer jobs.TestingSetAdoptAndCancelIntervals(100*time.Millisecond, 100*time.Millisecond)()
 
-	serverArgs := base.TestServerArgs{}
+	serverArgs := base.TestServerArgs{Knobs: base.TestingKnobs{JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals()}}
 	// Disable external processing of mutations so that the final check of
 	// crdb_internal.tables is guaranteed to not be cleaned up. Although this
 	// was never observed by a stress test, it is here for safety.
@@ -6603,10 +6605,8 @@ func TestPaginatedBackupTenant(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer jobs.TestingSetAdoptAndCancelIntervals(100*time.Millisecond, 100*time.Millisecond)()
-
 	const numAccounts = 1
-	serverArgs := base.TestServerArgs{}
+	serverArgs := base.TestServerArgs{Knobs: base.TestingKnobs{JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals()}}
 	params := base.TestClusterArgs{ServerArgs: serverArgs}
 	var numExportRequests int
 	exportRequestSpans := make([]string, 0)
@@ -6828,10 +6828,14 @@ func TestBackupRestoreTenant(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer jobs.TestingSetAdoptAndCancelIntervals(100*time.Millisecond, 100*time.Millisecond)()
+	params := base.TestClusterArgs{ServerArgs: base.TestServerArgs{
+		Knobs: base.TestingKnobs{JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals()},
+	}}
 
 	const numAccounts = 1
-	ctx, tc, systemDB, dir, cleanupFn := BackupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)
+	ctx, tc, systemDB, dir, cleanupFn := backupRestoreTestSetupWithParams(
+		t, singleNode, numAccounts, InitManualReplication, params,
+	)
 	_, _ = tc, systemDB
 	defer cleanupFn()
 	srv := tc.Server(0)
@@ -8085,10 +8089,9 @@ func TestRestoreJobEventLogging(t *testing.T) {
 	defer log.ScopeWithoutShowLogs(t).Close(t)
 
 	defer jobs.TestingSetProgressThresholds()()
-	defer jobs.TestingSetAdoptAndCancelIntervals(100*time.Millisecond, 100*time.Millisecond)()
 
 	baseDir := "testdata"
-	args := base.TestServerArgs{ExternalIODir: baseDir}
+	args := base.TestServerArgs{ExternalIODir: baseDir, Knobs: base.TestingKnobs{JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals()}}
 	params := base.TestClusterArgs{ServerArgs: args}
 	_, tc, sqlDB, _, cleanupFn := backupRestoreTestSetupWithParams(t, singleNode, 1,
 		InitManualReplication, params)
@@ -8361,13 +8364,12 @@ func TestBackupWorkerFailure(t *testing.T) {
 	skip.UnderStress(t, "under stress the test unexpectedly surfaces non-retryable errors on"+
 		" backup failure")
 
-	defer jobs.TestingSetAdoptAndCancelIntervals(10*time.Millisecond, 10*time.Millisecond)()
-
 	allowResponse := make(chan struct{})
 	params := base.TestClusterArgs{}
 	params.ServerArgs.Knobs.Store = &kvserver.StoreTestingKnobs{
 		TestingResponseFilter: jobutils.BulkOpResponseFilter(&allowResponse),
 	}
+	params.ServerArgs.Knobs.JobsTestingKnobs = jobs.NewTestingKnobsWithShortIntervals()
 
 	const numAccounts = 100
 

--- a/pkg/ccl/backupccl/restore_mid_schema_change_test.go
+++ b/pkg/ccl/backupccl/restore_mid_schema_change_test.go
@@ -15,7 +15,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
@@ -229,11 +228,13 @@ func restoreMidSchemaChange(
 ) func(t *testing.T) {
 	return func(t *testing.T) {
 		ctx := context.Background()
-		defer jobs.TestingSetAdoptAndCancelIntervals(100*time.Millisecond, 100*time.Millisecond)()
 
 		dir, dirCleanupFn := testutils.TempDir(t)
 		params := base.TestClusterArgs{
-			ServerArgs: base.TestServerArgs{ExternalIODir: dir},
+			ServerArgs: base.TestServerArgs{
+				ExternalIODir: dir,
+				Knobs:         base.TestingKnobs{JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals()},
+			},
 		}
 		tc := testcluster.StartTestCluster(t, singleNode, params)
 		defer func() {

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -2664,8 +2664,6 @@ func TestChangefeedPauseUnpause(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer jobs.TestingSetAdoptAndCancelIntervals(10*time.Millisecond, 10*time.Millisecond)()
-
 	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(db)
 		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING)`)
@@ -2725,7 +2723,6 @@ func TestChangefeedPauseUnpause(t *testing.T) {
 func TestChangefeedPauseUnpauseCursorAndInitialScan(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	defer jobs.TestingSetAdoptAndCancelIntervals(100*time.Millisecond, 100*time.Millisecond)()
 
 	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(db)
@@ -2935,7 +2932,6 @@ func TestChangefeedProtectedTimestamps(t *testing.T) {
 func TestChangefeedProtectedTimestampOnPause(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	defer jobs.TestingSetAdoptAndCancelIntervals(100*time.Millisecond, 100*time.Millisecond)()
 
 	testFn := func(shouldPause bool) cdcTestFn {
 		return func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
@@ -3161,9 +3157,10 @@ func TestChangefeedNodeShutdown(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	skip.WithIssue(t, 32232)
 
-	defer jobs.TestingSetAdoptAndCancelIntervals(100*time.Millisecond, 100*time.Millisecond)()
-
-	knobs := base.TestingKnobs{DistSQL: &execinfra.TestingKnobs{Changefeed: &TestingKnobs{}}}
+	knobs := base.TestingKnobs{
+		DistSQL:          &execinfra.TestingKnobs{Changefeed: &TestingKnobs{}},
+		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+	}
 
 	tc := serverutils.StartNewTestCluster(t, 3, base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
@@ -3456,8 +3453,6 @@ func TestChangefeedPrimaryKeyChangeWorks(t *testing.T) {
 	skip.UnderRace(t)
 	skip.UnderShort(t)
 
-	defer jobs.TestingSetAdoptAndCancelIntervals(10*time.Millisecond, 10*time.Millisecond)()
-
 	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(db)
 		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING NOT NULL)`)
@@ -3561,8 +3556,6 @@ func TestChangefeedPrimaryKeyChangeWorksWithMultipleTables(t *testing.T) {
 	skip.UnderRace(t)
 	skip.UnderShort(t)
 
-	defer jobs.TestingSetAdoptAndCancelIntervals(10*time.Millisecond, 10*time.Millisecond)()
-
 	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(db)
 		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING NOT NULL)`)
@@ -3655,8 +3648,6 @@ func TestChangefeedPrimaryKeyChangeMixedVersion(t *testing.T) {
 
 	skip.UnderRace(t)
 	skip.UnderShort(t)
-
-	defer jobs.TestingSetAdoptAndCancelIntervals(10*time.Millisecond, 10*time.Millisecond)()
 
 	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(db)

--- a/pkg/ccl/changefeedccl/nemeses_test.go
+++ b/pkg/ccl/changefeedccl/nemeses_test.go
@@ -14,10 +14,8 @@ import (
 	"regexp"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdctest"
-	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -27,8 +25,6 @@ func TestChangefeedNemeses(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	skip.UnderRace(t, "takes >1 min under race")
-
-	defer jobs.TestingSetAdoptAndCancelIntervals(10*time.Millisecond, 10*time.Millisecond)()
 
 	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
 		// TODO(dan): Ugly hack to disable `eventPause` in sinkless feeds. See comment in
@@ -42,6 +38,7 @@ func TestChangefeedNemeses(t *testing.T) {
 			t.Error(failure)
 		}
 	}
+
 	// Tenant tests disabled because ALTER TABLE .. SPLIT is not
 	// support in multi-tenancy mode:
 	//

--- a/pkg/ccl/changefeedccl/show_changefeed_jobs_test.go
+++ b/pkg/ccl/changefeedccl/show_changefeed_jobs_test.go
@@ -11,7 +11,6 @@ package changefeedccl
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
@@ -157,9 +156,9 @@ func TestShowChangefeedJobs(t *testing.T) {
 func TestShowChangefeedJobsStatusChange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	defer jobs.TestingSetAdoptAndCancelIntervals(10*time.Millisecond, 10*time.Millisecond)()
 
 	params, _ := tests.CreateTestServerParams()
+	params.Knobs.JobsTestingKnobs = jobs.NewTestingKnobsWithShortIntervals()
 	s, rawSQLDB, _ := serverutils.StartServer(t, params)
 	registry := s.JobRegistry().(*jobs.Registry)
 	sqlDB := sqlutils.MakeSQLRunner(rawSQLDB)

--- a/pkg/ccl/importccl/import_processor_test.go
+++ b/pkg/ccl/importccl/import_processor_test.go
@@ -17,7 +17,6 @@ import (
 	"os"
 	"sort"
 	"testing"
-	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/blobs"
@@ -641,11 +640,11 @@ func TestCSVImportCanBeResumed(t *testing.T) {
 	const batchSize = 5
 	defer TestingSetParallelImporterReaderBatchSize(batchSize)()
 	defer row.TestingSetDatumRowConverterBatchSize(2 * batchSize)()
-	defer jobs.TestingSetAdoptAndCancelIntervals(100*time.Millisecond, 100*time.Millisecond)()
 
 	s, db, _ := serverutils.StartServer(t,
 		base.TestServerArgs{
 			Knobs: base.TestingKnobs{
+				JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 				DistSQL: &execinfra.TestingKnobs{
 					BulkAdderFlushesEveryBatch: true,
 				},
@@ -747,11 +746,11 @@ func TestCSVImportMarksFilesFullyProcessed(t *testing.T) {
 	const batchSize = 5
 	defer TestingSetParallelImporterReaderBatchSize(batchSize)()
 	defer row.TestingSetDatumRowConverterBatchSize(2 * batchSize)()
-	defer jobs.TestingSetAdoptAndCancelIntervals(100*time.Millisecond, 100*time.Millisecond)()
 
 	s, db, _ := serverutils.StartServer(t,
 		base.TestServerArgs{
 			Knobs: base.TestingKnobs{
+				JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 				DistSQL: &execinfra.TestingKnobs{
 					BulkAdderFlushesEveryBatch: true,
 				},

--- a/pkg/ccl/multiregionccl/region_test.go
+++ b/pkg/ccl/multiregionccl/region_test.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/multiregionccl/multiregionccltestutils"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/sql"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqltestutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -217,9 +217,6 @@ func TestRegionAddDropEnclosingRegionalByRowOps(t *testing.T) {
 
 	skip.UnderRace(t, "times out under race")
 
-	// Decrease the adopt loop interval so that retries happen quickly.
-	defer sqltestutils.SetTestJobsAdoptInterval()()
-
 	regionAlterCmds := []struct {
 		name          string
 		cmd           string
@@ -284,6 +281,8 @@ func TestRegionAddDropEnclosingRegionalByRowOps(t *testing.T) {
 							return nil
 						},
 					},
+					// Decrease the adopt loop interval so that retries happen quickly.
+					JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 				}
 
 				_, sqlDB, cleanup := multiregionccltestutils.TestingCreateMultiRegionCluster(
@@ -432,9 +431,6 @@ func TestDroppingPrimaryRegionAsyncJobFailure(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	// Decrease the adopt loop interval so that retries happen quickly.
-	defer sqltestutils.SetTestJobsAdoptInterval()()
-
 	// Protects expectedCleanupRuns
 	var mu syncutil.Mutex
 	// We need to cleanup 2 times, once for the multi-region type descriptor and
@@ -456,6 +452,8 @@ func TestDroppingPrimaryRegionAsyncJobFailure(t *testing.T) {
 				return nil
 			},
 		},
+		// Decrease the adopt loop interval so that retries happen quickly.
+		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 	}
 
 	_, sqlDB, cleanup := multiregionccltestutils.TestingCreateMultiRegionCluster(
@@ -504,15 +502,14 @@ func TestRollbackDuringAddDropRegionAsyncJobFailure(t *testing.T) {
 
 	skip.UnderRace(t, "times out under race")
 
-	// Decrease the adopt loop interval so that retries happen quickly.
-	defer sqltestutils.SetTestJobsAdoptInterval()()
-
 	knobs := base.TestingKnobs{
 		SQLTypeSchemaChanger: &sql.TypeSchemaChangerTestingKnobs{
 			RunBeforeMultiRegionUpdates: func() error {
 				return errors.New("boom")
 			},
 		},
+		// Decrease the adopt loop interval so that retries happen quickly.
+		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 	}
 
 	// Setup.
@@ -594,9 +591,6 @@ func TestRegionAddDropWithConcurrentBackupOps(t *testing.T) {
 
 	skip.UnderRace(t, "times out under race")
 
-	// Decrease the adopt loop interval so that retries happen quickly.
-	defer sqltestutils.SetTestJobsAdoptInterval()()
-
 	regionAlterCmds := []struct {
 		name               string
 		cmd                string
@@ -665,6 +659,8 @@ func TestRegionAddDropWithConcurrentBackupOps(t *testing.T) {
 							return nil
 						},
 					},
+					// Decrease the adopt loop interval so that retries happen quickly.
+					JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 				}
 
 				tempExternalIODir, tempDirCleanup := testutils.TempDir(t)
@@ -718,6 +714,8 @@ INSERT INTO db.rbr VALUES (1,1),(2,2),(3,3);
 							return nil
 						},
 					},
+					// Decrease the adopt loop interval so that retries happen quickly.
+					JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 				}
 
 				// Start a new cluster (with new testing knobs) for restore.

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job_test.go
@@ -38,14 +38,17 @@ import (
 func TestTenantStreaming(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	defer jobs.TestingSetAdoptAndCancelIntervals(100*time.Millisecond, 100*time.Millisecond)()
 
 	skip.UnderRace(t, "slow under race")
 
 	ctx := context.Background()
 
+	args := base.TestServerArgs{Knobs: base.TestingKnobs{
+		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals()},
+	}
+
 	// Start the source server.
-	source, sourceDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	source, sourceDB, _ := serverutils.StartServer(t, args)
 	defer source.Stopper().Stop(ctx)
 
 	// Start tenant server in the srouce cluster.

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_test.go
@@ -77,7 +77,6 @@ func TestStreamIngestionJobWithRandomClient(t *testing.T) {
 	skip.UnderRaceWithIssue(t, 60710)
 
 	ctx := context.Background()
-	defer jobs.TestingSetAdoptAndCancelIntervals(100*time.Millisecond, 100*time.Millisecond)()
 
 	canBeCompletedCh := make(chan struct{})
 	const threshold = 10
@@ -120,6 +119,7 @@ func TestStreamIngestionJobWithRandomClient(t *testing.T) {
 		},
 		TestingResponseFilter: jobutils.BulkOpResponseFilter(&allowResponse),
 	}
+	params.ServerArgs.Knobs.JobsTestingKnobs = jobs.NewTestingKnobsWithShortIntervals()
 
 	numNodes := 3
 	tc := testcluster.StartTestCluster(t, numNodes, params)

--- a/pkg/ccl/streamingccl/streamingutils/utils_test.go
+++ b/pkg/ccl/streamingccl/streamingutils/utils_test.go
@@ -32,9 +32,11 @@ import (
 func TestCutoverBuiltin(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
-	defer jobs.TestingSetAdoptAndCancelIntervals(100*time.Millisecond, 100*time.Millisecond)()
 
-	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
+	args := base.TestClusterArgs{ServerArgs: base.TestServerArgs{
+		Knobs: base.TestingKnobs{JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals()},
+	}}
+	tc := testcluster.StartTestCluster(t, 1, args)
 	defer tc.Stopper().Stop(ctx)
 	registry := tc.Server(0).JobRegistry().(*jobs.Registry)
 	sqlDB := sqlutils.MakeSQLRunner(tc.ServerConn(0))

--- a/pkg/ccl/testutilsccl/BUILD.bazel
+++ b/pkg/ccl/testutilsccl/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/base",
+        "//pkg/jobs",
         "//pkg/roachpb",
         "//pkg/sql",
         "//pkg/sql/execinfra",

--- a/pkg/ccl/testutilsccl/alter_primary_key.go
+++ b/pkg/ccl/testutilsccl/alter_primary_key.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
@@ -47,9 +48,6 @@ type AlterPrimaryKeyCorrectZoneConfigTestCase struct {
 func AlterPrimaryKeyCorrectZoneConfigTest(
 	t *testing.T, createDBStatement string, testCases []AlterPrimaryKeyCorrectZoneConfigTestCase,
 ) {
-	// Decrease the adopt loop interval so that retries happen quickly.
-	defer sqltestutils.SetTestJobsAdoptInterval()()
-
 	chunkSize := int64(100)
 	maxValue := 4000
 
@@ -93,6 +91,8 @@ func AlterPrimaryKeyCorrectZoneConfigTest(
 						return nil
 					},
 				},
+				// Decrease the adopt loop interval so that retries happen quickly.
+				JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 			}
 			s, sqlDB, _ := serverutils.StartServer(t, params)
 			db = sqlDB

--- a/pkg/cli/debug_job_trace_test.go
+++ b/pkg/cli/debug_job_trace_test.go
@@ -19,8 +19,8 @@ import (
 	"strconv"
 	"strings"
 	"testing"
-	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/kv"
@@ -76,9 +76,11 @@ func TestDebugJobTrace(t *testing.T) {
 	skip.UnderRace(t, "test timing out")
 
 	ctx := context.Background()
-	defer jobs.TestingSetAdoptAndCancelIntervals(100*time.Millisecond, 100*time.Millisecond)()
+	argsFn := func(args *base.TestServerArgs) {
+		args.Knobs.JobsTestingKnobs = jobs.NewTestingKnobsWithShortIntervals()
+	}
 
-	c := NewCLITest(TestCLIParams{T: t})
+	c := newCLITestWithArgs(TestCLIParams{T: t}, argsFn)
 	defer c.Cleanup()
 	c.omitArgs = true
 

--- a/pkg/cli/testutils.go
+++ b/pkg/cli/testutils.go
@@ -116,6 +116,10 @@ func createTestCerts(certsDir string) (cleanup func() error) {
 
 // NewCLITest export for cclcli.
 func NewCLITest(params TestCLIParams) TestCLI {
+	return newCLITestWithArgs(params, nil)
+}
+
+func newCLITestWithArgs(params TestCLIParams, argsFn func(args *base.TestServerArgs)) TestCLI {
 	c := TestCLI{t: params.T}
 
 	certsDir, err := ioutil.TempDir("", "cli-test")
@@ -141,6 +145,9 @@ func NewCLITest(params TestCLIParams) TestCLI {
 			StoreSpecs:    params.StoreSpecs,
 			Locality:      params.Locality,
 			ExternalIODir: filepath.Join(certsDir, "extern"),
+		}
+		if argsFn != nil {
+			argsFn(&args)
 		}
 		if params.NoNodelocal {
 			args.ExternalIODir = ""

--- a/pkg/jobs/BUILD.bazel
+++ b/pkg/jobs/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "jobs",
     srcs = [
         "adopt.go",
+        "config.go",
         "executor_impl.go",
         "helpers.go",
         "job_scheduler.go",

--- a/pkg/jobs/adopt.go
+++ b/pkg/jobs/adopt.go
@@ -44,6 +44,15 @@ const (
 	NonTerminalStatusTupleString = `(` + nonTerminalStatusList + `)`
 )
 
+const claimQuery = `
+   UPDATE system.jobs
+      SET claim_session_id = $1, claim_instance_id = $2
+    WHERE (claim_session_id IS NULL)
+      AND (status IN ` + claimableStatusTupleString + `)
+ ORDER BY created DESC
+    LIMIT $3
+RETURNING id;`
+
 // claimJobs places a claim with the given SessionID to job rows that are
 // available.
 func (r *Registry) claimJobs(ctx context.Context, s sqlliveness.Session) error {
@@ -54,14 +63,7 @@ func (r *Registry) claimJobs(ctx context.Context, s sqlliveness.Session) error {
 			return errors.WithAssertionFailure(err)
 		}
 		numRows, err := r.ex.Exec(
-			ctx, "claim-jobs", txn, `
-   UPDATE system.jobs
-      SET claim_session_id = $1, claim_instance_id = $2
-    WHERE claim_session_id IS NULL
-      AND status IN `+claimableStatusTupleString+`
- ORDER BY created DESC
-    LIMIT $3
-RETURNING id;`,
+			ctx, "claim-jobs", txn, claimQuery,
 			s.ID().UnsafeBytes(), r.ID(), maxAdoptionsPerLoop,
 		)
 		if err != nil {
@@ -287,6 +289,17 @@ func (r *Registry) runJob(
 	return err
 }
 
+const cancelQuery = `
+UPDATE system.jobs
+SET status =
+    CASE
+      WHEN status = $1 THEN $2
+      WHEN status = $3 THEN $4
+      ELSE status
+    END
+WHERE (status IN ($1, $3)) AND ((claim_session_id = $5) AND (claim_instance_id = $6))
+RETURNING id, status`
+
 func (r *Registry) servePauseAndCancelRequests(ctx context.Context, s sqlliveness.Session) error {
 	return r.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 		// Run the claim transaction at low priority to ensure that it does not
@@ -299,16 +312,8 @@ func (r *Registry) servePauseAndCancelRequests(ctx context.Context, s sqllivenes
 		// error (otherwise, the system.jobs table might diverge from the jobs
 		// registry).
 		rows, err := r.ex.QueryBufferedEx(
-			ctx, "cancel/pause-requested", txn, sessiondata.InternalExecutorOverride{User: security.NodeUserName()}, `
-UPDATE system.jobs
-SET status =
-		CASE
-			WHEN status = $1 THEN $2
-			WHEN status = $3 THEN $4
-			ELSE status
-		END
-WHERE (status IN ($1, $3)) AND (claim_session_id = $5 AND claim_instance_id = $6)
-RETURNING id, status`,
+			ctx, "cancel/pause-requested", txn, sessiondata.InternalExecutorOverride{User: security.NodeUserName()},
+			cancelQuery,
 			StatusPauseRequested, StatusPaused,
 			StatusCancelRequested, StatusReverting,
 			s.ID().UnsafeBytes(), r.ID(),

--- a/pkg/jobs/config.go
+++ b/pkg/jobs/config.go
@@ -1,0 +1,180 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package jobs
+
+import (
+	"context"
+	"math/rand"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+const intervalBaseSettingKey = "jobs.registry.interval.base"
+const adoptIntervalSettingKey = "jobs.registry.interval.adopt"
+const cancelIntervalSettingKey = "jobs.registry.interval.cancel"
+const gcIntervalSettingKey = "jobs.registry.interval.gc"
+const retentionTimeSettingKey = "jobs.retention_time"
+const cancelUpdateLimitKey = "jobs.cancel_update_limit"
+
+// defaultAdoptInterval is the default adopt interval.
+var defaultAdoptInterval = 30 * time.Second
+
+// defaultCancelInterval is the default cancel interval.
+var defaultCancelInterval = 10 * time.Second
+
+// defaultGcInterval is the default GC Interval.
+var defaultGcInterval = 1 * time.Hour
+
+// defaultIntervalBase is the default interval base.
+var defaultIntervalBase = 1.0
+
+// defaultRetentionTime is the default duration for which terminal jobs are
+// kept in the records.
+var defaultRetentionTime = 14 * 24 * time.Hour
+
+// defaultCancellationsUpdateLimit is the default number of jobs that can be
+// updated when canceling jobs concurrently from dead sessions.
+var defaultCancellationsUpdateLimit int64 = 1000
+
+var (
+	intervalBaseSetting = settings.RegisterFloatSetting(
+		intervalBaseSettingKey,
+		"the base multiplier for other intervals such as adopt, cancel, and gc",
+		defaultIntervalBase,
+		settings.PositiveFloat,
+	)
+
+	adoptIntervalSetting = settings.RegisterDurationSetting(
+		adoptIntervalSettingKey,
+		"the interval at which a node (a) claims some of the pending jobs and "+
+			"(b) restart its already claimed jobs that are in running or reverting "+
+			"states but are not running",
+		defaultAdoptInterval,
+		settings.PositiveDuration,
+	)
+
+	cancelIntervalSetting = settings.RegisterDurationSetting(
+		cancelIntervalSettingKey,
+		"the interval at which a node cancels the jobs belonging to the known "+
+			"dead sessions",
+		defaultCancelInterval,
+		settings.PositiveDuration,
+	)
+
+	gcIntervalSetting = settings.RegisterDurationSetting(
+		gcIntervalSettingKey,
+		"the interval a node deletes expired job records that have exceeded their "+
+			"retention duration",
+		defaultGcInterval,
+		settings.PositiveDuration,
+	)
+
+	retentionTimeSetting = settings.RegisterDurationSetting(
+		retentionTimeSettingKey,
+		"the amount of time to retain records for completed jobs before",
+		defaultRetentionTime,
+		settings.PositiveDuration,
+	).WithPublic()
+
+	cancellationsUpdateLimitSetting = settings.RegisterIntSetting(
+		cancelUpdateLimitKey,
+		"the number of jobs that can be updated when canceling jobs concurrently from dead sessions",
+		defaultCancellationsUpdateLimit,
+		settings.NonNegativeInt,
+	)
+)
+
+// jitter adds a small jitter in the given duration.
+func jitter(dur time.Duration) time.Duration {
+	const jitter = 1 / 6
+	jitterFraction := 1 + (2*rand.Float64()-1)*jitter // 1 + [-1/6, +1/6)
+	return time.Duration(float64(dur) * jitterFraction)
+}
+
+// loopController controls the execution of a job at specific intervals. The
+// interval is controlled through a cluster setting. The structure consists
+// of a timer to execute the job at regular intervals and a notification
+// channel, updated, to update the timer through onUpdate() when
+// the cluster setting is changed. After each execution, onExecute() is called
+// to reset the timer. The structure internally keeps track of the last run of the job
+// using lastRun, which is updated in onExecute().
+//
+// Common usage pattern:
+//  lc, cleanup := makeLoopController(...)
+//  defer cleanup()
+//  for {
+//    select {
+//    case <- lc.update:
+//      lc.onUpdate() or lc.onUpdateWithBound()
+//    case <- lc.timer.C:
+//      executeJob()
+//      lc.onExecute() or lc.onExecuteWithBound
+//    }
+//  }
+//
+type loopController struct {
+	timer   *timeutil.Timer
+	lastRun time.Time
+	updated chan struct{}
+	// getInterval returns the value of the associated cluster setting.
+	getInterval func() time.Duration
+}
+
+// makeLoopController returns a structure that controls the execution of a job
+// at regular intervals. Moreover, it returns a cleanup function that should be
+// deferred to execute before destroying the instantiated structure.
+func makeLoopController(
+	st *cluster.Settings, s *settings.DurationSetting, overrideKnob *time.Duration,
+) (loopController, func()) {
+	lc := loopController{
+		timer:   timeutil.NewTimer(),
+		lastRun: timeutil.Now(),
+		updated: make(chan struct{}, 1),
+		// getInterval returns the value of the associated cluster setting. If
+		// overrideKnob is not nil, it overrides the cluster setting.
+		getInterval: func() time.Duration {
+			if overrideKnob != nil {
+				return *overrideKnob
+			}
+			return time.Duration(intervalBaseSetting.Get(&st.SV) * float64(s.Get(&st.SV)))
+		},
+	}
+
+	// onChange sends a notification on updated channel to notify a change in the
+	// associated cluster setting.
+	onChange := func(ctx context.Context) {
+		select {
+		case lc.updated <- struct{}{}:
+		default:
+		}
+	}
+
+	// register onChange() to get a notification when the cluster is updated.
+	s.SetOnChange(&st.SV, onChange)
+	intervalBaseSetting.SetOnChange(&st.SV, onChange)
+
+	lc.timer.Reset(jitter(lc.getInterval()))
+	return lc, func() { lc.timer.Stop() }
+}
+
+// onUpdate is called when the associated interval setting gets updated.
+func (lc *loopController) onUpdate() {
+	lc.timer.Reset(timeutil.Until(lc.lastRun.Add(jitter(lc.getInterval()))))
+}
+
+// onExecute is called after the associated job is executed.
+func (lc *loopController) onExecute() {
+	lc.lastRun = timeutil.Now()
+	lc.timer.Reset(jitter(lc.getInterval()))
+}

--- a/pkg/jobs/executor_impl_test.go
+++ b/pkg/jobs/executor_impl_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -25,8 +26,12 @@ import (
 func TestInlineExecutorFailedJobsHandling(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	defer TestingSetAdoptAndCancelIntervals(time.Millisecond, time.Microsecond)()
-	h, cleanup := newTestHelper(t)
+
+	argsFn := func(args *base.TestServerArgs) {
+		args.Knobs.JobsTestingKnobs = NewTestingKnobsWithIntervals(time.Millisecond, time.Millisecond)
+	}
+
+	h, cleanup := newTestHelperWithServerArgs(t, argsFn)
 	defer cleanup()
 
 	var tests = []struct {

--- a/pkg/jobs/helpers_test.go
+++ b/pkg/jobs/helpers_test.go
@@ -83,3 +83,33 @@ func (j *Job) Failed(ctx context.Context, causingErr error) error {
 func (j *Job) Succeeded(ctx context.Context) error {
 	return j.succeeded(ctx, nil /* txn */, nil /* fn */)
 }
+
+var (
+	AdoptQuery = claimQuery
+
+	CancelQuery = cancelQuery
+
+	GcQuery = expiredJobsQuery
+
+	IntervalBaseSettingKey = intervalBaseSettingKey
+
+	AdoptIntervalSettingKey = adoptIntervalSettingKey
+
+	CancelIntervalSettingKey = cancelIntervalSettingKey
+
+	GcIntervalSettingKey = gcIntervalSettingKey
+
+	RetentionTimeSettingKey = retentionTimeSettingKey
+
+	AdoptIntervalSetting = adoptIntervalSetting
+
+	CancelIntervalSetting = cancelIntervalSetting
+
+	CancellationsUpdateLimitSetting = cancellationsUpdateLimitSetting
+
+	GcIntervalSetting = gcIntervalSetting
+
+	RetentionTimeSetting = retentionTimeSetting
+
+	DefaultAdoptInterval = defaultAdoptInterval
+)

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -14,7 +14,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"math/rand"
 	"os"
 	"strconv"
 	"strings"
@@ -26,7 +25,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
-	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -45,23 +43,6 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/oserror"
 	"github.com/cockroachdb/logtags"
-)
-
-var (
-	gcSetting = settings.RegisterDurationSetting(
-		"jobs.retention_time",
-		"the amount of time to retain records for completed jobs before",
-		time.Hour*24*14,
-	).WithPublic()
-
-	// CancellationsUpdateLimitSetting the number of jobs can be updated when canceling jobs
-	// concurrently from dead sessions.
-	CancellationsUpdateLimitSetting = settings.RegisterIntSetting(
-		"jobs.cancel_update_limit",
-		"the number of jobs can be updated when canceling jobs concurrently from dead sessions",
-		1000,
-		settings.NonNegativeInt,
-	)
 )
 
 // adoptedJobs represents a the epoch and cancelation of a job id being run
@@ -582,43 +563,12 @@ func (r *Registry) UpdateJobWithTxn(
 	return j.Update(ctx, txn, updateFunc)
 }
 
-// DefaultCancelInterval is a reasonable interval at which to poll this node
-// for liveness failures and cancel running jobs.
-var DefaultCancelInterval = 10 * time.Second
-
-// DefaultAdoptInterval is a reasonable interval at which to poll system.jobs
-// for jobs with expired leases.
-//
-// DefaultAdoptInterval is mutable for testing. NB: Updates to this value after
-// Registry.Start has been called will not have any effect.
-var DefaultAdoptInterval = 30 * time.Second
-
-// TestingSetAdoptAndCancelIntervals can be used to accelerate job adoption and
-// state changes.
-func TestingSetAdoptAndCancelIntervals(adopt, cancel time.Duration) (cleanup func()) {
-	prevAdopt := DefaultAdoptInterval
-	prevCancel := DefaultCancelInterval
-	DefaultAdoptInterval = adopt
-	DefaultCancelInterval = cancel
-	return func() {
-		DefaultAdoptInterval = prevAdopt
-		DefaultCancelInterval = prevCancel
-	}
-}
-
 var maxAdoptionsPerLoop = envutil.EnvOrDefaultInt(`COCKROACH_JOB_ADOPTIONS_PER_PERIOD`, 10)
-
-// maxGCInterval is the maximum duration for how often we check for and delete job
-// records older than the retention limit.
-const maxGCInterval = 1 * time.Hour
 
 // Start polls the current node for liveness failures and cancels all registered
 // jobs if it observes a failure. Otherwise it starts all the main daemons of
 // registry that poll the jobs table and start/cancel/gc jobs.
-func (r *Registry) Start(
-	ctx context.Context, stopper *stop.Stopper, cancelInterval, adoptInterval time.Duration,
-) error {
-
+func (r *Registry) Start(ctx context.Context, stopper *stop.Stopper) error {
 	every := log.Every(time.Second)
 	withSession := func(
 		f func(ctx context.Context, s sqlliveness.Session),
@@ -637,6 +587,8 @@ func (r *Registry) Start(
 		}
 	}
 
+	// removeClaimsFromDeadSessions queries the jobs table for non-terminal
+	// jobs and nullifies their claims if the claims are owned by known dead sessions.
 	removeClaimsFromDeadSessions := func(ctx context.Context, s sqlliveness.Session) {
 		if err := r.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 			// Run the expiration transaction at low priority to ensure that it does
@@ -655,7 +607,7 @@ SELECT claim_session_id
  WHERE claim_session_id <> $1
    AND status IN `+claimableStatusTupleString+`
    AND NOT crdb_internal.sql_liveness_is_alive(claim_session_id) FETCH 
-	 FIRST `+strconv.Itoa(int(CancellationsUpdateLimitSetting.Get(&r.settings.SV)))+` ROWS ONLY)`,
+	 FIRST `+strconv.Itoa(int(cancellationsUpdateLimitSetting.Get(&r.settings.SV)))+` ROWS ONLY)`,
 				s.ID().UnsafeBytes(),
 			)
 			return err
@@ -663,6 +615,9 @@ SELECT claim_session_id
 			log.Errorf(ctx, "error expiring job sessions: %s", err)
 		}
 	}
+	// servePauseAndCancelRequests queries tho pause-requested and cancel-requested
+	// jobs that this node has claimed and sets their states to paused or cancel
+	// respectively, and then stops the execution of those jobs.
 	servePauseAndCancelRequests := func(ctx context.Context, s sqlliveness.Session) {
 		if err := r.servePauseAndCancelRequests(ctx, s); err != nil {
 			log.Errorf(ctx, "failed to serve pause and cancel requests: %v", err)
@@ -673,11 +628,16 @@ SELECT claim_session_id
 		r.maybeCancelJobs(ctx, s)
 		servePauseAndCancelRequests(ctx, s)
 	})
+	// claimJobs iterates the set of jobs which are not currently claimed and
+	// claims jobs up to maxAdoptionsPerLoop.
 	claimJobs := withSession(func(ctx context.Context, s sqlliveness.Session) {
 		if err := r.claimJobs(ctx, s); err != nil {
 			log.Errorf(ctx, "error claiming jobs: %s", err)
 		}
 	})
+	// processClaimedJobs iterates the jobs claimed by the current node that
+	// are in the running or reverting state, and then it starts those jobs if
+	// they are not already running.
 	processClaimedJobs := withSession(func(ctx context.Context, s sqlliveness.Session) {
 		if r.adoptionDisabled(ctx) {
 			log.Warningf(ctx, "canceling all adopted jobs due to liveness failure")
@@ -690,19 +650,24 @@ SELECT claim_session_id
 	})
 
 	if err := stopper.RunAsyncTask(context.Background(), "jobs/cancel", func(ctx context.Context) {
-		// Calling maybeCancelJobs once at the start ensures we have an up-to-date
-		// liveness epoch before we wait out the first cancelInterval.
 		ctx, cancel := stopper.WithCancelOnQuiesce(ctx)
 		defer cancel()
+
 		cancelLoopTask(ctx)
+		lc, cleanup := makeLoopController(r.settings, cancelIntervalSetting, r.knobs.IntervalOverrides.Cancel)
+		defer cleanup()
 		for {
 			select {
+			case <-lc.updated:
+				lc.onUpdate()
 			case <-r.stopper.ShouldQuiesce():
 				log.Warningf(ctx, "canceling all adopted jobs due to stopper quiescing")
 				r.cancelAllAdoptedJobs()
 				return
-			case <-time.After(cancelInterval):
+			case <-lc.timer.C:
+				lc.timer.Read = true
 				cancelLoopTask(ctx)
+				lc.onExecute()
 			}
 		}
 	}); err != nil {
@@ -710,43 +675,32 @@ SELECT claim_session_id
 	}
 	if err := stopper.RunAsyncTask(context.Background(), "jobs/gc", func(ctx context.Context) {
 		ctx, cancel := stopper.WithCancelOnQuiesce(ctx)
-		settingChanged := make(chan struct{}, 1)
-		gcSetting.SetOnChange(&r.settings.SV, func(ctx context.Context) {
-			select {
-			case settingChanged <- struct{}{}:
-			default:
-			}
-		})
-		gcInterval := func() time.Duration {
-			if setting := gcSetting.Get(&r.settings.SV); setting < maxGCInterval {
-				return setting
-			}
-			return maxGCInterval
-		}
-		timer := timeutil.NewTimer()
-		lastGC := timeutil.Now()
-		// We'll jitter the first cleanup run to avoid contention in case multiple
-		// nodes restart at once.
-
-		const jitter = 1 / 6
-		jitterFraction := 1 + (2*rand.Float64()-1)*jitter // 1 + [-1/6, +1/6)
-		jitterredDuration := float64(gcInterval()) * jitterFraction
-		timer.Reset(time.Duration(jitterredDuration))
 		defer cancel()
+
+		lc, cleanup := makeLoopController(r.settings, gcIntervalSetting, r.knobs.IntervalOverrides.Gc)
+		defer cleanup()
+
+		// Retention duration of terminal job records.
+		retentionDuration := func() time.Duration {
+			if r.knobs.IntervalOverrides.RetentionTime != nil {
+				return *r.knobs.IntervalOverrides.RetentionTime
+			}
+			return retentionTimeSetting.Get(&r.settings.SV)
+		}
+
 		for {
 			select {
-			case <-settingChanged:
-				timer.Reset(timeutil.Until(lastGC.Add(gcInterval())))
+			case <-lc.updated:
+				lc.onUpdate()
 			case <-stopper.ShouldQuiesce():
 				return
-			case <-timer.C:
-				timer.Read = true
-				old := timeutil.Now().Add(-1 * gcSetting.Get(&r.settings.SV))
+			case <-lc.timer.C:
+				lc.timer.Read = true
+				old := timeutil.Now().Add(-1 * retentionDuration())
 				if err := r.cleanupOldJobs(ctx, old); err != nil {
 					log.Warningf(ctx, "error cleaning up old job records: %v", err)
 				}
-				lastGC = timeutil.Now()
-				timer.Reset(gcInterval())
+				lc.onExecute()
 			}
 		}
 	}); err != nil {
@@ -755,11 +709,12 @@ SELECT claim_session_id
 	return stopper.RunAsyncTask(context.Background(), "jobs/adopt", func(ctx context.Context) {
 		ctx, cancel := stopper.WithCancelOnQuiesce(ctx)
 		defer cancel()
-		timer := timeutil.NewTimer()
-		defer timer.Stop()
-		timer.Reset(adoptInterval)
+		lc, cleanup := makeLoopController(r.settings, adoptIntervalSetting, r.knobs.IntervalOverrides.Adopt)
+		defer cleanup()
 		for {
 			select {
+			case <-lc.updated:
+				lc.onUpdate()
 			case <-stopper.ShouldQuiesce():
 				return
 			case shouldClaim := <-r.adoptionCh:
@@ -768,11 +723,11 @@ SELECT claim_session_id
 					claimJobs(ctx)
 				}
 				processClaimedJobs(ctx)
-			case <-timer.C:
-				timer.Read = true
+			case <-lc.timer.C:
+				lc.timer.Read = true
 				claimJobs(ctx)
 				processClaimedJobs(ctx)
-				timer.Reset(adoptInterval)
+				lc.onExecute()
 			}
 		}
 	})
@@ -804,17 +759,18 @@ func (r *Registry) cleanupOldJobs(ctx context.Context, olderThan time.Time) erro
 	}
 }
 
+const expiredJobsQuery = "SELECT id, payload, status, created FROM system.jobs " +
+	"WHERE (created < $1) AND (id > $2) " +
+	"ORDER BY id " + // the ordering is important as we keep track of the maximum ID we've seen
+	"LIMIT $3"
+
 // cleanupOldJobsPage deletes up to cleanupPageSize job rows with ID > minID.
 // minID is supposed to be the maximum ID returned by the previous page (0 if no
 // previous page).
 func (r *Registry) cleanupOldJobsPage(
 	ctx context.Context, olderThan time.Time, minID jobspb.JobID, pageSize int,
 ) (done bool, maxID jobspb.JobID, retErr error) {
-	const stmt = "SELECT id, payload, status, created FROM system.jobs " +
-		"WHERE created < $1 AND id > $2 " +
-		"ORDER BY id " + // the ordering is important as we keep track of the maximum ID we've seen
-		"LIMIT $3"
-	it, err := r.ex.QueryIterator(ctx, "gc-jobs", nil /* txn */, stmt, olderThan, minID, pageSize)
+	it, err := r.ex.QueryIterator(ctx, "gc-jobs", nil /* txn */, expiredJobsQuery, olderThan, minID, pageSize)
 	if err != nil {
 		return false, 0, err
 	}

--- a/pkg/jobs/registry_external_test.go
+++ b/pkg/jobs/registry_external_test.go
@@ -14,16 +14,25 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
+	"fmt"
 	"reflect"
+	"regexp"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -64,7 +73,7 @@ func TestRoundtripJob(t *testing.T) {
 	}
 }
 
-// TestExpiringSessionsDoesNotTouchTerminalJobs will ensure that we do not
+// TestExpiringSessionsAndClaimJobsDoesNotTouchTerminalJobs will ensure that we do not
 // update the claim_session_id field of jobs when expiring sessions or claiming
 // jobs.
 func TestExpiringSessionsAndClaimJobsDoesNotTouchTerminalJobs(t *testing.T) {
@@ -72,10 +81,14 @@ func TestExpiringSessionsAndClaimJobsDoesNotTouchTerminalJobs(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	// Don't adopt, cancel rapidly.
-	defer jobs.TestingSetAdoptAndCancelIntervals(10*time.Hour, 10*time.Millisecond)()
+	adopt := 10 * time.Hour
+	cancel := 10 * time.Millisecond
+	args := base.TestServerArgs{Knobs: base.TestingKnobs{
+		JobsTestingKnobs: jobs.NewTestingKnobsWithIntervals(adopt, cancel),
+	}}
 
 	ctx := context.Background()
-	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s, sqlDB, _ := serverutils.StartServer(t, args)
 	defer s.Stopper().Stop(ctx)
 
 	payload, err := protoutil.Marshal(&jobspb.Payload{
@@ -172,4 +185,233 @@ RETURNING id;
 	for _, id := range terminalIDs {
 		require.NoError(t, checkClaimEqual(id, nil))
 	}
+}
+
+// TestRegistrySettingUpdate checks whether the cluster settings are effective
+// and properly propagated through the SQL interface. The cluster settings
+// change the frequency of adopt, cancel, and gc jobs run by the registry.
+func TestRegistrySettingUpdate(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// Default interval at the beginning of each test. The duration should be long
+	// to ensure that no jobs are run in the initial phase of the tests.
+	const defaultDuration = time.Hour
+	// Interval to use when testing the value to go from a longer to a shorter duration.
+	const shortDuration = 5 * time.Millisecond
+	// Number of job runs to expect when job interval is set to shortDuration.
+	const moreThan = 2
+	// Base multiplier to convert defaultDuration into shortDuration
+	const shortDurationBase = float64(shortDuration) / float64(defaultDuration)
+
+	// Returns cluster settings that overrides the given setting to a long
+	// defaultDuration so that the cluster setting can be tested by reducing the
+	// intervals.
+	clusterSettings := func(ctx context.Context, setting *settings.DurationSetting) *cluster.Settings {
+		s := cluster.MakeTestingClusterSettings()
+		setting.Override(ctx, &s.SV, defaultDuration)
+		return s
+	}
+
+	for _, test := range [...]struct {
+		name       string      // Test case ID.
+		setting    string      // Cluster setting key.
+		value      interface{} // Duration when expecting a large number of job runs.
+		matchStmt  string      // SQL statement to match to identify the target job.
+		initCount  int         // Initial number of jobs to ignore at the beginning of the test.
+		toOverride *settings.DurationSetting
+	}{
+		{
+			name:       "adopt setting",
+			setting:    jobs.AdoptIntervalSettingKey,
+			value:      shortDuration,
+			matchStmt:  jobs.AdoptQuery,
+			initCount:  0,
+			toOverride: jobs.AdoptIntervalSetting,
+		},
+		{
+			name:       "adopt setting with base",
+			setting:    jobs.IntervalBaseSettingKey,
+			value:      shortDurationBase,
+			matchStmt:  jobs.AdoptQuery,
+			initCount:  0,
+			toOverride: jobs.AdoptIntervalSetting,
+		},
+		{
+			name:       "cancel setting",
+			setting:    jobs.CancelIntervalSettingKey,
+			value:      shortDuration,
+			matchStmt:  jobs.CancelQuery,
+			initCount:  1, // 1 because a cancelLoopTask is run before the job loop.
+			toOverride: jobs.CancelIntervalSetting,
+		},
+		{
+			name:       "cancel setting with base",
+			setting:    jobs.IntervalBaseSettingKey,
+			value:      shortDurationBase,
+			matchStmt:  jobs.CancelQuery,
+			initCount:  1, // 1 because a cancelLoopTask is run before the job loop.
+			toOverride: jobs.CancelIntervalSetting,
+		},
+		{
+			name:       "gc setting",
+			setting:    jobs.GcIntervalSettingKey,
+			value:      shortDuration,
+			matchStmt:  jobs.GcQuery,
+			initCount:  0,
+			toOverride: jobs.GcIntervalSetting,
+		},
+		{
+			name:       "gc setting with base",
+			setting:    jobs.IntervalBaseSettingKey,
+			value:      shortDurationBase,
+			matchStmt:  jobs.GcQuery,
+			initCount:  0,
+			toOverride: jobs.GcIntervalSetting,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			// Replace multiple white spaces with a single space, remove the last ';', and
+			// trim leading and trailing spaces.
+			matchStmt := strings.TrimSpace(regexp.MustCompile(`(\s+|;+)`).ReplaceAllString(test.matchStmt, " "))
+			var seen = int32(0)
+			stmtFilter := func(ctxt context.Context, stmt string, err error) {
+				if err != nil {
+					return
+				}
+				if stmt == matchStmt {
+					atomic.AddInt32(&seen, 1)
+				}
+			}
+
+			// Override the setting to be tested and set the value to a long duration.
+			// We do so to observe rapid increase in job runs in response to updating
+			// the job interval to a short duration.
+			cs := clusterSettings(ctx, test.toOverride)
+			args := base.TestServerArgs{
+				Settings: cs,
+				Knobs:    base.TestingKnobs{SQLExecutor: &sql.ExecutorTestingKnobs{StatementFilter: stmtFilter}},
+			}
+			s, sdb, _ := serverutils.StartServer(t, args)
+			defer s.Stopper().Stop(ctx)
+			tdb := sqlutils.MakeSQLRunner(sdb)
+
+			// Wait for the initial job runs to finish.
+			testutils.SucceedsSoon(t, func() error {
+				counted := int(atomic.LoadInt32(&seen))
+				if counted == test.initCount {
+					return nil
+				}
+				return errors.Errorf("%s: expected at least %d calls at the beginning, counted %d",
+					test.name, test.initCount, counted)
+			})
+
+			// Expect no jobs to run after a short duration to ensure that the
+			// long interval times are in effect.
+			atomic.StoreInt32(&seen, 0)
+			time.Sleep(3 * shortDuration)
+			counted := int(atomic.LoadInt32(&seen))
+			require.Equalf(t, 0, counted,
+				"expected no jobs after a short duration in the beginning, found %d", counted)
+
+			// Reduce the interval and expect a larger number of job runs in a few
+			// seconds.
+			tdb.Exec(t, fmt.Sprintf("SET CLUSTER SETTING %s = '%v'", test.setting, test.value))
+			atomic.StoreInt32(&seen, 0)
+			testutils.SucceedsSoon(t, func() error {
+				counted = int(atomic.LoadInt32(&seen))
+				if counted >= moreThan {
+					return nil
+				}
+				return errors.Errorf("%s: expected at least %d calls, counted %d",
+					test.name, moreThan, counted)
+			})
+		})
+	}
+}
+
+// TestGCDurationControl tests the effectiveness of job retention duration
+// cluster setting and its control through the SQL interface.
+func TestGCDurationControl(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	defer jobs.ResetConstructors()()
+	ctx := context.Background()
+
+	// Set a statement filter to monitor GC jobs that delete expired jobs.
+	//
+	// Replace multiple white spaces with a single space, remove the last ';', and
+	// trim leading and trailing spaces.
+	gcStmt := strings.TrimSpace(regexp.MustCompile(`(\s+|;+)`).ReplaceAllString(jobs.GcQuery, " "))
+	var seen = int32(0)
+	stmtFilter := func(ctxt context.Context, stmt string, err error) {
+		if err != nil {
+			return
+		}
+		if stmt == gcStmt {
+			atomic.AddInt32(&seen, 1)
+		}
+	}
+	cs := cluster.MakeTestingClusterSettings()
+	// Ensure that GC interval and job retention duration is long in the beginning
+	// of the test to ensure that the job is deleted when the retention time is
+	// reduced.
+	jobs.GcIntervalSetting.Override(ctx, &cs.SV, time.Hour)
+	jobs.RetentionTimeSetting.Override(ctx, &cs.SV, time.Hour)
+	// Shorten the adopt interval to minimize test time.
+	jobs.AdoptIntervalSetting.Override(ctx, &cs.SV, 5*time.Millisecond)
+	args := base.TestServerArgs{
+		Settings: cs,
+		Knobs: base.TestingKnobs{
+			SQLExecutor: &sql.ExecutorTestingKnobs{StatementFilter: stmtFilter},
+		},
+	}
+
+	jobs.RegisterConstructor(jobspb.TypeImport, func(_ *jobs.Job, cs *cluster.Settings) jobs.Resumer {
+		return jobs.FakeResumer{}
+	})
+	s, sqlDB, kvDB := serverutils.StartServer(t, args)
+	defer s.Stopper().Stop(ctx)
+	registry := s.JobRegistry().(*jobs.Registry)
+
+	// Create and run a dummy job.
+	id := registry.MakeJobID()
+	require.NoError(t, kvDB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+		_, err := registry.CreateJobWithTxn(ctx, jobs.Record{
+			// Job does not accept an empty Details field, so arbitrarily provide
+			// ImportDetails.
+			Details:  jobspb.ImportDetails{},
+			Progress: jobspb.ImportProgress{},
+		}, id, txn)
+		return err
+	}))
+	require.NoError(t,
+		registry.WaitForJobs(
+			ctx, s.InternalExecutor().(sqlutil.InternalExecutor), []jobspb.JobID{id},
+		))
+
+	tdb := sqlutils.MakeSQLRunner(sqlDB)
+	existsQuery := fmt.Sprintf("SELECT count(*) = 1 FROM system.jobs WHERE id = %d", id)
+	// Make sure the job exists even though it has completed.
+	tdb.CheckQueryResults(t, existsQuery, [][]string{{"true"}})
+	// Shorten the GC interval to try deleting the job.
+	tdb.Exec(t, fmt.Sprintf("SET CLUSTER SETTING %s = '5ms'", jobs.GcIntervalSettingKey))
+	// Wait for GC to run at least once.
+	atomic.StoreInt32(&seen, 0)
+	testutils.SucceedsSoon(t, func() error {
+		moreThan := 1
+		counted := int(atomic.LoadInt32(&seen))
+		if counted >= moreThan {
+			return nil
+		}
+		return errors.Errorf("expected at least %d calls, counted %d",
+			moreThan, counted)
+	})
+	// Make sure the job still exists.
+	tdb.CheckQueryResults(t, existsQuery, [][]string{{"true"}})
+	// Shorten the retention duration.
+	tdb.Exec(t, fmt.Sprintf("SET CLUSTER SETTING %s = '1ms'", jobs.RetentionTimeSettingKey))
+	// Wait for the job to be deleted.
+	tdb.CheckQueryResultsRetry(t, existsQuery, [][]string{{"false"}})
 }

--- a/pkg/jobs/schedule_control_test.go
+++ b/pkg/jobs/schedule_control_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobstest"
 	"github.com/cockroachdb/cockroach/pkg/security"
@@ -120,7 +121,7 @@ func TestScheduleControl(t *testing.T) {
 
 func TestJobsControlForSchedules(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	th, cleanup := newTestHelperForTables(t, jobstest.UseSystemTables)
+	th, cleanup := newTestHelperForTables(t, jobstest.UseSystemTables, nil)
 	defer cleanup()
 
 	registry := th.server.JobRegistry().(*Registry)
@@ -229,11 +230,14 @@ func TestJobsControlForSchedules(t *testing.T) {
 func TestFilterJobsControlForSchedules(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer ResetConstructors()()
-	th, cleanup := newTestHelperForTables(t, jobstest.UseSystemTables)
-	defer cleanup()
 
-	// Prevent registry from changing job state while running this test.
-	defer TestingSetAdoptAndCancelIntervals(24*time.Hour, 24*time.Hour)()
+	argsFn := func(args *base.TestServerArgs) {
+		// Prevent registry from changing job state while running this test.
+		interval := 24 * time.Hour
+		args.Knobs.JobsTestingKnobs = NewTestingKnobsWithIntervals(interval, interval)
+	}
+	th, cleanup := newTestHelperForTables(t, jobstest.UseSystemTables, argsFn)
+	defer cleanup()
 
 	registry := th.server.JobRegistry().(*Registry)
 	blockResume := make(chan struct{})

--- a/pkg/jobs/testing_knobs.go
+++ b/pkg/jobs/testing_knobs.go
@@ -51,7 +51,47 @@ type TestingKnobs struct {
 	// has run. If an error is returned, it will be propagated and the update will
 	// not be committed.
 	BeforeUpdate func(orig, updated JobMetadata) error
+
+	// IntervalOverrides consists of override knobs for job intervals.
+	IntervalOverrides TestingIntervalOverrides
+}
+
+// TestingIntervalOverrides contains variables to override the intervals and
+// settings of periodic tasks.
+type TestingIntervalOverrides struct {
+	// Adopt overrides the adoptIntervalSetting cluster setting.
+	Adopt *time.Duration
+
+	// Cancel overrides the cancelIntervalSetting cluster setting.
+	Cancel *time.Duration
+
+	// Gc overrides the gcIntervalSetting cluster setting.
+	Gc *time.Duration
+
+	// Base overrides the intervalBaseSetting cluster setting.
+	Base *float64
+
+	// RetentionTime overrides the retentionTimeSetting cluster setting.
+	RetentionTime *time.Duration
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.
 func (*TestingKnobs) ModuleTestingKnobs() {}
+
+// NewTestingKnobsWithShortIntervals return a TestingKnobs structure with
+// overrides for short adopt and cancel intervals.
+func NewTestingKnobsWithShortIntervals() *TestingKnobs {
+	const defaultShortInterval = 10 * time.Millisecond
+	return NewTestingKnobsWithIntervals(defaultShortInterval, defaultShortInterval)
+}
+
+// NewTestingKnobsWithIntervals return a TestingKnobs structure with overrides
+// for adopt and cancel intervals.
+func NewTestingKnobsWithIntervals(adopt, cancel time.Duration) *TestingKnobs {
+	return &TestingKnobs{
+		IntervalOverrides: TestingIntervalOverrides{
+			Adopt:  &adopt,
+			Cancel: &cancel,
+		},
+	}
+}

--- a/pkg/migration/migrationmanager/manager_external_test.go
+++ b/pkg/migration/migrationmanager/manager_external_test.go
@@ -382,10 +382,6 @@ func TestPauseMigration(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer jobs.TestingSetAdoptAndCancelIntervals(
-		10*time.Millisecond, 10*time.Millisecond,
-	)()
-
 	// We're going to be migrating from startCV to endCV.
 	startCV := clusterversion.ClusterVersion{Version: roachpb.Version{Major: 41}}
 	endCV := clusterversion.ClusterVersion{Version: roachpb.Version{Major: 42}}
@@ -401,6 +397,7 @@ func TestPauseMigration(t *testing.T) {
 		ServerArgs: base.TestServerArgs{
 			Settings: cluster.MakeTestingClusterSettingsWithVersions(endCV.Version, startCV.Version, false),
 			Knobs: base.TestingKnobs{
+				JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 				Server: &server.TestingKnobs{
 					BinaryVersionOverride:          startCV.Version,
 					DisableAutomaticVersionUpgrade: 1,

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -856,9 +856,7 @@ func (s *SQLServer) preStart(
 	)
 	s.sqlmigrationsMgr = sqlmigrationsMgr // only for testing via TestServer
 
-	if err := s.jobRegistry.Start(
-		ctx, stopper, jobs.DefaultCancelInterval, jobs.DefaultAdoptInterval,
-	); err != nil {
+	if err := s.jobRegistry.Start(ctx, stopper); err != nil {
 		return err
 	}
 

--- a/pkg/settings/duration.go
+++ b/pkg/settings/duration.go
@@ -191,7 +191,8 @@ func NonNegativeDuration(v time.Duration) error {
 	return nil
 }
 
-// NonNegativeDurationWithMaximum can be passed to RegisterDurationSetting.
+// NonNegativeDurationWithMaximum returns a validation function that can be
+// passed to RegisterDurationSetting.
 func NonNegativeDurationWithMaximum(maxValue time.Duration) func(time.Duration) error {
 	return func(v time.Duration) error {
 		if v < 0 {
@@ -202,4 +203,12 @@ func NonNegativeDurationWithMaximum(maxValue time.Duration) func(time.Duration) 
 		}
 		return nil
 	}
+}
+
+// PositiveDuration can be passed to RegisterDurationSetting.
+func PositiveDuration(v time.Duration) error {
+	if v <= 0 {
+		return errors.Errorf("cannot be set to a non-positive duration: %s", v)
+	}
+	return nil
 }

--- a/pkg/sql/alter_column_type_test.go
+++ b/pkg/sql/alter_column_type_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqltestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -190,8 +189,6 @@ func TestVisibilityDuringAlterColumnType(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer sqltestutils.SetTestJobsAdoptInterval()()
-
 	ctx := context.Background()
 	swapNotification := make(chan struct{})
 	waitBeforeContinuing := make(chan struct{})
@@ -205,6 +202,8 @@ func TestVisibilityDuringAlterColumnType(t *testing.T) {
 				<-waitBeforeContinuing
 			},
 		},
+		// Decrease the adopt loop interval so that retries happen quickly.
+		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 	}
 	s, db, _ := serverutils.StartServer(t, params)
 	sqlDB := sqlutils.MakeSQLRunner(db)
@@ -290,9 +289,10 @@ ALTER TABLE t.test ALTER COLUMN x TYPE INT;
 func TestQueryIntToString(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	defer sqltestutils.SetTestJobsAdoptInterval()()
 
 	params, _ := tests.CreateTestServerParams()
+	// Decrease the adopt loop interval so that retries happen quickly.
+	params.Knobs.JobsTestingKnobs = jobs.NewTestingKnobsWithShortIntervals()
 
 	s, db, _ := serverutils.StartServer(t, params)
 	sqlDB := sqlutils.MakeSQLRunner(db)

--- a/pkg/sql/gcjob_test/gc_job_test.go
+++ b/pkg/sql/gcjob_test/gc_job_test.go
@@ -49,7 +49,6 @@ import (
 func TestSchemaChangeGCJob(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	skip.WithIssue(t, 60664, "flaky test")
-	defer jobs.TestingSetAdoptAndCancelIntervals(100*time.Millisecond, 100*time.Millisecond)()
 
 	type DropItem int
 	const (
@@ -67,8 +66,9 @@ func TestSchemaChangeGCJob(t *testing.T) {
 
 	for _, dropItem := range []DropItem{INDEX, TABLE, DATABASE} {
 		for _, ttlTime := range []TTLTime{PAST, SOON, FUTURE} {
-			params := base.TestServerArgs{}
 			blockGC := make(chan struct{}, 1)
+			params := base.TestServerArgs{}
+			params.Knobs.JobsTestingKnobs = jobs.NewTestingKnobsWithShortIntervals()
 			params.Knobs.GCJob = &sql.GCJobTestingKnobs{
 				RunBeforePerformGC: func(_ jobspb.JobID) error {
 					<-blockGC
@@ -265,11 +265,11 @@ func TestSchemaChangeGCJob(t *testing.T) {
 func TestSchemaChangeGCJobTableGCdWhileWaitingForExpiration(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	defer jobs.TestingSetAdoptAndCancelIntervals(100*time.Millisecond, 100*time.Millisecond)()
+	args := base.TestServerArgs{Knobs: base.TestingKnobs{JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals()}}
 
 	// We're going to drop a table then manually delete it, then update the
 	// database zone config and ensure the job finishes successfully.
-	s, db, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+	s, db, kvDB := serverutils.StartServer(t, args)
 	ctx := context.Background()
 	defer s.Stopper().Stop(ctx)
 	sqlDB := sqlutils.MakeSQLRunner(db)
@@ -331,13 +331,13 @@ SELECT job_id, status, running_status
 // logic for GC-ing tenant.
 func TestGCResumer(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer jobs.TestingSetAdoptAndCancelIntervals(100*time.Millisecond, 100*time.Millisecond)()
 	defer log.Scope(t).Close(t)
 	defer jobs.ResetConstructors()()
 	gcjob.SetSmallMaxGCIntervalForTest()
 
 	ctx := context.Background()
-	srv, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+	args := base.TestServerArgs{Knobs: base.TestingKnobs{JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals()}}
+	srv, sqlDB, kvDB := serverutils.StartServer(t, args)
 	execCfg := srv.ExecutorConfig().(sql.ExecutorConfig)
 	jobRegistry := execCfg.JobRegistry
 	defer srv.Stopper().Stop(ctx)

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -1230,9 +1230,6 @@ func TestSchemaChangeRetry(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	// Decrease the adopt loop interval so that retries happen quickly.
-	defer sqltestutils.SetTestJobsAdoptInterval()()
-
 	params, _ := tests.CreateTestServerParams()
 
 	currChunk := 0
@@ -1277,7 +1274,10 @@ func TestSchemaChangeRetry(t *testing.T) {
 		SQLMigrationManager: &sqlmigrations.MigrationManagerTestingKnobs{
 			DisableBackfillMigrations: true,
 		},
+		// Decrease the adopt loop interval so that retries happen quickly.
+		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 	}
+
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.Background())
 
@@ -1314,9 +1314,6 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 func TestSchemaChangeRetryOnVersionChange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-
-	// Decrease the adopt loop interval so that retries happen quickly.
-	defer sqltestutils.SetTestJobsAdoptInterval()()
 
 	params, _ := tests.CreateTestServerParams()
 	var upTableVersion func()
@@ -1366,7 +1363,10 @@ func TestSchemaChangeRetryOnVersionChange(t *testing.T) {
 		SQLMigrationManager: &sqlmigrations.MigrationManagerTestingKnobs{
 			DisableBackfillMigrations: true,
 		},
+		// Decrease the adopt loop interval so that retries happen quickly.
+		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 	}
+
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.Background())
 
@@ -2238,8 +2238,6 @@ func TestVisibilityDuringPrimaryKeyChange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer sqltestutils.SetTestJobsAdoptInterval()()
-
 	ctx := context.Background()
 	swapNotification := make(chan struct{})
 	waitBeforeContinuing := make(chan struct{})
@@ -2253,6 +2251,7 @@ func TestVisibilityDuringPrimaryKeyChange(t *testing.T) {
 				<-waitBeforeContinuing
 			},
 		},
+		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 	}
 	s, sqlDB, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(ctx)
@@ -2322,8 +2321,6 @@ func TestPrimaryKeyChangeWithPrecedingIndexCreation(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer sqltestutils.SetTestJobsAdoptInterval()()
-
 	ctx := context.Background()
 
 	var chunkSize int64 = 100
@@ -2369,6 +2366,8 @@ func TestPrimaryKeyChangeWithPrecedingIndexCreation(t *testing.T) {
 				return nil
 			},
 		},
+		// Decrease the adopt loop interval so that retries happen quickly.
+		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 	}
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(ctx)
@@ -2972,10 +2971,9 @@ func TestPrimaryKeyIndexRewritesGetRemoved(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 
-	// Decrease the adopt loop interval so that retries happen quickly.
-	defer sqltestutils.SetTestJobsAdoptInterval()()
-
 	params, _ := tests.CreateTestServerParams()
+	// Decrease the adopt loop interval so that retries happen quickly.
+	params.Knobs.JobsTestingKnobs = jobs.NewTestingKnobsWithShortIntervals()
 
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(ctx)
@@ -3007,9 +3005,6 @@ ALTER TABLE t.test ALTER PRIMARY KEY USING COLUMNS (v);
 func TestPrimaryKeyChangeWithCancel(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-
-	// Decrease the adopt loop interval so that retries happen quickly.
-	defer sqltestutils.SetTestJobsAdoptInterval()()
 
 	var chunkSize int64 = 100
 	var maxValue = 4000
@@ -3044,7 +3039,10 @@ func TestPrimaryKeyChangeWithCancel(t *testing.T) {
 				return nil
 			},
 		},
+		// Decrease the adopt loop interval so that retries happen quickly.
+		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 	}
+
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
 	db = sqlDB
 	defer s.Stopper().Stop(ctx)
@@ -3155,13 +3153,12 @@ func TestMultiplePrimaryKeyChanges(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	// Decrease the adopt loop interval so that retries happen quickly.
-	defer sqltestutils.SetTestJobsAdoptInterval()()
-
 	ctx := context.Background()
 	params, _ := tests.CreateTestServerParams()
 	params.Knobs = base.TestingKnobs{
 		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{},
+		// Decrease the adopt loop interval so that retries happen quickly.
+		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 	}
 	s, sqlDB, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(ctx)
@@ -3197,7 +3194,6 @@ func TestGrantRevokeWhileIndexBackfill(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer sqltestutils.SetTestJobsAdoptInterval()()
 	backfillNotification := make(chan bool)
 
 	backfillCompleteNotification := make(chan bool)
@@ -3231,7 +3227,10 @@ func TestGrantRevokeWhileIndexBackfill(t *testing.T) {
 		SQLMigrationManager: &sqlmigrations.MigrationManagerTestingKnobs{
 			DisableBackfillMigrations: true,
 		},
+		// Decrease the adopt loop interval so that retries happen quickly.
+		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 	}
+
 	server, db, _ := serverutils.StartServer(t, params)
 	defer server.Stopper().Stop(context.Background())
 	sqlDB := sqlutils.MakeSQLRunner(db)
@@ -3292,7 +3291,6 @@ func TestCRUDWhileColumnBackfill(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer sqltestutils.SetTestJobsAdoptInterval()()
 	backfillNotification := make(chan bool)
 
 	backfillCompleteNotification := make(chan bool)
@@ -3325,6 +3323,8 @@ func TestCRUDWhileColumnBackfill(t *testing.T) {
 		SQLMigrationManager: &sqlmigrations.MigrationManagerTestingKnobs{
 			DisableBackfillMigrations: true,
 		},
+		// Decrease the adopt loop interval so that retries happen quickly.
+		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 	}
 	server, sqlDB, kvDB := serverutils.StartServer(t, params)
 	defer server.Stopper().Stop(context.Background())
@@ -4109,10 +4109,11 @@ func TestTruncateCompletion(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	const maxValue = 2000
 
-	defer sqltestutils.SetTestJobsAdoptInterval()()
 	defer gcjob.SetSmallMaxGCIntervalForTest()()
 
 	params, _ := tests.CreateTestServerParams()
+	// Decrease the adopt loop interval so that retries happen quickly.
+	params.Knobs.JobsTestingKnobs = jobs.NewTestingKnobsWithShortIntervals()
 
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
 	ctx := context.Background()
@@ -4240,10 +4241,11 @@ func TestTruncateInterleavedTables(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer sqltestutils.SetTestJobsAdoptInterval()()
 	defer gcjob.SetSmallMaxGCIntervalForTest()()
 
 	params, _ := tests.CreateTestServerParams()
+	// Decrease the adopt loop interval so that retries happen quickly.
+	params.Knobs.JobsTestingKnobs = jobs.NewTestingKnobsWithShortIntervals()
 
 	s, sqlDBRaw, kvDB := serverutils.StartServer(t, params)
 	ctx := context.Background()
@@ -4461,9 +4463,6 @@ func TestIndexBackfillAfterGC(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	// Decrease the adopt loop interval so that retries happen quickly.
-	defer sqltestutils.SetTestJobsAdoptInterval()()
-
 	var tc serverutils.TestClusterInterface
 	ctx := context.Background()
 	var gcAt hlc.Timestamp
@@ -4494,6 +4493,8 @@ func TestIndexBackfillAfterGC(t *testing.T) {
 				return nil
 			},
 		},
+		// Decrease the adopt loop interval so that retries happen quickly.
+		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 	}
 
 	tc = serverutils.StartNewTestCluster(t, 1, base.TestClusterArgs{ServerArgs: params})
@@ -5067,8 +5068,6 @@ func TestSchemaChangeGRPCError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer sqltestutils.SetTestJobsAdoptInterval()()
-
 	const maxValue = 100
 	params, _ := tests.CreateTestServerParams()
 	seenNodeUnavailable := false
@@ -5082,7 +5081,10 @@ func TestSchemaChangeGRPCError(t *testing.T) {
 				return nil
 			},
 		},
+		// Decrease the adopt loop interval so that retries happen quickly.
+		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 	}
+
 	s, db, kvDB := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.Background())
 	sqlDB := sqlutils.MakeSQLRunner(db)
@@ -6007,7 +6009,6 @@ func TestFKReferencesAddedOnlyOnceOnRetry(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer sqltestutils.SetTestJobsAdoptInterval()()
 	params, _ := tests.CreateTestServerParams()
 	var runBeforeConstraintValidation func() error
 	errorReturned := false
@@ -6021,7 +6022,10 @@ func TestFKReferencesAddedOnlyOnceOnRetry(t *testing.T) {
 		SQLMigrationManager: &sqlmigrations.MigrationManagerTestingKnobs{
 			DisableBackfillMigrations: true,
 		},
+		// Decrease the adopt loop interval so that retries happen quickly.
+		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 	}
+
 	s, sqlDB, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.Background())
 	if _, err := sqlDB.Exec(`
@@ -6163,7 +6167,6 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT8);
 func TestMultipleRevert(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	defer jobs.TestingSetAdoptAndCancelIntervals(100*time.Millisecond, 100*time.Millisecond)()
 
 	shouldBlockBackfill := true
 	ranCancelCommand := false
@@ -6172,6 +6175,7 @@ func TestMultipleRevert(t *testing.T) {
 	params, _ := tests.CreateTestServerParams()
 	var db *gosql.DB
 	params.Knobs = base.TestingKnobs{
+		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
 			RunBeforeBackfill: func() error {
 				if !shouldBlockBackfill {
@@ -6246,7 +6250,6 @@ ALTER TABLE t.public.test DROP COLUMN v;
 func TestRetriableErrorDuringRollback(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	defer sqltestutils.SetTestJobsAdoptInterval()()
 	ctx := context.Background()
 
 	runTest := func(params base.TestServerArgs) {
@@ -6307,6 +6310,8 @@ SELECT value
 					return context.Canceled
 				},
 			},
+			// Decrease the adopt loop interval so that retries happen quickly.
+			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 		}
 		runTest(params)
 	})
@@ -6332,6 +6337,8 @@ SELECT value
 					return context.Canceled
 				},
 			},
+			// Decrease the adopt loop interval so that retries happen quickly.
+			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 		}
 		runTest(params)
 	})
@@ -6342,7 +6349,6 @@ SELECT value
 func TestDropTableWhileSchemaChangeReverting(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	defer sqltestutils.SetTestJobsAdoptInterval()()
 	ctx := context.Background()
 
 	// Closed when we enter the RunBeforeOnFailOrCancel knob, at which point the
@@ -6362,7 +6368,10 @@ func TestDropTableWhileSchemaChangeReverting(t *testing.T) {
 				return jobs.NewRetryJobError("injected retry error")
 			},
 		},
+		// Decrease the adopt loop interval so that retries happen quickly.
+		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 	}
+
 	s, sqlDB, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(ctx)
 
@@ -6404,7 +6413,6 @@ SELECT status, error FROM crdb_internal.jobs WHERE description LIKE '%CREATE UNI
 func TestPermanentErrorDuringRollback(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	defer sqltestutils.SetTestJobsAdoptInterval()()
 	ctx := context.Background()
 
 	runTest := func(t *testing.T, params base.TestServerArgs, gcJobRecord bool) {
@@ -6461,6 +6469,8 @@ CREATE UNIQUE INDEX i ON t.test(v);
 					return errors.New("permanent error")
 				},
 			},
+			// Decrease the adopt loop interval so that retries happen quickly.
+			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 		}
 		// Don't GC the job record after the schema change, so we can test dropping
 		// the table with a failed mutation job.
@@ -6488,6 +6498,8 @@ CREATE UNIQUE INDEX i ON t.test(v);
 					return errors.New("permanent error")
 				},
 			},
+			// Decrease the adopt loop interval so that retries happen quickly.
+			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 		}
 		// GC the job record after the schema change, so we can test dropping the
 		// table with a nonexistent mutation job.
@@ -6627,7 +6639,6 @@ func TestAddingTableResolution(t *testing.T) {
 // descriptor.
 func TestFailureToMarkCanceledReversalLeadsToCanceledStatus(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer sqltestutils.SetTestJobsAdoptInterval()()
 	ctx := context.Background()
 
 	canProceed := make(chan struct{})
@@ -6643,6 +6654,7 @@ func TestFailureToMarkCanceledReversalLeadsToCanceledStatus(t *testing.T) {
 		defer jobCancellationsToFail.Unlock()
 		f(jobCancellationsToFail.jobs)
 	}
+	jobInterval := 100 * time.Millisecond
 	params.Knobs = base.TestingKnobs{
 		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
 			RunBeforeBackfill: func() error {
@@ -6659,6 +6671,11 @@ func TestFailureToMarkCanceledReversalLeadsToCanceledStatus(t *testing.T) {
 					}
 				})
 				return err
+			},
+			// Decrease the adopt loop interval so that retries happen quickly.
+			IntervalOverrides: jobs.TestingIntervalOverrides{
+				Adopt:  &jobInterval,
+				Cancel: &jobInterval,
 			},
 		},
 	}
@@ -6720,7 +6737,6 @@ SELECT job_id FROM crdb_internal.jobs
 // multiple queued schema changes works as expected.
 func TestCancelMultipleQueued(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer sqltestutils.SetTestJobsAdoptInterval()()
 	ctx := context.Background()
 
 	canProceed := make(chan struct{})
@@ -6732,6 +6748,8 @@ func TestCancelMultipleQueued(t *testing.T) {
 				return nil
 			},
 		},
+		// Decrease the adopt loop interval so that retries happen quickly.
+		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 	}
 	s, sqlDB, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(ctx)
@@ -6805,7 +6823,6 @@ SELECT job_id FROM crdb_internal.jobs
 // works correctly (#57596).
 func TestRollbackForeignKeyAddition(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer sqltestutils.SetTestJobsAdoptInterval()()
 	ctx := context.Background()
 
 	// Track whether we've attempted the backfill already, since there's a second
@@ -6828,7 +6845,10 @@ func TestRollbackForeignKeyAddition(t *testing.T) {
 				return nil
 			},
 		},
+		// Decrease the adopt loop interval so that retries happen quickly.
+		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 	}
+
 	s, sqlDB, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(ctx)
 
@@ -6872,7 +6892,6 @@ AND descriptor_ids[1] = 'db.t2'::regclass::int`,
 // tests that such jobs are not cancelable. Regression test for #59415.
 func TestRevertingJobsOnDatabasesAndSchemas(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer sqltestutils.SetTestJobsAdoptInterval()()
 
 	testCases := []struct {
 		name       string
@@ -6943,6 +6962,8 @@ func TestRevertingJobsOnDatabasesAndSchemas(t *testing.T) {
 					return nil
 				},
 			},
+			// Decrease the adopt loop interval so that retries happen quickly.
+			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 		}
 		var db *gosql.DB
 		s, db, _ = serverutils.StartServer(t, params)
@@ -7018,6 +7039,8 @@ func TestRevertingJobsOnDatabasesAndSchemas(t *testing.T) {
 					return nil
 				},
 			},
+			// Decrease the adopt loop interval so that retries happen quickly.
+			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 		}
 		var db *gosql.DB
 		s, db, _ = serverutils.StartServer(t, params)
@@ -7050,7 +7073,6 @@ func TestRevertingJobsOnDatabasesAndSchemas(t *testing.T) {
 // after an existing a mutation on the column
 func TestDropColumnAfterMutations(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer sqltestutils.SetTestJobsAdoptInterval()()
 	ctx := context.Background()
 	var jobControlMu syncutil.Mutex
 	var delayJobList []string
@@ -7091,7 +7113,10 @@ func TestDropColumnAfterMutations(t *testing.T) {
 				return <-proceedBeforeBackfill
 			},
 		},
+		// Decrease the adopt loop interval so that retries happen quickly.
+		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 	}
+
 	s, sqlDB, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(ctx)
 
@@ -7320,7 +7345,6 @@ COMMIT;
 // if they weren't fully validated.
 func TestCheckConstraintDropAndColumn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer sqltestutils.SetTestJobsAdoptInterval()()
 	ctx := context.Background()
 	var jobControlMu syncutil.Mutex
 	var delayJobList []string
@@ -7357,7 +7381,10 @@ func TestCheckConstraintDropAndColumn(t *testing.T) {
 				return nil
 			},
 		},
+		// Decrease the adopt loop interval so that retries happen quickly.
+		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 	}
+
 	s, sqlDB, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(ctx)
 

--- a/pkg/sql/schemachanger/BUILD.bazel
+++ b/pkg/sql/schemachanger/BUILD.bazel
@@ -21,7 +21,6 @@ go_test(
         "//pkg/sql/schemachanger/scexec",
         "//pkg/sql/schemachanger/scop",
         "//pkg/sql/schemachanger/scplan",
-        "//pkg/sql/sqltestutils",
         "//pkg/sql/tests",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",

--- a/pkg/sql/schemachanger/schemachanger_test.go
+++ b/pkg/sql/schemachanger/schemachanger_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scop"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqltestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -42,7 +41,6 @@ import (
 
 func TestSchemaChangeWaitsForOtherSchemaChanges(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer sqltestutils.SetTestJobsAdoptInterval()()
 
 	t.Run("wait for old-style schema changes", func(t *testing.T) {
 		// This test starts an old-style schema change job (job 1), and then starts
@@ -110,6 +108,7 @@ func TestSchemaChangeWaitsForOtherSchemaChanges(t *testing.T) {
 					})
 				},
 			},
+			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 		}
 		var sqlDB *gosql.DB
 		s, sqlDB, kvDB = serverutils.StartServer(t, params)
@@ -310,7 +309,6 @@ func TestSchemaChangeWaitsForOtherSchemaChanges(t *testing.T) {
 
 func TestConcurrentOldSchemaChangesCannotStart(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer sqltestutils.SetTestJobsAdoptInterval()()
 
 	ctx := context.Background()
 
@@ -357,6 +355,7 @@ func TestConcurrentOldSchemaChangesCannotStart(t *testing.T) {
 				return nil
 			},
 		},
+		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 	}
 
 	var s serverutils.TestServerInterface

--- a/pkg/sql/sqltestutils/BUILD.bazel
+++ b/pkg/sql/sqltestutils/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
     deps = [
         "//pkg/base",
         "//pkg/config/zonepb",
-        "//pkg/jobs",
         "//pkg/keys",
         "//pkg/kv",
         "//pkg/roachpb",

--- a/pkg/sql/sqltestutils/sql_test_utils.go
+++ b/pkg/sql/sqltestutils/sql_test_utils.go
@@ -17,10 +17,8 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
-	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
@@ -66,13 +64,6 @@ func AddDefaultZoneConfig(sqlDB *gosql.DB, id descpb.ID) (zonepb.ZoneConfig, err
 	}
 	_, err = sqlDB.Exec(`UPSERT INTO system.zones VALUES ($1, $2)`, id, buf)
 	return cfg, err
-}
-
-// SetTestJobsAdoptInterval sets a short job adoption interval for a test
-// and returns a function to reset it after the test. The intention is that
-// the returned function should be deferred.
-func SetTestJobsAdoptInterval() (reset func()) {
-	return jobs.TestingSetAdoptAndCancelIntervals(100*time.Millisecond, 100*time.Millisecond)
 }
 
 // BulkInsertIntoTable fills up table t.test with (maxValue + 1) rows.


### PR DESCRIPTION
Previously,  adopt and cancel intervals in the jobs
infrastructure were hardcoded. As a result, the job
adoption and cancellation frequencies were not
configurable. This commit provides cluster-settings to
update intervals to perform job adoptions, cancellations.
and garbage collection.

Release note: None

Fixes: #65079
