### PR TITLE
colexec: improve sort operator a bit

### DIFF
--- a/pkg/sql/colexec/BUILD.bazel
+++ b/pkg/sql/colexec/BUILD.bazel
@@ -64,6 +64,7 @@ go_library(
         "//pkg/sql/colmem",
         "//pkg/sql/execinfra",
         "//pkg/sql/execinfrapb",
+        "//pkg/sql/memsize",
         "//pkg/sql/rowenc",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sqlerrors",

--- a/pkg/sql/colexec/colexecbase/distinct.eg.go
+++ b/pkg/sql/colexec/colexecbase/distinct.eg.go
@@ -239,12 +239,14 @@ func (p *distinctBoolOp) Next() coldata.Batch {
 								// The current value is null, and either the previous one is not
 								// (meaning they are definitely distinct) or we treat nulls as
 								// distinct values.
+								_ = true
 								outputCol[outputIdx] = true
 							}
 						} else {
 							v := col.Get(checkIdx)
 							if lastValNull {
 								// The previous value was null while the current is not.
+								_ = true
 								outputCol[outputIdx] = true
 							} else {
 								// Neither value is null, so we must compare.
@@ -316,7 +318,6 @@ func (p *distinctBoolOp) Next() coldata.Batch {
 		_ = outputCol[n-1]
 		// Eliminate bounds checks for col[idx].
 		_ = col.Get(n - 1)
-		// TODO(yuzefovich): add BCE assertions for these.
 		if nulls != nil {
 			for idx := 0; idx < n; idx++ {
 				{
@@ -336,12 +337,17 @@ func (p *distinctBoolOp) Next() coldata.Batch {
 								// The current value is null, and either the previous one is not
 								// (meaning they are definitely distinct) or we treat nulls as
 								// distinct values.
+								_ = true
+								//gcassert:bce
 								outputCol[outputIdx] = true
 							}
 						} else {
+							//gcassert:bce
 							v := col.Get(checkIdx)
 							if lastValNull {
 								// The previous value was null while the current is not.
+								_ = true
+								//gcassert:bce
 								outputCol[outputIdx] = true
 							} else {
 								// Neither value is null, so we must compare.
@@ -361,6 +367,7 @@ func (p *distinctBoolOp) Next() coldata.Batch {
 									unique = cmpResult != 0
 								}
 
+								//gcassert:bce
 								outputCol[outputIdx] = outputCol[outputIdx] || unique
 							}
 							lastVal = v
@@ -382,6 +389,7 @@ func (p *distinctBoolOp) Next() coldata.Batch {
 							checkIdx  int = idx
 							outputIdx int = idx
 						)
+						//gcassert:bce
 						v := col.Get(checkIdx)
 						var unique bool
 
@@ -399,6 +407,7 @@ func (p *distinctBoolOp) Next() coldata.Batch {
 							unique = cmpResult != 0
 						}
 
+						//gcassert:bce
 						outputCol[outputIdx] = outputCol[outputIdx] || unique
 						{
 							__retval_0 = v
@@ -509,12 +518,14 @@ func (p *distinctBytesOp) Next() coldata.Batch {
 								// The current value is null, and either the previous one is not
 								// (meaning they are definitely distinct) or we treat nulls as
 								// distinct values.
+								_ = true
 								outputCol[outputIdx] = true
 							}
 						} else {
 							v := col.Get(checkIdx)
 							if lastValNull {
 								// The previous value was null while the current is not.
+								_ = true
 								outputCol[outputIdx] = true
 							} else {
 								// Neither value is null, so we must compare.
@@ -568,9 +579,6 @@ func (p *distinctBytesOp) Next() coldata.Batch {
 	} else {
 		// Eliminate bounds checks for outputCol[idx].
 		_ = outputCol[n-1]
-		// Eliminate bounds checks for col[idx].
-		_ = col.Get(n - 1)
-		// TODO(yuzefovich): add BCE assertions for these.
 		if nulls != nil {
 			for idx := 0; idx < n; idx++ {
 				{
@@ -590,12 +598,16 @@ func (p *distinctBytesOp) Next() coldata.Batch {
 								// The current value is null, and either the previous one is not
 								// (meaning they are definitely distinct) or we treat nulls as
 								// distinct values.
+								_ = true
+								//gcassert:bce
 								outputCol[outputIdx] = true
 							}
 						} else {
 							v := col.Get(checkIdx)
 							if lastValNull {
 								// The previous value was null while the current is not.
+								_ = true
+								//gcassert:bce
 								outputCol[outputIdx] = true
 							} else {
 								// Neither value is null, so we must compare.
@@ -607,6 +619,7 @@ func (p *distinctBytesOp) Next() coldata.Batch {
 									unique = cmpResult != 0
 								}
 
+								//gcassert:bce
 								outputCol[outputIdx] = outputCol[outputIdx] || unique
 							}
 							lastVal = v
@@ -637,6 +650,7 @@ func (p *distinctBytesOp) Next() coldata.Batch {
 							unique = cmpResult != 0
 						}
 
+						//gcassert:bce
 						outputCol[outputIdx] = outputCol[outputIdx] || unique
 						{
 							__retval_0 = v
@@ -747,12 +761,14 @@ func (p *distinctDecimalOp) Next() coldata.Batch {
 								// The current value is null, and either the previous one is not
 								// (meaning they are definitely distinct) or we treat nulls as
 								// distinct values.
+								_ = true
 								outputCol[outputIdx] = true
 							}
 						} else {
 							v := col.Get(checkIdx)
 							if lastValNull {
 								// The previous value was null while the current is not.
+								_ = true
 								outputCol[outputIdx] = true
 							} else {
 								// Neither value is null, so we must compare.
@@ -808,7 +824,6 @@ func (p *distinctDecimalOp) Next() coldata.Batch {
 		_ = outputCol[n-1]
 		// Eliminate bounds checks for col[idx].
 		_ = col.Get(n - 1)
-		// TODO(yuzefovich): add BCE assertions for these.
 		if nulls != nil {
 			for idx := 0; idx < n; idx++ {
 				{
@@ -828,12 +843,17 @@ func (p *distinctDecimalOp) Next() coldata.Batch {
 								// The current value is null, and either the previous one is not
 								// (meaning they are definitely distinct) or we treat nulls as
 								// distinct values.
+								_ = true
+								//gcassert:bce
 								outputCol[outputIdx] = true
 							}
 						} else {
+							//gcassert:bce
 							v := col.Get(checkIdx)
 							if lastValNull {
 								// The previous value was null while the current is not.
+								_ = true
+								//gcassert:bce
 								outputCol[outputIdx] = true
 							} else {
 								// Neither value is null, so we must compare.
@@ -845,6 +865,7 @@ func (p *distinctDecimalOp) Next() coldata.Batch {
 									unique = cmpResult != 0
 								}
 
+								//gcassert:bce
 								outputCol[outputIdx] = outputCol[outputIdx] || unique
 							}
 							lastVal = v
@@ -866,6 +887,7 @@ func (p *distinctDecimalOp) Next() coldata.Batch {
 							checkIdx  int = idx
 							outputIdx int = idx
 						)
+						//gcassert:bce
 						v := col.Get(checkIdx)
 						var unique bool
 
@@ -875,6 +897,7 @@ func (p *distinctDecimalOp) Next() coldata.Batch {
 							unique = cmpResult != 0
 						}
 
+						//gcassert:bce
 						outputCol[outputIdx] = outputCol[outputIdx] || unique
 						{
 							__retval_0 = v
@@ -985,12 +1008,14 @@ func (p *distinctInt16Op) Next() coldata.Batch {
 								// The current value is null, and either the previous one is not
 								// (meaning they are definitely distinct) or we treat nulls as
 								// distinct values.
+								_ = true
 								outputCol[outputIdx] = true
 							}
 						} else {
 							v := col.Get(checkIdx)
 							if lastValNull {
 								// The previous value was null while the current is not.
+								_ = true
 								outputCol[outputIdx] = true
 							} else {
 								// Neither value is null, so we must compare.
@@ -1068,7 +1093,6 @@ func (p *distinctInt16Op) Next() coldata.Batch {
 		_ = outputCol[n-1]
 		// Eliminate bounds checks for col[idx].
 		_ = col.Get(n - 1)
-		// TODO(yuzefovich): add BCE assertions for these.
 		if nulls != nil {
 			for idx := 0; idx < n; idx++ {
 				{
@@ -1088,12 +1112,17 @@ func (p *distinctInt16Op) Next() coldata.Batch {
 								// The current value is null, and either the previous one is not
 								// (meaning they are definitely distinct) or we treat nulls as
 								// distinct values.
+								_ = true
+								//gcassert:bce
 								outputCol[outputIdx] = true
 							}
 						} else {
+							//gcassert:bce
 							v := col.Get(checkIdx)
 							if lastValNull {
 								// The previous value was null while the current is not.
+								_ = true
+								//gcassert:bce
 								outputCol[outputIdx] = true
 							} else {
 								// Neither value is null, so we must compare.
@@ -1116,6 +1145,7 @@ func (p *distinctInt16Op) Next() coldata.Batch {
 									unique = cmpResult != 0
 								}
 
+								//gcassert:bce
 								outputCol[outputIdx] = outputCol[outputIdx] || unique
 							}
 							lastVal = v
@@ -1137,6 +1167,7 @@ func (p *distinctInt16Op) Next() coldata.Batch {
 							checkIdx  int = idx
 							outputIdx int = idx
 						)
+						//gcassert:bce
 						v := col.Get(checkIdx)
 						var unique bool
 
@@ -1157,6 +1188,7 @@ func (p *distinctInt16Op) Next() coldata.Batch {
 							unique = cmpResult != 0
 						}
 
+						//gcassert:bce
 						outputCol[outputIdx] = outputCol[outputIdx] || unique
 						{
 							__retval_0 = v
@@ -1267,12 +1299,14 @@ func (p *distinctInt32Op) Next() coldata.Batch {
 								// The current value is null, and either the previous one is not
 								// (meaning they are definitely distinct) or we treat nulls as
 								// distinct values.
+								_ = true
 								outputCol[outputIdx] = true
 							}
 						} else {
 							v := col.Get(checkIdx)
 							if lastValNull {
 								// The previous value was null while the current is not.
+								_ = true
 								outputCol[outputIdx] = true
 							} else {
 								// Neither value is null, so we must compare.
@@ -1350,7 +1384,6 @@ func (p *distinctInt32Op) Next() coldata.Batch {
 		_ = outputCol[n-1]
 		// Eliminate bounds checks for col[idx].
 		_ = col.Get(n - 1)
-		// TODO(yuzefovich): add BCE assertions for these.
 		if nulls != nil {
 			for idx := 0; idx < n; idx++ {
 				{
@@ -1370,12 +1403,17 @@ func (p *distinctInt32Op) Next() coldata.Batch {
 								// The current value is null, and either the previous one is not
 								// (meaning they are definitely distinct) or we treat nulls as
 								// distinct values.
+								_ = true
+								//gcassert:bce
 								outputCol[outputIdx] = true
 							}
 						} else {
+							//gcassert:bce
 							v := col.Get(checkIdx)
 							if lastValNull {
 								// The previous value was null while the current is not.
+								_ = true
+								//gcassert:bce
 								outputCol[outputIdx] = true
 							} else {
 								// Neither value is null, so we must compare.
@@ -1398,6 +1436,7 @@ func (p *distinctInt32Op) Next() coldata.Batch {
 									unique = cmpResult != 0
 								}
 
+								//gcassert:bce
 								outputCol[outputIdx] = outputCol[outputIdx] || unique
 							}
 							lastVal = v
@@ -1419,6 +1458,7 @@ func (p *distinctInt32Op) Next() coldata.Batch {
 							checkIdx  int = idx
 							outputIdx int = idx
 						)
+						//gcassert:bce
 						v := col.Get(checkIdx)
 						var unique bool
 
@@ -1439,6 +1479,7 @@ func (p *distinctInt32Op) Next() coldata.Batch {
 							unique = cmpResult != 0
 						}
 
+						//gcassert:bce
 						outputCol[outputIdx] = outputCol[outputIdx] || unique
 						{
 							__retval_0 = v
@@ -1549,12 +1590,14 @@ func (p *distinctInt64Op) Next() coldata.Batch {
 								// The current value is null, and either the previous one is not
 								// (meaning they are definitely distinct) or we treat nulls as
 								// distinct values.
+								_ = true
 								outputCol[outputIdx] = true
 							}
 						} else {
 							v := col.Get(checkIdx)
 							if lastValNull {
 								// The previous value was null while the current is not.
+								_ = true
 								outputCol[outputIdx] = true
 							} else {
 								// Neither value is null, so we must compare.
@@ -1632,7 +1675,6 @@ func (p *distinctInt64Op) Next() coldata.Batch {
 		_ = outputCol[n-1]
 		// Eliminate bounds checks for col[idx].
 		_ = col.Get(n - 1)
-		// TODO(yuzefovich): add BCE assertions for these.
 		if nulls != nil {
 			for idx := 0; idx < n; idx++ {
 				{
@@ -1652,12 +1694,17 @@ func (p *distinctInt64Op) Next() coldata.Batch {
 								// The current value is null, and either the previous one is not
 								// (meaning they are definitely distinct) or we treat nulls as
 								// distinct values.
+								_ = true
+								//gcassert:bce
 								outputCol[outputIdx] = true
 							}
 						} else {
+							//gcassert:bce
 							v := col.Get(checkIdx)
 							if lastValNull {
 								// The previous value was null while the current is not.
+								_ = true
+								//gcassert:bce
 								outputCol[outputIdx] = true
 							} else {
 								// Neither value is null, so we must compare.
@@ -1680,6 +1727,7 @@ func (p *distinctInt64Op) Next() coldata.Batch {
 									unique = cmpResult != 0
 								}
 
+								//gcassert:bce
 								outputCol[outputIdx] = outputCol[outputIdx] || unique
 							}
 							lastVal = v
@@ -1701,6 +1749,7 @@ func (p *distinctInt64Op) Next() coldata.Batch {
 							checkIdx  int = idx
 							outputIdx int = idx
 						)
+						//gcassert:bce
 						v := col.Get(checkIdx)
 						var unique bool
 
@@ -1721,6 +1770,7 @@ func (p *distinctInt64Op) Next() coldata.Batch {
 							unique = cmpResult != 0
 						}
 
+						//gcassert:bce
 						outputCol[outputIdx] = outputCol[outputIdx] || unique
 						{
 							__retval_0 = v
@@ -1831,12 +1881,14 @@ func (p *distinctFloat64Op) Next() coldata.Batch {
 								// The current value is null, and either the previous one is not
 								// (meaning they are definitely distinct) or we treat nulls as
 								// distinct values.
+								_ = true
 								outputCol[outputIdx] = true
 							}
 						} else {
 							v := col.Get(checkIdx)
 							if lastValNull {
 								// The previous value was null while the current is not.
+								_ = true
 								outputCol[outputIdx] = true
 							} else {
 								// Neither value is null, so we must compare.
@@ -1930,7 +1982,6 @@ func (p *distinctFloat64Op) Next() coldata.Batch {
 		_ = outputCol[n-1]
 		// Eliminate bounds checks for col[idx].
 		_ = col.Get(n - 1)
-		// TODO(yuzefovich): add BCE assertions for these.
 		if nulls != nil {
 			for idx := 0; idx < n; idx++ {
 				{
@@ -1950,12 +2001,17 @@ func (p *distinctFloat64Op) Next() coldata.Batch {
 								// The current value is null, and either the previous one is not
 								// (meaning they are definitely distinct) or we treat nulls as
 								// distinct values.
+								_ = true
+								//gcassert:bce
 								outputCol[outputIdx] = true
 							}
 						} else {
+							//gcassert:bce
 							v := col.Get(checkIdx)
 							if lastValNull {
 								// The previous value was null while the current is not.
+								_ = true
+								//gcassert:bce
 								outputCol[outputIdx] = true
 							} else {
 								// Neither value is null, so we must compare.
@@ -1986,6 +2042,7 @@ func (p *distinctFloat64Op) Next() coldata.Batch {
 									unique = cmpResult != 0
 								}
 
+								//gcassert:bce
 								outputCol[outputIdx] = outputCol[outputIdx] || unique
 							}
 							lastVal = v
@@ -2007,6 +2064,7 @@ func (p *distinctFloat64Op) Next() coldata.Batch {
 							checkIdx  int = idx
 							outputIdx int = idx
 						)
+						//gcassert:bce
 						v := col.Get(checkIdx)
 						var unique bool
 
@@ -2035,6 +2093,7 @@ func (p *distinctFloat64Op) Next() coldata.Batch {
 							unique = cmpResult != 0
 						}
 
+						//gcassert:bce
 						outputCol[outputIdx] = outputCol[outputIdx] || unique
 						{
 							__retval_0 = v
@@ -2145,12 +2204,14 @@ func (p *distinctTimestampOp) Next() coldata.Batch {
 								// The current value is null, and either the previous one is not
 								// (meaning they are definitely distinct) or we treat nulls as
 								// distinct values.
+								_ = true
 								outputCol[outputIdx] = true
 							}
 						} else {
 							v := col.Get(checkIdx)
 							if lastValNull {
 								// The previous value was null while the current is not.
+								_ = true
 								outputCol[outputIdx] = true
 							} else {
 								// Neither value is null, so we must compare.
@@ -2220,7 +2281,6 @@ func (p *distinctTimestampOp) Next() coldata.Batch {
 		_ = outputCol[n-1]
 		// Eliminate bounds checks for col[idx].
 		_ = col.Get(n - 1)
-		// TODO(yuzefovich): add BCE assertions for these.
 		if nulls != nil {
 			for idx := 0; idx < n; idx++ {
 				{
@@ -2240,12 +2300,17 @@ func (p *distinctTimestampOp) Next() coldata.Batch {
 								// The current value is null, and either the previous one is not
 								// (meaning they are definitely distinct) or we treat nulls as
 								// distinct values.
+								_ = true
+								//gcassert:bce
 								outputCol[outputIdx] = true
 							}
 						} else {
+							//gcassert:bce
 							v := col.Get(checkIdx)
 							if lastValNull {
 								// The previous value was null while the current is not.
+								_ = true
+								//gcassert:bce
 								outputCol[outputIdx] = true
 							} else {
 								// Neither value is null, so we must compare.
@@ -2264,6 +2329,7 @@ func (p *distinctTimestampOp) Next() coldata.Batch {
 									unique = cmpResult != 0
 								}
 
+								//gcassert:bce
 								outputCol[outputIdx] = outputCol[outputIdx] || unique
 							}
 							lastVal = v
@@ -2285,6 +2351,7 @@ func (p *distinctTimestampOp) Next() coldata.Batch {
 							checkIdx  int = idx
 							outputIdx int = idx
 						)
+						//gcassert:bce
 						v := col.Get(checkIdx)
 						var unique bool
 
@@ -2301,6 +2368,7 @@ func (p *distinctTimestampOp) Next() coldata.Batch {
 							unique = cmpResult != 0
 						}
 
+						//gcassert:bce
 						outputCol[outputIdx] = outputCol[outputIdx] || unique
 						{
 							__retval_0 = v
@@ -2411,12 +2479,14 @@ func (p *distinctIntervalOp) Next() coldata.Batch {
 								// The current value is null, and either the previous one is not
 								// (meaning they are definitely distinct) or we treat nulls as
 								// distinct values.
+								_ = true
 								outputCol[outputIdx] = true
 							}
 						} else {
 							v := col.Get(checkIdx)
 							if lastValNull {
 								// The previous value was null while the current is not.
+								_ = true
 								outputCol[outputIdx] = true
 							} else {
 								// Neither value is null, so we must compare.
@@ -2472,7 +2542,6 @@ func (p *distinctIntervalOp) Next() coldata.Batch {
 		_ = outputCol[n-1]
 		// Eliminate bounds checks for col[idx].
 		_ = col.Get(n - 1)
-		// TODO(yuzefovich): add BCE assertions for these.
 		if nulls != nil {
 			for idx := 0; idx < n; idx++ {
 				{
@@ -2492,12 +2561,17 @@ func (p *distinctIntervalOp) Next() coldata.Batch {
 								// The current value is null, and either the previous one is not
 								// (meaning they are definitely distinct) or we treat nulls as
 								// distinct values.
+								_ = true
+								//gcassert:bce
 								outputCol[outputIdx] = true
 							}
 						} else {
+							//gcassert:bce
 							v := col.Get(checkIdx)
 							if lastValNull {
 								// The previous value was null while the current is not.
+								_ = true
+								//gcassert:bce
 								outputCol[outputIdx] = true
 							} else {
 								// Neither value is null, so we must compare.
@@ -2509,6 +2583,7 @@ func (p *distinctIntervalOp) Next() coldata.Batch {
 									unique = cmpResult != 0
 								}
 
+								//gcassert:bce
 								outputCol[outputIdx] = outputCol[outputIdx] || unique
 							}
 							lastVal = v
@@ -2530,6 +2605,7 @@ func (p *distinctIntervalOp) Next() coldata.Batch {
 							checkIdx  int = idx
 							outputIdx int = idx
 						)
+						//gcassert:bce
 						v := col.Get(checkIdx)
 						var unique bool
 
@@ -2539,6 +2615,7 @@ func (p *distinctIntervalOp) Next() coldata.Batch {
 							unique = cmpResult != 0
 						}
 
+						//gcassert:bce
 						outputCol[outputIdx] = outputCol[outputIdx] || unique
 						{
 							__retval_0 = v
@@ -2649,12 +2726,14 @@ func (p *distinctJSONOp) Next() coldata.Batch {
 								// The current value is null, and either the previous one is not
 								// (meaning they are definitely distinct) or we treat nulls as
 								// distinct values.
+								_ = true
 								outputCol[outputIdx] = true
 							}
 						} else {
 							v := col.Get(checkIdx)
 							if lastValNull {
 								// The previous value was null while the current is not.
+								_ = true
 								outputCol[outputIdx] = true
 							} else {
 								// Neither value is null, so we must compare.
@@ -2720,9 +2799,6 @@ func (p *distinctJSONOp) Next() coldata.Batch {
 	} else {
 		// Eliminate bounds checks for outputCol[idx].
 		_ = outputCol[n-1]
-		// Eliminate bounds checks for col[idx].
-		_ = col.Get(n - 1)
-		// TODO(yuzefovich): add BCE assertions for these.
 		if nulls != nil {
 			for idx := 0; idx < n; idx++ {
 				{
@@ -2742,12 +2818,16 @@ func (p *distinctJSONOp) Next() coldata.Batch {
 								// The current value is null, and either the previous one is not
 								// (meaning they are definitely distinct) or we treat nulls as
 								// distinct values.
+								_ = true
+								//gcassert:bce
 								outputCol[outputIdx] = true
 							}
 						} else {
 							v := col.Get(checkIdx)
 							if lastValNull {
 								// The previous value was null while the current is not.
+								_ = true
+								//gcassert:bce
 								outputCol[outputIdx] = true
 							} else {
 								// Neither value is null, so we must compare.
@@ -2765,6 +2845,7 @@ func (p *distinctJSONOp) Next() coldata.Batch {
 									unique = cmpResult != 0
 								}
 
+								//gcassert:bce
 								outputCol[outputIdx] = outputCol[outputIdx] || unique
 							}
 							lastVal = v
@@ -2801,6 +2882,7 @@ func (p *distinctJSONOp) Next() coldata.Batch {
 							unique = cmpResult != 0
 						}
 
+						//gcassert:bce
 						outputCol[outputIdx] = outputCol[outputIdx] || unique
 						{
 							__retval_0 = v
@@ -2922,12 +3004,14 @@ func (p *distinctDatumOp) Next() coldata.Batch {
 								// The current value is null, and either the previous one is not
 								// (meaning they are definitely distinct) or we treat nulls as
 								// distinct values.
+								_ = true
 								outputCol[outputIdx] = true
 							}
 						} else {
 							v := col.Get(checkIdx)
 							if lastValNull {
 								// The previous value was null while the current is not.
+								_ = true
 								outputCol[outputIdx] = true
 							} else {
 								// Neither value is null, so we must compare.
@@ -2985,9 +3069,6 @@ func (p *distinctDatumOp) Next() coldata.Batch {
 	} else {
 		// Eliminate bounds checks for outputCol[idx].
 		_ = outputCol[n-1]
-		// Eliminate bounds checks for col[idx].
-		_ = col.Get(n - 1)
-		// TODO(yuzefovich): add BCE assertions for these.
 		if nulls != nil {
 			for idx := 0; idx < n; idx++ {
 				{
@@ -3007,12 +3088,16 @@ func (p *distinctDatumOp) Next() coldata.Batch {
 								// The current value is null, and either the previous one is not
 								// (meaning they are definitely distinct) or we treat nulls as
 								// distinct values.
+								_ = true
+								//gcassert:bce
 								outputCol[outputIdx] = true
 							}
 						} else {
 							v := col.Get(checkIdx)
 							if lastValNull {
 								// The previous value was null while the current is not.
+								_ = true
+								//gcassert:bce
 								outputCol[outputIdx] = true
 							} else {
 								// Neither value is null, so we must compare.
@@ -3026,6 +3111,7 @@ func (p *distinctDatumOp) Next() coldata.Batch {
 									unique = cmpResult != 0
 								}
 
+								//gcassert:bce
 								outputCol[outputIdx] = outputCol[outputIdx] || unique
 							}
 							lastVal = v
@@ -3058,6 +3144,7 @@ func (p *distinctDatumOp) Next() coldata.Batch {
 							unique = cmpResult != 0
 						}
 
+						//gcassert:bce
 						outputCol[outputIdx] = outputCol[outputIdx] || unique
 						{
 							__retval_0 = v

--- a/pkg/sql/colexec/colexecbase/distinct_tmpl.go
+++ b/pkg/sql/colexec/colexecbase/distinct_tmpl.go
@@ -261,15 +261,18 @@ func (p partitioner_TYPE) partitionWithOrder(
 	// Eliminate bounds checks.
 	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
+	_ = order[n-1]
 	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for outputIdx := 0; outputIdx < n; outputIdx++ {
+			//gcassert:bce
 			checkIdx := order[outputIdx]
 			lastVal, lastValNull = checkDistinctWithNulls(checkIdx, outputIdx, lastVal, nulls, lastValNull, col, outputCol, p.nullsAreDistinct)
 		}
 	} else {
 		for outputIdx := 0; outputIdx < n; outputIdx++ {
+			//gcassert:bce
 			checkIdx := order[outputIdx]
 			lastVal = checkDistinct(checkIdx, outputIdx, lastVal, col, outputCol)
 		}

--- a/pkg/sql/colexec/colexecbase/distinct_tmpl.go
+++ b/pkg/sql/colexec/colexecbase/distinct_tmpl.go
@@ -201,26 +201,27 @@ func (p *distinct_TYPEOp) Next() coldata.Batch {
 		sel = sel[:n]
 		if nulls != nil {
 			for _, idx := range sel {
-				lastVal, lastValNull = checkDistinctWithNulls(idx, idx, lastVal, nulls, lastValNull, col, outputCol, p.nullsAreDistinct)
+				lastVal, lastValNull = checkDistinctWithNulls(idx, idx, lastVal, nulls, lastValNull, col, outputCol, p.nullsAreDistinct, false, false)
 			}
 		} else {
 			for _, idx := range sel {
-				lastVal = checkDistinct(idx, idx, lastVal, col, outputCol)
+				lastVal = checkDistinct(idx, idx, lastVal, col, outputCol, false, false)
 			}
 		}
 	} else {
 		// Eliminate bounds checks for outputCol[idx].
 		_ = outputCol[n-1]
+		// {{if .Sliceable}}
 		// Eliminate bounds checks for col[idx].
 		_ = col.Get(n - 1)
-		// TODO(yuzefovich): add BCE assertions for these.
+		// {{end}}
 		if nulls != nil {
 			for idx := 0; idx < n; idx++ {
-				lastVal, lastValNull = checkDistinctWithNulls(idx, idx, lastVal, nulls, lastValNull, col, outputCol, p.nullsAreDistinct)
+				lastVal, lastValNull = checkDistinctWithNulls(idx, idx, lastVal, nulls, lastValNull, col, outputCol, p.nullsAreDistinct, true, true)
 			}
 		} else {
 			for idx := 0; idx < n; idx++ {
-				lastVal = checkDistinct(idx, idx, lastVal, col, outputCol)
+				lastVal = checkDistinct(idx, idx, lastVal, col, outputCol, true, true)
 			}
 		}
 	}
@@ -259,22 +260,20 @@ func (p partitioner_TYPE) partitionWithOrder(
 
 	col := colVec.TemplateType()
 	// Eliminate bounds checks.
-	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
 	_ = order[n-1]
-	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for outputIdx := 0; outputIdx < n; outputIdx++ {
 			//gcassert:bce
 			checkIdx := order[outputIdx]
-			lastVal, lastValNull = checkDistinctWithNulls(checkIdx, outputIdx, lastVal, nulls, lastValNull, col, outputCol, p.nullsAreDistinct)
+			lastVal, lastValNull = checkDistinctWithNulls(checkIdx, outputIdx, lastVal, nulls, lastValNull, col, outputCol, p.nullsAreDistinct, false, true)
 		}
 	} else {
 		for outputIdx := 0; outputIdx < n; outputIdx++ {
 			//gcassert:bce
 			checkIdx := order[outputIdx]
-			lastVal = checkDistinct(checkIdx, outputIdx, lastVal, col, outputCol)
+			lastVal = checkDistinct(checkIdx, outputIdx, lastVal, col, outputCol, false, true)
 		}
 	}
 }
@@ -290,17 +289,18 @@ func (p partitioner_TYPE) partition(colVec coldata.Vec, outputCol []bool, n int)
 	}
 
 	col := colVec.TemplateType()
+	// {{if .Sliceable}}
 	_ = col.Get(n - 1)
+	// {{end}}
 	_ = outputCol[n-1]
-	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for idx := 0; idx < n; idx++ {
-			lastVal, lastValNull = checkDistinctWithNulls(idx, idx, lastVal, nulls, lastValNull, col, outputCol, p.nullsAreDistinct)
+			lastVal, lastValNull = checkDistinctWithNulls(idx, idx, lastVal, nulls, lastValNull, col, outputCol, p.nullsAreDistinct, true, true)
 		}
 	} else {
 		for idx := 0; idx < n; idx++ {
-			lastVal = checkDistinct(idx, idx, lastVal, col, outputCol)
+			lastVal = checkDistinct(idx, idx, lastVal, col, outputCol, true, true)
 		}
 	}
 }
@@ -312,12 +312,27 @@ func (p partitioner_TYPE) partition(colVec coldata.Vec, outputCol []bool, n int)
 // compared values were distinct. It presumes that the current batch has no null
 // values.
 // execgen:inline
+// execgen:template<colBCE,outputBCE>
 func checkDistinct(
-	checkIdx int, outputIdx int, lastVal _GOTYPE, col []_GOTYPE, outputCol []bool,
+	checkIdx int,
+	outputIdx int,
+	lastVal _GOTYPE,
+	col []_GOTYPE,
+	outputCol []bool,
+	colBCE bool,
+	outputBCE bool,
 ) _GOTYPE {
+	if colBCE {
+		// {{if .Sliceable}}
+		//gcassert:bce
+		// {{end}}
+	}
 	v := col.Get(checkIdx)
 	var unique bool
 	_ASSIGN_NE(unique, v, lastVal, _, col, _)
+	if outputBCE {
+		//gcassert:bce
+	}
 	outputCol[outputIdx] = outputCol[outputIdx] || unique
 	return v
 }
@@ -326,6 +341,7 @@ func checkDistinct(
 // considers whether the previous and current values are null. It assumes that
 // `nulls` is non-nil.
 // execgen:inline
+// execgen:template<colBCE,outputBCE>
 func checkDistinctWithNulls(
 	checkIdx int,
 	outputIdx int,
@@ -335,6 +351,8 @@ func checkDistinctWithNulls(
 	col []_GOTYPE,
 	outputCol []bool,
 	nullsAreDistinct bool,
+	colBCE bool,
+	outputBCE bool,
 ) (lastVal _GOTYPE, lastValNull bool) {
 	null := nulls.NullAt(checkIdx)
 	if null {
@@ -342,17 +360,31 @@ func checkDistinctWithNulls(
 			// The current value is null, and either the previous one is not
 			// (meaning they are definitely distinct) or we treat nulls as
 			// distinct values.
+			if outputBCE {
+				//gcassert:bce
+			}
 			outputCol[outputIdx] = true
 		}
 	} else {
+		if colBCE {
+			// {{if .Sliceable}}
+			//gcassert:bce
+			// {{end}}
+		}
 		v := col.Get(checkIdx)
 		if lastValNull {
 			// The previous value was null while the current is not.
+			if outputBCE {
+				//gcassert:bce
+			}
 			outputCol[outputIdx] = true
 		} else {
 			// Neither value is null, so we must compare.
 			var unique bool
 			_ASSIGN_NE(unique, v, lastVal, _, col, _)
+			if outputBCE {
+				//gcassert:bce
+			}
 			outputCol[outputIdx] = outputCol[outputIdx] || unique
 		}
 		lastVal = v

--- a/pkg/sql/colexec/sort.go
+++ b/pkg/sql/colexec/sort.go
@@ -416,7 +416,7 @@ func (p *sortOp) sort() {
 		// Convert the distinct vector into a selection vector - a vector of indices
 		// that were true in the distinct vector.
 		sizeBefore := memsize.Int * int64(cap(p.scratch.partitions))
-		p.scratch.partitions = boolVecToSel64(partitionsCol, p.scratch.partitions[:0])
+		p.scratch.partitions = boolVecToSel(partitionsCol, p.scratch.partitions[:0])
 		sizeAfter := memsize.Int * int64(cap(p.scratch.partitions))
 		p.allocator.AdjustMemoryUsage(sizeAfter - sizeBefore)
 		// For each partition (set of tuples that are identical in all of the sort

--- a/pkg/sql/colexec/sort.go
+++ b/pkg/sql/colexec/sort.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/memsize"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/errors"
 )
@@ -211,6 +212,15 @@ type sortOp struct {
 	// state is the current state of the sort.
 	state sortState
 
+	// The fields in the scratch are only used when we're sorting on more than
+	// one column and are mostly useful in the scenario when this sortOp is
+	// being used by the external sorter.
+	scratch struct {
+		partitions []int
+		// partitionsCol is used only in the global sort (i.e. not sort chunks).
+		partitionsCol []bool
+	}
+
 	output coldata.Batch
 
 	exported int
@@ -350,7 +360,13 @@ func (p *sortOp) sort() {
 			return
 		}
 		sorters = sorters[1:]
-		partitionsCol = make([]bool, spooledTuples)
+		sizeBefore := memsize.Bool * int64(cap(p.scratch.partitionsCol))
+		// We want to make sure that partitionsCol is zeroed out if we're
+		// reusing it (and this method accomplishes that).
+		p.scratch.partitionsCol = colexecutils.MaybeAllocateBoolArray(p.scratch.partitionsCol, spooledTuples)
+		partitionsCol = p.scratch.partitionsCol
+		sizeAfter := memsize.Bool * int64(cap(p.scratch.partitionsCol))
+		p.allocator.AdjustMemoryUsage(sizeAfter - sizeBefore)
 	} else {
 		// There are at least two partitions already, so the first column needs the
 		// same special treatment as all others. The general sequence is as
@@ -386,7 +402,6 @@ func (p *sortOp) sort() {
 	// 2 a
 	// 2 b
 
-	partitions := make([]int, 0, 16)
 	for i, sorter := range sorters {
 		if !omitNextPartitioning {
 			// We partition the previous column by running an ordered distinct operation
@@ -400,10 +415,13 @@ func (p *sortOp) sort() {
 		}
 		// Convert the distinct vector into a selection vector - a vector of indices
 		// that were true in the distinct vector.
-		partitions = boolVecToSel64(partitionsCol, partitions[:0])
+		sizeBefore := memsize.Int * int64(cap(p.scratch.partitions))
+		p.scratch.partitions = boolVecToSel64(partitionsCol, p.scratch.partitions[:0])
+		sizeAfter := memsize.Int * int64(cap(p.scratch.partitions))
+		p.allocator.AdjustMemoryUsage(sizeAfter - sizeBefore)
 		// For each partition (set of tuples that are identical in all of the sort
 		// columns we've seen so far), sort based on the new column.
-		sorter.sortPartitions(partitions)
+		sorter.sortPartitions(p.scratch.partitions)
 	}
 }
 

--- a/pkg/sql/colexec/sort_chunks.go
+++ b/pkg/sql/colexec/sort_chunks.go
@@ -330,7 +330,7 @@ func (s *chunker) prepareNextChunks() chunkerReadingState {
 				s.partitioners[i].partition(s.batch.ColVec(int(orderedCol)), s.partitionCol,
 					s.batch.Length())
 			}
-			s.chunks = boolVecToSel64(s.partitionCol, s.chunks[:0])
+			s.chunks = boolVecToSel(s.partitionCol, s.chunks[:0])
 
 			if s.bufferedTuples.Length() == 0 {
 				// There are no buffered tuples, so a new chunk starts in the current

--- a/pkg/sql/colexec/sort_partitioner.eg.go
+++ b/pkg/sql/colexec/sort_partitioner.eg.go
@@ -129,10 +129,8 @@ func (p partitionerBool) partitionWithOrder(
 
 	col := colVec.Bool()
 	// Eliminate bounds checks.
-	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
 	_ = order[n-1]
-	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for outputIdx := 0; outputIdx < n; outputIdx++ {
@@ -151,12 +149,16 @@ func (p partitionerBool) partitionWithOrder(
 							// The current value is null, and either the previous one is not
 							// (meaning they are definitely distinct) or we treat nulls as
 							// distinct values.
+							_ = true
+							//gcassert:bce
 							outputCol[outputIdx] = true
 						}
 					} else {
 						v := col.Get(checkIdx)
 						if lastValNull {
 							// The previous value was null while the current is not.
+							_ = true
+							//gcassert:bce
 							outputCol[outputIdx] = true
 						} else {
 							// Neither value is null, so we must compare.
@@ -176,6 +178,7 @@ func (p partitionerBool) partitionWithOrder(
 								unique = cmpResult != 0
 							}
 
+							//gcassert:bce
 							outputCol[outputIdx] = outputCol[outputIdx] || unique
 						}
 						lastVal = v
@@ -212,6 +215,7 @@ func (p partitionerBool) partitionWithOrder(
 						unique = cmpResult != 0
 					}
 
+					//gcassert:bce
 					outputCol[outputIdx] = outputCol[outputIdx] || unique
 					{
 						__retval_0 = v
@@ -236,7 +240,6 @@ func (p partitionerBool) partition(colVec coldata.Vec, outputCol []bool, n int) 
 	col := colVec.Bool()
 	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
-	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for idx := 0; idx < n; idx++ {
@@ -257,12 +260,17 @@ func (p partitionerBool) partition(colVec coldata.Vec, outputCol []bool, n int) 
 							// The current value is null, and either the previous one is not
 							// (meaning they are definitely distinct) or we treat nulls as
 							// distinct values.
+							_ = true
+							//gcassert:bce
 							outputCol[outputIdx] = true
 						}
 					} else {
+						//gcassert:bce
 						v := col.Get(checkIdx)
 						if lastValNull {
 							// The previous value was null while the current is not.
+							_ = true
+							//gcassert:bce
 							outputCol[outputIdx] = true
 						} else {
 							// Neither value is null, so we must compare.
@@ -282,6 +290,7 @@ func (p partitionerBool) partition(colVec coldata.Vec, outputCol []bool, n int) 
 								unique = cmpResult != 0
 							}
 
+							//gcassert:bce
 							outputCol[outputIdx] = outputCol[outputIdx] || unique
 						}
 						lastVal = v
@@ -303,6 +312,7 @@ func (p partitionerBool) partition(colVec coldata.Vec, outputCol []bool, n int) 
 						checkIdx  int = idx
 						outputIdx int = idx
 					)
+					//gcassert:bce
 					v := col.Get(checkIdx)
 					var unique bool
 
@@ -320,6 +330,7 @@ func (p partitionerBool) partition(colVec coldata.Vec, outputCol []bool, n int) 
 						unique = cmpResult != 0
 					}
 
+					//gcassert:bce
 					outputCol[outputIdx] = outputCol[outputIdx] || unique
 					{
 						__retval_0 = v
@@ -351,10 +362,8 @@ func (p partitionerBytes) partitionWithOrder(
 
 	col := colVec.Bytes()
 	// Eliminate bounds checks.
-	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
 	_ = order[n-1]
-	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for outputIdx := 0; outputIdx < n; outputIdx++ {
@@ -373,12 +382,16 @@ func (p partitionerBytes) partitionWithOrder(
 							// The current value is null, and either the previous one is not
 							// (meaning they are definitely distinct) or we treat nulls as
 							// distinct values.
+							_ = true
+							//gcassert:bce
 							outputCol[outputIdx] = true
 						}
 					} else {
 						v := col.Get(checkIdx)
 						if lastValNull {
 							// The previous value was null while the current is not.
+							_ = true
+							//gcassert:bce
 							outputCol[outputIdx] = true
 						} else {
 							// Neither value is null, so we must compare.
@@ -390,6 +403,7 @@ func (p partitionerBytes) partitionWithOrder(
 								unique = cmpResult != 0
 							}
 
+							//gcassert:bce
 							outputCol[outputIdx] = outputCol[outputIdx] || unique
 						}
 						lastVal = v
@@ -418,6 +432,7 @@ func (p partitionerBytes) partitionWithOrder(
 						unique = cmpResult != 0
 					}
 
+					//gcassert:bce
 					outputCol[outputIdx] = outputCol[outputIdx] || unique
 					{
 						__retval_0 = v
@@ -440,9 +455,7 @@ func (p partitionerBytes) partition(colVec coldata.Vec, outputCol []bool, n int)
 	}
 
 	col := colVec.Bytes()
-	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
-	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for idx := 0; idx < n; idx++ {
@@ -463,12 +476,16 @@ func (p partitionerBytes) partition(colVec coldata.Vec, outputCol []bool, n int)
 							// The current value is null, and either the previous one is not
 							// (meaning they are definitely distinct) or we treat nulls as
 							// distinct values.
+							_ = true
+							//gcassert:bce
 							outputCol[outputIdx] = true
 						}
 					} else {
 						v := col.Get(checkIdx)
 						if lastValNull {
 							// The previous value was null while the current is not.
+							_ = true
+							//gcassert:bce
 							outputCol[outputIdx] = true
 						} else {
 							// Neither value is null, so we must compare.
@@ -480,6 +497,7 @@ func (p partitionerBytes) partition(colVec coldata.Vec, outputCol []bool, n int)
 								unique = cmpResult != 0
 							}
 
+							//gcassert:bce
 							outputCol[outputIdx] = outputCol[outputIdx] || unique
 						}
 						lastVal = v
@@ -510,6 +528,7 @@ func (p partitionerBytes) partition(colVec coldata.Vec, outputCol []bool, n int)
 						unique = cmpResult != 0
 					}
 
+					//gcassert:bce
 					outputCol[outputIdx] = outputCol[outputIdx] || unique
 					{
 						__retval_0 = v
@@ -541,10 +560,8 @@ func (p partitionerDecimal) partitionWithOrder(
 
 	col := colVec.Decimal()
 	// Eliminate bounds checks.
-	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
 	_ = order[n-1]
-	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for outputIdx := 0; outputIdx < n; outputIdx++ {
@@ -563,12 +580,16 @@ func (p partitionerDecimal) partitionWithOrder(
 							// The current value is null, and either the previous one is not
 							// (meaning they are definitely distinct) or we treat nulls as
 							// distinct values.
+							_ = true
+							//gcassert:bce
 							outputCol[outputIdx] = true
 						}
 					} else {
 						v := col.Get(checkIdx)
 						if lastValNull {
 							// The previous value was null while the current is not.
+							_ = true
+							//gcassert:bce
 							outputCol[outputIdx] = true
 						} else {
 							// Neither value is null, so we must compare.
@@ -580,6 +601,7 @@ func (p partitionerDecimal) partitionWithOrder(
 								unique = cmpResult != 0
 							}
 
+							//gcassert:bce
 							outputCol[outputIdx] = outputCol[outputIdx] || unique
 						}
 						lastVal = v
@@ -608,6 +630,7 @@ func (p partitionerDecimal) partitionWithOrder(
 						unique = cmpResult != 0
 					}
 
+					//gcassert:bce
 					outputCol[outputIdx] = outputCol[outputIdx] || unique
 					{
 						__retval_0 = v
@@ -632,7 +655,6 @@ func (p partitionerDecimal) partition(colVec coldata.Vec, outputCol []bool, n in
 	col := colVec.Decimal()
 	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
-	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for idx := 0; idx < n; idx++ {
@@ -653,12 +675,17 @@ func (p partitionerDecimal) partition(colVec coldata.Vec, outputCol []bool, n in
 							// The current value is null, and either the previous one is not
 							// (meaning they are definitely distinct) or we treat nulls as
 							// distinct values.
+							_ = true
+							//gcassert:bce
 							outputCol[outputIdx] = true
 						}
 					} else {
+						//gcassert:bce
 						v := col.Get(checkIdx)
 						if lastValNull {
 							// The previous value was null while the current is not.
+							_ = true
+							//gcassert:bce
 							outputCol[outputIdx] = true
 						} else {
 							// Neither value is null, so we must compare.
@@ -670,6 +697,7 @@ func (p partitionerDecimal) partition(colVec coldata.Vec, outputCol []bool, n in
 								unique = cmpResult != 0
 							}
 
+							//gcassert:bce
 							outputCol[outputIdx] = outputCol[outputIdx] || unique
 						}
 						lastVal = v
@@ -691,6 +719,7 @@ func (p partitionerDecimal) partition(colVec coldata.Vec, outputCol []bool, n in
 						checkIdx  int = idx
 						outputIdx int = idx
 					)
+					//gcassert:bce
 					v := col.Get(checkIdx)
 					var unique bool
 
@@ -700,6 +729,7 @@ func (p partitionerDecimal) partition(colVec coldata.Vec, outputCol []bool, n in
 						unique = cmpResult != 0
 					}
 
+					//gcassert:bce
 					outputCol[outputIdx] = outputCol[outputIdx] || unique
 					{
 						__retval_0 = v
@@ -731,10 +761,8 @@ func (p partitionerInt16) partitionWithOrder(
 
 	col := colVec.Int16()
 	// Eliminate bounds checks.
-	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
 	_ = order[n-1]
-	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for outputIdx := 0; outputIdx < n; outputIdx++ {
@@ -753,12 +781,16 @@ func (p partitionerInt16) partitionWithOrder(
 							// The current value is null, and either the previous one is not
 							// (meaning they are definitely distinct) or we treat nulls as
 							// distinct values.
+							_ = true
+							//gcassert:bce
 							outputCol[outputIdx] = true
 						}
 					} else {
 						v := col.Get(checkIdx)
 						if lastValNull {
 							// The previous value was null while the current is not.
+							_ = true
+							//gcassert:bce
 							outputCol[outputIdx] = true
 						} else {
 							// Neither value is null, so we must compare.
@@ -781,6 +813,7 @@ func (p partitionerInt16) partitionWithOrder(
 								unique = cmpResult != 0
 							}
 
+							//gcassert:bce
 							outputCol[outputIdx] = outputCol[outputIdx] || unique
 						}
 						lastVal = v
@@ -820,6 +853,7 @@ func (p partitionerInt16) partitionWithOrder(
 						unique = cmpResult != 0
 					}
 
+					//gcassert:bce
 					outputCol[outputIdx] = outputCol[outputIdx] || unique
 					{
 						__retval_0 = v
@@ -844,7 +878,6 @@ func (p partitionerInt16) partition(colVec coldata.Vec, outputCol []bool, n int)
 	col := colVec.Int16()
 	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
-	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for idx := 0; idx < n; idx++ {
@@ -865,12 +898,17 @@ func (p partitionerInt16) partition(colVec coldata.Vec, outputCol []bool, n int)
 							// The current value is null, and either the previous one is not
 							// (meaning they are definitely distinct) or we treat nulls as
 							// distinct values.
+							_ = true
+							//gcassert:bce
 							outputCol[outputIdx] = true
 						}
 					} else {
+						//gcassert:bce
 						v := col.Get(checkIdx)
 						if lastValNull {
 							// The previous value was null while the current is not.
+							_ = true
+							//gcassert:bce
 							outputCol[outputIdx] = true
 						} else {
 							// Neither value is null, so we must compare.
@@ -893,6 +931,7 @@ func (p partitionerInt16) partition(colVec coldata.Vec, outputCol []bool, n int)
 								unique = cmpResult != 0
 							}
 
+							//gcassert:bce
 							outputCol[outputIdx] = outputCol[outputIdx] || unique
 						}
 						lastVal = v
@@ -914,6 +953,7 @@ func (p partitionerInt16) partition(colVec coldata.Vec, outputCol []bool, n int)
 						checkIdx  int = idx
 						outputIdx int = idx
 					)
+					//gcassert:bce
 					v := col.Get(checkIdx)
 					var unique bool
 
@@ -934,6 +974,7 @@ func (p partitionerInt16) partition(colVec coldata.Vec, outputCol []bool, n int)
 						unique = cmpResult != 0
 					}
 
+					//gcassert:bce
 					outputCol[outputIdx] = outputCol[outputIdx] || unique
 					{
 						__retval_0 = v
@@ -965,10 +1006,8 @@ func (p partitionerInt32) partitionWithOrder(
 
 	col := colVec.Int32()
 	// Eliminate bounds checks.
-	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
 	_ = order[n-1]
-	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for outputIdx := 0; outputIdx < n; outputIdx++ {
@@ -987,12 +1026,16 @@ func (p partitionerInt32) partitionWithOrder(
 							// The current value is null, and either the previous one is not
 							// (meaning they are definitely distinct) or we treat nulls as
 							// distinct values.
+							_ = true
+							//gcassert:bce
 							outputCol[outputIdx] = true
 						}
 					} else {
 						v := col.Get(checkIdx)
 						if lastValNull {
 							// The previous value was null while the current is not.
+							_ = true
+							//gcassert:bce
 							outputCol[outputIdx] = true
 						} else {
 							// Neither value is null, so we must compare.
@@ -1015,6 +1058,7 @@ func (p partitionerInt32) partitionWithOrder(
 								unique = cmpResult != 0
 							}
 
+							//gcassert:bce
 							outputCol[outputIdx] = outputCol[outputIdx] || unique
 						}
 						lastVal = v
@@ -1054,6 +1098,7 @@ func (p partitionerInt32) partitionWithOrder(
 						unique = cmpResult != 0
 					}
 
+					//gcassert:bce
 					outputCol[outputIdx] = outputCol[outputIdx] || unique
 					{
 						__retval_0 = v
@@ -1078,7 +1123,6 @@ func (p partitionerInt32) partition(colVec coldata.Vec, outputCol []bool, n int)
 	col := colVec.Int32()
 	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
-	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for idx := 0; idx < n; idx++ {
@@ -1099,12 +1143,17 @@ func (p partitionerInt32) partition(colVec coldata.Vec, outputCol []bool, n int)
 							// The current value is null, and either the previous one is not
 							// (meaning they are definitely distinct) or we treat nulls as
 							// distinct values.
+							_ = true
+							//gcassert:bce
 							outputCol[outputIdx] = true
 						}
 					} else {
+						//gcassert:bce
 						v := col.Get(checkIdx)
 						if lastValNull {
 							// The previous value was null while the current is not.
+							_ = true
+							//gcassert:bce
 							outputCol[outputIdx] = true
 						} else {
 							// Neither value is null, so we must compare.
@@ -1127,6 +1176,7 @@ func (p partitionerInt32) partition(colVec coldata.Vec, outputCol []bool, n int)
 								unique = cmpResult != 0
 							}
 
+							//gcassert:bce
 							outputCol[outputIdx] = outputCol[outputIdx] || unique
 						}
 						lastVal = v
@@ -1148,6 +1198,7 @@ func (p partitionerInt32) partition(colVec coldata.Vec, outputCol []bool, n int)
 						checkIdx  int = idx
 						outputIdx int = idx
 					)
+					//gcassert:bce
 					v := col.Get(checkIdx)
 					var unique bool
 
@@ -1168,6 +1219,7 @@ func (p partitionerInt32) partition(colVec coldata.Vec, outputCol []bool, n int)
 						unique = cmpResult != 0
 					}
 
+					//gcassert:bce
 					outputCol[outputIdx] = outputCol[outputIdx] || unique
 					{
 						__retval_0 = v
@@ -1199,10 +1251,8 @@ func (p partitionerInt64) partitionWithOrder(
 
 	col := colVec.Int64()
 	// Eliminate bounds checks.
-	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
 	_ = order[n-1]
-	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for outputIdx := 0; outputIdx < n; outputIdx++ {
@@ -1221,12 +1271,16 @@ func (p partitionerInt64) partitionWithOrder(
 							// The current value is null, and either the previous one is not
 							// (meaning they are definitely distinct) or we treat nulls as
 							// distinct values.
+							_ = true
+							//gcassert:bce
 							outputCol[outputIdx] = true
 						}
 					} else {
 						v := col.Get(checkIdx)
 						if lastValNull {
 							// The previous value was null while the current is not.
+							_ = true
+							//gcassert:bce
 							outputCol[outputIdx] = true
 						} else {
 							// Neither value is null, so we must compare.
@@ -1249,6 +1303,7 @@ func (p partitionerInt64) partitionWithOrder(
 								unique = cmpResult != 0
 							}
 
+							//gcassert:bce
 							outputCol[outputIdx] = outputCol[outputIdx] || unique
 						}
 						lastVal = v
@@ -1288,6 +1343,7 @@ func (p partitionerInt64) partitionWithOrder(
 						unique = cmpResult != 0
 					}
 
+					//gcassert:bce
 					outputCol[outputIdx] = outputCol[outputIdx] || unique
 					{
 						__retval_0 = v
@@ -1312,7 +1368,6 @@ func (p partitionerInt64) partition(colVec coldata.Vec, outputCol []bool, n int)
 	col := colVec.Int64()
 	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
-	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for idx := 0; idx < n; idx++ {
@@ -1333,12 +1388,17 @@ func (p partitionerInt64) partition(colVec coldata.Vec, outputCol []bool, n int)
 							// The current value is null, and either the previous one is not
 							// (meaning they are definitely distinct) or we treat nulls as
 							// distinct values.
+							_ = true
+							//gcassert:bce
 							outputCol[outputIdx] = true
 						}
 					} else {
+						//gcassert:bce
 						v := col.Get(checkIdx)
 						if lastValNull {
 							// The previous value was null while the current is not.
+							_ = true
+							//gcassert:bce
 							outputCol[outputIdx] = true
 						} else {
 							// Neither value is null, so we must compare.
@@ -1361,6 +1421,7 @@ func (p partitionerInt64) partition(colVec coldata.Vec, outputCol []bool, n int)
 								unique = cmpResult != 0
 							}
 
+							//gcassert:bce
 							outputCol[outputIdx] = outputCol[outputIdx] || unique
 						}
 						lastVal = v
@@ -1382,6 +1443,7 @@ func (p partitionerInt64) partition(colVec coldata.Vec, outputCol []bool, n int)
 						checkIdx  int = idx
 						outputIdx int = idx
 					)
+					//gcassert:bce
 					v := col.Get(checkIdx)
 					var unique bool
 
@@ -1402,6 +1464,7 @@ func (p partitionerInt64) partition(colVec coldata.Vec, outputCol []bool, n int)
 						unique = cmpResult != 0
 					}
 
+					//gcassert:bce
 					outputCol[outputIdx] = outputCol[outputIdx] || unique
 					{
 						__retval_0 = v
@@ -1433,10 +1496,8 @@ func (p partitionerFloat64) partitionWithOrder(
 
 	col := colVec.Float64()
 	// Eliminate bounds checks.
-	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
 	_ = order[n-1]
-	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for outputIdx := 0; outputIdx < n; outputIdx++ {
@@ -1455,12 +1516,16 @@ func (p partitionerFloat64) partitionWithOrder(
 							// The current value is null, and either the previous one is not
 							// (meaning they are definitely distinct) or we treat nulls as
 							// distinct values.
+							_ = true
+							//gcassert:bce
 							outputCol[outputIdx] = true
 						}
 					} else {
 						v := col.Get(checkIdx)
 						if lastValNull {
 							// The previous value was null while the current is not.
+							_ = true
+							//gcassert:bce
 							outputCol[outputIdx] = true
 						} else {
 							// Neither value is null, so we must compare.
@@ -1491,6 +1556,7 @@ func (p partitionerFloat64) partitionWithOrder(
 								unique = cmpResult != 0
 							}
 
+							//gcassert:bce
 							outputCol[outputIdx] = outputCol[outputIdx] || unique
 						}
 						lastVal = v
@@ -1538,6 +1604,7 @@ func (p partitionerFloat64) partitionWithOrder(
 						unique = cmpResult != 0
 					}
 
+					//gcassert:bce
 					outputCol[outputIdx] = outputCol[outputIdx] || unique
 					{
 						__retval_0 = v
@@ -1562,7 +1629,6 @@ func (p partitionerFloat64) partition(colVec coldata.Vec, outputCol []bool, n in
 	col := colVec.Float64()
 	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
-	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for idx := 0; idx < n; idx++ {
@@ -1583,12 +1649,17 @@ func (p partitionerFloat64) partition(colVec coldata.Vec, outputCol []bool, n in
 							// The current value is null, and either the previous one is not
 							// (meaning they are definitely distinct) or we treat nulls as
 							// distinct values.
+							_ = true
+							//gcassert:bce
 							outputCol[outputIdx] = true
 						}
 					} else {
+						//gcassert:bce
 						v := col.Get(checkIdx)
 						if lastValNull {
 							// The previous value was null while the current is not.
+							_ = true
+							//gcassert:bce
 							outputCol[outputIdx] = true
 						} else {
 							// Neither value is null, so we must compare.
@@ -1619,6 +1690,7 @@ func (p partitionerFloat64) partition(colVec coldata.Vec, outputCol []bool, n in
 								unique = cmpResult != 0
 							}
 
+							//gcassert:bce
 							outputCol[outputIdx] = outputCol[outputIdx] || unique
 						}
 						lastVal = v
@@ -1640,6 +1712,7 @@ func (p partitionerFloat64) partition(colVec coldata.Vec, outputCol []bool, n in
 						checkIdx  int = idx
 						outputIdx int = idx
 					)
+					//gcassert:bce
 					v := col.Get(checkIdx)
 					var unique bool
 
@@ -1668,6 +1741,7 @@ func (p partitionerFloat64) partition(colVec coldata.Vec, outputCol []bool, n in
 						unique = cmpResult != 0
 					}
 
+					//gcassert:bce
 					outputCol[outputIdx] = outputCol[outputIdx] || unique
 					{
 						__retval_0 = v
@@ -1699,10 +1773,8 @@ func (p partitionerTimestamp) partitionWithOrder(
 
 	col := colVec.Timestamp()
 	// Eliminate bounds checks.
-	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
 	_ = order[n-1]
-	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for outputIdx := 0; outputIdx < n; outputIdx++ {
@@ -1721,12 +1793,16 @@ func (p partitionerTimestamp) partitionWithOrder(
 							// The current value is null, and either the previous one is not
 							// (meaning they are definitely distinct) or we treat nulls as
 							// distinct values.
+							_ = true
+							//gcassert:bce
 							outputCol[outputIdx] = true
 						}
 					} else {
 						v := col.Get(checkIdx)
 						if lastValNull {
 							// The previous value was null while the current is not.
+							_ = true
+							//gcassert:bce
 							outputCol[outputIdx] = true
 						} else {
 							// Neither value is null, so we must compare.
@@ -1745,6 +1821,7 @@ func (p partitionerTimestamp) partitionWithOrder(
 								unique = cmpResult != 0
 							}
 
+							//gcassert:bce
 							outputCol[outputIdx] = outputCol[outputIdx] || unique
 						}
 						lastVal = v
@@ -1780,6 +1857,7 @@ func (p partitionerTimestamp) partitionWithOrder(
 						unique = cmpResult != 0
 					}
 
+					//gcassert:bce
 					outputCol[outputIdx] = outputCol[outputIdx] || unique
 					{
 						__retval_0 = v
@@ -1804,7 +1882,6 @@ func (p partitionerTimestamp) partition(colVec coldata.Vec, outputCol []bool, n 
 	col := colVec.Timestamp()
 	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
-	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for idx := 0; idx < n; idx++ {
@@ -1825,12 +1902,17 @@ func (p partitionerTimestamp) partition(colVec coldata.Vec, outputCol []bool, n 
 							// The current value is null, and either the previous one is not
 							// (meaning they are definitely distinct) or we treat nulls as
 							// distinct values.
+							_ = true
+							//gcassert:bce
 							outputCol[outputIdx] = true
 						}
 					} else {
+						//gcassert:bce
 						v := col.Get(checkIdx)
 						if lastValNull {
 							// The previous value was null while the current is not.
+							_ = true
+							//gcassert:bce
 							outputCol[outputIdx] = true
 						} else {
 							// Neither value is null, so we must compare.
@@ -1849,6 +1931,7 @@ func (p partitionerTimestamp) partition(colVec coldata.Vec, outputCol []bool, n 
 								unique = cmpResult != 0
 							}
 
+							//gcassert:bce
 							outputCol[outputIdx] = outputCol[outputIdx] || unique
 						}
 						lastVal = v
@@ -1870,6 +1953,7 @@ func (p partitionerTimestamp) partition(colVec coldata.Vec, outputCol []bool, n 
 						checkIdx  int = idx
 						outputIdx int = idx
 					)
+					//gcassert:bce
 					v := col.Get(checkIdx)
 					var unique bool
 
@@ -1886,6 +1970,7 @@ func (p partitionerTimestamp) partition(colVec coldata.Vec, outputCol []bool, n 
 						unique = cmpResult != 0
 					}
 
+					//gcassert:bce
 					outputCol[outputIdx] = outputCol[outputIdx] || unique
 					{
 						__retval_0 = v
@@ -1917,10 +2002,8 @@ func (p partitionerInterval) partitionWithOrder(
 
 	col := colVec.Interval()
 	// Eliminate bounds checks.
-	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
 	_ = order[n-1]
-	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for outputIdx := 0; outputIdx < n; outputIdx++ {
@@ -1939,12 +2022,16 @@ func (p partitionerInterval) partitionWithOrder(
 							// The current value is null, and either the previous one is not
 							// (meaning they are definitely distinct) or we treat nulls as
 							// distinct values.
+							_ = true
+							//gcassert:bce
 							outputCol[outputIdx] = true
 						}
 					} else {
 						v := col.Get(checkIdx)
 						if lastValNull {
 							// The previous value was null while the current is not.
+							_ = true
+							//gcassert:bce
 							outputCol[outputIdx] = true
 						} else {
 							// Neither value is null, so we must compare.
@@ -1956,6 +2043,7 @@ func (p partitionerInterval) partitionWithOrder(
 								unique = cmpResult != 0
 							}
 
+							//gcassert:bce
 							outputCol[outputIdx] = outputCol[outputIdx] || unique
 						}
 						lastVal = v
@@ -1984,6 +2072,7 @@ func (p partitionerInterval) partitionWithOrder(
 						unique = cmpResult != 0
 					}
 
+					//gcassert:bce
 					outputCol[outputIdx] = outputCol[outputIdx] || unique
 					{
 						__retval_0 = v
@@ -2008,7 +2097,6 @@ func (p partitionerInterval) partition(colVec coldata.Vec, outputCol []bool, n i
 	col := colVec.Interval()
 	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
-	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for idx := 0; idx < n; idx++ {
@@ -2029,12 +2117,17 @@ func (p partitionerInterval) partition(colVec coldata.Vec, outputCol []bool, n i
 							// The current value is null, and either the previous one is not
 							// (meaning they are definitely distinct) or we treat nulls as
 							// distinct values.
+							_ = true
+							//gcassert:bce
 							outputCol[outputIdx] = true
 						}
 					} else {
+						//gcassert:bce
 						v := col.Get(checkIdx)
 						if lastValNull {
 							// The previous value was null while the current is not.
+							_ = true
+							//gcassert:bce
 							outputCol[outputIdx] = true
 						} else {
 							// Neither value is null, so we must compare.
@@ -2046,6 +2139,7 @@ func (p partitionerInterval) partition(colVec coldata.Vec, outputCol []bool, n i
 								unique = cmpResult != 0
 							}
 
+							//gcassert:bce
 							outputCol[outputIdx] = outputCol[outputIdx] || unique
 						}
 						lastVal = v
@@ -2067,6 +2161,7 @@ func (p partitionerInterval) partition(colVec coldata.Vec, outputCol []bool, n i
 						checkIdx  int = idx
 						outputIdx int = idx
 					)
+					//gcassert:bce
 					v := col.Get(checkIdx)
 					var unique bool
 
@@ -2076,6 +2171,7 @@ func (p partitionerInterval) partition(colVec coldata.Vec, outputCol []bool, n i
 						unique = cmpResult != 0
 					}
 
+					//gcassert:bce
 					outputCol[outputIdx] = outputCol[outputIdx] || unique
 					{
 						__retval_0 = v
@@ -2107,10 +2203,8 @@ func (p partitionerJSON) partitionWithOrder(
 
 	col := colVec.JSON()
 	// Eliminate bounds checks.
-	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
 	_ = order[n-1]
-	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for outputIdx := 0; outputIdx < n; outputIdx++ {
@@ -2129,12 +2223,16 @@ func (p partitionerJSON) partitionWithOrder(
 							// The current value is null, and either the previous one is not
 							// (meaning they are definitely distinct) or we treat nulls as
 							// distinct values.
+							_ = true
+							//gcassert:bce
 							outputCol[outputIdx] = true
 						}
 					} else {
 						v := col.Get(checkIdx)
 						if lastValNull {
 							// The previous value was null while the current is not.
+							_ = true
+							//gcassert:bce
 							outputCol[outputIdx] = true
 						} else {
 							// Neither value is null, so we must compare.
@@ -2152,6 +2250,7 @@ func (p partitionerJSON) partitionWithOrder(
 								unique = cmpResult != 0
 							}
 
+							//gcassert:bce
 							outputCol[outputIdx] = outputCol[outputIdx] || unique
 						}
 						lastVal = v
@@ -2186,6 +2285,7 @@ func (p partitionerJSON) partitionWithOrder(
 						unique = cmpResult != 0
 					}
 
+					//gcassert:bce
 					outputCol[outputIdx] = outputCol[outputIdx] || unique
 					{
 						__retval_0 = v
@@ -2208,9 +2308,7 @@ func (p partitionerJSON) partition(colVec coldata.Vec, outputCol []bool, n int) 
 	}
 
 	col := colVec.JSON()
-	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
-	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for idx := 0; idx < n; idx++ {
@@ -2231,12 +2329,16 @@ func (p partitionerJSON) partition(colVec coldata.Vec, outputCol []bool, n int) 
 							// The current value is null, and either the previous one is not
 							// (meaning they are definitely distinct) or we treat nulls as
 							// distinct values.
+							_ = true
+							//gcassert:bce
 							outputCol[outputIdx] = true
 						}
 					} else {
 						v := col.Get(checkIdx)
 						if lastValNull {
 							// The previous value was null while the current is not.
+							_ = true
+							//gcassert:bce
 							outputCol[outputIdx] = true
 						} else {
 							// Neither value is null, so we must compare.
@@ -2254,6 +2356,7 @@ func (p partitionerJSON) partition(colVec coldata.Vec, outputCol []bool, n int) 
 								unique = cmpResult != 0
 							}
 
+							//gcassert:bce
 							outputCol[outputIdx] = outputCol[outputIdx] || unique
 						}
 						lastVal = v
@@ -2290,6 +2393,7 @@ func (p partitionerJSON) partition(colVec coldata.Vec, outputCol []bool, n int) 
 						unique = cmpResult != 0
 					}
 
+					//gcassert:bce
 					outputCol[outputIdx] = outputCol[outputIdx] || unique
 					{
 						__retval_0 = v
@@ -2321,10 +2425,8 @@ func (p partitionerDatum) partitionWithOrder(
 
 	col := colVec.Datum()
 	// Eliminate bounds checks.
-	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
 	_ = order[n-1]
-	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for outputIdx := 0; outputIdx < n; outputIdx++ {
@@ -2343,12 +2445,16 @@ func (p partitionerDatum) partitionWithOrder(
 							// The current value is null, and either the previous one is not
 							// (meaning they are definitely distinct) or we treat nulls as
 							// distinct values.
+							_ = true
+							//gcassert:bce
 							outputCol[outputIdx] = true
 						}
 					} else {
 						v := col.Get(checkIdx)
 						if lastValNull {
 							// The previous value was null while the current is not.
+							_ = true
+							//gcassert:bce
 							outputCol[outputIdx] = true
 						} else {
 							// Neither value is null, so we must compare.
@@ -2362,6 +2468,7 @@ func (p partitionerDatum) partitionWithOrder(
 								unique = cmpResult != 0
 							}
 
+							//gcassert:bce
 							outputCol[outputIdx] = outputCol[outputIdx] || unique
 						}
 						lastVal = v
@@ -2392,6 +2499,7 @@ func (p partitionerDatum) partitionWithOrder(
 						unique = cmpResult != 0
 					}
 
+					//gcassert:bce
 					outputCol[outputIdx] = outputCol[outputIdx] || unique
 					{
 						__retval_0 = v
@@ -2414,9 +2522,7 @@ func (p partitionerDatum) partition(colVec coldata.Vec, outputCol []bool, n int)
 	}
 
 	col := colVec.Datum()
-	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
-	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for idx := 0; idx < n; idx++ {
@@ -2437,12 +2543,16 @@ func (p partitionerDatum) partition(colVec coldata.Vec, outputCol []bool, n int)
 							// The current value is null, and either the previous one is not
 							// (meaning they are definitely distinct) or we treat nulls as
 							// distinct values.
+							_ = true
+							//gcassert:bce
 							outputCol[outputIdx] = true
 						}
 					} else {
 						v := col.Get(checkIdx)
 						if lastValNull {
 							// The previous value was null while the current is not.
+							_ = true
+							//gcassert:bce
 							outputCol[outputIdx] = true
 						} else {
 							// Neither value is null, so we must compare.
@@ -2456,6 +2566,7 @@ func (p partitionerDatum) partition(colVec coldata.Vec, outputCol []bool, n int)
 								unique = cmpResult != 0
 							}
 
+							//gcassert:bce
 							outputCol[outputIdx] = outputCol[outputIdx] || unique
 						}
 						lastVal = v
@@ -2488,6 +2599,7 @@ func (p partitionerDatum) partition(colVec coldata.Vec, outputCol []bool, n int)
 						unique = cmpResult != 0
 					}
 
+					//gcassert:bce
 					outputCol[outputIdx] = outputCol[outputIdx] || unique
 					{
 						__retval_0 = v

--- a/pkg/sql/colexec/sort_partitioner.eg.go
+++ b/pkg/sql/colexec/sort_partitioner.eg.go
@@ -131,10 +131,12 @@ func (p partitionerBool) partitionWithOrder(
 	// Eliminate bounds checks.
 	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
+	_ = order[n-1]
 	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for outputIdx := 0; outputIdx < n; outputIdx++ {
+			//gcassert:bce
 			checkIdx := order[outputIdx]
 			{
 				var (
@@ -188,6 +190,7 @@ func (p partitionerBool) partitionWithOrder(
 		}
 	} else {
 		for outputIdx := 0; outputIdx < n; outputIdx++ {
+			//gcassert:bce
 			checkIdx := order[outputIdx]
 			{
 				var __retval_0 bool
@@ -350,10 +353,12 @@ func (p partitionerBytes) partitionWithOrder(
 	// Eliminate bounds checks.
 	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
+	_ = order[n-1]
 	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for outputIdx := 0; outputIdx < n; outputIdx++ {
+			//gcassert:bce
 			checkIdx := order[outputIdx]
 			{
 				var (
@@ -399,6 +404,7 @@ func (p partitionerBytes) partitionWithOrder(
 		}
 	} else {
 		for outputIdx := 0; outputIdx < n; outputIdx++ {
+			//gcassert:bce
 			checkIdx := order[outputIdx]
 			{
 				var __retval_0 []byte
@@ -537,10 +543,12 @@ func (p partitionerDecimal) partitionWithOrder(
 	// Eliminate bounds checks.
 	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
+	_ = order[n-1]
 	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for outputIdx := 0; outputIdx < n; outputIdx++ {
+			//gcassert:bce
 			checkIdx := order[outputIdx]
 			{
 				var (
@@ -586,6 +594,7 @@ func (p partitionerDecimal) partitionWithOrder(
 		}
 	} else {
 		for outputIdx := 0; outputIdx < n; outputIdx++ {
+			//gcassert:bce
 			checkIdx := order[outputIdx]
 			{
 				var __retval_0 apd.Decimal
@@ -724,10 +733,12 @@ func (p partitionerInt16) partitionWithOrder(
 	// Eliminate bounds checks.
 	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
+	_ = order[n-1]
 	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for outputIdx := 0; outputIdx < n; outputIdx++ {
+			//gcassert:bce
 			checkIdx := order[outputIdx]
 			{
 				var (
@@ -784,6 +795,7 @@ func (p partitionerInt16) partitionWithOrder(
 		}
 	} else {
 		for outputIdx := 0; outputIdx < n; outputIdx++ {
+			//gcassert:bce
 			checkIdx := order[outputIdx]
 			{
 				var __retval_0 int16
@@ -955,10 +967,12 @@ func (p partitionerInt32) partitionWithOrder(
 	// Eliminate bounds checks.
 	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
+	_ = order[n-1]
 	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for outputIdx := 0; outputIdx < n; outputIdx++ {
+			//gcassert:bce
 			checkIdx := order[outputIdx]
 			{
 				var (
@@ -1015,6 +1029,7 @@ func (p partitionerInt32) partitionWithOrder(
 		}
 	} else {
 		for outputIdx := 0; outputIdx < n; outputIdx++ {
+			//gcassert:bce
 			checkIdx := order[outputIdx]
 			{
 				var __retval_0 int32
@@ -1186,10 +1201,12 @@ func (p partitionerInt64) partitionWithOrder(
 	// Eliminate bounds checks.
 	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
+	_ = order[n-1]
 	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for outputIdx := 0; outputIdx < n; outputIdx++ {
+			//gcassert:bce
 			checkIdx := order[outputIdx]
 			{
 				var (
@@ -1246,6 +1263,7 @@ func (p partitionerInt64) partitionWithOrder(
 		}
 	} else {
 		for outputIdx := 0; outputIdx < n; outputIdx++ {
+			//gcassert:bce
 			checkIdx := order[outputIdx]
 			{
 				var __retval_0 int64
@@ -1417,10 +1435,12 @@ func (p partitionerFloat64) partitionWithOrder(
 	// Eliminate bounds checks.
 	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
+	_ = order[n-1]
 	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for outputIdx := 0; outputIdx < n; outputIdx++ {
+			//gcassert:bce
 			checkIdx := order[outputIdx]
 			{
 				var (
@@ -1485,6 +1505,7 @@ func (p partitionerFloat64) partitionWithOrder(
 		}
 	} else {
 		for outputIdx := 0; outputIdx < n; outputIdx++ {
+			//gcassert:bce
 			checkIdx := order[outputIdx]
 			{
 				var __retval_0 float64
@@ -1680,10 +1701,12 @@ func (p partitionerTimestamp) partitionWithOrder(
 	// Eliminate bounds checks.
 	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
+	_ = order[n-1]
 	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for outputIdx := 0; outputIdx < n; outputIdx++ {
+			//gcassert:bce
 			checkIdx := order[outputIdx]
 			{
 				var (
@@ -1736,6 +1759,7 @@ func (p partitionerTimestamp) partitionWithOrder(
 		}
 	} else {
 		for outputIdx := 0; outputIdx < n; outputIdx++ {
+			//gcassert:bce
 			checkIdx := order[outputIdx]
 			{
 				var __retval_0 time.Time
@@ -1895,10 +1919,12 @@ func (p partitionerInterval) partitionWithOrder(
 	// Eliminate bounds checks.
 	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
+	_ = order[n-1]
 	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for outputIdx := 0; outputIdx < n; outputIdx++ {
+			//gcassert:bce
 			checkIdx := order[outputIdx]
 			{
 				var (
@@ -1944,6 +1970,7 @@ func (p partitionerInterval) partitionWithOrder(
 		}
 	} else {
 		for outputIdx := 0; outputIdx < n; outputIdx++ {
+			//gcassert:bce
 			checkIdx := order[outputIdx]
 			{
 				var __retval_0 duration.Duration
@@ -2082,10 +2109,12 @@ func (p partitionerJSON) partitionWithOrder(
 	// Eliminate bounds checks.
 	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
+	_ = order[n-1]
 	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for outputIdx := 0; outputIdx < n; outputIdx++ {
+			//gcassert:bce
 			checkIdx := order[outputIdx]
 			{
 				var (
@@ -2137,6 +2166,7 @@ func (p partitionerJSON) partitionWithOrder(
 		}
 	} else {
 		for outputIdx := 0; outputIdx < n; outputIdx++ {
+			//gcassert:bce
 			checkIdx := order[outputIdx]
 			{
 				var __retval_0 json.JSON
@@ -2293,10 +2323,12 @@ func (p partitionerDatum) partitionWithOrder(
 	// Eliminate bounds checks.
 	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
+	_ = order[n-1]
 	// TODO(yuzefovich): add BCE assertions for these.
 	outputCol[0] = true
 	if nulls != nil {
 		for outputIdx := 0; outputIdx < n; outputIdx++ {
+			//gcassert:bce
 			checkIdx := order[outputIdx]
 			{
 				var (
@@ -2344,6 +2376,7 @@ func (p partitionerDatum) partitionWithOrder(
 		}
 	} else {
 		for outputIdx := 0; outputIdx < n; outputIdx++ {
+			//gcassert:bce
 			checkIdx := order[outputIdx]
 			{
 				var __retval_0 interface{}

--- a/pkg/sql/colexec/sort_utils.go
+++ b/pkg/sql/colexec/sort_utils.go
@@ -10,7 +10,7 @@
 
 package colexec
 
-func boolVecToSel64(vec []bool, sel []int) []int {
+func boolVecToSel(vec []bool, sel []int) []int {
 	l := len(vec)
 	for i := 0; i < l; i++ {
 		if vec[i] {


### PR DESCRIPTION
**colexec: improve sort operator a bit**

Previously, we were missing memory accounting around some slices
allocated internally by the sort operator which is now added.
Additionally, the references to those slices are now kept by the
operator which will be useful when the sorter is used by the external
sorter.

Additionally, this commit eliminates some bounds checks.

Release note: None

**colexec: add some BCE assertions for distinct and sort**

This is achieved by templating the inlined execgen functions. Note that
in some cases this templating leaves redundant `_ = true` lines, but
figuring out what's up with that is left as a TODO.

Additionally, this commit removes some redundant attempts at achieving
BCE for non-sliceable vectors (which had a negative impact in case of
JSONs) and clarifies the name of a utility function.

Release note: None