### PR TITLE
jobs: limit number of jobs updated per query when canceling

### DIFF
--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -55,6 +56,15 @@ var (
 		"the amount of time to retain records for completed jobs before",
 		time.Hour*24*14,
 	).WithPublic()
+
+	// CancellationsUpdateLimitSetting the number of jobs can be updated when canceling jobs
+	// concurrently from dead sessions.
+	CancellationsUpdateLimitSetting = settings.RegisterIntSetting(
+		"jobs.cancel_update_limit",
+		"the number of jobs can be updated when canceling jobs concurrently from dead sessions",
+		1000,
+		settings.NonNegativeInt,
+	)
 )
 
 // adoptedJobs represents a the epoch and cancelation of a job id being run
@@ -672,9 +682,12 @@ func (r *Registry) Start(
 				sessiondata.InternalExecutorOverride{User: security.RootUserName()}, `
 UPDATE system.jobs
    SET claim_session_id = NULL
+WHERE claim_session_id in (
+SELECT claim_session_id
  WHERE claim_session_id <> $1
    AND status IN `+claimableStatusTupleString+`
-   AND NOT crdb_internal.sql_liveness_is_alive(claim_session_id)`,
+   AND NOT crdb_internal.sql_liveness_is_alive(claim_session_id) FETCH 
+	 FIRST `+strconv.Itoa(int(CancellationsUpdateLimitSetting.Get(&r.settings.SV)))+` ROWS ONLY)`,
 				s.ID().UnsafeBytes(),
 			)
 			return err

--- a/pkg/jobs/registry_external_test.go
+++ b/pkg/jobs/registry_external_test.go
@@ -356,6 +356,8 @@ func TestExpiringSessionsAndClaimJobsDoesNotTouchTerminalJobs(t *testing.T) {
    VALUES ($1, $2, $3, $4, $5)
 RETURNING id;
 `
+	// Disallow clean up of claimed jobs
+	jobs.CancellationsUpdateLimitSetting.Override(ctx, &s.ClusterSettings().SV, 0)
 	terminalStatuses := []jobs.Status{jobs.StatusSucceeded, jobs.StatusCanceled, jobs.StatusFailed}
 	terminalIDs := make([]jobspb.JobID, len(terminalStatuses))
 	terminalClaims := make([][]byte, len(terminalStatuses))
@@ -377,6 +379,21 @@ RETURNING id;
 		}
 		return nil
 	}
+
+	getClaimCount := func(id jobspb.JobID) int {
+		const getClaimQuery = `SELECT count(claim_session_id) FROM system.jobs WHERE id = $1`
+		count := 0
+		tdb.QueryRow(t, getClaimQuery, id).Scan(&count)
+		return count
+	}
+	// Validate the claims were not cleaned up.
+	claimCount := getClaimCount(nonTerminalID)
+	if claimCount == 0 {
+		require.FailNowf(t, "unexpected claim sessions",
+			"claim session ID's were removed some how %d", claimCount)
+	}
+	// Allow clean up of claimed jobs
+	jobs.CancellationsUpdateLimitSetting.Override(ctx, &s.ClusterSettings().SV, 1000)
 	testutils.SucceedsSoon(t, func() error {
 		return checkClaimEqual(nonTerminalID, nil)
 	})


### PR DESCRIPTION
Previously, when jobs were updated during query cancellation
we would attempt to update all of the jobs at once. This was
inadequate because the query could touch a large number of jobs
and in a global cluster this could lead to locks being held for
a long time. To address this, this patch adds configurable limit
to only update a subset of jobs at a time.

Release note: None