### PR TITLE
util/sysutil: remove StatFS

### DIFF
--- a/pkg/util/sysutil/sysutil.go
+++ b/pkg/util/sysutil/sysutil.go
@@ -35,14 +35,6 @@ const (
 	ECONNREFUSED = syscall.ECONNREFUSED
 )
 
-// FSInfo describes a filesystem. It is returned by StatFS.
-type FSInfo struct {
-	FreeBlocks  int64
-	AvailBlocks int64
-	TotalBlocks int64
-	BlockSize   int64
-}
-
 // ExitStatus returns the exit status contained within an exec.ExitError.
 func ExitStatus(err *exec.ExitError) int {
 	// err.Sys() is of type syscall.WaitStatus on all supported platforms.

--- a/pkg/util/sysutil/sysutil_unix.go
+++ b/pkg/util/sysutil/sysutil_unix.go
@@ -16,7 +16,6 @@ package sysutil
 
 import (
 	"fmt"
-	"math"
 	"syscall"
 
 	"golang.org/x/sys/unix"
@@ -27,30 +26,6 @@ import (
 func ProcessIdentity() string {
 	return fmt.Sprintf("uid %d euid %d gid %d egid %d",
 		unix.Getuid(), unix.Geteuid(), unix.Getgid(), unix.Getegid())
-}
-
-// StatFS returns an FSInfo describing the named filesystem. It is only
-// supported on Unix-like platforms.
-func StatFS(path string) (*FSInfo, error) {
-	var fs unix.Statfs_t
-	if err := unix.Statfs(path, &fs); err != nil {
-		return nil, err
-	}
-	// Statfs_t's fields have different types on different platforms. Our FSInfo
-	// type uses int64s for all fields, so make sure the values returned by the OS
-	// will fit.
-	if uint64(fs.Bfree) > math.MaxInt64 ||
-		uint64(fs.Bavail) > math.MaxInt64 ||
-		uint64(fs.Blocks) > math.MaxInt64 ||
-		uint64(fs.Bsize) > math.MaxInt64 {
-		return nil, fmt.Errorf("statfs syscall returned unrepresentable value %#v", fs)
-	}
-	return &FSInfo{
-		FreeBlocks:  int64(fs.Bfree),
-		AvailBlocks: int64(fs.Bavail),
-		TotalBlocks: int64(fs.Blocks),
-		BlockSize:   int64(fs.Bsize),
-	}, nil
 }
 
 // IsCrossDeviceLinkErrno checks whether the given error object (as

--- a/pkg/util/sysutil/sysutil_windows.go
+++ b/pkg/util/sysutil/sysutil_windows.go
@@ -16,8 +16,6 @@ import (
 	"fmt"
 	"os/user"
 	"syscall"
-
-	"github.com/cockroachdb/errors"
 )
 
 // ProcessIdentity returns a string describing the user and group that this
@@ -28,12 +26,6 @@ func ProcessIdentity() string {
 		return "<unknown>"
 	}
 	return fmt.Sprintf("uid %s, gid %s", u.Uid, u.Gid)
-}
-
-// StatFS returns an FSInfo describing the named filesystem. It is only
-// supported on Unix-like platforms.
-func StatFS(path string) (*FSInfo, error) {
-	return nil, errors.New("unsupported on Windows")
 }
 
 // IsCrossDeviceLinkErrno checks whether the given error object (as


### PR DESCRIPTION
Remove the sysutil.StatFS function, which was only supported on
Unix systems. Update the single call site to use Pebble's VFS
GetDiskUsage function. This has the side effect of allowing the debug
ballast command to be called on Windows.

Release note (cli change): Support `cockroach debug ballast` on Windows.