### PR TITLE
release-20.2: kv: resolve only intents in rangefeed's own range from txnPushAttempt

### DIFF
--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -773,7 +773,7 @@ func (b *replicaAppBatch) runPreApplyTriggersAfterStagingWriteBatch(
 	// it will shut down with an error. If the WriteBatch is nil then we expect
 	// the logical operation log to also be nil. We don't want to trigger a
 	// shutdown of the rangefeed in that situation, so we don't pass anything to
-	// the rangefed. If no rangefeed is running at all, this call will be a noop.
+	// the rangefeed. If no rangefeed is running at all, this call will be a noop.
 	if ops := cmd.raftCmd.LogicalOpLog; cmd.raftCmd.WriteBatch != nil {
 		b.r.handleLogicalOpLogRaftMuLocked(ctx, ops, b.batch)
 	} else if ops != nil {

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -2050,6 +2050,37 @@ func (s Span) Overlaps(o Span) bool {
 	return bytes.Compare(s.EndKey, o.Key) > 0 && bytes.Compare(s.Key, o.EndKey) < 0
 }
 
+// Intersect returns the intersection of the key space covered by the two spans.
+// If there is no intersection between the two spans, an invalid span (see Valid)
+// is returned.
+func (s Span) Intersect(o Span) Span {
+	// If two spans do not overlap, there is no intersection between them.
+	if !s.Overlaps(o) {
+		return Span{}
+	}
+
+	// An empty end key means this span contains a single key. Overlaps already
+	// has special code for the single-key cases, so here we return whichever key
+	// is the single key, if any. If they are both a single key, we know they are
+	// equal anyway so the order doesn't matter.
+	if len(s.EndKey) == 0 {
+		return s
+	}
+	if len(o.EndKey) == 0 {
+		return o
+	}
+
+	key := s.Key
+	if key.Compare(o.Key) < 0 {
+		key = o.Key
+	}
+	endKey := s.EndKey
+	if endKey.Compare(o.EndKey) > 0 {
+		endKey = o.EndKey
+	}
+	return Span{key, endKey}
+}
+
 // Combine creates a new span containing the full union of the key
 // space covered by the two spans. This includes any key space not
 // covered by either span, but between them if the spans are disjoint.

--- a/pkg/roachpb/data_test.go
+++ b/pkg/roachpb/data_test.go
@@ -1091,6 +1091,59 @@ func TestSpanOverlaps(t *testing.T) {
 	}
 }
 
+func TestSpanIntersect(t *testing.T) {
+	sA := Span{Key: []byte("a")}
+	sD := Span{Key: []byte("d")}
+	sAtoC := Span{Key: []byte("a"), EndKey: []byte("c")}
+	sAtoD := Span{Key: []byte("a"), EndKey: []byte("d")}
+	sBtoC := Span{Key: []byte("b"), EndKey: []byte("c")}
+	sBtoD := Span{Key: []byte("b"), EndKey: []byte("d")}
+	sCtoD := Span{Key: []byte("c"), EndKey: []byte("d")}
+	// Invalid spans.
+	sCtoA := Span{Key: []byte("c"), EndKey: []byte("a")}
+	sDtoB := Span{Key: []byte("d"), EndKey: []byte("b")}
+
+	testData := []struct {
+		s1, s2 Span
+		expect Span
+	}{
+		{sA, sA, sA},
+		{sA, sAtoC, sA},
+		{sAtoC, sA, sA},
+		{sAtoC, sAtoC, sAtoC},
+		{sAtoC, sAtoD, sAtoC},
+		{sAtoD, sAtoC, sAtoC},
+		{sAtoC, sBtoC, sBtoC},
+		{sBtoC, sAtoC, sBtoC},
+		{sAtoC, sBtoD, sBtoC},
+		{sBtoD, sAtoC, sBtoC},
+		{sAtoD, sBtoC, sBtoC},
+		{sBtoC, sAtoD, sBtoC},
+		// Empty intersections.
+		{sA, sD, Span{}},
+		{sA, sBtoD, Span{}},
+		{sBtoD, sA, Span{}},
+		{sD, sBtoD, Span{}},
+		{sBtoD, sD, Span{}},
+		{sAtoC, sCtoD, Span{}},
+		{sCtoD, sAtoC, Span{}},
+		// Invalid spans.
+		{sAtoC, sDtoB, Span{}},
+		{sDtoB, sAtoC, Span{}},
+		{sBtoD, sCtoA, Span{}},
+		{sCtoA, sBtoD, Span{}},
+	}
+	for _, test := range testData {
+		in := test.s1.Intersect(test.s2)
+		if test.expect.Valid() {
+			require.True(t, in.Valid())
+			require.Equal(t, test.expect, in)
+		} else {
+			require.False(t, in.Valid())
+		}
+	}
+}
+
 func TestSpanCombine(t *testing.T) {
 	sA := Span{Key: []byte("a")}
 	sD := Span{Key: []byte("d")}


### PR DESCRIPTION
Backport 1/1 commits from #66746.

/cc @cockroachdb/release

---

Fixes #66741.

Before this change, `(*txnPushAttempt).pushOldTxns` would resolve all of
a committed or aborted transaction's intents that it discovered during a
push, instead of just those in the current range.

This was unnecessary for the purposes of the rangefeed, which only needs
a pushed transaction's intents in its range resolved. Worse, it could
result in quadratic behavior in cases where a large transaction wrote
many intents across many ranges that each had an active rangefeed
processor. In such cases, the rangefeed processor on each of the ranges
that the transaction touched would try to resolve its intents across all
ranges that the transaction touched. This could lead to a herd of
redundant intent resolution, which was especially disruptive if the
transaction had exceeded its precise intent span tracking and degraded
to ranged intent resolution.

This commit fixes this issue by having each rangefeed processor resolve
only those intents that are within the bounds of its own range. This
avoids the quadratic behavior that, in its worst form, could create a
pileup of ranged intent resolution across an entire table and starve out
foreground traffic.

Release note (bug fix): Changefeeds no longer interact poorly with
large, abandoned transactions. It was previously possible for this
combination to result in a cascade of work during transaction cleanup
that could starve out foreground traffic.

/cc. @cockroachdb/kv 
