### PR TITLE
sql/pgwire: add ops logging for draining events

### DIFF
--- a/pkg/server/drain.go
+++ b/pkg/server/drain.go
@@ -198,12 +198,12 @@ func (s *Server) drainClients(ctx context.Context, reporter func(int, redact.Saf
 	}
 
 	// Disable incoming SQL clients up to the queryWait timeout.
-	drainMaxWait := queryWait.Get(&s.st.SV)
-	if err := s.sqlServer.pgServer.Drain(drainMaxWait, reporter); err != nil {
+	queryMaxWait := queryWait.Get(&s.st.SV)
+	if err := s.sqlServer.pgServer.Drain(ctx, queryMaxWait, reporter); err != nil {
 		return err
 	}
 	// Stop ongoing SQL execution up to the queryWait timeout.
-	s.sqlServer.distSQLServer.Drain(ctx, drainMaxWait, reporter)
+	s.sqlServer.distSQLServer.Drain(ctx, queryMaxWait, reporter)
 
 	// Drain the SQL leases. This must be done after the pgServer has
 	// given sessions a chance to finish ongoing work.

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -497,8 +497,9 @@ func (c *conn) serveImpl(
 	if draining() {
 		// TODO(andrei): I think sending this extra error to the client if we also
 		// sent another error for the last query (like a context canceled) is a bad
-		// idead; see #22630. I think we should find a way to return the
+		// idea; see #22630. I think we should find a way to return the
 		// AdminShutdown error as the only result of the query.
+		log.Ops.Info(ctx, "closing existing connection while server is draining")
 		_ /* err */ = writeErr(ctx, &sqlServer.GetExecutorConfig().Settings.SV,
 			newAdminShutdownErr(ErrDrainingExistingConn), &c.msgBuilder, &c.writerState.buf)
 		_ /* n */, _ /* err */ = c.writerState.buf.WriteTo(c.conn)

--- a/pkg/sql/pgwire/helpers_test.go
+++ b/pkg/sql/pgwire/helpers_test.go
@@ -15,8 +15,10 @@ import (
 	"time"
 )
 
-func (s *Server) DrainImpl(drainWait time.Duration, cancelWait time.Duration) error {
-	return s.drainImpl(drainWait, cancelWait, nil /* reporter */)
+func (s *Server) DrainImpl(
+	ctx context.Context, queryWait time.Duration, cancelWait time.Duration,
+) error {
+	return s.drainImpl(ctx, queryWait, cancelWait, nil /* reporter */)
 }
 
 // OverwriteCancelMap overwrites all active connections' context.CancelFuncs so

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -141,7 +141,8 @@ func TestPGWireDrainOngoingTxns(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	params := base.TestServerArgs{Insecure: true}
 	s, _, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop(context.Background())
+	ctx := context.Background()
+	defer s.Stopper().Stop(ctx)
 
 	host, port, err := net.SplitHostPort(s.ServingSQLAddr())
 	if err != nil {
@@ -176,14 +177,14 @@ func TestPGWireDrainOngoingTxns(t *testing.T) {
 		// pgServer stops waiting for connections to respond to cancellation.
 		realCancels := pgServer.OverwriteCancelMap()
 
-		// Set draining with no drainWait or cancelWait timeout. The expected
+		// Set draining with no queryWait or cancelWait timeout. The expected
 		// behavior is that the ongoing session is immediately canceled but
 		// since we overwrote the context.CancelFunc, this cancellation will
 		// not have any effect. The pgServer will not bother to wait for the
 		// connection to close properly and should notify the caller that a
 		// session did not respond to cancellation.
 		if err := pgServer.DrainImpl(
-			0 /* drainWait */, 0, /* cancelWait */
+			ctx, 0 /* queryWait */, 0, /* cancelWait */
 		); !testutils.IsError(err, "some sessions did not respond to cancellation") {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -218,11 +219,11 @@ func TestPGWireDrainOngoingTxns(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		// Set draining with no drainWait timeout and a 2s cancelWait timeout.
+		// Set draining with no queryWait timeout and a 2s cancelWait timeout.
 		// The expected behavior is for the pgServer to immediately cancel any
 		// ongoing sessions and wait for 2s for the cancellation to take effect.
 		if err := pgServer.DrainImpl(
-			0 /* drainWait */, 2*time.Second, /* cancelWait */
+			ctx, 0 /* queryWait */, 2*time.Second, /* cancelWait */
 		); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -86,7 +86,7 @@ const (
 
 	// ErrDrainingNewConn is returned when a client attempts to connect to a server
 	// which is not accepting client connections.
-	ErrDrainingNewConn = "server is not accepting clients"
+	ErrDrainingNewConn = "server is not accepting clients, try another node"
 	// ErrDrainingExistingConn is returned when a connection is shut down because
 	// the server is draining.
 	ErrDrainingExistingConn = "server is shutting down"
@@ -369,8 +369,10 @@ func (s *Server) Metrics() (res []interface{}) {
 // to report work that needed to be done and which may or may not have
 // been done by the time this call returns. See the explanation in
 // pkg/server/drain.go for details.
-func (s *Server) Drain(drainWait time.Duration, reporter func(int, redact.SafeString)) error {
-	return s.drainImpl(drainWait, cancelMaxWait, reporter)
+func (s *Server) Drain(
+	ctx context.Context, drainWait time.Duration, reporter func(int, redact.SafeString),
+) error {
+	return s.drainImpl(ctx, drainWait, cancelMaxWait, reporter)
 }
 
 // Undrain switches the server back to the normal mode of operation in which
@@ -393,9 +395,9 @@ func (s *Server) setDrainingLocked(drain bool) bool {
 
 // drainImpl drains the SQL clients.
 //
-// The drainWait duration is used to wait on clients to
+// The queryWait duration is used to wait on clients to
 // self-disconnect after their session has been canceled. The
-// cancelWait is used to wait after the drainWait timer has expired
+// cancelWait is used to wait after the queryWait timer has expired
 // and there are still clients connected, and their context.Context is
 // canceled.
 //
@@ -404,7 +406,10 @@ func (s *Server) setDrainingLocked(drain bool) bool {
 // been done by the time this call returns. See the explanation in
 // pkg/server/drain.go for details.
 func (s *Server) drainImpl(
-	drainWait time.Duration, cancelWait time.Duration, reporter func(int, redact.SafeString),
+	ctx context.Context,
+	queryWait time.Duration,
+	cancelWait time.Duration,
+	reporter func(int, redact.SafeString),
 ) error {
 	// This anonymous function returns a copy of s.mu.connCancelMap if there are
 	// any active connections to cancel. We will only attempt to cancel
@@ -456,7 +461,8 @@ func (s *Server) drainImpl(
 
 	// Wait for all connections to finish up to drainWait.
 	select {
-	case <-time.After(drainWait):
+	case <-time.After(queryWait):
+		log.Ops.Warningf(ctx, "canceling all sessions after waiting %s", queryWait)
 	case <-allConnsDone:
 	}
 
@@ -601,6 +607,7 @@ func (s *Server) ServeConn(ctx context.Context, conn net.Conn, socketType Socket
 
 	// If the server is shutting down, terminate the connection early.
 	if draining {
+		log.Ops.Info(ctx, "rejecting new connection while server is draining")
 		return s.sendErr(ctx, conn, newAdminShutdownErr(ErrDrainingNewConn))
 	}
 


### PR DESCRIPTION
Release note (ops change): Added logs for important events during the
server draining/shutdown process: (1) log when the server closes an
existing connection while draining, (2) log when the server rejects a
new connection while draining, and (3) log when the server cancels
in-flight queries after waiting for the server.shutdown.query_wait
duration to elapse while draining.