### PR TITLE
rowexec: add comments around joinReaderStrategies

### DIFF
--- a/pkg/sql/execinfrapb/processors_sql.pb.go
+++ b/pkg/sql/execinfrapb/processors_sql.pb.go
@@ -927,9 +927,11 @@ type JoinReaderSpec struct {
 	// to BLOCK when locking_stength is FOR_NONE.
 	LockingWaitPolicy descpb.ScanLockingWaitPolicy `protobuf:"varint,10,opt,name=locking_wait_policy,json=lockingWaitPolicy,enum=cockroach.sql.sqlbase.ScanLockingWaitPolicy" json:"locking_wait_policy"`
 	// Indicates that the join reader should maintain the ordering of the input
-	// stream. This is applicable to both lookup joins and index joins.
-	// Maintaining ordering with lookup joins is expensive. With index joins,
-	// not maintaining ordering allows for optimizations at lower layers.
+	// stream. This is applicable to both lookup joins and index joins. For lookup
+	// joins, maintaining order is expensive because it requires buffering. For
+	// index joins buffering is not required, but still, if ordering is not
+	// required, we'll change the output order to allow for some Pebble
+	// optimizations.
 	MaintainOrdering bool `protobuf:"varint,11,opt,name=maintain_ordering,json=maintainOrdering" json:"maintain_ordering"`
 	// Indicates whether or not this JoinReader is expected to produce any
 	// system columns in its output.

--- a/pkg/sql/execinfrapb/processors_sql.proto
+++ b/pkg/sql/execinfrapb/processors_sql.proto
@@ -375,9 +375,11 @@ message JoinReaderSpec {
   optional sqlbase.ScanLockingWaitPolicy locking_wait_policy = 10 [(gogoproto.nullable) = false];
 
   // Indicates that the join reader should maintain the ordering of the input
-  // stream. This is applicable to both lookup joins and index joins.
-  // Maintaining ordering with lookup joins is expensive. With index joins,
-  // not maintaining ordering allows for optimizations at lower layers.
+  // stream. This is applicable to both lookup joins and index joins. For lookup
+  // joins, maintaining order is expensive because it requires buffering. For
+  // index joins buffering is not required, but still, if ordering is not
+  // required, we'll change the output order to allow for some Pebble
+  // optimizations.
   optional bool maintain_ordering = 11 [(gogoproto.nullable) = false];
 
   reserved 12;

--- a/pkg/sql/rowexec/joinreader_span_generator.go
+++ b/pkg/sql/rowexec/joinreader_span_generator.go
@@ -26,7 +26,10 @@ import (
 // joinReaderSpanGenerator is used by the joinReader to generate spans for
 // looking up into the index.
 type joinReaderSpanGenerator interface {
-	// generateSpans generates spans for the given batch of input rows.
+	// generateSpans generates spans for the given batch of input rows. The spans
+	// are returned in rows order, but there are no duplicates (i.e. if a 2nd row
+	// results in the same spans as a previous row, the results don't include them
+	// a second time).
 	generateSpans(rows []rowenc.EncDatumRow) (roachpb.Spans, error)
 
 	// getMatchingRowIndices returns the indices of the input rows that desire

--- a/pkg/sql/rowexec/joinreader_strategies.go
+++ b/pkg/sql/rowexec/joinreader_strategies.go
@@ -22,6 +22,27 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+// joinReaderStrategy abstracts the processing of looked-up rows. The joinReader
+// cooperates with a joinReaderStrategy to produce joined rows. More
+// specifically, the joinReader processes rows from the input-side, passes those
+// rows to the joinReaderStrategy.processLookupRows() which (usually) holds on
+// to them and returns key spans to be looked up, then the joinReader
+// iteratively looks up those spans and passes the resulting looked-up rows to
+// joinReaderStrategy.processLookedUpRow(). The joinReaderStrategy now has rows
+// from both sides of the join, and performs the actual joining, emitting output
+// rows from pairs of joined rows.
+//
+// There are three implementations of joinReaderStrategy:
+// - joinReaderNoOrderingStrategy: used when the joined rows do not need to be
+//   produced in input-row order.
+// - joinReaderOrderingStrategy: used when the joined rows need to be produced
+//   in input-row order. As opposed to the prior strategy, this one needs to do
+//   more buffering to deal with out-of-order looked-up rows.
+// - joinReaderIndexJoinStrategy: used when we're performing a join between an
+//   index and the table's PK. This one is the simplest and the most efficient
+//   because it doesn't actually join anything - it directly emits the PK rows.
+//   The joinReaderIndexJoinStrategy is used by both ordered and unordered index
+//   joins; see comments on joinReaderIndexJoinStrategy for details.
 type joinReaderStrategy interface {
 	// getLookupRowsBatchSizeHint returns the size in bytes of the batch of lookup
 	// rows.
@@ -36,8 +57,8 @@ type joinReaderStrategy interface {
 	// generatedRemoteSpans returns true if generateRemoteSpans has been called on
 	// the current batch of input rows.
 	generatedRemoteSpans() bool
-	// processLookupRows consumes the rows the joinReader has buffered and should
-	// return the lookup spans.
+	// processLookupRows consumes the rows the joinReader has buffered and returns
+	// the lookup spans.
 	processLookupRows(rows []rowenc.EncDatumRow) (roachpb.Spans, error)
 	// processLookedUpRow processes a looked up row. A joinReaderState is returned
 	// to indicate the next state to transition to. If this next state is
@@ -61,7 +82,25 @@ type joinReaderStrategy interface {
 }
 
 // joinReaderNoOrderingStrategy is a joinReaderStrategy that doesn't maintain
-// the input ordering. This is more performant than joinReaderOrderingStrategy.
+// the input ordering: the order in which joined rows are emitted does not
+// correspond to the order of the rows passed to processLookupRows(). This is
+// more performant than joinReaderOrderingStrategy.
+//
+// Consider the following example:
+// - the input side has rows (1, red), (2, blue), (3, blue), (4, red).
+// - the lookup side has rows (red, x), (blue, y).
+// - the join needs to produce the pairs (1, x), (2, y), (3, y), (4, x), in any
+//   order.
+//
+// Say the joinReader looks up rows in order: (red, x), then (blue, y). Once
+// (red, x) is fetched, it is handed to
+// joinReaderNoOrderingStrategy.processLookedUpRow(), which will match it
+// against all the corresponding input rows, and immediately emit (1, x), (4,
+// x). Then the joinReader will be handed in (blue, y), for which the
+// joinReaderNoOrderingStrategy will emit (2, blue) and (3, blue). Notice that
+// the rows were produced in an order different from the input order but, on the
+// flip side, there was no buffering of the looked-up rows. See
+// joinReaderOrderingStrategy for a contrast.
 type joinReaderNoOrderingStrategy struct {
 	*joinerBase
 	joinReaderSpanGenerator
@@ -239,7 +278,21 @@ func (s *joinReaderNoOrderingStrategy) spilled() bool { return false }
 func (s *joinReaderNoOrderingStrategy) close(_ context.Context) {}
 
 // joinReaderIndexJoinStrategy is a joinReaderStrategy that executes an index
-// join. It does not maintain the ordering.
+// join. This joinReaderStrategy is very simple - it immediately emits any row
+// passed to processLookedUpRow(). Since it is an index-join, it doesn't
+// actually do any joining: the looked-up rows correspond to a table's PK and
+// the input rows correspond to another one of the table's indexes; there's
+// nothing to join.
+//
+// joinReaderIndexJoinStrategy does not, by itself, do anything to output rows
+// in the order of the input rows (as they're ordered when passed to
+// processLookupRows). But, that will be the order in which the output rows are
+// produced if the looked-up rows are passed to processLookedUpRow() in the same
+// order as the spans returned by processLookupRows(). In other words, if the
+// spans resulting from processLookupRows() are not re-sorted, then
+// joinReaderIndexJoinStrategy will produce its output rows in order. Note that
+// the spans produced by processLookupRows correspond 1-1 with the input;
+// there's no deduping because they're all unique (representing PKs).
 type joinReaderIndexJoinStrategy struct {
 	*joinerBase
 	joinReaderSpanGenerator
@@ -317,7 +370,29 @@ func (s *joinReaderIndexJoinStrategy) close(ctx context.Context) {}
 var partialJoinSentinel = []int{-1}
 
 // joinReaderOrderingStrategy is a joinReaderStrategy that maintains the input
-// ordering. This is more expensive than joinReaderNoOrderingStrategy.
+// ordering: the order in which joined rows are emitted corresponds to the order
+// of the rows passed to processLookupRows().
+//
+// Consider the following example:
+// - the input side has rows (1, red), (2, blue), (3, blue), (4, red).
+// - the lookup side has rows (red, x), (blue, y).
+// - the join needs to produce the pairs (1, x), (2, y), (3, y), (4, x), in this
+//   order.
+//
+// Say the joinReader looks up rows in order: (red, x), then (blue, y). Once
+// (red, x) is fetched, it is handed to
+// joinReaderOderingStrategy.processLookedUpRow(), which will match it against
+// all the corresponding input rows, producing (1, x), (4, x). These two rows
+// are not emitted because that would violate the input ordering (well, (1, x)
+// could be emitted, but we're not smart enough). So, they are buffered until
+// all joined rows are produced. Then the joinReader will hand in (blue, y), for
+// which the joinReaderOrderingStrategy produces (2, y) and (3, y). Now that all
+// output rows are buffered, they are re-ordered according to the input order
+// and emitted.
+//
+// Because of the buffering required to eventually reorder the output, the
+// joinReaderOrderingStrategy is more expensive than
+// joinReaderNoOrderingStrategy.
 type joinReaderOrderingStrategy struct {
 	*joinerBase
 	joinReaderSpanGenerator
@@ -327,15 +402,19 @@ type joinReaderOrderingStrategy struct {
 	remoteSpansGenerated bool
 
 	// inputRowIdxToLookedUpRowIndices is a multimap from input row indices to
-	// corresponding looked up row indices. It's populated in the
-	// jrPerformingLookup state. For non partial joins (everything but semi/anti
-	// join), the looked up rows are the rows that came back from the lookup
-	// span for each input row, without checking for matches with respect to the
-	// on-condition. For semi/anti join, we store at most one sentinel value,
-	// indicating a matching lookup if it's present, since the right side of a
-	// semi/anti join is not used.
+	// corresponding looked up row indices. This serves to emit rows in input
+	// order even though lookups are performed out of order.
+	//
+	// The map is populated in the jrPerformingLookup state. For non partial joins
+	// (everything but semi/anti join), the looked up rows are the rows that came
+	// back from the lookup span for each input row, without checking for matches
+	// with respect to the on-condition. For semi/anti join, we store at most one
+	// sentinel value, indicating a matching lookup if it's present, since the
+	// right side of a semi/anti join is not used.
 	inputRowIdxToLookedUpRowIndices [][]int
 
+	// lookedUpRowIdx indicates the index of the current lookup row within the
+	// rows returned by a lookup batch.
 	lookedUpRowIdx int
 	lookedUpRows   *rowcontainer.DiskBackedNumberedRowContainer
 
@@ -385,10 +464,9 @@ func (s *joinReaderOrderingStrategy) generatedRemoteSpans() bool {
 func (s *joinReaderOrderingStrategy) processLookupRows(
 	rows []rowenc.EncDatumRow,
 ) (roachpb.Spans, error) {
-	// Maintain a map from input row index to the corresponding output rows. This
-	// will allow us to preserve the order of the input in the face of multiple
-	// input rows having the same lookup keyspan, or if we're doing an outer join
-	// and we need to emit unmatched rows.
+	// Reset s.inputRowIdxToLookedUpRowIndices. This map will be populated in
+	// processedLookedUpRow(), as lookup results are received (possibly out of
+	// order).
 	if cap(s.inputRowIdxToLookedUpRowIndices) >= len(rows) {
 		s.inputRowIdxToLookedUpRowIndices = s.inputRowIdxToLookedUpRowIndices[:len(rows)]
 		for i := range s.inputRowIdxToLookedUpRowIndices {

--- a/pkg/sql/rowexec/rowfetcher.go
+++ b/pkg/sql/rowexec/rowfetcher.go
@@ -28,7 +28,7 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// rowFetcher is an interface used to abstract a row fetcher so that a stat
+// rowFetcher is an interface used to abstract a row.Fetcher so that a stat
 // collector wrapper can be plugged in.
 type rowFetcher interface {
 	StartScan(


### PR DESCRIPTION
This patch adds comments around areas I have found confusing in the
joinReader and friends implementation. Particularly around the
management of the ordering guarantees in different cases.
Thanks Sumeer for explaining some things.

Release note: None