### PR TITLE
build: name aarch64 compiler appropriately in builder, `mkrelease`

### DIFF
--- a/build/builder.sh
+++ b/build/builder.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 image=cockroachdb/builder
-version=20210616-013156
+version=20210625-235250
 
 function init() {
   docker build --tag="${image}" "$(dirname "${0}")/builder"

--- a/build/builder/Dockerfile
+++ b/build/builder/Dockerfile
@@ -73,14 +73,14 @@ RUN mkdir -p /usr/local/lib/ccache \
  && ln -s /usr/bin/ccache /usr/local/lib/ccache/x86_64-unknown-linux-gnu-c++ \
  && ln -s /usr/bin/ccache /usr/local/lib/ccache/x86_64-w64-mingw32-cc \
  && ln -s /usr/bin/ccache /usr/local/lib/ccache/x86_64-w64-mingw32-c++ \
- && ln -s /usr/bin/ccache /usr/local/lib/ccache/aarch64-unknown-linux-gnueabi-cc \
- && ln -s /usr/bin/ccache /usr/local/lib/ccache/aarch64-unknown-linux-gnueabi-c++ \
+ && ln -s /usr/bin/ccache /usr/local/lib/ccache/aarch64-unknown-linux-gnu-cc \
+ && ln -s /usr/bin/ccache /usr/local/lib/ccache/aarch64-unknown-linux-gnu-c++ \
  && ln -s /usr/bin/ccache /usr/local/lib/ccache/s390x-ibm-linux-gnu-c++ \
  && ln -s /usr/bin/ccache /usr/local/lib/ccache/s390x-ibm-linux-gnu-cc \
  && ln -s /usr/bin/ccache /usr/local/lib/ccache/x86_64-apple-darwin19-cc \
  && ln -s /usr/bin/ccache /usr/local/lib/ccache/x86_64-apple-darwin19-c++
 
-ENV PATH $PATH:/x-tools/x86_64-unknown-linux-gnu/bin:/x-tools/x86_64-w64-mingw32/bin:/x-tools/aarch64-unknown-linux-gnueabi/bin:/x-tools/s390x-ibm-linux-gnu/bin:/x-tools/x86_64-apple-darwin19/bin
+ENV PATH $PATH:/x-tools/x86_64-unknown-linux-gnu/bin:/x-tools/x86_64-w64-mingw32/bin:/x-tools/aarch64-unknown-linux-gnu/bin:/x-tools/s390x-ibm-linux-gnu/bin:/x-tools/x86_64-apple-darwin19/bin
 
 # Compile GNU sed from source to pick up an unreleased change that buffers
 # output. This speeds up compiles on Docker for Mac by *minutes*.

--- a/build/builder/mkrelease.sh
+++ b/build/builder/mkrelease.sh
@@ -9,7 +9,7 @@
 # Possible configurations:
 #
 #   - amd64-linux-gnu:      amd64, Linux 2.6.32, dynamically link glibc 2.12.2
-#   - arm64-linux-gnueabi:  arm64, Linux 3.7.10, dynamically link glibc 2.12.2
+#   - arm64-linux-gnu:      arm64, Linux 3.7.10, dynamically link glibc 2.12.2
 #   - amd64-darwin:         amd64, macOS 10.9
 #   - amd64-windows:        amd64, Windows 8, statically link all non-Windows libraries
 #   - s390x-linux-gnu:      s390x, Linux 2.6.32, dynamically link glibc 2.12.2
@@ -48,7 +48,7 @@ case "${1-}" in
       SUFFIX=-linux-2.6.32-gnu-amd64
     ) ;;
 
-  ?(arm64-)linux?(-gnueabi))
+  ?(arm64-)linux?(-gnu))
     # Manually set the correct values for configure checks that libkrb5 won't be
     # able to perform because we're cross-compiling.
     export krb5_cv_attr_constructor_destructor=yes
@@ -58,7 +58,7 @@ case "${1-}" in
       XGOOS=linux
       XGOARCH=arm64
       XCMAKE_SYSTEM_NAME=Linux
-      TARGET_TRIPLE=aarch64-unknown-linux-gnueabi
+      TARGET_TRIPLE=aarch64-unknown-linux-gnu
       LDFLAGS="-static-libgcc -static-libstdc++"
       SUFFIX=-linux-3.7.10-gnu-aarch64
     ) ;;


### PR DESCRIPTION
At some point the ABI of this compiler changed from `gnueabi` to `gnu`.
Standardize on `gnu` everywhere.

Closes #66812.

Release note: None