### PR TITLE
Reduce node shutdown time by only calling time.Sleep once

### DIFF
--- a/pkg/server/testing_knobs.go
+++ b/pkg/server/testing_knobs.go
@@ -12,6 +12,7 @@ package server
 
 import (
 	"net"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
@@ -91,6 +92,9 @@ type TestingKnobs struct {
 	// ImportTimeseriesFile, if set, is a file created via `DumpRaw` that written
 	// back to the KV layer upon server start.
 	ImportTimeseriesFile string
+	// DrainSleepFn used in testing to override the usual sleep function with
+	// a custom function that counts the number of times the sleep function is called.
+	DrainSleepFn func(time.Duration)
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.


### PR DESCRIPTION
See #65842 for more context, but TL;DR - graceful drain incorrectly called sleep multiple times, which cut into time needed for range lease transfers.