### PR TITLE
roachtest: bump predecessor to v21.1.3

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1239,7 +1239,7 @@ func PredecessorVersion(buildVersion version.Version) (string, error) {
 	// (see runVersionUpgrade). The same is true for adding a new key to this
 	// map.
 	verMap := map[string]string{
-		"21.2": "21.1.2",
+		"21.2": "21.1.3",
 		"21.1": "20.2.10",
 		"20.2": "20.1.16",
 		"20.1": "19.2.11",


### PR DESCRIPTION
Release note: None
