### PR TITLE
bazel: gazelle excludes `.vendor.tmp.*`

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -75,6 +75,7 @@ load("@bazel_gazelle//:def.bzl", "gazelle")
 # gazelle:exclude c-deps/protobuf
 # gazelle:exclude artifacts
 # gazelle:exclude vendor
+# gazelle:exclude .vendor.tmp.*
 # gazelle:exclude **/zcgo_flags.go
 # gazelle:exclude **/zcgo_flags_*.go
 # gazelle:exclude **/*.og.go


### PR DESCRIPTION
It was observed that if `make vendor_rebuild` leaves its temporary copy
of the `vendor` directory behind for whatever reason, then Gazelle gets
confused and can insert "dependencies" like this:

```
        "//.vendor.tmp.2021-06-30.133525/github.com/knz/go-libedit",
```

This is obviously ridiculous, so just let `gazelle` know that its
services are not needed here.

Release note: None