### PR TITLE
release-21.1: kvserver: deadlock when getting replica.Desc while under lock

### DIFF
--- a/pkg/kv/kvserver/replica_protected_timestamp.go
+++ b/pkg/kv/kvserver/replica_protected_timestamp.go
@@ -192,7 +192,7 @@ func (r *Replica) protectedTimestampRecordCurrentlyApplies(
 	if args.Protected.LessEq(*r.mu.state.GCThreshold) {
 		gcReason := fmt.Sprintf("protected ts: %s is less than equal to the GCThreshold: %s for the"+
 			" range %s - %s", args.Protected.String(), r.mu.state.GCThreshold.String(),
-			r.Desc().StartKey.String(), r.Desc().EndKey.String())
+			desc.StartKey.String(), desc.EndKey.String())
 		return false, false, gcReason, nil
 	}
 	if args.RecordAliveAt.Less(ls.Lease.Start.ToTimestamp()) {
@@ -208,7 +208,7 @@ func (r *Replica) protectedTimestampRecordCurrentlyApplies(
 		gcReason := fmt.Sprintf(
 			"protected ts: %s is less than the pending GCThreshold: %s for the range %s - %s",
 			args.Protected.String(), r.protectedTimestampMu.pendingGCThreshold.String(),
-			r.Desc().StartKey.String(), r.Desc().EndKey.String())
+			desc.StartKey.String(), desc.EndKey.String())
 		return false, false, gcReason, nil
 	}
 


### PR DESCRIPTION
Backport 1/1 commits from #66760.

/cc @cockroachdb/release

---

Error logging was using replica.Desc() to get range keys while
already operating under replica read lock. It was causing deadlock
if another go routine tried to acquire a write.
We already have a description locally so no need to get locks at
all.

Release note (bug fix): Fix deadlock during backups and imports

Fixes #66759 
