### PR TITLE
ui: backport 20.2 custom chart changes

### DIFF
--- a/pkg/ui/src/views/cluster/components/linegraph/index.tsx
+++ b/pkg/ui/src/views/cluster/components/linegraph/index.tsx
@@ -380,6 +380,9 @@ export class LineGraph extends React.Component<LineGraphProps, {}> {
   // TODO(davidh): figure out why the timescale doesn't get more granular
   // automatically when a narrower time frame is selected.
   setNewTimeRange(startMillis: number, endMillis: number) {
+    if (startMillis === endMillis) {
+      return;
+    }
     const start = MilliToSeconds(startMillis);
     const end = MilliToSeconds(endMillis);
     this.props.setTimeRange({

--- a/pkg/ui/src/views/cluster/components/visualization/visualizations.styl
+++ b/pkg/ui/src/views/cluster/components/visualization/visualizations.styl
@@ -77,13 +77,6 @@ $viz-sides = 62px
   .icon-warning
     color $warning-color
 
-// TODO(davidh): Remove this rule once the legend display
-// is redesign for uPlot. Currently it takes up a lot of
-// space below the graph so the last graph needs to make
-// extra room for it.
-.visualization:last-child
-  margin-bottom: 600px
-
 .linegraph
   height 100%
 

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/index.tsx
@@ -52,7 +52,6 @@ import {
   TimeWindow,
   TimeScale,
 } from "src/redux/timewindow";
-
 interface GraphDashboard {
   label: string;
   component: (props: GraphDashboardProps) => React.ReactElement<any>[];
@@ -217,8 +216,17 @@ export class NodeGraphs extends React.Component<NodeGraphsProps, {}> {
       );
     });
 
+    // add padding to have last chart tooltip visible
+    // tooltip layout with header and paddings take up
+    // somewhere around 50px, after it have more than
+    // 9 nodes it switch to multi-column layout that take
+    // somewhere around 90px height + 10px for per node
+    // as we have 3 columns, we divide node amount on 3
+    const paddingBottom =
+      nodeIDs.length > 8 ? 90 + Math.ceil(nodeIDs.length / 3) * 10 : 50;
+
     return (
-      <div>
+      <div style={{ paddingBottom }}>
         <Helmet title={title} />
         <section className="section"><h1 className="base-heading">{ title }</h1></section>
         <PageConfig>

--- a/pkg/ui/src/views/reports/containers/customChart/index.tsx
+++ b/pkg/ui/src/views/reports/containers/customChart/index.tsx
@@ -30,6 +30,13 @@ import { INodeStatus } from "src/util/proto";
 import { CustomChartState, CustomChartTable } from "./customMetric";
 import "./customChart.styl";
 import { queryByName } from "src/util/query";
+import { PayloadAction } from "src/interfaces/action";
+import {
+  TimeWindow,
+  TimeScale,
+  setTimeRange,
+  setTimeScale,
+} from "src/redux/timewindow";
 
 export interface CustomChartProps {
   refreshNodes: typeof refreshNodes;
@@ -37,6 +44,8 @@ export interface CustomChartProps {
   nodesSummary: NodesSummary;
   refreshMetricMetadata: typeof refreshMetricMetadata;
   metricsMetadata: MetricsMetadata;
+  setTimeRange: (tw: TimeWindow) => PayloadAction<TimeWindow>;
+  setTimeScale: (ts: TimeScale) => PayloadAction<TimeScale>;
 }
 
 interface UrlState {
@@ -176,7 +185,12 @@ export class CustomChart extends React.Component<CustomChartProps & RouteCompone
     const { nodesSummary } = this.props;
 
     return (
-      <MetricsDataProvider id={`debug-custom-chart.${index}`} key={ index }>
+      <MetricsDataProvider
+        id={`debug-custom-chart.${index}`}
+        key={index}
+        setTimeRange={this.props.setTimeRange}
+        setTimeScale={this.props.setTimeScale}
+      >
         <LineGraph>
           <Axis units={units}>
             {
@@ -295,6 +309,8 @@ const mapStateToProps = (state: AdminUIState) => ({
 const mapDispatchToProps = {
   refreshNodes,
   refreshMetricMetadata,
+  setTimeRange,
+  setTimeScale,
 };
 
 export default withRouter(connect(mapStateToProps, mapDispatchToProps)(CustomChart));


### PR DESCRIPTION
backport:
 - fix for extra space on custom charts page
 - add drag-to-select time range feature on custom charts page