### PR TITLE
opt: improve statistics and cardinality calculation for enum types

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -1469,49 +1469,49 @@ LIMIT 1] OFFSET 2
             └── • union all
                 │ columns: (a, b)
                 │ ordering: +a,+b
-                │ estimated row count: 30
+                │ estimated row count: 999,995
                 │
                 ├── • union all
                 │   │ columns: (a, b)
                 │   │ ordering: +a,+b
-                │   │ estimated row count: 20
+                │   │ estimated row count: 666,663
                 │   │
                 │   ├── • filter
                 │   │   │ columns: (a, b)
                 │   │   │ ordering: +a,+b
-                │   │   │ estimated row count: 10
+                │   │   │ estimated row count: 333,332
                 │   │   │ filter: b IS NOT NULL
                 │   │   │
                 │   │   └── • scan
                 │   │         columns: (a, b)
                 │   │         ordering: +a,+b
-                │   │         estimated row count: 10 (<0.01% of the table; stats collected <hidden> ago)
+                │   │         estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
                 │   │         table: t56201@key_a_b
                 │   │         spans: /"@"/!NULL-/"@"/PrefixEnd
                 │   │
                 │   └── • filter
                 │       │ columns: (a, b)
                 │       │ ordering: +a,+b
-                │       │ estimated row count: 10
+                │       │ estimated row count: 333,332
                 │       │ filter: b IS NOT NULL
                 │       │
                 │       └── • scan
                 │             columns: (a, b)
                 │             ordering: +a,+b
-                │             estimated row count: 10 (<0.01% of the table; stats collected <hidden> ago)
+                │             estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
                 │             table: t56201@key_a_b
                 │             spans: /"\x80"/!NULL-/"\x80"/PrefixEnd
                 │
                 └── • filter
                     │ columns: (a, b)
                     │ ordering: +a,+b
-                    │ estimated row count: 10
+                    │ estimated row count: 333,332
                     │ filter: b IS NOT NULL
                     │
                     └── • scan
                           columns: (a, b)
                           ordering: +a,+b
-                          estimated row count: 10 (<0.01% of the table; stats collected <hidden> ago)
+                          estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
                           table: t56201@key_a_b
                           spans: /"\xc0"/!NULL-/"\xc0"/PrefixEnd
 
@@ -1555,31 +1555,31 @@ LIMIT 1] OFFSET 2
                 └── • union all
                     │ columns: (b, crdb_region, rowid)
                     │ ordering: +b
-                    │ estimated row count: 10
+                    │ estimated row count: 333,333
                     │
                     ├── • union all
                     │   │ columns: (b, crdb_region, rowid)
                     │   │ ordering: +b
-                    │   │ estimated row count: 7
+                    │   │ estimated row count: 222,222
                     │   │
                     │   ├── • scan
                     │   │     columns: (b, crdb_region, rowid)
                     │   │     ordering: +b
-                    │   │     estimated row count: 3 (<0.01% of the table; stats collected <hidden> ago)
+                    │   │     estimated row count: 111,111 (11% of the table; stats collected <hidden> ago)
                     │   │     table: t56201@key_b_partial (partial index)
                     │   │     spans: /"@"/!NULL-/"@"/PrefixEnd
                     │   │
                     │   └── • scan
                     │         columns: (b, crdb_region, rowid)
                     │         ordering: +b
-                    │         estimated row count: 3 (<0.01% of the table; stats collected <hidden> ago)
+                    │         estimated row count: 111,111 (11% of the table; stats collected <hidden> ago)
                     │         table: t56201@key_b_partial (partial index)
                     │         spans: /"\x80"/!NULL-/"\x80"/PrefixEnd
                     │
                     └── • scan
                           columns: (b, crdb_region, rowid)
                           ordering: +b
-                          estimated row count: 3 (<0.01% of the table; stats collected <hidden> ago)
+                          estimated row count: 111,111 (11% of the table; stats collected <hidden> ago)
                           table: t56201@key_b_partial (partial index)
                           spans: /"\xc0"/!NULL-/"\xc0"/PrefixEnd
 
@@ -1619,31 +1619,31 @@ LIMIT 1] OFFSET 2
             └── • union all
                 │ columns: (c)
                 │ ordering: +c
-                │ estimated row count: 10
+                │ estimated row count: 333,333
                 │
                 ├── • union all
                 │   │ columns: (c)
                 │   │ ordering: +c
-                │   │ estimated row count: 7
+                │   │ estimated row count: 222,222
                 │   │
                 │   ├── • scan
                 │   │     columns: (c)
                 │   │     ordering: +c
-                │   │     estimated row count: 3 (<0.01% of the table; stats collected <hidden> ago)
+                │   │     estimated row count: 111,111 (11% of the table; stats collected <hidden> ago)
                 │   │     table: t56201@key_c_partial (partial index)
                 │   │     spans: /"@"-/"@"/PrefixEnd
                 │   │
                 │   └── • scan
                 │         columns: (c)
                 │         ordering: +c
-                │         estimated row count: 3 (<0.01% of the table; stats collected <hidden> ago)
+                │         estimated row count: 111,111 (11% of the table; stats collected <hidden> ago)
                 │         table: t56201@key_c_partial (partial index)
                 │         spans: /"\x80"-/"\x80"/PrefixEnd
                 │
                 └── • scan
                       columns: (c)
                       ordering: +c
-                      estimated row count: 3 (<0.01% of the table; stats collected <hidden> ago)
+                      estimated row count: 111,111 (11% of the table; stats collected <hidden> ago)
                       table: t56201@key_c_partial (partial index)
                       spans: /"\xc0"-/"\xc0"/PrefixEnd
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/enums
+++ b/pkg/sql/opt/exec/execbuilder/testdata/enums
@@ -10,6 +10,21 @@ CREATE TYPE greeting AS ENUM ('hello', 'howdy', 'hi');
 CREATE TABLE t (x greeting PRIMARY KEY, y greeting, INDEX i (y), FAMILY (x, y));
 INSERT INTO t VALUES ('hello', 'howdy'), ('howdy', 'hi')
 
+# Test that we calculate the correct stats and cardinality.
+query T
+EXPLAIN (OPT,VERBOSE) SELECT * FROM t
+----
+scan t
+ ├── columns: x:1 y:2
+ ├── check constraint expressions
+ │    └── x:1 IN ('hello', 'howdy', 'hi') [outer=(1), constraints=(/1: [/'hello' - /'hello'] [/'howdy' - /'howdy'] [/'hi' - /'hi']; tight)]
+ ├── cardinality: [0 - 3]
+ ├── stats: [rows=3]
+ ├── cost: 18.05
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ └── prune: (1,2)
+
 query T
 EXPLAIN (OPT) SELECT * FROM t WHERE x = 'hello'
 ----
@@ -96,6 +111,26 @@ scan checks@checks_x_y_idx
       ├── [/'hi'/2 - /'hi'/2]
       └── [/'cheers'/2 - /'cheers'/2]
 
+# Test that we calculate the correct stats and cardinality.
+query T
+EXPLAIN (OPT,VERBOSE) SELECT DISTINCT x FROM checks
+----
+distinct-on
+ ├── columns: x:1
+ ├── grouping columns: x:1
+ ├── internal-ordering: +1
+ ├── cardinality: [0 - 4]
+ ├── stats: [rows=4, distinct(1)=4, null(1)=0]
+ ├── cost: 1115.67
+ ├── key: (1)
+ └── scan checks@checks_x_y_idx
+      ├── columns: x:1
+      ├── stats: [rows=1000, distinct(1)=4, null(1)=0]
+      ├── cost: 1105.61
+      ├── ordering: +1
+      ├── prune: (1)
+      └── interesting orderings: (+1)
+
 # Test that a limited, ordered scan is efficient.
 statement ok
 CREATE TABLE composite_key (x greeting, y INT, PRIMARY KEY (x, y), FAMILY (x, y));
@@ -120,3 +155,63 @@ limit
  │         ├── constraint: /26/27: [/'cheers' - /'cheers']
  │         └── limit: 5
  └── 5
+
+statement ok
+CREATE TABLE nulls (x greeting, y int, INDEX (x, y))
+
+# Test that we calculate the correct stats and cardinality including null values.
+query T
+EXPLAIN (OPT,VERBOSE) SELECT x FROM nulls WHERE y < 0 UNION SELECT x FROM nulls WHERE y > 10
+----
+union
+ ├── columns: x:11
+ ├── left columns: nulls.x:1
+ ├── right columns: nulls.x:6
+ ├── internal-ordering: +11
+ ├── cardinality: [0 - 5]
+ ├── stats: [rows=5, distinct(11)=5, null(11)=1]
+ ├── cost: 2278.80667
+ ├── key: (11)
+ ├── interesting orderings: (+11)
+ ├── project
+ │    ├── columns: nulls.x:1
+ │    ├── stats: [rows=333.333333, distinct(1)=5, null(1)=3.33333333]
+ │    ├── cost: 1139.37333
+ │    ├── ordering: +1
+ │    ├── interesting orderings: (+1)
+ │    └── select
+ │         ├── columns: nulls.x:1 y:2
+ │         ├── stats: [rows=333.333333, distinct(1)=5, null(1)=3.33333333, distinct(2)=33.3333333, null(2)=0]
+ │         ├── cost: 1136.03
+ │         ├── ordering: +1
+ │         ├── interesting orderings: (+1,+2)
+ │         ├── scan nulls@nulls_x_y_idx
+ │         │    ├── columns: nulls.x:1 y:2
+ │         │    ├── stats: [rows=1000, distinct(1)=5, null(1)=10, distinct(2)=100, null(2)=10]
+ │         │    ├── cost: 1126.01
+ │         │    ├── ordering: +1
+ │         │    ├── prune: (1,2)
+ │         │    └── interesting orderings: (+1,+2)
+ │         └── filters
+ │              └── y:2 < 0 [outer=(2), constraints=(/2: (/NULL - /-1]; tight)]
+ └── project
+      ├── columns: nulls.x:6
+      ├── stats: [rows=333.333333, distinct(6)=5, null(6)=3.33333333]
+      ├── cost: 1139.37333
+      ├── ordering: +6
+      ├── interesting orderings: (+6)
+      └── select
+           ├── columns: nulls.x:6 y:7
+           ├── stats: [rows=333.333333, distinct(6)=5, null(6)=3.33333333, distinct(7)=33.3333333, null(7)=0]
+           ├── cost: 1136.03
+           ├── ordering: +6
+           ├── interesting orderings: (+6,+7)
+           ├── scan nulls@nulls_x_y_idx
+           │    ├── columns: nulls.x:6 y:7
+           │    ├── stats: [rows=1000, distinct(6)=5, null(6)=10, distinct(7)=100, null(7)=10]
+           │    ├── cost: 1126.01
+           │    ├── ordering: +6
+           │    ├── prune: (6,7)
+           │    └── interesting orderings: (+6,+7)
+           └── filters
+                └── y:7 > 10 [outer=(7), constraints=(/7: [/11 - ]; tight)]

--- a/pkg/sql/opt/exec/execbuilder/testdata/unique
+++ b/pkg/sql/opt/exec/execbuilder/testdata/unique
@@ -2142,7 +2142,7 @@ vectorized: true
 
 # Test that we use the index when available for the update checks.
 query T
-EXPLAIN (VERBOSE) UPDATE uniq_enum SET r = DEFAULT, s = 'baz', i = 3 WHERE r = 'eu-west'
+EXPLAIN (VERBOSE) UPDATE uniq_enum SET r = DEFAULT, s = 'baz', i = 3 WHERE r = 'eu-west' AND i > 10 AND i <= 20
 ----
 distribution: local
 vectorized: true
@@ -2162,7 +2162,7 @@ vectorized: true
 │       │
 │       └── • render
 │           │ columns: (r, s, i, j, r_new, s_new, i_new, check1)
-│           │ estimated row count: 10 (missing stats)
+│           │ estimated row count: 9 (missing stats)
 │           │ render check1: r_new IN ('us-east', 'us-west', 'eu-west')
 │           │ render r: r
 │           │ render s: s
@@ -2174,7 +2174,7 @@ vectorized: true
 │           │
 │           └── • render
 │               │ columns: (r_new, s_new, i_new, r, s, i, j)
-│               │ estimated row count: 10 (missing stats)
+│               │ estimated row count: 9 (missing stats)
 │               │ render r_new: CASE (random() * 3.0)::INT8 WHEN 0 THEN 'us-east' WHEN 1 THEN 'us-west' ELSE 'eu-west' END
 │               │ render s_new: 'baz'
 │               │ render i_new: 3
@@ -2185,9 +2185,10 @@ vectorized: true
 │               │
 │               └── • scan
 │                     columns: (r, s, i, j)
-│                     estimated row count: 10 (missing stats)
+│                     estimated row count: 9 (missing stats)
 │                     table: uniq_enum@primary
-│                     spans: /"\xc0"-/"\xc0"/PrefixEnd
+│                     spans: /"\xc0"/11-/"\xc0"/20/#
+│                     parallel
 │                     locking strength: for update
 │
 ├── • constraint-check
@@ -2212,11 +2213,11 @@ vectorized: true
 │                   │
 │                   └── • cross join (inner)
 │                       │ columns: (r_new, i_new, "lookup_join_const_col_@17")
-│                       │ estimated row count: 30 (missing stats)
+│                       │ estimated row count: 28 (missing stats)
 │                       │
 │                       ├── • project
 │                       │   │ columns: (r_new, i_new)
-│                       │   │ estimated row count: 10 (missing stats)
+│                       │   │ estimated row count: 9 (missing stats)
 │                       │   │
 │                       │   └── • scan buffer
 │                       │         columns: (r, s, i, j, r_new, s_new, i_new, check1)
@@ -2251,11 +2252,11 @@ vectorized: true
                     │
                     └── • cross join (inner)
                         │ columns: (r_new, s_new, i_new, j, "lookup_join_const_col_@27")
-                        │ estimated row count: 30 (missing stats)
+                        │ estimated row count: 28 (missing stats)
                         │
                         ├── • project
                         │   │ columns: (r_new, s_new, i_new, j)
-                        │   │ estimated row count: 10 (missing stats)
+                        │   │ estimated row count: 9 (missing stats)
                         │   │
                         │   └── • scan buffer
                         │         columns: (r, s, i, j, r_new, s_new, i_new, check1)

--- a/pkg/sql/opt/memo/testdata/stats/project
+++ b/pkg/sql/opt/memo/testdata/stats/project
@@ -197,7 +197,8 @@ project
                      ├── columns: column12:12(bool)
                      ├── grouping columns: column12:12(bool)
                      ├── outer: (3)
-                     ├── stats: [rows=10, distinct(12)=10, null(12)=0]
+                     ├── cardinality: [0 - 3]
+                     ├── stats: [rows=3, distinct(12)=3, null(12)=0]
                      ├── key: (12)
                      └── project
                           ├── columns: column12:12(bool)

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -2712,6 +2712,7 @@ SELECT b, count(DISTINCT y) FROM xyzbs GROUP BY b
 group-by
  ├── columns: b:4!null count:8!null
  ├── grouping columns: b:4!null
+ ├── cardinality: [0 - 2]
  ├── key: (4)
  ├── fd: (4)-->(8)
  ├── distinct-on


### PR DESCRIPTION
Prior to this commit, there were three different places in the code
where we calculated the number of distinct values in a span. This
commit unifies them to remove code duplication and allow all three
places to benefit from improvements to one.

As a result, this commit improves statistics estimation and cardinality
calculation for enum values. This commit also improves statistics estimation
for enum values in cases where table statistics are not available or are
stale. Finally, this commit adds logic to use the column type for
cardinality calculation when building logical properties.

Release note (performance improvement): Improved the optimizer's
cardinality estimations for enum columns, including the `crdb_region` column
in `REGIONAL BY ROW` tables, as well as all other columns with user-defined
types. This may result in the optimizer choosing a better query plan in some
cases.