### PR TITLE
release-21.1: ui: fix custom chart initial no load

### DIFF
--- a/pkg/ui/src/views/cluster/components/linegraph/index.tsx
+++ b/pkg/ui/src/views/cluster/components/linegraph/index.tsx
@@ -502,6 +502,11 @@ export class LineGraph extends React.Component<LineGraphProps, {}> {
       if (this.u) {
         this.u.destroy();
       }
+
+      if (options.series?.length < 2) {
+        options.series.push({ scale: "1" });
+      }
+
       this.u = new uPlot(options, uPlotData, this.el.current);
     }
   }


### PR DESCRIPTION
**What was there before:** The original logic for drawing the custom chart.
**What was the issue:** On initial load the function to create the options returns an array with 1 object but the uplot lib expects 2 objects with the second object having an attribute 'scale'.
**How it was resolved:** Added a check on the functions return to see if the numbers of elements is < 2 and if so return a 'filler' object with a scale value of 1.

Release note (ui): fix custom chart bug where it does not load on initial
[Github issue](https://github.com/cockroachdb/cockroach/issues/66890)
[Jira](https://cockroachlabs.atlassian.net/browse/CRDB-8278)