### PR TITLE
roachtest: typeorm reinstall python3-apt

### DIFF
--- a/pkg/cmd/roachtest/tests/typeorm.go
+++ b/pkg/cmd/roachtest/tests/typeorm.go
@@ -59,6 +59,13 @@ func registerTypeORM(r registry.Registry) {
 		t.L().Printf("Supported TypeORM release is %s.", supportedTypeORMRelease)
 
 		if err := repeatRunE(
+			ctx, t, c, node, "maybe fix python3-apt",
+			`sudo apt-get install --reinstall -y python3-apt`,
+		); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repeatRunE(
 			ctx, t, c, node, "update apt-get", `sudo apt-get update`,
 		); err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
Fix `ModuleNotFoundError: No module named 'apt_pkg'` error.

Release note: None