### PR TITLE
sql,roachpb: move TransactionFingerprintID into roachpb

### DIFF
--- a/pkg/roachpb/app_stats.go
+++ b/pkg/roachpb/app_stats.go
@@ -46,6 +46,15 @@ func ConstructStatementFingerprintID(
 	return StmtFingerprintID(fnv.Sum())
 }
 
+// TransactionFingerprintID is the hashed string constructed using the
+// individual statement fingerprint IDs that comprise the transaction.
+type TransactionFingerprintID uint64
+
+// Size returns the size of the TransactionFingerprintID.
+func (t TransactionFingerprintID) Size() int64 {
+	return 8
+}
+
 // GetVariance retrieves the variance of the values.
 func (l *NumericStat) GetVariance(count int64) float64 {
 	return l.SquaredDiffs / (float64(count) - 1)

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -574,7 +574,6 @@ go_test(
         "//pkg/sql/sessiondatapb",
         "//pkg/sql/sessionphase",
         "//pkg/sql/span",
-        "//pkg/sql/sqlstats",
         "//pkg/sql/sqltestutils",
         "//pkg/sql/sqlutil",
         "//pkg/sql/stats",

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -451,7 +451,7 @@ func (s *Server) GetUnscrubbedTxnStats(
 	ctx context.Context,
 ) ([]roachpb.CollectedTransactionStatistics, error) {
 	var txnStats []roachpb.CollectedTransactionStatistics
-	txnStatsVisitor := func(_ sqlstats.TransactionFingerprintID, stat *roachpb.CollectedTransactionStatistics) error {
+	txnStatsVisitor := func(_ roachpb.TransactionFingerprintID, stat *roachpb.CollectedTransactionStatistics) error {
 		txnStats = append(txnStats, *stat)
 		return nil
 	}

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1597,7 +1597,7 @@ func (ex *connExecutor) recordTransaction(
 
 	return ex.statsCollector.RecordTransaction(
 		ctx,
-		sqlstats.TransactionFingerprintID(ex.extraTxnState.transactionStatementsHash.Sum()),
+		roachpb.TransactionFingerprintID(ex.extraTxnState.transactionStatementsHash.Sum()),
 		recordedTxnStats,
 	)
 }

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1070,7 +1070,7 @@ CREATE TABLE crdb_internal.node_transaction_statistics (
 
 		nodeID, _ := p.execCfg.NodeID.OptionalNodeID() // zero if not available
 
-		transactionVisitor := func(txnID sqlstats.TransactionFingerprintID, stats *roachpb.CollectedTransactionStatistics) error {
+		transactionVisitor := func(txnFingerprintID roachpb.TransactionFingerprintID, stats *roachpb.CollectedTransactionStatistics) error {
 			stmtFingerprintIDsDatum := tree.NewDArray(types.String)
 			for _, stmtFingerprintID := range stats.StatementFingerprintIDs {
 				if err := stmtFingerprintIDsDatum.Append(tree.NewDString(strconv.FormatUint(uint64(stmtFingerprintID), 10))); err != nil {
@@ -1081,7 +1081,7 @@ CREATE TABLE crdb_internal.node_transaction_statistics (
 			err := addRow(
 				tree.NewDInt(tree.DInt(nodeID)),                                                    // node_id
 				tree.NewDString(stats.App),                                                         // application_name
-				tree.NewDString(strconv.FormatUint(uint64(txnID), 10)),                             // key
+				tree.NewDString(strconv.FormatUint(uint64(txnFingerprintID), 10)),                  // key
 				stmtFingerprintIDsDatum,                                                            // statement_ids
 				tree.NewDInt(tree.DInt(stats.Stats.Count)),                                         // count
 				tree.NewDInt(tree.DInt(stats.Stats.MaxRetries)),                                    // max_retries

--- a/pkg/sql/instrumentation_test.go
+++ b/pkg/sql/instrumentation_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -126,7 +125,7 @@ func TestSampledStatsCollection(t *testing.T) {
 		key := util.MakeFNV64()
 		key.Add(uint64(aggStats.ID))
 		key.Add(uint64(selectStats.ID))
-		txStats, err := s.SQLServer().(*Server).sqlStats.GetTransactionStats("", sqlstats.TransactionFingerprintID(key.Sum()))
+		txStats, err := s.SQLServer().(*Server).sqlStats.GetTransactionStats("", roachpb.TransactionFingerprintID(key.Sum()))
 		require.NoError(t, err)
 
 		require.Equal(t, int64(2), txStats.Stats.Count, "expected to have collected two sets of general stats")

--- a/pkg/sql/sqlstats/sslocal/sslocal_provider.go
+++ b/pkg/sql/sqlstats/sslocal/sslocal_provider.go
@@ -184,7 +184,7 @@ func (s *SQLStats) GetStatementStats(
 
 // GetTransactionStats implements sqlstats.Provider interface.
 func (s *SQLStats) GetTransactionStats(
-	appName string, key sqlstats.TransactionFingerprintID,
+	appName string, key roachpb.TransactionFingerprintID,
 ) (*roachpb.CollectedTransactionStatistics, error) {
 	statsContainer := s.getStatsForApplication(appName)
 	if statsContainer == nil {

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
@@ -150,7 +150,7 @@ func (s *Container) ShouldSaveLogicalPlanDesc(
 // RecordTransaction implements sqlstats.Writer interface and saves
 // per-transaction statistics.
 func (s *Container) RecordTransaction(
-	ctx context.Context, key sqlstats.TransactionFingerprintID, value sqlstats.RecordedTxnStats,
+	ctx context.Context, key roachpb.TransactionFingerprintID, value sqlstats.RecordedTxnStats,
 ) error {
 	s.recordTransactionHighLevelStats(value.TransactionTimeSec, value.Committed, value.ImplicitTxn)
 

--- a/pkg/sql/sqlstats/ssmemstorage/utils.go
+++ b/pkg/sql/sqlstats/ssmemstorage/utils.go
@@ -10,7 +10,7 @@
 
 package ssmemstorage
 
-import "github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
+import "github.com/cockroachdb/cockroach/pkg/roachpb"
 
 type stmtList []stmtKey
 
@@ -24,7 +24,7 @@ func (s stmtList) Less(i, j int) bool {
 	return s[i].anonymizedStmt < s[j].anonymizedStmt
 }
 
-type txnList []sqlstats.TransactionFingerprintID
+type txnList []roachpb.TransactionFingerprintID
 
 func (t txnList) Len() int {
 	return len(t)

--- a/pkg/sql/sqlstats/ssprovider.go
+++ b/pkg/sql/sqlstats/ssprovider.go
@@ -42,7 +42,7 @@ type StatementWriter interface {
 // TransactionWriter is the interface that provides methods to record
 // transaction stats for a given application name..
 type TransactionWriter interface {
-	RecordTransaction(ctx context.Context, key TransactionFingerprintID, value RecordedTxnStats) error
+	RecordTransaction(ctx context.Context, key roachpb.TransactionFingerprintID, value RecordedTxnStats) error
 }
 
 // Writer is the interface that provides methods to record statement and
@@ -79,7 +79,7 @@ type Reader interface {
 	GetStatementStats(key *roachpb.StatementStatisticsKey) (*roachpb.CollectedStatementStatistics, error)
 
 	// GetTransactionStats performs a point lookup of a transaction fingerprint key.
-	GetTransactionStats(appName string, key TransactionFingerprintID) (*roachpb.CollectedTransactionStatistics, error)
+	GetTransactionStats(appName string, key roachpb.TransactionFingerprintID) (*roachpb.CollectedTransactionStatistics, error)
 }
 
 // IteratorOptions provides the ability to the caller to change how it iterates
@@ -105,7 +105,7 @@ type StatementVisitor func(*roachpb.CollectedStatementStatistics) error
 // TransactionVisitor is the callback that is invoked when caller iterate through
 // all transaction statistics using IterateTransactionStats(). If an error is
 // encountered when calling the visitor, the iteration is aborted.
-type TransactionVisitor func(TransactionFingerprintID, *roachpb.CollectedTransactionStatistics) error
+type TransactionVisitor func(roachpb.TransactionFingerprintID, *roachpb.CollectedTransactionStatistics) error
 
 // AggregatedTransactionVisitor is the callback invoked when iterate through
 // transaction statistics collected at the application level using
@@ -149,15 +149,6 @@ type Provider interface {
 	Storage
 
 	Start(ctx context.Context, stopper *stop.Stopper)
-}
-
-// TransactionFingerprintID is the hashed string constructed using the
-// individual statement fingerprint IDs that comprise the transaction.
-type TransactionFingerprintID uint64
-
-// Size returns the size of the TransactionFingerprintID.
-func (t TransactionFingerprintID) Size() int64 {
-	return 8
 }
 
 // RecordedStmtStats stores the statistics of a statement to be recorded.


### PR DESCRIPTION
Previously, the TransactionFingerprintID is defined within the sql/sqlstats
package whereas StmtFingerprintID is defined in roachpb package.
This commit moves TransactionFingerprintID to roachpb package to improve
consistency.

Release note: None