### PR TITLE
builtin: add {de,}compress builtins

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -2407,6 +2407,8 @@ The swap_ordinate_string parameter is a 2-character string naming the ordinates 
 </span></td></tr>
 <tr><td><a name="chr"></a><code>chr(val: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the character with the code given in <code>val</code>. Inverse function of <code>ascii()</code>.</p>
 </span></td></tr>
+<tr><td><a name="compress"></a><code>compress(data: <a href="bytes.html">bytes</a>, codec: <a href="string.html">string</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Compress <code>data</code> with the specified <code>codec</code> (<code>gzip</code>).</p>
+</span></td></tr>
 <tr><td><a name="concat"></a><code>concat(<a href="string.html">string</a>...) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Concatenates a comma-separated list of strings.</p>
 </span></td></tr>
 <tr><td><a name="concat_ws"></a><code>concat_ws(<a href="string.html">string</a>...) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Uses the first argument as a separator between the concatenation of the subsequent arguments.</p>
@@ -2425,6 +2427,8 @@ tables.
 The output can be used to recreate a database.’</p>
 </span></td></tr>
 <tr><td><a name="decode"></a><code>decode(text: <a href="string.html">string</a>, format: <a href="string.html">string</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Decodes <code>data</code> using <code>format</code> (<code>hex</code> / <code>escape</code> / <code>base64</code>).</p>
+</span></td></tr>
+<tr><td><a name="decompress"></a><code>decompress(data: <a href="bytes.html">bytes</a>, codec: <a href="string.html">string</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Decompress <code>data</code> with the specified <code>codec</code> (<code>gzip</code>).</p>
 </span></td></tr>
 <tr><td><a name="difference"></a><code>difference(source: <a href="string.html">string</a>, target: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Convert two strings to their Soundex codes and then reports the number of matching code positions.</p>
 </span></td></tr>


### PR DESCRIPTION
```
demo@127.0.0.1:26257/movr> select compress('hello there', 'gzip');
                                                        compress
------------------------------------------------------------------------------------------------------------------------
  \037\213\010\000\000\000\000\000\000\377\312H\315\311\311W(\311H-J\005\004\000\000\377\377P\351\022m\013\000\000\000
(1 row)

demo@127.0.0.1:26257/movr> select decompress(compress('hello there', 'gzip'), 'gzip');
  decompress
---------------
  hello there
(1 row)

demo@127.0.0.1:26257/movr> select length(repeat('hi there', 100)::bytes);
  length
----------
     800
(1 row)

demo@127.0.0.1:26257/movr> select length(compress(repeat('hi there', 100)::bytes, 'gzip'));
  length
----------
      39
(1 row)

demo@127.0.0.1:26257/movr> select decompress('not compressed', 'gzip');
ERROR: decompress(): failed to decompress: gzip: invalid header
demo@127.0.0.1:26257/movr> select decompress('bad codec', 'zip');
ERROR: decompress(): only 'gzip' codec is supported for decompress()
SQLSTATE: 22023
```

This commits adds builtins to compress and decompress bytes. The only
codec currently supported is `gzip`.

Release note (sql change): New builtins, compress(data, codec) and
decompress(data, codec), are added which can compress and decompress
bytes with the specified codec.  Gzip is the only currently supported
codec.
