### PR TITLE
geomfn: fix ST_LineSubString for LINESTRING EMPTY

### DIFF
--- a/pkg/geo/geomfn/linestring.go
+++ b/pkg/geo/geomfn/linestring.go
@@ -262,10 +262,6 @@ func LineSubstring(g geo.Geometry, start, end float64) (geo.Geometry, error) {
 			"end must be greater or equal to the start")
 	}
 
-	if start == end {
-		return LineInterpolatePoints(g, start, false)
-	}
-
 	lineT, err := g.AsGeomT()
 	if err != nil {
 		return g, err
@@ -273,7 +269,15 @@ func LineSubstring(g geo.Geometry, start, end float64) (geo.Geometry, error) {
 	lineString, ok := lineT.(*geom.LineString)
 	if !ok {
 		return g, pgerror.Newf(pgcode.InvalidParameterValue,
-			"first parameter has to be of type LineString")
+			"geometry has to be of type LineString")
+	}
+	if lineString.Empty() {
+		return geo.MakeGeometryFromGeomT(
+			geom.NewLineString(geom.XY).SetSRID(lineString.SRID()),
+		)
+	}
+	if start == end {
+		return LineInterpolatePoints(g, start, false)
 	}
 
 	lsLength := lineString.Length()

--- a/pkg/geo/geomfn/linestring_test.go
+++ b/pkg/geo/geomfn/linestring_test.go
@@ -495,12 +495,19 @@ func TestRemovePoint(t *testing.T) {
 func TestLineSubstring(t *testing.T) {
 	tests := []struct {
 		name          string
-		lineString    *geom.LineString
+		lineString    geom.T
 		start         float64
 		end           float64
 		wantGeomT     geom.T
 		wantErrString string
 	}{
+		{
+			name:       "empty",
+			lineString: geom.NewLineString(geom.XY),
+			start:      0.1,
+			end:        0.2,
+			wantGeomT:  geom.NewLineString(geom.XY),
+		},
 		{
 			name:       "1/3 mid-range part of a linestring",
 			lineString: geom.NewLineStringFlat(geom.XY, []float64{25, 50, 100, 125, 150, 190}),
@@ -579,6 +586,13 @@ func TestLineSubstring(t *testing.T) {
 			end:           0.1,
 			wantGeomT:     geom.NewLineStringFlat(geom.XY, []float64{25, 50, 100, 125, 150, 190}),
 			wantErrString: "end must be greater or equal to the start",
+		},
+		{
+			name:          "not a line string",
+			lineString:    geom.NewPointEmpty(geom.XY),
+			start:         0.4,
+			end:           0.6,
+			wantErrString: "geometry has to be of type LineString",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -5765,7 +5765,8 @@ select st_astext(st_linesubstring(g,star,"end"))from (VALUES
        ('LINESTRING(70 10, 10 125.6, 15.40 1.9, 4 6)'::geometry, 0.1, 0.8),
        ('LINESTRING(70 10, 10 125)'::geometry, 0.1, 0.8),
        ('LINESTRING(70 10, 10 125)'::geometry, 0.8, 0.8),
-       ('LINESTRING(0 0, 0 0)'::geometry, 0.8, 0.8)
+       ('LINESTRING(0 0, 0 0)'::geometry, 0.8, 0.8),
+       ('LINESTRING EMPTY'::geometry, 0.1, 0.2)
     ) t(g,star, "end");
 ----
 LINESTRING (0 0, 0 3.6)
@@ -5774,6 +5775,7 @@ LINESTRING (57.73791181125825 33.624956576975762, 10 125.599999999999994, 13.606
 LINESTRING (64 21.5, 22 102)
 POINT (22 102)
 POINT (0 0)
+NULL
 
 query T
 SELECT ST_AsEWKT(ST_ShiftLongitude(geom)) FROM ( VALUES

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -6694,6 +6694,10 @@ May return a Point or LineString in the case of degenerate inputs.`,
 				if err != nil {
 					return nil, err
 				}
+				// PostGIS returns nil for empty linestrings.
+				if g.Empty() && g.ShapeType2D() == geopb.ShapeType_LineString {
+					return tree.DNull, nil
+				}
 				geometry, err := geomfn.LineSubstring(g.Geometry, startFractionFloat, endFractionFloat)
 				if err != nil {
 					return nil, err


### PR DESCRIPTION
Resolves #66305

Release note (bug fix): Fix ST_LineSubstring for LINESTRING EMPTY
panicking instead of returning null.