### PR TITLE
opt: use join multiplicity in calculating semi join cardinality

### DIFF
--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -2341,16 +2341,31 @@ func (h *joinPropsHelper) setFuncDeps(rel *props.Relational) {
 
 func (h *joinPropsHelper) cardinality() props.Cardinality {
 	left := h.leftProps.Cardinality
+	right := h.rightProps.Cardinality
+	joinWithMult, isJoinWithMult := h.join.(joinWithMultiplicity)
 
 	switch h.joinType {
-	case opt.SemiJoinOp, opt.SemiJoinApplyOp, opt.AntiJoinOp, opt.AntiJoinApplyOp:
-		// Semi/Anti join cardinality never exceeds left input cardinality, and
+	case opt.AntiJoinOp, opt.AntiJoinApplyOp:
+		// Anti join cardinality never exceeds left input cardinality, and
 		// allows zero rows.
 		return left.AsLowAs(0)
+	case opt.SemiJoinOp, opt.SemiJoinApplyOp:
+		// Semi join cardinality never exceeds left input cardinality, and
+		// allows zero rows.
+		semiJoinCard := left.AsLowAs(0)
+		if isJoinWithMult {
+			multiplicity := joinWithMult.getMultiplicity()
+			if multiplicity.JoinFiltersDoNotDuplicateRightRows() {
+				// Each right row matches at most one left row on the join filters, so
+				// the Semi join output cardinality is at most the cardinality of the
+				// right input.
+				semiJoinCard = semiJoinCard.Limit(right.Max)
+			}
+		}
+		return semiJoinCard
 	}
 
 	// Other join types can return up to cross product of rows.
-	right := h.rightProps.Cardinality
 	innerJoinCard := left.Product(right)
 
 	// Apply filter to cardinality.
@@ -2363,7 +2378,6 @@ func (h *joinPropsHelper) cardinality() props.Cardinality {
 	}
 
 	// Adjust cardinality to account for outer joins as well as join multiplicity.
-	joinWithMult, isJoinWithMult := h.join.(joinWithMultiplicity)
 	switch h.joinType {
 	case opt.InnerJoinOp, opt.InnerJoinApplyOp:
 		if isJoinWithMult {

--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -742,6 +742,47 @@ project
       │    └── key: ()
       └── filters (true)
 
+# Maximum cardinality of the right input is propagated to the SemiJoin when
+# right rows are guaranteed at most one match each over the join filters.
+norm
+SELECT * FROM mn WHERE m IN (SELECT u FROM uv WHERE v > 20 LIMIT 10)
+----
+semi-join (hash)
+ ├── columns: m:1(int!null) n:2(int)
+ ├── cardinality: [0 - 10]
+ ├── key: (1)
+ ├── fd: (1)-->(2), (2)~~>(1)
+ ├── prune: (2)
+ ├── interesting orderings: (+1) (+2,+1)
+ ├── scan mn
+ │    ├── columns: m:1(int!null) n:2(int)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2), (2)~~>(1)
+ │    ├── prune: (1,2)
+ │    ├── interesting orderings: (+1) (+2,+1)
+ │    └── unfiltered-cols: (1-4)
+ ├── limit
+ │    ├── columns: u:5(int) v:6(int!null)
+ │    ├── cardinality: [0 - 10]
+ │    ├── prune: (5)
+ │    ├── select
+ │    │    ├── columns: u:5(int) v:6(int!null)
+ │    │    ├── limit hint: 10.00
+ │    │    ├── prune: (5)
+ │    │    ├── scan uv
+ │    │    │    ├── columns: u:5(int) v:6(int!null)
+ │    │    │    ├── limit hint: 30.00
+ │    │    │    └── prune: (5,6)
+ │    │    └── filters
+ │    │         └── gt [type=bool, outer=(6), constraints=(/6: [/21 - ]; tight)]
+ │    │              ├── variable: v:6 [type=int]
+ │    │              └── const: 20 [type=int]
+ │    └── const: 10 [type=int]
+ └── filters
+      └── eq [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+           ├── variable: m:1 [type=int]
+           └── variable: u:5 [type=int]
+
 # Calculate semi-join-apply cardinality.
 expr
 (SemiJoinApply

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -1377,9 +1377,11 @@ SELECT k FROM a WHERE (k, i) IN (SELECT b, a FROM (VALUES (1, 1), (2, 2), (3, 3)
 ----
 project
  ├── columns: k:1!null
+ ├── cardinality: [0 - 3]
  ├── key: (1)
  └── semi-join (hash)
       ├── columns: k:1!null i:2
+      ├── cardinality: [0 - 3]
       ├── key: (1)
       ├── fd: (1)-->(2)
       ├── scan a

--- a/pkg/sql/opt/xform/testdata/external/hibernate
+++ b/pkg/sql/opt/xform/testdata/external/hibernate
@@ -980,6 +980,7 @@ where
 ----
 project
  ├── columns: id1_2_:1!null address2_2_:2 createdo3_2_:3 name4_2_:4 nickname5_2_:5 version6_2_:6!null
+ ├── cardinality: [0 - 1]
  ├── has-placeholder
  ├── key: (1)
  ├── fd: (1)-->(2-6)
@@ -1033,6 +1034,7 @@ where
 ----
 project
  ├── columns: id1_2_:1!null address2_2_:2 createdo3_2_:3 name4_2_:4 nickname5_2_:5 version6_2_:6!null
+ ├── cardinality: [0 - 1]
  ├── has-placeholder
  ├── key: (1)
  ├── fd: (1)-->(2-6)


### PR DESCRIPTION
This patch updates the logic that calculates `SemiJoin` cardinality
to use the information provided by `JoinMultiplicity`. Specifically,
when each row in the right input is guaranteed to match at most once
over the join filters, the maximum `SemiJoin` cardinality will be at
most the maximum cardinality of the right side.

Release note: None