### PR TITLE
changefeedccl: support interval columns in avro changefeeds

### DIFF
--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -2774,6 +2774,11 @@ func (d *DInterval) Min(_ *EvalContext) (Datum, bool) {
 	return dMinInterval, true
 }
 
+// ValueAsISO8601String returns the interval as an ISO 8601 Duration string (e.g. "P1Y2MT6S").
+func (d *DInterval) ValueAsISO8601String() string {
+	return d.Duration.ISO8601String()
+}
+
 // AmbiguousFormat implements the Datum interface.
 func (*DInterval) AmbiguousFormat() bool { return true }
 

--- a/pkg/sql/sem/tree/interval_test.go
+++ b/pkg/sql/sem/tree/interval_test.go
@@ -564,6 +564,18 @@ func TestISO8601IntervalSyntax(t *testing.T) {
 			if s3 != test.output {
 				t.Fatalf(`%q: as datum, got "%s", expected "%s"`, test.input, s3, test.output)
 			}
+
+			// Test that ISO 8601 output format also round-trips
+			s4 := dur.ISO8601String()
+			di2, err := parseDInterval(s4, test.itm)
+			if err != nil {
+				t.Fatalf(`%q: ISO8601String "%s" unrecognized as datum: %v`, test.input, s4, err)
+			}
+			s5 := di2.Duration.String()
+			if s != s5 {
+				t.Fatalf(`%q: repr "%s" does not round-trip, got %s instead`, test.input, s4, s5)
+			}
+
 		})
 	}
 }

--- a/pkg/util/duration/duration.go
+++ b/pkg/util/duration/duration.go
@@ -633,6 +633,13 @@ func (d Duration) String() string {
 	return buf.String()
 }
 
+// ISO8601String returns an ISO 8601 representation ('P1Y2M3DT4H') of a Duration.
+func (d Duration) ISO8601String() string {
+	var buf bytes.Buffer
+	d.FormatWithStyle(&buf, IntervalStyle_ISO_8601)
+	return buf.String()
+}
+
 // StringNanos returns a string representation of a Duration including
 // its hidden nanoseconds value. To be used only by the encoding/decoding
 // packages for pretty printing of on-disk values. The encoded value is


### PR DESCRIPTION
We'd delayed implementing interval types in avro, unlike other
time types, because in theory there's an avro spec for durations
but no tooling. However the spec is a bit too limiting, so rather
than wait for tooling, we're just going to encode it as a string,
using the [ISO standard for durations](https://en.wikipedia.org/wiki/ISO_8601#Durations).

Adding in @otan since I'm touching the duration util package, and to check my assumption that it makes sense to keep truncating to the microsecond level.

Release note (bug fix): Interval columns are supported in avro changefeeds