### PR TITLE
cluster-ui: fix typo on network description

### DIFF
--- a/pkg/ui/cluster-ui/src/statsTableUtil/statsTableUtil.tsx
+++ b/pkg/ui/cluster-ui/src/statsTableUtil/statsTableUtil.tsx
@@ -424,7 +424,7 @@ export const statisticsTableTitles: StatisticTableTitleType = {
         content={
           <>
             <p>
-              {"Amount of data "}
+              {"Amount of "}
               <Anchor href={readsAndWrites} target="_blank">
                 data transferred over the network
               </Anchor>


### PR DESCRIPTION
Removal of one of the duplicates words "data" on the
network tooltip

Resolves: https://github.com/cockroachdb/cockroach/issues/66602

Release note (bug fix): Fix typo on Network Tooltip Description