### PR TITLE
release-21.1: util: reduce goschedstats sampling rate

### DIFF
--- a/pkg/util/goschedstats/runnable.go
+++ b/pkg/util/goschedstats/runnable.go
@@ -53,7 +53,7 @@ func RecentNormalizedRunnableGoroutines() float64 {
 var _ = numRunnableGoroutines
 
 // We sample the number of runnable goroutines once per samplePeriod.
-const samplePeriod = time.Millisecond
+const samplePeriod = 250 * time.Millisecond
 
 // We "report" the average value every reportingPeriod.
 // Note: if this is changed from 1s, CumulativeNormalizedRunnableGoroutines()


### PR DESCRIPTION
The goschedstats sampling is responsible for 5-10% CPU usage of an
idle cockroach process. This seems mostly related to the overhead of
waking up the process/go scheduler etc, as the usage goes down
significantly when there is load on the system.

This signal is in 21.1 only for observability, so we don't care too
much about its accuracy. This change reduces the sampling interval
from 1000 times per second to 4 per second.

Release note (bug fix): reduced CPU usage of idle cockroach processes.

Informs #66881.