### PR TITLE
sql: allow FKs to UNIQUE WITHOUT INDEX constraints with out-of-order columns

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -2538,7 +2538,10 @@ CREATE TABLE regional_by_row_unique_in_column (
   a INT PRIMARY KEY,
   b INT UNIQUE,
   c INT,
-  FAMILY (a, b, c)
+  d INT,
+  e INT,
+  UNIQUE (d, e),
+  FAMILY (a, b, c, d, e)
 ) LOCALITY REGIONAL BY ROW
 
 query TT
@@ -2548,34 +2551,43 @@ regional_by_row_unique_in_column  CREATE TABLE public.regional_by_row_unique_in_
                                   a INT8 NOT NULL,
                                   b INT8 NULL,
                                   c INT8 NULL,
+                                  d INT8 NULL,
+                                  e INT8 NULL,
                                   crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
                                   CONSTRAINT "primary" PRIMARY KEY (a ASC),
                                   UNIQUE INDEX regional_by_row_unique_in_column_b_key (b ASC),
-                                  FAMILY fam_0_a_b_c_crdb_region (a, b, c, crdb_region)
+                                  UNIQUE INDEX regional_by_row_unique_in_column_d_e_key (d ASC, e ASC),
+                                  FAMILY fam_0_a_b_c_d_e_crdb_region (a, b, c, d, e, crdb_region)
 ) LOCALITY REGIONAL BY ROW
 
 statement ok
 CREATE TABLE regional_by_row_fk (
-  d INT PRIMARY KEY,
-  e INT UNIQUE REFERENCES regional_by_row_unique_in_column(a),
-  f INT UNIQUE REFERENCES regional_by_row_unique_in_column(b),
-  FAMILY (d, e, f)
+  f INT PRIMARY KEY,
+  g INT UNIQUE REFERENCES regional_by_row_unique_in_column(a),
+  h INT UNIQUE REFERENCES regional_by_row_unique_in_column(b),
+  i INT,
+  j INT,
+  CONSTRAINT ij_fk FOREIGN KEY (i, j) REFERENCES regional_by_row_unique_in_column(e, d),
+  FAMILY (f, g, h, i, j)
 ) LOCALITY REGIONAL BY ROW
 
 query TT
 SHOW CREATE TABLE regional_by_row_fk
 ----
 regional_by_row_fk          CREATE TABLE public.regional_by_row_fk (
-                            d INT8 NOT NULL,
-                            e INT8 NULL,
-                            f INT8 NULL,
+                            f INT8 NOT NULL,
+                            g INT8 NULL,
+                            h INT8 NULL,
+                            i INT8 NULL,
+                            j INT8 NULL,
                             crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
-                            CONSTRAINT "primary" PRIMARY KEY (d ASC),
-                            CONSTRAINT fk_e_ref_regional_by_row_unique_in_column FOREIGN KEY (e) REFERENCES public.regional_by_row_unique_in_column(a),
-                            CONSTRAINT fk_f_ref_regional_by_row_unique_in_column FOREIGN KEY (f) REFERENCES public.regional_by_row_unique_in_column(b),
-                            UNIQUE INDEX regional_by_row_fk_e_key (e ASC),
-                            UNIQUE INDEX regional_by_row_fk_f_key (f ASC),
-                            FAMILY fam_0_d_e_f_crdb_region (d, e, f, crdb_region)
+                            CONSTRAINT "primary" PRIMARY KEY (f ASC),
+                            CONSTRAINT ij_fk FOREIGN KEY (i, j) REFERENCES public.regional_by_row_unique_in_column(e, d),
+                            CONSTRAINT fk_g_ref_regional_by_row_unique_in_column FOREIGN KEY (g) REFERENCES public.regional_by_row_unique_in_column(a),
+                            CONSTRAINT fk_h_ref_regional_by_row_unique_in_column FOREIGN KEY (h) REFERENCES public.regional_by_row_unique_in_column(b),
+                            UNIQUE INDEX regional_by_row_fk_g_key (g ASC),
+                            UNIQUE INDEX regional_by_row_fk_h_key (h ASC),
+                            FAMILY fam_0_f_g_h_i_j_crdb_region (f, g, h, i, j, crdb_region)
 ) LOCALITY REGIONAL BY ROW
 
 statement ok

--- a/pkg/sql/catalog/descpb/structured.go
+++ b/pkg/sql/catalog/descpb/structured.go
@@ -361,7 +361,7 @@ var _ UniqueConstraint = &IndexDescriptor{}
 func (u *UniqueWithoutIndexConstraint) IsValidReferencedUniqueConstraint(
 	referencedColIDs ColumnIDs,
 ) bool {
-	return ColumnIDs(u.ColumnIDs).Equals(referencedColIDs)
+	return ColumnIDs(u.ColumnIDs).PermutationOf(referencedColIDs)
 }
 
 // GetName is part of the UniqueConstraint interface.

--- a/pkg/sql/catalog/tabledesc/table.go
+++ b/pkg/sql/catalog/tabledesc/table.go
@@ -366,9 +366,7 @@ func FindFKReferencedUniqueConstraint(
 			continue
 		}
 
-		// TODO(rytaft): We should allow out-of-order unique constraints, as long
-		// as they have the same columns.
-		if descpb.ColumnIDs(c.ColumnIDs).Equals(referencedColIDs) {
+		if c.IsValidReferencedUniqueConstraint(referencedColIDs) {
 			return c, nil
 		}
 	}

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -1459,7 +1459,8 @@ statement ok
 CREATE TABLE uwi_child (
   d INT REFERENCES unique_without_index (d),
   e INT,
-  CONSTRAINT fk_d_e FOREIGN KEY (d, e) REFERENCES unique_without_index (d, e)
+  CONSTRAINT fk_d_e FOREIGN KEY (d, e) REFERENCES unique_without_index (d, e),
+  CONSTRAINT fk_e_d FOREIGN KEY (e, d) REFERENCES unique_without_index (e, d)
 )
 
 # We don't yet support adding a column marked as UNIQUE WITHOUT INDEX after a
@@ -1640,6 +1641,7 @@ SHOW CONSTRAINTS FROM uwi_child
 ----
 uwi_child  fk_d_e                         FOREIGN KEY  FOREIGN KEY (d, e) REFERENCES unique_without_index(d, e)  true
 uwi_child  fk_d_ref_unique_without_index  FOREIGN KEY  FOREIGN KEY (d) REFERENCES unique_without_index(d)        true
+uwi_child  fk_e_d                         FOREIGN KEY  FOREIGN KEY (e, d) REFERENCES unique_without_index(e, d)  true
 
 # Attempting to drop a column with a foreign key reference fails.
 statement error pq: "unique_d" is referenced by foreign key from table "uwi_child"


### PR DESCRIPTION
In #65209 it became possible to create a FK to a reference table with a
unique constraint (with an index) containing the same columns as the FK
but in a different order. This commit brings UNIQUE WITHOUT INDEX to
parity by allowing an FK to reference a UNIQUE WITHOUT INDEX constraint
containing the same columns in any order.

There is no release note because UNIQUE WITHOUT INDEX is used for
internal testing and is can only be used by setting the
experimental_enable_unique_without_index_constraints session setting.

Release note: None