### PR TITLE
sql: escape like operator properly

### DIFF
--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -1843,8 +1843,9 @@ func planSelectionOperators(
 			switch cmpOp {
 			case tree.Like, tree.NotLike:
 				negate := cmpOp == tree.NotLike
+				rightString := tree.UnescapePattern(string(tree.MustBeDString(constArg)), `\`)
 				op, err = colexecsel.GetLikeOperator(
-					evalCtx, leftOp, leftIdx, string(tree.MustBeDString(constArg)), negate,
+					evalCtx, leftOp, leftIdx, rightString, negate,
 				)
 			case tree.In, tree.NotIn:
 				negate := cmpOp == tree.NotIn
@@ -2284,9 +2285,9 @@ func planProjectionExpr(
 			switch projOp {
 			case tree.Like, tree.NotLike:
 				negate := projOp == tree.NotLike
+				rightString := tree.UnescapePattern(string(tree.MustBeDString(rConstArg)), `\`)
 				op, err = colexecproj.GetLikeProjectionOperator(
-					allocator, evalCtx, input, leftIdx, resultIdx,
-					string(tree.MustBeDString(rConstArg)), negate,
+					allocator, evalCtx, input, leftIdx, resultIdx, rightString, negate,
 				)
 			case tree.In, tree.NotIn:
 				negate := projOp == tree.NotIn

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -4814,6 +4814,12 @@ func unescapePattern(
 	return string(ret[0:retWidth]), nil
 }
 
+// UnescapePattern is useful for converting a LIKE predicate to a filter
+func UnescapePattern(pattern, escapeToken string) string {
+	s, _ := unescapePattern(pattern, `\`, false)
+	return s
+}
+
 // replaceUnescaped replaces all instances of oldStr that are not escaped (read:
 // preceded) with the specified unescape token with newStr.
 // For example, with an escape token of `\\`


### PR DESCRIPTION
Fixes #44123

This is rough first take needs a test obviously but wanted feedback on general approach.

Release note: none
