### PR TITLE
sql: add sql shell telemetry counter

### DIFF
--- a/pkg/cli/sql_shell_cmd.go
+++ b/pkg/cli/sql_shell_cmd.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/cli/clisqlshell"
 	"github.com/cockroachdb/cockroach/pkg/server/pgurl"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catconstants"
 	"github.com/cockroachdb/errors"
 	"github.com/spf13/cobra"
 )
@@ -51,7 +52,7 @@ func runTerm(cmd *cobra.Command, args []string) (resErr error) {
 		fmt.Print(welcomeMessage)
 	}
 
-	conn, err := makeSQLClient("cockroach sql", useDefaultDb)
+	conn, err := makeSQLClient(catconstants.InternalSQLAppName, useDefaultDb)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/catalog/catconstants/constants.go
+++ b/pkg/sql/catalog/catconstants/constants.go
@@ -30,6 +30,10 @@ const InternalAppNamePrefix = ReportableAppNamePrefix + "internal"
 // DelegatedAppNamePrefix should be scrubbed in reporting.
 const DelegatedAppNamePrefix = "$$ "
 
+// InternalSQLAppName is the application_name used by
+// the cockroach CLI by default
+const InternalSQLAppName = "cockroach sql"
+
 // Oid for virtual database and table.
 const (
 	CrdbInternalID = math.MaxUint32 - iota

--- a/pkg/sql/pgwire/BUILD.bazel
+++ b/pkg/sql/pgwire/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//pkg/settings/cluster",
         "//pkg/sql",
         "//pkg/sql/catalog/catalogkeys",
+        "//pkg/sql/catalog/catconstants",
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/lex",
         "//pkg/sql/parser",

--- a/pkg/sql/sqltelemetry/session.go
+++ b/pkg/sql/sqltelemetry/session.go
@@ -25,6 +25,10 @@ var DefaultIntSize4Counter = telemetry.GetCounterOnce("sql.default_int_size.4")
 // to a non-empty string.
 var ForceSavepointRestartCounter = telemetry.GetCounterOnce("sql.force_savepoint_restart")
 
+// CockroachShellCounter is to be incremented every time a
+// client uses the Cockroach SQL shell to connect to CockroachDB
+var CockroachShellCounter = telemetry.GetCounterOnce("sql.connection.cockroach_cli")
+
 // UnimplementedSessionVarValueCounter is to be incremented every time
 // a client attempts to set a compatitibility session var to an
 // unsupported value.

--- a/pkg/sql/telemetry_test.go
+++ b/pkg/sql/telemetry_test.go
@@ -11,14 +11,21 @@
 package sql_test
 
 import (
+	"context"
+	gosql "database/sql"
+	"net/url"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/kvccl/kvtenantccl"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltestutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
 )
 
 // Dummy import to pull in kvtenantccl. This allows us to start tenants.
@@ -35,4 +42,46 @@ func TestTelemetry(t *testing.T) {
 		[]base.TestServerArgs{{}},
 		true, /* testTenant */
 	)
+}
+
+func TestTelemetryRecordCockroachShell(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	cluster := serverutils.StartNewTestCluster(
+		t,
+		1,
+		base.TestClusterArgs{},
+	)
+	defer cluster.Stopper().Stop(context.Background())
+
+	pgUrl, cleanupFn := sqlutils.PGUrl(
+		t,
+		cluster.Server(0).ServingSQLAddr(),
+		"TestTelemetryRecordCockroachShell",
+		url.User("root"),
+	)
+	defer cleanupFn()
+	q := pgUrl.Query()
+
+	q.Add("application_name", catconstants.ReportableAppNamePrefix+catconstants.InternalSQLAppName)
+	pgUrl.RawQuery = q.Encode()
+
+	db, err := gosql.Open("postgres", pgUrl.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	var appName string
+	err = db.QueryRow("SHOW application_name").Scan(&appName)
+	require.NoError(t, err)
+	require.Equal(t, catconstants.ReportableAppNamePrefix+catconstants.InternalSQLAppName, appName)
+
+	var counter int
+	err = db.QueryRow(
+		"SELECT usage_count FROM crdb_internal.feature_usage WHERE feature_name = 'sql.connection.cockroach_cli'",
+	).Scan(&counter)
+	require.NoError(t, err)
+	require.Equal(t, 1, counter)
+
 }


### PR DESCRIPTION
Fixes #62208

This change allows us to keep track of
connections made using our internal SQl shell.

Release note: None