### PR TITLE
roachprod: add download command

### DIFF
--- a/pkg/cmd/roachprod/install/BUILD.bazel
+++ b/pkg/cmd/roachprod/install/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "cluster_synced.go",
         "cockroach.go",
+        "download.go",
         "expander.go",
         "install.go",
         "iterm2.go",
@@ -12,6 +13,7 @@ go_library(
         "session.go",
         "staging.go",
     ],
+    embedsrcs = ["scripts/download.sh"],
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/roachprod/install",
     visibility = ["//visibility:public"],
     deps = [

--- a/pkg/cmd/roachprod/install/download.go
+++ b/pkg/cmd/roachprod/install/download.go
@@ -1,0 +1,84 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package install
+
+import (
+	_ "embed" // required for go:embed
+	"fmt"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+)
+
+const (
+	gcsCacheBaseURL = "https://storage.googleapis.com/cockroach-fixtures/tools/"
+)
+
+//go:embed scripts/download.sh
+var downloadScript string
+
+// Download downloads the remote resource, preferring a GCS cache if available.
+func Download(c *SyncedCluster, sourceURLStr string, sha string, dest string) error {
+	// https://example.com/foo/bar.txt
+	sourceURL, err := url.Parse(sourceURLStr)
+	if err != nil {
+		return err
+	}
+
+	// bar.txt
+	basename := path.Base(sourceURL.Path)
+	// SHA-bar.txt
+	cacheBasename := fmt.Sprintf("%s-%s", sha, basename)
+	// https://storage.googleapis.com/SOME_BUCKET/SHA-bar.txt
+	gcsCacheURL, err := url.Parse(path.Join(gcsCacheBaseURL, cacheBasename))
+	if err != nil {
+		return err
+	}
+
+	if dest == "" {
+		dest = path.Join("./", basename)
+	}
+
+	// We don't want to deal with cross-platform file locking in
+	// shell scripts, so if we are on a local cluster, we download
+	// it on a single node and copy it from the cache on a single
+	// node if we have a non-relative path.
+	downloadNodes := c.Nodes
+	if c.IsLocal() {
+		downloadNodes = downloadNodes[:1]
+	}
+
+	downloadCmd := fmt.Sprintf(downloadScript,
+		sourceURL.String(),
+		gcsCacheURL.String(),
+		sha,
+		dest,
+	)
+	if err := c.Run(os.Stdout, os.Stderr,
+		downloadNodes,
+		fmt.Sprintf("downloading %s", basename),
+		downloadCmd,
+	); err != nil {
+		return err
+	}
+
+	// If we are local and the destination is relative, then copy
+	// the file from the download node to the other nodes
+	if c.IsLocal() && !filepath.IsAbs(dest) {
+		// ~/local/1/./bar.txt
+		src := fmt.Sprintf(os.ExpandEnv("${HOME}/local/%d/%s"), downloadNodes[0], dest)
+		cpCmd := fmt.Sprintf(`cp "%s" "%s"`, src, dest)
+		return c.Run(os.Stdout, os.Stderr, c.Nodes[1:], "copying to remaining nodes", cpCmd)
+	}
+
+	return nil
+}

--- a/pkg/cmd/roachprod/install/scripts/download.sh
+++ b/pkg/cmd/roachprod/install/scripts/download.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.txt.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0, included in the file
+# licenses/APL.txt.
+set -euo pipefail
+# These values are substituted in the Go code that uses this.
+SOURCE_URL="%s"
+CACHE_URL="%s"
+SHA256="%s"
+OUTPUT_FILE="%s"
+
+checkFile() {
+  local file_name="${1}"
+  local expected_shasum="${2}"
+
+  local actual_shasum=""
+  if command -v sha256sum > /dev/null 2>&1; then
+    actual_shasum=$(sha256sum "$file_name" | cut -f1 -d' ')
+  elif command -v shasum > /dev/null 2>&1; then
+    actual_shasum=$(shasum -a 256 "$file_name" | cut -f1 -d' ')
+  else
+    echo "sha256sum or shasum not found" >&2
+    return 1
+  fi
+
+  if [[ "$actual_shasum" == "$expected_shasum" ]]; then
+     return 0
+  else
+    echo "SHASUM MISMATCH: expected: $expected_shasum, actual: $actual_shasum"
+    return 1
+  fi
+}
+
+download() {
+  local url="$1"
+  local output_file="$2"
+  local output_dir
+  local tmpfile
+
+  output_dir="$(dirname "$output_file")"
+  tmpfile=$(mktemp "$output_dir/.roachprod_download_XXXX")
+  trap "rm -f -- ${tmpfile}" EXIT
+  # curl options:
+  #            -s: silent
+  #            -o: output file
+  #            -L: follow redirects
+  #  --show-error: show errors despite silent flag
+  #        --fail: Exit non-0 for non-2XX HTTP status codes
+  #       --retry: Retry transient errors
+  # --retry-delay: Time to wait (in seconds) between retries
+  if curl -s -L --retry 3 --retry-delay 1 --fail --show-error -o "$tmpfile" "$url"; then
+      mv "$tmpfile" "$output_file"
+  else
+      rm -f "$tmpfile"
+      return 1
+  fi
+}
+
+download_with_cache() {
+  local source_url="$1"
+  local cache_url="$2"
+  local sha256="$3"
+  local output_file="$4"
+
+  echo "Attempting to download from cache: $cache_url"
+  if ! download "$cache_url" "$output_file"; then
+    echo "Failed to download from cache ($cache_url), trying source: $source_url"
+    download "$source_url" "$output_file"
+  fi
+  checkFile "$output_file" "$sha256"
+}
+
+if ! [[ -f "$OUTPUT_FILE" ]]; then
+  echo "File not found on disk, downloading"
+  download_with_cache "$SOURCE_URL" "$CACHE_URL" "$SHA256" "$OUTPUT_FILE"
+else
+  if ! checkFile "$OUTPUT_FILE" "$SHA256"; then
+    echo "File found on disk but with wrong SHA256, redownloading"
+    download_with_cache "$SOURCE_URL" "$CACHE_URL" "$SHA256" "$OUTPUT_FILE"
+  else
+    echo "File already downloaded."
+  fi
+fi

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -1324,6 +1324,25 @@ var installCmd = &cobra.Command{
 	}),
 }
 
+var downloadCmd = &cobra.Command{
+	Use:   "download <cluster> <url> <sha256> [DESTINATION]",
+	Short: "download 3rd party tools",
+	Long:  "Downloads 3rd party tools, using a GCS cache if possible.",
+	Args:  cobra.RangeArgs(3, 4),
+	Run: wrap(func(cmd *cobra.Command, args []string) error {
+		c, err := newCluster(args[0])
+		if err != nil {
+			return err
+		}
+		src, sha := args[1], args[2]
+		var dest string
+		if len(args) == 4 {
+			dest = args[3]
+		}
+		return install.Download(c, src, sha, dest)
+	}),
+}
+
 var stageCmd = &cobra.Command{
 	Use:   "stage <cluster> <application> [<sha/version>]",
 	Short: "stage cockroach binaries",
@@ -1793,6 +1812,7 @@ func main() {
 		putCmd,
 		getCmd,
 		stageCmd,
+		downloadCmd,
 		sqlCmd,
 		ipCmd,
 		pgurlCmd,


### PR DESCRIPTION
This adds a download command that can downloads an artifact onto
cluster nodes, using an on-disk and cloud-based cache if possible.

Release note: None