### PR TITLE
release-21.1: roachtest: exit 10 when tests failed

### DIFF
--- a/build/teamcity-nightly-roachtest-invoke.sh
+++ b/build/teamcity-nightly-roachtest-invoke.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+set +e
 bin/roachtest run \
   --cloud="${CLOUD}" \
   --artifacts="${ARTIFACTS}" \
@@ -17,3 +18,16 @@ bin/roachtest run \
   --slack-token="${SLACK_TOKEN}" \
   --cluster-id="${TC_BUILD_ID}" \
   "${TESTS}"
+code=$?
+set -e
+
+if [[ ${code} -eq 10 ]]; then
+  # Exit code 10 indicates that some tests failed, but that roachtest
+  # as a whole passed. We want to exit zero in this case so that we
+  # can let TeamCity report failing tests without also failing the
+  # build. That way, build failures can be used to notify about serious
+  # problems that prevent tests from being invoked in the first place.
+  code=0
+fi
+
+exit ${code}

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -42,6 +42,8 @@ import (
 	"github.com/petermattis/goid"
 )
 
+var errTestsFailed = fmt.Errorf("some tests failed")
+
 // testRunner runs tests.
 type testRunner struct {
 	// buildVersion is the version of the Cockroach binary that tests will run against.
@@ -315,7 +317,7 @@ func (r *testRunner) Run(
 	passFailLine := r.generateReport()
 	shout(ctx, l, lopt.stdout, passFailLine)
 	if len(r.status.fail) > 0 {
-		return fmt.Errorf("some tests failed")
+		return errTestsFailed
 	}
 	return nil
 }


### PR DESCRIPTION
Backport 2/2 commits from #63835.

/cc @cockroachdb/release

---

Prior to this commit, `roachtest run` would always exit with code 1 if
it encountered ny problems. In practice, most of the time the reason it
would do that is because one of its tests failed; the exit status in
nightlies is always nonzero.

We want to distinguish that common case from that of roachtest itself
failing to run all of the tests. This commit adds a dedicated exit
status (10) which is used if some tests failed, but roachtest itself
did not encounter any problems.

In follow-up work, we will treat this exit status as a success, which
will allow us to configure notifications for the roachtest nightlies,
so that they can sound the alarm whenever seeing a truly unexpected
exit status (i.e. not zero or ten). For inspiration, see #63825 for
a recent roachtest breakage that this work should alert us to more
proactively in the future once the above plan is carried out.

Test failures continue to be emitted just the same (and issues are
still posted).

Independently roachtest also needs to be hardened against being taken
down by tests. This will require more invasive changes.

Release note: None
