### PR TITLE
ui: surface SQL Statement Contention Time more prominently in Metrics page

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/overview.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/overview.tsx
@@ -92,6 +92,20 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
+      title="SQL Statement Contention"
+      sources={nodeSources}
+      tooltip={`The total number of SQL statements that experienced contention ${tooltipSelection}.`}
+    >
+      <Axis label="queries">
+        <Metric
+          name="cr.node.sql.distsql.contended_queries.count"
+          title="Contention"
+          nonNegativeRate
+        />
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
       title="Replicas per Node"
       tooltip={
         <div>


### PR DESCRIPTION
Previously, SQL Statement Contention Time chart located fifth in the SQL
tab in the Metrics page.
This commit moves the chart to be the first one in the SQL tab and also adds
this chart into the overview tab.

Resolves #64188

Release note (ui change): SQL Statement Contention Time chart is surfaced
 more prominently in Metrics page.