### PR TITLE
cmd: mention kv-triage for kv-owned roachtests

### DIFF
--- a/pkg/cmd/github-post/main.go
+++ b/pkg/cmd/github-post/main.go
@@ -56,7 +56,7 @@ func defaultFormatter(ctx context.Context, f failure) (issues.IssueFormatter, is
 	if len(teams) > 0 {
 		projColID = teams[0].TriageColumnID
 		for _, team := range teams {
-			mentions = append(mentions, "@"+string(team.Aliases[0]))
+			mentions = append(mentions, "@"+string(team.Name()))
 		}
 	}
 	return issues.UnitTestFormatter, issues.PostRequest{

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -876,8 +876,7 @@ func (r *testRunner) maybePostGithubIssue(
 	if err != nil {
 		t.Fatalf("could not load teams: %v", err)
 	}
-	alias := ownerToAlias(t.spec.Owner)
-	owner := teams[ownerToAlias(t.spec.Owner)]
+	team := teams[ownerToAlias(t.spec.Owner)]
 
 	branch := "<unknown branch>"
 	if b := os.Getenv("TC_BUILD_BRANCH"); b != "" {
@@ -897,8 +896,8 @@ func (r *testRunner) maybePostGithubIssue(
 
 	req := issues.PostRequest{
 		AuthorEmail:     "", // intentionally unset - we add to the board and cc the team
-		Mention:         []string{"@" + string(alias)},
-		ProjectColumnID: owner.TriageColumnID,
+		Mention:         []string{"@" + string(team.Name())},
+		ProjectColumnID: team.TriageColumnID,
 		PackageName:     "roachtest",
 		TestName:        t.Name(),
 		Message:         msg,


### PR DESCRIPTION
Looks like we were only doing it for unittests. See #66720 for a recent
example.

Release note: None