### PR TITLE
goschedstats: support go1.17

### DIFF
--- a/pkg/util/goschedstats/runtime_go1.15.go
+++ b/pkg/util/goschedstats/runtime_go1.15.go
@@ -9,9 +9,10 @@
 // licenses/APL.txt.
 //
 // The structure definitions in this file have been cross-checked against
-// go1.15.5 and go1.16. Before allowing newer versions, please check that the
-// structures still match with those in go/src/runtime.
-// +build gc,go1.15,!go1.17
+// go1.15.5, go1.16, and go1.17beta1 (needs revalidation). Before allowing
+// newer versions, please check that the structures still match with those
+// in go/src/runtime.
+// +build gc,go1.15,!go1.18
 
 package goschedstats
 


### PR DESCRIPTION
These structures all still match the go1.17beta1. This will need re-validation when the final go1.17 release comes out. I'll file a separate issue to track this.