### PR TITLE
release-20.2: Reduce node shutdown time by only calling time.Sleep once

### DIFF
--- a/pkg/server/drain.go
+++ b/pkg/server/drain.go
@@ -202,13 +202,17 @@ func (s *Server) isDraining() bool {
 
 // drainClients starts draining the SQL layer.
 func (s *Server) drainClients(ctx context.Context, reporter func(int, redact.SafeString)) error {
+	shouldDelayDraining := !s.isDraining()
 	// Mark the server as draining in a way that probes to
 	// /health?ready=1 will notice.
 	s.grpc.setMode(modeDraining)
 	s.sqlServer.acceptingClients.Set(false)
 	// Wait for drainUnreadyWait. This will fail load balancer checks and
 	// delay draining so that client traffic can move off this node.
-	time.Sleep(drainWait.Get(&s.st.SV))
+	// Note delay only happens on first call to drain.
+	if shouldDelayDraining {
+		s.drainSleepFn(drainWait.Get(&s.st.SV))
+	}
 
 	// Disable incoming SQL clients up to the queryWait timeout.
 	drainMaxWait := queryWait.Get(&s.st.SV)

--- a/pkg/server/testing_knobs.go
+++ b/pkg/server/testing_knobs.go
@@ -12,6 +12,7 @@ package server
 
 import (
 	"net"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -76,6 +77,10 @@ type TestingKnobs struct {
 	// Clock Source used to an inject a custom clock for testing the server. It is
 	// typically either an hlc.HybridManualClock or hlc.ManualClock.
 	ClockSource func() int64
+
+	// DrainSleepFn used in testing to override the usual sleep function with
+	// a custom function that counts the number of times the sleep function is called.
+	DrainSleepFn func(time.Duration)
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.


### PR DESCRIPTION
Backport 1/1 commits from #66610.

/cc @cockroachdb/release

---
