### PR TITLE
sql: support GRANT/REVOKE ... ON ALL TABLES IN SCHEMA {schema_names...}

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -77,6 +77,7 @@ grant_stmt ::=
 	| 'GRANT' privilege_list 'TO' name_list 'WITH' 'ADMIN' 'OPTION'
 	| 'GRANT' privileges 'ON' 'TYPE' target_types 'TO' name_list
 	| 'GRANT' privileges 'ON' 'SCHEMA' schema_name_list 'TO' name_list
+	| 'GRANT' privileges 'ON' 'ALL' 'TABLES' 'IN' 'SCHEMA' schema_name_list 'TO' name_list
 
 prepare_stmt ::=
 	'PREPARE' table_alias_name prep_type_clause 'AS' preparable_stmt
@@ -87,6 +88,7 @@ revoke_stmt ::=
 	| 'REVOKE' 'ADMIN' 'OPTION' 'FOR' privilege_list 'FROM' name_list
 	| 'REVOKE' privileges 'ON' 'TYPE' target_types 'FROM' name_list
 	| 'REVOKE' privileges 'ON' 'SCHEMA' schema_name_list 'FROM' name_list
+	| 'REVOKE' privileges 'ON' 'ALL' 'TABLES' 'IN' 'SCHEMA' schema_name_list 'FROM' name_list
 
 savepoint_stmt ::=
 	'SAVEPOINT' name

--- a/pkg/sql/logictest/testdata/logic_test/grant_on_all_tables_in_schema
+++ b/pkg/sql/logictest/testdata/logic_test/grant_on_all_tables_in_schema
@@ -1,0 +1,96 @@
+statement ok
+CREATE USER testuser2
+
+statement ok
+CREATE SCHEMA s;
+CREATE SCHEMA s2;
+
+# Granting in a schema with no tables should be okay.
+statement ok
+GRANT SELECT ON ALL TABLES IN SCHEMA s TO testuser
+
+query TTTTT colnames
+SHOW GRANTS FOR testuser
+----
+database_name  schema_name  relation_name  grantee  privilege_type
+
+statement ok
+CREATE TABLE s.t();
+CREATE TABLE s2.t();
+
+statement ok
+GRANT SELECT ON ALL TABLES IN SCHEMA s TO testuser
+
+query TTTTT colnames
+SHOW GRANTS FOR testuser
+----
+database_name  schema_name  relation_name  grantee   privilege_type
+test           s            t              testuser  SELECT
+
+statement ok
+GRANT SELECT ON ALL TABLES IN SCHEMA s, s2 TO testuser, testuser2
+
+query TTTTT colnames
+SHOW GRANTS FOR testuser, testuser2
+----
+database_name  schema_name  relation_name  grantee    privilege_type
+test           s            t              testuser   SELECT
+test           s            t              testuser2  SELECT
+test           s2           t              testuser   SELECT
+test           s2           t              testuser2  SELECT
+
+statement ok
+GRANT ALL ON ALL TABLES IN SCHEMA s, s2 TO testuser, testuser2
+
+query TTTTT colnames
+SHOW GRANTS FOR testuser, testuser2
+----
+database_name  schema_name  relation_name  grantee    privilege_type
+test           s            t              testuser   ALL
+test           s            t              testuser2  ALL
+test           s2           t              testuser   ALL
+test           s2           t              testuser2  ALL
+
+statement ok
+REVOKE SELECT ON ALL TABLES IN SCHEMA s, s2 FROM testuser, testuser2
+
+query TTTTT colnames
+SHOW GRANTS FOR testuser, testuser2
+----
+database_name  schema_name  relation_name  grantee    privilege_type
+test           s            t              testuser   CREATE
+test           s            t              testuser   DELETE
+test           s            t              testuser   DROP
+test           s            t              testuser   GRANT
+test           s            t              testuser   INSERT
+test           s            t              testuser   UPDATE
+test           s            t              testuser   ZONECONFIG
+test           s            t              testuser2  CREATE
+test           s            t              testuser2  DELETE
+test           s            t              testuser2  DROP
+test           s            t              testuser2  GRANT
+test           s            t              testuser2  INSERT
+test           s            t              testuser2  UPDATE
+test           s            t              testuser2  ZONECONFIG
+test           s2           t              testuser   CREATE
+test           s2           t              testuser   DELETE
+test           s2           t              testuser   DROP
+test           s2           t              testuser   GRANT
+test           s2           t              testuser   INSERT
+test           s2           t              testuser   UPDATE
+test           s2           t              testuser   ZONECONFIG
+test           s2           t              testuser2  CREATE
+test           s2           t              testuser2  DELETE
+test           s2           t              testuser2  DROP
+test           s2           t              testuser2  GRANT
+test           s2           t              testuser2  INSERT
+test           s2           t              testuser2  UPDATE
+test           s2           t              testuser2  ZONECONFIG
+
+statement ok
+REVOKE ALL ON ALL TABLES IN SCHEMA s, s2 FROM testuser, testuser2
+
+query TTTTT colnames
+SHOW GRANTS FOR testuser, testuser2
+----
+database_name  schema_name  relation_name  grantee  privilege_type

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -4115,6 +4115,7 @@ deallocate_stmt:
 //   [TABLE] [<databasename> .] { <tablename> | * } [, ...]
 //   TYPE <typename> [, <typename>]...
 //   SCHEMA [<databasename> .]<schemaname> [, [<databasename> .]<schemaname>]...
+//   ALL TABLES IN SCHEMA schema_name [, ...]
 //
 // %SeeAlso: REVOKE, WEBDOCS/grant.html
 grant_stmt:
@@ -4148,6 +4149,17 @@ grant_stmt:
   {
     return unimplemented(sqllex, "grant privileges on schema with")
   }
+| GRANT privileges ON ALL TABLES IN SCHEMA schema_name_list TO name_list
+  {
+    $$.val = &tree.Grant{
+      Privileges: $2.privilegeList(),
+      Targets: tree.TargetList{
+        Schemas: $8.objectNamePrefixList(),
+        AllTablesInSchema: true,
+      },
+      Grantees: $10.nameList(),
+    }
+  }
 | GRANT privileges ON SEQUENCE error
   {
     return unimplemented(sqllex, "grant privileges on sequence")
@@ -4170,6 +4182,7 @@ grant_stmt:
 //   [TABLE] [<databasename> .] { <tablename> | * } [, ...]
 //   TYPE <typename> [, <typename>]...
 //   SCHEMA [<databasename> .]<schemaname> [, [<databasename> .]<schemaname]...
+//   ALL TABLES IN SCHEMA schema_name [, ...]
 //
 // %SeeAlso: GRANT, WEBDOCS/revoke.html
 revoke_stmt:
@@ -4197,6 +4210,17 @@ revoke_stmt:
         Schemas: $5.objectNamePrefixList(),
       },
       Grantees: $7.nameList(),
+    }
+  }
+| REVOKE privileges ON ALL TABLES IN SCHEMA schema_name_list FROM name_list
+  {
+    $$.val = &tree.Revoke{
+      Privileges: $2.privilegeList(),
+      Targets: tree.TargetList{
+        Schemas: $8.objectNamePrefixList(),
+        AllTablesInSchema: true,
+      },
+      Grantees: $10.nameList(),
     }
   }
 | REVOKE privileges ON SEQUENCE error

--- a/pkg/sql/parser/testdata/grant_revoke
+++ b/pkg/sql/parser/testdata/grant_revoke
@@ -224,6 +224,38 @@ GRANT ALL ON SCHEMA a.b, c.d TO root -- fully parenthesized
 GRANT ALL ON SCHEMA a.b, c.d TO root -- literals removed
 GRANT ALL ON SCHEMA _._, _._ TO _ -- identifiers removed
 
+parse
+GRANT ALL ON ALL TABLES IN SCHEMA s1 TO root
+----
+GRANT ALL ON ALL TABLES IN SCHEMA s1 TO root
+GRANT ALL ON ALL TABLES IN SCHEMA s1 TO root -- fully parenthesized
+GRANT ALL ON ALL TABLES IN SCHEMA s1 TO root -- literals removed
+GRANT ALL ON ALL TABLES IN SCHEMA _ TO _ -- identifiers removed
+
+parse
+GRANT ALL ON ALL TABLES IN SCHEMA s1, s2 TO root
+----
+GRANT ALL ON ALL TABLES IN SCHEMA s1, s2 TO root
+GRANT ALL ON ALL TABLES IN SCHEMA s1, s2 TO root -- fully parenthesized
+GRANT ALL ON ALL TABLES IN SCHEMA s1, s2 TO root -- literals removed
+GRANT ALL ON ALL TABLES IN SCHEMA _, _ TO _ -- identifiers removed
+
+parse
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA s1, s2 TO root
+----
+GRANT ALL ON ALL TABLES IN SCHEMA s1, s2 TO root -- normalized!
+GRANT ALL ON ALL TABLES IN SCHEMA s1, s2 TO root -- fully parenthesized
+GRANT ALL ON ALL TABLES IN SCHEMA s1, s2 TO root -- literals removed
+GRANT ALL ON ALL TABLES IN SCHEMA _, _ TO _ -- identifiers removed
+
+parse
+GRANT SELECT, UPDATE ON ALL TABLES IN SCHEMA s1, s2 TO root, bar
+----
+GRANT SELECT, UPDATE ON ALL TABLES IN SCHEMA s1, s2 TO root, bar
+GRANT SELECT, UPDATE ON ALL TABLES IN SCHEMA s1, s2 TO root, bar -- fully parenthesized
+GRANT SELECT, UPDATE ON ALL TABLES IN SCHEMA s1, s2 TO root, bar -- literals removed
+GRANT SELECT, UPDATE ON ALL TABLES IN SCHEMA _, _ TO _, _ -- identifiers removed
+
 ## Tables are the default, but can also be specified with
 ## REVOKE x ON TABLE y. However, the stringer does not output TABLE.
 
@@ -416,6 +448,38 @@ REVOKE ALL ON SCHEMA a.b, c.d FROM root -- normalized!
 REVOKE ALL ON SCHEMA a.b, c.d FROM root -- fully parenthesized
 REVOKE ALL ON SCHEMA a.b, c.d FROM root -- literals removed
 REVOKE ALL ON SCHEMA _._, _._ FROM _ -- identifiers removed
+
+parse
+REVOKE ALL ON ALL TABLES IN SCHEMA s1 FROM root
+----
+REVOKE ALL ON ALL TABLES IN SCHEMA s1 FROM root
+REVOKE ALL ON ALL TABLES IN SCHEMA s1 FROM root -- fully parenthesized
+REVOKE ALL ON ALL TABLES IN SCHEMA s1 FROM root -- literals removed
+REVOKE ALL ON ALL TABLES IN SCHEMA _ FROM _ -- identifiers removed
+
+parse
+REVOKE ALL ON ALL TABLES IN SCHEMA s1, s2 FROM root
+----
+REVOKE ALL ON ALL TABLES IN SCHEMA s1, s2 FROM root
+REVOKE ALL ON ALL TABLES IN SCHEMA s1, s2 FROM root -- fully parenthesized
+REVOKE ALL ON ALL TABLES IN SCHEMA s1, s2 FROM root -- literals removed
+REVOKE ALL ON ALL TABLES IN SCHEMA _, _ FROM _ -- identifiers removed
+
+parse
+REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA s1, s2 FROM root
+----
+REVOKE ALL ON ALL TABLES IN SCHEMA s1, s2 FROM root -- normalized!
+REVOKE ALL ON ALL TABLES IN SCHEMA s1, s2 FROM root -- fully parenthesized
+REVOKE ALL ON ALL TABLES IN SCHEMA s1, s2 FROM root -- literals removed
+REVOKE ALL ON ALL TABLES IN SCHEMA _, _ FROM _ -- identifiers removed
+
+parse
+REVOKE SELECT, UPDATE ON ALL TABLES IN SCHEMA s1, s2 FROM root, bar
+----
+REVOKE SELECT, UPDATE ON ALL TABLES IN SCHEMA s1, s2 FROM root, bar
+REVOKE SELECT, UPDATE ON ALL TABLES IN SCHEMA s1, s2 FROM root, bar -- fully parenthesized
+REVOKE SELECT, UPDATE ON ALL TABLES IN SCHEMA s1, s2 FROM root, bar -- literals removed
+REVOKE SELECT, UPDATE ON ALL TABLES IN SCHEMA _, _ FROM _, _ -- identifiers removed
 
 # Ensure that the support for ON ROLE <namelist> doesn't leak
 # where it should not be recognized.

--- a/pkg/sql/sem/tree/grant.go
+++ b/pkg/sql/sem/tree/grant.go
@@ -41,6 +41,8 @@ type TargetList struct {
 	Tables    TablePatterns
 	Tenant    roachpb.TenantID
 	Types     []*UnresolvedObjectName
+	// If the target is for all tables in a set of schemas.
+	AllTablesInSchema bool
 
 	// ForRoles and Roles are used internally in the parser and not used
 	// in the AST. Therefore they do not participate in pretty-printing,
@@ -54,6 +56,9 @@ func (tl *TargetList) Format(ctx *FmtCtx) {
 	if tl.Databases != nil {
 		ctx.WriteString("DATABASE ")
 		ctx.FormatNode(&tl.Databases)
+	} else if tl.AllTablesInSchema {
+		ctx.WriteString("ALL TABLES IN SCHEMA ")
+		ctx.FormatNode(&tl.Schemas)
 	} else if tl.Schemas != nil {
 		ctx.WriteString("SCHEMA ")
 		ctx.FormatNode(&tl.Schemas)

--- a/pkg/sql/sqltelemetry/iam.go
+++ b/pkg/sql/sqltelemetry/iam.go
@@ -34,6 +34,9 @@ const (
 	OnTable = "on_table"
 	// OnType is used when a GRANT/REVOKE is happening on a type.
 	OnType = "on_type"
+	// OnAllTablesInSchema is used when a GRANT/REVOKE is happening on
+	// all tables in a set of schemas.
+	OnAllTablesInSchema = "on_all_tables_in_schemas"
 
 	iamRoles = "iam.roles"
 )


### PR DESCRIPTION
Release note (sql change): Support syntax for granting and revoking
privileges for all the tables in the specified schemas.

New supported syntax:
GRANT {privileges...} ON ALL TABLES IN SCHEMA {schema_names...} TO {roles...}
REVOKE {privileges...} ON ALL TABLES IN SCHEMA {schema_names...} TO {roles...}

This command is added for Postgres compatibility.

Fixes #67440