### PR TITLE
clusterversion: make some room for a v21.1PLUS "release"

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -111,4 +111,4 @@ trace.datadog.project	string	CockroachDB	the project under which traces will be 
 trace.debug.enable	boolean	false	if set, traces for recent requests can be seen at https://<ui>/debug/requests
 trace.lightstep.token	string		if set, traces go to Lightstep using this token
 trace.zipkin.collector	string		if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'). Only one tracer can be configured at a time.
-version	version	21.1-12	set the active cluster version in the format '<major>.<minor>'
+version	version	21.1-112	set the active cluster version in the format '<major>.<minor>'

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -113,6 +113,6 @@
 <tr><td><code>trace.debug.enable</code></td><td>boolean</td><td><code>false</code></td><td>if set, traces for recent requests can be seen at https://<ui>/debug/requests</td></tr>
 <tr><td><code>trace.lightstep.token</code></td><td>string</td><td><code></code></td><td>if set, traces go to Lightstep using this token</td></tr>
 <tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'). Only one tracer can be configured at a time.</td></tr>
-<tr><td><code>version</code></td><td>version</td><td><code>21.1-12</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
+<tr><td><code>version</code></td><td>version</td><td><code>21.1-112</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
 </tbody>
 </table>

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -282,6 +282,10 @@ const (
 	// V21_1 is CockroachDB v21.1. It's used for all v21.1.x patch releases.
 	V21_1
 
+	// v21.1PLUS release. This is a special v21.1.x release with extra changes,
+	// used internally for the 2021 serverless offering.
+	Start21_1PLUS
+
 	// v21.2 versions.
 	//
 	// Start21_2 demarcates work towards CockroachDB v21.2.
@@ -321,7 +325,7 @@ const (
 // Such clusters would need to be wiped. As a result, do not bump the major or
 // minor version until we are absolutely sure that no new migrations will need
 // to be added (i.e., when cutting the final release candidate).
-var versionsSingleton = keyedVersions([]keyedVersion{
+var versionsSingleton = keyedVersions{
 
 	// v20.2 versions.
 	{
@@ -476,34 +480,46 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		Version: roachpb.Version{Major: 21, Minor: 1},
 	},
 
+	// v21.1PLUS version. This is a special v21.1.x release with extra changes,
+	// used internally for the 2021 Serverless offering.
+	//
+	// Any v21.1PLUS change that needs a migration will have a v21.2 version on
+	// master but a v21.1PLUS version on the v21.1PLUS branch.
+	{
+		Key: Start21_1PLUS,
+		// The Internal version starts out at 14 for historic reasons: at the time
+		// this was added, v21.2 versions were already defined up to 12.
+		Version: roachpb.Version{Major: 21, Minor: 1, Internal: 14},
+	},
+
 	// v21.2 versions.
 	{
 		Key:     Start21_2,
-		Version: roachpb.Version{Major: 21, Minor: 1, Internal: 2},
+		Version: roachpb.Version{Major: 21, Minor: 1, Internal: 102},
 	},
 	{
 		Key:     JoinTokensTable,
-		Version: roachpb.Version{Major: 21, Minor: 1, Internal: 4},
+		Version: roachpb.Version{Major: 21, Minor: 1, Internal: 104},
 	},
 	{
 		Key:     AcquisitionTypeInLeaseHistory,
-		Version: roachpb.Version{Major: 21, Minor: 1, Internal: 6},
+		Version: roachpb.Version{Major: 21, Minor: 1, Internal: 106},
 	},
 	{
 		Key:     SerializeViewUDTs,
-		Version: roachpb.Version{Major: 21, Minor: 1, Internal: 8},
+		Version: roachpb.Version{Major: 21, Minor: 1, Internal: 108},
 	},
 	{
 		Key:     ExpressionIndexes,
-		Version: roachpb.Version{Major: 21, Minor: 1, Internal: 10},
+		Version: roachpb.Version{Major: 21, Minor: 1, Internal: 110},
 	},
 	{
 		Key:     DeleteDeprecatedNamespaceTableDescriptorMigration,
-		Version: roachpb.Version{Major: 21, Minor: 1, Internal: 12},
+		Version: roachpb.Version{Major: 21, Minor: 1, Internal: 112},
 	},
 
 	// Step (2): Add new versions here.
-})
+}
 
 // TODO(irfansharif): clusterversion.binary{,MinimumSupported}Version
 // feels out of place. A "cluster version" and a "binary version" are two

--- a/pkg/clusterversion/key_string.go
+++ b/pkg/clusterversion/key_string.go
@@ -45,17 +45,18 @@ func _() {
 	_ = x[NonVotingReplicas-34]
 	_ = x[ProtectedTsMetaPrivilegesMigration-35]
 	_ = x[V21_1-36]
-	_ = x[Start21_2-37]
-	_ = x[JoinTokensTable-38]
-	_ = x[AcquisitionTypeInLeaseHistory-39]
-	_ = x[SerializeViewUDTs-40]
-	_ = x[ExpressionIndexes-41]
-	_ = x[DeleteDeprecatedNamespaceTableDescriptorMigration-42]
+	_ = x[Start21_1PLUS-37]
+	_ = x[Start21_2-38]
+	_ = x[JoinTokensTable-39]
+	_ = x[AcquisitionTypeInLeaseHistory-40]
+	_ = x[SerializeViewUDTs-41]
+	_ = x[ExpressionIndexes-42]
+	_ = x[DeleteDeprecatedNamespaceTableDescriptorMigration-43]
 }
 
-const _Key_name = "Start20_2GeospatialTypeAlterColumnTypeGeneralUserDefinedSchemasNoOriginFKIndexesNodeMembershipStatusMinPasswordLengthAbortSpanBytesMaterializedViewsBox2DTypeCreateLoginPrivilegeHBAForNonTLSV20_2Start21_1EmptyArraysInInvertedIndexesUniqueWithoutIndexConstraintsVirtualComputedColumnsCPutInlineReplicaVersionsreplacedTruncatedAndRangeAppliedStateMigrationreplacedPostTruncatedAndRangeAppliedStateMigrationNewSchemaChangerLongRunningMigrationsTruncatedAndRangeAppliedStateMigrationPostTruncatedAndRangeAppliedStateMigrationSeparatedIntentsTracingVerbosityIndependentSemanticsSequencesRegclassImplicitColumnPartitioningMultiRegionFeaturesClosedTimestampsRaftTransportChangefeedsSupportPrimaryIndexChangesForeignKeyRepresentationMigrationPriorReadSummariesNonVotingReplicasProtectedTsMetaPrivilegesMigrationV21_1Start21_2JoinTokensTableAcquisitionTypeInLeaseHistorySerializeViewUDTsExpressionIndexesDeleteDeprecatedNamespaceTableDescriptorMigration"
+const _Key_name = "Start20_2GeospatialTypeAlterColumnTypeGeneralUserDefinedSchemasNoOriginFKIndexesNodeMembershipStatusMinPasswordLengthAbortSpanBytesMaterializedViewsBox2DTypeCreateLoginPrivilegeHBAForNonTLSV20_2Start21_1EmptyArraysInInvertedIndexesUniqueWithoutIndexConstraintsVirtualComputedColumnsCPutInlineReplicaVersionsreplacedTruncatedAndRangeAppliedStateMigrationreplacedPostTruncatedAndRangeAppliedStateMigrationNewSchemaChangerLongRunningMigrationsTruncatedAndRangeAppliedStateMigrationPostTruncatedAndRangeAppliedStateMigrationSeparatedIntentsTracingVerbosityIndependentSemanticsSequencesRegclassImplicitColumnPartitioningMultiRegionFeaturesClosedTimestampsRaftTransportChangefeedsSupportPrimaryIndexChangesForeignKeyRepresentationMigrationPriorReadSummariesNonVotingReplicasProtectedTsMetaPrivilegesMigrationV21_1Start21_1PLUSStart21_2JoinTokensTableAcquisitionTypeInLeaseHistorySerializeViewUDTsExpressionIndexesDeleteDeprecatedNamespaceTableDescriptorMigration"
 
-var _Key_index = [...]uint16{0, 9, 23, 45, 63, 80, 100, 117, 131, 148, 157, 177, 189, 194, 203, 231, 260, 282, 292, 307, 353, 403, 419, 440, 478, 520, 536, 572, 589, 615, 634, 663, 700, 733, 751, 768, 802, 807, 816, 831, 860, 877, 894, 943}
+var _Key_index = [...]uint16{0, 9, 23, 45, 63, 80, 100, 117, 131, 148, 157, 177, 189, 194, 203, 231, 260, 282, 292, 307, 353, 403, 419, 440, 478, 520, 536, 572, 589, 615, 634, 663, 700, 733, 751, 768, 802, 807, 820, 829, 844, 873, 890, 907, 956}
 
 func (i Key) String() string {
 	if i < 0 || i >= Key(len(_Key_index)-1) {


### PR DESCRIPTION
The summer serverless offering requires an "in-between" release which
is v21.1.x plus multitenant-specific functionality. We will call this
the v21.1PLUS release. It has not yet been decided if v21.1PLUS
changes will become part of the 21.1.x branch or whether it will live
on its own branch.

This commit shifts cluster versions around to make some space for
migrations specific to this release:
 - we shift existing v21.2 versions (Major=21, Minor=1, Internal=2
   to Internal=102 through 112. Consequently, any existing cluster
   running `master` will rerun all the 21.2 migrations (which is ok
   since they are required to be idempotent).

 - we start a new chunk of v21.1PLUS versions at Major=21, Minor=1,
   Internal=14. We start at a value higher than the current master to
   avoid any confusion on clusters running master.

Any new v21.1PLUS feature that needs a migration will be developed on
master and will add a v21.2 version, e.g.
```
   {
     Key:     DeleteDeprecatedNamespaceTableDescriptorMigration,
     Version: roachpb.Version{Major: 21, Minor: 1, Internal: 112},
   },
+  {
+    Key:     SomeServerlessSpecificFeature,
+    Version: roachpb.Version{Major: 21, Minor: 1, Internal: 114},
+  },
```

When that change is backported to v21.1PLUS, this will become a
v21.2PLUS version:
```
   {
     Key: Start21_1PLUS,
     Version: roachpb.Version{Major: 21, Minor: 1, Internal: 14},
   },
+  {
+    Key:     SomeServerlessSpecificFeature,
+    Version: roachpb.Version{Major: 21, Minor: 1, Internal: 16},
+  },
```

Release note: None