### PR TITLE
bench/rttanalysis: give Truncate one more rtt of leeway

### DIFF
--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -72,11 +72,11 @@ exp,benchmark
 1,SystemDatabaseQueries/select_system.users_with_empty_database_name
 1,SystemDatabaseQueries/select_system.users_with_schema_name
 2,SystemDatabaseQueries/select_system.users_without_schema_name
-26,Truncate/truncate_1_column_0_rows
-26,Truncate/truncate_1_column_1_row
-26,Truncate/truncate_1_column_2_rows
-26,Truncate/truncate_2_column_0_rows
-26,Truncate/truncate_2_column_1_rows
-26,Truncate/truncate_2_column_2_rows
+26-27,Truncate/truncate_1_column_0_rows
+26-27,Truncate/truncate_1_column_1_row
+26-27,Truncate/truncate_1_column_2_rows
+26-27,Truncate/truncate_2_column_0_rows
+26-27,Truncate/truncate_2_column_1_rows
+26-27,Truncate/truncate_2_column_2_rows
 1,VirtualTableQueries/select_crdb_internal.invalid_objects_with_1_fk
 1,VirtualTableQueries/select_crdb_internal.tables_with_1_fk


### PR DESCRIPTION
I don't know what round-trip is "extra". In #66839 we see one extra RTT.
Maybe it has to do with the range cache. Honestly, don't know. Just want to
get this off my plate.

Fixes #66839.

Release note: None