### PR TITLE
build: add script for cross-compilation job to windows via bazel

### DIFF
--- a/build/bazelutil/bazelbuild.sh
+++ b/build/bazelutil/bazelbuild.sh
@@ -2,12 +2,8 @@
 
 set -xeuo pipefail
 
-# TODO(ricky): switching configurations to build `bazci` for the host before
-# building the actual `cockroach` binary introduces some delays. It doesn't
-# cause bazel to throw away its entire cache or anything, but it definitely
-# rebuilds more than is technically necessary. This merits more investigation.
-# TODO(ricky): I think it might be necessary to teach `bazci` about the
-# configurations instead of asking `bazci` to just pass the configuration flags
-# down to Bazel unchanged, but for now it seems fine.
 bazel build //pkg/cmd/bazci --config=ci
-$(bazel info bazel-bin)/pkg/cmd/bazci/bazci_/bazci build //pkg/cmd/cockroach-short -- --config=ci --config=crosslinux
+$(bazel info bazel-bin)/pkg/cmd/bazci/bazci_/bazci --compilation_mode opt \
+		       --config ci \
+		       --config crosslinux \
+		       build //pkg/cmd/cockroach-short

--- a/build/bazelutil/bazelbuildwindows.sh
+++ b/build/bazelutil/bazelbuildwindows.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -xeuo pipefail
+
+# TODO(ricky): switching configurations to build `bazci` for the host before
+# building the actual `cockroach` binary introduces some delays. It doesn't
+# cause bazel to throw away its entire cache or anything, but it definitely
+# rebuilds more than is technically necessary. This merits more investigation.
+bazel build //pkg/cmd/bazci --config=ci
+$(bazel info bazel-bin)/pkg/cmd/bazci/bazci_/bazci --compilation_mode opt \
+		       --config ci \
+		       --config crosswindows \
+		       build //pkg/cmd/cockroach-short

--- a/build/bazelutil/bazeltest.sh
+++ b/build/bazelutil/bazeltest.sh
@@ -3,4 +3,5 @@
 set -xeuo pipefail
 
 bazel build //pkg/cmd/bazci --config=ci
-$(bazel info bazel-bin)/pkg/cmd/bazci/bazci_/bazci test //pkg:small_tests //pkg:medium_tests //pkg:large_tests //pkg:enormous_tests -- --config=ci
+$(bazel info bazel-bin)/pkg/cmd/bazci/bazci_/bazci --config ci \
+		       test //pkg:small_tests //pkg:medium_tests //pkg:large_tests //pkg:enormous_tests

--- a/build/teamcity-bazel-windows-build.sh
+++ b/build/teamcity-bazel-windows-build.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source "$(dirname "${0}")/teamcity-support.sh"  # For $root
+source "$(dirname "${0}")/teamcity-bazel-support.sh"  # For run_bazel
+
+tc_prepare
+
+tc_start_block "Run Bazel build"
+run_bazel build/bazelutil/bazelbuildwindows.sh
+tc_end_block "Run Bazel build"

--- a/pkg/cmd/bazci/watch.go
+++ b/pkg/cmd/bazci/watch.go
@@ -197,6 +197,9 @@ func (w watcher) stageBinaryArtifacts() error {
 		head := strings.ReplaceAll(strings.TrimPrefix(bin, "//"), ":", "/")
 		components := strings.Split(bin, ":")
 		relBinPath := path.Join(head+"_", components[len(components)-1])
+		if usingCrossWindowsConfig() {
+			relBinPath = relBinPath + ".exe"
+		}
 		err := w.maybeStageArtifact(binSourceDir, relBinPath, 0777, finalizePhase,
 			copyContentTo)
 		if err != nil {


### PR DESCRIPTION
We need to teach `bazci` about the configurations and add a new script
to support this. Also run both the Linux cross job and the Windows cross
job with `-c opt`, so we can start getting optimized builds.

Also add a small hack to `proj` to work around
OSGeo/PROJ#1235.

Closes #66208
Closes #66209

Release note: None