### PR TITLE
roachtest: Run weekly/tpcc/headroom for 4 days rather than 6

### DIFF
--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -379,12 +379,12 @@ func registerTPCC(r *testRegistry) {
 		MinVersion: "v19.1.0",
 		Tags:       []string{`weekly`},
 		Cluster:    r.makeClusterSpec(4, spec.CPU(16)),
-		Timeout:    time.Duration(6*24)*time.Hour + time.Duration(10)*time.Minute,
+		Timeout:    time.Duration(4*24)*time.Hour + time.Duration(10)*time.Minute,
 		Run: func(ctx context.Context, t *test, c Cluster) {
 			warehouses := 1000
 			runTPCC(ctx, t, c, tpccOptions{
 				Warehouses: warehouses,
-				Duration:   6 * 24 * time.Hour,
+				Duration:   4 * 24 * time.Hour,
 				SetupType:  usingImport,
 			})
 		},


### PR DESCRIPTION
Our currently weekly tests will time out sometime during the 5th day.
We could alternatively extend this timeout, but I think it might be nice to have a
few more days to fix any errors we find during the test before the
next one starts.

Release note: None