### PR TITLE
release-21.1: workload/schemachange: "fix" workload

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -347,6 +347,7 @@ ALL_TESTS = [
     "//pkg/workload/cli:cli_test",
     "//pkg/workload/faker:faker_test",
     "//pkg/workload/movr:movr_test",
+    "//pkg/workload/schemachange:schemachange_test",
     "//pkg/workload/tpcc:tpcc_test",
     "//pkg/workload/workloadimpl:workloadimpl_test",
     "//pkg/workload/workloadsql:workloadsql_test",

--- a/pkg/sql/catalog/lease/helpers_test.go
+++ b/pkg/sql/catalog/lease/helpers_test.go
@@ -269,7 +269,8 @@ func (m *Manager) Publish(
 	updates := func(_ *kv.Txn, descs map[descpb.ID]catalog.MutableDescriptor) error {
 		desc, ok := descs[id]
 		if !ok {
-			return errors.AssertionFailedf("required descriptor with ID %d not provided to update closure", id)
+			return errors.AssertionFailedf(
+				"required descriptor with ID %d not provided to update closure", id)
 		}
 		return update(desc)
 	}

--- a/pkg/sql/drop_view.go
+++ b/pkg/sql/drop_view.go
@@ -196,7 +196,7 @@ func (p *planner) dropViewImpl(
 		dependencyDesc, err := p.Descriptors().GetMutableTableVersionByID(ctx, depID, p.txn)
 		if err != nil {
 			return cascadeDroppedViews,
-				errors.Errorf("error resolving dependency relation ID %d: %v", depID, err)
+				errors.Wrapf(err, "error resolving dependency relation ID %d", depID)
 		}
 		// The dependency is also being deleted, so we don't have to remove the
 		// references.

--- a/pkg/workload/schemachange/BUILD.bazel
+++ b/pkg/workload/schemachange/BUILD.bazel
@@ -65,5 +65,6 @@ go_test(
         "//pkg/workload",
         "//pkg/workload/histogram",
         "@com_github_stretchr_testify//require",
+        "@org_golang_x_sync//errgroup",
     ],
 )

--- a/pkg/workload/schemachange/BUILD.bazel
+++ b/pkg/workload/schemachange/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 load("//build:STRINGER.bzl", "stringer")
 
 go_library(
@@ -42,4 +42,28 @@ stringer(
     name = "gen-optype-stringer",
     src = "operation_generator.go",
     typ = "opType",
+)
+
+go_test(
+    name = "schemachange_test",
+    srcs = [
+        "main_test.go",
+        "schema_change_external_test.go",
+    ],
+    deps = [
+        "//pkg/base",
+        "//pkg/ccl",
+        "//pkg/security",
+        "//pkg/security/securitytest",
+        "//pkg/server",
+        "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
+        "//pkg/testutils/sqlutils",
+        "//pkg/testutils/testcluster",
+        "//pkg/util/leaktest",
+        "//pkg/util/randutil",
+        "//pkg/workload",
+        "//pkg/workload/histogram",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/pkg/workload/schemachange/error_screening.go
+++ b/pkg/workload/schemachange/error_screening.go
@@ -98,6 +98,7 @@ func tableHasDependencies(tx *pgx.Tx, tableName *tree.TableName) (bool, error) {
                             ns.oid = c.relnamespace
                      WHERE c.relname = $1 AND ns.nspname = $2
                 )
+           AND fd.descriptor_id != fd.dependedonby_id
        )
 	`, tableName.Object(), tableName.Schema())
 }

--- a/pkg/workload/schemachange/error_screening.go
+++ b/pkg/workload/schemachange/error_screening.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/errors"
 	"github.com/jackc/pgx"
 )
 
@@ -74,7 +75,7 @@ func tableHasRows(tx *pgx.Tx, tableName *tree.TableName) (bool, error) {
 
 func scanBool(tx *pgx.Tx, query string, args ...interface{}) (b bool, err error) {
 	err = tx.QueryRow(query, args...).Scan(&b)
-	return b, err
+	return b, errors.Wrapf(err, "scanBool: %q %q", query, args)
 }
 
 func schemaExists(tx *pgx.Tx, schemaName string) (bool, error) {
@@ -307,7 +308,7 @@ func violatesUniqueConstraintsHelper(
 func scanStringArrayRows(tx *pgx.Tx, query string, args ...interface{}) ([][]string, error) {
 	rows, err := tx.Query(query, args...)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "scanStringArrayRows: %q %q", query, args)
 	}
 	defer rows.Close()
 
@@ -316,12 +317,12 @@ func scanStringArrayRows(tx *pgx.Tx, query string, args ...interface{}) ([][]str
 		var columnNames []string
 		err := rows.Scan(&columnNames)
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrapf(err, "scan: %q, args %q, scanArgs %q", query, columnNames, args)
 		}
 		results = append(results, columnNames)
 	}
 
-	return results, err
+	return results, nil
 }
 
 func indexExists(tx *pgx.Tx, tableName *tree.TableName, indexName string) (bool, error) {
@@ -367,7 +368,7 @@ func columnsStoredInPrimaryIdx(
 
 func scanStringArray(tx *pgx.Tx, query string, args ...interface{}) (b []string, err error) {
 	err = tx.QueryRow(query, args...).Scan(&b)
-	return b, err
+	return b, errors.Wrapf(err, "scanStringArray %q %q", query, args)
 }
 
 // canApplyUniqueConstraint checks if the rows in a table are unique with respect

--- a/pkg/workload/schemachange/error_screening.go
+++ b/pkg/workload/schemachange/error_screening.go
@@ -472,15 +472,19 @@ func constraintIsUnique(
 }
 
 func columnIsComputed(tx *pgx.Tx, tableName *tree.TableName, columnName string) (bool, error) {
+	// Note that we COALESCE because the column may not exist.
 	return scanBool(tx, `
-     SELECT (
-			 SELECT is_generated
-				 FROM information_schema.columns
-				WHERE table_schema = $1
-				  AND table_name = $2
-				  AND column_name = $3
-            )
-	         = 'YES'
+     SELECT COALESCE(
+        (
+            SELECT is_generated
+              FROM information_schema.columns
+             WHERE table_schema = $1
+               AND table_name = $2
+               AND column_name = $3
+        )
+        = 'YES',
+        false
+       );
 `, tableName.Schema(), tableName.Object(), columnName)
 }
 

--- a/pkg/workload/schemachange/main_test.go
+++ b/pkg/workload/schemachange/main_test.go
@@ -1,0 +1,34 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package schemachange_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+func TestMain(m *testing.M) {
+	security.SetAssetLoader(securitytest.EmbeddedAssets)
+	randutil.SeedForTests()
+	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
+
+	os.Exit(m.Run())
+}
+
+//go:generate ../../util/leaktest/add-leaktest.sh *_test.go

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -1768,7 +1768,7 @@ func (og *operationGenerator) getTableColumns(
 `, tableName)
 	rows, err := tx.Query(q)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "getting table columns from %s", tableName)
 	}
 	defer rows.Close()
 	var typNames []string
@@ -1855,7 +1855,7 @@ ORDER BY random()
 	var col column
 	var typ string
 	if err := tx.QueryRow(q).Scan(&col.name, &typ, &col.nullable); err != nil {
-		return column{}, err
+		return column{}, errors.Wrapf(err, "randColumnWithMeta: %q", q)
 	}
 
 	var err error
@@ -2405,7 +2405,7 @@ func (og *operationGenerator) newUniqueSeqNum() int64 {
 func (og *operationGenerator) typeFromTypeName(tx *pgx.Tx, typeName string) (*types.T, error) {
 	stmt, err := parser.ParseOne(fmt.Sprintf("SELECT 'placeholder'::%s", typeName))
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "typeFromTypeName: %s", typeName)
 	}
 	typ, err := tree.ResolveType(
 		context.Background(),
@@ -2413,7 +2413,7 @@ func (og *operationGenerator) typeFromTypeName(tx *pgx.Tx, typeName string) (*ty
 		&txTypeResolver{tx: tx},
 	)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "ResolveType: %v", typeName)
 	}
 	return typ, nil
 }

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -186,7 +186,7 @@ var opWeights = []int{
 	createView:              1,
 	createEnum:              1,
 	createSchema:            1,
-	dropColumn:              1,
+	dropColumn:              0,
 	dropColumnDefault:       1,
 	dropColumnNotNull:       1,
 	dropColumnStored:        1,
@@ -204,7 +204,7 @@ var opWeights = []int{
 	setColumnDefault:        1,
 	setColumnNotNull:        1,
 	setColumnType:           1,
-	insertRow:               1,
+	insertRow:               0,
 	validate:                2, // validate twice more often
 }
 

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -2358,9 +2358,14 @@ func (og *operationGenerator) dropSchema(tx *pgx.Tx) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	crossReferences, err := schemaContainsTypesWithCrossSchemaReferences(tx, schemaName)
+	if err != nil {
+		return "", err
+	}
 	codesWithConditions{
 		{pgcode.UndefinedSchema, !schemaExists},
 		{pgcode.InvalidSchemaName, schemaName == tree.PublicSchema},
+		{pgcode.FeatureNotSupported, crossReferences},
 	}.add(og.expectedExecErrors)
 
 	return fmt.Sprintf(`DROP SCHEMA "%s" CASCADE`, schemaName), nil

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -213,46 +213,28 @@ var opWeights = []int{
 // change constructed. Constructing a random schema change may require a few
 // stochastic attempts and if verbosity is >= 2 the unsuccessful attempts are
 // recorded in `log` to help with debugging of the workload.
-func (og *operationGenerator) randOp(tx *pgx.Tx) (stmt string, noops []string, err error) {
-	savepointCount := 0
+func (og *operationGenerator) randOp(tx *pgx.Tx) (stmt string, err error) {
+
 	for {
 		op := opType(og.params.ops.Int())
 		og.resetOpState()
+		stmt, err = opFuncs[op](og, tx)
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				continue
+			}
 
-		// Savepoints are used to prevent an infinite loop from occurring as a result of the transaction
-		// becoming aborted by an op function. If a transaction becomes aborted, no op function will be able
-		// to complete without error because all op functions rely on the passed transaction to introspect the database.
-		// With sufficient verbosity, any failed op functions will be logged as NOOPs below for debugging purposes.
-		//
-		// For example, functions such as getTableColumns() can abort the transaction if called with
-		// a non existing table. getTableColumns() is used by op functions such as createIndex().
-		// Op functions normally ensure that a table exists by checking system tables before passing the
-		// table to getTableColumns(). However, due to bugs such as #57494, system tables
-		// may be inaccurate and can cause getTableColumns() to be called with a non-existing table. This
-		// will result in an aborted transaction. Wrapping calls to op functions with savepoints will protect
-		// the transaction from being aborted by spurious errors such as in the above example.
-		savepointCount++
-		if _, err := tx.Exec(fmt.Sprintf(`SAVEPOINT s%d`, savepointCount)); err != nil {
-			return "", noops, err
+			return "", err
 		}
+		// Screen for schema change after write in the same transaction.
+		og.checkIfOpViolatesDDLAfterWrite(op)
 
-		stmt, err := opFuncs[op](og, tx)
-
-		if err == nil {
-			// Screen for schema change after write in the same transaction.
-			og.checkIfOpViolatesDDLAfterWrite(op)
-
-			// Add candidateExpectedCommitErrors to expectedCommitErrors
-			og.expectedCommitErrors.merge(og.candidateExpectedCommitErrors)
-
-			return stmt, noops, err
-		}
-		if _, err := tx.Exec(fmt.Sprintf(`ROLLBACK TO SAVEPOINT s%d`, savepointCount)); err != nil {
-			return "", noops, err
-		}
-
-		noops = append(noops, fmt.Sprintf("NOOP: %s -> %v", op, err))
+		// Add candidateExpectedCommitErrors to expectedCommitErrors
+		og.expectedCommitErrors.merge(og.candidateExpectedCommitErrors)
+		break
 	}
+
+	return stmt, err
 }
 
 func (og *operationGenerator) checkIfOpViolatesDDLAfterWrite(ot opType) {

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -2204,7 +2204,7 @@ func (og *operationGenerator) randView(
 		}
 
 		q := fmt.Sprintf(`
-		  SELECT schema_name, table_name
+		  SELECT table_name
 		    FROM [SHOW TABLES]
 		   WHERE table_name LIKE 'view%%'
 				 AND schema_name = '%s'

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -617,7 +617,9 @@ func (og *operationGenerator) createSequence(tx *pgx.Tx) (string, error) {
 					Name:          tree.SeqOptOwnedBy,
 					ColumnItemVal: &tree.ColumnItem{TableName: table.ToUnresolvedObjectName(), ColumnName: "IrrelevantColumnName"}},
 			)
-			og.expectedExecErrors.add(pgcode.UndefinedTable)
+			if !(sequenceExists && ifNotExists) { // IF NOT EXISTS prevents the error
+				og.expectedExecErrors.add(pgcode.UndefinedTable)
+			}
 		} else {
 			column, err := og.randColumn(tx, *table, og.pctExisting(true))
 			if err != nil {

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -974,8 +974,13 @@ func (og *operationGenerator) dropColumn(tx *pgx.Tx) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	columnIsInDroppingIndex, err := columnIsInDroppingIndex(tx, tableName, columnName)
+	if err != nil {
+		return "", err
+	}
 
 	codesWithConditions{
+		{code: pgcode.ObjectNotInPrerequisiteState, condition: columnIsInDroppingIndex},
 		{code: pgcode.UndefinedColumn, condition: !columnExists},
 		{code: pgcode.InvalidColumnReference, condition: colIsPrimaryKey},
 		{code: pgcode.DependentObjectsStillExist, condition: columnIsDependedOn},

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -1134,6 +1134,14 @@ func (og *operationGenerator) dropConstraint(tx *pgx.Tx) (string, error) {
 		og.expectedExecErrors.add(pgcode.FeatureNotSupported)
 	}
 
+	constraintBeingDropped, err := constraintInDroppingState(tx, tableName, constraintName)
+	if err != nil {
+		return "", err
+	}
+	if constraintBeingDropped {
+		og.expectedExecErrors.add(pgcode.FeatureNotSupported)
+	}
+
 	return fmt.Sprintf(`ALTER TABLE %s DROP CONSTRAINT "%s"`, tableName, constraintName), nil
 }
 

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -1563,6 +1563,13 @@ func (og *operationGenerator) setColumnNotNull(tx *pgx.Tx) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	constraintBeingAdded, err := columnNotNullConstraintInMutation(tx, tableName, columnName)
+	if err != nil {
+		return "", err
+	}
+	if constraintBeingAdded {
+		og.expectedExecErrors.add(pgcode.ObjectNotInPrerequisiteState)
+	}
 
 	if !columnExists {
 		og.expectedExecErrors.add(pgcode.UndefinedColumn)

--- a/pkg/workload/schemachange/schema_change_external_test.go
+++ b/pkg/workload/schemachange/schema_change_external_test.go
@@ -1,0 +1,96 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package schemachange_test
+
+import (
+	"context"
+	gosql "database/sql"
+	"fmt"
+	"io/ioutil"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	_ "github.com/cockroachdb/cockroach/pkg/ccl"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/workload"
+	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWorkload(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	skip.UnderStressRace(t, "times out")
+
+	dir, err := ioutil.TempDir("", t.Name())
+	require.NoError(t, err)
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			ExternalIODir: dir,
+		},
+	})
+
+	defer tc.Stopper().Stop(ctx)
+	m, err := workload.Get("schemachange")
+	require.NoError(t, err)
+	wl := m.New().(interface {
+		workload.Opser
+		workload.Flagser
+	})
+	tdb := sqlutils.MakeSQLRunner(tc.ServerConn(0))
+	reg := histogram.NewRegistry(20 * time.Second)
+	tdb.Exec(t, "CREATE USER testuser")
+	tdb.Exec(t, "CREATE DATABASE schemachange")
+	tdb.Exec(t, "GRANT admin TO testuser")
+	tdb.Exec(t, "SET CLUSTER SETTING sql.trace.log_statement_execute = true")
+
+	// Grab a backup and also print the namespace and descriptor tables upon
+	// failure.
+	// It's not clear how helpful this actually is but it doesn't hurt.
+	printRows := func(rows *gosql.Rows) {
+		t.Helper()
+		mat, err := sqlutils.RowsToStrMatrix(rows)
+		require.NoError(t, err)
+		fmt.Printf("rows:\n%s", sqlutils.MatrixToStr(mat))
+	}
+	defer func() {
+		if !t.Failed() {
+			return
+		}
+		printRows(tdb.Query(t, "SELECT id, encode(descriptor, 'hex') FROM system.descriptor"))
+		printRows(tdb.Query(t, "SELECT * FROM system.namespace"))
+		tdb.Exec(t, "BACKUP DATABASE schemachange TO 'nodelocal://0/backup'")
+		t.Logf("backup in %s", dir)
+	}()
+
+	pgURL, cleanup := sqlutils.PGUrl(t, tc.Server(0).ServingSQLAddr(), t.Name(), url.User("testuser"))
+	defer cleanup()
+	require.NoError(t, wl.Flags().Parse([]string{
+		"--concurrency", "1",
+		"--verbose", "2",
+	}))
+
+	ql, err := wl.Ops(ctx, []string{pgURL.String()}, reg)
+	require.NoError(t, err)
+
+	const N = 100
+	for i := 0; i < N; i++ {
+		if err := ql.WorkerFns[0](ctx); err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -408,7 +408,7 @@ func (w *schemaChangeWorker) run(_ context.Context) error {
 	}
 
 	// Release log entry locks if holding all.
-	w.releaseLocksIfHeld()
+	defer w.releaseLocksIfHeld()
 
 	// Run between 1 and maxOpsPerWorker schema change operations.
 	start := timeutil.Now()

--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -340,22 +340,18 @@ func (w *schemaChangeWorker) runInTxn(tx *pgx.Tx) error {
 			break
 		}
 
-		op, noops, err := w.opGen.randOp(tx)
-		if w.logger.verbose >= 2 {
-			for _, noop := range noops {
-				w.logger.writeLog(noop)
-			}
-		}
+		op, err := w.opGen.randOp(tx)
 
-		w.logger.addExpectedErrors(w.opGen.expectedExecErrors, w.opGen.expectedCommitErrors)
-
-		if err != nil {
+		if pgErr := (pgx.PgError{}); errors.As(err, &pgErr) && pgcode.MakeCode(pgErr.Code) == pgcode.SerializationFailure {
+			return errors.Mark(err, errRunInTxnRbkSentinel)
+		} else if err != nil {
 			return errors.Mark(
 				errors.Wrap(err, "***UNEXPECTED ERROR; Failed to generate a random operation"),
 				errRunInTxnFatalSentinel,
 			)
 		}
 
+		w.logger.addExpectedErrors(w.opGen.expectedExecErrors, w.opGen.expectedCommitErrors)
 		w.logger.writeLog(op)
 		if !w.dryRun {
 			start := timeutil.Now()


### PR DESCRIPTION
NOTE: These are testing-only changes, to get the schemachange workload in a better place on 21.1.

Backport 20/20 commits from #59635.

/cc @cockroachdb/release

---

This is a variety of commits which fixes bugs in the schemachange workload. It also disables a number of features.
