### PR TITLE
sql: fix the interval mismatch between SQL and the CLI

### DIFF
--- a/pkg/cli/interactive_tests/test_timing.tcl
+++ b/pkg/cli/interactive_tests/test_timing.tcl
@@ -12,21 +12,44 @@ send "SELECT pg_sleep(0.02) FROM vehicles LIMIT 1;\r"
 eexpect "1 row"
 eexpect "execution"
 eexpect "network"
+eexpect root@
 
 # Ditto with multiple statements on one line
 send "SELECT * FROM vehicles LIMIT 1; CREATE TABLE t(a int);\r"
 eexpect "1 row"
 eexpect "Note: timings for multiple statements on a single line are not supported"
+eexpect root@
 end_test
 
 start_test "Test show_server_execution_times works correctly"
 send "\\set show_server_times=false\r"
 send "SELECT pg_sleep(0.02) FROM vehicles LIMIT 1;\r"
 eexpect "\nTime:"
+eexpect root@
 send "\\set show_server_times=true\r"
 send "SELECT pg_sleep(0.02) FROM vehicles LIMIT 1;\r"
 eexpect "execution"
 eexpect "network"
+eexpect root@
+end_test
+
+start_test "Check that server times also work if IntervalStyle is different"
+# regression test for issue #67618.
+send "set IntervalStyle = 'iso_8601';\r"
+eexpect "SET"
+eexpect root@
+send "SELECT pg_sleep(0.02) FROM vehicles LIMIT 1;\r"
+eexpect "execution"
+eexpect "network"
+eexpect root@
+
+send "set IntervalStyle = 'sql_standard';\r"
+eexpect "SET"
+eexpect root@
+send "SELECT pg_sleep(0.02) FROM vehicles LIMIT 1;\r"
+eexpect "execution"
+eexpect "network"
+eexpect root@
 end_test
 
 start_test "Test non-negative PREPARE stmt timings #54888"
@@ -34,10 +57,12 @@ send "create table t1 (a int, updated_at timestamptz);\r"
 send "prepare stmt (timestamptz) as insert into t1 values (1, \$1);\r"
 eexpect "execution \[0-9\]"
 eexpect "network \[0-9\]"
+eexpect root@
 end_test
 
 start_test "Test observer statements non neg timings #54750"
 send "SHOW SYNTAX 'CREATE TABLE t(a INT)';\r"
 eexpect "execution \[0-9\]"
 eexpect "network \[0-9\]"
+eexpect root@
 end_test

--- a/pkg/sql/catalog/colinfo/result_columns.go
+++ b/pkg/sql/catalog/colinfo/result_columns.go
@@ -189,11 +189,11 @@ var ShowSyntaxColumns = ResultColumns{
 // ShowLastQueryStatisticsColumns are the columns of a
 // SHOW LAST QUERY STATISTICS statement.
 var ShowLastQueryStatisticsColumns = ResultColumns{
-	{Name: "parse_latency", Typ: types.Interval},
-	{Name: "plan_latency", Typ: types.Interval},
-	{Name: "exec_latency", Typ: types.Interval},
-	{Name: "service_latency", Typ: types.Interval},
-	{Name: "post_commit_jobs_latency", Typ: types.Interval},
+	{Name: "parse_latency", Typ: types.String},
+	{Name: "plan_latency", Typ: types.String},
+	{Name: "exec_latency", Typ: types.String},
+	{Name: "service_latency", Typ: types.String},
+	{Name: "post_commit_jobs_latency", Typ: types.String},
 }
 
 // ShowFingerprintsColumns are the result columns of a


### PR DESCRIPTION
Fixes #67618.  (using solution 3)

See issue #67618 for details .

Release note (sql change): The column types of the results of
`SHOW LAST QUERY STATISTICS` (an undocumented statement meant
mostly for internal use by CockroachDB's  SQL shell) has
been changed from INTERVAL to STRING. They are populated by
the durations of the various phases of executions as
if the duration, as an INTERVAL, was converted to STRING
using the 'postgres' IntervalStyle. This ensures that the
server-side execution timings are always available regardless
of the value of the IntervalStyle session variable.