### PR TITLE
sql: "char" is supposed to truncate long values

### DIFF
--- a/pkg/sql/delegate/show_table.go
+++ b/pkg/sql/delegate/show_table.go
@@ -204,7 +204,7 @@ func (d *delegator) delegateShowConstraints(n *tree.ShowConstraints) (tree.State
            WHEN 'u' THEN 'UNIQUE'
            WHEN 'c' THEN 'CHECK'
            WHEN 'f' THEN 'FOREIGN KEY'
-           ELSE c.contype
+           ELSE c.contype::TEXT
         END AS constraint_type,
         c.condef AS details,
         c.convalidated AS validated

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring
@@ -508,6 +508,20 @@ SELECT s FROM nocase_strings2 WHERE s = ('bbb' COLLATE "en_US_u_ks_level2")
 ----
 Bbb
 
+# Test "char" is supposed to truncate long values
+subtest char_long_values
+
+statement ok
+CREATE TABLE t65631(a "char", b "char" COLLATE en)
+
+statement ok
+INSERT INTO t65631 VALUES ('abc', 'abc' COLLATE en)
+
+query TT
+SELECT a, b FROM t65631
+----
+a a
+
 subtest regression_45142
 
 statement ok

--- a/pkg/sql/sem/tree/constant.go
+++ b/pkg/sql/sem/tree/constant.go
@@ -554,12 +554,7 @@ func (expr *StrVal) ResolveAsType(
 		case types.UuidFamily:
 			return ParseDUuidFromBytes([]byte(expr.s))
 		case types.StringFamily:
-			// bpchar types truncate trailing whitespace.
-			if typ.Oid() == oid.T_bpchar {
-				expr.resString = DString(strings.TrimRight(expr.s, " "))
-				return &expr.resString, nil
-			}
-			expr.resString = DString(expr.s)
+			expr.resString = DString(adjustStringValueToType(typ, expr.s))
 			return &expr.resString, nil
 		}
 		return nil, errors.AssertionFailedf("attempt to type byte array literal to %T", typ)
@@ -572,12 +567,7 @@ func (expr *StrVal) ResolveAsType(
 			expr.resString = DString(expr.s)
 			return NewDNameFromDString(&expr.resString), nil
 		}
-		// bpchar types truncate trailing whitespace.
-		if typ.Oid() == oid.T_bpchar {
-			expr.resString = DString(strings.TrimRight(expr.s, " "))
-			return &expr.resString, nil
-		}
-		expr.resString = DString(expr.s)
+		expr.resString = DString(adjustStringValueToType(typ, expr.s))
 		return &expr.resString, nil
 
 	case types.BytesFamily:

--- a/pkg/sql/sem/tree/testdata/eval/cast
+++ b/pkg/sql/sem/tree/testdata/eval/cast
@@ -1203,3 +1203,14 @@ eval
 '[]'::jsonb::float
 ----
 invalid cast: jsonb -> float
+
+# "char" is supposed to truncate long values
+eval
+'abc'::"char"
+----
+'a'
+
+eval
+'abc'::string::"char"
+----
+'a'


### PR DESCRIPTION
Resolves #65631

Release note (sql change, backward-incompatible change): The `"char"`
column type will truncate long values in line with Postgres. 