### PR TITLE
storage: expose vfs for inmem test storage for inspections

### DIFF
--- a/pkg/kv/kvserver/consistency_queue_test.go
+++ b/pkg/kv/kvserver/consistency_queue_test.go
@@ -17,6 +17,7 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 
@@ -27,10 +28,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -233,12 +234,11 @@ func TestCheckConsistencyInconsistent(t *testing.T) {
 	// good to make sure we're overly redacting said diff.
 	defer log.TestingSetRedactable(true)()
 
-	if testing.Short() {
-		// Takes 30s as of 2020/07. The test uses on-disk stores because nodes get
-		// killed, and for some reason using the on-disk stores seems to cause
-		// WaitForFullReplication() to take forever.
-		skip.UnderShort(t)
-	}
+	// Test uses sticky registry to have persistent pebble state that could
+	// be analyzed for existence of snapshots and to verify snapshot content
+	// after failures.
+	stickyEngineRegistry := server.NewStickyInMemEnginesRegistry()
+	defer stickyEngineRegistry.CloseAllStickyInMemEngines()
 
 	const numStores = 3
 	testKnobs := kvserver.StoreTestingKnobs{
@@ -311,19 +311,19 @@ func TestCheckConsistencyInconsistent(t *testing.T) {
 		notifyFatal <- struct{}{}
 	}
 
-	dir, cleanup := testutils.TempDir(t)
-	defer cleanup()
-
 	serverArgsPerNode := make(map[int]base.TestServerArgs)
 	for i := 0; i < numStores; i++ {
 		testServerArgs := base.TestServerArgs{
 			Knobs: base.TestingKnobs{
 				Store: &testKnobs,
+				Server: &server.TestingKnobs{
+					StickyEngineRegistry: stickyEngineRegistry,
+				},
 			},
 			StoreSpecs: []base.StoreSpec{
 				{
-					Path:     filepath.Join(dir, fmt.Sprintf("%d", i)),
-					InMemory: false,
+					InMemory:               true,
+					StickyInMemoryEngineID: strconv.FormatInt(int64(i), 10),
 				},
 			},
 		}
@@ -353,7 +353,7 @@ func TestCheckConsistencyInconsistent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	runCheck := func() *roachpb.CheckConsistencyResponse {
+	runConsistencyCheck := func() *roachpb.CheckConsistencyResponse {
 		checkArgs := roachpb.CheckConsistencyRequest{
 			RequestHeader: roachpb.RequestHeader{
 				// span of keys that include "a" & "c".
@@ -369,20 +369,28 @@ func TestCheckConsistencyInconsistent(t *testing.T) {
 		return resp.(*roachpb.CheckConsistencyResponse)
 	}
 
-	checkpoints := func(nodeIdx int) []string {
+	onDiskCheckpointPaths := func(nodeIdx int) []string {
 		testServer := tc.Servers[nodeIdx]
+		fs, pErr := stickyEngineRegistry.GetUnderlyingFS(
+			base.StoreSpec{StickyInMemoryEngineID: strconv.FormatInt(int64(nodeIdx), 10)})
+		if pErr != nil {
+			t.Fatal(pErr)
+		}
 		testStore, pErr := testServer.Stores().GetStore(testServer.GetFirstStoreID())
 		if pErr != nil {
 			t.Fatal(pErr)
 		}
-		pat := filepath.Join(testStore.Engine().GetAuxiliaryDir(), "checkpoints") + "/*"
-		m, err := filepath.Glob(pat)
-		assert.NoError(t, err)
-		return m
+		checkpointPath := filepath.Join(testStore.Engine().GetAuxiliaryDir(), "checkpoints")
+		checkpoints, _ := fs.List(checkpointPath)
+		var checkpointPaths []string
+		for _, cpDirName := range checkpoints {
+			checkpointPaths = append(checkpointPaths, filepath.Join(checkpointPath, cpDirName))
+		}
+		return checkpointPaths
 	}
 
 	// Run the check the first time, it shouldn't find anything.
-	respOK := runCheck()
+	respOK := runConsistencyCheck()
 	assert.Len(t, respOK.Result, 1)
 	assert.Equal(t, roachpb.CheckConsistencyResponse_RANGE_CONSISTENT, respOK.Result[0].Status)
 	select {
@@ -395,7 +403,7 @@ func TestCheckConsistencyInconsistent(t *testing.T) {
 
 	// No checkpoints should have been created.
 	for i := 0; i < numStores; i++ {
-		assert.Empty(t, checkpoints(i))
+		assert.Empty(t, onDiskCheckpointPaths(i))
 	}
 
 	// Write some arbitrary data only to store 1. Inconsistent key "e"!
@@ -414,7 +422,7 @@ func TestCheckConsistencyInconsistent(t *testing.T) {
 	}
 
 	// Run consistency check again, this time it should find something.
-	resp := runCheck()
+	resp := runConsistencyCheck()
 
 	select {
 	case <-notifyReportDiff:
@@ -429,15 +437,14 @@ func TestCheckConsistencyInconsistent(t *testing.T) {
 
 	// Checkpoints should have been created on all stores and they're not empty.
 	for i := 0; i < numStores; i++ {
-		cps := checkpoints(i)
+		cps := onDiskCheckpointPaths(i)
 		assert.Len(t, cps, 1)
-		cpEng, err := storage.NewDefaultEngine(
-			1<<20,
-			base.StorageConfig{
-				Dir: cps[0],
-			},
-		)
+
+		// Create a new store on top of checkpoint location inside existing in mem
+		// VFS to verify its contents.
+		fs, err := stickyEngineRegistry.GetUnderlyingFS(base.StoreSpec{StickyInMemoryEngineID: strconv.FormatInt(int64(i), 10)})
 		assert.NoError(t, err)
+		cpEng := storage.InMemFromFS(context.Background(), roachpb.Attributes{}, 1<<20, 0, fs, cps[0], nil)
 		defer cpEng.Close()
 
 		iter := cpEng.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: []byte("\xff")})

--- a/pkg/server/settings_cache_test.go
+++ b/pkg/server/settings_cache_test.go
@@ -58,12 +58,17 @@ func TestCachedSettingsServerRestart(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	storeDir, cleanupFn := testutils.TempDir(t)
-	defer cleanupFn()
+	stickyEngineRegistry := NewStickyInMemEnginesRegistry()
+	defer stickyEngineRegistry.CloseAllStickyInMemEngines()
 
 	serverArgs := base.TestServerArgs{
 		StoreSpecs: []base.StoreSpec{
-			{InMemory: false, Path: storeDir},
+			{InMemory: true, StickyInMemoryEngineID: "1"},
+		},
+		Knobs: base.TestingKnobs{
+			Server: &TestingKnobs{
+				StickyEngineRegistry: stickyEngineRegistry,
+			},
 		},
 	}
 

--- a/pkg/server/sticky_engine.go
+++ b/pkg/server/sticky_engine.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/vfs"
 )
 
 // stickyInMemEngine extends a normal engine, but does not allow them to be
@@ -35,6 +36,9 @@ type stickyInMemEngine struct {
 
 	// Engine extends the Engine interface.
 	storage.Engine
+
+	// Underlying in-mem filesystem backing the engine
+	fs vfs.FS
 }
 
 // StickyInMemEnginesRegistry manages the lifecycle of sticky engines.
@@ -47,6 +51,9 @@ type StickyInMemEnginesRegistry interface {
 	// and cache size will be ignored.
 	// One must Close() on the sticky engine before another can be fetched.
 	GetOrCreateStickyInMemEngine(ctx context.Context, cfg *Config, spec base.StoreSpec) (storage.Engine, error)
+	// GetUnderlyingFS returns FS backing in mem engine. If engine was not created
+	// error is returned.
+	GetUnderlyingFS(spec base.StoreSpec) (vfs.FS, error)
 	// CloseAllStickyInMemEngines closes all sticky in memory engines that were
 	// created by this registry.
 	CloseAllStickyInMemEngines()
@@ -100,18 +107,34 @@ func (registry *stickyInMemEnginesRegistryImpl) GetOrCreateStickyInMemEngine(
 	}
 
 	log.Infof(ctx, "creating new sticky in-mem engine %s", spec.StickyInMemoryEngineID)
-	engine := &stickyInMemEngine{
+	fs := vfs.NewMem()
+	engine := storage.InMemFromFS(
+		ctx, spec.Attributes, cfg.CacheSize, spec.Size.InBytes, fs, "", storage.MakeRandomSettingsForSeparatedIntents())
+
+	engineEntry := &stickyInMemEngine{
 		id:     spec.StickyInMemoryEngineID,
 		closed: false,
 		// This engine will stay alive after the node dies, so we don't want the
 		// caller to pass in a *cluster.Settings from the current node. Just
 		// create a random one since that is what we like to do in tests (for
 		// better test coverage).
-		Engine: storage.NewInMem(
-			ctx, spec.Attributes, cfg.CacheSize, spec.Size.InBytes, storage.MakeRandomSettingsForSeparatedIntents()),
+		Engine: engine,
+		fs:     fs,
 	}
-	registry.entries[spec.StickyInMemoryEngineID] = engine
-	return engine, nil
+	registry.entries[spec.StickyInMemoryEngineID] = engineEntry
+	return engineEntry, nil
+}
+
+func (registry *stickyInMemEnginesRegistryImpl) GetUnderlyingFS(
+	spec base.StoreSpec,
+) (vfs.FS, error) {
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+
+	if engine, ok := registry.entries[spec.StickyInMemoryEngineID]; ok {
+		return engine.fs, nil
+	}
+	return nil, errors.Errorf("engine '%s' was not created", spec.StickyInMemoryEngineID)
 }
 
 // CloseAllStickyInMemEngines closes and removes all sticky in memory engines.

--- a/pkg/storage/batch_test.go
+++ b/pkg/storage/batch_test.go
@@ -1100,7 +1100,7 @@ func TestDecodeKey(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	e := newPebbleInMem(
+	e := NewInMem(
 		context.Background(),
 		roachpb.Attributes{},
 		1<<20,   /* cacheSize */

--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -1536,7 +1536,7 @@ func TestSupportsPrev(t *testing.T) {
 	}
 	t.Run("pebble", func(t *testing.T) {
 
-		eng := newPebbleInMem(
+		eng := NewInMem(
 			context.Background(),
 			roachpb.Attributes{},
 			1<<20,   /* cacheSize */
@@ -1666,7 +1666,7 @@ func TestScanSeparatedIntents(t *testing.T) {
 	for name, enableSeparatedIntents := range map[string]bool{"interleaved": false, "separated": true} {
 		t.Run(name, func(t *testing.T) {
 			settings := makeSettingsForSeparatedIntents(false, enableSeparatedIntents)
-			eng := newPebbleInMem(
+			eng := NewInMem(
 				ctx,
 				roachpb.Attributes{},
 				1<<20,   /* cacheSize */

--- a/pkg/storage/multi_iterator_test.go
+++ b/pkg/storage/multi_iterator_test.go
@@ -27,7 +27,7 @@ func TestMultiIterator(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	pebble := newPebbleInMem(
+	pebble := NewInMem(
 		context.Background(),
 		roachpb.Attributes{},
 		1<<20,   /* cacheSize */

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -85,7 +85,7 @@ func createTestPebbleEngine() Engine {
 }
 
 func createTestPebbleEngineWithSettings(settings *cluster.Settings) Engine {
-	return newPebbleInMem(
+	return NewInMem(
 		context.Background(),
 		roachpb.Attributes{},
 		1<<20,   /* cacheSize */

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -605,18 +605,21 @@ func newPebbleInMem(
 	ctx context.Context,
 	attrs roachpb.Attributes,
 	cacheSize, storeSize int64,
+	fs vfs.FS,
+	dir string,
 	settings *cluster.Settings,
 ) *Pebble {
 	opts := DefaultPebbleOptions()
 	opts.Cache = pebble.NewCache(cacheSize)
 	defer opts.Cache.Unref()
 
-	opts.FS = vfs.NewMem()
+	opts.FS = fs
 	db, err := NewPebble(
 		ctx,
 		PebbleConfig{
 			StorageConfig: base.StorageConfig{
 				Attrs:    attrs,
+				Dir:      dir,
 				MaxSize:  storeSize,
 				Settings: settings,
 			},

--- a/pkg/storage/pebble_test.go
+++ b/pkg/storage/pebble_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
 )
 
@@ -430,6 +431,8 @@ func TestPebbleDiskSlowEmit(t *testing.T) {
 		roachpb.Attributes{},
 		1<<20,   /* cacheSize */
 		512<<20, /* storeSize */
+		vfs.NewMem(),
+		"",
 		settings,
 	)
 	defer p.Close()


### PR DESCRIPTION
Unit tests have to rely on on-disk pebble for tests that want
to check storage side effects produced by server operations.
This is causing significantly slower performance on macos because
of fsync operations.
By using memory fs to store pebble data we could eliminate slow
operations. This diff exposes FS that is used by sticky storage
registry so that fs from store could be inspected by tests.

Release note: None