### PR TITLE
changefeedccl: support special decimals in avro feeds

### DIFF
--- a/pkg/ccl/changefeedccl/avro.go
+++ b/pkg/ccl/changefeedccl/avro.go
@@ -133,8 +133,9 @@ type avroSchemaField struct {
 	// and the value either null or the actual encoded value.
 	// nativeEncoded is a map that's returned by encodeFn.  We allocate
 	// this map once to avoid repeated map allocations.  We simply update
-	// "union key" value.
-	nativeEncoded map[string]interface{}
+	// "union key" value. nativeEncodedSecondaryType supports unions of two types (plus null).
+	nativeEncoded              map[string]interface{}
+	nativeEncodedSecondaryType map[string]interface{}
 }
 
 // avroRecord is our representation of the schema of an avro record. Serializing
@@ -218,6 +219,44 @@ func typeToAvroSchema(typ *types.T) (*avroSchemaField, error) {
 				return tree.DNull, nil
 			}
 			return decoder(x.(map[string]interface{})[unionKey])
+		}
+	}
+
+	// Handles types that mostly encode to non-strings,
+	// but have special cases like Infinity that encode as strings.
+	setNullableWithStringFallback := func(
+		avroType avroSchemaType,
+		encoder datumToNativeFn,
+		decoder func(interface{}) (tree.Datum, error),
+	) {
+		schema.SchemaType = []avroSchemaType{avroSchemaNull, avroType, avroSchemaString}
+		mainUnionKey := avroUnionKey(avroType)
+		stringUnionKey := avroUnionKey(avroSchemaString)
+		schema.nativeEncoded = map[string]interface{}{mainUnionKey: nil}
+		schema.nativeEncodedSecondaryType = map[string]interface{}{stringUnionKey: nil}
+		schema.encodeDatum = encoder
+
+		schema.encodeFn = func(d tree.Datum) (interface{}, error) {
+			if d == tree.DNull {
+				return nil /* value */, nil
+			}
+			encoded, err := encoder(d, schema.nativeEncoded[mainUnionKey])
+			if err != nil {
+				return nil, err
+			}
+			_, isString := encoded.(string)
+			if isString {
+				schema.nativeEncodedSecondaryType[stringUnionKey] = encoded
+				return schema.nativeEncodedSecondaryType, nil
+			}
+			schema.nativeEncoded[mainUnionKey] = encoded
+			return schema.nativeEncoded, nil
+		}
+		schema.decodeFn = func(x interface{}) (tree.Datum, error) {
+			if x == nil {
+				return tree.DNull, nil
+			}
+			return decoder(x.(map[string]interface{}))
 		}
 	}
 
@@ -445,15 +484,20 @@ func typeToAvroSchema(typ *types.T) (*avroSchemaField, error) {
 
 		width := int(typ.Width())
 		prec := int(typ.Precision())
-		setNullable(
-			avroLogicalType{
-				SchemaType:  avroSchemaBytes,
-				LogicalType: `decimal`,
-				Precision:   prec,
-				Scale:       width,
-			},
+		decimalType := avroLogicalType{
+			SchemaType:  avroSchemaBytes,
+			LogicalType: `decimal`,
+			Precision:   prec,
+			Scale:       width,
+		}
+		setNullableWithStringFallback(
+			decimalType,
 			func(d tree.Datum, _ interface{}) (interface{}, error) {
 				dec := d.(*tree.DDecimal).Decimal
+
+				if dec.Form != apd.Finite {
+					return d.String(), nil
+				}
 
 				// If the decimal happens to fit a smaller width than the
 				// column allows, add trailing zeroes so the scale is constant
@@ -478,7 +522,12 @@ func typeToAvroSchema(typ *types.T) (*avroSchemaField, error) {
 				return &rat, nil
 			},
 			func(x interface{}) (tree.Datum, error) {
-				return &tree.DDecimal{Decimal: ratToDecimal(*x.(*big.Rat), int32(width))}, nil
+				unionMap := x.(map[string]interface{})
+				rat, ok := unionMap[avroUnionKey(decimalType)]
+				if ok {
+					return &tree.DDecimal{Decimal: ratToDecimal(*rat.(*big.Rat), int32(width))}, nil
+				}
+				return tree.ParseDDecimal(unionMap[avroUnionKey(avroSchemaString)].(string))
 			},
 		)
 	case types.UuidFamily:

--- a/pkg/ccl/changefeedccl/avro_test.go
+++ b/pkg/ccl/changefeedccl/avro_test.go
@@ -435,7 +435,7 @@ func TestAvroSchema(t *testing.T) {
 			`VARBIT`:            `["null",{"type":"array","items":"long"}]`,
 
 			`BIT(3)`:       `["null",{"type":"array","items":"long"}]`,
-			`DECIMAL(3,2)`: `["null",{"type":"bytes","logicalType":"decimal","precision":3,"scale":2}]`,
+			`DECIMAL(3,2)`: `["null",{"type":"bytes","logicalType":"decimal","precision":3,"scale":2},"string"]`,
 		}
 
 		for _, typ := range append(types.Scalar, types.BoolArray, types.MakeCollatedString(types.String, `fr`), types.MakeBit(3)) {
@@ -532,6 +532,15 @@ func TestAvroSchema(t *testing.T) {
 			{sqlType: `DECIMAL(4,1)`,
 				sql:  `1.2`,
 				avro: `{"bytes.decimal":"\f"}`},
+			{sqlType: `DECIMAL(4,1)`,
+				sql:  `DECIMAL 'Infinity'`,
+				avro: `{"string":"Infinity"}`},
+			{sqlType: `DECIMAL(4,1)`,
+				sql:  `DECIMAL '-Infinity'`,
+				avro: `{"string":"-Infinity"}`},
+			{sqlType: `DECIMAL(4,1)`,
+				sql:  `DECIMAL 'NaN'`,
+				avro: `{"string":"NaN"}`},
 
 			{sqlType: `UUID`, sql: `NULL`, avro: `null`},
 			{sqlType: `UUID`,


### PR DESCRIPTION
Previously, changefeeds on a decimal column would error when encountering
NaN or infinite values, but those are valid in SQL.
This PR changes the schema type to a union of decimal and string, so that
special values won't break the feed.

Planning on using the same strategy with infinite dates, since apparently that's a thing.

This should be backwards compatible in most cases, but might be best to leave this one out of any backports.

Release note (bug fix): avro feeds support special decimals like Infinity