### PR TITLE
Change CI checkout cleanup script to not nuke artifacts

### DIFF
--- a/build/teamcity-assert-clean.sh
+++ b/build/teamcity-assert-clean.sh
@@ -4,9 +4,28 @@ set -euo pipefail
 
 source "$(dirname "${0}")/teamcity-support.sh"
 
+tmp_artifacts="$(mktemp -d -t artifacts-XXXXXXXXXX --tmpdir="$(dirname $root)")"
+
+cleanup_on_completion() {
+  remove_files_on_exit
+
+  # Restore the artifacts to the root directory so TeamCity can pick them up
+  if [ -d "${tmp_artifacts}/artifacts" ] ; then
+    mv "${tmp_artifacts}/artifacts" "$root"
+  fi
+
+  rm -rf "$tmp_artifacts"
+}
+trap cleanup_on_completion EXIT
+
 # The workspace is clean iff `git status --porcelain` produces no output. Any
 # output is either an error message or a listing of an untracked/dirty file.
 if [[ "$(git status --porcelain 2>&1)" != "" ]]; then
+  # Move the artifacts away so they are not nuked
+  if [ -d "${root}/artifacts" ] ; then
+    mv "${root}/artifacts" "$tmp_artifacts"
+  fi
+
   git status >&2 || true
   git diff -a >&2 || true
   echo "Nuking build cruft. Please teach this build to clean up after itself." >&2


### PR DESCRIPTION
Before: Many TeamCity build configurations run a cleanup script as the
last step in the process. This step nukes all non-checked-in contents of
the checkout, including the `artifacts` directory.

Why: We need to retain the artifacts to use in debugging issues.

Now: The artifacts directory is moved out of the checkout directory
while its contents are cleaned and then left in the checkout directory
once cleaning is complete so TeamCity can find and retain them.

Fixes #67116

Release note: None