### PR TITLE
importccl: respect storage options on PGDUMP index creation

### DIFF
--- a/pkg/ccl/importccl/read_import_pgdump.go
+++ b/pkg/ccl/importccl/read_import_pgdump.go
@@ -614,6 +614,7 @@ func readPostgresStmt(
 			Inverted:         stmt.Inverted,
 			Interleave:       stmt.Interleave,
 			PartitionByIndex: stmt.PartitionByIndex,
+			StorageParams:    stmt.StorageParams,
 		}
 		if stmt.Unique {
 			idx = &tree.UniqueConstraintTableDef{IndexTableDef: *idx.(*tree.IndexTableDef)}

--- a/pkg/ccl/importccl/testdata/pgdump/geo_ogr2ogr.sql
+++ b/pkg/ccl/importccl/testdata/pgdump/geo_ogr2ogr.sql
@@ -2,6 +2,7 @@ BEGIN;
 DELETE FROM geometry_columns WHERE f_table_name = 'nyc_census_blocks' AND f_table_schema = 'public';
 CREATE TABLE "public"."HydroNode" (    "fid" SERIAL,    CONSTRAINT "HydroNode_pk" PRIMARY KEY ("fid") );
 SELECT AddGeometryColumn('public','HydroNode','geom',4326,'POINT',2);
+CREATE INDEX ON "HydroNode" USING GIST(geom) WITH (fillfactor = 3, s2_max_level = 4);
 -- ALTER TABLE "HydroNode" ALTER COLUMN "geom" SET NOT NULL; blocked by https://github.com/cockroachdb/cockroach/issues/52501
 ALTER TABLE "public"."HydroNode" ADD COLUMN "id" VARCHAR(38) NOT NULL;
 ALTER TABLE "public"."HydroNode" ADD COLUMN "hydroNodeCategory" VARCHAR(20) NOT NULL;


### PR DESCRIPTION
IMPORT now detects the storage params that can be specified on a CREATE
INDEX statement from a PGDUMP file. See
https://www.cockroachlabs.com/docs/stable/create-index.html for more
details about storage options that can be specified on indexes.

Release note (bug fix): IMPORT now respects the spacial index storage
options specified in PGDUMP files on indexes it creates.
