### PR TITLE
sql: add infrastructure for rewriting computed column expressions

### DIFF
--- a/pkg/sql/add_column.go
+++ b/pkg/sql/add_column.go
@@ -32,6 +32,11 @@ func (p *planner) addColumnImpl(
 	t *tree.AlterTableAddColumn,
 ) error {
 	d := t.ColumnDef
+
+	if d.IsComputed() {
+		d.Computed.Expr = schemaexpr.MaybeRewriteComputedColumn(d.Computed.Expr, params.SessionData())
+	}
+
 	version := params.ExecCfg().Settings.Version.ActiveVersionOrEmpty(params.ctx)
 	toType, err := tree.ResolveType(params.ctx, d.Type, params.p.semaCtx.GetTypeResolver())
 	if err != nil {

--- a/pkg/sql/catalog/schemaexpr/BUILD.bazel
+++ b/pkg/sql/catalog/schemaexpr/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "check_constraint.go",
         "column.go",
         "computed_column.go",
+        "computed_column_rewrites.go",
         "computed_exprs.go",
         "default_exprs.go",
         "doc.go",
@@ -38,10 +39,12 @@ go_test(
     srcs = [
         "check_constraint_test.go",
         "column_test.go",
+        "computed_column_rewrites_test.go",
         "expr_test.go",
         "partial_index_test.go",
         "testutils_test.go",
     ],
+    data = glob(["testdata/**"]),
     embed = [":schemaexpr"],
     deps = [
         "//pkg/sql/catalog",
@@ -52,5 +55,8 @@ go_test(
         "//pkg/sql/sem/builtins",
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
+        "//pkg/util/leaktest",
+        "//pkg/util/log",
+        "@com_github_cockroachdb_datadriven//:datadriven",
     ],
 )

--- a/pkg/sql/catalog/schemaexpr/computed_column_rewrites.go
+++ b/pkg/sql/catalog/schemaexpr/computed_column_rewrites.go
@@ -1,0 +1,82 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package schemaexpr
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/errors"
+)
+
+// ComputedColumnRewritesMap stores a map of computed column expression
+// rewrites. The key is a formatted AST (using tree.Serialize()).
+type ComputedColumnRewritesMap map[string]tree.Expr
+
+// ParseComputedColumnRewrites parses a string of the form:
+//
+//   (before expression) -> (after expression) [, (before expression) -> (after expression) ...]
+//
+// into a ComputedColumnRewritesMap.
+//
+// Used to implement the experimental_computed_column_rewrites session setting.
+func ParseComputedColumnRewrites(val string) (ComputedColumnRewritesMap, error) {
+	if val == "" {
+		return nil, nil
+	}
+	stmt, err := parser.ParseOne(fmt.Sprintf("SET ROW (%s)", val))
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to parse column rewrites")
+	}
+	set, ok := stmt.AST.(*tree.SetVar)
+	if !ok {
+		return nil, errors.AssertionFailedf("expected a SET statement, but found %T", stmt)
+	}
+	result := make(ComputedColumnRewritesMap, len(set.Values))
+	for _, v := range set.Values {
+		binExpr, ok := v.(*tree.BinaryExpr)
+		if !ok || binExpr.Operator.Symbol != tree.JSONFetchVal {
+			return nil, errors.Newf("invalid column rewrites expression (expected -> operator)")
+		}
+		left, ok := binExpr.Left.(*tree.ParenExpr)
+		if !ok {
+			return nil, errors.Newf("missing parens around \"before\" expression")
+		}
+		right, ok := binExpr.Right.(*tree.ParenExpr)
+		if !ok {
+			return nil, errors.Newf("missing parens around \"after\" expression")
+		}
+		result[tree.Serialize(left.Expr)] = right.Expr
+	}
+	return result, nil
+}
+
+// MaybeRewriteComputedColumn consults the experimental_computed_column_rewrites
+// session setting; if the given expression matches a "before expression" in the
+// setting, it is replaced to the corresponding "after expression". Otherwise,
+// the given expression is returned unchanged.
+func MaybeRewriteComputedColumn(expr tree.Expr, sessionData *sessiondata.SessionData) tree.Expr {
+	rewritesStr := sessionData.ExperimentalComputedColumnRewrites
+	if rewritesStr == "" {
+		return expr
+	}
+	rewrites, err := ParseComputedColumnRewrites(rewritesStr)
+	if err != nil {
+		// This shouldn't happen - we should have validated the value.
+		return expr
+	}
+	if newExpr, ok := rewrites[tree.Serialize(expr)]; ok {
+		return newExpr
+	}
+	return expr
+}

--- a/pkg/sql/catalog/schemaexpr/computed_column_rewrites_test.go
+++ b/pkg/sql/catalog/schemaexpr/computed_column_rewrites_test.go
@@ -1,0 +1,53 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package schemaexpr
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/datadriven"
+)
+
+func TestParseComputedColumnRewrites(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	path := "testdata/computed_column_rewrites"
+	datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
+		switch d.Cmd {
+		case "parse":
+			rewrites, err := ParseComputedColumnRewrites(d.Input)
+			if err != nil {
+				return fmt.Sprintf("error: %v", err)
+			}
+			var keys []string
+			for k := range rewrites {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			var buf bytes.Buffer
+			for _, k := range keys {
+				fmt.Fprintf(&buf, "(%v) -> (%v)\n", k, tree.Serialize(rewrites[k]))
+			}
+			return buf.String()
+
+		default:
+			t.Fatalf("unsupported command %s", d.Cmd)
+			return ""
+		}
+	})
+}

--- a/pkg/sql/catalog/schemaexpr/testdata/computed_column_rewrites
+++ b/pkg/sql/catalog/schemaexpr/testdata/computed_column_rewrites
@@ -1,0 +1,47 @@
+parse
+foo
+----
+error: invalid column rewrites expression (expected -> operator)
+
+parse
+1 + 2
+----
+error: invalid column rewrites expression (expected -> operator)
+
+parse
+a -> b
+----
+error: missing parens around "before" expression
+
+parse
+(a) -> b
+----
+error: missing parens around "after" expression
+
+parse
+(a) -> (b), (c) -> (d)
+----
+(a) -> (b)
+(c) -> (d)
+
+parse
+(a) -> (b), (c) -> (d)
+----
+(a) -> (b)
+(c) -> (d)
+
+parse
+(a+1) -> (b+2), (c+10) -> (d+20)
+----
+(a + 1) -> (b + 2)
+(c + 10) -> (d + 20)
+
+parse
+(ts::STRING) -> ((ts AT TIME ZONE 'utc')::STRING)
+----
+(ts::STRING) -> ((timezone('utc', ts))::STRING)
+
+parse
+(mod(fnv32(ts::STRING),4)) -> (mod(fnv32((ts AT TIME ZONE 'utc')::STRING), 4))
+----
+(mod(fnv32(ts::STRING), 4)) -> (mod(fnv32((timezone('utc', ts))::STRING), 4))

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1672,6 +1672,9 @@ func NewTableDesc(
 
 	for i, def := range n.Defs {
 		if d, ok := def.(*tree.ColumnTableDef); ok {
+			if d.IsComputed() {
+				d.Computed.Expr = schemaexpr.MaybeRewriteComputedColumn(d.Computed.Expr, evalCtx.SessionData)
+			}
 			// NewTableDesc is called sometimes with a nil SemaCtx (for example
 			// during bootstrapping). In order to not panic, pass a nil TypeResolver
 			// when attempting to resolve the columns type.

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -53,6 +53,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/hydratedtables"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/contention"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsql"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
@@ -406,6 +407,17 @@ var stubCatalogTablesEnabledClusterValue = settings.RegisterBoolSetting(
 	`default value for stub_catalog_tables session setting`,
 	true,
 ).WithPublic()
+
+var experimentalComputedColumnRewrites = settings.RegisterValidatedStringSetting(
+	"sql.defaults.experimental_computed_column_rewrites",
+	"allows rewriting computed column expressions in CREATE TABLE and ALTER TABLE statements; "+
+		"the format is: '(before expression) -> (after expression) [, (before expression) -> (after expression) ...]'",
+	"", /* defaultValue */
+	func(_ *settings.Values, val string) error {
+		_, err := schemaexpr.ParseComputedColumnRewrites(val)
+		return err
+	},
+)
 
 // settingWorkMemBytes is a cluster setting that determines the maximum amount
 // of RAM that a processor can use.
@@ -2478,6 +2490,10 @@ func (m *sessionDataMutator) initSequenceCache() {
 // SetStubCatalogTableEnabled sets default value for stub_catalog_tables.
 func (m *sessionDataMutator) SetStubCatalogTablesEnabled(enabled bool) {
 	m.data.StubCatalogTablesEnabled = enabled
+}
+
+func (m *sessionDataMutator) SetExperimentalComputedColumnRewrites(val string) {
+	m.data.ExperimentalComputedColumnRewrites = val
 }
 
 // Utility functions related to scrubbing sensitive information on SQL Stats.

--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -906,3 +906,73 @@ t42418  CREATE TABLE public.t42418 (
         CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
         FAMILY "primary" (x, rowid, y)
 )
+
+# Tests for computed column rewrites.
+statement error context-dependent operators are not allowed in computed column
+CREATE TABLE trewrite(k INT PRIMARY KEY, ts TIMESTAMPTZ, c STRING AS (ts::STRING) STORED, FAMILY (k,ts,c))
+
+statement ok
+SET experimental_computed_column_rewrites = "(ts :: STRING) -> ((ts AT TIME ZONE 'utc')::STRING)";
+
+statement ok
+CREATE TABLE trewrite(k INT PRIMARY KEY, ts TIMESTAMPTZ, c STRING AS (ts::STRING) STORED, FAMILY (k,ts,c))
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE trewrite]
+----
+CREATE TABLE public.trewrite (
+   k INT8 NOT NULL,
+   ts TIMESTAMPTZ NULL,
+   c STRING NULL AS (timezone('utc':::STRING, ts)::STRING) STORED,
+   CONSTRAINT "primary" PRIMARY KEY (k ASC),
+   FAMILY fam_0_k_ts_c (k, ts, c)
+)
+
+statement ok
+DROP TABLE trewrite
+
+statement ok
+CREATE TABLE trewrite(k INT PRIMARY KEY, ts TIMESTAMPTZ, FAMILY (k,ts))
+
+statement ok
+ALTER TABLE trewrite ADD COLUMN c STRING AS (ts::STRING) STORED
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE trewrite]
+----
+CREATE TABLE public.trewrite (
+   k INT8 NOT NULL,
+   ts TIMESTAMPTZ NULL,
+   c STRING NULL AS (timezone('utc':::STRING, ts)::STRING) STORED,
+   CONSTRAINT "primary" PRIMARY KEY (k ASC),
+   FAMILY fam_0_k_ts (k, ts, c)
+)
+
+statement error invalid column rewrites expression
+SET experimental_computed_column_rewrites = "bad"
+
+statement error invalid column rewrites expression
+SET CLUSTER SETTING sql.defaults.experimental_computed_column_rewrites = "bad"
+
+statement ok
+SET experimental_computed_column_rewrites = ""
+
+statement ok
+CREATE TABLE trewrite_copy (LIKE trewrite INCLUDING ALL)
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE trewrite_copy]
+----
+CREATE TABLE public.trewrite_copy (
+   k INT8 NOT NULL,
+   ts TIMESTAMPTZ NULL,
+   c STRING NULL AS (timezone('utc':::STRING, ts)::STRING) STORED,
+   CONSTRAINT "primary" PRIMARY KEY (k ASC),
+   FAMILY "primary" (k, ts, c)
+)
+
+statement ok
+DROP TABLE trewrite
+
+statement ok
+DROP TABLE trewrite_copy

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -3994,6 +3994,7 @@ enable_insert_fast_path                               on
 enable_seqscan                                        on
 enable_zigzag_join                                    on
 escape_string_warning                                 on
+experimental_computed_column_rewrites                 ·
 experimental_enable_expression_indexes                off
 experimental_enable_hash_sharded_indexes              off
 experimental_enable_implicit_column_partitioning      off

--- a/pkg/sql/logictest/testdata/logic_test/new_schema_changer
+++ b/pkg/sql/logictest/testdata/logic_test/new_schema_changer
@@ -642,6 +642,30 @@ DROP DATABASE db1
 statement ok
 DROP DATABASE db1 CASCADE
 
+# Tests for computed column rewrites.
+statement ok
+CREATE TABLE trewrite(k INT PRIMARY KEY, ts TIMESTAMPTZ, FAMILY (k,ts))
+
+statement error context-dependent operators are not allowed in computed column
+ALTER TABLE trewrite ADD COLUMN c STRING AS (ts::STRING) STORED
+
+statement ok
+SET experimental_computed_column_rewrites = "(ts :: STRING) -> ((ts AT TIME ZONE 'utc')::STRING)";
+
+statement ok
+ALTER TABLE trewrite ADD COLUMN c STRING AS (ts::STRING) STORED
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE trewrite]
+----
+CREATE TABLE public.trewrite (
+   k INT8 NOT NULL,
+   ts TIMESTAMPTZ NULL,
+   c STRING NULL AS (timezone('utc':::STRING, ts)::STRING) STORED,
+   CONSTRAINT new_primary_key PRIMARY KEY (k ASC),
+   FAMILY fam_0_k_ts (k, ts, c)
+)
+
 # Works around view back references to tables not being cleaned up.
 # see issue #66677
 statement ok

--- a/pkg/sql/schemachanger/scbuild/table.go
+++ b/pkg/sql/schemachanger/scbuild/table.go
@@ -77,6 +77,10 @@ func (b *buildContext) alterTableAddColumn(
 ) {
 	d := t.ColumnDef
 
+	if d.IsComputed() {
+		d.Computed.Expr = schemaexpr.MaybeRewriteComputedColumn(d.Computed.Expr, b.EvalCtx.SessionData)
+	}
+
 	version := b.EvalCtx.Settings.Version.ActiveVersionOrEmpty(ctx)
 	toType, err := tree.ResolveType(ctx, d.Type, b.SemaCtx.GetTypeResolver())
 	if err != nil {

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -255,6 +255,12 @@ type LocalOnlySessionData struct {
 	// tables that are not yet implemented.
 	StubCatalogTablesEnabled bool
 
+	// ExperimentalComputedColumnRewrites allows automatic rewriting of computed
+	// column expressions in CREATE TABLE and ALTER TABLE statements. See the
+	// experimentalComputedColumnRewrites cluster setting for a description of the
+	// format.
+	ExperimentalComputedColumnRewrites string
+
 	///////////////////////////////////////////////////////////////////////////
 	// WARNING: consider whether a session parameter you're adding needs to  //
 	// be propagated to the remote nodes. If so, that parameter should live  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/delegate"
 	"github.com/cockroachdb/cockroach/pkg/sql/paramparse"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -1332,6 +1333,27 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: func(sv *settings.Values) string {
 			return formatBoolAsPostgresSetting(experimentalStreamReplicationEnabled.Get(sv))
+		},
+	},
+
+	// CockroachDB extension. See experimentalComputedColumnRewrites or
+	// ParseComputedColumnRewrites for a description of the format.
+	`experimental_computed_column_rewrites`: {
+		Hidden:       true,
+		GetStringVal: makePostgresBoolGetStringValFn(`experimental_computed_column_rewrites`),
+		Set: func(_ context.Context, m *sessionDataMutator, s string) error {
+			_, err := schemaexpr.ParseComputedColumnRewrites(s)
+			if err != nil {
+				return err
+			}
+			m.SetExperimentalComputedColumnRewrites(s)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext) string {
+			return evalCtx.SessionData.ExperimentalComputedColumnRewrites
+		},
+		GlobalDefault: func(sv *settings.Values) string {
+			return experimentalComputedColumnRewrites.Get(sv)
 		},
 	},
 }


### PR DESCRIPTION
sql: add infrastructure for rewriting computed column expressions
  
This commit adds infrastructure that allows automatic replacement of
computed column expressions in CREATE TABLE and ALTER TABLE
statements. This provides a workaround for cases where a computed
column expression is no longer allowed (because of better detection of
context-dependent operators) but the DDL statements cannot be easily
changed.

This is configured via a new (hidden) session setting
`experimental_computed_column_rewrites`. The default value of the
setting can be controlled using the cluster setting
`sql.defaults.experimental_computed_column_rewrites`.

The value is a string of the form:
```
(before expression) -> (after expression) [, (before expression) -> (after expression) ...]
```

In order for a computed column to be rewritten, the entire computed
column expression must parse into the same AST as a "before
expression".

Example:
```
CREATE TABLE t (ts TIMESTAMPTZ NOT NULL, shard INT NOT NULL AS (mod(fnv32(ts::STRING), 4)) STORED);
ERROR: mod(): fnv32(): timestamptz::string: context-dependent operators are not allowed in computed column
SQLSTATE: 0A000
HINT: TIMESTAMPTZ to STRING casts depend on the current timezone; consider using (t AT TIME ZONE 'UTC')::STRING instead.

SET experimental_computed_column_rewrites = "(mod(fnv32(ts::STRING), 4)) -> (mod(fnv32((ts AT TIME ZONE 'utc')::STRING), 4))";

CREATE TABLE t (ts TIMESTAMPTZ NOT NULL, shard INT NOT NULL AS (mod(fnv32(ts::STRING), 4)) STORED);

SHOW CREATE TABLE t;
  table_name |                                        create_statement
-------------+--------------------------------------------------------------------------------------------------
  t          | CREATE TABLE public.t (
             |     ts TIMESTAMPTZ NOT NULL,
             |     shard INT8 NOT NULL AS (mod(fnv32(timezone('utc':::STRING, ts)::STRING), 4:::INT8)) STORED,
             |     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
             |     CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
             |     FAMILY "primary" (ts, shard, rowid)
             | )
```

Release note: None