### PR TITLE
util: Fix a duplicated comment on the documentation

### DIFF
--- a/docs/generated/logging.md
+++ b/docs/generated/logging.md
@@ -73,8 +73,7 @@ layer events (RocksDB/Pebble).
 
 The `SESSIONS` channel is used to report client network activity when enabled via
 the `server.auth_log.sql_connections.enabled` and/or
-`server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html)
-[cluster settings](cluster-settings.html):
+`server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html):
 
 - Connections opened/closed
 - Authentication events: logins, failed attempts

--- a/pkg/util/log/channel/channel_generated.go
+++ b/pkg/util/log/channel/channel_generated.go
@@ -46,8 +46,7 @@ const STORAGE = logpb.Channel_STORAGE
 
 // SESSIONS is used to report client network activity when enabled via
 // the `server.auth_log.sql_connections.enabled` and/or
-// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html)
-// [cluster settings](cluster-settings.html):
+// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html):
 //
 // - Connections opened/closed
 // - Authentication events: logins, failed attempts

--- a/pkg/util/log/log_channels_generated.go
+++ b/pkg/util/log/log_channels_generated.go
@@ -2085,8 +2085,7 @@ type loggerSessions struct{}
 //
 // The `SESSIONS` channel is used to report client network activity when enabled via
 // the `server.auth_log.sql_connections.enabled` and/or
-// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html)
-// [cluster settings](cluster-settings.html):
+// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html):
 //
 // - Connections opened/closed
 // - Authentication events: logins, failed attempts
@@ -2109,8 +2108,7 @@ var _ ChannelLogger = Sessions
 //
 // The `SESSIONS` channel is used to report client network activity when enabled via
 // the `server.auth_log.sql_connections.enabled` and/or
-// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html)
-// [cluster settings](cluster-settings.html):
+// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html):
 //
 // - Connections opened/closed
 // - Authentication events: logins, failed attempts
@@ -2133,8 +2131,7 @@ func (loggerSessions) Infof(ctx context.Context, format string, args ...interfac
 //
 // The `SESSIONS` channel is used to report client network activity when enabled via
 // the `server.auth_log.sql_connections.enabled` and/or
-// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html)
-// [cluster settings](cluster-settings.html):
+// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html):
 //
 // - Connections opened/closed
 // - Authentication events: logins, failed attempts
@@ -2157,8 +2154,7 @@ func (loggerSessions) VInfof(ctx context.Context, level Level, format string, ar
 //
 // The `SESSIONS` channel is used to report client network activity when enabled via
 // the `server.auth_log.sql_connections.enabled` and/or
-// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html)
-// [cluster settings](cluster-settings.html):
+// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html):
 //
 // - Connections opened/closed
 // - Authentication events: logins, failed attempts
@@ -2180,8 +2176,7 @@ func (loggerSessions) Info(ctx context.Context, msg string) {
 //
 // The `SESSIONS` channel is used to report client network activity when enabled via
 // the `server.auth_log.sql_connections.enabled` and/or
-// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html)
-// [cluster settings](cluster-settings.html):
+// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html):
 //
 // - Connections opened/closed
 // - Authentication events: logins, failed attempts
@@ -2202,8 +2197,7 @@ func (loggerSessions) InfofDepth(ctx context.Context, depth int, format string, 
 //
 // The `SESSIONS` channel is used to report client network activity when enabled via
 // the `server.auth_log.sql_connections.enabled` and/or
-// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html)
-// [cluster settings](cluster-settings.html):
+// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html):
 //
 // - Connections opened/closed
 // - Authentication events: logins, failed attempts
@@ -2226,8 +2220,7 @@ func (loggerSessions) Warningf(ctx context.Context, format string, args ...inter
 //
 // The `SESSIONS` channel is used to report client network activity when enabled via
 // the `server.auth_log.sql_connections.enabled` and/or
-// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html)
-// [cluster settings](cluster-settings.html):
+// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html):
 //
 // - Connections opened/closed
 // - Authentication events: logins, failed attempts
@@ -2250,8 +2243,7 @@ func (loggerSessions) VWarningf(ctx context.Context, level Level, format string,
 //
 // The `SESSIONS` channel is used to report client network activity when enabled via
 // the `server.auth_log.sql_connections.enabled` and/or
-// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html)
-// [cluster settings](cluster-settings.html):
+// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html):
 //
 // - Connections opened/closed
 // - Authentication events: logins, failed attempts
@@ -2273,8 +2265,7 @@ func (loggerSessions) Warning(ctx context.Context, msg string) {
 //
 // The `SESSIONS` channel is used to report client network activity when enabled via
 // the `server.auth_log.sql_connections.enabled` and/or
-// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html)
-// [cluster settings](cluster-settings.html):
+// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html):
 //
 // - Connections opened/closed
 // - Authentication events: logins, failed attempts
@@ -2295,8 +2286,7 @@ func (loggerSessions) WarningfDepth(ctx context.Context, depth int, format strin
 //
 // The `SESSIONS` channel is used to report client network activity when enabled via
 // the `server.auth_log.sql_connections.enabled` and/or
-// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html)
-// [cluster settings](cluster-settings.html):
+// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html):
 //
 // - Connections opened/closed
 // - Authentication events: logins, failed attempts
@@ -2320,8 +2310,7 @@ func (loggerSessions) Errorf(ctx context.Context, format string, args ...interfa
 //
 // The `SESSIONS` channel is used to report client network activity when enabled via
 // the `server.auth_log.sql_connections.enabled` and/or
-// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html)
-// [cluster settings](cluster-settings.html):
+// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html):
 //
 // - Connections opened/closed
 // - Authentication events: logins, failed attempts
@@ -2345,8 +2334,7 @@ func (loggerSessions) VErrorf(ctx context.Context, level Level, format string, a
 //
 // The `SESSIONS` channel is used to report client network activity when enabled via
 // the `server.auth_log.sql_connections.enabled` and/or
-// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html)
-// [cluster settings](cluster-settings.html):
+// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html):
 //
 // - Connections opened/closed
 // - Authentication events: logins, failed attempts
@@ -2369,8 +2357,7 @@ func (loggerSessions) Error(ctx context.Context, msg string) {
 //
 // The `SESSIONS` channel is used to report client network activity when enabled via
 // the `server.auth_log.sql_connections.enabled` and/or
-// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html)
-// [cluster settings](cluster-settings.html):
+// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html):
 //
 // - Connections opened/closed
 // - Authentication events: logins, failed attempts
@@ -2392,8 +2379,7 @@ func (loggerSessions) ErrorfDepth(ctx context.Context, depth int, format string,
 //
 // The `SESSIONS` channel is used to report client network activity when enabled via
 // the `server.auth_log.sql_connections.enabled` and/or
-// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html)
-// [cluster settings](cluster-settings.html):
+// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html):
 //
 // - Connections opened/closed
 // - Authentication events: logins, failed attempts
@@ -2417,8 +2403,7 @@ func (loggerSessions) Fatalf(ctx context.Context, format string, args ...interfa
 //
 // The `SESSIONS` channel is used to report client network activity when enabled via
 // the `server.auth_log.sql_connections.enabled` and/or
-// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html)
-// [cluster settings](cluster-settings.html):
+// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html):
 //
 // - Connections opened/closed
 // - Authentication events: logins, failed attempts
@@ -2442,8 +2427,7 @@ func (loggerSessions) VFatalf(ctx context.Context, level Level, format string, a
 //
 // The `SESSIONS` channel is used to report client network activity when enabled via
 // the `server.auth_log.sql_connections.enabled` and/or
-// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html)
-// [cluster settings](cluster-settings.html):
+// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html):
 //
 // - Connections opened/closed
 // - Authentication events: logins, failed attempts
@@ -2466,8 +2450,7 @@ func (loggerSessions) Fatal(ctx context.Context, msg string) {
 //
 // The `SESSIONS` channel is used to report client network activity when enabled via
 // the `server.auth_log.sql_connections.enabled` and/or
-// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html)
-// [cluster settings](cluster-settings.html):
+// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html):
 //
 // - Connections opened/closed
 // - Authentication events: logins, failed attempts
@@ -2488,8 +2471,7 @@ func (loggerSessions) FatalfDepth(ctx context.Context, depth int, format string,
 //
 // The `SESSIONS` channel is used to report client network activity when enabled via
 // the `server.auth_log.sql_connections.enabled` and/or
-// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html)
-// [cluster settings](cluster-settings.html):
+// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html):
 //
 // - Connections opened/closed
 // - Authentication events: logins, failed attempts
@@ -2507,8 +2489,7 @@ func (loggerSessions) Shout(ctx context.Context, sev Severity, msg string) {
 //
 // The `SESSIONS` channel is used to report client network activity when enabled via
 // the `server.auth_log.sql_connections.enabled` and/or
-// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html)
-// [cluster settings](cluster-settings.html):
+// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html):
 //
 // - Connections opened/closed
 // - Authentication events: logins, failed attempts

--- a/pkg/util/log/logpb/log.pb.go
+++ b/pkg/util/log/logpb/log.pb.go
@@ -133,8 +133,7 @@ const (
 	Channel_STORAGE Channel = 3
 	// SESSIONS is used to report client network activity when enabled via
 	// the `server.auth_log.sql_connections.enabled` and/or
-	// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html)
-	// [cluster settings](cluster-settings.html):
+	// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html):
 	//
 	// - Connections opened/closed
 	// - Authentication events: logins, failed attempts

--- a/pkg/util/log/logpb/log.proto
+++ b/pkg/util/log/logpb/log.proto
@@ -96,8 +96,7 @@ enum Channel {
 
   // SESSIONS is used to report client network activity when enabled via
   // the `server.auth_log.sql_connections.enabled` and/or
-  // `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html)
-  // [cluster settings](cluster-settings.html):
+  // `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html):
   //
   // - Connections opened/closed
   // - Authentication events: logins, failed attempts


### PR DESCRIPTION
This patch fixes a trivial thing in which there is a duplicated comment in pkg/util/log/logpb/log.proto.
The online documentation can be checked in [here](https://www.cockroachlabs.com/docs/v21.1/logging#sessions).

Please let me know if I'm missing something because this is my first PR for CRDB.