### PR TITLE
release-21.1: storage: Add store id to the pebble logs in cockroach

### DIFF
--- a/pkg/base/node_id_test.go
+++ b/pkg/base/node_id_test.go
@@ -47,3 +47,37 @@ func TestNodeIDContainer(t *testing.T) {
 		t.Errorf("string should be 6, not %s", str)
 	}
 }
+
+func TestStoreIDPebbleLog(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	tempstore := &base.StoreIDContainer{}
+	if val := tempstore.Get(); val != 0 {
+		t.Errorf("store ID for temp store should be -1, not %d", val)
+	}
+	tempstore.Set(context.Background(), base.TempStoreID)
+	if val := tempstore.Get(); val != base.TempStoreID {
+		t.Errorf(
+			"store ID for temp store is incorrect, expected %d, but got %d",
+			base.TempStoreID, val)
+	}
+	if str := tempstore.String(); str != "temp" {
+		t.Errorf("String method for temp store should return, temp, not %s", str)
+	}
+
+	store := &base.StoreIDContainer{}
+	if val := store.Get(); val != 0 {
+		t.Errorf("store ID for store should initially be 0, not %d", val)
+	}
+	if str := store.String(); str != "?" {
+		t.Errorf("initial string should be ?, not %s", str)
+	}
+
+	store.Set(context.Background(), 5)
+	if val := store.Get(); val != 5 {
+		t.Errorf("value should be 5, not %d", val)
+	}
+	if str := store.String(); str != "5" {
+		t.Errorf("string should be 5, not %s", str)
+	}
+}

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1384,6 +1384,11 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 	ctx = s.AnnotateCtx(ctx)
 	log.Event(ctx, "read store identity")
 
+	// Communicate store ID to engine, if it needs it.
+	if logSetter, ok := s.engine.(storage.StoreIDSetter); ok {
+		logSetter.SetStoreID(ctx, int32(s.StoreID()))
+	}
+
 	// Add the store ID to the scanner's AmbientContext before starting it, since
 	// the AmbientContext provided during construction did not include it.
 	// Note that this is just a hacky way of getting around that without

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -455,6 +455,8 @@ type Pebble struct {
 	logger pebble.Logger
 
 	wrappedIntentWriter intentDemuxWriter
+
+	storeIDPebbleLog *base.StoreIDContainer
 }
 
 var _ Engine = &Pebble{}
@@ -464,6 +466,25 @@ var _ Engine = &Pebble{}
 // NewPebble(). The optionBytes is a binary serialized baseccl.EncryptionOptions, so that non-CCL
 // code does not depend on CCL code.
 var NewEncryptedEnvFunc func(fs vfs.FS, fr *PebbleFileRegistry, dbDir string, readOnly bool, optionBytes []byte) (vfs.FS, EncryptionStatsHandler, error)
+
+// StoreIDSetter is used to set the store id in the log.
+type StoreIDSetter interface {
+	// SetStoreID can be used to atomically set the store
+	// id as a tag in the pebble logs. Once set, the store id will be visible
+	// in pebble logs in cockroach.
+	SetStoreID(ctx context.Context, storeID int32)
+}
+
+// SetStoreID adds the store id to pebble logs.
+func (p *Pebble) SetStoreID(ctx context.Context, storeID int32) {
+	if p == nil {
+		return
+	}
+	if p.storeIDPebbleLog == nil {
+		return
+	}
+	p.storeIDPebbleLog.Set(ctx, storeID)
+}
 
 // ResolveEncryptedEnvOptions fills in cfg.Opts.FS with an encrypted vfs if this
 // store has encryption-at-rest enabled. Also returns the associated file
@@ -533,6 +554,11 @@ func NewPebble(ctx context.Context, cfg PebbleConfig) (*Pebble, error) {
 	// timeouts that has a copy of the log tags.
 	logCtx := logtags.WithTags(context.Background(), logtags.FromContext(ctx))
 	logCtx = logtags.AddTag(logCtx, "pebble", nil)
+	// The store id, could not necessarily be determined when this function
+	// is called. Therefore, we use a container for the store id.
+	storeIDContainer := &base.StoreIDContainer{}
+	logCtx = logtags.AddTag(logCtx, "s", storeIDContainer)
+
 	cfg.Opts.Logger = pebbleLogger{
 		ctx:   logCtx,
 		depth: 1,
@@ -542,15 +568,16 @@ func NewPebble(ctx context.Context, cfg PebbleConfig) (*Pebble, error) {
 		depth: 2, // skip over the EventListener stack frame
 	})
 	p := &Pebble{
-		path:         cfg.Dir,
-		auxDir:       auxDir,
-		maxSize:      cfg.MaxSize,
-		attrs:        cfg.Attrs,
-		settings:     cfg.Settings,
-		statsHandler: statsHandler,
-		fileRegistry: fileRegistry,
-		fs:           cfg.Opts.FS,
-		logger:       cfg.Opts.Logger,
+		path:             cfg.Dir,
+		auxDir:           auxDir,
+		maxSize:          cfg.MaxSize,
+		attrs:            cfg.Attrs,
+		settings:         cfg.Settings,
+		statsHandler:     statsHandler,
+		fileRegistry:     fileRegistry,
+		fs:               cfg.Opts.FS,
+		logger:           cfg.Opts.Logger,
+		storeIDPebbleLog: storeIDContainer,
 	}
 	p.connectEventMetrics(ctx, &cfg.Opts.EventListener)
 	p.eventListener = &cfg.Opts.EventListener

--- a/pkg/storage/temp_engine.go
+++ b/pkg/storage/temp_engine.go
@@ -107,9 +107,13 @@ func newPebbleTempEngine(
 			Opts:          opts,
 		},
 	)
+
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// Set store ID for the pebble engine.
+	p.SetStoreID(ctx, base.TempStoreID)
 
 	return &pebbleTempEngine{db: p.db}, p, nil
 }


### PR DESCRIPTION
Backport 1/1 commits from #66728.

/cc @cockroachdb/release

---

This change adds the store id to the pebble logger. Since
the store id isn't available when the pebble logger is
created, a struct with an int32 is used as the store id
tag in the log, instead of an int32. The store id in the
struct is updated atomically later when the store id is
available.

Resolves: #64798, #65742

Release note: None
