### PR TITLE
opt: allow test catalog to default to primary key for foreign key references

### DIFF
--- a/pkg/sql/opt/testutils/testcat/create_table.go
+++ b/pkg/sql/opt/testutils/testcat/create_table.go
@@ -365,8 +365,26 @@ func (tc *Catalog) resolveFK(tab *Table, d *tree.ForeignKeyConstraintTableDef) {
 		targetTable = tc.Table(&d.Table)
 	}
 
-	toCols := make([]int, len(d.ToCols))
-	for i, c := range d.ToCols {
+	referencedColNames := d.ToCols
+	if len(referencedColNames) == 0 {
+		// If no columns are specified, attempt to default to PK, ignoring implicit
+		// columns.
+		idx := targetTable.Index(cat.PrimaryIndex)
+		numImplicitCols := idx.ImplicitPartitioningColumnCount()
+		referencedColNames = make(
+			tree.NameList,
+			0,
+			idx.KeyColumnCount()-numImplicitCols,
+		)
+		for i := numImplicitCols; i < idx.KeyColumnCount(); i++ {
+			referencedColNames = append(
+				referencedColNames,
+				idx.Column(i).ColName(),
+			)
+		}
+	}
+	toCols := make([]int, len(referencedColNames))
+	for i, c := range referencedColNames {
 		toCols[i] = targetTable.FindOrdinal(string(c))
 	}
 

--- a/pkg/sql/opt/testutils/testcat/testdata/foreign_keys
+++ b/pkg/sql/opt/testutils/testcat/testdata/foreign_keys
@@ -183,3 +183,18 @@ CREATE TABLE self (a INT PRIMARY KEY, b INT REFERENCES self(a) ON DELETE CASCADE
 exec-ddl
 DROP TABLE self
 ----
+
+# Verify that we can use "ALTER TABLE ... ADD FOREIGN KEY" syntax to reference
+# a primary key without specifying the referenced column(s).
+
+exec-ddl
+CREATE TABLE child_implied_ref(ref INT, INDEX (ref))
+----
+
+exec-ddl
+ALTER TABLE child_implied_ref ADD FOREIGN KEY (ref) REFERENCES parent
+----
+
+exec-ddl
+DROP TABLE child_implied_ref
+----


### PR DESCRIPTION
This patch modifies the test catalog to attempt to use the primary key
of the referenced table during a foreign key declaration when the
referenced columns are not specified. This allows syntax like the
following in opt tests:
```
exec-ddl
ALTER TABLE child_implied_ref ADD FOREIGN KEY (ref) REFERENCES parent
----
```

Release note: None