### PR TITLE
colexec: refactor bytes column logic

### DIFF
--- a/pkg/col/coldata/bytes_test.go
+++ b/pkg/col/coldata/bytes_test.go
@@ -86,8 +86,12 @@ func applyMethodsAndVerify(
 		debugString += m.String()
 		switch m {
 		case set:
-			// Can only Set starting from maxSetIndex.
-			i := b1.maxSetIndex + rng.Intn(b1.Len()-b1.maxSetIndex)
+			// Can only Set starting from maxSetLength - 1 (or zero if maxSetLength is
+			// zero).
+			i := b1.maxSetLength - 1 + rng.Intn(b1.Len()-(b1.maxSetLength-1))
+			if i < 0 {
+				i = 0
+			}
 			new := make([]byte, rng.Intn(16))
 			rng.Read(new)
 			debugString += fmt.Sprintf("(%d, %v)", i, new)
@@ -160,8 +164,8 @@ func applyMethodsAndVerify(
 		debugString += fmt.Sprintf("\n%s\n", b1)
 		if err := verifyEqual(b1, b2); err != nil {
 			return errors.Wrapf(err,
-				"\ndebugString:\n%s\nflat (maxSetIdx=%d):\n%s\nreference:\n%s",
-				debugString, b1.maxSetIndex, b1.String(), prettyByteSlice(b2))
+				"\ndebugString:\n%s\nflat (maxSetLength=%d):\n%s\nreference:\n%s",
+				debugString, b1.maxSetLength, b1.String(), prettyByteSlice(b2))
 		}
 	}
 	return nil
@@ -363,6 +367,7 @@ func TestBytes(t *testing.T) {
 		// Set the length to 1 and follow it with testing a full overwrite of
 		// only one element.
 		b1.offsets = b1.offsets[:2]
+		b1.maxSetLength = 1
 		require.Equal(t, 1, b1.Len())
 		b1.CopySlice(b2, 0, 0, b2.Len())
 		require.Equal(t, 1, b1.Len())
@@ -507,4 +512,34 @@ func TestToArrowSerializationFormat(t *testing.T) {
 		element := data[offsets[i]:offsets[i+1]]
 		require.Equal(t, wind.Get(i), element)
 	}
+}
+
+func TestForRegressions(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	t.Run("Regression test for #42054", func(t *testing.T) {
+		b := NewBytes(4)
+		b.Set(0, []byte("zero"))
+		b.Set(1, []byte("one"))
+		b.Set(2, []byte("two"))
+
+		// Emulate copying when the first two values are null and the last is
+		// non-null.
+		b.Reset()
+		b.Set(2, []byte("three"))
+		b.AssertOffsetsAreNonDecreasing(2)
+
+		b.Reset()
+		b.Set(0, []byte("zero"))
+		b.Set(1, []byte("one"))
+		b.Set(2, []byte("two"))
+		b.Set(3, []byte("three"))
+
+		// Emulate copying when the first and last values are non-null, and the
+		// middle two are null.
+		b.Reset()
+		b.Set(0, []byte("zero"))
+		b.Set(3, []byte("four"))
+		b.AssertOffsetsAreNonDecreasing(3)
+	})
 }

--- a/pkg/col/coldata/json.go
+++ b/pkg/col/coldata/json.go
@@ -60,7 +60,7 @@ func (js *JSONs) Set(i int, j json.JSON) {
 		colexecerror.ExpectedError(err)
 	}
 	b.offsets[i+1] = int32(len(b.data))
-	b.maxSetIndex = i
+	b.maxSetLength = i + 1
 }
 
 // Window creates a "window" into the receiver. It behaves similarly to
@@ -100,8 +100,8 @@ func (js *JSONs) AppendVal(j json.JSON) {
 	if err != nil {
 		colexecerror.ExpectedError(err)
 	}
-	b.maxSetIndex = b.Len()
 	b.offsets = append(b.offsets, int32(len(b.data)))
+	b.maxSetLength = b.Len()
 }
 
 // String is used for debugging purposes.


### PR DESCRIPTION
This patch modifies `Bytes` columns to keep track of the number of
set elements, rather than the maximum set index (as was the case
previously). Keeping track of the length rather than an index means
that the value is valid even when the `Bytes` object is initially
constructed or is reset, whereas the default `maxSetIndex` value
(zero) doesn't make sense when there are no elements.

This patch also removes some extra logic which is no longer necessary
for maintaining the non-decreasing invariant for the flat bytes buffer.
First, the offsets no longer have to be zeroed out when `Reset` is called.
And second, the entire `offsets` slice no longer has to be updated when
`SetLength` is called - instead, the offsets only have to be updated
starting from `maxSetLength + 1`.

See #42054

Release note: None