### PR TITLE
server: move makeSQLServerArgs

### DIFF
--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -30,36 +30,28 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
-	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvtenant"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts/ptpb"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts/ptprovider"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
-	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/status"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/contention"
-	"github.com/cockroachdb/cockroach/pkg/sql/flowinfra"
-	"github.com/cockroachdb/cockroach/pkg/sql/optionalnodeliveness"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire"
 	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sqlmigrations"
 	"github.com/cockroachdb/cockroach/pkg/storage"
-	"github.com/cockroachdb/cockroach/pkg/storage/cloud"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/ts"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -72,7 +64,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/errors"
 	"github.com/gogo/protobuf/proto"
-	"google.golang.org/grpc"
 )
 
 // makeTestConfig returns a config for testing. It overrides the
@@ -462,177 +453,6 @@ type dummyProtectedTSProvider struct {
 
 func (d dummyProtectedTSProvider) Protect(context.Context, *kv.Txn, *ptpb.Record) error {
 	return errors.New("fake protectedts.Provider")
-}
-
-func makeSQLServerArgs(
-	stopper *stop.Stopper, kvClusterName string, baseCfg BaseConfig, sqlCfg SQLConfig,
-) (sqlServerArgs, error) {
-	st := baseCfg.Settings
-	baseCfg.AmbientCtx.AddLogTag("sql", nil)
-	// TODO(tbg): this is needed so that the RPC heartbeats between the testcluster
-	// and this tenant work.
-	//
-	// TODO(tbg): address this when we introduce the real tenant RPCs in:
-	// https://github.com/cockroachdb/cockroach/issues/47898
-	baseCfg.ClusterName = kvClusterName
-
-	clock := hlc.NewClock(hlc.UnixNano, time.Duration(baseCfg.MaxOffset))
-
-	registry := metric.NewRegistry()
-
-	var rpcTestingKnobs rpc.ContextTestingKnobs
-	if p, ok := baseCfg.TestingKnobs.Server.(*TestingKnobs); ok {
-		rpcTestingKnobs = p.ContextTestingKnobs
-	}
-	rpcContext := rpc.NewContext(rpc.ContextOptions{
-		TenantID:   sqlCfg.TenantID,
-		AmbientCtx: baseCfg.AmbientCtx,
-		Config:     baseCfg.Config,
-		Clock:      clock,
-		Stopper:    stopper,
-		Settings:   st,
-		Knobs:      rpcTestingKnobs,
-	})
-
-	var dsKnobs kvcoord.ClientTestingKnobs
-	if dsKnobsP, ok := baseCfg.TestingKnobs.DistSQL.(*kvcoord.ClientTestingKnobs); ok {
-		dsKnobs = *dsKnobsP
-	}
-	rpcRetryOptions := base.DefaultRetryOptions()
-
-	tcCfg := kvtenant.ConnectorConfig{
-		AmbientCtx:        baseCfg.AmbientCtx,
-		RPCContext:        rpcContext,
-		RPCRetryOptions:   rpcRetryOptions,
-		DefaultZoneConfig: &baseCfg.DefaultZoneConfig,
-	}
-	tenantConnect, err := kvtenant.Factory.NewConnector(tcCfg, sqlCfg.TenantKVAddrs)
-	if err != nil {
-		return sqlServerArgs{}, err
-	}
-	resolver := kvtenant.AddressResolver(tenantConnect)
-	nodeDialer := nodedialer.New(rpcContext, resolver)
-
-	dsCfg := kvcoord.DistSenderConfig{
-		AmbientCtx:        baseCfg.AmbientCtx,
-		Settings:          st,
-		Clock:             clock,
-		NodeDescs:         tenantConnect,
-		RPCRetryOptions:   &rpcRetryOptions,
-		RPCContext:        rpcContext,
-		NodeDialer:        nodeDialer,
-		RangeDescriptorDB: tenantConnect,
-		TestingKnobs:      dsKnobs,
-	}
-	ds := kvcoord.NewDistSender(dsCfg)
-
-	var clientKnobs kvcoord.ClientTestingKnobs
-	if p, ok := baseCfg.TestingKnobs.KVClient.(*kvcoord.ClientTestingKnobs); ok {
-		clientKnobs = *p
-	}
-
-	txnMetrics := kvcoord.MakeTxnMetrics(baseCfg.HistogramWindowInterval())
-	registry.AddMetricStruct(txnMetrics)
-	tcsFactory := kvcoord.NewTxnCoordSenderFactory(
-		kvcoord.TxnCoordSenderFactoryConfig{
-			AmbientCtx:        baseCfg.AmbientCtx,
-			Settings:          st,
-			Clock:             clock,
-			Stopper:           stopper,
-			HeartbeatInterval: base.DefaultTxnHeartbeatInterval,
-			Linearizable:      false,
-			Metrics:           txnMetrics,
-			TestingKnobs:      clientKnobs,
-		},
-		ds,
-	)
-	db := kv.NewDB(baseCfg.AmbientCtx, tcsFactory, clock, stopper)
-	rangeFeedKnobs, _ := baseCfg.TestingKnobs.RangeFeed.(*rangefeed.TestingKnobs)
-	rangeFeedFactory, err := rangefeed.NewFactory(stopper, db, rangeFeedKnobs)
-	if err != nil {
-		return sqlServerArgs{}, err
-	}
-
-	circularInternalExecutor := &sql.InternalExecutor{}
-	// Protected timestamps won't be available (at first) in multi-tenant
-	// clusters.
-	var protectedTSProvider protectedts.Provider
-	{
-		pp, err := ptprovider.New(ptprovider.Config{
-			DB:               db,
-			InternalExecutor: circularInternalExecutor,
-			Settings:         st,
-		})
-		if err != nil {
-			panic(err)
-		}
-		protectedTSProvider = dummyProtectedTSProvider{pp}
-	}
-
-	recorder := status.NewMetricsRecorder(clock, nil, rpcContext, nil, st)
-
-	const sqlInstanceID = base.SQLInstanceID(10001)
-	idContainer := base.NewSQLIDContainer(sqlInstanceID, nil /* nodeID */)
-
-	runtime := status.NewRuntimeStatSampler(context.Background(), clock)
-	registry.AddMetricStruct(runtime)
-
-	esb := &externalStorageBuilder{}
-	externalStorage := func(ctx context.Context, dest roachpb.ExternalStorage) (cloud.
-		ExternalStorage, error) {
-		return esb.makeExternalStorage(ctx, dest)
-	}
-	externalStorageFromURI := func(ctx context.Context, uri string,
-		user security.SQLUsername) (cloud.ExternalStorage, error) {
-		return esb.makeExternalStorageFromURI(ctx, uri, user)
-	}
-
-	esb.init(sqlCfg.ExternalIODirConfig, baseCfg.Settings, nil, circularInternalExecutor, db)
-
-	// We don't need this for anything except some services that want a gRPC
-	// server to register against (but they'll never get RPCs at the time of
-	// writing): the blob service and DistSQL.
-	dummyRPCServer := grpc.NewServer()
-	sessionRegistry := sql.NewSessionRegistry()
-	contentionRegistry := contention.NewRegistry()
-	flowScheduler := flowinfra.NewFlowScheduler(baseCfg.AmbientCtx, stopper, st)
-	return sqlServerArgs{
-		sqlServerOptionalKVArgs: sqlServerOptionalKVArgs{
-			nodesStatusServer: serverpb.MakeOptionalNodesStatusServer(nil),
-			nodeLiveness:      optionalnodeliveness.MakeContainer(nil),
-			gossip:            gossip.MakeOptionalGossip(nil),
-			grpcServer:        dummyRPCServer,
-			isMeta1Leaseholder: func(_ context.Context, _ hlc.ClockTimestamp) (bool, error) {
-				return false, errors.New("isMeta1Leaseholder is not available to secondary tenants")
-			},
-			nodeIDContainer:        idContainer,
-			externalStorage:        externalStorage,
-			externalStorageFromURI: externalStorageFromURI,
-		},
-		sqlServerOptionalTenantArgs: sqlServerOptionalTenantArgs{
-			tenantConnect: tenantConnect,
-		},
-		SQLConfig:                &sqlCfg,
-		BaseConfig:               &baseCfg,
-		stopper:                  stopper,
-		clock:                    clock,
-		runtime:                  runtime,
-		rpcContext:               rpcContext,
-		nodeDescs:                tenantConnect,
-		systemConfigProvider:     tenantConnect,
-		nodeDialer:               nodeDialer,
-		distSender:               ds,
-		db:                       db,
-		registry:                 registry,
-		recorder:                 recorder,
-		sessionRegistry:          sessionRegistry,
-		contentionRegistry:       contentionRegistry,
-		flowScheduler:            flowScheduler,
-		circularInternalExecutor: circularInternalExecutor,
-		circularJobRegistry:      &jobs.Registry{},
-		protectedtsProvider:      protectedTSProvider,
-		rangeFeedFactory:         rangeFeedFactory,
-	}, nil
 }
 
 // TestTenant is an in-memory instantiation of the SQL-only process created for


### PR DESCRIPTION
This function is used by the tenant code but is in `testserver.go`. I
tend to ignore `testserver.go` when I'm trying to understand a
non-testing code path so this was confusing.

This commit moves the function to `tenant.go` and gives it a more
specific name.

Release note: None