### PR TITLE
build: ignore exit status 10 in roachtest weekly

### DIFF
--- a/build/teamcity-weekly-roachtest.sh
+++ b/build/teamcity-weekly-roachtest.sh
@@ -58,6 +58,16 @@ timeout -s INT $((7800*60)) bin/roachtest run \
   --encrypt=random \
   --teamcity || exit_status=$?
 
+if [[ ${exit_status} -eq 10 ]]; then
+  # Exit code 10 indicates that some tests failed, but that roachtest
+  # as a whole passed. We want to exit zero in this case so that we
+  # can let TeamCity report failing tests without also failing the
+  # build. That way, build failures can be used to notify about serious
+  # problems that prevent tests from being invoked in the first place.
+  exit_status=0
+fi
+
+
 # Upload any stats.json files to the cockroach-nightly bucket.
 for file in $(find ${artifacts#${PWD}/} -name stats.json); do
     gsutil cp ${file} gs://cockroach-nightly/${file}


### PR DESCRIPTION
This establishes parity with
https://github.com/cockroachdb/cockroach/pull/63835 for the nightly
runs: we only want to exit nonzero if something went wrong with the
test harness; failures of individual tests should not trickle up as
a failure of the top-level build.

Release note: None
