### PR TITLE
colexec: refactor CASE operator to support all types

### DIFF
--- a/pkg/col/coldata/vec.eg.go
+++ b/pkg/col/coldata/vec.eg.go
@@ -307,19 +307,15 @@ func (m *memColumn) Append(args SliceArgs) {
 	}
 }
 
-func (m *memColumn) Copy(args CopySliceArgs) {
+func (m *memColumn) Copy(args SliceArgs) {
 	if args.SrcStartIdx == args.SrcEndIdx {
 		// Nothing to copy, so return early.
 		return
 	}
-	if !args.SelOnDest {
+	if m.Nulls().MaybeHasNulls() {
 		// We're about to overwrite this entire range, so unset all the nulls.
 		m.Nulls().UnsetNullRange(args.DestIdx, args.DestIdx+(args.SrcEndIdx-args.SrcStartIdx))
 	}
-	// } else {
-	// SelOnDest indicates that we're applying the input selection vector as a lens
-	// into the output vector as well. We'll set the non-nulls by hand below.
-	// }
 
 	switch m.CanonicalTypeFamily() {
 	case types.BoolFamily:
@@ -329,66 +325,38 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 			fromCol := args.Src.Bool()
 			toCol := m.Bool()
 			if args.Sel != nil {
-				sel := args.Sel
-				if args.SelOnDest {
-					sel = sel[args.SrcStartIdx:args.SrcEndIdx]
-					n := len(sel)
-					if args.Src.MaybeHasNulls() {
-						nulls := args.Src.Nulls()
-						for i := 0; i < n; i++ {
-							//gcassert:bce
-							selIdx := sel[i]
-							if nulls.NullAt(selIdx) {
-								m.nulls.SetNull(selIdx)
-							} else {
-								v := fromCol.Get(selIdx)
-								m.nulls.UnsetNull(selIdx)
-								toCol.Set(selIdx, v)
-							}
-						}
-						return
-					}
-					// No Nulls.
+				sel := args.Sel[args.SrcStartIdx:args.SrcEndIdx]
+				n := len(sel)
+				toCol = toCol[args.DestIdx:]
+				_ = toCol[n-1]
+				if args.Src.MaybeHasNulls() {
+					nulls := args.Src.Nulls()
 					for i := 0; i < n; i++ {
 						//gcassert:bce
 						selIdx := sel[i]
-						v := fromCol.Get(selIdx)
-						toCol.Set(selIdx, v)
-					}
-				} else {
-					sel = sel[args.SrcStartIdx:args.SrcEndIdx]
-					n := len(sel)
-					toCol = toCol[args.DestIdx:]
-					_ = toCol[n-1]
-					if args.Src.MaybeHasNulls() {
-						nulls := args.Src.Nulls()
-						for i := 0; i < n; i++ {
+						if nulls.NullAt(selIdx) {
+							m.nulls.SetNull(i + args.DestIdx)
+						} else {
+							v := fromCol.Get(selIdx)
 							//gcassert:bce
-							selIdx := sel[i]
-							if nulls.NullAt(selIdx) {
-								m.nulls.SetNull(i + args.DestIdx)
-							} else {
-								v := fromCol.Get(selIdx)
-								//gcassert:bce
-								toCol.Set(i, v)
-							}
+							toCol.Set(i, v)
 						}
-						return
 					}
-					// No Nulls.
-					for i := 0; i < n; i++ {
-						//gcassert:bce
-						selIdx := sel[i]
-						v := fromCol.Get(selIdx)
-						//gcassert:bce
-						toCol.Set(i, v)
-					}
+					return
+				}
+				// No Nulls.
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					selIdx := sel[i]
+					v := fromCol.Get(selIdx)
+					//gcassert:bce
+					toCol.Set(i, v)
 				}
 				return
 			}
 			// No Sel.
 			toCol.CopySlice(fromCol, args.DestIdx, args.SrcStartIdx, args.SrcEndIdx)
-			m.nulls.set(args.SliceArgs)
+			m.nulls.set(args)
 		}
 	case types.BytesFamily:
 		switch m.t.Width() {
@@ -397,62 +365,34 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 			fromCol := args.Src.Bytes()
 			toCol := m.Bytes()
 			if args.Sel != nil {
-				sel := args.Sel
-				if args.SelOnDest {
-					sel = sel[args.SrcStartIdx:args.SrcEndIdx]
-					n := len(sel)
-					if args.Src.MaybeHasNulls() {
-						nulls := args.Src.Nulls()
-						for i := 0; i < n; i++ {
-							//gcassert:bce
-							selIdx := sel[i]
-							if nulls.NullAt(selIdx) {
-								m.nulls.SetNull(selIdx)
-							} else {
-								v := fromCol.Get(selIdx)
-								m.nulls.UnsetNull(selIdx)
-								toCol.Set(selIdx, v)
-							}
-						}
-						return
-					}
-					// No Nulls.
+				sel := args.Sel[args.SrcStartIdx:args.SrcEndIdx]
+				n := len(sel)
+				if args.Src.MaybeHasNulls() {
+					nulls := args.Src.Nulls()
 					for i := 0; i < n; i++ {
 						//gcassert:bce
 						selIdx := sel[i]
-						v := fromCol.Get(selIdx)
-						toCol.Set(selIdx, v)
-					}
-				} else {
-					sel = sel[args.SrcStartIdx:args.SrcEndIdx]
-					n := len(sel)
-					if args.Src.MaybeHasNulls() {
-						nulls := args.Src.Nulls()
-						for i := 0; i < n; i++ {
-							//gcassert:bce
-							selIdx := sel[i]
-							if nulls.NullAt(selIdx) {
-								m.nulls.SetNull(i + args.DestIdx)
-							} else {
-								v := fromCol.Get(selIdx)
-								toCol.Set(i+args.DestIdx, v)
-							}
+						if nulls.NullAt(selIdx) {
+							m.nulls.SetNull(i + args.DestIdx)
+						} else {
+							v := fromCol.Get(selIdx)
+							toCol.Set(i+args.DestIdx, v)
 						}
-						return
 					}
-					// No Nulls.
-					for i := 0; i < n; i++ {
-						//gcassert:bce
-						selIdx := sel[i]
-						v := fromCol.Get(selIdx)
-						toCol.Set(i+args.DestIdx, v)
-					}
+					return
+				}
+				// No Nulls.
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					selIdx := sel[i]
+					v := fromCol.Get(selIdx)
+					toCol.Set(i+args.DestIdx, v)
 				}
 				return
 			}
 			// No Sel.
 			toCol.CopySlice(fromCol, args.DestIdx, args.SrcStartIdx, args.SrcEndIdx)
-			m.nulls.set(args.SliceArgs)
+			m.nulls.set(args)
 		}
 	case types.DecimalFamily:
 		switch m.t.Width() {
@@ -461,66 +401,38 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 			fromCol := args.Src.Decimal()
 			toCol := m.Decimal()
 			if args.Sel != nil {
-				sel := args.Sel
-				if args.SelOnDest {
-					sel = sel[args.SrcStartIdx:args.SrcEndIdx]
-					n := len(sel)
-					if args.Src.MaybeHasNulls() {
-						nulls := args.Src.Nulls()
-						for i := 0; i < n; i++ {
-							//gcassert:bce
-							selIdx := sel[i]
-							if nulls.NullAt(selIdx) {
-								m.nulls.SetNull(selIdx)
-							} else {
-								v := fromCol.Get(selIdx)
-								m.nulls.UnsetNull(selIdx)
-								toCol.Set(selIdx, v)
-							}
-						}
-						return
-					}
-					// No Nulls.
+				sel := args.Sel[args.SrcStartIdx:args.SrcEndIdx]
+				n := len(sel)
+				toCol = toCol[args.DestIdx:]
+				_ = toCol[n-1]
+				if args.Src.MaybeHasNulls() {
+					nulls := args.Src.Nulls()
 					for i := 0; i < n; i++ {
 						//gcassert:bce
 						selIdx := sel[i]
-						v := fromCol.Get(selIdx)
-						toCol.Set(selIdx, v)
-					}
-				} else {
-					sel = sel[args.SrcStartIdx:args.SrcEndIdx]
-					n := len(sel)
-					toCol = toCol[args.DestIdx:]
-					_ = toCol[n-1]
-					if args.Src.MaybeHasNulls() {
-						nulls := args.Src.Nulls()
-						for i := 0; i < n; i++ {
+						if nulls.NullAt(selIdx) {
+							m.nulls.SetNull(i + args.DestIdx)
+						} else {
+							v := fromCol.Get(selIdx)
 							//gcassert:bce
-							selIdx := sel[i]
-							if nulls.NullAt(selIdx) {
-								m.nulls.SetNull(i + args.DestIdx)
-							} else {
-								v := fromCol.Get(selIdx)
-								//gcassert:bce
-								toCol.Set(i, v)
-							}
+							toCol.Set(i, v)
 						}
-						return
 					}
-					// No Nulls.
-					for i := 0; i < n; i++ {
-						//gcassert:bce
-						selIdx := sel[i]
-						v := fromCol.Get(selIdx)
-						//gcassert:bce
-						toCol.Set(i, v)
-					}
+					return
+				}
+				// No Nulls.
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					selIdx := sel[i]
+					v := fromCol.Get(selIdx)
+					//gcassert:bce
+					toCol.Set(i, v)
 				}
 				return
 			}
 			// No Sel.
 			toCol.CopySlice(fromCol, args.DestIdx, args.SrcStartIdx, args.SrcEndIdx)
-			m.nulls.set(args.SliceArgs)
+			m.nulls.set(args)
 		}
 	case types.IntFamily:
 		switch m.t.Width() {
@@ -528,195 +440,111 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 			fromCol := args.Src.Int16()
 			toCol := m.Int16()
 			if args.Sel != nil {
-				sel := args.Sel
-				if args.SelOnDest {
-					sel = sel[args.SrcStartIdx:args.SrcEndIdx]
-					n := len(sel)
-					if args.Src.MaybeHasNulls() {
-						nulls := args.Src.Nulls()
-						for i := 0; i < n; i++ {
-							//gcassert:bce
-							selIdx := sel[i]
-							if nulls.NullAt(selIdx) {
-								m.nulls.SetNull(selIdx)
-							} else {
-								v := fromCol.Get(selIdx)
-								m.nulls.UnsetNull(selIdx)
-								toCol.Set(selIdx, v)
-							}
-						}
-						return
-					}
-					// No Nulls.
+				sel := args.Sel[args.SrcStartIdx:args.SrcEndIdx]
+				n := len(sel)
+				toCol = toCol[args.DestIdx:]
+				_ = toCol[n-1]
+				if args.Src.MaybeHasNulls() {
+					nulls := args.Src.Nulls()
 					for i := 0; i < n; i++ {
 						//gcassert:bce
 						selIdx := sel[i]
-						v := fromCol.Get(selIdx)
-						toCol.Set(selIdx, v)
-					}
-				} else {
-					sel = sel[args.SrcStartIdx:args.SrcEndIdx]
-					n := len(sel)
-					toCol = toCol[args.DestIdx:]
-					_ = toCol[n-1]
-					if args.Src.MaybeHasNulls() {
-						nulls := args.Src.Nulls()
-						for i := 0; i < n; i++ {
+						if nulls.NullAt(selIdx) {
+							m.nulls.SetNull(i + args.DestIdx)
+						} else {
+							v := fromCol.Get(selIdx)
 							//gcassert:bce
-							selIdx := sel[i]
-							if nulls.NullAt(selIdx) {
-								m.nulls.SetNull(i + args.DestIdx)
-							} else {
-								v := fromCol.Get(selIdx)
-								//gcassert:bce
-								toCol.Set(i, v)
-							}
+							toCol.Set(i, v)
 						}
-						return
 					}
-					// No Nulls.
-					for i := 0; i < n; i++ {
-						//gcassert:bce
-						selIdx := sel[i]
-						v := fromCol.Get(selIdx)
-						//gcassert:bce
-						toCol.Set(i, v)
-					}
+					return
+				}
+				// No Nulls.
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					selIdx := sel[i]
+					v := fromCol.Get(selIdx)
+					//gcassert:bce
+					toCol.Set(i, v)
 				}
 				return
 			}
 			// No Sel.
 			toCol.CopySlice(fromCol, args.DestIdx, args.SrcStartIdx, args.SrcEndIdx)
-			m.nulls.set(args.SliceArgs)
+			m.nulls.set(args)
 		case 32:
 			fromCol := args.Src.Int32()
 			toCol := m.Int32()
 			if args.Sel != nil {
-				sel := args.Sel
-				if args.SelOnDest {
-					sel = sel[args.SrcStartIdx:args.SrcEndIdx]
-					n := len(sel)
-					if args.Src.MaybeHasNulls() {
-						nulls := args.Src.Nulls()
-						for i := 0; i < n; i++ {
-							//gcassert:bce
-							selIdx := sel[i]
-							if nulls.NullAt(selIdx) {
-								m.nulls.SetNull(selIdx)
-							} else {
-								v := fromCol.Get(selIdx)
-								m.nulls.UnsetNull(selIdx)
-								toCol.Set(selIdx, v)
-							}
-						}
-						return
-					}
-					// No Nulls.
+				sel := args.Sel[args.SrcStartIdx:args.SrcEndIdx]
+				n := len(sel)
+				toCol = toCol[args.DestIdx:]
+				_ = toCol[n-1]
+				if args.Src.MaybeHasNulls() {
+					nulls := args.Src.Nulls()
 					for i := 0; i < n; i++ {
 						//gcassert:bce
 						selIdx := sel[i]
-						v := fromCol.Get(selIdx)
-						toCol.Set(selIdx, v)
-					}
-				} else {
-					sel = sel[args.SrcStartIdx:args.SrcEndIdx]
-					n := len(sel)
-					toCol = toCol[args.DestIdx:]
-					_ = toCol[n-1]
-					if args.Src.MaybeHasNulls() {
-						nulls := args.Src.Nulls()
-						for i := 0; i < n; i++ {
+						if nulls.NullAt(selIdx) {
+							m.nulls.SetNull(i + args.DestIdx)
+						} else {
+							v := fromCol.Get(selIdx)
 							//gcassert:bce
-							selIdx := sel[i]
-							if nulls.NullAt(selIdx) {
-								m.nulls.SetNull(i + args.DestIdx)
-							} else {
-								v := fromCol.Get(selIdx)
-								//gcassert:bce
-								toCol.Set(i, v)
-							}
+							toCol.Set(i, v)
 						}
-						return
 					}
-					// No Nulls.
-					for i := 0; i < n; i++ {
-						//gcassert:bce
-						selIdx := sel[i]
-						v := fromCol.Get(selIdx)
-						//gcassert:bce
-						toCol.Set(i, v)
-					}
+					return
+				}
+				// No Nulls.
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					selIdx := sel[i]
+					v := fromCol.Get(selIdx)
+					//gcassert:bce
+					toCol.Set(i, v)
 				}
 				return
 			}
 			// No Sel.
 			toCol.CopySlice(fromCol, args.DestIdx, args.SrcStartIdx, args.SrcEndIdx)
-			m.nulls.set(args.SliceArgs)
+			m.nulls.set(args)
 		case -1:
 		default:
 			fromCol := args.Src.Int64()
 			toCol := m.Int64()
 			if args.Sel != nil {
-				sel := args.Sel
-				if args.SelOnDest {
-					sel = sel[args.SrcStartIdx:args.SrcEndIdx]
-					n := len(sel)
-					if args.Src.MaybeHasNulls() {
-						nulls := args.Src.Nulls()
-						for i := 0; i < n; i++ {
-							//gcassert:bce
-							selIdx := sel[i]
-							if nulls.NullAt(selIdx) {
-								m.nulls.SetNull(selIdx)
-							} else {
-								v := fromCol.Get(selIdx)
-								m.nulls.UnsetNull(selIdx)
-								toCol.Set(selIdx, v)
-							}
-						}
-						return
-					}
-					// No Nulls.
+				sel := args.Sel[args.SrcStartIdx:args.SrcEndIdx]
+				n := len(sel)
+				toCol = toCol[args.DestIdx:]
+				_ = toCol[n-1]
+				if args.Src.MaybeHasNulls() {
+					nulls := args.Src.Nulls()
 					for i := 0; i < n; i++ {
 						//gcassert:bce
 						selIdx := sel[i]
-						v := fromCol.Get(selIdx)
-						toCol.Set(selIdx, v)
-					}
-				} else {
-					sel = sel[args.SrcStartIdx:args.SrcEndIdx]
-					n := len(sel)
-					toCol = toCol[args.DestIdx:]
-					_ = toCol[n-1]
-					if args.Src.MaybeHasNulls() {
-						nulls := args.Src.Nulls()
-						for i := 0; i < n; i++ {
+						if nulls.NullAt(selIdx) {
+							m.nulls.SetNull(i + args.DestIdx)
+						} else {
+							v := fromCol.Get(selIdx)
 							//gcassert:bce
-							selIdx := sel[i]
-							if nulls.NullAt(selIdx) {
-								m.nulls.SetNull(i + args.DestIdx)
-							} else {
-								v := fromCol.Get(selIdx)
-								//gcassert:bce
-								toCol.Set(i, v)
-							}
+							toCol.Set(i, v)
 						}
-						return
 					}
-					// No Nulls.
-					for i := 0; i < n; i++ {
-						//gcassert:bce
-						selIdx := sel[i]
-						v := fromCol.Get(selIdx)
-						//gcassert:bce
-						toCol.Set(i, v)
-					}
+					return
+				}
+				// No Nulls.
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					selIdx := sel[i]
+					v := fromCol.Get(selIdx)
+					//gcassert:bce
+					toCol.Set(i, v)
 				}
 				return
 			}
 			// No Sel.
 			toCol.CopySlice(fromCol, args.DestIdx, args.SrcStartIdx, args.SrcEndIdx)
-			m.nulls.set(args.SliceArgs)
+			m.nulls.set(args)
 		}
 	case types.FloatFamily:
 		switch m.t.Width() {
@@ -725,66 +553,38 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 			fromCol := args.Src.Float64()
 			toCol := m.Float64()
 			if args.Sel != nil {
-				sel := args.Sel
-				if args.SelOnDest {
-					sel = sel[args.SrcStartIdx:args.SrcEndIdx]
-					n := len(sel)
-					if args.Src.MaybeHasNulls() {
-						nulls := args.Src.Nulls()
-						for i := 0; i < n; i++ {
-							//gcassert:bce
-							selIdx := sel[i]
-							if nulls.NullAt(selIdx) {
-								m.nulls.SetNull(selIdx)
-							} else {
-								v := fromCol.Get(selIdx)
-								m.nulls.UnsetNull(selIdx)
-								toCol.Set(selIdx, v)
-							}
-						}
-						return
-					}
-					// No Nulls.
+				sel := args.Sel[args.SrcStartIdx:args.SrcEndIdx]
+				n := len(sel)
+				toCol = toCol[args.DestIdx:]
+				_ = toCol[n-1]
+				if args.Src.MaybeHasNulls() {
+					nulls := args.Src.Nulls()
 					for i := 0; i < n; i++ {
 						//gcassert:bce
 						selIdx := sel[i]
-						v := fromCol.Get(selIdx)
-						toCol.Set(selIdx, v)
-					}
-				} else {
-					sel = sel[args.SrcStartIdx:args.SrcEndIdx]
-					n := len(sel)
-					toCol = toCol[args.DestIdx:]
-					_ = toCol[n-1]
-					if args.Src.MaybeHasNulls() {
-						nulls := args.Src.Nulls()
-						for i := 0; i < n; i++ {
+						if nulls.NullAt(selIdx) {
+							m.nulls.SetNull(i + args.DestIdx)
+						} else {
+							v := fromCol.Get(selIdx)
 							//gcassert:bce
-							selIdx := sel[i]
-							if nulls.NullAt(selIdx) {
-								m.nulls.SetNull(i + args.DestIdx)
-							} else {
-								v := fromCol.Get(selIdx)
-								//gcassert:bce
-								toCol.Set(i, v)
-							}
+							toCol.Set(i, v)
 						}
-						return
 					}
-					// No Nulls.
-					for i := 0; i < n; i++ {
-						//gcassert:bce
-						selIdx := sel[i]
-						v := fromCol.Get(selIdx)
-						//gcassert:bce
-						toCol.Set(i, v)
-					}
+					return
+				}
+				// No Nulls.
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					selIdx := sel[i]
+					v := fromCol.Get(selIdx)
+					//gcassert:bce
+					toCol.Set(i, v)
 				}
 				return
 			}
 			// No Sel.
 			toCol.CopySlice(fromCol, args.DestIdx, args.SrcStartIdx, args.SrcEndIdx)
-			m.nulls.set(args.SliceArgs)
+			m.nulls.set(args)
 		}
 	case types.TimestampTZFamily:
 		switch m.t.Width() {
@@ -793,66 +593,38 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 			fromCol := args.Src.Timestamp()
 			toCol := m.Timestamp()
 			if args.Sel != nil {
-				sel := args.Sel
-				if args.SelOnDest {
-					sel = sel[args.SrcStartIdx:args.SrcEndIdx]
-					n := len(sel)
-					if args.Src.MaybeHasNulls() {
-						nulls := args.Src.Nulls()
-						for i := 0; i < n; i++ {
-							//gcassert:bce
-							selIdx := sel[i]
-							if nulls.NullAt(selIdx) {
-								m.nulls.SetNull(selIdx)
-							} else {
-								v := fromCol.Get(selIdx)
-								m.nulls.UnsetNull(selIdx)
-								toCol.Set(selIdx, v)
-							}
-						}
-						return
-					}
-					// No Nulls.
+				sel := args.Sel[args.SrcStartIdx:args.SrcEndIdx]
+				n := len(sel)
+				toCol = toCol[args.DestIdx:]
+				_ = toCol[n-1]
+				if args.Src.MaybeHasNulls() {
+					nulls := args.Src.Nulls()
 					for i := 0; i < n; i++ {
 						//gcassert:bce
 						selIdx := sel[i]
-						v := fromCol.Get(selIdx)
-						toCol.Set(selIdx, v)
-					}
-				} else {
-					sel = sel[args.SrcStartIdx:args.SrcEndIdx]
-					n := len(sel)
-					toCol = toCol[args.DestIdx:]
-					_ = toCol[n-1]
-					if args.Src.MaybeHasNulls() {
-						nulls := args.Src.Nulls()
-						for i := 0; i < n; i++ {
+						if nulls.NullAt(selIdx) {
+							m.nulls.SetNull(i + args.DestIdx)
+						} else {
+							v := fromCol.Get(selIdx)
 							//gcassert:bce
-							selIdx := sel[i]
-							if nulls.NullAt(selIdx) {
-								m.nulls.SetNull(i + args.DestIdx)
-							} else {
-								v := fromCol.Get(selIdx)
-								//gcassert:bce
-								toCol.Set(i, v)
-							}
+							toCol.Set(i, v)
 						}
-						return
 					}
-					// No Nulls.
-					for i := 0; i < n; i++ {
-						//gcassert:bce
-						selIdx := sel[i]
-						v := fromCol.Get(selIdx)
-						//gcassert:bce
-						toCol.Set(i, v)
-					}
+					return
+				}
+				// No Nulls.
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					selIdx := sel[i]
+					v := fromCol.Get(selIdx)
+					//gcassert:bce
+					toCol.Set(i, v)
 				}
 				return
 			}
 			// No Sel.
 			toCol.CopySlice(fromCol, args.DestIdx, args.SrcStartIdx, args.SrcEndIdx)
-			m.nulls.set(args.SliceArgs)
+			m.nulls.set(args)
 		}
 	case types.IntervalFamily:
 		switch m.t.Width() {
@@ -861,66 +633,38 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 			fromCol := args.Src.Interval()
 			toCol := m.Interval()
 			if args.Sel != nil {
-				sel := args.Sel
-				if args.SelOnDest {
-					sel = sel[args.SrcStartIdx:args.SrcEndIdx]
-					n := len(sel)
-					if args.Src.MaybeHasNulls() {
-						nulls := args.Src.Nulls()
-						for i := 0; i < n; i++ {
-							//gcassert:bce
-							selIdx := sel[i]
-							if nulls.NullAt(selIdx) {
-								m.nulls.SetNull(selIdx)
-							} else {
-								v := fromCol.Get(selIdx)
-								m.nulls.UnsetNull(selIdx)
-								toCol.Set(selIdx, v)
-							}
-						}
-						return
-					}
-					// No Nulls.
+				sel := args.Sel[args.SrcStartIdx:args.SrcEndIdx]
+				n := len(sel)
+				toCol = toCol[args.DestIdx:]
+				_ = toCol[n-1]
+				if args.Src.MaybeHasNulls() {
+					nulls := args.Src.Nulls()
 					for i := 0; i < n; i++ {
 						//gcassert:bce
 						selIdx := sel[i]
-						v := fromCol.Get(selIdx)
-						toCol.Set(selIdx, v)
-					}
-				} else {
-					sel = sel[args.SrcStartIdx:args.SrcEndIdx]
-					n := len(sel)
-					toCol = toCol[args.DestIdx:]
-					_ = toCol[n-1]
-					if args.Src.MaybeHasNulls() {
-						nulls := args.Src.Nulls()
-						for i := 0; i < n; i++ {
+						if nulls.NullAt(selIdx) {
+							m.nulls.SetNull(i + args.DestIdx)
+						} else {
+							v := fromCol.Get(selIdx)
 							//gcassert:bce
-							selIdx := sel[i]
-							if nulls.NullAt(selIdx) {
-								m.nulls.SetNull(i + args.DestIdx)
-							} else {
-								v := fromCol.Get(selIdx)
-								//gcassert:bce
-								toCol.Set(i, v)
-							}
+							toCol.Set(i, v)
 						}
-						return
 					}
-					// No Nulls.
-					for i := 0; i < n; i++ {
-						//gcassert:bce
-						selIdx := sel[i]
-						v := fromCol.Get(selIdx)
-						//gcassert:bce
-						toCol.Set(i, v)
-					}
+					return
+				}
+				// No Nulls.
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					selIdx := sel[i]
+					v := fromCol.Get(selIdx)
+					//gcassert:bce
+					toCol.Set(i, v)
 				}
 				return
 			}
 			// No Sel.
 			toCol.CopySlice(fromCol, args.DestIdx, args.SrcStartIdx, args.SrcEndIdx)
-			m.nulls.set(args.SliceArgs)
+			m.nulls.set(args)
 		}
 	case types.JsonFamily:
 		switch m.t.Width() {
@@ -929,62 +673,34 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 			fromCol := args.Src.JSON()
 			toCol := m.JSON()
 			if args.Sel != nil {
-				sel := args.Sel
-				if args.SelOnDest {
-					sel = sel[args.SrcStartIdx:args.SrcEndIdx]
-					n := len(sel)
-					if args.Src.MaybeHasNulls() {
-						nulls := args.Src.Nulls()
-						for i := 0; i < n; i++ {
-							//gcassert:bce
-							selIdx := sel[i]
-							if nulls.NullAt(selIdx) {
-								m.nulls.SetNull(selIdx)
-							} else {
-								v := fromCol.Get(selIdx)
-								m.nulls.UnsetNull(selIdx)
-								toCol.Set(selIdx, v)
-							}
-						}
-						return
-					}
-					// No Nulls.
+				sel := args.Sel[args.SrcStartIdx:args.SrcEndIdx]
+				n := len(sel)
+				if args.Src.MaybeHasNulls() {
+					nulls := args.Src.Nulls()
 					for i := 0; i < n; i++ {
 						//gcassert:bce
 						selIdx := sel[i]
-						v := fromCol.Get(selIdx)
-						toCol.Set(selIdx, v)
-					}
-				} else {
-					sel = sel[args.SrcStartIdx:args.SrcEndIdx]
-					n := len(sel)
-					if args.Src.MaybeHasNulls() {
-						nulls := args.Src.Nulls()
-						for i := 0; i < n; i++ {
-							//gcassert:bce
-							selIdx := sel[i]
-							if nulls.NullAt(selIdx) {
-								m.nulls.SetNull(i + args.DestIdx)
-							} else {
-								v := fromCol.Get(selIdx)
-								toCol.Set(i+args.DestIdx, v)
-							}
+						if nulls.NullAt(selIdx) {
+							m.nulls.SetNull(i + args.DestIdx)
+						} else {
+							v := fromCol.Get(selIdx)
+							toCol.Set(i+args.DestIdx, v)
 						}
-						return
 					}
-					// No Nulls.
-					for i := 0; i < n; i++ {
-						//gcassert:bce
-						selIdx := sel[i]
-						v := fromCol.Get(selIdx)
-						toCol.Set(i+args.DestIdx, v)
-					}
+					return
+				}
+				// No Nulls.
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					selIdx := sel[i]
+					v := fromCol.Get(selIdx)
+					toCol.Set(i+args.DestIdx, v)
 				}
 				return
 			}
 			// No Sel.
 			toCol.CopySlice(fromCol, args.DestIdx, args.SrcStartIdx, args.SrcEndIdx)
-			m.nulls.set(args.SliceArgs)
+			m.nulls.set(args)
 		}
 	case typeconv.DatumVecCanonicalTypeFamily:
 		switch m.t.Width() {
@@ -993,62 +709,34 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 			fromCol := args.Src.Datum()
 			toCol := m.Datum()
 			if args.Sel != nil {
-				sel := args.Sel
-				if args.SelOnDest {
-					sel = sel[args.SrcStartIdx:args.SrcEndIdx]
-					n := len(sel)
-					if args.Src.MaybeHasNulls() {
-						nulls := args.Src.Nulls()
-						for i := 0; i < n; i++ {
-							//gcassert:bce
-							selIdx := sel[i]
-							if nulls.NullAt(selIdx) {
-								m.nulls.SetNull(selIdx)
-							} else {
-								v := fromCol.Get(selIdx)
-								m.nulls.UnsetNull(selIdx)
-								toCol.Set(selIdx, v)
-							}
-						}
-						return
-					}
-					// No Nulls.
+				sel := args.Sel[args.SrcStartIdx:args.SrcEndIdx]
+				n := len(sel)
+				if args.Src.MaybeHasNulls() {
+					nulls := args.Src.Nulls()
 					for i := 0; i < n; i++ {
 						//gcassert:bce
 						selIdx := sel[i]
-						v := fromCol.Get(selIdx)
-						toCol.Set(selIdx, v)
-					}
-				} else {
-					sel = sel[args.SrcStartIdx:args.SrcEndIdx]
-					n := len(sel)
-					if args.Src.MaybeHasNulls() {
-						nulls := args.Src.Nulls()
-						for i := 0; i < n; i++ {
-							//gcassert:bce
-							selIdx := sel[i]
-							if nulls.NullAt(selIdx) {
-								m.nulls.SetNull(i + args.DestIdx)
-							} else {
-								v := fromCol.Get(selIdx)
-								toCol.Set(i+args.DestIdx, v)
-							}
+						if nulls.NullAt(selIdx) {
+							m.nulls.SetNull(i + args.DestIdx)
+						} else {
+							v := fromCol.Get(selIdx)
+							toCol.Set(i+args.DestIdx, v)
 						}
-						return
 					}
-					// No Nulls.
-					for i := 0; i < n; i++ {
-						//gcassert:bce
-						selIdx := sel[i]
-						v := fromCol.Get(selIdx)
-						toCol.Set(i+args.DestIdx, v)
-					}
+					return
+				}
+				// No Nulls.
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					selIdx := sel[i]
+					v := fromCol.Get(selIdx)
+					toCol.Set(i+args.DestIdx, v)
 				}
 				return
 			}
 			// No Sel.
 			toCol.CopySlice(fromCol, args.DestIdx, args.SrcStartIdx, args.SrcEndIdx)
-			m.nulls.set(args.SliceArgs)
+			m.nulls.set(args)
 		}
 	default:
 		panic(fmt.Sprintf("unhandled type %s", m.t))

--- a/pkg/col/coldata/vec.eg.go
+++ b/pkg/col/coldata/vec.eg.go
@@ -1055,6 +1055,374 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 	}
 }
 
+func (m *memColumn) CopyWithReorderedSource(src Vec, sel, order []int) {
+	if len(sel) == 0 {
+		return
+	}
+	if m.nulls.MaybeHasNulls() {
+		m.nulls.UnsetNulls()
+	}
+	switch m.CanonicalTypeFamily() {
+	case types.BoolFamily:
+		switch m.t.Width() {
+		case -1:
+		default:
+			fromCol := src.Bool()
+			toCol := m.Bool()
+			n := len(sel)
+			_ = sel[n-1]
+			if src.MaybeHasNulls() {
+				nulls := src.Nulls()
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					destIdx := sel[i]
+					srcIdx := order[destIdx]
+					if nulls.NullAt(srcIdx) {
+						m.nulls.SetNull(destIdx)
+					} else {
+						v := fromCol.Get(srcIdx)
+						toCol.Set(destIdx, v)
+					}
+				}
+			} else {
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					destIdx := sel[i]
+					srcIdx := order[destIdx]
+					{
+						v := fromCol.Get(srcIdx)
+						toCol.Set(destIdx, v)
+					}
+				}
+			}
+		}
+	case types.BytesFamily:
+		switch m.t.Width() {
+		case -1:
+		default:
+			fromCol := src.Bytes()
+			toCol := m.Bytes()
+			n := len(sel)
+			_ = sel[n-1]
+			if src.MaybeHasNulls() {
+				nulls := src.Nulls()
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					destIdx := sel[i]
+					srcIdx := order[destIdx]
+					if nulls.NullAt(srcIdx) {
+						m.nulls.SetNull(destIdx)
+					} else {
+						v := fromCol.Get(srcIdx)
+						toCol.Set(destIdx, v)
+					}
+				}
+			} else {
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					destIdx := sel[i]
+					srcIdx := order[destIdx]
+					{
+						v := fromCol.Get(srcIdx)
+						toCol.Set(destIdx, v)
+					}
+				}
+			}
+		}
+	case types.DecimalFamily:
+		switch m.t.Width() {
+		case -1:
+		default:
+			fromCol := src.Decimal()
+			toCol := m.Decimal()
+			n := len(sel)
+			_ = sel[n-1]
+			if src.MaybeHasNulls() {
+				nulls := src.Nulls()
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					destIdx := sel[i]
+					srcIdx := order[destIdx]
+					if nulls.NullAt(srcIdx) {
+						m.nulls.SetNull(destIdx)
+					} else {
+						v := fromCol.Get(srcIdx)
+						toCol.Set(destIdx, v)
+					}
+				}
+			} else {
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					destIdx := sel[i]
+					srcIdx := order[destIdx]
+					{
+						v := fromCol.Get(srcIdx)
+						toCol.Set(destIdx, v)
+					}
+				}
+			}
+		}
+	case types.IntFamily:
+		switch m.t.Width() {
+		case 16:
+			fromCol := src.Int16()
+			toCol := m.Int16()
+			n := len(sel)
+			_ = sel[n-1]
+			if src.MaybeHasNulls() {
+				nulls := src.Nulls()
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					destIdx := sel[i]
+					srcIdx := order[destIdx]
+					if nulls.NullAt(srcIdx) {
+						m.nulls.SetNull(destIdx)
+					} else {
+						v := fromCol.Get(srcIdx)
+						toCol.Set(destIdx, v)
+					}
+				}
+			} else {
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					destIdx := sel[i]
+					srcIdx := order[destIdx]
+					{
+						v := fromCol.Get(srcIdx)
+						toCol.Set(destIdx, v)
+					}
+				}
+			}
+		case 32:
+			fromCol := src.Int32()
+			toCol := m.Int32()
+			n := len(sel)
+			_ = sel[n-1]
+			if src.MaybeHasNulls() {
+				nulls := src.Nulls()
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					destIdx := sel[i]
+					srcIdx := order[destIdx]
+					if nulls.NullAt(srcIdx) {
+						m.nulls.SetNull(destIdx)
+					} else {
+						v := fromCol.Get(srcIdx)
+						toCol.Set(destIdx, v)
+					}
+				}
+			} else {
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					destIdx := sel[i]
+					srcIdx := order[destIdx]
+					{
+						v := fromCol.Get(srcIdx)
+						toCol.Set(destIdx, v)
+					}
+				}
+			}
+		case -1:
+		default:
+			fromCol := src.Int64()
+			toCol := m.Int64()
+			n := len(sel)
+			_ = sel[n-1]
+			if src.MaybeHasNulls() {
+				nulls := src.Nulls()
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					destIdx := sel[i]
+					srcIdx := order[destIdx]
+					if nulls.NullAt(srcIdx) {
+						m.nulls.SetNull(destIdx)
+					} else {
+						v := fromCol.Get(srcIdx)
+						toCol.Set(destIdx, v)
+					}
+				}
+			} else {
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					destIdx := sel[i]
+					srcIdx := order[destIdx]
+					{
+						v := fromCol.Get(srcIdx)
+						toCol.Set(destIdx, v)
+					}
+				}
+			}
+		}
+	case types.FloatFamily:
+		switch m.t.Width() {
+		case -1:
+		default:
+			fromCol := src.Float64()
+			toCol := m.Float64()
+			n := len(sel)
+			_ = sel[n-1]
+			if src.MaybeHasNulls() {
+				nulls := src.Nulls()
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					destIdx := sel[i]
+					srcIdx := order[destIdx]
+					if nulls.NullAt(srcIdx) {
+						m.nulls.SetNull(destIdx)
+					} else {
+						v := fromCol.Get(srcIdx)
+						toCol.Set(destIdx, v)
+					}
+				}
+			} else {
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					destIdx := sel[i]
+					srcIdx := order[destIdx]
+					{
+						v := fromCol.Get(srcIdx)
+						toCol.Set(destIdx, v)
+					}
+				}
+			}
+		}
+	case types.TimestampTZFamily:
+		switch m.t.Width() {
+		case -1:
+		default:
+			fromCol := src.Timestamp()
+			toCol := m.Timestamp()
+			n := len(sel)
+			_ = sel[n-1]
+			if src.MaybeHasNulls() {
+				nulls := src.Nulls()
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					destIdx := sel[i]
+					srcIdx := order[destIdx]
+					if nulls.NullAt(srcIdx) {
+						m.nulls.SetNull(destIdx)
+					} else {
+						v := fromCol.Get(srcIdx)
+						toCol.Set(destIdx, v)
+					}
+				}
+			} else {
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					destIdx := sel[i]
+					srcIdx := order[destIdx]
+					{
+						v := fromCol.Get(srcIdx)
+						toCol.Set(destIdx, v)
+					}
+				}
+			}
+		}
+	case types.IntervalFamily:
+		switch m.t.Width() {
+		case -1:
+		default:
+			fromCol := src.Interval()
+			toCol := m.Interval()
+			n := len(sel)
+			_ = sel[n-1]
+			if src.MaybeHasNulls() {
+				nulls := src.Nulls()
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					destIdx := sel[i]
+					srcIdx := order[destIdx]
+					if nulls.NullAt(srcIdx) {
+						m.nulls.SetNull(destIdx)
+					} else {
+						v := fromCol.Get(srcIdx)
+						toCol.Set(destIdx, v)
+					}
+				}
+			} else {
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					destIdx := sel[i]
+					srcIdx := order[destIdx]
+					{
+						v := fromCol.Get(srcIdx)
+						toCol.Set(destIdx, v)
+					}
+				}
+			}
+		}
+	case types.JsonFamily:
+		switch m.t.Width() {
+		case -1:
+		default:
+			fromCol := src.JSON()
+			toCol := m.JSON()
+			n := len(sel)
+			_ = sel[n-1]
+			if src.MaybeHasNulls() {
+				nulls := src.Nulls()
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					destIdx := sel[i]
+					srcIdx := order[destIdx]
+					if nulls.NullAt(srcIdx) {
+						m.nulls.SetNull(destIdx)
+					} else {
+						v := fromCol.Get(srcIdx)
+						toCol.Set(destIdx, v)
+					}
+				}
+			} else {
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					destIdx := sel[i]
+					srcIdx := order[destIdx]
+					{
+						v := fromCol.Get(srcIdx)
+						toCol.Set(destIdx, v)
+					}
+				}
+			}
+		}
+	case typeconv.DatumVecCanonicalTypeFamily:
+		switch m.t.Width() {
+		case -1:
+		default:
+			fromCol := src.Datum()
+			toCol := m.Datum()
+			n := len(sel)
+			_ = sel[n-1]
+			if src.MaybeHasNulls() {
+				nulls := src.Nulls()
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					destIdx := sel[i]
+					srcIdx := order[destIdx]
+					if nulls.NullAt(srcIdx) {
+						m.nulls.SetNull(destIdx)
+					} else {
+						v := fromCol.Get(srcIdx)
+						toCol.Set(destIdx, v)
+					}
+				}
+			} else {
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					destIdx := sel[i]
+					srcIdx := order[destIdx]
+					{
+						v := fromCol.Get(srcIdx)
+						toCol.Set(destIdx, v)
+					}
+				}
+			}
+		}
+	default:
+		panic(fmt.Sprintf("unhandled type %s", m.t))
+	}
+}
+
 func (m *memColumn) Window(start int, end int) Vec {
 	switch m.CanonicalTypeFamily() {
 	case types.BoolFamily:

--- a/pkg/col/coldata/vec.go
+++ b/pkg/col/coldata/vec.go
@@ -119,6 +119,12 @@ type Vec interface {
 	// Refer to the CopySliceArgs comment for specifics and TestCopy for examples.
 	Copy(CopySliceArgs)
 
+	// CopyWithReorderedSource copies a value at position order[sel[i]] in src
+	// into the receiver at position sel[i]. len(sel) elements are copied.
+	// Resulting values of elements not mentioned in sel are undefined after
+	// this function.
+	CopyWithReorderedSource(src Vec, sel, order []int)
+
 	// Window returns a "window" into the Vec. A "window" is similar to Golang's
 	// slice of the current Vec from [start, end), but the returned object is NOT
 	// allowed to be modified (the modification might result in an undefined

--- a/pkg/col/coldata/vec.go
+++ b/pkg/col/coldata/vec.go
@@ -42,17 +42,6 @@ type SliceArgs struct {
 	SrcEndIdx int
 }
 
-// CopySliceArgs represents the extension of SliceArgs that is passed in to
-// Vec.Copy.
-type CopySliceArgs struct {
-	SliceArgs
-	// SelOnDest, if true, uses the selection vector as a lens into the
-	// destination as well as the source. Normally, when SelOnDest is false, the
-	// selection vector is applied to the source vector, but the results are
-	// copied densely into the destination vector.
-	SelOnDest bool
-}
-
 // Vec is an interface that represents a column vector that's accessible by
 // Go native types.
 type Vec interface {
@@ -111,13 +100,13 @@ type Vec interface {
 	// undefined).
 	Append(SliceArgs)
 
-	// Copy uses CopySliceArgs to copy elements of a source Vec into this Vec. It is
+	// Copy uses SliceArgs to copy elements of a source Vec into this Vec. It is
 	// logically equivalent to:
 	// copy(destVec[args.DestIdx:], args.Src[args.SrcStartIdx:args.SrcEndIdx])
 	// An optional Sel slice can also be provided to apply a filter on the source
 	// Vec.
-	// Refer to the CopySliceArgs comment for specifics and TestCopy for examples.
-	Copy(CopySliceArgs)
+	// Refer to the SliceArgs comment for specifics and TestCopy for examples.
+	Copy(SliceArgs)
 
 	// CopyWithReorderedSource copies a value at position order[sel[i]] in src
 	// into the receiver at position sel[i]. len(sel) elements are copied.

--- a/pkg/col/coldata/vec_test.go
+++ b/pkg/col/coldata/vec_test.go
@@ -248,35 +248,31 @@ func TestCopy(t *testing.T) {
 
 	testCases := []struct {
 		name        string
-		args        coldata.CopySliceArgs
+		args        coldata.SliceArgs
 		expectedSum int
 	}{
 		{
 			name:        "CopyNothing",
-			args:        coldata.CopySliceArgs{},
+			args:        coldata.SliceArgs{},
 			expectedSum: 0,
 		},
 		{
 			name: "CopyBatchSizeMinus1WithOffset1",
-			args: coldata.CopySliceArgs{
-				SliceArgs: coldata.SliceArgs{
-					// Use DestIdx 1 to make sure that it is respected.
-					DestIdx:   1,
-					SrcEndIdx: coldata.BatchSize() - 1,
-				},
+			args: coldata.SliceArgs{
+				// Use DestIdx 1 to make sure that it is respected.
+				DestIdx:   1,
+				SrcEndIdx: coldata.BatchSize() - 1,
 			},
 			// expectedSum uses sum of positive integers formula.
 			expectedSum: (coldata.BatchSize() - 1) * coldata.BatchSize() / 2,
 		},
 		{
 			name: "CopyWithSel",
-			args: coldata.CopySliceArgs{
-				SliceArgs: coldata.SliceArgs{
-					Sel:         sel[1:],
-					DestIdx:     25,
-					SrcStartIdx: 1,
-					SrcEndIdx:   2,
-				},
+			args: coldata.SliceArgs{
+				Sel:         sel[1:],
+				DestIdx:     25,
+				SrcStartIdx: 1,
+				SrcEndIdx:   2,
 			},
 			// We'll have just the third element in the resulting slice.
 			expectedSum: 3,
@@ -334,13 +330,11 @@ func TestCopyNulls(t *testing.T) {
 		src.Nulls().SetNull(i)
 	}
 
-	copyArgs := coldata.CopySliceArgs{
-		SliceArgs: coldata.SliceArgs{
-			Src:         src,
-			DestIdx:     3,
-			SrcStartIdx: 3,
-			SrcEndIdx:   10,
-		},
+	copyArgs := coldata.SliceArgs{
+		Src:         src,
+		DestIdx:     3,
+		SrcStartIdx: 3,
+		SrcEndIdx:   10,
 	}
 
 	dst.Copy(copyArgs)
@@ -362,57 +356,6 @@ func TestCopyNulls(t *testing.T) {
 		require.True(t, dstInts[i] == 1, "data in dst outside copy range has been changed")
 		require.True(t, !dst.Nulls().NullAt(i), "no extra nulls were added")
 	}
-}
-
-func TestCopySelOnDestDoesNotUnsetOldNulls(t *testing.T) {
-	if coldata.BatchSize() < 5 {
-		return
-	}
-	var typ = types.Int
-
-	// Set up the destination vector. It is all nulls except for a single
-	// non-null at index 0.
-	dst := coldata.NewMemColumn(typ, coldata.BatchSize(), coldata.StandardColumnFactory)
-	dstInts := dst.Int64()
-	for i := range dstInts {
-		dstInts[i] = 1
-	}
-	dst.Nulls().SetNulls()
-	dst.Nulls().UnsetNull(0)
-
-	// Set up the source vector with two nulls.
-	src := coldata.NewMemColumn(typ, coldata.BatchSize(), coldata.StandardColumnFactory)
-	srcInts := src.Int64()
-	for i := range srcInts {
-		srcInts[i] = 2
-	}
-	src.Nulls().SetNull(0)
-	src.Nulls().SetNull(3)
-
-	// Using a small selection vector and SelOnDest, perform a copy and verify
-	// that nulls in between the selected tuples weren't unset.
-	copyArgs := coldata.CopySliceArgs{
-		SelOnDest: true,
-		SliceArgs: coldata.SliceArgs{
-			Src:         src,
-			SrcStartIdx: 1,
-			SrcEndIdx:   3,
-			Sel:         []int{0, 1, 3},
-		},
-	}
-
-	dst.Copy(copyArgs)
-
-	// 0 was not null in dest and null in source, but it wasn't selected. Not null.
-	require.False(t, dst.Nulls().NullAt(0))
-	// 1 was null in dest and not null in source: it becomes not null.
-	require.False(t, dst.Nulls().NullAt(1))
-	// 2 wasn't included in the selection vector: it stays null.
-	require.True(t, dst.Nulls().NullAt(2))
-	// 3 was null in dest and null in source: it stays null.
-	require.True(t, dst.Nulls().NullAt(3))
-	// 4 wasn't included: it stays null.
-	require.True(t, dst.Nulls().NullAt(4))
 }
 
 func TestCopyWithReorderedSource(t *testing.T) {
@@ -506,18 +449,16 @@ func BenchmarkCopy(b *testing.B) {
 
 	benchCases := []struct {
 		name string
-		args coldata.CopySliceArgs
+		args coldata.SliceArgs
 	}{
 		{
 			name: "CopySimple",
-			args: coldata.CopySliceArgs{},
+			args: coldata.SliceArgs{},
 		},
 		{
 			name: "CopyWithSel",
-			args: coldata.CopySliceArgs{
-				SliceArgs: coldata.SliceArgs{
-					Sel: sel,
-				},
+			args: coldata.SliceArgs{
+				Sel: sel,
 			},
 		},
 	}

--- a/pkg/col/coldata/vec_tmpl.go
+++ b/pkg/col/coldata/vec_tmpl.go
@@ -92,98 +92,15 @@ func (m *memColumn) Append(args SliceArgs) {
 	}
 }
 
-// {{/*
-func _COPY_WITH_SEL(
-	m *memColumn, args CopySliceArgs, fromCol, toCol _GOTYPESLICE, sel interface{}, _SEL_ON_DEST bool,
-) { // */}}
-	// {{define "copyWithSel" -}}
-	sel = sel[args.SrcStartIdx:args.SrcEndIdx]
-	n := len(sel)
-	// {{if and (.Sliceable) (not .SelOnDest)}}
-	toCol = toCol[args.DestIdx:]
-	_ = toCol[n-1]
-	// {{end}}
-	if args.Src.MaybeHasNulls() {
-		nulls := args.Src.Nulls()
-		for i := 0; i < n; i++ {
-			//gcassert:bce
-			selIdx := sel[i]
-			if nulls.NullAt(selIdx) {
-				// {{if .SelOnDest}}
-				m.nulls.SetNull(selIdx)
-				// {{else}}
-				m.nulls.SetNull(i + args.DestIdx)
-				// {{end}}
-			} else {
-				v := fromCol.Get(selIdx)
-				// {{if .SelOnDest}}
-				m.nulls.UnsetNull(selIdx)
-				toCol.Set(selIdx, v)
-				// {{else}}
-				// {{if .Sliceable}}
-				// {{/*
-				//     For the sliceable types, we sliced toCol to start at
-				//     args.DestIdx, so we use index i directly.
-				// */}}
-				//gcassert:bce
-				toCol.Set(i, v)
-				// {{else}}
-				// {{/*
-				//     For the non-sliceable types, toCol vector is the original
-				//     one (i.e. without an adjustment), so we need to add
-				//     args.DestIdx to set the element at the correct index.
-				// */}}
-				toCol.Set(i+args.DestIdx, v)
-				// {{end}}
-				// {{end}}
-			}
-		}
-		return
-	}
-	// No Nulls.
-	for i := 0; i < n; i++ {
-		//gcassert:bce
-		selIdx := sel[i]
-		v := fromCol.Get(selIdx)
-		// {{if .SelOnDest}}
-		toCol.Set(selIdx, v)
-		// {{else}}
-		// {{if .Sliceable}}
-		// {{/*
-		//     For the sliceable types, we sliced toCol to start at
-		//     args.DestIdx, so we use index i directly.
-		// */}}
-		//gcassert:bce
-		toCol.Set(i, v)
-		// {{else}}
-		// {{/*
-		//     For the non-sliceable types, toCol vector is the original one
-		//     (i.e. without an adjustment), so we need to add args.DestIdx to
-		//     set the element at the correct index.
-		// */}}
-		toCol.Set(i+args.DestIdx, v)
-		// {{end}}
-		// {{end}}
-	}
-	// {{end}}
-	// {{/*
-}
-
-// */}}
-
-func (m *memColumn) Copy(args CopySliceArgs) {
+func (m *memColumn) Copy(args SliceArgs) {
 	if args.SrcStartIdx == args.SrcEndIdx {
 		// Nothing to copy, so return early.
 		return
 	}
-	if !args.SelOnDest {
+	if m.Nulls().MaybeHasNulls() {
 		// We're about to overwrite this entire range, so unset all the nulls.
 		m.Nulls().UnsetNullRange(args.DestIdx, args.DestIdx+(args.SrcEndIdx-args.SrcStartIdx))
 	}
-	// } else {
-	// SelOnDest indicates that we're applying the input selection vector as a lens
-	// into the output vector as well. We'll set the non-nulls by hand below.
-	// }
 
 	switch m.CanonicalTypeFamily() {
 	// {{range .}}
@@ -194,17 +111,66 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 			fromCol := args.Src.TemplateType()
 			toCol := m.TemplateType()
 			if args.Sel != nil {
-				sel := args.Sel
-				if args.SelOnDest {
-					_COPY_WITH_SEL(m, args, sel, toCol, fromCol, true)
-				} else {
-					_COPY_WITH_SEL(m, args, sel, toCol, fromCol, false)
+				sel := args.Sel[args.SrcStartIdx:args.SrcEndIdx]
+				n := len(sel)
+				// {{if .Sliceable}}
+				toCol = toCol[args.DestIdx:]
+				_ = toCol[n-1]
+				// {{end}}
+				if args.Src.MaybeHasNulls() {
+					nulls := args.Src.Nulls()
+					for i := 0; i < n; i++ {
+						//gcassert:bce
+						selIdx := sel[i]
+						if nulls.NullAt(selIdx) {
+							m.nulls.SetNull(i + args.DestIdx)
+						} else {
+							v := fromCol.Get(selIdx)
+							// {{if .Sliceable}}
+							// {{/*
+							//     For the sliceable types, we sliced toCol to start at
+							//     args.DestIdx, so we use index i directly.
+							// */}}
+							//gcassert:bce
+							toCol.Set(i, v)
+							// {{else}}
+							// {{/*
+							//     For the non-sliceable types, toCol vector is the original
+							//     one (i.e. without an adjustment), so we need to add
+							//     args.DestIdx to set the element at the correct index.
+							// */}}
+							toCol.Set(i+args.DestIdx, v)
+							// {{end}}
+						}
+					}
+					return
+				}
+				// No Nulls.
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					selIdx := sel[i]
+					v := fromCol.Get(selIdx)
+					// {{if .Sliceable}}
+					// {{/*
+					//     For the sliceable types, we sliced toCol to start at
+					//     args.DestIdx, so we use index i directly.
+					// */}}
+					//gcassert:bce
+					toCol.Set(i, v)
+					// {{else}}
+					// {{/*
+					//     For the non-sliceable types, toCol vector is the original one
+					//     (i.e. without an adjustment), so we need to add args.DestIdx to
+					//     set the element at the correct index.
+					// */}}
+					toCol.Set(i+args.DestIdx, v)
+					// {{end}}
 				}
 				return
 			}
 			// No Sel.
 			toCol.CopySlice(fromCol, args.DestIdx, args.SrcStartIdx, args.SrcEndIdx)
-			m.nulls.set(args.SliceArgs)
+			m.nulls.set(args)
 			// {{end}}
 		}
 		// {{end}}

--- a/pkg/col/coldatatestutils/utils.go
+++ b/pkg/col/coldatatestutils/utils.go
@@ -25,11 +25,9 @@ func CopyBatch(
 	b := coldata.NewMemBatchWithCapacity(typs, original.Length(), factory)
 	b.SetLength(original.Length())
 	for colIdx, col := range original.ColVecs() {
-		b.ColVec(colIdx).Copy(coldata.CopySliceArgs{
-			SliceArgs: coldata.SliceArgs{
-				Src:       col,
-				SrcEndIdx: original.Length(),
-			},
+		b.ColVec(colIdx).Copy(coldata.SliceArgs{
+			Src:       col,
+			SrcEndIdx: original.Length(),
 		})
 	}
 	return b

--- a/pkg/sql/colexec/and_or_projection_tmpl.go
+++ b/pkg/sql/colexec/and_or_projection_tmpl.go
@@ -161,6 +161,15 @@ func (o *_OP_LOWERProjOp) Init(ctx context.Context) {
 // side projection only on the remaining tuples (i.e. those that were not
 // "subtracted"). Next, it restores the original selection vector and
 // populates the result of the logical operation.
+// {{/*
+//     TODO(yuzefovich): this operator is a bit sketchy because it works only
+//     under the assumption that the projection arms return exactly the same
+//     batch as they are fed (i.e. the projection operators aren't allowed to
+//     populate their own output batches from scratch) and that the deselection
+//     step isn't performed. Refactor this to make more resilient, and this will
+//     allow for simplifying the CASE operator by planning a deselector on top
+//     of its input.
+// */}}
 func (o *_OP_LOWERProjOp) Next() coldata.Batch {
 	batch := o.input.Next()
 	origLen := batch.Length()

--- a/pkg/sql/colexec/case.go
+++ b/pkg/sql/colexec/case.go
@@ -36,6 +36,62 @@ type caseOp struct {
 	outputIdx int
 	typ       *types.T
 
+	// scratch is used to populate the output vector out of order, before
+	// copying it into the batch. We need this because each WHEN arm can match
+	// an arbitrary set of tuples and some vectors don't support SET operation
+	// in arbitrary order.
+	//
+	// Consider the following example:
+	//   input column c = {0, 1, 2, 1, 0, 2}
+	// and CASE projection as
+	//   CASE WHEN c = 1 THEN -1 WHEN c = 2 THEN -2 ELSE 42 END.
+	// Then after running the first WHEN arm projection, we have
+	//   scratch output = {-1, -1}
+	//   scratch order = {x, 0, x, 1, x, x} (note that 'x' means 'not matched yet').
+	// After running the second WHEN arm projection:
+	//   scratch output = {-1, -1, -2, -2}
+	//   scratch order = {x, 0, 2, 1, x, 3}.
+	// After running the ELSE arm projection:
+	//   scratch output = {-1, -1, -2, -2, 42, 42}
+	//   scratch order = {4, 0, 2, 1, 5, 3}.
+	//
+	// It is guaranteed that after running all WHEN and ELSE arms, order will
+	// contain all tuple indices, and once that is the case, we simply need to
+	// copy the data out of the scratch into the output batch according to sel.
+	//
+	// Note that order doesn't satisfy the assumption of our normal selection
+	// vectors which are always increasing sequences, but that is ok since order
+	// is only used internally and Vec.Copy can handle it correctly.
+	//
+	// Things are a bit more complicated in case the batch comes with a
+	// selection vector itself. Consider the following example (where 'x'
+	// denotes some garbage value):
+	//   input column c = {x, 0, 1, x, 2, 1, 0, x, 2, x}
+	//   origSel = {1, 2, 4, 5, 6, 8}.
+	// Then after running the first WHEN arm projection, we have
+	//   scratch output = {-1, -1}
+	//   scratch order = {x, x, 0, x, x, 1, x, x, x}.
+	// After running the second WHEN arm projection:
+	//   scratch output = {-1, -1, -2, -2}
+	//   scratch order = {x, x, 0, x, 2, 1, x, x, 3}.
+	// After running the ELSE arm projection:
+	//   scratch output = {-1, -1, -2, -2, 42, 42}
+	//   scratch order = {x, 4, 0, x, 2, 1, 5, x, 3}.
+	// Note that order has the length sufficient to support all indices
+	// mentioned in the original selection vector and not selected elements will
+	// have garbage left in the corresponding positions in order.
+	//
+	// At this point we have to copy the output with "reordering" according to
+	// the selection vector so that
+	//   result[origSel[i]] = output[order[origSel[i]]]
+	// for all i in range [0, len(batch)).
+	scratch struct {
+		// output contains the result of CASE projections where results that
+		// came from the same WHEN arm are grouped together.
+		output coldata.Vec
+		order  []int
+	}
+
 	// origSel is a buffer used to keep track of the original selection vector of
 	// the input batch. We need to do this because we're going to destructively
 	// modify the selection vector in order to do the work of the case statement.
@@ -77,7 +133,7 @@ func (c *caseOp) Child(nth int, verbose bool) execinfra.OpNode {
 // elseOp is the ELSE condition.
 // whenCol is the index into the input batch to read from.
 // thenCol is the index into the output batch to write to.
-// typ is the type of the CASE expression.
+// typ is the output type of the CASE expression.
 func NewCaseOp(
 	allocator *colmem.Allocator,
 	buffer colexecop.Operator,
@@ -87,8 +143,9 @@ func NewCaseOp(
 	outputIdx int,
 	typ *types.T,
 ) colexecop.Operator {
-	// We internally use two selection vectors, origSel and prevSel.
-	allocator.AdjustMemoryUsage(2 * colmem.SizeOfBatchSizeSelVector)
+	// We internally use three selection vectors, scratch.order, origSel, and
+	// prevSel.
+	allocator.AdjustMemoryUsage(3 * colmem.SizeOfBatchSizeSelVector)
 	return &caseOp{
 		allocator: allocator,
 		buffer:    buffer.(*bufferOp),
@@ -110,6 +167,30 @@ func (c *caseOp) Init(ctx context.Context) {
 	c.elseOp.Init(c.Ctx)
 }
 
+// copyIntoScratch copies all values specified by the selection vector of the
+// batch from column at position inputColIdx into the scratch output vector. The
+// copied values are put starting at numAlreadyMatched index in the output
+// vector. It is assumed that the selection vector of batch is non-nil.
+func (c *caseOp) copyIntoScratch(batch coldata.Batch, inputColIdx int, numAlreadyMatched int) {
+	n := batch.Length()
+	inputCol := batch.ColVec(inputColIdx)
+	// Copy the results into the scratch output vector, using the selection
+	// vector to copy only the elements that we actually wrote according to the
+	// current projection arm.
+	c.scratch.output.Copy(
+		coldata.CopySliceArgs{
+			SliceArgs: coldata.SliceArgs{
+				Src:       inputCol,
+				Sel:       batch.Selection()[:n],
+				DestIdx:   numAlreadyMatched,
+				SrcEndIdx: n,
+			},
+		})
+	for j, tupleIdx := range batch.Selection()[:n] {
+		c.scratch.order[tupleIdx] = numAlreadyMatched + j
+	}
+}
+
 func (c *caseOp) Next() coldata.Batch {
 	c.buffer.advance()
 	origLen := c.buffer.batch.Length()
@@ -123,7 +204,6 @@ func (c *caseOp) Next() coldata.Batch {
 		copy(c.origSel, sel)
 	}
 
-	prevLen := origLen
 	prevHasSel := false
 	if sel := c.buffer.batch.Selection(); sel != nil {
 		prevHasSel = true
@@ -131,16 +211,21 @@ func (c *caseOp) Next() coldata.Batch {
 		copy(c.prevSel, sel)
 	}
 	outputCol := c.buffer.batch.ColVec(c.outputIdx)
-	if outputCol.MaybeHasNulls() {
-		// We need to make sure that there are no left over null values in the
-		// output vector.
-		// Note: technically, this is not necessary because we're using
-		// Vec.Copy method when populating the output vector which itself
-		// handles the null values, but we want to be on the safe side, so we
-		// have this (at the moment) redundant resetting behavior.
-		outputCol.Nulls().UnsetNulls()
+
+	if c.scratch.output == nil || c.scratch.output.Capacity() < origLen {
+		c.scratch.output = c.allocator.NewMemColumn(c.typ, origLen)
+	} else if c.scratch.output.IsBytesLike() {
+		coldata.Reset(c.scratch.output)
 	}
-	c.allocator.PerformOperation([]coldata.Vec{outputCol}, func() {
+	orderCapacity := origLen
+	if origHasSel {
+		orderCapacity = c.origSel[origLen-1] + 1
+	}
+	c.scratch.order = colexecutils.EnsureSelectionVectorLength(c.scratch.order, orderCapacity)
+
+	// Run all WHEN arms.
+	numAlreadyMatched := 0
+	c.allocator.PerformOperation([]coldata.Vec{c.scratch.output}, func() {
 		for i := range c.caseOps {
 			// Run the next case operator chain. It will project its THEN expression
 			// for all tuples that matched its WHEN expression and that were not
@@ -168,23 +253,17 @@ func (c *caseOp) Next() coldata.Batch {
 			toSubtract = toSubtract[:batch.Length()]
 			// toSubtract is now a selection vector containing all matched tuples of the
 			// current case arm.
-			var subtractIdx int
-			var curIdx int
 			if batch.Length() > 0 {
-				inputCol := batch.ColVec(c.thenIdxs[i])
-				// Copy the results into the output vector, using the toSubtract selection
-				// vector to copy only the elements that we actually wrote according to the
-				// current case arm.
-				outputCol.Copy(
-					coldata.CopySliceArgs{
-						SliceArgs: coldata.SliceArgs{
-							Src:         inputCol,
-							Sel:         toSubtract,
-							SrcStartIdx: 0,
-							SrcEndIdx:   len(toSubtract),
-						},
-						SelOnDest: true,
-					})
+				c.copyIntoScratch(batch, c.thenIdxs[i], numAlreadyMatched)
+
+				numAlreadyMatched += len(toSubtract)
+				if numAlreadyMatched == origLen {
+					// All tuples have already matched, so we can short-circuit.
+					return
+				}
+
+				var subtractIdx int
+				var curIdx int
 				if prevHasSel {
 					// We have a previous selection vector, which represents the tuples
 					// that haven't yet been matched. Remove the ones that just matched
@@ -220,7 +299,6 @@ func (c *caseOp) Next() coldata.Batch {
 				}
 				// Set the buffered batch into the desired state.
 				c.buffer.batch.SetLength(curIdx)
-				prevLen = curIdx
 				c.buffer.batch.SetSelection(true)
 				prevHasSel = true
 				copy(c.buffer.batch.Selection()[:curIdx], c.prevSel)
@@ -228,6 +306,7 @@ func (c *caseOp) Next() coldata.Batch {
 			} else {
 				// There were no matches with the current WHEN arm, so we simply need
 				// to restore the buffered batch into the previous state.
+				prevLen := origLen - numAlreadyMatched
 				c.buffer.batch.SetLength(prevLen)
 				c.buffer.batch.SetSelection(prevHasSel)
 				if prevHasSel {
@@ -239,24 +318,56 @@ func (c *caseOp) Next() coldata.Batch {
 			// matched so far. Reset the buffer and run the next case arm.
 			c.buffer.rewind()
 		}
-		// Finally, run the else operator, which will project into all tuples that
-		// are remaining in the selection vector (didn't match any case arms). Once
-		// that's done, restore the original selection vector and return the batch.
+	})
+
+	// Run the ELSE arm if necessary.
+	outputReady := false
+	if numAlreadyMatched == 0 && !origHasSel {
+		// If no tuples matched with any of the WHEN arms and the original batch
+		// didn't have a selection vector, we can copy the result of the ELSE
+		// projection straight into the output batch because the result will be
+		// in the correct order.
 		batch := c.elseOp.Next()
-		if batch.Length() > 0 {
-			inputCol := batch.ColVec(c.thenIdxs[len(c.thenIdxs)-1])
+		c.allocator.PerformOperation([]coldata.Vec{outputCol}, func() {
 			outputCol.Copy(
 				coldata.CopySliceArgs{
 					SliceArgs: coldata.SliceArgs{
-						Src:         inputCol,
-						Sel:         batch.Selection(),
-						SrcStartIdx: 0,
-						SrcEndIdx:   batch.Length(),
+						Src:       batch.ColVec(c.thenIdxs[len(c.thenIdxs)-1]),
+						SrcEndIdx: origLen,
 					},
-					SelOnDest: true,
 				})
-		}
-	})
+		})
+		outputReady = true
+	} else if numAlreadyMatched < origLen {
+		batch := c.elseOp.Next()
+		c.allocator.PerformOperation([]coldata.Vec{c.scratch.output}, func() {
+			c.copyIntoScratch(batch, c.thenIdxs[len(c.thenIdxs)-1], numAlreadyMatched)
+		})
+	}
+
+	// Copy the output vector from the scratch space into the batch if
+	// necessary.
+	if !outputReady {
+		c.allocator.PerformOperation([]coldata.Vec{outputCol}, func() {
+			if origHasSel {
+				// If the original batch had a selection vector, we cannot just
+				// copy the output from the scratch because we want to preserve
+				// that selection vector. See comment above c.scratch for an
+				// example.
+				outputCol.CopyWithReorderedSource(c.scratch.output, c.origSel, c.scratch.order)
+			} else {
+				outputCol.Copy(
+					coldata.CopySliceArgs{
+						SliceArgs: coldata.SliceArgs{
+							Src:       c.scratch.output,
+							Sel:       c.scratch.order,
+							SrcEndIdx: origLen,
+						},
+					})
+			}
+		})
+	}
+
 	// Restore the original state of the buffered batch.
 	c.buffer.batch.SetLength(origLen)
 	c.buffer.batch.SetSelection(origHasSel)

--- a/pkg/sql/colexec/case.go
+++ b/pkg/sql/colexec/case.go
@@ -178,13 +178,11 @@ func (c *caseOp) copyIntoScratch(batch coldata.Batch, inputColIdx int, numAlread
 	// vector to copy only the elements that we actually wrote according to the
 	// current projection arm.
 	c.scratch.output.Copy(
-		coldata.CopySliceArgs{
-			SliceArgs: coldata.SliceArgs{
-				Src:       inputCol,
-				Sel:       batch.Selection()[:n],
-				DestIdx:   numAlreadyMatched,
-				SrcEndIdx: n,
-			},
+		coldata.SliceArgs{
+			Src:       inputCol,
+			Sel:       batch.Selection()[:n],
+			DestIdx:   numAlreadyMatched,
+			SrcEndIdx: n,
 		})
 	for j, tupleIdx := range batch.Selection()[:n] {
 		c.scratch.order[tupleIdx] = numAlreadyMatched + j
@@ -330,11 +328,9 @@ func (c *caseOp) Next() coldata.Batch {
 		batch := c.elseOp.Next()
 		c.allocator.PerformOperation([]coldata.Vec{outputCol}, func() {
 			outputCol.Copy(
-				coldata.CopySliceArgs{
-					SliceArgs: coldata.SliceArgs{
-						Src:       batch.ColVec(c.thenIdxs[len(c.thenIdxs)-1]),
-						SrcEndIdx: origLen,
-					},
+				coldata.SliceArgs{
+					Src:       batch.ColVec(c.thenIdxs[len(c.thenIdxs)-1]),
+					SrcEndIdx: origLen,
 				})
 		})
 		outputReady = true
@@ -357,12 +353,10 @@ func (c *caseOp) Next() coldata.Batch {
 				outputCol.CopyWithReorderedSource(c.scratch.output, c.origSel, c.scratch.order)
 			} else {
 				outputCol.Copy(
-					coldata.CopySliceArgs{
-						SliceArgs: coldata.SliceArgs{
-							Src:       c.scratch.output,
-							Sel:       c.scratch.order,
-							SrcEndIdx: origLen,
-						},
+					coldata.SliceArgs{
+						Src:       c.scratch.output,
+						Sel:       c.scratch.order,
+						SrcEndIdx: origLen,
 					})
 			}
 		})

--- a/pkg/sql/colexec/case_test.go
+++ b/pkg/sql/colexec/case_test.go
@@ -12,17 +12,25 @@ package colexec
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecargs"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexectestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/randgen"
+	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCaseOp(t *testing.T) {
@@ -90,4 +98,115 @@ func TestCaseOp(t *testing.T) {
 			return colexecbase.NewSimpleProjectOp(caseOp, len(tc.inputTypes)+1, []uint32{uint32(len(tc.inputTypes))}), nil
 		})
 	}
+}
+
+func TestCaseOpRandomized(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+	defer evalCtx.Stop(ctx)
+	flowCtx := &execinfra.FlowCtx{
+		EvalCtx: &evalCtx,
+		Cfg: &execinfra.ServerConfig{
+			Settings: st,
+		},
+	}
+
+	var da rowenc.DatumAlloc
+	rng, _ := randutil.NewPseudoRand()
+
+	numWhenArms := 1 + rng.Intn(5)
+	hasElseArm := rng.Float64() < 0.5
+
+	// Pick a random type to be used as the output type for the CASE expression.
+	// We're giving more weight to the types natively supported by the
+	// vectorized engine because all datum-backed types have the same backing
+	// datumVec which would occur disproportionally often without adjusting the
+	// weights.
+	caseOutputType := randgen.RandType(rng)
+	for retry := 0; retry < 3; retry++ {
+		if typeconv.TypeFamilyToCanonicalTypeFamily(caseOutputType.Family()) != typeconv.DatumVecCanonicalTypeFamily {
+			break
+		}
+		caseOutputType = randgen.RandType(rng)
+	}
+
+	// Construct such a CASE expression that the first column from the input is
+	// used as the "partitioning" column (used by WHEN arms for matching), the
+	// following numWhenArms columns are the projections for the corresponding
+	// WHEN "partitions", and then optionally we have an ELSE projection.
+	caseExpr := "CASE @1"
+	for i := 0; i < numWhenArms; i++ {
+		caseExpr += fmt.Sprintf(" WHEN %d THEN @%d", i, i+2)
+	}
+	if hasElseArm {
+		caseExpr += fmt.Sprintf(" ELSE @%d", numWhenArms+2)
+	}
+	caseExpr += " END"
+
+	numInputCols := 1 + numWhenArms
+	if hasElseArm {
+		numInputCols++
+	}
+	numInputRows := 1 + rng.Intn(coldata.BatchSize()) + coldata.BatchSize()*rng.Intn(5)
+	inputRows := make(rowenc.EncDatumRows, numInputRows)
+	// We always have an extra partition, regardless of whether we use an ELSE
+	// projection or not (if we don't, the ELSE arm will project all NULLs).
+	numPartitions := numWhenArms + 1
+	// We will populate the expected output at the same time as we're generating
+	// the input data set. Note that all input columns will be projected out, so
+	// we memorize only the output column of the CASE expression.
+	expectedOutput := make([]rowenc.EncDatum, numInputRows)
+	for i := range inputRows {
+		inputRow := make(rowenc.EncDatumRow, numInputCols)
+		partitionIdx := rng.Intn(numPartitions)
+		inputRow[0].Datum = tree.NewDInt(tree.DInt(partitionIdx))
+		for j := 1; j < numInputCols; j++ {
+			inputRow[j] = rowenc.DatumToEncDatum(caseOutputType, randgen.RandDatum(rng, caseOutputType, true /* nullOk */))
+		}
+		inputRows[i] = inputRow
+		if !hasElseArm && partitionIdx == numWhenArms {
+			expectedOutput[i] = rowenc.DatumToEncDatum(caseOutputType, tree.DNull)
+		} else {
+			expectedOutput[i] = inputRow[partitionIdx+1]
+		}
+	}
+
+	inputTypes := make([]*types.T, numInputCols)
+	inputTypes[0] = types.Int
+	for i := 1; i < numInputCols; i++ {
+		inputTypes[i] = caseOutputType
+	}
+	input := execinfra.NewRepeatableRowSource(inputTypes, inputRows)
+	columnarizer := NewBufferingColumnarizer(testAllocator, flowCtx, 1 /* processorID */, input)
+	caseOp, err := colexectestutils.CreateTestProjectingOperator(
+		ctx, flowCtx, columnarizer, inputTypes, caseExpr,
+		false /* canFallbackToRowexec */, testMemAcc,
+	)
+	require.NoError(t, err)
+	// We will project out all input columns while keeping only the output
+	// column of the case operator, for simplicity.
+	op := colexecbase.NewSimpleProjectOp(caseOp, numInputCols+1, []uint32{uint32(numInputCols)})
+	materializer := NewMaterializer(
+		flowCtx,
+		1, /* processorID */
+		colexecargs.OpWithMetaInfo{Root: op},
+		[]*types.T{caseOutputType},
+	)
+
+	materializer.Start(ctx)
+	for _, expectedDatum := range expectedOutput {
+		actualRow, meta := materializer.Next()
+		require.Nil(t, meta)
+		require.Equal(t, 1, len(actualRow))
+		cmp, err := expectedDatum.Compare(caseOutputType, &da, &evalCtx, &actualRow[0])
+		require.NoError(t, err)
+		require.Equal(t, 0, cmp)
+	}
+	// The materializer must have been fully exhausted now.
+	row, meta := materializer.Next()
+	require.Nil(t, row)
+	require.Nil(t, meta)
 }

--- a/pkg/sql/colexec/case_test.go
+++ b/pkg/sql/colexec/case_test.go
@@ -48,8 +48,8 @@ func TestCaseOp(t *testing.T) {
 		{
 			// Basic test.
 			tuples:     colexectestutils.Tuples{{1}, {2}, {nil}, {3}},
-			renderExpr: "CASE WHEN @1 = 2 THEN 1 ELSE 0 END",
-			expected:   colexectestutils.Tuples{{0}, {1}, {0}, {0}},
+			renderExpr: "CASE WHEN @1 = 2 THEN 1 ELSE 42 END",
+			expected:   colexectestutils.Tuples{{42}, {1}, {42}, {42}},
 			inputTypes: []*types.T{types.Int},
 		},
 		{
@@ -65,6 +65,16 @@ func TestCaseOp(t *testing.T) {
 			renderExpr: "CASE WHEN @1 = 2 THEN 0::FLOAT WHEN @1 / @2 = 1 THEN 1::FLOAT END",
 			expected:   colexectestutils.Tuples{{nil}, {0.0}, {nil}, {1.0}},
 			inputTypes: []*types.T{types.Int, types.Int},
+		},
+		{
+			// Test when only the ELSE arm matches.
+			//
+			// Note that all input values are NULLs so that the "all nulls
+			// injection" subtest is skipped.
+			tuples:     colexectestutils.Tuples{{nil}, {nil}, {nil}, {nil}},
+			renderExpr: "CASE WHEN @1 = 42 THEN 1 WHEN @1 IS NOT NULL THEN 2 ELSE 42 END",
+			expected:   colexectestutils.Tuples{{42}, {42}, {42}, {42}},
+			inputTypes: []*types.T{types.Int},
 		},
 	} {
 		colexectestutils.RunTests(t, testAllocator, []colexectestutils.Tuples{tc.tuples}, tc.expected, colexectestutils.OrderedVerifier, func(inputs []colexecop.Operator) (colexecop.Operator, error) {

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -2045,16 +2045,6 @@ func planProjectionOperators(
 	case *tree.CaseExpr:
 		allocator := colmem.NewAllocator(ctx, acc, factory)
 		caseOutputType := t.ResolvedType()
-		family := typeconv.TypeFamilyToCanonicalTypeFamily(caseOutputType.Family())
-		if family == types.BytesFamily || family == types.JsonFamily {
-			// Currently, there is a contradiction between the way CASE operator
-			// works (which populates its output in arbitrary order) and the
-			// flat bytes implementation of Bytes type (which prohibits sets in
-			// arbitrary order), so we reject such scenario to fall back to
-			// row-by-row engine.
-			return nil, resultIdx, typs, errors.Newf(
-				"unsupported type %s in CASE operator", caseOutputType)
-		}
 		caseOutputIdx := len(columnTypes)
 		// We don't know the schema yet and will update it below, right before
 		// instantiating caseOp. The same goes for subsetEndIdx.

--- a/pkg/sql/colexec/colexecjoin/crossjoiner.eg.go
+++ b/pkg/sql/colexec/colexecjoin/crossjoiner.eg.go
@@ -1467,13 +1467,11 @@ func (b *crossJoinerBase) buildFromRightInput(ctx context.Context, destStartIdx 
 									}
 								} else {
 									out.Copy(
-										coldata.CopySliceArgs{
-											SliceArgs: coldata.SliceArgs{
-												Src:         src,
-												DestIdx:     outStartIdx,
-												SrcStartIdx: b.builderState.right.curSrcStartIdx,
-												SrcEndIdx:   b.builderState.right.curSrcStartIdx + toAppend,
-											},
+										coldata.SliceArgs{
+											Src:         src,
+											DestIdx:     outStartIdx,
+											SrcStartIdx: b.builderState.right.curSrcStartIdx,
+											SrcEndIdx:   b.builderState.right.curSrcStartIdx + toAppend,
 										},
 									)
 								}
@@ -1496,13 +1494,11 @@ func (b *crossJoinerBase) buildFromRightInput(ctx context.Context, destStartIdx 
 									}
 								} else {
 									out.Copy(
-										coldata.CopySliceArgs{
-											SliceArgs: coldata.SliceArgs{
-												Src:         src,
-												DestIdx:     outStartIdx,
-												SrcStartIdx: b.builderState.right.curSrcStartIdx,
-												SrcEndIdx:   b.builderState.right.curSrcStartIdx + toAppend,
-											},
+										coldata.SliceArgs{
+											Src:         src,
+											DestIdx:     outStartIdx,
+											SrcStartIdx: b.builderState.right.curSrcStartIdx,
+											SrcEndIdx:   b.builderState.right.curSrcStartIdx + toAppend,
 										},
 									)
 								}
@@ -1525,13 +1521,11 @@ func (b *crossJoinerBase) buildFromRightInput(ctx context.Context, destStartIdx 
 									}
 								} else {
 									out.Copy(
-										coldata.CopySliceArgs{
-											SliceArgs: coldata.SliceArgs{
-												Src:         src,
-												DestIdx:     outStartIdx,
-												SrcStartIdx: b.builderState.right.curSrcStartIdx,
-												SrcEndIdx:   b.builderState.right.curSrcStartIdx + toAppend,
-											},
+										coldata.SliceArgs{
+											Src:         src,
+											DestIdx:     outStartIdx,
+											SrcStartIdx: b.builderState.right.curSrcStartIdx,
+											SrcEndIdx:   b.builderState.right.curSrcStartIdx + toAppend,
 										},
 									)
 								}
@@ -1553,13 +1547,11 @@ func (b *crossJoinerBase) buildFromRightInput(ctx context.Context, destStartIdx 
 									}
 								} else {
 									out.Copy(
-										coldata.CopySliceArgs{
-											SliceArgs: coldata.SliceArgs{
-												Src:         src,
-												DestIdx:     outStartIdx,
-												SrcStartIdx: b.builderState.right.curSrcStartIdx,
-												SrcEndIdx:   b.builderState.right.curSrcStartIdx + toAppend,
-											},
+										coldata.SliceArgs{
+											Src:         src,
+											DestIdx:     outStartIdx,
+											SrcStartIdx: b.builderState.right.curSrcStartIdx,
+											SrcEndIdx:   b.builderState.right.curSrcStartIdx + toAppend,
 										},
 									)
 								}
@@ -1578,13 +1570,11 @@ func (b *crossJoinerBase) buildFromRightInput(ctx context.Context, destStartIdx 
 									}
 								} else {
 									out.Copy(
-										coldata.CopySliceArgs{
-											SliceArgs: coldata.SliceArgs{
-												Src:         src,
-												DestIdx:     outStartIdx,
-												SrcStartIdx: b.builderState.right.curSrcStartIdx,
-												SrcEndIdx:   b.builderState.right.curSrcStartIdx + toAppend,
-											},
+										coldata.SliceArgs{
+											Src:         src,
+											DestIdx:     outStartIdx,
+											SrcStartIdx: b.builderState.right.curSrcStartIdx,
+											SrcEndIdx:   b.builderState.right.curSrcStartIdx + toAppend,
 										},
 									)
 								}
@@ -1604,13 +1594,11 @@ func (b *crossJoinerBase) buildFromRightInput(ctx context.Context, destStartIdx 
 									}
 								} else {
 									out.Copy(
-										coldata.CopySliceArgs{
-											SliceArgs: coldata.SliceArgs{
-												Src:         src,
-												DestIdx:     outStartIdx,
-												SrcStartIdx: b.builderState.right.curSrcStartIdx,
-												SrcEndIdx:   b.builderState.right.curSrcStartIdx + toAppend,
-											},
+										coldata.SliceArgs{
+											Src:         src,
+											DestIdx:     outStartIdx,
+											SrcStartIdx: b.builderState.right.curSrcStartIdx,
+											SrcEndIdx:   b.builderState.right.curSrcStartIdx + toAppend,
 										},
 									)
 								}
@@ -1633,13 +1621,11 @@ func (b *crossJoinerBase) buildFromRightInput(ctx context.Context, destStartIdx 
 									}
 								} else {
 									out.Copy(
-										coldata.CopySliceArgs{
-											SliceArgs: coldata.SliceArgs{
-												Src:         src,
-												DestIdx:     outStartIdx,
-												SrcStartIdx: b.builderState.right.curSrcStartIdx,
-												SrcEndIdx:   b.builderState.right.curSrcStartIdx + toAppend,
-											},
+										coldata.SliceArgs{
+											Src:         src,
+											DestIdx:     outStartIdx,
+											SrcStartIdx: b.builderState.right.curSrcStartIdx,
+											SrcEndIdx:   b.builderState.right.curSrcStartIdx + toAppend,
 										},
 									)
 								}
@@ -1662,13 +1648,11 @@ func (b *crossJoinerBase) buildFromRightInput(ctx context.Context, destStartIdx 
 									}
 								} else {
 									out.Copy(
-										coldata.CopySliceArgs{
-											SliceArgs: coldata.SliceArgs{
-												Src:         src,
-												DestIdx:     outStartIdx,
-												SrcStartIdx: b.builderState.right.curSrcStartIdx,
-												SrcEndIdx:   b.builderState.right.curSrcStartIdx + toAppend,
-											},
+										coldata.SliceArgs{
+											Src:         src,
+											DestIdx:     outStartIdx,
+											SrcStartIdx: b.builderState.right.curSrcStartIdx,
+											SrcEndIdx:   b.builderState.right.curSrcStartIdx + toAppend,
 										},
 									)
 								}
@@ -1691,13 +1675,11 @@ func (b *crossJoinerBase) buildFromRightInput(ctx context.Context, destStartIdx 
 									}
 								} else {
 									out.Copy(
-										coldata.CopySliceArgs{
-											SliceArgs: coldata.SliceArgs{
-												Src:         src,
-												DestIdx:     outStartIdx,
-												SrcStartIdx: b.builderState.right.curSrcStartIdx,
-												SrcEndIdx:   b.builderState.right.curSrcStartIdx + toAppend,
-											},
+										coldata.SliceArgs{
+											Src:         src,
+											DestIdx:     outStartIdx,
+											SrcStartIdx: b.builderState.right.curSrcStartIdx,
+											SrcEndIdx:   b.builderState.right.curSrcStartIdx + toAppend,
 										},
 									)
 								}
@@ -1720,13 +1702,11 @@ func (b *crossJoinerBase) buildFromRightInput(ctx context.Context, destStartIdx 
 									}
 								} else {
 									out.Copy(
-										coldata.CopySliceArgs{
-											SliceArgs: coldata.SliceArgs{
-												Src:         src,
-												DestIdx:     outStartIdx,
-												SrcStartIdx: b.builderState.right.curSrcStartIdx,
-												SrcEndIdx:   b.builderState.right.curSrcStartIdx + toAppend,
-											},
+										coldata.SliceArgs{
+											Src:         src,
+											DestIdx:     outStartIdx,
+											SrcStartIdx: b.builderState.right.curSrcStartIdx,
+											SrcEndIdx:   b.builderState.right.curSrcStartIdx + toAppend,
 										},
 									)
 								}
@@ -1749,13 +1729,11 @@ func (b *crossJoinerBase) buildFromRightInput(ctx context.Context, destStartIdx 
 									}
 								} else {
 									out.Copy(
-										coldata.CopySliceArgs{
-											SliceArgs: coldata.SliceArgs{
-												Src:         src,
-												DestIdx:     outStartIdx,
-												SrcStartIdx: b.builderState.right.curSrcStartIdx,
-												SrcEndIdx:   b.builderState.right.curSrcStartIdx + toAppend,
-											},
+										coldata.SliceArgs{
+											Src:         src,
+											DestIdx:     outStartIdx,
+											SrcStartIdx: b.builderState.right.curSrcStartIdx,
+											SrcEndIdx:   b.builderState.right.curSrcStartIdx + toAppend,
 										},
 									)
 								}

--- a/pkg/sql/colexec/colexecjoin/crossjoiner_tmpl.go
+++ b/pkg/sql/colexec/colexecjoin/crossjoiner_tmpl.go
@@ -291,13 +291,11 @@ func (b *crossJoinerBase) buildFromRightInput(ctx context.Context, destStartIdx 
 									}
 								} else {
 									out.Copy(
-										coldata.CopySliceArgs{
-											SliceArgs: coldata.SliceArgs{
-												Src:         src,
-												DestIdx:     outStartIdx,
-												SrcStartIdx: b.builderState.right.curSrcStartIdx,
-												SrcEndIdx:   b.builderState.right.curSrcStartIdx + toAppend,
-											},
+										coldata.SliceArgs{
+											Src:         src,
+											DestIdx:     outStartIdx,
+											SrcStartIdx: b.builderState.right.curSrcStartIdx,
+											SrcEndIdx:   b.builderState.right.curSrcStartIdx + toAppend,
 										},
 									)
 								}

--- a/pkg/sql/colexec/colexecjoin/hashjoiner.go
+++ b/pkg/sql/colexec/colexecjoin/hashjoiner.go
@@ -397,12 +397,10 @@ func (hj *hashJoiner) emitRight(matched bool) {
 			outCol := outCols[i]
 			valCol := hj.ht.Vals.ColVec(i)
 			outCol.Copy(
-				coldata.CopySliceArgs{
-					SliceArgs: coldata.SliceArgs{
-						Src:       valCol,
-						SrcEndIdx: nResults,
-						Sel:       hj.probeState.buildIdx,
-					},
+				coldata.SliceArgs{
+					Src:       valCol,
+					SrcEndIdx: nResults,
+					Sel:       hj.probeState.buildIdx,
 				},
 			)
 		}
@@ -587,12 +585,10 @@ func (hj *hashJoiner) congregate(nResults int, batch coldata.Batch) {
 				outCol := outCols[i]
 				valCol := batch.ColVec(i)
 				outCol.Copy(
-					coldata.CopySliceArgs{
-						SliceArgs: coldata.SliceArgs{
-							Src:       valCol,
-							Sel:       hj.probeState.probeIdx,
-							SrcEndIdx: nResults,
-						},
+					coldata.SliceArgs{
+						Src:       valCol,
+						Sel:       hj.probeState.probeIdx,
+						SrcEndIdx: nResults,
 					},
 				)
 			}
@@ -611,12 +607,10 @@ func (hj *hashJoiner) congregate(nResults int, batch coldata.Batch) {
 					// hj.buildIdx[i] == 0 which will copy the garbage zeroth row of the
 					// hash table, but we will set the NULL value below.
 					outCol.Copy(
-						coldata.CopySliceArgs{
-							SliceArgs: coldata.SliceArgs{
-								Src:       valCol,
-								SrcEndIdx: nResults,
-								Sel:       hj.probeState.buildIdx,
-							},
+						coldata.SliceArgs{
+							Src:       valCol,
+							SrcEndIdx: nResults,
+							Sel:       hj.probeState.buildIdx,
 						},
 					)
 				}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner.go
@@ -585,14 +585,12 @@ func (o *mergeJoinBase) appendToBufferedGroup(
 		o.unlimitedAllocator.PerformOperation(bufferedGroup.firstTuple, func() {
 			for colIdx := range sourceTypes {
 				bufferedGroup.firstTuple[colIdx].Copy(
-					coldata.CopySliceArgs{
-						SliceArgs: coldata.SliceArgs{
-							Src:         batch.ColVec(colIdx),
-							Sel:         sel,
-							DestIdx:     0,
-							SrcStartIdx: groupStartIdx,
-							SrcEndIdx:   groupStartIdx + 1,
-						},
+					coldata.SliceArgs{
+						Src:         batch.ColVec(colIdx),
+						Sel:         sel,
+						DestIdx:     0,
+						SrcStartIdx: groupStartIdx,
+						SrcEndIdx:   groupStartIdx + 1,
 					},
 				)
 			}
@@ -608,14 +606,12 @@ func (o *mergeJoinBase) appendToBufferedGroup(
 	o.unlimitedAllocator.PerformOperation(bufferedGroup.scratchBatch.ColVecs(), func() {
 		for colIdx := range input.sourceTypes {
 			bufferedGroup.scratchBatch.ColVec(colIdx).Copy(
-				coldata.CopySliceArgs{
-					SliceArgs: coldata.SliceArgs{
-						Src:         batch.ColVec(colIdx),
-						Sel:         sel,
-						DestIdx:     0,
-						SrcStartIdx: groupStartIdx,
-						SrcEndIdx:   groupStartIdx + groupLength,
-					},
+				coldata.SliceArgs{
+					Src:         batch.ColVec(colIdx),
+					Sel:         sel,
+					DestIdx:     0,
+					SrcStartIdx: groupStartIdx,
+					SrcEndIdx:   groupStartIdx + groupLength,
 				},
 			)
 		}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_exceptall.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_exceptall.eg.go
@@ -12311,14 +12311,12 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -12380,14 +12378,12 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -12449,14 +12445,12 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -12517,14 +12511,12 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -12582,14 +12574,12 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -12648,14 +12638,12 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -12717,14 +12705,12 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -12786,14 +12772,12 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -12855,14 +12839,12 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -12924,14 +12906,12 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -12993,14 +12973,12 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -13072,14 +13050,12 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -13141,14 +13117,12 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -13210,14 +13184,12 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -13278,14 +13250,12 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -13343,14 +13313,12 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -13409,14 +13377,12 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -13478,14 +13444,12 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -13547,14 +13511,12 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -13616,14 +13578,12 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -13685,14 +13645,12 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -13754,14 +13712,12 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_fullouter.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_fullouter.eg.go
@@ -13361,14 +13361,12 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -13432,14 +13430,12 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -13503,14 +13499,12 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -13573,14 +13567,12 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -13640,14 +13632,12 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -13708,14 +13698,12 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -13779,14 +13767,12 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -13850,14 +13836,12 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -13921,14 +13905,12 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -13992,14 +13974,12 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -14063,14 +14043,12 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -14144,14 +14122,12 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -14215,14 +14191,12 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -14286,14 +14260,12 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -14356,14 +14328,12 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -14423,14 +14393,12 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -14491,14 +14459,12 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -14562,14 +14528,12 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -14633,14 +14597,12 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -14704,14 +14666,12 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -14775,14 +14735,12 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -14846,14 +14804,12 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_inner.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_inner.eg.go
@@ -8865,14 +8865,12 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -8934,14 +8932,12 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -9003,14 +8999,12 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -9071,14 +9065,12 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -9136,14 +9128,12 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -9202,14 +9192,12 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -9271,14 +9259,12 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -9340,14 +9326,12 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -9409,14 +9393,12 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -9478,14 +9460,12 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -9547,14 +9527,12 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -9626,14 +9604,12 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -9695,14 +9671,12 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -9764,14 +9738,12 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -9832,14 +9804,12 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -9897,14 +9867,12 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -9963,14 +9931,12 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -10032,14 +9998,12 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -10101,14 +10065,12 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -10170,14 +10132,12 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -10239,14 +10199,12 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -10308,14 +10266,12 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_intersectall.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_intersectall.eg.go
@@ -9701,14 +9701,12 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -9770,14 +9768,12 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -9839,14 +9835,12 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -9907,14 +9901,12 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -9972,14 +9964,12 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -10038,14 +10028,12 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -10107,14 +10095,12 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -10176,14 +10162,12 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -10245,14 +10229,12 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -10314,14 +10296,12 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -10383,14 +10363,12 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -10462,14 +10440,12 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -10531,14 +10507,12 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -10600,14 +10574,12 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -10668,14 +10640,12 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -10733,14 +10703,12 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -10799,14 +10767,12 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -10868,14 +10834,12 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -10937,14 +10901,12 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11006,14 +10968,12 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11075,14 +11035,12 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11144,14 +11102,12 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_leftanti.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_leftanti.eg.go
@@ -11123,14 +11123,12 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11192,14 +11190,12 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11261,14 +11257,12 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11329,14 +11323,12 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11394,14 +11386,12 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11460,14 +11450,12 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11529,14 +11517,12 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11598,14 +11584,12 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11667,14 +11651,12 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11736,14 +11718,12 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11805,14 +11785,12 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11884,14 +11862,12 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11953,14 +11929,12 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -12022,14 +11996,12 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -12090,14 +12062,12 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -12155,14 +12125,12 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -12221,14 +12189,12 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -12290,14 +12256,12 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -12359,14 +12323,12 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -12428,14 +12390,12 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -12497,14 +12457,12 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -12566,14 +12524,12 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_leftouter.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_leftouter.eg.go
@@ -11103,14 +11103,12 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11174,14 +11172,12 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11245,14 +11241,12 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11315,14 +11309,12 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11382,14 +11374,12 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11450,14 +11440,12 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11521,14 +11509,12 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11592,14 +11578,12 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11663,14 +11647,12 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11734,14 +11716,12 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11805,14 +11785,12 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11886,14 +11864,12 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11957,14 +11933,12 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -12028,14 +12002,12 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -12098,14 +12070,12 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -12165,14 +12135,12 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -12233,14 +12201,12 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -12304,14 +12270,12 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -12375,14 +12339,12 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -12446,14 +12408,12 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -12517,14 +12477,12 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -12588,14 +12546,12 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_leftsemi.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_leftsemi.eg.go
@@ -8821,14 +8821,12 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -8890,14 +8888,12 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -8959,14 +8955,12 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -9027,14 +9021,12 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -9092,14 +9084,12 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -9158,14 +9148,12 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -9227,14 +9215,12 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -9296,14 +9282,12 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -9365,14 +9349,12 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -9434,14 +9416,12 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -9503,14 +9483,12 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -9582,14 +9560,12 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -9651,14 +9627,12 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -9720,14 +9694,12 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -9788,14 +9760,12 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -9853,14 +9823,12 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -9919,14 +9887,12 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -9988,14 +9954,12 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -10057,14 +10021,12 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -10126,14 +10088,12 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -10195,14 +10155,12 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -10264,14 +10222,12 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_rightanti.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_rightanti.eg.go
@@ -11079,14 +11079,12 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11148,14 +11146,12 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11217,14 +11213,12 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11285,14 +11279,12 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11350,14 +11342,12 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11416,14 +11406,12 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11485,14 +11473,12 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11554,14 +11540,12 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11623,14 +11607,12 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11692,14 +11674,12 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11761,14 +11741,12 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11840,14 +11818,12 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11909,14 +11885,12 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11978,14 +11952,12 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -12046,14 +12018,12 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -12111,14 +12081,12 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -12177,14 +12145,12 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -12246,14 +12212,12 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -12315,14 +12279,12 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -12384,14 +12346,12 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -12453,14 +12413,12 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -12522,14 +12480,12 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_rightouter.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_rightouter.eg.go
@@ -11123,14 +11123,12 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11192,14 +11190,12 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11261,14 +11257,12 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11329,14 +11323,12 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11394,14 +11386,12 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11460,14 +11450,12 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11529,14 +11517,12 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11598,14 +11584,12 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11667,14 +11651,12 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11736,14 +11718,12 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11805,14 +11785,12 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11884,14 +11862,12 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -11953,14 +11929,12 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -12022,14 +11996,12 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -12090,14 +12062,12 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -12155,14 +12125,12 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -12221,14 +12189,12 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -12290,14 +12256,12 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -12359,14 +12323,12 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -12428,14 +12390,12 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -12497,14 +12457,12 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -12566,14 +12524,12 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_rightsemi.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_rightsemi.eg.go
@@ -8777,14 +8777,12 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -8846,14 +8844,12 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -8915,14 +8911,12 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -8983,14 +8977,12 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -9048,14 +9040,12 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -9114,14 +9104,12 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -9183,14 +9171,12 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -9252,14 +9238,12 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -9321,14 +9305,12 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -9390,14 +9372,12 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -9459,14 +9439,12 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -9538,14 +9516,12 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -9607,14 +9583,12 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -9676,14 +9650,12 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -9744,14 +9716,12 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -9809,14 +9779,12 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -9875,14 +9843,12 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -9944,14 +9910,12 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -10013,14 +9977,12 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -10082,14 +10044,12 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -10151,14 +10111,12 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}
@@ -10220,14 +10178,12 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 											}
 										} else {
 											out.Copy(
-												coldata.CopySliceArgs{
-													SliceArgs: coldata.SliceArgs{
-														Src:         src,
-														Sel:         sel,
-														DestIdx:     outStartIdx,
-														SrcStartIdx: o.builderState.right.curSrcStartIdx,
-														SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-													},
+												coldata.SliceArgs{
+													Src:         src,
+													Sel:         sel,
+													DestIdx:     outStartIdx,
+													SrcStartIdx: o.builderState.right.curSrcStartIdx,
+													SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 												},
 											)
 										}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_tmpl.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_tmpl.go
@@ -873,14 +873,12 @@ func _RIGHT_SWITCH(_JOIN_TYPE joinTypeInfo, _HAS_SELECTION bool) { // */}}
 							}
 						} else {
 							out.Copy(
-								coldata.CopySliceArgs{
-									SliceArgs: coldata.SliceArgs{
-										Src:         src,
-										Sel:         sel,
-										DestIdx:     outStartIdx,
-										SrcStartIdx: o.builderState.right.curSrcStartIdx,
-										SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
-									},
+								coldata.SliceArgs{
+									Src:         src,
+									Sel:         sel,
+									DestIdx:     outStartIdx,
+									SrcStartIdx: o.builderState.right.curSrcStartIdx,
+									SrcEndIdx:   o.builderState.right.curSrcStartIdx + toAppend,
 								},
 							)
 						}

--- a/pkg/sql/colexec/colexecutils/deselector.go
+++ b/pkg/sql/colexec/colexecutils/deselector.go
@@ -73,12 +73,10 @@ func (p *deselectorOp) Next() coldata.Batch {
 			toCol := p.output.ColVec(i)
 			fromCol := batch.ColVec(i)
 			toCol.Copy(
-				coldata.CopySliceArgs{
-					SliceArgs: coldata.SliceArgs{
-						Src:       fromCol,
-						Sel:       sel,
-						SrcEndIdx: batch.Length(),
-					},
+				coldata.SliceArgs{
+					Src:       fromCol,
+					Sel:       sel,
+					SrcEndIdx: batch.Length(),
 				},
 			)
 		}

--- a/pkg/sql/colexec/colexecutils/spilling_queue.go
+++ b/pkg/sql/colexec/colexecutils/spilling_queue.go
@@ -197,12 +197,10 @@ func (q *SpillingQueue) Enqueue(ctx context.Context, batch coldata.Batch) {
 			q.unlimitedAllocator.PerformOperation(q.diskQueueDeselectionScratch.ColVecs(), func() {
 				for i := range q.typs {
 					q.diskQueueDeselectionScratch.ColVec(i).Copy(
-						coldata.CopySliceArgs{
-							SliceArgs: coldata.SliceArgs{
-								Src:       batch.ColVec(i),
-								Sel:       sel,
-								SrcEndIdx: n,
-							},
+						coldata.SliceArgs{
+							Src:       batch.ColVec(i),
+							Sel:       sel,
+							SrcEndIdx: n,
 						},
 					)
 				}
@@ -252,14 +250,12 @@ func (q *SpillingQueue) Enqueue(ctx context.Context, batch coldata.Batch) {
 			q.unlimitedAllocator.PerformOperation(tailBatch.ColVecs(), func() {
 				for i := range q.typs {
 					tailBatch.ColVec(i).Copy(
-						coldata.CopySliceArgs{
-							SliceArgs: coldata.SliceArgs{
-								Src:         batch.ColVec(i),
-								Sel:         batch.Selection(),
-								DestIdx:     l,
-								SrcStartIdx: 0,
-								SrcEndIdx:   alreadyCopied,
-							},
+						coldata.SliceArgs{
+							Src:         batch.ColVec(i),
+							Sel:         batch.Selection(),
+							DestIdx:     l,
+							SrcStartIdx: 0,
+							SrcEndIdx:   alreadyCopied,
 						},
 					)
 				}
@@ -303,13 +299,11 @@ func (q *SpillingQueue) Enqueue(ctx context.Context, batch coldata.Batch) {
 	q.unlimitedAllocator.PerformOperation(newBatch.ColVecs(), func() {
 		for i := range q.typs {
 			newBatch.ColVec(i).Copy(
-				coldata.CopySliceArgs{
-					SliceArgs: coldata.SliceArgs{
-						Src:         batch.ColVec(i),
-						Sel:         batch.Selection(),
-						SrcStartIdx: alreadyCopied,
-						SrcEndIdx:   n,
-					},
+				coldata.SliceArgs{
+					Src:         batch.ColVec(i),
+					Sel:         batch.Selection(),
+					SrcStartIdx: alreadyCopied,
+					SrcEndIdx:   n,
 				},
 			)
 		}

--- a/pkg/sql/colexec/colexecwindow/buffered_window.go
+++ b/pkg/sql/colexec/colexecwindow/buffered_window.go
@@ -257,12 +257,10 @@ func (b *bufferedWindowOp) Next() coldata.Batch {
 						continue
 					}
 					b.currentBatch.ColVec(colIdx).Copy(
-						coldata.CopySliceArgs{
-							SliceArgs: coldata.SliceArgs{
-								Src:       vec,
-								Sel:       sel,
-								SrcEndIdx: n,
-							},
+						coldata.SliceArgs{
+							Src:       vec,
+							Sel:       sel,
+							SrcEndIdx: n,
 						},
 					)
 				}

--- a/pkg/sql/colexec/colexecwindow/relative_rank.eg.go
+++ b/pkg/sql/colexec/colexecwindow/relative_rank.eg.go
@@ -257,12 +257,10 @@ func (r *percentRankNoPartitionOp) Next() coldata.Batch {
 			r.allocator.PerformOperation(r.scratch.ColVecs(), func() {
 				for colIdx, vec := range r.scratch.ColVecs() {
 					vec.Copy(
-						coldata.CopySliceArgs{
-							SliceArgs: coldata.SliceArgs{
-								Src:       batch.ColVec(colIdx),
-								Sel:       sel,
-								SrcEndIdx: n,
-							},
+						coldata.SliceArgs{
+							Src:       batch.ColVec(colIdx),
+							Sel:       sel,
+							SrcEndIdx: n,
 						},
 					)
 				}
@@ -291,11 +289,9 @@ func (r *percentRankNoPartitionOp) Next() coldata.Batch {
 			r.allocator.PerformOperation(r.output.ColVecs()[:len(r.inputTypes)], func() {
 				for colIdx, vec := range r.output.ColVecs()[:len(r.inputTypes)] {
 					vec.Copy(
-						coldata.CopySliceArgs{
-							SliceArgs: coldata.SliceArgs{
-								Src:       r.scratch.ColVec(colIdx),
-								SrcEndIdx: n,
-							},
+						coldata.SliceArgs{
+							Src:       r.scratch.ColVec(colIdx),
+							SrcEndIdx: n,
 						},
 					)
 				}
@@ -482,12 +478,10 @@ func (r *percentRankWithPartitionOp) Next() coldata.Batch {
 			r.allocator.PerformOperation(r.scratch.ColVecs(), func() {
 				for colIdx, vec := range r.scratch.ColVecs() {
 					vec.Copy(
-						coldata.CopySliceArgs{
-							SliceArgs: coldata.SliceArgs{
-								Src:       batch.ColVec(colIdx),
-								Sel:       sel,
-								SrcEndIdx: n,
-							},
+						coldata.SliceArgs{
+							Src:       batch.ColVec(colIdx),
+							Sel:       sel,
+							SrcEndIdx: n,
 						},
 					)
 				}
@@ -572,11 +566,9 @@ func (r *percentRankWithPartitionOp) Next() coldata.Batch {
 			r.allocator.PerformOperation(r.output.ColVecs()[:len(r.inputTypes)], func() {
 				for colIdx, vec := range r.output.ColVecs()[:len(r.inputTypes)] {
 					vec.Copy(
-						coldata.CopySliceArgs{
-							SliceArgs: coldata.SliceArgs{
-								Src:       r.scratch.ColVec(colIdx),
-								SrcEndIdx: n,
-							},
+						coldata.SliceArgs{
+							Src:       r.scratch.ColVec(colIdx),
+							SrcEndIdx: n,
 						},
 					)
 				}
@@ -775,12 +767,10 @@ func (r *cumeDistNoPartitionOp) Next() coldata.Batch {
 			r.allocator.PerformOperation(r.scratch.ColVecs(), func() {
 				for colIdx, vec := range r.scratch.ColVecs() {
 					vec.Copy(
-						coldata.CopySliceArgs{
-							SliceArgs: coldata.SliceArgs{
-								Src:       batch.ColVec(colIdx),
-								Sel:       sel,
-								SrcEndIdx: n,
-							},
+						coldata.SliceArgs{
+							Src:       batch.ColVec(colIdx),
+							Sel:       sel,
+							SrcEndIdx: n,
 						},
 					)
 				}
@@ -868,11 +858,9 @@ func (r *cumeDistNoPartitionOp) Next() coldata.Batch {
 			r.allocator.PerformOperation(r.output.ColVecs()[:len(r.inputTypes)], func() {
 				for colIdx, vec := range r.output.ColVecs()[:len(r.inputTypes)] {
 					vec.Copy(
-						coldata.CopySliceArgs{
-							SliceArgs: coldata.SliceArgs{
-								Src:       r.scratch.ColVec(colIdx),
-								SrcEndIdx: n,
-							},
+						coldata.SliceArgs{
+							Src:       r.scratch.ColVec(colIdx),
+							SrcEndIdx: n,
 						},
 					)
 				}
@@ -1082,12 +1070,10 @@ func (r *cumeDistWithPartitionOp) Next() coldata.Batch {
 			r.allocator.PerformOperation(r.scratch.ColVecs(), func() {
 				for colIdx, vec := range r.scratch.ColVecs() {
 					vec.Copy(
-						coldata.CopySliceArgs{
-							SliceArgs: coldata.SliceArgs{
-								Src:       batch.ColVec(colIdx),
-								Sel:       sel,
-								SrcEndIdx: n,
-							},
+						coldata.SliceArgs{
+							Src:       batch.ColVec(colIdx),
+							Sel:       sel,
+							SrcEndIdx: n,
 						},
 					)
 				}
@@ -1231,11 +1217,9 @@ func (r *cumeDistWithPartitionOp) Next() coldata.Batch {
 			r.allocator.PerformOperation(r.output.ColVecs()[:len(r.inputTypes)], func() {
 				for colIdx, vec := range r.output.ColVecs()[:len(r.inputTypes)] {
 					vec.Copy(
-						coldata.CopySliceArgs{
-							SliceArgs: coldata.SliceArgs{
-								Src:       r.scratch.ColVec(colIdx),
-								SrcEndIdx: n,
-							},
+						coldata.SliceArgs{
+							Src:       r.scratch.ColVec(colIdx),
+							SrcEndIdx: n,
 						},
 					)
 				}

--- a/pkg/sql/colexec/colexecwindow/relative_rank_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/relative_rank_tmpl.go
@@ -409,12 +409,10 @@ func (r *_RELATIVE_RANK_STRINGOp) Next() coldata.Batch {
 			r.allocator.PerformOperation(r.scratch.ColVecs(), func() {
 				for colIdx, vec := range r.scratch.ColVecs() {
 					vec.Copy(
-						coldata.CopySliceArgs{
-							SliceArgs: coldata.SliceArgs{
-								Src:       batch.ColVec(colIdx),
-								Sel:       sel,
-								SrcEndIdx: n,
-							},
+						coldata.SliceArgs{
+							Src:       batch.ColVec(colIdx),
+							Sel:       sel,
+							SrcEndIdx: n,
 						},
 					)
 				}
@@ -499,11 +497,9 @@ func (r *_RELATIVE_RANK_STRINGOp) Next() coldata.Batch {
 			r.allocator.PerformOperation(r.output.ColVecs()[:len(r.inputTypes)], func() {
 				for colIdx, vec := range r.output.ColVecs()[:len(r.inputTypes)] {
 					vec.Copy(
-						coldata.CopySliceArgs{
-							SliceArgs: coldata.SliceArgs{
-								Src:       r.scratch.ColVec(colIdx),
-								SrcEndIdx: n,
-							},
+						coldata.SliceArgs{
+							Src:       r.scratch.ColVec(colIdx),
+							SrcEndIdx: n,
 						},
 					)
 				}

--- a/pkg/sql/colexec/execgen/cmd/execgen/vec_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/vec_gen.go
@@ -28,9 +28,6 @@ func genVec(inputFileContents string, wr io.Writer) error {
 	)
 	s := r.Replace(inputFileContents)
 
-	copyWithSel := makeFunctionRegex("_COPY_WITH_SEL", 6)
-	s = copyWithSel.ReplaceAllString(s, `{{template "copyWithSel" buildDict "Sliceable" .Sliceable "SelOnDest" $6}}`)
-
 	copyWithReorderedSource := makeFunctionRegex("_COPY_WITH_REORDERED_SOURCE", 1)
 	s = copyWithReorderedSource.ReplaceAllString(s, `{{template "copyWithReorderedSource" buildDict "SrcHasNulls" $1}}`)
 

--- a/pkg/sql/colexec/execgen/cmd/execgen/vec_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/vec_gen.go
@@ -31,6 +31,9 @@ func genVec(inputFileContents string, wr io.Writer) error {
 	copyWithSel := makeFunctionRegex("_COPY_WITH_SEL", 6)
 	s = copyWithSel.ReplaceAllString(s, `{{template "copyWithSel" buildDict "Sliceable" .Sliceable "SelOnDest" $6}}`)
 
+	copyWithReorderedSource := makeFunctionRegex("_COPY_WITH_REORDERED_SOURCE", 1)
+	s = copyWithReorderedSource.ReplaceAllString(s, `{{template "copyWithReorderedSource" buildDict "SrcHasNulls" $1}}`)
+
 	s = replaceManipulationFuncs(s)
 
 	// Now, generate the op, from the template.

--- a/pkg/sql/colexec/hash_based_partitioner.go
+++ b/pkg/sql/colexec/hash_based_partitioner.go
@@ -370,12 +370,10 @@ func (op *hashBasedPartitioner) partitionBatch(
 			colVecs := scratchBatch.ColVecs()
 			op.unlimitedAllocator.PerformOperation(colVecs, func() {
 				for i, colvec := range colVecs {
-					colvec.Copy(coldata.CopySliceArgs{
-						SliceArgs: coldata.SliceArgs{
-							Src:       batch.ColVec(i),
-							Sel:       sel,
-							SrcEndIdx: len(sel),
-						},
+					colvec.Copy(coldata.SliceArgs{
+						Src:       batch.ColVec(i),
+						Sel:       sel,
+						SrcEndIdx: len(sel),
 					})
 				}
 				scratchBatch.SetLength(len(sel))

--- a/pkg/sql/colexec/ordered_aggregator.go
+++ b/pkg/sql/colexec/ordered_aggregator.go
@@ -332,12 +332,10 @@ func (a *orderedAggregator) Next() coldata.Batch {
 				a.allocator.PerformOperation(a.unsafeBatch.ColVecs(), func() {
 					for i := 0; i < len(a.outputTypes); i++ {
 						a.unsafeBatch.ColVec(i).Copy(
-							coldata.CopySliceArgs{
-								SliceArgs: coldata.SliceArgs{
-									Src:         a.scratch.ColVec(i),
-									SrcStartIdx: 0,
-									SrcEndIdx:   coldata.BatchSize(),
-								},
+							coldata.SliceArgs{
+								Src:         a.scratch.ColVec(i),
+								SrcStartIdx: 0,
+								SrcEndIdx:   coldata.BatchSize(),
 							},
 						)
 					}
@@ -359,12 +357,10 @@ func (a *orderedAggregator) Next() coldata.Batch {
 				a.allocator.PerformOperation(a.scratch.tempBuffer.ColVecs(), func() {
 					for i := 0; i < len(a.outputTypes); i++ {
 						a.scratch.tempBuffer.ColVec(i).Copy(
-							coldata.CopySliceArgs{
-								SliceArgs: coldata.SliceArgs{
-									Src:         a.scratch.ColVec(i),
-									SrcStartIdx: coldata.BatchSize(),
-									SrcEndIdx:   a.scratch.resumeIdx,
-								},
+							coldata.SliceArgs{
+								Src:         a.scratch.ColVec(i),
+								SrcStartIdx: coldata.BatchSize(),
+								SrcEndIdx:   a.scratch.resumeIdx,
 							},
 						)
 					}
@@ -373,11 +369,9 @@ func (a *orderedAggregator) Next() coldata.Batch {
 				a.allocator.PerformOperation(a.scratch.ColVecs(), func() {
 					for i := 0; i < len(a.outputTypes); i++ {
 						a.scratch.ColVec(i).Copy(
-							coldata.CopySliceArgs{
-								SliceArgs: coldata.SliceArgs{
-									Src:       a.scratch.tempBuffer.ColVec(i),
-									SrcEndIdx: newResumeIdx,
-								},
+							coldata.SliceArgs{
+								Src:       a.scratch.tempBuffer.ColVec(i),
+								SrcEndIdx: newResumeIdx,
 							},
 						)
 					}

--- a/pkg/sql/colexec/sort.go
+++ b/pkg/sql/colexec/sort.go
@@ -297,13 +297,11 @@ func (p *sortOp) Next() coldata.Batch {
 				// variable-sized types like Bytes). Nonetheless, for performance reasons
 				// it would be sad to fallback to disk at this point.
 				p.output.ColVec(j).Copy(
-					coldata.CopySliceArgs{
-						SliceArgs: coldata.SliceArgs{
-							Sel:         p.order,
-							Src:         p.input.getValues(j),
-							SrcStartIdx: p.emitted,
-							SrcEndIdx:   newEmitted,
-						},
+					coldata.SliceArgs{
+						Sel:         p.order,
+						Src:         p.input.getValues(j),
+						SrcStartIdx: p.emitted,
+						SrcEndIdx:   newEmitted,
 					},
 				)
 			}

--- a/pkg/sql/colexec/sorttopk.go
+++ b/pkg/sql/colexec/sorttopk.go
@@ -247,13 +247,11 @@ func (t *topKSorter) emit() coldata.Batch {
 		// variable-sized types like Bytes). Nonetheless, for performance reasons
 		// it would be sad to fallback to disk at this point.
 		vec.Copy(
-			coldata.CopySliceArgs{
-				SliceArgs: coldata.SliceArgs{
-					Src:         t.topK.ColVec(i),
-					Sel:         t.sel,
-					SrcStartIdx: t.emitted,
-					SrcEndIdx:   t.emitted + toEmit,
-				},
+			coldata.SliceArgs{
+				Src:         t.topK.ColVec(i),
+				Sel:         t.sel,
+				SrcStartIdx: t.emitted,
+				SrcEndIdx:   t.emitted + toEmit,
 			},
 		)
 	}

--- a/pkg/sql/colexecop/testutils.go
+++ b/pkg/sql/colexecop/testutils.go
@@ -116,11 +116,9 @@ func (s *RepeatableBatchSource) Next() coldata.Batch {
 		// This Copy is outside of the allocator since the RepeatableBatchSource is
 		// a test utility which is often used in the benchmarks, and we want to
 		// reduce the performance impact of this operator.
-		s.output.ColVec(i).Copy(coldata.CopySliceArgs{
-			SliceArgs: coldata.SliceArgs{
-				Src:       colVec,
-				SrcEndIdx: s.numToCopy,
-			},
+		s.output.ColVec(i).Copy(coldata.SliceArgs{
+			Src:       colVec,
+			SrcEndIdx: s.numToCopy,
 		})
 	}
 	s.output.SetLength(s.batchLen)

--- a/pkg/sql/colflow/colrpc/colrpc_test.go
+++ b/pkg/sql/colflow/colrpc/colrpc_test.go
@@ -351,11 +351,9 @@ func TestOutboxInbox(t *testing.T) {
 					testAllocator.PerformOperation(batchCopy.ColVecs(), func() {
 						for i := range typs {
 							batchCopy.ColVec(i).Copy(
-								coldata.CopySliceArgs{
-									SliceArgs: coldata.SliceArgs{
-										Src:       outputBatch.ColVec(i),
-										SrcEndIdx: outputBatch.Length(),
-									},
+								coldata.SliceArgs{
+									Src:       outputBatch.ColVec(i),
+									SrcEndIdx: outputBatch.Length(),
 								},
 							)
 						}

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -1016,9 +1016,11 @@ SELECT * FROM t44304 WHERE CASE WHEN t44304.c0 > 0 THEN NULL END
 statement ok
 CREATE TABLE t44624(c0 STRING, c1 BOOL); INSERT INTO t44624(rowid, c0, c1) VALUES (0, '', true), (1, '', NULL);
 
-# TODO(yuzefovich): #44700.
-statement error .* unsupported type string in CASE operator
+query TB rowsort
 SELECT * FROM t44624 ORDER BY CASE WHEN c1 IS NULL THEN c0 WHEN true THEN c0 END
+----
+·  true
+·  NULL
 
 # Regression test for 44726 (unknown WHEN expression type).
 statement ok


### PR DESCRIPTION
**colexec: refactor CASE operator to support all types**

Previously, the CASE operator didn't support Bytes-like output types
because of the mismatch between the desire to do arbitrary SET
operations on the vectors (the way the case operator currently works)
and the flat bytes not supporting such operations. This commit refactors
the case operator in order to lift that restriction.

It is achieved by not populating the output vector directly, but rather
populating a scratch vector first (where all projected tuples matched by
the same WHEN arm are grouped together) and then copying over from the
scratch to the output batch (according to carefully maintained "fake"
selection vector).

However, there is a complication when the original batch has a selection
vector set. In this case we have to be quite tricky. Previously, the
trickiness was handled by using `SelOnDest` flag of `Vec.Copy`; this
commit introduces special `CopyWithReorderedSource` into `coldata.Vec`
interface that performs the needed for us reordering while paying
attention to the original selection vector.

The original idea of this commit was to side-step the complication with
this original selection vector by always planning a deselector on top of
the input to the case operator, but that didn't work out because it
broke the assumptions of the logical AND/OR projection operators.
Refactoring those seems quite hard, so I removed the planning of the
deselector and introduced the new method.

Fixes: #44700.

Release note (sql change): Vectorized engine now supports CASE
expressions that output BYTES-like types.

**colexec: add randomized test of the CASE operator**

This commit adds a randomized test of the CASE vectorized operator. It
creates the expressions like `CASE @1 WHEN 0 THEN @2 WHEN 1 THEN @3 ELSE @4 END`
and populates such an input data set that the first column "partitions"
the data into non-intersecting sets which allows us to easily compute
the expected output. The test also employs the help of the
columnarizer/materializer pair in order to use random datum generation
facilities.

Release note: None

**coldata: remove no longer used SelOnDest flag of Vec.Copy**

Previous commit removed the only usage of `SelOnDest` flag of `Vec.Copy`
method, and this commit removes the no longer used flag. This allows for
a nice cleanup.

Release note: None