### PR TITLE
generate-test-suites: tell user how to reproduce `bazel query` failure

### DIFF
--- a/pkg/cmd/generate-test-suites/main.go
+++ b/pkg/cmd/generate-test-suites/main.go
@@ -24,6 +24,7 @@ func main() {
 	buf, err := exec.Command("bazel", "query", "kind(go_test, //pkg/...)", "--output=label").Output()
 	if err != nil {
 		log.Printf("Could not query Bazel tests: got error %v", err)
+		log.Println("Run `bazel query 'kind(go_test, //pkg/...)'` to reproduce the failure")
 		os.Exit(1)
 	}
 	labels := strings.Split(string(buf[:]), "\n")


### PR DESCRIPTION
This used to fail with a really confusing error message. Also include
instructions on how to reproduce the failure.

Release note: None