### PR TITLE
sql: new schema changer sort operators by coarse ordering

### DIFF
--- a/pkg/sql/schemachanger/scexec/executor.go
+++ b/pkg/sql/schemachanger/scexec/executor.go
@@ -123,7 +123,7 @@ func (ex *Executor) executeBackfillOps(ctx context.Context, execute []scop.Op) e
 	for _, op := range execute {
 		var err error
 		switch op := op.(type) {
-		case scop.BackfillIndex:
+		case *scop.BackfillIndex:
 			err = ex.executeIndexBackfillOp(ctx, op)
 		default:
 			panic("unimplemented")
@@ -135,7 +135,7 @@ func (ex *Executor) executeBackfillOps(ctx context.Context, execute []scop.Op) e
 	return nil
 }
 
-func (ex *Executor) executeIndexBackfillOp(ctx context.Context, op scop.BackfillIndex) error {
+func (ex *Executor) executeIndexBackfillOp(ctx context.Context, op *scop.BackfillIndex) error {
 	// Note that the leasing here is subtle. We'll avoid the cache and ensure that
 	// the descriptor is read from the store. That means it will not be leased.
 	// This relies on changed to the descriptor not messing with this index

--- a/pkg/sql/schemachanger/scexec/scmutationexec/scmutationexec.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/scmutationexec.go
@@ -535,11 +535,11 @@ func (m *visitor) DropForeignKeyRef(ctx context.Context, op scop.DropForeignKeyR
 	}
 	newFks := make([]descpb.ForeignKeyConstraint, 0, len(fks)-1)
 	for _, fk := range fks {
-		if op.Outbound && fk.OriginTableID != op.TableID ||
-			op.Name != fk.Name {
+		if op.Outbound && (fk.OriginTableID != op.TableID ||
+			op.Name != fk.Name) {
 			newFks = append(newFks, fk)
-		} else if fk.ReferencedTableID != op.TableID ||
-			op.Name != fk.Name {
+		} else if !op.Outbound && (fk.ReferencedTableID != op.TableID ||
+			op.Name != fk.Name) {
 			newFks = append(newFks, fk)
 		}
 	}

--- a/pkg/sql/schemachanger/schemachanger_test.go
+++ b/pkg/sql/schemachanger/schemachanger_test.go
@@ -233,7 +233,7 @@ func TestSchemaChangeWaitsForOtherSchemaChanges(t *testing.T) {
 						return nil
 					}
 					for _, op := range ops.Slice() {
-						if backfillOp, ok := op.(scop.BackfillIndex); ok && backfillOp.IndexID == descpb.IndexID(2) {
+						if backfillOp, ok := op.(*scop.BackfillIndex); ok && backfillOp.IndexID == descpb.IndexID(2) {
 							job1Backfill.Do(func() {
 								close(job1BackfillNotification)
 								<-job1ContinueNotification
@@ -345,7 +345,7 @@ func TestConcurrentOldSchemaChangesCannotStart(t *testing.T) {
 					return nil
 				}
 				for _, op := range ops.Slice() {
-					if _, ok := op.(scop.BackfillIndex); ok {
+					if _, ok := op.(*scop.BackfillIndex); ok {
 						doOnce.Do(func() {
 							close(beforeBackfillNotification)
 							<-continueNotification
@@ -450,7 +450,7 @@ func TestInsertDuringAddColumnNotWritingToCurrentPrimaryIndex(t *testing.T) {
 					return nil
 				}
 				for _, op := range ops.Slice() {
-					if _, ok := op.(scop.BackfillIndex); ok {
+					if _, ok := op.(*scop.BackfillIndex); ok {
 						doOnce.Do(func() {
 							close(beforeBackfillNotification)
 							<-continueNotification

--- a/pkg/sql/schemachanger/scop/backfill.go
+++ b/pkg/sql/schemachanger/scop/backfill.go
@@ -14,6 +14,7 @@ import "github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 
 //go:generate go run ./generate_visitor.go scop Backfill backfill.go backfill_visitor_generated.go
 
+// Make sure baseOp is used for linter.
 type backfillOp struct{ baseOp }
 
 // Type implements the Op interface.
@@ -25,3 +26,6 @@ type BackfillIndex struct {
 	TableID descpb.ID
 	IndexID descpb.IndexID
 }
+
+// Make sure baseOp is used for linter.
+var _ = backfillOp{baseOp: baseOp{}}

--- a/pkg/sql/schemachanger/scop/mutation.go
+++ b/pkg/sql/schemachanger/scop/mutation.go
@@ -19,8 +19,7 @@ type mutationOp struct{ baseOp }
 // Make sure baseOp is used for linter.
 var _ = mutationOp{baseOp: baseOp{}}
 
-func (mutationOp) Type() Type        { return MutationType }
-func (*mutationOp) Revertible() bool { return true }
+func (mutationOp) Type() Type { return MutationType }
 
 // MakeAddedIndexDeleteOnly adds a non-existent primary index to the
 // table.
@@ -73,20 +72,10 @@ type MarkDescriptorAsDropped struct {
 	TableID descpb.ID
 }
 
-// Revertible implements if this operation can be reverted.
-func (*MarkDescriptorAsDropped) Revertible() bool {
-	return false
-}
-
 // DrainDescriptorName marks a descriptor as dropped.
 type DrainDescriptorName struct {
 	mutationOp
 	TableID descpb.ID
-}
-
-// Revertible implements if this operation can be reverted.
-func (*DrainDescriptorName) Revertible() bool {
-	return false
 }
 
 // UpdateRelationDeps updates dependencies for a relation.

--- a/pkg/sql/schemachanger/scop/ops.go
+++ b/pkg/sql/schemachanger/scop/ops.go
@@ -15,7 +15,6 @@ import "github.com/cockroachdb/errors"
 // Op represents an action to be taken on a single descriptor.
 type Op interface {
 	Type() Type
-	Revertible() bool
 }
 
 // Ops represents a slice of operations where all operations have the
@@ -89,5 +88,3 @@ var _ Ops = (backfillOps)(nil)
 var _ Ops = (validationOps)(nil)
 
 type baseOp struct{}
-
-func (baseOp) Revertible() bool { return true }

--- a/pkg/sql/schemachanger/scop/validation.go
+++ b/pkg/sql/schemachanger/scop/validation.go
@@ -32,3 +32,6 @@ type ValidateCheckConstraint struct {
 	TableID descpb.ID
 	Name    string
 }
+
+// Make sure baseOp is used for linter.
+var _ = validationOp{baseOp: baseOp{}}

--- a/pkg/sql/schemachanger/scplan/BUILD.bazel
+++ b/pkg/sql/schemachanger/scplan/BUILD.bazel
@@ -17,7 +17,6 @@ go_library(
         "//pkg/sql/schemachanger/scop",
         "//pkg/sql/schemachanger/scpb",
         "//pkg/util/iterutil",
-        "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/sql/schemachanger/scplan/declarative.go
+++ b/pkg/sql/schemachanger/scplan/declarative.go
@@ -26,9 +26,10 @@ type depMatcher struct {
 }
 
 type decOpEdge struct {
-	nextState scpb.State
-	predicate interface{}
-	op        interface{}
+	nextState     scpb.State
+	predicate     interface{}
+	op            interface{}
+	nonRevertible bool
 }
 
 type targetRules struct {
@@ -212,9 +213,9 @@ func buildSchemaChangeOpGenFunc(e scpb.Element, forward, backwards targetOpRules
 				}
 				out := reflect.ValueOf(rule.op).Call(opsArgs)
 				if op, ok := out[0].Interface().(scop.Op); ok {
-					builder.AddOpEdges(t, cur, rule.nextState, op)
+					builder.AddOpEdges(t, cur, rule.nextState, !rule.nonRevertible, op)
 				} else if opArray, ok := out[0].Interface().([]scop.Op); ok {
-					builder.AddOpEdges(t, cur, rule.nextState, opArray...)
+					builder.AddOpEdges(t, cur, rule.nextState, !rule.nonRevertible, opArray...)
 				}
 
 				cur = rule.nextState

--- a/pkg/sql/schemachanger/scplan/plan.go
+++ b/pkg/sql/schemachanger/scplan/plan.go
@@ -11,16 +11,13 @@
 package scplan
 
 import (
-	"math/rand"
 	"reflect"
-	"sort"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scgraph"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scop"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
 	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -56,9 +53,6 @@ type Params struct {
 	//
 	// This doesn't do anything right now.
 	CreatedDescriptorIDs catalog.DescriptorIDSet
-	// DisableOpRandomization disables randomization for the final set of
-	// operations.
-	DisableOpRandomization bool
 }
 
 // A Plan is a schema change plan, primarily containing ops to be executed that
@@ -79,6 +73,7 @@ type Plan struct {
 type Stage struct {
 	Before, After []*scpb.Node
 	Ops           scop.Ops
+	Revertible    bool
 }
 
 // MakePlan generates a Plan for a particular phase of a schema change, given
@@ -174,14 +169,23 @@ func buildStages(init []*scpb.Node, g *scgraph.Graph, params Params) []Stage {
 			return Stage{}, false
 		}
 		next := append(cur[:0:0], cur...)
+		isStageRevertible := true
 		var ops []scop.Op
-		for i, ts := range cur {
-			for _, e := range edges {
-				if e.From() == ts {
-					next[i] = e.To()
-					ops = append(ops, e.Op()...)
-					break
+		for revertible := 1; revertible >= 0; revertible-- {
+			isStageRevertible = revertible == 1
+			for i, ts := range cur {
+				for _, e := range edges {
+					if e.From() == ts && isStageRevertible == e.Revertible() {
+						next[i] = e.To()
+						ops = append(ops, e.Op()...)
+						break
+					}
 				}
+			}
+			// If we added non-revertible stages
+			// then this stage is done
+			if len(ops) != 0 {
+				break
 			}
 		}
 		return Stage{
@@ -234,29 +238,91 @@ func buildStages(init []*scpb.Node, g *scgraph.Graph, params Params) []Stage {
 		if !didSomething {
 			break
 		}
-		// Shuffle operations, since they should
-		// be order independent. Operations should
-		// be order independent, however we will
-		// try to execute non-failing ones first.
-		opsSlice := s.Ops.Slice()
-		if !params.DisableOpRandomization {
-			rand.Seed(timeutil.Now().UnixNano())
-			rand.Shuffle(len(opsSlice), func(i, j int) {
-				tmp := opsSlice[i]
-				opsSlice[i] = opsSlice[j]
-				opsSlice[j] = tmp
-			})
-		}
-		// Place non-revertible operations at the end
-		sort.SliceStable(opsSlice, func(i, j int) bool {
-			if opsSlice[i].Revertible() == opsSlice[j].Revertible() {
-				return false
-			}
-			return opsSlice[i].Revertible()
-		})
+		// Sort ops based on graph dependencies.
+		sortOps(g, s.Ops.Slice())
 		stages = append(stages, s)
 		cur = s.After
-
 	}
 	return stages
+}
+
+// Check if some route exists from curr to the
+// target node
+func doesPathExistToNode(graph *scgraph.Graph, start *scpb.Node, target *scpb.Node) bool {
+	nodesToVisit := []*scpb.Node{start}
+	visitedNodes := map[*scpb.Node]struct{}{}
+	for len(nodesToVisit) > 0 {
+		curr := nodesToVisit[0]
+		if curr == target {
+			return true
+		}
+		nodesToVisit = nodesToVisit[1:]
+		if _, ok := visitedNodes[curr]; !ok {
+			visitedNodes[curr] = struct{}{}
+			edges, ok := graph.GetDepEdgesFrom(curr)
+			if !ok {
+				return false
+			}
+			// Append all of the nodes to visit
+			for _, currEdge := range edges {
+				nodesToVisit = append(nodesToVisit, currEdge.To())
+			}
+		}
+	}
+	return false
+}
+
+// sortOps sorts the operations into order based on
+// graph dependencies
+func sortOps(graph *scgraph.Graph, ops []scop.Op) {
+	for i := 1; i < len(ops); i++ {
+		for j := i; j > 0; j-- {
+			if compareOps(graph, ops[j], ops[j-1]) {
+				tmp := ops[j]
+				ops[j] = ops[j-1]
+				ops[j-1] = tmp
+			}
+		}
+	}
+	// Sanity: Graph order is sane across all of
+	// the ops.
+	for i := 0; i < len(ops); i++ {
+		for j := i + 1; j < len(ops); j++ {
+			if !compareOps(graph, ops[i], ops[j]) && // Greater, but not equal (if equal opposite comparison would match).
+				compareOps(graph, ops[j], ops[i]) {
+				panic(errors.AssertionFailedf("Operators are not completely sorted %d %d", i, j))
+			} else if compareOps(graph, ops[j], ops[i]) {
+				compareOps(graph, ops[j], ops[i])
+				panic(errors.AssertionFailedf("Operators are not completely sorted %d %d", i, j))
+			}
+		}
+	}
+}
+
+// compareOps compares operations and orders them based on
+// followed by the graph dependencies.
+func compareOps(graph *scgraph.Graph, firstOp scop.Op, secondOp scop.Op) (less bool) {
+	// Otherwise, lets compare attributes
+	firstNode := graph.GetNodeFromOp(firstOp)
+	secondNode := graph.GetNodeFromOp(secondOp)
+	if firstNode == secondNode {
+		return false // Equal
+	}
+	firstExists := doesPathExistToNode(graph, firstNode, secondNode)
+	secondExists := doesPathExistToNode(graph, secondNode, firstNode)
+	if firstExists && secondExists {
+		if firstNode.Target.Direction == scpb.Target_DROP {
+			return true
+		} else if secondNode.Target.Direction == scpb.Target_DROP {
+			return false
+		} else {
+			panic(errors.AssertionFailedf("A potential cycle exists in plan the graph, without any"+
+				"nodes transitioning in opposite directions\n %s\n%s\n",
+				firstNode,
+				secondNode))
+		}
+	}
+
+	// Path exists from first to second, so we depend on second.
+	return firstExists
 }

--- a/pkg/sql/schemachanger/scplan/plan_test.go
+++ b/pkg/sql/schemachanger/scplan/plan_test.go
@@ -102,8 +102,7 @@ func TestPlanAlterTable(t *testing.T) {
 
 				plan, err := scplan.MakePlan(outputNodes,
 					scplan.Params{
-						ExecutionPhase:         scplan.PostCommitPhase,
-						DisableOpRandomization: true,
+						ExecutionPhase: scplan.PostCommitPhase,
 					})
 				require.NoError(t, err)
 

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table
@@ -36,22 +36,23 @@ Stage 0
       Version: 4
     TableID: 52
 Stage 1
-  *scop.MakeAddedColumnDeleteAndWriteOnly
-    ColumnID: 2
-    TableID: 52
   *scop.MakeAddedIndexDeleteAndWriteOnly
     IndexID: 2
     TableID: 52
 Stage 2
-  scop.BackfillIndex
-    IndexID: 2
+  *scop.MakeAddedColumnDeleteAndWriteOnly
+    ColumnID: 2
     TableID: 52
 Stage 3
-  scop.ValidateUniqueIndex
+  *scop.BackfillIndex
+    IndexID: 2
+    TableID: 52
+Stage 4
+  *scop.ValidateUniqueIndex
     IndexID: 2
     PrimaryIndexID: 1
     TableID: 52
-Stage 4
+Stage 5
   *scop.MakeColumnPublic
     ColumnID: 2
     TableID: 52
@@ -87,11 +88,11 @@ Stage 4
       Unique: true
       Version: 4
     TableID: 52
-Stage 5
+Stage 6
   *scop.MakeDroppedIndexDeleteOnly
     IndexID: 1
     TableID: 52
-Stage 6
+Stage 7
   *scop.MakeIndexAbsent
     IndexID: 1
     TableID: 52
@@ -131,22 +132,23 @@ Stage 0
       Version: 4
     TableID: 52
 Stage 1
-  *scop.MakeAddedColumnDeleteAndWriteOnly
-    ColumnID: 2
-    TableID: 52
   *scop.MakeAddedIndexDeleteAndWriteOnly
     IndexID: 2
     TableID: 52
 Stage 2
-  scop.BackfillIndex
-    IndexID: 2
+  *scop.MakeAddedColumnDeleteAndWriteOnly
+    ColumnID: 2
     TableID: 52
 Stage 3
-  scop.ValidateUniqueIndex
+  *scop.BackfillIndex
+    IndexID: 2
+    TableID: 52
+Stage 4
+  *scop.ValidateUniqueIndex
     IndexID: 2
     PrimaryIndexID: 1
     TableID: 52
-Stage 4
+Stage 5
   *scop.MakeColumnPublic
     ColumnID: 2
     TableID: 52
@@ -182,11 +184,11 @@ Stage 4
       Unique: true
       Version: 4
     TableID: 52
-Stage 5
+Stage 6
   *scop.MakeDroppedIndexDeleteOnly
     IndexID: 1
     TableID: 52
-Stage 6
+Stage 7
   *scop.MakeIndexAbsent
     IndexID: 1
     TableID: 52
@@ -241,25 +243,26 @@ Stage 0
     FamilyName: primary
     TableID: 52
 Stage 1
-  *scop.MakeAddedColumnDeleteAndWriteOnly
-    ColumnID: 2
-    TableID: 52
   *scop.MakeAddedIndexDeleteAndWriteOnly
     IndexID: 2
+    TableID: 52
+Stage 2
+  *scop.MakeAddedColumnDeleteAndWriteOnly
+    ColumnID: 2
     TableID: 52
   *scop.MakeAddedColumnDeleteAndWriteOnly
     ColumnID: 3
     TableID: 52
-Stage 2
-  scop.BackfillIndex
+Stage 3
+  *scop.BackfillIndex
     IndexID: 2
     TableID: 52
-Stage 3
-  scop.ValidateUniqueIndex
+Stage 4
+  *scop.ValidateUniqueIndex
     IndexID: 2
     PrimaryIndexID: 1
     TableID: 52
-Stage 4
+Stage 5
   *scop.MakeColumnPublic
     ColumnID: 2
     TableID: 52
@@ -300,11 +303,11 @@ Stage 4
   *scop.MakeColumnPublic
     ColumnID: 3
     TableID: 52
-Stage 5
+Stage 6
   *scop.MakeDroppedIndexDeleteOnly
     IndexID: 1
     TableID: 52
-Stage 6
+Stage 7
   *scop.MakeIndexAbsent
     IndexID: 1
     TableID: 52
@@ -344,22 +347,23 @@ Stage 0
       Version: 4
     TableID: 52
 Stage 1
-  *scop.MakeAddedColumnDeleteAndWriteOnly
-    ColumnID: 2
-    TableID: 52
   *scop.MakeAddedIndexDeleteAndWriteOnly
     IndexID: 2
     TableID: 52
 Stage 2
-  scop.BackfillIndex
-    IndexID: 2
+  *scop.MakeAddedColumnDeleteAndWriteOnly
+    ColumnID: 2
     TableID: 52
 Stage 3
-  scop.ValidateUniqueIndex
+  *scop.BackfillIndex
+    IndexID: 2
+    TableID: 52
+Stage 4
+  *scop.ValidateUniqueIndex
     IndexID: 2
     PrimaryIndexID: 1
     TableID: 52
-Stage 4
+Stage 5
   *scop.MakeColumnPublic
     ColumnID: 2
     TableID: 52
@@ -395,11 +399,11 @@ Stage 4
       Unique: true
       Version: 4
     TableID: 52
-Stage 5
+Stage 6
   *scop.MakeDroppedIndexDeleteOnly
     IndexID: 1
     TableID: 52
-Stage 6
+Stage 7
   *scop.MakeIndexAbsent
     IndexID: 1
     TableID: 52
@@ -475,35 +479,36 @@ Stage 0
       Version: 4
     TableID: 53
 Stage 1
-  *scop.MakeAddedColumnDeleteAndWriteOnly
-    ColumnID: 2
-    TableID: 52
   *scop.MakeAddedIndexDeleteAndWriteOnly
     IndexID: 2
     TableID: 52
-  *scop.MakeAddedColumnDeleteAndWriteOnly
-    ColumnID: 3
-    TableID: 53
   *scop.MakeAddedIndexDeleteAndWriteOnly
     IndexID: 2
     TableID: 53
 Stage 2
-  scop.BackfillIndex
-    IndexID: 2
+  *scop.MakeAddedColumnDeleteAndWriteOnly
+    ColumnID: 2
     TableID: 52
-  scop.BackfillIndex
-    IndexID: 2
+  *scop.MakeAddedColumnDeleteAndWriteOnly
+    ColumnID: 3
     TableID: 53
 Stage 3
-  scop.ValidateUniqueIndex
+  *scop.BackfillIndex
+    IndexID: 2
+    TableID: 52
+  *scop.BackfillIndex
+    IndexID: 2
+    TableID: 53
+Stage 4
+  *scop.ValidateUniqueIndex
     IndexID: 2
     PrimaryIndexID: 1
     TableID: 52
-  scop.ValidateUniqueIndex
+  *scop.ValidateUniqueIndex
     IndexID: 2
     PrimaryIndexID: 1
     TableID: 53
-Stage 4
+Stage 5
   *scop.MakeColumnPublic
     ColumnID: 2
     TableID: 52
@@ -580,14 +585,14 @@ Stage 4
       Unique: true
       Version: 4
     TableID: 53
-Stage 5
+Stage 6
   *scop.MakeDroppedIndexDeleteOnly
     IndexID: 1
     TableID: 52
   *scop.MakeDroppedIndexDeleteOnly
     IndexID: 1
     TableID: 53
-Stage 6
+Stage 7
   *scop.MakeIndexAbsent
     IndexID: 1
     TableID: 52

--- a/pkg/sql/schemachanger/scplan/testdata/drop_database
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_database
@@ -94,73 +94,73 @@ Stage 0
     DependedOnBy: 56
     TableID: 55
   *scop.MarkDescriptorAsDropped
-    TableID: 54
-  *scop.MarkDescriptorAsDropped
-    TableID: 57
-  *scop.MarkDescriptorAsDropped
-    TableID: 55
-  *scop.MarkDescriptorAsDropped
-    TableID: 58
-  *scop.MarkDescriptorAsDropped
-    TableID: 59
-  *scop.MarkDescriptorAsDropped
-    TableID: 60
-  *scop.MarkDescriptorAsDropped
-    TableID: 61
-  *scop.MarkDescriptorAsDropped
-    TableID: 64
-  *scop.MarkDescriptorAsDropped
-    TableID: 56
-  *scop.MarkDescriptorAsDropped
     TableID: 62
   *scop.MarkDescriptorAsDropped
     TableID: 63
+  *scop.MarkDescriptorAsDropped
+    TableID: 52
 Stage 1
+  *scop.MarkDescriptorAsDropped
+    TableID: 53
+Stage 2
+  *scop.MarkDescriptorAsDropped
+    TableID: 54
+  *scop.DrainDescriptorName
+    TableID: 54
   *scop.CreateGcJobForDescriptor
     DescID: 54
+  *scop.MarkDescriptorAsDropped
+    TableID: 57
+  *scop.DrainDescriptorName
+    TableID: 57
   *scop.CreateGcJobForDescriptor
     DescID: 57
+  *scop.MarkDescriptorAsDropped
+    TableID: 55
+  *scop.DrainDescriptorName
+    TableID: 55
   *scop.CreateGcJobForDescriptor
     DescID: 55
+  *scop.MarkDescriptorAsDropped
+    TableID: 58
+  *scop.DrainDescriptorName
+    TableID: 58
   *scop.CreateGcJobForDescriptor
     DescID: 58
+  *scop.MarkDescriptorAsDropped
+    TableID: 59
+  *scop.DrainDescriptorName
+    TableID: 59
   *scop.CreateGcJobForDescriptor
     DescID: 59
+  *scop.MarkDescriptorAsDropped
+    TableID: 60
+  *scop.DrainDescriptorName
+    TableID: 60
   *scop.CreateGcJobForDescriptor
     DescID: 60
+  *scop.MarkDescriptorAsDropped
+    TableID: 61
+  *scop.DrainDescriptorName
+    TableID: 61
   *scop.CreateGcJobForDescriptor
     DescID: 61
+  *scop.MarkDescriptorAsDropped
+    TableID: 64
+  *scop.DrainDescriptorName
+    TableID: 64
   *scop.CreateGcJobForDescriptor
     DescID: 64
+  *scop.MarkDescriptorAsDropped
+    TableID: 56
+  *scop.DrainDescriptorName
+    TableID: 56
   *scop.CreateGcJobForDescriptor
     DescID: 56
   *scop.DrainDescriptorName
-    TableID: 54
-  *scop.DrainDescriptorName
-    TableID: 57
-  *scop.DrainDescriptorName
-    TableID: 55
-  *scop.DrainDescriptorName
-    TableID: 58
-  *scop.DrainDescriptorName
-    TableID: 59
-  *scop.DrainDescriptorName
-    TableID: 60
-  *scop.DrainDescriptorName
-    TableID: 61
-  *scop.DrainDescriptorName
-    TableID: 64
-  *scop.DrainDescriptorName
-    TableID: 56
-  *scop.DrainDescriptorName
     TableID: 62
   *scop.DrainDescriptorName
     TableID: 63
-  *scop.MarkDescriptorAsDropped
-    TableID: 53
-  *scop.MarkDescriptorAsDropped
-    TableID: 52
-Stage 2
   *scop.DrainDescriptorName
     TableID: 53
   *scop.DrainDescriptorName
@@ -191,43 +191,43 @@ DROP DATABASE db1 CASCADE
   to:   [View:{DescID: 61}, ABSENT]
 - from: [Schema:{DescID: 53}, DELETE_ONLY]
   to:   [View:{DescID: 64}, ABSENT]
-- from: [Sequence:{DescID: 54}, DELETE_ONLY]
+- from: [Sequence:{DescID: 54}, PUBLIC]
   to:   [DefaultExpression:{DescID: 57, ColumnID: 3}, ABSENT]
-- from: [Sequence:{DescID: 55}, DELETE_ONLY]
+- from: [Sequence:{DescID: 55}, PUBLIC]
   to:   [DefaultExpression:{DescID: 56, ColumnID: 3}, ABSENT]
-- from: [Table:{DescID: 56}, ABSENT]
+- from: [Table:{DescID: 56}, PUBLIC]
   to:   [DefaultExpression:{DescID: 56, ColumnID: 1}, ABSENT]
-- from: [Table:{DescID: 56}, ABSENT]
+- from: [Table:{DescID: 56}, PUBLIC]
   to:   [DefaultExpression:{DescID: 56, ColumnID: 2}, ABSENT]
-- from: [Table:{DescID: 56}, ABSENT]
+- from: [Table:{DescID: 56}, PUBLIC]
   to:   [DefaultExpression:{DescID: 56, ColumnID: 3}, ABSENT]
-- from: [Table:{DescID: 56}, ABSENT]
+- from: [Table:{DescID: 56}, PUBLIC]
   to:   [RelationDependedOnBy:{DescID: 55, DepID: 56}, ABSENT]
-- from: [Table:{DescID: 56}, ABSENT]
+- from: [Table:{DescID: 56}, PUBLIC]
   to:   [View:{DescID: 58}, ABSENT]
-- from: [Table:{DescID: 57}, ABSENT]
+- from: [Table:{DescID: 57}, PUBLIC]
   to:   [DefaultExpression:{DescID: 57, ColumnID: 1}, ABSENT]
-- from: [Table:{DescID: 57}, ABSENT]
+- from: [Table:{DescID: 57}, PUBLIC]
   to:   [DefaultExpression:{DescID: 57, ColumnID: 2}, ABSENT]
-- from: [Table:{DescID: 57}, ABSENT]
+- from: [Table:{DescID: 57}, PUBLIC]
   to:   [DefaultExpression:{DescID: 57, ColumnID: 3}, ABSENT]
-- from: [Table:{DescID: 57}, ABSENT]
+- from: [Table:{DescID: 57}, PUBLIC]
   to:   [RelationDependedOnBy:{DescID: 54, DepID: 57}, ABSENT]
 - from: [Type:{DescID: 62}, PUBLIC]
   to:   [TypeReference:{DescID: 64, DepID: 62}, DELETE_ONLY]
 - from: [Type:{DescID: 63}, PUBLIC]
   to:   [TypeReference:{DescID: 64, DepID: 63}, DELETE_ONLY]
-- from: [View:{DescID: 58}, DELETE_ONLY]
-  to:   [View:{DescID: 59}, DELETE_ONLY]
-- from: [View:{DescID: 58}, DELETE_ONLY]
-  to:   [View:{DescID: 60}, DELETE_ONLY]
-- from: [View:{DescID: 59}, DELETE_ONLY]
-  to:   [View:{DescID: 60}, DELETE_ONLY]
-- from: [View:{DescID: 59}, DELETE_ONLY]
-  to:   [View:{DescID: 61}, DELETE_ONLY]
-- from: [View:{DescID: 61}, DELETE_ONLY]
-  to:   [View:{DescID: 64}, DELETE_ONLY]
-- from: [View:{DescID: 64}, DELETE_ONLY]
+- from: [View:{DescID: 58}, ABSENT]
+  to:   [View:{DescID: 59}, ABSENT]
+- from: [View:{DescID: 58}, ABSENT]
+  to:   [View:{DescID: 60}, ABSENT]
+- from: [View:{DescID: 59}, ABSENT]
+  to:   [View:{DescID: 60}, ABSENT]
+- from: [View:{DescID: 59}, ABSENT]
+  to:   [View:{DescID: 61}, ABSENT]
+- from: [View:{DescID: 61}, ABSENT]
+  to:   [View:{DescID: 64}, ABSENT]
+- from: [View:{DescID: 64}, ABSENT]
   to:   [TypeReference:{DescID: 64, DepID: 62}, ABSENT]
-- from: [View:{DescID: 64}, DELETE_ONLY]
+- from: [View:{DescID: 64}, ABSENT]
   to:   [TypeReference:{DescID: 64, DepID: 63}, ABSENT]

--- a/pkg/sql/schemachanger/scplan/testdata/drop_schema
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_schema
@@ -55,35 +55,35 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   to:   [View:{DescID: 58}, ABSENT]
 - from: [Schema:{DescID: 52}, DELETE_ONLY]
   to:   [View:{DescID: 61}, ABSENT]
-- from: [Sequence:{DescID: 53}, DELETE_ONLY]
+- from: [Sequence:{DescID: 53}, PUBLIC]
   to:   [DefaultExpression:{DescID: 54, ColumnID: 3}, ABSENT]
-- from: [Table:{DescID: 54}, ABSENT]
+- from: [Table:{DescID: 54}, PUBLIC]
   to:   [DefaultExpression:{DescID: 54, ColumnID: 1}, ABSENT]
-- from: [Table:{DescID: 54}, ABSENT]
+- from: [Table:{DescID: 54}, PUBLIC]
   to:   [DefaultExpression:{DescID: 54, ColumnID: 2}, ABSENT]
-- from: [Table:{DescID: 54}, ABSENT]
+- from: [Table:{DescID: 54}, PUBLIC]
   to:   [DefaultExpression:{DescID: 54, ColumnID: 3}, ABSENT]
-- from: [Table:{DescID: 54}, ABSENT]
+- from: [Table:{DescID: 54}, PUBLIC]
   to:   [RelationDependedOnBy:{DescID: 53, DepID: 54}, ABSENT]
-- from: [Table:{DescID: 54}, ABSENT]
+- from: [Table:{DescID: 54}, PUBLIC]
   to:   [View:{DescID: 55}, ABSENT]
 - from: [Type:{DescID: 59}, PUBLIC]
   to:   [TypeReference:{DescID: 61, DepID: 59}, DELETE_ONLY]
 - from: [Type:{DescID: 60}, PUBLIC]
   to:   [TypeReference:{DescID: 61, DepID: 60}, DELETE_ONLY]
-- from: [View:{DescID: 55}, DELETE_ONLY]
-  to:   [View:{DescID: 56}, DELETE_ONLY]
-- from: [View:{DescID: 55}, DELETE_ONLY]
-  to:   [View:{DescID: 57}, DELETE_ONLY]
-- from: [View:{DescID: 56}, DELETE_ONLY]
-  to:   [View:{DescID: 57}, DELETE_ONLY]
-- from: [View:{DescID: 56}, DELETE_ONLY]
-  to:   [View:{DescID: 58}, DELETE_ONLY]
-- from: [View:{DescID: 58}, DELETE_ONLY]
-  to:   [View:{DescID: 61}, DELETE_ONLY]
-- from: [View:{DescID: 61}, DELETE_ONLY]
+- from: [View:{DescID: 55}, ABSENT]
+  to:   [View:{DescID: 56}, ABSENT]
+- from: [View:{DescID: 55}, ABSENT]
+  to:   [View:{DescID: 57}, ABSENT]
+- from: [View:{DescID: 56}, ABSENT]
+  to:   [View:{DescID: 57}, ABSENT]
+- from: [View:{DescID: 56}, ABSENT]
+  to:   [View:{DescID: 58}, ABSENT]
+- from: [View:{DescID: 58}, ABSENT]
+  to:   [View:{DescID: 61}, ABSENT]
+- from: [View:{DescID: 61}, ABSENT]
   to:   [TypeReference:{DescID: 61, DepID: 59}, ABSENT]
-- from: [View:{DescID: 61}, DELETE_ONLY]
+- from: [View:{DescID: 61}, ABSENT]
   to:   [TypeReference:{DescID: 61, DepID: 60}, ABSENT]
 
 ops
@@ -115,58 +115,58 @@ Stage 0
     DependedOnBy: 54
     TableID: 53
   *scop.MarkDescriptorAsDropped
-    TableID: 53
-  *scop.MarkDescriptorAsDropped
-    TableID: 55
-  *scop.MarkDescriptorAsDropped
-    TableID: 56
-  *scop.MarkDescriptorAsDropped
-    TableID: 57
-  *scop.MarkDescriptorAsDropped
-    TableID: 58
-  *scop.MarkDescriptorAsDropped
-    TableID: 61
-  *scop.MarkDescriptorAsDropped
-    TableID: 54
-  *scop.MarkDescriptorAsDropped
     TableID: 59
   *scop.MarkDescriptorAsDropped
     TableID: 60
 Stage 1
-  *scop.CreateGcJobForDescriptor
-    DescID: 53
-  *scop.CreateGcJobForDescriptor
-    DescID: 55
-  *scop.CreateGcJobForDescriptor
-    DescID: 56
-  *scop.CreateGcJobForDescriptor
-    DescID: 57
-  *scop.CreateGcJobForDescriptor
-    DescID: 58
-  *scop.CreateGcJobForDescriptor
-    DescID: 61
-  *scop.CreateGcJobForDescriptor
-    DescID: 54
-  *scop.DrainDescriptorName
+  *scop.MarkDescriptorAsDropped
+    TableID: 52
+Stage 2
+  *scop.MarkDescriptorAsDropped
     TableID: 53
   *scop.DrainDescriptorName
+    TableID: 53
+  *scop.CreateGcJobForDescriptor
+    DescID: 53
+  *scop.MarkDescriptorAsDropped
     TableID: 55
   *scop.DrainDescriptorName
+    TableID: 55
+  *scop.CreateGcJobForDescriptor
+    DescID: 55
+  *scop.MarkDescriptorAsDropped
     TableID: 56
   *scop.DrainDescriptorName
+    TableID: 56
+  *scop.CreateGcJobForDescriptor
+    DescID: 56
+  *scop.MarkDescriptorAsDropped
     TableID: 57
   *scop.DrainDescriptorName
+    TableID: 57
+  *scop.CreateGcJobForDescriptor
+    DescID: 57
+  *scop.MarkDescriptorAsDropped
     TableID: 58
   *scop.DrainDescriptorName
+    TableID: 58
+  *scop.CreateGcJobForDescriptor
+    DescID: 58
+  *scop.MarkDescriptorAsDropped
     TableID: 61
   *scop.DrainDescriptorName
+    TableID: 61
+  *scop.CreateGcJobForDescriptor
+    DescID: 61
+  *scop.MarkDescriptorAsDropped
     TableID: 54
+  *scop.DrainDescriptorName
+    TableID: 54
+  *scop.CreateGcJobForDescriptor
+    DescID: 54
   *scop.DrainDescriptorName
     TableID: 59
   *scop.DrainDescriptorName
     TableID: 60
-  *scop.MarkDescriptorAsDropped
-    TableID: 52
-Stage 2
   *scop.DrainDescriptorName
     TableID: 52

--- a/pkg/sql/schemachanger/scplan/testdata/drop_sequence
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_sequence
@@ -8,11 +8,10 @@ DROP SEQUENCE defaultdb.SQ1 CASCADE
 Stage 0
   *scop.MarkDescriptorAsDropped
     TableID: 52
-Stage 1
-  *scop.CreateGcJobForDescriptor
-    DescID: 52
   *scop.DrainDescriptorName
     TableID: 52
+  *scop.CreateGcJobForDescriptor
+    DescID: 52
 
 create-table
 CREATE TABLE defaultdb.blog_posts (id INT PRIMARY KEY, val int DEFAULT nextval('defaultdb.sq1'), title text)
@@ -36,19 +35,19 @@ Stage 0
     TableID: 54
   *scop.UpdateRelationDeps
     TableID: 54
+Stage 1
   *scop.MarkDescriptorAsDropped
     TableID: 52
-Stage 1
-  *scop.CreateGcJobForDescriptor
-    DescID: 52
   *scop.DrainDescriptorName
     TableID: 52
+  *scop.CreateGcJobForDescriptor
+    DescID: 52
 
 
 deps
 DROP SEQUENCE defaultdb.SQ1 CASCADE
 ----
-- from: [Sequence:{DescID: 52}, DELETE_ONLY]
+- from: [Sequence:{DescID: 52}, PUBLIC]
   to:   [DefaultExpression:{DescID: 53, ColumnID: 2}, ABSENT]
-- from: [Sequence:{DescID: 52}, DELETE_ONLY]
+- from: [Sequence:{DescID: 52}, PUBLIC]
   to:   [DefaultExpression:{DescID: 54, ColumnID: 2}, ABSENT]

--- a/pkg/sql/schemachanger/scplan/testdata/drop_table
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_table
@@ -58,8 +58,6 @@ Stage 0
     TableID: 55
   *scop.UpdateRelationDeps
     TableID: 55
-  *scop.RemoveSequenceOwnedBy
-    TableID: 56
   *scop.RemoveColumnDefaultExpression
     ColumnID: 2
     TableID: 55
@@ -83,48 +81,48 @@ Stage 0
   *scop.RemoveRelationDependedOnBy
     DependedOnBy: 55
     TableID: 54
+Stage 1
   *scop.MarkDescriptorAsDropped
     TableID: 57
-  *scop.MarkDescriptorAsDropped
-    TableID: 56
-  *scop.MarkDescriptorAsDropped
-    TableID: 55
-Stage 1
+  *scop.DrainDescriptorName
+    TableID: 57
   *scop.CreateGcJobForDescriptor
     DescID: 57
-  *scop.CreateGcJobForDescriptor
-    DescID: 56
-  *scop.CreateGcJobForDescriptor
-    DescID: 55
-  *scop.DrainDescriptorName
-    TableID: 57
-  *scop.DrainDescriptorName
+  *scop.MarkDescriptorAsDropped
     TableID: 56
   *scop.DrainDescriptorName
+    TableID: 56
+  *scop.CreateGcJobForDescriptor
+    DescID: 56
+  *scop.MarkDescriptorAsDropped
     TableID: 55
+  *scop.DrainDescriptorName
+    TableID: 55
+  *scop.CreateGcJobForDescriptor
+    DescID: 55
 
 deps
 DROP TABLE defaultdb.shipments CASCADE;
 ----
 - from: [SequenceOwnedBy:{DescID: 56, DepID: 55}, ABSENT]
   to:   [Sequence:{DescID: 56}, DELETE_ONLY]
-- from: [Table:{DescID: 55}, ABSENT]
+- from: [Table:{DescID: 55}, PUBLIC]
   to:   [DefaultExpression:{DescID: 55, ColumnID: 1}, ABSENT]
-- from: [Table:{DescID: 55}, ABSENT]
+- from: [Table:{DescID: 55}, PUBLIC]
   to:   [DefaultExpression:{DescID: 55, ColumnID: 2}, ABSENT]
-- from: [Table:{DescID: 55}, ABSENT]
+- from: [Table:{DescID: 55}, PUBLIC]
   to:   [DefaultExpression:{DescID: 55, ColumnID: 3}, ABSENT]
-- from: [Table:{DescID: 55}, ABSENT]
+- from: [Table:{DescID: 55}, PUBLIC]
   to:   [DefaultExpression:{DescID: 55, ColumnID: 4}, ABSENT]
-- from: [Table:{DescID: 55}, ABSENT]
+- from: [Table:{DescID: 55}, PUBLIC]
   to:   [DefaultExpression:{DescID: 55, ColumnID: 5}, ABSENT]
-- from: [Table:{DescID: 55}, ABSENT]
+- from: [Table:{DescID: 55}, PUBLIC]
   to:   [OutboundForeignKey:{DescID: 55, DepID: 52, ElementName: "fk_customers"}, ABSENT]
-- from: [Table:{DescID: 55}, ABSENT]
+- from: [Table:{DescID: 55}, PUBLIC]
   to:   [OutboundForeignKey:{DescID: 55, DepID: 53, ElementName: "fk_orders"}, ABSENT]
-- from: [Table:{DescID: 55}, ABSENT]
+- from: [Table:{DescID: 55}, PUBLIC]
   to:   [RelationDependedOnBy:{DescID: 54, DepID: 55}, ABSENT]
-- from: [Table:{DescID: 55}, ABSENT]
+- from: [Table:{DescID: 55}, PUBLIC]
   to:   [SequenceOwnedBy:{DescID: 56, DepID: 55}, ABSENT]
-- from: [Table:{DescID: 55}, ABSENT]
+- from: [Table:{DescID: 55}, PUBLIC]
   to:   [View:{DescID: 57}, ABSENT]

--- a/pkg/sql/schemachanger/scplan/testdata/drop_view
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_view
@@ -12,11 +12,10 @@ DROP VIEW defaultdb.v1
 Stage 0
   *scop.MarkDescriptorAsDropped
     TableID: 53
-Stage 1
-  *scop.CreateGcJobForDescriptor
-    DescID: 53
   *scop.DrainDescriptorName
     TableID: 53
+  *scop.CreateGcJobForDescriptor
+    DescID: 53
 
 deps
 DROP VIEW defaultdb.v1
@@ -52,52 +51,52 @@ Stage 0
   *scop.RemoveTypeBackRef
     DescID: 59
     TypeID: 58
+Stage 1
   *scop.MarkDescriptorAsDropped
     TableID: 53
-  *scop.MarkDescriptorAsDropped
-    TableID: 54
-  *scop.MarkDescriptorAsDropped
-    TableID: 55
-  *scop.MarkDescriptorAsDropped
-    TableID: 56
-  *scop.MarkDescriptorAsDropped
-    TableID: 59
-Stage 1
+  *scop.DrainDescriptorName
+    TableID: 53
   *scop.CreateGcJobForDescriptor
     DescID: 53
-  *scop.CreateGcJobForDescriptor
-    DescID: 54
-  *scop.CreateGcJobForDescriptor
-    DescID: 55
-  *scop.CreateGcJobForDescriptor
-    DescID: 56
-  *scop.CreateGcJobForDescriptor
-    DescID: 59
-  *scop.DrainDescriptorName
-    TableID: 53
-  *scop.DrainDescriptorName
+  *scop.MarkDescriptorAsDropped
     TableID: 54
   *scop.DrainDescriptorName
+    TableID: 54
+  *scop.CreateGcJobForDescriptor
+    DescID: 54
+  *scop.MarkDescriptorAsDropped
     TableID: 55
   *scop.DrainDescriptorName
+    TableID: 55
+  *scop.CreateGcJobForDescriptor
+    DescID: 55
+  *scop.MarkDescriptorAsDropped
     TableID: 56
   *scop.DrainDescriptorName
+    TableID: 56
+  *scop.CreateGcJobForDescriptor
+    DescID: 56
+  *scop.MarkDescriptorAsDropped
     TableID: 59
+  *scop.DrainDescriptorName
+    TableID: 59
+  *scop.CreateGcJobForDescriptor
+    DescID: 59
 
 deps
 DROP VIEW defaultdb.v1 CASCADE
 ----
-- from: [View:{DescID: 53}, DELETE_ONLY]
-  to:   [View:{DescID: 54}, DELETE_ONLY]
-- from: [View:{DescID: 53}, DELETE_ONLY]
-  to:   [View:{DescID: 55}, DELETE_ONLY]
-- from: [View:{DescID: 54}, DELETE_ONLY]
-  to:   [View:{DescID: 55}, DELETE_ONLY]
-- from: [View:{DescID: 54}, DELETE_ONLY]
-  to:   [View:{DescID: 56}, DELETE_ONLY]
-- from: [View:{DescID: 56}, DELETE_ONLY]
-  to:   [View:{DescID: 59}, DELETE_ONLY]
-- from: [View:{DescID: 59}, DELETE_ONLY]
+- from: [View:{DescID: 53}, ABSENT]
+  to:   [View:{DescID: 54}, ABSENT]
+- from: [View:{DescID: 53}, ABSENT]
+  to:   [View:{DescID: 55}, ABSENT]
+- from: [View:{DescID: 54}, ABSENT]
+  to:   [View:{DescID: 55}, ABSENT]
+- from: [View:{DescID: 54}, ABSENT]
+  to:   [View:{DescID: 56}, ABSENT]
+- from: [View:{DescID: 56}, ABSENT]
+  to:   [View:{DescID: 59}, ABSENT]
+- from: [View:{DescID: 59}, ABSENT]
   to:   [TypeReference:{DescID: 59, DepID: 57}, ABSENT]
-- from: [View:{DescID: 59}, DELETE_ONLY]
+- from: [View:{DescID: 59}, ABSENT]
   to:   [TypeReference:{DescID: 59, DepID: 58}, ABSENT]


### PR DESCRIPTION
Previously, the new schema changer was needlessly injecting
extra stages to guarantee ordering of operations. This was
inadequate because, this could lead to different phases of
drops being spread across multiple transactions. To address,
this patch introduces ordering based on dependencies and
operation types, which allows us to eliminate injection of
extra stages.

Release note: None