### PR TITLE
build: add TeamCity build script to stress roachtests

### DIFF
--- a/build/teamcity-nightly-roachtest.sh
+++ b/build/teamcity-nightly-roachtest.sh
@@ -80,8 +80,6 @@ function upload_stats {
 trap upload_stats EXIT
 
 # Set up the parameters for the roachtest invocation.
-
-ARTIFACTS="${artifacts}"
 PARALLELISM=16
 CPUQUOTA=1024
 ZONES=""
@@ -108,22 +106,18 @@ case "${CLOUD}" in
     ;;
 esac
 
-export \
-CLOUD="${CLOUD}" \
-ARTIFACTS="${ARTIFACTS}" \
-PARALLELISM="${PARALLELISM}" \
-CPUQUOTA="${CPUQUOTA}" \
-ZONES="${ZONES}" \
-COUNT="${COUNT-1}" \
-DEBUG="${DEBUG-false}" \
-BUILD_TAG="${BUILD_TAG}" \
-COCKROACH_BINARY="${COCKROACH_BINARY}" \
-SLACK_TOKEN="${SLACK_TOKEN}" \
-TC_BUILD_ID="${TC_BUILD_ID}" \
-TESTS="${TESTS}"
-
 # Teamcity has a 1300 minute timeout that, when reached, kills the process
 # without a stack trace (probably SIGKILL).  We'd love to see a stack trace
 # though, so after 1200 minutes, kill with SIGINT which will allow roachtest to
 # fail tests and cleanup.
-timeout -s INT $((1200*60)) "build/teamcity-nightly-roachtest-invoke.sh"
+timeout -s INT $((1200*60)) "build/teamcity-roachtest-invoke.sh" \
+  --cloud="${CLOUD}" \
+  --count="${COUNT-1}" \
+  --parallelism="${PARALLELISM}" \
+  --cpu-quota="${CPUQUOTA}" \
+  --cluster-id="${TC_BUILD_ID}" \
+  --build-tag="${BUILD_TAG}" \
+  --cockroach="${COCKROACH_BINARY}" \
+  --artifacts="${artifacts}" \
+  --slack-token="${SLACK_TOKEN}" \
+  "${TESTS}"

--- a/build/teamcity-nightly-roachtest.sh
+++ b/build/teamcity-nightly-roachtest.sh
@@ -8,11 +8,6 @@ source "$(dirname "${0}")/teamcity-support.sh"
 # apologies, you're going to have to dig around for them below or even better
 # yet, look at the job).
 
-# Note that when this script is called, the cockroach binary to be tested
-# already exists in the current directory.
-COCKROACH_BINARY="${PWD}/cockroach.linux-2.6.32-gnu-amd64"
-chmod +x "${COCKROACH_BINARY}"
-
 if [[ ! -f ~/.ssh/id_rsa.pub ]]; then
   ssh-keygen -q -C "roachtest-nightly $(date)" -N "" -f ~/.ssh/id_rsa
 fi
@@ -25,7 +20,8 @@ chmod o+rwx "${artifacts}"
 # Disable global -json flag.
 export PATH=$PATH:$(GOFLAGS=; go env GOPATH)/bin
 
-build/builder/mkrelease.sh amd64-linux-gnu bin/workload bin/roachtest bin/roachprod > "${artifacts}/build.txt" 2>&1 || cat "${artifacts}/build.txt"
+build/builder/mkrelease.sh amd64-linux-gnu build bin/workload bin/roachtest bin/roachprod \
+  > "${artifacts}/build.txt" 2>&1 || (cat "${artifacts}/build.txt"; false)
 
 # Set up Google credentials. Note that we need this for all clouds since we upload
 # perf artifacts to Google Storage at the end.
@@ -117,7 +113,7 @@ timeout -s INT $((1200*60)) "build/teamcity-roachtest-invoke.sh" \
   --cpu-quota="${CPUQUOTA}" \
   --cluster-id="${TC_BUILD_ID}" \
   --build-tag="${BUILD_TAG}" \
-  --cockroach="${COCKROACH_BINARY}" \
+  --cockroach="${PWD}/cockroach-linux-2.6.32-gnu-amd64" \
   --artifacts="${artifacts}" \
   --slack-token="${SLACK_TOKEN}" \
   "${TESTS}"

--- a/build/teamcity-roachtest-invoke.sh
+++ b/build/teamcity-roachtest-invoke.sh
@@ -2,22 +2,13 @@
 set -euo pipefail
 
 set +e
+# Append any given command-line parameters. If a switch listed below is also
+# passed by the caller, the passed one takes precedence.
 bin/roachtest run \
-  --cloud="${CLOUD}" \
-  --artifacts="${ARTIFACTS}" \
-  --parallelism="${PARALLELISM}" \
-  --cpu-quota="${CPUQUOTA}" \
-  --zones="${ZONES}" \
-  --count="${COUNT-1}" \
-  --debug="${DEBUG-false}" \
-  --build-tag="${BUILD_TAG}" \
-  --cockroach="${COCKROACH_BINARY}" \
+  --teamcity \
   --roachprod="${PWD}/bin/roachprod" \
   --workload="${PWD}/bin/workload" \
-  --teamcity=true \
-  --slack-token="${SLACK_TOKEN}" \
-  --cluster-id="${TC_BUILD_ID}" \
-  "${TESTS}"
+  "$@"
 code=$?
 set -e
 

--- a/build/teamcity-roachtest-stress.sh
+++ b/build/teamcity-roachtest-stress.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(dirname "${0}")/teamcity-support.sh"
+
+google_credentials="$GOOGLE_EPHEMERAL_CREDENTIALS"
+generate_ssh_key
+log_into_gcloud
+
+set -x
+
+export ROACHPROD_USER=teamcity
+
+# TODO(erikgrinaker): We should use a dedicated or more appropriate project
+# here, but use andrei-jepsen for now. We don't want to use the regular test
+# project here to avoid disturbing test runs due to e.g. quota limits. See:
+# https://cockroachlabs.atlassian.net/browse/DEVINF-140
+export GCE_PROJECT=${GCE_PROJECT-andrei-jepsen}
+
+mkdir -p artifacts
+
+build/builder/mkrelease.sh amd64-linux-gnu build bin/workload bin/roachtest bin/roachprod \
+  > artifacts/build.txt 2>&1 || (cat artifacts/build.txt; false)
+
+build/teamcity-roachtest-invoke.sh \
+  --cloud=gce \
+  --zones=us-central1-b,us-west1-b,europe-west2-b \
+  --debug="${DEBUG-false}" \
+  --count="${COUNT-16}" \
+  --parallelism="${PARALLELISM-16}" \
+  --cpu-quota="${CPUQUOTA-1024}" \
+  --cluster-id="${TC_BUILD_ID}" \
+  --build-tag="${BUILD_TAG}" \
+  --create-args="--lifetime=36h" \
+  --cockroach="${PWD}/cockroach-linux-2.6.32-gnu-amd64" \
+  --artifacts="${PWD}/artifacts" \
+  --disable-issue \
+  "${TESTS}"

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -67,6 +67,7 @@ var (
 	clusterWipe      bool
 	zonesF           string
 	teamCity         bool
+	disableIssue     bool
 )
 
 type encryptValue string

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -187,6 +187,8 @@ runner itself.
 		&slackToken, "slack-token", "", "Slack bot token")
 	runCmd.Flags().BoolVar(
 		&teamCity, "teamcity", false, "include teamcity-specific markers in output")
+	runCmd.Flags().BoolVar(
+		&disableIssue, "disable-issue", false, "disable posting GitHub issue for failures")
 
 	var benchCmd = &cobra.Command{
 		// Don't display usage when tests fail.

--- a/pkg/cmd/roachtest/registry/owners.go
+++ b/pkg/cmd/roachtest/registry/owners.go
@@ -25,4 +25,5 @@ const (
 	OwnerSQLQueries    Owner = `sql-queries`
 	OwnerSQLSchema     Owner = `sql-schema`
 	OwnerStorage       Owner = `storage`
+	OwnerTestEng       Owner = `test-eng`
 )

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -468,10 +468,10 @@ func (r *testRunner) runWorker(
 			artifactsDir = filepath.Join(base, runSuffix)
 			logPath = filepath.Join(artifactsDir, "test.log")
 
-			// Map artifacts/TestFoo/** => TestFoo/**, i.e. collect the artifacts
+			// Map artifacts/TestFoo/run_?/** => TestFoo/run_?/**, i.e. collect the artifacts
 			// for this test exactly as they are laid out on disk (when the time
 			// comes).
-			artifactsSpec = fmt.Sprintf("%s/** => %s", base, escapedTestName)
+			artifactsSpec = fmt.Sprintf("%s/%s/** => %s/%s", base, runSuffix, escapedTestName, runSuffix)
 		}
 		testL, err := logger.RootLogger(logPath, teeOpt)
 		if err != nil {
@@ -497,7 +497,7 @@ func (r *testRunner) runWorker(
 		// Now run the test.
 		l.PrintfCtx(ctx, "starting test: %s:%d", testToRun.spec.Name, testToRun.runNum)
 		var success bool
-		success, err = r.runTest(ctx, t, testToRun.runNum, c, testRunnerLogPath, stdout, testL)
+		success, err = r.runTest(ctx, t, testToRun.runNum, testToRun.runCount, c, testRunnerLogPath, stdout, testL)
 		if err != nil {
 			shout(ctx, l, stdout, "test returned error: %s: %s", t.Name(), err)
 			// Mark the test as failed if it isn't already.
@@ -607,6 +607,7 @@ func (r *testRunner) runTest(
 	ctx context.Context,
 	t *testImpl,
 	runNum int,
+	runCount int,
 	c *clusterImpl,
 	testRunnerLogPath string,
 	stdout io.Writer,
@@ -616,10 +617,14 @@ func (r *testRunner) runTest(
 		return false, fmt.Errorf("can't run skipped test: %s: %s", t.Name(), t.Spec().(*registry.TestSpec).Skip)
 	}
 
+	runID := t.Name()
+	if runCount > 1 {
+		runID += fmt.Sprintf("#%d", runNum)
+	}
 	if teamCity {
-		shout(ctx, l, stdout, "##teamcity[testStarted name='%s' flowId='%s']", t.Name(), t.Name())
+		shout(ctx, l, stdout, "##teamcity[testStarted name='%s' flowId='%s']", t.Name(), runID)
 	} else {
-		shout(ctx, l, stdout, "=== RUN   %s", t.Name())
+		shout(ctx, l, stdout, "=== RUN   %s", runID)
 	}
 
 	r.status.Lock()
@@ -653,8 +658,7 @@ func (r *testRunner) runTest(
 
 			if teamCity {
 				shout(ctx, l, stdout, "##teamcity[testFailed name='%s' details='%s' flowId='%s']",
-					t.Name(), teamCityEscape(output), t.Name(),
-				)
+					t.Name(), teamCityEscape(output), runID)
 
 				// Copy a snapshot of the testrunner's log to the test's artifacts dir
 				// so that we collect it below.
@@ -664,7 +668,7 @@ func (r *testRunner) runTest(
 				}
 			}
 
-			shout(ctx, l, stdout, "--- FAIL: %s (%s)\n%s", t.Name(), durationStr, output)
+			shout(ctx, l, stdout, "--- FAIL: %s (%s)\n%s", runID, durationStr, output)
 
 			issueOutput := output
 			if t.timedOut() {
@@ -672,13 +676,13 @@ func (r *testRunner) runTest(
 			}
 			r.maybePostGithubIssue(ctx, l, t, stdout, issueOutput)
 		} else {
-			shout(ctx, l, stdout, "--- PASS: %s (%s)", t.Name(), durationStr)
+			shout(ctx, l, stdout, "--- PASS: %s (%s)", runID, durationStr)
 			// If `##teamcity[testFailed ...]` is not present before `##teamCity[testFinished ...]`,
 			// TeamCity regards the test as successful.
 		}
 
 		if teamCity {
-			shout(ctx, l, stdout, "##teamcity[testFinished name='%s' flowId='%s']", t.Name(), t.Name())
+			shout(ctx, l, stdout, "##teamcity[testFinished name='%s' flowId='%s']", t.Name(), runID)
 
 			// Zip the artifacts. This improves the TeamCity UX where we can navigate
 			// through zip files just fine, but we can't download subtrees of the

--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -93,6 +93,7 @@ go_library(
         "restart.go",
         "restore.go",
         "roachmart.go",
+        "roachtest.go",
         "ruby_pg.go",
         "ruby_pg_blocklist.go",
         "schema_change_database_version_upgrade.go",

--- a/pkg/cmd/roachtest/tests/registry.go
+++ b/pkg/cmd/roachtest/tests/registry.go
@@ -81,6 +81,7 @@ func RegisterTests(r registry.Registry) {
 	registerRestoreNodeShutdown(r)
 	registerRestore(r)
 	registerRoachmart(r)
+	registerRoachtest(r)
 	registerRubyPG(r)
 	registerSchemaChangeBulkIngest(r)
 	registerSchemaChangeDatabaseVersionUpgrade(r)

--- a/pkg/cmd/roachtest/tests/roachtest.go
+++ b/pkg/cmd/roachtest/tests/roachtest.go
@@ -1,0 +1,41 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tests
+
+import (
+	"context"
+	"math/rand"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+)
+
+func registerRoachtest(r registry.Registry) {
+	r.Add(registry.TestSpec{
+		Name:    "roachtest/noop",
+		Tags:    []string{"roachtest"},
+		Owner:   registry.OwnerTestEng,
+		Run:     func(_ context.Context, _ test.Test, _ cluster.Cluster) {},
+		Cluster: r.MakeClusterSpec(0),
+	})
+	r.Add(registry.TestSpec{
+		Name:  "roachtest/noop-maybefail",
+		Tags:  []string{"roachtest"},
+		Owner: registry.OwnerTestEng,
+		Run: func(_ context.Context, t test.Test, _ cluster.Cluster) {
+			if rand.Float64() <= 0.2 {
+				t.Fatal("randomly failing")
+			}
+		},
+		Cluster: r.MakeClusterSpec(0),
+	})
+}

--- a/pkg/cmd/roachtest/work_pool.go
+++ b/pkg/cmd/roachtest/work_pool.go
@@ -53,6 +53,8 @@ type testToRunRes struct {
 	noWork bool
 	// spec is the selected test.
 	spec registry.TestSpec
+	// runCount is the total number of runs. 1 if --count was not used.
+	runCount int
 	// runNum is run number. 1 if --count was not used.
 	runNum int
 
@@ -158,6 +160,7 @@ func (p *workPool) selectTestForCluster(
 	runNum := p.count - candidate.count + 1
 	return testToRunRes{
 		spec:            candidate.spec,
+		runCount:        p.count,
 		runNum:          runNum,
 		canReuseCluster: true,
 	}
@@ -212,6 +215,7 @@ func (p *workPool) selectTest(ctx context.Context, qp *quotapool.IntPool) (testT
 		p.decTestLocked(ctx, tc.spec.Name)
 		ttr = testToRunRes{
 			spec:            tc.spec,
+			runCount:        p.count,
 			runNum:          runNum,
 			canReuseCluster: false,
 		}


### PR DESCRIPTION
### roachtest: handle multiple runs of same test on TeamCity

The TeamCity markers output via `--teamcity` currently do not handle
multiple runs of the same test via `--count`, since they use the same
flow ID for all runs, making TeamCity unable to distinguish between
them. A similar problem exists with artifacts, where each run would
publish the root `artifacts/` directory rather than the `run_`
subdirectories.

This patch fixes the above issues by including run identifiers where
appropriate.

Release note: None

### roachtest: add roachtest/noop test

This adds a `roachtest/noop` test that instantly succeeds without
spinning up any servers, and a `roachtest/noop-maybefail` test that
randomly fails with 20% probability. These can be useful when testing
e.g. CI builds or other test infrastructure. They are disabled by
default and require the `roachtest` tag.

Release note: None

### roachtest: add --disable-issue flag to disable GitHub issues

Release note: None

### build: add TeamCity build script to stress roachtests

This adds a build script that can be used to stress roachtests on
TeamCity, in order to reproduce failures. The corresponding TeamCity
build is `Cockroach_Nightlies_RoachtestStress`.

Release note: None

### build: explicitly build binary for TeamCity nightly tests

The TeamCity nightly tests depend on the "publish bleeding edge" build,
which pulls in a ton of additional builds (e.g. for multiple OSes) that
we don't really need to run the nightlies. This can cause unrelated
build failures to fail the nightly tests.

This patch explicitly builds a CRDB binary in
`teamcity-nightly-roachtest.sh` such that the build can be decoupled
from "publish bleeding edge". This is a temporary mitigation until the
TeamCity builds and dependencies are cleaned up.

Touches https://cockroachlabs.atlassian.net/browse/DEVINF-16.
Touches cockroachdb#64263.

Release note: None

---

This is still a work-in-progress, but I suggest we merge the script itself
which makes it easier to generalize the TeamCity build and work on e.g.
branch specification.

There's a bit of work remaining on the actual build, which will be addressed
separately:

* Notifications: TeamCity does not expose the email address of the person
  who started the build, so for now we'll send notifications to the Slack
  channel `#roachtest-stress-ops`.

* Running clusters: We need to let the user know about any test clusters
  that are still running, so that these can be inspected and shut down as
  appropriate. We'll probably also need to change how roachtest extends
  cluster lifetimes, since we want to reuse clusters for tests but make sure
  every test invocation will extend the lifetime to 36 hours from the start
  of the test (not the cluster creation, which is currently the case).

* Trigger link: We should include a link on test failures to a TeamCity form
  for starting a stress build (if possible), or at least instructions for how
  to start one.

* Branch/commit selection: We need to make sure it's easy for users to pick
  which branch or commit to build.