### PR TITLE
storage: make ExportMVCCToSst take Writer

### DIFF
--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -409,7 +409,7 @@ func (s spanSetReader) ExportMVCCToSst(
 	exportAllRevisions bool,
 	targetSize, maxSize uint64,
 	useTBI bool,
-	dest io.WriteCloser,
+	dest io.Writer,
 ) (roachpb.BulkOpSummary, roachpb.Key, error) {
 	return s.r.ExportMVCCToSst(startKey, endKey, startTS, endTS, exportAllRevisions, targetSize,
 		maxSize, useTBI, dest)

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -410,7 +410,7 @@ type Reader interface {
 	ExportMVCCToSst(
 		startKey, endKey roachpb.Key, startTS, endTS hlc.Timestamp,
 		exportAllRevisions bool, targetSize uint64, maxSize uint64, useTBI bool,
-		dest io.WriteCloser,
+		dest io.Writer,
 	) (_ roachpb.BulkOpSummary, resumeKey roachpb.Key, _ error)
 	// Get returns the value for the given key, nil otherwise. Semantically, it
 	// behaves as if an iterator with MVCCKeyAndIntentsIterKind was used.

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -658,7 +658,7 @@ func (p *Pebble) ExportMVCCToSst(
 	exportAllRevisions bool,
 	targetSize, maxSize uint64,
 	useTBI bool,
-	dest io.WriteCloser,
+	dest io.Writer,
 ) (roachpb.BulkOpSummary, roachpb.Key, error) {
 	r := wrapReader(p)
 	// Doing defer r.Free() does not inline.
@@ -1294,7 +1294,7 @@ func (p *pebbleReadOnly) ExportMVCCToSst(
 	exportAllRevisions bool,
 	targetSize, maxSize uint64,
 	useTBI bool,
-	dest io.WriteCloser,
+	dest io.Writer,
 ) (roachpb.BulkOpSummary, roachpb.Key, error) {
 	r := wrapReader(p)
 	// Doing defer r.Free() does not inline.
@@ -1559,7 +1559,7 @@ func (p *pebbleSnapshot) ExportMVCCToSst(
 	exportAllRevisions bool,
 	targetSize, maxSize uint64,
 	useTBI bool,
-	dest io.WriteCloser,
+	dest io.Writer,
 ) (roachpb.BulkOpSummary, roachpb.Key, error) {
 	r := wrapReader(p)
 	// Doing defer r.Free() does not inline.
@@ -1672,10 +1672,10 @@ func pebbleExportToSst(
 	exportAllRevisions bool,
 	targetSize, maxSize uint64,
 	useTBI bool,
-	dest io.WriteCloser,
+	dest io.Writer,
 	maxIntentCount int64,
 ) (roachpb.BulkOpSummary, roachpb.Key, error) {
-	sstWriter := MakeBackupSSTWriter(noopSync{dest})
+	sstWriter := MakeBackupSSTWriter(dest)
 	defer sstWriter.Close()
 
 	var rows RowCounter

--- a/pkg/storage/pebble_batch.go
+++ b/pkg/storage/pebble_batch.go
@@ -134,7 +134,7 @@ func (p *pebbleBatch) ExportMVCCToSst(
 	exportAllRevisions bool,
 	targetSize, maxSize uint64,
 	useTBI bool,
-	dest io.WriteCloser,
+	dest io.Writer,
 ) (roachpb.BulkOpSummary, roachpb.Key, error) {
 	panic("unimplemented")
 }


### PR DESCRIPTION
This changes ExportMVCCToSst to take an io.Writer instead of io.WriteCloser.

This leaves it to the caller to decide if and when to Close() a writer that
they opened, rather than the SST writer always doing it automatically.

Release note: none.