### PR TITLE
backupccl: run all post-deserialization upgrades on restored descriptors

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -787,11 +787,7 @@ func loadBackupSQLDescs(
 		}
 	}
 
-	// Upgrade the table descriptors to use the new FK representation.
-	// TODO(lucy, jordan): This should become unnecessary in 20.1 when we stop
-	// writing old-style descs in RestoreDetails (unless a job persists across
-	// an upgrade?).
-	if err := maybeUpgradeTableDescsInSlice(ctx, sqlDescs, true /* skipFKsWithNoMatchingTable */); err != nil {
+	if err := maybeUpgradeDescriptors(ctx, sqlDescs, true /* skipFKsWithNoMatchingTable */); err != nil {
 		return nil, BackupManifest{}, nil, err
 	}
 	return backupManifests, latestBackupManifest, sqlDescs, nil

--- a/pkg/ccl/backupccl/restore_old_versions_test.go
+++ b/pkg/ccl/backupccl/restore_old_versions_test.go
@@ -191,6 +191,10 @@ func restoreOldVersionTest(exportDir string) func(t *testing.T) {
 		sqlDB.CheckQueryResults(t, `SELECT * FROM test.t1 ORDER BY k`, results)
 		sqlDB.CheckQueryResults(t, `SELECT * FROM test.t2 ORDER BY k`, results)
 		sqlDB.CheckQueryResults(t, `SELECT * FROM test.t4 ORDER BY k`, results)
+
+		results = append(results, []string{"4", "5", "6"})
+		sqlDB.Exec(t, `INSERT INTO test.t1 VALUES (4, 5 ,6)`)
+		sqlDB.CheckQueryResults(t, `SELECT * FROM test.t1 ORDER BY k`, results)
 	}
 }
 

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -926,81 +926,73 @@ func resolveTargetDB(
 	return database.Name, nil
 }
 
-// maybeUpgradeTableDescsInSlice updates the passed slice of table descriptors
-// to use the newer 19.2-style foreign key representation, if they are not
-// already upgraded. This requires resolving cross-table FK references, which is
-// done by looking up all table descriptors in the slice provided.
+// maybeUpgradeDescriptors performs post-deserialization upgrades on the
+// descriptors.
+//
+// This is done, for instance, to use the newer 19.2-style foreign key
+// representation, if they are not already upgraded.
 //
 // if skipFKsWithNoMatchingTable is set, FKs whose "other" table is missing from
 // the set provided are omitted during the upgrade, instead of causing an error
 // to be returned.
-func maybeUpgradeTableDescsInSlice(
+func maybeUpgradeDescriptors(
 	ctx context.Context, descs []catalog.Descriptor, skipFKsWithNoMatchingTable bool,
 ) error {
 	descGetter := catalog.MakeMapDescGetter()
 
-	// Populate the protoGetter with all table descriptors in all backup
-	// descriptors so that they can be looked up.
+	// Populate the catalog.DescGetter with all table descriptors in the backup.
 	for _, desc := range descs {
 		descGetter.Descriptors[desc.GetID()] = desc
 	}
 
 	for j, desc := range descs {
-		tableDesc, isTable := desc.(catalog.TableDescriptor)
-		if !isTable {
-			continue
+		var b catalog.DescriptorBuilder
+		if tableDesc, isTable := desc.(catalog.TableDescriptor); isTable {
+			b = tabledesc.NewBuilderForFKUpgrade(tableDesc.TableDesc(), skipFKsWithNoMatchingTable)
+		} else {
+			b = catalogkv.NewBuilder(desc.DescriptorProto())
 		}
-		if !tabledesc.TableHasDeprecatedForeignKeyRepresentation(tableDesc.TableDesc()) {
-			continue
-		}
-		b := tabledesc.NewBuilderForFKUpgrade(tableDesc.TableDesc(), skipFKsWithNoMatchingTable)
 		err := b.RunPostDeserializationChanges(ctx, descGetter)
 		if err != nil {
 			return err
 		}
-		descs[j] = b.BuildExistingMutableTable()
+		descs[j] = b.BuildExistingMutable()
 	}
 	return nil
 }
 
-// maybeUpgradeTableDescsInBackupManifests updates the backup descriptors'
-// table descriptors to use the newer 19.2-style foreign key representation,
-// if they are not already upgraded. This requires resolving cross-table FK
-// references, which is done by looking up all table descriptors across all
-// backup descriptors provided. if skipFKsWithNoMatchingTable is set, FKs whose
+// maybeUpgradeDescriptorsInBackupManifests updates the descriptors in the
+// manifests. This is done in particular to use the newer 19.2-style foreign
+// key representation, if they are not already upgraded.
+// This requires resolving cross-table FK references, which is done by looking
+// up all table descriptors across all backup descriptors provided.
+// If skipFKsWithNoMatchingTable is set, FKs whose
 // "other" table is missing from the set provided are omitted during the
 // upgrade, instead of causing an error to be returned.
-func maybeUpgradeTableDescsInBackupManifests(
+func maybeUpgradeDescriptorsInBackupManifests(
 	ctx context.Context, backupManifests []BackupManifest, skipFKsWithNoMatchingTable bool,
 ) error {
-	descGetter := catalog.MakeMapDescGetter()
-
-	// Populate the descGetter with all table descriptors in all backup
-	// descriptors so that they can be looked up.
+	if len(backupManifests) == 0 {
+		return nil
+	}
+	descs := make([]catalog.Descriptor, 0, len(backupManifests[0].Descriptors))
 	for _, backupManifest := range backupManifests {
-		for _, desc := range backupManifest.Descriptors {
-			if table, _, _, _ := descpb.FromDescriptor(&desc); table != nil {
-				descGetter.Descriptors[table.ID] = tabledesc.NewBuilder(table).BuildImmutable()
-			}
+		for _, pb := range backupManifest.Descriptors {
+			descs = append(descs, catalogkv.NewBuilder(&pb).BuildExistingMutable())
 		}
 	}
 
+	err := maybeUpgradeDescriptors(ctx, descs, skipFKsWithNoMatchingTable)
+	if err != nil {
+		return err
+	}
+
+	k := 0
 	for i := range backupManifests {
-		backupManifest := &backupManifests[i]
-		for j := range backupManifest.Descriptors {
-			table, _, _, _ := descpb.FromDescriptor(&backupManifest.Descriptors[j])
-			if table == nil {
-				continue
-			}
-			if !tabledesc.TableHasDeprecatedForeignKeyRepresentation(table) {
-				continue
-			}
-			b := tabledesc.NewBuilderForFKUpgrade(table, skipFKsWithNoMatchingTable)
-			err := b.RunPostDeserializationChanges(ctx, descGetter)
-			if err != nil {
-				return err
-			}
-			backupManifest.Descriptors[j] = *b.BuildExistingMutable().DescriptorProto()
+		manifest := &backupManifests[i]
+		for j := range manifest.Descriptors {
+			manifest.Descriptors[j] = *descs[k].DescriptorProto()
+			k++
 		}
 	}
 	return nil
@@ -1897,7 +1889,7 @@ func doRestorePlan(
 		}
 	}
 
-	if err := maybeUpgradeTableDescsInSlice(ctx, sqlDescs, restoreStmt.Options.SkipMissingFKs); err != nil {
+	if err := maybeUpgradeDescriptors(ctx, sqlDescs, restoreStmt.Options.SkipMissingFKs); err != nil {
 		return err
 	}
 

--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -205,11 +205,16 @@ func showBackupPlanHook(
 			manifests[i+1] = m
 		}
 
+		// Ensure that the descriptors in the backup manifests are up to date.
+		//
+		// This is necessary in particular for upgrading descriptors with old-style
+		// foreign keys which are no longer supported.
 		// If we are restoring a backup with old-style foreign keys, skip over the
 		// FKs for which we can't resolve the cross-table references. We can't
 		// display them anyway, because we don't have the referenced table names,
 		// etc.
-		if err := maybeUpgradeTableDescsInBackupManifests(ctx, manifests, true); err != nil {
+		err = maybeUpgradeDescriptorsInBackupManifests(ctx, manifests, true /* skipFKsWithNoMatchingTable */)
+		if err != nil {
 			return err
 		}
 

--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -332,28 +332,6 @@ func generatedFamilyName(familyID descpb.FamilyID, columnNames []string) string 
 	return buf.String()
 }
 
-func indexHasDeprecatedForeignKeyRepresentation(idx *descpb.IndexDescriptor) bool {
-	return idx.ForeignKey.IsSet() || len(idx.ReferencedBy) > 0
-}
-
-// TableHasDeprecatedForeignKeyRepresentation returns true if the table is not
-// dropped and any of the indexes on the table have deprecated foreign key
-// representations.
-func TableHasDeprecatedForeignKeyRepresentation(desc *descpb.TableDescriptor) bool {
-	if desc.Dropped() {
-		return false
-	}
-	if indexHasDeprecatedForeignKeyRepresentation(&desc.PrimaryIndex) {
-		return true
-	}
-	for i := range desc.Indexes {
-		if indexHasDeprecatedForeignKeyRepresentation(&desc.Indexes[i]) {
-			return true
-		}
-	}
-	return false
-}
-
 // ForEachExprStringInTableDesc runs a closure for each expression string
 // within a TableDescriptor. The closure takes in a string pointer so that
 // it can mutate the TableDescriptor if desired.


### PR DESCRIPTION
Previously, we ran these upgrades only on table descriptors which
contained deprecated foreign key references. In reality, all
post-serialization upgrades should be run on all restored descriptors,
otherwise we run the risk of restoring a descriptor which is not
compatible with the current cluster version. Concretely, this would
manifest itself as a descriptor validation failure at transaction commit
time.

This hasn't manifested itself so far probably because descriptors have
remained forward-compatible. This is not a safe assumption to make.
Descriptors can and do get corrupted by bugs, which subsequently get
fixed by migrations and post-deserialization upgrades, yet backups
can be made in the meantime.

Release note (bug fix): Fixed a bug which could have prevented
backups from being successfully restored.