### PR TITLE
release-20.2: kvserver: change shouldCampaignOnWake to campaign when the leader is dead

### DIFF
--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -609,7 +609,8 @@ type Store struct {
 	scheduler *raftScheduler
 
 	// livenessMap is a map from nodeID to a bool indicating
-	// liveness. It is updated periodically in raftTickLoop().
+	// liveness. It is updated periodically in raftTickLoop()
+	// and reactively in nodeIsLiveCallback() on liveness updates.
 	livenessMap atomic.Value
 
 	// cachedCapacity caches information on store capacity to prevent


### PR DESCRIPTION
Backport 1/1 commits from #65195.

This was not a clean backport as it overlapped with https://github.com/cockroachdb/cockroach/commit/ea9074ba76a842a928b18c403ec78ec362fcb4bd, so worth a second look. 

/cc @cockroachdb/release

---

Touches #57093

For a lease to move off a dead node to a new healthy node, a healthy node
must first win a raft election and then apply the lease transfer. For a
quiescent range this means the following:
 - Wait 9s for liveness to expire
 - Attempt to acquire the lease on a healthy node, this is rejected
   because lease acquisition can only happen on the raft leader
 - The rejection unquiesces the range
 - The nodes wait out the election timeout (3s) before trying to
   campaign
 - A raft election occurs and a healthy node wins
 - A lease transfer can now be processed by the newly elected leader

This change proposed to eliminate the extra wait between when the
range is unquiesced and a new campaign is kicked off. The node
unquiescing the range will now check if the raft leader is alive according
to liveness and if it's not it will kick off a campaign to try
and win raft leadership.

Release note: None
