### PR TITLE
build: fix double %% in date formatting

### DIFF
--- a/build/teamcity-weekly-roachtest.sh
+++ b/build/teamcity-weekly-roachtest.sh
@@ -30,7 +30,7 @@ fi
 
 chmod +x cockroach.linux-2.6.32-gnu-amd64
 
-artifacts=$PWD/artifacts/$(date +"%%Y%%m%%d")-${TC_BUILD_ID}
+artifacts=$PWD/artifacts/$(date +"%Y%m%d")-${TC_BUILD_ID}
 mkdir -p "$artifacts"
 # See https://github.com/cockroachdb/cockroach/issues/54570#issuecomment-706324593
 chmod o+rwx "${artifacts}"
@@ -41,7 +41,7 @@ chmod o+rwx "${artifacts}"
 # kill with SIGINT which will allow roachtest to fail tests and
 # cleanup.
 #
-# NB(2): We specify --zones below so that nodes are created in us-central1-b 
+# NB(2): We specify --zones below so that nodes are created in us-central1-b
 # by default. This reserves us-east1-b (the roachprod default zone) for use
 # by manually created clusters.
 exit_status=0


### PR DESCRIPTION
I believe these were likely the result of `%` needing to be escaped
when the script was specified directly in teamcity.

I'm not sure if this is actually causing any problems, but it at least
produces confusing directory names:

```
total 12
drwxr-xrwx  5 root  root  4096 Jun 22 09:21 %Y%m%d-3105291
drwxr-xr-x  3 root  root  4096 Jun 22 08:18 .
drwxrwxrwt 18 agent agent 4096 Jun 22 08:18 ..
```
Release note: None