### PR TITLE
release-20.2: kvserver: respect draining status on a node for lease transfers with …

### DIFF
--- a/pkg/kv/kvserver/allocator.go
+++ b/pkg/kv/kvserver/allocator.go
@@ -829,7 +829,12 @@ func (a *Allocator) TransferLeaseTarget(
 		if preferred[0].StoreID == leaseStoreID {
 			return roachpb.ReplicaDescriptor{}
 		}
-		return preferred[0]
+		// Verify that the preferred replica is eligible to receive the lease.
+		preferred, _ = a.storePool.liveAndDeadReplicas(preferred)
+		if len(preferred) == 1 {
+			return preferred[0]
+		}
+		return roachpb.ReplicaDescriptor{}
 	} else if len(preferred) > 1 {
 		// If the current leaseholder is not preferred, set checkTransferLeaseSource
 		// to false to motivate the below logic to transfer the lease.


### PR DESCRIPTION
Backport 1/1 commits from #66385.

/cc @cockroachdb/release

---

…lease preferences

Fixes #66103

Lease transfer logic in the allocator did not consider the health of
the node when transferring a lease from a node outside of preference
to a node inside of preference. This would have prevented a node with
a lease preference from draining gracefully, as it would shed leases
and then get them back.

Release note (bug fix): Allows a node with lease preferences to drain
gracefully.
