### PR TITLE
release-21.1: storage/cloud: Add List prefix API

### DIFF
--- a/pkg/blobs/local_storage.go
+++ b/pkg/blobs/local_storage.go
@@ -58,10 +58,14 @@ func (l *LocalStorage) prependExternalIODir(path string) (string, error) {
 		return "", errors.Errorf("local file access is disabled")
 	}
 	localBase := filepath.Join(l.externalIODir, path)
-	if !strings.HasPrefix(localBase, l.externalIODir) {
-		return "", errors.Errorf("local file access to paths outside of external-io-dir is not allowed: %s", path)
+	return localBase, l.ensureContained(localBase, path)
+}
+
+func (l *LocalStorage) ensureContained(realPath, inputPath string) error {
+	if !strings.HasPrefix(realPath, l.externalIODir) {
+		return errors.Errorf("local file access to paths outside of external-io-dir is not allowed: %s", inputPath)
 	}
-	return localBase, nil
+	return nil
 }
 
 // WriteFile prepends IO dir to filename and writes the content to that local file.
@@ -171,6 +175,45 @@ func (l *LocalStorage) List(pattern string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// If we are not given a glob pattern, we should recursively list this prefix
+	// just like a cloud storage provider, using filepath.Walk, because absent a
+	// wildcard in a pattern filepath.Glob matches at most one path.
+	// TODO(dt): make this the only case -- never pass a pattern and always just
+	// walk the prefix like a cloud storage listing API.
+	if !strings.ContainsAny(pattern, "*?[") {
+		var matches []string
+		walkRoot := fullPath
+		listingParent := false
+		if f, err := os.Stat(fullPath); err != nil || !f.IsDir() {
+			listingParent = true
+			walkRoot = filepath.Dir(fullPath)
+			if err := l.ensureContained(walkRoot, pattern); err != nil {
+				return nil, err
+			}
+		}
+
+		if err := filepath.Walk(walkRoot, func(p string, f os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if f.IsDir() {
+				return nil
+			}
+			if listingParent && !strings.HasPrefix(p, fullPath) {
+				return nil
+			}
+			matches = append(matches, strings.TrimPrefix(p, l.externalIODir))
+			return nil
+		}); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return nil, nil
+			}
+			return nil, err
+		}
+		return matches, nil
+	}
+
 	matches, err := filepath.Glob(fullPath)
 	if err != nil {
 		return nil, err

--- a/pkg/ccl/backupccl/backup_destination.go
+++ b/pkg/ccl/backupccl/backup_destination.go
@@ -123,7 +123,7 @@ func resolveDest(
 		if exists {
 			// The backup in the auto-append directory is the full backup.
 			prevBackupURIs = append(prevBackupURIs, defaultURI)
-			priors, err := findPriorBackupLocations(ctx, defaultStore)
+			priors, err := FindPriorBackups(ctx, defaultStore, OmitManifest)
 			for _, prior := range priors {
 				priorURI, err := url.Parse(defaultURI)
 				if err != nil {

--- a/pkg/ccl/backupccl/manifest_handling.go
+++ b/pkg/ccl/backupccl/manifest_handling.go
@@ -582,24 +582,18 @@ func getLocalityInfo(
 
 const incBackupSubdirGlob = "[0-9]*/[0-9]*.[0-9][0-9]/"
 
-// findPriorBackupNames finds "appended" incremental backups, as done by
-// findPriorBackupLocations and appends the backup manifest file name to
-// the URI.
-func findPriorBackupNames(ctx context.Context, store cloud.ExternalStorage) ([]string, error) {
-	prev, err := store.ListFiles(ctx, incBackupSubdirGlob+backupManifestName)
-	if err != nil {
-		return nil, errors.Wrap(err, "reading previous backup layers")
-	}
-	sort.Strings(prev)
-	return prev, nil
-}
+const (
+	// IncludeManifest is a named const that can be passed to FindPriorBackups.
+	IncludeManifest = true
+	// OmitManifest is a named const that can be passed to FindPriorBackups.
+	OmitManifest = false
+)
 
-// findPriorBackupLocations finds "appended" incremental backups by searching
+// FindPriorBackups finds "appended" incremental backups by searching
 // for the subdirectories matching the naming pattern (e.g. YYMMDD/HHmmss.ss).
-// Using file-system searching rather than keeping an explicit list allows
-// layers to be manually moved/removed/etc without needing to update/maintain
-// said list.
-func findPriorBackupLocations(ctx context.Context, store cloud.ExternalStorage) ([]string, error) {
+// If includeManifest is true the returned paths are to the manifests for the
+// prior backup, otherwise it is just to the backup path.
+func FindPriorBackups(ctx context.Context, store cloud.ExternalStorage, includeManifest bool) ([]string, error) {
 	backupManifestSuffix := backupManifestName
 	prev, err := store.ListFiles(ctx, incBackupSubdirGlob+backupManifestSuffix)
 	if err != nil {
@@ -616,8 +610,10 @@ func findPriorBackupLocations(ctx context.Context, store cloud.ExternalStorage) 
 		}
 	}
 
-	for i := range prev {
-		prev[i] = strings.TrimSuffix(prev[i], "/"+backupManifestSuffix)
+	if !includeManifest {
+		for i := range prev {
+			prev[i] = strings.TrimSuffix(prev[i], "/"+backupManifestSuffix)
+		}
 	}
 	sort.Strings(prev)
 	return prev, nil
@@ -684,7 +680,7 @@ func resolveBackupManifests(
 	} else {
 		// Since incremental layers were *not* explicitly specified, search for any
 		// automatically created incremental layers inside the base layer.
-		prev, err := findPriorBackupNames(ctx, baseStores[0])
+		prev, err := FindPriorBackups(ctx, baseStores[0], IncludeManifest)
 		if err != nil {
 			if errors.Is(err, cloudimpl.ErrListingUnsupported) {
 				log.Warningf(ctx, "storage sink %T does not support listing, only resolving the base backup", baseStores[0])

--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -537,12 +537,12 @@ func showBackupsInCollectionPlanHook(
 			return errors.Wrapf(err, "connect to external storage")
 		}
 		defer store.Close()
-		res, err := store.ListFiles(ctx, "/*/*/*/"+backupManifestName)
+		res, err := ListFullBackupsInCollection(ctx, store)
 		if err != nil {
 			return err
 		}
 		for _, i := range res {
-			resultsCh <- tree.Datums{tree.NewDString(strings.TrimSuffix(i, "/"+backupManifestName))}
+			resultsCh <- tree.Datums{tree.NewDString(i)}
 		}
 		return nil
 	}

--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -172,7 +172,7 @@ func showBackupPlanHook(
 				KMSInfo: defaultKMSInfo}
 		}
 
-		incPaths, err := findPriorBackupNames(ctx, store)
+		incPaths, err := FindPriorBackups(ctx, store, IncludeManifest)
 		if err != nil {
 			if errors.Is(err, cloudimpl.ErrListingUnsupported) {
 				// If we do not support listing, we have to just assume there are none

--- a/pkg/ccl/importccl/testutils_test.go
+++ b/pkg/ccl/importccl/testutils_test.go
@@ -281,6 +281,12 @@ func (es *generatorExternalStorage) ListFiles(ctx context.Context, _ string) ([]
 	return nil, errors.New("unsupported")
 }
 
+func (es *generatorExternalStorage) List(
+	ctx context.Context, _, _ string, _ cloud.ListingFn,
+) error {
+	return errors.New("unsupported")
+}
+
 func (es *generatorExternalStorage) Delete(ctx context.Context, basename string) error {
 	return errors.New("unsupported")
 }

--- a/pkg/storage/cloud/external_storage.go
+++ b/pkg/storage/cloud/external_storage.go
@@ -61,6 +61,15 @@ type ExternalStorage interface {
 	// WriteFile should write the content to requested name.
 	WriteFile(ctx context.Context, basename string, content io.ReadSeeker) error
 
+	// List enumerates files within the supplied prefix, calling the passed
+	// function with the name of each file found, relative to the external storage
+	// destination's configured prefix. If the passed function returns a non-nil
+	// error, iteration is stopped it is returned. If delimiter is non-empty names
+	// which have the same prefix, prior to the delimiter, are grouped into a
+	// single result which is that prefix. The order that results are passed to
+	// the callback is undefined.
+	List(ctx context.Context, prefix, delimiter string, fn ListingFn) error
+
 	// ListFiles returns files that match a globs-style pattern. The returned
 	// results are usually relative to the base path, meaning an ExternalStorage
 	// instance can be initialized with some base path, used to query for files,
@@ -80,6 +89,9 @@ type ExternalStorage interface {
 	// Size returns the length of the named file in bytes.
 	Size(ctx context.Context, basename string) (int64, error)
 }
+
+// ListingFn describes functions passed to ExternalStorage.ListFiles.
+type ListingFn func(string) error
 
 // ExternalStorageFactory describes a factory function for ExternalStorage.
 type ExternalStorageFactory func(ctx context.Context, dest roachpb.ExternalStorage) (ExternalStorage, error)

--- a/pkg/storage/cloudimpl/azure_storage.go
+++ b/pkg/storage/cloudimpl/azure_storage.go
@@ -190,6 +190,32 @@ func (s *azureStorage) ListFiles(ctx context.Context, patternSuffix string) ([]s
 	return fileList, nil
 }
 
+func (s *azureStorage) List(ctx context.Context, prefix, delim string, fn cloud.ListingFn) error {
+	dest := JoinPathPreservingTrailingSlash(s.prefix, prefix)
+
+	var marker azblob.Marker
+	for marker.NotDone() {
+		response, err := s.container.ListBlobsHierarchySegment(
+			ctx, marker, delim, azblob.ListBlobsSegmentOptions{Prefix: dest},
+		)
+		if err != nil {
+			return errors.Wrap(err, "unable to list files for specified blob")
+		}
+		for _, blob := range response.Segment.BlobPrefixes {
+			if err := fn(strings.TrimPrefix(blob.Name, dest)); err != nil {
+				return err
+			}
+		}
+		for _, blob := range response.Segment.BlobItems {
+			if err := fn(strings.TrimPrefix(blob.Name, dest)); err != nil {
+				return err
+			}
+		}
+		marker = response.NextMarker
+	}
+	return nil
+}
+
 func (s *azureStorage) Delete(ctx context.Context, basename string) error {
 	err := contextutil.RunWithTimeout(ctx, "delete azure file", timeoutSetting.Get(&s.settings.SV),
 		func(ctx context.Context) error {

--- a/pkg/storage/cloudimpl/cloudimpltests/external_storage_test.go
+++ b/pkg/storage/cloudimpl/cloudimpltests/external_storage_test.go
@@ -514,6 +514,99 @@ func testListFiles(
 		}
 	})
 
+	foreach := func(in []string, fn func(string) string) []string {
+		out := make([]string, len(in))
+		for i := range in {
+			out[i] = fn(in[i])
+		}
+		return out
+	}
+
+	t.Run("List", func(t *testing.T) {
+		for _, tc := range []struct {
+			name      string
+			uri       string
+			prefix    string
+			delimiter string
+			expected  []string
+		}{
+			{
+				"root",
+				storeURI,
+				"",
+				"",
+				foreach(fileNames, func(s string) string { return "/" + s }),
+			},
+			{
+				"file-slash-numbers-slash",
+				storeURI,
+				"file/numbers/",
+				"",
+				[]string{"data1.csv", "data2.csv", "data3.csv"},
+			},
+			{
+				"root-slash",
+				storeURI,
+				"/",
+				"",
+				foreach(fileNames, func(s string) string { return s }),
+			},
+			{
+				"file",
+				storeURI,
+				"file",
+				"",
+				foreach(fileNames, func(s string) string { return strings.TrimPrefix(s, "file") }),
+			},
+			{
+				"file-slash",
+				storeURI,
+				"file/",
+				"",
+				foreach(fileNames, func(s string) string { return strings.TrimPrefix(s, "file/") }),
+			},
+			{
+				"slash-f",
+				storeURI,
+				"/f",
+				"",
+				foreach(fileNames, func(s string) string { return strings.TrimPrefix(s, "f") }),
+			},
+			{
+				"nothing",
+				storeURI,
+				"nothing",
+				"",
+				nil,
+			},
+			{
+				"delim-slash-file-slash",
+				storeURI,
+				"file/",
+				"/",
+				[]string{"abc/", "letters/", "numbers/"},
+			},
+			{
+				"delim-data",
+				storeURI,
+				"",
+				"data",
+				[]string{"/file/abc/A.csv", "/file/abc/B.csv", "/file/abc/C.csv", "/file/letters/data", "/file/numbers/data"},
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				s := storeFromURI(ctx, t, tc.uri, clientFactory, user, ie, kvDB)
+				var actual []string
+				require.NoError(t, s.List(ctx, tc.prefix, tc.delimiter, func(f string) error {
+					actual = append(actual, f)
+					return nil
+				}))
+				sort.Strings(actual)
+				require.Equal(t, tc.expected, actual)
+			})
+		}
+	})
+
 	for _, fileName := range fileNames {
 		file := storeFromURI(ctx, t, storeURI, clientFactory, user, ie, kvDB)
 		if err := file.Delete(ctx, fileName); err != nil {

--- a/pkg/storage/cloudimpl/cloudimpltests/external_storage_test.go
+++ b/pkg/storage/cloudimpl/cloudimpltests/external_storage_test.go
@@ -575,6 +575,16 @@ func TestPutGoogleCloud(t *testing.T) {
 		}
 		testExportStore(t, fmt.Sprintf("gs://%s/%s?%s=%s", bucket, "backup-test-implicit",
 			cloudimpl.AuthParam, cloudimpl.AuthParamImplicit), false, user, nil, nil)
+		testListFiles(t,
+			fmt.Sprintf("gs://%s/%s/%s?%s=%s",
+				bucket,
+				"backup-test-implicit",
+				"listing-test",
+				cloudimpl.AuthParam,
+				cloudimpl.AuthParamImplicit,
+			),
+			security.RootUserName(), nil, nil,
+		)
 	})
 }
 

--- a/pkg/storage/cloudimpl/external_storage.go
+++ b/pkg/storage/cloudimpl/external_storage.go
@@ -562,3 +562,23 @@ func (r *resumingReader) Close() error {
 	}
 	return nil
 }
+
+// JoinPathPreservingTrailingSlash wraps path.Join but preserves the trailing
+// slash if there was one in the suffix.
+//
+// This is particularly important when the joined path is used as a prefix for
+// listing. When listing, the suffix *after the listed prefix* of each file name
+// is what is returned and, importantly, what is used when grouping using a
+// delimiter. E.g. when using `/` as a delimiter to find what might be called the
+// immediate children in a directory, we pass that directory's path *with a
+// trailing slash* as the prefix, so that the children do not start with a slash
+// and get grouped into nothing. Thus it is important that if we use path.Join
+// to construct the prefix, we always preserve the trailing slash.
+func JoinPathPreservingTrailingSlash(prefix, suffix string) string {
+	out := path.Join(prefix, suffix)
+	// path.Clean removes trailing slashes, so put it back if needed.
+	if strings.HasSuffix(suffix, "/") {
+		out += "/"
+	}
+	return out
+}

--- a/pkg/storage/cloudimpl/file_table_storage.go
+++ b/pkg/storage/cloudimpl/file_table_storage.go
@@ -16,6 +16,7 @@ import (
 	"io"
 	"net/url"
 	"path"
+	"sort"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -350,6 +351,39 @@ func (f *fileTableStorage) ListFiles(ctx context.Context, patternSuffix string) 
 	}
 
 	return fileList, nil
+}
+
+// List implements the ExternalStorage interface.
+func (f *fileTableStorage) List(
+	ctx context.Context, prefix, delim string, fn cloud.ListingFn,
+) error {
+	dest := JoinPathPreservingTrailingSlash(f.prefix, prefix)
+
+	res, err := f.fs.ListFiles(ctx, dest)
+	if err != nil {
+		return errors.Wrap(err, "fail to list destination")
+	}
+
+	sort.Strings(res)
+	var prevPrefix string
+
+	for _, f := range res {
+		f = strings.TrimPrefix(f, dest)
+		if delim != "" {
+			if i := strings.Index(f, delim); i >= 0 {
+				f = f[:i+len(delim)]
+			}
+			if f == prevPrefix {
+				continue
+			}
+			prevPrefix = f
+		}
+		if err := fn(f); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // Delete implements the ExternalStorage interface and deletes the file from the

--- a/pkg/storage/cloudimpl/gcs_storage.go
+++ b/pkg/storage/cloudimpl/gcs_storage.go
@@ -263,6 +263,29 @@ func (g *gcsStorage) ListFiles(ctx context.Context, patternSuffix string) ([]str
 	return fileList, nil
 }
 
+func (g *gcsStorage) List(ctx context.Context, prefix, delim string, fn cloud.ListingFn) error {
+	dest := JoinPathPreservingTrailingSlash(g.prefix, prefix)
+
+	it := g.bucket.Objects(ctx, &gcs.Query{Prefix: dest, Delimiter: delim})
+
+	for {
+		attrs, err := it.Next()
+		if errors.Is(err, iterator.Done) {
+			return nil
+		}
+		if err != nil {
+			return errors.Wrap(err, "unable to list files in gcs bucket")
+		}
+		name := attrs.Name
+		if name == "" {
+			name = attrs.Prefix
+		}
+		if err := fn(strings.TrimPrefix(name, dest)); err != nil {
+			return err
+		}
+	}
+}
+
 func (g *gcsStorage) Delete(ctx context.Context, basename string) error {
 	return contextutil.RunWithTimeout(ctx, "delete gcs file",
 		timeoutSetting.Get(&g.settings.SV),

--- a/pkg/storage/cloudimpl/http_storage.go
+++ b/pkg/storage/cloudimpl/http_storage.go
@@ -253,6 +253,10 @@ func (h *httpStorage) ListFiles(_ context.Context, _ string) ([]string, error) {
 	return nil, errors.Mark(errors.New("http storage does not support listing"), ErrListingUnsupported)
 }
 
+func (h *httpStorage) List(_ context.Context, _, _ string, _ cloud.ListingFn) error {
+	return errors.Mark(errors.New("http storage does not support listing"), ErrListingUnsupported)
+}
+
 func (h *httpStorage) Delete(ctx context.Context, basename string) error {
 	return contextutil.RunWithTimeout(ctx, fmt.Sprintf("DELETE %s", basename),
 		timeoutSetting.Get(&h.settings.SV), func(ctx context.Context) error {

--- a/pkg/storage/cloudimpl/s3_storage.go
+++ b/pkg/storage/cloudimpl/s3_storage.go
@@ -482,6 +482,45 @@ func (s *s3Storage) ListFiles(ctx context.Context, patternSuffix string) ([]stri
 	return fileList, nil
 }
 
+func nilIfEmpty(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return aws.String(s)
+}
+
+func (s *s3Storage) List(ctx context.Context, prefix, delim string, fn cloud.ListingFn) error {
+	dest := JoinPathPreservingTrailingSlash(s.prefix, prefix)
+
+	client, err := s.getClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	var fnErr error
+	pageFn := func(page *s3.ListObjectsOutput, lastPage bool) bool {
+		for _, x := range page.CommonPrefixes {
+			if fnErr = fn(strings.TrimPrefix(*x.Prefix, dest)); fnErr != nil {
+				return false
+			}
+		}
+		for _, fileObject := range page.Contents {
+			if fnErr = fn(strings.TrimPrefix(*fileObject.Key, dest)); fnErr != nil {
+				return false
+			}
+		}
+		return true
+	}
+
+	if err := client.ListObjectsPagesWithContext(
+		ctx, &s3.ListObjectsInput{Bucket: s.bucket, Prefix: aws.String(dest), Delimiter: nilIfEmpty(delim)}, pageFn,
+	); err != nil {
+		return errors.Wrap(err, `failed to list s3 bucket`)
+	}
+
+	return fnErr
+}
+
 func (s *s3Storage) Delete(ctx context.Context, basename string) error {
 	client, err := s.getClient(ctx)
 	if err != nil {

--- a/pkg/storage/cloudimpl/workload_storage.go
+++ b/pkg/storage/cloudimpl/workload_storage.go
@@ -118,6 +118,10 @@ func (s *workloadStorage) ListFiles(_ context.Context, _ string) ([]string, erro
 	return nil, errors.Errorf(`workload storage does not support listing files`)
 }
 
+func (s *workloadStorage) List(_ context.Context, _, _ string, _ cloud.ListingFn) error {
+	return errors.Errorf(`workload storage does not support listing files`)
+}
+
 func (s *workloadStorage) Delete(_ context.Context, _ string) error {
 	return errors.Errorf(`workload storage does not support deletes`)
 }


### PR DESCRIPTION
Backport 4/4 commits from #67214.

/cc @cockroachdb/release

---

This adds a new method to the external storage API: List().

List is very similar to the existing ListFiles and indeed is intended to
replace it, however the original method is left in place for now to make
this an additive-only change for now (and thus easier to backport) -- a
follow-up change can switch users of ListFiles and remove it.

This new method differs from ListFiles in two significant ways:
1) it lists all files within the requested prefix (i.e. recursively),
  rather than accepting glob-style patterns.
2) it accepts a grouping delimiter that mirrors (and is backed by) the
  corresponding flag in most cloud storage listing APIs, that collapses
  all results with the same prefix prior to that delimiter into one.

The second is significant because it can allow skipping large subtrees
when looking for certain files in a larger bucket, specifically skipping
over the thousands of data files in a bucket of backups when looking for
manifest files.

Replacing rather than extending the ListFiles API with this parameter
brings the listing API closer to the underlying cloud APIs which are the
backing implementations, to make it easier and simpler to test. Callers
which actually want to use glob-style pattern matching can filter the
results of listing using path.Match themselves.

Release note: none.

Release note (enterprise change): Incremental BACKUPs to a cloud storage location that already contains large existing backups now find their derived destination without listing as many remote files.
