### PR TITLE
colexec: fix bug in PerformAppend when batch is reset and reused

### DIFF
--- a/pkg/sql/colexec/colexechash/hashtable.go
+++ b/pkg/sql/colexec/colexechash/hashtable.go
@@ -365,7 +365,7 @@ func (ht *HashTable) FullBuild(input colexecop.Operator) {
 		if batch.Length() == 0 {
 			break
 		}
-		ht.allocator.PerformAppend(ht.Vals.ColVecs(), func() {
+		ht.allocator.PerformAppend(ht.Vals, func() {
 			ht.Vals.AppendTuples(batch, 0 /* startIdx */, batch.Length())
 		})
 	}
@@ -483,7 +483,7 @@ func (ht *HashTable) RemoveDuplicates(
 // NOTE: batch must be of non-zero length.
 func (ht *HashTable) AppendAllDistinct(batch coldata.Batch) {
 	numBuffered := uint64(ht.Vals.Length())
-	ht.allocator.PerformAppend(ht.Vals.ColVecs(), func() {
+	ht.allocator.PerformAppend(ht.Vals, func() {
 		ht.Vals.AppendTuples(batch, 0 /* startIdx */, batch.Length())
 	})
 	ht.BuildScratch.Next = append(ht.BuildScratch.Next, ht.ProbeScratch.HashBuffer[:batch.Length()]...)

--- a/pkg/sql/colexec/colexecutils/spilling_buffer.go
+++ b/pkg/sql/colexec/colexecutils/spilling_buffer.go
@@ -166,7 +166,7 @@ func (b *SpillingBuffer) AppendTuples(
 	maxInMemTuplesLimitReached := b.testingKnobs.maxTuplesStoredInMemory > 0 &&
 		b.bufferedTuples.Length() >= b.testingKnobs.maxTuplesStoredInMemory
 	if !memLimitReached && b.diskQueue == nil && !maxInMemTuplesLimitReached {
-		b.unlimitedAllocator.PerformAppend(b.bufferedTuples.ColVecs(), func() {
+		b.unlimitedAllocator.PerformAppend(b.bufferedTuples, func() {
 			b.bufferedTuples.AppendTuples(b.scratch, 0 /* startIdx */, b.scratch.Length())
 		})
 		return

--- a/pkg/sql/colexec/hash_aggregator.go
+++ b/pkg/sql/colexec/hash_aggregator.go
@@ -229,7 +229,7 @@ func (op *hashAggregator) Next() coldata.Batch {
 		switch op.state {
 		case hashAggregatorBuffering:
 			if op.bufferingState.pendingBatch != nil && op.bufferingState.unprocessedIdx < op.bufferingState.pendingBatch.Length() {
-				op.allocator.PerformAppend(op.bufferingState.tuples.ColVecs(), func() {
+				op.allocator.PerformAppend(op.bufferingState.tuples, func() {
 					op.bufferingState.tuples.AppendTuples(
 						op.bufferingState.pendingBatch, op.bufferingState.unprocessedIdx, op.bufferingState.pendingBatch.Length(),
 					)
@@ -268,7 +268,7 @@ func (op *hashAggregator) Next() coldata.Batch {
 				toBuffer = op.maxBuffered - op.bufferingState.tuples.Length()
 			}
 			if toBuffer > 0 {
-				op.allocator.PerformAppend(op.bufferingState.tuples.ColVecs(), func() {
+				op.allocator.PerformAppend(op.bufferingState.tuples, func() {
 					op.bufferingState.tuples.AppendTuples(op.bufferingState.pendingBatch, 0 /* startIdx */, toBuffer)
 				})
 				op.bufferingState.unprocessedIdx = toBuffer

--- a/pkg/sql/colexec/sort.go
+++ b/pkg/sql/colexec/sort.go
@@ -138,7 +138,7 @@ func (p *allSpooler) spool() {
 	}
 	p.spooled = true
 	for batch := p.Input.Next(); batch.Length() != 0; batch = p.Input.Next() {
-		p.allocator.PerformAppend(p.bufferedTuples.ColVecs(), func() {
+		p.allocator.PerformAppend(p.bufferedTuples, func() {
 			p.bufferedTuples.AppendTuples(batch, 0 /* startIdx */, batch.Length())
 		})
 	}

--- a/pkg/sql/colexec/sort_chunks.go
+++ b/pkg/sql/colexec/sort_chunks.go
@@ -429,7 +429,7 @@ func (s *chunker) buffer(start int, end int) {
 	if start == end {
 		return
 	}
-	s.allocator.PerformAppend(s.bufferedTuples.ColVecs(), func() {
+	s.allocator.PerformAppend(s.bufferedTuples, func() {
 		s.exportState.numProcessedTuplesFromBatch = end
 		s.bufferedTuples.AppendTuples(s.batch, start, end)
 	})

--- a/pkg/sql/colexec/sorttopk.go
+++ b/pkg/sql/colexec/sorttopk.go
@@ -168,7 +168,7 @@ func (t *topKSorter) spool() {
 			fromLength = int(remainingRows)
 		}
 		t.firstUnprocessedTupleIdx = fromLength
-		t.allocator.PerformAppend(t.topK.ColVecs(), func() {
+		t.allocator.PerformAppend(t.topK, func() {
 			t.topK.AppendTuples(t.inputBatch, 0 /* startIdx */, fromLength)
 		})
 		remainingRows -= uint64(fromLength)


### PR DESCRIPTION
The allocator method `PerformAppend` optimizes memory accounting for the
`AppendOnlyBufferedBatch.AppendTuples` method. However, `PerformAppend` uses
the 'Length' method of the batch's `ColVecs` rather than the batch's own
`Length` method. Since it is possible for the length of the batch to differ
from the length of its vectors, this led to inaccuracies in memory accounting
when the batch was reset and reused.

This patch modifies `PerformAppend` to take as input the batch itself, rather
than its vectors. This allows access to the batch's length, so that correct
memory accounting can be performed.

Release note: None