### PR TITLE
util/sysutil: add ResizeLargeFile

### DIFF
--- a/pkg/util/sysutil/BUILD.bazel
+++ b/pkg/util/sysutil/BUILD.bazel
@@ -68,7 +68,6 @@ go_test(
     embed = [":sysutil"],
     deps = [
         "@com_github_cockroachdb_errors//:errors",
-        "@com_github_cockroachdb_errors//oserror",
     ] + select({
         "@io_bazel_rules_go//go/platform:aix": [
             "@org_golang_x_sys//unix",

--- a/pkg/util/sysutil/large_file_linux.go
+++ b/pkg/util/sysutil/large_file_linux.go
@@ -19,18 +19,34 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// CreateLargeFile creates a large file at the given path with bytes size. On
-// Linux, it uses the fallocate syscall to efficiently create a file of the
-// given size. On other platforms, it naively writes the specified number of
-// bytes, which can take a long time.
-func CreateLargeFile(path string, bytes int64) error {
-	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0666)
+// ResizeLargeFile resizes the file at the given path to be the provided
+// length in bytes. If no file exists at path, ResizeLargeFile creates a file.
+// All disk blocks within the new file are allocated, and there are no sparse
+// regions.
+//
+// On Linux, it uses the fallocate syscall to efficiently allocate disk space.
+// On other platforms, it naively writes the specified number of bytes, which
+// can take a long time.
+func ResizeLargeFile(path string, bytes int64) error {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE, 0666)
 	if err != nil {
 		return err
 	}
 	defer f.Close()
-	if err := unix.Fallocate(int(f.Fd()), 0, 0, bytes); err != nil {
-		return errors.Wrap(err, "fallocate")
+
+	// Ensure that at least length bytes of the file are allocated. If the
+	// file already existed, the disk blocks may not have been allocated even
+	// if the file size is greater than length.
+	if bytes > 0 {
+		if err := unix.Fallocate(int(f.Fd()), 0, 0, bytes); err != nil {
+			return errors.Wrap(err, "fallocate")
+		}
+	}
+
+	// Truncate down to bytes, in case the file is longer than bytes. This
+	// will be a no-op if the file is already at the desired length.
+	if err := unix.Ftruncate(int(f.Fd()), bytes); err != nil {
+		return errors.Wrap(err, "ftruncate")
 	}
 	return errors.Wrap(f.Sync(), "fsync")
 }

--- a/pkg/util/sysutil/large_file_naive.go
+++ b/pkg/util/sysutil/large_file_naive.go
@@ -18,12 +18,16 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// CreateLargeFile creates a large file at the given path with bytes size. On
-// Linux, it uses the fallocate syscall to efficiently create the file. On other
-// platforms, it naively writes the specified number of bytes, which can take a
-// long time when the number of bytes is large.
-func CreateLargeFile(path string, bytes int64) error {
-	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0666)
+// ResizeLargeFile resizes the file at the given path to be the provided
+// length in bytes. If no file exists at path, ResizeLargeFile creates a file.
+// All disk blocks within the new file are allocated, and there are no sparse
+// regions.
+//
+// On Linux, it uses the fallocate syscall to efficiently allocate disk space.
+// On other platforms, it naively writes the specified number of bytes, which
+// can take a long time.
+func ResizeLargeFile(path string, bytes int64) error {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Modify and rename sysutil.CreateLargeFile to sysutil.ResizeLargeFile, to
be used for creating and resizing large ballasts. On Linux, this
function continues to use fallocate to efficiently allocate disk space.

I intend to use this function in managing an enabled-by-default ballast
that may be configured through the `--store` flag. When resizing down,
it's advantageous to truncate rather than remove and re-create because
some copy-on-write filesystems cannot remove a file while out of disk
space but can truncate an existing file.

This change leaves the behavior of CreateLargeFile's one caller, the
`cockroach debug ballast` command, unchanged.

Release note: None