### PR TITLE
kv: avoid 1k entry readahead in each scan of uncached Raft log

### DIFF
--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -131,11 +131,7 @@ func entries(
 	// sideloaded proposal, but the caller didn't give us a sideloaded storage.
 	canCache := true
 
-	var ent raftpb.Entry
-	scanFunc := func(kv roachpb.KeyValue) error {
-		if err := kv.Value.GetProto(&ent); err != nil {
-			return err
-		}
+	scanFunc := func(ent raftpb.Entry) error {
 		// Exit early if we have any gaps or it has been compacted.
 		if ent.Index != expectedIndex {
 			return iterutil.StopIteration()
@@ -226,22 +222,49 @@ func entries(
 	return nil, raft.ErrUnavailable
 }
 
+// iterateEntries iterates over each of the Raft log entries in the range
+// [lo,hi). At each step of the iteration, f() is invoked with the current log
+// entry.
+//
+// The function does not accept a maximum number of entries or bytes. Instead,
+// callers should enforce any limits by returning iterutil.StopIteration from
+// the iteration function to terminate iteration early, if necessary.
 func iterateEntries(
 	ctx context.Context,
 	reader storage.Reader,
 	rangeID roachpb.RangeID,
 	lo, hi uint64,
-	scanFunc func(roachpb.KeyValue) error,
+	f func(raftpb.Entry) error,
 ) error {
-	_, err := storage.MVCCIterate(
-		ctx, reader,
-		keys.RaftLogKey(rangeID, lo),
-		keys.RaftLogKey(rangeID, hi),
-		hlc.Timestamp{},
-		storage.MVCCScanOptions{},
-		scanFunc,
-	)
-	return err
+	key := keys.RaftLogKey(rangeID, lo)
+	endKey := keys.RaftLogKey(rangeID, hi)
+	iter := reader.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{
+		UpperBound: endKey,
+	})
+	defer iter.Close()
+
+	var meta enginepb.MVCCMetadata
+	var ent raftpb.Entry
+
+	iter.SeekGE(storage.MakeMVCCMetadataKey(key))
+	for ; ; iter.Next() {
+		if ok, err := iter.Valid(); err != nil || !ok {
+			return err
+		}
+
+		if err := protoutil.Unmarshal(iter.UnsafeValue(), &meta); err != nil {
+			return errors.Wrap(err, "unable to decode MVCCMetadata")
+		}
+		if err := storage.MakeValue(meta).GetProto(&ent); err != nil {
+			return errors.Wrap(err, "unable to unmarshal raft Entry")
+		}
+		if err := f(ent); err != nil {
+			if iterutil.Done(err) {
+				return nil
+			}
+			return err
+		}
+	}
 }
 
 // invalidLastTerm is an out-of-band value for r.mu.lastTerm that

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -382,52 +382,16 @@ func (kvSS *kvBatchSnapshotStrategy) Send(
 
 	// Iterate over the specified range of Raft entries and send them all out
 	// together.
+	rangeID := header.State.Desc.RangeID
 	firstIndex := header.State.TruncatedState.Index + 1
 	endIndex := snap.RaftSnap.Metadata.Index + 1
-	preallocSize := endIndex - firstIndex
-	const maxPreallocSize = 1000
-	if preallocSize > maxPreallocSize {
-		// It's possible for the raft log to become enormous in certain
-		// sustained failure conditions. We may bail out of the snapshot
-		// process early in scanFunc, but in the worst case this
-		// preallocation is enough to run the server out of memory. Limit
-		// the size of the buffer we will preallocate.
-		preallocSize = maxPreallocSize
+	logEntries := make([]raftpb.Entry, 0, endIndex-firstIndex)
+	scanFunc := func(ent raftpb.Entry) error {
+		logEntries = append(logEntries, ent)
+		return nil
 	}
-	logEntries := make([][]byte, 0, preallocSize)
-
-	var raftLogBytes int64
-	scanFunc := func(kv roachpb.KeyValue) error {
-		bytes, err := kv.Value.GetBytes()
-		if err == nil {
-			logEntries = append(logEntries, bytes)
-			raftLogBytes += int64(len(bytes))
-		}
-		return err
-	}
-
-	rangeID := header.State.Desc.RangeID
-
 	if err := iterateEntries(ctx, snap.EngineSnap, rangeID, firstIndex, endIndex, scanFunc); err != nil {
 		return 0, err
-	}
-
-	// The difference between the snapshot index (applied index at the time of
-	// snapshot) and the truncated index should equal the number of log entries
-	// shipped over.
-	expLen := endIndex - firstIndex
-	if expLen != uint64(len(logEntries)) {
-		// We've generated a botched snapshot. We could fatal right here but opt
-		// to warn loudly instead, and fatal at the caller to capture a checkpoint
-		// of the underlying storage engine.
-		entriesRange, err := extractRangeFromEntries(logEntries)
-		if err != nil {
-			return 0, err
-		}
-		log.Warningf(ctx, "missing log entries in snapshot (%s): "+
-			"got %d entries, expected %d (TruncatedState.Index=%d, LogEntries=%s)",
-			snap.String(), len(logEntries), expLen, snap.State.TruncatedState.Index, entriesRange)
-		return 0, errMalformedSnapshot
 	}
 
 	// Inline the payloads for all sideloaded proposals.
@@ -437,11 +401,7 @@ func (kvSS *kvBatchSnapshotStrategy) Send(
 	// solution, but let's see if it ever becomes relevant. Snapshots with
 	// inlined proposals are hopefully the exception.
 	{
-		var ent raftpb.Entry
-		for i := range logEntries {
-			if err := protoutil.Unmarshal(logEntries[i], &ent); err != nil {
-				return 0, err
-			}
+		for i, ent := range logEntries {
 			if !sniffSideloadedRaftCommand(ent.Data) {
 				continue
 			}
@@ -453,7 +413,7 @@ func (kvSS *kvBatchSnapshotStrategy) Send(
 					return err
 				}
 				if newEnt != nil {
-					ent = *newEnt
+					logEntries[i] = *newEnt
 				}
 				return nil
 			}); err != nil {
@@ -479,15 +439,39 @@ func (kvSS *kvBatchSnapshotStrategy) Send(
 				}
 				return 0, err
 			}
-			// TODO(tschottdorf): it should be possible to reuse `logEntries[i]` here.
-			var err error
-			if logEntries[i], err = protoutil.Marshal(&ent); err != nil {
-				return 0, err
-			}
 		}
 	}
+
+	// Marshal each of the log entries.
+	logEntriesRaw := make([][]byte, len(logEntries))
+	for i := range logEntries {
+		entRaw, err := protoutil.Marshal(&logEntries[i])
+		if err != nil {
+			return 0, err
+		}
+		logEntriesRaw[i] = entRaw
+	}
+
+	// The difference between the snapshot index (applied index at the time of
+	// snapshot) and the truncated index should equal the number of log entries
+	// shipped over.
+	expLen := endIndex - firstIndex
+	if expLen != uint64(len(logEntries)) {
+		// We've generated a botched snapshot. We could fatal right here but opt
+		// to warn loudly instead, and fatal at the caller to capture a checkpoint
+		// of the underlying storage engine.
+		entriesRange, err := extractRangeFromEntries(logEntriesRaw)
+		if err != nil {
+			return 0, err
+		}
+		log.Warningf(ctx, "missing log entries in snapshot (%s): "+
+			"got %d entries, expected %d (TruncatedState.Index=%d, LogEntries=%s)",
+			snap.String(), len(logEntries), expLen, snap.State.TruncatedState.Index, entriesRange)
+		return 0, errMalformedSnapshot
+	}
+
 	kvSS.status = fmt.Sprintf("kv pairs: %d, log entries: %d", kvs, len(logEntries))
-	if err := stream.Send(&SnapshotRequest{LogEntries: logEntries}); err != nil {
+	if err := stream.Send(&SnapshotRequest{LogEntries: logEntriesRaw}); err != nil {
 		return 0, err
 	}
 	return bytesSent, nil

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -2507,9 +2507,9 @@ type MVCCScanOptions struct {
 	MaxKeys int64
 	// TargetBytes is a byte threshold to limit the amount of data pulled into
 	// memory during a Scan operation. Once the target is satisfied (i.e. met or
-	// exceeded) by the emitted emitted KV pairs, iteration stops (with a
-	// ResumeSpan as appropriate). In particular, at least one kv pair is
-	// returned (when one exists).
+	// exceeded) by the emitted KV pairs, iteration stops (with a ResumeSpan as
+	// appropriate). In particular, at least one kv pair is returned (when one
+	// exists).
 	//
 	// The number of bytes a particular kv pair accrues depends on internal data
 	// structures, but it is guaranteed to exceed that of the bytes stored in
@@ -2633,11 +2633,12 @@ func MVCCScanAsTxn(
 
 // MVCCIterate iterates over the key range [start,end). At each step of the
 // iteration, f() is invoked with the current key/value pair. If f returns
-// true (done) or an error, the iteration stops and the error is propagated.
-// If the reverse is flag set the iterator will be moved in reverse order.
-// If the scan options specify an inconsistent scan, all "ignored" intents
-// will be returned. In consistent mode, intents are only ever returned as
-// part of a WriteIntentError.
+// iterutil.StopIteration, the iteration stops with no error propagated. If f
+// returns any other error, the iteration stops and the error is propagated. If
+// the reverse flag is set, the iterator will be moved in reverse order. If the
+// scan options specify an inconsistent scan, all "ignored" intents will be
+// returned. In consistent mode, intents are only ever returned as part of a
+// WriteIntentError.
 func MVCCIterate(
 	ctx context.Context,
 	reader Reader,


### PR DESCRIPTION
Fixes #66682.

In #66682, we noticed a poor interaction between Raft and the MVCC API. When a Raft leader is catching up its followers, it often sends out large chunks of log entries. We prevent this from being overly expensive in the presence of large log entries by limiting the aggregate size of these entries to 32 KB (`defaultRaftMaxSizePerMsg`) at a time. This is accomplished through the through the `maxBytes` param that is passed throughout the `raft.Storage` implementation.

What we noticed was that even though we configure a `maxBytes` of 32 KB, no limit is passed through to `iterateEntries`'s call to `MVCCIterate`. This seems harmless enough, because the iterator function passed to `MVCCIterate` terminates once the byte limit is exceeded. However, behind the scenes, `MVCCIterate` pulls in up to 1000 entries (`maxKeysPerScan`) from Pebble at a time, with no accompanying byte limit. So in a cluster with large log entries, where even just one is enough to exceed our budget, this ends up being very expensive.

In the customer cluster that we were looking at when we found #66682, each log entry was 131KB large. So each attempt to grab a new log entry read 131MB from the LSM. This was likely all cached, but even just unmarshaling this was expensive due to the memory copies doing so performs. This was so expensive that each call to grab a single entry took about 65ms. This was bad, and it became even worse when a follower sent 100 MsgAppResps in response to the 100 MsgApps sent by the leader (which is suboptimal but expected). If these all landed on the leader at once, it would spend `100*65ms = 6.5s` processing messages in `Store.processRequestQueue`. This stall was long enough for another follower to call an election and for the leader to lose its leadership. Since two replicas were possible leaders and both were in this situation, it never resolved and leadership ping-ponged.

This commit fixes this issue by replacing the call to `MVCCIterate` in `iterateEntries` with direct use of an MVCC iterator. This provides more control over iteration and allows us to avoid the unwanted readahead policy. It also allows us to avoid some of the unnecessary cruft of `MVCCIterate`.

### Rejected Alternatives

I briefly considered trying to adapt `MVCCIterate` to be more configurable through the `MVCCScanOptions` it is provided, but that seemed like a fraught task. This was primarily because the `TargetBytes` config is not quite what we want in this case, where we need to be precise about the sizes of these entries (see 9d46451) and don't want to count the key size of the MVCCMetadata wrapper size.

I also considered simply adding some conservative, non-configurable readahead byte limit to `MVCCIterate` to sit alongside its key limit. This may still be a good idea. But I also think we may want to restrict the cases where we even use the function.

Finally, I considered removing the readahead behavior in `MVCCIterate` entirely. I think it might have been added to avoid repeat CGo hops back when we had RocksDB. But now that we have Pebble and can manipulate an iterator cheaply, it can maybe be rejected. However, this would then require us to lift some logic from `pebbleMVCCScanner` into `MVCCIterate`, which I wasn't keen on doing.

Release note (bug fix): Catching up Raft followers on the Raft log is now more efficient in the presence of many large Raft log entries. This helps avoid situations where Raft leaders struggle to retain leadership while catching up their followers.

/cc. @cockroachdb/kv 