### PR TITLE
kvserver: mark 'desc not found' error as snapshot error

### DIFF
--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -549,7 +549,7 @@ func snapshot(
 		return OutgoingSnapshot{}, errors.Errorf("failed to get desc: %s", err)
 	}
 	if !ok {
-		return OutgoingSnapshot{}, errors.Errorf("couldn't find range descriptor")
+		return OutgoingSnapshot{}, errors.Mark(errors.Errorf("couldn't find range descriptor"), errMarkSnapshotError)
 	}
 
 	// Read the range metadata from the snapshot instead of the members


### PR DESCRIPTION
This should prevent it from bubbling up to the client.

Also, use `isSnapshotError` in `relocateOne`, which was previously using
ad-hoc string matching that predated our use of `cockroachdb/error`

Fixes #66946.

Release note: None
