### PR TITLE
colexec: optimize Bytes sorting with abbreviated values

### DIFF
--- a/pkg/col/coldata/bytes.go
+++ b/pkg/col/coldata/bytes.go
@@ -11,6 +11,7 @@
 package coldata
 
 import (
+	"encoding/binary"
 	"fmt"
 	"strings"
 	"unsafe"
@@ -397,6 +398,51 @@ func (b *Bytes) ProportionalSize(n int64) int64 {
 	// It is possible that we have a "window" into the vector that doesn't start
 	// from the offset of 0, so we have to look at the first actual offset.
 	return FlatBytesOverhead + int64(len(b.data[b.offsets[0]:b.offsets[n]])) + n*memsize.Int32
+}
+
+// Abbreviated returns a uint64 slice where each uint64 represents the first
+// eight bytes of each []byte. It is used for byte comparison fast paths.
+//
+// Given Bytes b, and abbr = b.Abbreviated():
+//
+//   - abbr[i] > abbr[j] iff b.Get(i) > b.Get(j)
+//   - abbr[i] < abbr[j] iff b.Get(i) < b.Get(j)
+//   - If abbr[i] == abbr[j], it is unknown if b.Get(i) is greater than, less
+//     than, or equal to b.Get(j). A full comparison of all bytes in each is
+//     required.
+//
+func (b *Bytes) Abbreviated() []uint64 {
+	r := make([]uint64, b.Len())
+	for i := range r {
+		bs := b.Get(i)
+		r[i] = abbreviate(bs)
+	}
+	return r
+}
+
+// abbreviate interprets up to the first 8 bytes of the slice as a big-endian
+// uint64. If the slice has less than 8 bytes, the value returned is the same as
+// if the slice was filled to 8 bytes with zero value bytes. For example:
+//
+//   abbreviate([]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01})
+//     => 1
+//
+//   abbreviate([]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00})
+//     => 256
+//
+//   abbreviate([]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01})
+//     => 256
+//
+func abbreviate(bs []byte) uint64 {
+	if len(bs) >= 8 {
+		return binary.BigEndian.Uint64(bs)
+	}
+	var v uint64
+	for _, b := range bs {
+		v <<= 8
+		v |= uint64(b)
+	}
+	return v << uint(8*(8-len(bs)))
 }
 
 // Reset resets the underlying Bytes for reuse.

--- a/pkg/col/coldata/bytes_test.go
+++ b/pkg/col/coldata/bytes_test.go
@@ -452,6 +452,35 @@ func TestBytes(t *testing.T) {
 		require.Equal(t, 0, b.maxSetLength)
 		require.NotPanics(t, func() { b.Set(4, []byte("deadbeef")) })
 	})
+
+	t.Run("Abbreviated", func(t *testing.T) {
+		rng, _ := randutil.NewPseudoRand()
+
+		// Create a vector with random bytes values.
+		b := NewBytes(250)
+		for i := 0; i < b.Len(); i++ {
+			size := rng.Intn(32)
+			b.Set(i, randutil.RandBytes(rng, size))
+		}
+
+		// Ensure that for every i and j:
+		//
+		//  - abbr[i] < abbr[j] iff b.Get(i) < b.Get(j)
+		//  - abbr[i] > abbr[j] iff b.Get(i) > b.Get(j)
+		//
+		abbr := b.Abbreviated()
+		for i := 0; i < b.Len(); i++ {
+			for j := 0; j < b.Len(); j++ {
+				cmp := bytes.Compare(b.Get(i), b.Get(j))
+				if abbr[i] < abbr[j] && cmp >= 0 {
+					t.Errorf("abbr value of %v should not be less than %v", b.Get(i), b.Get(j))
+				}
+				if abbr[i] > abbr[j] && cmp <= 0 {
+					t.Errorf("abbr value of %v should not be greater than %v", b.Get(i), b.Get(j))
+				}
+			}
+		}
+	})
 }
 
 func TestProportionalSize(t *testing.T) {

--- a/pkg/sql/colexec/BUILD.bazel
+++ b/pkg/sql/colexec/BUILD.bazel
@@ -179,6 +179,7 @@ go_test(
         "//pkg/util/mon",
         "//pkg/util/randutil",
         "//pkg/util/timeofday",
+        "//pkg/util/uuid",
         "@com_github_apache_arrow_go_arrow//array",
         "@com_github_cockroachdb_apd_v2//:apd",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/sql/colexec/execgen/cmd/execgen/BUILD.bazel
+++ b/pkg/sql/colexec/execgen/cmd/execgen/BUILD.bazel
@@ -35,6 +35,7 @@ go_library(
         "min_max_agg_gen.go",
         "ntile_gen.go",
         "ordered_synchronizer_gen.go",
+        "overloads_abbr.go",
         "overloads_base.go",
         "overloads_bin.go",
         "overloads_cmp.go",

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_abbr.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_abbr.go
@@ -1,0 +1,55 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import "github.com/cockroachdb/cockroach/pkg/sql/types"
+
+// CanAbbreviate returns true if the canonical type family supports abbreviation
+// to a uint64 that can be used for comparison fast paths.
+//
+// For each type for which CanAbbreviate() returns true, a corresponding method
+// must be defined on the type called Abbreviated that returns a []uint64
+// representing abbreviated values for each datum in the vector. Given datums a
+// and b, the following properties must hold true for the respective abbreviated
+// values abbrA and abbrB:
+//
+//   - abbrA > abbrB iff a > b
+//   - abbrA < abbrB iff a < b
+//   - If abbrA == abbrB, it is unknown if a is greater than, less than, or
+//     equal to b. A full comparison of all bytes in each is required.
+//
+// For an example, see Bytes.Abbreviated.
+//
+// Some operations, especially sorting, spend a significant amount of time
+// performing comparisons between two datums. Abbreviating values to a uint64
+// helps optimize these comparisons for datums that are larger than the size of
+// the system's native pointer (64-bits). If the abbreviated values of two
+// datums are different, there is no need to compare the full value of the
+// datums.
+//
+// This improves comparison performance for two reasons. First, comparing two
+// uint64s is a single CPU instruction. Any datum larger than 64 bits requires
+// multiple instructions for comparison. Second, CPU caches are more efficiently
+// used because the abbreviated values of a vector are packed into a []uint64 of
+// contiguous memory. This increases the chance that two datums can be compared
+// by only fetching information from CPU caches rather than main memory.
+func (b *argWidthOverloadBase) CanAbbreviate() bool {
+	switch b.CanonicalTypeFamily {
+	case types.BytesFamily:
+		return true
+	}
+	return false
+}
+
+// Remove unused warnings.
+var (
+	_ = awob.CanAbbreviate
+)

--- a/pkg/sql/colexec/sort.eg.go
+++ b/pkg/sql/colexec/sort.eg.go
@@ -19,7 +19,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/memsize"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/errors"
@@ -421,17 +423,28 @@ func newSingleSorter(
 }
 
 type sortBoolAscWithNullsOp struct {
+	allocator     *colmem.Allocator
 	sortCol       coldata.Bools
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortBoolAscWithNullsOp) init(ctx context.Context, col coldata.Vec, order []int) {
+func (s *sortBoolAscWithNullsOp) init(
+	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+) {
+	s.allocator = allocator
 	s.sortCol = col.Bool()
 	s.nulls = col.Nulls()
 	s.order = order
 	s.cancelChecker.Init(ctx)
+}
+
+func (s *sortBoolAscWithNullsOp) reset() {
+	s.sortCol = nil
+	s.nulls = nil
+	s.order = nil
+	s.allocator = nil
 }
 
 func (s *sortBoolAscWithNullsOp) sort() {
@@ -468,10 +481,14 @@ func (s *sortBoolAscWithNullsOp) Less(i, j int) bool {
 	} else if n2 {
 		return false
 	}
+
+	order1 := s.order[i]
+	order2 := s.order[j]
+
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i])
-	arg2 := s.sortCol.Get(s.order[j])
+	arg1 := s.sortCol.Get(order1)
+	arg2 := s.sortCol.Get(order2)
 
 	{
 		var cmpResult int
@@ -500,17 +517,33 @@ func (s *sortBoolAscWithNullsOp) Len() int {
 }
 
 type sortBytesAscWithNullsOp struct {
-	sortCol       *coldata.Bytes
-	nulls         *coldata.Nulls
-	order         []int
-	cancelChecker colexecutils.CancelChecker
+	allocator          *colmem.Allocator
+	sortCol            *coldata.Bytes
+	abbreviatedSortCol []uint64
+	nulls              *coldata.Nulls
+	order              []int
+	cancelChecker      colexecutils.CancelChecker
 }
 
-func (s *sortBytesAscWithNullsOp) init(ctx context.Context, col coldata.Vec, order []int) {
+func (s *sortBytesAscWithNullsOp) init(
+	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+) {
+	s.allocator = allocator
 	s.sortCol = col.Bytes()
+	s.allocator.AdjustMemoryUsage(memsize.Uint64 * int64(s.sortCol.Len()))
+	s.abbreviatedSortCol = s.sortCol.Abbreviated()
 	s.nulls = col.Nulls()
 	s.order = order
 	s.cancelChecker.Init(ctx)
+}
+
+func (s *sortBytesAscWithNullsOp) reset() {
+	s.allocator.AdjustMemoryUsage(0 - memsize.Uint64*int64(s.sortCol.Len()))
+	s.abbreviatedSortCol = nil
+	s.sortCol = nil
+	s.nulls = nil
+	s.order = nil
+	s.allocator = nil
 }
 
 func (s *sortBytesAscWithNullsOp) sort() {
@@ -547,10 +580,23 @@ func (s *sortBytesAscWithNullsOp) Less(i, j int) bool {
 	} else if n2 {
 		return false
 	}
+
+	order1 := s.order[i]
+	order2 := s.order[j]
+
+	// If the type can be abbreviated as a uint64, compare the abbreviated
+	// values first. If they are not equal, we are done with the comparison. If
+	// they are equal, we must fallback to a full comparison of the datums.
+	abbr1 := s.abbreviatedSortCol[order1]
+	abbr2 := s.abbreviatedSortCol[order2]
+	if abbr1 != abbr2 {
+		return abbr1 < abbr2
+	}
+
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i])
-	arg2 := s.sortCol.Get(s.order[j])
+	arg1 := s.sortCol.Get(order1)
+	arg2 := s.sortCol.Get(order2)
 
 	{
 		var cmpResult int
@@ -571,17 +617,28 @@ func (s *sortBytesAscWithNullsOp) Len() int {
 }
 
 type sortDecimalAscWithNullsOp struct {
+	allocator     *colmem.Allocator
 	sortCol       coldata.Decimals
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortDecimalAscWithNullsOp) init(ctx context.Context, col coldata.Vec, order []int) {
+func (s *sortDecimalAscWithNullsOp) init(
+	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+) {
+	s.allocator = allocator
 	s.sortCol = col.Decimal()
 	s.nulls = col.Nulls()
 	s.order = order
 	s.cancelChecker.Init(ctx)
+}
+
+func (s *sortDecimalAscWithNullsOp) reset() {
+	s.sortCol = nil
+	s.nulls = nil
+	s.order = nil
+	s.allocator = nil
 }
 
 func (s *sortDecimalAscWithNullsOp) sort() {
@@ -618,10 +675,14 @@ func (s *sortDecimalAscWithNullsOp) Less(i, j int) bool {
 	} else if n2 {
 		return false
 	}
+
+	order1 := s.order[i]
+	order2 := s.order[j]
+
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i])
-	arg2 := s.sortCol.Get(s.order[j])
+	arg1 := s.sortCol.Get(order1)
+	arg2 := s.sortCol.Get(order2)
 
 	{
 		var cmpResult int
@@ -642,17 +703,28 @@ func (s *sortDecimalAscWithNullsOp) Len() int {
 }
 
 type sortInt16AscWithNullsOp struct {
+	allocator     *colmem.Allocator
 	sortCol       coldata.Int16s
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortInt16AscWithNullsOp) init(ctx context.Context, col coldata.Vec, order []int) {
+func (s *sortInt16AscWithNullsOp) init(
+	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+) {
+	s.allocator = allocator
 	s.sortCol = col.Int16()
 	s.nulls = col.Nulls()
 	s.order = order
 	s.cancelChecker.Init(ctx)
+}
+
+func (s *sortInt16AscWithNullsOp) reset() {
+	s.sortCol = nil
+	s.nulls = nil
+	s.order = nil
+	s.allocator = nil
 }
 
 func (s *sortInt16AscWithNullsOp) sort() {
@@ -689,10 +761,14 @@ func (s *sortInt16AscWithNullsOp) Less(i, j int) bool {
 	} else if n2 {
 		return false
 	}
+
+	order1 := s.order[i]
+	order2 := s.order[j]
+
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i])
-	arg2 := s.sortCol.Get(s.order[j])
+	arg1 := s.sortCol.Get(order1)
+	arg2 := s.sortCol.Get(order2)
 
 	{
 		var cmpResult int
@@ -724,17 +800,28 @@ func (s *sortInt16AscWithNullsOp) Len() int {
 }
 
 type sortInt32AscWithNullsOp struct {
+	allocator     *colmem.Allocator
 	sortCol       coldata.Int32s
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortInt32AscWithNullsOp) init(ctx context.Context, col coldata.Vec, order []int) {
+func (s *sortInt32AscWithNullsOp) init(
+	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+) {
+	s.allocator = allocator
 	s.sortCol = col.Int32()
 	s.nulls = col.Nulls()
 	s.order = order
 	s.cancelChecker.Init(ctx)
+}
+
+func (s *sortInt32AscWithNullsOp) reset() {
+	s.sortCol = nil
+	s.nulls = nil
+	s.order = nil
+	s.allocator = nil
 }
 
 func (s *sortInt32AscWithNullsOp) sort() {
@@ -771,10 +858,14 @@ func (s *sortInt32AscWithNullsOp) Less(i, j int) bool {
 	} else if n2 {
 		return false
 	}
+
+	order1 := s.order[i]
+	order2 := s.order[j]
+
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i])
-	arg2 := s.sortCol.Get(s.order[j])
+	arg1 := s.sortCol.Get(order1)
+	arg2 := s.sortCol.Get(order2)
 
 	{
 		var cmpResult int
@@ -806,17 +897,28 @@ func (s *sortInt32AscWithNullsOp) Len() int {
 }
 
 type sortInt64AscWithNullsOp struct {
+	allocator     *colmem.Allocator
 	sortCol       coldata.Int64s
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortInt64AscWithNullsOp) init(ctx context.Context, col coldata.Vec, order []int) {
+func (s *sortInt64AscWithNullsOp) init(
+	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+) {
+	s.allocator = allocator
 	s.sortCol = col.Int64()
 	s.nulls = col.Nulls()
 	s.order = order
 	s.cancelChecker.Init(ctx)
+}
+
+func (s *sortInt64AscWithNullsOp) reset() {
+	s.sortCol = nil
+	s.nulls = nil
+	s.order = nil
+	s.allocator = nil
 }
 
 func (s *sortInt64AscWithNullsOp) sort() {
@@ -853,10 +955,14 @@ func (s *sortInt64AscWithNullsOp) Less(i, j int) bool {
 	} else if n2 {
 		return false
 	}
+
+	order1 := s.order[i]
+	order2 := s.order[j]
+
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i])
-	arg2 := s.sortCol.Get(s.order[j])
+	arg1 := s.sortCol.Get(order1)
+	arg2 := s.sortCol.Get(order2)
 
 	{
 		var cmpResult int
@@ -888,17 +994,28 @@ func (s *sortInt64AscWithNullsOp) Len() int {
 }
 
 type sortFloat64AscWithNullsOp struct {
+	allocator     *colmem.Allocator
 	sortCol       coldata.Float64s
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortFloat64AscWithNullsOp) init(ctx context.Context, col coldata.Vec, order []int) {
+func (s *sortFloat64AscWithNullsOp) init(
+	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+) {
+	s.allocator = allocator
 	s.sortCol = col.Float64()
 	s.nulls = col.Nulls()
 	s.order = order
 	s.cancelChecker.Init(ctx)
+}
+
+func (s *sortFloat64AscWithNullsOp) reset() {
+	s.sortCol = nil
+	s.nulls = nil
+	s.order = nil
+	s.allocator = nil
 }
 
 func (s *sortFloat64AscWithNullsOp) sort() {
@@ -935,10 +1052,14 @@ func (s *sortFloat64AscWithNullsOp) Less(i, j int) bool {
 	} else if n2 {
 		return false
 	}
+
+	order1 := s.order[i]
+	order2 := s.order[j]
+
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i])
-	arg2 := s.sortCol.Get(s.order[j])
+	arg1 := s.sortCol.Get(order1)
+	arg2 := s.sortCol.Get(order2)
 
 	{
 		var cmpResult int
@@ -978,17 +1099,28 @@ func (s *sortFloat64AscWithNullsOp) Len() int {
 }
 
 type sortTimestampAscWithNullsOp struct {
+	allocator     *colmem.Allocator
 	sortCol       coldata.Times
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortTimestampAscWithNullsOp) init(ctx context.Context, col coldata.Vec, order []int) {
+func (s *sortTimestampAscWithNullsOp) init(
+	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+) {
+	s.allocator = allocator
 	s.sortCol = col.Timestamp()
 	s.nulls = col.Nulls()
 	s.order = order
 	s.cancelChecker.Init(ctx)
+}
+
+func (s *sortTimestampAscWithNullsOp) reset() {
+	s.sortCol = nil
+	s.nulls = nil
+	s.order = nil
+	s.allocator = nil
 }
 
 func (s *sortTimestampAscWithNullsOp) sort() {
@@ -1025,10 +1157,14 @@ func (s *sortTimestampAscWithNullsOp) Less(i, j int) bool {
 	} else if n2 {
 		return false
 	}
+
+	order1 := s.order[i]
+	order2 := s.order[j]
+
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i])
-	arg2 := s.sortCol.Get(s.order[j])
+	arg1 := s.sortCol.Get(order1)
+	arg2 := s.sortCol.Get(order2)
 
 	{
 		var cmpResult int
@@ -1056,17 +1192,28 @@ func (s *sortTimestampAscWithNullsOp) Len() int {
 }
 
 type sortIntervalAscWithNullsOp struct {
+	allocator     *colmem.Allocator
 	sortCol       coldata.Durations
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortIntervalAscWithNullsOp) init(ctx context.Context, col coldata.Vec, order []int) {
+func (s *sortIntervalAscWithNullsOp) init(
+	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+) {
+	s.allocator = allocator
 	s.sortCol = col.Interval()
 	s.nulls = col.Nulls()
 	s.order = order
 	s.cancelChecker.Init(ctx)
+}
+
+func (s *sortIntervalAscWithNullsOp) reset() {
+	s.sortCol = nil
+	s.nulls = nil
+	s.order = nil
+	s.allocator = nil
 }
 
 func (s *sortIntervalAscWithNullsOp) sort() {
@@ -1103,10 +1250,14 @@ func (s *sortIntervalAscWithNullsOp) Less(i, j int) bool {
 	} else if n2 {
 		return false
 	}
+
+	order1 := s.order[i]
+	order2 := s.order[j]
+
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i])
-	arg2 := s.sortCol.Get(s.order[j])
+	arg1 := s.sortCol.Get(order1)
+	arg2 := s.sortCol.Get(order2)
 
 	{
 		var cmpResult int
@@ -1127,17 +1278,28 @@ func (s *sortIntervalAscWithNullsOp) Len() int {
 }
 
 type sortJSONAscWithNullsOp struct {
+	allocator     *colmem.Allocator
 	sortCol       *coldata.JSONs
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortJSONAscWithNullsOp) init(ctx context.Context, col coldata.Vec, order []int) {
+func (s *sortJSONAscWithNullsOp) init(
+	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+) {
+	s.allocator = allocator
 	s.sortCol = col.JSON()
 	s.nulls = col.Nulls()
 	s.order = order
 	s.cancelChecker.Init(ctx)
+}
+
+func (s *sortJSONAscWithNullsOp) reset() {
+	s.sortCol = nil
+	s.nulls = nil
+	s.order = nil
+	s.allocator = nil
 }
 
 func (s *sortJSONAscWithNullsOp) sort() {
@@ -1174,10 +1336,14 @@ func (s *sortJSONAscWithNullsOp) Less(i, j int) bool {
 	} else if n2 {
 		return false
 	}
+
+	order1 := s.order[i]
+	order2 := s.order[j]
+
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i])
-	arg2 := s.sortCol.Get(s.order[j])
+	arg1 := s.sortCol.Get(order1)
+	arg2 := s.sortCol.Get(order2)
 
 	{
 		var cmpResult int
@@ -1204,17 +1370,28 @@ func (s *sortJSONAscWithNullsOp) Len() int {
 }
 
 type sortDatumAscWithNullsOp struct {
+	allocator     *colmem.Allocator
 	sortCol       coldata.DatumVec
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortDatumAscWithNullsOp) init(ctx context.Context, col coldata.Vec, order []int) {
+func (s *sortDatumAscWithNullsOp) init(
+	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+) {
+	s.allocator = allocator
 	s.sortCol = col.Datum()
 	s.nulls = col.Nulls()
 	s.order = order
 	s.cancelChecker.Init(ctx)
+}
+
+func (s *sortDatumAscWithNullsOp) reset() {
+	s.sortCol = nil
+	s.nulls = nil
+	s.order = nil
+	s.allocator = nil
 }
 
 func (s *sortDatumAscWithNullsOp) sort() {
@@ -1251,10 +1428,14 @@ func (s *sortDatumAscWithNullsOp) Less(i, j int) bool {
 	} else if n2 {
 		return false
 	}
+
+	order1 := s.order[i]
+	order2 := s.order[j]
+
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i])
-	arg2 := s.sortCol.Get(s.order[j])
+	arg1 := s.sortCol.Get(order1)
+	arg2 := s.sortCol.Get(order2)
 
 	{
 		var cmpResult int
@@ -1277,17 +1458,28 @@ func (s *sortDatumAscWithNullsOp) Len() int {
 }
 
 type sortBoolDescWithNullsOp struct {
+	allocator     *colmem.Allocator
 	sortCol       coldata.Bools
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortBoolDescWithNullsOp) init(ctx context.Context, col coldata.Vec, order []int) {
+func (s *sortBoolDescWithNullsOp) init(
+	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+) {
+	s.allocator = allocator
 	s.sortCol = col.Bool()
 	s.nulls = col.Nulls()
 	s.order = order
 	s.cancelChecker.Init(ctx)
+}
+
+func (s *sortBoolDescWithNullsOp) reset() {
+	s.sortCol = nil
+	s.nulls = nil
+	s.order = nil
+	s.allocator = nil
 }
 
 func (s *sortBoolDescWithNullsOp) sort() {
@@ -1324,10 +1516,14 @@ func (s *sortBoolDescWithNullsOp) Less(i, j int) bool {
 	} else if n2 {
 		return true
 	}
+
+	order1 := s.order[i]
+	order2 := s.order[j]
+
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i])
-	arg2 := s.sortCol.Get(s.order[j])
+	arg1 := s.sortCol.Get(order1)
+	arg2 := s.sortCol.Get(order2)
 
 	{
 		var cmpResult int
@@ -1356,17 +1552,33 @@ func (s *sortBoolDescWithNullsOp) Len() int {
 }
 
 type sortBytesDescWithNullsOp struct {
-	sortCol       *coldata.Bytes
-	nulls         *coldata.Nulls
-	order         []int
-	cancelChecker colexecutils.CancelChecker
+	allocator          *colmem.Allocator
+	sortCol            *coldata.Bytes
+	abbreviatedSortCol []uint64
+	nulls              *coldata.Nulls
+	order              []int
+	cancelChecker      colexecutils.CancelChecker
 }
 
-func (s *sortBytesDescWithNullsOp) init(ctx context.Context, col coldata.Vec, order []int) {
+func (s *sortBytesDescWithNullsOp) init(
+	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+) {
+	s.allocator = allocator
 	s.sortCol = col.Bytes()
+	s.allocator.AdjustMemoryUsage(memsize.Uint64 * int64(s.sortCol.Len()))
+	s.abbreviatedSortCol = s.sortCol.Abbreviated()
 	s.nulls = col.Nulls()
 	s.order = order
 	s.cancelChecker.Init(ctx)
+}
+
+func (s *sortBytesDescWithNullsOp) reset() {
+	s.allocator.AdjustMemoryUsage(0 - memsize.Uint64*int64(s.sortCol.Len()))
+	s.abbreviatedSortCol = nil
+	s.sortCol = nil
+	s.nulls = nil
+	s.order = nil
+	s.allocator = nil
 }
 
 func (s *sortBytesDescWithNullsOp) sort() {
@@ -1403,10 +1615,23 @@ func (s *sortBytesDescWithNullsOp) Less(i, j int) bool {
 	} else if n2 {
 		return true
 	}
+
+	order1 := s.order[i]
+	order2 := s.order[j]
+
+	// If the type can be abbreviated as a uint64, compare the abbreviated
+	// values first. If they are not equal, we are done with the comparison. If
+	// they are equal, we must fallback to a full comparison of the datums.
+	abbr1 := s.abbreviatedSortCol[order1]
+	abbr2 := s.abbreviatedSortCol[order2]
+	if abbr1 != abbr2 {
+		return abbr1 > abbr2
+	}
+
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i])
-	arg2 := s.sortCol.Get(s.order[j])
+	arg1 := s.sortCol.Get(order1)
+	arg2 := s.sortCol.Get(order2)
 
 	{
 		var cmpResult int
@@ -1427,17 +1652,28 @@ func (s *sortBytesDescWithNullsOp) Len() int {
 }
 
 type sortDecimalDescWithNullsOp struct {
+	allocator     *colmem.Allocator
 	sortCol       coldata.Decimals
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortDecimalDescWithNullsOp) init(ctx context.Context, col coldata.Vec, order []int) {
+func (s *sortDecimalDescWithNullsOp) init(
+	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+) {
+	s.allocator = allocator
 	s.sortCol = col.Decimal()
 	s.nulls = col.Nulls()
 	s.order = order
 	s.cancelChecker.Init(ctx)
+}
+
+func (s *sortDecimalDescWithNullsOp) reset() {
+	s.sortCol = nil
+	s.nulls = nil
+	s.order = nil
+	s.allocator = nil
 }
 
 func (s *sortDecimalDescWithNullsOp) sort() {
@@ -1474,10 +1710,14 @@ func (s *sortDecimalDescWithNullsOp) Less(i, j int) bool {
 	} else if n2 {
 		return true
 	}
+
+	order1 := s.order[i]
+	order2 := s.order[j]
+
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i])
-	arg2 := s.sortCol.Get(s.order[j])
+	arg1 := s.sortCol.Get(order1)
+	arg2 := s.sortCol.Get(order2)
 
 	{
 		var cmpResult int
@@ -1498,17 +1738,28 @@ func (s *sortDecimalDescWithNullsOp) Len() int {
 }
 
 type sortInt16DescWithNullsOp struct {
+	allocator     *colmem.Allocator
 	sortCol       coldata.Int16s
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortInt16DescWithNullsOp) init(ctx context.Context, col coldata.Vec, order []int) {
+func (s *sortInt16DescWithNullsOp) init(
+	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+) {
+	s.allocator = allocator
 	s.sortCol = col.Int16()
 	s.nulls = col.Nulls()
 	s.order = order
 	s.cancelChecker.Init(ctx)
+}
+
+func (s *sortInt16DescWithNullsOp) reset() {
+	s.sortCol = nil
+	s.nulls = nil
+	s.order = nil
+	s.allocator = nil
 }
 
 func (s *sortInt16DescWithNullsOp) sort() {
@@ -1545,10 +1796,14 @@ func (s *sortInt16DescWithNullsOp) Less(i, j int) bool {
 	} else if n2 {
 		return true
 	}
+
+	order1 := s.order[i]
+	order2 := s.order[j]
+
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i])
-	arg2 := s.sortCol.Get(s.order[j])
+	arg1 := s.sortCol.Get(order1)
+	arg2 := s.sortCol.Get(order2)
 
 	{
 		var cmpResult int
@@ -1580,17 +1835,28 @@ func (s *sortInt16DescWithNullsOp) Len() int {
 }
 
 type sortInt32DescWithNullsOp struct {
+	allocator     *colmem.Allocator
 	sortCol       coldata.Int32s
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortInt32DescWithNullsOp) init(ctx context.Context, col coldata.Vec, order []int) {
+func (s *sortInt32DescWithNullsOp) init(
+	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+) {
+	s.allocator = allocator
 	s.sortCol = col.Int32()
 	s.nulls = col.Nulls()
 	s.order = order
 	s.cancelChecker.Init(ctx)
+}
+
+func (s *sortInt32DescWithNullsOp) reset() {
+	s.sortCol = nil
+	s.nulls = nil
+	s.order = nil
+	s.allocator = nil
 }
 
 func (s *sortInt32DescWithNullsOp) sort() {
@@ -1627,10 +1893,14 @@ func (s *sortInt32DescWithNullsOp) Less(i, j int) bool {
 	} else if n2 {
 		return true
 	}
+
+	order1 := s.order[i]
+	order2 := s.order[j]
+
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i])
-	arg2 := s.sortCol.Get(s.order[j])
+	arg1 := s.sortCol.Get(order1)
+	arg2 := s.sortCol.Get(order2)
 
 	{
 		var cmpResult int
@@ -1662,17 +1932,28 @@ func (s *sortInt32DescWithNullsOp) Len() int {
 }
 
 type sortInt64DescWithNullsOp struct {
+	allocator     *colmem.Allocator
 	sortCol       coldata.Int64s
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortInt64DescWithNullsOp) init(ctx context.Context, col coldata.Vec, order []int) {
+func (s *sortInt64DescWithNullsOp) init(
+	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+) {
+	s.allocator = allocator
 	s.sortCol = col.Int64()
 	s.nulls = col.Nulls()
 	s.order = order
 	s.cancelChecker.Init(ctx)
+}
+
+func (s *sortInt64DescWithNullsOp) reset() {
+	s.sortCol = nil
+	s.nulls = nil
+	s.order = nil
+	s.allocator = nil
 }
 
 func (s *sortInt64DescWithNullsOp) sort() {
@@ -1709,10 +1990,14 @@ func (s *sortInt64DescWithNullsOp) Less(i, j int) bool {
 	} else if n2 {
 		return true
 	}
+
+	order1 := s.order[i]
+	order2 := s.order[j]
+
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i])
-	arg2 := s.sortCol.Get(s.order[j])
+	arg1 := s.sortCol.Get(order1)
+	arg2 := s.sortCol.Get(order2)
 
 	{
 		var cmpResult int
@@ -1744,17 +2029,28 @@ func (s *sortInt64DescWithNullsOp) Len() int {
 }
 
 type sortFloat64DescWithNullsOp struct {
+	allocator     *colmem.Allocator
 	sortCol       coldata.Float64s
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortFloat64DescWithNullsOp) init(ctx context.Context, col coldata.Vec, order []int) {
+func (s *sortFloat64DescWithNullsOp) init(
+	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+) {
+	s.allocator = allocator
 	s.sortCol = col.Float64()
 	s.nulls = col.Nulls()
 	s.order = order
 	s.cancelChecker.Init(ctx)
+}
+
+func (s *sortFloat64DescWithNullsOp) reset() {
+	s.sortCol = nil
+	s.nulls = nil
+	s.order = nil
+	s.allocator = nil
 }
 
 func (s *sortFloat64DescWithNullsOp) sort() {
@@ -1791,10 +2087,14 @@ func (s *sortFloat64DescWithNullsOp) Less(i, j int) bool {
 	} else if n2 {
 		return true
 	}
+
+	order1 := s.order[i]
+	order2 := s.order[j]
+
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i])
-	arg2 := s.sortCol.Get(s.order[j])
+	arg1 := s.sortCol.Get(order1)
+	arg2 := s.sortCol.Get(order2)
 
 	{
 		var cmpResult int
@@ -1834,17 +2134,28 @@ func (s *sortFloat64DescWithNullsOp) Len() int {
 }
 
 type sortTimestampDescWithNullsOp struct {
+	allocator     *colmem.Allocator
 	sortCol       coldata.Times
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortTimestampDescWithNullsOp) init(ctx context.Context, col coldata.Vec, order []int) {
+func (s *sortTimestampDescWithNullsOp) init(
+	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+) {
+	s.allocator = allocator
 	s.sortCol = col.Timestamp()
 	s.nulls = col.Nulls()
 	s.order = order
 	s.cancelChecker.Init(ctx)
+}
+
+func (s *sortTimestampDescWithNullsOp) reset() {
+	s.sortCol = nil
+	s.nulls = nil
+	s.order = nil
+	s.allocator = nil
 }
 
 func (s *sortTimestampDescWithNullsOp) sort() {
@@ -1881,10 +2192,14 @@ func (s *sortTimestampDescWithNullsOp) Less(i, j int) bool {
 	} else if n2 {
 		return true
 	}
+
+	order1 := s.order[i]
+	order2 := s.order[j]
+
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i])
-	arg2 := s.sortCol.Get(s.order[j])
+	arg1 := s.sortCol.Get(order1)
+	arg2 := s.sortCol.Get(order2)
 
 	{
 		var cmpResult int
@@ -1912,17 +2227,28 @@ func (s *sortTimestampDescWithNullsOp) Len() int {
 }
 
 type sortIntervalDescWithNullsOp struct {
+	allocator     *colmem.Allocator
 	sortCol       coldata.Durations
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortIntervalDescWithNullsOp) init(ctx context.Context, col coldata.Vec, order []int) {
+func (s *sortIntervalDescWithNullsOp) init(
+	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+) {
+	s.allocator = allocator
 	s.sortCol = col.Interval()
 	s.nulls = col.Nulls()
 	s.order = order
 	s.cancelChecker.Init(ctx)
+}
+
+func (s *sortIntervalDescWithNullsOp) reset() {
+	s.sortCol = nil
+	s.nulls = nil
+	s.order = nil
+	s.allocator = nil
 }
 
 func (s *sortIntervalDescWithNullsOp) sort() {
@@ -1959,10 +2285,14 @@ func (s *sortIntervalDescWithNullsOp) Less(i, j int) bool {
 	} else if n2 {
 		return true
 	}
+
+	order1 := s.order[i]
+	order2 := s.order[j]
+
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i])
-	arg2 := s.sortCol.Get(s.order[j])
+	arg1 := s.sortCol.Get(order1)
+	arg2 := s.sortCol.Get(order2)
 
 	{
 		var cmpResult int
@@ -1983,17 +2313,28 @@ func (s *sortIntervalDescWithNullsOp) Len() int {
 }
 
 type sortJSONDescWithNullsOp struct {
+	allocator     *colmem.Allocator
 	sortCol       *coldata.JSONs
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortJSONDescWithNullsOp) init(ctx context.Context, col coldata.Vec, order []int) {
+func (s *sortJSONDescWithNullsOp) init(
+	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+) {
+	s.allocator = allocator
 	s.sortCol = col.JSON()
 	s.nulls = col.Nulls()
 	s.order = order
 	s.cancelChecker.Init(ctx)
+}
+
+func (s *sortJSONDescWithNullsOp) reset() {
+	s.sortCol = nil
+	s.nulls = nil
+	s.order = nil
+	s.allocator = nil
 }
 
 func (s *sortJSONDescWithNullsOp) sort() {
@@ -2030,10 +2371,14 @@ func (s *sortJSONDescWithNullsOp) Less(i, j int) bool {
 	} else if n2 {
 		return true
 	}
+
+	order1 := s.order[i]
+	order2 := s.order[j]
+
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i])
-	arg2 := s.sortCol.Get(s.order[j])
+	arg1 := s.sortCol.Get(order1)
+	arg2 := s.sortCol.Get(order2)
 
 	{
 		var cmpResult int
@@ -2060,17 +2405,28 @@ func (s *sortJSONDescWithNullsOp) Len() int {
 }
 
 type sortDatumDescWithNullsOp struct {
+	allocator     *colmem.Allocator
 	sortCol       coldata.DatumVec
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortDatumDescWithNullsOp) init(ctx context.Context, col coldata.Vec, order []int) {
+func (s *sortDatumDescWithNullsOp) init(
+	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+) {
+	s.allocator = allocator
 	s.sortCol = col.Datum()
 	s.nulls = col.Nulls()
 	s.order = order
 	s.cancelChecker.Init(ctx)
+}
+
+func (s *sortDatumDescWithNullsOp) reset() {
+	s.sortCol = nil
+	s.nulls = nil
+	s.order = nil
+	s.allocator = nil
 }
 
 func (s *sortDatumDescWithNullsOp) sort() {
@@ -2107,10 +2463,14 @@ func (s *sortDatumDescWithNullsOp) Less(i, j int) bool {
 	} else if n2 {
 		return true
 	}
+
+	order1 := s.order[i]
+	order2 := s.order[j]
+
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i])
-	arg2 := s.sortCol.Get(s.order[j])
+	arg1 := s.sortCol.Get(order1)
+	arg2 := s.sortCol.Get(order2)
 
 	{
 		var cmpResult int
@@ -2133,17 +2493,28 @@ func (s *sortDatumDescWithNullsOp) Len() int {
 }
 
 type sortBoolAscOp struct {
+	allocator     *colmem.Allocator
 	sortCol       coldata.Bools
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortBoolAscOp) init(ctx context.Context, col coldata.Vec, order []int) {
+func (s *sortBoolAscOp) init(
+	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+) {
+	s.allocator = allocator
 	s.sortCol = col.Bool()
 	s.nulls = col.Nulls()
 	s.order = order
 	s.cancelChecker.Init(ctx)
+}
+
+func (s *sortBoolAscOp) reset() {
+	s.sortCol = nil
+	s.nulls = nil
+	s.order = nil
+	s.allocator = nil
 }
 
 func (s *sortBoolAscOp) sort() {
@@ -2170,10 +2541,14 @@ func (s *sortBoolAscOp) sortPartitions(partitions []int) {
 }
 
 func (s *sortBoolAscOp) Less(i, j int) bool {
+
+	order1 := s.order[i]
+	order2 := s.order[j]
+
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i])
-	arg2 := s.sortCol.Get(s.order[j])
+	arg1 := s.sortCol.Get(order1)
+	arg2 := s.sortCol.Get(order2)
 
 	{
 		var cmpResult int
@@ -2202,17 +2577,33 @@ func (s *sortBoolAscOp) Len() int {
 }
 
 type sortBytesAscOp struct {
-	sortCol       *coldata.Bytes
-	nulls         *coldata.Nulls
-	order         []int
-	cancelChecker colexecutils.CancelChecker
+	allocator          *colmem.Allocator
+	sortCol            *coldata.Bytes
+	abbreviatedSortCol []uint64
+	nulls              *coldata.Nulls
+	order              []int
+	cancelChecker      colexecutils.CancelChecker
 }
 
-func (s *sortBytesAscOp) init(ctx context.Context, col coldata.Vec, order []int) {
+func (s *sortBytesAscOp) init(
+	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+) {
+	s.allocator = allocator
 	s.sortCol = col.Bytes()
+	s.allocator.AdjustMemoryUsage(memsize.Uint64 * int64(s.sortCol.Len()))
+	s.abbreviatedSortCol = s.sortCol.Abbreviated()
 	s.nulls = col.Nulls()
 	s.order = order
 	s.cancelChecker.Init(ctx)
+}
+
+func (s *sortBytesAscOp) reset() {
+	s.allocator.AdjustMemoryUsage(0 - memsize.Uint64*int64(s.sortCol.Len()))
+	s.abbreviatedSortCol = nil
+	s.sortCol = nil
+	s.nulls = nil
+	s.order = nil
+	s.allocator = nil
 }
 
 func (s *sortBytesAscOp) sort() {
@@ -2239,10 +2630,23 @@ func (s *sortBytesAscOp) sortPartitions(partitions []int) {
 }
 
 func (s *sortBytesAscOp) Less(i, j int) bool {
+
+	order1 := s.order[i]
+	order2 := s.order[j]
+
+	// If the type can be abbreviated as a uint64, compare the abbreviated
+	// values first. If they are not equal, we are done with the comparison. If
+	// they are equal, we must fallback to a full comparison of the datums.
+	abbr1 := s.abbreviatedSortCol[order1]
+	abbr2 := s.abbreviatedSortCol[order2]
+	if abbr1 != abbr2 {
+		return abbr1 < abbr2
+	}
+
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i])
-	arg2 := s.sortCol.Get(s.order[j])
+	arg1 := s.sortCol.Get(order1)
+	arg2 := s.sortCol.Get(order2)
 
 	{
 		var cmpResult int
@@ -2263,17 +2667,28 @@ func (s *sortBytesAscOp) Len() int {
 }
 
 type sortDecimalAscOp struct {
+	allocator     *colmem.Allocator
 	sortCol       coldata.Decimals
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortDecimalAscOp) init(ctx context.Context, col coldata.Vec, order []int) {
+func (s *sortDecimalAscOp) init(
+	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+) {
+	s.allocator = allocator
 	s.sortCol = col.Decimal()
 	s.nulls = col.Nulls()
 	s.order = order
 	s.cancelChecker.Init(ctx)
+}
+
+func (s *sortDecimalAscOp) reset() {
+	s.sortCol = nil
+	s.nulls = nil
+	s.order = nil
+	s.allocator = nil
 }
 
 func (s *sortDecimalAscOp) sort() {
@@ -2300,10 +2715,14 @@ func (s *sortDecimalAscOp) sortPartitions(partitions []int) {
 }
 
 func (s *sortDecimalAscOp) Less(i, j int) bool {
+
+	order1 := s.order[i]
+	order2 := s.order[j]
+
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i])
-	arg2 := s.sortCol.Get(s.order[j])
+	arg1 := s.sortCol.Get(order1)
+	arg2 := s.sortCol.Get(order2)
 
 	{
 		var cmpResult int
@@ -2324,17 +2743,28 @@ func (s *sortDecimalAscOp) Len() int {
 }
 
 type sortInt16AscOp struct {
+	allocator     *colmem.Allocator
 	sortCol       coldata.Int16s
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortInt16AscOp) init(ctx context.Context, col coldata.Vec, order []int) {
+func (s *sortInt16AscOp) init(
+	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+) {
+	s.allocator = allocator
 	s.sortCol = col.Int16()
 	s.nulls = col.Nulls()
 	s.order = order
 	s.cancelChecker.Init(ctx)
+}
+
+func (s *sortInt16AscOp) reset() {
+	s.sortCol = nil
+	s.nulls = nil
+	s.order = nil
+	s.allocator = nil
 }
 
 func (s *sortInt16AscOp) sort() {
@@ -2361,10 +2791,14 @@ func (s *sortInt16AscOp) sortPartitions(partitions []int) {
 }
 
 func (s *sortInt16AscOp) Less(i, j int) bool {
+
+	order1 := s.order[i]
+	order2 := s.order[j]
+
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i])
-	arg2 := s.sortCol.Get(s.order[j])
+	arg1 := s.sortCol.Get(order1)
+	arg2 := s.sortCol.Get(order2)
 
 	{
 		var cmpResult int
@@ -2396,17 +2830,28 @@ func (s *sortInt16AscOp) Len() int {
 }
 
 type sortInt32AscOp struct {
+	allocator     *colmem.Allocator
 	sortCol       coldata.Int32s
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortInt32AscOp) init(ctx context.Context, col coldata.Vec, order []int) {
+func (s *sortInt32AscOp) init(
+	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+) {
+	s.allocator = allocator
 	s.sortCol = col.Int32()
 	s.nulls = col.Nulls()
 	s.order = order
 	s.cancelChecker.Init(ctx)
+}
+
+func (s *sortInt32AscOp) reset() {
+	s.sortCol = nil
+	s.nulls = nil
+	s.order = nil
+	s.allocator = nil
 }
 
 func (s *sortInt32AscOp) sort() {
@@ -2433,10 +2878,14 @@ func (s *sortInt32AscOp) sortPartitions(partitions []int) {
 }
 
 func (s *sortInt32AscOp) Less(i, j int) bool {
+
+	order1 := s.order[i]
+	order2 := s.order[j]
+
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i])
-	arg2 := s.sortCol.Get(s.order[j])
+	arg1 := s.sortCol.Get(order1)
+	arg2 := s.sortCol.Get(order2)
 
 	{
 		var cmpResult int
@@ -2468,17 +2917,28 @@ func (s *sortInt32AscOp) Len() int {
 }
 
 type sortInt64AscOp struct {
+	allocator     *colmem.Allocator
 	sortCol       coldata.Int64s
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortInt64AscOp) init(ctx context.Context, col coldata.Vec, order []int) {
+func (s *sortInt64AscOp) init(
+	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+) {
+	s.allocator = allocator
 	s.sortCol = col.Int64()
 	s.nulls = col.Nulls()
 	s.order = order
 	s.cancelChecker.Init(ctx)
+}
+
+func (s *sortInt64AscOp) reset() {
+	s.sortCol = nil
+	s.nulls = nil
+	s.order = nil
+	s.allocator = nil
 }
 
 func (s *sortInt64AscOp) sort() {
@@ -2505,10 +2965,14 @@ func (s *sortInt64AscOp) sortPartitions(partitions []int) {
 }
 
 func (s *sortInt64AscOp) Less(i, j int) bool {
+
+	order1 := s.order[i]
+	order2 := s.order[j]
+
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i])
-	arg2 := s.sortCol.Get(s.order[j])
+	arg1 := s.sortCol.Get(order1)
+	arg2 := s.sortCol.Get(order2)
 
 	{
 		var cmpResult int
@@ -2540,17 +3004,28 @@ func (s *sortInt64AscOp) Len() int {
 }
 
 type sortFloat64AscOp struct {
+	allocator     *colmem.Allocator
 	sortCol       coldata.Float64s
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortFloat64AscOp) init(ctx context.Context, col coldata.Vec, order []int) {
+func (s *sortFloat64AscOp) init(
+	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+) {
+	s.allocator = allocator
 	s.sortCol = col.Float64()
 	s.nulls = col.Nulls()
 	s.order = order
 	s.cancelChecker.Init(ctx)
+}
+
+func (s *sortFloat64AscOp) reset() {
+	s.sortCol = nil
+	s.nulls = nil
+	s.order = nil
+	s.allocator = nil
 }
 
 func (s *sortFloat64AscOp) sort() {
@@ -2577,10 +3052,14 @@ func (s *sortFloat64AscOp) sortPartitions(partitions []int) {
 }
 
 func (s *sortFloat64AscOp) Less(i, j int) bool {
+
+	order1 := s.order[i]
+	order2 := s.order[j]
+
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i])
-	arg2 := s.sortCol.Get(s.order[j])
+	arg1 := s.sortCol.Get(order1)
+	arg2 := s.sortCol.Get(order2)
 
 	{
 		var cmpResult int
@@ -2620,17 +3099,28 @@ func (s *sortFloat64AscOp) Len() int {
 }
 
 type sortTimestampAscOp struct {
+	allocator     *colmem.Allocator
 	sortCol       coldata.Times
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortTimestampAscOp) init(ctx context.Context, col coldata.Vec, order []int) {
+func (s *sortTimestampAscOp) init(
+	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+) {
+	s.allocator = allocator
 	s.sortCol = col.Timestamp()
 	s.nulls = col.Nulls()
 	s.order = order
 	s.cancelChecker.Init(ctx)
+}
+
+func (s *sortTimestampAscOp) reset() {
+	s.sortCol = nil
+	s.nulls = nil
+	s.order = nil
+	s.allocator = nil
 }
 
 func (s *sortTimestampAscOp) sort() {
@@ -2657,10 +3147,14 @@ func (s *sortTimestampAscOp) sortPartitions(partitions []int) {
 }
 
 func (s *sortTimestampAscOp) Less(i, j int) bool {
+
+	order1 := s.order[i]
+	order2 := s.order[j]
+
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i])
-	arg2 := s.sortCol.Get(s.order[j])
+	arg1 := s.sortCol.Get(order1)
+	arg2 := s.sortCol.Get(order2)
 
 	{
 		var cmpResult int
@@ -2688,17 +3182,28 @@ func (s *sortTimestampAscOp) Len() int {
 }
 
 type sortIntervalAscOp struct {
+	allocator     *colmem.Allocator
 	sortCol       coldata.Durations
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortIntervalAscOp) init(ctx context.Context, col coldata.Vec, order []int) {
+func (s *sortIntervalAscOp) init(
+	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+) {
+	s.allocator = allocator
 	s.sortCol = col.Interval()
 	s.nulls = col.Nulls()
 	s.order = order
 	s.cancelChecker.Init(ctx)
+}
+
+func (s *sortIntervalAscOp) reset() {
+	s.sortCol = nil
+	s.nulls = nil
+	s.order = nil
+	s.allocator = nil
 }
 
 func (s *sortIntervalAscOp) sort() {
@@ -2725,10 +3230,14 @@ func (s *sortIntervalAscOp) sortPartitions(partitions []int) {
 }
 
 func (s *sortIntervalAscOp) Less(i, j int) bool {
+
+	order1 := s.order[i]
+	order2 := s.order[j]
+
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i])
-	arg2 := s.sortCol.Get(s.order[j])
+	arg1 := s.sortCol.Get(order1)
+	arg2 := s.sortCol.Get(order2)
 
 	{
 		var cmpResult int
@@ -2749,17 +3258,28 @@ func (s *sortIntervalAscOp) Len() int {
 }
 
 type sortJSONAscOp struct {
+	allocator     *colmem.Allocator
 	sortCol       *coldata.JSONs
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortJSONAscOp) init(ctx context.Context, col coldata.Vec, order []int) {
+func (s *sortJSONAscOp) init(
+	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+) {
+	s.allocator = allocator
 	s.sortCol = col.JSON()
 	s.nulls = col.Nulls()
 	s.order = order
 	s.cancelChecker.Init(ctx)
+}
+
+func (s *sortJSONAscOp) reset() {
+	s.sortCol = nil
+	s.nulls = nil
+	s.order = nil
+	s.allocator = nil
 }
 
 func (s *sortJSONAscOp) sort() {
@@ -2786,10 +3306,14 @@ func (s *sortJSONAscOp) sortPartitions(partitions []int) {
 }
 
 func (s *sortJSONAscOp) Less(i, j int) bool {
+
+	order1 := s.order[i]
+	order2 := s.order[j]
+
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i])
-	arg2 := s.sortCol.Get(s.order[j])
+	arg1 := s.sortCol.Get(order1)
+	arg2 := s.sortCol.Get(order2)
 
 	{
 		var cmpResult int
@@ -2816,17 +3340,28 @@ func (s *sortJSONAscOp) Len() int {
 }
 
 type sortDatumAscOp struct {
+	allocator     *colmem.Allocator
 	sortCol       coldata.DatumVec
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortDatumAscOp) init(ctx context.Context, col coldata.Vec, order []int) {
+func (s *sortDatumAscOp) init(
+	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+) {
+	s.allocator = allocator
 	s.sortCol = col.Datum()
 	s.nulls = col.Nulls()
 	s.order = order
 	s.cancelChecker.Init(ctx)
+}
+
+func (s *sortDatumAscOp) reset() {
+	s.sortCol = nil
+	s.nulls = nil
+	s.order = nil
+	s.allocator = nil
 }
 
 func (s *sortDatumAscOp) sort() {
@@ -2853,10 +3388,14 @@ func (s *sortDatumAscOp) sortPartitions(partitions []int) {
 }
 
 func (s *sortDatumAscOp) Less(i, j int) bool {
+
+	order1 := s.order[i]
+	order2 := s.order[j]
+
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i])
-	arg2 := s.sortCol.Get(s.order[j])
+	arg1 := s.sortCol.Get(order1)
+	arg2 := s.sortCol.Get(order2)
 
 	{
 		var cmpResult int
@@ -2879,17 +3418,28 @@ func (s *sortDatumAscOp) Len() int {
 }
 
 type sortBoolDescOp struct {
+	allocator     *colmem.Allocator
 	sortCol       coldata.Bools
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortBoolDescOp) init(ctx context.Context, col coldata.Vec, order []int) {
+func (s *sortBoolDescOp) init(
+	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+) {
+	s.allocator = allocator
 	s.sortCol = col.Bool()
 	s.nulls = col.Nulls()
 	s.order = order
 	s.cancelChecker.Init(ctx)
+}
+
+func (s *sortBoolDescOp) reset() {
+	s.sortCol = nil
+	s.nulls = nil
+	s.order = nil
+	s.allocator = nil
 }
 
 func (s *sortBoolDescOp) sort() {
@@ -2916,10 +3466,14 @@ func (s *sortBoolDescOp) sortPartitions(partitions []int) {
 }
 
 func (s *sortBoolDescOp) Less(i, j int) bool {
+
+	order1 := s.order[i]
+	order2 := s.order[j]
+
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i])
-	arg2 := s.sortCol.Get(s.order[j])
+	arg1 := s.sortCol.Get(order1)
+	arg2 := s.sortCol.Get(order2)
 
 	{
 		var cmpResult int
@@ -2948,17 +3502,33 @@ func (s *sortBoolDescOp) Len() int {
 }
 
 type sortBytesDescOp struct {
-	sortCol       *coldata.Bytes
-	nulls         *coldata.Nulls
-	order         []int
-	cancelChecker colexecutils.CancelChecker
+	allocator          *colmem.Allocator
+	sortCol            *coldata.Bytes
+	abbreviatedSortCol []uint64
+	nulls              *coldata.Nulls
+	order              []int
+	cancelChecker      colexecutils.CancelChecker
 }
 
-func (s *sortBytesDescOp) init(ctx context.Context, col coldata.Vec, order []int) {
+func (s *sortBytesDescOp) init(
+	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+) {
+	s.allocator = allocator
 	s.sortCol = col.Bytes()
+	s.allocator.AdjustMemoryUsage(memsize.Uint64 * int64(s.sortCol.Len()))
+	s.abbreviatedSortCol = s.sortCol.Abbreviated()
 	s.nulls = col.Nulls()
 	s.order = order
 	s.cancelChecker.Init(ctx)
+}
+
+func (s *sortBytesDescOp) reset() {
+	s.allocator.AdjustMemoryUsage(0 - memsize.Uint64*int64(s.sortCol.Len()))
+	s.abbreviatedSortCol = nil
+	s.sortCol = nil
+	s.nulls = nil
+	s.order = nil
+	s.allocator = nil
 }
 
 func (s *sortBytesDescOp) sort() {
@@ -2985,10 +3555,23 @@ func (s *sortBytesDescOp) sortPartitions(partitions []int) {
 }
 
 func (s *sortBytesDescOp) Less(i, j int) bool {
+
+	order1 := s.order[i]
+	order2 := s.order[j]
+
+	// If the type can be abbreviated as a uint64, compare the abbreviated
+	// values first. If they are not equal, we are done with the comparison. If
+	// they are equal, we must fallback to a full comparison of the datums.
+	abbr1 := s.abbreviatedSortCol[order1]
+	abbr2 := s.abbreviatedSortCol[order2]
+	if abbr1 != abbr2 {
+		return abbr1 > abbr2
+	}
+
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i])
-	arg2 := s.sortCol.Get(s.order[j])
+	arg1 := s.sortCol.Get(order1)
+	arg2 := s.sortCol.Get(order2)
 
 	{
 		var cmpResult int
@@ -3009,17 +3592,28 @@ func (s *sortBytesDescOp) Len() int {
 }
 
 type sortDecimalDescOp struct {
+	allocator     *colmem.Allocator
 	sortCol       coldata.Decimals
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortDecimalDescOp) init(ctx context.Context, col coldata.Vec, order []int) {
+func (s *sortDecimalDescOp) init(
+	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+) {
+	s.allocator = allocator
 	s.sortCol = col.Decimal()
 	s.nulls = col.Nulls()
 	s.order = order
 	s.cancelChecker.Init(ctx)
+}
+
+func (s *sortDecimalDescOp) reset() {
+	s.sortCol = nil
+	s.nulls = nil
+	s.order = nil
+	s.allocator = nil
 }
 
 func (s *sortDecimalDescOp) sort() {
@@ -3046,10 +3640,14 @@ func (s *sortDecimalDescOp) sortPartitions(partitions []int) {
 }
 
 func (s *sortDecimalDescOp) Less(i, j int) bool {
+
+	order1 := s.order[i]
+	order2 := s.order[j]
+
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i])
-	arg2 := s.sortCol.Get(s.order[j])
+	arg1 := s.sortCol.Get(order1)
+	arg2 := s.sortCol.Get(order2)
 
 	{
 		var cmpResult int
@@ -3070,17 +3668,28 @@ func (s *sortDecimalDescOp) Len() int {
 }
 
 type sortInt16DescOp struct {
+	allocator     *colmem.Allocator
 	sortCol       coldata.Int16s
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortInt16DescOp) init(ctx context.Context, col coldata.Vec, order []int) {
+func (s *sortInt16DescOp) init(
+	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+) {
+	s.allocator = allocator
 	s.sortCol = col.Int16()
 	s.nulls = col.Nulls()
 	s.order = order
 	s.cancelChecker.Init(ctx)
+}
+
+func (s *sortInt16DescOp) reset() {
+	s.sortCol = nil
+	s.nulls = nil
+	s.order = nil
+	s.allocator = nil
 }
 
 func (s *sortInt16DescOp) sort() {
@@ -3107,10 +3716,14 @@ func (s *sortInt16DescOp) sortPartitions(partitions []int) {
 }
 
 func (s *sortInt16DescOp) Less(i, j int) bool {
+
+	order1 := s.order[i]
+	order2 := s.order[j]
+
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i])
-	arg2 := s.sortCol.Get(s.order[j])
+	arg1 := s.sortCol.Get(order1)
+	arg2 := s.sortCol.Get(order2)
 
 	{
 		var cmpResult int
@@ -3142,17 +3755,28 @@ func (s *sortInt16DescOp) Len() int {
 }
 
 type sortInt32DescOp struct {
+	allocator     *colmem.Allocator
 	sortCol       coldata.Int32s
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortInt32DescOp) init(ctx context.Context, col coldata.Vec, order []int) {
+func (s *sortInt32DescOp) init(
+	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+) {
+	s.allocator = allocator
 	s.sortCol = col.Int32()
 	s.nulls = col.Nulls()
 	s.order = order
 	s.cancelChecker.Init(ctx)
+}
+
+func (s *sortInt32DescOp) reset() {
+	s.sortCol = nil
+	s.nulls = nil
+	s.order = nil
+	s.allocator = nil
 }
 
 func (s *sortInt32DescOp) sort() {
@@ -3179,10 +3803,14 @@ func (s *sortInt32DescOp) sortPartitions(partitions []int) {
 }
 
 func (s *sortInt32DescOp) Less(i, j int) bool {
+
+	order1 := s.order[i]
+	order2 := s.order[j]
+
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i])
-	arg2 := s.sortCol.Get(s.order[j])
+	arg1 := s.sortCol.Get(order1)
+	arg2 := s.sortCol.Get(order2)
 
 	{
 		var cmpResult int
@@ -3214,17 +3842,28 @@ func (s *sortInt32DescOp) Len() int {
 }
 
 type sortInt64DescOp struct {
+	allocator     *colmem.Allocator
 	sortCol       coldata.Int64s
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortInt64DescOp) init(ctx context.Context, col coldata.Vec, order []int) {
+func (s *sortInt64DescOp) init(
+	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+) {
+	s.allocator = allocator
 	s.sortCol = col.Int64()
 	s.nulls = col.Nulls()
 	s.order = order
 	s.cancelChecker.Init(ctx)
+}
+
+func (s *sortInt64DescOp) reset() {
+	s.sortCol = nil
+	s.nulls = nil
+	s.order = nil
+	s.allocator = nil
 }
 
 func (s *sortInt64DescOp) sort() {
@@ -3251,10 +3890,14 @@ func (s *sortInt64DescOp) sortPartitions(partitions []int) {
 }
 
 func (s *sortInt64DescOp) Less(i, j int) bool {
+
+	order1 := s.order[i]
+	order2 := s.order[j]
+
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i])
-	arg2 := s.sortCol.Get(s.order[j])
+	arg1 := s.sortCol.Get(order1)
+	arg2 := s.sortCol.Get(order2)
 
 	{
 		var cmpResult int
@@ -3286,17 +3929,28 @@ func (s *sortInt64DescOp) Len() int {
 }
 
 type sortFloat64DescOp struct {
+	allocator     *colmem.Allocator
 	sortCol       coldata.Float64s
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortFloat64DescOp) init(ctx context.Context, col coldata.Vec, order []int) {
+func (s *sortFloat64DescOp) init(
+	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+) {
+	s.allocator = allocator
 	s.sortCol = col.Float64()
 	s.nulls = col.Nulls()
 	s.order = order
 	s.cancelChecker.Init(ctx)
+}
+
+func (s *sortFloat64DescOp) reset() {
+	s.sortCol = nil
+	s.nulls = nil
+	s.order = nil
+	s.allocator = nil
 }
 
 func (s *sortFloat64DescOp) sort() {
@@ -3323,10 +3977,14 @@ func (s *sortFloat64DescOp) sortPartitions(partitions []int) {
 }
 
 func (s *sortFloat64DescOp) Less(i, j int) bool {
+
+	order1 := s.order[i]
+	order2 := s.order[j]
+
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i])
-	arg2 := s.sortCol.Get(s.order[j])
+	arg1 := s.sortCol.Get(order1)
+	arg2 := s.sortCol.Get(order2)
 
 	{
 		var cmpResult int
@@ -3366,17 +4024,28 @@ func (s *sortFloat64DescOp) Len() int {
 }
 
 type sortTimestampDescOp struct {
+	allocator     *colmem.Allocator
 	sortCol       coldata.Times
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortTimestampDescOp) init(ctx context.Context, col coldata.Vec, order []int) {
+func (s *sortTimestampDescOp) init(
+	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+) {
+	s.allocator = allocator
 	s.sortCol = col.Timestamp()
 	s.nulls = col.Nulls()
 	s.order = order
 	s.cancelChecker.Init(ctx)
+}
+
+func (s *sortTimestampDescOp) reset() {
+	s.sortCol = nil
+	s.nulls = nil
+	s.order = nil
+	s.allocator = nil
 }
 
 func (s *sortTimestampDescOp) sort() {
@@ -3403,10 +4072,14 @@ func (s *sortTimestampDescOp) sortPartitions(partitions []int) {
 }
 
 func (s *sortTimestampDescOp) Less(i, j int) bool {
+
+	order1 := s.order[i]
+	order2 := s.order[j]
+
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i])
-	arg2 := s.sortCol.Get(s.order[j])
+	arg1 := s.sortCol.Get(order1)
+	arg2 := s.sortCol.Get(order2)
 
 	{
 		var cmpResult int
@@ -3434,17 +4107,28 @@ func (s *sortTimestampDescOp) Len() int {
 }
 
 type sortIntervalDescOp struct {
+	allocator     *colmem.Allocator
 	sortCol       coldata.Durations
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortIntervalDescOp) init(ctx context.Context, col coldata.Vec, order []int) {
+func (s *sortIntervalDescOp) init(
+	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+) {
+	s.allocator = allocator
 	s.sortCol = col.Interval()
 	s.nulls = col.Nulls()
 	s.order = order
 	s.cancelChecker.Init(ctx)
+}
+
+func (s *sortIntervalDescOp) reset() {
+	s.sortCol = nil
+	s.nulls = nil
+	s.order = nil
+	s.allocator = nil
 }
 
 func (s *sortIntervalDescOp) sort() {
@@ -3471,10 +4155,14 @@ func (s *sortIntervalDescOp) sortPartitions(partitions []int) {
 }
 
 func (s *sortIntervalDescOp) Less(i, j int) bool {
+
+	order1 := s.order[i]
+	order2 := s.order[j]
+
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i])
-	arg2 := s.sortCol.Get(s.order[j])
+	arg1 := s.sortCol.Get(order1)
+	arg2 := s.sortCol.Get(order2)
 
 	{
 		var cmpResult int
@@ -3495,17 +4183,28 @@ func (s *sortIntervalDescOp) Len() int {
 }
 
 type sortJSONDescOp struct {
+	allocator     *colmem.Allocator
 	sortCol       *coldata.JSONs
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortJSONDescOp) init(ctx context.Context, col coldata.Vec, order []int) {
+func (s *sortJSONDescOp) init(
+	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+) {
+	s.allocator = allocator
 	s.sortCol = col.JSON()
 	s.nulls = col.Nulls()
 	s.order = order
 	s.cancelChecker.Init(ctx)
+}
+
+func (s *sortJSONDescOp) reset() {
+	s.sortCol = nil
+	s.nulls = nil
+	s.order = nil
+	s.allocator = nil
 }
 
 func (s *sortJSONDescOp) sort() {
@@ -3532,10 +4231,14 @@ func (s *sortJSONDescOp) sortPartitions(partitions []int) {
 }
 
 func (s *sortJSONDescOp) Less(i, j int) bool {
+
+	order1 := s.order[i]
+	order2 := s.order[j]
+
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i])
-	arg2 := s.sortCol.Get(s.order[j])
+	arg1 := s.sortCol.Get(order1)
+	arg2 := s.sortCol.Get(order2)
 
 	{
 		var cmpResult int
@@ -3562,17 +4265,28 @@ func (s *sortJSONDescOp) Len() int {
 }
 
 type sortDatumDescOp struct {
+	allocator     *colmem.Allocator
 	sortCol       coldata.DatumVec
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortDatumDescOp) init(ctx context.Context, col coldata.Vec, order []int) {
+func (s *sortDatumDescOp) init(
+	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
+) {
+	s.allocator = allocator
 	s.sortCol = col.Datum()
 	s.nulls = col.Nulls()
 	s.order = order
 	s.cancelChecker.Init(ctx)
+}
+
+func (s *sortDatumDescOp) reset() {
+	s.sortCol = nil
+	s.nulls = nil
+	s.order = nil
+	s.allocator = nil
 }
 
 func (s *sortDatumDescOp) sort() {
@@ -3599,10 +4313,14 @@ func (s *sortDatumDescOp) sortPartitions(partitions []int) {
 }
 
 func (s *sortDatumDescOp) Less(i, j int) bool {
+
+	order1 := s.order[i]
+	order2 := s.order[j]
+
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i])
-	arg2 := s.sortCol.Get(s.order[j])
+	arg1 := s.sortCol.Get(order1)
+	arg2 := s.sortCol.Get(order2)
 
 	{
 		var cmpResult int

--- a/pkg/sql/colexec/sort.go
+++ b/pkg/sql/colexec/sort.go
@@ -240,7 +240,10 @@ type colSorter interface {
 	// init prepares this sorter, given a particular Vec and an order vector,
 	// which must be the same size as the input Vec and will be permuted with
 	// the same swaps as the column.
-	init(ctx context.Context, col coldata.Vec, order []int)
+	init(ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int)
+	// reset releases memory allocated by the colSorter. It should be called
+	// when the colSorter is no longer needed.
+	reset()
 	// sort globally sorts this sorter's column.
 	sort()
 	// sortPartitions sorts this sorter's column once for every partition in the
@@ -329,9 +332,12 @@ func (p *sortOp) sort() {
 		// There is nothing to sort.
 		return
 	}
-	// Allocate p.order and p.workingSpace if it hasn't been allocated yet or the
-	// underlying memory is insufficient.
+	// Allocate p.order if it hasn't been allocated yet or the underlying memory
+	// is insufficient.
 	if p.order == nil || cap(p.order) < spooledTuples {
+		sizeBefore := memsize.Int * int64(cap(p.order))
+		sizeAfter := memsize.Int * int64(spooledTuples)
+		p.allocator.AdjustMemoryUsage(sizeAfter - sizeBefore)
 		p.order = make([]int, spooledTuples)
 	}
 	p.order = p.order[:spooledTuples]
@@ -341,10 +347,15 @@ func (p *sortOp) sort() {
 		p.order[i] = i
 	}
 
+	// TODO(mgartner): Avoid creating new sorters for ever invocation of this
+	// function. Instead, create two slices of sorters, one to use when the
+	// vector does not have nulls, and one to use when it maybe has nulls. The
+	// sorter reset function can be used to clean up the sorters for the next
+	// invocation.
 	for i := range p.orderingCols {
 		inputVec := p.input.getValues(int(p.orderingCols[i].ColIdx))
 		p.sorters[i] = newSingleSorter(p.inputTypes[p.orderingCols[i].ColIdx], p.orderingCols[i].Direction, inputVec.MaybeHasNulls())
-		p.sorters[i].init(p.Ctx, inputVec, p.order)
+		p.sorters[i].init(p.Ctx, p.allocator, inputVec, p.order)
 	}
 
 	// Now, sort each column in turn.
@@ -356,6 +367,7 @@ func (p *sortOp) sort() {
 		// All spooled tuples belong to the same partition, so the first column
 		// doesn't need special treatment - we just globally sort it.
 		p.sorters[0].sort()
+		p.sorters[0].reset()
 		if len(p.sorters) == 1 {
 			// We're done sorting. Transition to emitting.
 			return
@@ -423,6 +435,7 @@ func (p *sortOp) sort() {
 		// For each partition (set of tuples that are identical in all of the sort
 		// columns we've seen so far), sort based on the new column.
 		sorter.sortPartitions(p.scratch.partitions)
+		sorter.reset()
 	}
 }
 

--- a/pkg/sql/colexec/sort_test.go
+++ b/pkg/sql/colexec/sort_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 )
 
@@ -322,6 +323,74 @@ func BenchmarkSort(b *testing.B) {
 							if err != nil {
 								b.Fatal(err)
 							}
+						}
+						sorter.Init(ctx)
+						for out := sorter.Next(); out.Length() != 0; out = sorter.Next() {
+						}
+					}
+				})
+			}
+		}
+	}
+}
+
+func BenchmarkSortUUID(b *testing.B) {
+	rng, _ := randutil.NewPseudoRand()
+	ctx := context.Background()
+
+	for _, nBatches := range []int{1 << 1, 1 << 4, 1 << 8} {
+		for _, nCols := range []int{1, 2} {
+			for _, constAbbrPct := range []int{0, 10, 25, 50, 75, 90, 100} {
+				name := fmt.Sprintf("rows=%d/cols=%d/constAbbrPct=%d", nBatches*coldata.BatchSize(), nCols, constAbbrPct)
+				b.Run(name, func(b *testing.B) {
+					// 8 (bytes / int64) * nBatches (number of batches) * coldata.BatchSize() (rows /
+					// batch) * nCols (number of columns / row).
+					b.SetBytes(int64(8 * nBatches * coldata.BatchSize() * nCols))
+					typs := make([]*types.T, nCols)
+					for i := range typs {
+						typs[i] = types.Bytes
+					}
+					batch := testAllocator.NewMemBatchWithMaxCapacity(typs)
+					batch.SetLength(coldata.BatchSize())
+					ordCols := make([]execinfrapb.Ordering_Column, nCols)
+					for i := range ordCols {
+						ordCols[i].ColIdx = uint32(i)
+						ordCols[i].Direction = execinfrapb.Ordering_Column_Direction(rng.Int() % 2)
+
+						col := batch.ColVec(i).Bytes()
+
+						// Make a constant prefix used for constAbbrPct% of
+						// UUIDs. This helps measure the overhead of abbreviated
+						// comparisons with varying cardinality. For example, if
+						// all abbreviated values are the same, then comparing
+						// them is unnecessary work because we must always fall
+						// back to full comparisons.
+						id, err := uuid.NewV4()
+						if err != nil {
+							b.Fatalf("unexpected error: %s", err)
+						}
+						constPrefix := id[:8]
+
+						for j := 0; j < coldata.BatchSize(); j++ {
+							id, err := uuid.NewV4()
+							if err != nil {
+								b.Fatalf("unexpected error: %s", err)
+							}
+							idBytes := id[:16]
+							// Make the abbreviated bytes constant constAbbrPct% of
+							// the time.
+							if rng.Float32() < float32(constAbbrPct)/100 {
+								copy(idBytes, constPrefix)
+							}
+							col.Set(j, idBytes)
+						}
+					}
+					b.ResetTimer()
+					for n := 0; n < b.N; n++ {
+						source := colexectestutils.NewFiniteBatchSource(testAllocator, batch, typs, nBatches)
+						sorter, err := NewSorter(testAllocator, source, typs, ordCols, execinfra.DefaultMemoryLimit)
+						if err != nil {
+							b.Fatal(err)
 						}
 						sorter.Init(ctx)
 						for out := sorter.Next(); out.Length() != 0; out = sorter.Next() {

--- a/pkg/sql/colexec/sort_test.go
+++ b/pkg/sql/colexec/sort_test.go
@@ -157,7 +157,7 @@ func TestSortRandomized(t *testing.T) {
 	rng, _ := randutil.NewPseudoRand()
 	nTups := coldata.BatchSize()*2 + 1
 	maxCols := 3
-	// TODO(yuzefovich): randomize types as well.
+	// TODO(yuzefovich/mgartner): randomize types as well.
 	typs := make([]*types.T, maxCols)
 	for i := range typs {
 		typs[i] = types.Int
@@ -340,7 +340,7 @@ func BenchmarkSortUUID(b *testing.B) {
 
 	for _, nBatches := range []int{1 << 1, 1 << 4, 1 << 8} {
 		for _, nCols := range []int{1, 2} {
-			for _, constAbbrPct := range []int{0, 10, 25, 50, 75, 90, 100} {
+			for _, constAbbrPct := range []int{0, 50, 75, 90, 100} {
 				name := fmt.Sprintf("rows=%d/cols=%d/constAbbrPct=%d", nBatches*coldata.BatchSize(), nCols, constAbbrPct)
 				b.Run(name, func(b *testing.B) {
 					// 8 (bytes / int64) * nBatches (number of batches) * coldata.BatchSize() (rows /

--- a/pkg/sql/memsize/constants.go
+++ b/pkg/sql/memsize/constants.go
@@ -37,6 +37,9 @@ const (
 	// Int64 is the in-memory size of an int64 in bytes.
 	Int64 = int64(unsafe.Sizeof(int64(0)))
 
+	// Uint64 is the in-memory size of a uint64 in bytes.
+	Uint64 = int64(unsafe.Sizeof(uint64(0)))
+
 	// Float64 is the in-memory size of a float64 in bytes.
 	Float64 = int64(unsafe.Sizeof(float64(0)))
 


### PR DESCRIPTION
#### colexec: add benchmark for sorting UUIDs

Release note: None

#### colexec: optimize Bytes sorting with abbreviated values

This commit introduces an optimization for sorting `Bytes` vectors.
While sorting, a signification potion of time is spent performing
comparisons between two datums. These comparisons are optimized by
creating an abbreviated `uint64` value for each `[]byte` that represents
up to the first eight bytes in the slice. The abbreviated value is used
for a comparison fast path that avoid comparing all bytes in a slice in
some cases. This technique is used by Postgres[1][2] and Pebble[3].

Abbreviating values to a `uint64` helps optimize comparisons for datums
that are larger than the size of the system's native pointer (64 bits).
Given datums `a` and `b`, the following properties must hold true for
the respective abbreviated values `abbrA` and `abbrB`:

  - `abbrA > abbrB` iff `a > b`
  - `abbrA < abbrB` iff `a < b`
  - If `abbrA == abbrB`, it is unknown if `a` is greater than, less
    than, or equal to `b`. A full comparison of `a` and `b` is required.

Comparing the abbreviated values first improves comparison performance
for two reasons. First, comparing two `uint64`s is fast. It is a single
CPU instruction. Any datum larger than 64 bits requires multiple
instructions for comparison. For example, comparing two `[]byte`s
requires iterating over each byte until non-equal bytes are found.
Second, CPU caches are more efficiently used because the abbreviated
values of a vector are packed into a `[]uint64` of contiguous memory.
This increases the chance that two datums can be compared by only
fetching information from CPU caches rather than main memory.

In the benchmarks below, `rows` is the number of rows being sorted,
`cols` is the number of sort columns, and `constAbbrPct` is the
percentage of rows for which the abbreviated values are the same. The
benchmarks show that in the best case, when the abbreviated values are
all unique, sort throughput has increased by up to ~45%. In the worst
case, where all values share the same abbreviated value, throughput has
decreased by as much as ~8.5%. This is due to the extra overhead of
creating abbreviated values and comparing them, only to have to fall
back to a full comparison every time.

    name                                             old speed      new speed      delta
    SortUUID/rows=2048/cols=1/constAbbrPct=0-16      38.0MB/s ± 2%  55.3MB/s ± 3%  +45.30%
    SortUUID/rows=2048/cols=1/constAbbrPct=50-16     36.2MB/s ± 3%  43.0MB/s ± 4%  +18.82%
    SortUUID/rows=2048/cols=1/constAbbrPct=75-16     36.0MB/s ± 4%  37.1MB/s ± 4%     ~
    SortUUID/rows=2048/cols=1/constAbbrPct=90-16     36.8MB/s ± 1%  36.2MB/s ± 3%     ~
    SortUUID/rows=2048/cols=1/constAbbrPct=100-16    37.0MB/s ± 1%  33.8MB/s ± 5%   -8.66%
    SortUUID/rows=2048/cols=2/constAbbrPct=0-16      60.3MB/s ± 1%  74.0MB/s ± 3%  +22.85%
    SortUUID/rows=2048/cols=2/constAbbrPct=50-16     58.7MB/s ± 1%  63.7MB/s ± 1%   +8.54%
    SortUUID/rows=2048/cols=2/constAbbrPct=75-16     58.3MB/s ± 1%  56.6MB/s ± 6%     ~
    SortUUID/rows=2048/cols=2/constAbbrPct=90-16     58.7MB/s ± 1%  54.2MB/s ± 3%   -7.69%
    SortUUID/rows=2048/cols=2/constAbbrPct=100-16    59.3MB/s ± 1%  56.1MB/s ± 4%   -5.30%
    SortUUID/rows=16384/cols=1/constAbbrPct=0-16     30.7MB/s ± 2%  41.9MB/s ± 3%  +36.24%
    SortUUID/rows=16384/cols=1/constAbbrPct=50-16    30.6MB/s ± 1%  32.0MB/s ± 8%     ~
    SortUUID/rows=16384/cols=1/constAbbrPct=75-16    30.2MB/s ± 2%  30.9MB/s ± 6%     ~
    SortUUID/rows=16384/cols=1/constAbbrPct=90-16    30.4MB/s ± 2%  27.6MB/s ± 3%   -9.29%
    SortUUID/rows=16384/cols=1/constAbbrPct=100-16   30.6MB/s ± 2%  28.5MB/s ± 5%   -6.98%
    SortUUID/rows=16384/cols=2/constAbbrPct=0-16     49.5MB/s ± 2%  59.0MB/s ± 2%  +19.13%
    SortUUID/rows=16384/cols=2/constAbbrPct=50-16    48.6MB/s ± 1%  49.5MB/s ± 3%   +1.84%
    SortUUID/rows=16384/cols=2/constAbbrPct=75-16    47.3MB/s ± 2%  47.3MB/s ± 2%     ~
    SortUUID/rows=16384/cols=2/constAbbrPct=90-16    48.5MB/s ± 2%  45.2MB/s ± 1%   -6.65%
    SortUUID/rows=16384/cols=2/constAbbrPct=100-16   48.9MB/s ± 1%  44.4MB/s ± 2%   -9.13%
    SortUUID/rows=262144/cols=1/constAbbrPct=0-16    25.4MB/s ± 2%  35.7MB/s ± 3%  +40.53%
    SortUUID/rows=262144/cols=1/constAbbrPct=50-16   24.9MB/s ± 3%  28.8MB/s ± 3%  +15.44%
    SortUUID/rows=262144/cols=1/constAbbrPct=75-16   25.4MB/s ± 2%  25.7MB/s ± 5%     ~
    SortUUID/rows=262144/cols=1/constAbbrPct=90-16   25.4MB/s ± 3%  24.7MB/s ± 2%   -3.00%
    SortUUID/rows=262144/cols=1/constAbbrPct=100-16  25.1MB/s ± 3%  23.7MB/s ± 2%   -5.73%
    SortUUID/rows=262144/cols=2/constAbbrPct=0-16    37.5MB/s ± 2%  43.7MB/s ± 5%  +16.65%
    SortUUID/rows=262144/cols=2/constAbbrPct=50-16   37.5MB/s ± 1%  37.8MB/s ± 7%     ~
    SortUUID/rows=262144/cols=2/constAbbrPct=75-16   37.1MB/s ± 4%  36.4MB/s ± 1%     ~
    SortUUID/rows=262144/cols=2/constAbbrPct=90-16   36.9MB/s ± 5%  34.6MB/s ± 7%   -6.26%
    SortUUID/rows=262144/cols=2/constAbbrPct=100-16  37.2MB/s ± 3%  34.0MB/s ± 2%   -8.53%

I experimented with several mitigations to the regressions, but did not
have much luck. Postgres uses HyperLogLog while building abbreviated
values to track their cardinality and abort the optimization if the
cardinality is too low. I attempted this, but the overhead of
HyperLogLog negated the benefits of the optimization entirely.

Using a `map[uint64]struct{}` to track the cardinality of abbreviated
values was the most promising. It was able to reduce the worst
regressions at the expense of reducing the speedup of the best case
benchmarks.

These mechanisms for aborting the optimization when abbreviated value
cardinality is low are essentially a trade-off between maximizing sort
performance when their cardinality is high and minimizing the overhead
of generating and comparing abbreviated values when their cardinality is
low. It's worth future investigation to try to find a low-overhead
method of aborting, and to be more thoughtful about the trade-offs.

[1] https://brandur.org/sortsupport
[2] http://pgeoghegan.blogspot.com/2015/01/abbreviated-keys-exploiting-locality-to.html
[3] https://github.com/cockroachdb/pebble/blob/ea60b4722cca21fa0d3c2749c788e1ac76981f7d/internal/base/comparer.go#L28-L36

Release note (performance improvement): Sort performance has been
improved when sorting columns of type STRING, BYTES, or UUID.
