### PR TITLE
release-21.1: kv: split up intents into batches during gc cleanup

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -608,6 +608,7 @@ func runDebugGCCmd(cmd *cobra.Command, args []string) error {
 	var rangeID roachpb.RangeID
 	gcTTLInSeconds := int64((24 * time.Hour).Seconds())
 	intentAgeThreshold := gc.IntentAgeThreshold.Default()
+	intentBatchSize := gc.MaxIntentsPerCleanupBatch.Default()
 
 	if len(args) > 3 {
 		var err error
@@ -675,7 +676,7 @@ func runDebugGCCmd(cmd *cobra.Command, args []string) error {
 		info, err := gc.Run(
 			context.Background(),
 			&desc, snap,
-			now, thresh, intentAgeThreshold, policy,
+			now, thresh, gc.RunOptions{IntentAgeThreshold: intentAgeThreshold, MaxIntentsPerIntentCleanupBatch: intentBatchSize}, policy,
 			gc.NoopGCer{},
 			func(_ context.Context, _ []roachpb.Intent) error { return nil },
 			func(_ context.Context, _ *roachpb.Transaction) error { return nil },

--- a/pkg/kv/kvserver/gc/BUILD.bazel
+++ b/pkg/kv/kvserver/gc/BUILD.bazel
@@ -52,6 +52,7 @@ go_test(
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/protoutil",
+        "//pkg/util/randutil",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//assert",

--- a/pkg/kv/kvserver/gc/gc.go
+++ b/pkg/kv/kvserver/gc/gc.go
@@ -18,6 +18,7 @@ package gc
 import (
 	"context"
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -54,6 +55,41 @@ var IntentAgeThreshold = settings.RegisterDurationSetting(
 	func(d time.Duration) error {
 		if d < 2*time.Minute {
 			return errors.New("intent age threshold must be >= 2 minutes")
+		}
+		return nil
+	},
+)
+
+// MaxIntentsPerCleanupBatch is a maximum number of intents that GC will send
+// for intent resolution as a single batch.
+// Default value is set to half of the maximum lock table size at the time
+// of writing.
+// This value is subject to tuning in real environment as we have more
+// data available.
+var MaxIntentsPerCleanupBatch = settings.RegisterIntSetting(
+	"kv.gc.intent_cleanup_batch_size",
+	"if non zero, gc will split found intents into batches of this size when trying to resolve them",
+	5000,
+	func(batchSize int64) error {
+		if batchSize < 0 {
+			return errors.New("gc intent cleanup batch size must be non negative")
+		}
+		return nil
+	},
+)
+
+// MaxIntentKeyBytesPerCleanupBatch is maximum number of intent bytes GC will try to
+// send as a single batch to intent resolution. This number is approximate and
+// only includes size of the intent keys.
+// Default value is conservative limit to prevent pending intent key sizes from
+// ballooning.
+var MaxIntentKeyBytesPerCleanupBatch = settings.RegisterIntSetting(
+	"kv.gc.intent_cleanup_batch_byte_size",
+	"if non zero, gc will split found intents into batches of this size when trying to resolve them",
+	1e6,
+	func(batchSize int64) error {
+		if batchSize < 0 {
+			return errors.New("gc intent cleanup batch size must be non negative")
 		}
 		return nil
 	},
@@ -131,7 +167,10 @@ type Info struct {
 	// AbortSpanGCNum is the number of AbortSpan entries fit for removal (due
 	// to their transactions having terminated).
 	AbortSpanGCNum int
-	// PushTxn is the total number of pushes attempted in this cycle.
+	// PushTxn is the total number of pushes attempted in this cycle. Note that we
+	// could try to push single transaction multiple times because of intent
+	// batching so this number is equal or greater than actual number of transactions
+	// pushed.
 	PushTxn int
 	// ResolveTotal is the total number of attempted intent resolutions in
 	// this cycle.
@@ -146,6 +185,23 @@ type Info struct {
 	// AffectedVersionsValBytes is the number of (fully encoded) bytes deleted from values in the storage engine.
 	// See AffectedVersionsKeyBytes for caveats.
 	AffectedVersionsValBytes int64
+}
+
+// RunOptions contains collection of limits that GC run applies when performing operations
+type RunOptions struct {
+	// IntentAgeThreshold is the minimum age an intent must have before this GC run
+	// tries to resolve the intent.
+	IntentAgeThreshold time.Duration
+	// MaxIntentsPerIntentCleanupBatch is the maximum number of intent resolution requests passed
+	// to the intent resolver in a single batch. Helps reducing memory impact of cleanup operations.
+	MaxIntentsPerIntentCleanupBatch int64
+	// MaxIntentKeyBytesPerIntentCleanupBatch similar to MaxIntentsPerIntentCleanupBatch but counts
+	// number of bytes intent keys occupy.
+	MaxIntentKeyBytesPerIntentCleanupBatch int64
+	// MaxTxnsPerIntentCleanupBatch is a maximum number of txns passed to intent resolver to
+	// process in one go. This number should be lower than intent resolver default to
+	// prevent further splitting in resolver.
+	MaxTxnsPerIntentCleanupBatch int64
 }
 
 // CleanupIntentsFunc synchronously resolves the supplied intents
@@ -170,7 +226,7 @@ func Run(
 	desc *roachpb.RangeDescriptor,
 	snap storage.Reader,
 	now, newThreshold hlc.Timestamp,
-	intentAgeThreshold time.Duration,
+	options RunOptions,
 	policy zonepb.GCPolicy,
 	gcer GCer,
 	cleanupIntentsFn CleanupIntentsFunc,
@@ -191,11 +247,12 @@ func Run(
 		Threshold: newThreshold,
 	}
 
-	// Maps from txn ID to txn and intent key slice.
-	txnMap := map[uuid.UUID]*roachpb.Transaction{}
-	intentKeyMap := map[uuid.UUID][]roachpb.Key{}
-	err := processReplicatedKeyRange(ctx, desc, snap, now, newThreshold, intentAgeThreshold, gcer, txnMap, intentKeyMap,
-		&info)
+	err := processReplicatedKeyRange(ctx, desc, snap, now, newThreshold, options.IntentAgeThreshold, gcer,
+		intentBatcherOptions{
+			maxIntentsPerIntentCleanupBatch:        options.MaxIntentsPerIntentCleanupBatch,
+			maxIntentKeyBytesPerIntentCleanupBatch: options.MaxIntentKeyBytesPerIntentCleanupBatch,
+			maxTxnsPerIntentCleanupBatch:           options.MaxTxnsPerIntentCleanupBatch,
+		}, cleanupIntentsFn, &info)
 	if err != nil {
 		return Info{}, err
 	}
@@ -221,17 +278,6 @@ func Run(
 
 	log.Eventf(ctx, "GC'ed keys; stats %+v", info)
 
-	// Push transactions (if pending) and resolve intents.
-	var intents []roachpb.Intent
-	for txnID, txn := range txnMap {
-		intents = append(intents, roachpb.AsIntents(&txn.TxnMeta, intentKeyMap[txnID])...)
-	}
-	info.ResolveTotal += len(intents)
-	log.Eventf(ctx, "cleanup of %d intents", len(intents))
-	if err := cleanupIntentsFn(ctx, intents); err != nil {
-		return Info{}, err
-	}
-
 	return info, nil
 }
 
@@ -248,44 +294,36 @@ func processReplicatedKeyRange(
 	threshold hlc.Timestamp,
 	intentAgeThreshold time.Duration,
 	gcer GCer,
-	txnMap map[uuid.UUID]*roachpb.Transaction,
-	intentKeyMap map[uuid.UUID][]roachpb.Key,
+	options intentBatcherOptions,
+	cleanupIntentsFn CleanupIntentsFunc,
 	info *Info,
 ) error {
 	var alloc bufalloc.ByteAllocator
 	// Compute intent expiration (intent age at which we attempt to resolve).
 	intentExp := now.Add(-intentAgeThreshold.Nanoseconds(), 0)
-	handleIntent := func(md *storage.MVCCKeyValue) {
+
+	batcher := newIntentBatcher(cleanupIntentsFn, options, info)
+
+	handleIntent := func(keyValue *storage.MVCCKeyValue) error {
 		meta := &enginepb.MVCCMetadata{}
-		if err := protoutil.Unmarshal(md.Value, meta); err != nil {
-			log.Errorf(ctx, "unable to unmarshal MVCC metadata for key %q: %+v", md.Key, err)
-			return
+		if err := protoutil.Unmarshal(keyValue.Value, meta); err != nil {
+			log.Errorf(ctx, "unable to unmarshal MVCC metadata for key %q: %+v", keyValue.Key, err)
+			return nil
 		}
 		if meta.Txn != nil {
 			// Keep track of intent to resolve if older than the intent
 			// expiration threshold.
 			if meta.Timestamp.ToTimestamp().Less(intentExp) {
-				txnID := meta.Txn.ID
-				if _, ok := txnMap[txnID]; !ok {
-					txnMap[txnID] = &roachpb.Transaction{
-						TxnMeta: *meta.Txn,
-					}
-					// IntentTxns and PushTxn will be equal here, since
-					// pushes to transactions whose record lies in this
-					// range (but which are not associated to a remaining
-					// intent on it) happen asynchronously and are accounted
-					// for separately. Thus higher up in the stack, we
-					// expect PushTxn > IntentTxns.
-					info.IntentTxns++
-					// All transactions in txnMap may be PENDING and
-					// cleanupIntentsFn will push them to finalize them.
-					info.PushTxn++
-				}
 				info.IntentsConsidered++
-				alloc, md.Key.Key = alloc.Copy(md.Key.Key, 0)
-				intentKeyMap[txnID] = append(intentKeyMap[txnID], md.Key.Key)
+				if err := batcher.addAndMaybeFlushIntents(ctx, keyValue.Key.Key, meta); err != nil {
+					if errors.Is(err, ctx.Err()) {
+						return err
+					}
+					log.Warningf(ctx, "failed to cleanup intents batch: %v", err)
+				}
 			}
 		}
+		return nil
 	}
 
 	// Iterate all versions of all keys from oldest to newest. If a version is an
@@ -318,7 +356,9 @@ func processReplicatedKeyRange(
 			continue
 		}
 		if s.curIsIntent() {
-			handleIntent(s.next)
+			if err := handleIntent(s.next); err != nil {
+				return err
+			}
 			continue
 		}
 		isNewest := s.curIsNewest()
@@ -365,12 +405,134 @@ func processReplicatedKeyRange(
 			alloc = nil
 		}
 	}
+	// We need to send out last intent cleanup batch.
+	if err := batcher.maybeFlushPendingIntents(ctx); err != nil {
+		if errors.Is(err, ctx.Err()) {
+			return err
+		}
+		log.Warningf(ctx, "failed to cleanup intents batch: %v", err)
+	}
 	if len(batchGCKeys) > 0 {
 		if err := gcer.GC(ctx, batchGCKeys); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+type intentBatcher struct {
+	cleanupIntentsFn CleanupIntentsFunc
+
+	options intentBatcherOptions
+
+	// Maps from txn ID to bool and intent slice to accumulate a batch.
+	pendingTxns          map[uuid.UUID]bool
+	pendingIntents       []roachpb.Intent
+	collectedIntentBytes int64
+
+	alloc bufalloc.ByteAllocator
+
+	gcStats *Info
+}
+
+type intentBatcherOptions struct {
+	maxIntentsPerIntentCleanupBatch        int64
+	maxIntentKeyBytesPerIntentCleanupBatch int64
+	maxTxnsPerIntentCleanupBatch           int64
+}
+
+// newIntentBatcher initializes an intentBatcher. Batcher will take ownership of
+// provided *Info object while doing cleanup and update its counters.
+func newIntentBatcher(
+	cleanupIntentsFunc CleanupIntentsFunc, options intentBatcherOptions, gcStats *Info,
+) intentBatcher {
+	if options.maxIntentsPerIntentCleanupBatch <= 0 {
+		options.maxIntentsPerIntentCleanupBatch = math.MaxInt64
+	}
+	if options.maxIntentKeyBytesPerIntentCleanupBatch <= 0 {
+		options.maxIntentKeyBytesPerIntentCleanupBatch = math.MaxInt64
+	}
+	if options.maxTxnsPerIntentCleanupBatch <= 0 {
+		options.maxTxnsPerIntentCleanupBatch = math.MaxInt64
+	}
+	return intentBatcher{
+		cleanupIntentsFn: cleanupIntentsFunc,
+		options:          options,
+		pendingTxns:      make(map[uuid.UUID]bool),
+		gcStats:          gcStats,
+	}
+}
+
+// addAndMaybeFlushIntents collects intent for resolving batch, if
+// any of batching limits is reached sends batch for resolution.
+// Flushing is done retroactively e.g. if newly added intent would exceed
+// the limits the batch would be flushed and new intent is saved for
+// the subsequent batch.
+// Returns error if batch flushing was needed and failed.
+func (b *intentBatcher) addAndMaybeFlushIntents(
+	ctx context.Context, key roachpb.Key, meta *enginepb.MVCCMetadata,
+) error {
+	var err error = nil
+	txnID := meta.Txn.ID
+	_, existingTransaction := b.pendingTxns[txnID]
+	// Check batching thresholds if we need to flush collected data. Transaction
+	// count is treated specially because we want to check it only when we find
+	// a new transaction.
+	if int64(len(b.pendingIntents)) >= b.options.maxIntentsPerIntentCleanupBatch ||
+		b.collectedIntentBytes >= b.options.maxIntentKeyBytesPerIntentCleanupBatch ||
+		!existingTransaction && int64(len(b.pendingTxns)) >= b.options.maxTxnsPerIntentCleanupBatch {
+		err = b.maybeFlushPendingIntents(ctx)
+	}
+
+	// We need to register passed intent regardless of flushing operation result
+	// so that batcher is left in consistent state and don't miss any keys if
+	// caller resumes batching.
+	b.alloc, key = b.alloc.Copy(key, 0)
+	b.pendingIntents = append(b.pendingIntents, roachpb.MakeIntent(meta.Txn, key))
+	b.collectedIntentBytes += int64(len(key))
+	b.pendingTxns[txnID] = true
+
+	return err
+}
+
+// maybeFlushPendingIntents resolves currently collected intents.
+func (b *intentBatcher) maybeFlushPendingIntents(ctx context.Context) error {
+	if len(b.pendingIntents) == 0 {
+		// If there's nothing to flush we will try to preserve context
+		// for the sake of consistency with how flush behaves when context
+		// is canceled during cleanup.
+		return ctx.Err()
+	}
+
+	// FIXME(erikgrinaker): We should have a timeout for suboperations here now
+	// that the overall GC timeout has been increased, to make sure we'll make
+	// progress even with range unavailability. That's probably best done once
+	// batching is implemented, so we'll wait for that:
+	// https://github.com/cockroachdb/cockroach/pull/65847
+	err := b.cleanupIntentsFn(ctx, b.pendingIntents)
+	if err == nil {
+		// IntentTxns and PushTxn will be equal here, since
+		// pushes to transactions whose record lies in this
+		// range (but which are not associated to a remaining
+		// intent on it) happen asynchronously and are accounted
+		// for separately. Thus higher up in the stack, we
+		// expect PushTxn > IntentTxns.
+		b.gcStats.IntentTxns += len(b.pendingTxns)
+		// All transactions in pendingTxns may be PENDING and
+		// cleanupIntentsFn will push them to finalize them.
+		b.gcStats.PushTxn += len(b.pendingTxns)
+
+		b.gcStats.ResolveTotal += len(b.pendingIntents)
+	}
+
+	// Get rid of current transactions and intents regardless of
+	// status as we need to go on cleaning up without retries.
+	for k := range b.pendingTxns {
+		delete(b.pendingTxns, k)
+	}
+	b.pendingIntents = b.pendingIntents[:0]
+	b.collectedIntentBytes = 0
+	return err
 }
 
 // isGarbage makes a determination whether a key ('cur') is garbage. If 'next'

--- a/pkg/kv/kvserver/gc/gc_old_test.go
+++ b/pkg/kv/kvserver/gc/gc_old_test.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"sort"
 	"testing"
-	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
@@ -45,7 +44,7 @@ func runGCOld(
 	snap storage.Reader,
 	now hlc.Timestamp,
 	_ hlc.Timestamp, // exists to make signature match RunGC
-	intentAgeThreshold time.Duration,
+	options RunOptions,
 	policy zonepb.GCPolicy,
 	gcer GCer,
 	cleanupIntentsFn CleanupIntentsFunc,
@@ -56,7 +55,7 @@ func runGCOld(
 	defer iter.Close()
 
 	// Compute intent expiration (intent age at which we attempt to resolve).
-	intentExp := now.Add(-intentAgeThreshold.Nanoseconds(), 0)
+	intentExp := now.Add(-options.IntentAgeThreshold.Nanoseconds(), 0)
 	txnExp := now.Add(-kvserverbase.TxnCleanupThreshold.Nanoseconds(), 0)
 
 	gc := MakeGarbageCollector(now, policy)

--- a/pkg/kv/kvserver/gc/gc_random_test.go
+++ b/pkg/kv/kvserver/gc/gc_random_test.go
@@ -101,7 +101,7 @@ func TestRunNewVsOld(t *testing.T) {
 			policy := zonepb.GCPolicy{TTLSeconds: tc.ttl}
 			newThreshold := CalculateThreshold(tc.now, policy)
 			gcInfoOld, err := runGCOld(ctx, tc.ds.desc(), snap, tc.now,
-				newThreshold, intentAgeThreshold, policy,
+				newThreshold, RunOptions{IntentAgeThreshold: intentAgeThreshold}, policy,
 				&oldGCer,
 				oldGCer.resolveIntents,
 				oldGCer.resolveIntentsAsync)
@@ -109,7 +109,7 @@ func TestRunNewVsOld(t *testing.T) {
 
 			newGCer := makeFakeGCer()
 			gcInfoNew, err := Run(ctx, tc.ds.desc(), snap, tc.now,
-				newThreshold, intentAgeThreshold, policy,
+				newThreshold, RunOptions{IntentAgeThreshold: intentAgeThreshold}, policy,
 				&newGCer,
 				newGCer.resolveIntents,
 				newGCer.resolveIntentsAsync)
@@ -136,7 +136,7 @@ func BenchmarkRun(b *testing.B) {
 		snap := eng.NewSnapshot()
 		policy := zonepb.GCPolicy{TTLSeconds: spec.ttl}
 		return runGCFunc(ctx, spec.ds.desc(), snap, spec.now,
-			CalculateThreshold(spec.now, policy), intentAgeThreshold,
+			CalculateThreshold(spec.now, policy), RunOptions{IntentAgeThreshold: intentAgeThreshold},
 			policy,
 			NoopGCer{},
 			func(ctx context.Context, intents []roachpb.Intent) error {
@@ -188,6 +188,7 @@ type fakeGCer struct {
 	gcKeys     map[string]roachpb.GCRequest_GCKey
 	threshold  Threshold
 	intents    []roachpb.Intent
+	batches    [][]roachpb.Intent
 	txnIntents []txnIntents
 }
 
@@ -218,6 +219,7 @@ func (f *fakeGCer) resolveIntentsAsync(_ context.Context, txn *roachpb.Transacti
 
 func (f *fakeGCer) resolveIntents(_ context.Context, intents []roachpb.Intent) error {
 	f.intents = append(f.intents, intents...)
+	f.batches = append(f.batches, intents)
 	return nil
 }
 
@@ -232,6 +234,7 @@ func (f *fakeGCer) normalize() {
 	sort.Slice(f.txnIntents, func(i, j int) bool {
 		return f.txnIntents[i].txn.ID.String() < f.txnIntents[j].txn.ID.String()
 	})
+	f.batches = nil
 }
 
 func intentLess(a, b *roachpb.Intent) bool {

--- a/pkg/kv/kvserver/gc/gc_test.go
+++ b/pkg/kv/kvserver/gc/gc_test.go
@@ -13,14 +13,20 @@ package gc
 import (
 	"bytes"
 	"context"
+	"errors"
+	"fmt"
+	"math/rand"
 	"testing"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -132,15 +138,246 @@ func TestIntentAgeThresholdSetting(t *testing.T) {
 	fakeGCer := makeFakeGCer()
 
 	// Test GC desired behavior.
-	info, err := Run(ctx, &desc, snap, nowTs, nowTs, intentLongThreshold, policy, &fakeGCer, fakeGCer.resolveIntents,
+	info, err := Run(ctx, &desc, snap, nowTs, nowTs, RunOptions{IntentAgeThreshold: intentAgeThreshold}, policy, &fakeGCer, fakeGCer.resolveIntents,
 		fakeGCer.resolveIntentsAsync)
 	require.NoError(t, err, "GC Run shouldn't fail")
 	assert.Zero(t, info.IntentsConsidered,
 		"Expected no intents considered by GC with default threshold")
 
-	info, err = Run(ctx, &desc, snap, nowTs, nowTs, intentShortThreshold, policy, &fakeGCer, fakeGCer.resolveIntents,
+	info, err = Run(ctx, &desc, snap, nowTs, nowTs, RunOptions{IntentAgeThreshold: intentShortThreshold}, policy, &fakeGCer, fakeGCer.resolveIntents,
 		fakeGCer.resolveIntentsAsync)
 	require.NoError(t, err, "GC Run shouldn't fail")
 	assert.Equal(t, 1, info.IntentsConsidered,
 		"Expected 1 intents considered by GC with short threshold")
+}
+
+func TestIntentCleanupBatching(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	eng := storage.NewDefaultInMemForTesting()
+	defer eng.Close()
+
+	intentThreshold := 2 * time.Hour
+	now := 3 * intentThreshold
+	intentTs := now - intentThreshold*2
+
+	// Prepare test intents in MVCC.
+	txnPrefixes := []byte{'a', 'b', 'c'}
+	objectKeys := []byte{'a', 'b', 'c', 'd', 'e'}
+	value := roachpb.Value{RawBytes: []byte("0123456789")}
+	intentHlc := hlc.Timestamp{
+		WallTime: intentTs.Nanoseconds(),
+	}
+	for _, prefix := range txnPrefixes {
+		key := []byte{prefix, objectKeys[0]}
+		txn := roachpb.MakeTransaction("txn", key, roachpb.NormalUserPriority, intentHlc, 1000)
+		for _, suffix := range objectKeys {
+			key := []byte{prefix, suffix}
+			require.NoError(t, storage.MVCCPut(ctx, eng, nil, key, intentHlc, value, &txn))
+		}
+		require.NoError(t, eng.Flush())
+	}
+	desc := roachpb.RangeDescriptor{
+		StartKey: roachpb.RKey([]byte{txnPrefixes[0], objectKeys[0]}),
+		EndKey:   roachpb.RKey("z"),
+	}
+	policy := zonepb.GCPolicy{TTLSeconds: 1}
+	snap := eng.NewSnapshot()
+	nowTs := hlc.Timestamp{
+		WallTime: now.Nanoseconds(),
+	}
+
+	// Base GCer will cleanup all intents in one go and its result is used as a baseline
+	// to compare batched runs for checking completeness.
+	baseGCer := makeFakeGCer()
+	_, err := Run(ctx, &desc, snap, nowTs, nowTs, RunOptions{IntentAgeThreshold: intentAgeThreshold}, policy, &baseGCer, baseGCer.resolveIntents,
+		baseGCer.resolveIntentsAsync)
+	if err != nil {
+		t.Fatal("Can't prepare test fixture. Non batched GC run fails.")
+	}
+	baseGCer.normalize()
+
+	var batchSize int64 = 7
+	fakeGCer := makeFakeGCer()
+	info, err := Run(ctx, &desc, snap, nowTs, nowTs,
+		RunOptions{IntentAgeThreshold: intentAgeThreshold, MaxIntentsPerIntentCleanupBatch: batchSize}, policy,
+		&fakeGCer, fakeGCer.resolveIntents, fakeGCer.resolveIntentsAsync)
+	require.NoError(t, err, "GC Run shouldn't fail")
+	maxIntents := 0
+	for _, batch := range fakeGCer.batches {
+		if intents := len(batch); intents > maxIntents {
+			maxIntents = intents
+		}
+	}
+	require.Equal(t, int64(maxIntents), batchSize, "Batch size")
+	require.Equal(t, 15, info.ResolveTotal)
+	fakeGCer.normalize()
+	require.EqualValues(t, baseGCer, fakeGCer, "GC result with batching")
+}
+
+type testResolver [][]roachpb.Intent
+
+func (r *testResolver) resolveBatch(_ context.Context, batch []roachpb.Intent) error {
+	batchCopy := make([]roachpb.Intent, len(batch))
+	copy(batchCopy, batch)
+	*r = append(*r, batchCopy)
+	return nil
+}
+
+func (r *testResolver) assertInvariants(t *testing.T, opts intentBatcherOptions) {
+	tc := 0
+	for _, b := range *r {
+		tc += len(b)
+	}
+	for i, batch := range *r {
+		require.Greaterf(t, len(batch), 0, fmt.Sprintf("Batch %d/%d should not be empty", i+1, len(*r)))
+		var totalKeyBytes = 0
+		// Calculate batch size across dimensions.
+		txnMap := make(map[uuid.UUID]bool)
+		for _, intent := range batch {
+			txnMap[intent.Txn.ID] = true
+			totalKeyBytes += len(intent.Key)
+		}
+		// Validate that limits are not breached if set.
+		if opts.maxIntentsPerIntentCleanupBatch > 0 {
+			require.LessOrEqual(t, int64(len(batch)), opts.maxIntentsPerIntentCleanupBatch,
+				fmt.Sprintf("Batch size exceeded in batch %d/%d", i+1, len(*r)))
+		}
+		// Last key could overspill over limit, but that's ok.
+		if opts.maxIntentKeyBytesPerIntentCleanupBatch > 0 {
+			require.Less(t, int64(totalKeyBytes-len(batch[len(batch)-1].Key)), opts.maxIntentKeyBytesPerIntentCleanupBatch,
+				fmt.Sprintf("Byte limit was exceeded for more than the last key in batch %d/%d", i+1, len(*r)))
+		}
+		if opts.maxTxnsPerIntentCleanupBatch > 0 {
+			require.LessOrEqual(t, int64(len(txnMap)), opts.maxTxnsPerIntentCleanupBatch,
+				fmt.Sprintf("Max transactions per cleanup batch %d/%d", i+1, len(*r)))
+		}
+		// Validate that at least one of thresholds reached.
+		require.True(t, i == len(*r)-1 ||
+			int64(len(batch)) == opts.maxIntentsPerIntentCleanupBatch ||
+			int64(totalKeyBytes) >= opts.maxIntentKeyBytesPerIntentCleanupBatch ||
+			int64(len(txnMap)) == opts.maxTxnsPerIntentCleanupBatch,
+			fmt.Sprintf("None of batch thresholds were reached in batch %d/%d", i+1, len(*r)))
+	}
+}
+
+type testIntent struct {
+	key  roachpb.Key
+	meta *enginepb.MVCCMetadata
+}
+
+func generateScattered(total int, txns int, maxKeySize int, random *rand.Rand) []testIntent {
+	var txnIds []uuid.UUID
+	for len(txnIds) < txns {
+		txnIds = append(txnIds, uuid.FastMakeV4())
+	}
+	var intents []testIntent
+	for len(intents) < total {
+		intents = append(intents,
+			testIntent{randomLengthKey(random, maxKeySize),
+				&enginepb.MVCCMetadata{Txn: &enginepb.TxnMeta{ID: txnIds[random.Intn(len(txnIds))]}}})
+	}
+	return intents
+}
+
+// Random number from 1 to n inclusive.
+func intnFrom1(rnd *rand.Rand, n int) int {
+	return rnd.Intn(n) + 1
+}
+
+func randomLengthKey(rnd *rand.Rand, maxLength int) roachpb.Key {
+	return make([]byte, intnFrom1(rnd, maxLength))
+}
+
+func generateSequential(total int, maxTxnSize int, maxKeySize int, random *rand.Rand) []testIntent {
+	var intents []testIntent
+	var txnUUID uuid.UUID
+	leftForTransaction := 0
+	for ; len(intents) < total; leftForTransaction-- {
+		if leftForTransaction == 0 {
+			leftForTransaction = intnFrom1(random, maxTxnSize)
+			txnUUID = uuid.FastMakeV4()
+		}
+		intents = append(intents,
+			testIntent{randomLengthKey(random, maxKeySize),
+				&enginepb.MVCCMetadata{Txn: &enginepb.TxnMeta{ID: txnUUID}}})
+	}
+	return intents
+}
+
+func TestGCIntentBatcher(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	rand, _ := randutil.NewTestPseudoRand()
+
+	for _, s := range []struct {
+		name    string
+		intents []testIntent
+	}{
+		{"sequential", generateSequential(1000, 20, 20, rand)},
+		{"scattered", generateScattered(1000, 100, 20, rand)},
+	} {
+		for _, batchSize := range []int64{0, 1, 10, 100, 1000} {
+			for _, byteCount := range []int64{0, 1, 10, 100, 1000} {
+				for _, txnCount := range []int64{0, 1, 10, 100, 1000} {
+					t.Run(fmt.Sprintf("batch=%d,bytes=%d,txns=%d,txn_intents=%s", batchSize, byteCount, txnCount, s.name), func(t *testing.T) {
+						info := Info{}
+						opts := intentBatcherOptions{
+							maxIntentsPerIntentCleanupBatch:        batchSize,
+							maxIntentKeyBytesPerIntentCleanupBatch: byteCount,
+							maxTxnsPerIntentCleanupBatch:           txnCount,
+						}
+						resolver := testResolver{}
+
+						batcher := newIntentBatcher(resolver.resolveBatch, opts, &info)
+
+						for _, intent := range s.intents {
+							require.NoError(t, batcher.addAndMaybeFlushIntents(ctx, intent.key, intent.meta))
+						}
+						require.NoError(t, batcher.maybeFlushPendingIntents(ctx))
+						resolver.assertInvariants(t, opts)
+					})
+				}
+			}
+		}
+	}
+}
+
+func TestGCIntentBatcherErrorHandling(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	opts := intentBatcherOptions{maxIntentsPerIntentCleanupBatch: 1}
+
+	key1 := []byte("key1")
+	key2 := []byte("key2")
+	txn1 := enginepb.MVCCMetadata{Txn: &enginepb.TxnMeta{ID: uuid.FastMakeV4()}}
+
+	// Verify intent cleanup error is propagated to caller.
+	info := Info{}
+	batcher := newIntentBatcher(func(ctx context.Context, intents []roachpb.Intent) error {
+		return errors.New("having trouble cleaning up intents")
+	}, opts, &info)
+	require.NoError(t, batcher.addAndMaybeFlushIntents(context.Background(), key1, &txn1))
+	require.Error(t, batcher.addAndMaybeFlushIntents(context.Background(), key2, &txn1))
+	require.Equal(t, 0, info.ResolveTotal)
+
+	// Verify that flush propagates error to caller.
+	info = Info{}
+	batcher = newIntentBatcher(func(ctx context.Context, intents []roachpb.Intent) error {
+		return errors.New("having trouble cleaning up intents")
+	}, opts, &info)
+	require.NoError(t, batcher.addAndMaybeFlushIntents(context.Background(), key1, &txn1))
+	require.Error(t, batcher.maybeFlushPendingIntents(context.Background()))
+	require.Equal(t, 0, info.ResolveTotal)
+
+	// Verify that canceled context is propagated even if there's nothing to cleanup.
+	info = Info{}
+	ctx, cancel := context.WithCancel(context.Background())
+	batcher = newIntentBatcher(func(ctx context.Context, intents []roachpb.Intent) error {
+		return nil
+	}, opts, &info)
+	cancel()
+	require.Error(t, batcher.maybeFlushPendingIntents(ctx))
 }

--- a/pkg/kv/kvserver/gc_queue.go
+++ b/pkg/kv/kvserver/gc_queue.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/gc"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/intentresolver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
@@ -463,8 +464,17 @@ func (gcq *gcQueue) process(
 	defer snap.Close()
 
 	intentAgeThreshold := gc.IntentAgeThreshold.Get(&repl.store.ClusterSettings().SV)
+	maxIntentsPerCleanupBatch := gc.MaxIntentsPerCleanupBatch.Get(&repl.store.ClusterSettings().SV)
+	maxIntentKeyBytesPerCleanupBatch := gc.MaxIntentKeyBytesPerCleanupBatch.Get(&repl.store.ClusterSettings().SV)
 
-	info, err := gc.Run(ctx, desc, snap, gcTimestamp, newThreshold, intentAgeThreshold, *zone.GC,
+	info, err := gc.Run(ctx, desc, snap, gcTimestamp, newThreshold,
+		gc.RunOptions{
+			IntentAgeThreshold:                     intentAgeThreshold,
+			MaxIntentsPerIntentCleanupBatch:        maxIntentsPerCleanupBatch,
+			MaxIntentKeyBytesPerIntentCleanupBatch: maxIntentKeyBytesPerCleanupBatch,
+			MaxTxnsPerIntentCleanupBatch:           intentresolver.MaxTxnsPerIntentCleanupBatch,
+		},
+		*zone.GC,
 		&replicaGCer{repl: repl},
 		func(ctx context.Context, intents []roachpb.Intent) error {
 			intentCount, err := repl.store.intentResolver.

--- a/pkg/kv/kvserver/gc_queue_test.go
+++ b/pkg/kv/kvserver/gc_queue_test.go
@@ -571,7 +571,7 @@ func TestGCQueueProcess(t *testing.T) {
 
 		now := tc.Clock().Now()
 		newThreshold := gc.CalculateThreshold(now, *zone.GC)
-		return gc.Run(ctx, desc, snap, now, newThreshold, intentAgeThreshold, *zone.GC,
+		return gc.Run(ctx, desc, snap, now, newThreshold, gc.RunOptions{IntentAgeThreshold: intentAgeThreshold}, *zone.GC,
 			gc.NoopGCer{},
 			func(ctx context.Context, intents []roachpb.Intent) error {
 				return nil

--- a/pkg/kv/kvserver/intentresolver/intent_resolver.go
+++ b/pkg/kv/kvserver/intentresolver/intent_resolver.go
@@ -73,11 +73,11 @@ const (
 	// ResumeSpan and the batcher will send a new range request.
 	intentResolverRangeRequestSize = 200
 
-	// cleanupIntentsTxnsPerBatch is the number of transactions whose
+	// MaxTxnsPerIntentCleanupBatch is the number of transactions whose
 	// corresponding intents will be resolved at a time. Intents are batched
 	// by transaction to avoid timeouts while resolving intents and ensure that
 	// progress is made.
-	cleanupIntentsTxnsPerBatch = 100
+	MaxTxnsPerIntentCleanupBatch = 100
 
 	// defaultGCBatchIdle is the default duration which the gc request batcher
 	// will wait between requests for a range before sending it.
@@ -499,7 +499,7 @@ func (ir *IntentResolver) CleanupIntents(
 		var i int
 		for i = 0; i < len(unpushed); i++ {
 			if curTxn := &unpushed[i].Txn; curTxn.ID != prevTxnID {
-				if len(pushTxns) == cleanupIntentsTxnsPerBatch {
+				if len(pushTxns) >= MaxTxnsPerIntentCleanupBatch {
 					break
 				}
 				prevTxnID = curTxn.ID


### PR DESCRIPTION
Backport 1/1 commits from #65847.

/cc @cockroachdb/release

---

Previously, gc would create a single batch of intent from all found
transactions and pass them to intent resolver.
This operation was causing out of memory in degenerate cased with
too many intents.
To address this, batching is added to gc so that intents are grouped
together in smaller batches to minimize transient memory usage during
cleanup. Maximum size of the batch is controlled by
*kv.gc.intent_cleanup_batch_size* setting.

Release note: None

Release justification: this is a fix for OOM during GC.

Resolves #65400
