### PR TITLE
rowexec: fix window panic in GROUPS mode with OFFSET PRECEDING bounds

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -4034,3 +4034,18 @@ SELECT max(c) OVER (ORDER BY c ROWS BETWEEN UNBOUNDED PRECEDING AND 922337203685
 ----
 NULL
 NULL
+
+# Regression test for out-of-range error when computing window frame end index
+# for GROUPS mode with OFFSET PRECEDING (#66580).
+query II
+SELECT k, first_value(k) OVER (ORDER BY v GROUPS BETWEEN 0 PRECEDING AND 2 PRECEDING) FROM kv ORDER BY 1
+----
+1   NULL
+3   NULL
+5   NULL
+6   NULL
+7   NULL
+8   NULL
+9   NULL
+10  NULL
+11  NULL

--- a/pkg/sql/sem/tree/window_funcs.go
+++ b/pkg/sql/sem/tree/window_funcs.go
@@ -406,7 +406,7 @@ func (wfr *WindowFrameRun) FrameEndIdx(ctx context.Context, evalCtx *EvalContext
 		case OffsetPreceding:
 			offset := MustBeDInt(wfr.EndBoundOffset)
 			peerGroupNum := wfr.CurRowPeerGroupNum - int(offset)
-			if peerGroupNum < 0 {
+			if peerGroupNum < wfr.PeerHelper.headPeerGroupNum {
 				// EndBound's peer group is "outside" of the partition.
 				return 0, nil
 			}


### PR DESCRIPTION
When a window function is evaluated in `GROUPS` mode, a dequeue is used
to store the peer groups (rows that compare the same). The first peer
group is removed as the start index increments. However, when both the
start and end bounds are `OFFSET PRECEDING`, it is possible for the
end offset to be larger than the start offset. In this case the logic
for calculating the end index for the frame can attempt to access a peer
group which has already been removed, leading to an out-of-bounds error.

This patch fixes the problem by preventing the end index logic from
trying to access an already-deleted peer group.

Fixes #66580

Release note (bug fix): Fixed a bug that caused a panic for window
functions operating in GROUPS mode with OFFSET PRECEDING start and
end bounds.