### PR TITLE
builtins: add crdb_internal.read/write_file

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -818,6 +818,10 @@ that allows execution of the reads at the closest available replica without bloc
 </span></td></tr>
 <tr><td><a name="crdb_internal.pb_to_json"></a><code>crdb_internal.pb_to_json(pbname: <a href="string.html">string</a>, data: <a href="bytes.html">bytes</a>, emit_defaults: <a href="bool.html">bool</a>) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Converts protocol message to its JSONB representation.</p>
 </span></td></tr>
+<tr><td><a name="crdb_internal.read_file"></a><code>crdb_internal.read_file(uri: <a href="string.html">string</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Read the content of the file at the supplied external storage URI</p>
+</span></td></tr>
+<tr><td><a name="crdb_internal.write_file"></a><code>crdb_internal.write_file(data: <a href="bytes.html">bytes</a>, uri: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Write the content passed to a file at the supplied external storage URI</p>
+</span></td></tr>
 <tr><td><a name="json_array_length"></a><code>json_array_length(json: jsonb) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns the number of elements in the outermost JSON or JSONB array.</p>
 </span></td></tr>
 <tr><td><a name="json_build_array"></a><code>json_build_array(anyelement...) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Builds a possibly-heterogeneously-typed JSON or JSONB array out of a variadic argument list.</p>

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -212,6 +212,16 @@ func (ep *DummyEvalPlanner) MemberOfWithAdminOption(
 	return nil, errors.WithStack(errEvalPlanner)
 }
 
+// ExternalReadFile is part of the EvalPlanner interface.
+func (*DummyEvalPlanner) ExternalReadFile(ctx context.Context, uri string) ([]byte, error) {
+	return nil, errors.WithStack(errEvalPlanner)
+}
+
+// ExternalWriteFile is part of the EvalPlanner interface.
+func (*DummyEvalPlanner) ExternalWriteFile(ctx context.Context, uri string, content []byte) error {
+	return errors.WithStack(errEvalPlanner)
+}
+
 var _ tree.EvalPlanner = &DummyEvalPlanner{}
 
 var errEvalPlanner = pgerror.New(pgcode.ScalarOperationCannotRunWithoutFullSessionContext,

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -3519,6 +3519,42 @@ may increase either contention or retry errors, or both.`,
 			Volatility: tree.VolatilityImmutable,
 		}),
 
+	"crdb_internal.read_file": makeBuiltin(
+		jsonProps(),
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"uri", types.String},
+			},
+			ReturnType: tree.FixedReturnType(types.Bytes),
+			Fn: func(evalCtx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				uri := string(tree.MustBeDString(args[0]))
+				content, err := evalCtx.Planner.ExternalReadFile(evalCtx.Ctx(), uri)
+				return tree.NewDBytes(tree.DBytes(content)), err
+			},
+			Info:       "Read the content of the file at the supplied external storage URI",
+			Volatility: tree.VolatilityVolatile,
+		}),
+
+	"crdb_internal.write_file": makeBuiltin(
+		jsonProps(),
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"data", types.Bytes},
+				{"uri", types.String},
+			},
+			ReturnType: tree.FixedReturnType(types.Int),
+			Fn: func(evalCtx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				data := tree.MustBeDBytes(args[0])
+				uri := string(tree.MustBeDString(args[1]))
+				if err := evalCtx.Planner.ExternalWriteFile(evalCtx.Ctx(), uri, []byte(data)); err != nil {
+					return nil, err
+				}
+				return tree.NewDInt(tree.DInt(len(data))), nil
+			},
+			Info:       "Write the content passed to a file at the supplied external storage URI",
+			Volatility: tree.VolatilityVolatile,
+		}),
+
 	// Enum functions.
 	"enum_first": makeBuiltin(
 		tree.FunctionProperties{NullableArgs: true, Category: categoryEnum},

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3172,6 +3172,12 @@ type EvalPlanner interface {
 		ctx context.Context,
 		member security.SQLUsername,
 	) (map[security.SQLUsername]bool, error)
+
+	// ExternalReadFile reads the content from an external file URI.
+	ExternalReadFile(ctx context.Context, uri string) ([]byte, error)
+
+	// ExternalWriteFile writes the content to an external file URI.
+	ExternalWriteFile(ctx context.Context, uri string, content []byte) error
 }
 
 // CompactEngineSpanFunc is used to compact an engine key span at the given


### PR DESCRIPTION
Release note (security update): Added the admin-only debugging functions
crdb_internal.read/write_file to read/write bytes from/to external storage URIs
used by BACKUP or IMPORT.