### PR TITLE
roachtest: skip initBulkJobPerfArtifacts

### DIFF
--- a/pkg/cmd/roachtest/backup.go
+++ b/pkg/cmd/roachtest/backup.go
@@ -144,6 +144,10 @@ func registerBackupNodeShutdown(r *testRegistry) {
 // initBulkJobPerfArtifacts registers a histogram, creates a performance
 // artifact directory and returns a method that when invoked records a tick.
 func initBulkJobPerfArtifacts(ctx context.Context, testName string, timeout time.Duration) func() {
+	// TODO(tbg,aditya): this is temporarily skipped, figure out a fix. See:
+	// https://cockroachlabs.slack.com/archives/CJ0H8Q97C/p1623776034188400
+	return func() {}
+
 	// Register a named histogram to track the total time the bulk job took.
 	// Roachperf uses this information to display information about this
 	// roachtest.


### PR DESCRIPTION
When we added prometheus histograms we did not realize that this method would
register a histogram containing special characters. This would break the
roachtest run; it hasn't been running for a few days.

This is a hotfix to get it back on its feet. Real fix is tracked in:
https://github.com/cockroachdb/cockroach/issues/66491

cc @cockroachdb/test-eng @cockroachdb/bulk-io

Release note: None
