### PR TITLE
build: install 2 go versions on TeamCity agents

### DIFF
--- a/build/packer/teamcity-agent.sh
+++ b/build/packer/teamcity-agent.sh
@@ -49,6 +49,15 @@ b12c23023b68de22f74c0524f10b753e7b08b1504cb7e417eccebdd3fae49061 /tmp/go.tgz
 EOF
 tar -C /usr/local -zxf /tmp/go.tgz && rm /tmp/go.tgz
 
+# Install the older version in parallel in order to run the acceptance test on older branches
+# TODO: Remove this when 21.1 is EOL
+curl -fsSL https://dl.google.com/go/go1.15.11.linux-amd64.tar.gz > /tmp/go_old.tgz
+sha256sum -c - <<EOF
+8825b72d74b14e82b54ba3697813772eb94add3abf70f021b6bdebe193ed01ec /tmp/go_old.tgz
+EOF
+mkdir -p /usr/local/go1.15
+tar -C /usr/local/go1.15 --strip-components=1 -zxf /tmp/go_old.tgz && rm /tmp/go_old.tgz
+
 # Explicitly symlink the pinned version to /usr/bin.
 for f in `ls /usr/local/go/bin`; do
     ln -s /usr/local/go/bin/$f /usr/bin


### PR DESCRIPTION
Previously, to run the acceptance test we compiled the test binary using
the go version from the builder docker image, which depends on the
branch. TeamCity agents have only one version installed and with the go
1.16 upgrade it caused some issues. See #66977 for the details.

This patch installs 2 go versions in parallel. The older version is
installed in a location which is not added to `PATH` and has to be
called using its absolute path.

Release note: None