### PR TITLE
cli: print LSM stats every minute during manual compaction

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -802,9 +802,27 @@ func runDebugCompact(cmd *cobra.Command, args []string) error {
 		fmt.Printf("approximate reported database size before compaction: %s\n", humanizeutil.IBytes(int64(approxBytesBefore)))
 	}
 
-	if err := db.Compact(); err != nil {
-		return errors.Wrap(err, "while compacting")
+	// Begin compacting the store in a separate goroutine.
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- errors.Wrap(db.Compact(), "while compacting")
+	}()
+
+	// Print the current LSM every minute.
+	ticker := time.NewTicker(time.Minute)
+	for done := false; !done; {
+		select {
+		case <-ticker.C:
+			fmt.Printf("%s\n", db.GetMetrics())
+		case err := <-errCh:
+			ticker.Stop()
+			if err != nil {
+				return err
+			}
+			done = true
+		}
 	}
+	fmt.Printf("%s\n", db.GetMetrics())
 
 	{
 		approxBytesAfter, err := db.ApproximateDiskBytes(roachpb.KeyMin, roachpb.KeyMax)


### PR DESCRIPTION
When running a manual compaction of the entire LSM through
`cockroach debug compact` print the LSM stats table every minute. This
helps provide some indication of the pace of progress.

Release note: None