### PR TITLE
roachtest: improve multi-region TPC-C tests

### DIFF
--- a/pkg/cmd/roachtest/chaos.go
+++ b/pkg/cmd/roachtest/chaos.go
@@ -81,7 +81,7 @@ func (ch *Chaos) Runner(c cluster.Cluster, m *monitor) func(context.Context) err
 			period, downTime := ch.Timer.Timing()
 
 			target := ch.Target()
-			m.ExpectDeath()
+			m.ExpectDeaths(int32(len(target)))
 
 			if ch.DrainAndQuit {
 				l.Printf("stopping and draining %v\n", target)

--- a/pkg/cmd/roachtest/option/node_list_option.go
+++ b/pkg/cmd/roachtest/option/node_list_option.go
@@ -22,6 +22,16 @@ import (
 // assigned 1, the second 2, and so on.
 type NodeListOption []int
 
+// NewNodeListOptionRange returns a NodeListOption between start and end
+// inclusive.
+func NewNodeListOptionRange(start, end int) NodeListOption {
+	ret := make(NodeListOption, (end-start)+1)
+	for i := 0; i <= (end - start); i++ {
+		ret[i] = start + i
+	}
+	return ret
+}
+
 // Option implements Option.
 func (n NodeListOption) Option() {}
 

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -55,6 +55,11 @@ type tpccOptions struct {
 	Duration         time.Duration               // if zero, TPCC is not invoked
 	SetupType        tpccSetupType
 	PrometheusConfig *prometheus.Config
+	// WorkloadInstances contains a list of instances for
+	// workloads to run against.
+	// If unset, it will run one workload which talks to
+	// all cluster nodes.
+	WorkloadInstances []workloadInstance
 	// If specified, called to stage+start cockroach. If not
 	// specified, defaults to uploading the default binary to
 	// all nodes, and starting it on all but the last node.
@@ -64,6 +69,19 @@ type tpccOptions struct {
 	// is running, but that feels like jamming too much into the tpcc setup.
 	Start func(context.Context, test.Test, cluster.Cluster)
 }
+
+type workloadInstance struct {
+	// nodes dictates the nodes workload should run against.
+	nodes option.NodeListOption
+	// prometheusPort is the port on the workload which runs
+	// prometheus.
+	prometheusPort int
+	// extraRunArgs dictates unique arguments to use for the workload.
+	extraRunArgs string
+}
+
+const workloadPProfStartPort = 33333
+const workloadPrometheusPort = 2112
 
 // tpccImportCmd generates the command string to load tpcc data for the
 // specified warehouse count into a cluster.
@@ -138,6 +156,21 @@ func setupTPCC(
 }
 
 func runTPCC(ctx context.Context, t test.Test, c cluster.Cluster, opts tpccOptions) {
+	workloadInstances := opts.WorkloadInstances
+	if len(workloadInstances) == 0 {
+		workloadInstances = append(
+			workloadInstances,
+			workloadInstance{
+				nodes:          c.Range(1, c.Spec().NodeCount-1),
+				prometheusPort: workloadPrometheusPort,
+			},
+		)
+	}
+	var pgURLs []string
+	for _, workloadInstance := range workloadInstances {
+		pgURLs = append(pgURLs, fmt.Sprintf("{pgurl%s}", workloadInstance.nodes.String()))
+	}
+
 	if cfg := opts.PrometheusConfig; cfg != nil {
 		if c.IsLocal() {
 			t.Skip("skipping test as prometheus is needed, but prometheus does not yet work locally")
@@ -184,15 +217,26 @@ func runTPCC(ctx context.Context, t test.Test, c cluster.Cluster, opts tpccOptio
 	crdbNodes, workloadNode := setupTPCC(ctx, t, c, opts)
 	t.Status("waiting")
 	m := newMonitor(ctx, c, crdbNodes)
-	m.Go(func(ctx context.Context) error {
-		t.WorkerStatus("running tpcc")
-		cmd := fmt.Sprintf(
-			"./cockroach workload run tpcc --warehouses=%d --histograms="+perfArtifactsDir+"/stats.json "+
-				opts.ExtraRunArgs+" --ramp=%s --duration=%s {pgurl:1-%d}",
-			opts.Warehouses, rampDuration, opts.Duration, c.Spec().NodeCount-1)
-		c.Run(ctx, workloadNode, cmd)
-		return nil
-	})
+	for i := range workloadInstances {
+		// Make a copy of i for the goroutine.
+		i := i
+		m.Go(func(ctx context.Context) error {
+			t.WorkerStatus(fmt.Sprintf("running tpcc idx %d on %s", i, pgURLs[i]))
+			cmd := fmt.Sprintf(
+				"./cockroach workload run tpcc --warehouses=%d --histograms="+perfArtifactsDir+"/stats.json "+
+					opts.ExtraRunArgs+" --ramp=%s --duration=%s --prometheus-port=%d --pprofport=%d %s %s",
+				opts.Warehouses,
+				rampDuration,
+				opts.Duration,
+				workloadInstances[i].prometheusPort,
+				workloadPProfStartPort+i,
+				workloadInstances[i].extraRunArgs,
+				pgURLs[i],
+			)
+			c.Run(ctx, workloadNode, cmd)
+			return nil
+		})
+	}
 	if opts.Chaos != nil {
 		chaos := opts.Chaos()
 		m.Go(chaos.Runner(c, m))
@@ -392,71 +436,167 @@ func registerTPCC(r *testRegistry) {
 		},
 	})
 
-	for _, survivalGoal := range []string{"zone", "region"} {
-		zs := []string{
-			"us-east1-b", "us-west1-b", "europe-west2-b",
+	// Setup multi-region tests.
+	{
+		mrSetup := []struct {
+			region string
+			zones  string
+		}{
+			{region: "us-east1", zones: "us-east1-b"},
+			{region: "us-west1", zones: "us-west1-b"},
+			{region: "europe-west2", zones: "europe-west2-b"},
 		}
-		regions := []string{
-			"us-east1",
-			"us-west1",
-			"europe-west2",
+		zs := []string{}
+		// NOTE: region is currently only used for number of regions.
+		regions := []string{}
+		for _, s := range mrSetup {
+			regions = append(regions, s.region)
+			zs = append(zs, s.zones)
 		}
-		r.Add(TestSpec{
-			Name:       fmt.Sprintf("tpcc/multiregion/survive=%s/chaos=true", survivalGoal),
-			Owner:      OwnerMultiRegion,
-			MinVersion: "v21.1.0",
-			// 3 nodes per region + 1 node for workload.
-			Cluster: r.makeClusterSpec(10, spec.Geo(), spec.Zones(strings.Join(zs, ","))),
-			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-				duration := 90 * time.Minute
-				partitionArgs := fmt.Sprintf(
-					`--survival-goal=%s --regions=%s --partitions=%d`,
-					survivalGoal,
-					strings.Join(regions, ","),
-					len(regions),
-				)
-				workloadNode := c.Node(c.Spec().NodeCount)
+		const nodesPerRegion = 3
 
-				// TODO(#multiregion): setup workload to run specifically for a given partition
-				// on each node of a cluster, instead of one node using a workload on all clusters.
-				runTPCC(ctx, t, c, tpccOptions{
-					Warehouses:     len(regions) * 5,
-					Duration:       duration,
-					ExtraSetupArgs: partitionArgs,
-					ExtraRunArgs:   `--method=simple --wait=false --tolerate-errors ` + partitionArgs,
-					Chaos: func() Chaos {
-						return Chaos{
-							Timer: Periodic{
-								Period:   300 * time.Second,
-								DownTime: 300 * time.Second,
+		multiRegionTests := []struct {
+			desc              string
+			name              string
+			survivalGoal      string
+			chaosTarget       func(iter int) option.NodeListOption
+			workloadInstances []workloadInstance
+		}{
+			{
+				desc:         "test zone survivability works when single nodes are down",
+				name:         "tpcc/multiregion/survive=zone/chaos=true",
+				survivalGoal: "zone",
+				chaosTarget: func(iter int) option.NodeListOption {
+					return option.NodeListOption{(iter % (len(regions) * nodesPerRegion)) + 1}
+				},
+				workloadInstances: func() []workloadInstance {
+					const prometheusPortStart = 2110
+					ret := []workloadInstance{}
+					for i := 0; i < len(regions)*nodesPerRegion; i++ {
+						ret = append(
+							ret,
+							workloadInstance{
+								nodes:          option.NodeListOption{i + 1}, // 1-indexed
+								prometheusPort: prometheusPortStart + i,
+								extraRunArgs:   fmt.Sprintf("--partition-affinity=%d", i/nodesPerRegion), // 0-indexed
 							},
-							Target:       func() option.NodeListOption { return c.Node(1 + rand.Intn(c.Spec().NodeCount-1)) },
-							Stopper:      time.After(duration),
-							DrainAndQuit: false,
-						}
-					},
-					SetupType: usingInit,
-					PrometheusConfig: &prometheus.Config{
-						PrometheusNode: workloadNode,
-						ScrapeConfigs: []prometheus.ScrapeConfig{
-							prometheus.MakeInsecureCockroachScrapeConfig(
-								"cockroach",
-								c.Range(1, c.Spec().NodeCount-1),
-							),
-							prometheus.MakeWorkloadScrapeConfig(
-								"workload",
-								[]prometheus.ScrapeNode{
-									{
-										Nodes: workloadNode,
-										Port:  2112,
-									},
-								},
-							),
-						},
-					},
-				})
+						)
+					}
+					return ret
+				}(),
 			},
-		})
+			{
+				desc:         "test region survivability works when regions going down",
+				name:         "tpcc/multiregion/survive=region/chaos=true",
+				survivalGoal: "region",
+				chaosTarget: func(iter int) option.NodeListOption {
+					regionIdx := iter % len(regions)
+					return option.NewNodeListOptionRange(
+						(nodesPerRegion*regionIdx)+1,
+						(nodesPerRegion * (regionIdx + 1)),
+					)
+				},
+				workloadInstances: func() []workloadInstance {
+					// We run two sets of workloads:
+					// * for each region, have a workload that speaks SQL which only affects data
+					//   that is partitioned in the same region.
+					// * for each region, have a workload that speaks SQL which affects data
+					//   that is partitioned into a different region.
+					const prometheusLocalPortStart = 2110
+					const prometheusRemotePortStart = 2120
+					ret := []workloadInstance{}
+					for i := 0; i < len(regions); i++ {
+						// Data partitioned in the same region.
+						// e.g. nodes 1-3, partition-affinity=0, prometheus port 2111 means
+						// we talk to nodes 1-3, with nodes partitioned in nodes 1-3 (affinity 0).
+						ret = append(
+							ret,
+							workloadInstance{
+								nodes:          option.NewNodeListOptionRange((i*nodesPerRegion)+1, ((i + 1) * nodesPerRegion)), // 1-indexed
+								prometheusPort: prometheusLocalPortStart + i,
+								extraRunArgs:   fmt.Sprintf("--partition-affinity=%d", i-1), // 0-indexed
+							},
+						)
+						// Data partitioned in a different region.
+						// e.g. nodes 1-3, partition-affinity=1, prometheus port 2121 means
+						// we talk to nodes 1-3, with nodes partitioned in nodes 3-6 (affinity 1).
+						ret = append(
+							ret,
+							workloadInstance{
+								nodes:          option.NewNodeListOptionRange((i*nodesPerRegion)+1, ((i + 1) * nodesPerRegion)), // 1-indexed
+								prometheusPort: prometheusRemotePortStart + i,
+								extraRunArgs:   fmt.Sprintf("--partition-affinity=%d", i%len(regions)), // 0-indexed
+							},
+						)
+					}
+					return ret
+				}(),
+			},
+		}
+
+		for i := range multiRegionTests {
+			tc := multiRegionTests[i]
+			r.Add(TestSpec{
+				Name:       tc.name,
+				Owner:      OwnerMultiRegion,
+				MinVersion: "v21.1.0",
+				// Add an extra node which serves as the workload nodes.
+				Cluster: r.makeClusterSpec(len(regions)*nodesPerRegion+1, spec.Geo(), spec.Zones(strings.Join(zs, ","))),
+				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+					t.Status(tc.desc)
+					duration := 90 * time.Minute
+					partitionArgs := fmt.Sprintf(
+						`--survival-goal=%s --regions=%s --partitions=%d`,
+						tc.survivalGoal,
+						strings.Join(regions, ","),
+						len(regions),
+					)
+					workloadNode := c.Node(c.Spec().NodeCount)
+					workloadScrapeNodes := make([]prometheus.ScrapeNode, len(tc.workloadInstances))
+					for i, workloadInstance := range tc.workloadInstances {
+						workloadScrapeNodes[i] = prometheus.ScrapeNode{
+							Nodes: workloadNode,
+							Port:  workloadInstance.prometheusPort,
+						}
+					}
+
+					iter := 0
+					runTPCC(ctx, t, c, tpccOptions{
+						Warehouses:     len(regions) * 5,
+						Duration:       duration,
+						ExtraSetupArgs: partitionArgs,
+						ExtraRunArgs:   `--method=simple --wait=false --tolerate-errors ` + partitionArgs,
+						Chaos: func() Chaos {
+							return Chaos{
+								Timer: Periodic{
+									Period:   300 * time.Second,
+									DownTime: 300 * time.Second,
+								},
+								Target: func() option.NodeListOption {
+									ret := tc.chaosTarget(iter)
+									iter++
+									return ret
+								},
+								Stopper:      time.After(duration),
+								DrainAndQuit: false,
+							}
+						},
+						SetupType:         usingInit,
+						WorkloadInstances: tc.workloadInstances,
+						PrometheusConfig: &prometheus.Config{
+							PrometheusNode: workloadNode,
+							ScrapeConfigs: []prometheus.ScrapeConfig{
+								prometheus.MakeInsecureCockroachScrapeConfig(
+									"cockroach",
+									c.Range(1, c.Spec().NodeCount-1),
+								),
+								prometheus.MakeWorkloadScrapeConfig("workload", workloadScrapeNodes),
+							},
+						},
+					})
+				},
+			})
+		}
 	}
 
 	r.Add(TestSpec{


### PR DESCRIPTION
This commit changes the multi-region roachtests to target survivability
better, whilst also outputting better metrics. In particular:

* Region survivability now tests shutting down an entire region.
  Workloads now only target one region at a time, with a test for
  cross-region queries.
* Zone survivability now tests shut down one node at a time.
* Added prometheus metrics which can be observed by the snapshot or
  during test invocation.

Release note: None