### PR TITLE
multiregionccl: skip TestAlterTableLocalityRegionalByRowError under race

### DIFF
--- a/pkg/ccl/multiregionccl/regional_by_row_test.go
+++ b/pkg/ccl/multiregionccl/regional_by_row_test.go
@@ -172,6 +172,7 @@ func TestAlterTableLocalityRegionalByRowCorrectZoneConfigBeforeBackfill(t *testi
 func TestAlterTableLocalityRegionalByRowError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.UnderRace(t, "takes >400s under race")
 
 	var chunkSize int64 = 100
 	var maxValue = 4000


### PR DESCRIPTION
This was taking >400s under race.

Release note: None