### PR TITLE
opt: fix FoldEqZeroSTDistance with use_spheroid argument

### DIFF
--- a/pkg/sql/opt/norm/rules/comp.opt
+++ b/pkg/sql/opt/norm/rules/comp.opt
@@ -240,7 +240,8 @@
 # early-exit behavior, and may allow an inverted index scan to be generated.
 [FoldEqZeroSTDistance, Normalize]
 (Eq
-    (Function $args:* $private:(FunctionPrivate "st_distance"))
+    (Function $args:* $private:(FunctionPrivate "st_distance")) &
+        ^(STDistanceUseSpheroid $args)
     $right:(Const
         $value:* & (IsFloatDatum $value) & (DatumsEqual $value 0)
     )

--- a/pkg/sql/opt/norm/testdata/rules/comp
+++ b/pkg/sql/opt/norm/testdata/rules/comp
@@ -804,9 +804,9 @@ select
  └── filters
       └── st_intersects(geom:1, '010100000000000000000000000000000000000000') [outer=(1), immutable, constraints=(/1: (/NULL - ])]
 
-# Geography case.
+# Geography case with use_spheroid=false.
 norm expect=FoldEqZeroSTDistance
-SELECT * FROM geom_geog WHERE st_distance(geog, 'POINT(0.0 0.0)') = 0
+SELECT * FROM geom_geog WHERE st_distance(geog, 'POINT(0.0 0.0)', false) = 0
 ----
 select
  ├── columns: geom:1 geog:2!null val:3
@@ -827,6 +827,30 @@ select
  │    └── columns: geom:1 geog:2 val:3
  └── filters
       └── st_distance(geom:1, '010100000000000000000000000000000000000000') = 1.0 [outer=(1), immutable]
+
+# No-op case because use_spheroid=true implicitly.
+norm expect-not=FoldEqZeroSTDistance
+SELECT * FROM geom_geog WHERE st_distance(geog, 'POINT(0.0 0.0)') = 0
+----
+select
+ ├── columns: geom:1 geog:2 val:3
+ ├── immutable
+ ├── scan geom_geog
+ │    └── columns: geom:1 geog:2 val:3
+ └── filters
+      └── st_distance(geog:2, '0101000020E610000000000000000000000000000000000000') = 0.0 [outer=(2), immutable]
+
+# No-op case because use_spheroid=true.
+norm expect-not=FoldEqZeroSTDistance
+SELECT * FROM geom_geog WHERE st_distance(geog, 'POINT(0.0 0.0)', true) = 0
+----
+select
+ ├── columns: geom:1 geog:2 val:3
+ ├── immutable
+ ├── scan geom_geog
+ │    └── columns: geom:1 geog:2 val:3
+ └── filters
+      └── st_distance(geog:2, '0101000020E610000000000000000000000000000000000000', true) = 0.0 [outer=(2), immutable]
 
 # --------------------------------------------------
 # FoldCmpSTDistanceLeft


### PR DESCRIPTION
The `FoldEqZeroSTDistance` normalization rule normalizes expressions in
the form `st_distance(a, b) = 0` to `st_intersects(a, b)`. This
normalization rule is important because it allows an inverted index to
be used for more queries.

Previously, `FoldEqZeroSTDistance` did not handle the third argument of
`st_distance` for the geography overload, `use_spheroid`. The optimizer
panicked when a user supplied this third argument because it attempted
to find an `st_intersects` overload with the three arguments and no such
overload exists.

In addition to the panic, this rule was incorrectly firing in cases
where it shouldn't have.

From the [`ST_Distance` PostGIS docs](https://postgis.net/docs/ST_Distance.html):

> For geography types defaults to return the minimum geodesic distance
> between two geographies in meters, compute on the spheroid determined
> by the SRID. If use_spheroid is false, a faster spherical calculation
> is used.

From the [`ST_Intersects` PostGIS docs](https://postgis.net/docs/ST_Intersects.html):

> For geography, this function has a distance tolerance of about 0.00001
> meters and uses the sphere rather than spheroid calculation.

In summary, `st_distance` calculates on a spheroid by default, and only
on a sphere if `use_spheroid` is explicitly false. `st_intersects`
calculates on the sphere always. Therefore, this rule can only apply for
geography types if `use_spheroid=false` is explicitly passed.

This commit ensures that `FoldEqZeroSTDistance` only matches
`st_distance` functions with geography arguments if `use_spheroid=false`
is included in the function call. The panic is fixed by stripping the
`use_spheroid` argument from the list of arguments used to lookup the
`st_intersects` overload.

Fixes #67235

Release note (bug fix): Two bugs have been fixed which affected
geospatial queries with the `st_distance` function. The first caused
errors for filters of the form `st_distance(g1, g2, use_spheroid) = 0`.
The second could cause incorrect results in some cases. It incorrectly
transformed filters in the form `st_distance(g1, g2) = 0` when `g1` and
`g2` are geographies to `st_instersects(g1, g2)`. This is not a valid
transformation because `st_distance` makes spheroid-based calculations
by default while `st_intersects` only makes sphere-based calculations.
