### PR TITLE
sql: improve expression index usability

### DIFF
--- a/pkg/sql/alter_primary_key.go
+++ b/pkg/sql/alter_primary_key.go
@@ -133,6 +133,9 @@ func (p *planner) AlterPrimaryKey(
 			return pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
 				"column %q is being dropped", col.GetName())
 		}
+		if col.IsInaccessible() {
+			return pgerror.Newf(pgcode.InvalidSchemaDefinition, "cannot use inaccessible column %q in primary key", col.GetName())
+		}
 		if col.IsNullable() {
 			return pgerror.Newf(pgcode.InvalidSchemaDefinition, "cannot use nullable column %q in primary key", col.GetName())
 		}

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -472,6 +472,14 @@ func (n *alterTableNode) startExec(params runParams) error {
 				continue
 			}
 
+			if colToDrop.IsInaccessible() {
+				return pgerror.Newf(
+					pgcode.InvalidColumnReference,
+					"cannot drop inaccessible column %q",
+					t.Column,
+				)
+			}
+
 			// If the dropped column uses a sequence, remove references to it from that sequence.
 			if colToDrop.NumUsesSequences() > 0 {
 				if err := params.p.removeSequenceDependencies(params.ctx, n.tableDesc, colToDrop); err != nil {

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -230,18 +230,40 @@ func (n *alterTableNode) startExec(params runParams) error {
 					continue
 				}
 
+				if err := validateColumnsAreAccessible(n.tableDesc, d.Columns); err != nil {
+					return err
+				}
+
+				tableName, err := params.p.getQualifiedTableName(params.ctx, n.tableDesc)
+				if err != nil {
+					return err
+				}
+
+				if err := replaceExpressionElemsWithVirtualCols(
+					params.ctx,
+					n.tableDesc,
+					tableName,
+					d.Columns,
+					false, /* isInverted */
+					false, /* isNewTable */
+					params.p.SemaCtx(),
+					params.EvalContext(),
+					params.SessionData(),
+				); err != nil {
+					return err
+				}
+
 				// Check if the columns exist on the table.
 				for _, column := range d.Columns {
-					col, err := n.tableDesc.FindColumnWithName(column.Column)
+					if column.Expr != nil {
+						return pgerror.New(
+							pgcode.InvalidTableDefinition,
+							"cannot create a unique constraint on an expression, use UNIQUE INDEX instead",
+						)
+					}
+					_, err := n.tableDesc.FindColumnWithName(column.Column)
 					if err != nil {
 						return err
-					}
-					if col.IsInaccessible() {
-						return pgerror.Newf(
-							pgcode.UndefinedColumn,
-							"column %q is inaccessible and cannot be referenced by a unique constraint",
-							column.Column,
-						)
 					}
 				}
 				// If the index is named, ensure that the name is unique.
@@ -258,7 +280,6 @@ func (n *alterTableNode) startExec(params runParams) error {
 					return err
 				}
 
-				var err error
 				idx, err = params.p.configureIndexDescForNewIndexPartitioning(
 					params.ctx,
 					n.tableDesc,

--- a/pkg/sql/logictest/testdata/logic_test/expression_index
+++ b/pkg/sql/logictest/testdata/logic_test/expression_index
@@ -228,6 +228,10 @@ ALTER TABLE child ADD CONSTRAINT err FOREIGN KEY (a) REFERENCES t(crdb_internal_
 statement error column \"crdb_internal_idx_expr_4\" is inaccessible and cannot reference a foreign key
 ALTER TABLE t ADD CONSTRAINT err FOREIGN KEY (crdb_internal_idx_expr_4) REFERENCES child(a)
 
+# Dropping an inaccessible column is not allowed.
+statement error cannot drop inaccessible column \"crdb_internal_idx_expr_4\"
+ALTER TABLE t DROP COLUMN crdb_internal_idx_expr_4
+
 # Renaming a column to the same name as one of the inaccessible expression index
 # columns is not allowed.
 statement error column \"crdb_internal_idx_expr_4\" of relation \"t\" already exists

--- a/pkg/sql/logictest/testdata/logic_test/expression_index
+++ b/pkg/sql/logictest/testdata/logic_test/expression_index
@@ -329,6 +329,10 @@ CREATE INDEX err ON other ((t.a + 10))
 statement error column \"crdb_internal_idx_expr\" does not exist
 SELECT * FROM t WHERE crdb_internal_idx_expr > 0
 
+# An inaccessible column cannot be used in a view.
+statement error column \"crdb_internal_idx_expr\" does not exist
+CREATE VIEW v(a) AS SELECT crdb_internal_idx_expr FROM t
+
 statement ok
 CREATE TABLE pk (
   k INT PRIMARY KEY,

--- a/pkg/sql/logictest/testdata/logic_test/expression_index
+++ b/pkg/sql/logictest/testdata/logic_test/expression_index
@@ -129,6 +129,18 @@ CREATE TABLE err (a INT, INDEX ((a + z)))
 statement error index element expression cannot reference computed columns
 CREATE TABLE err (a INT, comp INT AS (a + 10) STORED, INDEX ((comp + 10)))
 
+# TODO(mgartner): Postgres does not allow unique constraints with expressions,
+# but does allow unique indexes with expressions. We may want to err in this
+# case to be consistent with Postgres. See #65825.
+statement ok
+CREATE TABLE err (a INT, UNIQUE ((a + 10)))
+
+# TODO(mgartner): Postgres does not allow unique constraints with expressions,
+# but does allow unique indexes with expressions. We may want to err in this
+# case to be consistent with Postgres. See #65825.
+statement ok
+ALTER TABLE t ADD CONSTRAINT err UNIQUE ((a + 10))
+
 statement ok
 DROP TABLE t
 
@@ -186,7 +198,7 @@ statement error column \"crdb_internal_idx_expr_4\" is inaccessible and cannot b
 ALTER TABLE t ALTER COLUMN crdb_internal_idx_expr_4 SET NOT NULL
 
 # Referencing an inaccessible column in a UNIQUE constraint is not allowed.
-statement error column \"crdb_internal_idx_expr_4\" is inaccessible and cannot be referenced by a unique constraint
+statement error column \"crdb_internal_idx_expr_4\" is inaccessible and cannot be referenced
 ALTER TABLE t ADD CONSTRAINT err UNIQUE (crdb_internal_idx_expr_4)
 
 # Referencing an inaccessible column in a computed column expression is not

--- a/pkg/sql/logictest/testdata/logic_test/expression_index
+++ b/pkg/sql/logictest/testdata/logic_test/expression_index
@@ -212,6 +212,15 @@ ALTER TABLE child ADD CONSTRAINT err FOREIGN KEY (a) REFERENCES t(crdb_internal_
 statement error column \"crdb_internal_idx_expr_4\" is inaccessible and cannot reference a foreign key
 ALTER TABLE t ADD CONSTRAINT err FOREIGN KEY (crdb_internal_idx_expr_4) REFERENCES child(a)
 
+# Renaming a column to the same name as one of the inaccessible expression index
+# columns is not allowed.
+statement error column \"crdb_internal_idx_expr_4\" of relation \"t\" already exists
+ALTER TABLE t RENAME COLUMN a TO crdb_internal_idx_expr_4
+
+# Renaming an inaccessible expression index column is not allowed.
+statement error column \"crdb_internal_idx_expr_4\" is inaccessible and cannot be renamed
+ALTER TABLE t RENAME COLUMN crdb_internal_idx_expr_4 TO err
+
 # Adding a column with the same name as one of the inaccessible columns created
 # for an expression index is not allowed.
 statement error column \"crdb_internal_idx_expr_4\" of relation \"t\" already exists

--- a/pkg/sql/logictest/testdata/logic_test/expression_index
+++ b/pkg/sql/logictest/testdata/logic_test/expression_index
@@ -181,6 +181,10 @@ CREATE TABLE public.t (
 statement error column \"crdb_internal_idx_expr_4\" is inaccessible and cannot be referenced
 ALTER TABLE t ADD CONSTRAINT err CHECK (crdb_internal_idx_expr_4 > 0)
 
+# Referencing an inaccessible column in a NOT NULL constraint is not allowed.
+statement error column \"crdb_internal_idx_expr_4\" is inaccessible and cannot be referenced
+ALTER TABLE t ALTER COLUMN crdb_internal_idx_expr_4 SET NOT NULL
+
 # Referencing an inaccessible column in a UNIQUE constraint is not allowed.
 statement error column \"crdb_internal_idx_expr_4\" is inaccessible and cannot be referenced by a unique constraint
 ALTER TABLE t ADD CONSTRAINT err UNIQUE (crdb_internal_idx_expr_4)
@@ -312,6 +316,17 @@ CREATE INDEX err ON other ((t.a + 10))
 # queries.
 statement error column \"crdb_internal_idx_expr\" does not exist
 SELECT * FROM t WHERE crdb_internal_idx_expr > 0
+
+statement ok
+CREATE TABLE pk (
+  k INT PRIMARY KEY,
+  UNIQUE INDEX ((k + 10))
+)
+
+statement error cannot use inaccessible column \"crdb_internal_idx_expr\" in primary key
+ALTER TABLE pk ALTER PRIMARY KEY USING COLUMNS (crdb_internal_idx_expr)
+
+# Tests for CREATE TABLE ... LIKE.
 
 statement ok
 CREATE TABLE src (

--- a/pkg/sql/rename_column.go
+++ b/pkg/sql/rename_column.go
@@ -126,6 +126,13 @@ func (p *planner) renameColumn(
 	if isShardColumn && !allowRenameOfShardColumn {
 		return false, pgerror.Newf(pgcode.ReservedName, "cannot rename shard column")
 	}
+	if col.IsInaccessible() {
+		return false, pgerror.Newf(
+			pgcode.UndefinedColumn,
+			"column %q is inaccessible and cannot be renamed",
+			col.GetName(),
+		)
+	}
 	// Understand if the active column already exists before checking for column
 	// mutations to detect assertion failure of empty mutation and no column.
 	// Otherwise we would have to make the above call twice.


### PR DESCRIPTION
#### sql: do not allow renaming inaccessible columns

Release note: None

#### sql: do not allow inaccessible columns in primary keys

Release note: None

#### sql: support expressions in unique constraints

Postgres does not allow expressions in unique constraints, but it does
allow expressions in unique indexes. For now we allow expressions in
unique constraints, because we cannot differentiate between a unique
constraint and a unique index table definition: they are both parsed
into the same struct, `tree.UniqueConstraintTableDef`.

In the long term we may want to disallow expression in unique
constraints to be consistent with Postgres. We could do this by changing
the parser so that `UNIQUE ((a + b))` does not parse successfully.
See #65825.

Release note: None

#### sql: better error message when creating a view with an inaccessible column

Previously, the error message returned when attempting to create a view
with an inaccessible column was confusing:

    unimplemented: views do not currently support * expressions

The error message now reads:

    column "x" does not exist

Release note: None

#### sql: do not allow inaccessible columns to be dropped

Release note: None
