### PR TITLE
release-21.1: sql: add ReType to resolveAndRequireType to fix vector engine panic

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/hash_sharded_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/hash_sharded_index
@@ -28,7 +28,7 @@ vectorized: true
     └── • render
         │ columns: (column6, column1)
         │ estimated row count: 2
-        │ render column6: mod(fnv32(COALESCE(column1::STRING, '')), 11)
+        │ render column6: mod(fnv32(COALESCE(column1::STRING, '')), 11)::INT4
         │ render column1: column1
         │
         └── • values
@@ -63,7 +63,7 @@ vectorized: true
     └── • render
         │ columns: (column8, column7, column1)
         │ estimated row count: 2
-        │ render column8: mod(fnv32(COALESCE(column1::STRING, '')), 12)
+        │ render column8: mod(fnv32(COALESCE(column1::STRING, '')), 12)::INT4
         │ render column7: unique_rowid()
         │ render column1: column1
         │

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -472,7 +472,7 @@ func (s *scope) resolveAndRequireType(expr tree.Expr, desired *types.T) tree.Typ
 	if err != nil {
 		panic(err)
 	}
-	return s.ensureNullType(texpr, desired)
+	return tree.ReType(s.ensureNullType(texpr, desired), desired)
 }
 
 // ensureNullType tests the type of the given expression. If types.Unknown, then

--- a/pkg/sql/opt/optbuilder/testdata/insert
+++ b/pkg/sql/opt/optbuilder/testdata/insert
@@ -1168,13 +1168,13 @@ insert decimals
       │    │    │    │    │    ├── columns: column1:6!null column2:7
       │    │    │    │    │    └── (1.1, ARRAY[0.95,NULL,15])
       │    │    │    │    └── projections
-      │    │    │    │         └── 1.23 [as=column8:8]
+      │    │    │    │         └── 1.23::DECIMAL(10,1) [as=column8:8]
       │    │    │    └── projections
       │    │    │         ├── crdb_internal.round_decimal_values(column1:6, 0) [as=a:9]
       │    │    │         ├── crdb_internal.round_decimal_values(column2:7, 1) [as=b:10]
       │    │    │         └── crdb_internal.round_decimal_values(column8:8, 1) [as=c:11]
       │    │    └── projections
-      │    │         └── a:9 + c:11 [as=column12:12]
+      │    │         └── (a:9 + c:11::DECIMAL)::DECIMAL(10,1) [as=column12:12]
       │    └── projections
       │         └── crdb_internal.round_decimal_values(column12:12, 1) [as=d:13]
       └── projections

--- a/pkg/sql/opt/optbuilder/testdata/update
+++ b/pkg/sql/opt/optbuilder/testdata/update
@@ -1631,7 +1631,7 @@ update decimals
       │    │    │    │    │    ├── columns: decimals.a:6!null decimals.b:7 c:8 decimals.d:9 crdb_internal_mvcc_timestamp:10
       │    │    │    │    │    └── computed column expressions
       │    │    │    │    │         └── decimals.d:9
-      │    │    │    │    │              └── decimals.a:6::DECIMAL + c:8::DECIMAL
+      │    │    │    │    │              └── (decimals.a:6::DECIMAL + c:8::DECIMAL)::DECIMAL(10,1)
       │    │    │    │    └── projections
       │    │    │    │         ├── 1.1 [as=a_new:11]
       │    │    │    │         └── ARRAY[0.95,NULL,15] [as=b_new:12]
@@ -1639,7 +1639,7 @@ update decimals
       │    │    │         ├── crdb_internal.round_decimal_values(a_new:11, 0) [as=a:13]
       │    │    │         └── crdb_internal.round_decimal_values(b_new:12, 1) [as=b:14]
       │    │    └── projections
-      │    │         └── a:13 + c:8::DECIMAL [as=column15:15]
+      │    │         └── (a:13 + c:8::DECIMAL)::DECIMAL(10,1) [as=column15:15]
       │    └── projections
       │         └── crdb_internal.round_decimal_values(column15:15, 1) [as=d:16]
       └── projections

--- a/pkg/sql/opt/optbuilder/testdata/update-col-cast-bug
+++ b/pkg/sql/opt/optbuilder/testdata/update-col-cast-bug
@@ -1,0 +1,52 @@
+exec-ddl
+create table t (a int2, b int2, c int2 as (a + b) virtual)
+----
+
+build format=show-types
+update t set a = (with cte as (select 1:::int8) select t.c from cte limit 1)
+----
+with &1 (cte)
+ ├── project
+ │    ├── columns: int8:11(int!null)
+ │    ├── values
+ │    │    └── () [type=tuple]
+ │    └── projections
+ │         └── 1 [as=int8:11, type=int]
+ └── update t
+      ├── columns: <none>
+      ├── fetch columns: a:6(int2) b:7(int2) t.c:8(int2) rowid:9(int)
+      ├── update-mapping:
+      │    ├── a_new:14 => a:1
+      │    └── column15:15 => t.c:3
+      └── project
+           ├── columns: column15:15(int2) a:6(int2) b:7(int2) t.c:8(int2) rowid:9(int!null) crdb_internal_mvcc_timestamp:10(decimal) a_new:14(int2)
+           ├── project
+           │    ├── columns: a_new:14(int2) a:6(int2) b:7(int2) t.c:8(int2) rowid:9(int!null) crdb_internal_mvcc_timestamp:10(decimal)
+           │    ├── project
+           │    │    ├── columns: t.c:8(int2) a:6(int2) b:7(int2) rowid:9(int!null) crdb_internal_mvcc_timestamp:10(decimal)
+           │    │    ├── scan t
+           │    │    │    ├── columns: a:6(int2) b:7(int2) rowid:9(int!null) crdb_internal_mvcc_timestamp:10(decimal)
+           │    │    │    └── computed column expressions
+           │    │    │         └── t.c:8
+           │    │    │              └── (a:6::INT8 + b:7::INT8)::INT2 [type=int2]
+           │    │    └── projections
+           │    │         └── (a:6::INT8 + b:7::INT8)::INT2 [as=t.c:8, type=int2]
+           │    └── projections
+           │         └── subquery [as=a_new:14, type=int2]
+           │              └── max1-row
+           │                   ├── columns: c:13(int2)
+           │                   └── limit
+           │                        ├── columns: c:13(int2)
+           │                        ├── project
+           │                        │    ├── columns: c:13(int2)
+           │                        │    ├── limit hint: 1.00
+           │                        │    ├── with-scan &1 (cte)
+           │                        │    │    ├── columns: int8:12(int!null)
+           │                        │    │    ├── mapping:
+           │                        │    │    │    └──  int8:11(int) => int8:12(int)
+           │                        │    │    └── limit hint: 1.00
+           │                        │    └── projections
+           │                        │         └── t.c:8 [as=c:13, type=int2]
+           │                        └── 1 [type=int]
+           └── projections
+                └── (a_new:14::INT8 + b:7::INT8)::INT2 [as=column15:15, type=int2]

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -1722,13 +1722,13 @@ upsert decimals
       │    │    │    │    │    │    │    │    │    ├── columns: column1:6!null column2:7
       │    │    │    │    │    │    │    │    │    └── (1.1, ARRAY[0.95])
       │    │    │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │    │    │         └── 1.23 [as=column8:8]
+      │    │    │    │    │    │    │    │         └── 1.23::DECIMAL(10,1) [as=column8:8]
       │    │    │    │    │    │    │    └── projections
       │    │    │    │    │    │    │         ├── crdb_internal.round_decimal_values(column1:6, 0) [as=a:9]
       │    │    │    │    │    │    │         ├── crdb_internal.round_decimal_values(column2:7, 1) [as=b:10]
       │    │    │    │    │    │    │         └── crdb_internal.round_decimal_values(column8:8, 1) [as=c:11]
       │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         └── a:9 + c:11 [as=column12:12]
+      │    │    │    │    │    │         └── (a:9 + c:11::DECIMAL)::DECIMAL(10,1) [as=column12:12]
       │    │    │    │    │    └── projections
       │    │    │    │    │         └── crdb_internal.round_decimal_values(column12:12, 1) [as=d:13]
       │    │    │    │    └── aggregations
@@ -1742,11 +1742,11 @@ upsert decimals
       │    │    │    │    ├── columns: decimals.a:14!null decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18
       │    │    │    │    └── computed column expressions
       │    │    │    │         └── decimals.d:17
-      │    │    │    │              └── decimals.a:14::DECIMAL + decimals.c:16::DECIMAL
+      │    │    │    │              └── (decimals.a:14::DECIMAL + decimals.c:16::DECIMAL)::DECIMAL(10,1)
       │    │    │    └── filters
       │    │    │         └── a:9 = decimals.a:14
       │    │    └── projections
-      │    │         └── decimals.a:14::DECIMAL + decimals.c:16::DECIMAL [as=column19:19]
+      │    │         └── (decimals.a:14::DECIMAL + decimals.c:16::DECIMAL)::DECIMAL(10,1) [as=column19:19]
       │    └── projections
       │         ├── CASE WHEN decimals.a:14 IS NULL THEN a:9 ELSE decimals.a:14 END [as=upsert_a:20]
       │         ├── CASE WHEN decimals.a:14 IS NULL THEN c:11 ELSE decimals.c:16 END [as=upsert_c:21]
@@ -1794,13 +1794,13 @@ upsert decimals
       │    │    │    │    │    │    │    │    │    └── (1.1,)
       │    │    │    │    │    │    │    │    └── projections
       │    │    │    │    │    │    │    │         ├── NULL::DECIMAL(5,1)[] [as=column7:7]
-      │    │    │    │    │    │    │    │         └── 1.23 [as=column8:8]
+      │    │    │    │    │    │    │    │         └── 1.23::DECIMAL(10,1) [as=column8:8]
       │    │    │    │    │    │    │    └── projections
       │    │    │    │    │    │    │         ├── crdb_internal.round_decimal_values(column1:6, 0) [as=a:9]
       │    │    │    │    │    │    │         ├── crdb_internal.round_decimal_values(column7:7, 1) [as=b:10]
       │    │    │    │    │    │    │         └── crdb_internal.round_decimal_values(column8:8, 1) [as=c:11]
       │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         └── a:9 + c:11 [as=column12:12]
+      │    │    │    │    │    │         └── (a:9 + c:11::DECIMAL)::DECIMAL(10,1) [as=column12:12]
       │    │    │    │    │    └── projections
       │    │    │    │    │         └── crdb_internal.round_decimal_values(column12:12, 1) [as=d:13]
       │    │    │    │    └── aggregations
@@ -1814,11 +1814,11 @@ upsert decimals
       │    │    │    │    ├── columns: decimals.a:14!null decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18
       │    │    │    │    └── computed column expressions
       │    │    │    │         └── decimals.d:17
-      │    │    │    │              └── decimals.a:14::DECIMAL + decimals.c:16::DECIMAL
+      │    │    │    │              └── (decimals.a:14::DECIMAL + decimals.c:16::DECIMAL)::DECIMAL(10,1)
       │    │    │    └── filters
       │    │    │         └── a:9 = decimals.a:14
       │    │    └── projections
-      │    │         └── decimals.a:14::DECIMAL + decimals.c:16::DECIMAL [as=column19:19]
+      │    │         └── (decimals.a:14::DECIMAL + decimals.c:16::DECIMAL)::DECIMAL(10,1) [as=column19:19]
       │    └── projections
       │         ├── CASE WHEN decimals.a:14 IS NULL THEN a:9 ELSE decimals.a:14 END [as=upsert_a:20]
       │         ├── CASE WHEN decimals.a:14 IS NULL THEN b:10 ELSE decimals.b:15 END [as=upsert_b:21]
@@ -1874,13 +1874,13 @@ upsert decimals
       │    │    │    │    │    │    │    │    │    │    │    ├── columns: column1:6!null column2:7
       │    │    │    │    │    │    │    │    │    │    │    └── (1.1, ARRAY[0.95])
       │    │    │    │    │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │    │    │    │    │         └── 1.23 [as=column8:8]
+      │    │    │    │    │    │    │    │    │    │         └── 1.23::DECIMAL(10,1) [as=column8:8]
       │    │    │    │    │    │    │    │    │    └── projections
       │    │    │    │    │    │    │    │    │         ├── crdb_internal.round_decimal_values(column1:6, 0) [as=a:9]
       │    │    │    │    │    │    │    │    │         ├── crdb_internal.round_decimal_values(column2:7, 1) [as=b:10]
       │    │    │    │    │    │    │    │    │         └── crdb_internal.round_decimal_values(column8:8, 1) [as=c:11]
       │    │    │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │    │    │         └── a:9 + c:11 [as=column12:12]
+      │    │    │    │    │    │    │    │         └── (a:9 + c:11::DECIMAL)::DECIMAL(10,1) [as=column12:12]
       │    │    │    │    │    │    │    └── projections
       │    │    │    │    │    │    │         └── crdb_internal.round_decimal_values(column12:12, 1) [as=d:13]
       │    │    │    │    │    │    └── aggregations
@@ -1894,7 +1894,7 @@ upsert decimals
       │    │    │    │    │    │    ├── columns: decimals.a:14!null decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18
       │    │    │    │    │    │    └── computed column expressions
       │    │    │    │    │    │         └── decimals.d:17
-      │    │    │    │    │    │              └── decimals.a:14::DECIMAL + decimals.c:16::DECIMAL
+      │    │    │    │    │    │              └── (decimals.a:14::DECIMAL + decimals.c:16::DECIMAL)::DECIMAL(10,1)
       │    │    │    │    │    └── filters
       │    │    │    │    │         └── a:9 = decimals.a:14
       │    │    │    │    └── projections
@@ -1902,7 +1902,7 @@ upsert decimals
       │    │    │    └── projections
       │    │    │         └── crdb_internal.round_decimal_values(b_new:19, 1) [as=b:20]
       │    │    └── projections
-      │    │         └── decimals.a:14::DECIMAL + decimals.c:16::DECIMAL [as=column21:21]
+      │    │         └── (decimals.a:14::DECIMAL + decimals.c:16::DECIMAL)::DECIMAL(10,1) [as=column21:21]
       │    └── projections
       │         ├── CASE WHEN decimals.a:14 IS NULL THEN a:9 ELSE decimals.a:14 END [as=upsert_a:22]
       │         ├── CASE WHEN decimals.a:14 IS NULL THEN b:10 ELSE b:20 END [as=upsert_b:23]

--- a/pkg/sql/opt/xform/testdata/external/trading-mutation
+++ b/pkg/sql/opt/xform/testdata/external/trading-mutation
@@ -1593,7 +1593,7 @@ update cardsinfo [as=ci]
       │         └── const-agg [as=q:35, outer=(35)]
       │              └── q:35
       └── projections
-           ├── crdb_internal.round_decimal_values(buyprice:22::DECIMAL - discount:24::DECIMAL, 4) [as=discountbuyprice:50, outer=(22,24), immutable]
+           ├── crdb_internal.round_decimal_values((buyprice:22::DECIMAL - discount:24::DECIMAL)::DECIMAL(10,4), 4) [as=discountbuyprice:50, outer=(22,24), immutable]
            ├── CAST(NULL AS STRING) [as=column47:47]
            ├── 0 [as=column48:48]
            └── COALESCE(sum_int:44, 0) [as=actualinventory_new:46, outer=(44)]


### PR DESCRIPTION
CC @cockroachdb/release 

Backport of #66885.

---
Fixes #66708

The vector engine needs exact type coercion, specifically when piping
computed column values into downstream operators.  Without this fix
the computed column was left as an int64 instead of cast back to the
required int16 type.

Exposed by sqlsmith, kudos to @michae2 for the reducer help

Release note: None
