### PR TITLE
kvserver: fix flaky TestStoreRangeMergeWatcher test

### DIFF
--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -250,7 +250,7 @@ var (
 	// NodeLivenessKeyMax is the maximum value for any node liveness key.
 	NodeLivenessKeyMax = NodeLivenessPrefix.PrefixEnd()
 	//
-	// BootstrapVersion is the key at which clusters bootstrapped with a version
+	// BootstrapVersionKey is the key at which clusters bootstrapped with a version
 	// > 1.0 persist the version at which they were bootstrapped.
 	BootstrapVersionKey = roachpb.Key(makeKey(SystemPrefix, roachpb.RKey("bootstrap-version")))
 	//
@@ -285,11 +285,14 @@ var (
 	//
 	// TODO(nvanbenschoten): Figure out what to do with all of these. At a
 	// minimum, prefix them all with "System".
-	//
+
 	// TableDataMin is the start of the range of table data keys.
 	TableDataMin = SystemSQLCodec.TablePrefix(0)
-	// TableDataMin is the end of the range of table data keys.
+	// TableDataMax is the end of the range of table data keys.
 	TableDataMax = SystemSQLCodec.TablePrefix(math.MaxUint32).PrefixEnd()
+	// ScratchRangeMin is a key used in tests to write arbitrary data without
+	// overlapping with meta, system or tenant ranges.
+	ScratchRangeMin = TableDataMax
 	//
 	// SystemConfigSplitKey is the key to split at immediately prior to the
 	// system config span. NB: Split keys need to be valid column keys.

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -67,6 +67,11 @@ const (
 	// the key space being written is starting out empty.
 	optimizePutThreshold = 10
 
+	// Transaction names used for range changes.
+	// Note that those names are used by tests to perform request filtering
+	// in absence of better criteria. If names are changed, tests should be
+	// updated accordingly to avoid flakiness.
+
 	replicaChangeTxnName = "change-replica"
 	splitTxnName         = "split"
 	mergeTxnName         = "merge"

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -1223,7 +1223,7 @@ func (ts *TestServer) ScratchRange() (roachpb.Key, error) {
 // ScratchRangeEx splits off a range suitable to be used as KV scratch space.
 // (it doesn't overlap system spans or SQL tables).
 func (ts *TestServer) ScratchRangeEx() (roachpb.RangeDescriptor, roachpb.RangeDescriptor, error) {
-	scratchKey := keys.TableDataMax
+	scratchKey := keys.ScratchRangeMin
 	return ts.SplitRange(scratchKey)
 }
 


### PR DESCRIPTION
Test is inserting failures into store which are very broad and
prevent initial test setup from performing upreplication.
This change makes request filter more specific so that failure
happens at the right time to verify that rhs merge correctly
rejects incoming requests after merge.

Fixes #67171

Release note: None