### PR TITLE
distsql: Avoid decomissioned nodes.

### DIFF
--- a/pkg/kv/kvserver/liveness/liveness.go
+++ b/pkg/kv/kvserver/liveness/liveness.go
@@ -639,7 +639,7 @@ func (nl *NodeLiveness) IsLive(nodeID roachpb.NodeID) (bool, error) {
 	}
 	// NB: We use clock.Now().GoTime() instead of clock.PhysicalTime() in order to
 	// consider clock signals from other nodes.
-	return liveness.IsLive(nl.clock.Now().GoTime()), nil
+	return liveness.IsLive(nl.clock.Now().GoTime()) && liveness.Membership.Active(), nil
 }
 
 // NodeLivenessStartOptions are the arguments to `NodeLiveness.Start`.


### PR DESCRIPTION
Avoid non-active nodes (i.e. those that are decomissioning or
decomissioned) when planning distributed sql flows.

Informs #66586
Informs #66636

Release Notes: None