### PR TITLE
contextutil: add a Context with richer cancellation

### DIFF
--- a/pkg/util/contextutil/BUILD.bazel
+++ b/pkg/util/contextutil/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "contextutil",
     srcs = [
+        "cancel.go",
         "context.go",
         "timeout_error.go",
     ],
@@ -20,6 +21,7 @@ go_test(
     name = "contextutil_test",
     size = "small",
     srcs = [
+        "cancel_test.go",
         "context_test.go",
         "timeout_error_test.go",
     ],
@@ -28,5 +30,6 @@ go_test(
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//errbase",
         "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/util/contextutil/cancel.go
+++ b/pkg/util/contextutil/cancel.go
@@ -1,0 +1,96 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package contextutil
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/errors"
+)
+
+type errCancelKey struct{}
+
+// WithErrCancel returns a cancelable context that whose cancellation function
+// takes an error. While that error will *not* be returned from `ctx.Err`, the
+// package-level method `Err` will return the error (annotated with
+// errors.WithStackDepth) for the returned context and its descendants.
+func WithErrCancel(parent context.Context) (context.Context, func(error)) {
+	wrappedCtx, wrappedCancel := context.WithCancel(parent)
+	ctx := &errCancelCtx{
+		Context: wrappedCtx,
+	}
+	return ctx, func(err error) {
+		if err == nil {
+			err = context.Canceled
+		}
+		err = errors.WithStackDepth(err, 1 /* depth */)
+		defer wrappedCancel() // actually cancel after we've populated our ctx's err
+		ctx.mu.Lock()
+		defer ctx.mu.Unlock()
+		ctx.err = err
+	}
+}
+
+// Err returns an error associated to the Context. This is nil unless the
+// Context is canceled, and will match `ctx.Err()` for contexts that were
+// not derived from a since-canceled parent created via WithErrCancel.
+//
+// However, for a Context derived from a since-canceled parent created via
+// WithErrCancel, Err returns the error passed to the cancellation function,
+// wrapped in an `errors.WithStackDepth` that identifies the caller of the
+// `cancel(err)` call. When the Context passed to `Err` has multiple such
+// parents, the "most distant" one is returned, under the assumption that
+// it provides the original reason for the context chain's cancellation.
+//
+// See ExampleWithErrCancel for an example.
+func Err(ctx context.Context) error {
+	err := ctx.Err()
+	if err == nil {
+		return nil
+	}
+	for {
+		// Walk to the closest errCancelCtx parent.
+		c, ok := ctx.Value(errCancelKey{}).(*errCancelCtx)
+		if !ok {
+			// None found, done.
+			break
+		}
+		ctx = c.Context
+
+		// If it's canceled, remember the error.
+		if extErr := c.getErr(); extErr != nil {
+			err = extErr
+		}
+
+		// Keep walking.
+	}
+	return err
+}
+
+type errCancelCtx struct {
+	context.Context
+	mu  syncutil.Mutex
+	err error // protected by mu
+}
+
+func (ctx *errCancelCtx) getErr() error {
+	ctx.mu.Lock()
+	defer ctx.mu.Unlock()
+	return ctx.err
+}
+
+func (ctx *errCancelCtx) Value(key interface{}) interface{} {
+	if key == (errCancelKey{}) {
+		return ctx
+	}
+	return ctx.Context.Value(key)
+}

--- a/pkg/util/contextutil/cancel_test.go
+++ b/pkg/util/contextutil/cancel_test.go
@@ -1,0 +1,154 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package contextutil
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func ExampleWithErrCancel() {
+	ctx1, cancel1 := WithErrCancel(context.Background())
+	ctx2, cancel2 := WithCancel(ctx1)
+	ctx3, cancel3 := WithErrCancel(ctx2)
+
+	cancel3(errors.New("boom"))
+	fmt.Println("ctx3 canceled:")
+	fmt.Println(Err(ctx1))
+	fmt.Println(Err(ctx2))
+	fmt.Println(Err(ctx3))
+	cancel2()
+	fmt.Println("ctx2 also canceled:")
+	fmt.Println(Err(ctx1))
+	fmt.Println(Err(ctx2))
+	fmt.Println(Err(ctx3))
+	cancel1(errors.New("explody"))
+	fmt.Println("ctx1 also canceled:")
+	fmt.Println(Err(ctx1))
+	fmt.Println(Err(ctx2))
+	fmt.Println(Err(ctx3))
+
+	// Output:
+	//
+	// ctx3 canceled:
+	// <nil>
+	// <nil>
+	// boom
+	// ctx2 also canceled:
+	// <nil>
+	// context canceled
+	// boom
+	// ctx1 also canceled:
+	// explody
+	// explody
+	// explody
+}
+
+type ctxs struct {
+	ctx0, ctx1, ctx2, ctx3 context.Context
+	cancel0                func()
+	cancel1, cancel2       func(error)
+}
+
+type testKey struct{}
+
+// context.Background <- (ctx0, cancel0) <- (ctx1, cancel1) <- (ctx2, cancel2) <- ctx3
+func mkCtxChain() ctxs {
+	ctx0, cancel0 := context.WithCancel(context.Background())
+	ctx1, cancel1 := WithErrCancel(ctx0)
+	ctx2, cancel2 := WithErrCancel(ctx1)
+	ctx3 := context.WithValue(ctx2, testKey{}, nil)
+	return ctxs{
+		ctx0: ctx0, ctx1: ctx1, ctx2: ctx2, ctx3: ctx3,
+		cancel0: cancel0, cancel1: cancel1, cancel2: cancel2,
+	}
+}
+
+func TestWithErrCancel(t *testing.T) {
+	err1 := errors.New("err1")
+	err2 := errors.New("err2")
+	tests := []struct {
+		name string
+		do   func(*testing.T, ctxs)
+	}{
+		{name: "basics", do: func(t *testing.T, c ctxs) {
+			require.Nil(t, c.ctx1.Err())
+			require.Nil(t, c.ctx2.Err())
+			require.Nil(t, c.ctx3.Err())
+			require.Nil(t, Err(c.ctx1))
+			require.Nil(t, Err(c.ctx2))
+			require.Nil(t, Err(c.ctx3))
+		}},
+		{name: "cancel0", do: func(t *testing.T, c ctxs) {
+			// Canceling a regular parent gives the standard unfriendly error,
+			// even from Err.
+			c.cancel0()
+			require.Equal(t, context.Canceled, c.ctx1.Err())
+			require.Equal(t, context.Canceled, c.ctx2.Err())
+			require.Equal(t, context.Canceled, c.ctx3.Err())
+			require.Equal(t, context.Canceled, Err(c.ctx1))
+			require.Equal(t, context.Canceled, Err(c.ctx2))
+			require.Equal(t, context.Canceled, Err(c.ctx3))
+		}},
+		{name: "cancel1", do: func(t *testing.T, c ctxs) {
+			// ctx1 is an extended context, so it does nice things.
+			c.cancel1(err1)
+			require.Equal(t, context.Canceled, c.ctx1.Err())
+			require.Equal(t, context.Canceled, c.ctx2.Err())
+			require.Equal(t, context.Canceled, c.ctx3.Err())
+			require.True(t, errors.Is(Err(c.ctx1), err1))
+			require.True(t, errors.Is(Err(c.ctx2), err1))
+			require.True(t, errors.Is(Err(c.ctx3), err1)) // vanilla context
+		}},
+		{name: "cancel2", do: func(t *testing.T, c ctxs) {
+			// ctx2 is an extended context, so it does nice things.
+			c.cancel2(err2)
+			require.Nil(t, c.ctx1.Err())
+			require.Equal(t, context.Canceled, c.ctx2.Err())
+			require.Equal(t, context.Canceled, c.ctx3.Err())
+			require.Nil(t, Err(c.ctx1))
+			require.True(t, errors.Is(Err(c.ctx2), err2))
+			require.True(t, errors.Is(Err(c.ctx3), err2)) // vanilla context
+		}},
+		{name: "cancel123", do: func(t *testing.T, c ctxs) {
+			// When multiple rich contexts are canceled, we get the topmost
+			// nice error back.
+			c.cancel0()
+			c.cancel1(err1)
+			c.cancel2(err2)
+			require.Equal(t, context.Canceled, c.ctx1.Err())
+			require.Equal(t, context.Canceled, c.ctx2.Err())
+			require.Equal(t, context.Canceled, c.ctx3.Err())
+			require.True(t, errors.Is(Err(c.ctx1), err1))
+			require.True(t, errors.Is(Err(c.ctx2), err1))
+			require.True(t, errors.Is(Err(c.ctx3), err1)) // vanilla context
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.do(t, mkCtxChain())
+		})
+	}
+}
+
+func TestWithErrCancelStack(t *testing.T) {
+	ctx, cancel := WithErrCancel(context.Background())
+	cancel(errors.New("boom"))
+	err := Err(ctx)
+	require.NotNil(t, err)
+	_, _, fn, ok := errors.GetOneLineSource(err)
+	require.True(t, ok)
+	require.Equal(t, "TestWithErrCancelStack", fn, "%+v", err)
+}


### PR DESCRIPTION
When a context gets canceled, by contract of `context.Context` we can
only ever return the opaque errors `context.{Canceled,DeadlineExceeded}`
from `ctx.Err()`. This is not helpful and we often struggle with
locating the source of a context cancellation.

The proximate motivation at hand is exposing the caller of `cancel()`,
which this commit allows:

```go
func TestWithCallerCancel(t *testing.T) {
	ctx, cancel := WithCallerCancel(context.Background())
	cancel()
	err := ExtErr(ctx)
	require.NotNil(t, err)
	_, _, fn, ok := errors.GetOneLineSource(err)
	require.True(t, ok)
	require.Equal(t, "TestWithCallerCancel", fn, "%+v", err)
}
```

Release note: None
