### PR TITLE
coldata: add Len() to the Column interface

### DIFF
--- a/pkg/col/colserde/arrowbatchconverter.go
+++ b/pkg/col/colserde/arrowbatchconverter.go
@@ -468,7 +468,7 @@ func (c *ArrowBatchConverter) ArrowToBatch(
 			}
 
 		default:
-			var col interface{}
+			var col coldata.Column
 			switch typeconv.TypeFamilyToCanonicalTypeFamily(typ.Family()) {
 			case types.IntFamily:
 				switch typ.Width() {


### PR DESCRIPTION
We have a slightly confusing structure for coldata.Vec: it's an
interface with a single implementation `memColumn` that contains a
`Column`, which is currently defined as an `interface{}`.

However, there are some untyped methods on `Column` that we could be
making actual interface methods to avoid manual type switching, such as
`Len()`.

This commit adds `Len()` to the `Column` interface and removes the
manual type switch in the `Vec.Length()` implementation.

It's possible that we could simplify a great deal of things by
coalescing parts of the `Vec` interface into the `Column` interface,
which would allow more native Go polymorphism in certain places (at the
cost of performance).

Release note: None