### PR TITLE
storage: improve performance of pebble file registry

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -125,6 +125,7 @@
 /pkg/ccl/cmdccl/stub-schema-registry/ @cockroachdb/cdc-prs
 /pkg/ccl/gssapiccl/          @cockroachdb/sql-queries
 /pkg/ccl/kvccl/              @cockroachdb/kv-noreview
+/pkg/ccl/migrationccl/       @cockroachdb/kv-prs
 /pkg/ccl/logictestccl/       @cockroachdb/sql-queries-noreview
 /pkg/ccl/multiregionccl/     @cockroachdb/multiregion
 /pkg/ccl/multitenantccl/     @cockroachdb/unowned

--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -152,4 +152,4 @@ trace.datadog.project	string	CockroachDB	the project under which traces will be 
 trace.debug.enable	boolean	false	if set, traces for recent requests can be seen at https://<ui>/debug/requests
 trace.lightstep.token	string		if set, traces go to Lightstep using this token
 trace.zipkin.collector	string		if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'). Only one tracer can be configured at a time.
-version	version	21.1-132	set the active cluster version in the format '<major>.<minor>'
+version	version	21.1-134	set the active cluster version in the format '<major>.<minor>'

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -156,6 +156,6 @@
 <tr><td><code>trace.debug.enable</code></td><td>boolean</td><td><code>false</code></td><td>if set, traces for recent requests can be seen at https://<ui>/debug/requests</td></tr>
 <tr><td><code>trace.lightstep.token</code></td><td>string</td><td><code></code></td><td>if set, traces go to Lightstep using this token</td></tr>
 <tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'). Only one tracer can be configured at a time.</td></tr>
-<tr><td><code>version</code></td><td>version</td><td><code>21.1-132</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
+<tr><td><code>version</code></td><td>version</td><td><code>21.1-134</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
 </tbody>
 </table>

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -23,6 +23,7 @@ ALL_TESTS = [
     "//pkg/ccl/kvccl/kvfollowerreadsccl:kvfollowerreadsccl_test",
     "//pkg/ccl/kvccl/kvtenantccl:kvtenantccl_test",
     "//pkg/ccl/logictestccl:logictestccl_test",
+    "//pkg/ccl/migrationccl/migrationsccl:migrationsccl_test",
     "//pkg/ccl/multiregionccl:multiregionccl_test",
     "//pkg/ccl/multitenantccl/tenantcostclient:tenantcostclient_test",
     "//pkg/ccl/multitenantccl/tenantcostserver:tenantcostserver_test",

--- a/pkg/ccl/migrationccl/migrationsccl/BUILD.bazel
+++ b/pkg/ccl/migrationccl/migrationsccl/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "migrationsccl_test",
+    srcs = [
+        "main_test.go",
+        "records_based_registry_external_test.go",
+    ],
+    deps = [
+        "//pkg/base",
+        "//pkg/ccl/baseccl",
+        "//pkg/clusterversion",
+        "//pkg/security",
+        "//pkg/security/securitytest",
+        "//pkg/server",
+        "//pkg/testutils/serverutils",
+        "//pkg/testutils/sqlutils",
+        "//pkg/testutils/testcluster",
+        "//pkg/util/leaktest",
+        "//pkg/util/protoutil",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/ccl/migrationccl/migrationsccl/main_test.go
+++ b/pkg/ccl/migrationccl/migrationsccl/main_test.go
@@ -1,0 +1,27 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package migrationsccl_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+)
+
+func TestMain(m *testing.M) {
+	security.SetAssetLoader(securitytest.EmbeddedAssets)
+	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
+	os.Exit(m.Run())
+}

--- a/pkg/ccl/migrationccl/migrationsccl/records_based_registry_external_test.go
+++ b/pkg/ccl/migrationccl/migrationsccl/records_based_registry_external_test.go
@@ -1,0 +1,145 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package migrationsccl_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/ccl/baseccl"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecordsBasedRegistryMigration(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	const (
+		stickyEngineId = "engine1"
+		key128         = "111111111111111111111111111111111234567890123456"
+		keyFile128     = "a.key"
+	)
+
+	type encryptionTiming bool
+	const (
+		beforeMigration encryptionTiming = false
+		afterMigration  encryptionTiming = true
+	)
+
+	testCases := []struct {
+		name                string
+		encryptionStartTime encryptionTiming
+	}{
+		{
+			name:                "enable-encryption-before-migration",
+			encryptionStartTime: beforeMigration,
+		},
+		{
+			name:                "enable-encryption-after-migration",
+			encryptionStartTime: afterMigration,
+		},
+	}
+
+	for _, c := range testCases {
+		ctx := context.Background()
+		registry := server.NewStickyInMemEnginesRegistry()
+
+		storeSpec := base.DefaultTestStoreSpec
+		storeSpec.StickyInMemoryEngineID = stickyEngineId
+
+		clusterArgs := base.TestClusterArgs{
+			ServerArgs: base.TestServerArgs{
+				Knobs: base.TestingKnobs{
+					Server: &server.TestingKnobs{
+						DisableAutomaticVersionUpgrade: 1,
+						BinaryVersionOverride:          clusterversion.ByKey(clusterversion.RecordsBasedRegistry - 1),
+						StickyEngineRegistry:           registry,
+					},
+				},
+				StoreSpecs: []base.StoreSpec{storeSpec},
+			},
+		}
+
+		// Start and stop the cluster in order to create a sticky engine.
+		tc := testcluster.StartTestCluster(t, 1 /* nodes */, clusterArgs)
+		if c.encryptionStartTime == afterMigration {
+			tdb := sqlutils.MakeSQLRunner(tc.ServerConn(0))
+			tdb.Exec(t, `SET CLUSTER SETTING version = $1`,
+				clusterversion.ByKey(clusterversion.RecordsBasedRegistry).String())
+		}
+		tc.Stopper().Stop(ctx)
+
+		// Write the keyfile to the sticky engine's underlying FS.
+		memFS, err := registry.GetUnderlyingFS(storeSpec)
+		require.NoError(t, err)
+		f, err := memFS.Create(keyFile128)
+		require.NoError(t, err)
+		_, err = f.Write([]byte(key128))
+		require.NoError(t, err)
+
+		// Add the keyfile details to the store spec.
+		encOpts := &baseccl.EncryptionOptions{
+			KeySource: baseccl.EncryptionKeySource_KeyFiles,
+			KeyFiles: &baseccl.EncryptionKeyFiles{
+				OldKey:     "plain",
+				CurrentKey: keyFile128,
+			},
+			DataKeyRotationPeriod: 1000,
+		}
+		b, err := protoutil.Marshal(encOpts)
+		require.NoError(t, err)
+		storeSpec.EncryptionOptions = b
+		storeSpec.UseFileRegistry = true
+
+		// Restart the cluster with encryption-at-rest turned on.
+		clusterArgs.ServerArgs.StoreSpecs = []base.StoreSpec{storeSpec}
+		tc = testcluster.StartTestCluster(t, 1 /* nodes */, clusterArgs)
+
+		// Create a SQL table, write some rows, and start migration.
+		tdb := sqlutils.MakeSQLRunner(tc.ServerConn(0))
+		tdb.Exec(t, `CREATE TABLE test (id int, abc string)`)
+		tdb.Exec(t, `INSERT INTO test ( VALUES (1, 'hi'), (2, 'bye'))`)
+		if c.encryptionStartTime == beforeMigration {
+			tdb.Exec(t, `SET CLUSTER SETTING version = $1`,
+				clusterversion.ByKey(clusterversion.RecordsBasedRegistry).String())
+		}
+
+		// Check that all engines are using the new records based registry and verify
+		// that we can still retrieve the rows from the table.
+		svr := tc.Server(0)
+		for _, eng := range svr.Engines() {
+			target := clusterversion.ByKey(clusterversion.RecordsBasedRegistry)
+			ok, err := eng.MinVersionIsAtLeastTargetVersion(&target)
+			require.NoError(t, err)
+			require.True(t, ok)
+			ok, err = eng.UsingRecordsEncryptionRegistry()
+			require.NoError(t, err)
+			require.True(t, ok)
+		}
+		tdb.Exec(t, `SELECT * FROM test`)
+		tc.Stopper().Stop(ctx)
+
+		// Restart the cluster to ensure there are no problems with loading the new
+		// records based registries.
+		tc = testcluster.StartTestCluster(t, 1 /* nodes */, clusterArgs)
+		tdb = sqlutils.MakeSQLRunner(tc.ServerConn(0))
+		tdb.Exec(t, `SELECT * FROM test`)
+		tc.Stopper().Stop(ctx)
+
+		// NB: We cannot defer this without leaking resources since a new sticky
+		// engine registry is created in each loop iteration.
+		registry.CloseAllStickyInMemEngines()
+	}
+}

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -282,6 +282,9 @@ const (
 	PostSeparatedIntentsMigration
 	// RetryJobsWithExponentialBackoff retries failed jobs with exponential delays.
 	RetryJobsWithExponentialBackoff
+	// RecordsBasedRegistry replaces the existing monolithic protobuf-based
+	// encryption-at-rest file registry with the new incremental records-based registry.
+	RecordsBasedRegistry
 
 	// Step (1): Add new versions here.
 )
@@ -466,6 +469,10 @@ var versionsSingleton = keyedVersions{
 	{
 		Key:     RetryJobsWithExponentialBackoff,
 		Version: roachpb.Version{Major: 21, Minor: 1, Internal: 132},
+	},
+	{
+		Key:     RecordsBasedRegistry,
+		Version: roachpb.Version{Major: 21, Minor: 1, Internal: 134},
 	},
 
 	// Step (2): Add new versions here.

--- a/pkg/clusterversion/key_string.go
+++ b/pkg/clusterversion/key_string.go
@@ -45,11 +45,12 @@ func _() {
 	_ = x[SeparatedIntentsMigration-34]
 	_ = x[PostSeparatedIntentsMigration-35]
 	_ = x[RetryJobsWithExponentialBackoff-36]
+	_ = x[RecordsBasedRegistry-37]
 }
 
-const _Key_name = "Start20_2NodeMembershipStatusMinPasswordLengthAbortSpanBytesCreateLoginPrivilegeHBAForNonTLSV20_2Start21_1CPutInlineReplicaVersionsreplacedTruncatedAndRangeAppliedStateMigrationreplacedPostTruncatedAndRangeAppliedStateMigrationTruncatedAndRangeAppliedStateMigrationPostTruncatedAndRangeAppliedStateMigrationSeparatedIntentsTracingVerbosityIndependentSemanticsClosedTimestampsRaftTransportPriorReadSummariesNonVotingReplicasV21_1Start21_1PLUSStart21_2JoinTokensTableAcquisitionTypeInLeaseHistorySerializeViewUDTsExpressionIndexesDeleteDeprecatedNamespaceTableDescriptorMigrationFixDescriptorsSQLStatsTableDatabaseRoleSettingsTenantUsageTableSQLInstancesTableNewRetryableRangefeedErrorsAlterSystemWebSessionsCreateIndexesSeparatedIntentsMigrationPostSeparatedIntentsMigrationRetryJobsWithExponentialBackoff"
+const _Key_name = "Start20_2NodeMembershipStatusMinPasswordLengthAbortSpanBytesCreateLoginPrivilegeHBAForNonTLSV20_2Start21_1CPutInlineReplicaVersionsreplacedTruncatedAndRangeAppliedStateMigrationreplacedPostTruncatedAndRangeAppliedStateMigrationTruncatedAndRangeAppliedStateMigrationPostTruncatedAndRangeAppliedStateMigrationSeparatedIntentsTracingVerbosityIndependentSemanticsClosedTimestampsRaftTransportPriorReadSummariesNonVotingReplicasV21_1Start21_1PLUSStart21_2JoinTokensTableAcquisitionTypeInLeaseHistorySerializeViewUDTsExpressionIndexesDeleteDeprecatedNamespaceTableDescriptorMigrationFixDescriptorsSQLStatsTableDatabaseRoleSettingsTenantUsageTableSQLInstancesTableNewRetryableRangefeedErrorsAlterSystemWebSessionsCreateIndexesSeparatedIntentsMigrationPostSeparatedIntentsMigrationRetryJobsWithExponentialBackoffRecordsBasedRegistry"
 
-var _Key_index = [...]uint16{0, 9, 29, 46, 60, 80, 92, 97, 106, 116, 131, 177, 227, 265, 307, 323, 359, 388, 406, 423, 428, 441, 450, 465, 494, 511, 528, 577, 591, 604, 624, 640, 657, 684, 719, 744, 773, 804}
+var _Key_index = [...]uint16{0, 9, 29, 46, 60, 80, 92, 97, 106, 116, 131, 177, 227, 265, 307, 323, 359, 388, 406, 423, 428, 441, 450, 465, 494, 511, 528, 577, 591, 604, 624, 640, 657, 684, 719, 744, 773, 804, 824}
 
 func (i Key) String() string {
 	if i < 0 || i >= Key(len(_Key_index)-1) {

--- a/pkg/migration/migrations/BUILD.bazel
+++ b/pkg/migration/migrations/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "fix_descriptor_migration.go",
         "join_tokens.go",
         "migrations.go",
+        "records_based_registry.go",
         "retry_jobs_with_exponential_backoff.go",
         "separated_intents.go",
         "sql_instances.go",

--- a/pkg/migration/migrations/migrations.go
+++ b/pkg/migration/migrations/migrations.go
@@ -49,6 +49,11 @@ var migrations = []migration.Migration{
 		toCV(clusterversion.PostTruncatedAndRangeAppliedStateMigration),
 		postTruncatedStateMigration,
 	),
+	migration.NewSystemMigration(
+		"stop using monolithic encryption-at-rest registry for all stores",
+		toCV(clusterversion.RecordsBasedRegistry),
+		recordsBasedRegistryMigration,
+	),
 	migration.NewTenantMigration(
 		"add the systems.join_tokens table",
 		toCV(clusterversion.JoinTokensTable),

--- a/pkg/migration/migrations/records_based_registry.go
+++ b/pkg/migration/migrations/records_based_registry.go
@@ -1,0 +1,29 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package migrations
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/migration"
+	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+)
+
+func recordsBasedRegistryMigration(
+	ctx context.Context, cv clusterversion.ClusterVersion, deps migration.SystemDeps,
+) error {
+	return deps.Cluster.ForEveryNode(ctx, "deprecate-base-encryption-registry", func(ctx context.Context, client serverpb.MigrationClient) error {
+		req := &serverpb.DeprecateBaseEncryptionRegistryRequest{Version: &cv.Version}
+		_, err := client.DeprecateBaseEncryptionRegistry(ctx, req)
+		return err
+	})
+}

--- a/pkg/server/serverpb/migration.pb.go
+++ b/pkg/server/serverpb/migration.pb.go
@@ -301,6 +301,79 @@ func (m *SyncAllEnginesResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_SyncAllEnginesResponse proto.InternalMessageInfo
 
+// DeprecateBaseEncryptionRegistryRequest is used to instruct the target node
+// to stop using the Base version monolithic encryption-at-rest registry.
+type DeprecateBaseEncryptionRegistryRequest struct {
+	Version *roachpb.Version `protobuf:"bytes,1,opt,name=version,proto3" json:"version,omitempty"`
+}
+
+func (m *DeprecateBaseEncryptionRegistryRequest) Reset() {
+	*m = DeprecateBaseEncryptionRegistryRequest{}
+}
+func (m *DeprecateBaseEncryptionRegistryRequest) String() string { return proto.CompactTextString(m) }
+func (*DeprecateBaseEncryptionRegistryRequest) ProtoMessage()    {}
+func (*DeprecateBaseEncryptionRegistryRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_031978814d391068, []int{8}
+}
+func (m *DeprecateBaseEncryptionRegistryRequest) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *DeprecateBaseEncryptionRegistryRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	b = b[:cap(b)]
+	n, err := m.MarshalToSizedBuffer(b)
+	if err != nil {
+		return nil, err
+	}
+	return b[:n], nil
+}
+func (m *DeprecateBaseEncryptionRegistryRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_DeprecateBaseEncryptionRegistryRequest.Merge(m, src)
+}
+func (m *DeprecateBaseEncryptionRegistryRequest) XXX_Size() int {
+	return m.Size()
+}
+func (m *DeprecateBaseEncryptionRegistryRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_DeprecateBaseEncryptionRegistryRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_DeprecateBaseEncryptionRegistryRequest proto.InternalMessageInfo
+
+// DeprecateBaseEncryptionRegistryResponse is the response to a
+// DeprecateBaseEncryptionRegistryRequest.
+type DeprecateBaseEncryptionRegistryResponse struct {
+}
+
+func (m *DeprecateBaseEncryptionRegistryResponse) Reset() {
+	*m = DeprecateBaseEncryptionRegistryResponse{}
+}
+func (m *DeprecateBaseEncryptionRegistryResponse) String() string { return proto.CompactTextString(m) }
+func (*DeprecateBaseEncryptionRegistryResponse) ProtoMessage()    {}
+func (*DeprecateBaseEncryptionRegistryResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_031978814d391068, []int{9}
+}
+func (m *DeprecateBaseEncryptionRegistryResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *DeprecateBaseEncryptionRegistryResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	b = b[:cap(b)]
+	n, err := m.MarshalToSizedBuffer(b)
+	if err != nil {
+		return nil, err
+	}
+	return b[:n], nil
+}
+func (m *DeprecateBaseEncryptionRegistryResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_DeprecateBaseEncryptionRegistryResponse.Merge(m, src)
+}
+func (m *DeprecateBaseEncryptionRegistryResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *DeprecateBaseEncryptionRegistryResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_DeprecateBaseEncryptionRegistryResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_DeprecateBaseEncryptionRegistryResponse proto.InternalMessageInfo
+
 func init() {
 	proto.RegisterType((*ValidateTargetClusterVersionRequest)(nil), "cockroach.server.serverpb.ValidateTargetClusterVersionRequest")
 	proto.RegisterType((*ValidateTargetClusterVersionResponse)(nil), "cockroach.server.serverpb.ValidateTargetClusterVersionResponse")
@@ -310,38 +383,44 @@ func init() {
 	proto.RegisterType((*PurgeOutdatedReplicasResponse)(nil), "cockroach.server.serverpb.PurgeOutdatedReplicasResponse")
 	proto.RegisterType((*SyncAllEnginesRequest)(nil), "cockroach.server.serverpb.SyncAllEnginesRequest")
 	proto.RegisterType((*SyncAllEnginesResponse)(nil), "cockroach.server.serverpb.SyncAllEnginesResponse")
+	proto.RegisterType((*DeprecateBaseEncryptionRegistryRequest)(nil), "cockroach.server.serverpb.DeprecateBaseEncryptionRegistryRequest")
+	proto.RegisterType((*DeprecateBaseEncryptionRegistryResponse)(nil), "cockroach.server.serverpb.DeprecateBaseEncryptionRegistryResponse")
 }
 
 func init() { proto.RegisterFile("server/serverpb/migration.proto", fileDescriptor_031978814d391068) }
 
 var fileDescriptor_031978814d391068 = []byte{
-	// 409 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0x2f, 0x4e, 0x2d, 0x2a,
-	0x4b, 0x2d, 0xd2, 0x87, 0x50, 0x05, 0x49, 0xfa, 0xb9, 0x99, 0xe9, 0x45, 0x89, 0x25, 0x99, 0xf9,
-	0x79, 0x7a, 0x05, 0x45, 0xf9, 0x25, 0xf9, 0x42, 0x92, 0xc9, 0xf9, 0xc9, 0xd9, 0x45, 0xf9, 0x89,
-	0xc9, 0x19, 0x7a, 0x10, 0x35, 0x7a, 0x30, 0xa5, 0x52, 0x2a, 0xc9, 0x39, 0xa5, 0xc5, 0x25, 0x60,
-	0x5e, 0x71, 0x66, 0x7e, 0x9e, 0x3e, 0x94, 0x1b, 0x0f, 0xe5, 0x43, 0x0c, 0x90, 0x12, 0x03, 0x6b,
-	0x06, 0x99, 0x9c, 0x5a, 0x92, 0x98, 0x92, 0x58, 0x92, 0x08, 0x11, 0x57, 0xaa, 0xe0, 0x52, 0x0e,
-	0x4b, 0xcc, 0xc9, 0x4c, 0x49, 0x2c, 0x49, 0x0d, 0x49, 0x2c, 0x4a, 0x4f, 0x2d, 0x71, 0x86, 0x68,
-	0x0f, 0x83, 0xe8, 0x0e, 0x4a, 0x2d, 0x2c, 0x4d, 0x2d, 0x2e, 0x11, 0x0a, 0xe4, 0xe2, 0x47, 0x33,
-	0x57, 0x82, 0x51, 0x81, 0x51, 0x83, 0xdb, 0x48, 0x43, 0x0f, 0xe1, 0x32, 0x54, 0x87, 0xe8, 0xa1,
-	0x99, 0xc4, 0x97, 0x8c, 0xc2, 0x57, 0x52, 0xe3, 0x52, 0xc1, 0x6f, 0x73, 0x71, 0x41, 0x7e, 0x5e,
-	0x71, 0xaa, 0x52, 0x1e, 0x97, 0xa4, 0x53, 0x69, 0x6e, 0x01, 0xdd, 0xdc, 0x25, 0xc3, 0x25, 0x85,
-	0xcd, 0x3e, 0xa8, 0x6b, 0x42, 0xb8, 0x64, 0x02, 0x4a, 0x8b, 0xd2, 0x53, 0xfd, 0x4b, 0x4b, 0x40,
-	0x2e, 0x4f, 0x09, 0x4a, 0x2d, 0xc8, 0xc9, 0x4c, 0x4e, 0x2c, 0x86, 0x39, 0xc8, 0x84, 0x8b, 0x1d,
-	0xd5, 0x21, 0x52, 0x48, 0x0e, 0x81, 0xc6, 0x81, 0x1e, 0xcc, 0x50, 0x98, 0x52, 0x25, 0x79, 0x2e,
-	0x59, 0x1c, 0xa6, 0x42, 0xad, 0x15, 0xe7, 0x12, 0x0d, 0xae, 0xcc, 0x4b, 0x76, 0xcc, 0xc9, 0x71,
-	0xcd, 0x4b, 0xcf, 0xcc, 0x4b, 0x85, 0xd9, 0xa7, 0x24, 0xc1, 0x25, 0x86, 0x2e, 0x01, 0xd1, 0x62,
-	0xb4, 0x97, 0x85, 0x8b, 0xd3, 0x17, 0x96, 0x8c, 0x84, 0x16, 0x32, 0x72, 0xc9, 0xe0, 0x0b, 0x6e,
-	0x21, 0x3b, 0x3d, 0x9c, 0x49, 0x4c, 0x8f, 0x88, 0x14, 0x22, 0x65, 0x4f, 0xb6, 0x7e, 0xa8, 0x17,
-	0x19, 0x84, 0x9a, 0x19, 0xb9, 0x84, 0x30, 0x83, 0x5e, 0xc8, 0x04, 0x8f, 0xc9, 0x38, 0x53, 0x86,
-	0x94, 0x29, 0x89, 0xba, 0xe0, 0xae, 0x28, 0xe7, 0xe2, 0x43, 0x0d, 0x51, 0x21, 0x03, 0x3c, 0x46,
-	0x61, 0x8d, 0x15, 0x29, 0x43, 0x12, 0x74, 0xc0, 0x2d, 0xee, 0x61, 0xe4, 0x12, 0xc5, 0x9a, 0x0a,
-	0x84, 0xcc, 0xf1, 0x18, 0x87, 0x2f, 0x35, 0x4a, 0x59, 0x90, 0xae, 0x11, 0xe6, 0x1c, 0x27, 0xad,
-	0x13, 0x0f, 0xe5, 0x18, 0x4e, 0x3c, 0x92, 0x63, 0xbc, 0xf0, 0x48, 0x8e, 0xf1, 0xc6, 0x23, 0x39,
-	0xc6, 0x07, 0x8f, 0xe4, 0x18, 0x27, 0x3c, 0x96, 0x63, 0xb8, 0xf0, 0x58, 0x8e, 0xe1, 0xc6, 0x63,
-	0x39, 0x86, 0x28, 0x0e, 0x98, 0x59, 0x49, 0x6c, 0xe0, 0xc2, 0xc4, 0x18, 0x10, 0x00, 0x00, 0xff,
-	0xff, 0x92, 0x08, 0x96, 0x7d, 0xc8, 0x04, 0x00, 0x00,
+	// 468 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xbc, 0x94, 0x3f, 0x6f, 0xd3, 0x40,
+	0x18, 0xc6, 0x7d, 0x03, 0xff, 0x5e, 0xa4, 0x22, 0x9d, 0xd4, 0xd2, 0x9e, 0xc2, 0x05, 0x99, 0xaa,
+	0x14, 0x86, 0x0b, 0x94, 0x22, 0x98, 0x40, 0x35, 0x74, 0x44, 0x40, 0xa9, 0x3a, 0x30, 0x80, 0xae,
+	0x97, 0x93, 0xb1, 0x70, 0xcf, 0xe6, 0xee, 0x0c, 0x64, 0x66, 0x65, 0xe0, 0x2b, 0xb0, 0xf2, 0x49,
+	0x3a, 0x76, 0xec, 0x08, 0xce, 0xc6, 0xa7, 0x40, 0xb1, 0x7d, 0x01, 0x87, 0xc4, 0x49, 0x88, 0xc4,
+	0x64, 0xbd, 0xf6, 0xfb, 0x3c, 0xef, 0xcf, 0x7e, 0x9f, 0x33, 0xb4, 0x8d, 0xd4, 0xef, 0xa5, 0xee,
+	0x94, 0x97, 0xf4, 0xb0, 0x73, 0x14, 0x85, 0x9a, 0xdb, 0x28, 0x51, 0x2c, 0xd5, 0x89, 0x4d, 0xf0,
+	0x9a, 0x48, 0xc4, 0x5b, 0x9d, 0x70, 0xf1, 0x86, 0x95, 0x3d, 0xcc, 0xb5, 0x92, 0x75, 0x11, 0x67,
+	0xc6, 0x16, 0x95, 0x89, 0x12, 0xd5, 0xa9, 0xca, 0xd7, 0x55, 0x5d, 0x1a, 0x90, 0x95, 0x42, 0x3c,
+	0x70, 0x96, 0x96, 0x77, 0xb9, 0xe5, 0xe5, 0x7d, 0xff, 0x23, 0x5c, 0x3b, 0xe0, 0x71, 0xd4, 0xe5,
+	0x56, 0xee, 0x73, 0x1d, 0x4a, 0xfb, 0xa8, 0x94, 0x1f, 0x94, 0xea, 0x3d, 0xf9, 0x2e, 0x93, 0xc6,
+	0xe2, 0xe7, 0x70, 0x69, 0xc4, 0x77, 0x15, 0x5d, 0x45, 0x9b, 0x17, 0xb7, 0x36, 0xd9, 0x6f, 0xb2,
+	0x3a, 0x08, 0x1b, 0x71, 0x5a, 0x12, 0xb5, 0xda, 0xdf, 0x80, 0xf5, 0xe6, 0xc9, 0x26, 0x4d, 0x94,
+	0x91, 0xbe, 0x82, 0xb5, 0x20, 0x3b, 0x4a, 0xff, 0x1b, 0x57, 0x0b, 0xc8, 0xb8, 0x79, 0x15, 0xcd,
+	0x3e, 0xb4, 0x9e, 0x65, 0x3a, 0x94, 0x4f, 0x33, 0x3b, 0x20, 0xef, 0xee, 0xc9, 0x34, 0x8e, 0x04,
+	0x37, 0x0e, 0x68, 0x1b, 0xce, 0xd5, 0x41, 0xc8, 0x1f, 0x20, 0xd5, 0x0e, 0x98, 0x33, 0x75, 0xad,
+	0x7e, 0x1b, 0xae, 0x4c, 0x70, 0xad, 0xc6, 0x5e, 0x86, 0xe5, 0x17, 0x3d, 0x25, 0x76, 0xe2, 0x78,
+	0x57, 0x85, 0x91, 0x92, 0x6e, 0x9e, 0xbf, 0x0a, 0x2b, 0xa3, 0x0f, 0x2a, 0xc9, 0x2b, 0xd8, 0x78,
+	0x2c, 0x53, 0x2d, 0x05, 0xb7, 0x32, 0xe0, 0x46, 0xee, 0x2a, 0xa1, 0x7b, 0xa9, 0x2d, 0x5e, 0x26,
+	0x8c, 0x8c, 0xd5, 0xbd, 0xc5, 0x98, 0x6f, 0xc0, 0xf5, 0xa9, 0xfe, 0x25, 0xca, 0xd6, 0xcf, 0x33,
+	0x70, 0xe1, 0x89, 0x4b, 0x34, 0xfe, 0x8a, 0xa0, 0xd5, 0xb4, 0x79, 0xfc, 0x80, 0x4d, 0x4c, 0x3b,
+	0x9b, 0x21, 0xac, 0xe4, 0xe1, 0x3f, 0xeb, 0xab, 0x4f, 0xe7, 0xe1, 0x4f, 0x08, 0xf0, 0xdf, 0x29,
+	0xc0, 0xdb, 0x0d, 0xce, 0x13, 0x43, 0x4a, 0xee, 0xce, 0xa9, 0x1a, 0x52, 0x7c, 0x80, 0xa5, 0xfa,
+	0x72, 0xf1, 0xad, 0x06, 0xab, 0xb1, 0x01, 0x21, 0xb7, 0xe7, 0x50, 0x0c, 0x07, 0x7f, 0x46, 0xb0,
+	0x3c, 0x36, 0x90, 0xf8, 0x5e, 0x83, 0x5d, 0xd3, 0xc1, 0x20, 0xf7, 0xe7, 0x17, 0x0e, 0x71, 0xbe,
+	0x21, 0x68, 0x4f, 0xc9, 0x1a, 0xde, 0x69, 0xf0, 0x9f, 0xed, 0x1c, 0x90, 0x60, 0x11, 0x0b, 0x07,
+	0x1b, 0xdc, 0x3c, 0xfe, 0x41, 0xbd, 0xe3, 0x9c, 0xa2, 0x93, 0x9c, 0xa2, 0xd3, 0x9c, 0xa2, 0xef,
+	0x39, 0x45, 0x5f, 0xfa, 0xd4, 0x3b, 0xe9, 0x53, 0xef, 0xb4, 0x4f, 0xbd, 0x97, 0xe7, 0x9d, 0xeb,
+	0xe1, 0xd9, 0xe2, 0x27, 0x7c, 0xe7, 0x57, 0x00, 0x00, 0x00, 0xff, 0xff, 0x76, 0xdf, 0x52, 0x7d,
+	0x00, 0x06, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -376,6 +455,9 @@ type MigrationClient interface {
 	// PurgeOutdatedReplicas is used to instruct the target node to purge all
 	// replicas with a version less than the one provided.
 	PurgeOutdatedReplicas(ctx context.Context, in *PurgeOutdatedReplicasRequest, opts ...grpc.CallOption) (*PurgeOutdatedReplicasResponse, error)
+	// DeprecateBaseRegistry is used to instruct the target node to stop
+	// using the Base version monolithic encryption-at-rest registry.
+	DeprecateBaseEncryptionRegistry(ctx context.Context, in *DeprecateBaseEncryptionRegistryRequest, opts ...grpc.CallOption) (*DeprecateBaseEncryptionRegistryResponse, error)
 }
 
 type migrationClient struct {
@@ -422,6 +504,15 @@ func (c *migrationClient) PurgeOutdatedReplicas(ctx context.Context, in *PurgeOu
 	return out, nil
 }
 
+func (c *migrationClient) DeprecateBaseEncryptionRegistry(ctx context.Context, in *DeprecateBaseEncryptionRegistryRequest, opts ...grpc.CallOption) (*DeprecateBaseEncryptionRegistryResponse, error) {
+	out := new(DeprecateBaseEncryptionRegistryResponse)
+	err := c.cc.Invoke(ctx, "/cockroach.server.serverpb.Migration/DeprecateBaseEncryptionRegistry", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // MigrationServer is the server API for Migration service.
 type MigrationServer interface {
 	// ValidateTargetClusterVersion is used to verify that the target node is
@@ -444,6 +535,9 @@ type MigrationServer interface {
 	// PurgeOutdatedReplicas is used to instruct the target node to purge all
 	// replicas with a version less than the one provided.
 	PurgeOutdatedReplicas(context.Context, *PurgeOutdatedReplicasRequest) (*PurgeOutdatedReplicasResponse, error)
+	// DeprecateBaseRegistry is used to instruct the target node to stop
+	// using the Base version monolithic encryption-at-rest registry.
+	DeprecateBaseEncryptionRegistry(context.Context, *DeprecateBaseEncryptionRegistryRequest) (*DeprecateBaseEncryptionRegistryResponse, error)
 }
 
 // UnimplementedMigrationServer can be embedded to have forward compatible implementations.
@@ -461,6 +555,9 @@ func (*UnimplementedMigrationServer) SyncAllEngines(ctx context.Context, req *Sy
 }
 func (*UnimplementedMigrationServer) PurgeOutdatedReplicas(ctx context.Context, req *PurgeOutdatedReplicasRequest) (*PurgeOutdatedReplicasResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method PurgeOutdatedReplicas not implemented")
+}
+func (*UnimplementedMigrationServer) DeprecateBaseEncryptionRegistry(ctx context.Context, req *DeprecateBaseEncryptionRegistryRequest) (*DeprecateBaseEncryptionRegistryResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeprecateBaseEncryptionRegistry not implemented")
 }
 
 func RegisterMigrationServer(s *grpc.Server, srv MigrationServer) {
@@ -539,6 +636,24 @@ func _Migration_PurgeOutdatedReplicas_Handler(srv interface{}, ctx context.Conte
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Migration_DeprecateBaseEncryptionRegistry_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeprecateBaseEncryptionRegistryRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MigrationServer).DeprecateBaseEncryptionRegistry(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/cockroach.server.serverpb.Migration/DeprecateBaseEncryptionRegistry",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MigrationServer).DeprecateBaseEncryptionRegistry(ctx, req.(*DeprecateBaseEncryptionRegistryRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _Migration_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "cockroach.server.serverpb.Migration",
 	HandlerType: (*MigrationServer)(nil),
@@ -558,6 +673,10 @@ var _Migration_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "PurgeOutdatedReplicas",
 			Handler:    _Migration_PurgeOutdatedReplicas_Handler,
+		},
+		{
+			MethodName: "DeprecateBaseEncryptionRegistry",
+			Handler:    _Migration_DeprecateBaseEncryptionRegistry_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -784,6 +903,64 @@ func (m *SyncAllEnginesResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) 
 	return len(dAtA) - i, nil
 }
 
+func (m *DeprecateBaseEncryptionRegistryRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *DeprecateBaseEncryptionRegistryRequest) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *DeprecateBaseEncryptionRegistryRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.Version != nil {
+		{
+			size, err := m.Version.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintMigration(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *DeprecateBaseEncryptionRegistryResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *DeprecateBaseEncryptionRegistryResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *DeprecateBaseEncryptionRegistryResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintMigration(dAtA []byte, offset int, v uint64) int {
 	offset -= sovMigration(v)
 	base := offset
@@ -871,6 +1048,28 @@ func (m *SyncAllEnginesRequest) Size() (n int) {
 }
 
 func (m *SyncAllEnginesResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	return n
+}
+
+func (m *DeprecateBaseEncryptionRegistryRequest) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Version != nil {
+		l = m.Version.Size()
+		n += 1 + l + sovMigration(uint64(l))
+	}
+	return n
+}
+
+func (m *DeprecateBaseEncryptionRegistryResponse) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -1370,6 +1569,142 @@ func (m *SyncAllEnginesResponse) Unmarshal(dAtA []byte) error {
 		}
 		if fieldNum <= 0 {
 			return fmt.Errorf("proto: SyncAllEnginesResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipMigration(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthMigration
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *DeprecateBaseEncryptionRegistryRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowMigration
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: DeprecateBaseEncryptionRegistryRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: DeprecateBaseEncryptionRegistryRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Version", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowMigration
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthMigration
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthMigration
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Version == nil {
+				m.Version = &roachpb.Version{}
+			}
+			if err := m.Version.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipMigration(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthMigration
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *DeprecateBaseEncryptionRegistryResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowMigration
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: DeprecateBaseEncryptionRegistryResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: DeprecateBaseEncryptionRegistryResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		default:

--- a/pkg/server/serverpb/migration.proto
+++ b/pkg/server/serverpb/migration.proto
@@ -52,6 +52,16 @@ message SyncAllEnginesRequest{}
 // SyncAllEnginesResponse is the response to a SyncAllEnginesRequest.
 message SyncAllEnginesResponse{}
 
+// DeprecateBaseEncryptionRegistryRequest is used to instruct the target node
+// to stop using the Base version monolithic encryption-at-rest registry.
+message DeprecateBaseEncryptionRegistryRequest {
+  roachpb.Version version = 1;
+}
+
+// DeprecateBaseEncryptionRegistryResponse is the response to a
+// DeprecateBaseEncryptionRegistryRequest.
+message DeprecateBaseEncryptionRegistryResponse{}
+
 service Migration {
    // ValidateTargetClusterVersion is used to verify that the target node is
    // running a binary that's able to support the specified cluster version.
@@ -76,4 +86,8 @@ service Migration {
    // PurgeOutdatedReplicas is used to instruct the target node to purge all
    // replicas with a version less than the one provided.
    rpc PurgeOutdatedReplicas (PurgeOutdatedReplicasRequest) returns (PurgeOutdatedReplicasResponse) { }
+
+   // DeprecateBaseRegistry is used to instruct the target node to stop
+   // using the Base version monolithic encryption-at-rest registry.
+   rpc DeprecateBaseEncryptionRegistry (DeprecateBaseEncryptionRegistryRequest) returns (DeprecateBaseEncryptionRegistryResponse) { }
 }

--- a/pkg/storage/BUILD.bazel
+++ b/pkg/storage/BUILD.bazel
@@ -41,6 +41,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/base",
+        "//pkg/clusterversion",
         "//pkg/keys",
         "//pkg/kv/kvserver/concurrency/lock",
         "//pkg/kv/kvserver/diskmap",
@@ -70,6 +71,7 @@ go_library(
         "@com_github_cockroachdb_logtags//:logtags",
         "@com_github_cockroachdb_pebble//:pebble",
         "@com_github_cockroachdb_pebble//bloom",
+        "@com_github_cockroachdb_pebble//record",
         "@com_github_cockroachdb_pebble//sstable",
         "@com_github_cockroachdb_pebble//vfs",
         "@com_github_cockroachdb_redact//:redact",

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -788,6 +788,18 @@ type Engine interface {
 	// that know that this enabled setting is not changing and need the value to
 	// adjust their expectations.
 	IsSeparatedIntentsEnabledForTesting(ctx context.Context) bool
+
+	// DeprecateBaseEncryptionRegistry is used to signal to the engine that it
+	// should stop using the Base version monolithic encryption-at-rest registry.
+	DeprecateBaseEncryptionRegistry(version *roachpb.Version) error
+
+	// UsingRecordsEncryptionRegistry returns whether the engine is using the
+	// Records version incremental encryption-at-rest registry.
+	UsingRecordsEncryptionRegistry() (bool, error)
+
+	// MinVersionIsAtLeastTargetVersion returns whether the engine's recorded
+	// storage min version is at least the target version.
+	MinVersionIsAtLeastTargetVersion(target *roachpb.Version) (bool, error)
 }
 
 // Batch is the interface for batch specific operations.

--- a/pkg/storage/enginepb/BUILD.bazel
+++ b/pkg/storage/enginepb/BUILD.bazel
@@ -37,6 +37,7 @@ go_library(
     srcs = [
         "decode.go",
         "engine.go",
+        "file_registry.go",
         "mvcc.go",
         "mvcc3.go",
     ],

--- a/pkg/storage/enginepb/file_registry.go
+++ b/pkg/storage/enginepb/file_registry.go
@@ -1,0 +1,56 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package enginepb
+
+// ProcessBatch processes a batch of updates to the file registry.
+func (r *FileRegistry) ProcessBatch(batch *RegistryUpdateBatch) {
+	for _, update := range batch.Updates {
+		r.ProcessUpdate(update)
+	}
+}
+
+// ProcessUpdate processes a single update to the file registry.
+func (r *FileRegistry) ProcessUpdate(update *RegistryUpdate) {
+	if update.Entry == nil {
+		delete(r.Files, update.Filename)
+	} else {
+		if r.Files == nil {
+			r.Files = make(map[string]*FileEntry)
+		}
+		r.Files[update.Filename] = update.Entry
+	}
+}
+
+// SetVersion updates the version of the file registry. This function will
+// panic if the provided version is lower than the current version.
+func (r *FileRegistry) SetVersion(version RegistryVersion) {
+	if version < r.Version {
+		panic("illegal downgrade of file registry version")
+	}
+	r.Version = version
+}
+
+// Empty returns whether a batch is empty.
+func (b *RegistryUpdateBatch) Empty() bool {
+	return len(b.Updates) == 0
+}
+
+// PutEntry adds an update to the batch corresponding to the addition of a new
+// file entry to the registry. The entry should not be nil.
+func (b *RegistryUpdateBatch) PutEntry(filename string, entry *FileEntry) {
+	b.Updates = append(b.Updates, &RegistryUpdate{Filename: filename, Entry: entry})
+}
+
+// DeleteEntry adds an update to the batch corresponding to the deletion of a
+// file entry from the registry.
+func (b *RegistryUpdateBatch) DeleteEntry(filename string) {
+	b.Updates = append(b.Updates, &RegistryUpdate{Filename: filename, Entry: nil})
+}

--- a/pkg/storage/enginepb/file_registry.proto
+++ b/pkg/storage/enginepb/file_registry.proto
@@ -14,9 +14,18 @@ option go_package = "enginepb";
 
 import "gogoproto/gogo.proto";
 
+// RegistryVersion defines the version of a registry. Newly added versions
+// should be larger than all currently and previously existing versions.
 enum RegistryVersion {
-  // The only version so far.
+  // The initial version of the file registry that wrote a marshaled
+  // FileRegistry proto to the COCKROACHDB_REGISTRY file on disk every time
+  // it was updated.
+  // TODO(ayang): replace with "reserved 0;" when we deprecate the old registry
   Base = 0;
+  // The current version of the file registry that writes incremental
+  // updates to the COCKROACHDB_ENCRYPTION_REGISTRY file on disk using
+  // pebble's record writer.
+  Records = 1;
 }
 
 // EnvType determines which rocksdb::Env is used and for what purpose.
@@ -35,7 +44,7 @@ enum EnvType {
 // Registry describes how a files are handled. This includes the
 // rockdb::Env responsible for each file as well as opaque env details.
 message FileRegistry {
-  // version is currently always Base.
+  // The version of the file registry.
   RegistryVersion version = 1;
   // Map of filename -> FileEntry.
   // Filename is relative to the rocksdb dir if the file is inside it.
@@ -52,4 +61,22 @@ message FileEntry {
   // This is a serialized protobuf. We cannot use protobuf.Any since we use
   // MessageLite in C++.
   bytes encryption_settings = 2;
+}
+
+message RegistryHeader {
+  // The version of the file registry.
+  RegistryVersion version = 1;
+}
+
+message RegistryUpdateBatch {
+  // An ordered list of updates to the registry.
+  repeated RegistryUpdate updates = 1;
+}
+
+message RegistryUpdate {
+  // Name of the file.
+  string filename = 1;
+
+  // Corresponding file entry. A nil entry indicates a file was deleted.
+  FileEntry entry = 2;
 }

--- a/pkg/storage/file_util.go
+++ b/pkg/storage/file_util.go
@@ -17,11 +17,13 @@ import (
 	"github.com/cockroachdb/pebble/vfs"
 )
 
+const tempFileExtension = ".crdbtmp"
+
 // SafeWriteToFile writes the byte slice to the filename, contained in dir,
 // using the given fs.  It returns after both the file and the containing
 // directory are synced.
 func SafeWriteToFile(fs vfs.FS, dir string, filename string, b []byte) error {
-	tempName := filename + ".crdbtmp"
+	tempName := filename + tempFileExtension
 	f, err := fs.Create(tempName)
 	if err != nil {
 		return err

--- a/pkg/storage/pebble_file_registry.go
+++ b/pkg/storage/pebble_file_registry.go
@@ -11,16 +11,19 @@
 package storage
 
 import (
-	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/oserror"
+	"github.com/cockroachdb/pebble/record"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/gogo/protobuf/proto"
 )
@@ -29,12 +32,19 @@ import (
 // elided instead of being written to the registry.
 var CanRegistryElideFunc func(entry *enginepb.FileEntry) bool
 
+const maxRegistrySize = 128 << 20 // 128 MB
+
 // PebbleFileRegistry keeps track of files for the data-FS and store-FS for Pebble (see encrypted_fs.go
 // for high-level comment).
 //
 // It is created even when file registry is disabled, so that it can be used to ensure that
 // a registry file did not exist previously, since that would indicate that disabling the registry
 // can cause data loss.
+//
+// The records-based registry file written to disk contains a sequence
+// of records: a marshaled enginepb.RegistryHeader byte slice followed by
+// marshaled enginepb.RegistryUpdateBatch byte slices that correspond to a
+// batch of updates to the file registry. The updates are replayed in Load.
 type PebbleFileRegistry struct {
 	// Initialize the following before calling Load().
 
@@ -51,24 +61,58 @@ type PebbleFileRegistry struct {
 	ReadOnly bool
 
 	// Implementation.
-	registryFilename string
+	// TODO(ayang): remove oldRegistryPath when we deprecate the old registry
+	oldRegistryPath string
+	registryPath    string
 
 	mu struct {
 		syncutil.Mutex
+		// currProto stores the current state of the file registry.
+		// TODO(ayang): convert enginepb.FileRegistry to a regular struct
+		// when we deprecate the old registry and rename currProto
 		currProto *enginepb.FileRegistry
+		// registryFile is the opened file for the records-based registry.
+		registryFile vfs.File
+		// registryWriter is a record.Writer for registryFile.
+		registryWriter *record.Writer
 	}
 }
 
 const (
-	fileRegistryFilename = "COCKROACHDB_REGISTRY"
+	// TODO(ayang): mark COCKROACHDB_REGISTRY as deprecated so it isn't reused
+	oldRegistryFilename = "COCKROACHDB_REGISTRY"
+	registryFilename    = "COCKROACHDB_ENCRYPTION_REGISTRY"
 )
 
 // CheckNoRegistryFile checks that no registry file currently exists.
 // CheckNoRegistryFile should be called if the file registry will not be used.
 func (r *PebbleFileRegistry) CheckNoRegistryFile() error {
-	// NB: We do not assign r.registryFilename if the registry will not be used.
-	registryFilename := r.FS.PathJoin(r.DBDir, fileRegistryFilename)
-	_, err := r.FS.Stat(registryFilename)
+	if err := r.checkNoBaseRegistry(); err != nil {
+		return err
+	}
+	if err := r.checkNoRecordsRegistry(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *PebbleFileRegistry) checkNoBaseRegistry() error {
+	// NB: We do not assign r.oldRegistryPath if the registry will not be used.
+	oldRegistryPath := r.FS.PathJoin(r.DBDir, oldRegistryFilename)
+	_, err := r.FS.Stat(oldRegistryPath)
+	if err == nil {
+		return os.ErrExist
+	}
+	if !oserror.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+func (r *PebbleFileRegistry) checkNoRecordsRegistry() error {
+	// NB: We do not assign r.registryPath if the registry will not be used.
+	registryPath := r.FS.PathJoin(r.DBDir, registryFilename)
+	_, err := r.FS.Stat(registryPath)
 	if err == nil {
 		return os.ErrExist
 	}
@@ -83,40 +127,161 @@ func (r *PebbleFileRegistry) CheckNoRegistryFile() error {
 func (r *PebbleFileRegistry) Load() error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+
+	// Initialize private fields needed when the file registry will be used.
+	r.oldRegistryPath = r.FS.PathJoin(r.DBDir, oldRegistryFilename)
+	r.registryPath = r.FS.PathJoin(r.DBDir, registryFilename)
 	r.mu.currProto = &enginepb.FileRegistry{}
-	r.registryFilename = r.FS.PathJoin(r.DBDir, fileRegistryFilename)
-	f, err := r.FS.Open(r.registryFilename)
-	if oserror.IsNotExist(err) {
-		return nil
-	}
-	if err != nil {
+
+	if err := r.loadRegistryFromFile(); err != nil {
 		return err
 	}
-	defer f.Close()
-	var b []byte
-	if b, err = ioutil.ReadAll(f); err != nil {
-		return err
-	}
-	if err = protoutil.Unmarshal(b, r.mu.currProto); err != nil {
-		return err
-	}
+
 	// Delete all unnecessary entries to reduce registry size.
 	if err := r.maybeElideEntries(); err != nil {
 		return err
 	}
+
 	return nil
 }
 
+func (r *PebbleFileRegistry) loadRegistryFromFile() error {
+	// We treat the old registry file as the source of truth until the version
+	// is finalized. At that point, we upgrade to the new records-based registry
+	// file and delete the old registry file.
+	ok, err := r.maybeLoadOldBaseRegistry()
+	if err != nil {
+		return err
+	}
+	if ok {
+		return nil
+	}
+	ok, err = r.maybeLoadNewRecordsRegistry()
+	if err != nil {
+		return err
+	}
+	if ok {
+		return nil
+	}
+	// If encryption-at-rest was not previously enabled, we check the storage min
+	// version to determine whether we still need to create an old base registry.
+	target := clusterversion.ByKey(clusterversion.RecordsBasedRegistry)
+	ok, err = MinVersionIsAtLeastTargetVersion(r.FS, r.DBDir, &target)
+	if err != nil {
+		return err
+	}
+	if ok {
+		r.mu.currProto.SetVersion(enginepb.RegistryVersion_Records)
+	}
+	return nil
+}
+
+func (r *PebbleFileRegistry) maybeLoadOldBaseRegistry() (bool, error) {
+	f, err := r.FS.Open(r.oldRegistryPath)
+	if oserror.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	var b []byte
+	if b, err = ioutil.ReadAll(f); err != nil {
+		return false, errors.CombineErrors(err, f.Close())
+	}
+	if err := f.Close(); err != nil {
+		return false, err
+	}
+	if err := protoutil.Unmarshal(b, r.mu.currProto); err != nil {
+		return false, err
+	}
+	if r.mu.currProto.Version == enginepb.RegistryVersion_Records {
+		return false, errors.New("old encryption registry with version Records should not exist")
+	}
+	return true, nil
+}
+
+func (r *PebbleFileRegistry) maybeLoadNewRecordsRegistry() (bool, error) {
+	records, err := r.FS.Open(r.registryPath)
+	if oserror.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	// We replay the records written to the registry to populate our in-memory map.
+	rr := record.NewReader(records, 0 /* logNum */)
+	rdr, err := rr.Next()
+	if err == io.EOF {
+		return false, errors.New("pebble new file registry exists but is missing a header")
+	}
+	if err != nil {
+		return false, err
+	}
+	registryHeaderBytes, err := ioutil.ReadAll(rdr)
+	if err != nil {
+		return false, err
+	}
+	registryHeader := &enginepb.RegistryHeader{}
+	if err := protoutil.Unmarshal(registryHeaderBytes, registryHeader); err != nil {
+		return false, err
+	}
+	// Since we only load the new registry if the old registry does not exist,
+	// we should never load a new registry that has version Base.
+	if registryHeader.Version == enginepb.RegistryVersion_Base {
+		return false, errors.New("new encryption registry with version Base should not exist")
+	}
+	r.mu.currProto.SetVersion(registryHeader.Version)
+	for {
+		rdr, err := rr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return false, err
+		}
+		b, err := ioutil.ReadAll(rdr)
+		if err != nil {
+			return false, err
+		}
+		batch := &enginepb.RegistryUpdateBatch{}
+		if err := protoutil.Unmarshal(b, batch); err != nil {
+			return false, err
+		}
+		r.mu.currProto.ProcessBatch(batch)
+	}
+	if err := records.Close(); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// StopUsingOldRegistry is called to signal that the old file registry
+// is no longer needed and can be safely deleted.
+// TODO(ayang): delete this function when we deprecate the old registry
+func (r *PebbleFileRegistry) StopUsingOldRegistry() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.upgradeToRecordsVersion()
+}
+
+// UpgradedToRecordsVersion returns whether the file registry has completed
+// its upgrade to the Records version of the file registry.
+func (r *PebbleFileRegistry) UpgradedToRecordsVersion() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.mu.currProto.Version == enginepb.RegistryVersion_Records
+}
+
 func (r *PebbleFileRegistry) maybeElideEntries() error {
-	newProto := &enginepb.FileRegistry{}
-	proto.Merge(newProto, r.mu.currProto)
-	filesChanged := false
-	for filename, entry := range newProto.Files {
+	if r.ReadOnly {
+		return nil
+	}
+	batch := &enginepb.RegistryUpdateBatch{}
+	for filename, entry := range r.mu.currProto.Files {
 		// Some entries may be elided. This is used within
 		// ccl/storageccl/engineccl to elide plaintext file entries.
 		if CanRegistryElideFunc != nil && CanRegistryElideFunc(entry) {
-			delete(newProto.Files, filename)
-			filesChanged = true
+			batch.DeleteEntry(filename)
 			continue
 		}
 
@@ -131,14 +296,10 @@ func (r *PebbleFileRegistry) maybeElideEntries() error {
 			path = r.FS.PathJoin(r.DBDir, filename)
 		}
 		if _, err := r.FS.Stat(path); oserror.IsNotExist(err) {
-			delete(newProto.Files, filename)
-			filesChanged = true
+			batch.DeleteEntry(filename)
 		}
 	}
-	if filesChanged {
-		return r.writeRegistry(newProto)
-	}
-	return nil
+	return r.processBatchLocked(batch)
 }
 
 // GetFileEntry gets the file entry corresponding to filename, if there is one, else returns nil.
@@ -159,16 +320,12 @@ func (r *PebbleFileRegistry) SetFileEntry(filename string, entry *enginepb.FileE
 	}
 
 	filename = r.tryMakeRelativePath(filename)
-	newProto := &enginepb.FileRegistry{}
 
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	proto.Merge(newProto, r.mu.currProto)
-	if newProto.Files == nil {
-		newProto.Files = make(map[string]*enginepb.FileEntry)
-	}
-	newProto.Files[filename] = entry
-	return r.writeRegistry(newProto)
+	batch := &enginepb.RegistryUpdateBatch{}
+	batch.PutEntry(filename, entry)
+	return r.processBatchLocked(batch)
 }
 
 // MaybeDeleteEntry deletes the entry for filename, if it exists, and persists the registry, if changed.
@@ -180,10 +337,9 @@ func (r *PebbleFileRegistry) MaybeDeleteEntry(filename string) error {
 	if r.mu.currProto.Files[filename] == nil {
 		return nil
 	}
-	newProto := &enginepb.FileRegistry{}
-	proto.Merge(newProto, r.mu.currProto)
-	delete(newProto.Files, filename)
-	return r.writeRegistry(newProto)
+	batch := &enginepb.RegistryUpdateBatch{}
+	batch.DeleteEntry(filename)
+	return r.processBatchLocked(batch)
 }
 
 // MaybeRenameEntry moves the entry under src to dst, if src exists. If src does not exist, but dst
@@ -197,15 +353,14 @@ func (r *PebbleFileRegistry) MaybeRenameEntry(src, dst string) error {
 	if r.mu.currProto.Files[src] == nil && r.mu.currProto.Files[dst] == nil {
 		return nil
 	}
-	newProto := &enginepb.FileRegistry{}
-	proto.Merge(newProto, r.mu.currProto)
-	if newProto.Files[src] == nil {
-		delete(newProto.Files, dst)
+	batch := &enginepb.RegistryUpdateBatch{}
+	if r.mu.currProto.Files[src] == nil {
+		batch.DeleteEntry(dst)
 	} else {
-		newProto.Files[dst] = newProto.Files[src]
-		delete(newProto.Files, src)
+		batch.PutEntry(dst, r.mu.currProto.Files[src])
+		batch.DeleteEntry(src)
 	}
-	return r.writeRegistry(newProto)
+	return r.processBatchLocked(batch)
 }
 
 // MaybeLinkEntry copies the entry under src to dst, if src exists. If src does not exist, but dst
@@ -219,14 +374,13 @@ func (r *PebbleFileRegistry) MaybeLinkEntry(src, dst string) error {
 	if r.mu.currProto.Files[src] == nil && r.mu.currProto.Files[dst] == nil {
 		return nil
 	}
-	newProto := &enginepb.FileRegistry{}
-	proto.Merge(newProto, r.mu.currProto)
-	if newProto.Files[src] == nil {
-		delete(newProto.Files, dst)
+	batch := &enginepb.RegistryUpdateBatch{}
+	if r.mu.currProto.Files[src] == nil {
+		batch.DeleteEntry(dst)
 	} else {
-		newProto.Files[dst] = newProto.Files[src]
+		batch.PutEntry(dst, r.mu.currProto.Files[src])
 	}
-	return r.writeRegistry(newProto)
+	return r.processBatchLocked(batch)
 }
 
 func (r *PebbleFileRegistry) tryMakeRelativePath(filename string) string {
@@ -259,18 +413,162 @@ func (r *PebbleFileRegistry) tryMakeRelativePath(filename string) string {
 	return filename
 }
 
-func (r *PebbleFileRegistry) writeRegistry(newProto *enginepb.FileRegistry) error {
-	if r.ReadOnly {
-		return fmt.Errorf("cannot write file registry since db is read-only")
+// TODO(ayang): delete this function when we deprecate the old registry
+func (r *PebbleFileRegistry) upgradeToRecordsVersion() error {
+	if r.mu.currProto.Version == enginepb.RegistryVersion_Records {
+		return nil
 	}
+	// Create a new registry file to record the upgraded version.
+	r.mu.currProto.SetVersion(enginepb.RegistryVersion_Records)
+	if err := r.createNewRegistryFile(); err != nil {
+		return err
+	}
+	return r.FS.Remove(r.oldRegistryPath)
+}
+
+func (r *PebbleFileRegistry) processBatchLocked(batch *enginepb.RegistryUpdateBatch) error {
+	if r.ReadOnly {
+		return errors.New("cannot write file registry since db is read-only")
+	}
+	if batch.Empty() {
+		return nil
+	}
+	// For durability reasons, we persist the changes to disk first before we
+	// update the in-memory registry. Any error during persisting is fatal.
+	if r.mu.currProto.Version == enginepb.RegistryVersion_Base {
+		newProto := &enginepb.FileRegistry{}
+		proto.Merge(newProto, r.mu.currProto)
+		newProto.ProcessBatch(batch)
+		if err := r.rewriteOldRegistry(newProto); err != nil {
+			panic(err)
+		}
+	}
+	if err := r.writeToRegistryFile(batch); err != nil {
+		panic(err)
+	}
+	r.mu.currProto.ProcessBatch(batch)
+	return nil
+}
+
+// TODO(ayang): delete this function when we deprecate the old registry
+func (r *PebbleFileRegistry) rewriteOldRegistry(newProto *enginepb.FileRegistry) error {
 	b, err := protoutil.Marshal(newProto)
 	if err != nil {
 		return err
 	}
-	if err = SafeWriteToFile(r.FS, r.DBDir, r.registryFilename, b); err != nil {
+	if err := SafeWriteToFile(r.FS, r.DBDir, r.oldRegistryPath, b); err != nil {
 		return err
 	}
-	r.mu.currProto = newProto
+	return nil
+}
+
+func (r *PebbleFileRegistry) writeToRegistryFile(batch *enginepb.RegistryUpdateBatch) error {
+	// Create a new file registry file if one doesn't exist yet.
+	if r.mu.registryWriter == nil {
+		if err := r.createNewRegistryFile(); err != nil {
+			return err
+		}
+	}
+	w, err := r.mu.registryWriter.Next()
+	if err != nil {
+		return err
+	}
+	b, err := protoutil.Marshal(batch)
+	if err != nil {
+		return err
+	}
+	if _, err := w.Write(b); err != nil {
+		return err
+	}
+	if err := r.mu.registryWriter.Flush(); err != nil {
+		return err
+	}
+	if err := r.mu.registryFile.Sync(); err != nil {
+		return err
+	}
+	// Create a new file registry file to hopefully shrink the size of the file
+	// if we have exceeded the max registry size.
+	if r.mu.registryWriter.Size() > maxRegistrySize {
+		if err := r.createNewRegistryFile(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *PebbleFileRegistry) createNewRegistryFile() error {
+	// Create a temporary file for the new registry file.
+	tempPath := r.registryPath + tempFileExtension
+	f, err := r.FS.Create(tempPath)
+	if err != nil {
+		return err
+	}
+	records := record.NewWriter(f)
+	w, err := records.Next()
+	if err != nil {
+		return errors.CombineErrors(err, f.Close())
+	}
+
+	errFunc := func(err error) error {
+		err1 := records.Close()
+		err2 := f.Close()
+		return errors.CombineErrors(err, errors.CombineErrors(err1, err2))
+	}
+
+	// Write the registry header as the first record in the registry file.
+	registryHeader := &enginepb.RegistryHeader{
+		Version: r.mu.currProto.Version,
+	}
+	b, err := protoutil.Marshal(registryHeader)
+	if err != nil {
+		return errFunc(err)
+	}
+	if _, err := w.Write(b); err != nil {
+		return errFunc(err)
+	}
+
+	// Write a RegistryUpdateBatch containing the current state of the registry.
+	batch := &enginepb.RegistryUpdateBatch{}
+	for filename, entry := range r.mu.currProto.Files {
+		batch.PutEntry(filename, entry)
+	}
+	b, err = protoutil.Marshal(batch)
+	if err != nil {
+		return errFunc(err)
+	}
+	w, err = records.Next()
+	if err != nil {
+		return errFunc(err)
+	}
+	if _, err := w.Write(b); err != nil {
+		return errFunc(err)
+	}
+	if err := records.Flush(); err != nil {
+		return errFunc(err)
+	}
+	if err := f.Sync(); err != nil {
+		return errFunc(err)
+	}
+
+	// Close and replace the current registry file with the temporary file.
+	if err := r.closeRegistry(); err != nil {
+		return errFunc(err)
+	}
+	if err := r.FS.Rename(tempPath, r.registryPath); err != nil {
+		return errFunc(err)
+	}
+	fdir, err := r.FS.OpenDir(r.DBDir)
+	if err != nil {
+		return errFunc(err)
+	}
+	if err := fdir.Sync(); err != nil {
+		return errFunc(err)
+	}
+	if err := fdir.Close(); err != nil {
+		return errFunc(err)
+	}
+	r.mu.registryFile = f
+	r.mu.registryWriter = records
 	return nil
 }
 
@@ -280,4 +578,25 @@ func (r *PebbleFileRegistry) getRegistryCopy() *enginepb.FileRegistry {
 	rv := &enginepb.FileRegistry{}
 	proto.Merge(rv, r.mu.currProto)
 	return rv
+}
+
+// Close closes the record writer and record file used for the registry.
+// It should be called when a Pebble instance is closed.
+func (r *PebbleFileRegistry) Close() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.closeRegistry()
+}
+
+func (r *PebbleFileRegistry) closeRegistry() error {
+	var err1, err2 error
+	if r.mu.registryWriter != nil {
+		err1 = r.mu.registryWriter.Close()
+		r.mu.registryWriter = nil
+	}
+	if r.mu.registryFile != nil {
+		err2 = r.mu.registryFile.Close()
+		r.mu.registryFile = nil
+	}
+	return errors.CombineErrors(err1, err2)
 }


### PR DESCRIPTION
This patch changes the pebble file registry used for encryption
from a protobuf-based registry to a records-based registry.
This should lead to a performance improvement since writing a
new entry will only lead to a single record being written
instead of rewriting the entire registry.

Refs: #55967

Release note (performance improvement): The COCKROACHDB_REGISTRY
file used for encryption-at-rest will be replaced with a
COCKROACHDB_ENCRYPTION_REGISTRY, which can be written to in a
more efficient manner.