### PR TITLE
build: patch go against CVE-2021-34558

### DIFF
--- a/build/builder.sh
+++ b/build/builder.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 image=cockroachdb/builder
-version=${USE_BUILDER_IMAGE:-20200818-182851}
+version=${USE_BUILDER_IMAGE:-20210714-111813}
 
 function init() {
   docker build --tag="${image}" "$(dirname "${0}")/builder"

--- a/build/builder/Dockerfile
+++ b/build/builder/Dockerfile
@@ -196,12 +196,14 @@ RUN curl -fsSL https://github.com/Kitware/CMake/releases/download/v3.17.0/cmake-
 # NB: care needs to be taken when updating this version because earlier
 # releases of Go will no longer be run in CI once it is changed. Consider
 # bumping the minimum allowed version of Go in /build/go-version-chech.sh.
+COPY cve-2021-34558.patch /tmp/
 RUN apt-get install -y --no-install-recommends golang \
  && curl -fsSL https://storage.googleapis.com/golang/go1.13.14.src.tar.gz -o golang.tar.gz \
  && echo '197333e97290e9ea8796f738d61019dcba1c377c2f3961fd6a114918ecc7ab06 golang.tar.gz' | sha256sum -c - \
  && tar -C /usr/local -xzf golang.tar.gz \
  && rm golang.tar.gz \
  && cd /usr/local/go/src \
+ && patch -p2 < /tmp/cve-2021-34558.patch \
  && GOROOT_BOOTSTRAP=$(go env GOROOT) CC=clang CXX=clang++ ./make.bash
 
 ENV GOPATH /go

--- a/build/builder/cve-2021-34558.patch
+++ b/build/builder/cve-2021-34558.patch
@@ -1,0 +1,17 @@
+diff -Naubr go.orig/src/crypto/tls/key_agreement.go go/src/crypto/tls/key_agreement.go
+--- go.orig/src/crypto/tls/key_agreement.go	2020-03-19 11:19:14.000000000 -0400
++++ go/src/crypto/tls/key_agreement.go	2021-07-13 23:50:17.000000000 -0400
+@@ -69,7 +69,12 @@
+ 		return nil, nil, err
+ 	}
+ 
+-	encrypted, err := rsa.EncryptPKCS1v15(config.rand(), cert.PublicKey.(*rsa.PublicKey), preMasterSecret)
++	rsaKey, ok := cert.PublicKey.(*rsa.PublicKey)
++
++	if !ok {
++		return nil, nil, errors.New("tls: server certificate contains incorrect key type for selected ciphersuite")
++	}
++	encrypted, err := rsa.EncryptPKCS1v15(config.rand(), rsaKey, preMasterSecret)
+ 	if err != nil {
+ 		return nil, nil, err
+ 	}


### PR DESCRIPTION
This patch updates the builder image to use the patched version of Go.

Release note: None