### PR TITLE
release-21.1: roachtest: fix typeorm apt-get update

### DIFF
--- a/pkg/cmd/roachtest/typeorm.go
+++ b/pkg/cmd/roachtest/typeorm.go
@@ -53,6 +53,13 @@ func registerTypeORM(r *testRegistry) {
 		c.l.Printf("Supported TypeORM release is %s.", supportedTypeORMRelease)
 
 		if err := repeatRunE(
+			ctx, c, node, "purge apt-get",
+			`sudo apt-get purge -y command-not-found`,
+		); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repeatRunE(
 			ctx, c, node, "update apt-get", `sudo apt-get -qq update`,
 		); err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
Backport 1/1 commits from #67548.

/cc @cockroachdb/release

---

Release note: None

Release justification: low risk roachtest fix