### PR TITLE
storage/cloud: Add List prefix API

### DIFF
--- a/pkg/blobs/local_storage.go
+++ b/pkg/blobs/local_storage.go
@@ -59,10 +59,14 @@ func (l *LocalStorage) prependExternalIODir(path string) (string, error) {
 		return "", errors.Errorf("local file access is disabled")
 	}
 	localBase := filepath.Join(l.externalIODir, path)
-	if !strings.HasPrefix(localBase, l.externalIODir) {
-		return "", errors.Errorf("local file access to paths outside of external-io-dir is not allowed: %s", path)
+	return localBase, l.ensureContained(localBase, path)
+}
+
+func (l *LocalStorage) ensureContained(realPath, inputPath string) error {
+	if !strings.HasPrefix(realPath, l.externalIODir) {
+		return errors.Errorf("local file access to paths outside of external-io-dir is not allowed: %s", inputPath)
 	}
-	return localBase, nil
+	return nil
 }
 
 type localWriter struct {
@@ -169,6 +173,45 @@ func (l *LocalStorage) List(pattern string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// If we are not given a glob pattern, we should recursively list this prefix
+	// just like a cloud storage provider, using filepath.Walk, because absent a
+	// wildcard in a pattern filepath.Glob matches at most one path.
+	// TODO(dt): make this the only case -- never pass a pattern and always just
+	// walk the prefix like a cloud storage listing API.
+	if !strings.ContainsAny(pattern, "*?[") {
+		var matches []string
+		walkRoot := fullPath
+		listingParent := false
+		if f, err := os.Stat(fullPath); err != nil || !f.IsDir() {
+			listingParent = true
+			walkRoot = filepath.Dir(fullPath)
+			if err := l.ensureContained(walkRoot, pattern); err != nil {
+				return nil, err
+			}
+		}
+
+		if err := filepath.Walk(walkRoot, func(p string, f os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if f.IsDir() {
+				return nil
+			}
+			if listingParent && !strings.HasPrefix(p, fullPath) {
+				return nil
+			}
+			matches = append(matches, strings.TrimPrefix(p, l.externalIODir))
+			return nil
+		}); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return nil, nil
+			}
+			return nil, err
+		}
+		return matches, nil
+	}
+
 	matches, err := filepath.Glob(fullPath)
 	if err != nil {
 		return nil, err

--- a/pkg/ccl/backupccl/backup_destination.go
+++ b/pkg/ccl/backupccl/backup_destination.go
@@ -122,7 +122,7 @@ func resolveDest(
 		if exists {
 			// The backup in the auto-append directory is the full backup.
 			prevBackupURIs = append(prevBackupURIs, defaultURI)
-			priors, err := FindPriorBackupLocations(ctx, defaultStore)
+			priors, err := FindPriorBackups(ctx, defaultStore, OmitManifest)
 			for _, prior := range priors {
 				priorURI, err := url.Parse(defaultURI)
 				if err != nil {

--- a/pkg/ccl/backupccl/manifest_handling.go
+++ b/pkg/ccl/backupccl/manifest_handling.go
@@ -591,7 +591,12 @@ func getLocalityInfo(
 	return info, nil
 }
 
-const incBackupSubdirGlob = "[0-9]*/[0-9]*.[0-9][0-9]/"
+const incBackupSubdirGlob = "/[0-9]*/[0-9]*.[0-9][0-9]/"
+
+// listingDelimDataSlash is used when listing to find backups and groups all the
+// data sst files in each backup, which start with "data/", into a single result
+// that can be skipped over quickly.
+const listingDelimDataSlash = "data/"
 
 const (
 	// IncludeManifest is a named const that can be passed to FindPriorBackups.
@@ -604,27 +609,31 @@ const (
 // for the subdirectories matching the naming pattern (e.g. YYMMDD/HHmmss.ss).
 // If includeManifest is true the returned paths are to the manifests for the
 // prior backup, otherwise it is just to the backup path.
-func FindPriorBackups(ctx context.Context, store cloud.ExternalStorage, includeManifest bool) ([]string, error) {
-	backupManifestSuffix := backupManifestName
-	prev, err := store.ListFiles(ctx, incBackupSubdirGlob+backupManifestSuffix)
-	if err != nil {
+func FindPriorBackups(
+	ctx context.Context, store cloud.ExternalStorage, includeManifest bool,
+) ([]string, error) {
+	var prev []string
+	if err := store.List(ctx, "", listingDelimDataSlash, func(p string) error {
+		if ok, err := path.Match(incBackupSubdirGlob+backupManifestName, p); err != nil {
+			return err
+		} else if ok {
+			if !includeManifest {
+				p = strings.TrimSuffix(p, "/"+backupManifestName)
+			}
+			prev = append(prev, p)
+			return nil
+		}
+		if ok, err := path.Match(incBackupSubdirGlob+backupOldManifestName, p); err != nil {
+			return err
+		} else if ok {
+			if !includeManifest {
+				p = strings.TrimSuffix(p, "/"+backupOldManifestName)
+			}
+			prev = append(prev, p)
+		}
+		return nil
+	}); err != nil {
 		return nil, errors.Wrap(err, "reading previous backup layers")
-	}
-
-	if len(prev) == 0 {
-		// 20.1 nodes and earlier will have an oldBackupManifestName so we check for
-		// that too.
-		backupManifestSuffix = backupOldManifestName
-		prev, err = store.ListFiles(ctx, incBackupSubdirGlob+backupManifestSuffix)
-		if err != nil {
-			return nil, errors.Wrap(err, "reading previous backup layers")
-		}
-	}
-
-	if !includeManifest {
-		for i := range prev {
-			prev[i] = strings.TrimSuffix(prev[i], "/"+backupManifestSuffix)
-		}
 	}
 	sort.Strings(prev)
 	return prev, nil
@@ -1012,8 +1021,15 @@ func tempCheckpointFileNameForJob(jobID jobspb.JobID) string {
 func ListFullBackupsInCollection(
 	ctx context.Context, store cloud.ExternalStorage,
 ) ([]string, error) {
-	backupPaths, err := store.ListFiles(ctx, "/*/*/*/"+backupManifestName)
-	if err != nil {
+	var backupPaths []string
+	if err := store.List(ctx, "", listingDelimDataSlash, func(f string) error {
+		if ok, err := path.Match("/*/*/*/"+backupManifestName, f); err != nil {
+			return err
+		} else if ok {
+			backupPaths = append(backupPaths, f)
+		}
+		return nil
+	}); err != nil {
 		return nil, err
 	}
 	for i, backupPath := range backupPaths {

--- a/pkg/ccl/backupccl/manifest_handling.go
+++ b/pkg/ccl/backupccl/manifest_handling.go
@@ -593,24 +593,18 @@ func getLocalityInfo(
 
 const incBackupSubdirGlob = "[0-9]*/[0-9]*.[0-9][0-9]/"
 
-// findPriorBackupNames finds "appended" incremental backups, as done by
-// findPriorBackupLocations and appends the backup manifest file name to
-// the URI.
-func findPriorBackupNames(ctx context.Context, store cloud.ExternalStorage) ([]string, error) {
-	prev, err := store.ListFiles(ctx, incBackupSubdirGlob+backupManifestName)
-	if err != nil {
-		return nil, errors.Wrap(err, "reading previous backup layers")
-	}
-	sort.Strings(prev)
-	return prev, nil
-}
+const (
+	// IncludeManifest is a named const that can be passed to FindPriorBackups.
+	IncludeManifest = true
+	// OmitManifest is a named const that can be passed to FindPriorBackups.
+	OmitManifest = false
+)
 
-// FindPriorBackupLocations finds "appended" incremental backups by searching
+// FindPriorBackups finds "appended" incremental backups by searching
 // for the subdirectories matching the naming pattern (e.g. YYMMDD/HHmmss.ss).
-// Using file-system searching rather than keeping an explicit list allows
-// layers to be manually moved/removed/etc without needing to update/maintain
-// said list.
-func FindPriorBackupLocations(ctx context.Context, store cloud.ExternalStorage) ([]string, error) {
+// If includeManifest is true the returned paths are to the manifests for the
+// prior backup, otherwise it is just to the backup path.
+func FindPriorBackups(ctx context.Context, store cloud.ExternalStorage, includeManifest bool) ([]string, error) {
 	backupManifestSuffix := backupManifestName
 	prev, err := store.ListFiles(ctx, incBackupSubdirGlob+backupManifestSuffix)
 	if err != nil {
@@ -627,8 +621,10 @@ func FindPriorBackupLocations(ctx context.Context, store cloud.ExternalStorage) 
 		}
 	}
 
-	for i := range prev {
-		prev[i] = strings.TrimSuffix(prev[i], "/"+backupManifestSuffix)
+	if !includeManifest {
+		for i := range prev {
+			prev[i] = strings.TrimSuffix(prev[i], "/"+backupManifestSuffix)
+		}
 	}
 	sort.Strings(prev)
 	return prev, nil
@@ -695,7 +691,7 @@ func resolveBackupManifests(
 	} else {
 		// Since incremental layers were *not* explicitly specified, search for any
 		// automatically created incremental layers inside the base layer.
-		prev, err := findPriorBackupNames(ctx, baseStores[0])
+		prev, err := FindPriorBackups(ctx, baseStores[0], IncludeManifest)
 		if err != nil {
 			if errors.Is(err, cloud.ErrListingUnsupported) {
 				log.Warningf(ctx, "storage sink %T does not support listing, only resolving the base backup", baseStores[0])

--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -177,7 +177,7 @@ func showBackupPlanHook(
 				KMSInfo: defaultKMSInfo}
 		}
 
-		incPaths, err := findPriorBackupNames(ctx, store)
+		incPaths, err := FindPriorBackups(ctx, store, IncludeManifest)
 		if err != nil {
 			if errors.Is(err, cloud.ErrListingUnsupported) {
 				// If we do not support listing, we have to just assume there are none

--- a/pkg/ccl/cliccl/debug_backup.go
+++ b/pkg/ccl/cliccl/debug_backup.go
@@ -366,7 +366,7 @@ func runListIncrementalCmd(cmd *cobra.Command, args []string) error {
 	}
 	defer store.Close()
 
-	incPaths, err := backupccl.FindPriorBackupLocations(ctx, store)
+	incPaths, err := backupccl.FindPriorBackups(ctx, store, backupccl.OmitManifest)
 	if err != nil {
 		return err
 	}

--- a/pkg/ccl/cliccl/debug_backup.go
+++ b/pkg/ccl/cliccl/debug_backup.go
@@ -340,8 +340,7 @@ func runListBackupsCmd(cmd *cobra.Command, args []string) error {
 	cols := []string{"path"}
 	rows := make([][]string, 0)
 	for _, backupPath := range backupPaths {
-		newRow := []string{"./" + backupPath}
-		rows = append(rows, newRow)
+		rows = append(rows, []string{"." + backupPath})
 	}
 	rowSliceIter := cli.NewRowSliceIter(rows, "l" /*align*/)
 	return cli.PrintQueryOutput(os.Stdout, cols, rowSliceIter)

--- a/pkg/ccl/importccl/testutils_test.go
+++ b/pkg/ccl/importccl/testutils_test.go
@@ -281,6 +281,12 @@ func (es *generatorExternalStorage) ListFiles(ctx context.Context, _ string) ([]
 	return nil, errors.New("unsupported")
 }
 
+func (es *generatorExternalStorage) List(
+	ctx context.Context, _, _ string, _ cloud.ListingFn,
+) error {
+	return errors.New("unsupported")
+}
+
 func (es *generatorExternalStorage) Delete(ctx context.Context, basename string) error {
 	return errors.New("unsupported")
 }

--- a/pkg/storage/cloud/amazon/s3_storage.go
+++ b/pkg/storage/cloud/amazon/s3_storage.go
@@ -546,6 +546,42 @@ func (s *s3Storage) ListFiles(ctx context.Context, patternSuffix string) ([]stri
 	return fileList, nil
 }
 
+func (s *s3Storage) List(ctx context.Context, prefix, delim string, fn cloud.ListingFn) error {
+	ctx, sp := tracing.ChildSpan(ctx, "s3.List")
+	defer sp.Finish()
+
+	dest := cloud.JoinPathPreservingTrailingSlash(s.prefix, prefix)
+	sp.RecordStructured(&types.StringValue{Value: fmt.Sprintf("s3.List: %s", dest)})
+
+	client, err := s.getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	var fnErr error
+	pageFn := func(page *s3.ListObjectsOutput, lastPage bool) bool {
+		for _, x := range page.CommonPrefixes {
+			if fnErr = fn(strings.TrimPrefix(*x.Prefix, dest)); fnErr != nil {
+				return false
+			}
+		}
+		for _, fileObject := range page.Contents {
+			if fnErr = fn(strings.TrimPrefix(*fileObject.Key, dest)); fnErr != nil {
+				return false
+			}
+		}
+		return true
+	}
+
+	if err := client.ListObjectsPagesWithContext(
+		ctx, &s3.ListObjectsInput{Bucket: s.bucket, Prefix: aws.String(dest), Delimiter: nilIfEmpty(delim)}, pageFn,
+	); err != nil {
+		return errors.Wrap(err, `failed to list s3 bucket`)
+	}
+
+	return fnErr
+}
+
 func (s *s3Storage) Delete(ctx context.Context, basename string) error {
 	client, err := s.getClient(ctx)
 	if err != nil {

--- a/pkg/storage/cloud/cloudtestutils/cloud_test_helpers.go
+++ b/pkg/storage/cloud/cloudtestutils/cloud_test_helpers.go
@@ -513,6 +513,99 @@ func CheckListFilesCanonical(
 		}
 	})
 
+	foreach := func(in []string, fn func(string) string) []string {
+		out := make([]string, len(in))
+		for i := range in {
+			out[i] = fn(in[i])
+		}
+		return out
+	}
+
+	t.Run("List", func(t *testing.T) {
+		for _, tc := range []struct {
+			name      string
+			uri       string
+			prefix    string
+			delimiter string
+			expected  []string
+		}{
+			{
+				"root",
+				storeURI,
+				"",
+				"",
+				foreach(fileNames, func(s string) string { return "/" + s }),
+			},
+			{
+				"file-slash-numbers-slash",
+				storeURI,
+				"file/numbers/",
+				"",
+				[]string{"data1.csv", "data2.csv", "data3.csv"},
+			},
+			{
+				"root-slash",
+				storeURI,
+				"/",
+				"",
+				foreach(fileNames, func(s string) string { return s }),
+			},
+			{
+				"file",
+				storeURI,
+				"file",
+				"",
+				foreach(fileNames, func(s string) string { return strings.TrimPrefix(s, "file") }),
+			},
+			{
+				"file-slash",
+				storeURI,
+				"file/",
+				"",
+				foreach(fileNames, func(s string) string { return strings.TrimPrefix(s, "file/") }),
+			},
+			{
+				"slash-f",
+				storeURI,
+				"/f",
+				"",
+				foreach(fileNames, func(s string) string { return strings.TrimPrefix(s, "f") }),
+			},
+			{
+				"nothing",
+				storeURI,
+				"nothing",
+				"",
+				nil,
+			},
+			{
+				"delim-slash-file-slash",
+				storeURI,
+				"file/",
+				"/",
+				[]string{"abc/", "letters/", "numbers/"},
+			},
+			{
+				"delim-data",
+				storeURI,
+				"",
+				"data",
+				[]string{"/file/abc/A.csv", "/file/abc/B.csv", "/file/abc/C.csv", "/file/letters/data", "/file/numbers/data"},
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				s := storeFromURI(ctx, t, tc.uri, clientFactory, user, ie, kvDB, testSettings)
+				var actual []string
+				require.NoError(t, s.List(ctx, tc.prefix, tc.delimiter, func(f string) error {
+					actual = append(actual, f)
+					return nil
+				}))
+				sort.Strings(actual)
+				require.Equal(t, tc.expected, actual)
+			})
+		}
+	})
+
 	for _, fileName := range fileNames {
 		file := storeFromURI(ctx, t, storeURI, clientFactory, user, ie, kvDB, testSettings)
 		if err := file.Delete(ctx, fileName); err != nil {

--- a/pkg/storage/cloud/external_storage.go
+++ b/pkg/storage/cloud/external_storage.go
@@ -74,6 +74,15 @@ type ExternalStorage interface {
 	// returned by the subsequent Close().
 	Writer(ctx context.Context, basename string) (io.WriteCloser, error)
 
+	// List enumerates files within the supplied prefix, calling the passed
+	// function with the name of each file found, relative to the external storage
+	// destination's configured prefix. If the passed function returns a non-nil
+	// error, iteration is stopped it is returned. If delimiter is non-empty names
+	// which have the same prefix, prior to the delimiter, are grouped into a
+	// single result which is that prefix. The order that results are passed to
+	// the callback is undefined.
+	List(ctx context.Context, prefix, delimiter string, fn ListingFn) error
+
 	// ListFiles returns files that match a globs-style pattern. The returned
 	// results are usually relative to the base path, meaning an ExternalStorage
 	// instance can be initialized with some base path, used to query for files,
@@ -93,6 +102,9 @@ type ExternalStorage interface {
 	// Size returns the length of the named file in bytes.
 	Size(ctx context.Context, basename string) (int64, error)
 }
+
+// ListingFn describes functions passed to ExternalStorage.ListFiles.
+type ListingFn func(string) error
 
 // ExternalStorageFactory describes a factory function for ExternalStorage.
 type ExternalStorageFactory func(ctx context.Context, dest roachpb.ExternalStorage) (ExternalStorage, error)

--- a/pkg/storage/cloud/gcp/gcs_storage.go
+++ b/pkg/storage/cloud/gcp/gcs_storage.go
@@ -272,6 +272,32 @@ func (g *gcsStorage) ListFiles(ctx context.Context, patternSuffix string) ([]str
 	return fileList, nil
 }
 
+func (g *gcsStorage) List(ctx context.Context, prefix, delim string, fn cloud.ListingFn) error {
+	dest := cloud.JoinPathPreservingTrailingSlash(g.prefix, prefix)
+	ctx, sp := tracing.ChildSpan(ctx, "gcs.List")
+	defer sp.Finish()
+	sp.RecordStructured(&types.StringValue{Value: fmt.Sprintf("gcs.List: %s", dest)})
+
+	it := g.bucket.Objects(ctx, &gcs.Query{Prefix: dest, Delimiter: delim})
+
+	for {
+		attrs, err := it.Next()
+		if errors.Is(err, iterator.Done) {
+			return nil
+		}
+		if err != nil {
+			return errors.Wrap(err, "unable to list files in gcs bucket")
+		}
+		name := attrs.Name
+		if name == "" {
+			name = attrs.Prefix
+		}
+		if err := fn(strings.TrimPrefix(name, dest)); err != nil {
+			return err
+		}
+	}
+}
+
 func (g *gcsStorage) Delete(ctx context.Context, basename string) error {
 	return contextutil.RunWithTimeout(ctx, "delete gcs file",
 		cloud.Timeout.Get(&g.settings.SV),

--- a/pkg/storage/cloud/gcp/gcs_storage_test.go
+++ b/pkg/storage/cloud/gcp/gcs_storage_test.go
@@ -80,6 +80,16 @@ func TestPutGoogleCloud(t *testing.T) {
 		}
 		cloudtestutils.CheckExportStore(t, fmt.Sprintf("gs://%s/%s?%s=%s", bucket, "backup-test-implicit",
 			cloud.AuthParam, cloud.AuthParamImplicit), false, user, nil, nil, testSettings)
+		cloudtestutils.CheckListFiles(t,
+			fmt.Sprintf("gs://%s/%s/%s?%s=%s",
+				bucket,
+				"backup-test-implicit",
+				"listing-test",
+				cloud.AuthParam,
+				cloud.AuthParamImplicit,
+			),
+			security.RootUserName(), nil, nil, testSettings,
+		)
 	})
 }
 

--- a/pkg/storage/cloud/httpsink/http_storage.go
+++ b/pkg/storage/cloud/httpsink/http_storage.go
@@ -183,6 +183,10 @@ func (h *httpStorage) ListFiles(_ context.Context, _ string) ([]string, error) {
 	return nil, errors.Mark(errors.New("http storage does not support listing"), cloud.ErrListingUnsupported)
 }
 
+func (h *httpStorage) List(_ context.Context, _, _ string, _ cloud.ListingFn) error {
+	return errors.Mark(errors.New("http storage does not support listing"), cloud.ErrListingUnsupported)
+}
+
 func (h *httpStorage) Delete(ctx context.Context, basename string) error {
 	return contextutil.RunWithTimeout(ctx, fmt.Sprintf("DELETE %s", basename),
 		cloud.Timeout.Get(&h.settings.SV), func(ctx context.Context) error {

--- a/pkg/storage/cloud/nodelocal/nodelocal_storage.go
+++ b/pkg/storage/cloud/nodelocal/nodelocal_storage.go
@@ -16,6 +16,7 @@ import (
 	"io"
 	"net/url"
 	"path"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -184,6 +185,37 @@ func (l *localFileStorage) ListFiles(ctx context.Context, patternSuffix string) 
 	}
 
 	return fileList, nil
+}
+
+func (l *localFileStorage) List(
+	ctx context.Context, prefix, delim string, fn cloud.ListingFn,
+) error {
+	dest := cloud.JoinPathPreservingTrailingSlash(l.base, prefix)
+
+	res, err := l.blobClient.List(ctx, dest)
+	if err != nil {
+		return errors.Wrap(err, "unable to match pattern provided")
+	}
+
+	// Sort results so that we can group as we go.
+	sort.Strings(res)
+	var prevPrefix string
+	for _, f := range res {
+		f = strings.TrimPrefix(f, dest)
+		if delim != "" {
+			if i := strings.Index(f, delim); i >= 0 {
+				f = f[:i+len(delim)]
+			}
+			if f == prevPrefix {
+				continue
+			}
+			prevPrefix = f
+		}
+		if err := fn(f); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (l *localFileStorage) Delete(ctx context.Context, basename string) error {

--- a/pkg/storage/cloud/nullsink/nullsink_storage.go
+++ b/pkg/storage/cloud/nullsink/nullsink_storage.go
@@ -84,6 +84,10 @@ func (n *nullSinkStorage) ListFiles(_ context.Context, _ string) ([]string, erro
 	return nil, nil
 }
 
+func (n *nullSinkStorage) List(_ context.Context, _, _ string, _ cloud.ListingFn) error {
+	return nil
+}
+
 func (n *nullSinkStorage) Delete(_ context.Context, _ string) error {
 	return nil
 }

--- a/pkg/storage/cloud/uris.go
+++ b/pkg/storage/cloud/uris.go
@@ -80,3 +80,23 @@ func RedactKMSURI(kmsURI string) (string, error) {
 	uri.Path = "/redacted"
 	return uri.String(), nil
 }
+
+// JoinPathPreservingTrailingSlash wraps path.Join but preserves the trailing
+// slash if there was one in the suffix.
+//
+// This is particularly important when the joined path is used as a prefix for
+// listing. When listing, the suffix *after the listed prefix* of each file name
+// is what is returned and, importantly, what is used when grouping using a
+// delimiter. E.g. when using `/` as a delimiter to find what might be called the
+// immediate children in a directory, we pass that directory's path *with a
+// trailing slash* as the prefix, so that the children do not start with a slash
+// and get grouped into nothing. Thus it is important that if we use path.Join
+// to construct the prefix, we always preserve the trailing slash.
+func JoinPathPreservingTrailingSlash(prefix, suffix string) string {
+	out := path.Join(prefix, suffix)
+	// path.Clean removes trailing slashes, so put it back if needed.
+	if strings.HasSuffix(suffix, "/") {
+		out += "/"
+	}
+	return out
+}


### PR DESCRIPTION
This adds a new method to the external storage API: List().

List is very similar to the existing ListFiles and indeed is intended to
replace it, however the original method is left in place for now to make
this an additive-only change for now (and thus easier to backport) -- a
follow-up change can switch users of ListFiles and remove it.

This new method differs from ListFiles in two significant ways:
1) it lists all files within the requested prefix (i.e. recursively),
  rather than accepting glob-style patterns.
2) it accepts a grouping delimiter that mirrors (and is backed by) the
  corresponding flag in most cloud storage listing APIs, that collapses
  all results with the same prefix prior to that delimiter into one.

The second is significant because it can allow skipping large subtrees
when looking for certain files in a larger bucket, specifically skipping
over the thousands of data files in a bucket of backups when looking for
manifest files.

Replacing rather than extending the ListFiles API with this parameter
brings the listing API closer to the underlying cloud APIs which are the
backing implementations, to make it easier and simpler to test. Callers
which actually want to use glob-style pattern matching can filter the
results of listing using path.Match themselves.

Release note: none.

Release note (enterprise change): Incremental BACKUPs to a cloud storage location that already contains large existing backups now find their derived destination without listing as many remote files.