### PR TITLE
sql,kv: permit txn rollbacks across LockNotAvailable errors

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -3324,6 +3324,7 @@ func TestMultipleErrorsMerged(t *testing.T) {
 	retryErr := roachpb.NewTransactionRetryError(roachpb.RETRY_SERIALIZABLE, "test err")
 	abortErr := roachpb.NewTransactionAbortedError(roachpb.ABORT_REASON_ABORTED_RECORD_FOUND)
 	conditionFailedErr := &roachpb.ConditionFailedError{}
+	writeIntentErr := &roachpb.WriteIntentError{}
 	sendErr := sendError{}
 	ambiguousErr := &roachpb.AmbiguousResultError{}
 	randomErr := &roachpb.IntegerOverflowError{}
@@ -3391,6 +3392,22 @@ func TestMultipleErrorsMerged(t *testing.T) {
 		},
 		{
 			err1:   conditionFailedErr,
+			err2:   randomErr,
+			expErr: "results in overflow",
+		},
+		// WriteIntentError also has a low score since it's "not ambiguous".
+		{
+			err1:   writeIntentErr,
+			err2:   ambiguousErr,
+			expErr: "result is ambiguous",
+		},
+		{
+			err1:   writeIntentErr,
+			err2:   sendErr,
+			expErr: "failed to send RPC",
+		},
+		{
+			err1:   writeIntentErr,
 			err2:   randomErr,
 			expErr: "results in overflow",
 		},

--- a/pkg/kv/kvclient/kvcoord/testdata/savepoints
+++ b/pkg/kv/kvclient/kvcoord/testdata/savepoints
@@ -368,6 +368,47 @@ subtest end
 
 
 
+subtest rollback_after_write_intent_error
+# Write intent errors are white-listed to allow a rollback to savepoint afterwards.
+# They make their way back up to the kv client when requests are run with an Error
+# wait policy.
+
+# NB: we're going to leak this txn, so write to an otherwise unused key.
+begin
+----
+0 <noignore>
+
+put conflict-key a
+----
+
+begin
+----
+0 <noignore>
+
+savepoint x
+----
+0 <noignore>
+
+get conflict-key locking nowait
+----
+(*roachpb.WriteIntentError) conflicting intents on "conflict-key"
+
+rollback x
+----
+0 <noignore>
+
+put conflict-key b nowait
+----
+(*roachpb.WriteIntentError) conflicting intents on "conflict-key"
+
+rollback x
+----
+1 [1-1]
+
+subtest end
+
+
+
 subtest rollback_after_random_err
 # Only CPut errors allow rollbacks after them. Any other error results in the rollback failing.
 

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_savepoints.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_savepoints.go
@@ -105,13 +105,13 @@ func (tc *TxnCoordSender) RollbackToSavepoint(ctx context.Context, s kv.Savepoin
 	}
 
 	// We don't allow rollback to savepoint after errors (except after
-	// ConditionFailedError which is special-cased elsewhere and doesn't move the
-	// txn to the txnError state). In particular, we cannot allow rollbacks to
-	// savepoint after ambiguous errors where it's possible for a
-	// previously-successfully written intent to have been pushed at a timestamp
-	// higher than the coordinator's WriteTimestamp. Doing so runs the risk that
-	// we'll commit at the lower timestamp, at which point the respective intent
-	// will be discarded. See
+	// ConditionFailedError and WriteIntentError, which are special-cased
+	// elsewhere and don't move the txn to the txnError state). In particular, we
+	// cannot allow rollbacks to savepoint after ambiguous errors where it's
+	// possible for a previously-successfully written intent to have been pushed
+	// at a timestamp higher than the coordinator's WriteTimestamp. Doing so runs
+	// the risk that we'll commit at the lower timestamp, at which point the
+	// respective intent will be discarded. See
 	// https://github.com/cockroachdb/cockroach/issues/47587.
 	//
 	// TODO(andrei): White-list more errors.

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_savepoints_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_savepoints_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils/kvclientutils"
@@ -122,9 +123,12 @@ func TestSavepoints(t *testing.T) {
 				fmt.Fprintf(&buf, "txn id %s\n", changed)
 
 			case "put":
-				if err := txn.Put(ctx,
-					roachpb.Key(td.CmdArgs[0].Key),
-					[]byte(td.CmdArgs[1].Key)); err != nil {
+				b := txn.NewBatch()
+				b.Put(td.CmdArgs[0].Key, td.CmdArgs[1].Key)
+				if td.HasArg("nowait") {
+					b.Header.WaitPolicy = lock.WaitPolicy_Error
+				}
+				if err := txn.Run(ctx, b); err != nil {
 					fmt.Fprintf(&buf, "(%T) %v\n", err, err)
 				}
 
@@ -150,12 +154,22 @@ func TestSavepoints(t *testing.T) {
 				}
 
 			case "get":
-				v, err := txn.Get(ctx, td.CmdArgs[0].Key)
-				if err != nil {
+				b := txn.NewBatch()
+				if td.HasArg("locking") {
+					b.GetForUpdate(td.CmdArgs[0].Key)
+				} else {
+					b.Get(td.CmdArgs[0].Key)
+				}
+				if td.HasArg("nowait") {
+					b.Header.WaitPolicy = lock.WaitPolicy_Error
+				}
+				if err := txn.Run(ctx, b); err != nil {
 					fmt.Fprintf(&buf, "(%T) %v\n", err, err)
 				} else {
-					ba, _ := v.Value.GetBytes()
-					fmt.Fprintf(&buf, "%v -> %v\n", v.Key, string(ba))
+					kv := b.Results[0].Rows[0]
+					ba, err := kv.Value.GetBytes()
+					require.NoError(t, err)
+					fmt.Fprintf(&buf, "%v -> %v\n", kv.Key, string(ba))
 				}
 
 			case "savepoint":

--- a/pkg/kv/kvnemesis/doc.go
+++ b/pkg/kv/kvnemesis/doc.go
@@ -34,4 +34,8 @@
 // - Root and leaf transactions
 // - GCRequest
 // - Protected timestamps
+// - Transactions being abandoned by their coordinator
+// - Continuing txns after CPut and WriteIntent errors (generally continuing
+//   after errors is not allowed, but it is allowed after ConditionFailedError and
+//   WriteIntentError as a special case)
 package kvnemesis

--- a/pkg/kv/kvnemesis/kvnemesis.go
+++ b/pkg/kv/kvnemesis/kvnemesis.go
@@ -25,12 +25,6 @@ import (
 
 // RunNemesis generates and applies a series of Operations to exercise the KV
 // api. It returns a slice of the logical failures encountered.
-//
-// Ideas for conditions to be added to KV nemesis:
-// - Transactions being abandoned by their coordinator.
-// - CPuts, and continuing after CPut errors (generally continuing after errors
-// is not allowed, but it is allowed after ConditionFailedError as a special
-// case).
 func RunNemesis(
 	ctx context.Context,
 	rng *rand.Rand,

--- a/pkg/roachpb/errors.proto
+++ b/pkg/roachpb/errors.proto
@@ -262,11 +262,39 @@ message TransactionStatusError {
   optional Reason reason = 2 [(gogoproto.nullable) = false];
 }
 
-// A WriteIntentError indicates that one or more write intent
-// belonging to another transaction were encountered leading to a
-// read/write or write/write conflict. The keys at which the intent
-// was encountered are set, as are the txn records for the intents'
-// transactions.
+// A WriteIntentError indicates that one or more write intents belonging
+// to another transaction were encountered, leading to a read/write or
+// write/write conflict. The keys at which the intents were encountered
+// are set, as are the txn metas for the intents' transactions.
+//
+// WriteIntentErrors are used at two different levels of the system. In
+// both cases, they have the same meaning — that an intent or lock (an
+// intent is a form of replicated lock) is preventing an operation from
+// completing.
+//
+// First, they are returned from MVCC during request evaluation when a
+// request finds a conflicting intent. A WriteIntentError is propagated
+// up through the Replica to the corresponding lock table and passed to
+// its AddDiscoveredLock method. This informs the lock table about the
+// intent(s) and allows the request to handle the conflicts through a
+// combination of waiting and pushing in the concurrency manager. See
+// concurrency_control.go for an explanation and diagram of the flow.
+//
+// Second, WriteIntentErrors are returned from the concurrency manager
+// for intents/locks that conflict with a request and are not handled.
+// This is typically because the request was configured with an Error
+// wait policy instead of a Block wait policy, so it is opting to fail
+// fast on conflicting locks instead of waiting for a lock to be
+// released. These errors make their way back up from KV to SQL, where
+// they are converted to a LockNotAvailable error.
+//
+// Note that the KV client is free to send more requests after a
+// WriteIntentError. This is not generally allowed after other errors
+// because of fears over the ambiguity of the side-effects of failed
+// requests (in particular, the timestamps at which intents might have
+// been written). WriteIntentError is a special case as we ensure
+// there's no ambiguity; the error carries a WriteTimestamp that's the
+// upper bound of the timestamps intents were written at.
 message WriteIntentError {
   repeated roachpb.Intent intents = 1 [(gogoproto.nullable) = false];
   reserved 2;

--- a/pkg/sql/testdata/savepoints
+++ b/pkg/sql/testdata/savepoints
@@ -189,6 +189,62 @@ DROP TABLE t
 
 subtest end
 
+subtest rollback_after_lock_not_avail_error
+
+sql
+CREATE TABLE t(x INT PRIMARY KEY)
+----
+1: CREATE TABLE t(x INT PRIMARY KEY) -- 0 rows
+-- NoTxn       -> NoTxn       #  (none)
+
+sql conn=conflict
+BEGIN
+INSERT INTO t VALUES (1)
+----
+1: BEGIN -- 0 rows
+-- NoTxn       -> Open        #.  (none)
+2: INSERT INTO t VALUES (1) -- 1 row
+-- Open        -> Open        ##  (none)
+
+sql
+BEGIN
+SAVEPOINT foo
+SELECT * FROM t WHERE x = 1 FOR UPDATE NOWAIT
+ROLLBACK TO SAVEPOINT foo
+SELECT * FROM t WHERE x = 2 FOR UPDATE NOWAIT
+COMMIT
+----
+1: BEGIN -- 0 rows
+-- NoTxn       -> Open        #.....  (none)
+2: SAVEPOINT foo -- 0 rows
+-- Open        -> Open        ##....  foo
+3: SELECT * FROM t WHERE x = 1 FOR UPDATE NOWAIT -- pq: could not obtain lock on row (x)=(1) in t@primary
+-- Open        -> Aborted     XXXXXX  foo
+4: ROLLBACK TO SAVEPOINT foo -- 0 rows
+-- Aborted     -> Open        ##....  foo
+5: SELECT * FROM t WHERE x = 2 FOR UPDATE NOWAIT -- 0 rows
+-- Open        -> Open        ##..#.  foo
+6: COMMIT -- 0 rows
+-- Open        -> NoTxn       ##..##  (none)
+
+# NB: the txn on the "conflict" connection is aborted by the test harness even
+# before the ROLLBACK is issued, so the ROLLBACK isn't technically necessary,
+# but we do need to run something on this connection to trigger test harness to
+# roll back the txn.
+sql conn=conflict
+ROLLBACK
+----
+1: ROLLBACK -- pq: there is no transaction in progress
+-- NoTxn       -> NoTxn       #  (none)
+
+sql
+DROP TABLE t
+----
+1: DROP TABLE t -- 0 rows
+-- NoTxn       -> NoTxn       #  (none)
+
+subtest end
+
 subtest rollback_after_ddl
 
 subtest rollback_after_ddl/release_normal_savepoint


### PR DESCRIPTION
This commit adds support for rolling a transaction back across a `LockNotAvailable` (pgcode 55P03) error. `LockNotAvailable` errors are returned in two cases:
1. when a locking SELECT is run with a NOWAIT wait policy and conflicts with an active lock
2. when a statement is run with a `lock_timeout` and this timeout is exceeded (unsupported, see #67513)

The following test case from `pkg/sql/testdata/savepoints` demonstrates this new capability:

```
# txn1
BEGIN
INSERT INTO t VALUES (1)
----
1: BEGIN -- 0 rows
-- NoTxn       -> Open        #.  (none)
2: INSERT INTO t VALUES (1) -- 1 row
-- Open        -> Open        ##  (none)

# txn2
BEGIN
SAVEPOINT foo
SELECT * FROM t WHERE x = 1 FOR UPDATE NOWAIT
ROLLBACK TO SAVEPOINT foo
SELECT * FROM t WHERE x = 2 FOR UPDATE NOWAIT
COMMIT
----
1: BEGIN -- 0 rows
-- NoTxn       -> Open        #.....  (none)
2: SAVEPOINT foo -- 0 rows
-- Open        -> Open        ##....  foo
3: SELECT * FROM t WHERE x = 1 FOR UPDATE NOWAIT -- pq: could not obtain lock on row (x)=(1) in t@primary
-- Open        -> Aborted     XXXXXX  foo
4: ROLLBACK TO SAVEPOINT foo -- 0 rows
-- Aborted     -> Open        ##....  foo
5: SELECT * FROM t WHERE x = 2 FOR UPDATE NOWAIT -- 0 rows
-- Open        -> Open        ##..#.  foo
6: COMMIT -- 0 rows
-- Open        -> NoTxn       ##..##  (none)
```

This becomes the second error type that supports rollbacks, with the first being duplicate key errors, which was added in 65e8045.

The primary motivation for this PR was to be able to give `WriteIntentErrors` an `ErrorPriority` of `ErrorScoreUnambiguousError` for #66146. However, the added functionality fell out of making that change.

Release note (sql change): ROLLBACK TO SAVEPOINT can now be used to recover from LockNotAvailable errors (pgcode 55P03), which are returned when performing a FOR UPDATE SELECT with a NOWAIT wait policy.