### PR TITLE
Makefile: bump test timeouts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,10 +130,10 @@ SUBTESTS :=
 LINTTIMEOUT := 30m
 
 ## Test timeout to use for regular tests.
-TESTTIMEOUT := 30m
+TESTTIMEOUT := 45m
 
 ## Test timeout to use for race tests.
-RACETIMEOUT := 30m
+RACETIMEOUT := 45m
 
 ## Test timeout to use for acceptance tests.
 ACCEPTANCETIMEOUT := 30m


### PR DESCRIPTION
Tests like logictestccl take 20-30 minutes, some of them pushing to the
limits of the 30 minute timeout. Extend the timeout to account for this.

Release note: None