### PR TITLE
colrpc: add memory accounting for temporary data in inbox/outbox

### DIFF
--- a/pkg/sql/colflow/colrpc/outbox.go
+++ b/pkg/sql/colflow/colrpc/outbox.go
@@ -49,6 +49,7 @@ type Outbox struct {
 
 	typs []*types.T
 
+	allocator  *colmem.Allocator
 	converter  *colserde.ArrowBatchConverter
 	serializer *colserde.RecordBatchSerializer
 
@@ -99,6 +100,7 @@ func NewOutbox(
 		// be).
 		OneInputNode:    colexecop.NewOneInputNode(colexecutils.NewDeselectorOp(allocator, input, typs)),
 		typs:            typs,
+		allocator:       allocator,
 		converter:       c,
 		serializer:      s,
 		getStats:        getStats,
@@ -111,6 +113,14 @@ func NewOutbox(
 }
 
 func (o *Outbox) close(ctx context.Context) {
+	o.scratch.buf = nil
+	o.scratch.msg = nil
+	// Unset the input (which is a deselector operator) so that its output batch
+	// could be garbage collected. This allows us to release all memory
+	// registered with the allocator (the allocator is shared by the outbox and
+	// the deselector).
+	o.Input = nil
+	o.allocator.ReleaseMemory(o.allocator.Used())
 	o.closers.CloseAndLogOnErr(ctx, "outbox")
 }
 
@@ -276,14 +286,26 @@ func (o *Outbox) sendBatches(
 				return
 			}
 
-			o.scratch.buf.Reset()
+			// Note that for certain types (like Decimals, Intervals,
+			// datum-backed types) BatchToArrow allocates some memory in order
+			// to perform the conversion, and we consciously choose to ignore it
+			// for the purposes of the memory accounting because the references
+			// to those slices are lost in Serialize call below.
 			d, err := o.converter.BatchToArrow(batch)
 			if err != nil {
 				colexecerror.InternalError(errors.Wrap(err, "Outbox BatchToArrow data serialization error"))
 			}
+
+			oldBufCap := o.scratch.buf.Cap()
+			o.scratch.buf.Reset()
 			if _, _, err := o.serializer.Serialize(o.scratch.buf, d, n); err != nil {
 				colexecerror.InternalError(errors.Wrap(err, "Outbox Serialize data error"))
 			}
+			// Account for the increase in the capacity of the scratch buffer.
+			// Note that because we never truncate the buffer, we are only
+			// adjusting the memory usage whenever the buffer's capacity
+			// increases (if it didn't increase, this call becomes a noop).
+			o.allocator.AdjustMemoryUsage(int64(o.scratch.buf.Cap() - oldBufCap))
 			o.scratch.msg.Data.RawBytes = o.scratch.buf.Bytes()
 
 			// o.scratch.msg can be reused as soon as Send returns since it returns as

--- a/pkg/sql/colmem/allocator.go
+++ b/pkg/sql/colmem/allocator.go
@@ -351,7 +351,7 @@ func (a *Allocator) AdjustMemoryUsage(delta int64) {
 		if err := a.acc.Grow(a.ctx, delta); err != nil {
 			colexecerror.InternalError(err)
 		}
-	} else {
+	} else if delta < 0 {
 		a.ReleaseMemory(-delta)
 	}
 }


### PR DESCRIPTION
**colrpc: fix memory accounting in inbox a bit**

Previously, we forgot to update the allocator once we have deserialized
the batch in the inbox (i.e. we would register only the original
allocation, upon the batch's creation). This could result in
under-accounting for variable length types, and it is now fixed.

Release note: None

**colrpc: add memory accounting for temporary data in inbox/outbox**

Previously, we were missing the memory accounting for the temporary
usage of serialized/deserialized bytes in the inbox/outbox pair. The
worst offense was that in the outbox we reuse the same scratch Bytes
buffer that is never truncated and can only increase in capacity
throughout the lifetime of the outbox, yet it wasn't accounted for. This
commit fixes those omissions.

Fixes: #67051.

Release note: None