### PR TITLE
storage: expose rocksdb.write-stalls timeseries metric

### DIFF
--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -303,7 +303,7 @@ var (
 		Unit:        metric.Unit_COUNT,
 	}
 
-	// RocksDB metrics.
+	// RocksDB/Pebble metrics.
 	metaRdbBlockCacheHits = metric.Metadata{
 		Name:        "rocksdb.block.cache.hits",
 		Help:        "Count of block cache hits",
@@ -416,6 +416,12 @@ var (
 		Name:        "storage.l0-num-files",
 		Help:        "Number of Level 0 files",
 		Measurement: "Storage",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaRdbWriteStalls = metric.Metadata{
+		Name:        "storage.write-stalls",
+		Help:        "Number of instances of intentional write stalls to backpressure incoming writes",
+		Measurement: "Events",
 		Unit:        metric.Unit_COUNT,
 	}
 
@@ -1180,6 +1186,7 @@ type StoreMetrics struct {
 	RdbPendingCompaction        *metric.Gauge
 	RdbL0Sublevels              *metric.Gauge
 	RdbL0NumFiles               *metric.Gauge
+	RdbWriteStalls              *metric.Gauge
 
 	// Disk health metrics.
 	DiskSlow    *metric.Gauge
@@ -1570,6 +1577,7 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		RdbPendingCompaction:        metric.NewGauge(metaRdbPendingCompaction),
 		RdbL0Sublevels:              metric.NewGauge(metaRdbL0Sublevels),
 		RdbL0NumFiles:               metric.NewGauge(metaRdbL0NumFiles),
+		RdbWriteStalls:              metric.NewGauge(metaRdbWriteStalls),
 
 		// Disk health metrics.
 		DiskSlow:    metric.NewGauge(metaDiskSlow),
@@ -1785,6 +1793,7 @@ func (sm *StoreMetrics) updateEngineMetrics(m storage.Metrics) {
 	sm.RdbL0Sublevels.Update(int64(m.Levels[0].Sublevels))
 	sm.RdbL0NumFiles.Update(m.Levels[0].NumFiles)
 	sm.RdbNumSSTables.Update(m.NumSSTables())
+	sm.RdbWriteStalls.Update(m.WriteStallCount)
 	sm.DiskSlow.Update(m.DiskSlowCount)
 	sm.DiskStalled.Update(m.DiskStallCount)
 }

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -807,10 +807,18 @@ type Batch interface {
 // *pebble.Metrics struct, which has its own documentation.
 type Metrics struct {
 	*pebble.Metrics
+	// WriteStallCount counts the number of times Pebble intentionally delayed
+	// incoming writes. Currently, the only two reasons for this to happen are:
+	// - "memtable count limit reached"
+	// - "L0 file count limit exceeded"
+	//
+	// We do not split this metric across these two reasons, but they can be
+	// distinguished in the pebble logs.
+	WriteStallCount int64
 	// DiskSlowCount counts the number of times Pebble records disk slowness.
 	DiskSlowCount int64
 	// DiskStallCount counts the number of times Pebble observes slow writes
-	// lasting longer than MaxSyncDuration (`storage.max_sync_duration`).
+	// on disk lasting longer than MaxSyncDuration (`storage.max_sync_duration`).
 	DiskStallCount int64
 }
 

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -451,18 +451,18 @@ type Pebble struct {
 	attrs   roachpb.Attributes
 	// settings must be non-nil if this Pebble instance will be used to write
 	// intents.
-	settings      *cluster.Settings
-	statsHandler  EncryptionStatsHandler
-	fileRegistry  *PebbleFileRegistry
-	eventListener *pebble.EventListener
+	settings     *cluster.Settings
+	statsHandler EncryptionStatsHandler
+	fileRegistry *PebbleFileRegistry
 
 	// Stats updated by pebble.EventListener invocations, and returned in
 	// GetStats. Updated and retrieved atomically.
 	diskSlowCount, diskStallCount uint64
 
 	// Relevant options copied over from pebble.Options.
-	fs     vfs.FS
-	logger pebble.Logger
+	fs            vfs.FS
+	logger        pebble.Logger
+	eventListener *pebble.EventListener
 
 	wrappedIntentWriter intentDemuxWriter
 
@@ -573,10 +573,6 @@ func NewPebble(ctx context.Context, cfg PebbleConfig) (*Pebble, error) {
 		ctx:   logCtx,
 		depth: 1,
 	}
-	cfg.Opts.EventListener = pebble.MakeLoggingEventListener(pebbleLogger{
-		ctx:   logCtx,
-		depth: 2, // skip over the EventListener stack frame
-	})
 	p := &Pebble{
 		path:             cfg.Dir,
 		auxDir:           auxDir,
@@ -589,7 +585,13 @@ func NewPebble(ctx context.Context, cfg PebbleConfig) (*Pebble, error) {
 		logger:           cfg.Opts.Logger,
 		storeIDPebbleLog: storeIDContainer,
 	}
-	p.connectEventMetrics(ctx, &cfg.Opts.EventListener)
+	cfg.Opts.EventListener = pebble.TeeEventListener(
+		pebble.MakeLoggingEventListener(pebbleLogger{
+			ctx:   logCtx,
+			depth: 2, // skip over the EventListener stack frame
+		}),
+		p.makeMetricEventListener(ctx),
+	)
 	p.eventListener = &cfg.Opts.EventListener
 	p.wrappedIntentWriter = wrapIntentWriter(ctx, p, cfg.Settings, true /* isLongLived */)
 
@@ -602,31 +604,30 @@ func NewPebble(ctx context.Context, cfg PebbleConfig) (*Pebble, error) {
 	return p, nil
 }
 
-func (p *Pebble) connectEventMetrics(ctx context.Context, eventListener *pebble.EventListener) {
-	oldDiskSlow := eventListener.DiskSlow
-
-	eventListener.DiskSlow = func(info pebble.DiskSlowInfo) {
-		oldDiskSlow(info)
-		maxSyncDuration := maxSyncDurationDefault
-		fatalOnExceeded := maxSyncDurationFatalOnExceededDefault
-		if p.settings != nil {
-			maxSyncDuration = MaxSyncDuration.Get(&p.settings.SV)
-			fatalOnExceeded = MaxSyncDurationFatalOnExceeded.Get(&p.settings.SV)
-		}
-		if info.Duration.Seconds() >= maxSyncDuration.Seconds() {
-			atomic.AddUint64(&p.diskStallCount, 1)
-			// Note that the below log messages go to the main cockroach log, not
-			// the pebble-specific log.
-			if fatalOnExceeded {
-				log.Fatalf(ctx, "disk stall detected: pebble unable to write to %s in %.2f seconds",
-					info.Path, redact.Safe(info.Duration.Seconds()))
-			} else {
-				log.Errorf(ctx, "disk stall detected: pebble unable to write to %s in %.2f seconds",
-					info.Path, redact.Safe(info.Duration.Seconds()))
+func (p *Pebble) makeMetricEventListener(ctx context.Context) pebble.EventListener {
+	return pebble.EventListener{
+		DiskSlow: func(info pebble.DiskSlowInfo) {
+			maxSyncDuration := maxSyncDurationDefault
+			fatalOnExceeded := maxSyncDurationFatalOnExceededDefault
+			if p.settings != nil {
+				maxSyncDuration = MaxSyncDuration.Get(&p.settings.SV)
+				fatalOnExceeded = MaxSyncDurationFatalOnExceeded.Get(&p.settings.SV)
 			}
-			return
-		}
-		atomic.AddUint64(&p.diskSlowCount, 1)
+			if info.Duration.Seconds() >= maxSyncDuration.Seconds() {
+				atomic.AddUint64(&p.diskStallCount, 1)
+				// Note that the below log messages go to the main cockroach log, not
+				// the pebble-specific log.
+				if fatalOnExceeded {
+					log.Fatalf(ctx, "disk stall detected: pebble unable to write to %s in %.2f seconds",
+						info.Path, redact.Safe(info.Duration.Seconds()))
+				} else {
+					log.Errorf(ctx, "disk stall detected: pebble unable to write to %s in %.2f seconds",
+						info.Path, redact.Safe(info.Duration.Seconds()))
+				}
+				return
+			}
+			atomic.AddUint64(&p.diskSlowCount, 1)
+		},
 	}
 }
 

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -2305,6 +2305,10 @@ var charts = []sectionDescription{
 				},
 				AxisLabel: "Bytes",
 			},
+			{
+				Title:   "Stalls",
+				Metrics: []string{"storage.write-stalls"},
+			},
 		},
 	},
 	{

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
@@ -191,6 +191,21 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
+      title="Write Stalls"
+      sources={storeSources}
+      tooltip={`The number of intentional write stalls per second ${tooltipSelection}. Write stalls
+        are used to backpressure incoming writes during periods of heavy write traffic.`}
+    >
+      <Axis label="count">
+        <Metric
+          name="cr.store.storage.write-stalls"
+          title="Write Stalls"
+          nonNegativeRate
+        />
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
       title="Time Series Writes"
       sources={nodeSources}
       tooltip={`The number of successfully written time series samples, and number of errors attempting


### PR DESCRIPTION
This commit exposes access to a new `rocksdb.write-stalls` timeseries metric (see comment about naming to discuss), which is incremented on each intentional Pebble write stall used to backpressure incoming writes.

The commit then adds a new graph to the Storage dashboard to display the rate of write stalls on a cluster.

We've seen cases in the past where this metric would have come in handy in pointing us towards the pebble logs to dig in deeper.

One thing this commit does not do is introduce any form of write stall duration histogram to live alongside this write stall counter. Such a metric is possible to implement cleanly because Pebble exposes a `WriteStallEnd` event alongside it `WriteStallBegin` event to `EventListeners`. However, a histogram is a more heavyweight and metric-specific (at least in CRDB code) data structure than an arbitrary counter and we don't maintain any histograms at the `pkg/storage` level, so we'll need to think through how we want this to interact with the periodic metric polling that we currently use for Storage metrics.
