### PR TITLE
colexecjoin: pull out a constant calculation from loops in merge joins

### DIFF
--- a/pkg/sql/colexec/colexecjoin/mergejoiner_exceptall.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_exceptall.eg.go
@@ -10790,6 +10790,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 	o.unlimitedAllocator.PerformOperation(
 		o.output.ColVecs()[:len(input.sourceTypes)],
 		func() {
+			outputCapacity := o.output.Capacity()
 			// Loop over every column.
 		LeftColLoop:
 			for colIdx := range input.sourceTypes {
@@ -10837,8 +10838,8 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10902,8 +10903,8 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10967,8 +10968,8 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11031,8 +11032,8 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11092,8 +11093,8 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11154,8 +11155,8 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11219,8 +11220,8 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11284,8 +11285,8 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11349,8 +11350,8 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11414,8 +11415,8 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11479,8 +11480,8 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11553,8 +11554,8 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11617,8 +11618,8 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11681,8 +11682,8 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11744,8 +11745,8 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11804,8 +11805,8 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11865,8 +11866,8 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11929,8 +11930,8 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11993,8 +11994,8 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -12057,8 +12058,8 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -12121,8 +12122,8 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -12185,8 +12186,8 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -12257,6 +12258,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 	o.unlimitedAllocator.PerformOperation(
 		o.output.ColVecs()[colOffset:colOffset+len(input.sourceTypes)],
 		func() {
+			outputCapacity := o.output.Capacity()
 			// Loop over every column.
 		RightColLoop:
 			for colIdx := range input.sourceTypes {
@@ -12292,8 +12294,8 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -12361,8 +12363,8 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -12430,8 +12432,8 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -12498,8 +12500,8 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -12563,8 +12565,8 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -12629,8 +12631,8 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -12698,8 +12700,8 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -12767,8 +12769,8 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -12836,8 +12838,8 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -12905,8 +12907,8 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -12974,8 +12976,8 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -13053,8 +13055,8 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -13122,8 +13124,8 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -13191,8 +13193,8 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -13259,8 +13261,8 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -13324,8 +13326,8 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -13390,8 +13392,8 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -13459,8 +13461,8 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -13528,8 +13530,8 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -13597,8 +13599,8 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -13666,8 +13668,8 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -13735,8 +13737,8 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -13868,6 +13870,7 @@ func (o *mergeJoinExceptAllOp) exhaustRightSource() {
 // accordingly.
 func (o *mergeJoinExceptAllOp) calculateOutputCount(groups []group) int {
 	count := o.builderState.outCount
+	outputCapacity := o.output.Capacity()
 
 	for i := 0; i < len(groups); i++ {
 		if !groups[i].unmatched {
@@ -13879,8 +13882,8 @@ func (o *mergeJoinExceptAllOp) calculateOutputCount(groups []group) int {
 		count += groups[i].toBuild
 		groups[i].toBuild = 0
 		if count > o.output.Capacity() {
-			groups[i].toBuild = count - o.output.Capacity()
-			count = o.output.Capacity()
+			groups[i].toBuild = count - outputCapacity
+			count = outputCapacity
 			return count
 		}
 	}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_fullouter.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_fullouter.eg.go
@@ -11838,6 +11838,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 	o.unlimitedAllocator.PerformOperation(
 		o.output.ColVecs()[:len(input.sourceTypes)],
 		func() {
+			outputCapacity := o.output.Capacity()
 			// Loop over every column.
 		LeftColLoop:
 			for colIdx := range input.sourceTypes {
@@ -11882,8 +11883,8 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -11947,8 +11948,8 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -12012,8 +12013,8 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -12076,8 +12077,8 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -12137,8 +12138,8 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -12199,8 +12200,8 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -12264,8 +12265,8 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -12329,8 +12330,8 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -12394,8 +12395,8 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -12459,8 +12460,8 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -12524,8 +12525,8 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -12598,8 +12599,8 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -12662,8 +12663,8 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -12726,8 +12727,8 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -12789,8 +12790,8 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -12849,8 +12850,8 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -12910,8 +12911,8 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -12974,8 +12975,8 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -13038,8 +13039,8 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -13102,8 +13103,8 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -13166,8 +13167,8 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -13230,8 +13231,8 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -13305,6 +13306,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 	o.unlimitedAllocator.PerformOperation(
 		o.output.ColVecs()[colOffset:colOffset+len(input.sourceTypes)],
 		func() {
+			outputCapacity := o.output.Capacity()
 			// Loop over every column.
 		RightColLoop:
 			for colIdx := range input.sourceTypes {
@@ -13340,8 +13342,8 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if rightGroup.nullGroup {
@@ -13411,8 +13413,8 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if rightGroup.nullGroup {
@@ -13482,8 +13484,8 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if rightGroup.nullGroup {
@@ -13552,8 +13554,8 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if rightGroup.nullGroup {
@@ -13619,8 +13621,8 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if rightGroup.nullGroup {
@@ -13687,8 +13689,8 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if rightGroup.nullGroup {
@@ -13758,8 +13760,8 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if rightGroup.nullGroup {
@@ -13829,8 +13831,8 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if rightGroup.nullGroup {
@@ -13900,8 +13902,8 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if rightGroup.nullGroup {
@@ -13971,8 +13973,8 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if rightGroup.nullGroup {
@@ -14042,8 +14044,8 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if rightGroup.nullGroup {
@@ -14123,8 +14125,8 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if rightGroup.nullGroup {
@@ -14194,8 +14196,8 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if rightGroup.nullGroup {
@@ -14265,8 +14267,8 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if rightGroup.nullGroup {
@@ -14335,8 +14337,8 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if rightGroup.nullGroup {
@@ -14402,8 +14404,8 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if rightGroup.nullGroup {
@@ -14470,8 +14472,8 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if rightGroup.nullGroup {
@@ -14541,8 +14543,8 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if rightGroup.nullGroup {
@@ -14612,8 +14614,8 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if rightGroup.nullGroup {
@@ -14683,8 +14685,8 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if rightGroup.nullGroup {
@@ -14754,8 +14756,8 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if rightGroup.nullGroup {
@@ -14825,8 +14827,8 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if rightGroup.nullGroup {
@@ -14986,13 +14988,14 @@ func (o *mergeJoinFullOuterOp) exhaustRightSource() {
 // accordingly.
 func (o *mergeJoinFullOuterOp) calculateOutputCount(groups []group) int {
 	count := o.builderState.outCount
+	outputCapacity := o.output.Capacity()
 
 	for i := 0; i < len(groups); i++ {
 		count += groups[i].toBuild
 		groups[i].toBuild = 0
 		if count > o.output.Capacity() {
-			groups[i].toBuild = count - o.output.Capacity()
-			count = o.output.Capacity()
+			groups[i].toBuild = count - outputCapacity
+			count = outputCapacity
 			return count
 		}
 	}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_inner.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_inner.eg.go
@@ -7410,6 +7410,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 	o.unlimitedAllocator.PerformOperation(
 		o.output.ColVecs()[:len(input.sourceTypes)],
 		func() {
+			outputCapacity := o.output.Capacity()
 			// Loop over every column.
 		LeftColLoop:
 			for colIdx := range input.sourceTypes {
@@ -7454,8 +7455,8 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -7516,8 +7517,8 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -7578,8 +7579,8 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -7639,8 +7640,8 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -7697,8 +7698,8 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -7756,8 +7757,8 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -7818,8 +7819,8 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -7880,8 +7881,8 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -7942,8 +7943,8 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8004,8 +8005,8 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8066,8 +8067,8 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8137,8 +8138,8 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8198,8 +8199,8 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8259,8 +8260,8 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8319,8 +8320,8 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8376,8 +8377,8 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8434,8 +8435,8 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8495,8 +8496,8 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8556,8 +8557,8 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8617,8 +8618,8 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8678,8 +8679,8 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8739,8 +8740,8 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8811,6 +8812,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 	o.unlimitedAllocator.PerformOperation(
 		o.output.ColVecs()[colOffset:colOffset+len(input.sourceTypes)],
 		func() {
+			outputCapacity := o.output.Capacity()
 			// Loop over every column.
 		RightColLoop:
 			for colIdx := range input.sourceTypes {
@@ -8846,8 +8848,8 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8915,8 +8917,8 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8984,8 +8986,8 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9052,8 +9054,8 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9117,8 +9119,8 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9183,8 +9185,8 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9252,8 +9254,8 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9321,8 +9323,8 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9390,8 +9392,8 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9459,8 +9461,8 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9528,8 +9530,8 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9607,8 +9609,8 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9676,8 +9678,8 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9745,8 +9747,8 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9813,8 +9815,8 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9878,8 +9880,8 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9944,8 +9946,8 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10013,8 +10015,8 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10082,8 +10084,8 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10151,8 +10153,8 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10220,8 +10222,8 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10289,8 +10291,8 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10410,13 +10412,14 @@ func (o *mergeJoinInnerOp) exhaustRightSource() {
 // accordingly.
 func (o *mergeJoinInnerOp) calculateOutputCount(groups []group) int {
 	count := o.builderState.outCount
+	outputCapacity := o.output.Capacity()
 
 	for i := 0; i < len(groups); i++ {
 		count += groups[i].toBuild
 		groups[i].toBuild = 0
 		if count > o.output.Capacity() {
-			groups[i].toBuild = count - o.output.Capacity()
-			count = o.output.Capacity()
+			groups[i].toBuild = count - outputCapacity
+			count = outputCapacity
 			return count
 		}
 	}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_intersectall.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_intersectall.eg.go
@@ -8246,6 +8246,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 	o.unlimitedAllocator.PerformOperation(
 		o.output.ColVecs()[:len(input.sourceTypes)],
 		func() {
+			outputCapacity := o.output.Capacity()
 			// Loop over every column.
 		LeftColLoop:
 			for colIdx := range input.sourceTypes {
@@ -8290,8 +8291,8 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8352,8 +8353,8 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8414,8 +8415,8 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8475,8 +8476,8 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8533,8 +8534,8 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8592,8 +8593,8 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8654,8 +8655,8 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8716,8 +8717,8 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8778,8 +8779,8 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8840,8 +8841,8 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8902,8 +8903,8 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8973,8 +8974,8 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9034,8 +9035,8 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9095,8 +9096,8 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9155,8 +9156,8 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9212,8 +9213,8 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9270,8 +9271,8 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9331,8 +9332,8 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9392,8 +9393,8 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9453,8 +9454,8 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9514,8 +9515,8 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9575,8 +9576,8 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9647,6 +9648,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 	o.unlimitedAllocator.PerformOperation(
 		o.output.ColVecs()[colOffset:colOffset+len(input.sourceTypes)],
 		func() {
+			outputCapacity := o.output.Capacity()
 			// Loop over every column.
 		RightColLoop:
 			for colIdx := range input.sourceTypes {
@@ -9682,8 +9684,8 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9751,8 +9753,8 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9820,8 +9822,8 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9888,8 +9890,8 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9953,8 +9955,8 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10019,8 +10021,8 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10088,8 +10090,8 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10157,8 +10159,8 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10226,8 +10228,8 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10295,8 +10297,8 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10364,8 +10366,8 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10443,8 +10445,8 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10512,8 +10514,8 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10581,8 +10583,8 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10649,8 +10651,8 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10714,8 +10716,8 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10780,8 +10782,8 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10849,8 +10851,8 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10918,8 +10920,8 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10987,8 +10989,8 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11056,8 +11058,8 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11125,8 +11127,8 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11246,13 +11248,14 @@ func (o *mergeJoinIntersectAllOp) exhaustRightSource() {
 // accordingly.
 func (o *mergeJoinIntersectAllOp) calculateOutputCount(groups []group) int {
 	count := o.builderState.outCount
+	outputCapacity := o.output.Capacity()
 
 	for i := 0; i < len(groups); i++ {
 		count += groups[i].toBuild
 		groups[i].toBuild = 0
 		if count > o.output.Capacity() {
-			groups[i].toBuild = count - o.output.Capacity()
-			count = o.output.Capacity()
+			groups[i].toBuild = count - outputCapacity
+			count = outputCapacity
 			return count
 		}
 	}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_leftanti.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_leftanti.eg.go
@@ -9602,6 +9602,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 	o.unlimitedAllocator.PerformOperation(
 		o.output.ColVecs()[:len(input.sourceTypes)],
 		func() {
+			outputCapacity := o.output.Capacity()
 			// Loop over every column.
 		LeftColLoop:
 			for colIdx := range input.sourceTypes {
@@ -9649,8 +9650,8 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9714,8 +9715,8 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9779,8 +9780,8 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9843,8 +9844,8 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9904,8 +9905,8 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9966,8 +9967,8 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10031,8 +10032,8 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10096,8 +10097,8 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10161,8 +10162,8 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10226,8 +10227,8 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10291,8 +10292,8 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10365,8 +10366,8 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10429,8 +10430,8 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10493,8 +10494,8 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10556,8 +10557,8 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10616,8 +10617,8 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10677,8 +10678,8 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10741,8 +10742,8 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10805,8 +10806,8 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10869,8 +10870,8 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10933,8 +10934,8 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10997,8 +10998,8 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11069,6 +11070,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 	o.unlimitedAllocator.PerformOperation(
 		o.output.ColVecs()[colOffset:colOffset+len(input.sourceTypes)],
 		func() {
+			outputCapacity := o.output.Capacity()
 			// Loop over every column.
 		RightColLoop:
 			for colIdx := range input.sourceTypes {
@@ -11104,8 +11106,8 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11173,8 +11175,8 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11242,8 +11244,8 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11310,8 +11312,8 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11375,8 +11377,8 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11441,8 +11443,8 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11510,8 +11512,8 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11579,8 +11581,8 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11648,8 +11650,8 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11717,8 +11719,8 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11786,8 +11788,8 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11865,8 +11867,8 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11934,8 +11936,8 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -12003,8 +12005,8 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -12071,8 +12073,8 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -12136,8 +12138,8 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -12202,8 +12204,8 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -12271,8 +12273,8 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -12340,8 +12342,8 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -12409,8 +12411,8 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -12478,8 +12480,8 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -12547,8 +12549,8 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -12680,6 +12682,7 @@ func (o *mergeJoinLeftAntiOp) exhaustRightSource() {
 // accordingly.
 func (o *mergeJoinLeftAntiOp) calculateOutputCount(groups []group) int {
 	count := o.builderState.outCount
+	outputCapacity := o.output.Capacity()
 
 	for i := 0; i < len(groups); i++ {
 		if !groups[i].unmatched {
@@ -12691,8 +12694,8 @@ func (o *mergeJoinLeftAntiOp) calculateOutputCount(groups []group) int {
 		count += groups[i].toBuild
 		groups[i].toBuild = 0
 		if count > o.output.Capacity() {
-			groups[i].toBuild = count - o.output.Capacity()
-			count = o.output.Capacity()
+			groups[i].toBuild = count - outputCapacity
+			count = outputCapacity
 			return count
 		}
 	}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_leftouter.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_leftouter.eg.go
@@ -9646,6 +9646,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 	o.unlimitedAllocator.PerformOperation(
 		o.output.ColVecs()[:len(input.sourceTypes)],
 		func() {
+			outputCapacity := o.output.Capacity()
 			// Loop over every column.
 		LeftColLoop:
 			for colIdx := range input.sourceTypes {
@@ -9690,8 +9691,8 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9752,8 +9753,8 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9814,8 +9815,8 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9875,8 +9876,8 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9933,8 +9934,8 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9992,8 +9993,8 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10054,8 +10055,8 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10116,8 +10117,8 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10178,8 +10179,8 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10240,8 +10241,8 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10302,8 +10303,8 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10373,8 +10374,8 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10434,8 +10435,8 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10495,8 +10496,8 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10555,8 +10556,8 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10612,8 +10613,8 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10670,8 +10671,8 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10731,8 +10732,8 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10792,8 +10793,8 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10853,8 +10854,8 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10914,8 +10915,8 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10975,8 +10976,8 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11047,6 +11048,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 	o.unlimitedAllocator.PerformOperation(
 		o.output.ColVecs()[colOffset:colOffset+len(input.sourceTypes)],
 		func() {
+			outputCapacity := o.output.Capacity()
 			// Loop over every column.
 		RightColLoop:
 			for colIdx := range input.sourceTypes {
@@ -11082,8 +11084,8 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if rightGroup.nullGroup {
@@ -11153,8 +11155,8 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if rightGroup.nullGroup {
@@ -11224,8 +11226,8 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if rightGroup.nullGroup {
@@ -11294,8 +11296,8 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if rightGroup.nullGroup {
@@ -11361,8 +11363,8 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if rightGroup.nullGroup {
@@ -11429,8 +11431,8 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if rightGroup.nullGroup {
@@ -11500,8 +11502,8 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if rightGroup.nullGroup {
@@ -11571,8 +11573,8 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if rightGroup.nullGroup {
@@ -11642,8 +11644,8 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if rightGroup.nullGroup {
@@ -11713,8 +11715,8 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if rightGroup.nullGroup {
@@ -11784,8 +11786,8 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if rightGroup.nullGroup {
@@ -11865,8 +11867,8 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if rightGroup.nullGroup {
@@ -11936,8 +11938,8 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if rightGroup.nullGroup {
@@ -12007,8 +12009,8 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if rightGroup.nullGroup {
@@ -12077,8 +12079,8 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if rightGroup.nullGroup {
@@ -12144,8 +12146,8 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if rightGroup.nullGroup {
@@ -12212,8 +12214,8 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if rightGroup.nullGroup {
@@ -12283,8 +12285,8 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if rightGroup.nullGroup {
@@ -12354,8 +12356,8 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if rightGroup.nullGroup {
@@ -12425,8 +12427,8 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if rightGroup.nullGroup {
@@ -12496,8 +12498,8 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if rightGroup.nullGroup {
@@ -12567,8 +12569,8 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if rightGroup.nullGroup {
@@ -12710,13 +12712,14 @@ func (o *mergeJoinLeftOuterOp) exhaustRightSource() {
 // accordingly.
 func (o *mergeJoinLeftOuterOp) calculateOutputCount(groups []group) int {
 	count := o.builderState.outCount
+	outputCapacity := o.output.Capacity()
 
 	for i := 0; i < len(groups); i++ {
 		count += groups[i].toBuild
 		groups[i].toBuild = 0
 		if count > o.output.Capacity() {
-			groups[i].toBuild = count - o.output.Capacity()
-			count = o.output.Capacity()
+			groups[i].toBuild = count - outputCapacity
+			count = outputCapacity
 			return count
 		}
 	}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_leftsemi.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_leftsemi.eg.go
@@ -7366,6 +7366,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 	o.unlimitedAllocator.PerformOperation(
 		o.output.ColVecs()[:len(input.sourceTypes)],
 		func() {
+			outputCapacity := o.output.Capacity()
 			// Loop over every column.
 		LeftColLoop:
 			for colIdx := range input.sourceTypes {
@@ -7410,8 +7411,8 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -7472,8 +7473,8 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -7534,8 +7535,8 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -7595,8 +7596,8 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -7653,8 +7654,8 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -7712,8 +7713,8 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -7774,8 +7775,8 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -7836,8 +7837,8 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -7898,8 +7899,8 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -7960,8 +7961,8 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8022,8 +8023,8 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8093,8 +8094,8 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8154,8 +8155,8 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8215,8 +8216,8 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8275,8 +8276,8 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8332,8 +8333,8 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8390,8 +8391,8 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8451,8 +8452,8 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8512,8 +8513,8 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8573,8 +8574,8 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8634,8 +8635,8 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8695,8 +8696,8 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8767,6 +8768,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 	o.unlimitedAllocator.PerformOperation(
 		o.output.ColVecs()[colOffset:colOffset+len(input.sourceTypes)],
 		func() {
+			outputCapacity := o.output.Capacity()
 			// Loop over every column.
 		RightColLoop:
 			for colIdx := range input.sourceTypes {
@@ -8802,8 +8804,8 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8871,8 +8873,8 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8940,8 +8942,8 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9008,8 +9010,8 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9073,8 +9075,8 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9139,8 +9141,8 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9208,8 +9210,8 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9277,8 +9279,8 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9346,8 +9348,8 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9415,8 +9417,8 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9484,8 +9486,8 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9563,8 +9565,8 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9632,8 +9634,8 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9701,8 +9703,8 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9769,8 +9771,8 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9834,8 +9836,8 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9900,8 +9902,8 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9969,8 +9971,8 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10038,8 +10040,8 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10107,8 +10109,8 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10176,8 +10178,8 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10245,8 +10247,8 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10366,13 +10368,14 @@ func (o *mergeJoinLeftSemiOp) exhaustRightSource() {
 // accordingly.
 func (o *mergeJoinLeftSemiOp) calculateOutputCount(groups []group) int {
 	count := o.builderState.outCount
+	outputCapacity := o.output.Capacity()
 
 	for i := 0; i < len(groups); i++ {
 		count += groups[i].toBuild
 		groups[i].toBuild = 0
 		if count > o.output.Capacity() {
-			groups[i].toBuild = count - o.output.Capacity()
-			count = o.output.Capacity()
+			groups[i].toBuild = count - outputCapacity
+			count = outputCapacity
 			return count
 		}
 	}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_rightanti.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_rightanti.eg.go
@@ -9558,6 +9558,7 @@ func (o *mergeJoinRightAntiOp) buildLeftGroupsFromBatch(
 	o.unlimitedAllocator.PerformOperation(
 		o.output.ColVecs()[:len(input.sourceTypes)],
 		func() {
+			outputCapacity := o.output.Capacity()
 			// Loop over every column.
 		LeftColLoop:
 			for colIdx := range input.sourceTypes {
@@ -9602,8 +9603,8 @@ func (o *mergeJoinRightAntiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -9667,8 +9668,8 @@ func (o *mergeJoinRightAntiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -9732,8 +9733,8 @@ func (o *mergeJoinRightAntiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -9796,8 +9797,8 @@ func (o *mergeJoinRightAntiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -9857,8 +9858,8 @@ func (o *mergeJoinRightAntiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -9919,8 +9920,8 @@ func (o *mergeJoinRightAntiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -9984,8 +9985,8 @@ func (o *mergeJoinRightAntiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -10049,8 +10050,8 @@ func (o *mergeJoinRightAntiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -10114,8 +10115,8 @@ func (o *mergeJoinRightAntiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -10179,8 +10180,8 @@ func (o *mergeJoinRightAntiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -10244,8 +10245,8 @@ func (o *mergeJoinRightAntiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -10318,8 +10319,8 @@ func (o *mergeJoinRightAntiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -10382,8 +10383,8 @@ func (o *mergeJoinRightAntiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -10446,8 +10447,8 @@ func (o *mergeJoinRightAntiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -10509,8 +10510,8 @@ func (o *mergeJoinRightAntiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -10569,8 +10570,8 @@ func (o *mergeJoinRightAntiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -10630,8 +10631,8 @@ func (o *mergeJoinRightAntiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -10694,8 +10695,8 @@ func (o *mergeJoinRightAntiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -10758,8 +10759,8 @@ func (o *mergeJoinRightAntiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -10822,8 +10823,8 @@ func (o *mergeJoinRightAntiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -10886,8 +10887,8 @@ func (o *mergeJoinRightAntiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -10950,8 +10951,8 @@ func (o *mergeJoinRightAntiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -11025,6 +11026,7 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 	o.unlimitedAllocator.PerformOperation(
 		o.output.ColVecs()[colOffset:colOffset+len(input.sourceTypes)],
 		func() {
+			outputCapacity := o.output.Capacity()
 			// Loop over every column.
 		RightColLoop:
 			for colIdx := range input.sourceTypes {
@@ -11060,8 +11062,8 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11129,8 +11131,8 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11198,8 +11200,8 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11266,8 +11268,8 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11331,8 +11333,8 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11397,8 +11399,8 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11466,8 +11468,8 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11535,8 +11537,8 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11604,8 +11606,8 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11673,8 +11675,8 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11742,8 +11744,8 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11821,8 +11823,8 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11890,8 +11892,8 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11959,8 +11961,8 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -12027,8 +12029,8 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -12092,8 +12094,8 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -12158,8 +12160,8 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -12227,8 +12229,8 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -12296,8 +12298,8 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -12365,8 +12367,8 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -12434,8 +12436,8 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -12503,8 +12505,8 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -12634,6 +12636,7 @@ func (o *mergeJoinRightAntiOp) exhaustRightSource() {
 // accordingly.
 func (o *mergeJoinRightAntiOp) calculateOutputCount(groups []group) int {
 	count := o.builderState.outCount
+	outputCapacity := o.output.Capacity()
 
 	for i := 0; i < len(groups); i++ {
 		if !groups[i].unmatched {
@@ -12645,8 +12648,8 @@ func (o *mergeJoinRightAntiOp) calculateOutputCount(groups []group) int {
 		count += groups[i].toBuild
 		groups[i].toBuild = 0
 		if count > o.output.Capacity() {
-			groups[i].toBuild = count - o.output.Capacity()
-			count = o.output.Capacity()
+			groups[i].toBuild = count - outputCapacity
+			count = outputCapacity
 			return count
 		}
 	}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_rightouter.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_rightouter.eg.go
@@ -9602,6 +9602,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 	o.unlimitedAllocator.PerformOperation(
 		o.output.ColVecs()[:len(input.sourceTypes)],
 		func() {
+			outputCapacity := o.output.Capacity()
 			// Loop over every column.
 		LeftColLoop:
 			for colIdx := range input.sourceTypes {
@@ -9646,8 +9647,8 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -9711,8 +9712,8 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -9776,8 +9777,8 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -9840,8 +9841,8 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -9901,8 +9902,8 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -9963,8 +9964,8 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -10028,8 +10029,8 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -10093,8 +10094,8 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -10158,8 +10159,8 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -10223,8 +10224,8 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -10288,8 +10289,8 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -10362,8 +10363,8 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -10426,8 +10427,8 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -10490,8 +10491,8 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -10553,8 +10554,8 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -10613,8 +10614,8 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -10674,8 +10675,8 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -10738,8 +10739,8 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -10802,8 +10803,8 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -10866,8 +10867,8 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -10930,8 +10931,8 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -10994,8 +10995,8 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									if leftGroup.nullGroup {
@@ -11069,6 +11070,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 	o.unlimitedAllocator.PerformOperation(
 		o.output.ColVecs()[colOffset:colOffset+len(input.sourceTypes)],
 		func() {
+			outputCapacity := o.output.Capacity()
 			// Loop over every column.
 		RightColLoop:
 			for colIdx := range input.sourceTypes {
@@ -11104,8 +11106,8 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11173,8 +11175,8 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11242,8 +11244,8 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11310,8 +11312,8 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11375,8 +11377,8 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11441,8 +11443,8 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11510,8 +11512,8 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11579,8 +11581,8 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11648,8 +11650,8 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11717,8 +11719,8 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11786,8 +11788,8 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11865,8 +11867,8 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -11934,8 +11936,8 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -12003,8 +12005,8 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -12071,8 +12073,8 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -12136,8 +12138,8 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -12202,8 +12204,8 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -12271,8 +12273,8 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -12340,8 +12342,8 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -12409,8 +12411,8 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -12478,8 +12480,8 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -12547,8 +12549,8 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -12686,13 +12688,14 @@ func (o *mergeJoinRightOuterOp) exhaustRightSource() {
 // accordingly.
 func (o *mergeJoinRightOuterOp) calculateOutputCount(groups []group) int {
 	count := o.builderState.outCount
+	outputCapacity := o.output.Capacity()
 
 	for i := 0; i < len(groups); i++ {
 		count += groups[i].toBuild
 		groups[i].toBuild = 0
 		if count > o.output.Capacity() {
-			groups[i].toBuild = count - o.output.Capacity()
-			count = o.output.Capacity()
+			groups[i].toBuild = count - outputCapacity
+			count = outputCapacity
 			return count
 		}
 	}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_rightsemi.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_rightsemi.eg.go
@@ -7322,6 +7322,7 @@ func (o *mergeJoinRightSemiOp) buildLeftGroupsFromBatch(
 	o.unlimitedAllocator.PerformOperation(
 		o.output.ColVecs()[:len(input.sourceTypes)],
 		func() {
+			outputCapacity := o.output.Capacity()
 			// Loop over every column.
 		LeftColLoop:
 			for colIdx := range input.sourceTypes {
@@ -7366,8 +7367,8 @@ func (o *mergeJoinRightSemiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -7428,8 +7429,8 @@ func (o *mergeJoinRightSemiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -7490,8 +7491,8 @@ func (o *mergeJoinRightSemiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -7551,8 +7552,8 @@ func (o *mergeJoinRightSemiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -7609,8 +7610,8 @@ func (o *mergeJoinRightSemiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -7668,8 +7669,8 @@ func (o *mergeJoinRightSemiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -7730,8 +7731,8 @@ func (o *mergeJoinRightSemiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -7792,8 +7793,8 @@ func (o *mergeJoinRightSemiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -7854,8 +7855,8 @@ func (o *mergeJoinRightSemiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -7916,8 +7917,8 @@ func (o *mergeJoinRightSemiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -7978,8 +7979,8 @@ func (o *mergeJoinRightSemiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8049,8 +8050,8 @@ func (o *mergeJoinRightSemiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8110,8 +8111,8 @@ func (o *mergeJoinRightSemiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8171,8 +8172,8 @@ func (o *mergeJoinRightSemiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8231,8 +8232,8 @@ func (o *mergeJoinRightSemiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8288,8 +8289,8 @@ func (o *mergeJoinRightSemiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8346,8 +8347,8 @@ func (o *mergeJoinRightSemiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8407,8 +8408,8 @@ func (o *mergeJoinRightSemiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8468,8 +8469,8 @@ func (o *mergeJoinRightSemiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8529,8 +8530,8 @@ func (o *mergeJoinRightSemiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8590,8 +8591,8 @@ func (o *mergeJoinRightSemiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8651,8 +8652,8 @@ func (o *mergeJoinRightSemiOp) buildLeftGroupsFromBatch(
 
 									repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 									toAppend := repeatsLeft
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8723,6 +8724,7 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 	o.unlimitedAllocator.PerformOperation(
 		o.output.ColVecs()[colOffset:colOffset+len(input.sourceTypes)],
 		func() {
+			outputCapacity := o.output.Capacity()
 			// Loop over every column.
 		RightColLoop:
 			for colIdx := range input.sourceTypes {
@@ -8758,8 +8760,8 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8827,8 +8829,8 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8896,8 +8898,8 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -8964,8 +8966,8 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9029,8 +9031,8 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9095,8 +9097,8 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9164,8 +9166,8 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9233,8 +9235,8 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9302,8 +9304,8 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9371,8 +9373,8 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9440,8 +9442,8 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9519,8 +9521,8 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9588,8 +9590,8 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9657,8 +9659,8 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9725,8 +9727,8 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9790,8 +9792,8 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9856,8 +9858,8 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9925,8 +9927,8 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -9994,8 +9996,8 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10063,8 +10065,8 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10132,8 +10134,8 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10201,8 +10203,8 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 										o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 									}
 									toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-									if outStartIdx+toAppend > o.output.Capacity() {
-										toAppend = o.output.Capacity() - outStartIdx
+									if outStartIdx+toAppend > outputCapacity {
+										toAppend = outputCapacity - outStartIdx
 									}
 
 									{
@@ -10322,13 +10324,14 @@ func (o *mergeJoinRightSemiOp) exhaustRightSource() {
 // accordingly.
 func (o *mergeJoinRightSemiOp) calculateOutputCount(groups []group) int {
 	count := o.builderState.outCount
+	outputCapacity := o.output.Capacity()
 
 	for i := 0; i < len(groups); i++ {
 		count += groups[i].toBuild
 		groups[i].toBuild = 0
 		if count > o.output.Capacity() {
-			groups[i].toBuild = count - o.output.Capacity()
-			count = o.output.Capacity()
+			groups[i].toBuild = count - outputCapacity
+			count = outputCapacity
 			return count
 		}
 	}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_tmpl.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_tmpl.go
@@ -704,8 +704,8 @@ func _LEFT_SWITCH(_JOIN_TYPE joinTypeInfo, _HAS_SELECTION bool) { // */}}
 
 					repeatsLeft := leftGroup.numRepeats - o.builderState.left.numRepeatsIdx
 					toAppend := repeatsLeft
-					if outStartIdx+toAppend > o.output.Capacity() {
-						toAppend = o.output.Capacity() - outStartIdx
+					if outStartIdx+toAppend > outputCapacity {
+						toAppend = outputCapacity - outStartIdx
 					}
 
 					// {{if or _JOIN_TYPE.IsRightOuter _JOIN_TYPE.IsRightAnti}}
@@ -789,6 +789,7 @@ func (o *mergeJoin_JOIN_TYPE_STRINGOp) buildLeftGroupsFromBatch(
 	o.unlimitedAllocator.PerformOperation(
 		o.output.ColVecs()[:len(input.sourceTypes)],
 		func() {
+			outputCapacity := o.output.Capacity()
 			// Loop over every column.
 		LeftColLoop:
 			for colIdx := range input.sourceTypes {
@@ -841,8 +842,8 @@ func _RIGHT_SWITCH(_JOIN_TYPE joinTypeInfo, _HAS_SELECTION bool) { // */}}
 						o.builderState.right.curSrcStartIdx = rightGroup.rowStartIdx
 					}
 					toAppend := rightGroup.rowEndIdx - o.builderState.right.curSrcStartIdx
-					if outStartIdx+toAppend > o.output.Capacity() {
-						toAppend = o.output.Capacity() - outStartIdx
+					if outStartIdx+toAppend > outputCapacity {
+						toAppend = outputCapacity - outStartIdx
 					}
 
 					// {{if _JOIN_TYPE.IsLeftOuter}}
@@ -943,6 +944,7 @@ func (o *mergeJoin_JOIN_TYPE_STRINGOp) buildRightGroupsFromBatch(
 	o.unlimitedAllocator.PerformOperation(
 		o.output.ColVecs()[colOffset:colOffset+len(input.sourceTypes)],
 		func() {
+			outputCapacity := o.output.Capacity()
 			// Loop over every column.
 		RightColLoop:
 			for colIdx := range input.sourceTypes {
@@ -1086,6 +1088,7 @@ func (o *mergeJoin_JOIN_TYPE_STRINGOp) exhaustRightSource() {
 // accordingly.
 func (o *mergeJoin_JOIN_TYPE_STRINGOp) calculateOutputCount(groups []group) int {
 	count := o.builderState.outCount
+	outputCapacity := o.output.Capacity()
 
 	for i := 0; i < len(groups); i++ {
 		// {{if or _JOIN_TYPE.IsLeftAnti _JOIN_TYPE.IsRightAnti}}
@@ -1099,8 +1102,8 @@ func (o *mergeJoin_JOIN_TYPE_STRINGOp) calculateOutputCount(groups []group) int 
 		count += groups[i].toBuild
 		groups[i].toBuild = 0
 		if count > o.output.Capacity() {
-			groups[i].toBuild = count - o.output.Capacity()
-			count = o.output.Capacity()
+			groups[i].toBuild = count - outputCapacity
+			count = outputCapacity
 			return count
 		}
 	}


### PR DESCRIPTION
We've just seen a cpu profile where this function call showed up
non-trivially.

Release note: None