### PR TITLE
build: update TeamCity secondary go to 1.15.14

### DIFF
--- a/build/packer/teamcity-agent.sh
+++ b/build/packer/teamcity-agent.sh
@@ -51,9 +51,9 @@ tar -C /usr/local -zxf /tmp/go.tgz && rm /tmp/go.tgz
 
 # Install the older version in parallel in order to run the acceptance test on older branches
 # TODO: Remove this when 21.1 is EOL
-curl -fsSL https://dl.google.com/go/go1.15.11.linux-amd64.tar.gz > /tmp/go_old.tgz
+curl -fsSL https://dl.google.com/go/go1.15.14.linux-amd64.tar.gz > /tmp/go_old.tgz
 sha256sum -c - <<EOF
-8825b72d74b14e82b54ba3697813772eb94add3abf70f021b6bdebe193ed01ec /tmp/go_old.tgz
+6f5410c113b803f437d7a1ee6f8f124100e536cc7361920f7e640fedf7add72d /tmp/go_old.tgz
 EOF
 mkdir -p /usr/local/go1.15
 tar -C /usr/local/go1.15 --strip-components=1 -zxf /tmp/go_old.tgz && rm /tmp/go_old.tgz


### PR DESCRIPTION
This updates the TeamCity agent go version to 1.15.14

Release note: None