### PR TITLE
sql,importccl: plumb database descriptor to avoid lookups

### DIFF
--- a/pkg/ccl/backupccl/backupresolver/targets.go
+++ b/pkg/ccl/backupccl/backupresolver/targets.go
@@ -540,6 +540,8 @@ func LoadAllDescs(
 
 // ResolveTargetsToDescriptors performs name resolution on a set of targets and
 // returns the resulting descriptors.
+//
+// TODO(ajwerner): adopt the collection here.
 func ResolveTargetsToDescriptors(
 	ctx context.Context, p sql.PlanHookState, endTime hlc.Timestamp, targets *tree.TargetList,
 ) ([]catalog.Descriptor, []descpb.ID, error) {

--- a/pkg/ccl/importccl/BUILD.bazel
+++ b/pkg/ccl/importccl/BUILD.bazel
@@ -144,6 +144,7 @@ go_test(
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/catalogkv",
         "//pkg/sql/catalog/catformat",
+        "//pkg/sql/catalog/dbdesc",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/distsql",

--- a/pkg/ccl/importccl/read_import_mysql_test.go
+++ b/pkg/ccl/importccl/read_import_mysql_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catformat"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/dbdesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
@@ -100,7 +101,7 @@ func TestMysqldumpDataReader(t *testing.T) {
 	}
 }
 
-const expectedParent = 52
+const expectedParentID = 52
 
 func readFile(t *testing.T, name string) string {
 	body, err := ioutil.ReadFile(filepath.Join("testdata", "mysqldump", name))
@@ -120,6 +121,9 @@ func readMysqlCreateFrom(
 	}
 	defer f.Close()
 	walltime := testEvalCtx.StmtTimestamp.UnixNano()
+	expectedParent := dbdesc.NewInitial(
+		expectedParentID, "test", security.RootUserName(),
+	)
 	tbl, err := readMysqlCreateTable(context.Background(), f, testEvalCtx, nil, id, expectedParent, name, fks, map[descpb.ID]int64{}, security.RootUserName(), walltime)
 	if err != nil {
 		t.Fatal(err)
@@ -134,8 +138,8 @@ func TestMysqldumpSchemaReader(t *testing.T) {
 
 	files := getMysqldumpTestdata(t)
 
-	simpleTable := descForTable(ctx, t, readFile(t, `simple.cockroach-schema.sql`), expectedParent, 52, NoFKs)
-	referencedSimple := descForTable(ctx, t, readFile(t, `simple.cockroach-schema.sql`), expectedParent, 52, NoFKs)
+	simpleTable := descForTable(ctx, t, readFile(t, `simple.cockroach-schema.sql`), expectedParentID, 52, NoFKs)
+	referencedSimple := descForTable(ctx, t, readFile(t, `simple.cockroach-schema.sql`), expectedParentID, 52, NoFKs)
 	fks := fkHandler{
 		allowed: true,
 		resolver: fkResolver{
@@ -150,14 +154,14 @@ func TestMysqldumpSchemaReader(t *testing.T) {
 	})
 
 	t.Run("second", func(t *testing.T) {
-		secondTable := descForTable(ctx, t, readFile(t, `second.cockroach-schema.sql`), expectedParent, 53, fks)
+		secondTable := descForTable(ctx, t, readFile(t, `second.cockroach-schema.sql`), expectedParentID, 53, fks)
 		expected := secondTable
 		got := readMysqlCreateFrom(t, files.second, "", 53, fks)
 		compareTables(t, expected.TableDesc(), got)
 	})
 
 	t.Run("everything", func(t *testing.T) {
-		expected := descForTable(ctx, t, readFile(t, `everything.cockroach-schema.sql`), expectedParent, 53, NoFKs)
+		expected := descForTable(ctx, t, readFile(t, `everything.cockroach-schema.sql`), expectedParentID, 53, NoFKs)
 		got := readMysqlCreateFrom(t, files.everything, "", 53, NoFKs)
 		compareTables(t, expected.TableDesc(), got)
 	})
@@ -173,7 +177,7 @@ func TestMysqldumpSchemaReader(t *testing.T) {
 			tableNameToDesc: make(map[string]*tabledesc.Mutable),
 			format:          mysqlDumpFormat(),
 		}}
-		expected := descForTable(ctx, t, readFile(t, `third.cockroach-schema.sql`), expectedParent, 52, skip)
+		expected := descForTable(ctx, t, readFile(t, `third.cockroach-schema.sql`), expectedParentID, 52, skip)
 		got := readMysqlCreateFrom(t, files.wholeDB, "third", 51, skip)
 		compareTables(t, expected.TableDesc(), got)
 	})

--- a/pkg/sql/alter_sequence.go
+++ b/pkg/sql/alter_sequence.go
@@ -37,7 +37,7 @@ func (p *planner) AlterSequence(ctx context.Context, n *tree.AlterSequence) (pla
 		return nil, err
 	}
 
-	seqDesc, err := p.ResolveMutableTableDescriptorEx(
+	_, seqDesc, err := p.ResolveMutableTableDescriptorEx(
 		ctx, n.Name, !n.IfExists, tree.ResolveRequireSequenceDesc,
 	)
 	if err != nil {

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -42,6 +42,7 @@ import (
 
 type alterTableNode struct {
 	n         *tree.AlterTable
+	prefix    catalog.ResolvedObjectPrefix
 	tableDesc *tabledesc.Mutable
 	// statsData is populated with data for "alter table inject statistics"
 	// commands - the JSON stats expressions.
@@ -62,12 +63,12 @@ func (p *planner) AlterTable(ctx context.Context, n *tree.AlterTable) (planNode,
 		return nil, err
 	}
 
-	tableDesc, err := p.ResolveMutableTableDescriptorEx(
+	prefix, tableDesc, err := p.ResolveMutableTableDescriptorEx(
 		ctx, n.Table, !n.IfExists, tree.ResolveRequireTableDesc,
 	)
 	if errors.Is(err, resolver.ErrNoPrimaryKey) {
 		if len(n.Cmds) > 0 && isAlterCmdValidWithoutPrimaryKey(n.Cmds[0]) {
-			tableDesc, err = p.ResolveMutableTableDescriptorExAllowNoPrimaryKey(
+			prefix, tableDesc, err = p.ResolveMutableTableDescriptorExAllowNoPrimaryKey(
 				ctx, n.Table, !n.IfExists, tree.ResolveRequireTableDesc,
 			)
 		}
@@ -111,6 +112,7 @@ func (p *planner) AlterTable(ctx context.Context, n *tree.AlterTable) (planNode,
 
 	return &alterTableNode{
 		n:         n,
+		prefix:    prefix,
 		tableDesc: tableDesc,
 		statsData: statsData,
 	}, nil
@@ -356,6 +358,8 @@ func (n *alterTableNode) startExec(params runParams) error {
 						params.ctx,
 						params.p.txn,
 						params.p,
+						n.prefix.Database,
+						n.prefix.Schema,
 						n.tableDesc,
 						d,
 						affected,

--- a/pkg/sql/alter_table_locality.go
+++ b/pkg/sql/alter_table_locality.go
@@ -50,7 +50,7 @@ func (p *planner) AlterTableLocality(
 		return nil, err
 	}
 
-	tableDesc, err := p.ResolveMutableTableDescriptorEx(
+	_, tableDesc, err := p.ResolveMutableTableDescriptorEx(
 		ctx, n.Name, !n.IfExists, tree.ResolveRequireTableDesc,
 	)
 	if err != nil {

--- a/pkg/sql/refresh_materialized_view.go
+++ b/pkg/sql/refresh_materialized_view.go
@@ -33,7 +33,7 @@ func (p *planner) RefreshMaterializedView(
 	if !p.EvalContext().TxnImplicit {
 		return nil, pgerror.Newf(pgcode.InvalidTransactionState, "cannot refresh view in an explicit transaction")
 	}
-	desc, err := p.ResolveMutableTableDescriptorEx(ctx, n.Name, true /* required */, tree.ResolveRequireViewDesc)
+	_, desc, err := p.ResolveMutableTableDescriptorEx(ctx, n.Name, true /* required */, tree.ResolveRequireViewDesc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -1327,22 +1327,22 @@ func (p *planner) ResolveMutableTableDescriptorEx(
 	name *tree.UnresolvedObjectName,
 	required bool,
 	requiredType tree.RequiredTableKind,
-) (*tabledesc.Mutable, error) {
+) (catalog.ResolvedObjectPrefix, *tabledesc.Mutable, error) {
 	tn := name.ToTableName()
 	prefix, table, err := resolver.ResolveMutableExistingTableObject(ctx, p, &tn, required, requiredType)
 	if err != nil {
-		return nil, err
+		return catalog.ResolvedObjectPrefix{}, nil, err
 	}
 	name.SetAnnotation(&p.semaCtx.Annotations, &tn)
 
 	if table != nil {
 		// Ensure that the user can access the target schema.
 		if err := p.canResolveDescUnderSchema(ctx, prefix.Schema, table); err != nil {
-			return nil, err
+			return catalog.ResolvedObjectPrefix{}, nil, err
 		}
 	}
 
-	return table, nil
+	return prefix, table, nil
 }
 
 // ResolveMutableTableDescriptorExAllowNoPrimaryKey performs the
@@ -1353,7 +1353,7 @@ func (p *planner) ResolveMutableTableDescriptorExAllowNoPrimaryKey(
 	name *tree.UnresolvedObjectName,
 	required bool,
 	requiredType tree.RequiredTableKind,
-) (*tabledesc.Mutable, error) {
+) (catalog.ResolvedObjectPrefix, *tabledesc.Mutable, error) {
 	lookupFlags := tree.ObjectLookupFlags{
 		CommonLookupFlags:      tree.CommonLookupFlags{Required: required, RequireMutable: true},
 		AllowWithoutPrimaryKey: true,
@@ -1362,7 +1362,7 @@ func (p *planner) ResolveMutableTableDescriptorExAllowNoPrimaryKey(
 	}
 	desc, prefix, err := resolver.ResolveExistingObject(ctx, p, name, lookupFlags)
 	if err != nil || desc == nil {
-		return nil, err
+		return catalog.ResolvedObjectPrefix{}, nil, err
 	}
 	tn := tree.MakeTableNameFromPrefix(prefix.NamePrefix(), tree.Name(name.Object()))
 	name.SetAnnotation(&p.semaCtx.Annotations, &tn)
@@ -1370,10 +1370,10 @@ func (p *planner) ResolveMutableTableDescriptorExAllowNoPrimaryKey(
 
 	// Ensure that the user can access the target schema.
 	if err := p.canResolveDescUnderSchema(ctx, prefix.Schema, table); err != nil {
-		return nil, err
+		return catalog.ResolvedObjectPrefix{}, nil, err
 	}
 
-	return table, nil
+	return prefix, table, err
 }
 
 // See ResolveUncachedTableDescriptor.


### PR DESCRIPTION
These lookups to qualify a name for an error when making an FK were bad. The thrust of this change is making qualifyFKColErrorWithDB not do any lookups.

Release note: None