### PR TITLE
admission: optimizations to admission.WorkQueue

### DIFF
--- a/pkg/util/admission/work_queue_test.go
+++ b/pkg/util/admission/work_queue_test.go
@@ -248,3 +248,5 @@ func scanTenantID(t *testing.T, d *datadriven.TestData) roachpb.TenantID {
 // - Test metrics
 // - Test race between grant and cancellation
 // - Test WorkQueue for tokens
+// - Add microbenchmark with high concurrency and procs for full admission
+//   system


### PR DESCRIPTION
These small optimizations reduce memory allocations and
the length of the critical sections.

A 10s mutex profile of kv50 with cpu overload had
~1.2s (of a total of 2s) in the admission package.
This was correlated with what showed up in the
corresponding cpu profile, which directed these
changes.

Release note: None