### PR TITLE
execgen: preserve comments around callsite of inlined function

### DIFF
--- a/pkg/sql/colexec/colexecjoin/hashjoiner.eg.go
+++ b/pkg/sql/colexec/colexecjoin/hashjoiner.eg.go
@@ -299,6 +299,8 @@ func collectLeftAnti_true(
 		//gcassert:bce
 		currentID := HeadIDs[i]
 		if currentID == 0 {
+			// currentID of 0 indicates that ith probing row didn't have a match, so
+			// we include it into the output.
 			{
 				var __retval_0 int
 				{
@@ -388,6 +390,8 @@ func collectLeftAnti_false(
 		//gcassert:bce
 		currentID := HeadIDs[i]
 		if currentID == 0 {
+			// currentID of 0 indicates that ith probing row didn't have a match, so
+			// we include it into the output.
 			{
 				var __retval_0 int
 				{

--- a/pkg/sql/colexec/execgen/inline.go
+++ b/pkg/sql/colexec/execgen/inline.go
@@ -122,6 +122,9 @@ func inlineFunc(inlineFuncMap map[string]funcInfo, n dst.Node) dst.Node {
 			// }
 			inlinedStatements := &dst.BlockStmt{
 				List: []dst.Stmt{retValDeclStmt},
+				Decs: dst.BlockStmtDecorations{
+					NodeDecs: n.Decs.NodeDecs,
+				},
 			}
 			body := dst.Clone(decl.Body).(*dst.BlockStmt)
 
@@ -179,6 +182,9 @@ func inlineFunc(inlineFuncMap map[string]funcInfo, n dst.Node) dst.Node {
 			// the mangled returns after the inlined function.
 			funcBlock := &dst.BlockStmt{
 				List: []dst.Stmt{reassignments},
+				Decs: dst.BlockStmtDecorations{
+					NodeDecs: n.Decs.NodeDecs,
+				},
 			}
 			body := dst.Clone(decl.Body).(*dst.BlockStmt)
 

--- a/pkg/sql/colexec/execgen/testdata/inline
+++ b/pkg/sql/colexec/execgen/testdata/inline
@@ -247,3 +247,34 @@ const _ = "inlined_b"
 const _ = "inlined_c"
 ----
 ----
+
+# Test that comments at call-site are preserved.
+inline
+package main
+
+func a() {
+	// This comment should not be removed.
+  b()
+  // This one too.
+}
+
+// execgen:inline
+func b() {
+  foo = bar
+}
+----
+----
+package main
+
+func a() {
+	// This comment should not be removed.
+	{
+		foo = bar
+	}
+	// This one too.
+}
+
+// execgen:inline
+const _ = "inlined_b"
+----
+----


### PR DESCRIPTION
This patch modifies the execgen `inline` directive to ensure that
comments before and after the callsites of inlined functions are
not removed. Example:
```
func a() {
  // This comment should not be removed.
  b()
  // This one too.
}

// execgen:inline
func b() {
  foo = bar
}
=>
func a() {
  // This comment should not be removed.
  {
    foo = bar
  }
  // This one too.
}

// execgen:inline
const _ = "inlined_b"
```

Release note: None