### PR TITLE
release-21.1: opt: fix panic due to concurrent map writes when copying metadata

### DIFF
--- a/pkg/sql/opt/table_meta.go
+++ b/pkg/sql/opt/table_meta.go
@@ -186,11 +186,21 @@ func (tm *TableMeta) copyScalars(copyScalar func(Expr) Expr) {
 	if tm.Constraints != nil {
 		tm.Constraints = copyScalar(tm.Constraints).(ScalarExpr)
 	}
-	for col, e := range tm.ComputedCols {
-		tm.ComputedCols[col] = copyScalar(e).(ScalarExpr)
+
+	if tm.ComputedCols != nil {
+		computedCols := make(map[ColumnID]ScalarExpr, len(tm.ComputedCols))
+		for col, e := range tm.ComputedCols {
+			computedCols[col] = copyScalar(e).(ScalarExpr)
+		}
+		tm.ComputedCols = computedCols
 	}
-	for idx, e := range tm.partialIndexPredicates {
-		tm.partialIndexPredicates[idx] = copyScalar(e).(ScalarExpr)
+
+	if tm.partialIndexPredicates != nil {
+		partialIndexPredicates := make(map[cat.IndexOrdinal]ScalarExpr, len(tm.partialIndexPredicates))
+		for idx, e := range tm.partialIndexPredicates {
+			partialIndexPredicates[idx] = copyScalar(e).(ScalarExpr)
+		}
+		tm.partialIndexPredicates = partialIndexPredicates
 	}
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #66792.

/cc @cockroachdb/release

---

This commit fixes a bug that caused a panic due to concurrent map writes
when copying table metadata. The fix is to make a deep copy of the map
before updating it.

Fixes #66717

Release note (bug fix): Fixed a panic that could occur in the optimizer
when executing a prepared plan with placeholders. This could happen when
one of the tables used by the query had computed columns or a partial
index.
