### PR TITLE
sql: fix regular explression operator parser(#66861)

### DIFF
--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -361,6 +361,9 @@ func TestParsePrecedence(t *testing.T) {
 
 		// Unary ~ should have highest precedence.
 		{`~1+2`, binary(tree.Plus, unary(tree.UnaryComplement, one), two)},
+
+		// OPERATOR(pg_catalog.~) should not be error (#66861).
+		{`'a' OPERATOR(pg_catalog.~) 'b'`, regmatch(a, b)},
 	}
 	for _, d := range testData {
 		t.Run(d.sql, func(t *testing.T) {

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -82,6 +82,16 @@ func processBinaryQualOp(
       return &tree.BinaryExpr{Operator: op, Left: lhs, Right: rhs}, 0
     case tree.ComparisonOperator:
       return &tree.ComparisonExpr{Operator: op, Left: lhs, Right: rhs}, 0
+    case tree.UnaryOperator:
+      // We have a unary operator which have the same symbol as the binary
+      // operator, so adjust accordingly.
+      switch op.Symbol {
+      case tree.UnaryComplement:
+        return &tree.ComparisonExpr{Operator: tree.RegMatch, Left: lhs, Right: rhs}, 0
+      default:
+        sqllex.Error(fmt.Sprintf("unknown binary operator %s", op))
+        return nil, -1
+      }
     default:
       sqllex.Error(fmt.Sprintf("unknown binary operator %s", op))
       return nil, 1


### PR DESCRIPTION
Previously, the following error occurs when using `OPERATOR(pg_catalog.~)`.

```
> SELECT 'test' OPERATOR(pg_catalog.~) '^(test)$';
invalid syntax: statement ignored: at or near "EOF": syntax error:
unknown binary operator ~
SQLSTATE: 42601
DETAIL: source SQL:
SELECT 'test' OPERATOR(pg_catalog.~) '^(test)$'
```

The reason why the error happens is that '\~' is used as UnaryOperator
and ComparisonExpr, and there is a lack of processing that took into
account the differences. When parsing `a_expr OPERATOR(pg_config.~) a_expr`,
'\~' means that only ComparisonExpr, but, CRDB recognized it as UnaryOperator.

Release note (bug fix): fix the error that occurred when executing OPERATOR(pg_catalog.~).