### PR TITLE
release-20.2: sql/pgwire: add ops logging for draining events

### DIFF
--- a/pkg/server/drain.go
+++ b/pkg/server/drain.go
@@ -215,12 +215,12 @@ func (s *Server) drainClients(ctx context.Context, reporter func(int, redact.Saf
 	}
 
 	// Disable incoming SQL clients up to the queryWait timeout.
-	drainMaxWait := queryWait.Get(&s.st.SV)
-	if err := s.sqlServer.pgServer.Drain(drainMaxWait, reporter); err != nil {
+	queryMaxWait := queryWait.Get(&s.st.SV)
+	if err := s.sqlServer.pgServer.Drain(ctx, queryMaxWait, reporter); err != nil {
 		return err
 	}
 	// Stop ongoing SQL execution up to the queryWait timeout.
-	s.sqlServer.distSQLServer.Drain(ctx, drainMaxWait, reporter)
+	s.sqlServer.distSQLServer.Drain(ctx, queryMaxWait, reporter)
 
 	// Drain the SQL leases. This must be done after the pgServer has
 	// given sessions a chance to finish ongoing work.

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -496,8 +496,9 @@ func (c *conn) serveImpl(
 	if draining() {
 		// TODO(andrei): I think sending this extra error to the client if we also
 		// sent another error for the last query (like a context canceled) is a bad
-		// idead; see #22630. I think we should find a way to return the
+		// idea; see #22630. I think we should find a way to return the
 		// AdminShutdown error as the only result of the query.
+		log.Info(ctx, "closing existing connection while server is draining")
 		_ /* err */ = writeErr(ctx, &sqlServer.GetExecutorConfig().Settings.SV,
 			newAdminShutdownErr(ErrDrainingExistingConn), &c.msgBuilder, &c.writerState.buf)
 		_ /* n */, _ /* err */ = c.writerState.buf.WriteTo(c.conn)

--- a/pkg/sql/pgwire/helpers_test.go
+++ b/pkg/sql/pgwire/helpers_test.go
@@ -15,8 +15,10 @@ import (
 	"time"
 )
 
-func (s *Server) DrainImpl(drainWait time.Duration, cancelWait time.Duration) error {
-	return s.drainImpl(drainWait, cancelWait, nil /* reporter */)
+func (s *Server) DrainImpl(
+	ctx context.Context, queryWait time.Duration, cancelWait time.Duration,
+) error {
+	return s.drainImpl(ctx, queryWait, cancelWait, nil /* reporter */)
 }
 
 // OverwriteCancelMap overwrites all active connections' context.CancelFuncs so


### PR DESCRIPTION
Backport 1/1 commits from #66817.

/cc @cockroachdb/release

Backporting for use by CC-SRE @joshimhoff 

---

Release note (ops change): Added logs for important events during the
server draining/shutdown process: (1) log when the server closes an
existing connection while draining, (2) log when the server rejects a
new connection while draining, and (3) log when the server cancels
in-flight queries after waiting for the server.shutdown.query_wait
duration to elapse while draining.
