### PR TITLE
sql: incorporate lookupExpr cpu cost into cost model

### DIFF
--- a/pkg/sql/opt/xform/testdata/coster/zone
+++ b/pkg/sql/opt/xform/testdata/coster/zone
@@ -752,7 +752,7 @@ anti-join (lookup abc_part@bc_idx [as=a2])
  │         └── a2.r:7 = 'west' [outer=(7), constraints=(/7: [/'west' - /'west']; tight), fd=()-->(7)]
  ├── cardinality: [0 - 1]
  ├── stats: [rows=1e-10]
- ├── cost: 18.1390458
+ ├── cost: 18.153533
  ├── key: ()
  ├── fd: ()-->(1-4)
  ├── anti-join (lookup abc_part@bc_idx [as=a2])
@@ -763,7 +763,7 @@ anti-join (lookup abc_part@bc_idx [as=a2])
  │    │         └── a2.r:7 = 'east' [outer=(7), constraints=(/7: [/'east' - /'east']; tight), fd=()-->(7)]
  │    ├── cardinality: [0 - 1]
  │    ├── stats: [rows=0.900900001, distinct(1)=0.89738934, null(1)=0, distinct(2)=0.900900001, null(2)=0, distinct(3)=0.900900001, null(3)=0, distinct(4)=0.900900001, null(4)=0]
- │    ├── cost: 10.8458567
+ │    ├── cost: 10.8531367
  │    ├── key: ()
  │    ├── fd: ()-->(1-4)
  │    ├── locality-optimized-search


### PR DESCRIPTION
Informs #51576

This is a prep-the-patient change required for enabling the lookup join inequality conditions.   It enables for instance partial indexes to be selected when there's a costing tie between a lookup join with a partial index vs a full index with the partial index qualifier as a lookup join condition.

Release note (sql): improve cost model to include cpu cost of lookupExprs used by lookup joins.
