### PR TITLE
cluster-ui: fix statement name label on column selector

### DIFF
--- a/pkg/ui/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -42,6 +42,7 @@ import {
   StatementsSortedTable,
 } from "../statementsTable";
 import {
+  getLabel,
   statisticsColumnLabels,
   StatisticTableColumnKeys,
 } from "../statsTableUtil/statsTableUtil";
@@ -428,7 +429,7 @@ export class StatementsPage extends React.Component<
       .filter(c => !c.alwaysShow)
       .map(
         (c): SelectOption => ({
-          label: statisticsColumnLabels[c.name as StatisticTableColumnKeys],
+          label: getLabel(c.name as StatisticTableColumnKeys, "statement"),
           value: c.name,
           isSelected: isColumnSelected(c),
         }),

--- a/pkg/ui/cluster-ui/src/statementsTable/statementsTable.tsx
+++ b/pkg/ui/cluster-ui/src/statementsTable/statementsTable.tsx
@@ -118,7 +118,7 @@ function makeCommonColumns(
         FixLong(Number(stmt.stats.bytes_read.mean)),
     },
     {
-      name: "statementTime",
+      name: "time",
       title: statisticsTableTitles.time(statType),
       className: cx("statements-table__col-latency"),
       cell: latencyBar,

--- a/pkg/ui/cluster-ui/src/statsTableUtil/statsTableUtil.tsx
+++ b/pkg/ui/cluster-ui/src/statsTableUtil/statsTableUtil.tsx
@@ -59,6 +59,30 @@ type StatisticTableTitleType = {
   [key in StatisticTableColumnKeys]: (statType: StatisticType) => JSX.Element;
 };
 
+export function getLabel(
+  key: StatisticTableColumnKeys,
+  statType?: StatisticType,
+): string {
+  if (key !== "time") return statisticsColumnLabels[key];
+
+  switch (statType) {
+    case "transaction":
+      return (
+        contentModifiers.transactionCapital + " " + statisticsColumnLabels[key]
+      );
+    case "statement":
+      return (
+        contentModifiers.statementCapital + " " + statisticsColumnLabels[key]
+      );
+    case "transactionDetails":
+      return (
+        contentModifiers.statementCapital + " " + statisticsColumnLabels[key]
+      );
+    default:
+      return statisticsColumnLabels[key];
+  }
+}
+
 // statisticsTableTitles is a mapping between statistic table columns and functions.
 // Each function provides tooltip information for its respective statistic column.
 // The function parameter is a StatisticType, which represents the type
@@ -86,7 +110,7 @@ export const statisticsTableTitles: StatisticTableTitleType = {
           </>
         }
       >
-        {statisticsColumnLabels.statements}
+        {getLabel("statements")}
       </Tooltip>
     );
   },
@@ -130,7 +154,7 @@ export const statisticsTableTitles: StatisticTableTitleType = {
           </>
         }
       >
-        Execution Count
+        {getLabel("executionCount")}
       </Tooltip>
     );
   },
@@ -151,7 +175,7 @@ export const statisticsTableTitles: StatisticTableTitleType = {
         style="tableTitle"
         content={<p>Database on which the ${contentModifier} was executed.</p>}
       >
-        {statisticsColumnLabels.database}
+        {getLabel("database")}
       </Tooltip>
     );
   },
@@ -196,7 +220,7 @@ export const statisticsTableTitles: StatisticTableTitleType = {
           </>
         }
       >
-        {statisticsColumnLabels.rowsRead}
+        {getLabel("rowsRead")}
       </Tooltip>
     );
   },
@@ -241,7 +265,7 @@ export const statisticsTableTitles: StatisticTableTitleType = {
           </>
         }
       >
-        {statisticsColumnLabels.bytesRead}
+        {getLabel("bytesRead")}
       </Tooltip>
     );
   },
@@ -286,7 +310,7 @@ export const statisticsTableTitles: StatisticTableTitleType = {
           </>
         }
       >
-        {columnLabel + " Time"}
+        {getLabel("time", statType)}
       </Tooltip>
     );
   },
@@ -331,7 +355,7 @@ export const statisticsTableTitles: StatisticTableTitleType = {
           </>
         }
       >
-        {statisticsColumnLabels.contention}
+        {getLabel("contention")}
       </Tooltip>
     );
   },
@@ -372,7 +396,7 @@ export const statisticsTableTitles: StatisticTableTitleType = {
           </>
         }
       >
-        {statisticsColumnLabels.maxMemUsage}
+        {getLabel("maxMemUsage")}
       </Tooltip>
     );
   },
@@ -421,7 +445,7 @@ export const statisticsTableTitles: StatisticTableTitleType = {
           </>
         }
       >
-        {statisticsColumnLabels.networkBytes}
+        {getLabel("networkBytes")}
       </Tooltip>
     );
   },
@@ -457,7 +481,7 @@ export const statisticsTableTitles: StatisticTableTitleType = {
           </>
         }
       >
-        {statisticsColumnLabels.retries}
+        {getLabel("retries")}
       </Tooltip>
     );
   },
@@ -489,7 +513,7 @@ export const statisticsTableTitles: StatisticTableTitleType = {
           </p>
         }
       >
-        {statisticsColumnLabels.workloadPct}
+        {getLabel("workloadPct")}
       </Tooltip>
     );
   },
@@ -512,7 +536,7 @@ export const statisticsTableTitles: StatisticTableTitleType = {
           <p>Regions/Nodes in which the ${contentModifier} was executed.</p>
         }
       >
-        {statisticsColumnLabels.regionNodes}
+        {getLabel("regionNodes")}
       </Tooltip>
     );
   },
@@ -536,7 +560,7 @@ export const statisticsTableTitles: StatisticTableTitleType = {
           </>
         }
       >
-        {statisticsColumnLabels.diagnostics}
+        {getLabel("diagnostics")}
       </Tooltip>
     );
   },


### PR DESCRIPTION
The label for Statement Time wasn't properly showing
on the column selctor on Statements page.

Release note (bug fix): Display Statement Time label on column selector
on Statements page.