### PR TITLE
logictest: add a regression test around apply joins

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/apply_join
+++ b/pkg/sql/logictest/testdata/logic_test/apply_join
@@ -453,3 +453,23 @@ FROM
   t39433 AS tab_57069;
 ----
 NULL
+
+# Regression test for mixing subqueries in "inner" and "outer" contexts
+# (#66923).
+query error unimplemented: apply joins with subqueries in the \"inner\" and \"outer\" contexts are not supported
+VALUES
+  (
+    (
+      SELECT
+        (
+          SELECT
+            NULL
+          FROM
+            (VALUES (tab_54747.col_95055)) AS tab_54752 (col_95061)
+          WHERE
+            (SELECT 0) < tab_54752.col_95061
+        )
+      FROM
+        (VALUES (0:::OID), (3790322641:::OID)) AS tab_54747 (col_95055)
+    )
+  );


### PR DESCRIPTION
This is a reduced version of #66923.

Release note: None