### PR TITLE
WIP

### DIFF
--- a/pkg/jobs/registry_external_test.go
+++ b/pkg/jobs/registry_external_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -276,7 +277,7 @@ func TestRegistrySettingUpdate(t *testing.T) {
 			// trim leading and trailing spaces.
 			matchStmt := strings.TrimSpace(regexp.MustCompile(`(\s+|;+)`).ReplaceAllString(test.matchStmt, " "))
 			var seen = int32(0)
-			stmtFilter := func(ctxt context.Context, stmt string, err error) {
+			stmtFilter := func(ctxt context.Context, _ *sessiondata.SessionData, stmt string, err error) {
 				if err != nil {
 					return
 				}
@@ -345,7 +346,7 @@ func TestGCDurationControl(t *testing.T) {
 	// trim leading and trailing spaces.
 	gcStmt := strings.TrimSpace(regexp.MustCompile(`(\s+|;+)`).ReplaceAllString(jobs.GcQuery, " "))
 	var seen = int32(0)
-	stmtFilter := func(ctxt context.Context, stmt string, err error) {
+	stmtFilter := func(ctxt context.Context, _ *sessiondata.SessionData, stmt string, err error) {
 		if err != nil {
 			return
 		}

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -480,7 +480,7 @@ func (ex *connExecutor) execStmtInOpenState(
 			if perr, ok := retPayload.(payloadWithError); ok {
 				execErr = perr.errorCause()
 			}
-			filter(ctx, ast.String(), execErr)
+			filter(ctx, ex.sessionData, ast.String(), execErr)
 		}
 
 		// Do the auto-commit, if necessary.

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -949,7 +949,7 @@ func (*ExecutorTestingKnobs) ModuleTestingKnobs() {}
 
 // StatementFilter is the type of callback that
 // ExecutorTestingKnobs.StatementFilter takes.
-type StatementFilter func(context.Context, string, error)
+type StatementFilter func(context.Context, *sessiondata.SessionData, string, error)
 
 // ExecutorTestingKnobs is part of the context used to control parts of the
 // system during testing.

--- a/pkg/sql/show_test.go
+++ b/pkg/sql/show_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -519,7 +520,7 @@ func TestShowQueries(t *testing.T) {
 	found := false
 	var failure error
 
-	execKnobs.StatementFilter = func(ctx context.Context, stmt string, err error) {
+	execKnobs.StatementFilter = func(ctx context.Context, _ *sessiondata.SessionData, stmt string, err error) {
 		if stmt == selectStmt {
 			found = true
 			const showQuery = "SELECT node_id, (now() - start)::FLOAT8, query FROM [SHOW CLUSTER QUERIES]"

--- a/pkg/sql/txn_restart_test.go
+++ b/pkg/sql/txn_restart_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -339,7 +340,9 @@ func (ta *TxnAborter) GetExecCount(stmt string) (int, bool) {
 	return 0, false
 }
 
-func (ta *TxnAborter) statementFilter(ctx context.Context, stmt string, err error) {
+func (ta *TxnAborter) statementFilter(
+	ctx context.Context, _ *sessiondata.SessionData, stmt string, err error,
+) {
 	ta.mu.Lock()
 	log.Infof(ctx, "statement filter running on: %s, with err=%v", stmt, err)
 	ri, ok := ta.mu.stmtsToAbort[stmt]


### PR DESCRIPTION
Given this test script, running against a `cockroach demo` cluster:

```ruby
require "pg"

c = PG::Connection.new(host: "localhost", port: 26257, user: "root")
c.prepare("test", "SELECT pg_sleep(20), upper($1)")
c.exec_prepared("test", ["hello"])
c.close
```

Here's what we would see before this change, in particular the $1 as the
argument to `upper()`:

```sql
> select query from [show queries] where application_name like '%run%';
              query
----------------------------------
  SELECT pg_sleep(20), upper($1)
(1 row)
```

And here's what we now see, the string 'hello' filled in:

```sql
> select query from [show queries] where application_name like '%run%';
                 query
---------------------------------------
  SELECT pg_sleep(20), upper('hello')
(1 row)
```

Release note (sql change): The SHOW QUERIES command was extended for prepared statements to show the actual values in use at query time, rather than the previous $1, $2, etc., placeholders.

We expect showing these values will greatly improve the experience of debugging slow queries.