### PR TITLE
server: re-load cluster settings on each engine checker loop

### DIFF
--- a/pkg/server/node_engine_health.go
+++ b/pkg/server/node_engine_health.go
@@ -27,8 +27,6 @@ import (
 func (n *Node) startAssertEngineHealth(
 	ctx context.Context, engines []storage.Engine, settings *cluster.Settings,
 ) {
-	maxSyncDuration := storage.MaxSyncDuration.Get(&settings.SV)
-	fatalOnExceeded := storage.MaxSyncDurationFatalOnExceeded.Get(&settings.SV)
 	_ = n.stopper.RunAsyncTask(ctx, "engine-health", func(ctx context.Context) {
 		t := timeutil.NewTimer()
 		t.Reset(0)
@@ -38,6 +36,8 @@ func (n *Node) startAssertEngineHealth(
 			case <-t.C:
 				t.Read = true
 				t.Reset(10 * time.Second)
+				maxSyncDuration := storage.MaxSyncDuration.Get(&settings.SV)
+				fatalOnExceeded := storage.MaxSyncDurationFatalOnExceeded.Get(&settings.SV)
 				n.assertEngineHealth(ctx, engines, maxSyncDuration, fatalOnExceeded)
 			case <-n.stopper.ShouldQuiesce():
 				return


### PR DESCRIPTION
Cluster settings can change, but they were read only once before going
into an infinite probing loop. They should have been re-loaded on each
iteration, which they now are.

Noticed this randomly.

Release note: None
