### PR TITLE
roachtest: ensure that bulk roachtest write to different artifact dirs

### DIFF
--- a/pkg/cmd/roachtest/tests/import.go
+++ b/pkg/cmd/roachtest/tests/import.go
@@ -13,6 +13,7 @@ package tests
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -106,7 +107,7 @@ func registerImportTPCC(r registry.Registry) {
 		hc := NewHealthChecker(t, c, c.All())
 		m.Go(hc.Runner)
 
-		tick := initBulkJobPerfArtifacts(ctx, t, testName, timeout)
+		tick, perfBuf := initBulkJobPerfArtifacts(testName, timeout)
 		workloadStr := `./cockroach workload fixtures import tpcc --warehouses=%d --csv-server='http://localhost:8081'`
 		m.Go(func(ctx context.Context) error {
 			defer dul.Done()
@@ -121,7 +122,8 @@ func registerImportTPCC(r registry.Registry) {
 
 			// Upload the perf artifacts to any one of the nodes so that the test
 			// runner copies it into an appropriate directory path.
-			if err := c.PutE(ctx, t.L(), t.PerfArtifactsDir(), t.PerfArtifactsDir(), c.Node(1)); err != nil {
+			dest := filepath.Join(t.PerfArtifactsDir(), "stats.json")
+			if err := c.PutString(ctx, perfBuf.String(), dest, 755, c.Node(1)); err != nil {
 				log.Errorf(ctx, "failed to upload perf artifacts to node: %s", err.Error())
 			}
 			return nil
@@ -180,7 +182,7 @@ func registerImportTPCH(r registry.Registry) {
 			Cluster: r.MakeClusterSpec(item.nodes),
 			Timeout: item.timeout,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-				tick := initBulkJobPerfArtifacts(ctx, t, t.Name(), item.timeout)
+				tick, perfBuf := initBulkJobPerfArtifacts(t.Name(), item.timeout)
 
 				// Randomize starting with encryption-at-rest enabled.
 				c.EncryptAtRandom(true)
@@ -257,7 +259,8 @@ func registerImportTPCH(r registry.Registry) {
 
 					// Upload the perf artifacts to any one of the nodes so that the test
 					// runner copies it into an appropriate directory path.
-					if err := c.PutE(ctx, t.L(), t.PerfArtifactsDir(), t.PerfArtifactsDir(), c.Node(1)); err != nil {
+					dest := filepath.Join(t.PerfArtifactsDir(), "stats.json")
+					if err := c.PutString(ctx, perfBuf.String(), dest, 755, c.Node(1)); err != nil {
 						log.Errorf(ctx, "failed to upload perf artifacts to node: %s", err.Error())
 					}
 					return nil

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net/http"
+	"path/filepath"
 	"sort"
 	"strings"
 	"text/tabwriter"
@@ -411,7 +412,7 @@ func registerRestore(r registry.Registry) {
 				// 	})
 				// })
 
-				tick := initBulkJobPerfArtifacts(ctx, t, testName, item.timeout)
+				tick, perfBuf := initBulkJobPerfArtifacts(testName, item.timeout)
 				m.Go(func(ctx context.Context) error {
 					defer dul.Done()
 					defer hc.Done()
@@ -436,7 +437,8 @@ func registerRestore(r registry.Registry) {
 
 					// Upload the perf artifacts to any one of the nodes so that the test
 					// runner copies it into an appropriate directory path.
-					if err := c.PutE(ctx, t.L(), t.PerfArtifactsDir(), t.PerfArtifactsDir(), c.Node(1)); err != nil {
+					dest := filepath.Join(t.PerfArtifactsDir(), "stats.json")
+					if err := c.PutString(ctx, perfBuf.String(), dest, 755, c.Node(1)); err != nil {
 						log.Errorf(ctx, "failed to upload perf artifacts to node: %s", err.Error())
 					}
 					return nil


### PR DESCRIPTION
This commit updates how bulk jobs write their perf artifacts. They now
just write them to an in-memory buffer and write the buffer when the
test succeeds.

Fixes https://github.com/cockroachdb/cockroach/issues/67379.

Release note: None