### PR TITLE
sql: eagerly discard inbox/outbox memory

### DIFF
--- a/pkg/col/colserde/arrowbatchconverter.go
+++ b/pkg/col/colserde/arrowbatchconverter.go
@@ -330,6 +330,11 @@ func (c *ArrowBatchConverter) ArrowToBatch(
 		vec := b.ColVec(i)
 		d := data[i]
 
+		// Eagerly release our data references to make sure they can be collected
+		// as quickly as possible as we copy each (or simply reference each) by
+		// coldata.Vecs below.
+		data[i] = nil
+
 		switch typeconv.TypeFamilyToCanonicalTypeFamily(typ.Family()) {
 		case types.BoolFamily:
 			boolArr := array.NewBooleanData(d)

--- a/pkg/col/colserde/record_batch.go
+++ b/pkg/col/colserde/record_batch.go
@@ -93,6 +93,9 @@ func calculatePadding(numBytes int) int {
 // Serialize serializes data as an arrow RecordBatch message and writes it to w.
 // Serializing a schema that does not match the schema given in
 // NewRecordBatchSerializer results in undefined behavior.
+// Each element of the input data array is consumed to minimize memory waste,
+// so users who wish to retain references to individual array.Data elements must
+// do so by making a copy elsewhere.
 func (s *RecordBatchSerializer) Serialize(
 	w io.Writer, data []*array.Data, headerLength int,
 ) (metadataLen uint32, dataLen uint64, _ error) {
@@ -213,6 +216,8 @@ func (s *RecordBatchSerializer) Serialize(
 				return 0, 0, err
 			}
 		}
+		// Eagerly discard the buffer; we have no use for it any longer.
+		data[i] = nil
 	}
 
 	// Add body padding. The body also needs to be a multiple of 8 bytes.

--- a/pkg/col/colserde/record_batch_test.go
+++ b/pkg/col/colserde/record_batch_test.go
@@ -279,7 +279,8 @@ func TestRecordBatchSerializerSerializeDeserializeRandom(t *testing.T) {
 	// Run Serialize/Deserialize in a loop to test reuse.
 	for i := 0; i < 2; i++ {
 		buf.Reset()
-		_, _, err := s.Serialize(&buf, data, dataLen)
+		dataCopy := append([]*array.Data{}, data...)
+		_, _, err := s.Serialize(&buf, dataCopy, dataLen)
 		require.NoError(t, err)
 		if buf.Len()%8 != 0 {
 			t.Fatal("message length must align to 8 byte boundary")

--- a/pkg/sql/colflow/colrpc/inbox.go
+++ b/pkg/sql/colflow/colrpc/inbox.go
@@ -331,6 +331,8 @@ func (i *Inbox) Next() coldata.Batch {
 		atomic.AddInt64(&i.statsAtomics.bytesRead, int64(len(m.Data.RawBytes)))
 		i.scratch.data = i.scratch.data[:0]
 		batchLength, err := i.serializer.Deserialize(&i.scratch.data, m.Data.RawBytes)
+		// Eagerly throw away the RawBytes memory.
+		m.Data.RawBytes = nil
 		if err != nil {
 			colexecerror.InternalError(err)
 		}


### PR DESCRIPTION
Updates but doesn't close #67051 

This commit adds some eager release of memory during batch serialization
and deserialization, in cases where scratch buffers aren't useful any
longer.

Release note (performance improvement): vectorized flows can use less
memory when sending and receiving data to the network.