### PR TITLE
kvserver: unconditionally log lease target transfer after rebalancing

### DIFF
--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -1325,8 +1325,8 @@ func (rq *replicateQueue) shedLease(
 		return noSuitableTarget, nil
 	}
 
+	log.VEventf(ctx, 1, "transferring lease to s%d", target.StoreID)
 	if opts.dryRun {
-		log.VEventf(ctx, 1, "transferring lease to s%d", target.StoreID)
 		return noTransferDryRun, nil
 	}
 


### PR DESCRIPTION
Before this patch, we were only logging the result of a
`replicateQueue.shedLease()` call for simulated allocator runs. This patch
changes that so we can also see this when we manually enqueue a replica through
the `replicateQueue`.

Release note: None