### PR TITLE
opt: push limits into the right side of a semi join

### DIFF
--- a/pkg/sql/opt/memo/multiplicity_builder.go
+++ b/pkg/sql/opt/memo/multiplicity_builder.go
@@ -42,7 +42,7 @@ func initJoinMultiplicity(in RelExpr) {
 // join operator will affect the rows of its left and right inputs (e.g.
 // duplicated and/or filtered). Panics if the method is called on an operator
 // that does not support JoinMultiplicity (any operator other than an InnerJoin,
-// LeftJoin, or FullJoin).
+// LeftJoin, FullJoin, or SemiJoin).
 func GetJoinMultiplicity(in RelExpr) props.JoinMultiplicity {
 	if join, ok := in.(joinWithMultiplicity); ok {
 		// JoinMultiplicity has already been initialized during construction of the

--- a/pkg/sql/opt/norm/general_funcs.go
+++ b/pkg/sql/opt/norm/general_funcs.go
@@ -927,35 +927,44 @@ func (c *CustomFuncs) MakeAggCols(aggOp opt.Operator, cols opt.ColSet) memo.Aggr
 //
 // ----------------------------------------------------------------------
 
-// JoinDoesNotDuplicateLeftRows returns true if the given InnerJoin, LeftJoin or
-// FullJoin is guaranteed not to output any given row from its left input more
-// than once.
+// JoinDoesNotDuplicateLeftRows returns true if the given InnerJoin, LeftJoin,
+// FullJoin, or SemiJoin is guaranteed not to output any given row from its
+// left input more than once.
 func (c *CustomFuncs) JoinDoesNotDuplicateLeftRows(join memo.RelExpr) bool {
 	mult := memo.GetJoinMultiplicity(join)
 	return mult.JoinDoesNotDuplicateLeftRows(join.Op())
 }
 
-// JoinDoesNotDuplicateRightRows returns true if the given InnerJoin, LeftJoin
-// or FullJoin is guaranteed not to output any given row from its right input
-// more than once.
+// JoinDoesNotDuplicateRightRows returns true if the given InnerJoin, LeftJoin,
+// FullJoin, or SemiJoin is guaranteed not to output any given row from its
+// right input more than once.
 func (c *CustomFuncs) JoinDoesNotDuplicateRightRows(join memo.RelExpr) bool {
 	mult := memo.GetJoinMultiplicity(join)
 	return mult.JoinDoesNotDuplicateRightRows(join.Op())
 }
 
-// JoinPreservesLeftRows returns true if the given InnerJoin, LeftJoin or
-// FullJoin is guaranteed to output every row from its left input at least once.
+// JoinPreservesLeftRows returns true if the given InnerJoin, LeftJoin,
+// FullJoin, or SemiJoin is guaranteed to output every row from its left input
+// at least once.
 func (c *CustomFuncs) JoinPreservesLeftRows(join memo.RelExpr) bool {
 	mult := memo.GetJoinMultiplicity(join)
 	return mult.JoinPreservesLeftRows(join.Op())
 }
 
-// JoinPreservesRightRows returns true if the given InnerJoin, LeftJoin or
-// FullJoin is guaranteed to output every row from its right input at least
-// once.
+// JoinPreservesRightRows returns true if the given InnerJoin, LeftJoin,
+// FullJoin, or SemiJoin is guaranteed to output every row from its right input
+// at least once.
 func (c *CustomFuncs) JoinPreservesRightRows(join memo.RelExpr) bool {
 	mult := memo.GetJoinMultiplicity(join)
 	return mult.JoinPreservesRightRows(join.Op())
+}
+
+// JoinFiltersMatchAllRightRows returns true if the filters of the given
+// InnerJoin, LeftJoin, FullJoin, or SemiJoin are guaranteed to return true at
+// least once for every row from the right input.
+func (c *CustomFuncs) JoinFiltersMatchAllRightRows(join memo.RelExpr) bool {
+	multiplicity := memo.GetJoinMultiplicity(join)
+	return multiplicity.JoinFiltersMatchAllRightRows()
 }
 
 // NoJoinHints returns true if no hints were specified for this join.

--- a/pkg/sql/opt/norm/rules/limit.opt
+++ b/pkg/sql/opt/norm/rules/limit.opt
@@ -147,7 +147,9 @@ $input
 # have matches, and would be outputted by the FullJoin with the left side
 # (t_r columns) null-extended. Therefore, pushing the limit into a join input
 # that may be null-extended (either input of a FullJoin) can lead to output rows
-# being replaced with null values.
+# being replaced with null values. This rule does not match a SemiJoin because
+# in any case where it is valid to push a limit into the left side of a
+# SemiJoin, the SemiJoin can just be eliminated.
 [PushLimitIntoJoinLeft, Normalize]
 (Limit
     $input:(InnerJoin | LeftJoin
@@ -178,16 +180,24 @@ $input
     $ordering
 )
 
-# PushLimitIntoJoinRight mirrors PushLimitIntoJoinLeft.
+# PushLimitIntoJoinRight mirrors PushLimitIntoJoinLeft. We use
+# JoinFiltersMatchAllRightRows instead of JoinPreservesRightRows because
+# SemiJoins do not project right rows. This does not change the behavior for
+# InnerJoins, since they do have any additional effect beyond their filters.
+#
+# TODO(drewk): for the SemiJoin case, consider attempting to remap the limit
+# ordering into right input columns using the join filters. As-is, the limit
+# ordering must be empty in the SemiJoin case since it cannot refer to right
+# input columns.
 [PushLimitIntoJoinRight, Normalize]
 (Limit
-    $input:(InnerJoin
+    $input:(InnerJoin | SemiJoin
             $left:*
             $right:* & ^(HasOuterCols $right)
             $on:*
             $private:*
         ) &
-        (JoinPreservesRightRows $input)
+        (JoinFiltersMatchAllRightRows $input)
     $limitExpr:(Const $limit:*) &
         (IsPositiveInt $limit) &
         ^(LimitGeMaxRows $limit $right)

--- a/pkg/sql/opt/norm/testdata/rules/limit
+++ b/pkg/sql/opt/norm/testdata/rules/limit
@@ -824,6 +824,46 @@ inner-join (hash)
  └── filters
       └── u:1 = r:7 [outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
 
+# SemiJoin case for PushLimitIntoJoinRight
+norm expect=PushLimitIntoJoinRight
+SELECT * FROM ab WHERE a IN (SELECT a FROM ab WHERE b > 4) LIMIT 10
+----
+limit
+ ├── columns: a:1!null b:2
+ ├── cardinality: [0 - 10]
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── semi-join (hash)
+ │    ├── columns: a:1!null b:2
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2)
+ │    ├── limit hint: 10.00
+ │    ├── scan ab
+ │    │    ├── columns: a:1!null b:2
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2)
+ │    ├── limit
+ │    │    ├── columns: a:5!null b:6!null
+ │    │    ├── cardinality: [0 - 10]
+ │    │    ├── key: (5)
+ │    │    ├── fd: (5)-->(6)
+ │    │    ├── select
+ │    │    │    ├── columns: a:5!null b:6!null
+ │    │    │    ├── key: (5)
+ │    │    │    ├── fd: (5)-->(6)
+ │    │    │    ├── limit hint: 10.00
+ │    │    │    ├── scan ab
+ │    │    │    │    ├── columns: a:5!null b:6
+ │    │    │    │    ├── key: (5)
+ │    │    │    │    ├── fd: (5)-->(6)
+ │    │    │    │    └── limit hint: 30.00
+ │    │    │    └── filters
+ │    │    │         └── b:6 > 4 [outer=(6), constraints=(/6: [/5 - ]; tight)]
+ │    │    └── 10
+ │    └── filters
+ │         └── a:1 = a:5 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+ └── 10
+
 # Ordering can be pushed down.
 norm expect=PushLimitIntoJoinLeft
 SELECT * FROM ab LEFT JOIN uv ON a = u ORDER BY a LIMIT 10
@@ -1204,6 +1244,62 @@ limit
  │    │    └── fd: (5)-->(6)
  │    └── filters
  │         └── a:1 = u:5 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+ └── 10
+
+# The SemiJoin can be eliminated, so don't push the limit into its left side.
+norm expect-not=(PushLimitIntoJoinLeft, PushLimitIntoJoinRight)
+SELECT * FROM kvr_fk WHERE EXISTS (SELECT * FROM uv WHERE u = r) LIMIT 10
+----
+limit
+ ├── columns: k:1!null v:2 r:3!null
+ ├── cardinality: [0 - 10]
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── scan kvr_fk
+ │    ├── columns: k:1!null kvr_fk.v:2 r:3!null
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    └── limit hint: 10.00
+ └── 10
+
+# The limit ordering does not (cannot) reference right input columns, so don't
+# push the limit into the right side of the join.
+norm expect-not=(PushLimitIntoJoinLeft, PushLimitIntoJoinRight)
+SELECT * FROM ab WHERE a IN (SELECT a FROM ab WHERE b > 4) ORDER BY b DESC LIMIT 10
+----
+limit
+ ├── columns: a:1!null b:2
+ ├── internal-ordering: -2
+ ├── cardinality: [0 - 10]
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── ordering: -2
+ ├── sort
+ │    ├── columns: a:1!null b:2
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2)
+ │    ├── ordering: -2
+ │    ├── limit hint: 10.00
+ │    └── semi-join (hash)
+ │         ├── columns: a:1!null b:2
+ │         ├── key: (1)
+ │         ├── fd: (1)-->(2)
+ │         ├── scan ab
+ │         │    ├── columns: a:1!null b:2
+ │         │    ├── key: (1)
+ │         │    └── fd: (1)-->(2)
+ │         ├── select
+ │         │    ├── columns: a:5!null b:6!null
+ │         │    ├── key: (5)
+ │         │    ├── fd: (5)-->(6)
+ │         │    ├── scan ab
+ │         │    │    ├── columns: a:5!null b:6
+ │         │    │    ├── key: (5)
+ │         │    │    └── fd: (5)-->(6)
+ │         │    └── filters
+ │         │         └── b:6 > 4 [outer=(6), constraints=(/6: [/5 - ]; tight)]
+ │         └── filters
+ │              └── a:1 = a:5 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
  └── 10
 
 # ----------

--- a/pkg/sql/opt/xform/testdata/external/tpce
+++ b/pkg/sql/opt/xform/testdata/external/tpce
@@ -1228,10 +1228,8 @@ project
 # Q10
 #
 # TODO:
-#   1. Allow limit push-down for semi-joins. Or normalize semi-joins to
-#      inner-joins.
-#   2. Adding explorer support for norm rules would allow the projects to be
-#      merged and the limit to be pushed down.
+#   1. Adding explorer support for norm rules would allow the projects to be
+#      merged.
 #
 opt
 SELECT hh_h_t_id, hh_t_id, hh_before_qty, hh_after_qty
@@ -1260,15 +1258,22 @@ limit
  │              ├── key: (2,7)
  │              ├── fd: ()-->(8), (1,2)-->(3,4), (1)==(7), (7)==(1)
  │              ├── limit hint: 20.00
- │              ├── select
+ │              ├── limit
  │              │    ├── columns: hh_h_t_id:7!null hh_t_id:8!null
+ │              │    ├── cardinality: [0 - 20]
  │              │    ├── key: (7)
  │              │    ├── fd: ()-->(8)
- │              │    ├── scan holding_history
+ │              │    ├── select
  │              │    │    ├── columns: hh_h_t_id:7!null hh_t_id:8!null
- │              │    │    └── key: (7,8)
- │              │    └── filters
- │              │         └── hh_t_id:8 = 0 [outer=(8), constraints=(/8: [/0 - /0]; tight), fd=()-->(8)]
+ │              │    │    ├── key: (7)
+ │              │    │    ├── fd: ()-->(8)
+ │              │    │    ├── limit hint: 20.00
+ │              │    │    ├── scan holding_history
+ │              │    │    │    ├── columns: hh_h_t_id:7!null hh_t_id:8!null
+ │              │    │    │    └── key: (7,8)
+ │              │    │    └── filters
+ │              │    │         └── hh_t_id:8 = 0 [outer=(8), constraints=(/8: [/0 - /0]; tight), fd=()-->(8)]
+ │              │    └── 20
  │              └── filters (true)
  └── 20
 

--- a/pkg/sql/opt/xform/testdata/external/tpce-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpce-no-stats
@@ -1235,10 +1235,8 @@ project
 # Q10
 #
 # TODO:
-#   1. Allow limit push-down for semi-joins. Or normalize semi-joins to
-#      inner-joins.
-#   2. Adding explorer support for norm rules would allow the projects to be
-#      merged and the limit to be pushed down.
+#   1. Adding explorer support for norm rules would allow the projects to be
+#      merged.
 #
 opt
 SELECT hh_h_t_id, hh_t_id, hh_before_qty, hh_after_qty
@@ -1263,23 +1261,27 @@ limit
  │         ├── limit hint: 20.00
  │         └── inner-join (lookup holding_history)
  │              ├── columns: hh_h_t_id:1!null hh_t_id:2!null hh_before_qty:3!null hh_after_qty:4!null hh_h_t_id:7!null hh_t_id:8!null
- │              ├── key columns: [1 14] = [7 8]
- │              ├── lookup columns are key
+ │              ├── key columns: [7] = [1]
  │              ├── key: (2,7)
  │              ├── fd: ()-->(8), (1,2)-->(3,4), (1)==(7), (7)==(1)
  │              ├── limit hint: 20.00
- │              ├── project
- │              │    ├── columns: "lookup_join_const_col_@8":14!null hh_h_t_id:1!null hh_t_id:2!null hh_before_qty:3!null hh_after_qty:4!null
- │              │    ├── key: (1,2)
- │              │    ├── fd: ()-->(14), (1,2)-->(3,4)
- │              │    ├── limit hint: 200.00
- │              │    ├── scan holding_history
- │              │    │    ├── columns: hh_h_t_id:1!null hh_t_id:2!null hh_before_qty:3!null hh_after_qty:4!null
- │              │    │    ├── key: (1,2)
- │              │    │    ├── fd: (1,2)-->(3,4)
- │              │    │    └── limit hint: 200.00
- │              │    └── projections
- │              │         └── 0 [as="lookup_join_const_col_@8":14]
+ │              ├── limit
+ │              │    ├── columns: hh_h_t_id:7!null hh_t_id:8!null
+ │              │    ├── cardinality: [0 - 20]
+ │              │    ├── key: (7)
+ │              │    ├── fd: ()-->(8)
+ │              │    ├── limit hint: 10.00
+ │              │    ├── select
+ │              │    │    ├── columns: hh_h_t_id:7!null hh_t_id:8!null
+ │              │    │    ├── key: (7)
+ │              │    │    ├── fd: ()-->(8)
+ │              │    │    ├── limit hint: 20.00
+ │              │    │    ├── scan holding_history
+ │              │    │    │    ├── columns: hh_h_t_id:7!null hh_t_id:8!null
+ │              │    │    │    └── key: (7,8)
+ │              │    │    └── filters
+ │              │    │         └── hh_t_id:8 = 0 [outer=(8), constraints=(/8: [/0 - /0]; tight), fd=()-->(8)]
+ │              │    └── 20
  │              └── filters (true)
  └── 20
 


### PR DESCRIPTION
This patch modifies the rule `PushLimitIntoJoinRight` to match
`SemiJoin`s in addition to `InnerJoin`s. This allows for a limit to
be pushed into the right input of a `SemiJoin`. Example:
```
SELECT * FROM ab
WHERE a IN (SELECT a FROM ab WHERE b > 4)
LIMIT 10
=>
SELECT * FROM ab
WHERE a IN (SELECT a FROM ab WHERE b > 4 LIMIT 10)
LIMIT 10
```
This transformation is valid whenever each row in the right input is
guaranteed to match at least one left row over the join filters.
In this example, the `SemiJoin` filter ends up being `a = a`, with
the right side of the `SemiJoin` always finding a match with at least
one left row because the columns initially have the same values, and
the left column is unfiltered.

Release note: None