### PR TITLE
workflow: change github stale issues bot timing

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,7 +2,7 @@ name: Mark stale issues and pull requests
 
 on:
   schedule:
-  - cron: "30 1 * * *"
+  - cron: "0 11 * * 1-4"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Changhe the github stale issue bot timing to be more
user friendly. The bot will now run at 6AM EST on
Mondays and Thursdays, to match up with our prevalent
working schedule.

Release note: None