### PR TITLE
ui: remove width styling calc on multibar

### DIFF
--- a/pkg/ui/cluster-ui/src/barCharts/barCharts.module.scss
+++ b/pkg/ui/cluster-ui/src/barCharts/barCharts.module.scss
@@ -14,7 +14,6 @@
   }
 
   &__multiplebars {
-    width: calc(100% - 75px);
     border-radius: 3px;
     position: relative;
     display: flex;


### PR DESCRIPTION
Multibar had a width calc style
This was causing the multibar to not be visible
Removed the width style to make it visible

Release note (ui): remove width styling calc on multibar

Related PR: https://github.com/cockroachdb/cockroach/pull/66734