### PR TITLE
release-20.2: release-21.1: storage/cloud: Add List prefix API

### DIFF
--- a/pkg/ccl/backupccl/backup_destination.go
+++ b/pkg/ccl/backupccl/backup_destination.go
@@ -122,7 +122,7 @@ func resolveDest(
 		if exists {
 			// The backup in the auto-append directory is the full backup.
 			prevBackupURIs = append(prevBackupURIs, defaultURI)
-			priors, err := findPriorBackupLocations(ctx, defaultStore)
+			priors, err := FindPriorBackups(ctx, defaultStore, OmitManifest)
 			for _, prior := range priors {
 				priorURI, err := url.Parse(defaultURI)
 				if err != nil {

--- a/pkg/ccl/backupccl/manifest_handling.go
+++ b/pkg/ccl/backupccl/manifest_handling.go
@@ -579,7 +579,12 @@ func getLocalityInfo(
 	return info, nil
 }
 
-const incBackupSubdirGlob = "[0-9]*/[0-9]*.[0-9][0-9]/"
+const incBackupSubdirGlob = "/[0-9]*/[0-9]*.[0-9][0-9]/"
+
+// listingDelimDataSlash is used when listing to find backups and groups all the
+// data sst files in each backup, which start with "data/", into a single result
+// that can be skipped over quickly.
+const listingDelimDataSlash = "data/"
 
 const (
 	// IncludeManifest is a named const that can be passed to FindPriorBackups.
@@ -592,27 +597,31 @@ const (
 // for the subdirectories matching the naming pattern (e.g. YYMMDD/HHmmss.ss).
 // If includeManifest is true the returned paths are to the manifests for the
 // prior backup, otherwise it is just to the backup path.
-func FindPriorBackups(ctx context.Context, store cloud.ExternalStorage, includeManifest bool) ([]string, error) {
-	backupManifestSuffix := backupManifestName
-	prev, err := store.ListFiles(ctx, incBackupSubdirGlob+backupManifestSuffix)
-	if err != nil {
+func FindPriorBackups(
+	ctx context.Context, store cloud.ExternalStorage, includeManifest bool,
+) ([]string, error) {
+	var prev []string
+	if err := store.List(ctx, "", listingDelimDataSlash, func(p string) error {
+		if ok, err := path.Match(incBackupSubdirGlob+backupManifestName, p); err != nil {
+			return err
+		} else if ok {
+			if !includeManifest {
+				p = strings.TrimSuffix(p, "/"+backupManifestName)
+			}
+			prev = append(prev, p)
+			return nil
+		}
+		if ok, err := path.Match(incBackupSubdirGlob+backupOldManifestName, p); err != nil {
+			return err
+		} else if ok {
+			if !includeManifest {
+				p = strings.TrimSuffix(p, "/"+backupOldManifestName)
+			}
+			prev = append(prev, p)
+		}
+		return nil
+	}); err != nil {
 		return nil, errors.Wrap(err, "reading previous backup layers")
-	}
-
-	if len(prev) == 0 {
-		// 20.1 nodes and earlier will have an oldBackupManifestName so we check for
-		// that too.
-		backupManifestSuffix = backupOldManifestName
-		prev, err = store.ListFiles(ctx, incBackupSubdirGlob+backupManifestSuffix)
-		if err != nil {
-			return nil, errors.Wrap(err, "reading previous backup layers")
-		}
-	}
-
-	if !includeManifest {
-		for i := range prev {
-			prev[i] = strings.TrimSuffix(prev[i], "/"+backupManifestSuffix)
-		}
 	}
 	sort.Strings(prev)
 	return prev, nil
@@ -996,4 +1005,26 @@ func checkForPreviousBackup(
 // tempCheckpointFileNameForJob returns temporary filename for backup manifest checkpoint.
 func tempCheckpointFileNameForJob(jobID int64) string {
 	return fmt.Sprintf("%s-%d", backupManifestCheckpointName, jobID)
+}
+
+// ListFullBackupsInCollection lists full backup paths in the collection
+// of an export store
+func ListFullBackupsInCollection(
+	ctx context.Context, store cloud.ExternalStorage,
+) ([]string, error) {
+	var backupPaths []string
+	if err := store.List(ctx, "", listingDelimDataSlash, func(f string) error {
+		if ok, err := path.Match("/*/*/*/"+backupManifestName, f); err != nil {
+			return err
+		} else if ok {
+			backupPaths = append(backupPaths, f)
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	for i, backupPath := range backupPaths {
+		backupPaths[i] = strings.TrimSuffix(backupPath, "/"+backupManifestName)
+	}
+	return backupPaths, nil
 }

--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -500,12 +500,12 @@ func showBackupsInCollectionPlanHook(
 			return errors.Wrapf(err, "connect to external storage")
 		}
 		defer store.Close()
-		res, err := store.ListFiles(ctx, "/*/*/*/"+backupManifestName)
+		res, err := ListFullBackupsInCollection(ctx, store)
 		if err != nil {
 			return err
 		}
 		for _, i := range res {
-			resultsCh <- tree.Datums{tree.NewDString(strings.TrimSuffix(i, "/"+backupManifestName))}
+			resultsCh <- tree.Datums{tree.NewDString(i)}
 		}
 		return nil
 	}

--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -147,7 +147,7 @@ func showBackupPlanHook(
 				KMSInfo: defaultKMSInfo}
 		}
 
-		incPaths, err := findPriorBackupNames(ctx, store)
+		incPaths, err := FindPriorBackups(ctx, store, IncludeManifest)
 		if err != nil {
 			if errors.Is(err, cloudimpl.ErrListingUnsupported) {
 				// If we do not support listing, we have to just assume there are none

--- a/pkg/ccl/importccl/testutils_test.go
+++ b/pkg/ccl/importccl/testutils_test.go
@@ -273,6 +273,12 @@ func (es *generatorExternalStorage) ListFiles(ctx context.Context, _ string) ([]
 	return nil, errors.New("unsupported")
 }
 
+func (es *generatorExternalStorage) List(
+	ctx context.Context, _, _ string, _ cloud.ListingFn,
+) error {
+	return errors.New("unsupported")
+}
+
 func (es *generatorExternalStorage) Delete(ctx context.Context, basename string) error {
 	return errors.New("unsupported")
 }

--- a/pkg/storage/cloud/external_storage.go
+++ b/pkg/storage/cloud/external_storage.go
@@ -57,6 +57,15 @@ type ExternalStorage interface {
 	// WriteFile should write the content to requested name.
 	WriteFile(ctx context.Context, basename string, content io.ReadSeeker) error
 
+	// List enumerates files within the supplied prefix, calling the passed
+	// function with the name of each file found, relative to the external storage
+	// destination's configured prefix. If the passed function returns a non-nil
+	// error, iteration is stopped it is returned. If delimiter is non-empty names
+	// which have the same prefix, prior to the delimiter, are grouped into a
+	// single result which is that prefix. The order that results are passed to
+	// the callback is undefined.
+	List(ctx context.Context, prefix, delimiter string, fn ListingFn) error
+
 	// ListFiles returns files that match a globs-style pattern. The returned
 	// results are usually relative to the base path, meaning an ExternalStorage
 	// instance can be initialized with some base path, used to query for files,
@@ -76,6 +85,9 @@ type ExternalStorage interface {
 	// Size returns the length of the named file in bytes.
 	Size(ctx context.Context, basename string) (int64, error)
 }
+
+// ListingFn describes functions passed to ExternalStorage.ListFiles.
+type ListingFn func(string) error
 
 // ExternalStorageFactory describes a factory function for ExternalStorage.
 type ExternalStorageFactory func(ctx context.Context, dest roachpb.ExternalStorage) (ExternalStorage, error)

--- a/pkg/storage/cloudimpl/cloudimpltests/external_storage_test.go
+++ b/pkg/storage/cloudimpl/cloudimpltests/external_storage_test.go
@@ -436,6 +436,99 @@ func testListFiles(t *testing.T, storeURI, user string, ie *sql.InternalExecutor
 		}
 	})
 
+	foreach := func(in []string, fn func(string) string) []string {
+		out := make([]string, len(in))
+		for i := range in {
+			out[i] = fn(in[i])
+		}
+		return out
+	}
+
+	t.Run("List", func(t *testing.T) {
+		for _, tc := range []struct {
+			name      string
+			uri       string
+			prefix    string
+			delimiter string
+			expected  []string
+		}{
+			{
+				"root",
+				storeURI,
+				"",
+				"",
+				foreach(fileNames, func(s string) string { return "/" + s }),
+			},
+			{
+				"file-slash-numbers-slash",
+				storeURI,
+				"file/numbers/",
+				"",
+				[]string{"data1.csv", "data2.csv", "data3.csv"},
+			},
+			{
+				"root-slash",
+				storeURI,
+				"/",
+				"",
+				foreach(fileNames, func(s string) string { return s }),
+			},
+			{
+				"file",
+				storeURI,
+				"file",
+				"",
+				foreach(fileNames, func(s string) string { return strings.TrimPrefix(s, "file") }),
+			},
+			{
+				"file-slash",
+				storeURI,
+				"file/",
+				"",
+				foreach(fileNames, func(s string) string { return strings.TrimPrefix(s, "file/") }),
+			},
+			{
+				"slash-f",
+				storeURI,
+				"/f",
+				"",
+				foreach(fileNames, func(s string) string { return strings.TrimPrefix(s, "f") }),
+			},
+			{
+				"nothing",
+				storeURI,
+				"nothing",
+				"",
+				nil,
+			},
+			{
+				"delim-slash-file-slash",
+				storeURI,
+				"file/",
+				"/",
+				[]string{"abc/", "letters/", "numbers/"},
+			},
+			{
+				"delim-data",
+				storeURI,
+				"",
+				"data",
+				[]string{"/file/abc/A.csv", "/file/abc/B.csv", "/file/abc/C.csv", "/file/letters/data", "/file/numbers/data"},
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				s := storeFromURI(ctx, t, tc.uri, clientFactory, user, ie, kvDB)
+				var actual []string
+				require.NoError(t, s.List(ctx, tc.prefix, tc.delimiter, func(f string) error {
+					actual = append(actual, f)
+					return nil
+				}))
+				sort.Strings(actual)
+				require.Equal(t, tc.expected, actual)
+			})
+		}
+	})
+
 	for _, fileName := range fileNames {
 		file := storeFromURI(ctx, t, storeURI, clientFactory, user, ie, kvDB)
 		if err := file.Delete(ctx, fileName); err != nil {

--- a/pkg/storage/cloudimpl/cloudimpltests/external_storage_test.go
+++ b/pkg/storage/cloudimpl/cloudimpltests/external_storage_test.go
@@ -497,6 +497,16 @@ func TestPutGoogleCloud(t *testing.T) {
 		}
 		testExportStore(t, fmt.Sprintf("gs://%s/%s?%s=%s", bucket, "backup-test-implicit",
 			cloudimpl.AuthParam, cloudimpl.AuthParamImplicit), false, user, nil, nil)
+		testListFiles(t,
+			fmt.Sprintf("gs://%s/%s/%s?%s=%s",
+				bucket,
+				"backup-test-implicit",
+				"listing-test",
+				cloudimpl.AuthParam,
+				cloudimpl.AuthParamImplicit,
+			),
+			security.RootUser, nil, nil,
+		)
 	})
 }
 

--- a/pkg/storage/cloudimpl/external_storage.go
+++ b/pkg/storage/cloudimpl/external_storage.go
@@ -477,3 +477,23 @@ const MaxDelayedRetryAttempts = 3
 // Maximum number of times we can attempt to retry reading from external storage,
 // without making any progress.
 const maxNoProgressReads = 3
+
+// JoinPathPreservingTrailingSlash wraps path.Join but preserves the trailing
+// slash if there was one in the suffix.
+//
+// This is particularly important when the joined path is used as a prefix for
+// listing. When listing, the suffix *after the listed prefix* of each file name
+// is what is returned and, importantly, what is used when grouping using a
+// delimiter. E.g. when using `/` as a delimiter to find what might be called the
+// immediate children in a directory, we pass that directory's path *with a
+// trailing slash* as the prefix, so that the children do not start with a slash
+// and get grouped into nothing. Thus it is important that if we use path.Join
+// to construct the prefix, we always preserve the trailing slash.
+func JoinPathPreservingTrailingSlash(prefix, suffix string) string {
+	out := path.Join(prefix, suffix)
+	// path.Clean removes trailing slashes, so put it back if needed.
+	if strings.HasSuffix(suffix, "/") {
+		out += "/"
+	}
+	return out
+}

--- a/pkg/storage/cloudimpl/file_table_storage.go
+++ b/pkg/storage/cloudimpl/file_table_storage.go
@@ -17,6 +17,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"sort"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -318,6 +319,39 @@ func (f *fileTableStorage) ListFiles(ctx context.Context, patternSuffix string) 
 	}
 
 	return fileList, nil
+}
+
+// List implements the ExternalStorage interface.
+func (f *fileTableStorage) List(
+	ctx context.Context, prefix, delim string, fn cloud.ListingFn,
+) error {
+	dest := JoinPathPreservingTrailingSlash(f.prefix, prefix)
+
+	res, err := f.fs.ListFiles(ctx, dest)
+	if err != nil {
+		return errors.Wrap(err, "fail to list destination")
+	}
+
+	sort.Strings(res)
+	var prevPrefix string
+
+	for _, f := range res {
+		f = strings.TrimPrefix(f, dest)
+		if delim != "" {
+			if i := strings.Index(f, delim); i >= 0 {
+				f = f[:i+len(delim)]
+			}
+			if f == prevPrefix {
+				continue
+			}
+			prevPrefix = f
+		}
+		if err := fn(f); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // Delete implements the ExternalStorage interface and deletes the file from the

--- a/pkg/storage/cloudimpl/http_storage.go
+++ b/pkg/storage/cloudimpl/http_storage.go
@@ -283,6 +283,10 @@ func (h *httpStorage) ListFiles(_ context.Context, _ string) ([]string, error) {
 	return nil, errors.Mark(errors.New("http storage does not support listing"), ErrListingUnsupported)
 }
 
+func (h *httpStorage) List(_ context.Context, _, _ string, _ cloud.ListingFn) error {
+	return errors.Mark(errors.New("http storage does not support listing"), ErrListingUnsupported)
+}
+
 func (h *httpStorage) Delete(ctx context.Context, basename string) error {
 	return contextutil.RunWithTimeout(ctx, fmt.Sprintf("DELETE %s", basename),
 		timeoutSetting.Get(&h.settings.SV), func(ctx context.Context) error {

--- a/pkg/storage/cloudimpl/nodelocal_storage.go
+++ b/pkg/storage/cloudimpl/nodelocal_storage.go
@@ -16,6 +16,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"sort"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -150,6 +151,37 @@ func (l *localFileStorage) ListFiles(ctx context.Context, patternSuffix string) 
 	}
 
 	return fileList, nil
+}
+
+func (l *localFileStorage) List(
+	ctx context.Context, prefix, delim string, fn cloud.ListingFn,
+) error {
+	dest := JoinPathPreservingTrailingSlash(l.base, prefix)
+
+	res, err := l.blobClient.List(ctx, dest)
+	if err != nil {
+		return errors.Wrap(err, "unable to match pattern provided")
+	}
+
+	// Sort results so that we can group as we go.
+	sort.Strings(res)
+	var prevPrefix string
+	for _, f := range res {
+		f = strings.TrimPrefix(f, dest)
+		if delim != "" {
+			if i := strings.Index(f, delim); i >= 0 {
+				f = f[:i+len(delim)]
+			}
+			if f == prevPrefix {
+				continue
+			}
+			prevPrefix = f
+		}
+		if err := fn(f); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (l *localFileStorage) Delete(ctx context.Context, basename string) error {

--- a/pkg/storage/cloudimpl/workload_storage.go
+++ b/pkg/storage/cloudimpl/workload_storage.go
@@ -112,6 +112,10 @@ func (s *workloadStorage) ListFiles(_ context.Context, _ string) ([]string, erro
 	return nil, errors.Errorf(`workload storage does not support listing files`)
 }
 
+func (s *workloadStorage) List(_ context.Context, _, _ string, _ cloud.ListingFn) error {
+	return errors.Errorf(`workload storage does not support listing files`)
+}
+
 func (s *workloadStorage) Delete(_ context.Context, _ string) error {
 	return errors.Errorf(`workload storage does not support deletes`)
 }


### PR DESCRIPTION
Backport 4/4 commits from #67286.

/cc @cockroachdb/release

---

Backport 4/4 commits from #67214.

/cc @cockroachdb/release

---

This adds a new method to the external storage API: List().

List is very similar to the existing ListFiles and indeed is intended to
replace it, however the original method is left in place for now to make
this an additive-only change for now (and thus easier to backport) -- a
follow-up change can switch users of ListFiles and remove it.

This new method differs from ListFiles in two significant ways:
1) it lists all files within the requested prefix (i.e. recursively),
  rather than accepting glob-style patterns.
2) it accepts a grouping delimiter that mirrors (and is backed by) the
  corresponding flag in most cloud storage listing APIs, that collapses
  all results with the same prefix prior to that delimiter into one.

The second is significant because it can allow skipping large subtrees
when looking for certain files in a larger bucket, specifically skipping
over the thousands of data files in a bucket of backups when looking for
manifest files.

Replacing rather than extending the ListFiles API with this parameter
brings the listing API closer to the underlying cloud APIs which are the
backing implementations, to make it easier and simpler to test. Callers
which actually want to use glob-style pattern matching can filter the
results of listing using path.Match themselves.

Release note: none.

Release note (enterprise change): Incremental BACKUPs to a cloud storage location that already contains large existing backups now find their derived destination without listing as many remote files.

