### PR TITLE
storageccl: delete pebble file registry entries for unencrypted files

### DIFF
--- a/pkg/ccl/cliccl/debug.go
+++ b/pkg/ccl/cliccl/debug.go
@@ -169,7 +169,7 @@ func runEncryptionStatus(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if len(registries.FileRegistry) == 0 || len(registries.KeyRegistry) == 0 {
+	if len(registries.KeyRegistry) == 0 {
 		return nil
 	}
 

--- a/pkg/cli/interactive_tests/test_encryption.tcl
+++ b/pkg/cli/interactive_tests/test_encryption.tcl
@@ -57,7 +57,9 @@ send "$argv debug encryption-status $storedir --enterprise-encryption=path=$stor
 eexpect "    \"Active\": true,\r\n    \"Type\": \"Plaintext\","
 # Try starting without the encryption flag.
 send "$argv start-single-node --insecure --store=$storedir\r"
-eexpect "encryption was used on this store before, but no encryption flags specified."
+eexpect "node starting"
+interrupt
+eexpect "shutdown completed"
 end_test
 
 start_test "Restart with AES-128."

--- a/pkg/storage/pebble_file_registry.go
+++ b/pkg/storage/pebble_file_registry.go
@@ -24,6 +24,10 @@ import (
 	"github.com/gogo/protobuf/proto"
 )
 
+// CanRegistryElideFunc is a function that returns true for entries that can be
+// elided instead of being written to the registry.
+var CanRegistryElideFunc func(entry *enginepb.FileEntry) bool
+
 // PebbleFileRegistry keeps track of files for the data-FS and store-FS for Pebble (see encrypted_fs.go
 // for high-level comment).
 //
@@ -89,6 +93,26 @@ func (r *PebbleFileRegistry) Load() error {
 	if err = protoutil.Unmarshal(b, r.mu.currProto); err != nil {
 		return err
 	}
+	// Delete all unnecessary entries to reduce registry size.
+	if err := r.maybeElideEntries(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *PebbleFileRegistry) maybeElideEntries() error {
+	newProto := &enginepb.FileRegistry{}
+	proto.Merge(newProto, r.mu.currProto)
+	filesChanged := false
+	for filename, entry := range newProto.Files {
+		if CanRegistryElideFunc != nil && CanRegistryElideFunc(entry) {
+			delete(newProto.Files, filename)
+			filesChanged = true
+		}
+	}
+	if filesChanged {
+		return r.writeRegistry(newProto)
+	}
 	return nil
 }
 
@@ -101,10 +125,11 @@ func (r *PebbleFileRegistry) GetFileEntry(filename string) *enginepb.FileEntry {
 }
 
 // SetFileEntry sets filename => entry in the registry map and persists the registry.
+// It should not be called for entries corresponding to unencrypted files since the
+// absence of a file in the file registry implies that it is unencrypted.
 func (r *PebbleFileRegistry) SetFileEntry(filename string, entry *enginepb.FileEntry) error {
-	// We choose not to store an entry for unencrypted files since the absence of
-	// a file in the file registry implies that it is unencrypted.
-	if entry != nil && entry.EnvType == enginepb.EnvType_Plaintext {
+	// We don't need to store nil entries since that's the default zero value.
+	if entry == nil {
 		return r.MaybeDeleteEntry(filename)
 	}
 

--- a/pkg/storage/pebble_file_registry_test.go
+++ b/pkg/storage/pebble_file_registry_test.go
@@ -169,3 +169,35 @@ func TestFileRegistryCheckNoFile(t *testing.T) {
 	registry = &PebbleFileRegistry{FS: mem}
 	require.Error(t, registry.checkNoRegistryFile())
 }
+
+func TestFileRegistryElideUnencrypted(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// Temporarily change the global CanRegistryElideFunc to test it.
+	prevRegistryElideFunc := CanRegistryElideFunc
+	defer func() {
+		CanRegistryElideFunc = prevRegistryElideFunc
+	}()
+	CanRegistryElideFunc = func(entry *enginepb.FileEntry) bool {
+		return entry == nil || len(entry.EncryptionSettings) == 0
+	}
+
+	// Create a new pebble file registry and inject a registry with an unencrypted file.
+	mem := vfs.NewMem()
+	registry := &PebbleFileRegistry{FS: mem}
+	require.NoError(t, registry.Load())
+	newProto := &enginepb.FileRegistry{}
+	newProto.Files = make(map[string]*enginepb.FileEntry)
+	newProto.Files["test1"] = &enginepb.FileEntry{EnvType: enginepb.EnvType_Data, EncryptionSettings: []byte(nil)}
+	newProto.Files["test2"] = &enginepb.FileEntry{EnvType: enginepb.EnvType_Store, EncryptionSettings: []byte("foo")}
+	require.NoError(t, registry.writeRegistry(newProto))
+
+	// Create another pebble file registry to verify that the unencrypted file is elided on startup.
+	registry2 := &PebbleFileRegistry{FS: mem}
+	require.NoError(t, registry2.Load())
+	require.NotContains(t, registry2.mu.currProto.Files, "test1")
+	entry := registry2.mu.currProto.Files["test2"]
+	require.NotNil(t, entry)
+	require.Equal(t, entry.EncryptionSettings, []byte("foo"))
+}


### PR DESCRIPTION
This patch updates the PebbleFileRegistry to delete unnecessary
entries for unencrypted files when loading an existing registry.

Release note: None