### PR TITLE
changefeedccl: Add a mechanism to throttle buffer drain rate.

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -3,6 +3,7 @@ admission.kv.enabled	boolean	false	when true, work performed by the KV layer is 
 admission.sql_kv_response.enabled	boolean	false	when true, work performed by the SQL layer when receiving a KV response is subject to admission control
 admission.sql_sql_response.enabled	boolean	false	when true, work performed by the SQL layer when receiving a DistSQL response is subject to admission control
 bulkio.stream_ingestion.minimum_flush_interval	duration	5s	the minimum timestamp between flushes; flushes may still occur if internal buffers fill up
+changefeed.node_throttle_config	string		specifies node level throttling configuration for all changefeeeds
 cloudstorage.http.custom_ca	string		custom root CA (appended to system's default CAs) for verifying certificates when interacting with HTTPS storage
 cloudstorage.timeout	duration	10m0s	the timeout for import/export storage operations
 cluster.organization	string		organization name

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -5,6 +5,7 @@
 <tr><td><code>admission.sql_kv_response.enabled</code></td><td>boolean</td><td><code>false</code></td><td>when true, work performed by the SQL layer when receiving a KV response is subject to admission control</td></tr>
 <tr><td><code>admission.sql_sql_response.enabled</code></td><td>boolean</td><td><code>false</code></td><td>when true, work performed by the SQL layer when receiving a DistSQL response is subject to admission control</td></tr>
 <tr><td><code>bulkio.stream_ingestion.minimum_flush_interval</code></td><td>duration</td><td><code>5s</code></td><td>the minimum timestamp between flushes; flushes may still occur if internal buffers fill up</td></tr>
+<tr><td><code>changefeed.node_throttle_config</code></td><td>string</td><td><code></code></td><td>specifies node level throttling configuration for all changefeeeds</td></tr>
 <tr><td><code>cloudstorage.http.custom_ca</code></td><td>string</td><td><code></code></td><td>custom root CA (appended to system's default CAs) for verifying certificates when interacting with HTTPS storage</td></tr>
 <tr><td><code>cloudstorage.timeout</code></td><td>duration</td><td><code>10m0s</code></td><td>the timeout for import/export storage operations</td></tr>
 <tr><td><code>cluster.organization</code></td><td>string</td><td><code></code></td><td>organization name</td></tr>

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -12,6 +12,7 @@ ALL_TESTS = [
     "//pkg/ccl/baseccl:baseccl_test",
     "//pkg/ccl/benchccl/rttanalysisccl:rttanalysisccl_test",
     "//pkg/ccl/changefeedccl/cdctest:cdctest_test",
+    "//pkg/ccl/changefeedccl/cdcutils:cdcutils_test",
     "//pkg/ccl/changefeedccl/kvevent:kvevent_test",
     "//pkg/ccl/changefeedccl/kvfeed:kvfeed_test",
     "//pkg/ccl/changefeedccl/schemafeed:schemafeed_test",

--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
     deps = [
         "//pkg/base",
         "//pkg/ccl/backupccl/backupresolver",
+        "//pkg/ccl/changefeedccl/cdcutils",
         "//pkg/ccl/changefeedccl/changefeedbase",
         "//pkg/ccl/changefeedccl/changefeeddist",
         "//pkg/ccl/changefeedccl/kvevent",

--- a/pkg/ccl/changefeedccl/cdcutils/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/cdcutils/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "cdcutils",
+    srcs = ["throttle.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdcutils",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/ccl/changefeedccl/changefeedbase",
+        "//pkg/settings",
+        "//pkg/util/log",
+        "//pkg/util/quotapool",
+        "//pkg/util/tracing",
+    ],
+)
+
+go_test(
+    name = "cdcutils_test",
+    srcs = ["throttle_test.go"],
+    embed = [":cdcutils"],
+    deps = [
+        "//pkg/ccl/changefeedccl/changefeedbase",
+        "//pkg/settings/cluster",
+        "//pkg/util/leaktest",
+        "//pkg/util/log",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/ccl/changefeedccl/cdcutils/throttle.go
+++ b/pkg/ccl/changefeedccl/cdcutils/throttle.go
@@ -1,0 +1,137 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package cdcutils
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
+	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+)
+
+// Throttler is a changefeed IO throttler.
+type Throttler struct {
+	name           string
+	messageLimiter *quotapool.RateLimiter
+	byteLimiter    *quotapool.RateLimiter
+	flushLimiter   *quotapool.RateLimiter
+}
+
+// AcquireMessageQuota acquires quota for a message with the specified size.
+// Blocks until such quota is available.
+func (t *Throttler) AcquireMessageQuota(ctx context.Context, sz int) error {
+	if t.messageLimiter.AdmitN(1) && t.byteLimiter.AdmitN(int64(sz)) {
+		return nil
+	}
+
+	// Slow case.
+	var span *tracing.Span
+	ctx, span = tracing.ChildSpan(ctx, fmt.Sprintf("quota-wait-%s", t.name))
+	defer span.Finish()
+
+	if err := t.messageLimiter.WaitN(ctx, 1); err != nil {
+		return err
+	}
+	return t.byteLimiter.WaitN(ctx, int64(sz))
+}
+
+// AcquireFlushQuota acquires quota for a message with the specified size.
+// Blocks until such quota is available.
+func (t *Throttler) AcquireFlushQuota(ctx context.Context) error {
+	if t.flushLimiter.AdmitN(1) {
+		return nil
+	}
+
+	// Slow case.
+	var span *tracing.Span
+	ctx, span = tracing.ChildSpan(ctx, fmt.Sprintf("quota-wait-flush-%s", t.name))
+	defer span.Finish()
+
+	return t.flushLimiter.WaitN(ctx, 1)
+}
+
+func (t *Throttler) updateConfig(config changefeedbase.SinkThrottleConfig) {
+	setLimits := func(rl *quotapool.RateLimiter, rate, burst float64) {
+		// set rateBudget to unlimited if rate is 0.
+		rateBudget := quotapool.Limit(math.MaxInt64)
+		if rate > 0 {
+			rateBudget = quotapool.Limit(rate)
+		}
+		// set burstBudget to be at least the rate.
+		burstBudget := int64(burst)
+		if burst < rate {
+			burstBudget = int64(rate)
+		}
+		rl.UpdateLimit(rateBudget, burstBudget)
+	}
+
+	setLimits(t.messageLimiter, config.MessageRate, config.MessageBurst)
+	setLimits(t.byteLimiter, config.ByteRate, config.ByteBurst)
+	setLimits(t.flushLimiter, config.FlushRate, config.FlushBurst)
+}
+
+// NewThrottler creates a new throttler with the specified configuration.
+func NewThrottler(name string, config changefeedbase.SinkThrottleConfig) *Throttler {
+	logSlowAcquisition := quotapool.OnSlowAcquisition(500*time.Millisecond, quotapool.LogSlowAcquisition)
+	t := &Throttler{
+		name: name,
+		messageLimiter: quotapool.NewRateLimiter(
+			fmt.Sprintf("%s-messages", name), 0, 0, logSlowAcquisition,
+		),
+		byteLimiter: quotapool.NewRateLimiter(
+			fmt.Sprintf("%s-bytes", name), 0, 0, logSlowAcquisition,
+		),
+		flushLimiter: quotapool.NewRateLimiter(
+			fmt.Sprintf("%s-flushes", name), 0, 0, logSlowAcquisition,
+		),
+	}
+	t.updateConfig(config)
+	return t
+}
+
+var nodeSinkThrottle = struct {
+	sync.Once
+	*Throttler
+}{}
+
+// NodeLevelThrottler returns node level Throttler for changefeeds.
+func NodeLevelThrottler(sv *settings.Values) *Throttler {
+	getConfig := func() (config changefeedbase.SinkThrottleConfig) {
+		configStr := changefeedbase.NodeSinkThrottleConfig.Get(sv)
+		if configStr != "" {
+			if err := json.Unmarshal([]byte(configStr), &config); err != nil {
+				log.Errorf(context.Background(),
+					"failed to parse node throttle config %q: err=%v; throttling disabled", configStr, err)
+			}
+		}
+		return
+	}
+
+	// Initialize node level throttler once.
+	nodeSinkThrottle.Do(func() {
+		if nodeSinkThrottle.Throttler != nil {
+			panic("unexpected state")
+		}
+		nodeSinkThrottle.Throttler = NewThrottler("cf.node.throttle", getConfig())
+		// Update node throttler configs when settings change.
+		changefeedbase.NodeSinkThrottleConfig.SetOnChange(sv, func(ctx context.Context) {
+			nodeSinkThrottle.Throttler.updateConfig(getConfig())
+		})
+	})
+
+	return nodeSinkThrottle.Throttler
+}

--- a/pkg/ccl/changefeedccl/cdcutils/throttle_test.go
+++ b/pkg/ccl/changefeedccl/cdcutils/throttle_test.go
@@ -1,0 +1,51 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package cdcutils
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNodeLevelThrottler(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	sv := &cluster.MakeTestingClusterSettings().SV
+
+	throttler := NodeLevelThrottler(sv)
+
+	// Default: no throttling
+	require.True(t, throttler.messageLimiter.AdmitN(10000000))
+	require.True(t, throttler.byteLimiter.AdmitN(10000000))
+	require.True(t, throttler.flushLimiter.AdmitN(10000000))
+
+	ctx := context.Background()
+	for i := 0; i < 1000; i++ {
+		require.NoError(t, throttler.AcquireMessageQuota(ctx, 100000000000))
+		require.NoError(t, throttler.AcquireFlushQuota(ctx))
+	}
+
+	// Update config and verify throttler been updated.
+	changefeedbase.NodeSinkThrottleConfig.Override(
+		ctx, sv, `{"MessageRate": 1, "ByteRate": 1, "FlushRate": 1}`,
+	)
+	require.True(t, throttler.messageLimiter.AdmitN(1))
+	require.False(t, throttler.messageLimiter.AdmitN(1))
+	require.True(t, throttler.byteLimiter.AdmitN(1))
+	require.False(t, throttler.byteLimiter.AdmitN(1))
+	require.True(t, throttler.flushLimiter.AdmitN(1))
+	require.False(t, throttler.flushLimiter.AdmitN(1))
+}

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -2208,13 +2208,12 @@ func TestChangefeedDataTTL(t *testing.T) {
 		knobs := f.Server().TestingKnobs().
 			DistSQL.(*execinfra.TestingKnobs).
 			Changefeed.(*TestingKnobs)
-		knobs.BeforeEmitRow = func(_ context.Context) error {
+		knobs.FeedKnobs.BeforeScanRequest = func(_ *kv.Batch) {
 			if atomic.LoadInt32(&shouldWait) == 0 {
-				return nil
+				return
 			}
 			wait <- struct{}{}
 			<-resume
-			return nil
 		}
 
 		sqlDB := sqlutils.MakeSQLRunner(db)

--- a/pkg/ccl/changefeedccl/kvevent/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/kvevent/BUILD.bazel
@@ -8,10 +8,12 @@ go_library(
         "err_buffer.go",
         "event.go",
         "metrics.go",
+        "throttling_buffer.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/kvevent",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/ccl/changefeedccl/cdcutils",
         "//pkg/ccl/changefeedccl/changefeedbase",
         "//pkg/jobs/jobspb",
         "//pkg/roachpb",

--- a/pkg/ccl/changefeedccl/kvevent/event.go
+++ b/pkg/ccl/changefeedccl/kvevent/event.go
@@ -77,6 +77,14 @@ func (b *Event) Type() Type {
 	return 0 // unreachable
 }
 
+// ApproximateSize returns events approximate size in bytes.
+func (b *Event) ApproximateSize() int {
+	if b.kv.Key != nil {
+		return b.kv.Size() + b.prevVal.Size()
+	}
+	return b.resolved.Size()
+}
+
 // KV is populated if this event returns true for IsKV().
 func (b *Event) KV() roachpb.KeyValue {
 	return b.kv

--- a/pkg/ccl/changefeedccl/kvevent/throttling_buffer.go
+++ b/pkg/ccl/changefeedccl/kvevent/throttling_buffer.go
@@ -1,0 +1,38 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package kvevent
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdcutils"
+)
+
+type throttlingBuffer struct {
+	Buffer
+	throttle *cdcutils.Throttler
+}
+
+// NewThrottlingBuffer wraps specified event buffer with a throttle that
+// regulates the rate of events returned by the buffer reader.
+func NewThrottlingBuffer(b Buffer, throttle *cdcutils.Throttler) Buffer {
+	return &throttlingBuffer{Buffer: b, throttle: throttle}
+}
+
+// Get implements kvevent.Reader interface.
+func (b *throttlingBuffer) Get(ctx context.Context) (Event, error) {
+	evt, err := b.Buffer.Get(ctx)
+	if err != nil {
+		return Event{}, err
+	}
+	if err := b.throttle.AcquireMessageQuota(ctx, evt.ApproximateSize()); err != nil {
+		return Event{}, err
+	}
+	return evt, nil
+}


### PR DESCRIPTION
Make it possible to specify per-node changefeed configuration
`changefeed.node_sink_throttle_config` which enables throttling
the rate of drain of the memory buffer.

The throttling can be configure to limit the rate of message
emmission, the size of the emitted messages, as well as the
sink flush counts.  All of the throttles are specified as a
base value in units per second as well as burst rate:

```
{"MessageRate": 100, "MessageBurst": 200, "FlushRate": 1},
```

If the value is unspecified, the throttling is disabled.
The throttling configuration does not imply exact match on the
observed emitted values.  This is primarily due to per-sink
buffering behavior.  However, the throttling apply to the
buffer drain rate will have proportinoal impact on the
traffic emitted to the downstream sink.

When throttling is active, and the traffic is throttled, the changefeed
enters a "pushback" mode.  If the throttling configuration is such
that the traffic throttled below the incoming rate of messages,
the changefeed will deal with this situation by eventually restarting
the rangefeeds and performing a catchup scan.  Note, however, that such
regime is detrimental for overall performance of changefeeds.
Throttling should be used in order to limit short burst of traffic.

Follow on PRs will add throttling to the sinks themselves, as well
as add monitoring metrics.

Informs cockroachdb#58967

Release Notes: Changefeeds can be configured to throttle the rate
of emission from the memory buffer thus making it possible to limit
the emission rate from the changefeeds.
