### PR TITLE
release-20.2: sql: add infrastructure for rewriting computed column expressions

### DIFF
--- a/pkg/ccl/importccl/import_table_creation.go
+++ b/pkg/ccl/importccl/import_table_creation.go
@@ -145,8 +145,9 @@ func MakeSimpleTableDescriptor(
 	create.Defs = filteredDefs
 
 	evalCtx := tree.EvalContext{
-		Context:  ctx,
-		Sequence: &importSequenceOperators{},
+		Context:     ctx,
+		Sequence:    &importSequenceOperators{},
+		SessionData: &sessiondata.SessionData{},
 	}
 	affected := make(map[descpb.ID]*tabledesc.Mutable)
 

--- a/pkg/sql/add_column.go
+++ b/pkg/sql/add_column.go
@@ -30,6 +30,11 @@ func (p *planner) addColumnImpl(
 	t *tree.AlterTableAddColumn,
 ) error {
 	d := t.ColumnDef
+
+	if d.IsComputed() {
+		d.Computed.Expr = schemaexpr.MaybeRewriteComputedColumn(d.Computed.Expr, params.SessionData())
+	}
+
 	version := params.ExecCfg().Settings.Version.ActiveVersionOrEmpty(params.ctx)
 	toType, err := tree.ResolveType(params.ctx, d.Type, params.p.semaCtx.GetTypeResolver())
 	if err != nil {

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1295,6 +1295,9 @@ func NewTableDesc(
 
 	for i, def := range n.Defs {
 		if d, ok := def.(*tree.ColumnTableDef); ok {
+			if d.IsComputed() {
+				d.Computed.Expr = schemaexpr.MaybeRewriteComputedColumn(d.Computed.Expr, evalCtx.SessionData)
+			}
 			// NewTableDesc is called sometimes with a nil SemaCtx (for example
 			// during bootstrapping). In order to not panic, pass a nil TypeResolver
 			// when attempting to resolve the columns type.

--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -888,3 +888,73 @@ t42418  CREATE TABLE public.t42418 (
         y INT8 NULL AS (1:::INT8) STORED,
         FAMILY "primary" (x, rowid, y)
 )
+
+# Tests for computed column rewrites.
+statement error context-dependent operators are not allowed in computed column
+CREATE TABLE trewrite(k INT PRIMARY KEY, ts TIMESTAMPTZ, c STRING AS (ts::STRING) STORED, FAMILY (k,ts,c))
+
+statement ok
+SET experimental_computed_column_rewrites = "(ts :: STRING) -> ((ts AT TIME ZONE 'utc')::STRING)";
+
+statement ok
+CREATE TABLE trewrite(k INT PRIMARY KEY, ts TIMESTAMPTZ, c STRING AS (ts::STRING) STORED, FAMILY (k,ts,c))
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE trewrite]
+----
+CREATE TABLE public.trewrite (
+   k INT8 NOT NULL,
+   ts TIMESTAMPTZ NULL,
+   c STRING NULL AS (timezone('utc':::STRING, ts)::STRING) STORED,
+   CONSTRAINT "primary" PRIMARY KEY (k ASC),
+   FAMILY fam_0_k_ts_c (k, ts, c)
+)
+
+statement ok
+DROP TABLE trewrite
+
+statement ok
+CREATE TABLE trewrite(k INT PRIMARY KEY, ts TIMESTAMPTZ, FAMILY (k,ts))
+
+statement ok
+ALTER TABLE trewrite ADD COLUMN c STRING AS (ts::STRING) STORED
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE trewrite]
+----
+CREATE TABLE public.trewrite (
+   k INT8 NOT NULL,
+   ts TIMESTAMPTZ NULL,
+   c STRING NULL AS (timezone('utc':::STRING, ts)::STRING) STORED,
+   CONSTRAINT "primary" PRIMARY KEY (k ASC),
+   FAMILY fam_0_k_ts (k, ts, c)
+)
+
+statement error invalid column rewrites expression
+SET experimental_computed_column_rewrites = "bad"
+
+statement error invalid column rewrites expression
+SET CLUSTER SETTING sql.defaults.experimental_computed_column_rewrites = "bad"
+
+statement ok
+SET experimental_computed_column_rewrites = ""
+
+statement ok
+CREATE TABLE trewrite_copy (LIKE trewrite INCLUDING ALL)
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE trewrite_copy]
+----
+CREATE TABLE public.trewrite_copy (
+   k INT8 NOT NULL,
+   ts TIMESTAMPTZ NULL,
+   c STRING NULL AS (timezone('utc':::STRING, ts)::STRING) STORED,
+   CONSTRAINT "primary" PRIMARY KEY (k ASC),
+   FAMILY "primary" (k, ts, c)
+)
+
+statement ok
+DROP TABLE trewrite
+
+statement ok
+DROP TABLE trewrite_copy

--- a/pkg/sql/schemaexpr/computed_column_rewrites.go
+++ b/pkg/sql/schemaexpr/computed_column_rewrites.go
@@ -1,0 +1,82 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package schemaexpr
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/errors"
+)
+
+// ComputedColumnRewritesMap stores a map of computed column expression
+// rewrites. The key is a formatted AST (using tree.Serialize()).
+type ComputedColumnRewritesMap map[string]tree.Expr
+
+// ParseComputedColumnRewrites parses a string of the form:
+//
+//   (before expression) -> (after expression) [, (before expression) -> (after expression) ...]
+//
+// into a ComputedColumnRewritesMap.
+//
+// Used to implement the experimental_computed_column_rewrites session setting.
+func ParseComputedColumnRewrites(val string) (ComputedColumnRewritesMap, error) {
+	if val == "" {
+		return nil, nil
+	}
+	stmt, err := parser.ParseOne(fmt.Sprintf("SET ROW (%s)", val))
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to parse column rewrites")
+	}
+	set, ok := stmt.AST.(*tree.SetVar)
+	if !ok {
+		return nil, errors.AssertionFailedf("expected a SET statement, but found %T", stmt)
+	}
+	result := make(ComputedColumnRewritesMap, len(set.Values))
+	for _, v := range set.Values {
+		binExpr, ok := v.(*tree.BinaryExpr)
+		if !ok || binExpr.Operator != tree.JSONFetchVal {
+			return nil, errors.Newf("invalid column rewrites expression (expected -> operator)")
+		}
+		left, ok := binExpr.Left.(*tree.ParenExpr)
+		if !ok {
+			return nil, errors.Newf("missing parens around \"before\" expression")
+		}
+		right, ok := binExpr.Right.(*tree.ParenExpr)
+		if !ok {
+			return nil, errors.Newf("missing parens around \"after\" expression")
+		}
+		result[tree.Serialize(left.Expr)] = right.Expr
+	}
+	return result, nil
+}
+
+// MaybeRewriteComputedColumn consults the experimental_computed_column_rewrites
+// session setting; if the given expression matches a "before expression" in the
+// setting, it is replaced to the corresponding "after expression". Otherwise,
+// the given expression is returned unchanged.
+func MaybeRewriteComputedColumn(expr tree.Expr, sessionData *sessiondata.SessionData) tree.Expr {
+	rewritesStr := sessionData.ExperimentalComputedColumnRewrites
+	if rewritesStr == "" {
+		return expr
+	}
+	rewrites, err := ParseComputedColumnRewrites(rewritesStr)
+	if err != nil {
+		// This shouldn't happen - we should have validated the value.
+		return expr
+	}
+	if newExpr, ok := rewrites[tree.Serialize(expr)]; ok {
+		return newExpr
+	}
+	return expr
+}

--- a/pkg/sql/schemaexpr/computed_column_rewrites_test.go
+++ b/pkg/sql/schemaexpr/computed_column_rewrites_test.go
@@ -1,0 +1,53 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package schemaexpr
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/datadriven"
+)
+
+func TestParseComputedColumnRewrites(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	path := "testdata/computed_column_rewrites"
+	datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
+		switch d.Cmd {
+		case "parse":
+			rewrites, err := ParseComputedColumnRewrites(d.Input)
+			if err != nil {
+				return fmt.Sprintf("error: %v", err)
+			}
+			var keys []string
+			for k := range rewrites {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			var buf bytes.Buffer
+			for _, k := range keys {
+				fmt.Fprintf(&buf, "(%v) -> (%v)\n", k, tree.Serialize(rewrites[k]))
+			}
+			return buf.String()
+
+		default:
+			t.Fatalf("unsupported command %s", d.Cmd)
+			return ""
+		}
+	})
+}

--- a/pkg/sql/schemaexpr/testdata/computed_column_rewrites
+++ b/pkg/sql/schemaexpr/testdata/computed_column_rewrites
@@ -1,0 +1,47 @@
+parse
+foo
+----
+error: invalid column rewrites expression (expected -> operator)
+
+parse
+1 + 2
+----
+error: invalid column rewrites expression (expected -> operator)
+
+parse
+a -> b
+----
+error: missing parens around "before" expression
+
+parse
+(a) -> b
+----
+error: missing parens around "after" expression
+
+parse
+(a) -> (b), (c) -> (d)
+----
+(a) -> (b)
+(c) -> (d)
+
+parse
+(a) -> (b), (c) -> (d)
+----
+(a) -> (b)
+(c) -> (d)
+
+parse
+(a+1) -> (b+2), (c+10) -> (d+20)
+----
+(a + 1) -> (b + 2)
+(c + 10) -> (d + 20)
+
+parse
+(ts::STRING) -> ((ts AT TIME ZONE 'utc')::STRING)
+----
+(ts::STRING) -> ((timezone('utc', ts))::STRING)
+
+parse
+(mod(fnv32(ts::STRING),4)) -> (mod(fnv32((ts AT TIME ZONE 'utc')::STRING), 4))
+----
+(mod(fnv32(ts::STRING), 4)) -> (mod(fnv32((timezone('utc', ts))::STRING), 4))

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -152,6 +152,12 @@ type SessionData struct {
 	SynchronousCommit bool
 	// EnableSeqScan is a dummy setting for the enable_seqscan var.
 	EnableSeqScan bool
+
+	// ExperimentalComputedColumnRewrites allows automatic rewriting of computed
+	// column expressions in CREATE TABLE and ALTER TABLE statements. See the
+	// experimentalComputedColumnRewrites cluster setting for a description of the
+	// format.
+	ExperimentalComputedColumnRewrites string
 }
 
 // IsTemporarySchemaID returns true if the given ID refers to any of the temp


### PR DESCRIPTION
Backport 1/1 commits from #67120.

/cc @cockroachdb/release

---

sql: add infrastructure for rewriting computed column expressions
  
This commit adds infrastructure that allows automatic replacement of
computed column expressions in CREATE TABLE and ALTER TABLE
statements. This provides a workaround for cases where a computed
column expression is no longer allowed (because of better detection of
context-dependent operators) but the DDL statements cannot be easily
changed.

This is configured via a new (hidden) session setting
`experimental_computed_column_rewrites`. The default value of the
setting can be controlled using the cluster setting
`sql.defaults.experimental_computed_column_rewrites`.

The value is a string of the form:
```
(before expression) -> (after expression) [, (before expression) -> (after expression) ...]
```

In order for a computed column to be rewritten, the entire computed
column expression must parse into the same AST as a "before
expression".

Example:
```
CREATE TABLE t (ts TIMESTAMPTZ NOT NULL, shard INT NOT NULL AS (mod(fnv32(ts::STRING), 4)) STORED);
ERROR: mod(): fnv32(): timestamptz::string: context-dependent operators are not allowed in computed column
SQLSTATE: 0A000
HINT: TIMESTAMPTZ to STRING casts depend on the current timezone; consider using (t AT TIME ZONE 'UTC')::STRING instead.

SET experimental_computed_column_rewrites = "(mod(fnv32(ts::STRING), 4)) -> (mod(fnv32((ts AT TIME ZONE 'utc')::STRING), 4))";

CREATE TABLE t (ts TIMESTAMPTZ NOT NULL, shard INT NOT NULL AS (mod(fnv32(ts::STRING), 4)) STORED);

SHOW CREATE TABLE t;
  table_name |                                        create_statement
-------------+--------------------------------------------------------------------------------------------------
  t          | CREATE TABLE public.t (
             |     ts TIMESTAMPTZ NOT NULL,
             |     shard INT8 NOT NULL AS (mod(fnv32(timezone('utc':::STRING, ts)::STRING), 4:::INT8)) STORED,
             |     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
             |     CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
             |     FAMILY "primary" (ts, shard, rowid)
             | )
```

Release note: None

