### PR TITLE
cli/debug: clean up handling of `--format` for `debug tsdump`

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -64,7 +64,7 @@ import (
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/tool"
 	"github.com/cockroachdb/pebble/vfs"
-	"github.com/dustin/go-humanize"
+	humanize "github.com/dustin/go-humanize"
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/kr/pretty"
 	"github.com/spf13/cobra"
@@ -1467,6 +1467,9 @@ func init() {
 
 	f = debugCheckLogConfigCmd.Flags()
 	f.Var(&debugLogChanSel, "only-channels", "selection of channels to include in the output diagram.")
+
+	f = debugTimeSeriesDumpCmd.Flags()
+	f.Var(&debugTimeSeriesDumpOpts.format, "format", "output format (text, csv, tsv, raw)")
 }
 
 func initPebbleCmds(cmd *cobra.Command) {

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -790,7 +790,6 @@ func init() {
 			genSettingsListCmd,
 			demoCmd,
 			debugListFilesCmd,
-			debugTimeSeriesDumpCmd,
 			debugJobTraceFromClusterCmd,
 		},
 		demoCmd.Commands()...)


### PR DESCRIPTION
Fixes #67225

The code was mistakenly piggy-backing on the `--format` flag
configuration for SQL tabular results, even though `tsdump`
does not use SQL and only supports a subset of output formats.

This patch fixes it by using a dedicated enum of output formats.

It also clarifies the behavior when `--format` is passed an invalid
value.

Release note: None