### PR TITLE
bazel: increase timeout of `pkg/sql/tests` test

### DIFF
--- a/pkg/sql/tests/BUILD.bazel
+++ b/pkg/sql/tests/BUILD.bazel
@@ -25,7 +25,7 @@ go_library(
 
 go_test(
     name = "tests_test",
-    size = "medium",
+    size = "large",
     srcs = [
         "bank_test.go",
         "enum_test.go",


### PR DESCRIPTION
This has timed out in CI.

Release note: None