### PR TITLE
sqlproxy: fallback to name routing when directory lookup fails

### DIFF
--- a/pkg/ccl/sqlproxyccl/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/BUILD.bazel
@@ -59,6 +59,7 @@ go_test(
         "//pkg/base",
         "//pkg/ccl/kvccl/kvtenantccl",
         "//pkg/ccl/sqlproxyccl/denylist",
+        "//pkg/ccl/sqlproxyccl/tenant",
         "//pkg/ccl/sqlproxyccl/tenantdirsvr",
         "//pkg/ccl/utilccl",
         "//pkg/roachpb",
@@ -75,12 +76,15 @@ go_test(
         "//pkg/util/log",
         "//pkg/util/randutil",
         "//pkg/util/stop",
+        "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_jackc_pgconn//:pgconn",
         "@com_github_jackc_pgproto3_v2//:pgproto3",
         "@com_github_jackc_pgx_v4//:pgx",
         "@com_github_stretchr_testify//require",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
     ],
 )
 

--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/kvccl/kvtenantccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/denylist"
+	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/tenant"
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/tenantdirsvr"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -34,11 +35,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/jackc/pgproto3/v2"
 	"github.com/jackc/pgx/v4"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // To ensure tenant startup code is included.
@@ -47,23 +51,726 @@ var _ = kvtenantccl.Connector{}
 const frontendError = "Frontend error!"
 const backendError = "Backend error!"
 
-func hookBackendDial(
-	f func(
+// notFoundTenantID is used to trigger a NotFound error when it is requested in
+// the test directory server.
+const notFoundTenantID = 99
+
+func TestLongDBName(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	te := newTester()
+	defer te.Close()
+
+	defer testutils.TestingHook(&backendDial, func(
+		_ *pgproto3.StartupMessage, outgoingAddr string, _ *tls.Config,
+	) (net.Conn, error) {
+		require.Equal(t, outgoingAddr, "dim-dog-28-0.cockroachdb:26257")
+		return nil, newErrorf(codeParamsRoutingFailed, "boom")
+	})()
+
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+	s, addr := newSecureProxyServer(ctx, t, stopper, &ProxyOptions{RoutingRule: "{{clusterName}}-0.cockroachdb:26257"})
+
+	longDB := strings.Repeat("x", 70) // 63 is limit
+	pgurl := fmt.Sprintf("postgres://unused:unused@%s/%s?options=--cluster=dim-dog-28", addr, longDB)
+	te.TestConnectErr(ctx, t, pgurl, codeParamsRoutingFailed, "boom")
+	require.Equal(t, int64(1), s.metrics.RoutingErrCount.Count())
+}
+
+// TestBackendDownRetry tries to connect to a unavailable backend. After 3
+// failed attempts, a "tenant not found" error simulates the tenant being
+// deleted.
+func TestBackendDownRetry(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	te := newTester()
+	defer te.Close()
+
+	callCount := 0
+	defer testutils.TestingHook(&backendLookupAddr, func(addr string) (string, error) {
+		callCount++
+		if callCount >= 3 {
+			return "", errors.New("tenant not found")
+		}
+		return addr, nil
+	})()
+
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+	_, addr := newSecureProxyServer(ctx, t, stopper, &ProxyOptions{RoutingRule: "undialable%$!@$"})
+
+	// Valid connection, but no backend server running.
+	pgurl := fmt.Sprintf("postgres://unused:unused@%s/db?options=--cluster=dim-dog-28", addr)
+	te.TestConnectErr(ctx, t, pgurl, codeParamsRoutingFailed, "cluster dim-dog-28 not found")
+	require.Equal(t, 3, callCount)
+}
+
+func TestFailedConnection(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	te := newTester()
+	defer te.Close()
+
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+	s, addr := newSecureProxyServer(ctx, t, stopper, &ProxyOptions{RoutingRule: "undialable%$!@$"})
+
+	// TODO(asubiotto): consider using datadriven for these, especially if the
+	// proxy becomes more complex.
+
+	_, p, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+	u := fmt.Sprintf("postgres://unused:unused@localhost:%s/", p)
+
+	// Unencrypted connections bounce.
+	for _, sslmode := range []string{"disable", "allow"} {
+		te.TestConnectErr(
+			ctx, t, u+"?options=--cluster=dim-dog-28&sslmode="+sslmode,
+			codeUnexpectedInsecureStartupMessage, "server requires encryption",
+		)
+	}
+	require.Equal(t, int64(0), s.metrics.RoutingErrCount.Count())
+
+	// TenantID rejected as malformed.
+	te.TestConnectErr(
+		ctx, t, u+"?options=--cluster=dim&sslmode=require",
+		codeParamsRoutingFailed, "invalid cluster name",
+	)
+	require.Equal(t, int64(1), s.metrics.RoutingErrCount.Count())
+
+	// No TenantID.
+	te.TestConnectErr(
+		ctx, t, u+"?sslmode=require",
+		codeParamsRoutingFailed, "missing cluster name",
+	)
+	require.Equal(t, int64(2), s.metrics.RoutingErrCount.Count())
+}
+
+func TestUnexpectedError(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	te := newTester()
+	defer te.Close()
+
+	// Set up a Server whose FrontendAdmitter function always errors with a
+	// non-codeError error.
+	defer testutils.TestingHook(&frontendAdmit, func(
+		conn net.Conn, incomingTLSConfig *tls.Config,
+	) (net.Conn, *pgproto3.StartupMessage, error) {
+		log.Infof(context.Background(), "frontendAdmit returning unexpected error")
+		return conn, nil, errors.New("unexpected error")
+	})()
+
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+	_, addr := newProxyServer(ctx, t, stopper, &ProxyOptions{})
+
+	u := fmt.Sprintf("postgres://root:admin@%s/?sslmode=disable&connect_timeout=5", addr)
+
+	// Time how long it takes for pgx.Connect to return. If the proxy handles
+	// errors appropriately, pgx.Connect should return near immediately
+	// because the server should close the connection. If not, it may take up
+	// to the 5s connect_timeout for pgx.Connect to give up.
+	start := timeutil.Now()
+	_, err := pgx.Connect(ctx, u)
+	require.Error(t, err)
+	t.Log(err)
+	elapsed := timeutil.Since(start)
+	if elapsed >= 5*time.Second {
+		t.Errorf("pgx.Connect took %s to error out", elapsed)
+	}
+}
+
+func TestProxyAgainstSecureCRDB(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	te := newTester()
+	defer te.Close()
+
+	sql, db, _ := serverutils.StartServer(t, base.TestServerArgs{Insecure: false})
+	sql.(*server.TestServer).PGServer().TestingSetTrustClientProvidedRemoteAddr(true)
+	defer sql.Stopper().Stop(ctx)
+
+	sqlDB := sqlutils.MakeSQLRunner(db)
+	sqlDB.Exec(t, `CREATE USER bob WITH PASSWORD 'builder'`)
+
+	s, addr := newSecureProxyServer(
+		ctx, t, sql.Stopper(), &ProxyOptions{RoutingRule: sql.ServingSQLAddr(), SkipVerify: true},
+	)
+
+	url := fmt.Sprintf("postgres://bob:wrong@%s/dim-dog-28.defaultdb?sslmode=require", addr)
+	te.TestConnectErr(ctx, t, url, 0, "ERROR: password authentication failed for user bob")
+
+	url = fmt.Sprintf("postgres://bob@%s/dim-dog-28.defaultdb?sslmode=require", addr)
+	te.TestConnectErr(ctx, t, url, 0, "ERROR: password authentication failed for user bob")
+
+	url = fmt.Sprintf("postgres://bob:builder@%s/dim-dog-28.defaultdb?sslmode=require", addr)
+	te.TestConnect(ctx, t, url, func(conn *pgx.Conn) {
+		require.Equal(t, int64(1), s.metrics.CurConnCount.Value())
+		require.NoError(t, runTestQuery(ctx, conn))
+	})
+	require.Equal(t, int64(1), s.metrics.SuccessfulConnCount.Count())
+	require.Equal(t, int64(2), s.metrics.AuthFailedCount.Count())
+}
+
+func TestProxyTLSClose(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	// NB: The leaktest call is an important part of this test. We're
+	// verifying that no goroutines are leaked, despite calling Close an
+	// underlying TCP connection (rather than the TLSConn that wraps it).
+
+	ctx := context.Background()
+	te := newTester()
+	defer te.Close()
+
+	sql, db, _ := serverutils.StartServer(t, base.TestServerArgs{Insecure: false})
+	sql.(*server.TestServer).PGServer().TestingSetTrustClientProvidedRemoteAddr(true)
+	defer sql.Stopper().Stop(ctx)
+
+	sqlDB := sqlutils.MakeSQLRunner(db)
+	sqlDB.Exec(t, `CREATE USER bob WITH PASSWORD 'builder'`)
+
+	var proxyIncomingConn atomic.Value // *conn
+	originalFrontendAdmit := frontendAdmit
+	defer testutils.TestingHook(&frontendAdmit, func(
+		conn net.Conn, incomingTLSConfig *tls.Config,
+	) (net.Conn, *pgproto3.StartupMessage, error) {
+		proxyIncomingConn.Store(conn)
+		return originalFrontendAdmit(conn, incomingTLSConfig)
+	})()
+
+	s, addr := newSecureProxyServer(
+		ctx, t, sql.Stopper(), &ProxyOptions{RoutingRule: sql.ServingSQLAddr(), SkipVerify: true},
+	)
+
+	url := fmt.Sprintf("postgres://bob:builder@%s/dim-dog-28.defaultdb?sslmode=require", addr)
+
+	conn, err := pgx.Connect(ctx, url)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), s.metrics.CurConnCount.Value())
+	require.NoError(t, runTestQuery(ctx, conn))
+
+	// Cut the connection.
+	incomingConn, ok := proxyIncomingConn.Load().(*proxyConn)
+	require.True(t, ok)
+	require.NoError(t, incomingConn.Close())
+	<-incomingConn.done() // should immediately proceed
+	_ = conn.Close(ctx)
+
+	require.Equal(t, int64(1), s.metrics.SuccessfulConnCount.Count())
+	require.Equal(t, int64(0), s.metrics.AuthFailedCount.Count())
+}
+
+func TestProxyModifyRequestParams(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	te := newTester()
+	defer te.Close()
+
+	sql, _, _ := serverutils.StartServer(t, base.TestServerArgs{Insecure: false})
+	sql.(*server.TestServer).PGServer().TestingSetTrustClientProvidedRemoteAddr(true)
+	defer sql.Stopper().Stop(ctx)
+
+	outgoingTLSConfig, err := sql.RPCContext().GetClientTLSConfig()
+	require.NoError(t, err)
+	proxyOutgoingTLSConfig := outgoingTLSConfig.Clone()
+	proxyOutgoingTLSConfig.InsecureSkipVerify = true
+
+	originalBackendDial := backendDial
+	defer testutils.TestingHook(&backendDial, func(
 		msg *pgproto3.StartupMessage, outgoingAddress string, tlsConfig *tls.Config,
-	) (net.Conn, error),
-) func() {
-	return testutils.TestingHook(&backendDial, f)
+	) (net.Conn, error) {
+		params := msg.Parameters
+		authToken, ok := params["authToken"]
+		require.True(t, ok)
+		require.Equal(t, "abc123", authToken)
+		user, ok := params["user"]
+		require.True(t, ok)
+		require.Equal(t, "bogususer", user)
+		require.Contains(t, params, "user")
+
+		// NB: This test will fail unless the user used between the proxy
+		// and the backend is changed to a user that actually exists.
+		delete(params, "authToken")
+		params["user"] = "root"
+
+		return originalBackendDial(msg, sql.ServingSQLAddr(), proxyOutgoingTLSConfig)
+	})()
+
+	s, proxyAddr := newSecureProxyServer(ctx, t, sql.Stopper(), &ProxyOptions{})
+
+	u := fmt.Sprintf("postgres://bogususer@%s/?sslmode=require&authToken=abc123&options=--cluster=dim-dog-28", proxyAddr)
+	te.TestConnect(ctx, t, u, func(conn *pgx.Conn) {
+		require.Equal(t, int64(1), s.metrics.CurConnCount.Value())
+		require.NoError(t, runTestQuery(ctx, conn))
+	})
 }
-func hookFrontendAdmit(
-	f func(conn net.Conn, incomingTLSConfig *tls.Config) (net.Conn, *pgproto3.StartupMessage, error),
-) func() {
-	return testutils.TestingHook(&frontendAdmit, f)
+
+func TestInsecureProxy(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	te := newTester()
+	defer te.Close()
+
+	sql, db, _ := serverutils.StartServer(t, base.TestServerArgs{Insecure: false})
+	sql.(*server.TestServer).PGServer().TestingSetTrustClientProvidedRemoteAddr(true)
+	defer sql.Stopper().Stop(ctx)
+
+	sqlDB := sqlutils.MakeSQLRunner(db)
+	sqlDB.Exec(t, `CREATE USER bob WITH PASSWORD 'builder'`)
+
+	s, addr := newProxyServer(
+		ctx, t, sql.Stopper(), &ProxyOptions{RoutingRule: sql.ServingSQLAddr(), SkipVerify: true},
+	)
+
+	url := fmt.Sprintf("postgres://bob:wrong@%s?sslmode=disable&options=--cluster=dim-dog-28", addr)
+	te.TestConnectErr(ctx, t, url, 0, "ERROR: password authentication failed for user bob")
+
+	url = fmt.Sprintf("postgres://bob:builder@%s/?sslmode=disable&options=--cluster=dim-dog-28", addr)
+	te.TestConnect(ctx, t, url, func(conn *pgx.Conn) {
+		require.NoError(t, runTestQuery(ctx, conn))
+	})
+	require.Equal(t, int64(1), s.metrics.AuthFailedCount.Count())
+	require.Equal(t, int64(1), s.metrics.SuccessfulConnCount.Count())
 }
-func hookSendErrToClient(f func(conn net.Conn, err error)) func() {
-	return testutils.TestingHook(&sendErrToClient, f)
+
+func TestInsecureDoubleProxy(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	te := newTester()
+	defer te.Close()
+
+	sql, _, _ := serverutils.StartServer(t, base.TestServerArgs{Insecure: true})
+	sql.(*server.TestServer).PGServer().TestingSetTrustClientProvidedRemoteAddr(true)
+	defer sql.Stopper().Stop(ctx)
+
+	// Test multiple proxies:  proxyB -> proxyA -> tc
+	_, proxyA := newProxyServer(ctx, t, sql.Stopper(),
+		&ProxyOptions{RoutingRule: sql.ServingSQLAddr(), Insecure: true},
+	)
+	_, proxyB := newProxyServer(ctx, t, sql.Stopper(),
+		&ProxyOptions{RoutingRule: proxyA, Insecure: true},
+	)
+
+	url := fmt.Sprintf("postgres://root:admin@%s/dim-dog-28.dim-dog-29.defaultdb?sslmode=disable", proxyB)
+	te.TestConnect(ctx, t, url, func(conn *pgx.Conn) {
+		require.NoError(t, runTestQuery(ctx, conn))
+	})
 }
-func hookAuthenticate(f func(clientConn, crdbConn net.Conn) error) func() {
-	return testutils.TestingHook(&authenticate, f)
+
+func TestErroneousFrontend(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	te := newTester()
+	defer te.Close()
+
+	defer testutils.TestingHook(&frontendAdmit, func(
+		conn net.Conn, incomingTLSConfig *tls.Config,
+	) (net.Conn, *pgproto3.StartupMessage, error) {
+		return conn, nil, errors.New(frontendError)
+	})()
+
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+	_, addr := newProxyServer(ctx, t, stopper, &ProxyOptions{})
+
+	url := fmt.Sprintf("postgres://bob:builder@%s/?sslmode=disable&options=--cluster=dim-dog-28", addr)
+
+	// Generic message here as the Frontend's error is not codeError and
+	// by default we don't pass back error's text. The startup message doesn't get
+	// processed in this case.
+	te.TestConnectErr(ctx, t, url, 0, "connection reset by peer|failed to receive message")
+}
+
+func TestErroneousBackend(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	te := newTester()
+	defer te.Close()
+
+	defer testutils.TestingHook(&backendDial, func(
+		msg *pgproto3.StartupMessage, outgoingAddress string, tlsConfig *tls.Config,
+	) (net.Conn, error) {
+		return nil, errors.New(backendError)
+	})()
+
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+	_, addr := newProxyServer(ctx, t, stopper, &ProxyOptions{})
+
+	url := fmt.Sprintf("postgres://bob:builder@%s/?sslmode=disable&options=--cluster=dim-dog-28", addr)
+
+	// Generic message here as the Backend's error is not codeError and
+	// by default we don't pass back error's text. The startup message has already
+	// been processed.
+	te.TestConnectErr(ctx, t, url, 0, "failed to receive message")
+}
+
+func TestProxyRefuseConn(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	te := newTester()
+	defer te.Close()
+
+	defer testutils.TestingHook(&backendDial, func(
+		msg *pgproto3.StartupMessage, outgoingAddress string, tlsConfig *tls.Config,
+	) (net.Conn, error) {
+		return nil, newErrorf(codeProxyRefusedConnection, "too many attempts")
+	})()
+
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+	s, addr := newSecureProxyServer(ctx, t, stopper, &ProxyOptions{})
+
+	url := fmt.Sprintf("postgres://root:admin@%s?sslmode=require&options=--cluster=dim-dog-28", addr)
+	te.TestConnectErr(ctx, t, url, codeProxyRefusedConnection, "too many attempts")
+	require.Equal(t, int64(1), s.metrics.RefusedConnCount.Count())
+	require.Equal(t, int64(0), s.metrics.SuccessfulConnCount.Count())
+	require.Equal(t, int64(0), s.metrics.AuthFailedCount.Count())
+}
+
+func TestDenylistUpdate(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	te := newTester()
+	defer te.Close()
+
+	denyList, err := ioutil.TempFile("", "*_denylist.yml")
+	require.NoError(t, err)
+
+	sql, _, _ := serverutils.StartServer(t, base.TestServerArgs{Insecure: false})
+	sql.(*server.TestServer).PGServer().TestingSetTrustClientProvidedRemoteAddr(true)
+	defer sql.Stopper().Stop(ctx)
+
+	outgoingTLSConfig, err := sql.RPCContext().GetClientTLSConfig()
+	require.NoError(t, err)
+	proxyOutgoingTLSConfig := outgoingTLSConfig.Clone()
+	proxyOutgoingTLSConfig.InsecureSkipVerify = true
+
+	originalBackendDial := backendDial
+	defer testutils.TestingHook(&backendDial, func(
+		msg *pgproto3.StartupMessage, outgoingAddress string, tlsConfig *tls.Config,
+	) (net.Conn, error) {
+		time.AfterFunc(100*time.Millisecond, func() {
+			dlf := denylist.File{
+				Denylist: []*denylist.DenyEntry{
+					{
+						Entity:     denylist.DenyEntity{Type: denylist.IPAddrType, Item: "127.0.0.1"},
+						Expiration: timeutil.Now().Add(time.Minute),
+						Reason:     "test-denied",
+					},
+				},
+			}
+
+			bytes, err := dlf.Serialize()
+			require.NoError(t, err)
+			_, err = denyList.Write(bytes)
+			require.NoError(t, err)
+		})
+		return originalBackendDial(msg, sql.ServingSQLAddr(), proxyOutgoingTLSConfig)
+	})()
+
+	s, addr := newSecureProxyServer(ctx, t, sql.Stopper(), &ProxyOptions{
+		Denylist:           denyList.Name(),
+		PollConfigInterval: 10 * time.Millisecond,
+	})
+	defer func() { _ = os.Remove(denyList.Name()) }()
+
+	url := fmt.Sprintf("postgres://root:admin@%s/defaultdb_29?sslmode=require&options=--cluster=dim-dog-28", addr)
+	te.TestConnect(ctx, t, url, func(conn *pgx.Conn) {
+		require.Eventuallyf(
+			t,
+			func() bool {
+				_, err = conn.Exec(context.Background(), "SELECT 1")
+				return err != nil
+			},
+			time.Second, 5*time.Millisecond,
+			"Expected the connection to eventually fail",
+		)
+		require.Regexp(t, "unexpected EOF|connection reset by peer", err.Error())
+		require.Equal(t, int64(1), s.metrics.ExpiredClientConnCount.Count())
+	})
+}
+
+func TestProxyAgainstSecureCRDBWithIdleTimeout(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	te := newTester()
+	defer te.Close()
+
+	sql, _, _ := serverutils.StartServer(t, base.TestServerArgs{Insecure: false})
+	sql.(*server.TestServer).PGServer().TestingSetTrustClientProvidedRemoteAddr(true)
+	defer sql.Stopper().Stop(ctx)
+
+	outgoingTLSConfig, err := sql.RPCContext().GetClientTLSConfig()
+	require.NoError(t, err)
+	proxyOutgoingTLSConfig := outgoingTLSConfig.Clone()
+	proxyOutgoingTLSConfig.InsecureSkipVerify = true
+
+	idleTimeout, _ := time.ParseDuration("0.5s")
+	originalBackendDial := backendDial
+	defer testutils.TestingHook(&backendDial, func(
+		msg *pgproto3.StartupMessage, outgoingAddress string, tlsConfig *tls.Config,
+	) (net.Conn, error) {
+		return originalBackendDial(msg, sql.ServingSQLAddr(), proxyOutgoingTLSConfig)
+	})()
+
+	s, addr := newSecureProxyServer(ctx, t, sql.Stopper(), &ProxyOptions{IdleTimeout: idleTimeout})
+
+	url := fmt.Sprintf("postgres://root:admin@%s/?sslmode=require&options=--cluster=dim-dog-28", addr)
+	te.TestConnect(ctx, t, url, func(conn *pgx.Conn) {
+		require.Equal(t, int64(1), s.metrics.CurConnCount.Value())
+
+		var n int
+		err = conn.QueryRow(ctx, "SELECT $1::int", 1).Scan(&n)
+		require.NoError(t, err)
+		require.EqualValues(t, 1, n)
+
+		time.Sleep(idleTimeout * 2)
+		err = conn.QueryRow(context.Background(), "SELECT $1::int", 1).Scan(&n)
+		require.EqualError(t, err, "unexpected EOF")
+		require.Equal(t, int64(1), s.metrics.IdleDisconnectCount.Count())
+		require.Equal(t, int64(1), s.metrics.SuccessfulConnCount.Count())
+	})
+}
+
+func TestDirectoryConnect(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	te := newTester()
+	defer te.Close()
+
+	srv, _, _ := serverutils.StartServer(t, base.TestServerArgs{Insecure: true})
+	srv.(*server.TestServer).PGServer().TestingSetTrustClientProvidedRemoteAddr(true)
+	defer srv.Stopper().Stop(ctx)
+
+	// Create tenant 28.
+	sqlConn := srv.InternalExecutor().(*sql.InternalExecutor)
+	_, err := sqlConn.Exec(ctx, "", nil, "SELECT crdb_internal.create_tenant(28)")
+	require.NoError(t, err)
+
+	// New test directory server.
+	dirStopper1, tdsAddr := newDirectoryServer(ctx, t, srv, &net.TCPAddr{})
+
+	// New proxy server using the directory. Define both the directory and the
+	// routing rule so that fallback to the routing rule can be tested.
+	opts := &ProxyOptions{
+		RoutingRule:   srv.ServingSQLAddr(),
+		DirectoryAddr: tdsAddr.String(),
+		Insecure:      true,
+	}
+	_, addr := newProxyServer(ctx, t, srv.Stopper(), opts)
+
+	t.Run("fallback when tenant not found", func(t *testing.T) {
+		defer testutils.TestingHook(&backendLookupAddr, func(addr string) (string, error) {
+			// Expect fallback.
+			require.Equal(t, srv.ServingSQLAddr(), addr)
+			return addr, nil
+		})()
+
+		url := fmt.Sprintf(
+			"postgres://root:admin@%s/?sslmode=disable&options=--cluster=tenant-cluster-%d",
+			addr, notFoundTenantID)
+		te.TestConnect(ctx, t, url, func(*pgx.Conn) {})
+	})
+
+	t.Run("fail to connect to backend", func(t *testing.T) {
+		// Retry the backend connection 3 times before permanent failure.
+		countFailures := 0
+		defer testutils.TestingHook(&backendDial, func(
+			*pgproto3.StartupMessage, string, *tls.Config,
+		) (net.Conn, error) {
+			countFailures++
+			if countFailures >= 3 {
+				return nil, newErrorf(codeBackendDisconnected, "backend disconnected")
+			}
+			return nil, newErrorf(codeBackendDown, "backend down")
+		})()
+
+		// Ensure that Directory.ReportFailure is being called correctly.
+		countReports := 0
+		defer testutils.TestingHook(&reportFailureToDirectory, func(
+			ctx context.Context, tenantID roachpb.TenantID, ip string, directory *tenant.Directory,
+		) error {
+			require.Equal(t, roachpb.MakeTenantID(28), tenantID)
+			addrs, err := directory.LookupTenantIPs(ctx, tenantID)
+			require.NoError(t, err)
+			require.Len(t, addrs, 1)
+			require.Equal(t, addrs[0], ip)
+
+			countReports++
+			err = directory.ReportFailure(ctx, tenantID, ip)
+			require.NoError(t, err)
+			return err
+		})()
+
+		url := fmt.Sprintf("postgres://root:admin@%s/?sslmode=disable&options=--cluster=tenant-cluster-28", addr)
+		te.TestConnectErr(ctx, t, url, codeBackendDisconnected, "backend disconnected")
+		require.Equal(t, 3, countFailures)
+		require.Equal(t, 2, countReports)
+	})
+
+	t.Run("successful connection", func(t *testing.T) {
+		url := fmt.Sprintf("postgres://root:admin@%s/?sslmode=disable&options=--cluster=tenant-cluster-28", addr)
+		te.TestConnect(ctx, t, url, func(conn *pgx.Conn) {
+			require.NoError(t, runTestQuery(ctx, conn))
+		})
+	})
+
+	// Stop the directory server and the tenant SQL process started earlier. This
+	// tests whether the proxy can recover when the directory server and a SQL
+	// tenant pod restart.
+	dirStopper1.Stop(ctx)
+
+	t.Run("successful connection after restart", func(t *testing.T) {
+		// Pass the same tdsAddr used to start up the directory server previously,
+		// since it's not allowed to jump to a different address.
+		dirStopper2, _ := newDirectoryServer(ctx, t, srv, tdsAddr)
+		defer dirStopper2.Stop(ctx)
+
+		// Try to connect through the proxy again. This may take several tries
+		// in order to clear the proxy directory of the old SQL tenant process
+		// address and replace with the new.
+		require.Eventually(t, func() bool {
+			url := fmt.Sprintf("postgres://root:admin@%s/?sslmode=disable&options=--cluster=tenant-cluster-28", addr)
+			conn, err := pgx.Connect(ctx, url)
+			if err != nil {
+				return false
+			}
+			defer func() { _ = conn.Close(ctx) }()
+			require.NoError(t, runTestQuery(ctx, conn))
+			return true
+		}, 30*time.Second, 100*time.Millisecond)
+	})
+}
+
+type tester struct {
+	// mu synchronizes the authenticated and errToClient fields, since they
+	// need to be set on background goroutines, and will cause race builds to
+	// fail if not synchronized.
+	mu struct {
+		syncutil.Mutex
+		authenticated bool
+		errToClient   *codeError
+	}
+
+	restoreBackendLookupAddr func()
+	restoreAuthenticate      func()
+	restoreSendErrToClient   func()
+}
+
+func newTester() *tester {
+	te := &tester{}
+
+	// Override default lookup function so that it does not use net.LookupAddr.
+	te.restoreBackendLookupAddr =
+		testutils.TestingHook(&backendLookupAddr, func(addr string) (string, error) {
+			return addr, nil
+		})
+
+	// Record successful connection and authentication.
+	originalAuthenticate := authenticate
+	te.restoreAuthenticate =
+		testutils.TestingHook(&authenticate, func(clientConn, crdbConn net.Conn) error {
+			err := originalAuthenticate(clientConn, crdbConn)
+			te.setAuthenticated(err == nil)
+			return err
+		})
+
+	// Capture any error sent to the client.
+	originalSendErrToClient := sendErrToClient
+	te.restoreSendErrToClient =
+		testutils.TestingHook(&sendErrToClient, func(conn net.Conn, err error) {
+			if codeErr, ok := err.(*codeError); ok {
+				te.setErrToClient(codeErr)
+			}
+			originalSendErrToClient(conn, err)
+		})
+
+	return te
+}
+
+func (te *tester) Close() {
+	te.restoreBackendLookupAddr()
+	te.restoreAuthenticate()
+	te.restoreSendErrToClient()
+}
+
+// Authenticated returns true if the connection was successfully established and
+// authenticated.
+func (te *tester) Authenticated() bool {
+	te.mu.Lock()
+	defer te.mu.Unlock()
+	return te.mu.authenticated
+}
+
+func (te *tester) setAuthenticated(auth bool) {
+	te.mu.Lock()
+	defer te.mu.Unlock()
+	te.mu.authenticated = auth
+}
+
+// ErrToClient returns any error sent by the proxy to the client.
+func (te *tester) ErrToClient() *codeError {
+	te.mu.Lock()
+	defer te.mu.Unlock()
+	return te.mu.errToClient
+}
+
+func (te *tester) setErrToClient(codeErr *codeError) {
+	te.mu.Lock()
+	defer te.mu.Unlock()
+	te.mu.errToClient = codeErr
+}
+
+// TestConnect connects to the given URL and invokes the given callback with the
+// established connection. Use TestConnectErr if connection establishment isn't
+// expected to succeed.
+func (te *tester) TestConnect(ctx context.Context, t *testing.T, url string, fn func(*pgx.Conn)) {
+	t.Helper()
+	te.setAuthenticated(false)
+	te.setErrToClient(nil)
+	conn, err := pgx.Connect(ctx, url)
+	require.NoError(t, err)
+	fn(conn)
+	require.NoError(t, conn.Close(ctx))
+	require.True(t, te.Authenticated())
+	require.Nil(t, te.ErrToClient())
+}
+
+// TestConnectErr tries to establish a connection to the given URL. It expects
+// an error to occur and validates the error matches the provided information.
+func (te *tester) TestConnectErr(
+	ctx context.Context, t *testing.T, url string, expCode errorCode, expErr string,
+) {
+	t.Helper()
+	te.setAuthenticated(false)
+	te.setErrToClient(nil)
+	conn, err := pgx.Connect(ctx, url)
+	if err == nil {
+		_ = conn.Close(ctx)
+	}
+	require.Regexp(t, expErr, err.Error())
+	require.False(t, te.Authenticated())
+	if expCode != 0 {
+		require.NotNil(t, te.ErrToClient())
+		require.Equal(t, expCode, te.ErrToClient().code)
+	}
 }
 
 func newSecureProxyServer(
@@ -73,7 +780,7 @@ func newSecureProxyServer(
 	const _ = `
 openssl genrsa -out testdata/testserver.key 2048
 openssl req -new -x509 -sha256 -key testdata/testserver.key -out testdata/testserver.crt \
-  -days 3650 -config testdata/testserver_config.cnf	
+  -days 3650 -config testdata/testserver_config.cnf
 `
 	opts.ListenKey = "testdata/testserver.key"
 	opts.ListenCert = "testdata/testserver.crt"
@@ -110,572 +817,6 @@ func runTestQuery(ctx context.Context, conn *pgx.Conn) error {
 	return nil
 }
 
-type assertCtx struct {
-	emittedCode *errorCode
-}
-
-func makeAssertCtx() assertCtx {
-	var emittedCode errorCode = -1
-	return assertCtx{
-		emittedCode: &emittedCode,
-	}
-}
-
-func (ac *assertCtx) onSendErrToClient(code errorCode) {
-	*ac.emittedCode = code
-}
-
-func (ac *assertCtx) assertConnectErr(
-	ctx context.Context, t *testing.T, prefix, suffix string, expCode errorCode, expErr string,
-) {
-	t.Helper()
-	*ac.emittedCode = -1
-	t.Run(suffix, func(t *testing.T) {
-		conn, err := pgx.Connect(ctx, prefix+suffix)
-		if err == nil {
-			_ = conn.Close(ctx)
-		}
-		require.Contains(t, err.Error(), expErr)
-		require.Equal(t, expCode, *ac.emittedCode)
-	})
-}
-
-func TestLongDBName(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	ctx := context.Background()
-
-	defer hookBackendDial(func(_ *pgproto3.StartupMessage, outgoingAddr string, _ *tls.Config) (net.Conn, error) {
-		require.Equal(t, outgoingAddr, "dim-dog-28-0.cockroachdb:26257")
-		return nil, newErrorf(codeParamsRoutingFailed, "boom")
-	})()
-
-	ac := makeAssertCtx()
-	originalSendErrToClient := sendErrToClient
-	defer hookSendErrToClient(func(conn net.Conn, err error) {
-		if codeErr, ok := err.(*codeError); ok {
-			ac.onSendErrToClient(codeErr.code)
-		}
-		originalSendErrToClient(conn, err)
-	})()
-
-	stopper := stop.NewStopper()
-	defer stopper.Stop(context.Background())
-
-	s, addr := newSecureProxyServer(ctx, t, stopper, &ProxyOptions{RoutingRule: "{{clusterName}}-0.cockroachdb:26257"})
-
-	longDB := strings.Repeat("x", 70) // 63 is limit
-	pgurl := fmt.Sprintf("postgres://unused:unused@%s/%s?options=--cluster=dim-dog-28", addr, longDB)
-	ac.assertConnectErr(ctx, t, pgurl, "" /* suffix */, codeParamsRoutingFailed, "boom")
-	require.Equal(t, int64(1), s.metrics.RoutingErrCount.Count())
-}
-
-func TestFailedConnection(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	ctx := context.Background()
-
-	// TODO(asubiotto): consider using datadriven for these, especially if the
-	// proxy becomes more complex.
-
-	var originalSendErrToClient = sendErrToClient
-	ac := makeAssertCtx()
-	defer hookSendErrToClient(func(conn net.Conn, err error) {
-		if codeErr, ok := err.(*codeError); ok {
-			ac.onSendErrToClient(codeErr.code)
-		}
-		originalSendErrToClient(conn, err)
-	})()
-
-	stopper := stop.NewStopper()
-	defer stopper.Stop(context.Background())
-
-	s, addr := newSecureProxyServer(ctx, t, stopper, &ProxyOptions{RoutingRule: "undialable%$!@$"})
-
-	_, p, err := net.SplitHostPort(addr)
-	require.NoError(t, err)
-	u := fmt.Sprintf("postgres://unused:unused@localhost:%s/", p)
-	// Valid connections, but no backend server running.
-	for _, sslmode := range []string{"require", "prefer"} {
-		ac.assertConnectErr(
-			ctx, t, u, "?options=--cluster=dim-dog-28&sslmode="+sslmode,
-			codeBackendDown, "unable to reach backend SQL server",
-		)
-	}
-
-	ac.assertConnectErr(
-		ctx, t, u, "?options=--cluster=dim-dog-28&sslmode=verify-ca&sslrootcert=testdata/testserver.crt",
-		codeBackendDown, "unable to reach backend SQL server",
-	)
-	ac.assertConnectErr(
-		ctx, t, u, "?options=--cluster=dim-dog-28&sslmode=verify-full&sslrootcert=testdata/testserver.crt",
-		codeBackendDown, "unable to reach backend SQL server",
-	)
-	require.Equal(t, int64(4), s.metrics.BackendDownCount.Count())
-
-	// Unencrypted connections bounce.
-	for _, sslmode := range []string{"disable", "allow"} {
-		ac.assertConnectErr(
-			ctx, t, u, "?options=--cluster=dim-dog-28&sslmode="+sslmode,
-			codeUnexpectedInsecureStartupMessage, "server requires encryption",
-		)
-	}
-	require.Equal(t, int64(0), s.metrics.RoutingErrCount.Count())
-	// TenantID rejected as malformed.
-	ac.assertConnectErr(
-		ctx, t, u, "?options=--cluster=dim&sslmode=require",
-		codeParamsRoutingFailed, "invalid cluster name",
-	)
-	require.Equal(t, int64(1), s.metrics.RoutingErrCount.Count())
-	// No TenantID.
-	ac.assertConnectErr(
-		ctx, t, u, "?sslmode=require",
-		codeParamsRoutingFailed, "missing cluster name",
-	)
-	require.Equal(t, int64(2), s.metrics.RoutingErrCount.Count())
-}
-
-func TestUnexpectedError(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	ctx := context.Background()
-
-	// Set up a Server whose FrontendAdmitter function always errors with a
-	// non-codeError error.
-	defer hookFrontendAdmit(
-		func(conn net.Conn, incomingTLSConfig *tls.Config) (net.Conn, *pgproto3.StartupMessage, error) {
-			log.Infof(context.Background(), "frontendAdmit returning unexpected error")
-			return conn, nil, errors.New("unexpected error")
-		})()
-
-	stopper := stop.NewStopper()
-	defer stopper.Stop(ctx)
-
-	_, addr := newProxyServer(ctx, t, stopper, &ProxyOptions{})
-
-	u := fmt.Sprintf("postgres://root:admin@%s/?sslmode=disable&connect_timeout=5", addr)
-
-	// Time how long it takes for pgx.Connect to return. If the proxy handles
-	// errors appropriately, pgx.Connect should return near immediately
-	// because the server should close the connection. If not, it may take up
-	// to the 5s connect_timeout for pgx.Connect to give up.
-	start := timeutil.Now()
-	_, err := pgx.Connect(ctx, u)
-	require.Error(t, err)
-	t.Log(err)
-	elapsed := timeutil.Since(start)
-	if elapsed >= 5*time.Second {
-		t.Errorf("pgx.Connect took %s to error out", elapsed)
-	}
-}
-
-func TestProxyAgainstSecureCRDB(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	ctx := context.Background()
-
-	sql, db, _ := serverutils.StartServer(t, base.TestServerArgs{Insecure: false})
-	sql.(*server.TestServer).PGServer().TestingSetTrustClientProvidedRemoteAddr(true)
-
-	sqlDB := sqlutils.MakeSQLRunner(db)
-	sqlDB.Exec(t, `CREATE USER bob WITH PASSWORD 'builder'`)
-
-	var connSuccess bool
-	originalAuthenticate := authenticate
-	defer hookAuthenticate(func(clientConn, crdbConn net.Conn) error {
-		err := originalAuthenticate(clientConn, crdbConn)
-		connSuccess = err == nil
-		return err
-	})()
-
-	defer sql.Stopper().Stop(ctx)
-
-	s, addr := newSecureProxyServer(
-		ctx, t, sql.Stopper(), &ProxyOptions{RoutingRule: sql.ServingSQLAddr(), SkipVerify: true},
-	)
-
-	url := fmt.Sprintf("postgres://bob:wrong@%s/dim-dog-28.defaultdb?sslmode=require", addr)
-	_, err := pgx.Connect(ctx, url)
-	require.Regexp(t, "ERROR: password authentication failed for user bob", err)
-
-	url = fmt.Sprintf("postgres://bob@%s/dim-dog-28.defaultdb?sslmode=require", addr)
-	_, err = pgx.Connect(ctx, url)
-	require.Regexp(t, "ERROR: password authentication failed for user bob", err)
-
-	url = fmt.Sprintf("postgres://bob:builder@%s/dim-dog-28.defaultdb?sslmode=require", addr)
-	conn, err := pgx.Connect(ctx, url)
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, conn.Close(ctx))
-		require.True(t, connSuccess)
-		require.Equal(t, int64(1), s.metrics.SuccessfulConnCount.Count())
-		require.Equal(t, int64(2), s.metrics.AuthFailedCount.Count())
-	}()
-
-	require.Equal(t, int64(1), s.metrics.CurConnCount.Value())
-	require.NoError(t, runTestQuery(ctx, conn))
-}
-
-func TestProxyTLSClose(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	// NB: The leaktest call is an important part of this test. We're
-	// verifying that no goroutines are leaked, despite calling Close an
-	// underlying TCP connection (rather than the TLSConn that wraps it).
-
-	ctx := context.Background()
-
-	sql, db, _ := serverutils.StartServer(t, base.TestServerArgs{Insecure: false})
-	sql.(*server.TestServer).PGServer().TestingSetTrustClientProvidedRemoteAddr(true)
-
-	sqlDB := sqlutils.MakeSQLRunner(db)
-	sqlDB.Exec(t, `CREATE USER bob WITH PASSWORD 'builder'`)
-
-	var proxyIncomingConn atomic.Value // *conn
-	var connSuccess bool
-	frontendAdmit := frontendAdmit
-	defer hookFrontendAdmit(func(conn net.Conn, incomingTLSConfig *tls.Config) (net.Conn, *pgproto3.StartupMessage, error) {
-		proxyIncomingConn.Store(conn)
-		return frontendAdmit(conn, incomingTLSConfig)
-	})()
-	originalAuthenticate := authenticate
-	defer hookAuthenticate(func(clientConn, crdbConn net.Conn) error {
-		err := originalAuthenticate(clientConn, crdbConn)
-		connSuccess = err == nil
-		return err
-	})()
-
-	defer sql.Stopper().Stop(ctx)
-
-	s, addr := newSecureProxyServer(
-		ctx, t, sql.Stopper(), &ProxyOptions{RoutingRule: sql.ServingSQLAddr(), SkipVerify: true},
-	)
-
-	url := fmt.Sprintf("postgres://bob:builder@%s/dim-dog-28.defaultdb?sslmode=require", addr)
-	c, err := pgx.Connect(ctx, url)
-	require.NoError(t, err)
-	require.Equal(t, int64(1), s.metrics.CurConnCount.Value())
-	defer func() {
-		incomingConn, ok := proxyIncomingConn.Load().(*conn)
-		require.True(t, ok)
-		require.NoError(t, incomingConn.Close())
-		<-incomingConn.done() // should immediately proceed
-
-		require.True(t, connSuccess)
-		require.Equal(t, int64(1), s.metrics.SuccessfulConnCount.Count())
-		require.Equal(t, int64(0), s.metrics.AuthFailedCount.Count())
-	}()
-
-	require.NoError(t, runTestQuery(ctx, c))
-}
-
-func TestProxyModifyRequestParams(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	ctx := context.Background()
-
-	sql, _, _ := serverutils.StartServer(t, base.TestServerArgs{Insecure: false})
-	sql.(*server.TestServer).PGServer().TestingSetTrustClientProvidedRemoteAddr(true)
-
-	outgoingTLSConfig, err := sql.RPCContext().GetClientTLSConfig()
-	require.NoError(t, err)
-	proxyOutgoingTLSConfig := outgoingTLSConfig.Clone()
-	proxyOutgoingTLSConfig.InsecureSkipVerify = true
-
-	backendDial := backendDial
-	defer hookBackendDial(func(msg *pgproto3.StartupMessage, outgoingAddress string, tlsConfig *tls.Config) (net.Conn, error) {
-		params := msg.Parameters
-		authToken, ok := params["authToken"]
-		require.True(t, ok)
-		require.Equal(t, "abc123", authToken)
-		user, ok := params["user"]
-		require.True(t, ok)
-		require.Equal(t, "bogususer", user)
-		require.Contains(t, params, "user")
-
-		// NB: This test will fail unless the user used between the proxy
-		// and the backend is changed to a user that actually exists.
-		delete(params, "authToken")
-		params["user"] = "root"
-
-		return backendDial(msg, sql.ServingSQLAddr(), proxyOutgoingTLSConfig)
-	})()
-
-	defer sql.Stopper().Stop(ctx)
-
-	s, proxyAddr := newSecureProxyServer(ctx, t, sql.Stopper(), &ProxyOptions{})
-
-	u := fmt.Sprintf("postgres://bogususer@%s/?sslmode=require&authToken=abc123&options=--cluster=dim-dog-28", proxyAddr)
-	conn, err := pgx.Connect(ctx, u)
-	require.NoError(t, err)
-	require.Equal(t, int64(1), s.metrics.CurConnCount.Value())
-	defer func() {
-		require.NoError(t, conn.Close(ctx))
-	}()
-
-	require.NoError(t, runTestQuery(ctx, conn))
-}
-
-func TestInsecureProxy(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	ctx := context.Background()
-
-	sql, db, _ := serverutils.StartServer(t, base.TestServerArgs{Insecure: false})
-	defer sql.Stopper().Stop(ctx)
-	sql.(*server.TestServer).PGServer().TestingSetTrustClientProvidedRemoteAddr(true)
-
-	sqlDB := sqlutils.MakeSQLRunner(db)
-	sqlDB.Exec(t, `CREATE USER bob WITH PASSWORD 'builder'`)
-
-	s, addr := newProxyServer(
-		ctx, t, sql.Stopper(), &ProxyOptions{RoutingRule: sql.ServingSQLAddr(), SkipVerify: true},
-	)
-
-	u := fmt.Sprintf("postgres://bob:wrong@%s?sslmode=disable&options=--cluster=dim-dog-28", addr)
-	_, err := pgx.Connect(ctx, u)
-	require.Error(t, err)
-	require.Regexp(t, "ERROR: password authentication failed for user bob", err)
-
-	u = fmt.Sprintf("postgres://bob:builder@%s/?sslmode=disable&options=--cluster=dim-dog-28", addr)
-	conn, err := pgx.Connect(ctx, u)
-	require.NoError(t, err)
-
-	defer func() {
-		require.NoError(t, conn.Close(ctx))
-		require.Equal(t, int64(1), s.metrics.AuthFailedCount.Count())
-		require.Equal(t, int64(1), s.metrics.SuccessfulConnCount.Count())
-	}()
-
-	require.NoError(t, runTestQuery(ctx, conn))
-}
-
-func TestInsecureDoubleProxy(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	ctx := context.Background()
-
-	sql, _, _ := serverutils.StartServer(t, base.TestServerArgs{Insecure: true})
-	defer sql.Stopper().Stop(ctx)
-	sql.(*server.TestServer).PGServer().TestingSetTrustClientProvidedRemoteAddr(true)
-
-	// Test multiple proxies:  proxyB -> proxyA -> tc
-	_, proxyA := newProxyServer(ctx, t, sql.Stopper(),
-		&ProxyOptions{RoutingRule: sql.ServingSQLAddr(), Insecure: true},
-	)
-	_, proxyB := newProxyServer(ctx, t, sql.Stopper(),
-		&ProxyOptions{RoutingRule: proxyA, Insecure: true},
-	)
-
-	u := fmt.Sprintf("postgres://root:admin@%s/dim-dog-28.dim-dog-29.defaultdb?sslmode=disable", proxyB)
-	conn, err := pgx.Connect(ctx, u)
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, conn.Close(ctx))
-	}()
-	require.NoError(t, runTestQuery(ctx, conn))
-}
-
-func TestErroneousFrontend(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	ctx := context.Background()
-
-	defer hookFrontendAdmit(func(conn net.Conn, incomingTLSConfig *tls.Config) (net.Conn, *pgproto3.StartupMessage, error) {
-		return conn, nil, errors.New(frontendError)
-	})()
-
-	stopper := stop.NewStopper()
-	defer stopper.Stop(ctx)
-
-	_, addr := newProxyServer(ctx, t, stopper, &ProxyOptions{})
-
-	u := fmt.Sprintf("postgres://bob:builder@%s/?sslmode=disable&options=--cluster=dim-dog-28", addr)
-
-	_, err := pgx.Connect(ctx, u)
-	require.Error(t, err)
-	// Generic message here as the Frontend's error is not codeError and
-	// by default we don't pass back error's text. The startup message doesn't get
-	// processed in this case.
-	require.Regexp(t, "connection reset by peer|failed to receive message", err)
-}
-
-func TestErroneousBackend(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	ctx := context.Background()
-
-	defer hookBackendDial(
-		func(msg *pgproto3.StartupMessage, outgoingAddress string, tlsConfig *tls.Config) (net.Conn, error) {
-			return nil, errors.New(backendError)
-		})()
-
-	stopper := stop.NewStopper()
-	defer stopper.Stop(context.Background())
-
-	_, addr := newProxyServer(ctx, t, stopper, &ProxyOptions{})
-
-	u := fmt.Sprintf("postgres://bob:builder@%s/?sslmode=disable&options=--cluster=dim-dog-28", addr)
-
-	_, err := pgx.Connect(ctx, u)
-	require.Error(t, err)
-	// Generic message here as the Backend's error is not codeError and
-	// by default we don't pass back error's text. The startup message has already
-	// been processed.
-	require.Regexp(t, "failed to receive message", err)
-}
-
-func TestProxyRefuseConn(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	ctx := context.Background()
-
-	defer hookBackendDial(func(_ *pgproto3.StartupMessage, _ string, _ *tls.Config) (net.Conn, error) {
-		return nil, newErrorf(codeProxyRefusedConnection, "too many attempts")
-	})()
-
-	ac := makeAssertCtx()
-	originalSendErrToClient := sendErrToClient
-	defer hookSendErrToClient(func(conn net.Conn, err error) {
-		if codeErr, ok := err.(*codeError); ok {
-			ac.onSendErrToClient(codeErr.code)
-		}
-		originalSendErrToClient(conn, err)
-	})()
-
-	stopper := stop.NewStopper()
-	defer stopper.Stop(context.Background())
-
-	s, addr := newSecureProxyServer(ctx, t, stopper, &ProxyOptions{})
-
-	ac.assertConnectErr(
-		ctx, t, fmt.Sprintf("postgres://root:admin@%s/", addr),
-		"?sslmode=require&options=--cluster=dim-dog-28",
-		codeProxyRefusedConnection, "too many attempts",
-	)
-	require.Equal(t, int64(1), s.metrics.RefusedConnCount.Count())
-	require.Equal(t, int64(0), s.metrics.SuccessfulConnCount.Count())
-	require.Equal(t, int64(0), s.metrics.AuthFailedCount.Count())
-}
-
-func TestDenylistUpdate(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	ctx := context.Background()
-	sql, _, _ := serverutils.StartServer(t, base.TestServerArgs{Insecure: false})
-	sql.(*server.TestServer).PGServer().TestingSetTrustClientProvidedRemoteAddr(true)
-
-	denyList, err := ioutil.TempFile("", "*_denylist.yml")
-	require.NoError(t, err)
-
-	outgoingTLSConfig, err := sql.RPCContext().GetClientTLSConfig()
-	require.NoError(t, err)
-	proxyOutgoingTLSConfig := outgoingTLSConfig.Clone()
-	proxyOutgoingTLSConfig.InsecureSkipVerify = true
-
-	backendDial := backendDial
-	defer hookBackendDial(func(msg *pgproto3.StartupMessage, outgoingAddress string, tlsConfig *tls.Config) (net.Conn, error) {
-		time.AfterFunc(100*time.Millisecond, func() {
-			dlf := denylist.File{
-				Denylist: []*denylist.DenyEntry{
-					{
-						Entity:     denylist.DenyEntity{Type: denylist.IPAddrType, Item: "127.0.0.1"},
-						Expiration: timeutil.Now().Add(time.Minute),
-						Reason:     "test-denied",
-					},
-				},
-			}
-
-			bytes, err := dlf.Serialize()
-			require.NoError(t, err)
-			_, err = denyList.Write(bytes)
-			require.NoError(t, err)
-		})
-		return backendDial(msg, sql.ServingSQLAddr(), proxyOutgoingTLSConfig)
-	})()
-
-	defer sql.Stopper().Stop(ctx)
-
-	s, addr := newSecureProxyServer(ctx, t, sql.Stopper(), &ProxyOptions{
-		Denylist:           denyList.Name(),
-		PollConfigInterval: 10 * time.Millisecond,
-	})
-	defer func() { _ = os.Remove(denyList.Name()) }()
-
-	url := fmt.Sprintf("postgres://root:admin@%s/defaultdb_29?sslmode=require&options=--cluster=dim-dog-28", addr)
-	conn, err := pgx.Connect(context.Background(), url)
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, conn.Close(ctx))
-		require.Equal(t, int64(1), s.metrics.ExpiredClientConnCount.Count())
-	}()
-
-	require.Eventuallyf(
-		t,
-		func() bool {
-			_, err = conn.Exec(context.Background(), "SELECT 1")
-			return err != nil
-		},
-		time.Second, 5*time.Millisecond,
-		"Expected the connection to eventually fail",
-	)
-	require.EqualError(t, err, "unexpected EOF")
-}
-
-func TestProxyAgainstSecureCRDBWithIdleTimeout(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	ctx := context.Background()
-
-	sql, _, _ := serverutils.StartServer(t, base.TestServerArgs{Insecure: false})
-	sql.(*server.TestServer).PGServer().TestingSetTrustClientProvidedRemoteAddr(true)
-
-	outgoingTLSConfig, err := sql.RPCContext().GetClientTLSConfig()
-	require.NoError(t, err)
-	proxyOutgoingTLSConfig := outgoingTLSConfig.Clone()
-	proxyOutgoingTLSConfig.InsecureSkipVerify = true
-
-	idleTimeout, _ := time.ParseDuration("0.5s")
-	var connSuccess bool
-	frontendAdmit := frontendAdmit
-	defer hookFrontendAdmit(func(conn net.Conn, incomingTLSConfig *tls.Config) (net.Conn, *pgproto3.StartupMessage, error) {
-		return frontendAdmit(conn, incomingTLSConfig)
-	})()
-	backendDial := backendDial
-	defer hookBackendDial(func(msg *pgproto3.StartupMessage, outgoingAddress string, tlsConfig *tls.Config) (net.Conn, error) {
-		return backendDial(msg, sql.ServingSQLAddr(), proxyOutgoingTLSConfig)
-	})()
-	originalAuthenticate := authenticate
-	defer hookAuthenticate(func(clientConn, crdbConn net.Conn) error {
-		err := originalAuthenticate(clientConn, crdbConn)
-		connSuccess = err == nil
-		return err
-	})()
-
-	defer sql.Stopper().Stop(ctx)
-
-	s, addr := newSecureProxyServer(ctx, t, sql.Stopper(), &ProxyOptions{IdleTimeout: idleTimeout})
-
-	url := fmt.Sprintf("postgres://root:admin@%s/?sslmode=require&options=--cluster=dim-dog-28", addr)
-	conn, err := pgx.Connect(ctx, url)
-	require.NoError(t, err)
-	require.Equal(t, int64(1), s.metrics.CurConnCount.Value())
-	defer func() {
-		require.NoError(t, conn.Close(ctx))
-		require.True(t, connSuccess)
-		require.Equal(t, int64(1), s.metrics.SuccessfulConnCount.Count())
-	}()
-
-	var n int
-	err = conn.QueryRow(ctx, "SELECT $1::int", 1).Scan(&n)
-	require.NoError(t, err)
-	require.EqualValues(t, 1, n)
-
-	time.Sleep(idleTimeout * 2)
-	err = conn.QueryRow(context.Background(), "SELECT $1::int", 1).Scan(&n)
-	require.EqualError(t, err, "unexpected EOF")
-	require.Equal(t, int64(1), s.metrics.IdleDisconnectCount.Count())
-}
-
 func newDirectoryServer(
 	ctx context.Context, t *testing.T, srv serverutils.TestServerInterface, addr *net.TCPAddr,
 ) (*stop.Stopper, *net.TCPAddr) {
@@ -690,6 +831,11 @@ func newDirectoryServer(
 	tds, err := tenantdirsvr.New(tdsStopper)
 	require.NoError(t, err)
 	tds.TenantStarterFunc = func(ctx context.Context, tenantID uint64) (*tenantdirsvr.Process, error) {
+		// Recognize special tenant ID that triggers an error.
+		if tenantID == notFoundTenantID {
+			return nil, status.Error(codes.NotFound, "tenant not found")
+		}
+
 		log.TestingClearServerIdentifiers()
 		tenantStopper := tenantdirsvr.NewSubStopper(tdsStopper)
 		ten, err := srv.StartTenant(ctx, base.TestTenantArgs{
@@ -706,45 +852,4 @@ func newDirectoryServer(
 	}
 	go func() { require.NoError(t, tds.Serve(listener)) }()
 	return tdsStopper, listener.Addr().(*net.TCPAddr)
-}
-
-func TestDirectoryReconnect(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	ctx := context.Background()
-
-	// New test cluster
-	srv, _, _ := serverutils.StartServer(t, base.TestServerArgs{Insecure: true})
-	defer srv.Stopper().Stop(ctx)
-
-	// Create tenant 28
-	sqlConn := srv.InternalExecutor().(*sql.InternalExecutor)
-	_, err := sqlConn.Exec(ctx, "", nil, "SELECT crdb_internal.create_tenant(28)")
-	require.NoError(t, err)
-
-	// New test directory server
-	stopper1, tdsAddr := newDirectoryServer(ctx, t, srv, &net.TCPAddr{})
-
-	// New proxy server using the directory
-	_, addr := newProxyServer(
-		ctx, t, srv.Stopper(), &ProxyOptions{DirectoryAddr: tdsAddr.String(), Insecure: true},
-	)
-
-	// try to connect - should be successful.
-	url := fmt.Sprintf("postgres://root:admin@%s/?sslmode=disable&options=--cluster=tenant-cluster-28", addr)
-	_, err = pgx.Connect(ctx, url)
-	require.NoError(t, err)
-
-	// Stop the directory server and the tenant
-	stopper1.Stop(ctx)
-
-	stopper2, _ := newDirectoryServer(ctx, t, srv, tdsAddr)
-	defer stopper2.Stop(ctx)
-
-	require.Eventually(t, func() bool {
-		// try to connect through the proxy again - should be successful.
-		url = fmt.Sprintf("postgres://root:admin@%s/?sslmode=disable&options=--cluster=tenant-cluster-28", addr)
-		_, err = pgx.Connect(ctx, url)
-		return err == nil
-	}, 1000*time.Second, 100*time.Millisecond)
 }

--- a/pkg/ccl/sqlproxyccl/tenant/directory.pb.go
+++ b/pkg/ccl/sqlproxyccl/tenant/directory.pb.go
@@ -277,7 +277,8 @@ var xxx_messageInfo_Endpoint proto.InternalMessageInfo
 // ListEndpointsResponse is sent back as a result of requesting the list of
 // endpoints for a given tenant.
 type ListEndpointsResponse struct {
-	// Endpoints is the list of endpoints currently active for the requested tenant.
+	// Endpoints is the list of endpoints currently active for the requested
+	// tenant.
 	Endpoints []*Endpoint `protobuf:"bytes,1,rep,name=endpoints,proto3" json:"endpoints,omitempty"`
 }
 
@@ -453,11 +454,14 @@ type DirectoryClient interface {
 	// WatchEndpoints is used to get a stream, that is used to receive notifications
 	// about changes in tenant backend's state - added, modified and deleted.
 	WatchEndpoints(ctx context.Context, in *WatchEndpointsRequest, opts ...grpc.CallOption) (Directory_WatchEndpointsClient, error)
-	// EnsureEndpoint is used to ensure that a tenant's backend is active. If there
-	// is an active backend then the server doesn't have to do anything. If there
-	// isn't an active backend, then the server has to bring a new one up.
+	// EnsureEndpoint is used to ensure that a tenant's backend is active. If
+	// there is an active backend then the server doesn't have to do anything. If
+	// there isn't an active backend, then the server has to bring a new one up.
+	// If the requested tenant does not exist, EnsureEndpoint returns a GRPC
+	// NotFound error.
 	EnsureEndpoint(ctx context.Context, in *EnsureEndpointRequest, opts ...grpc.CallOption) (*EnsureEndpointResponse, error)
-	// GetTenant is used to fetch the metadata of a specific tenant.
+	// GetTenant is used to fetch the metadata of a specific tenant. If the tenant
+	// does not exist, GetTenant returns a GRPC NotFound error.
 	GetTenant(ctx context.Context, in *GetTenantRequest, opts ...grpc.CallOption) (*GetTenantResponse, error)
 }
 
@@ -536,11 +540,14 @@ type DirectoryServer interface {
 	// WatchEndpoints is used to get a stream, that is used to receive notifications
 	// about changes in tenant backend's state - added, modified and deleted.
 	WatchEndpoints(*WatchEndpointsRequest, Directory_WatchEndpointsServer) error
-	// EnsureEndpoint is used to ensure that a tenant's backend is active. If there
-	// is an active backend then the server doesn't have to do anything. If there
-	// isn't an active backend, then the server has to bring a new one up.
+	// EnsureEndpoint is used to ensure that a tenant's backend is active. If
+	// there is an active backend then the server doesn't have to do anything. If
+	// there isn't an active backend, then the server has to bring a new one up.
+	// If the requested tenant does not exist, EnsureEndpoint returns a GRPC
+	// NotFound error.
 	EnsureEndpoint(context.Context, *EnsureEndpointRequest) (*EnsureEndpointResponse, error)
-	// GetTenant is used to fetch the metadata of a specific tenant.
+	// GetTenant is used to fetch the metadata of a specific tenant. If the tenant
+	// does not exist, GetTenant returns a GRPC NotFound error.
 	GetTenant(context.Context, *GetTenantRequest) (*GetTenantResponse, error)
 }
 

--- a/pkg/ccl/sqlproxyccl/tenant/directory.proto
+++ b/pkg/ccl/sqlproxyccl/tenant/directory.proto
@@ -67,7 +67,8 @@ message Endpoint {
 // ListEndpointsResponse is sent back as a result of requesting the list of
 // endpoints for a given tenant.
 message ListEndpointsResponse {
-  // Endpoints is the list of endpoints currently active for the requested tenant.
+  // Endpoints is the list of endpoints currently active for the requested
+  // tenant.
   repeated Endpoint endpoints = 1;
 }
 
@@ -93,10 +94,13 @@ service Directory {
   // WatchEndpoints is used to get a stream, that is used to receive notifications
   // about changes in tenant backend's state - added, modified and deleted.
   rpc WatchEndpoints(WatchEndpointsRequest) returns (stream WatchEndpointsResponse);
-  // EnsureEndpoint is used to ensure that a tenant's backend is active. If there
-  // is an active backend then the server doesn't have to do anything. If there
-  // isn't an active backend, then the server has to bring a new one up.
+  // EnsureEndpoint is used to ensure that a tenant's backend is active. If
+  // there is an active backend then the server doesn't have to do anything. If
+  // there isn't an active backend, then the server has to bring a new one up.
+  // If the requested tenant does not exist, EnsureEndpoint returns a GRPC
+  // NotFound error.
   rpc EnsureEndpoint(EnsureEndpointRequest) returns (EnsureEndpointResponse);
-  // GetTenant is used to fetch the metadata of a specific tenant.
+  // GetTenant is used to fetch the metadata of a specific tenant. If the tenant
+  // does not exist, GetTenant returns a GRPC NotFound error.
   rpc GetTenant(GetTenantRequest) returns (GetTenantResponse);
 }


### PR DESCRIPTION
Previously, when a tenant directory was present, the sqlproxy would exclusively
use that to determine how to route incoming connections. However, until we've
switched all free-tier tenants over to use the tenant directory methodology, we
need to fallback on the older name routing methodology if the tenant cannot be
found in the directory.

This commit implements the fallback logic in the "outgoingAddress" method. If
tenant lookup returns NotFound, then we fallback to name routing. This commit
also retools the sqlproxy tests to be more compact due to better helper
routines, and expands the Directory test significantly.

Release note: None