### PR TITLE
bazel: bump timeout of `backupccl_test`

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -119,7 +119,7 @@ go_library(
 
 go_test(
     name = "backupccl_test",
-    size = "large",
+    size = "enormous",
     srcs = [
         "backup_cloud_test.go",
         "backup_destination_test.go",


### PR DESCRIPTION
Closes #67480.

Release note: None