### PR TITLE
release-21.1: ui: maintain scroll position as line graphs render

### DIFF
--- a/pkg/ui/src/views/cluster/components/linegraph/index.tsx
+++ b/pkg/ui/src/views/cluster/components/linegraph/index.tsx
@@ -447,9 +447,14 @@ export class LineGraph extends React.Component<LineGraphProps, {}> {
   xAxisDomain: AxisDomain;
 
   componentDidUpdate(prevProps: Readonly<LineGraphProps>) {
-    if (!this.props.data || !this.props.data.results) {
+    if (
+      !this.props.data ||
+      !this.props.data.results ||
+      prevProps.data === this.props.data
+    ) {
       return;
     }
+
     const data = this.props.data;
     const metrics = this.metrics(this.props);
     const axis = this.axis(this.props);
@@ -477,7 +482,6 @@ export class LineGraph extends React.Component<LineGraphProps, {}> {
     if (
       this.u && // we already created a uPlot instance
       prevProps.data && // prior update had data as well
-      prevProps.data !== this.props.data && // prior update had different data
       sameKeys // prior update had same set of series identified by key
     ) {
       // The axis label option on uPlot doesn't accept


### PR DESCRIPTION
Backport 1/1 commits from #66983.

/cc @cockroachdb/release

---

Previously, calling this `componentDidUpdate` method with identical properties would cause the underlying uPlot object to be destroyed and rebuilt, jostling the DOM and losing the browser scroll position, making the page jump.

This behavior was particularly severe because `componentDidUpdate` is called multiple times when fresh data arrives; and for all but the initial call of the series, `prevProps` is identical to `this.props`, so the page scroll position would jump every 10 seconds or so, making it frustrating to focus on one chart.

Resolves #66093

Release note (bug fix): Fixed bug where metrics pages would lose their scroll position on chart data updates.
