### PR TITLE
dev: teach `dev` how to `stress`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,6 @@
 build --symlink_prefix=_bazel/ --ui_event_filters=-DEBUG --define gotags=bazel,crdb_test_off
-test --symlink_prefix=_bazel/ --define gotags=bazel,crdb_test --test_env=TZ=
+test --config=test
+build:test --symlink_prefix=_bazel/ --define gotags=bazel,crdb_test --test_env=TZ=
 query --ui_event_filters=-DEBUG
 
 try-import %workspace%/.bazelrc.user

--- a/Makefile
+++ b/Makefile
@@ -1699,6 +1699,7 @@ bins = \
   bin/cockroach-short \
   bin/cockroach-sql \
   bin/compile-builds \
+  bin/dev \
   bin/docgen \
   bin/execgen \
   bin/fuzz \
@@ -1719,11 +1720,11 @@ bins = \
   bin/roachprod \
   bin/roachprod-stress \
   bin/roachtest \
-	bin/skip-test \
+  bin/skip-test \
   bin/teamcity-trigger \
   bin/uptodate \
   bin/urlcheck \
-	bin/whoownsit \
+  bin/whoownsit \
   bin/zerosum
 
 # `xbins` contains binaries that should be compiled for the target architecture

--- a/pkg/cmd/dev/bench.go
+++ b/pkg/cmd/dev/bench.go
@@ -11,24 +11,104 @@
 package main
 
 import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+
 	"github.com/cockroachdb/errors"
 	"github.com/spf13/cobra"
 )
 
 // makeBenchCmd constructs the subcommand used to run the specified benchmarks.
 func makeBenchCmd(runE func(cmd *cobra.Command, args []string) error) *cobra.Command {
-	return &cobra.Command{
-		Use:   "bench",
+	benchCmd := &cobra.Command{
+		Use:   "bench [pkg...]",
 		Short: `Run the specified benchmarks`,
 		Long:  `Run the specified benchmarks.`,
 		Example: `
-	dev bench --pkg=sql/parser --filter=BenchmarkParse`,
-		Args: cobra.NoArgs,
+	dev bench
+        dev bench pkg/sql/parser
+        dev bench pkg/sql/parser/...
+        dev bench pkg/sql/parser --filter=BenchmarkParse`,
+		Args: cobra.MinimumNArgs(0),
 		RunE: runE,
 	}
+	addCommonTestFlags(benchCmd)
+	return benchCmd
 }
 
-func (*dev) bench(*cobra.Command, []string) error {
-	// TODO(irfansharif): Flesh out the example usage patterns.
-	return errors.New("unimplemented")
+func (d *dev) bench(cmd *cobra.Command, pkgs []string) error {
+	ctx := cmd.Context()
+	filter := mustGetFlagString(cmd, filterFlag)
+	timeout := mustGetFlagDuration(cmd, timeoutFlag)
+
+	// Enumerate all benches to run.
+	if len(pkgs) == 0 {
+		// Empty `dev bench` does the same thing as `dev bench pkg/...`
+		pkgs = append(pkgs, "pkg/...")
+	}
+	benchesMap := make(map[string]bool)
+	for _, pkg := range pkgs {
+		pkg = strings.TrimPrefix(pkg, "//")
+
+		if !strings.HasPrefix(pkg, "pkg/") {
+			return errors.Newf("malformed package %q, expecting %q", pkg, "pkg/{...}")
+		}
+
+		if strings.HasSuffix(pkg, "/...") {
+			pkg = strings.TrimSuffix(pkg, "/...")
+			// Use `git grep` to find all Go files that contain benchmark tests.
+			out, err := d.exec.CommandContextSilent(ctx, "git", "grep", "-l", "^func Benchmark", "--", pkg+"/*_test.go")
+			if err != nil {
+				return err
+			}
+			files := strings.Split(strings.TrimSpace(string(out)), "\n")
+			for _, file := range files {
+				dir, _ := filepath.Split(file)
+				dir = strings.TrimSuffix(dir, "/")
+				benchesMap[dir] = true
+			}
+		} else {
+			benchesMap[pkg] = true
+		}
+	}
+	// De-duplicate and sort the list of benches to run.
+	var benches []string
+	for pkg := range benchesMap {
+		benches = append(benches, pkg)
+	}
+	sort.Slice(benches, func(i, j int) bool { return benches[i] < benches[j] })
+
+	var argsBase []string
+	// NOTE the --config=test here. It's very important we compile the test binary with the
+	// appropriate stuff (gotags, etc.)
+	argsBase = append(argsBase, "run", "--color=yes", "--experimental_convenience_symlinks=ignore", "--config=test")
+	argsBase = append(argsBase, getConfigFlags()...)
+	argsBase = append(argsBase, mustGetRemoteCacheArgs(remoteCacheAddr)...)
+	if numCPUs != 0 {
+		argsBase = append(argsBase, fmt.Sprintf("--local_cpu_resources=%d", numCPUs))
+	}
+
+	for _, bench := range benches {
+		args := make([]string, len(argsBase))
+		copy(args, argsBase)
+		base := filepath.Base(bench)
+		target := "//" + bench + ":" + base + "_test"
+		args = append(args, target, "--")
+		if filter == "" {
+			args = append(args, "-test.bench=.")
+		} else {
+			args = append(args, "-test.bench="+filter)
+		}
+		if timeout > 0 {
+			args = append(args, fmt.Sprintf("-test.timeout=%s", timeout.String()))
+		}
+		_, err := d.exec.CommandContext(ctx, "bazel", args...)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/pkg/cmd/dev/build.go
+++ b/pkg/cmd/dev/build.go
@@ -46,6 +46,7 @@ var buildTargetMapping = map[string]string{
 	"cockroach":        "//pkg/cmd/cockroach",
 	"cockroach-oss":    "//pkg/cmd/cockroach-oss",
 	"cockroach-short":  "//pkg/cmd/cockroach-short",
+	"dev":              "//pkg/cmd/dev",
 	"docgen":           "//pkg/cmd/docgen",
 	"execgen":          "//pkg/sql/colexec/execgen/cmd/execgen",
 	"optgen":           "//pkg/sql/opt/optgen/cmd/optgen",
@@ -53,6 +54,7 @@ var buildTargetMapping = map[string]string{
 	"langgen":          "//pkg/sql/opt/optgen/cmd/langgen",
 	"roachprod":        "//pkg/cmd/roachprod",
 	"roachprod-stress": "//pkg/cmd/roachprod-stress",
+	"short":            "//pkg/cmd/cockroach-short",
 	"workload":         "//pkg/cmd/workload",
 	"roachtest":        "//pkg/cmd/roachtest",
 }
@@ -77,12 +79,21 @@ func (d *dev) build(cmd *cobra.Command, targets []string) (err error) {
 		args = append(args, fmt.Sprintf("--local_cpu_resources=%d", numCPUs))
 	}
 
+	var fullTargets []string
 	for _, target := range targets {
+		// Assume that targets beginning with `//` or containing `/`
+		// don't need to be munged.
+		if strings.HasPrefix(target, "//") || strings.Contains(target, "/") {
+			args = append(args, target)
+			fullTargets = append(fullTargets, target)
+			continue
+		}
 		buildTarget, ok := buildTargetMapping[target]
 		if !ok {
 			return errors.Newf("unrecognized target: %s", target)
 		}
 
+		fullTargets = append(fullTargets, buildTarget)
 		args = append(args, buildTarget)
 	}
 
@@ -90,7 +101,7 @@ func (d *dev) build(cmd *cobra.Command, targets []string) (err error) {
 		return err
 	}
 
-	return d.symlinkBinaries(ctx, targets)
+	return d.symlinkBinaries(ctx, fullTargets)
 }
 
 func (d *dev) symlinkBinaries(ctx context.Context, targets []string) error {
@@ -104,19 +115,19 @@ func (d *dev) symlinkBinaries(ctx context.Context, targets []string) error {
 	}
 
 	for _, target := range targets {
-		buildTarget := buildTargetMapping[target]
-		binaryPath, err := d.getPathToBin(ctx, buildTarget)
+		binaryPath, err := d.getPathToBin(ctx, target)
 		if err != nil {
 			return err
 		}
+		base := filepath.Base(strings.TrimPrefix(target, "//"))
 
 		var symlinkPath string
 		// Binaries beginning with the string "cockroach" go right at
 		// the top of the workspace; others go in the `bin` directory.
-		if strings.HasPrefix(target, "cockroach") {
-			symlinkPath = path.Join(workspace, target)
+		if strings.HasPrefix(base, "cockroach") {
+			symlinkPath = path.Join(workspace, base)
 		} else {
-			symlinkPath = path.Join(workspace, "bin", target)
+			symlinkPath = path.Join(workspace, "bin", base)
 		}
 
 		// Symlink from binaryPath -> symlinkPath

--- a/pkg/cmd/dev/build.go
+++ b/pkg/cmd/dev/build.go
@@ -150,7 +150,19 @@ func (d *dev) getPathToBin(ctx context.Context, target string) (string, error) {
 		return "", err
 	}
 	bazelBin := strings.TrimSpace(string(out))
-	target = strings.TrimPrefix(target, "//")
-	_, filename := filepath.Split(target)
-	return filepath.Join(bazelBin, target, filename+"_", filename), nil
+	var head string
+	if strings.HasPrefix(target, "@") {
+		doubleSlash := strings.Index(target, "//")
+		head = filepath.Join("external", target[1:doubleSlash])
+	} else {
+		head = strings.TrimPrefix(target, "//")
+	}
+	var bin string
+	colon := strings.Index(target, ":")
+	if colon >= 0 {
+		bin = target[colon+1:]
+	} else {
+		bin = target[strings.LastIndex(target, "/")+1:]
+	}
+	return filepath.Join(bazelBin, head, bin+"_", bin), nil
 }

--- a/pkg/cmd/dev/testdata/bench.txt
+++ b/pkg/cmd/dev/testdata/bench.txt
@@ -1,0 +1,9 @@
+dev bench pkg/util/...
+----
+git grep -l ^func Benchmark -- pkg/util/*_test.go
+bazel run --color=yes --experimental_convenience_symlinks=ignore --config=test --config=dev //pkg/util:util_test -- -test.bench=.
+bazel run --color=yes --experimental_convenience_symlinks=ignore --config=test --config=dev //pkg/util/uuid:uuid_test -- -test.bench=.
+
+dev bench pkg/sql/parser --filter=BenchmarkParse
+----
+bazel run --color=yes --experimental_convenience_symlinks=ignore --config=test --config=dev //pkg/sql/parser:parser_test -- -test.bench=BenchmarkParse

--- a/pkg/cmd/dev/testdata/recording/bench.txt
+++ b/pkg/cmd/dev/testdata/recording/bench.txt
@@ -1,0 +1,15 @@
+git grep -l ^func Benchmark -- pkg/util/*_test.go
+----
+pkg/util/topk_test.go
+pkg/util/uuid/benchmark_fast_test.go
+pkg/util/uuid/codec_test.go
+pkg/util/uuid/generator_test.go
+
+bazel run --color=yes --experimental_convenience_symlinks=ignore --config=test --config=dev //pkg/util:util_test -- -test.bench=.
+----
+
+bazel run --color=yes --experimental_convenience_symlinks=ignore --config=test --config=dev //pkg/util/uuid:uuid_test -- -test.bench=.
+----
+
+bazel run --color=yes --experimental_convenience_symlinks=ignore --config=test --config=dev //pkg/sql/parser:parser_test -- -test.bench=BenchmarkParse
+----

--- a/pkg/cmd/dev/testdata/recording/test.txt
+++ b/pkg/cmd/dev/testdata/recording/test.txt
@@ -60,7 +60,21 @@ Executed 1 out of 1 test: 1 test passes.
 ----
 ----
 
-bazel test --color=yes --experimental_convenience_symlinks=ignore --config=dev //pkg/util/tracing:tracing_test --run_under stress -maxtime=10s --test_filter='TestStartChild*' --test_output errors
+bazel build --color=yes --experimental_convenience_symlinks=ignore --config=dev @com_github_cockroachdb_stress//:stress
+----
+----
+ok
+----
+----
+
+bazel info bazel-bin --color=no --config=dev
+----
+----
+/private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin
+----
+----
+
+bazel test --color=yes --experimental_convenience_symlinks=ignore --config=dev //pkg/util/tracing:tracing_test --run_under /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/external/com_github_cockroachdb_stress/stress_/stress --test_filter='TestStartChild*' --test_output errors
 ----
 ----
 //pkg/util/tracing:tracing_test                                          [0m[32mPASSED[0m in 12.3s
@@ -69,7 +83,21 @@ Executed 1 out of 1 test: 1 test passes.
 ----
 ----
 
-bazel test --color=yes --experimental_convenience_symlinks=ignore --config=dev //pkg/util/tracing:tracing_test --run_under stress -maxtime=10s --test_filter='TestStartChild*' --test_output all --test_arg -test.v
+bazel build --color=yes --experimental_convenience_symlinks=ignore --config=dev @com_github_cockroachdb_stress//:stress
+----
+----
+ok
+----
+----
+
+bazel info bazel-bin --color=no --config=dev
+----
+----
+/private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin
+----
+----
+
+bazel test --color=yes --experimental_convenience_symlinks=ignore --config=dev //pkg/util/tracing:tracing_test --run_under /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/external/com_github_cockroachdb_stress/stress_/stress -maxtime=10s --test_filter='TestStartChild*' --test_output all --test_arg -test.v
 ----
 ----
 ==================== Test output for //pkg/util/tracing:tracing_test:

--- a/pkg/cmd/dev/testdata/recording/test.txt
+++ b/pkg/cmd/dev/testdata/recording/test.txt
@@ -84,3 +84,27 @@ Executed 1 out of 1 test: 1 test passes.
 ----
 ----
 
+bazel test --color=yes --experimental_convenience_symlinks=ignore --config=dev //pkg/testutils:testutils_test --test_timeout=10 --test_output errors
+----
+----
+[32mLoading:[0m 
+[32mLoading:[0m 0 packages loaded
+[32mINFO: [0mBuild option --test_timeout has changed, discarding analysis cache.
+[32mAnalyzing:[0m target //pkg/testutils:testutils_test (0 packages loaded, 0 targets configured)
+[32mINFO: [0mAnalyzed target //pkg/testutils:testutils_test (0 packages loaded, 11870 targets configured).
+[32mINFO: [0mFound 1 test target...
+[32m[0 / 2][0m [Prepa] BazelWorkspaceStatusAction stable-status.txt
+[32m[1,220 / 1,221][0m GoLink pkg/testutils/testutils_test_/testutils_test; 0s darwin-sandbox
+[32m[1,221 / 1,222][0m Testing //pkg/testutils:testutils_test; 0s darwin-sandbox
+Target //pkg/testutils:testutils_test up-to-date:
+  _bazel/bin/pkg/testutils/testutils_test_/testutils_test
+[32mINFO: [0mElapsed time: 4.336s, Critical Path: 2.79s
+[32mINFO: [0m3 processes: 1 internal, 2 darwin-sandbox.
+[32mINFO:[0m Build completed successfully, 3 total actions
+//pkg/testutils:testutils_test                                           [0m[32mPASSED[0m in 0.8s
+
+Executed 1 out of 1 test: 1 test passes.
+[32mINFO:[0m Build completed successfully, 3 total actions
+[0m
+----
+----

--- a/pkg/cmd/dev/testdata/test.txt
+++ b/pkg/cmd/dev/testdata/test.txt
@@ -30,3 +30,7 @@ bazel test --color=yes --experimental_convenience_symlinks=ignore --config=dev /
 dev test --stress pkg/util/tracing --filter 'TestStartChild*' --timeout=10s -v
 ----
 bazel test --color=yes --experimental_convenience_symlinks=ignore --config=dev //pkg/util/tracing:tracing_test --run_under stress -maxtime=10s --test_filter='TestStartChild*' --test_output all --test_arg -test.v
+
+dev test //pkg/testutils --timeout=10s
+----
+bazel test --color=yes --experimental_convenience_symlinks=ignore --config=dev //pkg/testutils:testutils_test --test_timeout=10 --test_output errors

--- a/pkg/cmd/dev/testdata/test.txt
+++ b/pkg/cmd/dev/testdata/test.txt
@@ -23,13 +23,17 @@ dev test pkg/util/tracing -f 'TestStartChild*' --ignore-cache
 ----
 bazel test --color=yes --experimental_convenience_symlinks=ignore --config=dev //pkg/util/tracing:tracing_test --nocache_test_results --test_filter='TestStartChild*' --test_output errors
 
-dev test --stress pkg/util/tracing --filter 'TestStartChild*' --timeout=10s
+dev test --stress pkg/util/tracing --filter 'TestStartChild*'
 ----
-bazel test --color=yes --experimental_convenience_symlinks=ignore --config=dev //pkg/util/tracing:tracing_test --run_under stress -maxtime=10s --test_filter='TestStartChild*' --test_output errors
+bazel build --color=yes --experimental_convenience_symlinks=ignore --config=dev @com_github_cockroachdb_stress//:stress
+bazel info bazel-bin --color=no --config=dev
+bazel test --color=yes --experimental_convenience_symlinks=ignore --config=dev //pkg/util/tracing:tracing_test --run_under /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/external/com_github_cockroachdb_stress/stress_/stress --test_filter='TestStartChild*' --test_output errors
 
 dev test --stress pkg/util/tracing --filter 'TestStartChild*' --timeout=10s -v
 ----
-bazel test --color=yes --experimental_convenience_symlinks=ignore --config=dev //pkg/util/tracing:tracing_test --run_under stress -maxtime=10s --test_filter='TestStartChild*' --test_output all --test_arg -test.v
+bazel build --color=yes --experimental_convenience_symlinks=ignore --config=dev @com_github_cockroachdb_stress//:stress
+bazel info bazel-bin --color=no --config=dev
+bazel test --color=yes --experimental_convenience_symlinks=ignore --config=dev //pkg/util/tracing:tracing_test --run_under /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/external/com_github_cockroachdb_stress/stress_/stress -maxtime=10s --test_filter='TestStartChild*' --test_output all --test_arg -test.v
 
 dev test //pkg/testutils --timeout=10s
 ----

--- a/pkg/cmd/dev/util.go
+++ b/pkg/cmd/dev/util.go
@@ -98,3 +98,8 @@ func getConfigFlags() []string {
 	}
 	return []string{"--config=dev"}
 }
+
+func addCommonTestFlags(cmd *cobra.Command) {
+	cmd.Flags().StringP(filterFlag, "f", "", "run unit tests matching this regex")
+	cmd.Flags().Duration(timeoutFlag, 0*time.Minute, "timeout for test")
+}


### PR DESCRIPTION
Only the latest commit counts for this review, the other is from #67631.

The previous version of this code would assume that you had `stress`
installed globally -- this doesn't work in the long term, so instead if
you're stress testing pre-build the `stress` binary and pass it in to
`bazel test` invocation.

Closes #67165.

Release note: None