### PR TITLE
vendor: bump pebble to pick up snappy bump

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -612,8 +612,8 @@ def go_deps():
         name = "com_github_cockroachdb_pebble",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/cockroachdb/pebble",
-        sum = "h1:2m8R3O36SP52zVgLarf0n5QSeXD2BwypmRGZhh7Otns=",
-        version = "v0.0.0-20210601160505-25f8258be7ea",
+        sum = "h1:rUhVWQwwQyA9n7tE4DT7JQy1uCXeKQrsfIb3/JfsGJg=",
+        version = "v0.0.0-20210616164745-bd9aafed099a",
     )
 
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f
-	github.com/cockroachdb/pebble v0.0.0-20210601160505-25f8258be7ea
+	github.com/cockroachdb/pebble v0.0.0-20210616164745-bd9aafed099a
 	github.com/cockroachdb/redact v1.0.9
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2

--- a/go.sum
+++ b/go.sum
@@ -259,8 +259,8 @@ github.com/cockroachdb/gostdlib v1.13.0 h1:TzSEPYgkKDNei3gbLc0rrHu4iHyBp7/+NxPOF
 github.com/cockroachdb/gostdlib v1.13.0/go.mod h1:eXX95p9QDrYwJfJ6AgeN9QnRa/lqqid9LAzWz/l5OgA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f h1:o/kfcElHqOiXqcou5a3rIlMc7oJbMQkeLk0VQJ7zgqY=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/cockroachdb/pebble v0.0.0-20210601160505-25f8258be7ea h1:2m8R3O36SP52zVgLarf0n5QSeXD2BwypmRGZhh7Otns=
-github.com/cockroachdb/pebble v0.0.0-20210601160505-25f8258be7ea/go.mod h1:1XpB4cLQcF189RAcWi4gUc110zJgtOfT7SVNGY8sOe0=
+github.com/cockroachdb/pebble v0.0.0-20210616164745-bd9aafed099a h1:rUhVWQwwQyA9n7tE4DT7JQy1uCXeKQrsfIb3/JfsGJg=
+github.com/cockroachdb/pebble v0.0.0-20210616164745-bd9aafed099a/go.mod h1:JXfQr3d+XO4bL1pxGwKKo09xylQSdZ/mpZ9b2wfVcPs=
 github.com/cockroachdb/pq v0.0.0-20210517091544-990dd3347596 h1:xTc0ViFhuelzQZAYQOxMR2J5QDO9/C+0L0fkPXIcoMI=
 github.com/cockroachdb/pq v0.0.0-20210517091544-990dd3347596/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/cockroachdb/redact v1.0.8/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
@@ -629,7 +629,6 @@ github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/snappy v0.0.0-20170215233205-553a64147049/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
-github.com/golang/snappy v0.0.2-0.20190904063534-ff6b7dc882cf/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.3 h1:fHPg5GQYlCeLIPB9BZqMVR5nR9A+IM5zcgeTdjMYmLA=
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/gomodule/redigo v1.7.1-0.20190724094224-574c33c3df38/go.mod h1:B4C85qUVwatsJoIUNIfCRsp7qO0iAmpGFZ4EELWSbC4=


### PR DESCRIPTION
Bumps pebble to pick up snappy v0.0.3. Changes included:

- 0369dc2e bump snappy to v0.0.3
- 99939fea vfs: use Bavail in GetFreeSpace
- a9e4c56e vfs: add OnDiskFull VFS wrapper
- a7f14024 sstable: vectorize shared prefix byte comparison
- abf31e35 sstable: add shared prefix to BenchmarkWriter
- 91c52f60 compaction: hoist nilPacer check outside compaction loop

Release note: none.