### PR TITLE
kv/kvserver: skip TestAdminRelocateRange

### DIFF
--- a/pkg/kv/kvserver/client_relocate_range_test.go
+++ b/pkg/kv/kvserver/client_relocate_range_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -153,6 +154,7 @@ func usesAtomicReplicationChange(ops []roachpb.ReplicationChange) bool {
 
 func TestAdminRelocateRange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 67031, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()


### PR DESCRIPTION
Refs: #67031

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None