### PR TITLE
opt: add support for prefix spans for regexp

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -1137,6 +1137,18 @@ vectorized: true
       table: str@str_v_idx
       spans: /"ABC"-/"ABD"
 
+query T
+EXPLAIN (VERBOSE) SELECT k, v FROM str WHERE v ~ '^ABC'
+----
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (k, v)
+  estimated row count: 330 (missing stats)
+  table: str@str_v_idx
+  spans: /"ABC"-/"ABD"
+
 # Test that we generate spans for IS (NOT) DISTINCT FROM.
 statement ok
 CREATE TABLE xy (x INT, y INT, INDEX (y))

--- a/pkg/sql/opt/idxconstraint/testdata/strings
+++ b/pkg/sql/opt/idxconstraint/testdata/strings
@@ -78,6 +78,55 @@ a SIMILAR TO '.*'
 Remaining filter: a SIMILAR TO '.*'
 
 index-constraints vars=(a string) index=(a)
+a ~ '^foo'
+----
+[/'foo' - /'fop')
+
+# This could be converted to simple equality.
+index-constraints vars=(a string) index=(a)
+a ~ '^foo$'
+----
+[/'foo' - /'fop')
+Remaining filter: a ~ '^foo$'
+
+index-constraints vars=(a string) index=(a)
+a ~ '^foo[a-z]'
+----
+[/'foo' - /'fop')
+Remaining filter: a ~ '^foo[a-z]'
+
+index-constraints vars=(a string) index=(a)
+a ~ '^foo.*bar'
+----
+[/'foo' - /'fop')
+Remaining filter: a ~ '^foo.*bar'
+
+index-constraints vars=(a string) index=(a)
+a ~ '^(abx|aby|abz)'
+----
+[/'ab' - /'ac')
+Remaining filter: a ~ '^(abx|aby|abz)'
+
+index-constraints vars=(a string) index=(a)
+a ~ '^?fo*'
+----
+(/NULL - ]
+Remaining filter: a ~ '^?fo*'
+
+index-constraints vars=(a string) index=(a)
+a ~ 'foo'
+----
+(/NULL - ]
+Remaining filter: a ~ 'foo'
+
+# Case insensitive matches cannot get a span.
+index-constraints vars=(a string) index=(a)
+a ~* '^foo'
+----
+(/NULL - ]
+Remaining filter: a ~* '^foo'
+
+index-constraints vars=(a string) index=(a)
 a = 'eu' OR (a > 'eu' AND a < 'us')
 ----
 [/'eu' - /'us')


### PR DESCRIPTION
This change adds support for index constraints for expressions like
`x ~ '^foo'`, where we can restrict an index to a prefix.

Fixes #30124.

Release note (performance improvement): regexp expressions that
restrict values to a prefix (e.g. `x ^ '^foo'`) now result in better
plans if there is a suitable index.