### PR TITLE
ui: remove styling width calculation from multiple bars

### DIFF
--- a/pkg/ui/cluster-ui/src/barCharts/barCharts.module.scss
+++ b/pkg/ui/cluster-ui/src/barCharts/barCharts.module.scss
@@ -14,7 +14,6 @@
   }
 
   &__multiplebars {
-    width: calc(100% - 75px);
     border-radius: 3px;
     position: relative;
     display: flex;


### PR DESCRIPTION
Previously, we had a width calculation on multiple bars to style
It needed to be removed in ordered for the multiple bars to show up
Removed the styling on width to default to auto

Release note (ui): remove styling width calculation from multiple bars

Before: 
![Screen Shot 2021-06-22 at 1 31 50 PM](https://user-images.githubusercontent.com/17861665/122995311-53212600-d35e-11eb-9e24-6a1ad3733d33.png)
After:
![Screen Shot 2021-06-22 at 1 26 17 PM](https://user-images.githubusercontent.com/17861665/122995336-5a483400-d35e-11eb-8ae7-4d570b4cb6b6.png)
Jira: [CC-4422](https://cockroachlabs.atlassian.net/browse/CC-4422)