### PR TITLE
bazel: add toolchain for cross-compiling to linux on aarch64

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -22,3 +22,5 @@ build:crosswindows --platforms=//build/toolchains:cross_windows
 build:crosswindows --crosstool_top=@toolchain_cross_x86_64-w64-mingw32//:suite
 build:crossmacos --platforms=//build/toolchains:cross_macos
 build:crossmacos --crosstool_top=@toolchain_cross_x86_64-apple-darwin19//:suite
+build:crosslinuxarm --platforms=//build/toolchains:cross_linux_arm
+build:crosslinuxarm --crosstool_top=@toolchain_cross_aarch64-unknown-linux-gnu//:suite

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -181,6 +181,7 @@ toolchain_dependencies()
 
 register_toolchains(
     "//build/toolchains:cross_linux_toolchain",
+    "//build/toolchains:cross_linux_arm_toolchain",
     "//build/toolchains:cross_macos_toolchain",
     "//build/toolchains:cross_windows_toolchain",
 )

--- a/build/teamcity-bazel-arm-build.sh
+++ b/build/teamcity-bazel-arm-build.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source "$(dirname "${0}")/teamcity-support.sh"  # For $root
+source "$(dirname "${0}")/teamcity-bazel-support.sh"  # For run_bazel
+
+tc_prepare
+
+tc_start_block "Run Bazel build"
+run_bazel build/bazelutil/bazelbuild.sh crosslinuxarm
+tc_end_block "Run Bazel build"

--- a/build/toolchains/BUILD.bazel
+++ b/build/toolchains/BUILD.bazel
@@ -63,3 +63,25 @@ platform(
         "@platforms//cpu:x86_64",
     ],
 )
+
+toolchain(
+    name = "cross_linux_arm_toolchain",
+    exec_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+    target_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:arm64",
+    ],
+    toolchain = "@toolchain_cross_aarch64-unknown-linux-gnu//:toolchain",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+)
+
+platform(
+    name = "cross_linux_arm",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:arm64",
+    ],
+)

--- a/c-deps/BUILD.bazel
+++ b/c-deps/BUILD.bazel
@@ -12,6 +12,7 @@ configure_make(
     ] + select({
         "@io_bazel_rules_go//go/platform:windows": ["--host=x86_64-w64-mingw32"],
         "@io_bazel_rules_go//go/platform:darwin": ["--host=x86_64-apple-darwin19"],
+        "@io_bazel_rules_go//go/platform:linux_arm64": ["--host=aarch64-unknown-linux-gnu"],
         "//conditions:default": [],
     }),
     lib_source = "@jemalloc//:all",


### PR DESCRIPTION
This is just another `crosstool-ng` toolchain, so we use all the
pre-existing stuff added in b782105503fb47bc06d37001fb7e3ef7894c7ca9.

Release note: None