### PR TITLE
tracing: collector was incorrectly flattening recordings

### DIFF
--- a/pkg/util/tracing/collector/BUILD.bazel
+++ b/pkg/util/tracing/collector/BUILD.bazel
@@ -15,7 +15,6 @@ go_library(
         "//pkg/rpc/nodedialer",
         "//pkg/util/log",
         "//pkg/util/tracing",
-        "//pkg/util/tracing/tracingpb",
         "//pkg/util/tracing/tracingservicepb:tracingservicepb_go_proto",
     ],
 )
@@ -31,6 +30,7 @@ go_test(
         "//pkg/base",
         "//pkg/ccl/utilccl",
         "//pkg/kv/kvserver/liveness",
+        "//pkg/roachpb",
         "//pkg/rpc/nodedialer",
         "//pkg/security",
         "//pkg/security/securitytest",

--- a/pkg/util/tracing/collector/collector.go
+++ b/pkg/util/tracing/collector/collector.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
-	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingservicepb"
 )
 
@@ -50,9 +49,9 @@ func New(
 	}
 }
 
-// Iterator can be used to return RecordedSpans from all live
-// nodes in the cluster, in a streaming manner. The iterator buffers the
-// RecordedSpans of one node at a time.
+// Iterator can be used to return tracing.Recordings from all live nodes in the
+// cluster, in a streaming manner. The iterator buffers the tracing.Recordings
+// of one node at a time.
 type Iterator struct {
 	collector *TraceCollector
 
@@ -64,19 +63,24 @@ type Iterator struct {
 	// and will be contacted for inflight trace spans by the iterator.
 	liveNodes []roachpb.NodeID
 
-	// curNodeIndex maintains the node from which the iterator has pulled inflight
-	// span recordings and buffered them in `recordedSpans` for consumption via
-	// the iterator.
+	// curNodeIndex maintains the index in liveNodes from which the iterator has
+	// pulled inflight span recordings and buffered them in `recordedSpans` for
+	// consumption via the iterator.
 	curNodeIndex int
 
-	// recordedSpanIndex maintains the current position of of the iterator in the
-	// list of recorded spans. The recorded spans that the iterator points to are
-	// buffered in `recordedSpans`.
-	recordedSpanIndex int
+	// curNode maintains the node from which the iterator has pulled inflight span
+	// recordings and buffered them in `recordings` for consumption via the
+	// iterator.
+	curNode roachpb.NodeID
 
-	// recordedSpans represents all recorded spans for a given node currently
+	// recordingIndex maintains the current position of the iterator in the list
+	// of tracing.Recordings. The tracing.Recording that the iterator points to is
+	// buffered in `recordings`.
+	recordingIndex int
+
+	// recordings represent all the tracing.Recordings for a given node currently
 	// accessed by the iterator.
-	recordedSpans []tracingpb.RecordedSpan
+	recordings []tracing.Recording
 
 	iterErr error
 }
@@ -104,9 +108,9 @@ func (i *Iterator) Valid() bool {
 		return false
 	}
 
-	// If recordedSpanIndex is within recordedSpans and there are some buffered
-	// recordedSpans, it is valid to return from the buffer.
-	if i.recordedSpans != nil && i.recordedSpanIndex < len(i.recordedSpans) {
+	// If recordingIndex is within recordings and there are some buffered
+	// recordings, it is valid to return from the buffer.
+	if i.recordings != nil && i.recordingIndex < len(i.recordings) {
 		return true
 	}
 
@@ -117,29 +121,29 @@ func (i *Iterator) Valid() bool {
 
 // Next sets the Iterator to point to the next value to be returned.
 func (i *Iterator) Next() {
-	i.recordedSpanIndex++
+	i.recordingIndex++
 
-	// If recordedSpanIndex is within recordedSpans and there are some buffered
-	// recordedSpans, then we can return them when Value() is called.
-	if i.recordedSpans != nil && i.recordedSpanIndex < len(i.recordedSpans) {
+	// If recordingIndex is within recordings and there are some buffered
+	// recordings, it is valid to return from the buffer.
+	if i.recordings != nil && i.recordingIndex < len(i.recordings) {
 		return
 	}
 
 	// Reset buffer variables.
-	i.recordedSpans = nil
-	i.recordedSpanIndex = 0
+	i.recordings = nil
+	i.recordingIndex = 0
 
 	// Either there are no more spans or we have exhausted the recordings from the
 	// current node, and we need to pull the inflight recordings from another
 	// node.
 	// Keep searching for recordings from all live nodes in the cluster.
-	for i.recordedSpans == nil {
+	for i.recordings == nil {
 		// No more spans to return from any of the live nodes in the cluster.
 		if !(i.curNodeIndex < len(i.liveNodes)) {
 			return
 		}
-		i.recordedSpans, i.iterErr = i.collector.getTraceSpanRecordingsForNode(i.ctx, i.traceID,
-			i.liveNodes[i.curNodeIndex])
+		i.curNode = i.liveNodes[i.curNodeIndex]
+		i.recordings, i.iterErr = i.collector.getTraceSpanRecordingsForNode(i.ctx, i.traceID, i.curNode)
 		// TODO(adityamaru): We might want to consider not failing if a single node
 		// fails to return span recordings.
 		if i.iterErr != nil {
@@ -150,8 +154,8 @@ func (i *Iterator) Next() {
 }
 
 // Value returns the current value pointed to by the Iterator.
-func (i *Iterator) Value() tracingpb.RecordedSpan {
-	return i.recordedSpans[i.recordedSpanIndex]
+func (i *Iterator) Value() (roachpb.NodeID, tracing.Recording) {
+	return i.curNode, i.recordings[i.recordingIndex]
 }
 
 // Error returns the error encountered by the Iterator during iteration.
@@ -166,7 +170,7 @@ func (i *Iterator) Error() error {
 // inflight spans, and relies on gRPC short circuiting local requests.
 func (t *TraceCollector) getTraceSpanRecordingsForNode(
 	ctx context.Context, traceID uint64, nodeID roachpb.NodeID,
-) ([]tracingpb.RecordedSpan, error) {
+) ([]tracing.Recording, error) {
 	log.Infof(ctx, "getting span recordings from node %s", nodeID.String())
 	conn, err := t.dialer.Dial(ctx, nodeID, rpc.DefaultClass)
 	if err != nil {
@@ -174,14 +178,24 @@ func (t *TraceCollector) getTraceSpanRecordingsForNode(
 	}
 	traceClient := tracingservicepb.NewTracingClient(conn)
 	resp, err := traceClient.GetSpanRecordings(ctx,
-		&tracingservicepb.SpanRecordingRequest{TraceID: traceID})
+		&tracingservicepb.GetSpanRecordingsRequest{TraceID: traceID})
 	if err != nil {
 		return nil, err
 	}
 
-	sort.SliceStable(resp.SpanRecordings, func(i, j int) bool {
-		return resp.SpanRecordings[i].StartTime.Before(resp.SpanRecordings[j].StartTime)
+	var res []tracing.Recording
+	for _, recording := range resp.Recordings {
+		if recording.RecordedSpans == nil {
+			continue
+		}
+		res = append(res, recording.RecordedSpans)
+	}
+
+	// This sort ensures that if a node has multiple trace.Recordings then they
+	// are ordered relative to each other by StartTime.
+	sort.SliceStable(res, func(i, j int) bool {
+		return res[i][0].StartTime.Before(res[j][0].StartTime)
 	})
 
-	return resp.SpanRecordings, nil
+	return res, nil
 }

--- a/pkg/util/tracing/collector/collector_test.go
+++ b/pkg/util/tracing/collector/collector_test.go
@@ -13,12 +13,12 @@ package collector_test
 import (
 	"context"
 	"fmt"
-	"sort"
 	"testing"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -129,51 +129,63 @@ func TestTracingCollectorGetSpanRecordings(t *testing.T) {
 	localTraceID, remoteTraceID, cleanup := setupTraces(localTracer, remoteTracer)
 	defer cleanup()
 
-	getSpansFromAllNodes := func(traceID uint64) tracing.Recording {
-		res := make(tracing.Recording, 0)
+	getSpansFromAllNodes := func(traceID uint64) map[roachpb.NodeID][]tracing.Recording {
+		res := make(map[roachpb.NodeID][]tracing.Recording)
 
 		var iter *collector.Iterator
 		for iter = traceCollector.StartIter(ctx, traceID); iter.Valid(); iter.Next() {
-			res = append(res, iter.Value())
+			nodeID, recording := iter.Value()
+			res[nodeID] = append(res[nodeID], recording)
 		}
 		require.NoError(t, iter.Error())
-
-		sort.SliceStable(res, func(i, j int) bool {
-			return res[i].StartTime.Before(res[j].StartTime)
-		})
 		return res
 	}
 
 	t.Run("fetch-local-recordings", func(t *testing.T) {
-		recordedSpan := getSpansFromAllNodes(localTraceID)
-		require.NoError(t, tracing.TestingCheckRecordedSpans(recordedSpan, `
-			span: root
-				tags: _unfinished=1 _verbose=1
-				event: structured=root
-				span: root.child
+		nodeRecordings := getSpansFromAllNodes(localTraceID)
+		node1Recordings := nodeRecordings[roachpb.NodeID(1)]
+		require.Equal(t, 1, len(node1Recordings))
+		require.NoError(t, tracing.TestingCheckRecordedSpans(node1Recordings[0], `
+				span: root
 					tags: _unfinished=1 _verbose=1
-					span: root.child.remotechild
+					event: structured=root
+					span: root.child
 						tags: _unfinished=1 _verbose=1
-						event: structured=root.child.remotechild
-					span: root.child.remotechilddone
-						tags: _verbose=1
-`))
+						span: root.child.remotechilddone
+							tags: _verbose=1
+	`))
+		node2Recordings := nodeRecordings[roachpb.NodeID(2)]
+		require.Equal(t, 1, len(node2Recordings))
+		require.NoError(t, tracing.TestingCheckRecordedSpans(node2Recordings[0], `
+				span: root.child.remotechild
+					tags: _unfinished=1 _verbose=1
+					event: structured=root.child.remotechild
+	`))
 	})
 
 	// The traceCollector is running on node 1, so most of the recordings for this
 	// subtest will be passed back by node 2 over RPC.
 	t.Run("fetch-remote-recordings", func(t *testing.T) {
-		recordedSpan := getSpansFromAllNodes(remoteTraceID)
-		require.NoError(t, tracing.TestingCheckRecordedSpans(recordedSpan, `
-			span: root2
-				tags: _unfinished=1 _verbose=1
-				event: structured=root2
-				span: root2.child
+		nodeRecordings := getSpansFromAllNodes(remoteTraceID)
+		node1Recordings := nodeRecordings[roachpb.NodeID(1)]
+		require.Equal(t, 2, len(node1Recordings))
+		require.NoError(t, tracing.TestingCheckRecordedSpans(node1Recordings[0], `
+				span: root2.child.remotechild
 					tags: _unfinished=1 _verbose=1
-					span: root2.child.remotechild
+	`))
+		require.NoError(t, tracing.TestingCheckRecordedSpans(node1Recordings[1], `
+				span: root2.child.remotechild2
+					tags: _unfinished=1 _verbose=1
+	`))
+
+		node2Recordings := nodeRecordings[roachpb.NodeID(2)]
+		require.Equal(t, 1, len(node2Recordings))
+		require.NoError(t, tracing.TestingCheckRecordedSpans(node2Recordings[0], `
+				span: root2
+					tags: _unfinished=1 _verbose=1
+					event: structured=root2
+					span: root2.child
 						tags: _unfinished=1 _verbose=1
-					span: root2.child.remotechild2
-						tags: _unfinished=1 _verbose=1
-`))
+	`))
 	})
 }

--- a/pkg/util/tracing/grpc_interceptor.go
+++ b/pkg/util/tracing/grpc_interceptor.go
@@ -421,6 +421,6 @@ func (cs *tracingClientStream) CloseSend() error {
 	return err
 }
 
-// Recording represents a group of RecordedSpans, as returned by GetRecording.
-// Spans are sorted by StartTime.
+// Recording represents a group of RecordedSpans rooted at a fixed root span, as
+// returned by GetRecording. Spans are sorted by StartTime.
 type Recording []tracingpb.RecordedSpan

--- a/pkg/util/tracing/tracingservicepb/tracing_service.pb.go
+++ b/pkg/util/tracing/tracingservicepb/tracing_service.pb.go
@@ -28,20 +28,20 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
-type SpanRecordingRequest struct {
+type GetSpanRecordingsRequest struct {
 	TraceID uint64 `protobuf:"varint,1,opt,name=trace_id,json=traceId,proto3" json:"trace_id,omitempty"`
 }
 
-func (m *SpanRecordingRequest) Reset()         { *m = SpanRecordingRequest{} }
-func (m *SpanRecordingRequest) String() string { return proto.CompactTextString(m) }
-func (*SpanRecordingRequest) ProtoMessage()    {}
-func (*SpanRecordingRequest) Descriptor() ([]byte, []int) {
+func (m *GetSpanRecordingsRequest) Reset()         { *m = GetSpanRecordingsRequest{} }
+func (m *GetSpanRecordingsRequest) String() string { return proto.CompactTextString(m) }
+func (*GetSpanRecordingsRequest) ProtoMessage()    {}
+func (*GetSpanRecordingsRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_29b78bec82996ca3, []int{0}
 }
-func (m *SpanRecordingRequest) XXX_Unmarshal(b []byte) error {
+func (m *GetSpanRecordingsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *SpanRecordingRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *GetSpanRecordingsRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	b = b[:cap(b)]
 	n, err := m.MarshalToSizedBuffer(b)
 	if err != nil {
@@ -49,32 +49,32 @@ func (m *SpanRecordingRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte
 	}
 	return b[:n], nil
 }
-func (m *SpanRecordingRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_SpanRecordingRequest.Merge(m, src)
+func (m *GetSpanRecordingsRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetSpanRecordingsRequest.Merge(m, src)
 }
-func (m *SpanRecordingRequest) XXX_Size() int {
+func (m *GetSpanRecordingsRequest) XXX_Size() int {
 	return m.Size()
 }
-func (m *SpanRecordingRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_SpanRecordingRequest.DiscardUnknown(m)
+func (m *GetSpanRecordingsRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_GetSpanRecordingsRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_SpanRecordingRequest proto.InternalMessageInfo
+var xxx_messageInfo_GetSpanRecordingsRequest proto.InternalMessageInfo
 
-type SpanRecordingResponse struct {
-	SpanRecordings []tracingpb.RecordedSpan `protobuf:"bytes,1,rep,name=span_recordings,json=spanRecordings,proto3" json:"span_recordings"`
+type GetSpanRecordingsResponse struct {
+	Recordings []GetSpanRecordingsResponse_Recording `protobuf:"bytes,1,rep,name=recordings,proto3" json:"recordings"`
 }
 
-func (m *SpanRecordingResponse) Reset()         { *m = SpanRecordingResponse{} }
-func (m *SpanRecordingResponse) String() string { return proto.CompactTextString(m) }
-func (*SpanRecordingResponse) ProtoMessage()    {}
-func (*SpanRecordingResponse) Descriptor() ([]byte, []int) {
+func (m *GetSpanRecordingsResponse) Reset()         { *m = GetSpanRecordingsResponse{} }
+func (m *GetSpanRecordingsResponse) String() string { return proto.CompactTextString(m) }
+func (*GetSpanRecordingsResponse) ProtoMessage()    {}
+func (*GetSpanRecordingsResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_29b78bec82996ca3, []int{1}
 }
-func (m *SpanRecordingResponse) XXX_Unmarshal(b []byte) error {
+func (m *GetSpanRecordingsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *SpanRecordingResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *GetSpanRecordingsResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	b = b[:cap(b)]
 	n, err := m.MarshalToSizedBuffer(b)
 	if err != nil {
@@ -82,21 +82,55 @@ func (m *SpanRecordingResponse) XXX_Marshal(b []byte, deterministic bool) ([]byt
 	}
 	return b[:n], nil
 }
-func (m *SpanRecordingResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_SpanRecordingResponse.Merge(m, src)
+func (m *GetSpanRecordingsResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetSpanRecordingsResponse.Merge(m, src)
 }
-func (m *SpanRecordingResponse) XXX_Size() int {
+func (m *GetSpanRecordingsResponse) XXX_Size() int {
 	return m.Size()
 }
-func (m *SpanRecordingResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_SpanRecordingResponse.DiscardUnknown(m)
+func (m *GetSpanRecordingsResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_GetSpanRecordingsResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_SpanRecordingResponse proto.InternalMessageInfo
+var xxx_messageInfo_GetSpanRecordingsResponse proto.InternalMessageInfo
+
+type GetSpanRecordingsResponse_Recording struct {
+	RecordedSpans []tracingpb.RecordedSpan `protobuf:"bytes,1,rep,name=recorded_spans,json=recordedSpans,proto3" json:"recorded_spans"`
+}
+
+func (m *GetSpanRecordingsResponse_Recording) Reset()         { *m = GetSpanRecordingsResponse_Recording{} }
+func (m *GetSpanRecordingsResponse_Recording) String() string { return proto.CompactTextString(m) }
+func (*GetSpanRecordingsResponse_Recording) ProtoMessage()    {}
+func (*GetSpanRecordingsResponse_Recording) Descriptor() ([]byte, []int) {
+	return fileDescriptor_29b78bec82996ca3, []int{1, 0}
+}
+func (m *GetSpanRecordingsResponse_Recording) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *GetSpanRecordingsResponse_Recording) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	b = b[:cap(b)]
+	n, err := m.MarshalToSizedBuffer(b)
+	if err != nil {
+		return nil, err
+	}
+	return b[:n], nil
+}
+func (m *GetSpanRecordingsResponse_Recording) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetSpanRecordingsResponse_Recording.Merge(m, src)
+}
+func (m *GetSpanRecordingsResponse_Recording) XXX_Size() int {
+	return m.Size()
+}
+func (m *GetSpanRecordingsResponse_Recording) XXX_DiscardUnknown() {
+	xxx_messageInfo_GetSpanRecordingsResponse_Recording.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_GetSpanRecordingsResponse_Recording proto.InternalMessageInfo
 
 func init() {
-	proto.RegisterType((*SpanRecordingRequest)(nil), "cockroach.util.tracing.SpanRecordingRequest")
-	proto.RegisterType((*SpanRecordingResponse)(nil), "cockroach.util.tracing.SpanRecordingResponse")
+	proto.RegisterType((*GetSpanRecordingsRequest)(nil), "cockroach.util.tracing.GetSpanRecordingsRequest")
+	proto.RegisterType((*GetSpanRecordingsResponse)(nil), "cockroach.util.tracing.GetSpanRecordingsResponse")
+	proto.RegisterType((*GetSpanRecordingsResponse_Recording)(nil), "cockroach.util.tracing.GetSpanRecordingsResponse.Recording")
 }
 
 func init() {
@@ -104,26 +138,28 @@ func init() {
 }
 
 var fileDescriptor_29b78bec82996ca3 = []byte{
-	// 301 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x51, 0x4d, 0x4b, 0xc3, 0x30,
-	0x00, 0x4d, 0x70, 0x38, 0xc9, 0xc0, 0x8f, 0x32, 0x65, 0xec, 0x90, 0x8d, 0x1d, 0x64, 0x88, 0x66,
-	0xd0, 0xdd, 0x3d, 0x14, 0x41, 0x76, 0xad, 0x9e, 0x04, 0x29, 0x6d, 0x1a, 0x6a, 0x50, 0x92, 0x98,
-	0x74, 0xbb, 0xf9, 0x1f, 0xfc, 0x59, 0x3d, 0xee, 0xb8, 0xd3, 0xd0, 0xf6, 0x8f, 0x48, 0xfa, 0x21,
-	0x3a, 0x2a, 0x78, 0x6a, 0x79, 0x1f, 0x79, 0xef, 0x25, 0x68, 0xbe, 0x4c, 0xf9, 0xcb, 0x2c, 0xd5,
-	0x21, 0xe5, 0x22, 0x69, 0xbe, 0x86, 0xe9, 0x15, 0xa7, 0x4c, 0x45, 0x0d, 0x10, 0xd4, 0x08, 0x51,
-	0x5a, 0xa6, 0xd2, 0x39, 0xa3, 0x92, 0x3e, 0x6b, 0x19, 0xd2, 0x27, 0x62, 0xed, 0xa4, 0x56, 0x0d,
-	0xfb, 0x89, 0x4c, 0x64, 0x29, 0x99, 0xd9, 0xbf, 0x4a, 0x3d, 0xbc, 0x68, 0x8b, 0x50, 0xd1, 0x4c,
-	0x33, 0x2a, 0x75, 0xcc, 0xe2, 0xc0, 0xa8, 0x50, 0x54, 0xda, 0xc9, 0x35, 0xea, 0xdf, 0xa9, 0x50,
-	0xf8, 0x25, 0xc5, 0x45, 0xe2, 0xb3, 0xd7, 0x25, 0x33, 0xa9, 0x73, 0x8e, 0x0e, 0xac, 0x91, 0x05,
-	0x3c, 0x1e, 0xc0, 0x31, 0x9c, 0x76, 0xbc, 0x5e, 0xbe, 0x1d, 0x75, 0xef, 0x2d, 0xb6, 0xb8, 0xf1,
-	0xbb, 0x25, 0xb9, 0x88, 0x27, 0x2b, 0x74, 0xba, 0xe3, 0x37, 0x4a, 0x0a, 0xc3, 0x9c, 0x47, 0x74,
-	0x64, 0x63, 0x02, 0xdd, 0x30, 0x66, 0x00, 0xc7, 0x7b, 0xd3, 0x9e, 0x4b, 0x48, 0xfb, 0x18, 0xf2,
-	0x5d, 0x94, 0xf8, 0x75, 0x51, 0x7b, 0xb2, 0xd7, 0xc9, 0xb6, 0x23, 0xe0, 0x1f, 0x9a, 0x9f, 0x29,
-	0xc6, 0x7d, 0x43, 0x65, 0x17, 0x2e, 0x12, 0x47, 0xa3, 0x93, 0x5b, 0x96, 0xfe, 0x6a, 0x61, 0x9c,
-	0xcb, 0xbf, 0x52, 0xda, 0xd6, 0x0e, 0xaf, 0xfe, 0xa9, 0xae, 0xb6, 0x4d, 0x80, 0xe7, 0x66, 0x9f,
-	0x18, 0x64, 0x39, 0x86, 0xeb, 0x1c, 0xc3, 0x4d, 0x8e, 0xe1, 0x47, 0x8e, 0xe1, 0x7b, 0x81, 0xc1,
-	0xba, 0xc0, 0x60, 0x53, 0x60, 0xf0, 0x70, 0xbc, 0xfb, 0xb4, 0xd1, 0x7e, 0x79, 0xe3, 0xf3, 0xaf,
-	0x00, 0x00, 0x00, 0xff, 0xff, 0xe4, 0xe8, 0x32, 0x41, 0x02, 0x02, 0x00, 0x00,
+	// 322 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x32, 0x2e, 0x2d, 0xc9, 0xcc,
+	0xd1, 0x2f, 0x29, 0x4a, 0x4c, 0xce, 0xcc, 0x4b, 0x87, 0xd1, 0xc5, 0xa9, 0x45, 0x65, 0x99, 0xc9,
+	0xa9, 0x05, 0x49, 0x30, 0x81, 0x78, 0xa8, 0x88, 0x5e, 0x41, 0x51, 0x7e, 0x49, 0xbe, 0x90, 0x58,
+	0x72, 0x7e, 0x72, 0x76, 0x51, 0x7e, 0x62, 0x72, 0x86, 0x1e, 0x48, 0xbb, 0x1e, 0x54, 0x95, 0x94,
+	0x48, 0x7a, 0x7e, 0x7a, 0x3e, 0x58, 0x89, 0x3e, 0x88, 0x05, 0x51, 0x2d, 0xa5, 0x85, 0xcd, 0x8a,
+	0x82, 0x24, 0xfd, 0xa2, 0xd4, 0xe4, 0xfc, 0xa2, 0x94, 0xd4, 0x94, 0xf8, 0xe2, 0x82, 0xc4, 0x3c,
+	0x88, 0x5a, 0x25, 0x27, 0x2e, 0x09, 0xf7, 0xd4, 0x92, 0xe0, 0x82, 0xc4, 0xbc, 0x20, 0xb0, 0x2c,
+	0xc8, 0x31, 0x41, 0xa9, 0x85, 0xa5, 0xa9, 0xc5, 0x25, 0x42, 0x6a, 0x5c, 0x1c, 0x20, 0xcd, 0xa9,
+	0xf1, 0x99, 0x29, 0x12, 0x8c, 0x0a, 0x8c, 0x1a, 0x2c, 0x4e, 0xdc, 0x8f, 0xee, 0xc9, 0xb3, 0x87,
+	0x80, 0xc4, 0x3c, 0x5d, 0x82, 0xd8, 0xc1, 0x92, 0x9e, 0x29, 0x4a, 0x2f, 0x18, 0xb9, 0x24, 0xb1,
+	0x18, 0x52, 0x5c, 0x90, 0x9f, 0x57, 0x9c, 0x2a, 0x94, 0xc8, 0xc5, 0x55, 0x04, 0x17, 0x95, 0x60,
+	0x54, 0x60, 0xd6, 0xe0, 0x36, 0xb2, 0xd6, 0xc3, 0xee, 0x21, 0x3d, 0x9c, 0xc6, 0xe8, 0xc1, 0x85,
+	0x9c, 0x58, 0x4e, 0xdc, 0x93, 0x67, 0x08, 0x42, 0x32, 0x54, 0x2a, 0x83, 0x8b, 0x13, 0x2e, 0x2d,
+	0x14, 0xcd, 0xc5, 0x87, 0xe2, 0x51, 0x98, 0x9d, 0x7a, 0xb8, 0xec, 0x84, 0x07, 0x10, 0xd4, 0x8e,
+	0xd4, 0x14, 0x90, 0x13, 0xa0, 0xd6, 0xf0, 0x16, 0x21, 0x89, 0x15, 0x1b, 0xb5, 0x32, 0x72, 0x81,
+	0xfd, 0x0f, 0xb2, 0xa8, 0x8a, 0x4b, 0x10, 0xc3, 0xb9, 0x42, 0x06, 0x24, 0xf8, 0x0c, 0x1c, 0xca,
+	0x52, 0x86, 0x24, 0x87, 0x85, 0x12, 0x83, 0x93, 0xd1, 0x89, 0x87, 0x72, 0x0c, 0x27, 0x1e, 0xc9,
+	0x31, 0x5e, 0x78, 0x24, 0xc7, 0x78, 0xe3, 0x91, 0x1c, 0xe3, 0x83, 0x47, 0x72, 0x8c, 0x13, 0x1e,
+	0xcb, 0x31, 0x5c, 0x78, 0x2c, 0xc7, 0x70, 0xe3, 0xb1, 0x1c, 0x43, 0x94, 0x00, 0x7a, 0xd2, 0x4a,
+	0x62, 0x03, 0xc7, 0xb8, 0x31, 0x20, 0x00, 0x00, 0xff, 0xff, 0x43, 0x42, 0x98, 0x9f, 0x82, 0x02,
+	0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -138,7 +174,9 @@ const _ = grpc.SupportPackageIsVersion4
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type TracingClient interface {
-	GetSpanRecordings(ctx context.Context, in *SpanRecordingRequest, opts ...grpc.CallOption) (*SpanRecordingResponse, error)
+	// GetSpanRecordings contacts a nodes' inflight span registry to return the
+	// tracing.Recordings for each root span with a matching TraceID.
+	GetSpanRecordings(ctx context.Context, in *GetSpanRecordingsRequest, opts ...grpc.CallOption) (*GetSpanRecordingsResponse, error)
 }
 
 type tracingClient struct {
@@ -149,8 +187,8 @@ func NewTracingClient(cc *grpc.ClientConn) TracingClient {
 	return &tracingClient{cc}
 }
 
-func (c *tracingClient) GetSpanRecordings(ctx context.Context, in *SpanRecordingRequest, opts ...grpc.CallOption) (*SpanRecordingResponse, error) {
-	out := new(SpanRecordingResponse)
+func (c *tracingClient) GetSpanRecordings(ctx context.Context, in *GetSpanRecordingsRequest, opts ...grpc.CallOption) (*GetSpanRecordingsResponse, error) {
+	out := new(GetSpanRecordingsResponse)
 	err := c.cc.Invoke(ctx, "/cockroach.util.tracing.Tracing/GetSpanRecordings", in, out, opts...)
 	if err != nil {
 		return nil, err
@@ -160,14 +198,16 @@ func (c *tracingClient) GetSpanRecordings(ctx context.Context, in *SpanRecording
 
 // TracingServer is the server API for Tracing service.
 type TracingServer interface {
-	GetSpanRecordings(context.Context, *SpanRecordingRequest) (*SpanRecordingResponse, error)
+	// GetSpanRecordings contacts a nodes' inflight span registry to return the
+	// tracing.Recordings for each root span with a matching TraceID.
+	GetSpanRecordings(context.Context, *GetSpanRecordingsRequest) (*GetSpanRecordingsResponse, error)
 }
 
 // UnimplementedTracingServer can be embedded to have forward compatible implementations.
 type UnimplementedTracingServer struct {
 }
 
-func (*UnimplementedTracingServer) GetSpanRecordings(ctx context.Context, req *SpanRecordingRequest) (*SpanRecordingResponse, error) {
+func (*UnimplementedTracingServer) GetSpanRecordings(ctx context.Context, req *GetSpanRecordingsRequest) (*GetSpanRecordingsResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetSpanRecordings not implemented")
 }
 
@@ -176,7 +216,7 @@ func RegisterTracingServer(s *grpc.Server, srv TracingServer) {
 }
 
 func _Tracing_GetSpanRecordings_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(SpanRecordingRequest)
+	in := new(GetSpanRecordingsRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -188,7 +228,7 @@ func _Tracing_GetSpanRecordings_Handler(srv interface{}, ctx context.Context, de
 		FullMethod: "/cockroach.util.tracing.Tracing/GetSpanRecordings",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(TracingServer).GetSpanRecordings(ctx, req.(*SpanRecordingRequest))
+		return srv.(TracingServer).GetSpanRecordings(ctx, req.(*GetSpanRecordingsRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -206,7 +246,7 @@ var _Tracing_serviceDesc = grpc.ServiceDesc{
 	Metadata: "util/tracing/tracingservicepb/tracing_service.proto",
 }
 
-func (m *SpanRecordingRequest) Marshal() (dAtA []byte, err error) {
+func (m *GetSpanRecordingsRequest) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
@@ -216,12 +256,12 @@ func (m *SpanRecordingRequest) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *SpanRecordingRequest) MarshalTo(dAtA []byte) (int, error) {
+func (m *GetSpanRecordingsRequest) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
-func (m *SpanRecordingRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+func (m *GetSpanRecordingsRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
@@ -234,7 +274,7 @@ func (m *SpanRecordingRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-func (m *SpanRecordingResponse) Marshal() (dAtA []byte, err error) {
+func (m *GetSpanRecordingsResponse) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
@@ -244,20 +284,57 @@ func (m *SpanRecordingResponse) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *SpanRecordingResponse) MarshalTo(dAtA []byte) (int, error) {
+func (m *GetSpanRecordingsResponse) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
-func (m *SpanRecordingResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+func (m *GetSpanRecordingsResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.SpanRecordings) > 0 {
-		for iNdEx := len(m.SpanRecordings) - 1; iNdEx >= 0; iNdEx-- {
+	if len(m.Recordings) > 0 {
+		for iNdEx := len(m.Recordings) - 1; iNdEx >= 0; iNdEx-- {
 			{
-				size, err := m.SpanRecordings[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				size, err := m.Recordings[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintTracingService(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *GetSpanRecordingsResponse_Recording) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *GetSpanRecordingsResponse_Recording) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *GetSpanRecordingsResponse_Recording) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.RecordedSpans) > 0 {
+		for iNdEx := len(m.RecordedSpans) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.RecordedSpans[iNdEx].MarshalToSizedBuffer(dAtA[:i])
 				if err != nil {
 					return 0, err
 				}
@@ -282,7 +359,7 @@ func encodeVarintTracingService(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
-func (m *SpanRecordingRequest) Size() (n int) {
+func (m *GetSpanRecordingsRequest) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -294,14 +371,29 @@ func (m *SpanRecordingRequest) Size() (n int) {
 	return n
 }
 
-func (m *SpanRecordingResponse) Size() (n int) {
+func (m *GetSpanRecordingsResponse) Size() (n int) {
 	if m == nil {
 		return 0
 	}
 	var l int
 	_ = l
-	if len(m.SpanRecordings) > 0 {
-		for _, e := range m.SpanRecordings {
+	if len(m.Recordings) > 0 {
+		for _, e := range m.Recordings {
+			l = e.Size()
+			n += 1 + l + sovTracingService(uint64(l))
+		}
+	}
+	return n
+}
+
+func (m *GetSpanRecordingsResponse_Recording) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if len(m.RecordedSpans) > 0 {
+		for _, e := range m.RecordedSpans {
 			l = e.Size()
 			n += 1 + l + sovTracingService(uint64(l))
 		}
@@ -315,7 +407,7 @@ func sovTracingService(x uint64) (n int) {
 func sozTracingService(x uint64) (n int) {
 	return sovTracingService(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
-func (m *SpanRecordingRequest) Unmarshal(dAtA []byte) error {
+func (m *GetSpanRecordingsRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -338,10 +430,10 @@ func (m *SpanRecordingRequest) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: SpanRecordingRequest: wiretype end group for non-group")
+			return fmt.Errorf("proto: GetSpanRecordingsRequest: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: SpanRecordingRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: GetSpanRecordingsRequest: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
@@ -384,7 +476,7 @@ func (m *SpanRecordingRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *SpanRecordingResponse) Unmarshal(dAtA []byte) error {
+func (m *GetSpanRecordingsResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -407,15 +499,15 @@ func (m *SpanRecordingResponse) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: SpanRecordingResponse: wiretype end group for non-group")
+			return fmt.Errorf("proto: GetSpanRecordingsResponse: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: SpanRecordingResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: GetSpanRecordingsResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field SpanRecordings", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field Recordings", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -442,8 +534,92 @@ func (m *SpanRecordingResponse) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.SpanRecordings = append(m.SpanRecordings, tracingpb.RecordedSpan{})
-			if err := m.SpanRecordings[len(m.SpanRecordings)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			m.Recordings = append(m.Recordings, GetSpanRecordingsResponse_Recording{})
+			if err := m.Recordings[len(m.Recordings)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTracingService(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTracingService
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *GetSpanRecordingsResponse_Recording) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTracingService
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: Recording: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: Recording: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RecordedSpans", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTracingService
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthTracingService
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthTracingService
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.RecordedSpans = append(m.RecordedSpans, tracingpb.RecordedSpan{})
+			if err := m.RecordedSpans[len(m.RecordedSpans)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/pkg/util/tracing/tracingservicepb/tracing_service.proto
+++ b/pkg/util/tracing/tracingservicepb/tracing_service.proto
@@ -15,14 +15,19 @@ option go_package = "tracingservicepb";
 import "gogoproto/gogo.proto";
 import "util/tracing/tracingpb/recorded_span.proto";
 
-message SpanRecordingRequest {
+message GetSpanRecordingsRequest {
   uint64 trace_id = 1 [(gogoproto.customname) = "TraceID"];
 }
 
-message SpanRecordingResponse {
-  repeated tracing.tracingpb.RecordedSpan span_recordings = 1 [(gogoproto.nullable) = false];
+message GetSpanRecordingsResponse {
+  message Recording {
+    repeated tracing.tracingpb.RecordedSpan recorded_spans = 1 [(gogoproto.nullable) = false];
+  }
+  repeated Recording recordings = 1 [(gogoproto.nullable) = false];
 }
 
 service Tracing {
-  rpc GetSpanRecordings(SpanRecordingRequest) returns (SpanRecordingResponse) {}
+  // GetSpanRecordings contacts a nodes' inflight span registry to return the
+  // tracing.Recordings for each root span with a matching TraceID.
+  rpc GetSpanRecordings(GetSpanRecordingsRequest) returns (GetSpanRecordingsResponse) {}
 }


### PR DESCRIPTION
Previously, the trace collector was dialing up a node, visiting
all the root spans on the nodes inflight registry, and placing
`tracingpb.RecordedSpans` into a flat slice. This caused loss of
information about which spans belonged to a chain
rooted at a fixed root span. Such a chain is referred to as a
`tracing.Recording`. Every node can have multiple `tracing.Recording`s
with the same `trace_id`, and they each represent a traced remote
operation.

This change maintains the `tracing.Recording` grouping of spans
by getting the collector to return a `[]tracing.Recording` for each
node. The collectors' unit of iteration consequently becomes a
`tracing.Recording`. This makes more sense when you think about
how we want to consume these traces. Every `tracing.Recording` is
a new traced remote operation, and should be visualized as such in
Jaegar, JSON etc.

This change also augments the collector iterator to return the nodeID
of the node that the current `tracing.Recording` belongs too.

Informs: #64992

Release note: None