### PR TITLE
envutil,server: report more env vars upon server startup and in telemetry

### DIFF
--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -963,7 +963,7 @@ func clientFlagsRPC() string {
 func reportConfiguration(ctx context.Context) {
 	serverCfg.Report(ctx)
 	if envVarsUsed := envutil.GetEnvVarsUsed(); len(envVarsUsed) > 0 {
-		log.Ops.Infof(ctx, "using local environment variables: %s", strings.Join(envVarsUsed, ", "))
+		log.Ops.Infof(ctx, "using local environment variables:\n%s", redact.Join("\n", envVarsUsed))
 	}
 	// If a user ever reports "bad things have happened", any
 	// troubleshooting steps will want to rule out that the user was

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -1362,7 +1362,7 @@ func (s *statusServer) Nodes(
 		return nil, err
 	}
 
-	resp, _, err := s.nodesHelper(ctx, 0, 0)
+	resp, _, err := s.nodesHelper(ctx, 0 /* limit */, 0 /* offset */)
 	return resp, err
 }
 
@@ -1371,7 +1371,7 @@ func (s *statusServer) Nodes(
 func (s *statusServer) ListNodesInternal(
 	ctx context.Context, req *serverpb.NodesRequest,
 ) (*serverpb.NodesResponse, error) {
-	resp, _, err := s.nodesHelper(ctx, 0, 0)
+	resp, _, err := s.nodesHelper(ctx, 0 /* limit */, 0 /* offset */)
 	return resp, err
 }
 

--- a/pkg/server/status/BUILD.bazel
+++ b/pkg/server/status/BUILD.bazel
@@ -63,6 +63,7 @@ go_library(
         "//pkg/util/system",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_dustin_go_humanize//:go-humanize",
         "@com_github_elastic_gosigar//:gosigar",
         "@com_github_shirou_gopsutil//net",

--- a/pkg/util/envutil/BUILD.bazel
+++ b/pkg/util/envutil/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/util/humanizeutil",
         "//pkg/util/syncutil",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 


### PR DESCRIPTION
Supersedes #66805. 
Informs #66838 (option 2).

We want more visibility into the env vars that influence the server's
state, for example HTTP_PROXY or more generally those env vars that
our dependency and the go runtime observe.

However, we need to be careful:

- we can't report *all* env vars because there are many cases where
  even the name of an env var or its presence is confidential
  information.
- even for the env vars where we're confident that we can
  report that it is set, we cannot always report its value
  because the value itself could be confidential (e.g. HTTP_PROXY).

This patch thus adds env var reporting with a nuance between the
following:

- safe name, safe value (e.g. GOMAXPROCS)
- safe name, redactable value (e.g. TERM)
- safe name, no value (e.g HTTP_PROXY)

Example:
![image](https://user-images.githubusercontent.com/642886/127644871-816b4e0d-4de8-4e37-a451-dcdafc8b4bc4.png)


Release note (cli change): CockroachDB server nodes now report
more environment variables in logs upon startup. Only certain
environment variables that may have an influence on the server's
behavior are reported.