### PR TITLE
schemachange: fix alterTableLocality op, avoid "REGIONAL BY ROWAS"

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -479,7 +479,7 @@ func (og *operationGenerator) alterTableLocality(tx *pgx.Tx) (string, error) {
 			ret := "REGIONAL BY ROW"
 			if columnForAs.typ.TypeMeta.Name != nil {
 				if columnForAs.typ.TypeMeta.Name.Basename() == tree.RegionEnum {
-					ret += "AS " + columnForAs.name
+					ret += " AS " + columnForAs.name
 				}
 			}
 			return ret, nil


### PR DESCRIPTION
Related to recent failures in #56081.
Related to recent failures in #56230.

The `REGIONAL BY ROW AS crdb_region` syntax was being incorrectly
printed as `REGIONAL BY ROWAS crdb_region`, which was tripping up
the workload.`