### PR TITLE
release-21.1: colrpc: add memory accounting for temporary data in inbox/outbox

### DIFF
--- a/pkg/sql/colflow/colrpc/inbox.go
+++ b/pkg/sql/colflow/colrpc/inbox.go
@@ -355,9 +355,11 @@ func (i *Inbox) Next(ctx context.Context) coldata.Batch {
 		// TODO(yuzefovich): refactor this.
 		const maxBatchMemSize = math.MaxInt64
 		i.scratch.b, _ = i.allocator.ResetMaybeReallocate(i.typs, i.scratch.b, batchLength, maxBatchMemSize)
-		if err := i.converter.ArrowToBatch(i.scratch.data, batchLength, i.scratch.b); err != nil {
-			colexecerror.InternalError(err)
-		}
+		i.allocator.PerformOperation(i.scratch.b.ColVecs(), func() {
+			if err := i.converter.ArrowToBatch(i.scratch.data, batchLength, i.scratch.b); err != nil {
+				colexecerror.InternalError(err)
+			}
+		})
 		atomic.AddInt64(&i.statsAtomics.rowsRead, int64(i.scratch.b.Length()))
 		return i.scratch.b
 	}

--- a/pkg/sql/colflow/colrpc/inbox.go
+++ b/pkg/sql/colflow/colrpc/inbox.go
@@ -343,7 +343,11 @@ func (i *Inbox) Next(ctx context.Context) coldata.Batch {
 			// Protect against Deserialization panics by skipping empty messages.
 			continue
 		}
-		atomic.AddInt64(&i.statsAtomics.bytesRead, int64(len(m.Data.RawBytes)))
+		numSerializedBytes := int64(len(m.Data.RawBytes))
+		atomic.AddInt64(&i.statsAtomics.bytesRead, numSerializedBytes)
+		// Update the allocator since we're holding onto the serialized bytes
+		// for now.
+		i.allocator.AdjustMemoryUsage(numSerializedBytes)
 		i.scratch.data = i.scratch.data[:0]
 		batchLength, err := i.serializer.Deserialize(&i.scratch.data, m.Data.RawBytes)
 		// Eagerly throw away the RawBytes memory.
@@ -360,6 +364,10 @@ func (i *Inbox) Next(ctx context.Context) coldata.Batch {
 				colexecerror.InternalError(err)
 			}
 		})
+		// At this point, we have lost all references to the serialized bytes
+		// (because ArrowToBatch nils out elements in i.scratch.data once
+		// processed), so we update the allocator accordingly.
+		i.allocator.AdjustMemoryUsage(-numSerializedBytes)
 		atomic.AddInt64(&i.statsAtomics.rowsRead, int64(i.scratch.b.Length()))
 		return i.scratch.b
 	}

--- a/pkg/sql/colmem/allocator.go
+++ b/pkg/sql/colmem/allocator.go
@@ -315,7 +315,7 @@ func (a *Allocator) AdjustMemoryUsage(delta int64) {
 		if err := a.acc.Grow(a.ctx, delta); err != nil {
 			colexecerror.InternalError(err)
 		}
-	} else {
+	} else if delta < 0 {
 		a.ReleaseMemory(-delta)
 	}
 }


### PR DESCRIPTION
Backport 2/2 commits from #67577.

/cc @cockroachdb/release

Release justification: low risk bug fix to memory accounting.

---

**colrpc: fix memory accounting in inbox a bit**

Previously, we forgot to update the allocator once we have deserialized
the batch in the inbox (i.e. we would register only the original
allocation, upon the batch's creation). This could result in
under-accounting for variable length types, and it is now fixed.

Release note: None

**colrpc: add memory accounting for temporary data in inbox/outbox**

Previously, we were missing the memory accounting for the temporary
usage of serialized/deserialized bytes in the inbox/outbox pair. The
worst offense was that in the outbox we reuse the same scratch Bytes
buffer that is never truncated and can only increase in capacity
throughout the lifetime of the outbox, yet it wasn't accounted for. This
commit fixes those omissions.

Fixes: #67051.

Release note: None
