### PR TITLE
roachtest: fix tpchvec/smithcmp

### DIFF
--- a/pkg/cmd/roachtest/tests/tpchvec.go
+++ b/pkg/cmd/roachtest/tests/tpchvec.go
@@ -520,7 +520,7 @@ func smithcmpTestRun(
 	tc.preTestRunHook(ctx, t, c, conn, runConfig.clusterSetups[0])
 	const (
 		configFile = `tpchvec_smithcmp.toml`
-		configURL  = `https://raw.githubusercontent.com/cockroachdb/cockroach/master/pkg/cmd/roachtest/` + configFile
+		configURL  = `https://raw.githubusercontent.com/cockroachdb/cockroach/master/pkg/cmd/roachtest/tests/` + configFile
 	)
 	firstNode := c.Node(1)
 	if err := c.RunE(ctx, firstNode, fmt.Sprintf("curl %s > %s", configURL, configFile)); err != nil {


### PR DESCRIPTION
The config file has recently been moved to a different location, and
`tpchvec/smithcmp` test was broken. This is now fixed.

Fixes: #67353.
Fixes: #67361.

Release note: None