### PR TITLE
tree: don't normalize tuple labels

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/json_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/json_builtins
@@ -1178,6 +1178,11 @@ SELECT row_to_json(row(1,'foo')), row_to_json(NULL), row_to_json(row())
 ----
 {"f1": 1, "f2": "foo"}  NULL  {}
 
+query T
+SELECT row_to_json(x) FROM (SELECT 1 AS "OnE", 2 AS "tO_") x
+----
+{"OnE": 1, "tO_": 2}
+
 
 # TODO(jordan,radu): this should also work without the .*.
 query T

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -16,7 +16,6 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
-	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -1460,9 +1459,7 @@ func (expr *Tuple) TypeCheck(
 	// Copy the labels if there are any.
 	if len(expr.Labels) > 0 {
 		labels = make([]string, len(expr.Labels))
-		for i := range expr.Labels {
-			labels[i] = lexbase.NormalizeName(expr.Labels[i])
-		}
+		copy(labels, expr.Labels)
 	}
 	expr.typ = types.MakeLabeledTuple(contents, labels)
 	return expr, nil


### PR DESCRIPTION
Resolves: #66541

Release note (bug fix): Previously, rows treated as tuples in functions
such as `row_to_json` may have had their keys normalized to lowercase,
instead of being preserved in the original casing as per PostgreSQL.
This is now fixed.