### PR TITLE
roachtest: update version map

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1183,7 +1183,7 @@ func PredecessorVersion(buildVersion version.Version) (string, error) {
 	// (see runVersionUpgrade). The same is true for adding a new key to this
 	// map.
 	verMap := map[string]string{
-		"21.1": "20.2.5",
+		"21.1": "20.2.11",
 		"20.2": "20.1.12",
 		"20.1": "19.2.11",
 		"19.2": "19.1.11",


### PR DESCRIPTION
Update the predecessor version for 21.1 to be the latest
20.2 release - 20.2.11

Release note None