### PR TITLE
build: update go to 1.16.5

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -2580,13 +2580,7 @@ def go_deps():
         sum = "h1:umdPgllno4d03WCBsA0UIwzGIJYV8FfV4325kOYIhBU=",
         version = "v1.0.0",
     )
-    go_repository(
-        name = "com_github_lusis_go_slackbot",
-        build_file_proto_mode = "disable_global",
-        importpath = "github.com/lusis/go-slackbot",
-        sum = "h1:AsEBgzv3DhuYHI/GiQh2HxvTP71HCCE9E/tzGUzGdtU=",
-        version = "v0.0.0-20180109053408-401027ccfef5",
-    )
+
     go_repository(
         name = "com_github_lusis_slack_test",
         build_file_proto_mode = "disable_global",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -27,7 +27,7 @@ http_archive(
 # repo.
 git_repository(
     name = "bazel_gazelle",
-    commit = "e9091445339de2ba7c01c3561f751b64a7fab4a5",
+    commit = "d038863ba2e096792c6bb6afca31f6514f1aeecd",
     remote = "https://github.com/bazelbuild/bazel-gazelle",
 )
 
@@ -108,7 +108,7 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_depe
 
 go_rules_dependencies()
 
-go_register_toolchains(go_version = "1.15.11")
+go_register_toolchains(go_version = "1.16.5")
 
 # Configure nodeJS.
 load("@build_bazel_rules_nodejs//:index.bzl", "yarn_install")

--- a/build/README.md
+++ b/build/README.md
@@ -107,16 +107,16 @@ back to this document and perform these steps:
 
 * [ ] Adjust the Pebble tests to run in new version.
 * [ ] Adjust version in Docker image ([source](./builder/Dockerfile)).
+* [ ] Adjust version in the TeamCity agent image ([setup script](./packer/teamcity-agent.sh))
 * [ ] Rebuild and push the Docker image (following [Basic Process](#basic-process))
 * [ ] Bump the version in `WORKSPACE` under `go_register_toolchains`. You may need to bump [rules_go](https://github.com/bazelbuild/rules_go/releases).
 * [ ] Bump the version in `builder.sh` accordingly ([source](./builder.sh#L6)).
 * [ ] Bump the version in `go-version-check.sh` ([source](./go-version-check.sh)), unless bumping to a new patch release.
 * [ ] Bump the go version in `go.mod`. You may also need to rerun `make vendor_rebuild` if vendoring has changed.
-* [ ] Bump the default installed version of Go in `bootstrap-debian.sh` ([source](./bootstrap/bootstrap-debian.sh#L40-42)).
+* [ ] Bump the default installed version of Go in `bootstrap-debian.sh` ([source](./bootstrap/bootstrap-debian.sh)).
 * [ ] Replace other mentions of the older version of go (grep for `golang:<old_version>` and `go<old_version>`).
 * [ ] Update the `builder.dockerImage` parameter in the TeamCity [`Cockroach`](https://teamcity.cockroachdb.com/admin/editProject.html?projectId=Cockroach&tab=projectParams) and [`Internal`](https://teamcity.cockroachdb.com/admin/editProject.html?projectId=Internal&tab=projectParams) projects.
-* [ ] Adjust `GO_VERSION` in the TeamCity agent image ([setup script](./packer/teamcity-agent.sh))
-  and ask the Developer Infrastructure team to deploy new images.
+* [ ] Ask the Developer Infrastructure team to deploy new TeamCity agent images according to [packer/README.md](./packer/README.md)
 
 You can test the new builder image in TeamCity by using the custom parameters
 UI (the "..." icon next to the "Run" button) to verify the image before

--- a/build/STRINGER.bzl
+++ b/build/STRINGER.bzl
@@ -12,7 +12,8 @@ def stringer(src, typ, name):
       cmd = """
          GO_REL_PATH=`dirname $(location @go_sdk//:bin/go)`
          GO_ABS_PATH=`cd $$GO_REL_PATH && pwd`
-         env PATH=$$GO_ABS_PATH HOME=$(GENDIR) \
+         # Set GOPATH to something to workaround https://github.com/golang/go/issues/43938
+         env PATH=$$GO_ABS_PATH HOME=$(GENDIR) GOPATH=/nonexist-gopath \
          $(location @org_golang_x_tools//cmd/stringer:stringer) -output=$@ -type={} $<
       """.format(typ),
       tools = [

--- a/build/bootstrap/bootstrap-debian.sh
+++ b/build/bootstrap/bootstrap-debian.sh
@@ -46,9 +46,9 @@ sudo tar -C /usr -zxf /tmp/cmake.tgz && rm /tmp/cmake.tgz
 
 # Install Go.
 trap 'rm -f /tmp/go.tgz' EXIT
-curl -fsSL https://dl.google.com/go/go1.15.11.linux-amd64.tar.gz > /tmp/go.tgz
+curl -fsSL https://dl.google.com/go/go1.16.5.linux-amd64.tar.gz > /tmp/go.tgz
 sha256sum -c - <<EOF
-8825b72d74b14e82b54ba3697813772eb94add3abf70f021b6bdebe193ed01ec /tmp/go.tgz
+b12c23023b68de22f74c0524f10b753e7b08b1504cb7e417eccebdd3fae49061 /tmp/go.tgz
 EOF
 sudo tar -C /usr/local -zxf /tmp/go.tgz && rm /tmp/go.tgz
 

--- a/build/builder.sh
+++ b/build/builder.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 image=cockroachdb/builder
-version=20210604-193254
+version=20210616-013156
 
 function init() {
   docker build --tag="${image}" "$(dirname "${0}")/builder"

--- a/build/builder/Dockerfile
+++ b/build/builder/Dockerfile
@@ -112,8 +112,8 @@ RUN curl -fsSL https://github.com/Kitware/CMake/releases/download/v3.20.3/cmake-
 # releases of Go will no longer be run in CI once it is changed. Consider
 # bumping the minimum allowed version of Go in /build/go-version-check.sh.
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends golang \
- && curl -fsSL https://storage.googleapis.com/golang/go1.15.11.src.tar.gz -o golang.tar.gz \
- && echo 'f25b2441d4c76cf63cde94d59bab237cc33e8a2a139040d904c8630f46d061e5 golang.tar.gz' | sha256sum -c - \
+ && curl -fsSL https://storage.googleapis.com/golang/go1.16.5.src.tar.gz -o golang.tar.gz \
+ && echo '7bfa7e5908c7cc9e75da5ddf3066d7cbcf3fd9fa51945851325eebc17f50ba80 golang.tar.gz' | sha256sum -c - \
  && tar -C /usr/local -xzf golang.tar.gz \
  && rm golang.tar.gz \
  && cd /usr/local/go/src \

--- a/build/go-version-check.sh
+++ b/build/go-version-check.sh
@@ -6,9 +6,8 @@
 # To bump the required version of Go, edit the appropriate variables:
 
 required_version_major=1
-minimum_version_minor=15
-minimum_version_15_patch=10 # update to 11 when issue #63836 is addressed
-minimum_version_16_patch=3
+minimum_version_minor=16
+minimum_version_16_patch=5
 
 go=${1-go}
 

--- a/build/packer/teamcity-agent.sh
+++ b/build/packer/teamcity-agent.sh
@@ -42,9 +42,9 @@ apt-get install --yes \
   pass \
   unzip
 
-curl -fsSL https://dl.google.com/go/go1.15.11.linux-amd64.tar.gz > /tmp/go.tgz
+curl -fsSL https://dl.google.com/go/go1.16.5.linux-amd64.tar.gz > /tmp/go.tgz
 sha256sum -c - <<EOF
-8825b72d74b14e82b54ba3697813772eb94add3abf70f021b6bdebe193ed01ec /tmp/go.tgz
+b12c23023b68de22f74c0524f10b753e7b08b1504cb7e417eccebdd3fae49061 /tmp/go.tgz
 EOF
 tar -C /usr/local -zxf /tmp/go.tgz && rm /tmp/go.tgz
 

--- a/build/teamcity-verify-archive.sh
+++ b/build/teamcity-verify-archive.sh
@@ -32,7 +32,7 @@ run docker run \
   --rm \
   --volume="$(cd "$(dirname "$0")" && pwd):/work:ro" \
   --workdir="/work" \
-  golang:1.15-buster ./verify-archive.sh
+  golang:1.16-buster ./verify-archive.sh
 tc_end_block "Test archive"
 
 tc_start_block "Clean up"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cockroachdb/cockroach
 
-go 1.15
+go 1.16
 
 require (
 	cloud.google.com/go/storage v1.10.0
@@ -110,7 +110,6 @@ require (
 	github.com/lightstep/lightstep-tracer-go v0.24.0
 	github.com/linkedin/goavro/v2 v2.9.8
 	github.com/lufia/iostat v1.0.0
-	github.com/lusis/go-slackbot v0.0.0-20180109053408-401027ccfef5 // indirect
 	github.com/lusis/slack-test v0.0.0-20190426140909-c40012f20018 // indirect
 	github.com/maruel/panicparse v1.1.2-0.20180806203336-f20d4c4d746f
 	github.com/marusama/semaphore v0.0.0-20190110074507-6952cef993b2

--- a/go.sum
+++ b/go.sum
@@ -935,8 +935,6 @@ github.com/linkedin/goavro/v2 v2.9.8 h1:jN50elxBsGBDGVDEKqUlDuU1cFwJ11K/yrJCBMe/
 github.com/linkedin/goavro/v2 v2.9.8/go.mod h1:UgQUb2N/pmueQYH9bfqFioWxzYCZXSfF8Jw03O5sjqA=
 github.com/lufia/iostat v1.0.0 h1:umdPgllno4d03WCBsA0UIwzGIJYV8FfV4325kOYIhBU=
 github.com/lufia/iostat v1.0.0/go.mod h1:lRgtFVamD7L7GaXOSwBiuXMwU3Aicfn5h66LVs4u2SA=
-github.com/lusis/go-slackbot v0.0.0-20180109053408-401027ccfef5 h1:AsEBgzv3DhuYHI/GiQh2HxvTP71HCCE9E/tzGUzGdtU=
-github.com/lusis/go-slackbot v0.0.0-20180109053408-401027ccfef5/go.mod h1:c2mYKRyMb1BPkO5St0c/ps62L4S0W2NAkaTXj9qEI+0=
 github.com/lusis/slack-test v0.0.0-20190426140909-c40012f20018 h1:MNApn+Z+fIT4NPZopPfCc1obT6aY3SVM6DOctz1A9ZU=
 github.com/lusis/slack-test v0.0.0-20190426140909-c40012f20018/go.mod h1:sFlOUpQL1YcjhFVXhg1CG8ZASEs/Mf1oVb6H75JL/zg=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
@@ -1862,7 +1860,6 @@ gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/square/go-jose.v2 v2.2.2/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/square/go-jose.v2 v2.5.1 h1:7odma5RETjNHWJnR32wx8t+Io4djHE1PqxCFx3iiZ2w=
 gopkg.in/square/go-jose.v2 v2.5.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
-gopkg.in/src-d/go-billy.v4 v4.3.0 h1:KtlZ4c1OWbIs4jCv5ZXrTqG8EQocr0g/d4DjNg70aek=
 gopkg.in/src-d/go-billy.v4 v4.3.0/go.mod h1:tm33zBoOwxjYHZIE+OV8bxTWFMJLrconzFMd38aARFk=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=

--- a/pkg/acceptance/compose/gss/psql/Dockerfile
+++ b/pkg/acceptance/compose/gss/psql/Dockerfile
@@ -1,9 +1,10 @@
 # Build the test binary in a multistage build.
-FROM golang:1.15 AS builder
+FROM golang:1.16 AS builder
 WORKDIR /workspace
 COPY . .
-RUN go get -d -t -tags gss_compose
-RUN go test -v -c -tags gss_compose -o gss.test
+# go 1.16 requires go.mod to be present unless GO111MODULE is set to off
+RUN GO111MODULE=off go get -d -t -tags gss_compose
+RUN GO111MODULE=off go test -v -c -tags gss_compose -o gss.test
 
 # Copy the test binary to an image with psql and krb installed.
 FROM postgres:11

--- a/pkg/build/bazel/bazel.go
+++ b/pkg/build/bazel/bazel.go
@@ -59,8 +59,13 @@ func SetGoEnv() {
 	if err != nil {
 		panic(err)
 	}
-
 	if err := os.Setenv("PATH", fmt.Sprintf("%s%c%s", filepath.Dir(gobin), os.PathListSeparator, os.Getenv("PATH"))); err != nil {
+		panic(err)
+	}
+	// GOPATH has to be set to some value (not equal to GOROOT) in order for `go env` to work.
+	// See https://github.com/golang/go/issues/43938 for the details.
+	// Specify a name under the system TEMP/TMP directory in order to be platform agnostic.
+	if err := os.Setenv("GOPATH", filepath.Join(os.TempDir(), "nonexist-gopath")); err != nil {
 		panic(err)
 	}
 	if err := os.Setenv("GOROOT", filepath.Dir(filepath.Dir(gobin))); err != nil {

--- a/pkg/cmd/roachprod/docker/Dockerfile
+++ b/pkg/cmd/roachprod/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15
+FROM golang:1.16
 WORKDIR /build
 COPY . .
 RUN ["/build/build.sh"]

--- a/pkg/cmd/roachtest/go_helpers.go
+++ b/pkg/cmd/roachtest/go_helpers.go
@@ -39,13 +39,13 @@ func installGolang(ctx context.Context, t *test, c Cluster, node option.NodeList
 	}
 
 	if err := repeatRunE(
-		ctx, t, c, node, "download go", `curl -fsSL https://dl.google.com/go/go1.15.11.linux-amd64.tar.gz > /tmp/go.tgz`,
+		ctx, t, c, node, "download go", `curl -fsSL https://dl.google.com/go/go1.16.5.linux-amd64.tar.gz > /tmp/go.tgz`,
 	); err != nil {
 		t.Fatal(err)
 	}
 	if err := repeatRunE(
 		ctx, t, c, node, "verify tarball", `sha256sum -c - <<EOF
-8825b72d74b14e82b54ba3697813772eb94add3abf70f021b6bdebe193ed01ec /tmp/go.tgz
+b12c23023b68de22f74c0524f10b753e7b08b1504cb7e417eccebdd3fae49061 /tmp/go.tgz
 EOF`,
 	); err != nil {
 		t.Fatal(err)

--- a/pkg/cmd/urlcheck/BUILD.bazel
+++ b/pkg/cmd/urlcheck/BUILD.bazel
@@ -1,3 +1,4 @@
+# gazelle:resolve go github.com/cockroachdb/cockroach/pkg/cmd/urlcheck/lib/urlcheck //pkg/cmd/urlcheck/lib/urlcheck:go_default_library
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
@@ -5,7 +6,7 @@ go_library(
     srcs = ["main.go"],
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/urlcheck",
     visibility = ["//visibility:private"],
-    deps = ["//pkg/cmd/urlcheck/lib/urlcheck"],
+    deps = ["//pkg/cmd/urlcheck/lib/urlcheck:go_default_library"],
 )
 
 go_binary(

--- a/pkg/sql/opt/BUILD.bazel
+++ b/pkg/sql/opt/BUILD.bazel
@@ -114,7 +114,8 @@ genrule(
       cp $(location rule_name.go) `dirname $(location :gen-rulenames)`/rule_name.go
       GO_REL_PATH=`dirname $(location @go_sdk//:bin/go)`
       GO_ABS_PATH=`cd $$GO_REL_PATH && pwd`
-      env PATH=$$GO_ABS_PATH HOME=$(GENDIR) \
+      # Set GOPATH to something to workaround https://github.com/golang/go/issues/43938
+      env PATH=$$GO_ABS_PATH HOME=$(GENDIR) GOPATH=/nonexist-gopath \
       $(location @org_golang_x_tools//cmd/stringer:stringer) -output=$@ \
       -type=RuleName `dirname $(location :gen-rulenames)`/rule_name.go $(location :gen-rulenames)
     """,

--- a/pkg/sql/schemachange/BUILD.bazel
+++ b/pkg/sql/schemachange/BUILD.bazel
@@ -58,7 +58,8 @@ genrule(
     cmd = """
        GO_REL_PATH=`dirname $(location @go_sdk//:bin/go)`
        GO_ABS_PATH=`cd $$GO_REL_PATH && pwd`
-       env PATH=$$GO_ABS_PATH HOME=$(GENDIR) \
+       # Set GOPATH to something to workaround https://github.com/golang/go/issues/43938
+       env PATH=$$GO_ABS_PATH HOME=$(GENDIR) GOPATH=/nonexist-gopath \
        $(location @org_golang_x_tools//cmd/stringer:stringer) -output=$@ -type=ColumnConversionKind -trimprefix ColumnConversion $<
     """,
     exec_tools = [

--- a/pkg/sql/schemachanger/scpb/BUILD.bazel
+++ b/pkg/sql/schemachanger/scpb/BUILD.bazel
@@ -69,7 +69,8 @@ genrule(
     cmd = """
        GO_REL_PATH=`dirname $(location @go_sdk//:bin/go)`
        GO_ABS_PATH=`cd $$GO_REL_PATH && pwd`
-       env PATH=$$GO_ABS_PATH HOME=$(GENDIR) \
+       # Set GOPATH to something to workaround https://github.com/golang/go/issues/43938
+       env PATH=$$GO_ABS_PATH HOME=$(GENDIR) GOPATH=/nonexist-gopath \
        $(location @org_golang_x_tools//cmd/stringer:stringer) -output=$@ -type=Attribute -trimprefix Attribute $<
     """,
     exec_tools = [

--- a/pkg/util/encoding/BUILD.bazel
+++ b/pkg/util/encoding/BUILD.bazel
@@ -82,8 +82,9 @@ genrule(
     cmd = """
        GO_REL_PATH=`dirname $(location @go_sdk//:bin/go)`
        GO_ABS_PATH=`cd $$GO_REL_PATH && pwd`
+       # Set GOPATH to something to workaround https://github.com/golang/go/issues/43938
        sed -e 's/type Type encodingtype.T/type Type int/' $(location encoding.go) > encoding_tmp.go && \
-       env PATH=$$GO_ABS_PATH HOME=$(GENDIR) \
+       env PATH=$$GO_ABS_PATH HOME=$(GENDIR) GOPATH=/nonexist-gopath \
          $(location @org_golang_x_tools//cmd/stringer:stringer) -output=$@ -type=Type encoding_tmp.go
     """,
     exec_tools = [

--- a/pkg/util/goschedstats/BUILD.bazel
+++ b/pkg/util/goschedstats/BUILD.bazel
@@ -4,7 +4,7 @@ go_library(
     name = "goschedstats",
     srcs = [
         "runnable.go",
-        "runtime_go1.15.go",
+        "runtime_go1.16.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/util/goschedstats",
     visibility = ["//visibility:public"],

--- a/pkg/util/goschedstats/runnable.go
+++ b/pkg/util/goschedstats/runnable.go
@@ -48,7 +48,7 @@ func RecentNormalizedRunnableGoroutines() float64 {
 }
 
 // If you get a compilation error here, the Go version you are using is not
-// supported by this package. Cross-check the structures in runtime_go1.15.go
+// supported by this package. Cross-check the structures in runtime_go1.16.go
 // against those in the new Go's runtime, and if they are still accurate adjust
 // the build tag in that file to accept the version. If they don't match, you
 // will have to add a new version of that file.

--- a/pkg/util/goschedstats/runtime_go1.16.go
+++ b/pkg/util/goschedstats/runtime_go1.16.go
@@ -9,10 +9,10 @@
 // licenses/APL.txt.
 //
 // The structure definitions in this file have been cross-checked against
-// go1.15.5, go1.16, and go1.17beta1 (needs revalidation). Before allowing
-// newer versions, please check that the structures still match with those
-// in go/src/runtime.
-// +build gc,go1.15,!go1.18
+// go1.16, and go1.17beta1 (needs revalidation). Before allowing newer
+// versions, please check that the structures still match with those in
+// go/src/runtime.
+// +build gc,go1.16,!go1.18
 
 package goschedstats
 


### PR DESCRIPTION
Fixes #66404

* Upgrade gazelle to latest version. Go 1.16 updates `go.sum` when
  gazelle calls `go download`. The new version fixes this issue. See
  https://github.com/bazelbuild/bazel-gazelle/pull/1015.
* Remove line references in `build/README.md`, because they are not
  stable.
* Set `GOPATH` in various places for bazel based builds and tests in
  order to work round the case when `go env` fails when `GOPATH` and
  `HOME` are unset. See https://github.com/golang/go/issues/43938 for
  the details.
* Set `GO111MODULE=off` in `pkg/acceptance/compose/gss/psql/Dockerfile`.
  Go 1.16 requires `go.mod` in order to build and test the module
  without `GO111MODULE=off`.

Checklist:

* [x] Adjust the Pebble tests to run in new version.
* [x] Adjust version in Docker image ([source](./builder/Dockerfile)).
* [x] Adjust version in the TeamCity agent image ([setup script](./packer/teamcity-agent.sh))
* [x] Rebuild and push the Docker image (following [Basic Process](#basic-process))
* [x] Bump the version in `WORKSPACE` under `go_register_toolchains`. You may need to bump [rules_go](https://github.com/bazelbuild/rules_go/releases).
* [x] Bump the version in `builder.sh` accordingly ([source](./builder.sh#L6)).
* [x] Bump the version in `go-version-check.sh` ([source](./go-version-check.sh)), unless bumping to a new patch release.
* [x] Bump the go version in `go.mod`. You may also need to rerun `make vendor_rebuild` if vendoring has changed.
* [x] Bump the default installed version of Go in `bootstrap-debian.sh` ([source](./bootstrap/bootstrap-debian.sh)).
* [x] Replace other mentions of the older version of go (grep for `golang:<old_version>` and `go<old_version>`).
* [x] Update the `builder.dockerImage` parameter in the TeamCity [`Cockroach`](https://teamcity.cockroachdb.com/admin/editProject.html?projectId=Cockroach&tab=projectParams) and [`Internal`](https://teamcity.cockroachdb.com/admin/editProject.html?projectId=Internal&tab=projectParams) projects.
* [ ] Ask the Developer Infrastructure team to deploy new TeamCity agent images according to [packer/README.md](./packer/README.md)

Release note: None