### PR TITLE
histogram: improve implementation, documentation and testing

### DIFF
--- a/pkg/workload/histogram/BUILD.bazel
+++ b/pkg/workload/histogram/BUILD.bazel
@@ -19,6 +19,7 @@ go_test(
     srcs = ["histogram_test.go"],
     embed = [":histogram"],
     deps = [
+        "//pkg/util/ctxgroup",
         "@com_github_prometheus_client_golang//prometheus",
         "@com_github_prometheus_client_model//go",
         "@com_github_stretchr_testify//require",

--- a/pkg/workload/histogram/histogram.go
+++ b/pkg/workload/histogram/histogram.go
@@ -53,13 +53,21 @@ type NamedHistogram struct {
 	}
 }
 
-func newNamedHistogram(reg *Registry, name string) *NamedHistogram {
-	w := &NamedHistogram{
+// newNamedHistogramLocked creates a new instance of a NamedHistogram for the
+// given name and adds it to the list of histograms tracked under this name. It
+// also creates a prometheus histogram, but it is shared across all
+// NamedHistograms for the same name (i.e. it is created when the respective
+// name is first seen). This is because the sharding within a name is a perf
+// optimization that doesn't apply to the prometheus histogram (plus everything
+// gets more complex once we have to merge multiple prom histograms together
+// for exposure via Gatherer()). See *Histograms for details.
+func (w *Registry) newNamedHistogramLocked(name string) *NamedHistogram {
+	hist := &NamedHistogram{
 		name:                name,
-		prometheusHistogram: reg.getPrometheusHistogram(name),
+		prometheusHistogram: w.getPrometheusHistogramLocked(name),
 	}
-	w.mu.current = reg.newHistogram()
-	return w
+	hist.mu.current = w.newHistogram()
+	return hist
 }
 
 // Record saves a new datapoint and should be called once per logical operation.
@@ -101,18 +109,13 @@ func (w *NamedHistogram) tick(
 // counts and also supports aggregations.
 type Registry struct {
 	workloadName string // name of the workload reporting to this registry
+	promReg      *prometheus.Registry
 	mu           struct {
 		syncutil.Mutex
+		// maps histogram name to []{histogram created through handle 1, histogram created through handle 2, ...}
 		registered map[string][]*NamedHistogram
-	}
-
-	promReg *prometheus.Registry
-	// prometheusHistograms cannot be stored in a NamedHistogram,
-	// as NamedHistogram objects get recycled. Prometheus histograms
-	// must be uniquely registered, and recreating a Histogram on
-	// each new NamedHistogram causes a panic.
-	prometheusMu struct {
-		syncutil.RWMutex
+		// maps histogram name to a single prometheus histogram shared by all
+		// handles. These will be registered with promReg.
 		prometheusHistograms map[string]prometheus.Histogram
 	}
 
@@ -142,7 +145,7 @@ func NewRegistry(maxLat time.Duration, workloadName string) *Registry {
 		},
 	}
 	r.mu.registered = make(map[string][]*NamedHistogram)
-	r.prometheusMu.prometheusHistograms = make(map[string]prometheus.Histogram)
+	r.mu.prometheusHistograms = make(map[string]prometheus.Histogram)
 	return r
 }
 
@@ -172,18 +175,9 @@ func makePrometheusLatencyHistogramBuckets() []float64 {
 	return prometheus.ExponentialBuckets(0.0005, 1.1, 150)
 }
 
-func (w *Registry) getPrometheusHistogram(name string) prometheus.Histogram {
-	w.prometheusMu.RLock()
-	ph, ok := w.prometheusMu.prometheusHistograms[name]
-	w.prometheusMu.RUnlock()
+func (w *Registry) getPrometheusHistogramLocked(name string) prometheus.Histogram {
+	ph, ok := w.mu.prometheusHistograms[name]
 
-	if ok {
-		return ph
-	}
-
-	w.prometheusMu.Lock()
-	defer w.prometheusMu.Unlock()
-	ph, ok = w.prometheusMu.prometheusHistograms[name]
 	if !ok {
 		// Metric names must be sanitized or NewHistogram will panic.
 		promName := cleanPrometheusName(name) + "_duration_seconds"
@@ -193,13 +187,15 @@ func (w *Registry) getPrometheusHistogram(name string) prometheus.Histogram {
 			Name:      promName,
 			Buckets:   makePrometheusLatencyHistogramBuckets(),
 		})
-		w.prometheusMu.prometheusHistograms[name] = ph
+		w.mu.prometheusHistograms[name] = ph
 	}
+
 	return ph
 }
 
 // GetHandle returns a thread-local handle for creating and registering
-// NamedHistograms.
+// NamedHistograms. A handle should be created for each long-lived goroutine
+// for best performance, see the comment on Histograms.
 func (w *Registry) GetHandle() *Histograms {
 	hists := &Histograms{
 		reg: w,
@@ -209,7 +205,8 @@ func (w *Registry) GetHandle() *Histograms {
 }
 
 // Tick aggregates all registered histograms, grouped by name. It is expected to
-// be called periodically from one goroutine.
+// be called periodically from one goroutine. The closure must not leak references
+// to the histograms contained in the Tick as their backing memory is pooled.
 func (w *Registry) Tick(fn func(Tick)) {
 	merged := make(map[string]*hdrhistogram.Histogram)
 	var names []string
@@ -263,7 +260,18 @@ func (w *Registry) Tick(fn func(Tick)) {
 }
 
 // Histograms is a thread-local handle for creating and registering
-// NamedHistograms.
+// NamedHistograms. A Histograms handle reduces mutex contention
+// in the common case of many worker goroutines reporting under the
+// same histogram name. It does so by collecting observations locally
+// (and thus avoiding contention that would arise from all workers
+// observing into the same histogram). When the parent Registry's Tick
+// method is called, all Histograms handles for the same name will be
+// visited and the observations merged.
+//
+// Note that there is also a cumulative shared prometheus histogram (exposed
+// under Registry.Gatherer) but since its implementation already optimizes for
+// concurrent access, a single instance per name is shared across all handles on
+// a Registry.
 type Histograms struct {
 	reg *Registry
 	mu  struct {
@@ -285,17 +293,15 @@ func (w *Histograms) Get(name string) *NamedHistogram {
 	w.mu.RUnlock()
 
 	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.reg.mu.Lock()
+	defer w.reg.mu.Unlock()
+
 	hist, ok = w.mu.hists[name]
 	if !ok {
-		hist = newNamedHistogram(w.reg, name)
+		hist = w.reg.newNamedHistogramLocked(name)
 		w.mu.hists[name] = hist
-	}
-	w.mu.Unlock()
-
-	if !ok {
-		w.reg.mu.Lock()
 		w.reg.mu.registered[name] = append(w.reg.mu.registered[name], hist)
-		w.reg.mu.Unlock()
 	}
 
 	return hist

--- a/pkg/workload/histogram/histogram_test.go
+++ b/pkg/workload/histogram/histogram_test.go
@@ -11,9 +11,11 @@
 package histogram
 
 import (
+	"context"
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
@@ -27,28 +29,89 @@ func TestRegistry(t *testing.T) {
 	r := NewRegistry(10*time.Second, "lorkwoad")
 	h := r.GetHandle()
 
-	h.Get(good).Record(time.Second)
+	for i := 0; i < 3; i++ {
+		t.Run("", func(t *testing.T) {
+			h.Get(good).Record(time.Second)
 
-	h.Get(bad).Record(time.Minute)
-	h.Get(bad).Record(time.Second)
+			h.Get(bad).Record(time.Minute)
+			h.Get(bad).Record(time.Second)
 
-	hGood := h.mu.hists[good]
-	hBad := h.mu.hists[bad]
+			hGood := h.mu.hists[good]
+			hBad := h.mu.hists[bad]
 
-	require.NotNil(t, hGood)
-	require.NotNil(t, hBad)
+			require.NotNil(t, hGood)
+			require.NotNil(t, hBad)
 
-	require.Equal(t, good, hGood.name)
-	require.Contains(t, hGood.prometheusHistogram.Desc().String(), good)
+			require.Equal(t, good, hGood.name)
+			require.Contains(t, hGood.prometheusHistogram.Desc().String(), good)
 
-	require.Equal(t, bad, hBad.name)
-	require.Contains(t, hBad.prometheusHistogram.Desc().String(), "yes_we_do_not__crash")
+			require.Equal(t, bad, hBad.name)
+			require.Contains(t, hBad.prometheusHistogram.Desc().String(), "yes_we_do_not__crash")
 
-	// Check that the "bad" metric registered both observations. We could do the same for hGood
-	// but there's little reason for that to behave differently.
-	ch := make(chan prometheus.Metric, 1)
-	hBad.prometheusHistogram.Collect(ch)
-	var m dto.Metric
-	require.NoError(t, (<-ch).Write(&m))
-	require.EqualValues(t, 2, m.GetHistogram().GetSampleCount())
+			// Check that the "bad" metric registered both observations. We could do the same for hGood
+			// but there's little reason for that to behave differently.
+			ch := make(chan prometheus.Metric, 1)
+			hBad.prometheusHistogram.Collect(ch)
+			var m dto.Metric
+			require.NoError(t, (<-ch).Write(&m))
+			// The count should be cumulative, i.e. not reset on Tick().
+			require.EqualValues(t, 2*(i+1), m.GetHistogram().GetSampleCount())
+
+			r.Tick(func(tick Tick) {
+				switch tick.Name {
+				case good:
+					// The good metric got pinged once, so 1 tick per current histogram
+					// and i+1 in total.
+					require.EqualValues(t, 1, tick.Hist.TotalCount())
+					require.EqualValues(t, i+1, tick.Cumulative.TotalCount())
+				case bad:
+					// The bad case gets pinged twice per iteration, so double the numbers.
+					require.EqualValues(t, 2, tick.Hist.TotalCount())
+					require.EqualValues(t, 2*(i+1), tick.Cumulative.TotalCount())
+				default:
+					t.Errorf("unknown name %s", tick.Name)
+				}
+			})
+		})
+	}
+}
+
+func TestRegistrySameMetricFromMultipleHandles(t *testing.T) {
+	r := NewRegistry(10*time.Second, "jepsen")
+	const name = "foo"
+	h1 := r.GetHandle()
+	h2 := r.GetHandle()
+	h1.Get(name).Record(time.Second)
+	require.EqualValues(t, 1, h1.Get(name).mu.current.TotalCount())
+	require.NotPanics(t, func() {
+		h2.Get(name).Record(time.Minute)
+	})
+	// The handles don't share the underlying *NamedHistogram.
+	require.NotEqual(t, h1.Get(name), h2.Get(name))
+	require.EqualValues(t, 1, h2.Get(name).mu.current.TotalCount())
+	require.EqualValues(t, 1, h1.Get(name).mu.current.TotalCount())
+	// But when we observe via Tick(), they get merged, i.e. the sharding is
+	// purely internal.
+	r.Tick(func(tick Tick) {
+		require.Equal(t, name, tick.Name)
+		require.EqualValues(t, 2, tick.Hist.TotalCount())
+		require.EqualValues(t, 2, tick.Cumulative.TotalCount())
+	})
+}
+
+func TestRegistrySameMetricFromMultipleHandlesConcurrently(t *testing.T) {
+	const num = 1000
+	reg := NewRegistry(10*time.Second, "conc")
+	h1, h2 := reg.GetHandle(), reg.GetHandle()
+	require.NoError(t, ctxgroup.GroupWorkers(context.Background(), num, func(ctx context.Context, i int) error {
+		h := h1
+		if i%2 == 1 {
+			h = h2
+		}
+		h.Get("op").Record(time.Minute)
+		return nil
+	}))
+	reg.Tick(func(tick Tick) {
+		require.EqualValues(t, num, tick.Cumulative.TotalCount())
+	})
 }


### PR DESCRIPTION
Simplify how the various histogram maps are organized. Now they live
next to each other and share a mutex, and a few methods have been
re-anchored to simplify the locking story.

Beef up the existing test of the total counts, and also add a test that
verifies that the registry handles the same name registered through
multiple handles.

Also document why "handles" exist: when we spin up a ton of workers
that all report to the same histogram name, we'd end up with possibly
pretty bad lock contention on `mu.current` (since everyone needs write
access to the current HDRHistogram).

cc @cockroachdb/test-eng

Release note: None
