### PR TITLE
backfill: fix backfills for indexes on non-null virtual columns

### DIFF
--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -702,7 +702,7 @@ func (ib *IndexBackfiller) initIndexes(desc catalog.TableDescriptor) util.FastIn
 			ib.added = append(ib.added, idx)
 			for i := range ib.cols {
 				id := ib.cols[i].GetID()
-				if colIDs.Contains(id) && i < len(desc.PublicColumns()) {
+				if colIDs.Contains(id) && i < len(desc.PublicColumns()) && !ib.cols[i].IsVirtual() {
 					valNeededForCol.Add(i)
 				}
 			}

--- a/pkg/sql/logictest/testdata/logic_test/virtual_columns
+++ b/pkg/sql/logictest/testdata/logic_test/virtual_columns
@@ -1193,3 +1193,18 @@ SELECT * FROM t_65915;
 
 statement ok
 DROP TABLE t_65915
+
+# Test that backfills on indexes with non-null virtual columns work.
+subtest 67528
+
+statement ok
+CREATE TABLE t67528 (
+  s STRING,
+  v STRING AS (lower(s)) VIRTUAL NOT NULL
+)
+
+statement ok
+INSERT INTO t67528 (s) VALUES ('')
+
+statement ok
+CREATE INDEX ON t67528 (v DESC)


### PR DESCRIPTION
Refactoring in #65514 broke backfills for indexes that include non-null
virtual columns. This specific case was not tested so it was not caught
earlier. This commit fixes the issue and adds a test.

Fixes #67528

There is no release note because this bug was not included in any prior
releases.

Release note: None