### PR TITLE
ui,cluster-ui: update tooltips to use underline instead of icon

### DIFF
--- a/pkg/ui/cluster-ui/src/sortedtable/tableHead/tableHead.module.scss
+++ b/pkg/ui/cluster-ui/src/sortedtable/tableHead/tableHead.module.scss
@@ -16,6 +16,9 @@
   &__row--header {
     border-bottom: 1px solid $colors--neutral-3;
     height: $line-height--x-large;
+    .column-title {
+      border-bottom: 1px dashed $colors--neutral-5;
+    }
     // Display the sort direction arrow in header cells.
     .sorted__cell {
       padding: $spacing-base $spacing-base $spacing-base $spacing-small;

--- a/pkg/ui/cluster-ui/src/sortedtable/tableHead/tableHead.tsx
+++ b/pkg/ui/cluster-ui/src/sortedtable/tableHead/tableHead.tsx
@@ -69,6 +69,7 @@ export const TableHead: React.FC<TableHeadProps> = ({
             !sortSetting.ascending && picked && "sorted__cell--descending",
             firstCellBordered && idx === 0 && "cell-header",
           );
+          const titleClasses = cx("column-title");
 
           return (
             <th
@@ -78,7 +79,7 @@ export const TableHead: React.FC<TableHeadProps> = ({
               style={style}
             >
               <div className={cellContentWrapper}>
-                {c.title}
+                <span className={titleClasses}>{c.title} </span>
                 {sortable && <span className={arrowsClass} />}
               </div>
             </th>

--- a/pkg/ui/cluster-ui/src/table/table.module.scss
+++ b/pkg/ui/cluster-ui/src/table/table.module.scss
@@ -32,6 +32,10 @@
   .column--align-right {
     text-align: end;
   }
+
+  :global(.column-title) {
+    border-bottom: 1px dashed $colors--neutral-5;
+  }
   // END: Table Column
 
   // Expand/Collapse icon

--- a/pkg/ui/src/views/cluster/components/visualization/index.tsx
+++ b/pkg/ui/src/views/cluster/components/visualization/index.tsx
@@ -10,11 +10,9 @@
 
 import React from "react";
 import classNames from "classnames";
-
-import { InfoTooltip } from "src/components/infoTooltip";
-
 import "./visualizations.styl";
 import spinner from "assets/spinner.gif";
+import { Tooltip } from "antd";
 
 interface VisualizationProps {
   title: string;
@@ -38,7 +36,7 @@ interface VisualizationProps {
  */
 export default class extends React.Component<VisualizationProps, {}> {
   render() {
-    const { title, tooltip, stale } = this.props;
+    const { title, subtitle, tooltip, stale } = this.props;
     const vizClasses = classNames("visualization", {
       "visualization--faded": stale || false,
     });
@@ -46,22 +44,35 @@ export default class extends React.Component<VisualizationProps, {}> {
       "visualization--loading": this.props.loading,
     });
 
-    let tooltipNode: React.ReactNode = "";
+    let titleClass = "visualization__title";
     if (tooltip) {
-      tooltipNode = <InfoTooltip text={tooltip} />;
+      titleClass += " visualization__underline";
+    }
+
+    const chartSubtitle = subtitle ? (
+      <span className="visualization__subtitle">{subtitle}</span>
+    ) : null;
+
+    const chartTitle: React.ReactNode = (
+      <div>
+        <span className={titleClass}>{title}</span>
+        {chartSubtitle}
+      </div>
+    );
+
+    let tooltipNode: React.ReactNode = chartTitle;
+
+    if (tooltip) {
+      tooltipNode = (
+        <Tooltip placement="bottom" title={tooltip}>
+          {chartTitle}
+        </Tooltip>
+      );
     }
 
     return (
       <div className={vizClasses}>
-        <div className="visualization__header">
-          <span className="visualization__title">{title}</span>
-          {this.props.subtitle ? (
-            <span className="visualization__subtitle">
-              {this.props.subtitle}
-            </span>
-          ) : null}
-          {tooltipNode}
-        </div>
+        <div className="visualization__header">{tooltipNode}</div>
         <div className={contentClasses}>
           {this.props.loading ? (
             <img className="visualization__spinner" src={spinner} />

--- a/pkg/ui/src/views/cluster/components/visualization/visualizations.styl
+++ b/pkg/ui/src/views/cluster/components/visualization/visualizations.styl
@@ -42,6 +42,9 @@ $viz-sides = 62px
     font-family $font-family--bold
     color $body-color
 
+  &__underline
+    border-bottom 1px dashed $colors--neutral-5;
+
   &__subtitle
     color $tooltip-color
     margin-left 5px
@@ -54,6 +57,13 @@ $viz-sides = 62px
 
   .icon-warning
     color $warning-color
+
+.anchor-light
+  color white
+  text-decoration underline
+  &:hover
+    color gray
+    text-decoration underline
 
 .linegraph
   height 100%

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/graphTooltips.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/graphTooltips.tsx
@@ -25,8 +25,11 @@ export const CapacityGraphTooltip: React.FC<{ tooltipSelection?: string }> = ({
           Maximum store size{" "}
           {tooltipSelection || "across all nodes / on node <node>"}. This value
           may be explicitly set per node using&nbsp;
-          <Anchor href={docsURL.clusterStore}>--store</Anchor>. If a store size
-          has not been set, this metric displays the actual disk capacity.
+          <Anchor href={docsURL.clusterStore} className={"anchor-light"}>
+            --store
+          </Anchor>
+          . If a store size has not been set, this metric displays the actual
+          disk capacity.
         </p>
         <p>
           <strong>Available: </strong>
@@ -41,7 +44,10 @@ export const CapacityGraphTooltip: React.FC<{ tooltipSelection?: string }> = ({
           files.
         </p>
         <p>
-          <Anchor href={docsURL.howAreCapacityMetricsCalculated}>
+          <Anchor
+            href={docsURL.howAreCapacityMetricsCalculated}
+            className={"anchor-light"}
+          >
             How are these metrics calculated?
           </Anchor>
         </p>
@@ -56,7 +62,10 @@ export const AvailableDiscCapacityGraphTooltip: React.FC<{}> = () => (
       <dd>
         <p>Free disk space available to CockroachDB data on each node.</p>
         <p>
-          <Anchor href={docsURL.howAreCapacityMetricsCalculated}>
+          <Anchor
+            href={docsURL.howAreCapacityMetricsCalculated}
+            className={"anchor-light"}
+          >
             How is this metric calculated?
           </Anchor>
         </p>
@@ -71,7 +80,9 @@ export const LogicalBytesGraphTooltip: React.FC = () => (
       <dd>
         <p>
           {"Number of logical bytes stored in "}
-          <Anchor href={docsURL.keyValuePairs}>key-value pairs</Anchor>
+          <Anchor href={docsURL.keyValuePairs} className={"anchor-light"}>
+            key-value pairs
+          </Anchor>
           {" on each node."}
         </p>
         <p>This includes historical and deleted data.</p>
@@ -93,14 +104,16 @@ export const LiveBytesGraphTooltip: React.FC<{ tooltipSelection?: string }> = ({
         <p>
           <strong>Live: </strong>
           Number of logical bytes stored in live&nbsp;
-          <Anchor href={docsURL.keyValuePairs}>key-value pairs&nbsp;</Anchor>
+          <Anchor href={docsURL.keyValuePairs} className={"anchor-light"}>
+            key-value pairs&nbsp;
+          </Anchor>
           {tooltipSelection || "across all nodes / on node <node>"}. Live data
           excludes historical and deleted data.
         </p>
         <p>
           <strong>System: </strong>
           Number of physical bytes stored in&nbsp;
-          <Anchor href={docsURL.keyValuePairs}>
+          <Anchor href={docsURL.keyValuePairs} className={"anchor-light"}>
             system key-value pairs&nbsp;
           </Anchor>
           {tooltipSelection || "across all nodes / on node <node>"}.
@@ -115,7 +128,10 @@ export const StatementDenialsClusterSettingsTooltip: React.FC<{
 }> = ({ tooltipSelection }) => (
   <div>
     The total number of statements denied per second {tooltipSelection} due to a
-    <Anchor href={docsURL.clusterSettings}> cluster setting </Anchor>
+    <Anchor href={docsURL.clusterSettings} className={"anchor-light"}>
+      {" "}
+      cluster setting{" "}
+    </Anchor>
     in the format feature.statement_type.enabled = FALSE.
   </div>
 );

--- a/pkg/ui/src/views/cluster/containers/nodesOverview/tooltips.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/tooltips.tsx
@@ -123,7 +123,7 @@ export const NodeCountTooltip: PlainTooltip = (props) => (
       </div>
     }
   >
-    {props.children}
+    <span className={"column-title"}>{props.children}</span>
   </Tooltip>
 );
 
@@ -137,7 +137,7 @@ export const UptimeTooltip: PlainTooltip = (props) => (
       </div>
     }
   >
-    {props.children}
+    <span className={"column-title"}>{props.children}</span>
   </Tooltip>
 );
 
@@ -151,7 +151,7 @@ export const ReplicasTooltip: PlainTooltip = (props) => (
       </div>
     }
   >
-    {props.children}
+    <span className={"column-title"}>{props.children}</span>
   </Tooltip>
 );
 
@@ -173,7 +173,7 @@ export const NodelistCapacityUsageTooltip: PlainTooltip = (props) => (
       </div>
     }
   >
-    {props.children}
+    <span className={"column-title"}>{props.children}</span>
   </Tooltip>
 );
 
@@ -190,7 +190,7 @@ export const MemoryUseTooltip: PlainTooltip = (props) => (
       </div>
     }
   >
-    {props.children}
+    <span className={"column-title"}>{props.children}</span>
   </Tooltip>
 );
 
@@ -204,7 +204,7 @@ export const CPUsTooltip: PlainTooltip = (props) => (
       </div>
     }
   >
-    {props.children}
+    <span className={"column-title"}>{props.children}</span>
   </Tooltip>
 );
 
@@ -218,7 +218,7 @@ export const VersionTooltip: PlainTooltip = (props) => (
       </div>
     }
   >
-    {props.children}
+    <span className={"column-title"}>{props.children}</span>
   </Tooltip>
 );
 
@@ -235,7 +235,7 @@ export const StatusTooltip: PlainTooltip = (props) => (
       </div>
     }
   >
-    {props.children}
+    <span className={"column-title"}>{props.children}</span>
   </Tooltip>
 );
 

--- a/pkg/ui/src/views/reports/containers/network/legend/index.tsx
+++ b/pkg/ui/src/views/reports/containers/network/legend/index.tsx
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import { Divider, Icon, Tooltip } from "antd";
+import { Divider, Tooltip } from "antd";
 import { Chip } from "src/views/app/components/chip";
 import Modal from "src/views/app/components/modal";
 import { getDisplayName } from "src/redux/nodes";
@@ -37,12 +37,11 @@ export const Legend: React.SFC<ILegendProps> = ({
   <div key="legend" className="Legend">
     <div className="Legend--container">
       <div className="Legend--container__head">
-        <h3 className="Legend--container__head--title">Standard Deviation</h3>
         <Tooltip
           placement="bottom"
           title="This legend represents the standard deviation of network latencies across all nodes in your cluster. It will help you understand if there are high latencies across nodes or regions."
         >
-          <Icon type="info-circle" className="info-icon" />
+          <h3 className="Legend--container__head--title">Standard Deviation</h3>
         </Tooltip>
       </div>
       <div className="Legend--container__body">
@@ -112,7 +111,14 @@ export const Legend: React.SFC<ILegendProps> = ({
           title={`No Connections (${noConnections.length})`}
           trigger={
             noConnections.length === 0 && (
-              <span>{`No Connections (${noConnections.length})`}</span>
+              <Tooltip
+                placement="bottom"
+                title="This legend represents the loss of a connection between nodes and will help you understand if there is a one-way partition in your cluster."
+              >
+                <span
+                  className={"underline"}
+                >{`No Connections (${noConnections.length})`}</span>
+              </Tooltip>
             )
           }
           triggerStyle="Legend--container__head--title color--link"
@@ -157,12 +163,6 @@ export const Legend: React.SFC<ILegendProps> = ({
             ))}
           </table>
         </Modal>
-        <Tooltip
-          placement="bottom"
-          title="This legend represents the loss of a connection between nodes and will help you understand if there is a one-way partition in your cluster."
-        >
-          <Icon type="info-circle" className="info-icon" />
-        </Tooltip>
       </div>
       <div className="Legend--container__body">
         <Chip title="--" type="yellow" />

--- a/pkg/ui/src/views/reports/containers/network/legend/legend.styl
+++ b/pkg/ui/src/views/reports/containers/network/legend/legend.styl
@@ -34,6 +34,7 @@
         line-height 1.17
         letter-spacing 1.5px
         margin 0
+        border-bottom 1px dashed $colors--neutral-5;
       .info-icon
         color $colors--neutral-5
         font-size 16px
@@ -52,6 +53,9 @@
         margin-bottom 1em
       &--label-suffix
         color $colors--neutral-5
+
+.underline
+  border-bottom 1px dashed $colors--neutral-5;
 
 .noConnections__table
   width 100%


### PR DESCRIPTION
Update tooltips to dotted underline on pages:
Statements, Transactions, Transaction Details, Sessions,
Overview, Metrics and Network Latency.

Resolves: https://github.com/cockroachdb/cockroach/issues/66871

A few examples:
<img width="225" alt="Screen Shot 2021-06-29 at 1 56 04 PM" src="https://user-images.githubusercontent.com/1017486/123845208-e966c600-d8e1-11eb-9231-7eccce3083b0.png">
<img width="333" alt="Screen Shot 2021-06-29 at 1 56 15 PM" src="https://user-images.githubusercontent.com/1017486/123845222-ed92e380-d8e1-11eb-861d-cffeb41ef7f8.png">
<img width="765" alt="Screen Shot 2021-06-29 at 1 56 24 PM" src="https://user-images.githubusercontent.com/1017486/123845237-f1bf0100-d8e1-11eb-8816-c807c23fcd06.png">
<img width="917" alt="Screen Shot 2021-06-29 at 1 56 33 PM" src="https://user-images.githubusercontent.com/1017486/123845244-f5528800-d8e1-11eb-96c4-383147f8b42d.png">


Release note (ui change): Use gotted underline on text that contains tooltip
and remove and 'i' icon.