### PR TITLE
kv: implement SafeFormatter for Table/Tenant roachpb.Key

### DIFF
--- a/pkg/keys/printer_test.go
+++ b/pkg/keys/printer_test.go
@@ -14,6 +14,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
+
 	"math"
 	"strconv"
 	"strings"
@@ -30,11 +31,40 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/keysutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
+	"github.com/stretchr/testify/require"
 )
 
 func lockTableKey(key roachpb.Key) roachpb.Key {
 	k, _ := keys.LockTableSingleKey(key, nil)
 	return k
+}
+
+func TestSafeFormatKey(t *testing.T) {
+	tenSysCodec := keys.SystemSQLCodec
+	ten5Codec := keys.MakeSQLCodec(roachpb.MakeTenantID(5))
+	testCases := []struct {
+		key roachpb.Key
+		exp string
+	}{
+		{roachpb.Key(makeKey(ten5Codec.TablePrefix(42),
+			roachpb.RKey(encoding.EncodeVarintAscending(nil, 1222)),
+			roachpb.RKey(encoding.EncodeStringAscending(nil, "handsome man")))), `/Tenant/5/Table/42/1222/‹"handsome man"›`},
+		{roachpb.Key(makeKey(tenSysCodec.TablePrefix(42),
+			roachpb.RKey(encoding.EncodeVarintAscending(nil, 1222)),
+			roachpb.RKey(encoding.EncodeStringAscending(nil, "handsome man")))), `/Table/42/1222/‹"handsome man"›`},
+		{keys.UserTableDataMin, "/Table/50"},
+		{roachpb.Key(tenSysCodec.IndexPrefix(42, 5)), "/Table/42/5"},
+		{makeKey(tenSysCodec.TablePrefix(42),
+			roachpb.RKey(encoding.EncodeNullAscending(nil))), "/Table/42/‹NULL›"},
+		{keys.SystemConfigSpan.Key, "/Table/SystemConfigSpan/Start"},
+	}
+
+	for i, test := range testCases {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			require.Equal(t, redact.RedactableString(test.exp), redact.Sprint(test.key))
+		})
+	}
 }
 
 func TestPrettyPrint(t *testing.T) {

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -394,8 +394,8 @@ func (r *Replica) adminSplitWithDescriptor(
 	}
 	extra += splitSnapshotWarningStr(r.RangeID, r.RaftStatus())
 
-	log.Infof(ctx, "initiating a split of this range at key %s [r%d] (%s)%s",
-		splitKey.StringWithDirs(nil /* valDirs */, 50 /* maxLen */), rightRangeID, reason, extra)
+	log.Infof(ctx, "initiating a split of this range at key %v [r%d] (%s)%s",
+		splitKey, rightRangeID, reason, extra)
 
 	if err := r.store.DB().Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 		return splitTxnAttempt(ctx, r.store, txn, rightRangeID, splitKey, args.ExpirationTime, desc)

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -75,11 +75,42 @@ var (
 	// encoding.go:prettyPrintFirstValue).
 	PrettyPrintKey func(valDirs []encoding.Direction, key Key) string
 
+	SafeFormatKey func(w redact.SafeWriter, key Key, opts KeyFormatOptions)
+
 	// PrettyPrintRange prints a key range in human readable format. It's
 	// implemented in package git.com/cockroachdb/cockroach/keys to avoid
 	// package circle import.
 	PrettyPrintRange func(start, end Key, maxChars int) string
 )
+
+// KeyFormatOptions contains fields for customizing the pretty printer formatting
+// of a Key.
+type KeyFormatOptions struct {
+	// Dirs correspond to the encoding direction of each encoded value in key.
+	// For example, table keys could have column values encoded in ascending or
+	// descending directions.
+	// If Dirs is nil, the default encoding direction for each value
+	// type is used (see encoding.go:prettyPrintFirstValue).
+	Dirs []encoding.Direction
+	// QuoteRaw toggle quotations around keys that don't match any prefix in
+	// keys.KeyDict.
+	QuoteRaw bool
+}
+
+// FormattedKey is a wrapper for Key to include formatting options.
+type FormattedKey struct {
+	Key
+	KeyFormatOptions
+}
+
+// SafeFormat implements the redact.SafeFormatter interface.
+func (k FormattedKey) SafeFormat(w redact.SafePrinter, r rune) {
+	SafeFormatKey(w, k.Key, k.KeyFormatOptions)
+}
+
+func (k FormattedKey) String() string {
+	return redact.StringWithoutMarkers(k)
+}
 
 // RKey denotes a Key whose local addressing has been accounted for.
 // A key can be transformed to an RKey by keys.Addr().
@@ -129,11 +160,21 @@ func (rk RKey) PrefixEnd() RKey {
 	return RKey(bytesPrefixEnd(rk))
 }
 
+// WithFormat - see Key.WithFormat
+func (rk RKey) WithFormat(dirs []encoding.Direction, quoteRaw bool) FormattedKey {
+	return Key(rk).WithFormat(dirs, quoteRaw)
+}
+
+// SafeFormat - see Key.SafeFormat.
+func (rk RKey) SafeFormat(w redact.SafePrinter, r rune) {
+	rk.AsRawKey().SafeFormat(w, r)
+}
+
 func (rk RKey) String() string {
 	return Key(rk).String()
 }
 
-// StringWithDirs - see Key.String.WithDirs.
+// StringWithDirs - see Key.StringWithDirs.
 func (rk RKey) StringWithDirs(valDirs []encoding.Direction, maxLen int) string {
 	return Key(rk).StringWithDirs(valDirs, maxLen)
 }
@@ -208,9 +249,24 @@ func (k Key) Compare(b Key) int {
 	return bytes.Compare(k, b)
 }
 
+// WithFormat wraps the key into a FormattedKey containing the formatting options.
+func (k Key) WithFormat(dirs []encoding.Direction, quoteRaw bool) FormattedKey {
+	return FormattedKey{k, KeyFormatOptions{dirs, quoteRaw}}
+}
+
+var DefaultKeyFormatOptions = KeyFormatOptions{
+	Dirs:     nil,
+	QuoteRaw: true,
+}
+
+// SafeFormat implements the redact.SafeFormatter interface.
+func (k Key) SafeFormat(w redact.SafePrinter, _ rune) {
+	SafeFormatKey(w, k, DefaultKeyFormatOptions)
+}
+
 // String returns a string-formatted version of the key.
 func (k Key) String() string {
-	return k.StringWithDirs(nil /* valDirs */, 0 /* maxLen */)
+	return redact.StringWithoutMarkers(k)
 }
 
 // StringWithDirs is the value encoding direction-aware version of String.

--- a/pkg/roachpb/tenant.go
+++ b/pkg/roachpb/tenant.go
@@ -65,6 +65,8 @@ func (t TenantID) String() string {
 	}
 }
 
+func (t TenantID) SafeValue() {}
+
 // Protects against zero value.
 func checkValid(id uint64) {
 	if id == 0 {

--- a/pkg/util/encoding/encoding.go
+++ b/pkg/util/encoding/encoding.go
@@ -70,7 +70,7 @@ const (
 	decimalPosMedium        = decimalPosSmall + 1
 	decimalPosLarge         = decimalPosMedium + 11
 	decimalInfinity         = decimalPosLarge + 1
-	decimalNaNDesc          = decimalInfinity + 1 // NaN encoded descendingly
+	decimalNaNDesc          = decimalInfinity + 1      // NaN encoded descendingly
 	decimalTerminator       = 0x00
 
 	jsonInvertedIndex = decimalNaNDesc + 1
@@ -115,7 +115,7 @@ const (
 
 	// IntMin is chosen such that the range of int tags does not overlap the
 	// ascii character set that is frequently used in testing.
-	IntMin      = 0x80 // 128
+	IntMin      = 0x80                           // 128
 	intMaxWidth = 8
 	intZero     = IntMin + intMaxWidth           // 136
 	intSmall    = IntMax - intZero - intMaxWidth // 109
@@ -1850,6 +1850,29 @@ func PrettyPrintValue(valDirs []Direction, b []byte, sep string) string {
 		}
 	}
 	return s1
+}
+
+// PrettyPrintValuesWithTypes returns a slice containing each contiguous decodable value
+// in the provided byte slice along with a slice containing the type of each value.
+func PrettyPrintValuesWithTypes(valDirs []Direction, b []byte) (vals []string, types []Type) {
+	for len(b) > 0 {
+		var valDir Direction
+		if len(valDirs) > 0 {
+			valDir = valDirs[0]
+			valDirs = valDirs[1:]
+		}
+
+		bb, s, err := prettyPrintFirstValue(valDir, b)
+		if err != nil {
+			vals = append(vals, "???")
+			types = append(types, Unknown)
+		} else {
+			vals = append(vals, s)
+			types = append(types, PeekType(b))
+		}
+		b = bb
+	}
+	return
 }
 
 func prettyPrintValueImpl(valDirs []Direction, b []byte, sep string) (string, bool) {


### PR DESCRIPTION
This patch introduces initial scaffolding for integrating log redaction into the existing pretty printer for keys.
It also adds support for Table and Tenant keys in the SafeFormatter implementation.

todo: add more comments

This resolves #66136.