### PR TITLE
opt: add test to ensure Metadata.CopyFrom makes copies of table metadata maps

### DIFF
--- a/pkg/sql/opt/metadata_test.go
+++ b/pkg/sql/opt/metadata_test.go
@@ -13,6 +13,7 @@ package opt_test
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -117,8 +118,20 @@ func TestMetadata(t *testing.T) {
 		t.Fatalf("expected constraints to be copied")
 	}
 
+	compColsPtr := reflect.ValueOf(tabMeta.ComputedCols).Pointer()
+	newCompColsPtr := reflect.ValueOf(tabMetaNew.ComputedCols).Pointer()
+	if newCompColsPtr == compColsPtr {
+		t.Fatalf("expected computed columns map to be copied, not shared")
+	}
+
 	if tabMetaNew.ComputedCols[cmpID] == scalar {
 		t.Fatalf("expected computed column expression to be copied")
+	}
+
+	partialIdxPredPtr := reflect.ValueOf(tabMeta.PartialIndexPredicatesUnsafe()).Pointer()
+	newPartialIdxPredPtr := reflect.ValueOf(tabMetaNew.PartialIndexPredicatesUnsafe()).Pointer()
+	if newPartialIdxPredPtr == partialIdxPredPtr {
+		t.Fatalf("expected partial index predicates map to be copied, not shared")
 	}
 
 	if tabMetaNew.PartialIndexPredicatesUnsafe()[0] == scalar {


### PR DESCRIPTION
This commit adds assertions to `TestMetadata` that ensure that
`Metadata.CopyFrom` makes copies of computed column expression maps and
parital index predicate maps in table metadata, rather than sharing the
same underlying map. These tests would have caught the bug that was
fixed in #66792.

Release note: None