### PR TITLE
execgen: remove COPYSLICE and WINDOW directives in favor of methods

### DIFF
--- a/pkg/col/coldata/bytes.go
+++ b/pkg/col/coldata/bytes.go
@@ -372,6 +372,7 @@ func (b *Bytes) AppendVal(v []byte) {
 }
 
 // Len returns how many []byte values the receiver contains.
+//gcassert:inline
 func (b *Bytes) Len() int {
 	return len(b.offsets) - 1
 }

--- a/pkg/col/coldata/datum_vec.go
+++ b/pkg/col/coldata/datum_vec.go
@@ -25,9 +25,9 @@ type DatumVec interface {
 	// Set sets the datum at index i in the vector. It must check whether the
 	// provided datum is compatible with the type that the DatumVec stores.
 	Set(i int, v Datum)
-	// Slice creates a "window" into the vector. It behaves similarly to
+	// Window creates a "window" into the vector. It behaves similarly to
 	// Golang's slice.
-	Slice(start, end int) DatumVec
+	Window(start, end int) DatumVec
 	// CopySlice copies srcStartIdx inclusive and srcEndIdx exclusive
 	// tree.Datum values from src into the vector starting at destIdx.
 	CopySlice(src DatumVec, destIdx, srcStartIdx, srcEndIdx int)

--- a/pkg/col/coldata/native_types.go
+++ b/pkg/col/coldata/native_types.go
@@ -211,3 +211,35 @@ func (c Times) CopySlice(src Times, destIdx, srcStartIdx, srcEndIdx int) {
 func (c Durations) CopySlice(src Durations, destIdx, srcStartIdx, srcEndIdx int) {
 	copy(c[destIdx:], src[srcStartIdx:srcEndIdx])
 }
+
+// Window returns the window into the vector.
+//gcassert:inline
+func (c Bools) Window(start, end int) Bools { return c[start:end] }
+
+// Window returns the window into the vector.
+//gcassert:inline
+func (c Int16s) Window(start, end int) Int16s { return c[start:end] }
+
+// Window returns the window into the vector.
+//gcassert:inline
+func (c Int32s) Window(start, end int) Int32s { return c[start:end] }
+
+// Window returns the window into the vector.
+//gcassert:inline
+func (c Int64s) Window(start, end int) Int64s { return c[start:end] }
+
+// Window returns the window into the vector.
+//gcassert:inline
+func (c Float64s) Window(start, end int) Float64s { return c[start:end] }
+
+// Window returns the window into the vector.
+//gcassert:inline
+func (c Decimals) Window(start, end int) Decimals { return c[start:end] }
+
+// Window returns the window into the vector.
+//gcassert:inline
+func (c Times) Window(start, end int) Times { return c[start:end] }
+
+// Window returns the window into the vector.
+//gcassert:inline
+func (c Durations) Window(start, end int) Durations { return c[start:end] }

--- a/pkg/col/coldata/native_types.go
+++ b/pkg/col/coldata/native_types.go
@@ -149,3 +149,65 @@ func (c Times) Len() int { return len(c) }
 // Len returns the length of the vector.
 //gcassert:inline
 func (c Durations) Len() int { return len(c) }
+
+// CopySlice copies src[srcStartIdx:srcEndIdx] into c starting at position
+// destIdx.
+//gcassert:inline
+func (c Bools) CopySlice(src Bools, destIdx, srcStartIdx, srcEndIdx int) {
+	copy(c[destIdx:], src[srcStartIdx:srcEndIdx])
+}
+
+// CopySlice copies src[srcStartIdx:srcEndIdx] into c starting at position
+// destIdx.
+//gcassert:inline
+func (c Int16s) CopySlice(src Int16s, destIdx, srcStartIdx, srcEndIdx int) {
+	copy(c[destIdx:], src[srcStartIdx:srcEndIdx])
+}
+
+// CopySlice copies src[srcStartIdx:srcEndIdx] into c starting at position
+// destIdx.
+//gcassert:inline
+func (c Int32s) CopySlice(src Int32s, destIdx, srcStartIdx, srcEndIdx int) {
+	copy(c[destIdx:], src[srcStartIdx:srcEndIdx])
+}
+
+// CopySlice copies src[srcStartIdx:srcEndIdx] into c starting at position
+// destIdx.
+//gcassert:inline
+func (c Int64s) CopySlice(src Int64s, destIdx, srcStartIdx, srcEndIdx int) {
+	copy(c[destIdx:], src[srcStartIdx:srcEndIdx])
+}
+
+// CopySlice copies src[srcStartIdx:srcEndIdx] into c starting at position
+// destIdx.
+//gcassert:inline
+func (c Float64s) CopySlice(src Float64s, destIdx, srcStartIdx, srcEndIdx int) {
+	copy(c[destIdx:], src[srcStartIdx:srcEndIdx])
+}
+
+// CopySlice copies src[srcStartIdx:srcEndIdx] into c starting at position
+// destIdx.
+//
+// Note that this method is usually inlined, but it isn't in case of the
+// memColumn.Copy generated code (probably because of the size of that
+// function), so we don't assert the inlining with the GCAssert linter.
+func (c Decimals) CopySlice(src Decimals, destIdx, srcStartIdx, srcEndIdx int) {
+	srcSlice := src[srcStartIdx:srcEndIdx]
+	for i := range srcSlice {
+		c[destIdx+i].Set(&srcSlice[i])
+	}
+}
+
+// CopySlice copies src[srcStartIdx:srcEndIdx] into c starting at position
+// destIdx.
+//gcassert:inline
+func (c Times) CopySlice(src Times, destIdx, srcStartIdx, srcEndIdx int) {
+	copy(c[destIdx:], src[srcStartIdx:srcEndIdx])
+}
+
+// CopySlice copies src[srcStartIdx:srcEndIdx] into c starting at position
+// destIdx.
+//gcassert:inline
+func (c Durations) CopySlice(src Durations, destIdx, srcStartIdx, srcEndIdx int) {
+	copy(c[destIdx:], src[srcStartIdx:srcEndIdx])
+}

--- a/pkg/col/coldata/native_types.go
+++ b/pkg/col/coldata/native_types.go
@@ -119,25 +119,33 @@ func (c Times) Set(idx int, val time.Time) { c[idx] = val }
 func (c Durations) Set(idx int, val duration.Duration) { c[idx] = val }
 
 // Len returns the length of the vector.
+//gcassert:inline
 func (c Bools) Len() int { return len(c) }
 
 // Len returns the length of the vector.
+//gcassert:inline
 func (c Int16s) Len() int { return len(c) }
 
 // Len returns the length of the vector.
+//gcassert:inline
 func (c Int32s) Len() int { return len(c) }
 
 // Len returns the length of the vector.
+//gcassert:inline
 func (c Int64s) Len() int { return len(c) }
 
 // Len returns the length of the vector.
+//gcassert:inline
 func (c Float64s) Len() int { return len(c) }
 
 // Len returns the length of the vector.
+//gcassert:inline
 func (c Decimals) Len() int { return len(c) }
 
 // Len returns the length of the vector.
+//gcassert:inline
 func (c Times) Len() int { return len(c) }
 
 // Len returns the length of the vector.
+//gcassert:inline
 func (c Durations) Len() int { return len(c) }

--- a/pkg/col/coldata/testutils.go
+++ b/pkg/col/coldata/testutils.go
@@ -132,8 +132,8 @@ func AssertEquivalentBatches(t testingT, expected, actual Batch) {
 				}
 			}
 		} else if canonicalTypeFamily == typeconv.DatumVecCanonicalTypeFamily {
-			expectedDatum := expectedVec.Datum().Slice(0 /* start */, expected.Length())
-			resultDatum := actualVec.Datum().Slice(0 /* start */, actual.Length())
+			expectedDatum := expectedVec.Datum().Window(0 /* start */, expected.Length())
+			resultDatum := actualVec.Datum().Window(0 /* start */, actual.Length())
 			require.Equal(t, expectedDatum.Len(), resultDatum.Len())
 			for i := 0; i < expectedDatum.Len(); i++ {
 				if !expectedNulls.NullAt(i) {

--- a/pkg/col/coldata/vec.eg.go
+++ b/pkg/col/coldata/vec.eg.go
@@ -387,7 +387,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 				return
 			}
 			// No Sel.
-			copy(toCol[args.DestIdx:], fromCol[args.SrcStartIdx:args.SrcEndIdx])
+			toCol.CopySlice(fromCol, args.DestIdx, args.SrcStartIdx, args.SrcEndIdx)
 			m.nulls.set(args.SliceArgs)
 		}
 	case types.BytesFamily:
@@ -519,13 +519,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 				return
 			}
 			// No Sel.
-			{
-				__tgt_slice := toCol[args.DestIdx:]
-				__src_slice := fromCol[args.SrcStartIdx:args.SrcEndIdx]
-				for __i := range __src_slice {
-					__tgt_slice[__i].Set(&__src_slice[__i])
-				}
-			}
+			toCol.CopySlice(fromCol, args.DestIdx, args.SrcStartIdx, args.SrcEndIdx)
 			m.nulls.set(args.SliceArgs)
 		}
 	case types.IntFamily:
@@ -592,7 +586,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 				return
 			}
 			// No Sel.
-			copy(toCol[args.DestIdx:], fromCol[args.SrcStartIdx:args.SrcEndIdx])
+			toCol.CopySlice(fromCol, args.DestIdx, args.SrcStartIdx, args.SrcEndIdx)
 			m.nulls.set(args.SliceArgs)
 		case 32:
 			fromCol := args.Src.Int32()
@@ -656,7 +650,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 				return
 			}
 			// No Sel.
-			copy(toCol[args.DestIdx:], fromCol[args.SrcStartIdx:args.SrcEndIdx])
+			toCol.CopySlice(fromCol, args.DestIdx, args.SrcStartIdx, args.SrcEndIdx)
 			m.nulls.set(args.SliceArgs)
 		case -1:
 		default:
@@ -721,7 +715,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 				return
 			}
 			// No Sel.
-			copy(toCol[args.DestIdx:], fromCol[args.SrcStartIdx:args.SrcEndIdx])
+			toCol.CopySlice(fromCol, args.DestIdx, args.SrcStartIdx, args.SrcEndIdx)
 			m.nulls.set(args.SliceArgs)
 		}
 	case types.FloatFamily:
@@ -789,7 +783,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 				return
 			}
 			// No Sel.
-			copy(toCol[args.DestIdx:], fromCol[args.SrcStartIdx:args.SrcEndIdx])
+			toCol.CopySlice(fromCol, args.DestIdx, args.SrcStartIdx, args.SrcEndIdx)
 			m.nulls.set(args.SliceArgs)
 		}
 	case types.TimestampTZFamily:
@@ -857,7 +851,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 				return
 			}
 			// No Sel.
-			copy(toCol[args.DestIdx:], fromCol[args.SrcStartIdx:args.SrcEndIdx])
+			toCol.CopySlice(fromCol, args.DestIdx, args.SrcStartIdx, args.SrcEndIdx)
 			m.nulls.set(args.SliceArgs)
 		}
 	case types.IntervalFamily:
@@ -925,7 +919,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 				return
 			}
 			// No Sel.
-			copy(toCol[args.DestIdx:], fromCol[args.SrcStartIdx:args.SrcEndIdx])
+			toCol.CopySlice(fromCol, args.DestIdx, args.SrcStartIdx, args.SrcEndIdx)
 			m.nulls.set(args.SliceArgs)
 		}
 	case types.JsonFamily:

--- a/pkg/col/coldata/vec.eg.go
+++ b/pkg/col/coldata/vec.eg.go
@@ -45,7 +45,7 @@ func (m *memColumn) Append(args SliceArgs) {
 				toCol = append(toCol[:args.DestIdx], fromCol[args.SrcStartIdx:args.SrcEndIdx]...)
 			} else {
 				sel := args.Sel[args.SrcStartIdx:args.SrcEndIdx]
-				toCol = toCol[0:args.DestIdx]
+				toCol = toCol.Window(0, args.DestIdx)
 				for _, selIdx := range sel {
 					val := fromCol.Get(selIdx)
 					toCol = append(toCol, val)
@@ -114,7 +114,7 @@ func (m *memColumn) Append(args SliceArgs) {
 				}
 			} else {
 				sel := args.Sel[args.SrcStartIdx:args.SrcEndIdx]
-				toCol = toCol[0:args.DestIdx]
+				toCol = toCol.Window(0, args.DestIdx)
 				for _, selIdx := range sel {
 					val := fromCol.Get(selIdx)
 					toCol = append(toCol, apd.Decimal{})
@@ -137,7 +137,7 @@ func (m *memColumn) Append(args SliceArgs) {
 				toCol = append(toCol[:args.DestIdx], fromCol[args.SrcStartIdx:args.SrcEndIdx]...)
 			} else {
 				sel := args.Sel[args.SrcStartIdx:args.SrcEndIdx]
-				toCol = toCol[0:args.DestIdx]
+				toCol = toCol.Window(0, args.DestIdx)
 				for _, selIdx := range sel {
 					val := fromCol.Get(selIdx)
 					toCol = append(toCol, val)
@@ -156,7 +156,7 @@ func (m *memColumn) Append(args SliceArgs) {
 				toCol = append(toCol[:args.DestIdx], fromCol[args.SrcStartIdx:args.SrcEndIdx]...)
 			} else {
 				sel := args.Sel[args.SrcStartIdx:args.SrcEndIdx]
-				toCol = toCol[0:args.DestIdx]
+				toCol = toCol.Window(0, args.DestIdx)
 				for _, selIdx := range sel {
 					val := fromCol.Get(selIdx)
 					toCol = append(toCol, val)
@@ -176,7 +176,7 @@ func (m *memColumn) Append(args SliceArgs) {
 				toCol = append(toCol[:args.DestIdx], fromCol[args.SrcStartIdx:args.SrcEndIdx]...)
 			} else {
 				sel := args.Sel[args.SrcStartIdx:args.SrcEndIdx]
-				toCol = toCol[0:args.DestIdx]
+				toCol = toCol.Window(0, args.DestIdx)
 				for _, selIdx := range sel {
 					val := fromCol.Get(selIdx)
 					toCol = append(toCol, val)
@@ -199,7 +199,7 @@ func (m *memColumn) Append(args SliceArgs) {
 				toCol = append(toCol[:args.DestIdx], fromCol[args.SrcStartIdx:args.SrcEndIdx]...)
 			} else {
 				sel := args.Sel[args.SrcStartIdx:args.SrcEndIdx]
-				toCol = toCol[0:args.DestIdx]
+				toCol = toCol.Window(0, args.DestIdx)
 				for _, selIdx := range sel {
 					val := fromCol.Get(selIdx)
 					toCol = append(toCol, val)
@@ -222,7 +222,7 @@ func (m *memColumn) Append(args SliceArgs) {
 				toCol = append(toCol[:args.DestIdx], fromCol[args.SrcStartIdx:args.SrcEndIdx]...)
 			} else {
 				sel := args.Sel[args.SrcStartIdx:args.SrcEndIdx]
-				toCol = toCol[0:args.DestIdx]
+				toCol = toCol.Window(0, args.DestIdx)
 				for _, selIdx := range sel {
 					val := fromCol.Get(selIdx)
 					toCol = append(toCol, val)
@@ -245,7 +245,7 @@ func (m *memColumn) Append(args SliceArgs) {
 				toCol = append(toCol[:args.DestIdx], fromCol[args.SrcStartIdx:args.SrcEndIdx]...)
 			} else {
 				sel := args.Sel[args.SrcStartIdx:args.SrcEndIdx]
-				toCol = toCol[0:args.DestIdx]
+				toCol = toCol.Window(0, args.DestIdx)
 				for _, selIdx := range sel {
 					val := fromCol.Get(selIdx)
 					toCol = append(toCol, val)
@@ -293,7 +293,7 @@ func (m *memColumn) Append(args SliceArgs) {
 				toCol.AppendSlice(fromCol, args.DestIdx, args.SrcStartIdx, args.SrcEndIdx)
 			} else {
 				sel := args.Sel[args.SrcStartIdx:args.SrcEndIdx]
-				toCol = toCol.Slice(0, args.DestIdx)
+				toCol = toCol.Window(0, args.DestIdx)
 				for _, selIdx := range sel {
 					val := fromCol.Get(selIdx)
 					toCol.AppendVal(val)
@@ -1065,7 +1065,7 @@ func (m *memColumn) Window(start int, end int) Vec {
 			return &memColumn{
 				t:                   m.t,
 				canonicalTypeFamily: m.canonicalTypeFamily,
-				col:                 col[start:end],
+				col:                 col.Window(start, end),
 				nulls:               m.nulls.Slice(start, end),
 			}
 		}
@@ -1089,7 +1089,7 @@ func (m *memColumn) Window(start int, end int) Vec {
 			return &memColumn{
 				t:                   m.t,
 				canonicalTypeFamily: m.canonicalTypeFamily,
-				col:                 col[start:end],
+				col:                 col.Window(start, end),
 				nulls:               m.nulls.Slice(start, end),
 			}
 		}
@@ -1100,7 +1100,7 @@ func (m *memColumn) Window(start int, end int) Vec {
 			return &memColumn{
 				t:                   m.t,
 				canonicalTypeFamily: m.canonicalTypeFamily,
-				col:                 col[start:end],
+				col:                 col.Window(start, end),
 				nulls:               m.nulls.Slice(start, end),
 			}
 		case 32:
@@ -1108,7 +1108,7 @@ func (m *memColumn) Window(start int, end int) Vec {
 			return &memColumn{
 				t:                   m.t,
 				canonicalTypeFamily: m.canonicalTypeFamily,
-				col:                 col[start:end],
+				col:                 col.Window(start, end),
 				nulls:               m.nulls.Slice(start, end),
 			}
 		case -1:
@@ -1117,7 +1117,7 @@ func (m *memColumn) Window(start int, end int) Vec {
 			return &memColumn{
 				t:                   m.t,
 				canonicalTypeFamily: m.canonicalTypeFamily,
-				col:                 col[start:end],
+				col:                 col.Window(start, end),
 				nulls:               m.nulls.Slice(start, end),
 			}
 		}
@@ -1129,7 +1129,7 @@ func (m *memColumn) Window(start int, end int) Vec {
 			return &memColumn{
 				t:                   m.t,
 				canonicalTypeFamily: m.canonicalTypeFamily,
-				col:                 col[start:end],
+				col:                 col.Window(start, end),
 				nulls:               m.nulls.Slice(start, end),
 			}
 		}
@@ -1141,7 +1141,7 @@ func (m *memColumn) Window(start int, end int) Vec {
 			return &memColumn{
 				t:                   m.t,
 				canonicalTypeFamily: m.canonicalTypeFamily,
-				col:                 col[start:end],
+				col:                 col.Window(start, end),
 				nulls:               m.nulls.Slice(start, end),
 			}
 		}
@@ -1153,7 +1153,7 @@ func (m *memColumn) Window(start int, end int) Vec {
 			return &memColumn{
 				t:                   m.t,
 				canonicalTypeFamily: m.canonicalTypeFamily,
-				col:                 col[start:end],
+				col:                 col.Window(start, end),
 				nulls:               m.nulls.Slice(start, end),
 			}
 		}
@@ -1177,7 +1177,7 @@ func (m *memColumn) Window(start int, end int) Vec {
 			return &memColumn{
 				t:                   m.t,
 				canonicalTypeFamily: m.canonicalTypeFamily,
-				col:                 col.Slice(start, end),
+				col:                 col.Window(start, end),
 				nulls:               m.nulls.Slice(start, end),
 			}
 		}

--- a/pkg/col/coldata/vec_tmpl.go
+++ b/pkg/col/coldata/vec_tmpl.go
@@ -203,7 +203,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 				return
 			}
 			// No Sel.
-			execgen.COPYSLICE(toCol, fromCol, args.DestIdx, args.SrcStartIdx, args.SrcEndIdx)
+			toCol.CopySlice(fromCol, args.DestIdx, args.SrcStartIdx, args.SrcEndIdx)
 			m.nulls.set(args.SliceArgs)
 			// {{end}}
 		}

--- a/pkg/col/coldata/vec_tmpl.go
+++ b/pkg/col/coldata/vec_tmpl.go
@@ -74,8 +74,8 @@ func (m *memColumn) Append(args SliceArgs) {
 				// bytes-like columns, we append an empty slice.
 				execgen.APPENDSLICE(toCol, toCol, args.DestIdx, 0, 0)
 				// {{else}}
-				// {{/* Here WINDOW means slicing which allows us to use APPENDVAL below. */}}
-				toCol = execgen.WINDOW(toCol, 0, args.DestIdx)
+				// {{/* Here Window means slicing which allows us to use APPENDVAL below. */}}
+				toCol = toCol.Window(0, args.DestIdx)
 				// {{end}}
 				for _, selIdx := range sel {
 					val := fromCol.Get(selIdx)
@@ -224,7 +224,7 @@ func (m *memColumn) Window(start int, end int) Vec {
 			return &memColumn{
 				t:                   m.t,
 				canonicalTypeFamily: m.canonicalTypeFamily,
-				col:                 execgen.WINDOW(col, start, end),
+				col:                 col.Window(start, end),
 				nulls:               m.nulls.Slice(start, end),
 			}
 			// {{end}}

--- a/pkg/col/coldataext/datum_vec.go
+++ b/pkg/col/coldataext/datum_vec.go
@@ -117,8 +117,8 @@ func (dv *datumVec) Set(i int, v coldata.Datum) {
 	dv.data[i] = datum
 }
 
-// Slice implements coldata.DatumVec interface.
-func (dv *datumVec) Slice(start, end int) coldata.DatumVec {
+// Window implements coldata.DatumVec interface.
+func (dv *datumVec) Window(start, end int) coldata.DatumVec {
 	return &datumVec{
 		t:       dv.t,
 		data:    dv.data[start:end],

--- a/pkg/col/colserde/arrowbatchconverter.go
+++ b/pkg/col/colserde/arrowbatchconverter.go
@@ -213,7 +213,7 @@ func (c *ArrowBatchConverter) BatchToArrow(batch coldata.Batch) ([]*array.Data, 
 
 		case typeconv.DatumVecCanonicalTypeFamily:
 			offsets := make([]int32, 0, n+1)
-			datums := vec.Datum().Slice(0 /* start */, n)
+			datums := vec.Datum().Window(0 /* start */, n)
 			// Make a very very rough estimate of the number of bytes we'll have to
 			// allocate for the datums in this vector. This will likely be an
 			// undercount, but the estimate is better than nothing.

--- a/pkg/sql/colexec/execgen/cmd/execgen/data_manipulation_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/data_manipulation_gen.go
@@ -40,11 +40,6 @@ var dataManipulationReplacementInfos = []dataManipulationReplacementInfo{
 		replaceWith:         "AppendVal",
 	},
 	{
-		templatePlaceholder: "execgen.WINDOW",
-		numArgs:             3,
-		replaceWith:         "Window",
-	},
-	{
 		templatePlaceholder: "execgen.SETVARIABLESIZE",
 		numArgs:             2,
 		replaceWith:         "SetVariableSize",

--- a/pkg/sql/colexec/execgen/cmd/execgen/data_manipulation_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/data_manipulation_gen.go
@@ -30,11 +30,6 @@ var dataManipulationReplacementInfos = []dataManipulationReplacementInfo{
 		replaceWith:         "CopyVal",
 	},
 	{
-		templatePlaceholder: "execgen.COPYSLICE",
-		numArgs:             5,
-		replaceWith:         "CopySlice",
-	},
-	{
 		templatePlaceholder: "execgen.APPENDSLICE",
 		numArgs:             5,
 		replaceWith:         "AppendSlice",

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_base.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_base.go
@@ -489,18 +489,6 @@ func (b *argWidthOverloadBase) CopyVal(dest, src string) string {
 	return copyVal(b.CanonicalTypeFamily, dest, src)
 }
 
-// slice is a function that should only be used in templates.
-func (b *argWidthOverloadBase) slice(target, start, end string) string {
-	switch b.CanonicalTypeFamily {
-	case types.BytesFamily, types.JsonFamily:
-		// Bytes-like vector doesn't support slicing.
-		colexecerror.InternalError(errors.AssertionFailedf("slice method is attempted to be generated on Bytes vector"))
-	case typeconv.DatumVecCanonicalTypeFamily:
-		return fmt.Sprintf(`%s.Slice(%s, %s)`, target, start, end)
-	}
-	return fmt.Sprintf("%s[%s:%s]", target, start, end)
-}
-
 // sliceable returns whether the vector of canonicalTypeFamily can be sliced
 // (i.e. whether it is a Golang's slice).
 func sliceable(canonicalTypeFamily types.Family) bool {
@@ -577,15 +565,6 @@ func (b *argWidthOverloadBase) AppendVal(target, v string) string {
 	return fmt.Sprintf("%[1]s = append(%[1]s, %[2]s)", target, v)
 }
 
-// Window is a function that should only be used in templates.
-func (b *argWidthOverloadBase) Window(target, start, end string) string {
-	switch b.CanonicalTypeFamily {
-	case types.BytesFamily, types.JsonFamily:
-		return fmt.Sprintf(`%s.Window(%s, %s)`, target, start, end)
-	}
-	return b.slice(target, start, end)
-}
-
 // setVariableSize is a function that should only be used in templates. It
 // returns a string that contains a code snippet for computing the size of the
 // object named 'value' if it has variable size and assigns it to the variable
@@ -633,7 +612,6 @@ var (
 	_    = awob.Sliceable
 	_    = awob.AppendSlice
 	_    = awob.AppendVal
-	_    = awob.Window
 	_    = awob.SetVariableSize
 	_    = awob.IsBytesLike
 )

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_base.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_base.go
@@ -517,39 +517,6 @@ func (b *argWidthOverloadBase) Sliceable() bool {
 	return sliceable(b.CanonicalTypeFamily)
 }
 
-// CopySlice is a function that should only be used in templates.
-func (b *argWidthOverloadBase) CopySlice(
-	target, src, destIdx, srcStartIdx, srcEndIdx string,
-) string {
-	var tmpl string
-	switch b.CanonicalTypeFamily {
-	case types.BytesFamily, types.JsonFamily, typeconv.DatumVecCanonicalTypeFamily:
-		tmpl = `{{.Tgt}}.CopySlice({{.Src}}, {{.TgtIdx}}, {{.SrcStart}}, {{.SrcEnd}})`
-	case types.DecimalFamily:
-		tmpl = `{
-  __tgt_slice := {{.Tgt}}[{{.TgtIdx}}:]
-  __src_slice := {{.Src}}[{{.SrcStart}}:{{.SrcEnd}}]
-  for __i := range __src_slice {
-    __tgt_slice[__i].Set(&__src_slice[__i])
-  }
-}`
-	default:
-		tmpl = `copy({{.Tgt}}[{{.TgtIdx}}:], {{.Src}}[{{.SrcStart}}:{{.SrcEnd}}])`
-	}
-	args := map[string]string{
-		"Tgt":      target,
-		"Src":      src,
-		"TgtIdx":   destIdx,
-		"SrcStart": srcStartIdx,
-		"SrcEnd":   srcEndIdx,
-	}
-	var buf strings.Builder
-	if err := template.Must(template.New("").Parse(tmpl)).Execute(&buf, args); err != nil {
-		colexecerror.InternalError(err)
-	}
-	return buf.String()
-}
-
 // AppendSlice is a function that should only be used in templates.
 func (b *argWidthOverloadBase) AppendSlice(
 	target, src, destIdx, srcStartIdx, srcEndIdx string,
@@ -664,7 +631,6 @@ var (
 	_    = awob.GoTypeSliceName
 	_    = awob.CopyVal
 	_    = awob.Sliceable
-	_    = awob.CopySlice
 	_    = awob.AppendSlice
 	_    = awob.AppendVal
 	_    = awob.Window

--- a/pkg/sql/colexec/execgen/placeholders.go
+++ b/pkg/sql/colexec/execgen/placeholders.go
@@ -22,7 +22,6 @@ var (
 	_ = COPYVAL
 	_ = APPENDSLICE
 	_ = APPENDVAL
-	_ = WINDOW
 	_ = SETVARIABLESIZE
 )
 
@@ -42,12 +41,6 @@ func APPENDSLICE(target, src, destIdx, srcStartIdx, srcEndIdx interface{}) {
 // APPENDVAL is a template function.
 func APPENDVAL(target, v interface{}) {
 	colexecerror.InternalError(errors.AssertionFailedf(nonTemplatePanic))
-}
-
-// WINDOW is a template function.
-func WINDOW(target, start, end interface{}) interface{} {
-	colexecerror.InternalError(errors.AssertionFailedf(nonTemplatePanic))
-	return nil
 }
 
 // SETVARIABLESIZE is a template function.

--- a/pkg/sql/colexec/execgen/placeholders.go
+++ b/pkg/sql/colexec/execgen/placeholders.go
@@ -20,12 +20,8 @@ const nonTemplatePanic = "do not call from non-template code"
 // Remove unused warnings.
 var (
 	_ = COPYVAL
-	_ = SET
-	_ = COPYSLICE
 	_ = APPENDSLICE
 	_ = APPENDVAL
-	_ = LEN
-	_ = ZERO
 	_ = WINDOW
 	_ = SETVARIABLESIZE
 )
@@ -38,16 +34,6 @@ func COPYVAL(dest, src interface{}) {
 	colexecerror.InternalError(errors.AssertionFailedf(nonTemplatePanic))
 }
 
-// SET is a template function.
-func SET(target, i, new interface{}) {
-	colexecerror.InternalError(errors.AssertionFailedf(nonTemplatePanic))
-}
-
-// COPYSLICE is a template function.
-func COPYSLICE(target, src, destIdx, srcStartIdx, srcEndIdx interface{}) {
-	colexecerror.InternalError(errors.AssertionFailedf(nonTemplatePanic))
-}
-
 // APPENDSLICE is a template function.
 func APPENDSLICE(target, src, destIdx, srcStartIdx, srcEndIdx interface{}) {
 	colexecerror.InternalError(errors.AssertionFailedf(nonTemplatePanic))
@@ -55,17 +41,6 @@ func APPENDSLICE(target, src, destIdx, srcStartIdx, srcEndIdx interface{}) {
 
 // APPENDVAL is a template function.
 func APPENDVAL(target, v interface{}) {
-	colexecerror.InternalError(errors.AssertionFailedf(nonTemplatePanic))
-}
-
-// LEN is a template function.
-func LEN(target interface{}) interface{} {
-	colexecerror.InternalError(errors.AssertionFailedf(nonTemplatePanic))
-	return nil
-}
-
-// ZERO is a template function.
-func ZERO(target interface{}) {
 	colexecerror.InternalError(errors.AssertionFailedf(nonTemplatePanic))
 }
 

--- a/pkg/sql/colexec/vec_comparators_tmpl.go
+++ b/pkg/sql/colexec/vec_comparators_tmpl.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coldataext"
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
-	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -118,7 +117,7 @@ func (c *_TYPEVecComparator) set(srcVecIdx, dstVecIdx int, srcIdx, dstIdx int) {
 		// variable number of bytes in `dstVecIdx`, so we will have to either shift
 		// the bytes after that element left or right, depending on how long the
 		// source bytes slice is. Refer to the CopySlice comment for an example.
-		execgen.COPYSLICE(c.vecs[dstVecIdx], c.vecs[srcVecIdx], dstIdx, srcIdx, srcIdx+1)
+		c.vecs[dstVecIdx].CopySlice(c.vecs[srcVecIdx], dstIdx, srcIdx, srcIdx+1)
 		// {{else}}
 		v := c.vecs[srcVecIdx].Get(srcIdx)
 		c.vecs[dstVecIdx].Set(dstIdx, v)


### PR DESCRIPTION
**coldata: ensure Len() methods are inlined**

Release note: None

**execgen: remove COPYSLICE directive in favor of the method**

This commit removes `execgen.COPYSLICE` directive in favor of
newly-introduced `CopySlice` method on the well-typed vectors. Most of
these methods are inlined (decimals are an exception in some cases).

Additionally, this commit removes some leftover stuff.

Release note: None

**execgen: remove WINDOW directive in favor of the method**

All calls of the newly-introduced method are actually inlined.

Release note: None