### PR TITLE
sql: Added pg_stat_database and pg_stat_database_conflicts

### DIFF
--- a/pkg/sql/catalog/catconstants/constants.go
+++ b/pkg/sql/catalog/catconstants/constants.go
@@ -249,6 +249,8 @@ const (
 	PgCatalogShdependTableID
 	PgCatalogShmemAllocationsTableID
 	PgCatalogStatActivityTableID
+	PgCatalogStatDatabaseConflictsTableID
+	PgCatalogStatDatabaseTableID
 	PgCatalogStatisticExtTableID
 	PgCatalogSubscriptionRelTableID
 	PgCatalogSubscriptionTableID

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -4592,6 +4592,68 @@ CREATE TABLE pg_catalog.pg_stat_activity (
    backend_type STRING NULL,
    leader_pid INT4 NULL
 )  {}  {}
+CREATE TABLE pg_catalog.pg_stat_database (
+   datid OID NULL,
+   datname NAME NULL,
+   numbackends INT4 NULL,
+   xact_commit INT8 NULL,
+   xact_rollback INT8 NULL,
+   blks_read INT8 NULL,
+   blks_hit INT8 NULL,
+   tup_returned INT8 NULL,
+   tup_fetched INT8 NULL,
+   tup_inserted INT8 NULL,
+   tup_updated INT8 NULL,
+   tup_deleted INT8 NULL,
+   conflicts INT8 NULL,
+   temp_files INT8 NULL,
+   temp_bytes INT8 NULL,
+   deadlocks INT8 NULL,
+   checksum_failures INT8 NULL,
+   checksum_last_failure TIMESTAMPTZ NULL,
+   blk_read_time FLOAT8 NULL,
+   blk_write_time FLOAT8 NULL,
+   stats_reset TIMESTAMPTZ NULL
+)  CREATE TABLE pg_catalog.pg_stat_database (
+   datid OID NULL,
+   datname NAME NULL,
+   numbackends INT4 NULL,
+   xact_commit INT8 NULL,
+   xact_rollback INT8 NULL,
+   blks_read INT8 NULL,
+   blks_hit INT8 NULL,
+   tup_returned INT8 NULL,
+   tup_fetched INT8 NULL,
+   tup_inserted INT8 NULL,
+   tup_updated INT8 NULL,
+   tup_deleted INT8 NULL,
+   conflicts INT8 NULL,
+   temp_files INT8 NULL,
+   temp_bytes INT8 NULL,
+   deadlocks INT8 NULL,
+   checksum_failures INT8 NULL,
+   checksum_last_failure TIMESTAMPTZ NULL,
+   blk_read_time FLOAT8 NULL,
+   blk_write_time FLOAT8 NULL,
+   stats_reset TIMESTAMPTZ NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_stat_database_conflicts (
+   datid OID NULL,
+   datname NAME NULL,
+   confl_tablespace INT8 NULL,
+   confl_lock INT8 NULL,
+   confl_snapshot INT8 NULL,
+   confl_bufferpin INT8 NULL,
+   confl_deadlock INT8 NULL
+)  CREATE TABLE pg_catalog.pg_stat_database_conflicts (
+   datid OID NULL,
+   datname NAME NULL,
+   confl_tablespace INT8 NULL,
+   confl_lock INT8 NULL,
+   confl_snapshot INT8 NULL,
+   confl_bufferpin INT8 NULL,
+   confl_deadlock INT8 NULL
+)  {}  {}
 CREATE TABLE pg_catalog.pg_statistic_ext (
    stxrelid OID NULL,
    stxstattarget INT4 NULL,

--- a/pkg/sql/logictest/testdata/logic_test/grant_table
+++ b/pkg/sql/logictest/testdata/logic_test/grant_table
@@ -382,6 +382,8 @@ test           pg_catalog          pg_shdescription                       public
 test           pg_catalog          pg_shmem_allocations                   public   SELECT
 test           pg_catalog          pg_shseclabel                          public   SELECT
 test           pg_catalog          pg_stat_activity                       public   SELECT
+test           pg_catalog          pg_stat_database                       public   SELECT
+test           pg_catalog          pg_stat_database_conflicts             public   SELECT
 test           pg_catalog          pg_statistic_ext                       public   SELECT
 test           pg_catalog          pg_subscription                        public   SELECT
 test           pg_catalog          pg_subscription_rel                    public   SELECT

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -610,6 +610,8 @@ pg_catalog          pg_shdescription
 pg_catalog          pg_shmem_allocations
 pg_catalog          pg_shseclabel
 pg_catalog          pg_stat_activity
+pg_catalog          pg_stat_database
+pg_catalog          pg_stat_database_conflicts
 pg_catalog          pg_statistic_ext
 pg_catalog          pg_subscription
 pg_catalog          pg_subscription_rel
@@ -881,6 +883,8 @@ pg_shdescription
 pg_shmem_allocations
 pg_shseclabel
 pg_stat_activity
+pg_stat_database
+pg_stat_database_conflicts
 pg_statistic_ext
 pg_subscription
 pg_subscription_rel
@@ -1187,6 +1191,8 @@ system         pg_catalog          pg_shdescription                       SYSTEM
 system         pg_catalog          pg_shmem_allocations                   SYSTEM VIEW  NO                  1
 system         pg_catalog          pg_shseclabel                          SYSTEM VIEW  NO                  1
 system         pg_catalog          pg_stat_activity                       SYSTEM VIEW  NO                  1
+system         pg_catalog          pg_stat_database                       SYSTEM VIEW  NO                  1
+system         pg_catalog          pg_stat_database_conflicts             SYSTEM VIEW  NO                  1
 system         pg_catalog          pg_statistic_ext                       SYSTEM VIEW  NO                  1
 system         pg_catalog          pg_subscription                        SYSTEM VIEW  NO                  1
 system         pg_catalog          pg_subscription_rel                    SYSTEM VIEW  NO                  1
@@ -2639,6 +2645,8 @@ NULL     public   system         pg_catalog          pg_shdescription           
 NULL     public   system         pg_catalog          pg_shmem_allocations                   SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_shseclabel                          SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_stat_activity                       SELECT          NULL          YES
+NULL     public   system         pg_catalog          pg_stat_database                       SELECT          NULL          YES
+NULL     public   system         pg_catalog          pg_stat_database_conflicts             SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_statistic_ext                       SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_subscription                        SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_subscription_rel                    SELECT          NULL          YES
@@ -3159,6 +3167,8 @@ NULL     public   system         pg_catalog          pg_shdescription           
 NULL     public   system         pg_catalog          pg_shmem_allocations                   SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_shseclabel                          SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_stat_activity                       SELECT          NULL          YES
+NULL     public   system         pg_catalog          pg_stat_database                       SELECT          NULL          YES
+NULL     public   system         pg_catalog          pg_stat_database_conflicts             SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_statistic_ext                       SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_subscription                        SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_subscription_rel                    SELECT          NULL          YES

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -88,6 +88,8 @@ pg_catalog  pg_shdescription                 table  NULL  NULL  NULL
 pg_catalog  pg_shmem_allocations             table  NULL  NULL  NULL
 pg_catalog  pg_shseclabel                    table  NULL  NULL  NULL
 pg_catalog  pg_stat_activity                 table  NULL  NULL  NULL
+pg_catalog  pg_stat_database                 table  NULL  NULL  NULL
+pg_catalog  pg_stat_database_conflicts       table  NULL  NULL  NULL
 pg_catalog  pg_statistic_ext                 table  NULL  NULL  NULL
 pg_catalog  pg_subscription                  table  NULL  NULL  NULL
 pg_catalog  pg_subscription_rel              table  NULL  NULL  NULL
@@ -204,6 +206,8 @@ pg_catalog  pg_shdescription                 table  NULL  NULL  NULL
 pg_catalog  pg_shmem_allocations             table  NULL  NULL  NULL
 pg_catalog  pg_shseclabel                    table  NULL  NULL  NULL
 pg_catalog  pg_stat_activity                 table  NULL  NULL  NULL
+pg_catalog  pg_stat_database                 table  NULL  NULL  NULL
+pg_catalog  pg_stat_database_conflicts       table  NULL  NULL  NULL
 pg_catalog  pg_statistic_ext                 table  NULL  NULL  NULL
 pg_catalog  pg_subscription                  table  NULL  NULL  NULL
 pg_catalog  pg_subscription_rel              table  NULL  NULL  NULL
@@ -1452,28 +1456,30 @@ oid         typname                                typnamespace  typowner    typ
 100072      _newtype1                              2332901747    1546506610  -1      false     b
 100073      newtype2                               2332901747    1546506610  -1      false     e
 100074      _newtype2                              2332901747    1546506610  -1      false     b
-4294967056  spatial_ref_sys                        3553698885    3233629770  -1      false     c
-4294967057  geometry_columns                       3553698885    3233629770  -1      false     c
-4294967058  geography_columns                      3553698885    3233629770  -1      false     c
-4294967060  pg_views                               1307062959    3233629770  -1      false     c
-4294967061  pg_user                                1307062959    3233629770  -1      false     c
-4294967062  pg_user_mappings                       1307062959    3233629770  -1      false     c
-4294967063  pg_user_mapping                        1307062959    3233629770  -1      false     c
-4294967064  pg_type                                1307062959    3233629770  -1      false     c
-4294967065  pg_ts_template                         1307062959    3233629770  -1      false     c
-4294967066  pg_ts_parser                           1307062959    3233629770  -1      false     c
-4294967067  pg_ts_dict                             1307062959    3233629770  -1      false     c
-4294967068  pg_ts_config                           1307062959    3233629770  -1      false     c
-4294967069  pg_ts_config_map                       1307062959    3233629770  -1      false     c
-4294967070  pg_trigger                             1307062959    3233629770  -1      false     c
-4294967071  pg_transform                           1307062959    3233629770  -1      false     c
-4294967072  pg_timezone_names                      1307062959    3233629770  -1      false     c
-4294967073  pg_timezone_abbrevs                    1307062959    3233629770  -1      false     c
-4294967074  pg_tablespace                          1307062959    3233629770  -1      false     c
-4294967075  pg_tables                              1307062959    3233629770  -1      false     c
-4294967076  pg_subscription                        1307062959    3233629770  -1      false     c
-4294967077  pg_subscription_rel                    1307062959    3233629770  -1      false     c
-4294967078  pg_statistic_ext                       1307062959    3233629770  -1      false     c
+4294967054  spatial_ref_sys                        3553698885    3233629770  -1      false     c
+4294967055  geometry_columns                       3553698885    3233629770  -1      false     c
+4294967056  geography_columns                      3553698885    3233629770  -1      false     c
+4294967058  pg_views                               1307062959    3233629770  -1      false     c
+4294967059  pg_user                                1307062959    3233629770  -1      false     c
+4294967060  pg_user_mappings                       1307062959    3233629770  -1      false     c
+4294967061  pg_user_mapping                        1307062959    3233629770  -1      false     c
+4294967062  pg_type                                1307062959    3233629770  -1      false     c
+4294967063  pg_ts_template                         1307062959    3233629770  -1      false     c
+4294967064  pg_ts_parser                           1307062959    3233629770  -1      false     c
+4294967065  pg_ts_dict                             1307062959    3233629770  -1      false     c
+4294967066  pg_ts_config                           1307062959    3233629770  -1      false     c
+4294967067  pg_ts_config_map                       1307062959    3233629770  -1      false     c
+4294967068  pg_trigger                             1307062959    3233629770  -1      false     c
+4294967069  pg_transform                           1307062959    3233629770  -1      false     c
+4294967070  pg_timezone_names                      1307062959    3233629770  -1      false     c
+4294967071  pg_timezone_abbrevs                    1307062959    3233629770  -1      false     c
+4294967072  pg_tablespace                          1307062959    3233629770  -1      false     c
+4294967073  pg_tables                              1307062959    3233629770  -1      false     c
+4294967074  pg_subscription                        1307062959    3233629770  -1      false     c
+4294967075  pg_subscription_rel                    1307062959    3233629770  -1      false     c
+4294967076  pg_statistic_ext                       1307062959    3233629770  -1      false     c
+4294967077  pg_stat_database                       1307062959    3233629770  -1      false     c
+4294967078  pg_stat_database_conflicts             1307062959    3233629770  -1      false     c
 4294967079  pg_stat_activity                       1307062959    3233629770  -1      false     c
 4294967080  pg_shmem_allocations                   1307062959    3233629770  -1      false     c
 4294967081  pg_shdepend                            1307062959    3233629770  -1      false     c
@@ -1785,28 +1791,30 @@ oid         typname                                typcategory  typispreferred  
 100072      _newtype1                              A            false           true          ,         0           100071   0
 100073      newtype2                               E            false           true          ,         0           0        100074
 100074      _newtype2                              A            false           true          ,         0           100073   0
-4294967056  spatial_ref_sys                        C            false           true          ,         4294967056  0        0
-4294967057  geometry_columns                       C            false           true          ,         4294967057  0        0
-4294967058  geography_columns                      C            false           true          ,         4294967058  0        0
-4294967060  pg_views                               C            false           true          ,         4294967060  0        0
-4294967061  pg_user                                C            false           true          ,         4294967061  0        0
-4294967062  pg_user_mappings                       C            false           true          ,         4294967062  0        0
-4294967063  pg_user_mapping                        C            false           true          ,         4294967063  0        0
-4294967064  pg_type                                C            false           true          ,         4294967064  0        0
-4294967065  pg_ts_template                         C            false           true          ,         4294967065  0        0
-4294967066  pg_ts_parser                           C            false           true          ,         4294967066  0        0
-4294967067  pg_ts_dict                             C            false           true          ,         4294967067  0        0
-4294967068  pg_ts_config                           C            false           true          ,         4294967068  0        0
-4294967069  pg_ts_config_map                       C            false           true          ,         4294967069  0        0
-4294967070  pg_trigger                             C            false           true          ,         4294967070  0        0
-4294967071  pg_transform                           C            false           true          ,         4294967071  0        0
-4294967072  pg_timezone_names                      C            false           true          ,         4294967072  0        0
-4294967073  pg_timezone_abbrevs                    C            false           true          ,         4294967073  0        0
-4294967074  pg_tablespace                          C            false           true          ,         4294967074  0        0
-4294967075  pg_tables                              C            false           true          ,         4294967075  0        0
-4294967076  pg_subscription                        C            false           true          ,         4294967076  0        0
-4294967077  pg_subscription_rel                    C            false           true          ,         4294967077  0        0
-4294967078  pg_statistic_ext                       C            false           true          ,         4294967078  0        0
+4294967054  spatial_ref_sys                        C            false           true          ,         4294967054  0        0
+4294967055  geometry_columns                       C            false           true          ,         4294967055  0        0
+4294967056  geography_columns                      C            false           true          ,         4294967056  0        0
+4294967058  pg_views                               C            false           true          ,         4294967058  0        0
+4294967059  pg_user                                C            false           true          ,         4294967059  0        0
+4294967060  pg_user_mappings                       C            false           true          ,         4294967060  0        0
+4294967061  pg_user_mapping                        C            false           true          ,         4294967061  0        0
+4294967062  pg_type                                C            false           true          ,         4294967062  0        0
+4294967063  pg_ts_template                         C            false           true          ,         4294967063  0        0
+4294967064  pg_ts_parser                           C            false           true          ,         4294967064  0        0
+4294967065  pg_ts_dict                             C            false           true          ,         4294967065  0        0
+4294967066  pg_ts_config                           C            false           true          ,         4294967066  0        0
+4294967067  pg_ts_config_map                       C            false           true          ,         4294967067  0        0
+4294967068  pg_trigger                             C            false           true          ,         4294967068  0        0
+4294967069  pg_transform                           C            false           true          ,         4294967069  0        0
+4294967070  pg_timezone_names                      C            false           true          ,         4294967070  0        0
+4294967071  pg_timezone_abbrevs                    C            false           true          ,         4294967071  0        0
+4294967072  pg_tablespace                          C            false           true          ,         4294967072  0        0
+4294967073  pg_tables                              C            false           true          ,         4294967073  0        0
+4294967074  pg_subscription                        C            false           true          ,         4294967074  0        0
+4294967075  pg_subscription_rel                    C            false           true          ,         4294967075  0        0
+4294967076  pg_statistic_ext                       C            false           true          ,         4294967076  0        0
+4294967077  pg_stat_database                       C            false           true          ,         4294967077  0        0
+4294967078  pg_stat_database_conflicts             C            false           true          ,         4294967078  0        0
 4294967079  pg_stat_activity                       C            false           true          ,         4294967079  0        0
 4294967080  pg_shmem_allocations                   C            false           true          ,         4294967080  0        0
 4294967081  pg_shdepend                            C            false           true          ,         4294967081  0        0
@@ -2118,28 +2126,30 @@ oid         typname                                typinput        typoutput    
 100072      _newtype1                              array_in        array_out        array_recv        array_send        0         0          0
 100073      newtype2                               enum_in         enum_out         enum_recv         enum_send         0         0          0
 100074      _newtype2                              array_in        array_out        array_recv        array_send        0         0          0
-4294967056  spatial_ref_sys                        record_in       record_out       record_recv       record_send       0         0          0
-4294967057  geometry_columns                       record_in       record_out       record_recv       record_send       0         0          0
-4294967058  geography_columns                      record_in       record_out       record_recv       record_send       0         0          0
-4294967060  pg_views                               record_in       record_out       record_recv       record_send       0         0          0
-4294967061  pg_user                                record_in       record_out       record_recv       record_send       0         0          0
-4294967062  pg_user_mappings                       record_in       record_out       record_recv       record_send       0         0          0
-4294967063  pg_user_mapping                        record_in       record_out       record_recv       record_send       0         0          0
-4294967064  pg_type                                record_in       record_out       record_recv       record_send       0         0          0
-4294967065  pg_ts_template                         record_in       record_out       record_recv       record_send       0         0          0
-4294967066  pg_ts_parser                           record_in       record_out       record_recv       record_send       0         0          0
-4294967067  pg_ts_dict                             record_in       record_out       record_recv       record_send       0         0          0
-4294967068  pg_ts_config                           record_in       record_out       record_recv       record_send       0         0          0
-4294967069  pg_ts_config_map                       record_in       record_out       record_recv       record_send       0         0          0
-4294967070  pg_trigger                             record_in       record_out       record_recv       record_send       0         0          0
-4294967071  pg_transform                           record_in       record_out       record_recv       record_send       0         0          0
-4294967072  pg_timezone_names                      record_in       record_out       record_recv       record_send       0         0          0
-4294967073  pg_timezone_abbrevs                    record_in       record_out       record_recv       record_send       0         0          0
-4294967074  pg_tablespace                          record_in       record_out       record_recv       record_send       0         0          0
-4294967075  pg_tables                              record_in       record_out       record_recv       record_send       0         0          0
-4294967076  pg_subscription                        record_in       record_out       record_recv       record_send       0         0          0
-4294967077  pg_subscription_rel                    record_in       record_out       record_recv       record_send       0         0          0
-4294967078  pg_statistic_ext                       record_in       record_out       record_recv       record_send       0         0          0
+4294967054  spatial_ref_sys                        record_in       record_out       record_recv       record_send       0         0          0
+4294967055  geometry_columns                       record_in       record_out       record_recv       record_send       0         0          0
+4294967056  geography_columns                      record_in       record_out       record_recv       record_send       0         0          0
+4294967058  pg_views                               record_in       record_out       record_recv       record_send       0         0          0
+4294967059  pg_user                                record_in       record_out       record_recv       record_send       0         0          0
+4294967060  pg_user_mappings                       record_in       record_out       record_recv       record_send       0         0          0
+4294967061  pg_user_mapping                        record_in       record_out       record_recv       record_send       0         0          0
+4294967062  pg_type                                record_in       record_out       record_recv       record_send       0         0          0
+4294967063  pg_ts_template                         record_in       record_out       record_recv       record_send       0         0          0
+4294967064  pg_ts_parser                           record_in       record_out       record_recv       record_send       0         0          0
+4294967065  pg_ts_dict                             record_in       record_out       record_recv       record_send       0         0          0
+4294967066  pg_ts_config                           record_in       record_out       record_recv       record_send       0         0          0
+4294967067  pg_ts_config_map                       record_in       record_out       record_recv       record_send       0         0          0
+4294967068  pg_trigger                             record_in       record_out       record_recv       record_send       0         0          0
+4294967069  pg_transform                           record_in       record_out       record_recv       record_send       0         0          0
+4294967070  pg_timezone_names                      record_in       record_out       record_recv       record_send       0         0          0
+4294967071  pg_timezone_abbrevs                    record_in       record_out       record_recv       record_send       0         0          0
+4294967072  pg_tablespace                          record_in       record_out       record_recv       record_send       0         0          0
+4294967073  pg_tables                              record_in       record_out       record_recv       record_send       0         0          0
+4294967074  pg_subscription                        record_in       record_out       record_recv       record_send       0         0          0
+4294967075  pg_subscription_rel                    record_in       record_out       record_recv       record_send       0         0          0
+4294967076  pg_statistic_ext                       record_in       record_out       record_recv       record_send       0         0          0
+4294967077  pg_stat_database                       record_in       record_out       record_recv       record_send       0         0          0
+4294967078  pg_stat_database_conflicts             record_in       record_out       record_recv       record_send       0         0          0
 4294967079  pg_stat_activity                       record_in       record_out       record_recv       record_send       0         0          0
 4294967080  pg_shmem_allocations                   record_in       record_out       record_recv       record_send       0         0          0
 4294967081  pg_shdepend                            record_in       record_out       record_recv       record_send       0         0          0
@@ -2451,28 +2461,30 @@ oid         typname                                typalign  typstorage  typnotn
 100072      _newtype1                              NULL      NULL        false       0            -1
 100073      newtype2                               NULL      NULL        false       0            -1
 100074      _newtype2                              NULL      NULL        false       0            -1
-4294967056  spatial_ref_sys                        NULL      NULL        false       0            -1
-4294967057  geometry_columns                       NULL      NULL        false       0            -1
-4294967058  geography_columns                      NULL      NULL        false       0            -1
-4294967060  pg_views                               NULL      NULL        false       0            -1
-4294967061  pg_user                                NULL      NULL        false       0            -1
-4294967062  pg_user_mappings                       NULL      NULL        false       0            -1
-4294967063  pg_user_mapping                        NULL      NULL        false       0            -1
-4294967064  pg_type                                NULL      NULL        false       0            -1
-4294967065  pg_ts_template                         NULL      NULL        false       0            -1
-4294967066  pg_ts_parser                           NULL      NULL        false       0            -1
-4294967067  pg_ts_dict                             NULL      NULL        false       0            -1
-4294967068  pg_ts_config                           NULL      NULL        false       0            -1
-4294967069  pg_ts_config_map                       NULL      NULL        false       0            -1
-4294967070  pg_trigger                             NULL      NULL        false       0            -1
-4294967071  pg_transform                           NULL      NULL        false       0            -1
-4294967072  pg_timezone_names                      NULL      NULL        false       0            -1
-4294967073  pg_timezone_abbrevs                    NULL      NULL        false       0            -1
-4294967074  pg_tablespace                          NULL      NULL        false       0            -1
-4294967075  pg_tables                              NULL      NULL        false       0            -1
-4294967076  pg_subscription                        NULL      NULL        false       0            -1
-4294967077  pg_subscription_rel                    NULL      NULL        false       0            -1
-4294967078  pg_statistic_ext                       NULL      NULL        false       0            -1
+4294967054  spatial_ref_sys                        NULL      NULL        false       0            -1
+4294967055  geometry_columns                       NULL      NULL        false       0            -1
+4294967056  geography_columns                      NULL      NULL        false       0            -1
+4294967058  pg_views                               NULL      NULL        false       0            -1
+4294967059  pg_user                                NULL      NULL        false       0            -1
+4294967060  pg_user_mappings                       NULL      NULL        false       0            -1
+4294967061  pg_user_mapping                        NULL      NULL        false       0            -1
+4294967062  pg_type                                NULL      NULL        false       0            -1
+4294967063  pg_ts_template                         NULL      NULL        false       0            -1
+4294967064  pg_ts_parser                           NULL      NULL        false       0            -1
+4294967065  pg_ts_dict                             NULL      NULL        false       0            -1
+4294967066  pg_ts_config                           NULL      NULL        false       0            -1
+4294967067  pg_ts_config_map                       NULL      NULL        false       0            -1
+4294967068  pg_trigger                             NULL      NULL        false       0            -1
+4294967069  pg_transform                           NULL      NULL        false       0            -1
+4294967070  pg_timezone_names                      NULL      NULL        false       0            -1
+4294967071  pg_timezone_abbrevs                    NULL      NULL        false       0            -1
+4294967072  pg_tablespace                          NULL      NULL        false       0            -1
+4294967073  pg_tables                              NULL      NULL        false       0            -1
+4294967074  pg_subscription                        NULL      NULL        false       0            -1
+4294967075  pg_subscription_rel                    NULL      NULL        false       0            -1
+4294967076  pg_statistic_ext                       NULL      NULL        false       0            -1
+4294967077  pg_stat_database                       NULL      NULL        false       0            -1
+4294967078  pg_stat_database_conflicts             NULL      NULL        false       0            -1
 4294967079  pg_stat_activity                       NULL      NULL        false       0            -1
 4294967080  pg_shmem_allocations                   NULL      NULL        false       0            -1
 4294967081  pg_shdepend                            NULL      NULL        false       0            -1
@@ -2784,28 +2796,30 @@ oid         typname                                typndims  typcollation  typde
 100072      _newtype1                              0         0             NULL           NULL        NULL
 100073      newtype2                               0         0             NULL           NULL        NULL
 100074      _newtype2                              0         0             NULL           NULL        NULL
-4294967056  spatial_ref_sys                        0         0             NULL           NULL        NULL
-4294967057  geometry_columns                       0         0             NULL           NULL        NULL
-4294967058  geography_columns                      0         0             NULL           NULL        NULL
-4294967060  pg_views                               0         0             NULL           NULL        NULL
-4294967061  pg_user                                0         0             NULL           NULL        NULL
-4294967062  pg_user_mappings                       0         0             NULL           NULL        NULL
-4294967063  pg_user_mapping                        0         0             NULL           NULL        NULL
-4294967064  pg_type                                0         0             NULL           NULL        NULL
-4294967065  pg_ts_template                         0         0             NULL           NULL        NULL
-4294967066  pg_ts_parser                           0         0             NULL           NULL        NULL
-4294967067  pg_ts_dict                             0         0             NULL           NULL        NULL
-4294967068  pg_ts_config                           0         0             NULL           NULL        NULL
-4294967069  pg_ts_config_map                       0         0             NULL           NULL        NULL
-4294967070  pg_trigger                             0         0             NULL           NULL        NULL
-4294967071  pg_transform                           0         0             NULL           NULL        NULL
-4294967072  pg_timezone_names                      0         0             NULL           NULL        NULL
-4294967073  pg_timezone_abbrevs                    0         0             NULL           NULL        NULL
-4294967074  pg_tablespace                          0         0             NULL           NULL        NULL
-4294967075  pg_tables                              0         0             NULL           NULL        NULL
-4294967076  pg_subscription                        0         0             NULL           NULL        NULL
-4294967077  pg_subscription_rel                    0         0             NULL           NULL        NULL
-4294967078  pg_statistic_ext                       0         0             NULL           NULL        NULL
+4294967054  spatial_ref_sys                        0         0             NULL           NULL        NULL
+4294967055  geometry_columns                       0         0             NULL           NULL        NULL
+4294967056  geography_columns                      0         0             NULL           NULL        NULL
+4294967058  pg_views                               0         0             NULL           NULL        NULL
+4294967059  pg_user                                0         0             NULL           NULL        NULL
+4294967060  pg_user_mappings                       0         0             NULL           NULL        NULL
+4294967061  pg_user_mapping                        0         0             NULL           NULL        NULL
+4294967062  pg_type                                0         0             NULL           NULL        NULL
+4294967063  pg_ts_template                         0         0             NULL           NULL        NULL
+4294967064  pg_ts_parser                           0         0             NULL           NULL        NULL
+4294967065  pg_ts_dict                             0         0             NULL           NULL        NULL
+4294967066  pg_ts_config                           0         0             NULL           NULL        NULL
+4294967067  pg_ts_config_map                       0         0             NULL           NULL        NULL
+4294967068  pg_trigger                             0         0             NULL           NULL        NULL
+4294967069  pg_transform                           0         0             NULL           NULL        NULL
+4294967070  pg_timezone_names                      0         0             NULL           NULL        NULL
+4294967071  pg_timezone_abbrevs                    0         0             NULL           NULL        NULL
+4294967072  pg_tablespace                          0         0             NULL           NULL        NULL
+4294967073  pg_tables                              0         0             NULL           NULL        NULL
+4294967074  pg_subscription                        0         0             NULL           NULL        NULL
+4294967075  pg_subscription_rel                    0         0             NULL           NULL        NULL
+4294967076  pg_statistic_ext                       0         0             NULL           NULL        NULL
+4294967077  pg_stat_database                       0         0             NULL           NULL        NULL
+4294967078  pg_stat_database_conflicts             0         0             NULL           NULL        NULL
 4294967079  pg_stat_activity                       0         0             NULL           NULL        NULL
 4294967080  pg_shmem_allocations                   0         0             NULL           NULL        NULL
 4294967081  pg_shdepend                            0         0             NULL           NULL        NULL
@@ -3436,28 +3450,30 @@ objoid      classoid    objsubid  description
 4294967080  4294967138  0         pg_shmem_allocations was created for compatibility and is currently unimplemented
 4294967082  4294967138  0         shared security labels (empty - feature not supported)
 4294967079  4294967138  0         backend access statistics (empty - monitoring works differently in CockroachDB)
-4294967078  4294967138  0         pg_statistic_ext was created for compatibility and is currently unimplemented
-4294967076  4294967138  0         pg_subscription was created for compatibility and is currently unimplemented
-4294967077  4294967138  0         pg_subscription_rel was created for compatibility and is currently unimplemented
-4294967075  4294967138  0         tables summary (see also information_schema.tables, pg_catalog.pg_class)
-4294967074  4294967138  0         available tablespaces (incomplete; concept inapplicable to CockroachDB)
-4294967073  4294967138  0         pg_timezone_abbrevs was created for compatibility and is currently unimplemented
-4294967072  4294967138  0         pg_timezone_names was created for compatibility and is currently unimplemented
-4294967071  4294967138  0         pg_transform was created for compatibility and is currently unimplemented
-4294967070  4294967138  0         triggers (empty - feature does not exist)
-4294967068  4294967138  0         pg_ts_config was created for compatibility and is currently unimplemented
-4294967069  4294967138  0         pg_ts_config_map was created for compatibility and is currently unimplemented
-4294967067  4294967138  0         pg_ts_dict was created for compatibility and is currently unimplemented
-4294967066  4294967138  0         pg_ts_parser was created for compatibility and is currently unimplemented
-4294967065  4294967138  0         pg_ts_template was created for compatibility and is currently unimplemented
-4294967064  4294967138  0         scalar types (incomplete)
-4294967061  4294967138  0         database users
-4294967063  4294967138  0         local to remote user mapping (empty - feature does not exist)
-4294967062  4294967138  0         pg_user_mappings was created for compatibility and is currently unimplemented
-4294967060  4294967138  0         view definitions (incomplete - see also information_schema.views)
-4294967058  4294967138  0         Shows all defined geography columns. Matches PostGIS' geography_columns functionality.
-4294967057  4294967138  0         Shows all defined geometry columns. Matches PostGIS' geometry_columns functionality.
-4294967056  4294967138  0         Shows all defined Spatial Reference Identifiers (SRIDs). Matches PostGIS' spatial_ref_sys table.
+4294967077  4294967138  0         pg_stat_database was created for compatibility and is currently unimplemented
+4294967078  4294967138  0         pg_stat_database_conflicts was created for compatibility and is currently unimplemented
+4294967076  4294967138  0         pg_statistic_ext was created for compatibility and is currently unimplemented
+4294967074  4294967138  0         pg_subscription was created for compatibility and is currently unimplemented
+4294967075  4294967138  0         pg_subscription_rel was created for compatibility and is currently unimplemented
+4294967073  4294967138  0         tables summary (see also information_schema.tables, pg_catalog.pg_class)
+4294967072  4294967138  0         available tablespaces (incomplete; concept inapplicable to CockroachDB)
+4294967071  4294967138  0         pg_timezone_abbrevs was created for compatibility and is currently unimplemented
+4294967070  4294967138  0         pg_timezone_names was created for compatibility and is currently unimplemented
+4294967069  4294967138  0         pg_transform was created for compatibility and is currently unimplemented
+4294967068  4294967138  0         triggers (empty - feature does not exist)
+4294967066  4294967138  0         pg_ts_config was created for compatibility and is currently unimplemented
+4294967067  4294967138  0         pg_ts_config_map was created for compatibility and is currently unimplemented
+4294967065  4294967138  0         pg_ts_dict was created for compatibility and is currently unimplemented
+4294967064  4294967138  0         pg_ts_parser was created for compatibility and is currently unimplemented
+4294967063  4294967138  0         pg_ts_template was created for compatibility and is currently unimplemented
+4294967062  4294967138  0         scalar types (incomplete)
+4294967059  4294967138  0         database users
+4294967061  4294967138  0         local to remote user mapping (empty - feature does not exist)
+4294967060  4294967138  0         pg_user_mappings was created for compatibility and is currently unimplemented
+4294967058  4294967138  0         view definitions (incomplete - see also information_schema.views)
+4294967056  4294967138  0         Shows all defined geography columns. Matches PostGIS' geography_columns functionality.
+4294967055  4294967138  0         Shows all defined geometry columns. Matches PostGIS' geometry_columns functionality.
+4294967054  4294967138  0         Shows all defined Spatial Reference Identifiers (SRIDs). Matches PostGIS' spatial_ref_sys table.
 
 ## pg_catalog.pg_shdescription
 
@@ -4653,7 +4669,7 @@ indoption
 query TTI
 SELECT database_name, descriptor_name, descriptor_id from test.crdb_internal.create_statements where descriptor_name = 'pg_views'
 ----
-test  pg_views  4294967060
+test  pg_views  4294967058
 
 # Verify INCLUDED columns appear in pg_index. See issue #59563
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/table
+++ b/pkg/sql/logictest/testdata/logic_test/table
@@ -758,6 +758,8 @@ pg_shdescription                       NULL
 pg_shmem_allocations                   NULL
 pg_shseclabel                          NULL
 pg_stat_activity                       NULL
+pg_stat_database                       NULL
+pg_stat_database_conflicts             NULL
 pg_statistic_ext                       NULL
 pg_subscription                        NULL
 pg_subscription_rel                    NULL

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -91,8 +91,6 @@ var pgCatalog = virtualSchema{
 		"pg_stat_all_tables",
 		"pg_stat_archiver",
 		"pg_stat_bgwriter",
-		"pg_stat_database",
-		"pg_stat_database_conflicts",
 		"pg_stat_progress_vacuum",
 		"pg_stat_replication",
 		"pg_stat_ssl",
@@ -191,6 +189,8 @@ var pgCatalog = virtualSchema{
 		catconstants.PgCatalogShdependTableID:                   pgCatalogShdependTable,
 		catconstants.PgCatalogShmemAllocationsTableID:           pgCatalogShmemAllocationsTable,
 		catconstants.PgCatalogStatActivityTableID:               pgCatalogStatActivityTable,
+		catconstants.PgCatalogStatDatabaseConflictsTableID:      pgCatalogStatDatabaseConflictsTable,
+		catconstants.PgCatalogStatDatabaseTableID:               pgCatalogStatDatabaseTable,
 		catconstants.PgCatalogStatisticExtTableID:               pgCatalogStatisticExtTable,
 		catconstants.PgCatalogSubscriptionRelTableID:            pgCatalogSubscriptionRelTable,
 		catconstants.PgCatalogSubscriptionTableID:               pgCatalogSubscriptionTable,
@@ -3086,6 +3086,24 @@ https://www.postgresql.org/docs/13/view-pg-sequences.html
 			},
 		)
 	},
+}
+
+var pgCatalogStatDatabaseTable = virtualSchemaTable{
+	comment: "pg_stat_database was created for compatibility and is currently unimplemented",
+	schema:  vtable.PgCatalogStatDatabase,
+	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
+		return nil
+	},
+	unimplemented: true,
+}
+
+var pgCatalogStatDatabaseConflictsTable = virtualSchemaTable{
+	comment: "pg_stat_database_conflicts was created for compatibility and is currently unimplemented",
+	schema:  vtable.PgCatalogStatDatabaseConflicts,
+	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
+		return nil
+	},
+	unimplemented: true,
 }
 
 // typOid is the only OID generation approach that does not use oidHasher, because

--- a/pkg/sql/testdata/pg_catalog_tables_from_postgres.json
+++ b/pkg/sql/testdata/pg_catalog_tables_from_postgres.json
@@ -1,5 +1,12 @@
 {
-  "pgVersion": "13.2",
+  "pgVersion": "13.3",
+  "diffSummary": {
+    "TotalTables": 0,
+    "TotalColumns": 0,
+    "MissingTables": 0,
+    "MissingColumns": 0,
+    "DatatypeMismatches": 0
+  },
   "pgMetadata": {
     "pg_aggregate": {
       "aggcombinefn": {
@@ -3653,6 +3660,178 @@
       "provider": {
         "oid": 25,
         "dataType": "text",
+        "expectedOid": null,
+        "expectedDataType": null
+      }
+    },
+    "pg_stat_database": {
+      "blk_read_time": {
+        "oid": 701,
+        "dataType": "float8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "blk_write_time": {
+        "oid": 701,
+        "dataType": "float8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "blks_hit": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "blks_read": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "checksum_failures": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "checksum_last_failure": {
+        "oid": 1184,
+        "dataType": "timestamptz",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "conflicts": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "datid": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "datname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "deadlocks": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "numbackends": {
+        "oid": 23,
+        "dataType": "int4",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "stats_reset": {
+        "oid": 1184,
+        "dataType": "timestamptz",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "temp_bytes": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "temp_files": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "tup_deleted": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "tup_fetched": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "tup_inserted": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "tup_returned": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "tup_updated": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "xact_commit": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "xact_rollback": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      }
+    },
+    "pg_stat_database_conflicts": {
+      "confl_bufferpin": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "confl_deadlock": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "confl_lock": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "confl_snapshot": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "confl_tablespace": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "datid": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "datname": {
+        "oid": 19,
+        "dataType": "name",
         "expectedOid": null,
         "expectedDataType": null
       }

--- a/pkg/sql/testdata/postgres_test_expected_diffs_on_pg_catalog.json
+++ b/pkg/sql/testdata/postgres_test_expected_diffs_on_pg_catalog.json
@@ -1,11 +1,11 @@
 {
-  "pgVersion": "13.2",
+  "pgVersion": "13.3",
   "diffSummary": {
-    "TotalTables": 88,
-    "TotalColumns": 725,
+    "TotalTables": 90,
+    "TotalColumns": 753,
     "MissingTables": 0,
     "MissingColumns": 1,
-    "DatatypeMismatches": 35
+    "DatatypeMismatches": 18
   },
   "pgMetadata": {
     "pg_am": {
@@ -18,20 +18,6 @@
     },
     "pg_attribute": {
       "attmissingval": null
-    },
-    "pg_class": {
-      "relfrozenxid": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": 26,
-        "expectedDataType": "OID"
-      },
-      "relminmxid": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": 26,
-        "expectedDataType": "OID"
-      }
     },
     "pg_collation": {
       "collcollate": {
@@ -51,32 +37,6 @@
         "dataType": "text",
         "expectedOid": 19,
         "expectedDataType": "name"
-      }
-    },
-    "pg_constraint": {
-      "confdeltype": {
-        "oid": 25,
-        "dataType": "text",
-        "expectedOid": 18,
-        "expectedDataType": "char"
-      },
-      "confmatchtype": {
-        "oid": 25,
-        "dataType": "text",
-        "expectedOid": 18,
-        "expectedDataType": "char"
-      },
-      "confupdtype": {
-        "oid": 25,
-        "dataType": "text",
-        "expectedOid": 18,
-        "expectedDataType": "char"
-      },
-      "contype": {
-        "oid": 25,
-        "dataType": "text",
-        "expectedOid": 18,
-        "expectedDataType": "char"
       }
     },
     "pg_conversion": {
@@ -99,18 +59,6 @@
         "dataType": "text",
         "expectedOid": 19,
         "expectedDataType": "name"
-      },
-      "datfrozenxid": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": 26,
-        "expectedDataType": "OID"
-      },
-      "datminmxid": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": 26,
-        "expectedDataType": "OID"
       }
     },
     "pg_enum": {
@@ -135,14 +83,6 @@
         "expectedDataType": "_oid"
       }
     },
-    "pg_locks": {
-      "transactionid": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": 26,
-        "expectedDataType": "OID"
-      }
-    },
     "pg_operator": {
       "oprcode": {
         "oid": 26,
@@ -156,33 +96,11 @@
         "expectedOid": 24,
         "expectedDataType": "regproc"
       },
-      "oprkind": {
-        "oid": 25,
-        "dataType": "text",
-        "expectedOid": 18,
-        "expectedDataType": "char"
-      },
       "oprrest": {
         "oid": 26,
         "dataType": "oid",
         "expectedOid": 24,
         "expectedDataType": "regproc"
-      }
-    },
-    "pg_prepared_xacts": {
-      "transaction": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": 26,
-        "expectedDataType": "OID"
-      }
-    },
-    "pg_proc": {
-      "proargmodes": {
-        "oid": 1009,
-        "dataType": "_text",
-        "expectedOid": 1002,
-        "expectedDataType": "_char"
       }
     },
     "pg_range": {
@@ -199,34 +117,6 @@
         "expectedDataType": "regproc"
       }
     },
-    "pg_replication_slots": {
-      "catalog_xmin": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": 26,
-        "expectedDataType": "OID"
-      },
-      "xmin": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": 26,
-        "expectedDataType": "OID"
-      }
-    },
-    "pg_rewrite": {
-      "ev_enabled": {
-        "oid": 25,
-        "dataType": "text",
-        "expectedOid": 18,
-        "expectedDataType": "char"
-      },
-      "ev_type": {
-        "oid": 25,
-        "dataType": "text",
-        "expectedOid": 18,
-        "expectedDataType": "char"
-      }
-    },
     "pg_seclabel": {
       "objsubid": {
         "oid": 20,
@@ -241,14 +131,6 @@
         "dataType": "text",
         "expectedOid": 1009,
         "expectedDataType": "_text"
-      }
-    },
-    "pg_trigger": {
-      "tgenabled": {
-        "oid": 25,
-        "dataType": "text",
-        "expectedOid": 18,
-        "expectedDataType": "char"
       }
     },
     "pg_user": {

--- a/pkg/sql/vtable/pg_catalog.go
+++ b/pkg/sql/vtable/pg_catalog.go
@@ -1370,3 +1370,41 @@ CREATE TABLE pg_catalog.pg_subscription_rel (
 	srsublsn STRING,
 	srsubstate "char"
 )`
+
+//PgCatalogStatDatabase is an empty table in the pg_catalog that is not implemented yet
+const PgCatalogStatDatabase = `
+CREATE TABLE pg_catalog.pg_stat_database (
+	datid OID,
+	datname NAME,
+	numbackends INT4,
+	xact_commit INT,
+  xact_rollback INT,
+	blks_read INT,
+	blks_hit INT,
+	tup_returned INT,
+	tup_fetched INT,
+	tup_inserted INT,
+	tup_updated INT,
+	tup_deleted INT,
+	conflicts INT,
+	temp_files INT,
+	temp_bytes INT,
+	deadlocks INT,
+	checksum_failures INT,
+	checksum_last_failure TIMESTAMPTZ,
+	blk_read_time FLOAT,
+	blk_write_time FLOAT,
+	stats_reset TIMESTAMPTZ
+)`
+
+//PgCatalogStatDatabaseConflicts is an empty table in the pg_catalog that is not implemented yet
+const PgCatalogStatDatabaseConflicts = `
+CREATE TABLE pg_catalog.pg_stat_database_conflicts (
+  datid OID,
+  datname NAME,
+  confl_tablespace INT,
+  confl_lock INT,
+	confl_snapshot INT,
+	confl_bufferpin INT,
+	confl_deadlock INT
+)`


### PR DESCRIPTION
Previously, pg_stat_database and pg_stat_database_conflicts were not
included in pg_catalog
This was inadequate because not having these tables causes
compatibility issues
To address this, this patch adds these tables as empty and not
implemented tables.

Release note (sql change): Added pg_stat_database and
pg_stat_database_conflicts on pg_catalog

Fixes #26400, #26399