### PR TITLE
roachtest: unskip import/tpcc/warehouses=4000/geo

### DIFF
--- a/pkg/cmd/roachtest/import.go
+++ b/pkg/cmd/roachtest/import.go
@@ -147,7 +147,6 @@ func registerImportTPCC(r *testRegistry) {
 	const geoWarehouses = 4000
 	const geoZones = "europe-west2-b,europe-west4-b,asia-northeast1-b,us-west1-b"
 	r.Add(TestSpec{
-		Skip:    "#37349 - OOMing",
 		Name:    fmt.Sprintf("import/tpcc/warehouses=%d/geo", geoWarehouses),
 		Owner:   OwnerBulkIO,
 		Cluster: r.makeClusterSpec(8, spec.CPU(16), spec.Geo(), spec.Zones(geoZones)),


### PR DESCRIPTION
This test completed successfully 5/5 times and it was skipped a long time
ago (~2 years), unskipping and will keep an eye on it in case it starts
OOMing again.

Will continue running in background to get more successful runs.

Release note: None