### PR TITLE
ui: remove width styling on multi bar

### DIFF
--- a/pkg/ui/cluster-ui/src/barCharts/barCharts.module.scss
+++ b/pkg/ui/cluster-ui/src/barCharts/barCharts.module.scss
@@ -14,7 +14,6 @@
   }
 
   &__multiplebars {
-    width: calc(100% - 75px);
     border-radius: 3px;
     position: relative;
     display: flex;


### PR DESCRIPTION
Previously a width styling calc was on the multi bar
This calc prevented it from being visible
Remove width styling on multi bar

Release note (ui): remove width styling on multi bar

Related PR: https://github.com/cockroachdb/cockroach/pull/66734