### PR TITLE
ccl: add stub-schema-registry

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -94,6 +94,7 @@
 /pkg/ccl/buildccl/           @cockroachdb/dev-inf
 /pkg/ccl/cliccl/             @cockroachdb/cli-prs
 /pkg/ccl/cmdccl/enc_utils/   @cockroachdb/storage
+/pkg/ccl/cmdccl/stub-schema-registry/ @cockroachdb/cdc-prs
 /pkg/ccl/gssapiccl/          @cockroachdb/sql-queries
 /pkg/ccl/kvccl/              @cockroachdb/kv-noreview
 /pkg/ccl/logictestccl/       @cockroachdb/sql-queries-noreview

--- a/pkg/ccl/cmdccl/stub-schema-registry/BUILD.bazel
+++ b/pkg/ccl/cmdccl/stub-schema-registry/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "stub-schema-registry_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/ccl/cmdccl/stub-schema-registry",
+    visibility = ["//visibility:private"],
+    deps = ["//pkg/ccl/changefeedccl/cdctest"],
+)
+
+go_binary(
+    name = "stub-schema-registry",
+    embed = [":stub-schema-registry_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/ccl/cmdccl/stub-schema-registry/main.go
+++ b/pkg/ccl/cmdccl/stub-schema-registry/main.go
@@ -1,0 +1,30 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdctest"
+)
+
+func main() {
+	reg := cdctest.StartTestSchemaRegistry()
+	defer reg.Close()
+
+	fmt.Printf("Stub Schema Registry listening at %s\n", reg.URL())
+
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+
+	sig := <-c
+	fmt.Printf("Shutting down on signal: %s\n", sig)
+}


### PR DESCRIPTION
Occasionally it is nice to be able to start a "good enough" schema
registry to manually test avro-formatted changefeeds.

Release note: None