### PR TITLE
sqlproxyccl: rename endpoint to pod and IP to addr

### DIFF
--- a/pkg/ccl/sqlproxyccl/proxy_handler.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler.go
@@ -394,13 +394,13 @@ func (handler *proxyHandler) handle(ctx context.Context, incomingConn *proxyConn
 }
 
 // outgoingAddress resolves a tenant ID and a tenant cluster name to the address
-// of a backend endpoint.
+// of a backend pod.
 func (handler *proxyHandler) outgoingAddress(
 	ctx context.Context, name string, tenID roachpb.TenantID,
 ) (string, error) {
 	// First try to lookup tenant in the directory (if available).
 	if handler.directory != nil {
-		addr, err := handler.directory.EnsureTenantIP(ctx, tenID, name)
+		addr, err := handler.directory.EnsureTenantAddr(ctx, tenID, name)
 		if err != nil {
 			if status.Code(err) != codes.NotFound {
 				return "", err
@@ -473,7 +473,7 @@ func (handler *proxyHandler) validateAccess(
 	return nil
 }
 
-// incomingTLSConfig gets back the current TLS config for the incoiming client
+// incomingTLSConfig gets back the current TLS config for the incoming client
 // connection endpoint.
 func (handler *proxyHandler) incomingTLSConfig() *tls.Config {
 	if handler.incomingCert == nil {
@@ -526,9 +526,9 @@ func (handler *proxyHandler) setupIncomingCert() error {
 // reportFailureToDirectory is a hookable function that calls the given tenant
 // directory's ReportFailure method.
 var reportFailureToDirectory = func(
-	ctx context.Context, tenantID roachpb.TenantID, ip string, directory *tenant.Directory,
+	ctx context.Context, tenantID roachpb.TenantID, addr string, directory *tenant.Directory,
 ) error {
-	return directory.ReportFailure(ctx, tenantID, ip)
+	return directory.ReportFailure(ctx, tenantID, addr)
 }
 
 // clusterNameAndTenantFromParams extracts the cluster name from the connection

--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -605,16 +605,16 @@ func TestDirectoryConnect(t *testing.T) {
 		// Ensure that Directory.ReportFailure is being called correctly.
 		countReports := 0
 		defer testutils.TestingHook(&reportFailureToDirectory, func(
-			ctx context.Context, tenantID roachpb.TenantID, ip string, directory *tenant.Directory,
+			ctx context.Context, tenantID roachpb.TenantID, addr string, directory *tenant.Directory,
 		) error {
 			require.Equal(t, roachpb.MakeTenantID(28), tenantID)
-			addrs, err := directory.LookupTenantIPs(ctx, tenantID)
+			addrs, err := directory.LookupTenantAddrs(ctx, tenantID)
 			require.NoError(t, err)
 			require.Len(t, addrs, 1)
-			require.Equal(t, addrs[0], ip)
+			require.Equal(t, addrs[0], addr)
 
 			countReports++
-			err = directory.ReportFailure(ctx, tenantID, ip)
+			err = directory.ReportFailure(ctx, tenantID, addr)
 			require.NoError(t, err)
 			return err
 		})()

--- a/pkg/ccl/sqlproxyccl/tenant/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/tenant/BUILD.bazel
@@ -50,7 +50,7 @@ gomock(
     out = "mocks_generated.go",
     interfaces = [
         "DirectoryClient",
-        "Directory_WatchEndpointsClient",
+        "Directory_WatchPodsClient",
     ],
     library = ":tenant_go_proto",
     package = "tenant",

--- a/pkg/ccl/sqlproxyccl/tenant/directory.pb.go
+++ b/pkg/ccl/sqlproxyccl/tenant/directory.pb.go
@@ -57,20 +57,20 @@ func (EventType) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_ec8b5028e8f2b222, []int{0}
 }
 
-// WatchEndpointsRequest is empty as we want to get all notifications.
-type WatchEndpointsRequest struct {
+// WatchPodsRequest is empty as we want to get all notifications.
+type WatchPodsRequest struct {
 }
 
-func (m *WatchEndpointsRequest) Reset()         { *m = WatchEndpointsRequest{} }
-func (m *WatchEndpointsRequest) String() string { return proto.CompactTextString(m) }
-func (*WatchEndpointsRequest) ProtoMessage()    {}
-func (*WatchEndpointsRequest) Descriptor() ([]byte, []int) {
+func (m *WatchPodsRequest) Reset()         { *m = WatchPodsRequest{} }
+func (m *WatchPodsRequest) String() string { return proto.CompactTextString(m) }
+func (*WatchPodsRequest) ProtoMessage()    {}
+func (*WatchPodsRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_ec8b5028e8f2b222, []int{0}
 }
-func (m *WatchEndpointsRequest) XXX_Unmarshal(b []byte) error {
+func (m *WatchPodsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *WatchEndpointsRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *WatchPodsRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	b = b[:cap(b)]
 	n, err := m.MarshalToSizedBuffer(b)
 	if err != nil {
@@ -78,39 +78,39 @@ func (m *WatchEndpointsRequest) XXX_Marshal(b []byte, deterministic bool) ([]byt
 	}
 	return b[:n], nil
 }
-func (m *WatchEndpointsRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_WatchEndpointsRequest.Merge(m, src)
+func (m *WatchPodsRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_WatchPodsRequest.Merge(m, src)
 }
-func (m *WatchEndpointsRequest) XXX_Size() int {
+func (m *WatchPodsRequest) XXX_Size() int {
 	return m.Size()
 }
-func (m *WatchEndpointsRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_WatchEndpointsRequest.DiscardUnknown(m)
+func (m *WatchPodsRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_WatchPodsRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_WatchEndpointsRequest proto.InternalMessageInfo
+var xxx_messageInfo_WatchPodsRequest proto.InternalMessageInfo
 
-// WatchEndpointsResponse represents the notifications that the server sends to
+// WatchPodsResponse represents the notifications that the server sends to
 // its clients when clients want to monitor the directory server activity.
-type WatchEndpointsResponse struct {
+type WatchPodsResponse struct {
 	// EventType is the type of the notifications - added, modified, deleted.
 	Typ EventType `protobuf:"varint,1,opt,name=typ,proto3,enum=cockroach.ccl.sqlproxyccl.tenant.EventType" json:"typ,omitempty"`
-	// IP is the endpoint that this notification applies to.
-	IP string `protobuf:"bytes,2,opt,name=ip,proto3" json:"ip,omitempty"`
-	// TenantID is the tenant that owns the endpoint.
+	// Addr is the address of the pod that this notification applies to.
+	Addr string `protobuf:"bytes,2,opt,name=addr,proto3" json:"addr,omitempty"`
+	// TenantID is the tenant that owns the pod.
 	TenantID uint64 `protobuf:"varint,3,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
 }
 
-func (m *WatchEndpointsResponse) Reset()         { *m = WatchEndpointsResponse{} }
-func (m *WatchEndpointsResponse) String() string { return proto.CompactTextString(m) }
-func (*WatchEndpointsResponse) ProtoMessage()    {}
-func (*WatchEndpointsResponse) Descriptor() ([]byte, []int) {
+func (m *WatchPodsResponse) Reset()         { *m = WatchPodsResponse{} }
+func (m *WatchPodsResponse) String() string { return proto.CompactTextString(m) }
+func (*WatchPodsResponse) ProtoMessage()    {}
+func (*WatchPodsResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_ec8b5028e8f2b222, []int{1}
 }
-func (m *WatchEndpointsResponse) XXX_Unmarshal(b []byte) error {
+func (m *WatchPodsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *WatchEndpointsResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *WatchPodsResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	b = b[:cap(b)]
 	n, err := m.MarshalToSizedBuffer(b)
 	if err != nil {
@@ -118,36 +118,36 @@ func (m *WatchEndpointsResponse) XXX_Marshal(b []byte, deterministic bool) ([]by
 	}
 	return b[:n], nil
 }
-func (m *WatchEndpointsResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_WatchEndpointsResponse.Merge(m, src)
+func (m *WatchPodsResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_WatchPodsResponse.Merge(m, src)
 }
-func (m *WatchEndpointsResponse) XXX_Size() int {
+func (m *WatchPodsResponse) XXX_Size() int {
 	return m.Size()
 }
-func (m *WatchEndpointsResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_WatchEndpointsResponse.DiscardUnknown(m)
+func (m *WatchPodsResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_WatchPodsResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_WatchEndpointsResponse proto.InternalMessageInfo
+var xxx_messageInfo_WatchPodsResponse proto.InternalMessageInfo
 
-// ListEndpointsRequest is used to query the server for the list of current
-// endpoints of a given tenant.
-type ListEndpointsRequest struct {
+// ListPodsRequest is used to query the server for the list of current
+// pods of a given tenant.
+type ListPodsRequest struct {
 	// TenantID identifies the tenant for which the client is requesting a list of
-	// the endpoints.
+	// the pods.
 	TenantID uint64 `protobuf:"varint,1,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
 }
 
-func (m *ListEndpointsRequest) Reset()         { *m = ListEndpointsRequest{} }
-func (m *ListEndpointsRequest) String() string { return proto.CompactTextString(m) }
-func (*ListEndpointsRequest) ProtoMessage()    {}
-func (*ListEndpointsRequest) Descriptor() ([]byte, []int) {
+func (m *ListPodsRequest) Reset()         { *m = ListPodsRequest{} }
+func (m *ListPodsRequest) String() string { return proto.CompactTextString(m) }
+func (*ListPodsRequest) ProtoMessage()    {}
+func (*ListPodsRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_ec8b5028e8f2b222, []int{2}
 }
-func (m *ListEndpointsRequest) XXX_Unmarshal(b []byte) error {
+func (m *ListPodsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *ListEndpointsRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *ListPodsRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	b = b[:cap(b)]
 	n, err := m.MarshalToSizedBuffer(b)
 	if err != nil {
@@ -155,36 +155,36 @@ func (m *ListEndpointsRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte
 	}
 	return b[:n], nil
 }
-func (m *ListEndpointsRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ListEndpointsRequest.Merge(m, src)
+func (m *ListPodsRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ListPodsRequest.Merge(m, src)
 }
-func (m *ListEndpointsRequest) XXX_Size() int {
+func (m *ListPodsRequest) XXX_Size() int {
 	return m.Size()
 }
-func (m *ListEndpointsRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_ListEndpointsRequest.DiscardUnknown(m)
+func (m *ListPodsRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_ListPodsRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_ListEndpointsRequest proto.InternalMessageInfo
+var xxx_messageInfo_ListPodsRequest proto.InternalMessageInfo
 
-// EnsureEndpointRequest is used to ensure that a tenant's backend is active. If
+// EnsurePodRequest is used to ensure that a tenant's backend is active. If
 // there is an active backend then the server doesn't have to do anything. If
 // there isn't an active backend, then the server has to bring a new one up.
-type EnsureEndpointRequest struct {
+type EnsurePodRequest struct {
 	// TenantID is the id of the tenant for which an active backend is requested.
 	TenantID uint64 `protobuf:"varint,1,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
 }
 
-func (m *EnsureEndpointRequest) Reset()         { *m = EnsureEndpointRequest{} }
-func (m *EnsureEndpointRequest) String() string { return proto.CompactTextString(m) }
-func (*EnsureEndpointRequest) ProtoMessage()    {}
-func (*EnsureEndpointRequest) Descriptor() ([]byte, []int) {
+func (m *EnsurePodRequest) Reset()         { *m = EnsurePodRequest{} }
+func (m *EnsurePodRequest) String() string { return proto.CompactTextString(m) }
+func (*EnsurePodRequest) ProtoMessage()    {}
+func (*EnsurePodRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_ec8b5028e8f2b222, []int{3}
 }
-func (m *EnsureEndpointRequest) XXX_Unmarshal(b []byte) error {
+func (m *EnsurePodRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *EnsureEndpointRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *EnsurePodRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	b = b[:cap(b)]
 	n, err := m.MarshalToSizedBuffer(b)
 	if err != nil {
@@ -192,33 +192,33 @@ func (m *EnsureEndpointRequest) XXX_Marshal(b []byte, deterministic bool) ([]byt
 	}
 	return b[:n], nil
 }
-func (m *EnsureEndpointRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_EnsureEndpointRequest.Merge(m, src)
+func (m *EnsurePodRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_EnsurePodRequest.Merge(m, src)
 }
-func (m *EnsureEndpointRequest) XXX_Size() int {
+func (m *EnsurePodRequest) XXX_Size() int {
 	return m.Size()
 }
-func (m *EnsureEndpointRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_EnsureEndpointRequest.DiscardUnknown(m)
+func (m *EnsurePodRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_EnsurePodRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_EnsureEndpointRequest proto.InternalMessageInfo
+var xxx_messageInfo_EnsurePodRequest proto.InternalMessageInfo
 
-// EnsureEndpointResponse is empty and indicates that the server processed the
+// EnsurePodResponse is empty and indicates that the server processed the
 // request.
-type EnsureEndpointResponse struct {
+type EnsurePodResponse struct {
 }
 
-func (m *EnsureEndpointResponse) Reset()         { *m = EnsureEndpointResponse{} }
-func (m *EnsureEndpointResponse) String() string { return proto.CompactTextString(m) }
-func (*EnsureEndpointResponse) ProtoMessage()    {}
-func (*EnsureEndpointResponse) Descriptor() ([]byte, []int) {
+func (m *EnsurePodResponse) Reset()         { *m = EnsurePodResponse{} }
+func (m *EnsurePodResponse) String() string { return proto.CompactTextString(m) }
+func (*EnsurePodResponse) ProtoMessage()    {}
+func (*EnsurePodResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_ec8b5028e8f2b222, []int{4}
 }
-func (m *EnsureEndpointResponse) XXX_Unmarshal(b []byte) error {
+func (m *EnsurePodResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *EnsureEndpointResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *EnsurePodResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	b = b[:cap(b)]
 	n, err := m.MarshalToSizedBuffer(b)
 	if err != nil {
@@ -226,35 +226,35 @@ func (m *EnsureEndpointResponse) XXX_Marshal(b []byte, deterministic bool) ([]by
 	}
 	return b[:n], nil
 }
-func (m *EnsureEndpointResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_EnsureEndpointResponse.Merge(m, src)
+func (m *EnsurePodResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_EnsurePodResponse.Merge(m, src)
 }
-func (m *EnsureEndpointResponse) XXX_Size() int {
+func (m *EnsurePodResponse) XXX_Size() int {
 	return m.Size()
 }
-func (m *EnsureEndpointResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_EnsureEndpointResponse.DiscardUnknown(m)
+func (m *EnsurePodResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_EnsurePodResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_EnsureEndpointResponse proto.InternalMessageInfo
+var xxx_messageInfo_EnsurePodResponse proto.InternalMessageInfo
 
-// Endpoint contains the information about a tenant endpoint. Most often it is a
+// Pod contains the information about a tenant pod. Most often it is a
 // combination of an ip address and port, e.g. 132.130.1.11:34576.
-type Endpoint struct {
-	// IP is the ip and port combo identifying the tenant endpoint.
-	IP string `protobuf:"bytes,1,opt,name=IP,proto3" json:"IP,omitempty"`
+type Pod struct {
+	// Addr is the ip and port combo identifying the tenant pod.
+	Addr string `protobuf:"bytes,1,opt,name=Addr,proto3" json:"Addr,omitempty"`
 }
 
-func (m *Endpoint) Reset()         { *m = Endpoint{} }
-func (m *Endpoint) String() string { return proto.CompactTextString(m) }
-func (*Endpoint) ProtoMessage()    {}
-func (*Endpoint) Descriptor() ([]byte, []int) {
+func (m *Pod) Reset()         { *m = Pod{} }
+func (m *Pod) String() string { return proto.CompactTextString(m) }
+func (*Pod) ProtoMessage()    {}
+func (*Pod) Descriptor() ([]byte, []int) {
 	return fileDescriptor_ec8b5028e8f2b222, []int{5}
 }
-func (m *Endpoint) XXX_Unmarshal(b []byte) error {
+func (m *Pod) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *Endpoint) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *Pod) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	b = b[:cap(b)]
 	n, err := m.MarshalToSizedBuffer(b)
 	if err != nil {
@@ -262,36 +262,36 @@ func (m *Endpoint) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	}
 	return b[:n], nil
 }
-func (m *Endpoint) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Endpoint.Merge(m, src)
+func (m *Pod) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Pod.Merge(m, src)
 }
-func (m *Endpoint) XXX_Size() int {
+func (m *Pod) XXX_Size() int {
 	return m.Size()
 }
-func (m *Endpoint) XXX_DiscardUnknown() {
-	xxx_messageInfo_Endpoint.DiscardUnknown(m)
+func (m *Pod) XXX_DiscardUnknown() {
+	xxx_messageInfo_Pod.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_Endpoint proto.InternalMessageInfo
+var xxx_messageInfo_Pod proto.InternalMessageInfo
 
-// ListEndpointsResponse is sent back as a result of requesting the list of
-// endpoints for a given tenant.
-type ListEndpointsResponse struct {
-	// Endpoints is the list of endpoints currently active for the requested
+// ListPodsResponse is sent back as a result of requesting the list of
+// pods for a given tenant.
+type ListPodsResponse struct {
+	// Pods is the list of pods currently active for the requested
 	// tenant.
-	Endpoints []*Endpoint `protobuf:"bytes,1,rep,name=endpoints,proto3" json:"endpoints,omitempty"`
+	Pods []*Pod `protobuf:"bytes,1,rep,name=pods,proto3" json:"pods,omitempty"`
 }
 
-func (m *ListEndpointsResponse) Reset()         { *m = ListEndpointsResponse{} }
-func (m *ListEndpointsResponse) String() string { return proto.CompactTextString(m) }
-func (*ListEndpointsResponse) ProtoMessage()    {}
-func (*ListEndpointsResponse) Descriptor() ([]byte, []int) {
+func (m *ListPodsResponse) Reset()         { *m = ListPodsResponse{} }
+func (m *ListPodsResponse) String() string { return proto.CompactTextString(m) }
+func (*ListPodsResponse) ProtoMessage()    {}
+func (*ListPodsResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_ec8b5028e8f2b222, []int{6}
 }
-func (m *ListEndpointsResponse) XXX_Unmarshal(b []byte) error {
+func (m *ListPodsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *ListEndpointsResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *ListPodsResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	b = b[:cap(b)]
 	n, err := m.MarshalToSizedBuffer(b)
 	if err != nil {
@@ -299,17 +299,17 @@ func (m *ListEndpointsResponse) XXX_Marshal(b []byte, deterministic bool) ([]byt
 	}
 	return b[:n], nil
 }
-func (m *ListEndpointsResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ListEndpointsResponse.Merge(m, src)
+func (m *ListPodsResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ListPodsResponse.Merge(m, src)
 }
-func (m *ListEndpointsResponse) XXX_Size() int {
+func (m *ListPodsResponse) XXX_Size() int {
 	return m.Size()
 }
-func (m *ListEndpointsResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_ListEndpointsResponse.DiscardUnknown(m)
+func (m *ListPodsResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_ListPodsResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_ListEndpointsResponse proto.InternalMessageInfo
+var xxx_messageInfo_ListPodsResponse proto.InternalMessageInfo
 
 // GetTenantRequest is used by a client to request from the sever metadata
 // related to a given tenant.
@@ -384,13 +384,13 @@ var xxx_messageInfo_GetTenantResponse proto.InternalMessageInfo
 
 func init() {
 	proto.RegisterEnum("cockroach.ccl.sqlproxyccl.tenant.EventType", EventType_name, EventType_value)
-	proto.RegisterType((*WatchEndpointsRequest)(nil), "cockroach.ccl.sqlproxyccl.tenant.WatchEndpointsRequest")
-	proto.RegisterType((*WatchEndpointsResponse)(nil), "cockroach.ccl.sqlproxyccl.tenant.WatchEndpointsResponse")
-	proto.RegisterType((*ListEndpointsRequest)(nil), "cockroach.ccl.sqlproxyccl.tenant.ListEndpointsRequest")
-	proto.RegisterType((*EnsureEndpointRequest)(nil), "cockroach.ccl.sqlproxyccl.tenant.EnsureEndpointRequest")
-	proto.RegisterType((*EnsureEndpointResponse)(nil), "cockroach.ccl.sqlproxyccl.tenant.EnsureEndpointResponse")
-	proto.RegisterType((*Endpoint)(nil), "cockroach.ccl.sqlproxyccl.tenant.Endpoint")
-	proto.RegisterType((*ListEndpointsResponse)(nil), "cockroach.ccl.sqlproxyccl.tenant.ListEndpointsResponse")
+	proto.RegisterType((*WatchPodsRequest)(nil), "cockroach.ccl.sqlproxyccl.tenant.WatchPodsRequest")
+	proto.RegisterType((*WatchPodsResponse)(nil), "cockroach.ccl.sqlproxyccl.tenant.WatchPodsResponse")
+	proto.RegisterType((*ListPodsRequest)(nil), "cockroach.ccl.sqlproxyccl.tenant.ListPodsRequest")
+	proto.RegisterType((*EnsurePodRequest)(nil), "cockroach.ccl.sqlproxyccl.tenant.EnsurePodRequest")
+	proto.RegisterType((*EnsurePodResponse)(nil), "cockroach.ccl.sqlproxyccl.tenant.EnsurePodResponse")
+	proto.RegisterType((*Pod)(nil), "cockroach.ccl.sqlproxyccl.tenant.Pod")
+	proto.RegisterType((*ListPodsResponse)(nil), "cockroach.ccl.sqlproxyccl.tenant.ListPodsResponse")
 	proto.RegisterType((*GetTenantRequest)(nil), "cockroach.ccl.sqlproxyccl.tenant.GetTenantRequest")
 	proto.RegisterType((*GetTenantResponse)(nil), "cockroach.ccl.sqlproxyccl.tenant.GetTenantResponse")
 }
@@ -400,40 +400,39 @@ func init() {
 }
 
 var fileDescriptor_ec8b5028e8f2b222 = []byte{
-	// 523 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x9c, 0x94, 0xc1, 0x8b, 0xd3, 0x40,
-	0x14, 0xc6, 0x33, 0x6d, 0xad, 0xcd, 0x6b, 0x2d, 0x75, 0xd8, 0xd6, 0x92, 0x43, 0x36, 0xe6, 0x20,
-	0x71, 0x85, 0x54, 0xba, 0xb0, 0xeb, 0x65, 0x0f, 0x5b, 0x12, 0x35, 0xb0, 0x6a, 0x09, 0x05, 0xc1,
-	0xcb, 0x12, 0xa7, 0xc3, 0x6e, 0xb0, 0x9b, 0xc9, 0x26, 0x53, 0xb1, 0x37, 0x41, 0x04, 0x8f, 0xe2,
-	0xd1, 0xab, 0xff, 0xcc, 0x1e, 0xf7, 0xb8, 0xa7, 0x45, 0xd3, 0x7f, 0x44, 0xda, 0x69, 0xd6, 0x36,
-	0x14, 0xdb, 0xee, 0x6d, 0x78, 0x93, 0xdf, 0x37, 0xdf, 0x7b, 0xf9, 0x66, 0xe0, 0x11, 0x21, 0x83,
-	0x56, 0x7c, 0x3e, 0x08, 0x23, 0xf6, 0x69, 0x34, 0x59, 0x73, 0x1a, 0x78, 0x01, 0x6f, 0xf5, 0xfd,
-	0x88, 0x12, 0xce, 0xa2, 0x91, 0x19, 0x46, 0x8c, 0x33, 0xac, 0x11, 0x46, 0x3e, 0x44, 0xcc, 0x23,
-	0xa7, 0x26, 0x21, 0x03, 0x73, 0x8e, 0x30, 0x05, 0xa1, 0x6c, 0x9d, 0xb0, 0x13, 0x36, 0xfd, 0xb8,
-	0x35, 0x59, 0x09, 0x4e, 0x7f, 0x00, 0xf5, 0xb7, 0x1e, 0x27, 0xa7, 0x76, 0xd0, 0x0f, 0x99, 0x1f,
-	0xf0, 0xd8, 0xa5, 0xe7, 0x43, 0x1a, 0x73, 0xfd, 0x27, 0x82, 0x46, 0x76, 0x27, 0x0e, 0x59, 0x10,
-	0x53, 0x7c, 0x00, 0x79, 0x3e, 0x0a, 0x9b, 0x48, 0x43, 0x46, 0xb5, 0xfd, 0xc4, 0x5c, 0x75, 0xb2,
-	0x69, 0x7f, 0xa4, 0x01, 0xef, 0x8d, 0x42, 0xea, 0x4e, 0x38, 0xdc, 0x80, 0x9c, 0x1f, 0x36, 0x73,
-	0x1a, 0x32, 0xe4, 0x4e, 0x31, 0xb9, 0xde, 0xce, 0x39, 0x5d, 0x37, 0xe7, 0x87, 0xf8, 0x31, 0xc8,
-	0x02, 0x38, 0xf6, 0xfb, 0xcd, 0xbc, 0x86, 0x8c, 0x42, 0xa7, 0x92, 0x5c, 0x6f, 0x97, 0x7a, 0xd3,
-	0xa2, 0x63, 0xb9, 0x25, 0xb1, 0xed, 0xf4, 0xf5, 0x43, 0xd8, 0x3a, 0xf2, 0x63, 0x9e, 0x35, 0xbd,
-	0x28, 0x81, 0xfe, 0x2b, 0xd1, 0x81, 0xba, 0x1d, 0xc4, 0xc3, 0x88, 0xa6, 0x22, 0xb7, 0xd0, 0x68,
-	0x42, 0x23, 0xab, 0x21, 0x46, 0xa4, 0xeb, 0x50, 0x4a, 0x6b, 0x93, 0x7e, 0x9d, 0xee, 0x54, 0x69,
-	0xae, 0x5f, 0xa7, 0xab, 0x7b, 0x50, 0xcf, 0x34, 0x31, 0x9b, 0xef, 0x4b, 0x90, 0x69, 0x5a, 0x6c,
-	0x22, 0x2d, 0x6f, 0x94, 0xdb, 0x3b, 0x6b, 0x4c, 0x39, 0xf5, 0xf0, 0x0f, 0xd6, 0x0f, 0xa0, 0xf6,
-	0x82, 0x72, 0xe1, 0xfc, 0x16, 0xfd, 0xed, 0xc1, 0xfd, 0x39, 0x7c, 0xe6, 0xee, 0x21, 0x54, 0xc8,
-	0x60, 0x18, 0x73, 0x1a, 0x1d, 0x07, 0xde, 0x19, 0x15, 0x8d, 0xb9, 0xe5, 0x59, 0xed, 0xb5, 0x77,
-	0x46, 0x77, 0xf6, 0x41, 0xbe, 0xf9, 0xe7, 0x58, 0x86, 0x3b, 0x87, 0x96, 0x65, 0x5b, 0x35, 0x09,
-	0x57, 0xa0, 0xf4, 0xea, 0x8d, 0xe5, 0x3c, 0x77, 0x6c, 0xab, 0x86, 0x70, 0x19, 0xee, 0x5a, 0xf6,
-	0x91, 0xdd, 0xb3, 0xad, 0x5a, 0x4e, 0x29, 0x7c, 0xfb, 0xa5, 0x4a, 0xed, 0x1f, 0x05, 0x90, 0xad,
-	0x34, 0xd9, 0xf8, 0x33, 0x82, 0x7b, 0x0b, 0x13, 0xc2, 0x7b, 0xab, 0xc7, 0xb0, 0x2c, 0x17, 0xca,
-	0xfe, 0xc6, 0xdc, 0xac, 0xd9, 0xaf, 0x08, 0xaa, 0x8b, 0xb7, 0x00, 0xaf, 0xa1, 0xb5, 0xf4, 0x46,
-	0x29, 0xcf, 0x36, 0x07, 0x85, 0x8b, 0xa7, 0x08, 0x7f, 0x41, 0x50, 0x5d, 0x8c, 0xda, 0x3a, 0x3e,
-	0x96, 0x06, 0x7c, 0x1d, 0x1f, 0xcb, 0x53, 0x8d, 0x39, 0xc8, 0x37, 0x79, 0xc0, 0xed, 0xd5, 0x32,
-	0xd9, 0xec, 0x29, 0xbb, 0x1b, 0x31, 0xe2, 0xd4, 0x8e, 0x71, 0xf1, 0x47, 0x95, 0x2e, 0x12, 0x15,
-	0x5d, 0x26, 0x2a, 0xba, 0x4a, 0x54, 0xf4, 0x3b, 0x51, 0xd1, 0xf7, 0xb1, 0x2a, 0x5d, 0x8e, 0x55,
-	0xe9, 0x6a, 0xac, 0x4a, 0xef, 0x8a, 0x82, 0x7d, 0x5f, 0x9c, 0xbe, 0x69, 0xbb, 0x7f, 0x03, 0x00,
-	0x00, 0xff, 0xff, 0xba, 0xed, 0x85, 0x11, 0x35, 0x05, 0x00, 0x00,
+	// 498 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x9c, 0x94, 0xc1, 0x6e, 0xd3, 0x40,
+	0x10, 0x86, 0xbd, 0x75, 0x28, 0xf1, 0x24, 0x02, 0x67, 0xe1, 0x10, 0x72, 0x30, 0xc6, 0x12, 0xc8,
+	0x80, 0xe4, 0x40, 0x2a, 0x81, 0x90, 0xe8, 0xa1, 0x95, 0x0d, 0x8a, 0xd4, 0x42, 0x14, 0x45, 0x42,
+	0xe2, 0x52, 0x99, 0xf5, 0xaa, 0x8d, 0x48, 0xbd, 0x8e, 0x77, 0x53, 0x91, 0x37, 0xe0, 0x08, 0xcf,
+	0xc0, 0xcb, 0xf4, 0xd8, 0x63, 0x4f, 0x08, 0x9c, 0x17, 0x41, 0xeb, 0x75, 0x83, 0x49, 0x25, 0xe2,
+	0xf6, 0x36, 0x5a, 0xef, 0xe7, 0xff, 0x9f, 0x99, 0xdf, 0x86, 0x47, 0x84, 0x4c, 0xba, 0x7c, 0x3a,
+	0x49, 0x52, 0xf6, 0x65, 0x2e, 0x6b, 0x41, 0xe3, 0x30, 0x16, 0xdd, 0x68, 0x9c, 0x52, 0x22, 0x58,
+	0x3a, 0xf7, 0x92, 0x94, 0x09, 0x86, 0x6d, 0xc2, 0xc8, 0xe7, 0x94, 0x85, 0xe4, 0xc8, 0x23, 0x64,
+	0xe2, 0x95, 0x08, 0x4f, 0x11, 0x9d, 0xbb, 0x87, 0xec, 0x90, 0xe5, 0x97, 0xbb, 0xb2, 0x52, 0x9c,
+	0x83, 0xc1, 0xfc, 0x10, 0x0a, 0x72, 0x34, 0x60, 0x11, 0x1f, 0xd2, 0xe9, 0x8c, 0x72, 0xe1, 0x7c,
+	0x47, 0xd0, 0x2a, 0x1d, 0xf2, 0x84, 0xc5, 0x9c, 0xe2, 0x6d, 0xd0, 0xc5, 0x3c, 0x69, 0x23, 0x1b,
+	0xb9, 0xb7, 0x7a, 0x4f, 0xbd, 0x75, 0x7a, 0x5e, 0x70, 0x42, 0x63, 0x31, 0x9a, 0x27, 0x74, 0x28,
+	0x39, 0x8c, 0xa1, 0x16, 0x46, 0x51, 0xda, 0xde, 0xb0, 0x91, 0x6b, 0x0c, 0xf3, 0x1a, 0x3f, 0x06,
+	0x43, 0x5d, 0x3e, 0x18, 0x47, 0x6d, 0xdd, 0x46, 0x6e, 0x6d, 0xb7, 0x99, 0xfd, 0xbc, 0x5f, 0x1f,
+	0xe5, 0x87, 0x7d, 0x7f, 0x58, 0x57, 0x8f, 0xfb, 0x91, 0xf3, 0x1a, 0x6e, 0xef, 0x8d, 0xb9, 0x28,
+	0xd9, 0xfc, 0x97, 0x46, 0xff, 0xa5, 0xb7, 0xc1, 0x0c, 0x62, 0x3e, 0x4b, 0xe9, 0x80, 0x45, 0xd7,
+	0xc0, 0xef, 0x40, 0xab, 0x84, 0xab, 0x79, 0x38, 0xf7, 0x40, 0x1f, 0xb0, 0x48, 0xf6, 0xb5, 0x23,
+	0xfb, 0x42, 0xaa, 0x2f, 0x59, 0x3b, 0xfb, 0x60, 0xfe, 0x35, 0x5b, 0x8c, 0xef, 0x15, 0xd4, 0x12,
+	0x16, 0xf1, 0x36, 0xb2, 0x75, 0xb7, 0xd1, 0x7b, 0xb8, 0x7e, 0x7e, 0x52, 0x2b, 0x47, 0xa4, 0xfb,
+	0xb7, 0x54, 0x28, 0x5f, 0xd7, 0x70, 0xff, 0x02, 0x5a, 0x25, 0xbc, 0xb0, 0xf3, 0x00, 0x9a, 0x64,
+	0x32, 0xe3, 0x82, 0xa6, 0x07, 0x71, 0x78, 0x4c, 0x0b, 0xfb, 0x8d, 0xe2, 0xec, 0x5d, 0x78, 0x4c,
+	0x9f, 0xbc, 0x04, 0x63, 0xb9, 0x43, 0x6c, 0xc0, 0x8d, 0x1d, 0xdf, 0x0f, 0x7c, 0x53, 0xc3, 0x4d,
+	0xa8, 0xef, 0xbf, 0xf7, 0xfb, 0x6f, 0xfa, 0x81, 0x6f, 0x22, 0xdc, 0x80, 0x9b, 0x7e, 0xb0, 0x17,
+	0x8c, 0x02, 0xdf, 0xdc, 0xe8, 0xd4, 0xbe, 0xfe, 0xb0, 0xb4, 0x5e, 0xa6, 0x83, 0xe1, 0x5f, 0xe4,
+	0x13, 0x4f, 0xa1, 0x7e, 0x31, 0x0c, 0xfc, 0x7c, 0x7d, 0xdb, 0x2b, 0x5b, 0xee, 0xf4, 0xae, 0x82,
+	0x14, 0xcd, 0x9d, 0x80, 0xb1, 0xcc, 0x2f, 0xae, 0xf0, 0x82, 0xd5, 0x2f, 0xa0, 0xb3, 0x75, 0x25,
+	0x46, 0xa9, 0x3e, 0x43, 0x58, 0x80, 0xb1, 0xcc, 0x49, 0x15, 0xdd, 0xd5, 0x4c, 0x56, 0xd1, 0xbd,
+	0x14, 0x44, 0xa9, 0xba, 0xdc, 0x6f, 0x15, 0xd5, 0xd5, 0x2c, 0x55, 0x51, 0xbd, 0x14, 0xa0, 0x5d,
+	0xf7, 0xf4, 0xb7, 0xa5, 0x9d, 0x66, 0x16, 0x3a, 0xcb, 0x2c, 0x74, 0x9e, 0x59, 0xe8, 0x57, 0x66,
+	0xa1, 0x6f, 0x0b, 0x4b, 0x3b, 0x5b, 0x58, 0xda, 0xf9, 0xc2, 0xd2, 0x3e, 0x6e, 0x2a, 0xf6, 0xd3,
+	0x66, 0xfe, 0xa7, 0xd9, 0xfa, 0x13, 0x00, 0x00, 0xff, 0xff, 0xd8, 0x33, 0x05, 0xac, 0xcb, 0x04,
+	0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -448,18 +447,18 @@ const _ = grpc.SupportPackageIsVersion4
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type DirectoryClient interface {
-	// ListEndpoints is used to query the server for the list of current endpoints
+	// ListPods is used to query the server for the list of current pods
 	// of a given tenant.
-	ListEndpoints(ctx context.Context, in *ListEndpointsRequest, opts ...grpc.CallOption) (*ListEndpointsResponse, error)
-	// WatchEndpoints is used to get a stream, that is used to receive notifications
+	ListPods(ctx context.Context, in *ListPodsRequest, opts ...grpc.CallOption) (*ListPodsResponse, error)
+	// WatchPods is used to get a stream, that is used to receive notifications
 	// about changes in tenant backend's state - added, modified and deleted.
-	WatchEndpoints(ctx context.Context, in *WatchEndpointsRequest, opts ...grpc.CallOption) (Directory_WatchEndpointsClient, error)
-	// EnsureEndpoint is used to ensure that a tenant's backend is active. If
+	WatchPods(ctx context.Context, in *WatchPodsRequest, opts ...grpc.CallOption) (Directory_WatchPodsClient, error)
+	// EnsurePod is used to ensure that a tenant's backend is active. If
 	// there is an active backend then the server doesn't have to do anything. If
 	// there isn't an active backend, then the server has to bring a new one up.
-	// If the requested tenant does not exist, EnsureEndpoint returns a GRPC
+	// If the requested tenant does not exist, EnsurePod returns a GRPC
 	// NotFound error.
-	EnsureEndpoint(ctx context.Context, in *EnsureEndpointRequest, opts ...grpc.CallOption) (*EnsureEndpointResponse, error)
+	EnsurePod(ctx context.Context, in *EnsurePodRequest, opts ...grpc.CallOption) (*EnsurePodResponse, error)
 	// GetTenant is used to fetch the metadata of a specific tenant. If the tenant
 	// does not exist, GetTenant returns a GRPC NotFound error.
 	GetTenant(ctx context.Context, in *GetTenantRequest, opts ...grpc.CallOption) (*GetTenantResponse, error)
@@ -473,21 +472,21 @@ func NewDirectoryClient(cc *grpc.ClientConn) DirectoryClient {
 	return &directoryClient{cc}
 }
 
-func (c *directoryClient) ListEndpoints(ctx context.Context, in *ListEndpointsRequest, opts ...grpc.CallOption) (*ListEndpointsResponse, error) {
-	out := new(ListEndpointsResponse)
-	err := c.cc.Invoke(ctx, "/cockroach.ccl.sqlproxyccl.tenant.Directory/ListEndpoints", in, out, opts...)
+func (c *directoryClient) ListPods(ctx context.Context, in *ListPodsRequest, opts ...grpc.CallOption) (*ListPodsResponse, error) {
+	out := new(ListPodsResponse)
+	err := c.cc.Invoke(ctx, "/cockroach.ccl.sqlproxyccl.tenant.Directory/ListPods", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *directoryClient) WatchEndpoints(ctx context.Context, in *WatchEndpointsRequest, opts ...grpc.CallOption) (Directory_WatchEndpointsClient, error) {
-	stream, err := c.cc.NewStream(ctx, &_Directory_serviceDesc.Streams[0], "/cockroach.ccl.sqlproxyccl.tenant.Directory/WatchEndpoints", opts...)
+func (c *directoryClient) WatchPods(ctx context.Context, in *WatchPodsRequest, opts ...grpc.CallOption) (Directory_WatchPodsClient, error) {
+	stream, err := c.cc.NewStream(ctx, &_Directory_serviceDesc.Streams[0], "/cockroach.ccl.sqlproxyccl.tenant.Directory/WatchPods", opts...)
 	if err != nil {
 		return nil, err
 	}
-	x := &directoryWatchEndpointsClient{stream}
+	x := &directoryWatchPodsClient{stream}
 	if err := x.ClientStream.SendMsg(in); err != nil {
 		return nil, err
 	}
@@ -497,26 +496,26 @@ func (c *directoryClient) WatchEndpoints(ctx context.Context, in *WatchEndpoints
 	return x, nil
 }
 
-type Directory_WatchEndpointsClient interface {
-	Recv() (*WatchEndpointsResponse, error)
+type Directory_WatchPodsClient interface {
+	Recv() (*WatchPodsResponse, error)
 	grpc.ClientStream
 }
 
-type directoryWatchEndpointsClient struct {
+type directoryWatchPodsClient struct {
 	grpc.ClientStream
 }
 
-func (x *directoryWatchEndpointsClient) Recv() (*WatchEndpointsResponse, error) {
-	m := new(WatchEndpointsResponse)
+func (x *directoryWatchPodsClient) Recv() (*WatchPodsResponse, error) {
+	m := new(WatchPodsResponse)
 	if err := x.ClientStream.RecvMsg(m); err != nil {
 		return nil, err
 	}
 	return m, nil
 }
 
-func (c *directoryClient) EnsureEndpoint(ctx context.Context, in *EnsureEndpointRequest, opts ...grpc.CallOption) (*EnsureEndpointResponse, error) {
-	out := new(EnsureEndpointResponse)
-	err := c.cc.Invoke(ctx, "/cockroach.ccl.sqlproxyccl.tenant.Directory/EnsureEndpoint", in, out, opts...)
+func (c *directoryClient) EnsurePod(ctx context.Context, in *EnsurePodRequest, opts ...grpc.CallOption) (*EnsurePodResponse, error) {
+	out := new(EnsurePodResponse)
+	err := c.cc.Invoke(ctx, "/cockroach.ccl.sqlproxyccl.tenant.Directory/EnsurePod", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -534,18 +533,18 @@ func (c *directoryClient) GetTenant(ctx context.Context, in *GetTenantRequest, o
 
 // DirectoryServer is the server API for Directory service.
 type DirectoryServer interface {
-	// ListEndpoints is used to query the server for the list of current endpoints
+	// ListPods is used to query the server for the list of current pods
 	// of a given tenant.
-	ListEndpoints(context.Context, *ListEndpointsRequest) (*ListEndpointsResponse, error)
-	// WatchEndpoints is used to get a stream, that is used to receive notifications
+	ListPods(context.Context, *ListPodsRequest) (*ListPodsResponse, error)
+	// WatchPods is used to get a stream, that is used to receive notifications
 	// about changes in tenant backend's state - added, modified and deleted.
-	WatchEndpoints(*WatchEndpointsRequest, Directory_WatchEndpointsServer) error
-	// EnsureEndpoint is used to ensure that a tenant's backend is active. If
+	WatchPods(*WatchPodsRequest, Directory_WatchPodsServer) error
+	// EnsurePod is used to ensure that a tenant's backend is active. If
 	// there is an active backend then the server doesn't have to do anything. If
 	// there isn't an active backend, then the server has to bring a new one up.
-	// If the requested tenant does not exist, EnsureEndpoint returns a GRPC
+	// If the requested tenant does not exist, EnsurePod returns a GRPC
 	// NotFound error.
-	EnsureEndpoint(context.Context, *EnsureEndpointRequest) (*EnsureEndpointResponse, error)
+	EnsurePod(context.Context, *EnsurePodRequest) (*EnsurePodResponse, error)
 	// GetTenant is used to fetch the metadata of a specific tenant. If the tenant
 	// does not exist, GetTenant returns a GRPC NotFound error.
 	GetTenant(context.Context, *GetTenantRequest) (*GetTenantResponse, error)
@@ -555,14 +554,14 @@ type DirectoryServer interface {
 type UnimplementedDirectoryServer struct {
 }
 
-func (*UnimplementedDirectoryServer) ListEndpoints(ctx context.Context, req *ListEndpointsRequest) (*ListEndpointsResponse, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method ListEndpoints not implemented")
+func (*UnimplementedDirectoryServer) ListPods(ctx context.Context, req *ListPodsRequest) (*ListPodsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListPods not implemented")
 }
-func (*UnimplementedDirectoryServer) WatchEndpoints(req *WatchEndpointsRequest, srv Directory_WatchEndpointsServer) error {
-	return status.Errorf(codes.Unimplemented, "method WatchEndpoints not implemented")
+func (*UnimplementedDirectoryServer) WatchPods(req *WatchPodsRequest, srv Directory_WatchPodsServer) error {
+	return status.Errorf(codes.Unimplemented, "method WatchPods not implemented")
 }
-func (*UnimplementedDirectoryServer) EnsureEndpoint(ctx context.Context, req *EnsureEndpointRequest) (*EnsureEndpointResponse, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method EnsureEndpoint not implemented")
+func (*UnimplementedDirectoryServer) EnsurePod(ctx context.Context, req *EnsurePodRequest) (*EnsurePodResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method EnsurePod not implemented")
 }
 func (*UnimplementedDirectoryServer) GetTenant(ctx context.Context, req *GetTenantRequest) (*GetTenantResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetTenant not implemented")
@@ -572,59 +571,59 @@ func RegisterDirectoryServer(s *grpc.Server, srv DirectoryServer) {
 	s.RegisterService(&_Directory_serviceDesc, srv)
 }
 
-func _Directory_ListEndpoints_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(ListEndpointsRequest)
+func _Directory_ListPods_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListPodsRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(DirectoryServer).ListEndpoints(ctx, in)
+		return srv.(DirectoryServer).ListPods(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/cockroach.ccl.sqlproxyccl.tenant.Directory/ListEndpoints",
+		FullMethod: "/cockroach.ccl.sqlproxyccl.tenant.Directory/ListPods",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(DirectoryServer).ListEndpoints(ctx, req.(*ListEndpointsRequest))
+		return srv.(DirectoryServer).ListPods(ctx, req.(*ListPodsRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _Directory_WatchEndpoints_Handler(srv interface{}, stream grpc.ServerStream) error {
-	m := new(WatchEndpointsRequest)
+func _Directory_WatchPods_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(WatchPodsRequest)
 	if err := stream.RecvMsg(m); err != nil {
 		return err
 	}
-	return srv.(DirectoryServer).WatchEndpoints(m, &directoryWatchEndpointsServer{stream})
+	return srv.(DirectoryServer).WatchPods(m, &directoryWatchPodsServer{stream})
 }
 
-type Directory_WatchEndpointsServer interface {
-	Send(*WatchEndpointsResponse) error
+type Directory_WatchPodsServer interface {
+	Send(*WatchPodsResponse) error
 	grpc.ServerStream
 }
 
-type directoryWatchEndpointsServer struct {
+type directoryWatchPodsServer struct {
 	grpc.ServerStream
 }
 
-func (x *directoryWatchEndpointsServer) Send(m *WatchEndpointsResponse) error {
+func (x *directoryWatchPodsServer) Send(m *WatchPodsResponse) error {
 	return x.ServerStream.SendMsg(m)
 }
 
-func _Directory_EnsureEndpoint_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(EnsureEndpointRequest)
+func _Directory_EnsurePod_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(EnsurePodRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(DirectoryServer).EnsureEndpoint(ctx, in)
+		return srv.(DirectoryServer).EnsurePod(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/cockroach.ccl.sqlproxyccl.tenant.Directory/EnsureEndpoint",
+		FullMethod: "/cockroach.ccl.sqlproxyccl.tenant.Directory/EnsurePod",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(DirectoryServer).EnsureEndpoint(ctx, req.(*EnsureEndpointRequest))
+		return srv.(DirectoryServer).EnsurePod(ctx, req.(*EnsurePodRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -652,12 +651,12 @@ var _Directory_serviceDesc = grpc.ServiceDesc{
 	HandlerType: (*DirectoryServer)(nil),
 	Methods: []grpc.MethodDesc{
 		{
-			MethodName: "ListEndpoints",
-			Handler:    _Directory_ListEndpoints_Handler,
+			MethodName: "ListPods",
+			Handler:    _Directory_ListPods_Handler,
 		},
 		{
-			MethodName: "EnsureEndpoint",
-			Handler:    _Directory_EnsureEndpoint_Handler,
+			MethodName: "EnsurePod",
+			Handler:    _Directory_EnsurePod_Handler,
 		},
 		{
 			MethodName: "GetTenant",
@@ -666,15 +665,15 @@ var _Directory_serviceDesc = grpc.ServiceDesc{
 	},
 	Streams: []grpc.StreamDesc{
 		{
-			StreamName:    "WatchEndpoints",
-			Handler:       _Directory_WatchEndpoints_Handler,
+			StreamName:    "WatchPods",
+			Handler:       _Directory_WatchPods_Handler,
 			ServerStreams: true,
 		},
 	},
 	Metadata: "ccl/sqlproxyccl/tenant/directory.proto",
 }
 
-func (m *WatchEndpointsRequest) Marshal() (dAtA []byte, err error) {
+func (m *WatchPodsRequest) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
@@ -684,12 +683,12 @@ func (m *WatchEndpointsRequest) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *WatchEndpointsRequest) MarshalTo(dAtA []byte) (int, error) {
+func (m *WatchPodsRequest) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
-func (m *WatchEndpointsRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+func (m *WatchPodsRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
@@ -697,7 +696,7 @@ func (m *WatchEndpointsRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-func (m *WatchEndpointsResponse) Marshal() (dAtA []byte, err error) {
+func (m *WatchPodsResponse) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
@@ -707,12 +706,12 @@ func (m *WatchEndpointsResponse) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *WatchEndpointsResponse) MarshalTo(dAtA []byte) (int, error) {
+func (m *WatchPodsResponse) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
-func (m *WatchEndpointsResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+func (m *WatchPodsResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
@@ -722,10 +721,10 @@ func (m *WatchEndpointsResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) 
 		i--
 		dAtA[i] = 0x18
 	}
-	if len(m.IP) > 0 {
-		i -= len(m.IP)
-		copy(dAtA[i:], m.IP)
-		i = encodeVarintDirectory(dAtA, i, uint64(len(m.IP)))
+	if len(m.Addr) > 0 {
+		i -= len(m.Addr)
+		copy(dAtA[i:], m.Addr)
+		i = encodeVarintDirectory(dAtA, i, uint64(len(m.Addr)))
 		i--
 		dAtA[i] = 0x12
 	}
@@ -737,7 +736,7 @@ func (m *WatchEndpointsResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) 
 	return len(dAtA) - i, nil
 }
 
-func (m *ListEndpointsRequest) Marshal() (dAtA []byte, err error) {
+func (m *ListPodsRequest) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
@@ -747,12 +746,12 @@ func (m *ListEndpointsRequest) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *ListEndpointsRequest) MarshalTo(dAtA []byte) (int, error) {
+func (m *ListPodsRequest) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
-func (m *ListEndpointsRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+func (m *ListPodsRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
@@ -765,7 +764,7 @@ func (m *ListEndpointsRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-func (m *EnsureEndpointRequest) Marshal() (dAtA []byte, err error) {
+func (m *EnsurePodRequest) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
@@ -775,12 +774,12 @@ func (m *EnsureEndpointRequest) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *EnsureEndpointRequest) MarshalTo(dAtA []byte) (int, error) {
+func (m *EnsurePodRequest) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
-func (m *EnsureEndpointRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+func (m *EnsurePodRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
@@ -793,7 +792,7 @@ func (m *EnsureEndpointRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-func (m *EnsureEndpointResponse) Marshal() (dAtA []byte, err error) {
+func (m *EnsurePodResponse) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
@@ -803,12 +802,12 @@ func (m *EnsureEndpointResponse) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *EnsureEndpointResponse) MarshalTo(dAtA []byte) (int, error) {
+func (m *EnsurePodResponse) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
-func (m *EnsureEndpointResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+func (m *EnsurePodResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
@@ -816,7 +815,7 @@ func (m *EnsureEndpointResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) 
 	return len(dAtA) - i, nil
 }
 
-func (m *Endpoint) Marshal() (dAtA []byte, err error) {
+func (m *Pod) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
@@ -826,27 +825,27 @@ func (m *Endpoint) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *Endpoint) MarshalTo(dAtA []byte) (int, error) {
+func (m *Pod) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
-func (m *Endpoint) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+func (m *Pod) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.IP) > 0 {
-		i -= len(m.IP)
-		copy(dAtA[i:], m.IP)
-		i = encodeVarintDirectory(dAtA, i, uint64(len(m.IP)))
+	if len(m.Addr) > 0 {
+		i -= len(m.Addr)
+		copy(dAtA[i:], m.Addr)
+		i = encodeVarintDirectory(dAtA, i, uint64(len(m.Addr)))
 		i--
 		dAtA[i] = 0xa
 	}
 	return len(dAtA) - i, nil
 }
 
-func (m *ListEndpointsResponse) Marshal() (dAtA []byte, err error) {
+func (m *ListPodsResponse) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
@@ -856,20 +855,20 @@ func (m *ListEndpointsResponse) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *ListEndpointsResponse) MarshalTo(dAtA []byte) (int, error) {
+func (m *ListPodsResponse) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
-func (m *ListEndpointsResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+func (m *ListPodsResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.Endpoints) > 0 {
-		for iNdEx := len(m.Endpoints) - 1; iNdEx >= 0; iNdEx-- {
+	if len(m.Pods) > 0 {
+		for iNdEx := len(m.Pods) - 1; iNdEx >= 0; iNdEx-- {
 			{
-				size, err := m.Endpoints[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				size, err := m.Pods[iNdEx].MarshalToSizedBuffer(dAtA[:i])
 				if err != nil {
 					return 0, err
 				}
@@ -952,7 +951,7 @@ func encodeVarintDirectory(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
-func (m *WatchEndpointsRequest) Size() (n int) {
+func (m *WatchPodsRequest) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -961,7 +960,7 @@ func (m *WatchEndpointsRequest) Size() (n int) {
 	return n
 }
 
-func (m *WatchEndpointsResponse) Size() (n int) {
+func (m *WatchPodsResponse) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -970,7 +969,7 @@ func (m *WatchEndpointsResponse) Size() (n int) {
 	if m.Typ != 0 {
 		n += 1 + sovDirectory(uint64(m.Typ))
 	}
-	l = len(m.IP)
+	l = len(m.Addr)
 	if l > 0 {
 		n += 1 + l + sovDirectory(uint64(l))
 	}
@@ -980,7 +979,7 @@ func (m *WatchEndpointsResponse) Size() (n int) {
 	return n
 }
 
-func (m *ListEndpointsRequest) Size() (n int) {
+func (m *ListPodsRequest) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -992,7 +991,7 @@ func (m *ListEndpointsRequest) Size() (n int) {
 	return n
 }
 
-func (m *EnsureEndpointRequest) Size() (n int) {
+func (m *EnsurePodRequest) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -1004,7 +1003,7 @@ func (m *EnsureEndpointRequest) Size() (n int) {
 	return n
 }
 
-func (m *EnsureEndpointResponse) Size() (n int) {
+func (m *EnsurePodResponse) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -1013,27 +1012,27 @@ func (m *EnsureEndpointResponse) Size() (n int) {
 	return n
 }
 
-func (m *Endpoint) Size() (n int) {
+func (m *Pod) Size() (n int) {
 	if m == nil {
 		return 0
 	}
 	var l int
 	_ = l
-	l = len(m.IP)
+	l = len(m.Addr)
 	if l > 0 {
 		n += 1 + l + sovDirectory(uint64(l))
 	}
 	return n
 }
 
-func (m *ListEndpointsResponse) Size() (n int) {
+func (m *ListPodsResponse) Size() (n int) {
 	if m == nil {
 		return 0
 	}
 	var l int
 	_ = l
-	if len(m.Endpoints) > 0 {
-		for _, e := range m.Endpoints {
+	if len(m.Pods) > 0 {
+		for _, e := range m.Pods {
 			l = e.Size()
 			n += 1 + l + sovDirectory(uint64(l))
 		}
@@ -1072,7 +1071,7 @@ func sovDirectory(x uint64) (n int) {
 func sozDirectory(x uint64) (n int) {
 	return sovDirectory(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
-func (m *WatchEndpointsRequest) Unmarshal(dAtA []byte) error {
+func (m *WatchPodsRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -1095,10 +1094,10 @@ func (m *WatchEndpointsRequest) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: WatchEndpointsRequest: wiretype end group for non-group")
+			return fmt.Errorf("proto: WatchPodsRequest: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: WatchEndpointsRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: WatchPodsRequest: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		default:
@@ -1122,7 +1121,7 @@ func (m *WatchEndpointsRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *WatchEndpointsResponse) Unmarshal(dAtA []byte) error {
+func (m *WatchPodsResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -1145,10 +1144,10 @@ func (m *WatchEndpointsResponse) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: WatchEndpointsResponse: wiretype end group for non-group")
+			return fmt.Errorf("proto: WatchPodsResponse: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: WatchEndpointsResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: WatchPodsResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
@@ -1172,7 +1171,7 @@ func (m *WatchEndpointsResponse) Unmarshal(dAtA []byte) error {
 			}
 		case 2:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field IP", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field Addr", wireType)
 			}
 			var stringLen uint64
 			for shift := uint(0); ; shift += 7 {
@@ -1200,7 +1199,7 @@ func (m *WatchEndpointsResponse) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.IP = string(dAtA[iNdEx:postIndex])
+			m.Addr = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		case 3:
 			if wireType != 0 {
@@ -1242,7 +1241,7 @@ func (m *WatchEndpointsResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *ListEndpointsRequest) Unmarshal(dAtA []byte) error {
+func (m *ListPodsRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -1265,10 +1264,10 @@ func (m *ListEndpointsRequest) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: ListEndpointsRequest: wiretype end group for non-group")
+			return fmt.Errorf("proto: ListPodsRequest: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: ListEndpointsRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: ListPodsRequest: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
@@ -1311,7 +1310,7 @@ func (m *ListEndpointsRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *EnsureEndpointRequest) Unmarshal(dAtA []byte) error {
+func (m *EnsurePodRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -1334,10 +1333,10 @@ func (m *EnsureEndpointRequest) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: EnsureEndpointRequest: wiretype end group for non-group")
+			return fmt.Errorf("proto: EnsurePodRequest: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: EnsureEndpointRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: EnsurePodRequest: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
@@ -1380,7 +1379,7 @@ func (m *EnsureEndpointRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *EnsureEndpointResponse) Unmarshal(dAtA []byte) error {
+func (m *EnsurePodResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -1403,10 +1402,10 @@ func (m *EnsureEndpointResponse) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: EnsureEndpointResponse: wiretype end group for non-group")
+			return fmt.Errorf("proto: EnsurePodResponse: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: EnsureEndpointResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: EnsurePodResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		default:
@@ -1430,7 +1429,7 @@ func (m *EnsureEndpointResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *Endpoint) Unmarshal(dAtA []byte) error {
+func (m *Pod) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -1453,15 +1452,15 @@ func (m *Endpoint) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: Endpoint: wiretype end group for non-group")
+			return fmt.Errorf("proto: Pod: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: Endpoint: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: Pod: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field IP", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field Addr", wireType)
 			}
 			var stringLen uint64
 			for shift := uint(0); ; shift += 7 {
@@ -1489,7 +1488,7 @@ func (m *Endpoint) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.IP = string(dAtA[iNdEx:postIndex])
+			m.Addr = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -1512,7 +1511,7 @@ func (m *Endpoint) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *ListEndpointsResponse) Unmarshal(dAtA []byte) error {
+func (m *ListPodsResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -1535,15 +1534,15 @@ func (m *ListEndpointsResponse) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: ListEndpointsResponse: wiretype end group for non-group")
+			return fmt.Errorf("proto: ListPodsResponse: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: ListEndpointsResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: ListPodsResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Endpoints", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field Pods", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -1570,8 +1569,8 @@ func (m *ListEndpointsResponse) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.Endpoints = append(m.Endpoints, &Endpoint{})
-			if err := m.Endpoints[len(m.Endpoints)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			m.Pods = append(m.Pods, &Pod{})
+			if err := m.Pods[len(m.Pods)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/pkg/ccl/sqlproxyccl/tenant/directory.proto
+++ b/pkg/ccl/sqlproxyccl/tenant/directory.proto
@@ -12,8 +12,8 @@ option go_package="tenant";
 
 import "gogoproto/gogo.proto";
 
-// WatchEndpointsRequest is empty as we want to get all notifications.
-message WatchEndpointsRequest {}
+// WatchPodsRequest is empty as we want to get all notifications.
+message WatchPodsRequest {}
 
 // EventType shows the event type of the notifications that the server streams
 // to its clients.
@@ -25,51 +25,51 @@ enum EventType {
   DELETED = 2;
 }
 
-// WatchEndpointsResponse represents the notifications that the server sends to
+// WatchPodsResponse represents the notifications that the server sends to
 // its clients when clients want to monitor the directory server activity.
-message WatchEndpointsResponse {
+message WatchPodsResponse {
   // EventType is the type of the notifications - added, modified, deleted.
   EventType typ = 1;
-  // IP is the endpoint that this notification applies to.
-  string ip = 2 [(gogoproto.customname) = "IP"];
-  // TenantID is the tenant that owns the endpoint.
+  // Addr is the address of the pod that this notification applies to.
+  string addr = 2;
+  // TenantID is the tenant that owns the pod.
   uint64 tenant_id = 3[(gogoproto.customname) = "TenantID"];
 }
 
-// ListEndpointsRequest is used to query the server for the list of current
-// endpoints of a given tenant.
-message ListEndpointsRequest {
+// ListPodsRequest is used to query the server for the list of current
+// pods of a given tenant.
+message ListPodsRequest {
   // TenantID identifies the tenant for which the client is requesting a list of
-  // the endpoints.
+  // the pods.
   uint64 tenant_id = 1[(gogoproto.customname) = "TenantID"];
 }
 
-// EnsureEndpointRequest is used to ensure that a tenant's backend is active. If
+// EnsurePodRequest is used to ensure that a tenant's backend is active. If
 // there is an active backend then the server doesn't have to do anything. If
 // there isn't an active backend, then the server has to bring a new one up.
-message EnsureEndpointRequest {
+message EnsurePodRequest {
   // TenantID is the id of the tenant for which an active backend is requested.
   uint64 tenant_id = 1[(gogoproto.customname) = "TenantID"];
 }
 
-// EnsureEndpointResponse is empty and indicates that the server processed the
+// EnsurePodResponse is empty and indicates that the server processed the
 // request.
-message EnsureEndpointResponse {
+message EnsurePodResponse {
 }
 
-// Endpoint contains the information about a tenant endpoint. Most often it is a
+// Pod contains the information about a tenant pod. Most often it is a
 // combination of an ip address and port, e.g. 132.130.1.11:34576.
-message Endpoint {
-  // IP is the ip and port combo identifying the tenant endpoint.
-  string IP = 1[(gogoproto.customname) = "IP"];
+message Pod {
+  // Addr is the ip and port combo identifying the tenant pod.
+  string Addr = 1;
 }
 
-// ListEndpointsResponse is sent back as a result of requesting the list of
-// endpoints for a given tenant.
-message ListEndpointsResponse {
-  // Endpoints is the list of endpoints currently active for the requested
+// ListPodsResponse is sent back as a result of requesting the list of
+// pods for a given tenant.
+message ListPodsResponse {
+  // Pods is the list of pods currently active for the requested
   // tenant.
-  repeated Endpoint endpoints = 1;
+  repeated Pod pods = 1;
 }
 
 // GetTenantRequest is used by a client to request from the sever metadata
@@ -86,20 +86,20 @@ message GetTenantResponse {
 }
 
 // Directory specifies a service that keeps track and manages tenant backends,
-// related metadata and their endpoints.
+// related metadata and their pods.
 service Directory {
-  // ListEndpoints is used to query the server for the list of current endpoints
+  // ListPods is used to query the server for the list of current pods
   // of a given tenant.
-  rpc ListEndpoints(ListEndpointsRequest) returns (ListEndpointsResponse);
-  // WatchEndpoints is used to get a stream, that is used to receive notifications
+  rpc ListPods(ListPodsRequest) returns (ListPodsResponse);
+  // WatchPods is used to get a stream, that is used to receive notifications
   // about changes in tenant backend's state - added, modified and deleted.
-  rpc WatchEndpoints(WatchEndpointsRequest) returns (stream WatchEndpointsResponse);
-  // EnsureEndpoint is used to ensure that a tenant's backend is active. If
+  rpc WatchPods(WatchPodsRequest) returns (stream WatchPodsResponse);
+  // EnsurePod is used to ensure that a tenant's backend is active. If
   // there is an active backend then the server doesn't have to do anything. If
   // there isn't an active backend, then the server has to bring a new one up.
-  // If the requested tenant does not exist, EnsureEndpoint returns a GRPC
+  // If the requested tenant does not exist, EnsurePod returns a GRPC
   // NotFound error.
-  rpc EnsureEndpoint(EnsureEndpointRequest) returns (EnsureEndpointResponse);
+  rpc EnsurePod(EnsurePodRequest) returns (EnsurePodResponse);
   // GetTenant is used to fetch the metadata of a specific tenant. If the tenant
   // does not exist, GetTenant returns a GRPC NotFound error.
   rpc GetTenant(GetTenantRequest) returns (GetTenantResponse);


### PR DESCRIPTION
Previously we used endpoint to refer to the backend
processes. This is a bit verbose so we are changing it to pod to shorten
and reflect better the name used by k8s clusters. We also used IP in all
cases where pass combination of ip and port. This is now replaced by
addr so it matches more closely how GO calls the combination.

Release note: None