### PR TITLE
sql: support backslash_quote session setting

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4067,6 +4067,7 @@ SELECT * FROM information_schema.session_variables where variable not in ('crdb_
 variable                                              value
 allow_prepare_as_opt_plan                             off
 application_name                                      ·
+backslash_quote                                       safe_encoding
 bytea_output                                          hex
 client_encoding                                       UTF8
 client_min_messages                                   notice

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3394,6 +3394,7 @@ WHERE
 ----
 name                                                  setting             category  short_desc  extra_desc  vartype
 application_name                                      ·                   NULL      NULL        NULL        string
+backslash_quote                                       safe_encoding       NULL      NULL        NULL        string
 bytea_output                                          hex                 NULL      NULL        NULL        string
 client_encoding                                       UTF8                NULL      NULL        NULL        string
 client_min_messages                                   notice              NULL      NULL        NULL        string
@@ -3476,6 +3477,7 @@ WHERE
 ----
 name                                                  setting             unit  context  enumvals  boot_val            reset_val
 application_name                                      ·                   NULL  user     NULL      ·                   ·
+backslash_quote                                       safe_encoding       NULL  user     NULL      safe_encoding       safe_encoding
 bytea_output                                          hex                 NULL  user     NULL      hex                 hex
 client_encoding                                       UTF8                NULL  user     NULL      UTF8                UTF8
 client_min_messages                                   notice              NULL  user     NULL      notice              notice
@@ -3553,6 +3555,7 @@ SELECT name, source, min_val, max_val, sourcefile, sourceline FROM pg_catalog.pg
 ----
 name                                                  source  min_val  max_val  sourcefile  sourceline
 application_name                                      NULL    NULL     NULL     NULL        NULL
+backslash_quote                                       NULL    NULL     NULL     NULL        NULL
 bytea_output                                          NULL    NULL     NULL     NULL        NULL
 client_encoding                                       NULL    NULL     NULL     NULL        NULL
 client_min_messages                                   NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -476,3 +476,17 @@ SET standard_conforming_strings='true'
 
 statement ok
 SET standard_conforming_strings='on'
+
+subtest backslash_quote_test
+
+statement ok
+SET backslash_quote = 'safe_encoding';
+
+statement error invalid value for parameter "backslash_quote"
+SET backslash_quote = 'on';
+
+statement error invalid value for parameter "backslash_quote"
+SET backslash_quote = 'off';
+
+statement error invalid value for parameter "backslash_quote"
+SET backslash_quote = '123';

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -27,6 +27,7 @@ WHERE variable != 'optimizer' AND variable != 'crdb_version' AND variable != 'se
 ----
 variable                                              value
 application_name                                      ·
+backslash_quote                                       safe_encoding
 bytea_output                                          hex
 client_encoding                                       UTF8
 client_min_messages                                   notice

--- a/pkg/sql/unsupported_vars.go
+++ b/pkg/sql/unsupported_vars.go
@@ -64,7 +64,6 @@ var UnsupportedVars = func(ss ...string) map[string]struct{} {
 	// "application_name",
 	"array_nulls",
 	"backend_flush_after",
-	"backslash_quote",
 	// "bytea_output",
 	"check_function_bodies",
 	// "client_encoding",

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -831,6 +831,12 @@ var varGen = map[string]sessionVar{
 	// See https://www.postgresql.org/docs/10/static/runtime-config-client.html#GUC-LOC-TIMEOUT
 	`lock_timeout`: makeCompatIntVar(`lock_timeout`, 0),
 
+	// See https://www.postgresql.org/docs/13/runtime-config-compatible.html
+	// CockroachDB only supports safe_encoding for now. If `client_encoding` is updated to
+	// allow encodings other than UTF8, then the default value of `backslash_quote` should
+	// be changed to `on`.
+	`backslash_quote`: makeCompatStringVar(`backslash_quote`, `safe_encoding`),
+
 	// Supported for PG compatibility only.
 	// See https://www.postgresql.org/docs/10/static/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
 	`max_identifier_length`: {


### PR DESCRIPTION
This setting is based on a previous issue: cockroachdb#45774. This commit set a placeholder for PostgreSQL configuration setting called [backslash_quote](https://www.postgresql.org/docs/12/runtime-config-compatible.html#GUC-BACKSLASH-QUOTE), and ensured it is compatible with ORMS. Currently, we only allow the value to be `backslash_quote`.  If `client_encoding` is updated to allow encodings other than UTF8, then the default value of `backslash_quote` should be changed to `on`.

When users try setting the backslash_quote session variable, CRDB will let it pass, but not making any changes. We leave the functionality implementation to future works.

Details:
- Added `backslash_quote` at varGen at `sql/vars.go` without implementing the true functionality

- Tested it with `subtest backslash_quote_test` at `pkg/sql/logictest/testdata/logic_test/set`

- Removed `backslash_quote` from `unsupported_vars.go`

Passed local test:
<img src="https://i.imgur.com/crZFk9w.png">

Updates:

- nil: updated url for backslash_quote, and removed extra spaces

- Deleted `backslash_quote` from `unsupported_vars.go`

- Ran `make testlogic FILES=information_schema TESTFLAGS=-rewrite`

Release note (sql change): Added session variable backslash_quote for compatibility, setting it does a no-op, and only `safe_encoding` is supported.
