### PR TITLE
sql: First round of cleanup of schemachange/random-load

### DIFF
--- a/pkg/cmd/roachtest/schemachange_random_load.go
+++ b/pkg/cmd/roachtest/schemachange_random_load.go
@@ -181,6 +181,7 @@ func runSchemaChangeRandomLoad(ctx context.Context, t *test, c Cluster, maxOps, 
 // saveArtifacts saves important test artifacts in the artifacts directory.
 func saveArtifacts(ctx context.Context, t *test, c Cluster, storeDirectory string) {
 	db := c.Conn(ctx, 1)
+	defer db.Close()
 
 	// Save a backup file called schemachange to the store directory.
 	_, err := db.Exec("BACKUP DATABASE schemachange to 'nodelocal://1/schemachange'")

--- a/pkg/kv/kvclient/kvcoord/testdata/savepoints
+++ b/pkg/kv/kvclient/kvcoord/testdata/savepoints
@@ -385,7 +385,7 @@ injected error
 
 rollback x
 ----
-(*telemetrykeys.withTelemetry) unimplemented: cannot rollback to savepoint after error
+(*pgerror.withCandidateCode) unimplemented: cannot rollback to savepoint after error
 
 subtest end
 

--- a/pkg/sql/catalog/tabledesc/validate.go
+++ b/pkg/sql/catalog/tabledesc/validate.go
@@ -598,13 +598,13 @@ func (desc *wrapper) ValidateSelf(vea catalog.ValidationErrorAccumulator) {
 			if alterPKMutation == m.MutationID {
 				vea.Report(unimplemented.NewWithIssue(
 					45615,
-					"cannot perform other schema changes in the same transaction as a primary key change",
-				))
+					"cannot perform other schema changes in the same transaction as a primary key change"),
+				)
 			} else {
 				vea.Report(unimplemented.NewWithIssue(
 					45615,
-					"cannot perform a schema change operation while a primary key change is in progress",
-				))
+					"cannot perform a schema change operation while a primary key change is in progress"),
+				)
 			}
 			return
 		}
@@ -969,7 +969,7 @@ func (desc *wrapper) validateTableIndexes(columnNames map[string]descpb.ColumnID
 					idx.GetName(), name, colID, idx.IndexDesc().KeyColumnIDs[i])
 			}
 			if validateIndexDup.Contains(colID) {
-				return fmt.Errorf("index %q contains duplicate column %q", idx.GetName(), name)
+				return pgerror.Newf(pgcode.FeatureNotSupported, "index %q contains duplicate column %q", idx.GetName(), name)
 			}
 			validateIndexDup.Add(colID)
 		}

--- a/pkg/util/errorutil/unimplemented/BUILD.bazel
+++ b/pkg/util/errorutil/unimplemented/BUILD.bazel
@@ -7,6 +7,8 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/build",
+        "//pkg/sql/pgwire/pgcode",
+        "//pkg/sql/pgwire/pgerror",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/util/errorutil/unimplemented/unimplemented.go
+++ b/pkg/util/errorutil/unimplemented/unimplemented.go
@@ -14,6 +14,8 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/build"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/errors"
 )
 
@@ -96,5 +98,8 @@ func unimplementedInternal(
 		// perform telemetry.
 		err = errors.WithTelemetry(err, detail)
 	}
+
+	// Wrap with the corresponding PG error for unimplemented.
+	err = pgerror.WithCandidateCode(err, pgcode.FeatureNotSupported)
 	return err
 }


### PR DESCRIPTION
This issue addresses several issues uncovered in running the randomized
schema changer. Specifically:

- Makes several errors pgcodes, so that they can be properly added to
  the expected errors list in the randomized schema changer.
- Detects cases where the region column (crdb_region) is used multiple
  times in an index definition.
- Allows for column type changes, which must have the experimental flag
  enable_experimental_alter_column_type_general flag set.

It also disables the testing of setColumnType (tracked with #66662) as
well as making a column nullable/non-nullable due to a timing hole
(tracked with #66663).

Release note: None.