### PR TITLE
jobs: Fix job-intervals in TestLoseLeaseDuringExecution

### DIFF
--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -2718,7 +2718,7 @@ func TestLoseLeaseDuringExecution(t *testing.T) {
 	defer jobs.ResetConstructors()()
 
 	// Disable the loops from messing with the job execution.
-	knobs := base.TestingKnobs{JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals()}
+	knobs := base.TestingKnobs{JobsTestingKnobs: jobs.NewTestingKnobsWithIntervals(time.Hour, time.Hour)}
 
 	ctx := context.Background()
 


### PR DESCRIPTION
Job-intervals in TestLoseLeaseDuringExecution were inadequately
set while updating the code to use testing knobs, which were
added in #66392. As a result, the test started to fail. This
commit fixes the intervals.

Release note: None

Fixes: #66635 