### PR TITLE
backupccl: back up all table targets in a specified schema

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -2325,6 +2325,72 @@ INSERT INTO sc.tb2 VALUES ('hello');
 		sqlDB.ExpectErr(t, `pq: schema "unused" already exists`, `USE d; CREATE SCHEMA unused`)
 	})
 
+	// Tests backing up and restoring all tables in requested user defined
+	// schemas.
+	t.Run("all-tables-in-requested-schema", func(t *testing.T) {
+		_, _, sqlDB, _, cleanupFn := BackupRestoreTestSetup(t, singleNode, 0, InitManualReplication)
+		defer cleanupFn()
+
+		sqlDB.Exec(t, `
+CREATE TABLE table_in_data (x INT);
+
+CREATE SCHEMA data;
+CREATE TABLE data.tb1 (x INT);
+
+CREATE DATABASE foo;
+USE foo;
+CREATE SCHEMA schema_in_foo;
+CREATE TABLE schema_in_foo.tb1 (x INT);
+
+CREATE SCHEMA schema_in_foo2;
+CREATE TABLE schema_in_foo2.tb1 (x INT);
+
+CREATE SCHEMA foo;
+CREATE TABLE foo.tb1 (x INT);
+
+CREATE TABLE tb2 (y INT);
+`)
+
+		for _, tc := range []struct {
+			name                   string
+			target                 string
+			expectedTablesInBackup [][]string
+		}{
+			{
+				name:                   "fully-qualified-target",
+				target:                 "foo.schema_in_foo.*",
+				expectedTablesInBackup: [][]string{{"schema_in_foo", "tb1"}},
+			},
+			{
+				name:                   "schema-qualified-target",
+				target:                 "schema_in_foo.*",
+				expectedTablesInBackup: [][]string{{"schema_in_foo", "tb1"}},
+			},
+			{
+				name:                   "schema-qualified-target-with-identical-name-as-curdb",
+				target:                 "foo.*",
+				expectedTablesInBackup: [][]string{{"foo", "tb1"}},
+			},
+			{
+				name:                   "curdb-public-schema-target",
+				target:                 "*",
+				expectedTablesInBackup: [][]string{{"public", "tb2"}},
+			},
+			{
+				name:                   "cross-db-qualified-target",
+				target:                 "data.*",
+				expectedTablesInBackup: [][]string{{"data", "tb1"}, {"public", "bank"}, {"public", "table_in_data"}},
+			},
+		} {
+			sqlDB.Exec(t, fmt.Sprintf(`BACKUP TABLE %s TO 'nodelocal://0/%s'`, tc.target, tc.name))
+			sqlDB.Exec(t, `CREATE DATABASE restore`)
+			sqlDB.Exec(t, fmt.Sprintf(`RESTORE TABLE %s FROM 'nodelocal://0/%s' WITH into_db='restore'`, tc.target, tc.name))
+			sqlDB.CheckQueryResults(t, `SELECT schema_name,
+table_name from [SHOW TABLES FROM restore] ORDER BY schema_name, table_name`, tc.expectedTablesInBackup)
+			sqlDB.Exec(t, `DROP DATABASE restore CASCADE`)
+		}
+	})
+
 	// Test restoring tables with user defined schemas when restore schemas are
 	// not being remapped.
 	t.Run("no-remap", func(t *testing.T) {

--- a/pkg/ccl/backupccl/backupresolver/targets.go
+++ b/pkg/ccl/backupccl/backupresolver/targets.go
@@ -367,6 +367,8 @@ func DescriptorsMatchingTargets(
 	// Process all the TABLE requests.
 	// Pulling in a table needs to pull in the underlying database too.
 	alreadyRequestedTables := make(map[descpb.ID]struct{})
+	// Process specific SCHEMAs requested for a database.
+	alreadyRequestedSchemasByDBs := make(map[descpb.ID]map[string]struct{})
 	for _, pattern := range targets.Tables {
 		var err error
 		pattern, err = pattern.NormalizeTablePattern()
@@ -437,6 +439,10 @@ func DescriptorsMatchingTargets(
 			}
 
 		case *tree.AllTablesSelector:
+			// We should only back up targets in the scoped schema if the table
+			// pattern is fully qualified, i.e., `db.schema.*`, both the schema
+			// field and catalog field were set.
+			hasSchemaScope := p.ExplicitSchema && p.ExplicitCatalog
 			found, prefix, err := resolver.ResolveObjectNamePrefix(ctx, r, currentDatabase, searchPath, &p.ObjectNamePrefix)
 			if err != nil {
 				return ret, err
@@ -458,59 +464,98 @@ func DescriptorsMatchingTargets(
 				alreadyExpandedDBs[prefix.Database.GetID()] = struct{}{}
 			}
 
+			// If the target was fully qualified, i.e. `db.schema.*` then
+			// `hasSchemaScope` would be set to true above.
+			//
+			// After resolution if the target does not have ExplicitCatalog
+			// set to true, it means that the target was of the form `schema.*`.
+			// In this case, we want to only backup the object in the schema scope.
+			//
+			// If neither of the above cases apply, the target is of the form `db.*`.
+			// In this case we want to backup all objects in db and so `hasSchemaScope`
+			// should be set to false.
+			if !hasSchemaScope && !p.ExplicitCatalog {
+				hasSchemaScope = true
+			}
+
+			// If we are given a specified schema scope, i.e., `db.schema.*`
+			// or `schema.*`, add the schema to `alreadyRequestedSchemasByDBs`
+			if hasSchemaScope {
+				if _, ok := alreadyRequestedSchemasByDBs[dbID]; !ok {
+					scMap := make(map[string]struct{})
+					alreadyRequestedSchemasByDBs[dbID] = scMap
+				}
+				scMap := alreadyRequestedSchemasByDBs[dbID]
+				scMap[p.Schema()] = struct{}{}
+			}
 		default:
 			return ret, errors.Errorf("unknown pattern %T: %+v", pattern, pattern)
 		}
 	}
 
+	addTableDescsInSchema := func(schemas map[string]descpb.ID) error {
+		for _, id := range schemas {
+			desc := r.DescByID[id]
+			switch desc := desc.(type) {
+			case catalog.TableDescriptor:
+				if err := catalog.FilterDescriptorState(
+					desc, tree.CommonLookupFlags{},
+				); err != nil {
+					// Don't include this table in the expansion since it's not in a valid
+					// state. Silently fail since this table was not directly requested,
+					// but was just part of an expansion.
+					continue
+				}
+				if _, ok := alreadyRequestedTables[id]; !ok {
+					ret.Descs = append(ret.Descs, desc)
+				}
+				// If this table is a member of a user defined schema, then request the
+				// user defined schema.
+				if desc.GetParentSchemaID() != keys.PublicSchemaID {
+					// Note, that although we're processing the database expansions,
+					// since the table is in a PUBLIC state, we also expect the schema
+					// to be in a similar state.
+					if err := maybeAddSchemaDesc(desc.GetParentSchemaID(), true /* requirePublic */); err != nil {
+						return err
+					}
+				}
+				// Get all the types used by this table.
+				dbRaw := r.DescByID[desc.GetParentID()]
+				dbDesc := dbRaw.(catalog.DatabaseDescriptor)
+				typeIDs, err := desc.GetAllReferencedTypeIDs(dbDesc, getTypeByID)
+				if err != nil {
+					return err
+				}
+				for _, id := range typeIDs {
+					maybeAddTypeDesc(id)
+				}
+			case catalog.TypeDescriptor:
+				maybeAddTypeDesc(desc.GetID())
+			}
+		}
+		return nil
+	}
+
 	// Then process the database expansions.
 	for dbID := range alreadyExpandedDBs {
-		for schemaName, schemas := range r.ObjsByName[dbID] {
-			schemaID, err := getSchemaIDByName(schemaName, dbID)
-			if err != nil {
-				return ret, err
+		if requestedSchemas, ok := alreadyRequestedSchemasByDBs[dbID]; !ok {
+			for schemaName, schemas := range r.ObjsByName[dbID] {
+				schemaID, err := getSchemaIDByName(schemaName, dbID)
+				if err != nil {
+					return ret, err
+				}
+				if err := maybeAddSchemaDesc(schemaID, false /* requirePublic */); err != nil {
+					return ret, err
+				}
+				if err := addTableDescsInSchema(schemas); err != nil {
+					return ret, err
+				}
 			}
-			if err := maybeAddSchemaDesc(schemaID, false /* requirePublic */); err != nil {
-				return ret, err
-			}
-
-			for _, id := range schemas {
-				desc := r.DescByID[id]
-				switch desc := desc.(type) {
-				case catalog.TableDescriptor:
-					if err := catalog.FilterDescriptorState(
-						desc, tree.CommonLookupFlags{},
-					); err != nil {
-						// Don't include this table in the expansion since it's not in a valid
-						// state. Silently fail since this table was not directly requested,
-						// but was just part of an expansion.
-						continue
-					}
-					if _, ok := alreadyRequestedTables[id]; !ok {
-						ret.Descs = append(ret.Descs, desc)
-					}
-					// If this table is a member of a user defined schema, then request the
-					// user defined schema.
-					if desc.GetParentSchemaID() != keys.PublicSchemaID {
-						// Note, that although we're processing the database expansions,
-						// since the table is in a PUBLIC state, we also expect the schema
-						// to be in a similar state.
-						if err := maybeAddSchemaDesc(desc.GetParentSchemaID(), true /* requirePublic */); err != nil {
-							return ret, err
-						}
-					}
-					// Get all the types used by this table.
-					dbRaw := r.DescByID[desc.GetParentID()]
-					dbDesc := dbRaw.(catalog.DatabaseDescriptor)
-					typeIDs, err := desc.GetAllReferencedTypeIDs(dbDesc, getTypeByID)
-					if err != nil {
-						return ret, err
-					}
-					for _, id := range typeIDs {
-						maybeAddTypeDesc(id)
-					}
-				case catalog.TypeDescriptor:
-					maybeAddTypeDesc(desc.GetID())
+		} else {
+			for schemaName := range requestedSchemas {
+				schemas := r.ObjsByName[dbID][schemaName]
+				if err := addTableDescsInSchema(schemas); err != nil {
+					return ret, err
 				}
 			}
 		}

--- a/pkg/sql/catalog/resolver/resolver.go
+++ b/pkg/sql/catalog/resolver/resolver.go
@@ -488,7 +488,6 @@ func ResolveObjectNamePrefix(
 				tp.CatalogName = tp.SchemaName
 				tp.SchemaName = tree.PublicSchemaName
 				tp.ExplicitCatalog = true
-				tp.ExplicitCatalog = true
 			}
 			return found, scMeta, err
 		}


### PR DESCRIPTION
Previously, when users try to backup all tables in a specific user defined schema using wildcard patterns, such as `UDS.*`, all tables in the database end up getting backed up. This commit fixes the bug by only backing up tables that the user has requested.

Resolves: #67367

Release note (sql change): BACKUP now supports backing up tables in a specified schema (e.g. BACKUP `my_schema.*`, or `my_db.my_schema.*`). Schemas will be resolved before databases, so `my_object.*` will resolve to a schema of that name in the current database before matching a database with that name.