### PR TITLE
util/cache: pool short-lived Entry objects

### DIFF
--- a/pkg/util/cache/cache.go
+++ b/pkg/util/cache/cache.go
@@ -16,6 +16,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"sync"
 	"sync/atomic"
 
 	"github.com/biogo/store/llrb"
@@ -69,6 +70,22 @@ type Config struct {
 type Entry struct {
 	Key, Value interface{}
 	next, prev *Entry
+}
+
+// Object pool used for short-lived Entry objects.
+var entryPool = sync.Pool{
+	New: func() interface{} { return &Entry{} },
+}
+
+func newEntry(key interface{}) *Entry {
+	e := entryPool.Get().(*Entry)
+	e.Key = key
+	return e
+}
+
+func (e *Entry) release() {
+	*e = Entry{}
+	entryPool.Put(e)
 }
 
 func (e Entry) String() string {
@@ -399,7 +416,9 @@ func (oc *OrderedCache) init() {
 	oc.llrb = llrb.Tree{}
 }
 func (oc *OrderedCache) get(key interface{}) *Entry {
-	if e, ok := oc.llrb.Get(&Entry{Key: key}).(*Entry); ok {
+	eKey := newEntry(key)
+	defer eKey.release()
+	if e, ok := oc.llrb.Get(eKey).(*Entry); ok {
 		return e
 	}
 	return nil
@@ -416,7 +435,9 @@ func (oc *OrderedCache) length() int {
 
 // CeilEntry returns the smallest cache entry greater than or equal to key.
 func (oc *OrderedCache) CeilEntry(key interface{}) (*Entry, bool) {
-	if e, ok := oc.llrb.Ceil(&Entry{Key: key}).(*Entry); ok {
+	eKey := newEntry(key)
+	defer eKey.release()
+	if e, ok := oc.llrb.Ceil(eKey).(*Entry); ok {
 		return e, true
 	}
 	return nil, false
@@ -432,7 +453,9 @@ func (oc *OrderedCache) Ceil(key interface{}) (interface{}, interface{}, bool) {
 
 // FloorEntry returns the greatest cache entry less than or equal to key.
 func (oc *OrderedCache) FloorEntry(key interface{}) (*Entry, bool) {
-	if e, ok := oc.llrb.Floor(&Entry{Key: key}).(*Entry); ok {
+	eKey := newEntry(key)
+	defer eKey.release()
+	if e, ok := oc.llrb.Floor(eKey).(*Entry); ok {
 		return e, true
 	}
 	return nil, false
@@ -470,9 +493,13 @@ func (oc *OrderedCache) Do(f func(k, v interface{}) bool) bool {
 // DoRangeEntry loop will exit; false, it will continue. DoRangeEntry returns
 // whether the iteration exited early.
 func (oc *OrderedCache) DoRangeEntry(f func(e *Entry) bool, from, to interface{}) bool {
+	eFrom := newEntry(from)
+	eTo := newEntry(to)
+	defer eFrom.release()
+	defer eTo.release()
 	return oc.llrb.DoRange(func(e llrb.Comparable) bool {
 		return f(e.(*Entry))
-	}, &Entry{Key: from}, &Entry{Key: to})
+	}, eFrom, eTo)
 }
 
 // DoRangeReverseEntry invokes f on all cache entries in the range (to, from]. from
@@ -481,9 +508,13 @@ func (oc *OrderedCache) DoRangeEntry(f func(e *Entry) bool, from, to interface{}
 // DoRangeReverseEntry loop will exit; false, it will continue.
 // DoRangeReverseEntry returns whether the iteration exited early.
 func (oc *OrderedCache) DoRangeReverseEntry(f func(e *Entry) bool, from, to interface{}) bool {
+	eFrom := newEntry(from)
+	eTo := newEntry(to)
+	defer eFrom.release()
+	defer eTo.release()
 	return oc.llrb.DoRangeReverse(func(e llrb.Comparable) bool {
 		return f(e.(*Entry))
-	}, &Entry{Key: from}, &Entry{Key: to})
+	}, eFrom, eTo)
 }
 
 // DoRange invokes f on all key-value pairs in the range of from -> to. f


### PR DESCRIPTION
This commit pools short-lived Entry objects used to facilitate lookups into an `OrderedCache`. This avoids heap allocations when retrieving from `OrderedCache` instances, including in `RangeCache.Lookup`.

_microbenchmarks_
```
> benchdiff ./pkg/util/cache

name               old time/op    new time/op    delta
OrderedCache-16      1.24µs ± 2%    1.10µs ± 1%  -11.23%  (p=0.000 n=10+10)
UnorderedCache-16     642ns ± 1%     632ns ± 1%   -1.59%  (p=0.000 n=10+9)
IntervalCache-16     1.56µs ± 2%    1.55µs ± 1%     ~     (p=0.079 n=10+10)

name               old alloc/op   new alloc/op   delta
OrderedCache-16        720B ± 0%      480B ± 0%  -33.33%  (p=0.000 n=10+10)
UnorderedCache-16      576B ± 0%      576B ± 0%     ~     (all equal)
IntervalCache-16       832B ± 0%      832B ± 0%     ~     (all equal)

name               old allocs/op  new allocs/op  delta
OrderedCache-16        15.0 ± 0%      10.0 ± 0%  -33.33%  (p=0.000 n=10+10)
UnorderedCache-16      7.00 ± 0%      7.00 ± 0%     ~     (all equal)
IntervalCache-16       16.0 ± 0%      16.0 ± 0%     ~     (all equal)
```

_kv-level benchmarks_
```
> benchdiff --run='KV/./Native' ./pkg/sql/tests

name                        old time/op    new time/op    delta
KV/Insert/Native/rows=1-16    97.2µs ± 4%    96.3µs ± 5%    ~     (p=0.315 n=9+10)
KV/Update/Native/rows=1-16     151µs ± 3%     152µs ± 3%    ~     (p=0.447 n=10+9)
KV/Delete/Native/rows=1-16    94.5µs ± 2%    96.9µs ± 6%    ~     (p=0.052 n=10+10)
KV/Scan/Native/rows=1-16      28.1µs ± 3%    27.9µs ± 3%    ~     (p=0.497 n=10+9)

name                        old alloc/op   new alloc/op   delta
KV/Scan/Native/rows=1-16      6.46kB ± 0%    6.41kB ± 0%  -0.72%  (p=0.000 n=10+10)
KV/Update/Native/rows=1-16    20.3kB ± 1%    20.2kB ± 1%  -0.39%  (p=0.034 n=10+8)
KV/Insert/Native/rows=1-16    14.0kB ± 1%    13.9kB ± 1%    ~     (p=0.055 n=10+10)
KV/Delete/Native/rows=1-16    13.7kB ± 1%    13.7kB ± 0%    ~     (p=0.591 n=10+10)

name                        old allocs/op  new allocs/op  delta
KV/Scan/Native/rows=1-16        48.0 ± 0%      47.0 ± 0%  -2.08%  (p=0.000 n=10+10)
KV/Update/Native/rows=1-16       173 ± 0%       171 ± 0%  -1.16%  (p=0.000 n=10+8)
KV/Delete/Native/rows=1-16       112 ± 0%       111 ± 0%  -0.89%  (p=0.000 n=10+9)
KV/Insert/Native/rows=1-16       113 ± 0%       112 ± 0%  -0.88%  (p=0.000 n=9+10)
```