### PR TITLE
sql: order descriptors in drop DB/schema for new schema changer

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/new_schema_changer
+++ b/pkg/sql/logictest/testdata/logic_test/new_schema_changer
@@ -641,3 +641,8 @@ DROP DATABASE db1
 
 statement ok
 DROP DATABASE db1 CASCADE
+
+# Works around view back references to tables not being cleaned up.
+# see issue #66677
+statement ok
+SET experimental_use_new_schema_changer = 'off'

--- a/pkg/sql/schemachanger/scbuild/schema.go
+++ b/pkg/sql/schemachanger/scbuild/schema.go
@@ -12,6 +12,7 @@ package scbuild
 
 import (
 	"context"
+	"sort"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/dbdesc"
@@ -51,6 +52,11 @@ func (b *buildContext) dropSchemaDesc(
 		panic(pgerror.Newf(pgcode.DependentObjectsStillExist,
 			"schema %q is not empty and CASCADE was not specified", sc.GetName()))
 	}
+	// Sort the dropped IDs to ensure a consistent order of
+	// operations.
+	sort.SliceStable(dropIDs, func(i, j int) bool {
+		return dropIDs[i] < dropIDs[j]
+	})
 	schemaNode := scpb.Schema{
 		SchemaID:         sc.GetID(),
 		DependentObjects: dropIDs,

--- a/pkg/sql/schemachanger/scbuild/testdata/drop_database
+++ b/pkg/sql/schemachanger/scbuild/testdata/drop_database
@@ -107,14 +107,14 @@ DROP DATABASE db1 CASCADE
   state: PUBLIC
   details:
     dependentObjects:
-    - 63
     - 55
     - 56
-    - 62
     - 58
     - 59
     - 60
     - 61
+    - 62
+    - 63
     - 64
     schemaId: 53
 - DROP Sequence:{DescID: 54}

--- a/pkg/sql/schemachanger/scbuild/testdata/drop_schema
+++ b/pkg/sql/schemachanger/scbuild/testdata/drop_schema
@@ -71,14 +71,14 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   state: PUBLIC
   details:
     dependentObjects:
-    - 61
     - 54
     - 55
-    - 60
     - 56
     - 57
     - 58
     - 59
+    - 60
+    - 61
     - 62
     schemaId: 52
 - DROP Sequence:{DescID: 54}

--- a/pkg/sql/schemachanger/scplan/rules.go
+++ b/pkg/sql/schemachanger/scplan/rules.go
@@ -266,9 +266,6 @@ var rules = map[scpb.Element]targetRules{
 					nextState: scpb.State_ABSENT,
 					op: func(this *scpb.Database) []scop.Op {
 						ops := []scop.Op{
-							&scop.CreateGcJobForDescriptor{
-								DescID: this.DatabaseID,
-							},
 							&scop.DrainDescriptorName{TableID: this.DatabaseID},
 						}
 						return ops
@@ -334,9 +331,6 @@ var rules = map[scpb.Element]targetRules{
 					nextState: scpb.State_ABSENT,
 					op: func(this *scpb.Schema) []scop.Op {
 						ops := []scop.Op{
-							&scop.CreateGcJobForDescriptor{
-								DescID: this.SchemaID,
-							},
 							&scop.DrainDescriptorName{TableID: this.SchemaID},
 						}
 						return ops
@@ -511,9 +505,6 @@ var rules = map[scpb.Element]targetRules{
 					nextState: scpb.State_ABSENT,
 					op: func(this *scpb.Type) []scop.Op {
 						ops := []scop.Op{
-							&scop.CreateGcJobForDescriptor{
-								DescID: this.TypeID,
-							},
 							&scop.DrainDescriptorName{TableID: this.TypeID},
 						}
 						return ops

--- a/pkg/sql/schemachanger/scplan/testdata/drop_database
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_database
@@ -134,10 +134,6 @@ Stage 1
     DescID: 64
   *scop.CreateGcJobForDescriptor
     DescID: 56
-  *scop.CreateGcJobForDescriptor
-    DescID: 62
-  *scop.CreateGcJobForDescriptor
-    DescID: 63
   *scop.DrainDescriptorName
     TableID: 54
   *scop.DrainDescriptorName
@@ -165,10 +161,6 @@ Stage 1
   *scop.MarkDescriptorAsDropped
     TableID: 52
 Stage 2
-  *scop.CreateGcJobForDescriptor
-    DescID: 53
-  *scop.CreateGcJobForDescriptor
-    DescID: 52
   *scop.DrainDescriptorName
     TableID: 53
   *scop.DrainDescriptorName

--- a/pkg/sql/schemachanger/scplan/testdata/drop_schema
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_schema
@@ -147,10 +147,6 @@ Stage 1
     DescID: 61
   *scop.CreateGcJobForDescriptor
     DescID: 54
-  *scop.CreateGcJobForDescriptor
-    DescID: 59
-  *scop.CreateGcJobForDescriptor
-    DescID: 60
   *scop.DrainDescriptorName
     TableID: 53
   *scop.DrainDescriptorName
@@ -172,7 +168,5 @@ Stage 1
   *scop.MarkDescriptorAsDropped
     TableID: 52
 Stage 2
-  *scop.CreateGcJobForDescriptor
-    DescID: 52
   *scop.DrainDescriptorName
     TableID: 52

--- a/pkg/sql/schemachanger/scplan/testdata/drop_type
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_type
@@ -11,10 +11,6 @@ Stage 0
   *scop.MarkDescriptorAsDropped
     TableID: 53
 Stage 1
-  *scop.CreateGcJobForDescriptor
-    DescID: 52
-  *scop.CreateGcJobForDescriptor
-    DescID: 53
   *scop.DrainDescriptorName
     TableID: 52
   *scop.DrainDescriptorName


### PR DESCRIPTION
Fixes: #66649

Previously, the when drop DB/schema was added into the new
schema changer, the ordering of descriptor ID's are not fixed.
This was inadequate because, plan testing could have operator
ordering shift intermittently leading to intermittent test
failures. To address this, this patch orders dependent descriptor
ID's for drop DB/ schema.

Release note: None