### PR TITLE
ui: exclude antd global styles from `cluster-ui` [backport 20.2]

### DIFF
--- a/pkg/ui/cluster-ui/babel.config.js
+++ b/pkg/ui/cluster-ui/babel.config.js
@@ -28,7 +28,7 @@ const plugins = [
   "@babel/proposal-class-properties",
   "@babel/proposal-object-rest-spread",
   "@babel/plugin-transform-runtime",
-  ["import", { "libraryName": "antd", "style": "css" }],
+  ["import", { "libraryName": "antd", "style": true }],
 ];
 
 const env = {

--- a/pkg/ui/cluster-ui/src/core/antd-patch.less
+++ b/pkg/ui/cluster-ui/src/core/antd-patch.less
@@ -1,0 +1,18 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// this file is replaced with `pkg/ui/cluster-ui/node_modules/antd/lib/style/index.less` file
+// during build time (see webpack.config.js > webpack.NormalModuleReplacementPlugin usage).
+// It allows to avoid importing of `~antd/lib/style/core/base.less` file which includes lots
+// of global styles that can affect components outside of `cluster-ui`.
+@import '~antd/lib/style/themes/index';
+@import '~antd/lib/style/mixins/index';
+@import '~antd/lib/style/core/iconfont';
+@import '~antd/lib/style/core/motion';

--- a/pkg/ui/cluster-ui/webpack.config.js
+++ b/pkg/ui/cluster-ui/webpack.config.js
@@ -9,6 +9,7 @@
 // licenses/APL.txt.
 
 const path = require("path");
+const webpack = require("webpack");
 const WebpackBar = require("webpackbar");
 const MomentLocalesPlugin = require("moment-locales-webpack-plugin");
 
@@ -118,6 +119,10 @@ module.exports = {
       profile: true,
     }),
     new MomentLocalesPlugin(),
+    new webpack.NormalModuleReplacementPlugin(
+      /node_modules\/antd\/lib\/style\/index\.less/,
+      path.resolve(__dirname, "src/core/antd-patch.less"),
+    ),
   ],
 
   // When importing a module whose path matches one of the following, just


### PR DESCRIPTION
This change alters the compilation of styles for `antd` library.
By default, `antd` styles include global styles and it affects
components inside of `cluster-ui` package and outer components.

Current change excludes these global styles from bundled styles.

Release note: None