### PR TITLE
Prototype for instance id initialization and usage - NO MERGE

### DIFF
--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -134,6 +134,8 @@ go_library(
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/sql/sessiondatapb",
+        "//pkg/sql/sqlinstance",
+        "//pkg/sql/sqlinstance/instancemanager",
         "//pkg/sql/sqlliveness",
         "//pkg/sql/sqlliveness/slprovider",
         "//pkg/sql/sqlutil",

--- a/pkg/sql/sqlinstance/BUILD.bazel
+++ b/pkg/sql/sqlinstance/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "sqlinstance",
+    srcs = ["sqlinstance.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/sql/sqlinstance",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/base",
+        "//pkg/sql/sqlliveness",
+    ],
+)

--- a/pkg/sql/sqlinstance/instancemanager/BUILD.bazel
+++ b/pkg/sql/sqlinstance/instancemanager/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "instancemanager",
+    srcs = ["instancemanager.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/sql/sqlinstance/instancemanager",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/base",
+        "//pkg/settings",
+        "//pkg/settings/cluster",
+        "//pkg/sql/sqlinstance",
+        "//pkg/sql/sqlliveness",
+        "//pkg/util/cache",
+        "//pkg/util/stop",
+        "//pkg/util/syncutil",
+    ],
+)

--- a/pkg/sql/sqlinstance/instancemanager/instancemanager.go
+++ b/pkg/sql/sqlinstance/instancemanager/instancemanager.go
@@ -1,0 +1,118 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package instance provides implementation to initialize unique
+// instance ids for SQL pods and associate them with network
+// addresses
+
+package instancemanager
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlinstance"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
+	"github.com/cockroachdb/cockroach/pkg/util/cache"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+)
+
+// SQLInstance implements the SQLInstance interface
+// defined in the sqlinstance package
+type SQLInstance struct {
+	id base.SQLInstanceID
+}
+
+// InstanceID returns the instance ID
+// associated with the SQL server
+func (s *SQLInstance) InstanceID() base.SQLInstanceID {
+	return s.id
+}
+
+// CacheSize governs the size of the cache used to
+// cache sql instance address mappings
+var CacheSize = settings.RegisterIntSetting(
+	"server.sqlinstance.storage_instance_cache_size",
+	"number of instance-address entries to store in the LRU",
+	512)
+
+type instancemanager struct {
+	settings *cluster.Settings
+	stopper  *stop.Stopper
+	mu       struct {
+		syncutil.Mutex
+		activeInstances *cache.UnorderedCache
+		instanceIDCtr   int
+	}
+}
+
+// NewSQLInstanceManager creates a new instance manager for managing SQL instances
+func NewSQLInstanceManager(
+	settings *cluster.Settings, stopper *stop.Stopper,
+) sqlinstance.InstanceManager {
+	i := &instancemanager{
+		settings: settings,
+		stopper:  stopper,
+	}
+	cacheConfig := cache.Config{
+		Policy: cache.CacheLRU,
+		ShouldEvict: func(size int, key, value interface{}) bool {
+			return size > int(CacheSize.Get(&settings.SV))
+		},
+	}
+	i.mu.activeInstances = cache.NewUnorderedCache(cacheConfig)
+	i.mu.instanceIDCtr = 10001
+	return i
+}
+
+// CreateInstance creates a new SQL instance id
+func (i *instancemanager) CreateInstance(_ sqlliveness.SessionID) (sqlinstance.SQLInstance, error) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	newInstanceID := SQLInstance{
+		id: base.SQLInstanceID(i.mu.instanceIDCtr),
+	}
+
+	// TODO(rima): Add logic to init instance id using sqlinstance system table
+	return &newInstanceID, nil
+}
+
+// SetInstanceAddr sets the http address within the sqlinstance subsystem for
+// a given SQL instance id
+func (i *instancemanager) SetInstanceAddr(id base.SQLInstanceID, httpAddr string) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.mu.activeInstances.Add(id, httpAddr)
+	// TODO(rima): Add logic to update sqlinstance system table with the http addr
+}
+
+// ShutdownInstance will release the instance id with the sqlinstance system table
+// and shutdown the SQL server
+func (i *instancemanager) ShutdownInstance(ctx context.Context, _ sqlliveness.SessionID) {
+	// TODO(rima): Add logic to update entry in sqlinstance system table
+	i.stopper.Stop(ctx)
+}
+
+// GetInstanceAddr return the http address for a SQL instance id
+func (i *instancemanager) GetInstanceAddr(id base.SQLInstanceID) (httpAddr string, _ error) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if addr, ok := i.mu.activeInstances.Get(id); ok {
+		addr := addr.(string)
+		return addr, nil
+	}
+	// TODO (rima): Add logic to read from sqlinstance system table and add
+	// to cache
+	return "", fmt.Errorf("non existent instance id %d", id)
+}

--- a/pkg/sql/sqlinstance/sqlinstance.go
+++ b/pkg/sql/sqlinstance/sqlinstance.go
@@ -1,0 +1,49 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package sqlinstance provides interfaces to initialize unique
+// instance ids for SQL pods and resolve network addresses
+// for a pod given an instance id
+package sqlinstance
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
+)
+
+// AddressResolver resolves http address mapping
+// for a given SQL instance id
+type AddressResolver interface {
+	GetInstanceAddr(base.SQLInstanceID) (string, error)
+}
+
+// SQLInstance is a wrapper around the the SQLInstanceID
+// type
+type SQLInstance interface {
+	InstanceID() base.SQLInstanceID
+}
+
+// Writer interface exposes methods necessary to create
+// a new SQL instance id and associate an http address
+// with it
+type Writer interface {
+	CreateInstance(sqlliveness.SessionID) (SQLInstance, error)
+	SetInstanceAddr(base.SQLInstanceID, string)
+}
+
+// InstanceManager is a wrapper around the SQL instance
+// initialization and management subsystem
+type InstanceManager interface {
+	AddressResolver
+	Writer
+	ShutdownInstance(context.Context, sqlliveness.SessionID)
+}

--- a/pkg/sql/sqlliveness/slinstance/BUILD.bazel
+++ b/pkg/sql/sqlliveness/slinstance/BUILD.bazel
@@ -30,6 +30,7 @@ go_test(
     deps = [
         "//pkg/clusterversion",
         "//pkg/settings/cluster",
+        "//pkg/sql/sqlinstance/instancemanager",
         "//pkg/sql/sqlliveness",
         "//pkg/sql/sqlliveness/slstorage",
         "//pkg/util/hlc",

--- a/pkg/sql/sqlliveness/slprovider/BUILD.bazel
+++ b/pkg/sql/sqlliveness/slprovider/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/keys",
         "//pkg/kv",
+        "//pkg/kv/kvclient/kvtenant",
         "//pkg/settings/cluster",
         "//pkg/sql/sqlliveness",
         "//pkg/sql/sqlliveness/slinstance",


### PR DESCRIPTION
This outlines the interfaces for initializing a new instance
id and resolving http addresses for individual SQL pods.
As a part of this, we also move sqlliveness subsystem
initialization outside of the sqlserver prestart method
so as to be able to use it for instance id initialization.

The backing store for instance id will be a per tenant
system table. However, in this PR, we continue using
a hardcoded constant. This will be changed in a followup
PR which will define and use a system table to initialize
and store instance ids.

Release note: None