### PR TITLE
execgen: remove SET in favor of Set method on the typed vector

### DIFF
--- a/pkg/col/coldata/native_types.go
+++ b/pkg/col/coldata/native_types.go
@@ -81,6 +81,43 @@ func (c Times) Get(idx int) time.Time { return c[idx] }
 //gcassert:inline
 func (c Durations) Get(idx int) duration.Duration { return c[idx] }
 
+// Set sets the element at index idx of the vector to val.
+//gcassert:inline
+func (c Bools) Set(idx int, val bool) { c[idx] = val }
+
+// Set sets the element at index idx of the vector to val.
+//gcassert:inline
+func (c Int16s) Set(idx int, val int16) { c[idx] = val }
+
+// Set sets the element at index idx of the vector to val.
+//gcassert:inline
+func (c Int32s) Set(idx int, val int32) { c[idx] = val }
+
+// Set sets the element at index idx of the vector to val.
+//gcassert:inline
+func (c Int64s) Set(idx int, val int64) { c[idx] = val }
+
+// Set sets the element at index idx of the vector to val.
+//gcassert:inline
+func (c Float64s) Set(idx int, val float64) { c[idx] = val }
+
+// Set sets the element at index idx of the vector to val.
+//
+// Note that this method is usually inlined, but it isn't in case of the merge
+// joiner generated code (probably because of the size of the functions), so we
+// don't assert the inlining with the GCAssert linter.
+// TODO(yuzefovich): consider whether Get and Set on Decimals should operate on
+// pointers to apd.Decimal.
+func (c Decimals) Set(idx int, val apd.Decimal) { c[idx].Set(&val) }
+
+// Set sets the element at index idx of the vector to val.
+//gcassert:inline
+func (c Times) Set(idx int, val time.Time) { c[idx] = val }
+
+// Set sets the element at index idx of the vector to val.
+//gcassert:inline
+func (c Durations) Set(idx int, val duration.Duration) { c[idx] = val }
+
 // Len returns the length of the vector.
 func (c Bools) Len() int { return len(c) }
 

--- a/pkg/col/coldata/vec.eg.go
+++ b/pkg/col/coldata/vec.eg.go
@@ -343,7 +343,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 							} else {
 								v := fromCol.Get(selIdx)
 								m.nulls.UnsetNull(selIdx)
-								toCol[selIdx] = v
+								toCol.Set(selIdx, v)
 							}
 						}
 						return
@@ -353,7 +353,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 						//gcassert:bce
 						selIdx := sel[i]
 						v := fromCol.Get(selIdx)
-						toCol[selIdx] = v
+						toCol.Set(selIdx, v)
 					}
 				} else {
 					sel = sel[args.SrcStartIdx:args.SrcEndIdx]
@@ -370,7 +370,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 							} else {
 								v := fromCol.Get(selIdx)
 								//gcassert:bce
-								toCol[i] = v
+								toCol.Set(i, v)
 							}
 						}
 						return
@@ -381,7 +381,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 						selIdx := sel[i]
 						v := fromCol.Get(selIdx)
 						//gcassert:bce
-						toCol[i] = v
+						toCol.Set(i, v)
 					}
 				}
 				return
@@ -475,7 +475,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 							} else {
 								v := fromCol.Get(selIdx)
 								m.nulls.UnsetNull(selIdx)
-								toCol[selIdx].Set(&v)
+								toCol.Set(selIdx, v)
 							}
 						}
 						return
@@ -485,7 +485,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 						//gcassert:bce
 						selIdx := sel[i]
 						v := fromCol.Get(selIdx)
-						toCol[selIdx].Set(&v)
+						toCol.Set(selIdx, v)
 					}
 				} else {
 					sel = sel[args.SrcStartIdx:args.SrcEndIdx]
@@ -502,7 +502,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 							} else {
 								v := fromCol.Get(selIdx)
 								//gcassert:bce
-								toCol[i].Set(&v)
+								toCol.Set(i, v)
 							}
 						}
 						return
@@ -513,7 +513,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 						selIdx := sel[i]
 						v := fromCol.Get(selIdx)
 						//gcassert:bce
-						toCol[i].Set(&v)
+						toCol.Set(i, v)
 					}
 				}
 				return
@@ -548,7 +548,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 							} else {
 								v := fromCol.Get(selIdx)
 								m.nulls.UnsetNull(selIdx)
-								toCol[selIdx] = v
+								toCol.Set(selIdx, v)
 							}
 						}
 						return
@@ -558,7 +558,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 						//gcassert:bce
 						selIdx := sel[i]
 						v := fromCol.Get(selIdx)
-						toCol[selIdx] = v
+						toCol.Set(selIdx, v)
 					}
 				} else {
 					sel = sel[args.SrcStartIdx:args.SrcEndIdx]
@@ -575,7 +575,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 							} else {
 								v := fromCol.Get(selIdx)
 								//gcassert:bce
-								toCol[i] = v
+								toCol.Set(i, v)
 							}
 						}
 						return
@@ -586,7 +586,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 						selIdx := sel[i]
 						v := fromCol.Get(selIdx)
 						//gcassert:bce
-						toCol[i] = v
+						toCol.Set(i, v)
 					}
 				}
 				return
@@ -612,7 +612,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 							} else {
 								v := fromCol.Get(selIdx)
 								m.nulls.UnsetNull(selIdx)
-								toCol[selIdx] = v
+								toCol.Set(selIdx, v)
 							}
 						}
 						return
@@ -622,7 +622,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 						//gcassert:bce
 						selIdx := sel[i]
 						v := fromCol.Get(selIdx)
-						toCol[selIdx] = v
+						toCol.Set(selIdx, v)
 					}
 				} else {
 					sel = sel[args.SrcStartIdx:args.SrcEndIdx]
@@ -639,7 +639,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 							} else {
 								v := fromCol.Get(selIdx)
 								//gcassert:bce
-								toCol[i] = v
+								toCol.Set(i, v)
 							}
 						}
 						return
@@ -650,7 +650,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 						selIdx := sel[i]
 						v := fromCol.Get(selIdx)
 						//gcassert:bce
-						toCol[i] = v
+						toCol.Set(i, v)
 					}
 				}
 				return
@@ -677,7 +677,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 							} else {
 								v := fromCol.Get(selIdx)
 								m.nulls.UnsetNull(selIdx)
-								toCol[selIdx] = v
+								toCol.Set(selIdx, v)
 							}
 						}
 						return
@@ -687,7 +687,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 						//gcassert:bce
 						selIdx := sel[i]
 						v := fromCol.Get(selIdx)
-						toCol[selIdx] = v
+						toCol.Set(selIdx, v)
 					}
 				} else {
 					sel = sel[args.SrcStartIdx:args.SrcEndIdx]
@@ -704,7 +704,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 							} else {
 								v := fromCol.Get(selIdx)
 								//gcassert:bce
-								toCol[i] = v
+								toCol.Set(i, v)
 							}
 						}
 						return
@@ -715,7 +715,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 						selIdx := sel[i]
 						v := fromCol.Get(selIdx)
 						//gcassert:bce
-						toCol[i] = v
+						toCol.Set(i, v)
 					}
 				}
 				return
@@ -745,7 +745,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 							} else {
 								v := fromCol.Get(selIdx)
 								m.nulls.UnsetNull(selIdx)
-								toCol[selIdx] = v
+								toCol.Set(selIdx, v)
 							}
 						}
 						return
@@ -755,7 +755,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 						//gcassert:bce
 						selIdx := sel[i]
 						v := fromCol.Get(selIdx)
-						toCol[selIdx] = v
+						toCol.Set(selIdx, v)
 					}
 				} else {
 					sel = sel[args.SrcStartIdx:args.SrcEndIdx]
@@ -772,7 +772,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 							} else {
 								v := fromCol.Get(selIdx)
 								//gcassert:bce
-								toCol[i] = v
+								toCol.Set(i, v)
 							}
 						}
 						return
@@ -783,7 +783,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 						selIdx := sel[i]
 						v := fromCol.Get(selIdx)
 						//gcassert:bce
-						toCol[i] = v
+						toCol.Set(i, v)
 					}
 				}
 				return
@@ -813,7 +813,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 							} else {
 								v := fromCol.Get(selIdx)
 								m.nulls.UnsetNull(selIdx)
-								toCol[selIdx] = v
+								toCol.Set(selIdx, v)
 							}
 						}
 						return
@@ -823,7 +823,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 						//gcassert:bce
 						selIdx := sel[i]
 						v := fromCol.Get(selIdx)
-						toCol[selIdx] = v
+						toCol.Set(selIdx, v)
 					}
 				} else {
 					sel = sel[args.SrcStartIdx:args.SrcEndIdx]
@@ -840,7 +840,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 							} else {
 								v := fromCol.Get(selIdx)
 								//gcassert:bce
-								toCol[i] = v
+								toCol.Set(i, v)
 							}
 						}
 						return
@@ -851,7 +851,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 						selIdx := sel[i]
 						v := fromCol.Get(selIdx)
 						//gcassert:bce
-						toCol[i] = v
+						toCol.Set(i, v)
 					}
 				}
 				return
@@ -881,7 +881,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 							} else {
 								v := fromCol.Get(selIdx)
 								m.nulls.UnsetNull(selIdx)
-								toCol[selIdx] = v
+								toCol.Set(selIdx, v)
 							}
 						}
 						return
@@ -891,7 +891,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 						//gcassert:bce
 						selIdx := sel[i]
 						v := fromCol.Get(selIdx)
-						toCol[selIdx] = v
+						toCol.Set(selIdx, v)
 					}
 				} else {
 					sel = sel[args.SrcStartIdx:args.SrcEndIdx]
@@ -908,7 +908,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 							} else {
 								v := fromCol.Get(selIdx)
 								//gcassert:bce
-								toCol[i] = v
+								toCol.Set(i, v)
 							}
 						}
 						return
@@ -919,7 +919,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 						selIdx := sel[i]
 						v := fromCol.Get(selIdx)
 						//gcassert:bce
-						toCol[i] = v
+						toCol.Set(i, v)
 					}
 				}
 				return
@@ -1201,7 +1201,7 @@ func SetValueAt(v Vec, elem interface{}, rowIdx int) {
 		default:
 			target := v.Bool()
 			newVal := elem.(bool)
-			target[rowIdx] = newVal
+			target.Set(rowIdx, newVal)
 		}
 	case types.BytesFamily:
 		switch t.Width() {
@@ -1217,23 +1217,23 @@ func SetValueAt(v Vec, elem interface{}, rowIdx int) {
 		default:
 			target := v.Decimal()
 			newVal := elem.(apd.Decimal)
-			target[rowIdx].Set(&newVal)
+			target.Set(rowIdx, newVal)
 		}
 	case types.IntFamily:
 		switch t.Width() {
 		case 16:
 			target := v.Int16()
 			newVal := elem.(int16)
-			target[rowIdx] = newVal
+			target.Set(rowIdx, newVal)
 		case 32:
 			target := v.Int32()
 			newVal := elem.(int32)
-			target[rowIdx] = newVal
+			target.Set(rowIdx, newVal)
 		case -1:
 		default:
 			target := v.Int64()
 			newVal := elem.(int64)
-			target[rowIdx] = newVal
+			target.Set(rowIdx, newVal)
 		}
 	case types.FloatFamily:
 		switch t.Width() {
@@ -1241,7 +1241,7 @@ func SetValueAt(v Vec, elem interface{}, rowIdx int) {
 		default:
 			target := v.Float64()
 			newVal := elem.(float64)
-			target[rowIdx] = newVal
+			target.Set(rowIdx, newVal)
 		}
 	case types.TimestampTZFamily:
 		switch t.Width() {
@@ -1249,7 +1249,7 @@ func SetValueAt(v Vec, elem interface{}, rowIdx int) {
 		default:
 			target := v.Timestamp()
 			newVal := elem.(time.Time)
-			target[rowIdx] = newVal
+			target.Set(rowIdx, newVal)
 		}
 	case types.IntervalFamily:
 		switch t.Width() {
@@ -1257,7 +1257,7 @@ func SetValueAt(v Vec, elem interface{}, rowIdx int) {
 		default:
 			target := v.Interval()
 			newVal := elem.(duration.Duration)
-			target[rowIdx] = newVal
+			target.Set(rowIdx, newVal)
 		}
 	case types.JsonFamily:
 		switch t.Width() {

--- a/pkg/col/coldata/vec_tmpl.go
+++ b/pkg/col/coldata/vec_tmpl.go
@@ -99,7 +99,7 @@ func _COPY_WITH_SEL(
 	// {{define "copyWithSel" -}}
 	sel = sel[args.SrcStartIdx:args.SrcEndIdx]
 	n := len(sel)
-	// {{if and (.Global.Sliceable) (not .SelOnDest)}}
+	// {{if and (.Sliceable) (not .SelOnDest)}}
 	toCol = toCol[args.DestIdx:]
 	_ = toCol[n-1]
 	// {{end}}
@@ -115,31 +115,25 @@ func _COPY_WITH_SEL(
 				m.nulls.SetNull(i + args.DestIdx)
 				// {{end}}
 			} else {
-				// {{with .Global}}
 				v := fromCol.Get(selIdx)
-				// {{end}}
 				// {{if .SelOnDest}}
 				m.nulls.UnsetNull(selIdx)
-				// {{with .Global}}
-				execgen.SET(toCol, selIdx, v)
-				// {{end}}
+				toCol.Set(selIdx, v)
 				// {{else}}
-				// {{with .Global}}
 				// {{if .Sliceable}}
 				// {{/*
 				//     For the sliceable types, we sliced toCol to start at
 				//     args.DestIdx, so we use index i directly.
 				// */}}
 				//gcassert:bce
-				execgen.SET(toCol, i, v)
+				toCol.Set(i, v)
 				// {{else}}
 				// {{/*
 				//     For the non-sliceable types, toCol vector is the original
 				//     one (i.e. without an adjustment), so we need to add
 				//     args.DestIdx to set the element at the correct index.
 				// */}}
-				execgen.SET(toCol, i+args.DestIdx, v)
-				// {{end}}
+				toCol.Set(i+args.DestIdx, v)
 				// {{end}}
 				// {{end}}
 			}
@@ -150,30 +144,24 @@ func _COPY_WITH_SEL(
 	for i := 0; i < n; i++ {
 		//gcassert:bce
 		selIdx := sel[i]
-		// {{with .Global}}
 		v := fromCol.Get(selIdx)
-		// {{end}}
 		// {{if .SelOnDest}}
-		// {{with .Global}}
-		execgen.SET(toCol, selIdx, v)
-		// {{end}}
+		toCol.Set(selIdx, v)
 		// {{else}}
-		// {{with .Global}}
 		// {{if .Sliceable}}
 		// {{/*
 		//     For the sliceable types, we sliced toCol to start at
 		//     args.DestIdx, so we use index i directly.
 		// */}}
 		//gcassert:bce
-		execgen.SET(toCol, i, v)
+		toCol.Set(i, v)
 		// {{else}}
 		// {{/*
 		//     For the non-sliceable types, toCol vector is the original one
 		//     (i.e. without an adjustment), so we need to add args.DestIdx to
 		//     set the element at the correct index.
 		// */}}
-		execgen.SET(toCol, i+args.DestIdx, v)
-		// {{end}}
+		toCol.Set(i+args.DestIdx, v)
 		// {{end}}
 		// {{end}}
 	}
@@ -257,7 +245,7 @@ func SetValueAt(v Vec, elem interface{}, rowIdx int) {
 		case _TYPE_WIDTH:
 			target := v.TemplateType()
 			newVal := elem.(_GOTYPE)
-			execgen.SET(target, rowIdx, newVal)
+			target.Set(rowIdx, newVal)
 			// {{end}}
 		}
 		// {{end}}

--- a/pkg/sql/colexec/colexecagg/any_not_null_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/any_not_null_agg_tmpl.go
@@ -179,7 +179,7 @@ func (a *anyNotNull_TYPE_AGGKINDAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		execgen.SET(a.col, outputIdx, a.curAgg)
+		a.col.Set(outputIdx, a.curAgg)
 	}
 	// {{if or (.IsBytesLike) (eq .VecMethod "Datum")}}
 	// Release the reference to curAgg eagerly.
@@ -246,9 +246,7 @@ func _FIND_ANY_NOT_NULL(
 			if !a.foundNonNullForCurrentGroup {
 				a.nulls.SetNull(a.curIdx)
 			} else {
-				// {{with .Global}}
-				execgen.SET(a.col, a.curIdx, a.curAgg)
-				// {{end}}
+				a.col.Set(a.curIdx, a.curAgg)
 			}
 			a.curIdx++
 			a.foundNonNullForCurrentGroup = false
@@ -270,8 +268,8 @@ func _FIND_ANY_NOT_NULL(
 		// {{if and (.Sliceable) (not .HasSel)}}
 		//gcassert:bce
 		// {{end}}
-		// {{with .Global}}
 		val := col.Get(i)
+		// {{with .Global}}
 		execgen.COPYVAL(a.curAgg, val)
 		// {{end}}
 		a.foundNonNullForCurrentGroup = true

--- a/pkg/sql/colexec/colexecagg/hash_any_not_null_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_any_not_null_agg.eg.go
@@ -188,7 +188,7 @@ func (a *anyNotNullBoolHashAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -418,7 +418,7 @@ func (a *anyNotNullDecimalHashAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx].Set(&a.curAgg)
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -531,7 +531,7 @@ func (a *anyNotNullInt16HashAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -644,7 +644,7 @@ func (a *anyNotNullInt32HashAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -757,7 +757,7 @@ func (a *anyNotNullInt64HashAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -870,7 +870,7 @@ func (a *anyNotNullFloat64HashAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -983,7 +983,7 @@ func (a *anyNotNullTimestampHashAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -1096,7 +1096,7 @@ func (a *anyNotNullIntervalHashAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 

--- a/pkg/sql/colexec/colexecagg/hash_min_max_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_min_max_agg.eg.go
@@ -224,7 +224,7 @@ func (a *minBoolHashAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -482,7 +482,7 @@ func (a *minDecimalHashAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx].Set(&a.curAgg)
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -631,7 +631,7 @@ func (a *minInt16HashAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -780,7 +780,7 @@ func (a *minInt32HashAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -929,7 +929,7 @@ func (a *minInt64HashAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -1094,7 +1094,7 @@ func (a *minFloat64HashAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -1235,7 +1235,7 @@ func (a *minTimestampHashAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -1362,7 +1362,7 @@ func (a *minIntervalHashAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -1917,7 +1917,7 @@ func (a *maxBoolHashAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -2175,7 +2175,7 @@ func (a *maxDecimalHashAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx].Set(&a.curAgg)
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -2324,7 +2324,7 @@ func (a *maxInt16HashAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -2473,7 +2473,7 @@ func (a *maxInt32HashAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -2622,7 +2622,7 @@ func (a *maxInt64HashAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -2787,7 +2787,7 @@ func (a *maxFloat64HashAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -2928,7 +2928,7 @@ func (a *maxTimestampHashAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -3055,7 +3055,7 @@ func (a *maxIntervalHashAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 

--- a/pkg/sql/colexec/colexecagg/min_max_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/min_max_agg_tmpl.go
@@ -180,7 +180,7 @@ func (a *_AGG_TYPE_AGGKINDAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		execgen.SET(a.col, outputIdx, a.curAgg)
+		a.col.Set(outputIdx, a.curAgg)
 	}
 	// {{if or (.IsBytesLike) (eq .VecMethod "Datum")}}
 	execgen.SETVARIABLESIZE(oldCurAggSize, a.curAgg)
@@ -243,9 +243,7 @@ func _ACCUMULATE_MINMAX(
 			if !a.foundNonNullForCurrentGroup {
 				a.nulls.SetNull(a.curIdx)
 			} else {
-				// {{with .Global}}
-				execgen.SET(a.col, a.curIdx, a.curAgg)
-				// {{end}}
+				a.col.Set(a.curIdx, a.curAgg)
 			}
 			a.curIdx++
 			a.foundNonNullForCurrentGroup = false

--- a/pkg/sql/colexec/colexecagg/ordered_any_not_null_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_any_not_null_agg.eg.go
@@ -145,7 +145,7 @@ func (a *anyNotNullBoolOrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -174,7 +174,7 @@ func (a *anyNotNullBoolOrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -205,7 +205,7 @@ func (a *anyNotNullBoolOrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -233,7 +233,7 @@ func (a *anyNotNullBoolOrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -272,7 +272,7 @@ func (a *anyNotNullBoolOrderedAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -545,7 +545,7 @@ func (a *anyNotNullDecimalOrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx].Set(&a.curAgg)
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -574,7 +574,7 @@ func (a *anyNotNullDecimalOrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx].Set(&a.curAgg)
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -605,7 +605,7 @@ func (a *anyNotNullDecimalOrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx].Set(&a.curAgg)
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -633,7 +633,7 @@ func (a *anyNotNullDecimalOrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx].Set(&a.curAgg)
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -672,7 +672,7 @@ func (a *anyNotNullDecimalOrderedAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx].Set(&a.curAgg)
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -743,7 +743,7 @@ func (a *anyNotNullInt16OrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -772,7 +772,7 @@ func (a *anyNotNullInt16OrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -803,7 +803,7 @@ func (a *anyNotNullInt16OrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -831,7 +831,7 @@ func (a *anyNotNullInt16OrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -870,7 +870,7 @@ func (a *anyNotNullInt16OrderedAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -941,7 +941,7 @@ func (a *anyNotNullInt32OrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -970,7 +970,7 @@ func (a *anyNotNullInt32OrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -1001,7 +1001,7 @@ func (a *anyNotNullInt32OrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -1029,7 +1029,7 @@ func (a *anyNotNullInt32OrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -1068,7 +1068,7 @@ func (a *anyNotNullInt32OrderedAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -1139,7 +1139,7 @@ func (a *anyNotNullInt64OrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -1168,7 +1168,7 @@ func (a *anyNotNullInt64OrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -1199,7 +1199,7 @@ func (a *anyNotNullInt64OrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -1227,7 +1227,7 @@ func (a *anyNotNullInt64OrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -1266,7 +1266,7 @@ func (a *anyNotNullInt64OrderedAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -1337,7 +1337,7 @@ func (a *anyNotNullFloat64OrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -1366,7 +1366,7 @@ func (a *anyNotNullFloat64OrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -1397,7 +1397,7 @@ func (a *anyNotNullFloat64OrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -1425,7 +1425,7 @@ func (a *anyNotNullFloat64OrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -1464,7 +1464,7 @@ func (a *anyNotNullFloat64OrderedAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -1535,7 +1535,7 @@ func (a *anyNotNullTimestampOrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -1564,7 +1564,7 @@ func (a *anyNotNullTimestampOrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -1595,7 +1595,7 @@ func (a *anyNotNullTimestampOrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -1623,7 +1623,7 @@ func (a *anyNotNullTimestampOrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -1662,7 +1662,7 @@ func (a *anyNotNullTimestampOrderedAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -1733,7 +1733,7 @@ func (a *anyNotNullIntervalOrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -1762,7 +1762,7 @@ func (a *anyNotNullIntervalOrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -1793,7 +1793,7 @@ func (a *anyNotNullIntervalOrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -1821,7 +1821,7 @@ func (a *anyNotNullIntervalOrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -1860,7 +1860,7 @@ func (a *anyNotNullIntervalOrderedAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 

--- a/pkg/sql/colexec/colexecagg/ordered_min_max_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_min_max_agg.eg.go
@@ -155,7 +155,7 @@ func (a *minBoolOrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -205,7 +205,7 @@ func (a *minBoolOrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -257,7 +257,7 @@ func (a *minBoolOrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -306,7 +306,7 @@ func (a *minBoolOrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -366,7 +366,7 @@ func (a *minBoolOrderedAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -699,7 +699,7 @@ func (a *minDecimalOrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx].Set(&a.curAgg)
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -741,7 +741,7 @@ func (a *minDecimalOrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx].Set(&a.curAgg)
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -785,7 +785,7 @@ func (a *minDecimalOrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx].Set(&a.curAgg)
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -826,7 +826,7 @@ func (a *minDecimalOrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx].Set(&a.curAgg)
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -878,7 +878,7 @@ func (a *minDecimalOrderedAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx].Set(&a.curAgg)
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -953,7 +953,7 @@ func (a *minInt16OrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -1006,7 +1006,7 @@ func (a *minInt16OrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -1061,7 +1061,7 @@ func (a *minInt16OrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -1113,7 +1113,7 @@ func (a *minInt16OrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -1176,7 +1176,7 @@ func (a *minInt16OrderedAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -1251,7 +1251,7 @@ func (a *minInt32OrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -1304,7 +1304,7 @@ func (a *minInt32OrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -1359,7 +1359,7 @@ func (a *minInt32OrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -1411,7 +1411,7 @@ func (a *minInt32OrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -1474,7 +1474,7 @@ func (a *minInt32OrderedAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -1549,7 +1549,7 @@ func (a *minInt64OrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -1602,7 +1602,7 @@ func (a *minInt64OrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -1657,7 +1657,7 @@ func (a *minInt64OrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -1709,7 +1709,7 @@ func (a *minInt64OrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -1772,7 +1772,7 @@ func (a *minInt64OrderedAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -1847,7 +1847,7 @@ func (a *minFloat64OrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -1908,7 +1908,7 @@ func (a *minFloat64OrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -1971,7 +1971,7 @@ func (a *minFloat64OrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -2031,7 +2031,7 @@ func (a *minFloat64OrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -2102,7 +2102,7 @@ func (a *minFloat64OrderedAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -2177,7 +2177,7 @@ func (a *minTimestampOrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -2226,7 +2226,7 @@ func (a *minTimestampOrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -2277,7 +2277,7 @@ func (a *minTimestampOrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -2325,7 +2325,7 @@ func (a *minTimestampOrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -2384,7 +2384,7 @@ func (a *minTimestampOrderedAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -2459,7 +2459,7 @@ func (a *minIntervalOrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -2501,7 +2501,7 @@ func (a *minIntervalOrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -2545,7 +2545,7 @@ func (a *minIntervalOrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -2586,7 +2586,7 @@ func (a *minIntervalOrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -2638,7 +2638,7 @@ func (a *minIntervalOrderedAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -3439,7 +3439,7 @@ func (a *maxBoolOrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -3489,7 +3489,7 @@ func (a *maxBoolOrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -3541,7 +3541,7 @@ func (a *maxBoolOrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -3590,7 +3590,7 @@ func (a *maxBoolOrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -3650,7 +3650,7 @@ func (a *maxBoolOrderedAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -3983,7 +3983,7 @@ func (a *maxDecimalOrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx].Set(&a.curAgg)
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -4025,7 +4025,7 @@ func (a *maxDecimalOrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx].Set(&a.curAgg)
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -4069,7 +4069,7 @@ func (a *maxDecimalOrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx].Set(&a.curAgg)
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -4110,7 +4110,7 @@ func (a *maxDecimalOrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx].Set(&a.curAgg)
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -4162,7 +4162,7 @@ func (a *maxDecimalOrderedAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx].Set(&a.curAgg)
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -4237,7 +4237,7 @@ func (a *maxInt16OrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -4290,7 +4290,7 @@ func (a *maxInt16OrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -4345,7 +4345,7 @@ func (a *maxInt16OrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -4397,7 +4397,7 @@ func (a *maxInt16OrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -4460,7 +4460,7 @@ func (a *maxInt16OrderedAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -4535,7 +4535,7 @@ func (a *maxInt32OrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -4588,7 +4588,7 @@ func (a *maxInt32OrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -4643,7 +4643,7 @@ func (a *maxInt32OrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -4695,7 +4695,7 @@ func (a *maxInt32OrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -4758,7 +4758,7 @@ func (a *maxInt32OrderedAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -4833,7 +4833,7 @@ func (a *maxInt64OrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -4886,7 +4886,7 @@ func (a *maxInt64OrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -4941,7 +4941,7 @@ func (a *maxInt64OrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -4993,7 +4993,7 @@ func (a *maxInt64OrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -5056,7 +5056,7 @@ func (a *maxInt64OrderedAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -5131,7 +5131,7 @@ func (a *maxFloat64OrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -5192,7 +5192,7 @@ func (a *maxFloat64OrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -5255,7 +5255,7 @@ func (a *maxFloat64OrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -5315,7 +5315,7 @@ func (a *maxFloat64OrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -5386,7 +5386,7 @@ func (a *maxFloat64OrderedAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -5461,7 +5461,7 @@ func (a *maxTimestampOrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -5510,7 +5510,7 @@ func (a *maxTimestampOrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -5561,7 +5561,7 @@ func (a *maxTimestampOrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -5609,7 +5609,7 @@ func (a *maxTimestampOrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -5668,7 +5668,7 @@ func (a *maxTimestampOrderedAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -5743,7 +5743,7 @@ func (a *maxIntervalOrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -5785,7 +5785,7 @@ func (a *maxIntervalOrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -5829,7 +5829,7 @@ func (a *maxIntervalOrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -5870,7 +5870,7 @@ func (a *maxIntervalOrderedAgg) Compute(
 							if !a.foundNonNullForCurrentGroup {
 								a.nulls.SetNull(a.curIdx)
 							} else {
-								a.col[a.curIdx] = a.curAgg
+								a.col.Set(a.curIdx, a.curAgg)
 							}
 							a.curIdx++
 							a.foundNonNullForCurrentGroup = false
@@ -5922,7 +5922,7 @@ func (a *maxIntervalOrderedAgg) Flush(outputIdx int) {
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 

--- a/pkg/sql/colexec/colexecbase/cast.eg.go
+++ b/pkg/sql/colexec/colexecbase/cast.eg.go
@@ -813,7 +813,7 @@ func (c *castBoolBoolOp) Next() coldata.Batch {
 						v := inputCol.Get(tupleIdx)
 						var r bool
 						r = v
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -830,7 +830,7 @@ func (c *castBoolBoolOp) Next() coldata.Batch {
 						var r bool
 						r = v
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			} else {
@@ -845,7 +845,7 @@ func (c *castBoolBoolOp) Next() coldata.Batch {
 						v := inputCol.Get(tupleIdx)
 						var r bool
 						r = v
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -859,7 +859,7 @@ func (c *castBoolBoolOp) Next() coldata.Batch {
 						var r bool
 						r = v
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			}
@@ -919,7 +919,7 @@ func (c *castBoolFloat64Op) Next() coldata.Batch {
 							r = 1
 						}
 
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -941,7 +941,7 @@ func (c *castBoolFloat64Op) Next() coldata.Batch {
 						}
 
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			} else {
@@ -961,7 +961,7 @@ func (c *castBoolFloat64Op) Next() coldata.Batch {
 							r = 1
 						}
 
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -980,7 +980,7 @@ func (c *castBoolFloat64Op) Next() coldata.Batch {
 						}
 
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			}
@@ -1040,7 +1040,7 @@ func (c *castBoolInt16Op) Next() coldata.Batch {
 							r = 1
 						}
 
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -1062,7 +1062,7 @@ func (c *castBoolInt16Op) Next() coldata.Batch {
 						}
 
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			} else {
@@ -1082,7 +1082,7 @@ func (c *castBoolInt16Op) Next() coldata.Batch {
 							r = 1
 						}
 
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -1101,7 +1101,7 @@ func (c *castBoolInt16Op) Next() coldata.Batch {
 						}
 
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			}
@@ -1161,7 +1161,7 @@ func (c *castBoolInt32Op) Next() coldata.Batch {
 							r = 1
 						}
 
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -1183,7 +1183,7 @@ func (c *castBoolInt32Op) Next() coldata.Batch {
 						}
 
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			} else {
@@ -1203,7 +1203,7 @@ func (c *castBoolInt32Op) Next() coldata.Batch {
 							r = 1
 						}
 
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -1222,7 +1222,7 @@ func (c *castBoolInt32Op) Next() coldata.Batch {
 						}
 
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			}
@@ -1282,7 +1282,7 @@ func (c *castBoolInt64Op) Next() coldata.Batch {
 							r = 1
 						}
 
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -1304,7 +1304,7 @@ func (c *castBoolInt64Op) Next() coldata.Batch {
 						}
 
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			} else {
@@ -1324,7 +1324,7 @@ func (c *castBoolInt64Op) Next() coldata.Batch {
 							r = 1
 						}
 
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -1343,7 +1343,7 @@ func (c *castBoolInt64Op) Next() coldata.Batch {
 						}
 
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			}
@@ -1398,7 +1398,7 @@ func (c *castDecimalBoolOp) Next() coldata.Batch {
 						v := inputCol.Get(tupleIdx)
 						var r bool
 						r = v.Sign() != 0
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -1415,7 +1415,7 @@ func (c *castDecimalBoolOp) Next() coldata.Batch {
 						var r bool
 						r = v.Sign() != 0
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			} else {
@@ -1430,7 +1430,7 @@ func (c *castDecimalBoolOp) Next() coldata.Batch {
 						v := inputCol.Get(tupleIdx)
 						var r bool
 						r = v.Sign() != 0
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -1444,7 +1444,7 @@ func (c *castDecimalBoolOp) Next() coldata.Batch {
 						var r bool
 						r = v.Sign() != 0
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			}
@@ -1522,7 +1522,7 @@ func (c *castDecimalInt16Op) Next() coldata.Batch {
 
 						}
 
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -1558,7 +1558,7 @@ func (c *castDecimalInt16Op) Next() coldata.Batch {
 						}
 
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			} else {
@@ -1592,7 +1592,7 @@ func (c *castDecimalInt16Op) Next() coldata.Batch {
 
 						}
 
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -1625,7 +1625,7 @@ func (c *castDecimalInt16Op) Next() coldata.Batch {
 						}
 
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			}
@@ -1703,7 +1703,7 @@ func (c *castDecimalInt32Op) Next() coldata.Batch {
 
 						}
 
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -1739,7 +1739,7 @@ func (c *castDecimalInt32Op) Next() coldata.Batch {
 						}
 
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			} else {
@@ -1773,7 +1773,7 @@ func (c *castDecimalInt32Op) Next() coldata.Batch {
 
 						}
 
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -1806,7 +1806,7 @@ func (c *castDecimalInt32Op) Next() coldata.Batch {
 						}
 
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			}
@@ -1878,7 +1878,7 @@ func (c *castDecimalInt64Op) Next() coldata.Batch {
 							r = int64(_i)
 						}
 
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -1908,7 +1908,7 @@ func (c *castDecimalInt64Op) Next() coldata.Batch {
 						}
 
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			} else {
@@ -1936,7 +1936,7 @@ func (c *castDecimalInt64Op) Next() coldata.Batch {
 							r = int64(_i)
 						}
 
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -1963,7 +1963,7 @@ func (c *castDecimalInt64Op) Next() coldata.Batch {
 						}
 
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			}
@@ -2026,7 +2026,7 @@ func (c *castDecimalFloat64Op) Next() coldata.Batch {
 							r = f
 						}
 
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -2051,7 +2051,7 @@ func (c *castDecimalFloat64Op) Next() coldata.Batch {
 						}
 
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			} else {
@@ -2074,7 +2074,7 @@ func (c *castDecimalFloat64Op) Next() coldata.Batch {
 							r = f
 						}
 
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -2096,7 +2096,7 @@ func (c *castDecimalFloat64Op) Next() coldata.Batch {
 						}
 
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			}
@@ -2156,7 +2156,7 @@ func (c *castDecimalDecimalOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(err)
 						}
 
-						outputCol[tupleIdx].Set(&r)
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -2178,7 +2178,7 @@ func (c *castDecimalDecimalOp) Next() coldata.Batch {
 						}
 
 						//gcassert:bce
-						outputCol[tupleIdx].Set(&r)
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			} else {
@@ -2198,7 +2198,7 @@ func (c *castDecimalDecimalOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(err)
 						}
 
-						outputCol[tupleIdx].Set(&r)
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -2217,7 +2217,7 @@ func (c *castDecimalDecimalOp) Next() coldata.Batch {
 						}
 
 						//gcassert:bce
-						outputCol[tupleIdx].Set(&r)
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			}
@@ -2272,7 +2272,7 @@ func (c *castInt16Int16Op) Next() coldata.Batch {
 						v := inputCol.Get(tupleIdx)
 						var r int16
 						r = v
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -2289,7 +2289,7 @@ func (c *castInt16Int16Op) Next() coldata.Batch {
 						var r int16
 						r = v
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			} else {
@@ -2304,7 +2304,7 @@ func (c *castInt16Int16Op) Next() coldata.Batch {
 						v := inputCol.Get(tupleIdx)
 						var r int16
 						r = v
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -2318,7 +2318,7 @@ func (c *castInt16Int16Op) Next() coldata.Batch {
 						var r int16
 						r = v
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			}
@@ -2373,7 +2373,7 @@ func (c *castInt16Int32Op) Next() coldata.Batch {
 						v := inputCol.Get(tupleIdx)
 						var r int32
 						r = int32(v)
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -2390,7 +2390,7 @@ func (c *castInt16Int32Op) Next() coldata.Batch {
 						var r int32
 						r = int32(v)
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			} else {
@@ -2405,7 +2405,7 @@ func (c *castInt16Int32Op) Next() coldata.Batch {
 						v := inputCol.Get(tupleIdx)
 						var r int32
 						r = int32(v)
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -2419,7 +2419,7 @@ func (c *castInt16Int32Op) Next() coldata.Batch {
 						var r int32
 						r = int32(v)
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			}
@@ -2474,7 +2474,7 @@ func (c *castInt16Int64Op) Next() coldata.Batch {
 						v := inputCol.Get(tupleIdx)
 						var r int64
 						r = int64(v)
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -2491,7 +2491,7 @@ func (c *castInt16Int64Op) Next() coldata.Batch {
 						var r int64
 						r = int64(v)
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			} else {
@@ -2506,7 +2506,7 @@ func (c *castInt16Int64Op) Next() coldata.Batch {
 						v := inputCol.Get(tupleIdx)
 						var r int64
 						r = int64(v)
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -2520,7 +2520,7 @@ func (c *castInt16Int64Op) Next() coldata.Batch {
 						var r int64
 						r = int64(v)
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			}
@@ -2577,7 +2577,7 @@ func (c *castInt16BoolOp) Next() coldata.Batch {
 
 						r = v != 0
 
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -2596,7 +2596,7 @@ func (c *castInt16BoolOp) Next() coldata.Batch {
 						r = v != 0
 
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			} else {
@@ -2613,7 +2613,7 @@ func (c *castInt16BoolOp) Next() coldata.Batch {
 
 						r = v != 0
 
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -2629,7 +2629,7 @@ func (c *castInt16BoolOp) Next() coldata.Batch {
 						r = v != 0
 
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			}
@@ -2690,7 +2690,7 @@ func (c *castInt16DecimalOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(err)
 						}
 
-						outputCol[tupleIdx].Set(&r)
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -2713,7 +2713,7 @@ func (c *castInt16DecimalOp) Next() coldata.Batch {
 						}
 
 						//gcassert:bce
-						outputCol[tupleIdx].Set(&r)
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			} else {
@@ -2734,7 +2734,7 @@ func (c *castInt16DecimalOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(err)
 						}
 
-						outputCol[tupleIdx].Set(&r)
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -2754,7 +2754,7 @@ func (c *castInt16DecimalOp) Next() coldata.Batch {
 						}
 
 						//gcassert:bce
-						outputCol[tupleIdx].Set(&r)
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			}
@@ -2811,7 +2811,7 @@ func (c *castInt16Float64Op) Next() coldata.Batch {
 
 						r = float64(v)
 
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -2830,7 +2830,7 @@ func (c *castInt16Float64Op) Next() coldata.Batch {
 						r = float64(v)
 
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			} else {
@@ -2847,7 +2847,7 @@ func (c *castInt16Float64Op) Next() coldata.Batch {
 
 						r = float64(v)
 
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -2863,7 +2863,7 @@ func (c *castInt16Float64Op) Next() coldata.Batch {
 						r = float64(v)
 
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			}
@@ -2924,7 +2924,7 @@ func (c *castInt32Int16Op) Next() coldata.Batch {
 						}
 						r = int16(v)
 
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -2947,7 +2947,7 @@ func (c *castInt32Int16Op) Next() coldata.Batch {
 						r = int16(v)
 
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			} else {
@@ -2968,7 +2968,7 @@ func (c *castInt32Int16Op) Next() coldata.Batch {
 						}
 						r = int16(v)
 
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -2988,7 +2988,7 @@ func (c *castInt32Int16Op) Next() coldata.Batch {
 						r = int16(v)
 
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			}
@@ -3043,7 +3043,7 @@ func (c *castInt32Int32Op) Next() coldata.Batch {
 						v := inputCol.Get(tupleIdx)
 						var r int32
 						r = v
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -3060,7 +3060,7 @@ func (c *castInt32Int32Op) Next() coldata.Batch {
 						var r int32
 						r = v
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			} else {
@@ -3075,7 +3075,7 @@ func (c *castInt32Int32Op) Next() coldata.Batch {
 						v := inputCol.Get(tupleIdx)
 						var r int32
 						r = v
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -3089,7 +3089,7 @@ func (c *castInt32Int32Op) Next() coldata.Batch {
 						var r int32
 						r = v
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			}
@@ -3144,7 +3144,7 @@ func (c *castInt32Int64Op) Next() coldata.Batch {
 						v := inputCol.Get(tupleIdx)
 						var r int64
 						r = int64(v)
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -3161,7 +3161,7 @@ func (c *castInt32Int64Op) Next() coldata.Batch {
 						var r int64
 						r = int64(v)
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			} else {
@@ -3176,7 +3176,7 @@ func (c *castInt32Int64Op) Next() coldata.Batch {
 						v := inputCol.Get(tupleIdx)
 						var r int64
 						r = int64(v)
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -3190,7 +3190,7 @@ func (c *castInt32Int64Op) Next() coldata.Batch {
 						var r int64
 						r = int64(v)
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			}
@@ -3247,7 +3247,7 @@ func (c *castInt32BoolOp) Next() coldata.Batch {
 
 						r = v != 0
 
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -3266,7 +3266,7 @@ func (c *castInt32BoolOp) Next() coldata.Batch {
 						r = v != 0
 
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			} else {
@@ -3283,7 +3283,7 @@ func (c *castInt32BoolOp) Next() coldata.Batch {
 
 						r = v != 0
 
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -3299,7 +3299,7 @@ func (c *castInt32BoolOp) Next() coldata.Batch {
 						r = v != 0
 
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			}
@@ -3360,7 +3360,7 @@ func (c *castInt32DecimalOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(err)
 						}
 
-						outputCol[tupleIdx].Set(&r)
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -3383,7 +3383,7 @@ func (c *castInt32DecimalOp) Next() coldata.Batch {
 						}
 
 						//gcassert:bce
-						outputCol[tupleIdx].Set(&r)
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			} else {
@@ -3404,7 +3404,7 @@ func (c *castInt32DecimalOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(err)
 						}
 
-						outputCol[tupleIdx].Set(&r)
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -3424,7 +3424,7 @@ func (c *castInt32DecimalOp) Next() coldata.Batch {
 						}
 
 						//gcassert:bce
-						outputCol[tupleIdx].Set(&r)
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			}
@@ -3481,7 +3481,7 @@ func (c *castInt32Float64Op) Next() coldata.Batch {
 
 						r = float64(v)
 
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -3500,7 +3500,7 @@ func (c *castInt32Float64Op) Next() coldata.Batch {
 						r = float64(v)
 
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			} else {
@@ -3517,7 +3517,7 @@ func (c *castInt32Float64Op) Next() coldata.Batch {
 
 						r = float64(v)
 
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -3533,7 +3533,7 @@ func (c *castInt32Float64Op) Next() coldata.Batch {
 						r = float64(v)
 
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			}
@@ -3594,7 +3594,7 @@ func (c *castInt64Int16Op) Next() coldata.Batch {
 						}
 						r = int16(v)
 
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -3617,7 +3617,7 @@ func (c *castInt64Int16Op) Next() coldata.Batch {
 						r = int16(v)
 
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			} else {
@@ -3638,7 +3638,7 @@ func (c *castInt64Int16Op) Next() coldata.Batch {
 						}
 						r = int16(v)
 
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -3658,7 +3658,7 @@ func (c *castInt64Int16Op) Next() coldata.Batch {
 						r = int16(v)
 
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			}
@@ -3719,7 +3719,7 @@ func (c *castInt64Int32Op) Next() coldata.Batch {
 						}
 						r = int32(v)
 
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -3742,7 +3742,7 @@ func (c *castInt64Int32Op) Next() coldata.Batch {
 						r = int32(v)
 
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			} else {
@@ -3763,7 +3763,7 @@ func (c *castInt64Int32Op) Next() coldata.Batch {
 						}
 						r = int32(v)
 
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -3783,7 +3783,7 @@ func (c *castInt64Int32Op) Next() coldata.Batch {
 						r = int32(v)
 
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			}
@@ -3838,7 +3838,7 @@ func (c *castInt64Int64Op) Next() coldata.Batch {
 						v := inputCol.Get(tupleIdx)
 						var r int64
 						r = v
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -3855,7 +3855,7 @@ func (c *castInt64Int64Op) Next() coldata.Batch {
 						var r int64
 						r = v
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			} else {
@@ -3870,7 +3870,7 @@ func (c *castInt64Int64Op) Next() coldata.Batch {
 						v := inputCol.Get(tupleIdx)
 						var r int64
 						r = v
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -3884,7 +3884,7 @@ func (c *castInt64Int64Op) Next() coldata.Batch {
 						var r int64
 						r = v
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			}
@@ -3941,7 +3941,7 @@ func (c *castInt64BoolOp) Next() coldata.Batch {
 
 						r = v != 0
 
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -3960,7 +3960,7 @@ func (c *castInt64BoolOp) Next() coldata.Batch {
 						r = v != 0
 
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			} else {
@@ -3977,7 +3977,7 @@ func (c *castInt64BoolOp) Next() coldata.Batch {
 
 						r = v != 0
 
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -3993,7 +3993,7 @@ func (c *castInt64BoolOp) Next() coldata.Batch {
 						r = v != 0
 
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			}
@@ -4054,7 +4054,7 @@ func (c *castInt64DecimalOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(err)
 						}
 
-						outputCol[tupleIdx].Set(&r)
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -4077,7 +4077,7 @@ func (c *castInt64DecimalOp) Next() coldata.Batch {
 						}
 
 						//gcassert:bce
-						outputCol[tupleIdx].Set(&r)
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			} else {
@@ -4098,7 +4098,7 @@ func (c *castInt64DecimalOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(err)
 						}
 
-						outputCol[tupleIdx].Set(&r)
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -4118,7 +4118,7 @@ func (c *castInt64DecimalOp) Next() coldata.Batch {
 						}
 
 						//gcassert:bce
-						outputCol[tupleIdx].Set(&r)
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			}
@@ -4175,7 +4175,7 @@ func (c *castInt64Float64Op) Next() coldata.Batch {
 
 						r = float64(v)
 
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -4194,7 +4194,7 @@ func (c *castInt64Float64Op) Next() coldata.Batch {
 						r = float64(v)
 
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			} else {
@@ -4211,7 +4211,7 @@ func (c *castInt64Float64Op) Next() coldata.Batch {
 
 						r = float64(v)
 
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -4227,7 +4227,7 @@ func (c *castInt64Float64Op) Next() coldata.Batch {
 						r = float64(v)
 
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			}
@@ -4282,7 +4282,7 @@ func (c *castFloat64Float64Op) Next() coldata.Batch {
 						v := inputCol.Get(tupleIdx)
 						var r float64
 						r = v
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -4299,7 +4299,7 @@ func (c *castFloat64Float64Op) Next() coldata.Batch {
 						var r float64
 						r = v
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			} else {
@@ -4314,7 +4314,7 @@ func (c *castFloat64Float64Op) Next() coldata.Batch {
 						v := inputCol.Get(tupleIdx)
 						var r float64
 						r = v
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -4328,7 +4328,7 @@ func (c *castFloat64Float64Op) Next() coldata.Batch {
 						var r float64
 						r = v
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			}
@@ -4385,7 +4385,7 @@ func (c *castFloat64BoolOp) Next() coldata.Batch {
 
 						r = v != 0
 
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -4404,7 +4404,7 @@ func (c *castFloat64BoolOp) Next() coldata.Batch {
 						r = v != 0
 
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			} else {
@@ -4421,7 +4421,7 @@ func (c *castFloat64BoolOp) Next() coldata.Batch {
 
 						r = v != 0
 
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -4437,7 +4437,7 @@ func (c *castFloat64BoolOp) Next() coldata.Batch {
 						r = v != 0
 
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			}
@@ -4500,7 +4500,7 @@ func (c *castFloat64DecimalOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(err)
 						}
 
-						outputCol[tupleIdx].Set(&r)
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -4525,7 +4525,7 @@ func (c *castFloat64DecimalOp) Next() coldata.Batch {
 						}
 
 						//gcassert:bce
-						outputCol[tupleIdx].Set(&r)
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			} else {
@@ -4548,7 +4548,7 @@ func (c *castFloat64DecimalOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(err)
 						}
 
-						outputCol[tupleIdx].Set(&r)
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -4570,7 +4570,7 @@ func (c *castFloat64DecimalOp) Next() coldata.Batch {
 						}
 
 						//gcassert:bce
-						outputCol[tupleIdx].Set(&r)
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			}
@@ -4630,7 +4630,7 @@ func (c *castFloat64Int16Op) Next() coldata.Batch {
 						}
 						r = int16(v)
 
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -4652,7 +4652,7 @@ func (c *castFloat64Int16Op) Next() coldata.Batch {
 						r = int16(v)
 
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			} else {
@@ -4672,7 +4672,7 @@ func (c *castFloat64Int16Op) Next() coldata.Batch {
 						}
 						r = int16(v)
 
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -4691,7 +4691,7 @@ func (c *castFloat64Int16Op) Next() coldata.Batch {
 						r = int16(v)
 
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			}
@@ -4751,7 +4751,7 @@ func (c *castFloat64Int32Op) Next() coldata.Batch {
 						}
 						r = int32(v)
 
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -4773,7 +4773,7 @@ func (c *castFloat64Int32Op) Next() coldata.Batch {
 						r = int32(v)
 
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			} else {
@@ -4793,7 +4793,7 @@ func (c *castFloat64Int32Op) Next() coldata.Batch {
 						}
 						r = int32(v)
 
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -4812,7 +4812,7 @@ func (c *castFloat64Int32Op) Next() coldata.Batch {
 						r = int32(v)
 
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			}
@@ -4872,7 +4872,7 @@ func (c *castFloat64Int64Op) Next() coldata.Batch {
 						}
 						r = int64(v)
 
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -4894,7 +4894,7 @@ func (c *castFloat64Int64Op) Next() coldata.Batch {
 						r = int64(v)
 
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			} else {
@@ -4914,7 +4914,7 @@ func (c *castFloat64Int64Op) Next() coldata.Batch {
 						}
 						r = int64(v)
 
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -4933,7 +4933,7 @@ func (c *castFloat64Int64Op) Next() coldata.Batch {
 						r = int64(v)
 
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			}
@@ -4996,7 +4996,7 @@ func (c *castDatumBoolOp) Next() coldata.Batch {
 							r = _castedDatum == tree.DBoolTrue
 						}
 
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -5021,7 +5021,7 @@ func (c *castDatumBoolOp) Next() coldata.Batch {
 						}
 
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			} else {
@@ -5044,7 +5044,7 @@ func (c *castDatumBoolOp) Next() coldata.Batch {
 							r = _castedDatum == tree.DBoolTrue
 						}
 
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				} else {
 					// Remove bounds checks for inputCol[i] and outputCol[i].
@@ -5066,7 +5066,7 @@ func (c *castDatumBoolOp) Next() coldata.Batch {
 						}
 
 						//gcassert:bce
-						outputCol[tupleIdx] = r
+						outputCol.Set(tupleIdx, r)
 					}
 				}
 			}

--- a/pkg/sql/colexec/colexecbase/cast_tmpl.go
+++ b/pkg/sql/colexec/colexecbase/cast_tmpl.go
@@ -66,11 +66,6 @@ func _CAST(to, from, fromCol, toType interface{}) {
 	colexecerror.InternalError(errors.AssertionFailedf(""))
 }
 
-// This will be replaced with execgen.SET.
-func _R_SET(to, from interface{}) {
-	colexecerror.InternalError(errors.AssertionFailedf(""))
-}
-
 // */}}
 
 func GetCastOperator(
@@ -315,7 +310,7 @@ func _CAST_TUPLES(_HAS_NULLS, _HAS_SEL bool) { // */}}
 		// {{if and (.Right.Sliceable) (not $hasSel)}}
 		//gcassert:bce
 		// {{end}}
-		_R_SET(outputCol, tupleIdx, r)
+		outputCol.Set(tupleIdx, r)
 		// {{if eq .Right.VecMethod "Datum"}}
 		// Casting to datum-backed vector might produce a null value on
 		// non-null tuple, so we need to check that case after the cast was

--- a/pkg/sql/colexec/colexecbase/const.eg.go
+++ b/pkg/sql/colexec/colexecbase/const.eg.go
@@ -190,13 +190,13 @@ func (c constBoolOp) Next() coldata.Batch {
 			col := col
 			if sel := batch.Selection(); sel != nil {
 				for _, i := range sel[:n] {
-					col[i] = c.constVal
+					col.Set(i, c.constVal)
 				}
 			} else {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					//gcassert:bce
-					col[i] = c.constVal
+					col.Set(i, c.constVal)
 				}
 			}
 		},
@@ -277,13 +277,13 @@ func (c constDecimalOp) Next() coldata.Batch {
 			col := col
 			if sel := batch.Selection(); sel != nil {
 				for _, i := range sel[:n] {
-					col[i].Set(&c.constVal)
+					col.Set(i, c.constVal)
 				}
 			} else {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					//gcassert:bce
-					col[i].Set(&c.constVal)
+					col.Set(i, c.constVal)
 				}
 			}
 		},
@@ -321,13 +321,13 @@ func (c constInt16Op) Next() coldata.Batch {
 			col := col
 			if sel := batch.Selection(); sel != nil {
 				for _, i := range sel[:n] {
-					col[i] = c.constVal
+					col.Set(i, c.constVal)
 				}
 			} else {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					//gcassert:bce
-					col[i] = c.constVal
+					col.Set(i, c.constVal)
 				}
 			}
 		},
@@ -365,13 +365,13 @@ func (c constInt32Op) Next() coldata.Batch {
 			col := col
 			if sel := batch.Selection(); sel != nil {
 				for _, i := range sel[:n] {
-					col[i] = c.constVal
+					col.Set(i, c.constVal)
 				}
 			} else {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					//gcassert:bce
-					col[i] = c.constVal
+					col.Set(i, c.constVal)
 				}
 			}
 		},
@@ -409,13 +409,13 @@ func (c constInt64Op) Next() coldata.Batch {
 			col := col
 			if sel := batch.Selection(); sel != nil {
 				for _, i := range sel[:n] {
-					col[i] = c.constVal
+					col.Set(i, c.constVal)
 				}
 			} else {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					//gcassert:bce
-					col[i] = c.constVal
+					col.Set(i, c.constVal)
 				}
 			}
 		},
@@ -453,13 +453,13 @@ func (c constFloat64Op) Next() coldata.Batch {
 			col := col
 			if sel := batch.Selection(); sel != nil {
 				for _, i := range sel[:n] {
-					col[i] = c.constVal
+					col.Set(i, c.constVal)
 				}
 			} else {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					//gcassert:bce
-					col[i] = c.constVal
+					col.Set(i, c.constVal)
 				}
 			}
 		},
@@ -497,13 +497,13 @@ func (c constTimestampOp) Next() coldata.Batch {
 			col := col
 			if sel := batch.Selection(); sel != nil {
 				for _, i := range sel[:n] {
-					col[i] = c.constVal
+					col.Set(i, c.constVal)
 				}
 			} else {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					//gcassert:bce
-					col[i] = c.constVal
+					col.Set(i, c.constVal)
 				}
 			}
 		},
@@ -541,13 +541,13 @@ func (c constIntervalOp) Next() coldata.Batch {
 			col := col
 			if sel := batch.Selection(); sel != nil {
 				for _, i := range sel[:n] {
-					col[i] = c.constVal
+					col.Set(i, c.constVal)
 				}
 			} else {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					//gcassert:bce
-					col[i] = c.constVal
+					col.Set(i, c.constVal)
 				}
 			}
 		},

--- a/pkg/sql/colexec/colexecbase/const_tmpl.go
+++ b/pkg/sql/colexec/colexecbase/const_tmpl.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecutils"
-	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -118,7 +117,7 @@ func (c const_TYPEOp) Next() coldata.Batch {
 			col := col
 			if sel := batch.Selection(); sel != nil {
 				for _, i := range sel[:n] {
-					execgen.SET(col, i, c.constVal)
+					col.Set(i, c.constVal)
 				}
 			} else {
 				_ = col.Get(n - 1)
@@ -126,7 +125,7 @@ func (c const_TYPEOp) Next() coldata.Batch {
 					// {{if .Sliceable}}
 					//gcassert:bce
 					// {{end}}
-					execgen.SET(col, i, c.constVal)
+					col.Set(i, c.constVal)
 				}
 			}
 		},

--- a/pkg/sql/colexec/colexecjoin/crossjoiner.eg.go
+++ b/pkg/sql/colexec/colexecjoin/crossjoiner.eg.go
@@ -98,7 +98,7 @@ func (b *crossJoinerBase) buildFromLeftInput(ctx context.Context, destStartIdx i
 										outNulls.SetNull(outStartIdx)
 									} else {
 										val := srcCol.Get(srcStartIdx)
-										outCol[outStartIdx] = val
+										outCol.Set(outStartIdx, val)
 									}
 									outStartIdx++
 									b.builderState.left.curSrcStartIdx++
@@ -151,7 +151,7 @@ func (b *crossJoinerBase) buildFromLeftInput(ctx context.Context, destStartIdx i
 									} else {
 										val := srcCol.Get(srcStartIdx)
 										for i := 0; i < toAppend; i++ {
-											outCol[outStartIdx] = val
+											outCol.Set(outStartIdx, val)
 											outStartIdx++
 										}
 									}
@@ -338,7 +338,7 @@ func (b *crossJoinerBase) buildFromLeftInput(ctx context.Context, destStartIdx i
 										outNulls.SetNull(outStartIdx)
 									} else {
 										val := srcCol.Get(srcStartIdx)
-										outCol[outStartIdx].Set(&val)
+										outCol.Set(outStartIdx, val)
 									}
 									outStartIdx++
 									b.builderState.left.curSrcStartIdx++
@@ -391,7 +391,7 @@ func (b *crossJoinerBase) buildFromLeftInput(ctx context.Context, destStartIdx i
 									} else {
 										val := srcCol.Get(srcStartIdx)
 										for i := 0; i < toAppend; i++ {
-											outCol[outStartIdx].Set(&val)
+											outCol.Set(outStartIdx, val)
 											outStartIdx++
 										}
 									}
@@ -457,7 +457,7 @@ func (b *crossJoinerBase) buildFromLeftInput(ctx context.Context, destStartIdx i
 										outNulls.SetNull(outStartIdx)
 									} else {
 										val := srcCol.Get(srcStartIdx)
-										outCol[outStartIdx] = val
+										outCol.Set(outStartIdx, val)
 									}
 									outStartIdx++
 									b.builderState.left.curSrcStartIdx++
@@ -510,7 +510,7 @@ func (b *crossJoinerBase) buildFromLeftInput(ctx context.Context, destStartIdx i
 									} else {
 										val := srcCol.Get(srcStartIdx)
 										for i := 0; i < toAppend; i++ {
-											outCol[outStartIdx] = val
+											outCol.Set(outStartIdx, val)
 											outStartIdx++
 										}
 									}
@@ -573,7 +573,7 @@ func (b *crossJoinerBase) buildFromLeftInput(ctx context.Context, destStartIdx i
 										outNulls.SetNull(outStartIdx)
 									} else {
 										val := srcCol.Get(srcStartIdx)
-										outCol[outStartIdx] = val
+										outCol.Set(outStartIdx, val)
 									}
 									outStartIdx++
 									b.builderState.left.curSrcStartIdx++
@@ -626,7 +626,7 @@ func (b *crossJoinerBase) buildFromLeftInput(ctx context.Context, destStartIdx i
 									} else {
 										val := srcCol.Get(srcStartIdx)
 										for i := 0; i < toAppend; i++ {
-											outCol[outStartIdx] = val
+											outCol.Set(outStartIdx, val)
 											outStartIdx++
 										}
 									}
@@ -690,7 +690,7 @@ func (b *crossJoinerBase) buildFromLeftInput(ctx context.Context, destStartIdx i
 										outNulls.SetNull(outStartIdx)
 									} else {
 										val := srcCol.Get(srcStartIdx)
-										outCol[outStartIdx] = val
+										outCol.Set(outStartIdx, val)
 									}
 									outStartIdx++
 									b.builderState.left.curSrcStartIdx++
@@ -743,7 +743,7 @@ func (b *crossJoinerBase) buildFromLeftInput(ctx context.Context, destStartIdx i
 									} else {
 										val := srcCol.Get(srcStartIdx)
 										for i := 0; i < toAppend; i++ {
-											outCol[outStartIdx] = val
+											outCol.Set(outStartIdx, val)
 											outStartIdx++
 										}
 									}
@@ -810,7 +810,7 @@ func (b *crossJoinerBase) buildFromLeftInput(ctx context.Context, destStartIdx i
 										outNulls.SetNull(outStartIdx)
 									} else {
 										val := srcCol.Get(srcStartIdx)
-										outCol[outStartIdx] = val
+										outCol.Set(outStartIdx, val)
 									}
 									outStartIdx++
 									b.builderState.left.curSrcStartIdx++
@@ -863,7 +863,7 @@ func (b *crossJoinerBase) buildFromLeftInput(ctx context.Context, destStartIdx i
 									} else {
 										val := srcCol.Get(srcStartIdx)
 										for i := 0; i < toAppend; i++ {
-											outCol[outStartIdx] = val
+											outCol.Set(outStartIdx, val)
 											outStartIdx++
 										}
 									}
@@ -930,7 +930,7 @@ func (b *crossJoinerBase) buildFromLeftInput(ctx context.Context, destStartIdx i
 										outNulls.SetNull(outStartIdx)
 									} else {
 										val := srcCol.Get(srcStartIdx)
-										outCol[outStartIdx] = val
+										outCol.Set(outStartIdx, val)
 									}
 									outStartIdx++
 									b.builderState.left.curSrcStartIdx++
@@ -983,7 +983,7 @@ func (b *crossJoinerBase) buildFromLeftInput(ctx context.Context, destStartIdx i
 									} else {
 										val := srcCol.Get(srcStartIdx)
 										for i := 0; i < toAppend; i++ {
-											outCol[outStartIdx] = val
+											outCol.Set(outStartIdx, val)
 											outStartIdx++
 										}
 									}
@@ -1050,7 +1050,7 @@ func (b *crossJoinerBase) buildFromLeftInput(ctx context.Context, destStartIdx i
 										outNulls.SetNull(outStartIdx)
 									} else {
 										val := srcCol.Get(srcStartIdx)
-										outCol[outStartIdx] = val
+										outCol.Set(outStartIdx, val)
 									}
 									outStartIdx++
 									b.builderState.left.curSrcStartIdx++
@@ -1103,7 +1103,7 @@ func (b *crossJoinerBase) buildFromLeftInput(ctx context.Context, destStartIdx i
 									} else {
 										val := srcCol.Get(srcStartIdx)
 										for i := 0; i < toAppend; i++ {
-											outCol[outStartIdx] = val
+											outCol.Set(outStartIdx, val)
 											outStartIdx++
 										}
 									}
@@ -1463,7 +1463,7 @@ func (b *crossJoinerBase) buildFromRightInput(ctx context.Context, destStartIdx 
 										outNulls.SetNull(outStartIdx)
 									} else {
 										v := srcCol.Get(b.builderState.right.curSrcStartIdx)
-										outCol[outStartIdx] = v
+										outCol.Set(outStartIdx, v)
 									}
 								} else {
 									out.Copy(
@@ -1521,7 +1521,7 @@ func (b *crossJoinerBase) buildFromRightInput(ctx context.Context, destStartIdx 
 										outNulls.SetNull(outStartIdx)
 									} else {
 										v := srcCol.Get(b.builderState.right.curSrcStartIdx)
-										outCol[outStartIdx].Set(&v)
+										outCol.Set(outStartIdx, v)
 									}
 								} else {
 									out.Copy(
@@ -1549,7 +1549,7 @@ func (b *crossJoinerBase) buildFromRightInput(ctx context.Context, destStartIdx 
 										outNulls.SetNull(outStartIdx)
 									} else {
 										v := srcCol.Get(b.builderState.right.curSrcStartIdx)
-										outCol[outStartIdx] = v
+										outCol.Set(outStartIdx, v)
 									}
 								} else {
 									out.Copy(
@@ -1574,7 +1574,7 @@ func (b *crossJoinerBase) buildFromRightInput(ctx context.Context, destStartIdx 
 										outNulls.SetNull(outStartIdx)
 									} else {
 										v := srcCol.Get(b.builderState.right.curSrcStartIdx)
-										outCol[outStartIdx] = v
+										outCol.Set(outStartIdx, v)
 									}
 								} else {
 									out.Copy(
@@ -1600,7 +1600,7 @@ func (b *crossJoinerBase) buildFromRightInput(ctx context.Context, destStartIdx 
 										outNulls.SetNull(outStartIdx)
 									} else {
 										v := srcCol.Get(b.builderState.right.curSrcStartIdx)
-										outCol[outStartIdx] = v
+										outCol.Set(outStartIdx, v)
 									}
 								} else {
 									out.Copy(
@@ -1629,7 +1629,7 @@ func (b *crossJoinerBase) buildFromRightInput(ctx context.Context, destStartIdx 
 										outNulls.SetNull(outStartIdx)
 									} else {
 										v := srcCol.Get(b.builderState.right.curSrcStartIdx)
-										outCol[outStartIdx] = v
+										outCol.Set(outStartIdx, v)
 									}
 								} else {
 									out.Copy(
@@ -1658,7 +1658,7 @@ func (b *crossJoinerBase) buildFromRightInput(ctx context.Context, destStartIdx 
 										outNulls.SetNull(outStartIdx)
 									} else {
 										v := srcCol.Get(b.builderState.right.curSrcStartIdx)
-										outCol[outStartIdx] = v
+										outCol.Set(outStartIdx, v)
 									}
 								} else {
 									out.Copy(
@@ -1687,7 +1687,7 @@ func (b *crossJoinerBase) buildFromRightInput(ctx context.Context, destStartIdx 
 										outNulls.SetNull(outStartIdx)
 									} else {
 										v := srcCol.Get(b.builderState.right.curSrcStartIdx)
-										outCol[outStartIdx] = v
+										outCol.Set(outStartIdx, v)
 									}
 								} else {
 									out.Copy(

--- a/pkg/sql/colexec/colexecjoin/crossjoiner_tmpl.go
+++ b/pkg/sql/colexec/colexecjoin/crossjoiner_tmpl.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
-	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/errors"
@@ -111,7 +110,7 @@ func (b *crossJoinerBase) buildFromLeftInput(ctx context.Context, destStartIdx i
 										outNulls.SetNull(outStartIdx)
 									} else {
 										val := srcCol.Get(srcStartIdx)
-										execgen.SET(outCol, outStartIdx, val)
+										outCol.Set(outStartIdx, val)
 									}
 									outStartIdx++
 									b.builderState.left.curSrcStartIdx++
@@ -164,7 +163,7 @@ func (b *crossJoinerBase) buildFromLeftInput(ctx context.Context, destStartIdx i
 									} else {
 										val := srcCol.Get(srcStartIdx)
 										for i := 0; i < toAppend; i++ {
-											execgen.SET(outCol, outStartIdx, val)
+											outCol.Set(outStartIdx, val)
 											outStartIdx++
 										}
 									}
@@ -288,7 +287,7 @@ func (b *crossJoinerBase) buildFromRightInput(ctx context.Context, destStartIdx 
 										outNulls.SetNull(outStartIdx)
 									} else {
 										v := srcCol.Get(b.builderState.right.curSrcStartIdx)
-										execgen.SET(outCol, outStartIdx, v)
+										outCol.Set(outStartIdx, v)
 									}
 								} else {
 									out.Copy(

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_exceptall.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_exceptall.eg.go
@@ -10848,7 +10848,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -10978,7 +10978,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx].Set(&val)
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -11042,7 +11042,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -11103,7 +11103,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -11165,7 +11165,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -11230,7 +11230,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -11295,7 +11295,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -11360,7 +11360,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -11564,7 +11564,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -11692,7 +11692,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx].Set(&val)
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -11755,7 +11755,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -11815,7 +11815,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -11876,7 +11876,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -11940,7 +11940,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -12004,7 +12004,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -12068,7 +12068,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -12305,7 +12305,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -12443,7 +12443,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx].Set(&v)
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -12511,7 +12511,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -12576,7 +12576,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -12642,7 +12642,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -12711,7 +12711,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -12780,7 +12780,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -12849,7 +12849,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -13066,7 +13066,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -13204,7 +13204,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx].Set(&v)
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -13272,7 +13272,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -13337,7 +13337,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -13403,7 +13403,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -13472,7 +13472,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -13541,7 +13541,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -13610,7 +13610,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_fullouter.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_fullouter.eg.go
@@ -11896,7 +11896,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -12026,7 +12026,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx].Set(&val)
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -12090,7 +12090,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -12151,7 +12151,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -12213,7 +12213,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -12278,7 +12278,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -12343,7 +12343,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -12408,7 +12408,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -12612,7 +12612,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -12740,7 +12740,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx].Set(&val)
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -12803,7 +12803,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -12863,7 +12863,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -12924,7 +12924,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -12988,7 +12988,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -13052,7 +13052,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -13116,7 +13116,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -13355,7 +13355,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -13497,7 +13497,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx].Set(&v)
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -13567,7 +13567,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -13634,7 +13634,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -13702,7 +13702,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -13773,7 +13773,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -13844,7 +13844,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -13915,7 +13915,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -14138,7 +14138,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -14280,7 +14280,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx].Set(&v)
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -14350,7 +14350,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -14417,7 +14417,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -14485,7 +14485,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -14556,7 +14556,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -14627,7 +14627,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -14698,7 +14698,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_inner.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_inner.eg.go
@@ -7465,7 +7465,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -7589,7 +7589,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx].Set(&val)
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -7650,7 +7650,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -7708,7 +7708,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -7767,7 +7767,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -7829,7 +7829,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -7891,7 +7891,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -7953,7 +7953,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -8148,7 +8148,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -8270,7 +8270,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx].Set(&val)
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -8330,7 +8330,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -8387,7 +8387,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -8445,7 +8445,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -8506,7 +8506,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -8567,7 +8567,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -8628,7 +8628,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -8859,7 +8859,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -8997,7 +8997,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx].Set(&v)
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -9065,7 +9065,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -9130,7 +9130,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -9196,7 +9196,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -9265,7 +9265,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -9334,7 +9334,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -9403,7 +9403,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -9620,7 +9620,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -9758,7 +9758,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx].Set(&v)
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -9826,7 +9826,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -9891,7 +9891,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -9957,7 +9957,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -10026,7 +10026,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -10095,7 +10095,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -10164,7 +10164,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_intersectall.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_intersectall.eg.go
@@ -8301,7 +8301,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -8425,7 +8425,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx].Set(&val)
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -8486,7 +8486,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -8544,7 +8544,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -8603,7 +8603,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -8665,7 +8665,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -8727,7 +8727,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -8789,7 +8789,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -8984,7 +8984,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -9106,7 +9106,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx].Set(&val)
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -9166,7 +9166,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -9223,7 +9223,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -9281,7 +9281,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -9342,7 +9342,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -9403,7 +9403,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -9464,7 +9464,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -9695,7 +9695,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -9833,7 +9833,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx].Set(&v)
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -9901,7 +9901,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -9966,7 +9966,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -10032,7 +10032,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -10101,7 +10101,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -10170,7 +10170,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -10239,7 +10239,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -10456,7 +10456,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -10594,7 +10594,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx].Set(&v)
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -10662,7 +10662,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -10727,7 +10727,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -10793,7 +10793,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -10862,7 +10862,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -10931,7 +10931,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -11000,7 +11000,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_leftanti.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_leftanti.eg.go
@@ -9660,7 +9660,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -9790,7 +9790,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx].Set(&val)
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -9854,7 +9854,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -9915,7 +9915,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -9977,7 +9977,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -10042,7 +10042,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -10107,7 +10107,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -10172,7 +10172,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -10376,7 +10376,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -10504,7 +10504,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx].Set(&val)
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -10567,7 +10567,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -10627,7 +10627,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -10688,7 +10688,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -10752,7 +10752,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -10816,7 +10816,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -10880,7 +10880,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -11117,7 +11117,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -11255,7 +11255,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx].Set(&v)
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -11323,7 +11323,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -11388,7 +11388,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -11454,7 +11454,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -11523,7 +11523,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -11592,7 +11592,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -11661,7 +11661,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -11878,7 +11878,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -12016,7 +12016,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx].Set(&v)
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -12084,7 +12084,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -12149,7 +12149,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -12215,7 +12215,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -12284,7 +12284,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -12353,7 +12353,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -12422,7 +12422,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_leftouter.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_leftouter.eg.go
@@ -9701,7 +9701,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -9825,7 +9825,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx].Set(&val)
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -9886,7 +9886,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -9944,7 +9944,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -10003,7 +10003,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -10065,7 +10065,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -10127,7 +10127,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -10189,7 +10189,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -10384,7 +10384,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -10506,7 +10506,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx].Set(&val)
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -10566,7 +10566,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -10623,7 +10623,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -10681,7 +10681,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -10742,7 +10742,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -10803,7 +10803,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -10864,7 +10864,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -11097,7 +11097,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -11239,7 +11239,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx].Set(&v)
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -11309,7 +11309,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -11376,7 +11376,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -11444,7 +11444,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -11515,7 +11515,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -11586,7 +11586,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -11657,7 +11657,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -11880,7 +11880,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -12022,7 +12022,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx].Set(&v)
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -12092,7 +12092,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -12159,7 +12159,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -12227,7 +12227,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -12298,7 +12298,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -12369,7 +12369,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -12440,7 +12440,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_leftsemi.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_leftsemi.eg.go
@@ -7421,7 +7421,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -7545,7 +7545,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx].Set(&val)
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -7606,7 +7606,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -7664,7 +7664,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -7723,7 +7723,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -7785,7 +7785,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -7847,7 +7847,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -7909,7 +7909,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -8104,7 +8104,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -8226,7 +8226,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx].Set(&val)
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -8286,7 +8286,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -8343,7 +8343,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -8401,7 +8401,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -8462,7 +8462,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -8523,7 +8523,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -8584,7 +8584,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -8815,7 +8815,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -8953,7 +8953,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx].Set(&v)
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -9021,7 +9021,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -9086,7 +9086,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -9152,7 +9152,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -9221,7 +9221,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -9290,7 +9290,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -9359,7 +9359,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -9576,7 +9576,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -9714,7 +9714,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx].Set(&v)
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -9782,7 +9782,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -9847,7 +9847,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -9913,7 +9913,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -9982,7 +9982,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -10051,7 +10051,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -10120,7 +10120,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_rightanti.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_rightanti.eg.go
@@ -9616,7 +9616,7 @@ func (o *mergeJoinRightAntiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -9746,7 +9746,7 @@ func (o *mergeJoinRightAntiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx].Set(&val)
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -9810,7 +9810,7 @@ func (o *mergeJoinRightAntiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -9871,7 +9871,7 @@ func (o *mergeJoinRightAntiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -9933,7 +9933,7 @@ func (o *mergeJoinRightAntiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -9998,7 +9998,7 @@ func (o *mergeJoinRightAntiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -10063,7 +10063,7 @@ func (o *mergeJoinRightAntiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -10128,7 +10128,7 @@ func (o *mergeJoinRightAntiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -10332,7 +10332,7 @@ func (o *mergeJoinRightAntiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -10460,7 +10460,7 @@ func (o *mergeJoinRightAntiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx].Set(&val)
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -10523,7 +10523,7 @@ func (o *mergeJoinRightAntiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -10583,7 +10583,7 @@ func (o *mergeJoinRightAntiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -10644,7 +10644,7 @@ func (o *mergeJoinRightAntiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -10708,7 +10708,7 @@ func (o *mergeJoinRightAntiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -10772,7 +10772,7 @@ func (o *mergeJoinRightAntiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -10836,7 +10836,7 @@ func (o *mergeJoinRightAntiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -11073,7 +11073,7 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -11211,7 +11211,7 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx].Set(&v)
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -11279,7 +11279,7 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -11344,7 +11344,7 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -11410,7 +11410,7 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -11479,7 +11479,7 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -11548,7 +11548,7 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -11617,7 +11617,7 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -11834,7 +11834,7 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -11972,7 +11972,7 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx].Set(&v)
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -12040,7 +12040,7 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -12105,7 +12105,7 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -12171,7 +12171,7 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -12240,7 +12240,7 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -12309,7 +12309,7 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -12378,7 +12378,7 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_rightouter.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_rightouter.eg.go
@@ -9660,7 +9660,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -9790,7 +9790,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx].Set(&val)
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -9854,7 +9854,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -9915,7 +9915,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -9977,7 +9977,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -10042,7 +10042,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -10107,7 +10107,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -10172,7 +10172,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -10376,7 +10376,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -10504,7 +10504,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx].Set(&val)
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -10567,7 +10567,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -10627,7 +10627,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -10688,7 +10688,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -10752,7 +10752,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -10816,7 +10816,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -10880,7 +10880,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -11117,7 +11117,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -11255,7 +11255,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx].Set(&v)
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -11323,7 +11323,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -11388,7 +11388,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -11454,7 +11454,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -11523,7 +11523,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -11592,7 +11592,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -11661,7 +11661,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -11878,7 +11878,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -12016,7 +12016,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx].Set(&v)
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -12084,7 +12084,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -12149,7 +12149,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -12215,7 +12215,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -12284,7 +12284,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -12353,7 +12353,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -12422,7 +12422,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_rightsemi.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_rightsemi.eg.go
@@ -7377,7 +7377,7 @@ func (o *mergeJoinRightSemiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -7501,7 +7501,7 @@ func (o *mergeJoinRightSemiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx].Set(&val)
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -7562,7 +7562,7 @@ func (o *mergeJoinRightSemiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -7620,7 +7620,7 @@ func (o *mergeJoinRightSemiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -7679,7 +7679,7 @@ func (o *mergeJoinRightSemiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -7741,7 +7741,7 @@ func (o *mergeJoinRightSemiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -7803,7 +7803,7 @@ func (o *mergeJoinRightSemiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -7865,7 +7865,7 @@ func (o *mergeJoinRightSemiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -8060,7 +8060,7 @@ func (o *mergeJoinRightSemiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -8182,7 +8182,7 @@ func (o *mergeJoinRightSemiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx].Set(&val)
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -8242,7 +8242,7 @@ func (o *mergeJoinRightSemiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -8299,7 +8299,7 @@ func (o *mergeJoinRightSemiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -8357,7 +8357,7 @@ func (o *mergeJoinRightSemiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -8418,7 +8418,7 @@ func (o *mergeJoinRightSemiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -8479,7 +8479,7 @@ func (o *mergeJoinRightSemiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -8540,7 +8540,7 @@ func (o *mergeJoinRightSemiOp) buildLeftGroupsFromBatch(
 										} else {
 											val = srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol[outStartIdx] = val
+												outCol.Set(outStartIdx, val)
 												outStartIdx++
 											}
 										}
@@ -8771,7 +8771,7 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -8909,7 +8909,7 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx].Set(&v)
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -8977,7 +8977,7 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -9042,7 +9042,7 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -9108,7 +9108,7 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -9177,7 +9177,7 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -9246,7 +9246,7 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -9315,7 +9315,7 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -9532,7 +9532,7 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -9670,7 +9670,7 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx].Set(&v)
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -9738,7 +9738,7 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -9803,7 +9803,7 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -9869,7 +9869,7 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -9938,7 +9938,7 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -10007,7 +10007,7 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(
@@ -10076,7 +10076,7 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 												outNulls.SetNull(outStartIdx)
 											} else {
 												v := srcCol.Get(srcIdx)
-												outCol[outStartIdx] = v
+												outCol.Set(outStartIdx, v)
 											}
 										} else {
 											out.Copy(

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_tmpl.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_tmpl.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coldataext"
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
-	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
@@ -727,7 +726,7 @@ func _LEFT_SWITCH(_JOIN_TYPE joinTypeInfo, _HAS_SELECTION bool) { // */}}
 						} else {
 							val = srcCol.Get(srcStartIdx)
 							for i := 0; i < toAppend; i++ {
-								execgen.SET(outCol, outStartIdx, val)
+								outCol.Set(outStartIdx, val)
 								outStartIdx++
 							}
 						}
@@ -869,7 +868,7 @@ func _RIGHT_SWITCH(_JOIN_TYPE joinTypeInfo, _HAS_SELECTION bool) { // */}}
 								outNulls.SetNull(outStartIdx)
 							} else {
 								v := srcCol.Get(srcIdx)
-								execgen.SET(outCol, outStartIdx, v)
+								outCol.Set(outStartIdx, v)
 							}
 						} else {
 							out.Copy(

--- a/pkg/sql/colexec/colexecwindow/lag.eg.go
+++ b/pkg/sql/colexec/colexecwindow/lag.eg.go
@@ -261,7 +261,7 @@ func (w *lagBoolWindow) processBatch(batch coldata.Batch, startIdx, endIdx int) 
 						continue
 					}
 					val := defaultCol.Get(i)
-					leadLagCol[i] = val
+					leadLagCol.Set(i, val)
 					continue
 				}
 				b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -272,7 +272,7 @@ func (w *lagBoolWindow) processBatch(batch coldata.Batch, startIdx, endIdx int) 
 				}
 				col := vec.Bool()
 				val := col.Get(idx)
-				leadLagCol[i] = val
+				leadLagCol.Set(i, val)
 			}
 			return
 		}
@@ -288,7 +288,7 @@ func (w *lagBoolWindow) processBatch(batch coldata.Batch, startIdx, endIdx int) 
 			if requestedIdx < 0 || requestedIdx >= w.partitionSize {
 				// The offset is out of range, so set the output value to the default.
 				val := defaultCol.Get(i)
-				leadLagCol[i] = val
+				leadLagCol.Set(i, val)
 				continue
 			}
 			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -299,7 +299,7 @@ func (w *lagBoolWindow) processBatch(batch coldata.Batch, startIdx, endIdx int) 
 			}
 			col := vec.Bool()
 			val := col.Get(idx)
-			leadLagCol[i] = val
+			leadLagCol.Set(i, val)
 		}
 		return
 	}
@@ -314,7 +314,7 @@ func (w *lagBoolWindow) processBatch(batch coldata.Batch, startIdx, endIdx int) 
 					continue
 				}
 				val := defaultCol.Get(i)
-				leadLagCol[i] = val
+				leadLagCol.Set(i, val)
 				continue
 			}
 			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -325,7 +325,7 @@ func (w *lagBoolWindow) processBatch(batch coldata.Batch, startIdx, endIdx int) 
 			}
 			col := vec.Bool()
 			val := col.Get(idx)
-			leadLagCol[i] = val
+			leadLagCol.Set(i, val)
 		}
 		return
 	}
@@ -335,7 +335,7 @@ func (w *lagBoolWindow) processBatch(batch coldata.Batch, startIdx, endIdx int) 
 		if requestedIdx < 0 || requestedIdx >= w.partitionSize {
 			// The offset is out of range, so set the output value to the default.
 			val := defaultCol.Get(i)
-			leadLagCol[i] = val
+			leadLagCol.Set(i, val)
 			continue
 		}
 		b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -346,7 +346,7 @@ func (w *lagBoolWindow) processBatch(batch coldata.Batch, startIdx, endIdx int) 
 		}
 		col := vec.Bool()
 		val := col.Get(idx)
-		leadLagCol[i] = val
+		leadLagCol.Set(i, val)
 	}
 }
 
@@ -601,7 +601,7 @@ func (w *lagDecimalWindow) processBatch(batch coldata.Batch, startIdx, endIdx in
 						continue
 					}
 					val := defaultCol.Get(i)
-					leadLagCol[i].Set(&val)
+					leadLagCol.Set(i, val)
 					continue
 				}
 				b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -612,7 +612,7 @@ func (w *lagDecimalWindow) processBatch(batch coldata.Batch, startIdx, endIdx in
 				}
 				col := vec.Decimal()
 				val := col.Get(idx)
-				leadLagCol[i].Set(&val)
+				leadLagCol.Set(i, val)
 			}
 			return
 		}
@@ -628,7 +628,7 @@ func (w *lagDecimalWindow) processBatch(batch coldata.Batch, startIdx, endIdx in
 			if requestedIdx < 0 || requestedIdx >= w.partitionSize {
 				// The offset is out of range, so set the output value to the default.
 				val := defaultCol.Get(i)
-				leadLagCol[i].Set(&val)
+				leadLagCol.Set(i, val)
 				continue
 			}
 			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -639,7 +639,7 @@ func (w *lagDecimalWindow) processBatch(batch coldata.Batch, startIdx, endIdx in
 			}
 			col := vec.Decimal()
 			val := col.Get(idx)
-			leadLagCol[i].Set(&val)
+			leadLagCol.Set(i, val)
 		}
 		return
 	}
@@ -654,7 +654,7 @@ func (w *lagDecimalWindow) processBatch(batch coldata.Batch, startIdx, endIdx in
 					continue
 				}
 				val := defaultCol.Get(i)
-				leadLagCol[i].Set(&val)
+				leadLagCol.Set(i, val)
 				continue
 			}
 			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -665,7 +665,7 @@ func (w *lagDecimalWindow) processBatch(batch coldata.Batch, startIdx, endIdx in
 			}
 			col := vec.Decimal()
 			val := col.Get(idx)
-			leadLagCol[i].Set(&val)
+			leadLagCol.Set(i, val)
 		}
 		return
 	}
@@ -675,7 +675,7 @@ func (w *lagDecimalWindow) processBatch(batch coldata.Batch, startIdx, endIdx in
 		if requestedIdx < 0 || requestedIdx >= w.partitionSize {
 			// The offset is out of range, so set the output value to the default.
 			val := defaultCol.Get(i)
-			leadLagCol[i].Set(&val)
+			leadLagCol.Set(i, val)
 			continue
 		}
 		b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -686,7 +686,7 @@ func (w *lagDecimalWindow) processBatch(batch coldata.Batch, startIdx, endIdx in
 		}
 		col := vec.Decimal()
 		val := col.Get(idx)
-		leadLagCol[i].Set(&val)
+		leadLagCol.Set(i, val)
 	}
 }
 
@@ -773,7 +773,7 @@ func (w *lagInt16Window) processBatch(batch coldata.Batch, startIdx, endIdx int)
 						continue
 					}
 					val := defaultCol.Get(i)
-					leadLagCol[i] = val
+					leadLagCol.Set(i, val)
 					continue
 				}
 				b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -784,7 +784,7 @@ func (w *lagInt16Window) processBatch(batch coldata.Batch, startIdx, endIdx int)
 				}
 				col := vec.Int16()
 				val := col.Get(idx)
-				leadLagCol[i] = val
+				leadLagCol.Set(i, val)
 			}
 			return
 		}
@@ -800,7 +800,7 @@ func (w *lagInt16Window) processBatch(batch coldata.Batch, startIdx, endIdx int)
 			if requestedIdx < 0 || requestedIdx >= w.partitionSize {
 				// The offset is out of range, so set the output value to the default.
 				val := defaultCol.Get(i)
-				leadLagCol[i] = val
+				leadLagCol.Set(i, val)
 				continue
 			}
 			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -811,7 +811,7 @@ func (w *lagInt16Window) processBatch(batch coldata.Batch, startIdx, endIdx int)
 			}
 			col := vec.Int16()
 			val := col.Get(idx)
-			leadLagCol[i] = val
+			leadLagCol.Set(i, val)
 		}
 		return
 	}
@@ -826,7 +826,7 @@ func (w *lagInt16Window) processBatch(batch coldata.Batch, startIdx, endIdx int)
 					continue
 				}
 				val := defaultCol.Get(i)
-				leadLagCol[i] = val
+				leadLagCol.Set(i, val)
 				continue
 			}
 			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -837,7 +837,7 @@ func (w *lagInt16Window) processBatch(batch coldata.Batch, startIdx, endIdx int)
 			}
 			col := vec.Int16()
 			val := col.Get(idx)
-			leadLagCol[i] = val
+			leadLagCol.Set(i, val)
 		}
 		return
 	}
@@ -847,7 +847,7 @@ func (w *lagInt16Window) processBatch(batch coldata.Batch, startIdx, endIdx int)
 		if requestedIdx < 0 || requestedIdx >= w.partitionSize {
 			// The offset is out of range, so set the output value to the default.
 			val := defaultCol.Get(i)
-			leadLagCol[i] = val
+			leadLagCol.Set(i, val)
 			continue
 		}
 		b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -858,7 +858,7 @@ func (w *lagInt16Window) processBatch(batch coldata.Batch, startIdx, endIdx int)
 		}
 		col := vec.Int16()
 		val := col.Get(idx)
-		leadLagCol[i] = val
+		leadLagCol.Set(i, val)
 	}
 }
 
@@ -945,7 +945,7 @@ func (w *lagInt32Window) processBatch(batch coldata.Batch, startIdx, endIdx int)
 						continue
 					}
 					val := defaultCol.Get(i)
-					leadLagCol[i] = val
+					leadLagCol.Set(i, val)
 					continue
 				}
 				b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -956,7 +956,7 @@ func (w *lagInt32Window) processBatch(batch coldata.Batch, startIdx, endIdx int)
 				}
 				col := vec.Int32()
 				val := col.Get(idx)
-				leadLagCol[i] = val
+				leadLagCol.Set(i, val)
 			}
 			return
 		}
@@ -972,7 +972,7 @@ func (w *lagInt32Window) processBatch(batch coldata.Batch, startIdx, endIdx int)
 			if requestedIdx < 0 || requestedIdx >= w.partitionSize {
 				// The offset is out of range, so set the output value to the default.
 				val := defaultCol.Get(i)
-				leadLagCol[i] = val
+				leadLagCol.Set(i, val)
 				continue
 			}
 			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -983,7 +983,7 @@ func (w *lagInt32Window) processBatch(batch coldata.Batch, startIdx, endIdx int)
 			}
 			col := vec.Int32()
 			val := col.Get(idx)
-			leadLagCol[i] = val
+			leadLagCol.Set(i, val)
 		}
 		return
 	}
@@ -998,7 +998,7 @@ func (w *lagInt32Window) processBatch(batch coldata.Batch, startIdx, endIdx int)
 					continue
 				}
 				val := defaultCol.Get(i)
-				leadLagCol[i] = val
+				leadLagCol.Set(i, val)
 				continue
 			}
 			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -1009,7 +1009,7 @@ func (w *lagInt32Window) processBatch(batch coldata.Batch, startIdx, endIdx int)
 			}
 			col := vec.Int32()
 			val := col.Get(idx)
-			leadLagCol[i] = val
+			leadLagCol.Set(i, val)
 		}
 		return
 	}
@@ -1019,7 +1019,7 @@ func (w *lagInt32Window) processBatch(batch coldata.Batch, startIdx, endIdx int)
 		if requestedIdx < 0 || requestedIdx >= w.partitionSize {
 			// The offset is out of range, so set the output value to the default.
 			val := defaultCol.Get(i)
-			leadLagCol[i] = val
+			leadLagCol.Set(i, val)
 			continue
 		}
 		b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -1030,7 +1030,7 @@ func (w *lagInt32Window) processBatch(batch coldata.Batch, startIdx, endIdx int)
 		}
 		col := vec.Int32()
 		val := col.Get(idx)
-		leadLagCol[i] = val
+		leadLagCol.Set(i, val)
 	}
 }
 
@@ -1117,7 +1117,7 @@ func (w *lagInt64Window) processBatch(batch coldata.Batch, startIdx, endIdx int)
 						continue
 					}
 					val := defaultCol.Get(i)
-					leadLagCol[i] = val
+					leadLagCol.Set(i, val)
 					continue
 				}
 				b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -1128,7 +1128,7 @@ func (w *lagInt64Window) processBatch(batch coldata.Batch, startIdx, endIdx int)
 				}
 				col := vec.Int64()
 				val := col.Get(idx)
-				leadLagCol[i] = val
+				leadLagCol.Set(i, val)
 			}
 			return
 		}
@@ -1144,7 +1144,7 @@ func (w *lagInt64Window) processBatch(batch coldata.Batch, startIdx, endIdx int)
 			if requestedIdx < 0 || requestedIdx >= w.partitionSize {
 				// The offset is out of range, so set the output value to the default.
 				val := defaultCol.Get(i)
-				leadLagCol[i] = val
+				leadLagCol.Set(i, val)
 				continue
 			}
 			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -1155,7 +1155,7 @@ func (w *lagInt64Window) processBatch(batch coldata.Batch, startIdx, endIdx int)
 			}
 			col := vec.Int64()
 			val := col.Get(idx)
-			leadLagCol[i] = val
+			leadLagCol.Set(i, val)
 		}
 		return
 	}
@@ -1170,7 +1170,7 @@ func (w *lagInt64Window) processBatch(batch coldata.Batch, startIdx, endIdx int)
 					continue
 				}
 				val := defaultCol.Get(i)
-				leadLagCol[i] = val
+				leadLagCol.Set(i, val)
 				continue
 			}
 			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -1181,7 +1181,7 @@ func (w *lagInt64Window) processBatch(batch coldata.Batch, startIdx, endIdx int)
 			}
 			col := vec.Int64()
 			val := col.Get(idx)
-			leadLagCol[i] = val
+			leadLagCol.Set(i, val)
 		}
 		return
 	}
@@ -1191,7 +1191,7 @@ func (w *lagInt64Window) processBatch(batch coldata.Batch, startIdx, endIdx int)
 		if requestedIdx < 0 || requestedIdx >= w.partitionSize {
 			// The offset is out of range, so set the output value to the default.
 			val := defaultCol.Get(i)
-			leadLagCol[i] = val
+			leadLagCol.Set(i, val)
 			continue
 		}
 		b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -1202,7 +1202,7 @@ func (w *lagInt64Window) processBatch(batch coldata.Batch, startIdx, endIdx int)
 		}
 		col := vec.Int64()
 		val := col.Get(idx)
-		leadLagCol[i] = val
+		leadLagCol.Set(i, val)
 	}
 }
 
@@ -1289,7 +1289,7 @@ func (w *lagFloat64Window) processBatch(batch coldata.Batch, startIdx, endIdx in
 						continue
 					}
 					val := defaultCol.Get(i)
-					leadLagCol[i] = val
+					leadLagCol.Set(i, val)
 					continue
 				}
 				b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -1300,7 +1300,7 @@ func (w *lagFloat64Window) processBatch(batch coldata.Batch, startIdx, endIdx in
 				}
 				col := vec.Float64()
 				val := col.Get(idx)
-				leadLagCol[i] = val
+				leadLagCol.Set(i, val)
 			}
 			return
 		}
@@ -1316,7 +1316,7 @@ func (w *lagFloat64Window) processBatch(batch coldata.Batch, startIdx, endIdx in
 			if requestedIdx < 0 || requestedIdx >= w.partitionSize {
 				// The offset is out of range, so set the output value to the default.
 				val := defaultCol.Get(i)
-				leadLagCol[i] = val
+				leadLagCol.Set(i, val)
 				continue
 			}
 			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -1327,7 +1327,7 @@ func (w *lagFloat64Window) processBatch(batch coldata.Batch, startIdx, endIdx in
 			}
 			col := vec.Float64()
 			val := col.Get(idx)
-			leadLagCol[i] = val
+			leadLagCol.Set(i, val)
 		}
 		return
 	}
@@ -1342,7 +1342,7 @@ func (w *lagFloat64Window) processBatch(batch coldata.Batch, startIdx, endIdx in
 					continue
 				}
 				val := defaultCol.Get(i)
-				leadLagCol[i] = val
+				leadLagCol.Set(i, val)
 				continue
 			}
 			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -1353,7 +1353,7 @@ func (w *lagFloat64Window) processBatch(batch coldata.Batch, startIdx, endIdx in
 			}
 			col := vec.Float64()
 			val := col.Get(idx)
-			leadLagCol[i] = val
+			leadLagCol.Set(i, val)
 		}
 		return
 	}
@@ -1363,7 +1363,7 @@ func (w *lagFloat64Window) processBatch(batch coldata.Batch, startIdx, endIdx in
 		if requestedIdx < 0 || requestedIdx >= w.partitionSize {
 			// The offset is out of range, so set the output value to the default.
 			val := defaultCol.Get(i)
-			leadLagCol[i] = val
+			leadLagCol.Set(i, val)
 			continue
 		}
 		b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -1374,7 +1374,7 @@ func (w *lagFloat64Window) processBatch(batch coldata.Batch, startIdx, endIdx in
 		}
 		col := vec.Float64()
 		val := col.Get(idx)
-		leadLagCol[i] = val
+		leadLagCol.Set(i, val)
 	}
 }
 
@@ -1461,7 +1461,7 @@ func (w *lagTimestampWindow) processBatch(batch coldata.Batch, startIdx, endIdx 
 						continue
 					}
 					val := defaultCol.Get(i)
-					leadLagCol[i] = val
+					leadLagCol.Set(i, val)
 					continue
 				}
 				b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -1472,7 +1472,7 @@ func (w *lagTimestampWindow) processBatch(batch coldata.Batch, startIdx, endIdx 
 				}
 				col := vec.Timestamp()
 				val := col.Get(idx)
-				leadLagCol[i] = val
+				leadLagCol.Set(i, val)
 			}
 			return
 		}
@@ -1488,7 +1488,7 @@ func (w *lagTimestampWindow) processBatch(batch coldata.Batch, startIdx, endIdx 
 			if requestedIdx < 0 || requestedIdx >= w.partitionSize {
 				// The offset is out of range, so set the output value to the default.
 				val := defaultCol.Get(i)
-				leadLagCol[i] = val
+				leadLagCol.Set(i, val)
 				continue
 			}
 			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -1499,7 +1499,7 @@ func (w *lagTimestampWindow) processBatch(batch coldata.Batch, startIdx, endIdx 
 			}
 			col := vec.Timestamp()
 			val := col.Get(idx)
-			leadLagCol[i] = val
+			leadLagCol.Set(i, val)
 		}
 		return
 	}
@@ -1514,7 +1514,7 @@ func (w *lagTimestampWindow) processBatch(batch coldata.Batch, startIdx, endIdx 
 					continue
 				}
 				val := defaultCol.Get(i)
-				leadLagCol[i] = val
+				leadLagCol.Set(i, val)
 				continue
 			}
 			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -1525,7 +1525,7 @@ func (w *lagTimestampWindow) processBatch(batch coldata.Batch, startIdx, endIdx 
 			}
 			col := vec.Timestamp()
 			val := col.Get(idx)
-			leadLagCol[i] = val
+			leadLagCol.Set(i, val)
 		}
 		return
 	}
@@ -1535,7 +1535,7 @@ func (w *lagTimestampWindow) processBatch(batch coldata.Batch, startIdx, endIdx 
 		if requestedIdx < 0 || requestedIdx >= w.partitionSize {
 			// The offset is out of range, so set the output value to the default.
 			val := defaultCol.Get(i)
-			leadLagCol[i] = val
+			leadLagCol.Set(i, val)
 			continue
 		}
 		b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -1546,7 +1546,7 @@ func (w *lagTimestampWindow) processBatch(batch coldata.Batch, startIdx, endIdx 
 		}
 		col := vec.Timestamp()
 		val := col.Get(idx)
-		leadLagCol[i] = val
+		leadLagCol.Set(i, val)
 	}
 }
 
@@ -1633,7 +1633,7 @@ func (w *lagIntervalWindow) processBatch(batch coldata.Batch, startIdx, endIdx i
 						continue
 					}
 					val := defaultCol.Get(i)
-					leadLagCol[i] = val
+					leadLagCol.Set(i, val)
 					continue
 				}
 				b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -1644,7 +1644,7 @@ func (w *lagIntervalWindow) processBatch(batch coldata.Batch, startIdx, endIdx i
 				}
 				col := vec.Interval()
 				val := col.Get(idx)
-				leadLagCol[i] = val
+				leadLagCol.Set(i, val)
 			}
 			return
 		}
@@ -1660,7 +1660,7 @@ func (w *lagIntervalWindow) processBatch(batch coldata.Batch, startIdx, endIdx i
 			if requestedIdx < 0 || requestedIdx >= w.partitionSize {
 				// The offset is out of range, so set the output value to the default.
 				val := defaultCol.Get(i)
-				leadLagCol[i] = val
+				leadLagCol.Set(i, val)
 				continue
 			}
 			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -1671,7 +1671,7 @@ func (w *lagIntervalWindow) processBatch(batch coldata.Batch, startIdx, endIdx i
 			}
 			col := vec.Interval()
 			val := col.Get(idx)
-			leadLagCol[i] = val
+			leadLagCol.Set(i, val)
 		}
 		return
 	}
@@ -1686,7 +1686,7 @@ func (w *lagIntervalWindow) processBatch(batch coldata.Batch, startIdx, endIdx i
 					continue
 				}
 				val := defaultCol.Get(i)
-				leadLagCol[i] = val
+				leadLagCol.Set(i, val)
 				continue
 			}
 			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -1697,7 +1697,7 @@ func (w *lagIntervalWindow) processBatch(batch coldata.Batch, startIdx, endIdx i
 			}
 			col := vec.Interval()
 			val := col.Get(idx)
-			leadLagCol[i] = val
+			leadLagCol.Set(i, val)
 		}
 		return
 	}
@@ -1707,7 +1707,7 @@ func (w *lagIntervalWindow) processBatch(batch coldata.Batch, startIdx, endIdx i
 		if requestedIdx < 0 || requestedIdx >= w.partitionSize {
 			// The offset is out of range, so set the output value to the default.
 			val := defaultCol.Get(i)
-			leadLagCol[i] = val
+			leadLagCol.Set(i, val)
 			continue
 		}
 		b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -1718,7 +1718,7 @@ func (w *lagIntervalWindow) processBatch(batch coldata.Batch, startIdx, endIdx i
 		}
 		col := vec.Interval()
 		val := col.Get(idx)
-		leadLagCol[i] = val
+		leadLagCol.Set(i, val)
 	}
 }
 

--- a/pkg/sql/colexec/colexecwindow/lead.eg.go
+++ b/pkg/sql/colexec/colexecwindow/lead.eg.go
@@ -261,7 +261,7 @@ func (w *leadBoolWindow) processBatch(batch coldata.Batch, startIdx, endIdx int)
 						continue
 					}
 					val := defaultCol.Get(i)
-					leadLagCol[i] = val
+					leadLagCol.Set(i, val)
 					continue
 				}
 				b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -272,7 +272,7 @@ func (w *leadBoolWindow) processBatch(batch coldata.Batch, startIdx, endIdx int)
 				}
 				col := vec.Bool()
 				val := col.Get(idx)
-				leadLagCol[i] = val
+				leadLagCol.Set(i, val)
 			}
 			return
 		}
@@ -288,7 +288,7 @@ func (w *leadBoolWindow) processBatch(batch coldata.Batch, startIdx, endIdx int)
 			if requestedIdx < 0 || requestedIdx >= w.partitionSize {
 				// The offset is out of range, so set the output value to the default.
 				val := defaultCol.Get(i)
-				leadLagCol[i] = val
+				leadLagCol.Set(i, val)
 				continue
 			}
 			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -299,7 +299,7 @@ func (w *leadBoolWindow) processBatch(batch coldata.Batch, startIdx, endIdx int)
 			}
 			col := vec.Bool()
 			val := col.Get(idx)
-			leadLagCol[i] = val
+			leadLagCol.Set(i, val)
 		}
 		return
 	}
@@ -314,7 +314,7 @@ func (w *leadBoolWindow) processBatch(batch coldata.Batch, startIdx, endIdx int)
 					continue
 				}
 				val := defaultCol.Get(i)
-				leadLagCol[i] = val
+				leadLagCol.Set(i, val)
 				continue
 			}
 			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -325,7 +325,7 @@ func (w *leadBoolWindow) processBatch(batch coldata.Batch, startIdx, endIdx int)
 			}
 			col := vec.Bool()
 			val := col.Get(idx)
-			leadLagCol[i] = val
+			leadLagCol.Set(i, val)
 		}
 		return
 	}
@@ -335,7 +335,7 @@ func (w *leadBoolWindow) processBatch(batch coldata.Batch, startIdx, endIdx int)
 		if requestedIdx < 0 || requestedIdx >= w.partitionSize {
 			// The offset is out of range, so set the output value to the default.
 			val := defaultCol.Get(i)
-			leadLagCol[i] = val
+			leadLagCol.Set(i, val)
 			continue
 		}
 		b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -346,7 +346,7 @@ func (w *leadBoolWindow) processBatch(batch coldata.Batch, startIdx, endIdx int)
 		}
 		col := vec.Bool()
 		val := col.Get(idx)
-		leadLagCol[i] = val
+		leadLagCol.Set(i, val)
 	}
 }
 
@@ -601,7 +601,7 @@ func (w *leadDecimalWindow) processBatch(batch coldata.Batch, startIdx, endIdx i
 						continue
 					}
 					val := defaultCol.Get(i)
-					leadLagCol[i].Set(&val)
+					leadLagCol.Set(i, val)
 					continue
 				}
 				b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -612,7 +612,7 @@ func (w *leadDecimalWindow) processBatch(batch coldata.Batch, startIdx, endIdx i
 				}
 				col := vec.Decimal()
 				val := col.Get(idx)
-				leadLagCol[i].Set(&val)
+				leadLagCol.Set(i, val)
 			}
 			return
 		}
@@ -628,7 +628,7 @@ func (w *leadDecimalWindow) processBatch(batch coldata.Batch, startIdx, endIdx i
 			if requestedIdx < 0 || requestedIdx >= w.partitionSize {
 				// The offset is out of range, so set the output value to the default.
 				val := defaultCol.Get(i)
-				leadLagCol[i].Set(&val)
+				leadLagCol.Set(i, val)
 				continue
 			}
 			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -639,7 +639,7 @@ func (w *leadDecimalWindow) processBatch(batch coldata.Batch, startIdx, endIdx i
 			}
 			col := vec.Decimal()
 			val := col.Get(idx)
-			leadLagCol[i].Set(&val)
+			leadLagCol.Set(i, val)
 		}
 		return
 	}
@@ -654,7 +654,7 @@ func (w *leadDecimalWindow) processBatch(batch coldata.Batch, startIdx, endIdx i
 					continue
 				}
 				val := defaultCol.Get(i)
-				leadLagCol[i].Set(&val)
+				leadLagCol.Set(i, val)
 				continue
 			}
 			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -665,7 +665,7 @@ func (w *leadDecimalWindow) processBatch(batch coldata.Batch, startIdx, endIdx i
 			}
 			col := vec.Decimal()
 			val := col.Get(idx)
-			leadLagCol[i].Set(&val)
+			leadLagCol.Set(i, val)
 		}
 		return
 	}
@@ -675,7 +675,7 @@ func (w *leadDecimalWindow) processBatch(batch coldata.Batch, startIdx, endIdx i
 		if requestedIdx < 0 || requestedIdx >= w.partitionSize {
 			// The offset is out of range, so set the output value to the default.
 			val := defaultCol.Get(i)
-			leadLagCol[i].Set(&val)
+			leadLagCol.Set(i, val)
 			continue
 		}
 		b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -686,7 +686,7 @@ func (w *leadDecimalWindow) processBatch(batch coldata.Batch, startIdx, endIdx i
 		}
 		col := vec.Decimal()
 		val := col.Get(idx)
-		leadLagCol[i].Set(&val)
+		leadLagCol.Set(i, val)
 	}
 }
 
@@ -773,7 +773,7 @@ func (w *leadInt16Window) processBatch(batch coldata.Batch, startIdx, endIdx int
 						continue
 					}
 					val := defaultCol.Get(i)
-					leadLagCol[i] = val
+					leadLagCol.Set(i, val)
 					continue
 				}
 				b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -784,7 +784,7 @@ func (w *leadInt16Window) processBatch(batch coldata.Batch, startIdx, endIdx int
 				}
 				col := vec.Int16()
 				val := col.Get(idx)
-				leadLagCol[i] = val
+				leadLagCol.Set(i, val)
 			}
 			return
 		}
@@ -800,7 +800,7 @@ func (w *leadInt16Window) processBatch(batch coldata.Batch, startIdx, endIdx int
 			if requestedIdx < 0 || requestedIdx >= w.partitionSize {
 				// The offset is out of range, so set the output value to the default.
 				val := defaultCol.Get(i)
-				leadLagCol[i] = val
+				leadLagCol.Set(i, val)
 				continue
 			}
 			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -811,7 +811,7 @@ func (w *leadInt16Window) processBatch(batch coldata.Batch, startIdx, endIdx int
 			}
 			col := vec.Int16()
 			val := col.Get(idx)
-			leadLagCol[i] = val
+			leadLagCol.Set(i, val)
 		}
 		return
 	}
@@ -826,7 +826,7 @@ func (w *leadInt16Window) processBatch(batch coldata.Batch, startIdx, endIdx int
 					continue
 				}
 				val := defaultCol.Get(i)
-				leadLagCol[i] = val
+				leadLagCol.Set(i, val)
 				continue
 			}
 			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -837,7 +837,7 @@ func (w *leadInt16Window) processBatch(batch coldata.Batch, startIdx, endIdx int
 			}
 			col := vec.Int16()
 			val := col.Get(idx)
-			leadLagCol[i] = val
+			leadLagCol.Set(i, val)
 		}
 		return
 	}
@@ -847,7 +847,7 @@ func (w *leadInt16Window) processBatch(batch coldata.Batch, startIdx, endIdx int
 		if requestedIdx < 0 || requestedIdx >= w.partitionSize {
 			// The offset is out of range, so set the output value to the default.
 			val := defaultCol.Get(i)
-			leadLagCol[i] = val
+			leadLagCol.Set(i, val)
 			continue
 		}
 		b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -858,7 +858,7 @@ func (w *leadInt16Window) processBatch(batch coldata.Batch, startIdx, endIdx int
 		}
 		col := vec.Int16()
 		val := col.Get(idx)
-		leadLagCol[i] = val
+		leadLagCol.Set(i, val)
 	}
 }
 
@@ -945,7 +945,7 @@ func (w *leadInt32Window) processBatch(batch coldata.Batch, startIdx, endIdx int
 						continue
 					}
 					val := defaultCol.Get(i)
-					leadLagCol[i] = val
+					leadLagCol.Set(i, val)
 					continue
 				}
 				b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -956,7 +956,7 @@ func (w *leadInt32Window) processBatch(batch coldata.Batch, startIdx, endIdx int
 				}
 				col := vec.Int32()
 				val := col.Get(idx)
-				leadLagCol[i] = val
+				leadLagCol.Set(i, val)
 			}
 			return
 		}
@@ -972,7 +972,7 @@ func (w *leadInt32Window) processBatch(batch coldata.Batch, startIdx, endIdx int
 			if requestedIdx < 0 || requestedIdx >= w.partitionSize {
 				// The offset is out of range, so set the output value to the default.
 				val := defaultCol.Get(i)
-				leadLagCol[i] = val
+				leadLagCol.Set(i, val)
 				continue
 			}
 			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -983,7 +983,7 @@ func (w *leadInt32Window) processBatch(batch coldata.Batch, startIdx, endIdx int
 			}
 			col := vec.Int32()
 			val := col.Get(idx)
-			leadLagCol[i] = val
+			leadLagCol.Set(i, val)
 		}
 		return
 	}
@@ -998,7 +998,7 @@ func (w *leadInt32Window) processBatch(batch coldata.Batch, startIdx, endIdx int
 					continue
 				}
 				val := defaultCol.Get(i)
-				leadLagCol[i] = val
+				leadLagCol.Set(i, val)
 				continue
 			}
 			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -1009,7 +1009,7 @@ func (w *leadInt32Window) processBatch(batch coldata.Batch, startIdx, endIdx int
 			}
 			col := vec.Int32()
 			val := col.Get(idx)
-			leadLagCol[i] = val
+			leadLagCol.Set(i, val)
 		}
 		return
 	}
@@ -1019,7 +1019,7 @@ func (w *leadInt32Window) processBatch(batch coldata.Batch, startIdx, endIdx int
 		if requestedIdx < 0 || requestedIdx >= w.partitionSize {
 			// The offset is out of range, so set the output value to the default.
 			val := defaultCol.Get(i)
-			leadLagCol[i] = val
+			leadLagCol.Set(i, val)
 			continue
 		}
 		b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -1030,7 +1030,7 @@ func (w *leadInt32Window) processBatch(batch coldata.Batch, startIdx, endIdx int
 		}
 		col := vec.Int32()
 		val := col.Get(idx)
-		leadLagCol[i] = val
+		leadLagCol.Set(i, val)
 	}
 }
 
@@ -1117,7 +1117,7 @@ func (w *leadInt64Window) processBatch(batch coldata.Batch, startIdx, endIdx int
 						continue
 					}
 					val := defaultCol.Get(i)
-					leadLagCol[i] = val
+					leadLagCol.Set(i, val)
 					continue
 				}
 				b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -1128,7 +1128,7 @@ func (w *leadInt64Window) processBatch(batch coldata.Batch, startIdx, endIdx int
 				}
 				col := vec.Int64()
 				val := col.Get(idx)
-				leadLagCol[i] = val
+				leadLagCol.Set(i, val)
 			}
 			return
 		}
@@ -1144,7 +1144,7 @@ func (w *leadInt64Window) processBatch(batch coldata.Batch, startIdx, endIdx int
 			if requestedIdx < 0 || requestedIdx >= w.partitionSize {
 				// The offset is out of range, so set the output value to the default.
 				val := defaultCol.Get(i)
-				leadLagCol[i] = val
+				leadLagCol.Set(i, val)
 				continue
 			}
 			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -1155,7 +1155,7 @@ func (w *leadInt64Window) processBatch(batch coldata.Batch, startIdx, endIdx int
 			}
 			col := vec.Int64()
 			val := col.Get(idx)
-			leadLagCol[i] = val
+			leadLagCol.Set(i, val)
 		}
 		return
 	}
@@ -1170,7 +1170,7 @@ func (w *leadInt64Window) processBatch(batch coldata.Batch, startIdx, endIdx int
 					continue
 				}
 				val := defaultCol.Get(i)
-				leadLagCol[i] = val
+				leadLagCol.Set(i, val)
 				continue
 			}
 			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -1181,7 +1181,7 @@ func (w *leadInt64Window) processBatch(batch coldata.Batch, startIdx, endIdx int
 			}
 			col := vec.Int64()
 			val := col.Get(idx)
-			leadLagCol[i] = val
+			leadLagCol.Set(i, val)
 		}
 		return
 	}
@@ -1191,7 +1191,7 @@ func (w *leadInt64Window) processBatch(batch coldata.Batch, startIdx, endIdx int
 		if requestedIdx < 0 || requestedIdx >= w.partitionSize {
 			// The offset is out of range, so set the output value to the default.
 			val := defaultCol.Get(i)
-			leadLagCol[i] = val
+			leadLagCol.Set(i, val)
 			continue
 		}
 		b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -1202,7 +1202,7 @@ func (w *leadInt64Window) processBatch(batch coldata.Batch, startIdx, endIdx int
 		}
 		col := vec.Int64()
 		val := col.Get(idx)
-		leadLagCol[i] = val
+		leadLagCol.Set(i, val)
 	}
 }
 
@@ -1289,7 +1289,7 @@ func (w *leadFloat64Window) processBatch(batch coldata.Batch, startIdx, endIdx i
 						continue
 					}
 					val := defaultCol.Get(i)
-					leadLagCol[i] = val
+					leadLagCol.Set(i, val)
 					continue
 				}
 				b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -1300,7 +1300,7 @@ func (w *leadFloat64Window) processBatch(batch coldata.Batch, startIdx, endIdx i
 				}
 				col := vec.Float64()
 				val := col.Get(idx)
-				leadLagCol[i] = val
+				leadLagCol.Set(i, val)
 			}
 			return
 		}
@@ -1316,7 +1316,7 @@ func (w *leadFloat64Window) processBatch(batch coldata.Batch, startIdx, endIdx i
 			if requestedIdx < 0 || requestedIdx >= w.partitionSize {
 				// The offset is out of range, so set the output value to the default.
 				val := defaultCol.Get(i)
-				leadLagCol[i] = val
+				leadLagCol.Set(i, val)
 				continue
 			}
 			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -1327,7 +1327,7 @@ func (w *leadFloat64Window) processBatch(batch coldata.Batch, startIdx, endIdx i
 			}
 			col := vec.Float64()
 			val := col.Get(idx)
-			leadLagCol[i] = val
+			leadLagCol.Set(i, val)
 		}
 		return
 	}
@@ -1342,7 +1342,7 @@ func (w *leadFloat64Window) processBatch(batch coldata.Batch, startIdx, endIdx i
 					continue
 				}
 				val := defaultCol.Get(i)
-				leadLagCol[i] = val
+				leadLagCol.Set(i, val)
 				continue
 			}
 			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -1353,7 +1353,7 @@ func (w *leadFloat64Window) processBatch(batch coldata.Batch, startIdx, endIdx i
 			}
 			col := vec.Float64()
 			val := col.Get(idx)
-			leadLagCol[i] = val
+			leadLagCol.Set(i, val)
 		}
 		return
 	}
@@ -1363,7 +1363,7 @@ func (w *leadFloat64Window) processBatch(batch coldata.Batch, startIdx, endIdx i
 		if requestedIdx < 0 || requestedIdx >= w.partitionSize {
 			// The offset is out of range, so set the output value to the default.
 			val := defaultCol.Get(i)
-			leadLagCol[i] = val
+			leadLagCol.Set(i, val)
 			continue
 		}
 		b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -1374,7 +1374,7 @@ func (w *leadFloat64Window) processBatch(batch coldata.Batch, startIdx, endIdx i
 		}
 		col := vec.Float64()
 		val := col.Get(idx)
-		leadLagCol[i] = val
+		leadLagCol.Set(i, val)
 	}
 }
 
@@ -1461,7 +1461,7 @@ func (w *leadTimestampWindow) processBatch(batch coldata.Batch, startIdx, endIdx
 						continue
 					}
 					val := defaultCol.Get(i)
-					leadLagCol[i] = val
+					leadLagCol.Set(i, val)
 					continue
 				}
 				b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -1472,7 +1472,7 @@ func (w *leadTimestampWindow) processBatch(batch coldata.Batch, startIdx, endIdx
 				}
 				col := vec.Timestamp()
 				val := col.Get(idx)
-				leadLagCol[i] = val
+				leadLagCol.Set(i, val)
 			}
 			return
 		}
@@ -1488,7 +1488,7 @@ func (w *leadTimestampWindow) processBatch(batch coldata.Batch, startIdx, endIdx
 			if requestedIdx < 0 || requestedIdx >= w.partitionSize {
 				// The offset is out of range, so set the output value to the default.
 				val := defaultCol.Get(i)
-				leadLagCol[i] = val
+				leadLagCol.Set(i, val)
 				continue
 			}
 			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -1499,7 +1499,7 @@ func (w *leadTimestampWindow) processBatch(batch coldata.Batch, startIdx, endIdx
 			}
 			col := vec.Timestamp()
 			val := col.Get(idx)
-			leadLagCol[i] = val
+			leadLagCol.Set(i, val)
 		}
 		return
 	}
@@ -1514,7 +1514,7 @@ func (w *leadTimestampWindow) processBatch(batch coldata.Batch, startIdx, endIdx
 					continue
 				}
 				val := defaultCol.Get(i)
-				leadLagCol[i] = val
+				leadLagCol.Set(i, val)
 				continue
 			}
 			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -1525,7 +1525,7 @@ func (w *leadTimestampWindow) processBatch(batch coldata.Batch, startIdx, endIdx
 			}
 			col := vec.Timestamp()
 			val := col.Get(idx)
-			leadLagCol[i] = val
+			leadLagCol.Set(i, val)
 		}
 		return
 	}
@@ -1535,7 +1535,7 @@ func (w *leadTimestampWindow) processBatch(batch coldata.Batch, startIdx, endIdx
 		if requestedIdx < 0 || requestedIdx >= w.partitionSize {
 			// The offset is out of range, so set the output value to the default.
 			val := defaultCol.Get(i)
-			leadLagCol[i] = val
+			leadLagCol.Set(i, val)
 			continue
 		}
 		b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -1546,7 +1546,7 @@ func (w *leadTimestampWindow) processBatch(batch coldata.Batch, startIdx, endIdx
 		}
 		col := vec.Timestamp()
 		val := col.Get(idx)
-		leadLagCol[i] = val
+		leadLagCol.Set(i, val)
 	}
 }
 
@@ -1633,7 +1633,7 @@ func (w *leadIntervalWindow) processBatch(batch coldata.Batch, startIdx, endIdx 
 						continue
 					}
 					val := defaultCol.Get(i)
-					leadLagCol[i] = val
+					leadLagCol.Set(i, val)
 					continue
 				}
 				b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -1644,7 +1644,7 @@ func (w *leadIntervalWindow) processBatch(batch coldata.Batch, startIdx, endIdx 
 				}
 				col := vec.Interval()
 				val := col.Get(idx)
-				leadLagCol[i] = val
+				leadLagCol.Set(i, val)
 			}
 			return
 		}
@@ -1660,7 +1660,7 @@ func (w *leadIntervalWindow) processBatch(batch coldata.Batch, startIdx, endIdx 
 			if requestedIdx < 0 || requestedIdx >= w.partitionSize {
 				// The offset is out of range, so set the output value to the default.
 				val := defaultCol.Get(i)
-				leadLagCol[i] = val
+				leadLagCol.Set(i, val)
 				continue
 			}
 			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -1671,7 +1671,7 @@ func (w *leadIntervalWindow) processBatch(batch coldata.Batch, startIdx, endIdx 
 			}
 			col := vec.Interval()
 			val := col.Get(idx)
-			leadLagCol[i] = val
+			leadLagCol.Set(i, val)
 		}
 		return
 	}
@@ -1686,7 +1686,7 @@ func (w *leadIntervalWindow) processBatch(batch coldata.Batch, startIdx, endIdx 
 					continue
 				}
 				val := defaultCol.Get(i)
-				leadLagCol[i] = val
+				leadLagCol.Set(i, val)
 				continue
 			}
 			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -1697,7 +1697,7 @@ func (w *leadIntervalWindow) processBatch(batch coldata.Batch, startIdx, endIdx 
 			}
 			col := vec.Interval()
 			val := col.Get(idx)
-			leadLagCol[i] = val
+			leadLagCol.Set(i, val)
 		}
 		return
 	}
@@ -1707,7 +1707,7 @@ func (w *leadIntervalWindow) processBatch(batch coldata.Batch, startIdx, endIdx 
 		if requestedIdx < 0 || requestedIdx >= w.partitionSize {
 			// The offset is out of range, so set the output value to the default.
 			val := defaultCol.Get(i)
-			leadLagCol[i] = val
+			leadLagCol.Set(i, val)
 			continue
 		}
 		b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
@@ -1718,7 +1718,7 @@ func (w *leadIntervalWindow) processBatch(batch coldata.Batch, startIdx, endIdx 
 		}
 		col := vec.Interval()
 		val := col.Get(idx)
-		leadLagCol[i] = val
+		leadLagCol.Set(i, val)
 	}
 }
 

--- a/pkg/sql/colexec/colexecwindow/lead_lag_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/lead_lag_tmpl.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecutils"
-	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -266,10 +265,8 @@ func _PROCESS_BATCH(_OFFSET_HAS_NULLS bool, _DEFAULT_HAS_NULLS bool) { // */}}
 			// {{if .IsBytesLike}}
 			leadLagCol.CopySlice(defaultCol, i, i, i+1)
 			// {{else}}
-			// {{with .Global}}
 			val := defaultCol.Get(i)
-			execgen.SET(leadLagCol, i, val)
-			// {{end}}
+			leadLagCol.Set(i, val)
 			// {{end}}
 			continue
 		}
@@ -279,10 +276,8 @@ func _PROCESS_BATCH(_OFFSET_HAS_NULLS bool, _DEFAULT_HAS_NULLS bool) { // */}}
 			leadLagNulls.SetNull(i)
 			continue
 		}
-		// {{with .Global}}
 		col := vec.TemplateType()
-		// {{end}}
-		// {{if $.IsBytesLike}}
+		// {{if .IsBytesLike}}
 		// We have to use CopySlice here because the column already has a length of
 		// n elements, and Set cannot set values before the last one.
 		leadLagCol.CopySlice(col, i, idx, idx+1)
@@ -291,9 +286,7 @@ func _PROCESS_BATCH(_OFFSET_HAS_NULLS bool, _DEFAULT_HAS_NULLS bool) { // */}}
 		// {{if .Sliceable}}
 		//gcassert:bce
 		// {{end}}
-		// {{with .Global}}
-		execgen.SET(leadLagCol, i, val)
-		// {{end}}
+		leadLagCol.Set(i, val)
 		// {{end}}
 	}
 	// {{end}}

--- a/pkg/sql/colexec/execgen/cmd/execgen/cast_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/cast_gen.go
@@ -43,9 +43,6 @@ func genCastOperators(inputFileContents string, wr io.Writer) error {
 	s = strings.ReplaceAll(s, "_R_UNSAFEGET", "execgen.UNSAFEGET")
 	s = replaceManipulationFuncsAmbiguous(".Right", s)
 
-	s = strings.ReplaceAll(s, "_R_SET", "execgen.SET")
-	s = replaceManipulationFuncsAmbiguous(".Right", s)
-
 	tmpl, err := template.New("cast").Funcs(template.FuncMap{"buildDict": buildDict}).Parse(s)
 	if err != nil {
 		return err

--- a/pkg/sql/colexec/execgen/cmd/execgen/data_manipulation_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/data_manipulation_gen.go
@@ -30,11 +30,6 @@ var dataManipulationReplacementInfos = []dataManipulationReplacementInfo{
 		replaceWith:         "CopyVal",
 	},
 	{
-		templatePlaceholder: "execgen.SET",
-		numArgs:             3,
-		replaceWith:         "Set",
-	},
-	{
 		templatePlaceholder: "execgen.COPYSLICE",
 		numArgs:             5,
 		replaceWith:         "CopySlice",

--- a/pkg/sql/colexec/execgen/cmd/execgen/lead_lag_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/lead_lag_gen.go
@@ -31,7 +31,7 @@ func replaceLeadLagTmplVariables(tmpl string) string {
 	s := r.Replace(tmpl)
 
 	processBatch := makeFunctionRegex("_PROCESS_BATCH", 2)
-	s = processBatch.ReplaceAllString(s, `{{template "processBatchTmpl" buildDict "Global" . "IsBytesLike" .IsBytesLike "OffsetHasNulls" $1 "DefaultHasNulls" $2}}`)
+	s = processBatch.ReplaceAllString(s, `{{template "processBatchTmpl" buildDict "VecMethod" .VecMethod "IsBytesLike" .IsBytesLike "OffsetHasNulls" $1 "DefaultHasNulls" $2}}`)
 
 	return replaceManipulationFuncs(s)
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_base.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_base.go
@@ -489,21 +489,6 @@ func (b *argWidthOverloadBase) CopyVal(dest, src string) string {
 	return copyVal(b.CanonicalTypeFamily, dest, src)
 }
 
-func set(canonicalTypeFamily types.Family, target, i, new string) string {
-	switch canonicalTypeFamily {
-	case types.BytesFamily, types.JsonFamily, typeconv.DatumVecCanonicalTypeFamily:
-		return fmt.Sprintf("%s.Set(%s, %s)", target, i, new)
-	case types.DecimalFamily:
-		return fmt.Sprintf("%s[%s].Set(&%s)", target, i, new)
-	}
-	return fmt.Sprintf("%s[%s] = %s", target, i, new)
-}
-
-// Set is a function that should only be used in templates.
-func (b *argWidthOverloadBase) Set(target, i, new string) string {
-	return set(b.CanonicalTypeFamily, target, i, new)
-}
-
 // slice is a function that should only be used in templates.
 func (b *argWidthOverloadBase) slice(target, start, end string) string {
 	switch b.CanonicalTypeFamily {
@@ -678,7 +663,6 @@ var (
 	awob = &argWidthOverloadBase{}
 	_    = awob.GoTypeSliceName
 	_    = awob.CopyVal
-	_    = awob.Set
 	_    = awob.Sliceable
 	_    = awob.CopySlice
 	_    = awob.AppendSlice

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_bin.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_bin.go
@@ -300,9 +300,9 @@ func (bytesCustomizer) getBinOpAssignFunc() assignFunc {
 				var r = []byte{}
 				r = append(r, %s...)
 				r = append(r, %s...)
-				%s
+				%s.Set(%s, r)
 			}
-			`, leftElem, rightElem, set(types.BytesFamily, caller, idx, "r"))
+			`, leftElem, rightElem, caller, idx)
 		} else {
 			colexecerror.InternalError(errors.AssertionFailedf("unhandled binary operator %s", op.overloadBase.BinOp.String()))
 		}
@@ -960,9 +960,8 @@ func executeBinOpOnDatums(prelude, targetElem, leftColdataExtDatum, rightDatumEl
 			if _res == tree.DNull {
 				_outNulls.SetNull(%s)
 			}
-			%s
-		`, prelude, leftColdataExtDatum, rightDatumElem, idxVariable,
-		set(typeconv.DatumVecCanonicalTypeFamily, vecVariable, idxVariable, "_res"),
+			%s.Set(%s, _res)
+		`, prelude, leftColdataExtDatum, rightDatumElem, idxVariable, vecVariable, idxVariable,
 	)
 }
 

--- a/pkg/sql/colexec/execgen/cmd/execgen/rowstovec_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/rowstovec_gen.go
@@ -58,10 +58,6 @@ func (i rowsToVecWidthTmplInfo) Convert(datum string) string {
 	return fmt.Sprintf(i.ConversionTmpl, datum)
 }
 
-func (i rowsToVecWidthTmplInfo) Set(col, idx, castV string) string {
-	return set(i.canonicalTypeFamily, col, idx, castV)
-}
-
 func (i rowsToVecWidthTmplInfo) Sliceable() bool {
 	return sliceable(i.canonicalTypeFamily)
 }
@@ -69,7 +65,6 @@ func (i rowsToVecWidthTmplInfo) Sliceable() bool {
 // Remove unused warnings.
 var _ = rowsToVecWidthTmplInfo{}.Prelude
 var _ = rowsToVecWidthTmplInfo{}.Convert
-var _ = rowsToVecWidthTmplInfo{}.Set
 var _ = rowsToVecWidthTmplInfo{}.Sliceable
 
 type familyWidthPair struct {
@@ -123,8 +118,6 @@ func genRowsToVec(inputFileContents string, wr io.Writer) error {
 	s = preludeRe.ReplaceAllString(s, makeTemplateFunctionCall("Prelude", 1))
 	convertRe := makeFunctionRegex("_CONVERT", 1)
 	s = convertRe.ReplaceAllString(s, makeTemplateFunctionCall("Convert", 1))
-	setRe := makeFunctionRegex("_SET", 3)
-	s = setRe.ReplaceAllString(s, makeTemplateFunctionCall("Set", 3))
 
 	tmpl, err := template.New("rowsToVec").Parse(s)
 	if err != nil {

--- a/pkg/sql/colexec/execgen/cmd/execgen/vec_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/vec_gen.go
@@ -29,7 +29,7 @@ func genVec(inputFileContents string, wr io.Writer) error {
 	s := r.Replace(inputFileContents)
 
 	copyWithSel := makeFunctionRegex("_COPY_WITH_SEL", 6)
-	s = copyWithSel.ReplaceAllString(s, `{{template "copyWithSel" buildDict "Global" . "SelOnDest" $6}}`)
+	s = copyWithSel.ReplaceAllString(s, `{{template "copyWithSel" buildDict "Sliceable" .Sliceable "SelOnDest" $6}}`)
 
 	s = replaceManipulationFuncs(s)
 

--- a/pkg/sql/colexec/ordered_synchronizer.eg.go
+++ b/pkg/sql/colexec/ordered_synchronizer.eg.go
@@ -160,7 +160,7 @@ func (o *OrderedSynchronizer) Next() coldata.Batch {
 							srcCol := vec.Bool()
 							outCol := o.outBoolCols[o.outColsMap[i]]
 							v := srcCol.Get(srcRowIdx)
-							outCol[outputIdx] = v
+							outCol.Set(outputIdx, v)
 						}
 					case types.BytesFamily:
 						switch o.typs[i].Width() {
@@ -178,7 +178,7 @@ func (o *OrderedSynchronizer) Next() coldata.Batch {
 							srcCol := vec.Decimal()
 							outCol := o.outDecimalCols[o.outColsMap[i]]
 							v := srcCol.Get(srcRowIdx)
-							outCol[outputIdx].Set(&v)
+							outCol.Set(outputIdx, v)
 						}
 					case types.IntFamily:
 						switch o.typs[i].Width() {
@@ -186,18 +186,18 @@ func (o *OrderedSynchronizer) Next() coldata.Batch {
 							srcCol := vec.Int16()
 							outCol := o.outInt16Cols[o.outColsMap[i]]
 							v := srcCol.Get(srcRowIdx)
-							outCol[outputIdx] = v
+							outCol.Set(outputIdx, v)
 						case 32:
 							srcCol := vec.Int32()
 							outCol := o.outInt32Cols[o.outColsMap[i]]
 							v := srcCol.Get(srcRowIdx)
-							outCol[outputIdx] = v
+							outCol.Set(outputIdx, v)
 						case -1:
 						default:
 							srcCol := vec.Int64()
 							outCol := o.outInt64Cols[o.outColsMap[i]]
 							v := srcCol.Get(srcRowIdx)
-							outCol[outputIdx] = v
+							outCol.Set(outputIdx, v)
 						}
 					case types.FloatFamily:
 						switch o.typs[i].Width() {
@@ -206,7 +206,7 @@ func (o *OrderedSynchronizer) Next() coldata.Batch {
 							srcCol := vec.Float64()
 							outCol := o.outFloat64Cols[o.outColsMap[i]]
 							v := srcCol.Get(srcRowIdx)
-							outCol[outputIdx] = v
+							outCol.Set(outputIdx, v)
 						}
 					case types.TimestampTZFamily:
 						switch o.typs[i].Width() {
@@ -215,7 +215,7 @@ func (o *OrderedSynchronizer) Next() coldata.Batch {
 							srcCol := vec.Timestamp()
 							outCol := o.outTimestampCols[o.outColsMap[i]]
 							v := srcCol.Get(srcRowIdx)
-							outCol[outputIdx] = v
+							outCol.Set(outputIdx, v)
 						}
 					case types.IntervalFamily:
 						switch o.typs[i].Width() {
@@ -224,7 +224,7 @@ func (o *OrderedSynchronizer) Next() coldata.Batch {
 							srcCol := vec.Interval()
 							outCol := o.outIntervalCols[o.outColsMap[i]]
 							v := srcCol.Get(srcRowIdx)
-							outCol[outputIdx] = v
+							outCol.Set(outputIdx, v)
 						}
 					case types.JsonFamily:
 						switch o.typs[i].Width() {

--- a/pkg/sql/colexec/ordered_synchronizer_tmpl.go
+++ b/pkg/sql/colexec/ordered_synchronizer_tmpl.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecargs"
-	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
@@ -180,7 +179,7 @@ func (o *OrderedSynchronizer) Next() coldata.Batch {
 							srcCol := vec._TYPE()
 							outCol := o.out_TYPECols[o.outColsMap[i]]
 							v := srcCol.Get(srcRowIdx)
-							execgen.SET(outCol, outputIdx, v)
+							outCol.Set(outputIdx, v)
 							// {{end}}
 						}
 						// {{end}}

--- a/pkg/sql/colexec/rowstovec.eg.go
+++ b/pkg/sql/colexec/rowstovec.eg.go
@@ -72,7 +72,7 @@ func EncDatumRowsToColVec(
 								v = bool(*datum.(*tree.DBool))
 								castV := v.(bool)
 								//gcassert:bce
-								col[i] = castV
+								col.Set(i, castV)
 							}
 						}
 					}
@@ -99,7 +99,7 @@ func EncDatumRowsToColVec(
 								v = int16(*datum.(*tree.DInt))
 								castV := v.(int16)
 								//gcassert:bce
-								col[i] = castV
+								col.Set(i, castV)
 							}
 						}
 					}
@@ -123,7 +123,7 @@ func EncDatumRowsToColVec(
 								v = int32(*datum.(*tree.DInt))
 								castV := v.(int32)
 								//gcassert:bce
-								col[i] = castV
+								col.Set(i, castV)
 							}
 						}
 					}
@@ -148,7 +148,7 @@ func EncDatumRowsToColVec(
 								v = int64(*datum.(*tree.DInt))
 								castV := v.(int64)
 								//gcassert:bce
-								col[i] = castV
+								col.Set(i, castV)
 							}
 						}
 					}
@@ -176,7 +176,7 @@ func EncDatumRowsToColVec(
 								v = float64(*datum.(*tree.DFloat))
 								castV := v.(float64)
 								//gcassert:bce
-								col[i] = castV
+								col.Set(i, castV)
 							}
 						}
 					}
@@ -203,7 +203,7 @@ func EncDatumRowsToColVec(
 
 								v = datum.(*tree.DDecimal).Decimal
 								castV := v.(apd.Decimal)
-								col[i].Set(&castV)
+								col.Set(i, castV)
 							}
 						}
 					}
@@ -231,7 +231,7 @@ func EncDatumRowsToColVec(
 								v = datum.(*tree.DDate).UnixEpochDaysWithOrig()
 								castV := v.(int64)
 								//gcassert:bce
-								col[i] = castV
+								col.Set(i, castV)
 							}
 						}
 					}
@@ -259,7 +259,7 @@ func EncDatumRowsToColVec(
 								v = datum.(*tree.DTimestamp).Time
 								castV := v.(time.Time)
 								//gcassert:bce
-								col[i] = castV
+								col.Set(i, castV)
 							}
 						}
 					}
@@ -287,7 +287,7 @@ func EncDatumRowsToColVec(
 								v = datum.(*tree.DInterval).Duration
 								castV := v.(duration.Duration)
 								//gcassert:bce
-								col[i] = castV
+								col.Set(i, castV)
 							}
 						}
 					}
@@ -373,7 +373,7 @@ func EncDatumRowsToColVec(
 								v = datum.(*tree.DTimestampTZ).Time
 								castV := v.(time.Time)
 								//gcassert:bce
-								col[i] = castV
+								col.Set(i, castV)
 							}
 						}
 					}

--- a/pkg/sql/colexec/rowstovec_tmpl.go
+++ b/pkg/sql/colexec/rowstovec_tmpl.go
@@ -76,7 +76,7 @@ func _ROWS_TO_COL_VEC(
 				//gcassert:bce
 				// {{end}}
 				// {{end}}
-				_SET(col, i, castV)
+				col.Set(i, castV)
 			}
 		}
 	}

--- a/pkg/sql/colexec/vec_comparators.eg.go
+++ b/pkg/sql/colexec/vec_comparators.eg.go
@@ -89,7 +89,7 @@ func (c *BoolVecComparator) set(srcVecIdx, dstVecIdx int, srcIdx, dstIdx int) {
 	} else {
 		c.nulls[dstVecIdx].UnsetNull(dstIdx)
 		v := c.vecs[srcVecIdx].Get(srcIdx)
-		c.vecs[dstVecIdx][dstIdx] = v
+		c.vecs[dstVecIdx].Set(dstIdx, v)
 	}
 }
 
@@ -168,7 +168,7 @@ func (c *DecimalVecComparator) set(srcVecIdx, dstVecIdx int, srcIdx, dstIdx int)
 	} else {
 		c.nulls[dstVecIdx].UnsetNull(dstIdx)
 		v := c.vecs[srcVecIdx].Get(srcIdx)
-		c.vecs[dstVecIdx][dstIdx].Set(&v)
+		c.vecs[dstVecIdx].Set(dstIdx, v)
 	}
 }
 
@@ -216,7 +216,7 @@ func (c *Int16VecComparator) set(srcVecIdx, dstVecIdx int, srcIdx, dstIdx int) {
 	} else {
 		c.nulls[dstVecIdx].UnsetNull(dstIdx)
 		v := c.vecs[srcVecIdx].Get(srcIdx)
-		c.vecs[dstVecIdx][dstIdx] = v
+		c.vecs[dstVecIdx].Set(dstIdx, v)
 	}
 }
 
@@ -264,7 +264,7 @@ func (c *Int32VecComparator) set(srcVecIdx, dstVecIdx int, srcIdx, dstIdx int) {
 	} else {
 		c.nulls[dstVecIdx].UnsetNull(dstIdx)
 		v := c.vecs[srcVecIdx].Get(srcIdx)
-		c.vecs[dstVecIdx][dstIdx] = v
+		c.vecs[dstVecIdx].Set(dstIdx, v)
 	}
 }
 
@@ -312,7 +312,7 @@ func (c *Int64VecComparator) set(srcVecIdx, dstVecIdx int, srcIdx, dstIdx int) {
 	} else {
 		c.nulls[dstVecIdx].UnsetNull(dstIdx)
 		v := c.vecs[srcVecIdx].Get(srcIdx)
-		c.vecs[dstVecIdx][dstIdx] = v
+		c.vecs[dstVecIdx].Set(dstIdx, v)
 	}
 }
 
@@ -368,7 +368,7 @@ func (c *Float64VecComparator) set(srcVecIdx, dstVecIdx int, srcIdx, dstIdx int)
 	} else {
 		c.nulls[dstVecIdx].UnsetNull(dstIdx)
 		v := c.vecs[srcVecIdx].Get(srcIdx)
-		c.vecs[dstVecIdx][dstIdx] = v
+		c.vecs[dstVecIdx].Set(dstIdx, v)
 	}
 }
 
@@ -412,7 +412,7 @@ func (c *TimestampVecComparator) set(srcVecIdx, dstVecIdx int, srcIdx, dstIdx in
 	} else {
 		c.nulls[dstVecIdx].UnsetNull(dstIdx)
 		v := c.vecs[srcVecIdx].Get(srcIdx)
-		c.vecs[dstVecIdx][dstIdx] = v
+		c.vecs[dstVecIdx].Set(dstIdx, v)
 	}
 }
 
@@ -449,7 +449,7 @@ func (c *IntervalVecComparator) set(srcVecIdx, dstVecIdx int, srcIdx, dstIdx int
 	} else {
 		c.nulls[dstVecIdx].UnsetNull(dstIdx)
 		v := c.vecs[srcVecIdx].Get(srcIdx)
-		c.vecs[dstVecIdx][dstIdx] = v
+		c.vecs[dstVecIdx].Set(dstIdx, v)
 	}
 }
 

--- a/pkg/sql/colexec/vec_comparators_tmpl.go
+++ b/pkg/sql/colexec/vec_comparators_tmpl.go
@@ -121,7 +121,7 @@ func (c *_TYPEVecComparator) set(srcVecIdx, dstVecIdx int, srcIdx, dstIdx int) {
 		execgen.COPYSLICE(c.vecs[dstVecIdx], c.vecs[srcVecIdx], dstIdx, srcIdx, srcIdx+1)
 		// {{else}}
 		v := c.vecs[srcVecIdx].Get(srcIdx)
-		execgen.SET(c.vecs[dstVecIdx], dstIdx, v)
+		c.vecs[dstVecIdx].Set(dstIdx, v)
 		// {{end}}
 	}
 }


### PR DESCRIPTION
This commit introduces `Set` method onto the typed vectors (which is
inlined in most cases) that replaces `execgen.SET` directives. This
allows us to simplify calling `Set` method from inside of the templated
functions, so this commit also cleans up some stuff around `.Global` way
of propagation of the "outer" template struct.

Release note: None