### PR TITLE
sql: match SampleAggregator MinSampleSize to Sampler MinSampleSize

### DIFF
--- a/pkg/sql/distsql_plan_stats.go
+++ b/pkg/sql/distsql_plan_stats.go
@@ -214,8 +214,7 @@ func (dsp *DistSQLPlanner) createStatsPlan(
 		Sketches:         sketchSpecs,
 		InvertedSketches: invSketchSpecs,
 		SampleSize:       sampler.SampleSize,
-		// This could be anything >= 2 to produce a histogram.
-		MinSampleSize:    defaultHistogramBuckets,
+		MinSampleSize:    sampler.MinSampleSize,
 		SampledColumnIDs: sampledColumnIDs,
 		TableID:          desc.GetID(),
 		JobID:            jobID,


### PR DESCRIPTION
(I noticed this while backporting 9afb59c302bc79bce6f469cfd72a6b7059bcdf82.)

In 9afb59c302bc79bce6f469cfd72a6b7059bcdf82 we added dynamic shrinking
of histogram resolution to stay within memory limits, down to a minimum
sample size. This minimum sample size was always set to a constant for
SampleAggregator, but instead it should match the Sampler setting.

Release note: None