### PR TITLE
release-21.1: opt: fix qualified star expansion after joins

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/join
+++ b/pkg/sql/logictest/testdata/logic_test/join
@@ -1112,3 +1112,39 @@ statement ok
 DROP TABLE empty;
 DROP TABLE fk_ref;
 DROP TABLE xy;
+
+statement ok
+CREATE TABLE abcd (a INT, b INT, c INT, d INT)
+
+statement ok
+INSERT INTO abcd VALUES (1, 1, 1, 1), (2, 2, 2, 2)
+
+statement ok
+CREATE TABLE dxby (d INT, x INT, b INT, y INT)
+
+statement ok
+INSERT INTO dxby VALUES (2, 2, 2, 2), (3, 3, 3, 3)
+
+query IIIIII colnames,rowsort
+SELECT * FROM abcd NATURAL FULL OUTER JOIN dxby
+----
+b  d  a     c     x     y
+1  1  1     1     NULL  NULL
+2  2  2     2     2     2
+3  3  NULL  NULL  3     3
+
+# Test that qualified stars expand to all table columns (even those that aren't
+# directly visible); see #66123.
+query IIIIIIII colnames,rowsort
+SELECT abcd.*, dxby.* FROM abcd NATURAL FULL OUTER JOIN dxby
+----
+a     b     c     d     d     x     b     y
+1     1     1     1     NULL  NULL  NULL  NULL
+2     2     2     2     2     2     2     2
+NULL  NULL  NULL  NULL  3     3     3     3
+
+query IIIIIIII colnames,rowsort
+SELECT abcd.*, dxby.* FROM abcd INNER JOIN dxby USING (d, b)
+----
+a  b  c  d  d  x  b  y
+2  2  2  2  2  2  2  2

--- a/pkg/sql/opt/optbuilder/BUILD.bazel
+++ b/pkg/sql/opt/optbuilder/BUILD.bazel
@@ -92,7 +92,6 @@ go_test(
     embed = [":optbuilder"],
     deps = [
         "//pkg/settings/cluster",
-        "//pkg/sql/opt/cat",
         "//pkg/sql/opt/memo",
         "//pkg/sql/opt/testutils",
         "//pkg/sql/opt/testutils/opttester",

--- a/pkg/sql/opt/optbuilder/distinct.go
+++ b/pkg/sql/opt/optbuilder/distinct.go
@@ -12,7 +12,6 @@ package optbuilder
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -25,7 +24,7 @@ func (b *Builder) constructDistinct(inScope *scope) memo.RelExpr {
 	// We are doing a distinct along all the projected columns.
 	var private memo.GroupingPrivate
 	for i := range inScope.cols {
-		if inScope.cols[i].visibility == cat.Visible {
+		if inScope.cols[i].visibility == visible {
 			private.GroupingCols.Add(inScope.cols[i].id)
 		}
 	}

--- a/pkg/sql/opt/optbuilder/join.go
+++ b/pkg/sql/opt/optbuilder/join.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -375,7 +374,7 @@ func (jb *usingJoinBuilder) buildNaturalJoin(natural tree.NaturalJoinCond) {
 	var seenCols opt.ColSet
 	for i := range jb.leftScope.cols {
 		leftCol := &jb.leftScope.cols[i]
-		if leftCol.visibility != cat.Visible {
+		if leftCol.visibility != visible {
 			continue
 		}
 		if seenCols.Contains(leftCol.id) {
@@ -444,7 +443,7 @@ func (jb *usingJoinBuilder) addRemainingCols(cols []scopeColumn) {
 		col := &cols[i]
 		if _, ok := jb.hideCols[col]; ok {
 			jb.outScope.cols = append(jb.outScope.cols, *col)
-			jb.outScope.cols[len(jb.outScope.cols)-1].visibility = cat.Hidden
+			jb.outScope.cols[len(jb.outScope.cols)-1].visibility = accessibleByName
 		} else if _, ok := jb.showCols[col]; !ok {
 			jb.outScope.cols = append(jb.outScope.cols, *col)
 		}
@@ -461,7 +460,7 @@ func (jb *usingJoinBuilder) findUsingColumn(
 	var foundCol *scopeColumn
 	for i := range cols {
 		col := &cols[i]
-		if col.visibility == cat.Visible && col.name == name {
+		if col.visibility == visible && col.name == name {
 			if foundCol != nil {
 				jb.raiseDuplicateColError(name, context)
 			}

--- a/pkg/sql/opt/optbuilder/name_resolution_test.go
+++ b/pkg/sql/opt/optbuilder/name_resolution_test.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 )
@@ -46,7 +45,7 @@ func (s *scope) ResolveQualifiedStarTestResults(
 	nl := make(tree.NameList, 0, len(s.cols))
 	for i := range s.cols {
 		col := s.cols[i]
-		if col.table == *srcName && col.visibility == cat.Visible {
+		if col.table == *srcName && col.visibility == visible {
 			nl = append(nl, col.name)
 		}
 	}

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -236,7 +236,7 @@ func (s *scope) appendOrdinaryColumnsFromTable(tabMeta *opt.TableMeta, alias *tr
 			table:      *alias,
 			typ:        tabCol.DatumType(),
 			id:         tabMeta.MetaID.ColumnID(i),
-			visibility: tabCol.Visibility(),
+			visibility: columnVisibility(tabCol.Visibility()),
 		})
 	}
 }
@@ -372,7 +372,7 @@ func (s *scope) makePresentation() physical.Presentation {
 	presentation := make(physical.Presentation, 0, len(s.cols))
 	for i := range s.cols {
 		col := &s.cols[i]
-		if col.visibility == cat.Visible {
+		if col.visibility == visible {
 			presentation = append(presentation, opt.AliasedColumn{
 				Alias: string(col.name),
 				ID:    col.id,
@@ -553,7 +553,7 @@ func (s *scope) hasSameColumns(other *scope) bool {
 func (s *scope) removeHiddenCols() {
 	n := 0
 	for i := range s.cols {
-		if s.cols[i].visibility != cat.Visible {
+		if s.cols[i].visibility != visible {
 			s.extraCols = append(s.extraCols, s.cols[i])
 		} else {
 			if n != i {
@@ -710,27 +710,64 @@ func (*scopeColumn) ColumnSourceMeta() {}
 // ColumnResolutionResult implements the tree.ColumnResolutionResult interface.
 func (*scopeColumn) ColumnResolutionResult() {}
 
+// columnMatchClass identifies a class of column matches.
+//
+// We have three classes of column matches:
+//  1. Anonymous source columns
+//  2. Qualified source columns
+//  3. Hidden columns
+//
+// The classes have strict precedence; within a given scope, the resolution
+// outcome is determined by the first class that has at least one match. If
+// there is exactly one match in that class, resolution is successful. If there
+// are more matches, it is an ambiguity error.
+type columnMatchClass int8
+
+const (
+	anonymousSourceMatch columnMatchClass = iota
+	qualifiedSourceMatch
+	hiddenMatch
+)
+
+// candidateTracker keeps track of a candidate *scopeColumn, its match class,
+// and whether there is an ambiguity within that match class. Only information
+// relevant to the "best" match class encountered is retained.
+type candidateTracker struct {
+	col        *scopeColumn
+	ambiguous  bool
+	matchClass columnMatchClass
+}
+
+// Add a potential candidate.
+func (c *candidateTracker) Add(col *scopeColumn, matchClass columnMatchClass) {
+	if c.col == nil || c.matchClass > matchClass {
+		c.col = col
+		c.ambiguous = false
+		c.matchClass = matchClass
+	} else if c.matchClass == matchClass {
+		c.ambiguous = true
+	}
+}
+
 // FindSourceProvidingColumn is part of the tree.ColumnItemResolver interface.
 func (s *scope) FindSourceProvidingColumn(
 	_ context.Context, colName tree.Name,
 ) (prefix *tree.TableName, srcMeta tree.ColumnSourceMeta, colHint int, err error) {
-	var candidateFromAnonSource *scopeColumn
-	var candidateWithPrefix *scopeColumn
-	var hiddenCandidate *scopeColumn
-	var moreThanOneCandidateFromAnonSource bool
-	var moreThanOneCandidateWithPrefix bool
-	var moreThanOneHiddenCandidate bool
+	// We start from the current scope; if we find at least one match we are done
+	// (either with a result or an ambiguity error). Otherwise, we search the
+	// parent scope.
+
+	// In case we find no matches anywhere, we remember if we saw an inaccessible
+	// mutation column on the way, in which case we can present a more useful
+	// error.
+	reportBackfillError := false
 
 	// We only allow hidden columns in the current scope. Hidden columns
 	// in parent scopes are not accessible.
 	allowHidden := true
-
-	// If multiple columns match c in the same scope, we return an error
-	// due to ambiguity. If no columns match in the current scope, we
-	// search the parent scope. If the column is not found in any of the
-	// ancestor scopes, we return an error.
-	reportBackfillError := false
 	for ; s != nil; s, allowHidden = s.parent, false {
+		var candidate candidateTracker
+
 		for i := range s.cols {
 			col := &s.cols[i]
 			if col.name != colName {
@@ -738,65 +775,32 @@ func (s *scope) FindSourceProvidingColumn(
 			}
 
 			switch col.visibility {
-			case cat.Inaccessible:
-				// Act as if this column is not present so that matches in higher scopes
-				// can be found. However, if no match is found in higher scopes and this
-				// is a mutation column, report a backfill error rather than a "not
-				// found" error.
+			case inaccessible:
 				if col.mutation {
 					reportBackfillError = true
 				}
 
-			case cat.Visible:
+			case visible:
 				if col.table.ObjectName == "" {
-					if candidateFromAnonSource != nil {
-						moreThanOneCandidateFromAnonSource = true
-					}
-					candidateFromAnonSource = col
+					candidate.Add(col, anonymousSourceMatch)
 				} else {
-					if candidateWithPrefix != nil {
-						moreThanOneCandidateWithPrefix = true
-					}
-					candidateWithPrefix = col
+					candidate.Add(col, qualifiedSourceMatch)
 				}
 
-			case cat.Hidden:
+			case accessibleByName, accessibleByQualifiedStar:
 				if allowHidden {
-					if hiddenCandidate != nil {
-						moreThanOneHiddenCandidate = true
-					}
-					hiddenCandidate = col
+					candidate.Add(col, hiddenMatch)
 				}
 			}
 		}
 
-		// The table name was unqualified, so if a single anonymous source exists
-		// with a matching non-hidden column, use that.
-		if moreThanOneCandidateFromAnonSource {
-			return nil, nil, -1, s.newAmbiguousColumnError(
-				colName, allowHidden, moreThanOneCandidateFromAnonSource, moreThanOneCandidateWithPrefix, moreThanOneHiddenCandidate,
-			)
+		if col := candidate.col; col != nil {
+			if candidate.ambiguous {
+				return nil, nil, -1, s.newAmbiguousColumnError(colName, candidate.matchClass)
+			}
+			return &col.table, col, int(col.id), nil
 		}
-		if candidateFromAnonSource != nil {
-			return &candidateFromAnonSource.table, candidateFromAnonSource, int(candidateFromAnonSource.id), nil
-		}
-
-		// Else if a single named source exists with a matching non-hidden column,
-		// use that.
-		if candidateWithPrefix != nil && !moreThanOneCandidateWithPrefix {
-			return &candidateWithPrefix.table, candidateWithPrefix, int(candidateWithPrefix.id), nil
-		}
-		if moreThanOneCandidateWithPrefix || moreThanOneHiddenCandidate {
-			return nil, nil, -1, s.newAmbiguousColumnError(
-				colName, allowHidden, moreThanOneCandidateFromAnonSource, moreThanOneCandidateWithPrefix, moreThanOneHiddenCandidate,
-			)
-		}
-
-		// One last option: if a single source exists with a matching hidden
-		// column, use that.
-		if hiddenCandidate != nil {
-			return &hiddenCandidate.table, hiddenCandidate, int(hiddenCandidate.id), nil
-		}
+		// No matches in this scope; proceed to the parent scope.
 	}
 
 	// Make a copy of colName so that passing a reference to tree.ErrString does
@@ -807,6 +811,51 @@ func (s *scope) FindSourceProvidingColumn(
 		return nil, nil, -1, makeBackfillError(tmpName)
 	}
 	return nil, nil, -1, colinfo.NewUndefinedColumnError(tree.ErrString(&tmpName))
+}
+
+// newAmbiguousColumnError returns an error with a helpful error message to be
+// used in case of an ambiguous column reference.
+func (s *scope) newAmbiguousColumnError(n tree.Name, matchClass columnMatchClass) error {
+	colString := tree.ErrString(&n)
+	var msgBuf bytes.Buffer
+	// Search the scope for columns that match our column name and the match
+	// class.
+	for i := range s.cols {
+		col := &s.cols[i]
+		if col.name != n {
+			continue
+		}
+		var match bool
+		switch matchClass {
+		case anonymousSourceMatch:
+			match = (col.visibility == visible && col.table.ObjectName == "")
+
+		case qualifiedSourceMatch:
+			match = (col.visibility == visible && col.table.ObjectName != "")
+
+		case hiddenMatch:
+			match = (col.visibility == accessibleByName || col.visibility == accessibleByQualifiedStar)
+		}
+
+		if match {
+			srcName := tree.ErrString(&col.table)
+			if len(srcName) == 0 {
+				srcName = "<anonymous>"
+			}
+			if msgBuf.Len() > 0 {
+				msgBuf.WriteString(", ")
+			}
+			fmt.Fprintf(&msgBuf, "%s.%s", srcName, colString)
+			if matchClass == anonymousSourceMatch {
+				// All anonymous sources are identical; only print the first one.
+				break
+			}
+		}
+	}
+
+	return pgerror.Newf(pgcode.AmbiguousColumn,
+		"column reference %q is ambiguous (candidates: %s)", colString, msgBuf.String(),
+	)
 }
 
 // FindSourceMatchingName is part of the tree.ColumnItemResolver interface.
@@ -1523,49 +1572,6 @@ func (s *scope) IndexedVarResolvedType(idx int) *types.T {
 // IndexedVarNodeFormatter is part of the IndexedVarContainer interface.
 func (s *scope) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
 	panic(errors.AssertionFailedf("unimplemented: scope.IndexedVarNodeFormatter"))
-}
-
-// newAmbiguousColumnError returns an error with a helpful error message to be
-// used in case of an ambiguous column reference.
-func (s *scope) newAmbiguousColumnError(
-	n tree.Name,
-	allowHidden, moreThanOneCandidateFromAnonSource, moreThanOneCandidateWithPrefix, moreThanOneHiddenCandidate bool,
-) error {
-	colString := tree.ErrString(&n)
-	var msgBuf bytes.Buffer
-	sep := ""
-	fmtCandidate := func(tn tree.TableName) {
-		name := tree.ErrString(&tn)
-		if len(name) == 0 {
-			name = "<anonymous>"
-		}
-		fmt.Fprintf(&msgBuf, "%s%s.%s", sep, name, colString)
-		sep = ", "
-	}
-	for i := range s.cols {
-		col := &s.cols[i]
-		if col.name == n && (col.visibility == cat.Visible || (col.visibility == cat.Hidden && allowHidden)) {
-			if col.table.ObjectName == "" && col.visibility == cat.Visible {
-				if moreThanOneCandidateFromAnonSource {
-					// Only print first anonymous source, since other(s) are identical.
-					fmtCandidate(col.table)
-					break
-				}
-			} else if col.visibility == cat.Visible {
-				if moreThanOneCandidateWithPrefix && !moreThanOneCandidateFromAnonSource {
-					fmtCandidate(col.table)
-				}
-			} else {
-				if moreThanOneHiddenCandidate && !moreThanOneCandidateWithPrefix && !moreThanOneCandidateFromAnonSource {
-					fmtCandidate(col.table)
-				}
-			}
-		}
-	}
-
-	return pgerror.Newf(pgcode.AmbiguousColumn,
-		"column reference %q is ambiguous (candidates: %s)", colString, msgBuf.String(),
-	)
 }
 
 // newAmbiguousSourceError returns an error with a helpful error message to be

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -357,7 +357,7 @@ func (b *Builder) renameSource(as tree.AliasClause, scope *scope) {
 					))
 				}
 				col := &scope.cols[colIdx]
-				if col.visibility != cat.Visible {
+				if col.visibility != visible {
 					continue
 				}
 				col.name = colAlias[aliasIdx]
@@ -484,7 +484,7 @@ func (b *Builder) buildScan(
 			name:         name,
 			table:        tabMeta.Alias,
 			typ:          col.DatumType(),
-			visibility:   col.Visibility(),
+			visibility:   columnVisibility(col.Visibility()),
 			kind:         kind,
 			mutation:     kind == cat.WriteOnly || kind == cat.DeleteOnly,
 			tableOrdinal: ord,

--- a/pkg/sql/opt/optbuilder/testdata/join
+++ b/pkg/sql/opt/optbuilder/testdata/join
@@ -1391,7 +1391,7 @@ build
 SELECT t1.*, t2.* FROM t1 NATURAL JOIN t2
 ----
 project
- ├── columns: x:2!null y:4!null col1:1 col2:3 col3:7 col4:10
+ ├── columns: col1:1 x:2!null col2:3 y:4!null col3:7 y:8!null x:9!null col4:10
  └── inner-join (hash)
       ├── columns: col1:1 t1.x:2!null col2:3 t1.y:4!null t1.rowid:5!null t1.crdb_internal_mvcc_timestamp:6 col3:7 t2.y:8!null t2.x:9!null col4:10 t2.rowid:11!null t2.crdb_internal_mvcc_timestamp:12
       ├── scan t1
@@ -2670,3 +2670,158 @@ inner-join (hash)
  │              └── columns: c0:4 rowid:5!null crdb_internal_mvcc_timestamp:6
  └── filters
       └── c0:1 = c0:4
+
+exec-ddl
+CREATE TABLE abcd (a INT, b INT, c INT, d INT)
+----
+
+exec-ddl
+CREATE TABLE dxby (d INT, x INT, b INT, y INT)
+----
+
+build
+SELECT * FROM abcd NATURAL FULL OUTER JOIN dxby
+----
+project
+ ├── columns: b:13 d:14 a:1 c:3 x:8 y:10
+ └── project
+      ├── columns: b:13 d:14 a:1 abcd.b:2 c:3 abcd.d:4 abcd.rowid:5 abcd.crdb_internal_mvcc_timestamp:6 dxby.d:7 x:8 dxby.b:9 y:10 dxby.rowid:11 dxby.crdb_internal_mvcc_timestamp:12
+      ├── full-join (hash)
+      │    ├── columns: a:1 abcd.b:2 c:3 abcd.d:4 abcd.rowid:5 abcd.crdb_internal_mvcc_timestamp:6 dxby.d:7 x:8 dxby.b:9 y:10 dxby.rowid:11 dxby.crdb_internal_mvcc_timestamp:12
+      │    ├── scan abcd
+      │    │    └── columns: a:1 abcd.b:2 c:3 abcd.d:4 abcd.rowid:5!null abcd.crdb_internal_mvcc_timestamp:6
+      │    ├── scan dxby
+      │    │    └── columns: dxby.d:7 x:8 dxby.b:9 y:10 dxby.rowid:11!null dxby.crdb_internal_mvcc_timestamp:12
+      │    └── filters
+      │         ├── abcd.b:2 = dxby.b:9
+      │         └── abcd.d:4 = dxby.d:7
+      └── projections
+           ├── COALESCE(abcd.b:2, dxby.b:9) [as=b:13]
+           └── COALESCE(abcd.d:4, dxby.d:7) [as=d:14]
+
+# Test that qualified stars expand to all table columns (even those that aren't
+# directly visible); see #66123.
+build
+SELECT abcd.*, dxby.* FROM abcd NATURAL INNER JOIN dxby
+----
+project
+ ├── columns: a:1 b:2!null c:3 d:4!null d:7!null x:8 b:9!null y:10
+ └── inner-join (hash)
+      ├── columns: a:1 abcd.b:2!null c:3 abcd.d:4!null abcd.rowid:5!null abcd.crdb_internal_mvcc_timestamp:6 dxby.d:7!null x:8 dxby.b:9!null y:10 dxby.rowid:11!null dxby.crdb_internal_mvcc_timestamp:12
+      ├── scan abcd
+      │    └── columns: a:1 abcd.b:2 c:3 abcd.d:4 abcd.rowid:5!null abcd.crdb_internal_mvcc_timestamp:6
+      ├── scan dxby
+      │    └── columns: dxby.d:7 x:8 dxby.b:9 y:10 dxby.rowid:11!null dxby.crdb_internal_mvcc_timestamp:12
+      └── filters
+           ├── abcd.b:2 = dxby.b:9
+           └── abcd.d:4 = dxby.d:7
+
+build
+SELECT abcd.*, dxby.* FROM abcd NATURAL LEFT OUTER JOIN dxby
+----
+project
+ ├── columns: a:1 b:2 c:3 d:4 d:7 x:8 b:9 y:10
+ └── left-join (hash)
+      ├── columns: a:1 abcd.b:2 c:3 abcd.d:4 abcd.rowid:5!null abcd.crdb_internal_mvcc_timestamp:6 dxby.d:7 x:8 dxby.b:9 y:10 dxby.rowid:11 dxby.crdb_internal_mvcc_timestamp:12
+      ├── scan abcd
+      │    └── columns: a:1 abcd.b:2 c:3 abcd.d:4 abcd.rowid:5!null abcd.crdb_internal_mvcc_timestamp:6
+      ├── scan dxby
+      │    └── columns: dxby.d:7 x:8 dxby.b:9 y:10 dxby.rowid:11!null dxby.crdb_internal_mvcc_timestamp:12
+      └── filters
+           ├── abcd.b:2 = dxby.b:9
+           └── abcd.d:4 = dxby.d:7
+
+build
+SELECT abcd.*, dxby.* FROM abcd NATURAL RIGHT OUTER JOIN dxby
+----
+project
+ ├── columns: a:1 b:2 c:3 d:4 d:7 x:8 b:9 y:10
+ └── right-join (hash)
+      ├── columns: a:1 abcd.b:2 c:3 abcd.d:4 abcd.rowid:5 abcd.crdb_internal_mvcc_timestamp:6 dxby.d:7 x:8 dxby.b:9 y:10 dxby.rowid:11!null dxby.crdb_internal_mvcc_timestamp:12
+      ├── scan abcd
+      │    └── columns: a:1 abcd.b:2 c:3 abcd.d:4 abcd.rowid:5!null abcd.crdb_internal_mvcc_timestamp:6
+      ├── scan dxby
+      │    └── columns: dxby.d:7 x:8 dxby.b:9 y:10 dxby.rowid:11!null dxby.crdb_internal_mvcc_timestamp:12
+      └── filters
+           ├── abcd.b:2 = dxby.b:9
+           └── abcd.d:4 = dxby.d:7
+
+build
+SELECT abcd.*, dxby.* FROM abcd NATURAL FULL OUTER JOIN dxby
+----
+project
+ ├── columns: a:1 b:2 c:3 d:4 d:7 x:8 b:9 y:10
+ └── project
+      ├── columns: b:13 d:14 a:1 abcd.b:2 c:3 abcd.d:4 abcd.rowid:5 abcd.crdb_internal_mvcc_timestamp:6 dxby.d:7 x:8 dxby.b:9 y:10 dxby.rowid:11 dxby.crdb_internal_mvcc_timestamp:12
+      ├── full-join (hash)
+      │    ├── columns: a:1 abcd.b:2 c:3 abcd.d:4 abcd.rowid:5 abcd.crdb_internal_mvcc_timestamp:6 dxby.d:7 x:8 dxby.b:9 y:10 dxby.rowid:11 dxby.crdb_internal_mvcc_timestamp:12
+      │    ├── scan abcd
+      │    │    └── columns: a:1 abcd.b:2 c:3 abcd.d:4 abcd.rowid:5!null abcd.crdb_internal_mvcc_timestamp:6
+      │    ├── scan dxby
+      │    │    └── columns: dxby.d:7 x:8 dxby.b:9 y:10 dxby.rowid:11!null dxby.crdb_internal_mvcc_timestamp:12
+      │    └── filters
+      │         ├── abcd.b:2 = dxby.b:9
+      │         └── abcd.d:4 = dxby.d:7
+      └── projections
+           ├── COALESCE(abcd.b:2, dxby.b:9) [as=b:13]
+           └── COALESCE(abcd.d:4, dxby.d:7) [as=d:14]
+
+build
+SELECT abcd.*, dxby.* FROM abcd FULL OUTER JOIN dxby USING (d, b)
+----
+project
+ ├── columns: a:1 b:2 c:3 d:4 d:7 x:8 b:9 y:10
+ └── project
+      ├── columns: d:13 b:14 a:1 abcd.b:2 c:3 abcd.d:4 abcd.rowid:5 abcd.crdb_internal_mvcc_timestamp:6 dxby.d:7 x:8 dxby.b:9 y:10 dxby.rowid:11 dxby.crdb_internal_mvcc_timestamp:12
+      ├── full-join (hash)
+      │    ├── columns: a:1 abcd.b:2 c:3 abcd.d:4 abcd.rowid:5 abcd.crdb_internal_mvcc_timestamp:6 dxby.d:7 x:8 dxby.b:9 y:10 dxby.rowid:11 dxby.crdb_internal_mvcc_timestamp:12
+      │    ├── scan abcd
+      │    │    └── columns: a:1 abcd.b:2 c:3 abcd.d:4 abcd.rowid:5!null abcd.crdb_internal_mvcc_timestamp:6
+      │    ├── scan dxby
+      │    │    └── columns: dxby.d:7 x:8 dxby.b:9 y:10 dxby.rowid:11!null dxby.crdb_internal_mvcc_timestamp:12
+      │    └── filters
+      │         ├── abcd.d:4 = dxby.d:7
+      │         └── abcd.b:2 = dxby.b:9
+      └── projections
+           ├── COALESCE(abcd.d:4, dxby.d:7) [as=d:13]
+           └── COALESCE(abcd.b:2, dxby.b:9) [as=b:14]
+
+build
+SELECT abcd.a, abcd.b, abcd.c, abcd.d, dxby.d, dxby.x, dxby.b, dxby.y FROM abcd NATURAL FULL OUTER JOIN dxby
+----
+project
+ ├── columns: a:1 b:2 c:3 d:4 d:7 x:8 b:9 y:10
+ └── project
+      ├── columns: b:13 d:14 a:1 abcd.b:2 c:3 abcd.d:4 abcd.rowid:5 abcd.crdb_internal_mvcc_timestamp:6 dxby.d:7 x:8 dxby.b:9 y:10 dxby.rowid:11 dxby.crdb_internal_mvcc_timestamp:12
+      ├── full-join (hash)
+      │    ├── columns: a:1 abcd.b:2 c:3 abcd.d:4 abcd.rowid:5 abcd.crdb_internal_mvcc_timestamp:6 dxby.d:7 x:8 dxby.b:9 y:10 dxby.rowid:11 dxby.crdb_internal_mvcc_timestamp:12
+      │    ├── scan abcd
+      │    │    └── columns: a:1 abcd.b:2 c:3 abcd.d:4 abcd.rowid:5!null abcd.crdb_internal_mvcc_timestamp:6
+      │    ├── scan dxby
+      │    │    └── columns: dxby.d:7 x:8 dxby.b:9 y:10 dxby.rowid:11!null dxby.crdb_internal_mvcc_timestamp:12
+      │    └── filters
+      │         ├── abcd.b:2 = dxby.b:9
+      │         └── abcd.d:4 = dxby.d:7
+      └── projections
+           ├── COALESCE(abcd.b:2, dxby.b:9) [as=b:13]
+           └── COALESCE(abcd.d:4, dxby.d:7) [as=d:14]
+
+build
+SELECT abcd.a, abcd.b, abcd.c, abcd.d, dxby.d, dxby.x, dxby.b, dxby.y FROM abcd FULL OUTER JOIN dxby USING (d, b)
+----
+project
+ ├── columns: a:1 b:2 c:3 d:4 d:7 x:8 b:9 y:10
+ └── project
+      ├── columns: d:13 b:14 a:1 abcd.b:2 c:3 abcd.d:4 abcd.rowid:5 abcd.crdb_internal_mvcc_timestamp:6 dxby.d:7 x:8 dxby.b:9 y:10 dxby.rowid:11 dxby.crdb_internal_mvcc_timestamp:12
+      ├── full-join (hash)
+      │    ├── columns: a:1 abcd.b:2 c:3 abcd.d:4 abcd.rowid:5 abcd.crdb_internal_mvcc_timestamp:6 dxby.d:7 x:8 dxby.b:9 y:10 dxby.rowid:11 dxby.crdb_internal_mvcc_timestamp:12
+      │    ├── scan abcd
+      │    │    └── columns: a:1 abcd.b:2 c:3 abcd.d:4 abcd.rowid:5!null abcd.crdb_internal_mvcc_timestamp:6
+      │    ├── scan dxby
+      │    │    └── columns: dxby.d:7 x:8 dxby.b:9 y:10 dxby.rowid:11!null dxby.crdb_internal_mvcc_timestamp:12
+      │    └── filters
+      │         ├── abcd.d:4 = dxby.d:7
+      │         └── abcd.b:2 = dxby.b:9
+      └── projections
+           ├── COALESCE(abcd.d:4, dxby.d:7) [as=d:13]
+           └── COALESCE(abcd.b:2, dxby.b:9) [as=b:14]

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -119,7 +119,7 @@ func (b *Builder) expandStar(
 		aliases = make([]string, 0, len(refScope.cols))
 		for i := range refScope.cols {
 			col := &refScope.cols[i]
-			if col.table == *src && col.visibility == cat.Visible {
+			if col.table == *src && (col.visibility == visible || col.visibility == accessibleByQualifiedStar) {
 				exprs = append(exprs, col)
 				aliases = append(aliases, string(col.name))
 			}
@@ -134,7 +134,7 @@ func (b *Builder) expandStar(
 		aliases = make([]string, 0, len(inScope.cols))
 		for i := range inScope.cols {
 			col := &inScope.cols[i]
-			if col.visibility == cat.Visible {
+			if col.visibility == visible {
 				exprs = append(exprs, col)
 				aliases = append(aliases, string(col.name))
 			}
@@ -248,7 +248,7 @@ func (b *Builder) synthesizeResultColumns(scope *scope, cols colinfo.ResultColum
 	for i := range cols {
 		c := b.synthesizeColumn(scope, cols[i].Name, cols[i].Typ, nil /* expr */, nil /* scalar */)
 		if cols[i].Hidden {
-			c.visibility = cat.Hidden
+			c.visibility = accessibleByName
 		}
 	}
 }


### PR DESCRIPTION
Backport 2/2 commits from #66380.

/cc @cockroachdb/release

---

#### opt: introduce "accessible by qualified star" column visibility in optbuilder

This commit extends `cat.Visibility` into a new `columnVisibility`
type and adds a new value for columns which are not visible by default
but are part of qualified star expansions (`<table_name>.*` aka "all
columns selector").

Release note: None

#### opt: fix qualified star expansion after joins

When using JOIN NATURAL/USING, the equality columns are visible in the
result only once. However, the original table columns are still
accessible by qualified star ("<table_name>.*"). These columns are
currently missing from the qualified star expansion.

This commit fixes this problem by making use of the new
`accessibleByQualifiedStar` visibility.

Fixes #66123.
