### PR TITLE
roachtest: allow small tolerance for errors in DRTs

### DIFF
--- a/pkg/cmd/roachtest/tests/drt.go
+++ b/pkg/cmd/roachtest/tests/drt.go
@@ -35,6 +35,14 @@ type tpccChaosEventProcessor struct {
 	ch                chan ChaosEvent
 	promClient        promClient
 	errs              []error
+
+	// allowZeroSuccessDuringUptime allows 0 successes during an uptime event.
+	// Otherwise, we expect success rates to be strictly increasing during
+	// uptime.
+	allowZeroSuccessDuringUptime bool
+	// maxErrorsDuringUptime dictates the number of errors to accept during
+	// uptime.
+	maxErrorsDuringUptime int
 }
 
 func (ep *tpccChaosEventProcessor) checkUptime(
@@ -56,13 +64,18 @@ func (ep *tpccChaosEventProcessor) checkUptime(
 			if to > from {
 				return nil
 			}
+			// We allow to == from if allowZeroSuccessDuringUptime is set.
+			if ep.allowZeroSuccessDuringUptime && to == from {
+				return nil
+			}
 			return errors.Newf("expected successes to be increasing, found from %f, to %f", from, to)
 		},
 		func(from, to model.SampleValue) error {
-			if to == from {
+			// Allow up to maxErrorsDuringUptime errors during uptime.
+			if to <= from+model.SampleValue(ep.maxErrorsDuringUptime) {
 				return nil
 			}
-			return errors.Newf("expected 0 errors, found from %f, to %f", from, to)
+			return errors.Newf("expected <=%d errors, found from %f, to %f", ep.maxErrorsDuringUptime, from, to)
 		},
 	)
 }

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -641,6 +641,12 @@ func registerTPCC(r registry.Registry) {
 								},
 								ch:         chaosEventCh,
 								promClient: promv1.NewAPI(client),
+								// We see a slow trickle of errors after a server has been
+								// force shutdown due to queries before the shutdown not
+								// fully completing.
+								maxErrorsDuringUptime: 10,
+								// "delivery" does not trigger often.
+								allowZeroSuccessDuringUptime: true,
 							}, nil
 						},
 						SetupType:         usingInit,


### PR DESCRIPTION
Looks like we have a very low error rate during shutdown because of long
running queries still relying on force shutdown nodes. Account for this
by allowing a very small error margin during a stats read.

Resolves #67601 
Resolves #67602 
Release note: None