### PR TITLE
.gitattributes: show diffs in deps.bzl

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,3 @@
 *.pb.* -diff
 *.eg.go -diff
-DEPS.bzl -diff
 pkg/BUILD.bazel -diff


### PR DESCRIPTION
These diffs are meaningful and can be made by hand so they should not be hidden.

Release note: none.