### PR TITLE
migration,keys: fix incorrect range descriptor iteration

### DIFF
--- a/pkg/keys/keys.go
+++ b/pkg/keys/keys.go
@@ -657,6 +657,11 @@ func UserKey(key roachpb.RKey) roachpb.RKey {
 	return buf
 }
 
+// InMeta1 returns true iff a key is in the meta1 range (which includes RKeyMin).
+func InMeta1(k roachpb.RKey) bool {
+	return k.Equal(roachpb.RKeyMin) || bytes.HasPrefix(k, MustAddr(Meta1Prefix))
+}
+
 // validateRangeMetaKey validates that the given key is a valid Range Metadata
 // key. This checks only the constraints common to forward and backwards scans:
 // correct prefix and not exceeding KeyMax.

--- a/pkg/migration/migrationcluster/BUILD.bazel
+++ b/pkg/migration/migrationcluster/BUILD.bazel
@@ -36,6 +36,7 @@ go_test(
     ],
     embed = [":migrationcluster"],
     deps = [
+        "//pkg/keys",
         "//pkg/kv/kvserver",
         "//pkg/migration/nodelivenesstest",
         "//pkg/roachpb",

--- a/pkg/migration/migrationcluster/client_test.go
+++ b/pkg/migration/migrationcluster/client_test.go
@@ -12,8 +12,10 @@ package migrationcluster_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/migration/migrationcluster"
 	"github.com/cockroachdb/cockroach/pkg/migration/nodelivenesstest"
@@ -23,43 +25,60 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
-func TestCluster_IterateRangeDescriptors(t *testing.T) {
+func TestClusterIterateRangeDescriptors(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
 	const numNodes = 1
 
-	params, _ := tests.CreateTestServerParams()
-	server, _, kvDB := serverutils.StartServer(t, params)
-	defer server.Stopper().Stop(context.Background())
+	for _, splits := range [][]roachpb.Key{
+		{},                                    // no splits
+		{keys.Meta2Prefix},                    // split between meta1 and meta2
+		{keys.SystemPrefix},                   // split after the meta range
+		{keys.Meta2Prefix, keys.SystemPrefix}, // split before and after meta2
+		{keys.RangeMetaKey(roachpb.RKey("middle")).AsRawKey()},                   // split within meta2
+		{keys.Meta2Prefix, keys.RangeMetaKey(roachpb.RKey("middle")).AsRawKey()}, // split at start of and within meta2
+	} {
+		t.Run(fmt.Sprintf("with-splits-at=%s", splits), func(t *testing.T) {
+			params, _ := tests.CreateTestServerParams()
+			server, _, kvDB := serverutils.StartServer(t, params)
+			defer server.Stopper().Stop(context.Background())
 
-	var numRanges int
-	if err := server.GetStores().(*kvserver.Stores).VisitStores(func(s *kvserver.Store) error {
-		numRanges = s.ReplicaCount()
-		return nil
-	}); err != nil {
-		t.Fatal(err)
-	}
+			for _, split := range splits {
+				if _, _, err := server.SplitRange(split); err != nil {
+					t.Fatal(err)
+				}
+			}
 
-	c := nodelivenesstest.New(numNodes)
-	h := migrationcluster.New(migrationcluster.ClusterConfig{
-		NodeLiveness: c,
-		Dialer:       migrationcluster.NoopDialer{},
-		DB:           kvDB,
-	})
+			var numRanges int
+			if err := server.GetStores().(*kvserver.Stores).VisitStores(func(s *kvserver.Store) error {
+				numRanges = s.ReplicaCount()
+				return nil
+			}); err != nil {
+				t.Fatal(err)
+			}
 
-	for _, blockSize := range []int{1, 5, 10, 50} {
-		var numDescs int
-		init := func() { numDescs = 0 }
-		if err := h.IterateRangeDescriptors(ctx, blockSize, init, func(descriptors ...roachpb.RangeDescriptor) error {
-			numDescs += len(descriptors)
-			return nil
-		}); err != nil {
-			t.Fatal(err)
-		}
+			c := nodelivenesstest.New(numNodes)
+			h := migrationcluster.New(migrationcluster.ClusterConfig{
+				NodeLiveness: c,
+				Dialer:       migrationcluster.NoopDialer{},
+				DB:           kvDB,
+			})
 
-		if numDescs != numRanges {
-			t.Fatalf("expected to find %d ranges, found %d", numRanges+1, numDescs)
-		}
+			for _, blockSize := range []int{1, 5, 10, 50} {
+				var numDescs int
+				init := func() { numDescs = 0 }
+				if err := h.IterateRangeDescriptors(ctx, blockSize, init, func(descriptors ...roachpb.RangeDescriptor) error {
+					numDescs += len(descriptors)
+					return nil
+				}); err != nil {
+					t.Fatal(err)
+				}
+
+				if numDescs != numRanges {
+					t.Fatalf("expected to find %d ranges, found %d", numRanges, numDescs)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
The long-running migrations infrastructure exposes an
`IterateRangeDescriptors` interface to paginate through all the ranges
in the system. It was previously doing this (erroneously) by scanning
through the meta2 range. It was thus possible to entirely miss
descriptors for the meta ranges themselves. This could only happen for
large enough clusters with splits in the meta range. This issue was
caught during the careful review of #66445.

We remedy the situation by scanning over the entire `[MetaMin, MetaMax)`
span instead. One thing to take care of is the possibility of finding
the same range descriptor in both the `meta1` and `meta2` range. This is
possible when the first range in the system includes part of the user
keyspace (typically `[/Min, /System/NodeLiveness)`). We de-dup these
descriptors away by maintaining an in-memory map of the range IDs seen
in meta1.

---

What does this mean for existing long running migrations? There was only
one that made use of this descriptor iteration API: the truncated state
migration. Fortunately that migration was a below-raft one, so as part
of it we purged all extant ranges that hadn't seen the corresponding
`Migrate` command (see `postTruncatedStateMigration` and
`PurgeOutdatedReplicas`; the purge attempt reaches out to every store
and ensures every replica has been migrated, and if not, has been GC-ed).

If we had found unmigrated ranges (possible for the meta ranges as
described above), the migration would be blocked. We haven't seen this
happen with users running 21.1, which makes sense since this bug is only
possible in clusters with enough ranges to necessitate a split in the
meta range (very unlikely with our large default range size of 512 MB).

Still, we'll backport this PR to 21.1. Should users run into this
stalled migration, we'll recommend upgrading to whatever patch release
this will be part of.

Release note: None