### PR TITLE
roachtest,workload: avoid us-central1-a

### DIFF
--- a/pkg/cmd/roachtest/ledger.go
+++ b/pkg/cmd/roachtest/ledger.go
@@ -19,7 +19,9 @@ import (
 
 func registerLedger(r *testRegistry) {
 	const nodes = 6
-	const azs = "us-central1-a,us-central1-b,us-central1-c"
+	// NB: us-central1-a has been causing issues, see:
+	// https://github.com/cockroachdb/cockroach/issues/66184
+	const azs = "us-central1-f,us-central1-b,us-central1-c"
 	r.Add(testSpec{
 		Name:    fmt.Sprintf("ledger/nodes=%d/multi-az", nodes),
 		Owner:   OwnerKV,

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -526,7 +526,9 @@ func (d tpccBenchDistribution) zones() []string {
 	case singleZone:
 		return []string{"us-central1-b"}
 	case multiZone:
-		return []string{"us-central1-a", "us-central1-b", "us-central1-c"}
+		// NB: us-central1-a has been causing issues, see:
+		// https://github.com/cockroachdb/cockroach/issues/66184
+		return []string{"us-central1-f", "us-central1-b", "us-central1-c"}
 	case multiRegion:
 		return []string{"us-east1-b", "us-west1-b", "europe-west2-b"}
 	default:

--- a/pkg/workload/interleavedpartitioned/interleavedpartitioned.go
+++ b/pkg/workload/interleavedpartitioned/interleavedpartitioned.go
@@ -360,7 +360,9 @@ var interleavedPartitionedMeta = workload.Meta{
 		g.flags.IntVar(&g.rowsPerDelete, `rows-per-delete`, 1, `Number of rows per delete operation`)
 		g.flags.StringVar(&g.eastZoneName, `east-zone-name`, `us-east1-b`, `Name of the zone to be used as east`)
 		g.flags.StringVar(&g.westZoneName, `west-zone-name`, `us-west1-b`, `Name of the zone to be used as west`)
-		g.flags.StringVar(&g.centralZoneName, `central-zone-name`, `us-central1-a`, `Name of the zone to be used as central`)
+		// NB: us-central1-a has been causing issues, see:
+		// https://github.com/cockroachdb/cockroach/issues/66184
+		g.flags.StringVar(&g.centralZoneName, `central-zone-name`, `us-central1-f`, `Name of the zone to be used as central`)
 		g.flags.StringVar(&g.locality, `locality`, ``, `Which locality is the workload running in? (east,west,central)`)
 		g.connFlags = workload.NewConnFlags(&g.flags)
 		return g


### PR DESCRIPTION
For some reason, it won't allow for any more NVME to be instantiated in
the cockroach-ephemeral project, despite quota being available and
despite this working through the andrei-jepsen project.

Touches https://github.com/cockroachdb/cockroach/issues/66184.

Release note: None
