### PR TITLE
release-21.1: sql: fix "descriptor not found" error when dropping a database with t…

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/temp_table
+++ b/pkg/sql/logictest/testdata/logic_test/temp_table
@@ -285,3 +285,54 @@ grant testuser to root
 
 statement ok
 ALTER TABLE second_db.pg_temp.a OWNER TO testuser
+
+# Regression test for dropping a database which contains schemas from other
+# sessions.
+
+subtest drop_database_with_temp_schemas_from_other_sessions
+
+statement ok
+CREATE DATABASE to_drop;
+ALTER DATABASE to_drop OWNER TO testuser;
+
+user testuser
+
+statement ok
+USE to_drop;
+SET experimental_enable_temp_tables=true;
+CREATE TABLE not_temp (i INT PRIMARY KEY);
+CREATE TEMPORARY TABLE testuser_tmp (i INT PRIMARY KEY);
+CREATE TEMPORARY VIEW tempuser_view AS SELECT i FROM testuser_tmp;
+USE test
+
+user root
+
+statement ok
+USE to_drop;
+CREATE TEMPORARY TABLE root_temp (i INT PRIMARY KEY);
+
+let $before_drop
+SELECT now()
+
+statement ok
+USE test;
+DROP DATABASE to_drop CASCADE
+
+query T
+  SELECT regexp_replace(
+            json_array_elements_text(
+                (info::JSONB)->'DroppedSchemaObjects'
+            ),
+            'pg_temp_[^.]+.',
+            'pg_temp.'
+         ) AS name
+    FROM system.eventlog
+   WHERE "timestamp" > '$before_drop'
+ORDER BY name DESC;
+----
+to_drop.public.not_temp
+to_drop.pg_temp.testuser_tmp
+to_drop.pg_temp.tempuser_view
+to_drop.pg_temp.root_temp
+
+user testuser


### PR DESCRIPTION
Backport 1/1 commits from #67104.

/cc @cockroachdb/release

---

…emp views

The bug here is that there are cases in drop database cascade where we'll
attempt to qualify the name of a view involved in a cascaded drop that is
not part of the current session's temporary schema. In that scenario, we
don't know the schema except by its ID. The temporary schemas do not have
descriptors, only namespace entries.

We could do something different like delete all of the views first but that
won't help for the backport PR we need to make as we only carry prefix
descriptors around in master.

Release note (bug fix): Fixed a bug where DROP DATABASE could return errors
if the database contained temporary views in use in an another session.
