### PR TITLE
kvserver: skip TestReplicateQueueDecommissioningNonVoters under race

### DIFF
--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -402,6 +402,7 @@ func checkReplicaCount(
 func TestReplicateQueueDecommissioningNonVoters(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.UnderRace(t, "takes a long time or times out under race")
 
 	ctx := context.Background()
 
@@ -511,8 +512,8 @@ func TestReplicateQueueDecommissioningNonVoters(t *testing.T) {
 // non-voting replicas on dead nodes are replaced or removed.
 func TestReplicateQueueDeadNonVoters(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.UnderRaceWithIssue(t, 65932, "flaky test")
 	defer log.Scope(t).Close(t)
+	skip.UnderRace(t, "takes a long time or times out under race")
 
 	ctx := context.Background()
 
@@ -656,8 +657,8 @@ func getNonVoterNodeIDs(rangeDesc roachpb.RangeDescriptor) (result []roachpb.Nod
 // from voter to non-voter.
 func TestReplicateQueueSwapVotersWithNonVoters(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.UnderRaceWithIssue(t, 65932, "flaky test")
 	defer log.Scope(t).Close(t)
+	skip.UnderRace(t, "takes a long time or times out under race")
 
 	ctx := context.Background()
 	serverArgs := make(map[int]base.TestServerArgs)


### PR DESCRIPTION
These tests frequently time out under race when our CI machines are too pegged.
See discussion on the linked issue.

Closes #65932

Release note: None