### PR TITLE
sql: pretty print sample plan in node statement statistics table

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -914,7 +914,7 @@ CREATE TABLE crdb_internal.node_statement_statistics (
   contention_time_var FLOAT,
   implicit_txn        BOOL NOT NULL,
   full_scan           BOOL NOT NULL,
-  sample_plan         JSONB,
+  sample_plan         STRING,
   database_name       STRING NOT NULL,
   exec_node_ids       INT[] NOT NULL
 )`,
@@ -955,15 +955,19 @@ CREATE TABLE crdb_internal.node_statement_statistics (
 			}
 
 			samplePlan := ExplainTreePlanNodeToJSON(&stats.Stats.SensitiveInfo.MostRecentPlanDescription)
+			samplePlanPretty, err := json.Pretty(samplePlan)
+			if err != nil {
+				return err
+			}
 
 			execNodeIDs := tree.NewDArray(types.Int)
 			for _, nodeID := range stats.Stats.Nodes {
-				if err := execNodeIDs.Append(tree.NewDInt(tree.DInt(nodeID))); err != nil {
+				if err = execNodeIDs.Append(tree.NewDInt(tree.DInt(nodeID))); err != nil {
 					return err
 				}
 			}
 
-			err := addRow(
+			err = addRow(
 				tree.NewDInt(tree.DInt(nodeID)),                           // node_id
 				tree.NewDString(stats.Key.App),                            // application_name
 				tree.NewDString(flags),                                    // flags
@@ -1002,9 +1006,9 @@ CREATE TABLE crdb_internal.node_statement_statistics (
 				execStatVar(stats.Stats.ExecStats.Count, stats.Stats.ExecStats.ContentionTime),      // contention_time_var
 				tree.MakeDBool(tree.DBool(stats.Key.ImplicitTxn)),                                   // implicit_txn
 				tree.MakeDBool(tree.DBool(stats.Key.FullScan)),                                      // full_scan
-				tree.NewDJSON(samplePlan),           // sample_plan
-				tree.NewDString(stats.Key.Database), // database_name
-				execNodeIDs,                         // exec_node_ids
+				tree.NewDString(samplePlanPretty),                                                   // sample_plan
+				tree.NewDString(stats.Key.Database),                                                 // database_name
+				execNodeIDs,                                                                         // exec_node_ids
 			)
 			if err != nil {
 				return err

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -738,7 +738,7 @@ CREATE TABLE crdb_internal.node_statement_statistics (
    contention_time_var FLOAT8 NULL,
    implicit_txn BOOL NOT NULL,
    full_scan BOOL NOT NULL,
-   sample_plan JSONB NULL,
+   sample_plan STRING NULL,
    database_name STRING NOT NULL,
    exec_node_ids INT8[] NOT NULL
 )  CREATE TABLE crdb_internal.node_statement_statistics (
@@ -780,7 +780,7 @@ CREATE TABLE crdb_internal.node_statement_statistics (
    contention_time_var FLOAT8 NULL,
    implicit_txn BOOL NOT NULL,
    full_scan BOOL NOT NULL,
-   sample_plan JSONB NULL,
+   sample_plan STRING NULL,
    database_name STRING NOT NULL,
    exec_node_ids INT8[] NOT NULL
 )  {}  {}


### PR DESCRIPTION
Prior to this change, the `sample_plan` column of the `crdb_internal.node_statement_statistics` table was unformatted JSON. This change formats it nicely for easy reading.

Prior to change:
```
                                                                                                                                                                                                    sample_plan
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  {"Children": [{"Children": [{"Children": [{"Children": [], "Missing Stats": "", "Name": "scan", "Spans": "FULL SCAN", "Table": "users@primary"}, {"Children": [], "Missing Stats": "", "Name": "scan", "Spans": "FULL SCAN", "Table": "rides@rides_auto_index_fk_city_ref_users"}], "Equality": "(id) = (rider_id)", "Name": "hash join"}], "Distinct On": "id", "Name": "distinct"}], "Name": "group (scalar)"}
```

After change:
```
                                                   sample_plan
-----------------------------------------------------------------------------------------------------------------
  {
      "Children": [
          {
              "Children": [
                  {
                      "Children": [
                          {
                              "Children": [],
                              "Estimated Row Count": "500 (100% of the table; stats collected 45 seconds ago)",
                              "Name": "scan",
                              "Spans": "FULL SCAN",
                              "Table": "rides@rides_auto_index_fk_city_ref_users"
                          },
                          {
                              "Children": [],
                              "Estimated Row Count": "50 (100% of the table; stats collected 45 seconds ago)",
                              "Name": "scan",
                              "Spans": "FULL SCAN",
                              "Table": "users@primary"
                          }
                      ],
                      "Equality": "(rider_id) = (id)",
                      "Estimated Row Count": "500",
                      "Name": "hash join"
                  }
              ],
              "Distinct On": "id",
              "Estimated Row Count": "50",
              "Name": "distinct"
          }
      ],
      "Estimated Row Count": "1",
      "Name": "group (scalar)"
  }
```

Resolves: #66982

Release note (sql change): pretty print sample plan in node statement statistics table