### PR TITLE
release-21.1: colexec: fix a crash with EXPLAIN (VEC) and some mutations

### DIFF
--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -573,7 +573,11 @@ func (r opResult) createAndWrapRowSource(
 	// releasables are put back into their pools upon the subquery's flow
 	// cleanup, yet the subquery planNode tree isn't closed yet since its
 	// closure is done when the main planNode tree is being closed.
-	materializerSafeToRelease := spec.Core.LocalPlanNode == nil
+	// TODO(yuzefovich): currently there are some other cases as well, figure
+	// those out. I believe all those cases can occur **only** if we have
+	// LocalPlanNode cores which is the case when we have non-empty
+	// LocalProcessors.
+	materializerSafeToRelease := len(args.LocalProcessors) == 0
 	c, releasables, err := wrapRowSources(
 		ctx,
 		flowCtx,

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_local
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_local
@@ -359,3 +359,18 @@ EXPLAIN (VEC) SELECT concat_agg(_bytes), concat_agg(_string) FROM bytes_string
   └ *colexec.orderedAggregator
     └ *colexecbase.distinctChainOps
       └ *colfetcher.ColBatchScan
+
+# Regression test that we can run EXPLAIN (VEC) on a mutation that utilizes the
+# vectorized engine for some internal operations (#66568).
+statement ok
+CREATE TABLE t66568 (c INT PRIMARY KEY);
+
+query T
+EXPLAIN (VEC) INSERT INTO t66568 VALUES (1) ON CONFLICT DO NOTHING
+----
+│
+└ Node 1
+  └ *sql.planNodeToRowSource
+    └ *colexecjoin.crossJoiner
+      ├ *sql.planNodeToRowSource
+      └ *colfetcher.ColBatchScan


### PR DESCRIPTION
Backport 1/1 commits from #66569.

/cc @cockroachdb/release

---

I stumbled upon a crash when running `EXPLAIN (VEC)` on the mutation
that used some vectorized operators. The problem is that we seem to be
releasing some components of the vectorized flow before the
corresponding `planNode` tree is closed, and when the tree is closed, we
attempt to close already released things. At this moment I'm not sure
whether the problem is with `explainVecNode` itself or a more general
one, but I decided to assume the latter and put a more general fix in
place. Finishing up the investigation is left as a TODO.

Fixes: #66568.

Release note (bug fix): CockroachDB could previously crash when
executing `EXPLAIN (VEC)` on some mutations. The bug is present only in
21.1.1-21.1.3 releases.