### PR TITLE
tpr/r21 1 66708

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/hash_sharded_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/hash_sharded_index
@@ -28,7 +28,7 @@ vectorized: true
     └── • render
         │ columns: (column6, column1)
         │ estimated row count: 2
-        │ render column6: mod(fnv32(COALESCE(column1::STRING, '')), 11)
+        │ render column6: mod(fnv32(COALESCE(column1::STRING, '')), 11)::INT4
         │ render column1: column1
         │
         └── • values
@@ -63,7 +63,7 @@ vectorized: true
     └── • render
         │ columns: (column8, column7, column1)
         │ estimated row count: 2
-        │ render column8: mod(fnv32(COALESCE(column1::STRING, '')), 12)
+        │ render column8: mod(fnv32(COALESCE(column1::STRING, '')), 12)::INT4
         │ render column7: unique_rowid()
         │ render column1: column1
         │

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -472,7 +472,7 @@ func (s *scope) resolveAndRequireType(expr tree.Expr, desired *types.T) tree.Typ
 	if err != nil {
 		panic(err)
 	}
-	return s.ensureNullType(texpr, desired)
+	return tree.ReType(s.ensureNullType(texpr, desired), desired)
 }
 
 // ensureNullType tests the type of the given expression. If types.Unknown, then

--- a/pkg/sql/opt/optbuilder/testdata/insert
+++ b/pkg/sql/opt/optbuilder/testdata/insert
@@ -1168,13 +1168,13 @@ insert decimals
       │    │    │    │    │    ├── columns: column1:6!null column2:7
       │    │    │    │    │    └── (1.1, ARRAY[0.95,NULL,15])
       │    │    │    │    └── projections
-      │    │    │    │         └── 1.23 [as=column8:8]
+      │    │    │    │         └── 1.23::DECIMAL(10,1) [as=column8:8]
       │    │    │    └── projections
       │    │    │         ├── crdb_internal.round_decimal_values(column1:6, 0) [as=a:9]
       │    │    │         ├── crdb_internal.round_decimal_values(column2:7, 1) [as=b:10]
       │    │    │         └── crdb_internal.round_decimal_values(column8:8, 1) [as=c:11]
       │    │    └── projections
-      │    │         └── a:9 + c:11 [as=column12:12]
+      │    │         └── (a:9 + c:11::DECIMAL)::DECIMAL(10,1) [as=column12:12]
       │    └── projections
       │         └── crdb_internal.round_decimal_values(column12:12, 1) [as=d:13]
       └── projections

--- a/pkg/sql/opt/optbuilder/testdata/update
+++ b/pkg/sql/opt/optbuilder/testdata/update
@@ -1631,7 +1631,7 @@ update decimals
       │    │    │    │    │    ├── columns: decimals.a:6!null decimals.b:7 c:8 decimals.d:9 crdb_internal_mvcc_timestamp:10
       │    │    │    │    │    └── computed column expressions
       │    │    │    │    │         └── decimals.d:9
-      │    │    │    │    │              └── decimals.a:6::DECIMAL + c:8::DECIMAL
+      │    │    │    │    │              └── (decimals.a:6::DECIMAL + c:8::DECIMAL)::DECIMAL(10,1)
       │    │    │    │    └── projections
       │    │    │    │         ├── 1.1 [as=a_new:11]
       │    │    │    │         └── ARRAY[0.95,NULL,15] [as=b_new:12]
@@ -1639,7 +1639,7 @@ update decimals
       │    │    │         ├── crdb_internal.round_decimal_values(a_new:11, 0) [as=a:13]
       │    │    │         └── crdb_internal.round_decimal_values(b_new:12, 1) [as=b:14]
       │    │    └── projections
-      │    │         └── a:13 + c:8::DECIMAL [as=column15:15]
+      │    │         └── (a:13 + c:8::DECIMAL)::DECIMAL(10,1) [as=column15:15]
       │    └── projections
       │         └── crdb_internal.round_decimal_values(column15:15, 1) [as=d:16]
       └── projections

--- a/pkg/sql/opt/optbuilder/testdata/update-col-cast-bug
+++ b/pkg/sql/opt/optbuilder/testdata/update-col-cast-bug
@@ -1,0 +1,52 @@
+exec-ddl
+create table t (a int2, b int2, c int2 as (a + b) virtual)
+----
+
+build format=show-types
+update t set a = (with cte as (select 1:::int8) select t.c from cte limit 1)
+----
+with &1 (cte)
+ ├── project
+ │    ├── columns: int8:11(int!null)
+ │    ├── values
+ │    │    └── () [type=tuple]
+ │    └── projections
+ │         └── 1 [as=int8:11, type=int]
+ └── update t
+      ├── columns: <none>
+      ├── fetch columns: a:6(int2) b:7(int2) t.c:8(int2) rowid:9(int)
+      ├── update-mapping:
+      │    ├── a_new:14 => a:1
+      │    └── column15:15 => t.c:3
+      └── project
+           ├── columns: column15:15(int2) a:6(int2) b:7(int2) t.c:8(int2) rowid:9(int!null) crdb_internal_mvcc_timestamp:10(decimal) a_new:14(int2)
+           ├── project
+           │    ├── columns: a_new:14(int2) a:6(int2) b:7(int2) t.c:8(int2) rowid:9(int!null) crdb_internal_mvcc_timestamp:10(decimal)
+           │    ├── project
+           │    │    ├── columns: t.c:8(int2) a:6(int2) b:7(int2) rowid:9(int!null) crdb_internal_mvcc_timestamp:10(decimal)
+           │    │    ├── scan t
+           │    │    │    ├── columns: a:6(int2) b:7(int2) rowid:9(int!null) crdb_internal_mvcc_timestamp:10(decimal)
+           │    │    │    └── computed column expressions
+           │    │    │         └── t.c:8
+           │    │    │              └── (a:6::INT8 + b:7::INT8)::INT2 [type=int2]
+           │    │    └── projections
+           │    │         └── (a:6::INT8 + b:7::INT8)::INT2 [as=t.c:8, type=int2]
+           │    └── projections
+           │         └── subquery [as=a_new:14, type=int2]
+           │              └── max1-row
+           │                   ├── columns: c:13(int2)
+           │                   └── limit
+           │                        ├── columns: c:13(int2)
+           │                        ├── project
+           │                        │    ├── columns: c:13(int2)
+           │                        │    ├── limit hint: 1.00
+           │                        │    ├── with-scan &1 (cte)
+           │                        │    │    ├── columns: int8:12(int!null)
+           │                        │    │    ├── mapping:
+           │                        │    │    │    └──  int8:11(int) => int8:12(int)
+           │                        │    │    └── limit hint: 1.00
+           │                        │    └── projections
+           │                        │         └── t.c:8 [as=c:13, type=int2]
+           │                        └── 1 [type=int]
+           └── projections
+                └── (a_new:14::INT8 + b:7::INT8)::INT2 [as=column15:15, type=int2]

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -1722,13 +1722,13 @@ upsert decimals
       │    │    │    │    │    │    │    │    │    ├── columns: column1:6!null column2:7
       │    │    │    │    │    │    │    │    │    └── (1.1, ARRAY[0.95])
       │    │    │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │    │    │         └── 1.23 [as=column8:8]
+      │    │    │    │    │    │    │    │         └── 1.23::DECIMAL(10,1) [as=column8:8]
       │    │    │    │    │    │    │    └── projections
       │    │    │    │    │    │    │         ├── crdb_internal.round_decimal_values(column1:6, 0) [as=a:9]
       │    │    │    │    │    │    │         ├── crdb_internal.round_decimal_values(column2:7, 1) [as=b:10]
       │    │    │    │    │    │    │         └── crdb_internal.round_decimal_values(column8:8, 1) [as=c:11]
       │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         └── a:9 + c:11 [as=column12:12]
+      │    │    │    │    │    │         └── (a:9 + c:11::DECIMAL)::DECIMAL(10,1) [as=column12:12]
       │    │    │    │    │    └── projections
       │    │    │    │    │         └── crdb_internal.round_decimal_values(column12:12, 1) [as=d:13]
       │    │    │    │    └── aggregations
@@ -1742,11 +1742,11 @@ upsert decimals
       │    │    │    │    ├── columns: decimals.a:14!null decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18
       │    │    │    │    └── computed column expressions
       │    │    │    │         └── decimals.d:17
-      │    │    │    │              └── decimals.a:14::DECIMAL + decimals.c:16::DECIMAL
+      │    │    │    │              └── (decimals.a:14::DECIMAL + decimals.c:16::DECIMAL)::DECIMAL(10,1)
       │    │    │    └── filters
       │    │    │         └── a:9 = decimals.a:14
       │    │    └── projections
-      │    │         └── decimals.a:14::DECIMAL + decimals.c:16::DECIMAL [as=column19:19]
+      │    │         └── (decimals.a:14::DECIMAL + decimals.c:16::DECIMAL)::DECIMAL(10,1) [as=column19:19]
       │    └── projections
       │         ├── CASE WHEN decimals.a:14 IS NULL THEN a:9 ELSE decimals.a:14 END [as=upsert_a:20]
       │         ├── CASE WHEN decimals.a:14 IS NULL THEN c:11 ELSE decimals.c:16 END [as=upsert_c:21]
@@ -1794,13 +1794,13 @@ upsert decimals
       │    │    │    │    │    │    │    │    │    └── (1.1,)
       │    │    │    │    │    │    │    │    └── projections
       │    │    │    │    │    │    │    │         ├── NULL::DECIMAL(5,1)[] [as=column7:7]
-      │    │    │    │    │    │    │    │         └── 1.23 [as=column8:8]
+      │    │    │    │    │    │    │    │         └── 1.23::DECIMAL(10,1) [as=column8:8]
       │    │    │    │    │    │    │    └── projections
       │    │    │    │    │    │    │         ├── crdb_internal.round_decimal_values(column1:6, 0) [as=a:9]
       │    │    │    │    │    │    │         ├── crdb_internal.round_decimal_values(column7:7, 1) [as=b:10]
       │    │    │    │    │    │    │         └── crdb_internal.round_decimal_values(column8:8, 1) [as=c:11]
       │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         └── a:9 + c:11 [as=column12:12]
+      │    │    │    │    │    │         └── (a:9 + c:11::DECIMAL)::DECIMAL(10,1) [as=column12:12]
       │    │    │    │    │    └── projections
       │    │    │    │    │         └── crdb_internal.round_decimal_values(column12:12, 1) [as=d:13]
       │    │    │    │    └── aggregations
@@ -1814,11 +1814,11 @@ upsert decimals
       │    │    │    │    ├── columns: decimals.a:14!null decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18
       │    │    │    │    └── computed column expressions
       │    │    │    │         └── decimals.d:17
-      │    │    │    │              └── decimals.a:14::DECIMAL + decimals.c:16::DECIMAL
+      │    │    │    │              └── (decimals.a:14::DECIMAL + decimals.c:16::DECIMAL)::DECIMAL(10,1)
       │    │    │    └── filters
       │    │    │         └── a:9 = decimals.a:14
       │    │    └── projections
-      │    │         └── decimals.a:14::DECIMAL + decimals.c:16::DECIMAL [as=column19:19]
+      │    │         └── (decimals.a:14::DECIMAL + decimals.c:16::DECIMAL)::DECIMAL(10,1) [as=column19:19]
       │    └── projections
       │         ├── CASE WHEN decimals.a:14 IS NULL THEN a:9 ELSE decimals.a:14 END [as=upsert_a:20]
       │         ├── CASE WHEN decimals.a:14 IS NULL THEN b:10 ELSE decimals.b:15 END [as=upsert_b:21]
@@ -1874,13 +1874,13 @@ upsert decimals
       │    │    │    │    │    │    │    │    │    │    │    ├── columns: column1:6!null column2:7
       │    │    │    │    │    │    │    │    │    │    │    └── (1.1, ARRAY[0.95])
       │    │    │    │    │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │    │    │    │    │         └── 1.23 [as=column8:8]
+      │    │    │    │    │    │    │    │    │    │         └── 1.23::DECIMAL(10,1) [as=column8:8]
       │    │    │    │    │    │    │    │    │    └── projections
       │    │    │    │    │    │    │    │    │         ├── crdb_internal.round_decimal_values(column1:6, 0) [as=a:9]
       │    │    │    │    │    │    │    │    │         ├── crdb_internal.round_decimal_values(column2:7, 1) [as=b:10]
       │    │    │    │    │    │    │    │    │         └── crdb_internal.round_decimal_values(column8:8, 1) [as=c:11]
       │    │    │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │    │    │         └── a:9 + c:11 [as=column12:12]
+      │    │    │    │    │    │    │    │         └── (a:9 + c:11::DECIMAL)::DECIMAL(10,1) [as=column12:12]
       │    │    │    │    │    │    │    └── projections
       │    │    │    │    │    │    │         └── crdb_internal.round_decimal_values(column12:12, 1) [as=d:13]
       │    │    │    │    │    │    └── aggregations
@@ -1894,7 +1894,7 @@ upsert decimals
       │    │    │    │    │    │    ├── columns: decimals.a:14!null decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18
       │    │    │    │    │    │    └── computed column expressions
       │    │    │    │    │    │         └── decimals.d:17
-      │    │    │    │    │    │              └── decimals.a:14::DECIMAL + decimals.c:16::DECIMAL
+      │    │    │    │    │    │              └── (decimals.a:14::DECIMAL + decimals.c:16::DECIMAL)::DECIMAL(10,1)
       │    │    │    │    │    └── filters
       │    │    │    │    │         └── a:9 = decimals.a:14
       │    │    │    │    └── projections
@@ -1902,7 +1902,7 @@ upsert decimals
       │    │    │    └── projections
       │    │    │         └── crdb_internal.round_decimal_values(b_new:19, 1) [as=b:20]
       │    │    └── projections
-      │    │         └── decimals.a:14::DECIMAL + decimals.c:16::DECIMAL [as=column21:21]
+      │    │         └── (decimals.a:14::DECIMAL + decimals.c:16::DECIMAL)::DECIMAL(10,1) [as=column21:21]
       │    └── projections
       │         ├── CASE WHEN decimals.a:14 IS NULL THEN a:9 ELSE decimals.a:14 END [as=upsert_a:22]
       │         ├── CASE WHEN decimals.a:14 IS NULL THEN b:10 ELSE b:20 END [as=upsert_b:23]

--- a/pkg/sql/opt/xform/testdata/external/trading-mutation
+++ b/pkg/sql/opt/xform/testdata/external/trading-mutation
@@ -1593,7 +1593,7 @@ update cardsinfo [as=ci]
       │         └── const-agg [as=q:35, outer=(35)]
       │              └── q:35
       └── projections
-           ├── crdb_internal.round_decimal_values(buyprice:22::DECIMAL - discount:24::DECIMAL, 4) [as=discountbuyprice:50, outer=(22,24), immutable]
+           ├── crdb_internal.round_decimal_values((buyprice:22::DECIMAL - discount:24::DECIMAL)::DECIMAL(10,4), 4) [as=discountbuyprice:50, outer=(22,24), immutable]
            ├── CAST(NULL AS STRING) [as=column47:47]
            ├── 0 [as=column48:48]
            └── COALESCE(sum_int:44, 0) [as=actualinventory_new:46, outer=(44)]


### PR DESCRIPTION
- Update BSL change date for master/21.2
- Revert "Update BSL change date for master/21.2"
- sql: only qualify sequences with database names if sequence is in a different database
- opt: detect invalid tuple comparison with ANY
- geogen: reduce range of randomly generated points
- sql: add tests for prepared EXPLAIN and EXPLAIN ANALYZE
- nightly build: add missing license files
- build: disable required release justifications
- ui: backend fix for full table scan filter checkbox
- sql: use stopper for virtual table row pushing go routine
- sql: finish SQL txn in connExecutor.close
- tracing: remove WithBypassRegistry
- changefeedccl: remove unnecessary and/or impossible privilege checks
- backupccl: fix TestProtectedTimestampSpanSelectionDuringBackup
- backupccl: do not fail backup job when stats collection fails
- backupccl: add warning when restoring table does not have stats
- sql: move `ALTER TYPE ... DROP VALUE` behind a feature flag
- sql: make jobs that involve dropping enum values non-cancellable
- changefeedccl: Apply avro schema prefix as a namespace
- colexec: initialize operators in an edge case
- colexec: check that Init is always called before Next and DrainMeta
- sqlsmith: add complete_stream_ingestion_job to sqlsmith blocklist
- sql: report correct schema name in pg_indexes.indexdef
- roachtest: update tag of ActiveRecord version to test
- sql: use stmt's span for exec stats propagation
- sql,jobs: stop depending on streamingccl
- sql,streamingccl: remove stream ingestion job knobs
- sql: graciously handle vectorize=201auto option removal
- sql: stop mutating AST in AlterPrimaryKey
- flowinfra: set flow stats only when collecting stats
- opt: increase cost of full scans
- sql: add json{,b}_extract_path_text Release note (sql change): Added json_extract_path_text and                            jsonb_extract_path_text builtins.
- kvserver: remove FUD from comment
- kvserver: don't let closed timestamps squeeze writes
- kvserver: don't panic when closedts appears above lease
- kvserver: don't double WallPrev for closedts target
- hlc: fix WallPrev test
- kvserver: fix leak of tracked requests
- builtins: add Z and M dimension support for ST_SnapToGrid
- sql: report virtual computed columns in pg_catalog
- sql: properly detect DROP STORED for virtual column
- catalog,catalogkv: add and use descriptor builder
- ui: add contention graph to SQL metrics overview page
- rangefeed: handle closed timestamps with logical parts
- kvserver: truncate logical part from closed timestamps
- vendor: Bump pebble to 958290ba5bd6
- sql: remove fake index and statistics collectors pg_catalog tables
- colexec: propagate disk full error as expected
- sql: don't save memo unnecessarily
- sql/*: stop defaulting to public schema in various places
- cli: Add cockroach dump support for --dump-mode=schema
- sql: add logictest for SHOW CREATE ALL TABLES for udts/column families.
- sql: stop writing trace to statement_diagnostics
- opt: require column type for computed column expressions
- opt: more granular redaction of EXPLAIN
- sql: show time since table stats were collected in EXPLAIN
- opt: consider limit hint for select filter cost
- opt: fix non-existent columns due to mutation rounding
- sql: include non-voters in crdb_internal.ranges{_no_leases}
- sql: revert "sql: use stmt's span for exec stats propagation"
- sql: only create real spans when session tracing/sampling
- builtins: fix json_extract_path_text NULL bug
- rsg: don't test st_frechetdistance in randomized test
- ui: bump cluster-ui to 0.2.15
- storageccl: use chunked encryption for new backups
- sql: fix crdb_internal.zones(target) to show user-defined schemas
- sql: add schema_name column to crdb_internal.zones
- sql: fix display of idle_in_*session_timeout
- sql: Fix panic when transitioning from REGIONAL BY ROW
- sql: validate against array type usages when dropping enum values
- migration: add protected_ts_meta privilege migration
- contention: store contention events on non-SQL keys
- roachpb: ignore ExecStats in StatementStatistics.AlmostEqual
- util/timeutil: fix stopwatch for concurrent usage
- colflow: clean up vectorized stats for rowexec processors
- colexec: make vectorized stats concurrency safe
- sql: delay saving of flows till after the setup
- sql: add EXPLAIN (VEC) output to the stmt bundle
- sqlsmith: add inverted indexes
- sqlsmith: add more column types
- sql: add execution stats to node_{statement,transaction}_statistics
- sql: allow `MDY, ISO` as a setting for DateStyle
- mutations: disallow VIRTUAL columns for PostgreSQL
- kvserver: do not consider non-voting replicas as suspect for GC
- kvserver: consider replica GC when leader loses quorum
- kvserver: fix removal of separated intents in ClearRange
- opt: expand set expression and Max1Row FD sets
- parser: remove experimental multi-region locality syntaxes
- sql: Block zone config updates to multi-region tables
- sql: Use session variable instead of FORCE to override zone configs
- sql: Enable index GC test under race
- mutations: disallow spatial types for Potgres Tables
- sql: prevent dropping regions when regions <= 3 on SURVIVE REGION FAILURE
- sql: preserve non multi region zone constraints on SET PRIMARY REGION
- sql: clear zone configs on final DROP REGION of a multi-region database
- sql: Block discarding zone config for MR entities
- contention: properly protect AddContentionEvent by mutex
- sql: allow VIEW and SEQUENCEs for multi-region databases
- sql: disallow adding OIDVECTOR and INT2VECTOR columns
- sql: add cluster settings for timeout settings
- sql: stop duplicating regions on the database descriptor
- sql: set locality to GLOBAL for materialized views
- sql: set GLOBAL on MATERIALIZED VIEW tables on first ADD REGION
- mutations: do not generate histograms for JSON
- sql: remove global zone configs on final DROP REGION
- mutations: handle computed columns for postgres
- mutations: don't use inverted indexes for postgres
- sql: use oid.OID instead of int64 for OID argument
- sql: fix pg_type_is_visible for UDTs
- sql: handle regtype casts for UDTs
- catalog: add namespace validation
- vendor: upgrade cockroachdb/errors to 1.8.3
- sql: incorrect behaviour setting NOT NULL on column and dropping it
- sql: capture sequences used in cast exprs
- importccl: log all ignored pgdump stmts in different log files
- sql: do not reset planner if PREPARE is executed as a stmt
- sql: set default sample_rate to 0.1
- bulkio: update help text for create/resume/drop schedule
- cdc: Improve error message.
- sql: disallow table/view/sequence rename from making cross DB references
- tracing: keep noopSpan immutable
- bench/ddl_analysis: deal with retries, rewrite expectations
- bench/ddl_analysis: make output more pleasant
- bench/ddl_analysis: tweak the output format
- bench/ddl_analysis: make debugging easier
- bench/ddl_analysis: run the different benchmarks in parallel
- util,bench/ddl_analysis: ensure that metamorphic testing is disabled
- bench/ddl_analysis: fix subtests
- bench/ddl_analysis: don't skip under metamorphic
- bench/ddl_analysis: make rewrite parallel
- colexec: handle panics in Init gracefully by the materializer
- telemetry: add test for ALTER TYPE ... DROP VALUE
- sql: Fix multi-region-restore
- storage: add version check to IsSeparatedIntentsEnabledForTesting
- kvserver: detect and return intents in ClearRange
- cdc: Record retryable error in job status.
- mutations: format SQL so it can be reparsed successfully
- sql: use lookup join input to get DistSQL distribution recommendation
- colbuilder: use correct processorID for wrapped filterers
- bench/ddl_analysis: add range from master
- importccl: commit planner txn in planHook
- backupccl,backupbase: change backup base to backupresolved
- backupccl: clean up scheduled backup test
- backupccl: prevent restoring a newer backup
- kvserver: stop spuriously refusing non-voters in `replicateQueue.shouldQueue()`
- kvserver, allocator: emit actions to handle dead/decommissioning non-voters
- kvserver: teach replicateQueue to replace dead/decommisioning non-voters
- opt: add telemetry for locality optimized search
- Revert "sql: add EXPLAIN (VEC) output to the stmt bundle"
- Revert "sql: delay saving of flows till after the setup"
- kvserver: expose a more user friendly protected ts error
- opt: add a regression test for INSERT ON CONFLICT with ORDER BY
- kvclient: don't route to follower replica if kv.c_t.target_duration is 0
- dbdesc: move db schema map validation to higher level
- sql: ensure user has correct privileges when adding/removing regions
- sql: refactor alter table locality privileges check
- backupccl: mark type descs as dropped if there is a failure in restore
- colflow: fix premature stats collection and improve tracking
- sql: fix pgerror code for ADD REGION when region already added
- mutations: fix partial index and FK constraint bug
- colfetcher: respect limit hint
- sql: hint scan batch size by expected row count
- roachtest: not fail sqlsmith on known issue
- colbuilder: minor optimization of removing redundant allocations
- kvserver: allow lease extensions from followers in propBuf
- sql: Don't require override for multiple MR abstractions in a transaction
- importccl: add ignore rules to PGDUMP
- sql: fix privileges for multi-region ALTER DATABASE commands
- filetable: fix race in userfile table creation
- opt: fix issue with dangling pointer in statisticsBuilder
- geo/geomfn: fix st_shortestline and st_longestline for ZM coords
- colexecjoin: optimize the initialization of the merge joiner
- geo: fix st_segmentize to work with ZM coords
- geo/geomfn: fix st_linelocatepoint to work with ZM coords
- sql: make zone configs much cheaper
- sql/sem/tree: properly encode serialize physical values of enums
- roachtest: use 2-minute ramp times for YCSB workloads
- kvccl: re-order enterprise check in canSendToFollower
- sql: add catalog.Mutation interface for table mutations
- sql: move multi-region privilege checks to the planning phase
- sql: ensure users have correct privileges when adding/dropping regions
- sql: add tabledesc.NewUnsafeImmutable constructor
- delegate: order AZs in SHOW REGIONS commands
- sql: added setting for enable/disable queries against unimplemented virtual tables
- sql: fix flaky batch size test
- sql: fix insert fast path when columns are not in order
- sql: default to batch size 1 in allocator
- sql: fix internal error when comparing collation names
- sql: remove two KV lookups from pg_catalog queries
- sql: avoid extra descriptor lookup for DB privileges
- vendor: Bump pebble to b49f2eeba24b
- show internal statements with option all
- roachtest: precreate topic to avoid race in cdc/bank setup
- gcjob,partitionccl: use descs.Collection to fix bug in partitioning by enums
- partitionccl: do not generate subzone spans for dropped tables
- settings: add default value accessors for settings
- kvserver: add hidden cluster setting kv.gc.intent_age_threshold
- sql: refactor statisticsMutator
- sql: generate random inverted index histograms in statisticsMutator
- build: add a script for RandomSyntaxTests
- sql: stop spuriously removing non-voters on `EXPERIMENTAL_RELOCATE`
- sql, parser: add `EXPERIMENTAL_RELOCATE VOTERS` as alias of `EXPERIMENTAL_RELOCATE`
- sql, parser: add EXPERIMENTAL_RELOCATE NON_VOTERS
- changefeedccl: Disable sinkful changefeeds when external io is disabled.
- kvserver: remove rotten comment inside `AdminRelocateRange`
- kvserver: update `AdminRelocateRange` to leverage explicit swaps of voters to non-voters
- kvserver: get rid of bespoke relocation logic used by the mergeQueue
- lease: remove code from 20.1->20.2 migration
- kvserver: remove misguided TODO
- kvserver: plumb ctx to Replica.GetCurrentReadSummary()
- kvserver: include sidetransport data in read summary
- kvserver/closedts: optimize sidetransport closer
- kv: prevent STAGING -> PENDING transition during high-priority push
- kv: don't consider lease start time as closed timestamp
- storage: fix read behavior for large key-values
- opt: speed up new init pattern
- opt: allow casts in initial CTE expression
- geo: fix st_segmentize to not panic when passed NaN as param
- sql: fix ALTER PRIMARY KEY with virtual columns on the table
- kvserver: purge gc-able, unmigrated replicas during migrations
- bazel: upgrade to latest version of `rules_go`
- colexecjoin: fix the merge joiner in some cases
- importccl: more ignore import rules
- importccl: wrap ignore error with hint to point to docs
- sql: fix error when adding and dropping a constraint in same txn.
- catalog: add telemetry for descriptor validation errors
- catalog: fix descriptor validation early exit
- sql: add cluster setting to enable TBI during RevertRange
- build: upgrade go to 1.15.10
- sql: improve telemetry test cases for descriptor corruption
- kvserver: deflake TestFollowerReadsWithStaleDescriptor
- colserde: fix the edge case with nulls handling
- sql: add crdb_internal.validate_multi_region_zone_configs builtin
- zonepb: make subzone DiffWithZone more accurate
- build: use -json for RandomSyntax test
- sql: s/tuples/rows/ in vectorized stats
- opt: fix internal error when calculating stats for mutation passthrough cols
- roachtest/follower-reads: adopt multi-region abstractions, add GLOBAL tables
- roachtest: wait for range split in follower-reads test
- roachprod: support encryption with multiple stores
- roachtest: remove cdc/poller/rangefeed=false
- sql: gate global_reads zone attribute on cluster version and enterprise license
- kv: bump timestamp cache to MinTimestamp on PUSH_ABORT
- roachtest: fix log depth for test status
- sqlsmith: add support for ALTER TYPE ... DROP VALUE
- log,importccl,backupccl: add event logs for import and restore jobs
- kvserver: make the StoreRebalancer aware of non-voters
- colexec: optimize CASE, AND, and OR projection operators
- bench,sql: add logScope to some benchmarks
- sql: lower default sampling rate to 1%
- sql: add tests for concurrent add/drop region operations
- compare_test: check for backends being ready
- sql/rowenc: use CASE instead of IF() for random computed columns
- compare_test: log name when attempting connection
- mutations: allow spatial types for Postgres
- mutations: prevent context-dependent casts in Postgres
- mutations: don't allow box2d as a primary key for Postgres
- sqlsmith: ignore crdb_internal_mvcc_timestamp in postgres mode
- sqlsmith: fix date arithmetic in postgres mode
- sqlsmith: ignore CockroachDB-specific functions in postgres mode
- sqlsmith: ignore missing binops in postgres mode
- sqlsmith: use INT4 args for functions in postgres mode
- sqlsmith: use INT4 for Postgres BinOps that require it
- sqlsmith: don't ORDER/GROUP BY box2d in postgres mode
- sqlsmith: fallback to constant args for aggregate functions
- mutations: handle tuple formatting difference in postgres
- testutils: fix inspection of FK constraints
- compare_test: only use PostgresMutator in postgres test
- sql: Re-enable multi_region_backup test
- colflow: get the correct latency from remote nodes
- ccl/changfeedccl: fix changefeed processors shutdown
- colexecerror: catch panics from packages in sql/sem folder
- colfetcher: use the limit hint to size the batch
- backupccl: stop disallowing overlap when merging backup spans
- github-pull-request-make: control stress parallelism
- storage: reduce memory allocations in intentInterleavingIter
- sql: Test exporting from REGIONAL BY ROW tables
- sql: drop expired zone configs on REGIONAL BY ROW -> REGIONAL BY ROW
- sql: Add telemetry for multi-region IMPORT
- ui: add event log entry for ALTER DATABASE ADD REGION
- ui: add event log entry for ALTER DATABASE SET PRIMARY REGION
- ui: add event log entry for ALTER DATABASE ... SURVIVE ... FAILURE
- ui: add event log entry for ALTER DATABASE DROP REGION
- ui: add event log entry for CREATE TYPE
- ui: add event log entry for ALTER TYPE
- ui: add event log entry for DROP TYPE
- sql: fix or disallow hazardous interactions between TRUNCATE and schema changes
- sql: add pg_get_partkeydef builtin for compatibility
- geo/geoindex: temp fix for clipping geometries with Z/M coords
- vendor: Bump pebble to e3809b89b488b6ebba340449a2a024324310df2a
- sql: copy VIRTUAL columns in CREATE TABLE LIKE
- sql: fix ADD COLUMN ... UNIQUE for PARTITION ALL BY tables
- sem/builtins: vectorized engine no longer catches crdb_internal.force_panic
- importccl: clear range when reverting IMPORT INTO of empty tables
- backupccl: clean up mid schema change tests
- backupccl: only backup public indexes
- backupccl: test that only public spans are backed up
- backupccl: disallow cluster restore between tenants
- sql: fix constraint name roundtripping
- colexec: wrap DrainMeta with panic-catcher and protect columnarizer
- colfetcher,execinfra: use soft limit for sizing batches
- sql,xform: remove no longer used scanNode.limitHint
- release: publish to RedHat should use explicit tag
- sqlsmith: fix INSERTs for rand-tables
- opt: fix UPSERT error with REGIONAL BY ROW tables
- backupccl: run FK schema migration during RESTORE AOST
- sql: fix dropping zone configs from REGIONAL BY ROW during failure
- sql: mark implicit partition columns in information_schema.pg_indexes
- rsg_test: remove panic and fmt.Print
- backupccl: unit test makeImportSpans
- backupccl: support re-introducing spans in backup
- backupccl: re-backup spans that come online during incremental backups
- sql: Ensure that ALTER TABLE to GLOBAL resets zone configuration
- sql: collect exec stats for a statement if we see it for the first time
- sql: drain instead of hard shutdown in DistSQLReceiver.Push
- sqlsmith: fix RESTORE generation
- sql: batch GETs for crdb_internal.multi_region_zone_configs
- sql: refactor zone config validation checks
- sql: rename forEachTableInMultiRegionDatabase to forEachMutableTableInDatabase
- sql: block initial multi-region if zone configs have multi-region fields set
- sql: add pgcode for DROP REGION on PRIMARY REGION
- sql: fix an edge case in the internal executor
- sql: add context to IncrementRowsAffected interface
- sql: properly synchronize the internal executor iterator
- sql: fix bug in close of ieSyncResultChannel
- sql: clean up ieResultChannel concepts and fix race condition
- changefeedccl: Make it possible to configure kafka behavior.
- roachtest: stabilize splits/largerange/size=32GiB,nodes=6
- kvserver: perform initial upreplication of non-voters synchronously
- go.mod: bump etcd/raft to pick up proto size improvements
- roachtest: enable slow query log in follower-reads tests
- kv: add client-side follower read attempt trace event
- roachtest: wait for rebalancing to each region in follower-reads test
- kv: don't consider Subsume error as assertion failures
- kv: mark error from Replica.GetSnapshot with errMarkSnapshotError
- kv: allow two more errors with TransferLeaseOperation
- execinfrapb: introduce aliases for agg funcs and use everywhere
- colexec: clean up aggregator test cases
- colexec: fix hash aggregator when spilling to disk
- sql: fix drop schema bug which corrupts schemas using the name of the db
- changefeedccl: Use SQL memory monitor as a parent of changefeed monitor.
- colexec: fix usage of incorrect type schema for external hash agg
- raftentry: fix accidental no-op in truncateFrom
- kvserver: assert against term regressions
- raftentry: address review comments
- roachtest: upgrade ORM versions under test
- sql/sem,sql/parser: fix the AST anonymization
- sql/parser: reveal broken statement telemetry
- sql,docs: hide UNIQUE WITHOUT INDEX from the docs
- backupccl: require explicit option to backup interleaved tables
- sql: rename "partial_index" telemetry test file to "index"
- sql: add telemetry for partial and multi-column inverted indexes
- sql/ccl: add telemetry for partitioned inverted indexes
- cli/demo: label the URLs consistently with 'start'
- cli/demo: `--empty` -> `--no-example-database`; add env var
- cli: support addr 0 in multi-node demo
- cli: fix demo --global latencies
- cli: fix \demo shutdown with --global
- server,testutils: ensure server start is friendly to async cancellation
- cli/demo: refactor the server initialization
- cli: disallow adding or shutting down nodes in demo --global
- cli: wrap intro message around printfUnlessEmbedded
- cli: add notice about --global being experimental on demo startup
- rpc: avoid a panic in delayingConn
- cli: fix the handling of environment variables
- timeutil: Throw parsing error in case of wrong Julian date format instead of throwing 5xx
- pgdate: sprinkle some SafeFormat methods + fix error message generation
- pgdate: fix TestExtractInvalidJulianDate
- pgdate: add more context to date parsing errors
- sql: add crdb_internal.get_vmodule
- sql: add unpriviledged user test for get_vmodule
- catalog/descs: fix panic when type resolution finds a non-type descriptor
- changefeedccl: disallow changfeeds on regional by row tables
- changefeed: detect regional by row changes in kv_feed
- importccl: fix bug swallowing txn errors
- sql: lease acquisition of OFFLINE descs may starve bulk operations
- sql: wrap CastExpr within IndirectionExpr in a ParenExpr
- roachtest: fix ORM tests after upgrading them
- backup: revalidate restored indexes if added during inc backup
- tabledesc: MakeFirstMutationPublic should ignore PK swaps
- backup: extend mid-schema change test to count row in resulting table
- changefeedccl: Use memory monitor for kafka and cloud sinks.
- kvclient: move a test
- opt: fix error when crdb_internal_mvcc_timestamp used in view
- coldata: do not allocate wasteful memory for UUIDs
- colbuilder: pool materializers if possible when wrapping row sources
- rowenc: copy JSON bytes more efficiently in DecodeUntaggedDatum
- roachtest: rename SQLExec to SQLQueries
- roachtest: revive cancel roachtest
- sql: add some logging for DistSQLReceiver transitions
- server: anonymize voter_constraints in diagnostics
- sql: add test for multi-region enum name clash
- kvclient: add metrics for txns with condensed intents
- colexec: add some logging for external operators
- geomfn: fix check of st_segmentize when number of segments overflow
- geogfn: fix segmentize of >MaxInt64 coordinates
- kv: don't commit-wait on each columnBackfiller chunk
- rowexec: optimize the inverted filterer
- sql: wrap typed Array within IndirectionExpr in ParenExpr
- colexec: reuse buckets in the external hash aggregator
- sql, config: make `voter_constraints` inherit from parent by default
- cli: remove cgosymbolizer
- geomfn: fix st_simplify with NaN
- sql: fix index out of range error in inverted filterer
- roachtest: fix calling t.Fatal in non-runner goroutine in cancel
- colexec: run distinct benchmarks on Bytes columns
- colexec: remove redundant deep copies in distinct template
- sql: Clear all multi-region fields on table locality changes
- sql: Improve error message when user's modified MR zone config
- sql: fix zone config validation during a REGIONAL BY ROW transition
- sql: remove transitioning regions from zone config validation
- sql: refactor SynthesizeRegionConfig to take in options
- sql: refactor SynthesizeRegionConfig usages
- sql: pull out multi-region finalization into its own struct
- sql: fix bad interraction with DROP region rollback and alter to RBR
- kvserver: small closedts assignment refactor
- kvserver: tighten comment
- kvserver: add a closedts assertion
- kvserver: move submitProposalFilter down
- kvserver: improve test utilities for lease info
- kvserver: fix write below closedts bug
- build: upgrade go to 1.15.11
- stop: break deadlock between Stopper.mu and Replica.mu
- builtins: fix crdb_internal.encode_key for user defined types
- sql: add more testing for concurrent region/rbr interactions
- sql: skip uniqueness check during backfill for ALTER LOCALITY REGIONAL BY ROW
- sql: support alter column SET VISIBLE and NOT VISIBLE to unhide or hide column
- kvserver: improve a TODO
- kvserver: don't track non-MVCC requests
- closedts: add comment to connection drop
- kvserver: fix propagation of closedts from side trans to replica state
- server: skip TestTelemetrySQLStatsIndependence
- roachtest: added hibernate ignorelist for 21.1
- changefeedccl: Make `kafka_sink_config` a valid option.
- changefeedccl: Correctly account for memory when closing gzip compressed files.
- multiregionccl: deflake TestIndexCleanupAfterAlterFromRegionalByRow
- doctor: add verbose flag
- doctor: fix string comparison bug
- sql: add checks in unsafe_upsert_descriptor
- doctor: add examine and recreate commands
- roachtest: skip psycopg password_encryption test
- storage: pool pebbleReadOnly allocations
- release-21.1: sql: gate new schema changer behind testing knob
- roachtest: update libpq blocklist to ignore TestCopyInBinaryError
- roachtest: install dependencies used by pgx
- execinfra: mark 'sql.distsql.temp_storage.workmem' as public
- sql: use exec cluster settings in schemachange
- kvserver: assign closed timestamp to lease requests again
- sidetransport: record reasons for failure to close
- kvserver: add debug pages for the side transport
- opt: include NULL first column values in spans between partitions
- sql: use read ts as batch ts to send index backfill SSTs
- sql: make column backfill batch size a setting
- kvserverpb: update comment on RER.Timestamp
- kvserver: switch meaning of RER.Timestamp
- kvserver: future-proof RER.WriteTimestamp
- ui: display closedts info on range report page
- sql: backfill indexes at fixed TS
- kvserver: rationalize proposal timestamp
- kvserver: more Raft closed timestamp assertions
- kvserver: even more closed ts assertions
- kvserver: add safe formatters for lease and friends
- tree: fix comparing an infinite date from subquery as a timestamp
- kvserver: fix tscache read summaries
- libroach: make DumpThreadStacks thread-safe
- testutils: fix a nil pointer panic in TestCluster.GetRaftLeader
- sql: fix flaky test
- kvserver: fix delaying of splits with uninitialized followers
- kvserver: enqueue update check after Campaign()
- util/log: merge the default and test config
- util/log: Fix TestFluentClient
- util/log: fix `-show-logs` for tests that customize the log config
- kvserver: disable assertion in TestSplitBurstWithSlowFollower
- kv: properly handle intent pushes to synthetic timestamps
- kvserver: improve the closedts regression message
- kvserver: include Raft log in assertion
- colflow: cancel flow on ungraceful stream shutdown in outbox
- issues: clean up and allow easier customization
- issues: use Renderers instead of text templates
- sql: add CREATE STATISTICS regression test
- roachtest: don't auto-assign individuals, but mention teams
- roachtest: retire `bank` tests
- issues: make artifacts link stand out more
- issues: don't emit internal log when no author provided
- roachtest: don't inline the repro helper script
- issues: tweak the footer
- issues: don't assign author, mention them
- cli: walk directories in debug merge-logs
- cli: default program-filter for merge-logs to match everything
- sql: fix multi-region test knob
- sql: fetch REGIONAL BY ROW tables before type change repartitioning
- sql: add validation for partitions matching REGIONAL BY ROW
- sql: pull out partitioning checks into testutils
- sql: add test TestAlterRegionalByRowEnclosingRegionAddDrop
- sql: disallow RBR transforms if transitioning indexes are incompatible
- sql: add schemaName to getAllMutableTableDescriptors
- sql: disallow ADD/DROP REGION during certain REGIONAL BY ROW ops
- sql: prevent certain operations if regions are being added or dropped
- sql: fix bug where view exprs using enum arrays could prevent enum drops
- opt: disallow fast path for cascading deletes with subqueries
- kvserver: add safeguard against spurious calls to AdminRelocateRange
- kvserver: prevent the StoreRebalancer from downreplicating a range
- hlc: support context cancellation in Clock.SleepUntil
- kv: commit-wait before running commit triggers and resolving intents
- kv: don't respect global_reads on node liveness range
- sql: limit internal executor memory use
- pkg/kv/kvserver: don't redact LSM compaction stats
- opt: remove non-equivalent group columns in OrderingChoice.Simplify
- backupccl: make job system table restoration idempotent
- changefeedccl: fail changefeeds when tables go offline
- clusterversion: mint 21.1 cluster version
- backupccl: reset restored jobs during cluster restore
- kvserver: synchronize replica removal with read-only requests
- pkg/storage: sync file in SafeWriteToFile
- ui: upgrade Typescript from 3.8.0 to 4.2.4
- ui: use uPlot lib for line graphs on metrics page
- ui: metrics legend is under graph when large
- roachtest: update epected failures for pgjdbc
- roachtest: update ORM blocklists for v21.2
- kvserver: prefer leaseholder for range metrics
- build: save roachtest stats for all release branches
- build: fix teamcity-nightly-roachtest.sh
- kvserver: deflake TestStoreRangeMergeSlowWatcher
- roachprod: improve the way cockroach is run
- roachprod: upgrade AWS VM
- install: fix limits for cockroach process
- backupccl: don't include empty import entries during restore
- backupccl: rework split and scatter mechanism
- backupccl: fix a bug in routing scattered ranges
- backupccl: create more chunks on larger clusters
- sql: add memory accounting for the results of the subqueries
- sql: audit implementations of Releasable interface of slices' reuse
- colrpc: use the correct pgcode for connection failure
- storage: report all encountered intents in sst export error
- sql: fix ordered set aggregates with constant ORDER BY expressions
- sql: fix the session tracing in some cases
- util/log: default the line split size to 16K instead of 1K
- util/log: fix line splitting behavior
- util/log: better honor the maximum line length
- cli: better document the logging flags
- cli/flags: make 'cockroach help sql' more narrow
- cli/flags: remove 8 excess columns of indentation in help texts
- pkg/cli: new flag `--log-config-file` to simplify log configuration
- colexecbase: fix casting integers to smaller widths
- colrpc: shut down outbox tree on a graceful termination of a stream
- logictest: increase --max-sql-memory for SQLLite logic tests
- kvserver: synchronize replica removal with read-write requests
- opt: reduce the cost of locality optimized scan
- duration: fix Add on DST boundaries
- builtins: fix date_trunc on DST boundaries
- builtins: make ST_EstimatedExtent always return NULL
- builtins: implement ST_Envelope(box2d)
- sql: implement ST_AsTWKB
- geomfn: rename Simplify to SimplifyGEOS
- geomfn: implement ST_Simplify, 3 arg variant
- storage: fix usage of in-memory size attribute
- opt: fix a few omissions for locality optimized search
- opt: refactor and move some functions for locality optimized search
- opt: support locality optimized anti join
- kvserver: speed up intent resolution for aborted txns
- intentresolver: reduce ranged resolution batch size
- cli/sql: properly format different times and floats
- cli/zip: issue per-node requests concurrently
- opt: rework opt/bench
- sql: use a range feed for refreshing the table stats cache
- opt: fix null reject rule cycle
- util: introduce goschedstats
- ui: add average number of runnable goroutines to the runtime graphs
- opt: reduce cost of locality optimized anti join
- cli/zip: new reporting output format
- cli/zip: anchor newZipReporter on zipCtx
- cli/debug: new sub-command `list-files`
- cli: add a missing unit test
- cli/debug: allow the user to refine which files get included
- cli: fix a comment
- cli/zip: clamp file retrieval by date, default to last 48 hours
- opt: add opttester facility to test placeholder assignment
- opt: allow IN subquery to be converted to lookup join
- cli: fix debug keys iteration
- roachpb: propagate gRPC Status errors across Error
- *: improve handling of permanent errors
- opt: do not provide project ordering for columns removed when simplified
- opt: fix geospatial function NULL argument panics
- sql: fix nil pointer panic due to bind after failed BEGIN
- kvserver: speed up TestRollbackSyncRangedIntentResolution
- sql: resolve inferred types in prepare using appropriate planner
- tabledesc: prevent panic when removing constraint from Checks slice
- sql: unify crdb_internal.invalid_objects contents with doctor
- delegate: fix zone configs for SHOW CREATE TABLE with no partitions
- kvserver: reduce ReplicaGCQueueInactivityThreshold to 12 hours
- build: add script for automated diagram generation
- sql: fix Usage privilege on Tables/DBs after upgrading from 20.1
- restore: fix ZONECONFIG privilege when restoring from 20.1 version or prior.
- roachprod: Install and configure chrony on GCE clusters
- gce: rework chrony config
- roachprod: upgrade to a newer ubuntu image
- coldata: fix Nulls.Or in some edge cases
- colrpc: mark flow ctx cancellation in inbox as ungraceful
- opt: change SplitScanIntoUnionScans to use UnionAll operators
- opt: add support for SplitScanIntoUnionScans with enum columns
- sql: add a hint for string-to-timestamp cast error
- backupccl: test table restoration AOST
- backupccl: include dropped databases in cluster backups with rev history
- bulk: stop splitting on range flushes during RESTORE
- vendor: Bump pebble to f7a68a4d19a49e434f7d90e18a0e7a5730799293
- kvserver: fix flake in TestStoreMetrics
- randgen: prevent date->string cast in postgres computed columns
- tree: make string concat do a normal cast
- sql/pgwire: change formatting of floating point infinity values
- storage: Disable read sampling and read-triggered compactions
- tracing: fix benign data race
- kv: don't clear raftRequestQueue of right-hand side of Range split
- kv: don't allow node liveness to regress in Gossip network
- kv: bump kv.range_merge.queue_interval to 5s
- sql: use GetForUpdate in kvNative.Update
- kv: copy key memory before assigning to unreplicated lock
- sql/opt: use maximally selective constant filter for lookup joins
- delegate: fix SHOW CREATE TABLE showing zone configs of other schemas
- storage: discard memory in pebbleMVCCScanner before putting in pool
- sql/opt: support implicit SELECT FOR UPDATE locking with nested renders
- roachtest: upgrade to confluent 6 in cdc roachtests
- changefeedccl: Treat memory monitor errors as retryable.
- importccl: add `chunk_size` option to EXPORT CSV
- changefeedccl: extract job retrying code into common package
- backupccl,importccl: retry DistSQL flow on retryable failure
- build: add pipefail to teamcity-diagram-generation.sh
- pgwire: report telemetry for GSS encryption
- geo: minor performance improvement for looping over edges
- build: correct root path in build/release/teamcity-support.sh
- kvserver: improve comment over `rankedCandidateListForRebalancing()`
- kvserver: disallow replica rebalancing to dead nodes
- roachtest: add nodeShutdown roachtests
- importccl: add more errors to transient retryable error list
- backupccl: add test that shuts down worker during BACKUP
- jobs: don't check the number of deleted rows
- builtins: mark ST_GeomFromGeoJSON(string) as preferred
- opt: support SplitScanIntoUnionScans for exclusive constraint boundaries
- sql: add an internal table showing lost table descriptors
- sql: builtin that clears a range of table data based on descID
- kvcoord: simplify test
- kvcoord: prepare rep slice test for multiple replicas on node
- kvcoord: make test less confusing
- kvcoord: fix sorting of replicas
- build: add build/teamcity-common-support.sh as source to build/teamcity-support.sh
- catalog: add strict index column guarantees
- kvserver: prevent StoreRebalancer from downreplicating
- roachtest: fix import/nodeShutdown
- opt: format CollateExpr.Locale in opt trees
- opt: normalize CollateExpr Locale
- sql: fix has_database_privilege to work cross-DB
- sql: fix panic in CTAS with some virtual tables
- roachtest: fix psycopg/hibernate/django tests
- sql: formatting of `TableIndexName` can be wrong in certain contexts
- sql: batch write event logs for grant/revoke
- sql,log: also include the stmt tag in query logs
- sql: simplify the internal event logging APIs
- sql: use a single code path for both single-event and multi-event logging
- sql: rename the system event log cluster setting
- sql: move a function to its right place
- sql/event_log: avoid boolean parameters
- sql: pass SQL exec details as a struct to the event log functions
- sql/event_log: clarify the API in an explanatory comment
- sql/event_log: fix bug with verbose logging
- pgwire: fix decoding of binary TimeTZ values
- kvserver: add lock table spans to spanset assertions
- kvserver: fix race condition during synchronous txn record cleanup
- kvserver: improve intent cleanup for disconnected clients
- kvserver: deflake TestReliableIntentCleanup
- kvserver: skip TestReliableIntentCleanup
- migration: rename SQL/KV migration to Tenant/System respectively
- rpc: permit secondary tenants to use an older version
- server,sql,kvtenantccl: provide a path to upgrade tenant
- logictestccl: actually run tenant tests on logictestccl
- sql: populate version value when creating a tenant
- clusterversion: document requirements for baking in versions
- kvtenantccl: add test to exercise tenant upgrade
- testutils: add testutils.TB and adopt in sqlutils.SQLRunner
- roachtest: add multitenant version upgrade test
- tenantrate: add "test" that reports IOPS estimations
- util/quotapool: clean up some commentary, improve interface
- quotapool: extract token bucket accounting
- tenantrate: switch to a single token bucket
- tenantrate: fix test flake
- opt: copy LimitExpr input FDs regardless of limit value
- sql: return a SQL Notice if "CREATE TYPE IF NOT EXISTS" command is used to create a type and the type's already existed.
- returns notice when table already exist in case of IF NOT EXIST
- workload/movr: add --multi-region and --survive settings
- release-21.1: skip acceptance/rapid-restart
- sql: show full table scans query
- sql: add crdb_internal.reset_sql_stats() builtin
- sql, server: add SQLStatsResetter to distsql and internalExecutor
- sql: use column attrnum as sub_id
- geo/geomfn: fix Node if the LineString is the same point
- backupccl: fix include interleaved tables option for scheduled backup
- settings: mark diagnostics.forced_stat_reset.interval as retired
- sql: add ALTER DATABASE ... ADD REGION IF NOT EXISTS ...
- sql: fix error message for dropping non-added region
- sql: add ALTER DATABASE ... DROP REGION IF EXISTS ...
- sql/pgwire: add telemetry for pgwire extended protcol
- settings: add `backup.table_statistics.enabled` to retired settings
- ui: fix jobs page crash
- builtsin: fix get/set_bit for bytea arguments
- kvserver: change Migrate evaluation to wait for laxer LAI
- importccl: add IMPORT INTO telemetry
- ctxgroup: add GoAndWait method
- sql: add `CACHE` clause to `SHOW CREATE SEQUENCE` when relevant
- ui: fix rejoin event message
- sql/catalog/descs: use allDescriptors as a negative cache for by-ID lookups
- sql: ensure schema only has valid privileges after reparent database is done
- acceptance: maybe deflake acceptance/multi-tenant
- acceptance: maybe deflake log check in acceptance/multitenant
- sql: Don't clear zone configs on indexes during a RBR transition
- sql: More nuanced blocking of zone config DISCARD
- sql: Add tests for COPY FROM PARENT on multi-region tables
- sql: Add telemetry for zone configuration override
- sql/tests: TestRandomSyntaxSchemaChangeColumn fails due to timeout
- colexecutils: make closure of nil spilling queue a no-op
- backupccl: avoid panic if not collecting prior IDs
- colbuilder: optimize casting in some cases
- cli/interactive_tests: re-enable test_demo_partitioning.tcl
- cli/interactive_tests: add tests for --multi-region on demo movr
- filetable: fix NPE when an empty file is downloaded from userfile
- importccl: unskip userfile benchmark
- backupccl: fix cluster restore progress logging
- backupccl: fix cluster restore progress logging
- kvserver: fix bug obstructing range merges on multi-store clusters
- Admin UI components rename (#154)
- v0.1.38
- db-console: optimize webpack builds with production mode
- v0.1.39
- db-console: optimize highlight.js imports
- db-console: optimize antd imports
- db-console: optimize moment.js imports
- v0.1.40
- cluster-ui: fix ts config for storybooks (#180)
- v0.1.41
- Publish (#183)
- cluster-ui: provide ordered list of diagnostics to statements page
- v0.1.43
- cluster-ui: nodes redux functionality
- Revert "cluster-ui: nodes redux functionality"
- v0.1.44
- cluster-ui: nodes redux functionality
- cluster-ui: aggregate node stats in selectors
- v0.1.45
- # cluster-ui // Truncating long queries with CSS (#179)
- v0.1.46
- cluster-ui: update statements page
- cluster-ui: small cleanup of stmts table css
- cluster-ui: fix lint errors in barCharts.tsx
- v0.1.47
- cluster-ui: StatementDetailsConnected component
- cluster-ui: fix modules path resolution when import from src/index.ts
- v0.1.48
- cluster-ui: fix link on statement diagnostics bundle
- v0.1.49
- cluster-ui: fix usage of wrong count in barCharts stddev calculation
- cluster-ui: update transactions page with execution stats
- cluster-ui: add Required to addStatementStats
- v0.1.50
- Bump ini from 1.3.5 to 1.3.7 (#157)
- v0.1.51
- cluster-ui: bump cluster-ui to 0.2.x version
- v0.2.1
- cluster-ui: add babel-runtime to support dynamic loading
- v0.2.2
- cluster-ui: sessions redux functionality
- v0.2.3
- cluster-ui: update README to summarize dev workflow (#199)
- v0.2.4
- cluster-ui: update transaction overview page with execution stats
- v0.2.5
- cluster-ui: add execution stats to statement details page
- v0.2.6
- v0.2.7
- cluster-ui: update crdb-protobuf-client
- v0.2.8
- cluster-ui: clean up unused CSS import
- v0.2.9
- cluster-ui: fix appstat utils
- v0.2.10
- cluster-ui: remove TXN Type column in statements page
- cluster-ui: fix sort order in statement/transaction table views
- cluster-ui: update "Latency" column titles to "{Statement,Transaction} Time"
- cluster-ui: use formatTwoPlaces when displaying row stat in transaction details
- cluster-ui: add contention column to statements/transactions pages
- cluster-ui: add max scratch disk usage to statement/transaction details
- v0.2.11
- cluster-ui: add full table or index scan filter to statements page
- v0.2.12
- cluster-ui: fix styles for execution stats tables
- v0.2.13
- cluster-ui: aggregate stmn data on txn details page
- v0.2.14
- cluster-ui: update tooltips on statements/transaction pages
- cluster-ui: display "no samples" and a tooltip when no stats have been sampled
- v0.2.15
- cluster-ui: Fixed version of crdb-protobuf-client
- cluster-ui: Increasing version to align release branches (#318)
- cluster-ui: sessions, terminate modal notifications
- cluster-ui: ui customization parameters
- cluster-ui: correct design for empty states in statements table
- cluster-ui: fix styles for statements page
- cluster-ui: fix statements page styles
- cluster-ui: reset redux state action
- add pct of all runtime to statements
- cluster-ui: re-export uiConfiguration actions
- cluster-ui: default values for statement details ui configuration
- cluster-ui: proper empty state design for statement diagnostics view
- cluster-ui: create component for filter and table stats and  use them on transaction and statements page
- cluster-ui: analytics tracking events
- cluster-ui: fix table styles
- cluster-ui: cancel active sagas when redux state is reset
- cluster-ui: sessions style fixes (#275)
- cluster-ui: sessions tracking events (#278)
- ui-components: tooltip component updates (#290)
- cluster-ui: sessions tracking (#288)
- cluster-ui: tooltip fixes (#292)
- ui: fix typo on network tooltip
- cluster-ui: bump ui-components (#299)
- cluster-ui: fix styling for statements filter component
- cluster-ui: fix sort on tables
- v0.2.44
- ui: integrate cluster-ui package into db-console
- ui: add copyright headers to `cluster-ui` files
- sql: Add test for CREATE TABLE AS on REGIONAL BY ROW table
- ui: fix typos in integrated ui/cluster-ui package
- sql: Fix TestTelemetry in cases where retries occur
- kvserver: improve suspect replica GC heuristics
- kvserver: remove replica GC heuristic for quiesced followers
- kv: stop txn heartbeater early on txn abort
- ui: add button to reset SQL stats
- cluster-ui: add button to reset SQL stats on statement page and txn page
- sql/gcjob: retry failed GC jobs
- sql: fix bug in column backfill with virtual columns
- multiregionccl: fix bazel build
- sql: check for duplicate index name when creating UNIQUE INDEX
- sql: properly detect duplicate index name when adding unique index
- sql: TRUNCATE preserves split points of indexes
- sql: remove transactional meta scan in TRUNCATE
- colbuilder: improve logging of planning for traces
- storage: max number of intents in WriteIntentError during scan
- sql: Repartition tables before dropping regions
- opt: normalize x=True, x=False, x != True, and x != False to x or NOT x
- sql: fix schema privileges on descriptor read
- docgen: fix collated string links in auto-gen functions doc
- colbuilder: return custom error for LocalPlanNode core
- colbuilder: optimize casting in edge cases
- release: check remote tag before pushing
- release: configure ssh key before using git
- ui: fix metric rendering when node data is missing
- backupccl: run parallel workers during restore
- sql: fix lease_holder_locality in SHOW RANGES
- ui: Adding TransactionsPageConnected for export
- kvserver: deflake TestMergeQueue
- ui: Replace node-sass with sass
- cloud/amazon: CredentialsChainVerboseErrors
- sql: fix statement diagnostics for EXECUTE
- sql: add logic test for previously fixed casting bug
- sql: fix inflated "overhead" in statement timings
- release-21.1: kvserver: add missing regexp to IsExpectedRelocateError
- cli/demo: clarify the details printed upon startup
- ui: style fix of login password input
- row: fix intra-query memory leak in kvfetcher
- row: release memory more eagerly in txnKVFetcher
- colcontainer: fix intra-query memory leak
- ui: Cluster UI TransactionsPageConnected
- sql: allow computed columns to reference foreign key columns
- docs, server: update auto-generated logging docs
- pgwire: log HBA parsing errors to the OPS channel
- logpb: don't mention 'pgwire events' under SQL_EXEC. Mention panics.
- docs: mention the full table scan setting for SQL_PERF events
- sql: clarify the entropy available via `random()`
- pgwire: only show TZ minutes offset if non-zero
- cli: format time zones and floating points to match SQL
- cli/sql: properly format common array types
- backup: put SSTs in own dir
- roachtest: update sqlalchemy roachtest to use SQLA 1.4
- tenantrate: add old settings to retiredSettings
- kvserver: counters for intent resolution failures
- ui: add reset sql stats feature flag
- cloud/amazon: reuse s3 client sessions
- changefeedccl: set sarama's flush frequency to 0 by default.
- changefeedccl: Use default sarama flush configuration
- roachtest: fix cancel test name
- execbuilder: fix column mapping for insert fast path FK violations
- sqlsmith: don't use postgis build function
- builtins: handle null correctly for fuzzystrmatch functions
- randgen: remove unneeded replacements in PostgresMutator
- opt: add benchmark for a table with many columns and indexes
- sql: optimize optIndex.Column
- opt: only explore zig zag joins with two or more fixed columns
- changefeedccl: allow user to configure kafka server version
- multiple: fix uses of provably nil errors
- jobs,storage: don't call errors.Wrap-style functions with nil errors
- server: simplify an error case
- cloudimpl: fix GCS storage to use the resuming reader
- jobs: surface the trace_id linked to job execution
- jobs: use low-priority transactions for claim, adopt, cancel/pause
- cli/sql: ensure that client-side commands set errors properly
- cli/sql: make it possible to run any client-side command via `-e`
- ui: bump cluster-ui v21.1.1 version
- ui: changing chart name to be compatible with other charts
- sql: add regions to EXPLAIN ANALYZE
- sql: drop "cluster" from EXPLAIN ANALYZE to improve readability
- sql: remove code not pertinent to this backport
- util/limit: replace unfair semaphore with fair quotapool
- kvserver: deflake TestRollbackSyncRangedIntentResolution
- contextutil: preserve contextutil.TimeoutError details across the network
- kv: don't hold latches while rate limiting ExportRequests
- backupccl: add cluster setting to disable GCS chunking
- log/eventpb: make certain fields conditionally redactable
- storageccl: don't update file registry when creating unencrypted files
- sem/tree: fix integer overflow for ROWS mode of window frame
- roachtest: update version map
- bulkio: Rework scheduled job test.
- roachtest: bump activerecord adapter and blocklist
- roachtest: handle transient error when downloading bumptime
- roachtest/tpcc: pass correct warehouse count in multi-region tpccbench
- sql: add hints for timestamptz cast errors
- colbuilder: fix recently introduced bug in an edge case
- cmd/roachtest: fix dependencies for typeorm
- builtins: implement ST_HasArc
- sql/pgwire: fix encoding of decimals with trailing 0s
- security: protect calls to bcrypt hashes by a semaphore
- util/log: move the crdb-v1 test code to a separate file
- util/log: use a datadriven test for the crdb-v1 format/parse test
- util/log: make `logpb.Entry` slightly more able to represent crdb-v2 entries
- util/log: report the logging format at the start of new files
- logconfig: fix the handling of crdb-v1 explicit config
- cli: report explicit log config in logs
- util/log,logspy: make the logspy mechanism better
- util/log,server/debug: new API `/debug/vmodule`, change `logspy`
- kvserver: change shouldCampaignOnWake to campaign when the leader is dead
- opt: introduce "accessible by qualified star" column visibility in optbuilder
- opt: fix qualified star expansion after joins
- kvserver: fix possile NPE in follower read condition
- colexec: fix a crash with EXPLAIN (VEC) and some mutations
- ui: jobs remaining time fix
- jobs: limit number of jobs updated per query when canceling
- kvserver: don't reset local keys in tscache on r1 lease move
- kvserver: plumb ctx to txn record creation helper
- kvserver: improve some closedts comments
- kvserver: don't assign closed timestamps to lease requests
- kvserver: simplify TestClosedTimestampInactiveAfterSubsumption
- backupccl: run all post-deserialization upgrades on restored descriptors
- roachtest: update pgjdbc block list for new passing test
- opt: fix partial index implication for prepared statements
- jobs: fix flakey TestMetrics
- backupccl: report partial span progress
- sql: add zone partitions when using ADD COLUMN UNIQUE on RBR
- roachprod: update to recommended ubuntu focal image
- ui: remove width styling calc on multibar
- changefeedccl: add test for disabled outbound IO
- serverutils: Add TestTenantID()
- changefeedccl: add test for sinkless changefeed on tenant
- roachtest: remove scaledata
- roachtest: fix segfault logging in sysbench
- kvserver: deadlock when getting replica.Desc while under lock
- ts: allow dumping raw timeseries KV pairs
- cli,ts: allow (hacky) visualization of timeseries dumps
- roachpb: fix incorrect addition of roachpb.ExecStats Count field
- release-21.1: go.mod: switch google cloud to fork of v0.45.1
- kvserver: respect draining status on a node for lease transfers with lease preferences
- ui: exclude antd global styles from `cluster-ui`
- codeowners: enforce ownership of ./pkg/...
- roachtest: don't call t.Fatal in FailOnReplicaDivergence
- roachtest: handle VM overload under tpccbench
- roachprod: don't swallow panic when failing to fetch subscription
- roachtest: exclude `lost+found` directory
- roachtest: fix error formatting in web UI
- testfilter: improve the help for package-level failures
- github-post: cc teams and use project triage columns
- roachtest: add Owner for server team
- TEAMS: add simple way to find triage column ID
- TEAMS: populate a few triage_column_ids
- roachtest,TEAMS: add cockroachdb/kv-triage handle
- roachtest: own `quit-all-nodes` to Server
- roachtest: tpccbench: handle overload vm crash in last search iter
- roachtest: tpccbench: ignore error from `c.Reset`
- roachtest: add link to clusters' admin ui from the roachtest webui
- Update CODEOWNERS and TEAMS from master
- roachtest: use TEAMS.yaml for team metadata
- roachtest: don't post issues from non-release branches
- cmd: mention kv-triage for kv-owned roachtests
- opt: fix panic due to concurrent map writes when copying metadata
- kvserver: add a concept of suspect nodes to the allocator
- server: fix node shutdown calling time.sleep more than once
- sql/pgwire: add ops logging for draining events
- backupccl: fixing flaky backup regression test
- util: reduce goschedstats sampling rate
- backupccl: fix error during span-merging optimization
- sql: add ReType to resolveAndRequireType to fix vector engine panic
