### PR TITLE
build: use go1.15 for acceptance test

### DIFF
--- a/build/teamcity-acceptance.sh
+++ b/build/teamcity-acceptance.sh
@@ -41,7 +41,15 @@ tc_start_block "Run acceptance tests"
 #
 # Note that ./pkg/acceptance without the tag is an empty test package, so it's fine to compile
 # outside of builder.
-run_json_test env TZ=America/New_York stdbuf -eL -oL go test \
+go=go
+# Use older version of Go on the agent in case it's installed. See
+# https://github.com/cockroachdb/cockroach/issues/66977 for the details.
+if [ -x /usr/local/go1.15/bin/go ]; then
+  go=/usr/local/go1.15/bin/go
+  echo "WARN: using previous version of Go from $go"
+fi
+
+run_json_test env TZ=America/New_York stdbuf -eL -oL $go test \
   -mod=vendor -json -timeout 30m -v \
 	-exec "../../build/teamcity-go-test-precompiled.sh ./pkg/acceptance/acceptance.test" ./pkg/acceptance \
 	-l "$TMPDIR"


### PR DESCRIPTION
Previously, to run the acceptance test we compiled the test binary using
the go version from the builder docker image, which depends on the
branch. TeamCity agents have only one version installed and with the go
1.16 upgrade it caused some issues. See #66977 for the details.

This patch uses absolute path to the go binary to run the acceptance
test in case it is installed on the agent.

Release note: None