### PR TITLE
sqlsmith: make TLP predicates immutable

### DIFF
--- a/pkg/internal/sqlsmith/tlp.go
+++ b/pkg/internal/sqlsmith/tlp.go
@@ -53,6 +53,13 @@ import (
 // If the resulting counts of the two queries are not equal, there is a logical
 // bug.
 func (s *Smither) GenerateTLP() (unpartitioned, partitioned string) {
+	// Set disableImpureFns to true so that generated predicates are immutable.
+	originalDisableImpureFns := s.disableImpureFns
+	s.disableImpureFns = true
+	defer func() {
+		s.disableImpureFns = originalDisableImpureFns
+	}()
+
 	f := tree.NewFmtCtx(tree.FmtParsable)
 
 	table, _, _, cols, ok := s.getSchemaTable()


### PR DESCRIPTION
Previously, `GenerateTLP` could generate predicates that were not
immutable. For example, a predicate could include `random()`. The TLP
method only works correctly if predicates are immutable. A non-immutable
predicate can cause TLP to erroneously report a correctness bug.

Release note: None