### PR TITLE
kv: remove EvalContext.DB

### DIFF
--- a/pkg/kv/kvserver/batcheval/BUILD.bazel
+++ b/pkg/kv/kvserver/batcheval/BUILD.bazel
@@ -50,7 +50,6 @@ go_library(
     deps = [
         "//pkg/clusterversion",
         "//pkg/keys",
-        "//pkg/kv",
         "//pkg/kv/kvserver/abortspan",
         "//pkg/kv/kvserver/batcheval/result",
         "//pkg/kv/kvserver/closedts",

--- a/pkg/kv/kvserver/batcheval/eval_context.go
+++ b/pkg/kv/kvserver/batcheval/eval_context.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/abortspan"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency"
@@ -53,7 +52,6 @@ type EvalContext interface {
 
 	Engine() storage.Engine
 	Clock() *hlc.Clock
-	DB() *kv.DB
 	AbortSpan() *abortspan.AbortSpan
 	GetConcurrencyManager() concurrency.Manager
 
@@ -177,9 +175,6 @@ func (m *mockEvalCtxImpl) Engine() storage.Engine {
 }
 func (m *mockEvalCtxImpl) Clock() *hlc.Clock {
 	return m.MockEvalCtx.Clock
-}
-func (m *mockEvalCtxImpl) DB() *kv.DB {
-	panic("unimplemented")
 }
 func (m *mockEvalCtxImpl) AbortSpan() *abortspan.AbortSpan {
 	return m.MockEvalCtx.AbortSpan

--- a/pkg/kv/kvserver/replica_eval_context_span.go
+++ b/pkg/kv/kvserver/replica_eval_context_span.go
@@ -14,7 +14,6 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
-	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/abortspan"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts"
@@ -70,11 +69,6 @@ func (rec *SpanSetReplicaEvalContext) ClusterSettings() *cluster.Settings {
 // Clock returns the Replica's clock.
 func (rec *SpanSetReplicaEvalContext) Clock() *hlc.Clock {
 	return rec.i.Clock()
-}
-
-// DB returns the Replica's client DB.
-func (rec *SpanSetReplicaEvalContext) DB() *kv.DB {
-	return rec.i.DB()
 }
 
 // GetConcurrencyManager returns the concurrency.Manager.


### PR DESCRIPTION
Related to #66486.

Command evaluation is meant to operate in a sandbox. It certainly shouldn't have access to a `DB` handle.