### PR TITLE
build: don't swallow exit status in teamcity-weekly-roachtest.sh

### DIFF
--- a/build/teamcity-weekly-roachtest.sh
+++ b/build/teamcity-weekly-roachtest.sh
@@ -44,7 +44,7 @@ chmod o+rwx "${artifacts}"
 # by default. This reserves us-east1-b (the roachprod default zone) for use
 # by manually created clusters.
 exit_status=0
-if ! timeout -s INT $((7800*60)) bin/roachtest run \
+timeout -s INT $((7800*60)) bin/roachtest run \
   tag:weekly \
   --build-tag "${build_tag}" \
   --cluster-id "${TC_BUILD_ID}" \
@@ -55,9 +55,7 @@ if ! timeout -s INT $((7800*60)) bin/roachtest run \
   --artifacts "$artifacts" \
   --parallelism 5 \
   --encrypt=random \
-  --teamcity; then
-  exit_status=$?
-fi
+  --teamcity || exit_status=$?
 
 # Upload any stats.json files to the cockroach-nightly bucket.
 for file in $(find ${artifacts#${PWD}/} -name stats.json); do


### PR DESCRIPTION
The assignment to exit_status would always assign 0:

```
$ if [ false ]; then echo $?; fi
0
```

Now we do this:

```
$ false || echo $?
1
```

(This also works under `set -e`, as in that script).

Release note: None
