### PR TITLE
ui: remove node summary flickering [backport 21.1]

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/index.tsx
@@ -37,7 +37,6 @@ import {
   nodesSummarySelector,
   NodesSummary,
   LivenessStatus,
-  selectNodesSummaryValid,
 } from "src/redux/nodes";
 import Alerts from "src/views/shared/containers/alerts";
 import { MetricsDataProvider } from "src/views/shared/containers/metricDataProvider";
@@ -95,7 +94,6 @@ const dashboardDropdownOptions = _.map(dashboards, (dashboard, key) => {
 type MapStateToProps = {
   nodesSummary: NodesSummary;
   hoverState: HoverState;
-  nodesSummaryValid: boolean;
 };
 
 type MapDispatchToProps = {
@@ -290,7 +288,6 @@ export class NodeGraphs extends React.Component<NodeGraphsProps> {
               <ClusterSummaryBar
                 nodesSummary={this.props.nodesSummary}
                 nodeSources={nodeSources}
-                nodesSummaryValid={this.props.nodesSummaryValid}
               />
             </div>
           </div>
@@ -303,7 +300,6 @@ export class NodeGraphs extends React.Component<NodeGraphsProps> {
 const mapStateToProps = (state: AdminUIState): MapStateToProps => ({
   nodesSummary: nodesSummarySelector(state),
   hoverState: hoverStateSelector(state),
-  nodesSummaryValid: selectNodesSummaryValid(state),
 });
 
 const mapDispatchToProps: MapDispatchToProps = {

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/summaryBar.spec.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/summaryBar.spec.tsx
@@ -1,0 +1,77 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import { assert } from "chai";
+import { shallow, mount } from "enzyme";
+import { MemoryRouter as Router } from "react-router-dom";
+
+import { ClusterNodeTotalsComponent } from "./summaryBar";
+import { SummaryStatBreakdown } from "src/views/shared/components/summaryBar";
+
+describe("<ClusterNodeTotals>", () => {
+  it("hidden when no data", () => {
+    const wrapper = shallow(
+      <Router>
+        <ClusterNodeTotalsComponent
+          nodesSummary={null}
+          nodesSummaryEmpty={true}
+        />
+      </Router>,
+    );
+    assert.isTrue(wrapper.html() === "");
+  });
+
+  it("renders", () => {
+    const nodesSummary = {
+      nodeSums: {
+        nodeCounts: {
+          total: 1,
+          healthy: 1,
+          suspect: 0,
+          dead: 0,
+          decommissioned: 0,
+        },
+      },
+    };
+    const wrapper = shallow(
+      <Router>
+        <ClusterNodeTotalsComponent
+          nodesSummary={nodesSummary as any}
+          nodesSummaryEmpty={false}
+        />
+      </Router>,
+    );
+    assert.isTrue(wrapper.find(ClusterNodeTotalsComponent).exists());
+  });
+
+  it("renders dead nodes", () => {
+    const nodesSummary = {
+      nodeSums: {
+        nodeCounts: {
+          total: 2,
+          healthy: 0,
+          suspect: 1,
+          dead: 1,
+          decommissioned: 0,
+        },
+      },
+    };
+    const wrapper = mount(
+      <Router>
+        <ClusterNodeTotalsComponent
+          nodesSummary={nodesSummary as any}
+          nodesSummaryEmpty={false}
+        />
+      </Router>,
+    );
+    assert.isTrue(wrapper.find(SummaryStatBreakdown).exists());
+  });
+});


### PR DESCRIPTION
before: to avoid display wrong values on metrics page - summary
initial load we was hiding this block completly, but this leads to
flickering when new data was requested

after: change condition for hide smmary only when we have no
data to display (initial load). after that we display values as long as
we do not have new to display. do not hide summary block while
request in flight and data become "not valid".

Resolves: #61729

Release note(ui): fix flickering of summary block on metrics page