### PR TITLE
storage: export PebbleFileRegistry.CheckNoRegistryFile function

### DIFF
--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -507,7 +507,7 @@ func ResolveEncryptedEnvOptions(
 			return nil, nil, err
 		}
 	} else {
-		if err := fileRegistry.checkNoRegistryFile(); err != nil {
+		if err := fileRegistry.CheckNoRegistryFile(); err != nil {
 			return nil, nil, fmt.Errorf("encryption was used on this store before, but no encryption flags " +
 				"specified. You need a CCL build and must fully specify the --enterprise-encryption flag")
 		}

--- a/pkg/storage/pebble_file_registry_test.go
+++ b/pkg/storage/pebble_file_registry_test.go
@@ -163,9 +163,9 @@ func TestFileRegistryCheckNoFile(t *testing.T) {
 	fileEntry :=
 		&enginepb.FileEntry{EnvType: enginepb.EnvType_Data, EncryptionSettings: []byte("foo")}
 	registry := &PebbleFileRegistry{FS: mem}
-	require.NoError(t, registry.checkNoRegistryFile())
+	require.NoError(t, registry.CheckNoRegistryFile())
 	require.NoError(t, registry.Load())
 	require.NoError(t, registry.SetFileEntry("/foo", fileEntry))
 	registry = &PebbleFileRegistry{FS: mem}
-	require.Error(t, registry.checkNoRegistryFile())
+	require.Error(t, registry.CheckNoRegistryFile())
 }


### PR DESCRIPTION
This patch exports the CheckNoRegistryFile receiver function on
PebbleFileRegistry since it should be called instead of Load
when the file registry will not be needed.

Release note: None