### PR TITLE
ui: disallow imports from cluster-ui sources

### DIFF
--- a/pkg/ui/.eslintrc.json
+++ b/pkg/ui/.eslintrc.json
@@ -8,6 +8,9 @@
     "react/no-unescaped-entities": "off",
     "@typescript-eslint/no-unused-vars": "off",
     "@typescript-eslint/explicit-module-boundary-types": "off",
-    "@typescript-eslint/no-explicit-any": "off"
+    "@typescript-eslint/no-explicit-any": "off",
+    "no-restricted-imports": ["error", {
+      "patterns": ["@cockroachlabs/cluster-ui/src/*"]
+    }]
   }
 }


### PR DESCRIPTION
Db Console depends on local `cluster-ui` package that and it was possible to specify
imports to its modules as a paths to source modules or use exported `index` file which
is an entry point for bundled module.
`cluster-ui` package has to be built before imports in Db Console because it has its
own dependencies and build process which isn't compatible with build process of Db Console.
To prevent incorrect imports, this change adds es lint rule to prohibit any imports from
`@cockroachlabs/cluster-ui/src/*` path.

Release note: none