### PR TITLE
roachtest: fix restore/nodeShutdown tests

### DIFF
--- a/pkg/cmd/roachtest/tests/jobs.go
+++ b/pkg/cmd/roachtest/tests/jobs.go
@@ -128,10 +128,8 @@ func jobSurvivesNodeShutdown(
 		return nil
 	})
 
-	// Let the current tasks finish and use a new monitor for the restart.
-	// This lets us separate the failure modes.
+	m.ExpectDeath()
 	m.Wait()
-	m = c.NewMonitor(ctx)
 
 	// NB: the roachtest harness checks that at the end of the test, all nodes
 	// that have data also have a running process.
@@ -139,6 +137,4 @@ func jobSurvivesNodeShutdown(
 	if err := c.StartE(ctx, target); err != nil {
 		t.Fatal(errors.Wrapf(err, "could not restart node %s", target))
 	}
-
-	m.Wait()
 }


### PR DESCRIPTION
I had to slightly change their use of the monitor in
1477c4c5a0e29d72ca6bc261ced68289b2224d49, and introduced a buglet in the
process that would lead to all of these tests to fail.

Fixes #67254
Fixes #67253
Fixes #67252
Fixes #67251
Fixes #67250
Fixes #67249

Release note: None
