### PR TITLE
release-20.2: roachtest: fix sqlalchemy roachtest after alembic support

### DIFF
--- a/pkg/cmd/roachtest/sqlalchemy.go
+++ b/pkg/cmd/roachtest/sqlalchemy.go
@@ -22,7 +22,16 @@ import (
 var sqlAlchemyResultRegex = regexp.MustCompile(`^(?P<test>test.*::.*::[^ \[\]]*(?:\[.*])?) (?P<result>\w+)\s+\[.+]$`)
 var sqlAlchemyReleaseTagRegex = regexp.MustCompile(`^rel_(?P<major>\d+)_(?P<minor>\d+)_(?P<point>\d+)$`)
 
+// TODO(arul): Investigate why we need this and can't install sql alchemy using
+//  pip.
 var supportedSQLAlchemyTag = "rel_1_4_17"
+
+// TODO(arul): This manual install of alembic is only there until alembic 1.7
+//  comes out. Once that happens, all of this can be removed and we can simply
+// 	install alembic when installing dependencies.
+var supportedAlembicTag = "rel_1_6_5"
+
+var alembicReleaseTagRegex = regexp.MustCompile(`^rel_(?P<major>\d+)_(?P<minor>\d+)_(?P<point>\d+)$`)
 
 // This test runs the SQLAlchemy dialect test suite against a single Cockroach
 // node.
@@ -54,6 +63,13 @@ func runSQLAlchemy(ctx context.Context, t *test, c *cluster) {
 	}
 	c.l.Printf("Latest sqlalchemy release is %s.", latestTag)
 	c.l.Printf("Supported sqlalchemy release is %s.", supportedSQLAlchemyTag)
+
+	latestAlembicTag, err := repeatGetLatestTag(ctx, c, "sqlalchemy", "alembic", alembicReleaseTagRegex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.l.Printf("Latest alembic release is %s.", latestAlembicTag)
+	t.l.Printf("Supported alembic release is %s.", supportedAlembicTag)
 
 	if err := repeatRunE(ctx, c, node, "update apt-get", `
 		sudo add-apt-repository ppa:deadsnakes/ppa &&
@@ -107,6 +123,25 @@ func runSQLAlchemy(ctx context.Context, t *test, c *cluster) {
 		t.Fatal(err)
 	}
 
+	if err := repeatRunE(ctx, c, node, "remove old sqlalchemy-alembic", `
+		sudo rm -rf /mnt/data1/sqlalchemy-alembic
+	`); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := repeatGitCloneE(ctx, t.l, c,
+		"https://github.com/sqlalchemy/alembic", "/mnt/data1/sqlalchemy-alembic",
+		"master", node); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Status("installing alembic from github")
+	if err := repeatRunE(ctx, c, node, "installing sqlalchemy-alembic", `
+		cd /mnt/data1/sqlalchemy-alembic && sudo pip3 install .
+	`); err != nil {
+		t.Fatal(err)
+	}
+
 	if err := repeatRunE(ctx, c, node, "remove old sqlalchemy", `
 		sudo rm -rf /mnt/data1/sqlalchemy
 	`); err != nil {
@@ -152,10 +187,9 @@ func runSQLAlchemy(ctx context.Context, t *test, c *cluster) {
 	// Note that this is expected to return an error, since the test suite
 	// will fail. And it is safe to swallow it here.
 	rawResults, _ := c.RunWithBuffer(ctx, t.l, node,
-		`cd /mnt/data1/sqlalchemy/ && pytest --maxfail=0 \
-		--requirements=sqlalchemy_cockroachdb.requirements:Requirements \
+		`cd /mnt/data1/sqlalchemy-cockroachdb/ && pytest --maxfail=0 \
 		--dburi=cockroachdb://root@localhost:26257/defaultdb?sslmode=disable \
-		test/dialect/test_suite.py
+		test/test_suite_sqlalchemy.py
 	`)
 
 	t.Status("collating the test results")


### PR DESCRIPTION
Backport 1/1 commits from #66918.

/cc @cockroachdb/release

Closes #66756

---

Previously, we were running the sqlalchemy test suite from the
sqlalchemy repo. This patch changes it to trigger the test suite from
cockroachdb-sqlalchemy repo (our dialect). Running it from the
sqlalchemy repo was broken after adding alembic support.

Release note: None
