### PR TITLE
release-20.2: sql: fix apply joins when inner plans have subqueries

### DIFF
--- a/pkg/cmd/roachtest/sqlsmith.go
+++ b/pkg/cmd/roachtest/sqlsmith.go
@@ -178,10 +178,9 @@ func registerSQLSmith(r *testRegistry) {
 				es := err.Error()
 				if strings.Contains(es, "internal error") {
 					// TODO(yuzefovich): we temporarily ignore internal errors
-					// that are because of #39433 and #40929.
+					// that are because of #40929.
 					var expectedError bool
 					for _, exp := range []string{
-						"internal error: invalid index",
 						"could not parse \"0E-2019\" as type decimal",
 					} {
 						expectedError = expectedError || strings.Contains(es, exp)

--- a/pkg/sql/apply_join.go
+++ b/pkg/sql/apply_join.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
@@ -243,18 +244,38 @@ func runPlanInsidePlan(
 	)
 	defer recv.Release()
 
-	if !params.p.extendedEvalCtx.ExecCfg.DistSQLPlanner.PlanAndRunSubqueries(
-		params.ctx,
-		params.p,
-		params.extendedEvalCtx.copy,
-		plan.subqueryPlans,
-		recv,
-		true, /* maybeDistribute */
-	) {
-		if err := rowResultWriter.Err(); err != nil {
-			return err
+	if len(plan.subqueryPlans) != 0 {
+		// We currently don't support cases when both the "inner" and the
+		// "outer" plans have subqueries due to limitations of how we're
+		// propagating the results of the subqueries.
+		if len(params.p.curPlan.subqueryPlans) != 0 {
+			return unimplemented.NewWithIssue(66447, `apply joins with subqueries in the "inner" and "outer" contexts are not supported`)
 		}
-		return recv.commErr
+		// Right now curPlan.subqueryPlans are the subqueries from the "outer"
+		// plan (and we know there are none given the check above). If parts of
+		// the "inner" plan refer to the subqueries, we know that they must
+		// refer to the "inner" subqueries. To allow for that to happen we have
+		// to manually replace the subqueries on the planner's curPlan and
+		// restore the original state before exiting.
+		oldSubqueries := params.p.curPlan.subqueryPlans
+		params.p.curPlan.subqueryPlans = plan.subqueryPlans
+		defer func() {
+			params.p.curPlan.subqueryPlans = oldSubqueries
+		}()
+
+		if !params.p.extendedEvalCtx.ExecCfg.DistSQLPlanner.PlanAndRunSubqueries(
+			params.ctx,
+			params.p,
+			params.extendedEvalCtx.copy,
+			plan.subqueryPlans,
+			recv,
+			true, /* maybeDistribute */
+		) {
+			if err := rowResultWriter.Err(); err != nil {
+				return err
+			}
+			return recv.commErr
+		}
 	}
 
 	// Make a copy of the EvalContext so it can be safely modified.

--- a/pkg/sql/logictest/testdata/logic_test/apply_join
+++ b/pkg/sql/logictest/testdata/logic_test/apply_join
@@ -352,9 +352,9 @@ UPDATE cpk SET extra = (
 )
 WHERE ((cpk.key, cpk.value) IN (SELECT new_values.k, new_values.v FROM new_values))
 
-# Regression test for not closing the subqueries in the apply join if they hit
-# an error (#54166).
-query error pgcode XX000 invalid index .*
+# Regression tests for not handling the subqueries in the "inner" plans
+# correctly (#39433).
+query I
 SELECT
   (
     SELECT
@@ -379,3 +379,47 @@ SELECT
 FROM
   (VALUES (NULL)) AS tab_4 (col_4),
   (VALUES (NULL), (NULL)) AS tab_5 (col_5)
+----
+NULL
+NULL
+
+statement ok
+CREATE TABLE t39433 AS SELECT true AS _bool;
+
+query I
+SELECT
+  (
+    SELECT
+      NULL
+    FROM
+      t39433
+      LEFT JOIN t39433 AS tab_57077
+        RIGHT JOIN t39433 AS tab_57078 FULL JOIN t39433 AS tab_57079 ON true ON tab_57069._bool
+        CROSS JOIN t39433 AS tab_57080
+        INNER JOIN t39433 AS tab_57081 ON true ON
+          EXISTS(SELECT NULL FROM t39433 AS tab_57082 LEFT JOIN t39433 ON EXISTS(SELECT NULL FROM t39433))
+  )
+FROM
+  t39433 AS tab_57069;
+----
+NULL
+
+# Regression test for mixing subqueries in "inner" and "outer" contexts
+# (#66923).
+query error unimplemented: apply joins with subqueries in the \"inner\" and \"outer\" contexts are not supported
+VALUES
+  (
+    (
+      SELECT
+        (
+          SELECT
+            NULL
+          FROM
+            (VALUES (tab_54747.col_95055)) AS tab_54752 (col_95061)
+          WHERE
+            (SELECT 0) < tab_54752.col_95061
+        )
+      FROM
+        (VALUES (0:::OID), (3790322641:::OID)) AS tab_54747 (col_95055)
+    )
+  );


### PR DESCRIPTION
Backport 1/1 commits from #66442.
Backport 1/1 commits from #67569.

Two commits are squashed.

/cc @cockroachdb/release

Release justification: fix to a bug that could lead to crashes or correctness issues.
Fix is a low risk.

---

Previously, whenever the inner plan of an apply join was executed, it
would try to refer to the results of the subqueries of the outer plan
because the way we "connect" the subqueries with their results is a bit
fragile - by having an index into subquery plans slice that lives on the
`planner`. This could be incorrect when the "inner" plan has its own
subqueries.

In case when the "inner" plan is referring to the "inner" subqueries,
there are two bug-scenarios:
- if the "outer" plan also contains the subqueries, then the "inner"
plan could use the incorrect result, and the whole query silently would
return an incorrect result too;
- if the "outer" plan has no subqueries, then a panic (converted to an
internal error by the vectorized engine) would occur.

This commit partially mitigates the problem by detecting the scenario
when both "inner" and "outer" plans have subqueries (and returning an
unsupported error) and by updating the planner to point to the "inner"
subqueries when there are no "outer" subqueries.

Fixes: #39433.

Release note (bug fix): Correlated subqueries that couldn't be
decorrelated and that have their own subqueries are now executed
correctly when supported. Note that it is an edge case of an edge case,
so it's unlikely the users have hit this bug (it was found by the
randomized testing).