### PR TITLE
build: set ROACHPROD_USER in weekly roachtest script

### DIFF
--- a/build/teamcity-weekly-roachtest.sh
+++ b/build/teamcity-weekly-roachtest.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 google_credentials="$GOOGLE_EPHEMERAL_CREDENTIALS"
 source "$(dirname "${0}")/teamcity-support.sh"
 log_into_gcloud
+export ROACHPROD_USER=teamcity
 
 set -x
 


### PR DESCRIPTION
This was lost in 6651a08752080a3594714b9e8de009bf4155fbb1.

Release note: None