### PR TITLE
kvserver: fix TestStoreRangeMergeTimestampCache

### DIFF
--- a/pkg/testutils/testchan.go
+++ b/pkg/testutils/testchan.go
@@ -1,0 +1,73 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package testutils
+
+import (
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/errors"
+)
+
+type TestChan struct {
+	s *stop.Stopper
+	c chan interface{}
+}
+
+// NewTestChan is a wrapper around a `chan interface{}` that facilitates
+// writing robust tests.
+//
+// 1. error handling for send and receive when the stopper quiesces
+// 2. timeout-enforcing API.
+//
+// These help solve a common problem, namely that test failures often turn
+// into hanging packages or ... TBD
+func NewTestChan(s *stop.Stopper, cap int) *TestChan {
+	ch := &TestChan{
+		s: s,
+		c: make(chan interface{}, cap),
+	}
+	return ch
+}
+
+func (ch *TestChan) RecvD(timeout time.Duration) (interface{}, error) {
+	select {
+	case data := <-ch.c:
+		return data, nil
+	case <-time.After(timeout):
+		return nil, errors.New("timeout reached")
+	case <-ch.s.ShouldQuiesce():
+		return nil, errors.New("stopper quiescing")
+	}
+}
+
+func (ch *TestChan) Recv() (interface{}, error) {
+	return ch.RecvD(DefaultSucceedsSoonDuration)
+}
+
+func (ch *TestChan) SendD(timeout time.Duration, data interface{}) error {
+	select {
+	case ch.c <- data:
+		return nil
+	case <-time.After(timeout):
+		return errors.New("timeout reached")
+	case <-ch.s.ShouldQuiesce():
+		return errors.New("stopper is quiescing")
+	}
+}
+
+func (ch *TestChan) Send(data interface{}) error {
+	return ch.SendD(DefaultSucceedsSoonDuration, data)
+}
+
+func (ch *TestChan) Close() {
+	close(ch.c)
+}

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -1316,7 +1316,12 @@ func (tc *TestCluster) ReadIntFromStores(key roachpb.Key) []int64 {
 // Fails the test if they do not match.
 func (tc *TestCluster) WaitForValues(t testing.TB, key roachpb.Key, expected []int64) {
 	t.Helper()
-	testutils.SucceedsSoon(t, func() error {
+	require.NoError(t, tc.WaitForValuesE(key, expected))
+}
+
+// WaitForValuesE is like WaitForValues, but returns the error and does not take a T.
+func (tc *TestCluster) WaitForValuesE(key roachpb.Key, expected []int64) error {
+	return testutils.SucceedsSoonError(func() error {
 		actual := tc.ReadIntFromStores(key)
 		if !reflect.DeepEqual(expected, actual) {
 			return errors.Errorf("expected %v, got %v", expected, actual)


### PR DESCRIPTION
Don't look yet, this is just me pushing what I have before I switch
workstations.

Release note: None
