### PR TITLE
roachtest: re-mark `pkg/cmd/roachtest` tests as `broken_in_bazel`

### DIFF
--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -59,6 +59,7 @@ go_test(
         "test_test.go",
     ],
     embed = [":roachtest_lib"],
+    tags = ["broken_in_bazel"],
     deps = [
         "//pkg/cmd/roachtest/cluster",
         "//pkg/cmd/roachtest/logger",


### PR DESCRIPTION
`faa4c2ccdaeca01eca3ccee29a8a64973cf8b043` removed this tag, which
caused all Bazel test runs to begin failing.

Closes #67595.

Release note: None