### PR TITLE
kvserver: de-flake TestAdminRelocateRange

### DIFF
--- a/pkg/kv/kvserver/client_relocate_range_test.go
+++ b/pkg/kv/kvserver/client_relocate_range_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -154,7 +153,6 @@ func usesAtomicReplicationChange(ops []roachpb.ReplicationChange) bool {
 
 func TestAdminRelocateRange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.WithIssue(t, 67031, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
@@ -162,37 +160,39 @@ func TestAdminRelocateRange(t *testing.T) {
 	type intercept struct {
 		ops         []roachpb.ReplicationChange
 		leaseTarget *roachpb.ReplicationTarget
-		err         error
 	}
 	var intercepted []intercept
 
-	requireNumAtomic := func(expAtomic int, expSingle int, f func() (retries int)) {
+	requireNumAtomic := func(expAtomic int, expSingle int, f func()) {
 		t.Helper()
 		intercepted = nil
-		retries := f()
+		f()
 		var actAtomic, actSingle int
 		for _, ic := range intercepted {
-			if ic.err != nil {
-				continue
-			}
 			if usesAtomicReplicationChange(ic.ops) {
 				actAtomic++
 			} else {
 				actSingle += len(ic.ops)
 			}
 		}
-		actAtomic -= retries
-		require.Equal(t, expAtomic, actAtomic, "wrong number of atomic changes: %+v", intercepted)
-		require.Equal(t, expSingle, actSingle, "wrong number of single changes: %+v", intercepted)
+		assert.Equal(t, expAtomic, actAtomic, "wrong number of atomic changes")
+		assert.Equal(t, expSingle, actSingle, "wrong number of single changes")
+		if t.Failed() {
+			t.Log("all changes:")
+			for i, ic := range intercepted {
+				t.Logf("%d: %v", i+1, ic.ops)
+			}
+			t.FailNow()
+		}
+
 	}
 
 	knobs := base.TestingKnobs{
 		Store: &kvserver.StoreTestingKnobs{
-			BeforeRelocateOne: func(ops []roachpb.ReplicationChange, leaseTarget *roachpb.ReplicationTarget, err error) {
+			OnRelocatedOne: func(ops []roachpb.ReplicationChange, leaseTarget *roachpb.ReplicationTarget) {
 				intercepted = append(intercepted, intercept{
 					ops:         ops,
 					leaseTarget: leaseTarget,
-					err:         err,
 				})
 			},
 		},
@@ -210,8 +210,8 @@ func TestAdminRelocateRange(t *testing.T) {
 	{
 		targets := tc.Targets(1, 0, 2)
 		// Expect two single additions, and that's it.
-		requireNumAtomic(0, 2, func() int {
-			return relocateAndCheck(t, tc, k, targets, nil /* nonVoterTargets */)
+		requireNumAtomic(0, 2, func() {
+			relocateAndCheck(t, tc, k, targets, nil /* nonVoterTargets */)
 		})
 	}
 
@@ -224,16 +224,16 @@ func TestAdminRelocateRange(t *testing.T) {
 		// Should carry out three swaps. Note that the leaseholder gets removed
 		// in the process (i.e. internally the lease must've been moved around
 		// to achieve that).
-		requireNumAtomic(3, 0, func() int {
-			return relocateAndCheck(t, tc, k, targets, nil /* nonVoterTargets */)
+		requireNumAtomic(3, 0, func() {
+			relocateAndCheck(t, tc, k, targets, nil /* nonVoterTargets */)
 		})
 	}
 
 	// s4 (LH) s5 s6 ---> s5 (LH)
 	// Pure downreplication.
 	{
-		requireNumAtomic(0, 2, func() int {
-			return relocateAndCheck(t, tc, k, tc.Targets(4), nil /* nonVoterTargets */)
+		requireNumAtomic(0, 2, func() {
+			relocateAndCheck(t, tc, k, tc.Targets(4), nil /* nonVoterTargets */)
 		})
 	}
 
@@ -241,8 +241,8 @@ func TestAdminRelocateRange(t *testing.T) {
 	// Lateral movement while at replication factor one. In this case atomic
 	// replication changes cannot be used; we add-then-remove instead.
 	{
-		requireNumAtomic(0, 2, func() int {
-			return relocateAndCheck(t, tc, k, tc.Targets(2), nil /* nonVoterTargets */)
+		requireNumAtomic(0, 2, func() {
+			relocateAndCheck(t, tc, k, tc.Targets(2), nil /* nonVoterTargets */)
 		})
 	}
 
@@ -250,51 +250,51 @@ func TestAdminRelocateRange(t *testing.T) {
 	// A grab bag.
 	{
 		// s3 -(add)-> s3 s2 -(swap)-> s4 s2 -(add)-> s4 s2 s1 (=s2 s4 s1)
-		requireNumAtomic(1, 2, func() int {
-			return relocateAndCheck(t, tc, k, tc.Targets(1, 3, 0), nil /* nonVoterTargets */)
+		requireNumAtomic(1, 2, func() {
+			relocateAndCheck(t, tc, k, tc.Targets(1, 3, 0), nil /* nonVoterTargets */)
 		})
 		// s2 s4 s1 -(add)-> s2 s4 s1 s6 (=s4 s2 s6 s1)
-		requireNumAtomic(0, 1, func() int {
-			return relocateAndCheck(t, tc, k, tc.Targets(3, 1, 5, 0), nil /* nonVoterTargets */)
+		requireNumAtomic(0, 1, func() {
+			relocateAndCheck(t, tc, k, tc.Targets(3, 1, 5, 0), nil /* nonVoterTargets */)
 		})
 		// s4 s2 s6 s1 -(swap)-> s3 s2 s6 s1 -(swap)-> s3 s5 s6 s1 -(del)-> s3 s5 s6 -(del)-> s3 s5
-		requireNumAtomic(2, 2, func() int {
-			return relocateAndCheck(t, tc, k, tc.Targets(2, 4), nil /* nonVoterTargets */)
+		requireNumAtomic(2, 2, func() {
+			relocateAndCheck(t, tc, k, tc.Targets(2, 4), nil /* nonVoterTargets */)
 		})
 	}
 
 	// Simple non-voter relocations.
 	{
-		requireNumAtomic(0, 2, func() int {
-			return relocateAndCheck(t, tc, k, tc.Targets(2, 4), tc.Targets(1, 3))
+		requireNumAtomic(0, 2, func() {
+			relocateAndCheck(t, tc, k, tc.Targets(2, 4), tc.Targets(1, 3))
 		})
 		// Add & remove.
-		requireNumAtomic(0, 2, func() int {
-			return relocateAndCheck(t, tc, k, tc.Targets(2, 4), tc.Targets(1, 5))
+		requireNumAtomic(0, 2, func() {
+			relocateAndCheck(t, tc, k, tc.Targets(2, 4), tc.Targets(1, 5))
 		})
 		// 2 add and 2 remove operations.
-		requireNumAtomic(0, 4, func() int {
-			return relocateAndCheck(t, tc, k, tc.Targets(2, 4), tc.Targets(0, 3))
+		requireNumAtomic(0, 4, func() {
+			relocateAndCheck(t, tc, k, tc.Targets(2, 4), tc.Targets(0, 3))
 		})
 	}
 
 	// Relocation scenarios that require swapping of voters with non-voters.
 	{
 		// Single swap of voter and non-voter.
-		requireNumAtomic(1, 0, func() int {
-			return relocateAndCheck(t, tc, k, tc.Targets(0, 4), tc.Targets(2, 3))
+		requireNumAtomic(1, 0, func() {
+			relocateAndCheck(t, tc, k, tc.Targets(0, 4), tc.Targets(2, 3))
 		})
 		// Multiple swaps.
-		requireNumAtomic(2, 0, func() int {
-			return relocateAndCheck(t, tc, k, tc.Targets(2, 3), tc.Targets(0, 4))
+		requireNumAtomic(2, 0, func() {
+			relocateAndCheck(t, tc, k, tc.Targets(2, 3), tc.Targets(0, 4))
 		})
 		// Single promotion of non-voter to a voter.
-		requireNumAtomic(1, 0, func() int {
-			return relocateAndCheck(t, tc, k, tc.Targets(2, 3, 4), tc.Targets(0))
+		requireNumAtomic(1, 0, func() {
+			relocateAndCheck(t, tc, k, tc.Targets(2, 3, 4), tc.Targets(0))
 		})
 		// Single demotion of voter to a non-voter.
-		requireNumAtomic(1, 0, func() int {
-			return relocateAndCheck(t, tc, k, tc.Targets(2, 4), tc.Targets(0, 3))
+		requireNumAtomic(1, 0, func() {
+			relocateAndCheck(t, tc, k, tc.Targets(2, 4), tc.Targets(0, 3))
 		})
 	}
 }

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -2759,9 +2759,6 @@ func (s *Store) relocateReplicas(
 				// Done.
 				return rangeDesc, ctx.Err()
 			}
-			if fn := s.cfg.TestingKnobs.BeforeRelocateOne; fn != nil {
-				fn(ops, leaseTarget, err)
-			}
 
 			opss := [][]roachpb.ReplicationChange{ops}
 			success := true
@@ -2781,6 +2778,10 @@ func (s *Store) relocateReplicas(
 				rangeDesc = *newDesc
 			}
 			if success {
+				if fn := s.cfg.TestingKnobs.OnRelocatedOne; fn != nil {
+					fn(ops, leaseTarget)
+				}
+
 				break
 			}
 		}

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -284,9 +284,9 @@ type StoreTestingKnobs struct {
 	// BeforeSnapshotSSTIngestion is run just before the SSTs are ingested when
 	// applying a snapshot.
 	BeforeSnapshotSSTIngestion func(IncomingSnapshot, SnapshotRequest_Type, []string) error
-	// BeforeRelocateOne intercepts the return values of s.relocateOne before
-	// they're being put into effect.
-	BeforeRelocateOne func(_ []roachpb.ReplicationChange, leaseTarget *roachpb.ReplicationTarget, _ error)
+	// OnRelocatedOne intercepts the return values of s.relocateOne after they
+	// have successfully been put into effect.
+	OnRelocatedOne func(_ []roachpb.ReplicationChange, leaseTarget *roachpb.ReplicationTarget)
 	// DontIgnoreFailureToTransferLease makes `AdminRelocateRange` return an error
 	// to its client if it failed to transfer the lease to the first voting
 	// replica in the set of relocation targets.


### PR DESCRIPTION
This test became flaky with
https://github.com/cockroachdb/cockroach/pull/67007 as we now got better
at retrying (the previous string matcher had rotted). I spent more time
fixing this test than I am willing to admit, but in the end it turned
out that there was a simple solution: call the hook the test had
provided *after* getting through the retries, rather than trying to
track and account for the retries.

Fixes #67031.

Release note: None
