### PR TITLE
roachtest: add test for authentication under network partition

### DIFF
--- a/pkg/cmd/roachtest/network.go
+++ b/pkg/cmd/roachtest/network.go
@@ -15,10 +15,14 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"os"
+	"path/filepath"
 	"time"
 
 	toxiproxy "github.com/Shopify/toxiproxy/client"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
+	"github.com/cockroachdb/errors"
 	_ "github.com/lib/pq"
 )
 
@@ -92,6 +96,177 @@ select age, message from [ show trace for session ];
 		return nil
 	})
 
+	m.Wait()
+}
+
+// runNetworkAuthentication creates a network black hole to the leaseholder
+// of system.users, and then measures how long it takes to be able to create
+// new connections to the cluster afterwards.
+func runNetworkAuthentication(ctx context.Context, t *test, c Cluster) {
+	c.Put(ctx, cockroach, "./cockroach", c.All())
+
+	c.Start(ctx, t, c.Node(1), startArgs("--secure", "--args=--locality=node=1"))
+	c.Start(ctx, t, c.Nodes(2, 3), startArgs("--secure", "--args=--locality=node=other"))
+
+	certsDir := "/home/ubuntu/certs"
+	localCertsDir, err := filepathAbs("./certs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(localCertsDir); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := c.Get(ctx, t.l, certsDir, localCertsDir, c.Node(1)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Certs can have at max 0600 privilege.
+	if err := filepath.Walk(localCertsDir, func(path string, info os.FileInfo, err error) error {
+		// Don't change permissions for the certs directory.
+		if path == localCertsDir {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		return os.Chmod(path, os.FileMode(0600))
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	db, err := c.ConnSecure(ctx, 2, "root", localCertsDir, 26257)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	waitForFullReplication(t, db)
+
+	if _, err := db.Exec(`CREATE USER testuser WITH PASSWORD 'password'`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`ALTER RANGE liveness CONFIGURE ZONE USING lease_preferences = '[[+node=1]]', constraints = '{"+node=1": 1}'`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`ALTER RANGE meta CONFIGURE ZONE USING lease_preferences = '[[+node=1]]', constraints = '{"+node=1": 1}'`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`ALTER RANGE system CONFIGURE ZONE USING lease_preferences = '[[+node=1]]', constraints = '{"+node=1": 1}'`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`ALTER DATABASE system CONFIGURE ZONE USING lease_preferences = '[[+node=1]]', constraints = '{"+node=1": 1}'`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`ALTER RANGE default CONFIGURE ZONE USING lease_preferences = '[[+node=1]]', constraints = '{"+node=1": 1}'`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`ALTER TABLE system.public.replication_constraint_stats CONFIGURE ZONE USING lease_preferences = '[[+node=1]]', constraints = '{"+node=1": 1}', num_replicas = 3`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`ALTER TABLE system.public.replication_stats CONFIGURE ZONE USING lease_preferences = '[[+node=1]]', constraints = '{"+node=1": 1}', num_replicas = 3`); err != nil {
+		t.Fatal(err)
+	}
+
+	const expectedLeaseholder = 1
+	testutils.SucceedsSoon(t, func() error {
+		var leaseholder int
+		if err := db.QueryRow(`
+SELECT lease_holder FROM crdb_internal.ranges
+WHERE start_pretty = '/System/NodeLiveness' AND end_pretty = '/System/NodeLivenessMax'`,
+		).Scan(&leaseholder); err != nil {
+			return err
+		}
+		if leaseholder != expectedLeaseholder {
+			return errors.Newf("liveness leaseholder should be node %d", expectedLeaseholder)
+		}
+		if err := db.QueryRow(
+			"SELECT lease_holder FROM [SHOW RANGES FROM TABLE system.public.users]",
+		).Scan(&leaseholder); err != nil {
+			return err
+		}
+		if leaseholder != expectedLeaseholder {
+			return errors.Newf("system.users leaseholder should be node %d", expectedLeaseholder)
+		}
+		return nil
+	})
+
+	rows, err := db.Query(`
+WITH
+    at_risk_zones AS (
+            SELECT
+                zone_id, locality, at_risk_ranges
+            FROM
+                system.replication_critical_localities
+            WHERE
+                at_risk_ranges > 0
+        ),
+    report AS (
+            SELECT
+                crdb_internal.zones.zone_id,
+                target,
+                database_name,
+                table_name,
+                index_name,
+                at_risk_zones.at_risk_ranges
+            FROM
+                crdb_internal.zones, at_risk_zones
+            WHERE
+                crdb_internal.zones.zone_id
+                = at_risk_zones.zone_id
+        )
+SELECT DISTINCT * FROM report;
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for rows.Next() {
+		var at_risk_target string
+		err := rows.Scan(&at_risk_target)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.l.Printf("found at risk range. target: %s\n", at_risk_target)
+	}
+
+	m := newMonitor(ctx, c, c.All())
+	m.Go(func(ctx context.Context) error {
+		endTest := time.After(20 * time.Second)
+		tick := time.Tick(500 * time.Millisecond)
+		errorCount := 0
+		keepLooping := true
+		for attempt := 0; keepLooping; attempt++ {
+			select {
+			case <-endTest:
+				keepLooping = false
+			case <-tick:
+			}
+			t.l.Printf("connection attempt %d\n", attempt)
+			for i := 1; i <= c.Spec().NodeCount; i++ {
+				if i == expectedLeaseholder {
+					continue
+				}
+
+				url := "postgres://testuser:password@localhost:26257/defaultdb?sslmode=require"
+				b, err := c.RunWithBuffer(ctx, t.l, c.Node(i),
+					"time", "-p", "./cockroach", "sql",
+					"--url", url, "--certs-dir", certsDir, "-e", "'SELECT now()'")
+				t.l.Printf("%s\n", b)
+				if err != nil {
+					errorCount++
+				}
+			}
+		}
+
+		if errorCount >= 1 /*c.Spec().NodeCount*/ {
+			return errors.Newf("failed authentication %d times; expected fewer than %d", errorCount, 1 /*c.Spec().NodeCount*/)
+		}
+		return nil
+	})
+
+	time.Sleep(5 * time.Second)
+	if err := blackholeNode(ctx, c, expectedLeaseholder); err != nil {
+		t.Fatal(err)
+	}
 	m.Wait()
 }
 
@@ -233,6 +408,42 @@ func runNetworkTPCC(ctx context.Context, t *test, origC Cluster, nodes int) {
 	m.Wait()
 }
 
+// blackholeNode sets an iptables rule on the given node to block all
+// network traffic except for SSH.
+func blackholeNode(ctx context.Context, c Cluster, nodeId int) error {
+	nodeIP, err := c.InternalIP(ctx, c.Node(nodeId))
+	if err != nil {
+		return err
+	}
+	nodeExternalIP, err := c.ExternalIP(ctx, c.Node(nodeId))
+	if err != nil {
+		return err
+	}
+	if err := c.RunE(ctx, c.Node(nodeId), fmt.Sprintf(`
+# Setting default filter policy
+sudo iptables -P INPUT DROP;
+sudo iptables -P OUTPUT DROP;
+sudo iptables -P FORWARD DROP;
+
+# Allow unlimited traffic on loopback
+sudo iptables -A INPUT -i lo -j ACCEPT;
+sudo iptables -A OUTPUT -o lo -j ACCEPT;
+
+# Allow incoming ssh only
+sudo iptables -A INPUT -p tcp -s 0/0 -d %[1]s --sport 513:65535 --dport 22 -j ACCEPT;
+sudo iptables -A OUTPUT -p tcp -s %[1]s -d 0/0 --sport 22 --dport 513:65535 -j ACCEPT;
+sudo iptables -A INPUT -p tcp -s 0/0 -d %[2]s --sport 513:65535 --dport 22 -j ACCEPT;
+sudo iptables -A OUTPUT -p tcp -s %[2]s -d 0/0 --sport 22 --dport 513:65535 -j ACCEPT;
+
+# make sure nothing comes or goes out of this box
+sudo iptables -A INPUT -j DROP;
+sudo iptables -A OUTPUT -j DROP;
+sudo iptables-save`, nodeIP[0], nodeExternalIP[0])); err != nil {
+		return errors.Wrapf(err, "error applying iptables rules")
+	}
+	return nil
+}
+
 func registerNetwork(r *testRegistry) {
 	const numNodes = 4
 
@@ -242,6 +453,14 @@ func registerNetwork(r *testRegistry) {
 		Cluster: makeClusterSpec(numNodes),
 		Run: func(ctx context.Context, t *test, c Cluster) {
 			runNetworkSanity(ctx, t, c, numNodes)
+		},
+	})
+	r.Add(testSpec{
+		Name:    fmt.Sprintf("network/authentication/nodes=3"),
+		Owner:   OwnerKV,
+		Cluster: makeClusterSpec(3),
+		Run: func(ctx context.Context, t *test, c Cluster) {
+			runNetworkAuthentication(ctx, t, c)
 		},
 	})
 	r.Add(testSpec{


### PR DESCRIPTION
Customers have raised major complaints about this situation. If a node
disappears under a network partition (or the host is hard-killed), then
it is possible that no connections can be established to any other node.
Specifically, if the system.users leaseholder is the node that
disappears, authentication can fail. We expect on the order of ~10
seconds of authentication unavailability, but customers have showed us
an outage period of up to 40 seconds.

This test tries to repro what our customers have shown us so that we can
iterate on the root cause more quickly.

Release note: None