### PR TITLE
Add dev-inf as codeowners for /build/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,6 +19,8 @@
 
 /.github/                    @cockroachdb/dev-inf
 
+/build/                      @cockroachdb/dev-inf
+
 /docs/RFCS/                  @cockroachdb/rfc-prs
 
 /Makefile                    @cockroachdb/dev-inf


### PR DESCRIPTION
Before: no owners were set for /build/

Why: dev-inf owns /build/

Now: dev-inf is set as code owners for /build/

Release note: None