### PR TITLE
jobs/jobspb,sql/stats: move constant from stats to jobspb

### DIFF
--- a/pkg/jobs/jobspb/BUILD.bazel
+++ b/pkg/jobs/jobspb/BUILD.bazel
@@ -10,7 +10,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/sql/catalog/descpb",
-        "//pkg/sql/stats",
         "//pkg/storage/cloud",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_gogo_protobuf//jsonpb",

--- a/pkg/jobs/jobspb/wrap.go
+++ b/pkg/jobs/jobspb/wrap.go
@@ -16,7 +16,6 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/storage/cloud"
 	"github.com/cockroachdb/errors"
 	"github.com/gogo/protobuf/jsonpb"
@@ -59,6 +58,11 @@ func (p *Payload) Type() Type {
 	return DetailsType(p.Details)
 }
 
+// AutoStatsName is the name to use for statistics created automatically.
+// The name is chosen to be something that users are unlikely to choose when
+// running CREATE STATISTICS manually.
+const AutoStatsName = "__auto__"
+
 // DetailsType returns the type for a payload detail.
 func DetailsType(d isPayload_Details) Type {
 	switch d := d.(type) {
@@ -74,7 +78,7 @@ func DetailsType(d isPayload_Details) Type {
 		return TypeChangefeed
 	case *Payload_CreateStats:
 		createStatsName := d.CreateStats.Name
-		if createStatsName == stats.AutoStatsName {
+		if createStatsName == AutoStatsName {
 			return TypeAutoCreateStats
 		}
 		return TypeCreateStats

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -124,7 +124,7 @@ func (n *createStatsNode) startJob(ctx context.Context, resultsCh chan<- tree.Da
 		return err
 	}
 
-	if n.Name == stats.AutoStatsName {
+	if n.Name == jobspb.AutoStatsName {
 		// Don't start the job if there is already a CREATE STATISTICS job running.
 		// (To handle race conditions we check this again after the job starts,
 		// but this check is used to prevent creating a large number of jobs that
@@ -266,7 +266,7 @@ func (n *createStatsNode) makeJobRecord(ctx context.Context) (*jobs.Record, erro
 	statement := tree.AsStringWithFQNames(n, n.p.EvalContext().Annotations)
 	eventLogStatement := statement
 	var description string
-	if n.Name == stats.AutoStatsName {
+	if n.Name == jobspb.AutoStatsName {
 		// Use a user-friendly description for automatic statistics.
 		description = fmt.Sprintf("Table statistics refresh for %s", fqTableName)
 	} else {
@@ -495,7 +495,7 @@ var _ jobs.Resumer = &createStatsResumer{}
 func (r *createStatsResumer) Resume(ctx context.Context, execCtx interface{}) error {
 	p := execCtx.(JobExecContext)
 	details := r.job.Details().(jobspb.CreateStatsDetails)
-	if details.Name == stats.AutoStatsName {
+	if details.Name == jobspb.AutoStatsName {
 		// We want to make sure that an automatic CREATE STATISTICS job only runs if
 		// there are no other CREATE STATISTICS jobs running, automatic or manual.
 		if err := checkRunningJobs(ctx, r.job, p); err != nil {

--- a/pkg/sql/opt/testutils/opttester/BUILD.bazel
+++ b/pkg/sql/opt/testutils/opttester/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/build/bazel",
+        "//pkg/jobs/jobspb",
         "//pkg/roachpb",
         "//pkg/security",
         "//pkg/settings/cluster",

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/build/bazel"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -1893,7 +1894,7 @@ func (ot *OptTester) makeStat(
 	columns []string, rowCount, distinctCount, nullCount uint64,
 ) stats.JSONStatistic {
 	return stats.JSONStatistic{
-		Name: stats.AutoStatsName,
+		Name: jobspb.AutoStatsName,
 		CreatedAt: tree.AsStringWithFlags(
 			&tree.DTimestamp{Time: timeutil.Now()}, tree.FmtBareStrings,
 		),

--- a/pkg/sql/stats/BUILD.bazel
+++ b/pkg/sql/stats/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/gossip",
+        "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/kv",
         "//pkg/kv/kvclient/rangefeed",

--- a/pkg/sql/stats/automatic_stats_test.go
+++ b/pkg/sql/stats/automatic_stats_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed"
@@ -275,7 +276,7 @@ func TestAverageRefreshTime(t *testing.T) {
 			if err != nil {
 				return err
 			}
-			if err := insertStat(txn, AutoStatsName, columnIDsVal, createdAt); err != nil {
+			if err := insertStat(txn, jobspb.AutoStatsName, columnIDsVal, createdAt); err != nil {
 				return err
 			}
 		}
@@ -326,7 +327,7 @@ func TestAverageRefreshTime(t *testing.T) {
 			if err != nil {
 				return err
 			}
-			if err := insertStat(txn, AutoStatsName, columnIDsVal, createdAt); err != nil {
+			if err := insertStat(txn, jobspb.AutoStatsName, columnIDsVal, createdAt); err != nil {
 				return err
 			}
 		}

--- a/pkg/sql/stats/delete_stats.go
+++ b/pkg/sql/stats/delete_stats.go
@@ -13,6 +13,7 @@ package stats
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -64,7 +65,7 @@ func DeleteOldStatsForColumns(
                    LIMIT $4
                )`,
 		tableID,
-		AutoStatsName,
+		jobspb.AutoStatsName,
 		columnIDsVal,
 		keepCount,
 	)

--- a/pkg/sql/stats/delete_stats_test.go
+++ b/pkg/sql/stats/delete_stats_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed"
@@ -56,7 +57,7 @@ func TestDeleteOldStatsForColumns(t *testing.T) {
 		{
 			TableID:       descpb.ID(100),
 			StatisticID:   1,
-			Name:          AutoStatsName,
+			Name:          jobspb.AutoStatsName,
 			ColumnIDs:     []descpb.ColumnID{1},
 			CreatedAt:     timeutil.Now().Add(-1 * time.Hour),
 			RowCount:      1000,
@@ -66,7 +67,7 @@ func TestDeleteOldStatsForColumns(t *testing.T) {
 		{
 			TableID:       descpb.ID(100),
 			StatisticID:   2,
-			Name:          AutoStatsName,
+			Name:          jobspb.AutoStatsName,
 			ColumnIDs:     []descpb.ColumnID{1},
 			CreatedAt:     timeutil.Now().Add(-2 * time.Hour),
 			RowCount:      1000,
@@ -86,7 +87,7 @@ func TestDeleteOldStatsForColumns(t *testing.T) {
 		{
 			TableID:       descpb.ID(100),
 			StatisticID:   4,
-			Name:          AutoStatsName,
+			Name:          jobspb.AutoStatsName,
 			ColumnIDs:     []descpb.ColumnID{1},
 			CreatedAt:     timeutil.Now().Add(-4 * time.Hour),
 			RowCount:      1000,
@@ -96,7 +97,7 @@ func TestDeleteOldStatsForColumns(t *testing.T) {
 		{
 			TableID:       descpb.ID(100),
 			StatisticID:   5,
-			Name:          AutoStatsName,
+			Name:          jobspb.AutoStatsName,
 			ColumnIDs:     []descpb.ColumnID{1},
 			CreatedAt:     timeutil.Now().Add(-5 * time.Hour),
 			RowCount:      1000,
@@ -106,7 +107,7 @@ func TestDeleteOldStatsForColumns(t *testing.T) {
 		{
 			TableID:       descpb.ID(100),
 			StatisticID:   6,
-			Name:          AutoStatsName,
+			Name:          jobspb.AutoStatsName,
 			ColumnIDs:     []descpb.ColumnID{1},
 			CreatedAt:     timeutil.Now().Add(-6 * time.Hour),
 			RowCount:      1000,
@@ -116,7 +117,7 @@ func TestDeleteOldStatsForColumns(t *testing.T) {
 		{
 			TableID:       descpb.ID(100),
 			StatisticID:   7,
-			Name:          AutoStatsName,
+			Name:          jobspb.AutoStatsName,
 			ColumnIDs:     []descpb.ColumnID{2, 3},
 			CreatedAt:     timeutil.Now().Add(-7 * time.Hour),
 			RowCount:      1000,
@@ -126,7 +127,7 @@ func TestDeleteOldStatsForColumns(t *testing.T) {
 		{
 			TableID:       descpb.ID(100),
 			StatisticID:   8,
-			Name:          AutoStatsName,
+			Name:          jobspb.AutoStatsName,
 			ColumnIDs:     []descpb.ColumnID{2, 3},
 			CreatedAt:     timeutil.Now().Add(-8 * time.Hour),
 			RowCount:      1000,
@@ -146,7 +147,7 @@ func TestDeleteOldStatsForColumns(t *testing.T) {
 		{
 			TableID:       descpb.ID(100),
 			StatisticID:   10,
-			Name:          AutoStatsName,
+			Name:          jobspb.AutoStatsName,
 			ColumnIDs:     []descpb.ColumnID{2, 3},
 			CreatedAt:     timeutil.Now().Add(-10 * time.Hour),
 			RowCount:      1000,
@@ -156,7 +157,7 @@ func TestDeleteOldStatsForColumns(t *testing.T) {
 		{
 			TableID:       descpb.ID(100),
 			StatisticID:   11,
-			Name:          AutoStatsName,
+			Name:          jobspb.AutoStatsName,
 			ColumnIDs:     []descpb.ColumnID{2, 3},
 			CreatedAt:     timeutil.Now().Add(-11 * time.Hour),
 			RowCount:      1000,
@@ -166,7 +167,7 @@ func TestDeleteOldStatsForColumns(t *testing.T) {
 		{
 			TableID:       descpb.ID(100),
 			StatisticID:   12,
-			Name:          AutoStatsName,
+			Name:          jobspb.AutoStatsName,
 			ColumnIDs:     []descpb.ColumnID{2, 3},
 			CreatedAt:     timeutil.Now().Add(-12 * time.Hour),
 			RowCount:      1000,
@@ -176,7 +177,7 @@ func TestDeleteOldStatsForColumns(t *testing.T) {
 		{
 			TableID:       descpb.ID(100),
 			StatisticID:   13,
-			Name:          AutoStatsName,
+			Name:          jobspb.AutoStatsName,
 			ColumnIDs:     []descpb.ColumnID{2},
 			CreatedAt:     timeutil.Now().Add(-13 * time.Hour),
 			RowCount:      1000,
@@ -196,7 +197,7 @@ func TestDeleteOldStatsForColumns(t *testing.T) {
 		{
 			TableID:       descpb.ID(100),
 			StatisticID:   15,
-			Name:          AutoStatsName,
+			Name:          jobspb.AutoStatsName,
 			ColumnIDs:     []descpb.ColumnID{3, 2},
 			CreatedAt:     timeutil.Now().Add(-15 * time.Hour),
 			RowCount:      1000,
@@ -216,7 +217,7 @@ func TestDeleteOldStatsForColumns(t *testing.T) {
 		{
 			TableID:       descpb.ID(102),
 			StatisticID:   17,
-			Name:          AutoStatsName,
+			Name:          jobspb.AutoStatsName,
 			ColumnIDs:     []descpb.ColumnID{2, 3},
 			CreatedAt:     timeutil.Now().Add(-17 * time.Hour),
 			RowCount:      0,
@@ -315,7 +316,7 @@ func TestDeleteOldStatsForColumns(t *testing.T) {
 			if !reflect.DeepEqual(stat.ColumnIDs, columnIDs) {
 				continue
 			}
-			if stat.Name == AutoStatsName && keptStats < keepCount {
+			if stat.Name == jobspb.AutoStatsName && keptStats < keepCount {
 				keptStats++
 				continue
 			}


### PR DESCRIPTION
It seemed crazy for jobspb to depend on stats over this one string constant.

Release note: None