### PR TITLE
limit,storage: add more trace spans to backup path

### DIFF
--- a/pkg/ccl/storageccl/export.go
+++ b/pkg/ccl/storageccl/export.go
@@ -168,7 +168,7 @@ func evalExport(
 	var curSizeOfExportedSSTs int64
 	for start := args.Key; start != nil; {
 		destFile := &storage.MemFile{}
-		summary, resume, err := reader.ExportMVCCToSst(start, args.EndKey, args.StartTime,
+		summary, resume, err := reader.ExportMVCCToSst(ctx, start, args.EndKey, args.StartTime,
 			h.Timestamp, exportAllRevisions, targetSize, maxSize, useTBI, destFile)
 		if err != nil {
 			return result.Result{}, err

--- a/pkg/ccl/storageccl/export_test.go
+++ b/pkg/ccl/storageccl/export_test.go
@@ -569,7 +569,7 @@ func assertEqualKVs(
 			maxSize := uint64(0)
 			prevStart := start
 			sstFile := &storage.MemFile{}
-			summary, start, err = e.ExportMVCCToSst(start, endKey, startTime, endTime,
+			summary, start, err = e.ExportMVCCToSst(ctx, start, endKey, startTime, endTime,
 				exportAllRevisions, targetSize, maxSize, enableTimeBoundIteratorOptimization, sstFile)
 			require.NoError(t, err)
 			sst = sstFile.Data()
@@ -609,7 +609,7 @@ func assertEqualKVs(
 				if dataSizeWhenExceeded == maxSize {
 					maxSize--
 				}
-				_, _, err = e.ExportMVCCToSst(prevStart, endKey, startTime, endTime,
+				_, _, err = e.ExportMVCCToSst(ctx, prevStart, endKey, startTime, endTime,
 					exportAllRevisions, targetSize, maxSize, enableTimeBoundIteratorOptimization, &storage.MemFile{})
 				require.Regexp(t, fmt.Sprintf("export size \\(%d bytes\\) exceeds max size \\(%d bytes\\)",
 					dataSizeWhenExceeded, maxSize), err)

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -399,6 +399,7 @@ func (s spanSetReader) Closed() bool {
 
 // ExportMVCCToSst is part of the storage.Reader interface.
 func (s spanSetReader) ExportMVCCToSst(
+	ctx context.Context,
 	startKey, endKey roachpb.Key,
 	startTS, endTS hlc.Timestamp,
 	exportAllRevisions bool,
@@ -406,7 +407,7 @@ func (s spanSetReader) ExportMVCCToSst(
 	useTBI bool,
 	dest io.Writer,
 ) (roachpb.BulkOpSummary, roachpb.Key, error) {
-	return s.r.ExportMVCCToSst(startKey, endKey, startTS, endTS, exportAllRevisions, targetSize,
+	return s.r.ExportMVCCToSst(ctx, startKey, endKey, startTS, endTS, exportAllRevisions, targetSize,
 		maxSize, useTBI, dest)
 }
 

--- a/pkg/storage/BUILD.bazel
+++ b/pkg/storage/BUILD.bazel
@@ -95,6 +95,7 @@ go_library(
         "//pkg/util/stop",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
+        "//pkg/util/tracing",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//oserror",

--- a/pkg/storage/bench_test.go
+++ b/pkg/storage/bench_test.go
@@ -1434,7 +1434,7 @@ func runExportToSst(
 	for i := 0; i < b.N; i++ {
 		startTS := hlc.Timestamp{WallTime: int64(numRevisions / 2)}
 		endTS := hlc.Timestamp{WallTime: int64(numRevisions + 2)}
-		_, _, err := engine.ExportMVCCToSst(keys.LocalMax, roachpb.KeyMax, startTS, endTS,
+		_, _, err := engine.ExportMVCCToSst(context.Background(), keys.LocalMax, roachpb.KeyMax, startTS, endTS,
 			exportAllRevisions, 0 /* targetSize */, 0 /* maxSize */, useTBI, noopWriter{})
 		if err != nil {
 			b.Fatal(err)

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -409,7 +409,7 @@ type Reader interface {
 	// This function looks at MVCC versions and intents, and returns an error if an
 	// intent is found.
 	ExportMVCCToSst(
-		startKey, endKey roachpb.Key, startTS, endTS hlc.Timestamp,
+		ctx context.Context, startKey, endKey roachpb.Key, startTS, endTS hlc.Timestamp,
 		exportAllRevisions bool, targetSize uint64, maxSize uint64, useTBI bool,
 		dest io.Writer,
 	) (_ roachpb.BulkOpSummary, resumeKey roachpb.Key, _ error)

--- a/pkg/storage/mvcc_incremental_iterator_test.go
+++ b/pkg/storage/mvcc_incremental_iterator_test.go
@@ -152,8 +152,8 @@ func assertExportedErrs(
 ) {
 	const big = 1 << 30
 	sstFile := &MemFile{}
-	_, _, err := e.ExportMVCCToSst(startKey, endKey, startTime, endTime, revisions, big, big,
-		useTBI, sstFile)
+	_, _, err := e.ExportMVCCToSst(context.Background(), startKey, endKey, startTime, endTime,
+		revisions, big, big, useTBI, sstFile)
 	require.Error(t, err)
 
 	if intentErr := (*roachpb.WriteIntentError)(nil); errors.As(err, &intentErr) {
@@ -181,8 +181,8 @@ func assertExportedKVs(
 ) {
 	const big = 1 << 30
 	sstFile := &MemFile{}
-	_, _, err := e.ExportMVCCToSst(startKey, endKey, startTime, endTime, revisions, big, big,
-		useTBI, sstFile)
+	_, _, err := e.ExportMVCCToSst(context.Background(), startKey, endKey, startTime, endTime,
+		revisions, big, big, useTBI, sstFile)
 	require.NoError(t, err)
 	data := sstFile.Data()
 	if data == nil {

--- a/pkg/storage/pebble_batch.go
+++ b/pkg/storage/pebble_batch.go
@@ -130,6 +130,7 @@ func (p *pebbleBatch) Closed() bool {
 
 // ExportMVCCToSst is part of the engine.Reader interface.
 func (p *pebbleBatch) ExportMVCCToSst(
+	ctx context.Context,
 	startKey, endKey roachpb.Key,
 	startTS, endTS hlc.Timestamp,
 	exportAllRevisions bool,

--- a/pkg/storage/pebble_test.go
+++ b/pkg/storage/pebble_test.go
@@ -634,7 +634,7 @@ func TestSstExportFailureIntentBatching(t *testing.T) {
 			require.NoError(t, fillInData(ctx, engine, data))
 
 			destination := &MemFile{}
-			_, _, err := engine.ExportMVCCToSst(key(10), key(20000), ts(999), ts(2000),
+			_, _, err := engine.ExportMVCCToSst(ctx, key(10), key(20000), ts(999), ts(2000),
 				true, 0, 0, true, destination)
 			if len(expectedIntentIndices) == 0 {
 				require.NoError(t, err)

--- a/pkg/util/limit/BUILD.bazel
+++ b/pkg/util/limit/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//pkg/util/quotapool",
         "//pkg/util/tracing",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_gogo_protobuf//types",
     ],
 )
 

--- a/pkg/util/limit/limiter.go
+++ b/pkg/util/limit/limiter.go
@@ -12,10 +12,12 @@ package limit
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
+	"github.com/gogo/protobuf/types"
 )
 
 // ConcurrentRequestLimiter wraps a simple semaphore, adding a tracing span when
@@ -52,6 +54,7 @@ func (l *ConcurrentRequestLimiter) Begin(ctx context.Context) (Reservation, erro
 		var span *tracing.Span
 		ctx, span = tracing.ChildSpan(ctx, l.spanName)
 		defer span.Finish()
+		span.RecordStructured(&types.StringValue{Value: fmt.Sprintf("%d requests are waiting", l.sem.Len())})
 		res, err = l.sem.Acquire(ctx, 1)
 	}
 	return res, err


### PR DESCRIPTION
This change adds a trace recording to track how
many requests are waiting in the the concurrent limiter
queue.

The change also adds a child span to ExportMVCCToSst
to track how long the scan+SST creation is taking per
ExportRequest during backup.

Release note: None