### PR TITLE
changefeedccl: don't attempt to protect timestamp in tenant

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -81,6 +81,7 @@ go_library(
         "//pkg/util/bitarray",
         "//pkg/util/bufalloc",
         "//pkg/util/encoding",
+        "//pkg/util/errorutil",
         "//pkg/util/hlc",
         "//pkg/util/httputil",
         "//pkg/util/humanizeutil",

--- a/pkg/ccl/changefeedccl/changefeed.go
+++ b/pkg/ccl/changefeedccl/changefeed.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/cockroachdb/errors"
 )
 
 const (
@@ -56,6 +57,10 @@ func createProtectedTimestampRecord(
 	resolved hlc.Timestamp,
 	progress *jobspb.ChangefeedProgress,
 ) error {
+	if !codec.ForSystemTenant() {
+		return errors.AssertionFailedf("createProtectedTimestampRecord called on tenant-based changefeed")
+	}
+
 	progress.ProtectedTimestampRecord = uuid.MakeV4()
 	log.VEventf(ctx, 2, "creating protected timestamp %v at %v",
 		progress.ProtectedTimestampRecord, resolved)

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -1386,7 +1386,7 @@ func (cf *changeFrontier) maybeProtectTimestamp(
 	txn *kv.Txn,
 	resolved hlc.Timestamp,
 ) error {
-	if cf.isSinkless() || !cf.frontier.schemaChangeBoundaryReached() || !cf.shouldProtectBoundaries() {
+	if cf.isSinkless() || cf.isTenant() || !cf.frontier.schemaChangeBoundaryReached() || !cf.shouldProtectBoundaries() {
 		return nil
 	}
 
@@ -1467,6 +1467,12 @@ func (cf *changeFrontier) ConsumerClosed() {
 // have a job.
 func (cf *changeFrontier) isSinkless() bool {
 	return cf.spec.JobID == 0
+}
+
+// isTenant() bool returns true if this changeFrontier is running on a
+// tenant.
+func (cf *changeFrontier) isTenant() bool {
+	return !cf.flowCtx.Codec().ForSystemTenant()
 }
 
 // type to make embedding span.Frontier in schemaChangeFrontier convenient.

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -320,6 +320,14 @@ type testServerShim struct {
 	sqlServer serverutils.TestTenantInterface
 }
 
+func (t *testServerShim) DistSQLServer() interface{} {
+	return t.sqlServer.DistSQLServer()
+}
+
+func (t *testServerShim) JobRegistry() interface{} {
+	return t.sqlServer.JobRegistry()
+}
+
 func (t *testServerShim) ServingSQLAddr() string {
 	return t.sqlServer.SQLAddr()
 }

--- a/pkg/ccl/changefeedccl/testfeed_test.go
+++ b/pkg/ccl/changefeedccl/testfeed_test.go
@@ -405,6 +405,14 @@ func (s *notifyFlushSink) Flush(ctx context.Context) error {
 
 var _ Sink = (*notifyFlushSink)(nil)
 
+// feedInjectable is the subset of the
+// TestServerInterface/TestTenantInterface needed for depInjector to
+// work correctly.
+type feedInjectable interface {
+	JobRegistry() interface{}
+	DistSQLServer() interface{}
+}
+
 // depInjector facilitates dependency injection to provide orchestration
 // between test feed and the changefeed itself.
 // A single instance of depInjector should be used per feed factory.
@@ -420,7 +428,7 @@ type depInjector struct {
 }
 
 // newDepInjector configures specified server with necessary hooks and knobs.
-func newDepInjector(s serverutils.TestServerInterface) *depInjector {
+func newDepInjector(s feedInjectable) *depInjector {
 	di := &depInjector{
 		startedJobs: make(map[jobspb.JobID]*jobFeed),
 	}

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -491,6 +491,16 @@ func (t *TestTenant) StatusServer() interface{} {
 	return t.execCfg.SQLStatusServer
 }
 
+// DistSQLServer is part of the TestTenantInterface interface.
+func (t *TestTenant) DistSQLServer() interface{} {
+	return t.SQLServer.distSQLServer
+}
+
+// JobRegistry is part of the TestTenantInterface interface.
+func (t *TestTenant) JobRegistry() interface{} {
+	return t.SQLServer.jobRegistry
+}
+
 // SetupIdleMonitor will monitor the active connections and if there are none,
 // will activate a `defaultCountdownDuration` countdown timer and terminate
 // the application. The monitoring will start after a warmup period

--- a/pkg/testutils/serverutils/test_tenant_shim.go
+++ b/pkg/testutils/serverutils/test_tenant_shim.go
@@ -39,4 +39,11 @@ type TestTenantInterface interface {
 	// StatusServer returns the tenant's *server.SQLStatusServer as an
 	// interface{}.
 	StatusServer() interface{}
+
+	// DistSQLServer returns the *distsql.ServerImpl as an
+	// interface{}.
+	DistSQLServer() interface{}
+
+	// JobRegistry returns the *jobs.Registry as an interface{}.
+	JobRegistry() interface{}
 }


### PR DESCRIPTION
The protectedts system does not support tenants. This changes skips
the creation of protected timestamps for backfills and initial scans
when running in a tenant.  Further, it makes it an error to use the
protect_data_from_gc_on_pause option when running in a tenant.

Release note (enterprise change): CHANGEFEEDs don't attempt to use
protected timestamps when running in a multi-tenant environment.