### PR TITLE
kvclient: add a comment to DistSender sub-batch iteration

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -1220,6 +1220,21 @@ func (ds *DistSender) divideAndSendBatchToRanges(
 		canParallelize = canParallelize && !isExpensive
 	}
 
+	// Iterate over the ranges that the batch touches. The iteration is done in
+	// key order - the order of requests in the batch is not relevant for the
+	// iteration. Each iteration sends for evaluation one sub-batch to one range.
+	// The sub-batch is the union of requests in the batch overlapping the
+	// current range. The order of requests in a sub-batch is the same as the
+	// relative order of requests in the complete batch. On the server-side,
+	// requests in a sub-batch are executed in order. Depending on whether the
+	// sub-batches can be executed in parallel or not, each iteration either waits
+	// for the sub-batch results (in the no-parallelism case) or defers the
+	// results to a channel that will be processed in the defer above.
+	//
+	// After each sub-batch is executed, if ba has key or memory limits (which
+	// imply no parallelism), ba.MaxSpanRequestKeys and ba.TargetBytes are
+	// adjusted with the responses for the sub-batch. If a limit is exhausted, the
+	// loop breaks.
 	for ; ri.Valid(); ri.Seek(ctx, seekKey, scanDir) {
 		responseCh := make(chan response, 1)
 		responseChs = append(responseChs, responseCh)


### PR DESCRIPTION
... cause the code in this load-bearing loop is not the easiest to
follow.

Release note: None