### PR TITLE
util/bufalloc: wrap ByteAllocator in a struct to avoid easy type errors

### DIFF
--- a/pkg/ccl/importccl/read_import_workload.go
+++ b/pkg/ccl/importccl/read_import_workload.go
@@ -235,7 +235,7 @@ func (w *WorkloadKVConverter) Worker(ctx context.Context, evalCtx *tree.EvalCont
 		if batchIdx >= w.batchEnd {
 			break
 		}
-		a = a[:0]
+		a = a.Truncate()
 		w.rows.FillBatch(batchIdx, cb, &a)
 		for rowIdx, numRows := 0, cb.Length(); rowIdx < numRows; rowIdx++ {
 			for colIdx, col := range cb.ColVecs() {

--- a/pkg/ccl/workloadccl/allccl/all_test.go
+++ b/pkg/ccl/workloadccl/allccl/all_test.go
@@ -197,7 +197,7 @@ func hashTableInitialData(
 	var scratch [8]byte
 	b := coldata.NewMemBatchWithCapacity(nil /* typs */, 0 /* capacity */, coldata.StandardColumnFactory)
 	for batchIdx := 0; batchIdx < data.NumBatches; batchIdx++ {
-		*a = (*a)[:0]
+		*a = a.Truncate()
 		data.FillBatch(batchIdx, b, a)
 		for _, col := range b.ColVecs() {
 			switch t := col.Type(); col.CanonicalTypeFamily() {

--- a/pkg/kv/kvnemesis/engine.go
+++ b/pkg/kv/kvnemesis/engine.go
@@ -68,7 +68,7 @@ func (e *Engine) Get(key roachpb.Key, ts hlc.Timestamp) roachpb.Value {
 		return roachpb.Value{}
 	}
 	var valCopy []byte
-	valCopy, e.b = e.b.Copy(iter.Value(), 0 /* extraCap */)
+	e.b, valCopy = e.b.Copy(iter.Value(), 0 /* extraCap */)
 	return roachpb.Value{RawBytes: valCopy, Timestamp: mvccKey.Timestamp}
 }
 
@@ -91,8 +91,8 @@ func (e *Engine) Iterate(fn func(key storage.MVCCKey, value []byte, err error)) 
 			continue
 		}
 		var keyCopy, valCopy []byte
-		keyCopy, e.b = e.b.Copy(iter.Key(), 0 /* extraCap */)
-		valCopy, e.b = e.b.Copy(iter.Value(), 0 /* extraCap */)
+		e.b, keyCopy = e.b.Copy(iter.Key(), 0 /* extraCap */)
+		e.b, valCopy = e.b.Copy(iter.Value(), 0 /* extraCap */)
 		key, err := storage.DecodeMVCCKey(keyCopy)
 		if err != nil {
 			fn(storage.MVCCKey{}, nil, err)

--- a/pkg/kv/kvserver/gc/gc.go
+++ b/pkg/kv/kvserver/gc/gc.go
@@ -362,7 +362,7 @@ func processReplicatedKeyRange(
 			}
 			batchGCKeys = nil
 			batchGCKeysBytes = 0
-			alloc = nil
+			alloc = bufalloc.ByteAllocator{}
 		}
 	}
 	if len(batchGCKeys) > 0 {

--- a/pkg/kv/kvserver/gc/gc_iterator.go
+++ b/pkg/kv/kvserver/gc/gc_iterator.go
@@ -160,7 +160,7 @@ func (b *gcIteratorRingBuf) pushBack(it iterator) {
 		panic("cannot add to full gcIteratorRingBuf")
 	}
 	i := (b.head + b.len) % gcIteratorRingBufSize
-	b.allocs[i] = b.allocs[i][:0]
+	b.allocs[i] = b.allocs[i].Truncate()
 	k := it.UnsafeKey()
 	v := it.UnsafeValue()
 	b.allocs[i], k.Key = b.allocs[i].Copy(k.Key, len(v))

--- a/pkg/util/bufalloc/byte_allocator.go
+++ b/pkg/util/bufalloc/byte_allocator.go
@@ -17,13 +17,15 @@ package bufalloc
 // indicates the total amount of memory and len() is the amount already
 // allocated. The size of the buffer to allocate from is grown exponentially
 // when it runs out of room up to a maximum size (chunkAllocMaxSize).
-type ByteAllocator []byte
+type ByteAllocator struct {
+	b []byte
+}
 
 const chunkAllocMinSize = 512
 const chunkAllocMaxSize = 16384
 
 func (a ByteAllocator) reserve(n int) ByteAllocator {
-	allocSize := cap(a) * 2
+	allocSize := cap(a.b) * 2
 	if allocSize < chunkAllocMinSize {
 		allocSize = chunkAllocMinSize
 	} else if allocSize > chunkAllocMaxSize {
@@ -32,19 +34,20 @@ func (a ByteAllocator) reserve(n int) ByteAllocator {
 	if allocSize < n {
 		allocSize = n
 	}
-	return make([]byte, 0, allocSize)
+	a.b = make([]byte, 0, allocSize)
+	return a
 }
 
 // Alloc allocates a new chunk of memory with the specified length. extraCap
 // indicates additional zero bytes that will be present in the returned []byte,
 // but not part of the length.
 func (a ByteAllocator) Alloc(n int, extraCap int) (ByteAllocator, []byte) {
-	if cap(a)-len(a) < n+extraCap {
+	if cap(a.b)-len(a.b) < n+extraCap {
 		a = a.reserve(n + extraCap)
 	}
-	p := len(a)
-	r := a[p : p+n : p+n+extraCap]
-	a = a[:p+n+extraCap]
+	p := len(a.b)
+	r := a.b[p : p+n : p+n+extraCap]
+	a.b = a.b[:p+n+extraCap]
 	return a, r
 }
 
@@ -56,4 +59,11 @@ func (a ByteAllocator) Copy(src []byte, extraCap int) (ByteAllocator, []byte) {
 	a, alloc = a.Alloc(len(src), extraCap)
 	copy(alloc, src)
 	return a, alloc
+}
+
+// Truncate resets the length of the underlying buffer to zero, allowing the
+// reserved capacity in the buffer to be written over and reused.
+func (a ByteAllocator) Truncate() ByteAllocator {
+	a.b = a.b[:0]
+	return a
 }

--- a/pkg/workload/bench_test.go
+++ b/pkg/workload/bench_test.go
@@ -57,7 +57,7 @@ func benchmarkInitialData(b *testing.B, gen workload.Generator) {
 		var a bufalloc.ByteAllocator
 		for _, table := range tables {
 			for rowIdx := 0; rowIdx < table.InitialRows.NumBatches; rowIdx++ {
-				a = a[:0]
+				a = a.Truncate()
 				table.InitialRows.FillBatch(rowIdx, cb, &a)
 				for _, col := range cb.ColVecs() {
 					bytes += columnByteSize(col)

--- a/pkg/workload/bulkingest/bulkingest.go
+++ b/pkg/workload/bulkingest/bulkingest.go
@@ -157,7 +157,7 @@ func (w *bulkingest) Tables() []workload.Table {
 
 				rng := rand.New(rand.NewSource(w.seed + int64(ab)))
 				var payload []byte
-				payload, *alloc = alloc.Alloc(w.cCount*w.payloadBytes, 0 /* extraCap */)
+				*alloc, payload = alloc.Alloc(w.cCount*w.payloadBytes, 0 /* extraCap */)
 				randutil.ReadTestdataBytes(rng, payload)
 				payloadCol.Reset()
 				for rowIdx := 0; rowIdx < w.cCount; rowIdx++ {

--- a/pkg/workload/csv.go
+++ b/pkg/workload/csv.go
@@ -55,7 +55,7 @@ func WriteCSVRows(
 			return 0, ctx.Err()
 		default:
 		}
-		a = a[:0]
+		a = a.Truncate()
 		table.InitialRows.FillBatch(rowBatchIdx, cb, &a)
 		if numCols := cb.Width(); cap(rowStrings) < numCols {
 			rowStrings = make([]string, numCols)
@@ -102,7 +102,7 @@ func (r *csvRowsReader) Read(p []byte) (n int, err error) {
 		if r.batchIdx == r.batchEnd {
 			return 0, io.EOF
 		}
-		r.a = r.a[:0]
+		r.a = r.a.Truncate()
 		r.t.InitialRows.FillBatch(r.batchIdx, r.cb, &r.a)
 		r.batchIdx++
 		if numCols := r.cb.Width(); cap(r.stringsBuf) < numCols {


### PR DESCRIPTION
As ByteAllocator was a type simply defined as `[]byte` that received
the `Alloc()` and `Copy()` methods, it was very easy to confuse the two
return values of those functions because they both returned
`(ByteAllocator, []byte)`, essentially returning two values of the same
type.  This makes it possible and very easy to have bugs in client code
that accidentally swap those two return values.  This change modifies
the `ByteAllocator` type to be a struct that wrappes the byte array,
ensuring that any code using `Alloc()/Copy()` with incorrectly ordered
return values will fail to compile.  This was found as there was a
preexisting bug in `pkg/kv/kvnemesis/engine.go`:
```
valCopy, e.b /* (ByteAllocator, []byte) */ = e.b.Copy(iter.Value(), 0 /* extraCap */)
```
and with this change, this is the result of attempting to compile
without fixing the incorrect order of the return parameters:
```
~/go/src/github.com/cockroachdb/cockroach (wrap_byte_allocator) >> make test PKG=./pkg/kv/kvnemesis TESTFLAGS="-v" TESTS=TestEngine

Running make with -j16
GOPATH set to /Users/asarkesian/go
mkdir -p lib
rm -f lib/lib{geos,geos_c}.dylib
make[1]: Nothing to be done for 'build_lib_static'.
cp -L /Users/asarkesian/go/native/x86_64-apple-darwin20.5.0/geos/lib/lib{geos,geos_c}.dylib lib
GOFLAGS= go test   -mod=vendor -tags 'make x86_64_apple_darwin20.5.0 crdb_test' -ldflags '-X github.com/cockroachdb/cockroach/pkg/build.typ=development -extldflags "" -X "github.com/cockroachdb/cockroach/pkg/build.tag=v21.2.0-alpha.00000000-1945-g0682747271-dirty" -X "github.com/cockroachdb/cockroach/pkg/build.rev=0682747271ca10ce5c1b4524299d641489eab8c9" -X "github.com/cockroachdb/cockroach/pkg/build.cgoTargetTriple=x86_64-apple-darwin20.5.0"  ' -run "TestEngine"  -timeout 30m ./pkg/kv/kvnemesis -v
pkg/kv/kvnemesis/engine.go:71:15: cannot assign bufalloc.ByteAllocator to valCopy (type []byte) in multiple assignment
pkg/kv/kvnemesis/engine.go:71:15: cannot assign []byte to e.b (type bufalloc.ByteAllocator) in multiple assignment
...
FAIL    github.com/cockroachdb/cockroach/pkg/kv/kvnemesis [build failed]
FAIL
make: *** [Makefile:1102: test] Error 2
```

Release note: None
