### PR TITLE
release-20.2: bulkio: Rework scheduled job test.

### DIFF
--- a/pkg/jobs/job_scheduler_test.go
+++ b/pkg/jobs/job_scheduler_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/scheduledjobs"
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -596,6 +597,58 @@ func TestJobSchedulerDaemonUsesSystemTables(t *testing.T) {
 	})
 }
 
+type txnConflictExecutor struct {
+	beforeUpdate, proceed chan struct{}
+}
+
+func (e *txnConflictExecutor) ExecuteJob(
+	ctx context.Context,
+	cfg *scheduledjobs.JobExecutionConfig,
+	env scheduledjobs.JobSchedulerEnv,
+	schedule *ScheduledJob,
+	txn *kv.Txn,
+) error {
+	// Read number of rows -- this count will be used when updating
+	// a single row in the table.
+	row, err := cfg.InternalExecutor.QueryRow(
+		ctx, "txn-executor", txn, "SELECT count(*) FROM defaultdb.foo")
+	if err != nil {
+		return err
+	}
+	cnt := int(tree.MustBeDInt(row[0]))
+	if e.beforeUpdate != nil {
+		// Wait to be signaled.
+		e.beforeUpdate <- struct{}{}
+		<-e.proceed
+		e.beforeUpdate = nil
+		e.proceed = nil
+	}
+
+	// Try updating.
+	_, err = cfg.InternalExecutor.Exec(
+		ctx, "txn-executor", txn, "UPDATE defaultdb.foo SET b=b+$1 WHERE a=1", cnt)
+	return err
+}
+
+func (e *txnConflictExecutor) NotifyJobTermination(
+	ctx context.Context,
+	jobID int64,
+	jobStatus Status,
+	details jobspb.Details,
+	env scheduledjobs.JobSchedulerEnv,
+	schedule *ScheduledJob,
+	ex sqlutil.InternalExecutor,
+	txn *kv.Txn,
+) error {
+	return nil
+}
+
+func (e *txnConflictExecutor) Metrics() metric.Struct {
+	return nil
+}
+
+var _ ScheduledJobExecutor = (*txnConflictExecutor)(nil)
+
 func TestTransientTxnErrors(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -604,42 +657,64 @@ func TestTransientTxnErrors(t *testing.T) {
 	defer cleanup()
 	ctx := context.Background()
 
-	h.sqlDB.Exec(t, "CREATE TABLE defaultdb.foo(a int primary key, b timestamp not null)")
+	h.sqlDB.Exec(t, `
+CREATE TABLE defaultdb.foo(a int primary key, b int);
+INSERT INTO defaultdb.foo VALUES(1, 1)
+`)
 
-	// Setup 10 schedules updating defaultdb.foo timestamp.
-	for i := 0; i < 10; i++ {
-		schedule := NewScheduledJob(h.env)
-		schedule.SetScheduleLabel(fmt.Sprintf("test schedule: %d", i))
-		schedule.SetOwner("test")
-		require.NoError(t, schedule.SetSchedule("*/1 * * * *"))
-		any, err := types.MarshalAny(&jobspb.SqlStatementExecutionArg{
-			Statement: fmt.Sprintf("UPSERT INTO defaultdb.foo (a, b) VALUES (%d, now())", i),
-		})
-		require.NoError(t, err)
-		schedule.SetExecutionDetails(InlineExecutorName, jobspb.ExecutionArguments{Args: any})
-		require.NoError(t, schedule.Create(
-			ctx, h.cfg.InternalExecutor, nil))
+	const execName = "test-executor"
+	ex := &txnConflictExecutor{
+		beforeUpdate: make(chan struct{}),
+		proceed:      make(chan struct{}),
 	}
+	defer registerScopedScheduledJobExecutor(execName, ex)()
 
-	// Setup numConcurrent workers, each executing maxExec executeSchedule calls.
-	const maxExec = 100
-	const numConcurrent = 3
+	// Setup schedule with our test executor.
+	schedule := NewScheduledJob(h.env)
+	schedule.SetScheduleLabel("test schedule")
+	schedule.SetOwner("test")
+	nextRun := h.env.Now().Add(time.Hour)
+	schedule.SetNextRun(nextRun)
+	schedule.SetExecutionDetails(execName, jobspb.ExecutionArguments{})
+	require.NoError(t, schedule.Create(
+		ctx, h.cfg.InternalExecutor, nil))
+
+	// Execute schedule on another thread.
+	g := ctxgroup.WithContext(context.Background())
+	g.Go(func() error {
+		return h.cfg.DB.Txn(context.Background(),
+			func(ctx context.Context, txn *kv.Txn) error {
+				err := h.execSchedules(ctx, allSchedules, txn)
+				return err
+			},
+		)
+	})
+
 	require.NoError(t,
-		ctxgroup.GroupWorkers(context.Background(), numConcurrent, func(ctx context.Context, _ int) error {
-			ticker := time.NewTicker(time.Millisecond)
-			numExecs := 0
-			for range ticker.C {
-				h.env.AdvanceTime(time.Minute)
-				// Transaction retry errors should never bubble up.
-				require.NoError(t,
-					h.cfg.DB.Txn(context.Background(), func(ctx context.Context, txn *kv.Txn) error {
-						return h.execSchedules(ctx, allSchedules, txn)
-					}))
-				numExecs++
-				if numExecs == maxExec {
-					return nil
-				}
+		h.cfg.DB.Txn(context.Background(), func(ctx context.Context, txn *kv.Txn) error {
+			// Let schedule start running, and wait for it to be ready to update.
+			h.env.SetTime(nextRun.Add(time.Second))
+			<-ex.beforeUpdate
+
+			// Before we let schedule proceed, update the number of rows in the table.
+			// This should cause transaction in schedule to restart, but we don't
+			// expect to see any errors in the schedule status.
+			if _, err := h.cfg.InternalExecutor.Exec(ctx, "update-a", txn,
+				`UPDATE defaultdb.foo SET b=3 WHERE a=1`); err != nil {
+				return err
 			}
+			if _, err := h.cfg.InternalExecutor.Exec(ctx, "add-row", txn,
+				`INSERT INTO defaultdb.foo VALUES (123, 123)`); err != nil {
+				return err
+			}
+			ex.proceed <- struct{}{}
 			return nil
 		}))
+
+	err := g.Wait()
+	require.True(t, errors.HasType(err, &savePointError{}))
+
+	// Reload schedule -- verify it doesn't have any errors in its status.
+	updated := h.loadSchedule(t, schedule.ScheduleID())
+	require.Equal(t, "", updated.ScheduleStatus())
 }

--- a/pkg/jobs/scheduled_job_executor_test.go
+++ b/pkg/jobs/scheduled_job_executor_test.go
@@ -72,9 +72,10 @@ func TestScheduledJobExecutorRegistration(t *testing.T) {
 	instance := newStatusTrackingExecutor()
 	defer registerScopedScheduledJobExecutor(executorName, instance)()
 
-	registered, err := newScheduledJobExecutor(executorName)
+	registered, created, err := GetScheduledJobExecutor(executorName)
 	require.NoError(t, err)
 	require.Equal(t, instance, registered)
+	require.True(t, created)
 }
 
 func TestJobTerminationNotification(t *testing.T) {

--- a/pkg/jobs/testutils_test.go
+++ b/pkg/jobs/testutils_test.go
@@ -150,7 +150,10 @@ func registerScopedScheduledJobExecutor(name string, ex ScheduledJobExecutor) fu
 			return ex, nil
 		})
 	return func() {
-		delete(registeredExecutorFactories, name)
+		executorRegistry.Lock()
+		defer executorRegistry.Unlock()
+		delete(executorRegistry.factories, name)
+		delete(executorRegistry.executors, name)
 	}
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #62671.

/cc @cockroachdb/release

---

Rework `TestTransientTxnErrors` to be much simpler and faster.
Instead of creating multiple go routines that try to race
with each other to cause txn restarts, create a simple schedule
that we can manaully synchronize with the test to cause the same
condition.

Unskip this test under race since it now takes 250ms instead of
4-5 seconds.

Fix executor registration mechanism (used in tests) so that defer'ed
cleanup does not race when running multiple test.count executions.

Fixes #62230

Release note: None 
