### PR TITLE
release-21.1: colbuilder: fix recently introduced bug in an edge case

### DIFF
--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -541,12 +541,8 @@ func (r opResult) makeDiskBackedSorterConstructor(
 // createAndWrapRowSource takes a processor spec, creating the row source and
 // wrapping it using wrapRowSources. Note that the post process spec is included
 // in the processor creation, so make sure to clear it if it will be inspected
-// again. NewColOperatorResult is updated with the new OutputTypes and the
-// resulting Columnarizer if there is no error. The result is also annotated as
-// streaming because the resulting operator is not a buffering operator (even if
-// it is a buffering processor). This is not a problem for memory accounting
-// because each processor does that on its own, so the used memory will be
-// accounted for.
+// again. opResult is updated with the new ColumnTypes and the resulting
+// Columnarizer if there is no error.
 // - causeToWrap is an error that prompted us to wrap a processor core into the
 // vectorized plan (for example, it could be an unsupported processor core, an
 // unsupported function, etc).
@@ -1437,14 +1433,11 @@ func (r opResult) wrapPostProcessSpec(
 		Post:        *post,
 		ResultTypes: resultTypes,
 	}
-	if err := r.createAndWrapRowSource(
+	// createAndWrapRowSource updates r.ColumnTypes accordingly.
+	return r.createAndWrapRowSource(
 		ctx, flowCtx, args, []colexecop.Operator{r.Op}, [][]*types.T{r.ColumnTypes},
 		noopSpec, factory, causeToWrap,
-	); err != nil {
-		return err
-	}
-	r.ColumnTypes = resultTypes
-	return nil
+	)
 }
 
 // planPostProcessSpec plans the post processing stage specified in post on top

--- a/pkg/sql/logictest/testdata/logic_test/dist_vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/dist_vectorize
@@ -484,3 +484,29 @@ SELECT CASE WHEN a>1 THEN b*2 ELSE b*10 END FROM t1
 ----
 NULL
 NULL
+
+# Regression test for the wrapped row-execution processor not satisfying the
+# width of an integer column during a cast and the vectorized engine not
+# performing the cast to the integer of the desired width (#66306).
+statement ok
+CREATE TABLE t66306 (k DECIMAL PRIMARY KEY);
+INSERT INTO t66306 VALUES (1);
+ALTER TABLE t66306 EXPERIMENTAL_RELOCATE VALUES (ARRAY[2], 1);
+
+query II
+SELECT 1::INT2, k::INT8 FROM t66306;
+----
+1 1
+
+# Sanity check that the wrapped processor is planned for the query above. If it
+# no longer is, we should adjust the query here and above.
+query T
+EXPLAIN (VEC) SELECT 1::INT2, k::INT8 FROM t66306;
+----
+│
+├ Node 1
+│ └ *colrpc.Inbox
+└ Node 2
+  └ *colrpc.Outbox
+    └ *colexecbase.castInt64Int16Op
+      └ *rowexec.tableReader


### PR DESCRIPTION
Backport 1/1 commits from #66346.

/cc @cockroachdb/release

---

Our typing system is pretty broken, especially when it comes to the
integers of non-default width. The row-execution processors don't
respect the width of integers and always operate on INT8; however, the
vectorized engine respects the widths. We work around this complication
by having to plan casts occasionally.

In eb24f95 we introduced a subtle bug
when a wrapped noop processor is planned by updating `ColumnTypes` to
the desired once assuming that the noop processor always is able to
satisfy the desired schema. But this isn't true for integers of
different widths. Before that change we would correct plan vectorized
casts to get integers of the desired widths, but that commit overwrote
the actual schema with the desired one, so we no longer knew we needed
a cast. This is now fixed.

Fixes: #66306.

Release note (bug fix): CockroachDB could previously return an internal
error under rare circumstances when a query involving integers of widths
2 or 4 was executed in the distributed manner via the vectorized engine.
The bug is a regression in 21.1.2 release (which is the only stable
release containing this bug).
