### PR TITLE
release-21.1: roachprod: update to recommended ubuntu focal image

### DIFF
--- a/pkg/cmd/roachprod/vm/gce/gcloud.go
+++ b/pkg/cmd/roachprod/vm/gce/gcloud.go
@@ -273,7 +273,7 @@ func (o *providerOpts) ConfigureCreateFlags(flags *pflag.FlagSet) {
 		"Machine type (see https://cloud.google.com/compute/docs/machine-types)")
 	flags.StringVar(&o.MinCPUPlatform, ProviderName+"-min-cpu-platform", "",
 		"Minimum CPU platform (see https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform)")
-	flags.StringVar(&o.Image, ProviderName+"-image", "ubuntu-2004-focal-v20210325",
+	flags.StringVar(&o.Image, ProviderName+"-image", "ubuntu-2004-focal-v20210603",
 		"Image to use to create the vm, "+
 			"use `gcloud compute images list --filter=\"family=ubuntu-2004-lts\"` to list available images")
 


### PR DESCRIPTION
Backport 1/1 commits from #66498.

Closes #66183

/cc @cockroachdb/release

---

The previous version was deprecated -- see #66183 for context.

Release note: None
