### PR TITLE
roachtest: don't terminate suite when single test hangs after timeout

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -596,6 +596,9 @@ func allStacks() []byte {
 // testRunnerLogPath: The path to the test runner's log. It will be copied to
 //  	the test's artifacts dir if the test fails and we're running under
 //  	TeamCity.
+//
+// TODO(test-eng): the `bool` should go away, instead `t.Failed()` can be consulted
+// by the caller to determine whether the test passed.
 func (r *testRunner) runTest(
 	ctx context.Context,
 	t *testImpl,
@@ -829,9 +832,9 @@ func (r *testRunner) runTest(
 			const msg = "test timed out and afterwards failed to respond to cancelation"
 			t.L().PrintfCtx(ctx, msg)
 			r.collectClusterLogs(ctx, c, t)
-			// We return an error here because the test goroutine is still running, so
-			// we want to alert the caller of this unusual situation.
-			return false, errors.New(msg)
+			// We already marked the test as failing, so don't return an error here.
+			// Doing so would shut down the entire roachtest run.
+			return false, nil
 		}
 	}
 

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -829,8 +829,14 @@ func (r *testRunner) runTest(
 			// We really shouldn't get here unless the test code somehow managed
 			// to deadlock without blocking on anything remote - since we killed
 			// everything.
-			const msg = "test timed out and afterwards failed to respond to cancelation"
+			const msg = "test timed out and afterwards failed to respond to cancellation"
 			t.L().PrintfCtx(ctx, msg)
+
+			const stacksFile = "__stacks_after_cancellation"
+			if cl, err := t.L().ChildLogger(stacksFile, logger.QuietStderr, logger.QuietStdout); err == nil {
+				cl.PrintfCtx(ctx, "all stacks:\n\n%s\n", allStacks())
+				t.L().PrintfCtx(ctx, "dumped stacks (after cancellation) to %s", stacksFile)
+			}
 			r.collectClusterLogs(ctx, c, t)
 			// We already marked the test as failing, so don't return an error here.
 			// Doing so would shut down the entire roachtest run.


### PR DESCRIPTION
Previously, when a single test went over timeout & failed to terminate
within a grace period (as can happen when one forgets to put the right
context cancellation everywhere, etc), we would return an error to the
worker running the test which the worker would treat as fatal, causing
the entire roachtest suite to stop.

With this commit, the suite continues. The cluster is not re-used in
this case, since we failed the test and thus hit line 528 below:

https://github.com/cockroachdb/cockroach/blob/25f1ad82d4431939f706577dfdaf6d76f832da6a/pkg/cmd/roachtest/test_runner.go#L510-L530

and so the goroutines that are sticking around from the failed test,
while annoying, are benign.

Found this problem while looking at failed nightly build [3123385].

[3123385]: https://teamcity.cockroachdb.com/viewLog.html?buildId=3123385&buildTypeId=Cockroach_Nightlies_WorkloadNightly&tab=buildLog&_focus=4756

Release note: None
