### PR TITLE
backupccl: error out BACKUPs with invalid wildcard targets

### DIFF
--- a/pkg/ccl/backupccl/backupresolver/targets.go
+++ b/pkg/ccl/backupccl/backupresolver/targets.go
@@ -437,6 +437,14 @@ func DescriptorsMatchingTargets(
 			}
 
 		case *tree.AllTablesSelector:
+			resolvedSchema, _, err := r.LookupSchema(ctx, currentDatabase, p.SchemaName.String())
+			if err != nil {
+				return ret, err
+			}
+			if resolvedSchema && !p.ExplicitCatalog {
+				return ret, sqlerrors.NewInvalidWildcardError(tree.ErrString(p))
+			}
+
 			found, prefix, err := resolver.ResolveObjectNamePrefix(ctx, r, currentDatabase, searchPath, &p.ObjectNamePrefix)
 			if err != nil {
 				return ret, err


### PR DESCRIPTION
Previously, BACKUP statements containing wildcard targets with a schema as its prefix would execute successfully. When backing up wildcard targets, there should not be an option to backing up all tables in a schema, instead, users should back up all tables in a database only.

The below command backing up all tables in the `public` schema should error out:
```
BACKUP public.* INTO 'nodelocal://0/backup'
```

Release note (bug fix): For any BACKUP statements having wildcard targets with a schema as its prefix, the BACKUP will now error out.