### PR TITLE
opt: only prune synthesized check constraint columns for UPDATEs

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/check_constraints
+++ b/pkg/sql/logictest/testdata/logic_test/check_constraints
@@ -310,6 +310,33 @@ UPDATE t9 SET a = 7 WHERE a = 4
 statement error pgcode 23514 failed to satisfy CHECK constraint \(a > b\)
 UPDATE t9 SET a = 2 WHERE a = 5
 
+# Check constraints on computed columns.
+
+statement ok
+CREATE TABLE t10 (
+  a INT,
+  b INT AS (a - 1) STORED,
+  CHECK (b > 0)
+);
+
+statement error failed to satisfy CHECK constraint \(b > 0:::INT8\)
+INSERT INTO t10 VALUES (1)
+
+statement error failed to satisfy CHECK constraint \(b > 0:::INT8\)
+UPSERT INTO t10 VALUES (1)
+
+statement ok
+INSERT INTO t10 VALUES (2)
+
+statement ok
+UPSERT INTO t10 VALUES (2)
+
+statement error failed to satisfy CHECK constraint \(b > 0:::INT8\)
+UPDATE t10 SET a = 1
+
+statement ok
+UPDATE t10 SET a = 3
+
 # Regression test for #36293. Make sure we don't panic with a false check
 # constraint.
 statement ok
@@ -349,3 +376,22 @@ CREATE TABLE t51690(x INT, y INT, CHECK(x / y = 1));
 
 statement error pq: division by zero
 INSERT INTO t51690 VALUES (1, 0)
+
+# Regression test for #67100. Inserts should fail when a check constraint always
+# evaluates to false.
+
+statement ok
+CREATE TABLE t67100a (a INT, CHECK (false));
+CREATE TABLE t67100b (a INT, CHECK (true AND 0 > 1));
+
+statement error failed to satisfy CHECK constraint \(false\)
+INSERT INTO t67100a VALUES (1)
+
+statement error failed to satisfy CHECK constraint \(false\)
+UPSERT INTO t67100a VALUES (1)
+
+statement error failed to satisfy CHECK constraint \(true AND \(0:::INT8 > 1:::INT8\)\)
+INSERT INTO t67100b VALUES (1)
+
+statement error failed to satisfy CHECK constraint \(true AND \(0:::INT8 > 1:::INT8\)\)
+UPSERT INTO t67100b VALUES (1)

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -653,7 +653,7 @@ func (mb *mutationBuilder) buildInsert(returning tree.ReturningExprs) {
 	mb.disambiguateColumns()
 
 	// Add any check constraint boolean columns to the input.
-	mb.addCheckConstraintCols()
+	mb.addCheckConstraintCols(false /* isUpdate */)
 
 	// Project partial index PUT boolean columns.
 	mb.projectPartialIndexPutCols()
@@ -865,7 +865,7 @@ func (mb *mutationBuilder) buildUpsert(returning tree.ReturningExprs) {
 	mb.disambiguateColumns()
 
 	// Add any check constraint boolean columns to the input.
-	mb.addCheckConstraintCols()
+	mb.addCheckConstraintCols(false /* isUpdate */)
 
 	// Add the partial index predicate expressions to the table metadata.
 	// These expressions are used to prune fetch columns during

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -846,7 +846,13 @@ func findRoundingFunction(
 // addCheckConstraintCols synthesizes a boolean output column for each check
 // constraint defined on the target table. The mutation operator will report a
 // constraint violation error if the value of the column is false.
-func (mb *mutationBuilder) addCheckConstraintCols() {
+//
+// Synthesized check columns are not necessary for UPDATE mutations if the
+// columns referenced in the check expression are not being mutated. If isUpdate
+// is true, check columns that do not reference mutation columns are not added
+// to checkColIDs, which allows pruning normalization rules to remove the
+// unnecessary projected column.
+func (mb *mutationBuilder) addCheckConstraintCols(isUpdate bool) {
 	if mb.tab.CheckCount() != 0 {
 		projectionsScope := mb.outScope.replace()
 		projectionsScope.appendColumnsFromScope(mb.outScope)
@@ -870,12 +876,11 @@ func (mb *mutationBuilder) addCheckConstraintCols() {
 			referencedCols := &opt.ColSet{}
 			mb.b.buildScalar(texpr, mb.outScope, projectionsScope, scopeCol, referencedCols)
 
-			// Synthesized check columns are only necessary if the columns
-			// referenced in the check expression are being mutated. If they are
-			// not being mutated, we do not add the newly built column to
-			// checkColIDs. This allows pruning normalization rules to remove
-			// the unnecessary projected column.
-			if referencedCols.Intersects(mutationCols) {
+			// If the mutation is not an UPDATE, track the synthesized check
+			// columns in checkColIDS. If the mutation is an UPDATE, only track
+			// the check columns if the columns referenced in the check
+			// expression are being mutated.
+			if !isUpdate || referencedCols.Intersects(mutationCols) {
 				mb.checkColIDs[i] = scopeCol.id
 			}
 		}

--- a/pkg/sql/opt/optbuilder/testdata/insert
+++ b/pkg/sql/opt/optbuilder/testdata/insert
@@ -1233,3 +1233,38 @@ insert defvals2
       └── projections
            ├── ARRAY[NULL] [as=arr1_default:7]
            └── ARRAY[NULL] [as=arr2_default:8]
+
+# Regression test for #67100. Do not prune check columns for INSERTs even if the
+# expression does not reference any mutating columns.
+
+exec-ddl
+CREATE TABLE t67100 (
+  a INT,
+  CHECK (false),
+  CHECK (0 > 1),
+  CHECK (true AND 0 > 1)
+)
+----
+
+build
+INSERT INTO t67100 VALUES (1)
+----
+insert t67100
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:5 => a:1
+ │    └── rowid_default:6 => rowid:2
+ ├── check columns: check1:7 check2:8 check3:9
+ └── project
+      ├── columns: check1:7!null check2:8!null check3:9!null column1:5!null rowid_default:6
+      ├── project
+      │    ├── columns: rowid_default:6 column1:5!null
+      │    ├── values
+      │    │    ├── columns: column1:5!null
+      │    │    └── (1,)
+      │    └── projections
+      │         └── unique_rowid() [as=rowid_default:6]
+      └── projections
+           ├── false [as=check1:7]
+           ├── 0 > 1 [as=check2:8]
+           └── true AND (0 > 1) [as=check3:9]

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -1911,3 +1911,38 @@ upsert decimals
       └── projections
            ├── round(upsert_a:24) = upsert_a:24 [as=check1:28]
            └── upsert_b:25[0] > 1 [as=check2:29]
+
+# Regression test for #67100. Do not prune check columns for UPSERTs even if the
+# expression does not reference any mutating columns.
+
+exec-ddl
+CREATE TABLE t67100 (
+  a INT,
+  CHECK (false),
+  CHECK (0 > 1),
+  CHECK (true AND 0 > 1)
+)
+----
+
+build
+UPSERT INTO t67100 VALUES (1)
+----
+upsert t67100
+ ├── columns: <none>
+ ├── upsert-mapping:
+ │    ├── column1:5 => a:1
+ │    └── rowid_default:6 => rowid:2
+ ├── check columns: check1:7 check2:8 check3:9
+ └── project
+      ├── columns: check1:7!null check2:8!null check3:9!null column1:5!null rowid_default:6
+      ├── project
+      │    ├── columns: rowid_default:6 column1:5!null
+      │    ├── values
+      │    │    ├── columns: column1:5!null
+      │    │    └── (1,)
+      │    └── projections
+      │         └── unique_rowid() [as=rowid_default:6]
+      └── projections
+           ├── false [as=check1:7]
+           ├── 0 > 1 [as=check2:8]
+           └── true AND (0 > 1) [as=check3:9]

--- a/pkg/sql/opt/optbuilder/update.go
+++ b/pkg/sql/opt/optbuilder/update.go
@@ -332,7 +332,7 @@ func (mb *mutationBuilder) buildUpdate(returning tree.ReturningExprs) {
 	mb.disambiguateColumns()
 
 	// Add any check constraint boolean columns to the input.
-	mb.addCheckConstraintCols()
+	mb.addCheckConstraintCols(true /* isUpdate */)
 
 	// Add the partial index predicate expressions to the table metadata.
 	// These expressions are used to prune fetch columns during


### PR DESCRIPTION
Check constraint columns are synthesized columns that allow the
execution engine to enforce check constraints. Previously, the optimizer
would prune these columns for INSERT and UPSERT mutations if the check
expression did not reference any mutating columns. Normally, these
columns were never pruned because inserts mutate all columns in the
table.

However, if the check expression did not reference any columns, like in
`CHECK (false)`, the columns were pruned and the check constraint was
not enforced. This allowed rows to be inserted into the table when they
should have instead violated the check constraint.

This commit fixes the issue by ensuring that synthesized check
constraint columns are only pruned for UPDATE mutations.

Fixes #67100

Release note (bug fix): A bug has been fixed that allowed rows to be
inserted into a table with a check constraint that always evaluated to
false, like `CHECK (false)`. This bug was present since version 21.1.0.