### PR TITLE
importccl: add deprecation warning to IMPORT TABLE

### DIFF
--- a/pkg/ccl/importccl/BUILD.bazel
+++ b/pkg/ccl/importccl/BUILD.bazel
@@ -57,6 +57,7 @@ go_library(
         "//pkg/sql/parser",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
+        "//pkg/sql/pgwire/pgnotice",
         "//pkg/sql/privilege",
         "//pkg/sql/row",
         "//pkg/sql/rowenc",

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -51,6 +51,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/gcjob"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
@@ -294,6 +295,11 @@ func importPlanHook(
 	importStmt, ok := stmt.(*tree.Import)
 	if !ok {
 		return nil, nil, nil, false, nil
+	}
+
+	if !importStmt.Bundle && !importStmt.Into {
+		p.BufferClientNotice(ctx, pgnotice.Newf("IMPORT TABLE has been deprecated in 21.2, and will be removed in a future version."+
+			" Instead, use CREATE TABLE with the desired schema, and IMPORT INTO the newly created table."))
 	}
 
 	addToFileFormatTelemetry(importStmt.FileFormat, "attempted")

--- a/pkg/cli/sql_util.go
+++ b/pkg/cli/sql_util.go
@@ -972,13 +972,17 @@ func maybeShowTimes(
 
 	// Print a newline early. This provides a discreet visual
 	// feedback that execution finished, and that the next line of
-	// output will be execution time(s).
+	// output will be a warning or execution time(s).
 	fmt.Fprintln(w)
 
 	// We accumulate the timing details into a buffer prior to emitting
 	// them to the output stream, so as to avoid interleaving warnings
 	// or SQL notices with the full timing string.
 	var stats strings.Builder
+
+	// Print a newline so that there is a visual separation between a notice and
+	// the timing information.
+	fmt.Fprintln(&stats)
 
 	// Suggested by Radu: for sub-second results, show simplified
 	// timings in milliseconds.

--- a/pkg/sql/planhook.go
+++ b/pkg/sql/planhook.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/resolver"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -94,6 +95,7 @@ type PlanHookState interface {
 	CreateSchemaNamespaceEntry(ctx context.Context, schemaNameKey roachpb.Key,
 		schemaID descpb.ID) error
 	MigrationJobDeps() migration.JobDeps
+	BufferClientNotice(ctx context.Context, notice pgnotice.Notice)
 }
 
 // AddPlanHook adds a hook used to short-circuit creating a planNode from a


### PR DESCRIPTION
Fixes: #66732

Release note (sql change): IMPORT TABLE will be deprecated
in 21.2 and removed in a future release. Users should create a table
using CREATE TABLE and the IMPORT INTO the newly created table