### PR TITLE
bazel: add cross-toolchain targeting macOS

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -20,3 +20,5 @@ build:crosslinux --platforms=//build/toolchains:cross_linux
 build:crosslinux --crosstool_top=@toolchain_cross_x86_64-unknown-linux-gnu//:suite
 build:crosswindows --platforms=//build/toolchains:cross_windows
 build:crosswindows --crosstool_top=@toolchain_cross_x86_64-w64-mingw32//:suite
+build:crossmacos --platforms=//build/toolchains:cross_macos
+build:crossmacos --crosstool_top=@toolchain_cross_x86_64-apple-darwin19//:suite

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,7 +12,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 # Load go bazel tools. This gives us access to the go bazel SDK/toolchains.
 git_repository(
     name = "io_bazel_rules_go",
-    commit = "a94a425d26532613e71f9c7432c19c36302e1f1d",
+    commit = "91c4e2b0f233c7031b191b93587f562ffe21f86f",
     remote = "https://github.com/cockroachdb/rules_go",
 )
 
@@ -181,6 +181,7 @@ toolchain_dependencies()
 
 register_toolchains(
     "//build/toolchains:cross_linux_toolchain",
+    "//build/toolchains:cross_macos_toolchain",
     "//build/toolchains:cross_windows_toolchain",
 )
 

--- a/build/toolchains/BUILD.bazel
+++ b/build/toolchains/BUILD.bazel
@@ -41,3 +41,25 @@ platform(
         "@platforms//cpu:x86_64",
     ],
 )
+
+toolchain(
+    name = "cross_macos_toolchain",
+    exec_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+    target_compatible_with = [
+        "@platforms//os:macos",
+        "@platforms//cpu:x86_64",
+    ],
+    toolchain = "@toolchain_cross_x86_64-apple-darwin19//:toolchain",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+)
+
+platform(
+    name = "cross_macos",
+    constraint_values = [
+        "@platforms//os:macos",
+        "@platforms//cpu:x86_64",
+    ],
+)

--- a/build/toolchains/REPOSITORIES.bzl
+++ b/build/toolchains/REPOSITORIES.bzl
@@ -2,6 +2,8 @@ load("//build/toolchains:dev/darwin-x86_64/toolchain.bzl",
      _dev_darwin_x86_repo = "dev_darwin_x86_repo")
 load("//build/toolchains:crosstool-ng/toolchain.bzl",
      _crosstool_toolchain_repo = "crosstool_toolchain_repo")
+load("//build/toolchains:darwin-x86_64/toolchain.bzl",
+     _macos_toolchain_repo = "macos_toolchain_repo")
 
 def toolchain_dependencies():
     _dev_darwin_x86_repo(name = "toolchain_dev_darwin_x86-64")
@@ -25,3 +27,4 @@ def toolchain_dependencies():
         target = "x86_64-w64-mingw32",
         tarball_sha256 = "6900b96f7bbd86ba96c4c9704eab6fcb2241fdb5df0a8b9cb3416505a6ef19f7",
     )
+    _macos_toolchain_repo(name = "toolchain_cross_x86_64-apple-darwin19")

--- a/build/toolchains/darwin-x86_64/BUILD.tmpl
+++ b/build/toolchains/darwin-x86_64/BUILD.tmpl
@@ -1,0 +1,75 @@
+package(default_visibility = ["//visibility:public"])
+
+load(":cc_toolchain_config.bzl", "cc_toolchain_config")
+
+cc_toolchain_suite(
+    name = "suite",
+    toolchains = {
+        "k8": ":toolchain",
+    },
+)
+
+cc_toolchain_config(name = "toolchain_config")
+
+filegroup(name = "empty")
+
+filegroup(
+    name = "all_files",
+    srcs = [
+        ":ar_files",
+        ":compiler_files",
+        ":linker_files",
+        ":strip_files",
+    ],
+)
+
+filegroup(
+    name = "compiler_files",
+    srcs = [
+        "bin/x86_64-apple-darwin19-cc",
+        "bin/x86_64-apple-darwin19-c++",
+    ],
+)
+
+filegroup(
+    name = "ar_files",
+    srcs = [
+        "bin/x86_64-apple-darwin19-ar",
+    ],
+)
+
+filegroup(
+    name = "linker_files",
+    srcs = [
+        "bin/x86_64-apple-darwin19-cc",
+        "bin/xcrun",
+    ],
+)
+
+filegroup(
+    name = "objcopy_files",
+    srcs = [
+        "bin/x86_64-apple-darwin19-objcopy",
+    ],
+)
+
+filegroup(
+    name = "strip_files",
+    srcs = [
+        "bin/x86_64-apple-darwin19-strip",
+    ],
+)
+
+cc_toolchain(
+    name = "toolchain",
+    toolchain_identifier = "x86_64-apple-darwin19-cross-toolchain",
+    toolchain_config = ":toolchain_config",
+    all_files = ":all_files",
+    ar_files = ":ar_files",
+    compiler_files = ":compiler_files",
+    dwp_files = ":empty",
+    linker_files = ":linker_files",
+    objcopy_files = ":empty",
+    strip_files = ":strip_files",
+    supports_param_files = 0,
+)

--- a/build/toolchains/darwin-x86_64/cc_toolchain_config.bzl.tmpl
+++ b/build/toolchains/darwin-x86_64/cc_toolchain_config.bzl.tmpl
@@ -1,0 +1,214 @@
+load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
+load("@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl",
+     "env_entry",
+     "env_set",
+     "feature",
+     "flag_group",
+     "flag_set",
+     "tool_path")
+
+all_compile_actions = [
+    ACTION_NAMES.c_compile,
+    ACTION_NAMES.cpp_compile,
+    ACTION_NAMES.linkstamp_compile,
+    ACTION_NAMES.assemble,
+    ACTION_NAMES.preprocess_assemble,
+    ACTION_NAMES.cpp_header_parsing,
+    ACTION_NAMES.cpp_module_compile,
+    ACTION_NAMES.cpp_module_codegen,
+    ACTION_NAMES.clif_match,
+    ACTION_NAMES.lto_backend,
+]
+
+all_link_actions = [
+    ACTION_NAMES.cpp_link_executable,
+    ACTION_NAMES.cpp_link_dynamic_library,
+    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+]
+
+all_archive_actions = [
+    ACTION_NAMES.cpp_link_static_library,
+]
+
+def _impl(ctx):
+    tool_paths = [
+        tool_path(
+            name = "gcc",
+            path = "bin/x86_64-apple-darwin19-cc",
+        ),
+        tool_path(
+            name = "ld",
+            path = "bin/x86_64-apple-darwin19-ld",
+        ),
+        tool_path(
+            name = "cpp",
+            path = "bin/x86_64-apple-darwin19-c++",
+        ),
+        tool_path(
+            name = "gcov",
+            path = "bin/x86_64-apple-darwin19-gcov",
+        ),
+        tool_path(
+            name = "nm",
+            path = "bin/x86_64-apple-darwin19-nm",
+        ),
+        tool_path(
+            name = "objdump",
+            path = "bin/x86_64-apple-darwin19-objdump",
+        ),
+        tool_path(
+            name = "strip",
+            path = "bin/x86_64-apple-darwin19-strip",
+        ),
+        tool_path(
+            name = "ar",
+            path = "bin/x86_64-apple-darwin19-ar",
+        ),
+    ]
+
+    opt_feature = feature(
+        name = "opt",
+        flag_sets = [
+            flag_set(
+                actions = all_compile_actions,
+                flag_groups = ([
+                    flag_group(
+                        flags = [
+                            "-O3",
+                        ]
+                    ),
+                ]),
+            ),
+        ],
+    )
+    fastbuild_feature = feature(name = "fastbuild")
+    dbg_feature = feature(
+        name = "dbg",
+        flag_sets = [
+            flag_set(
+                actions = all_compile_actions,
+                flag_groups = ([
+                    flag_group(
+                        flags = [
+                            "-g3",
+                        ]
+                    ),
+                ]),
+            ),
+        ],
+    )
+
+    supports_pic_feature = feature(name = "supports_pic", enabled = True)
+    supports_dynamic_linker_feature = feature(name = "supports_dynamic_linker", enabled = False)
+
+    default_compile_flags = feature(
+        name = "default_compile_flags",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_compile_actions,
+                flag_groups = ([
+                    flag_group(
+                        flags = [
+                            "-g1",
+                            "-Wall",
+                            "-I%{repo_path}/SDK/MacOSX10.15.sdk/usr/include/c++/v1",
+                        ],
+                    ),
+                ]),
+            ),
+        ],
+    )
+
+    linker_flags = [
+        "-lstdc++",
+        "-L%{repo_path}/lib",
+    ]
+
+    default_linker_flags = feature(
+        name = "default_linker_flags",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_link_actions,
+                flag_groups = ([flag_group(flags = linker_flags)]),
+            ),
+        ],
+	env_sets = [
+            env_set(
+                actions = all_link_actions,
+                env_entries = [
+                    env_entry(key = "LD_LIBRARY_PATH", value = "%{repo_path}/lib"),
+                ],
+            ),
+	]
+    )
+
+    default_archiver_flags = feature(
+        name = "archiver_flags",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_archive_actions,
+                flag_groups = [
+                    # NOTE(ricky): Bazel defaults to using rcsD here -- the
+                    # macOS ar doesn't understand the D flag, though.
+                    flag_group(flags = ["rcs"]),
+                    flag_group(
+                        flags = ["%{output_execpath}"],
+                        expand_if_available = "output_execpath",
+                    ),
+                ],
+            ),
+            flag_set(
+                actions = all_archive_actions,
+                flag_groups = [
+                    flag_group(
+                        iterate_over = "libraries_to_link",
+                        flag_groups = [
+                            flag_group(
+                                flags = ["%{libraries_to_link.name}"],
+                            ),
+                        ],
+                        expand_if_available = "libraries_to_link",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    features = [
+        opt_feature,
+        fastbuild_feature,
+        dbg_feature,
+        supports_pic_feature,
+        supports_dynamic_linker_feature,
+        default_archiver_flags,
+        default_compile_flags,
+        default_linker_flags,
+    ]
+
+    return cc_common.create_cc_toolchain_config_info(
+        ctx = ctx,
+        features = features,
+        toolchain_identifier = "x86_64-apple-darwin19-cross-toolchain",
+        host_system_name = "x86_64-apple-darwin19",
+        target_system_name = "x86_64-apple-darwin19",
+        target_cpu = "x86_64-apple-darwin19",
+        target_libc = "glibc-2.14",
+        compiler = "clang",
+        abi_version = "clang-10.0.0",
+        abi_libc_version = "x86_64-apple-darwin19",
+        tool_paths = tool_paths,
+        cxx_builtin_include_directories = [
+            "%sysroot%/usr/include",
+            "/usr/lib/llvm-10/lib/clang/10.0.0/include",
+        ],
+        builtin_sysroot = "%{repo_path}/SDK/MacOSX10.15.sdk",
+    )
+
+cc_toolchain_config = rule(
+    implementation = _impl,
+    attrs = {},
+    provides = [CcToolchainConfigInfo],
+)

--- a/build/toolchains/darwin-x86_64/toolchain.bzl
+++ b/build/toolchains/darwin-x86_64/toolchain.bzl
@@ -1,0 +1,24 @@
+def _impl(rctx):
+    rctx.download_and_extract(
+        url = [
+            "https://storage.googleapis.com/public-bazel-artifacts/toolchains/crosstool-ng/20210601-231954/x86_64-apple-darwin19.tar.gz",
+        ],
+        sha256 = "79ecc64d57f05cc4eccb3e57ce19fe016a3ba24c00fbe2435650f58168df8937",
+        stripPrefix = "x-tools/x86_64-apple-darwin19/",
+    )
+
+    repo_path = str(rctx.path(""))
+
+    rctx.template("BUILD",
+                  Label("@cockroach//build:toolchains/darwin-x86_64/BUILD.tmpl"),
+                  executable = False)
+    rctx.template("cc_toolchain_config.bzl",
+                  Label("@cockroach//build:toolchains/darwin-x86_64/cc_toolchain_config.bzl.tmpl"),
+                  substitutions = {
+                      "%{repo_path}": repo_path,
+                  },
+                  executable = False)
+
+macos_toolchain_repo = repository_rule(
+    implementation = _impl,
+)

--- a/c-deps/BUILD.bazel
+++ b/c-deps/BUILD.bazel
@@ -11,6 +11,7 @@ configure_make(
         "--enable-prof",
     ] + select({
         "@io_bazel_rules_go//go/platform:windows": ["--host=x86_64-w64-mingw32"],
+        "@io_bazel_rules_go//go/platform:darwin": ["--host=x86_64-apple-darwin19"],
         "//conditions:default": [],
     }),
     lib_source = "@jemalloc//:all",
@@ -38,6 +39,11 @@ cmake(
         # way to do it?
         # https://github.com/bazelbuild/bazel/issues/12457 would help.
         "@io_bazel_rules_go//go/platform:windows": {
+            "BUILD_LIBPROJ_SHARED": "OFF",
+            "CMAKE_BUILD_TYPE": "Release",
+            "CMAKE_SYSTEM_NAME": "Generic",
+        },
+        "@io_bazel_rules_go//go/platform:darwin": {
             "BUILD_LIBPROJ_SHARED": "OFF",
             "CMAKE_BUILD_TYPE": "Release",
             "CMAKE_SYSTEM_NAME": "Generic",


### PR DESCRIPTION
We follow up on previous commits that introduce cross-compilers for
Linux and Windows with a final one that builds for macOS.

The new toolchain files are in `build/toolchains/darwin-x86_64` -- we
don't reuse `build/toolchains/crosstool-ng` because we don't actually
use `crosstool-ng` for the Darwin toolchain, so things are actually
quite different under the hood.

We also pull in a new `rules_go` commit to handle an obscure bug.
Without it, builds using the cross toolchain end with an error like
this:

    ERROR: /cockroach/pkg/cmd/cockroach-short/BUILD.bazel:14:10: GoLink pkg/cmd/cockroach-short/cockroach-short_/cockroach-short failed: (Exit 1): process-wrapper failed: error executing command
      (cd /root/.cache/bazel/_bazel_root/cc377fc379544923cc7508dd261e4a48/sandbox/processwrapper-sandbox/961/execroot/cockroach && \
      exec env - \
      ...
        PATH=external/toolchain_cross_x86_64-apple-darwin19/bin:/bin:/usr/bin \
      ...
      /root/.cache/bazel/_bazel_root/install/1a4a2fac02d50c77031d44c0d91b8920/process-wrapper '--timeout=0' '--kill_delay=15' bazel-out/host/bin/external/go_sdk/builder '-param=bazel-out/k8-fastbuild/bin/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short-0.params' -- -extld external/toolchain_cross_x86_64-apple-darwin19/bin/x86_64-apple-darwin19-cc '-buildid=redacted' -extldflags '-L/root/.cache/bazel/_bazel_root/cc377fc379544923cc7508dd261e4a48/external/toolchain_cross_x86_64-apple-darwin19/lib --sysroot=/root/.cache/bazel/_bazel_root/cc377fc379544923cc7508dd261e4a48/external/toolchain_cross_x86_64-apple-darwin19/SDK/MacOSX10.15.sdk') process-wrapper failed: error executing command
    external/go_sdk/pkg/tool/linux_amd64/link: external/go_sdk/pkg/tool/linux_amd64/link: running dsymutil failed: xcrun resolves to executable relative to current directory (./external/toolchain_cross_x86_64-apple-darwin19/bin/xcrun)

This error comes from the golang toolchain, specifically
[this commit](https://github.com/golang/go/commit/953d1feca9b21af075ad5fc8a3dad096d3ccc3a0)
which landed in Go 1.16. Go courageously refuses to run executables that
are relative to the current path, since (particularly on Windows) this
is very liable to introduce remote code execution bugs. Bazel routinely
uses relative paths in the `PATH` environment variable, however. To
address this we just add a small function to munge the `PATH` to contain
absolute paths whenever we're linking.

Release note: None