### PR TITLE
execgen: improve templating engine

### DIFF
--- a/pkg/sql/colconv/vec_to_datum.eg.go
+++ b/pkg/sql/colconv/vec_to_datum.eg.go
@@ -251,598 +251,724 @@ func ColVecToDatumAndDeselect(
 	}
 	if col.MaybeHasNulls() {
 		nulls := col.Nulls()
-		_ = converted[length-1]
-		_ = sel[length-1]
-		var idx, destIdx, srcIdx int
-		switch ct := col.Type(); ct.Family() {
-		case types.StringFamily:
-			// Note that there is no need for a copy since casting to a string will
-			// do that.
-			bytes := col.Bytes()
-			if ct.Oid() == oid.T_name {
+		{
+			_ = converted[length-1]
+			_ = sel[length-1]
+			var idx, destIdx, srcIdx int
+			switch ct := col.Type(); ct.Family() {
+			case types.StringFamily:
+				// Note that there is no need for a copy since casting to a string will
+				// do that.
+				bytes := col.Bytes()
+				if ct.Oid() == oid.T_name {
+					for idx = 0; idx < length; idx++ {
+						{
+							destIdx = idx
+						}
+						{
+							//gcassert:bce
+							srcIdx = sel[idx]
+						}
+						if nulls.NullAt(srcIdx) {
+							converted[destIdx] = tree.DNull
+							continue
+						}
+						v := da.NewDName(tree.DString(bytes.Get(srcIdx)))
+						converted[destIdx] = v
+					}
+					goto vecToDatum_true_true_true_return_0
+				}
 				for idx = 0; idx < length; idx++ {
-					destIdx = idx
-					//gcassert:bce
-					srcIdx = sel[idx]
-					if nulls.NullAt(srcIdx) {
+					{
+						destIdx = idx
+					}
+					{
 						//gcassert:bce
+						srcIdx = sel[idx]
+					}
+					if nulls.NullAt(srcIdx) {
 						converted[destIdx] = tree.DNull
 						continue
 					}
-					v := da.NewDName(tree.DString(bytes.Get(srcIdx)))
-					//gcassert:bce
+					v := da.NewDString(tree.DString(bytes.Get(srcIdx)))
 					converted[destIdx] = v
 				}
-				return
-			}
-			for idx = 0; idx < length; idx++ {
-				destIdx = idx
-				//gcassert:bce
-				srcIdx = sel[idx]
-				if nulls.NullAt(srcIdx) {
-					//gcassert:bce
-					converted[destIdx] = tree.DNull
-					continue
-				}
-				v := da.NewDString(tree.DString(bytes.Get(srcIdx)))
-				//gcassert:bce
-				converted[destIdx] = v
-			}
-		case types.BoolFamily:
-			switch ct.Width() {
-			case -1:
-			default:
-				typedCol := col.Bool()
-				for idx = 0; idx < length; idx++ {
-					destIdx = idx
-					//gcassert:bce
-					srcIdx = sel[idx]
-					if nulls.NullAt(srcIdx) {
-						//gcassert:bce
-						converted[destIdx] = tree.DNull
-						continue
+			case types.BoolFamily:
+				switch ct.Width() {
+				case -1:
+				default:
+					typedCol := col.Bool()
+					_ = true
+					for idx = 0; idx < length; idx++ {
+						{
+							destIdx = idx
+						}
+						{
+							//gcassert:bce
+							srcIdx = sel[idx]
+						}
+						if nulls.NullAt(srcIdx) {
+							converted[destIdx] = tree.DNull
+							continue
+						}
+						_ = true
+						v := typedCol.Get(srcIdx)
+						_converted := tree.MakeDBool(tree.DBool(v))
+						converted[destIdx] = _converted
 					}
-					v := typedCol.Get(srcIdx)
-					_converted := tree.MakeDBool(tree.DBool(v))
-					//gcassert:bce
-					converted[destIdx] = _converted
 				}
-			}
-		case types.IntFamily:
-			switch ct.Width() {
-			case 16:
-				typedCol := col.Int16()
-				for idx = 0; idx < length; idx++ {
-					destIdx = idx
-					//gcassert:bce
-					srcIdx = sel[idx]
-					if nulls.NullAt(srcIdx) {
-						//gcassert:bce
-						converted[destIdx] = tree.DNull
-						continue
+			case types.IntFamily:
+				switch ct.Width() {
+				case 16:
+					typedCol := col.Int16()
+					_ = true
+					for idx = 0; idx < length; idx++ {
+						{
+							destIdx = idx
+						}
+						{
+							//gcassert:bce
+							srcIdx = sel[idx]
+						}
+						if nulls.NullAt(srcIdx) {
+							converted[destIdx] = tree.DNull
+							continue
+						}
+						_ = true
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDInt(tree.DInt(v))
+						converted[destIdx] = _converted
 					}
-					v := typedCol.Get(srcIdx)
-					_converted := da.NewDInt(tree.DInt(v))
-					//gcassert:bce
-					converted[destIdx] = _converted
+				case 32:
+					typedCol := col.Int32()
+					_ = true
+					for idx = 0; idx < length; idx++ {
+						{
+							destIdx = idx
+						}
+						{
+							//gcassert:bce
+							srcIdx = sel[idx]
+						}
+						if nulls.NullAt(srcIdx) {
+							converted[destIdx] = tree.DNull
+							continue
+						}
+						_ = true
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDInt(tree.DInt(v))
+						converted[destIdx] = _converted
+					}
+				case -1:
+				default:
+					typedCol := col.Int64()
+					_ = true
+					for idx = 0; idx < length; idx++ {
+						{
+							destIdx = idx
+						}
+						{
+							//gcassert:bce
+							srcIdx = sel[idx]
+						}
+						if nulls.NullAt(srcIdx) {
+							converted[destIdx] = tree.DNull
+							continue
+						}
+						_ = true
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDInt(tree.DInt(v))
+						converted[destIdx] = _converted
+					}
 				}
-			case 32:
-				typedCol := col.Int32()
-				for idx = 0; idx < length; idx++ {
-					destIdx = idx
-					//gcassert:bce
-					srcIdx = sel[idx]
-					if nulls.NullAt(srcIdx) {
-						//gcassert:bce
-						converted[destIdx] = tree.DNull
-						continue
+			case types.FloatFamily:
+				switch ct.Width() {
+				case -1:
+				default:
+					typedCol := col.Float64()
+					_ = true
+					for idx = 0; idx < length; idx++ {
+						{
+							destIdx = idx
+						}
+						{
+							//gcassert:bce
+							srcIdx = sel[idx]
+						}
+						if nulls.NullAt(srcIdx) {
+							converted[destIdx] = tree.DNull
+							continue
+						}
+						_ = true
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDFloat(tree.DFloat(v))
+						converted[destIdx] = _converted
 					}
-					v := typedCol.Get(srcIdx)
-					_converted := da.NewDInt(tree.DInt(v))
-					//gcassert:bce
-					converted[destIdx] = _converted
 				}
-			case -1:
-			default:
-				typedCol := col.Int64()
-				for idx = 0; idx < length; idx++ {
-					destIdx = idx
-					//gcassert:bce
-					srcIdx = sel[idx]
-					if nulls.NullAt(srcIdx) {
-						//gcassert:bce
-						converted[destIdx] = tree.DNull
-						continue
+			case types.DecimalFamily:
+				switch ct.Width() {
+				case -1:
+				default:
+					typedCol := col.Decimal()
+					_ = true
+					for idx = 0; idx < length; idx++ {
+						{
+							destIdx = idx
+						}
+						{
+							//gcassert:bce
+							srcIdx = sel[idx]
+						}
+						if nulls.NullAt(srcIdx) {
+							converted[destIdx] = tree.DNull
+							continue
+						}
+						_ = true
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDDecimal(tree.DDecimal{Decimal: v})
+						// Clear the Coeff so that the Set below allocates a new slice for the
+						// Coeff.abs field.
+						_converted.Coeff = big.Int{}
+						_converted.Coeff.Set(&v.Coeff)
+						converted[destIdx] = _converted
 					}
-					v := typedCol.Get(srcIdx)
-					_converted := da.NewDInt(tree.DInt(v))
-					//gcassert:bce
-					converted[destIdx] = _converted
 				}
-			}
-		case types.FloatFamily:
-			switch ct.Width() {
-			case -1:
-			default:
-				typedCol := col.Float64()
-				for idx = 0; idx < length; idx++ {
-					destIdx = idx
-					//gcassert:bce
-					srcIdx = sel[idx]
-					if nulls.NullAt(srcIdx) {
-						//gcassert:bce
-						converted[destIdx] = tree.DNull
-						continue
+			case types.DateFamily:
+				switch ct.Width() {
+				case -1:
+				default:
+					typedCol := col.Int64()
+					_ = true
+					for idx = 0; idx < length; idx++ {
+						{
+							destIdx = idx
+						}
+						{
+							//gcassert:bce
+							srcIdx = sel[idx]
+						}
+						if nulls.NullAt(srcIdx) {
+							converted[destIdx] = tree.DNull
+							continue
+						}
+						_ = true
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDDate(tree.DDate{Date: pgdate.MakeCompatibleDateFromDisk(v)})
+						converted[destIdx] = _converted
 					}
-					v := typedCol.Get(srcIdx)
-					_converted := da.NewDFloat(tree.DFloat(v))
-					//gcassert:bce
-					converted[destIdx] = _converted
 				}
-			}
-		case types.DecimalFamily:
-			switch ct.Width() {
-			case -1:
-			default:
-				typedCol := col.Decimal()
-				for idx = 0; idx < length; idx++ {
-					destIdx = idx
-					//gcassert:bce
-					srcIdx = sel[idx]
-					if nulls.NullAt(srcIdx) {
-						//gcassert:bce
-						converted[destIdx] = tree.DNull
-						continue
+			case types.BytesFamily:
+				switch ct.Width() {
+				case -1:
+				default:
+					typedCol := col.Bytes()
+					for idx = 0; idx < length; idx++ {
+						{
+							destIdx = idx
+						}
+						{
+							//gcassert:bce
+							srcIdx = sel[idx]
+						}
+						if nulls.NullAt(srcIdx) {
+							converted[destIdx] = tree.DNull
+							continue
+						}
+						v := typedCol.Get(srcIdx)
+						// Note that there is no need for a copy since DBytes uses a string
+						// as underlying storage, which will perform the copy for us.
+						_converted := da.NewDBytes(tree.DBytes(v))
+						converted[destIdx] = _converted
 					}
-					v := typedCol.Get(srcIdx)
-					_converted := da.NewDDecimal(tree.DDecimal{Decimal: v})
-					// Clear the Coeff so that the Set below allocates a new slice for the
-					// Coeff.abs field.
-					_converted.Coeff = big.Int{}
-					_converted.Coeff.Set(&v.Coeff)
-					//gcassert:bce
-					converted[destIdx] = _converted
 				}
-			}
-		case types.DateFamily:
-			switch ct.Width() {
-			case -1:
-			default:
-				typedCol := col.Int64()
-				for idx = 0; idx < length; idx++ {
-					destIdx = idx
-					//gcassert:bce
-					srcIdx = sel[idx]
-					if nulls.NullAt(srcIdx) {
-						//gcassert:bce
-						converted[destIdx] = tree.DNull
-						continue
-					}
-					v := typedCol.Get(srcIdx)
-					_converted := da.NewDDate(tree.DDate{Date: pgdate.MakeCompatibleDateFromDisk(v)})
-					//gcassert:bce
-					converted[destIdx] = _converted
-				}
-			}
-		case types.BytesFamily:
-			switch ct.Width() {
-			case -1:
-			default:
-				typedCol := col.Bytes()
-				for idx = 0; idx < length; idx++ {
-					destIdx = idx
-					//gcassert:bce
-					srcIdx = sel[idx]
-					if nulls.NullAt(srcIdx) {
-						//gcassert:bce
-						converted[destIdx] = tree.DNull
-						continue
-					}
-					v := typedCol.Get(srcIdx)
-					// Note that there is no need for a copy since DBytes uses a string
-					// as underlying storage, which will perform the copy for us.
-					_converted := da.NewDBytes(tree.DBytes(v))
-					//gcassert:bce
-					converted[destIdx] = _converted
-				}
-			}
-		case types.JsonFamily:
-			switch ct.Width() {
-			case -1:
-			default:
-				typedCol := col.JSON()
-				for idx = 0; idx < length; idx++ {
-					destIdx = idx
-					//gcassert:bce
-					srcIdx = sel[idx]
-					if nulls.NullAt(srcIdx) {
-						//gcassert:bce
-						converted[destIdx] = tree.DNull
-						continue
-					}
-					v := typedCol.Get(srcIdx)
+			case types.JsonFamily:
+				switch ct.Width() {
+				case -1:
+				default:
+					typedCol := col.JSON()
+					for idx = 0; idx < length; idx++ {
+						{
+							destIdx = idx
+						}
+						{
+							//gcassert:bce
+							srcIdx = sel[idx]
+						}
+						if nulls.NullAt(srcIdx) {
+							converted[destIdx] = tree.DNull
+							continue
+						}
+						v := typedCol.Get(srcIdx)
 
-					// The following operation deliberately copies the input JSON
-					// bytes, since FromEncoding is lazy and keeps a handle on the bytes
-					// it is passed in.
-					_bytes, _err := json.EncodeJSON(nil, v)
-					if _err != nil {
-						colexecerror.ExpectedError(_err)
+						// The following operation deliberately copies the input JSON
+						// bytes, since FromEncoding is lazy and keeps a handle on the bytes
+						// it is passed in.
+						_bytes, _err := json.EncodeJSON(nil, v)
+						if _err != nil {
+							colexecerror.ExpectedError(_err)
+						}
+						var _j json.JSON
+						_j, _err = json.FromEncoding(_bytes)
+						if _err != nil {
+							colexecerror.ExpectedError(_err)
+						}
+						_converted := da.NewDJSON(tree.DJSON{JSON: _j})
+						converted[destIdx] = _converted
 					}
-					var _j json.JSON
-					_j, _err = json.FromEncoding(_bytes)
-					if _err != nil {
-						colexecerror.ExpectedError(_err)
-					}
-					_converted := da.NewDJSON(tree.DJSON{JSON: _j})
-					//gcassert:bce
-					converted[destIdx] = _converted
 				}
-			}
-		case types.UuidFamily:
-			switch ct.Width() {
-			case -1:
+			case types.UuidFamily:
+				switch ct.Width() {
+				case -1:
+				default:
+					typedCol := col.Bytes()
+					for idx = 0; idx < length; idx++ {
+						{
+							destIdx = idx
+						}
+						{
+							//gcassert:bce
+							srcIdx = sel[idx]
+						}
+						if nulls.NullAt(srcIdx) {
+							converted[destIdx] = tree.DNull
+							continue
+						}
+						v := typedCol.Get(srcIdx)
+						// Note that there is no need for a copy because uuid.FromBytes
+						// will perform a copy.
+						id, err := uuid.FromBytes(v)
+						if err != nil {
+							colexecerror.InternalError(err)
+						}
+						_converted := da.NewDUuid(tree.DUuid{UUID: id})
+						converted[destIdx] = _converted
+					}
+				}
+			case types.TimestampFamily:
+				switch ct.Width() {
+				case -1:
+				default:
+					typedCol := col.Timestamp()
+					_ = true
+					for idx = 0; idx < length; idx++ {
+						{
+							destIdx = idx
+						}
+						{
+							//gcassert:bce
+							srcIdx = sel[idx]
+						}
+						if nulls.NullAt(srcIdx) {
+							converted[destIdx] = tree.DNull
+							continue
+						}
+						_ = true
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDTimestamp(tree.DTimestamp{Time: v})
+						converted[destIdx] = _converted
+					}
+				}
+			case types.TimestampTZFamily:
+				switch ct.Width() {
+				case -1:
+				default:
+					typedCol := col.Timestamp()
+					_ = true
+					for idx = 0; idx < length; idx++ {
+						{
+							destIdx = idx
+						}
+						{
+							//gcassert:bce
+							srcIdx = sel[idx]
+						}
+						if nulls.NullAt(srcIdx) {
+							converted[destIdx] = tree.DNull
+							continue
+						}
+						_ = true
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDTimestampTZ(tree.DTimestampTZ{Time: v})
+						converted[destIdx] = _converted
+					}
+				}
+			case types.IntervalFamily:
+				switch ct.Width() {
+				case -1:
+				default:
+					typedCol := col.Interval()
+					_ = true
+					for idx = 0; idx < length; idx++ {
+						{
+							destIdx = idx
+						}
+						{
+							//gcassert:bce
+							srcIdx = sel[idx]
+						}
+						if nulls.NullAt(srcIdx) {
+							converted[destIdx] = tree.DNull
+							continue
+						}
+						_ = true
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDInterval(tree.DInterval{Duration: v})
+						converted[destIdx] = _converted
+					}
+				}
+			case typeconv.DatumVecCanonicalTypeFamily:
 			default:
-				typedCol := col.Bytes()
-				for idx = 0; idx < length; idx++ {
-					destIdx = idx
-					//gcassert:bce
-					srcIdx = sel[idx]
-					if nulls.NullAt(srcIdx) {
-						//gcassert:bce
-						converted[destIdx] = tree.DNull
-						continue
+				switch ct.Width() {
+				case -1:
+				default:
+					typedCol := col.Datum()
+					for idx = 0; idx < length; idx++ {
+						{
+							destIdx = idx
+						}
+						{
+							//gcassert:bce
+							srcIdx = sel[idx]
+						}
+						if nulls.NullAt(srcIdx) {
+							converted[destIdx] = tree.DNull
+							continue
+						}
+						v := typedCol.Get(srcIdx)
+						_converted := v.(*coldataext.Datum).Datum
+						converted[destIdx] = _converted
 					}
-					v := typedCol.Get(srcIdx)
-					// Note that there is no need for a copy because uuid.FromBytes
-					// will perform a copy.
-					id, err := uuid.FromBytes(v)
-					if err != nil {
-						colexecerror.InternalError(err)
-					}
-					_converted := da.NewDUuid(tree.DUuid{UUID: id})
-					//gcassert:bce
-					converted[destIdx] = _converted
 				}
 			}
-		case types.TimestampFamily:
-			switch ct.Width() {
-			case -1:
-			default:
-				typedCol := col.Timestamp()
-				for idx = 0; idx < length; idx++ {
-					destIdx = idx
-					//gcassert:bce
-					srcIdx = sel[idx]
-					if nulls.NullAt(srcIdx) {
-						//gcassert:bce
-						converted[destIdx] = tree.DNull
-						continue
-					}
-					v := typedCol.Get(srcIdx)
-					_converted := da.NewDTimestamp(tree.DTimestamp{Time: v})
-					//gcassert:bce
-					converted[destIdx] = _converted
-				}
-			}
-		case types.TimestampTZFamily:
-			switch ct.Width() {
-			case -1:
-			default:
-				typedCol := col.Timestamp()
-				for idx = 0; idx < length; idx++ {
-					destIdx = idx
-					//gcassert:bce
-					srcIdx = sel[idx]
-					if nulls.NullAt(srcIdx) {
-						//gcassert:bce
-						converted[destIdx] = tree.DNull
-						continue
-					}
-					v := typedCol.Get(srcIdx)
-					_converted := da.NewDTimestampTZ(tree.DTimestampTZ{Time: v})
-					//gcassert:bce
-					converted[destIdx] = _converted
-				}
-			}
-		case types.IntervalFamily:
-			switch ct.Width() {
-			case -1:
-			default:
-				typedCol := col.Interval()
-				for idx = 0; idx < length; idx++ {
-					destIdx = idx
-					//gcassert:bce
-					srcIdx = sel[idx]
-					if nulls.NullAt(srcIdx) {
-						//gcassert:bce
-						converted[destIdx] = tree.DNull
-						continue
-					}
-					v := typedCol.Get(srcIdx)
-					_converted := da.NewDInterval(tree.DInterval{Duration: v})
-					//gcassert:bce
-					converted[destIdx] = _converted
-				}
-			}
-		case typeconv.DatumVecCanonicalTypeFamily:
-		default:
-			switch ct.Width() {
-			case -1:
-			default:
-				typedCol := col.Datum()
-				for idx = 0; idx < length; idx++ {
-					destIdx = idx
-					//gcassert:bce
-					srcIdx = sel[idx]
-					if nulls.NullAt(srcIdx) {
-						//gcassert:bce
-						converted[destIdx] = tree.DNull
-						continue
-					}
-					v := typedCol.Get(srcIdx)
-					_converted := v.(*coldataext.Datum).Datum
-					//gcassert:bce
-					converted[destIdx] = _converted
-				}
-			}
+		vecToDatum_true_true_true_return_0:
 		}
 	} else {
-		_ = converted[length-1]
-		_ = sel[length-1]
-		var idx, destIdx, srcIdx int
-		switch ct := col.Type(); ct.Family() {
-		case types.StringFamily:
-			// Note that there is no need for a copy since casting to a string will
-			// do that.
-			bytes := col.Bytes()
-			if ct.Oid() == oid.T_name {
+		{
+			_ = converted[length-1]
+			_ = sel[length-1]
+			var idx, destIdx, srcIdx int
+			switch ct := col.Type(); ct.Family() {
+			case types.StringFamily:
+				// Note that there is no need for a copy since casting to a string will
+				// do that.
+				bytes := col.Bytes()
+				if ct.Oid() == oid.T_name {
+					for idx = 0; idx < length; idx++ {
+						{
+							destIdx = idx
+						}
+						{
+							//gcassert:bce
+							srcIdx = sel[idx]
+						}
+						v := da.NewDName(tree.DString(bytes.Get(srcIdx)))
+						converted[destIdx] = v
+					}
+					goto vecToDatum_false_true_true_return_1
+				}
 				for idx = 0; idx < length; idx++ {
-					destIdx = idx
-					//gcassert:bce
-					srcIdx = sel[idx]
-					v := da.NewDName(tree.DString(bytes.Get(srcIdx)))
-					//gcassert:bce
+					{
+						destIdx = idx
+					}
+					{
+						//gcassert:bce
+						srcIdx = sel[idx]
+					}
+					v := da.NewDString(tree.DString(bytes.Get(srcIdx)))
 					converted[destIdx] = v
 				}
-				return
-			}
-			for idx = 0; idx < length; idx++ {
-				destIdx = idx
-				//gcassert:bce
-				srcIdx = sel[idx]
-				v := da.NewDString(tree.DString(bytes.Get(srcIdx)))
-				//gcassert:bce
-				converted[destIdx] = v
-			}
-		case types.BoolFamily:
-			switch ct.Width() {
-			case -1:
-			default:
-				typedCol := col.Bool()
-				for idx = 0; idx < length; idx++ {
-					destIdx = idx
-					//gcassert:bce
-					srcIdx = sel[idx]
-					v := typedCol.Get(srcIdx)
-					_converted := tree.MakeDBool(tree.DBool(v))
-					//gcassert:bce
-					converted[destIdx] = _converted
+			case types.BoolFamily:
+				switch ct.Width() {
+				case -1:
+				default:
+					typedCol := col.Bool()
+					_ = true
+					for idx = 0; idx < length; idx++ {
+						{
+							destIdx = idx
+						}
+						{
+							//gcassert:bce
+							srcIdx = sel[idx]
+						}
+						_ = true
+						v := typedCol.Get(srcIdx)
+						_converted := tree.MakeDBool(tree.DBool(v))
+						converted[destIdx] = _converted
+					}
 				}
-			}
-		case types.IntFamily:
-			switch ct.Width() {
-			case 16:
-				typedCol := col.Int16()
-				for idx = 0; idx < length; idx++ {
-					destIdx = idx
-					//gcassert:bce
-					srcIdx = sel[idx]
-					v := typedCol.Get(srcIdx)
-					_converted := da.NewDInt(tree.DInt(v))
-					//gcassert:bce
-					converted[destIdx] = _converted
+			case types.IntFamily:
+				switch ct.Width() {
+				case 16:
+					typedCol := col.Int16()
+					_ = true
+					for idx = 0; idx < length; idx++ {
+						{
+							destIdx = idx
+						}
+						{
+							//gcassert:bce
+							srcIdx = sel[idx]
+						}
+						_ = true
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDInt(tree.DInt(v))
+						converted[destIdx] = _converted
+					}
+				case 32:
+					typedCol := col.Int32()
+					_ = true
+					for idx = 0; idx < length; idx++ {
+						{
+							destIdx = idx
+						}
+						{
+							//gcassert:bce
+							srcIdx = sel[idx]
+						}
+						_ = true
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDInt(tree.DInt(v))
+						converted[destIdx] = _converted
+					}
+				case -1:
+				default:
+					typedCol := col.Int64()
+					_ = true
+					for idx = 0; idx < length; idx++ {
+						{
+							destIdx = idx
+						}
+						{
+							//gcassert:bce
+							srcIdx = sel[idx]
+						}
+						_ = true
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDInt(tree.DInt(v))
+						converted[destIdx] = _converted
+					}
 				}
-			case 32:
-				typedCol := col.Int32()
-				for idx = 0; idx < length; idx++ {
-					destIdx = idx
-					//gcassert:bce
-					srcIdx = sel[idx]
-					v := typedCol.Get(srcIdx)
-					_converted := da.NewDInt(tree.DInt(v))
-					//gcassert:bce
-					converted[destIdx] = _converted
+			case types.FloatFamily:
+				switch ct.Width() {
+				case -1:
+				default:
+					typedCol := col.Float64()
+					_ = true
+					for idx = 0; idx < length; idx++ {
+						{
+							destIdx = idx
+						}
+						{
+							//gcassert:bce
+							srcIdx = sel[idx]
+						}
+						_ = true
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDFloat(tree.DFloat(v))
+						converted[destIdx] = _converted
+					}
 				}
-			case -1:
-			default:
-				typedCol := col.Int64()
-				for idx = 0; idx < length; idx++ {
-					destIdx = idx
-					//gcassert:bce
-					srcIdx = sel[idx]
-					v := typedCol.Get(srcIdx)
-					_converted := da.NewDInt(tree.DInt(v))
-					//gcassert:bce
-					converted[destIdx] = _converted
+			case types.DecimalFamily:
+				switch ct.Width() {
+				case -1:
+				default:
+					typedCol := col.Decimal()
+					_ = true
+					for idx = 0; idx < length; idx++ {
+						{
+							destIdx = idx
+						}
+						{
+							//gcassert:bce
+							srcIdx = sel[idx]
+						}
+						_ = true
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDDecimal(tree.DDecimal{Decimal: v})
+						// Clear the Coeff so that the Set below allocates a new slice for the
+						// Coeff.abs field.
+						_converted.Coeff = big.Int{}
+						_converted.Coeff.Set(&v.Coeff)
+						converted[destIdx] = _converted
+					}
 				}
-			}
-		case types.FloatFamily:
-			switch ct.Width() {
-			case -1:
-			default:
-				typedCol := col.Float64()
-				for idx = 0; idx < length; idx++ {
-					destIdx = idx
-					//gcassert:bce
-					srcIdx = sel[idx]
-					v := typedCol.Get(srcIdx)
-					_converted := da.NewDFloat(tree.DFloat(v))
-					//gcassert:bce
-					converted[destIdx] = _converted
+			case types.DateFamily:
+				switch ct.Width() {
+				case -1:
+				default:
+					typedCol := col.Int64()
+					_ = true
+					for idx = 0; idx < length; idx++ {
+						{
+							destIdx = idx
+						}
+						{
+							//gcassert:bce
+							srcIdx = sel[idx]
+						}
+						_ = true
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDDate(tree.DDate{Date: pgdate.MakeCompatibleDateFromDisk(v)})
+						converted[destIdx] = _converted
+					}
 				}
-			}
-		case types.DecimalFamily:
-			switch ct.Width() {
-			case -1:
-			default:
-				typedCol := col.Decimal()
-				for idx = 0; idx < length; idx++ {
-					destIdx = idx
-					//gcassert:bce
-					srcIdx = sel[idx]
-					v := typedCol.Get(srcIdx)
-					_converted := da.NewDDecimal(tree.DDecimal{Decimal: v})
-					// Clear the Coeff so that the Set below allocates a new slice for the
-					// Coeff.abs field.
-					_converted.Coeff = big.Int{}
-					_converted.Coeff.Set(&v.Coeff)
-					//gcassert:bce
-					converted[destIdx] = _converted
+			case types.BytesFamily:
+				switch ct.Width() {
+				case -1:
+				default:
+					typedCol := col.Bytes()
+					for idx = 0; idx < length; idx++ {
+						{
+							destIdx = idx
+						}
+						{
+							//gcassert:bce
+							srcIdx = sel[idx]
+						}
+						v := typedCol.Get(srcIdx)
+						// Note that there is no need for a copy since DBytes uses a string
+						// as underlying storage, which will perform the copy for us.
+						_converted := da.NewDBytes(tree.DBytes(v))
+						converted[destIdx] = _converted
+					}
 				}
-			}
-		case types.DateFamily:
-			switch ct.Width() {
-			case -1:
-			default:
-				typedCol := col.Int64()
-				for idx = 0; idx < length; idx++ {
-					destIdx = idx
-					//gcassert:bce
-					srcIdx = sel[idx]
-					v := typedCol.Get(srcIdx)
-					_converted := da.NewDDate(tree.DDate{Date: pgdate.MakeCompatibleDateFromDisk(v)})
-					//gcassert:bce
-					converted[destIdx] = _converted
-				}
-			}
-		case types.BytesFamily:
-			switch ct.Width() {
-			case -1:
-			default:
-				typedCol := col.Bytes()
-				for idx = 0; idx < length; idx++ {
-					destIdx = idx
-					//gcassert:bce
-					srcIdx = sel[idx]
-					v := typedCol.Get(srcIdx)
-					// Note that there is no need for a copy since DBytes uses a string
-					// as underlying storage, which will perform the copy for us.
-					_converted := da.NewDBytes(tree.DBytes(v))
-					//gcassert:bce
-					converted[destIdx] = _converted
-				}
-			}
-		case types.JsonFamily:
-			switch ct.Width() {
-			case -1:
-			default:
-				typedCol := col.JSON()
-				for idx = 0; idx < length; idx++ {
-					destIdx = idx
-					//gcassert:bce
-					srcIdx = sel[idx]
-					v := typedCol.Get(srcIdx)
+			case types.JsonFamily:
+				switch ct.Width() {
+				case -1:
+				default:
+					typedCol := col.JSON()
+					for idx = 0; idx < length; idx++ {
+						{
+							destIdx = idx
+						}
+						{
+							//gcassert:bce
+							srcIdx = sel[idx]
+						}
+						v := typedCol.Get(srcIdx)
 
-					// The following operation deliberately copies the input JSON
-					// bytes, since FromEncoding is lazy and keeps a handle on the bytes
-					// it is passed in.
-					_bytes, _err := json.EncodeJSON(nil, v)
-					if _err != nil {
-						colexecerror.ExpectedError(_err)
+						// The following operation deliberately copies the input JSON
+						// bytes, since FromEncoding is lazy and keeps a handle on the bytes
+						// it is passed in.
+						_bytes, _err := json.EncodeJSON(nil, v)
+						if _err != nil {
+							colexecerror.ExpectedError(_err)
+						}
+						var _j json.JSON
+						_j, _err = json.FromEncoding(_bytes)
+						if _err != nil {
+							colexecerror.ExpectedError(_err)
+						}
+						_converted := da.NewDJSON(tree.DJSON{JSON: _j})
+						converted[destIdx] = _converted
 					}
-					var _j json.JSON
-					_j, _err = json.FromEncoding(_bytes)
-					if _err != nil {
-						colexecerror.ExpectedError(_err)
+				}
+			case types.UuidFamily:
+				switch ct.Width() {
+				case -1:
+				default:
+					typedCol := col.Bytes()
+					for idx = 0; idx < length; idx++ {
+						{
+							destIdx = idx
+						}
+						{
+							//gcassert:bce
+							srcIdx = sel[idx]
+						}
+						v := typedCol.Get(srcIdx)
+						// Note that there is no need for a copy because uuid.FromBytes
+						// will perform a copy.
+						id, err := uuid.FromBytes(v)
+						if err != nil {
+							colexecerror.InternalError(err)
+						}
+						_converted := da.NewDUuid(tree.DUuid{UUID: id})
+						converted[destIdx] = _converted
 					}
-					_converted := da.NewDJSON(tree.DJSON{JSON: _j})
-					//gcassert:bce
-					converted[destIdx] = _converted
 				}
-			}
-		case types.UuidFamily:
-			switch ct.Width() {
-			case -1:
-			default:
-				typedCol := col.Bytes()
-				for idx = 0; idx < length; idx++ {
-					destIdx = idx
-					//gcassert:bce
-					srcIdx = sel[idx]
-					v := typedCol.Get(srcIdx)
-					// Note that there is no need for a copy because uuid.FromBytes
-					// will perform a copy.
-					id, err := uuid.FromBytes(v)
-					if err != nil {
-						colexecerror.InternalError(err)
+			case types.TimestampFamily:
+				switch ct.Width() {
+				case -1:
+				default:
+					typedCol := col.Timestamp()
+					_ = true
+					for idx = 0; idx < length; idx++ {
+						{
+							destIdx = idx
+						}
+						{
+							//gcassert:bce
+							srcIdx = sel[idx]
+						}
+						_ = true
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDTimestamp(tree.DTimestamp{Time: v})
+						converted[destIdx] = _converted
 					}
-					_converted := da.NewDUuid(tree.DUuid{UUID: id})
-					//gcassert:bce
-					converted[destIdx] = _converted
 				}
-			}
-		case types.TimestampFamily:
-			switch ct.Width() {
-			case -1:
+			case types.TimestampTZFamily:
+				switch ct.Width() {
+				case -1:
+				default:
+					typedCol := col.Timestamp()
+					_ = true
+					for idx = 0; idx < length; idx++ {
+						{
+							destIdx = idx
+						}
+						{
+							//gcassert:bce
+							srcIdx = sel[idx]
+						}
+						_ = true
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDTimestampTZ(tree.DTimestampTZ{Time: v})
+						converted[destIdx] = _converted
+					}
+				}
+			case types.IntervalFamily:
+				switch ct.Width() {
+				case -1:
+				default:
+					typedCol := col.Interval()
+					_ = true
+					for idx = 0; idx < length; idx++ {
+						{
+							destIdx = idx
+						}
+						{
+							//gcassert:bce
+							srcIdx = sel[idx]
+						}
+						_ = true
+						v := typedCol.Get(srcIdx)
+						_converted := da.NewDInterval(tree.DInterval{Duration: v})
+						converted[destIdx] = _converted
+					}
+				}
+			case typeconv.DatumVecCanonicalTypeFamily:
 			default:
-				typedCol := col.Timestamp()
-				for idx = 0; idx < length; idx++ {
-					destIdx = idx
-					//gcassert:bce
-					srcIdx = sel[idx]
-					v := typedCol.Get(srcIdx)
-					_converted := da.NewDTimestamp(tree.DTimestamp{Time: v})
-					//gcassert:bce
-					converted[destIdx] = _converted
+				switch ct.Width() {
+				case -1:
+				default:
+					typedCol := col.Datum()
+					for idx = 0; idx < length; idx++ {
+						{
+							destIdx = idx
+						}
+						{
+							//gcassert:bce
+							srcIdx = sel[idx]
+						}
+						v := typedCol.Get(srcIdx)
+						_converted := v.(*coldataext.Datum).Datum
+						converted[destIdx] = _converted
+					}
 				}
 			}
-		case types.TimestampTZFamily:
-			switch ct.Width() {
-			case -1:
-			default:
-				typedCol := col.Timestamp()
-				for idx = 0; idx < length; idx++ {
-					destIdx = idx
-					//gcassert:bce
-					srcIdx = sel[idx]
-					v := typedCol.Get(srcIdx)
-					_converted := da.NewDTimestampTZ(tree.DTimestampTZ{Time: v})
-					//gcassert:bce
-					converted[destIdx] = _converted
-				}
-			}
-		case types.IntervalFamily:
-			switch ct.Width() {
-			case -1:
-			default:
-				typedCol := col.Interval()
-				for idx = 0; idx < length; idx++ {
-					destIdx = idx
-					//gcassert:bce
-					srcIdx = sel[idx]
-					v := typedCol.Get(srcIdx)
-					_converted := da.NewDInterval(tree.DInterval{Duration: v})
-					//gcassert:bce
-					converted[destIdx] = _converted
-				}
-			}
-		case typeconv.DatumVecCanonicalTypeFamily:
-		default:
-			switch ct.Width() {
-			case -1:
-			default:
-				typedCol := col.Datum()
-				for idx = 0; idx < length; idx++ {
-					destIdx = idx
-					//gcassert:bce
-					srcIdx = sel[idx]
-					v := typedCol.Get(srcIdx)
-					_converted := v.(*coldataext.Datum).Datum
-					//gcassert:bce
-					converted[destIdx] = _converted
-				}
-			}
+		vecToDatum_false_true_true_return_1:
 		}
 	}
 }
@@ -860,1183 +986,1569 @@ func ColVecToDatum(
 	if col.MaybeHasNulls() {
 		nulls := col.Nulls()
 		if sel != nil {
-			_ = sel[length-1]
-			var idx, destIdx, srcIdx int
-			switch ct := col.Type(); ct.Family() {
-			case types.StringFamily:
-				// Note that there is no need for a copy since casting to a string will
-				// do that.
-				bytes := col.Bytes()
-				if ct.Oid() == oid.T_name {
+			{
+				_ = sel[length-1]
+				var idx, destIdx, srcIdx int
+				switch ct := col.Type(); ct.Family() {
+				case types.StringFamily:
+					// Note that there is no need for a copy since casting to a string will
+					// do that.
+					bytes := col.Bytes()
+					if ct.Oid() == oid.T_name {
+						for idx = 0; idx < length; idx++ {
+							{
+								//gcassert:bce
+								destIdx = sel[idx]
+							}
+							{
+								//gcassert:bce
+								srcIdx = sel[idx]
+							}
+							if nulls.NullAt(srcIdx) {
+								converted[destIdx] = tree.DNull
+								continue
+							}
+							v := da.NewDName(tree.DString(bytes.Get(srcIdx)))
+							converted[destIdx] = v
+						}
+						goto vecToDatum_true_true_false_return_2
+					}
 					for idx = 0; idx < length; idx++ {
-						//gcassert:bce
-						destIdx = sel[idx]
-						//gcassert:bce
-						srcIdx = sel[idx]
+						{
+							//gcassert:bce
+							destIdx = sel[idx]
+						}
+						{
+							//gcassert:bce
+							srcIdx = sel[idx]
+						}
 						if nulls.NullAt(srcIdx) {
 							converted[destIdx] = tree.DNull
 							continue
 						}
-						v := da.NewDName(tree.DString(bytes.Get(srcIdx)))
+						v := da.NewDString(tree.DString(bytes.Get(srcIdx)))
 						converted[destIdx] = v
 					}
-					return
-				}
-				for idx = 0; idx < length; idx++ {
-					//gcassert:bce
-					destIdx = sel[idx]
-					//gcassert:bce
-					srcIdx = sel[idx]
-					if nulls.NullAt(srcIdx) {
-						converted[destIdx] = tree.DNull
-						continue
-					}
-					v := da.NewDString(tree.DString(bytes.Get(srcIdx)))
-					converted[destIdx] = v
-				}
-			case types.BoolFamily:
-				switch ct.Width() {
-				case -1:
-				default:
-					typedCol := col.Bool()
-					for idx = 0; idx < length; idx++ {
-						//gcassert:bce
-						destIdx = sel[idx]
-						//gcassert:bce
-						srcIdx = sel[idx]
-						if nulls.NullAt(srcIdx) {
-							converted[destIdx] = tree.DNull
-							continue
+				case types.BoolFamily:
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.Bool()
+						_ = true
+						for idx = 0; idx < length; idx++ {
+							{
+								//gcassert:bce
+								destIdx = sel[idx]
+							}
+							{
+								//gcassert:bce
+								srcIdx = sel[idx]
+							}
+							if nulls.NullAt(srcIdx) {
+								converted[destIdx] = tree.DNull
+								continue
+							}
+							_ = true
+							v := typedCol.Get(srcIdx)
+							_converted := tree.MakeDBool(tree.DBool(v))
+							converted[destIdx] = _converted
 						}
-						v := typedCol.Get(srcIdx)
-						_converted := tree.MakeDBool(tree.DBool(v))
-						converted[destIdx] = _converted
 					}
-				}
-			case types.IntFamily:
-				switch ct.Width() {
-				case 16:
-					typedCol := col.Int16()
-					for idx = 0; idx < length; idx++ {
-						//gcassert:bce
-						destIdx = sel[idx]
-						//gcassert:bce
-						srcIdx = sel[idx]
-						if nulls.NullAt(srcIdx) {
-							converted[destIdx] = tree.DNull
-							continue
+				case types.IntFamily:
+					switch ct.Width() {
+					case 16:
+						typedCol := col.Int16()
+						_ = true
+						for idx = 0; idx < length; idx++ {
+							{
+								//gcassert:bce
+								destIdx = sel[idx]
+							}
+							{
+								//gcassert:bce
+								srcIdx = sel[idx]
+							}
+							if nulls.NullAt(srcIdx) {
+								converted[destIdx] = tree.DNull
+								continue
+							}
+							_ = true
+							v := typedCol.Get(srcIdx)
+							_converted := da.NewDInt(tree.DInt(v))
+							converted[destIdx] = _converted
 						}
-						v := typedCol.Get(srcIdx)
-						_converted := da.NewDInt(tree.DInt(v))
-						converted[destIdx] = _converted
+					case 32:
+						typedCol := col.Int32()
+						_ = true
+						for idx = 0; idx < length; idx++ {
+							{
+								//gcassert:bce
+								destIdx = sel[idx]
+							}
+							{
+								//gcassert:bce
+								srcIdx = sel[idx]
+							}
+							if nulls.NullAt(srcIdx) {
+								converted[destIdx] = tree.DNull
+								continue
+							}
+							_ = true
+							v := typedCol.Get(srcIdx)
+							_converted := da.NewDInt(tree.DInt(v))
+							converted[destIdx] = _converted
+						}
+					case -1:
+					default:
+						typedCol := col.Int64()
+						_ = true
+						for idx = 0; idx < length; idx++ {
+							{
+								//gcassert:bce
+								destIdx = sel[idx]
+							}
+							{
+								//gcassert:bce
+								srcIdx = sel[idx]
+							}
+							if nulls.NullAt(srcIdx) {
+								converted[destIdx] = tree.DNull
+								continue
+							}
+							_ = true
+							v := typedCol.Get(srcIdx)
+							_converted := da.NewDInt(tree.DInt(v))
+							converted[destIdx] = _converted
+						}
 					}
-				case 32:
-					typedCol := col.Int32()
-					for idx = 0; idx < length; idx++ {
-						//gcassert:bce
-						destIdx = sel[idx]
-						//gcassert:bce
-						srcIdx = sel[idx]
-						if nulls.NullAt(srcIdx) {
-							converted[destIdx] = tree.DNull
-							continue
+				case types.FloatFamily:
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.Float64()
+						_ = true
+						for idx = 0; idx < length; idx++ {
+							{
+								//gcassert:bce
+								destIdx = sel[idx]
+							}
+							{
+								//gcassert:bce
+								srcIdx = sel[idx]
+							}
+							if nulls.NullAt(srcIdx) {
+								converted[destIdx] = tree.DNull
+								continue
+							}
+							_ = true
+							v := typedCol.Get(srcIdx)
+							_converted := da.NewDFloat(tree.DFloat(v))
+							converted[destIdx] = _converted
 						}
-						v := typedCol.Get(srcIdx)
-						_converted := da.NewDInt(tree.DInt(v))
-						converted[destIdx] = _converted
 					}
-				case -1:
-				default:
-					typedCol := col.Int64()
-					for idx = 0; idx < length; idx++ {
-						//gcassert:bce
-						destIdx = sel[idx]
-						//gcassert:bce
-						srcIdx = sel[idx]
-						if nulls.NullAt(srcIdx) {
-							converted[destIdx] = tree.DNull
-							continue
+				case types.DecimalFamily:
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.Decimal()
+						_ = true
+						for idx = 0; idx < length; idx++ {
+							{
+								//gcassert:bce
+								destIdx = sel[idx]
+							}
+							{
+								//gcassert:bce
+								srcIdx = sel[idx]
+							}
+							if nulls.NullAt(srcIdx) {
+								converted[destIdx] = tree.DNull
+								continue
+							}
+							_ = true
+							v := typedCol.Get(srcIdx)
+							_converted := da.NewDDecimal(tree.DDecimal{Decimal: v})
+							// Clear the Coeff so that the Set below allocates a new slice for the
+							// Coeff.abs field.
+							_converted.Coeff = big.Int{}
+							_converted.Coeff.Set(&v.Coeff)
+							converted[destIdx] = _converted
 						}
-						v := typedCol.Get(srcIdx)
-						_converted := da.NewDInt(tree.DInt(v))
-						converted[destIdx] = _converted
 					}
-				}
-			case types.FloatFamily:
-				switch ct.Width() {
-				case -1:
-				default:
-					typedCol := col.Float64()
-					for idx = 0; idx < length; idx++ {
-						//gcassert:bce
-						destIdx = sel[idx]
-						//gcassert:bce
-						srcIdx = sel[idx]
-						if nulls.NullAt(srcIdx) {
-							converted[destIdx] = tree.DNull
-							continue
+				case types.DateFamily:
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.Int64()
+						_ = true
+						for idx = 0; idx < length; idx++ {
+							{
+								//gcassert:bce
+								destIdx = sel[idx]
+							}
+							{
+								//gcassert:bce
+								srcIdx = sel[idx]
+							}
+							if nulls.NullAt(srcIdx) {
+								converted[destIdx] = tree.DNull
+								continue
+							}
+							_ = true
+							v := typedCol.Get(srcIdx)
+							_converted := da.NewDDate(tree.DDate{Date: pgdate.MakeCompatibleDateFromDisk(v)})
+							converted[destIdx] = _converted
 						}
-						v := typedCol.Get(srcIdx)
-						_converted := da.NewDFloat(tree.DFloat(v))
-						converted[destIdx] = _converted
 					}
-				}
-			case types.DecimalFamily:
-				switch ct.Width() {
-				case -1:
-				default:
-					typedCol := col.Decimal()
-					for idx = 0; idx < length; idx++ {
-						//gcassert:bce
-						destIdx = sel[idx]
-						//gcassert:bce
-						srcIdx = sel[idx]
-						if nulls.NullAt(srcIdx) {
-							converted[destIdx] = tree.DNull
-							continue
+				case types.BytesFamily:
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.Bytes()
+						for idx = 0; idx < length; idx++ {
+							{
+								//gcassert:bce
+								destIdx = sel[idx]
+							}
+							{
+								//gcassert:bce
+								srcIdx = sel[idx]
+							}
+							if nulls.NullAt(srcIdx) {
+								converted[destIdx] = tree.DNull
+								continue
+							}
+							v := typedCol.Get(srcIdx)
+							// Note that there is no need for a copy since DBytes uses a string
+							// as underlying storage, which will perform the copy for us.
+							_converted := da.NewDBytes(tree.DBytes(v))
+							converted[destIdx] = _converted
 						}
-						v := typedCol.Get(srcIdx)
-						_converted := da.NewDDecimal(tree.DDecimal{Decimal: v})
-						// Clear the Coeff so that the Set below allocates a new slice for the
-						// Coeff.abs field.
-						_converted.Coeff = big.Int{}
-						_converted.Coeff.Set(&v.Coeff)
-						converted[destIdx] = _converted
 					}
-				}
-			case types.DateFamily:
-				switch ct.Width() {
-				case -1:
-				default:
-					typedCol := col.Int64()
-					for idx = 0; idx < length; idx++ {
-						//gcassert:bce
-						destIdx = sel[idx]
-						//gcassert:bce
-						srcIdx = sel[idx]
-						if nulls.NullAt(srcIdx) {
-							converted[destIdx] = tree.DNull
-							continue
-						}
-						v := typedCol.Get(srcIdx)
-						_converted := da.NewDDate(tree.DDate{Date: pgdate.MakeCompatibleDateFromDisk(v)})
-						converted[destIdx] = _converted
-					}
-				}
-			case types.BytesFamily:
-				switch ct.Width() {
-				case -1:
-				default:
-					typedCol := col.Bytes()
-					for idx = 0; idx < length; idx++ {
-						//gcassert:bce
-						destIdx = sel[idx]
-						//gcassert:bce
-						srcIdx = sel[idx]
-						if nulls.NullAt(srcIdx) {
-							converted[destIdx] = tree.DNull
-							continue
-						}
-						v := typedCol.Get(srcIdx)
-						// Note that there is no need for a copy since DBytes uses a string
-						// as underlying storage, which will perform the copy for us.
-						_converted := da.NewDBytes(tree.DBytes(v))
-						converted[destIdx] = _converted
-					}
-				}
-			case types.JsonFamily:
-				switch ct.Width() {
-				case -1:
-				default:
-					typedCol := col.JSON()
-					for idx = 0; idx < length; idx++ {
-						//gcassert:bce
-						destIdx = sel[idx]
-						//gcassert:bce
-						srcIdx = sel[idx]
-						if nulls.NullAt(srcIdx) {
-							converted[destIdx] = tree.DNull
-							continue
-						}
-						v := typedCol.Get(srcIdx)
+				case types.JsonFamily:
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.JSON()
+						for idx = 0; idx < length; idx++ {
+							{
+								//gcassert:bce
+								destIdx = sel[idx]
+							}
+							{
+								//gcassert:bce
+								srcIdx = sel[idx]
+							}
+							if nulls.NullAt(srcIdx) {
+								converted[destIdx] = tree.DNull
+								continue
+							}
+							v := typedCol.Get(srcIdx)
 
-						// The following operation deliberately copies the input JSON
-						// bytes, since FromEncoding is lazy and keeps a handle on the bytes
-						// it is passed in.
-						_bytes, _err := json.EncodeJSON(nil, v)
-						if _err != nil {
-							colexecerror.ExpectedError(_err)
+							// The following operation deliberately copies the input JSON
+							// bytes, since FromEncoding is lazy and keeps a handle on the bytes
+							// it is passed in.
+							_bytes, _err := json.EncodeJSON(nil, v)
+							if _err != nil {
+								colexecerror.ExpectedError(_err)
+							}
+							var _j json.JSON
+							_j, _err = json.FromEncoding(_bytes)
+							if _err != nil {
+								colexecerror.ExpectedError(_err)
+							}
+							_converted := da.NewDJSON(tree.DJSON{JSON: _j})
+							converted[destIdx] = _converted
 						}
-						var _j json.JSON
-						_j, _err = json.FromEncoding(_bytes)
-						if _err != nil {
-							colexecerror.ExpectedError(_err)
-						}
-						_converted := da.NewDJSON(tree.DJSON{JSON: _j})
-						converted[destIdx] = _converted
 					}
-				}
-			case types.UuidFamily:
-				switch ct.Width() {
-				case -1:
+				case types.UuidFamily:
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.Bytes()
+						for idx = 0; idx < length; idx++ {
+							{
+								//gcassert:bce
+								destIdx = sel[idx]
+							}
+							{
+								//gcassert:bce
+								srcIdx = sel[idx]
+							}
+							if nulls.NullAt(srcIdx) {
+								converted[destIdx] = tree.DNull
+								continue
+							}
+							v := typedCol.Get(srcIdx)
+							// Note that there is no need for a copy because uuid.FromBytes
+							// will perform a copy.
+							id, err := uuid.FromBytes(v)
+							if err != nil {
+								colexecerror.InternalError(err)
+							}
+							_converted := da.NewDUuid(tree.DUuid{UUID: id})
+							converted[destIdx] = _converted
+						}
+					}
+				case types.TimestampFamily:
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.Timestamp()
+						_ = true
+						for idx = 0; idx < length; idx++ {
+							{
+								//gcassert:bce
+								destIdx = sel[idx]
+							}
+							{
+								//gcassert:bce
+								srcIdx = sel[idx]
+							}
+							if nulls.NullAt(srcIdx) {
+								converted[destIdx] = tree.DNull
+								continue
+							}
+							_ = true
+							v := typedCol.Get(srcIdx)
+							_converted := da.NewDTimestamp(tree.DTimestamp{Time: v})
+							converted[destIdx] = _converted
+						}
+					}
+				case types.TimestampTZFamily:
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.Timestamp()
+						_ = true
+						for idx = 0; idx < length; idx++ {
+							{
+								//gcassert:bce
+								destIdx = sel[idx]
+							}
+							{
+								//gcassert:bce
+								srcIdx = sel[idx]
+							}
+							if nulls.NullAt(srcIdx) {
+								converted[destIdx] = tree.DNull
+								continue
+							}
+							_ = true
+							v := typedCol.Get(srcIdx)
+							_converted := da.NewDTimestampTZ(tree.DTimestampTZ{Time: v})
+							converted[destIdx] = _converted
+						}
+					}
+				case types.IntervalFamily:
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.Interval()
+						_ = true
+						for idx = 0; idx < length; idx++ {
+							{
+								//gcassert:bce
+								destIdx = sel[idx]
+							}
+							{
+								//gcassert:bce
+								srcIdx = sel[idx]
+							}
+							if nulls.NullAt(srcIdx) {
+								converted[destIdx] = tree.DNull
+								continue
+							}
+							_ = true
+							v := typedCol.Get(srcIdx)
+							_converted := da.NewDInterval(tree.DInterval{Duration: v})
+							converted[destIdx] = _converted
+						}
+					}
+				case typeconv.DatumVecCanonicalTypeFamily:
 				default:
-					typedCol := col.Bytes()
-					for idx = 0; idx < length; idx++ {
-						//gcassert:bce
-						destIdx = sel[idx]
-						//gcassert:bce
-						srcIdx = sel[idx]
-						if nulls.NullAt(srcIdx) {
-							converted[destIdx] = tree.DNull
-							continue
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.Datum()
+						for idx = 0; idx < length; idx++ {
+							{
+								//gcassert:bce
+								destIdx = sel[idx]
+							}
+							{
+								//gcassert:bce
+								srcIdx = sel[idx]
+							}
+							if nulls.NullAt(srcIdx) {
+								converted[destIdx] = tree.DNull
+								continue
+							}
+							v := typedCol.Get(srcIdx)
+							_converted := v.(*coldataext.Datum).Datum
+							converted[destIdx] = _converted
 						}
-						v := typedCol.Get(srcIdx)
-						// Note that there is no need for a copy because uuid.FromBytes
-						// will perform a copy.
-						id, err := uuid.FromBytes(v)
-						if err != nil {
-							colexecerror.InternalError(err)
-						}
-						_converted := da.NewDUuid(tree.DUuid{UUID: id})
-						converted[destIdx] = _converted
 					}
 				}
-			case types.TimestampFamily:
-				switch ct.Width() {
-				case -1:
-				default:
-					typedCol := col.Timestamp()
-					for idx = 0; idx < length; idx++ {
-						//gcassert:bce
-						destIdx = sel[idx]
-						//gcassert:bce
-						srcIdx = sel[idx]
-						if nulls.NullAt(srcIdx) {
-							converted[destIdx] = tree.DNull
-							continue
-						}
-						v := typedCol.Get(srcIdx)
-						_converted := da.NewDTimestamp(tree.DTimestamp{Time: v})
-						converted[destIdx] = _converted
-					}
-				}
-			case types.TimestampTZFamily:
-				switch ct.Width() {
-				case -1:
-				default:
-					typedCol := col.Timestamp()
-					for idx = 0; idx < length; idx++ {
-						//gcassert:bce
-						destIdx = sel[idx]
-						//gcassert:bce
-						srcIdx = sel[idx]
-						if nulls.NullAt(srcIdx) {
-							converted[destIdx] = tree.DNull
-							continue
-						}
-						v := typedCol.Get(srcIdx)
-						_converted := da.NewDTimestampTZ(tree.DTimestampTZ{Time: v})
-						converted[destIdx] = _converted
-					}
-				}
-			case types.IntervalFamily:
-				switch ct.Width() {
-				case -1:
-				default:
-					typedCol := col.Interval()
-					for idx = 0; idx < length; idx++ {
-						//gcassert:bce
-						destIdx = sel[idx]
-						//gcassert:bce
-						srcIdx = sel[idx]
-						if nulls.NullAt(srcIdx) {
-							converted[destIdx] = tree.DNull
-							continue
-						}
-						v := typedCol.Get(srcIdx)
-						_converted := da.NewDInterval(tree.DInterval{Duration: v})
-						converted[destIdx] = _converted
-					}
-				}
-			case typeconv.DatumVecCanonicalTypeFamily:
-			default:
-				switch ct.Width() {
-				case -1:
-				default:
-					typedCol := col.Datum()
-					for idx = 0; idx < length; idx++ {
-						//gcassert:bce
-						destIdx = sel[idx]
-						//gcassert:bce
-						srcIdx = sel[idx]
-						if nulls.NullAt(srcIdx) {
-							converted[destIdx] = tree.DNull
-							continue
-						}
-						v := typedCol.Get(srcIdx)
-						_converted := v.(*coldataext.Datum).Datum
-						converted[destIdx] = _converted
-					}
-				}
+			vecToDatum_true_true_false_return_2:
 			}
 		} else {
-			_ = converted[length-1]
-			var idx, destIdx, srcIdx int
-			switch ct := col.Type(); ct.Family() {
-			case types.StringFamily:
-				// Note that there is no need for a copy since casting to a string will
-				// do that.
-				bytes := col.Bytes()
-				if ct.Oid() == oid.T_name {
+			{
+				_ = converted[length-1]
+				var idx, destIdx, srcIdx int
+				switch ct := col.Type(); ct.Family() {
+				case types.StringFamily:
+					// Note that there is no need for a copy since casting to a string will
+					// do that.
+					bytes := col.Bytes()
+					if ct.Oid() == oid.T_name {
+						for idx = 0; idx < length; idx++ {
+							{
+								destIdx = idx
+							}
+							{
+								srcIdx = idx
+							}
+							if nulls.NullAt(srcIdx) {
+								converted[destIdx] = tree.DNull
+								continue
+							}
+							v := da.NewDName(tree.DString(bytes.Get(srcIdx)))
+							converted[destIdx] = v
+						}
+						goto vecToDatum_true_false_false_return_3
+					}
 					for idx = 0; idx < length; idx++ {
-						destIdx = idx
-						srcIdx = idx
+						{
+							destIdx = idx
+						}
+						{
+							srcIdx = idx
+						}
 						if nulls.NullAt(srcIdx) {
-							//gcassert:bce
 							converted[destIdx] = tree.DNull
 							continue
 						}
-						v := da.NewDName(tree.DString(bytes.Get(srcIdx)))
-						//gcassert:bce
+						v := da.NewDString(tree.DString(bytes.Get(srcIdx)))
 						converted[destIdx] = v
 					}
-					return
-				}
-				for idx = 0; idx < length; idx++ {
-					destIdx = idx
-					srcIdx = idx
-					if nulls.NullAt(srcIdx) {
-						//gcassert:bce
-						converted[destIdx] = tree.DNull
-						continue
-					}
-					v := da.NewDString(tree.DString(bytes.Get(srcIdx)))
-					//gcassert:bce
-					converted[destIdx] = v
-				}
-			case types.BoolFamily:
-				switch ct.Width() {
-				case -1:
-				default:
-					typedCol := col.Bool()
-					_ = typedCol.Get(length - 1)
-					for idx = 0; idx < length; idx++ {
-						destIdx = idx
-						srcIdx = idx
-						if nulls.NullAt(srcIdx) {
-							//gcassert:bce
-							converted[destIdx] = tree.DNull
-							continue
+				case types.BoolFamily:
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.Bool()
+						_ = true
+						_ = typedCol.Get(length - 1)
+						for idx = 0; idx < length; idx++ {
+							{
+								destIdx = idx
+							}
+							{
+								srcIdx = idx
+							}
+							if nulls.NullAt(srcIdx) {
+								converted[destIdx] = tree.DNull
+								continue
+							}
+							_ = true
+							v := typedCol.Get(srcIdx)
+							_converted := tree.MakeDBool(tree.DBool(v))
+							converted[destIdx] = _converted
 						}
-						//gcassert:bce
-						v := typedCol.Get(srcIdx)
-						_converted := tree.MakeDBool(tree.DBool(v))
-						//gcassert:bce
-						converted[destIdx] = _converted
 					}
-				}
-			case types.IntFamily:
-				switch ct.Width() {
-				case 16:
-					typedCol := col.Int16()
-					_ = typedCol.Get(length - 1)
-					for idx = 0; idx < length; idx++ {
-						destIdx = idx
-						srcIdx = idx
-						if nulls.NullAt(srcIdx) {
-							//gcassert:bce
-							converted[destIdx] = tree.DNull
-							continue
+				case types.IntFamily:
+					switch ct.Width() {
+					case 16:
+						typedCol := col.Int16()
+						_ = true
+						_ = typedCol.Get(length - 1)
+						for idx = 0; idx < length; idx++ {
+							{
+								destIdx = idx
+							}
+							{
+								srcIdx = idx
+							}
+							if nulls.NullAt(srcIdx) {
+								converted[destIdx] = tree.DNull
+								continue
+							}
+							_ = true
+							v := typedCol.Get(srcIdx)
+							_converted := da.NewDInt(tree.DInt(v))
+							converted[destIdx] = _converted
 						}
-						//gcassert:bce
-						v := typedCol.Get(srcIdx)
-						_converted := da.NewDInt(tree.DInt(v))
-						//gcassert:bce
-						converted[destIdx] = _converted
+					case 32:
+						typedCol := col.Int32()
+						_ = true
+						_ = typedCol.Get(length - 1)
+						for idx = 0; idx < length; idx++ {
+							{
+								destIdx = idx
+							}
+							{
+								srcIdx = idx
+							}
+							if nulls.NullAt(srcIdx) {
+								converted[destIdx] = tree.DNull
+								continue
+							}
+							_ = true
+							v := typedCol.Get(srcIdx)
+							_converted := da.NewDInt(tree.DInt(v))
+							converted[destIdx] = _converted
+						}
+					case -1:
+					default:
+						typedCol := col.Int64()
+						_ = true
+						_ = typedCol.Get(length - 1)
+						for idx = 0; idx < length; idx++ {
+							{
+								destIdx = idx
+							}
+							{
+								srcIdx = idx
+							}
+							if nulls.NullAt(srcIdx) {
+								converted[destIdx] = tree.DNull
+								continue
+							}
+							_ = true
+							v := typedCol.Get(srcIdx)
+							_converted := da.NewDInt(tree.DInt(v))
+							converted[destIdx] = _converted
+						}
 					}
-				case 32:
-					typedCol := col.Int32()
-					_ = typedCol.Get(length - 1)
-					for idx = 0; idx < length; idx++ {
-						destIdx = idx
-						srcIdx = idx
-						if nulls.NullAt(srcIdx) {
-							//gcassert:bce
-							converted[destIdx] = tree.DNull
-							continue
+				case types.FloatFamily:
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.Float64()
+						_ = true
+						_ = typedCol.Get(length - 1)
+						for idx = 0; idx < length; idx++ {
+							{
+								destIdx = idx
+							}
+							{
+								srcIdx = idx
+							}
+							if nulls.NullAt(srcIdx) {
+								converted[destIdx] = tree.DNull
+								continue
+							}
+							_ = true
+							v := typedCol.Get(srcIdx)
+							_converted := da.NewDFloat(tree.DFloat(v))
+							converted[destIdx] = _converted
 						}
-						//gcassert:bce
-						v := typedCol.Get(srcIdx)
-						_converted := da.NewDInt(tree.DInt(v))
-						//gcassert:bce
-						converted[destIdx] = _converted
 					}
-				case -1:
-				default:
-					typedCol := col.Int64()
-					_ = typedCol.Get(length - 1)
-					for idx = 0; idx < length; idx++ {
-						destIdx = idx
-						srcIdx = idx
-						if nulls.NullAt(srcIdx) {
-							//gcassert:bce
-							converted[destIdx] = tree.DNull
-							continue
+				case types.DecimalFamily:
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.Decimal()
+						_ = true
+						_ = typedCol.Get(length - 1)
+						for idx = 0; idx < length; idx++ {
+							{
+								destIdx = idx
+							}
+							{
+								srcIdx = idx
+							}
+							if nulls.NullAt(srcIdx) {
+								converted[destIdx] = tree.DNull
+								continue
+							}
+							_ = true
+							v := typedCol.Get(srcIdx)
+							_converted := da.NewDDecimal(tree.DDecimal{Decimal: v})
+							// Clear the Coeff so that the Set below allocates a new slice for the
+							// Coeff.abs field.
+							_converted.Coeff = big.Int{}
+							_converted.Coeff.Set(&v.Coeff)
+							converted[destIdx] = _converted
 						}
-						//gcassert:bce
-						v := typedCol.Get(srcIdx)
-						_converted := da.NewDInt(tree.DInt(v))
-						//gcassert:bce
-						converted[destIdx] = _converted
 					}
-				}
-			case types.FloatFamily:
-				switch ct.Width() {
-				case -1:
-				default:
-					typedCol := col.Float64()
-					_ = typedCol.Get(length - 1)
-					for idx = 0; idx < length; idx++ {
-						destIdx = idx
-						srcIdx = idx
-						if nulls.NullAt(srcIdx) {
-							//gcassert:bce
-							converted[destIdx] = tree.DNull
-							continue
+				case types.DateFamily:
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.Int64()
+						_ = true
+						_ = typedCol.Get(length - 1)
+						for idx = 0; idx < length; idx++ {
+							{
+								destIdx = idx
+							}
+							{
+								srcIdx = idx
+							}
+							if nulls.NullAt(srcIdx) {
+								converted[destIdx] = tree.DNull
+								continue
+							}
+							_ = true
+							v := typedCol.Get(srcIdx)
+							_converted := da.NewDDate(tree.DDate{Date: pgdate.MakeCompatibleDateFromDisk(v)})
+							converted[destIdx] = _converted
 						}
-						//gcassert:bce
-						v := typedCol.Get(srcIdx)
-						_converted := da.NewDFloat(tree.DFloat(v))
-						//gcassert:bce
-						converted[destIdx] = _converted
 					}
-				}
-			case types.DecimalFamily:
-				switch ct.Width() {
-				case -1:
-				default:
-					typedCol := col.Decimal()
-					_ = typedCol.Get(length - 1)
-					for idx = 0; idx < length; idx++ {
-						destIdx = idx
-						srcIdx = idx
-						if nulls.NullAt(srcIdx) {
-							//gcassert:bce
-							converted[destIdx] = tree.DNull
-							continue
+				case types.BytesFamily:
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.Bytes()
+						for idx = 0; idx < length; idx++ {
+							{
+								destIdx = idx
+							}
+							{
+								srcIdx = idx
+							}
+							if nulls.NullAt(srcIdx) {
+								converted[destIdx] = tree.DNull
+								continue
+							}
+							v := typedCol.Get(srcIdx)
+							// Note that there is no need for a copy since DBytes uses a string
+							// as underlying storage, which will perform the copy for us.
+							_converted := da.NewDBytes(tree.DBytes(v))
+							converted[destIdx] = _converted
 						}
-						//gcassert:bce
-						v := typedCol.Get(srcIdx)
-						_converted := da.NewDDecimal(tree.DDecimal{Decimal: v})
-						// Clear the Coeff so that the Set below allocates a new slice for the
-						// Coeff.abs field.
-						_converted.Coeff = big.Int{}
-						_converted.Coeff.Set(&v.Coeff)
-						//gcassert:bce
-						converted[destIdx] = _converted
 					}
-				}
-			case types.DateFamily:
-				switch ct.Width() {
-				case -1:
-				default:
-					typedCol := col.Int64()
-					_ = typedCol.Get(length - 1)
-					for idx = 0; idx < length; idx++ {
-						destIdx = idx
-						srcIdx = idx
-						if nulls.NullAt(srcIdx) {
-							//gcassert:bce
-							converted[destIdx] = tree.DNull
-							continue
-						}
-						//gcassert:bce
-						v := typedCol.Get(srcIdx)
-						_converted := da.NewDDate(tree.DDate{Date: pgdate.MakeCompatibleDateFromDisk(v)})
-						//gcassert:bce
-						converted[destIdx] = _converted
-					}
-				}
-			case types.BytesFamily:
-				switch ct.Width() {
-				case -1:
-				default:
-					typedCol := col.Bytes()
-					for idx = 0; idx < length; idx++ {
-						destIdx = idx
-						srcIdx = idx
-						if nulls.NullAt(srcIdx) {
-							//gcassert:bce
-							converted[destIdx] = tree.DNull
-							continue
-						}
-						v := typedCol.Get(srcIdx)
-						// Note that there is no need for a copy since DBytes uses a string
-						// as underlying storage, which will perform the copy for us.
-						_converted := da.NewDBytes(tree.DBytes(v))
-						//gcassert:bce
-						converted[destIdx] = _converted
-					}
-				}
-			case types.JsonFamily:
-				switch ct.Width() {
-				case -1:
-				default:
-					typedCol := col.JSON()
-					for idx = 0; idx < length; idx++ {
-						destIdx = idx
-						srcIdx = idx
-						if nulls.NullAt(srcIdx) {
-							//gcassert:bce
-							converted[destIdx] = tree.DNull
-							continue
-						}
-						v := typedCol.Get(srcIdx)
+				case types.JsonFamily:
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.JSON()
+						for idx = 0; idx < length; idx++ {
+							{
+								destIdx = idx
+							}
+							{
+								srcIdx = idx
+							}
+							if nulls.NullAt(srcIdx) {
+								converted[destIdx] = tree.DNull
+								continue
+							}
+							v := typedCol.Get(srcIdx)
 
-						// The following operation deliberately copies the input JSON
-						// bytes, since FromEncoding is lazy and keeps a handle on the bytes
-						// it is passed in.
-						_bytes, _err := json.EncodeJSON(nil, v)
-						if _err != nil {
-							colexecerror.ExpectedError(_err)
+							// The following operation deliberately copies the input JSON
+							// bytes, since FromEncoding is lazy and keeps a handle on the bytes
+							// it is passed in.
+							_bytes, _err := json.EncodeJSON(nil, v)
+							if _err != nil {
+								colexecerror.ExpectedError(_err)
+							}
+							var _j json.JSON
+							_j, _err = json.FromEncoding(_bytes)
+							if _err != nil {
+								colexecerror.ExpectedError(_err)
+							}
+							_converted := da.NewDJSON(tree.DJSON{JSON: _j})
+							converted[destIdx] = _converted
 						}
-						var _j json.JSON
-						_j, _err = json.FromEncoding(_bytes)
-						if _err != nil {
-							colexecerror.ExpectedError(_err)
-						}
-						_converted := da.NewDJSON(tree.DJSON{JSON: _j})
-						//gcassert:bce
-						converted[destIdx] = _converted
 					}
-				}
-			case types.UuidFamily:
-				switch ct.Width() {
-				case -1:
+				case types.UuidFamily:
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.Bytes()
+						for idx = 0; idx < length; idx++ {
+							{
+								destIdx = idx
+							}
+							{
+								srcIdx = idx
+							}
+							if nulls.NullAt(srcIdx) {
+								converted[destIdx] = tree.DNull
+								continue
+							}
+							v := typedCol.Get(srcIdx)
+							// Note that there is no need for a copy because uuid.FromBytes
+							// will perform a copy.
+							id, err := uuid.FromBytes(v)
+							if err != nil {
+								colexecerror.InternalError(err)
+							}
+							_converted := da.NewDUuid(tree.DUuid{UUID: id})
+							converted[destIdx] = _converted
+						}
+					}
+				case types.TimestampFamily:
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.Timestamp()
+						_ = true
+						_ = typedCol.Get(length - 1)
+						for idx = 0; idx < length; idx++ {
+							{
+								destIdx = idx
+							}
+							{
+								srcIdx = idx
+							}
+							if nulls.NullAt(srcIdx) {
+								converted[destIdx] = tree.DNull
+								continue
+							}
+							_ = true
+							v := typedCol.Get(srcIdx)
+							_converted := da.NewDTimestamp(tree.DTimestamp{Time: v})
+							converted[destIdx] = _converted
+						}
+					}
+				case types.TimestampTZFamily:
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.Timestamp()
+						_ = true
+						_ = typedCol.Get(length - 1)
+						for idx = 0; idx < length; idx++ {
+							{
+								destIdx = idx
+							}
+							{
+								srcIdx = idx
+							}
+							if nulls.NullAt(srcIdx) {
+								converted[destIdx] = tree.DNull
+								continue
+							}
+							_ = true
+							v := typedCol.Get(srcIdx)
+							_converted := da.NewDTimestampTZ(tree.DTimestampTZ{Time: v})
+							converted[destIdx] = _converted
+						}
+					}
+				case types.IntervalFamily:
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.Interval()
+						_ = true
+						_ = typedCol.Get(length - 1)
+						for idx = 0; idx < length; idx++ {
+							{
+								destIdx = idx
+							}
+							{
+								srcIdx = idx
+							}
+							if nulls.NullAt(srcIdx) {
+								converted[destIdx] = tree.DNull
+								continue
+							}
+							_ = true
+							v := typedCol.Get(srcIdx)
+							_converted := da.NewDInterval(tree.DInterval{Duration: v})
+							converted[destIdx] = _converted
+						}
+					}
+				case typeconv.DatumVecCanonicalTypeFamily:
 				default:
-					typedCol := col.Bytes()
-					for idx = 0; idx < length; idx++ {
-						destIdx = idx
-						srcIdx = idx
-						if nulls.NullAt(srcIdx) {
-							//gcassert:bce
-							converted[destIdx] = tree.DNull
-							continue
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.Datum()
+						for idx = 0; idx < length; idx++ {
+							{
+								destIdx = idx
+							}
+							{
+								srcIdx = idx
+							}
+							if nulls.NullAt(srcIdx) {
+								converted[destIdx] = tree.DNull
+								continue
+							}
+							v := typedCol.Get(srcIdx)
+							_converted := v.(*coldataext.Datum).Datum
+							converted[destIdx] = _converted
 						}
-						v := typedCol.Get(srcIdx)
-						// Note that there is no need for a copy because uuid.FromBytes
-						// will perform a copy.
-						id, err := uuid.FromBytes(v)
-						if err != nil {
-							colexecerror.InternalError(err)
-						}
-						_converted := da.NewDUuid(tree.DUuid{UUID: id})
-						//gcassert:bce
-						converted[destIdx] = _converted
 					}
 				}
-			case types.TimestampFamily:
-				switch ct.Width() {
-				case -1:
-				default:
-					typedCol := col.Timestamp()
-					_ = typedCol.Get(length - 1)
-					for idx = 0; idx < length; idx++ {
-						destIdx = idx
-						srcIdx = idx
-						if nulls.NullAt(srcIdx) {
-							//gcassert:bce
-							converted[destIdx] = tree.DNull
-							continue
-						}
-						//gcassert:bce
-						v := typedCol.Get(srcIdx)
-						_converted := da.NewDTimestamp(tree.DTimestamp{Time: v})
-						//gcassert:bce
-						converted[destIdx] = _converted
-					}
-				}
-			case types.TimestampTZFamily:
-				switch ct.Width() {
-				case -1:
-				default:
-					typedCol := col.Timestamp()
-					_ = typedCol.Get(length - 1)
-					for idx = 0; idx < length; idx++ {
-						destIdx = idx
-						srcIdx = idx
-						if nulls.NullAt(srcIdx) {
-							//gcassert:bce
-							converted[destIdx] = tree.DNull
-							continue
-						}
-						//gcassert:bce
-						v := typedCol.Get(srcIdx)
-						_converted := da.NewDTimestampTZ(tree.DTimestampTZ{Time: v})
-						//gcassert:bce
-						converted[destIdx] = _converted
-					}
-				}
-			case types.IntervalFamily:
-				switch ct.Width() {
-				case -1:
-				default:
-					typedCol := col.Interval()
-					_ = typedCol.Get(length - 1)
-					for idx = 0; idx < length; idx++ {
-						destIdx = idx
-						srcIdx = idx
-						if nulls.NullAt(srcIdx) {
-							//gcassert:bce
-							converted[destIdx] = tree.DNull
-							continue
-						}
-						//gcassert:bce
-						v := typedCol.Get(srcIdx)
-						_converted := da.NewDInterval(tree.DInterval{Duration: v})
-						//gcassert:bce
-						converted[destIdx] = _converted
-					}
-				}
-			case typeconv.DatumVecCanonicalTypeFamily:
-			default:
-				switch ct.Width() {
-				case -1:
-				default:
-					typedCol := col.Datum()
-					for idx = 0; idx < length; idx++ {
-						destIdx = idx
-						srcIdx = idx
-						if nulls.NullAt(srcIdx) {
-							//gcassert:bce
-							converted[destIdx] = tree.DNull
-							continue
-						}
-						v := typedCol.Get(srcIdx)
-						_converted := v.(*coldataext.Datum).Datum
-						//gcassert:bce
-						converted[destIdx] = _converted
-					}
-				}
+			vecToDatum_true_false_false_return_3:
 			}
 		}
 	} else {
 		if sel != nil {
-			_ = sel[length-1]
-			var idx, destIdx, srcIdx int
-			switch ct := col.Type(); ct.Family() {
-			case types.StringFamily:
-				// Note that there is no need for a copy since casting to a string will
-				// do that.
-				bytes := col.Bytes()
-				if ct.Oid() == oid.T_name {
+			{
+				_ = sel[length-1]
+				var idx, destIdx, srcIdx int
+				switch ct := col.Type(); ct.Family() {
+				case types.StringFamily:
+					// Note that there is no need for a copy since casting to a string will
+					// do that.
+					bytes := col.Bytes()
+					if ct.Oid() == oid.T_name {
+						for idx = 0; idx < length; idx++ {
+							{
+								//gcassert:bce
+								destIdx = sel[idx]
+							}
+							{
+								//gcassert:bce
+								srcIdx = sel[idx]
+							}
+							v := da.NewDName(tree.DString(bytes.Get(srcIdx)))
+							converted[destIdx] = v
+						}
+						goto vecToDatum_false_true_false_return_4
+					}
 					for idx = 0; idx < length; idx++ {
-						//gcassert:bce
-						destIdx = sel[idx]
-						//gcassert:bce
-						srcIdx = sel[idx]
-						v := da.NewDName(tree.DString(bytes.Get(srcIdx)))
+						{
+							//gcassert:bce
+							destIdx = sel[idx]
+						}
+						{
+							//gcassert:bce
+							srcIdx = sel[idx]
+						}
+						v := da.NewDString(tree.DString(bytes.Get(srcIdx)))
 						converted[destIdx] = v
 					}
-					return
-				}
-				for idx = 0; idx < length; idx++ {
-					//gcassert:bce
-					destIdx = sel[idx]
-					//gcassert:bce
-					srcIdx = sel[idx]
-					v := da.NewDString(tree.DString(bytes.Get(srcIdx)))
-					converted[destIdx] = v
-				}
-			case types.BoolFamily:
-				switch ct.Width() {
-				case -1:
-				default:
-					typedCol := col.Bool()
-					for idx = 0; idx < length; idx++ {
-						//gcassert:bce
-						destIdx = sel[idx]
-						//gcassert:bce
-						srcIdx = sel[idx]
-						v := typedCol.Get(srcIdx)
-						_converted := tree.MakeDBool(tree.DBool(v))
-						converted[destIdx] = _converted
+				case types.BoolFamily:
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.Bool()
+						_ = true
+						for idx = 0; idx < length; idx++ {
+							{
+								//gcassert:bce
+								destIdx = sel[idx]
+							}
+							{
+								//gcassert:bce
+								srcIdx = sel[idx]
+							}
+							_ = true
+							v := typedCol.Get(srcIdx)
+							_converted := tree.MakeDBool(tree.DBool(v))
+							converted[destIdx] = _converted
+						}
 					}
-				}
-			case types.IntFamily:
-				switch ct.Width() {
-				case 16:
-					typedCol := col.Int16()
-					for idx = 0; idx < length; idx++ {
-						//gcassert:bce
-						destIdx = sel[idx]
-						//gcassert:bce
-						srcIdx = sel[idx]
-						v := typedCol.Get(srcIdx)
-						_converted := da.NewDInt(tree.DInt(v))
-						converted[destIdx] = _converted
+				case types.IntFamily:
+					switch ct.Width() {
+					case 16:
+						typedCol := col.Int16()
+						_ = true
+						for idx = 0; idx < length; idx++ {
+							{
+								//gcassert:bce
+								destIdx = sel[idx]
+							}
+							{
+								//gcassert:bce
+								srcIdx = sel[idx]
+							}
+							_ = true
+							v := typedCol.Get(srcIdx)
+							_converted := da.NewDInt(tree.DInt(v))
+							converted[destIdx] = _converted
+						}
+					case 32:
+						typedCol := col.Int32()
+						_ = true
+						for idx = 0; idx < length; idx++ {
+							{
+								//gcassert:bce
+								destIdx = sel[idx]
+							}
+							{
+								//gcassert:bce
+								srcIdx = sel[idx]
+							}
+							_ = true
+							v := typedCol.Get(srcIdx)
+							_converted := da.NewDInt(tree.DInt(v))
+							converted[destIdx] = _converted
+						}
+					case -1:
+					default:
+						typedCol := col.Int64()
+						_ = true
+						for idx = 0; idx < length; idx++ {
+							{
+								//gcassert:bce
+								destIdx = sel[idx]
+							}
+							{
+								//gcassert:bce
+								srcIdx = sel[idx]
+							}
+							_ = true
+							v := typedCol.Get(srcIdx)
+							_converted := da.NewDInt(tree.DInt(v))
+							converted[destIdx] = _converted
+						}
 					}
-				case 32:
-					typedCol := col.Int32()
-					for idx = 0; idx < length; idx++ {
-						//gcassert:bce
-						destIdx = sel[idx]
-						//gcassert:bce
-						srcIdx = sel[idx]
-						v := typedCol.Get(srcIdx)
-						_converted := da.NewDInt(tree.DInt(v))
-						converted[destIdx] = _converted
+				case types.FloatFamily:
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.Float64()
+						_ = true
+						for idx = 0; idx < length; idx++ {
+							{
+								//gcassert:bce
+								destIdx = sel[idx]
+							}
+							{
+								//gcassert:bce
+								srcIdx = sel[idx]
+							}
+							_ = true
+							v := typedCol.Get(srcIdx)
+							_converted := da.NewDFloat(tree.DFloat(v))
+							converted[destIdx] = _converted
+						}
 					}
-				case -1:
-				default:
-					typedCol := col.Int64()
-					for idx = 0; idx < length; idx++ {
-						//gcassert:bce
-						destIdx = sel[idx]
-						//gcassert:bce
-						srcIdx = sel[idx]
-						v := typedCol.Get(srcIdx)
-						_converted := da.NewDInt(tree.DInt(v))
-						converted[destIdx] = _converted
+				case types.DecimalFamily:
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.Decimal()
+						_ = true
+						for idx = 0; idx < length; idx++ {
+							{
+								//gcassert:bce
+								destIdx = sel[idx]
+							}
+							{
+								//gcassert:bce
+								srcIdx = sel[idx]
+							}
+							_ = true
+							v := typedCol.Get(srcIdx)
+							_converted := da.NewDDecimal(tree.DDecimal{Decimal: v})
+							// Clear the Coeff so that the Set below allocates a new slice for the
+							// Coeff.abs field.
+							_converted.Coeff = big.Int{}
+							_converted.Coeff.Set(&v.Coeff)
+							converted[destIdx] = _converted
+						}
 					}
-				}
-			case types.FloatFamily:
-				switch ct.Width() {
-				case -1:
-				default:
-					typedCol := col.Float64()
-					for idx = 0; idx < length; idx++ {
-						//gcassert:bce
-						destIdx = sel[idx]
-						//gcassert:bce
-						srcIdx = sel[idx]
-						v := typedCol.Get(srcIdx)
-						_converted := da.NewDFloat(tree.DFloat(v))
-						converted[destIdx] = _converted
+				case types.DateFamily:
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.Int64()
+						_ = true
+						for idx = 0; idx < length; idx++ {
+							{
+								//gcassert:bce
+								destIdx = sel[idx]
+							}
+							{
+								//gcassert:bce
+								srcIdx = sel[idx]
+							}
+							_ = true
+							v := typedCol.Get(srcIdx)
+							_converted := da.NewDDate(tree.DDate{Date: pgdate.MakeCompatibleDateFromDisk(v)})
+							converted[destIdx] = _converted
+						}
 					}
-				}
-			case types.DecimalFamily:
-				switch ct.Width() {
-				case -1:
-				default:
-					typedCol := col.Decimal()
-					for idx = 0; idx < length; idx++ {
-						//gcassert:bce
-						destIdx = sel[idx]
-						//gcassert:bce
-						srcIdx = sel[idx]
-						v := typedCol.Get(srcIdx)
-						_converted := da.NewDDecimal(tree.DDecimal{Decimal: v})
-						// Clear the Coeff so that the Set below allocates a new slice for the
-						// Coeff.abs field.
-						_converted.Coeff = big.Int{}
-						_converted.Coeff.Set(&v.Coeff)
-						converted[destIdx] = _converted
+				case types.BytesFamily:
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.Bytes()
+						for idx = 0; idx < length; idx++ {
+							{
+								//gcassert:bce
+								destIdx = sel[idx]
+							}
+							{
+								//gcassert:bce
+								srcIdx = sel[idx]
+							}
+							v := typedCol.Get(srcIdx)
+							// Note that there is no need for a copy since DBytes uses a string
+							// as underlying storage, which will perform the copy for us.
+							_converted := da.NewDBytes(tree.DBytes(v))
+							converted[destIdx] = _converted
+						}
 					}
-				}
-			case types.DateFamily:
-				switch ct.Width() {
-				case -1:
-				default:
-					typedCol := col.Int64()
-					for idx = 0; idx < length; idx++ {
-						//gcassert:bce
-						destIdx = sel[idx]
-						//gcassert:bce
-						srcIdx = sel[idx]
-						v := typedCol.Get(srcIdx)
-						_converted := da.NewDDate(tree.DDate{Date: pgdate.MakeCompatibleDateFromDisk(v)})
-						converted[destIdx] = _converted
-					}
-				}
-			case types.BytesFamily:
-				switch ct.Width() {
-				case -1:
-				default:
-					typedCol := col.Bytes()
-					for idx = 0; idx < length; idx++ {
-						//gcassert:bce
-						destIdx = sel[idx]
-						//gcassert:bce
-						srcIdx = sel[idx]
-						v := typedCol.Get(srcIdx)
-						// Note that there is no need for a copy since DBytes uses a string
-						// as underlying storage, which will perform the copy for us.
-						_converted := da.NewDBytes(tree.DBytes(v))
-						converted[destIdx] = _converted
-					}
-				}
-			case types.JsonFamily:
-				switch ct.Width() {
-				case -1:
-				default:
-					typedCol := col.JSON()
-					for idx = 0; idx < length; idx++ {
-						//gcassert:bce
-						destIdx = sel[idx]
-						//gcassert:bce
-						srcIdx = sel[idx]
-						v := typedCol.Get(srcIdx)
+				case types.JsonFamily:
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.JSON()
+						for idx = 0; idx < length; idx++ {
+							{
+								//gcassert:bce
+								destIdx = sel[idx]
+							}
+							{
+								//gcassert:bce
+								srcIdx = sel[idx]
+							}
+							v := typedCol.Get(srcIdx)
 
-						// The following operation deliberately copies the input JSON
-						// bytes, since FromEncoding is lazy and keeps a handle on the bytes
-						// it is passed in.
-						_bytes, _err := json.EncodeJSON(nil, v)
-						if _err != nil {
-							colexecerror.ExpectedError(_err)
+							// The following operation deliberately copies the input JSON
+							// bytes, since FromEncoding is lazy and keeps a handle on the bytes
+							// it is passed in.
+							_bytes, _err := json.EncodeJSON(nil, v)
+							if _err != nil {
+								colexecerror.ExpectedError(_err)
+							}
+							var _j json.JSON
+							_j, _err = json.FromEncoding(_bytes)
+							if _err != nil {
+								colexecerror.ExpectedError(_err)
+							}
+							_converted := da.NewDJSON(tree.DJSON{JSON: _j})
+							converted[destIdx] = _converted
 						}
-						var _j json.JSON
-						_j, _err = json.FromEncoding(_bytes)
-						if _err != nil {
-							colexecerror.ExpectedError(_err)
+					}
+				case types.UuidFamily:
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.Bytes()
+						for idx = 0; idx < length; idx++ {
+							{
+								//gcassert:bce
+								destIdx = sel[idx]
+							}
+							{
+								//gcassert:bce
+								srcIdx = sel[idx]
+							}
+							v := typedCol.Get(srcIdx)
+							// Note that there is no need for a copy because uuid.FromBytes
+							// will perform a copy.
+							id, err := uuid.FromBytes(v)
+							if err != nil {
+								colexecerror.InternalError(err)
+							}
+							_converted := da.NewDUuid(tree.DUuid{UUID: id})
+							converted[destIdx] = _converted
 						}
-						_converted := da.NewDJSON(tree.DJSON{JSON: _j})
-						converted[destIdx] = _converted
 					}
-				}
-			case types.UuidFamily:
-				switch ct.Width() {
-				case -1:
-				default:
-					typedCol := col.Bytes()
-					for idx = 0; idx < length; idx++ {
-						//gcassert:bce
-						destIdx = sel[idx]
-						//gcassert:bce
-						srcIdx = sel[idx]
-						v := typedCol.Get(srcIdx)
-						// Note that there is no need for a copy because uuid.FromBytes
-						// will perform a copy.
-						id, err := uuid.FromBytes(v)
-						if err != nil {
-							colexecerror.InternalError(err)
+				case types.TimestampFamily:
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.Timestamp()
+						_ = true
+						for idx = 0; idx < length; idx++ {
+							{
+								//gcassert:bce
+								destIdx = sel[idx]
+							}
+							{
+								//gcassert:bce
+								srcIdx = sel[idx]
+							}
+							_ = true
+							v := typedCol.Get(srcIdx)
+							_converted := da.NewDTimestamp(tree.DTimestamp{Time: v})
+							converted[destIdx] = _converted
 						}
-						_converted := da.NewDUuid(tree.DUuid{UUID: id})
-						converted[destIdx] = _converted
 					}
-				}
-			case types.TimestampFamily:
-				switch ct.Width() {
-				case -1:
+				case types.TimestampTZFamily:
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.Timestamp()
+						_ = true
+						for idx = 0; idx < length; idx++ {
+							{
+								//gcassert:bce
+								destIdx = sel[idx]
+							}
+							{
+								//gcassert:bce
+								srcIdx = sel[idx]
+							}
+							_ = true
+							v := typedCol.Get(srcIdx)
+							_converted := da.NewDTimestampTZ(tree.DTimestampTZ{Time: v})
+							converted[destIdx] = _converted
+						}
+					}
+				case types.IntervalFamily:
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.Interval()
+						_ = true
+						for idx = 0; idx < length; idx++ {
+							{
+								//gcassert:bce
+								destIdx = sel[idx]
+							}
+							{
+								//gcassert:bce
+								srcIdx = sel[idx]
+							}
+							_ = true
+							v := typedCol.Get(srcIdx)
+							_converted := da.NewDInterval(tree.DInterval{Duration: v})
+							converted[destIdx] = _converted
+						}
+					}
+				case typeconv.DatumVecCanonicalTypeFamily:
 				default:
-					typedCol := col.Timestamp()
-					for idx = 0; idx < length; idx++ {
-						//gcassert:bce
-						destIdx = sel[idx]
-						//gcassert:bce
-						srcIdx = sel[idx]
-						v := typedCol.Get(srcIdx)
-						_converted := da.NewDTimestamp(tree.DTimestamp{Time: v})
-						converted[destIdx] = _converted
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.Datum()
+						for idx = 0; idx < length; idx++ {
+							{
+								//gcassert:bce
+								destIdx = sel[idx]
+							}
+							{
+								//gcassert:bce
+								srcIdx = sel[idx]
+							}
+							v := typedCol.Get(srcIdx)
+							_converted := v.(*coldataext.Datum).Datum
+							converted[destIdx] = _converted
+						}
 					}
 				}
-			case types.TimestampTZFamily:
-				switch ct.Width() {
-				case -1:
-				default:
-					typedCol := col.Timestamp()
-					for idx = 0; idx < length; idx++ {
-						//gcassert:bce
-						destIdx = sel[idx]
-						//gcassert:bce
-						srcIdx = sel[idx]
-						v := typedCol.Get(srcIdx)
-						_converted := da.NewDTimestampTZ(tree.DTimestampTZ{Time: v})
-						converted[destIdx] = _converted
-					}
-				}
-			case types.IntervalFamily:
-				switch ct.Width() {
-				case -1:
-				default:
-					typedCol := col.Interval()
-					for idx = 0; idx < length; idx++ {
-						//gcassert:bce
-						destIdx = sel[idx]
-						//gcassert:bce
-						srcIdx = sel[idx]
-						v := typedCol.Get(srcIdx)
-						_converted := da.NewDInterval(tree.DInterval{Duration: v})
-						converted[destIdx] = _converted
-					}
-				}
-			case typeconv.DatumVecCanonicalTypeFamily:
-			default:
-				switch ct.Width() {
-				case -1:
-				default:
-					typedCol := col.Datum()
-					for idx = 0; idx < length; idx++ {
-						//gcassert:bce
-						destIdx = sel[idx]
-						//gcassert:bce
-						srcIdx = sel[idx]
-						v := typedCol.Get(srcIdx)
-						_converted := v.(*coldataext.Datum).Datum
-						converted[destIdx] = _converted
-					}
-				}
+			vecToDatum_false_true_false_return_4:
 			}
 		} else {
-			_ = converted[length-1]
-			var idx, destIdx, srcIdx int
-			switch ct := col.Type(); ct.Family() {
-			case types.StringFamily:
-				// Note that there is no need for a copy since casting to a string will
-				// do that.
-				bytes := col.Bytes()
-				if ct.Oid() == oid.T_name {
+			{
+				_ = converted[length-1]
+				var idx, destIdx, srcIdx int
+				switch ct := col.Type(); ct.Family() {
+				case types.StringFamily:
+					// Note that there is no need for a copy since casting to a string will
+					// do that.
+					bytes := col.Bytes()
+					if ct.Oid() == oid.T_name {
+						for idx = 0; idx < length; idx++ {
+							{
+								destIdx = idx
+							}
+							{
+								srcIdx = idx
+							}
+							v := da.NewDName(tree.DString(bytes.Get(srcIdx)))
+							converted[destIdx] = v
+						}
+						goto vecToDatum_false_false_false_return_5
+					}
 					for idx = 0; idx < length; idx++ {
-						destIdx = idx
-						srcIdx = idx
-						v := da.NewDName(tree.DString(bytes.Get(srcIdx)))
-						//gcassert:bce
+						{
+							destIdx = idx
+						}
+						{
+							srcIdx = idx
+						}
+						v := da.NewDString(tree.DString(bytes.Get(srcIdx)))
 						converted[destIdx] = v
 					}
-					return
-				}
-				for idx = 0; idx < length; idx++ {
-					destIdx = idx
-					srcIdx = idx
-					v := da.NewDString(tree.DString(bytes.Get(srcIdx)))
-					//gcassert:bce
-					converted[destIdx] = v
-				}
-			case types.BoolFamily:
-				switch ct.Width() {
-				case -1:
-				default:
-					typedCol := col.Bool()
-					_ = typedCol.Get(length - 1)
-					for idx = 0; idx < length; idx++ {
-						destIdx = idx
-						srcIdx = idx
-						//gcassert:bce
-						v := typedCol.Get(srcIdx)
-						_converted := tree.MakeDBool(tree.DBool(v))
-						//gcassert:bce
-						converted[destIdx] = _converted
+				case types.BoolFamily:
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.Bool()
+						_ = true
+						_ = typedCol.Get(length - 1)
+						for idx = 0; idx < length; idx++ {
+							{
+								destIdx = idx
+							}
+							{
+								srcIdx = idx
+							}
+							_ = true
+							v := typedCol.Get(srcIdx)
+							_converted := tree.MakeDBool(tree.DBool(v))
+							converted[destIdx] = _converted
+						}
 					}
-				}
-			case types.IntFamily:
-				switch ct.Width() {
-				case 16:
-					typedCol := col.Int16()
-					_ = typedCol.Get(length - 1)
-					for idx = 0; idx < length; idx++ {
-						destIdx = idx
-						srcIdx = idx
-						//gcassert:bce
-						v := typedCol.Get(srcIdx)
-						_converted := da.NewDInt(tree.DInt(v))
-						//gcassert:bce
-						converted[destIdx] = _converted
+				case types.IntFamily:
+					switch ct.Width() {
+					case 16:
+						typedCol := col.Int16()
+						_ = true
+						_ = typedCol.Get(length - 1)
+						for idx = 0; idx < length; idx++ {
+							{
+								destIdx = idx
+							}
+							{
+								srcIdx = idx
+							}
+							_ = true
+							v := typedCol.Get(srcIdx)
+							_converted := da.NewDInt(tree.DInt(v))
+							converted[destIdx] = _converted
+						}
+					case 32:
+						typedCol := col.Int32()
+						_ = true
+						_ = typedCol.Get(length - 1)
+						for idx = 0; idx < length; idx++ {
+							{
+								destIdx = idx
+							}
+							{
+								srcIdx = idx
+							}
+							_ = true
+							v := typedCol.Get(srcIdx)
+							_converted := da.NewDInt(tree.DInt(v))
+							converted[destIdx] = _converted
+						}
+					case -1:
+					default:
+						typedCol := col.Int64()
+						_ = true
+						_ = typedCol.Get(length - 1)
+						for idx = 0; idx < length; idx++ {
+							{
+								destIdx = idx
+							}
+							{
+								srcIdx = idx
+							}
+							_ = true
+							v := typedCol.Get(srcIdx)
+							_converted := da.NewDInt(tree.DInt(v))
+							converted[destIdx] = _converted
+						}
 					}
-				case 32:
-					typedCol := col.Int32()
-					_ = typedCol.Get(length - 1)
-					for idx = 0; idx < length; idx++ {
-						destIdx = idx
-						srcIdx = idx
-						//gcassert:bce
-						v := typedCol.Get(srcIdx)
-						_converted := da.NewDInt(tree.DInt(v))
-						//gcassert:bce
-						converted[destIdx] = _converted
+				case types.FloatFamily:
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.Float64()
+						_ = true
+						_ = typedCol.Get(length - 1)
+						for idx = 0; idx < length; idx++ {
+							{
+								destIdx = idx
+							}
+							{
+								srcIdx = idx
+							}
+							_ = true
+							v := typedCol.Get(srcIdx)
+							_converted := da.NewDFloat(tree.DFloat(v))
+							converted[destIdx] = _converted
+						}
 					}
-				case -1:
-				default:
-					typedCol := col.Int64()
-					_ = typedCol.Get(length - 1)
-					for idx = 0; idx < length; idx++ {
-						destIdx = idx
-						srcIdx = idx
-						//gcassert:bce
-						v := typedCol.Get(srcIdx)
-						_converted := da.NewDInt(tree.DInt(v))
-						//gcassert:bce
-						converted[destIdx] = _converted
+				case types.DecimalFamily:
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.Decimal()
+						_ = true
+						_ = typedCol.Get(length - 1)
+						for idx = 0; idx < length; idx++ {
+							{
+								destIdx = idx
+							}
+							{
+								srcIdx = idx
+							}
+							_ = true
+							v := typedCol.Get(srcIdx)
+							_converted := da.NewDDecimal(tree.DDecimal{Decimal: v})
+							// Clear the Coeff so that the Set below allocates a new slice for the
+							// Coeff.abs field.
+							_converted.Coeff = big.Int{}
+							_converted.Coeff.Set(&v.Coeff)
+							converted[destIdx] = _converted
+						}
 					}
-				}
-			case types.FloatFamily:
-				switch ct.Width() {
-				case -1:
-				default:
-					typedCol := col.Float64()
-					_ = typedCol.Get(length - 1)
-					for idx = 0; idx < length; idx++ {
-						destIdx = idx
-						srcIdx = idx
-						//gcassert:bce
-						v := typedCol.Get(srcIdx)
-						_converted := da.NewDFloat(tree.DFloat(v))
-						//gcassert:bce
-						converted[destIdx] = _converted
+				case types.DateFamily:
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.Int64()
+						_ = true
+						_ = typedCol.Get(length - 1)
+						for idx = 0; idx < length; idx++ {
+							{
+								destIdx = idx
+							}
+							{
+								srcIdx = idx
+							}
+							_ = true
+							v := typedCol.Get(srcIdx)
+							_converted := da.NewDDate(tree.DDate{Date: pgdate.MakeCompatibleDateFromDisk(v)})
+							converted[destIdx] = _converted
+						}
 					}
-				}
-			case types.DecimalFamily:
-				switch ct.Width() {
-				case -1:
-				default:
-					typedCol := col.Decimal()
-					_ = typedCol.Get(length - 1)
-					for idx = 0; idx < length; idx++ {
-						destIdx = idx
-						srcIdx = idx
-						//gcassert:bce
-						v := typedCol.Get(srcIdx)
-						_converted := da.NewDDecimal(tree.DDecimal{Decimal: v})
-						// Clear the Coeff so that the Set below allocates a new slice for the
-						// Coeff.abs field.
-						_converted.Coeff = big.Int{}
-						_converted.Coeff.Set(&v.Coeff)
-						//gcassert:bce
-						converted[destIdx] = _converted
+				case types.BytesFamily:
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.Bytes()
+						for idx = 0; idx < length; idx++ {
+							{
+								destIdx = idx
+							}
+							{
+								srcIdx = idx
+							}
+							v := typedCol.Get(srcIdx)
+							// Note that there is no need for a copy since DBytes uses a string
+							// as underlying storage, which will perform the copy for us.
+							_converted := da.NewDBytes(tree.DBytes(v))
+							converted[destIdx] = _converted
+						}
 					}
-				}
-			case types.DateFamily:
-				switch ct.Width() {
-				case -1:
-				default:
-					typedCol := col.Int64()
-					_ = typedCol.Get(length - 1)
-					for idx = 0; idx < length; idx++ {
-						destIdx = idx
-						srcIdx = idx
-						//gcassert:bce
-						v := typedCol.Get(srcIdx)
-						_converted := da.NewDDate(tree.DDate{Date: pgdate.MakeCompatibleDateFromDisk(v)})
-						//gcassert:bce
-						converted[destIdx] = _converted
-					}
-				}
-			case types.BytesFamily:
-				switch ct.Width() {
-				case -1:
-				default:
-					typedCol := col.Bytes()
-					for idx = 0; idx < length; idx++ {
-						destIdx = idx
-						srcIdx = idx
-						v := typedCol.Get(srcIdx)
-						// Note that there is no need for a copy since DBytes uses a string
-						// as underlying storage, which will perform the copy for us.
-						_converted := da.NewDBytes(tree.DBytes(v))
-						//gcassert:bce
-						converted[destIdx] = _converted
-					}
-				}
-			case types.JsonFamily:
-				switch ct.Width() {
-				case -1:
-				default:
-					typedCol := col.JSON()
-					for idx = 0; idx < length; idx++ {
-						destIdx = idx
-						srcIdx = idx
-						v := typedCol.Get(srcIdx)
+				case types.JsonFamily:
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.JSON()
+						for idx = 0; idx < length; idx++ {
+							{
+								destIdx = idx
+							}
+							{
+								srcIdx = idx
+							}
+							v := typedCol.Get(srcIdx)
 
-						// The following operation deliberately copies the input JSON
-						// bytes, since FromEncoding is lazy and keeps a handle on the bytes
-						// it is passed in.
-						_bytes, _err := json.EncodeJSON(nil, v)
-						if _err != nil {
-							colexecerror.ExpectedError(_err)
+							// The following operation deliberately copies the input JSON
+							// bytes, since FromEncoding is lazy and keeps a handle on the bytes
+							// it is passed in.
+							_bytes, _err := json.EncodeJSON(nil, v)
+							if _err != nil {
+								colexecerror.ExpectedError(_err)
+							}
+							var _j json.JSON
+							_j, _err = json.FromEncoding(_bytes)
+							if _err != nil {
+								colexecerror.ExpectedError(_err)
+							}
+							_converted := da.NewDJSON(tree.DJSON{JSON: _j})
+							converted[destIdx] = _converted
 						}
-						var _j json.JSON
-						_j, _err = json.FromEncoding(_bytes)
-						if _err != nil {
-							colexecerror.ExpectedError(_err)
+					}
+				case types.UuidFamily:
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.Bytes()
+						for idx = 0; idx < length; idx++ {
+							{
+								destIdx = idx
+							}
+							{
+								srcIdx = idx
+							}
+							v := typedCol.Get(srcIdx)
+							// Note that there is no need for a copy because uuid.FromBytes
+							// will perform a copy.
+							id, err := uuid.FromBytes(v)
+							if err != nil {
+								colexecerror.InternalError(err)
+							}
+							_converted := da.NewDUuid(tree.DUuid{UUID: id})
+							converted[destIdx] = _converted
 						}
-						_converted := da.NewDJSON(tree.DJSON{JSON: _j})
-						//gcassert:bce
-						converted[destIdx] = _converted
 					}
-				}
-			case types.UuidFamily:
-				switch ct.Width() {
-				case -1:
-				default:
-					typedCol := col.Bytes()
-					for idx = 0; idx < length; idx++ {
-						destIdx = idx
-						srcIdx = idx
-						v := typedCol.Get(srcIdx)
-						// Note that there is no need for a copy because uuid.FromBytes
-						// will perform a copy.
-						id, err := uuid.FromBytes(v)
-						if err != nil {
-							colexecerror.InternalError(err)
+				case types.TimestampFamily:
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.Timestamp()
+						_ = true
+						_ = typedCol.Get(length - 1)
+						for idx = 0; idx < length; idx++ {
+							{
+								destIdx = idx
+							}
+							{
+								srcIdx = idx
+							}
+							_ = true
+							v := typedCol.Get(srcIdx)
+							_converted := da.NewDTimestamp(tree.DTimestamp{Time: v})
+							converted[destIdx] = _converted
 						}
-						_converted := da.NewDUuid(tree.DUuid{UUID: id})
-						//gcassert:bce
-						converted[destIdx] = _converted
 					}
-				}
-			case types.TimestampFamily:
-				switch ct.Width() {
-				case -1:
+				case types.TimestampTZFamily:
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.Timestamp()
+						_ = true
+						_ = typedCol.Get(length - 1)
+						for idx = 0; idx < length; idx++ {
+							{
+								destIdx = idx
+							}
+							{
+								srcIdx = idx
+							}
+							_ = true
+							v := typedCol.Get(srcIdx)
+							_converted := da.NewDTimestampTZ(tree.DTimestampTZ{Time: v})
+							converted[destIdx] = _converted
+						}
+					}
+				case types.IntervalFamily:
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.Interval()
+						_ = true
+						_ = typedCol.Get(length - 1)
+						for idx = 0; idx < length; idx++ {
+							{
+								destIdx = idx
+							}
+							{
+								srcIdx = idx
+							}
+							_ = true
+							v := typedCol.Get(srcIdx)
+							_converted := da.NewDInterval(tree.DInterval{Duration: v})
+							converted[destIdx] = _converted
+						}
+					}
+				case typeconv.DatumVecCanonicalTypeFamily:
 				default:
-					typedCol := col.Timestamp()
-					_ = typedCol.Get(length - 1)
-					for idx = 0; idx < length; idx++ {
-						destIdx = idx
-						srcIdx = idx
-						//gcassert:bce
-						v := typedCol.Get(srcIdx)
-						_converted := da.NewDTimestamp(tree.DTimestamp{Time: v})
-						//gcassert:bce
-						converted[destIdx] = _converted
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.Datum()
+						for idx = 0; idx < length; idx++ {
+							{
+								destIdx = idx
+							}
+							{
+								srcIdx = idx
+							}
+							v := typedCol.Get(srcIdx)
+							_converted := v.(*coldataext.Datum).Datum
+							converted[destIdx] = _converted
+						}
 					}
 				}
-			case types.TimestampTZFamily:
-				switch ct.Width() {
-				case -1:
-				default:
-					typedCol := col.Timestamp()
-					_ = typedCol.Get(length - 1)
-					for idx = 0; idx < length; idx++ {
-						destIdx = idx
-						srcIdx = idx
-						//gcassert:bce
-						v := typedCol.Get(srcIdx)
-						_converted := da.NewDTimestampTZ(tree.DTimestampTZ{Time: v})
-						//gcassert:bce
-						converted[destIdx] = _converted
-					}
-				}
-			case types.IntervalFamily:
-				switch ct.Width() {
-				case -1:
-				default:
-					typedCol := col.Interval()
-					_ = typedCol.Get(length - 1)
-					for idx = 0; idx < length; idx++ {
-						destIdx = idx
-						srcIdx = idx
-						//gcassert:bce
-						v := typedCol.Get(srcIdx)
-						_converted := da.NewDInterval(tree.DInterval{Duration: v})
-						//gcassert:bce
-						converted[destIdx] = _converted
-					}
-				}
-			case typeconv.DatumVecCanonicalTypeFamily:
-			default:
-				switch ct.Width() {
-				case -1:
-				default:
-					typedCol := col.Datum()
-					for idx = 0; idx < length; idx++ {
-						destIdx = idx
-						srcIdx = idx
-						v := typedCol.Get(srcIdx)
-						_converted := v.(*coldataext.Datum).Datum
-						//gcassert:bce
-						converted[destIdx] = _converted
-					}
-				}
+			vecToDatum_false_false_false_return_5:
 			}
 		}
 	}
 }
+
+// This template function is a small helper that updates destIdx based on
+// whether we want the deselection behavior.
+// execgen:inline
+const _ = "template_setDestIdx"
+
+// execgen:inline
+const _ = "template_setSrcIdx"
+
+// vecToDatum converts the columnar data in col to the corresponding
+// tree.Datum representation that is assigned to converted. length determines
+// how many columnar values need to be converted and sel is an optional
+// selection vector.
+// NOTE: if sel is non-nil, it might perform the deselection
+// step meaning (that it will densely populate converted with only values that
+// are selected according to sel) based on deselect value.
+// Note: len(converted) must be of sufficient length.
+// execgen:inline
+const _ = "template_vecToDatum"
+
+// vecToDatum converts the columnar data in col to the corresponding
+// tree.Datum representation that is assigned to converted. length determines
+// how many columnar values need to be converted and sel is an optional
+// selection vector.
+// NOTE: if sel is non-nil, it might perform the deselection
+// step meaning (that it will densely populate converted with only values that
+// are selected according to sel) based on deselect value.
+// Note: len(converted) must be of sufficient length.
+// execgen:inline
+const _ = "inlined_vecToDatum_true_true_true"
+
+// vecToDatum converts the columnar data in col to the corresponding
+// tree.Datum representation that is assigned to converted. length determines
+// how many columnar values need to be converted and sel is an optional
+// selection vector.
+// NOTE: if sel is non-nil, it might perform the deselection
+// step meaning (that it will densely populate converted with only values that
+// are selected according to sel) based on deselect value.
+// Note: len(converted) must be of sufficient length.
+// execgen:inline
+const _ = "inlined_vecToDatum_false_true_true"
+
+// vecToDatum converts the columnar data in col to the corresponding
+// tree.Datum representation that is assigned to converted. length determines
+// how many columnar values need to be converted and sel is an optional
+// selection vector.
+// NOTE: if sel is non-nil, it might perform the deselection
+// step meaning (that it will densely populate converted with only values that
+// are selected according to sel) based on deselect value.
+// Note: len(converted) must be of sufficient length.
+// execgen:inline
+const _ = "inlined_vecToDatum_true_true_false"
+
+// vecToDatum converts the columnar data in col to the corresponding
+// tree.Datum representation that is assigned to converted. length determines
+// how many columnar values need to be converted and sel is an optional
+// selection vector.
+// NOTE: if sel is non-nil, it might perform the deselection
+// step meaning (that it will densely populate converted with only values that
+// are selected according to sel) based on deselect value.
+// Note: len(converted) must be of sufficient length.
+// execgen:inline
+const _ = "inlined_vecToDatum_true_false_false"
+
+// vecToDatum converts the columnar data in col to the corresponding
+// tree.Datum representation that is assigned to converted. length determines
+// how many columnar values need to be converted and sel is an optional
+// selection vector.
+// NOTE: if sel is non-nil, it might perform the deselection
+// step meaning (that it will densely populate converted with only values that
+// are selected according to sel) based on deselect value.
+// Note: len(converted) must be of sufficient length.
+// execgen:inline
+const _ = "inlined_vecToDatum_false_true_false"
+
+// vecToDatum converts the columnar data in col to the corresponding
+// tree.Datum representation that is assigned to converted. length determines
+// how many columnar values need to be converted and sel is an optional
+// selection vector.
+// NOTE: if sel is non-nil, it might perform the deselection
+// step meaning (that it will densely populate converted with only values that
+// are selected according to sel) based on deselect value.
+// Note: len(converted) must be of sufficient length.
+// execgen:inline
+const _ = "inlined_vecToDatum_false_false_false"
+
+// This template function is a small helper that updates destIdx based on
+// whether we want the deselection behavior.
+// execgen:inline
+const _ = "inlined_setDestIdx_true_true"
+
+// execgen:inline
+const _ = "inlined_setSrcIdx_true"
+
+// This template function is a small helper that updates destIdx based on
+// whether we want the deselection behavior.
+// execgen:inline
+const _ = "inlined_setDestIdx_true_false"
+
+// This template function is a small helper that updates destIdx based on
+// whether we want the deselection behavior.
+// execgen:inline
+const _ = "inlined_setDestIdx_false_false"
+
+// execgen:inline
+const _ = "inlined_setSrcIdx_false"

--- a/pkg/sql/colexec/colexecjoin/hashjoiner.eg.go
+++ b/pkg/sql/colexec/colexecjoin/hashjoiner.eg.go
@@ -13,343 +13,12 @@ import "github.com/cockroachdb/cockroach/pkg/col/coldata"
 
 const _ = "template_collectProbeOuter"
 
-func collectProbeOuter_false(
-	hj *hashJoiner, batchSize int, nResults int, batch coldata.Batch, sel []int) int {
-	// Early bounds checks.
-	// Capture the slices in order for BCE to occur.
-	HeadIDs := hj.ht.ProbeScratch.HeadID
-	startIdx := hj.probeState.prevBatchResumeIdx
-	_ = HeadIDs[startIdx]
-	_ = HeadIDs[batchSize-1]
-	maxResults := len(hj.probeState.buildIdx)
-	buildIdx := hj.probeState.buildIdx
-	probeIdx := hj.probeState.probeIdx
-	_ = buildIdx[nResults]
-	_ = probeIdx[nResults]
-	_ = buildIdx[maxResults-1]
-	_ = probeIdx[maxResults-1]
-	for i := startIdx; i < batchSize; i++ {
-		//gcassert:bce
-		currentID := HeadIDs[i]
-
-		for ; nResults < maxResults; nResults++ {
-			rowUnmatched := currentID == 0
-			// For some reason, BCE doesn't occur for probeRowUnmatched slice.
-			// TODO(yuzefovich): figure it out.
-			hj.probeState.probeRowUnmatched[nResults] = rowUnmatched
-			if rowUnmatched {
-				// The row is unmatched, and we set the corresponding buildIdx
-				// to zero so that (as long as the build hash table has at least
-				// one row) we can copy the values vector without paying
-				// attention to probeRowUnmatched.
-				//gcassert:bce
-				buildIdx[nResults] = 0
-			} else {
-				//gcassert:bce
-				buildIdx[nResults] = int(currentID - 1)
-			}
-			var pIdx int
-			{
-				var __retval_0 int
-				{
-					{
-						__retval_0 = i
-					}
-				}
-				pIdx = __retval_0
-			}
-			//gcassert:bce
-			probeIdx[nResults] = pIdx
-			currentID = hj.ht.Same[currentID]
-			//gcassert:bce
-			HeadIDs[i] = currentID
-
-			if currentID == 0 {
-				nResults++
-				break
-			}
-		}
-
-		if nResults == maxResults {
-			// We have collected the maximum number of results that fit into the
-			// current output batch.
-			if currentID != 0 {
-				// We haven't finished probing the ith tuple of the current
-				// probing batch, so we'll need to resume from the same state.
-				hj.probeState.prevBatch = batch
-				hj.probeState.prevBatchResumeIdx = i
-			} else {
-				// We're done probing the ith tuple.
-				if i+1 < batchSize {
-					// But we're not done probing the batch yet.
-					hj.probeState.prevBatch = batch
-					hj.probeState.prevBatchResumeIdx = i + 1
-				}
-			}
-			return nResults
-		}
-	}
-	return nResults
-}
-
-func collectProbeOuter_true(
-	hj *hashJoiner, batchSize int, nResults int, batch coldata.Batch, sel []int) int {
-	// Early bounds checks.
-	// Capture the slices in order for BCE to occur.
-	HeadIDs := hj.ht.ProbeScratch.HeadID
-	startIdx := hj.probeState.prevBatchResumeIdx
-	_ = HeadIDs[startIdx]
-	_ = HeadIDs[batchSize-1]
-	_ = sel[batchSize-1]
-	maxResults := len(hj.probeState.buildIdx)
-	buildIdx := hj.probeState.buildIdx
-	probeIdx := hj.probeState.probeIdx
-	_ = buildIdx[nResults]
-	_ = probeIdx[nResults]
-	_ = buildIdx[maxResults-1]
-	_ = probeIdx[maxResults-1]
-	for i := startIdx; i < batchSize; i++ {
-		//gcassert:bce
-		currentID := HeadIDs[i]
-
-		for ; nResults < maxResults; nResults++ {
-			rowUnmatched := currentID == 0
-			// For some reason, BCE doesn't occur for probeRowUnmatched slice.
-			// TODO(yuzefovich): figure it out.
-			hj.probeState.probeRowUnmatched[nResults] = rowUnmatched
-			if rowUnmatched {
-				// The row is unmatched, and we set the corresponding buildIdx
-				// to zero so that (as long as the build hash table has at least
-				// one row) we can copy the values vector without paying
-				// attention to probeRowUnmatched.
-				//gcassert:bce
-				buildIdx[nResults] = 0
-			} else {
-				//gcassert:bce
-				buildIdx[nResults] = int(currentID - 1)
-			}
-			var pIdx int
-			{
-				var __retval_0 int
-				{
-					{
-						__retval_0 = sel[i]
-					}
-				}
-				pIdx = __retval_0
-			}
-			//gcassert:bce
-			probeIdx[nResults] = pIdx
-			currentID = hj.ht.Same[currentID]
-			//gcassert:bce
-			HeadIDs[i] = currentID
-
-			if currentID == 0 {
-				nResults++
-				break
-			}
-		}
-
-		if nResults == maxResults {
-			// We have collected the maximum number of results that fit into the
-			// current output batch.
-			if currentID != 0 {
-				// We haven't finished probing the ith tuple of the current
-				// probing batch, so we'll need to resume from the same state.
-				hj.probeState.prevBatch = batch
-				hj.probeState.prevBatchResumeIdx = i
-			} else {
-				// We're done probing the ith tuple.
-				if i+1 < batchSize {
-					// But we're not done probing the batch yet.
-					hj.probeState.prevBatch = batch
-					hj.probeState.prevBatchResumeIdx = i + 1
-				}
-			}
-			return nResults
-		}
-	}
-	return nResults
-}
-
 const _ = "template_collectProbeNoOuter"
-
-func collectProbeNoOuter_false(
-	hj *hashJoiner, batchSize int, nResults int, batch coldata.Batch, sel []int) int {
-	// Early bounds checks.
-	// Capture the slices in order for BCE to occur.
-	HeadIDs := hj.ht.ProbeScratch.HeadID
-	startIdx := hj.probeState.prevBatchResumeIdx
-	_ = HeadIDs[startIdx]
-	_ = HeadIDs[batchSize-1]
-	maxResults := len(hj.probeState.buildIdx)
-	probeIdx := hj.probeState.probeIdx
-	_ = probeIdx[nResults]
-	_ = probeIdx[maxResults-1]
-	for i := startIdx; i < batchSize; i++ {
-		//gcassert:bce
-		currentID := HeadIDs[i]
-		for ; currentID != 0 && nResults < maxResults; nResults++ {
-			// For some reason, BCE doesn't occur for buildIdx slice.
-			// TODO(yuzefovich): figure it out.
-			hj.probeState.buildIdx[nResults] = int(currentID - 1)
-			var pIdx int
-			{
-				var __retval_0 int
-				{
-					{
-						__retval_0 = i
-					}
-				}
-				pIdx = __retval_0
-			}
-			//gcassert:bce
-			probeIdx[nResults] = pIdx
-			currentID = hj.ht.Same[currentID]
-			//gcassert:bce
-			HeadIDs[i] = currentID
-		}
-
-		if nResults == maxResults {
-			// We have collected the maximum number of results that fit into the
-			// current output batch.
-			if currentID != 0 {
-				// We haven't finished probing the ith tuple of the current
-				// probing batch, so we'll need to resume from the same state.
-				hj.probeState.prevBatch = batch
-				hj.probeState.prevBatchResumeIdx = i
-			} else {
-				// We're done probing the ith tuple.
-				if i+1 < batchSize {
-					// But we're not done probing the batch yet.
-					hj.probeState.prevBatch = batch
-					hj.probeState.prevBatchResumeIdx = i + 1
-				}
-			}
-			return nResults
-		}
-	}
-	return nResults
-}
-
-func collectProbeNoOuter_true(
-	hj *hashJoiner, batchSize int, nResults int, batch coldata.Batch, sel []int) int {
-	// Early bounds checks.
-	// Capture the slices in order for BCE to occur.
-	HeadIDs := hj.ht.ProbeScratch.HeadID
-	startIdx := hj.probeState.prevBatchResumeIdx
-	_ = HeadIDs[startIdx]
-	_ = HeadIDs[batchSize-1]
-	_ = sel[batchSize-1]
-	maxResults := len(hj.probeState.buildIdx)
-	probeIdx := hj.probeState.probeIdx
-	_ = probeIdx[nResults]
-	_ = probeIdx[maxResults-1]
-	for i := startIdx; i < batchSize; i++ {
-		//gcassert:bce
-		currentID := HeadIDs[i]
-		for ; currentID != 0 && nResults < maxResults; nResults++ {
-			// For some reason, BCE doesn't occur for buildIdx slice.
-			// TODO(yuzefovich): figure it out.
-			hj.probeState.buildIdx[nResults] = int(currentID - 1)
-			var pIdx int
-			{
-				var __retval_0 int
-				{
-					{
-						__retval_0 = sel[i]
-					}
-				}
-				pIdx = __retval_0
-			}
-			//gcassert:bce
-			probeIdx[nResults] = pIdx
-			currentID = hj.ht.Same[currentID]
-			//gcassert:bce
-			HeadIDs[i] = currentID
-		}
-
-		if nResults == maxResults {
-			// We have collected the maximum number of results that fit into the
-			// current output batch.
-			if currentID != 0 {
-				// We haven't finished probing the ith tuple of the current
-				// probing batch, so we'll need to resume from the same state.
-				hj.probeState.prevBatch = batch
-				hj.probeState.prevBatchResumeIdx = i
-			} else {
-				// We're done probing the ith tuple.
-				if i+1 < batchSize {
-					// But we're not done probing the batch yet.
-					hj.probeState.prevBatch = batch
-					hj.probeState.prevBatchResumeIdx = i + 1
-				}
-			}
-			return nResults
-		}
-	}
-	return nResults
-}
 
 // This code snippet collects the "matches" for LEFT ANTI and EXCEPT ALL joins.
 // "Matches" are in quotes because we're actually interested in non-matches
 // from the left side.
 const _ = "template_collectLeftAnti"
-
-func collectLeftAnti_false(
-	hj *hashJoiner, batchSize int, nResults int, batch coldata.Batch, sel []int) int {
-	// Early bounds checks.
-	// Capture the slice in order for BCE to occur.
-	HeadIDs := hj.ht.ProbeScratch.HeadID
-	_ = HeadIDs[batchSize-1]
-	for i := 0; i < batchSize; i++ {
-		//gcassert:bce
-		currentID := HeadIDs[i]
-		if currentID == 0 {
-			{
-				var __retval_0 int
-				{
-					{
-						__retval_0 = i
-					}
-				}
-				// currentID of 0 indicates that ith probing row didn't have a match, so
-				// we include it into the output.
-				hj.probeState.probeIdx[nResults] = __retval_0
-			}
-			nResults++
-		}
-	}
-	return nResults
-}
-
-func collectLeftAnti_true(
-	hj *hashJoiner, batchSize int, nResults int, batch coldata.Batch, sel []int) int {
-	// Early bounds checks.
-	// Capture the slice in order for BCE to occur.
-	HeadIDs := hj.ht.ProbeScratch.HeadID
-	_ = HeadIDs[batchSize-1]
-	_ = sel[batchSize-1]
-	for i := 0; i < batchSize; i++ {
-		//gcassert:bce
-		currentID := HeadIDs[i]
-		if currentID == 0 {
-			{
-				var __retval_0 int
-				{
-					{
-						__retval_0 = sel[i]
-					}
-				}
-				// currentID of 0 indicates that ith probing row didn't have a match, so
-				// we include it into the output.
-				hj.probeState.probeIdx[nResults] = __retval_0
-			}
-			nResults++
-		}
-	}
-	return nResults
-}
 
 // collectRightSemiAnti processes all matches for right semi/anti joins. Note
 // that during the probing phase we do not emit any output for these joins and
@@ -372,151 +41,7 @@ func collectRightSemiAnti(hj *hashJoiner, batchSize int) {
 
 const _ = "template_distinctCollectProbeOuter"
 
-func distinctCollectProbeOuter_false(hj *hashJoiner, batchSize int, sel []int) {
-	// Early bounds checks.
-	// Capture the slices in order for BCE to occur.
-	groupIDs := hj.ht.ProbeScratch.GroupID
-	probeRowUnmatched := hj.probeState.probeRowUnmatched
-	buildIdx := hj.probeState.buildIdx
-	probeIdx := hj.probeState.probeIdx
-	_ = groupIDs[batchSize-1]
-	_ = probeRowUnmatched[batchSize-1]
-	_ = buildIdx[batchSize-1]
-	_ = probeIdx[batchSize-1]
-	for i := 0; i < batchSize; i++ {
-		// Index of keys and outputs in the hash table is calculated as ID - 1.
-		//gcassert:bce
-		id := groupIDs[i]
-		rowUnmatched := id == 0
-		//gcassert:bce
-		probeRowUnmatched[i] = rowUnmatched
-		if rowUnmatched {
-			// The row is unmatched, and we set the corresponding buildIdx
-			// to zero so that (as long as the build hash table has at least
-			// one row) we can copy the values vector without paying
-			// attention to probeRowUnmatched.
-			//gcassert:bce
-			buildIdx[i] = 0
-		} else {
-			//gcassert:bce
-			buildIdx[i] = int(id - 1)
-		}
-		var pIdx int
-		{
-			var __retval_0 int
-			{
-				{
-					__retval_0 = i
-				}
-			}
-			pIdx = __retval_0
-		}
-		//gcassert:bce
-		probeIdx[i] = pIdx
-	}
-}
-
-func distinctCollectProbeOuter_true(hj *hashJoiner, batchSize int, sel []int) {
-	// Early bounds checks.
-	// Capture the slices in order for BCE to occur.
-	groupIDs := hj.ht.ProbeScratch.GroupID
-	probeRowUnmatched := hj.probeState.probeRowUnmatched
-	buildIdx := hj.probeState.buildIdx
-	probeIdx := hj.probeState.probeIdx
-	_ = groupIDs[batchSize-1]
-	_ = probeRowUnmatched[batchSize-1]
-	_ = buildIdx[batchSize-1]
-	_ = probeIdx[batchSize-1]
-	_ = sel[batchSize-1]
-	for i := 0; i < batchSize; i++ {
-		// Index of keys and outputs in the hash table is calculated as ID - 1.
-		//gcassert:bce
-		id := groupIDs[i]
-		rowUnmatched := id == 0
-		//gcassert:bce
-		probeRowUnmatched[i] = rowUnmatched
-		if rowUnmatched {
-			// The row is unmatched, and we set the corresponding buildIdx
-			// to zero so that (as long as the build hash table has at least
-			// one row) we can copy the values vector without paying
-			// attention to probeRowUnmatched.
-			//gcassert:bce
-			buildIdx[i] = 0
-		} else {
-			//gcassert:bce
-			buildIdx[i] = int(id - 1)
-		}
-		var pIdx int
-		{
-			var __retval_0 int
-			{
-				{
-					__retval_0 = sel[i]
-				}
-			}
-			pIdx = __retval_0
-		}
-		//gcassert:bce
-		probeIdx[i] = pIdx
-	}
-}
-
 const _ = "template_distinctCollectProbeNoOuter"
-
-func distinctCollectProbeNoOuter_false(
-	hj *hashJoiner, batchSize int, nResults int, sel []int) int {
-	// Early bounds checks.
-	// Capture the slice in order for BCE to occur.
-	groupIDs := hj.ht.ProbeScratch.GroupID
-	_ = groupIDs[batchSize-1]
-	for i := 0; i < batchSize; i++ {
-		//gcassert:bce
-		id := groupIDs[i]
-		if id != 0 {
-			// Index of keys and outputs in the hash table is calculated as ID - 1.
-			hj.probeState.buildIdx[nResults] = int(id - 1)
-			{
-				var __retval_0 int
-				{
-					{
-						__retval_0 = i
-					}
-				}
-				hj.probeState.probeIdx[nResults] = __retval_0
-			}
-			nResults++
-		}
-	}
-	return nResults
-}
-
-func distinctCollectProbeNoOuter_true(
-	hj *hashJoiner, batchSize int, nResults int, sel []int) int {
-	// Early bounds checks.
-	// Capture the slice in order for BCE to occur.
-	groupIDs := hj.ht.ProbeScratch.GroupID
-	_ = groupIDs[batchSize-1]
-	_ = sel[batchSize-1]
-	for i := 0; i < batchSize; i++ {
-		//gcassert:bce
-		id := groupIDs[i]
-		if id != 0 {
-			// Index of keys and outputs in the hash table is calculated as ID - 1.
-			hj.probeState.buildIdx[nResults] = int(id - 1)
-			{
-				var __retval_0 int
-				{
-					{
-						__retval_0 = sel[i]
-					}
-				}
-				hj.probeState.probeIdx[nResults] = __retval_0
-			}
-			nResults++
-		}
-	}
-	return nResults
-}
 
 // collect prepares the buildIdx and probeIdx arrays where the buildIdx and
 // probeIdx at each index are joined to make an output row. The total number of
@@ -601,8 +126,489 @@ func (hj *hashJoiner) distinctCollect(batch coldata.Batch, batchSize int, sel []
 // execgen:inline
 const _ = "template_getIdx"
 
-// execgen:inline
-const _ = "inlined_getIdx_false"
+func collectProbeOuter_true(
+	hj *hashJoiner, batchSize int, nResults int, batch coldata.Batch, sel []int) int {
+	// Early bounds checks.
+	// Capture the slices in order for BCE to occur.
+	HeadIDs := hj.ht.ProbeScratch.HeadID
+	startIdx := hj.probeState.prevBatchResumeIdx
+	_ = HeadIDs[startIdx]
+	_ = HeadIDs[batchSize-1]
+	_ = sel[batchSize-1]
+	maxResults := len(hj.probeState.buildIdx)
+	buildIdx := hj.probeState.buildIdx
+	probeIdx := hj.probeState.probeIdx
+	_ = buildIdx[nResults]
+	_ = probeIdx[nResults]
+	_ = buildIdx[maxResults-1]
+	_ = probeIdx[maxResults-1]
+	for i := startIdx; i < batchSize; i++ {
+		//gcassert:bce
+		currentID := HeadIDs[i]
+
+		for ; nResults < maxResults; nResults++ {
+			rowUnmatched := currentID == 0
+			// For some reason, BCE doesn't occur for probeRowUnmatched slice.
+			// TODO(yuzefovich): figure it out.
+			hj.probeState.probeRowUnmatched[nResults] = rowUnmatched
+			if rowUnmatched {
+				// The row is unmatched, and we set the corresponding buildIdx
+				// to zero so that (as long as the build hash table has at least
+				// one row) we can copy the values vector without paying
+				// attention to probeRowUnmatched.
+				//gcassert:bce
+				buildIdx[nResults] = 0
+			} else {
+				//gcassert:bce
+				buildIdx[nResults] = int(currentID - 1)
+			}
+			var pIdx int
+			{
+				var __retval_0 int
+				{
+					{
+						__retval_0 = sel[i]
+					}
+				}
+				pIdx = __retval_0
+			}
+			//gcassert:bce
+			probeIdx[nResults] = pIdx
+			currentID = hj.ht.Same[currentID]
+			//gcassert:bce
+			HeadIDs[i] = currentID
+
+			if currentID == 0 {
+				nResults++
+				break
+			}
+		}
+
+		if nResults == maxResults {
+			// We have collected the maximum number of results that fit into the
+			// current output batch.
+			if currentID != 0 {
+				// We haven't finished probing the ith tuple of the current
+				// probing batch, so we'll need to resume from the same state.
+				hj.probeState.prevBatch = batch
+				hj.probeState.prevBatchResumeIdx = i
+			} else {
+				// We're done probing the ith tuple.
+				if i+1 < batchSize {
+					// But we're not done probing the batch yet.
+					hj.probeState.prevBatch = batch
+					hj.probeState.prevBatchResumeIdx = i + 1
+				}
+			}
+			return nResults
+		}
+	}
+	return nResults
+}
+
+func collectProbeOuter_false(
+	hj *hashJoiner, batchSize int, nResults int, batch coldata.Batch, sel []int) int {
+	// Early bounds checks.
+	// Capture the slices in order for BCE to occur.
+	HeadIDs := hj.ht.ProbeScratch.HeadID
+	startIdx := hj.probeState.prevBatchResumeIdx
+	_ = HeadIDs[startIdx]
+	_ = HeadIDs[batchSize-1]
+	maxResults := len(hj.probeState.buildIdx)
+	buildIdx := hj.probeState.buildIdx
+	probeIdx := hj.probeState.probeIdx
+	_ = buildIdx[nResults]
+	_ = probeIdx[nResults]
+	_ = buildIdx[maxResults-1]
+	_ = probeIdx[maxResults-1]
+	for i := startIdx; i < batchSize; i++ {
+		//gcassert:bce
+		currentID := HeadIDs[i]
+
+		for ; nResults < maxResults; nResults++ {
+			rowUnmatched := currentID == 0
+			// For some reason, BCE doesn't occur for probeRowUnmatched slice.
+			// TODO(yuzefovich): figure it out.
+			hj.probeState.probeRowUnmatched[nResults] = rowUnmatched
+			if rowUnmatched {
+				// The row is unmatched, and we set the corresponding buildIdx
+				// to zero so that (as long as the build hash table has at least
+				// one row) we can copy the values vector without paying
+				// attention to probeRowUnmatched.
+				//gcassert:bce
+				buildIdx[nResults] = 0
+			} else {
+				//gcassert:bce
+				buildIdx[nResults] = int(currentID - 1)
+			}
+			var pIdx int
+			{
+				var __retval_0 int
+				{
+					{
+						__retval_0 = i
+					}
+				}
+				pIdx = __retval_0
+			}
+			//gcassert:bce
+			probeIdx[nResults] = pIdx
+			currentID = hj.ht.Same[currentID]
+			//gcassert:bce
+			HeadIDs[i] = currentID
+
+			if currentID == 0 {
+				nResults++
+				break
+			}
+		}
+
+		if nResults == maxResults {
+			// We have collected the maximum number of results that fit into the
+			// current output batch.
+			if currentID != 0 {
+				// We haven't finished probing the ith tuple of the current
+				// probing batch, so we'll need to resume from the same state.
+				hj.probeState.prevBatch = batch
+				hj.probeState.prevBatchResumeIdx = i
+			} else {
+				// We're done probing the ith tuple.
+				if i+1 < batchSize {
+					// But we're not done probing the batch yet.
+					hj.probeState.prevBatch = batch
+					hj.probeState.prevBatchResumeIdx = i + 1
+				}
+			}
+			return nResults
+		}
+	}
+	return nResults
+}
+
+// This code snippet collects the "matches" for LEFT ANTI and EXCEPT ALL joins.
+// "Matches" are in quotes because we're actually interested in non-matches
+// from the left side.
+func collectLeftAnti_true(
+	hj *hashJoiner, batchSize int, nResults int, batch coldata.Batch, sel []int) int {
+	// Early bounds checks.
+	// Capture the slice in order for BCE to occur.
+	HeadIDs := hj.ht.ProbeScratch.HeadID
+	_ = HeadIDs[batchSize-1]
+	_ = sel[batchSize-1]
+	for i := 0; i < batchSize; i++ {
+		//gcassert:bce
+		currentID := HeadIDs[i]
+		if currentID == 0 {
+			{
+				var __retval_0 int
+				{
+					{
+						__retval_0 = sel[i]
+					}
+				}
+				// currentID of 0 indicates that ith probing row didn't have a match, so
+				// we include it into the output.
+				hj.probeState.probeIdx[nResults] = __retval_0
+			}
+			nResults++
+		}
+	}
+	return nResults
+}
+
+func collectProbeNoOuter_true(
+	hj *hashJoiner, batchSize int, nResults int, batch coldata.Batch, sel []int) int {
+	// Early bounds checks.
+	// Capture the slices in order for BCE to occur.
+	HeadIDs := hj.ht.ProbeScratch.HeadID
+	startIdx := hj.probeState.prevBatchResumeIdx
+	_ = HeadIDs[startIdx]
+	_ = HeadIDs[batchSize-1]
+	_ = sel[batchSize-1]
+	maxResults := len(hj.probeState.buildIdx)
+	probeIdx := hj.probeState.probeIdx
+	_ = probeIdx[nResults]
+	_ = probeIdx[maxResults-1]
+	for i := startIdx; i < batchSize; i++ {
+		//gcassert:bce
+		currentID := HeadIDs[i]
+		for ; currentID != 0 && nResults < maxResults; nResults++ {
+			// For some reason, BCE doesn't occur for buildIdx slice.
+			// TODO(yuzefovich): figure it out.
+			hj.probeState.buildIdx[nResults] = int(currentID - 1)
+			var pIdx int
+			{
+				var __retval_0 int
+				{
+					{
+						__retval_0 = sel[i]
+					}
+				}
+				pIdx = __retval_0
+			}
+			//gcassert:bce
+			probeIdx[nResults] = pIdx
+			currentID = hj.ht.Same[currentID]
+			//gcassert:bce
+			HeadIDs[i] = currentID
+		}
+
+		if nResults == maxResults {
+			// We have collected the maximum number of results that fit into the
+			// current output batch.
+			if currentID != 0 {
+				// We haven't finished probing the ith tuple of the current
+				// probing batch, so we'll need to resume from the same state.
+				hj.probeState.prevBatch = batch
+				hj.probeState.prevBatchResumeIdx = i
+			} else {
+				// We're done probing the ith tuple.
+				if i+1 < batchSize {
+					// But we're not done probing the batch yet.
+					hj.probeState.prevBatch = batch
+					hj.probeState.prevBatchResumeIdx = i + 1
+				}
+			}
+			return nResults
+		}
+	}
+	return nResults
+}
+
+// This code snippet collects the "matches" for LEFT ANTI and EXCEPT ALL joins.
+// "Matches" are in quotes because we're actually interested in non-matches
+// from the left side.
+func collectLeftAnti_false(
+	hj *hashJoiner, batchSize int, nResults int, batch coldata.Batch, sel []int) int {
+	// Early bounds checks.
+	// Capture the slice in order for BCE to occur.
+	HeadIDs := hj.ht.ProbeScratch.HeadID
+	_ = HeadIDs[batchSize-1]
+	for i := 0; i < batchSize; i++ {
+		//gcassert:bce
+		currentID := HeadIDs[i]
+		if currentID == 0 {
+			{
+				var __retval_0 int
+				{
+					{
+						__retval_0 = i
+					}
+				}
+				// currentID of 0 indicates that ith probing row didn't have a match, so
+				// we include it into the output.
+				hj.probeState.probeIdx[nResults] = __retval_0
+			}
+			nResults++
+		}
+	}
+	return nResults
+}
+
+func collectProbeNoOuter_false(
+	hj *hashJoiner, batchSize int, nResults int, batch coldata.Batch, sel []int) int {
+	// Early bounds checks.
+	// Capture the slices in order for BCE to occur.
+	HeadIDs := hj.ht.ProbeScratch.HeadID
+	startIdx := hj.probeState.prevBatchResumeIdx
+	_ = HeadIDs[startIdx]
+	_ = HeadIDs[batchSize-1]
+	maxResults := len(hj.probeState.buildIdx)
+	probeIdx := hj.probeState.probeIdx
+	_ = probeIdx[nResults]
+	_ = probeIdx[maxResults-1]
+	for i := startIdx; i < batchSize; i++ {
+		//gcassert:bce
+		currentID := HeadIDs[i]
+		for ; currentID != 0 && nResults < maxResults; nResults++ {
+			// For some reason, BCE doesn't occur for buildIdx slice.
+			// TODO(yuzefovich): figure it out.
+			hj.probeState.buildIdx[nResults] = int(currentID - 1)
+			var pIdx int
+			{
+				var __retval_0 int
+				{
+					{
+						__retval_0 = i
+					}
+				}
+				pIdx = __retval_0
+			}
+			//gcassert:bce
+			probeIdx[nResults] = pIdx
+			currentID = hj.ht.Same[currentID]
+			//gcassert:bce
+			HeadIDs[i] = currentID
+		}
+
+		if nResults == maxResults {
+			// We have collected the maximum number of results that fit into the
+			// current output batch.
+			if currentID != 0 {
+				// We haven't finished probing the ith tuple of the current
+				// probing batch, so we'll need to resume from the same state.
+				hj.probeState.prevBatch = batch
+				hj.probeState.prevBatchResumeIdx = i
+			} else {
+				// We're done probing the ith tuple.
+				if i+1 < batchSize {
+					// But we're not done probing the batch yet.
+					hj.probeState.prevBatch = batch
+					hj.probeState.prevBatchResumeIdx = i + 1
+				}
+			}
+			return nResults
+		}
+	}
+	return nResults
+}
+
+func distinctCollectProbeOuter_true(hj *hashJoiner, batchSize int, sel []int) {
+	// Early bounds checks.
+	// Capture the slices in order for BCE to occur.
+	groupIDs := hj.ht.ProbeScratch.GroupID
+	probeRowUnmatched := hj.probeState.probeRowUnmatched
+	buildIdx := hj.probeState.buildIdx
+	probeIdx := hj.probeState.probeIdx
+	_ = groupIDs[batchSize-1]
+	_ = probeRowUnmatched[batchSize-1]
+	_ = buildIdx[batchSize-1]
+	_ = probeIdx[batchSize-1]
+	_ = sel[batchSize-1]
+	for i := 0; i < batchSize; i++ {
+		// Index of keys and outputs in the hash table is calculated as ID - 1.
+		//gcassert:bce
+		id := groupIDs[i]
+		rowUnmatched := id == 0
+		//gcassert:bce
+		probeRowUnmatched[i] = rowUnmatched
+		if rowUnmatched {
+			// The row is unmatched, and we set the corresponding buildIdx
+			// to zero so that (as long as the build hash table has at least
+			// one row) we can copy the values vector without paying
+			// attention to probeRowUnmatched.
+			//gcassert:bce
+			buildIdx[i] = 0
+		} else {
+			//gcassert:bce
+			buildIdx[i] = int(id - 1)
+		}
+		var pIdx int
+		{
+			var __retval_0 int
+			{
+				{
+					__retval_0 = sel[i]
+				}
+			}
+			pIdx = __retval_0
+		}
+		//gcassert:bce
+		probeIdx[i] = pIdx
+	}
+}
+
+func distinctCollectProbeOuter_false(hj *hashJoiner, batchSize int, sel []int) {
+	// Early bounds checks.
+	// Capture the slices in order for BCE to occur.
+	groupIDs := hj.ht.ProbeScratch.GroupID
+	probeRowUnmatched := hj.probeState.probeRowUnmatched
+	buildIdx := hj.probeState.buildIdx
+	probeIdx := hj.probeState.probeIdx
+	_ = groupIDs[batchSize-1]
+	_ = probeRowUnmatched[batchSize-1]
+	_ = buildIdx[batchSize-1]
+	_ = probeIdx[batchSize-1]
+	for i := 0; i < batchSize; i++ {
+		// Index of keys and outputs in the hash table is calculated as ID - 1.
+		//gcassert:bce
+		id := groupIDs[i]
+		rowUnmatched := id == 0
+		//gcassert:bce
+		probeRowUnmatched[i] = rowUnmatched
+		if rowUnmatched {
+			// The row is unmatched, and we set the corresponding buildIdx
+			// to zero so that (as long as the build hash table has at least
+			// one row) we can copy the values vector without paying
+			// attention to probeRowUnmatched.
+			//gcassert:bce
+			buildIdx[i] = 0
+		} else {
+			//gcassert:bce
+			buildIdx[i] = int(id - 1)
+		}
+		var pIdx int
+		{
+			var __retval_0 int
+			{
+				{
+					__retval_0 = i
+				}
+			}
+			pIdx = __retval_0
+		}
+		//gcassert:bce
+		probeIdx[i] = pIdx
+	}
+}
+
+func distinctCollectProbeNoOuter_true(
+	hj *hashJoiner, batchSize int, nResults int, sel []int) int {
+	// Early bounds checks.
+	// Capture the slice in order for BCE to occur.
+	groupIDs := hj.ht.ProbeScratch.GroupID
+	_ = groupIDs[batchSize-1]
+	_ = sel[batchSize-1]
+	for i := 0; i < batchSize; i++ {
+		//gcassert:bce
+		id := groupIDs[i]
+		if id != 0 {
+			// Index of keys and outputs in the hash table is calculated as ID - 1.
+			hj.probeState.buildIdx[nResults] = int(id - 1)
+			{
+				var __retval_0 int
+				{
+					{
+						__retval_0 = sel[i]
+					}
+				}
+				hj.probeState.probeIdx[nResults] = __retval_0
+			}
+			nResults++
+		}
+	}
+	return nResults
+}
+
+func distinctCollectProbeNoOuter_false(
+	hj *hashJoiner, batchSize int, nResults int, sel []int) int {
+	// Early bounds checks.
+	// Capture the slice in order for BCE to occur.
+	groupIDs := hj.ht.ProbeScratch.GroupID
+	_ = groupIDs[batchSize-1]
+	for i := 0; i < batchSize; i++ {
+		//gcassert:bce
+		id := groupIDs[i]
+		if id != 0 {
+			// Index of keys and outputs in the hash table is calculated as ID - 1.
+			hj.probeState.buildIdx[nResults] = int(id - 1)
+			{
+				var __retval_0 int
+				{
+					{
+						__retval_0 = i
+					}
+				}
+				hj.probeState.probeIdx[nResults] = __retval_0
+			}
+			nResults++
+		}
+	}
+	return nResults
+}
 
 // execgen:inline
 const _ = "inlined_getIdx_true"
+
+// execgen:inline
+const _ = "inlined_getIdx_false"

--- a/pkg/sql/colexec/execgen/cmd/execgen/vec_to_datum_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/vec_to_datum_gen.go
@@ -109,21 +109,11 @@ const vecToDatumTmpl = "pkg/sql/colconv/vec_to_datum_tmpl.go"
 
 func genVecToDatum(inputFileContents string, wr io.Writer) error {
 	r := strings.NewReplacer(
-		"_HAS_NULLS", "$.HasNulls",
-		"_HAS_SEL", "$.HasSel",
-		"_DESELECT", "$.Deselect",
 		"_TYPE_FAMILY", "{{.TypeFamily}}",
 		"_TYPE_WIDTH", typeWidthReplacement,
 		"_VEC_METHOD", "{{.VecMethod}}",
 	)
 	s := r.Replace(inputFileContents)
-
-	setDestIdx := makeFunctionRegex("_SET_DEST_IDX", 5)
-	s = setDestIdx.ReplaceAllString(s, `{{template "setDestIdx" buildDict "HasSel" $4 "Deselect" $5}}`)
-	setSrcIdx := makeFunctionRegex("_SET_SRC_IDX", 4)
-	s = setSrcIdx.ReplaceAllString(s, `{{template "setSrcIdx" buildDict "HasSel" $4}}`)
-	vecToDatum := makeFunctionRegex("_VEC_TO_DATUM", 8)
-	s = vecToDatum.ReplaceAllString(s, `{{template "vecToDatum" buildDict "Global" . "HasNulls" $6 "HasSel" $7 "Deselect" $8}}`)
 
 	assignConvertedRe := makeFunctionRegex("_ASSIGN_CONVERTED", 3)
 	s = assignConvertedRe.ReplaceAllString(s, makeTemplateFunctionCall("AssignConverted", 3))

--- a/pkg/sql/colexec/execgen/template.go
+++ b/pkg/sql/colexec/execgen/template.go
@@ -72,37 +72,47 @@ func replaceTemplateVars(
 // statements that use the template variables and output only the branches that
 // match.
 //
-// Currently, this only works on booleans :)
-//
 // For example, given the function:
 // // execgen:inline
-// // execgen:template<t>
-// func b(t bool) int {
+// // execgen:template<t, i>
+// func b(t bool, i int) int {
 //   if t {
 //     x = 3
 //   } else {
 //     x = 4
 //   }
+//   switch i {
+//     case 5: fmt.Println("5")
+//     case 6: fmt.Println("6")
+//   }
 //   return x
 // }
 //
 // and a caller
-//   b(true)
+//   b(true, 5)
 // this function will generate
 //   if true {
 //     x = 3
 //   } else {
 //     x = 4
 //   }
+//   switch 5 {
+//     case 5: fmt.Println("5")
+//     case 6: fmt.Println("6")
+//   }
 //   return x
 //
-// but because true is a constant, it will be reduced to
+// in its first pass. However, because the if's condition (true, in this case)
+// is a logical expression containing boolean literals, and the switch statement
+// is a switch on a template variable alone, a second pass "folds"
+// the conditionals and replaces them like so:
 //
-// x = 3
-// return x
+//   x = 3
+//   fmt.Println(5)
+//   return x
 //
 // Note that this method lexically replaces all formal parameters, so together
-// with createTemplateFuncVariants, it enables templates to call other templates
+// with createTemplateFuncVariant, it enables templates to call other templates
 // with template variables.
 func monomorphizeTemplate(n dst.Node, info *funcInfo, args []dst.Expr) dst.Node {
 	// Create map from formal param name to arg.
@@ -110,85 +120,170 @@ func monomorphizeTemplate(n dst.Node, info *funcInfo, args []dst.Expr) dst.Node 
 	for i, p := range info.templateParams {
 		paramMap[p.field.Names[0].Name] = args[i]
 	}
+	templateSwitches := make(map[*dst.SwitchStmt]struct{})
 	n = dstutil.Apply(n, func(cursor *dstutil.Cursor) bool {
 		// Replace all usages of the formal parameter with the template arg.
 		c := cursor.Node()
 		switch t := c.(type) {
 		case *dst.Ident:
 			if arg := paramMap[t.Name]; arg != nil {
+				p := cursor.Parent()
+				if s, ok := p.(*dst.SwitchStmt); ok {
+					if s.Tag.(*dst.Ident) == t {
+						// Write down the switch statements we see that are of the form:
+						// switch <templateParam> {
+						// ...
+						// }
+						// We'll replace these later.
+						templateSwitches[s] = struct{}{}
+					}
+				}
 				cursor.Replace(dst.Clone(arg))
 			}
 		}
 		return true
 	}, nil)
 
-	return foldConditionals(n, info, args)
+	return foldConditionals(n, info, templateSwitches)
 }
 
 // foldConditionals edits conditional statements to try to remove branches that
-// are statically falsifiable.
-func foldConditionals(n dst.Node, info *funcInfo, args []dst.Expr) dst.Node {
+// are statically falsifiable. It works with two cases:
+//
+// if <bool> { } else { } and if !<bool> { } else { }
+//
+// execgen:switch
+// switch <ident> {
+//   case <otherIdent>:
+//   case <ident>:
+//   ...
+// }
+func foldConditionals(
+	n dst.Node, info *funcInfo, templateSwitches map[*dst.SwitchStmt]struct{},
+) dst.Node {
 	return dstutil.Apply(n, func(cursor *dstutil.Cursor) bool {
 		n := cursor.Node()
 		switch n := n.(type) {
+		case *dst.SwitchStmt:
+			if _, ok := templateSwitches[n]; !ok {
+				// Not a template switch.
+				return true
+			}
+			t := prettyPrintExprs(n.Tag)
+			for _, item := range n.Body.List {
+				c := item.(*dst.CaseClause)
+				for _, e := range c.List {
+					if prettyPrintExprs(e) == t {
+						body := &dst.BlockStmt{List: c.Body}
+						newBody := foldConditionals(body, info, templateSwitches).(*dst.BlockStmt)
+						for _, stmt := range newBody.List {
+							cursor.InsertBefore(stmt)
+						}
+						cursor.Delete()
+						return true
+					}
+				}
+			}
 		case *dst.IfStmt:
-			switch c := n.Cond.(type) {
-			case *dst.Ident:
-				if c.Name == "true" {
-					newBody := foldConditionals(n.Body, info, args).(*dst.BlockStmt)
-					for _, stmt := range newBody.List {
+			ret, ok := tryEvalBool(n.Cond)
+			if !ok {
+				return true
+			}
+			// Since we're replacing the node, make sure we preserve any comments.
+			if len(n.Decs.NodeDecs.Start) > 0 {
+				cursor.InsertBefore(&dst.AssignStmt{
+					Tok: token.ASSIGN,
+					Lhs: []dst.Expr{dst.NewIdent("_")},
+					Rhs: []dst.Expr{
+						&dst.BasicLit{
+							Kind:  token.STRING,
+							Value: "true",
+						},
+					},
+					Decs: dst.AssignStmtDecorations{
+						NodeDecs: n.Decs.NodeDecs,
+					},
+				})
+			}
+			if ret {
+				// Replace with the if side.
+				newBody := foldConditionals(n.Body, info, templateSwitches).(*dst.BlockStmt)
+				for _, stmt := range newBody.List {
+					cursor.InsertBefore(stmt)
+				}
+				cursor.Delete()
+				return true
+			}
+			// Replace with the else side, if it exists.
+			if n.Else != nil {
+				newElse := foldConditionals(n.Else, info, templateSwitches)
+				switch e := newElse.(type) {
+				case *dst.BlockStmt:
+					for _, stmt := range e.List {
 						cursor.InsertBefore(stmt)
 					}
 					cursor.Delete()
-					return true
+				default:
+					cursor.Replace(newElse)
 				}
-				if c.Name == "false" {
-					if n.Else != nil {
-						newElse := foldConditionals(n.Else, info, args)
-						switch e := newElse.(type) {
-						case *dst.BlockStmt:
-							for _, stmt := range e.List {
-								cursor.InsertBefore(stmt)
-							}
-							cursor.Delete()
-						default:
-							cursor.Replace(newElse)
-						}
-					} else {
-						cursor.Delete()
-					}
-				}
+			} else {
+				cursor.Delete()
 			}
 		}
 		return true
 	}, nil)
 }
 
-// createTemplateFuncVariants, given an AST, finds all functions annotated with
-// execgen:template<foo,bar>, and produces all of the necessary variants for
-// every combination of possible values for the type of each template argument.
-//
-// For example, given a template function:
-//
-// // execgen:template<b>
-// func foo (a int, b bool) {
-//   if b {
-//     return a
-//   } else {
-//     return a + 1
-//   }
-// }
-//
-// This function will add 2 new func decls to the AST:
-//
-// func foo_true(a int) {
-//   return a
-// }
-//
-// func foo_false(a int) {
-//   return a + 1
-// }
-func createTemplateFuncVariants(f *dst.File) map[string]*funcInfo {
+// tryEvalBool attempts to statically evaluate the input expr as a logical
+// combination of boolean literals (like false || true). It returns the result
+// of the evaluation and whether or not the expression was actually evaluable
+// as such.
+func tryEvalBool(n dst.Expr) (ret bool, ok bool) {
+	switch n := n.(type) {
+	case *dst.UnaryExpr:
+		// !<expr>
+		if n.Op == token.NOT {
+			ret, ok = tryEvalBool(n.X)
+			ret = !ret
+			return ret, ok
+		}
+		return false, false
+	case *dst.BinaryExpr:
+		// expr && expr or expr || expr
+		if n.Op != token.LAND && n.Op != token.LOR {
+			return false, false
+		}
+		l, ok := tryEvalBool(n.X)
+		if !ok {
+			return false, false
+		}
+		r, ok := tryEvalBool(n.Y)
+		if !ok {
+			return false, false
+		}
+		switch n.Op {
+		case token.LAND:
+			return l && r, true
+		case token.LOR:
+			return l || r, true
+		default:
+			panic("unreachable")
+		}
+	case *dst.Ident:
+		switch n.Name {
+		case "true":
+			return true, true
+		case "false":
+			return false, true
+		}
+		return false, false
+	}
+	return false, false
+}
+
+// findTemplateFuncs, given an AST, finds all functions annotated with
+// execgen:template<foo,bar>, and returns a funcInfo for each of them.
+func findTemplateFuncs(f *dst.File) map[string]*funcInfo {
 	ret := make(map[string]*funcInfo)
 
 	dstutil.Apply(f, func(cursor *dstutil.Cursor) bool {
@@ -227,9 +322,6 @@ func createTemplateFuncVariants(f *dst.File) map[string]*funcInfo {
 					// one name, and we've already banned the case where they have more
 					// than one. (e.g. func a (a int, b int, c, d int))
 					if f.Names[0].Name == v {
-						if ident, ok := f.Type.(*dst.Ident); !ok || ident.Name != "bool" {
-							panic("can't currently handle non-boolean template variables :)")
-						}
 						info.templateParams = append(info.templateParams, templateParamInfo{
 							fieldOrdinal: i,
 							field:        dst.Clone(f).(*dst.Field),
@@ -242,8 +334,6 @@ func createTemplateFuncVariants(f *dst.File) map[string]*funcInfo {
 					panic(fmt.Errorf("template var %s not found", v))
 				}
 			}
-			info.decl = n
-
 			// Delete template params from runtime definition.
 			newParamList := make([]*dst.Field, 0, len(n.Type.Params.List)-len(info.templateParams))
 			for i, field := range n.Type.Params.List {
@@ -258,13 +348,7 @@ func createTemplateFuncVariants(f *dst.File) map[string]*funcInfo {
 					newParamList = append(newParamList, field)
 				}
 			}
-			n.Type.Params.List = newParamList
-
-			// Now, make variants for every possible combination of allowed values of
-			// the template variables.
-			argsPossibilities := generateAllTemplateArgs(info.templateParams)
-
-			funcDecs := info.decl.Decs
+			funcDecs := n.Decs
 			// Replace the template function with a const marker, just so we can keep
 			// the comments above the template function available.
 			cursor.InsertBefore(&dst.GenDecl{
@@ -284,39 +368,18 @@ func createTemplateFuncVariants(f *dst.File) map[string]*funcInfo {
 					NodeDecs: funcDecs.NodeDecs,
 				},
 			})
-
-			// Extract the remaining execgen directives.
-			directives := make([]string, 0)
-			for _, s := range funcDecs.Start {
-				if strings.HasPrefix(s, "// execgen") {
-					directives = append(directives, s)
-				}
-			}
-
-			for _, args := range argsPossibilities {
-				newBody := monomorphizeTemplate(dst.Clone(n.Body).(*dst.BlockStmt), info, args).(*dst.BlockStmt)
-				newName := getTemplateVariantName(info, args)
-				cursor.InsertAfter(&dst.FuncDecl{
-					Name: newName,
-					Type: dst.Clone(info.decl.Type).(*dst.FuncType),
-					Body: newBody,
-					Decs: dst.FuncDeclDecorations{
-						NodeDecs: dst.NodeDecs{
-							Before: dst.EmptyLine,
-							Start:  directives,
-						},
-					},
-				})
-			}
+			n.Type.Params.List = newParamList
+			info.decl = n
 			ret[info.decl.Name.Name] = info
 			cursor.Delete()
-			return false
 		}
-
 		return true
 	}, nil)
+
 	return ret
 }
+
+var nameMangler = strings.NewReplacer(".", "DOT", "*", "STAR")
 
 func getTemplateVariantName(info *funcInfo, args []dst.Expr) *dst.Ident {
 	var newName strings.Builder
@@ -325,63 +388,173 @@ func getTemplateVariantName(info *funcInfo, args []dst.Expr) *dst.Ident {
 		newName.WriteByte('_')
 		newName.WriteString(prettyPrintExprs(args[j]))
 	}
-	return dst.NewIdent(newName.String())
+	s := newName.String()
+	s = nameMangler.Replace(s)
+	return dst.NewIdent(s)
 }
 
-// generateAllTemplateArgs returns every possible combination of values for the
-// list of parameter types passed in.
-func generateAllTemplateArgs(paramInfos []templateParamInfo) [][]dst.Expr {
-	if len(paramInfos) == 0 {
-		return [][]dst.Expr{nil}
-	}
-	if ident, ok := paramInfos[0].field.Type.(*dst.Ident); !ok || ident.Name != "bool" {
-		panic("can't deal with non-boolean template arguments right now")
-	}
-
-	inner := generateAllTemplateArgs(paramInfos[:len(paramInfos)-1])
-
-	result := make([][]dst.Expr, 0)
-	for _, b := range []bool{true, false} {
-		for _, s := range inner {
-			// s here should be the list of possible arguments of the first n-1 types.
-			s = append(s[:], dst.NewIdent(fmt.Sprintf("%t", b)))
-			result = append(result, s)
-		}
-	}
-
-	return result
-}
-
-// replaceTemplateCallSites finds all CallExprs in the input AST that are calling
+// replaceAndExpandTemplates finds all CallExprs in the input AST that are calling
 // the functions that had been annotated with // execgen:template that are
-// passed in via the templateFuncInfos map.
-func replaceTemplateCallSites(f *dst.File, templateFuncInfos map[string]*funcInfo) dst.Node {
-	return dstutil.Apply(f, func(cursor *dstutil.Cursor) bool {
+// passed in via the templateFuncInfos map. It recursively replaces the
+// CallExprs with their expanded, mangled template function names, and creates
+// the requisite monomorphized FuncDecls on demand.
+//
+// For example, given a template function:
+//
+// // execgen:template<b>
+// func foo (a int, b bool) {
+//   if b {
+//     return a
+//   } else {
+//     return a + 1
+//   }
+// }
+//
+// And callsites:
+//
+// foo(a, true)
+// foo(a, false)
+//
+// This function will add 2 new func decls to the AST:
+//
+// func foo_true(a int) {
+//   return a
+// }
+//
+// func foo_false(a int) {
+//   return a + 1
+// }
+func replaceAndExpandTemplates(f *dst.File, templateFuncInfos map[string]*funcInfo) dst.Node {
+	// First, create the DAG of template functions. This DAG points from template
+	// function to any other template functions that are called from within its
+	// body that propagate template arguments.
+	// First, find all "roots": template CallExprs that only have concrete
+	// arguments.
+	var q []*dst.CallExpr
+	dstutil.Apply(f, func(cursor *dstutil.Cursor) bool {
 		n := cursor.Node()
 		switch n := n.(type) {
+		case *dst.FuncDecl:
+			q = append(q, findConcreteTemplateCallSites(n, templateFuncInfos)...)
+		}
+		return true
+	}, nil)
+
+	// For every remaining concrete call site, replace it with its mangled template
+	// function call, and generate the requisite monomorphized template function
+	// if we haven't already.
+	//
+	// Then, process the new monomorphized template function and add any newly
+	// created concrete template call sites to the queue. Do this until we have no
+	// more concrete template call sites.
+	seenCallsites := make(map[string]struct{})
+	for len(q) > 0 {
+		q = q[:0]
+		dstutil.Apply(f, func(cursor *dstutil.Cursor) bool {
+			n := cursor.Node()
+			switch n := n.(type) {
+			case *dst.CallExpr:
+				ident, ok := n.Fun.(*dst.Ident)
+				if !ok {
+					return true
+				}
+				info, ok := templateFuncInfos[ident.Name]
+				if !ok {
+					// Nothing to do, it's not a templated function.
+					return true
+				}
+				templateArgs, newCall := replaceTemplateVars(info, n)
+				name := getTemplateVariantName(info, templateArgs)
+				newCall.Fun = name
+				cursor.Replace(newCall)
+				// Have we already replaced this template function with these args?
+				funcInstance := name.Name + prettyPrintExprs(templateArgs...)
+				if _, ok := seenCallsites[funcInstance]; !ok {
+					seenCallsites[funcInstance] = struct{}{}
+					newFuncVariant := createTemplateFuncVariant(f, info, templateArgs)
+					q = append(q, findConcreteTemplateCallSites(newFuncVariant, templateFuncInfos)...)
+				}
+			}
+			return true
+		}, nil)
+	}
+	return nil
+}
+
+// findConcreteTemplateCallSites finds all CallExprs within the input funcDecl
+// that do not contain template arguments and thus can be immediately replaced.
+func findConcreteTemplateCallSites(
+	funcDecl *dst.FuncDecl, templateFuncInfos map[string]*funcInfo,
+) []*dst.CallExpr {
+	info, calledFromTemplate := templateFuncInfos[funcDecl.Name.Name]
+	var ret []*dst.CallExpr
+	dstutil.Apply(funcDecl, func(cursor *dstutil.Cursor) bool {
+		n := cursor.Node()
+		switch callExpr := n.(type) {
 		case *dst.CallExpr:
-			ident, ok := n.Fun.(*dst.Ident)
+			ident, ok := callExpr.Fun.(*dst.Ident)
 			if !ok {
 				return true
 			}
-			info, ok := templateFuncInfos[ident.Name]
+			_, ok = templateFuncInfos[ident.Name]
 			if !ok {
 				// Nothing to do, it's not a templated function.
 				return true
 			}
-			templateArgs, newCall := replaceTemplateVars(info, n)
-			newCall.Fun = getTemplateVariantName(info, templateArgs)
-			cursor.Replace(newCall)
-			return false
+			if !calledFromTemplate {
+				// All arguments are concrete since the callsite isn't within another
+				// templated function decl.
+				ret = append(ret, callExpr)
+				return true
+			}
+			for i := range callExpr.Args {
+				switch a := callExpr.Args[i].(type) {
+				case *dst.Ident:
+					for _, param := range info.templateParams {
+						if param.field.Names[0].Name == a.Name {
+							// Found a propagated template parameter, so we don't return
+							// this CallExpr (it's not concrete).
+							// NOTE: This is broken in the presence of shadowing.
+							// Let's assume nobody shadows template vars for now.
+							return true
+						}
+					}
+				}
+			}
+			ret = append(ret, callExpr)
 		}
 		return true
 	}, nil)
+	return ret
 }
 
 // expandTemplates is the main entry point to the templater. Given a dst.File,
 // it modifies the dst.File to include all expanded template functions, and
 // edits call sites to call the newly expanded functions.
 func expandTemplates(f *dst.File) {
-	funcInfos := createTemplateFuncVariants(f)
-	replaceTemplateCallSites(f, funcInfos)
+	funcInfos := findTemplateFuncs(f)
+	replaceAndExpandTemplates(f, funcInfos)
+}
+
+// createTemplateFuncVariant creates a variant of the input funcInfo given the
+// template arguments passed in args, and adds the variant to the end of the
+// input file.
+func createTemplateFuncVariant(f *dst.File, info *funcInfo, args []dst.Expr) *dst.FuncDecl {
+	n := info.decl
+	directives := n.Decs.NodeDecs.Start
+	newBody := monomorphizeTemplate(dst.Clone(n.Body).(*dst.BlockStmt), info, args).(*dst.BlockStmt)
+	newName := getTemplateVariantName(info, args)
+	ret := &dst.FuncDecl{
+		Name: newName,
+		Type: dst.Clone(info.decl.Type).(*dst.FuncType),
+		Body: newBody,
+		Decs: dst.FuncDeclDecorations{
+			NodeDecs: dst.NodeDecs{
+				Before: dst.EmptyLine,
+				Start:  directives,
+			},
+		},
+	}
+	f.Decls = append(f.Decls, ret)
+	return ret
 }

--- a/pkg/sql/colexec/execgen/template_test.go
+++ b/pkg/sql/colexec/execgen/template_test.go
@@ -11,31 +11,76 @@
 package execgen
 
 import (
+	"go/token"
 	"testing"
 
 	"github.com/dave/dst"
+	"github.com/stretchr/testify/assert"
 )
 
-func TestGenerateAllTemplateArgs(t *testing.T) {
-	params := make([]templateParamInfo, 3)
-	for i := range params {
-		params[i] = templateParamInfo{
-			field: &dst.Field{Type: dst.NewIdent("bool")},
-		}
+func TestTryEvalBools(t *testing.T) {
+	tcs := []struct {
+		expr     dst.Expr
+		expected bool
+		failed   bool
+	}{
+		{
+			expr:     &dst.Ident{Name: "true"},
+			expected: true,
+		},
+		{
+			expr:     &dst.Ident{Name: "false"},
+			expected: false,
+		},
+		{
+			expr:     &dst.UnaryExpr{Op: token.NOT, X: &dst.Ident{Name: "true"}},
+			expected: false,
+		},
+		{
+			expr:     &dst.UnaryExpr{Op: token.NOT, X: &dst.Ident{Name: "false"}},
+			expected: true,
+		},
+		{
+			expr:     &dst.BinaryExpr{Op: token.LAND, X: &dst.Ident{Name: "false"}, Y: &dst.Ident{Name: "false"}},
+			expected: false,
+		},
+		{
+			expr:     &dst.BinaryExpr{Op: token.LAND, X: &dst.Ident{Name: "true"}, Y: &dst.Ident{Name: "false"}},
+			expected: false,
+		},
+		{
+			expr:     &dst.BinaryExpr{Op: token.LAND, X: &dst.Ident{Name: "false"}, Y: &dst.Ident{Name: "true"}},
+			expected: false,
+		},
+		{
+			expr:     &dst.BinaryExpr{Op: token.LAND, X: &dst.Ident{Name: "true"}, Y: &dst.Ident{Name: "true"}},
+			expected: true,
+		},
+		{
+			expr:     &dst.BinaryExpr{Op: token.LOR, X: &dst.Ident{Name: "false"}, Y: &dst.Ident{Name: "false"}},
+			expected: false,
+		},
+		{
+			expr:     &dst.BinaryExpr{Op: token.LOR, X: &dst.Ident{Name: "true"}, Y: &dst.Ident{Name: "false"}},
+			expected: true,
+		},
+		{
+			expr:     &dst.BinaryExpr{Op: token.LOR, X: &dst.Ident{Name: "false"}, Y: &dst.Ident{Name: "true"}},
+			expected: true,
+		},
+		{
+			expr:     &dst.BinaryExpr{Op: token.LOR, X: &dst.Ident{Name: "true"}, Y: &dst.Ident{Name: "true"}},
+			expected: true,
+		},
+		{
+			expr:     &dst.BinaryExpr{Op: token.ADD, X: &dst.Ident{Name: "true"}, Y: &dst.Ident{Name: "true"}},
+			expected: false,
+			failed:   true,
+		},
 	}
-
-	res := generateAllTemplateArgs(params)
-
-	argsMap := map[string]struct{}{}
-	for _, args := range res {
-		argsStr := prettyPrintExprs(args...)
-		if _, ok := argsMap[argsStr]; ok {
-			t.Fatalf("duplicate template args %s", argsStr)
-		}
-		argsMap[argsStr] = struct{}{}
-	}
-
-	if len(res) != 8 {
-		t.Fatalf("wrong number of template arg set, expected 8, found %d", len(res))
+	for _, tc := range tcs {
+		actual, ok := tryEvalBool(tc.expr)
+		assert.NotEqual(t, ok, tc.failed, "unexpected value for ok")
+		assert.Equal(t, actual, tc.expected, "wrong result for expr", prettyPrintExprs(tc.expr))
 	}
 }

--- a/pkg/sql/colexec/execgen/testdata/template
+++ b/pkg/sql/colexec/execgen/testdata/template
@@ -27,13 +27,13 @@ func a() {
 
 const _ = "template_b"
 
-func b_false() int {
-	x = 4
+func b_true() int {
+	x = 3
 	return x
 }
 
-func b_true() int {
-	x = 3
+func b_false() int {
+	x = 4
 	return x
 }
 ----
@@ -79,9 +79,9 @@ func a() {
 const _ = "template_b"
 
 // execgen:inline
-func b_false_false(a int) int {
+func b_true_true(a int) int {
 	var x int
-	x = 4
+	x = 3
 	return x
 }
 
@@ -101,9 +101,9 @@ func b_false_true(a int) int {
 }
 
 // execgen:inline
-func b_true_true(a int) int {
+func b_false_false(a int) int {
 	var x int
-	x = 3
+	x = 4
 	return x
 }
 ----
@@ -156,10 +156,7 @@ func main() {
 const _ = "template_a"
 
 // execgen:inline
-func a_false(x int) {
-	b_false_true(x)
-	b_false_false(x)
-}
+const _ = "template_b"
 
 // execgen:inline
 func a_true(x int) {
@@ -168,11 +165,14 @@ func a_true(x int) {
 }
 
 // execgen:inline
-const _ = "template_b"
+func a_false(x int) {
+	b_false_true(x)
+	b_false_false(x)
+}
 
 // execgen:inline
-func b_false_false(x int) int {
-	fmt.Println("not y not z")
+func b_true_true(x int) int {
+	fmt.Println("y and z")
 }
 
 // execgen:inline
@@ -186,8 +186,8 @@ func b_false_true(x int) int {
 }
 
 // execgen:inline
-func b_true_true(x int) int {
-	fmt.Println("y and z")
+func b_false_false(x int) int {
+	fmt.Println("not y not z")
 }
 ----
 ----
@@ -238,8 +238,23 @@ func main() {
 const _ = "template_b"
 
 // execgen:inline
-func b_false_false(x int) int {
-	fmt.Println("not y not z")
+const _ = "template_a"
+
+// execgen:inline
+func a_true(x int) {
+	b_true_true(x)
+	b_true_false(x)
+}
+
+// execgen:inline
+func a_false(x int) {
+	b_false_true(x)
+	b_false_false(x)
+}
+
+// execgen:inline
+func b_true_true(x int) int {
+	fmt.Println("y and z")
 }
 
 // execgen:inline
@@ -253,23 +268,134 @@ func b_false_true(x int) int {
 }
 
 // execgen:inline
-func b_true_true(x int) int {
-	fmt.Println("y and z")
+func b_false_false(x int) int {
+	fmt.Println("not y not z")
+}
+----
+----
+
+# Test non-bool templates and execgen:switch
+template
+package main
+
+func main() {
+  a(1, blah.Foo)
+  a(1, *blah.Bar)
+  a(1, *blah.Bar)
+}
+
+// execgen:inline
+// execgen:template<y>
+func a(x int, y blah.Derp) {
+  // execgen:switch
+  switch y {
+  case blah.Foo:
+    fmt.Println("foo")
+    b(x, true, y)
+  case *blah.Bar:
+    fmt.Println("bar")
+    b(x, false, y)
+  }
+}
+
+// execgen:template<b, y>
+func b(x int, b bool, y blah.Derp) {
+  if !b {
+    switch y {
+      case blah.Foo:
+        fmt.Println("foo false")
+      case *blah.Bar:
+        fmt.Println("bar false")
+    }
+  } else {
+    switch y {
+      case blah.Foo:
+        fmt.Println("foo true")
+      case *blah.Bar:
+        fmt.Println("bar true")
+    }
+  }
+}
+----
+----
+package main
+
+func main() {
+	a_blahDOTFoo(1)
+	a_STARblahDOTBar(1)
+	a_STARblahDOTBar(1)
 }
 
 // execgen:inline
 const _ = "template_a"
 
+const _ = "template_b"
+
 // execgen:inline
-func a_false(x int) {
-	b_false_true(x)
-	b_false_false(x)
+func a_blahDOTFoo(x int) {
+	fmt.Println("foo")
+	b_true_blahDOTFoo(x)
 }
 
 // execgen:inline
-func a_true(x int) {
-	b_true_true(x)
-	b_true_false(x)
+func a_STARblahDOTBar(x int) {
+	fmt.Println("bar")
+	b_false_STARblahDOTBar(x)
+}
+
+func b_true_blahDOTFoo(x int) {
+	fmt.Println("foo true")
+}
+
+func b_false_STARblahDOTBar(x int) {
+	fmt.Println("bar false")
+}
+----
+----
+
+# Test an example type template
+template
+package main
+// execgen:template<family, width>
+func frobnicateColumn(col coldata.Vec, family types.Family, width int32) {
+   switch family {
+   case types.Int:
+     switch width {
+       case 32:
+         fmt.Println("i'm an int32!", col.Int32()[0])
+     }
+   case types.Interval, types.Interval2:
+     fmt.Println("I'm an interval!", col.Interval()[0])
+   }
+}
+
+func otherFunc(col coldata.Vec) {
+  frobnicateColumn(col, types.Int, 32)
+  frobnicateColumn(col, types.Interval, 0)
+  frobnicateColumn(col, types.Interval2, 0)
+}
+----
+----
+package main
+
+const _ = "template_frobnicateColumn"
+
+func otherFunc(col coldata.Vec) {
+	frobnicateColumn_typesDOTInt_32(col)
+	frobnicateColumn_typesDOTInterval_0(col)
+	frobnicateColumn_typesDOTInterval2_0(col)
+}
+
+func frobnicateColumn_typesDOTInt_32(col coldata.Vec) {
+	fmt.Println("i'm an int32!", col.Int32()[0])
+}
+
+func frobnicateColumn_typesDOTInterval_0(col coldata.Vec) {
+	fmt.Println("I'm an interval!", col.Interval()[0])
+}
+
+func frobnicateColumn_typesDOTInterval2_0(col coldata.Vec) {
+	fmt.Println("I'm an interval!", col.Interval()[0])
 }
 ----
 ----

--- a/pkg/sql/colexec/hash_aggregator.eg.go
+++ b/pkg/sql/colexec/hash_aggregator.eg.go
@@ -19,44 +19,40 @@ import "github.com/cockroachdb/cockroach/pkg/col/coldata"
 // zeroes and be of at least batchLength length.
 const _ = "template_populateEqChains"
 
-func populateEqChains_false(
-	op *hashAggregator, batchLength int, sel []int, headToEqChainsID []int) int {
-	eqChainsCount := 0
-	// Capture the slices in order for BCE to occur.
-	HeadIDs := op.ht.ProbeScratch.HeadID
-	hashBuffer := op.ht.ProbeScratch.HashBuffer
-	_ = HeadIDs[batchLength-1]
-	_ = hashBuffer[batchLength-1]
-	for i := 0; i < batchLength; i++ {
-		// Since we're essentially probing the batch against itself, HeadID
-		// cannot be 0, so we don't need to check that. What we have here is
-		// the tuple at position i belongs to the same equality chain as the
-		// tuple at position HeadID-1.
-		// We will use a similar to keyID encoding for eqChains slot - all
-		// tuples that should be included in eqChains[i] chain will have
-		// eqChainsID = i + 1. headToEqChainsID is a mapping from HeadID to
-		// eqChainsID that we're currently building in which eqChainsID
-		// indicates that the current tuple is the head of its equality chain.
-		//gcassert:bce
-		HeadID := HeadIDs[i]
-		if eqChainsID := headToEqChainsID[HeadID-1]; eqChainsID == 0 {
-			// This tuple is the head of the new equality chain, so we include
-			// it in updated selection vector. We also compact the hash buffer
-			// accordingly.
-			//gcassert:bce
-			h := hashBuffer[i]
-			hashBuffer[eqChainsCount] = h
-			sel[eqChainsCount] = i
-			op.scratch.eqChains[eqChainsCount] = append(op.scratch.eqChains[eqChainsCount], i)
-			eqChainsCount++
-			headToEqChainsID[HeadID-1] = eqChainsCount
-		} else {
-			op.scratch.eqChains[eqChainsID-1] = append(op.scratch.eqChains[eqChainsID-1], i)
-		}
+// populateEqChains populates op.scratch.eqChains with indices of tuples from b
+// that belong to the same groups. It returns the number of equality chains as
+// well as a selection vector that contains "heads" of each of the chains. The
+// method assumes that op.ht.ProbeScratch.HeadID has been populated with keyIDs
+// of all tuples.
+// NOTE: selection vector of b is modified to include only heads of each of the
+// equality chains.
+// NOTE: op.ht.ProbeScratch.HeadID and op.ht.ProbeScratch.differs are reset.
+func (op *hashAggregator) populateEqChains(
+	b coldata.Batch,
+) (eqChainsCount int, eqChainsHeadsSel []int) {
+	batchLength := b.Length()
+	if batchLength == 0 {
+		return
 	}
-	return eqChainsCount
+	HeadIDToEqChainsID := op.scratch.intSlice[:batchLength]
+	copy(HeadIDToEqChainsID, zeroIntColumn)
+	sel := b.Selection()
+	if sel != nil {
+		eqChainsCount = populateEqChains_true(op, batchLength, sel, HeadIDToEqChainsID)
+	} else {
+		b.SetSelection(true)
+		sel = b.Selection()
+		eqChainsCount = populateEqChains_false(op, batchLength, sel, HeadIDToEqChainsID)
+	}
+	return eqChainsCount, sel
 }
 
+// populateEqChains populates op.scratch.eqChains with indices of tuples from b
+// that belong to the same groups. It returns the number of equality chains.
+// Passed-in sel is updated to include tuples that are "heads" of the
+// corresponding equality chains and op.ht.ProbeScratch.HashBuffer is adjusted
+// accordingly. headToEqChainsID is a scratch space that must contain all
+// zeroes and be of at least batchLength length.
 func populateEqChains_true(
 	op *hashAggregator, batchLength int, sel []int, headToEqChainsID []int) int {
 	eqChainsCount := 0
@@ -92,6 +88,9 @@ func populateEqChains_true(
 			eqChainsCount++
 			headToEqChainsID[HeadID-1] = eqChainsCount
 		} else {
+			// This tuple is not the head of its equality chain, so we append
+			// it to already existing chain.
+			_ = true
 			//gcassert:bce
 			s := sel[i]
 			op.scratch.eqChains[eqChainsID-1] = append(op.scratch.eqChains[eqChainsID-1], s)
@@ -101,29 +100,48 @@ func populateEqChains_true(
 }
 
 // populateEqChains populates op.scratch.eqChains with indices of tuples from b
-// that belong to the same groups. It returns the number of equality chains as
-// well as a selection vector that contains "heads" of each of the chains. The
-// method assumes that op.ht.ProbeScratch.HeadID has been populated with keyIDs
-// of all tuples.
-// NOTE: selection vector of b is modified to include only heads of each of the
-// equality chains.
-// NOTE: op.ht.ProbeScratch.HeadID and op.ht.ProbeScratch.differs are reset.
-func (op *hashAggregator) populateEqChains(
-	b coldata.Batch,
-) (eqChainsCount int, eqChainsHeadsSel []int) {
-	batchLength := b.Length()
-	if batchLength == 0 {
-		return
+// that belong to the same groups. It returns the number of equality chains.
+// Passed-in sel is updated to include tuples that are "heads" of the
+// corresponding equality chains and op.ht.ProbeScratch.HashBuffer is adjusted
+// accordingly. headToEqChainsID is a scratch space that must contain all
+// zeroes and be of at least batchLength length.
+func populateEqChains_false(
+	op *hashAggregator, batchLength int, sel []int, headToEqChainsID []int) int {
+	eqChainsCount := 0
+	// Capture the slices in order for BCE to occur.
+	HeadIDs := op.ht.ProbeScratch.HeadID
+	hashBuffer := op.ht.ProbeScratch.HashBuffer
+	_ = HeadIDs[batchLength-1]
+	_ = hashBuffer[batchLength-1]
+	for i := 0; i < batchLength; i++ {
+		// Since we're essentially probing the batch against itself, HeadID
+		// cannot be 0, so we don't need to check that. What we have here is
+		// the tuple at position i belongs to the same equality chain as the
+		// tuple at position HeadID-1.
+		// We will use a similar to keyID encoding for eqChains slot - all
+		// tuples that should be included in eqChains[i] chain will have
+		// eqChainsID = i + 1. headToEqChainsID is a mapping from HeadID to
+		// eqChainsID that we're currently building in which eqChainsID
+		// indicates that the current tuple is the head of its equality chain.
+		//gcassert:bce
+		HeadID := HeadIDs[i]
+		if eqChainsID := headToEqChainsID[HeadID-1]; eqChainsID == 0 {
+			// This tuple is the head of the new equality chain, so we include
+			// it in updated selection vector. We also compact the hash buffer
+			// accordingly.
+			//gcassert:bce
+			h := hashBuffer[i]
+			hashBuffer[eqChainsCount] = h
+			sel[eqChainsCount] = i
+			op.scratch.eqChains[eqChainsCount] = append(op.scratch.eqChains[eqChainsCount], i)
+			eqChainsCount++
+			headToEqChainsID[HeadID-1] = eqChainsCount
+		} else {
+			// This tuple is not the head of its equality chain, so we append
+			// it to already existing chain.
+			_ = true
+			op.scratch.eqChains[eqChainsID-1] = append(op.scratch.eqChains[eqChainsID-1], i)
+		}
 	}
-	HeadIDToEqChainsID := op.scratch.intSlice[:batchLength]
-	copy(HeadIDToEqChainsID, zeroIntColumn)
-	sel := b.Selection()
-	if sel != nil {
-		eqChainsCount = populateEqChains_true(op, batchLength, sel, HeadIDToEqChainsID)
-	} else {
-		b.SetSelection(true)
-		sel = b.Selection()
-		eqChainsCount = populateEqChains_false(op, batchLength, sel, HeadIDToEqChainsID)
-	}
-	return eqChainsCount, sel
+	return eqChainsCount
 }


### PR DESCRIPTION
This commit adds several improvements to the template engine.

1. static boolean expressions in conditionals like `true || !false` are
   now automatically folded after template expansion, to make it easier
   to write template code based on the output of several conditionals.
2. switch statements on template parameters are now supported. They are
   evaluated lexically, making them suitable for switch statements based
   on enums or other comparable vars like types.Family.
3. execgen:template now supports non-boolean parameters.
4. template monomorphization is now performed by examining the actual
   callsites and generating the necessary template expansions on demand.

Hopefully, this paves the way to using the execgen:template directive to
program "actual" type-specific code, instead of just some of the boolean
simplification template functions we've been using thus far.

For example, we can now do the following:

```
// execgen:template<family, width>
func frobnicateColumn(col coldata.Vec, family types.Family, width int32) {
   switch family {
   case types.Int:
     switch width {
       case 32:
         fmt.Println("i'm an int32!", col.Int32()[0])
     }
   case types.Interval:
     fmt.Println("I'm an interval!", col.Interval()[0])
   }
}

func otherFunc(col coldata.Vec) {
  frobnicateColumn(col, types.Int, 32)
  frobnicateColumn(col, types.Interval, 0)
}
```

This will generate two variants of frobnicateColumn with their
conditionals removed, that look like this:

```
func frobnicateColumn_typesDOTInt_32(col coldata.Vec) {
  fmt.Println("I'm an int32!", col.Int32()[0])
}

func frobnicateColumn_typesDOTInterval_0(col coldata.Vec) {
  fmt.Println("I'm an interval!", col.Interval()[0])
}
```

---

colconv: convert VecToDatum to execgen:template 
... and simplify some of the custom template code as a result.
