### PR TITLE
sql: add metric for SQL connection latency

### DIFF
--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1985,6 +1985,13 @@ var charts = []sectionDescription{
 				},
 			},
 			{
+				Title: "Connection Latency",
+				Metrics: []string{
+					"sql.conn.latency",
+				},
+				AxisLabel: "Latency",
+			},
+			{
 				Title: "Open Transactions",
 				Metrics: []string{
 					"sql.txns.open",

--- a/pkg/ui/cluster-ui/src/store/nodes/nodes.fixtures.ts
+++ b/pkg/ui/cluster-ui/src/store/nodes/nodes.fixtures.ts
@@ -462,6 +462,7 @@ export const getNodeStatus = () => {
       "sql.misc.started.count": 0,
       "sql.misc.started.count.internal": 2,
       "sql.new_conns": 0,
+      "sql.conn.latency": 0,
       "sql.optimizer.fallback.count": 0,
       "sql.optimizer.fallback.count.internal": 0,
       "sql.optimizer.plan_cache.hits": 0,

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
@@ -154,6 +154,40 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
+      title="Connection Latency: 99th percentile"
+      tooltip={`Over the last minute, this node established and authenticated 99% of connections within this time.`}
+    >
+      <Axis units={AxisUnits.Duration} label="latency">
+        {_.map(nodeIDs, (node) => (
+          <Metric
+            key={node}
+            name="cr.node.sql.conn.latency-p99"
+            title={nodeDisplayName(nodesSummary, node)}
+            sources={[node]}
+            downsampleMax
+          />
+        ))}
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
+      title="Connection Latency: 90th percentile"
+      tooltip={`Over the last minute, this node established and authenticated 90% of connections within this time.`}
+    >
+      <Axis units={AxisUnits.Duration} label="latency">
+        {_.map(nodeIDs, (node) => (
+          <Metric
+            key={node}
+            name="cr.node.sql.conn.latency-p90"
+            title={nodeDisplayName(nodesSummary, node)}
+            sources={[node]}
+            downsampleMax
+          />
+        ))}
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
       title="Service Latency: SQL Statements, 99th percentile"
       tooltip={
         <div>


### PR DESCRIPTION
This adds a new metric "sql.conn.latency" to know the latency of
creating new SQL connections(#66014). It's useful for debugging sessions.

The metric specifies the duration between the time a new connection
is received and the time the connection is ready to serve a SQL query.
It also includes authentication time.

fixes #66014

Release note (ops change): Add a new metric to know the latency of
creating new SQL connection including authentication time.

Release note (ui change): Added a new chart showing the latency of
establishing a new SQL connection, including the time spent on
authentication.