### PR TITLE
kvcoord: setting to reject txns above lock span limit

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -34,6 +34,7 @@ kv.rangefeed.enabled	boolean	false	if set, rangefeed registration is enabled
 kv.replication_reports.interval	duration	1m0s	the frequency for generating the replication_constraint_stats, replication_stats_report and replication_critical_localities reports (set to 0 to disable)
 kv.transaction.max_intents_bytes	integer	262144	maximum number of bytes used to track locks in transactions
 kv.transaction.max_refresh_spans_bytes	integer	256000	maximum number of bytes used to track refresh spans in serializable transactions
+kv.transaction.reject_over_max_intents_budget.enabled	boolean	false	if set, transactions that exceed their lock tracking budget (kv.transaction.max_intents_bytes) are rejected instead of having their lock spans imprecisely compressed
 security.ocsp.mode	enumeration	off	"use OCSP to check whether TLS certificates are revoked. If the OCSP
 server is unreachable, in strict mode all certificates will be rejected
 and in lax mode all certificates will be accepted. [off = 0, lax = 1, strict = 2]"

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -38,6 +38,7 @@
 <tr><td><code>kv.snapshot_recovery.max_rate</code></td><td>byte size</td><td><code>8.0 MiB</code></td><td>the rate limit (bytes/sec) to use for recovery snapshots</td></tr>
 <tr><td><code>kv.transaction.max_intents_bytes</code></td><td>integer</td><td><code>262144</code></td><td>maximum number of bytes used to track locks in transactions</td></tr>
 <tr><td><code>kv.transaction.max_refresh_spans_bytes</code></td><td>integer</td><td><code>256000</code></td><td>maximum number of bytes used to track refresh spans in serializable transactions</td></tr>
+<tr><td><code>kv.transaction.reject_over_max_intents_budget.enabled</code></td><td>boolean</td><td><code>false</code></td><td>if set, transactions that exceed their lock tracking budget (kv.transaction.max_intents_bytes) are rejected instead of having their lock spans imprecisely compressed</td></tr>
 <tr><td><code>security.ocsp.mode</code></td><td>enumeration</td><td><code>off</code></td><td>use OCSP to check whether TLS certificates are revoked. If the OCSP<br/>server is unreachable, in strict mode all certificates will be rejected<br/>and in lax mode all certificates will be accepted. [off = 0, lax = 1, strict = 2]</td></tr>
 <tr><td><code>security.ocsp.timeout</code></td><td>duration</td><td><code>3s</code></td><td>timeout before considering the OCSP server unreachable</td></tr>
 <tr><td><code>server.auth_log.sql_connections.enabled</code></td><td>boolean</td><td><code>false</code></td><td>if set, log SQL client connect and disconnect events (note: may hinder performance on loaded nodes)</td></tr>

--- a/pkg/kv/kvclient/kvcoord/condensable_span_set.go
+++ b/pkg/kv/kvclient/kvcoord/condensable_span_set.go
@@ -78,7 +78,7 @@ func (s *condensableSpanSet) mergeAndSort() {
 func (s *condensableSpanSet) maybeCondense(
 	ctx context.Context, riGen rangeIteratorFactory, maxBytes int64,
 ) bool {
-	if s.bytes < maxBytes {
+	if s.bytes <= maxBytes {
 		return false
 	}
 
@@ -87,7 +87,7 @@ func (s *condensableSpanSet) maybeCondense(
 	// nice property that it sorts the spans by start key, which we rely on
 	// lower in this method.
 	s.mergeAndSort()
-	if s.bytes < maxBytes {
+	if s.bytes <= maxBytes {
 		return false
 	}
 

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner_test.go
@@ -1404,7 +1404,7 @@ func TestTxnPipelinerCondenseLockSpans(t *testing.T) {
 	a := roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key(nil)}
 	b := roachpb.Span{Key: roachpb.Key("b"), EndKey: roachpb.Key(nil)}
 	c := roachpb.Span{Key: roachpb.Key("c"), EndKey: roachpb.Key(nil)}
-	d := roachpb.Span{Key: roachpb.Key("dddddd"), EndKey: roachpb.Key(nil)}
+	d := roachpb.Span{Key: roachpb.Key("ddddddd"), EndKey: roachpb.Key(nil)}
 	e := roachpb.Span{Key: roachpb.Key("e"), EndKey: roachpb.Key(nil)}
 	aToBClosed := roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("b").Next()}
 	cToEClosed := roachpb.Span{Key: roachpb.Key("c"), EndKey: roachpb.Key("e").Next()}
@@ -1420,14 +1420,14 @@ func TestTxnPipelinerCondenseLockSpans(t *testing.T) {
 		{span: a, expLocks: []roachpb.Span{a}, expLocksSize: 1},
 		{span: b, expLocks: []roachpb.Span{a, b}, expLocksSize: 2},
 		{span: c, expLocks: []roachpb.Span{a, b, c}, expLocksSize: 3},
-		{span: d, expLocks: []roachpb.Span{a, b, c, d}, expLocksSize: 9},
+		{span: d, expLocks: []roachpb.Span{a, b, c, d}, expLocksSize: 10},
 		// Note that c-e condenses and then lists first.
 		{span: e, expLocks: []roachpb.Span{cToEClosed, a, b}, expLocksSize: 5},
 		{span: fTof0, expLocks: []roachpb.Span{cToEClosed, a, b, fTof0}, expLocksSize: 8},
 		{span: g, expLocks: []roachpb.Span{cToEClosed, a, b, fTof0, g}, expLocksSize: 9},
 		{span: g0Tog1, expLocks: []roachpb.Span{fTog1Closed, cToEClosed, aToBClosed}, expLocksSize: 9},
 		// Add a key in the middle of a span, which will get merged on commit.
-		{span: c, expLocks: []roachpb.Span{aToBClosed, cToEClosed, fTog1Closed}, expLocksSize: 9},
+		{span: c, expLocks: []roachpb.Span{fTog1Closed, cToEClosed, aToBClosed, c}, expLocksSize: 10},
 	}
 	splits := []roachpb.Span{
 		{Key: roachpb.Key("a"), EndKey: roachpb.Key("c")},

--- a/pkg/kv/kvclient/kvcoord/txn_metrics.go
+++ b/pkg/kv/kvclient/kvcoord/txn_metrics.go
@@ -35,6 +35,7 @@ type TxnMetrics struct {
 
 	TxnsWithCondensedIntents      *metric.Counter
 	TxnsWithCondensedIntentsGauge *metric.Gauge
+	TxnsRejectedByLockSpanBudget  *metric.Counter
 
 	// Restarts is the number of times we had to restart the transaction.
 	Restarts *metric.Histogram
@@ -148,6 +149,15 @@ var (
 		Measurement: "KV Transactions",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaTxnsRejectedByLockSpanBudget = metric.Metadata{
+		Name: "txn.condensed_intent_spans_rejected",
+		Help: "KV transactions that have been aborted because they exceeded their intent tracking " +
+			"memory budget (kv.transaction.max_intents_bytes). " +
+			"Rejection is caused by kv.transaction.reject_over_max_intents_budget.",
+		Measurement: "KV Transactions",
+		Unit:        metric.Unit_COUNT,
+	}
+
 	metaRestartsHistogram = metric.Metadata{
 		Name:        "txn.restarts",
 		Help:        "Number of restarted KV transactions",
@@ -260,6 +270,7 @@ func MakeTxnMetrics(histogramWindow time.Duration) TxnMetrics {
 		Durations:                     metric.NewLatency(metaDurationsHistograms, histogramWindow),
 		TxnsWithCondensedIntents:      metric.NewCounter(metaTxnsWithCondensedIntentSpans),
 		TxnsWithCondensedIntentsGauge: metric.NewGauge(metaTxnsWithCondensedIntentSpansGauge),
+		TxnsRejectedByLockSpanBudget:  metric.NewCounter(metaTxnsRejectedByLockSpanBudget),
 		Restarts:                      metric.NewHistogram(metaRestartsHistogram, histogramWindow, 100, 3),
 		RestartsWriteTooOld:           telemetry.NewCounterWithMetric(metaRestartsWriteTooOld),
 		RestartsWriteTooOldMulti:      telemetry.NewCounterWithMetric(metaRestartsWriteTooOldMulti),

--- a/pkg/roachpb/errors.proto
+++ b/pkg/roachpb/errors.proto
@@ -518,12 +518,13 @@ message ErrorDetail {
     ReplicaTooOldError replica_too_old = 18;
     AmbiguousResultError ambiguous_result = 26;
     StoreNotFoundError store_not_found = 27;
-    // The following three are ErrorDetails (and proto messages) because they
+    // The following four are ErrorDetails (and proto messages) because they
     // needs to be communicated from the TxnCoordSender and Txn to the upper
     // layers through the Sender interface.
     TransactionRetryWithProtoRefreshError transaction_retry_with_proto_refresh = 28;
     IntegerOverflowError integer_overflow = 31;
     UnsupportedRequestError unsupported_request = 32;
+
     BatchTimestampBeforeGCError timestamp_before = 34;
     TxnAlreadyEncounteredErrorError txn_already_encountered_error = 35;
     IntentMissingError intent_missing = 36;

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1146,6 +1146,7 @@ func TestLint(t *testing.T) {
 			"*.go",
 			":!*.pb.go",
 			":!*.pb.gw.go",
+			":!kv/kvclient/kvcoord/txn_interceptor_pipeliner.go",
 			":!sql/pgwire/pgerror/constraint_name.go",
 			":!sql/pgwire/pgerror/severity.go",
 			":!sql/pgwire/pgerror/with_candidate_code.go",

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1029,6 +1029,13 @@ var charts = []sectionDescription{
 					"txn.condensed_intent_spans_gauge",
 				},
 			},
+			{
+				Title:       "Intents condensing - transactions rejected",
+				Downsampler: DescribeAggregator_MAX,
+				Metrics: []string{
+					"txn.condensed_intent_spans_rejected",
+				},
+			},
 		},
 	},
 	{


### PR DESCRIPTION
This patch introduces kv.transaction.reject_over_max_intents_budget.  If
set, this changes our behavior when a txn exceeds its span budget
(kv.transaction.max_intents_bytes): instead of compacting some of its
lock spans with precision loss, the request causing the budget to be
exceeded will be rejected instead.

The idea is that we've seen transactions that exceed this budget be very
expensive to clean up - they have to scan a lot to find their intents,
and these cleanups take wide latches. So now one has the option to
reject these transactions, instead of risking this performance cliff.

Fixes #66742

Release note (general change): A new cluster setting
(kv.transaction.reject_over_max_intents_budget) affords control over the
behavior when a transaction exceeds its "locks-tracking memory budget"
(dictated by kv.transaction.max_intents_bytes). Instead of allowing such
transaction to continue with imprecise tracking of their locks, setting
this new option rejects the query that would push its transaction over
this budget with an error (error code 53400 - "configuration limit
exceeded). Transactions that don't track their locks precisely are
potentially destabilizing for the cluster since cleaning them up can
take considerable resources. Transactions that change many rows have the
potential to run into this memory budget issue.