### PR TITLE
release: update 20.2 mapping in PredecessorVersion()

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1218,7 +1218,7 @@ func PredecessorVersion(buildVersion version.Version) (string, error) {
 	// map.
 	verMap := map[string]string{
 		"21.1": "20.2.11",
-		"20.2": "20.1.12",
+		"20.2": "20.1.13",
 		"20.1": "19.2.11",
 		"19.2": "19.1.11",
 		"19.1": "2.1.9",


### PR DESCRIPTION
This updates the version mapping of the `20.2` branch to point to the
latest version (`20.2.13`).

Release note: None