### PR TITLE
release-21.1: respect --external-io-disabled on SQL nodes

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -88,6 +88,10 @@ type TestServerArgs struct {
 	// ExternalIODir is used to initialize field in cluster.Settings.
 	ExternalIODir string
 
+	// ExternalIODirConfig is used to initialize the same-named
+	// field on the server.Config struct.
+	ExternalIODirConfig ExternalIODirConfig
+
 	// Fields copied to the server.Config.
 	Insecure                    bool
 	RetryOptions                retry.Options // TODO(tbg): make testing knob.

--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -258,4 +258,8 @@ type TestTenantArgs struct {
 	// TempStorageConfig is used to configure temp storage, which stores
 	// ephemeral data when processing large queries.
 	TempStorageConfig *TempStorageConfig
+
+	// ExternalIODirConfig is used to initialize the same-named
+	// field on the server.Config struct.
+	ExternalIODirConfig ExternalIODirConfig
 }

--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -124,6 +124,7 @@ go_test(
         "//pkg/ccl/changefeedccl/changefeedbase",
         "//pkg/ccl/changefeedccl/kvfeed",
         "//pkg/ccl/importccl",
+        "//pkg/ccl/kvccl/kvtenantccl",
         "//pkg/ccl/multiregionccl",
         "//pkg/ccl/partitionccl",
         "//pkg/ccl/storageccl",

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -29,6 +29,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdctest"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
+	// Imported to allow multi-tenant tests
+	_ "github.com/cockroachdb/cockroach/pkg/ccl/kvccl/kvtenantccl"
 	// Imported to allow locality-related table mutations
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/multiregionccl"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/partitionccl"
@@ -163,6 +165,78 @@ func TestChangefeedDiff(t *testing.T) {
 	t.Run(`sinkless`, sinklessTest(testFn))
 	t.Run(`enterprise`, enterpriseTest(testFn))
 	t.Run(`cloudstorage`, cloudStorageTest(testFn))
+}
+
+func TestChangefeedTenants(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	defer changefeedbase.TestingSetDefaultFlushFrequency(testSinkFlushFrequency)()
+
+	kvServer, kvSQLdb, _ := serverutils.StartServer(t, base.TestServerArgs{
+		ExternalIODirConfig: base.ExternalIODirConfig{
+			DisableOutbound: true,
+		},
+	})
+	defer kvServer.Stopper().Stop(ctx)
+
+	tenantArgs := base.TestTenantArgs{
+		// crdb_internal.create_tenant called by StartTenant
+		TenantID: serverutils.TestTenantID(),
+		// Non-enterprise changefeeds are currently only
+		// disabled by setting DisableOutbound true
+		// everywhere.
+		ExternalIODirConfig: base.ExternalIODirConfig{
+			DisableOutbound: true,
+		},
+	}
+
+	tenantServer, tenantDB := serverutils.StartTenant(t, kvServer, tenantArgs)
+	tenantSQL := sqlutils.MakeSQLRunner(tenantDB)
+	// TODO(ssd): Cleanup this shared setup code once the refactor
+	// in #64693 is setttled.
+	tenantSQL.Exec(t, `SET CLUSTER SETTING kv.rangefeed.enabled = true`)
+	tenantSQL.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'`)
+	tenantSQL.Exec(t, `SET CLUSTER SETTING changefeed.experimental_poll_interval = '10ms'`)
+
+	// Database `d` is hardcoded in a number of places. Create it
+	// and create a new connection to that database.
+	tenantSQL.Exec(t, `CREATE DATABASE d`)
+	tenantSQL = sqlutils.MakeSQLRunner(
+		serverutils.OpenDBConn(t,
+			tenantServer.SQLAddr(), `d`, false /* insecure */, kvServer.Stopper()))
+	tenantSQL.Exec(t, `CREATE TABLE foo_in_tenant (pk INT PRIMARY KEY)`)
+
+	t.Run("changefeed on non-tenant table fails", func(t *testing.T) {
+		kvSQL := sqlutils.MakeSQLRunner(kvSQLdb)
+		kvSQL.Exec(t, `CREATE DATABASE d`)
+		kvSQL.Exec(t, `CREATE TABLE d.foo (pk INT PRIMARY KEY)`)
+
+		tenantSQL.ExpectErr(t, `table "foo" does not exist`,
+			`CREATE CHANGEFEED FOR foo`,
+		)
+	})
+	t.Run("sinkful changefeed fails", func(t *testing.T) {
+		tenantSQL.ExpectErr(t, "Outbound IO is disabled by configuration, cannot create changefeed into kafka",
+			`CREATE CHANGEFEED FOR foo_in_tenant INTO 'kafka://does-not-matter'`,
+		)
+	})
+	t.Run("sinkless changefeed works", func(t *testing.T) {
+		sqlAddr := tenantServer.SQLAddr()
+		sink, cleanup := sqlutils.PGUrl(t, sqlAddr, t.Name(), url.User(security.RootUser))
+		defer cleanup()
+
+		// kvServer is used here because we require a
+		// TestServerInterface implementor. It is only used as
+		// the return value for f.Server()
+		f := cdctest.MakeSinklessFeedFactory(kvServer, sink)
+		tenantSQL.Exec(t, `INSERT INTO foo_in_tenant VALUES (1)`)
+		feed := feed(t, f, `CREATE CHANGEFEED FOR foo_in_tenant`)
+		assertPayloads(t, feed, []string{
+			`foo_in_tenant: [1]->{"after": {"pk": 1}}`,
+		})
+	})
 }
 
 func TestChangefeedEnvelope(t *testing.T) {

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -499,6 +499,53 @@ func TestChangefeedUserDefinedTypes(t *testing.T) {
 	t.Run(`enterprise`, enterpriseTest(testFn))
 }
 
+func TestChangefeedExternalIODisabled(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	t.Run("sinkful changefeeds not allowed with disabled external io", func(t *testing.T) {
+		disallowedSinkProtos := []string{
+			changefeedbase.SinkSchemeExperimentalSQL,
+			changefeedbase.SinkSchemeKafka,
+			// Cloud sink schemes
+			"experimental-s3",
+			"experimental-gs",
+			"experimental-nodelocal",
+			"experimental-http",
+			"experimental-https",
+			"experimental-azure",
+		}
+		ctx := context.Background()
+		s, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+			ExternalIODirConfig: base.ExternalIODirConfig{
+				DisableOutbound: true,
+			},
+		})
+		defer s.Stopper().Stop(ctx)
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		sqlDB.Exec(t, "CREATE TABLE target_table (pk INT PRIMARY KEY)")
+		for _, proto := range disallowedSinkProtos {
+			sqlDB.ExpectErr(t, "Outbound IO is disabled by configuration, cannot create changefeed",
+				"CREATE CHANGEFEED FOR target_table INTO $1",
+				fmt.Sprintf("%s://does-not-matter", proto),
+			)
+		}
+	})
+
+	withDisabledOutbound := func(args *base.TestServerArgs) { args.ExternalIODirConfig.DisableOutbound = true }
+	t.Run("sinkless changfeeds are allowed with disabled external io",
+		sinklessTestWithServerArgs(withDisabledOutbound,
+			func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
+				sqlDB := sqlutils.MakeSQLRunner(db)
+				sqlDB.Exec(t, "CREATE TABLE target_table (pk INT PRIMARY KEY)")
+				sqlDB.Exec(t, "INSERT INTO target_table VALUES (1)")
+				feed := feed(t, f, "CREATE CHANGEFEED FOR target_table")
+				defer closeFeed(t, feed)
+				assertPayloads(t, feed, []string{
+					`target_table: [1]->{"after": {"pk": 1}}`,
+				})
+			}))
+}
+
 // Test how Changefeeds react to schema changes that do not require a backfill
 // operation.
 func TestChangefeedSchemaChangeNoBackfill(t *testing.T) {

--- a/pkg/ccl/serverccl/server_sql_test.go
+++ b/pkg/ccl/serverccl/server_sql_test.go
@@ -51,7 +51,7 @@ func TestSQLServer(t *testing.T) {
 	_, db := serverutils.StartTenant(
 		t,
 		tc.Server(0),
-		base.TestTenantArgs{TenantID: roachpb.MakeTenantID(security.EmbeddedTenantIDs()[0])},
+		base.TestTenantArgs{TenantID: serverutils.TestTenantID()},
 	)
 	defer db.Close()
 	r := sqlutils.MakeSQLRunner(db)
@@ -74,7 +74,7 @@ func TestTenantCannotSetClusterSetting(t *testing.T) {
 	defer tc.Stopper().Stop(ctx)
 
 	// StartTenant with the default permissions to
-	_, db := serverutils.StartTenant(t, tc.Server(0), base.TestTenantArgs{TenantID: roachpb.MakeTenantID(10), AllowSettingClusterSettings: false})
+	_, db := serverutils.StartTenant(t, tc.Server(0), base.TestTenantArgs{TenantID: serverutils.TestTenantID(), AllowSettingClusterSettings: false})
 	defer db.Close()
 	_, err := db.Exec(`SET CLUSTER SETTING sql.defaults.vectorize=off`)
 	require.NoError(t, err)
@@ -116,7 +116,7 @@ func TestTenantHTTP(t *testing.T) {
 	defer tc.Stopper().Stop(ctx)
 
 	tenant, err := tc.Server(0).StartTenant(base.TestTenantArgs{
-		TenantID: roachpb.MakeTenantID(security.EmbeddedTenantIDs()[0]),
+		TenantID: serverutils.TestTenantID(),
 	})
 	require.NoError(t, err)
 	t.Run("prometheus", func(t *testing.T) {
@@ -151,7 +151,7 @@ func TestIdleExit(t *testing.T) {
 	warmupDuration := 500 * time.Millisecond
 	countdownDuration := 4000 * time.Millisecond
 	tenant, err := tc.Server(0).StartTenant(base.TestTenantArgs{
-		TenantID:      roachpb.MakeTenantID(10),
+		TenantID:      serverutils.TestTenantID(),
 		IdleExitAfter: warmupDuration,
 		TestingKnobs: base.TestingKnobs{
 			TenantTestingKnobs: &sql.TenantTestingKnobs{

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job_test.go
@@ -21,7 +21,6 @@ import (
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/streamingccl/streamproducer"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/jobutils"
@@ -50,7 +49,7 @@ func TestTenantStreaming(t *testing.T) {
 	defer source.Stopper().Stop(ctx)
 
 	// Start tenant server in the srouce cluster.
-	tenantID := roachpb.MakeTenantID(10)
+	tenantID := serverutils.TestTenantID()
 	_, tenantConn := serverutils.StartTenant(t, source, base.TestTenantArgs{TenantID: tenantID})
 	defer tenantConn.Close()
 	// sourceSQL refers to the tenant generating the data.

--- a/pkg/ccl/streamingccl/streamingtest/replication_helpers.go
+++ b/pkg/ccl/streamingccl/streamingtest/replication_helpers.go
@@ -186,7 +186,7 @@ SET CLUSTER SETTING sql.defaults.experimental_stream_replication.enabled = 'on';
 	require.NoError(t, err)
 
 	// Start tenant server
-	tenantID := roachpb.MakeTenantID(10)
+	tenantID := serverutils.TestTenantID()
 	_, tenantConn := serverutils.StartTenant(t, s, base.TestTenantArgs{TenantID: tenantID})
 
 	// Sink to read data from.

--- a/pkg/kv/kvserver/client_tenant_test.go
+++ b/pkg/kv/kvserver/client_tenant_test.go
@@ -60,7 +60,7 @@ func TestTenantsStorageMetricsOnSplit(t *testing.T) {
 	require.NoError(t, err)
 	defer store.Stopper().Stop(ctx)
 
-	tenantID := roachpb.MakeTenantID(10)
+	tenantID := serverutils.TestTenantID()
 	codec := keys.MakeSQLCodec(tenantID)
 
 	tenantPrefix := codec.TenantPrefix()
@@ -162,7 +162,7 @@ func TestTenantRateLimiter(t *testing.T) {
 	ctx := context.Background()
 	defer s.Stopper().Stop(ctx)
 
-	tenantID := roachpb.MakeTenantID(10)
+	tenantID := serverutils.TestTenantID()
 	codec := keys.MakeSQLCodec(tenantID)
 
 	tenantPrefix := codec.TenantPrefix()
@@ -235,7 +235,7 @@ func TestTenantRateLimiter(t *testing.T) {
 		return string(read)
 	}
 	makeMetricStr := func(expCount int64) string {
-		const tenantMetricStr = `kv_tenant_rate_limit_write_requests_admitted{store="1",tenant_id="10"}`
+		tenantMetricStr := fmt.Sprintf(`kv_tenant_rate_limit_write_requests_admitted{store="1",tenant_id="%d"}`, tenantID.ToUint64())
 		return fmt.Sprintf("%s %d", tenantMetricStr, expCount)
 	}
 

--- a/pkg/server/diagnostics/reporter_test.go
+++ b/pkg/server/diagnostics/reporter_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/server/diagnostics"
 	"github.com/cockroachdb/cockroach/pkg/server/diagnostics/diagnosticspb"
@@ -55,7 +54,7 @@ func TestTenantReport(t *testing.T) {
 	defer rt.Close()
 
 	tenantArgs := base.TestTenantArgs{
-		TenantID:                    roachpb.MakeTenantID(security.EmbeddedTenantIDs()[0]),
+		TenantID:                    serverutils.TestTenantID(),
 		AllowSettingClusterSettings: true,
 		TestingKnobs:                rt.testingKnobs,
 	}

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -592,7 +592,7 @@ func makeSQLServerArgs(
 		return esb.makeExternalStorageFromURI(ctx, uri, user)
 	}
 
-	esb.init(base.ExternalIODirConfig{}, baseCfg.Settings, nil, circularInternalExecutor, db)
+	esb.init(sqlCfg.ExternalIODirConfig, baseCfg.Settings, nil, circularInternalExecutor, db)
 
 	// We don't need this for anything except some services that want a gRPC
 	// server to register against (but they'll never get RPCs at the time of
@@ -725,6 +725,7 @@ func (ts *TestServer) StartTenant(
 	}
 	sqlCfg := makeTestSQLConfig(st, params.TenantID)
 	sqlCfg.TenantKVAddrs = []string{ts.ServingRPCAddr()}
+	sqlCfg.ExternalIODirConfig = params.ExternalIODirConfig
 	if params.MemoryPoolSize != 0 {
 		sqlCfg.MemoryPoolSize = params.MemoryPoolSize
 	}

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -148,6 +148,7 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 		cfg.JoinList = []string{params.JoinAddr}
 	}
 	cfg.ClusterName = params.ClusterName
+	cfg.ExternalIODirConfig = params.ExternalIODirConfig
 	cfg.Insecure = params.Insecure
 	cfg.AutoInitializeCluster = !params.NoAutoInitializeCluster
 	cfg.SocketFile = params.SocketFile

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1440,7 +1440,7 @@ func (t *logicTest) newCluster(serverArgs TestServerArgs) {
 	if cfg.useTenant {
 		var err error
 		tenantArgs := base.TestTenantArgs{
-			TenantID:                    roachpb.MakeTenantID(10),
+			TenantID:                    serverutils.TestTenantID(),
 			AllowSettingClusterSettings: true,
 			TestingKnobs: base.TestingKnobs{
 				SQLExecutor: &sql.ExecutorTestingKnobs{

--- a/pkg/sql/sqltestutils/BUILD.bazel
+++ b/pkg/sql/sqltestutils/BUILD.bazel
@@ -16,7 +16,6 @@ go_library(
         "//pkg/keys",
         "//pkg/kv",
         "//pkg/roachpb",
-        "//pkg/security",
         "//pkg/server",
         "//pkg/server/diagnostics",
         "//pkg/sql",

--- a/pkg/sql/sqltestutils/telemetry.go
+++ b/pkg/sql/sqltestutils/telemetry.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/server/diagnostics"
 	"github.com/cockroachdb/cockroach/pkg/sql"
@@ -161,7 +160,7 @@ func (tt *telemetryTest) Start(t *testing.T, serverArgs []base.TestServerArgs) {
 	log.TestingClearServerIdentifiers()
 
 	tt.tenant, tt.tenantDB = serverutils.StartTenant(tt.t, tt.server, base.TestTenantArgs{
-		TenantID:                    roachpb.MakeTenantID(security.EmbeddedTenantIDs()[0]),
+		TenantID:                    serverutils.TestTenantID(),
 		AllowSettingClusterSettings: true,
 		TestingKnobs:                mapServerArgs[0].Knobs,
 	})

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -355,6 +355,13 @@ func StartTenant(
 	return tenant, goDB
 }
 
+// TestTenantID returns a roachpb.TenantID that can be used when
+// starting a test Tenant. The returned tenant IDs match those built
+// into the test certificates.
+func TestTenantID() roachpb.TenantID {
+	return roachpb.MakeTenantID(security.EmbeddedTenantIDs()[0])
+}
+
 // GetJSONProto uses the supplied client to GET the URL specified by the parameters
 // and unmarshals the result into response.
 func GetJSONProto(ts TestServerInterface, path string, response protoutil.Message) error {


### PR DESCRIPTION
Backport:
  * 1/1 commits from "changefeedccl: add test for disabled outbound IO" (#64775)
  * 1/1 commits from "serverutils: Add TestTenantID" (#65003)
  * 1/1 commits from "changefeedccl: add test for sinkless changefeed on tenant" (#64988)

The important change to backport is in `pkg/server/testserver.go` where we now respect
the value of the external-io-disabled flag on SQL nodes.  This fix was part of some test-centric changes
and was missed for backporting earlier.  I've backported the test changes as well to make it easier
to backport future changes that include multi-tenant testing.

Please see individual PRs for details.

/cc @cockroachdb/release
