### PR TITLE
cli: render debug merge-logs output in color

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -664,8 +664,8 @@ def go_deps():
         name = "com_github_cockroachdb_ttycolor",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/cockroachdb/ttycolor",
-        sum = "h1:TNsiMS1Ij2aleP/05UNSPzsOu9eJm9mfUGLm7Ylt7Dg=",
-        version = "v0.0.0-20180709150743-a1d5aaeb377d",
+        sum = "h1:S2vg+TZySZ0jBGFPM2kmcYr0OwIPRoMX8/AMTajFmzE=",
+        version = "v0.0.0-20210717002733-a2a538deeb8c",
     )
     go_repository(
         name = "com_github_codahale_hdrhistogram",

--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2
 	github.com/cockroachdb/stress v0.0.0-20170808184505-29b5d31b4c3a
-	github.com/cockroachdb/ttycolor v0.0.0-20180709150743-a1d5aaeb377d
+	github.com/cockroachdb/ttycolor v0.0.0-20210717002733-a2a538deeb8c
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd
 	github.com/containerd/containerd v1.4.6
 	github.com/coreos/go-oidc v2.2.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -280,8 +280,9 @@ github.com/cockroachdb/tablewriter v0.0.5-0.20200105123400-bd15540e8847 h1:c7yLg
 github.com/cockroachdb/tablewriter v0.0.5-0.20200105123400-bd15540e8847/go.mod h1:zq6QwlOf5SlnkVbMSr5EoBv3636FWnp+qbPhuoO21uA=
 github.com/cockroachdb/teamcity v0.0.0-20180905144921-8ca25c33eb11 h1:UAqRo5xPCyTtZznAJ9iPVpDUFxGI0a6QWtQ8E+zwJRg=
 github.com/cockroachdb/teamcity v0.0.0-20180905144921-8ca25c33eb11/go.mod h1:3299Mt0Q7PkqGqbsxhvbrTpMqRyIcZ6OMw4IEmiO09g=
-github.com/cockroachdb/ttycolor v0.0.0-20180709150743-a1d5aaeb377d h1:TNsiMS1Ij2aleP/05UNSPzsOu9eJm9mfUGLm7Ylt7Dg=
 github.com/cockroachdb/ttycolor v0.0.0-20180709150743-a1d5aaeb377d/go.mod h1:NltwFG0VBANi1jHKpn5KL9AbsHTE+8fPaAHT0TzL20k=
+github.com/cockroachdb/ttycolor v0.0.0-20210717002733-a2a538deeb8c h1:S2vg+TZySZ0jBGFPM2kmcYr0OwIPRoMX8/AMTajFmzE=
+github.com/cockroachdb/ttycolor v0.0.0-20210717002733-a2a538deeb8c/go.mod h1:NltwFG0VBANi1jHKpn5KL9AbsHTE+8fPaAHT0TzL20k=
 github.com/cockroachdb/vitess v0.0.0-20210218160543-54524729cc82 h1:8htEd1lLILqfjKardWfKKGgXVCs0WmcgEj9cXnmcuos=
 github.com/cockroachdb/vitess v0.0.0-20210218160543-54524729cc82/go.mod h1:+bhevpN4bd6bstiRREkJDaMWZR3lTe5ypydTtXgf7GU=
 github.com/cockroachdb/yaml v0.0.0-20180705215940-0e2822948641 h1:EqoCicA1pbWWDGniFxhTElh2hvui7E7tEvuBNJSDn3A=

--- a/pkg/cli/debug_merge_logs.go
+++ b/pkg/cli/debug_merge_logs.go
@@ -57,14 +57,19 @@ func writeLogStream(
 		*fileInfo
 	}
 	render := func(ei entryInfo, w io.Writer) (err error) {
+		// TODO(postamar): add support for other output formats
+		// Currently, `render` applies the `crdb-v1-tty` format regardless of the
+		// output logging format defined for the stderr sink. It should instead
+		// apply the selected output format.
 		var prefixBytes []byte
 		if prefixBytes, err = getPrefix(ei.fileInfo); err != nil {
 			return err
 		}
-		if _, err = w.Write(prefixBytes); err != nil {
+		err = log.FormatLegacyEntryPrefixTTY(prefixBytes, w)
+		if err != nil {
 			return err
 		}
-		return log.FormatLegacyEntry(ei.Entry, w)
+		return log.FormatLegacyEntryTTY(ei.Entry, w)
 	}
 
 	g, ctx := errgroup.WithContext(context.Background())

--- a/pkg/util/log/format_crdb.go
+++ b/pkg/util/log/format_crdb.go
@@ -11,9 +11,12 @@
 package log
 
 import (
+	"hash/adler32"
 	"io"
 
 	"github.com/cockroachdb/cockroach/pkg/util/log/logpb"
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/ttycolor"
 )
 
 const severityChar = "IWEF"
@@ -24,8 +27,50 @@ const MessageTimeFormat = "060102 15:04:05.999999"
 
 // FormatLegacyEntry writes the contents of the legacy log entry struct to the specified writer.
 func FormatLegacyEntry(e logpb.Entry, w io.Writer) error {
-	buf := formatLogEntryInternalV1(e, false /* isHeader */, true /* showCounter */, nil)
+	return formatLegacyEntry(e, w, nil /* cp */)
+}
+
+// FormatLegacyEntryTTY writes the legacy log entry to the specified writer,
+// using colors if possible.
+func FormatLegacyEntryTTY(e logpb.Entry, w io.Writer) error {
+	cp := ttycolor.StderrProfile
+	if logging.stderrSink.noColor.Get() {
+		cp = nil
+	}
+	return formatLegacyEntry(e, w, cp)
+}
+
+func formatLegacyEntry(e logpb.Entry, w io.Writer, cp ttycolor.Profile) error {
+	buf := formatLogEntryInternalV1(e, false /* isHeader */, true /* showCounter */, cp)
 	defer putBuffer(buf)
 	_, err := w.Write(buf.Bytes())
+	return err
+}
+
+// FormatLegacyEntryPrefixTTY writes a color-decorated prefix to the specified
+// writer. The color is rendered in the background of the prefix and is chosen
+// from an arbitrary but deterministic mapping from the prefix bytes to the
+// color profile entries.
+func FormatLegacyEntryPrefixTTY(prefix []byte, w io.Writer) (err error) {
+	if prefix == nil {
+		return nil
+	}
+	cp := ttycolor.StderrProfile
+	if logging.stderrSink.noColor.Get() {
+		cp = nil
+	}
+
+	if cp != nil {
+		code := ttycolor.PickArbitraryColor(adler32.Checksum(prefix))
+		if _, err = w.Write(cp.BackgroundColorSequence(code)); err != nil {
+			return err
+		}
+		defer func() {
+			_, errReset := w.Write(cp[ttycolor.Reset])
+			err = errors.CombineErrors(err, errReset)
+		}()
+	}
+
+	_, err = w.Write(prefix)
 	return err
 }


### PR DESCRIPTION
Previously, the log entries printed by the 'cockroach debug merge-logs'
command were not rendered in color. This command takes log files,
typically from a debug.zip, and merges them in a single stream. In so
doing, it prefixes each entry with a string identifying its pre-merged
origin on-disk. Typically, this is a node number.

This commit renders the merged log entries in color using the existing
legacy (v1) color scheme. Furthermore, the prefix backgrounds are also
colored in a deterministic pseudorandom fashion to help identify the
origin of each log entry.

Release note (cli change): The 'cockroach debug merge-logs' command now
renders in color by default.