### PR TITLE
envutil: include HTTP_PROXY in 'used' env vars

### DIFF
--- a/pkg/util/envutil/env.go
+++ b/pkg/util/envutil/env.go
@@ -117,7 +117,7 @@ func GetEnvVarsUsed() []string {
 		}
 	}
 
-	for _, name := range []string{"GOGC", "GODEBUG", "GOMAXPROCS", "GOTRACEBACK"} {
+	for _, name := range []string{"GOGC", "GODEBUG", "GOMAXPROCS", "GOTRACEBACK", "HTTP_PROXY", "HTTPS_PROXY"} {
 		if val, ok := os.LookupEnv(name); ok {
 			vars = append(vars, name+"="+val)
 		}


### PR DESCRIPTION
When filtering env vars for those which are 'used' we include a few
that affect the go runtime in addition to any with a COCKROACH_ prefix.
The vars HTTP_PROXY and HTTPS_PROXY are used by the Go net/http
client which is used by the external storage SDKs/clients so
it should be included here too.

Fixes #66799.

Release note (ops change): if set HTTP_PROXY and HTTPS_PROXY are now included in debugging reporting of env vars.