### PR TITLE
roachpb: fix incorrect addition of roachpb.ExecStats Count field

### DIFF
--- a/pkg/roachpb/app_stats.go
+++ b/pkg/roachpb/app_stats.go
@@ -202,5 +202,5 @@ func (s *ExecStats) Add(other ExecStats) {
 	s.NetworkMessages.Add(other.NetworkMessages, execStatCollectionCount, other.Count)
 	s.MaxDiskUsage.Add(other.MaxDiskUsage, execStatCollectionCount, other.Count)
 
-	s.Count += s.Count
+	s.Count += other.Count
 }

--- a/pkg/roachpb/app_stats_test.go
+++ b/pkg/roachpb/app_stats_test.go
@@ -85,12 +85,13 @@ func TestAddNumericStats(t *testing.T) {
 }
 
 func TestAddExecStats(t *testing.T) {
-	numericStatA := NumericStat{Mean: 1, SquaredDiffs: 1}
-	numericStatB := NumericStat{Mean: 1, SquaredDiffs: 1}
-	a := ExecStats{Count: 1, NetworkBytes: numericStatA}
+	numericStatA := NumericStat{Mean: 354.123, SquaredDiffs: 34.34123}
+	numericStatB := NumericStat{Mean: 9.34354, SquaredDiffs: 75.321}
+	a := ExecStats{Count: 3, NetworkBytes: numericStatA}
 	b := ExecStats{Count: 1, NetworkBytes: numericStatB}
 	expectedNumericStat := AddNumericStats(a.NetworkBytes, b.NetworkBytes, a.Count, b.Count)
 	a.Add(b)
-	require.Equal(t, int64(2), a.Count)
-	require.Equal(t, expectedNumericStat, a.NetworkBytes)
+	require.Equal(t, int64(4), a.Count)
+	epsilon := 0.00000001
+	require.True(t, expectedNumericStat.AlmostEqual(a.NetworkBytes, epsilon), "expected %+v, but found %+v", expectedNumericStat, a.NetworkMessages)
 }


### PR DESCRIPTION
Release note (bug fix): fix incorrect accounting for statement/transaction sampled execution statistics.