### PR TITLE
dev: infer and pass in an appropriate `dev` config to bazel invocations

### DIFF
--- a/pkg/cmd/dev/build.go
+++ b/pkg/cmd/dev/build.go
@@ -71,6 +71,7 @@ func (d *dev) build(cmd *cobra.Command, targets []string) (err error) {
 	// Don't let bazel generate any convenience symlinks, we'll create them
 	// ourself.
 	args = append(args, "--experimental_convenience_symlinks=ignore")
+	args = append(args, getConfigFlags()...)
 	args = append(args, mustGetRemoteCacheArgs(remoteCacheAddr)...)
 	if numCPUs != 0 {
 		args = append(args, fmt.Sprintf("--local_cpu_resources=%d", numCPUs))
@@ -131,7 +132,9 @@ func (d *dev) symlinkBinaries(ctx context.Context, targets []string) error {
 }
 
 func (d *dev) getPathToBin(ctx context.Context, target string) (string, error) {
-	out, err := d.exec.CommandContextSilent(ctx, "bazel", "info", "bazel-bin", "--color=no")
+	args := []string{"info", "bazel-bin", "--color=no"}
+	args = append(args, getConfigFlags()...)
+	out, err := d.exec.CommandContextSilent(ctx, "bazel", args...)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/cmd/dev/datadriven_test.go
+++ b/pkg/cmd/dev/datadriven_test.go
@@ -43,6 +43,10 @@ var (
 	)
 )
 
+func init() {
+	predictableDevProfile = true
+}
+
 // TestDatadriven makes use of datadriven and recorder to capture all operations
 // executed by individual `dev` invocations. The testcases are defined under
 // testdata/*, where each test files corresponds to a recording capture found in

--- a/pkg/cmd/dev/dev.go
+++ b/pkg/cmd/dev/dev.go
@@ -31,6 +31,7 @@ var (
 	// Shared flags.
 	remoteCacheAddr string
 	numCPUs         int
+	skipDevConfig   bool
 )
 
 func makeDevCmd() *dev {
@@ -76,7 +77,6 @@ lets engineers do a few things:
 		makeLintCmd(ret.lint),
 		makeTestCmd(ret.test),
 	)
-
 	// Add all the shared flags.
 	var debugVar bool
 	for _, subCmd := range ret.cli.Commands() {
@@ -88,6 +88,7 @@ lets engineers do a few things:
 		// support for the  Remote Asset API, which helps speed things up when
 		// the cache sits across the network boundary.
 		subCmd.Flags().StringVar(&remoteCacheAddr, "remote-cache", "", "remote caching grpc endpoint to use")
+		subCmd.Flags().BoolVar(&skipDevConfig, "skip-dev-config", false, "Don't infer an appropriate dev config to build with")
 	}
 	for _, subCmd := range ret.cli.Commands() {
 		subCmd.PreRun = func(cmd *cobra.Command, args []string) {

--- a/pkg/cmd/dev/test.go
+++ b/pkg/cmd/dev/test.go
@@ -109,7 +109,8 @@ func (d *dev) runUnitTest(cmd *cobra.Command, pkgs []string) error {
 	var args []string
 	args = append(args, "test")
 	args = append(args, "--color=yes")
-	args = append(args, "--experimental_convenience_symlinks=ignore") // don't generate any convenience symlinks
+	args = append(args, "--experimental_convenience_symlinks=ignore")
+	args = append(args, getConfigFlags()...)
 	args = append(args, mustGetRemoteCacheArgs(remoteCacheAddr)...)
 	if numCPUs != 0 {
 		args = append(args, fmt.Sprintf("--local_cpu_resources=%d", numCPUs))

--- a/pkg/cmd/dev/testdata/build.txt
+++ b/pkg/cmd/dev/testdata/build.txt
@@ -1,33 +1,42 @@
 dev build cockroach-short
 ----
-bazel build --color=yes --experimental_convenience_symlinks=ignore //pkg/cmd/cockroach-short
-bazel info workspace --color=no
+bazel build --color=yes --experimental_convenience_symlinks=ignore --config=dev //pkg/cmd/cockroach-short
+bazel info workspace --color=no --config=dev
 mkdir go/src/github.com/cockroachdb/cockroach/bin
-bazel info bazel-bin --color=no
+bazel info bazel-bin --color=no --config=dev
 rm go/src/github.com/cockroachdb/cockroach/cockroach-short
 ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short go/src/github.com/cockroachdb/cockroach/cockroach-short
 
 dev build cockroach-short --cpus=12
 ----
-bazel build --color=yes --experimental_convenience_symlinks=ignore --local_cpu_resources=12 //pkg/cmd/cockroach-short
-bazel info workspace --color=no
+bazel build --color=yes --experimental_convenience_symlinks=ignore --config=dev --local_cpu_resources=12 //pkg/cmd/cockroach-short
+bazel info workspace --color=no --config=dev
 mkdir go/src/github.com/cockroachdb/cockroach/bin
-bazel info bazel-bin --color=no
+bazel info bazel-bin --color=no --config=dev
 rm go/src/github.com/cockroachdb/cockroach/cockroach-short
 ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short go/src/github.com/cockroachdb/cockroach/cockroach-short
 
 dev build --debug cockroach-short
 ----
-bazel build --color=yes --experimental_convenience_symlinks=ignore //pkg/cmd/cockroach-short
-bazel info workspace --color=no
+bazel build --color=yes --experimental_convenience_symlinks=ignore --config=dev //pkg/cmd/cockroach-short
+bazel info workspace --color=no --config=dev
 mkdir go/src/github.com/cockroachdb/cockroach/bin
-bazel info bazel-bin --color=no
+bazel info bazel-bin --color=no --config=dev
 rm go/src/github.com/cockroachdb/cockroach/cockroach-short
 ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short go/src/github.com/cockroachdb/cockroach/cockroach-short
 
 dev build cockroach-short --remote-cache 127.0.0.1:9090
 ----
-bazel build --color=yes --experimental_convenience_symlinks=ignore --remote_local_fallback --remote_cache=grpc://127.0.0.1:9090 --experimental_remote_downloader=grpc://127.0.0.1:9090 //pkg/cmd/cockroach-short
+bazel build --color=yes --experimental_convenience_symlinks=ignore --config=dev --remote_local_fallback --remote_cache=grpc://127.0.0.1:9090 --experimental_remote_downloader=grpc://127.0.0.1:9090 //pkg/cmd/cockroach-short
+bazel info workspace --color=no --config=dev
+mkdir go/src/github.com/cockroachdb/cockroach/bin
+bazel info bazel-bin --color=no --config=dev
+rm go/src/github.com/cockroachdb/cockroach/cockroach-short
+ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short go/src/github.com/cockroachdb/cockroach/cockroach-short
+
+dev build --skip-dev-config cockroach-short
+----
+bazel build --color=yes --experimental_convenience_symlinks=ignore //pkg/cmd/cockroach-short
 bazel info workspace --color=no
 mkdir go/src/github.com/cockroachdb/cockroach/bin
 bazel info bazel-bin --color=no

--- a/pkg/cmd/dev/testdata/generate.txt
+++ b/pkg/cmd/dev/testdata/generate.txt
@@ -1,4 +1,4 @@
 dev gen bazel
 ----
-bazel info workspace --color=no
+bazel info workspace --color=no --config=dev
 go/src/github.com/cockroachdb/cockroach/build/bazelutil/bazel-generate.sh

--- a/pkg/cmd/dev/testdata/recording/build.txt
+++ b/pkg/cmd/dev/testdata/recording/build.txt
@@ -1,3 +1,83 @@
+bazel build --color=yes --experimental_convenience_symlinks=ignore --config=dev //pkg/cmd/cockroach-short
+----
+
+bazel info workspace --color=no --config=dev
+----
+go/src/github.com/cockroachdb/cockroach
+
+mkdir go/src/github.com/cockroachdb/cockroach/bin
+----
+
+bazel info bazel-bin --color=no --config=dev
+----
+/private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin
+
+rm go/src/github.com/cockroachdb/cockroach/cockroach-short
+----
+
+ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short go/src/github.com/cockroachdb/cockroach/cockroach-short
+----
+
+bazel build --color=yes --experimental_convenience_symlinks=ignore --config=dev --local_cpu_resources=12 //pkg/cmd/cockroach-short
+----
+
+bazel info workspace --color=no --config=dev
+----
+go/src/github.com/cockroachdb/cockroach
+
+mkdir go/src/github.com/cockroachdb/cockroach/bin
+----
+
+bazel info bazel-bin --color=no --config=dev
+----
+/private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin
+
+rm go/src/github.com/cockroachdb/cockroach/cockroach-short
+----
+
+ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short go/src/github.com/cockroachdb/cockroach/cockroach-short
+----
+
+bazel build --color=yes --experimental_convenience_symlinks=ignore --config=dev //pkg/cmd/cockroach-short
+----
+
+bazel info workspace --color=no --config=dev
+----
+go/src/github.com/cockroachdb/cockroach
+
+mkdir go/src/github.com/cockroachdb/cockroach/bin
+----
+
+bazel info bazel-bin --color=no --config=dev
+----
+/private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin
+
+rm go/src/github.com/cockroachdb/cockroach/cockroach-short
+----
+
+ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short go/src/github.com/cockroachdb/cockroach/cockroach-short
+----
+
+bazel build --color=yes --experimental_convenience_symlinks=ignore --config=dev --remote_local_fallback --remote_cache=grpc://127.0.0.1:9090 --experimental_remote_downloader=grpc://127.0.0.1:9090 //pkg/cmd/cockroach-short
+----
+
+bazel info workspace --color=no --config=dev
+----
+go/src/github.com/cockroachdb/cockroach
+
+mkdir go/src/github.com/cockroachdb/cockroach/bin
+----
+
+bazel info bazel-bin --color=no --config=dev
+----
+/private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin
+
+rm go/src/github.com/cockroachdb/cockroach/cockroach-short
+----
+
+ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short go/src/github.com/cockroachdb/cockroach/cockroach-short
+----
+
 bazel build --color=yes --experimental_convenience_symlinks=ignore //pkg/cmd/cockroach-short
 ----
 
@@ -17,64 +97,3 @@ rm go/src/github.com/cockroachdb/cockroach/cockroach-short
 
 ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short go/src/github.com/cockroachdb/cockroach/cockroach-short
 ----
-
-bazel build --color=yes --experimental_convenience_symlinks=ignore --local_cpu_resources=12 //pkg/cmd/cockroach-short
-----
-
-bazel info workspace --color=no
-----
-go/src/github.com/cockroachdb/cockroach
-
-mkdir go/src/github.com/cockroachdb/cockroach/bin
-----
-
-bazel info bazel-bin --color=no
-----
-/private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin
-
-rm go/src/github.com/cockroachdb/cockroach/cockroach-short
-----
-
-ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short go/src/github.com/cockroachdb/cockroach/cockroach-short
-----
-
-bazel build --color=yes --experimental_convenience_symlinks=ignore //pkg/cmd/cockroach-short
-----
-
-bazel info workspace --color=no
-----
-go/src/github.com/cockroachdb/cockroach
-
-mkdir go/src/github.com/cockroachdb/cockroach/bin
-----
-
-bazel info bazel-bin --color=no
-----
-/private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin
-
-rm go/src/github.com/cockroachdb/cockroach/cockroach-short
-----
-
-ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short go/src/github.com/cockroachdb/cockroach/cockroach-short
-----
-
-bazel build --color=yes --experimental_convenience_symlinks=ignore --remote_local_fallback --remote_cache=grpc://127.0.0.1:9090 --experimental_remote_downloader=grpc://127.0.0.1:9090 //pkg/cmd/cockroach-short
-----
-
-bazel info workspace --color=no
-----
-go/src/github.com/cockroachdb/cockroach
-
-mkdir go/src/github.com/cockroachdb/cockroach/bin
-----
-
-bazel info bazel-bin --color=no
-----
-/private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin
-
-rm go/src/github.com/cockroachdb/cockroach/cockroach-short
-----
-
-ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short go/src/github.com/cockroachdb/cockroach/cockroach-short
-----
-

--- a/pkg/cmd/dev/testdata/recording/generate.txt
+++ b/pkg/cmd/dev/testdata/recording/generate.txt
@@ -1,4 +1,4 @@
-bazel info workspace --color=no
+bazel info workspace --color=no --config=dev
 ----
 go/src/github.com/cockroachdb/cockroach
 

--- a/pkg/cmd/dev/testdata/recording/test.txt
+++ b/pkg/cmd/dev/testdata/recording/test.txt
@@ -1,4 +1,4 @@
-bazel test --color=yes --experimental_convenience_symlinks=ignore //pkg/util/tracing:tracing_test --test_output errors
+bazel test --color=yes --experimental_convenience_symlinks=ignore --config=dev //pkg/util/tracing:tracing_test --test_output errors
 ----
 ----
 //pkg/util/tracing:tracing_test                                          [0m[32mPASSED[0m in 0.2s
@@ -11,7 +11,7 @@ bazel query kind(go_test,  //pkg/util/tracing/...)
 ----
 //pkg/util/tracing:tracing_test
 
-bazel test --color=yes --experimental_convenience_symlinks=ignore //pkg/util/tracing:tracing_test --test_output errors
+bazel test --color=yes --experimental_convenience_symlinks=ignore --config=dev //pkg/util/tracing:tracing_test --test_output errors
 ----
 ----
 //pkg/util/tracing:tracing_test                                 [0m[32m(cached) PASSED[0m in 0.2s
@@ -20,7 +20,7 @@ Executed 0 out of 1 test: 1 test passes.
 ----
 ----
 
-bazel test --color=yes --experimental_convenience_symlinks=ignore //pkg/util/tracing:tracing_test --test_filter='TestStartChild*' --test_output errors
+bazel test --color=yes --experimental_convenience_symlinks=ignore --config=dev //pkg/util/tracing:tracing_test --test_filter='TestStartChild*' --test_output errors
 ----
 ----
 //pkg/util/tracing:tracing_test                                          [0m[32mPASSED[0m in 0.1s
@@ -29,7 +29,7 @@ Executed 1 out of 1 test: 1 test passes.
 ----
 ----
 
-bazel test --color=yes --experimental_convenience_symlinks=ignore //pkg/util/tracing:tracing_test --test_filter='TestStartChild*' --test_output all --test_arg -test.v
+bazel test --color=yes --experimental_convenience_symlinks=ignore --config=dev //pkg/util/tracing:tracing_test --test_filter='TestStartChild*' --test_output all --test_arg -test.v
 ----
 ----
 ==================== Test output for //pkg/util/tracing:tracing_test:
@@ -42,7 +42,7 @@ Executed 1 out of 1 test: 1 test passes.
 ----
 ----
 
-bazel test --color=yes --experimental_convenience_symlinks=ignore --remote_local_fallback --remote_cache=grpc://127.0.0.1:9092 --experimental_remote_downloader=grpc://127.0.0.1:9092 //pkg/util/tracing:tracing_test --test_filter='TestStartChild*' --test_output errors
+bazel test --color=yes --experimental_convenience_symlinks=ignore --config=dev --remote_local_fallback --remote_cache=grpc://127.0.0.1:9092 --experimental_remote_downloader=grpc://127.0.0.1:9092 //pkg/util/tracing:tracing_test --test_filter='TestStartChild*' --test_output errors
 ----
 ----
 //pkg/util/tracing:tracing_test                                 [0m[32m(cached) PASSED[0m in 0.0s
@@ -51,7 +51,7 @@ Executed 0 out of 1 test: 1 test passes.
 ----
 ----
 
-bazel test --color=yes --experimental_convenience_symlinks=ignore //pkg/util/tracing:tracing_test --nocache_test_results --test_filter='TestStartChild*' --test_output errors
+bazel test --color=yes --experimental_convenience_symlinks=ignore --config=dev //pkg/util/tracing:tracing_test --nocache_test_results --test_filter='TestStartChild*' --test_output errors
 ----
 ----
 //pkg/util/tracing:tracing_test                                          [0m[32mPASSED[0m in 0.1s
@@ -60,7 +60,7 @@ Executed 1 out of 1 test: 1 test passes.
 ----
 ----
 
-bazel test --color=yes --experimental_convenience_symlinks=ignore //pkg/util/tracing:tracing_test --run_under stress -maxtime=10s --test_filter='TestStartChild*' --test_output errors
+bazel test --color=yes --experimental_convenience_symlinks=ignore --config=dev //pkg/util/tracing:tracing_test --run_under stress -maxtime=10s --test_filter='TestStartChild*' --test_output errors
 ----
 ----
 //pkg/util/tracing:tracing_test                                          [0m[32mPASSED[0m in 12.3s
@@ -69,7 +69,7 @@ Executed 1 out of 1 test: 1 test passes.
 ----
 ----
 
-bazel test --color=yes --experimental_convenience_symlinks=ignore //pkg/util/tracing:tracing_test --run_under stress -maxtime=10s --test_filter='TestStartChild*' --test_output all --test_arg -test.v
+bazel test --color=yes --experimental_convenience_symlinks=ignore --config=dev //pkg/util/tracing:tracing_test --run_under stress -maxtime=10s --test_filter='TestStartChild*' --test_output all --test_arg -test.v
 ----
 ----
 ==================== Test output for //pkg/util/tracing:tracing_test:

--- a/pkg/cmd/dev/testdata/test.txt
+++ b/pkg/cmd/dev/testdata/test.txt
@@ -1,32 +1,32 @@
 dev test pkg/util/tracing
 ----
-bazel test --color=yes --experimental_convenience_symlinks=ignore //pkg/util/tracing:tracing_test --test_output errors
+bazel test --color=yes --experimental_convenience_symlinks=ignore --config=dev //pkg/util/tracing:tracing_test --test_output errors
 
 dev test pkg/util/tracing/...
 ----
 bazel query kind(go_test,  //pkg/util/tracing/...)
-bazel test --color=yes --experimental_convenience_symlinks=ignore //pkg/util/tracing:tracing_test --test_output errors
+bazel test --color=yes --experimental_convenience_symlinks=ignore --config=dev //pkg/util/tracing:tracing_test --test_output errors
 
 dev test pkg/util/tracing -f 'TestStartChild*'
 ----
-bazel test --color=yes --experimental_convenience_symlinks=ignore //pkg/util/tracing:tracing_test --test_filter='TestStartChild*' --test_output errors
+bazel test --color=yes --experimental_convenience_symlinks=ignore --config=dev //pkg/util/tracing:tracing_test --test_filter='TestStartChild*' --test_output errors
 
 dev test pkg/util/tracing -f 'TestStartChild*' -v
 ----
-bazel test --color=yes --experimental_convenience_symlinks=ignore //pkg/util/tracing:tracing_test --test_filter='TestStartChild*' --test_output all --test_arg -test.v
+bazel test --color=yes --experimental_convenience_symlinks=ignore --config=dev //pkg/util/tracing:tracing_test --test_filter='TestStartChild*' --test_output all --test_arg -test.v
 
 dev test pkg/util/tracing -f 'TestStartChild*' --remote-cache 127.0.0.1:9092
 ----
-bazel test --color=yes --experimental_convenience_symlinks=ignore --remote_local_fallback --remote_cache=grpc://127.0.0.1:9092 --experimental_remote_downloader=grpc://127.0.0.1:9092 //pkg/util/tracing:tracing_test --test_filter='TestStartChild*' --test_output errors
+bazel test --color=yes --experimental_convenience_symlinks=ignore --config=dev --remote_local_fallback --remote_cache=grpc://127.0.0.1:9092 --experimental_remote_downloader=grpc://127.0.0.1:9092 //pkg/util/tracing:tracing_test --test_filter='TestStartChild*' --test_output errors
 
 dev test pkg/util/tracing -f 'TestStartChild*' --ignore-cache
 ----
-bazel test --color=yes --experimental_convenience_symlinks=ignore //pkg/util/tracing:tracing_test --nocache_test_results --test_filter='TestStartChild*' --test_output errors
+bazel test --color=yes --experimental_convenience_symlinks=ignore --config=dev //pkg/util/tracing:tracing_test --nocache_test_results --test_filter='TestStartChild*' --test_output errors
 
 dev test --stress pkg/util/tracing --filter 'TestStartChild*' --timeout=10s
 ----
-bazel test --color=yes --experimental_convenience_symlinks=ignore //pkg/util/tracing:tracing_test --run_under stress -maxtime=10s --test_filter='TestStartChild*' --test_output errors
+bazel test --color=yes --experimental_convenience_symlinks=ignore --config=dev //pkg/util/tracing:tracing_test --run_under stress -maxtime=10s --test_filter='TestStartChild*' --test_output errors
 
 dev test --stress pkg/util/tracing --filter 'TestStartChild*' --timeout=10s -v
 ----
-bazel test --color=yes --experimental_convenience_symlinks=ignore //pkg/util/tracing:tracing_test --run_under stress -maxtime=10s --test_filter='TestStartChild*' --test_output all --test_arg -test.v
+bazel test --color=yes --experimental_convenience_symlinks=ignore --config=dev //pkg/util/tracing:tracing_test --run_under stress -maxtime=10s --test_filter='TestStartChild*' --test_output all --test_arg -test.v


### PR DESCRIPTION
Passing `--config=dev` for `dev` builds is a good choice, and
`--config=devdarwinx86_64` is required for most dev builds on macOS
machines. Automatically pass that flag unless the user requests not to.

Release note: None