### PR TITLE
sql/pgwire: implement pgwire query cancellation 

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -2082,6 +2082,54 @@ Response returned by target query's gateway node.
 
 
 
+## CancelQueryByKey
+
+
+
+CancelQueryByKey cancels a SQL query given its pgwire BackendKeyData.
+It is invoked through the pgwire protocol, so it's not exposed as an
+HTTP endpoint.
+
+Support status: [reserved](#support-status)
+
+#### Request Parameters
+
+
+
+
+Request object for issuing a pgwire query cancel request.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| sql_instance_id | [int32](#cockroach.server.serverpb.CancelQueryByKeyRequest-int32) |  | The SQLInstanceID of the gateway node for the query to be canceled. | [reserved](#support-status) |
+| cancel_query_key | [uint64](#cockroach.server.serverpb.CancelQueryByKeyRequest-uint64) |  | The key that was generated during session initialization as part of the pgwire protocol. | [reserved](#support-status) |
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+Response returned by target query's gateway node for a pgwire cancel request.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| canceled | [bool](#cockroach.server.serverpb.CancelQueryByKeyResponse-bool) |  | Whether the cancellation request succeeded and the query was canceled. | [reserved](#support-status) |
+| error | [string](#cockroach.server.serverpb.CancelQueryByKeyResponse-string) |  | Error message (accompanied with canceled = false). | [reserved](#support-status) |
+
+
+
+
+
+
+
 ## ListContentionEvents
 
 `GET /_status/contention_events`

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -295,6 +295,7 @@ ALL_TESTS = [
     "//pkg/sql/pgwire/hba:hba_test",
     "//pkg/sql/pgwire/identmap:identmap_test",
     "//pkg/sql/pgwire/pgerror:pgerror_test",
+    "//pkg/sql/pgwire/pgwirecancel:pgwirecancel_test",
     "//pkg/sql/pgwire:pgwire_test",
     "//pkg/sql/physicalplan/replicaoracle:replicaoracle_test",
     "//pkg/sql/physicalplan:physicalplan_test",

--- a/pkg/ccl/streamingccl/streamclient/partitioned_stream_client_test.go
+++ b/pkg/ccl/streamingccl/streamclient/partitioned_stream_client_test.go
@@ -72,7 +72,7 @@ INSERT INTO d.t2 VALUES (2);
 
 	client, err := newPartitionedStreamClient(&h.PGUrl)
 	defer func() {
-		require.NoError(t, client.Close())
+		_ = client.Close()
 	}()
 	require.NoError(t, err)
 	expectStreamState := func(streamID streaming.StreamID, status jobs.Status) {

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -157,6 +157,7 @@ go_library(
         "//pkg/sql/optionalnodeliveness",
         "//pkg/sql/parser",
         "//pkg/sql/pgwire",
+        "//pkg/sql/pgwire/pgwirecancel",
         "//pkg/sql/physicalplan",
         "//pkg/sql/querycache",
         "//pkg/sql/roleoption",

--- a/pkg/server/serverpb/BUILD.bazel
+++ b/pkg/server/serverpb/BUILD.bazel
@@ -52,6 +52,7 @@ go_proto_library(
     proto = ":serverpb_proto",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/base",  # keep
         "//pkg/build",
         "//pkg/clusterversion",
         "//pkg/config/zonepb",
@@ -65,6 +66,7 @@ go_proto_library(
         "//pkg/sql/catalog/descpb",  # keep
         "//pkg/sql/contentionpb",
         "//pkg/sql/execinfrapb",
+        "//pkg/sql/pgwire/pgwirecancel",  # keep
         "//pkg/storage/enginepb",
         "//pkg/ts/catalog",
         "//pkg/util",

--- a/pkg/server/serverpb/status.go
+++ b/pkg/server/serverpb/status.go
@@ -22,6 +22,7 @@ type SQLStatusServer interface {
 	ListSessions(context.Context, *ListSessionsRequest) (*ListSessionsResponse, error)
 	ListLocalSessions(context.Context, *ListSessionsRequest) (*ListSessionsResponse, error)
 	CancelQuery(context.Context, *CancelQueryRequest) (*CancelQueryResponse, error)
+	CancelQueryByKey(context.Context, *CancelQueryByKeyRequest) (*CancelQueryByKeyResponse, error)
 	CancelSession(context.Context, *CancelSessionRequest) (*CancelSessionResponse, error)
 	ListContentionEvents(context.Context, *ListContentionEventsRequest) (*ListContentionEventsResponse, error)
 	ListLocalContentionEvents(context.Context, *ListContentionEventsRequest) (*ListContentionEventsResponse, error)

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -846,6 +846,30 @@ message CancelQueryResponse {
   string error = 2;
 }
 
+// Request object for issuing a pgwire query cancel request.
+message CancelQueryByKeyRequest {
+  // The SQLInstanceID of the gateway node for the query to be canceled.
+  int32 sql_instance_id = 1 [
+    (gogoproto.customname) = "SQLInstanceID",
+    (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/base.SQLInstanceID"
+  ];
+
+  // The key that was generated during session initialization as
+  // part of the pgwire protocol.
+  uint64 cancel_query_key = 2 [
+    (gogoproto.customname) = "CancelQueryKey",
+    (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirecancel.BackendKeyData"
+  ];
+}
+
+// Response returned by target query's gateway node for a pgwire cancel request.
+message CancelQueryByKeyResponse {
+  // Whether the cancellation request succeeded and the query was canceled.
+  bool canceled = 1;
+  // Error message (accompanied with canceled = false).
+  string error = 2;
+}
+
 message CancelSessionRequest {
   // TODO(abhimadan): use [(gogoproto.customname) = "NodeID"] below. Need to
   // figure out how to teach grpc-gateway about custom names.
@@ -1543,6 +1567,11 @@ service Status {
       body: "*"
     };
   }
+
+  // CancelQueryByKey cancels a SQL query given its pgwire BackendKeyData.
+  // It is invoked through the pgwire protocol, so it's not exposed as an
+  // HTTP endpoint.
+  rpc CancelQueryByKey(CancelQueryByKeyRequest) returns (CancelQueryByKeyResponse) {}
 
   // ListContentionEvents retrieves the contention events across the entire
   // cluster.

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -2421,6 +2421,15 @@ func (s *statusServer) CancelQuery(
 	return output, nil
 }
 
+// CancelQueryByKey responds to a pgwire query cancellation request, and
+// cancels  the target query's associated context and sets a cancellation flag.
+func (s *statusServer) CancelQueryByKey(
+	ctx context.Context, req *serverpb.CancelQueryByKeyRequest,
+) (*serverpb.CancelQueryByKeyResponse, error) {
+	var output = &serverpb.CancelQueryByKeyResponse{}
+	return output, nil
+}
+
 // ListContentionEvents returns a list of contention events on all nodes in the
 // cluster.
 func (s *statusServer) ListContentionEvents(

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -54,6 +54,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/contention"
 	"github.com/cockroachdb/cockroach/pkg/sql/flowinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirecancel"
 	"github.com/cockroachdb/cockroach/pkg/sql/roleoption"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
@@ -2421,13 +2422,56 @@ func (s *statusServer) CancelQuery(
 	return output, nil
 }
 
-// CancelQueryByKey responds to a pgwire query cancellation request, and
-// cancels  the target query's associated context and sets a cancellation flag.
+// CancelQueryByKey responds to a pgwire query cancellation request, and cancels
+// the target query's associated context and sets a cancellation flag. This
+// endpoint is rate-limited by a semaphore.
 func (s *statusServer) CancelQueryByKey(
 	ctx context.Context, req *serverpb.CancelQueryByKeyRequest,
-) (*serverpb.CancelQueryByKeyResponse, error) {
-	var output = &serverpb.CancelQueryByKeyResponse{}
-	return output, nil
+) (resp *serverpb.CancelQueryByKeyResponse, retErr error) {
+	local := req.SQLInstanceID == s.sqlServer.SQLInstanceID()
+	resp = &serverpb.CancelQueryByKeyResponse{}
+
+	// Acquiring the semaphore here helps protect both the source and destination
+	// nodes. The source node is protected against an attacker causing too much
+	// inter-node network traffic by spamming cancel requests. The destination
+	// node is protected so that if an attacker spams all the nodes in the cluster
+	// with requests that all go to the same node, this semaphore will prevent
+	// them from having too many guesses.
+	// More concretely, suppose we have a 100-node cluster. If we limit the
+	// ingress only, then each node is limited to processing X requests per
+	// second. But if an attacker crafts the CancelRequests to all target the
+	// same SQLInstance, then that one instance would have to process 100*X
+	// requests per second.
+	alloc, err := pgwirecancel.CancelSemaphore.TryAcquire(ctx, 1)
+	if err != nil {
+		return nil, status.Errorf(codes.ResourceExhausted, "exceeded rate limit of pgwire cancellation requests")
+	}
+	defer func() {
+		// If we acquired the semaphore but the cancellation request failed, then
+		// hold on to the semaphore for longer. This helps mitigate a DoS attack
+		// of random cancellation requests.
+		if !resp.Canceled {
+			time.Sleep(1 * time.Second)
+		}
+		alloc.Release()
+	}()
+
+	if local {
+		resp.Canceled, err = s.sessionRegistry.CancelQueryByKey(req.CancelQueryKey)
+		if err != nil {
+			resp.Error = err.Error()
+		}
+		return resp, nil
+	}
+
+	// This request needs to be forwarded to another node.
+	ctx = propagateGatewayMetadata(ctx)
+	ctx = s.AnnotateCtx(ctx)
+	client, err := s.dialNode(ctx, roachpb.NodeID(req.SQLInstanceID))
+	if err != nil {
+		return nil, err
+	}
+	return client.CancelQueryByKey(ctx, req)
 }
 
 // ListContentionEvents returns a list of contention events on all nodes in the

--- a/pkg/server/tenant_status.go
+++ b/pkg/server/tenant_status.go
@@ -237,6 +237,13 @@ func (t *tenantStatusServer) CancelLocalQuery(
 	return output, nil
 }
 
+func (t *tenantStatusServer) CancelQueryByKey(
+	ctx context.Context, request *serverpb.CancelQueryByKeyRequest,
+) (*serverpb.CancelQueryByKeyResponse, error) {
+	var output = &serverpb.CancelQueryByKeyResponse{}
+	return output, nil
+}
+
 func (t *tenantStatusServer) CancelSession(
 	ctx context.Context, request *serverpb.CancelSessionRequest,
 ) (*serverpb.CancelSessionResponse, error) {

--- a/pkg/server/tenant_status.go
+++ b/pkg/server/tenant_status.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -32,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/contention"
 	"github.com/cockroachdb/cockroach/pkg/sql/flowinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirecancel"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlinstance"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -237,11 +239,62 @@ func (t *tenantStatusServer) CancelLocalQuery(
 	return output, nil
 }
 
+// CancelQueryByKey responds to a pgwire query cancellation request, and cancels
+// the target query's associated context and sets a cancellation flag. This
+// endpoint is rate-limited by a semaphore.
 func (t *tenantStatusServer) CancelQueryByKey(
-	ctx context.Context, request *serverpb.CancelQueryByKeyRequest,
-) (*serverpb.CancelQueryByKeyResponse, error) {
-	var output = &serverpb.CancelQueryByKeyResponse{}
-	return output, nil
+	ctx context.Context, req *serverpb.CancelQueryByKeyRequest,
+) (resp *serverpb.CancelQueryByKeyResponse, retErr error) {
+	// We are interpreting the `NodeID` in the request as an `InstanceID` since
+	// we are executing in the context of a tenant.
+	local := req.SQLInstanceID == t.sqlServer.SQLInstanceID()
+	resp = &serverpb.CancelQueryByKeyResponse{}
+
+	// Acquiring the semaphore here helps protect both the source and destination
+	// nodes. The source node is protected against an attacker causing too much
+	// inter-node network traffic by spamming cancel requests. The destination
+	// node is protected so that if an attacker spams all the nodes in the cluster
+	// with requests that all go to the same node, this semaphore will prevent
+	// them from having too many guesses.
+	// More concretely, suppose we have a 100-node cluster. If we limit the
+	// ingress only, then each node is limited to processing X requests per
+	// second. But if an attacker crafts the CancelRequests to all target the
+	// same SQLInstance, then that one instance would have to process 100*X
+	// requests per second.
+	alloc, err := pgwirecancel.CancelSemaphore.TryAcquire(ctx, 1)
+	if err != nil {
+		return nil, status.Errorf(codes.ResourceExhausted, "exceeded rate limit of pgwire cancellation requests")
+	}
+	defer func() {
+		// If we acquired the semaphore but the cancellation request failed, then
+		// hold on to the semaphore for longer. This helps mitigate a DoS attack
+		// of random cancellation requests.
+		if !resp.Canceled {
+			time.Sleep(1 * time.Second)
+		}
+		alloc.Release()
+	}()
+
+	if local {
+		resp.Canceled, err = t.sessionRegistry.CancelQueryByKey(req.CancelQueryKey)
+		if err != nil {
+			resp.Error = err.Error()
+		}
+		return resp, nil
+	}
+
+	// This request needs to be forwarded to another node.
+	ctx = propagateGatewayMetadata(ctx)
+	ctx = t.AnnotateCtx(ctx)
+	instance, err := t.sqlServer.sqlInstanceProvider.GetInstance(ctx, req.SQLInstanceID)
+	if err != nil {
+		return nil, err
+	}
+	statusClient, err := t.dialPod(ctx, req.SQLInstanceID, instance.InstanceAddr)
+	if err != nil {
+		return nil, err
+	}
+	return statusClient.CancelQueryByKey(ctx, req)
 }
 
 func (t *tenantStatusServer) CancelSession(

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -345,6 +345,7 @@ go_library(
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/pgwire/pgnotice",
         "//pkg/sql/pgwire/pgwirebase",
+        "//pkg/sql/pgwire/pgwirecancel",
         "//pkg/sql/physicalplan",
         "//pkg/sql/physicalplan/replicaoracle",
         "//pkg/sql/privilege",

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -68,6 +68,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirecancel"
 	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
 	"github.com/cockroachdb/cockroach/pkg/sql/querycache"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
@@ -1864,30 +1865,39 @@ type SessionArgs struct {
 // Use register() and deregister() to modify this registry.
 type SessionRegistry struct {
 	syncutil.Mutex
-	sessions map[ClusterWideID]registrySession
+	sessions            map[ClusterWideID]registrySession
+	sessionsByCancelKey map[pgwirecancel.BackendKeyData]registrySession
 }
 
 // NewSessionRegistry creates a new SessionRegistry with an empty set
 // of sessions.
 func NewSessionRegistry() *SessionRegistry {
-	return &SessionRegistry{sessions: make(map[ClusterWideID]registrySession)}
+	return &SessionRegistry{
+		sessions:            make(map[ClusterWideID]registrySession),
+		sessionsByCancelKey: make(map[pgwirecancel.BackendKeyData]registrySession),
+	}
 }
 
-func (r *SessionRegistry) register(id ClusterWideID, s registrySession) {
+func (r *SessionRegistry) register(
+	id ClusterWideID, queryCancelKey pgwirecancel.BackendKeyData, s registrySession,
+) {
 	r.Lock()
+	defer r.Unlock()
 	r.sessions[id] = s
-	r.Unlock()
+	r.sessionsByCancelKey[queryCancelKey] = s
 }
 
-func (r *SessionRegistry) deregister(id ClusterWideID) {
+func (r *SessionRegistry) deregister(id ClusterWideID, queryCancelKey pgwirecancel.BackendKeyData) {
 	r.Lock()
+	defer r.Unlock()
 	delete(r.sessions, id)
-	r.Unlock()
+	delete(r.sessionsByCancelKey, queryCancelKey)
 }
 
 type registrySession interface {
 	user() security.SQLUsername
 	cancelQuery(queryID ClusterWideID) bool
+	cancelCurrentQueries() bool
 	cancelSession()
 	// serialize serializes a Session into a serverpb.Session
 	// that can be served over RPC.
@@ -1912,6 +1922,21 @@ func (r *SessionRegistry) CancelQuery(queryIDStr string) (bool, error) {
 	}
 
 	return false, fmt.Errorf("query ID %s not found", queryID)
+}
+
+// CancelQueryByKey looks up the associated query in the session registry and
+// cancels it.
+func (r *SessionRegistry) CancelQueryByKey(
+	queryCancelKey pgwirecancel.BackendKeyData,
+) (bool, error) {
+	r.Lock()
+	defer r.Unlock()
+	if session, ok := r.sessionsByCancelKey[queryCancelKey]; ok {
+		if session.cancelCurrentQueries() {
+			return true, nil
+		}
+	}
+	return false, fmt.Errorf("query for cancel key %d not found", queryCancelKey)
 }
 
 // CancelSession looks up the specified session in the session registry and

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1928,15 +1928,16 @@ func (r *SessionRegistry) CancelQuery(queryIDStr string) (bool, error) {
 // cancels it.
 func (r *SessionRegistry) CancelQueryByKey(
 	queryCancelKey pgwirecancel.BackendKeyData,
-) (bool, error) {
+) (canceled bool, err error) {
 	r.Lock()
 	defer r.Unlock()
 	if session, ok := r.sessionsByCancelKey[queryCancelKey]; ok {
 		if session.cancelCurrentQueries() {
 			return true, nil
 		}
+		return false, nil
 	}
-	return false, fmt.Errorf("query for cancel key %d not found", queryCancelKey)
+	return false, fmt.Errorf("session for cancel key %d not found", queryCancelKey)
 }
 
 // CancelSession looks up the specified session in the session registry and

--- a/pkg/sql/pgwire/BUILD.bazel
+++ b/pkg/sql/pgwire/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//pkg/col/coldata",
         "//pkg/security",
         "//pkg/security/sessionrevival",
+        "//pkg/server/serverpb",
         "//pkg/server/telemetry",
         "//pkg/settings",
         "//pkg/settings/cluster",

--- a/pkg/sql/pgwire/BUILD.bazel
+++ b/pkg/sql/pgwire/BUILD.bazel
@@ -39,6 +39,7 @@ go_library(
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/pgwire/pgnotice",
         "//pkg/sql/pgwire/pgwirebase",
+        "//pkg/sql/pgwire/pgwirecancel",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondatapb",
         "//pkg/sql/sqltelemetry",

--- a/pkg/sql/pgwire/conn_test.go
+++ b/pkg/sql/pgwire/conn_test.go
@@ -1623,50 +1623,6 @@ func TestSetSessionArguments(t *testing.T) {
 	}
 }
 
-// TestCancelQuery uses the pgwire-level query cancellation protocol provided
-// by lib/pq to make sure that canceling a query has no effect, and makes sure
-// the dummy BackendKeyData does not cause problems.
-func TestCancelQuery(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
-	cancelCtx, cancel := context.WithCancel(context.Background())
-	args := base.TestServerArgs{
-		Knobs: base.TestingKnobs{
-			SQLExecutor: &sql.ExecutorTestingKnobs{
-				BeforeExecute: func(ctx context.Context, stmt string) {
-					if strings.Contains(stmt, "pg_sleep") {
-						cancel()
-					}
-				},
-			},
-		},
-	}
-	s, _, _ := serverutils.StartServer(t, args)
-	defer s.Stopper().Stop(cancelCtx)
-
-	pgURL, cleanupFunc := sqlutils.PGUrl(
-		t, s.ServingSQLAddr(), "TestCancelQuery" /* prefix */, url.User(security.RootUser),
-	)
-	defer cleanupFunc()
-
-	db, err := gosql.Open("postgres", pgURL.String())
-	require.NoError(t, err)
-	defer db.Close()
-
-	// Cancellation has no effect on ongoing query.
-	if _, err := db.QueryContext(cancelCtx, "select pg_sleep(0)"); err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
-
-	// Context is already canceled, so error should come before execution.
-	if _, err := db.QueryContext(cancelCtx, "select 1"); err == nil {
-		t.Fatal("expected error")
-	} else if err.Error() != "context canceled" {
-		t.Fatalf("unexpected error: %s", err)
-	}
-}
-
 func TestRoleDefaultSettings(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -1948,7 +1948,7 @@ func TestCancelRequest(t *testing.T) {
 		if _, err := fe.Receive(); !errors.Is(err, io.ErrUnexpectedEOF) {
 			t.Fatalf("unexpected: %v", err)
 		}
-		if count := telemetry.GetRawFeatureCounts()["pgwire.unimplemented.cancel_request"]; count != 1 {
+		if count := telemetry.GetRawFeatureCounts()["pgwire.cancel_request"]; count != 1 {
 			t.Fatalf("expected 1 cancel request, got %d", count)
 		}
 	})

--- a/pkg/sql/pgwire/pgwirebase/encoding.go
+++ b/pkg/sql/pgwire/pgwirebase/encoding.go
@@ -262,6 +262,16 @@ func (b *ReadBuffer) GetUint32() (uint32, error) {
 	return v, nil
 }
 
+// GetUint64 returns the buffer's contents as a uint64.
+func (b *ReadBuffer) GetUint64() (uint64, error) {
+	if len(b.Msg) < 8 {
+		return 0, NewProtocolViolationErrorf("insufficient data: %d", len(b.Msg))
+	}
+	v := binary.BigEndian.Uint64(b.Msg[:8])
+	b.Msg = b.Msg[8:]
+	return v, nil
+}
+
 // NewUnrecognizedMsgTypeErr creates an error for an unrecognized pgwire
 // message.
 func NewUnrecognizedMsgTypeErr(typ ClientMessageType) error {

--- a/pkg/sql/pgwire/pgwirecancel/BUILD.bazel
+++ b/pkg/sql/pgwire/pgwirecancel/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "pgwirecancel",
+    srcs = ["backend_key_data.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirecancel",
+    visibility = ["//visibility:public"],
+    deps = ["//pkg/base"],
+)
+
+go_test(
+    name = "pgwirecancel_test",
+    srcs = ["backend_key_data_test.go"],
+    embed = [":pgwirecancel"],
+    deps = [
+        "//pkg/base",
+        "//pkg/util/timeutil",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/sql/pgwire/pgwirecancel/BUILD.bazel
+++ b/pkg/sql/pgwire/pgwirecancel/BUILD.bazel
@@ -2,18 +2,40 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "pgwirecancel",
-    srcs = ["backend_key_data.go"],
+    srcs = [
+        "backend_key_data.go",
+        "cancel_semaphore.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirecancel",
     visibility = ["//visibility:public"],
-    deps = ["//pkg/base"],
+    deps = [
+        "//pkg/base",
+        "//pkg/util/quotapool",
+    ],
 )
 
 go_test(
     name = "pgwirecancel_test",
-    srcs = ["backend_key_data_test.go"],
+    srcs = [
+        "backend_key_data_test.go",
+        "cancel_test.go",
+        "main_test.go",
+    ],
     embed = [":pgwirecancel"],
     deps = [
         "//pkg/base",
+        "//pkg/security",
+        "//pkg/security/securitytest",
+        "//pkg/server",
+        "//pkg/sql",
+        "//pkg/testutils/serverutils",
+        "//pkg/testutils/sqlutils",
+        "//pkg/testutils/testcluster",
+        "//pkg/util",
+        "//pkg/util/ctxgroup",
+        "//pkg/util/leaktest",
+        "//pkg/util/log",
+        "//pkg/util/randutil",
         "//pkg/util/timeutil",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/sql/pgwire/pgwirecancel/backend_key_data.go
+++ b/pkg/sql/pgwire/pgwirecancel/backend_key_data.go
@@ -1,0 +1,74 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package pgwirecancel
+
+import (
+	"math/rand"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+)
+
+// BackendKeyData is a 64-bit identifier used by the pgwire protocol to cancel
+// queries. It is created at the time of session initialization. It contains the
+// SQLInstanceID of the node. SQLInstanceID is an alias of int32, but we use a
+// variable number of bits here. The leading bit will only be set if the
+// SQLInstanceID is greater than or equal to 2^11. If it is set, the other 31
+// bits are used for the ID; otherwise 11 bits are used for the ID. This is safe
+// because SQLInstanceID is always a non-negative integer. The remaining bits
+// (either 32 bits or 52 bits) are random, and are used to uniquely identify a
+// session on that SQL node.
+//
+// See information about how Postgres uses it here:
+// https://www.postgresql.org/docs/current/protocol-flow.html#id-1.10.5.7.9
+type BackendKeyData uint64
+
+const (
+	lower32BitsMask uint64 = 0x00000000FFFFFFFF
+	lower52BitsMask uint64 = 0x000FFFFFFFFFFFFF
+	leadingBitMask         = 1 << 63
+)
+
+// MakeBackendKeyData creates a new BackendKayData that contains the given
+// SQLInstanceID. The rest of the data are random bits. The number of random
+// bits is larger of the SQLInstanceID is small enough.
+func MakeBackendKeyData(rng *rand.Rand, sqlInstanceID base.SQLInstanceID) BackendKeyData {
+	ret := rng.Uint64()
+	if sqlInstanceID < 1<<11 {
+		// Only keep the lower 52 bits
+		ret = ret & lower52BitsMask
+		// Set the upper 12 bits based on the sqlInstanceID.
+		ret = ret | (uint64(sqlInstanceID) << 52)
+	} else {
+		// Only keep the lower 32 bits.
+		ret = ret & lower32BitsMask
+		// Set the leading bit.
+		ret = ret | leadingBitMask
+		// Set the other upper 31 bits based on the sqlInstanceID.
+		ret = ret | (uint64(sqlInstanceID) << 32)
+	}
+	return BackendKeyData(ret)
+}
+
+// GetSQLInstanceID returns the SQLInstanceID that is encoded in this
+// BackendKeyData.
+func (b BackendKeyData) GetSQLInstanceID() base.SQLInstanceID {
+	bits := uint64(b)
+	if bits&leadingBitMask == 0 {
+		// Use the upper 12 bits as the sqlInstanceID.
+		return base.SQLInstanceID(bits >> 52)
+	}
+
+	// Clear the leading bit.
+	bits = bits &^ leadingBitMask
+	// Use the upper 32 bits as the sqlInstanceID.
+	return base.SQLInstanceID(bits >> 32)
+
+}

--- a/pkg/sql/pgwire/pgwirecancel/backend_key_data_test.go
+++ b/pkg/sql/pgwire/pgwirecancel/backend_key_data_test.go
@@ -17,11 +17,14 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/stretchr/testify/require"
 )
 
 func TestMakeBackendKeyData(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
 	rng := rand.New(rand.NewSource(timeutil.Now().Unix()))
 	b1 := MakeBackendKeyData(rng, base.SQLInstanceID(1))
 	b2 := MakeBackendKeyData(rng, base.SQLInstanceID(1))
@@ -29,8 +32,9 @@ func TestMakeBackendKeyData(t *testing.T) {
 }
 
 func TestGetSQLInstanceID(t *testing.T) {
-	rng := rand.New(rand.NewSource(timeutil.Now().Unix()))
+	defer leaktest.AfterTest(t)()
 
+	rng := rand.New(rand.NewSource(timeutil.Now().Unix()))
 	t.Run("small id", func(t *testing.T) {
 		for i := 0; i < 1<<11; i++ {
 			b := MakeBackendKeyData(rng, base.SQLInstanceID(i))

--- a/pkg/sql/pgwire/pgwirecancel/backend_key_data_test.go
+++ b/pkg/sql/pgwire/pgwirecancel/backend_key_data_test.go
@@ -1,0 +1,47 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package pgwirecancel
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMakeBackendKeyData(t *testing.T) {
+	rng := rand.New(rand.NewSource(timeutil.Now().Unix()))
+	b1 := MakeBackendKeyData(rng, base.SQLInstanceID(1))
+	b2 := MakeBackendKeyData(rng, base.SQLInstanceID(1))
+	require.NotEqual(t, b1, b2)
+}
+
+func TestGetSQLInstanceID(t *testing.T) {
+	rng := rand.New(rand.NewSource(timeutil.Now().Unix()))
+
+	t.Run("small id", func(t *testing.T) {
+		for i := 0; i < 1<<11; i++ {
+			b := MakeBackendKeyData(rng, base.SQLInstanceID(i))
+			require.Equal(t, base.SQLInstanceID(i), b.GetSQLInstanceID())
+		}
+	})
+
+	for i := 1 << 11; i < math.MaxInt32; i = (i * 2) + 1 {
+		t.Run(fmt.Sprintf("large id %d", i), func(t *testing.T) {
+			b := MakeBackendKeyData(rng, base.SQLInstanceID(i))
+			require.Equal(t, base.SQLInstanceID(i), b.GetSQLInstanceID())
+		})
+	}
+}

--- a/pkg/sql/pgwire/pgwirecancel/cancel_semaphore.go
+++ b/pkg/sql/pgwire/pgwirecancel/cancel_semaphore.go
@@ -1,0 +1,26 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package pgwirecancel
+
+import "github.com/cockroachdb/cockroach/pkg/util/quotapool"
+
+// CancelSemaphore is a semaphore that limits the number of concurrent
+// calls to the pgwire query cancellation endpoint. This is needed to avoid the
+// risk of a DoS attack by malicious users that attempts to cancel random
+// queries by spamming the request.
+//
+// We hard-code a limit of 256 concurrent pgwire cancel requests (per node).
+// We also add a 1-second penalty for failed cancellation requests, meaning
+// that an attacker needs 1 second per guess. With an attacker randomly
+// guessing a 32-bit secret, it would take 2^24 seconds to hit one query. If
+// we suppose there are 256 concurrent queries actively running on a node,
+// then it would take 2^16 seconds (18 hours) to hit any one of them.
+var CancelSemaphore = quotapool.NewIntPool("pgwire-cancel", 256)

--- a/pkg/sql/pgwire/pgwirecancel/cancel_test.go
+++ b/pkg/sql/pgwire/pgwirecancel/cancel_test.go
@@ -1,0 +1,163 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package pgwirecancel_test
+
+import (
+	"context"
+	gosql "database/sql"
+	"io"
+	"net"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCancelQuery uses the pgwire-level query cancellation protocol provided
+// by lib/pq to make sure that canceling a query works correctly.
+func TestCancelQuery(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	cancelCtx, cancel := context.WithCancel(context.Background())
+	args := base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			SQLExecutor: &sql.ExecutorTestingKnobs{
+				BeforeExecute: func(ctx context.Context, stmt string) {
+					if strings.Contains(stmt, "pg_sleep") {
+						cancel()
+					}
+				},
+			},
+		},
+	}
+	s, db, _ := serverutils.StartServer(t, args)
+	defer s.Stopper().Stop(cancelCtx)
+	defer db.Close()
+
+	// Cancellation should stop the query.
+	var b bool
+	err := db.QueryRowContext(cancelCtx, "select pg_sleep(30)").Scan(&b)
+	require.EqualError(t, err, "pq: query execution canceled")
+
+	// Context is already canceled, so error should come before execution.
+	var i int
+	err = db.QueryRowContext(cancelCtx, "select 1").Scan(&i)
+	require.EqualError(t, err, "context canceled")
+}
+
+// TestCancelQueryOtherNode uses the pgwire-level query cancellation protocol
+// to make sure cancel requests are forwarded to the correct node. It sets up
+// a very simple load balancer so that the cancel request is sent to a
+// different node than the node with the SQL session.
+func TestCancelQueryOtherNode(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	args := base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			SQLExecutor: &sql.ExecutorTestingKnobs{
+				BeforeExecute: func(ctx context.Context, stmt string) {
+					if strings.Contains(stmt, "pg_sleep") {
+						cancel()
+					}
+				},
+			},
+		},
+	}
+	tc := serverutils.StartNewTestCluster(t, 3, base.TestClusterArgs{ServerArgs: args})
+	defer tc.Stopper().Stop(ctx)
+
+	proxy, err := net.Listen("tcp", util.TestAddr.String())
+	require.NoError(t, err)
+
+	node0, err := net.Dial("tcp", tc.Server(0).ServingSQLAddr())
+	require.NoError(t, err)
+	defer node0.Close()
+	node1, err := net.Dial("tcp", tc.Server(1).ServingSQLAddr())
+	require.NoError(t, err)
+	defer node1.Close()
+
+	gotSecondConn := false
+	group := ctxgroup.WithContext(ctx)
+	group.GoCtx(func(ctx context.Context) error {
+		// The forwarder only expects to receive two connections: one for the
+		// SQL session, and one for the cancel request. After that, the forwarder
+		// stops serving connections.
+		for i := 0; i < 2; i++ {
+			i := i
+			clientConn, err := proxy.Accept()
+			if err != nil {
+				return err
+			}
+			var crdbConn net.Conn
+			if i == 0 {
+				// The first connection is routed to node0.
+				crdbConn = node0
+			} else if i == 1 {
+				// The first connection is routed to node1.
+				gotSecondConn = true
+				crdbConn = node1
+			}
+			group.GoCtx(func(ctx context.Context) error {
+				return ctxgroup.GoAndWait(
+					ctx,
+					func(ctx context.Context) error {
+						_, err := io.Copy(crdbConn, clientConn)
+						crdbConn.Close()
+						return err
+					},
+					func(ctx context.Context) error {
+						_, err := io.Copy(clientConn, crdbConn)
+						clientConn.Close()
+						return err
+					},
+				)
+			})
+		}
+		return nil
+	})
+
+	pgURL, cleanup := sqlutils.PGUrl(
+		t,
+		proxy.Addr().String(),
+		"TestCancelQueryOtherNode",
+		url.User(security.RootUser),
+	)
+	defer cleanup()
+	db, err := gosql.Open("postgres", pgURL.String())
+	require.NoError(t, err)
+	defer db.Close()
+
+	// The cancel will be sent before the query completes.
+	var b bool
+	err = db.QueryRowContext(ctx, "select pg_sleep(5)").Scan(&b)
+	require.EqualError(t, err, "pq: query execution canceled")
+
+	// The simple proxy doesn't close connections cleanly, so we ignore the error
+	// it returns.
+	_ = group.Wait()
+
+	// Check this after the previous goroutines finish to avoid a data race.
+	require.Truef(t, gotSecondConn, "expected cancel request to arrive on a different connection")
+
+}

--- a/pkg/sql/pgwire/pgwirecancel/main_test.go
+++ b/pkg/sql/pgwire/pgwirecancel/main_test.go
@@ -1,0 +1,33 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package pgwirecancel_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+//go:generate ../../../util/leaktest/add-leaktest.sh *_test.go
+
+func TestMain(m *testing.M) {
+	security.SetAssetLoader(securitytest.EmbeddedAssets)
+	randutil.SeedForTests()
+	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
+	os.Exit(m.Run())
+}

--- a/pkg/sql/sqltelemetry/pgwire.go
+++ b/pkg/sql/sqltelemetry/pgwire.go
@@ -19,7 +19,7 @@ import (
 
 // CancelRequestCounter is to be incremented every time a pgwire-level
 // cancel request is received from a client.
-var CancelRequestCounter = telemetry.GetCounterOnce("pgwire.unimplemented.cancel_request")
+var CancelRequestCounter = telemetry.GetCounterOnce("pgwire.cancel_request")
 
 // UnimplementedClientStatusParameterCounter is to be incremented
 // every time a client attempts to configure a status parameter

--- a/pkg/testutils/pgtest/pgtest.go
+++ b/pkg/testutils/pgtest/pgtest.go
@@ -72,16 +72,11 @@ func NewPGTest(ctx context.Context, addr, user string) (*PGTest, error) {
 			foundCrdb = true
 		}
 		if d, ok := msg.(*pgproto3.BackendKeyData); ok {
-			// We inspect the BackendKeyData outside of the loop since we only
-			// want to do the assertions if foundCrdb==true.
 			backendKeyData = d
 		}
 	}
 	if backendKeyData == nil {
 		return nil, errors.Errorf("did not receive BackendKeyData")
-	}
-	if foundCrdb && (backendKeyData.ProcessID != 0 || backendKeyData.SecretKey != 0) {
-		return nil, errors.Errorf("unexpected BackendKeyData: %+v", d)
 	}
 	p.isCockroachDB = foundCrdb
 	success = err == nil


### PR DESCRIPTION
closes #41335

See individual commits for more details.

This adds a BackendKeyData struct which identifies a session and SQLInstance
running that session. Clients send it to cancel a request, and it's handled by a new
CancelQueryByBackendKeyData endpoint in the status server. The cancellation
gets forwarded to the correct node, and there is a per-node rate limit to
prevent a DoS attack.

Also, refer to the RFC: https://github.com/cockroachdb/cockroach/pull/75870

This PR only adds support for non-multitenant clusters. Refer to the RFC for additional
work needed for serverless/multitenant support.
