### PR TITLE
importccl: fix panic when importing CSV with virtual columns

### DIFF
--- a/pkg/ccl/importccl/csv_internal_test.go
+++ b/pkg/ccl/importccl/csv_internal_test.go
@@ -50,6 +50,10 @@ func TestMakeSimpleTableDescriptorErrors(t *testing.T) {
 			error: `this IMPORT format does not support foreign keys`,
 		},
 		{
+			stmt:  "create table a (i int, j int as (i + 10) virtual)",
+			error: `to import into a table with virtual computed columns, use IMPORT INTO`,
+		},
+		{
 			stmt: `create table a (
 				i int check (i > 0),
 				b int default 1,

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -4499,12 +4499,28 @@ INSERT INTO users (a, b) VALUES (1, 2), (3, 4);
 			expectedError: "to use computed columns, use IMPORT INTO",
 		},
 		{
+			into:          false,
+			name:          "import-table-csv-virtual",
+			data:          "35,23\n67,10",
+			create:        "a INT, c INT AS (a + b) VIRTUAL, b INT",
+			format:        "CSV",
+			expectedError: "to import into a table with virtual computed columns, use IMPORT INTO",
+		},
+		{
 			into:            false,
 			name:            "import-table-avro",
 			data:            avroData,
 			create:          "a INT, c INT AS (a + b) STORED, b INT",
 			format:          "AVRO",
 			expectedResults: [][]string{{"1", "3", "2"}, {"3", "7", "4"}},
+		},
+		{
+			into:          false,
+			name:          "import-table-avro-virtual",
+			data:          avroData,
+			create:        "a INT, c INT AS (a + b) VIRTUAL, b INT",
+			format:        "AVRO",
+			expectedError: "to import into a table with virtual computed columns, use IMPORT INTO",
 		},
 		{
 			into:            false,

--- a/pkg/ccl/importccl/import_table_creation.go
+++ b/pkg/ccl/importccl/import_table_creation.go
@@ -126,6 +126,11 @@ func MakeSimpleTableDescriptor(
 			*tree.UniqueConstraintTableDef:
 			// ignore
 		case *tree.ColumnTableDef:
+			if def.IsComputed() && def.IsVirtual() {
+				return nil, unimplemented.NewWithIssueDetail(56002, "import.computed",
+					"to import into a table with virtual computed columns, use IMPORT INTO")
+			}
+
 			if err := sql.SimplifySerialInColumnDefWithRowID(ctx, def, &create.Table); err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Previously, `IMPORT TABLE` would panic for a CSV import when the table
included a virtual computed column. This was caused by empty
`SessionData` being passed to `sql.NewTableDesc` in
`importccl.MakeSimpleTableDescriptor` which consults session data to
determine if all nodes in the cluster are running a version that
supports virtual computed columns.

This commit fixes the issue by returning an error in
`importccl.MakeSimpleTableDescriptor` before calling `sql.NewTableDesc`
if the `IMPORT TABLE` statement specifies a virtual computed
column. This is acceptable behavior because stored computed columns are
also not supported in the `IMPORT TABLE` statement.

Fixes #66694

Release note (bug fix): A bug has been fixed which caused internal
errors when running an `IMPORT TABLE` statement with a virtual computed
column to import a CSV file. This bug has been present since virtual
computed columns were introduced in version 21.1.0.