### PR TITLE
roachtest: skip failing liquibase test

### DIFF
--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -61,6 +61,7 @@ go_library(
         "libpq.go",
         "libpq_blocklist.go",
         "liquibase.go",
+        "liquibase_blocklist.go",
         "many_splits.go",
         "mixed_version_decommission.go",
         "mixed_version_jobs.go",

--- a/pkg/cmd/roachtest/tests/liquibase_blocklist.go
+++ b/pkg/cmd/roachtest/tests/liquibase_blocklist.go
@@ -1,0 +1,31 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tests
+
+var liquibaseBlocklists = blocklistsForVersion{
+	{"v20.2", "liquibaseBlocklist20_2", liquibaseBlocklist20_2, "liquibaseIgnorelist20_2", liquibaseIgnorelist20_2},
+	{"v21.1", "liquibaseBlocklist21_1", liquibaseBlocklist21_1, "liquibaseIgnorelist21_1", liquibaseIgnorelist21_1},
+	{"v21.2", "liquibaseBlocklist21_2", liquibaseBlocklist21_2, "liquibaseIgnorelist21_2", liquibaseIgnorelist21_2},
+}
+
+var liquibaseBlocklist21_2 = blocklist{
+	"liquibase.harness.change.ChangeObjectTests.apply addDefaultValueSequenceNext against cockroachdb 20.2; verify generated SQL and DB snapshot": "",
+}
+
+var liquibaseBlocklist21_1 = liquibaseBlocklist20_2
+
+var liquibaseBlocklist20_2 = blocklist{}
+
+var liquibaseIgnorelist21_2 = liquibaseIgnorelist21_1
+
+var liquibaseIgnorelist21_1 = liquibaseIgnorelist20_2
+
+var liquibaseIgnorelist20_2 = blocklist{}


### PR DESCRIPTION
Not sure why this is failing, the SQL being executed in the test passes against Cockroach v20.2+.

Will re-evaluate once liquibase test harness v1.0.3 is released.

Release note: None

Resolves https://github.com/cockroachdb/cockroach/issues/66524