### PR TITLE
roachtest: improve end-user documentation

### DIFF
--- a/pkg/cmd/github-post/BUILD.bazel
+++ b/pkg/cmd/github-post/BUILD.bazel
@@ -26,5 +26,9 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":github-post_lib"],
     tags = ["broken_in_bazel"],
-    deps = ["@com_github_stretchr_testify//assert"],
+    deps = [
+        "//pkg/cmd/internal/issues",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/pkg/cmd/github-post/main.go
+++ b/pkg/cmd/github-post/main.go
@@ -65,7 +65,7 @@ func defaultFormatter(ctx context.Context, f failure) (issues.IssueFormatter, is
 		Message:             f.testMessage,
 		Artifacts:           "/", // best we can do for unit tests
 		AuthorEmail:         authorEmail,
-		ReproductionCommand: repro,
+		ReproductionCommand: issues.ReproductionCommandFromString(repro),
 		Mention:             mentions,
 		ProjectColumnID:     projColID,
 	}
@@ -575,7 +575,7 @@ func formatPebbleMetamorphicIssue(
 		PackageName:         f.packageName,
 		Message:             f.testMessage,
 		Artifacts:           "meta",
-		ReproductionCommand: repro,
+		ReproductionCommand: issues.ReproductionCommandFromString(repro),
 		ExtraLabels:         []string{"metamorphic-failure"},
 	}
 }

--- a/pkg/cmd/internal/issues/formatter_unit.go
+++ b/pkg/cmd/internal/issues/formatter_unit.go
@@ -68,12 +68,8 @@ var UnitTestFormatter = IssueFormatter{
 		}
 
 		r.Collapsed("Reproduce", func() {
-			// TODO(tbg): this should be generated here.
-			if data.ReproductionCommand != "" {
-				r.P(func() {
-					r.Escaped("To reproduce, try:\n")
-					r.CodeBlock("bash", data.ReproductionCommand)
-				})
+			if data.ReproductionCommand != nil {
+				data.ReproductionCommand(r)
 			}
 
 			if len(data.Parameters) != 0 {

--- a/pkg/cmd/internal/issues/issues.go
+++ b/pkg/cmd/internal/issues/issues.go
@@ -483,7 +483,7 @@ type PostRequest struct {
 	// that should be mentioned in the message.
 	Mention []string
 	// The instructions to reproduce the failure.
-	ReproductionCommand string
+	ReproductionCommand func(*Renderer)
 	// Additional labels that will be added to the issue. They will be created
 	// as necessary (as a side effect of creating an issue with them). An
 	// existing issue may be adopted even if it does not have these labels.
@@ -508,4 +508,19 @@ func Post(ctx context.Context, formatter IssueFormatter, req PostRequest) error 
 		&oauth2.Token{AccessToken: opts.Token},
 	)))
 	return newPoster(client, opts).post(ctx, formatter, req)
+}
+
+// ReproductionCommandFromString returns a value for the
+// PostRequest.ReproductionCommand field that is a command to run. It is
+// formatted as a bash code block.
+func ReproductionCommandFromString(repro string) func(*Renderer) {
+	if repro == "" {
+		return func(*Renderer) {}
+	}
+	return func(r *Renderer) {
+		r.P(func() {
+			r.Escaped("To reproduce, try:\n")
+			r.CodeBlock("bash", repro)
+		})
+	}
 }

--- a/pkg/cmd/internal/issues/issues_test.go
+++ b/pkg/cmd/internal/issues/issues_test.go
@@ -274,7 +274,7 @@ test logs left over in: /go/src/github.com/cockroachdb/cockroach/artifacts/logTe
 						Message:             c.message,
 						Artifacts:           c.artifacts,
 						AuthorEmail:         c.author,
-						ReproductionCommand: c.reproCmd,
+						ReproductionCommand: ReproductionCommandFromString(c.reproCmd),
 						ExtraLabels:         []string{"release-blocker"},
 					}
 					require.NoError(t, p.post(ctx, UnitTestFormatter, req))

--- a/pkg/cmd/internal/issues/render.go
+++ b/pkg/cmd/internal/issues/render.go
@@ -116,3 +116,8 @@ func (r *Renderer) Collapsed(title string, inner func()) {
 	})
 	r.nl()
 }
+
+// String prints the buffer.
+func (r *Renderer) String() string {
+	return r.buf.String()
+}

--- a/pkg/cmd/roachprod/README.md
+++ b/pkg/cmd/roachprod/README.md
@@ -3,6 +3,8 @@
 ⚠️ roachprod is an **internal** tool for creating and testing
 CockroachDB clusters. Use at your own risk! ⚠️
 
+Note that an internal tutorial is also maintained [at the Developer Infrastructure Team's wiki](https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/144408811/Roachprod+Tutorial).
+
 ## Setup
 
 1. Make sure you have [gcloud installed] and configured (`gcloud auth list` to
@@ -37,9 +39,6 @@ installations (`gcloud components update`).
 # with your username.
 export CLUSTER="${USER}-test"
 roachprod create ${CLUSTER} -n 4 --local-ssd
-
-# Add gcloud SSH key. Optional for most commands, but some require it.
-ssh-add ~/.ssh/google_compute_engine
 
 # Stage binaries.
 roachprod stage ${CLUSTER} workload

--- a/pkg/cmd/roachtest/README.md
+++ b/pkg/cmd/roachtest/README.md
@@ -6,38 +6,189 @@ separate) tool `roachprod`.
 
 # Setup
 
-1. [Set up `roachprod`](https://github.com/cockroachdb/cockroach/blob/master/pkg/cmd/roachprod/README.md), if you haven't already. This includes making sure `$PWD/bin` is on your `PATH` and `gcloud` is installed and properly configured.
-1. Build a linux release binary of `cockroach`: `build/builder.sh mkrelease amd64-linux-gnu`
-1. Build a linux binary of the `workload` tool: `build/builder.sh mkrelease amd64-linux-gnu bin/workload`
-1. Build a local binary of `roachtest`: `make bin/roachtest`
+- [Set up `roachprod`](https://github.com/cockroachdb/cockroach/blob/master/pkg/cmd/roachprod/README.md), if you haven't already.
+- If you want to run tests that require an Enterprise license, add `COCKROACH_DEV_LICENSE=<key>` to your path. Cockroach Labs employees can find one in [Slack](https://cockroachlabs.slack.com/archives/CJX8V9SJ2/p1597348203368800?thread_ts=1597348076.367800&cid=CJX8V9SJ2).
+- For Cockroach Labs employees, if your local username does not match your
+  gcloud/`@cockroachlabs.com` username, add
+`ROACHPROD_USER=<your_crl_username>` to your environment, or add the
+`--user=$CRL_USERNAME` flag to the `roachtest run` invocations. Non-Cockroach
+Labs employees will want to set `--gce-project` (and maybe `--user` too) as the
+default project will not be accessible to them.
 
 # Usage
 
-You'll usually use `roachtest run` and specify a single test.
+`roachtest` has the list of tests it supports compiled in. They can be listed via:
 
-For Cockroach Labs employees, if your local username does not match
-your gcloud/`@cockroachlabs.com` username, you'll need to add
-`--user=$CRL_USERNAME` to the `roachtest` command. For non-Cockroach
-Labs employees, set `--gce-project` (and maybe `--user` too).
-
-If `$PWD/bin` isn't on your `PATH`, you'll need to add `--roachprod=<path-to-roachprod>`
-to the `roachtest` command.
-
-```shell
-roachtest run jepsen/1/bank/split
+```
+$ roachtest list
+acceptance/build-analyze [server]
+acceptance/build-info [server]
+acceptance/cli/node-status [server]
+[...]
 ```
 
-While iterating, don't forget to rebuild whichever of the above
-binaries you've touched. For example, the command line that you might use
-while iterating on jepsen tests is `make bin/roachtest &&
-roachtest run jepsen/1/bank/split`
+## Getting the binaries
 
-To keep your cluster after the roachtest finishes, use the `--debug` flag
-with `roachtest run`. You can use `roachprod` to connect to your cluster and
-examine the state by using `roachprod setup-ssh <cluster name>`. This will print
-out an IP address to connect to using `ssh`. To have `roachtest` reuse an
-existing cluster, pass the `--cluster <clustername>` argument to 
-`roachtest run`. 
+To run a test, the `roachtest run` command is used. Since a test typically
+deploys a CockroachDB cluster, `roachtest` needs to know which cockroach binary
+to use. It also needs to know where to find `roachprod`, and also generically
+requires the `workload` binary which is used by many tests to deploy load
+against the cluster. To that effect, `roachtest run` takes the `--cockroach`,
+`--roachprod`, and `--workload` flags. The default values for these are set up
+so that they do not need to be specified in the common case. Besides, when
+the binaries have nonstandard names, it is often more convenient to move them
+to the location `roachtest` expects (it will tell you) rather than to specify
+the flags. However, when multiple binaries are around, it might be preferrable
+to be explicit, to avoid accidentally running tests against against the wrong
+version of CockroachDB.
 
-A custom pebble executable can be specified by setting the `$PEBBLE_BIN` environment
-variable.
+### Building your own
+
+The `cockroach` and `workload` binaries need to be built for the architecture
+of the target cluster. In most cases, this means `amd64-linux-gnu`, i.e. OSX
+users have to either download the binary they need from somewhere (see below)
+or cross-compile the binary locally, which unfortunately takes a long time (due
+to the overhead of virtualization for Docker on Mac).
+
+As a general rule of thumb, if running against "real" VMs, and the version to
+test is checked out, the following will build the right binaries and put them
+where `roachtest` will find them:
+
+`build/builder.sh mkrelease amd64-linux-gnu build bin/workload`
+
+`roachtest` will look first in `$PATH`, then (except when `--local` is
+specified) in `bin.docker_amd64` in the repo root, followed by `bin`. This
+is complicated enough to be surprising, which might be another reason to
+pass the `--cockroach`, `--workload`, `--roachprod` flags explicitly.
+
+Some roachtests can also be run with the `--local` flag, i.e. will use a
+cluster on the local machine created via `roachprod create local`. In that
+case, the `cockroach` and `workload` binary must target the local architecture,
+which means
+
+`make build bin/workload`
+
+will do the trick. However, most roachtests don't make a lot of sense in local
+mode or will do outright dangerous things (like trying to install packages on
+the system), so don't use this option unless you know what you're doing. Often
+the `--local` option is used in development.
+
+### Getting them from elsewhere
+
+Especially for OSX users, building a linux CockroachDB binary is an extremely time-consuming process (think 30 minutes). If the version to be tested is a released version, a somewhat convenient way of getting a binary is to run
+
+```
+# Make a single-node local cluster.
+roachprod create -n 1 local
+# Tell roachprod to place a CockroachDB 21.1.5 Linux binary onto node 1.
+roachprod stage local release v21.1.5 --os linux
+# Copy it from (local) node 1 to the current directory
+mv ~/local/1/cockroach cockroach
+# Can now use roachtest with the `--cockroach=./cockroach` flag.
+```
+
+This doesn't work for the `workload` binary but this builds a lot faster anyway
+(via `build/builder.sh mkrelease amd64-linux-gnu bin/workload`; note the
+absence of the word `build` which prevents unnecessarily building CockroachDB
+again).  The above strategy also works for recent SHAs from the master/release
+branches, where the incantation is `roachprod stage local cockroach <SHA>`; the
+SHA is optional and defaults to a recent build from the `master` branch, which
+may not be what you want. As a bonus, `roachprod stage local workload <SHA>
+--os linux` does allow getting a `workload` binary as well, meaning you can run
+a roachtest without compiling anything yourself.
+
+## Running a test
+
+With the binaries in place, it should be possible to run a simple test.
+As a smoke test, the following should work and not take too long:
+
+```
+$ roachtest run acceptance/build-info
+```
+
+If this doesn't work, the output should tell you why. Perhaps the binaries you
+use are not in the canonical locations and need to be specified via the
+`--cockroach`, `--workload`, `--roachprod` flags. Common other errors include
+not having set up roachprod properly (does `roachprod create -n 1 $USER-foo &&
+roachprod destroy $USER-foo` work?), or having the binaries for the wrong
+architecture in place (reminder: `roachtest` and `roachprod` run on your own
+system, `cockroach` and `workload` on the typically remote VMs).
+
+After the test, artifacts for the test are collected under the `artifacts`
+directory.  For failed tests, this includes a debug.zip and the cluster logs
+(assuming the test got far enough to set up a cluster and also managed to
+download these after the failure). The test's "main log" is `test.log`.
+
+The `roachtest run` command takes a number of optional flags which can be listed
+via `roachtest run --help`. A few important ones are:
+
+- `--debug`: keeps the cluster alive on failure. The cluster name can be
+  obtained from the artifacts and it can be manually inspected (and must
+  manually be destroyed via `roachprod destroy <name>`).
+- `--count`: instructs roachtest to run the test multiple times. This may be able
+  to reuse clusters and also runs multiple instances concurrently, so it's the
+  option of choice when trying to reproduce a failing roachtest.
+- A custom pebble executable can be specified by setting the `$PEBBLE_BIN`
+  environment variable; this is used only in pebble-specific tests.
+- `--clouds` specifies which cloud provider to use. This allows multiple
+  comma-separated entries for multi-region testing (see `--help`) but with a
+  single entry such as `aws` it will run the test against AWS instead of GCE (the
+  default).
+
+## Tips for developers
+
+### Adding a roachtest
+
+A new roachtest should not be added without prior due diligence. Some questions to ask are:
+
+- what am I trying to test and could I be testing it more directly using the Go test framework
+  and, for example, a narrower unit test or using an in-memory TestCluster?
+- is my team willing and able to own this test going forward? Roachtests run
+  against cloud-provisioned hardware and have a higher rate of spurious
+  failures than other tests. They are also more likely to fail as a result of
+  problems not attributable to the owning team.
+
+The #test-eng channel is a good place to get guidance on these questions and
+it is recommended that those seek to add a roachtest ask there.
+
+This is doubly encouraged once it comes to actually writing the test. There
+is no comprehensive guide on how to do so, and in practice one learns from
+existing tests, not all of which are good examples to learn from. The test-eng
+team will help steer you towards good examples.
+
+While writing the test it is encouraged to use the `--local` mode to sanity-check
+the test. Additionally, tests interact with the test harness through interfaces
+and so it is in principle possible to mock everything. It is encouraged to make
+use of this as much as possible, and to add unit tests for nontrivial pieces of
+code. It might seem silly to write tests for a test but the cost of investigating
+a roachtest failure is often comparable to investing a customer incident, so it
+makes sense to invest heavily in prevention.
+
+When running the roachtest during iteration (perhaps using `--local` to save
+time; note that the test can use `c.IsLocal()` to take short-cuts in that
+case which is helpful during development), don't forget to rebuild the binaries
+you've touched (i.e. most likely only `roachtest`). For example, the command
+line that you might use while iterating on a new test `foo/garble-wozzler` is
+
+`make bin/roachtest && roachtest run --local foo/garble-wozzler`.
+
+### Reproducing a test failure
+
+To reproduce a failing roachtest, the following flags are helpful:
+
+- `--count`: run multiple instances of the test (concurrently)
+- `--cpu-quota`: sets the number of vCPUs that roachtest can use for its clusters (determines the degree of parallelism).
+- `--debug`: preserves failing clusters.
+- `--artifacts`: override the default artifacts dir.
+
+The HTTP endpoint (by default `:8080`) is useful to find the "run" numbers for
+failing tests (to find the artifacts) and to get a general overview of the
+progress of the invocation.
+
+A solid foundation for building the binaries and stressing a roachtest is
+provided via the [roachstress.sh] script, which can either be used outright or
+saved and adjusted. The script can be invoked without parameters from a clean
+checkout of the cockroach repository at the revision to be tested. It will
+prompt for user input on which test to stress.
+
+[roachstress.sh]: https://github.com/cockroachdb/cockroach/blob/master/pkg/cmd/roachtest/roachstress.sh

--- a/pkg/cmd/roachtest/roachstress.sh
+++ b/pkg/cmd/roachtest/roachstress.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This script is an opinionated helper around building binaries and artifacts.
+# It is particularly helpful for stressing roachtests at multiple revisions.
+#
+# This script is to be invoked from the repository root checked out at the revision
+# to be tested.
+#
+# It's best practice to invoke this script with "caffeinate" on OSX and/or linux
+# to avoid computer going to standby.
+
+if [ "${GCE_PROJECT-cockroach-ephemeral}" == "cockroach-ephemeral" ]; then
+  cat <<EOF
+Please do not use roachstress on the cockroach-ephemeral project.
+This may compete over quota with scheduled roachtest builds.
+Use the andrei-jepsen project instead or reach out to dev-inf.
+
+The project can be specified via the environment:
+  export GCE_PROJECT=XXX
+EOF
+  exit 2
+fi
+
+# Define the artifacts base dir, within which both the built binaries and the
+# artifacts will be stored.
+sha=$(git rev-parse --short HEAD)
+abase="artifacts/${sha}"
+
+# Locations of the binaries.
+rt="${abase}/roachtest"
+rp="${abase}/roachprod"
+wl="${abase}/workload"
+cr="${abase}/cockroach"
+
+# This is the artifacts dir we'll pass to the roachtest invocation. It's
+# disambiguated by a timestamp because one often ends up invoking roachtest on
+# the same SHA multiple times and artifacts shouldn't mix.
+a="${abase}/$(date '+%H%M%S')"
+
+# Read user input.
+read -e -i "${TEST-}" -p "Test regexp: " TEST
+read -e -i "${COUNT-10}" -p "Count: " COUNT
+
+short="short"
+if [ ! -f "${cr}" ]; then
+  yn=""
+  read -e -i "${SHORT-y}" -p "Build cockroach without the UI: " yn
+  case $yn in
+    [Nn]* | false | "") short=""
+  esac
+fi
+
+mkdir -p "${a}"
+
+if [ ! -f "${cr}" ]; then
+  ./build/builder.sh mkrelease amd64-linux-gnu "build${short}"
+  mv "cockroach${short}-linux-2.6.32-gnu-amd64" "${cr}"
+fi
+
+if [ ! -f "${rt}" ]; then
+  ./build/builder.sh mkrelease amd64-linux-gnu bin/workload
+  mv -f bin.docker_amd64/workload "${wl}"
+  make bin/roach{prod,test}
+  mv -f bin/roachprod "${rp}"
+  mv -f bin/roachtest "${rt}"
+fi
+
+# Run roachtest. Use a random port so that multiple
+# tests can be stressed from the same workstation.
+"${rt}" run "${TEST}" \
+  --port "$((8080+$RANDOM % 1000))" \
+  --roachprod "${rp}" \
+  --workload "${wl}" \
+  --cockroach "${cr}" \
+  --artifacts "${a}" \
+  --count "${COUNT}"

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -933,15 +933,12 @@ func (r *testRunner) maybePostGithubIssue(
 		Message:         msg,
 		Artifacts:       artifacts,
 		ExtraLabels:     labels,
-		ReproductionCommand: fmt.Sprintf(
-			`## Simple repro (linux-only):
-  $ make cockroachshort bin/worklaod bin/roachprod bin/roachtest
-  $ PATH=$PWD/bin:$PATH roachtest run %[1]s --local
-
-## Proper repro probably needs more roachtest flags, or running
-## the programs remotely on GCE. For more details, refer to
-## pkg/cmd/roachtest/README.md.
-`, t.Name()),
+		ReproductionCommand: func(r *issues.Renderer) {
+			r.P(func() {
+				r.Escaped("See the corresponding section in the ")
+				r.A("roachtest README", "https://github.com/cockroachdb/cockroach/tree/master/pkg/cmd/roachtest")
+			})
+		},
 	}
 	if err := issues.Post(
 		context.Background(),


### PR DESCRIPTION
This (attempts) to give some practical tips on how to get to the
point of invoking a simple roachtest, and provides troubleshooting
advice.

I also added a developer-centric section which covers (at a very high
level) adding new tests and reproducing test failures.

cc @vy-ton

Release note: None
