### PR TITLE
release-20.2: Avro encoding backports

### DIFF
--- a/pkg/ccl/changefeedccl/avro.go
+++ b/pkg/ccl/changefeedccl/avro.go
@@ -439,6 +439,26 @@ func typeToAvroSchema(typ *types.T) (*avroSchemaField, error) {
 				return tree.MakeDTimestampTZ(x.(time.Time), time.Microsecond)
 			},
 		)
+	case types.IntervalFamily:
+		setNullable(
+			// This would ideally be the avro Duration logical type
+			// However, the spec is not implemented in most tooling
+			// and is problematic--it requires 32-bit integers
+			// representing months, days, and milliseconds, meaning
+			// it can't encode everything we can with our int64 years.
+			// String encoding is still fairly terse and arguably the
+			// only semantically exact representation.
+			// Using ISO 8601 format (https://en.wikipedia.org/wiki/ISO_8601#Durations)
+			// because it's the tersest of the input formats we support
+			// and isn't golang-specific.
+			avroSchemaString,
+			func(d tree.Datum, _ interface{}) (interface{}, error) {
+				return d.(*tree.DInterval).ValueAsISO8601String(), nil
+			},
+			func(x interface{}) (tree.Datum, error) {
+				return tree.ParseDInterval(x.(string))
+			},
+		)
 	case types.DecimalFamily:
 		if typ.Precision() == 0 {
 			return nil, errors.Errorf(

--- a/pkg/ccl/changefeedccl/avro.go
+++ b/pkg/ccl/changefeedccl/avro.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/bitarray"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/timeofday"
 	"github.com/cockroachdb/errors"
@@ -101,6 +102,10 @@ func avroUnionKey(t avroSchemaType) string {
 	}
 }
 
+// memo is either nil or a previously-returned value
+// that can be safely overwritten to save allocs.
+type datumToNativeFn func(datum tree.Datum, memo interface{}) (interface{}, error)
+
 // avroSchemaField is our representation of the schema of a field in an avro
 // record. Serializing it to JSON gives the standard schema representation.
 type avroSchemaField struct {
@@ -113,7 +118,16 @@ type avroSchemaField struct {
 	typ *types.T
 
 	// encodeFn encodes specified tree.Datum as go "native" interface value.
-	encodeFn func(tree.Datum) (interface{}, error)
+	// This function may memoize results to save allocations.
+	encodeFn func(datum tree.Datum) (interface{}, error)
+
+	// encodeDatum encodes specified datum as go "native" interface value.
+	// encodeDatum is a low level encoding function -- it should not memoize
+	// on its own, but may use the passed-in memo.
+	encodeDatum datumToNativeFn
+
+	// decodeFn decodes specified go "native" value into tree.Datum.
+	decodeFn func(interface{}) (tree.Datum, error)
 
 	// Avro encoder treats every field as optional -- that is, we always
 	// allow null values.  As such, every value returned by encodeFn is an
@@ -123,9 +137,6 @@ type avroSchemaField struct {
 	// this map once to avoid repeated map allocations.  We simply update
 	// "union key" value.
 	nativeEncoded map[string]interface{}
-
-	// decodeFn decodes specified go "native" value into tree.Datum.
-	decodeFn func(interface{}) (tree.Datum, error)
 }
 
 // avroRecord is our representation of the schema of an avro record. Serializing
@@ -171,9 +182,7 @@ type avroEnvelopeRecord struct {
 }
 
 // typeToAvroSchema converts a database type to an avro field
-// reuseMap is false for nested elements since the same key may occur multiple times
-// we may need a map pool or a streaming serializer if elements get too big
-func typeToAvroSchema(typ *types.T, reuseMap bool) (*avroSchemaField, error) {
+func typeToAvroSchema(typ *types.T) (*avroSchemaField, error) {
 	schema := &avroSchemaField{
 		typ: typ,
 	}
@@ -185,7 +194,7 @@ func typeToAvroSchema(typ *types.T, reuseMap bool) (*avroSchemaField, error) {
 	// especially for things like loading into analytics databases.
 	setNullable := func(
 		avroType avroSchemaType,
-		encoder func(datum tree.Datum) (interface{}, error),
+		encoder datumToNativeFn,
 		decoder func(interface{}) (tree.Datum, error),
 	) {
 		// The default for a union type is the default for the first element of
@@ -193,20 +202,18 @@ func typeToAvroSchema(typ *types.T, reuseMap bool) (*avroSchemaField, error) {
 		schema.SchemaType = []avroSchemaType{avroSchemaNull, avroType}
 		unionKey := avroUnionKey(avroType)
 		schema.nativeEncoded = map[string]interface{}{unionKey: nil}
+		schema.encodeDatum = encoder
 
 		schema.encodeFn = func(d tree.Datum) (interface{}, error) {
 			if d == tree.DNull {
 				return nil /* value */, nil
 			}
-			encoded, err := encoder(d)
+			encoded, err := encoder(d, schema.nativeEncoded[unionKey])
 			if err != nil {
 				return nil, err
 			}
-			if reuseMap {
-				schema.nativeEncoded[unionKey] = encoded
-				return schema.nativeEncoded, nil
-			}
-			return map[string]interface{}{unionKey: encoded}, nil
+			schema.nativeEncoded[unionKey] = encoded
+			return schema.nativeEncoded, nil
 		}
 		schema.decodeFn = func(x interface{}) (tree.Datum, error) {
 			if x == nil {
@@ -220,7 +227,7 @@ func typeToAvroSchema(typ *types.T, reuseMap bool) (*avroSchemaField, error) {
 	case types.IntFamily:
 		setNullable(
 			avroSchemaLong,
-			func(d tree.Datum) (interface{}, error) {
+			func(d tree.Datum, _ interface{}) (interface{}, error) {
 				return int64(*d.(*tree.DInt)), nil
 			},
 			func(x interface{}) (tree.Datum, error) {
@@ -230,17 +237,54 @@ func typeToAvroSchema(typ *types.T, reuseMap bool) (*avroSchemaField, error) {
 	case types.BoolFamily:
 		setNullable(
 			avroSchemaBoolean,
-			func(d tree.Datum) (interface{}, error) {
+			func(d tree.Datum, _ interface{}) (interface{}, error) {
 				return bool(*d.(*tree.DBool)), nil
 			},
 			func(x interface{}) (tree.Datum, error) {
 				return tree.MakeDBool(tree.DBool(x.(bool))), nil
 			},
 		)
+	case types.BitFamily:
+		setNullable(
+			avroArrayType{
+				SchemaType: avroSchemaArray,
+				Items:      avroSchemaLong,
+			},
+			func(d tree.Datum, memo interface{}) (interface{}, error) {
+				uints, lastBitsUsed := d.(*tree.DBitArray).EncodingParts()
+				var signedLongs []interface{}
+				// reuse a previously allocated array if it exists
+				// and is long enough
+				if memo != nil {
+					signedLongs = memo.([]interface{})
+					if len(signedLongs) > len(uints)+1 {
+						signedLongs = signedLongs[:len(uints)+1]
+					}
+				}
+				if signedLongs == nil {
+					signedLongs = make([]interface{}, len(uints)+1)
+				}
+				signedLongs[0] = int64(lastBitsUsed)
+				for idx, word := range uints {
+					signedLongs[idx+1] = int64(word)
+				}
+				return signedLongs, nil
+			},
+			func(x interface{}) (tree.Datum, error) {
+				arr := x.([]interface{})
+				lastBitsUsed, ints := arr[0], arr[1:]
+				uints := make([]uint64, len(ints))
+				for idx, word := range ints {
+					uints[idx] = uint64(word.(int64))
+				}
+				ba, err := bitarray.FromEncodingParts(uints, uint64(lastBitsUsed.(int64)))
+				return &tree.DBitArray{BitArray: ba}, err
+			},
+		)
 	case types.FloatFamily:
 		setNullable(
 			avroSchemaDouble,
-			func(d tree.Datum) (interface{}, error) {
+			func(d tree.Datum, _ interface{}) (interface{}, error) {
 				return float64(*d.(*tree.DFloat)), nil
 			},
 			func(x interface{}) (tree.Datum, error) {
@@ -250,7 +294,7 @@ func typeToAvroSchema(typ *types.T, reuseMap bool) (*avroSchemaField, error) {
 	case types.Box2DFamily:
 		setNullable(
 			avroSchemaString,
-			func(d tree.Datum) (interface{}, error) {
+			func(d tree.Datum, _ interface{}) (interface{}, error) {
 				return d.(*tree.DBox2D).CartesianBoundingBox.Repr(), nil
 			},
 			func(x interface{}) (tree.Datum, error) {
@@ -264,7 +308,7 @@ func typeToAvroSchema(typ *types.T, reuseMap bool) (*avroSchemaField, error) {
 	case types.GeographyFamily:
 		setNullable(
 			avroSchemaBytes,
-			func(d tree.Datum) (interface{}, error) {
+			func(d tree.Datum, _ interface{}) (interface{}, error) {
 				return []byte(d.(*tree.DGeography).EWKB()), nil
 			},
 			func(x interface{}) (tree.Datum, error) {
@@ -278,7 +322,7 @@ func typeToAvroSchema(typ *types.T, reuseMap bool) (*avroSchemaField, error) {
 	case types.GeometryFamily:
 		setNullable(
 			avroSchemaBytes,
-			func(d tree.Datum) (interface{}, error) {
+			func(d tree.Datum, _ interface{}) (interface{}, error) {
 				return []byte(d.(*tree.DGeometry).EWKB()), nil
 			},
 			func(x interface{}) (tree.Datum, error) {
@@ -292,7 +336,7 @@ func typeToAvroSchema(typ *types.T, reuseMap bool) (*avroSchemaField, error) {
 	case types.StringFamily:
 		setNullable(
 			avroSchemaString,
-			func(d tree.Datum) (interface{}, error) {
+			func(d tree.Datum, _ interface{}) (interface{}, error) {
 				return string(*d.(*tree.DString)), nil
 			},
 			func(x interface{}) (tree.Datum, error) {
@@ -302,7 +346,7 @@ func typeToAvroSchema(typ *types.T, reuseMap bool) (*avroSchemaField, error) {
 	case types.CollatedStringFamily:
 		setNullable(
 			avroSchemaString,
-			func(d tree.Datum) (interface{}, error) {
+			func(d tree.Datum, _ interface{}) (interface{}, error) {
 				return d.(*tree.DCollatedString).Contents, nil
 			},
 			func(x interface{}) (tree.Datum, error) {
@@ -312,7 +356,7 @@ func typeToAvroSchema(typ *types.T, reuseMap bool) (*avroSchemaField, error) {
 	case types.BytesFamily:
 		setNullable(
 			avroSchemaBytes,
-			func(d tree.Datum) (interface{}, error) {
+			func(d tree.Datum, _ interface{}) (interface{}, error) {
 				return []byte(*d.(*tree.DBytes)), nil
 			},
 			func(x interface{}) (tree.Datum, error) {
@@ -325,7 +369,7 @@ func typeToAvroSchema(typ *types.T, reuseMap bool) (*avroSchemaField, error) {
 				SchemaType:  avroSchemaInt,
 				LogicalType: `date`,
 			},
-			func(d tree.Datum) (interface{}, error) {
+			func(d tree.Datum, _ interface{}) (interface{}, error) {
 				date := *d.(*tree.DDate)
 				if !date.IsFinite() {
 					return nil, errors.Errorf(
@@ -345,7 +389,7 @@ func typeToAvroSchema(typ *types.T, reuseMap bool) (*avroSchemaField, error) {
 				SchemaType:  avroSchemaLong,
 				LogicalType: `time-micros`,
 			},
-			func(d tree.Datum) (interface{}, error) {
+			func(d tree.Datum, _ interface{}) (interface{}, error) {
 				// The avro library requires us to return this as a time.Duration.
 				duration := time.Duration(*d.(*tree.DTime)) * time.Microsecond
 				return duration, nil
@@ -361,7 +405,7 @@ func typeToAvroSchema(typ *types.T, reuseMap bool) (*avroSchemaField, error) {
 			avroSchemaString,
 			// We cannot encode this as a long, as it does not encode
 			// timezone correctly.
-			func(d tree.Datum) (interface{}, error) {
+			func(d tree.Datum, _ interface{}) (interface{}, error) {
 				return d.(*tree.DTimeTZ).TimeTZ.String(), nil
 			},
 			func(x interface{}) (tree.Datum, error) {
@@ -375,7 +419,7 @@ func typeToAvroSchema(typ *types.T, reuseMap bool) (*avroSchemaField, error) {
 				SchemaType:  avroSchemaLong,
 				LogicalType: `timestamp-micros`,
 			},
-			func(d tree.Datum) (interface{}, error) {
+			func(d tree.Datum, _ interface{}) (interface{}, error) {
 				return d.(*tree.DTimestamp).Time, nil
 			},
 			func(x interface{}) (tree.Datum, error) {
@@ -388,7 +432,7 @@ func typeToAvroSchema(typ *types.T, reuseMap bool) (*avroSchemaField, error) {
 				SchemaType:  avroSchemaLong,
 				LogicalType: `timestamp-micros`,
 			},
-			func(d tree.Datum) (interface{}, error) {
+			func(d tree.Datum, _ interface{}) (interface{}, error) {
 				return d.(*tree.DTimestampTZ).Time, nil
 			},
 			func(x interface{}) (tree.Datum, error) {
@@ -410,7 +454,7 @@ func typeToAvroSchema(typ *types.T, reuseMap bool) (*avroSchemaField, error) {
 				Precision:   prec,
 				Scale:       width,
 			},
-			func(d tree.Datum) (interface{}, error) {
+			func(d tree.Datum, _ interface{}) (interface{}, error) {
 				dec := d.(*tree.DDecimal).Decimal
 
 				// If the decimal happens to fit a smaller width than the
@@ -444,7 +488,7 @@ func typeToAvroSchema(typ *types.T, reuseMap bool) (*avroSchemaField, error) {
 		// that yet.
 		setNullable(
 			avroSchemaString,
-			func(d tree.Datum) (interface{}, error) {
+			func(d tree.Datum, _ interface{}) (interface{}, error) {
 				return d.(*tree.DUuid).UUID.String(), nil
 			},
 			func(x interface{}) (tree.Datum, error) {
@@ -454,7 +498,7 @@ func typeToAvroSchema(typ *types.T, reuseMap bool) (*avroSchemaField, error) {
 	case types.INetFamily:
 		setNullable(
 			avroSchemaString,
-			func(d tree.Datum) (interface{}, error) {
+			func(d tree.Datum, _ interface{}) (interface{}, error) {
 				return d.(*tree.DIPAddr).IPAddr.String(), nil
 			},
 			func(x interface{}) (tree.Datum, error) {
@@ -464,7 +508,7 @@ func typeToAvroSchema(typ *types.T, reuseMap bool) (*avroSchemaField, error) {
 	case types.JsonFamily:
 		setNullable(
 			avroSchemaString,
-			func(d tree.Datum) (interface{}, error) {
+			func(d tree.Datum, _ interface{}) (interface{}, error) {
 				return d.(*tree.DJSON).JSON.String(), nil
 			},
 			func(x interface{}) (tree.Datum, error) {
@@ -474,7 +518,7 @@ func typeToAvroSchema(typ *types.T, reuseMap bool) (*avroSchemaField, error) {
 	case types.EnumFamily:
 		setNullable(
 			avroSchemaString,
-			func(d tree.Datum) (interface{}, error) {
+			func(d tree.Datum, _ interface{}) (interface{}, error) {
 				return d.(*tree.DEnum).LogicalRep, nil
 			},
 			func(x interface{}) (tree.Datum, error) {
@@ -482,28 +526,70 @@ func typeToAvroSchema(typ *types.T, reuseMap bool) (*avroSchemaField, error) {
 			},
 		)
 	case types.ArrayFamily:
-		itemSchema, err := typeToAvroSchema(typ.ArrayContents(), false /*reuse map*/)
+		itemSchema, err := typeToAvroSchema(typ.ArrayContents())
 		if err != nil {
 			return nil, errors.Wrapf(err, `could not create item schema for %s`,
 				typ)
 		}
+		itemUnionKey := avroUnionKey(itemSchema.SchemaType.([]avroSchemaType)[1])
+
 		setNullable(
 			avroArrayType{
 				SchemaType: avroSchemaArray,
 				Items:      itemSchema.SchemaType,
 			},
-			func(d tree.Datum) (interface{}, error) {
+			func(d tree.Datum, memo interface{}) (interface{}, error) {
 				datumArr := d.(*tree.DArray)
-				avroArr := make([]interface{}, datumArr.Len())
-				for i, elt := range datumArr.Array {
-					encoded, err := itemSchema.encodeFn(elt)
-					if err != nil {
-						return nil, err
+				var avroArr []interface{}
+				if memo != nil {
+					avroArr = memo.([]interface{})
+					if len(avroArr) > datumArr.Len() {
+						avroArr = avroArr[:datumArr.Len()]
 					}
-					avroArr[i] = encoded
+				} else {
+					avroArr = make([]interface{}, 0, datumArr.Len())
+				}
+
+				for i, elt := range datumArr.Array {
+					var encoded interface{}
+					if elt == tree.DNull {
+						encoded = nil
+					} else {
+						var encErr error
+						if i < len(avroArr) {
+							encoded, encErr = itemSchema.encodeDatum(elt, avroArr[i].(map[string]interface{})[itemUnionKey])
+						} else {
+							encoded, encErr = itemSchema.encodeDatum(elt, nil)
+						}
+						if encErr != nil {
+							return nil, encErr
+						}
+					}
+
+					if i < len(avroArr) {
+						// We have previously memoized array value.
+						if encoded == nil {
+							avroArr[i] = encoded
+						} else if itemMap, ok := avroArr[i].(map[string]interface{}); ok {
+							// encoded is not nil and previous value wasn't nil either.
+							itemMap[itemUnionKey] = encoded
+						} else {
+							// encoded is not nil, but previous value was.
+							encMap := make(map[string]interface{})
+							encMap[itemUnionKey] = encoded
+							avroArr[i] = encMap
+						}
+					} else {
+						if encoded == nil {
+							avroArr = append(avroArr, encoded)
+						} else {
+							encMap := make(map[string]interface{})
+							encMap[itemUnionKey] = encoded
+							avroArr = append(avroArr, encMap)
+						}
+					}
 				}
 				return avroArr, nil
-
 			},
 			func(x interface{}) (tree.Datum, error) {
 				datumArr := tree.NewDArray(itemSchema.typ)
@@ -533,7 +619,7 @@ func typeToAvroSchema(typ *types.T, reuseMap bool) (*avroSchemaField, error) {
 // columnToAvroSchema converts a column descriptor into its corresponding
 // avro field schema.
 func columnToAvroSchema(col descpb.ColumnDescriptor) (*avroSchemaField, error) {
-	schema, err := typeToAvroSchema(col.Type, true /*reuse map */)
+	schema, err := typeToAvroSchema(col.Type)
 	if err != nil {
 		return nil, errors.Wrapf(err, "column %s", col.Name)
 	}

--- a/pkg/ccl/changefeedccl/avro.go
+++ b/pkg/ccl/changefeedccl/avro.go
@@ -297,6 +297,16 @@ func typeToAvroSchema(typ *types.T, reuseMap bool) (*avroSchemaField, error) {
 				return tree.NewDString(x.(string)), nil
 			},
 		)
+	case types.CollatedStringFamily:
+		setNullable(
+			avroSchemaString,
+			func(d tree.Datum) (interface{}, error) {
+				return d.(*tree.DCollatedString).Contents, nil
+			},
+			func(x interface{}) (tree.Datum, error) {
+				return tree.NewDCollatedString(x.(string), typ.Locale(), &tree.CollationEnvironment{})
+			},
+		)
 	case types.BytesFamily:
 		setNullable(
 			avroSchemaBytes,

--- a/pkg/ccl/changefeedccl/avro.go
+++ b/pkg/ccl/changefeedccl/avro.go
@@ -103,7 +103,19 @@ type avroSchemaField struct {
 
 	typ *types.T
 
+	// encodeFn encodes specified tree.Datum as go "native" interface value.
 	encodeFn func(tree.Datum) (interface{}, error)
+
+	// Avro encoder treats every field as optional -- that is, we always
+	// allow null values.  As such, every value returned by encodeFn is an
+	// avro record represented as a map with a single "union" key (see avroUnionKey())
+	// and the value either null or the actual encoded value.
+	// nativeEncoded is a map that's returned by encodeFn.  We allocate
+	// this map once to avoid repeated map allocations.  We simply update
+	// "union key" value.
+	nativeEncoded map[string]interface{}
+
+	// decodeFn decodes specified go "native" value into tree.Datum.
 	decodeFn func(interface{}) (tree.Datum, error)
 }
 
@@ -124,7 +136,10 @@ type avroDataRecord struct {
 
 	colIdxByFieldIdx map[int]int
 	fieldIdxByName   map[string]int
-	alloc            rowenc.DatumAlloc
+	// Allocate Go native representation once, to avoid repeated map allocation
+	// when encoding.
+	native map[string]interface{}
+	alloc  rowenc.DatumAlloc
 }
 
 // avroMetadata is the `avroEnvelopeRecord` metadata.
@@ -155,237 +170,289 @@ func columnDescToAvroSchema(colDesc *descpb.ColumnDescriptor) (*avroSchemaField,
 		typ:      colDesc.Type,
 	}
 
-	var avroType avroSchemaType
-	switch colDesc.Type.Family() {
-	case types.IntFamily:
-		avroType = avroSchemaLong
-		schema.encodeFn = func(d tree.Datum) (interface{}, error) {
-			return int64(*d.(*tree.DInt)), nil
-		}
-		schema.decodeFn = func(x interface{}) (tree.Datum, error) {
-			return tree.NewDInt(tree.DInt(x.(int64))), nil
-		}
-	case types.BoolFamily:
-		avroType = avroSchemaBoolean
-		schema.encodeFn = func(d tree.Datum) (interface{}, error) {
-			return bool(*d.(*tree.DBool)), nil
-		}
-		schema.decodeFn = func(x interface{}) (tree.Datum, error) {
-			return tree.MakeDBool(tree.DBool(x.(bool))), nil
-		}
-	case types.FloatFamily:
-		avroType = avroSchemaDouble
-		schema.encodeFn = func(d tree.Datum) (interface{}, error) {
-			return float64(*d.(*tree.DFloat)), nil
-		}
-		schema.decodeFn = func(x interface{}) (tree.Datum, error) {
-			return tree.NewDFloat(tree.DFloat(x.(float64))), nil
-		}
-	case types.Box2DFamily:
-		avroType = avroSchemaString
-		schema.encodeFn = func(d tree.Datum) (interface{}, error) {
-			return d.(*tree.DBox2D).CartesianBoundingBox.Repr(), nil
-		}
-		schema.decodeFn = func(x interface{}) (tree.Datum, error) {
-			b, err := geo.ParseCartesianBoundingBox(x.(string))
-			if err != nil {
-				return nil, err
-			}
-			return tree.NewDBox2D(b), nil
-		}
-	case types.GeographyFamily:
-		avroType = avroSchemaBytes
-		schema.encodeFn = func(d tree.Datum) (interface{}, error) {
-			return []byte(d.(*tree.DGeography).EWKB()), nil
-		}
-		schema.decodeFn = func(x interface{}) (tree.Datum, error) {
-			g, err := geo.ParseGeographyFromEWKBUnsafe(geopb.EWKB(x.([]byte)))
-			if err != nil {
-				return nil, err
-			}
-			return &tree.DGeography{Geography: g}, nil
-		}
-	case types.GeometryFamily:
-		avroType = avroSchemaBytes
-		schema.encodeFn = func(d tree.Datum) (interface{}, error) {
-			return []byte(d.(*tree.DGeometry).EWKB()), nil
-		}
-		schema.decodeFn = func(x interface{}) (tree.Datum, error) {
-			g, err := geo.ParseGeometryFromEWKBUnsafe(geopb.EWKB(x.([]byte)))
-			if err != nil {
-				return nil, err
-			}
-			return &tree.DGeometry{Geometry: g}, nil
-		}
-	case types.StringFamily:
-		avroType = avroSchemaString
-		schema.encodeFn = func(d tree.Datum) (interface{}, error) {
-			return string(*d.(*tree.DString)), nil
-		}
-		schema.decodeFn = func(x interface{}) (tree.Datum, error) {
-			return tree.NewDString(x.(string)), nil
-		}
-	case types.BytesFamily:
-		avroType = avroSchemaBytes
-		schema.encodeFn = func(d tree.Datum) (interface{}, error) {
-			return []byte(*d.(*tree.DBytes)), nil
-		}
-		schema.decodeFn = func(x interface{}) (tree.Datum, error) {
-			return tree.NewDBytes(tree.DBytes(x.([]byte))), nil
-		}
-	case types.DateFamily:
-		avroType = avroLogicalType{
-			SchemaType:  avroSchemaInt,
-			LogicalType: `date`,
-		}
-		schema.encodeFn = func(d tree.Datum) (interface{}, error) {
-			date := *d.(*tree.DDate)
-			if !date.IsFinite() {
-				return nil, errors.Errorf(
-					`column %s: infinite date not yet supported with avro`, colDesc.Name)
-			}
-			// The avro library requires us to return this as a time.Time.
-			return date.ToTime()
-		}
-		schema.decodeFn = func(x interface{}) (tree.Datum, error) {
-			// The avro library hands this back as a time.Time.
-			return tree.NewDDateFromTime(x.(time.Time))
-		}
-	case types.TimeFamily:
-		avroType = avroLogicalType{
-			SchemaType:  avroSchemaLong,
-			LogicalType: `time-micros`,
-		}
-		schema.encodeFn = func(d tree.Datum) (interface{}, error) {
-			// The avro library requires us to return this as a time.Duration.
-			duration := time.Duration(*d.(*tree.DTime)) * time.Microsecond
-			return duration, nil
-		}
-		schema.decodeFn = func(x interface{}) (tree.Datum, error) {
-			// The avro library hands this back as a time.Duration.
-			micros := x.(time.Duration) / time.Microsecond
-			return tree.MakeDTime(timeofday.TimeOfDay(micros)), nil
-		}
-	case types.TimeTZFamily:
-		avroType = avroSchemaString
-		// We cannot encode this as a long, as it does not encode
-		// timezone correctly.
-		schema.encodeFn = func(d tree.Datum) (interface{}, error) {
-			return d.(*tree.DTimeTZ).TimeTZ.String(), nil
-		}
-		schema.decodeFn = func(x interface{}) (tree.Datum, error) {
-			d, _, err := tree.ParseDTimeTZ(nil, x.(string), time.Microsecond)
-			return d, err
-		}
-	case types.TimestampFamily:
-		avroType = avroLogicalType{
-			SchemaType:  avroSchemaLong,
-			LogicalType: `timestamp-micros`,
-		}
-		schema.encodeFn = func(d tree.Datum) (interface{}, error) {
-			return d.(*tree.DTimestamp).Time, nil
-		}
-		schema.decodeFn = func(x interface{}) (tree.Datum, error) {
-			return tree.MakeDTimestamp(x.(time.Time), time.Microsecond)
-		}
-	case types.TimestampTZFamily:
-		avroType = avroLogicalType{
-			SchemaType:  avroSchemaLong,
-			LogicalType: `timestamp-micros`,
-		}
-		schema.encodeFn = func(d tree.Datum) (interface{}, error) {
-			return d.(*tree.DTimestampTZ).Time, nil
-		}
-		schema.decodeFn = func(x interface{}) (tree.Datum, error) {
-			return tree.MakeDTimestampTZ(x.(time.Time), time.Microsecond)
-		}
-	case types.DecimalFamily:
-		if colDesc.Type.Precision() == 0 {
-			return nil, errors.Errorf(
-				`column %s: decimal with no precision not yet supported with avro`, colDesc.Name)
-		}
-		avroType = avroLogicalType{
-			SchemaType:  avroSchemaBytes,
-			LogicalType: `decimal`,
-			Precision:   int(colDesc.Type.Precision()),
-			Scale:       int(colDesc.Type.Width()),
-		}
-		schema.encodeFn = func(d tree.Datum) (interface{}, error) {
-			dec := d.(*tree.DDecimal).Decimal
-			// TODO(dan): For the cases that the avro defined decimal format
-			// would not roundtrip, serialize the decimal as a string. Also
-			// support the unspecified precision/scale case in this branch. We
-			// can't currently do this without surgery to the avro library we're
-			// using and that's too scary leading up to 2.1.0.
-			rat, err := decimalToRat(dec, colDesc.Type.Width())
-			if err != nil {
-				return nil, err
-			}
-			return &rat, nil
-		}
-		schema.decodeFn = func(x interface{}) (tree.Datum, error) {
-			return &tree.DDecimal{Decimal: ratToDecimal(*x.(*big.Rat), colDesc.Type.Width())}, nil
-		}
-	case types.UuidFamily:
-		// Should be logical type of "uuid", but the avro library doesn't support
-		// that yet.
-		avroType = avroSchemaString
-		schema.encodeFn = func(d tree.Datum) (interface{}, error) {
-			return d.(*tree.DUuid).UUID.String(), nil
-		}
-		schema.decodeFn = func(x interface{}) (tree.Datum, error) {
-			return tree.ParseDUuidFromString(x.(string))
-		}
-	case types.INetFamily:
-		avroType = avroSchemaString
-		schema.encodeFn = func(d tree.Datum) (interface{}, error) {
-			return d.(*tree.DIPAddr).IPAddr.String(), nil
-		}
-		schema.decodeFn = func(x interface{}) (tree.Datum, error) {
-			return tree.ParseDIPAddrFromINetString(x.(string))
-		}
-	case types.JsonFamily:
-		avroType = avroSchemaString
-		schema.encodeFn = func(d tree.Datum) (interface{}, error) {
-			return d.(*tree.DJSON).JSON.String(), nil
-		}
-		schema.decodeFn = func(x interface{}) (tree.Datum, error) {
-			return tree.ParseDJSON(x.(string))
-		}
-	default:
-		return nil, errors.Errorf(`column %s: type %s not yet supported with avro`,
-			colDesc.Name, colDesc.Type.SQLString())
-	}
-	schema.SchemaType = avroType
-
 	// Make every field optional by unioning it with null, so that all schema
 	// evolutions for a table are considered "backward compatible" by avro. This
 	// means that the Avro type doesn't mirror the column's nullability, but it
 	// makes it much easier to work with long histories of table data afterward,
 	// especially for things like loading into analytics databases.
-	{
+	setNullable := func(
+		avroType avroSchemaType,
+		encoder func(datum tree.Datum) (interface{}, error),
+		decoder func(interface{}) (tree.Datum, error),
+	) {
 		// The default for a union type is the default for the first element of
 		// the union.
 		schema.SchemaType = []avroSchemaType{avroSchemaNull, avroType}
-		encodeFn := schema.encodeFn
-		decodeFn := schema.decodeFn
 		unionKey := avroUnionKey(avroType)
+		schema.nativeEncoded = map[string]interface{}{unionKey: nil}
+
 		schema.encodeFn = func(d tree.Datum) (interface{}, error) {
 			if d == tree.DNull {
-				return goavro.Union(avroSchemaNull, nil), nil
+				return nil /* value */, nil
 			}
-			encoded, err := encodeFn(d)
+			encoded, err := encoder(d)
 			if err != nil {
 				return nil, err
 			}
-			return goavro.Union(unionKey, encoded), nil
+			schema.nativeEncoded[unionKey] = encoded
+			return schema.nativeEncoded, nil
 		}
 		schema.decodeFn = func(x interface{}) (tree.Datum, error) {
 			if x == nil {
 				return tree.DNull, nil
 			}
-			return decodeFn(x.(map[string]interface{})[unionKey])
+			return decoder(x.(map[string]interface{})[unionKey])
 		}
+	}
+
+	switch colDesc.Type.Family() {
+	case types.IntFamily:
+		setNullable(
+			avroSchemaLong,
+			func(d tree.Datum) (interface{}, error) {
+				return int64(*d.(*tree.DInt)), nil
+			},
+			func(x interface{}) (tree.Datum, error) {
+				return tree.NewDInt(tree.DInt(x.(int64))), nil
+			},
+		)
+	case types.BoolFamily:
+		setNullable(
+			avroSchemaBoolean,
+			func(d tree.Datum) (interface{}, error) {
+				return bool(*d.(*tree.DBool)), nil
+			},
+			func(x interface{}) (tree.Datum, error) {
+				return tree.MakeDBool(tree.DBool(x.(bool))), nil
+			},
+		)
+	case types.FloatFamily:
+		setNullable(
+			avroSchemaDouble,
+			func(d tree.Datum) (interface{}, error) {
+				return float64(*d.(*tree.DFloat)), nil
+			},
+			func(x interface{}) (tree.Datum, error) {
+				return tree.NewDFloat(tree.DFloat(x.(float64))), nil
+			},
+		)
+	case types.Box2DFamily:
+		setNullable(
+			avroSchemaString,
+			func(d tree.Datum) (interface{}, error) {
+				return d.(*tree.DBox2D).CartesianBoundingBox.Repr(), nil
+			},
+			func(x interface{}) (tree.Datum, error) {
+				b, err := geo.ParseCartesianBoundingBox(x.(string))
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDBox2D(b), nil
+			},
+		)
+	case types.GeographyFamily:
+		setNullable(
+			avroSchemaBytes,
+			func(d tree.Datum) (interface{}, error) {
+				return []byte(d.(*tree.DGeography).EWKB()), nil
+			},
+			func(x interface{}) (tree.Datum, error) {
+				g, err := geo.ParseGeographyFromEWKBUnsafe(geopb.EWKB(x.([]byte)))
+				if err != nil {
+					return nil, err
+				}
+				return &tree.DGeography{Geography: g}, nil
+			},
+		)
+	case types.GeometryFamily:
+		setNullable(
+			avroSchemaBytes,
+			func(d tree.Datum) (interface{}, error) {
+				return []byte(d.(*tree.DGeometry).EWKB()), nil
+			},
+			func(x interface{}) (tree.Datum, error) {
+				g, err := geo.ParseGeometryFromEWKBUnsafe(geopb.EWKB(x.([]byte)))
+				if err != nil {
+					return nil, err
+				}
+				return &tree.DGeometry{Geometry: g}, nil
+			},
+		)
+	case types.StringFamily:
+		setNullable(
+			avroSchemaString,
+			func(d tree.Datum) (interface{}, error) {
+				return string(*d.(*tree.DString)), nil
+			},
+			func(x interface{}) (tree.Datum, error) {
+				return tree.NewDString(x.(string)), nil
+			},
+		)
+	case types.BytesFamily:
+		setNullable(
+			avroSchemaBytes,
+			func(d tree.Datum) (interface{}, error) {
+				return []byte(*d.(*tree.DBytes)), nil
+			},
+			func(x interface{}) (tree.Datum, error) {
+				return tree.NewDBytes(tree.DBytes(x.([]byte))), nil
+			},
+		)
+	case types.DateFamily:
+		setNullable(
+			avroLogicalType{
+				SchemaType:  avroSchemaInt,
+				LogicalType: `date`,
+			},
+			func(d tree.Datum) (interface{}, error) {
+				date := *d.(*tree.DDate)
+				if !date.IsFinite() {
+					return nil, errors.Errorf(
+						`column %s: infinite date not yet supported with avro`, colDesc.Name)
+				}
+				// The avro library requires us to return this as a time.Time.
+				return date.ToTime()
+			},
+			func(x interface{}) (tree.Datum, error) {
+				// The avro library hands this back as a time.Time.
+				return tree.NewDDateFromTime(x.(time.Time))
+			},
+		)
+	case types.TimeFamily:
+		setNullable(
+			avroLogicalType{
+				SchemaType:  avroSchemaLong,
+				LogicalType: `time-micros`,
+			},
+			func(d tree.Datum) (interface{}, error) {
+				// The avro library requires us to return this as a time.Duration.
+				duration := time.Duration(*d.(*tree.DTime)) * time.Microsecond
+				return duration, nil
+			},
+			func(x interface{}) (tree.Datum, error) {
+				// The avro library hands this back as a time.Duration.
+				micros := x.(time.Duration) / time.Microsecond
+				return tree.MakeDTime(timeofday.TimeOfDay(micros)), nil
+			},
+		)
+	case types.TimeTZFamily:
+		setNullable(
+			avroSchemaString,
+			// We cannot encode this as a long, as it does not encode
+			// timezone correctly.
+			func(d tree.Datum) (interface{}, error) {
+				return d.(*tree.DTimeTZ).TimeTZ.String(), nil
+			},
+			func(x interface{}) (tree.Datum, error) {
+				d, _, err := tree.ParseDTimeTZ(nil, x.(string), time.Microsecond)
+				return d, err
+			},
+		)
+	case types.TimestampFamily:
+		setNullable(
+			avroLogicalType{
+				SchemaType:  avroSchemaLong,
+				LogicalType: `timestamp-micros`,
+			},
+			func(d tree.Datum) (interface{}, error) {
+				return d.(*tree.DTimestamp).Time, nil
+			},
+			func(x interface{}) (tree.Datum, error) {
+				return tree.MakeDTimestamp(x.(time.Time), time.Microsecond)
+			},
+		)
+	case types.TimestampTZFamily:
+		setNullable(
+			avroLogicalType{
+				SchemaType:  avroSchemaLong,
+				LogicalType: `timestamp-micros`,
+			},
+			func(d tree.Datum) (interface{}, error) {
+				return d.(*tree.DTimestampTZ).Time, nil
+			},
+			func(x interface{}) (tree.Datum, error) {
+				return tree.MakeDTimestampTZ(x.(time.Time), time.Microsecond)
+			},
+		)
+	case types.DecimalFamily:
+		if colDesc.Type.Precision() == 0 {
+			return nil, errors.Errorf(
+				`column %s: decimal with no precision not yet supported with avro`, colDesc.Name)
+		}
+
+		width := int(colDesc.Type.Width())
+		prec := int(colDesc.Type.Precision())
+		setNullable(
+			avroLogicalType{
+				SchemaType:  avroSchemaBytes,
+				LogicalType: `decimal`,
+				Precision:   prec,
+				Scale:       width,
+			},
+			func(d tree.Datum) (interface{}, error) {
+				dec := d.(*tree.DDecimal).Decimal
+
+				// If the decimal happens to fit a smaller width than the
+				// column allows, add trailing zeroes so the scale is constant
+				if colDesc.Type.Width() > -dec.Exponent {
+					_, err := tree.DecimalCtx.WithPrecision(uint32(prec)).Quantize(&dec, &dec, -int32(width))
+					if err != nil {
+						// This should always be possible without rounding since we're using the column def,
+						// but if it's not, WithPrecision will force it to error.
+						return nil, err
+					}
+				}
+
+				// TODO(dan): For the cases that the avro defined decimal format
+				// would not roundtrip, serialize the decimal as a string. Also
+				// support the unspecified precision/scale case in this branch. We
+				// can't currently do this without surgery to the avro library we're
+				// using and that's too scary leading up to 2.1.0.
+				rat, err := decimalToRat(dec, int32(width))
+				if err != nil {
+					return nil, err
+				}
+				return &rat, nil
+			},
+			func(x interface{}) (tree.Datum, error) {
+				return &tree.DDecimal{Decimal: ratToDecimal(*x.(*big.Rat), int32(width))}, nil
+			},
+		)
+	case types.UuidFamily:
+		// Should be logical type of "uuid", but the avro library doesn't support
+		// that yet.
+		setNullable(
+			avroSchemaString,
+			func(d tree.Datum) (interface{}, error) {
+				return d.(*tree.DUuid).UUID.String(), nil
+			},
+			func(x interface{}) (tree.Datum, error) {
+				return tree.ParseDUuidFromString(x.(string))
+			},
+		)
+	case types.INetFamily:
+		setNullable(
+			avroSchemaString,
+			func(d tree.Datum) (interface{}, error) {
+				return d.(*tree.DIPAddr).IPAddr.String(), nil
+			},
+			func(x interface{}) (tree.Datum, error) {
+				return tree.ParseDIPAddrFromINetString(x.(string))
+			},
+		)
+	case types.JsonFamily:
+		setNullable(
+			avroSchemaString,
+			func(d tree.Datum) (interface{}, error) {
+				return d.(*tree.DJSON).JSON.String(), nil
+			},
+			func(x interface{}) (tree.Datum, error) {
+				return tree.ParseDJSON(x.(string))
+			},
+		)
+	default:
+		return nil, errors.Errorf(`column %s: type %s not yet supported with avro`,
+			colDesc.Name, colDesc.Type.SQLString())
 	}
 
 	return schema, nil
@@ -525,18 +592,23 @@ func (r *avroDataRecord) RowFromBinary(buf []byte) (rowenc.EncDatumRow, error) {
 }
 
 func (r *avroDataRecord) nativeFromRow(row rowenc.EncDatumRow) (interface{}, error) {
-	avroDatums := make(map[string]interface{}, len(row))
+	if r.native == nil {
+		// Note that it's safe to reuse r.native without clearing it because all records will
+		// contain the same complete set of fields.
+		r.native = make(map[string]interface{}, len(r.Fields))
+	}
+
 	for fieldIdx, field := range r.Fields {
 		d := row[r.colIdxByFieldIdx[fieldIdx]]
 		if err := d.EnsureDecoded(field.typ, &r.alloc); err != nil {
 			return nil, err
 		}
 		var err error
-		if avroDatums[field.Name], err = field.encodeFn(d.Datum); err != nil {
+		if r.native[field.Name], err = field.encodeFn(d.Datum); err != nil {
 			return nil, err
 		}
 	}
-	return avroDatums, nil
+	return r.native, nil
 }
 
 func (r *avroDataRecord) rowFromNative(native interface{}) (rowenc.EncDatumRow, error) {

--- a/pkg/ccl/changefeedccl/avro.go
+++ b/pkg/ccl/changefeedccl/avro.go
@@ -60,6 +60,7 @@ import (
 type avroSchemaType interface{}
 
 const (
+	avroSchemaArray   = `array`
 	avroSchemaBoolean = `boolean`
 	avroSchemaBytes   = `bytes`
 	avroSchemaDouble  = `double`
@@ -76,12 +77,19 @@ type avroLogicalType struct {
 	Scale       int            `json:"scale,omitempty"`
 }
 
+type avroArrayType struct {
+	SchemaType avroSchemaType `json:"type"`
+	Items      avroSchemaType `json:"items"`
+}
+
 func avroUnionKey(t avroSchemaType) string {
 	switch s := t.(type) {
 	case string:
 		return s
 	case avroLogicalType:
 		return avroUnionKey(s.SchemaType) + `.` + s.LogicalType
+	case avroArrayType:
+		return avroUnionKey(s.SchemaType)
 	case *avroRecord:
 		if s.Namespace == "" {
 			return s.Name
@@ -160,14 +168,12 @@ type avroEnvelopeRecord struct {
 	before, after *avroDataRecord
 }
 
-// columnDescToAvroSchema converts a column descriptor into its corresponding
-// avro field schema.
-func columnDescToAvroSchema(colDesc *descpb.ColumnDescriptor) (*avroSchemaField, error) {
+// typeToAvroSchema converts a database type to an avro field
+// reuseMap is false for nested elements since the same key may occur multiple times
+// we may need a map pool or a streaming serializer if elements get too big
+func typeToAvroSchema(typ *types.T, reuseMap bool) (*avroSchemaField, error) {
 	schema := &avroSchemaField{
-		Name:     SQLNameToAvroName(colDesc.Name),
-		Metadata: colDesc.SQLStringNotHumanReadable(),
-		Default:  nil,
-		typ:      colDesc.Type,
+		typ: typ,
 	}
 
 	// Make every field optional by unioning it with null, so that all schema
@@ -194,8 +200,11 @@ func columnDescToAvroSchema(colDesc *descpb.ColumnDescriptor) (*avroSchemaField,
 			if err != nil {
 				return nil, err
 			}
-			schema.nativeEncoded[unionKey] = encoded
-			return schema.nativeEncoded, nil
+			if reuseMap {
+				schema.nativeEncoded[unionKey] = encoded
+				return schema.nativeEncoded, nil
+			}
+			return map[string]interface{}{unionKey: encoded}, nil
 		}
 		schema.decodeFn = func(x interface{}) (tree.Datum, error) {
 			if x == nil {
@@ -205,7 +214,7 @@ func columnDescToAvroSchema(colDesc *descpb.ColumnDescriptor) (*avroSchemaField,
 		}
 	}
 
-	switch colDesc.Type.Family() {
+	switch typ.Family() {
 	case types.IntFamily:
 		setNullable(
 			avroSchemaLong,
@@ -308,7 +317,7 @@ func columnDescToAvroSchema(colDesc *descpb.ColumnDescriptor) (*avroSchemaField,
 				date := *d.(*tree.DDate)
 				if !date.IsFinite() {
 					return nil, errors.Errorf(
-						`column %s: infinite date not yet supported with avro`, colDesc.Name)
+						`infinite date not yet supported with avro`)
 				}
 				// The avro library requires us to return this as a time.Time.
 				return date.ToTime()
@@ -375,13 +384,13 @@ func columnDescToAvroSchema(colDesc *descpb.ColumnDescriptor) (*avroSchemaField,
 			},
 		)
 	case types.DecimalFamily:
-		if colDesc.Type.Precision() == 0 {
+		if typ.Precision() == 0 {
 			return nil, errors.Errorf(
-				`column %s: decimal with no precision not yet supported with avro`, colDesc.Name)
+				`decimal with no precision not yet supported with avro`)
 		}
 
-		width := int(colDesc.Type.Width())
-		prec := int(colDesc.Type.Precision())
+		width := int(typ.Width())
+		prec := int(typ.Precision())
 		setNullable(
 			avroLogicalType{
 				SchemaType:  avroSchemaBytes,
@@ -394,7 +403,7 @@ func columnDescToAvroSchema(colDesc *descpb.ColumnDescriptor) (*avroSchemaField,
 
 				// If the decimal happens to fit a smaller width than the
 				// column allows, add trailing zeroes so the scale is constant
-				if colDesc.Type.Width() > -dec.Exponent {
+				if typ.Width() > -dec.Exponent {
 					_, err := tree.DecimalCtx.WithPrecision(uint32(prec)).Quantize(&dec, &dec, -int32(width))
 					if err != nil {
 						// This should always be possible without rounding since we're using the column def,
@@ -450,10 +459,65 @@ func columnDescToAvroSchema(colDesc *descpb.ColumnDescriptor) (*avroSchemaField,
 				return tree.ParseDJSON(x.(string))
 			},
 		)
+	case types.ArrayFamily:
+		itemSchema, err := typeToAvroSchema(typ.ArrayContents(), false /*reuse map*/)
+		if err != nil {
+			return nil, errors.Wrapf(err, `could not create item schema for %s`,
+				typ)
+		}
+		setNullable(
+			avroArrayType{
+				SchemaType: avroSchemaArray,
+				Items:      itemSchema.SchemaType,
+			},
+			func(d tree.Datum) (interface{}, error) {
+				datumArr := d.(*tree.DArray)
+				avroArr := make([]interface{}, datumArr.Len())
+				for i, elt := range datumArr.Array {
+					encoded, err := itemSchema.encodeFn(elt)
+					if err != nil {
+						return nil, err
+					}
+					avroArr[i] = encoded
+				}
+				return avroArr, nil
+
+			},
+			func(x interface{}) (tree.Datum, error) {
+				datumArr := tree.NewDArray(itemSchema.typ)
+				avroArr := x.([]interface{})
+				for _, item := range avroArr {
+					itemDatum, err := itemSchema.decodeFn(item)
+					if err != nil {
+						return nil, err
+					}
+					err = datumArr.Append(itemDatum)
+					if err != nil {
+						return nil, err
+					}
+				}
+				return datumArr, nil
+			},
+		)
+
 	default:
-		return nil, errors.Errorf(`column %s: type %s not yet supported with avro`,
-			colDesc.Name, colDesc.Type.SQLString())
+		return nil, errors.Errorf(`type %s not yet supported with avro`,
+			typ.SQLString())
 	}
+
+	return schema, nil
+}
+
+// columnToAvroSchema converts a column descriptor into its corresponding
+// avro field schema.
+func columnToAvroSchema(col descpb.ColumnDescriptor) (*avroSchemaField, error) {
+	schema, err := typeToAvroSchema(col.Type, true /*reuse map */)
+	if err != nil {
+		return nil, errors.Wrapf(err, "column %s", col.Name)
+	}
+	schema.Name = SQLNameToAvroName(col.Name)
+	schema.Metadata = col.SQLStringNotHumanReadable()
+	schema.Default = nil
 
 	return schema, nil
 }
@@ -482,8 +546,9 @@ func indexToAvroSchema(
 		if !ok {
 			return nil, errors.Errorf(`unknown column id: %d`, colID)
 		}
-		col := tableDesc.GetColumnAtIdx(colIdx)
-		field, err := columnDescToAvroSchema(col)
+
+		col := tableDesc.GetPublicColumns()[colIdx]
+		field, err := columnToAvroSchema(col)
 		if err != nil {
 			return nil, err
 		}
@@ -528,9 +593,11 @@ func tableToAvroSchema(
 		fieldIdxByName:   make(map[string]int),
 		colIdxByFieldIdx: make(map[int]int),
 	}
+
 	for colIdx := range tableDesc.GetPublicColumns() {
 		col := tableDesc.GetColumnAtIdx(colIdx)
-		field, err := columnDescToAvroSchema(col)
+		field, err := columnToAvroSchema(*col)
+
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/ccl/changefeedccl/avro_test.go
+++ b/pkg/ccl/changefeedccl/avro_test.go
@@ -240,7 +240,7 @@ func TestAvroSchema(t *testing.T) {
 		case types.AnyFamily, types.OidFamily, types.TupleFamily:
 			// These aren't expected to be needed for changefeeds.
 			return true
-		case types.IntervalFamily, types.BitFamily:
+		case types.IntervalFamily:
 			// Implement these as customer demand dictates.
 			return true
 		case types.ArrayFamily:
@@ -374,12 +374,15 @@ func TestAvroSchema(t *testing.T) {
 			`TIMESTAMP`:         `["null",{"type":"long","logicalType":"timestamp-micros"}]`,
 			`TIMESTAMPTZ`:       `["null",{"type":"long","logicalType":"timestamp-micros"}]`,
 			`UUID`:              `["null","string"]`,
-			`DECIMAL(3,2)`:      `["null",{"type":"bytes","logicalType":"decimal","precision":3,"scale":2}]`,
+			`VARBIT`:            `["null",{"type":"array","items":"long"}]`,
+
+			`BIT(3)`:       `["null",{"type":"array","items":"long"}]`,
+			`DECIMAL(3,2)`: `["null",{"type":"bytes","logicalType":"decimal","precision":3,"scale":2}]`,
 		}
 
-		for _, typ := range append(types.Scalar, types.BoolArray, types.MakeCollatedString(types.String, `fr`)) {
+		for _, typ := range append(types.Scalar, types.BoolArray, types.MakeCollatedString(types.String, `fr`), types.MakeBit(3)) {
 			switch typ.Family() {
-			case types.IntervalFamily, types.OidFamily, types.BitFamily:
+			case types.IntervalFamily, types.OidFamily:
 				continue
 			case types.DecimalFamily:
 				typ = types.MakeDecimal(3, 2)
@@ -502,6 +505,9 @@ func TestAvroSchema(t *testing.T) {
 			{sqlType: `JSONB`,
 				sql:  `'{"b": 1}'`,
 				avro: `{"string":"{\"b\": 1}"}`},
+
+			{sqlType: `VARBIT`, sql: `B'010'`, avro: `{"array":[3,4611686018427387904]}`}, // Take the 3 most significant bits of 1<<62
+
 			{sqlType: `BOOL[]`,
 				sql:  `'{true, true, false, null}'`,
 				avro: `{"array":[{"boolean":true},{"boolean":true},{"boolean":false},null]}`},

--- a/pkg/ccl/changefeedccl/avro_test.go
+++ b/pkg/ccl/changefeedccl/avro_test.go
@@ -171,24 +171,12 @@ func TestAvroSchema(t *testing.T) {
 			values: `(1, 1.23, 4.5)`,
 		},
 	}
-	// Generate a test for each column type with a random datum of that type.
-	for _, typ := range types.OidToType {
-		switch typ.Family() {
-		case types.AnyFamily, types.OidFamily, types.TupleFamily:
-			// These aren't expected to be needed for changefeeds.
-			continue
-		case types.IntervalFamily, types.ArrayFamily, types.BitFamily,
-			types.CollatedStringFamily:
-			// Implement these as customer demand dictates.
-			continue
-		}
-		datum := rowenc.RandDatum(rng, typ, false /* nullOk */)
-		if datum == tree.DNull {
-			// DNull is returned by RandDatum for types.UNKNOWN or if the
-			// column type is unimplemented in RandDatum. In either case, the
-			// correct thing to do is skip this one.
-			continue
-		}
+
+	// Type-specific random logic for when we can't use the randgen library
+	// and/or need to modify the type to add random user-defined values
+	// The returned datum will be nil if we can just use randgen
+	var overrideRandGen func(typ *types.T) (tree.Datum, *types.T)
+	overrideRandGen = func(typ *types.T) (tree.Datum, *types.T) {
 		switch typ.Family() {
 		case types.TimestampFamily:
 			// Truncate to millisecond instead of microsecond because of a bug
@@ -200,31 +188,77 @@ func TestAvroSchema(t *testing.T) {
 			// whose nanosecond representation overflows an
 			// int64, so restrict input to fit.
 			t := randTime(rng).Truncate(time.Millisecond)
-			datum = tree.MustMakeDTimestamp(t, time.Microsecond)
+			return tree.MustMakeDTimestamp(t, time.Microsecond), typ
 		case types.TimestampTZFamily:
 			// See comments above for TimestampFamily.
 			t := randTime(rng).Truncate(time.Millisecond)
-			datum = tree.MustMakeDTimestampTZ(t, time.Microsecond)
+			return tree.MustMakeDTimestampTZ(t, time.Microsecond), typ
 		case types.DecimalFamily:
 			// TODO(dan): Make RandDatum respect Precision and Width instead.
 			// TODO(dan): The precision is really meant to be in [1,10], but it
 			// sure looks like there's an off by one error in the avro library
 			// that makes this test flake if it picks precision of 1.
-			precision := rng.Int31n(10) + 2
-			scale := rng.Int31n(precision + 1)
-			typ = types.MakeDecimal(precision, scale)
+			var precision, scale int32
+			if typ.Precision() < 2 {
+				precision = rng.Int31n(10) + 2
+				scale = rng.Int31n(precision + 1)
+				typ = types.MakeDecimal(precision, scale)
+			} else {
+				precision = typ.Precision()
+				scale = typ.Scale()
+			}
 			coeff := rng.Int63n(int64(math.Pow10(int(precision))))
-			datum = &tree.DDecimal{Decimal: *apd.New(coeff, -scale)}
+			return &tree.DDecimal{Decimal: *apd.New(coeff, -scale)}, typ
 		case types.DateFamily:
 			// TODO(mjibson): goavro mishandles dates whose
 			// nanosecond representation overflows an int64,
 			// so restrict input to fit.
 			var err error
-			datum, err = tree.NewDDateFromTime(randTime(rng))
+			datum, err := tree.NewDDateFromTime(randTime(rng))
 			if err != nil {
 				panic(err)
 			}
+			return datum, typ
 		}
+		return nil, typ
+	}
+
+	// Types we don't support that are present in types.OidToType
+	var skipType func(typ *types.T) bool
+	skipType = func(typ *types.T) bool {
+		switch typ.Family() {
+		case types.AnyFamily, types.OidFamily, types.TupleFamily:
+			// These aren't expected to be needed for changefeeds.
+			return true
+		case types.IntervalFamily, types.BitFamily,
+			types.CollatedStringFamily:
+			// Implement these as customer demand dictates.
+			return true
+		case types.ArrayFamily:
+			// Backported support, but these tests rely on newer randgen
+			// Tested in encoder_test.go instead
+			return true
+		}
+		return false
+	}
+
+	// Generate a test for each column type with a random datum of that type.
+	for _, typ := range types.OidToType {
+		if skipType(typ) {
+			continue
+		}
+		var datum tree.Datum
+		datum, typ = overrideRandGen(typ)
+		if datum == nil {
+			datum = rowenc.RandDatum(rng, typ, false /* nullOk */)
+		}
+		if datum == tree.DNull {
+			// DNull is returned by RandDatum for types.UNKNOWN or if the
+			// column type is unimplemented in RandDatum. In either case, the
+			// correct thing to do is skip this one.
+			continue
+		}
+
 		serializedDatum := tree.Serialize(datum)
 		// name can be "char" (with quotes), so needs to be escaped.
 		escapedName := fmt.Sprintf("%s_table", strings.Replace(typ.String(), "\"", "", -1))
@@ -301,6 +335,7 @@ func TestAvroSchema(t *testing.T) {
 	t.Run("type_goldens", func(t *testing.T) {
 		goldens := map[string]string{
 			`BOOL`:         `["null","boolean"]`,
+			`BOOL[]`:       `["null",{"type":"array","items":["null","boolean"]}]`,
 			`BOX2D`:        `["null","string"]`,
 			`BYTES`:        `["null","bytes"]`,
 			`DATE`:         `["null",{"type":"int","logicalType":"date"}]`,
@@ -319,7 +354,7 @@ func TestAvroSchema(t *testing.T) {
 			`DECIMAL(3,2)`: `["null",{"type":"bytes","logicalType":"decimal","precision":3,"scale":2}]`,
 		}
 
-		for _, typ := range types.Scalar {
+		for _, typ := range append(types.Scalar, types.BoolArray) {
 			switch typ.Family() {
 			case types.IntervalFamily, types.OidFamily, types.BitFamily:
 				continue
@@ -330,7 +365,8 @@ func TestAvroSchema(t *testing.T) {
 			colType := typ.SQLString()
 			tableDesc, err := parseTableDesc(`CREATE TABLE foo (pk INT PRIMARY KEY, a ` + colType + `)`)
 			require.NoError(t, err)
-			field, err := columnDescToAvroSchema(tableDesc.GetColumnAtIdx(1))
+
+			field, err := columnToAvroSchema(tableDesc.GetPublicColumns()[1])
 			require.NoError(t, err)
 			schema, err := json.Marshal(field.SchemaType)
 			require.NoError(t, err)
@@ -443,6 +479,9 @@ func TestAvroSchema(t *testing.T) {
 			{sqlType: `JSONB`,
 				sql:  `'{"b": 1}'`,
 				avro: `{"string":"{\"b\": 1}"}`},
+			{sqlType: `BOOL[]`,
+				sql:  `'{true, true, false, null}'`,
+				avro: `{"array":[{"boolean":true},{"boolean":true},{"boolean":false},null]}`},
 		}
 
 		for _, test := range goldens {

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -486,6 +486,16 @@ func TestChangefeedUserDefinedTypes(t *testing.T) {
 			`tt: [3]->{"after": {"x": 3, "y": "hiya", "z": "bye"}}`,
 			`tt: [4]->{"after": {"x": 4, "y": "hello", "z": "cya"}}`,
 		})
+
+		// If we rename a value in an existing type, it doesn't count as a change
+		// but the rename is reflected in future changes.
+		sqlDB.Exec(t, `ALTER TYPE t RENAME VALUE 'hi' TO 'yo'`)
+		sqlDB.Exec(t, `UPDATE tt SET z='cya' where x=2`)
+
+		assertPayloads(t, cf, []string{
+			`tt: [2]->{"after": {"x": 2, "y": "yo", "z": "cya"}}`,
+		})
+
 	}
 
 	t.Run(`sinkless`, sinklessTest(testFn))

--- a/pkg/ccl/changefeedccl/encoder.go
+++ b/pkg/ccl/changefeedccl/encoder.go
@@ -375,6 +375,10 @@ func (e *confluentAvroEncoder) EncodeKey(ctx context.Context, row encodeRow) ([]
 		e.keyCache[cacheKey] = registered
 	}
 
+	if ok {
+		registered.schema.refreshTypeMetadata(row.tableDesc)
+	}
+
 	// https://docs.confluent.io/current/schema-registry/docs/serializer-formatter.html#wire-format
 	header := []byte{
 		confluentAvroWireFormatMagic,
@@ -428,6 +432,13 @@ func (e *confluentAvroEncoder) EncodeValue(ctx context.Context, row encodeRow) (
 		// TODO(dan): Bound the size of this cache.
 		e.valueCache[cacheKey] = registered
 	}
+	if ok {
+		registered.schema.after.refreshTypeMetadata(row.tableDesc)
+		if row.prevTableDesc != nil && registered.schema.before != nil {
+			registered.schema.before.refreshTypeMetadata(row.prevTableDesc)
+		}
+	}
+
 	var meta avroMetadata
 	if registered.schema.opts.updatedField {
 		meta = map[string]interface{}{

--- a/pkg/ccl/changefeedccl/encoder_test.go
+++ b/pkg/ccl/changefeedccl/encoder_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdctest"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -229,12 +230,14 @@ func TestEncoders(t *testing.T) {
 			}
 			require.NoError(t, err)
 
+			immutable := &tableDesc.(*tabledesc.Mutable).Immutable
+
 			rowInsert := encodeRow{
 				datums:        row,
 				updated:       ts,
-				tableDesc:     tableDesc,
+				tableDesc:     immutable,
 				prevDatums:    nil,
-				prevTableDesc: tableDesc,
+				prevTableDesc: immutable,
 			}
 			keyInsert, err := e.EncodeKey(context.Background(), rowInsert)
 			require.NoError(t, err)
@@ -248,8 +251,8 @@ func TestEncoders(t *testing.T) {
 				deleted:       true,
 				prevDatums:    row,
 				updated:       ts,
-				tableDesc:     tableDesc,
-				prevTableDesc: tableDesc,
+				tableDesc:     immutable,
+				prevTableDesc: immutable,
 			}
 			keyDelete, err := e.EncodeKey(context.Background(), rowDelete)
 			require.NoError(t, err)

--- a/pkg/ccl/changefeedccl/encoder_test.go
+++ b/pkg/ccl/changefeedccl/encoder_test.go
@@ -400,6 +400,40 @@ func TestAvroEncoder(t *testing.T) {
 	t.Run(`enterprise`, enterpriseTest(testFn))
 }
 
+func TestAvroArray(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
+		reg := makeTestSchemaRegistry()
+		defer reg.Close()
+
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b INT[])`)
+		sqlDB.Exec(t,
+			`INSERT INTO foo VALUES 
+			(1, ARRAY[10,20,30]), 
+			(2, NULL), 
+			(3, ARRAY[42, NULL, 42, 43]),
+			(4, ARRAY[])`,
+		)
+
+		foo := feed(t, f, `CREATE CHANGEFEED FOR foo `+
+			`WITH format=$1, confluent_schema_registry=$2, diff, resolved`,
+			changefeedbase.OptFormatAvro, reg.server.URL)
+		defer closeFeed(t, foo)
+		assertPayloadsAvro(t, reg, foo, []string{
+			`foo: {"a":{"long":1}}->{"after":{"foo":{"a":{"long":1},"b":{"array":[{"long":10},{"long":20},{"long":30}]}}},"before":null}`,
+			`foo: {"a":{"long":2}}->{"after":{"foo":{"a":{"long":2},"b":null}},"before":null}`,
+			`foo: {"a":{"long":3}}->{"after":{"foo":{"a":{"long":3},"b":{"array":[{"long":42},null,{"long":42},{"long":43}]}}},"before":null}`,
+			`foo: {"a":{"long":4}}->{"after":{"foo":{"a":{"long":4},"b":{"array":[]}}},"before":null}`,
+		})
+	}
+
+	t.Run(`sinkless`, sinklessTest(testFn))
+	t.Run(`enterprise`, enterpriseTest(testFn))
+}
+
 func TestAvroSchemaNaming(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -2752,6 +2752,12 @@ func (d *DInterval) Min(_ *EvalContext) (Datum, bool) {
 // ValueAsString returns the interval as a string (e.g. "1h2m").
 func (d *DInterval) ValueAsString() string {
 	return d.Duration.String()
+
+}
+
+// ValueAsISO8601String returns the interval as an ISO 8601 Duration string (e.g. "P1Y2MT6S").
+func (d *DInterval) ValueAsISO8601String() string {
+	return d.Duration.ISO8601String()
 }
 
 // AmbiguousFormat implements the Datum interface.

--- a/pkg/sql/sem/tree/interval.go
+++ b/pkg/sql/sem/tree/interval.go
@@ -429,7 +429,7 @@ func iso8601ToDuration(s string) (duration.Duration, error) {
 			l.offset++
 		}
 
-		v := l.consumeInt()
+		v, hasDecimal, vp := l.consumeNum()
 		u := l.consumeUnit('T')
 		if l.err != nil {
 			return d, l.err
@@ -437,6 +437,13 @@ func iso8601ToDuration(s string) (duration.Duration, error) {
 
 		if unit, ok := unitMap[u]; ok {
 			d = d.Add(unit.Mul(v))
+			if hasDecimal {
+				var err error
+				d, err = addFrac(d, unit, vp)
+				if err != nil {
+					return d, err
+				}
+			}
 		} else {
 			return d, pgerror.Newf(
 				pgcode.InvalidDatetimeFormat,

--- a/pkg/sql/sem/tree/interval_test.go
+++ b/pkg/sql/sem/tree/interval_test.go
@@ -563,6 +563,18 @@ func TestISO8601IntervalSyntax(t *testing.T) {
 			if s3 != test.output {
 				t.Fatalf(`%q: as datum, got "%s", expected "%s"`, test.input, s3, test.output)
 			}
+
+			// Test that ISO 8601 output format also round-trips
+			s4 := dur.ISO8601String()
+			di2, err := parseDInterval(s4, test.itm)
+			if err != nil {
+				t.Fatalf(`%q: ISO8601String "%s" unrecognized as datum: %v`, test.input, s4, err)
+			}
+			s5 := di2.Duration.String()
+			if s != s5 {
+				t.Fatalf(`%q: repr "%s" does not round-trip, got %s instead`, test.input, s4, s5)
+			}
+
 		})
 	}
 }

--- a/pkg/storage/enginepb/mvcc3.pb.go
+++ b/pkg/storage/enginepb/mvcc3.pb.go
@@ -4275,7 +4275,9 @@ var (
 	ErrIntOverflowMvcc3   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("storage/enginepb/mvcc3.proto", fileDescriptor_mvcc3_4c1a1e86b5330d4d) }
+func init() {
+	proto.RegisterFile("storage/enginepb/mvcc3.proto", fileDescriptor_mvcc3_4c1a1e86b5330d4d)
+}
 
 var fileDescriptor_mvcc3_4c1a1e86b5330d4d = []byte{
 	// 1190 bytes of a gzipped FileDescriptorProto

--- a/pkg/util/duration/duration.go
+++ b/pkg/util/duration/duration.go
@@ -442,6 +442,61 @@ func (d Duration) Format(buf *bytes.Buffer) {
 	}
 }
 
+// FormatISO8601 emits an ISO 6801 string representation of a Duration to a Buffer truncated to microseconds.
+func (d Duration) FormatISO8601(buf *bytes.Buffer) {
+	buf.WriteString("P")
+	if d.nanos < nanosInMicro && d.Days == 0 && d.Months == 0 {
+		buf.WriteString("T0S")
+		return
+	}
+	months := d.Months
+	if absGE(months, 12) {
+		years := months / 12
+		fmt.Fprintf(buf, "%dY", years)
+		months %= 12
+	}
+	if months != 0 {
+		fmt.Fprintf(buf, "%dM", months)
+	}
+	if d.Days != 0 {
+		fmt.Fprintf(buf, "%dD", d.Days)
+	}
+	if d.nanos == 0 {
+		return
+	}
+	buf.WriteString("T")
+	// Extract abs(d.nanos). See https://play.golang.org/p/U3_gNMpyUew.
+	var nanos uint64
+	sign := ""
+	if d.nanos >= 0 {
+		nanos = uint64(d.nanos)
+	} else {
+		nanos = uint64(-d.nanos)
+		sign = "-"
+	}
+	hn := nanos / hourNanos
+	nanos %= hourNanos
+	mn := nanos / minuteNanos
+	nanos %= minuteNanos
+	sn := nanos / secondNanos
+	nanos %= secondNanos
+	micros := nanos / nanosInMicro
+	if hn != 0 {
+		fmt.Fprintf(buf, "%s%dH", sign, hn)
+	}
+	if mn != 0 {
+		fmt.Fprintf(buf, "%s%dM", sign, mn)
+	}
+	if sn != 0 || micros != 0 {
+		fmt.Fprintf(buf, "%s%d", sign, sn)
+		if micros != 0 {
+			s := fmt.Sprintf(".%06d", micros)
+			buf.WriteString(strings.TrimRight(s, "0"))
+		}
+		buf.WriteString("S")
+	}
+}
+
 func isPlural(i int64) string {
 	if i == 1 {
 		return ""
@@ -462,6 +517,13 @@ func absGE(x, y int64) bool {
 func (d Duration) String() string {
 	var buf bytes.Buffer
 	d.Format(&buf)
+	return buf.String()
+}
+
+// ISO8601String returns an ISO 8601 representation ('P1Y2M3DT4H') of a Duration.
+func (d Duration) ISO8601String() string {
+	var buf bytes.Buffer
+	d.FormatISO8601(&buf)
 	return buf.String()
 }
 

--- a/pkg/util/hlc/timestamp.pb.go
+++ b/pkg/util/hlc/timestamp.pb.go
@@ -435,7 +435,9 @@ var (
 	ErrIntOverflowTimestamp   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("util/hlc/timestamp.proto", fileDescriptor_timestamp_7743fc20d6f93748) }
+func init() {
+	proto.RegisterFile("util/hlc/timestamp.proto", fileDescriptor_timestamp_7743fc20d6f93748)
+}
 
 var fileDescriptor_timestamp_7743fc20d6f93748 = []byte{
 	// 191 bytes of a gzipped FileDescriptorProto


### PR DESCRIPTION
Backports are the same as https://github.com/cockroachdb/cockroach/pull/67433, but manually cherry-picked from that branch to avoid redoing work.  I've also pulled in https://github.com/cockroachdb/cockroach/pull/60570 as it's needed to ensure the Interval type roundtrips correctly.