### PR TITLE
cluster-ui: add "" to whitespace app names

### DIFF
--- a/pkg/ui/cluster-ui/src/queryFilter/filter.tsx
+++ b/pkg/ui/cluster-ui/src/queryFilter/filter.tsx
@@ -395,6 +395,14 @@ export class Filter extends React.Component<QueryFilter, FilterState> {
     );
     // TODO replace all onChange actions in Selects and Checkboxes with one onSubmit in <form />
 
+    // Some app names could be empty strings, so we're adding " " to those names,
+    // this way it's easier for the user to recognize the blank name.
+    const apps = appNames.map(app => {
+      const label =
+        app.label.trim().length === 0 ? '"' + app.label + '"' : app.label;
+      return { label: label, value: app.value };
+    });
+
     return (
       <div onClick={this.insideClick} ref={this.dropdownRef}>
         <div className={dropdownButton} onClick={this.toggleFilters}>
@@ -405,9 +413,9 @@ export class Filter extends React.Component<QueryFilter, FilterState> {
           <div className={dropdownContentWrapper}>
             <div className={filterLabel.top}>App</div>
             <Select
-              options={appNames}
+              options={apps}
               onChange={e => this.handleChange(e, "app")}
-              value={appNames.filter(app => app.label == filters.app)}
+              value={apps.filter(app => app.value === filters.app)}
               placeholder="All"
               styles={customStyles}
             />


### PR DESCRIPTION
A user can setup the application name as whitespaces and
it's hard to recognize it when selecting the filter.
This commit adds "" to the name.

Resolves: https://github.com/cockroachdb/cockroach/issues/63419

Before:
<img width="299" alt="Screen Shot 2021-06-28 at 10 46 12 AM" src="https://user-images.githubusercontent.com/1017486/123656626-180b7080-d7fe-11eb-9dde-f642c645d5d5.png">

After:
<img width="302" alt="Screen Shot 2021-06-28 at 10 36 13 AM" src="https://user-images.githubusercontent.com/1017486/123656329-cfec4e00-d7fd-11eb-9152-43846b91ae6a.png">


Release note (ui change): Add "" to whitespace application names
on filter selection on statements and transactions page.