### PR TITLE
ccl/sqlproxyccl: TestFrontendAdmitWithClientSSLRequire failed fix

### DIFF
--- a/pkg/ccl/sqlproxyccl/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/BUILD.bazel
@@ -72,7 +72,6 @@ go_test(
         "//pkg/sql/pgwire",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
-        "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",

--- a/pkg/ccl/sqlproxyccl/frontend_admitter_test.go
+++ b/pkg/ccl/sqlproxyccl/frontend_admitter_test.go
@@ -15,7 +15,6 @@ import (
 	"net"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/jackc/pgconn"
@@ -69,7 +68,6 @@ func TestFrontendAdmitWithClientSSLDisableAndCustomParam(t *testing.T) {
 
 func TestFrontendAdmitWithClientSSLRequire(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.WithIssue(t, 66752, "flaky test")
 
 	cli, srv := net.Pipe()
 	require.NoError(t, srv.SetReadDeadline(timeutil.Now().Add(3e9)))
@@ -92,6 +90,7 @@ func TestFrontendAdmitWithClientSSLRequire(t *testing.T) {
 	require.NoError(t, err)
 	frontendCon, msg, err := frontendAdmit(srv, tlsConfig)
 	require.NoError(t, err)
+	defer func() { _ = frontendCon.Close() }()
 	require.NotEqual(t, srv, frontendCon) // The connection was replaced by SSL
 	require.NotNil(t, msg)
 }


### PR DESCRIPTION
TestFrontendAdmitWithClientSSLRequire started failing with the upgrade
to go 1.16 and was skipped. This fixes the test.

Refs: cockroachdb#66752

Reason: flaky test fix

Release justification: non-production code changes

Release note: None