### PR TITLE
Update Kubernetes Manifests to comment out liveness probe

### DIFF
--- a/cloud/kubernetes/bring-your-own-certs/cockroachdb-statefulset.yaml
+++ b/cloud/kubernetes/bring-your-own-certs/cockroachdb-statefulset.yaml
@@ -170,13 +170,14 @@ spec:
           name: grpc
         - containerPort: 8080
           name: http
-        livenessProbe:
-          httpGet:
-            path: "/health"
-            port: http
-            scheme: HTTPS
-          initialDelaySeconds: 30
-          periodSeconds: 5
+# We recommend that users don't configure liveness probes for production environments as it can impact availability of production databases.
+#        livenessProbe:
+#          httpGet:
+#            path: "/health"
+#            port: http
+#            scheme: HTTPS
+#          initialDelaySeconds: 30
+#          periodSeconds: 5
         readinessProbe:
           httpGet:
             path: "/health?ready=1"

--- a/cloud/kubernetes/bring-your-own-certs/cockroachdb-statefulset.yaml
+++ b/cloud/kubernetes/bring-your-own-certs/cockroachdb-statefulset.yaml
@@ -170,14 +170,14 @@ spec:
           name: grpc
         - containerPort: 8080
           name: http
-# We recommend that users don't configure liveness probes for production environments as it can impact availability of production databases.
-#        livenessProbe:
-#          httpGet:
-#            path: "/health"
-#            port: http
-#            scheme: HTTPS
-#          initialDelaySeconds: 30
-#          periodSeconds: 5
+# We recommend that you do not configure a liveness probe on a production environment, as this can impact the availability of production databases.
+#      livenessProbe:
+#        httpGet:
+#          path: "/health"
+#          port: http
+#          scheme: HTTPS
+#        initialDelaySeconds: 30
+#        periodSeconds: 5
         readinessProbe:
           httpGet:
             path: "/health?ready=1"

--- a/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
@@ -212,14 +212,14 @@ spec:
           name: grpc
         - containerPort: 8080
           name: http
-# We recommend that users don't configure liveness probes for production environments as it can impact availability of production databases.
-#        livenessProbe:
-#          httpGet:
-#            path: "/health"
-#            port: http
-#            scheme: HTTPS
-#          initialDelaySeconds: 30
-#          periodSeconds: 5
+# We recommend that you do not configure a liveness probe on a production environment, as this can impact the availability of production databases.
+#       livenessProbe:
+#         httpGet:
+#           path: "/health"
+#           port: http
+#           scheme: HTTPS
+#         initialDelaySeconds: 30
+#         periodSeconds: 5
         readinessProbe:
           httpGet:
             path: "/health?ready=1"

--- a/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
@@ -212,13 +212,14 @@ spec:
           name: grpc
         - containerPort: 8080
           name: http
-        livenessProbe:
-          httpGet:
-            path: "/health"
-            port: http
-            scheme: HTTPS
-          initialDelaySeconds: 30
-          periodSeconds: 5
+# We recommend that users don't configure liveness probes for production environments as it can impact availability of production databases.
+#        livenessProbe:
+#          httpGet:
+#            path: "/health"
+#            port: http
+#            scheme: HTTPS
+#          initialDelaySeconds: 30
+#          periodSeconds: 5
         readinessProbe:
           httpGet:
             path: "/health?ready=1"

--- a/cloud/kubernetes/cockroachdb-statefulset.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset.yaml
@@ -115,13 +115,13 @@ spec:
           name: grpc
         - containerPort: 8080
           name: http
-# We recommend that users don't configure liveness probes for production environments as it can impact availability of production databases.
-#        livenessProbe:
-#          httpGet:
-#            path: "/health"
-#            port: http
-#          initialDelaySeconds: 30
-#          periodSeconds: 5
+# We recommend that you do not configure a liveness probe on a production environment, as this can impact the availability of production databases.
+#       livenessProbe:
+#         httpGet:
+#           path: "/health"
+#           port: http
+#         initialDelaySeconds: 30
+#         periodSeconds: 5
         readinessProbe:
           httpGet:
             path: "/health?ready=1"

--- a/cloud/kubernetes/cockroachdb-statefulset.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset.yaml
@@ -115,12 +115,13 @@ spec:
           name: grpc
         - containerPort: 8080
           name: http
-        livenessProbe:
-          httpGet:
-            path: "/health"
-            port: http
-          initialDelaySeconds: 30
-          periodSeconds: 5
+# We recommend that users don't configure liveness probes for production environments as it can impact availability of production databases.
+#        livenessProbe:
+#          httpGet:
+#            path: "/health"
+#            port: http
+#          initialDelaySeconds: 30
+#          periodSeconds: 5
         readinessProbe:
           httpGet:
             path: "/health?ready=1"

--- a/cloud/kubernetes/multiregion/cockroachdb-statefulset-secure.yaml
+++ b/cloud/kubernetes/multiregion/cockroachdb-statefulset-secure.yaml
@@ -173,14 +173,14 @@ spec:
           name: grpc
         - containerPort: 8080
           name: http
-# We recommend that users don't configure liveness probes for production environments as it can impact availability of production databases.
-#        livenessProbe:
-#          httpGet:
-#            path: "/health"
-#            port: http
-#            scheme: HTTPS
-#          initialDelaySeconds: 30
-#          periodSeconds: 5
+# We recommend that you do not configure a liveness probe on a production environment, as this can impact the availability of production databases.
+#      livenessProbe:
+#        httpGet:
+#          path: "/health"
+#          port: http
+#          scheme: HTTPS
+#        initialDelaySeconds: 30
+#        periodSeconds: 5
         readinessProbe:
           httpGet:
             path: "/health?ready=1"

--- a/cloud/kubernetes/multiregion/cockroachdb-statefulset-secure.yaml
+++ b/cloud/kubernetes/multiregion/cockroachdb-statefulset-secure.yaml
@@ -173,13 +173,14 @@ spec:
           name: grpc
         - containerPort: 8080
           name: http
-        livenessProbe:
-          httpGet:
-            path: "/health"
-            port: http
-            scheme: HTTPS
-          initialDelaySeconds: 30
-          periodSeconds: 5
+# We recommend that users don't configure liveness probes for production environments as it can impact availability of production databases.
+#        livenessProbe:
+#          httpGet:
+#            path: "/health"
+#            port: http
+#            scheme: HTTPS
+#          initialDelaySeconds: 30
+#          periodSeconds: 5
         readinessProbe:
           httpGet:
             path: "/health?ready=1"

--- a/cloud/kubernetes/multiregion/eks/cockroachdb-statefulset-secure-eks.yaml
+++ b/cloud/kubernetes/multiregion/eks/cockroachdb-statefulset-secure-eks.yaml
@@ -202,13 +202,14 @@ spec:
           name: grpc
         - containerPort: 8080
           name: http
-        livenessProbe:
-          httpGet:
-            path: "/health"
-            port: http
-            scheme: HTTPS
-          initialDelaySeconds: 30
-          periodSeconds: 5
+# We recommend that users don't configure liveness probes for production environments as it can impact availability of production databases.
+#        livenessProbe:
+#          httpGet:
+#            path: "/health"
+#            port: http
+#            scheme: HTTPS
+#          initialDelaySeconds: 30
+#          periodSeconds: 5
         readinessProbe:
           httpGet:
             path: "/health?ready=1"

--- a/cloud/kubernetes/multiregion/eks/cockroachdb-statefulset-secure-eks.yaml
+++ b/cloud/kubernetes/multiregion/eks/cockroachdb-statefulset-secure-eks.yaml
@@ -202,14 +202,14 @@ spec:
           name: grpc
         - containerPort: 8080
           name: http
-# We recommend that users don't configure liveness probes for production environments as it can impact availability of production databases.
-#        livenessProbe:
-#          httpGet:
-#            path: "/health"
-#            port: http
-#            scheme: HTTPS
-#          initialDelaySeconds: 30
-#          periodSeconds: 5
+# We recommend that you do not configure a liveness probe on a production environment, as this can impact the availability of production databases.
+#       livenessProbe:
+#         httpGet:
+#           path: "/health"
+#           port: http
+#           scheme: HTTPS
+#         initialDelaySeconds: 30
+#         periodSeconds: 5
         readinessProbe:
           httpGet:
             path: "/health?ready=1"

--- a/cloud/kubernetes/performance/cockroachdb-daemonset-insecure.yaml
+++ b/cloud/kubernetes/performance/cockroachdb-daemonset-insecure.yaml
@@ -107,14 +107,14 @@ spec:
         - containerPort: 8080
           hostPort: 8080
           name: http
-# We recommend that users don't configure liveness probes for production environments as it can impact availability of production databases.
-#        livenessProbe:
-#          httpGet:
-#            path: "/health"
-#            port: http
-#            scheme: HTTP
-#          initialDelaySeconds: 30
-#          periodSeconds: 5
+# We recommend that you do not configure a liveness probe on a production environment, as this can impact the availability of production databases.
+#       livenessProbe:
+#         httpGet:
+#           path: "/health"
+#           port: http
+#           scheme: HTTP
+#         initialDelaySeconds: 30
+#         periodSeconds: 5
         readinessProbe:
           httpGet:
             path: "/health?ready=1"

--- a/cloud/kubernetes/performance/cockroachdb-daemonset-insecure.yaml
+++ b/cloud/kubernetes/performance/cockroachdb-daemonset-insecure.yaml
@@ -107,13 +107,14 @@ spec:
         - containerPort: 8080
           hostPort: 8080
           name: http
-        livenessProbe:
-          httpGet:
-            path: "/health"
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 30
-          periodSeconds: 5
+# We recommend that users don't configure liveness probes for production environments as it can impact availability of production databases.
+#        livenessProbe:
+#          httpGet:
+#            path: "/health"
+#            port: http
+#            scheme: HTTP
+#          initialDelaySeconds: 30
+#          periodSeconds: 5
         readinessProbe:
           httpGet:
             path: "/health?ready=1"

--- a/cloud/kubernetes/performance/cockroachdb-daemonset-secure.yaml
+++ b/cloud/kubernetes/performance/cockroachdb-daemonset-secure.yaml
@@ -223,14 +223,14 @@ spec:
         - containerPort: 8080
           hostPort: 8080
           name: http
-# We recommend that users don't configure liveness probes for production environments as it can impact availability of production databases.
-#        livenessProbe:
-#          httpGet:
-#            path: "/health"
-#            port: http
-#            scheme: HTTPS
-#          initialDelaySeconds: 30
-#          periodSeconds: 5
+# We recommend that you do not configure a liveness probe on a production environment, as this can impact the availability of production databases.
+#       livenessProbe:
+#         httpGet:
+#           path: "/health"
+#           port: http
+#           scheme: HTTPS
+#         initialDelaySeconds: 30
+#         periodSeconds: 5
         readinessProbe:
           httpGet:
             path: "/health?ready=1"

--- a/cloud/kubernetes/performance/cockroachdb-daemonset-secure.yaml
+++ b/cloud/kubernetes/performance/cockroachdb-daemonset-secure.yaml
@@ -223,13 +223,14 @@ spec:
         - containerPort: 8080
           hostPort: 8080
           name: http
-        livenessProbe:
-          httpGet:
-            path: "/health"
-            port: http
-            scheme: HTTPS
-          initialDelaySeconds: 30
-          periodSeconds: 5
+# We recommend that users don't configure liveness probes for production environments as it can impact availability of production databases.
+#        livenessProbe:
+#          httpGet:
+#            path: "/health"
+#            port: http
+#            scheme: HTTPS
+#          initialDelaySeconds: 30
+#          periodSeconds: 5
         readinessProbe:
           httpGet:
             path: "/health?ready=1"

--- a/cloud/kubernetes/performance/cockroachdb-statefulset-insecure.yaml
+++ b/cloud/kubernetes/performance/cockroachdb-statefulset-insecure.yaml
@@ -158,13 +158,13 @@ spec:
           name: grpc
         - containerPort: 8080
           name: http
-# We recommend that users don't configure liveness probes for production environments as it can impact availability of production databases.
-#        livenessProbe:
-#          httpGet:
-#            path: "/health"
-#            port: http
-#          initialDelaySeconds: 30
-#          periodSeconds: 5
+# We recommend that you do not configure a liveness probe on a production environment, as this can impact the availability of production databases.
+#       livenessProbe:
+#         httpGet:
+#           path: "/health"
+#           port: http
+#         initialDelaySeconds: 30
+#         periodSeconds: 5
         readinessProbe:
           httpGet:
             path: "/health?ready=1"

--- a/cloud/kubernetes/performance/cockroachdb-statefulset-insecure.yaml
+++ b/cloud/kubernetes/performance/cockroachdb-statefulset-insecure.yaml
@@ -158,12 +158,13 @@ spec:
           name: grpc
         - containerPort: 8080
           name: http
-        livenessProbe:
-          httpGet:
-            path: "/health"
-            port: http
-          initialDelaySeconds: 30
-          periodSeconds: 5
+# We recommend that users don't configure liveness probes for production environments as it can impact availability of production databases.
+#        livenessProbe:
+#          httpGet:
+#            path: "/health"
+#            port: http
+#          initialDelaySeconds: 30
+#          periodSeconds: 5
         readinessProbe:
           httpGet:
             path: "/health?ready=1"

--- a/cloud/kubernetes/performance/cockroachdb-statefulset-secure.yaml
+++ b/cloud/kubernetes/performance/cockroachdb-statefulset-secure.yaml
@@ -249,13 +249,14 @@ spec:
           name: grpc
         - containerPort: 8080
           name: http
-        livenessProbe:
-          httpGet:
-            path: "/health"
-            port: http
-            scheme: HTTPS
-          initialDelaySeconds: 30
-          periodSeconds: 5
+# We recommend that users don't configure liveness probes for production environments as it can impact availability of production databases.
+#        livenessProbe:
+#          httpGet:
+#            path: "/health"
+#            port: http
+#            scheme: HTTPS
+#          initialDelaySeconds: 30
+#          periodSeconds: 5
         readinessProbe:
           httpGet:
             path: "/health?ready=1"

--- a/cloud/kubernetes/performance/cockroachdb-statefulset-secure.yaml
+++ b/cloud/kubernetes/performance/cockroachdb-statefulset-secure.yaml
@@ -249,14 +249,14 @@ spec:
           name: grpc
         - containerPort: 8080
           name: http
-# We recommend that users don't configure liveness probes for production environments as it can impact availability of production databases.
-#        livenessProbe:
-#          httpGet:
-#            path: "/health"
-#            port: http
-#            scheme: HTTPS
-#          initialDelaySeconds: 30
-#          periodSeconds: 5
+# We recommend that you do not configure a liveness probe on a production environment, as this can impact the availability of production databases.
+#       livenessProbe:
+#         httpGet:
+#           path: "/health"
+#           port: http
+#           scheme: HTTPS
+#         initialDelaySeconds: 30
+#         periodSeconds: 5
         readinessProbe:
           httpGet:
             path: "/health?ready=1"


### PR DESCRIPTION
Liveness probe can cause kubernetes to reboot nodes when the database is busy but functioning properly, so we are commenting out that probe.