### PR TITLE
changefeedccl: retry webhook sink requests upon HTTP error

### DIFF
--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -82,7 +82,7 @@ func getSink(
 		case u.Scheme == changefeedbase.SinkSchemeKafka:
 			return makeKafkaSink(ctx, sinkURL{URL: u}, feedCfg.Targets, feedCfg.Opts, acc)
 		case isWebhookSink(u):
-			return makeWebhookSink(ctx, sinkURL{URL: u}, feedCfg.Opts, defaultWorkerCount(), acc)
+			return makeWebhookSink(ctx, sinkURL{URL: u}, feedCfg.Opts, defaultWorkerCount(), acc, defaultRetryConfig())
 		case isCloudStorageSink(u):
 			return makeCloudStorageSink(
 				ctx, sinkURL{URL: u}, serverCfg.NodeID.SQLInstanceID(), serverCfg.Settings,


### PR DESCRIPTION
Before, webhook sink requests simply resulted in retryable changefeed
errors upon failure. This change adds default retry behavior for HTTP
requests, preventing the need for changefeeds to shut down and restart
every time.

Resolves #67312

Release note: None