### PR TITLE
kvserver: skip TestReliableIntentCleanup

### DIFF
--- a/pkg/kv/kvserver/intent_resolver_integration_test.go
+++ b/pkg/kv/kvserver/intent_resolver_integration_test.go
@@ -221,6 +221,7 @@ func TestRollbackSyncRangedIntentResolution(t *testing.T) {
 func TestReliableIntentCleanup(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.WithIssue(t, 66895, "Flaky due to non-deterministic txn cleanup")
 	skip.UnderShort(t) // takes 294s
 	skip.UnderRace(t, "timing-sensitive test")
 	skip.UnderStress(t, "memory-hungry test")


### PR DESCRIPTION
Flakorama. Unclear if it'll be possible to salvage this test without
significant changes to txn cleanup.

Touches #66895.

Release note: None