### PR TITLE
ui: build time optimization for UI packages

### DIFF
--- a/pkg/ui/cluster-ui/webpack.config.js
+++ b/pkg/ui/cluster-ui/webpack.config.js
@@ -107,6 +107,7 @@ module.exports = {
         enforce: "pre",
         test: /\.js$/,
         loader: "source-map-loader",
+        exclude: /node_modules/,
       },
       { test: /\.css$/, use: [ "style-loader", "css-loader" ] },
     ],

--- a/pkg/ui/webpack.app.js
+++ b/pkg/ui/webpack.app.js
@@ -121,12 +121,18 @@ module.exports = (env, argv) => {
         {
           test: /\.js$/,
           include: localRoots,
+          exclude: [
+            /node_modules/,
+            /src\/js/,
+            /ccl\/src\/js/,
+            /cluster-ui\/dist/,
+          ],
           use: ["cache-loader", "babel-loader"],
         },
         {
           test: /\.(ts|tsx)?$/,
           include: localRoots,
-          exclude: /\/node_modules/,
+          exclude: /node_modules/,
           use: [
             "cache-loader",
             "babel-loader",
@@ -140,7 +146,12 @@ module.exports = (env, argv) => {
           test: /\.js$/,
           loader: "source-map-loader",
           include: localRoots,
-          exclude: /\/node_modules/,
+          exclude: [
+            /node_modules/,
+            /src\/js/,
+            /ccl\/src\/js/,
+            /cluster-ui\/dist/,
+          ],
         },
       ],
     },

--- a/pkg/ui/webpack.protos.js
+++ b/pkg/ui/webpack.protos.js
@@ -32,6 +32,7 @@ module.exports = (env) => ({
       {
         test: /\.js$/,
         use: ["cache-loader", "thread-loader", "babel-loader"],
+        exclude: [/node_modules/, /src\/js/, /ccl\/src\/js/],
       },
     ],
   },

--- a/pkg/ui/webpack.vendor.js
+++ b/pkg/ui/webpack.vendor.js
@@ -23,7 +23,7 @@ module.exports = {
     vendor: prodDependencies,
   },
 
-  mode: "none",
+  mode: "production",
 
   output: {
     filename: "vendor.oss.dll.js",
@@ -43,7 +43,12 @@ module.exports = {
         // of 8/25/2017 there appears to be no better way to run babel only on
         // the specific packages in node_modules that actually use ES6.
         // https://github.com/babel/babel-loader/issues/171
-        exclude: /node_modules\/(?!analytics-node)/,
+        exclude: [
+          /node_modules\/(?!analytics-node)/,
+          /src\/js/,
+          /ccl\/src\/js/,
+          /cluster-ui\/dist/,
+        ],
         use: ["cache-loader", "thread-loader", "babel-loader"],
       },
     ],


### PR DESCRIPTION
Before, `cluster-ui` package was built twice
1) before installing `db-console` dependencies because `cluster-ui` is
one of its dependencies and has to be built before installing dependencies;
2) right before `db-console` is built to make sure that it includes most
recent changes

With this change, `cluster-ui` package is built as a separate Make target
with assumption that target is output bundle and ignoring typing files.
Such change reduces the build time with unnecessary extra build of
`cluster-ui` package.

protobuf js files (generated by `protobufjs` lib) is already es5 compliant
and there is no need to preprocess them with babel during build.
Current change excludes these auto generated files from preprocessing
and improves build time.
Also it excludes preprocessing of bundled `cluster-ui` package.

Release note: None
