### PR TITLE
release-21.1: vendor: bump Pebble to a61576f22457

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -518,8 +518,8 @@ def go_deps():
         name = "com_github_cockroachdb_pebble",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/cockroachdb/pebble",
-        sum = "h1:o0DLnNsZJLbeduC+0OaD65YHQrt7cwTKYX/oq+kC/eM=",
-        version = "v0.0.0-20210516191704-f7a68a4d19a4",
+        sum = "h1:Qdl2ida1OhpTIYAznj0aWEulZjqgdsK1qLrfop/joBs=",
+        version = "v0.0.0-20210714153122-a61576f22457",
     )
     go_repository(
         name = "com_github_cockroachdb_redact",

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f
-	github.com/cockroachdb/pebble v0.0.0-20210516191704-f7a68a4d19a4
+	github.com/cockroachdb/pebble v0.0.0-20210714153122-a61576f22457
 	github.com/cockroachdb/redact v1.0.9
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2

--- a/go.sum
+++ b/go.sum
@@ -197,8 +197,8 @@ github.com/cockroachdb/grpc-gateway v1.14.6-0.20200519165156-52697fc4a249 h1:pZu
 github.com/cockroachdb/grpc-gateway v1.14.6-0.20200519165156-52697fc4a249/go.mod h1:UJ0EZAp832vCd54Wev9N1BMKEyvcZ5+IM0AwDrnlkEc=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f h1:o/kfcElHqOiXqcou5a3rIlMc7oJbMQkeLk0VQJ7zgqY=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/cockroachdb/pebble v0.0.0-20210516191704-f7a68a4d19a4 h1:o0DLnNsZJLbeduC+0OaD65YHQrt7cwTKYX/oq+kC/eM=
-github.com/cockroachdb/pebble v0.0.0-20210516191704-f7a68a4d19a4/go.mod h1:1XpB4cLQcF189RAcWi4gUc110zJgtOfT7SVNGY8sOe0=
+github.com/cockroachdb/pebble v0.0.0-20210714153122-a61576f22457 h1:Qdl2ida1OhpTIYAznj0aWEulZjqgdsK1qLrfop/joBs=
+github.com/cockroachdb/pebble v0.0.0-20210714153122-a61576f22457/go.mod h1:1XpB4cLQcF189RAcWi4gUc110zJgtOfT7SVNGY8sOe0=
 github.com/cockroachdb/redact v1.0.8/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/redact v1.0.9 h1:sjlUvGorKMIVQfo+w2RqDi5eewCHn453C/vdIXMzjzI=
 github.com/cockroachdb/redact v1.0.9/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=


### PR DESCRIPTION
```
a61576f2 compaction: remove nonzero-seqnum splitting logic
```

Release note (bug fix): Fix a storage-level bug where Pebble would
occasionally create excessively large sstables, causing poor compaction
performance and high read-amplification. This was especially likely
after a manual offline compaction (cockroach debug compact).

Release justification: Fixes a bug that causes high read amplfiication,
which dramatically reduces performance and may impact store
availability.