### PR TITLE
release-20.2: sql: shrink SampleReservoir capacity on memory exhaustion

### DIFF
--- a/pkg/sql/distsql_plan_stats.go
+++ b/pkg/sql/distsql_plan_stats.go
@@ -34,7 +34,7 @@ import (
 type requestedStat struct {
 	columns             []descpb.ColumnID
 	histogram           bool
-	histogramMaxBuckets int
+	histogramMaxBuckets uint32
 	name                string
 	inverted            bool
 }
@@ -107,7 +107,7 @@ func (dsp *DistSQLPlanner) createStatsPlan(
 		spec := execinfrapb.SketchSpec{
 			SketchType:          execinfrapb.SketchType_HLL_PLUS_PLUS_V1,
 			GenerateHistogram:   s.histogram,
-			HistogramMaxBuckets: uint32(s.histogramMaxBuckets),
+			HistogramMaxBuckets: s.histogramMaxBuckets,
 			Columns:             make([]uint32, len(s.columns)),
 			StatName:            s.name,
 		}
@@ -238,9 +238,9 @@ func (dsp *DistSQLPlanner) createPlanForCreateStats(
 	histogramCollectionEnabled := stats.HistogramClusterMode.Get(&dsp.st.SV)
 	for i := 0; i < len(reqStats); i++ {
 		histogram := details.ColumnStats[i].HasHistogram && histogramCollectionEnabled
-		histogramMaxBuckets := defaultHistogramBuckets
+		var histogramMaxBuckets uint32 = defaultHistogramBuckets
 		if details.ColumnStats[i].HistogramMaxBuckets > 0 {
-			histogramMaxBuckets = int(details.ColumnStats[i].HistogramMaxBuckets)
+			histogramMaxBuckets = details.ColumnStats[i].HistogramMaxBuckets
 		}
 		reqStats[i] = requestedStat{
 			columns:             details.ColumnStats[i].ColumnIDs,

--- a/pkg/sql/execinfrapb/processors_table_stats.pb.go
+++ b/pkg/sql/execinfrapb/processors_table_stats.pb.go
@@ -64,7 +64,7 @@ func (x *SketchType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (SketchType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_table_stats_c04eac705a3f9235, []int{0}
+	return fileDescriptor_processors_table_stats_63ed6e1c0410997c, []int{0}
 }
 
 // SketchSpec contains the specification for a generated statistic.
@@ -89,7 +89,7 @@ func (m *SketchSpec) Reset()         { *m = SketchSpec{} }
 func (m *SketchSpec) String() string { return proto.CompactTextString(m) }
 func (*SketchSpec) ProtoMessage()    {}
 func (*SketchSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_table_stats_c04eac705a3f9235, []int{0}
+	return fileDescriptor_processors_table_stats_63ed6e1c0410997c, []int{0}
 }
 func (m *SketchSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -152,9 +152,10 @@ var xxx_messageInfo_SketchSpec proto.InternalMessageInfo
 //       - a BYTE column of the inverted index key.
 //
 // There are four row types produced:
-//   1. sample rows, using column group #1.
+//   1. sample rows, using column group #1 and the numRows column from #2.
 //   2. sketch rows, using column group #2.
-//   3. inverted sample rows, using column group #3 and the rank column from #1.
+//   3. inverted sample rows, using column group #3, the rank column from #1,
+//      and numRows column from #2.
 //   4. inverted sketch rows, using column group #2 and first column from #3.
 //
 // Rows have NULLs on either all the sampled row columns or on all the
@@ -178,7 +179,7 @@ func (m *SamplerSpec) Reset()         { *m = SamplerSpec{} }
 func (m *SamplerSpec) String() string { return proto.CompactTextString(m) }
 func (*SamplerSpec) ProtoMessage()    {}
 func (*SamplerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_table_stats_c04eac705a3f9235, []int{1}
+	return fileDescriptor_processors_table_stats_63ed6e1c0410997c, []int{1}
 }
 func (m *SamplerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -243,7 +244,7 @@ func (m *SampleAggregatorSpec) Reset()         { *m = SampleAggregatorSpec{} }
 func (m *SampleAggregatorSpec) String() string { return proto.CompactTextString(m) }
 func (*SampleAggregatorSpec) ProtoMessage()    {}
 func (*SampleAggregatorSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_table_stats_c04eac705a3f9235, []int{2}
+	return fileDescriptor_processors_table_stats_63ed6e1c0410997c, []int{2}
 }
 func (m *SampleAggregatorSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1287,10 +1288,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("sql/execinfrapb/processors_table_stats.proto", fileDescriptor_processors_table_stats_c04eac705a3f9235)
+	proto.RegisterFile("sql/execinfrapb/processors_table_stats.proto", fileDescriptor_processors_table_stats_63ed6e1c0410997c)
 }
 
-var fileDescriptor_processors_table_stats_c04eac705a3f9235 = []byte{
+var fileDescriptor_processors_table_stats_63ed6e1c0410997c = []byte{
 	// 695 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xc4, 0x54, 0xcd, 0x6e, 0xdb, 0x46,
 	0x10, 0x16, 0xf5, 0x63, 0xc9, 0xab, 0xaa, 0x95, 0x59, 0x17, 0x20, 0x7c, 0xa0, 0x58, 0xd5, 0x2d,

--- a/pkg/sql/execinfrapb/processors_table_stats.proto
+++ b/pkg/sql/execinfrapb/processors_table_stats.proto
@@ -90,9 +90,10 @@ message SketchSpec {
 //       - a BYTE column of the inverted index key.
 //
 // There are four row types produced:
-//   1. sample rows, using column group #1.
+//   1. sample rows, using column group #1 and the numRows column from #2.
 //   2. sketch rows, using column group #2.
-//   3. inverted sample rows, using column group #3 and the rank column from #1.
+//   3. inverted sample rows, using column group #3, the rank column from #1,
+//      and numRows column from #2.
 //   4. inverted sketch rows, using column group #2 and first column from #3.
 //
 // Rows have NULLs on either all the sampled row columns or on all the

--- a/pkg/sql/rowexec/processors.go
+++ b/pkg/sql/rowexec/processors.go
@@ -226,13 +226,18 @@ func NewProcessor(
 		if err := checkNumInOut(inputs, outputs, 1, 1); err != nil {
 			return nil, err
 		}
-		return newSamplerProcessor(flowCtx, processorID, core.Sampler, inputs[0], post, outputs[0])
+		return newSamplerProcessor(
+			flowCtx, processorID, core.Sampler, defaultMinSampleSize, inputs[0], post, outputs[0],
+		)
 	}
 	if core.SampleAggregator != nil {
 		if err := checkNumInOut(inputs, outputs, 1, 1); err != nil {
 			return nil, err
 		}
-		return newSampleAggregator(flowCtx, processorID, core.SampleAggregator, inputs[0], post, outputs[0])
+		return newSampleAggregator(
+			flowCtx, processorID, core.SampleAggregator, defaultMinSampleSize, inputs[0], post,
+			outputs[0],
+		)
 	}
 	if core.ReadImport != nil {
 		if err := checkNumInOut(inputs, outputs, 0, 1); err != nil {

--- a/pkg/sql/rowexec/sample_aggregator.go
+++ b/pkg/sql/rowexec/sample_aggregator.go
@@ -86,6 +86,7 @@ func newSampleAggregator(
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
 	spec *execinfrapb.SampleAggregatorSpec,
+	minSampleSize int,
 	input execinfra.RowSource,
 	post *execinfrapb.PostProcessSpec,
 	output execinfra.RowReceiver,
@@ -144,14 +145,16 @@ func newSampleAggregator(
 		}
 	}
 
-	s.sr.Init(int(spec.SampleSize), input.OutputTypes()[:rankCol], &s.memAcc, sampleCols)
+	s.sr.Init(
+		int(spec.SampleSize), minSampleSize, input.OutputTypes()[:rankCol], &s.memAcc, sampleCols,
+	)
 	for i := range spec.InvertedSketches {
 		var sr stats.SampleReservoir
 		// The datums are converted to their inverted index bytes and
 		// sent as a single DBytes column.
 		var srCols util.FastIntSet
 		srCols.Add(0)
-		sr.Init(int(spec.SampleSize), bytesRowType, &s.memAcc, srCols)
+		sr.Init(int(spec.SampleSize), minSampleSize, bytesRowType, &s.memAcc, srCols)
 		col := spec.InvertedSketches[i].Columns[0]
 		s.invSr[col] = &sr
 		s.invSketch[col] = &sketchInfo{
@@ -387,6 +390,7 @@ func (s *sampleAggregator) maybeDecreaseSamples(
 func (s *sampleAggregator) sampleRow(
 	ctx context.Context, sr *stats.SampleReservoir, sampleRow rowenc.EncDatumRow, rank uint64,
 ) error {
+	prevCapacity := sr.Cap()
 	if err := sr.SampleRow(ctx, s.EvalCtx, sampleRow, rank); err != nil {
 		if code := pgerror.GetPGCode(err); code != pgcode.OutOfMemory {
 			return err
@@ -396,6 +400,11 @@ func (s *sampleAggregator) sampleRow(
 		sr.Disable()
 		log.Info(ctx, "disabling histogram collection due to excessive memory utilization")
 		telemetry.Inc(sqltelemetry.StatsHistogramOOMCounter)
+	} else if sr.Cap() != prevCapacity {
+		log.Infof(
+			ctx, "histogram samples reduced from %d to %d due to excessive memory utilization",
+			prevCapacity, sr.Cap(),
+		)
 	}
 	return nil
 }

--- a/pkg/sql/rowexec/sample_aggregator_test.go
+++ b/pkg/sql/rowexec/sample_aggregator_test.go
@@ -124,7 +124,8 @@ func runSampleAggregator(
 			SampleSize: childNumSamples, Sketches: sketchSpecs,
 		}
 		p, err := newSamplerProcessor(
-			&flowCtx, 0 /* processorID */, spec, in, &execinfrapb.PostProcessSpec{}, outputs[i],
+			&flowCtx, 0 /* processorID */, spec, defaultMinSampleSize, in, &execinfrapb.PostProcessSpec{},
+			outputs[i],
 		)
 		if err != nil {
 			t.Fatal(err)
@@ -157,7 +158,8 @@ func runSampleAggregator(
 	}
 
 	agg, err := newSampleAggregator(
-		&flowCtx, 0 /* processorID */, spec, samplerResults, &execinfrapb.PostProcessSpec{}, finalOut,
+		&flowCtx, 0 /* processorID */, spec, defaultMinSampleSize, samplerResults,
+		&execinfrapb.PostProcessSpec{}, finalOut,
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/sql/rowexec/sample_aggregator_test.go
+++ b/pkg/sql/rowexec/sample_aggregator_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
@@ -35,6 +36,228 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
 
+type resultBucket struct {
+	numEq, numRange, upper int
+}
+
+type result struct {
+	tableID                            int
+	name, colIDs                       string
+	rowCount, distinctCount, nullCount int
+	buckets                            []resultBucket
+}
+
+// runSampleAggregator runs a full distsql sampling flow on a canned set of
+// input rows, and checks that the generated stats match what we expect.
+func runSampleAggregator(
+	t *testing.T,
+	server serverutils.TestServerInterface,
+	sqlDB *gosql.DB,
+	kvDB *kv.DB,
+	st *cluster.Settings,
+	evalCtx *tree.EvalContext,
+	memLimitBytes int64,
+	expectOutOfMemory bool,
+	childNumSamples, aggNumSamples uint32,
+	maxBuckets, expectedMaxBuckets uint32,
+	inputRows [][]int,
+	expected []result,
+) {
+	flowCtx := execinfra.FlowCtx{
+		EvalCtx: evalCtx,
+		Cfg: &execinfra.ServerConfig{
+			Settings: st,
+			DB:       kvDB,
+			Executor: server.InternalExecutor().(sqlutil.InternalExecutor),
+			Gossip:   gossip.MakeOptionalGossip(server.GossipI().(*gossip.Gossip)),
+		},
+	}
+	// Override the default memory limit. If memLimitBytes is small but
+	// non-zero, the processor will hit this limit and disable sampling.
+	flowCtx.Cfg.TestingKnobs.MemoryLimitBytes = memLimitBytes
+
+	// We randomly distribute the input rows between multiple Samplers and
+	// aggregate the results.
+	numSamplers := 3
+
+	samplerOutTypes := []*types.T{
+		types.Int,   // original column
+		types.Int,   // original column
+		types.Int,   // rank
+		types.Int,   // sketch index
+		types.Int,   // num rows
+		types.Int,   // null vals
+		types.Bytes, // sketch data
+		types.Int,   // inverted index column
+		types.Bytes, // inverted index data
+	}
+
+	sketchSpecs := []execinfrapb.SketchSpec{
+		{
+			SketchType:        execinfrapb.SketchType_HLL_PLUS_PLUS_V1,
+			Columns:           []uint32{0},
+			GenerateHistogram: false,
+			StatName:          "a",
+		},
+		{
+			SketchType:          execinfrapb.SketchType_HLL_PLUS_PLUS_V1,
+			Columns:             []uint32{1},
+			GenerateHistogram:   true,
+			HistogramMaxBuckets: maxBuckets,
+		},
+	}
+
+	rng, _ := randutil.NewPseudoRand()
+	rowPartitions := make([][][]int, numSamplers)
+	for _, row := range inputRows {
+		j := rng.Intn(numSamplers)
+		rowPartitions[j] = append(rowPartitions[j], row)
+	}
+
+	outputs := make([]*distsqlutils.RowBuffer, numSamplers)
+	for i := 0; i < numSamplers; i++ {
+		rows := rowenc.GenEncDatumRowsInt(rowPartitions[i])
+		in := distsqlutils.NewRowBuffer(rowenc.TwoIntCols, rows, distsqlutils.RowBufferArgs{})
+		outputs[i] = distsqlutils.NewRowBuffer(samplerOutTypes, nil /* rows */, distsqlutils.RowBufferArgs{})
+
+		spec := &execinfrapb.SamplerSpec{
+			SampleSize: childNumSamples, Sketches: sketchSpecs,
+		}
+		p, err := newSamplerProcessor(
+			&flowCtx, 0 /* processorID */, spec, in, &execinfrapb.PostProcessSpec{}, outputs[i],
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		p.Run(context.Background())
+	}
+	// Randomly interleave the output rows from the samplers into a single buffer.
+	samplerResults := distsqlutils.NewRowBuffer(samplerOutTypes, nil /* rows */, distsqlutils.RowBufferArgs{})
+	for len(outputs) > 0 {
+		i := rng.Intn(len(outputs))
+		row, meta := outputs[i].Next()
+		if meta != nil {
+			if meta.SamplerProgress == nil {
+				t.Fatalf("unexpected metadata: %v", meta)
+			}
+		} else if row == nil {
+			outputs = append(outputs[:i], outputs[i+1:]...)
+		} else {
+			samplerResults.Push(row, nil /* meta */)
+		}
+	}
+
+	// Now run the sample aggregator.
+	finalOut := distsqlutils.NewRowBuffer([]*types.T{}, nil /* rows*/, distsqlutils.RowBufferArgs{})
+	spec := &execinfrapb.SampleAggregatorSpec{
+		SampleSize:       aggNumSamples,
+		Sketches:         sketchSpecs,
+		SampledColumnIDs: []descpb.ColumnID{100, 101},
+		TableID:          13,
+	}
+
+	agg, err := newSampleAggregator(
+		&flowCtx, 0 /* processorID */, spec, samplerResults, &execinfrapb.PostProcessSpec{}, finalOut,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	agg.Run(context.Background())
+	// Make sure there was no error.
+	finalOut.GetRowsNoMeta(t)
+	r := sqlutils.MakeSQLRunner(sqlDB)
+
+	rows := r.Query(t, `
+	  SELECT "tableID",
+					 "name",
+					 "columnIDs",
+					 "rowCount",
+					 "distinctCount",
+					 "nullCount",
+					 histogram
+	  FROM system.table_statistics
+  `)
+	defer rows.Close()
+
+	for _, exp := range expected {
+		if !rows.Next() {
+			t.Fatal("fewer rows than expected")
+		}
+		if expectOutOfMemory {
+			exp.buckets = nil
+		}
+
+		var histData []byte
+		var name gosql.NullString
+		var r result
+		if err := rows.Scan(
+			&r.tableID, &name, &r.colIDs, &r.rowCount, &r.distinctCount, &r.nullCount, &histData,
+		); err != nil {
+			t.Fatal(err)
+		}
+		if name.Valid {
+			r.name = name.String
+		} else {
+			r.name = "<NULL>"
+		}
+
+		if len(histData) > 0 {
+			var h stats.HistogramData
+			if err := protoutil.Unmarshal(histData, &h); err != nil {
+				t.Fatal(err)
+			}
+
+			for _, b := range h.Buckets {
+				ed, _, err := rowenc.EncDatumFromBuffer(
+					types.Int, descpb.DatumEncoding_ASCENDING_KEY, b.UpperBound,
+				)
+				if err != nil {
+					t.Fatal(err)
+				}
+				var d rowenc.DatumAlloc
+				if err := ed.EnsureDecoded(types.Int, &d); err != nil {
+					t.Fatal(err)
+				}
+				r.buckets = append(r.buckets, resultBucket{
+					numEq:    int(b.NumEq),
+					numRange: int(b.NumRange),
+					upper:    int(*ed.Datum.(*tree.DInt)),
+				})
+			}
+
+			// If we collected fewer samples than rows, the generated histogram will
+			// be nondeterministic. Rather than checking for an exact match, verify
+			// some properties and then ignore it.
+			if childNumSamples < uint32(len(inputRows)) || aggNumSamples < uint32(len(inputRows)) {
+				if uint32(len(r.buckets)) > expectedMaxBuckets {
+					t.Errorf("Expected at most %d buckets, got:\n  %v", expectedMaxBuckets, r)
+				}
+				var count int
+				for _, bucket := range r.buckets {
+					count += bucket.numEq + bucket.numRange
+				}
+				if count != r.rowCount-r.nullCount {
+					t.Errorf(
+						"Expected %d rows counted in histogram, got %d:\n  %v",
+						r.rowCount-r.nullCount, count, r,
+					)
+				}
+				r.buckets = nil
+				exp.buckets = nil
+			}
+		} else if len(exp.buckets) > 0 {
+			t.Error("no histogram")
+		}
+
+		if !reflect.DeepEqual(exp, r) {
+			t.Errorf("Expected:\n  %v\ngot:\n  %v", exp, r)
+		}
+	}
+	if rows.Next() {
+		t.Fatal("more rows than expected")
+	}
+}
+
 func TestSampleAggregator(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
@@ -45,231 +268,75 @@ func TestSampleAggregator(t *testing.T) {
 	evalCtx := tree.MakeTestingEvalContext(st)
 	defer evalCtx.Stop(context.Background())
 
-	runTest := func(memLimitBytes int64, expectOutOfMemory bool) {
-		flowCtx := execinfra.FlowCtx{
-			EvalCtx: &evalCtx,
-			Cfg: &execinfra.ServerConfig{
-				Settings: st,
-				DB:       kvDB,
-				Executor: server.InternalExecutor().(sqlutil.InternalExecutor),
-				Gossip:   gossip.MakeOptionalGossip(server.GossipI().(*gossip.Gossip)),
-			},
-		}
-		// Override the default memory limit. If memLimitBytes is small but
-		// non-zero, the processor will hit this limit and disable sampling.
-		flowCtx.Cfg.TestingKnobs.MemoryLimitBytes = memLimitBytes
-
-		inputRows := [][]int{
-			{-1, 1},
-			{1, 1},
-			{2, 2},
-			{1, 3},
-			{2, 4},
-			{1, 5},
-			{2, 6},
-			{1, 7},
-			{2, 8},
-			{-1, 3},
-			{1, -1},
-		}
-
-		// We randomly distribute the input rows between multiple Samplers and
-		// aggregate the results.
-		numSamplers := 3
-
-		samplerOutTypes := []*types.T{
-			types.Int,   // original column
-			types.Int,   // original column
-			types.Int,   // rank
-			types.Int,   // sketch index
-			types.Int,   // num rows
-			types.Int,   // null vals
-			types.Bytes, // sketch data
-			types.Int,   // inverted index column
-			types.Bytes, // inverted index data
-		}
-
-		sketchSpecs := []execinfrapb.SketchSpec{
-			{
-				SketchType:        execinfrapb.SketchType_HLL_PLUS_PLUS_V1,
-				Columns:           []uint32{0},
-				GenerateHistogram: false,
-				StatName:          "a",
-			},
-			{
-				SketchType:          execinfrapb.SketchType_HLL_PLUS_PLUS_V1,
-				Columns:             []uint32{1},
-				GenerateHistogram:   true,
-				HistogramMaxBuckets: 4,
-			},
-		}
-
-		rng, _ := randutil.NewPseudoRand()
-		rowPartitions := make([][][]int, numSamplers)
-		for _, row := range inputRows {
-			j := rng.Intn(numSamplers)
-			rowPartitions[j] = append(rowPartitions[j], row)
-		}
-
-		outputs := make([]*distsqlutils.RowBuffer, numSamplers)
-		for i := 0; i < numSamplers; i++ {
-			rows := rowenc.GenEncDatumRowsInt(rowPartitions[i])
-			in := distsqlutils.NewRowBuffer(rowenc.TwoIntCols, rows, distsqlutils.RowBufferArgs{})
-			outputs[i] = distsqlutils.NewRowBuffer(samplerOutTypes, nil /* rows */, distsqlutils.RowBufferArgs{})
-
-			spec := &execinfrapb.SamplerSpec{SampleSize: 100, Sketches: sketchSpecs}
-			p, err := newSamplerProcessor(
-				&flowCtx, 0 /* processorID */, spec, in, &execinfrapb.PostProcessSpec{}, outputs[i],
-			)
-			if err != nil {
-				t.Fatal(err)
-			}
-			p.Run(context.Background())
-		}
-		// Randomly interleave the output rows from the samplers into a single buffer.
-		samplerResults := distsqlutils.NewRowBuffer(samplerOutTypes, nil /* rows */, distsqlutils.RowBufferArgs{})
-		for len(outputs) > 0 {
-			i := rng.Intn(len(outputs))
-			row, meta := outputs[i].Next()
-			if meta != nil {
-				if meta.SamplerProgress == nil {
-					t.Fatalf("unexpected metadata: %v", meta)
-				}
-			} else if row == nil {
-				outputs = append(outputs[:i], outputs[i+1:]...)
-			} else {
-				samplerResults.Push(row, nil /* meta */)
-			}
-		}
-
-		// Now run the sample aggregator.
-		finalOut := distsqlutils.NewRowBuffer([]*types.T{}, nil /* rows*/, distsqlutils.RowBufferArgs{})
-		spec := &execinfrapb.SampleAggregatorSpec{
-			SampleSize:       100,
-			Sketches:         sketchSpecs,
-			SampledColumnIDs: []descpb.ColumnID{100, 101},
-			TableID:          13,
-		}
-
-		agg, err := newSampleAggregator(
-			&flowCtx, 0 /* processorID */, spec, samplerResults, &execinfrapb.PostProcessSpec{}, finalOut,
-		)
-		if err != nil {
-			t.Fatal(err)
-		}
-		agg.Run(context.Background())
-		// Make sure there was no error.
-		finalOut.GetRowsNoMeta(t)
-		r := sqlutils.MakeSQLRunner(sqlDB)
-
-		rows := r.Query(t, `
-	  SELECT "tableID",
-					 "name",
-					 "columnIDs",
-					 "rowCount",
-					 "distinctCount",
-					 "nullCount",
-					 histogram
-	  FROM system.table_statistics
-  `)
-		defer rows.Close()
-
-		type resultBucket struct {
-			numEq, numRange, upper int
-		}
-
-		type result struct {
-			tableID                            int
-			name, colIDs                       string
-			rowCount, distinctCount, nullCount int
-			buckets                            []resultBucket
-		}
-
-		expected := []result{
-			{
-				tableID:       13,
-				name:          "a",
-				colIDs:        "{100}",
-				rowCount:      11,
-				distinctCount: 3,
-				nullCount:     2,
-			},
-			{
-				tableID:       13,
-				name:          "<NULL>",
-				colIDs:        "{101}",
-				rowCount:      11,
-				distinctCount: 9,
-				nullCount:     1,
-				buckets: []resultBucket{
-					{numEq: 2, numRange: 0, upper: 1},
-					{numEq: 2, numRange: 1, upper: 3},
-					{numEq: 1, numRange: 1, upper: 5},
-					{numEq: 1, numRange: 2, upper: 8},
-				},
-			},
-		}
-
-		for _, exp := range expected {
-			if !rows.Next() {
-				t.Fatal("fewer rows than expected")
-			}
-			if expectOutOfMemory {
-				exp.buckets = nil
-			}
-
-			var histData []byte
-			var name gosql.NullString
-			var r result
-			if err := rows.Scan(
-				&r.tableID, &name, &r.colIDs, &r.rowCount, &r.distinctCount, &r.nullCount, &histData,
-			); err != nil {
-				t.Fatal(err)
-			}
-			if name.Valid {
-				r.name = name.String
-			} else {
-				r.name = "<NULL>"
-			}
-
-			if len(histData) > 0 {
-				var h stats.HistogramData
-				if err := protoutil.Unmarshal(histData, &h); err != nil {
-					t.Fatal(err)
-				}
-
-				for _, b := range h.Buckets {
-					ed, _, err := rowenc.EncDatumFromBuffer(
-						types.Int, descpb.DatumEncoding_ASCENDING_KEY, b.UpperBound,
-					)
-					if err != nil {
-						t.Fatal(err)
-					}
-					var d rowenc.DatumAlloc
-					if err := ed.EnsureDecoded(types.Int, &d); err != nil {
-						t.Fatal(err)
-					}
-					r.buckets = append(r.buckets, resultBucket{
-						numEq:    int(b.NumEq),
-						numRange: int(b.NumRange),
-						upper:    int(*ed.Datum.(*tree.DInt)),
-					})
-				}
-			} else if len(exp.buckets) > 0 {
-				t.Error("no histogram")
-			}
-
-			if !reflect.DeepEqual(exp, r) {
-				t.Errorf("Expected:\n  %v\ngot:\n  %v", exp, r)
-			}
-		}
-		if rows.Next() {
-			t.Fatal("more rows than expected")
-		}
+	type sampAggTestCase struct {
+		memLimitBytes                  int64
+		expectOutOfMemory              bool
+		childNumSamples, aggNumSamples uint32
+		maxBuckets, expectedMaxBuckets uint32
 	}
 
-	runTest(0 /* memLimitBytes */, false /* expectOutOfMemory */)
-	runTest(1 /* memLimitBytes */, true /* expectOutOfMemory */)
-	runTest(20 /* memLimitBytes */, true /* expectOutOfMemory */)
-	runTest(20*1024 /* memLimitBytes */, false /* expectOutOfMemory */)
+	inputRows := [][]int{
+		{-1, 1},
+		{1, 1},
+		{2, 2},
+		{1, 3},
+		{2, 4},
+		{1, 5},
+		{2, 6},
+		{1, 7},
+		{2, 8},
+		{-1, 3},
+		{1, -1},
+	}
+
+	expected := []result{
+		{
+			tableID:       13,
+			name:          "a",
+			colIDs:        "{100}",
+			rowCount:      11,
+			distinctCount: 3,
+			nullCount:     2,
+		},
+		{
+			tableID:       13,
+			name:          "<NULL>",
+			colIDs:        "{101}",
+			rowCount:      11,
+			distinctCount: 9,
+			nullCount:     1,
+			buckets: []resultBucket{
+				{numEq: 2, numRange: 0, upper: 1},
+				{numEq: 2, numRange: 1, upper: 3},
+				{numEq: 1, numRange: 1, upper: 5},
+				{numEq: 1, numRange: 2, upper: 8},
+			},
+		},
+	}
+
+	for _, tc := range []sampAggTestCase{
+		// Sample all rows, check that stats match expected results exactly except
+		// with histograms disabled in cases when stats collection hits the memory
+		// limit.
+		{0, false, 100, 100, 4, 4},
+		{1 << 0, true, 100, 100, 4, 4},
+		{1 << 4, true, 100, 100, 4, 4},
+		{1 << 15, false, 100, 100, 4, 4},
+
+		// Sample some rows, check that stats match expected results except for
+		// histograms, which are nondeterministic. Only check the number of buckets
+		// and the number of rows counted by the histogram. This also tests that
+		// sampleAggregator can dynamically shrink capacity if fed from a
+		// lower-capacity samplerProcessor.
+		{0, false, 2, 2, 2, 2},
+		{0, false, 2, 2, 4, 2},
+		{0, false, 100, 2, 4, 2},
+		{0, false, 2, 100, 4, 2},
+	} {
+		runSampleAggregator(
+			t, server, sqlDB, kvDB, st, &evalCtx, tc.memLimitBytes, tc.expectOutOfMemory,
+			tc.childNumSamples, tc.aggNumSamples, tc.maxBuckets, tc.expectedMaxBuckets,
+			inputRows, expected,
+		)
+	}
 }

--- a/pkg/sql/rowexec/sampler_test.go
+++ b/pkg/sql/rowexec/sampler_test.go
@@ -26,9 +26,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
-// runSampler runs the sampler aggregator on numRows and returns numSamples rows.
+// runSampler runs the samplerProcessor on numRows and returns numSamples rows.
 func runSampler(
-	t *testing.T, numRows, numSamples int, memLimitBytes int64, expectOutOfMemory bool,
+	t *testing.T,
+	numRows, numSamples, minNumSamples, expectedSamples int,
+	memLimitBytes int64,
+	expectOutOfMemory bool,
 ) []int {
 	rows := make([]rowenc.EncDatumRow, numRows)
 	for i := range rows {
@@ -75,18 +78,17 @@ func runSampler(
 		SampleSize: uint32(numSamples),
 	}
 	p, err := newSamplerProcessor(
-		&flowCtx, 0 /* processorID */, spec, in, &execinfrapb.PostProcessSpec{}, out,
+		&flowCtx, 0 /* processorID */, spec, minNumSamples, in, &execinfrapb.PostProcessSpec{}, out,
 	)
 	if err != nil {
 		t.Fatal(err)
 	}
 	p.Run(context.Background())
 
-	// Verify we have numSamples distinct rows.
+	// Verify we have expectedSamples distinct rows.
 	res := make([]int, 0, numSamples)
 	seen := make(map[tree.DInt]bool)
 	histogramDisabled := false
-	n := 0
 	for {
 		row, meta := out.Next()
 		if meta != nil {
@@ -116,43 +118,49 @@ func runSampler(
 		}
 		seen[v] = true
 		res = append(res, int(v))
-		n++
 	}
 	if expectOutOfMemory {
 		if !histogramDisabled {
 			t.Fatal("expected processor to disable histogram collection")
 		}
-	} else if n != numSamples {
-		t.Fatalf("expected %d rows, got %d", numSamples, n)
+	} else if histogramDisabled {
+		t.Fatal("processor unexpectedly disabled histogram collection")
+	} else if len(res) != expectedSamples {
+		t.Fatalf("expected %d rows, got %d", expectedSamples, len(res))
 	}
 	return res
 }
 
-func TestSampler(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	// We run many samplings and record the frequencies.
-	numRows := 100
-	numSamples := 20
+// checkSamplerDistribution runs the sampler many times over the same input and
+// verifies that the distribution of samples approaches a uniform distribution.
+func checkSamplerDistribution(
+	t *testing.T,
+	numRows, numSamples, minNumSamples, expectedSamples int,
+	memLimitBytes int64,
+	expectOutOfMemory bool,
+) {
 	minRuns := 200
 	maxRuns := 5000
 	delta := 0.5
+	totalSamples := 0
 
 	freq := make([]int, numRows)
 	var err error
 	// Instead of doing maxRuns and checking at the end, we do minRuns at a time
-	// and exit early. This speeds up the test.
+	// and exit as soon as the distribution is uniform enough. This speeds up the
+	// test.
 	for r := 0; r < maxRuns; r += minRuns {
 		for i := 0; i < minRuns; i++ {
 			for _, v := range runSampler(
-				t, numRows, numSamples, 0 /* memLimitBytes */, false, /* expectOutOfMemory */
+				t, numRows, numSamples, minNumSamples, expectedSamples, memLimitBytes, expectOutOfMemory,
 			) {
 				freq[v]++
+				totalSamples++
 			}
 		}
 
-		// The expected frequency of each row is f = numRuns * (numSamples / numRows).
-		f := float64(r) * float64(numSamples) / float64(numRows)
+		// The expected frequency of each row is totalSamples / numRows.
+		f := float64(totalSamples) / float64(numRows)
 
 		// Verify that no frequency is outside of the range (f / (1+delta), f * (1+delta));
 		// the probability of a given row violating this is subject to the Chernoff
@@ -168,18 +176,61 @@ func TestSampler(t *testing.T) {
 			return
 		}
 	}
+	// The distribution failed to become uniform enough after maxRuns.
 	t.Error(err)
+}
+
+type testCase struct {
+	numRows, numSamples, minNumSamples, expectedSamples int
+	memLimit                                            int64
+	expectOutOfMemory                                   bool
+}
+
+func TestSampler(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	for _, tc := range []testCase{
+		// Check distribution when capacity is held steady.
+		{100, 20, 20, 20, 0, false},
+		// Check distribution when capacity shrinks due to hitting memory limit.
+		{1000, 200, 20, 64, 1 << 14, false},
+	} {
+		checkSamplerDistribution(
+			t, tc.numRows, tc.numSamples, tc.minNumSamples, tc.expectedSamples, tc.memLimit,
+			tc.expectOutOfMemory,
+		)
+	}
 }
 
 func TestSamplerMemoryLimit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	numRows := 100
-	numSamples := 20
 
-	runSampler(t, numRows, numSamples, 0 /* memLimitBytes */, false /* expectOutOfMemory */)
-	runSampler(t, numRows, numSamples, 1 /* memLimitBytes */, true /* expectOutOfMemory */)
-	runSampler(t, numRows, numSamples, 20 /* memLimitBytes */, true /* expectOutOfMemory */)
-	runSampler(t, numRows, numSamples, 20*1024 /* memLimitBytes */, false /* expectOutOfMemory */)
+	for _, tc := range []testCase{
+		// While holding numSamples and minNumSamples fixed, increase the memory
+		// limit until we no longer hit it.
+		{100, 20, 2, 20, 0, false},
+		{100, 20, 2, 0, 1 << 0, true},
+		{100, 20, 2, 0, 1 << 1, true},
+		{100, 20, 2, 0, 1 << 4, true},
+		{100, 20, 2, 0, 1 << 8, true},
+		{100, 20, 2, 20, 1 << 14, false},
+
+		// Same as above, but 10x larger population to check dynamic shrinking.
+		{1000, 200, 20, 0, 1 << 13, true},
+		{1000, 200, 20, 64, 1 << 14, false},
+		{1000, 200, 20, 200, 1 << 15, false},
+
+		// While holding the memory limit fixed, decrease minNumSamples until we no
+		// longer hit the memory limit.
+		{1000, 200, 100, 0, 1 << 14, true},
+		{1000, 200, 75, 0, 1 << 14, true},
+		{1000, 200, 50, 64, 1 << 14, false},
+	} {
+		runSampler(
+			t, tc.numRows, tc.numSamples, tc.minNumSamples, tc.expectedSamples, tc.memLimit,
+			tc.expectOutOfMemory,
+		)
+	}
 }
 
 func TestSamplerSketch(t *testing.T) {
@@ -251,7 +302,10 @@ func TestSamplerSketch(t *testing.T) {
 			},
 		},
 	}
-	p, err := newSamplerProcessor(&flowCtx, 0 /* processorID */, spec, in, &execinfrapb.PostProcessSpec{}, out)
+	p, err := newSamplerProcessor(
+		&flowCtx, 0 /* processorID */, spec, defaultMinSampleSize, in, &execinfrapb.PostProcessSpec{},
+		out,
+	)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/stats/row_sampling_test.go
+++ b/pkg/sql/stats/row_sampling_test.go
@@ -13,6 +13,7 @@ package stats
 import (
 	"context"
 	"fmt"
+	"math"
 	"reflect"
 	"sort"
 	"testing"
@@ -22,19 +23,32 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
 
 // runSampleTest feeds rows with the given ranks through a reservoir
 // of a given size and verifies the results are correct.
-func runSampleTest(t *testing.T, evalCtx *tree.EvalContext, numSamples int, ranks []int) {
+func runSampleTest(
+	t *testing.T,
+	evalCtx *tree.EvalContext,
+	numSamples, expectedNumSamples int,
+	ranks []int,
+	memAcc *mon.BoundAccount,
+) {
 	ctx := context.Background()
 	var sr SampleReservoir
-	sr.Init(numSamples, []*types.T{types.Int}, nil /* memAcc */, util.MakeFastIntSet(0))
+	sr.Init(numSamples, 1, []*types.T{types.Int}, memAcc, util.MakeFastIntSet(0))
 	for _, r := range ranks {
 		d := rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(r)))
+		prevCapacity := sr.Cap()
 		if err := sr.SampleRow(ctx, evalCtx, rowenc.EncDatumRow{d}, uint64(r)); err != nil {
-			t.Errorf("%v", err)
+			t.Fatal(err)
+		} else if sr.Cap() != prevCapacity {
+			t.Logf(
+				"samples reduced from %d to %d during SampleRow",
+				prevCapacity, sr.Cap(),
+			)
 		}
 	}
 	samples := sr.Get()
@@ -51,12 +65,12 @@ func runSampleTest(t *testing.T, evalCtx *tree.EvalContext, numSamples int, rank
 		sampledRanks[i] = int(s.Rank)
 	}
 
-	// Verify the top ranks made it.
+	// Verify that the top (smallest) ranks made it.
 	sort.Ints(sampledRanks)
 	expected := append([]int(nil), ranks...)
 	sort.Ints(expected)
-	if len(expected) > numSamples {
-		expected = expected[:numSamples]
+	if len(expected) > expectedNumSamples {
+		expected = expected[:expectedNumSamples]
 	}
 	if !reflect.DeepEqual(expected, sampledRanks) {
 		t.Errorf("invalid ranks: %v vs %v", sampledRanks, expected)
@@ -64,7 +78,10 @@ func runSampleTest(t *testing.T, evalCtx *tree.EvalContext, numSamples int, rank
 }
 
 func TestSampleReservoir(t *testing.T) {
-	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+
 	for _, n := range []int{10, 100, 1000, 10000} {
 		rng, _ := randutil.NewPseudoRand()
 		ranks := make([]int, n)
@@ -72,9 +89,34 @@ func TestSampleReservoir(t *testing.T) {
 			ranks[i] = rng.Int()
 		}
 		for _, k := range []int{1, 5, 10, 100} {
-			t.Run(fmt.Sprintf("%d/%d", n, k), func(t *testing.T) {
-				runSampleTest(t, &evalCtx, k, ranks)
+			t.Run(fmt.Sprintf("n=%d/k=%d/mem=nolimit", n, k), func(t *testing.T) {
+				runSampleTest(t, &evalCtx, k, k, ranks, nil)
 			})
+			for _, mem := range []int64{1 << 8, 1 << 10, 1 << 12} {
+				t.Run(fmt.Sprintf("n=%d/k=%d/mem=%d", n, k, mem), func(t *testing.T) {
+					monitor := mon.NewMonitorWithLimit(
+						"test-monitor",
+						mon.MemoryResource,
+						mem,
+						nil,
+						nil,
+						1,
+						math.MaxInt64,
+						st,
+					)
+					monitor.Start(ctx, nil, mon.MakeStandaloneBudget(math.MaxInt64))
+					memAcc := monitor.MakeBoundAccount()
+					expectedK := k
+					if mem == 1<<8 && n > 1 && k > 1 {
+						expectedK = 1
+					} else if mem == 1<<10 && n > 10 && k > 10 {
+						expectedK = 6
+					} else if mem == 1<<12 && n > 10 && k > 10 {
+						expectedK = 25
+					}
+					runSampleTest(t, &evalCtx, k, expectedK, ranks, &memAcc)
+				})
+			}
 		}
 	}
 }


### PR DESCRIPTION
Backport 3/3 commits from #65491.

/cc @cockroachdb/release

***Backport note: execinfrapb changes were removed from the second commit to allow backporting without incrementing execinfrapb.Version. This means we are always using a hardcoded 200 as MinSampleSize instead of picking MinSampleSize based on MaxHistogramBuckets. For most stats this behavior is identical (MaxHistogramBuckets is usually 200). For stats on non-key columns MaxHistogramBuckets is 2, so when collecting those stats this will be slightly more strict about sample size than necessary. But it seems unlikely that we will hit the memory limit of 64 MiB at < 200 samples anyway.***

---
**sql, stats: shrink sampleAggregator capacity to match child capacity**

To avoid bias, sampleAggregator must always use a capacity <= the
capacity of each child samplerProcessor feeding it. This was always
implicitly true before, as every samplerProcessor and sampleAggregator
used the same fixed capacity. But the next few commits will give
sampleProcessors (and sampleAggregators) the ability to dynamically
shrink capacity when out of memory, meaning we now sometimes need to
resize sampleAggregator to keep this invariant true.

(Resizing sampleAggregator really means resizing the underlying
SampleReservoir, so most of the changes are there.)

This commit does not yet change any behavior, because the capacities of
samplerProcessors are still static. Next few commits will change that.

Also factor the giant closure out of TestSampleAggregator into an
external function, to make table-driven testing easier.

Release note: None

---
**sql, stats: shrink SampleReservoir capacity on memory exhaustion**

Fixes: #62206

Instead of returning an error when out of memory, make
SampleReservoir.SampleRow dynamically reduce capacity and retry. Fewer
samples will result in a less accurate histogram, but less accurate is
probably still better than no histogram at all, up to a point.

If the number of samples falls below a minimum threshold, then give up
and disable histogram collection, as we were doing originally, rather
than using a wildly inaccurate histogram.

Also fix some memory accounting in SampleReservoir.copyRow.

Release note (performance improvement): continue to generate histograms
when table statistics collection reaches memory limits, instead of
disabling histogram generation.

---
**sql, stats: shrink sampleAggregator capacity before histogram generation**

SampleAggregator can also run out of memory when gathering the datums
for histogram generation. Push this datum gathering down into
SampleReservoir so that we can use the same dynamic capacity-shrinking
strategy as used in SampleRow to reclaim some memory and try again.

Release note: None