### PR TITLE
release-21.1: changefeedccl: avoid consumer blocking forever in BlockingBuffer

### DIFF
--- a/pkg/ccl/changefeedccl/kvfeed/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/kvfeed/BUILD.bazel
@@ -46,7 +46,10 @@ go_library(
 go_test(
     name = "kvfeed_test",
     size = "small",
-    srcs = ["kv_feed_test.go"],
+    srcs = [
+        "blocking_buffer_test.go",
+        "kv_feed_test.go",
+    ],
     embed = [":kvfeed"],
     deps = [
         "//pkg/ccl/changefeedccl/changefeedbase",

--- a/pkg/ccl/changefeedccl/kvfeed/blocking_buffer_test.go
+++ b/pkg/ccl/changefeedccl/kvfeed/blocking_buffer_test.go
@@ -1,0 +1,85 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package kvfeed_test
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/kvfeed"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/stretchr/testify/require"
+)
+
+func makeKVs(t *testing.T, count int) []roachpb.KeyValue {
+	kv := func(tableID uint32, k, v string, ts hlc.Timestamp) roachpb.KeyValue {
+		vDatum := tree.DString(k)
+		key, err := rowenc.EncodeTableKey(keys.SystemSQLCodec.TablePrefix(tableID), &vDatum, encoding.Ascending)
+		require.NoError(t, err)
+
+		return roachpb.KeyValue{
+			Key: key,
+			Value: roachpb.Value{
+				RawBytes:  []byte(v),
+				Timestamp: ts,
+			},
+		}
+	}
+
+	ret := make([]roachpb.KeyValue, count)
+	for i := 0; i < count; i++ {
+		ret[i] = kv(42, "a", fmt.Sprintf("b-%d", count), hlc.Timestamp{WallTime: int64(count + 1)})
+	}
+	return ret
+}
+
+func TestBlockingBuffer(t *testing.T) {
+	metrics := kvfeed.MakeMetrics(time.Minute)
+	settings := cluster.MakeTestingClusterSettings()
+	mm := mon.NewUnlimitedMonitor(
+		context.Background(), "test", mon.MemoryResource,
+		nil /* curCount */, nil /* maxHist */, math.MaxInt64, settings,
+	)
+
+	buf := kvfeed.MakeMemBuffer(mm.MakeBoundAccount(), &metrics)
+	kvCount := rand.Intn(20) + 1
+	kvs := makeKVs(t, kvCount)
+	ctx := context.Background()
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		for _, kv := range kvs {
+			err := buf.AddKV(ctx, kv, roachpb.Value{}, hlc.Timestamp{})
+			require.NoError(t, err)
+		}
+		wg.Done()
+	}()
+	wg.Add(1)
+	go func() {
+		for i := 0; i < kvCount; i++ {
+			_, err := buf.Get(ctx)
+			require.NoError(t, err)
+		}
+		wg.Done()
+	}()
+	wg.Wait()
+}

--- a/pkg/ccl/changefeedccl/kvfeed/buffer.go
+++ b/pkg/ccl/changefeedccl/kvfeed/buffer.go
@@ -386,7 +386,7 @@ type blockingBuffer struct {
 // account, an error will be returned when attempting to buffer it.
 func NewBlockingBuffer(acc mon.BoundAccount, metrics *Metrics) EventBuffer {
 	bb := &blockingBuffer{
-		signalCh: make(chan struct{}),
+		signalCh: make(chan struct{}, 1),
 	}
 	bb.acc = acc
 	bb.metrics = metrics


### PR DESCRIPTION
Backport 1/1 commits from #67223.

/cc @cockroachdb/release

---

The blocking buffer uses a channel to wake a caller to Get up after
AddKV has been called. However, since we use non-blocking sends to the
signal channel, the following is possible:

    Thread 1                            Thread 2

    b.mu.Lock()
    b.mu.queue.dequeue() -> nil
    b.mu.Unlock()
                                        b.mu.Lock()
                                        b.mu.queue.enqueue(event)
                                        b.mu.Unlock()
                                        b.signalCh <- struct{}{} (not sent as it would have blocked)

    <-b.signalCh (potentially blocks forever)

This change solves this by adding a 1 message buffer to the signal
channel. I believe this solves the race condition for a single
consumer. However, in the multiple consumer case, we still have a
problem.

This code is only called currently with a single consumer.

If we want to fix it for multiple consumers, one option is a fallback
timeout in Get() to recheck the queue after some time if it hasn't
otherwise gotten a wakeup signal.

I've avoided this for now simply because I didn't want to add overhead
for a use-case that we don't actually have.

Fixes #67200

Release note: None
