### PR TITLE
roachtest: fix another accidental uppercasing

### DIFF
--- a/pkg/cmd/roachtest/spec/cluster_spec.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec.go
@@ -153,7 +153,7 @@ func (s *ClusterSpec) Args(extra ...string) ([]string, error) {
 	if localSSD && s.SSDs != 0 {
 		switch s.Cloud {
 		case GCE:
-			args = append(args, fmt.Sprintf("--gce-local-SSD-count=%d", s.SSDs))
+			args = append(args, fmt.Sprintf("--gce-local-ssd-count=%d", s.SSDs))
 		default:
 			return nil, errors.Errorf("specifying SSD count is not yet supported on %s", s.Cloud)
 		}

--- a/pkg/cmd/roachtest/spec/testdata/collected_specs.txt
+++ b/pkg/cmd/roachtest/spec/testdata/collected_specs.txt
@@ -49,13 +49,13 @@ print-args-for-all
 24: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:9, CPUs:1, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-1 --lifetime=12h0m0s
 25: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:6, CPUs:32, SSDs:2, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}}
-  --clouds=gce --local-ssd=true --gce-machine-type=n1-highcpu-32 --gce-local-SSD-count=2 --lifetime=12h0m0s
+  --clouds=gce --local-ssd=true --gce-machine-type=n1-highcpu-32 --gce-local-ssd-count=2 --lifetime=12h0m0s
 26: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:10, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-highcpu-16 --lifetime=12h0m0s
 27: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:4, CPUs:96, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-highcpu-96 --lifetime=12h0m0s
 28: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:4, CPUs:4, SSDs:1, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}}
-  --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-4 --gce-local-SSD-count=1 --lifetime=12h0m0s
+  --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-4 --gce-local-ssd-count=1 --lifetime=12h0m0s
 29: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:2, CPUs:8, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-8 --lifetime=12h0m0s
 30: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:8, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}}


### PR DESCRIPTION
This caused nightly roachtest failures in tests that hit that option,
leading to the entire suite getting torn down :sadface:

I accidentally introduced this during the refactoring bonanza in #66430.
My lesson here is to by default exclude all changes in "comments and
other strings" that Golang offers during its rename operations.

Release note: None
