### PR TITLE
importccl: support IMPORT INTO for AVRO format on non-target columns with UDT default values

### DIFF
--- a/pkg/ccl/importccl/bench_test.go
+++ b/pkg/ccl/importccl/bench_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -184,7 +185,10 @@ func benchmarkConvertToKVs(b *testing.B, g workload.Generator) {
 				SessionData: &sessiondata.SessionData{},
 				Codec:       keys.SystemSQLCodec,
 			}
-			return wc.Worker(ctx, evalCtx)
+			flowCtx := execinfra.FlowCtx{
+				EvalCtx: evalCtx,
+			}
+			return wc.Worker(ctx, &flowCtx, evalCtx)
 		})
 		for kvBatch := range kvCh {
 			for i := range kvBatch.KVs {

--- a/pkg/ccl/importccl/read_import_avro_test.go
+++ b/pkg/ccl/importccl/read_import_avro_test.go
@@ -18,14 +18,17 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/linkedin/goavro/v2"
@@ -247,14 +250,27 @@ func (th *testHelper) newRecordStream(
 		th.genRecordsData(t, format, numRecords, opts.RecordSeparator, records)
 	}
 
-	avro, err := newAvroInputReader(nil, th.schemaTable, opts, 0, 1, &th.evalCtx)
+	avro, err := newAvroInputReader(nil, th.schemaTable, nil, /* targetCols */
+		opts, 0, 1, &th.evalCtx)
 	require.NoError(t, err)
 	producer, consumer, err := newImportAvroPipeline(avro, &fileReader{Reader: records})
 	require.NoError(t, err)
 
+	ctx := context.Background()
+	evalCtx := th.evalCtx.Copy()
+	s, _, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+	flowCtx := &execinfra.FlowCtx{
+		EvalCtx: evalCtx,
+		Cfg: &execinfra.ServerConfig{
+			DB:       kvDB,
+			Settings: th.settings,
+		},
+	}
+
 	conv, err := row.NewDatumRowConverter(
-		context.Background(), th.schemaTable, nil, th.evalCtx.Copy(), nil,
-		nil /* seqChunkProvider */)
+		ctx, flowCtx, th.schemaTable, nil,
+		evalCtx, nil, nil /* seqChunkProvider */)
 	require.NoError(t, err)
 	return &testRecordStream{
 		producer: producer,
@@ -549,8 +565,6 @@ func BenchmarkBinaryJSONImport(b *testing.B) {
 }
 
 func benchmarkAvroImport(b *testing.B, avroOpts roachpb.AvroOptions, testData string) {
-	ctx := context.Background()
-
 	b.SetBytes(120) // Raw input size. With 8 indexes, expect more on output side.
 
 	stmt, err := parser.ParseOne(`CREATE TABLE stock (
@@ -577,9 +591,17 @@ func benchmarkAvroImport(b *testing.B, avroOpts roachpb.AvroOptions, testData st
 	require.NoError(b, err)
 
 	create := stmt.AST.(*tree.CreateTable)
-	st := cluster.MakeTestingClusterSettings()
 	semaCtx := tree.MakeSemaContext()
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
 	evalCtx := tree.MakeTestingEvalContext(st)
+	defer evalCtx.Stop(ctx)
+	flowCtx := &execinfra.FlowCtx{
+		EvalCtx: &evalCtx,
+		Cfg: &execinfra.ServerConfig{
+			Settings: st,
+		},
+	}
 
 	tableDesc, err := MakeTestingSimpleTableDescriptor(ctx, &semaCtx, st, create, descpb.ID(100), keys.PublicSchemaID, descpb.ID(100), NoFKs, 1)
 	require.NoError(b, err)
@@ -595,7 +617,7 @@ func benchmarkAvroImport(b *testing.B, avroOpts roachpb.AvroOptions, testData st
 	require.NoError(b, err)
 
 	avro, err := newAvroInputReader(kvCh,
-		tableDesc.ImmutableCopy().(catalog.TableDescriptor),
+		tableDesc.ImmutableCopy().(catalog.TableDescriptor), nil, /* targetCols */
 		avroOpts, 0, 0, &evalCtx)
 	require.NoError(b, err)
 
@@ -608,6 +630,6 @@ func benchmarkAvroImport(b *testing.B, avroOpts roachpb.AvroOptions, testData st
 	require.NoError(b, err)
 	b.ResetTimer()
 	require.NoError(
-		b, runParallelImport(ctx, avro.importContext, &importFileContext{}, limitStream, consumer))
+		b, runParallelImport(ctx, flowCtx, avro.importContext, &importFileContext{}, limitStream, consumer))
 	close(kvCh)
 }

--- a/pkg/ccl/importccl/read_import_base.go
+++ b/pkg/ccl/importccl/read_import_base.go
@@ -73,7 +73,7 @@ func runImport(
 	// TODO(adityamaru): Should we just plumb the flowCtx instead of this
 	// assignment.
 	evalCtx.DB = flowCtx.Cfg.DB
-	conv, err := makeInputConverter(ctx, spec, evalCtx, kvCh, seqChunkProvider)
+	conv, err := makeInputConverter(ctx, flowCtx, spec, evalCtx, kvCh, seqChunkProvider)
 	if err != nil {
 		return nil, err
 	}
@@ -103,8 +103,8 @@ func runImport(
 			inputs = spec.Uri
 		}
 
-		return conv.readFiles(ctx, inputs, spec.ResumePos, spec.Format, flowCtx.Cfg.ExternalStorage,
-			spec.User())
+		return conv.readFiles(ctx, flowCtx, inputs, spec.ResumePos, spec.Format,
+			flowCtx.Cfg.ExternalStorage, spec.User())
 	})
 
 	// Ingest the KVs that the producer group emitted to the chan and the row result
@@ -137,7 +137,7 @@ func runImport(
 	return summary, nil
 }
 
-type readFileFunc func(context.Context, *fileReader, int32, int64, chan string) error
+type readFileFunc func(context.Context, *execinfra.FlowCtx, *fileReader, int32, int64, chan string) error
 
 // readInputFile reads each of the passed dataFiles using the passed func. The
 // key part of dataFiles is the unique index of the data file among all files in
@@ -149,6 +149,7 @@ type readFileFunc func(context.Context, *fileReader, int32, int64, chan string) 
 // reported only after each file has been read.
 func readInputFiles(
 	ctx context.Context,
+	flowCtx *execinfra.FlowCtx,
 	dataFiles map[int32]string,
 	resumePos map[int32]int64,
 	format roachpb.IOFileFormat,
@@ -257,7 +258,8 @@ func readInputFiles(
 
 				grp.GoCtx(func(ctx context.Context) error {
 					defer close(rejected)
-					if err := fileFunc(ctx, src, dataFileIndex, resumePos[dataFileIndex], rejected); err != nil {
+					if err := fileFunc(ctx, flowCtx, src, dataFileIndex,
+						resumePos[dataFileIndex], rejected); err != nil {
 						return err
 					}
 					return nil
@@ -267,7 +269,8 @@ func readInputFiles(
 					return errors.Wrapf(err, "%s", dataFile)
 				}
 			} else {
-				if err := fileFunc(ctx, src, dataFileIndex, resumePos[dataFileIndex], nil /* rejected */); err != nil {
+				if err := fileFunc(ctx, flowCtx, src, dataFileIndex,
+					resumePos[dataFileIndex], nil /* rejected */); err != nil {
 					return errors.Wrapf(err, "%s", dataFile)
 				}
 			}
@@ -346,8 +349,9 @@ func (f fileReader) ReadFraction() float32 {
 
 type inputConverter interface {
 	start(group ctxgroup.Group)
-	readFiles(ctx context.Context, dataFiles map[int32]string, resumePos map[int32]int64,
-		format roachpb.IOFileFormat, makeExternalStorage cloud.ExternalStorageFactory, user security.SQLUsername) error
+	readFiles(ctx context.Context, flowCtx *execinfra.FlowCtx, dataFiles map[int32]string,
+		resumePos map[int32]int64, format roachpb.IOFileFormat,
+		makeExternalStorage cloud.ExternalStorageFactory, user security.SQLUsername) error
 }
 
 // formatHasNamedColumns returns true if the data in the input files can be
@@ -443,11 +447,14 @@ func handleCorruptRow(ctx context.Context, fileCtx *importFileContext, err error
 }
 
 func makeDatumConverter(
-	ctx context.Context, importCtx *parallelImportContext, fileCtx *importFileContext,
+	ctx context.Context,
+	flowCtx *execinfra.FlowCtx,
+	importCtx *parallelImportContext,
+	fileCtx *importFileContext,
 ) (*row.DatumRowConverter, error) {
 	conv, err := row.NewDatumRowConverter(
-		ctx, importCtx.tableDesc, importCtx.targetCols, importCtx.evalCtx, importCtx.kvCh,
-		importCtx.seqChunkProvider)
+		ctx, flowCtx, importCtx.tableDesc, importCtx.targetCols, importCtx.evalCtx,
+		importCtx.kvCh, importCtx.seqChunkProvider)
 	if err == nil {
 		conv.KvBatch.Source = fileCtx.source
 	}
@@ -519,6 +526,7 @@ func TestingSetParallelImporterReaderBatchSize(s int) func() {
 // appropriate key/values.
 func runParallelImport(
 	ctx context.Context,
+	flowCtx *execinfra.FlowCtx,
 	importCtx *parallelImportContext,
 	fileCtx *importFileContext,
 	producer importRowProducer,
@@ -550,7 +558,7 @@ func runParallelImport(
 		ctx, span = tracing.ChildSpan(ctx, "import-rows-to-datums")
 		defer span.Finish()
 		return ctxgroup.GroupWorkers(ctx, parallelism, func(ctx context.Context, id int) error {
-			return importer.importWorker(ctx, id, consumer, importCtx, fileCtx, minEmited)
+			return importer.importWorker(ctx, flowCtx, id, consumer, importCtx, fileCtx, minEmited)
 		})
 	})
 
@@ -647,13 +655,14 @@ func timestampAfterEpoch(walltime int64) uint64 {
 
 func (p *parallelImporter) importWorker(
 	ctx context.Context,
+	flowCtx *execinfra.FlowCtx,
 	workerID int,
 	consumer importRowConsumer,
 	importCtx *parallelImportContext,
 	fileCtx *importFileContext,
 	minEmitted []int64,
 ) error {
-	conv, err := makeDatumConverter(ctx, importCtx, fileCtx)
+	conv, err := makeDatumConverter(ctx, flowCtx, importCtx, fileCtx)
 	if err != nil {
 		return err
 	}

--- a/pkg/ccl/importccl/read_import_pgcopy.go
+++ b/pkg/ccl/importccl/read_import_pgcopy.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -66,13 +67,15 @@ func (d *pgCopyReader) start(ctx ctxgroup.Group) {
 
 func (d *pgCopyReader) readFiles(
 	ctx context.Context,
+	flowCtx *execinfra.FlowCtx,
 	dataFiles map[int32]string,
 	resumePos map[int32]int64,
 	format roachpb.IOFileFormat,
 	makeExternalStorage cloud.ExternalStorageFactory,
 	user security.SQLUsername,
 ) error {
-	return readInputFiles(ctx, dataFiles, resumePos, format, d.readFile, makeExternalStorage, user)
+	return readInputFiles(ctx, flowCtx, dataFiles, resumePos, format, d.readFile,
+		makeExternalStorage, user)
 }
 
 type postgreStreamCopy struct {
@@ -341,7 +344,12 @@ func (p *pgCopyConsumer) FillDatums(
 }
 
 func (d *pgCopyReader) readFile(
-	ctx context.Context, input *fileReader, inputIdx int32, resumePos int64, rejected chan string,
+	ctx context.Context,
+	flowCtx *execinfra.FlowCtx,
+	input *fileReader,
+	inputIdx int32,
+	resumePos int64,
+	rejected chan string,
 ) error {
 	s := bufio.NewScanner(input)
 	s.Split(bufio.ScanLines)
@@ -369,5 +377,5 @@ func (d *pgCopyReader) readFile(
 		rejected: rejected,
 	}
 
-	return runParallelImport(ctx, d.importCtx, fileCtx, producer, consumer)
+	return runParallelImport(ctx, flowCtx, d.importCtx, fileCtx, producer, consumer)
 }

--- a/pkg/sql/rowexec/bulk_row_writer.go
+++ b/pkg/sql/rowexec/bulk_row_writer.go
@@ -101,8 +101,8 @@ func (sp *bulkRowWriter) work(ctx context.Context) error {
 	kvCh := make(chan row.KVBatch, 10)
 	var g ctxgroup.Group
 
-	conv, err := row.NewDatumRowConverter(ctx,
-		sp.tableDesc, nil /* targetColNames */, sp.EvalCtx, kvCh, nil /* seqChunkProvider */)
+	conv, err := row.NewDatumRowConverter(ctx, sp.flowCtx, sp.tableDesc,
+		nil /* targetColNames */, sp.EvalCtx, kvCh, nil /* seqChunkProvider */)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Previously, doing `IMPORT INTO` using the AVRO format on a table with a
non-target column that has a UDT as the default value would fail with an error
like `process default and computed columns: type OID 100058 does not exist`.

This change fixes the above scenario. It plumbs `flowCtx` to
`NewDatumRowConverter()` and uses it to create a `semaCtx` with a
`TypeResolver` inside a DB closure. This `semaCtx` can then be used to resolve
types where `defaultExprs` and `computedExprs` are created.

This change also adds handling of non-target columns to the AVRO IMPORT flow
since it previously ignored non-target columns.

Release note (sql change): IMPORT INTO for AVRO format now works with
non-target columns that have user-defined types as default values.