### PR TITLE
release-21.1: sql: add a hint for timestamptz -> string error

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -317,6 +317,20 @@ CREATE TABLE y (
   b TIMESTAMP AS (a::TIMESTAMP) STORED
 )
 
+# Make sure the error has a hint that mentions AT TIME ZONE.
+statement error context-dependent operators are not allowed in computed column.*\nHINT:.*AT TIME ZONE
+CREATE TABLE y (
+  a TIMESTAMPTZ,
+  b STRING AS (a::STRING) STORED
+)
+
+# Make sure the error has a hint that mentions AT TIME ZONE.
+statement error context-dependent operators are not allowed in computed column.*\nHINT:.*AT TIME ZONE
+CREATE TABLE y (
+  a TIMESTAMPTZ,
+  b TIMESTAMP AS (a::TIMESTAMP) STORED
+)
+
 statement error context-dependent operators are not allowed in computed column
 CREATE TABLE y (
   a TIMESTAMPTZ,

--- a/pkg/sql/sem/tree/casts.go
+++ b/pkg/sql/sem/tree/casts.go
@@ -42,6 +42,11 @@ type castInfo struct {
 	to         types.Family
 	volatility Volatility
 
+	// volatilityHint is an optional string for VolatilityStable casts. When set,
+	// it is used as an error hint suggesting a possible workaround when stable
+	// casts are not allowed.
+	volatilityHint string
+
 	// Telemetry counter; set by init().
 	counter telemetry.Counter
 
@@ -170,7 +175,10 @@ var validCasts = []castInfo{
 	{from: types.GeographyFamily, to: types.StringFamily, volatility: VolatilityImmutable},
 	{from: types.BytesFamily, to: types.StringFamily, volatility: VolatilityStable},
 	{from: types.TimestampFamily, to: types.StringFamily, volatility: VolatilityImmutable},
-	{from: types.TimestampTZFamily, to: types.StringFamily, volatility: VolatilityStable},
+	{
+		from: types.TimestampTZFamily, to: types.StringFamily, volatility: VolatilityStable,
+		volatilityHint: "TIMESTAMPTZ to STRING casts depend on the current timezone; consider using (t AT TIME ZONE 'UTC')::STRING instead.",
+	},
 	{from: types.IntervalFamily, to: types.StringFamily, volatility: VolatilityImmutable},
 	{from: types.UuidFamily, to: types.StringFamily, volatility: VolatilityImmutable},
 	{from: types.DateFamily, to: types.StringFamily, volatility: VolatilityImmutable},
@@ -246,11 +254,17 @@ var validCasts = []castInfo{
 
 	// Casts to TimestampFamily.
 	{from: types.UnknownFamily, to: types.TimestampFamily, volatility: VolatilityImmutable},
-	{from: types.StringFamily, to: types.TimestampFamily, volatility: VolatilityStable},
+	{
+		from: types.StringFamily, to: types.TimestampFamily, volatility: VolatilityStable,
+		volatilityHint: "STRING to TIMESTAMP casts are context-dependent because of relative timestamp strings like 'now'; use parse_timestamp() instead.",
+	},
 	{from: types.CollatedStringFamily, to: types.TimestampFamily, volatility: VolatilityStable},
 	{from: types.DateFamily, to: types.TimestampFamily, volatility: VolatilityImmutable},
 	{from: types.TimestampFamily, to: types.TimestampFamily, volatility: VolatilityImmutable},
-	{from: types.TimestampTZFamily, to: types.TimestampFamily, volatility: VolatilityStable},
+	{
+		from: types.TimestampTZFamily, to: types.TimestampFamily, volatility: VolatilityStable,
+		volatilityHint: "TIMESTAMPTZ to TIMESTAMP casts depend on the current timezone; consider using AT TIME ZONE 'UTC' instead",
+	},
 	{from: types.IntFamily, to: types.TimestampFamily, volatility: VolatilityImmutable},
 
 	// Casts to TimestampTZFamily.

--- a/pkg/sql/sem/tree/datum_invariants_test.go
+++ b/pkg/sql/sem/tree/datum_invariants_test.go
@@ -22,7 +22,7 @@ func TestAllTypesCastableToString(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	for _, typ := range types.Scalar {
-		if ok, _, _ := isCastDeepValid(typ, types.String); !ok {
+		if err := resolveCast("", typ, types.String, true /* allowStable */); err != nil {
 			t.Errorf("%s is not castable to STRING, all types should be", typ)
 		}
 	}
@@ -32,7 +32,7 @@ func TestAllTypesCastableFromString(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	for _, typ := range types.Scalar {
-		if ok, _, _ := isCastDeepValid(types.String, typ); !ok {
+		if err := resolveCast("", types.String, typ, true /* allowStable */); err != nil {
 			t.Errorf("%s is not castable from STRING, all types should be", typ)
 		}
 	}


### PR DESCRIPTION
Backport 1/1 commits from #66454.

/cc @cockroachdb/release

---

This adds a hint to the error that you get if you try to cast a
TIMESTAMPTZ to STRING in a computed column expression. It mentions a
workaround where you first convert to a timestamp using a specific
timezone.

Release note: None
