### PR TITLE
release-21.1: backupccl: run all post-deserialization upgrades on restored descriptors

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -806,11 +806,7 @@ func loadBackupSQLDescs(
 		}
 	}
 
-	// Upgrade the table descriptors to use the new FK representation.
-	// TODO(lucy, jordan): This should become unnecessary in 20.1 when we stop
-	// writing old-style descs in RestoreDetails (unless a job persists across
-	// an upgrade?).
-	if err := maybeUpgradeTableDescsInSlice(ctx, sqlDescs, true /* skipFKsWithNoMatchingTable */); err != nil {
+	if err := maybeUpgradeDescriptors(ctx, sqlDescs, true /* skipFKsWithNoMatchingTable */); err != nil {
 		return nil, BackupManifest{}, nil, err
 	}
 	return backupManifests, latestBackupManifest, sqlDescs, nil

--- a/pkg/ccl/backupccl/restore_old_versions_test.go
+++ b/pkg/ccl/backupccl/restore_old_versions_test.go
@@ -191,6 +191,10 @@ func restoreOldVersionTest(exportDir string) func(t *testing.T) {
 		sqlDB.CheckQueryResults(t, `SELECT * FROM test.t1 ORDER BY k`, results)
 		sqlDB.CheckQueryResults(t, `SELECT * FROM test.t2 ORDER BY k`, results)
 		sqlDB.CheckQueryResults(t, `SELECT * FROM test.t4 ORDER BY k`, results)
+
+		results = append(results, []string{"4", "5", "6"})
+		sqlDB.Exec(t, `INSERT INTO test.t1 VALUES (4, 5 ,6)`)
+		sqlDB.CheckQueryResults(t, `SELECT * FROM test.t1 ORDER BY k`, results)
 	}
 }
 

--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -200,11 +200,16 @@ func showBackupPlanHook(
 			manifests[i+1] = m
 		}
 
+		// Ensure that the descriptors in the backup manifests are up to date.
+		//
+		// This is necessary in particular for upgrading descriptors with old-style
+		// foreign keys which are no longer supported.
 		// If we are restoring a backup with old-style foreign keys, skip over the
 		// FKs for which we can't resolve the cross-table references. We can't
 		// display them anyway, because we don't have the referenced table names,
 		// etc.
-		if err := maybeUpgradeTableDescsInBackupManifests(ctx, manifests, true); err != nil {
+		err = maybeUpgradeDescriptorsInBackupManifests(ctx, manifests, true /* skipFKsWithNoMatchingTable */)
+		if err != nil {
 			return err
 		}
 

--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -327,28 +327,6 @@ func generatedFamilyName(familyID descpb.FamilyID, columnNames []string) string 
 	return buf.String()
 }
 
-func indexHasDeprecatedForeignKeyRepresentation(idx *descpb.IndexDescriptor) bool {
-	return idx.ForeignKey.IsSet() || len(idx.ReferencedBy) > 0
-}
-
-// TableHasDeprecatedForeignKeyRepresentation returns true if the table is not
-// dropped and any of the indexes on the table have deprecated foreign key
-// representations.
-func TableHasDeprecatedForeignKeyRepresentation(desc *descpb.TableDescriptor) bool {
-	if desc.Dropped() {
-		return false
-	}
-	if indexHasDeprecatedForeignKeyRepresentation(&desc.PrimaryIndex) {
-		return true
-	}
-	for i := range desc.Indexes {
-		if indexHasDeprecatedForeignKeyRepresentation(&desc.Indexes[i]) {
-			return true
-		}
-	}
-	return false
-}
-
 // ForEachExprStringInTableDesc runs a closure for each expression string
 // within a TableDescriptor. The closure takes in a string pointer so that
 // it can mutate the TableDescriptor if desired.


### PR DESCRIPTION
Backport 1/1 commits from #66598.

/cc @cockroachdb/release

---

Previously, we ran these upgrades only on table descriptors which
contained deprecated foreign key references. In reality, all
post-serialization upgrades should be run on all restored descriptors,
otherwise we run the risk of restoring a descriptor which is not
compatible with the current cluster version. Concretely, this would
manifest itself as a descriptor validation failure at transaction commit
time.

This hasn't manifested itself so far probably because descriptors have
remained forward-compatible. This is not a safe assumption to make.
Descriptors can and do get corrupted by bugs, which subsequently get
fixed by migrations and post-deserialization upgrades, yet backups
can be made in the meantime.

Release note (bug fix): Fixed a bug which could have prevented
backups from being successfully restored.
