### PR TITLE
compare_test: account for more differences from postgres

### DIFF
--- a/pkg/cmd/cmpconn/compare.go
+++ b/pkg/cmd/cmpconn/compare.go
@@ -108,7 +108,11 @@ var (
 					// Postgres sometimes adds spaces to the end of a string.
 					t = strings.TrimSpace(t)
 					v = strings.Replace(t, "T00:00:00+00:00", "T00:00:00Z", 1)
-					v = strings.Replace(t, ":00+00:00", ":00", 1)
+
+					// Postgres only shows the minutes offset of a timezone if it is
+					// non-zero.
+					// See https://github.com/cockroachdb/cockroach/issues/41563
+					v = strings.Replace(t, ":00+00:00", ":00+00", 1)
 				case *pgtype.Numeric:
 					if t.Status == pgtype.Present {
 						v = apd.NewWithBigInt(t.Int, t.Exp)

--- a/pkg/internal/sqlsmith/scalar.go
+++ b/pkg/internal/sqlsmith/scalar.go
@@ -148,7 +148,13 @@ func makeConstExpr(s *Smither, typ *types.T, refs colRefs) tree.TypedExpr {
 		}
 	}
 
-	return makeConstDatum(s, typ)
+	expr := tree.TypedExpr(makeConstDatum(s, typ))
+	// In Postgres mode, make sure the datum is resolved as the type we want.
+	// CockroachDB and Postgres differ in how constants are typed otherwise.
+	if s.postgres {
+		expr = tree.NewTypedCastExpr(expr, typ)
+	}
+	return expr
 }
 
 func makeConstDatum(s *Smither, typ *types.T) tree.Datum {

--- a/pkg/internal/sqlsmith/sqlsmith.go
+++ b/pkg/internal/sqlsmith/sqlsmith.go
@@ -396,4 +396,5 @@ var PostgresMode = multiOption(
 	IgnoreFNs("st_.*withinexclusive$"),
 	IgnoreFNs("^postgis_.*build_date"),
 	IgnoreFNs("^postgis_.*version"),
+	IgnoreFNs("^postgis_.*scripts"),
 )


### PR DESCRIPTION
- explicit cast for constants https://github.com/cockroachdb/cockroach/issues/62602#issuecomment-879600692
- don't use postgis_script builtin https://github.com/cockroachdb/cockroach/issues/62602#issuecomment-876137015
- handle differences in timezone offset display https://github.com/cockroachdb/cockroach/issues/62602#issuecomment-878791614

Release note: None