### PR TITLE
sqlproxyccl: fix DNS resolution logic in backendLookupAddr

### DIFF
--- a/pkg/ccl/sqlproxyccl/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/base",
         "//pkg/ccl/sqlproxyccl/cache",
         "//pkg/ccl/sqlproxyccl/denylist",
         "//pkg/ccl/sqlproxyccl/idle",
@@ -48,6 +49,7 @@ go_test(
     size = "small",
     srcs = [
         "authentication_test.go",
+        "backend_dialer_test.go",
         "frontend_admitter_test.go",
         "main_test.go",
         "proxy_handler_test.go",

--- a/pkg/ccl/sqlproxyccl/backend_dialer_test.go
+++ b/pkg/ccl/sqlproxyccl/backend_dialer_test.go
@@ -1,0 +1,63 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package sqlproxyccl
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestBackendLookupAddr(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+
+	// Note that this list isn't exhaustive. We only cover the common cases.
+	// backendLookupAddr is only temporary, and will go away soon.
+	testData := []struct {
+		in          string
+		expected    string
+		expectedErr string
+	}{
+		// Invalid routing rules.
+		{"foobar", "", "missing port in address"},
+		{"foobar:", "", "no port was provided for 'foobar:'"},
+		{":80", "", "no host was provided for ':80'"},
+		{":", "", "no host was provided for ':'"},
+
+		// Invalid hosts.
+		{"nonexistent.example.com:26257", "", "no such host"},
+		{"333.333.333.333:26257", "", "no such host"},
+
+		// Valid hosts.
+		{"127.0.0.1:80", "127.0.0.1:80", ""},
+		{"localhost:80", "127.0.0.1:80", ""},
+	}
+	for i, test := range testData {
+		t.Run(fmt.Sprintf("%d/%s", i, test.in), func(t *testing.T) {
+			addr, err := backendLookupAddr(ctx, test.in)
+			if err != nil {
+				if !testutils.IsError(err, test.expectedErr) {
+					t.Fatalf("expected error %q, got %v", test.expectedErr, err)
+				}
+				return
+			}
+			if test.expectedErr != "" {
+				t.Fatalf("expected error %q, got success", test.expectedErr)
+			}
+			if addr != test.expected {
+				t.Fatalf("expected %q,\ngot %q", test.expected, addr)
+			}
+		})
+	}
+}

--- a/pkg/ccl/sqlproxyccl/proxy_handler.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler.go
@@ -267,6 +267,7 @@ func (handler *proxyHandler) handle(ctx context.Context, incomingConn *proxyConn
 			}
 
 			// Remap error for external consumption.
+			log.Errorf(ctx, "could not retrieve outgoing address: %v", err.Error())
 			err = newErrorf(
 				codeParamsRoutingFailed, "cluster %s-%d not found", clusterName, tenID.ToUint64())
 			break
@@ -417,7 +418,7 @@ func (handler *proxyHandler) outgoingAddress(
 	addr := strings.ReplaceAll(
 		handler.RoutingRule, "{{clusterName}}", fmt.Sprintf("%s-%d", name, tenID.ToUint64()),
 	)
-	_, err := backendLookupAddr(addr)
+	_, err := backendLookupAddr(ctx, addr)
 	if err != nil {
 		return "", status.Error(codes.NotFound, err.Error())
 	}

--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -90,7 +90,7 @@ func TestBackendDownRetry(t *testing.T) {
 	defer te.Close()
 
 	callCount := 0
-	defer testutils.TestingHook(&backendLookupAddr, func(addr string) (string, error) {
+	defer testutils.TestingHook(&backendLookupAddr, func(_ context.Context, addr string) (string, error) {
 		callCount++
 		if callCount >= 3 {
 			return "", errors.New("tenant not found")
@@ -559,7 +559,7 @@ func TestDirectoryConnect(t *testing.T) {
 	_, addr := newProxyServer(ctx, t, srv.Stopper(), opts)
 
 	t.Run("fallback when tenant not found", func(t *testing.T) {
-		defer testutils.TestingHook(&backendLookupAddr, func(addr string) (string, error) {
+		defer testutils.TestingHook(&backendLookupAddr, func(_ context.Context, addr string) (string, error) {
 			// Expect fallback.
 			require.Equal(t, srv.ServingSQLAddr(), addr)
 			return addr, nil
@@ -864,9 +864,9 @@ type tester struct {
 func newTester() *tester {
 	te := &tester{}
 
-	// Override default lookup function so that it does not use net.LookupAddr.
+	// Override default lookup function so that it does not use base.LookupAddr.
 	te.restoreBackendLookupAddr =
-		testutils.TestingHook(&backendLookupAddr, func(addr string) (string, error) {
+		testutils.TestingHook(&backendLookupAddr, func(ctx context.Context, addr string) (string, error) {
 			return addr, nil
 		})
 

--- a/pkg/cli/cliflags/flags_mt.go
+++ b/pkg/cli/cliflags/flags_mt.go
@@ -50,8 +50,10 @@ var (
 	}
 
 	RoutingRule = FlagInfo{
-		Name:        "routing-rule",
-		Description: "Routing rule for incoming connections. Use '{{clusterName}}' for substitution.",
+		Name: "routing-rule",
+		Description: `
+Routing rule for incoming connections. Use '{{clusterName}}' for substitution.
+This rule must include the port of the SQL pod.`,
 	}
 
 	DirectoryAddr = FlagInfo{


### PR DESCRIPTION
Previously, we were using net.LookupAddr in backendLookupAddr, but that was
incorrect since [net.LookupAddr](https://golang.org/pkg/net/#LookupAddr) is meant to perform a reverse lookup. The
intention was to resolve the address (e.g. foo-bar-2-0.cockroachdb:80) to an
IP. This patch fixes that by using base.LookupAddr instead, which will resolve
the given address/host to an IP address.

Note that the tests added are not exhaustive since the code in
backendLookupAddr will eventually go away.

Release note: None