### PR TITLE
sql: properly wrap some errors

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -1352,7 +1352,7 @@ func (p *planner) updateFKBackReferenceName(
 	} else {
 		lookup, err := p.Descriptors().GetMutableTableVersionByID(ctx, ref.ReferencedTableID, p.txn)
 		if err != nil {
-			return errors.Errorf("error resolving referenced table ID %d: %v", ref.ReferencedTableID, err)
+			return errors.Wrapf(err, "error resolving referenced table ID %d", ref.ReferencedTableID)
 		}
 		referencedTableDesc = lookup
 	}

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -2222,7 +2222,7 @@ func runSchemaChangesInTxn(
 			} else {
 				lookup, err := planner.Descriptors().GetMutableTableVersionByID(ctx, fk.ReferencedTableID, planner.Txn())
 				if err != nil {
-					return errors.Errorf("error resolving referenced table ID %d: %v", fk.ReferencedTableID, err)
+					return errors.Wrapf(err, "error resolving referenced table ID %d", fk.ReferencedTableID)
 				}
 				referencedTableDesc = lookup
 			}

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -439,7 +439,7 @@ func (s *Server) GetUnscrubbedStmtStats(
 		s.sqlStats.IterateStatementStats(ctx, &sqlstats.IteratorOptions{}, stmtStatsVisitor)
 
 	if err != nil {
-		return nil, errors.Errorf("failed to fetch statement stats: %s", err)
+		return nil, errors.Wrap(err, "failed to fetch statement stats")
 	}
 
 	return stmtStats, nil
@@ -459,7 +459,7 @@ func (s *Server) GetUnscrubbedTxnStats(
 		s.sqlStats.IterateTransactionStats(ctx, &sqlstats.IteratorOptions{}, txnStatsVisitor)
 
 	if err != nil {
-		return nil, errors.Errorf("failed to fetch statement stats: %s", err)
+		return nil, errors.Wrap(err, "failed to fetch statement stats")
 	}
 
 	return txnStats, nil
@@ -509,7 +509,7 @@ func (s *Server) getScrubbedStmtStats(
 		statsProvider.IterateStatementStats(ctx, &sqlstats.IteratorOptions{}, stmtStatsVisitor)
 
 	if err != nil {
-		return nil, errors.Errorf("failed to fetch scrubbed statement stats: %s", err)
+		return nil, errors.Wrap(err, "failed to fetch scrubbed statement stats")
 	}
 
 	return scrubbedStats, nil

--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -549,7 +549,7 @@ func (p *planner) removeFKForBackReference(
 	} else {
 		lookup, err := p.Descriptors().GetMutableTableVersionByID(ctx, ref.OriginTableID, p.txn)
 		if err != nil {
-			return errors.Errorf("error resolving origin table ID %d: %v", ref.OriginTableID, err)
+			return errors.Wrapf(err, "error resolving origin table ID %d", ref.OriginTableID)
 		}
 		originTableDesc = lookup
 	}
@@ -607,7 +607,7 @@ func (p *planner) removeFKBackReference(
 	} else {
 		lookup, err := p.Descriptors().GetMutableTableVersionByID(ctx, ref.ReferencedTableID, p.txn)
 		if err != nil {
-			return errors.Errorf("error resolving referenced table ID %d: %v", ref.ReferencedTableID, err)
+			return errors.Wrapf(err, "error resolving referenced table ID %d", ref.ReferencedTableID)
 		}
 		referencedTableDesc = lookup
 	}
@@ -663,7 +663,7 @@ func (p *planner) removeInterleaveBackReference(
 	} else {
 		lookup, err := p.Descriptors().GetMutableTableVersionByID(ctx, ancestor.TableID, p.txn)
 		if err != nil {
-			return errors.Errorf("error resolving referenced table ID %d: %v", ancestor.TableID, err)
+			return errors.Wrapf(err, "error resolving referenced table ID %d", ancestor.TableID)
 		}
 		t = lookup
 	}


### PR DESCRIPTION
These errors may contain transaction restarts. We need to wrap them instead of
swallowing them.

Touches most recent failures on #64461.

Release note: None