### PR TITLE
tree: refactor FmtCtx to use option pattern

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1609,9 +1609,15 @@ func hideNonVirtualTableNameFunc(vt VirtualTabler) func(ctx *tree.FmtCtx, name *
 
 func anonymizeStmtAndConstants(stmt tree.Statement, vt VirtualTabler) string {
 	// Re-format to remove most names.
-	f := tree.NewFmtCtx(tree.FmtAnonymize | tree.FmtHideConstants)
+	fmtFlags := tree.FmtAnonymize | tree.FmtHideConstants
+	var f *tree.FmtCtx
 	if vt != nil {
-		f.SetReformatTableNames(hideNonVirtualTableNameFunc(vt))
+		f = tree.NewFmtCtx(
+			fmtFlags,
+			tree.FmtReformatTableNames(hideNonVirtualTableNameFunc(vt)),
+		)
+	} else {
+		f = tree.NewFmtCtx(fmtFlags)
 	}
 	f.FormatNode(stmt)
 	return f.CloseAndGetString()
@@ -2504,8 +2510,10 @@ func scrubStmtStatKey(vt VirtualTabler, key string) (string, bool) {
 	}
 
 	// Re-format to remove most names.
-	f := tree.NewFmtCtx(tree.FmtAnonymize)
-	f.SetReformatTableNames(hideNonVirtualTableNameFunc(vt))
+	f := tree.NewFmtCtx(
+		tree.FmtAnonymize,
+		tree.FmtReformatTableNames(hideNonVirtualTableNameFunc(vt)),
+	)
 	f.FormatNode(stmt.AST)
 	return f.CloseAndGetString(), true
 }

--- a/pkg/sql/exec_util_test.go
+++ b/pkg/sql/exec_util_test.go
@@ -50,8 +50,10 @@ func TestHideNonVirtualTableNameFunc(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		f := tree.NewFmtCtx(tree.FmtSimple)
-		f.SetReformatTableNames(tableNameFunc)
+		f := tree.NewFmtCtx(
+			tree.FmtSimple,
+			tree.FmtReformatTableNames(tableNameFunc),
+		)
 		f.FormatNode(stmt.AST)
 		actual := f.CloseAndGetString()
 		require.Equal(t, test.expected, actual)

--- a/pkg/sql/execinfrapb/data.go
+++ b/pkg/sql/execinfrapb/data.go
@@ -75,15 +75,18 @@ func ConvertToMappedSpecOrdering(
 // IndexedVar formatting function needs to be added on. It replaces placeholders
 // with their values.
 func ExprFmtCtxBase(evalCtx *tree.EvalContext) *tree.FmtCtx {
-	fmtCtx := tree.NewFmtCtx(tree.FmtCheckEquivalence)
-	fmtCtx.SetPlaceholderFormat(
-		func(fmtCtx *tree.FmtCtx, p *tree.Placeholder) {
-			d, err := p.Eval(evalCtx)
-			if err != nil {
-				panic(errors.AssertionFailedf("failed to serialize placeholder: %s", err))
-			}
-			d.Format(fmtCtx)
-		})
+	fmtCtx := tree.NewFmtCtx(
+		tree.FmtCheckEquivalence,
+		tree.FmtPlaceholderFormat(
+			func(fmtCtx *tree.FmtCtx, p *tree.Placeholder) {
+				d, err := p.Eval(evalCtx)
+				if err != nil {
+					panic(errors.AssertionFailedf("failed to serialize placeholder: %s", err))
+				}
+				d.Format(fmtCtx)
+			},
+		),
+	)
 	return fmtCtx
 }
 

--- a/pkg/sql/opt/exec/execbuilder/format.go
+++ b/pkg/sql/opt/exec/execbuilder/format.go
@@ -41,10 +41,12 @@ func fmtInterceptor(f *memo.ExprFmtCtx, scalar opt.ScalarExpr) string {
 		// Not all scalar operators are supported (e.g. Projections).
 		return ""
 	}
-	fmtCtx := tree.NewFmtCtx(tree.FmtSimple)
-	fmtCtx.SetIndexedVarFormat(func(ctx *tree.FmtCtx, idx int) {
-		ctx.WriteString(f.ColumnString(opt.ColumnID(idx + 1)))
-	})
+	fmtCtx := tree.NewFmtCtx(
+		tree.FmtSimple,
+		tree.FmtIndexedVarFormat(func(ctx *tree.FmtCtx, idx int) {
+			ctx.WriteString(f.ColumnString(opt.ColumnID(idx + 1)))
+		}),
+	)
 	expr.Format(fmtCtx)
 	return fmtCtx.String()
 }

--- a/pkg/sql/opt/exec/explain/output.go
+++ b/pkg/sql/opt/exec/explain/output.go
@@ -147,12 +147,14 @@ func (ob *OutputBuilder) Expr(key string, expr tree.TypedExpr, varColumns colinf
 	if ob.flags.HideValues {
 		flags |= tree.FmtHideConstants
 	}
-	f := tree.NewFmtCtx(flags)
-	f.SetIndexedVarFormat(func(ctx *tree.FmtCtx, idx int) {
-		// Ensure proper quoting.
-		n := tree.Name(varColumns[idx].Name)
-		ctx.WriteString(n.String())
-	})
+	f := tree.NewFmtCtx(
+		flags,
+		tree.FmtIndexedVarFormat(func(ctx *tree.FmtCtx, idx int) {
+			// Ensure proper quoting.
+			n := tree.Name(varColumns[idx].Name)
+			ctx.WriteString(n.String())
+		}),
+	)
 	f.FormatNode(expr)
 	ob.AddField(key, f.CloseAndGetString())
 }

--- a/pkg/sql/opt/idxconstraint/index_constraints_test.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints_test.go
@@ -141,10 +141,12 @@ func TestIndexConstraints(t *testing.T) {
 					if err != nil {
 						return fmt.Sprintf("error: %v\n", err)
 					}
-					fmtCtx := tree.NewFmtCtx(tree.FmtSimple)
-					fmtCtx.SetIndexedVarFormat(func(ctx *tree.FmtCtx, idx int) {
-						ctx.WriteString(md.ColumnMeta(opt.ColumnID(idx + 1)).Alias)
-					})
+					fmtCtx := tree.NewFmtCtx(
+						tree.FmtSimple,
+						tree.FmtIndexedVarFormat(func(ctx *tree.FmtCtx, idx int) {
+							ctx.WriteString(md.ColumnMeta(opt.ColumnID(idx + 1)).Alias)
+						}),
+					)
 					expr.Format(fmtCtx)
 					fmt.Fprintf(&buf, "Remaining filter: %s\n", fmtCtx.String())
 				}

--- a/pkg/sql/opt/partialidx/implicator_test.go
+++ b/pkg/sql/opt/partialidx/implicator_test.go
@@ -119,10 +119,12 @@ func TestImplicator(t *testing.T) {
 				if err != nil {
 					d.Fatalf(t, "unexpected error: %v\n", err)
 				}
-				fmtCtx := tree.NewFmtCtx(tree.FmtSimple)
-				fmtCtx.SetIndexedVarFormat(func(ctx *tree.FmtCtx, idx int) {
-					ctx.WriteString(md.ColumnMeta(opt.ColumnID(idx + 1)).Alias)
-				})
+				fmtCtx := tree.NewFmtCtx(
+					tree.FmtSimple,
+					tree.FmtIndexedVarFormat(func(ctx *tree.FmtCtx, idx int) {
+						ctx.WriteString(md.ColumnMeta(opt.ColumnID(idx + 1)).Alias)
+					}),
+				)
 				expr.Format(fmtCtx)
 				buf.WriteString(fmtCtx.String())
 			}

--- a/pkg/sql/sem/tree/format_test.go
+++ b/pkg/sql/sem/tree/format_test.go
@@ -99,10 +99,12 @@ func TestFormatTableName(t *testing.T) {
 		// `GRANT SELECT ON xoxoxo TO foo`},
 	}
 
-	f := tree.NewFmtCtx(tree.FmtSimple)
-	f.SetReformatTableNames(func(ctx *tree.FmtCtx, _ *tree.TableName) {
-		ctx.WriteString("xoxoxo")
-	})
+	f := tree.NewFmtCtx(
+		tree.FmtSimple,
+		tree.FmtReformatTableNames(func(ctx *tree.FmtCtx, _ *tree.TableName) {
+			ctx.WriteString("xoxoxo")
+		}),
+	)
 
 	for i, test := range testData {
 		t.Run(fmt.Sprintf("%d %s", i, test.stmt), func(t *testing.T) {

--- a/pkg/sql/sem/tree/indexed_vars_test.go
+++ b/pkg/sql/sem/tree/indexed_vars_test.go
@@ -78,10 +78,13 @@ func TestIndexedVars(t *testing.T) {
 	}
 
 	// Test formatting using the indexed var format interceptor.
-	f := NewFmtCtx(FmtSimple)
-	f.SetIndexedVarFormat(func(ctx *FmtCtx, idx int) {
-		ctx.Printf("customVar%d", idx)
-	})
+	f := NewFmtCtx(
+		FmtSimple,
+		FmtIndexedVarFormat(
+			func(ctx *FmtCtx, idx int) {
+				ctx.Printf("customVar%d", idx)
+			}),
+	)
 	f.FormatNode(typedExpr)
 	str = f.CloseAndGetString()
 

--- a/pkg/sql/sem/tree/name_part_test.go
+++ b/pkg/sql/sem/tree/name_part_test.go
@@ -86,7 +86,10 @@ func TestUnresolvedNameAnnotation(t *testing.T) {
 
 	expect := func(expected string) {
 		t.Helper()
-		ctx := tree.NewFmtCtxEx(tree.FmtAlwaysQualifyTableNames, &ann)
+		ctx := tree.NewFmtCtx(
+			tree.FmtAlwaysQualifyTableNames,
+			tree.FmtAnnotations(&ann),
+		)
 		ctx.FormatNode(u)
 		if actual := ctx.CloseAndGetString(); actual != expected {
 			t.Errorf("expected: `%s`, got `%s`", expected, actual)


### PR DESCRIPTION
There are many setters or optional arguments to FmtCtx. Consolidate this
altogether by using the option pattern.

Refs: #65724

Release note: None