### PR TITLE
release-21.1: backupccl: add cluster setting to disable GCS chunking

### DIFF
--- a/pkg/storage/cloudimpl/gcs_storage.go
+++ b/pkg/storage/cloudimpl/gcs_storage.go
@@ -21,6 +21,7 @@ import (
 	gcs "cloud.google.com/go/storage"
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/cloud"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
@@ -29,6 +30,14 @@ import (
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
+)
+
+// gcsChunkingEnabled is used to enable and disable chunking of file upload to
+// Google Cloud Storage.
+var gcsChunkingEnabled = settings.RegisterBoolSetting(
+	"cloudstorage.gs.chunking.enabled",
+	"enable chunking of file upload to Google Cloud Storage",
+	true, /* default */
 )
 
 func gcsQueryParams(conf *roachpb.ExternalStorage_GCS) string {
@@ -161,6 +170,9 @@ func (g *gcsStorage) WriteFile(ctx context.Context, basename string, content io.
 		return contextutil.RunWithTimeout(ctx, "put gcs file", timeoutSetting.Get(&g.settings.SV),
 			func(ctx context.Context) error {
 				w := g.bucket.Object(path.Join(g.prefix, basename)).NewWriter(ctx)
+				if !gcsChunkingEnabled.Get(&g.settings.SV) {
+					w.ChunkSize = 0
+				}
 				if _, err := io.Copy(w, content); err != nil {
 					_ = w.Close()
 					return err


### PR DESCRIPTION
Backport 1/1 commits from #66150.

/cc @cockroachdb/release

---

Adds a cluster setting that can disable GCS chunking during file upload.
This might be desirable if writing to GCS is stuck trying in the SDK.
See googleapis/google-cloud-go#1507 for details.

Encountering this retry is quite rare and so this cluster setting is not
public since it's not expected to be set most of the time, but could
serve as a useful escape-hatch.

Release note: None
