### PR TITLE
roachtest: avoid access to `cockroach` and `workload` globals

### DIFF
--- a/pkg/cmd/roachtest/activerecord.go
+++ b/pkg/cmd/roachtest/activerecord.go
@@ -39,7 +39,7 @@ func registerActiveRecord(r *testRegistry) {
 		}
 		node := c.Node(1)
 		t.Status("setting up cockroach")
-		c.Put(ctx, cockroach, "./cockroach", c.All())
+		c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
 		if err := c.PutLibraries(ctx, "./lib"); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/cmd/roachtest/allocator.go
+++ b/pkg/cmd/roachtest/allocator.go
@@ -27,7 +27,7 @@ import (
 
 func registerAllocator(r *testRegistry) {
 	runAllocator := func(ctx context.Context, t test.Test, c cluster.Cluster, start int, maxStdDev float64) {
-		c.Put(ctx, cockroach, "./cockroach")
+		c.Put(ctx, t.Cockroach(), "./cockroach")
 
 		// Start the first `start` nodes and restore a tpch fixture.
 		args := startArgs("--args=--vmodule=store_rebalancer=5,allocator=5,allocator_scorer=5,replicate_queue=5")
@@ -266,7 +266,7 @@ func runWideReplication(ctx context.Context, t test.Test, c cluster.Cluster) {
 		"--env=COCKROACH_SCAN_MAX_IDLE_TIME=5ms",
 		"--args=--vmodule=replicate_queue=6",
 	)
-	c.Put(ctx, cockroach, "./cockroach")
+	c.Put(ctx, t.Cockroach(), "./cockroach")
 	c.Start(ctx, c.All(), args)
 
 	db := c.Conn(ctx, 1)

--- a/pkg/cmd/roachtest/alterpk.go
+++ b/pkg/cmd/roachtest/alterpk.go
@@ -29,7 +29,7 @@ func registerAlterPK(r *testRegistry) {
 		loadNode := c.Node(c.Spec().NodeCount)
 		t.Status("copying binaries")
 		c.Put(ctx, t.Cockroach(), "./cockroach", roachNodes)
-		c.Put(ctx, workload, "./workload", loadNode)
+		c.Put(ctx, t.DeprecatedWorkload(), "./workload", loadNode)
 
 		t.Status("starting cockroach nodes")
 		c.Start(ctx, roachNodes)

--- a/pkg/cmd/roachtest/alterpk.go
+++ b/pkg/cmd/roachtest/alterpk.go
@@ -28,7 +28,7 @@ func registerAlterPK(r *testRegistry) {
 		roachNodes := c.Range(1, c.Spec().NodeCount-1)
 		loadNode := c.Node(c.Spec().NodeCount)
 		t.Status("copying binaries")
-		c.Put(ctx, cockroach, "./cockroach", roachNodes)
+		c.Put(ctx, t.Cockroach(), "./cockroach", roachNodes)
 		c.Put(ctx, workload, "./workload", loadNode)
 
 		t.Status("starting cockroach nodes")

--- a/pkg/cmd/roachtest/autoupgrade.go
+++ b/pkg/cmd/roachtest/autoupgrade.go
@@ -121,7 +121,7 @@ func registerAutoUpgrade(r *testRegistry) {
 			if err := c.StopCockroachGracefullyOnNode(ctx, i); err != nil {
 				t.Fatal(err)
 			}
-			c.Put(ctx, cockroach, "./cockroach", c.Node(i))
+			c.Put(ctx, t.Cockroach(), "./cockroach", c.Node(i))
 			c.Start(ctx, c.Node(i), startArgsDontEncrypt)
 			if err := sleep(stageDuration); err != nil {
 				t.Fatal(err)
@@ -143,7 +143,7 @@ func registerAutoUpgrade(r *testRegistry) {
 		if err := c.StopCockroachGracefullyOnNode(ctx, nodes); err != nil {
 			t.Fatal(err)
 		}
-		c.Put(ctx, cockroach, "./cockroach", c.Node(nodes))
+		c.Put(ctx, t.Cockroach(), "./cockroach", c.Node(nodes))
 		c.Start(ctx, c.Node(nodes), startArgsDontEncrypt)
 		if err := sleep(stageDuration); err != nil {
 			t.Fatal(err)

--- a/pkg/cmd/roachtest/backup.go
+++ b/pkg/cmd/roachtest/backup.go
@@ -52,7 +52,7 @@ const (
 )
 
 func importBankDataSplit(
-	ctx context.Context, rows, ranges int, _ test.Test, c cluster.Cluster,
+	ctx context.Context, rows, ranges int, t test.Test, c cluster.Cluster,
 ) string {
 	dest := c.Name()
 	// Randomize starting with encryption-at-rest enabled.
@@ -63,7 +63,7 @@ func importBankDataSplit(
 	}
 
 	c.Put(ctx, workload, "./workload")
-	c.Put(ctx, cockroach, "./cockroach")
+	c.Put(ctx, t.Cockroach(), "./cockroach")
 
 	// NB: starting the cluster creates the logs dir as a side effect,
 	// needed below.
@@ -346,7 +346,7 @@ func registerBackup(r *testRegistry) {
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			// Randomize starting with encryption-at-rest enabled.
 			c.EncryptAtRandom(true)
-			c.Put(ctx, cockroach, "./cockroach")
+			c.Put(ctx, t.Cockroach(), "./cockroach")
 			c.Put(ctx, workload, "./workload")
 			c.Start(ctx)
 			conn := c.Conn(ctx, 1)

--- a/pkg/cmd/roachtest/backup.go
+++ b/pkg/cmd/roachtest/backup.go
@@ -62,7 +62,7 @@ func importBankDataSplit(
 		dest += fmt.Sprintf("%d", timeutil.Now().UnixNano())
 	}
 
-	c.Put(ctx, workload, "./workload")
+	c.Put(ctx, t.DeprecatedWorkload(), "./workload")
 	c.Put(ctx, t.Cockroach(), "./cockroach")
 
 	// NB: starting the cluster creates the logs dir as a side effect,
@@ -347,7 +347,7 @@ func registerBackup(r *testRegistry) {
 			// Randomize starting with encryption-at-rest enabled.
 			c.EncryptAtRandom(true)
 			c.Put(ctx, t.Cockroach(), "./cockroach")
-			c.Put(ctx, workload, "./workload")
+			c.Put(ctx, t.DeprecatedWorkload(), "./workload")
 			c.Start(ctx)
 			conn := c.Conn(ctx, 1)
 

--- a/pkg/cmd/roachtest/build_info.go
+++ b/pkg/cmd/roachtest/build_info.go
@@ -22,7 +22,7 @@ import (
 )
 
 func runBuildInfo(ctx context.Context, t test.Test, c cluster.Cluster) {
-	c.Put(ctx, cockroach, "./cockroach")
+	c.Put(ctx, t.Cockroach(), "./cockroach")
 	c.Start(ctx)
 
 	var details serverpb.DetailsResponse
@@ -60,7 +60,7 @@ func runBuildAnalyze(ctx context.Context, t test.Test, c cluster.Cluster) {
 		t.Skip("local execution not supported")
 	}
 
-	c.Put(ctx, cockroach, "./cockroach")
+	c.Put(ctx, t.Cockroach(), "./cockroach")
 
 	// 1. Check for executable stack.
 	//

--- a/pkg/cmd/roachtest/cancel.go
+++ b/pkg/cmd/roachtest/cancel.go
@@ -40,7 +40,7 @@ import (
 // replaced with unit tests.
 func registerCancel(r *testRegistry) {
 	runCancel := func(ctx context.Context, t test.Test, c cluster.Cluster, tpchQueriesToRun []int, useDistsql bool) {
-		c.Put(ctx, cockroach, "./cockroach", c.All())
+		c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
 		c.Start(ctx, c.All())
 
 		m := newMonitor(ctx, c, c.All())

--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -81,7 +81,7 @@ func cdcBasicTest(ctx context.Context, t test.Test, c cluster.Cluster, args cdcT
 	workloadNode := c.Node(c.Spec().NodeCount)
 	kafkaNode := c.Node(c.Spec().NodeCount)
 	c.Put(ctx, t.Cockroach(), "./cockroach")
-	c.Put(ctx, workload, "./workload", workloadNode)
+	c.Put(ctx, t.DeprecatedWorkload(), "./workload", workloadNode)
 	c.Start(ctx, crdbNodes)
 
 	db := c.Conn(ctx, 1)
@@ -275,7 +275,7 @@ func runCDCBank(ctx context.Context, t test.Test, c cluster.Cluster) {
 
 	crdbNodes, workloadNode, kafkaNode := c.Range(1, c.Spec().NodeCount-1), c.Node(c.Spec().NodeCount), c.Node(c.Spec().NodeCount)
 	c.Put(ctx, t.Cockroach(), "./cockroach", crdbNodes)
-	c.Put(ctx, workload, "./workload", workloadNode)
+	c.Put(ctx, t.DeprecatedWorkload(), "./workload", workloadNode)
 	c.Start(ctx, crdbNodes)
 	kafka := kafkaManager{
 		t:     t,

--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -80,7 +80,7 @@ func cdcBasicTest(ctx context.Context, t test.Test, c cluster.Cluster, args cdcT
 	crdbNodes := c.Range(1, c.Spec().NodeCount-1)
 	workloadNode := c.Node(c.Spec().NodeCount)
 	kafkaNode := c.Node(c.Spec().NodeCount)
-	c.Put(ctx, cockroach, "./cockroach")
+	c.Put(ctx, t.Cockroach(), "./cockroach")
 	c.Put(ctx, workload, "./workload", workloadNode)
 	c.Start(ctx, crdbNodes)
 
@@ -274,7 +274,7 @@ func runCDCBank(ctx context.Context, t test.Test, c cluster.Cluster) {
 	c.Run(ctx, c.All(), `mkdir -p logs`)
 
 	crdbNodes, workloadNode, kafkaNode := c.Range(1, c.Spec().NodeCount-1), c.Node(c.Spec().NodeCount), c.Node(c.Spec().NodeCount)
-	c.Put(ctx, cockroach, "./cockroach", crdbNodes)
+	c.Put(ctx, t.Cockroach(), "./cockroach", crdbNodes)
 	c.Put(ctx, workload, "./workload", workloadNode)
 	c.Start(ctx, crdbNodes)
 	kafka := kafkaManager{
@@ -427,7 +427,7 @@ func runCDCBank(ctx context.Context, t test.Test, c cluster.Cluster) {
 func runCDCSchemaRegistry(ctx context.Context, t test.Test, c cluster.Cluster) {
 
 	crdbNodes, kafkaNode := c.Node(1), c.Node(1)
-	c.Put(ctx, cockroach, "./cockroach", crdbNodes)
+	c.Put(ctx, t.Cockroach(), "./cockroach", crdbNodes)
 	c.Start(ctx, crdbNodes)
 	kafka := kafkaManager{
 		t:     t,
@@ -558,7 +558,7 @@ func runCDCKafkaAuth(ctx context.Context, t test.Test, c cluster.Cluster) {
 	}
 
 	crdbNodes, kafkaNode := c.Range(1, lastCrdbNode), c.Node(c.Spec().NodeCount)
-	c.Put(ctx, cockroach, "./cockroach", crdbNodes)
+	c.Put(ctx, t.Cockroach(), "./cockroach", crdbNodes)
 	c.Start(ctx, crdbNodes)
 
 	kafka := kafkaManager{

--- a/pkg/cmd/roachtest/clearrange.go
+++ b/pkg/cmd/roachtest/clearrange.go
@@ -44,7 +44,7 @@ func registerClearRange(r *testRegistry) {
 func runClearRange(ctx context.Context, t test.Test, c cluster.Cluster, aggressiveChecks bool) {
 	// Randomize starting with encryption-at-rest enabled.
 	c.EncryptAtRandom(true)
-	c.Put(ctx, cockroach, "./cockroach")
+	c.Put(ctx, t.Cockroach(), "./cockroach")
 
 	t.Status("restoring fixture")
 	c.Start(ctx)

--- a/pkg/cmd/roachtest/cli.go
+++ b/pkg/cmd/roachtest/cli.go
@@ -22,7 +22,7 @@ import (
 )
 
 func runCLINodeStatus(ctx context.Context, t test.Test, c cluster.Cluster) {
-	c.Put(ctx, cockroach, "./cockroach")
+	c.Put(ctx, t.Cockroach(), "./cockroach")
 	c.Start(ctx, c.Range(1, 3))
 
 	db := c.Conn(ctx, 1)

--- a/pkg/cmd/roachtest/clock_jump_crash.go
+++ b/pkg/cmd/roachtest/clock_jump_crash.go
@@ -35,7 +35,7 @@ func runClockJump(ctx context.Context, t test.Test, c cluster.Cluster, tc clockJ
 	}
 
 	if err := c.RunE(ctx, c.Node(1), "test -x ./cockroach"); err != nil {
-		c.Put(ctx, cockroach, "./cockroach", c.All())
+		c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
 	}
 	c.Wipe(ctx)
 	c.Start(ctx)

--- a/pkg/cmd/roachtest/clock_monotonic.go
+++ b/pkg/cmd/roachtest/clock_monotonic.go
@@ -37,7 +37,7 @@ func runClockMonotonicity(
 	}
 
 	if err := c.RunE(ctx, c.Node(1), "test -x ./cockroach"); err != nil {
-		c.Put(ctx, cockroach, "./cockroach", c.All())
+		c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
 	}
 	c.Wipe(ctx)
 	c.Start(ctx)

--- a/pkg/cmd/roachtest/cluster_init.go
+++ b/pkg/cmd/roachtest/cluster_init.go
@@ -29,7 +29,7 @@ import (
 )
 
 func runClusterInit(ctx context.Context, t test.Test, c cluster.Cluster) {
-	c.Put(ctx, cockroach, "./cockroach")
+	c.Put(ctx, t.Cockroach(), "./cockroach")
 
 	addrs, err := c.InternalAddr(ctx, c.All())
 	if err != nil {

--- a/pkg/cmd/roachtest/cluster_test.go
+++ b/pkg/cmd/roachtest/cluster_test.go
@@ -67,6 +67,10 @@ func (t testWrapper) BuildVersion() *version.Version {
 	panic("implement me")
 }
 
+func (t testWrapper) Cockroach() string {
+	return "./dummy-path/to/cockroach"
+}
+
 func (t testWrapper) IsBuildVersion(s string) bool {
 	panic("implement me")
 }

--- a/pkg/cmd/roachtest/cluster_test.go
+++ b/pkg/cmd/roachtest/cluster_test.go
@@ -71,6 +71,10 @@ func (t testWrapper) Cockroach() string {
 	return "./dummy-path/to/cockroach"
 }
 
+func (t testWrapper) DeprecatedWorkload() string {
+	return "./dummy-path/to/workload"
+}
+
 func (t testWrapper) IsBuildVersion(s string) bool {
 	panic("implement me")
 }

--- a/pkg/cmd/roachtest/connection_latency.go
+++ b/pkg/cmd/roachtest/connection_latency.go
@@ -34,7 +34,7 @@ func runConnectionLatencyTest(
 	err := c.PutE(ctx, t.L(), t.Cockroach(), "./cockroach")
 	require.NoError(t, err)
 
-	err = c.PutE(ctx, t.L(), workload, "./workload")
+	err = c.PutE(ctx, t.L(), t.DeprecatedWorkload(), "./workload")
 	require.NoError(t, err)
 
 	err = c.StartE(ctx, startArgs("--secure"))

--- a/pkg/cmd/roachtest/connection_latency.go
+++ b/pkg/cmd/roachtest/connection_latency.go
@@ -31,7 +31,7 @@ const (
 func runConnectionLatencyTest(
 	ctx context.Context, t test.Test, c cluster.Cluster, numNodes int, numZones int,
 ) {
-	err := c.PutE(ctx, t.L(), cockroach, "./cockroach")
+	err := c.PutE(ctx, t.L(), t.Cockroach(), "./cockroach")
 	require.NoError(t, err)
 
 	err = c.PutE(ctx, t.L(), workload, "./workload")

--- a/pkg/cmd/roachtest/copy.go
+++ b/pkg/cmd/roachtest/copy.go
@@ -41,7 +41,7 @@ func registerCopy(r *testRegistry) {
 		const rowEstimate = rowOverheadEstimate + payload
 
 		c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
-		c.Put(ctx, workload, "./workload", c.All())
+		c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.All())
 		c.Start(ctx, c.All())
 
 		m := newMonitor(ctx, c, c.All())

--- a/pkg/cmd/roachtest/copy.go
+++ b/pkg/cmd/roachtest/copy.go
@@ -40,7 +40,7 @@ func registerCopy(r *testRegistry) {
 		const rowOverheadEstimate = 160
 		const rowEstimate = rowOverheadEstimate + payload
 
-		c.Put(ctx, cockroach, "./cockroach", c.All())
+		c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
 		c.Put(ctx, workload, "./workload", c.All())
 		c.Start(ctx, c.All())
 

--- a/pkg/cmd/roachtest/decommission.go
+++ b/pkg/cmd/roachtest/decommission.go
@@ -105,7 +105,7 @@ func runDecommission(
 	// through which we run the workload and other queries.
 	pinnedNode := 1
 	c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
-	c.Put(ctx, workload, "./workload", c.Node(pinnedNode))
+	c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(pinnedNode))
 
 	for i := 1; i <= nodes; i++ {
 		c.Start(ctx, c.Node(i), startArgs(fmt.Sprintf("-a=--attrs=node%d", i)))

--- a/pkg/cmd/roachtest/decommission.go
+++ b/pkg/cmd/roachtest/decommission.go
@@ -104,7 +104,7 @@ func runDecommission(
 	// node1 is kept pinned (i.e. not decommissioned/restarted), and is the node
 	// through which we run the workload and other queries.
 	pinnedNode := 1
-	c.Put(ctx, cockroach, "./cockroach", c.All())
+	c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
 	c.Put(ctx, workload, "./workload", c.Node(pinnedNode))
 
 	for i := 1; i <= nodes; i++ {
@@ -304,7 +304,7 @@ func runDecommission(
 // irreversible operation.
 func runDecommissionRandomized(ctx context.Context, t test.Test, c cluster.Cluster) {
 	args := startArgs("--env=COCKROACH_SCAN_MAX_IDLE_TIME=5ms")
-	c.Put(ctx, cockroach, "./cockroach")
+	c.Put(ctx, t.Cockroach(), "./cockroach")
 	c.Start(ctx, args)
 
 	h := newDecommTestHelper(t, c)

--- a/pkg/cmd/roachtest/disk_full.go
+++ b/pkg/cmd/roachtest/disk_full.go
@@ -34,7 +34,7 @@ func registerDiskFull(r *testRegistry) {
 
 			nodes := c.Spec().NodeCount - 1
 			c.Put(ctx, t.Cockroach(), "./cockroach", c.Range(1, nodes))
-			c.Put(ctx, workload, "./workload", c.Node(nodes+1))
+			c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(nodes+1))
 			c.Start(ctx, c.Range(1, nodes))
 
 			t.Status("running workload")

--- a/pkg/cmd/roachtest/disk_full.go
+++ b/pkg/cmd/roachtest/disk_full.go
@@ -33,7 +33,7 @@ func registerDiskFull(r *testRegistry) {
 			}
 
 			nodes := c.Spec().NodeCount - 1
-			c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
+			c.Put(ctx, t.Cockroach(), "./cockroach", c.Range(1, nodes))
 			c.Put(ctx, workload, "./workload", c.Node(nodes+1))
 			c.Start(ctx, c.Range(1, nodes))
 

--- a/pkg/cmd/roachtest/disk_stall.go
+++ b/pkg/cmd/roachtest/disk_stall.go
@@ -55,7 +55,7 @@ func runDiskStalledDetection(
 
 	n := c.Node(1)
 
-	c.Put(ctx, cockroach, "./cockroach")
+	c.Put(ctx, t.Cockroach(), "./cockroach")
 	c.Run(ctx, n, "sudo umount -f {store-dir}/faulty || true")
 	c.Run(ctx, n, "mkdir -p {store-dir}/{real,faulty} || true")
 	// Make sure the actual logs are downloaded as artifacts.

--- a/pkg/cmd/roachtest/django.go
+++ b/pkg/cmd/roachtest/django.go
@@ -37,7 +37,7 @@ func registerDjango(r *testRegistry) {
 		}
 		node := c.Node(1)
 		t.Status("setting up cockroach")
-		c.Put(ctx, cockroach, "./cockroach", c.All())
+		c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
 		c.Start(ctx, c.All())
 
 		version, err := fetchCockroachVersion(ctx, c, node[0], nil)

--- a/pkg/cmd/roachtest/drop.go
+++ b/pkg/cmd/roachtest/drop.go
@@ -32,7 +32,7 @@ func registerDrop(r *testRegistry) {
 	// rows). Next, it issues a `DROP` for the whole database, and sets the GC TTL
 	// to one second.
 	runDrop := func(ctx context.Context, t test.Test, c cluster.Cluster, warehouses, nodes int) {
-		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
+		c.Put(ctx, t.Cockroach(), "./cockroach", c.Range(1, nodes))
 		c.Put(ctx, workload, "./workload", c.Range(1, nodes))
 		c.Start(ctx, c.Range(1, nodes), startArgs("-e", "COCKROACH_MEMPROF_INTERVAL=15s"))
 

--- a/pkg/cmd/roachtest/drop.go
+++ b/pkg/cmd/roachtest/drop.go
@@ -33,7 +33,7 @@ func registerDrop(r *testRegistry) {
 	// to one second.
 	runDrop := func(ctx context.Context, t test.Test, c cluster.Cluster, warehouses, nodes int) {
 		c.Put(ctx, t.Cockroach(), "./cockroach", c.Range(1, nodes))
-		c.Put(ctx, workload, "./workload", c.Range(1, nodes))
+		c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Range(1, nodes))
 		c.Start(ctx, c.Range(1, nodes), startArgs("-e", "COCKROACH_MEMPROF_INTERVAL=15s"))
 
 		m := newMonitor(ctx, c, c.Range(1, nodes))

--- a/pkg/cmd/roachtest/encryption.go
+++ b/pkg/cmd/roachtest/encryption.go
@@ -25,7 +25,7 @@ func registerEncryption(r *testRegistry) {
 	// to test the correctness of encryption at rest.
 	runEncryption := func(ctx context.Context, t test.Test, c cluster.Cluster) {
 		nodes := c.Spec().NodeCount
-		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
+		c.Put(ctx, t.Cockroach(), "./cockroach", c.Range(1, nodes))
 		c.Start(ctx, c.Range(1, nodes), startArgs("--encrypt"))
 
 		// Check that /_status/stores/local endpoint has encryption status.

--- a/pkg/cmd/roachtest/engine_switch.go
+++ b/pkg/cmd/roachtest/engine_switch.go
@@ -29,7 +29,7 @@ func registerEngineSwitch(r *testRegistry) {
 	runEngineSwitch := func(ctx context.Context, t test.Test, c cluster.Cluster, additionalArgs ...string) {
 		roachNodes := c.Range(1, c.Spec().NodeCount-1)
 		loadNode := c.Node(c.Spec().NodeCount)
-		c.Put(ctx, workload, "./workload", loadNode)
+		c.Put(ctx, t.DeprecatedWorkload(), "./workload", loadNode)
 		c.Put(ctx, t.Cockroach(), "./cockroach", roachNodes)
 		pebbleArgs := startArgs(append(additionalArgs, "--args=--storage-engine=pebble")...)
 		rocksdbArgs := startArgs(append(additionalArgs, "--args=--storage-engine=rocksdb")...)

--- a/pkg/cmd/roachtest/engine_switch.go
+++ b/pkg/cmd/roachtest/engine_switch.go
@@ -30,7 +30,7 @@ func registerEngineSwitch(r *testRegistry) {
 		roachNodes := c.Range(1, c.Spec().NodeCount-1)
 		loadNode := c.Node(c.Spec().NodeCount)
 		c.Put(ctx, workload, "./workload", loadNode)
-		c.Put(ctx, cockroach, "./cockroach", roachNodes)
+		c.Put(ctx, t.Cockroach(), "./cockroach", roachNodes)
 		pebbleArgs := startArgs(append(additionalArgs, "--args=--storage-engine=pebble")...)
 		rocksdbArgs := startArgs(append(additionalArgs, "--args=--storage-engine=rocksdb")...)
 		c.Start(ctx, roachNodes, rocksdbArgs)

--- a/pkg/cmd/roachtest/event_log.go
+++ b/pkg/cmd/roachtest/event_log.go
@@ -28,7 +28,7 @@ func runEventLog(ctx context.Context, t test.Test, c cluster.Cluster) {
 		NodeID roachpb.NodeID
 	}
 
-	c.Put(ctx, cockroach, "./cockroach")
+	c.Put(ctx, t.Cockroach(), "./cockroach")
 	c.Start(ctx)
 
 	// Verify that "node joined" and "node restart" events are recorded whenever

--- a/pkg/cmd/roachtest/flowable.go
+++ b/pkg/cmd/roachtest/flowable.go
@@ -33,7 +33,7 @@ func registerFlowable(r *testRegistry) {
 		}
 		node := c.Node(1)
 		t.Status("setting up cockroach")
-		c.Put(ctx, cockroach, "./cockroach", c.All())
+		c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
 		c.Start(ctx, c.All())
 
 		t.Status("cloning flowable and installing prerequisites")

--- a/pkg/cmd/roachtest/follower_reads.go
+++ b/pkg/cmd/roachtest/follower_reads.go
@@ -47,7 +47,7 @@ func registerFollowerReads(r *testRegistry) {
 			Owner:   OwnerKV,
 			Cluster: r.makeClusterSpec(6, spec.CPU(2), spec.Geo(), spec.Zones("us-east1-b,us-east1-b,us-east1-b,us-west1-b,us-west1-b,europe-west2-b")),
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-				c.Put(ctx, cockroach, "./cockroach")
+				c.Put(ctx, t.Cockroach(), "./cockroach")
 				c.Wipe(ctx)
 				c.Start(ctx)
 				topology := topologySpec{multiRegion: true, locality: locality, survival: survival}

--- a/pkg/cmd/roachtest/gopg.go
+++ b/pkg/cmd/roachtest/gopg.go
@@ -46,7 +46,7 @@ func registerGopg(r *testRegistry) {
 		}
 		node := c.Node(1)
 		t.Status("setting up cockroach")
-		c.Put(ctx, cockroach, "./cockroach", c.All())
+		c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
 		c.Start(ctx, c.All())
 		version, err := fetchCockroachVersion(ctx, c, node[0], nil)
 		if err != nil {

--- a/pkg/cmd/roachtest/gorm.go
+++ b/pkg/cmd/roachtest/gorm.go
@@ -30,7 +30,7 @@ func registerGORM(r *testRegistry) {
 		}
 		node := c.Node(1)
 		t.Status("setting up cockroach")
-		c.Put(ctx, cockroach, "./cockroach", c.All())
+		c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
 		c.Start(ctx, c.All())
 		version, err := fetchCockroachVersion(ctx, c, node[0], nil)
 		if err != nil {

--- a/pkg/cmd/roachtest/gossip.go
+++ b/pkg/cmd/roachtest/gossip.go
@@ -36,7 +36,7 @@ import (
 func registerGossip(r *testRegistry) {
 	runGossipChaos := func(ctx context.Context, t test.Test, c cluster.Cluster) {
 		args := startArgs("--args=--vmodule=*=1")
-		c.Put(ctx, cockroach, "./cockroach", c.All())
+		c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
 		c.Start(ctx, c.All(), args)
 		waitForFullReplication(t, c.Conn(ctx, 1))
 
@@ -286,7 +286,7 @@ func (g *gossipUtil) checkConnectedAndFunctional(
 }
 
 func runGossipPeerings(ctx context.Context, t test.Test, c cluster.Cluster) {
-	c.Put(ctx, cockroach, "./cockroach")
+	c.Put(ctx, t.Cockroach(), "./cockroach")
 	c.Start(ctx)
 
 	// Repeatedly restart a random node and verify that all of the nodes are
@@ -321,7 +321,7 @@ func runGossipPeerings(ctx context.Context, t test.Test, c cluster.Cluster) {
 func runGossipRestart(ctx context.Context, t test.Test, c cluster.Cluster) {
 	t.Skip("skipping flaky acceptance/gossip/restart", "https://github.com/cockroachdb/cockroach/issues/48423")
 
-	c.Put(ctx, cockroach, "./cockroach")
+	c.Put(ctx, t.Cockroach(), "./cockroach")
 	c.Start(ctx)
 
 	// Repeatedly stop and restart a cluster and verify that we can perform basic
@@ -346,7 +346,7 @@ func runGossipRestart(ctx context.Context, t test.Test, c cluster.Cluster) {
 
 func runGossipRestartNodeOne(ctx context.Context, t test.Test, c cluster.Cluster) {
 	args := startArgs("--env=COCKROACH_SCAN_MAX_IDLE_TIME=5ms", "--encrypt=false")
-	c.Put(ctx, cockroach, "./cockroach")
+	c.Put(ctx, t.Cockroach(), "./cockroach")
 	// Reduce the scan max idle time to speed up evacuation of node 1.
 	c.Start(ctx, racks(c.Spec().NodeCount), args)
 
@@ -496,7 +496,7 @@ SELECT count(replicas)
 }
 
 func runCheckLocalityIPAddress(ctx context.Context, t test.Test, c cluster.Cluster) {
-	c.Put(ctx, cockroach, "./cockroach")
+	c.Put(ctx, t.Cockroach(), "./cockroach")
 
 	externalIP, err := c.ExternalIP(ctx, c.Range(1, c.Spec().NodeCount))
 	if err != nil {

--- a/pkg/cmd/roachtest/hibernate.go
+++ b/pkg/cmd/roachtest/hibernate.go
@@ -76,7 +76,7 @@ func registerHibernate(r *testRegistry, opt hibernateOptions) {
 		}
 		node := c.Node(1)
 		t.Status("setting up cockroach")
-		c.Put(ctx, cockroach, "./cockroach", c.All())
+		c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
 		if err := c.PutLibraries(ctx, "./lib"); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/cmd/roachtest/hotspotsplits.go
+++ b/pkg/cmd/roachtest/hotspotsplits.go
@@ -35,7 +35,7 @@ func registerHotSpotSplits(r *testRegistry) {
 		c.Put(ctx, t.Cockroach(), "./cockroach", roachNodes)
 		c.Start(ctx, roachNodes)
 
-		c.Put(ctx, workload, "./workload", appNode)
+		c.Put(ctx, t.DeprecatedWorkload(), "./workload", appNode)
 		c.Run(ctx, appNode, `./workload init kv --drop {pgurl:1}`)
 
 		var m *errgroup.Group // see comment in version.go

--- a/pkg/cmd/roachtest/hotspotsplits.go
+++ b/pkg/cmd/roachtest/hotspotsplits.go
@@ -32,7 +32,7 @@ func registerHotSpotSplits(r *testRegistry) {
 		roachNodes := c.Range(1, c.Spec().NodeCount-1)
 		appNode := c.Node(c.Spec().NodeCount)
 
-		c.Put(ctx, cockroach, "./cockroach", roachNodes)
+		c.Put(ctx, t.Cockroach(), "./cockroach", roachNodes)
 		c.Start(ctx, roachNodes)
 
 		c.Put(ctx, workload, "./workload", appNode)

--- a/pkg/cmd/roachtest/import.go
+++ b/pkg/cmd/roachtest/import.go
@@ -95,7 +95,7 @@ func registerImportTPCC(r *testRegistry) {
 		// Randomize starting with encryption-at-rest enabled.
 		c.EncryptAtRandom(true)
 		c.Put(ctx, t.Cockroach(), "./cockroach")
-		c.Put(ctx, workload, "./workload")
+		c.Put(ctx, t.DeprecatedWorkload(), "./workload")
 		t.Status("starting csv servers")
 		c.Start(ctx)
 		c.Run(ctx, c.All(), `./workload csv-server --port=8081 &> logs/workload-csv-server.log < /dev/null &`)
@@ -330,7 +330,7 @@ func registerImportDecommissioned(r *testRegistry) {
 		}
 
 		c.Put(ctx, t.Cockroach(), "./cockroach")
-		c.Put(ctx, workload, "./workload")
+		c.Put(ctx, t.DeprecatedWorkload(), "./workload")
 		t.Status("starting csv servers")
 		c.Start(ctx)
 		c.Run(ctx, c.All(), `./workload csv-server --port=8081 &> logs/workload-csv-server.log < /dev/null &`)

--- a/pkg/cmd/roachtest/import.go
+++ b/pkg/cmd/roachtest/import.go
@@ -63,7 +63,7 @@ func registerImportNodeShutdown(r *testRegistry) {
 		Cluster:    r.makeClusterSpec(4),
 		MinVersion: "v21.1.0",
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			c.Put(ctx, cockroach, "./cockroach")
+			c.Put(ctx, t.Cockroach(), "./cockroach")
 			c.Start(ctx)
 			gatewayNode := 2
 			nodeToShutdown := 3
@@ -78,7 +78,7 @@ func registerImportNodeShutdown(r *testRegistry) {
 		Cluster:    r.makeClusterSpec(4),
 		MinVersion: "v21.1.0",
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			c.Put(ctx, cockroach, "./cockroach")
+			c.Put(ctx, t.Cockroach(), "./cockroach")
 			c.Start(ctx)
 			gatewayNode := 2
 			nodeToShutdown := 2
@@ -94,7 +94,7 @@ func registerImportTPCC(r *testRegistry) {
 		timeout time.Duration, warehouses int) {
 		// Randomize starting with encryption-at-rest enabled.
 		c.EncryptAtRandom(true)
-		c.Put(ctx, cockroach, "./cockroach")
+		c.Put(ctx, t.Cockroach(), "./cockroach")
 		c.Put(ctx, workload, "./workload")
 		t.Status("starting csv servers")
 		c.Start(ctx)
@@ -185,7 +185,7 @@ func registerImportTPCH(r *testRegistry) {
 
 				// Randomize starting with encryption-at-rest enabled.
 				c.EncryptAtRandom(true)
-				c.Put(ctx, cockroach, "./cockroach")
+				c.Put(ctx, t.Cockroach(), "./cockroach")
 				c.Start(ctx)
 				conn := c.Conn(ctx, 1)
 				if _, err := conn.Exec(`CREATE DATABASE csv;`); err != nil {
@@ -329,7 +329,7 @@ func registerImportDecommissioned(r *testRegistry) {
 			warehouses = 10
 		}
 
-		c.Put(ctx, cockroach, "./cockroach")
+		c.Put(ctx, t.Cockroach(), "./cockroach")
 		c.Put(ctx, workload, "./workload")
 		t.Status("starting csv servers")
 		c.Start(ctx)

--- a/pkg/cmd/roachtest/inconsistency.go
+++ b/pkg/cmd/roachtest/inconsistency.go
@@ -35,7 +35,7 @@ func runInconsistency(ctx context.Context, t test.Test, c cluster.Cluster) {
 	c.EncryptDefault(false)
 
 	nodes := c.Range(1, 3)
-	c.Put(ctx, cockroach, "./cockroach", nodes)
+	c.Put(ctx, t.Cockroach(), "./cockroach", nodes)
 	c.Start(ctx, nodes)
 
 	{

--- a/pkg/cmd/roachtest/indexes.go
+++ b/pkg/cmd/roachtest/indexes.go
@@ -42,7 +42,7 @@ func registerNIndexes(r *testRegistry, secondaryIndexes int) {
 			gatewayNodes := c.Range(1, nodes/3)
 			loadNode := c.Node(nodes + 1)
 
-			c.Put(ctx, cockroach, "./cockroach", roachNodes)
+			c.Put(ctx, t.Cockroach(), "./cockroach", roachNodes)
 			c.Put(ctx, workload, "./workload", loadNode)
 			c.Start(ctx, roachNodes)
 			conn := c.Conn(ctx, 1)

--- a/pkg/cmd/roachtest/indexes.go
+++ b/pkg/cmd/roachtest/indexes.go
@@ -43,7 +43,7 @@ func registerNIndexes(r *testRegistry, secondaryIndexes int) {
 			loadNode := c.Node(nodes + 1)
 
 			c.Put(ctx, t.Cockroach(), "./cockroach", roachNodes)
-			c.Put(ctx, workload, "./workload", loadNode)
+			c.Put(ctx, t.DeprecatedWorkload(), "./workload", loadNode)
 			c.Start(ctx, roachNodes)
 			conn := c.Conn(ctx, 1)
 

--- a/pkg/cmd/roachtest/interleavedpartitioned.go
+++ b/pkg/cmd/roachtest/interleavedpartitioned.go
@@ -54,7 +54,7 @@ func registerInterleaved(r *testRegistry) {
 		t.L().Printf("workload nodes: %s", workloadNodes.String()[1:])
 
 		c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
-		c.Put(ctx, workload, "./workload", c.All())
+		c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.All())
 		c.Start(ctx, cockroachNodes)
 
 		zones := fmt.Sprintf("--east-zone-name %s --west-zone-name %s --central-zone-name %s",

--- a/pkg/cmd/roachtest/interleavedpartitioned.go
+++ b/pkg/cmd/roachtest/interleavedpartitioned.go
@@ -53,7 +53,7 @@ func registerInterleaved(r *testRegistry) {
 		t.L().Printf("cockroach nodes: %s", cockroachNodes.String()[1:])
 		t.L().Printf("workload nodes: %s", workloadNodes.String()[1:])
 
-		c.Put(ctx, cockroach, "./cockroach", c.All())
+		c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
 		c.Put(ctx, workload, "./workload", c.All())
 		c.Start(ctx, cockroachNodes)
 

--- a/pkg/cmd/roachtest/inverted_index.go
+++ b/pkg/cmd/roachtest/inverted_index.go
@@ -37,7 +37,7 @@ func runSchemaChangeInvertedIndex(ctx context.Context, t test.Test, c cluster.Cl
 	crdbNodes := c.Range(1, c.Spec().NodeCount-1)
 	workloadNode := c.Node(c.Spec().NodeCount)
 
-	c.Put(ctx, cockroach, "./cockroach", crdbNodes)
+	c.Put(ctx, t.Cockroach(), "./cockroach", crdbNodes)
 	c.Put(ctx, workload, "./workload", workloadNode)
 	c.Start(ctx, crdbNodes)
 

--- a/pkg/cmd/roachtest/inverted_index.go
+++ b/pkg/cmd/roachtest/inverted_index.go
@@ -38,7 +38,7 @@ func runSchemaChangeInvertedIndex(ctx context.Context, t test.Test, c cluster.Cl
 	workloadNode := c.Node(c.Spec().NodeCount)
 
 	c.Put(ctx, t.Cockroach(), "./cockroach", crdbNodes)
-	c.Put(ctx, workload, "./workload", workloadNode)
+	c.Put(ctx, t.DeprecatedWorkload(), "./workload", workloadNode)
 	c.Start(ctx, crdbNodes)
 
 	cmdInit := "./workload init json {pgurl:1}"

--- a/pkg/cmd/roachtest/jepsen.go
+++ b/pkg/cmd/roachtest/jepsen.go
@@ -98,7 +98,7 @@ func initJepsen(ctx context.Context, t test.Test, c cluster.Cluster) {
 	// quirks in tar. The --transform option is only available on gnu
 	// tar. To be able to run from a macOS host with BSD tar we'd need
 	// use the similar -s option on that platform.
-	c.Put(ctx, cockroach, "./cockroach", c.All())
+	c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
 	// Jepsen expects a tarball that expands to cockroach/cockroach
 	// (which is not how our official builds are laid out).
 	c.Run(ctx, c.All(), "tar --transform s,^,cockroach/, -c -z -f cockroach.tgz cockroach")

--- a/pkg/cmd/roachtest/kv.go
+++ b/pkg/cmd/roachtest/kv.go
@@ -66,7 +66,7 @@ func registerKV(r *testRegistry) {
 	}
 	runKV := func(ctx context.Context, t test.Test, c cluster.Cluster, opts kvOptions) {
 		nodes := c.Spec().NodeCount - 1
-		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
+		c.Put(ctx, t.Cockroach(), "./cockroach", c.Range(1, nodes))
 		c.Put(ctx, workload, "./workload", c.Node(nodes+1))
 		c.Start(ctx, c.Range(1, nodes), startArgs(fmt.Sprintf("--encrypt=%t", opts.encryption)))
 
@@ -246,7 +246,7 @@ func registerKVContention(r *testRegistry) {
 		MinVersion: "v20.1.0",
 		Cluster:    r.makeClusterSpec(nodes + 1),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
+			c.Put(ctx, t.Cockroach(), "./cockroach", c.Range(1, nodes))
 			c.Put(ctx, workload, "./workload", c.Node(nodes+1))
 
 			// Start the cluster with an extremely high txn liveness threshold.
@@ -316,7 +316,7 @@ func registerKVQuiescenceDead(r *testRegistry) {
 		MinVersion: "v2.1.0",
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			nodes := c.Spec().NodeCount - 1
-			c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
+			c.Put(ctx, t.Cockroach(), "./cockroach", c.Range(1, nodes))
 			c.Put(ctx, workload, "./workload", c.Node(nodes+1))
 			c.Start(ctx, c.Range(1, nodes))
 
@@ -397,7 +397,7 @@ func registerKVGracefulDraining(r *testRegistry) {
 		Cluster: r.makeClusterSpec(4),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			nodes := c.Spec().NodeCount - 1
-			c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
+			c.Put(ctx, t.Cockroach(), "./cockroach", c.Range(1, nodes))
 			c.Put(ctx, workload, "./workload", c.Node(nodes+1))
 
 			t.Status("starting cluster")
@@ -614,7 +614,7 @@ func registerKVSplits(r *testRegistry) {
 			Cluster: r.makeClusterSpec(4),
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				nodes := c.Spec().NodeCount - 1
-				c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
+				c.Put(ctx, t.Cockroach(), "./cockroach", c.Range(1, nodes))
 				c.Put(ctx, workload, "./workload", c.Node(nodes+1))
 				c.Start(ctx, c.Range(1, nodes), startArgs(
 					// NB: this works. Don't change it or only one of the two vars may actually
@@ -646,7 +646,7 @@ func registerKVScalability(r *testRegistry) {
 	runScalability := func(ctx context.Context, t test.Test, c cluster.Cluster, percent int) {
 		nodes := c.Spec().NodeCount - 1
 
-		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
+		c.Put(ctx, t.Cockroach(), "./cockroach", c.Range(1, nodes))
 		c.Put(ctx, workload, "./workload", c.Node(nodes+1))
 
 		const maxPerNodeConcurrency = 64
@@ -700,7 +700,7 @@ func registerKVRangeLookups(r *testRegistry) {
 		nodes := c.Spec().NodeCount - 1
 		doneInit := make(chan struct{})
 		doneWorkload := make(chan struct{})
-		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
+		c.Put(ctx, t.Cockroach(), "./cockroach", c.Range(1, nodes))
 		c.Put(ctx, workload, "./workload", c.Node(nodes+1))
 		c.Start(ctx, c.Range(1, nodes))
 

--- a/pkg/cmd/roachtest/kv.go
+++ b/pkg/cmd/roachtest/kv.go
@@ -67,7 +67,7 @@ func registerKV(r *testRegistry) {
 	runKV := func(ctx context.Context, t test.Test, c cluster.Cluster, opts kvOptions) {
 		nodes := c.Spec().NodeCount - 1
 		c.Put(ctx, t.Cockroach(), "./cockroach", c.Range(1, nodes))
-		c.Put(ctx, workload, "./workload", c.Node(nodes+1))
+		c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(nodes+1))
 		c.Start(ctx, c.Range(1, nodes), startArgs(fmt.Sprintf("--encrypt=%t", opts.encryption)))
 
 		if opts.splits < 0 {
@@ -247,7 +247,7 @@ func registerKVContention(r *testRegistry) {
 		Cluster:    r.makeClusterSpec(nodes + 1),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			c.Put(ctx, t.Cockroach(), "./cockroach", c.Range(1, nodes))
-			c.Put(ctx, workload, "./workload", c.Node(nodes+1))
+			c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(nodes+1))
 
 			// Start the cluster with an extremely high txn liveness threshold.
 			// If requests ever get stuck on a transaction that was abandoned
@@ -317,7 +317,7 @@ func registerKVQuiescenceDead(r *testRegistry) {
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			nodes := c.Spec().NodeCount - 1
 			c.Put(ctx, t.Cockroach(), "./cockroach", c.Range(1, nodes))
-			c.Put(ctx, workload, "./workload", c.Node(nodes+1))
+			c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(nodes+1))
 			c.Start(ctx, c.Range(1, nodes))
 
 			run := func(cmd string, lastDown bool) {
@@ -398,7 +398,7 @@ func registerKVGracefulDraining(r *testRegistry) {
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			nodes := c.Spec().NodeCount - 1
 			c.Put(ctx, t.Cockroach(), "./cockroach", c.Range(1, nodes))
-			c.Put(ctx, workload, "./workload", c.Node(nodes+1))
+			c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(nodes+1))
 
 			t.Status("starting cluster")
 
@@ -615,7 +615,7 @@ func registerKVSplits(r *testRegistry) {
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				nodes := c.Spec().NodeCount - 1
 				c.Put(ctx, t.Cockroach(), "./cockroach", c.Range(1, nodes))
-				c.Put(ctx, workload, "./workload", c.Node(nodes+1))
+				c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(nodes+1))
 				c.Start(ctx, c.Range(1, nodes), startArgs(
 					// NB: this works. Don't change it or only one of the two vars may actually
 					// make it to the server.
@@ -647,7 +647,7 @@ func registerKVScalability(r *testRegistry) {
 		nodes := c.Spec().NodeCount - 1
 
 		c.Put(ctx, t.Cockroach(), "./cockroach", c.Range(1, nodes))
-		c.Put(ctx, workload, "./workload", c.Node(nodes+1))
+		c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(nodes+1))
 
 		const maxPerNodeConcurrency = 64
 		for i := nodes; i <= nodes*maxPerNodeConcurrency; i += nodes {
@@ -701,7 +701,7 @@ func registerKVRangeLookups(r *testRegistry) {
 		doneInit := make(chan struct{})
 		doneWorkload := make(chan struct{})
 		c.Put(ctx, t.Cockroach(), "./cockroach", c.Range(1, nodes))
-		c.Put(ctx, workload, "./workload", c.Node(nodes+1))
+		c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(nodes+1))
 		c.Start(ctx, c.Range(1, nodes))
 
 		t.Status("running workload")

--- a/pkg/cmd/roachtest/kvbench.go
+++ b/pkg/cmd/roachtest/kvbench.go
@@ -202,7 +202,7 @@ func runKVBench(ctx context.Context, t test.Test, c cluster.Cluster, b kvBenchSp
 	if err := c.PutE(ctx, t.L(), t.Cockroach(), "./cockroach", roachNodes); err != nil {
 		t.Fatal(err)
 	}
-	if err := c.PutE(ctx, t.L(), workload, "./workload", loadNodes); err != nil {
+	if err := c.PutE(ctx, t.L(), t.DeprecatedWorkload(), "./workload", loadNodes); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/cmd/roachtest/kvbench.go
+++ b/pkg/cmd/roachtest/kvbench.go
@@ -199,7 +199,7 @@ func runKVBench(ctx context.Context, t test.Test, c cluster.Cluster, b kvBenchSp
 	roachNodes := loadGroup.roachNodes
 	loadNodes := loadGroup.loadNodes
 
-	if err := c.PutE(ctx, t.L(), cockroach, "./cockroach", roachNodes); err != nil {
+	if err := c.PutE(ctx, t.L(), t.Cockroach(), "./cockroach", roachNodes); err != nil {
 		t.Fatal(err)
 	}
 	if err := c.PutE(ctx, t.L(), workload, "./workload", loadNodes); err != nil {

--- a/pkg/cmd/roachtest/ledger.go
+++ b/pkg/cmd/roachtest/ledger.go
@@ -33,7 +33,7 @@ func registerLedger(r *testRegistry) {
 			gatewayNodes := c.Range(1, nodes/3)
 			loadNode := c.Node(nodes + 1)
 
-			c.Put(ctx, cockroach, "./cockroach", roachNodes)
+			c.Put(ctx, t.Cockroach(), "./cockroach", roachNodes)
 			c.Put(ctx, workload, "./workload", loadNode)
 			c.Start(ctx, roachNodes)
 

--- a/pkg/cmd/roachtest/ledger.go
+++ b/pkg/cmd/roachtest/ledger.go
@@ -34,7 +34,7 @@ func registerLedger(r *testRegistry) {
 			loadNode := c.Node(nodes + 1)
 
 			c.Put(ctx, t.Cockroach(), "./cockroach", roachNodes)
-			c.Put(ctx, workload, "./workload", loadNode)
+			c.Put(ctx, t.DeprecatedWorkload(), "./workload", loadNode)
 			c.Start(ctx, roachNodes)
 
 			t.Status("running workload")

--- a/pkg/cmd/roachtest/libpq.go
+++ b/pkg/cmd/roachtest/libpq.go
@@ -31,7 +31,7 @@ func registerLibPQ(r *testRegistry) {
 		}
 		node := c.Node(1)
 		t.Status("setting up cockroach")
-		c.Put(ctx, cockroach, "./cockroach", c.All())
+		c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
 		c.Start(ctx, c.All())
 
 		version, err := fetchCockroachVersion(ctx, c, node[0], nil)

--- a/pkg/cmd/roachtest/liquibase.go
+++ b/pkg/cmd/roachtest/liquibase.go
@@ -31,7 +31,7 @@ func registerLiquibase(r *testRegistry) {
 		}
 		node := c.Node(1)
 		t.Status("setting up cockroach")
-		c.Put(ctx, cockroach, "./cockroach", c.All())
+		c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
 		c.Start(ctx, c.All())
 
 		version, err := fetchCockroachVersion(ctx, c, node[0], nil)

--- a/pkg/cmd/roachtest/many_splits.go
+++ b/pkg/cmd/roachtest/many_splits.go
@@ -24,7 +24,7 @@ func runManySplits(ctx context.Context, t test.Test, c cluster.Cluster) {
 	// Randomize starting with encryption-at-rest enabled.
 	c.EncryptAtRandom(true)
 	args := startArgs("--env=COCKROACH_SCAN_MAX_IDLE_TIME=5ms")
-	c.Put(ctx, cockroach, "./cockroach")
+	c.Put(ctx, t.Cockroach(), "./cockroach")
 	c.Start(ctx, args)
 
 	db := c.Conn(ctx, 1)

--- a/pkg/cmd/roachtest/mixed_version_jobs.go
+++ b/pkg/cmd/roachtest/mixed_version_jobs.go
@@ -235,7 +235,7 @@ func runJobsMixedVersions(
 	roachNodes := c.All()
 	backgroundTPCC := backgroundJobsTestTPCCImport(t, warehouses)
 	resumeAllJobsAndWaitStep := makeResumeAllJobsAndWaitStep(10 * time.Second)
-	c.Put(ctx, workload, "./workload", c.Node(1))
+	c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(1))
 
 	u := newVersionUpgradeTest(c,
 		uploadAndStartFromCheckpointFixture(roachNodes, predecessorVersion),

--- a/pkg/cmd/roachtest/mixed_version_schemachange.go
+++ b/pkg/cmd/roachtest/mixed_version_schemachange.go
@@ -44,7 +44,7 @@ func uploadAndInitSchemaChangeWorkload() versionStep {
 	return func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
 		// Stage workload on all nodes as the load node to run workload is chosen
 		// randomly.
-		u.c.Put(ctx, workload, "./workload", u.c.All())
+		u.c.Put(ctx, t.DeprecatedWorkload(), "./workload", u.c.All())
 		u.c.Run(ctx, u.c.All(), "./workload init schemachange")
 	}
 }

--- a/pkg/cmd/roachtest/multitenant.go
+++ b/pkg/cmd/roachtest/multitenant.go
@@ -21,7 +21,7 @@ import (
 )
 
 func runAcceptanceMultitenant(ctx context.Context, t test.Test, c cluster.Cluster) {
-	c.Put(ctx, cockroach, "./cockroach")
+	c.Put(ctx, t.Cockroach(), "./cockroach")
 
 	c.Start(ctx, c.All())
 

--- a/pkg/cmd/roachtest/network.go
+++ b/pkg/cmd/roachtest/network.go
@@ -101,7 +101,7 @@ func runNetworkTPCC(ctx context.Context, t test.Test, origC cluster.Cluster, nod
 	n := origC.Spec().NodeCount
 	serverNodes, workerNode := origC.Range(1, n-1), origC.Node(n)
 	origC.Put(ctx, t.Cockroach(), "./cockroach", origC.All())
-	origC.Put(ctx, workload, "./workload", origC.All())
+	origC.Put(ctx, t.DeprecatedWorkload(), "./workload", origC.All())
 
 	c, err := Toxify(ctx, t, origC, serverNodes)
 	if err != nil {

--- a/pkg/cmd/roachtest/network.go
+++ b/pkg/cmd/roachtest/network.go
@@ -28,7 +28,7 @@ import (
 // correctly. It injects latency between the nodes and verifies that we're not
 // seeing the latency on the client connection running `SELECT 1` on each node.
 func runNetworkSanity(ctx context.Context, t test.Test, origC cluster.Cluster, nodes int) {
-	origC.Put(ctx, cockroach, "./cockroach", origC.All())
+	origC.Put(ctx, t.Cockroach(), "./cockroach", origC.All())
 	c, err := Toxify(ctx, t, origC, origC.All())
 	if err != nil {
 		t.Fatal(err)
@@ -100,7 +100,7 @@ select age, message from [ show trace for session ];
 func runNetworkTPCC(ctx context.Context, t test.Test, origC cluster.Cluster, nodes int) {
 	n := origC.Spec().NodeCount
 	serverNodes, workerNode := origC.Range(1, n-1), origC.Node(n)
-	origC.Put(ctx, cockroach, "./cockroach", origC.All())
+	origC.Put(ctx, t.Cockroach(), "./cockroach", origC.All())
 	origC.Put(ctx, workload, "./workload", origC.All())
 
 	c, err := Toxify(ctx, t, origC, serverNodes)

--- a/pkg/cmd/roachtest/nodejs_postgres.go
+++ b/pkg/cmd/roachtest/nodejs_postgres.go
@@ -39,7 +39,7 @@ func registerNodeJSPostgres(r *testRegistry) {
 		}
 		node := c.Node(1)
 		t.Status("setting up cockroach")
-		err := c.PutE(ctx, t.L(), cockroach, "./cockroach", c.All())
+		err := c.PutE(ctx, t.L(), t.Cockroach(), "./cockroach", c.All())
 		require.NoError(t, err)
 		err = c.StartE(ctx, startArgs("--secure"))
 		require.NoError(t, err)

--- a/pkg/cmd/roachtest/pgjdbc.go
+++ b/pkg/cmd/roachtest/pgjdbc.go
@@ -35,7 +35,7 @@ func registerPgjdbc(r *testRegistry) {
 		}
 		node := c.Node(1)
 		t.Status("setting up cockroach")
-		c.Put(ctx, cockroach, "./cockroach", c.All())
+		c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
 		c.Start(ctx, c.All())
 
 		version, err := fetchCockroachVersion(ctx, c, node[0], nil)

--- a/pkg/cmd/roachtest/pgx.go
+++ b/pkg/cmd/roachtest/pgx.go
@@ -35,7 +35,7 @@ func registerPgx(r *testRegistry) {
 		}
 		node := c.Node(1)
 		t.Status("setting up cockroach")
-		c.Put(ctx, cockroach, "./cockroach", c.All())
+		c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
 		c.Start(ctx, c.All())
 
 		version, err := fetchCockroachVersion(ctx, c, node[0], nil)

--- a/pkg/cmd/roachtest/pop.go
+++ b/pkg/cmd/roachtest/pop.go
@@ -30,7 +30,7 @@ func registerPop(r *testRegistry) {
 		}
 		node := c.Node(1)
 		t.Status("setting up cockroach")
-		c.Put(ctx, cockroach, "./cockroach", c.All())
+		c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
 		c.Start(ctx, c.All())
 		version, err := fetchCockroachVersion(ctx, c, node[0], nil)
 		if err != nil {

--- a/pkg/cmd/roachtest/psycopg.go
+++ b/pkg/cmd/roachtest/psycopg.go
@@ -33,7 +33,7 @@ func registerPsycopg(r *testRegistry) {
 		}
 		node := c.Node(1)
 		t.Status("setting up cockroach")
-		c.Put(ctx, cockroach, "./cockroach", c.All())
+		c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
 		c.Start(ctx, c.All())
 
 		version, err := fetchCockroachVersion(ctx, c, node[0], nil)

--- a/pkg/cmd/roachtest/queue.go
+++ b/pkg/cmd/roachtest/queue.go
@@ -41,7 +41,7 @@ func runQueue(ctx context.Context, t test.Test, c cluster.Cluster) {
 
 	// Distribute programs to the correct nodes and start CockroachDB.
 	c.Put(ctx, t.Cockroach(), "./cockroach", c.Range(1, dbNodeCount))
-	c.Put(ctx, workload, "./workload", c.Node(workloadNode))
+	c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(workloadNode))
 	c.Start(ctx, c.Range(1, dbNodeCount))
 
 	runQueueWorkload := func(duration time.Duration, initTables bool) {

--- a/pkg/cmd/roachtest/queue.go
+++ b/pkg/cmd/roachtest/queue.go
@@ -40,7 +40,7 @@ func runQueue(ctx context.Context, t test.Test, c cluster.Cluster) {
 	workloadNode := c.Spec().NodeCount
 
 	// Distribute programs to the correct nodes and start CockroachDB.
-	c.Put(ctx, cockroach, "./cockroach", c.Range(1, dbNodeCount))
+	c.Put(ctx, t.Cockroach(), "./cockroach", c.Range(1, dbNodeCount))
 	c.Put(ctx, workload, "./workload", c.Node(workloadNode))
 	c.Start(ctx, c.Range(1, dbNodeCount))
 

--- a/pkg/cmd/roachtest/quit.go
+++ b/pkg/cmd/roachtest/quit.go
@@ -54,7 +54,7 @@ func (q *quitTest) init(ctx context.Context) {
 		"--env=COCKROACH_SCAN_MAX_IDLE_TIME=5ms",               // iterate fast for rebalancing
 		"-a", "--vmodule=store=1,replica=1,replica_proposal=1", // verbosity to troubleshoot drains
 	)
-	q.c.Put(ctx, cockroach, "./cockroach")
+	q.c.Put(ctx, q.t.Cockroach(), "./cockroach")
 	q.c.Start(ctx, q.args)
 }
 

--- a/pkg/cmd/roachtest/rapid_restart.go
+++ b/pkg/cmd/roachtest/rapid_restart.go
@@ -28,7 +28,7 @@ import (
 func runRapidRestart(ctx context.Context, t test.Test, c cluster.Cluster) {
 	// Use a single-node cluster which speeds the stop/start cycle.
 	nodes := c.Node(1)
-	c.Put(ctx, cockroach, "./cockroach", nodes)
+	c.Put(ctx, t.Cockroach(), "./cockroach", nodes)
 
 	// In a loop, bootstrap a new single-node cluster and immediately kill
 	// it. This is more effective at finding problems than restarting an existing

--- a/pkg/cmd/roachtest/rebalance_load.go
+++ b/pkg/cmd/roachtest/rebalance_load.go
@@ -54,7 +54,7 @@ func registerRebalanceLoad(r *testRegistry) {
 		appNode := c.Node(c.Spec().NodeCount)
 		splits := len(roachNodes) - 1 // n-1 splits => n ranges => 1 lease per node
 
-		c.Put(ctx, cockroach, "./cockroach", roachNodes)
+		c.Put(ctx, t.Cockroach(), "./cockroach", roachNodes)
 		args := startArgs(
 			"--args=--vmodule=store_rebalancer=5,allocator=5,allocator_scorer=5,replicate_queue=5")
 		c.Start(ctx, roachNodes, args)

--- a/pkg/cmd/roachtest/rebalance_load.go
+++ b/pkg/cmd/roachtest/rebalance_load.go
@@ -59,7 +59,7 @@ func registerRebalanceLoad(r *testRegistry) {
 			"--args=--vmodule=store_rebalancer=5,allocator=5,allocator_scorer=5,replicate_queue=5")
 		c.Start(ctx, roachNodes, args)
 
-		c.Put(ctx, workload, "./workload", appNode)
+		c.Put(ctx, t.DeprecatedWorkload(), "./workload", appNode)
 		c.Run(ctx, appNode, fmt.Sprintf("./workload init kv --drop --splits=%d {pgurl:1}", splits))
 
 		var m *errgroup.Group // see comment in version.go

--- a/pkg/cmd/roachtest/replicagc.go
+++ b/pkg/cmd/roachtest/replicagc.go
@@ -58,7 +58,7 @@ func runReplicaGCChangedPeers(
 
 	args := startArgs("--env=COCKROACH_SCAN_MAX_IDLE_TIME=5ms")
 	c.Put(ctx, t.Cockroach(), "./cockroach")
-	c.Put(ctx, workload, "./workload", c.Node(1))
+	c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(1))
 	c.Start(ctx, args, c.Range(1, 3))
 
 	h := &replicagcTestHelper{c: c, t: t}

--- a/pkg/cmd/roachtest/replicagc.go
+++ b/pkg/cmd/roachtest/replicagc.go
@@ -57,7 +57,7 @@ func runReplicaGCChangedPeers(
 	}
 
 	args := startArgs("--env=COCKROACH_SCAN_MAX_IDLE_TIME=5ms")
-	c.Put(ctx, cockroach, "./cockroach")
+	c.Put(ctx, t.Cockroach(), "./cockroach")
 	c.Put(ctx, workload, "./workload", c.Node(1))
 	c.Start(ctx, args, c.Range(1, 3))
 

--- a/pkg/cmd/roachtest/reset_quorum.go
+++ b/pkg/cmd/roachtest/reset_quorum.go
@@ -33,7 +33,7 @@ func runResetQuorum(ctx context.Context, t test.Test, c cluster.Cluster) {
 	}
 	// n1-n5 will be in locality A, n6-n8 in B. We'll pin a single table to B and
 	// let the the nodes in B fail permanently.
-	c.Put(ctx, cockroach, "./cockroach")
+	c.Put(ctx, t.Cockroach(), "./cockroach")
 	c.Start(ctx, c.Range(1, 5), args("A"))
 	db := c.Conn(ctx, 1)
 	defer db.Close()

--- a/pkg/cmd/roachtest/restart.go
+++ b/pkg/cmd/roachtest/restart.go
@@ -26,7 +26,7 @@ func runRestart(ctx context.Context, t test.Test, c cluster.Cluster, downDuratio
 	const restartNode = 3
 
 	t.Status("installing cockroach")
-	c.Put(ctx, cockroach, "./cockroach", crdbNodes)
+	c.Put(ctx, t.Cockroach(), "./cockroach", crdbNodes)
 	c.Start(ctx, crdbNodes, startArgs(`--args=--vmodule=raft_log_queue=3`))
 
 	// We don't really need tpcc, we just need a good amount of traffic and a good

--- a/pkg/cmd/roachtest/restore.go
+++ b/pkg/cmd/roachtest/restore.go
@@ -292,7 +292,7 @@ func registerRestoreNodeShutdown(r *testRegistry) {
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			gatewayNode := 2
 			nodeToShutdown := 3
-			c.Put(ctx, cockroach, "./cockroach")
+			c.Put(ctx, t.Cockroach(), "./cockroach")
 			c.Start(ctx)
 
 			jobSurvivesNodeShutdown(ctx, t, c, nodeToShutdown, makeRestoreStarter(ctx, t, c, gatewayNode))
@@ -307,7 +307,7 @@ func registerRestoreNodeShutdown(r *testRegistry) {
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			gatewayNode := 2
 			nodeToShutdown := 2
-			c.Put(ctx, cockroach, "./cockroach")
+			c.Put(ctx, t.Cockroach(), "./cockroach")
 			c.Start(ctx)
 
 			jobSurvivesNodeShutdown(ctx, t, c, nodeToShutdown, makeRestoreStarter(ctx, t, c, gatewayNode))
@@ -390,7 +390,7 @@ func registerRestore(r *testRegistry) {
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				// Randomize starting with encryption-at-rest enabled.
 				c.EncryptAtRandom(true)
-				c.Put(ctx, cockroach, "./cockroach")
+				c.Put(ctx, t.Cockroach(), "./cockroach")
 				c.Start(ctx)
 				m := newMonitor(ctx, c)
 

--- a/pkg/cmd/roachtest/roachmart.go
+++ b/pkg/cmd/roachtest/roachmart.go
@@ -22,7 +22,7 @@ import (
 func registerRoachmart(r *testRegistry) {
 	runRoachmart := func(ctx context.Context, t test.Test, c cluster.Cluster, partition bool) {
 		c.Put(ctx, t.Cockroach(), "./cockroach")
-		c.Put(ctx, workload, "./workload")
+		c.Put(ctx, t.DeprecatedWorkload(), "./workload")
 		c.Start(ctx)
 
 		// TODO(benesch): avoid hardcoding this list.

--- a/pkg/cmd/roachtest/roachmart.go
+++ b/pkg/cmd/roachtest/roachmart.go
@@ -21,7 +21,7 @@ import (
 
 func registerRoachmart(r *testRegistry) {
 	runRoachmart := func(ctx context.Context, t test.Test, c cluster.Cluster, partition bool) {
-		c.Put(ctx, cockroach, "./cockroach")
+		c.Put(ctx, t.Cockroach(), "./cockroach")
 		c.Put(ctx, workload, "./workload")
 		c.Start(ctx)
 

--- a/pkg/cmd/roachtest/ruby_pg.go
+++ b/pkg/cmd/roachtest/ruby_pg.go
@@ -38,7 +38,7 @@ func registerRubyPG(r *testRegistry) {
 		}
 		node := c.Node(1)
 		t.Status("setting up cockroach")
-		c.Put(ctx, cockroach, "./cockroach", c.All())
+		c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
 		if err := c.PutLibraries(ctx, "./lib"); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/cmd/roachtest/schemachange.go
+++ b/pkg/cmd/roachtest/schemachange.go
@@ -32,7 +32,7 @@ func registerSchemaChangeDuringKV(r *testRegistry) {
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			const fixturePath = `gs://cockroach-fixtures/workload/tpch/scalefactor=10/backup?AUTH=implicit`
 
-			c.Put(ctx, cockroach, "./cockroach")
+			c.Put(ctx, t.Cockroach(), "./cockroach")
 			c.Put(ctx, workload, "./workload")
 
 			c.Start(ctx, c.All())
@@ -353,7 +353,7 @@ func makeSchemaChangeBulkIngestTest(
 			crdbNodes := c.Range(1, c.Spec().NodeCount-1)
 			workloadNode := c.Node(c.Spec().NodeCount)
 
-			c.Put(ctx, cockroach, "./cockroach")
+			c.Put(ctx, t.Cockroach(), "./cockroach")
 			c.Put(ctx, workload, "./workload", workloadNode)
 			// TODO (lucy): Remove flag once the faster import is enabled by default
 			c.Start(ctx, crdbNodes, startArgs("--env=COCKROACH_IMPORT_WORKLOAD_FASTER=true"))

--- a/pkg/cmd/roachtest/schemachange.go
+++ b/pkg/cmd/roachtest/schemachange.go
@@ -33,7 +33,7 @@ func registerSchemaChangeDuringKV(r *testRegistry) {
 			const fixturePath = `gs://cockroach-fixtures/workload/tpch/scalefactor=10/backup?AUTH=implicit`
 
 			c.Put(ctx, t.Cockroach(), "./cockroach")
-			c.Put(ctx, workload, "./workload")
+			c.Put(ctx, t.DeprecatedWorkload(), "./workload")
 
 			c.Start(ctx, c.All())
 			db := c.Conn(ctx, 1)
@@ -354,7 +354,7 @@ func makeSchemaChangeBulkIngestTest(
 			workloadNode := c.Node(c.Spec().NodeCount)
 
 			c.Put(ctx, t.Cockroach(), "./cockroach")
-			c.Put(ctx, workload, "./workload", workloadNode)
+			c.Put(ctx, t.DeprecatedWorkload(), "./workload", workloadNode)
 			// TODO (lucy): Remove flag once the faster import is enabled by default
 			c.Start(ctx, crdbNodes, startArgs("--env=COCKROACH_IMPORT_WORKLOAD_FASTER=true"))
 

--- a/pkg/cmd/roachtest/schemachange_random_load.go
+++ b/pkg/cmd/roachtest/schemachange_random_load.go
@@ -132,7 +132,7 @@ func runSchemaChangeRandomLoad(
 	loadNode := c.Node(1)
 	roachNodes := c.Range(1, c.Spec().NodeCount)
 	t.Status("copying binaries")
-	c.Put(ctx, cockroach, "./cockroach", roachNodes)
+	c.Put(ctx, t.Cockroach(), "./cockroach", roachNodes)
 	c.Put(ctx, workload, "./workload", loadNode)
 
 	t.Status("starting cockroach nodes")

--- a/pkg/cmd/roachtest/schemachange_random_load.go
+++ b/pkg/cmd/roachtest/schemachange_random_load.go
@@ -133,7 +133,7 @@ func runSchemaChangeRandomLoad(
 	roachNodes := c.Range(1, c.Spec().NodeCount)
 	t.Status("copying binaries")
 	c.Put(ctx, t.Cockroach(), "./cockroach", roachNodes)
-	c.Put(ctx, workload, "./workload", loadNode)
+	c.Put(ctx, t.DeprecatedWorkload(), "./workload", loadNode)
 
 	t.Status("starting cockroach nodes")
 	c.Start(ctx, roachNodes)

--- a/pkg/cmd/roachtest/sequelize.go
+++ b/pkg/cmd/roachtest/sequelize.go
@@ -33,7 +33,7 @@ func registerSequelize(r *testRegistry) {
 		}
 		node := c.Node(1)
 		t.Status("setting up cockroach")
-		c.Put(ctx, cockroach, "./cockroach", c.All())
+		c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
 		if err := c.PutLibraries(ctx, "./lib"); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/cmd/roachtest/split.go
+++ b/pkg/cmd/roachtest/split.go
@@ -131,7 +131,7 @@ func registerLoadSplits(r *testRegistry) {
 // splits occur in different workload scenarios.
 func runLoadSplits(ctx context.Context, t test.Test, c cluster.Cluster, params splitParams) {
 	c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
-	c.Put(ctx, workload, "./workload", c.Node(1))
+	c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(1))
 	c.Start(ctx, c.All())
 
 	m := newMonitor(ctx, c, c.All())
@@ -247,7 +247,7 @@ func runLargeRangeSplits(ctx context.Context, t test.Test, c cluster.Cluster, si
 	rows := size / rowEstimate
 
 	c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
-	c.Put(ctx, workload, "./workload", c.All())
+	c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.All())
 	c.Start(ctx, c.All())
 
 	m := newMonitor(ctx, c, c.All())

--- a/pkg/cmd/roachtest/split.go
+++ b/pkg/cmd/roachtest/split.go
@@ -130,7 +130,7 @@ func registerLoadSplits(r *testRegistry) {
 // conditions defined by the params. It checks whether certain number of
 // splits occur in different workload scenarios.
 func runLoadSplits(ctx context.Context, t test.Test, c cluster.Cluster, params splitParams) {
-	c.Put(ctx, cockroach, "./cockroach", c.All())
+	c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
 	c.Put(ctx, workload, "./workload", c.Node(1))
 	c.Start(ctx, c.All())
 
@@ -246,7 +246,7 @@ func runLargeRangeSplits(ctx context.Context, t test.Test, c cluster.Cluster, si
 	// to produce a range of roughly the right size.
 	rows := size / rowEstimate
 
-	c.Put(ctx, cockroach, "./cockroach", c.All())
+	c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
 	c.Put(ctx, workload, "./workload", c.All())
 	c.Start(ctx, c.All())
 

--- a/pkg/cmd/roachtest/sqlalchemy.go
+++ b/pkg/cmd/roachtest/sqlalchemy.go
@@ -167,7 +167,7 @@ func runSQLAlchemy(ctx context.Context, t test.Test, c cluster.Cluster) {
 	// Phew, after having setup all that, let's actually run the test.
 
 	t.Status("setting up cockroach")
-	c.Put(ctx, cockroach, "./cockroach", c.All())
+	c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
 	c.Start(ctx, c.All())
 
 	version, err := fetchCockroachVersion(ctx, c, node[0], nil)

--- a/pkg/cmd/roachtest/sqlsmith.go
+++ b/pkg/cmd/roachtest/sqlsmith.go
@@ -83,7 +83,7 @@ func registerSQLSmith(r *testRegistry) {
 		rng, seed := randutil.NewPseudoRand()
 		t.L().Printf("seed: %d", seed)
 
-		c.Put(ctx, cockroach, "./cockroach")
+		c.Put(ctx, t.Cockroach(), "./cockroach")
 		if err := c.PutLibraries(ctx, "./lib"); err != nil {
 			t.Fatalf("could not initialize libraries: %v", err)
 		}

--- a/pkg/cmd/roachtest/status_server.go
+++ b/pkg/cmd/roachtest/status_server.go
@@ -26,7 +26,7 @@ import (
 )
 
 func runStatusServer(ctx context.Context, t test.Test, c cluster.Cluster) {
-	c.Put(ctx, cockroach, "./cockroach")
+	c.Put(ctx, t.Cockroach(), "./cockroach")
 	c.Start(ctx)
 
 	// Get the ids for each node.

--- a/pkg/cmd/roachtest/synctest.go
+++ b/pkg/cmd/roachtest/synctest.go
@@ -53,7 +53,7 @@ fi
 				t.Fatal(err)
 			}
 
-			c.Put(ctx, cockroach, "./cockroach")
+			c.Put(ctx, t.Cockroach(), "./cockroach")
 			c.Put(ctx, nemesis, "./nemesis")
 			c.Run(ctx, n, "chmod +x nemesis")
 			c.Run(ctx, n, "sudo umount {store-dir}/faulty || true")

--- a/pkg/cmd/roachtest/sysbench.go
+++ b/pkg/cmd/roachtest/sysbench.go
@@ -93,7 +93,7 @@ func runSysbench(ctx context.Context, t test.Test, c cluster.Cluster, opts sysbe
 	loadNode := c.Node(c.Spec().NodeCount)
 
 	t.Status("installing cockroach")
-	c.Put(ctx, cockroach, "./cockroach", allNodes)
+	c.Put(ctx, t.Cockroach(), "./cockroach", allNodes)
 	c.Start(ctx, roachNodes)
 	waitForFullReplication(t, c.Conn(ctx, allNodes[0]))
 

--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -125,6 +125,7 @@ type testStatus struct {
 type testImpl struct {
 	spec *TestSpec
 
+	cockroach string
 	// buildVersion is the version of the Cockroach binary that the test will run
 	// against.
 	buildVersion version.Version
@@ -179,6 +180,10 @@ type testImpl struct {
 // in this test.
 func (t *testImpl) BuildVersion() *version.Version {
 	return &t.buildVersion
+}
+
+func (t *testImpl) Cockroach() string {
+	return t.cockroach
 }
 
 func (t *testImpl) VersionsBinaryOverride() map[string]string {

--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -125,7 +125,8 @@ type testStatus struct {
 type testImpl struct {
 	spec *TestSpec
 
-	cockroach string
+	cockroach          string // path to main cockroach binary
+	deprecatedWorkload string // path to workload binary
 	// buildVersion is the version of the Cockroach binary that the test will run
 	// against.
 	buildVersion version.Version
@@ -184,6 +185,10 @@ func (t *testImpl) BuildVersion() *version.Version {
 
 func (t *testImpl) Cockroach() string {
 	return t.cockroach
+}
+
+func (t *testImpl) DeprecatedWorkload() string {
+	return t.deprecatedWorkload
 }
 
 func (t *testImpl) VersionsBinaryOverride() map[string]string {

--- a/pkg/cmd/roachtest/test/test_interface.go
+++ b/pkg/cmd/roachtest/test/test_interface.go
@@ -38,4 +38,8 @@ type Test interface {
 	Status(args ...interface{})
 	WorkerStatus(args ...interface{})
 	WorkerProgress(float64)
+
+	// DeprecatedWorkload returns the path to the workload binary.
+	// Don't use this, invoke `./cockroach workload` instead.
+	DeprecatedWorkload() string
 }

--- a/pkg/cmd/roachtest/test/test_interface.go
+++ b/pkg/cmd/roachtest/test/test_interface.go
@@ -18,6 +18,7 @@ import (
 // Test is the interface through which roachtests interact with the
 // test harness.
 type Test interface {
+	Cockroach() string // path to main cockroach binary
 	Name() string
 	BuildVersion() *version.Version
 	IsBuildVersion(string) bool // "vXX.YY"

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -477,6 +477,7 @@ func (r *testRunner) runWorker(
 		}
 		t := &testImpl{
 			spec:                   &testToRun.spec,
+			cockroach:              cockroach,
 			buildVersion:           r.buildVersion,
 			artifactsDir:           artifactsDir,
 			artifactsSpec:          artifactsSpec,

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -478,6 +478,7 @@ func (r *testRunner) runWorker(
 		t := &testImpl{
 			spec:                   &testToRun.spec,
 			cockroach:              cockroach,
+			deprecatedWorkload:     workload,
 			buildVersion:           r.buildVersion,
 			artifactsDir:           artifactsDir,
 			artifactsSpec:          artifactsSpec,

--- a/pkg/cmd/roachtest/tlp.go
+++ b/pkg/cmd/roachtest/tlp.go
@@ -65,7 +65,7 @@ func runTLP(ctx context.Context, t test.Test, c cluster.Cluster) {
 	rnd, seed := randutil.NewPseudoRand()
 	t.L().Printf("seed: %d", seed)
 
-	c.Put(ctx, cockroach, "./cockroach")
+	c.Put(ctx, t.Cockroach(), "./cockroach")
 	if err := c.PutLibraries(ctx, "./lib"); err != nil {
 		t.Fatalf("could not initialize libraries: %v", err)
 	}

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -120,7 +120,7 @@ func setupTPCC(
 			c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
 			// We still use bare workload, though we could likely replace
 			// those with ./cockroach workload as well.
-			c.Put(ctx, workload, "./workload", workloadNode)
+			c.Put(ctx, t.DeprecatedWorkload(), "./workload", workloadNode)
 			c.Start(ctx, crdbNodes)
 		}
 	}

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -117,7 +117,7 @@ func setupTPCC(
 		opts.Start = func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			// NB: workloadNode also needs ./cockroach because
 			// of `./cockroach workload` for usingImport.
-			c.Put(ctx, cockroach, "./cockroach", c.All())
+			c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
 			// We still use bare workload, though we could likely replace
 			// those with ./cockroach workload as well.
 			c.Put(ctx, workload, "./workload", workloadNode)
@@ -987,11 +987,11 @@ func runTPCCBench(ctx context.Context, t test.Test, c cluster.Cluster, b tpccBen
 	loadGroups := makeLoadGroups(c, numZones, b.Nodes, numLoadGroups)
 	roachNodes := loadGroups.roachNodes()
 	loadNodes := loadGroups.loadNodes()
-	c.Put(ctx, cockroach, "./cockroach", roachNodes)
+	c.Put(ctx, t.Cockroach(), "./cockroach", roachNodes)
 	// Fixture import needs './cockroach workload' on loadNodes[0],
 	// and if we use haproxy (see below) we need it on the others
 	// as well.
-	c.Put(ctx, cockroach, "./cockroach", loadNodes)
+	c.Put(ctx, t.Cockroach(), "./cockroach", loadNodes)
 	// Don't encrypt in tpccbench tests.
 	c.EncryptDefault(false)
 	c.EncryptAtRandom(false)

--- a/pkg/cmd/roachtest/tpcdsvec.go
+++ b/pkg/cmd/roachtest/tpcdsvec.go
@@ -54,7 +54,7 @@ func registerTPCDSVec(r *testRegistry) {
 	}
 
 	runTPCDSVec := func(ctx context.Context, t test.Test, c cluster.Cluster) {
-		c.Put(ctx, cockroach, "./cockroach", c.All())
+		c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
 		c.Start(ctx)
 
 		clusterConn := c.Conn(ctx, 1)

--- a/pkg/cmd/roachtest/tpce.go
+++ b/pkg/cmd/roachtest/tpce.go
@@ -39,7 +39,7 @@ func registerTPCE(r *testRegistry) {
 		racks := opts.nodes
 
 		t.Status("installing cockroach")
-		c.Put(ctx, cockroach, "./cockroach", roachNodes)
+		c.Put(ctx, t.Cockroach(), "./cockroach", roachNodes)
 		c.Start(ctx, roachNodes, startArgs(
 			fmt.Sprintf("--racks=%d", racks),
 			fmt.Sprintf("--store-count=%d", opts.ssds),

--- a/pkg/cmd/roachtest/tpchbench.go
+++ b/pkg/cmd/roachtest/tpchbench.go
@@ -55,7 +55,7 @@ func runTPCHBench(ctx context.Context, t test.Test, c cluster.Cluster, b tpchBen
 	loadNode := c.Node(c.Spec().NodeCount)
 
 	t.Status("copying binaries")
-	c.Put(ctx, cockroach, "./cockroach", roachNodes)
+	c.Put(ctx, t.Cockroach(), "./cockroach", roachNodes)
 	c.Put(ctx, workload, "./workload", loadNode)
 
 	filename := b.benchType

--- a/pkg/cmd/roachtest/tpchbench.go
+++ b/pkg/cmd/roachtest/tpchbench.go
@@ -56,7 +56,7 @@ func runTPCHBench(ctx context.Context, t test.Test, c cluster.Cluster, b tpchBen
 
 	t.Status("copying binaries")
 	c.Put(ctx, t.Cockroach(), "./cockroach", roachNodes)
-	c.Put(ctx, workload, "./workload", loadNode)
+	c.Put(ctx, t.DeprecatedWorkload(), "./workload", loadNode)
 
 	filename := b.benchType
 	t.Status(fmt.Sprintf("downloading %s query file from %s", filename, b.url))

--- a/pkg/cmd/roachtest/tpchvec.go
+++ b/pkg/cmd/roachtest/tpchvec.go
@@ -540,7 +540,7 @@ func runTPCHVec(
 ) {
 	firstNode := c.Node(1)
 	c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
-	c.Put(ctx, workload, "./workload", firstNode)
+	c.Put(ctx, t.DeprecatedWorkload(), "./workload", firstNode)
 	c.Start(ctx)
 
 	conn := c.Conn(ctx, 1)

--- a/pkg/cmd/roachtest/tpchvec.go
+++ b/pkg/cmd/roachtest/tpchvec.go
@@ -539,7 +539,7 @@ func runTPCHVec(
 	testRun func(ctx context.Context, t test.Test, c cluster.Cluster, conn *gosql.DB, tc tpchVecTestCase),
 ) {
 	firstNode := c.Node(1)
-	c.Put(ctx, cockroach, "./cockroach", c.All())
+	c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
 	c.Put(ctx, workload, "./workload", firstNode)
 	c.Start(ctx)
 

--- a/pkg/cmd/roachtest/typeorm.go
+++ b/pkg/cmd/roachtest/typeorm.go
@@ -35,7 +35,7 @@ func registerTypeORM(r *testRegistry) {
 		}
 		node := c.Node(1)
 		t.Status("setting up cockroach")
-		c.Put(ctx, cockroach, "./cockroach", c.All())
+		c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
 		c.Start(ctx, c.All())
 
 		version, err := fetchCockroachVersion(ctx, c, node[0], nil)

--- a/pkg/cmd/roachtest/version.go
+++ b/pkg/cmd/roachtest/version.go
@@ -137,7 +137,7 @@ func registerVersion(r *testRegistry) {
 				if err := stop(i); err != nil {
 					return err
 				}
-				c.Put(ctx, cockroach, "./cockroach", c.Node(i))
+				c.Put(ctx, t.Cockroach(), "./cockroach", c.Node(i))
 				c.Start(ctx, c.Node(i), startArgsDontEncrypt)
 				if err := sleepAndCheck(); err != nil {
 					return err
@@ -161,7 +161,7 @@ func registerVersion(r *testRegistry) {
 
 			// Do upgrade for the last node.
 			l.Printf("upgrading last node\n")
-			c.Put(ctx, cockroach, "./cockroach", c.Node(nodes))
+			c.Put(ctx, t.Cockroach(), "./cockroach", c.Node(nodes))
 			c.Start(ctx, c.Node(nodes), startArgsDontEncrypt)
 			if err := sleepAndCheck(); err != nil {
 				return err
@@ -190,7 +190,7 @@ func registerVersion(r *testRegistry) {
 				if err := stop(i); err != nil {
 					return err
 				}
-				c.Put(ctx, cockroach, "./cockroach", c.Node(i))
+				c.Put(ctx, t.Cockroach(), "./cockroach", c.Node(i))
 				c.Start(ctx, c.Node(i), startArgsDontEncrypt)
 				if err := sleepAndCheck(); err != nil {
 					return err

--- a/pkg/cmd/roachtest/version.go
+++ b/pkg/cmd/roachtest/version.go
@@ -33,7 +33,7 @@ func registerVersion(r *testRegistry) {
 			t.Fatal(err)
 		}
 
-		c.Put(ctx, workload, "./workload", c.Node(nodes+1))
+		c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(nodes+1))
 
 		// Force disable encryption.
 		// TODO(mberhault): allow it once version >= 2.1.

--- a/pkg/cmd/roachtest/versionupgrade.go
+++ b/pkg/cmd/roachtest/versionupgrade.go
@@ -263,7 +263,7 @@ func uploadVersion(
 ) (binaryName string) {
 	binaryName = "./cockroach"
 	if newVersion == "" {
-		if err := c.PutE(ctx, t.L(), cockroach, binaryName, nodes); err != nil {
+		if err := c.PutE(ctx, t.L(), t.Cockroach(), binaryName, nodes); err != nil {
 			t.Fatal(err)
 		}
 	} else if binary, ok := t.VersionsBinaryOverride()[newVersion]; ok {

--- a/pkg/cmd/roachtest/ycsb.go
+++ b/pkg/cmd/roachtest/ycsb.go
@@ -45,7 +45,7 @@ func registerYCSB(r *testRegistry) {
 		}
 
 		c.Put(ctx, t.Cockroach(), "./cockroach", c.Range(1, nodes))
-		c.Put(ctx, workload, "./workload", c.Node(nodes+1))
+		c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(nodes+1))
 		c.Start(ctx, c.Range(1, nodes))
 		waitForFullReplication(t, c.Conn(ctx, 1))
 

--- a/pkg/cmd/roachtest/ycsb.go
+++ b/pkg/cmd/roachtest/ycsb.go
@@ -44,7 +44,7 @@ func registerYCSB(r *testRegistry) {
 			t.Fatalf("missing concurrency for (workload, cpus) = (%s, %d)", wl, cpus)
 		}
 
-		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
+		c.Put(ctx, t.Cockroach(), "./cockroach", c.Range(1, nodes))
 		c.Put(ctx, workload, "./workload", c.Node(nodes+1))
 		c.Start(ctx, c.Range(1, nodes))
 		waitForFullReplication(t, c.Conn(ctx, 1))


### PR DESCRIPTION
Most tests do something like this

```go
c.Put(ctx, cockroach, c.All())
c.Put(ctx, workload, c.All())
```

where `cockroach` and `workload` are globals hooked up to flags.
This isn't good, we want tests to be receive all of their inputs
directly and besides, we want them to be in separate packages so
they can't keep referencing a global from `package main`.

Release note: None
