### PR TITLE
execgen: add execgen:instantiate and execgen:let declarations

### DIFF
--- a/pkg/sql/colexec/execgen/template.go
+++ b/pkg/sql/colexec/execgen/template.go
@@ -14,11 +14,18 @@ import (
 	"fmt"
 	"go/token"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/dave/dst"
 	"github.com/dave/dst/dstutil"
 )
+
+type templateInfo struct {
+	funcInfos map[string]*funcInfo
+
+	letInfos map[string]*letInfo
+}
 
 type templateParamInfo struct {
 	fieldOrdinal int
@@ -32,6 +39,13 @@ type funcInfo struct {
 	// instantiateArgs is a list of lists of arguments that were passed explicitly
 	// as execgen:instantiate declarations.
 	instantiateArgs [][]string
+}
+
+// letInfo contains a list of all of the values in an execgen:let declaration.
+type letInfo struct {
+	// typ is a type literal.
+	typ  *dst.ArrayType
+	vals []string
 }
 
 // Match // execgen:template<foo, bar>
@@ -325,10 +339,15 @@ func trimTemplateDeclMatches(matches []string) []string {
 
 const runtimeToTemplateSuffix = "_runtime_to_template"
 
-// findTemplateFuncs, given an AST, finds all functions annotated with
-// execgen:template<foo,bar>, and returns a funcInfo for each of them.
-func findTemplateFuncs(f *dst.File) map[string]*funcInfo {
-	ret := make(map[string]*funcInfo)
+// findTemplateDecls, given an AST, finds all functions annotated with
+// execgen:template<foo,bar>, and returns a funcInfo for each of them, and
+// finds all var decls annotated with execgen:let, returning a letInfo for
+// each of them.
+func findTemplateDecls(f *dst.File) templateInfo {
+	ret := templateInfo{
+		funcInfos: make(map[string]*funcInfo),
+		letInfos:  make(map[string]*letInfo),
+	}
 
 	dstutil.Apply(f, func(cursor *dstutil.Cursor) bool {
 		n := cursor.Node()
@@ -344,7 +363,9 @@ func findTemplateFuncs(f *dst.File) map[string]*funcInfo {
 				}
 
 				if matches := instantiateRe.FindStringSubmatch(dec); matches != nil {
-					instantiateArgs = append(instantiateArgs, trimTemplateDeclMatches(matches))
+					instantiateMatches := trimTemplateDeclMatches(matches)
+					newInstantiateArgs := expandInstantiateArgs(instantiateMatches, ret.letInfos)
+					instantiateArgs = append(instantiateArgs, newInstantiateArgs...)
 					// Eventually let's delete the instantiate comments as well.
 					continue
 				}
@@ -419,7 +440,7 @@ func findTemplateFuncs(f *dst.File) map[string]*funcInfo {
 			n.Type.Params.List = newParamList
 			n.Decs.Start = trimStartDecs(n)
 			info.decl = n
-			ret[info.decl.Name.Name] = info
+			ret.funcInfos[info.decl.Name.Name] = info
 
 			for _, args := range info.instantiateArgs {
 				exprList := make([]dst.Expr, len(args))
@@ -454,10 +475,98 @@ func findTemplateFuncs(f *dst.File) map[string]*funcInfo {
 				cursor.InsertAfter(decl)
 			}
 			cursor.Delete()
+
+		case *dst.GenDecl:
+			// Search for execgen:let declarations.
+			isLet := false
+			for _, dec := range n.Decs.Start {
+				if dec == "// execgen:let" {
+					isLet = true
+					break
+				}
+			}
+			if !isLet {
+				return true
+			}
+			if n.Tok != token.VAR {
+				panic("execgen:let only allowed on vars")
+			}
+			for _, spec := range n.Specs {
+				n := spec.(*dst.ValueSpec)
+				if len(n.Names) != 1 || len(n.Values) != 1 {
+					panic("execgen:let must have 1 name and one value per var")
+				}
+				info := &letInfo{}
+				name := n.Names[0].Name
+				c, ok := n.Values[0].(*dst.CompositeLit)
+				if !ok {
+					panic("execgen:let must use a composite literal value")
+				}
+				typ, ok := c.Type.(*dst.ArrayType)
+				if !ok {
+					panic("execgen:let must be on an array type literal")
+				}
+				info.vals = make([]string, len(c.Elts))
+				info.typ = typ
+				for i := range c.Elts {
+					info.vals[i] = prettyPrintExprs(c.Elts[i])
+				}
+				ret.letInfos[name] = info
+			}
+
+			cursor.Delete()
 		}
 		return true
 	}, nil)
 
+	return ret
+}
+
+// expandInstantiateArgs takes a list of strings, the arguments to an
+// execgen:instantiate annotation, and returns a list of list of strings, after
+// combinatorially expanding any execgen:let lists in the instantiate arguments.
+// For example, given the instantiateArgs:
+// ["Bools", "Bools", 3]
+// and an execgen:let that maps "Bools" to ["true", "false"], we'd return the
+// list of lists:
+// [true, true, 3]
+// [true, false, 3]
+// [false, true, 3]
+// [false, false, 3]
+func expandInstantiateArgs(instantiateArgs []string, letInfos map[string]*letInfo) [][]string {
+	expandedArgs := make([][]string, len(instantiateArgs))
+	for i, arg := range instantiateArgs {
+		if info := letInfos[arg]; info != nil {
+			expandedArgs[i] = info.vals
+		} else {
+			expandedArgs[i] = []string{arg}
+		}
+	}
+	return generateInstantiateCombinations(expandedArgs)
+}
+
+func generateInstantiateCombinations(args [][]string) [][]string {
+	if len(args) == 1 {
+		// Base case: transform the final options list into an arguments list of
+		// lists where each arguments list is a single element containing one of
+		// the final options.
+		// For example, given [[true, false]], we'll return:
+		// [[true], [false]]
+		ret := make([][]string, len(args[0]))
+		for i, arg := range args[0] {
+			ret[i] = []string{arg}
+		}
+		return ret
+	}
+	rest := generateInstantiateCombinations(args[1:])
+	ret := make([][]string, 0, len(rest)*len(args[0]))
+	for _, argOption := range args[0] {
+		// For every option of argument, prepend it to every args list from
+		// the recursive step.
+		for _, args := range rest {
+			ret = append(ret, append([]string{argOption}, args...))
+		}
+	}
 	return ret
 }
 
@@ -515,8 +624,15 @@ func generateSwitchStatementLookup(
 		groupedArgs[firstArg] = append(groupedArgs[firstArg], argList[1:])
 	}
 	stmtList := make([]dst.Stmt, len(groupedArgs)+1)
-	var i int
-	for firstArg, restArgs := range groupedArgs {
+	// Sort firstArgs lexicographically, so we have a consistent output order.
+	firstArgs := make([]string, 0, len(groupedArgs))
+	for firstArg := range groupedArgs {
+		firstArgs = append(firstArgs, firstArg)
+	}
+	sort.Strings(firstArgs)
+
+	for i, firstArg := range firstArgs {
+		restArgs := groupedArgs[firstArg]
 		argList := append(curArgs, dst.NewIdent(firstArg))
 		stmtList[i] = &dst.CaseClause{
 			List: []dst.Expr{dst.NewIdent(firstArg)},
@@ -527,7 +643,6 @@ func generateSwitchStatementLookup(
 				restArgs,
 			)},
 		}
-		i++
 	}
 	stmtList[len(stmtList)-1] = defaultCase
 	ret.Body.List = stmtList
@@ -716,8 +831,8 @@ func findConcreteTemplateCallSites(
 // it modifies the dst.File to include all expanded template functions, and
 // edits call sites to call the newly expanded functions.
 func expandTemplates(f *dst.File) {
-	funcInfos := findTemplateFuncs(f)
-	replaceAndExpandTemplates(f, funcInfos)
+	templateInfo := findTemplateDecls(f)
+	replaceAndExpandTemplates(f, templateInfo.funcInfos)
 }
 
 // createTemplateFuncVariant creates a variant of the input funcInfo given the

--- a/pkg/sql/colexec/execgen/template_test.go
+++ b/pkg/sql/colexec/execgen/template_test.go
@@ -84,3 +84,46 @@ func TestTryEvalBools(t *testing.T) {
 		assert.Equal(t, actual, tc.expected, "wrong result for expr", prettyPrintExprs(tc.expr))
 	}
 }
+
+func TestGenerateInstantiateCombinations(t *testing.T) {
+	tcs := []struct {
+		args     [][]string
+		expected [][]string
+	}{
+		{
+			args: [][]string{
+				{"1"},
+			},
+			expected: [][]string{
+				{"1"},
+			},
+		},
+		{
+			args: [][]string{
+				{"true", "false"},
+			},
+			expected: [][]string{
+				{"true"},
+				{"false"},
+			},
+		},
+		{
+			args: [][]string{
+				{"t", "f"},
+				{"1"},
+				{"foo", "bar", "baz"},
+			},
+			expected: [][]string{
+				{"t", "1", "foo"},
+				{"t", "1", "bar"},
+				{"t", "1", "baz"},
+				{"f", "1", "foo"},
+				{"f", "1", "bar"},
+				{"f", "1", "baz"},
+			},
+		},
+	}
+	for _, tc := range tcs {
+		assert.Equal(t, tc.expected, generateInstantiateCombinations(tc.args))
+	}
+}

--- a/pkg/sql/colexec/execgen/testdata/instantiate
+++ b/pkg/sql/colexec/execgen/testdata/instantiate
@@ -143,19 +143,19 @@ const _ = "template_b"
 
 func b_runtime_to_template(t bool, i int) int {
 	switch t {
-	case true:
-		switch i {
-		case 3:
-			return b_true_3()
-		default:
-			panic(fmt.Sprint("unknown value", i))
-		}
 	case false:
 		switch i {
 		case 3:
 			return b_false_3()
 		case 4:
 			return b_false_4()
+		default:
+			panic(fmt.Sprint("unknown value", i))
+		}
+	case true:
+		switch i {
+		case 3:
+			return b_true_3()
 		default:
 			panic(fmt.Sprint("unknown value", i))
 		}
@@ -176,6 +176,100 @@ func b_false_3() int {
 
 func b_false_4() int {
 	x = 2
+	return x
+}
+----
+----
+
+template
+package main
+
+func a(input bool) {
+  b(input)
+}
+
+// execgen:let
+var Bools = []bool{true, false}
+
+// execgen:let
+var MyIntegers = []int{1,4,7}
+
+// execgen:template<t, i>
+// execgen:instantiate<Bools, MyIntegers>
+func b(t bool, i int) int {
+  if t {
+    x = 3
+  } else {
+    x = 4
+  }
+  return x
+}
+----
+----
+package main
+
+func a(input bool) {
+	b_runtime_to_template(input)
+}
+
+const _ = "template_b"
+
+func b_runtime_to_template(t bool, i int) int {
+	switch t {
+	case false:
+		switch i {
+		case 1:
+			return b_false_1()
+		case 4:
+			return b_false_4()
+		case 7:
+			return b_false_7()
+		default:
+			panic(fmt.Sprint("unknown value", i))
+		}
+	case true:
+		switch i {
+		case 1:
+			return b_true_1()
+		case 4:
+			return b_true_4()
+		case 7:
+			return b_true_7()
+		default:
+			panic(fmt.Sprint("unknown value", i))
+		}
+	default:
+		panic(fmt.Sprint("unknown value", t))
+	}
+}
+
+func b_true_1() int {
+	x = 3
+	return x
+}
+
+func b_true_4() int {
+	x = 3
+	return x
+}
+
+func b_true_7() int {
+	x = 3
+	return x
+}
+
+func b_false_1() int {
+	x = 4
+	return x
+}
+
+func b_false_4() int {
+	x = 4
+	return x
+}
+
+func b_false_7() int {
+	x = 4
 	return x
 }
 ----

--- a/pkg/sql/colexec/execgen/testdata/instantiate
+++ b/pkg/sql/colexec/execgen/testdata/instantiate
@@ -1,0 +1,182 @@
+template
+package main
+
+func a(input bool) {
+  b(input)
+}
+
+// execgen:template<t>
+// execgen:instantiate<true>
+// execgen:instantiate<false>
+func b(t bool) int {
+  if t {
+    x = 3
+  } else {
+    x = 4
+  }
+  return x
+}
+----
+----
+package main
+
+func a(input bool) {
+	b_runtime_to_template(input)
+}
+
+const _ = "template_b"
+
+func b_runtime_to_template(t bool) int {
+	switch t {
+	case true:
+		return b_true()
+	case false:
+		return b_false()
+	default:
+		panic(fmt.Sprint("unknown value", t))
+	}
+}
+
+func b_true() int {
+	x = 3
+	return x
+}
+
+func b_false() int {
+	x = 4
+	return x
+}
+----
+----
+
+template
+package main
+
+// execgen:instantiate<1>
+// execgen:instantiate<2>
+// execgen:instantiate<3>
+// execgen:template<i>
+func b(i int) {
+  switch i {
+    case 1:
+      fmt.Println("found a 1")
+    case 2:
+      fmt.Println("found a 2")
+    case 3:
+      fmt.Println("found a 3")
+  }
+}
+
+func a(input int) {
+    b(input)
+}
+----
+----
+package main
+
+const _ = "template_b"
+
+func b_runtime_to_template(i int) {
+	switch i {
+	case 1:
+		b_1()
+	case 2:
+		b_2()
+	case 3:
+		b_3()
+	default:
+		panic(fmt.Sprint("unknown value", i))
+	}
+}
+
+func a(input int) {
+	b_runtime_to_template(input)
+}
+
+func b_1() {
+	fmt.Println("found a 1")
+}
+
+func b_2() {
+	fmt.Println("found a 2")
+}
+
+func b_3() {
+	fmt.Println("found a 3")
+}
+----
+----
+
+template
+package main
+
+func a(input bool, i int) {
+  b(input, i)
+}
+
+// execgen:template<t, i>
+// execgen:instantiate<true, 3>
+// execgen:instantiate<false, 3>
+// execgen:instantiate<false, 4>
+func b(t bool, i int) int {
+  if t {
+    x = 3
+  } else {
+    switch i {
+      case 3:
+        x = 1
+      case 4:
+        x = 2
+    }
+  }
+  return x
+}
+----
+----
+package main
+
+func a(input bool, i int) {
+	b_runtime_to_template(input, i)
+}
+
+const _ = "template_b"
+
+func b_runtime_to_template(t bool, i int) int {
+	switch t {
+	case true:
+		switch i {
+		case 3:
+			return b_true_3()
+		default:
+			panic(fmt.Sprint("unknown value", i))
+		}
+	case false:
+		switch i {
+		case 3:
+			return b_false_3()
+		case 4:
+			return b_false_4()
+		default:
+			panic(fmt.Sprint("unknown value", i))
+		}
+	default:
+		panic(fmt.Sprint("unknown value", t))
+	}
+}
+
+func b_true_3() int {
+	x = 3
+	return x
+}
+
+func b_false_3() int {
+	x = 1
+	return x
+}
+
+func b_false_4() int {
+	x = 2
+	return x
+}
+----
+----

--- a/pkg/sql/colexec/execgen/util.go
+++ b/pkg/sql/colexec/execgen/util.go
@@ -11,6 +11,7 @@
 package execgen
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/dave/dst"
@@ -51,4 +52,24 @@ func prettyPrintExprs(exprs ...dst.Expr) string {
 		stmts[i] = &dst.ExprStmt{X: exprs[i]}
 	}
 	return prettyPrintStmts(stmts...)
+}
+
+func parseStmt(stmt string) (dst.Stmt, error) {
+	f, err := decorator.Parse(fmt.Sprintf(
+		`package main
+func test() {
+	%s
+}`, stmt))
+	if err != nil {
+		return nil, err
+	}
+	return f.Decls[0].(*dst.FuncDecl).Body.List[0], nil
+}
+
+func mustParseStmt(stmt string) dst.Stmt {
+	ret, err := parseStmt(stmt)
+	if err != nil {
+		panic(err)
+	}
+	return ret
 }

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1724,6 +1724,7 @@ func TestLint(t *testing.T) {
 			// (see git help gitglossary) makes * behave like a normal, single dir
 			// glob, and exclude is the synonym of !.
 			":(glob,exclude)sql/colexec/execgen/*.go",
+			":!sql/colexec/execgen/testdata",
 		)
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
execgen:instantiate provides a way to inform execgen about the possible
inputs to a template function, besides providing a concrete callsite.

This allows us to solve the problem of how to convert a runtime value
into a template value without having to write out a big switch/case
statement by hand.

For example, consider an integer template like this:

    // execgen:template<i>
    func b(i int) {
      switch i {
        case 1:
          fmt.Println("found a 1")
        case 2:
          fmt.Println("found a 2")
        case 3:
          fmt.Println("found a 3")
      }
    }

    func a() {
      b(1)
      b(2)
    }

Previously, this template would be instantiated for all unique callsites
of the template, in this case, 1 and 2.

But what if we had a *runtime* value that we wanted to pass into the `b`
function? How would we do that? Previously, we'd have to have another
trivial case statement, to link up the dynamic value with an
explicit call to the template:

    func a(input int) {
      if input == 1 {
        b(1)
      } else if input == 2 {
        b(2)
      }
    }

Of course this code looks really silly, but without it, we can't
specialize the `b` function properly, since we don't have the
compile-time values 1 and 2 available to do so.

This commit solves this problem by introducing a new directive, called
execgen:instantiate, which provides a list of the possible arguments to
a template function.

With execgen:instantiate, our example can be rewritten like this:

    // execgen:instantiate<1>
    // execgen:instantiate<2>
    // execgen:instantiate<3>
    // execgen:template<i>
    func b(i int) {
      switch i {
        case 1:
          fmt.Println("found a 1")
        case 2:
          fmt.Println("found a 2")
        case 3:
          fmt.Println("found a 3")
      }
    }

    func a(input int) {
        b(input)
    }

Given this input, execgen will generate variants for all of the
instantiate annotations, and create a runtime-to-template switch
function that allows us to simply call b(input), magically turning the
runtime input value into an invocation of a compiled, specialized
function:

    func b_runtime_to_template(i int) {
	    switch i {
	    case 1:
		    b_1()
	    case 2:
		    b_2()
	    case 3:
		    b_3()
	    default:
		    panic(fmt.Sprintf("unknown value %s", i))
	    }
    }

    func a(input int) {
	    b_runtime_to_template(input)
    }

    func b_1() {
	    fmt.Println("found a 1")
    }

    func b_2() {
	    fmt.Println("found a 2")
    }

    func b_3() {
	    fmt.Println("found a 3")
    }

--- 

execgen:let is a new annotation that declares the following slice
literal var as a compile-time argument options list that can be used in
an execgen:instantiate annotation as a shortcut for frequently-used sets
of arguments.

For example, take the following list of execgen:instantiate arguments:

```
// execgen:template<b, i>
// execgen:instantiate<true, 1>
// execgen:instantiate<true, 2>
// execgen:instantiate<true, 3>
// execgen:instantiate<false, 1>
// execgen:instantiate<false, 2>
// execgen:instantiate<false, 3>
func foo (b bool, i int) {
  ...
}
```

As a shortcut to typing out all of these instantiate declarations, we
can do the following with execgen:let:

```
// execgen:let
var bools = []bool{true, false}

// execgen:let
var ints = []int{1, 2, 3}

// execgen:template<b, i>
// execgen:instantiate<bools, ints>
func foo (b bool, i int) {
  ...
}
