### PR TITLE
server: skip TestSetupIdleMonitor_WithWarmupProvided

### DIFF
--- a/pkg/server/testserver_test.go
+++ b/pkg/server/testserver_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/netutil"
@@ -54,6 +55,7 @@ func TestSetupIdleMonitor_WithNoWarmupProvided(t *testing.T) {
 
 func TestSetupIdleMonitor_WithWarmupProvided(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 66767, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()


### PR DESCRIPTION
Refs: #66767

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None