### PR TITLE
roachtest: move Cluster to subpackage

### DIFF
--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -22,7 +22,6 @@ go_library(
         "clock_util.go",
         "cluster.go",
         "cluster_init.go",
-        "cluster_interface.go",
         "connection_latency.go",
         "copy.go",
         "decommission.go",
@@ -134,6 +133,7 @@ go_library(
         "//pkg/cli",
         "//pkg/cmd/cmpconn",
         "//pkg/cmd/internal/issues",
+        "//pkg/cmd/roachtest/cluster",
         "//pkg/cmd/roachtest/logger",
         "//pkg/cmd/roachtest/option",
         "//pkg/cmd/roachtest/prometheus",
@@ -218,6 +218,7 @@ go_test(
     embed = [":roachtest_lib"],
     tags = ["broken_in_bazel"],
     deps = [
+        "//pkg/cmd/roachtest/cluster",
         "//pkg/cmd/roachtest/logger",
         "//pkg/cmd/roachtest/option",
         "//pkg/cmd/roachtest/spec",

--- a/pkg/cmd/roachtest/acceptance.go
+++ b/pkg/cmd/roachtest/acceptance.go
@@ -14,13 +14,13 @@ import (
 	"context"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 )
 
 func registerAcceptance(r *testRegistry) {
 	testCases := map[Owner][]struct {
 		name       string
-		fn         func(ctx context.Context, t *test, c cluster2.Cluster)
+		fn         func(ctx context.Context, t *test, c cluster.Cluster)
 		skip       string
 		minVersion string
 		numNodes   int
@@ -45,7 +45,7 @@ func registerAcceptance(r *testRegistry) {
 			},
 			{
 				name: "version-upgrade",
-				fn: func(ctx context.Context, t *test, c cluster2.Cluster) {
+				fn: func(ctx context.Context, t *test, c cluster.Cluster) {
 					runVersionUpgrade(ctx, t, c, r.buildVersion)
 				},
 				// This test doesn't like running on old versions because it upgrades to
@@ -99,7 +99,7 @@ func registerAcceptance(r *testRegistry) {
 			if tc.timeout != 0 {
 				spec.Timeout = tc.timeout
 			}
-			spec.Run = func(ctx context.Context, t *test, c cluster2.Cluster) {
+			spec.Run = func(ctx context.Context, t *test, c cluster.Cluster) {
 				tc.fn(ctx, t, c)
 			}
 			r.Add(spec)

--- a/pkg/cmd/roachtest/acceptance.go
+++ b/pkg/cmd/roachtest/acceptance.go
@@ -13,12 +13,14 @@ package main
 import (
 	"context"
 	"time"
+
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 )
 
 func registerAcceptance(r *testRegistry) {
 	testCases := map[Owner][]struct {
 		name       string
-		fn         func(ctx context.Context, t *test, c Cluster)
+		fn         func(ctx context.Context, t *test, c cluster2.Cluster)
 		skip       string
 		minVersion string
 		numNodes   int
@@ -43,7 +45,7 @@ func registerAcceptance(r *testRegistry) {
 			},
 			{
 				name: "version-upgrade",
-				fn: func(ctx context.Context, t *test, c Cluster) {
+				fn: func(ctx context.Context, t *test, c cluster2.Cluster) {
 					runVersionUpgrade(ctx, t, c, r.buildVersion)
 				},
 				// This test doesn't like running on old versions because it upgrades to
@@ -97,7 +99,7 @@ func registerAcceptance(r *testRegistry) {
 			if tc.timeout != 0 {
 				spec.Timeout = tc.timeout
 			}
-			spec.Run = func(ctx context.Context, t *test, c Cluster) {
+			spec.Run = func(ctx context.Context, t *test, c cluster2.Cluster) {
 				tc.fn(ctx, t, c)
 			}
 			r.Add(spec)

--- a/pkg/cmd/roachtest/activerecord.go
+++ b/pkg/cmd/roachtest/activerecord.go
@@ -31,7 +31,7 @@ func registerActiveRecord(r *testRegistry) {
 		t *test,
 		c Cluster,
 	) {
-		if c.isLocal() {
+		if c.IsLocal() {
 			t.Fatal("cannot be run in local mode")
 		}
 		node := c.Node(1)

--- a/pkg/cmd/roachtest/activerecord.go
+++ b/pkg/cmd/roachtest/activerecord.go
@@ -40,7 +40,7 @@ func registerActiveRecord(r *testRegistry) {
 		if err := c.PutLibraries(ctx, "./lib"); err != nil {
 			t.Fatal(err)
 		}
-		c.Start(ctx, t, c.All())
+		c.Start(ctx, c.All())
 
 		version, err := fetchCockroachVersion(ctx, c, node[0], nil)
 		if err != nil {

--- a/pkg/cmd/roachtest/activerecord.go
+++ b/pkg/cmd/roachtest/activerecord.go
@@ -16,6 +16,8 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 )
 
 var activerecordResultRegex = regexp.MustCompile(`^(?P<test>[^\s]+#[^\s]+) = (?P<timing>\d+\.\d+ s) = (?P<result>.)$`)
@@ -29,7 +31,7 @@ func registerActiveRecord(r *testRegistry) {
 	runActiveRecord := func(
 		ctx context.Context,
 		t *test,
-		c Cluster,
+		c cluster2.Cluster,
 	) {
 		if c.IsLocal() {
 			t.Fatal("cannot be run in local mode")

--- a/pkg/cmd/roachtest/activerecord.go
+++ b/pkg/cmd/roachtest/activerecord.go
@@ -17,7 +17,7 @@ import (
 	"fmt"
 	"regexp"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 )
 
 var activerecordResultRegex = regexp.MustCompile(`^(?P<test>[^\s]+#[^\s]+) = (?P<timing>\d+\.\d+ s) = (?P<result>.)$`)
@@ -31,7 +31,7 @@ func registerActiveRecord(r *testRegistry) {
 	runActiveRecord := func(
 		ctx context.Context,
 		t *test,
-		c cluster2.Cluster,
+		c cluster.Cluster,
 	) {
 		if c.IsLocal() {
 			t.Fatal("cannot be run in local mode")

--- a/pkg/cmd/roachtest/allocator.go
+++ b/pkg/cmd/roachtest/allocator.go
@@ -17,7 +17,7 @@ import (
 	"math"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/logger"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -25,7 +25,7 @@ import (
 )
 
 func registerAllocator(r *testRegistry) {
-	runAllocator := func(ctx context.Context, t *test, c cluster2.Cluster, start int, maxStdDev float64) {
+	runAllocator := func(ctx context.Context, t *test, c cluster.Cluster, start int, maxStdDev float64) {
 		c.Put(ctx, cockroach, "./cockroach")
 
 		// Start the first `start` nodes and restore a tpch fixture.
@@ -77,7 +77,7 @@ func registerAllocator(r *testRegistry) {
 		Name:    `replicate/up/1to3`,
 		Owner:   OwnerKV,
 		Cluster: r.makeClusterSpec(3),
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runAllocator(ctx, t, c, 1, 10.0)
 		},
 	})
@@ -85,7 +85,7 @@ func registerAllocator(r *testRegistry) {
 		Name:    `replicate/rebalance/3to5`,
 		Owner:   OwnerKV,
 		Cluster: r.makeClusterSpec(5),
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runAllocator(ctx, t, c, 3, 42.0)
 		},
 	})
@@ -255,7 +255,7 @@ func waitForRebalance(
 	}
 }
 
-func runWideReplication(ctx context.Context, t *test, c cluster2.Cluster) {
+func runWideReplication(ctx context.Context, t *test, c cluster.Cluster) {
 	nodes := c.Spec().NodeCount
 	if nodes != 9 {
 		t.Fatalf("9-node cluster required")

--- a/pkg/cmd/roachtest/allocator.go
+++ b/pkg/cmd/roachtest/allocator.go
@@ -29,7 +29,7 @@ func registerAllocator(r *testRegistry) {
 
 		// Start the first `start` nodes and restore a tpch fixture.
 		args := startArgs("--args=--vmodule=store_rebalancer=5,allocator=5,allocator_scorer=5,replicate_queue=5")
-		c.Start(ctx, t, c.Range(1, start), args)
+		c.Start(ctx, c.Range(1, start), args)
 		db := c.Conn(ctx, 1)
 		defer db.Close()
 
@@ -46,7 +46,7 @@ func registerAllocator(r *testRegistry) {
 		m.Wait()
 
 		// Start the remaining nodes to kick off upreplication/rebalancing.
-		c.Start(ctx, t, c.Range(start+1, c.Spec().NodeCount), args)
+		c.Start(ctx, c.Range(start+1, c.Spec().NodeCount), args)
 
 		c.Run(ctx, c.Node(1), `./cockroach workload init kv --drop`)
 		for node := 1; node <= c.Spec().NodeCount; node++ {
@@ -265,7 +265,7 @@ func runWideReplication(ctx context.Context, t *test, c Cluster) {
 		"--args=--vmodule=replicate_queue=6",
 	)
 	c.Put(ctx, cockroach, "./cockroach")
-	c.Start(ctx, t, c.All(), args)
+	c.Start(ctx, c.All(), args)
 
 	db := c.Conn(ctx, 1)
 	defer db.Close()
@@ -334,7 +334,7 @@ func runWideReplication(ctx context.Context, t *test, c Cluster) {
 	// Stop the cluster and restart 2/3 of the nodes.
 	c.Stop(ctx)
 	tBeginDown := timeutil.Now()
-	c.Start(ctx, t, c.Range(1, 6), args)
+	c.Start(ctx, c.Range(1, 6), args)
 
 	waitForUnderReplicated := func(count int) {
 		for start := timeutil.Now(); ; time.Sleep(time.Second) {
@@ -390,5 +390,5 @@ FROM crdb_internal.kv_store_status
 	waitForReplication(5)
 
 	// Restart the down nodes to prevent the dead node detector from complaining.
-	c.Start(ctx, t, c.Range(7, 9))
+	c.Start(ctx, c.Range(7, 9))
 }

--- a/pkg/cmd/roachtest/allocator.go
+++ b/pkg/cmd/roachtest/allocator.go
@@ -60,7 +60,7 @@ func registerAllocator(r *testRegistry) {
 					t.Fatal(err)
 				}
 				defer l.Close()
-				_ = execCmd(ctx, t.l, roachprod, "ssh", c.makeNodes(c.Node(node)), "--", cmd)
+				_ = execCmd(ctx, t.l, roachprod, "ssh", c.MakeNodes(c.Node(node)), "--", cmd)
 			}()
 		}
 

--- a/pkg/cmd/roachtest/allocator.go
+++ b/pkg/cmd/roachtest/allocator.go
@@ -17,6 +17,7 @@ import (
 	"math"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/logger"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -24,7 +25,7 @@ import (
 )
 
 func registerAllocator(r *testRegistry) {
-	runAllocator := func(ctx context.Context, t *test, c Cluster, start int, maxStdDev float64) {
+	runAllocator := func(ctx context.Context, t *test, c cluster2.Cluster, start int, maxStdDev float64) {
 		c.Put(ctx, cockroach, "./cockroach")
 
 		// Start the first `start` nodes and restore a tpch fixture.
@@ -76,7 +77,7 @@ func registerAllocator(r *testRegistry) {
 		Name:    `replicate/up/1to3`,
 		Owner:   OwnerKV,
 		Cluster: r.makeClusterSpec(3),
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runAllocator(ctx, t, c, 1, 10.0)
 		},
 	})
@@ -84,7 +85,7 @@ func registerAllocator(r *testRegistry) {
 		Name:    `replicate/rebalance/3to5`,
 		Owner:   OwnerKV,
 		Cluster: r.makeClusterSpec(5),
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runAllocator(ctx, t, c, 3, 42.0)
 		},
 	})
@@ -254,7 +255,7 @@ func waitForRebalance(
 	}
 }
 
-func runWideReplication(ctx context.Context, t *test, c Cluster) {
+func runWideReplication(ctx context.Context, t *test, c cluster2.Cluster) {
 	nodes := c.Spec().NodeCount
 	if nodes != 9 {
 		t.Fatalf("9-node cluster required")

--- a/pkg/cmd/roachtest/alterpk.go
+++ b/pkg/cmd/roachtest/alterpk.go
@@ -30,7 +30,7 @@ func registerAlterPK(r *testRegistry) {
 		c.Put(ctx, workload, "./workload", loadNode)
 
 		t.Status("starting cockroach nodes")
-		c.Start(ctx, t, roachNodes)
+		c.Start(ctx, roachNodes)
 		return roachNodes, loadNode
 	}
 

--- a/pkg/cmd/roachtest/alterpk.go
+++ b/pkg/cmd/roachtest/alterpk.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
@@ -22,7 +23,7 @@ import (
 
 func registerAlterPK(r *testRegistry) {
 
-	setupTest := func(ctx context.Context, t *test, c Cluster) (option.NodeListOption, option.NodeListOption) {
+	setupTest := func(ctx context.Context, t *test, c cluster2.Cluster) (option.NodeListOption, option.NodeListOption) {
 		roachNodes := c.Range(1, c.Spec().NodeCount-1)
 		loadNode := c.Node(c.Spec().NodeCount)
 		t.Status("copying binaries")
@@ -35,7 +36,7 @@ func registerAlterPK(r *testRegistry) {
 	}
 
 	// runAlterPKBank runs a primary key change while the bank workload runs.
-	runAlterPKBank := func(ctx context.Context, t *test, c Cluster) {
+	runAlterPKBank := func(ctx context.Context, t *test, c cluster2.Cluster) {
 		const numRows = 1000000
 		const duration = 1 * time.Minute
 
@@ -90,7 +91,7 @@ func registerAlterPK(r *testRegistry) {
 	}
 
 	// runAlterPKTPCC runs a primary key change while the TPCC workload runs.
-	runAlterPKTPCC := func(ctx context.Context, t *test, c Cluster, warehouses int, expensiveChecks bool) {
+	runAlterPKTPCC := func(ctx context.Context, t *test, c cluster2.Cluster, warehouses int, expensiveChecks bool) {
 		const duration = 10 * time.Minute
 
 		roachNodes, loadNode := setupTest(ctx, t, c)
@@ -182,7 +183,7 @@ func registerAlterPK(r *testRegistry) {
 		// workload driver node.
 		MinVersion: "v20.1.0",
 		Cluster:    r.makeClusterSpec(4, spec.CPU(32)),
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runAlterPKTPCC(ctx, t, c, 250 /* warehouses */, true /* expensiveChecks */)
 		},
 	})
@@ -193,7 +194,7 @@ func registerAlterPK(r *testRegistry) {
 		// workload driver node.
 		MinVersion: "v20.1.0",
 		Cluster:    r.makeClusterSpec(4, spec.CPU(16)),
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runAlterPKTPCC(ctx, t, c, 500 /* warehouses */, false /* expensiveChecks */)
 		},
 	})

--- a/pkg/cmd/roachtest/alterpk.go
+++ b/pkg/cmd/roachtest/alterpk.go
@@ -15,7 +15,7 @@ import (
 	"fmt"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
@@ -23,7 +23,7 @@ import (
 
 func registerAlterPK(r *testRegistry) {
 
-	setupTest := func(ctx context.Context, t *test, c cluster2.Cluster) (option.NodeListOption, option.NodeListOption) {
+	setupTest := func(ctx context.Context, t *test, c cluster.Cluster) (option.NodeListOption, option.NodeListOption) {
 		roachNodes := c.Range(1, c.Spec().NodeCount-1)
 		loadNode := c.Node(c.Spec().NodeCount)
 		t.Status("copying binaries")
@@ -36,7 +36,7 @@ func registerAlterPK(r *testRegistry) {
 	}
 
 	// runAlterPKBank runs a primary key change while the bank workload runs.
-	runAlterPKBank := func(ctx context.Context, t *test, c cluster2.Cluster) {
+	runAlterPKBank := func(ctx context.Context, t *test, c cluster.Cluster) {
 		const numRows = 1000000
 		const duration = 1 * time.Minute
 
@@ -91,7 +91,7 @@ func registerAlterPK(r *testRegistry) {
 	}
 
 	// runAlterPKTPCC runs a primary key change while the TPCC workload runs.
-	runAlterPKTPCC := func(ctx context.Context, t *test, c cluster2.Cluster, warehouses int, expensiveChecks bool) {
+	runAlterPKTPCC := func(ctx context.Context, t *test, c cluster.Cluster, warehouses int, expensiveChecks bool) {
 		const duration = 10 * time.Minute
 
 		roachNodes, loadNode := setupTest(ctx, t, c)
@@ -183,7 +183,7 @@ func registerAlterPK(r *testRegistry) {
 		// workload driver node.
 		MinVersion: "v20.1.0",
 		Cluster:    r.makeClusterSpec(4, spec.CPU(32)),
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runAlterPKTPCC(ctx, t, c, 250 /* warehouses */, true /* expensiveChecks */)
 		},
 	})
@@ -194,7 +194,7 @@ func registerAlterPK(r *testRegistry) {
 		// workload driver node.
 		MinVersion: "v20.1.0",
 		Cluster:    r.makeClusterSpec(4, spec.CPU(16)),
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runAlterPKTPCC(ctx, t, c, 500 /* warehouses */, false /* expensiveChecks */)
 		},
 	})

--- a/pkg/cmd/roachtest/autoupgrade.go
+++ b/pkg/cmd/roachtest/autoupgrade.go
@@ -36,7 +36,7 @@ func registerAutoUpgrade(r *testRegistry) {
 			t.Fatal(err)
 		}
 
-		c.Start(ctx, t, c.Range(1, nodes))
+		c.Start(ctx, c.Range(1, nodes))
 
 		const stageDuration = 30 * time.Second
 		const timeUntilStoreDead = 90 * time.Second
@@ -120,7 +120,7 @@ func registerAutoUpgrade(r *testRegistry) {
 				t.Fatal(err)
 			}
 			c.Put(ctx, cockroach, "./cockroach", c.Node(i))
-			c.Start(ctx, t, c.Node(i), startArgsDontEncrypt)
+			c.Start(ctx, c.Node(i), startArgsDontEncrypt)
 			if err := sleep(stageDuration); err != nil {
 				t.Fatal(err)
 			}
@@ -142,7 +142,7 @@ func registerAutoUpgrade(r *testRegistry) {
 			t.Fatal(err)
 		}
 		c.Put(ctx, cockroach, "./cockroach", c.Node(nodes))
-		c.Start(ctx, t, c.Node(nodes), startArgsDontEncrypt)
+		c.Start(ctx, c.Node(nodes), startArgsDontEncrypt)
 		if err := sleep(stageDuration); err != nil {
 			t.Fatal(err)
 		}
@@ -185,7 +185,7 @@ func registerAutoUpgrade(r *testRegistry) {
 		}
 
 		// Restart the previously stopped node.
-		c.Start(ctx, t, c.Node(nodes-1), startArgsDontEncrypt)
+		c.Start(ctx, c.Node(nodes-1), startArgsDontEncrypt)
 		if err := sleep(stageDuration); err != nil {
 			t.Fatal(err)
 		}
@@ -238,7 +238,7 @@ func registerAutoUpgrade(r *testRegistry) {
 		}
 
 		// Start n3 again to satisfy the dead node detector.
-		c.Start(ctx, t, c.Node(nodeDecommissioned))
+		c.Start(ctx, c.Node(nodeDecommissioned))
 	}
 
 	r.Add(testSpec{

--- a/pkg/cmd/roachtest/autoupgrade.go
+++ b/pkg/cmd/roachtest/autoupgrade.go
@@ -15,7 +15,7 @@ import (
 	"fmt"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/errors"
 )
@@ -30,7 +30,7 @@ import (
 // You want to look at versionupgrade.go, which has a test harness you
 // can use.
 func registerAutoUpgrade(r *testRegistry) {
-	runAutoUpgrade := func(ctx context.Context, t *test, c cluster2.Cluster, oldVersion string) {
+	runAutoUpgrade := func(ctx context.Context, t *test, c cluster.Cluster, oldVersion string) {
 		nodes := c.Spec().NodeCount
 
 		if err := c.Stage(ctx, t.l, "release", "v"+oldVersion, "", c.Range(1, nodes)); err != nil {
@@ -247,7 +247,7 @@ func registerAutoUpgrade(r *testRegistry) {
 		Owner:      OwnerKV,
 		MinVersion: "v19.1.0",
 		Cluster:    r.makeClusterSpec(5),
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			pred, err := PredecessorVersion(r.buildVersion)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/cmd/roachtest/autoupgrade.go
+++ b/pkg/cmd/roachtest/autoupgrade.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/errors"
 )
@@ -29,7 +30,7 @@ import (
 // You want to look at versionupgrade.go, which has a test harness you
 // can use.
 func registerAutoUpgrade(r *testRegistry) {
-	runAutoUpgrade := func(ctx context.Context, t *test, c Cluster, oldVersion string) {
+	runAutoUpgrade := func(ctx context.Context, t *test, c cluster2.Cluster, oldVersion string) {
 		nodes := c.Spec().NodeCount
 
 		if err := c.Stage(ctx, t.l, "release", "v"+oldVersion, "", c.Range(1, nodes)); err != nil {
@@ -246,7 +247,7 @@ func registerAutoUpgrade(r *testRegistry) {
 		Owner:      OwnerKV,
 		MinVersion: "v19.1.0",
 		Cluster:    r.makeClusterSpec(5),
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			pred, err := PredecessorVersion(r.buildVersion)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/cmd/roachtest/backup.go
+++ b/pkg/cmd/roachtest/backup.go
@@ -63,7 +63,7 @@ func importBankDataSplit(ctx context.Context, rows, ranges int, t *test, c Clust
 
 	// NB: starting the cluster creates the logs dir as a side effect,
 	// needed below.
-	c.Start(ctx, t)
+	c.Start(ctx)
 	c.Run(ctx, c.All(), `./workload csv-server --port=8081 &> logs/workload-csv-server.log < /dev/null &`)
 	time.Sleep(time.Second) // wait for csv server to open listener
 
@@ -344,7 +344,7 @@ func registerBackup(r *testRegistry) {
 			c.EncryptAtRandom(true)
 			c.Put(ctx, cockroach, "./cockroach")
 			c.Put(ctx, workload, "./workload")
-			c.Start(ctx, t)
+			c.Start(ctx)
 			conn := c.Conn(ctx, 1)
 
 			duration := 5 * time.Minute

--- a/pkg/cmd/roachtest/backup.go
+++ b/pkg/cmd/roachtest/backup.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	cloudstorage "github.com/cockroachdb/cockroach/pkg/storage/cloud"
 	"github.com/cockroachdb/cockroach/pkg/storage/cloud/amazon"
@@ -49,7 +50,9 @@ const (
 	rows3GiB   = rows30GiB / 10
 )
 
-func importBankDataSplit(ctx context.Context, rows, ranges int, t *test, c Cluster) string {
+func importBankDataSplit(
+	ctx context.Context, rows, ranges int, t *test, c cluster2.Cluster,
+) string {
 	dest := c.Name()
 	// Randomize starting with encryption-at-rest enabled.
 	c.EncryptAtRandom(true)
@@ -77,7 +80,7 @@ func importBankDataSplit(ctx context.Context, rows, ranges int, t *test, c Clust
 	return dest
 }
 
-func importBankData(ctx context.Context, rows int, t *test, c Cluster) string {
+func importBankData(ctx context.Context, rows int, t *test, c cluster2.Cluster) string {
 	return importBankDataSplit(ctx, rows, 0 /* ranges */, t, c)
 }
 
@@ -85,7 +88,7 @@ func registerBackupNodeShutdown(r *testRegistry) {
 	// backupNodeRestartSpec runs a backup and randomly shuts down a node during
 	// the backup.
 	backupNodeRestartSpec := r.makeClusterSpec(4)
-	loadBackupData := func(ctx context.Context, t *test, c Cluster) string {
+	loadBackupData := func(ctx context.Context, t *test, c cluster2.Cluster) string {
 		// This aught to be enough since this isn't a performance test.
 		rows := rows15GiB
 		if local {
@@ -101,12 +104,12 @@ func registerBackupNodeShutdown(r *testRegistry) {
 		Owner:      OwnerBulkIO,
 		Cluster:    backupNodeRestartSpec,
 		MinVersion: "v21.1.0",
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			gatewayNode := 2
 			nodeToShutdown := 3
 			dest := loadBackupData(ctx, t, c)
 			backupQuery := `BACKUP bank.bank TO 'nodelocal://1/` + dest + `' WITH DETACHED`
-			startBackup := func(c Cluster) (jobID string, err error) {
+			startBackup := func(c cluster2.Cluster) (jobID string, err error) {
 				gatewayDB := c.Conn(ctx, gatewayNode)
 				defer gatewayDB.Close()
 
@@ -122,12 +125,12 @@ func registerBackupNodeShutdown(r *testRegistry) {
 		Owner:      OwnerBulkIO,
 		Cluster:    backupNodeRestartSpec,
 		MinVersion: "v21.1.0",
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			gatewayNode := 2
 			nodeToShutdown := 2
 			dest := loadBackupData(ctx, t, c)
 			backupQuery := `BACKUP bank.bank TO 'nodelocal://1/` + dest + `' WITH DETACHED`
-			startBackup := func(c Cluster) (jobID string, err error) {
+			startBackup := func(c cluster2.Cluster) (jobID string, err error) {
 				gatewayDB := c.Conn(ctx, gatewayNode)
 				defer gatewayDB.Close()
 
@@ -184,7 +187,7 @@ func registerBackup(r *testRegistry) {
 		Owner:      OwnerBulkIO,
 		Cluster:    backup2TBSpec,
 		MinVersion: "v2.1.0",
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			rows := rows2TiB
 			if local {
 				rows = 100
@@ -220,7 +223,7 @@ func registerBackup(r *testRegistry) {
 		Owner:      OwnerBulkIO,
 		Cluster:    KMSSpec,
 		MinVersion: "v20.2.0",
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			if cloud == spec.GCE {
 				t.Skip("backupKMS roachtest is only configured to run on AWS", "")
 			}
@@ -339,7 +342,7 @@ func registerBackup(r *testRegistry) {
 		Owner:   OwnerBulkIO,
 		Cluster: r.makeClusterSpec(3),
 		Timeout: 1 * time.Hour,
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			// Randomize starting with encryption-at-rest enabled.
 			c.EncryptAtRandom(true)
 			c.Put(ctx, cockroach, "./cockroach")

--- a/pkg/cmd/roachtest/build_info.go
+++ b/pkg/cmd/roachtest/build_info.go
@@ -15,12 +15,12 @@ import (
 	"net/http"
 	"os/exec"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 )
 
-func runBuildInfo(ctx context.Context, t *test, c cluster2.Cluster) {
+func runBuildInfo(ctx context.Context, t *test, c cluster.Cluster) {
 	c.Put(ctx, cockroach, "./cockroach")
 	c.Start(ctx)
 
@@ -51,7 +51,7 @@ func runBuildInfo(ctx context.Context, t *test, c cluster2.Cluster) {
 
 // runBuildAnalyze performs static analysis on the built binary to
 // ensure it's built as expected.
-func runBuildAnalyze(ctx context.Context, t *test, c cluster2.Cluster) {
+func runBuildAnalyze(ctx context.Context, t *test, c cluster.Cluster) {
 
 	if c.IsLocal() {
 		// This test is linux-specific and needs to be able to install apt

--- a/pkg/cmd/roachtest/build_info.go
+++ b/pkg/cmd/roachtest/build_info.go
@@ -15,11 +15,12 @@ import (
 	"net/http"
 	"os/exec"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 )
 
-func runBuildInfo(ctx context.Context, t *test, c Cluster) {
+func runBuildInfo(ctx context.Context, t *test, c cluster2.Cluster) {
 	c.Put(ctx, cockroach, "./cockroach")
 	c.Start(ctx)
 
@@ -50,7 +51,7 @@ func runBuildInfo(ctx context.Context, t *test, c Cluster) {
 
 // runBuildAnalyze performs static analysis on the built binary to
 // ensure it's built as expected.
-func runBuildAnalyze(ctx context.Context, t *test, c Cluster) {
+func runBuildAnalyze(ctx context.Context, t *test, c cluster2.Cluster) {
 
 	if c.IsLocal() {
 		// This test is linux-specific and needs to be able to install apt

--- a/pkg/cmd/roachtest/build_info.go
+++ b/pkg/cmd/roachtest/build_info.go
@@ -21,7 +21,7 @@ import (
 
 func runBuildInfo(ctx context.Context, t *test, c Cluster) {
 	c.Put(ctx, cockroach, "./cockroach")
-	c.Start(ctx, t)
+	c.Start(ctx)
 
 	var details serverpb.DetailsResponse
 	adminUIAddrs, err := c.ExternalAdminUIAddr(ctx, c.Node(1))

--- a/pkg/cmd/roachtest/build_info.go
+++ b/pkg/cmd/roachtest/build_info.go
@@ -52,7 +52,7 @@ func runBuildInfo(ctx context.Context, t *test, c Cluster) {
 // ensure it's built as expected.
 func runBuildAnalyze(ctx context.Context, t *test, c Cluster) {
 
-	if c.isLocal() {
+	if c.IsLocal() {
 		// This test is linux-specific and needs to be able to install apt
 		// packages, so only run it on dedicated remote VMs.
 		t.spec.Skip = "local execution not supported"
@@ -85,7 +85,7 @@ func runBuildAnalyze(ctx context.Context, t *test, c Cluster) {
 	c.Run(ctx, c.Node(1), "sudo apt-get update")
 	c.Run(ctx, c.Node(1), "sudo apt-get -qqy install pax-utils")
 
-	cmd := exec.CommandContext(ctx, roachprod, "run", c.makeNodes(c.Node(1)), "scanelf -qe cockroach")
+	cmd := exec.CommandContext(ctx, roachprod, "run", c.MakeNodes(c.Node(1)), "scanelf -qe cockroach")
 	output, err := cmd.Output()
 	if err != nil {
 		t.Fatalf("scanelf failed: %s", err)

--- a/pkg/cmd/roachtest/canary.go
+++ b/pkg/cmd/roachtest/canary.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 )
@@ -87,7 +87,7 @@ func (b blocklistsForVersion) getLists(version string) (string, blocklist, strin
 
 func fetchCockroachVersion(
 	ctx context.Context,
-	c cluster2.Cluster,
+	c cluster.Cluster,
 	nodeIndex int,
 	dbConnectionParams *SecureDBConnectionParams,
 ) (string, error) {
@@ -145,7 +145,7 @@ var canaryRetryOptions = retry.Options{
 func repeatRunE(
 	ctx context.Context,
 	t *test,
-	c cluster2.Cluster,
+	c cluster.Cluster,
 	node option.NodeListOption,
 	operation string,
 	args ...string,
@@ -174,7 +174,7 @@ func repeatRunE(
 // automatic retry loop.
 func repeatRunWithBuffer(
 	ctx context.Context,
-	c cluster2.Cluster,
+	c cluster.Cluster,
 	t *test,
 	node option.NodeListOption,
 	operation string,
@@ -208,7 +208,7 @@ func repeatRunWithBuffer(
 func repeatGitCloneE(
 	ctx context.Context,
 	t *test,
-	c cluster2.Cluster,
+	c cluster.Cluster,
 	src, dest, branch string,
 	node option.NodeListOption,
 ) error {

--- a/pkg/cmd/roachtest/canary.go
+++ b/pkg/cmd/roachtest/canary.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 )
@@ -85,7 +86,10 @@ func (b blocklistsForVersion) getLists(version string) (string, blocklist, strin
 }
 
 func fetchCockroachVersion(
-	ctx context.Context, c Cluster, nodeIndex int, dbConnectionParams *SecureDBConnectionParams,
+	ctx context.Context,
+	c cluster2.Cluster,
+	nodeIndex int,
+	dbConnectionParams *SecureDBConnectionParams,
 ) (string, error) {
 	var db *gosql.DB
 	var err error
@@ -141,7 +145,7 @@ var canaryRetryOptions = retry.Options{
 func repeatRunE(
 	ctx context.Context,
 	t *test,
-	c Cluster,
+	c cluster2.Cluster,
 	node option.NodeListOption,
 	operation string,
 	args ...string,
@@ -170,7 +174,7 @@ func repeatRunE(
 // automatic retry loop.
 func repeatRunWithBuffer(
 	ctx context.Context,
-	c Cluster,
+	c cluster2.Cluster,
 	t *test,
 	node option.NodeListOption,
 	operation string,
@@ -202,7 +206,11 @@ func repeatRunWithBuffer(
 // repeatGitCloneE is the same function as c.GitCloneE but with an automatic
 // retry loop.
 func repeatGitCloneE(
-	ctx context.Context, t *test, c Cluster, src, dest, branch string, node option.NodeListOption,
+	ctx context.Context,
+	t *test,
+	c cluster2.Cluster,
+	src, dest, branch string,
+	node option.NodeListOption,
 ) error {
 	var lastError error
 	for attempt, r := 0, retry.StartWithCtx(ctx, canaryRetryOptions); r.Next(); {

--- a/pkg/cmd/roachtest/cancel.go
+++ b/pkg/cmd/roachtest/cancel.go
@@ -39,7 +39,7 @@ import (
 func registerCancel(r *testRegistry) {
 	runCancel := func(ctx context.Context, t *test, c Cluster, tpchQueriesToRun []int, useDistsql bool) {
 		c.Put(ctx, cockroach, "./cockroach", c.All())
-		c.Start(ctx, t, c.All())
+		c.Start(ctx, c.All())
 
 		m := newMonitor(ctx, c, c.All())
 		m.Go(func(ctx context.Context) error {

--- a/pkg/cmd/roachtest/cancel.go
+++ b/pkg/cmd/roachtest/cancel.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/cancelchecker"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/workload/tpch"
@@ -37,7 +38,7 @@ import (
 // Once DistSQL queries provide more testing knobs, these tests can likely be
 // replaced with unit tests.
 func registerCancel(r *testRegistry) {
-	runCancel := func(ctx context.Context, t *test, c Cluster, tpchQueriesToRun []int, useDistsql bool) {
+	runCancel := func(ctx context.Context, t *test, c cluster2.Cluster, tpchQueriesToRun []int, useDistsql bool) {
 		c.Put(ctx, cockroach, "./cockroach", c.All())
 		c.Start(ctx, c.All())
 
@@ -131,7 +132,7 @@ func registerCancel(r *testRegistry) {
 		Name:    fmt.Sprintf("cancel/tpch/distsql/queries=%s,nodes=%d", queries, numNodes),
 		Owner:   OwnerSQLQueries,
 		Cluster: r.makeClusterSpec(numNodes),
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runCancel(ctx, t, c, tpchQueriesToRun, true /* useDistsql */)
 		},
 	})
@@ -140,7 +141,7 @@ func registerCancel(r *testRegistry) {
 		Name:    fmt.Sprintf("cancel/tpch/local/queries=%s,nodes=%d", queries, numNodes),
 		Owner:   OwnerSQLQueries,
 		Cluster: r.makeClusterSpec(numNodes),
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runCancel(ctx, t, c, tpchQueriesToRun, false /* useDistsql */)
 		},
 	})

--- a/pkg/cmd/roachtest/cancel.go
+++ b/pkg/cmd/roachtest/cancel.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/cancelchecker"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/workload/tpch"
@@ -38,7 +38,7 @@ import (
 // Once DistSQL queries provide more testing knobs, these tests can likely be
 // replaced with unit tests.
 func registerCancel(r *testRegistry) {
-	runCancel := func(ctx context.Context, t *test, c cluster2.Cluster, tpchQueriesToRun []int, useDistsql bool) {
+	runCancel := func(ctx context.Context, t *test, c cluster.Cluster, tpchQueriesToRun []int, useDistsql bool) {
 		c.Put(ctx, cockroach, "./cockroach", c.All())
 		c.Start(ctx, c.All())
 
@@ -132,7 +132,7 @@ func registerCancel(r *testRegistry) {
 		Name:    fmt.Sprintf("cancel/tpch/distsql/queries=%s,nodes=%d", queries, numNodes),
 		Owner:   OwnerSQLQueries,
 		Cluster: r.makeClusterSpec(numNodes),
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runCancel(ctx, t, c, tpchQueriesToRun, true /* useDistsql */)
 		},
 	})
@@ -141,7 +141,7 @@ func registerCancel(r *testRegistry) {
 		Name:    fmt.Sprintf("cancel/tpch/local/queries=%s,nodes=%d", queries, numNodes),
 		Owner:   OwnerSQLQueries,
 		Cluster: r.makeClusterSpec(numNodes),
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runCancel(ctx, t, c, tpchQueriesToRun, false /* useDistsql */)
 		},
 	})

--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/Shopify/sarama"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdctest"
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/logger"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
@@ -65,7 +66,7 @@ type cdcTestArgs struct {
 	targetTxnPerSecond       float64
 }
 
-func cdcBasicTest(ctx context.Context, t *test, c Cluster, args cdcTestArgs) {
+func cdcBasicTest(ctx context.Context, t *test, c cluster2.Cluster, args cdcTestArgs) {
 	crdbNodes := c.Range(1, c.Spec().NodeCount-1)
 	workloadNode := c.Node(c.Spec().NodeCount)
 	kafkaNode := c.Node(c.Spec().NodeCount)
@@ -235,7 +236,7 @@ func cdcBasicTest(ctx context.Context, t *test, c Cluster, args cdcTestArgs) {
 	}
 }
 
-func runCDCBank(ctx context.Context, t *test, c Cluster) {
+func runCDCBank(ctx context.Context, t *test, c cluster2.Cluster) {
 
 	// Make the logs dir on every node to work around the `roachprod get logs`
 	// spam.
@@ -392,7 +393,7 @@ func runCDCBank(ctx context.Context, t *test, c Cluster) {
 // This test verifies that the changefeed avro + confluent schema registry works
 // end-to-end (including the schema registry default of requiring backward
 // compatibility within a topic).
-func runCDCSchemaRegistry(ctx context.Context, t *test, c Cluster) {
+func runCDCSchemaRegistry(ctx context.Context, t *test, c cluster2.Cluster) {
 
 	crdbNodes, kafkaNode := c.Node(1), c.Node(1)
 	c.Put(ctx, cockroach, "./cockroach", crdbNodes)
@@ -519,7 +520,7 @@ func runCDCSchemaRegistry(ctx context.Context, t *test, c Cluster) {
 	}
 }
 
-func runCDCKafkaAuth(ctx context.Context, t *test, c Cluster) {
+func runCDCKafkaAuth(ctx context.Context, t *test, c cluster2.Cluster) {
 	lastCrdbNode := c.Spec().NodeCount - 1
 	if lastCrdbNode == 0 {
 		lastCrdbNode = 1
@@ -610,7 +611,7 @@ func registerCDC(r *testRegistry) {
 		Owner:           OwnerCDC,
 		Cluster:         r.makeClusterSpec(4, spec.CPU(16)),
 		RequiresLicense: true,
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType:             tpccWorkloadType,
 				tpccWarehouseCount:       1000,
@@ -626,7 +627,7 @@ func registerCDC(r *testRegistry) {
 		Cluster:         r.makeClusterSpec(4, spec.CPU(16)),
 		Tags:            []string{"manual"},
 		RequiresLicense: true,
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType:             tpccWorkloadType,
 				tpccWarehouseCount:       1000,
@@ -642,7 +643,7 @@ func registerCDC(r *testRegistry) {
 		Owner:           OwnerCDC,
 		Cluster:         r.makeClusterSpec(4, spec.CPU(16)),
 		RequiresLicense: true,
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType:             tpccWorkloadType,
 				tpccWarehouseCount:       100,
@@ -658,7 +659,7 @@ func registerCDC(r *testRegistry) {
 		Owner:           `cdc`,
 		Cluster:         r.makeClusterSpec(4, spec.CPU(16)),
 		RequiresLicense: true,
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType:             tpccWorkloadType,
 				tpccWarehouseCount:       100,
@@ -674,7 +675,7 @@ func registerCDC(r *testRegistry) {
 		Owner:           `cdc`,
 		Cluster:         r.makeClusterSpec(4, spec.CPU(16)),
 		RequiresLicense: true,
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType:             tpccWorkloadType,
 				tpccWarehouseCount:       100,
@@ -695,7 +696,7 @@ func registerCDC(r *testRegistry) {
 		// of this test. Look into it.
 		Cluster:         r.makeClusterSpec(4, spec.CPU(16)),
 		RequiresLicense: true,
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType:             ledgerWorkloadType,
 				workloadDuration:         "30m",
@@ -711,7 +712,7 @@ func registerCDC(r *testRegistry) {
 		Owner:           `cdc`,
 		Cluster:         r.makeClusterSpec(4, spec.CPU(16)),
 		RequiresLicense: true,
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType: tpccWorkloadType,
 				// Sending data to Google Cloud Storage is a bit slower than sending to
@@ -732,7 +733,7 @@ func registerCDC(r *testRegistry) {
 		Owner:           `cdc`,
 		Cluster:         r.makeClusterSpec(1),
 		RequiresLicense: true,
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runCDCKafkaAuth(ctx, t, c)
 		},
 	})
@@ -741,7 +742,7 @@ func registerCDC(r *testRegistry) {
 		Owner:           `cdc`,
 		Cluster:         r.makeClusterSpec(4),
 		RequiresLicense: true,
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runCDCBank(ctx, t, c)
 		},
 	})
@@ -750,7 +751,7 @@ func registerCDC(r *testRegistry) {
 		Owner:           `cdc`,
 		Cluster:         r.makeClusterSpec(1),
 		RequiresLicense: true,
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runCDCSchemaRegistry(ctx, t, c)
 		},
 	})
@@ -1086,7 +1087,7 @@ confluent.support.customer.id=anonymous
 
 type kafkaManager struct {
 	t     *test
-	c     Cluster
+	c     cluster2.Cluster
 	nodes option.NodeListOption
 }
 
@@ -1388,7 +1389,7 @@ type tpccWorkload struct {
 	tolerateErrors     bool
 }
 
-func (tw *tpccWorkload) install(ctx context.Context, c Cluster) {
+func (tw *tpccWorkload) install(ctx context.Context, c cluster2.Cluster) {
 	// For fixtures import, use the version built into the cockroach binary so
 	// the tpcc workload-versions match on release branches.
 	c.Run(ctx, tw.workloadNodes, fmt.Sprintf(
@@ -1398,7 +1399,7 @@ func (tw *tpccWorkload) install(ctx context.Context, c Cluster) {
 	))
 }
 
-func (tw *tpccWorkload) run(ctx context.Context, c Cluster, workloadDuration string) {
+func (tw *tpccWorkload) run(ctx context.Context, c cluster2.Cluster, workloadDuration string) {
 	tolerateErrors := ""
 	if tw.tolerateErrors {
 		tolerateErrors = "--tolerate-errors"
@@ -1414,14 +1415,14 @@ type ledgerWorkload struct {
 	sqlNodes      option.NodeListOption
 }
 
-func (lw *ledgerWorkload) install(ctx context.Context, c Cluster) {
+func (lw *ledgerWorkload) install(ctx context.Context, c cluster2.Cluster) {
 	c.Run(ctx, lw.workloadNodes.RandNode(), fmt.Sprintf(
 		`./workload init ledger {pgurl%s}`,
 		lw.sqlNodes.RandNode(),
 	))
 }
 
-func (lw *ledgerWorkload) run(ctx context.Context, c Cluster, workloadDuration string) {
+func (lw *ledgerWorkload) run(ctx context.Context, c cluster2.Cluster, workloadDuration string) {
 	c.Run(ctx, lw.workloadNodes, fmt.Sprintf(
 		`./workload run ledger --mix=balance=0,withdrawal=50,deposit=50,reversal=0 {pgurl%s} --duration=%s`,
 		lw.sqlNodes,

--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -251,7 +251,7 @@ func runCDCBank(ctx context.Context, t *test, c Cluster) {
 		nodes: kafkaNode,
 	}
 	kafka.install(ctx)
-	if !c.isLocal() {
+	if !c.IsLocal() {
 		// TODO(dan): This test currently connects to kafka from the test
 		// runner, so kafka needs to advertise the external address. Better
 		// would be a binary we could run on one of the roachprod machines.
@@ -1091,7 +1091,7 @@ type kafkaManager struct {
 }
 
 func (k kafkaManager) basePath() string {
-	if k.c.isLocal() {
+	if k.c.IsLocal() {
 		return `/tmp/confluent`
 	}
 	return `/mnt/data1/confluent`
@@ -1129,7 +1129,7 @@ func (k kafkaManager) install(ctx context.Context) {
 		k.t.Fatal(err)
 	}
 	k.c.Run(ctx, k.nodes, downloadScriptPath, folder)
-	if !k.c.isLocal() {
+	if !k.c.IsLocal() {
 		k.c.Run(ctx, k.nodes, `mkdir -p logs`)
 		k.c.Run(ctx, k.nodes, `sudo apt-get -q update 2>&1 > logs/apt-get-update.log`)
 		k.c.Run(ctx, k.nodes, `yes | sudo apt-get -q install openssl default-jre 2>&1 > logs/apt-get-install.log`)

--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -71,7 +71,7 @@ func cdcBasicTest(ctx context.Context, t *test, c Cluster, args cdcTestArgs) {
 	kafkaNode := c.Node(c.Spec().NodeCount)
 	c.Put(ctx, cockroach, "./cockroach")
 	c.Put(ctx, workload, "./workload", workloadNode)
-	c.Start(ctx, t, crdbNodes)
+	c.Start(ctx, crdbNodes)
 
 	db := c.Conn(ctx, 1)
 	defer stopFeeds(db)
@@ -244,7 +244,7 @@ func runCDCBank(ctx context.Context, t *test, c Cluster) {
 	crdbNodes, workloadNode, kafkaNode := c.Range(1, c.Spec().NodeCount-1), c.Node(c.Spec().NodeCount), c.Node(c.Spec().NodeCount)
 	c.Put(ctx, cockroach, "./cockroach", crdbNodes)
 	c.Put(ctx, workload, "./workload", workloadNode)
-	c.Start(ctx, t, crdbNodes)
+	c.Start(ctx, crdbNodes)
 	kafka := kafkaManager{
 		t:     t,
 		c:     c,
@@ -396,7 +396,7 @@ func runCDCSchemaRegistry(ctx context.Context, t *test, c Cluster) {
 
 	crdbNodes, kafkaNode := c.Node(1), c.Node(1)
 	c.Put(ctx, cockroach, "./cockroach", crdbNodes)
-	c.Start(ctx, t, crdbNodes)
+	c.Start(ctx, crdbNodes)
 	kafka := kafkaManager{
 		t:     t,
 		c:     c,
@@ -527,7 +527,7 @@ func runCDCKafkaAuth(ctx context.Context, t *test, c Cluster) {
 
 	crdbNodes, kafkaNode := c.Range(1, lastCrdbNode), c.Node(c.Spec().NodeCount)
 	c.Put(ctx, cockroach, "./cockroach", crdbNodes)
-	c.Start(ctx, t, crdbNodes)
+	c.Start(ctx, crdbNodes)
 
 	kafka := kafkaManager{
 		t:     t,

--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -32,7 +32,7 @@ import (
 
 	"github.com/Shopify/sarama"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdctest"
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/logger"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
@@ -66,7 +66,7 @@ type cdcTestArgs struct {
 	targetTxnPerSecond       float64
 }
 
-func cdcBasicTest(ctx context.Context, t *test, c cluster2.Cluster, args cdcTestArgs) {
+func cdcBasicTest(ctx context.Context, t *test, c cluster.Cluster, args cdcTestArgs) {
 	crdbNodes := c.Range(1, c.Spec().NodeCount-1)
 	workloadNode := c.Node(c.Spec().NodeCount)
 	kafkaNode := c.Node(c.Spec().NodeCount)
@@ -236,7 +236,7 @@ func cdcBasicTest(ctx context.Context, t *test, c cluster2.Cluster, args cdcTest
 	}
 }
 
-func runCDCBank(ctx context.Context, t *test, c cluster2.Cluster) {
+func runCDCBank(ctx context.Context, t *test, c cluster.Cluster) {
 
 	// Make the logs dir on every node to work around the `roachprod get logs`
 	// spam.
@@ -393,7 +393,7 @@ func runCDCBank(ctx context.Context, t *test, c cluster2.Cluster) {
 // This test verifies that the changefeed avro + confluent schema registry works
 // end-to-end (including the schema registry default of requiring backward
 // compatibility within a topic).
-func runCDCSchemaRegistry(ctx context.Context, t *test, c cluster2.Cluster) {
+func runCDCSchemaRegistry(ctx context.Context, t *test, c cluster.Cluster) {
 
 	crdbNodes, kafkaNode := c.Node(1), c.Node(1)
 	c.Put(ctx, cockroach, "./cockroach", crdbNodes)
@@ -520,7 +520,7 @@ func runCDCSchemaRegistry(ctx context.Context, t *test, c cluster2.Cluster) {
 	}
 }
 
-func runCDCKafkaAuth(ctx context.Context, t *test, c cluster2.Cluster) {
+func runCDCKafkaAuth(ctx context.Context, t *test, c cluster.Cluster) {
 	lastCrdbNode := c.Spec().NodeCount - 1
 	if lastCrdbNode == 0 {
 		lastCrdbNode = 1
@@ -611,7 +611,7 @@ func registerCDC(r *testRegistry) {
 		Owner:           OwnerCDC,
 		Cluster:         r.makeClusterSpec(4, spec.CPU(16)),
 		RequiresLicense: true,
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType:             tpccWorkloadType,
 				tpccWarehouseCount:       1000,
@@ -627,7 +627,7 @@ func registerCDC(r *testRegistry) {
 		Cluster:         r.makeClusterSpec(4, spec.CPU(16)),
 		Tags:            []string{"manual"},
 		RequiresLicense: true,
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType:             tpccWorkloadType,
 				tpccWarehouseCount:       1000,
@@ -643,7 +643,7 @@ func registerCDC(r *testRegistry) {
 		Owner:           OwnerCDC,
 		Cluster:         r.makeClusterSpec(4, spec.CPU(16)),
 		RequiresLicense: true,
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType:             tpccWorkloadType,
 				tpccWarehouseCount:       100,
@@ -659,7 +659,7 @@ func registerCDC(r *testRegistry) {
 		Owner:           `cdc`,
 		Cluster:         r.makeClusterSpec(4, spec.CPU(16)),
 		RequiresLicense: true,
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType:             tpccWorkloadType,
 				tpccWarehouseCount:       100,
@@ -675,7 +675,7 @@ func registerCDC(r *testRegistry) {
 		Owner:           `cdc`,
 		Cluster:         r.makeClusterSpec(4, spec.CPU(16)),
 		RequiresLicense: true,
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType:             tpccWorkloadType,
 				tpccWarehouseCount:       100,
@@ -696,7 +696,7 @@ func registerCDC(r *testRegistry) {
 		// of this test. Look into it.
 		Cluster:         r.makeClusterSpec(4, spec.CPU(16)),
 		RequiresLicense: true,
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType:             ledgerWorkloadType,
 				workloadDuration:         "30m",
@@ -712,7 +712,7 @@ func registerCDC(r *testRegistry) {
 		Owner:           `cdc`,
 		Cluster:         r.makeClusterSpec(4, spec.CPU(16)),
 		RequiresLicense: true,
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType: tpccWorkloadType,
 				// Sending data to Google Cloud Storage is a bit slower than sending to
@@ -733,7 +733,7 @@ func registerCDC(r *testRegistry) {
 		Owner:           `cdc`,
 		Cluster:         r.makeClusterSpec(1),
 		RequiresLicense: true,
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runCDCKafkaAuth(ctx, t, c)
 		},
 	})
@@ -742,7 +742,7 @@ func registerCDC(r *testRegistry) {
 		Owner:           `cdc`,
 		Cluster:         r.makeClusterSpec(4),
 		RequiresLicense: true,
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runCDCBank(ctx, t, c)
 		},
 	})
@@ -751,7 +751,7 @@ func registerCDC(r *testRegistry) {
 		Owner:           `cdc`,
 		Cluster:         r.makeClusterSpec(1),
 		RequiresLicense: true,
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runCDCSchemaRegistry(ctx, t, c)
 		},
 	})
@@ -1087,7 +1087,7 @@ confluent.support.customer.id=anonymous
 
 type kafkaManager struct {
 	t     *test
-	c     cluster2.Cluster
+	c     cluster.Cluster
 	nodes option.NodeListOption
 }
 
@@ -1389,7 +1389,7 @@ type tpccWorkload struct {
 	tolerateErrors     bool
 }
 
-func (tw *tpccWorkload) install(ctx context.Context, c cluster2.Cluster) {
+func (tw *tpccWorkload) install(ctx context.Context, c cluster.Cluster) {
 	// For fixtures import, use the version built into the cockroach binary so
 	// the tpcc workload-versions match on release branches.
 	c.Run(ctx, tw.workloadNodes, fmt.Sprintf(
@@ -1399,7 +1399,7 @@ func (tw *tpccWorkload) install(ctx context.Context, c cluster2.Cluster) {
 	))
 }
 
-func (tw *tpccWorkload) run(ctx context.Context, c cluster2.Cluster, workloadDuration string) {
+func (tw *tpccWorkload) run(ctx context.Context, c cluster.Cluster, workloadDuration string) {
 	tolerateErrors := ""
 	if tw.tolerateErrors {
 		tolerateErrors = "--tolerate-errors"
@@ -1415,14 +1415,14 @@ type ledgerWorkload struct {
 	sqlNodes      option.NodeListOption
 }
 
-func (lw *ledgerWorkload) install(ctx context.Context, c cluster2.Cluster) {
+func (lw *ledgerWorkload) install(ctx context.Context, c cluster.Cluster) {
 	c.Run(ctx, lw.workloadNodes.RandNode(), fmt.Sprintf(
 		`./workload init ledger {pgurl%s}`,
 		lw.sqlNodes.RandNode(),
 	))
 }
 
-func (lw *ledgerWorkload) run(ctx context.Context, c cluster2.Cluster, workloadDuration string) {
+func (lw *ledgerWorkload) run(ctx context.Context, c cluster.Cluster, workloadDuration string) {
 	c.Run(ctx, lw.workloadNodes, fmt.Sprintf(
 		`./workload run ledger --mix=balance=0,withdrawal=50,deposit=50,reversal=0 {pgurl%s} --duration=%s`,
 		lw.sqlNodes,

--- a/pkg/cmd/roachtest/chaos.go
+++ b/pkg/cmd/roachtest/chaos.go
@@ -14,7 +14,7 @@ import (
 	"context"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
@@ -54,7 +54,7 @@ type Chaos struct {
 // Runner returns a closure that runs chaos against the given cluster without
 // setting off the monitor. The process returns without an error after the chaos
 // duration.
-func (ch *Chaos) Runner(c cluster2.Cluster, m *monitor) func(context.Context) error {
+func (ch *Chaos) Runner(c cluster.Cluster, m *monitor) func(context.Context) error {
 	return func(ctx context.Context) (err error) {
 		l, err := m.l.ChildLogger("CHAOS")
 		if err != nil {

--- a/pkg/cmd/roachtest/chaos.go
+++ b/pkg/cmd/roachtest/chaos.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
@@ -53,7 +54,7 @@ type Chaos struct {
 // Runner returns a closure that runs chaos against the given cluster without
 // setting off the monitor. The process returns without an error after the chaos
 // duration.
-func (ch *Chaos) Runner(c Cluster, m *monitor) func(context.Context) error {
+func (ch *Chaos) Runner(c cluster2.Cluster, m *monitor) func(context.Context) error {
 	return func(ctx context.Context) (err error) {
 		l, err := m.l.ChildLogger("CHAOS")
 		if err != nil {

--- a/pkg/cmd/roachtest/clearrange.go
+++ b/pkg/cmd/roachtest/clearrange.go
@@ -45,7 +45,7 @@ func runClearRange(ctx context.Context, t *test, c Cluster, aggressiveChecks boo
 	c.Put(ctx, cockroach, "./cockroach")
 
 	t.Status("restoring fixture")
-	c.Start(ctx, t)
+	c.Start(ctx)
 
 	// NB: on a 10 node cluster, this should take well below 3h.
 	tBegin := timeutil.Now()
@@ -65,7 +65,7 @@ func runClearRange(ctx context.Context, t *test, c Cluster, aggressiveChecks boo
 			"--env", "COCKROACH_CONSISTENCY_AGGRESSIVE=true COCKROACH_ENFORCE_CONSISTENT_STATS=true",
 		))
 	}
-	c.Start(ctx, t, opts...)
+	c.Start(ctx, opts...)
 
 	// Also restore a much smaller table. We'll use it to run queries against
 	// the cluster after having dropped the large table above, verifying that

--- a/pkg/cmd/roachtest/clearrange.go
+++ b/pkg/cmd/roachtest/clearrange.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -32,14 +33,14 @@ func registerClearRange(r *testRegistry) {
 			Timeout:    5*time.Hour + 90*time.Minute,
 			MinVersion: "v19.1.0",
 			Cluster:    r.makeClusterSpec(10, spec.CPU(16)),
-			Run: func(ctx context.Context, t *test, c Cluster) {
+			Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 				runClearRange(ctx, t, c, checks)
 			},
 		})
 	}
 }
 
-func runClearRange(ctx context.Context, t *test, c Cluster, aggressiveChecks bool) {
+func runClearRange(ctx context.Context, t *test, c cluster2.Cluster, aggressiveChecks bool) {
 	// Randomize starting with encryption-at-rest enabled.
 	c.EncryptAtRandom(true)
 	c.Put(ctx, cockroach, "./cockroach")

--- a/pkg/cmd/roachtest/clearrange.go
+++ b/pkg/cmd/roachtest/clearrange.go
@@ -15,7 +15,7 @@ import (
 	"fmt"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -33,14 +33,14 @@ func registerClearRange(r *testRegistry) {
 			Timeout:    5*time.Hour + 90*time.Minute,
 			MinVersion: "v19.1.0",
 			Cluster:    r.makeClusterSpec(10, spec.CPU(16)),
-			Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+			Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 				runClearRange(ctx, t, c, checks)
 			},
 		})
 	}
 }
 
-func runClearRange(ctx context.Context, t *test, c cluster2.Cluster, aggressiveChecks bool) {
+func runClearRange(ctx context.Context, t *test, c cluster.Cluster, aggressiveChecks bool) {
 	// Randomize starting with encryption-at-rest enabled.
 	c.EncryptAtRandom(true)
 	c.Put(ctx, cockroach, "./cockroach")

--- a/pkg/cmd/roachtest/cli.go
+++ b/pkg/cmd/roachtest/cli.go
@@ -17,10 +17,10 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cli"
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 )
 
-func runCLINodeStatus(ctx context.Context, t *test, c cluster2.Cluster) {
+func runCLINodeStatus(ctx context.Context, t *test, c cluster.Cluster) {
 	c.Put(ctx, cockroach, "./cockroach")
 	c.Start(ctx, c.Range(1, 3))
 

--- a/pkg/cmd/roachtest/cli.go
+++ b/pkg/cmd/roachtest/cli.go
@@ -21,7 +21,7 @@ import (
 
 func runCLINodeStatus(ctx context.Context, t *test, c Cluster) {
 	c.Put(ctx, cockroach, "./cockroach")
-	c.Start(ctx, t, c.Range(1, 3))
+	c.Start(ctx, c.Range(1, 3))
 
 	db := c.Conn(ctx, 1)
 	defer db.Close()
@@ -106,7 +106,7 @@ func runCLINodeStatus(ctx context.Context, t *test, c Cluster) {
 	// Stop the cluster and restart only 2 of the nodes. Verify that three nodes
 	// show up in the node status output.
 	c.Stop(ctx, c.Range(1, 3))
-	c.Start(ctx, t, c.Range(1, 2))
+	c.Start(ctx, c.Range(1, 2))
 
 	// Wait for the cluster to come back up.
 	waitForFullReplication(t, db)
@@ -119,5 +119,5 @@ func runCLINodeStatus(ctx context.Context, t *test, c Cluster) {
 	})
 
 	// Start node again to satisfy roachtest.
-	c.Start(ctx, t, c.Node(3))
+	c.Start(ctx, c.Node(3))
 }

--- a/pkg/cmd/roachtest/cli.go
+++ b/pkg/cmd/roachtest/cli.go
@@ -17,9 +17,10 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cli"
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 )
 
-func runCLINodeStatus(ctx context.Context, t *test, c Cluster) {
+func runCLINodeStatus(ctx context.Context, t *test, c cluster2.Cluster) {
 	c.Put(ctx, cockroach, "./cockroach")
 	c.Start(ctx, c.Range(1, 3))
 

--- a/pkg/cmd/roachtest/clock_jump_crash.go
+++ b/pkg/cmd/roachtest/clock_jump_crash.go
@@ -15,11 +15,12 @@ import (
 	"fmt"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	_ "github.com/lib/pq"
 )
 
-func runClockJump(ctx context.Context, t *test, c Cluster, tc clockJumpTestCase) {
+func runClockJump(ctx context.Context, t *test, c cluster2.Cluster, tc clockJumpTestCase) {
 	// Test with a single node so that the node does not crash due to MaxOffset
 	// violation when injecting offset
 	if c.Spec().NodeCount != 1 {
@@ -135,7 +136,7 @@ func registerClockJumpTests(r *testRegistry) {
 			// These tests muck with NTP, therefore we don't want the cluster reused
 			// by others.
 			Cluster: r.makeClusterSpec(1, spec.ReuseTagged("offset-injector")),
-			Run: func(ctx context.Context, t *test, c Cluster) {
+			Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 				runClockJump(ctx, t, c, tc)
 			},
 		}

--- a/pkg/cmd/roachtest/clock_jump_crash.go
+++ b/pkg/cmd/roachtest/clock_jump_crash.go
@@ -36,7 +36,7 @@ func runClockJump(ctx context.Context, t *test, c Cluster, tc clockJumpTestCase)
 		c.Put(ctx, cockroach, "./cockroach", c.All())
 	}
 	c.Wipe(ctx)
-	c.Start(ctx, t)
+	c.Start(ctx)
 
 	db := c.Conn(ctx, c.Spec().NodeCount)
 	defer db.Close()
@@ -67,7 +67,7 @@ func runClockJump(ctx context.Context, t *test, c Cluster, tc clockJumpTestCase)
 		// restarting it if not.
 		time.Sleep(3 * time.Second)
 		if !isAlive(db, t.l) {
-			c.Start(ctx, t, c.Node(1))
+			c.Start(ctx, c.Node(1))
 		}
 	}()
 	defer offsetInjector.recover(ctx, c.Spec().NodeCount)

--- a/pkg/cmd/roachtest/clock_jump_crash.go
+++ b/pkg/cmd/roachtest/clock_jump_crash.go
@@ -15,12 +15,12 @@ import (
 	"fmt"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	_ "github.com/lib/pq"
 )
 
-func runClockJump(ctx context.Context, t *test, c cluster2.Cluster, tc clockJumpTestCase) {
+func runClockJump(ctx context.Context, t *test, c cluster.Cluster, tc clockJumpTestCase) {
 	// Test with a single node so that the node does not crash due to MaxOffset
 	// violation when injecting offset
 	if c.Spec().NodeCount != 1 {
@@ -136,7 +136,7 @@ func registerClockJumpTests(r *testRegistry) {
 			// These tests muck with NTP, therefore we don't want the cluster reused
 			// by others.
 			Cluster: r.makeClusterSpec(1, spec.ReuseTagged("offset-injector")),
-			Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+			Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 				runClockJump(ctx, t, c, tc)
 			},
 		}

--- a/pkg/cmd/roachtest/clock_monotonic.go
+++ b/pkg/cmd/roachtest/clock_monotonic.go
@@ -15,13 +15,13 @@ import (
 	"fmt"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	_ "github.com/lib/pq"
 )
 
 func runClockMonotonicity(
-	ctx context.Context, t *test, c cluster2.Cluster, tc clockMonotonicityTestCase,
+	ctx context.Context, t *test, c cluster.Cluster, tc clockMonotonicityTestCase,
 ) {
 	// Test with a single node so that the node does not crash due to MaxOffset
 	// violation when introducing offset
@@ -138,7 +138,7 @@ func registerClockMonotonicTests(r *testRegistry) {
 			// These tests muck with NTP, therefor we don't want the cluster reused by
 			// others.
 			Cluster: r.makeClusterSpec(1, spec.ReuseTagged("offset-injector")),
-			Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+			Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 				runClockMonotonicity(ctx, t, c, tc)
 			},
 		}

--- a/pkg/cmd/roachtest/clock_monotonic.go
+++ b/pkg/cmd/roachtest/clock_monotonic.go
@@ -15,11 +15,14 @@ import (
 	"fmt"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	_ "github.com/lib/pq"
 )
 
-func runClockMonotonicity(ctx context.Context, t *test, c Cluster, tc clockMonotonicityTestCase) {
+func runClockMonotonicity(
+	ctx context.Context, t *test, c cluster2.Cluster, tc clockMonotonicityTestCase,
+) {
 	// Test with a single node so that the node does not crash due to MaxOffset
 	// violation when introducing offset
 	if c.Spec().NodeCount != 1 {
@@ -135,7 +138,7 @@ func registerClockMonotonicTests(r *testRegistry) {
 			// These tests muck with NTP, therefor we don't want the cluster reused by
 			// others.
 			Cluster: r.makeClusterSpec(1, spec.ReuseTagged("offset-injector")),
-			Run: func(ctx context.Context, t *test, c Cluster) {
+			Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 				runClockMonotonicity(ctx, t, c, tc)
 			},
 		}

--- a/pkg/cmd/roachtest/clock_monotonic.go
+++ b/pkg/cmd/roachtest/clock_monotonic.go
@@ -36,7 +36,7 @@ func runClockMonotonicity(ctx context.Context, t *test, c Cluster, tc clockMonot
 		c.Put(ctx, cockroach, "./cockroach", c.All())
 	}
 	c.Wipe(ctx)
-	c.Start(ctx, t)
+	c.Start(ctx)
 
 	db := c.Conn(ctx, c.Spec().NodeCount)
 	defer db.Close()
@@ -70,7 +70,7 @@ func runClockMonotonicity(ctx context.Context, t *test, c Cluster, tc clockMonot
 
 		offsetInjector.recover(ctx, c.Spec().NodeCount)
 
-		c.Start(ctx, t, c.Node(c.Spec().NodeCount))
+		c.Start(ctx, c.Node(c.Spec().NodeCount))
 		if !isAlive(db, t.l) {
 			t.Fatal("Node unexpectedly crashed")
 		}
@@ -82,7 +82,7 @@ func runClockMonotonicity(ctx context.Context, t *test, c Cluster, tc clockMonot
 	t.Status("injecting offset")
 	offsetInjector.offset(ctx, c.Spec().NodeCount, tc.offset)
 	t.Status("starting cockroach post offset")
-	c.Start(ctx, t, c.Node(c.Spec().NodeCount))
+	c.Start(ctx, c.Node(c.Spec().NodeCount))
 
 	if !isAlive(db, t.l) {
 		t.Fatal("Node unexpectedly crashed")

--- a/pkg/cmd/roachtest/clock_util.go
+++ b/pkg/cmd/roachtest/clock_util.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/logger"
 )
 
@@ -46,7 +47,7 @@ func dbUnixEpoch(db *gosql.DB) (float64, error) {
 // offsetInjector is used to inject clock offsets in roachtests.
 type offsetInjector struct {
 	t        *test
-	c        Cluster
+	c        cluster2.Cluster
 	deployed bool
 }
 
@@ -122,6 +123,6 @@ func (oi *offsetInjector) recover(ctx context.Context, nodeID int) {
 
 // newOffsetInjector creates a offsetInjector which can be used to inject
 // and recover from clock offsets.
-func newOffsetInjector(t *test, c Cluster) *offsetInjector {
+func newOffsetInjector(t *test, c cluster2.Cluster) *offsetInjector {
 	return &offsetInjector{t: t, c: c}
 }

--- a/pkg/cmd/roachtest/clock_util.go
+++ b/pkg/cmd/roachtest/clock_util.go
@@ -16,7 +16,7 @@ import (
 	"fmt"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/logger"
 )
 
@@ -47,7 +47,7 @@ func dbUnixEpoch(db *gosql.DB) (float64, error) {
 // offsetInjector is used to inject clock offsets in roachtests.
 type offsetInjector struct {
 	t        *test
-	c        cluster2.Cluster
+	c        cluster.Cluster
 	deployed bool
 }
 
@@ -123,6 +123,6 @@ func (oi *offsetInjector) recover(ctx context.Context, nodeID int) {
 
 // newOffsetInjector creates a offsetInjector which can be used to inject
 // and recover from clock offsets.
-func newOffsetInjector(t *test, c cluster2.Cluster) *offsetInjector {
+func newOffsetInjector(t *test, c cluster.Cluster) *offsetInjector {
 	return &offsetInjector{t: t, c: c}
 }

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -237,23 +237,23 @@ func initBinariesAndLibraries() {
 type clusterRegistry struct {
 	mu struct {
 		syncutil.Mutex
-		clusters map[string]*cluster
+		clusters map[string]*clusterImpl
 		tagCount map[string]int
 		// savedClusters keeps track of clusters that have been saved for further
 		// debugging. Each cluster comes with a message about the test failure
 		// causing it to be saved for debugging.
-		savedClusters map[*cluster]string
+		savedClusters map[*clusterImpl]string
 	}
 }
 
 func newClusterRegistry() *clusterRegistry {
 	cr := &clusterRegistry{}
-	cr.mu.clusters = make(map[string]*cluster)
-	cr.mu.savedClusters = make(map[*cluster]string)
+	cr.mu.clusters = make(map[string]*clusterImpl)
+	cr.mu.savedClusters = make(map[*clusterImpl]string)
 	return cr
 }
 
-func (r *clusterRegistry) registerCluster(c *cluster) error {
+func (r *clusterRegistry) registerCluster(c *clusterImpl) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.mu.clusters[c.name] != nil {
@@ -263,7 +263,7 @@ func (r *clusterRegistry) registerCluster(c *cluster) error {
 	return nil
 }
 
-func (r *clusterRegistry) unregisterCluster(c *cluster) bool {
+func (r *clusterRegistry) unregisterCluster(c *clusterImpl) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if _, ok := r.mu.clusters[c.name]; !ok {
@@ -291,14 +291,14 @@ func (r *clusterRegistry) countForTag(tag string) int {
 // destroyAllClusters.
 // msg is a message recording the reason why the cluster is being saved (i.e.
 // generally a test failure error).
-func (r *clusterRegistry) markClusterAsSaved(c *cluster, msg string) {
+func (r *clusterRegistry) markClusterAsSaved(c *clusterImpl, msg string) {
 	r.mu.Lock()
 	r.mu.savedClusters[c] = msg
 	r.mu.Unlock()
 }
 
 type clusterWithMsg struct {
-	*cluster
+	*clusterImpl
 	savedMsg string
 }
 
@@ -311,8 +311,8 @@ func (r *clusterRegistry) savedClusters() []clusterWithMsg {
 	i := 0
 	for c, msg := range r.mu.savedClusters {
 		res[i] = clusterWithMsg{
-			cluster:  c,
-			savedMsg: msg,
+			clusterImpl: c,
+			savedMsg:    msg,
 		}
 		i++
 	}
@@ -332,8 +332,8 @@ func (r *clusterRegistry) destroyAllClusters(ctx context.Context, l *logger.Logg
 	go func() {
 		defer close(done)
 
-		var clusters []*cluster
-		savedClusters := make(map[*cluster]struct{})
+		var clusters []*clusterImpl
+		savedClusters := make(map[*clusterImpl]struct{})
 		r.mu.Lock()
 		for _, c := range r.mu.clusters {
 			clusters = append(clusters, c)
@@ -346,7 +346,7 @@ func (r *clusterRegistry) destroyAllClusters(ctx context.Context, l *logger.Logg
 		var wg sync.WaitGroup
 		wg.Add(len(clusters))
 		for _, c := range clusters {
-			go func(c *cluster) {
+			go func(c *clusterImpl) {
 				defer wg.Done()
 				if _, ok := savedClusters[c]; !ok {
 					// We don't close the logger here since the cluster may be still in use
@@ -684,12 +684,10 @@ func withWorkerAction() option.Option {
 	return workerAction{}
 }
 
-// cluster provides an interface for interacting with a set of machines,
-// starting and stopping a cockroach cluster on a subset of those machines, and
-// running load generators and other operations on the machines.
-//
-// A cluster is safe for concurrent use by multiple goroutines.
-type cluster struct {
+// clusterImpl implements cluster.Cluster.
+
+// It is safe for concurrent use by multiple goroutines.
+type clusterImpl struct {
 	name string
 	tag  string
 	spec spec.ClusterSpec
@@ -717,43 +715,43 @@ type cluster struct {
 }
 
 // Name returns the cluster name, i.e. something like `teamcity-....`
-func (c *cluster) Name() string {
+func (c *clusterImpl) Name() string {
 	return c.name
 }
 
 // EncryptAtRandom sets whether the cluster will start new nodes with
 // encryption enabled.
-func (c *cluster) EncryptAtRandom(b bool) {
+func (c *clusterImpl) EncryptAtRandom(b bool) {
 	c.encryptAtRandom = b
 }
 
 // EncryptDefault sets the default for encryption-at-rest. This can be overridden
 // by options passed to `c.Start`.
-func (c *cluster) EncryptDefault(b bool) {
+func (c *clusterImpl) EncryptDefault(b bool) {
 	c.encryptDefault = b
 }
 
 // Spec returns the spec underlying the cluster.
-func (c *cluster) Spec() spec.ClusterSpec {
+func (c *clusterImpl) Spec() spec.ClusterSpec {
 	return c.spec
 }
 
 // status is used to communicate the test's status. It's a no-op until the
 // cluster is passed to a test, at which point it's hooked up to test.Status().
-func (c *cluster) status(args ...interface{}) {
+func (c *clusterImpl) status(args ...interface{}) {
 	if c.t == nil {
 		return
 	}
 	c.t.Status(args...)
 }
 
-func (c *cluster) workerStatus(args ...interface{}) {
+func (c *clusterImpl) workerStatus(args ...interface{}) {
 	if impl, ok := c.t.(*test); ok {
 		impl.WorkerStatus(args...)
 	}
 }
 
-func (c *cluster) String() string {
+func (c *clusterImpl) String() string {
 	return fmt.Sprintf("%s [tag:%s] (%d nodes)", c.name, c.tag, c.Spec().NodeCount)
 }
 
@@ -786,7 +784,7 @@ type destroyState struct {
 }
 
 // closeLogger closes c.l. It can be called multiple times.
-func (c *cluster) closeLogger() {
+func (c *clusterImpl) closeLogger() {
 	c.destroyState.mu.Lock()
 	defer c.destroyState.mu.Unlock()
 	if c.destroyState.mu.loggerClosed {
@@ -858,7 +856,7 @@ func (f *clusterFactory) releaseSem() {
 // NOTE: setTest() needs to be called before a test can use this cluster.
 func (f *clusterFactory) newCluster(
 	ctx context.Context, cfg clusterConfig, setStatus func(string), teeOpt logger.TeeOptType,
-) (*cluster, error) {
+) (*clusterImpl, error) {
 	if ctx.Err() != nil {
 		return nil, errors.Wrap(ctx.Err(), "newCluster")
 	}
@@ -874,7 +872,7 @@ func (f *clusterFactory) newCluster(
 
 	if cfg.spec.NodeCount == 0 {
 		// For tests. Return the minimum that makes them happy.
-		c := &cluster{
+		c := &clusterImpl{
 			name:       name,
 			expiration: timeutil.Now().Add(24 * time.Hour),
 			r:          f.r,
@@ -890,7 +888,7 @@ func (f *clusterFactory) newCluster(
 		// Local clusters never expire.
 		exp = timeutil.Now().Add(100000 * time.Hour)
 	}
-	c := &cluster{
+	c := &clusterImpl{
 		name:           name,
 		spec:           cfg.spec,
 		expiration:     exp,
@@ -977,12 +975,12 @@ func attachToExistingCluster(
 	spec spec.ClusterSpec,
 	opt attachOpt,
 	r *clusterRegistry,
-) (*cluster, error) {
+) (*clusterImpl, error) {
 	exp := spec.Expiration()
 	if name == "local" {
 		exp = timeutil.Now().Add(100000 * time.Hour)
 	}
-	c := &cluster{
+	c := &clusterImpl{
 		name:           name,
 		spec:           spec,
 		l:              l,
@@ -1028,14 +1026,14 @@ func attachToExistingCluster(
 // setTest prepares c for being used on behalf of t.
 //
 // TODO(andrei): Get rid of c.t, c.l and of this method.
-func (c *cluster) setTest(t testI) {
+func (c *clusterImpl) setTest(t testI) {
 	c.t = t
 	c.l = t.logger()
 }
 
 // StopCockroachGracefullyOnNode stops a running cockroach instance on the requested
 // node before a version upgrade.
-func (c *cluster) StopCockroachGracefullyOnNode(ctx context.Context, node int) error {
+func (c *clusterImpl) StopCockroachGracefullyOnNode(ctx context.Context, node int) error {
 	port := fmt.Sprintf("{pgport:%d}", node)
 	// Note that the following command line needs to run against both v2.1
 	// and the current branch. Do not change it in a manner that is
@@ -1057,7 +1055,7 @@ func (c *cluster) StopCockroachGracefullyOnNode(ctx context.Context, node int) e
 }
 
 // Save marks the cluster as "saved" so that it doesn't get destroyed.
-func (c *cluster) Save(ctx context.Context, msg string, l *logger.Logger) {
+func (c *clusterImpl) Save(ctx context.Context, msg string, l *logger.Logger) {
 	l.PrintfCtx(ctx, "saving cluster %s for debugging (--debug specified)", c)
 	// TODO(andrei): should we extend the cluster here? For how long?
 	if c.destroyState.owned { // we won't have an alloc for an unowned cluster
@@ -1074,7 +1072,9 @@ func (c *cluster) Save(ctx context.Context, msg string, l *logger.Logger) {
 // the cluster's spec. It's intended to be used with clusters created by
 // attachToExistingCluster(); otherwise, clusters create with newCluster() are
 // know to be up to spec.
-func (c *cluster) validate(ctx context.Context, nodes spec.ClusterSpec, l *logger.Logger) error {
+func (c *clusterImpl) validate(
+	ctx context.Context, nodes spec.ClusterSpec, l *logger.Logger,
+) error {
 	// Perform validation on the existing cluster.
 	c.status("checking that existing cluster matches spec")
 	sargs := []string{roachprod, "list", c.name, "--json", "--quiet"}
@@ -1118,12 +1118,12 @@ func (c *cluster) validate(ctx context.Context, nodes spec.ClusterSpec, l *logge
 }
 
 // All returns a node list containing all of the nodes in the cluster.
-func (c *cluster) All() option.NodeListOption {
+func (c *clusterImpl) All() option.NodeListOption {
 	return c.Range(1, c.spec.NodeCount)
 }
 
 // All returns a node list containing the nodes [begin,end].
-func (c *cluster) Range(begin, end int) option.NodeListOption {
+func (c *clusterImpl) Range(begin, end int) option.NodeListOption {
 	if begin < 1 || end > c.spec.NodeCount {
 		c.t.Fatalf("invalid node range: %d-%d (1-%d)", begin, end, c.spec.NodeCount)
 	}
@@ -1135,7 +1135,7 @@ func (c *cluster) Range(begin, end int) option.NodeListOption {
 }
 
 // All returns a node list containing only the node i.
-func (c *cluster) Nodes(ns ...int) option.NodeListOption {
+func (c *clusterImpl) Nodes(ns ...int) option.NodeListOption {
 	r := make(option.NodeListOption, 0, len(ns))
 	for _, n := range ns {
 		if n < 1 || n > c.spec.NodeCount {
@@ -1148,13 +1148,13 @@ func (c *cluster) Nodes(ns ...int) option.NodeListOption {
 }
 
 // All returns a node list containing only the node with id i. IDs are 1-based.
-func (c *cluster) Node(i int) option.NodeListOption {
+func (c *clusterImpl) Node(i int) option.NodeListOption {
 	return c.Range(i, i)
 }
 
 // FetchLogs downloads the logs from the cluster using `roachprod get`.
 // The logs will be placed in the test's artifacts dir.
-func (c *cluster) FetchLogs(ctx context.Context, t *test) error {
+func (c *clusterImpl) FetchLogs(ctx context.Context, t *test) error {
 	if c.spec.NodeCount == 0 {
 		// No nodes can happen during unit tests and implies nothing to do.
 		return nil
@@ -1209,7 +1209,7 @@ func saveDiskUsageToLogsDir(ctx context.Context, c cluster2.Cluster) error {
 
 // CopyRoachprodState copies the roachprod state directory in to the test
 // artifacts.
-func (c *cluster) CopyRoachprodState(ctx context.Context) error {
+func (c *clusterImpl) CopyRoachprodState(ctx context.Context) error {
 	if c.spec.NodeCount == 0 {
 		// No nodes can happen during unit tests and implies nothing to do.
 		return nil
@@ -1232,7 +1232,7 @@ func (c *cluster) CopyRoachprodState(ctx context.Context) error {
 // the first available node. They can be visualized via:
 //
 // `COCKROACH_DEBUG_TS_IMPORT_FILE=tsdump.gob ./cockroach start-single-node --insecure --store=$(mktemp -d)`
-func (c *cluster) FetchTimeseriesData(ctx context.Context, t *test) error {
+func (c *clusterImpl) FetchTimeseriesData(ctx context.Context, t *test) error {
 	return contextutil.RunWithTimeout(ctx, "debug zip", 5*time.Minute, func(ctx context.Context) error {
 		var err error
 		for i := 1; i <= c.spec.NodeCount; i++ {
@@ -1251,7 +1251,7 @@ func (c *cluster) FetchTimeseriesData(ctx context.Context, t *test) error {
 
 // FetchDebugZip downloads the debug zip from the cluster using `roachprod ssh`.
 // The logs will be placed in the test's artifacts dir.
-func (c *cluster) FetchDebugZip(ctx context.Context, t *test) error {
+func (c *clusterImpl) FetchDebugZip(ctx context.Context, t *test) error {
 	if c.spec.NodeCount == 0 {
 		// No nodes can happen during unit tests and implies nothing to do.
 		return nil
@@ -1293,7 +1293,7 @@ func (c *cluster) FetchDebugZip(ctx context.Context, t *test) error {
 
 // FailOnDeadNodes fails the test if nodes that have a populated data dir are
 // found to be not running. It prints both to t.l and the test output.
-func (c *cluster) FailOnDeadNodes(ctx context.Context, t *test) {
+func (c *clusterImpl) FailOnDeadNodes(ctx context.Context, t *test) {
 	if c.spec.NodeCount == 0 {
 		// No nodes can happen during unit tests and implies nothing to do.
 		return
@@ -1322,7 +1322,7 @@ func (c *cluster) FailOnDeadNodes(ctx context.Context, t *test) {
 // error. Note that this will swallow errors returned directly from the consistency
 // check since we know that such spurious errors are possibly without any relation
 // to the check having failed.
-func (c *cluster) CheckReplicaDivergenceOnDB(
+func (c *clusterImpl) CheckReplicaDivergenceOnDB(
 	ctx context.Context, l *logger.Logger, db *gosql.DB,
 ) error {
 	// NB: we set a statement_timeout since context cancellation won't work here,
@@ -1364,7 +1364,7 @@ WHERE t.status NOT IN ('RANGE_CONSISTENT', 'RANGE_INDETERMINATE')`)
 // crdb_internal.check_consistency(true, '', '') indicates that any ranges'
 // replicas are inconsistent with each other. It uses the first node that
 // is up to run the query.
-func (c *cluster) FailOnReplicaDivergence(ctx context.Context, t *test) {
+func (c *clusterImpl) FailOnReplicaDivergence(ctx context.Context, t *test) {
 	if c.spec.NodeCount < 1 {
 		return // unit tests
 	}
@@ -1409,7 +1409,7 @@ func (c *cluster) FailOnReplicaDivergence(ctx context.Context, t *test) {
 
 // FetchDmesg grabs the dmesg logs if possible. This requires being able to run
 // `sudo dmesg` on the remote nodes.
-func (c *cluster) FetchDmesg(ctx context.Context, t *test) error {
+func (c *clusterImpl) FetchDmesg(ctx context.Context, t *test) error {
 	if c.spec.NodeCount == 0 || c.IsLocal() {
 		// No nodes can happen during unit tests and implies nothing to do.
 		// Also, don't grab dmesg on local runs.
@@ -1440,7 +1440,7 @@ func (c *cluster) FetchDmesg(ctx context.Context, t *test) error {
 
 // FetchJournalctl grabs the journalctl logs if possible. This requires being
 // able to run `sudo journalctl` on the remote nodes.
-func (c *cluster) FetchJournalctl(ctx context.Context, t *test) error {
+func (c *clusterImpl) FetchJournalctl(ctx context.Context, t *test) error {
 	if c.spec.NodeCount == 0 || c.IsLocal() {
 		// No nodes can happen during unit tests and implies nothing to do.
 		// Also, don't grab journalctl on local runs.
@@ -1470,7 +1470,7 @@ func (c *cluster) FetchJournalctl(ctx context.Context, t *test) error {
 }
 
 // FetchCores fetches any core files on the cluster.
-func (c *cluster) FetchCores(ctx context.Context, t *test) error {
+func (c *clusterImpl) FetchCores(ctx context.Context, t *test) error {
 	if c.spec.NodeCount == 0 || c.IsLocal() {
 		// No nodes can happen during unit tests and implies nothing to do.
 		// Also, don't grab dmesg on local runs.
@@ -1519,7 +1519,7 @@ const (
 // l is the logger that will log this destroy operation.
 //
 // This method generally does not react to ctx cancelation.
-func (c *cluster) Destroy(ctx context.Context, lo closeLoggerOpt, l *logger.Logger) {
+func (c *clusterImpl) Destroy(ctx context.Context, lo closeLoggerOpt, l *logger.Logger) {
 	if ctx.Err() != nil {
 		return
 	}
@@ -1539,7 +1539,7 @@ func (c *cluster) Destroy(ctx context.Context, lo closeLoggerOpt, l *logger.Logg
 	}
 }
 
-func (c *cluster) doDestroy(ctx context.Context, l *logger.Logger) <-chan struct{} {
+func (c *clusterImpl) doDestroy(ctx context.Context, l *logger.Logger) <-chan struct{} {
 	var inFlight <-chan struct{}
 	c.destroyState.mu.Lock()
 	if c.destroyState.mu.saved {
@@ -1602,14 +1602,14 @@ func loggedCommand(ctx context.Context, l *logger.Logger, arg0 string, args ...s
 
 // Put a local file to all of the machines in a cluster.
 // Put is DEPRECATED. Use PutE instead.
-func (c *cluster) Put(ctx context.Context, src, dest string, opts ...option.Option) {
+func (c *clusterImpl) Put(ctx context.Context, src, dest string, opts ...option.Option) {
 	if err := c.PutE(ctx, c.l, src, dest, opts...); err != nil {
 		c.t.Fatal(err)
 	}
 }
 
 // PutE puts a local file to all of the machines in a cluster.
-func (c *cluster) PutE(
+func (c *clusterImpl) PutE(
 	ctx context.Context, l *logger.Logger, src, dest string, opts ...option.Option,
 ) error {
 	if ctx.Err() != nil {
@@ -1628,7 +1628,7 @@ func (c *cluster) PutE(
 
 // PutLibraries inserts all available library files into all nodes on the cluster
 // at the specified location.
-func (c *cluster) PutLibraries(ctx context.Context, libraryDir string) error {
+func (c *clusterImpl) PutLibraries(ctx context.Context, libraryDir string) error {
 	if ctx.Err() != nil {
 		return errors.Wrap(ctx.Err(), "cluster.Put")
 	}
@@ -1654,7 +1654,7 @@ func (c *cluster) PutLibraries(ctx context.Context, libraryDir string) error {
 }
 
 // Stage stages a binary to the cluster.
-func (c *cluster) Stage(
+func (c *clusterImpl) Stage(
 	ctx context.Context,
 	l *logger.Logger,
 	application, versionOrSHA, dir string,
@@ -1679,7 +1679,7 @@ func (c *cluster) Stage(
 }
 
 // Get gets files from remote hosts.
-func (c *cluster) Get(
+func (c *clusterImpl) Get(
 	ctx context.Context, l *logger.Logger, src, dest string, opts ...option.Option,
 ) error {
 	if ctx.Err() != nil {
@@ -1694,7 +1694,7 @@ func (c *cluster) Get(
 }
 
 // Put a string into the specified file on the remote(s).
-func (c *cluster) PutString(
+func (c *clusterImpl) PutString(
 	ctx context.Context, content, dest string, mode os.FileMode, opts ...option.Option,
 ) error {
 	if ctx.Err() != nil {
@@ -1728,7 +1728,7 @@ func (c *cluster) PutString(
 // GitClone clones a git repo from src into dest and checks out origin's
 // version of the given branch. The src, dest, and branch arguments must not
 // contain shell special characters.
-func (c *cluster) GitClone(
+func (c *clusterImpl) GitClone(
 	ctx context.Context, l *logger.Logger, src, dest, branch string, node option.NodeListOption,
 ) error {
 	return c.RunL(ctx, l, node, "bash", "-e", "-c", fmt.Sprintf(`'
@@ -1782,7 +1782,7 @@ func roachprodArgs(opts []option.Option) []string {
 	return args
 }
 
-func (c *cluster) setStatusForClusterOpt(operation string, opts ...option.Option) {
+func (c *clusterImpl) setStatusForClusterOpt(operation string, opts ...option.Option) {
 	var nodes option.NodeListOption
 	worker := false
 	for _, o := range opts {
@@ -1805,7 +1805,7 @@ func (c *cluster) setStatusForClusterOpt(operation string, opts ...option.Option
 	}
 }
 
-func (c *cluster) clearStatusForClusterOpt(opts ...option.Option) {
+func (c *clusterImpl) clearStatusForClusterOpt(opts ...option.Option) {
 	worker := false
 	for _, o := range opts {
 		if _, ok := o.(workerAction); ok {
@@ -1822,7 +1822,7 @@ func (c *cluster) clearStatusForClusterOpt(opts ...option.Option) {
 // StartE starts cockroach nodes on a subset of the cluster. The nodes parameter
 // can either be a specific node, empty (to indicate all nodes), or a pair of
 // nodes indicating a range.
-func (c *cluster) StartE(ctx context.Context, opts ...option.Option) error {
+func (c *clusterImpl) StartE(ctx context.Context, opts ...option.Option) error {
 	if ctx.Err() != nil {
 		return errors.Wrap(ctx.Err(), "cluster.StartE")
 	}
@@ -1854,7 +1854,7 @@ func (c *cluster) StartE(ctx context.Context, opts ...option.Option) error {
 }
 
 // Start is like StartE() except that it will fatal the test on error.
-func (c *cluster) Start(ctx context.Context, opts ...option.Option) {
+func (c *clusterImpl) Start(ctx context.Context, opts ...option.Option) {
 	if err := c.StartE(ctx, opts...); err != nil {
 		c.t.Fatal(err)
 	}
@@ -1871,7 +1871,7 @@ func argExists(args []string, target string) bool {
 
 // StopE cockroach nodes running on a subset of the cluster. See cluster.Start()
 // for a description of the nodes parameter.
-func (c *cluster) StopE(ctx context.Context, opts ...option.Option) error {
+func (c *clusterImpl) StopE(ctx context.Context, opts ...option.Option) error {
 	if ctx.Err() != nil {
 		return errors.Wrap(ctx.Err(), "cluster.StopE")
 	}
@@ -1888,7 +1888,7 @@ func (c *cluster) StopE(ctx context.Context, opts ...option.Option) error {
 
 // Stop is like StopE, except instead of returning an error, it does
 // c.t.Fatal(). c.t needs to be set.
-func (c *cluster) Stop(ctx context.Context, opts ...option.Option) {
+func (c *clusterImpl) Stop(ctx context.Context, opts ...option.Option) {
 	if c.t.Failed() {
 		// If the test has failed, don't try to limp along.
 		return
@@ -1898,7 +1898,7 @@ func (c *cluster) Stop(ctx context.Context, opts ...option.Option) {
 	}
 }
 
-func (c *cluster) Reset(ctx context.Context) error {
+func (c *clusterImpl) Reset(ctx context.Context) error {
 	if c.t.Failed() {
 		return errors.New("already failed")
 	}
@@ -1917,7 +1917,7 @@ func (c *cluster) Reset(ctx context.Context) error {
 
 // WipeE wipes a subset of the nodes in a cluster. See cluster.Start() for a
 // description of the nodes parameter.
-func (c *cluster) WipeE(ctx context.Context, l *logger.Logger, opts ...option.Option) error {
+func (c *clusterImpl) WipeE(ctx context.Context, l *logger.Logger, opts ...option.Option) error {
 	if ctx.Err() != nil {
 		return errors.Wrap(ctx.Err(), "cluster.WipeE")
 	}
@@ -1932,7 +1932,7 @@ func (c *cluster) WipeE(ctx context.Context, l *logger.Logger, opts ...option.Op
 
 // Wipe is like WipeE, except instead of returning an error, it does
 // c.t.Fatal(). c.t needs to be set.
-func (c *cluster) Wipe(ctx context.Context, opts ...option.Option) {
+func (c *clusterImpl) Wipe(ctx context.Context, opts ...option.Option) {
 	if ctx.Err() != nil {
 		return
 	}
@@ -1942,7 +1942,7 @@ func (c *cluster) Wipe(ctx context.Context, opts ...option.Option) {
 }
 
 // Run a command on the specified node.
-func (c *cluster) Run(ctx context.Context, node option.NodeListOption, args ...string) {
+func (c *clusterImpl) Run(ctx context.Context, node option.NodeListOption, args ...string) {
 	err := c.RunE(ctx, node, args...)
 	if err != nil {
 		c.t.Fatal(err)
@@ -1950,7 +1950,7 @@ func (c *cluster) Run(ctx context.Context, node option.NodeListOption, args ...s
 }
 
 // Reformat the disk on the specified node.
-func (c *cluster) Reformat(ctx context.Context, node option.NodeListOption, args ...string) {
+func (c *clusterImpl) Reformat(ctx context.Context, node option.NodeListOption, args ...string) {
 	err := execCmd(ctx, c.l,
 		append([]string{roachprod, "reformat", c.MakeNodes(node), "--"}, args...)...)
 	if err != nil {
@@ -1959,10 +1959,10 @@ func (c *cluster) Reformat(ctx context.Context, node option.NodeListOption, args
 }
 
 // Silence unused warning.
-var _ = (&cluster{}).Reformat
+var _ = (&clusterImpl{}).Reformat
 
 // Install a package in a node
-func (c *cluster) Install(
+func (c *clusterImpl) Install(
 	ctx context.Context, l *logger.Logger, node option.NodeListOption, args ...string,
 ) error {
 	return execCmd(ctx, l,
@@ -2000,7 +2000,7 @@ func cmdLogFileName(t time.Time, nodes option.NodeListOption, args ...string) st
 // will be redirected to a file which is logged via the cluster-wide logger in
 // case of an error. Logs will sort chronologically. Failing invocations will
 // have an additional marker file with a `.failed` extension instead of `.log`.
-func (c *cluster) RunE(ctx context.Context, node option.NodeListOption, args ...string) error {
+func (c *clusterImpl) RunE(ctx context.Context, node option.NodeListOption, args ...string) error {
 	logFile := cmdLogFileName(timeutil.Now(), node, args...)
 
 	// NB: we set no prefix because it's only going to a file anyway.
@@ -2026,7 +2026,7 @@ func (c *cluster) RunE(ctx context.Context, node option.NodeListOption, args ...
 }
 
 // RunL runs a command on the specified node, returning an error.
-func (c *cluster) RunL(
+func (c *clusterImpl) RunL(
 	ctx context.Context, l *logger.Logger, node option.NodeListOption, args ...string,
 ) error {
 	if err := errors.Wrap(ctx.Err(), "cluster.RunL"); err != nil {
@@ -2038,7 +2038,7 @@ func (c *cluster) RunL(
 
 // RunWithBuffer runs a command on the specified node, returning the resulting combined stderr
 // and stdout or an error.
-func (c *cluster) RunWithBuffer(
+func (c *clusterImpl) RunWithBuffer(
 	ctx context.Context, l *logger.Logger, node option.NodeListOption, args ...string,
 ) ([]byte, error) {
 	if err := errors.Wrap(ctx.Err(), "cluster.RunWithBuffer"); err != nil {
@@ -2053,7 +2053,7 @@ func (c *cluster) RunWithBuffer(
 // external IP address. In general, inter-cluster communication and should use
 // internal IPs and communication from a test driver to nodes in a cluster
 // should use external IPs.
-func (c *cluster) pgURLErr(
+func (c *clusterImpl) pgURLErr(
 	ctx context.Context, node option.NodeListOption, external bool,
 ) ([]string, error) {
 	args := []string{roachprod, "pgurl"}
@@ -2085,21 +2085,25 @@ func (c *cluster) pgURLErr(
 }
 
 // InternalPGUrl returns the internal Postgres endpoint for the specified nodes.
-func (c *cluster) InternalPGUrl(ctx context.Context, node option.NodeListOption) ([]string, error) {
+func (c *clusterImpl) InternalPGUrl(
+	ctx context.Context, node option.NodeListOption,
+) ([]string, error) {
 	return c.pgURLErr(ctx, node, false /* external */)
 }
 
 // Silence unused warning.
-var _ = (&cluster{}).InternalPGUrl
+var _ = (&clusterImpl{}).InternalPGUrl
 
 // ExternalPGUrl returns the external Postgres endpoint for the specified nodes.
-func (c *cluster) ExternalPGUrl(ctx context.Context, node option.NodeListOption) ([]string, error) {
+func (c *clusterImpl) ExternalPGUrl(
+	ctx context.Context, node option.NodeListOption,
+) ([]string, error) {
 	return c.pgURLErr(ctx, node, true /* external */)
 }
 
 // ExternalPGUrlSecure returns the external Postgres endpoint for the specified
 // nodes.
-func (c *cluster) ExternalPGUrlSecure(
+func (c *clusterImpl) ExternalPGUrlSecure(
 	ctx context.Context, node option.NodeListOption, user string, certsDir string, port int,
 ) ([]string, error) {
 	urlTemplate := "postgres://%s@%s:%d?sslcert=%s/client.%s.crt&sslkey=%s/client.%s.key&sslrootcert=%s/ca.crt&sslmode=require"
@@ -2114,7 +2118,7 @@ func (c *cluster) ExternalPGUrlSecure(
 	return urls, nil
 }
 
-func addrToAdminUIAddr(c *cluster, addr string) (string, error) {
+func addrToAdminUIAddr(c *clusterImpl, addr string) (string, error) {
 	host, port, err := net.SplitHostPort(addr)
 	if err != nil {
 		return "", err
@@ -2157,7 +2161,7 @@ func addrToHostPort(addr string) (string, int, error) {
 
 // InternalAdminUIAddr returns the internal Admin UI address in the form host:port
 // for the specified node.
-func (c *cluster) InternalAdminUIAddr(
+func (c *clusterImpl) InternalAdminUIAddr(
 	ctx context.Context, node option.NodeListOption,
 ) ([]string, error) {
 	var addrs []string
@@ -2177,7 +2181,7 @@ func (c *cluster) InternalAdminUIAddr(
 
 // ExternalAdminUIAddr returns the internal Admin UI address in the form host:port
 // for the specified node.
-func (c *cluster) ExternalAdminUIAddr(
+func (c *clusterImpl) ExternalAdminUIAddr(
 	ctx context.Context, node option.NodeListOption,
 ) ([]string, error) {
 	var addrs []string
@@ -2197,7 +2201,9 @@ func (c *cluster) ExternalAdminUIAddr(
 
 // InternalAddr returns the internal address in the form host:port for the
 // specified nodes.
-func (c *cluster) InternalAddr(ctx context.Context, node option.NodeListOption) ([]string, error) {
+func (c *clusterImpl) InternalAddr(
+	ctx context.Context, node option.NodeListOption,
+) ([]string, error) {
 	var addrs []string
 	urls, err := c.pgURLErr(ctx, node, false /* external */)
 	if err != nil {
@@ -2214,7 +2220,9 @@ func (c *cluster) InternalAddr(ctx context.Context, node option.NodeListOption) 
 }
 
 // InternalIP returns the internal IP addresses for the specified nodes.
-func (c *cluster) InternalIP(ctx context.Context, node option.NodeListOption) ([]string, error) {
+func (c *clusterImpl) InternalIP(
+	ctx context.Context, node option.NodeListOption,
+) ([]string, error) {
 	var ips []string
 	addrs, err := c.InternalAddr(ctx, node)
 	if err != nil {
@@ -2232,7 +2240,9 @@ func (c *cluster) InternalIP(ctx context.Context, node option.NodeListOption) ([
 
 // ExternalAddr returns the external address in the form host:port for the
 // specified node.
-func (c *cluster) ExternalAddr(ctx context.Context, node option.NodeListOption) ([]string, error) {
+func (c *clusterImpl) ExternalAddr(
+	ctx context.Context, node option.NodeListOption,
+) ([]string, error) {
 	var addrs []string
 	urls, err := c.pgURLErr(ctx, node, true /* external */)
 	if err != nil {
@@ -2249,7 +2259,9 @@ func (c *cluster) ExternalAddr(ctx context.Context, node option.NodeListOption) 
 }
 
 // ExternalIP returns the external IP addresses for the specified node.
-func (c *cluster) ExternalIP(ctx context.Context, node option.NodeListOption) ([]string, error) {
+func (c *clusterImpl) ExternalIP(
+	ctx context.Context, node option.NodeListOption,
+) ([]string, error) {
 	var ips []string
 	addrs, err := c.ExternalAddr(ctx, node)
 	if err != nil {
@@ -2266,10 +2278,10 @@ func (c *cluster) ExternalIP(ctx context.Context, node option.NodeListOption) ([
 }
 
 // Silence unused warning.
-var _ = (&cluster{}).ExternalIP
+var _ = (&clusterImpl{}).ExternalIP
 
 // Conn returns a SQL connection to the specified node.
-func (c *cluster) Conn(ctx context.Context, node int) *gosql.DB {
+func (c *clusterImpl) Conn(ctx context.Context, node int) *gosql.DB {
 	urls, err := c.ExternalPGUrl(ctx, c.Node(node))
 	if err != nil {
 		c.t.Fatal(err)
@@ -2282,7 +2294,7 @@ func (c *cluster) Conn(ctx context.Context, node int) *gosql.DB {
 }
 
 // ConnE returns a SQL connection to the specified node.
-func (c *cluster) ConnE(ctx context.Context, node int) (*gosql.DB, error) {
+func (c *clusterImpl) ConnE(ctx context.Context, node int) (*gosql.DB, error) {
 	urls, err := c.ExternalPGUrl(ctx, c.Node(node))
 	if err != nil {
 		return nil, err
@@ -2295,7 +2307,7 @@ func (c *cluster) ConnE(ctx context.Context, node int) (*gosql.DB, error) {
 }
 
 // ConnSecure returns a secure SQL connection to the specified node.
-func (c *cluster) ConnSecure(
+func (c *clusterImpl) ConnSecure(
 	ctx context.Context, node int, user string, certsDir string, port int,
 ) (*gosql.DB, error) {
 	urls, err := c.ExternalPGUrlSecure(ctx, c.Node(node), user, certsDir, port)
@@ -2309,7 +2321,7 @@ func (c *cluster) ConnSecure(
 	return db, nil
 }
 
-func (c *cluster) MakeNodes(opts ...option.Option) string {
+func (c *clusterImpl) MakeNodes(opts ...option.Option) string {
 	var r option.NodeListOption
 	for _, o := range opts {
 		if s, ok := o.(nodeSelector); ok {
@@ -2319,13 +2331,13 @@ func (c *cluster) MakeNodes(opts ...option.Option) string {
 	return c.name + r.String()
 }
 
-func (c *cluster) IsLocal() bool {
+func (c *clusterImpl) IsLocal() bool {
 	return c.name == "local"
 }
 
 // Extend extends the cluster's expiration by d, after truncating d to minute
 // granularity.
-func (c *cluster) Extend(ctx context.Context, d time.Duration, l *logger.Logger) error {
+func (c *clusterImpl) Extend(ctx context.Context, d time.Duration, l *logger.Logger) error {
 	if ctx.Err() != nil {
 		return errors.Wrap(ctx.Err(), "cluster.Extend")
 	}
@@ -2402,7 +2414,7 @@ type monitor struct {
 }
 
 func newMonitor(ctx context.Context, ci cluster2.Cluster, opts ...option.Option) *monitor {
-	c := ci.(*cluster) // TODO(tbg): pass `t` to `newMonitor` and avoid need for `MakeNodes`
+	c := ci.(*clusterImpl) // TODO(tbg): pass `t` to `newMonitor` and avoid need for `MakeNodes`
 	m := &monitor{
 		t:     c.t,
 		l:     c.l,

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -35,6 +35,7 @@ import (
 	"time"
 
 	"github.com/armon/circbuf"
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/logger"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
@@ -1190,7 +1191,7 @@ func (c *cluster) FetchLogs(ctx context.Context, t *test) error {
 }
 
 // saveDiskUsageToLogsDir collects a summary of the disk usage to logs/diskusage.txt on each node.
-func saveDiskUsageToLogsDir(ctx context.Context, c Cluster) error {
+func saveDiskUsageToLogsDir(ctx context.Context, c cluster2.Cluster) error {
 	// TODO(jackson): This is temporary for debugging out-of-disk-space
 	// failures like #44845.
 	if c.Spec().NodeCount == 0 || c.IsLocal() {
@@ -2343,7 +2344,7 @@ func (c *cluster) Extend(ctx context.Context, d time.Duration, l *logger.Logger)
 
 // getDiskUsageInBytes does what's on the tin. nodeIdx starts at one.
 func getDiskUsageInBytes(
-	ctx context.Context, c Cluster, logger *logger.Logger, nodeIdx int,
+	ctx context.Context, c cluster2.Cluster, logger *logger.Logger, nodeIdx int,
 ) (int, error) {
 	var out []byte
 	for {
@@ -2400,7 +2401,7 @@ type monitor struct {
 	expDeaths int32 // atomically
 }
 
-func newMonitor(ctx context.Context, ci Cluster, opts ...option.Option) *monitor {
+func newMonitor(ctx context.Context, ci cluster2.Cluster, opts ...option.Option) *monitor {
 	c := ci.(*cluster) // TODO(tbg): pass `t` to `newMonitor` and avoid need for `MakeNodes`
 	m := &monitor{
 		t:     c.t,
@@ -2665,7 +2666,7 @@ func (lg loadGroupList) loadNodes() option.NodeListOption {
 // makeLoadGroups create a loadGroupList that has an equal number of cockroach
 // nodes per zone. It assumes that numLoadNodes <= numZones and that numZones is
 // divisible by numLoadNodes.
-func makeLoadGroups(c Cluster, numZones, numRoachNodes, numLoadNodes int) loadGroupList {
+func makeLoadGroups(c cluster2.Cluster, numZones, numRoachNodes, numLoadNodes int) loadGroupList {
 	if numLoadNodes > numZones {
 		panic("cannot have more than one load node per zone")
 	} else if numZones%numLoadNodes != 0 {

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1853,7 +1853,7 @@ func (c *cluster) StartE(ctx context.Context, opts ...option.Option) error {
 }
 
 // Start is like StartE() except that it will fatal the test on error.
-func (c *cluster) Start(ctx context.Context, _ignored interface{}, opts ...option.Option) {
+func (c *cluster) Start(ctx context.Context, opts ...option.Option) {
 	if err := c.StartE(ctx, opts...); err != nil {
 		c.t.Fatal(err)
 	}

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1852,9 +1852,11 @@ func (c *cluster) StartE(ctx context.Context, opts ...option.Option) error {
 	return execCmd(ctx, c.l, args...)
 }
 
-// Start is like StartE() except it takes a test and, on error, calls t.Fatal().
-func (c *cluster) Start(ctx context.Context, t *test, opts ...option.Option) {
-	FatalIfErr(t, c.StartE(ctx, opts...))
+// Start is like StartE() except that it will fatal the test on error.
+func (c *cluster) Start(ctx context.Context, _ignored interface{}, opts ...option.Option) {
+	if err := c.StartE(ctx, opts...); err != nil {
+		c.t.Fatal(err)
+	}
 }
 
 func argExists(args []string, target string) bool {

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -35,7 +35,7 @@ import (
 	"time"
 
 	"github.com/armon/circbuf"
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/logger"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
@@ -1191,7 +1191,7 @@ func (c *clusterImpl) FetchLogs(ctx context.Context, t *test) error {
 }
 
 // saveDiskUsageToLogsDir collects a summary of the disk usage to logs/diskusage.txt on each node.
-func saveDiskUsageToLogsDir(ctx context.Context, c cluster2.Cluster) error {
+func saveDiskUsageToLogsDir(ctx context.Context, c cluster.Cluster) error {
 	// TODO(jackson): This is temporary for debugging out-of-disk-space
 	// failures like #44845.
 	if c.Spec().NodeCount == 0 || c.IsLocal() {
@@ -2356,7 +2356,7 @@ func (c *clusterImpl) Extend(ctx context.Context, d time.Duration, l *logger.Log
 
 // getDiskUsageInBytes does what's on the tin. nodeIdx starts at one.
 func getDiskUsageInBytes(
-	ctx context.Context, c cluster2.Cluster, logger *logger.Logger, nodeIdx int,
+	ctx context.Context, c cluster.Cluster, logger *logger.Logger, nodeIdx int,
 ) (int, error) {
 	var out []byte
 	for {
@@ -2413,7 +2413,7 @@ type monitor struct {
 	expDeaths int32 // atomically
 }
 
-func newMonitor(ctx context.Context, ci cluster2.Cluster, opts ...option.Option) *monitor {
+func newMonitor(ctx context.Context, ci cluster.Cluster, opts ...option.Option) *monitor {
 	c := ci.(*clusterImpl) // TODO(tbg): pass `t` to `newMonitor` and avoid need for `MakeNodes`
 	m := &monitor{
 		t:     c.t,
@@ -2678,7 +2678,7 @@ func (lg loadGroupList) loadNodes() option.NodeListOption {
 // makeLoadGroups create a loadGroupList that has an equal number of cockroach
 // nodes per zone. It assumes that numLoadNodes <= numZones and that numZones is
 // divisible by numLoadNodes.
-func makeLoadGroups(c cluster2.Cluster, numZones, numRoachNodes, numLoadNodes int) loadGroupList {
+func makeLoadGroups(c cluster.Cluster, numZones, numRoachNodes, numLoadNodes int) loadGroupList {
 	if numLoadNodes > numZones {
 		panic("cannot have more than one load node per zone")
 	} else if numZones%numLoadNodes != 0 {

--- a/pkg/cmd/roachtest/cluster/BUILD.bazel
+++ b/pkg/cmd/roachtest/cluster/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "cluster",
+    srcs = ["cluster_interface.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/cmd/roachtest/logger",
+        "//pkg/cmd/roachtest/option",
+        "//pkg/cmd/roachtest/spec",
+    ],
+)

--- a/pkg/cmd/roachtest/cluster/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster/cluster_interface.go
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package main
+package cluster
 
 import (
 	"context"

--- a/pkg/cmd/roachtest/cluster_init.go
+++ b/pkg/cmd/roachtest/cluster_init.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
@@ -27,7 +27,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-func runClusterInit(ctx context.Context, t *test, c cluster2.Cluster) {
+func runClusterInit(ctx context.Context, t *test, c cluster.Cluster) {
 	c.Put(ctx, cockroach, "./cockroach")
 
 	addrs, err := c.InternalAddr(ctx, c.All())

--- a/pkg/cmd/roachtest/cluster_init.go
+++ b/pkg/cmd/roachtest/cluster_init.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
@@ -26,7 +27,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-func runClusterInit(ctx context.Context, t *test, c Cluster) {
+func runClusterInit(ctx context.Context, t *test, c cluster2.Cluster) {
 	c.Put(ctx, cockroach, "./cockroach")
 
 	addrs, err := c.InternalAddr(ctx, c.All())

--- a/pkg/cmd/roachtest/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster_interface.go
@@ -49,7 +49,7 @@ type Cluster interface {
 	// Starting and stopping CockroachDB.
 
 	StartE(ctx context.Context, opts ...option.Option) error
-	Start(ctx context.Context, t *test, opts ...option.Option)
+	Start(ctx context.Context, _ignored interface{}, opts ...option.Option)
 	StopE(ctx context.Context, opts ...option.Option) error
 	Stop(ctx context.Context, opts ...option.Option)
 	StopCockroachGracefullyOnNode(ctx context.Context, node int) error

--- a/pkg/cmd/roachtest/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster_interface.go
@@ -95,7 +95,7 @@ type Cluster interface {
 
 	Spec() spec.ClusterSpec
 	Name() string
-	isLocal() bool
+	IsLocal() bool
 
 	// Deleting CockroachDB data and logs on nodes.
 
@@ -118,7 +118,7 @@ type Cluster interface {
 	// Methods whose inclusion on this interface is purely historical.
 	// These should be removed over time.
 
-	makeNodes(opts ...option.Option) string
+	MakeNodes(opts ...option.Option) string
 	CheckReplicaDivergenceOnDB(context.Context, *logger.Logger, *gosql.DB) error
 	GitClone(
 		ctx context.Context, l *logger.Logger, src, dest, branch string, node option.NodeListOption,

--- a/pkg/cmd/roachtest/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster_interface.go
@@ -49,7 +49,7 @@ type Cluster interface {
 	// Starting and stopping CockroachDB.
 
 	StartE(ctx context.Context, opts ...option.Option) error
-	Start(ctx context.Context, _ignored interface{}, opts ...option.Option)
+	Start(ctx context.Context, opts ...option.Option)
 	StopE(ctx context.Context, opts ...option.Option) error
 	Stop(ctx context.Context, opts ...option.Option)
 	StopCockroachGracefullyOnNode(ctx context.Context, node int) error

--- a/pkg/cmd/roachtest/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster_interface.go
@@ -120,7 +120,6 @@ type Cluster interface {
 
 	makeNodes(opts ...option.Option) string
 	CheckReplicaDivergenceOnDB(context.Context, *test, *gosql.DB) error
-	FetchDiskUsage(ctx context.Context, t *test) error
 	GitClone(
 		ctx context.Context, l *logger.Logger, src, dest, branch string, node option.NodeListOption,
 	) error

--- a/pkg/cmd/roachtest/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster_interface.go
@@ -119,7 +119,7 @@ type Cluster interface {
 	// These should be removed over time.
 
 	makeNodes(opts ...option.Option) string
-	CheckReplicaDivergenceOnDB(context.Context, *test, *gosql.DB) error
+	CheckReplicaDivergenceOnDB(context.Context, *logger.Logger, *gosql.DB) error
 	GitClone(
 		ctx context.Context, l *logger.Logger, src, dest, branch string, node option.NodeListOption,
 	) error

--- a/pkg/cmd/roachtest/cluster_test.go
+++ b/pkg/cmd/roachtest/cluster_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestClusterNodes(t *testing.T) {
-	c := &cluster{spec: spec.MakeClusterSpec(spec.GCE, "", 10)}
+	c := &clusterImpl{spec: spec.MakeClusterSpec(spec.GCE, "", 10)}
 	opts := func(opts ...option.Option) []option.Option {
 		return opts
 	}
@@ -133,7 +133,7 @@ func TestClusterMonitor(t *testing.T) {
 	}
 
 	t.Run(`success`, func(t *testing.T) {
-		c := &cluster{t: testWrapper{t}, l: logger}
+		c := &clusterImpl{t: testWrapper{t}, l: logger}
 		m := newMonitor(context.Background(), c)
 		m.Go(func(context.Context) error { return nil })
 		if err := m.wait(`echo`, `1`); err != nil {
@@ -142,7 +142,7 @@ func TestClusterMonitor(t *testing.T) {
 	})
 
 	t.Run(`dead`, func(t *testing.T) {
-		c := &cluster{t: testWrapper{t}, l: logger}
+		c := &clusterImpl{t: testWrapper{t}, l: logger}
 		m := newMonitor(context.Background(), c)
 		m.Go(func(ctx context.Context) error {
 			<-ctx.Done()
@@ -158,7 +158,7 @@ func TestClusterMonitor(t *testing.T) {
 	})
 
 	t.Run(`worker-fail`, func(t *testing.T) {
-		c := &cluster{t: testWrapper{t}, l: logger}
+		c := &clusterImpl{t: testWrapper{t}, l: logger}
 		m := newMonitor(context.Background(), c)
 		m.Go(func(context.Context) error {
 			return errors.New(`worker-fail`)
@@ -176,7 +176,7 @@ func TestClusterMonitor(t *testing.T) {
 	})
 
 	t.Run(`wait-fail`, func(t *testing.T) {
-		c := &cluster{t: testWrapper{t}, l: logger}
+		c := &clusterImpl{t: testWrapper{t}, l: logger}
 		m := newMonitor(context.Background(), c)
 		m.Go(func(ctx context.Context) error {
 			<-ctx.Done()
@@ -196,7 +196,7 @@ func TestClusterMonitor(t *testing.T) {
 	})
 
 	t.Run(`wait-ok`, func(t *testing.T) {
-		c := &cluster{t: testWrapper{t}, l: logger}
+		c := &clusterImpl{t: testWrapper{t}, l: logger}
 		m := newMonitor(context.Background(), c)
 		m.Go(func(ctx context.Context) error {
 			<-ctx.Done()
@@ -218,7 +218,7 @@ func TestClusterMonitor(t *testing.T) {
 	// them finish pretty soon (think stress testing). As a matter of fact, `make test` waits
 	// for these child goroutines to finish (so these tests take seconds).
 	t.Run(`worker-fd-error`, func(t *testing.T) {
-		c := &cluster{t: testWrapper{t}, l: logger}
+		c := &clusterImpl{t: testWrapper{t}, l: logger}
 		m := newMonitor(context.Background(), c)
 		m.Go(func(ctx context.Context) error {
 			defer func() {
@@ -240,7 +240,7 @@ func TestClusterMonitor(t *testing.T) {
 		}
 	})
 	t.Run(`worker-fd-fatal`, func(t *testing.T) {
-		c := &cluster{t: testWrapper{t}, l: logger}
+		c := &clusterImpl{t: testWrapper{t}, l: logger}
 		m := newMonitor(context.Background(), c)
 		m.Go(func(ctx context.Context) error {
 			err := execCmd(ctx, logger, "/bin/bash", "-c", "echo foo && sleep 3& wait")
@@ -358,7 +358,7 @@ func TestLoadGroups(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf("%d/%d/%d", tc.numZones, tc.numRoachNodes, tc.numLoadNodes),
 			func(t *testing.T) {
-				c := &cluster{t: testWrapper{t}, l: logger, spec: spec.MakeClusterSpec(spec.GCE, "", tc.numRoachNodes+tc.numLoadNodes)}
+				c := &clusterImpl{t: testWrapper{t}, l: logger, spec: spec.MakeClusterSpec(spec.GCE, "", tc.numRoachNodes+tc.numLoadNodes)}
 				lg := makeLoadGroups(c, tc.numZones, tc.numRoachNodes, tc.numLoadNodes)
 				require.EqualValues(t, lg, tc.loadGroups)
 			})

--- a/pkg/cmd/roachtest/cluster_test.go
+++ b/pkg/cmd/roachtest/cluster_test.go
@@ -49,7 +49,7 @@ func TestClusterNodes(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run("", func(t *testing.T) {
-			nodes := c.makeNodes(tc.opts...)
+			nodes := c.MakeNodes(tc.opts...)
 			if tc.expected != nodes {
 				t.Fatalf("expected %s, but found %s", tc.expected, nodes)
 			}

--- a/pkg/cmd/roachtest/connection_latency.go
+++ b/pkg/cmd/roachtest/connection_latency.go
@@ -15,7 +15,7 @@ import (
 	"fmt"
 	"strings"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/stretchr/testify/require"
@@ -28,7 +28,7 @@ const (
 )
 
 func runConnectionLatencyTest(
-	ctx context.Context, t *test, c cluster2.Cluster, numNodes int, numZones int,
+	ctx context.Context, t *test, c cluster.Cluster, numNodes int, numZones int,
 ) {
 	err := c.PutE(ctx, t.l, cockroach, "./cockroach")
 	require.NoError(t, err)
@@ -98,7 +98,7 @@ func registerConnectionLatencyTest(r *testRegistry) {
 		Name:       fmt.Sprintf("connection_latency/nodes=%d", numNodes),
 		Owner:      OwnerSQLExperience,
 		Cluster:    r.makeClusterSpec(numNodes + 1), // Add one for load node.
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runConnectionLatencyTest(ctx, t, c, numNodes, 1)
 		},
 	})
@@ -113,7 +113,7 @@ func registerConnectionLatencyTest(r *testRegistry) {
 		Name:       fmt.Sprintf("connection_latency/nodes=%d/multiregion", numMultiRegionNodes),
 		Owner:      OwnerSQLExperience,
 		Cluster:    r.makeClusterSpec(numMultiRegionNodes+loadNodes, spec.Geo(), spec.Zones(geoZonesStr)),
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runConnectionLatencyTest(ctx, t, c, numMultiRegionNodes, numZones)
 		},
 	})

--- a/pkg/cmd/roachtest/connection_latency.go
+++ b/pkg/cmd/roachtest/connection_latency.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"strings"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/stretchr/testify/require"
@@ -26,7 +27,9 @@ const (
 	regionEuWest = "europe-west2-b"
 )
 
-func runConnectionLatencyTest(ctx context.Context, t *test, c Cluster, numNodes int, numZones int) {
+func runConnectionLatencyTest(
+	ctx context.Context, t *test, c cluster2.Cluster, numNodes int, numZones int,
+) {
 	err := c.PutE(ctx, t.l, cockroach, "./cockroach")
 	require.NoError(t, err)
 
@@ -95,7 +98,7 @@ func registerConnectionLatencyTest(r *testRegistry) {
 		Name:       fmt.Sprintf("connection_latency/nodes=%d", numNodes),
 		Owner:      OwnerSQLExperience,
 		Cluster:    r.makeClusterSpec(numNodes + 1), // Add one for load node.
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runConnectionLatencyTest(ctx, t, c, numNodes, 1)
 		},
 	})
@@ -110,7 +113,7 @@ func registerConnectionLatencyTest(r *testRegistry) {
 		Name:       fmt.Sprintf("connection_latency/nodes=%d/multiregion", numMultiRegionNodes),
 		Owner:      OwnerSQLExperience,
 		Cluster:    r.makeClusterSpec(numMultiRegionNodes+loadNodes, spec.Geo(), spec.Zones(geoZonesStr)),
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runConnectionLatencyTest(ctx, t, c, numMultiRegionNodes, numZones)
 		},
 	})

--- a/pkg/cmd/roachtest/copy.go
+++ b/pkg/cmd/roachtest/copy.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach-go/crdb"
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/errors"
 	_ "github.com/lib/pq"
 )
@@ -27,7 +28,7 @@ func registerCopy(r *testRegistry) {
 	// This test imports a fully-populated Bank table. It then creates an empty
 	// Bank schema. Finally, it performs a series of `INSERT ... SELECT ...`
 	// statements to copy all data from the first table into the second table.
-	runCopy := func(ctx context.Context, t *test, c Cluster, rows int, inTxn bool) {
+	runCopy := func(ctx context.Context, t *test, c cluster2.Cluster, rows int, inTxn bool) {
 		// payload is the size of the payload column for each row in the Bank
 		// table. If this is adjusted, a new fixture may need to be generated.
 		const payload = 100
@@ -174,7 +175,7 @@ func registerCopy(r *testRegistry) {
 			Name:    fmt.Sprintf("copy/bank/rows=%d,nodes=%d,txn=%t", tc.rows, tc.nodes, tc.txn),
 			Owner:   OwnerKV,
 			Cluster: r.makeClusterSpec(tc.nodes),
-			Run: func(ctx context.Context, t *test, c Cluster) {
+			Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 				runCopy(ctx, t, c, tc.rows, tc.txn)
 			},
 		})

--- a/pkg/cmd/roachtest/copy.go
+++ b/pkg/cmd/roachtest/copy.go
@@ -19,7 +19,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach-go/crdb"
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/errors"
 	_ "github.com/lib/pq"
 )
@@ -28,7 +28,7 @@ func registerCopy(r *testRegistry) {
 	// This test imports a fully-populated Bank table. It then creates an empty
 	// Bank schema. Finally, it performs a series of `INSERT ... SELECT ...`
 	// statements to copy all data from the first table into the second table.
-	runCopy := func(ctx context.Context, t *test, c cluster2.Cluster, rows int, inTxn bool) {
+	runCopy := func(ctx context.Context, t *test, c cluster.Cluster, rows int, inTxn bool) {
 		// payload is the size of the payload column for each row in the Bank
 		// table. If this is adjusted, a new fixture may need to be generated.
 		const payload = 100
@@ -175,7 +175,7 @@ func registerCopy(r *testRegistry) {
 			Name:    fmt.Sprintf("copy/bank/rows=%d,nodes=%d,txn=%t", tc.rows, tc.nodes, tc.txn),
 			Owner:   OwnerKV,
 			Cluster: r.makeClusterSpec(tc.nodes),
-			Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+			Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 				runCopy(ctx, t, c, tc.rows, tc.txn)
 			},
 		})

--- a/pkg/cmd/roachtest/copy.go
+++ b/pkg/cmd/roachtest/copy.go
@@ -40,7 +40,7 @@ func registerCopy(r *testRegistry) {
 
 		c.Put(ctx, cockroach, "./cockroach", c.All())
 		c.Put(ctx, workload, "./workload", c.All())
-		c.Start(ctx, t, c.All())
+		c.Start(ctx, c.All())
 
 		m := newMonitor(ctx, c, c.All())
 		m.Go(func(ctx context.Context) error {

--- a/pkg/cmd/roachtest/decommission.go
+++ b/pkg/cmd/roachtest/decommission.go
@@ -104,7 +104,7 @@ func runDecommission(ctx context.Context, t *test, c Cluster, nodes int, duratio
 	c.Put(ctx, workload, "./workload", c.Node(pinnedNode))
 
 	for i := 1; i <= nodes; i++ {
-		c.Start(ctx, t, c.Node(i), startArgs(fmt.Sprintf("-a=--attrs=node%d", i)))
+		c.Start(ctx, c.Node(i), startArgs(fmt.Sprintf("-a=--attrs=node%d", i)))
 	}
 	c.Run(ctx, c.Node(pinnedNode), `./workload init kv --drop`)
 
@@ -301,7 +301,7 @@ func runDecommission(ctx context.Context, t *test, c Cluster, nodes int, duratio
 func runDecommissionRandomized(ctx context.Context, t *test, c Cluster) {
 	args := startArgs("--env=COCKROACH_SCAN_MAX_IDLE_TIME=5ms")
 	c.Put(ctx, cockroach, "./cockroach")
-	c.Start(ctx, t, args)
+	c.Start(ctx, args)
 
 	h := newDecommTestHelper(t, c)
 
@@ -636,7 +636,7 @@ func runDecommissionRandomized(ctx context.Context, t *test, c Cluster) {
 			t.l.Printf("expected to fail: restarting [n%d,n%d] and attempting to recommission through n%d\n",
 				targetNodeA, targetNodeB, runNode)
 			c.Stop(ctx, c.Nodes(targetNodeA, targetNodeB))
-			c.Start(ctx, t, c.Nodes(targetNodeA, targetNodeB), args)
+			c.Start(ctx, c.Nodes(targetNodeA, targetNodeB), args)
 
 			if _, err := h.recommission(ctx, c.Nodes(targetNodeA, targetNodeB), runNode); err == nil {
 				t.Fatalf("expected recommission to fail")
@@ -698,7 +698,7 @@ func runDecommissionRandomized(ctx context.Context, t *test, c Cluster) {
 
 			// Bring targetNode it back up to verify that its replicas still get
 			// removed.
-			c.Start(ctx, t, c.Node(targetNode), args)
+			c.Start(ctx, c.Node(targetNode), args)
 		}
 
 		// Run decommission a second time to wait until the replicas have
@@ -774,7 +774,7 @@ func runDecommissionRandomized(ctx context.Context, t *test, c Cluster) {
 				t.Fatal(err)
 			}
 			joinAddr := internalAddrs[0]
-			c.Start(ctx, t, c.Node(targetNode), startArgs(
+			c.Start(ctx, c.Node(targetNode), startArgs(
 				fmt.Sprintf("-a=--join %s", joinAddr),
 			))
 		}

--- a/pkg/cmd/roachtest/decommission.go
+++ b/pkg/cmd/roachtest/decommission.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cli"
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
@@ -39,7 +40,7 @@ func registerDecommission(r *testRegistry) {
 			Owner:      OwnerKV,
 			MinVersion: "v20.2.0",
 			Cluster:    r.makeClusterSpec(4),
-			Run: func(ctx context.Context, t *test, c Cluster) {
+			Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 				if local {
 					duration = 5 * time.Minute
 					t.l.Printf("running with duration=%s in local mode\n", duration)
@@ -56,7 +57,7 @@ func registerDecommission(r *testRegistry) {
 			MinVersion: "v20.2.0",
 			Timeout:    10 * time.Minute,
 			Cluster:    r.makeClusterSpec(numNodes),
-			Run: func(ctx context.Context, t *test, c Cluster) {
+			Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 				runDecommissionRandomized(ctx, t, c)
 			},
 		})
@@ -68,7 +69,7 @@ func registerDecommission(r *testRegistry) {
 			Owner:      OwnerKV,
 			MinVersion: "v20.2.0",
 			Cluster:    r.makeClusterSpec(numNodes),
-			Run: func(ctx context.Context, t *test, c Cluster) {
+			Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 				runDecommissionMixedVersions(ctx, t, c, r.buildVersion)
 			},
 		})
@@ -84,7 +85,9 @@ func registerDecommission(r *testRegistry) {
 // that would spam the log before #23605. I wonder if we should really
 // start grepping the logs. An alternative is to introduce a metric
 // that would have signaled this and check that instead.
-func runDecommission(ctx context.Context, t *test, c Cluster, nodes int, duration time.Duration) {
+func runDecommission(
+	ctx context.Context, t *test, c cluster2.Cluster, nodes int, duration time.Duration,
+) {
 	const defaultReplicationFactor = 3
 	if defaultReplicationFactor > nodes {
 		t.Fatal("improper configuration: replication factor greater than number of nodes in the test")
@@ -298,7 +301,7 @@ func runDecommission(ctx context.Context, t *test, c Cluster, nodes int, duratio
 // through partial decommissioning of random nodes, ensuring we're able to undo
 // those operations. We then fully decommission nodes, verifying it's an
 // irreversible operation.
-func runDecommissionRandomized(ctx context.Context, t *test, c Cluster) {
+func runDecommissionRandomized(ctx context.Context, t *test, c cluster2.Cluster) {
 	args := startArgs("--env=COCKROACH_SCAN_MAX_IDLE_TIME=5ms")
 	c.Put(ctx, cockroach, "./cockroach")
 	c.Start(ctx, args)
@@ -898,14 +901,14 @@ const statusHeaderMembershipColumnIdx = 11
 
 type decommTestHelper struct {
 	t       *test
-	c       Cluster
+	c       cluster2.Cluster
 	nodeIDs []int
 	// randNodeBlocklist are the nodes that won't be returned from randNode().
 	// populated via blockFromRandNode().
 	randNodeBlocklist map[int]struct{}
 }
 
-func newDecommTestHelper(t *test, c Cluster) *decommTestHelper {
+func newDecommTestHelper(t *test, c cluster2.Cluster) *decommTestHelper {
 	var nodeIDs []int
 	for i := 1; i <= c.Spec().NodeCount; i++ {
 		nodeIDs = append(nodeIDs, i)
@@ -1056,7 +1059,7 @@ func (h *decommTestHelper) getRandNodeOtherThan(ids ...int) int {
 }
 
 func execCLI(
-	ctx context.Context, t *test, c Cluster, runNode int, extraArgs ...string,
+	ctx context.Context, t *test, c cluster2.Cluster, runNode int, extraArgs ...string,
 ) (string, error) {
 	args := []string{"./cockroach"}
 	args = append(args, extraArgs...)

--- a/pkg/cmd/roachtest/decommission.go
+++ b/pkg/cmd/roachtest/decommission.go
@@ -19,7 +19,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cli"
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
@@ -40,7 +40,7 @@ func registerDecommission(r *testRegistry) {
 			Owner:      OwnerKV,
 			MinVersion: "v20.2.0",
 			Cluster:    r.makeClusterSpec(4),
-			Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+			Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 				if local {
 					duration = 5 * time.Minute
 					t.l.Printf("running with duration=%s in local mode\n", duration)
@@ -57,7 +57,7 @@ func registerDecommission(r *testRegistry) {
 			MinVersion: "v20.2.0",
 			Timeout:    10 * time.Minute,
 			Cluster:    r.makeClusterSpec(numNodes),
-			Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+			Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 				runDecommissionRandomized(ctx, t, c)
 			},
 		})
@@ -69,7 +69,7 @@ func registerDecommission(r *testRegistry) {
 			Owner:      OwnerKV,
 			MinVersion: "v20.2.0",
 			Cluster:    r.makeClusterSpec(numNodes),
-			Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+			Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 				runDecommissionMixedVersions(ctx, t, c, r.buildVersion)
 			},
 		})
@@ -86,7 +86,7 @@ func registerDecommission(r *testRegistry) {
 // start grepping the logs. An alternative is to introduce a metric
 // that would have signaled this and check that instead.
 func runDecommission(
-	ctx context.Context, t *test, c cluster2.Cluster, nodes int, duration time.Duration,
+	ctx context.Context, t *test, c cluster.Cluster, nodes int, duration time.Duration,
 ) {
 	const defaultReplicationFactor = 3
 	if defaultReplicationFactor > nodes {
@@ -301,7 +301,7 @@ func runDecommission(
 // through partial decommissioning of random nodes, ensuring we're able to undo
 // those operations. We then fully decommission nodes, verifying it's an
 // irreversible operation.
-func runDecommissionRandomized(ctx context.Context, t *test, c cluster2.Cluster) {
+func runDecommissionRandomized(ctx context.Context, t *test, c cluster.Cluster) {
 	args := startArgs("--env=COCKROACH_SCAN_MAX_IDLE_TIME=5ms")
 	c.Put(ctx, cockroach, "./cockroach")
 	c.Start(ctx, args)
@@ -901,14 +901,14 @@ const statusHeaderMembershipColumnIdx = 11
 
 type decommTestHelper struct {
 	t       *test
-	c       cluster2.Cluster
+	c       cluster.Cluster
 	nodeIDs []int
 	// randNodeBlocklist are the nodes that won't be returned from randNode().
 	// populated via blockFromRandNode().
 	randNodeBlocklist map[int]struct{}
 }
 
-func newDecommTestHelper(t *test, c cluster2.Cluster) *decommTestHelper {
+func newDecommTestHelper(t *test, c cluster.Cluster) *decommTestHelper {
 	var nodeIDs []int
 	for i := 1; i <= c.Spec().NodeCount; i++ {
 		nodeIDs = append(nodeIDs, i)
@@ -1059,7 +1059,7 @@ func (h *decommTestHelper) getRandNodeOtherThan(ids ...int) int {
 }
 
 func execCLI(
-	ctx context.Context, t *test, c cluster2.Cluster, runNode int, extraArgs ...string,
+	ctx context.Context, t *test, c cluster.Cluster, runNode int, extraArgs ...string,
 ) (string, error) {
 	args := []string{"./cockroach"}
 	args = append(args, extraArgs...)

--- a/pkg/cmd/roachtest/decommission_self.go
+++ b/pkg/cmd/roachtest/decommission_self.go
@@ -13,13 +13,13 @@ package main
 import (
 	"context"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 )
 
 // runDecommissionSelf decommissions n2 through n2. This is an acceptance test.
 //
 // See https://github.com/cockroachdb/cockroach/issues/56718
-func runDecommissionSelf(ctx context.Context, t *test, c cluster2.Cluster) {
+func runDecommissionSelf(ctx context.Context, t *test, c cluster.Cluster) {
 	// An empty string means that the cockroach binary specified by flag
 	// `cockroach` will be used.
 	const mainVersion = ""

--- a/pkg/cmd/roachtest/decommission_self.go
+++ b/pkg/cmd/roachtest/decommission_self.go
@@ -10,12 +10,16 @@
 
 package main
 
-import "context"
+import (
+	"context"
+
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+)
 
 // runDecommissionSelf decommissions n2 through n2. This is an acceptance test.
 //
 // See https://github.com/cockroachdb/cockroach/issues/56718
-func runDecommissionSelf(ctx context.Context, t *test, c Cluster) {
+func runDecommissionSelf(ctx context.Context, t *test, c cluster2.Cluster) {
 	// An empty string means that the cockroach binary specified by flag
 	// `cockroach` will be used.
 	const mainVersion = ""

--- a/pkg/cmd/roachtest/disk_full.go
+++ b/pkg/cmd/roachtest/disk_full.go
@@ -34,7 +34,7 @@ func registerDiskFull(r *testRegistry) {
 			nodes := c.Spec().NodeCount - 1
 			c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 			c.Put(ctx, workload, "./workload", c.Node(nodes+1))
-			c.Start(ctx, t, c.Range(1, nodes))
+			c.Start(ctx, c.Range(1, nodes))
 
 			t.Status("running workload")
 			m := newMonitor(ctx, c, c.Range(1, nodes))

--- a/pkg/cmd/roachtest/disk_full.go
+++ b/pkg/cmd/roachtest/disk_full.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
@@ -26,7 +26,7 @@ func registerDiskFull(r *testRegistry) {
 		Owner:      OwnerStorage,
 		MinVersion: `v20.2.0`,
 		Cluster:    r.makeClusterSpec(5),
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			if c.IsLocal() {
 				t.spec.Skip = "you probably don't want to fill your local disk"
 				return

--- a/pkg/cmd/roachtest/disk_full.go
+++ b/pkg/cmd/roachtest/disk_full.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
@@ -25,7 +26,7 @@ func registerDiskFull(r *testRegistry) {
 		Owner:      OwnerStorage,
 		MinVersion: `v20.2.0`,
 		Cluster:    r.makeClusterSpec(5),
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			if c.IsLocal() {
 				t.spec.Skip = "you probably don't want to fill your local disk"
 				return

--- a/pkg/cmd/roachtest/disk_full.go
+++ b/pkg/cmd/roachtest/disk_full.go
@@ -26,7 +26,7 @@ func registerDiskFull(r *testRegistry) {
 		MinVersion: `v20.2.0`,
 		Cluster:    r.makeClusterSpec(5),
 		Run: func(ctx context.Context, t *test, c Cluster) {
-			if c.isLocal() {
+			if c.IsLocal() {
 				t.spec.Skip = "you probably don't want to fill your local disk"
 				return
 			}

--- a/pkg/cmd/roachtest/disk_stall.go
+++ b/pkg/cmd/roachtest/disk_stall.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
@@ -37,7 +37,7 @@ func registerDiskStalledDetection(r *testRegistry) {
 				Owner:      OwnerStorage,
 				MinVersion: "v19.2.0",
 				Cluster:    r.makeClusterSpec(1),
-				Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+				Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 					runDiskStalledDetection(ctx, t, c, affectsLogDir, affectsDataDir)
 				},
 			})
@@ -46,7 +46,7 @@ func registerDiskStalledDetection(r *testRegistry) {
 }
 
 func runDiskStalledDetection(
-	ctx context.Context, t *test, c cluster2.Cluster, affectsLogDir bool, affectsDataDir bool,
+	ctx context.Context, t *test, c cluster.Cluster, affectsLogDir bool, affectsDataDir bool,
 ) {
 	if local && runtime.GOOS != "linux" {
 		t.Fatalf("must run on linux os, found %s", runtime.GOOS)

--- a/pkg/cmd/roachtest/disk_stall.go
+++ b/pkg/cmd/roachtest/disk_stall.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
@@ -36,7 +37,7 @@ func registerDiskStalledDetection(r *testRegistry) {
 				Owner:      OwnerStorage,
 				MinVersion: "v19.2.0",
 				Cluster:    r.makeClusterSpec(1),
-				Run: func(ctx context.Context, t *test, c Cluster) {
+				Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 					runDiskStalledDetection(ctx, t, c, affectsLogDir, affectsDataDir)
 				},
 			})
@@ -45,7 +46,7 @@ func registerDiskStalledDetection(r *testRegistry) {
 }
 
 func runDiskStalledDetection(
-	ctx context.Context, t *test, c Cluster, affectsLogDir bool, affectsDataDir bool,
+	ctx context.Context, t *test, c cluster2.Cluster, affectsLogDir bool, affectsDataDir bool,
 ) {
 	if local && runtime.GOOS != "linux" {
 		t.Fatalf("must run on linux os, found %s", runtime.GOOS)

--- a/pkg/cmd/roachtest/disk_stall.go
+++ b/pkg/cmd/roachtest/disk_stall.go
@@ -61,7 +61,7 @@ func runDiskStalledDetection(
 
 	t.Status("setting up charybdefs")
 
-	if err := execCmd(ctx, t.l, roachprod, "install", c.makeNodes(n), "charybdefs"); err != nil {
+	if err := execCmd(ctx, t.l, roachprod, "install", c.MakeNodes(n), "charybdefs"); err != nil {
 		t.Fatal(err)
 	}
 	c.Run(ctx, n, "sudo charybdefs {store-dir}/faulty -oallow_other,modules=subdir,subdir={store-dir}/real")

--- a/pkg/cmd/roachtest/django.go
+++ b/pkg/cmd/roachtest/django.go
@@ -30,7 +30,7 @@ func registerDjango(r *testRegistry) {
 		t *test,
 		c Cluster,
 	) {
-		if c.isLocal() {
+		if c.IsLocal() {
 			t.Fatal("cannot be run in local mode")
 		}
 		node := c.Node(1)

--- a/pkg/cmd/roachtest/django.go
+++ b/pkg/cmd/roachtest/django.go
@@ -15,7 +15,7 @@ import (
 	"fmt"
 	"regexp"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 )
 
@@ -29,7 +29,7 @@ func registerDjango(r *testRegistry) {
 	runDjango := func(
 		ctx context.Context,
 		t *test,
-		c cluster2.Cluster,
+		c cluster.Cluster,
 	) {
 		if c.IsLocal() {
 			t.Fatal("cannot be run in local mode")
@@ -219,7 +219,7 @@ func registerDjango(r *testRegistry) {
 		Owner:      OwnerSQLExperience,
 		Cluster:    r.makeClusterSpec(1, spec.CPU(16)),
 		Tags:       []string{`default`, `orm`},
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runDjango(ctx, t, c)
 		},
 	})

--- a/pkg/cmd/roachtest/django.go
+++ b/pkg/cmd/roachtest/django.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"regexp"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 )
 
@@ -28,7 +29,7 @@ func registerDjango(r *testRegistry) {
 	runDjango := func(
 		ctx context.Context,
 		t *test,
-		c Cluster,
+		c cluster2.Cluster,
 	) {
 		if c.IsLocal() {
 			t.Fatal("cannot be run in local mode")
@@ -218,7 +219,7 @@ func registerDjango(r *testRegistry) {
 		Owner:      OwnerSQLExperience,
 		Cluster:    r.makeClusterSpec(1, spec.CPU(16)),
 		Tags:       []string{`default`, `orm`},
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runDjango(ctx, t, c)
 		},
 	})

--- a/pkg/cmd/roachtest/django.go
+++ b/pkg/cmd/roachtest/django.go
@@ -36,7 +36,7 @@ func registerDjango(r *testRegistry) {
 		node := c.Node(1)
 		t.Status("setting up cockroach")
 		c.Put(ctx, cockroach, "./cockroach", c.All())
-		c.Start(ctx, t, c.All())
+		c.Start(ctx, c.All())
 
 		version, err := fetchCockroachVersion(ctx, c, node[0], nil)
 		if err != nil {

--- a/pkg/cmd/roachtest/drop.go
+++ b/pkg/cmd/roachtest/drop.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	_ "github.com/lib/pq"
@@ -29,7 +30,7 @@ func registerDrop(r *testRegistry) {
 	// by a truncation for the `stock` table (which contains warehouses*100k
 	// rows). Next, it issues a `DROP` for the whole database, and sets the GC TTL
 	// to one second.
-	runDrop := func(ctx context.Context, t *test, c Cluster, warehouses, nodes int) {
+	runDrop := func(ctx context.Context, t *test, c cluster2.Cluster, warehouses, nodes int) {
 		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 		c.Put(ctx, workload, "./workload", c.Range(1, nodes))
 		c.Start(ctx, c.Range(1, nodes), startArgs("-e", "COCKROACH_MEMPROF_INTERVAL=15s"))
@@ -159,7 +160,7 @@ func registerDrop(r *testRegistry) {
 		Owner:      OwnerKV,
 		MinVersion: `v2.1.0`,
 		Cluster:    r.makeClusterSpec(numNodes),
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			// NB: this is likely not going to work out in `-local` mode. Edit the
 			// numbers during iteration.
 			if local {

--- a/pkg/cmd/roachtest/drop.go
+++ b/pkg/cmd/roachtest/drop.go
@@ -32,7 +32,7 @@ func registerDrop(r *testRegistry) {
 	runDrop := func(ctx context.Context, t *test, c Cluster, warehouses, nodes int) {
 		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 		c.Put(ctx, workload, "./workload", c.Range(1, nodes))
-		c.Start(ctx, t, c.Range(1, nodes), startArgs("-e", "COCKROACH_MEMPROF_INTERVAL=15s"))
+		c.Start(ctx, c.Range(1, nodes), startArgs("-e", "COCKROACH_MEMPROF_INTERVAL=15s"))
 
 		m := newMonitor(ctx, c, c.Range(1, nodes))
 		m.Go(func(ctx context.Context) error {

--- a/pkg/cmd/roachtest/drop.go
+++ b/pkg/cmd/roachtest/drop.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	_ "github.com/lib/pq"
@@ -30,7 +30,7 @@ func registerDrop(r *testRegistry) {
 	// by a truncation for the `stock` table (which contains warehouses*100k
 	// rows). Next, it issues a `DROP` for the whole database, and sets the GC TTL
 	// to one second.
-	runDrop := func(ctx context.Context, t *test, c cluster2.Cluster, warehouses, nodes int) {
+	runDrop := func(ctx context.Context, t *test, c cluster.Cluster, warehouses, nodes int) {
 		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 		c.Put(ctx, workload, "./workload", c.Range(1, nodes))
 		c.Start(ctx, c.Range(1, nodes), startArgs("-e", "COCKROACH_MEMPROF_INTERVAL=15s"))
@@ -160,7 +160,7 @@ func registerDrop(r *testRegistry) {
 		Owner:      OwnerKV,
 		MinVersion: `v2.1.0`,
 		Cluster:    r.makeClusterSpec(numNodes),
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			// NB: this is likely not going to work out in `-local` mode. Edit the
 			// numbers during iteration.
 			if local {

--- a/pkg/cmd/roachtest/encryption.go
+++ b/pkg/cmd/roachtest/encryption.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/errors"
 )
 
@@ -21,7 +22,7 @@ func registerEncryption(r *testRegistry) {
 	// Note that no workload is run in this roachtest because kv roachtest
 	// ideally runs with encryption turned on to see the performance impact and
 	// to test the correctness of encryption at rest.
-	runEncryption := func(ctx context.Context, t *test, c Cluster) {
+	runEncryption := func(ctx context.Context, t *test, c cluster2.Cluster) {
 		nodes := c.Spec().NodeCount
 		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 		c.Start(ctx, c.Range(1, nodes), startArgs("--encrypt"))
@@ -83,7 +84,7 @@ func registerEncryption(r *testRegistry) {
 			Owner:      OwnerStorage,
 			MinVersion: "v2.1.0",
 			Cluster:    r.makeClusterSpec(n),
-			Run: func(ctx context.Context, t *test, c Cluster) {
+			Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 				runEncryption(ctx, t, c)
 			},
 		})

--- a/pkg/cmd/roachtest/encryption.go
+++ b/pkg/cmd/roachtest/encryption.go
@@ -14,7 +14,7 @@ import (
 	"context"
 	"fmt"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/errors"
 )
 
@@ -22,7 +22,7 @@ func registerEncryption(r *testRegistry) {
 	// Note that no workload is run in this roachtest because kv roachtest
 	// ideally runs with encryption turned on to see the performance impact and
 	// to test the correctness of encryption at rest.
-	runEncryption := func(ctx context.Context, t *test, c cluster2.Cluster) {
+	runEncryption := func(ctx context.Context, t *test, c cluster.Cluster) {
 		nodes := c.Spec().NodeCount
 		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 		c.Start(ctx, c.Range(1, nodes), startArgs("--encrypt"))
@@ -84,7 +84,7 @@ func registerEncryption(r *testRegistry) {
 			Owner:      OwnerStorage,
 			MinVersion: "v2.1.0",
 			Cluster:    r.makeClusterSpec(n),
-			Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+			Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 				runEncryption(ctx, t, c)
 			},
 		})

--- a/pkg/cmd/roachtest/encryption.go
+++ b/pkg/cmd/roachtest/encryption.go
@@ -24,7 +24,7 @@ func registerEncryption(r *testRegistry) {
 	runEncryption := func(ctx context.Context, t *test, c Cluster) {
 		nodes := c.Spec().NodeCount
 		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
-		c.Start(ctx, t, c.Range(1, nodes), startArgs("--encrypt"))
+		c.Start(ctx, c.Range(1, nodes), startArgs("--encrypt"))
 
 		// Check that /_status/stores/local endpoint has encryption status.
 		adminAddrs, err := c.InternalAdminUIAddr(ctx, c.Range(1, nodes))
@@ -44,7 +44,7 @@ func registerEncryption(r *testRegistry) {
 		}
 
 		// Restart node with encryption turned on to verify old key works.
-		c.Start(ctx, t, c.Range(1, nodes), startArgs("--encrypt"))
+		c.Start(ctx, c.Range(1, nodes), startArgs("--encrypt"))
 
 		testCLIGenKey := func(size int) error {
 			// Generate encryption store key through `./cockroach gen encryption-key -s=size aes-size.key`.

--- a/pkg/cmd/roachtest/engine_switch.go
+++ b/pkg/cmd/roachtest/engine_switch.go
@@ -15,7 +15,7 @@ import (
 	"fmt"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/version"
@@ -25,7 +25,7 @@ import (
 )
 
 func registerEngineSwitch(r *testRegistry) {
-	runEngineSwitch := func(ctx context.Context, t *test, c cluster2.Cluster, additionalArgs ...string) {
+	runEngineSwitch := func(ctx context.Context, t *test, c cluster.Cluster, additionalArgs ...string) {
 		roachNodes := c.Range(1, c.Spec().NodeCount-1)
 		loadNode := c.Node(c.Spec().NodeCount)
 		c.Put(ctx, workload, "./workload", loadNode)
@@ -145,7 +145,7 @@ func registerEngineSwitch(r *testRegistry) {
 		Skip:       "rocksdb removed in 21.1",
 		MinVersion: "v20.1.0",
 		Cluster:    r.makeClusterSpec(n + 1),
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runEngineSwitch(ctx, t, c)
 		},
 	})
@@ -155,7 +155,7 @@ func registerEngineSwitch(r *testRegistry) {
 		Skip:       "rocksdb removed in 21.1",
 		MinVersion: "v20.1.0",
 		Cluster:    r.makeClusterSpec(n + 1),
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runEngineSwitch(ctx, t, c, "--encrypt=true")
 		},
 	})

--- a/pkg/cmd/roachtest/engine_switch.go
+++ b/pkg/cmd/roachtest/engine_switch.go
@@ -89,7 +89,7 @@ func registerEngineSwitch(r *testRegistry) {
 					if err := rows.Close(); err != nil {
 						return err
 					}
-					if err := c.CheckReplicaDivergenceOnDB(ctx, t, db); err != nil {
+					if err := c.CheckReplicaDivergenceOnDB(ctx, t.l, db); err != nil {
 						return errors.Wrapf(err, "node %d", i)
 					}
 				}

--- a/pkg/cmd/roachtest/engine_switch.go
+++ b/pkg/cmd/roachtest/engine_switch.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/version"
@@ -24,7 +25,7 @@ import (
 )
 
 func registerEngineSwitch(r *testRegistry) {
-	runEngineSwitch := func(ctx context.Context, t *test, c Cluster, additionalArgs ...string) {
+	runEngineSwitch := func(ctx context.Context, t *test, c cluster2.Cluster, additionalArgs ...string) {
 		roachNodes := c.Range(1, c.Spec().NodeCount-1)
 		loadNode := c.Node(c.Spec().NodeCount)
 		c.Put(ctx, workload, "./workload", loadNode)
@@ -144,7 +145,7 @@ func registerEngineSwitch(r *testRegistry) {
 		Skip:       "rocksdb removed in 21.1",
 		MinVersion: "v20.1.0",
 		Cluster:    r.makeClusterSpec(n + 1),
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runEngineSwitch(ctx, t, c)
 		},
 	})
@@ -154,7 +155,7 @@ func registerEngineSwitch(r *testRegistry) {
 		Skip:       "rocksdb removed in 21.1",
 		MinVersion: "v20.1.0",
 		Cluster:    r.makeClusterSpec(n + 1),
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runEngineSwitch(ctx, t, c, "--encrypt=true")
 		},
 	})

--- a/pkg/cmd/roachtest/engine_switch.go
+++ b/pkg/cmd/roachtest/engine_switch.go
@@ -31,7 +31,7 @@ func registerEngineSwitch(r *testRegistry) {
 		c.Put(ctx, cockroach, "./cockroach", roachNodes)
 		pebbleArgs := startArgs(append(additionalArgs, "--args=--storage-engine=pebble")...)
 		rocksdbArgs := startArgs(append(additionalArgs, "--args=--storage-engine=rocksdb")...)
-		c.Start(ctx, t, roachNodes, rocksdbArgs)
+		c.Start(ctx, roachNodes, rocksdbArgs)
 		stageDuration := 1 * time.Minute
 		if local {
 			t.l.Printf("local mode: speeding up test\n")
@@ -126,7 +126,7 @@ func registerEngineSwitch(r *testRegistry) {
 				if err := stop(i + 1); err != nil {
 					return err
 				}
-				c.Start(ctx, t, c.Node(i+1), args)
+				c.Start(ctx, c.Node(i+1), args)
 			}
 			return sleepAndCheck()
 		})

--- a/pkg/cmd/roachtest/event_log.go
+++ b/pkg/cmd/roachtest/event_log.go
@@ -17,12 +17,12 @@ import (
 	"fmt"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 )
 
-func runEventLog(ctx context.Context, t *test, c cluster2.Cluster) {
+func runEventLog(ctx context.Context, t *test, c cluster.Cluster) {
 	type nodeEventInfo struct {
 		NodeID roachpb.NodeID
 	}

--- a/pkg/cmd/roachtest/event_log.go
+++ b/pkg/cmd/roachtest/event_log.go
@@ -17,11 +17,12 @@ import (
 	"fmt"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 )
 
-func runEventLog(ctx context.Context, t *test, c Cluster) {
+func runEventLog(ctx context.Context, t *test, c cluster2.Cluster) {
 	type nodeEventInfo struct {
 		NodeID roachpb.NodeID
 	}

--- a/pkg/cmd/roachtest/event_log.go
+++ b/pkg/cmd/roachtest/event_log.go
@@ -27,7 +27,7 @@ func runEventLog(ctx context.Context, t *test, c Cluster) {
 	}
 
 	c.Put(ctx, cockroach, "./cockroach")
-	c.Start(ctx, t)
+	c.Start(ctx)
 
 	// Verify that "node joined" and "node restart" events are recorded whenever
 	// a node starts and contacts the cluster.
@@ -83,7 +83,7 @@ func runEventLog(ctx context.Context, t *test, c Cluster) {
 
 	// Stop and Start Node 3, and verify the node restart message.
 	c.Stop(ctx, c.Node(3))
-	c.Start(ctx, t, c.Node(3))
+	c.Start(ctx, c.Node(3))
 
 	err = retry.ForDuration(10*time.Second, func() error {
 		// Query all node restart events. There should only be one.

--- a/pkg/cmd/roachtest/flowable.go
+++ b/pkg/cmd/roachtest/flowable.go
@@ -14,7 +14,7 @@ import (
 	"context"
 	"regexp"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 )
 
 var flowableReleaseTagRegex = regexp.MustCompile(`^flowable-(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)$`)
@@ -25,7 +25,7 @@ func registerFlowable(r *testRegistry) {
 	runFlowable := func(
 		ctx context.Context,
 		t *test,
-		c cluster2.Cluster,
+		c cluster.Cluster,
 	) {
 		if c.IsLocal() {
 			t.Fatal("cannot be run in local mode")
@@ -103,7 +103,7 @@ func registerFlowable(r *testRegistry) {
 		Owner:      OwnerSQLExperience,
 		Cluster:    r.makeClusterSpec(1),
 		MinVersion: "v19.1.0",
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runFlowable(ctx, t, c)
 		},
 	})

--- a/pkg/cmd/roachtest/flowable.go
+++ b/pkg/cmd/roachtest/flowable.go
@@ -13,6 +13,8 @@ package main
 import (
 	"context"
 	"regexp"
+
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 )
 
 var flowableReleaseTagRegex = regexp.MustCompile(`^flowable-(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)$`)
@@ -23,7 +25,7 @@ func registerFlowable(r *testRegistry) {
 	runFlowable := func(
 		ctx context.Context,
 		t *test,
-		c Cluster,
+		c cluster2.Cluster,
 	) {
 		if c.IsLocal() {
 			t.Fatal("cannot be run in local mode")
@@ -101,7 +103,7 @@ func registerFlowable(r *testRegistry) {
 		Owner:      OwnerSQLExperience,
 		Cluster:    r.makeClusterSpec(1),
 		MinVersion: "v19.1.0",
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runFlowable(ctx, t, c)
 		},
 	})

--- a/pkg/cmd/roachtest/flowable.go
+++ b/pkg/cmd/roachtest/flowable.go
@@ -25,7 +25,7 @@ func registerFlowable(r *testRegistry) {
 		t *test,
 		c Cluster,
 	) {
-		if c.isLocal() {
+		if c.IsLocal() {
 			t.Fatal("cannot be run in local mode")
 		}
 		node := c.Node(1)

--- a/pkg/cmd/roachtest/flowable.go
+++ b/pkg/cmd/roachtest/flowable.go
@@ -31,7 +31,7 @@ func registerFlowable(r *testRegistry) {
 		node := c.Node(1)
 		t.Status("setting up cockroach")
 		c.Put(ctx, cockroach, "./cockroach", c.All())
-		c.Start(ctx, t, c.All())
+		c.Start(ctx, c.All())
 
 		t.Status("cloning flowable and installing prerequisites")
 		latestTag, err := repeatGetLatestTag(

--- a/pkg/cmd/roachtest/follower_reads.go
+++ b/pkg/cmd/roachtest/follower_reads.go
@@ -47,7 +47,7 @@ func registerFollowerReads(r *testRegistry) {
 			Run: func(ctx context.Context, t *test, c Cluster) {
 				c.Put(ctx, cockroach, "./cockroach")
 				c.Wipe(ctx)
-				c.Start(ctx, t)
+				c.Start(ctx)
 				topology := topologySpec{multiRegion: true, locality: locality, survival: survival}
 				data := initFollowerReadsDB(ctx, t, c, topology)
 				runFollowerReadsTest(ctx, t, c, topology, data)
@@ -752,7 +752,7 @@ func runFollowerReadsMixedVersionSingleRegionTest(
 
 	// Start the cluster at the old version.
 	args := startArgs("--binary=" + uploadVersion(ctx, t, c, c.All(), predecessorVersion))
-	c.Start(ctx, t, c.All(), args)
+	c.Start(ctx, c.All(), args)
 	topology := topologySpec{multiRegion: false}
 	data := initFollowerReadsDB(ctx, t, c, topology)
 

--- a/pkg/cmd/roachtest/follower_reads.go
+++ b/pkg/cmd/roachtest/follower_reads.go
@@ -24,7 +24,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -45,7 +45,7 @@ func registerFollowerReads(r *testRegistry) {
 			Name:    fmt.Sprintf("follower-reads/survival=%s/locality=%s", survival, locality),
 			Owner:   OwnerKV,
 			Cluster: r.makeClusterSpec(6, spec.CPU(2), spec.Geo(), spec.Zones("us-east1-b,us-east1-b,us-east1-b,us-west1-b,us-west1-b,europe-west2-b")),
-			Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+			Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 				c.Put(ctx, cockroach, "./cockroach")
 				c.Wipe(ctx)
 				c.Start(ctx)
@@ -68,7 +68,7 @@ func registerFollowerReads(r *testRegistry) {
 			3, /* nodeCount */
 			spec.CPU(2),
 		),
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runFollowerReadsMixedVersionSingleRegionTest(ctx, t, c, r.buildVersion)
 		},
 	})
@@ -119,7 +119,7 @@ type topologySpec struct {
 //    time are under 10ms which implies that no WAN RPCs occurred.
 //
 func runFollowerReadsTest(
-	ctx context.Context, t *test, c cluster2.Cluster, topology topologySpec, data map[int]int64,
+	ctx context.Context, t *test, c cluster.Cluster, topology topologySpec, data map[int]int64,
 ) {
 	var conns []*gosql.DB
 	for i := 0; i < c.Spec().NodeCount; i++ {
@@ -311,7 +311,7 @@ func runFollowerReadsTest(
 // initFollowerReadsDB initializes a database for the follower reads test.
 // Returns the data inserted into the test table.
 func initFollowerReadsDB(
-	ctx context.Context, t *test, c cluster2.Cluster, topology topologySpec,
+	ctx context.Context, t *test, c cluster.Cluster, topology topologySpec,
 ) (data map[int]int64) {
 	db := c.Conn(ctx, 1)
 	// Disable load based splitting and range merging because splits and merges
@@ -489,7 +489,7 @@ func computeFollowerReadDuration(ctx context.Context, db *gosql.DB) (time.Durati
 // ignoring the first 20s.
 func verifySQLLatency(
 	ctx context.Context,
-	c cluster2.Cluster,
+	c cluster.Cluster,
 	t *test,
 	adminNode option.NodeListOption,
 	start, end time.Time,
@@ -542,7 +542,7 @@ func verifySQLLatency(
 // to zero (the new leaseholder), and another one's rises (the old leaseholder).
 func verifyHighFollowerReadRatios(
 	ctx context.Context,
-	c cluster2.Cluster,
+	c cluster.Cluster,
 	t *test,
 	node option.NodeListOption,
 	start, end time.Time,
@@ -669,7 +669,7 @@ const followerReadsMetric = "follower_reads_success_count"
 
 // getFollowerReadCounts returns a slice from node to follower read count
 // according to the metric.
-func getFollowerReadCounts(ctx context.Context, c cluster2.Cluster) ([]int, error) {
+func getFollowerReadCounts(ctx context.Context, c cluster.Cluster) ([]int, error) {
 	followerReadCounts := make([]int, c.Spec().NodeCount)
 	getFollowerReadCount := func(ctx context.Context, node int) func() error {
 		return func() error {
@@ -743,7 +743,7 @@ func parsePrometheusMetric(s string) (*prometheusMetric, bool) {
 // sufficient for this purpose; we're not testing non-voting replicas here
 // (which are used in multi-region tests).
 func runFollowerReadsMixedVersionSingleRegionTest(
-	ctx context.Context, t *test, c cluster2.Cluster, buildVersion version.Version,
+	ctx context.Context, t *test, c cluster.Cluster, buildVersion version.Version,
 ) {
 	predecessorVersion, err := PredecessorVersion(buildVersion)
 	require.NoError(t, err)

--- a/pkg/cmd/roachtest/follower_reads.go
+++ b/pkg/cmd/roachtest/follower_reads.go
@@ -24,6 +24,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -44,7 +45,7 @@ func registerFollowerReads(r *testRegistry) {
 			Name:    fmt.Sprintf("follower-reads/survival=%s/locality=%s", survival, locality),
 			Owner:   OwnerKV,
 			Cluster: r.makeClusterSpec(6, spec.CPU(2), spec.Geo(), spec.Zones("us-east1-b,us-east1-b,us-east1-b,us-west1-b,us-west1-b,europe-west2-b")),
-			Run: func(ctx context.Context, t *test, c Cluster) {
+			Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 				c.Put(ctx, cockroach, "./cockroach")
 				c.Wipe(ctx)
 				c.Start(ctx)
@@ -67,7 +68,7 @@ func registerFollowerReads(r *testRegistry) {
 			3, /* nodeCount */
 			spec.CPU(2),
 		),
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runFollowerReadsMixedVersionSingleRegionTest(ctx, t, c, r.buildVersion)
 		},
 	})
@@ -118,7 +119,7 @@ type topologySpec struct {
 //    time are under 10ms which implies that no WAN RPCs occurred.
 //
 func runFollowerReadsTest(
-	ctx context.Context, t *test, c Cluster, topology topologySpec, data map[int]int64,
+	ctx context.Context, t *test, c cluster2.Cluster, topology topologySpec, data map[int]int64,
 ) {
 	var conns []*gosql.DB
 	for i := 0; i < c.Spec().NodeCount; i++ {
@@ -310,7 +311,7 @@ func runFollowerReadsTest(
 // initFollowerReadsDB initializes a database for the follower reads test.
 // Returns the data inserted into the test table.
 func initFollowerReadsDB(
-	ctx context.Context, t *test, c Cluster, topology topologySpec,
+	ctx context.Context, t *test, c cluster2.Cluster, topology topologySpec,
 ) (data map[int]int64) {
 	db := c.Conn(ctx, 1)
 	// Disable load based splitting and range merging because splits and merges
@@ -488,7 +489,7 @@ func computeFollowerReadDuration(ctx context.Context, db *gosql.DB) (time.Durati
 // ignoring the first 20s.
 func verifySQLLatency(
 	ctx context.Context,
-	c Cluster,
+	c cluster2.Cluster,
 	t *test,
 	adminNode option.NodeListOption,
 	start, end time.Time,
@@ -541,7 +542,7 @@ func verifySQLLatency(
 // to zero (the new leaseholder), and another one's rises (the old leaseholder).
 func verifyHighFollowerReadRatios(
 	ctx context.Context,
-	c Cluster,
+	c cluster2.Cluster,
 	t *test,
 	node option.NodeListOption,
 	start, end time.Time,
@@ -668,7 +669,7 @@ const followerReadsMetric = "follower_reads_success_count"
 
 // getFollowerReadCounts returns a slice from node to follower read count
 // according to the metric.
-func getFollowerReadCounts(ctx context.Context, c Cluster) ([]int, error) {
+func getFollowerReadCounts(ctx context.Context, c cluster2.Cluster) ([]int, error) {
 	followerReadCounts := make([]int, c.Spec().NodeCount)
 	getFollowerReadCount := func(ctx context.Context, node int) func() error {
 		return func() error {
@@ -742,7 +743,7 @@ func parsePrometheusMetric(s string) (*prometheusMetric, bool) {
 // sufficient for this purpose; we're not testing non-voting replicas here
 // (which are used in multi-region tests).
 func runFollowerReadsMixedVersionSingleRegionTest(
-	ctx context.Context, t *test, c Cluster, buildVersion version.Version,
+	ctx context.Context, t *test, c cluster2.Cluster, buildVersion version.Version,
 ) {
 	predecessorVersion, err := PredecessorVersion(buildVersion)
 	require.NoError(t, err)

--- a/pkg/cmd/roachtest/go_helpers.go
+++ b/pkg/cmd/roachtest/go_helpers.go
@@ -13,7 +13,7 @@ package main
 import (
 	"context"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 )
 
@@ -21,7 +21,7 @@ const goPath = `/mnt/data1/go`
 
 // installGolang installs a specific version of Go on all nodes in
 // "node".
-func installGolang(ctx context.Context, t *test, c cluster2.Cluster, node option.NodeListOption) {
+func installGolang(ctx context.Context, t *test, c cluster.Cluster, node option.NodeListOption) {
 	if err := repeatRunE(
 		ctx, t, c, node, "update apt-get", `sudo apt-get -qq update`,
 	); err != nil {

--- a/pkg/cmd/roachtest/go_helpers.go
+++ b/pkg/cmd/roachtest/go_helpers.go
@@ -13,6 +13,7 @@ package main
 import (
 	"context"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 )
 
@@ -20,7 +21,7 @@ const goPath = `/mnt/data1/go`
 
 // installGolang installs a specific version of Go on all nodes in
 // "node".
-func installGolang(ctx context.Context, t *test, c Cluster, node option.NodeListOption) {
+func installGolang(ctx context.Context, t *test, c cluster2.Cluster, node option.NodeListOption) {
 	if err := repeatRunE(
 		ctx, t, c, node, "update apt-get", `sudo apt-get -qq update`,
 	); err != nil {

--- a/pkg/cmd/roachtest/gopg.go
+++ b/pkg/cmd/roachtest/gopg.go
@@ -19,7 +19,7 @@ import (
 	"strconv"
 	"strings"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/errors"
 )
 
@@ -38,7 +38,7 @@ func registerGopg(r *testRegistry) {
 	runGopg := func(
 		ctx context.Context,
 		t *test,
-		c cluster2.Cluster,
+		c cluster.Cluster,
 	) {
 		if c.IsLocal() {
 			t.Fatal("cannot be run in local mode")
@@ -151,7 +151,7 @@ func registerGopg(r *testRegistry) {
 		Cluster:    r.makeClusterSpec(1),
 		MinVersion: "v20.2.0",
 		Tags:       []string{`default`, `orm`},
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runGopg(ctx, t, c)
 		},
 	})

--- a/pkg/cmd/roachtest/gopg.go
+++ b/pkg/cmd/roachtest/gopg.go
@@ -39,7 +39,7 @@ func registerGopg(r *testRegistry) {
 		t *test,
 		c Cluster,
 	) {
-		if c.isLocal() {
+		if c.IsLocal() {
 			t.Fatal("cannot be run in local mode")
 		}
 		node := c.Node(1)

--- a/pkg/cmd/roachtest/gopg.go
+++ b/pkg/cmd/roachtest/gopg.go
@@ -45,7 +45,7 @@ func registerGopg(r *testRegistry) {
 		node := c.Node(1)
 		t.Status("setting up cockroach")
 		c.Put(ctx, cockroach, "./cockroach", c.All())
-		c.Start(ctx, t, c.All())
+		c.Start(ctx, c.All())
 		version, err := fetchCockroachVersion(ctx, c, node[0], nil)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/cmd/roachtest/gopg.go
+++ b/pkg/cmd/roachtest/gopg.go
@@ -19,6 +19,7 @@ import (
 	"strconv"
 	"strings"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/errors"
 )
 
@@ -37,7 +38,7 @@ func registerGopg(r *testRegistry) {
 	runGopg := func(
 		ctx context.Context,
 		t *test,
-		c Cluster,
+		c cluster2.Cluster,
 	) {
 		if c.IsLocal() {
 			t.Fatal("cannot be run in local mode")
@@ -150,7 +151,7 @@ func registerGopg(r *testRegistry) {
 		Cluster:    r.makeClusterSpec(1),
 		MinVersion: "v20.2.0",
 		Tags:       []string{`default`, `orm`},
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runGopg(ctx, t, c)
 		},
 	})

--- a/pkg/cmd/roachtest/gorm.go
+++ b/pkg/cmd/roachtest/gorm.go
@@ -23,7 +23,7 @@ var gormSupportedTag = "v1.21.8"
 
 func registerGORM(r *testRegistry) {
 	runGORM := func(ctx context.Context, t *test, c Cluster) {
-		if c.isLocal() {
+		if c.IsLocal() {
 			t.Fatal("cannot be run in local mode")
 		}
 		node := c.Node(1)

--- a/pkg/cmd/roachtest/gorm.go
+++ b/pkg/cmd/roachtest/gorm.go
@@ -15,7 +15,7 @@ import (
 	"fmt"
 	"regexp"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/stretchr/testify/require"
 )
 
@@ -23,7 +23,7 @@ var gormReleaseTag = regexp.MustCompile(`^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<p
 var gormSupportedTag = "v1.21.8"
 
 func registerGORM(r *testRegistry) {
-	runGORM := func(ctx context.Context, t *test, c cluster2.Cluster) {
+	runGORM := func(ctx context.Context, t *test, c cluster.Cluster) {
 		if c.IsLocal() {
 			t.Fatal("cannot be run in local mode")
 		}

--- a/pkg/cmd/roachtest/gorm.go
+++ b/pkg/cmd/roachtest/gorm.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"regexp"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,7 +23,7 @@ var gormReleaseTag = regexp.MustCompile(`^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<p
 var gormSupportedTag = "v1.21.8"
 
 func registerGORM(r *testRegistry) {
-	runGORM := func(ctx context.Context, t *test, c Cluster) {
+	runGORM := func(ctx context.Context, t *test, c cluster2.Cluster) {
 		if c.IsLocal() {
 			t.Fatal("cannot be run in local mode")
 		}

--- a/pkg/cmd/roachtest/gorm.go
+++ b/pkg/cmd/roachtest/gorm.go
@@ -29,7 +29,7 @@ func registerGORM(r *testRegistry) {
 		node := c.Node(1)
 		t.Status("setting up cockroach")
 		c.Put(ctx, cockroach, "./cockroach", c.All())
-		c.Start(ctx, t, c.All())
+		c.Start(ctx, c.All())
 		version, err := fetchCockroachVersion(ctx, c, node[0], nil)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/cmd/roachtest/gossip.go
+++ b/pkg/cmd/roachtest/gossip.go
@@ -23,7 +23,7 @@ import (
 	"time"
 	"unicode"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
@@ -33,7 +33,7 @@ import (
 )
 
 func registerGossip(r *testRegistry) {
-	runGossipChaos := func(ctx context.Context, t *test, c cluster2.Cluster) {
+	runGossipChaos := func(ctx context.Context, t *test, c cluster.Cluster) {
 		args := startArgs("--args=--vmodule=*=1")
 		c.Put(ctx, cockroach, "./cockroach", c.All())
 		c.Start(ctx, c.All(), args)
@@ -154,7 +154,7 @@ SELECT string_agg(source_id::TEXT || ':' || target_id::TEXT, ',')
 		Name:    "gossip/chaos/nodes=9",
 		Owner:   OwnerKV,
 		Cluster: r.makeClusterSpec(9),
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runGossipChaos(ctx, t, c)
 		},
 	})
@@ -166,7 +166,7 @@ type gossipUtil struct {
 	conn     func(ctx context.Context, i int) *gosql.DB
 }
 
-func newGossipUtil(ctx context.Context, t *test, c cluster2.Cluster) *gossipUtil {
+func newGossipUtil(ctx context.Context, t *test, c cluster.Cluster) *gossipUtil {
 	urlMap := make(map[int]string)
 	adminUIAddrs, err := c.ExternalAdminUIAddr(ctx, c.All())
 	if err != nil {
@@ -187,7 +187,7 @@ type checkGossipFunc func(map[string]gossip.Info) error
 // checkGossip fetches the gossip infoStore from each node and invokes the
 // given function. The test passes if the function returns 0 for every node,
 // retrying for up to the given duration.
-func (g *gossipUtil) check(ctx context.Context, c cluster2.Cluster, f checkGossipFunc) error {
+func (g *gossipUtil) check(ctx context.Context, c cluster.Cluster, f checkGossipFunc) error {
 	return retry.ForDuration(g.waitTime, func() error {
 		var infoStatus gossip.InfoStatus
 		for i := 1; i <= c.Spec().NodeCount; i++ {
@@ -237,7 +237,7 @@ func (gossipUtil) hasClusterID(infos map[string]gossip.Info) error {
 	return nil
 }
 
-func (g *gossipUtil) checkConnectedAndFunctional(ctx context.Context, t *test, c cluster2.Cluster) {
+func (g *gossipUtil) checkConnectedAndFunctional(ctx context.Context, t *test, c cluster.Cluster) {
 	t.l.Printf("waiting for gossip to be connected\n")
 	if err := g.check(ctx, c, g.hasPeers(c.Spec().NodeCount)); err != nil {
 		t.Fatal(err)
@@ -282,7 +282,7 @@ func (g *gossipUtil) checkConnectedAndFunctional(ctx context.Context, t *test, c
 	}
 }
 
-func runGossipPeerings(ctx context.Context, t *test, c cluster2.Cluster) {
+func runGossipPeerings(ctx context.Context, t *test, c cluster.Cluster) {
 	c.Put(ctx, cockroach, "./cockroach")
 	c.Start(ctx)
 
@@ -315,7 +315,7 @@ func runGossipPeerings(ctx context.Context, t *test, c cluster2.Cluster) {
 	}
 }
 
-func runGossipRestart(ctx context.Context, t *test, c cluster2.Cluster) {
+func runGossipRestart(ctx context.Context, t *test, c cluster.Cluster) {
 	t.Skip("skipping flaky acceptance/gossip/restart", "https://github.com/cockroachdb/cockroach/issues/48423")
 
 	c.Put(ctx, cockroach, "./cockroach")
@@ -341,7 +341,7 @@ func runGossipRestart(ctx context.Context, t *test, c cluster2.Cluster) {
 	}
 }
 
-func runGossipRestartNodeOne(ctx context.Context, t *test, c cluster2.Cluster) {
+func runGossipRestartNodeOne(ctx context.Context, t *test, c cluster.Cluster) {
 	args := startArgs("--env=COCKROACH_SCAN_MAX_IDLE_TIME=5ms", "--encrypt=false")
 	c.Put(ctx, cockroach, "./cockroach")
 	// Reduce the scan max idle time to speed up evacuation of node 1.
@@ -492,7 +492,7 @@ SELECT count(replicas)
 	c.Start(ctx, c.Node(1))
 }
 
-func runCheckLocalityIPAddress(ctx context.Context, t *test, c cluster2.Cluster) {
+func runCheckLocalityIPAddress(ctx context.Context, t *test, c cluster.Cluster) {
 	c.Put(ctx, cockroach, "./cockroach")
 
 	externalIP, err := c.ExternalIP(ctx, c.Range(1, c.Spec().NodeCount))

--- a/pkg/cmd/roachtest/hibernate.go
+++ b/pkg/cmd/roachtest/hibernate.go
@@ -68,7 +68,7 @@ func registerHibernate(r *testRegistry, opt hibernateOptions) {
 		t *test,
 		c Cluster,
 	) {
-		if c.isLocal() {
+		if c.IsLocal() {
 			t.Fatal("cannot be run in local mode")
 		}
 		node := c.Node(1)

--- a/pkg/cmd/roachtest/hibernate.go
+++ b/pkg/cmd/roachtest/hibernate.go
@@ -14,6 +14,8 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 )
 
 var hibernateReleaseTagRegex = regexp.MustCompile(`^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)$`)
@@ -25,7 +27,7 @@ type hibernateOptions struct {
 	buildCmd,
 	testCmd string
 	blocklists  blocklistsForVersion
-	dbSetupFunc func(ctx context.Context, t *test, c Cluster)
+	dbSetupFunc func(ctx context.Context, t *test, c cluster2.Cluster)
 }
 
 var (
@@ -46,7 +48,7 @@ var (
 		testCmd: `cd /mnt/data1/hibernate/hibernate-spatial && ` +
 			`HIBERNATE_CONNECTION_LEAK_DETECTION=true ./../gradlew test -Pdb=cockroachdb_spatial`,
 		blocklists: hibernateSpatialBlocklists,
-		dbSetupFunc: func(ctx context.Context, t *test, c Cluster) {
+		dbSetupFunc: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			db := c.Conn(ctx, 1)
 			defer db.Close()
 			if _, err := db.ExecContext(
@@ -66,7 +68,7 @@ func registerHibernate(r *testRegistry, opt hibernateOptions) {
 	runHibernate := func(
 		ctx context.Context,
 		t *test,
-		c Cluster,
+		c cluster2.Cluster,
 	) {
 		if c.IsLocal() {
 			t.Fatal("cannot be run in local mode")
@@ -237,7 +239,7 @@ func registerHibernate(r *testRegistry, opt hibernateOptions) {
 		MinVersion: "v20.2.0",
 		Cluster:    r.makeClusterSpec(1),
 		Tags:       []string{`default`, `orm`},
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runHibernate(ctx, t, c)
 		},
 	})

--- a/pkg/cmd/roachtest/hibernate.go
+++ b/pkg/cmd/roachtest/hibernate.go
@@ -15,7 +15,7 @@ import (
 	"fmt"
 	"regexp"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 )
 
 var hibernateReleaseTagRegex = regexp.MustCompile(`^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)$`)
@@ -27,7 +27,7 @@ type hibernateOptions struct {
 	buildCmd,
 	testCmd string
 	blocklists  blocklistsForVersion
-	dbSetupFunc func(ctx context.Context, t *test, c cluster2.Cluster)
+	dbSetupFunc func(ctx context.Context, t *test, c cluster.Cluster)
 }
 
 var (
@@ -48,7 +48,7 @@ var (
 		testCmd: `cd /mnt/data1/hibernate/hibernate-spatial && ` +
 			`HIBERNATE_CONNECTION_LEAK_DETECTION=true ./../gradlew test -Pdb=cockroachdb_spatial`,
 		blocklists: hibernateSpatialBlocklists,
-		dbSetupFunc: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		dbSetupFunc: func(ctx context.Context, t *test, c cluster.Cluster) {
 			db := c.Conn(ctx, 1)
 			defer db.Close()
 			if _, err := db.ExecContext(
@@ -68,7 +68,7 @@ func registerHibernate(r *testRegistry, opt hibernateOptions) {
 	runHibernate := func(
 		ctx context.Context,
 		t *test,
-		c cluster2.Cluster,
+		c cluster.Cluster,
 	) {
 		if c.IsLocal() {
 			t.Fatal("cannot be run in local mode")
@@ -239,7 +239,7 @@ func registerHibernate(r *testRegistry, opt hibernateOptions) {
 		MinVersion: "v20.2.0",
 		Cluster:    r.makeClusterSpec(1),
 		Tags:       []string{`default`, `orm`},
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runHibernate(ctx, t, c)
 		},
 	})

--- a/pkg/cmd/roachtest/hibernate.go
+++ b/pkg/cmd/roachtest/hibernate.go
@@ -77,7 +77,7 @@ func registerHibernate(r *testRegistry, opt hibernateOptions) {
 		if err := c.PutLibraries(ctx, "./lib"); err != nil {
 			t.Fatal(err)
 		}
-		c.Start(ctx, t, c.All())
+		c.Start(ctx, c.All())
 
 		if opt.dbSetupFunc != nil {
 			opt.dbSetupFunc(ctx, t, c)

--- a/pkg/cmd/roachtest/hotspotsplits.go
+++ b/pkg/cmd/roachtest/hotspotsplits.go
@@ -31,7 +31,7 @@ func registerHotSpotSplits(r *testRegistry) {
 		appNode := c.Node(c.Spec().NodeCount)
 
 		c.Put(ctx, cockroach, "./cockroach", roachNodes)
-		c.Start(ctx, t, roachNodes)
+		c.Start(ctx, roachNodes)
 
 		c.Put(ctx, workload, "./workload", appNode)
 		c.Run(ctx, appNode, `./workload init kv --drop {pgurl:1}`)

--- a/pkg/cmd/roachtest/hotspotsplits.go
+++ b/pkg/cmd/roachtest/hotspotsplits.go
@@ -15,7 +15,7 @@ import (
 	"fmt"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
@@ -27,7 +27,7 @@ func registerHotSpotSplits(r *testRegistry) {
 	// This test sets up a cluster and runs kv on it with high concurrency and a large block size
 	// to force a large range. We then make sure that the largest range isn't larger than a threshold and
 	// that backpressure is working correctly.
-	runHotSpot := func(ctx context.Context, t *test, c cluster2.Cluster, duration time.Duration, concurrency int) {
+	runHotSpot := func(ctx context.Context, t *test, c cluster.Cluster, duration time.Duration, concurrency int) {
 		roachNodes := c.Range(1, c.Spec().NodeCount-1)
 		appNode := c.Node(c.Spec().NodeCount)
 
@@ -97,7 +97,7 @@ func registerHotSpotSplits(r *testRegistry) {
 		// https://github.com/cockroachdb/cockroach/pull/45323.
 		MinVersion: "v20.1.0",
 		Cluster:    r.makeClusterSpec(numNodes),
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			if local {
 				concurrency = 32
 				fmt.Printf("lowering concurrency to %d in local testing\n", concurrency)

--- a/pkg/cmd/roachtest/hotspotsplits.go
+++ b/pkg/cmd/roachtest/hotspotsplits.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
@@ -26,7 +27,7 @@ func registerHotSpotSplits(r *testRegistry) {
 	// This test sets up a cluster and runs kv on it with high concurrency and a large block size
 	// to force a large range. We then make sure that the largest range isn't larger than a threshold and
 	// that backpressure is working correctly.
-	runHotSpot := func(ctx context.Context, t *test, c Cluster, duration time.Duration, concurrency int) {
+	runHotSpot := func(ctx context.Context, t *test, c cluster2.Cluster, duration time.Duration, concurrency int) {
 		roachNodes := c.Range(1, c.Spec().NodeCount-1)
 		appNode := c.Node(c.Spec().NodeCount)
 
@@ -96,7 +97,7 @@ func registerHotSpotSplits(r *testRegistry) {
 		// https://github.com/cockroachdb/cockroach/pull/45323.
 		MinVersion: "v20.1.0",
 		Cluster:    r.makeClusterSpec(numNodes),
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			if local {
 				concurrency = 32
 				fmt.Printf("lowering concurrency to %d in local testing\n", concurrency)

--- a/pkg/cmd/roachtest/import.go
+++ b/pkg/cmd/roachtest/import.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
@@ -24,7 +25,7 @@ import (
 
 func registerImportNodeShutdown(r *testRegistry) {
 	getImportRunner := func(ctx context.Context, gatewayNode int) jobStarter {
-		startImport := func(c Cluster) (jobID string, err error) {
+		startImport := func(c cluster2.Cluster) (jobID string, err error) {
 			// partsupp is 11.2 GiB.
 			tableName := "partsupp"
 			if local {
@@ -60,7 +61,7 @@ func registerImportNodeShutdown(r *testRegistry) {
 		Owner:      OwnerBulkIO,
 		Cluster:    r.makeClusterSpec(4),
 		MinVersion: "v21.1.0",
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			c.Put(ctx, cockroach, "./cockroach")
 			c.Start(ctx)
 			gatewayNode := 2
@@ -75,7 +76,7 @@ func registerImportNodeShutdown(r *testRegistry) {
 		Owner:      OwnerBulkIO,
 		Cluster:    r.makeClusterSpec(4),
 		MinVersion: "v21.1.0",
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			c.Put(ctx, cockroach, "./cockroach")
 			c.Start(ctx)
 			gatewayNode := 2
@@ -88,7 +89,7 @@ func registerImportNodeShutdown(r *testRegistry) {
 }
 
 func registerImportTPCC(r *testRegistry) {
-	runImportTPCC := func(ctx context.Context, t *test, c Cluster, testName string,
+	runImportTPCC := func(ctx context.Context, t *test, c cluster2.Cluster, testName string,
 		timeout time.Duration, warehouses int) {
 		// Randomize starting with encryption-at-rest enabled.
 		c.EncryptAtRandom(true)
@@ -137,7 +138,7 @@ func registerImportTPCC(r *testRegistry) {
 			Owner:   OwnerBulkIO,
 			Cluster: r.makeClusterSpec(numNodes),
 			Timeout: timeout,
-			Run: func(ctx context.Context, t *test, c Cluster) {
+			Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 				runImportTPCC(ctx, t, c, testName, timeout, warehouses)
 			},
 		})
@@ -150,7 +151,7 @@ func registerImportTPCC(r *testRegistry) {
 		Owner:   OwnerBulkIO,
 		Cluster: r.makeClusterSpec(8, spec.CPU(16), spec.Geo(), spec.Zones(geoZones)),
 		Timeout: 5 * time.Hour,
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runImportTPCC(ctx, t, c, fmt.Sprintf("import/tpcc/warehouses=%d/geo", geoWarehouses),
 				5*time.Hour, geoWarehouses)
 		},
@@ -179,7 +180,7 @@ func registerImportTPCH(r *testRegistry) {
 			Owner:   OwnerBulkIO,
 			Cluster: r.makeClusterSpec(item.nodes),
 			Timeout: item.timeout,
-			Run: func(ctx context.Context, t *test, c Cluster) {
+			Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 				tick := initBulkJobPerfArtifacts(ctx, t.Name(), item.timeout)
 
 				// Randomize starting with encryption-at-rest enabled.
@@ -277,7 +278,7 @@ func successfulImportStep(warehouses, nodeID int) versionStep {
 }
 
 func runImportMixedVersion(
-	ctx context.Context, t *test, c Cluster, warehouses int, predecessorVersion string,
+	ctx context.Context, t *test, c cluster2.Cluster, warehouses int, predecessorVersion string,
 ) {
 	// An empty string means that the cockroach binary specified by flag
 	// `cockroach` will be used.
@@ -307,7 +308,7 @@ func registerImportMixedVersion(r *testRegistry) {
 		// Mixed-version support was added in 21.1.
 		MinVersion: "v21.1.0",
 		Cluster:    r.makeClusterSpec(4),
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			predV, err := PredecessorVersion(r.buildVersion)
 			if err != nil {
 				t.Fatal(err)
@@ -322,7 +323,7 @@ func registerImportMixedVersion(r *testRegistry) {
 }
 
 func registerImportDecommissioned(r *testRegistry) {
-	runImportDecommissioned := func(ctx context.Context, t *test, c Cluster) {
+	runImportDecommissioned := func(ctx context.Context, t *test, c cluster2.Cluster) {
 		warehouses := 100
 		if local {
 			warehouses = 10

--- a/pkg/cmd/roachtest/import.go
+++ b/pkg/cmd/roachtest/import.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
@@ -25,7 +25,7 @@ import (
 
 func registerImportNodeShutdown(r *testRegistry) {
 	getImportRunner := func(ctx context.Context, gatewayNode int) jobStarter {
-		startImport := func(c cluster2.Cluster) (jobID string, err error) {
+		startImport := func(c cluster.Cluster) (jobID string, err error) {
 			// partsupp is 11.2 GiB.
 			tableName := "partsupp"
 			if local {
@@ -61,7 +61,7 @@ func registerImportNodeShutdown(r *testRegistry) {
 		Owner:      OwnerBulkIO,
 		Cluster:    r.makeClusterSpec(4),
 		MinVersion: "v21.1.0",
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			c.Put(ctx, cockroach, "./cockroach")
 			c.Start(ctx)
 			gatewayNode := 2
@@ -76,7 +76,7 @@ func registerImportNodeShutdown(r *testRegistry) {
 		Owner:      OwnerBulkIO,
 		Cluster:    r.makeClusterSpec(4),
 		MinVersion: "v21.1.0",
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			c.Put(ctx, cockroach, "./cockroach")
 			c.Start(ctx)
 			gatewayNode := 2
@@ -89,7 +89,7 @@ func registerImportNodeShutdown(r *testRegistry) {
 }
 
 func registerImportTPCC(r *testRegistry) {
-	runImportTPCC := func(ctx context.Context, t *test, c cluster2.Cluster, testName string,
+	runImportTPCC := func(ctx context.Context, t *test, c cluster.Cluster, testName string,
 		timeout time.Duration, warehouses int) {
 		// Randomize starting with encryption-at-rest enabled.
 		c.EncryptAtRandom(true)
@@ -138,7 +138,7 @@ func registerImportTPCC(r *testRegistry) {
 			Owner:   OwnerBulkIO,
 			Cluster: r.makeClusterSpec(numNodes),
 			Timeout: timeout,
-			Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+			Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 				runImportTPCC(ctx, t, c, testName, timeout, warehouses)
 			},
 		})
@@ -151,7 +151,7 @@ func registerImportTPCC(r *testRegistry) {
 		Owner:   OwnerBulkIO,
 		Cluster: r.makeClusterSpec(8, spec.CPU(16), spec.Geo(), spec.Zones(geoZones)),
 		Timeout: 5 * time.Hour,
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runImportTPCC(ctx, t, c, fmt.Sprintf("import/tpcc/warehouses=%d/geo", geoWarehouses),
 				5*time.Hour, geoWarehouses)
 		},
@@ -180,7 +180,7 @@ func registerImportTPCH(r *testRegistry) {
 			Owner:   OwnerBulkIO,
 			Cluster: r.makeClusterSpec(item.nodes),
 			Timeout: item.timeout,
-			Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+			Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 				tick := initBulkJobPerfArtifacts(ctx, t.Name(), item.timeout)
 
 				// Randomize starting with encryption-at-rest enabled.
@@ -278,7 +278,7 @@ func successfulImportStep(warehouses, nodeID int) versionStep {
 }
 
 func runImportMixedVersion(
-	ctx context.Context, t *test, c cluster2.Cluster, warehouses int, predecessorVersion string,
+	ctx context.Context, t *test, c cluster.Cluster, warehouses int, predecessorVersion string,
 ) {
 	// An empty string means that the cockroach binary specified by flag
 	// `cockroach` will be used.
@@ -308,7 +308,7 @@ func registerImportMixedVersion(r *testRegistry) {
 		// Mixed-version support was added in 21.1.
 		MinVersion: "v21.1.0",
 		Cluster:    r.makeClusterSpec(4),
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			predV, err := PredecessorVersion(r.buildVersion)
 			if err != nil {
 				t.Fatal(err)
@@ -323,7 +323,7 @@ func registerImportMixedVersion(r *testRegistry) {
 }
 
 func registerImportDecommissioned(r *testRegistry) {
-	runImportDecommissioned := func(ctx context.Context, t *test, c cluster2.Cluster) {
+	runImportDecommissioned := func(ctx context.Context, t *test, c cluster.Cluster) {
 		warehouses := 100
 		if local {
 			warehouses = 10

--- a/pkg/cmd/roachtest/import.go
+++ b/pkg/cmd/roachtest/import.go
@@ -62,7 +62,7 @@ func registerImportNodeShutdown(r *testRegistry) {
 		MinVersion: "v21.1.0",
 		Run: func(ctx context.Context, t *test, c Cluster) {
 			c.Put(ctx, cockroach, "./cockroach")
-			c.Start(ctx, t)
+			c.Start(ctx)
 			gatewayNode := 2
 			nodeToShutdown := 3
 			startImport := getImportRunner(ctx, gatewayNode)
@@ -77,7 +77,7 @@ func registerImportNodeShutdown(r *testRegistry) {
 		MinVersion: "v21.1.0",
 		Run: func(ctx context.Context, t *test, c Cluster) {
 			c.Put(ctx, cockroach, "./cockroach")
-			c.Start(ctx, t)
+			c.Start(ctx)
 			gatewayNode := 2
 			nodeToShutdown := 2
 			startImport := getImportRunner(ctx, gatewayNode)
@@ -95,7 +95,7 @@ func registerImportTPCC(r *testRegistry) {
 		c.Put(ctx, cockroach, "./cockroach")
 		c.Put(ctx, workload, "./workload")
 		t.Status("starting csv servers")
-		c.Start(ctx, t)
+		c.Start(ctx)
 		c.Run(ctx, c.All(), `./workload csv-server --port=8081 &> logs/workload-csv-server.log < /dev/null &`)
 
 		t.Status("running workload")
@@ -185,7 +185,7 @@ func registerImportTPCH(r *testRegistry) {
 				// Randomize starting with encryption-at-rest enabled.
 				c.EncryptAtRandom(true)
 				c.Put(ctx, cockroach, "./cockroach")
-				c.Start(ctx, t)
+				c.Start(ctx)
 				conn := c.Conn(ctx, 1)
 				if _, err := conn.Exec(`CREATE DATABASE csv;`); err != nil {
 					t.Fatal(err)
@@ -331,7 +331,7 @@ func registerImportDecommissioned(r *testRegistry) {
 		c.Put(ctx, cockroach, "./cockroach")
 		c.Put(ctx, workload, "./workload")
 		t.Status("starting csv servers")
-		c.Start(ctx, t)
+		c.Start(ctx)
 		c.Run(ctx, c.All(), `./workload csv-server --port=8081 &> logs/workload-csv-server.log < /dev/null &`)
 
 		// Decommission a node.

--- a/pkg/cmd/roachtest/inconsistency.go
+++ b/pkg/cmd/roachtest/inconsistency.go
@@ -14,7 +14,7 @@ import (
 	"context"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	_ "github.com/lib/pq"
 )
 
@@ -28,7 +28,7 @@ func registerInconsistency(r *testRegistry) {
 	})
 }
 
-func runInconsistency(ctx context.Context, t *test, c cluster2.Cluster) {
+func runInconsistency(ctx context.Context, t *test, c cluster.Cluster) {
 	// With encryption on, our attempt below to manually introduce an inconsistency
 	// will fail.
 	c.EncryptDefault(false)

--- a/pkg/cmd/roachtest/inconsistency.go
+++ b/pkg/cmd/roachtest/inconsistency.go
@@ -34,7 +34,7 @@ func runInconsistency(ctx context.Context, t *test, c Cluster) {
 
 	nodes := c.Range(1, 3)
 	c.Put(ctx, cockroach, "./cockroach", nodes)
-	c.Start(ctx, t, nodes)
+	c.Start(ctx, nodes)
 
 	{
 		db := c.Conn(ctx, 1)
@@ -89,7 +89,7 @@ func runInconsistency(ctx context.Context, t *test, c Cluster) {
 	m := newMonitor(ctx, c)
 	// If the consistency check "fails to fail", the verbose logging will help
 	// determine why.
-	c.Start(ctx, t, nodes, startArgs("--args='--vmodule=consistency_queue=5,replica_consistency=5,queue=5'"))
+	c.Start(ctx, nodes, startArgs("--args='--vmodule=consistency_queue=5,replica_consistency=5,queue=5'"))
 	m.Go(func(ctx context.Context) error {
 		select {
 		case <-time.After(5 * time.Minute):

--- a/pkg/cmd/roachtest/inconsistency.go
+++ b/pkg/cmd/roachtest/inconsistency.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	_ "github.com/lib/pq"
 )
 
@@ -27,7 +28,7 @@ func registerInconsistency(r *testRegistry) {
 	})
 }
 
-func runInconsistency(ctx context.Context, t *test, c Cluster) {
+func runInconsistency(ctx context.Context, t *test, c cluster2.Cluster) {
 	// With encryption on, our attempt below to manually introduce an inconsistency
 	// will fail.
 	c.EncryptDefault(false)

--- a/pkg/cmd/roachtest/indexes.go
+++ b/pkg/cmd/roachtest/indexes.go
@@ -42,7 +42,7 @@ func registerNIndexes(r *testRegistry, secondaryIndexes int) {
 
 			c.Put(ctx, cockroach, "./cockroach", roachNodes)
 			c.Put(ctx, workload, "./workload", loadNode)
-			c.Start(ctx, t, roachNodes)
+			c.Start(ctx, roachNodes)
 			conn := c.Conn(ctx, 1)
 
 			t.Status("running workload")

--- a/pkg/cmd/roachtest/indexes.go
+++ b/pkg/cmd/roachtest/indexes.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 )
@@ -34,7 +35,7 @@ func registerNIndexes(r *testRegistry, secondaryIndexes int) {
 		Cluster: r.makeClusterSpec(nodes+1, spec.CPU(16), spec.Geo(), spec.Zones(geoZonesStr)),
 		// Uses CONFIGURE ZONE USING ... COPY FROM PARENT syntax.
 		MinVersion: `v19.1.0`,
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			firstAZ := geoZones[0]
 			roachNodes := c.Range(1, nodes)
 			gatewayNodes := c.Range(1, nodes/3)

--- a/pkg/cmd/roachtest/indexes.go
+++ b/pkg/cmd/roachtest/indexes.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 )
@@ -35,7 +35,7 @@ func registerNIndexes(r *testRegistry, secondaryIndexes int) {
 		Cluster: r.makeClusterSpec(nodes+1, spec.CPU(16), spec.Geo(), spec.Zones(geoZonesStr)),
 		// Uses CONFIGURE ZONE USING ... COPY FROM PARENT syntax.
 		MinVersion: `v19.1.0`,
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			firstAZ := geoZones[0]
 			roachNodes := c.Range(1, nodes)
 			gatewayNodes := c.Range(1, nodes/3)

--- a/pkg/cmd/roachtest/interleavedpartitioned.go
+++ b/pkg/cmd/roachtest/interleavedpartitioned.go
@@ -53,7 +53,7 @@ func registerInterleaved(r *testRegistry) {
 
 		c.Put(ctx, cockroach, "./cockroach", c.All())
 		c.Put(ctx, workload, "./workload", c.All())
-		c.Start(ctx, t, cockroachNodes)
+		c.Start(ctx, cockroachNodes)
 
 		zones := fmt.Sprintf("--east-zone-name %s --west-zone-name %s --central-zone-name %s",
 			config.eastName, config.westName, config.centralName)

--- a/pkg/cmd/roachtest/interleavedpartitioned.go
+++ b/pkg/cmd/roachtest/interleavedpartitioned.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 )
@@ -34,7 +35,7 @@ func registerInterleaved(r *testRegistry) {
 	runInterleaved := func(
 		ctx context.Context,
 		t *test,
-		c Cluster,
+		c cluster2.Cluster,
 		config config,
 	) {
 		numZones, numRoachNodes, numLoadNodes := 3, 9, 3
@@ -124,7 +125,7 @@ func registerInterleaved(r *testRegistry) {
 		Name:    "interleavedpartitioned",
 		Owner:   OwnerKV,
 		Cluster: r.makeClusterSpec(12, spec.Geo(), spec.Zones("us-east1-b,us-west1-b,europe-west2-b")),
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runInterleaved(ctx, t, c,
 				config{
 					eastName:        `europe-west2-b`,

--- a/pkg/cmd/roachtest/interleavedpartitioned.go
+++ b/pkg/cmd/roachtest/interleavedpartitioned.go
@@ -14,7 +14,7 @@ import (
 	"context"
 	"fmt"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 )
@@ -35,7 +35,7 @@ func registerInterleaved(r *testRegistry) {
 	runInterleaved := func(
 		ctx context.Context,
 		t *test,
-		c cluster2.Cluster,
+		c cluster.Cluster,
 		config config,
 	) {
 		numZones, numRoachNodes, numLoadNodes := 3, 9, 3
@@ -125,7 +125,7 @@ func registerInterleaved(r *testRegistry) {
 		Name:    "interleavedpartitioned",
 		Owner:   OwnerKV,
 		Cluster: r.makeClusterSpec(12, spec.Geo(), spec.Zones("us-east1-b,us-west1-b,europe-west2-b")),
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runInterleaved(ctx, t, c,
 				config{
 					eastName:        `europe-west2-b`,

--- a/pkg/cmd/roachtest/inverted_index.go
+++ b/pkg/cmd/roachtest/inverted_index.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
@@ -23,7 +24,7 @@ func registerSchemaChangeInvertedIndex(r *testRegistry) {
 		Name:    "schemachange/invertedindex",
 		Owner:   OwnerSQLSchema,
 		Cluster: r.makeClusterSpec(5),
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runSchemaChangeInvertedIndex(ctx, t, c)
 		},
 	})
@@ -31,7 +32,7 @@ func registerSchemaChangeInvertedIndex(r *testRegistry) {
 
 // runInvertedIndex tests the correctness and performance of building an
 // inverted index on randomly generated JSON data (from the JSON workload).
-func runSchemaChangeInvertedIndex(ctx context.Context, t *test, c Cluster) {
+func runSchemaChangeInvertedIndex(ctx context.Context, t *test, c cluster2.Cluster) {
 	crdbNodes := c.Range(1, c.Spec().NodeCount-1)
 	workloadNode := c.Node(c.Spec().NodeCount)
 

--- a/pkg/cmd/roachtest/inverted_index.go
+++ b/pkg/cmd/roachtest/inverted_index.go
@@ -15,7 +15,7 @@ import (
 	"fmt"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
@@ -24,7 +24,7 @@ func registerSchemaChangeInvertedIndex(r *testRegistry) {
 		Name:    "schemachange/invertedindex",
 		Owner:   OwnerSQLSchema,
 		Cluster: r.makeClusterSpec(5),
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runSchemaChangeInvertedIndex(ctx, t, c)
 		},
 	})
@@ -32,7 +32,7 @@ func registerSchemaChangeInvertedIndex(r *testRegistry) {
 
 // runInvertedIndex tests the correctness and performance of building an
 // inverted index on randomly generated JSON data (from the JSON workload).
-func runSchemaChangeInvertedIndex(ctx context.Context, t *test, c cluster2.Cluster) {
+func runSchemaChangeInvertedIndex(ctx context.Context, t *test, c cluster.Cluster) {
 	crdbNodes := c.Range(1, c.Spec().NodeCount-1)
 	workloadNode := c.Node(c.Spec().NodeCount)
 

--- a/pkg/cmd/roachtest/inverted_index.go
+++ b/pkg/cmd/roachtest/inverted_index.go
@@ -37,7 +37,7 @@ func runSchemaChangeInvertedIndex(ctx context.Context, t *test, c Cluster) {
 
 	c.Put(ctx, cockroach, "./cockroach", crdbNodes)
 	c.Put(ctx, workload, "./workload", workloadNode)
-	c.Start(ctx, t, crdbNodes)
+	c.Start(ctx, crdbNodes)
 
 	cmdInit := "./workload init json {pgurl:1}"
 	c.Run(ctx, workloadNode, cmdInit)

--- a/pkg/cmd/roachtest/inverted_index.go
+++ b/pkg/cmd/roachtest/inverted_index.go
@@ -45,7 +45,7 @@ func runSchemaChangeInvertedIndex(ctx context.Context, t *test, c Cluster) {
 	// On a 4-node GCE cluster with the standard configuration, this generates ~10 million rows
 	initialDataDuration := time.Minute * 20
 	indexDuration := time.Hour
-	if c.isLocal() {
+	if c.IsLocal() {
 		initialDataDuration = time.Minute
 		indexDuration = time.Minute
 	}

--- a/pkg/cmd/roachtest/java_helpers.go
+++ b/pkg/cmd/roachtest/java_helpers.go
@@ -17,7 +17,7 @@ import (
 	"regexp"
 	"strings"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 )
 
@@ -177,7 +177,7 @@ func (r *ormTestsResults) parseJUnitXML(
 func parseAndSummarizeJavaORMTestsResults(
 	ctx context.Context,
 	t *test,
-	c cluster2.Cluster,
+	c cluster.Cluster,
 	node option.NodeListOption,
 	ormName string,
 	testOutput []byte,

--- a/pkg/cmd/roachtest/java_helpers.go
+++ b/pkg/cmd/roachtest/java_helpers.go
@@ -17,6 +17,7 @@ import (
 	"regexp"
 	"strings"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 )
 
@@ -176,7 +177,7 @@ func (r *ormTestsResults) parseJUnitXML(
 func parseAndSummarizeJavaORMTestsResults(
 	ctx context.Context,
 	t *test,
-	c Cluster,
+	c cluster2.Cluster,
 	node option.NodeListOption,
 	ormName string,
 	testOutput []byte,

--- a/pkg/cmd/roachtest/jepsen.go
+++ b/pkg/cmd/roachtest/jepsen.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 )
@@ -43,7 +43,7 @@ var jepsenNemeses = []struct {
 	{"parts-start-kill-2", "--nemesis parts --nemesis2 start-kill-2"},
 }
 
-func initJepsen(ctx context.Context, t *test, c cluster2.Cluster) {
+func initJepsen(ctx context.Context, t *test, c cluster.Cluster) {
 	// NB: comment this out to see the commands jepsen would run locally.
 	if c.IsLocal() {
 		t.Fatal("local execution not supported")
@@ -143,7 +143,7 @@ func initJepsen(ctx context.Context, t *test, c cluster2.Cluster) {
 	c.Run(ctx, c.Node(1), "touch jepsen_initialized")
 }
 
-func runJepsen(ctx context.Context, t *test, c cluster2.Cluster, testName, nemesis string) {
+func runJepsen(ctx context.Context, t *test, c cluster.Cluster, testName, nemesis string) {
 	initJepsen(ctx, t, c)
 
 	controller := c.Node(c.Spec().NodeCount)
@@ -159,7 +159,7 @@ func runJepsen(ctx context.Context, t *test, c cluster2.Cluster, testName, nemes
 	}
 	nodesStr := strings.Join(nodeFlags, " ")
 
-	run := func(c cluster2.Cluster, ctx context.Context, node option.NodeListOption, args ...string) {
+	run := func(c cluster.Cluster, ctx context.Context, node option.NodeListOption, args ...string) {
 		if !c.IsLocal() {
 			c.Run(ctx, node, args...)
 			return
@@ -167,7 +167,7 @@ func runJepsen(ctx context.Context, t *test, c cluster2.Cluster, testName, nemes
 		args = append([]string{roachprod, "run", c.MakeNodes(node), "--"}, args...)
 		t.l.Printf("> %s\n", strings.Join(args, " "))
 	}
-	runE := func(c cluster2.Cluster, ctx context.Context, node option.NodeListOption, args ...string) error {
+	runE := func(c cluster.Cluster, ctx context.Context, node option.NodeListOption, args ...string) error {
 		if !c.IsLocal() {
 			return c.RunE(ctx, node, args...)
 		}
@@ -355,7 +355,7 @@ func registerJepsen(r *testRegistry) {
 				// if they detect that the machines have already been properly
 				// initialized.
 				Cluster: r.makeClusterSpec(6, spec.ReuseTagged("jepsen")),
-				Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+				Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 					runJepsen(ctx, t, c, testName, nemesis.config)
 				},
 			}

--- a/pkg/cmd/roachtest/jepsen.go
+++ b/pkg/cmd/roachtest/jepsen.go
@@ -44,11 +44,11 @@ var jepsenNemeses = []struct {
 
 func initJepsen(ctx context.Context, t *test, c Cluster) {
 	// NB: comment this out to see the commands jepsen would run locally.
-	if c.isLocal() {
+	if c.IsLocal() {
 		t.Fatal("local execution not supported")
 	}
 
-	if c.isLocal() {
+	if c.IsLocal() {
 		// We can't perform any of the remaining setup locally and while we can't
 		// run jepsen locally we let the test run to indicate which commands it
 		// would have run remotely.
@@ -121,7 +121,7 @@ func initJepsen(ctx context.Context, t *test, c Cluster) {
 	}
 	c.Run(ctx, controller, "sh", "-c", `"test -f .ssh/id_rsa || ssh-keygen -f .ssh/id_rsa -t rsa -N ''"`)
 	pubSSHKey := filepath.Join(tempDir, "id_rsa.pub")
-	cmd := loggedCommand(ctx, t.l, roachprod, "get", c.makeNodes(controller), ".ssh/id_rsa.pub", pubSSHKey)
+	cmd := loggedCommand(ctx, t.l, roachprod, "get", c.MakeNodes(controller), ".ssh/id_rsa.pub", pubSSHKey)
 	if err := cmd.Run(); err != nil {
 		t.Fatal(err)
 	}
@@ -159,18 +159,18 @@ func runJepsen(ctx context.Context, t *test, c Cluster, testName, nemesis string
 	nodesStr := strings.Join(nodeFlags, " ")
 
 	run := func(c Cluster, ctx context.Context, node option.NodeListOption, args ...string) {
-		if !c.isLocal() {
+		if !c.IsLocal() {
 			c.Run(ctx, node, args...)
 			return
 		}
-		args = append([]string{roachprod, "run", c.makeNodes(node), "--"}, args...)
+		args = append([]string{roachprod, "run", c.MakeNodes(node), "--"}, args...)
 		t.l.Printf("> %s\n", strings.Join(args, " "))
 	}
 	runE := func(c Cluster, ctx context.Context, node option.NodeListOption, args ...string) error {
-		if !c.isLocal() {
+		if !c.IsLocal() {
 			return c.RunE(ctx, node, args...)
 		}
-		args = append([]string{roachprod, "run", c.makeNodes(node), "--"}, args...)
+		args = append([]string{roachprod, "run", c.MakeNodes(node), "--"}, args...)
 		t.l.Printf("> %s\n", strings.Join(args, " "))
 		return nil
 	}
@@ -280,7 +280,7 @@ cd /mnt/data1/jepsen/cockroachdb && set -eo pipefail && \
 			ignoreErr = true
 		}
 
-		cmd := exec.CommandContext(ctx, roachprod, "run", c.makeNodes(controller),
+		cmd := exec.CommandContext(ctx, roachprod, "run", c.MakeNodes(controller),
 			// -h causes tar to follow symlinks; needed by the "latest" symlink.
 			// -f- sends the output to stdout, we read it and save it to a local file.
 			"tar -chj --ignore-failed-read -C /mnt/data1/jepsen/cockroachdb -f- store/latest invoke.log")
@@ -301,7 +301,7 @@ cd /mnt/data1/jepsen/cockroachdb && set -eo pipefail && \
 		}
 		anyFailed := false
 		for _, file := range collectFiles {
-			cmd := loggedCommand(ctx, t.l, roachprod, "get", c.makeNodes(controller),
+			cmd := loggedCommand(ctx, t.l, roachprod, "get", c.MakeNodes(controller),
 				"/mnt/data1/jepsen/cockroachdb/store/latest/"+file,
 				filepath.Join(outputDir, file))
 			cmd.Stdout = t.l.Stdout
@@ -312,7 +312,7 @@ cd /mnt/data1/jepsen/cockroachdb && set -eo pipefail && \
 		}
 		if anyFailed {
 			// Try to figure out why this is so common.
-			cmd := loggedCommand(ctx, t.l, roachprod, "get", c.makeNodes(controller),
+			cmd := loggedCommand(ctx, t.l, roachprod, "get", c.MakeNodes(controller),
 				"/mnt/data1/jepsen/cockroachdb/invoke.log",
 				filepath.Join(outputDir, "invoke.log"))
 			cmd.Stdout = t.l.Stdout

--- a/pkg/cmd/roachtest/jepsen.go
+++ b/pkg/cmd/roachtest/jepsen.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 )
@@ -42,7 +43,7 @@ var jepsenNemeses = []struct {
 	{"parts-start-kill-2", "--nemesis parts --nemesis2 start-kill-2"},
 }
 
-func initJepsen(ctx context.Context, t *test, c Cluster) {
+func initJepsen(ctx context.Context, t *test, c cluster2.Cluster) {
 	// NB: comment this out to see the commands jepsen would run locally.
 	if c.IsLocal() {
 		t.Fatal("local execution not supported")
@@ -142,7 +143,7 @@ func initJepsen(ctx context.Context, t *test, c Cluster) {
 	c.Run(ctx, c.Node(1), "touch jepsen_initialized")
 }
 
-func runJepsen(ctx context.Context, t *test, c Cluster, testName, nemesis string) {
+func runJepsen(ctx context.Context, t *test, c cluster2.Cluster, testName, nemesis string) {
 	initJepsen(ctx, t, c)
 
 	controller := c.Node(c.Spec().NodeCount)
@@ -158,7 +159,7 @@ func runJepsen(ctx context.Context, t *test, c Cluster, testName, nemesis string
 	}
 	nodesStr := strings.Join(nodeFlags, " ")
 
-	run := func(c Cluster, ctx context.Context, node option.NodeListOption, args ...string) {
+	run := func(c cluster2.Cluster, ctx context.Context, node option.NodeListOption, args ...string) {
 		if !c.IsLocal() {
 			c.Run(ctx, node, args...)
 			return
@@ -166,7 +167,7 @@ func runJepsen(ctx context.Context, t *test, c Cluster, testName, nemesis string
 		args = append([]string{roachprod, "run", c.MakeNodes(node), "--"}, args...)
 		t.l.Printf("> %s\n", strings.Join(args, " "))
 	}
-	runE := func(c Cluster, ctx context.Context, node option.NodeListOption, args ...string) error {
+	runE := func(c cluster2.Cluster, ctx context.Context, node option.NodeListOption, args ...string) error {
 		if !c.IsLocal() {
 			return c.RunE(ctx, node, args...)
 		}
@@ -354,7 +355,7 @@ func registerJepsen(r *testRegistry) {
 				// if they detect that the machines have already been properly
 				// initialized.
 				Cluster: r.makeClusterSpec(6, spec.ReuseTagged("jepsen")),
-				Run: func(ctx context.Context, t *test, c Cluster) {
+				Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 					runJepsen(ctx, t, c, testName, nemesis.config)
 				},
 			}

--- a/pkg/cmd/roachtest/jobs.go
+++ b/pkg/cmd/roachtest/jobs.go
@@ -15,12 +15,13 @@ import (
 	"fmt"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
 
-type jobStarter func(c Cluster) (string, error)
+type jobStarter func(c cluster2.Cluster) (string, error)
 
 // jobSurvivesNodeShutdown is a helper that tests that a given job,
 // running on the specified gatewayNode will still complete successfully
@@ -32,7 +33,7 @@ type jobStarter func(c Cluster) (string, error)
 // - That the statement running the job is a detached statement, and does not
 // block until the job completes.
 func jobSurvivesNodeShutdown(
-	ctx context.Context, t *test, c Cluster, nodeToShutdown int, startJob jobStarter,
+	ctx context.Context, t *test, c cluster2.Cluster, nodeToShutdown int, startJob jobStarter,
 ) {
 	watcherNode := 1 + (nodeToShutdown)%c.Spec().NodeCount
 	target := c.Node(nodeToShutdown)

--- a/pkg/cmd/roachtest/jobs.go
+++ b/pkg/cmd/roachtest/jobs.go
@@ -15,13 +15,13 @@ import (
 	"fmt"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
 
-type jobStarter func(c cluster2.Cluster) (string, error)
+type jobStarter func(c cluster.Cluster) (string, error)
 
 // jobSurvivesNodeShutdown is a helper that tests that a given job,
 // running on the specified gatewayNode will still complete successfully
@@ -33,7 +33,7 @@ type jobStarter func(c cluster2.Cluster) (string, error)
 // - That the statement running the job is a detached statement, and does not
 // block until the job completes.
 func jobSurvivesNodeShutdown(
-	ctx context.Context, t *test, c cluster2.Cluster, nodeToShutdown int, startJob jobStarter,
+	ctx context.Context, t *test, c cluster.Cluster, nodeToShutdown int, startJob jobStarter,
 ) {
 	watcherNode := 1 + (nodeToShutdown)%c.Spec().NodeCount
 	target := c.Node(nodeToShutdown)

--- a/pkg/cmd/roachtest/kv.go
+++ b/pkg/cmd/roachtest/kv.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -62,7 +63,7 @@ func registerKV(r *testRegistry) {
 			return opts.splits
 		}
 	}
-	runKV := func(ctx context.Context, t *test, c Cluster, opts kvOptions) {
+	runKV := func(ctx context.Context, t *test, c cluster2.Cluster, opts kvOptions) {
 		nodes := c.Spec().NodeCount - 1
 		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 		c.Put(ctx, workload, "./workload", c.Node(nodes+1))
@@ -228,7 +229,7 @@ func registerKV(r *testRegistry) {
 			Owner:      OwnerKV,
 			MinVersion: minVersion,
 			Cluster:    r.makeClusterSpec(opts.nodes+1, spec.CPU(opts.cpus)),
-			Run: func(ctx context.Context, t *test, c Cluster) {
+			Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 				runKV(ctx, t, c, opts)
 			},
 			Tags: opts.tags,
@@ -243,7 +244,7 @@ func registerKVContention(r *testRegistry) {
 		Owner:      OwnerKV,
 		MinVersion: "v20.1.0",
 		Cluster:    r.makeClusterSpec(nodes + 1),
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 			c.Put(ctx, workload, "./workload", c.Node(nodes+1))
 
@@ -312,7 +313,7 @@ func registerKVQuiescenceDead(r *testRegistry) {
 		Owner:      OwnerKV,
 		Cluster:    r.makeClusterSpec(4),
 		MinVersion: "v2.1.0",
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			nodes := c.Spec().NodeCount - 1
 			c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 			c.Put(ctx, workload, "./workload", c.Node(nodes+1))
@@ -393,7 +394,7 @@ func registerKVGracefulDraining(r *testRegistry) {
 		Name:    "kv/gracefuldraining/nodes=3",
 		Owner:   OwnerKV,
 		Cluster: r.makeClusterSpec(4),
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			nodes := c.Spec().NodeCount - 1
 			c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 			c.Put(ctx, workload, "./workload", c.Node(nodes+1))
@@ -610,7 +611,7 @@ func registerKVSplits(r *testRegistry) {
 			Owner:   OwnerKV,
 			Timeout: item.timeout,
 			Cluster: r.makeClusterSpec(4),
-			Run: func(ctx context.Context, t *test, c Cluster) {
+			Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 				nodes := c.Spec().NodeCount - 1
 				c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 				c.Put(ctx, workload, "./workload", c.Node(nodes+1))
@@ -641,7 +642,7 @@ func registerKVSplits(r *testRegistry) {
 }
 
 func registerKVScalability(r *testRegistry) {
-	runScalability := func(ctx context.Context, t *test, c Cluster, percent int) {
+	runScalability := func(ctx context.Context, t *test, c cluster2.Cluster, percent int) {
 		nodes := c.Spec().NodeCount - 1
 
 		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
@@ -674,7 +675,7 @@ func registerKVScalability(r *testRegistry) {
 				Name:    fmt.Sprintf("kv%d/scale/nodes=6", p),
 				Owner:   OwnerKV,
 				Cluster: r.makeClusterSpec(7, spec.CPU(8)),
-				Run: func(ctx context.Context, t *test, c Cluster) {
+				Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 					runScalability(ctx, t, c, p)
 				},
 			})
@@ -694,7 +695,7 @@ func registerKVRangeLookups(r *testRegistry) {
 		cpus  = 8
 	)
 
-	runRangeLookups := func(ctx context.Context, t *test, c Cluster, workers int, workloadType rangeLookupWorkloadType, maximumRangeLookupsPerSec float64) {
+	runRangeLookups := func(ctx context.Context, t *test, c cluster2.Cluster, workers int, workloadType rangeLookupWorkloadType, maximumRangeLookupsPerSec float64) {
 		nodes := c.Spec().NodeCount - 1
 		doneInit := make(chan struct{})
 		doneWorkload := make(chan struct{})
@@ -809,7 +810,7 @@ func registerKVRangeLookups(r *testRegistry) {
 			Owner:      OwnerKV,
 			MinVersion: "v19.2.0",
 			Cluster:    r.makeClusterSpec(nodes+1, spec.CPU(cpus)),
-			Run: func(ctx context.Context, t *test, c Cluster) {
+			Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 				runRangeLookups(ctx, t, c, item.workers, item.workloadType, item.maximumRangeLookupsPerSec)
 			},
 		})

--- a/pkg/cmd/roachtest/kv.go
+++ b/pkg/cmd/roachtest/kv.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -63,7 +63,7 @@ func registerKV(r *testRegistry) {
 			return opts.splits
 		}
 	}
-	runKV := func(ctx context.Context, t *test, c cluster2.Cluster, opts kvOptions) {
+	runKV := func(ctx context.Context, t *test, c cluster.Cluster, opts kvOptions) {
 		nodes := c.Spec().NodeCount - 1
 		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 		c.Put(ctx, workload, "./workload", c.Node(nodes+1))
@@ -229,7 +229,7 @@ func registerKV(r *testRegistry) {
 			Owner:      OwnerKV,
 			MinVersion: minVersion,
 			Cluster:    r.makeClusterSpec(opts.nodes+1, spec.CPU(opts.cpus)),
-			Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+			Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 				runKV(ctx, t, c, opts)
 			},
 			Tags: opts.tags,
@@ -244,7 +244,7 @@ func registerKVContention(r *testRegistry) {
 		Owner:      OwnerKV,
 		MinVersion: "v20.1.0",
 		Cluster:    r.makeClusterSpec(nodes + 1),
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 			c.Put(ctx, workload, "./workload", c.Node(nodes+1))
 
@@ -313,7 +313,7 @@ func registerKVQuiescenceDead(r *testRegistry) {
 		Owner:      OwnerKV,
 		Cluster:    r.makeClusterSpec(4),
 		MinVersion: "v2.1.0",
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			nodes := c.Spec().NodeCount - 1
 			c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 			c.Put(ctx, workload, "./workload", c.Node(nodes+1))
@@ -394,7 +394,7 @@ func registerKVGracefulDraining(r *testRegistry) {
 		Name:    "kv/gracefuldraining/nodes=3",
 		Owner:   OwnerKV,
 		Cluster: r.makeClusterSpec(4),
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			nodes := c.Spec().NodeCount - 1
 			c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 			c.Put(ctx, workload, "./workload", c.Node(nodes+1))
@@ -611,7 +611,7 @@ func registerKVSplits(r *testRegistry) {
 			Owner:   OwnerKV,
 			Timeout: item.timeout,
 			Cluster: r.makeClusterSpec(4),
-			Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+			Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 				nodes := c.Spec().NodeCount - 1
 				c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 				c.Put(ctx, workload, "./workload", c.Node(nodes+1))
@@ -642,7 +642,7 @@ func registerKVSplits(r *testRegistry) {
 }
 
 func registerKVScalability(r *testRegistry) {
-	runScalability := func(ctx context.Context, t *test, c cluster2.Cluster, percent int) {
+	runScalability := func(ctx context.Context, t *test, c cluster.Cluster, percent int) {
 		nodes := c.Spec().NodeCount - 1
 
 		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
@@ -675,7 +675,7 @@ func registerKVScalability(r *testRegistry) {
 				Name:    fmt.Sprintf("kv%d/scale/nodes=6", p),
 				Owner:   OwnerKV,
 				Cluster: r.makeClusterSpec(7, spec.CPU(8)),
-				Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+				Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 					runScalability(ctx, t, c, p)
 				},
 			})
@@ -695,7 +695,7 @@ func registerKVRangeLookups(r *testRegistry) {
 		cpus  = 8
 	)
 
-	runRangeLookups := func(ctx context.Context, t *test, c cluster2.Cluster, workers int, workloadType rangeLookupWorkloadType, maximumRangeLookupsPerSec float64) {
+	runRangeLookups := func(ctx context.Context, t *test, c cluster.Cluster, workers int, workloadType rangeLookupWorkloadType, maximumRangeLookupsPerSec float64) {
 		nodes := c.Spec().NodeCount - 1
 		doneInit := make(chan struct{})
 		doneWorkload := make(chan struct{})
@@ -810,7 +810,7 @@ func registerKVRangeLookups(r *testRegistry) {
 			Owner:      OwnerKV,
 			MinVersion: "v19.2.0",
 			Cluster:    r.makeClusterSpec(nodes+1, spec.CPU(cpus)),
-			Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+			Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 				runRangeLookups(ctx, t, c, item.workers, item.workloadType, item.maximumRangeLookupsPerSec)
 			},
 		})

--- a/pkg/cmd/roachtest/kvbench.go
+++ b/pkg/cmd/roachtest/kvbench.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/util/search"
 	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
@@ -91,7 +91,7 @@ func registerKVBenchSpec(r *testRegistry, b kvBenchSpec) {
 		Tags:    []string{"manual"},
 		Owner:   OwnerKV,
 		Cluster: nodes,
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runKVBench(ctx, t, c, b)
 		},
 	})
@@ -178,7 +178,7 @@ func registerKVBench(r *testRegistry) {
 	}
 }
 
-func makeKVLoadGroup(c cluster2.Cluster, numRoachNodes, numLoadNodes int) loadGroup {
+func makeKVLoadGroup(c cluster.Cluster, numRoachNodes, numLoadNodes int) loadGroup {
 	return loadGroup{
 		roachNodes: c.Range(1, numRoachNodes),
 		loadNodes:  c.Range(numRoachNodes+1, numRoachNodes+numLoadNodes),
@@ -193,7 +193,7 @@ func makeKVLoadGroup(c cluster2.Cluster, numRoachNodes, numLoadNodes int) loadGr
 // This tool was primarily written with the objective of demonstrating the write
 // performance characteristics of using hash sharded indexes, for sequential workloads
 // which would've otherwise created a single-range hotspot.
-func runKVBench(ctx context.Context, t *test, c cluster2.Cluster, b kvBenchSpec) {
+func runKVBench(ctx context.Context, t *test, c cluster.Cluster, b kvBenchSpec) {
 	loadGroup := makeKVLoadGroup(c, b.Nodes, 1)
 	roachNodes := loadGroup.roachNodes
 	loadNodes := loadGroup.loadNodes

--- a/pkg/cmd/roachtest/kvbench.go
+++ b/pkg/cmd/roachtest/kvbench.go
@@ -225,7 +225,7 @@ func runKVBench(ctx context.Context, t *test, c Cluster, b kvBenchSpec) {
 		// splitting can significantly change the underlying layout of the table and
 		// affect benchmark results.
 		c.Wipe(ctx, roachNodes)
-		c.Start(ctx, t, roachNodes)
+		c.Start(ctx, roachNodes)
 		time.Sleep(restartWait)
 
 		// We currently only support one loadGroup.

--- a/pkg/cmd/roachtest/kvbench.go
+++ b/pkg/cmd/roachtest/kvbench.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/util/search"
 	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
@@ -90,7 +91,7 @@ func registerKVBenchSpec(r *testRegistry, b kvBenchSpec) {
 		Tags:    []string{"manual"},
 		Owner:   OwnerKV,
 		Cluster: nodes,
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runKVBench(ctx, t, c, b)
 		},
 	})
@@ -177,7 +178,7 @@ func registerKVBench(r *testRegistry) {
 	}
 }
 
-func makeKVLoadGroup(c Cluster, numRoachNodes, numLoadNodes int) loadGroup {
+func makeKVLoadGroup(c cluster2.Cluster, numRoachNodes, numLoadNodes int) loadGroup {
 	return loadGroup{
 		roachNodes: c.Range(1, numRoachNodes),
 		loadNodes:  c.Range(numRoachNodes+1, numRoachNodes+numLoadNodes),
@@ -192,7 +193,7 @@ func makeKVLoadGroup(c Cluster, numRoachNodes, numLoadNodes int) loadGroup {
 // This tool was primarily written with the objective of demonstrating the write
 // performance characteristics of using hash sharded indexes, for sequential workloads
 // which would've otherwise created a single-range hotspot.
-func runKVBench(ctx context.Context, t *test, c Cluster, b kvBenchSpec) {
+func runKVBench(ctx context.Context, t *test, c cluster2.Cluster, b kvBenchSpec) {
 	loadGroup := makeKVLoadGroup(c, b.Nodes, 1)
 	roachNodes := loadGroup.roachNodes
 	loadNodes := loadGroup.loadNodes

--- a/pkg/cmd/roachtest/ledger.go
+++ b/pkg/cmd/roachtest/ledger.go
@@ -33,7 +33,7 @@ func registerLedger(r *testRegistry) {
 
 			c.Put(ctx, cockroach, "./cockroach", roachNodes)
 			c.Put(ctx, workload, "./workload", loadNode)
-			c.Start(ctx, t, roachNodes)
+			c.Start(ctx, roachNodes)
 
 			t.Status("running workload")
 			m := newMonitor(ctx, c, roachNodes)

--- a/pkg/cmd/roachtest/ledger.go
+++ b/pkg/cmd/roachtest/ledger.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 )
 
@@ -26,7 +27,7 @@ func registerLedger(r *testRegistry) {
 		Name:    fmt.Sprintf("ledger/nodes=%d/multi-az", nodes),
 		Owner:   OwnerKV,
 		Cluster: r.makeClusterSpec(nodes+1, spec.CPU(16), spec.Geo(), spec.Zones(azs)),
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			roachNodes := c.Range(1, nodes)
 			gatewayNodes := c.Range(1, nodes/3)
 			loadNode := c.Node(nodes + 1)

--- a/pkg/cmd/roachtest/ledger.go
+++ b/pkg/cmd/roachtest/ledger.go
@@ -14,7 +14,7 @@ import (
 	"context"
 	"fmt"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 )
 
@@ -27,7 +27,7 @@ func registerLedger(r *testRegistry) {
 		Name:    fmt.Sprintf("ledger/nodes=%d/multi-az", nodes),
 		Owner:   OwnerKV,
 		Cluster: r.makeClusterSpec(nodes+1, spec.CPU(16), spec.Geo(), spec.Zones(azs)),
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			roachNodes := c.Range(1, nodes)
 			gatewayNodes := c.Range(1, nodes/3)
 			loadNode := c.Node(nodes + 1)

--- a/pkg/cmd/roachtest/libpq.go
+++ b/pkg/cmd/roachtest/libpq.go
@@ -16,7 +16,7 @@ import (
 	"regexp"
 	"strings"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,7 +24,7 @@ var libPQReleaseTagRegex = regexp.MustCompile(`^v(?P<major>\d+)\.(?P<minor>\d+)\
 var libPQSupportedTag = "v1.10.0"
 
 func registerLibPQ(r *testRegistry) {
-	runLibPQ := func(ctx context.Context, t *test, c cluster2.Cluster) {
+	runLibPQ := func(ctx context.Context, t *test, c cluster.Cluster) {
 		if c.IsLocal() {
 			t.Fatal("cannot be run in local mode")
 		}

--- a/pkg/cmd/roachtest/libpq.go
+++ b/pkg/cmd/roachtest/libpq.go
@@ -24,7 +24,7 @@ var libPQSupportedTag = "v1.10.0"
 
 func registerLibPQ(r *testRegistry) {
 	runLibPQ := func(ctx context.Context, t *test, c Cluster) {
-		if c.isLocal() {
+		if c.IsLocal() {
 			t.Fatal("cannot be run in local mode")
 		}
 		node := c.Node(1)

--- a/pkg/cmd/roachtest/libpq.go
+++ b/pkg/cmd/roachtest/libpq.go
@@ -16,6 +16,7 @@ import (
 	"regexp"
 	"strings"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/stretchr/testify/require"
 )
 
@@ -23,7 +24,7 @@ var libPQReleaseTagRegex = regexp.MustCompile(`^v(?P<major>\d+)\.(?P<minor>\d+)\
 var libPQSupportedTag = "v1.10.0"
 
 func registerLibPQ(r *testRegistry) {
-	runLibPQ := func(ctx context.Context, t *test, c Cluster) {
+	runLibPQ := func(ctx context.Context, t *test, c cluster2.Cluster) {
 		if c.IsLocal() {
 			t.Fatal("cannot be run in local mode")
 		}

--- a/pkg/cmd/roachtest/libpq.go
+++ b/pkg/cmd/roachtest/libpq.go
@@ -30,7 +30,7 @@ func registerLibPQ(r *testRegistry) {
 		node := c.Node(1)
 		t.Status("setting up cockroach")
 		c.Put(ctx, cockroach, "./cockroach", c.All())
-		c.Start(ctx, t, c.All())
+		c.Start(ctx, c.All())
 
 		version, err := fetchCockroachVersion(ctx, c, node[0], nil)
 		if err != nil {

--- a/pkg/cmd/roachtest/liquibase.go
+++ b/pkg/cmd/roachtest/liquibase.go
@@ -27,7 +27,7 @@ func registerLiquibase(r *testRegistry) {
 		node := c.Node(1)
 		t.Status("setting up cockroach")
 		c.Put(ctx, cockroach, "./cockroach", c.All())
-		c.Start(ctx, t, c.All())
+		c.Start(ctx, c.All())
 
 		version, err := fetchCockroachVersion(ctx, c, node[0], nil)
 		if err != nil {

--- a/pkg/cmd/roachtest/liquibase.go
+++ b/pkg/cmd/roachtest/liquibase.go
@@ -21,7 +21,7 @@ func registerLiquibase(r *testRegistry) {
 		t *test,
 		c Cluster,
 	) {
-		if c.isLocal() {
+		if c.IsLocal() {
 			t.Fatal("cannot be run in local mode")
 		}
 		node := c.Node(1)

--- a/pkg/cmd/roachtest/liquibase.go
+++ b/pkg/cmd/roachtest/liquibase.go
@@ -13,7 +13,7 @@ package main
 import (
 	"context"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 )
 
 var supportedLiquibaseHarnessTag = "liquibase-test-harness-1.0.1"
@@ -23,7 +23,7 @@ func registerLiquibase(r *testRegistry) {
 	runLiquibase := func(
 		ctx context.Context,
 		t *test,
-		c cluster2.Cluster,
+		c cluster.Cluster,
 	) {
 		if c.IsLocal() {
 			t.Fatal("cannot be run in local mode")
@@ -110,7 +110,7 @@ func registerLiquibase(r *testRegistry) {
 		Owner:      OwnerSQLExperience,
 		Cluster:    r.makeClusterSpec(1),
 		Tags:       []string{`default`, `tool`},
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runLiquibase(ctx, t, c)
 		},
 	})

--- a/pkg/cmd/roachtest/liquibase.go
+++ b/pkg/cmd/roachtest/liquibase.go
@@ -10,7 +10,11 @@
 
 package main
 
-import "context"
+import (
+	"context"
+
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+)
 
 var supportedLiquibaseHarnessTag = "liquibase-test-harness-1.0.1"
 
@@ -19,7 +23,7 @@ func registerLiquibase(r *testRegistry) {
 	runLiquibase := func(
 		ctx context.Context,
 		t *test,
-		c Cluster,
+		c cluster2.Cluster,
 	) {
 		if c.IsLocal() {
 			t.Fatal("cannot be run in local mode")
@@ -106,7 +110,7 @@ func registerLiquibase(r *testRegistry) {
 		Owner:      OwnerSQLExperience,
 		Cluster:    r.makeClusterSpec(1),
 		Tags:       []string{`default`, `tool`},
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runLiquibase(ctx, t, c)
 		},
 	})

--- a/pkg/cmd/roachtest/many_splits.go
+++ b/pkg/cmd/roachtest/many_splits.go
@@ -13,11 +13,13 @@ package main
 import (
 	"context"
 	"fmt"
+
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 )
 
 // runManySplits attempts to create 2000 tiny ranges on a 4-node cluster using
 // left-to-right splits and check the cluster is still live afterwards.
-func runManySplits(ctx context.Context, t *test, c Cluster) {
+func runManySplits(ctx context.Context, t *test, c cluster2.Cluster) {
 	// Randomize starting with encryption-at-rest enabled.
 	c.EncryptAtRandom(true)
 	args := startArgs("--env=COCKROACH_SCAN_MAX_IDLE_TIME=5ms")

--- a/pkg/cmd/roachtest/many_splits.go
+++ b/pkg/cmd/roachtest/many_splits.go
@@ -22,7 +22,7 @@ func runManySplits(ctx context.Context, t *test, c Cluster) {
 	c.EncryptAtRandom(true)
 	args := startArgs("--env=COCKROACH_SCAN_MAX_IDLE_TIME=5ms")
 	c.Put(ctx, cockroach, "./cockroach")
-	c.Start(ctx, t, args)
+	c.Start(ctx, args)
 
 	db := c.Conn(ctx, 1)
 	defer db.Close()

--- a/pkg/cmd/roachtest/many_splits.go
+++ b/pkg/cmd/roachtest/many_splits.go
@@ -14,12 +14,12 @@ import (
 	"context"
 	"fmt"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 )
 
 // runManySplits attempts to create 2000 tiny ranges on a 4-node cluster using
 // left-to-right splits and check the cluster is still live afterwards.
-func runManySplits(ctx context.Context, t *test, c cluster2.Cluster) {
+func runManySplits(ctx context.Context, t *test, c cluster.Cluster) {
 	// Randomize starting with encryption-at-rest enabled.
 	c.EncryptAtRandom(true)
 	args := startArgs("--env=COCKROACH_SCAN_MAX_IDLE_TIME=5ms")

--- a/pkg/cmd/roachtest/mixed_version_decommission.go
+++ b/pkg/cmd/roachtest/mixed_version_decommission.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"strconv"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
@@ -25,7 +26,7 @@ import (
 // runDecommissionMixedVersions runs through randomized
 // decommission/recommission processes in mixed-version clusters.
 func runDecommissionMixedVersions(
-	ctx context.Context, t *test, c Cluster, buildVersion version.Version,
+	ctx context.Context, t *test, c cluster2.Cluster, buildVersion version.Version,
 ) {
 	predecessorVersion, err := PredecessorVersion(buildVersion)
 	if err != nil {

--- a/pkg/cmd/roachtest/mixed_version_decommission.go
+++ b/pkg/cmd/roachtest/mixed_version_decommission.go
@@ -261,6 +261,6 @@ func uploadVersionStep(nodes option.NodeListOption, version string) versionStep 
 func startVersion(nodes option.NodeListOption, version string) versionStep {
 	return func(ctx context.Context, t *test, u *versionUpgradeTest) {
 		args := startArgs("--binary=" + cockroachBinaryPath(version))
-		u.c.Start(ctx, t, nodes, args, startArgsDontEncrypt)
+		u.c.Start(ctx, nodes, args, startArgsDontEncrypt)
 	}
 }

--- a/pkg/cmd/roachtest/mixed_version_decommission.go
+++ b/pkg/cmd/roachtest/mixed_version_decommission.go
@@ -15,7 +15,7 @@ import (
 	"fmt"
 	"strconv"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
@@ -26,7 +26,7 @@ import (
 // runDecommissionMixedVersions runs through randomized
 // decommission/recommission processes in mixed-version clusters.
 func runDecommissionMixedVersions(
-	ctx context.Context, t *test, c cluster2.Cluster, buildVersion version.Version,
+	ctx context.Context, t *test, c cluster.Cluster, buildVersion version.Version,
 ) {
 	predecessorVersion, err := PredecessorVersion(buildVersion)
 	if err != nil {

--- a/pkg/cmd/roachtest/mixed_version_jobs.go
+++ b/pkg/cmd/roachtest/mixed_version_jobs.go
@@ -15,7 +15,7 @@ import (
 	"fmt"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
@@ -226,7 +226,7 @@ FROM [SHOW JOBS] WHERE status = $1 OR status = $2`,
 }
 
 func runJobsMixedVersions(
-	ctx context.Context, t *test, c cluster2.Cluster, warehouses int, predecessorVersion string,
+	ctx context.Context, t *test, c cluster.Cluster, warehouses int, predecessorVersion string,
 ) {
 	// An empty string means that the cockroach binary specified by flag
 	// `cockroach` will be used.
@@ -335,7 +335,7 @@ func registerJobsMixedVersions(r *testRegistry) {
 		MinVersion: "v20.1.0",
 		Skip:       "https://github.com/cockroachdb/cockroach/issues/57230",
 		Cluster:    r.makeClusterSpec(4),
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			predV, err := PredecessorVersion(r.buildVersion)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/cmd/roachtest/mixed_version_jobs.go
+++ b/pkg/cmd/roachtest/mixed_version_jobs.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
@@ -225,7 +226,7 @@ FROM [SHOW JOBS] WHERE status = $1 OR status = $2`,
 }
 
 func runJobsMixedVersions(
-	ctx context.Context, t *test, c Cluster, warehouses int, predecessorVersion string,
+	ctx context.Context, t *test, c cluster2.Cluster, warehouses int, predecessorVersion string,
 ) {
 	// An empty string means that the cockroach binary specified by flag
 	// `cockroach` will be used.
@@ -334,7 +335,7 @@ func registerJobsMixedVersions(r *testRegistry) {
 		MinVersion: "v20.1.0",
 		Skip:       "https://github.com/cockroachdb/cockroach/issues/57230",
 		Cluster:    r.makeClusterSpec(4),
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			predV, err := PredecessorVersion(r.buildVersion)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/cmd/roachtest/mixed_version_schemachange.go
+++ b/pkg/cmd/roachtest/mixed_version_schemachange.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/version"
 )
 
@@ -26,7 +27,7 @@ func registerSchemaChangeMixedVersions(r *testRegistry) {
 		// order to prevent bugs during upgrades.
 		MinVersion: "v20.1.0",
 		Cluster:    r.makeClusterSpec(4),
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			maxOps := 100
 			concurrency := 5
 			if local {
@@ -71,7 +72,7 @@ func runSchemaChangeWorkloadStep(loadNode, maxOps, concurrency int) versionStep 
 func runSchemaChangeMixedVersions(
 	ctx context.Context,
 	t *test,
-	c Cluster,
+	c cluster2.Cluster,
 	maxOps int,
 	concurrency int,
 	buildVersion version.Version,

--- a/pkg/cmd/roachtest/mixed_version_schemachange.go
+++ b/pkg/cmd/roachtest/mixed_version_schemachange.go
@@ -14,7 +14,7 @@ import (
 	"context"
 	"fmt"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/version"
 )
 
@@ -27,7 +27,7 @@ func registerSchemaChangeMixedVersions(r *testRegistry) {
 		// order to prevent bugs during upgrades.
 		MinVersion: "v20.1.0",
 		Cluster:    r.makeClusterSpec(4),
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			maxOps := 100
 			concurrency := 5
 			if local {
@@ -72,7 +72,7 @@ func runSchemaChangeWorkloadStep(loadNode, maxOps, concurrency int) versionStep 
 func runSchemaChangeMixedVersions(
 	ctx context.Context,
 	t *test,
-	c cluster2.Cluster,
+	c cluster.Cluster,
 	maxOps int,
 	concurrency int,
 	buildVersion version.Version,

--- a/pkg/cmd/roachtest/multitenant.go
+++ b/pkg/cmd/roachtest/multitenant.go
@@ -14,12 +14,12 @@ import (
 	"context"
 	"path/filepath"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
-func runAcceptanceMultitenant(ctx context.Context, t *test, c cluster2.Cluster) {
+func runAcceptanceMultitenant(ctx context.Context, t *test, c cluster.Cluster) {
 	c.Put(ctx, cockroach, "./cockroach")
 
 	c.Start(ctx, c.All())

--- a/pkg/cmd/roachtest/multitenant.go
+++ b/pkg/cmd/roachtest/multitenant.go
@@ -14,11 +14,12 @@ import (
 	"context"
 	"path/filepath"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
-func runAcceptanceMultitenant(ctx context.Context, t *test, c Cluster) {
+func runAcceptanceMultitenant(ctx context.Context, t *test, c cluster2.Cluster) {
 	c.Put(ctx, cockroach, "./cockroach")
 
 	c.Start(ctx, c.All())

--- a/pkg/cmd/roachtest/multitenant.go
+++ b/pkg/cmd/roachtest/multitenant.go
@@ -21,7 +21,7 @@ import (
 func runAcceptanceMultitenant(ctx context.Context, t *test, c Cluster) {
 	c.Put(ctx, cockroach, "./cockroach")
 
-	c.Start(ctx, t, c.All())
+	c.Start(ctx, c.All())
 
 	const tenantID = 123
 	{

--- a/pkg/cmd/roachtest/multitenant_upgrade.go
+++ b/pkg/cmd/roachtest/multitenant_upgrade.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
@@ -34,7 +34,7 @@ func registerMultiTenantUpgrade(r *testRegistry) {
 		Cluster:           r.makeClusterSpec(2),
 		Owner:             OwnerKV,
 		NonReleaseBlocker: false,
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runMultiTenantUpgrade(ctx, t, c, r.buildVersion)
 		},
 	})
@@ -55,7 +55,7 @@ type tenantNode struct {
 func createTenantNode(
 	ctx context.Context,
 	t *test,
-	c cluster2.Cluster,
+	c cluster.Cluster,
 	binary string,
 	kvAddrs []string,
 	tenantID int,
@@ -74,7 +74,7 @@ func createTenantNode(
 	return tn
 }
 
-func (tn *tenantNode) stop(ctx context.Context, t *test, c cluster2.Cluster) {
+func (tn *tenantNode) stop(ctx context.Context, t *test, c cluster.Cluster) {
 	if tn.errCh == nil {
 		return
 	}
@@ -90,7 +90,7 @@ func (tn *tenantNode) logDir() string {
 	return fmt.Sprintf("logs/mt-%d", tn.tenantID)
 }
 
-func (tn *tenantNode) start(ctx context.Context, t *test, c cluster2.Cluster, binary string) {
+func (tn *tenantNode) start(ctx context.Context, t *test, c cluster.Cluster, binary string) {
 	tn.binary = binary
 	tn.errCh = startTenantServer(
 		ctx, c, c.Node(tn.node), binary, tn.kvAddrs, tn.tenantID,
@@ -156,7 +156,7 @@ func (tn *tenantNode) start(ctx context.Context, t *test, c cluster2.Cluster, bi
 //  * Tenant12{Binary: Cur, Cluster: Cur}: Restart tenant 13 and make sure it still works.
 //  * Tenant14{Binary: Cur, Cluster: Cur}: Create tenant 14 and verify it works.
 //  * Tenant12{Binary: Cur, Cluster: Cur}: Restart tenant 14 and make sure it still works.
-func runMultiTenantUpgrade(ctx context.Context, t *test, c cluster2.Cluster, v version.Version) {
+func runMultiTenantUpgrade(ctx context.Context, t *test, c cluster.Cluster, v version.Version) {
 	predecessor, err := PredecessorVersion(v)
 	require.NoError(t, err)
 
@@ -408,7 +408,7 @@ func runMultiTenantUpgrade(ctx context.Context, t *test, c cluster2.Cluster, v v
 
 func startTenantServer(
 	tenantCtx context.Context,
-	c cluster2.Cluster,
+	c cluster.Cluster,
 	node option.NodeListOption,
 	binary string,
 	kvAddrs []string,

--- a/pkg/cmd/roachtest/multitenant_upgrade.go
+++ b/pkg/cmd/roachtest/multitenant_upgrade.go
@@ -164,7 +164,7 @@ func runMultiTenantUpgrade(ctx context.Context, t *test, c Cluster, v version.Ve
 
 	kvNodes := c.Node(1)
 
-	c.Start(ctx, t, kvNodes, startArgs("--binary="+predecessorBinary))
+	c.Start(ctx, kvNodes, startArgs("--binary="+predecessorBinary))
 
 	kvAddrs, err := c.ExternalAddr(ctx, kvNodes)
 	require.NoError(t, err)
@@ -228,7 +228,7 @@ func runMultiTenantUpgrade(ctx context.Context, t *test, c Cluster, v version.Ve
 
 	t.Status("upgrading host server")
 	c.Stop(ctx, kvNodes)
-	c.Start(ctx, t, kvNodes, startArgs("--binary="+currentBinary))
+	c.Start(ctx, kvNodes, startArgs("--binary="+currentBinary))
 	time.Sleep(time.Second)
 
 	t.Status("checking the pre-upgrade sql server still works after the KV binary upgrade")

--- a/pkg/cmd/roachtest/network.go
+++ b/pkg/cmd/roachtest/network.go
@@ -18,7 +18,7 @@ import (
 	"time"
 
 	toxiproxy "github.com/Shopify/toxiproxy/client"
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	_ "github.com/lib/pq"
 )
@@ -26,7 +26,7 @@ import (
 // runNetworkSanity is just a sanity check to make sure we're setting up toxiproxy
 // correctly. It injects latency between the nodes and verifies that we're not
 // seeing the latency on the client connection running `SELECT 1` on each node.
-func runNetworkSanity(ctx context.Context, t *test, origC cluster2.Cluster, nodes int) {
+func runNetworkSanity(ctx context.Context, t *test, origC cluster.Cluster, nodes int) {
 	origC.Put(ctx, cockroach, "./cockroach", origC.All())
 	c, err := Toxify(ctx, t, origC, origC.All())
 	if err != nil {
@@ -96,7 +96,7 @@ select age, message from [ show trace for session ];
 	m.Wait()
 }
 
-func runNetworkTPCC(ctx context.Context, t *test, origC cluster2.Cluster, nodes int) {
+func runNetworkTPCC(ctx context.Context, t *test, origC cluster.Cluster, nodes int) {
 	n := origC.Spec().NodeCount
 	serverNodes, workerNode := origC.Range(1, n-1), origC.Node(n)
 	origC.Put(ctx, cockroach, "./cockroach", origC.All())
@@ -241,7 +241,7 @@ func registerNetwork(r *testRegistry) {
 		Name:    fmt.Sprintf("network/sanity/nodes=%d", numNodes),
 		Owner:   OwnerKV,
 		Cluster: r.makeClusterSpec(numNodes),
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runNetworkSanity(ctx, t, c, numNodes)
 		},
 	})
@@ -271,7 +271,7 @@ there to resolve the partition when the test aborts prematurely. (And the
 command to resolve the partition should not be sensitive to the test
 context's Done() channel, because during a tear-down that is closed already)
 `,
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runNetworkTPCC(ctx, t, c, numNodes)
 		},
 	})

--- a/pkg/cmd/roachtest/network.go
+++ b/pkg/cmd/roachtest/network.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	toxiproxy "github.com/Shopify/toxiproxy/client"
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	_ "github.com/lib/pq"
 )
@@ -25,7 +26,7 @@ import (
 // runNetworkSanity is just a sanity check to make sure we're setting up toxiproxy
 // correctly. It injects latency between the nodes and verifies that we're not
 // seeing the latency on the client connection running `SELECT 1` on each node.
-func runNetworkSanity(ctx context.Context, t *test, origC Cluster, nodes int) {
+func runNetworkSanity(ctx context.Context, t *test, origC cluster2.Cluster, nodes int) {
 	origC.Put(ctx, cockroach, "./cockroach", origC.All())
 	c, err := Toxify(ctx, t, origC, origC.All())
 	if err != nil {
@@ -95,7 +96,7 @@ select age, message from [ show trace for session ];
 	m.Wait()
 }
 
-func runNetworkTPCC(ctx context.Context, t *test, origC Cluster, nodes int) {
+func runNetworkTPCC(ctx context.Context, t *test, origC cluster2.Cluster, nodes int) {
 	n := origC.Spec().NodeCount
 	serverNodes, workerNode := origC.Range(1, n-1), origC.Node(n)
 	origC.Put(ctx, cockroach, "./cockroach", origC.All())
@@ -240,7 +241,7 @@ func registerNetwork(r *testRegistry) {
 		Name:    fmt.Sprintf("network/sanity/nodes=%d", numNodes),
 		Owner:   OwnerKV,
 		Cluster: r.makeClusterSpec(numNodes),
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runNetworkSanity(ctx, t, c, numNodes)
 		},
 	})
@@ -270,7 +271,7 @@ there to resolve the partition when the test aborts prematurely. (And the
 command to resolve the partition should not be sensitive to the test
 context's Done() channel, because during a tear-down that is closed already)
 `,
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runNetworkTPCC(ctx, t, c, numNodes)
 		},
 	})

--- a/pkg/cmd/roachtest/network.go
+++ b/pkg/cmd/roachtest/network.go
@@ -32,7 +32,7 @@ func runNetworkSanity(ctx context.Context, t *test, origC Cluster, nodes int) {
 		t.Fatal(err)
 	}
 
-	c.Start(ctx, t, c.All())
+	c.Start(ctx, c.All())
 
 	db := c.Conn(ctx, 1) // unaffected by toxiproxy
 	defer db.Close()
@@ -107,7 +107,7 @@ func runNetworkTPCC(ctx context.Context, t *test, origC Cluster, nodes int) {
 	}
 
 	const warehouses = 1
-	c.Start(ctx, t, serverNodes)
+	c.Start(ctx, serverNodes)
 	c.Run(ctx, c.Node(1), tpccImportCmd(warehouses))
 
 	db := c.Conn(ctx, 1)

--- a/pkg/cmd/roachtest/nodejs_postgres.go
+++ b/pkg/cmd/roachtest/nodejs_postgres.go
@@ -17,6 +17,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/stretchr/testify/require"
 )
 
@@ -30,7 +31,7 @@ func registerNodeJSPostgres(r *testRegistry) {
 	runNodeJSPostgres := func(
 		ctx context.Context,
 		t *test,
-		c Cluster,
+		c cluster2.Cluster,
 	) {
 		if c.IsLocal() {
 			t.Fatal("cannot be run in local mode")
@@ -184,7 +185,7 @@ PGSSLCERT=%s/client.%s.crt PGSSLKEY=%s/client.%s.key PGSSLROOTCERT=%s/ca.crt yar
 		Cluster:    r.makeClusterSpec(1),
 		MinVersion: "v20.1.0",
 		Tags:       []string{`default`, `driver`},
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runNodeJSPostgres(ctx, t, c)
 		},
 	})

--- a/pkg/cmd/roachtest/nodejs_postgres.go
+++ b/pkg/cmd/roachtest/nodejs_postgres.go
@@ -32,7 +32,7 @@ func registerNodeJSPostgres(r *testRegistry) {
 		t *test,
 		c Cluster,
 	) {
-		if c.isLocal() {
+		if c.IsLocal() {
 			t.Fatal("cannot be run in local mode")
 		}
 		node := c.Node(1)

--- a/pkg/cmd/roachtest/nodejs_postgres.go
+++ b/pkg/cmd/roachtest/nodejs_postgres.go
@@ -17,7 +17,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/stretchr/testify/require"
 )
 
@@ -31,7 +31,7 @@ func registerNodeJSPostgres(r *testRegistry) {
 	runNodeJSPostgres := func(
 		ctx context.Context,
 		t *test,
-		c cluster2.Cluster,
+		c cluster.Cluster,
 	) {
 		if c.IsLocal() {
 			t.Fatal("cannot be run in local mode")
@@ -185,7 +185,7 @@ PGSSLCERT=%s/client.%s.crt PGSSLKEY=%s/client.%s.key PGSSLROOTCERT=%s/ca.crt yar
 		Cluster:    r.makeClusterSpec(1),
 		MinVersion: "v20.1.0",
 		Tags:       []string{`default`, `driver`},
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runNodeJSPostgres(ctx, t, c)
 		},
 	})

--- a/pkg/cmd/roachtest/orm_helpers.go
+++ b/pkg/cmd/roachtest/orm_helpers.go
@@ -16,6 +16,8 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 )
 
 // alterZoneConfigAndClusterSettings changes the zone configurations so that GC
@@ -26,7 +28,7 @@ import (
 func alterZoneConfigAndClusterSettings(
 	ctx context.Context,
 	version string,
-	c Cluster,
+	c cluster2.Cluster,
 	nodeIdx int,
 	dbConnectionParams *SecureDBConnectionParams,
 ) error {

--- a/pkg/cmd/roachtest/orm_helpers.go
+++ b/pkg/cmd/roachtest/orm_helpers.go
@@ -17,7 +17,7 @@ import (
 	"sort"
 	"strings"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 )
 
 // alterZoneConfigAndClusterSettings changes the zone configurations so that GC
@@ -28,7 +28,7 @@ import (
 func alterZoneConfigAndClusterSettings(
 	ctx context.Context,
 	version string,
-	c cluster2.Cluster,
+	c cluster.Cluster,
 	nodeIdx int,
 	dbConnectionParams *SecureDBConnectionParams,
 ) error {

--- a/pkg/cmd/roachtest/overload_tpcc_olap.go
+++ b/pkg/cmd/roachtest/overload_tpcc_olap.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/ts/tspb"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
@@ -43,7 +44,7 @@ type tpccOLAPSpec struct {
 	Concurrency int
 }
 
-func (s tpccOLAPSpec) run(ctx context.Context, t *test, c Cluster) {
+func (s tpccOLAPSpec) run(ctx context.Context, t *test, c cluster2.Cluster) {
 	crdbNodes, workloadNode := setupTPCC(
 		ctx, t, c, tpccOptions{
 			Warehouses: s.Warehouses, SetupType: usingImport,
@@ -75,7 +76,9 @@ func (s tpccOLAPSpec) run(ctx context.Context, t *test, c Cluster) {
 
 // Check that node liveness did not fail more than maxFailures times across
 // all of the nodes.
-func verifyNodeLiveness(ctx context.Context, c Cluster, t *test, runDuration time.Duration) {
+func verifyNodeLiveness(
+	ctx context.Context, c cluster2.Cluster, t *test, runDuration time.Duration,
+) {
 	const maxFailures = 10
 	adminURLs, err := c.ExternalAdminUIAddr(ctx, c.Node(1))
 	if err != nil {

--- a/pkg/cmd/roachtest/overload_tpcc_olap.go
+++ b/pkg/cmd/roachtest/overload_tpcc_olap.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/ts/tspb"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
@@ -44,7 +44,7 @@ type tpccOLAPSpec struct {
 	Concurrency int
 }
 
-func (s tpccOLAPSpec) run(ctx context.Context, t *test, c cluster2.Cluster) {
+func (s tpccOLAPSpec) run(ctx context.Context, t *test, c cluster.Cluster) {
 	crdbNodes, workloadNode := setupTPCC(
 		ctx, t, c, tpccOptions{
 			Warehouses: s.Warehouses, SetupType: usingImport,
@@ -77,7 +77,7 @@ func (s tpccOLAPSpec) run(ctx context.Context, t *test, c cluster2.Cluster) {
 // Check that node liveness did not fail more than maxFailures times across
 // all of the nodes.
 func verifyNodeLiveness(
-	ctx context.Context, c cluster2.Cluster, t *test, runDuration time.Duration,
+	ctx context.Context, c cluster.Cluster, t *test, runDuration time.Duration,
 ) {
 	const maxFailures = 10
 	adminURLs, err := c.ExternalAdminUIAddr(ctx, c.Node(1))

--- a/pkg/cmd/roachtest/pebble.go
+++ b/pkg/cmd/roachtest/pebble.go
@@ -17,7 +17,7 @@ import (
 	"path/filepath"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 )
 
@@ -27,7 +27,7 @@ func registerPebble(r *testRegistry) {
 		pebble = "./pebble.linux"
 	}
 
-	run := func(ctx context.Context, t *test, c cluster2.Cluster, size int) {
+	run := func(ctx context.Context, t *test, c cluster.Cluster, size int) {
 		c.Put(ctx, pebble, "./pebble")
 
 		const initialKeys = 10_000_000
@@ -110,7 +110,7 @@ func registerPebble(r *testRegistry) {
 			MinVersion: "v20.1.0",
 			Cluster:    r.makeClusterSpec(5, spec.CPU(16)),
 			Tags:       []string{"pebble"},
-			Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+			Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 				run(ctx, t, c, size)
 			},
 		})

--- a/pkg/cmd/roachtest/pebble.go
+++ b/pkg/cmd/roachtest/pebble.go
@@ -17,6 +17,7 @@ import (
 	"path/filepath"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 )
 
@@ -26,7 +27,7 @@ func registerPebble(r *testRegistry) {
 		pebble = "./pebble.linux"
 	}
 
-	run := func(ctx context.Context, t *test, c Cluster, size int) {
+	run := func(ctx context.Context, t *test, c cluster2.Cluster, size int) {
 		c.Put(ctx, pebble, "./pebble")
 
 		const initialKeys = 10_000_000
@@ -109,7 +110,7 @@ func registerPebble(r *testRegistry) {
 			MinVersion: "v20.1.0",
 			Cluster:    r.makeClusterSpec(5, spec.CPU(16)),
 			Tags:       []string{"pebble"},
-			Run: func(ctx context.Context, t *test, c Cluster) {
+			Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 				run(ctx, t, c, size)
 			},
 		})

--- a/pkg/cmd/roachtest/pgjdbc.go
+++ b/pkg/cmd/roachtest/pgjdbc.go
@@ -33,7 +33,7 @@ func registerPgjdbc(r *testRegistry) {
 		node := c.Node(1)
 		t.Status("setting up cockroach")
 		c.Put(ctx, cockroach, "./cockroach", c.All())
-		c.Start(ctx, t, c.All())
+		c.Start(ctx, c.All())
 
 		version, err := fetchCockroachVersion(ctx, c, node[0], nil)
 		if err != nil {

--- a/pkg/cmd/roachtest/pgjdbc.go
+++ b/pkg/cmd/roachtest/pgjdbc.go
@@ -15,7 +15,7 @@ import (
 	"fmt"
 	"regexp"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 )
 
 var pgjdbcReleaseTagRegex = regexp.MustCompile(`^REL(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)$`)
@@ -27,7 +27,7 @@ func registerPgjdbc(r *testRegistry) {
 	runPgjdbc := func(
 		ctx context.Context,
 		t *test,
-		c cluster2.Cluster,
+		c cluster.Cluster,
 	) {
 		if c.IsLocal() {
 			t.Fatal("cannot be run in local mode")
@@ -194,7 +194,7 @@ func registerPgjdbc(r *testRegistry) {
 		Owner:      OwnerSQLExperience,
 		Cluster:    r.makeClusterSpec(1),
 		Tags:       []string{`default`, `driver`},
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runPgjdbc(ctx, t, c)
 		},
 	})

--- a/pkg/cmd/roachtest/pgjdbc.go
+++ b/pkg/cmd/roachtest/pgjdbc.go
@@ -14,6 +14,8 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 )
 
 var pgjdbcReleaseTagRegex = regexp.MustCompile(`^REL(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)$`)
@@ -25,7 +27,7 @@ func registerPgjdbc(r *testRegistry) {
 	runPgjdbc := func(
 		ctx context.Context,
 		t *test,
-		c Cluster,
+		c cluster2.Cluster,
 	) {
 		if c.IsLocal() {
 			t.Fatal("cannot be run in local mode")
@@ -192,7 +194,7 @@ func registerPgjdbc(r *testRegistry) {
 		Owner:      OwnerSQLExperience,
 		Cluster:    r.makeClusterSpec(1),
 		Tags:       []string{`default`, `driver`},
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runPgjdbc(ctx, t, c)
 		},
 	})

--- a/pkg/cmd/roachtest/pgjdbc.go
+++ b/pkg/cmd/roachtest/pgjdbc.go
@@ -27,7 +27,7 @@ func registerPgjdbc(r *testRegistry) {
 		t *test,
 		c Cluster,
 	) {
-		if c.isLocal() {
+		if c.IsLocal() {
 			t.Fatal("cannot be run in local mode")
 		}
 		node := c.Node(1)

--- a/pkg/cmd/roachtest/pgx.go
+++ b/pkg/cmd/roachtest/pgx.go
@@ -15,7 +15,7 @@ import (
 	"fmt"
 	"regexp"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 )
 
 var pgxReleaseTagRegex = regexp.MustCompile(`^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)$`)
@@ -27,7 +27,7 @@ func registerPgx(r *testRegistry) {
 	runPgx := func(
 		ctx context.Context,
 		t *test,
-		c cluster2.Cluster,
+		c cluster.Cluster,
 	) {
 		if c.IsLocal() {
 			t.Fatal("cannot be run in local mode")
@@ -131,7 +131,7 @@ func registerPgx(r *testRegistry) {
 		Cluster:    r.makeClusterSpec(1),
 		MinVersion: "v20.2.0",
 		Tags:       []string{`default`, `driver`},
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runPgx(ctx, t, c)
 		},
 	})

--- a/pkg/cmd/roachtest/pgx.go
+++ b/pkg/cmd/roachtest/pgx.go
@@ -14,6 +14,8 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 )
 
 var pgxReleaseTagRegex = regexp.MustCompile(`^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)$`)
@@ -25,7 +27,7 @@ func registerPgx(r *testRegistry) {
 	runPgx := func(
 		ctx context.Context,
 		t *test,
-		c Cluster,
+		c cluster2.Cluster,
 	) {
 		if c.IsLocal() {
 			t.Fatal("cannot be run in local mode")
@@ -129,7 +131,7 @@ func registerPgx(r *testRegistry) {
 		Cluster:    r.makeClusterSpec(1),
 		MinVersion: "v20.2.0",
 		Tags:       []string{`default`, `driver`},
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runPgx(ctx, t, c)
 		},
 	})

--- a/pkg/cmd/roachtest/pgx.go
+++ b/pkg/cmd/roachtest/pgx.go
@@ -27,7 +27,7 @@ func registerPgx(r *testRegistry) {
 		t *test,
 		c Cluster,
 	) {
-		if c.isLocal() {
+		if c.IsLocal() {
 			t.Fatal("cannot be run in local mode")
 		}
 		node := c.Node(1)

--- a/pkg/cmd/roachtest/pgx.go
+++ b/pkg/cmd/roachtest/pgx.go
@@ -33,7 +33,7 @@ func registerPgx(r *testRegistry) {
 		node := c.Node(1)
 		t.Status("setting up cockroach")
 		c.Put(ctx, cockroach, "./cockroach", c.All())
-		c.Start(ctx, t, c.All())
+		c.Start(ctx, c.All())
 
 		version, err := fetchCockroachVersion(ctx, c, node[0], nil)
 		if err != nil {

--- a/pkg/cmd/roachtest/pop.go
+++ b/pkg/cmd/roachtest/pop.go
@@ -23,7 +23,7 @@ var popSupportedTag = "v5.3.3"
 
 func registerPop(r *testRegistry) {
 	runPop := func(ctx context.Context, t *test, c Cluster) {
-		if c.isLocal() {
+		if c.IsLocal() {
 			t.Fatal("cannot be run in local mode")
 		}
 		node := c.Node(1)

--- a/pkg/cmd/roachtest/pop.go
+++ b/pkg/cmd/roachtest/pop.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"regexp"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,7 +23,7 @@ var popReleaseTag = regexp.MustCompile(`^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<po
 var popSupportedTag = "v5.3.3"
 
 func registerPop(r *testRegistry) {
-	runPop := func(ctx context.Context, t *test, c Cluster) {
+	runPop := func(ctx context.Context, t *test, c cluster2.Cluster) {
 		if c.IsLocal() {
 			t.Fatal("cannot be run in local mode")
 		}

--- a/pkg/cmd/roachtest/pop.go
+++ b/pkg/cmd/roachtest/pop.go
@@ -15,7 +15,7 @@ import (
 	"fmt"
 	"regexp"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/stretchr/testify/require"
 )
 
@@ -23,7 +23,7 @@ var popReleaseTag = regexp.MustCompile(`^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<po
 var popSupportedTag = "v5.3.3"
 
 func registerPop(r *testRegistry) {
-	runPop := func(ctx context.Context, t *test, c cluster2.Cluster) {
+	runPop := func(ctx context.Context, t *test, c cluster.Cluster) {
 		if c.IsLocal() {
 			t.Fatal("cannot be run in local mode")
 		}

--- a/pkg/cmd/roachtest/pop.go
+++ b/pkg/cmd/roachtest/pop.go
@@ -29,7 +29,7 @@ func registerPop(r *testRegistry) {
 		node := c.Node(1)
 		t.Status("setting up cockroach")
 		c.Put(ctx, cockroach, "./cockroach", c.All())
-		c.Start(ctx, t, c.All())
+		c.Start(ctx, c.All())
 		version, err := fetchCockroachVersion(ctx, c, node[0], nil)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/cmd/roachtest/psycopg.go
+++ b/pkg/cmd/roachtest/psycopg.go
@@ -13,6 +13,8 @@ package main
 import (
 	"context"
 	"regexp"
+
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 )
 
 var psycopgReleaseTagRegex = regexp.MustCompile(`^(?P<major>\d+)(?:_(?P<minor>\d+)(?:_(?P<point>\d+)(?:_(?P<subpoint>\d+))?)?)?$`)
@@ -23,7 +25,7 @@ func registerPsycopg(r *testRegistry) {
 	runPsycopg := func(
 		ctx context.Context,
 		t *test,
-		c Cluster,
+		c cluster2.Cluster,
 	) {
 		if c.IsLocal() {
 			t.Fatal("cannot be run in local mode")
@@ -134,7 +136,7 @@ func registerPsycopg(r *testRegistry) {
 		Cluster:    r.makeClusterSpec(1),
 		MinVersion: "v20.2.0",
 		Tags:       []string{`default`, `driver`},
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runPsycopg(ctx, t, c)
 		},
 	})

--- a/pkg/cmd/roachtest/psycopg.go
+++ b/pkg/cmd/roachtest/psycopg.go
@@ -14,7 +14,7 @@ import (
 	"context"
 	"regexp"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 )
 
 var psycopgReleaseTagRegex = regexp.MustCompile(`^(?P<major>\d+)(?:_(?P<minor>\d+)(?:_(?P<point>\d+)(?:_(?P<subpoint>\d+))?)?)?$`)
@@ -25,7 +25,7 @@ func registerPsycopg(r *testRegistry) {
 	runPsycopg := func(
 		ctx context.Context,
 		t *test,
-		c cluster2.Cluster,
+		c cluster.Cluster,
 	) {
 		if c.IsLocal() {
 			t.Fatal("cannot be run in local mode")
@@ -136,7 +136,7 @@ func registerPsycopg(r *testRegistry) {
 		Cluster:    r.makeClusterSpec(1),
 		MinVersion: "v20.2.0",
 		Tags:       []string{`default`, `driver`},
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runPsycopg(ctx, t, c)
 		},
 	})

--- a/pkg/cmd/roachtest/psycopg.go
+++ b/pkg/cmd/roachtest/psycopg.go
@@ -25,7 +25,7 @@ func registerPsycopg(r *testRegistry) {
 		t *test,
 		c Cluster,
 	) {
-		if c.isLocal() {
+		if c.IsLocal() {
 			t.Fatal("cannot be run in local mode")
 		}
 		node := c.Node(1)

--- a/pkg/cmd/roachtest/psycopg.go
+++ b/pkg/cmd/roachtest/psycopg.go
@@ -31,7 +31,7 @@ func registerPsycopg(r *testRegistry) {
 		node := c.Node(1)
 		t.Status("setting up cockroach")
 		c.Put(ctx, cockroach, "./cockroach", c.All())
-		c.Start(ctx, t, c.All())
+		c.Start(ctx, c.All())
 
 		version, err := fetchCockroachVersion(ctx, c, node[0], nil)
 		if err != nil {

--- a/pkg/cmd/roachtest/queue.go
+++ b/pkg/cmd/roachtest/queue.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
@@ -27,13 +28,13 @@ func registerQueue(r *testRegistry) {
 		Name:    fmt.Sprintf("queue/nodes=%d", numNodes-1),
 		Owner:   OwnerKV,
 		Cluster: r.makeClusterSpec(numNodes),
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runQueue(ctx, t, c)
 		},
 	})
 }
 
-func runQueue(ctx context.Context, t *test, c Cluster) {
+func runQueue(ctx context.Context, t *test, c cluster2.Cluster) {
 	dbNodeCount := c.Spec().NodeCount - 1
 	workloadNode := c.Spec().NodeCount
 

--- a/pkg/cmd/roachtest/queue.go
+++ b/pkg/cmd/roachtest/queue.go
@@ -40,7 +40,7 @@ func runQueue(ctx context.Context, t *test, c Cluster) {
 	// Distribute programs to the correct nodes and start CockroachDB.
 	c.Put(ctx, cockroach, "./cockroach", c.Range(1, dbNodeCount))
 	c.Put(ctx, workload, "./workload", c.Node(workloadNode))
-	c.Start(ctx, t, c.Range(1, dbNodeCount))
+	c.Start(ctx, c.Range(1, dbNodeCount))
 
 	runQueueWorkload := func(duration time.Duration, initTables bool) {
 		m := newMonitor(ctx, c, c.Range(1, dbNodeCount))

--- a/pkg/cmd/roachtest/queue.go
+++ b/pkg/cmd/roachtest/queue.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
@@ -28,13 +28,13 @@ func registerQueue(r *testRegistry) {
 		Name:    fmt.Sprintf("queue/nodes=%d", numNodes-1),
 		Owner:   OwnerKV,
 		Cluster: r.makeClusterSpec(numNodes),
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runQueue(ctx, t, c)
 		},
 	})
 }
 
-func runQueue(ctx context.Context, t *test, c cluster2.Cluster) {
+func runQueue(ctx context.Context, t *test, c cluster.Cluster) {
 	dbNodeCount := c.Spec().NodeCount - 1
 	workloadNode := c.Spec().NodeCount
 

--- a/pkg/cmd/roachtest/quit.go
+++ b/pkg/cmd/roachtest/quit.go
@@ -53,7 +53,7 @@ func (q *quitTest) init(ctx context.Context) {
 		"-a", "--vmodule=store=1,replica=1,replica_proposal=1", // verbosity to troubleshoot drains
 	)
 	q.c.Put(ctx, cockroach, "./cockroach")
-	q.c.Start(ctx, q.t, q.args)
+	q.c.Start(ctx, q.args)
 }
 
 func (q *quitTest) Fatal(args ...interface{}) {
@@ -94,7 +94,7 @@ func (q *quitTest) runTest(
 // restartNode restarts one node and waits until it's up and ready to
 // accept clients.
 func (q *quitTest) restartNode(ctx context.Context, nodeID int) {
-	q.c.Start(ctx, q.t, q.args, q.c.Node(nodeID))
+	q.c.Start(ctx, q.args, q.c.Node(nodeID))
 
 	q.t.l.Printf("waiting for readiness of node %d\n", nodeID)
 	// Now perform a SQL query. This achieves two goals:
@@ -455,7 +455,7 @@ func registerQuitAllNodes(r *testRegistry) {
 			// At the end, restart all nodes. We do this to check that
 			// the cluster can indeed restart, and also to please
 			// the dead node detection check at the end of each test.
-			q.c.Start(ctx, q.t, q.args)
+			q.c.Start(ctx, q.args)
 		},
 	})
 }

--- a/pkg/cmd/roachtest/quit.go
+++ b/pkg/cmd/roachtest/quit.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
@@ -28,7 +28,7 @@ import (
 
 type quitTest struct {
 	t    *test
-	c    cluster2.Cluster
+	c    cluster.Cluster
 	args option.Option
 }
 
@@ -39,9 +39,9 @@ type quitTest struct {
 func runQuitTransfersLeases(
 	ctx context.Context,
 	t *test,
-	c cluster2.Cluster,
+	c cluster.Cluster,
 	methodName string,
-	method func(ctx context.Context, t *test, c cluster2.Cluster, nodeID int),
+	method func(ctx context.Context, t *test, c cluster.Cluster, nodeID int),
 ) {
 	q := quitTest{t: t, c: c}
 	q.init(ctx)
@@ -66,7 +66,7 @@ func (q *quitTest) Fatalf(format string, args ...interface{}) {
 }
 
 func (q *quitTest) runTest(
-	ctx context.Context, method func(ctx context.Context, t *test, c cluster2.Cluster, nodeID int),
+	ctx context.Context, method func(ctx context.Context, t *test, c cluster.Cluster, nodeID int),
 ) {
 	q.waitForUpReplication(ctx)
 	q.createRanges(ctx)
@@ -336,13 +336,13 @@ func (q *quitTest) checkNoLeases(ctx context.Context, nodeID int) {
 }
 
 func registerQuitTransfersLeases(r *testRegistry) {
-	registerTest := func(name, minver string, method func(context.Context, *test, cluster2.Cluster, int)) {
+	registerTest := func(name, minver string, method func(context.Context, *test, cluster.Cluster, int)) {
 		r.Add(testSpec{
 			Name:       fmt.Sprintf("transfer-leases/%s", name),
 			Owner:      OwnerKV,
 			Cluster:    r.makeClusterSpec(3),
 			MinVersion: minver,
-			Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+			Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 				runQuitTransfersLeases(ctx, t, c, name, method)
 			},
 		})
@@ -350,7 +350,7 @@ func registerQuitTransfersLeases(r *testRegistry) {
 
 	// Uses 'roachprod stop --sig 15 --wait', ie send SIGTERM and wait
 	// until the process exits.
-	registerTest("signal", "v19.2.0", func(ctx context.Context, t *test, c cluster2.Cluster, nodeID int) {
+	registerTest("signal", "v19.2.0", func(ctx context.Context, t *test, c cluster.Cluster, nodeID int) {
 		c.Stop(ctx, c.Node(nodeID),
 			roachprodArgOption{"--sig", "15", "--wait"}, // graceful shutdown
 		)
@@ -358,14 +358,14 @@ func registerQuitTransfersLeases(r *testRegistry) {
 
 	// Uses 'cockroach quit' which should drain and then request a
 	// shutdown. It then waits for the process to self-exit.
-	registerTest("quit", "v19.2.0", func(ctx context.Context, t *test, c cluster2.Cluster, nodeID int) {
+	registerTest("quit", "v19.2.0", func(ctx context.Context, t *test, c cluster.Cluster, nodeID int) {
 		_ = runQuit(ctx, t, c, nodeID)
 	})
 
 	// Uses 'cockroach drain', followed by a non-graceful process
 	// kill. If the drain is successful, the leases are transferred
 	// successfully even if if the process terminates non-gracefully.
-	registerTest("drain", "v20.1.0", func(ctx context.Context, t *test, c cluster2.Cluster, nodeID int) {
+	registerTest("drain", "v20.1.0", func(ctx context.Context, t *test, c cluster.Cluster, nodeID int) {
 		buf, err := c.RunWithBuffer(ctx, t.l, c.Node(nodeID),
 			"./cockroach", "node", "drain", "--insecure", "--logtostderr=INFO",
 			fmt.Sprintf("--port={pgport:%d}", nodeID),
@@ -398,7 +398,7 @@ func registerQuitTransfersLeases(r *testRegistry) {
 }
 
 func runQuit(
-	ctx context.Context, t *test, c cluster2.Cluster, nodeID int, extraArgs ...string,
+	ctx context.Context, t *test, c cluster.Cluster, nodeID int, extraArgs ...string,
 ) []byte {
 	args := append([]string{
 		"./cockroach", "quit", "--insecure", "--logtostderr=INFO",
@@ -424,7 +424,7 @@ func registerQuitAllNodes(r *testRegistry) {
 		Owner:      OwnerServer,
 		Cluster:    r.makeClusterSpec(5),
 		MinVersion: "v20.1.0",
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			q := quitTest{t: t, c: c}
 
 			// Start the cluster.

--- a/pkg/cmd/roachtest/rapid_restart.go
+++ b/pkg/cmd/roachtest/rapid_restart.go
@@ -17,14 +17,14 @@ import (
 	"os/exec"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/cockroachdb/cockroach/pkg/util/sysutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
 
-func runRapidRestart(ctx context.Context, t *test, c cluster2.Cluster) {
+func runRapidRestart(ctx context.Context, t *test, c cluster.Cluster) {
 	// Use a single-node cluster which speeds the stop/start cycle.
 	nodes := c.Node(1)
 	c.Put(ctx, cockroach, "./cockroach", nodes)

--- a/pkg/cmd/roachtest/rapid_restart.go
+++ b/pkg/cmd/roachtest/rapid_restart.go
@@ -17,13 +17,14 @@ import (
 	"os/exec"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/cockroachdb/cockroach/pkg/util/sysutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
 
-func runRapidRestart(ctx context.Context, t *test, c Cluster) {
+func runRapidRestart(ctx context.Context, t *test, c cluster2.Cluster) {
 	// Use a single-node cluster which speeds the stop/start cycle.
 	nodes := c.Node(1)
 	c.Put(ctx, cockroach, "./cockroach", nodes)

--- a/pkg/cmd/roachtest/rebalance_load.go
+++ b/pkg/cmd/roachtest/rebalance_load.go
@@ -55,7 +55,7 @@ func registerRebalanceLoad(r *testRegistry) {
 		c.Put(ctx, cockroach, "./cockroach", roachNodes)
 		args := startArgs(
 			"--args=--vmodule=store_rebalancer=5,allocator=5,allocator_scorer=5,replicate_queue=5")
-		c.Start(ctx, t, roachNodes, args)
+		c.Start(ctx, roachNodes, args)
 
 		c.Put(ctx, workload, "./workload", appNode)
 		c.Run(ctx, appNode, fmt.Sprintf("./workload init kv --drop --splits=%d {pgurl:1}", splits))

--- a/pkg/cmd/roachtest/rebalance_load.go
+++ b/pkg/cmd/roachtest/rebalance_load.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/logger"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
@@ -43,7 +44,7 @@ func registerRebalanceLoad(r *testRegistry) {
 	rebalanceLoadRun := func(
 		ctx context.Context,
 		t *test,
-		c Cluster,
+		c cluster2.Cluster,
 		rebalanceMode string,
 		maxDuration time.Duration,
 		concurrency int,
@@ -131,7 +132,7 @@ func registerRebalanceLoad(r *testRegistry) {
 		Owner:      OwnerKV,
 		Cluster:    r.makeClusterSpec(4), // the last node is just used to generate load
 		MinVersion: "v2.1.0",
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			if local {
 				concurrency = 32
 				fmt.Printf("lowering concurrency to %d in local testing\n", concurrency)
@@ -144,7 +145,7 @@ func registerRebalanceLoad(r *testRegistry) {
 		Owner:      OwnerKV,
 		Cluster:    r.makeClusterSpec(7), // the last node is just used to generate load
 		MinVersion: "v2.1.0",
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			if local {
 				concurrency = 32
 				fmt.Printf("lowering concurrency to %d in local testing\n", concurrency)

--- a/pkg/cmd/roachtest/rebalance_load.go
+++ b/pkg/cmd/roachtest/rebalance_load.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/logger"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
@@ -44,7 +44,7 @@ func registerRebalanceLoad(r *testRegistry) {
 	rebalanceLoadRun := func(
 		ctx context.Context,
 		t *test,
-		c cluster2.Cluster,
+		c cluster.Cluster,
 		rebalanceMode string,
 		maxDuration time.Duration,
 		concurrency int,
@@ -132,7 +132,7 @@ func registerRebalanceLoad(r *testRegistry) {
 		Owner:      OwnerKV,
 		Cluster:    r.makeClusterSpec(4), // the last node is just used to generate load
 		MinVersion: "v2.1.0",
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			if local {
 				concurrency = 32
 				fmt.Printf("lowering concurrency to %d in local testing\n", concurrency)
@@ -145,7 +145,7 @@ func registerRebalanceLoad(r *testRegistry) {
 		Owner:      OwnerKV,
 		Cluster:    r.makeClusterSpec(7), // the last node is just used to generate load
 		MinVersion: "v2.1.0",
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			if local {
 				concurrency = 32
 				fmt.Printf("lowering concurrency to %d in local testing\n", concurrency)

--- a/pkg/cmd/roachtest/replicagc.go
+++ b/pkg/cmd/roachtest/replicagc.go
@@ -17,7 +17,7 @@ import (
 	"strconv"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
@@ -28,7 +28,7 @@ func registerReplicaGC(r *testRegistry) {
 			Name:    fmt.Sprintf("replicagc-changed-peers/restart=%t", restart),
 			Owner:   OwnerKV,
 			Cluster: r.makeClusterSpec(6),
-			Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+			Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 				runReplicaGCChangedPeers(ctx, t, c, restart)
 			},
 		})
@@ -48,7 +48,7 @@ var deadNodeAttr = "deadnode"
 // replicas off of them, and after having done so, it recommissions the downed
 // node. It expects the downed node to discover the new replica placement and gc
 // its replicas.
-func runReplicaGCChangedPeers(ctx context.Context, t *test, c cluster2.Cluster, withRestart bool) {
+func runReplicaGCChangedPeers(ctx context.Context, t *test, c cluster.Cluster, withRestart bool) {
 	if c.Spec().NodeCount != 6 {
 		t.Fatal("test needs to be run with 6 nodes")
 	}
@@ -140,7 +140,7 @@ func runReplicaGCChangedPeers(ctx context.Context, t *test, c cluster2.Cluster, 
 
 type replicagcTestHelper struct {
 	t *test
-	c cluster2.Cluster
+	c cluster.Cluster
 }
 
 func (h *replicagcTestHelper) waitForFullReplication(ctx context.Context) {

--- a/pkg/cmd/roachtest/replicagc.go
+++ b/pkg/cmd/roachtest/replicagc.go
@@ -17,6 +17,7 @@ import (
 	"strconv"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
@@ -27,7 +28,7 @@ func registerReplicaGC(r *testRegistry) {
 			Name:    fmt.Sprintf("replicagc-changed-peers/restart=%t", restart),
 			Owner:   OwnerKV,
 			Cluster: r.makeClusterSpec(6),
-			Run: func(ctx context.Context, t *test, c Cluster) {
+			Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 				runReplicaGCChangedPeers(ctx, t, c, restart)
 			},
 		})
@@ -47,7 +48,7 @@ var deadNodeAttr = "deadnode"
 // replicas off of them, and after having done so, it recommissions the downed
 // node. It expects the downed node to discover the new replica placement and gc
 // its replicas.
-func runReplicaGCChangedPeers(ctx context.Context, t *test, c Cluster, withRestart bool) {
+func runReplicaGCChangedPeers(ctx context.Context, t *test, c cluster2.Cluster, withRestart bool) {
 	if c.Spec().NodeCount != 6 {
 		t.Fatal("test needs to be run with 6 nodes")
 	}
@@ -139,7 +140,7 @@ func runReplicaGCChangedPeers(ctx context.Context, t *test, c Cluster, withResta
 
 type replicagcTestHelper struct {
 	t *test
-	c Cluster
+	c cluster2.Cluster
 }
 
 func (h *replicagcTestHelper) waitForFullReplication(ctx context.Context) {

--- a/pkg/cmd/roachtest/replicagc.go
+++ b/pkg/cmd/roachtest/replicagc.go
@@ -55,7 +55,7 @@ func runReplicaGCChangedPeers(ctx context.Context, t *test, c Cluster, withResta
 	args := startArgs("--env=COCKROACH_SCAN_MAX_IDLE_TIME=5ms")
 	c.Put(ctx, cockroach, "./cockroach")
 	c.Put(ctx, workload, "./workload", c.Node(1))
-	c.Start(ctx, t, args, c.Range(1, 3))
+	c.Start(ctx, args, c.Range(1, 3))
 
 	h := &replicagcTestHelper{c: c, t: t}
 
@@ -71,7 +71,7 @@ func runReplicaGCChangedPeers(ctx context.Context, t *test, c Cluster, withResta
 	c.Stop(ctx, c.Node(3))
 
 	// Start three new nodes that will take over all data.
-	c.Start(ctx, t, args, c.Range(4, 6))
+	c.Start(ctx, args, c.Range(4, 6))
 
 	// Recommission n1-3, with n3 in absentia, moving the replicas to n4-6.
 	if err := h.decommission(ctx, c.Range(1, 3), 2, "--wait=none"); err != nil {
@@ -111,7 +111,7 @@ func runReplicaGCChangedPeers(ctx context.Context, t *test, c Cluster, withResta
 		// do that within the store dead interval (5m, i.e. too long for this
 		// test).
 		c.Stop(ctx, c.Range(4, 6))
-		c.Start(ctx, t, args, c.Range(4, 6))
+		c.Start(ctx, args, c.Range(4, 6))
 	}
 
 	// Restart n3. We have to manually tell it where to find a new node or it
@@ -122,7 +122,7 @@ func runReplicaGCChangedPeers(ctx context.Context, t *test, c Cluster, withResta
 	if err != nil {
 		t.Fatal(err)
 	}
-	c.Start(ctx, t, c.Node(3), startArgs(
+	c.Start(ctx, c.Node(3), startArgs(
 		"--args=--join="+internalAddrs[0],
 		"--args=--attrs="+deadNodeAttr,
 		"--args=--vmodule=raft=5,replicate_queue=5,allocator=5",
@@ -134,7 +134,7 @@ func runReplicaGCChangedPeers(ctx context.Context, t *test, c Cluster, withResta
 	h.waitForZeroReplicas(ctx, 3)
 
 	// Restart the remaining nodes to satisfy the dead node detector.
-	c.Start(ctx, t, c.Range(1, 2))
+	c.Start(ctx, c.Range(1, 2))
 }
 
 type replicagcTestHelper struct {

--- a/pkg/cmd/roachtest/reset_quorum.go
+++ b/pkg/cmd/roachtest/reset_quorum.go
@@ -16,12 +16,13 @@ import (
 	"strings"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/stretchr/testify/require"
 )
 
-func runResetQuorum(ctx context.Context, t *test, c Cluster) {
+func runResetQuorum(ctx context.Context, t *test, c cluster2.Cluster) {
 	skip.WithIssue(t, 58165)
 	args := func(attr string) option.Option {
 		return startArgs(

--- a/pkg/cmd/roachtest/reset_quorum.go
+++ b/pkg/cmd/roachtest/reset_quorum.go
@@ -32,7 +32,7 @@ func runResetQuorum(ctx context.Context, t *test, c Cluster) {
 	// n1-n5 will be in locality A, n6-n8 in B. We'll pin a single table to B and
 	// let the the nodes in B fail permanently.
 	c.Put(ctx, cockroach, "./cockroach")
-	c.Start(ctx, t, c.Range(1, 5), args("A"))
+	c.Start(ctx, c.Range(1, 5), args("A"))
 	db := c.Conn(ctx, 1)
 	defer db.Close()
 
@@ -46,7 +46,7 @@ func runResetQuorum(ctx context.Context, t *test, c Cluster) {
 	}
 	require.NoError(t, rows.Err())
 
-	c.Start(ctx, t, c.Range(6, 8), args("B"))
+	c.Start(ctx, c.Range(6, 8), args("B"))
 	_, err = db.Exec(`CREATE TABLE lostrange (id INT PRIMARY KEY, v STRING)`)
 	require.NoError(t, err)
 

--- a/pkg/cmd/roachtest/reset_quorum.go
+++ b/pkg/cmd/roachtest/reset_quorum.go
@@ -16,13 +16,13 @@ import (
 	"strings"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/stretchr/testify/require"
 )
 
-func runResetQuorum(ctx context.Context, t *test, c cluster2.Cluster) {
+func runResetQuorum(ctx context.Context, t *test, c cluster.Cluster) {
 	skip.WithIssue(t, 58165)
 	args := func(attr string) option.Option {
 		return startArgs(

--- a/pkg/cmd/roachtest/restart.go
+++ b/pkg/cmd/roachtest/restart.go
@@ -15,11 +15,11 @@ import (
 	"fmt"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
-func runRestart(ctx context.Context, t *test, c cluster2.Cluster, downDuration time.Duration) {
+func runRestart(ctx context.Context, t *test, c cluster.Cluster, downDuration time.Duration) {
 	crdbNodes := c.Range(1, c.Spec().NodeCount)
 	workloadNode := c.Node(1)
 	const restartNode = 3
@@ -90,7 +90,7 @@ func registerRestart(r *testRegistry) {
 		Cluster: r.makeClusterSpec(3),
 		// "cockroach workload is only in 19.1+"
 		MinVersion: "v19.1.0",
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runRestart(ctx, t, c, 2*time.Minute)
 		},
 	})

--- a/pkg/cmd/roachtest/restart.go
+++ b/pkg/cmd/roachtest/restart.go
@@ -25,7 +25,7 @@ func runRestart(ctx context.Context, t *test, c Cluster, downDuration time.Durat
 
 	t.Status("installing cockroach")
 	c.Put(ctx, cockroach, "./cockroach", crdbNodes)
-	c.Start(ctx, t, crdbNodes, startArgs(`--args=--vmodule=raft_log_queue=3`))
+	c.Start(ctx, crdbNodes, startArgs(`--args=--vmodule=raft_log_queue=3`))
 
 	// We don't really need tpcc, we just need a good amount of traffic and a good
 	// amount of data.
@@ -60,7 +60,7 @@ func runRestart(ctx context.Context, t *test, c Cluster, downDuration time.Durat
 
 	// Bring it back up and make sure it can serve a query within a reasonable
 	// time limit. For now, less time than it was down for.
-	c.Start(ctx, t, c.Node(restartNode))
+	c.Start(ctx, c.Node(restartNode))
 
 	// Dialing the formerly down node may still be prevented by the circuit breaker
 	// for a short moment (seconds) after n3 restarts. If it happens, the COUNT(*)

--- a/pkg/cmd/roachtest/restart.go
+++ b/pkg/cmd/roachtest/restart.go
@@ -15,10 +15,11 @@ import (
 	"fmt"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
-func runRestart(ctx context.Context, t *test, c Cluster, downDuration time.Duration) {
+func runRestart(ctx context.Context, t *test, c cluster2.Cluster, downDuration time.Duration) {
 	crdbNodes := c.Range(1, c.Spec().NodeCount)
 	workloadNode := c.Node(1)
 	const restartNode = 3
@@ -89,7 +90,7 @@ func registerRestart(r *testRegistry) {
 		Cluster: r.makeClusterSpec(3),
 		// "cockroach workload is only in 19.1+"
 		MinVersion: "v19.1.0",
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runRestart(ctx, t, c, 2*time.Minute)
 		},
 	})

--- a/pkg/cmd/roachtest/restore.go
+++ b/pkg/cmd/roachtest/restore.go
@@ -291,7 +291,7 @@ func registerRestoreNodeShutdown(r *testRegistry) {
 			gatewayNode := 2
 			nodeToShutdown := 3
 			c.Put(ctx, cockroach, "./cockroach")
-			c.Start(ctx, t)
+			c.Start(ctx)
 
 			jobSurvivesNodeShutdown(ctx, t, c, nodeToShutdown, makeRestoreStarter(ctx, t, c, gatewayNode))
 		},
@@ -306,7 +306,7 @@ func registerRestoreNodeShutdown(r *testRegistry) {
 			gatewayNode := 2
 			nodeToShutdown := 2
 			c.Put(ctx, cockroach, "./cockroach")
-			c.Start(ctx, t)
+			c.Start(ctx)
 
 			jobSurvivesNodeShutdown(ctx, t, c, nodeToShutdown, makeRestoreStarter(ctx, t, c, gatewayNode))
 		},
@@ -389,7 +389,7 @@ func registerRestore(r *testRegistry) {
 				// Randomize starting with encryption-at-rest enabled.
 				c.EncryptAtRandom(true)
 				c.Put(ctx, cockroach, "./cockroach")
-				c.Start(ctx, t)
+				c.Start(ctx)
 				m := newMonitor(ctx, c)
 
 				// Run the disk usage logger in the monitor to guarantee its

--- a/pkg/cmd/roachtest/restore.go
+++ b/pkg/cmd/roachtest/restore.go
@@ -22,6 +22,7 @@ import (
 	"text/tabwriter"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/logger"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
@@ -40,13 +41,13 @@ import (
 // future.
 type HealthChecker struct {
 	t      *test
-	c      Cluster
+	c      cluster2.Cluster
 	nodes  option.NodeListOption
 	doneCh chan struct{}
 }
 
 // NewHealthChecker returns a populated HealthChecker.
-func NewHealthChecker(t *test, c Cluster, nodes option.NodeListOption) *HealthChecker {
+func NewHealthChecker(t *test, c cluster2.Cluster, nodes option.NodeListOption) *HealthChecker {
 	return &HealthChecker{
 		t:      t,
 		c:      c,
@@ -147,12 +148,12 @@ func (hc *HealthChecker) Runner(ctx context.Context) (err error) {
 // DiskUsageLogger regularly logs the disk spaced used by the nodes in the cluster.
 type DiskUsageLogger struct {
 	t      *test
-	c      Cluster
+	c      cluster2.Cluster
 	doneCh chan struct{}
 }
 
 // NewDiskUsageLogger populates a DiskUsageLogger.
-func NewDiskUsageLogger(t *test, c Cluster) *DiskUsageLogger {
+func NewDiskUsageLogger(t *test, c cluster2.Cluster) *DiskUsageLogger {
 	return &DiskUsageLogger{
 		t:      t,
 		c:      c,
@@ -218,8 +219,8 @@ func (dul *DiskUsageLogger) Runner(ctx context.Context) error {
 	}
 }
 func registerRestoreNodeShutdown(r *testRegistry) {
-	makeRestoreStarter := func(ctx context.Context, t *test, c Cluster, gatewayNode int) jobStarter {
-		return func(c Cluster) (string, error) {
+	makeRestoreStarter := func(ctx context.Context, t *test, c cluster2.Cluster, gatewayNode int) jobStarter {
+		return func(c cluster2.Cluster) (string, error) {
 			t.l.Printf("connecting to gateway")
 			gatewayDB := c.Conn(ctx, gatewayNode)
 			defer gatewayDB.Close()
@@ -287,7 +288,7 @@ func registerRestoreNodeShutdown(r *testRegistry) {
 		Owner:      OwnerBulkIO,
 		Cluster:    r.makeClusterSpec(4),
 		MinVersion: "v21.1.0",
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			gatewayNode := 2
 			nodeToShutdown := 3
 			c.Put(ctx, cockroach, "./cockroach")
@@ -302,7 +303,7 @@ func registerRestoreNodeShutdown(r *testRegistry) {
 		Owner:      OwnerBulkIO,
 		Cluster:    r.makeClusterSpec(4),
 		MinVersion: "v21.1.0",
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			gatewayNode := 2
 			nodeToShutdown := 2
 			c.Put(ctx, cockroach, "./cockroach")
@@ -318,7 +319,7 @@ type testDataSet interface {
 	// runRestore does any setup that's required and restores the dataset into
 	// the given cluster. Any setup shouldn't take a long amount of time since
 	// perf artifacts are based on how long this takes.
-	runRestore(ctx context.Context, c Cluster)
+	runRestore(ctx context.Context, c cluster2.Cluster)
 }
 
 type dataBank2TB struct{}
@@ -327,7 +328,7 @@ func (dataBank2TB) name() string {
 	return "2TB"
 }
 
-func (dataBank2TB) runRestore(ctx context.Context, c Cluster) {
+func (dataBank2TB) runRestore(ctx context.Context, c cluster2.Cluster) {
 	c.Run(ctx, c.Node(1), `./cockroach sql --insecure -e "CREATE DATABASE restore2tb"`)
 	c.Run(ctx, c.Node(1), `./cockroach sql --insecure -e "
 				RESTORE csv.bank FROM
@@ -341,7 +342,7 @@ func (tpccIncData) name() string {
 	return "TPCCInc"
 }
 
-func (tpccIncData) runRestore(ctx context.Context, c Cluster) {
+func (tpccIncData) runRestore(ctx context.Context, c cluster2.Cluster) {
 	// This data set restores a 1.80TB (replicated) backup consisting of 50
 	// incremental backup layers taken every 15 minutes. 8000 warehouses
 	// were imported and then a workload of 1000 warehouses was run against
@@ -385,7 +386,7 @@ func registerRestore(r *testRegistry) {
 			Owner:   OwnerBulkIO,
 			Cluster: r.makeClusterSpec(item.nodes, clusterOpts...),
 			Timeout: item.timeout,
-			Run: func(ctx context.Context, t *test, c Cluster) {
+			Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 				// Randomize starting with encryption-at-rest enabled.
 				c.EncryptAtRandom(true)
 				c.Put(ctx, cockroach, "./cockroach")
@@ -451,7 +452,7 @@ func registerRestore(r *testRegistry) {
 // specified in m. This is particularly useful for verifying that a counter
 // metric does not exceed some threshold during a test. For example, the
 // restore and import tests verify that the range merge queue is inactive.
-func verifyMetrics(ctx context.Context, c Cluster, m map[string]float64) error {
+func verifyMetrics(ctx context.Context, c cluster2.Cluster, m map[string]float64) error {
 	const sample = 10 * time.Second
 	// Query needed information over the timespan of the query.
 	adminUIAddrs, err := c.ExternalAdminUIAddr(ctx, c.Node(1))

--- a/pkg/cmd/roachtest/roachmart.go
+++ b/pkg/cmd/roachtest/roachmart.go
@@ -14,11 +14,12 @@ import (
 	"context"
 	"fmt"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 )
 
 func registerRoachmart(r *testRegistry) {
-	runRoachmart := func(ctx context.Context, t *test, c Cluster, partition bool) {
+	runRoachmart := func(ctx context.Context, t *test, c cluster2.Cluster, partition bool) {
 		c.Put(ctx, cockroach, "./cockroach")
 		c.Put(ctx, workload, "./workload")
 		c.Start(ctx)
@@ -69,7 +70,7 @@ func registerRoachmart(r *testRegistry) {
 			Name:    fmt.Sprintf("roachmart/partition=%v", v),
 			Owner:   OwnerKV,
 			Cluster: r.makeClusterSpec(9, spec.Geo(), spec.Zones("us-central1-b,us-west1-b,europe-west2-b")),
-			Run: func(ctx context.Context, t *test, c Cluster) {
+			Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 				runRoachmart(ctx, t, c, v)
 			},
 		})

--- a/pkg/cmd/roachtest/roachmart.go
+++ b/pkg/cmd/roachtest/roachmart.go
@@ -14,12 +14,12 @@ import (
 	"context"
 	"fmt"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 )
 
 func registerRoachmart(r *testRegistry) {
-	runRoachmart := func(ctx context.Context, t *test, c cluster2.Cluster, partition bool) {
+	runRoachmart := func(ctx context.Context, t *test, c cluster.Cluster, partition bool) {
 		c.Put(ctx, cockroach, "./cockroach")
 		c.Put(ctx, workload, "./workload")
 		c.Start(ctx)
@@ -70,7 +70,7 @@ func registerRoachmart(r *testRegistry) {
 			Name:    fmt.Sprintf("roachmart/partition=%v", v),
 			Owner:   OwnerKV,
 			Cluster: r.makeClusterSpec(9, spec.Geo(), spec.Zones("us-central1-b,us-west1-b,europe-west2-b")),
-			Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+			Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 				runRoachmart(ctx, t, c, v)
 			},
 		})

--- a/pkg/cmd/roachtest/roachmart.go
+++ b/pkg/cmd/roachtest/roachmart.go
@@ -21,7 +21,7 @@ func registerRoachmart(r *testRegistry) {
 	runRoachmart := func(ctx context.Context, t *test, c Cluster, partition bool) {
 		c.Put(ctx, cockroach, "./cockroach")
 		c.Put(ctx, workload, "./workload")
-		c.Start(ctx, t)
+		c.Start(ctx)
 
 		// TODO(benesch): avoid hardcoding this list.
 		nodes := []struct {

--- a/pkg/cmd/roachtest/ruby_pg.go
+++ b/pkg/cmd/roachtest/ruby_pg.go
@@ -31,7 +31,7 @@ func registerRubyPG(r *testRegistry) {
 		t *test,
 		c Cluster,
 	) {
-		if c.isLocal() {
+		if c.IsLocal() {
 			t.Fatal("cannot be run in local mode")
 		}
 		node := c.Node(1)

--- a/pkg/cmd/roachtest/ruby_pg.go
+++ b/pkg/cmd/roachtest/ruby_pg.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"regexp"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/stretchr/testify/require"
 )
@@ -29,7 +30,7 @@ func registerRubyPG(r *testRegistry) {
 	runRubyPGTest := func(
 		ctx context.Context,
 		t *test,
-		c Cluster,
+		c cluster2.Cluster,
 	) {
 		if c.IsLocal() {
 			t.Fatal("cannot be run in local mode")
@@ -202,7 +203,7 @@ func registerRubyPG(r *testRegistry) {
 		Owner:      OwnerSQLExperience,
 		Cluster:    r.makeClusterSpec(1),
 		Tags:       []string{`default`, `orm`},
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runRubyPGTest(ctx, t, c)
 		},
 	})

--- a/pkg/cmd/roachtest/ruby_pg.go
+++ b/pkg/cmd/roachtest/ruby_pg.go
@@ -17,7 +17,7 @@ import (
 	"fmt"
 	"regexp"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/stretchr/testify/require"
 )
@@ -30,7 +30,7 @@ func registerRubyPG(r *testRegistry) {
 	runRubyPGTest := func(
 		ctx context.Context,
 		t *test,
-		c cluster2.Cluster,
+		c cluster.Cluster,
 	) {
 		if c.IsLocal() {
 			t.Fatal("cannot be run in local mode")
@@ -203,7 +203,7 @@ func registerRubyPG(r *testRegistry) {
 		Owner:      OwnerSQLExperience,
 		Cluster:    r.makeClusterSpec(1),
 		Tags:       []string{`default`, `orm`},
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runRubyPGTest(ctx, t, c)
 		},
 	})

--- a/pkg/cmd/roachtest/ruby_pg.go
+++ b/pkg/cmd/roachtest/ruby_pg.go
@@ -40,7 +40,7 @@ func registerRubyPG(r *testRegistry) {
 		if err := c.PutLibraries(ctx, "./lib"); err != nil {
 			t.Fatal(err)
 		}
-		c.Start(ctx, t, c.All())
+		c.Start(ctx, c.All())
 
 		version, err := fetchCockroachVersion(ctx, c, node[0], nil)
 		if err != nil {

--- a/pkg/cmd/roachtest/schema_change_database_version_upgrade.go
+++ b/pkg/cmd/roachtest/schema_change_database_version_upgrade.go
@@ -15,7 +15,7 @@ import (
 	gosql "database/sql"
 	"fmt"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/version"
@@ -36,7 +36,7 @@ func registerSchemaChangeDatabaseVersionUpgrade(r *testRegistry) {
 		Owner:      OwnerSQLSchema,
 		MinVersion: "v20.2.0",
 		Cluster:    r.makeClusterSpec(3),
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runSchemaChangeDatabaseVersionUpgrade(ctx, t, c, r.buildVersion)
 		},
 	})
@@ -63,7 +63,7 @@ func uploadAndStart(nodes option.NodeListOption, v string) versionStep {
 }
 
 func runSchemaChangeDatabaseVersionUpgrade(
-	ctx context.Context, t *test, c cluster2.Cluster, buildVersion version.Version,
+	ctx context.Context, t *test, c cluster.Cluster, buildVersion version.Version,
 ) {
 	// An empty string means that the cockroach binary specified by flag
 	// `cockroach` will be used.

--- a/pkg/cmd/roachtest/schema_change_database_version_upgrade.go
+++ b/pkg/cmd/roachtest/schema_change_database_version_upgrade.go
@@ -57,7 +57,7 @@ func uploadAndStart(nodes option.NodeListOption, v string) versionStep {
 		// Put and start the binary.
 		args := u.uploadVersion(ctx, t, nodes, v)
 		// NB: can't start sequentially since cluster already bootstrapped.
-		u.c.Start(ctx, t, nodes, args, startArgsDontEncrypt, roachprodArgOption{"--sequential=false"})
+		u.c.Start(ctx, nodes, args, startArgsDontEncrypt, roachprodArgOption{"--sequential=false"})
 	}
 }
 

--- a/pkg/cmd/roachtest/schema_change_database_version_upgrade.go
+++ b/pkg/cmd/roachtest/schema_change_database_version_upgrade.go
@@ -15,6 +15,7 @@ import (
 	gosql "database/sql"
 	"fmt"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/version"
@@ -35,7 +36,7 @@ func registerSchemaChangeDatabaseVersionUpgrade(r *testRegistry) {
 		Owner:      OwnerSQLSchema,
 		MinVersion: "v20.2.0",
 		Cluster:    r.makeClusterSpec(3),
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runSchemaChangeDatabaseVersionUpgrade(ctx, t, c, r.buildVersion)
 		},
 	})
@@ -62,7 +63,7 @@ func uploadAndStart(nodes option.NodeListOption, v string) versionStep {
 }
 
 func runSchemaChangeDatabaseVersionUpgrade(
-	ctx context.Context, t *test, c Cluster, buildVersion version.Version,
+	ctx context.Context, t *test, c cluster2.Cluster, buildVersion version.Version,
 ) {
 	// An empty string means that the cockroach binary specified by flag
 	// `cockroach` will be used.

--- a/pkg/cmd/roachtest/schemachange.go
+++ b/pkg/cmd/roachtest/schemachange.go
@@ -16,7 +16,7 @@ import (
 	"fmt"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/logger"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -28,7 +28,7 @@ func registerSchemaChangeDuringKV(r *testRegistry) {
 		Name:    `schemachange/during/kv`,
 		Owner:   OwnerSQLSchema,
 		Cluster: r.makeClusterSpec(5),
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			const fixturePath = `gs://cockroach-fixtures/workload/tpch/scalefactor=10/backup?AUTH=implicit`
 
 			c.Put(ctx, cockroach, "./cockroach")
@@ -303,7 +303,7 @@ func makeIndexAddTpccTest(spec spec.ClusterSpec, warehouses int, length time.Dur
 		Owner:   OwnerSQLSchema,
 		Cluster: spec,
 		Timeout: length * 3,
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runTPCC(ctx, t, c, tpccOptions{
 				Warehouses: warehouses,
 				// We limit the number of workers because the default results in a lot
@@ -338,7 +338,7 @@ func makeSchemaChangeBulkIngestTest(
 		Timeout: length * 2,
 		// `fixtures import` (with the workload paths) is not supported in 2.1
 		MinVersion: "v19.1.0",
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			// Configure column a to have sequential ascending values, and columns b and c to be constant.
 			// The payload column will be randomized and thus uncorrelated with the primary key (a, b, c).
 			aNum := numRows
@@ -422,7 +422,7 @@ func makeSchemaChangeDuringTPCC(
 		Owner:   OwnerSQLSchema,
 		Cluster: spec,
 		Timeout: length * 3,
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runTPCC(ctx, t, c, tpccOptions{
 				Warehouses: warehouses,
 				// We limit the number of workers because the default results in a lot
@@ -474,7 +474,7 @@ func makeSchemaChangeDuringTPCC(
 }
 
 func runAndLogStmts(
-	ctx context.Context, t *test, c cluster2.Cluster, prefix string, stmts []string,
+	ctx context.Context, t *test, c cluster.Cluster, prefix string, stmts []string,
 ) error {
 	db := c.Conn(ctx, 1)
 	defer db.Close()

--- a/pkg/cmd/roachtest/schemachange.go
+++ b/pkg/cmd/roachtest/schemachange.go
@@ -33,7 +33,7 @@ func registerSchemaChangeDuringKV(r *testRegistry) {
 			c.Put(ctx, cockroach, "./cockroach")
 			c.Put(ctx, workload, "./workload")
 
-			c.Start(ctx, t, c.All())
+			c.Start(ctx, c.All())
 			db := c.Conn(ctx, 1)
 			defer db.Close()
 
@@ -354,7 +354,7 @@ func makeSchemaChangeBulkIngestTest(
 			c.Put(ctx, cockroach, "./cockroach")
 			c.Put(ctx, workload, "./workload", workloadNode)
 			// TODO (lucy): Remove flag once the faster import is enabled by default
-			c.Start(ctx, t, crdbNodes, startArgs("--env=COCKROACH_IMPORT_WORKLOAD_FASTER=true"))
+			c.Start(ctx, crdbNodes, startArgs("--env=COCKROACH_IMPORT_WORKLOAD_FASTER=true"))
 
 			// Don't add another index when importing.
 			cmdWrite := fmt.Sprintf(

--- a/pkg/cmd/roachtest/schemachange.go
+++ b/pkg/cmd/roachtest/schemachange.go
@@ -59,7 +59,7 @@ func registerSchemaChangeDuringKV(r *testRegistry) {
 						t.Fatal(err)
 					}
 					defer l.Close()
-					_ = execCmd(ctx, t.l, roachprod, "ssh", c.makeNodes(c.Node(node)), "--", cmd)
+					_ = execCmd(ctx, t.l, roachprod, "ssh", c.MakeNodes(c.Node(node)), "--", cmd)
 				}()
 			}
 
@@ -341,7 +341,7 @@ func makeSchemaChangeBulkIngestTest(
 			// Configure column a to have sequential ascending values, and columns b and c to be constant.
 			// The payload column will be randomized and thus uncorrelated with the primary key (a, b, c).
 			aNum := numRows
-			if c.isLocal() {
+			if c.IsLocal() {
 				aNum = 100000
 			}
 			bNum := 1
@@ -369,7 +369,7 @@ func makeSchemaChangeBulkIngestTest(
 			m := newMonitor(ctx, c, crdbNodes)
 
 			indexDuration := length
-			if c.isLocal() {
+			if c.IsLocal() {
 				indexDuration = time.Second * 30
 			}
 			cmdWriteAndRead := fmt.Sprintf(
@@ -385,7 +385,7 @@ func makeSchemaChangeBulkIngestTest(
 				db := c.Conn(ctx, 1)
 				defer db.Close()
 
-				if !c.isLocal() {
+				if !c.IsLocal() {
 					// Wait for the load generator to run for a few minutes before creating the index.
 					sleepInterval := time.Minute * 5
 					maxSleep := length / 2

--- a/pkg/cmd/roachtest/schemachange.go
+++ b/pkg/cmd/roachtest/schemachange.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/logger"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -27,7 +28,7 @@ func registerSchemaChangeDuringKV(r *testRegistry) {
 		Name:    `schemachange/during/kv`,
 		Owner:   OwnerSQLSchema,
 		Cluster: r.makeClusterSpec(5),
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			const fixturePath = `gs://cockroach-fixtures/workload/tpch/scalefactor=10/backup?AUTH=implicit`
 
 			c.Put(ctx, cockroach, "./cockroach")
@@ -302,7 +303,7 @@ func makeIndexAddTpccTest(spec spec.ClusterSpec, warehouses int, length time.Dur
 		Owner:   OwnerSQLSchema,
 		Cluster: spec,
 		Timeout: length * 3,
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runTPCC(ctx, t, c, tpccOptions{
 				Warehouses: warehouses,
 				// We limit the number of workers because the default results in a lot
@@ -337,7 +338,7 @@ func makeSchemaChangeBulkIngestTest(
 		Timeout: length * 2,
 		// `fixtures import` (with the workload paths) is not supported in 2.1
 		MinVersion: "v19.1.0",
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			// Configure column a to have sequential ascending values, and columns b and c to be constant.
 			// The payload column will be randomized and thus uncorrelated with the primary key (a, b, c).
 			aNum := numRows
@@ -421,7 +422,7 @@ func makeSchemaChangeDuringTPCC(
 		Owner:   OwnerSQLSchema,
 		Cluster: spec,
 		Timeout: length * 3,
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runTPCC(ctx, t, c, tpccOptions{
 				Warehouses: warehouses,
 				// We limit the number of workers because the default results in a lot
@@ -472,7 +473,9 @@ func makeSchemaChangeDuringTPCC(
 	}
 }
 
-func runAndLogStmts(ctx context.Context, t *test, c Cluster, prefix string, stmts []string) error {
+func runAndLogStmts(
+	ctx context.Context, t *test, c cluster2.Cluster, prefix string, stmts []string,
+) error {
 	db := c.Conn(ctx, 1)
 	defer db.Close()
 	t.l.Printf("%s: running %d statements\n", prefix, len(stmts))

--- a/pkg/cmd/roachtest/schemachange_random_load.go
+++ b/pkg/cmd/roachtest/schemachange_random_load.go
@@ -17,6 +17,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 )
 
@@ -44,7 +45,7 @@ func registerSchemaChangeRandomLoad(r *testRegistry) {
 		// This is set while development is still happening on the workload and we
 		// fix (or bypass) minor schema change bugs that are discovered.
 		NonReleaseBlocker: true,
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			maxOps := 5000
 			concurrency := 20
 			if local {
@@ -87,13 +88,15 @@ func registerRandomLoadBenchSpec(r *testRegistry, b randomLoadBenchSpec) {
 		// This is set while development is still happening on the workload and we
 		// fix (or bypass) minor schema change bugs that are discovered.
 		NonReleaseBlocker: true,
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runSchemaChangeRandomLoad(ctx, t, c, b.Ops, b.Concurrency)
 		},
 	})
 }
 
-func runSchemaChangeRandomLoad(ctx context.Context, t *test, c Cluster, maxOps, concurrency int) {
+func runSchemaChangeRandomLoad(
+	ctx context.Context, t *test, c cluster2.Cluster, maxOps, concurrency int,
+) {
 	validate := func(db *gosql.DB) {
 		var (
 			id           int
@@ -179,7 +182,7 @@ func runSchemaChangeRandomLoad(ctx context.Context, t *test, c Cluster, maxOps, 
 }
 
 // saveArtifacts saves important test artifacts in the artifacts directory.
-func saveArtifacts(ctx context.Context, t *test, c Cluster, storeDirectory string) {
+func saveArtifacts(ctx context.Context, t *test, c cluster2.Cluster, storeDirectory string) {
 	db := c.Conn(ctx, 1)
 	defer db.Close()
 

--- a/pkg/cmd/roachtest/schemachange_random_load.go
+++ b/pkg/cmd/roachtest/schemachange_random_load.go
@@ -17,7 +17,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 )
 
@@ -45,7 +45,7 @@ func registerSchemaChangeRandomLoad(r *testRegistry) {
 		// This is set while development is still happening on the workload and we
 		// fix (or bypass) minor schema change bugs that are discovered.
 		NonReleaseBlocker: true,
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			maxOps := 5000
 			concurrency := 20
 			if local {
@@ -88,14 +88,14 @@ func registerRandomLoadBenchSpec(r *testRegistry, b randomLoadBenchSpec) {
 		// This is set while development is still happening on the workload and we
 		// fix (or bypass) minor schema change bugs that are discovered.
 		NonReleaseBlocker: true,
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runSchemaChangeRandomLoad(ctx, t, c, b.Ops, b.Concurrency)
 		},
 	})
 }
 
 func runSchemaChangeRandomLoad(
-	ctx context.Context, t *test, c cluster2.Cluster, maxOps, concurrency int,
+	ctx context.Context, t *test, c cluster.Cluster, maxOps, concurrency int,
 ) {
 	validate := func(db *gosql.DB) {
 		var (
@@ -182,7 +182,7 @@ func runSchemaChangeRandomLoad(
 }
 
 // saveArtifacts saves important test artifacts in the artifacts directory.
-func saveArtifacts(ctx context.Context, t *test, c cluster2.Cluster, storeDirectory string) {
+func saveArtifacts(ctx context.Context, t *test, c cluster.Cluster, storeDirectory string) {
 	db := c.Conn(ctx, 1)
 	defer db.Close()
 

--- a/pkg/cmd/roachtest/schemachange_random_load.go
+++ b/pkg/cmd/roachtest/schemachange_random_load.go
@@ -132,7 +132,7 @@ func runSchemaChangeRandomLoad(ctx context.Context, t *test, c Cluster, maxOps, 
 	c.Put(ctx, workload, "./workload", loadNode)
 
 	t.Status("starting cockroach nodes")
-	c.Start(ctx, t, roachNodes)
+	c.Start(ctx, roachNodes)
 	c.Run(ctx, loadNode, "./workload init schemachange")
 
 	storeDirectory, err := c.RunWithBuffer(ctx, t.l, c.Node(1), "echo", "-n", "{store-dir}")

--- a/pkg/cmd/roachtest/scrub.go
+++ b/pkg/cmd/roachtest/scrub.go
@@ -15,7 +15,7 @@ import (
 	"fmt"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
@@ -55,7 +55,7 @@ func makeScrubTPCCTest(
 		Name:    fmt.Sprintf("scrub/%s/tpcc/w=%d", optionName, warehouses),
 		Owner:   OwnerSQLQueries,
 		Cluster: r.makeClusterSpec(numNodes),
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runTPCC(ctx, t, c, tpccOptions{
 				Warehouses:   warehouses,
 				ExtraRunArgs: "--wait=false --tolerate-errors",

--- a/pkg/cmd/roachtest/scrub.go
+++ b/pkg/cmd/roachtest/scrub.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
@@ -54,7 +55,7 @@ func makeScrubTPCCTest(
 		Name:    fmt.Sprintf("scrub/%s/tpcc/w=%d", optionName, warehouses),
 		Owner:   OwnerSQLQueries,
 		Cluster: r.makeClusterSpec(numNodes),
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runTPCC(ctx, t, c, tpccOptions{
 				Warehouses:   warehouses,
 				ExtraRunArgs: "--wait=false --tolerate-errors",

--- a/pkg/cmd/roachtest/scrub.go
+++ b/pkg/cmd/roachtest/scrub.go
@@ -59,7 +59,7 @@ func makeScrubTPCCTest(
 				Warehouses:   warehouses,
 				ExtraRunArgs: "--wait=false --tolerate-errors",
 				During: func(ctx context.Context) error {
-					if !c.isLocal() {
+					if !c.IsLocal() {
 						// Wait until tpcc has been running for a few minutes to start SCRUB checks
 						sleepInterval := time.Minute * 10
 						maxSleep := length / 2

--- a/pkg/cmd/roachtest/secondary_indexes.go
+++ b/pkg/cmd/roachtest/secondary_indexes.go
@@ -13,14 +13,14 @@ package main
 import (
 	"context"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/stretchr/testify/require"
 )
 
 // runIndexUpgrade runs a test that creates an index before a version upgrade,
 // and modifies it in a mixed version setting. It aims to test the changes made
 // to index encodings done to allow secondary indexes to respect column families.
-func runIndexUpgrade(ctx context.Context, t *test, c cluster2.Cluster, predecessorVersion string) {
+func runIndexUpgrade(ctx context.Context, t *test, c cluster.Cluster, predecessorVersion string) {
 	firstExpected := [][]int{
 		{2, 3, 4},
 		{6, 7, 8},
@@ -136,7 +136,7 @@ func registerSecondaryIndexesMultiVersionCluster(r *testRegistry) {
 		Owner:      OwnerSQLSchema,
 		Cluster:    r.makeClusterSpec(3),
 		MinVersion: "v20.1.0",
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			predV, err := PredecessorVersion(r.buildVersion)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/cmd/roachtest/secondary_indexes.go
+++ b/pkg/cmd/roachtest/secondary_indexes.go
@@ -13,13 +13,14 @@ package main
 import (
 	"context"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/stretchr/testify/require"
 )
 
 // runIndexUpgrade runs a test that creates an index before a version upgrade,
 // and modifies it in a mixed version setting. It aims to test the changes made
 // to index encodings done to allow secondary indexes to respect column families.
-func runIndexUpgrade(ctx context.Context, t *test, c Cluster, predecessorVersion string) {
+func runIndexUpgrade(ctx context.Context, t *test, c cluster2.Cluster, predecessorVersion string) {
 	firstExpected := [][]int{
 		{2, 3, 4},
 		{6, 7, 8},
@@ -135,7 +136,7 @@ func registerSecondaryIndexesMultiVersionCluster(r *testRegistry) {
 		Owner:      OwnerSQLSchema,
 		Cluster:    r.makeClusterSpec(3),
 		MinVersion: "v20.1.0",
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			predV, err := PredecessorVersion(r.buildVersion)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/cmd/roachtest/sequelize.go
+++ b/pkg/cmd/roachtest/sequelize.go
@@ -13,7 +13,7 @@ import (
 	"context"
 	"regexp"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 )
 
 var sequelizeReleaseTagRegex = regexp.MustCompile(`^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)$`)
@@ -25,7 +25,7 @@ func registerSequelize(r *testRegistry) {
 	runSequelize := func(
 		ctx context.Context,
 		t *test,
-		c cluster2.Cluster,
+		c cluster.Cluster,
 	) {
 		if c.IsLocal() {
 			t.Fatal("cannot be run in local mode")
@@ -151,7 +151,7 @@ func registerSequelize(r *testRegistry) {
 		Owner:      OwnerSQLExperience,
 		Cluster:    r.makeClusterSpec(1),
 		Tags:       []string{`default`, `orm`},
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runSequelize(ctx, t, c)
 		},
 	})

--- a/pkg/cmd/roachtest/sequelize.go
+++ b/pkg/cmd/roachtest/sequelize.go
@@ -12,6 +12,8 @@ package main
 import (
 	"context"
 	"regexp"
+
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 )
 
 var sequelizeReleaseTagRegex = regexp.MustCompile(`^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)$`)
@@ -23,7 +25,7 @@ func registerSequelize(r *testRegistry) {
 	runSequelize := func(
 		ctx context.Context,
 		t *test,
-		c Cluster,
+		c cluster2.Cluster,
 	) {
 		if c.IsLocal() {
 			t.Fatal("cannot be run in local mode")
@@ -149,7 +151,7 @@ func registerSequelize(r *testRegistry) {
 		Owner:      OwnerSQLExperience,
 		Cluster:    r.makeClusterSpec(1),
 		Tags:       []string{`default`, `orm`},
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runSequelize(ctx, t, c)
 		},
 	})

--- a/pkg/cmd/roachtest/sequelize.go
+++ b/pkg/cmd/roachtest/sequelize.go
@@ -25,7 +25,7 @@ func registerSequelize(r *testRegistry) {
 		t *test,
 		c Cluster,
 	) {
-		if c.isLocal() {
+		if c.IsLocal() {
 			t.Fatal("cannot be run in local mode")
 		}
 		node := c.Node(1)

--- a/pkg/cmd/roachtest/sequelize.go
+++ b/pkg/cmd/roachtest/sequelize.go
@@ -34,7 +34,7 @@ func registerSequelize(r *testRegistry) {
 		if err := c.PutLibraries(ctx, "./lib"); err != nil {
 			t.Fatal(err)
 		}
-		c.Start(ctx, t, c.All())
+		c.Start(ctx, c.All())
 
 		version, err := fetchCockroachVersion(ctx, c, node[0], nil)
 		if err != nil {

--- a/pkg/cmd/roachtest/sequence_upgrade.go
+++ b/pkg/cmd/roachtest/sequence_upgrade.go
@@ -14,7 +14,7 @@ import (
 	"context"
 	"fmt"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 )
 
 func registerSequenceUpgrade(r *testRegistry) {
@@ -23,7 +23,7 @@ func registerSequenceUpgrade(r *testRegistry) {
 		Owner:      OwnerSQLSchema,
 		MinVersion: "v21.1.0",
 		Cluster:    r.makeClusterSpec(1),
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runSequenceUpgradeMigration(ctx, t, c)
 		},
 	})
@@ -80,7 +80,7 @@ func verifySequences(node int) versionStep {
 	}
 }
 
-func runSequenceUpgradeMigration(ctx context.Context, t *test, c cluster2.Cluster) {
+func runSequenceUpgradeMigration(ctx context.Context, t *test, c cluster.Cluster) {
 	const (
 		v20_2 = "20.2.4"
 		// An empty string means that the cockroach binary specified by flag

--- a/pkg/cmd/roachtest/sequence_upgrade.go
+++ b/pkg/cmd/roachtest/sequence_upgrade.go
@@ -13,6 +13,8 @@ package main
 import (
 	"context"
 	"fmt"
+
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 )
 
 func registerSequenceUpgrade(r *testRegistry) {
@@ -21,7 +23,7 @@ func registerSequenceUpgrade(r *testRegistry) {
 		Owner:      OwnerSQLSchema,
 		MinVersion: "v21.1.0",
 		Cluster:    r.makeClusterSpec(1),
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runSequenceUpgradeMigration(ctx, t, c)
 		},
 	})
@@ -78,7 +80,7 @@ func verifySequences(node int) versionStep {
 	}
 }
 
-func runSequenceUpgradeMigration(ctx context.Context, t *test, c Cluster) {
+func runSequenceUpgradeMigration(ctx context.Context, t *test, c cluster2.Cluster) {
 	const (
 		v20_2 = "20.2.4"
 		// An empty string means that the cockroach binary specified by flag

--- a/pkg/cmd/roachtest/split.go
+++ b/pkg/cmd/roachtest/split.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/errors"
 	humanize "github.com/dustin/go-humanize"
@@ -45,7 +45,7 @@ func registerLoadSplits(r *testRegistry) {
 		Owner:      OwnerKV,
 		MinVersion: "v19.1.0",
 		Cluster:    r.makeClusterSpec(numNodes),
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			// This number was determined experimentally. Often, but not always,
 			// more splits will happen.
 			expSplits := 10
@@ -89,7 +89,7 @@ func registerLoadSplits(r *testRegistry) {
 		Owner:      OwnerKV,
 		MinVersion: "v19.1.0",
 		Cluster:    r.makeClusterSpec(numNodes),
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runLoadSplits(ctx, t, c, splitParams{
 				maxSize:       10 << 30, // 10 GB
 				concurrency:   64,       // 64 concurrent workers
@@ -110,7 +110,7 @@ func registerLoadSplits(r *testRegistry) {
 		Owner:      OwnerKV,
 		MinVersion: "v19.1.0",
 		Cluster:    r.makeClusterSpec(numNodes),
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runLoadSplits(ctx, t, c, splitParams{
 				maxSize:       10 << 30, // 10 GB
 				concurrency:   64,       // 64 concurrent workers
@@ -128,7 +128,7 @@ func registerLoadSplits(r *testRegistry) {
 // runLoadSplits tests behavior of load based splitting under
 // conditions defined by the params. It checks whether certain number of
 // splits occur in different workload scenarios.
-func runLoadSplits(ctx context.Context, t *test, c cluster2.Cluster, params splitParams) {
+func runLoadSplits(ctx context.Context, t *test, c cluster.Cluster, params splitParams) {
 	c.Put(ctx, cockroach, "./cockroach", c.All())
 	c.Put(ctx, workload, "./workload", c.Node(1))
 	c.Start(ctx, c.All())
@@ -217,7 +217,7 @@ func registerLargeRange(r *testRegistry) {
 		Owner:   OwnerKV,
 		Cluster: r.makeClusterSpec(numNodes),
 		Timeout: 5 * time.Hour,
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runLargeRangeSplits(ctx, t, c, size)
 		},
 	})
@@ -231,7 +231,7 @@ func bytesStr(size uint64) string {
 // so by setting the max range size to a huge number before populating the
 // table. It then drops the range size back down to normal and watches as
 // the large range splits apart.
-func runLargeRangeSplits(ctx context.Context, t *test, c cluster2.Cluster, size int) {
+func runLargeRangeSplits(ctx context.Context, t *test, c cluster.Cluster, size int) {
 	// payload is the size of the payload column for each row in the Bank
 	// table.
 	const payload = 100

--- a/pkg/cmd/roachtest/split.go
+++ b/pkg/cmd/roachtest/split.go
@@ -130,7 +130,7 @@ func registerLoadSplits(r *testRegistry) {
 func runLoadSplits(ctx context.Context, t *test, c Cluster, params splitParams) {
 	c.Put(ctx, cockroach, "./cockroach", c.All())
 	c.Put(ctx, workload, "./workload", c.Node(1))
-	c.Start(ctx, t, c.All())
+	c.Start(ctx, c.All())
 
 	m := newMonitor(ctx, c, c.All())
 	m.Go(func(ctx context.Context) error {
@@ -246,7 +246,7 @@ func runLargeRangeSplits(ctx context.Context, t *test, c Cluster, size int) {
 
 	c.Put(ctx, cockroach, "./cockroach", c.All())
 	c.Put(ctx, workload, "./workload", c.All())
-	c.Start(ctx, t, c.All())
+	c.Start(ctx, c.All())
 
 	m := newMonitor(ctx, c, c.All())
 	m.Go(func(ctx context.Context) error {

--- a/pkg/cmd/roachtest/split.go
+++ b/pkg/cmd/roachtest/split.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/errors"
 	humanize "github.com/dustin/go-humanize"
@@ -44,7 +45,7 @@ func registerLoadSplits(r *testRegistry) {
 		Owner:      OwnerKV,
 		MinVersion: "v19.1.0",
 		Cluster:    r.makeClusterSpec(numNodes),
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			// This number was determined experimentally. Often, but not always,
 			// more splits will happen.
 			expSplits := 10
@@ -88,7 +89,7 @@ func registerLoadSplits(r *testRegistry) {
 		Owner:      OwnerKV,
 		MinVersion: "v19.1.0",
 		Cluster:    r.makeClusterSpec(numNodes),
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runLoadSplits(ctx, t, c, splitParams{
 				maxSize:       10 << 30, // 10 GB
 				concurrency:   64,       // 64 concurrent workers
@@ -109,7 +110,7 @@ func registerLoadSplits(r *testRegistry) {
 		Owner:      OwnerKV,
 		MinVersion: "v19.1.0",
 		Cluster:    r.makeClusterSpec(numNodes),
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runLoadSplits(ctx, t, c, splitParams{
 				maxSize:       10 << 30, // 10 GB
 				concurrency:   64,       // 64 concurrent workers
@@ -127,7 +128,7 @@ func registerLoadSplits(r *testRegistry) {
 // runLoadSplits tests behavior of load based splitting under
 // conditions defined by the params. It checks whether certain number of
 // splits occur in different workload scenarios.
-func runLoadSplits(ctx context.Context, t *test, c Cluster, params splitParams) {
+func runLoadSplits(ctx context.Context, t *test, c cluster2.Cluster, params splitParams) {
 	c.Put(ctx, cockroach, "./cockroach", c.All())
 	c.Put(ctx, workload, "./workload", c.Node(1))
 	c.Start(ctx, c.All())
@@ -216,7 +217,7 @@ func registerLargeRange(r *testRegistry) {
 		Owner:   OwnerKV,
 		Cluster: r.makeClusterSpec(numNodes),
 		Timeout: 5 * time.Hour,
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runLargeRangeSplits(ctx, t, c, size)
 		},
 	})
@@ -230,7 +231,7 @@ func bytesStr(size uint64) string {
 // so by setting the max range size to a huge number before populating the
 // table. It then drops the range size back down to normal and watches as
 // the large range splits apart.
-func runLargeRangeSplits(ctx context.Context, t *test, c Cluster, size int) {
+func runLargeRangeSplits(ctx context.Context, t *test, c cluster2.Cluster, size int) {
 	// payload is the size of the payload column for each row in the Bank
 	// table.
 	const payload = 100

--- a/pkg/cmd/roachtest/sqlalchemy.go
+++ b/pkg/cmd/roachtest/sqlalchemy.go
@@ -17,6 +17,8 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 )
 
 var sqlAlchemyResultRegex = regexp.MustCompile(`^(?P<test>test.*::.*::[^ \[\]]*(?:\[.*])?) (?P<result>\w+)\s+\[.+]$`)
@@ -34,13 +36,13 @@ func registerSQLAlchemy(r *testRegistry) {
 		Cluster:    r.makeClusterSpec(1),
 		MinVersion: "v20.2.0",
 		Tags:       []string{`default`, `orm`},
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runSQLAlchemy(ctx, t, c)
 		},
 	})
 }
 
-func runSQLAlchemy(ctx context.Context, t *test, c Cluster) {
+func runSQLAlchemy(ctx context.Context, t *test, c cluster2.Cluster) {
 	if c.IsLocal() {
 		t.Fatal("cannot be run in local mode")
 	}

--- a/pkg/cmd/roachtest/sqlalchemy.go
+++ b/pkg/cmd/roachtest/sqlalchemy.go
@@ -41,7 +41,7 @@ func registerSQLAlchemy(r *testRegistry) {
 }
 
 func runSQLAlchemy(ctx context.Context, t *test, c Cluster) {
-	if c.isLocal() {
+	if c.IsLocal() {
 		t.Fatal("cannot be run in local mode")
 	}
 

--- a/pkg/cmd/roachtest/sqlalchemy.go
+++ b/pkg/cmd/roachtest/sqlalchemy.go
@@ -18,7 +18,7 @@ import (
 	"regexp"
 	"strings"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 )
 
 var sqlAlchemyResultRegex = regexp.MustCompile(`^(?P<test>test.*::.*::[^ \[\]]*(?:\[.*])?) (?P<result>\w+)\s+\[.+]$`)
@@ -36,13 +36,13 @@ func registerSQLAlchemy(r *testRegistry) {
 		Cluster:    r.makeClusterSpec(1),
 		MinVersion: "v20.2.0",
 		Tags:       []string{`default`, `orm`},
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runSQLAlchemy(ctx, t, c)
 		},
 	})
 }
 
-func runSQLAlchemy(ctx context.Context, t *test, c cluster2.Cluster) {
+func runSQLAlchemy(ctx context.Context, t *test, c cluster.Cluster) {
 	if c.IsLocal() {
 		t.Fatal("cannot be run in local mode")
 	}

--- a/pkg/cmd/roachtest/sqlalchemy.go
+++ b/pkg/cmd/roachtest/sqlalchemy.go
@@ -130,7 +130,7 @@ func runSQLAlchemy(ctx context.Context, t *test, c Cluster) {
 
 	t.Status("setting up cockroach")
 	c.Put(ctx, cockroach, "./cockroach", c.All())
-	c.Start(ctx, t, c.All())
+	c.Start(ctx, c.All())
 
 	version, err := fetchCockroachVersion(ctx, c, node[0], nil)
 	if err != nil {

--- a/pkg/cmd/roachtest/sqlsmith.go
+++ b/pkg/cmd/roachtest/sqlsmith.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/internal/sqlsmith"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/errors"
@@ -57,7 +58,7 @@ func registerSQLSmith(r *testRegistry) {
 		"no-ddl":       sqlsmith.Settings["no-ddl"],
 	}
 
-	runSQLSmith := func(ctx context.Context, t *test, c Cluster, setupName, settingName string) {
+	runSQLSmith := func(ctx context.Context, t *test, c cluster2.Cluster, setupName, settingName string) {
 		// Set up a statement logger for easy reproduction. We only
 		// want to log successful statements and statements that
 		// produced a final error or panic.
@@ -246,7 +247,7 @@ func registerSQLSmith(r *testRegistry) {
 			Cluster:    r.makeClusterSpec(4),
 			MinVersion: "v20.2.0",
 			Timeout:    time.Minute * 20,
-			Run: func(ctx context.Context, t *test, c Cluster) {
+			Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 				runSQLSmith(ctx, t, c, setup, setting)
 			},
 		})

--- a/pkg/cmd/roachtest/sqlsmith.go
+++ b/pkg/cmd/roachtest/sqlsmith.go
@@ -85,7 +85,7 @@ func registerSQLSmith(r *testRegistry) {
 		if err := c.PutLibraries(ctx, "./lib"); err != nil {
 			t.Fatalf("could not initialize libraries: %v", err)
 		}
-		c.Start(ctx, t)
+		c.Start(ctx)
 
 		setupFunc, ok := setups[setupName]
 		if !ok {

--- a/pkg/cmd/roachtest/sqlsmith.go
+++ b/pkg/cmd/roachtest/sqlsmith.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/internal/sqlsmith"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/errors"
@@ -58,7 +58,7 @@ func registerSQLSmith(r *testRegistry) {
 		"no-ddl":       sqlsmith.Settings["no-ddl"],
 	}
 
-	runSQLSmith := func(ctx context.Context, t *test, c cluster2.Cluster, setupName, settingName string) {
+	runSQLSmith := func(ctx context.Context, t *test, c cluster.Cluster, setupName, settingName string) {
 		// Set up a statement logger for easy reproduction. We only
 		// want to log successful statements and statements that
 		// produced a final error or panic.
@@ -247,7 +247,7 @@ func registerSQLSmith(r *testRegistry) {
 			Cluster:    r.makeClusterSpec(4),
 			MinVersion: "v20.2.0",
 			Timeout:    time.Minute * 20,
-			Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+			Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 				runSQLSmith(ctx, t, c, setup, setting)
 			},
 		})

--- a/pkg/cmd/roachtest/status_server.go
+++ b/pkg/cmd/roachtest/status_server.go
@@ -17,14 +17,14 @@ import (
 	"net/http"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 )
 
-func runStatusServer(ctx context.Context, t *test, c cluster2.Cluster) {
+func runStatusServer(ctx context.Context, t *test, c cluster.Cluster) {
 	c.Put(ctx, cockroach, "./cockroach")
 	c.Start(ctx)
 

--- a/pkg/cmd/roachtest/status_server.go
+++ b/pkg/cmd/roachtest/status_server.go
@@ -25,7 +25,7 @@ import (
 
 func runStatusServer(ctx context.Context, t *test, c Cluster) {
 	c.Put(ctx, cockroach, "./cockroach")
-	c.Start(ctx, t)
+	c.Start(ctx)
 
 	// Get the ids for each node.
 	idMap := make(map[int]roachpb.NodeID)

--- a/pkg/cmd/roachtest/status_server.go
+++ b/pkg/cmd/roachtest/status_server.go
@@ -17,13 +17,14 @@ import (
 	"net/http"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 )
 
-func runStatusServer(ctx context.Context, t *test, c Cluster) {
+func runStatusServer(ctx context.Context, t *test, c cluster2.Cluster) {
 	c.Put(ctx, cockroach, "./cockroach")
 	c.Start(ctx)
 

--- a/pkg/cmd/roachtest/synctest.go
+++ b/pkg/cmd/roachtest/synctest.go
@@ -16,7 +16,7 @@ import (
 	"os"
 	"path/filepath"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 )
 
@@ -37,7 +37,7 @@ fi
 		MinVersion: "v19.1.0",
 		// This test sets up a custom file system; we don't want the cluster reused.
 		Cluster: r.makeClusterSpec(1, spec.ReuseNone()),
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			n := c.Node(1)
 			tmpDir, err := ioutil.TempDir("", "synctest")
 			if err != nil {

--- a/pkg/cmd/roachtest/synctest.go
+++ b/pkg/cmd/roachtest/synctest.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"path/filepath"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 )
 
@@ -36,7 +37,7 @@ fi
 		MinVersion: "v19.1.0",
 		// This test sets up a custom file system; we don't want the cluster reused.
 		Cluster: r.makeClusterSpec(1, spec.ReuseNone()),
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			n := c.Node(1)
 			tmpDir, err := ioutil.TempDir("", "synctest")
 			if err != nil {

--- a/pkg/cmd/roachtest/synctest.go
+++ b/pkg/cmd/roachtest/synctest.go
@@ -58,7 +58,7 @@ fi
 			c.Run(ctx, n, "mkdir -p {store-dir}/{real,faulty} || true")
 			t.Status("setting up charybdefs")
 
-			if err := execCmd(ctx, t.l, roachprod, "install", c.makeNodes(n), "charybdefs"); err != nil {
+			if err := execCmd(ctx, t.l, roachprod, "install", c.MakeNodes(n), "charybdefs"); err != nil {
 				t.Fatal(err)
 			}
 			c.Run(ctx, n, "sudo charybdefs {store-dir}/faulty -oallow_other,modules=subdir,subdir={store-dir}/real && chmod 777 {store-dir}/{real,faulty}")

--- a/pkg/cmd/roachtest/sysbench.go
+++ b/pkg/cmd/roachtest/sysbench.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 )
 
@@ -86,7 +86,7 @@ func (o *sysbenchOptions) cmd(haproxy bool) string {
 	)
 }
 
-func runSysbench(ctx context.Context, t *test, c cluster2.Cluster, opts sysbenchOptions) {
+func runSysbench(ctx context.Context, t *test, c cluster.Cluster, opts sysbenchOptions) {
 	allNodes := c.Range(1, c.Spec().NodeCount)
 	roachNodes := c.Range(1, c.Spec().NodeCount-1)
 	loadNode := c.Node(c.Spec().NodeCount)
@@ -144,7 +144,7 @@ func registerSysbench(r *testRegistry) {
 			Name:    fmt.Sprintf("sysbench/%s/nodes=%d/cpu=%d/conc=%d", w, n, cpus, conc),
 			Owner:   OwnerKV,
 			Cluster: r.makeClusterSpec(n+1, spec.CPU(cpus)),
-			Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+			Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 				runSysbench(ctx, t, c, opts)
 			},
 		})

--- a/pkg/cmd/roachtest/sysbench.go
+++ b/pkg/cmd/roachtest/sysbench.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 )
 
@@ -85,7 +86,7 @@ func (o *sysbenchOptions) cmd(haproxy bool) string {
 	)
 }
 
-func runSysbench(ctx context.Context, t *test, c Cluster, opts sysbenchOptions) {
+func runSysbench(ctx context.Context, t *test, c cluster2.Cluster, opts sysbenchOptions) {
 	allNodes := c.Range(1, c.Spec().NodeCount)
 	roachNodes := c.Range(1, c.Spec().NodeCount-1)
 	loadNode := c.Node(c.Spec().NodeCount)
@@ -143,7 +144,7 @@ func registerSysbench(r *testRegistry) {
 			Name:    fmt.Sprintf("sysbench/%s/nodes=%d/cpu=%d/conc=%d", w, n, cpus, conc),
 			Owner:   OwnerKV,
 			Cluster: r.makeClusterSpec(n+1, spec.CPU(cpus)),
-			Run: func(ctx context.Context, t *test, c Cluster) {
+			Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 				runSysbench(ctx, t, c, opts)
 			},
 		})

--- a/pkg/cmd/roachtest/sysbench.go
+++ b/pkg/cmd/roachtest/sysbench.go
@@ -92,7 +92,7 @@ func runSysbench(ctx context.Context, t *test, c Cluster, opts sysbenchOptions) 
 
 	t.Status("installing cockroach")
 	c.Put(ctx, cockroach, "./cockroach", allNodes)
-	c.Start(ctx, t, roachNodes)
+	c.Start(ctx, roachNodes)
 	waitForFullReplication(t, c.Conn(ctx, allNodes[0]))
 
 	t.Status("installing haproxy")

--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -527,7 +527,7 @@ type workerStatus struct {
 
 		ttr testToRunRes
 		t   *test
-		c   *cluster
+		c   *clusterImpl
 	}
 }
 
@@ -543,13 +543,13 @@ func (w *workerStatus) SetStatus(status string) {
 	w.mu.Unlock()
 }
 
-func (w *workerStatus) Cluster() *cluster {
+func (w *workerStatus) Cluster() *clusterImpl {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	return w.mu.c
 }
 
-func (w *workerStatus) SetCluster(c *cluster) {
+func (w *workerStatus) SetCluster(c *clusterImpl) {
 	w.mu.Lock()
 	w.mu.c = c
 	w.mu.Unlock()

--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/logger"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
@@ -84,7 +84,7 @@ type testSpec struct {
 	RequiresLicense bool
 
 	// Run is the test function.
-	Run func(ctx context.Context, t *test, c cluster2.Cluster)
+	Run func(ctx context.Context, t *test, c cluster.Cluster)
 }
 
 // perfArtifactsDir is the directory on cluster nodes in which perf artifacts

--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/logger"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
@@ -83,7 +84,7 @@ type testSpec struct {
 	RequiresLicense bool
 
 	// Run is the test function.
-	Run func(ctx context.Context, t *test, c Cluster)
+	Run func(ctx context.Context, t *test, c cluster2.Cluster)
 }
 
 // perfArtifactsDir is the directory on cluster nodes in which perf artifacts

--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -317,13 +317,6 @@ func (t *test) fatalfInner(format string, args ...interface{}) {
 	panic(errTestFatal)
 }
 
-// FatalIfErr calls t.Fatal() if err != nil.
-func FatalIfErr(t *test, err error) {
-	if err != nil {
-		t.fatalfInner("" /* format */, err)
-	}
-}
-
 func (t *test) printAndFail(skip int, args ...interface{}) {
 	var msg string
 	if len(args) == 1 {

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -927,6 +927,11 @@ func (r *testRunner) collectClusterLogs(ctx context.Context, c *cluster, t *test
 	// hang sometimes at the time of writing, see:
 	// https://github.com/cockroachdb/cockroach/issues/39620
 	t.l.PrintfCtx(ctx, "collecting cluster logs")
+	// Do this before collecting logs to make sure the file gets
+	// downloaded below.
+	if err := saveDiskUsageToLogsDir(ctx, c); err != nil {
+		t.l.Printf("failed to fetch disk uage summary: %s", err)
+	}
 	if err := c.FetchLogs(ctx, t); err != nil {
 		t.l.Printf("failed to download logs: %s", err)
 	}
@@ -941,9 +946,6 @@ func (r *testRunner) collectClusterLogs(ctx context.Context, c *cluster, t *test
 	}
 	if err := c.CopyRoachprodState(ctx); err != nil {
 		t.l.Printf("failed to copy roachprod state: %s", err)
-	}
-	if err := c.FetchDiskUsage(ctx, t); err != nil {
-		t.l.Printf("failed to fetch disk uage summary: %s", err)
 	}
 	if err := c.FetchTimeseriesData(ctx, t); err != nil {
 		t.l.Printf("failed to fetch timeseries data: %s", err)

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -231,7 +231,7 @@ func (r *testRunner) Run(
 		alloc *quotapool.IntAlloc,
 		artifactsDir string,
 		wStatus *workerStatus,
-	) (*cluster, error) {
+	) (*clusterImpl, error) {
 		wStatus.SetStatus("creating cluster")
 		defer wStatus.SetStatus("")
 
@@ -345,7 +345,7 @@ type clusterAllocatorFn func(
 	alloc *quotapool.IntAlloc,
 	artifactsDir string,
 	wStatus *workerStatus,
-) (*cluster, error)
+) (*clusterImpl, error)
 
 // runWorker runs tests in a loop until work is exhausted.
 //
@@ -389,7 +389,7 @@ func (r *testRunner) runWorker(
 		r.removeWorker(ctx, name)
 	}()
 
-	var c *cluster // The cluster currently being used.
+	var c *clusterImpl // The cluster currently being used.
 	var err error
 	// When this method returns we'll destroy the cluster we had at the time.
 	// Note that, if debug was set, c has been set to nil.
@@ -439,7 +439,7 @@ func (r *testRunner) runWorker(
 		testToRun, c, err = r.getWork(
 			ctx, work, qp, c, interrupt, l,
 			getWorkCallbacks{
-				createCluster: func(ctx context.Context, ttr testToRunRes) (*cluster, error) {
+				createCluster: func(ctx context.Context, ttr testToRunRes) (*clusterImpl, error) {
 					wStatus.SetTest(nil /* test */, ttr)
 					return allocateCluster(ctx, ttr.spec, ttr.alloc, artifactsRootDir, wStatus)
 				},
@@ -542,7 +542,7 @@ func (r *testRunner) runWorker(
 // getPerfArtifacts retrieves the perf artifacts for the test.
 // If there's an error, oh well, don't do anything rash like fail a test
 // which already passed.
-func getPerfArtifacts(ctx context.Context, l *logger.Logger, c *cluster, t *test) {
+func getPerfArtifacts(ctx context.Context, l *logger.Logger, c *clusterImpl, t *test) {
 	g := ctxgroup.WithContext(ctx)
 	fetchNode := func(node int) func(context.Context) error {
 		return func(ctx context.Context) error {
@@ -599,7 +599,7 @@ func (r *testRunner) runTest(
 	ctx context.Context,
 	t *test,
 	runNum int,
-	c *cluster,
+	c *clusterImpl,
 	testRunnerLogPath string,
 	stdout io.Writer,
 	l *logger.Logger,
@@ -917,7 +917,7 @@ caffeinate ./roachstress.sh %s
 	}
 }
 
-func (r *testRunner) collectClusterLogs(ctx context.Context, c *cluster, t *test) {
+func (r *testRunner) collectClusterLogs(ctx context.Context, c *clusterImpl, t *test) {
 	// NB: fetch the logs even when we have a debug zip because
 	// debug zip can't ever get the logs for down nodes.
 	// We only save artifacts for failed tests in CI, so this
@@ -985,7 +985,7 @@ func (r *testRunner) generateReport() string {
 }
 
 type getWorkCallbacks struct {
-	createCluster func(context.Context, testToRunRes) (*cluster, error)
+	createCluster func(context.Context, testToRunRes) (*clusterImpl, error)
 	onDestroy     func()
 }
 
@@ -1001,11 +1001,11 @@ func (r *testRunner) getWork(
 	ctx context.Context,
 	work *workPool,
 	qp *quotapool.IntPool,
-	c *cluster,
+	c *clusterImpl,
 	interrupt <-chan struct{},
 	l *logger.Logger,
 	callbacks getWorkCallbacks,
-) (testToRunRes, *cluster, error) {
+) (testToRunRes, *clusterImpl, error) {
 
 	select {
 	case <-interrupt:

--- a/pkg/cmd/roachtest/test_test.go
+++ b/pkg/cmd/roachtest/test_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/logger"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -92,13 +92,13 @@ func TestRunnerRun(t *testing.T) {
 	r.Add(testSpec{
 		Name:    "pass",
 		Owner:   OwnerUnitTest,
-		Run:     func(ctx context.Context, t *test, c cluster2.Cluster) {},
+		Run:     func(ctx context.Context, t *test, c cluster.Cluster) {},
 		Cluster: r.makeClusterSpec(0),
 	})
 	r.Add(testSpec{
 		Name:  "fail",
 		Owner: OwnerUnitTest,
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			t.Fatal("failed")
 		},
 		Cluster: r.makeClusterSpec(0),
@@ -186,7 +186,7 @@ func TestRunnerTestTimeout(t *testing.T) {
 		Owner:   OwnerUnitTest,
 		Timeout: 10 * time.Millisecond,
 		Cluster: spec.MakeClusterSpec(spec.GCE, "", 0),
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			<-ctx.Done()
 		},
 	}
@@ -204,7 +204,7 @@ func TestRunnerTestTimeout(t *testing.T) {
 }
 
 func TestRegistryPrepareSpec(t *testing.T) {
-	dummyRun := func(context.Context, *test, cluster2.Cluster) {}
+	dummyRun := func(context.Context, *test, cluster.Cluster) {}
 
 	var listTests = func(t *testSpec) []string {
 		return []string{t.Name}
@@ -301,7 +301,7 @@ func TestRegistryMinVersion(t *testing.T) {
 				Owner:      OwnerUnitTest,
 				MinVersion: "v2.0.0",
 				Cluster:    spec.MakeClusterSpec(spec.GCE, "", 0),
-				Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+				Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 					runA = true
 				},
 			})
@@ -310,7 +310,7 @@ func TestRegistryMinVersion(t *testing.T) {
 				Owner:      OwnerUnitTest,
 				MinVersion: "v2.1.0",
 				Cluster:    spec.MakeClusterSpec(spec.GCE, "", 0),
-				Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+				Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 					runB = true
 				},
 			})
@@ -359,7 +359,7 @@ func runExitCodeTest(t *testing.T, injectedError error) error {
 		Name:    "boom",
 		Owner:   OwnerUnitTest,
 		Cluster: spec.MakeClusterSpec(spec.GCE, "", 0),
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			if injectedError != nil {
 				t.Fatal(injectedError)
 			}

--- a/pkg/cmd/roachtest/test_test.go
+++ b/pkg/cmd/roachtest/test_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/logger"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -91,13 +92,13 @@ func TestRunnerRun(t *testing.T) {
 	r.Add(testSpec{
 		Name:    "pass",
 		Owner:   OwnerUnitTest,
-		Run:     func(ctx context.Context, t *test, c Cluster) {},
+		Run:     func(ctx context.Context, t *test, c cluster2.Cluster) {},
 		Cluster: r.makeClusterSpec(0),
 	})
 	r.Add(testSpec{
 		Name:  "fail",
 		Owner: OwnerUnitTest,
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			t.Fatal("failed")
 		},
 		Cluster: r.makeClusterSpec(0),
@@ -185,7 +186,7 @@ func TestRunnerTestTimeout(t *testing.T) {
 		Owner:   OwnerUnitTest,
 		Timeout: 10 * time.Millisecond,
 		Cluster: spec.MakeClusterSpec(spec.GCE, "", 0),
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			<-ctx.Done()
 		},
 	}
@@ -203,7 +204,7 @@ func TestRunnerTestTimeout(t *testing.T) {
 }
 
 func TestRegistryPrepareSpec(t *testing.T) {
-	dummyRun := func(context.Context, *test, Cluster) {}
+	dummyRun := func(context.Context, *test, cluster2.Cluster) {}
 
 	var listTests = func(t *testSpec) []string {
 		return []string{t.Name}
@@ -300,7 +301,7 @@ func TestRegistryMinVersion(t *testing.T) {
 				Owner:      OwnerUnitTest,
 				MinVersion: "v2.0.0",
 				Cluster:    spec.MakeClusterSpec(spec.GCE, "", 0),
-				Run: func(ctx context.Context, t *test, c Cluster) {
+				Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 					runA = true
 				},
 			})
@@ -309,7 +310,7 @@ func TestRegistryMinVersion(t *testing.T) {
 				Owner:      OwnerUnitTest,
 				MinVersion: "v2.1.0",
 				Cluster:    spec.MakeClusterSpec(spec.GCE, "", 0),
-				Run: func(ctx context.Context, t *test, c Cluster) {
+				Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 					runB = true
 				},
 			})
@@ -358,7 +359,7 @@ func runExitCodeTest(t *testing.T, injectedError error) error {
 		Name:    "boom",
 		Owner:   OwnerUnitTest,
 		Cluster: spec.MakeClusterSpec(spec.GCE, "", 0),
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			if injectedError != nil {
 				t.Fatal(injectedError)
 			}

--- a/pkg/cmd/roachtest/tlp.go
+++ b/pkg/cmd/roachtest/tlp.go
@@ -67,7 +67,7 @@ func runTLP(ctx context.Context, t *test, c Cluster) {
 	if err := c.PutLibraries(ctx, "./lib"); err != nil {
 		t.Fatalf("could not initialize libraries: %v", err)
 	}
-	c.Start(ctx, t)
+	c.Start(ctx)
 
 	setup := sqlsmith.Setups["rand-tables"](rnd)
 

--- a/pkg/cmd/roachtest/tlp.go
+++ b/pkg/cmd/roachtest/tlp.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/internal/sqlsmith"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/errors"
@@ -37,7 +38,7 @@ func registerTLP(r *testRegistry) {
 	})
 }
 
-func runTLP(ctx context.Context, t *test, c Cluster) {
+func runTLP(ctx context.Context, t *test, c cluster2.Cluster) {
 	// Set up a statement logger for easy reproduction. We only
 	// want to log successful statements and statements that
 	// produced a TLP error.

--- a/pkg/cmd/roachtest/tlp.go
+++ b/pkg/cmd/roachtest/tlp.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/internal/sqlsmith"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/errors"
@@ -38,7 +38,7 @@ func registerTLP(r *testRegistry) {
 	})
 }
 
-func runTLP(ctx context.Context, t *test, c cluster2.Cluster) {
+func runTLP(ctx context.Context, t *test, c cluster.Cluster) {
 	// Set up a statement logger for easy reproduction. We only
 	// want to log successful statements and statements that
 	// produced a TLP error.

--- a/pkg/cmd/roachtest/toxiproxy.go
+++ b/pkg/cmd/roachtest/toxiproxy.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	toxiproxy "github.com/Shopify/toxiproxy/client"
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/errors"
 )
@@ -74,7 +75,7 @@ until nc -z localhost $1; do sleep 0.1; echo "waiting for toxiproxy-server..."; 
 // See Toxify() for details.
 type ToxiCluster struct {
 	t *test
-	Cluster
+	cluster2.Cluster
 	toxClients map[int]*toxiproxy.Client
 	toxProxies map[int]*toxiproxy.Proxy
 }
@@ -86,7 +87,7 @@ type ToxiCluster struct {
 // toxiproxy. The upstream (i.e. non-intercepted) addresses are accessible via
 // getters prefixed with "External".
 func Toxify(
-	ctx context.Context, t *test, c Cluster, node option.NodeListOption,
+	ctx context.Context, t *test, c cluster2.Cluster, node option.NodeListOption,
 ) (*ToxiCluster, error) {
 	toxiURL := "https://github.com/Shopify/toxiproxy/releases/download/v2.1.4/toxiproxy-server-linux-amd64"
 	if local && runtime.GOOS == "darwin" {

--- a/pkg/cmd/roachtest/toxiproxy.go
+++ b/pkg/cmd/roachtest/toxiproxy.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	toxiproxy "github.com/Shopify/toxiproxy/client"
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/errors"
 )
@@ -75,7 +75,7 @@ until nc -z localhost $1; do sleep 0.1; echo "waiting for toxiproxy-server..."; 
 // See Toxify() for details.
 type ToxiCluster struct {
 	t *test
-	cluster2.Cluster
+	cluster.Cluster
 	toxClients map[int]*toxiproxy.Client
 	toxProxies map[int]*toxiproxy.Proxy
 }
@@ -87,7 +87,7 @@ type ToxiCluster struct {
 // toxiproxy. The upstream (i.e. non-intercepted) addresses are accessible via
 // getters prefixed with "External".
 func Toxify(
-	ctx context.Context, t *test, c cluster2.Cluster, node option.NodeListOption,
+	ctx context.Context, t *test, c cluster.Cluster, node option.NodeListOption,
 ) (*ToxiCluster, error) {
 	toxiURL := "https://github.com/Shopify/toxiproxy/releases/download/v2.1.4/toxiproxy-server-linux-amd64"
 	if local && runtime.GOOS == "darwin" {

--- a/pkg/cmd/roachtest/tpc_utils.go
+++ b/pkg/cmd/roachtest/tpc_utils.go
@@ -15,6 +15,7 @@ import (
 	gosql "database/sql"
 	"fmt"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/errors"
@@ -27,7 +28,12 @@ import (
 // scale factor at least as large as the provided scale factor), performing an
 // expensive dataset restore only if it doesn't.
 func loadTPCHDataset(
-	ctx context.Context, t *test, c Cluster, sf int, m *monitor, roachNodes option.NodeListOption,
+	ctx context.Context,
+	t *test,
+	c cluster2.Cluster,
+	sf int,
+	m *monitor,
+	roachNodes option.NodeListOption,
 ) error {
 	db := c.Conn(ctx, roachNodes[0])
 	defer db.Close()

--- a/pkg/cmd/roachtest/tpc_utils.go
+++ b/pkg/cmd/roachtest/tpc_utils.go
@@ -60,7 +60,7 @@ func loadTPCHDataset(
 		// cluster and restore.
 		m.ExpectDeaths(int32(c.Spec().NodeCount))
 		c.Wipe(ctx, roachNodes)
-		c.Start(ctx, t, roachNodes)
+		c.Start(ctx, roachNodes)
 		m.ResetDeaths()
 	} else if pqErr := (*pq.Error)(nil); !(errors.As(err, &pqErr) &&
 		pgcode.MakeCode(string(pqErr.Code)) == pgcode.InvalidCatalogName) {

--- a/pkg/cmd/roachtest/tpc_utils.go
+++ b/pkg/cmd/roachtest/tpc_utils.go
@@ -15,7 +15,7 @@ import (
 	gosql "database/sql"
 	"fmt"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/errors"
@@ -30,7 +30,7 @@ import (
 func loadTPCHDataset(
 	ctx context.Context,
 	t *test,
-	c cluster2.Cluster,
+	c cluster.Cluster,
 	sf int,
 	m *monitor,
 	roachNodes option.NodeListOption,

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -101,7 +101,7 @@ func setupTPCC(
 			// We still use bare workload, though we could likely replace
 			// those with ./cockroach workload as well.
 			c.Put(ctx, workload, "./workload", workloadNode)
-			c.Start(ctx, t, crdbNodes)
+			c.Start(ctx, crdbNodes)
 		}
 	}
 
@@ -757,7 +757,7 @@ func loadTPCCBench(
 		// If the dataset exists but is not large enough, wipe the cluster
 		// before restoring.
 		c.Wipe(ctx, roachNodes)
-		c.Start(ctx, t, append(b.startOpts(), roachNodes)...)
+		c.Start(ctx, append(b.startOpts(), roachNodes)...)
 	} else if pqErr := (*pq.Error)(nil); !(errors.As(err, &pqErr) &&
 		pgcode.MakeCode(string(pqErr.Code)) == pgcode.InvalidCatalogName) {
 		return err
@@ -851,7 +851,7 @@ func runTPCCBench(ctx context.Context, t *test, c Cluster, b tpccBenchSpec) {
 	// Don't encrypt in tpccbench tests.
 	c.EncryptDefault(false)
 	c.EncryptAtRandom(false)
-	c.Start(ctx, t, append(b.startOpts(), roachNodes)...)
+	c.Start(ctx, append(b.startOpts(), roachNodes)...)
 
 	useHAProxy := b.Chaos
 	const restartWait = 15 * time.Second
@@ -940,7 +940,7 @@ func runTPCCBench(ctx context.Context, t *test, c Cluster, b tpccBenchSpec) {
 			t.Fatalf("VM is hosed; giving up")
 		}
 
-		c.Start(ctx, t, append(b.startOpts(), roachNodes)...)
+		c.Start(ctx, append(b.startOpts(), roachNodes)...)
 	}
 
 	s := search.NewLineSearcher(1, b.LoadWarehouses, b.EstimatedMax, initStepSize, precision)

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/prometheus"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
@@ -61,7 +61,7 @@ type tpccOptions struct {
 	// TODO(tbg): for better coverage at scale of the migration process, we should
 	// also be doing a rolling-restart into the new binary while the cluster
 	// is running, but that feels like jamming too much into the tpcc setup.
-	Start func(context.Context, *test, cluster2.Cluster)
+	Start func(context.Context, *test, cluster.Cluster)
 }
 
 // tpccImportCmd generates the command string to load tpcc data for the
@@ -84,7 +84,7 @@ func tpccImportCmdWithCockroachBinary(
 }
 
 func setupTPCC(
-	ctx context.Context, t *test, c cluster2.Cluster, opts tpccOptions,
+	ctx context.Context, t *test, c cluster.Cluster, opts tpccOptions,
 ) (crdbNodes, workloadNode option.NodeListOption) {
 	// Randomize starting with encryption-at-rest enabled.
 	c.EncryptAtRandom(true)
@@ -95,7 +95,7 @@ func setupTPCC(
 	}
 
 	if opts.Start == nil {
-		opts.Start = func(ctx context.Context, t *test, c cluster2.Cluster) {
+		opts.Start = func(ctx context.Context, t *test, c cluster.Cluster) {
 			// NB: workloadNode also needs ./cockroach because
 			// of `./cockroach workload` for usingImport.
 			c.Put(ctx, cockroach, "./cockroach", c.All())
@@ -136,7 +136,7 @@ func setupTPCC(
 	return crdbNodes, workloadNode
 }
 
-func runTPCC(ctx context.Context, t *test, c cluster2.Cluster, opts tpccOptions) {
+func runTPCC(ctx context.Context, t *test, c cluster.Cluster, opts tpccOptions) {
 	if cfg := opts.PrometheusConfig; cfg != nil {
 		if c.IsLocal() {
 			t.Skip("skipping test as prometheus is needed, but prometheus does not yet work locally")
@@ -261,7 +261,7 @@ func registerTPCC(r *testRegistry) {
 		MinVersion: "v19.1.0",
 		Tags:       []string{`default`, `release_qualification`},
 		Cluster:    headroomSpec,
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			maxWarehouses := maxSupportedTPCCWarehouses(r.buildVersion, cloud, t.spec.Cluster)
 			headroomWarehouses := int(float64(maxWarehouses) * 0.7)
 			t.l.Printf("computed headroom warehouses of %d\n", headroomWarehouses)
@@ -285,7 +285,7 @@ func registerTPCC(r *testRegistry) {
 		// buggy.
 		Tags:    []string{`default`},
 		Cluster: mixedHeadroomSpec,
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			crdbNodes := c.Range(1, 4)
 			workloadNode := c.Node(5)
 
@@ -305,7 +305,7 @@ func registerTPCC(r *testRegistry) {
 						Warehouses: headroomWarehouses,
 						Duration:   duration,
 						SetupType:  usingExistingData,
-						Start: func(ctx context.Context, t *test, c cluster2.Cluster) {
+						Start: func(ctx context.Context, t *test, c cluster.Cluster) {
 							// Noop - we don't let tpcc upload or start binaries in this test.
 						},
 					})
@@ -365,7 +365,7 @@ func registerTPCC(r *testRegistry) {
 		Owner:      OwnerKV,
 		MinVersion: "v19.1.0",
 		Cluster:    r.makeClusterSpec(4, spec.CPU(16)),
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runTPCC(ctx, t, c, tpccOptions{
 				Warehouses:   1,
 				Duration:     10 * time.Minute,
@@ -381,7 +381,7 @@ func registerTPCC(r *testRegistry) {
 		Tags:       []string{`weekly`},
 		Cluster:    r.makeClusterSpec(4, spec.CPU(16)),
 		Timeout:    time.Duration(4*24)*time.Hour + time.Duration(10)*time.Minute,
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			warehouses := 1000
 			runTPCC(ctx, t, c, tpccOptions{
 				Warehouses: warehouses,
@@ -406,7 +406,7 @@ func registerTPCC(r *testRegistry) {
 			MinVersion: "v21.1.0",
 			// 3 nodes per region + 1 node for workload.
 			Cluster: r.makeClusterSpec(10, spec.Geo(), spec.Zones(strings.Join(zs, ","))),
-			Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+			Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 				duration := 90 * time.Minute
 				partitionArgs := fmt.Sprintf(
 					`--survival-goal=%s --regions=%s --partitions=%d`,
@@ -463,7 +463,7 @@ func registerTPCC(r *testRegistry) {
 		Owner:      OwnerKV,
 		MinVersion: "v19.1.0",
 		Cluster:    r.makeClusterSpec(4),
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			duration := 30 * time.Minute
 			runTPCC(ctx, t, c, tpccOptions{
 				Warehouses: 100,
@@ -492,7 +492,7 @@ func registerTPCC(r *testRegistry) {
 		MinVersion: "v20.1.0",
 		Cluster:    r.makeClusterSpec(4, spec.CPU(16)),
 		Timeout:    6 * time.Hour,
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			skip.WithIssue(t, 53886)
 			runTPCC(ctx, t, c, tpccOptions{
 				// Currently, we do not support import on interleaved tables which
@@ -720,7 +720,7 @@ func registerTPCCBenchSpec(r *testRegistry, b tpccBenchSpec) {
 		Cluster:    nodes,
 		MinVersion: minVersion,
 		Tags:       b.Tags,
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runTPCCBench(ctx, t, c, b)
 		},
 	})
@@ -732,7 +732,7 @@ func registerTPCCBenchSpec(r *testRegistry, b tpccBenchSpec) {
 func loadTPCCBench(
 	ctx context.Context,
 	t *test,
-	c cluster2.Cluster,
+	c cluster.Cluster,
 	b tpccBenchSpec,
 	roachNodes, loadNode option.NodeListOption,
 ) error {
@@ -836,7 +836,7 @@ func loadTPCCBench(
 // the tool to allow roachtest to create the correct set of VMs required by the
 // test. The `--wipe` flag will prevent this cluster from being destroyed, so it
 // can then be used during future runs.
-func runTPCCBench(ctx context.Context, t *test, c cluster2.Cluster, b tpccBenchSpec) {
+func runTPCCBench(ctx context.Context, t *test, c cluster.Cluster, b tpccBenchSpec) {
 	// Determine the nodes in each load group. A load group consists of a set of
 	// Cockroach nodes and a single load generator.
 	numLoadGroups := b.LoadConfig.numLoadNodes(b.Distribution)

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -89,7 +89,7 @@ func setupTPCC(
 	c.EncryptAtRandom(true)
 	crdbNodes = c.Range(1, c.Spec().NodeCount-1)
 	workloadNode = c.Node(c.Spec().NodeCount)
-	if c.isLocal() {
+	if c.IsLocal() {
 		opts.Warehouses = 1
 	}
 
@@ -137,7 +137,7 @@ func setupTPCC(
 
 func runTPCC(ctx context.Context, t *test, c Cluster, opts tpccOptions) {
 	if cfg := opts.PrometheusConfig; cfg != nil {
-		if c.isLocal() {
+		if c.IsLocal() {
 			t.Skip("skipping test as prometheus is needed, but prometheus does not yet work locally")
 			return
 		}
@@ -172,7 +172,7 @@ func runTPCC(ctx context.Context, t *test, c Cluster, opts tpccOptions) {
 	}
 
 	rampDuration := 5 * time.Minute
-	if c.isLocal() {
+	if c.IsLocal() {
 		opts.Warehouses = 1
 		if opts.Duration > time.Minute {
 			opts.Duration = time.Minute

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/prometheus"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
@@ -60,7 +61,7 @@ type tpccOptions struct {
 	// TODO(tbg): for better coverage at scale of the migration process, we should
 	// also be doing a rolling-restart into the new binary while the cluster
 	// is running, but that feels like jamming too much into the tpcc setup.
-	Start func(context.Context, *test, Cluster)
+	Start func(context.Context, *test, cluster2.Cluster)
 }
 
 // tpccImportCmd generates the command string to load tpcc data for the
@@ -83,7 +84,7 @@ func tpccImportCmdWithCockroachBinary(
 }
 
 func setupTPCC(
-	ctx context.Context, t *test, c Cluster, opts tpccOptions,
+	ctx context.Context, t *test, c cluster2.Cluster, opts tpccOptions,
 ) (crdbNodes, workloadNode option.NodeListOption) {
 	// Randomize starting with encryption-at-rest enabled.
 	c.EncryptAtRandom(true)
@@ -94,7 +95,7 @@ func setupTPCC(
 	}
 
 	if opts.Start == nil {
-		opts.Start = func(ctx context.Context, t *test, c Cluster) {
+		opts.Start = func(ctx context.Context, t *test, c cluster2.Cluster) {
 			// NB: workloadNode also needs ./cockroach because
 			// of `./cockroach workload` for usingImport.
 			c.Put(ctx, cockroach, "./cockroach", c.All())
@@ -135,7 +136,7 @@ func setupTPCC(
 	return crdbNodes, workloadNode
 }
 
-func runTPCC(ctx context.Context, t *test, c Cluster, opts tpccOptions) {
+func runTPCC(ctx context.Context, t *test, c cluster2.Cluster, opts tpccOptions) {
 	if cfg := opts.PrometheusConfig; cfg != nil {
 		if c.IsLocal() {
 			t.Skip("skipping test as prometheus is needed, but prometheus does not yet work locally")
@@ -260,7 +261,7 @@ func registerTPCC(r *testRegistry) {
 		MinVersion: "v19.1.0",
 		Tags:       []string{`default`, `release_qualification`},
 		Cluster:    headroomSpec,
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			maxWarehouses := maxSupportedTPCCWarehouses(r.buildVersion, cloud, t.spec.Cluster)
 			headroomWarehouses := int(float64(maxWarehouses) * 0.7)
 			t.l.Printf("computed headroom warehouses of %d\n", headroomWarehouses)
@@ -284,7 +285,7 @@ func registerTPCC(r *testRegistry) {
 		// buggy.
 		Tags:    []string{`default`},
 		Cluster: mixedHeadroomSpec,
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			crdbNodes := c.Range(1, 4)
 			workloadNode := c.Node(5)
 
@@ -304,7 +305,7 @@ func registerTPCC(r *testRegistry) {
 						Warehouses: headroomWarehouses,
 						Duration:   duration,
 						SetupType:  usingExistingData,
-						Start: func(ctx context.Context, t *test, c Cluster) {
+						Start: func(ctx context.Context, t *test, c cluster2.Cluster) {
 							// Noop - we don't let tpcc upload or start binaries in this test.
 						},
 					})
@@ -364,7 +365,7 @@ func registerTPCC(r *testRegistry) {
 		Owner:      OwnerKV,
 		MinVersion: "v19.1.0",
 		Cluster:    r.makeClusterSpec(4, spec.CPU(16)),
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runTPCC(ctx, t, c, tpccOptions{
 				Warehouses:   1,
 				Duration:     10 * time.Minute,
@@ -380,7 +381,7 @@ func registerTPCC(r *testRegistry) {
 		Tags:       []string{`weekly`},
 		Cluster:    r.makeClusterSpec(4, spec.CPU(16)),
 		Timeout:    time.Duration(4*24)*time.Hour + time.Duration(10)*time.Minute,
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			warehouses := 1000
 			runTPCC(ctx, t, c, tpccOptions{
 				Warehouses: warehouses,
@@ -405,7 +406,7 @@ func registerTPCC(r *testRegistry) {
 			MinVersion: "v21.1.0",
 			// 3 nodes per region + 1 node for workload.
 			Cluster: r.makeClusterSpec(10, spec.Geo(), spec.Zones(strings.Join(zs, ","))),
-			Run: func(ctx context.Context, t *test, c Cluster) {
+			Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 				duration := 90 * time.Minute
 				partitionArgs := fmt.Sprintf(
 					`--survival-goal=%s --regions=%s --partitions=%d`,
@@ -462,7 +463,7 @@ func registerTPCC(r *testRegistry) {
 		Owner:      OwnerKV,
 		MinVersion: "v19.1.0",
 		Cluster:    r.makeClusterSpec(4),
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			duration := 30 * time.Minute
 			runTPCC(ctx, t, c, tpccOptions{
 				Warehouses: 100,
@@ -491,7 +492,7 @@ func registerTPCC(r *testRegistry) {
 		MinVersion: "v20.1.0",
 		Cluster:    r.makeClusterSpec(4, spec.CPU(16)),
 		Timeout:    6 * time.Hour,
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			skip.WithIssue(t, 53886)
 			runTPCC(ctx, t, c, tpccOptions{
 				// Currently, we do not support import on interleaved tables which
@@ -719,7 +720,7 @@ func registerTPCCBenchSpec(r *testRegistry, b tpccBenchSpec) {
 		Cluster:    nodes,
 		MinVersion: minVersion,
 		Tags:       b.Tags,
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runTPCCBench(ctx, t, c, b)
 		},
 	})
@@ -731,7 +732,7 @@ func registerTPCCBenchSpec(r *testRegistry, b tpccBenchSpec) {
 func loadTPCCBench(
 	ctx context.Context,
 	t *test,
-	c Cluster,
+	c cluster2.Cluster,
 	b tpccBenchSpec,
 	roachNodes, loadNode option.NodeListOption,
 ) error {
@@ -835,7 +836,7 @@ func loadTPCCBench(
 // the tool to allow roachtest to create the correct set of VMs required by the
 // test. The `--wipe` flag will prevent this cluster from being destroyed, so it
 // can then be used during future runs.
-func runTPCCBench(ctx context.Context, t *test, c Cluster, b tpccBenchSpec) {
+func runTPCCBench(ctx context.Context, t *test, c cluster2.Cluster, b tpccBenchSpec) {
 	// Determine the nodes in each load group. A load group consists of a set of
 	// Cockroach nodes and a single load generator.
 	numLoadGroups := b.LoadConfig.numLoadNodes(b.Distribution)

--- a/pkg/cmd/roachtest/tpcdsvec.go
+++ b/pkg/cmd/roachtest/tpcdsvec.go
@@ -53,7 +53,7 @@ func registerTPCDSVec(r *testRegistry) {
 
 	runTPCDSVec := func(ctx context.Context, t *test, c Cluster) {
 		c.Put(ctx, cockroach, "./cockroach", c.All())
-		c.Start(ctx, t)
+		c.Start(ctx)
 
 		clusterConn := c.Conn(ctx, 1)
 		disableAutoStats(t, clusterConn)

--- a/pkg/cmd/roachtest/tpcdsvec.go
+++ b/pkg/cmd/roachtest/tpcdsvec.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/cmpconn"
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/workload/tpcds"
 	"github.com/cockroachdb/errors"
@@ -51,7 +52,7 @@ func registerTPCDSVec(r *testRegistry) {
 		`web_sales`, `web_site`,
 	}
 
-	runTPCDSVec := func(ctx context.Context, t *test, c Cluster) {
+	runTPCDSVec := func(ctx context.Context, t *test, c cluster2.Cluster) {
 		c.Put(ctx, cockroach, "./cockroach", c.All())
 		c.Start(ctx)
 
@@ -174,7 +175,7 @@ func registerTPCDSVec(r *testRegistry) {
 		Owner:      OwnerSQLQueries,
 		Cluster:    r.makeClusterSpec(3),
 		MinVersion: "v20.1.0",
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runTPCDSVec(ctx, t, c)
 		},
 	})

--- a/pkg/cmd/roachtest/tpcdsvec.go
+++ b/pkg/cmd/roachtest/tpcdsvec.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/cmpconn"
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/workload/tpcds"
 	"github.com/cockroachdb/errors"
@@ -52,7 +52,7 @@ func registerTPCDSVec(r *testRegistry) {
 		`web_sales`, `web_site`,
 	}
 
-	runTPCDSVec := func(ctx context.Context, t *test, c cluster2.Cluster) {
+	runTPCDSVec := func(ctx context.Context, t *test, c cluster.Cluster) {
 		c.Put(ctx, cockroach, "./cockroach", c.All())
 		c.Start(ctx)
 
@@ -175,7 +175,7 @@ func registerTPCDSVec(r *testRegistry) {
 		Owner:      OwnerSQLQueries,
 		Cluster:    r.makeClusterSpec(3),
 		MinVersion: "v20.1.0",
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runTPCDSVec(ctx, t, c)
 		},
 	})

--- a/pkg/cmd/roachtest/tpce.go
+++ b/pkg/cmd/roachtest/tpce.go
@@ -38,7 +38,7 @@ func registerTPCE(r *testRegistry) {
 
 		t.Status("installing cockroach")
 		c.Put(ctx, cockroach, "./cockroach", roachNodes)
-		c.Start(ctx, t, roachNodes, startArgs(
+		c.Start(ctx, roachNodes, startArgs(
 			fmt.Sprintf("--racks=%d", racks),
 			fmt.Sprintf("--store-count=%d", opts.ssds),
 		))

--- a/pkg/cmd/roachtest/tpce.go
+++ b/pkg/cmd/roachtest/tpce.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/errors"
 )
@@ -31,7 +32,7 @@ func registerTPCE(r *testRegistry) {
 		timeout time.Duration
 	}
 
-	runTPCE := func(ctx context.Context, t *test, c Cluster, opts tpceOptions) {
+	runTPCE := func(ctx context.Context, t *test, c cluster2.Cluster, opts tpceOptions) {
 		roachNodes := c.Range(1, opts.nodes)
 		loadNode := c.Node(opts.nodes + 1)
 		racks := opts.nodes
@@ -113,7 +114,7 @@ func registerTPCE(r *testRegistry) {
 			Tags:    opts.tags,
 			Timeout: opts.timeout,
 			Cluster: r.makeClusterSpec(opts.nodes+1, spec.CPU(opts.cpus), spec.SSD(opts.ssds)),
-			Run: func(ctx context.Context, t *test, c Cluster) {
+			Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 				runTPCE(ctx, t, c, opts)
 			},
 		})

--- a/pkg/cmd/roachtest/tpce.go
+++ b/pkg/cmd/roachtest/tpce.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/errors"
 )
@@ -32,7 +32,7 @@ func registerTPCE(r *testRegistry) {
 		timeout time.Duration
 	}
 
-	runTPCE := func(ctx context.Context, t *test, c cluster2.Cluster, opts tpceOptions) {
+	runTPCE := func(ctx context.Context, t *test, c cluster.Cluster, opts tpceOptions) {
 		roachNodes := c.Range(1, opts.nodes)
 		loadNode := c.Node(opts.nodes + 1)
 		racks := opts.nodes
@@ -114,7 +114,7 @@ func registerTPCE(r *testRegistry) {
 			Tags:    opts.tags,
 			Timeout: opts.timeout,
 			Cluster: r.makeClusterSpec(opts.nodes+1, spec.CPU(opts.cpus), spec.SSD(opts.ssds)),
-			Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+			Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 				runTPCE(ctx, t, c, opts)
 			},
 		})

--- a/pkg/cmd/roachtest/tpchbench.go
+++ b/pkg/cmd/roachtest/tpchbench.go
@@ -63,7 +63,7 @@ func runTPCHBench(ctx context.Context, t *test, c Cluster, b tpchBenchSpec) {
 	}
 
 	t.Status("starting nodes")
-	c.Start(ctx, t, roachNodes)
+	c.Start(ctx, roachNodes)
 
 	m := newMonitor(ctx, c, roachNodes)
 	m.Go(func(ctx context.Context) error {

--- a/pkg/cmd/roachtest/tpchbench.go
+++ b/pkg/cmd/roachtest/tpchbench.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/cockroachdb/cockroach/pkg/workload/querybench"
 )
@@ -49,7 +49,7 @@ type tpchBenchSpec struct {
 //
 // This benchmark runs with a single load generator node running a single
 // worker.
-func runTPCHBench(ctx context.Context, t *test, c cluster2.Cluster, b tpchBenchSpec) {
+func runTPCHBench(ctx context.Context, t *test, c cluster.Cluster, b tpchBenchSpec) {
 	roachNodes := c.Range(1, c.Spec().NodeCount-1)
 	loadNode := c.Node(c.Spec().NodeCount)
 
@@ -168,7 +168,7 @@ func registerTPCHBenchSpec(r *testRegistry, b tpchBenchSpec) {
 		Owner:      OwnerSQLQueries,
 		Cluster:    r.makeClusterSpec(numNodes),
 		MinVersion: minVersion,
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runTPCHBench(ctx, t, c, b)
 		},
 	})

--- a/pkg/cmd/roachtest/tpchbench.go
+++ b/pkg/cmd/roachtest/tpchbench.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/cockroachdb/cockroach/pkg/workload/querybench"
 )
@@ -48,7 +49,7 @@ type tpchBenchSpec struct {
 //
 // This benchmark runs with a single load generator node running a single
 // worker.
-func runTPCHBench(ctx context.Context, t *test, c Cluster, b tpchBenchSpec) {
+func runTPCHBench(ctx context.Context, t *test, c cluster2.Cluster, b tpchBenchSpec) {
 	roachNodes := c.Range(1, c.Spec().NodeCount-1)
 	loadNode := c.Node(c.Spec().NodeCount)
 
@@ -167,7 +168,7 @@ func registerTPCHBenchSpec(r *testRegistry, b tpchBenchSpec) {
 		Owner:      OwnerSQLQueries,
 		Cluster:    r.makeClusterSpec(numNodes),
 		MinVersion: minVersion,
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runTPCHBench(ctx, t, c, b)
 		},
 	})

--- a/pkg/cmd/roachtest/tpchvec.go
+++ b/pkg/cmd/roachtest/tpchvec.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"strings"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/binfetcher"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/workload/tpch"
@@ -70,13 +71,13 @@ type tpchVecTestCase interface {
 	// preTestRunHook is called before any tpch query is run. Can be used to
 	// perform any setup that cannot be expressed as a modification to
 	// cluster-wide settings (those should go into tpchVecTestRunConfig).
-	preTestRunHook(ctx context.Context, t *test, c Cluster, conn *gosql.DB, clusterSetup []string)
+	preTestRunHook(ctx context.Context, t *test, c cluster2.Cluster, conn *gosql.DB, clusterSetup []string)
 	// postQueryRunHook is called after each tpch query is run with the output and
 	// the index of the setup it was run in.
 	postQueryRunHook(t *test, output []byte, setupIdx int)
 	// postTestRunHook is called after all tpch queries are run. Can be used to
 	// perform teardown or general validation.
-	postTestRunHook(ctx context.Context, t *test, c Cluster, conn *gosql.DB)
+	postTestRunHook(ctx context.Context, t *test, c cluster2.Cluster, conn *gosql.DB)
 }
 
 // tpchVecTestCaseBase is a default tpchVecTestCase implementation that can be
@@ -109,7 +110,7 @@ func (b tpchVecTestCaseBase) preTestRunHook(
 
 func (b tpchVecTestCaseBase) postQueryRunHook(*test, []byte, int) {}
 
-func (b tpchVecTestCaseBase) postTestRunHook(context.Context, *test, Cluster, *gosql.DB) {
+func (b tpchVecTestCaseBase) postTestRunHook(context.Context, *test, cluster2.Cluster, *gosql.DB) {
 }
 
 type tpchVecPerfHelper struct {
@@ -192,7 +193,7 @@ func (p tpchVecPerfTest) getRunConfig() tpchVecTestRunConfig {
 }
 
 func (p tpchVecPerfTest) preTestRunHook(
-	ctx context.Context, t *test, c Cluster, conn *gosql.DB, clusterSetup []string,
+	ctx context.Context, t *test, c cluster2.Cluster, conn *gosql.DB, clusterSetup []string,
 ) {
 	p.tpchVecTestCaseBase.preTestRunHook(t, conn, clusterSetup, !p.disableStatsCreation /* createStats */)
 }
@@ -201,7 +202,9 @@ func (p *tpchVecPerfTest) postQueryRunHook(t *test, output []byte, setupIdx int)
 	p.parseQueryOutput(t, output, setupIdx)
 }
 
-func (p *tpchVecPerfTest) postTestRunHook(ctx context.Context, t *test, c Cluster, conn *gosql.DB) {
+func (p *tpchVecPerfTest) postTestRunHook(
+	ctx context.Context, t *test, c cluster2.Cluster, conn *gosql.DB,
+) {
 	runConfig := p.getRunConfig()
 	t.Status("comparing the runtimes (only median values for each query are compared)")
 	for _, queryNum := range runConfig.queriesToRun {
@@ -354,7 +357,7 @@ func (b tpchVecBenchTest) getRunConfig() tpchVecTestRunConfig {
 }
 
 func (b tpchVecBenchTest) preTestRunHook(
-	_ context.Context, t *test, _ Cluster, conn *gosql.DB, clusterSetup []string,
+	_ context.Context, t *test, _ cluster2.Cluster, conn *gosql.DB, clusterSetup []string,
 ) {
 	b.tpchVecTestCaseBase.preTestRunHook(t, conn, clusterSetup, true /* createStats */)
 }
@@ -364,7 +367,7 @@ func (b *tpchVecBenchTest) postQueryRunHook(t *test, output []byte, setupIdx int
 }
 
 func (b *tpchVecBenchTest) postTestRunHook(
-	ctx context.Context, t *test, c Cluster, conn *gosql.DB,
+	ctx context.Context, t *test, c cluster2.Cluster, conn *gosql.DB,
 ) {
 	runConfig := b.getRunConfig()
 	t.Status("comparing the runtimes (average of values (excluding best and worst) for each query are compared)")
@@ -423,7 +426,7 @@ type tpchVecDiskTest struct {
 }
 
 func (d tpchVecDiskTest) preTestRunHook(
-	ctx context.Context, t *test, c Cluster, conn *gosql.DB, clusterSetup []string,
+	ctx context.Context, t *test, c cluster2.Cluster, conn *gosql.DB, clusterSetup []string,
 ) {
 	d.tpchVecTestCaseBase.preTestRunHook(t, conn, clusterSetup, true /* createStats */)
 	// In order to stress the disk spilling of the vectorized engine, we will
@@ -446,7 +449,9 @@ func (d tpchVecDiskTest) preTestRunHook(
 	}
 }
 
-func baseTestRun(ctx context.Context, t *test, c Cluster, conn *gosql.DB, tc tpchVecTestCase) {
+func baseTestRun(
+	ctx context.Context, t *test, c cluster2.Cluster, conn *gosql.DB, tc tpchVecTestCase,
+) {
 	firstNode := c.Node(1)
 	runConfig := tc.getRunConfig()
 	for setupIdx, setup := range runConfig.clusterSetups {
@@ -479,7 +484,7 @@ type tpchVecSmithcmpTest struct {
 const tpchVecSmithcmp = "smithcmp"
 
 func (s tpchVecSmithcmpTest) preTestRunHook(
-	ctx context.Context, t *test, c Cluster, conn *gosql.DB, clusterSetup []string,
+	ctx context.Context, t *test, c cluster2.Cluster, conn *gosql.DB, clusterSetup []string,
 ) {
 	s.tpchVecTestCaseBase.preTestRunHook(t, conn, clusterSetup, true /* createStats */)
 	const smithcmpSHA = "a3f41f5ba9273249c5ecfa6348ea8ee3ac4b77e3"
@@ -504,7 +509,9 @@ func (s tpchVecSmithcmpTest) preTestRunHook(
 	c.Put(ctx, smithcmp, "./"+tpchVecSmithcmp, node)
 }
 
-func smithcmpTestRun(ctx context.Context, t *test, c Cluster, conn *gosql.DB, tc tpchVecTestCase) {
+func smithcmpTestRun(
+	ctx context.Context, t *test, c cluster2.Cluster, conn *gosql.DB, tc tpchVecTestCase,
+) {
 	runConfig := tc.getRunConfig()
 	tc.preTestRunHook(ctx, t, c, conn, runConfig.clusterSetups[0])
 	const (
@@ -524,9 +531,9 @@ func smithcmpTestRun(ctx context.Context, t *test, c Cluster, conn *gosql.DB, tc
 func runTPCHVec(
 	ctx context.Context,
 	t *test,
-	c Cluster,
+	c cluster2.Cluster,
 	testCase tpchVecTestCase,
-	testRun func(ctx context.Context, t *test, c Cluster, conn *gosql.DB, tc tpchVecTestCase),
+	testRun func(ctx context.Context, t *test, c cluster2.Cluster, conn *gosql.DB, tc tpchVecTestCase),
 ) {
 	firstNode := c.Node(1)
 	c.Put(ctx, cockroach, "./cockroach", c.All())
@@ -559,7 +566,7 @@ func registerTPCHVec(r *testRegistry) {
 		Owner:      OwnerSQLQueries,
 		Cluster:    r.makeClusterSpec(tpchVecNodeCount),
 		MinVersion: "v19.2.0",
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runTPCHVec(ctx, t, c, newTpchVecPerfTest(false /* disableStatsCreation */), baseTestRun)
 		},
 	})
@@ -571,7 +578,7 @@ func registerTPCHVec(r *testRegistry) {
 		// 19.2 version doesn't have disk spilling nor memory monitoring, so
 		// there is no point in running this config on that version.
 		MinVersion: "v20.1.0",
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runTPCHVec(ctx, t, c, tpchVecDiskTest{}, baseTestRun)
 		},
 	})
@@ -581,7 +588,7 @@ func registerTPCHVec(r *testRegistry) {
 		Owner:      OwnerSQLQueries,
 		Cluster:    r.makeClusterSpec(tpchVecNodeCount),
 		MinVersion: "v20.1.0",
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runTPCHVec(ctx, t, c, tpchVecSmithcmpTest{}, smithcmpTestRun)
 		},
 	})
@@ -591,7 +598,7 @@ func registerTPCHVec(r *testRegistry) {
 		Owner:      OwnerSQLQueries,
 		Cluster:    r.makeClusterSpec(tpchVecNodeCount),
 		MinVersion: "v20.2.0",
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runTPCHVec(ctx, t, c, newTpchVecPerfTest(true /* disableStatsCreation */), baseTestRun)
 		},
 	})
@@ -603,7 +610,7 @@ func registerTPCHVec(r *testRegistry) {
 		MinVersion: "v20.2.0",
 		Skip: "This config can be used to perform some benchmarking and is not " +
 			"meant to be run on a nightly basis",
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			// In order to use this test for benchmarking, include the queries
 			// that modify the cluster settings for all configs to benchmark
 			// like in the example below. The example benchmarks three values

--- a/pkg/cmd/roachtest/tpchvec.go
+++ b/pkg/cmd/roachtest/tpchvec.go
@@ -531,7 +531,7 @@ func runTPCHVec(
 	firstNode := c.Node(1)
 	c.Put(ctx, cockroach, "./cockroach", c.All())
 	c.Put(ctx, workload, "./workload", firstNode)
-	c.Start(ctx, t)
+	c.Start(ctx)
 
 	conn := c.Conn(ctx, 1)
 	disableAutoStats(t, conn)

--- a/pkg/cmd/roachtest/tpchvec.go
+++ b/pkg/cmd/roachtest/tpchvec.go
@@ -23,7 +23,7 @@ import (
 	"strconv"
 	"strings"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/binfetcher"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/workload/tpch"
@@ -71,13 +71,13 @@ type tpchVecTestCase interface {
 	// preTestRunHook is called before any tpch query is run. Can be used to
 	// perform any setup that cannot be expressed as a modification to
 	// cluster-wide settings (those should go into tpchVecTestRunConfig).
-	preTestRunHook(ctx context.Context, t *test, c cluster2.Cluster, conn *gosql.DB, clusterSetup []string)
+	preTestRunHook(ctx context.Context, t *test, c cluster.Cluster, conn *gosql.DB, clusterSetup []string)
 	// postQueryRunHook is called after each tpch query is run with the output and
 	// the index of the setup it was run in.
 	postQueryRunHook(t *test, output []byte, setupIdx int)
 	// postTestRunHook is called after all tpch queries are run. Can be used to
 	// perform teardown or general validation.
-	postTestRunHook(ctx context.Context, t *test, c cluster2.Cluster, conn *gosql.DB)
+	postTestRunHook(ctx context.Context, t *test, c cluster.Cluster, conn *gosql.DB)
 }
 
 // tpchVecTestCaseBase is a default tpchVecTestCase implementation that can be
@@ -110,7 +110,7 @@ func (b tpchVecTestCaseBase) preTestRunHook(
 
 func (b tpchVecTestCaseBase) postQueryRunHook(*test, []byte, int) {}
 
-func (b tpchVecTestCaseBase) postTestRunHook(context.Context, *test, cluster2.Cluster, *gosql.DB) {
+func (b tpchVecTestCaseBase) postTestRunHook(context.Context, *test, cluster.Cluster, *gosql.DB) {
 }
 
 type tpchVecPerfHelper struct {
@@ -193,7 +193,7 @@ func (p tpchVecPerfTest) getRunConfig() tpchVecTestRunConfig {
 }
 
 func (p tpchVecPerfTest) preTestRunHook(
-	ctx context.Context, t *test, c cluster2.Cluster, conn *gosql.DB, clusterSetup []string,
+	ctx context.Context, t *test, c cluster.Cluster, conn *gosql.DB, clusterSetup []string,
 ) {
 	p.tpchVecTestCaseBase.preTestRunHook(t, conn, clusterSetup, !p.disableStatsCreation /* createStats */)
 }
@@ -203,7 +203,7 @@ func (p *tpchVecPerfTest) postQueryRunHook(t *test, output []byte, setupIdx int)
 }
 
 func (p *tpchVecPerfTest) postTestRunHook(
-	ctx context.Context, t *test, c cluster2.Cluster, conn *gosql.DB,
+	ctx context.Context, t *test, c cluster.Cluster, conn *gosql.DB,
 ) {
 	runConfig := p.getRunConfig()
 	t.Status("comparing the runtimes (only median values for each query are compared)")
@@ -357,7 +357,7 @@ func (b tpchVecBenchTest) getRunConfig() tpchVecTestRunConfig {
 }
 
 func (b tpchVecBenchTest) preTestRunHook(
-	_ context.Context, t *test, _ cluster2.Cluster, conn *gosql.DB, clusterSetup []string,
+	_ context.Context, t *test, _ cluster.Cluster, conn *gosql.DB, clusterSetup []string,
 ) {
 	b.tpchVecTestCaseBase.preTestRunHook(t, conn, clusterSetup, true /* createStats */)
 }
@@ -367,7 +367,7 @@ func (b *tpchVecBenchTest) postQueryRunHook(t *test, output []byte, setupIdx int
 }
 
 func (b *tpchVecBenchTest) postTestRunHook(
-	ctx context.Context, t *test, c cluster2.Cluster, conn *gosql.DB,
+	ctx context.Context, t *test, c cluster.Cluster, conn *gosql.DB,
 ) {
 	runConfig := b.getRunConfig()
 	t.Status("comparing the runtimes (average of values (excluding best and worst) for each query are compared)")
@@ -426,7 +426,7 @@ type tpchVecDiskTest struct {
 }
 
 func (d tpchVecDiskTest) preTestRunHook(
-	ctx context.Context, t *test, c cluster2.Cluster, conn *gosql.DB, clusterSetup []string,
+	ctx context.Context, t *test, c cluster.Cluster, conn *gosql.DB, clusterSetup []string,
 ) {
 	d.tpchVecTestCaseBase.preTestRunHook(t, conn, clusterSetup, true /* createStats */)
 	// In order to stress the disk spilling of the vectorized engine, we will
@@ -450,7 +450,7 @@ func (d tpchVecDiskTest) preTestRunHook(
 }
 
 func baseTestRun(
-	ctx context.Context, t *test, c cluster2.Cluster, conn *gosql.DB, tc tpchVecTestCase,
+	ctx context.Context, t *test, c cluster.Cluster, conn *gosql.DB, tc tpchVecTestCase,
 ) {
 	firstNode := c.Node(1)
 	runConfig := tc.getRunConfig()
@@ -484,7 +484,7 @@ type tpchVecSmithcmpTest struct {
 const tpchVecSmithcmp = "smithcmp"
 
 func (s tpchVecSmithcmpTest) preTestRunHook(
-	ctx context.Context, t *test, c cluster2.Cluster, conn *gosql.DB, clusterSetup []string,
+	ctx context.Context, t *test, c cluster.Cluster, conn *gosql.DB, clusterSetup []string,
 ) {
 	s.tpchVecTestCaseBase.preTestRunHook(t, conn, clusterSetup, true /* createStats */)
 	const smithcmpSHA = "a3f41f5ba9273249c5ecfa6348ea8ee3ac4b77e3"
@@ -510,7 +510,7 @@ func (s tpchVecSmithcmpTest) preTestRunHook(
 }
 
 func smithcmpTestRun(
-	ctx context.Context, t *test, c cluster2.Cluster, conn *gosql.DB, tc tpchVecTestCase,
+	ctx context.Context, t *test, c cluster.Cluster, conn *gosql.DB, tc tpchVecTestCase,
 ) {
 	runConfig := tc.getRunConfig()
 	tc.preTestRunHook(ctx, t, c, conn, runConfig.clusterSetups[0])
@@ -531,9 +531,9 @@ func smithcmpTestRun(
 func runTPCHVec(
 	ctx context.Context,
 	t *test,
-	c cluster2.Cluster,
+	c cluster.Cluster,
 	testCase tpchVecTestCase,
-	testRun func(ctx context.Context, t *test, c cluster2.Cluster, conn *gosql.DB, tc tpchVecTestCase),
+	testRun func(ctx context.Context, t *test, c cluster.Cluster, conn *gosql.DB, tc tpchVecTestCase),
 ) {
 	firstNode := c.Node(1)
 	c.Put(ctx, cockroach, "./cockroach", c.All())
@@ -566,7 +566,7 @@ func registerTPCHVec(r *testRegistry) {
 		Owner:      OwnerSQLQueries,
 		Cluster:    r.makeClusterSpec(tpchVecNodeCount),
 		MinVersion: "v19.2.0",
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runTPCHVec(ctx, t, c, newTpchVecPerfTest(false /* disableStatsCreation */), baseTestRun)
 		},
 	})
@@ -578,7 +578,7 @@ func registerTPCHVec(r *testRegistry) {
 		// 19.2 version doesn't have disk spilling nor memory monitoring, so
 		// there is no point in running this config on that version.
 		MinVersion: "v20.1.0",
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runTPCHVec(ctx, t, c, tpchVecDiskTest{}, baseTestRun)
 		},
 	})
@@ -588,7 +588,7 @@ func registerTPCHVec(r *testRegistry) {
 		Owner:      OwnerSQLQueries,
 		Cluster:    r.makeClusterSpec(tpchVecNodeCount),
 		MinVersion: "v20.1.0",
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runTPCHVec(ctx, t, c, tpchVecSmithcmpTest{}, smithcmpTestRun)
 		},
 	})
@@ -598,7 +598,7 @@ func registerTPCHVec(r *testRegistry) {
 		Owner:      OwnerSQLQueries,
 		Cluster:    r.makeClusterSpec(tpchVecNodeCount),
 		MinVersion: "v20.2.0",
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runTPCHVec(ctx, t, c, newTpchVecPerfTest(true /* disableStatsCreation */), baseTestRun)
 		},
 	})
@@ -610,7 +610,7 @@ func registerTPCHVec(r *testRegistry) {
 		MinVersion: "v20.2.0",
 		Skip: "This config can be used to perform some benchmarking and is not " +
 			"meant to be run on a nightly basis",
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			// In order to use this test for benchmarking, include the queries
 			// that modify the cluster settings for all configs to benchmark
 			// like in the example below. The example benchmarks three values

--- a/pkg/cmd/roachtest/ts_util.go
+++ b/pkg/cmd/roachtest/ts_util.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/ts/tspb"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
@@ -92,7 +93,7 @@ func getMetrics(
 
 func verifyTxnPerSecond(
 	ctx context.Context,
-	c Cluster,
+	c cluster2.Cluster,
 	t *test,
 	adminNode option.NodeListOption,
 	start, end time.Time,
@@ -143,7 +144,7 @@ func verifyTxnPerSecond(
 
 func verifyLookupsPerSec(
 	ctx context.Context,
-	c Cluster,
+	c cluster2.Cluster,
 	t *test,
 	adminNode option.NodeListOption,
 	start, end time.Time,

--- a/pkg/cmd/roachtest/ts_util.go
+++ b/pkg/cmd/roachtest/ts_util.go
@@ -15,7 +15,7 @@ import (
 	"net/http"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/ts/tspb"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
@@ -93,7 +93,7 @@ func getMetrics(
 
 func verifyTxnPerSecond(
 	ctx context.Context,
-	c cluster2.Cluster,
+	c cluster.Cluster,
 	t *test,
 	adminNode option.NodeListOption,
 	start, end time.Time,
@@ -144,7 +144,7 @@ func verifyTxnPerSecond(
 
 func verifyLookupsPerSec(
 	ctx context.Context,
-	c cluster2.Cluster,
+	c cluster.Cluster,
 	t *test,
 	adminNode option.NodeListOption,
 	start, end time.Time,

--- a/pkg/cmd/roachtest/typeorm.go
+++ b/pkg/cmd/roachtest/typeorm.go
@@ -16,7 +16,7 @@ import (
 	"regexp"
 	"strings"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 )
 
 var typeORMReleaseTagRegex = regexp.MustCompile(`^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)$`)
@@ -27,7 +27,7 @@ func registerTypeORM(r *testRegistry) {
 	runTypeORM := func(
 		ctx context.Context,
 		t *test,
-		c cluster2.Cluster,
+		c cluster.Cluster,
 	) {
 		if c.IsLocal() {
 			t.Fatal("cannot be run in local mode")
@@ -177,7 +177,7 @@ func registerTypeORM(r *testRegistry) {
 		Cluster:    r.makeClusterSpec(1),
 		MinVersion: "v20.2.0",
 		Tags:       []string{`default`, `orm`},
-		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 			runTypeORM(ctx, t, c)
 		},
 	})

--- a/pkg/cmd/roachtest/typeorm.go
+++ b/pkg/cmd/roachtest/typeorm.go
@@ -27,7 +27,7 @@ func registerTypeORM(r *testRegistry) {
 		t *test,
 		c Cluster,
 	) {
-		if c.isLocal() {
+		if c.IsLocal() {
 			t.Fatal("cannot be run in local mode")
 		}
 		node := c.Node(1)

--- a/pkg/cmd/roachtest/typeorm.go
+++ b/pkg/cmd/roachtest/typeorm.go
@@ -33,7 +33,7 @@ func registerTypeORM(r *testRegistry) {
 		node := c.Node(1)
 		t.Status("setting up cockroach")
 		c.Put(ctx, cockroach, "./cockroach", c.All())
-		c.Start(ctx, t, c.All())
+		c.Start(ctx, c.All())
 
 		version, err := fetchCockroachVersion(ctx, c, node[0], nil)
 		if err != nil {

--- a/pkg/cmd/roachtest/typeorm.go
+++ b/pkg/cmd/roachtest/typeorm.go
@@ -15,6 +15,8 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 )
 
 var typeORMReleaseTagRegex = regexp.MustCompile(`^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)$`)
@@ -25,7 +27,7 @@ func registerTypeORM(r *testRegistry) {
 	runTypeORM := func(
 		ctx context.Context,
 		t *test,
-		c Cluster,
+		c cluster2.Cluster,
 	) {
 		if c.IsLocal() {
 			t.Fatal("cannot be run in local mode")
@@ -175,7 +177,7 @@ func registerTypeORM(r *testRegistry) {
 		Cluster:    r.makeClusterSpec(1),
 		MinVersion: "v20.2.0",
 		Tags:       []string{`default`, `orm`},
-		Run: func(ctx context.Context, t *test, c Cluster) {
+		Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 			runTypeORM(ctx, t, c)
 		},
 	})

--- a/pkg/cmd/roachtest/version.go
+++ b/pkg/cmd/roachtest/version.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/version"
 	"github.com/cockroachdb/errors"
 	_ "github.com/lib/pq"
@@ -25,7 +25,7 @@ import (
 // TODO(tbg): remove this test. Use the harness in versionupgrade.go
 // to make a much better one, much more easily.
 func registerVersion(r *testRegistry) {
-	runVersion := func(ctx context.Context, t *test, c cluster2.Cluster, binaryVersion string) {
+	runVersion := func(ctx context.Context, t *test, c cluster.Cluster, binaryVersion string) {
 		nodes := c.Spec().NodeCount - 1
 
 		if err := c.Stage(ctx, t.l, "release", "v"+binaryVersion, "", c.Range(1, nodes)); err != nil {
@@ -215,7 +215,7 @@ func registerVersion(r *testRegistry) {
 			Owner:      OwnerKV,
 			MinVersion: "v2.1.0",
 			Cluster:    r.makeClusterSpec(n + 1),
-			Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+			Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 				pred, err := PredecessorVersion(r.buildVersion)
 				if err != nil {
 					t.Fatal(err)

--- a/pkg/cmd/roachtest/version.go
+++ b/pkg/cmd/roachtest/version.go
@@ -35,7 +35,7 @@ func registerVersion(r *testRegistry) {
 
 		// Force disable encryption.
 		// TODO(mberhault): allow it once version >= 2.1.
-		c.Start(ctx, t, c.Range(1, nodes), startArgsDontEncrypt)
+		c.Start(ctx, c.Range(1, nodes), startArgsDontEncrypt)
 
 		stageDuration := 10 * time.Minute
 		buffer := 10 * time.Minute
@@ -136,7 +136,7 @@ func registerVersion(r *testRegistry) {
 					return err
 				}
 				c.Put(ctx, cockroach, "./cockroach", c.Node(i))
-				c.Start(ctx, t, c.Node(i), startArgsDontEncrypt)
+				c.Start(ctx, c.Node(i), startArgsDontEncrypt)
 				if err := sleepAndCheck(); err != nil {
 					return err
 				}
@@ -160,7 +160,7 @@ func registerVersion(r *testRegistry) {
 			// Do upgrade for the last node.
 			l.Printf("upgrading last node\n")
 			c.Put(ctx, cockroach, "./cockroach", c.Node(nodes))
-			c.Start(ctx, t, c.Node(nodes), startArgsDontEncrypt)
+			c.Start(ctx, c.Node(nodes), startArgsDontEncrypt)
 			if err := sleepAndCheck(); err != nil {
 				return err
 			}
@@ -175,7 +175,7 @@ func registerVersion(r *testRegistry) {
 				if err := c.Stage(ctx, t.l, "release", "v"+binaryVersion, "", c.Node(i)); err != nil {
 					t.Fatal(err)
 				}
-				c.Start(ctx, t, c.Node(i), startArgsDontEncrypt)
+				c.Start(ctx, c.Node(i), startArgsDontEncrypt)
 				if err := sleepAndCheck(); err != nil {
 					return err
 				}
@@ -189,7 +189,7 @@ func registerVersion(r *testRegistry) {
 					return err
 				}
 				c.Put(ctx, cockroach, "./cockroach", c.Node(i))
-				c.Start(ctx, t, c.Node(i), startArgsDontEncrypt)
+				c.Start(ctx, c.Node(i), startArgsDontEncrypt)
 				if err := sleepAndCheck(); err != nil {
 					return err
 				}

--- a/pkg/cmd/roachtest/version.go
+++ b/pkg/cmd/roachtest/version.go
@@ -98,7 +98,7 @@ func registerVersion(r *testRegistry) {
 					//
 					// https://github.com/cockroachdb/cockroach/issues/37737#issuecomment-496026918
 					if !strings.HasPrefix(binaryVersion, "2.") {
-						if err := c.CheckReplicaDivergenceOnDB(ctx, t, db); err != nil {
+						if err := c.CheckReplicaDivergenceOnDB(ctx, t.l, db); err != nil {
 							return errors.Wrapf(err, "node %d", i)
 						}
 					}

--- a/pkg/cmd/roachtest/version.go
+++ b/pkg/cmd/roachtest/version.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/version"
 	"github.com/cockroachdb/errors"
 	_ "github.com/lib/pq"
@@ -24,7 +25,7 @@ import (
 // TODO(tbg): remove this test. Use the harness in versionupgrade.go
 // to make a much better one, much more easily.
 func registerVersion(r *testRegistry) {
-	runVersion := func(ctx context.Context, t *test, c Cluster, binaryVersion string) {
+	runVersion := func(ctx context.Context, t *test, c cluster2.Cluster, binaryVersion string) {
 		nodes := c.Spec().NodeCount - 1
 
 		if err := c.Stage(ctx, t.l, "release", "v"+binaryVersion, "", c.Range(1, nodes)); err != nil {
@@ -214,7 +215,7 @@ func registerVersion(r *testRegistry) {
 			Owner:      OwnerKV,
 			MinVersion: "v2.1.0",
 			Cluster:    r.makeClusterSpec(n + 1),
-			Run: func(ctx context.Context, t *test, c Cluster) {
+			Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 				pred, err := PredecessorVersion(r.buildVersion)
 				if err != nil {
 					t.Fatal(err)

--- a/pkg/cmd/roachtest/versionupgrade.go
+++ b/pkg/cmd/roachtest/versionupgrade.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 	"time"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -78,7 +79,9 @@ DROP TABLE test.t;
 	`),
 }
 
-func runVersionUpgrade(ctx context.Context, t *test, c Cluster, buildVersion version.Version) {
+func runVersionUpgrade(
+	ctx context.Context, t *test, c cluster2.Cluster, buildVersion version.Version,
+) {
 	predecessorVersion, err := PredecessorVersion(buildVersion)
 	if err != nil {
 		t.Fatal(err)
@@ -216,7 +219,7 @@ func (u *versionUpgradeTest) run(ctx context.Context, t *test) {
 
 type versionUpgradeTest struct {
 	goOS  string
-	c     Cluster
+	c     cluster2.Cluster
 	steps []versionStep
 
 	// Cache conns because opening one takes hundreds of ms, and we do it quite
@@ -224,7 +227,7 @@ type versionUpgradeTest struct {
 	conns []*gosql.DB
 }
 
-func newVersionUpgradeTest(c Cluster, steps ...versionStep) *versionUpgradeTest {
+func newVersionUpgradeTest(c cluster2.Cluster, steps ...versionStep) *versionUpgradeTest {
 	return &versionUpgradeTest{
 		goOS:  ifLocal(runtime.GOOS, "linux"),
 		c:     c,
@@ -253,7 +256,7 @@ func (u *versionUpgradeTest) conn(ctx context.Context, t *test, i int) *gosql.DB
 // path of the uploaded binaries on the nodes, suitable to be used with
 // `roachdprod start --binary=<path>`.
 func uploadVersion(
-	ctx context.Context, t *test, c Cluster, nodes option.NodeListOption, newVersion string,
+	ctx context.Context, t *test, c cluster2.Cluster, nodes option.NodeListOption, newVersion string,
 ) (binaryName string) {
 	binaryName = "./cockroach"
 	if newVersion == "" {
@@ -382,7 +385,7 @@ func binaryUpgradeStep(nodes option.NodeListOption, newVersion string) versionSt
 }
 
 func upgradeNodes(
-	ctx context.Context, nodes option.NodeListOption, newVersion string, t *test, c Cluster,
+	ctx context.Context, nodes option.NodeListOption, newVersion string, t *test, c cluster2.Cluster,
 ) {
 	// NB: We could technically stage the binary on all nodes before
 	// restarting each one, but on Unix it's invalid to write to an
@@ -542,7 +545,7 @@ func stmtFeatureTest(
 // test will then fail on purpose when it's done with instructions on where to
 // move the files.
 func makeVersionFixtureAndFatal(
-	ctx context.Context, t *test, c Cluster, makeFixtureVersion string,
+	ctx context.Context, t *test, c cluster2.Cluster, makeFixtureVersion string,
 ) {
 	var useLocalBinary bool
 	if makeFixtureVersion == "" {

--- a/pkg/cmd/roachtest/versionupgrade.go
+++ b/pkg/cmd/roachtest/versionupgrade.go
@@ -20,7 +20,7 @@ import (
 	"strconv"
 	"time"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -80,7 +80,7 @@ DROP TABLE test.t;
 }
 
 func runVersionUpgrade(
-	ctx context.Context, t *test, c cluster2.Cluster, buildVersion version.Version,
+	ctx context.Context, t *test, c cluster.Cluster, buildVersion version.Version,
 ) {
 	predecessorVersion, err := PredecessorVersion(buildVersion)
 	if err != nil {
@@ -219,7 +219,7 @@ func (u *versionUpgradeTest) run(ctx context.Context, t *test) {
 
 type versionUpgradeTest struct {
 	goOS  string
-	c     cluster2.Cluster
+	c     cluster.Cluster
 	steps []versionStep
 
 	// Cache conns because opening one takes hundreds of ms, and we do it quite
@@ -227,7 +227,7 @@ type versionUpgradeTest struct {
 	conns []*gosql.DB
 }
 
-func newVersionUpgradeTest(c cluster2.Cluster, steps ...versionStep) *versionUpgradeTest {
+func newVersionUpgradeTest(c cluster.Cluster, steps ...versionStep) *versionUpgradeTest {
 	return &versionUpgradeTest{
 		goOS:  ifLocal(runtime.GOOS, "linux"),
 		c:     c,
@@ -256,7 +256,7 @@ func (u *versionUpgradeTest) conn(ctx context.Context, t *test, i int) *gosql.DB
 // path of the uploaded binaries on the nodes, suitable to be used with
 // `roachdprod start --binary=<path>`.
 func uploadVersion(
-	ctx context.Context, t *test, c cluster2.Cluster, nodes option.NodeListOption, newVersion string,
+	ctx context.Context, t *test, c cluster.Cluster, nodes option.NodeListOption, newVersion string,
 ) (binaryName string) {
 	binaryName = "./cockroach"
 	if newVersion == "" {
@@ -385,7 +385,7 @@ func binaryUpgradeStep(nodes option.NodeListOption, newVersion string) versionSt
 }
 
 func upgradeNodes(
-	ctx context.Context, nodes option.NodeListOption, newVersion string, t *test, c cluster2.Cluster,
+	ctx context.Context, nodes option.NodeListOption, newVersion string, t *test, c cluster.Cluster,
 ) {
 	// NB: We could technically stage the binary on all nodes before
 	// restarting each one, but on Unix it's invalid to write to an
@@ -545,7 +545,7 @@ func stmtFeatureTest(
 // test will then fail on purpose when it's done with instructions on where to
 // move the files.
 func makeVersionFixtureAndFatal(
-	ctx context.Context, t *test, c cluster2.Cluster, makeFixtureVersion string,
+	ctx context.Context, t *test, c cluster.Cluster, makeFixtureVersion string,
 ) {
 	var useLocalBinary bool
 	if makeFixtureVersion == "" {

--- a/pkg/cmd/roachtest/versionupgrade.go
+++ b/pkg/cmd/roachtest/versionupgrade.go
@@ -365,7 +365,7 @@ func uploadAndStartFromCheckpointFixture(nodes option.NodeListOption, v string) 
 		// Put and start the binary.
 		args := u.uploadVersion(ctx, t, nodes, v)
 		// NB: can't start sequentially since cluster already bootstrapped.
-		u.c.Start(ctx, t, nodes, args, startArgsDontEncrypt, roachprodArgOption{"--sequential=false"})
+		u.c.Start(ctx, nodes, args, startArgsDontEncrypt, roachprodArgOption{"--sequential=false"})
 	}
 }
 
@@ -406,7 +406,7 @@ func upgradeNodes(
 		t.l.Printf("restarting node %d into version %s", node, newVersionMsg)
 		c.Stop(ctx, c.Node(node))
 		args := startArgs("--binary=" + uploadVersion(ctx, t, c, c.Node(node), newVersion))
-		c.Start(ctx, t, c.Node(node), args, startArgsDontEncrypt)
+		c.Start(ctx, c.Node(node), args, startArgsDontEncrypt)
 	}
 }
 
@@ -546,7 +546,7 @@ func makeVersionFixtureAndFatal(
 ) {
 	var useLocalBinary bool
 	if makeFixtureVersion == "" {
-		c.Start(ctx, t, c.Node(1))
+		c.Start(ctx, c.Node(1))
 		require.NoError(t, c.Conn(ctx, 1).QueryRowContext(
 			ctx,
 			`select regexp_extract(value, '^v([0-9]+\.[0-9]+\.[0-9]+)') from crdb_internal.node_build_info where field = 'Version';`,

--- a/pkg/cmd/roachtest/work_pool.go
+++ b/pkg/cmd/roachtest/work_pool.go
@@ -86,7 +86,7 @@ func (p *workPool) workRemaining() []testWithCount {
 // have noWork set.
 func (p *workPool) getTestToRun(
 	ctx context.Context,
-	c *cluster,
+	c *clusterImpl,
 	qp *quotapool.IntPool,
 	cr *clusterRegistry,
 	onDestroy func(),

--- a/pkg/cmd/roachtest/ycsb.go
+++ b/pkg/cmd/roachtest/ycsb.go
@@ -44,7 +44,7 @@ func registerYCSB(r *testRegistry) {
 
 		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 		c.Put(ctx, workload, "./workload", c.Node(nodes+1))
-		c.Start(ctx, t, c.Range(1, nodes))
+		c.Start(ctx, c.Range(1, nodes))
 		waitForFullReplication(t, c.Conn(ctx, 1))
 
 		t.Status("running workload")

--- a/pkg/cmd/roachtest/ycsb.go
+++ b/pkg/cmd/roachtest/ycsb.go
@@ -14,7 +14,7 @@ import (
 	"context"
 	"fmt"
 
-	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 )
 
@@ -35,7 +35,7 @@ func registerYCSB(r *testRegistry) {
 		"F": {8: 96, 32: 144},
 	}
 
-	runYCSB := func(ctx context.Context, t *test, c cluster2.Cluster, wl string, cpus int) {
+	runYCSB := func(ctx context.Context, t *test, c cluster.Cluster, wl string, cpus int) {
 		nodes := c.Spec().NodeCount - 1
 
 		conc, ok := concurrencyConfigs[wl][cpus]
@@ -78,7 +78,7 @@ func registerYCSB(r *testRegistry) {
 				Name:    name,
 				Owner:   OwnerKV,
 				Cluster: r.makeClusterSpec(4, spec.CPU(cpus)),
-				Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
+				Run: func(ctx context.Context, t *test, c cluster.Cluster) {
 					runYCSB(ctx, t, c, wl, cpus)
 				},
 			})

--- a/pkg/cmd/roachtest/ycsb.go
+++ b/pkg/cmd/roachtest/ycsb.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 
+	cluster2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 )
 
@@ -34,7 +35,7 @@ func registerYCSB(r *testRegistry) {
 		"F": {8: 96, 32: 144},
 	}
 
-	runYCSB := func(ctx context.Context, t *test, c Cluster, wl string, cpus int) {
+	runYCSB := func(ctx context.Context, t *test, c cluster2.Cluster, wl string, cpus int) {
 		nodes := c.Spec().NodeCount - 1
 
 		conc, ok := concurrencyConfigs[wl][cpus]
@@ -77,7 +78,7 @@ func registerYCSB(r *testRegistry) {
 				Name:    name,
 				Owner:   OwnerKV,
 				Cluster: r.makeClusterSpec(4, spec.CPU(cpus)),
-				Run: func(ctx context.Context, t *test, c Cluster) {
+				Run: func(ctx context.Context, t *test, c cluster2.Cluster) {
 					runYCSB(ctx, t, c, wl, cpus)
 				},
 			})


### PR DESCRIPTION
See individual commits. The bottom line is, we're closing in on separating the test infra from the actual tests. `*test` is next and then we should be mostly there.