### PR TITLE
ui: Updating Cluster UI README

### DIFF
--- a/pkg/ui/cluster-ui/README.md
+++ b/pkg/ui/cluster-ui/README.md
@@ -1,66 +1,61 @@
 # Cluster UI Components
 
 This library contains components used by the CockroachDB Console
-and CockroachCloud to display cluster-level information.
+and CockroachCloud Console to display cluster-level information.
 
-```shell
-$ npm install --save-dev @cockroachlabs/cluster-ui
-```
-
-Components are exported individually from the package,
-
-```javascript
-import { Drawer } from "@cockroachlabs/cluster-ui";
-
-export default props => (
-  <div>
-    <Drawer />
-  </div>
-);
-```
-# Overview of how this package interacts with CRDB and CockroachCloud
+## Overview of how this package interacts with CRDB and CockroachCloud
 
 The diagram below describes how this package is published
 and imported in the two application codebases it's used in:
 
 ![@startuml
-title "Javascript Dependency Diagram"
-package "DB Console (cockroachdb/cockroach/pkg/ui)" {
-[DB Console App]
-[protos-js]
+title "Cluster UI, Dependency Diagram"
+folder "cockroachdb/cockroach" {
+  frame "master" {
+    node "pkg/ui" as mui
+    node "pkg/ui/cluster" as mcui
+  }
+  frame "release-21.1" {
+    node "pkg/ui" as 211UI
+    node "pkg/ui/cluster-ui" as 211cui
+  }
+  frame "release-20.2" {
+    node "pkg/ui" as 200UI
+    node "pkg/ui/cluster-ui" as 200cui
+  }
 }
-note bottom of [protos-js] : Client and types\ngenerated from\nprotos in CRDB
-package "Cluster UI (cockroachdb/ui/packages/cluster-ui)" {
-[cluster-ui code]
+cloud "NPM" {
+  frame "@cockroachlabs/cluster-ui" {
+    [21.2.x]
+    [21.1.x]
+    [20.2.x]
+  }
 }
-frame "cockroachlabs/managed-service" {
-[CC Frontend App]
+folder "cockroachlabs/managed-service/console" {
+  [@cockroachlabs/cluster-ui-21-2]
+  [@cockroachlabs/cluster-ui-21-1]
+  [@cockroachlabs/cluster-ui-20-2]
 }
-cloud "NPM Javascript Packages" {
-[crdb-protobuf-client]
-[cluster-ui]
-}
-[protos-js] -> [crdb-protobuf-client] : Manually published
-[cluster-ui code] --> [cluster-ui]: Automatically published\non merge to master
-[cluster-ui code] <-- [crdb-protobuf-client]
-[CC Frontend App] <-- [cluster-ui]
-[DB Console App] <-- [cluster-ui]
-@enduml](http://www.plantuml.com/plantuml/png/TPB1Qjj048RlUef1f_Qmw6vAI29JQ24b57ggVHZjZfMjTsUMtTc0ANttMew99HpVnEZ_Hjy_wBuePgqnDEer4BJVyHMBpJufh2aHEs9xWBN7CMDicuHsZ-Cnjtw4NhZ8aVbanUwpe7rnG_V-tANzs5N_kOM_3S3lMVuXfUqqIbbKYlbJjis_XaK91b6L2BARluGLzC4JAo0xq4EYik6Hc38gETXbYHj-YuDdw7-k7vkBPnzgKShmwzlIi_hkd2cTVSkOY-rb0bOSJOBDBcCaQD-N11nA5v5n96SAvLTlwOptFNpDmahifhOJReDK1-sFvoUOdVZvh73cR7Q3ELKPwixOK-ljqkUaCh-EkRl1mGgUa2k6S81KX-3B2xdcgXeOSxVum0eUgaf4zNR9RbWO8kMHG0KYJi07-xuOSwl9rM6cyBBTx4UvaRW_mZM6_m00)
+[mui] <-l-- [mcui]
+[211UI] <-l-- [211cui]
+[200UI] <-l-- [200cui]
+[mcui] --d-> [21.2.x]
+[211cui] --d-> [21.1.x]
+[200cui] --d-> [20.2.x]
+[21.2.x] --d->[@cockroachlabs/cluster-ui-21-2]
+[21.1.x] --d-> [@cockroachlabs/cluster-ui-21-1]
+[20.2.x] --d-> [@cockroachlabs/cluster-ui-20-2]
+@enduml](http://www.plantuml.com/plantuml/png/XPCnRy8m48Nt-nMdp3KucQiAgImChRemHGp6FcY4ao0xgLfL_FSwN8s5KEIDU_VyFV5EMVb1kM5iBGpDO0cBLplwWHnkDq-ufZDrXZhzW-j67Prg2u13RqtO5xhN9zSh_Mdsozll0dy1yH2S0TMgYSGIOjURe9rFn-NO5AWyjcFpi5XgZcU3lZekYUZ8al8agd9HpdAhijnkS1OjacsUBnVLF5_AxIQFbpBYBm3QzgF1ultZxQwXrQqug_R-3i7XTVYdrU9xTnlAD4ZUSCB3MPZOgauToGXFxglH50xL-TuIu-lP-52mg7PPIvcpo8bo0QZ3hNVuBAmGMBSw351VpnJ5QVgNfKpoD5rbu5SeX14liHM693qMn9IafwuWlkH5je08P7k-ZHYKztCriABEJ1yVuXy0)
 
 To look one level of abstraction below the diagram above, the
 components used in CockroachCloud and CRDB from this package differ
 due to the way that the component state management code integrates
-with the different apps. In CRDB, we import the React page component
+with the different applications. In CRDB, we import the React page component
 and connect it to _existing Redux code that manages state_ whereas
 in CockroachCloud, we import a "Connected component" which is already
 coupled to the Redux code that retrieves and manages its data. In
 CockroachCloud we link the `cluster-ui` redux store to the global
 app store which lets our Connected component store and retrieve data.
-
-We are likely to move the Statements Page Redux/Saga
-code below directly into CockroachCloud's repository
-to clarify the fact that each app manages its own
-state-related code and that none of that is shared.
 
 ![@startuml
 left to right direction
@@ -97,110 +92,48 @@ backgroundColor<<connected>> RosyBrown
 [Statements Page in CC] -> [CC Redux]: Merges its redux\nstate tree with app
 @enduml](http://www.plantuml.com/plantuml/png/dPD1Jzj048Nl_XKZd-0G-OuGefX3KLK9WJWr73RhiRFoUcOrEoP15V-zZ4AeQn9QzPQitypi--RjPLOdEWwnYDWgA8E4RgtG146lWQdGe16X_Ffwl8ZuX14y3ua9IS69NmT5hwCWj2nGnp4h2ZpSBEdaNftYWAGPRbs7W5itf8YdPL4avtixAg-le6RA715EFFjUsFbriwhUVrUfxwend9Rmim3uKT-zLjnXCsuVxUzyH20mnIESdu_acGYzOdDnOTeahBmQM_0n8AdL4ok-6URsemBE8B9t4PvGih6OLqolSmPTv9MBu5A2RFSgNeg9qzze_dGwXkfDaok_qopsVYUeothl1cQcorUp4wjM1n_HV41oKBNpKjsxpXcV5-FcfLajzcWMH-0TbXb1IiDnVf-CFmF1ZGHL98iMu5R5MIJ9KhfXwPUq2Rg6keQSq8SsU1VZir5lnGq8vJlcw5Qv6Xov3fj5HdaA7lU1glyIfzh8JRaTI47zQGPo7oWvSSDadJPxvNpV2O_Kr1nPPlk1QoVzjxNhmo7fL7Z7-VbAU4CsxFYJM5pCylgGCGDkGzP07OYTWkS6bvG4izqoIM01vGdyOjh3UivVpRwnFYVCuAY1BxStRz-AuhEDMxTvZFwZvJ_sEOAgtfLFLleTfSCCGVEEqPAorO4A8bW2RTl59L8p3l4N)
 
-# Version alignment with CRDB releases
+## Version alignment with CRDB releases
 
-`cluster-ui` is dependent on the API of CRDB through a dependency on 
-`crdb-protobuf-clients`. The published version of `cluster-ui` is aligned to
-CRDB by minor versions. These minor versions are maintained on development branches,
-with the latest unreleased version of CRDB being master both in that repository
-and in the `cluster-ui` package.
+`cluster-ui` is dependent on the API of CRDB through a dependency on protobuf clients.
+Since the API can change in incompatible ways between major versions of the database,
+versions of cluster-ui are published following the version scheme of CockroachDB.
 
-| CRDB Version | Cluster UI Version | Cluster UI branch |
-|--------------|--------------------|-------------------|
-| 20.2.x       | 0.1.x              | cluster-ui-20.2   |
-| 21.1.x       | 0.2.x              | cluster-ui-21.1   |
-| 21.2.x       | 0.3.x              | master            |
+| CRDB Version | Cluster UI Version | development branch |
+|--------------|--------------------|--------------------|
+| v20.2.x      | 20.2.x             | release-20.2       |
+| v21.1.x      | 21.1.x             | release-21.1       |
+| v21.2.x      | 21.2.x             | master             |
 
-## 21.1 Release skew
+Note, that the patch versions of the CRDB version and the Cluster UI version will
+not align. The versioning schemes between CRDB and Cluster UI may vary slightly,
+but the goal is to provide guidance about compatibility.
 
-During the release process of CRDB version 21.1, the versions of cluster-ui skewed
-from the above alignment. A release branch was cut for CRDB 21.1 dependent on
-`cluster-ui` version 0.2.15, while development continued on `cluster-ui` against
-the CRDB master branch and was published using the minor versions `0.2.x`. Since
-this development was against the _next_ version of CRDB (21.2), the minor version
-of cluster-ui should have been increased to `0.3.x`.
+## Development Workflow with CRDB
 
-To correct this error, `cluster-ui-21.1` was created from version `0.2.15` and 
-the version increased to version `0.2.43`, and on master we increased the version
-to `0.3.0` to align with `21.2` development. This is confusing, in that the ancestry
-of these versions isn't determined by the minor version.
-
-| CRDB Version | Cluster UI Version |
-|--------------|--------------------|
-| 20.2.x       | 0.1.x              |
-| 21.1.x       | 0.2.0 -> 0.2.15, 0.2.43 -> 0.2.x |
-| 21.2.x       | 0.2.16 -> 0.2.42, 0.3.0 -> 0.3.x |
-
-To account for this, `cluster-ui` versions `0.2.16` to `0.2.42` are deprecated.
-Features from these versions required for CRDB 21.1 are backported to the
-`cluster-ui-21.1` branch and published as versions after `0.2.43`.
-
-# Development Workflow with CRDB
-
-Make sure you have a `node` version that is below `15`. Versions
-above `14` currently cause issues with compiling `node-sass`. This
-is a dependency we will hopefully replace at some point to eliminate
-this blocker. You can either use `brew` or your local package
-manager to install a specific node version or a tool like `nodenv`
-which lets you manage multiple locally installed `node` versions.
-
-If you would like changes in this package to be reflected
-in a locally running DB Console instance, you will need to
-locally link the library to your DB Console project like this:
-
-In `packages/cluster-ui` run:
+The build processes for Cluster UI have been integrated into the `make` commands
+for `/pkg/ui`. The intention is that the development workflow between DB Console
+and Cluster UI components be seamless. If you would like to build cluster-ui
+independently, you can run the following commands,
 
 ```shell
-$ yarn
-$ yarn link
-$ yarn run build:watch
+  > make pkg/ui/yarn.protobuf.installed -B; # to build protobufs cluster-ui depends on
+  > make pkg/ui/yarn.cluster-ui.installed -B; # to build cluster-ui
 ```
 
-Then in `pkg/ui` in CRDB repo run:
+## Development Workflow with CockroachCloud
+
+In CockroachCloud Console, we install multiple *aliased* versions of cluster-ui.
+This, in addition to certain peer dependencies, prevent us from using a traditional
+`yarn link` for local development of cluster-ui. Instead, you must *pack* the dependency
+and install it from a local tarball. To view a local change to cluster-ui in CockroachCloud,
 
 ```shell
-$ yarn link "@cockroachlabs/cluster-ui"
-$ cd ../../
-$ make ui-watch TARGET=http://localhost:8080
-```
-
-Now open up `http://localhost:3000` to see the development
-DB Console which will auto-refresh when you make any changes.
-
-We also recommend installing the React Devtools
-and Redux Devtools to help you in your workflow.
-
-While running a local CRDB cluster. This will link your DB Console
-code to the local copy of `cluster-ui` and the `build:watch` task
-in `cluster-ui` will update the build with any changes you make
-which will get picked up in the `ui-watch` job on the DB side.
-
-## PR Workflow with Protobuf Changes
-
-The process for making a change that also relies on db-level
-protobuf changes will look something like this. See the
-section below for publishing CRDB Protobuf definition updates.
-
-![@startuml
-title "Development process with CRDB when using new protos"
-"CRDB Repo" ->o "CRDB Repo": PR in CRDB with new protos
-"CRDB Repo" -> "NPM": Publish new proto client\n(manual process)
-"NPM" -> "UI Repo": Update version\nin package.json\nto use new client
-"UI Repo" ->o "UI Repo": PR in UI repo with new changes
-"UI Repo" -> "NPM": Version is bumped\nand published automatically
-"NPM" ->o "CRDB Repo": PR in CRDB to update\ncluster-ui version\nin package.json
-@enduml](http://www.plantuml.com/plantuml/png/VP2nJiD038RtF8ML2ORo00oeWYuCe2fIcRAu5ointFbEiQyHRqzpKPK82SO_yMT__-tLSBGSV6Lidg0-q8LyJ87488tHaIfCR0EyD8Tdc0OIoChIWz0q3rZKkghBpuPIh67t566J7-7O0Ck2bqKh-8k3-ltuDWFvx5atW-0yarWhTm4bex-9tLU5AEZfzNRlb3eqWWkDob5QOO64xWjxUlZK-OD5o4fb_RAuAlHglwJL_Ph7QrxrtO3IaswurVvZkGkiSCuXKTSAIWTfAKKTOBOOqDYXzz-bmV-FDkkMIgqudzLet6N-irwr9-boy3y0)
-
-# Development Workflow with CockroachCloud
-
-_Note: The above workflow won't work with CockroachCloud
-due to the fact that `yarn link` works poorly with
-peer dependencies, which redux is for this library._
-
-In `packages/cluster-ui` run:
-
-```shell
-$ yarn build
+# after making your code change,
+# in the root of cockroachdb/cockroach
+$ make pkg/ui/yarn.protobuf.installed -B
+$ make pkg/ui/yarn.cluster-ui.installed -B
+# in pkg/ui/cluster-ui
+$ yarn run build
 $ yarn pack --prod
 ```
 
@@ -209,10 +142,15 @@ And then install the package in `managed-service` repo:
 ```shell
 $ cd /console
 $ yarn cache clean
-$ yarn add --force /Users/<full path to cluster-ui>/cockroachlabs-cluster-ui-vXXXX.tgz
+# yarn add --force [cluster-ui package alias]@[full path to tarball],
+# here's an example
+$ yarn add --force @cockroachlabs/cluster-ui-21-1@/path/to/cockroachlabs-cluster-ui.tgz
 ```
 
-# Storybook
+Test your changes by running CockroachCloud locally, but please be careful to not
+commit the changes to `package.json` or to `yarn.lock`
+
+## Storybook
 
 Learn more about Storybook here: https://storybook.js.org/
 
@@ -246,41 +184,133 @@ Storybook stories **should** use the CSF format as described
 here: https://storybook.js.org/docs/react/api/csf in order to
 facilitate writing unit tests with the storybook components.
 
-# Updating Protobuf definitions from CRDB
+## Publishing Cluster UI package to npm
+WIP
 
-The `cluster-ui` components rely on protobuf types and code from
-CRDB in order to know what data shapes they should expect and how
-to query them. Sometimes you might need to develop components using
-updated definitions that were merged recently or are in progress.
+### 1. Change the version in package.json
+CockroachDB uses a form of [calver](https://calver.org/) versioning where the major part
+is a *Short Year* and the minor part is an iterative number.The micro part (in
+semver, this is called the "patch" part) is also an iterative number. The first
+two numbers comprise a major version of CockroachDB, and the third denotes a minor
+release of that major version. For example, `21.1.6` is a version released in 2021,
+is part of the first major release of that year, and the seventh release in that
+series (`21.1.0` being the first).
 
-The protobuf definitions are currently manually
-published from the CRDB repo into this package:
-https://www.npmjs.com/package/@cockroachlabs/crdb-protobuf-client
+npm package versions must be parseable by [semantic versioning](https://docs.npmjs.com/cli/v6/using-npm/semver). To denote what versions of the cluster-ui package are intended for use with specific major version of CockroachDB, cluster-ui mimicks the version of CockroachDB. For example `cluster-ui@21.1.4` is a version of cluster-ui compatible with the API of CockroachDB version `21.1` and is the fourth release in this major version. It's important to note that `cluster-ui@21.1.4` is **not** directly published from CockroachDB version `21.1.4`. Only that `cluster-ui@21.1.x` was published from CockroachDB branch `release-21.1`.
 
-### How to publish protobuf client updates to npm
+So when incrementing (or "bumping") the version of cluster-ui the only number that should change will be the "patch"
+version (the third number). For example, if you're working on master and find the version to be `21.2.1` you would
+change the version to be `21.2.2`. The version change should accompany the pull-request with the changes to the code, and should be merged with them.
 
-Once you have updated definitions locally, run `make ui-lint`
-to generate them and make sure typescript is run, then modify
-the `pkg/ui/src/js/package.json` file with a new version (if
-your work isn't merged yet, use `0.0.<next>-beta.<integer>`)
-like `0.0.23-beta.0` if the latest one is `0.0.22` and run:
+### 2. Create a git tag
+
+Once a pull-request has been merged into respective branch, a git tag should be made against the commit that contains
+the changes to cluster-ui and the version change. The form of the tag should be `@cockroachlabs/cluster@[version]`
+where `[version]` is the version found in the `package.json`. After creating a tag, push the tag to a remote referencing
+`git@github.com/cockroachdb/cockroach.git`.
 
 ```shell
-$ npm publish --access public
+$ git tag [tag name] [SHA] # SHA can be omitted if desired commit is HEAD
+$ git push [remote] [tag name]
 ```
 
-This will push a new version to npm and you can bump
-the dependency in `pkg/ui` in this repo to use it.
+### Build Cluster UI prerequisites (protobufs, etc)
+To build the prerequisites for cluster-ui run the following commands from the root
+directory of CockroachDB.
 
-If you'd like permission to do this, please ask in #_cc-observability
-on Slack. Otherwise, Observability team is happy to publish a
+```shell
+$ make ui-maintainer-clean
+$ make pkg/ui/yarn.protobuf.installed -B
+$ make pkg/ui/yarn.cluster-ui.installed -B
+```
 
-We're hoping to move this into an automated workflow to publish
-on all merges to `master` on CRDB to remove this pain point.
+### 4. Publish
+If you have not done so already, request publishing permissions from the Cluster
+UI team at Cockroach Labs. You will be required to create an account on [npm](https://www.npmjs.com/)
+and configure two factor authentication. You will then be added to the `@cockroachlabs`
+npm organization and given permission to publish the `clutser-ui` package.
 
-### Expert Level
+Before publishing, ensure that you have authenticated with the npm registry by
+running the following command,
 
-You can use the same `yarn link` workflow described above to
-link the `crdb-protobuf-client` to `cluster-ui` locally if
-you'd like to live on the fully bleeding edge :sunglasses:
+```shell
+$ yarn login
+```
 
+To log in, you will be prompted for your credentials.
+```shell
+$ yarn login
+yarn login v1.22.10
+question npm username: *********
+question npm email: **************@*****.***
+✨  Done in 11.56s.
+```
+
+If you were logged in already, you will see the current authenticated user
+```shell
+$ yarn login
+yarn login v1.XX.XX
+info npm username: xxxxxxxxxxx
+info npm email: xxxxxxxx@xxxxx.zzz
+✨  Done in 0.05s.
+```
+
+Once you have authenticated, you will run the publish command like so
+
+```shell
+$ yarn publish --access public
+```
+
+During a publish you can expect to see some prepublish steps before the package
+is delivered to the registry. `clean` will delete the contents of the `dist`
+directory and `build` will compile TypeScript and bundle the code using Webpack.
+The publish will create a tarball and send it to the registry.
+
+### 5. Add a distribution tag
+We use [distribution tags](https://docs.npmjs.com/adding-dist-tags-to-packages) to organize the versions of `cluster-ui`. By default
+the most recent published version will be tagged as `latest`. Depending on the
+version you are publishing, you will most likely need to add distribution tags to
+the version you published. Our current distribution tags are,
+
+dist tag name| example version | purpose
+-------------|--------
+latest       | 21.1.2 | latest version of major stable version of CRDB
+release-21.1 | 21.1.2 | latest version from version 21.1 of CRDB
+release-20.2 | 20.2.3 | latest version from version 20.2 of CRDB
+next         | 21.2.0-prerelease-1 | latest version of development version of CRDB
+
+At the time of writing, CockroachDB v21.1 is the latest stable version so cluster
+ui versions from this release branch should be tagged as both `latest` and `release-20.1`.
+CockroachDB v21.2 is currently under development and so versions published from
+master should be tagged as `next` and are expected to have a [prerelease identifiers](https://semver.org/#backusnaur-form-grammar-for-valid-semver-versions)
+(a portion of the version appended by a `-`, for example `21.2.0-prerelease-1`)
+This is to designate that a `.0` version of `21.2` should be reserved until CockroachDB v21.2
+is released publicly.
+
+Distribution tags are easily modified and so there should be little concern about
+adding or removing them as needed. To add (or modify) a distribution tag, run the
+following command,
+
+```shell
+$ npm dist-tag add @cockroachlabs/cluster-ui@[version] [dist tag name];
+# for example,
+# npm dist-tag add @cockroachlabs/cluster-ui@21.1.2 release-21.1
+# npm dist-tag add @cockroachlabs/cluster-ui@21.2.0-prerelease-2 next
+# npm dist-tag add @cockroachlabs/cluster-ui@21.1.0 latest
+```
+
+If a mistake is made, simply add again the correct version/tag pair or remove the
+tag with the following command,
+```shell
+$ npm dist-tag rm @cockroachlabs/cluster-ui [dist tag name];
+```
+
+To see what the current distribution tags for cluster-ui, run
+```shell
+$ npm dist-tag ls @cockroachlabs/cluster-ui
+# example output:
+# latest: 21.1.1
+# next: 21.2.0-prerelease-1
+# release-20.2: 20.2.0
+# release-21.1: 21.1.1
+```


### PR DESCRIPTION
After the migration of cluster-ui into this repo, some of the
information about the architecture and running a local development
environment were out of date; updated relevant sections of the README.

Release note: None