### PR TITLE
[WIP] sql: enable rehoming of rows on update

### DIFF
--- a/pkg/ccl/multiregionccl/rehoming_test.go
+++ b/pkg/ccl/multiregionccl/rehoming_test.go
@@ -1,0 +1,183 @@
+package multiregionccl
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/ccl/multiregionccl/multiregionccltestutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestAutoHoming(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var p int
+	var s string
+	var crdbRegion string
+
+	tc, _, cleanup := multiregionccltestutils.TestingCreateMultiRegionCluster(t, 3, base.TestingKnobs{})
+	defer cleanup()
+
+	sql0 := sqlutils.MakeSQLRunner(tc.Conns[0])
+	sql1 := sqlutils.MakeSQLRunner(tc.Conns[1])
+	sql2 := sqlutils.MakeSQLRunner(tc.Conns[2])
+
+	sql0.Exec(t, `
+SET CLUSTER SETTING sql.defaults.rehome_on_update.enabled = true;
+SET enable_rehome_on_update = true;`)
+
+	sql0.Exec(t, `
+CREATE DATABASE test PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3";
+USE test;
+CREATE TABLE rbr (p int, s string) LOCALITY REGIONAL BY ROW;
+INSERT INTO rbr (p, s) VALUES (1, 'hi');
+`)
+
+	row := sql0.QueryRow(t, `
+SELECT p, s, crdb_region FROM rbr WHERE p = 1`)
+	row.Scan(&p, &s, &crdbRegion)
+
+	if crdbRegion != "us-east1" {
+		t.Fatalf("expected crdbRegion to be us-east1 but got %s", crdbRegion)
+	}
+
+	// Update from us-east2 should rehome row to us-east2.
+	sql1.Exec(t, `
+USE test;
+UPDATE rbr SET (s) = ('whaddup') WHERE p = 1;`)
+
+	row = sql0.QueryRow(t, `
+SELECT p, s, crdb_region FROM rbr WHERE p = 1`)
+	row.Scan(&p, &s, &crdbRegion)
+
+	if crdbRegion != "us-east2" {
+		t.Fatalf("expected crdbRegion to be us-east2 but got %s", crdbRegion)
+	}
+
+	// Update from us-east3 should rehome row to us-east3.
+	sql2.Exec(t, `
+USE test;
+UPDATE rbr SET (s) = ('anothaone') WHERE p = 1;`)
+
+	row = sql0.QueryRow(t, `
+SELECT p, s, crdb_region FROM rbr WHERE p = 1`)
+	row.Scan(&p, &s, &crdbRegion)
+
+	if crdbRegion != "us-east3" {
+		t.Fatalf("expected crdbRegion to be us-east3 but got %s", crdbRegion)
+	}
+}
+
+func TestAutoHomingDisabled(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var p int
+	var s string
+	var crdbRegion string
+
+	tc, _, cleanup := multiregionccltestutils.TestingCreateMultiRegionCluster(t, 3, base.TestingKnobs{})
+	defer cleanup()
+
+	sql0 := sqlutils.MakeSQLRunner(tc.Conns[0])
+	sql1 := sqlutils.MakeSQLRunner(tc.Conns[1])
+	sql2 := sqlutils.MakeSQLRunner(tc.Conns[2])
+
+	sql0.Exec(t, `
+CREATE DATABASE test PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3";
+USE test;
+CREATE TABLE rbr (p int, s string) LOCALITY REGIONAL BY ROW;
+INSERT INTO rbr (p, s) VALUES (1, 'hi');
+`)
+
+	row := sql0.QueryRow(t, `
+SELECT p, s, crdb_region FROM rbr WHERE p = 1`)
+	row.Scan(&p, &s, &crdbRegion)
+
+	if crdbRegion != "us-east1" {
+		t.Fatalf("expected crdbRegion to be us-east1 but got %s", crdbRegion)
+	}
+
+	// Update from us-east2 should not rehome row to us-east2 because cluster setting is disabled.
+	sql1.Exec(t, `
+USE test;
+UPDATE rbr SET (s) = ('whaddup') WHERE p = 1;`)
+
+	row = sql0.QueryRow(t, `
+SELECT p, s, crdb_region FROM rbr WHERE p = 1`)
+	row.Scan(&p, &s, &crdbRegion)
+
+	if crdbRegion != "us-east1" {
+		t.Fatalf("expected crdbRegion to be us-east1 but got %s", crdbRegion)
+	}
+
+	// Update from us-east3 should not rehome row to us-east3.
+	sql2.Exec(t, `
+USE test;
+UPDATE rbr SET (s) = ('anothaone') WHERE p = 1;`)
+
+	row = sql0.QueryRow(t, `
+SELECT p, s, crdb_region FROM rbr WHERE p = 1`)
+	row.Scan(&p, &s, &crdbRegion)
+
+	if crdbRegion != "us-east1" {
+		t.Fatalf("expected crdbRegion to be us-east1 but got %s", crdbRegion)
+	}
+}
+
+func TestAutoHomingOutsideRegion(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var p int
+	var s string
+	var crdbRegion string
+
+	tc, _, cleanup := multiregionccltestutils.TestingCreateMultiRegionCluster(t, 3, base.TestingKnobs{})
+	defer cleanup()
+
+	sql0 := sqlutils.MakeSQLRunner(tc.Conns[0])
+	sql1 := sqlutils.MakeSQLRunner(tc.Conns[1])
+	sql2 := sqlutils.MakeSQLRunner(tc.Conns[2])
+
+	sql0.Exec(t, `
+SET CLUSTER SETTING sql.defaults.rehome_on_update.enabled = true;
+SET enable_rehome_on_update = true;`)
+
+	sql0.Exec(t, `
+CREATE DATABASE test PRIMARY REGION "us-east1" REGIONS "us-east2";
+USE test;
+CREATE TABLE rbr (p int, s string) LOCALITY REGIONAL BY ROW;
+INSERT INTO rbr (p, s) VALUES (1, 'hi');
+`)
+
+	row := sql0.QueryRow(t, `
+SELECT p, s, crdb_region FROM rbr WHERE p = 1`)
+	row.Scan(&p, &s, &crdbRegion)
+
+	if crdbRegion != "us-east1" {
+		t.Fatalf("expected crdbRegion to be us-east1 but got %s", crdbRegion)
+	}
+
+	// Update from us-east2 should rehome row to us-east2.
+	sql1.Exec(t, `
+USE test;
+UPDATE rbr SET (s) = ('whaddup') WHERE p = 1;`)
+
+	row = sql0.QueryRow(t, `
+SELECT p, s, crdb_region FROM rbr WHERE p = 1`)
+	row.Scan(&p, &s, &crdbRegion)
+
+	if crdbRegion != "us-east2" {
+		t.Fatalf("expected crdbRegion to be us-east2 but got %s", crdbRegion)
+	}
+
+	// Update from us-east3 should rehome row to us-east1 since us-east3 isn't in the database and us-east1 is primary.
+	sql2.Exec(t, `
+USE test;
+UPDATE rbr SET (s) = ('anothaone') WHERE p = 1;`)
+
+	row = sql0.QueryRow(t, `
+SELECT p, s, crdb_region FROM rbr WHERE p = 1`)
+	row.Scan(&p, &s, &crdbRegion)
+
+	if crdbRegion != "us-east1" {
+		t.Fatalf("expected crdbRegion to be us-east1 but got %s", crdbRegion)
+	}
+}

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -241,6 +241,13 @@ var dropEnumValueEnabledClusterMode = settings.RegisterBoolSetting(
 	false,
 )
 
+var rehomeOnUpdateClusterMode = settings.RegisterBoolSetting(
+	"sql.defaults.rehome_on_update.enabled",
+	`default value for rehome_on_update;`+
+		` allows for automatically rehoming rows in regional by row tables to their gateway region`,
+	false,
+)
+
 var overrideMultiRegionZoneConfigClusterMode = settings.RegisterBoolSetting(
 	"sql.defaults.override_multi_region_zone_config.enabled",
 	"default value for override_multi_region_zone_config; "+
@@ -2411,6 +2418,10 @@ func (m *sessionDataMutator) SetImplicitColumnPartitioningEnabled(val bool) {
 
 func (m *sessionDataMutator) SetDropEnumValueEnabled(val bool) {
 	m.data.DropEnumValueEnabled = val
+}
+
+func (m *sessionDataMutator) SetRehomeOnUpdateEnabled(val bool) {
+	m.data.RehomeOnUpdate = val
 }
 
 func (m *sessionDataMutator) SetOverrideMultiRegionZoneConfigEnabled(val bool) {

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -3691,6 +3691,7 @@ enable_experimental_alter_column_type_general         off
 enable_experimental_stream_replication                off
 enable_implicit_select_for_update                     on
 enable_insert_fast_path                               on
+enable_rehome_on_update                               off
 enable_seqscan                                        on
 enable_zigzag_join                                    on
 escape_string_warning                                 on

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2143,6 +2143,7 @@ enable_experimental_alter_column_type_general         off                 NULL  
 enable_experimental_stream_replication                off                 NULL      NULL        NULL        string
 enable_implicit_select_for_update                     on                  NULL      NULL        NULL        string
 enable_insert_fast_path                               on                  NULL      NULL        NULL        string
+enable_rehome_on_update                               off                 NULL      NULL        NULL        string
 enable_seqscan                                        on                  NULL      NULL        NULL        string
 enable_zigzag_join                                    on                  NULL      NULL        NULL        string
 escape_string_warning                                 on                  NULL      NULL        NULL        string
@@ -2225,6 +2226,7 @@ enable_experimental_alter_column_type_general         off                 NULL  
 enable_experimental_stream_replication                off                 NULL  user     NULL      off                 off
 enable_implicit_select_for_update                     on                  NULL  user     NULL      on                  on
 enable_insert_fast_path                               on                  NULL  user     NULL      on                  on
+enable_rehome_on_update                               off                 NULL  user     NULL      off                 off
 enable_seqscan                                        on                  NULL  user     NULL      on                  on
 enable_zigzag_join                                    on                  NULL  user     NULL      on                  on
 escape_string_warning                                 on                  NULL  user     NULL      on                  on
@@ -2303,6 +2305,7 @@ enable_experimental_alter_column_type_general         NULL    NULL     NULL     
 enable_experimental_stream_replication                NULL    NULL     NULL     NULL        NULL
 enable_implicit_select_for_update                     NULL    NULL     NULL     NULL        NULL
 enable_insert_fast_path                               NULL    NULL     NULL     NULL        NULL
+enable_rehome_on_update                               NULL    NULL     NULL     NULL        NULL
 enable_seqscan                                        NULL    NULL     NULL     NULL        NULL
 enable_zigzag_join                                    NULL    NULL     NULL     NULL        NULL
 escape_string_warning                                 NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -47,6 +47,7 @@ enable_experimental_alter_column_type_general         off
 enable_experimental_stream_replication                off
 enable_implicit_select_for_update                     on
 enable_insert_fast_path                               on
+enable_rehome_on_update                               off
 enable_seqscan                                        on
 enable_zigzag_join                                    on
 escape_string_warning                                 on

--- a/pkg/sql/opt/cat/table.go
+++ b/pkg/sql/opt/cat/table.go
@@ -133,6 +133,9 @@ type Table interface {
 	// Unique returns the ith unique constraint defined on this table, where
 	// i < UniqueCount.
 	Unique(i UniqueOrdinal) UniqueConstraint
+
+	// GetRegionalByRowTableRegionColumnName returns the RBR column name if one exists and returns an error otherwise.
+	GetRegionalByRowTableRegionColumnName() (tree.Name, error)
 }
 
 // CheckConstraint contains the SQL text and the validity status for a check

--- a/pkg/sql/opt/optbuilder/update.go
+++ b/pkg/sql/opt/optbuilder/update.go
@@ -96,6 +96,11 @@ func (b *Builder) buildUpdate(upd *tree.Update, inScope *scope) (outScope *scope
 	// All columns from the update table will be projected.
 	mb.buildInputForUpdate(inScope, upd.Table, upd.From, upd.Where, upd.Limit, upd.OrderBy)
 
+	// add computed column for crdb_region if it is not in the UPDATE
+	if b.evalCtx.SessionData.RehomeOnUpdate {
+		addRegionalByRowUpdate(tab, upd)
+	}
+
 	// Derive the columns that will be updated from the SET expressions.
 	mb.addTargetColsForUpdate(upd.Exprs)
 

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -653,6 +653,11 @@ func (tt *Table) IsVirtualTable() bool {
 	return tt.IsVirtual
 }
 
+// GetRegionalByRowTableRegionColumnName is part of the cat.Table interface.
+func (tt *Table) GetRegionalByRowTableRegionColumnName() (tree.Name, error) {
+	return "", errors.New("testing table cannot be regional by row")
+}
+
 // IsMaterializedView is part of the cat.Table interface.
 func (tt *Table) IsMaterializedView() bool {
 	return false

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -1010,6 +1010,11 @@ func (ot *optTable) IsVirtualTable() bool {
 	return false
 }
 
+// GetRegionalByRowTableRegionColumnName is part of the cat.Table interface.
+func (ot *optTable) GetRegionalByRowTableRegionColumnName() (tree.Name, error) {
+	return ot.desc.GetRegionalByRowTableRegionColumnName()
+}
+
 // IsMaterializedView implements the cat.Table interface.
 func (ot *optTable) IsMaterializedView() bool {
 	return ot.desc.MaterializedView()
@@ -1890,6 +1895,11 @@ func (ot *optVirtualTable) Equals(other cat.Object) bool {
 // Name is part of the cat.Table interface.
 func (ot *optVirtualTable) Name() tree.Name {
 	return ot.name.ObjectName
+}
+
+// GetRegionalByRowTableRegionColumnName is part of the cat.Table interface.
+func (tt *optVirtualTable) GetRegionalByRowTableRegionColumnName() (tree.Name, error) {
+	return "", errors.New("virtual table cannot be regional by row")
 }
 
 // IsVirtualTable is part of the cat.Table interface.

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -208,6 +208,8 @@ type LocalOnlySessionData struct {
 	ImplicitColumnPartitioningEnabled bool
 	// DropEnumValueEnabled indicates whether enum values can be dropped.
 	DropEnumValueEnabled bool
+	// RehomeOnUpdate indicates whether rows in regional by row tables should be rehomed on update.
+	RehomeOnUpdate bool
 	// OverrideMultiRegionZoneConfigEnabled indicates whether zone configurations can be
 	// modified for multi-region databases and tables/indexes/partitions.
 	OverrideMultiRegionZoneConfigEnabled bool

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -1184,6 +1184,25 @@ var varGen = map[string]sessionVar{
 	},
 
 	// CockroachDB extension.
+	`enable_rehome_on_update`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`enable_rehome_on_update`),
+		Set: func(_ context.Context, m *sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("enable_rehome_on_update", s)
+			if err != nil {
+				return err
+			}
+			m.SetRehomeOnUpdateEnabled(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext) string {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData.RehomeOnUpdate)
+		},
+		GlobalDefault: func(sv *settings.Values) string {
+			return formatBoolAsPostgresSetting(rehomeOnUpdateClusterMode.Get(sv))
+		},
+	},
+
+	// CockroachDB extension.
 	`override_multi_region_zone_config`: {
 		GetStringVal: makePostgresBoolGetStringValFn(`override_multi_region_zone_config`),
 		Set: func(_ context.Context, m *sessionDataMutator, s string) error {


### PR DESCRIPTION
Previously, rows in REGIONAL BY ROW tables would never relocate unless
manually moved.
This patch adds a cluster setting,
`sql.defaults.rehome_on_update.enabled` which, when enabled,
automatically moves rows on UPDATE to the gateway region for the UPDATE.

Release note (sql change): The cluster setting
`sql.defaults.rehome_on_update.enabled` was added. When enabled, this
setting will rehome rows in REGIONAL BY ROW tables to the gateway region
for any UPDATEs.