### PR TITLE
sql: support dropping expression indexes

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -230,8 +230,16 @@ func (n *alterTableNode) startExec(params runParams) error {
 
 				// Check if the columns exist on the table.
 				for _, column := range d.Columns {
-					if _, err := n.tableDesc.FindColumnWithName(column.Column); err != nil {
+					col, err := n.tableDesc.FindColumnWithName(column.Column)
+					if err != nil {
 						return err
+					}
+					if col.IsInaccessible() {
+						return pgerror.Newf(
+							pgcode.UndefinedColumn,
+							"column %q is inaccessible and cannot be referenced by a unique constraint",
+							column.Column,
+						)
 					}
 				}
 				// If the index is named, ensure that the name is unique.

--- a/pkg/sql/catalog/descpb/BUILD.bazel
+++ b/pkg/sql/catalog/descpb/BUILD.bazel
@@ -26,6 +26,8 @@ go_library(
         "//pkg/security",
         "//pkg/sql/catalog/catconstants",
         "//pkg/sql/parser",
+        "//pkg/sql/pgwire/pgcode",
+        "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/privilege",
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",

--- a/pkg/sql/catalog/schemaexpr/column.go
+++ b/pkg/sql/catalog/schemaexpr/column.go
@@ -263,6 +263,10 @@ func replaceColumnVars(
 			return false, nil, pgerror.Newf(pgcode.UndefinedColumn,
 				"column %q does not exist, referenced in %q", c.ColumnName, rootExpr.String())
 		}
+		if col.IsInaccessible() {
+			return false, nil, pgerror.Newf(pgcode.UndefinedColumn,
+				"column %q is inaccessible and cannot be referenced", c.ColumnName)
+		}
 		colIDs.Add(col.GetID())
 
 		// Convert to a dummyColumn of the correct type.

--- a/pkg/sql/logictest/testdata/logic_test/expression_index
+++ b/pkg/sql/logictest/testdata/logic_test/expression_index
@@ -45,6 +45,38 @@ CREATE TABLE public.t (
    FAMILY fam_0_k_a_b_c_j (k, a, b, c, j)
 )
 
+# Referencing an inaccessible column in a CHECK constraint is not allowed.
+statement error column \"crdb_internal_idx_expr_4\" is inaccessible and cannot be referenced
+ALTER TABLE t ADD CONSTRAINT err CHECK (crdb_internal_idx_expr_4 > 0)
+
+# Referencing an inaccessible column in a UNIQUE constraint is not allowed.
+statement error column \"crdb_internal_idx_expr_4\" is inaccessible and cannot be referenced by a unique constraint
+ALTER TABLE t ADD CONSTRAINT err UNIQUE (crdb_internal_idx_expr_4)
+
+# Referencing an inaccessible column in a computed column expression is not
+# allowed.
+statement error column \"crdb_internal_idx_expr_4\" is inaccessible and cannot be referenced in a computed column expression
+ALTER TABLE t ADD COLUMN err INT AS (crdb_internal_idx_expr_4 + 10) STORED
+
+# Referencing an inaccessible column in an index is not allowed.
+statement error column \"crdb_internal_idx_expr_4\" is inaccessible and cannot be indexed
+CREATE INDEX err ON t (crdb_internal_idx_expr_4)
+
+# Referencing an inaccessible column in a partial index predicate expression is
+# not allowed.
+statement error column \"crdb_internal_idx_expr_4\" is inaccessible and cannot be referenced
+CREATE INDEX err ON t (a) WHERE crdb_internal_idx_expr_4 > 0
+
+# Referencing an inaccessible column in a FK is not allowed.
+statement error column \"crdb_internal_idx_expr_4\" is inaccessible and cannot be referenced by a foreign key
+CREATE TABLE child (a INT REFERENCES t(crdb_internal_idx_expr_4))
+
+statement ok
+CREATE TABLE child (a INT)
+
+statement error column \"crdb_internal_idx_expr_4\" is inaccessible and cannot be referenced by a foreign key
+ALTER TABLE child ADD CONSTRAINT err FOREIGN KEY (a) REFERENCES t(crdb_internal_idx_expr_4)
+
 statement error volatile functions are not allowed in index element
 CREATE INDEX err ON t ((a + random()::INT))
 

--- a/pkg/sql/logictest/testdata/logic_test/expression_index
+++ b/pkg/sql/logictest/testdata/logic_test/expression_index
@@ -27,6 +27,9 @@ CREATE INDEX t_lower_c_a_plus_b_idx ON t (lower(c), (a + b))
 statement ok
 CREATE INDEX t_a_plus_ten_idx ON t ((a + 10))
 
+statement ok
+CREATE INDEX t_a_plus_ten_a_plus_ten_idx ON t ((a + 10), (a + 10))
+
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE t]
 ----
@@ -42,6 +45,7 @@ CREATE TABLE public.t (
    INDEX t_lower_c_idx (lower(c) ASC),
    INDEX t_lower_c_a_plus_b_idx (lower(c) ASC, (a + b) ASC),
    INDEX t_a_plus_ten_idx ((a + 10:::INT8) ASC),
+   INDEX t_a_plus_ten_a_plus_ten_idx ((a + 10:::INT8) ASC, (a + 10:::INT8) ASC),
    FAMILY fam_0_k_a_b_c_j (k, a, b, c, j)
 )
 
@@ -76,6 +80,51 @@ CREATE TABLE child (a INT)
 
 statement error column \"crdb_internal_idx_expr_4\" is inaccessible and cannot be referenced by a foreign key
 ALTER TABLE child ADD CONSTRAINT err FOREIGN KEY (a) REFERENCES t(crdb_internal_idx_expr_4)
+
+# Adding a column with the same name as one of the inaccessible columns created
+# for an expression index is not allowed.
+statement error column \"crdb_internal_idx_expr_4\" of relation \"t\" already exists
+ALTER TABLE t ADD COLUMN crdb_internal_idx_expr_4 INT
+
+query T
+SELECT * FROM (
+  SELECT json_array_elements(
+    crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', descriptor, false)->'table'->'columns'
+  ) AS desc FROM system.descriptor WHERE id = 't'::REGCLASS
+) AS cols WHERE cols.desc->'name' = '"crdb_internal_idx_expr_4"'
+----
+{"computeExpr": "a + 10:::INT8", "id": 11, "inaccessible": true, "name": "crdb_internal_idx_expr_4", "nullable": true, "type": {"family": "IntFamily", "oid": 20, "width": 64}, "virtual": true}
+
+statement ok
+DROP INDEX t_a_plus_ten_idx
+
+# Verify that the inaccessible column created for t_a_plus_ten_idx no longer
+# exists in the descriptor.
+query T
+SELECT * FROM (
+  SELECT json_array_elements(
+    crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', descriptor, false)->'table'->'columns'
+  ) AS desc FROM system.descriptor WHERE id = 't'::REGCLASS
+) AS cols WHERE cols.desc->'name' = '"crdb_internal_idx_expr_4"'
+----
+
+statement ok
+DROP INDEX t_a_plus_ten_a_plus_ten_idx
+
+# Verify that the inaccessible columns created for t_a_plus_ten_a_plus_b_idx no
+# longer exists in the descriptor.
+query T
+SELECT * FROM (
+  SELECT json_array_elements(
+    crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', descriptor, false)->'table'->'columns'
+  ) AS desc FROM system.descriptor WHERE id = 't'::REGCLASS
+) AS cols WHERE cols.desc->'name' IN ('"crdb_internal_idx_expr_5"', '"crdb_internal_idx_expr_6"')
+----
+
+# Adding a column with the same name as one of the inaccessible columns created
+# for an expression index is allowed after the index has been dropped.
+statement ok
+ALTER TABLE t ADD COLUMN crd_internal_idx_expr_4 INT
 
 statement error volatile functions are not allowed in index element
 CREATE INDEX err ON t ((a + random()::INT))

--- a/pkg/sql/pgwire/testdata/pgtest/notice
+++ b/pkg/sql/pgwire/testdata/pgtest/notice
@@ -55,7 +55,7 @@ Query {"String": "DROP INDEX t_x_idx"}
 until crdb_only
 CommandComplete
 ----
-{"Severity":"NOTICE","SeverityUnlocalized":"","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":530,"Routine":"dropIndexByName","UnknownFields":null}
+{"Severity":"NOTICE","SeverityUnlocalized":"","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":574,"Routine":"dropIndexByName","UnknownFields":null}
 {"Type":"CommandComplete","CommandTag":"DROP INDEX"}
 
 until noncrdb_only


### PR DESCRIPTION
#### sql: disallow references to inaccessible columns

This commit ensures that inaccessible columns cannot be referenced in
`CHECK` constraints, `UNIQUE` constraints, computed column expressions,
indexes, partial index predicate expressions, and foreign keys.

Release note: None

#### sql: drop inaccessible columns when expression indexes are dropped

Any inaccessible columns created by the system for an expression index
are now dropped when the index is dropped.

There is no release note because expression-based indexes are not
enabled by default. They will be enabled when they are fully supported.

Release note: None
