### PR TITLE
sqlmigrations: run stats reporting migrations in tenant clusters

### DIFF
--- a/pkg/ccl/serverccl/BUILD.bazel
+++ b/pkg/ccl/serverccl/BUILD.bazel
@@ -28,6 +28,7 @@ go_test(
         "//pkg/security/securitytest",
         "//pkg/server",
         "//pkg/server/serverpb",
+        "//pkg/settings/cluster",
         "//pkg/sql",
         "//pkg/sql/catalog/catconstants",
         "//pkg/sql/pgwire/pgcode",

--- a/pkg/ccl/serverccl/server_sql_test.go
+++ b/pkg/ccl/serverccl/server_sql_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -158,6 +159,7 @@ func TestIdleExit(t *testing.T) {
 			IdleExitAfter: warmupDuration,
 			TestingKnobs: base.TestingKnobs{
 				TenantTestingKnobs: &sql.TenantTestingKnobs{
+					ClusterSettingsUpdater:    cluster.MakeTestingClusterSettings().MakeUpdater(),
 					IdleExitCountdownDuration: countdownDuration,
 				},
 			},

--- a/pkg/sqlmigrations/migrations.go
+++ b/pkg/sqlmigrations/migrations.go
@@ -95,9 +95,8 @@ var backwardCompatibleMigrations = []migrationDescriptor{
 	},
 	{
 		// Introduced in v1.0. Permanent migration.
-		name:        "enable diagnostics reporting",
-		workFn:      optInToDiagnosticsStatReporting,
-		clusterWide: true,
+		name:   "enable diagnostics reporting",
+		workFn: optInToDiagnosticsStatReporting,
 	},
 	{
 		// Introduced in v1.1. Baked into v2.0.
@@ -169,9 +168,8 @@ var backwardCompatibleMigrations = []migrationDescriptor{
 	},
 	{
 		// Introduced in v2.0. Permanent migration.
-		name:        "initialize cluster.secret",
-		workFn:      initializeClusterSecret,
-		clusterWide: true,
+		name:   "initialize cluster.secret",
+		workFn: initializeClusterSecret,
 	},
 	{
 		// Introduced in v2.0. Repeated in v2.1 below.
@@ -264,8 +262,7 @@ var backwardCompatibleMigrations = []migrationDescriptor{
 	},
 	{
 		// Introduced in v20.1. Baked into v20.2.
-		name:   "add CREATEROLE privilege to admin/root",
-		workFn: nil,
+		name: "add CREATEROLE privilege to admin/root",
 	},
 	{
 		// Introduced in v20.2. Baked into v21.1.


### PR DESCRIPTION
Previously, the two stats reporting migrations were only run by system tenants.
This means that tenant clusters do not have stats reporting enabled (though it
was enabled prior to 21.1 by chance). This commit changes the migrations table
to run these migrations on tenant clusters if they have not yet been run:

  optInToDiagnosticsStatReporting
  initializeClusterSecret

Once we have a patch release for 21.1, these migrations will automatically be
run on all tenant clusters and stats reporting will again work.

Release note: None