### PR TITLE
build: don't require latest go for local builds

### DIFF
--- a/build/go-version-check.sh
+++ b/build/go-version-check.sh
@@ -7,7 +7,7 @@
 
 required_version_major=1
 minimum_version_minor=16
-minimum_version_16_patch=6
+minimum_version_16_patch=5
 
 go=${1-go}
 


### PR DESCRIPTION
In #67594 we switched to go 1.16.5, but it's not available via brew yet.
Because we tend to use the brew version to build locally, it would be
better to downgrade the requirements.

Release note: None