### PR TITLE
roachtest: make timeout obvious in posted issues

### DIFF
--- a/pkg/cmd/roachtest/test_impl.go
+++ b/pkg/cmd/roachtest/test_impl.go
@@ -69,8 +69,9 @@ type testImpl struct {
 
 	mu struct {
 		syncutil.RWMutex
-		done   bool
-		failed bool
+		done    bool
+		failed  bool
+		timeout bool // if failed == true, this indicates whether the test timed out
 		// cancel, if set, is called from the t.Fatal() family of functions when the
 		// test is being marked as failed (i.e. when the failed field above is also
 		// set). This is used to cancel the context passed to t.spec.Run(), so async
@@ -94,6 +95,18 @@ type testImpl struct {
 	//
 	// Version strings look like "20.1.4".
 	versionsBinaryOverride map[string]string
+}
+
+func (t *testImpl) timedOut() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.mu.timeout
+}
+
+func (t *testImpl) setTimedOut() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.mu.timeout = true
 }
 
 // BuildVersion exposes the build version of the cluster


### PR DESCRIPTION
When a test times out, roachtest will rip the cluster out from under it
to try to force it to terminate. This is essentially guaranteed to
produce a posted issue that sweeps the original reason of the failure
(the timeout) under the rug. Instead, such issues now plainly state
that there was a timeout and refer the readers to the artifacts.

See here for an example issue without this fix: https://github.com/cockroachdb/cockroach/issues/67464

cc @dt, who pointed this out [internally]

[internally]: https://cockroachlabs.slack.com/archives/C023S0V4YEB/p1626098863019500

Release note: None
