### PR TITLE
rangecache: add a gcassert:noescape

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -2329,8 +2329,8 @@ def go_deps():
         name = "com_github_jordanlewis_gcassert",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/jordanlewis/gcassert",
-        sum = "h1:d1Ov7s7RbMdHcgE1Eh1CxR+yd2TTKYOCHZf92Tm/fLs=",
-        version = "v0.0.0-20200706043056-bf61eb72ee48",
+        sum = "h1:FbSxO07tzDVa/yRmizUG+QKpPWCLsfNhT0Rno2SN+HU=",
+        version = "v0.0.0-20210709222130-81f5df3faab8",
     )
     go_repository(
         name = "com_github_josharian_intern",

--- a/go.mod
+++ b/go.mod
@@ -94,7 +94,7 @@ require (
 	github.com/jackc/pgx v3.6.2+incompatible
 	github.com/jackc/pgx/v4 v4.6.0
 	github.com/jaegertracing/jaeger v1.18.1
-	github.com/jordanlewis/gcassert v0.0.0-20200706043056-bf61eb72ee48
+	github.com/jordanlewis/gcassert v0.0.0-20210709222130-81f5df3faab8
 	github.com/kevinburke/go-bindata v3.13.0+incompatible
 	github.com/kisielk/errcheck v1.5.0
 	github.com/kisielk/gotool v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -870,8 +870,8 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGw
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
-github.com/jordanlewis/gcassert v0.0.0-20200706043056-bf61eb72ee48 h1:d1Ov7s7RbMdHcgE1Eh1CxR+yd2TTKYOCHZf92Tm/fLs=
-github.com/jordanlewis/gcassert v0.0.0-20200706043056-bf61eb72ee48/go.mod h1:Qc93dJSt1iLNJCuG9Gy9ds0k/oh4ckhXGkD4AI3cEtM=
+github.com/jordanlewis/gcassert v0.0.0-20210709222130-81f5df3faab8 h1:FbSxO07tzDVa/yRmizUG+QKpPWCLsfNhT0Rno2SN+HU=
+github.com/jordanlewis/gcassert v0.0.0-20210709222130-81f5df3faab8/go.mod h1:Qc93dJSt1iLNJCuG9Gy9ds0k/oh4ckhXGkD4AI3cEtM=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v0.0.0-20180612202835-f2b4162afba3/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=

--- a/pkg/kv/kvclient/rangecache/range_cache.go
+++ b/pkg/kv/kvclient/rangecache/range_cache.go
@@ -286,6 +286,7 @@ func (et *EvictionToken) clear() {
 //
 // Note that the returned descriptor might have Generation = 0. This means that
 // the descriptor is speculative; it is not know to have committed.
+//gcassert:noescape
 func (et EvictionToken) Desc() *roachpb.RangeDescriptor {
 	if !et.Valid() {
 		return nil

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1953,6 +1953,7 @@ func TestLint(t *testing.T) {
 			"../../sql/colexec/colexecwindow",
 			"../../sql/colfetcher",
 			"../../sql/row",
+			"../../kv/kvclient/rangecache",
 		); err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
#66374 made some changes to the rangecache to avoid allocations.

https://github.com/jordanlewis/gcassert just learned the `//gcassert:noescape` annotation, so upgrade the library, add the annotation to one of the spots that we don't want to escape, and add the rangecache package to the list of packages checked with gcassert.