### PR TITLE
colexec: benchmark and optimize window functions

### DIFF
--- a/pkg/sql/colexec/colexecwindow/buffered_window.go
+++ b/pkg/sql/colexec/colexecwindow/buffered_window.go
@@ -115,7 +115,7 @@ const (
 // buffer all tuples from each partition.
 type bufferedWindower interface {
 	Init(ctx context.Context)
-	Close() error
+	Close()
 
 	// seekNextPartition is called during the windowSeeking state on the current
 	// batch. It gives windowers a chance to perform any necessary pre-processing,
@@ -354,9 +354,9 @@ func (b *bufferedWindowOp) Close() error {
 		// both cases there is nothing to do.
 		return nil
 	}
-	var err error
-	if err = b.bufferQueue.Close(b.EnsureCtx()); err != nil {
+	if err := b.bufferQueue.Close(b.EnsureCtx()); err != nil {
 		return err
 	}
-	return b.windower.Close()
+	b.windower.Close()
+	return nil
 }

--- a/pkg/sql/colexec/colexecwindow/lag.eg.go
+++ b/pkg/sql/colexec/colexecwindow/lag.eg.go
@@ -42,7 +42,6 @@ func NewLagOperator(
 	offsetIdx int,
 	defaultIdx int,
 ) (colexecop.Operator, error) {
-	argType := inputTypes[argIdx]
 	// Allow the direct-access buffer 10% of the available memory. The rest will
 	// be given to the bufferedWindowOp queue. While it is somewhat more important
 	// for the direct-access buffer tuples to be kept in-memory, it only has to
@@ -50,7 +49,7 @@ func NewLagOperator(
 	// good empirically-supported fraction to use.
 	bufferMemLimit := int64(float64(memoryLimit) * 0.10)
 	buffer := colexecutils.NewSpillingBuffer(
-		bufferAllocator, bufferMemLimit, diskQueueCfg, fdSemaphore, []*types.T{argType}, diskAcc, argIdx)
+		bufferAllocator, bufferMemLimit, diskQueueCfg, fdSemaphore, inputTypes, diskAcc, argIdx)
 	base := lagBase{
 		buffer:          buffer,
 		outputColIdx:    outputColIdx,
@@ -59,6 +58,7 @@ func NewLagOperator(
 		offsetIdx:       offsetIdx,
 		defaultIdx:      defaultIdx,
 	}
+	argType := inputTypes[argIdx]
 	switch typeconv.TypeFamilyToCanonicalTypeFamily(argType.Family()) {
 	case types.BoolFamily:
 		switch argType.Width() {
@@ -264,9 +264,8 @@ func (w *lagBoolWindow) processBatch(batch coldata.Batch, startIdx, endIdx int) 
 					leadLagCol.Set(i, val)
 					continue
 				}
-				b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
-				vec := b.ColVec(0)
-				if vec.Nulls().NullAt(idx) {
+				vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
+				if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(idx) {
 					leadLagNulls.SetNull(i)
 					continue
 				}
@@ -291,9 +290,8 @@ func (w *lagBoolWindow) processBatch(batch coldata.Batch, startIdx, endIdx int) 
 				leadLagCol.Set(i, val)
 				continue
 			}
-			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
-			vec := b.ColVec(0)
-			if vec.Nulls().NullAt(idx) {
+			vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
+			if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(idx) {
 				leadLagNulls.SetNull(i)
 				continue
 			}
@@ -317,9 +315,8 @@ func (w *lagBoolWindow) processBatch(batch coldata.Batch, startIdx, endIdx int) 
 				leadLagCol.Set(i, val)
 				continue
 			}
-			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
-			vec := b.ColVec(0)
-			if vec.Nulls().NullAt(idx) {
+			vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
+			if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(idx) {
 				leadLagNulls.SetNull(i)
 				continue
 			}
@@ -338,9 +335,8 @@ func (w *lagBoolWindow) processBatch(batch coldata.Batch, startIdx, endIdx int) 
 			leadLagCol.Set(i, val)
 			continue
 		}
-		b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
-		vec := b.ColVec(0)
-		if vec.Nulls().NullAt(idx) {
+		vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
+		if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(idx) {
 			leadLagNulls.SetNull(i)
 			continue
 		}
@@ -431,9 +427,8 @@ func (w *lagBytesWindow) processBatch(batch coldata.Batch, startIdx, endIdx int)
 					leadLagCol.CopySlice(defaultCol, i, i, i+1)
 					continue
 				}
-				b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
-				vec := b.ColVec(0)
-				if vec.Nulls().NullAt(idx) {
+				vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
+				if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(idx) {
 					leadLagNulls.SetNull(i)
 					continue
 				}
@@ -458,9 +453,8 @@ func (w *lagBytesWindow) processBatch(batch coldata.Batch, startIdx, endIdx int)
 				leadLagCol.CopySlice(defaultCol, i, i, i+1)
 				continue
 			}
-			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
-			vec := b.ColVec(0)
-			if vec.Nulls().NullAt(idx) {
+			vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
+			if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(idx) {
 				leadLagNulls.SetNull(i)
 				continue
 			}
@@ -484,9 +478,8 @@ func (w *lagBytesWindow) processBatch(batch coldata.Batch, startIdx, endIdx int)
 				leadLagCol.CopySlice(defaultCol, i, i, i+1)
 				continue
 			}
-			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
-			vec := b.ColVec(0)
-			if vec.Nulls().NullAt(idx) {
+			vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
+			if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(idx) {
 				leadLagNulls.SetNull(i)
 				continue
 			}
@@ -505,9 +498,8 @@ func (w *lagBytesWindow) processBatch(batch coldata.Batch, startIdx, endIdx int)
 			leadLagCol.CopySlice(defaultCol, i, i, i+1)
 			continue
 		}
-		b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
-		vec := b.ColVec(0)
-		if vec.Nulls().NullAt(idx) {
+		vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
+		if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(idx) {
 			leadLagNulls.SetNull(i)
 			continue
 		}
@@ -604,9 +596,8 @@ func (w *lagDecimalWindow) processBatch(batch coldata.Batch, startIdx, endIdx in
 					leadLagCol.Set(i, val)
 					continue
 				}
-				b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
-				vec := b.ColVec(0)
-				if vec.Nulls().NullAt(idx) {
+				vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
+				if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(idx) {
 					leadLagNulls.SetNull(i)
 					continue
 				}
@@ -631,9 +622,8 @@ func (w *lagDecimalWindow) processBatch(batch coldata.Batch, startIdx, endIdx in
 				leadLagCol.Set(i, val)
 				continue
 			}
-			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
-			vec := b.ColVec(0)
-			if vec.Nulls().NullAt(idx) {
+			vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
+			if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(idx) {
 				leadLagNulls.SetNull(i)
 				continue
 			}
@@ -657,9 +647,8 @@ func (w *lagDecimalWindow) processBatch(batch coldata.Batch, startIdx, endIdx in
 				leadLagCol.Set(i, val)
 				continue
 			}
-			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
-			vec := b.ColVec(0)
-			if vec.Nulls().NullAt(idx) {
+			vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
+			if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(idx) {
 				leadLagNulls.SetNull(i)
 				continue
 			}
@@ -678,9 +667,8 @@ func (w *lagDecimalWindow) processBatch(batch coldata.Batch, startIdx, endIdx in
 			leadLagCol.Set(i, val)
 			continue
 		}
-		b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
-		vec := b.ColVec(0)
-		if vec.Nulls().NullAt(idx) {
+		vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
+		if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(idx) {
 			leadLagNulls.SetNull(i)
 			continue
 		}
@@ -776,9 +764,8 @@ func (w *lagInt16Window) processBatch(batch coldata.Batch, startIdx, endIdx int)
 					leadLagCol.Set(i, val)
 					continue
 				}
-				b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
-				vec := b.ColVec(0)
-				if vec.Nulls().NullAt(idx) {
+				vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
+				if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(idx) {
 					leadLagNulls.SetNull(i)
 					continue
 				}
@@ -803,9 +790,8 @@ func (w *lagInt16Window) processBatch(batch coldata.Batch, startIdx, endIdx int)
 				leadLagCol.Set(i, val)
 				continue
 			}
-			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
-			vec := b.ColVec(0)
-			if vec.Nulls().NullAt(idx) {
+			vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
+			if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(idx) {
 				leadLagNulls.SetNull(i)
 				continue
 			}
@@ -829,9 +815,8 @@ func (w *lagInt16Window) processBatch(batch coldata.Batch, startIdx, endIdx int)
 				leadLagCol.Set(i, val)
 				continue
 			}
-			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
-			vec := b.ColVec(0)
-			if vec.Nulls().NullAt(idx) {
+			vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
+			if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(idx) {
 				leadLagNulls.SetNull(i)
 				continue
 			}
@@ -850,9 +835,8 @@ func (w *lagInt16Window) processBatch(batch coldata.Batch, startIdx, endIdx int)
 			leadLagCol.Set(i, val)
 			continue
 		}
-		b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
-		vec := b.ColVec(0)
-		if vec.Nulls().NullAt(idx) {
+		vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
+		if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(idx) {
 			leadLagNulls.SetNull(i)
 			continue
 		}
@@ -948,9 +932,8 @@ func (w *lagInt32Window) processBatch(batch coldata.Batch, startIdx, endIdx int)
 					leadLagCol.Set(i, val)
 					continue
 				}
-				b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
-				vec := b.ColVec(0)
-				if vec.Nulls().NullAt(idx) {
+				vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
+				if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(idx) {
 					leadLagNulls.SetNull(i)
 					continue
 				}
@@ -975,9 +958,8 @@ func (w *lagInt32Window) processBatch(batch coldata.Batch, startIdx, endIdx int)
 				leadLagCol.Set(i, val)
 				continue
 			}
-			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
-			vec := b.ColVec(0)
-			if vec.Nulls().NullAt(idx) {
+			vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
+			if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(idx) {
 				leadLagNulls.SetNull(i)
 				continue
 			}
@@ -1001,9 +983,8 @@ func (w *lagInt32Window) processBatch(batch coldata.Batch, startIdx, endIdx int)
 				leadLagCol.Set(i, val)
 				continue
 			}
-			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
-			vec := b.ColVec(0)
-			if vec.Nulls().NullAt(idx) {
+			vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
+			if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(idx) {
 				leadLagNulls.SetNull(i)
 				continue
 			}
@@ -1022,9 +1003,8 @@ func (w *lagInt32Window) processBatch(batch coldata.Batch, startIdx, endIdx int)
 			leadLagCol.Set(i, val)
 			continue
 		}
-		b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
-		vec := b.ColVec(0)
-		if vec.Nulls().NullAt(idx) {
+		vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
+		if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(idx) {
 			leadLagNulls.SetNull(i)
 			continue
 		}
@@ -1120,9 +1100,8 @@ func (w *lagInt64Window) processBatch(batch coldata.Batch, startIdx, endIdx int)
 					leadLagCol.Set(i, val)
 					continue
 				}
-				b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
-				vec := b.ColVec(0)
-				if vec.Nulls().NullAt(idx) {
+				vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
+				if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(idx) {
 					leadLagNulls.SetNull(i)
 					continue
 				}
@@ -1147,9 +1126,8 @@ func (w *lagInt64Window) processBatch(batch coldata.Batch, startIdx, endIdx int)
 				leadLagCol.Set(i, val)
 				continue
 			}
-			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
-			vec := b.ColVec(0)
-			if vec.Nulls().NullAt(idx) {
+			vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
+			if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(idx) {
 				leadLagNulls.SetNull(i)
 				continue
 			}
@@ -1173,9 +1151,8 @@ func (w *lagInt64Window) processBatch(batch coldata.Batch, startIdx, endIdx int)
 				leadLagCol.Set(i, val)
 				continue
 			}
-			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
-			vec := b.ColVec(0)
-			if vec.Nulls().NullAt(idx) {
+			vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
+			if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(idx) {
 				leadLagNulls.SetNull(i)
 				continue
 			}
@@ -1194,9 +1171,8 @@ func (w *lagInt64Window) processBatch(batch coldata.Batch, startIdx, endIdx int)
 			leadLagCol.Set(i, val)
 			continue
 		}
-		b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
-		vec := b.ColVec(0)
-		if vec.Nulls().NullAt(idx) {
+		vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
+		if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(idx) {
 			leadLagNulls.SetNull(i)
 			continue
 		}
@@ -1292,9 +1268,8 @@ func (w *lagFloat64Window) processBatch(batch coldata.Batch, startIdx, endIdx in
 					leadLagCol.Set(i, val)
 					continue
 				}
-				b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
-				vec := b.ColVec(0)
-				if vec.Nulls().NullAt(idx) {
+				vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
+				if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(idx) {
 					leadLagNulls.SetNull(i)
 					continue
 				}
@@ -1319,9 +1294,8 @@ func (w *lagFloat64Window) processBatch(batch coldata.Batch, startIdx, endIdx in
 				leadLagCol.Set(i, val)
 				continue
 			}
-			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
-			vec := b.ColVec(0)
-			if vec.Nulls().NullAt(idx) {
+			vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
+			if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(idx) {
 				leadLagNulls.SetNull(i)
 				continue
 			}
@@ -1345,9 +1319,8 @@ func (w *lagFloat64Window) processBatch(batch coldata.Batch, startIdx, endIdx in
 				leadLagCol.Set(i, val)
 				continue
 			}
-			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
-			vec := b.ColVec(0)
-			if vec.Nulls().NullAt(idx) {
+			vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
+			if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(idx) {
 				leadLagNulls.SetNull(i)
 				continue
 			}
@@ -1366,9 +1339,8 @@ func (w *lagFloat64Window) processBatch(batch coldata.Batch, startIdx, endIdx in
 			leadLagCol.Set(i, val)
 			continue
 		}
-		b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
-		vec := b.ColVec(0)
-		if vec.Nulls().NullAt(idx) {
+		vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
+		if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(idx) {
 			leadLagNulls.SetNull(i)
 			continue
 		}
@@ -1464,9 +1436,8 @@ func (w *lagTimestampWindow) processBatch(batch coldata.Batch, startIdx, endIdx 
 					leadLagCol.Set(i, val)
 					continue
 				}
-				b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
-				vec := b.ColVec(0)
-				if vec.Nulls().NullAt(idx) {
+				vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
+				if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(idx) {
 					leadLagNulls.SetNull(i)
 					continue
 				}
@@ -1491,9 +1462,8 @@ func (w *lagTimestampWindow) processBatch(batch coldata.Batch, startIdx, endIdx 
 				leadLagCol.Set(i, val)
 				continue
 			}
-			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
-			vec := b.ColVec(0)
-			if vec.Nulls().NullAt(idx) {
+			vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
+			if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(idx) {
 				leadLagNulls.SetNull(i)
 				continue
 			}
@@ -1517,9 +1487,8 @@ func (w *lagTimestampWindow) processBatch(batch coldata.Batch, startIdx, endIdx 
 				leadLagCol.Set(i, val)
 				continue
 			}
-			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
-			vec := b.ColVec(0)
-			if vec.Nulls().NullAt(idx) {
+			vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
+			if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(idx) {
 				leadLagNulls.SetNull(i)
 				continue
 			}
@@ -1538,9 +1507,8 @@ func (w *lagTimestampWindow) processBatch(batch coldata.Batch, startIdx, endIdx 
 			leadLagCol.Set(i, val)
 			continue
 		}
-		b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
-		vec := b.ColVec(0)
-		if vec.Nulls().NullAt(idx) {
+		vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
+		if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(idx) {
 			leadLagNulls.SetNull(i)
 			continue
 		}
@@ -1636,9 +1604,8 @@ func (w *lagIntervalWindow) processBatch(batch coldata.Batch, startIdx, endIdx i
 					leadLagCol.Set(i, val)
 					continue
 				}
-				b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
-				vec := b.ColVec(0)
-				if vec.Nulls().NullAt(idx) {
+				vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
+				if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(idx) {
 					leadLagNulls.SetNull(i)
 					continue
 				}
@@ -1663,9 +1630,8 @@ func (w *lagIntervalWindow) processBatch(batch coldata.Batch, startIdx, endIdx i
 				leadLagCol.Set(i, val)
 				continue
 			}
-			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
-			vec := b.ColVec(0)
-			if vec.Nulls().NullAt(idx) {
+			vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
+			if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(idx) {
 				leadLagNulls.SetNull(i)
 				continue
 			}
@@ -1689,9 +1655,8 @@ func (w *lagIntervalWindow) processBatch(batch coldata.Batch, startIdx, endIdx i
 				leadLagCol.Set(i, val)
 				continue
 			}
-			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
-			vec := b.ColVec(0)
-			if vec.Nulls().NullAt(idx) {
+			vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
+			if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(idx) {
 				leadLagNulls.SetNull(i)
 				continue
 			}
@@ -1710,9 +1675,8 @@ func (w *lagIntervalWindow) processBatch(batch coldata.Batch, startIdx, endIdx i
 			leadLagCol.Set(i, val)
 			continue
 		}
-		b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
-		vec := b.ColVec(0)
-		if vec.Nulls().NullAt(idx) {
+		vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
+		if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(idx) {
 			leadLagNulls.SetNull(i)
 			continue
 		}
@@ -1803,9 +1767,8 @@ func (w *lagJSONWindow) processBatch(batch coldata.Batch, startIdx, endIdx int) 
 					leadLagCol.CopySlice(defaultCol, i, i, i+1)
 					continue
 				}
-				b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
-				vec := b.ColVec(0)
-				if vec.Nulls().NullAt(idx) {
+				vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
+				if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(idx) {
 					leadLagNulls.SetNull(i)
 					continue
 				}
@@ -1830,9 +1793,8 @@ func (w *lagJSONWindow) processBatch(batch coldata.Batch, startIdx, endIdx int) 
 				leadLagCol.CopySlice(defaultCol, i, i, i+1)
 				continue
 			}
-			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
-			vec := b.ColVec(0)
-			if vec.Nulls().NullAt(idx) {
+			vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
+			if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(idx) {
 				leadLagNulls.SetNull(i)
 				continue
 			}
@@ -1856,9 +1818,8 @@ func (w *lagJSONWindow) processBatch(batch coldata.Batch, startIdx, endIdx int) 
 				leadLagCol.CopySlice(defaultCol, i, i, i+1)
 				continue
 			}
-			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
-			vec := b.ColVec(0)
-			if vec.Nulls().NullAt(idx) {
+			vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
+			if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(idx) {
 				leadLagNulls.SetNull(i)
 				continue
 			}
@@ -1877,9 +1838,8 @@ func (w *lagJSONWindow) processBatch(batch coldata.Batch, startIdx, endIdx int) 
 			leadLagCol.CopySlice(defaultCol, i, i, i+1)
 			continue
 		}
-		b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
-		vec := b.ColVec(0)
-		if vec.Nulls().NullAt(idx) {
+		vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
+		if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(idx) {
 			leadLagNulls.SetNull(i)
 			continue
 		}
@@ -1972,9 +1932,8 @@ func (w *lagDatumWindow) processBatch(batch coldata.Batch, startIdx, endIdx int)
 					leadLagCol.Set(i, val)
 					continue
 				}
-				b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
-				vec := b.ColVec(0)
-				if vec.Nulls().NullAt(idx) {
+				vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
+				if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(idx) {
 					leadLagNulls.SetNull(i)
 					continue
 				}
@@ -1999,9 +1958,8 @@ func (w *lagDatumWindow) processBatch(batch coldata.Batch, startIdx, endIdx int)
 				leadLagCol.Set(i, val)
 				continue
 			}
-			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
-			vec := b.ColVec(0)
-			if vec.Nulls().NullAt(idx) {
+			vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
+			if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(idx) {
 				leadLagNulls.SetNull(i)
 				continue
 			}
@@ -2025,9 +1983,8 @@ func (w *lagDatumWindow) processBatch(batch coldata.Batch, startIdx, endIdx int)
 				leadLagCol.Set(i, val)
 				continue
 			}
-			b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
-			vec := b.ColVec(0)
-			if vec.Nulls().NullAt(idx) {
+			vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
+			if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(idx) {
 				leadLagNulls.SetNull(i)
 				continue
 			}
@@ -2046,9 +2003,8 @@ func (w *lagDatumWindow) processBatch(batch coldata.Batch, startIdx, endIdx int)
 			leadLagCol.Set(i, val)
 			continue
 		}
-		b, idx := w.buffer.GetBatchWithTuple(w.Ctx, requestedIdx)
-		vec := b.ColVec(0)
-		if vec.Nulls().NullAt(idx) {
+		vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
+		if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(idx) {
 			leadLagNulls.SetNull(i)
 			continue
 		}
@@ -2074,9 +2030,9 @@ func (b *lagBase) Init(ctx context.Context) {
 	}
 }
 
-func (b *lagBase) Close() error {
+func (b *lagBase) Close() {
 	if !b.CloserHelper.Close() {
-		return nil
+		return
 	}
-	return b.buffer.Close(b.EnsureCtx())
+	b.buffer.Close(b.EnsureCtx())
 }

--- a/pkg/sql/colexec/colexecwindow/ntile.eg.go
+++ b/pkg/sql/colexec/colexecwindow/ntile.eg.go
@@ -292,10 +292,6 @@ func (b *nTileBase) startNewPartition() {
 	b.hasArg = false
 }
 
-func (b *nTileBase) Init(ctx context.Context) {
+func (b *nTileBase) Init(ctx context.Context) {}
 
-}
-
-func (b *nTileBase) Close() error {
-	return nil
-}
+func (b *nTileBase) Close() {}

--- a/pkg/sql/colexec/colexecwindow/ntile_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/ntile_tmpl.go
@@ -270,10 +270,6 @@ func (b *nTileBase) startNewPartition() {
 	b.hasArg = false
 }
 
-func (b *nTileBase) Init(ctx context.Context) {
+func (b *nTileBase) Init(ctx context.Context) {}
 
-}
-
-func (b *nTileBase) Close() error {
-	return nil
-}
+func (b *nTileBase) Close() {}

--- a/pkg/sql/colexec/colexecwindow/window_functions_test.go
+++ b/pkg/sql/colexec/colexecwindow/window_functions_test.go
@@ -12,12 +12,16 @@ package colexecwindow
 
 import (
 	"context"
+	"fmt"
+	"math"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecargs"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexectestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
+	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -602,5 +606,167 @@ func TestWindowFunctions(t *testing.T) {
 
 	for _, m := range monitors {
 		m.Stop(ctx)
+	}
+}
+
+func BenchmarkWindowFunctions(b *testing.B) {
+	defer log.Scope(b).Close(b)
+	ctx := context.Background()
+
+	const memLimit = 64 << 20
+	const fdLimit = 3
+	const partitionSize = 5
+	const peerGroupSize = 3
+	const arg1ColIdx = 0
+	const arg2ColIdx = 1
+	const arg3ColIdx = 2
+	const partitionColIdx = 3
+	const orderColIdx = 4
+	const peersColIdx = 5
+	const numIntCols = 4
+	const numBoolCols = 2
+
+	sourceTypes := []*types.T{
+		types.Int, types.Int, types.Int, // Window function arguments
+		types.Bool, // Partition column
+		types.Int,  // Ordering column
+		types.Bool, // Peer groups column
+	}
+
+	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(b, false /* inMem */)
+	defer cleanup()
+	benchMemAccount := testMemMonitor.MakeBoundAccount()
+	defer benchMemAccount.Close(ctx)
+
+	getWindowFn := func(
+		windowFn execinfrapb.WindowerSpec_WindowFunc, source colexecop.Operator, partition, order bool,
+	) (op colexecop.Operator) {
+		var err error
+		outputIdx := len(sourceTypes)
+		benchMemAccount.Clear(ctx)
+		mainAllocator := colmem.NewAllocator(ctx, &benchMemAccount, testColumnFactory)
+		bufferAllocator := colmem.NewAllocator(ctx, &benchMemAccount, testColumnFactory)
+
+		var orderingCols []execinfrapb.Ordering_Column
+		partitionCol, peersCol := tree.NoColumnIdx, tree.NoColumnIdx
+		if partition {
+			partitionCol = partitionColIdx
+		}
+		if order {
+			peersCol = peersColIdx
+			orderingCols = append(orderingCols, execinfrapb.Ordering_Column{
+				ColIdx:    uint32(orderColIdx),
+				Direction: execinfrapb.Ordering_Column_ASC,
+			})
+		}
+
+		switch windowFn {
+		case execinfrapb.WindowerSpec_ROW_NUMBER:
+			op = NewRowNumberOperator(mainAllocator, source, outputIdx, partitionCol)
+		case execinfrapb.WindowerSpec_RANK, execinfrapb.WindowerSpec_DENSE_RANK:
+			op, err = NewRankOperator(
+				mainAllocator, source, windowFn, orderingCols, outputIdx, partitionCol, peersCol,
+			)
+		case execinfrapb.WindowerSpec_PERCENT_RANK, execinfrapb.WindowerSpec_CUME_DIST:
+			op, err = NewRelativeRankOperator(
+				mainAllocator, memLimit, queueCfg, colexecop.NewTestingSemaphore(fdLimit), source,
+				sourceTypes, windowFn, orderingCols, outputIdx, partitionColIdx, peersColIdx, testDiskAcc,
+			)
+		case execinfrapb.WindowerSpec_NTILE:
+			op = NewNTileOperator(mainAllocator, memLimit, queueCfg,
+				colexecop.NewTestingSemaphore(fdLimit), testDiskAcc, source, sourceTypes,
+				outputIdx, partitionCol, arg1ColIdx,
+			)
+		case execinfrapb.WindowerSpec_LAG:
+			op, err = NewLagOperator(
+				mainAllocator, bufferAllocator, memLimit, queueCfg,
+				colexecop.NewTestingSemaphore(fdLimit), testDiskAcc, source, sourceTypes,
+				outputIdx, partitionCol, arg1ColIdx, arg2ColIdx, arg3ColIdx,
+			)
+		case execinfrapb.WindowerSpec_LEAD:
+			op, err = NewLeadOperator(
+				mainAllocator, bufferAllocator, memLimit, queueCfg,
+				colexecop.NewTestingSemaphore(fdLimit), testDiskAcc, source, sourceTypes,
+				outputIdx, partitionCol, arg1ColIdx, arg2ColIdx, arg3ColIdx,
+			)
+		}
+		require.NoError(b, err)
+		return op
+	}
+
+	var batch coldata.Batch
+	batchCreator := func(batchLength int) coldata.Batch {
+		const arg1Offset = 5
+		batch, _ = testAllocator.ResetMaybeReallocate(sourceTypes, batch, batchLength, math.MaxInt64)
+		argCol1 := batch.ColVec(arg1ColIdx).Int64()
+		argCol2 := batch.ColVec(arg2ColIdx).Int64()
+		partitionCol := batch.ColVec(partitionColIdx).Bool()
+		orderCol := batch.ColVec(orderColIdx).Int64()
+		peersCol := batch.ColVec(peersColIdx).Bool()
+		for i := 0; i < batchLength; i++ {
+			argCol1[i] = int64(i + arg1Offset)
+			argCol2[i] = 1
+			partitionCol[i] = i%partitionSize == 0
+			orderCol[i] = int64(i / peerGroupSize)
+			peersCol[i] = i%peerGroupSize == 0
+		}
+		batch.ColVec(arg1ColIdx).Nulls().UnsetNulls()
+		batch.ColVec(arg2ColIdx).Nulls().UnsetNulls()
+		batch.ColVec(arg3ColIdx).Nulls().SetNulls()
+		batch.ColVec(partitionColIdx).Nulls().UnsetNulls()
+		batch.ColVec(orderColIdx).Nulls().UnsetNulls()
+		batch.ColVec(peersColIdx).Nulls().UnsetNulls()
+		batch.SetLength(batchLength)
+		return batch
+	}
+
+	windowFns := []execinfrapb.WindowerSpec_WindowFunc{
+		execinfrapb.WindowerSpec_ROW_NUMBER,
+		execinfrapb.WindowerSpec_RANK,
+		execinfrapb.WindowerSpec_DENSE_RANK,
+		execinfrapb.WindowerSpec_PERCENT_RANK,
+		execinfrapb.WindowerSpec_CUME_DIST,
+		execinfrapb.WindowerSpec_NTILE,
+		execinfrapb.WindowerSpec_LAG,
+		execinfrapb.WindowerSpec_LEAD,
+	}
+
+	rowsOptions := []int{4 * coldata.BatchSize(), 32 * coldata.BatchSize()}
+
+	for _, windowFn := range windowFns {
+		b.Run(fmt.Sprintf("%v", windowFn), func(b *testing.B) {
+			for _, nRows := range rowsOptions {
+				b.Run(fmt.Sprintf("rows=%d", nRows), func(b *testing.B) {
+					batchLength := nRows
+					nBatches := 1
+					if nRows >= coldata.BatchSize() {
+						batchLength = coldata.BatchSize()
+						nBatches = nRows / coldata.BatchSize()
+					}
+					batch := batchCreator(batchLength)
+					b.SetBytes(int64(nRows * (8*numIntCols + numBoolCols)))
+					for _, partitionInput := range []bool{true, false} {
+						b.Run(fmt.Sprintf("partition=%v", partitionInput), func(b *testing.B) {
+							for _, orderInput := range []bool{true, false} {
+								b.Run(fmt.Sprintf("order=%v", orderInput), func(b *testing.B) {
+									b.ResetTimer()
+									for i := 0; i < b.N; i++ {
+										source := colexectestutils.NewFiniteChunksSource(
+											testAllocator, batch, sourceTypes, nBatches, 1,
+										)
+										s := getWindowFn(windowFn, source, partitionInput, orderInput)
+										s.Init(ctx)
+										b.StartTimer()
+										for b := s.Next(); b.Length() != 0; b = s.Next() {
+										}
+										b.StopTimer()
+									}
+								})
+							}
+						})
+					}
+				})
+			}
+		})
 	}
 }


### PR DESCRIPTION
**colexec: add benchmarks for window functions**

This patch adds a benchmark which runs each window function with each
combination of partitioning vs not partitioning, and ordering vs not
ordering. For window functions that take arguments, the argument
columns are simple `int64` columns.

Release note: None

**colexec: optimize window functions for frame with many partitions**

This patch optimizes `SpillingBuffer` and the `lag` and `lead` window
functions for the case when the input is split into many partitions.
This is primarily accomplished in two ways:
1. By removing the need to take a window into input batches for
   `SpillingBuffer.AppendTuples` in the in-memory case.
2. By holding on to memory after calls to `SpillingBuffer.Reset`.
   `lag` and `lead` reset the `SpillingBuffer` at the start of
   each partition, so deeply reseting the `AppendOnlyBufferedBatch`
   is expensive when there are many partitions.

Release note: None