### PR TITLE
server: TestTelemetrySQLStatsIndependence uses test reg server

### DIFF
--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -325,6 +325,7 @@ go_test(
         "//pkg/storage",
         "//pkg/storage/enginepb",
         "//pkg/testutils",
+        "//pkg/testutils/diagutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",


### PR DESCRIPTION
Previously, this test hit the real registration server which caused
goroutine leaks when the reg server was unavailable.

The test now creates a test reg server to handle the stats calls.
The test is no longer skipped.

Resolves #63851

Release note: None