### PR TITLE
bazel: add config setting for `devdarwinx86_64`, fix broken build

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -24,3 +24,9 @@ build:crossmacos --platforms=//build/toolchains:cross_macos
 build:crossmacos --crosstool_top=@toolchain_cross_x86_64-apple-darwin19//:suite
 build:crosslinuxarm --platforms=//build/toolchains:cross_linux_arm
 build:crosslinuxarm --crosstool_top=@toolchain_cross_aarch64-unknown-linux-gnu//:suite
+
+# developer configurations. Add e.g. --config=devdarwinx86_64 to turn these on.
+build:devdarwinx86_64 --crosstool_top=@toolchain_dev_darwin_x86-64//:suite
+# NOTE(ricky): This is consumed in `BUILD` files (see
+# `build/toolchains/BUILD.bazel`).
+build:devdarwinx86_64 --define cockroach_bazel_dev=y

--- a/build/toolchains/BUILD.bazel
+++ b/build/toolchains/BUILD.bazel
@@ -85,3 +85,10 @@ platform(
         "@platforms//cpu:arm64",
     ],
 )
+
+config_setting(
+    name = "dev",
+    define_values = {
+        "cockroach_bazel_dev": "y",
+    },
+)

--- a/c-deps/BUILD.bazel
+++ b/c-deps/BUILD.bazel
@@ -6,6 +6,10 @@ load("@rules_foreign_cc//foreign_cc:configure.bzl", "configure_make")
 configure_make(
     name = "libjemalloc",
     autoconf = True,
+    configure_env_vars = select({
+        "//build/toolchains:dev": {"AR": ""},
+        "//conditions:default": {},
+    }),
     configure_in_place = True,
     configure_options = [
         "--enable-prof",


### PR DESCRIPTION
We already have `--config`s for various CI options, so adding one for
developers makes sense too. Also, restore an environment variable that
needs to be set on Windows machines when compiling `jemalloc` for macOS
native builds (`AR=`). This was part of the `c-deps/BUILD.bazel` file
until `7a68bbdf5b4424379e83288a87af93e5b72d7174`, but the build has been
broken on my machine since that commit -- the `select()` here preserves
the existing behavior but allows you to opt into the hack where
necessary.

Release note: None