### PR TITLE
changefeedccl: avoid consumer blocking forever in BlockingBuffer

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -12,6 +12,7 @@ ALL_TESTS = [
     "//pkg/ccl/baseccl:baseccl_test",
     "//pkg/ccl/benchccl/rttanalysisccl:rttanalysisccl_test",
     "//pkg/ccl/changefeedccl/cdctest:cdctest_test",
+    "//pkg/ccl/changefeedccl/kvevent:kvevent_test",
     "//pkg/ccl/changefeedccl/kvfeed:kvfeed_test",
     "//pkg/ccl/changefeedccl/schemafeed:schemafeed_test",
     "//pkg/ccl/changefeedccl:changefeedccl_test",

--- a/pkg/ccl/changefeedccl/kvevent/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/kvevent/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "kvevent",
@@ -22,5 +22,22 @@ go_library(
         "//pkg/util/quotapool",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
+    ],
+)
+
+go_test(
+    name = "kvevent_test",
+    srcs = ["blocking_buffer_test.go"],
+    deps = [
+        ":kvevent",
+        "//pkg/keys",
+        "//pkg/roachpb",
+        "//pkg/settings/cluster",
+        "//pkg/sql/rowenc",
+        "//pkg/sql/sem/tree",
+        "//pkg/util/encoding",
+        "//pkg/util/hlc",
+        "//pkg/util/mon",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/ccl/changefeedccl/kvevent/blocking_buffer.go
+++ b/pkg/ccl/changefeedccl/kvevent/blocking_buffer.go
@@ -41,7 +41,7 @@ type blockingBuffer struct {
 // account, an error will be returned when attempting to buffer it.
 func NewMemBuffer(acc mon.BoundAccount, metrics *Metrics) Buffer {
 	bb := &blockingBuffer{
-		signalCh: make(chan struct{}),
+		signalCh: make(chan struct{}, 1),
 	}
 	bb.acc = acc
 	bb.metrics = metrics

--- a/pkg/ccl/changefeedccl/kvevent/blocking_buffer_test.go
+++ b/pkg/ccl/changefeedccl/kvevent/blocking_buffer_test.go
@@ -1,0 +1,85 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package kvevent_test
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/kvevent"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/stretchr/testify/require"
+)
+
+func makeKVs(t *testing.T, count int) []roachpb.KeyValue {
+	kv := func(tableID uint32, k, v string, ts hlc.Timestamp) roachpb.KeyValue {
+		vDatum := tree.DString(k)
+		key, err := rowenc.EncodeTableKey(keys.SystemSQLCodec.TablePrefix(tableID), &vDatum, encoding.Ascending)
+		require.NoError(t, err)
+
+		return roachpb.KeyValue{
+			Key: key,
+			Value: roachpb.Value{
+				RawBytes:  []byte(v),
+				Timestamp: ts,
+			},
+		}
+	}
+
+	ret := make([]roachpb.KeyValue, count)
+	for i := 0; i < count; i++ {
+		ret[i] = kv(42, "a", fmt.Sprintf("b-%d", count), hlc.Timestamp{WallTime: int64(count + 1)})
+	}
+	return ret
+}
+
+func TestBlockingBuffer(t *testing.T) {
+	metrics := kvevent.MakeMetrics(time.Minute)
+	settings := cluster.MakeTestingClusterSettings()
+	mm := mon.NewUnlimitedMonitor(
+		context.Background(), "test", mon.MemoryResource,
+		nil /* curCount */, nil /* maxHist */, math.MaxInt64, settings,
+	)
+
+	buf := kvevent.NewMemBuffer(mm.MakeBoundAccount(), &metrics)
+	kvCount := rand.Intn(20) + 1
+	kvs := makeKVs(t, kvCount)
+	ctx := context.Background()
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		for _, kv := range kvs {
+			err := buf.AddKV(ctx, kv, roachpb.Value{}, hlc.Timestamp{})
+			require.NoError(t, err)
+		}
+		wg.Done()
+	}()
+	wg.Add(1)
+	go func() {
+		for i := 0; i < kvCount; i++ {
+			_, err := buf.Get(ctx)
+			require.NoError(t, err)
+		}
+		wg.Done()
+	}()
+	wg.Wait()
+}


### PR DESCRIPTION
The blocking buffer uses a channel to wake a caller to Get up after
AddKV has been called. However, since we use non-blocking sends to the
signal channel, the following is possible:

    Thread 1                            Thread 2

    b.mu.Lock()
    b.mu.queue.dequeue() -> nil
    b.mu.Unlock()
                                        b.mu.Lock()
                                        b.mu.queue.enqueue(event)
                                        b.mu.Unlock()
                                        b.signalCh <- struct{}{} (not sent as it would have blocked)

    <-b.signalCh (potentially blocks forever)

This change solves this by adding a 1 message buffer to the signal
channel. I believe this solves the race condition for a single
consumer. However, in the multiple consumer case, we still have a
problem.

This code is only called currently with a single consumer.

If we want to fix it for multiple consumers, one option is a fallback
timeout in Get() to recheck the queue after some time if it hasn't
otherwise gotten a wakeup signal.

I've avoided this for now simply because I didn't want to add overhead
for a use-case that we don't actually have.

Fixes #67200

Release note: None