### PR TITLE
server: pod-to-pod fanout for statements api on tenant 

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -2799,7 +2799,12 @@ Support status: [reserved](#support-status)
 
 
 
-
+StatementsRequest is used by both tenant and node-level
+implementations to serve fan-out requests across multiple nodes or
+instances. When implemented on a node, the `node_id` field refers to
+the cluster nodes by their nodeID. When implemented on a tenant, the
+`node_id` field refers to the instanceIDs that identify individual
+tenant pods.
 
 
 | Field | Type | Label | Description | Support status |

--- a/pkg/ccl/serverccl/BUILD.bazel
+++ b/pkg/ccl/serverccl/BUILD.bazel
@@ -15,6 +15,7 @@ go_test(
         "main_test.go",
         "role_authentication_test.go",
         "server_sql_test.go",
+        "tenant_grpc_test.go",
         "tenant_status_test.go",
     ],
     embed = [":serverccl"],
@@ -24,6 +25,7 @@ go_test(
         "//pkg/ccl/kvccl",
         "//pkg/ccl/utilccl",
         "//pkg/roachpb:with-mocks",
+        "//pkg/rpc",
         "//pkg/security",
         "//pkg/security/securitytest",
         "//pkg/server",
@@ -43,6 +45,7 @@ go_test(
         "//pkg/util/timeutil",
         "@com_github_lib_pq//:pq",
         "@com_github_stretchr_testify//require",
+        "@org_golang_google_grpc//:go_default_library",
         "@org_golang_x_crypto//bcrypt",
     ],
 )

--- a/pkg/ccl/serverccl/tenant_grpc_test.go
+++ b/pkg/ccl/serverccl/tenant_grpc_test.go
@@ -1,0 +1,152 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package serverccl
+
+import (
+	"context"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
+	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/httputil"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+// TestTenantGRPCServices tests that the gRPC servers that are externally
+// facing have been started up on the tenant server. This includes gRPC that is
+// used for pod-to-pod communication as well as the HTTP services powered by
+// gRPC Gateway that are used to serve endpoints to power observability UIs.
+func TestTenantGRPCServices(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	testCluster := serverutils.StartNewTestCluster(t, 3, base.TestClusterArgs{})
+	defer testCluster.Stopper().Stop(ctx)
+
+	server := testCluster.Server(0)
+
+	tenantID := serverutils.TestTenantID()
+	tenant, connTenant := serverutils.StartTenant(t, server, base.TestTenantArgs{
+		TenantID: tenantID,
+	})
+	defer connTenant.Close()
+
+	t.Run("gRPC is running", func(t *testing.T) {
+		grpcAddr := tenant.SQLAddr()
+		rpcCtx := tenant.RPCContext()
+
+		nodeID := roachpb.NodeID(tenant.SQLInstanceID())
+		conn, err := rpcCtx.GRPCDialNode(grpcAddr, nodeID, rpc.DefaultClass).Connect(ctx)
+		require.NoError(t, err)
+		defer func(conn *grpc.ClientConn) {
+			_ = conn.Close()
+		}(conn)
+
+		client := serverpb.NewStatusClient(conn)
+
+		resp, err := client.Statements(ctx, &serverpb.StatementsRequest{NodeID: "local"})
+		require.NoError(t, err)
+		require.NotEmpty(t, resp.Statements)
+	})
+
+	t.Run("gRPC Gateway is running", func(t *testing.T) {
+		resp, err := httputil.Get(ctx, "http://"+tenant.HTTPAddr()+"/_status/statements")
+		defer http.DefaultClient.CloseIdleConnections()
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		body, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Contains(t, string(body), "transactions")
+	})
+
+	sqlRunner := sqlutils.MakeSQLRunner(connTenant)
+	sqlRunner.Exec(t, "CREATE TABLE test (id int)")
+	sqlRunner.Exec(t, "INSERT INTO test VALUES (1)")
+
+	log.TestingClearServerIdentifiers()
+	tenant2, connTenant2 := serverutils.StartTenant(t, server, base.TestTenantArgs{
+		TenantID: tenantID,
+		Existing: true,
+	})
+	defer connTenant2.Close()
+
+	t.Run("statements endpoint fans out request to multiple pods", func(t *testing.T) {
+		resp, err := httputil.Get(ctx, "http://"+tenant2.HTTPAddr()+"/_status/statements")
+		defer http.DefaultClient.CloseIdleConnections()
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		body, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Contains(t, string(body), "CREATE TABLE test")
+		require.Contains(t, string(body), "INSERT INTO test VALUES")
+	})
+
+	log.TestingClearServerIdentifiers()
+	tenant3, connTenant3 := serverutils.StartTenant(t, server, base.TestTenantArgs{
+		TenantID: roachpb.MakeTenantID(11),
+	})
+	defer connTenant3.Close()
+
+	t.Run("fanout of statements endpoint is segregated by tenant", func(t *testing.T) {
+		resp, err := httputil.Get(ctx, "http://"+tenant3.HTTPAddr()+"/_status/statements")
+		defer http.DefaultClient.CloseIdleConnections()
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		body, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.NotContains(t, string(body), "CREATE TABLE test")
+		require.NotContains(t, string(body), "INSERT INTO test VALUES")
+	})
+
+	t.Run("fanout of statements endpoint between tenants", func(t *testing.T) {
+		grpcAddr := tenant.SQLAddr()
+		rpcCtx := tenant2.RPCContext()
+
+		nodeID := roachpb.NodeID(tenant.SQLInstanceID())
+		conn, err := rpcCtx.GRPCDialNode(grpcAddr, nodeID, rpc.DefaultClass).Connect(ctx)
+		require.NoError(t, err)
+		defer func(conn *grpc.ClientConn) {
+			_ = conn.Close()
+		}(conn)
+
+		client := serverpb.NewStatusClient(conn)
+
+		resp, err := client.Statements(ctx, &serverpb.StatementsRequest{NodeID: "local"})
+		require.NoError(t, err)
+		require.NotEmpty(t, resp.Statements)
+	})
+
+	t.Run("tenant request to KV Node Statements fails", func(t *testing.T) {
+		grpcAddr := server.RPCAddr()
+		rpcCtx := tenant.RPCContext()
+
+		conn, err := rpcCtx.GRPCDialNode(grpcAddr, server.NodeID(), rpc.DefaultClass).Connect(ctx)
+		require.NoError(t, err)
+		defer func(conn *grpc.ClientConn) {
+			_ = conn.Close()
+		}(conn)
+
+		client := serverpb.NewStatusClient(conn)
+
+		_, err = client.Statements(ctx, &serverpb.StatementsRequest{NodeID: "local"})
+		require.Errorf(t, err, "statements endpoint should not be accessed on KV node by tenant")
+	})
+
+}

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -157,7 +157,11 @@ func NewServer(ctx *Context, opts ...ServerOption) *grpc.Server {
 	var streamInterceptor []grpc.StreamServerInterceptor
 
 	if !ctx.Config.Insecure {
-		a := kvAuth{}
+		a := kvAuth{
+			tenant: tenantAuthorizer{
+				tenantID: ctx.tenID,
+			},
+		}
 
 		unaryInterceptor = append(unaryInterceptor, a.AuthUnary())
 		streamInterceptor = append(streamInterceptor, a.AuthStream())
@@ -1024,6 +1028,19 @@ func (ctx *Context) GRPCDialNode(
 		log.Fatalf(context.TODO(), "%v", errors.AssertionFailedf("invalid node ID 0 in GRPCDialNode()"))
 	}
 	return ctx.grpcDialNodeInternal(target, remoteNodeID, class)
+}
+
+// GRPCDialPod wraps GRPCDialNode and treats the `remoteInstanceID`
+// argument as a `NodeID` which it converts. This works because the
+// tenant gRPC server is initialized using the `InstanceID` so it
+// accepts our connection as matching the ID we're dialing.
+//
+// Since GRPCDialNode accepts a separate `target` and `NodeID` it
+// requires no further modification to work between pods.
+func (ctx *Context) GRPCDialPod(
+	target string, remoteInstanceID base.SQLInstanceID, class ConnectionClass,
+) *Connection {
+	return ctx.GRPCDialNode(target, roachpb.NodeID(remoteInstanceID), class)
 }
 
 func (ctx *Context) grpcDialNodeInternal(

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -282,6 +282,7 @@ go_test(
         "server_test.go",
         "settings_cache_test.go",
         "settingsworker_test.go",
+        "statements_test.go",
         "stats_test.go",
         "status_test.go",
         "sticky_engine_test.go",

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1317,7 +1317,7 @@ func (s *Server) PreStart(ctx context.Context) error {
 	// and dispatches the server worker for the RPC.
 	// The SQL listener is returned, to start the SQL server later
 	// below when the server has initialized.
-	pgL, startRPCServer, err := s.startListenRPCAndSQL(ctx, workersCtx)
+	pgL, startRPCServer, err := StartListenRPCAndSQL(ctx, workersCtx, s.cfg.BaseConfig, s.stopper, s.grpc)
 	if err != nil {
 		return err
 	}
@@ -1350,82 +1350,17 @@ func (s *Server) PreStart(ctx context.Context) error {
 
 	// Initialize grpc-gateway mux and context in order to get the /health
 	// endpoint working even before the node has fully initialized.
-	jsonpb := &protoutil.JSONPb{
-		EnumsAsInts:  true,
-		EmitDefaults: true,
-		Indent:       "  ",
-	}
-	protopb := new(protoutil.ProtoPb)
-	gwMux := gwruntime.NewServeMux(
-		gwruntime.WithMarshalerOption(gwruntime.MIMEWildcard, jsonpb),
-		gwruntime.WithMarshalerOption(httputil.JSONContentType, jsonpb),
-		gwruntime.WithMarshalerOption(httputil.AltJSONContentType, jsonpb),
-		gwruntime.WithMarshalerOption(httputil.ProtoContentType, protopb),
-		gwruntime.WithMarshalerOption(httputil.AltProtoContentType, protopb),
-		gwruntime.WithOutgoingHeaderMatcher(authenticationHeaderMatcher),
-		gwruntime.WithMetadata(forwardAuthenticationMetadata),
+	gwMux, gwCtx, conn, err := ConfigureGRPCGateway(
+		ctx,
+		workersCtx,
+		s.cfg.AmbientCtx,
+		s.rpcContext,
+		s.stopper,
+		s.grpc,
+		s.cfg.AdvertiseAddr,
 	)
-	gwCtx, gwCancel := context.WithCancel(s.AnnotateCtx(context.Background()))
-	s.stopper.AddCloser(stop.CloserFn(gwCancel))
-
-	// loopback handles the HTTP <-> RPC loopback connection.
-	loopback := newLoopbackListener(workersCtx, s.stopper)
-
-	waitQuiesce := func(context.Context) {
-		<-s.stopper.ShouldQuiesce()
-		_ = loopback.Close()
-	}
-	if err := s.stopper.RunAsyncTask(workersCtx, "gw-quiesce", waitQuiesce); err != nil {
-		waitQuiesce(workersCtx)
-	}
-
-	_ = s.stopper.RunAsyncTask(workersCtx, "serve-loopback", func(context.Context) {
-		netutil.FatalIfUnexpected(s.grpc.Serve(loopback))
-	})
-
-	// Eschew `(*rpc.Context).GRPCDial` to avoid unnecessary moving parts on the
-	// uniquely in-process connection.
-	dialOpts, err := s.rpcContext.GRPCDialOptions()
 	if err != nil {
 		return err
-	}
-
-	callCountInterceptor := func(
-		ctx context.Context,
-		method string,
-		req, reply interface{},
-		cc *grpc.ClientConn,
-		invoker grpc.UnaryInvoker,
-		opts ...grpc.CallOption,
-	) error {
-		telemetry.Inc(getServerEndpointCounter(method))
-		return invoker(ctx, method, req, reply, cc, opts...)
-	}
-	conn, err := grpc.DialContext(ctx, s.cfg.AdvertiseAddr, append(append(
-		dialOpts,
-		grpc.WithUnaryInterceptor(callCountInterceptor)),
-		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
-			return loopback.Connect(ctx)
-		}),
-	)...)
-	if err != nil {
-		return err
-	}
-	{
-		waitQuiesce := func(workersCtx context.Context) {
-			<-s.stopper.ShouldQuiesce()
-			// NB: we can't do this as a Closer because (*Server).ServeWith is
-			// running in a worker and usually sits on accept() which unblocks
-			// only when the listener closes. In other words, the listener needs
-			// to close when quiescing starts to allow that worker to shut down.
-			err := conn.Close() // nolint:grpcconnclose
-			if err != nil {
-				log.Ops.Fatalf(workersCtx, "%v", err)
-			}
-		}
-		if err := s.stopper.RunAsyncTask(workersCtx, "wait-quiesce", waitQuiesce); err != nil {
-			waitQuiesce(workersCtx)
-		}
 	}
 
 	for _, gw := range []grpcGatewayServer{s.admin, s.status, s.authentication, s.tsServer} {
@@ -1916,6 +1851,104 @@ func (s *Server) PreStart(ctx context.Context) error {
 	return maybeImportTS(ctx, s)
 }
 
+// ConfigureGRPCGateway initializes services necessary for running the
+// GRPC Gateway services proxied against the server at `grpcSrv`.
+//
+// The connection between the reverse proxy provided by grpc-gateway
+// and our grpc server uses a loopback-based listener to create
+// connections between the two.
+//
+// The function returns 3 arguments that are necessary to call
+// `RegisterGateway` which generated for each of your gRPC services
+// by grpc-gateway.
+func ConfigureGRPCGateway(
+	ctx, workersCtx context.Context,
+	ambientCtx log.AmbientContext,
+	rpcContext *rpc.Context,
+	stopper *stop.Stopper,
+	grpcSrv *grpcServer,
+	GRPCAddr string,
+) (*gwruntime.ServeMux, context.Context, *grpc.ClientConn, error) {
+	jsonpb := &protoutil.JSONPb{
+		EnumsAsInts:  true,
+		EmitDefaults: true,
+		Indent:       "  ",
+	}
+	protopb := new(protoutil.ProtoPb)
+	gwMux := gwruntime.NewServeMux(
+		gwruntime.WithMarshalerOption(gwruntime.MIMEWildcard, jsonpb),
+		gwruntime.WithMarshalerOption(httputil.JSONContentType, jsonpb),
+		gwruntime.WithMarshalerOption(httputil.AltJSONContentType, jsonpb),
+		gwruntime.WithMarshalerOption(httputil.ProtoContentType, protopb),
+		gwruntime.WithMarshalerOption(httputil.AltProtoContentType, protopb),
+		gwruntime.WithOutgoingHeaderMatcher(authenticationHeaderMatcher),
+		gwruntime.WithMetadata(forwardAuthenticationMetadata),
+	)
+	gwCtx, gwCancel := context.WithCancel(ambientCtx.AnnotateCtx(context.Background()))
+	stopper.AddCloser(stop.CloserFn(gwCancel))
+
+	// loopback handles the HTTP <-> RPC loopback connection.
+	loopback := newLoopbackListener(workersCtx, stopper)
+
+	waitQuiesce := func(context.Context) {
+		<-stopper.ShouldQuiesce()
+		_ = loopback.Close()
+	}
+	if err := stopper.RunAsyncTask(workersCtx, "gw-quiesce", waitQuiesce); err != nil {
+		waitQuiesce(workersCtx)
+	}
+
+	_ = stopper.RunAsyncTask(workersCtx, "serve-loopback", func(context.Context) {
+		netutil.FatalIfUnexpected(grpcSrv.Serve(loopback))
+	})
+
+	// Eschew `(*rpc.Context).GRPCDial` to avoid unnecessary moving parts on the
+	// uniquely in-process connection.
+	dialOpts, err := rpcContext.GRPCDialOptions()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	callCountInterceptor := func(
+		ctx context.Context,
+		method string,
+		req, reply interface{},
+		cc *grpc.ClientConn,
+		invoker grpc.UnaryInvoker,
+		opts ...grpc.CallOption,
+	) error {
+		telemetry.Inc(getServerEndpointCounter(method))
+		return invoker(ctx, method, req, reply, cc, opts...)
+	}
+	conn, err := grpc.DialContext(ctx, GRPCAddr, append(append(
+		dialOpts,
+		grpc.WithUnaryInterceptor(callCountInterceptor)),
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return loopback.Connect(ctx)
+		}),
+	)...)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	{
+		waitQuiesce := func(workersCtx context.Context) {
+			<-stopper.ShouldQuiesce()
+			// NB: we can't do this as a Closer because (*Server).ServeWith is
+			// running in a worker and usually sits on accept() which unblocks
+			// only when the listener closes. In other words, the listener needs
+			// to close when quiescing starts to allow that worker to shut down.
+			err := conn.Close() // nolint:grpcconnclose
+			if err != nil {
+				log.Ops.Fatalf(workersCtx, "%v", err)
+			}
+		}
+		if err := stopper.RunAsyncTask(workersCtx, "wait-quiesce", waitQuiesce); err != nil {
+			waitQuiesce(workersCtx)
+		}
+	}
+	return gwMux, gwCtx, conn, nil
+}
+
 func maybeImportTS(ctx context.Context, s *Server) error {
 	knobs, _ := s.cfg.TestingKnobs.Server.(*TestingKnobs)
 	if knobs == nil {
@@ -2062,43 +2095,43 @@ func (s *Server) AcceptClients(ctx context.Context) error {
 	return nil
 }
 
-// startListenRPCAndSQL starts the RPC and SQL listeners.
+// StartListenRPCAndSQL starts the RPC and SQL listeners.
 // It returns the SQL listener, which can be used
 // to start the SQL server when initialization has completed.
 // It also returns a function that starts the RPC server,
 // when the cluster is known to have bootstrapped or
 // when waiting for init().
-func (s *Server) startListenRPCAndSQL(
-	ctx, workersCtx context.Context,
+func StartListenRPCAndSQL(
+	ctx, workersCtx context.Context, cfg BaseConfig, stopper *stop.Stopper, grpc *grpcServer,
 ) (sqlListener net.Listener, startRPCServer func(ctx context.Context), err error) {
 	rpcChanName := "rpc/sql"
-	if s.cfg.SplitListenSQL {
+	if cfg.SplitListenSQL {
 		rpcChanName = "rpc"
 	}
 	var ln net.Listener
-	if k := s.cfg.TestingKnobs.Server; k != nil {
+	if k := cfg.TestingKnobs.Server; k != nil {
 		knobs := k.(*TestingKnobs)
 		ln = knobs.RPCListener
 	}
 	if ln == nil {
 		var err error
-		ln, err = ListenAndUpdateAddrs(ctx, &s.cfg.Addr, &s.cfg.AdvertiseAddr, rpcChanName)
+		ln, err = ListenAndUpdateAddrs(ctx, &cfg.Addr, &cfg.AdvertiseAddr, rpcChanName)
 		if err != nil {
 			return nil, nil, err
 		}
-		log.Eventf(ctx, "listening on port %s", s.cfg.Addr)
+		log.Eventf(ctx, "listening on port %s", cfg.Addr)
 	}
 
 	var pgL net.Listener
-	if s.cfg.SplitListenSQL {
-		pgL, err = ListenAndUpdateAddrs(ctx, &s.cfg.SQLAddr, &s.cfg.SQLAdvertiseAddr, "sql")
+	if cfg.SplitListenSQL {
+		pgL, err = ListenAndUpdateAddrs(ctx, &cfg.SQLAddr, &cfg.SQLAdvertiseAddr, "sql")
 		if err != nil {
 			return nil, nil, err
 		}
 		// The SQL listener shutdown worker, which closes everything under
 		// the SQL port when the stopper indicates we are shutting down.
 		waitQuiesce := func(ctx context.Context) {
-			<-s.stopper.ShouldQuiesce()
+			<-stopper.ShouldQuiesce()
 			// NB: we can't do this as a Closer because (*Server).ServeWith is
 			// running in a worker and usually sits on accept() which unblocks
 			// only when the listener closes. In other words, the listener needs
@@ -2107,11 +2140,11 @@ func (s *Server) startListenRPCAndSQL(
 				log.Ops.Fatalf(ctx, "%v", err)
 			}
 		}
-		if err := s.stopper.RunAsyncTask(workersCtx, "wait-quiesce", waitQuiesce); err != nil {
+		if err := stopper.RunAsyncTask(workersCtx, "wait-quiesce", waitQuiesce); err != nil {
 			waitQuiesce(workersCtx)
 			return nil, nil, err
 		}
-		log.Eventf(ctx, "listening on sql port %s", s.cfg.SQLAddr)
+		log.Eventf(ctx, "listening on sql port %s", cfg.SQLAddr)
 	}
 
 	// serveOnMux is used to ensure that the mux gets listened on eventually,
@@ -2120,7 +2153,7 @@ func (s *Server) startListenRPCAndSQL(
 
 	m := cmux.New(ln)
 
-	if !s.cfg.SplitListenSQL {
+	if !cfg.SplitListenSQL {
 		// If the pg port is split, it will be opened above. Otherwise,
 		// we make it hang off the RPC listener via cmux here.
 		pgL = m.Match(func(r io.Reader) bool {
@@ -2129,12 +2162,12 @@ func (s *Server) startListenRPCAndSQL(
 		// Also if the pg port is not split, the actual listen
 		// and advertise addresses for SQL become equal to that
 		// of RPC, regardless of what was configured.
-		s.cfg.SQLAddr = s.cfg.Addr
-		s.cfg.SQLAdvertiseAddr = s.cfg.AdvertiseAddr
+		cfg.SQLAddr = cfg.Addr
+		cfg.SQLAdvertiseAddr = cfg.AdvertiseAddr
 	}
 
 	anyL := m.Match(cmux.Any())
-	if serverTestKnobs, ok := s.cfg.TestingKnobs.Server.(*TestingKnobs); ok {
+	if serverTestKnobs, ok := cfg.TestingKnobs.Server.(*TestingKnobs); ok {
 		if serverTestKnobs.ContextTestingKnobs.ArtificialLatencyMap != nil {
 			anyL = rpc.NewDelayingListener(anyL)
 		}
@@ -2142,12 +2175,12 @@ func (s *Server) startListenRPCAndSQL(
 
 	// The remainder shutdown worker.
 	waitForQuiesce := func(context.Context) {
-		<-s.stopper.ShouldQuiesce()
+		<-stopper.ShouldQuiesce()
 		// TODO(bdarnell): Do we need to also close the other listeners?
 		netutil.FatalIfUnexpected(anyL.Close())
 	}
-	s.stopper.AddCloser(stop.CloserFn(func() {
-		s.grpc.Stop()
+	stopper.AddCloser(stop.CloserFn(func() {
+		grpc.Stop()
 		serveOnMux.Do(func() {
 			// The cmux matches don't shut down properly unless serve is called on the
 			// cmux at some point. Use serveOnMux to ensure it's called during shutdown
@@ -2155,7 +2188,7 @@ func (s *Server) startListenRPCAndSQL(
 			netutil.FatalIfUnexpected(m.Serve())
 		})
 	}))
-	if err := s.stopper.RunAsyncTask(
+	if err := stopper.RunAsyncTask(
 		workersCtx, "grpc-quiesce", waitForQuiesce,
 	); err != nil {
 		return nil, nil, err
@@ -2167,11 +2200,11 @@ func (s *Server) startListenRPCAndSQL(
 	// (Server.Start) will call this at the right moment.
 	startRPCServer = func(ctx context.Context) {
 		// Serve the gRPC endpoint.
-		_ = s.stopper.RunAsyncTask(workersCtx, "serve-grpc", func(context.Context) {
-			netutil.FatalIfUnexpected(s.grpc.Serve(anyL))
+		_ = stopper.RunAsyncTask(workersCtx, "serve-grpc", func(context.Context) {
+			netutil.FatalIfUnexpected(grpc.Serve(anyL))
 		})
 
-		_ = s.stopper.RunAsyncTask(ctx, "serve-mux", func(context.Context) {
+		_ = stopper.RunAsyncTask(ctx, "serve-mux", func(context.Context) {
 			serveOnMux.Do(func() {
 				netutil.FatalIfUnexpected(m.Serve())
 			})

--- a/pkg/server/serverpb/status.pb.go
+++ b/pkg/server/serverpb/status.pb.go
@@ -3385,6 +3385,12 @@ func (m *StoresResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_StoresResponse proto.InternalMessageInfo
 
+// StatementsRequest is used by both tenant and node-level
+// implementations to serve fan-out requests across multiple nodes or
+// instances. When implemented on a node, the `node_id` field refers to
+// the cluster nodes by their nodeID. When implemented on a tenant, the
+// `node_id` field refers to the instanceIDs that identify individual
+// tenant pods.
 type StatementsRequest struct {
 	NodeID string `protobuf:"bytes,1,opt,name=node_id,json=nodeId,proto3" json:"node_id,omitempty"`
 }

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -997,6 +997,12 @@ message StoresResponse {
   repeated StoreDetails stores = 1 [ (gogoproto.nullable) = false ];
 }
 
+// StatementsRequest is used by both tenant and node-level
+// implementations to serve fan-out requests across multiple nodes or
+// instances. When implemented on a node, the `node_id` field refers to
+// the cluster nodes by their nodeID. When implemented on a tenant, the
+// `node_id` field refers to the instanceIDs that identify individual
+// tenant pods.
 message StatementsRequest {
   string node_id = 1 [(gogoproto.customname) = "NodeID"];
 }

--- a/pkg/server/statements.go
+++ b/pkg/server/statements.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catconstants"
@@ -33,6 +32,10 @@ func (s *statusServer) Statements(
 		return nil, err
 	}
 
+	if s.gossip.NodeID.Get() == 0 {
+		return nil, status.Errorf(codes.Unavailable, "nodeID not set")
+	}
+
 	response := &serverpb.StatementsResponse{
 		Statements:            []serverpb.StatementsResponse_CollectedStatementStatistics{},
 		LastReset:             timeutil.Now(),
@@ -49,7 +52,7 @@ func (s *statusServer) Statements(
 			return nil, status.Errorf(codes.InvalidArgument, err.Error())
 		}
 		if local {
-			return statementsLocal(ctx, s.gossip.NodeID, s.admin.server.sqlServer)
+			return statementsLocal(ctx, s.gossip.NodeID.Get(), s.admin.server.sqlServer)
 		}
 		status, err := s.dialNode(ctx, requestedNodeID)
 		if err != nil {
@@ -89,7 +92,7 @@ func (s *statusServer) Statements(
 }
 
 func statementsLocal(
-	ctx context.Context, nodeID *base.NodeIDContainer, sqlServer *SQLServer,
+	ctx context.Context, nodeID roachpb.NodeID, sqlServer *SQLServer,
 ) (*serverpb.StatementsResponse, error) {
 	stmtStats, err := sqlServer.pgServer.SQLServer.GetUnscrubbedStmtStats(ctx)
 	if err != nil {
@@ -113,7 +116,7 @@ func statementsLocal(
 	for i, txn := range txnStats {
 		resp.Transactions[i] = serverpb.StatementsResponse_ExtendedCollectedTransactionStatistics{
 			StatsData: txn,
-			NodeID:    nodeID.Get(),
+			NodeID:    nodeID,
 		}
 	}
 
@@ -121,7 +124,7 @@ func statementsLocal(
 		resp.Statements[i] = serverpb.StatementsResponse_CollectedStatementStatistics{
 			Key: serverpb.StatementsResponse_ExtendedStatementStatisticsKey{
 				KeyData: stmt.Key,
-				NodeID:  nodeID.Get(),
+				NodeID:  nodeID,
 			},
 			ID:    stmt.ID,
 			Stats: stmt.Stats,

--- a/pkg/server/statements_test.go
+++ b/pkg/server/statements_test.go
@@ -1,0 +1,62 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
+	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+// TestStatements ensures that the Statements endpoint is accessible
+// via gRPC and returns information reflecting recently run SQL
+// queries.
+func TestStatements(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	testServer, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer testServer.Stopper().Stop(ctx)
+
+	conn, err := testServer.RPCContext().GRPCDialNode(
+		testServer.RPCAddr(), testServer.NodeID(), rpc.DefaultClass,
+	).Connect(ctx)
+	require.NoError(t, err)
+	defer func(conn *grpc.ClientConn) {
+		_ = conn.Close()
+	}(conn)
+
+	client := serverpb.NewStatusClient(conn)
+
+	testQuery := "CREATE TABLE foo (id INT8)"
+	_, err = db.Exec(testQuery)
+	require.NoError(t, err)
+
+	resp, err := client.Statements(ctx, &serverpb.StatementsRequest{NodeID: "local"})
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.Statements)
+
+	queries := make([]string, len(resp.Statements))
+	for _, s := range resp.Statements {
+		queries = append(queries, s.Key.KeyData.Query)
+	}
+	require.Contains(t, queries, testQuery)
+}

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -79,7 +79,23 @@ func StartTenant(
 		SetupIdleMonitor(ctx, args.stopper, baseCfg.IdleExitAfter, connManager)
 	}
 
-	pgL, err := ListenAndUpdateAddrs(ctx, &args.Config.SQLAddr, &args.Config.SQLAdvertiseAddr, "sql")
+	// Initialize gRPC server for use on shared port with pg
+	grpcMain := newGRPCServer(args.rpcContext)
+	grpcMain.setMode(modeOperational)
+
+	// TODO(davidh): Do we need to force this to be false?
+	baseCfg.SplitListenSQL = false
+
+	background := baseCfg.AmbientCtx.AnnotateCtx(context.Background())
+
+	// StartListenRPCAndSQL will replace the SQLAddr fields if we choose
+	// to share the SQL and gRPC port so here, since the tenant config
+	// expects to have port set on the SQL param we transfer those to
+	// the base Addr params in order for the RPC to be configured
+	// correctly.
+	baseCfg.Addr = baseCfg.SQLAddr
+	baseCfg.AdvertiseAddr = baseCfg.SQLAdvertiseAddr
+	pgL, startRPCServer, err := StartListenRPCAndSQL(ctx, background, baseCfg, stopper, grpcMain)
 	if err != nil {
 		return nil, "", "", err
 	}
@@ -122,14 +138,42 @@ func StartTenant(
 		return nil, "", "", err
 	}
 
-	s.execCfg.SQLStatusServer = newTenantStatusServer(
+	tenantStatusServer := newTenantStatusServer(
 		baseCfg.AmbientCtx, &adminPrivilegeChecker{ie: args.circularInternalExecutor},
 		args.sessionRegistry, args.contentionRegistry, args.flowScheduler, baseCfg.Settings, s,
+		args.rpcContext, args.stopper,
 	)
+
+	s.execCfg.SQLStatusServer = tenantStatusServer
 
 	// TODO(asubiotto): remove this. Right now it is needed to initialize the
 	// SpanResolver.
 	s.execCfg.DistSQLPlanner.SetNodeInfo(roachpb.NodeDescriptor{NodeID: 0})
+
+	workersCtx := tenantStatusServer.AnnotateCtx(context.Background())
+
+	// Register and start gRPC service on pod. This is separate from the
+	// gRPC + Gateway services configured below.
+	tenantStatusServer.RegisterService(grpcMain.Server)
+	startRPCServer(workersCtx)
+
+	// Begin configuration of GRPC Gateway
+	gwMux, gwCtx, conn, err := ConfigureGRPCGateway(
+		ctx,
+		workersCtx,
+		args.AmbientCtx,
+		tenantStatusServer.rpcCtx,
+		s.stopper,
+		grpcMain,
+		pgLAddr,
+	)
+	if err != nil {
+		return nil, "", "", err
+	}
+	if err := tenantStatusServer.RegisterGateway(gwCtx, gwMux, conn); err != nil {
+		return nil, "", "", err
+	}
+
 	args.recorder.AddNode(
 		args.registry,
 		roachpb.NodeDescriptor{},
@@ -143,6 +187,7 @@ func StartTenant(
 		mux := http.NewServeMux()
 		debugServer := debug.NewServer(args.Settings, s.pgServer.HBADebugFn())
 		mux.Handle("/", debugServer)
+		mux.Handle("/_status/", gwMux)
 		mux.HandleFunc("/health", func(w http.ResponseWriter, req *http.Request) {
 			// Return Bad Request if called with arguments.
 			if err := req.ParseForm(); err != nil || len(req.Form) != 0 {
@@ -185,6 +230,13 @@ func StartTenant(
 	); err != nil {
 		return nil, "", "", err
 	}
+
+	// This is necessary so the grpc server doesn't error out on heartbeat
+	// ping when we make pod-to-pod calls, we pass the InstanceID with the
+	// request to ensure we're dialing the pod we think we are.
+	//
+	// The InstanceID subsystem is not available until `preStart`.
+	args.rpcContext.NodeID.Set(ctx, roachpb.NodeID(s.SQLInstanceID()))
 
 	// Register the server's identifiers so that log events are
 	// decorated with the server's identity. This helps when gathering

--- a/pkg/server/tenant_status.go
+++ b/pkg/server/tenant_status.go
@@ -17,15 +17,30 @@ package server
 
 import (
 	"context"
+	"fmt"
+	"strconv"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/contention"
 	"github.com/cockroachdb/cockroach/pkg/sql/flowinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlinstance"
+	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
+	gwruntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // tenantStatusServer is an implementation of a SQLStatusServer that is
@@ -35,8 +50,26 @@ import (
 // Phase 2 requirements that there can only be at most one live SQL pod per
 // tenant.
 type tenantStatusServer struct {
-	baseStatusServer
+	baseStatusServer // embeds UnimplementedStatusServer
 }
+
+// We require that `tenantStatusServer` implement
+// `serverpb.StatusServer` even though we only have partial
+// implementation, in order to serve some endpoints on tenants.
+var _ serverpb.StatusServer = &tenantStatusServer{}
+
+func (t *tenantStatusServer) RegisterService(g *grpc.Server) {
+	serverpb.RegisterStatusServer(g, t)
+}
+
+func (t *tenantStatusServer) RegisterGateway(
+	ctx context.Context, mux *gwruntime.ServeMux, conn *grpc.ClientConn,
+) error {
+	ctx = t.AnnotateCtx(ctx)
+	return serverpb.RegisterStatusHandler(ctx, mux, conn)
+}
+
+var _ grpcGatewayServer = &tenantStatusServer{}
 
 func newTenantStatusServer(
 	ambient log.AmbientContext,
@@ -46,6 +79,8 @@ func newTenantStatusServer(
 	flowScheduler *flowinfra.FlowScheduler,
 	st *cluster.Settings,
 	sqlServer *SQLServer,
+	rpcCtx *rpc.Context,
+	stopper *stop.Stopper,
 ) *tenantStatusServer {
 	ambient.AddLogTag("tenant-status", nil)
 	return &tenantStatusServer{
@@ -57,6 +92,8 @@ func newTenantStatusServer(
 			flowScheduler:      flowScheduler,
 			st:                 st,
 			sqlServer:          sqlServer,
+			rpcCtx:             rpcCtx,
+			stopper:            stopper,
 		},
 	}
 }
@@ -118,21 +155,212 @@ func (t *tenantStatusServer) ResetSQLStats(
 	return &serverpb.ResetSQLStatsResponse{}, nil
 }
 
+// Statements implements the relevant endpoint on the StatusServer by
+// fanning out a request to all pods on the current tenant via gRPC to collect
+// in-memory statistics and append them together for the caller.
+//
+// The implementation is based on the one in statements.go but differs
+// by leaning on the InstanceID subsystem to implement the fan-out. If
+// the InstanceID and NodeID subsystems can be unified in some way,
+// these implementations could be merged.
 func (t *tenantStatusServer) Statements(
-	ctx context.Context, _ *serverpb.StatementsRequest,
+	ctx context.Context, req *serverpb.StatementsRequest,
 ) (*serverpb.StatementsResponse, error) {
+	ctx = propagateGatewayMetadata(ctx)
+	ctx = t.AnnotateCtx(ctx)
+
 	if _, err := t.privilegeChecker.requireViewActivityPermission(ctx); err != nil {
 		return nil, err
 	}
-	// Use a dummy value here until pod-to-pod communication is implemented since tenant status server
-	// does not have concept of node.
-	resp, err := statementsLocal(ctx, &base.NodeIDContainer{}, t.sqlServer)
 
+	if t.sqlServer.SQLInstanceID() == 0 {
+		return nil, status.Errorf(codes.Unavailable, "instanceID not set")
+	}
+
+	response := &serverpb.StatementsResponse{
+		Statements:            []serverpb.StatementsResponse_CollectedStatementStatistics{},
+		LastReset:             timeutil.Now(),
+		InternalAppNamePrefix: catconstants.InternalAppNamePrefix,
+	}
+
+	localReq := &serverpb.StatementsRequest{
+		NodeID: "local",
+	}
+
+	if len(req.NodeID) > 0 {
+		// We are interpreting the `NodeID` in the request as an `InstanceID` since
+		// we are executing in the context of a tenant.
+		parsedInstanceID, local, err := t.parseInstanceID(req.NodeID)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, err.Error())
+		}
+		if local {
+			return statementsLocal(ctx, roachpb.NodeID(t.sqlServer.SQLInstanceID()), t.sqlServer)
+		}
+		instance, err := t.sqlServer.sqlInstanceProvider.GetInstance(ctx, parsedInstanceID)
+		if err != nil {
+			return nil, err
+		}
+		statusClient, err := t.dialPod(ctx, parsedInstanceID, instance.InstanceAddr)
+		if err != nil {
+			return nil, err
+		}
+		return statusClient.Statements(ctx, localReq)
+	}
+
+	dialFn := func(ctx context.Context, instanceID base.SQLInstanceID, addr string) (interface{}, error) {
+		client, err := t.dialPod(ctx, instanceID, addr)
+		return client, err
+	}
+	nodeStatement := func(ctx context.Context, client interface{}, _ base.SQLInstanceID) (interface{}, error) {
+		statusClient := client.(serverpb.StatusClient)
+		return statusClient.Statements(ctx, localReq)
+	}
+
+	if err := t.iteratePods(ctx, fmt.Sprintf("statement statistics for node %s", req.NodeID),
+		dialFn,
+		nodeStatement,
+		func(instanceID base.SQLInstanceID, resp interface{}) {
+			statementsResp := resp.(*serverpb.StatementsResponse)
+			response.Statements = append(response.Statements, statementsResp.Statements...)
+			response.Transactions = append(response.Transactions, statementsResp.Transactions...)
+			if response.LastReset.After(statementsResp.LastReset) {
+				response.LastReset = statementsResp.LastReset
+			}
+		},
+		func(instanceID base.SQLInstanceID, err error) {
+			// We log warnings when fanout returns error, but proceed with
+			// constructing a response from whoever returns a good one.
+			log.Warningf(ctx, "fan out statements request recorded error from node %d: %v", instanceID, err)
+		},
+	); err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+// parseInstanceID is based on status.parseNodeID
+func (t *tenantStatusServer) parseInstanceID(
+	instanceIDParam string,
+) (instanceID base.SQLInstanceID, isLocal bool, err error) {
+	// No parameter provided or set to local.
+	if len(instanceIDParam) == 0 || localRE.MatchString(instanceIDParam) {
+		return t.sqlServer.SQLInstanceID(), true /* isLocal */, nil /* err */
+	}
+
+	id, err := strconv.ParseInt(instanceIDParam, 0, 32)
+	if err != nil {
+		return 0 /* instanceID */, false /* isLocal */, errors.Wrap(err, "instance ID could not be parsed")
+	}
+	instanceID = base.SQLInstanceID(id)
+	return instanceID, instanceID == t.sqlServer.SQLInstanceID() /* isLocal */, nil
+}
+
+func (t *tenantStatusServer) dialPod(
+	ctx context.Context, instanceID base.SQLInstanceID, addr string,
+) (serverpb.StatusClient, error) {
+	conn, err := t.rpcCtx.GRPCDialPod(addr, instanceID, rpc.DefaultClass).Connect(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	return resp, nil
+	// nb: The server on the pods doesn't implement all the methods of the
+	// `StatusService`. It is up to the caller of `dialPod` to only call
+	// methods that are implemented on the tenant server.
+	return serverpb.NewStatusClient(conn), nil
+}
+
+// iteratePods is based on the implementation of `iterateNodes in the
+// status server. The two implementations have not been unified into one
+// because there are some deep differences since we use `InstanceInfo`
+// instead of `NodeID`. Since the eventual plan is to deprecate
+// `tenant_status.go` altogether, we're leaving this code-as is.
+//
+// TODO(davidh): unify with `status.iterateNodes` once this server is
+// deprecated
+func (t *tenantStatusServer) iteratePods(
+	ctx context.Context,
+	errorCtx string,
+	dialFn func(ctx context.Context, instanceID base.SQLInstanceID, addr string) (interface{}, error),
+	instanceFn func(ctx context.Context, client interface{}, instanceID base.SQLInstanceID) (interface{}, error),
+	responseFn func(instanceID base.SQLInstanceID, resp interface{}),
+	errorFn func(instanceID base.SQLInstanceID, nodeFnError error),
+) error {
+	liveTenantInstances, err := t.sqlServer.sqlInstanceProvider.GetAllInstances(ctx)
+	if err != nil {
+		return err
+	}
+
+	type instanceResponse struct {
+		instanceID base.SQLInstanceID
+		response   interface{}
+		err        error
+	}
+
+	numInstances := len(liveTenantInstances)
+	responseChan := make(chan instanceResponse, numInstances)
+
+	instanceQuery := func(ctx context.Context, instance sqlinstance.InstanceInfo) {
+		var client interface{}
+		err := contextutil.RunWithTimeout(ctx, "dial instance", base.NetworkTimeout, func(ctx context.Context) error {
+			var err error
+			client, err = dialFn(ctx, instance.InstanceID, instance.InstanceAddr)
+			return err
+		})
+
+		instanceID := instance.InstanceID
+		if err != nil {
+			err = errors.Wrapf(err, "failed to dial into node %d",
+				instanceID)
+			responseChan <- instanceResponse{instanceID: instanceID, err: err}
+			return
+		}
+
+		res, err := instanceFn(ctx, client, instanceID)
+		if err != nil {
+			err = errors.Wrapf(err, "error requesting %s from instance %d",
+				errorCtx, instanceID)
+			responseChan <- instanceResponse{instanceID: instanceID, err: err}
+			return
+		}
+		responseChan <- instanceResponse{instanceID: instanceID, response: res}
+	}
+
+	sem := quotapool.NewIntPool("instance status", maxConcurrentRequests)
+	ctx, cancel := t.stopper.WithCancelOnQuiesce(ctx)
+	defer cancel()
+
+	for _, instance := range liveTenantInstances {
+		instance := instance
+		if err := t.stopper.RunAsyncTaskEx(
+			ctx, stop.TaskOpts{
+				TaskName:   fmt.Sprintf("server.tenantStatusServer: requesting %s", errorCtx),
+				Sem:        sem,
+				WaitForSem: true,
+			},
+			func(ctx context.Context) {
+				instanceQuery(ctx, instance)
+			}); err != nil {
+			return err
+		}
+	}
+
+	var resultErr error
+	for numInstances > 0 {
+		select {
+		case res := <-responseChan:
+			if res.err != nil {
+				errorFn(res.instanceID, res.err)
+			} else {
+				responseFn(res.instanceID, res.response)
+			}
+		case <-ctx.Done():
+			resultErr = errors.Errorf("request of %s canceled before completion", errorCtx)
+		}
+		numInstances--
+	}
+	return resultErr
 }
 
 func (t *tenantStatusServer) ListDistSQLFlows(

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -524,6 +524,11 @@ func (t *TestTenant) DistSQLServer() interface{} {
 	return t.SQLServer.distSQLServer
 }
 
+// RPCContext is part of the TestTenantInterface interface
+func (t *TestTenant) RPCContext() *rpc.Context {
+	return t.execCfg.RPCContext
+}
+
 // JobRegistry is part of the TestTenantInterface interface.
 func (t *TestTenant) JobRegistry() interface{} {
 	return t.SQLServer.jobRegistry

--- a/pkg/testutils/serverutils/test_tenant_shim.go
+++ b/pkg/testutils/serverutils/test_tenant_shim.go
@@ -13,7 +13,10 @@
 
 package serverutils
 
-import "github.com/cockroachdb/cockroach/pkg/base"
+import (
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
+)
 
 // TestTenantInterface defines SQL-only tenant functionality that tests need; it
 // is implemented by server.TestTenant.
@@ -50,4 +53,7 @@ type TestTenantInterface interface {
 	// TestingKnobs returns the TestingKnobs in use by the test
 	// tenant.
 	TestingKnobs() *base.TestingKnobs
+
+	// RPCContext returns the *rpc.Context
+	RPCContext() *rpc.Context
 }


### PR DESCRIPTION
Previously, the Statements endpoint implementation was purely local in
its execution and reported only in-memory data on the current tenant.
This change initializes a gRPC and gRPC-gateway server on the tenant,
much like we do on the hosts already, and uses the newly added
InstanceID subsystem for tenants to implement a gRPC-based fanout for
the Statements endpoint implementation.

The fanout is done much in the same manner as on hosts and we
expose the status server endpoints via HTTP on the tenant as well.

This change is necessary to support serverless observability features
and provide our UIs access to the Statements endpoint. Future work may
move this API to SQL-only

Resolves cockroachdb#64477

Release note (api change): tenant pods now expose the Statements API at
`/_status/statements` on their HTTP port.