### PR TITLE
ts: fix a bug of chart catalog admin API

### DIFF
--- a/pkg/ccl/changefeedccl/metrics.go
+++ b/pkg/ccl/changefeedccl/metrics.go
@@ -126,7 +126,7 @@ var (
 	metaChangefeedFailures = metric.Metadata{
 		Name:        "changefeed.failures",
 		Help:        "Total number of changefeed jobs which have failed",
-		Measurement: "Changefeed Jobs",
+		Measurement: "Errors",
 		Unit:        metric.Unit_COUNT,
 	}
 

--- a/pkg/ccl/serverccl/admin_test.go
+++ b/pkg/ccl/serverccl/admin_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
 )
 
 var adminPrefix = "/_admin/v1/"
@@ -74,4 +75,18 @@ func TestAdminAPIDataDistributionPartitioning(t *testing.T) {
 	if !reflect.DeepEqual(actualZoneConfigNames, expectedZoneConfigNames) {
 		t.Fatalf("expected zone config names %v; got %v", expectedZoneConfigNames, actualZoneConfigNames)
 	}
+}
+
+// TestAdminAPIChartCatalog verifies that an error doesn't happen.
+func TestAdminAPIChartCatalog(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testCluster := serverutils.StartNewTestCluster(t, 3, base.TestClusterArgs{})
+	defer testCluster.Stopper().Stop(context.Background())
+
+	firstServer := testCluster.Server(0)
+
+	var resp serverpb.ChartCatalogResponse
+	err := serverutils.GetJSONProto(firstServer, adminPrefix+"chartcatalog", &resp)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
When to access the chart catalog admin API (/_admin/v1/chartcatalog),
the following error happened.

```
{
    "error": "Chart Errors has metrics with different axis labels
    (Changefeed Jobs vs Errors); \n\t\t\t\tneed to specify an AxisLabel
    in its chartDescription: title:\"\" longTitle:\"\"
    collectionTitle:\"\" units:UNSET_UNITS axisLabel:\"\"
    percentiles:false metrics:\u003cname:\"changefeed.error_retries\"
    help:\"Total retryable errors encountered by all changefeeds\"
    axisLabel:\"Errors\" preferredUnits:COUNT metricType:COUNTERCOUNTER
    \u003e metrics:\u003cname:\"changefeed.failures\" help:\"Total
    number of changefeed jobs which have failed\" axisLabel:\"Changefeed
    Jobs\" preferredUnits:COUNT metricType:COUNTERCOUNTER \u003e",
      "code": 2,
        "message": "Chart Errors has metrics with different axis labels
        (Changefeed Jobs vs Errors); \n\t\t\t\tneed to specify an
        AxisLabel in its chartDescription: title:\"\" longTitle:\"\"
        collectionTitle:\"\" units:UNSET_UNITS axisLabel:\"\"
        percentiles:false
        metrics:\u003cname:\"changefeed.error_retries\" help:\"Total
        retryable errors encountered by all changefeeds\"
        axisLabel:\"Errors\" preferredUnits:COUNT
        metricType:COUNTERCOUNTER \u003e
        metrics:\u003cname:\"changefeed.failures\" help:\"Total number
        of changefeed jobs which have failed\" axisLabel:\"Changefeed
        Jobs\" preferredUnits:COUNT metricType:COUNTERCOUNTER \u003e",
          "details": [
            ]
}
```

The cause is that two metrics (changefeed.error_retries, changefeed.failures)
with different units were managed as one chunk. This patch separates the
metrics into another chunks.

Release note (bug fix): Fixed a bug of chart catalog admin API.