### PR TITLE
opt: fix infinite loop in ColumnStatistics.Less

### DIFF
--- a/pkg/sql/opt/props/BUILD.bazel
+++ b/pkg/sql/opt/props/BUILD.bazel
@@ -44,6 +44,7 @@ go_test(
         "multiplicity_test.go",
         "ordering_choice_test.go",
         "selectivity_test.go",
+        "statistics_test.go",
         "volatility_test.go",
     ],
     embed = [":props"],

--- a/pkg/sql/opt/props/statistics.go
+++ b/pkg/sql/opt/props/statistics.go
@@ -229,14 +229,14 @@ func (c ColumnStatistics) Less(i, j int) bool {
 
 	prev := opt.ColumnID(0)
 	for {
-		nextI, ok := c[i].Cols.Next(prev)
+		nextI, ok := c[i].Cols.Next(prev + 1)
 		if !ok {
 			return false
 		}
 
 		// No need to check if ok since both ColSets are the same length and
 		// so far have had the same elements.
-		nextJ, _ := c[j].Cols.Next(prev)
+		nextJ, _ := c[j].Cols.Next(prev + 1)
 
 		if nextI != nextJ {
 			return nextI < nextJ

--- a/pkg/sql/opt/props/statistics_test.go
+++ b/pkg/sql/opt/props/statistics_test.go
@@ -1,0 +1,66 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package props
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+)
+
+func TestColumnStatisticsSort(t *testing.T) {
+	type testCase struct {
+		input    ColumnStatistics
+		expected string
+	}
+	testCases := []testCase{
+		{
+			input: ColumnStatistics{
+				{Cols: opt.MakeColSet(3)},
+				{Cols: opt.MakeColSet(1)},
+				{Cols: opt.MakeColSet(5)},
+			},
+			expected: "(1) (3) (5)",
+		},
+		{
+			input: ColumnStatistics{
+				{Cols: opt.MakeColSet(1, 3)},
+				{Cols: opt.MakeColSet(1, 5)},
+			},
+			expected: "(1,3) (1,5)",
+		},
+		{
+			input: ColumnStatistics{
+				{Cols: opt.MakeColSet(3)},
+				{Cols: opt.MakeColSet(1, 7)},
+				{Cols: opt.MakeColSet(5)},
+				{Cols: opt.MakeColSet(1, 3)},
+				{Cols: opt.MakeColSet(1, 4, 6)},
+				{Cols: opt.MakeColSet(1, 4, 7)},
+			},
+			expected: "(3) (5) (1,3) (1,7) (1,4,6) (1,4,7)",
+		},
+	}
+
+	for _, tc := range testCases {
+		sort.Sort(tc.input)
+		var cols []string
+		for i := 0; i < len(tc.input); i++ {
+			cols = append(cols, tc.input[i].Cols.String())
+		}
+		result := strings.Join(cols, " ")
+		if result != tc.expected {
+			t.Errorf("expected %q, got %q", tc.expected, result)
+		}
+	}
+}


### PR DESCRIPTION
Previously, `EXPLAIN (OPT)` could hang forever on some queries because
of an infinite loop in `ColumnStatistics.Less`. The column statistics
are sorted for display, which can induce this infinite loop.

This bug has been present in the code for years, but it was only
encountered recently because #64976 made it possible for relational
expression statistics to contain column statistics with overlapping
columns.

Fixes #67041

There is no release note because this bug is not present in any previous
releases.

Release note: None