### PR TITLE
release-21.1: roachtest: fix tpchvec/smithcmp

### DIFF
--- a/pkg/cmd/roachtest/tpchvec.go
+++ b/pkg/cmd/roachtest/tpchvec.go
@@ -591,7 +591,7 @@ func smithcmpTestRun(
 	tc.preTestRunHook(ctx, t, c, conn, version, runConfig.clusterSetups[0])
 	const (
 		configFile = `tpchvec_smithcmp.toml`
-		configURL  = `https://raw.githubusercontent.com/cockroachdb/cockroach/master/pkg/cmd/roachtest/` + configFile
+		configURL  = `https://raw.githubusercontent.com/cockroachdb/cockroach/master/pkg/cmd/roachtest/tests/` + configFile
 	)
 	firstNode := c.Node(1)
 	if err := c.RunE(ctx, firstNode, fmt.Sprintf("curl %s > %s", configURL, configFile)); err != nil {


### PR DESCRIPTION
Backport 1/1 commits from #67543.

/cc @cockroachdb/release

Release justification: Test only change.

---

The config file has recently been moved to a different location, and
`tpchvec/smithcmp` test was broken. This is now fixed.

Fixes: #67353.
Fixes: #67361.

Release note: None
