### PR TITLE
vendor: bump Pebble to a9e4c56e2fc6

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -612,8 +612,8 @@ def go_deps():
         name = "com_github_cockroachdb_pebble",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/cockroachdb/pebble",
-        sum = "h1:2m8R3O36SP52zVgLarf0n5QSeXD2BwypmRGZhh7Otns=",
-        version = "v0.0.0-20210601160505-25f8258be7ea",
+        sum = "h1:zzOXU92hb+aeG0GjjJw5miY2aZ+dMT1cHJdlhKqdvFE=",
+        version = "v0.0.0-20210614215137-a9e4c56e2fc6",
     )
 
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f
-	github.com/cockroachdb/pebble v0.0.0-20210601160505-25f8258be7ea
+	github.com/cockroachdb/pebble v0.0.0-20210614215137-a9e4c56e2fc6
 	github.com/cockroachdb/redact v1.0.9
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2

--- a/go.sum
+++ b/go.sum
@@ -259,8 +259,8 @@ github.com/cockroachdb/gostdlib v1.13.0 h1:TzSEPYgkKDNei3gbLc0rrHu4iHyBp7/+NxPOF
 github.com/cockroachdb/gostdlib v1.13.0/go.mod h1:eXX95p9QDrYwJfJ6AgeN9QnRa/lqqid9LAzWz/l5OgA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f h1:o/kfcElHqOiXqcou5a3rIlMc7oJbMQkeLk0VQJ7zgqY=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/cockroachdb/pebble v0.0.0-20210601160505-25f8258be7ea h1:2m8R3O36SP52zVgLarf0n5QSeXD2BwypmRGZhh7Otns=
-github.com/cockroachdb/pebble v0.0.0-20210601160505-25f8258be7ea/go.mod h1:1XpB4cLQcF189RAcWi4gUc110zJgtOfT7SVNGY8sOe0=
+github.com/cockroachdb/pebble v0.0.0-20210614215137-a9e4c56e2fc6 h1:zzOXU92hb+aeG0GjjJw5miY2aZ+dMT1cHJdlhKqdvFE=
+github.com/cockroachdb/pebble v0.0.0-20210614215137-a9e4c56e2fc6/go.mod h1:1XpB4cLQcF189RAcWi4gUc110zJgtOfT7SVNGY8sOe0=
 github.com/cockroachdb/pq v0.0.0-20210517091544-990dd3347596 h1:xTc0ViFhuelzQZAYQOxMR2J5QDO9/C+0L0fkPXIcoMI=
 github.com/cockroachdb/pq v0.0.0-20210517091544-990dd3347596/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/cockroachdb/redact v1.0.8/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=


### PR DESCRIPTION
```
a9e4c56e vfs: add OnDiskFull VFS wrapper
a7f14024 sstable: vectorize shared prefix byte comparison
abf31e35 sstable: add shared prefix to BenchmarkWriter
91c52f60 compaction: hoist nilPacer check outside compaction loop
```

Release note: none