### PR TITLE
release-21.1: cmd/roachtest: fix dependencies for typeorm

### DIFF
--- a/pkg/cmd/roachtest/typeorm.go
+++ b/pkg/cmd/roachtest/typeorm.go
@@ -64,7 +64,7 @@ func registerTypeORM(r *testRegistry) {
 			node,
 			"install dependencies",
 			`sudo apt-get -qq install make python3 libpq-dev python-dev gcc g++ `+
-				`python-software-properties build-essential`,
+				`software-properties-common build-essential`,
 		); err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Backport 1/1 commits from #63902.

/cc @cockroachdb/release

Resolves #62650

---

The update to the roachtest ubuntu version requires a software package
tweak from python-software-properties to software-properties-common.

Release note: None

Resolves #63895 
