### PR TITLE
execgen: fix template function names with argument comments

### DIFF
--- a/pkg/sql/colexec/execgen/datadriven_test.go
+++ b/pkg/sql/colexec/execgen/datadriven_test.go
@@ -36,7 +36,9 @@ func TestExecgen(t *testing.T) {
 				return ""
 			}
 			var sb strings.Builder
-			_ = decorator.Fprint(&sb, f)
+			if err := decorator.Fprint(&sb, f); err != nil {
+				return err.Error()
+			}
 			return sb.String()
 		})
 	})

--- a/pkg/sql/colexec/execgen/execgen.go
+++ b/pkg/sql/colexec/execgen/execgen.go
@@ -34,6 +34,8 @@ func Generate(inputFileContents string) (string, error) {
 
 	// Produce output string.
 	var sb strings.Builder
-	_ = decorator.Fprint(&sb, f)
+	if err := decorator.Fprint(&sb, f); err != nil {
+		panic(err)
+	}
 	return sb.String(), nil
 }

--- a/pkg/sql/colexec/execgen/template.go
+++ b/pkg/sql/colexec/execgen/template.go
@@ -46,6 +46,10 @@ func replaceTemplateVars(
 	// Collect template arguments.
 	for i, param := range info.templateParams {
 		templateArgs[i] = dst.Clone(call.Args[param.fieldOrdinal]).(dst.Expr)
+		// Clear the decorations so that argument comments are not used in
+		// template function names.
+		templateArgs[i].Decorations().Start.Clear()
+		templateArgs[i].Decorations().End.Clear()
 	}
 	// Remove template vars from callsite.
 	newArgs := make([]dst.Expr, 0, len(call.Args)-len(info.templateParams))

--- a/pkg/sql/colexec/execgen/testdata/template
+++ b/pkg/sql/colexec/execgen/testdata/template
@@ -442,3 +442,38 @@ func b_false() int {
 }
 ----
 ----
+
+# Do not include comment decoration in template function names.
+template
+package main
+
+func a() {
+	b(true /* t */)
+}
+
+// execgen:inline
+// execgen:template<t>
+func b(t bool) int {
+	if t {
+	    return 0
+	} else {
+	    return 1
+	}
+}
+----
+----
+package main
+
+func a() {
+	b_true()
+}
+
+// execgen:inline
+const _ = "template_b"
+
+// execgen:inline
+func b_true() int {
+	return 0
+}
+----
+----


### PR DESCRIPTION
#### execgen: do not silently err when producing output string

Previously, execgen would silently fail if `decorator.Fprint` returned
an error. This could happen if templating logic created an invalid DST.
The result of the silent failure was an empty `.eg.go` file without any
indication of what went wrong. Errors are now more explicit which should
give us a starting place for tracking down templating bugs.

Release note: None

#### execgen: fix template function names with argument comments

Previously, execgen would generate invalid DSTs for template function
variants when call sites had comments describing an argument. For
example:

    func a() {
        b(true /* t */)
    }

    // execgen:inline
    // execgen:template<t>
    func b(t bool) {
        // ...
    }

This would produce a template function variant with `/* t */`, which was
invalid because it contains spaces.

Template argument decorations are now cleared to avoid this issue.

Release note: None
