### PR TITLE
sql: rename virtual inverted columns as artificial inverted columns

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
@@ -161,7 +161,7 @@ TABLE t
  ├── j jsonb
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── tableoid oid [hidden] [system]
- ├── j_inverted_key bytes not null [virtual-inverted]
+ ├── j_inverted_key bytes not null [artificial-inverted]
  ├── FAMILY fam_0_pk_a_b_c_d_j (pk, a, b, c, d, j)
  ├── PRIMARY INDEX primary
  │    ├── a int not null (implicit)
@@ -198,7 +198,7 @@ TABLE t
  │                   └── (4)
  ├── INVERTED INDEX t_j_idx
  │    ├── a int not null (implicit)
- │    ├── j_inverted_key bytes not null [virtual-inverted]
+ │    ├── j_inverted_key bytes not null [artificial-inverted]
  │    ├── pk int not null
  │    └── partitions
  │         └── j_implicit

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -285,7 +285,7 @@ TABLE regional_by_row_table
  ├── crdb_region crdb_internal_region not null default (default_to_database_primary_region(gateway_region())::@100054) [hidden]
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── tableoid oid [hidden] [system]
- ├── j_inverted_key bytes not null [virtual-inverted]
+ ├── j_inverted_key bytes not null [artificial-inverted]
  ├── FAMILY fam_0_pk_pk2_a_b_j_crdb_region (pk, pk2, a, b, j, crdb_region)
  ├── CHECK (crdb_region IN (x'40':::@100054, x'80':::@100054, x'c0':::@100054))
  ├── PRIMARY INDEX primary
@@ -415,7 +415,7 @@ TABLE regional_by_row_table
  │                   └── lease preference: [+region=us-east-1]
  ├── INVERTED INDEX regional_by_row_table_j_idx
  │    ├── crdb_region crdb_internal_region not null default (default_to_database_primary_region(gateway_region())::@100054) [hidden] (implicit)
- │    ├── j_inverted_key bytes not null [virtual-inverted]
+ │    ├── j_inverted_key bytes not null [artificial-inverted]
  │    ├── pk int not null
  │    ├── ZONE
  │    │    ├── replica constraints

--- a/pkg/sql/colencoding/key_encoding.go
+++ b/pkg/sql/colencoding/key_encoding.go
@@ -174,8 +174,8 @@ func DecodeKeyValsToCols(
 				unseen.Remove(i)
 			}
 			var isNull bool
-			isVirtualInverted := invertedColIdx == i
-			key, isNull, err = decodeTableKeyToCol(da, vecs[i], idx, types[j], key, enc, isVirtualInverted)
+			isArtificialInverted := invertedColIdx == i
+			key, isNull, err = decodeTableKeyToCol(da, vecs[i], idx, types[j], key, enc, isArtificialInverted)
 			foundNull = isNull || foundNull
 		}
 		if err != nil {
@@ -196,7 +196,7 @@ func decodeTableKeyToCol(
 	valType *types.T,
 	key []byte,
 	dir descpb.IndexDescriptor_Direction,
-	isVirtualInverted bool,
+	isArtificialInverted bool,
 ) ([]byte, bool, error) {
 	if (dir != descpb.IndexDescriptor_ASC) && (dir != descpb.IndexDescriptor_DESC) {
 		return nil, false, errors.AssertionFailedf("invalid direction: %d", log.Safe(dir))
@@ -211,9 +211,9 @@ func decodeTableKeyToCol(
 	// value here.
 	vec.Nulls().UnsetNull(idx)
 
-	// Virtual inverted columns should not be decoded, but should instead be
+	// Artificial inverted columns should not be decoded, but should instead be
 	// passed on as a DBytes datum.
-	if isVirtualInverted {
+	if isArtificialInverted {
 		keyLen, err := encoding.PeekLength(key)
 		if err != nil {
 			return nil, false, err

--- a/pkg/sql/colfetcher/cfetcher.go
+++ b/pkg/sql/colfetcher/cfetcher.go
@@ -90,9 +90,9 @@ type cTableInfo struct {
 	// does not contain any -1's. It is meant to be used only in logging.
 	allExtraValColOrdinals []int
 
-	// invertedColOrdinal is a column index (into cols), indicating the virtual
-	// inverted column; -1 if there is no virtual inverted column or we don't
-	// need the value for that column.
+	// invertedColOrdinal is a column index (into cols), indicating the
+	// artificial inverted column; -1 if there is no artificial inverted column
+	// or we don't need the value for that column.
 	invertedColOrdinal int
 
 	// maxColumnFamilyID is the maximum possible family id for the configured

--- a/pkg/sql/exec_factory_util.go
+++ b/pkg/sql/exec_factory_util.go
@@ -101,7 +101,7 @@ func makeScanColumnsConfig(table cat.Table, cols exec.TableColumnOrdinalSet) sca
 	for ord, ok := cols.Next(0); ok; ord, ok = cols.Next(ord + 1) {
 		col := table.Column(ord)
 		colOrd := ord
-		if col.Kind() == cat.VirtualInverted {
+		if col.Kind() == cat.ArtificialInverted {
 			typ := col.DatumType()
 			colOrd = col.InvertedSourceColumnOrdinal()
 			col = table.Column(colOrd)

--- a/pkg/sql/opt/cat/column.go
+++ b/pkg/sql/opt/cat/column.go
@@ -50,11 +50,11 @@ func (c *Column) Ordinal() int {
 // dropped and then re-added with the same name; the new column will have a
 // different ID. See the comment for StableID for more detail.
 //
-// Virtual inverted columns don't have stable IDs; for these columns ColID()
+// Artificial inverted columns don't have stable IDs; for these columns ColID()
 // must not be called.
 func (c *Column) ColID() StableID {
-	if c.kind == VirtualInverted {
-		panic(errors.AssertionFailedf("virtual inverted columns have no StableID"))
+	if c.kind == ArtificialInverted {
+		panic(errors.AssertionFailedf("artificial inverted columns have no StableID"))
 	}
 	return c.stableID
 }
@@ -123,18 +123,19 @@ func (c *Column) IsVirtualComputed() bool {
 	return c.virtualComputed
 }
 
-// InvertedSourceColumnOrdinal is used for virtual columns that are part
+// InvertedSourceColumnOrdinal is used for artificial columns that are part
 // of inverted indexes. It returns the ordinal of the table column from which
 // the inverted column is derived.
 //
 // For example, if we have an inverted index on a JSON column `j`, the index is
-// on a virtual `j_inverted` column and calling InvertedSourceColumnOrdinal() on
-// `j_inverted` returns the ordinal of the `j` column.
+// on an artificial `j_inverted` column and calling
+// InvertedSourceColumnOrdinal() on `j_inverted` returns the ordinal of the `j`
+// column.
 //
-// Must not be called if this is not a virtual column.
+// Must not be called if this is not an artificial column.
 func (c *Column) InvertedSourceColumnOrdinal() int {
-	if c.kind != VirtualInverted {
-		panic(errors.AssertionFailedf("non-virtual columns have no inverted source column ordinal"))
+	if c.kind != ArtificialInverted {
+		panic(errors.AssertionFailedf("non-artificial columns have no inverted source column ordinal"))
 	}
 	return c.invertedSourceColumnOrdinal
 }
@@ -157,9 +158,9 @@ const (
 	// as part of mutations. They also cannot be part of the lax or key columns
 	// for indexes. System columns are not members of any column family.
 	System
-	// VirtualInverted columns are implicit columns that are used by inverted
+	// ArtificialInverted columns are implicit columns that are used by inverted
 	// indexes.
-	VirtualInverted
+	ArtificialInverted
 )
 
 // ColumnVisibility controls if a column is visible for queries and if it is
@@ -188,9 +189,9 @@ func MaybeHidden(hidden bool) ColumnVisibility {
 	return Visible
 }
 
-// InitNonVirtual is used by catalog implementations to populate a non-virtual
-// Column. It should not be used anywhere else.
-func (c *Column) InitNonVirtual(
+// Init is used by catalog implementations to populate a non-artificial and
+// non-virtual Column. It should not be used anywhere else.
+func (c *Column) Init(
 	ordinal int,
 	stableID StableID,
 	name tree.Name,
@@ -201,7 +202,7 @@ func (c *Column) InitNonVirtual(
 	defaultExpr *string,
 	computedExpr *string,
 ) {
-	if kind == VirtualInverted {
+	if kind == ArtificialInverted {
 		panic(errors.AssertionFailedf("incorrect init method"))
 	}
 	if (kind == WriteOnly || kind == DeleteOnly) && visibility != Inaccessible {
@@ -227,9 +228,9 @@ func (c *Column) InitNonVirtual(
 	}
 }
 
-// InitVirtualInverted is used by catalog implementations to populate a
-// VirtualInverted Column. It should not be used anywhere else.
-func (c *Column) InitVirtualInverted(
+// InitArtificialInverted is used by catalog implementations to populate a
+// ArtificialInverted Column. It should not be used anywhere else.
+func (c *Column) InitArtificialInverted(
 	ordinal int, name tree.Name, datumType *types.T, nullable bool, invertedSourceColumnOrdinal int,
 ) {
 	// This initialization pattern ensures that fields are not unwittingly
@@ -238,7 +239,7 @@ func (c *Column) InitVirtualInverted(
 		ordinal:                     ordinal,
 		stableID:                    0,
 		name:                        name,
-		kind:                        VirtualInverted,
+		kind:                        ArtificialInverted,
 		datumType:                   datumType,
 		nullable:                    nullable,
 		visibility:                  Inaccessible,

--- a/pkg/sql/opt/cat/index.go
+++ b/pkg/sql/opt/cat/index.go
@@ -133,9 +133,9 @@ type Index interface {
 	// i < ColumnCount.
 	Column(i int) IndexColumn
 
-	// VirtualInvertedColumn returns the VirtualInverted IndexColumn of the
+	// ArtificialInvertedColumn returns the ArtificialInverted IndexColumn of the
 	// index. Panics if the index is not an inverted index.
-	VirtualInvertedColumn() IndexColumn
+	ArtificialInvertedColumn() IndexColumn
 
 	// Predicate returns the partial index predicate expression and true if the
 	// index is a partial index. If it is not a partial index, the empty string

--- a/pkg/sql/opt/cat/utils.go
+++ b/pkg/sql/opt/cat/utils.go
@@ -332,9 +332,9 @@ func formatColumn(col *Column, buf *bytes.Buffer) {
 		fmt.Fprintf(buf, " default (%s)", col.DefaultExprStr())
 	}
 	kind := col.Kind()
-	// Omit the visibility for mutation and virtual inverted columns, which are
-	// always inacessible.
-	if kind != WriteOnly && kind != DeleteOnly && kind != VirtualInverted {
+	// Omit the visibility for mutation and artificial inverted columns, which
+	// are always inaccessible.
+	if kind != WriteOnly && kind != DeleteOnly && kind != ArtificialInverted {
 		switch col.Visibility() {
 		case Hidden:
 			fmt.Fprintf(buf, " [hidden]")
@@ -353,8 +353,8 @@ func formatColumn(col *Column, buf *bytes.Buffer) {
 	case System:
 		fmt.Fprintf(buf, " [system]")
 
-	case VirtualInverted:
-		fmt.Fprintf(buf, " [virtual-inverted]")
+	case ArtificialInverted:
+		fmt.Fprintf(buf, " [artificial-inverted]")
 	}
 }
 

--- a/pkg/sql/opt/invertedidx/geo.go
+++ b/pkg/sql/opt/invertedidx/geo.go
@@ -468,7 +468,7 @@ func extractInfoFromExpr(
 	if !ok {
 		return 0, nil, nil, nil, false
 	}
-	if arg2.Col != tabID.ColumnID(index.VirtualInvertedColumn().InvertedSourceColumnOrdinal()) {
+	if arg2.Col != tabID.ColumnID(index.ArtificialInvertedColumn().InvertedSourceColumnOrdinal()) {
 		// The column in the function does not match the index column.
 		return 0, nil, nil, nil, false
 	}

--- a/pkg/sql/opt/invertedidx/inverted_index_expr.go
+++ b/pkg/sql/opt/invertedidx/inverted_index_expr.go
@@ -116,7 +116,7 @@ func TryFilterInvertedIndex(
 			index:           index,
 			computedColumns: computedColumns,
 		}
-		col := index.VirtualInvertedColumn().InvertedSourceColumnOrdinal()
+		col := index.ArtificialInvertedColumn().InvertedSourceColumnOrdinal()
 		typ = factory.Metadata().Table(tabID).Column(col).DatumType()
 	}
 
@@ -509,7 +509,7 @@ func extractInvertedFilterCondition(
 func isIndexColumn(
 	tabID opt.TableID, index cat.Index, e opt.Expr, computedColumns map[opt.ColumnID]opt.ScalarExpr,
 ) bool {
-	invertedSourceCol := tabID.ColumnID(index.VirtualInvertedColumn().InvertedSourceColumnOrdinal())
+	invertedSourceCol := tabID.ColumnID(index.ArtificialInvertedColumn().InvertedSourceColumnOrdinal())
 	if v, ok := e.(*memo.VariableExpr); ok && v.Col == invertedSourceCol {
 		return true
 	}

--- a/pkg/sql/opt/memo/check_expr.go
+++ b/pkg/sql/opt/memo/check_expr.go
@@ -260,8 +260,8 @@ func (m *Memo) CheckExpr(e opt.Expr) {
 				switch kind {
 				case cat.System:
 					panic(errors.AssertionFailedf("system column found in insertion columns"))
-				case cat.VirtualInverted:
-					panic(errors.AssertionFailedf("virtual inverted column found in insertion columns"))
+				case cat.ArtificialInverted:
+					panic(errors.AssertionFailedf("artificial inverted column found in insertion columns"))
 				}
 			}
 		}

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -511,22 +511,22 @@ func (sb *statisticsBuilder) makeTableStatistics(tabID opt.TableID) *props.Stati
 
 	tab := sb.md.Table(tabID)
 
-	// Create a mapping from table column ordinals to inverted index virtual column
-	// ordinals. This allows us to do a fast lookup while iterating over all stats
-	// from a statistic's column to any associated virtual columns. We don't merely
-	// loop over all table columns looking for virtual columns here because other
-	// things may one day use virtual columns and we want these to be explicitly
-	// tied to inverted indexes.
-	invIndexVirtualCols := make(map[int][]int)
+	// Create a mapping from table column ordinals to inverted index artificial
+	// column ordinals. This allows us to do a fast lookup while iterating over
+	// all stats from a statistic's column to any associated artificial columns.
+	// We don't merely loop over all table columns looking for artificial
+	// columns here because other things may one day use artificial columns and
+	// we want these to be explicitly tied to inverted indexes.
+	invIndexArtificialCols := make(map[int][]int)
 	for indexI, indexN := 0, tab.IndexCount(); indexI < indexN; indexI++ {
 		index := tab.Index(indexI)
 		if !index.IsInverted() {
 			continue
 		}
-		// The inverted column of an inverted index is virtual.
-		col := index.VirtualInvertedColumn()
+		// The inverted column of an inverted index is artificial.
+		col := index.ArtificialInvertedColumn()
 		srcOrd := col.InvertedSourceColumnOrdinal()
-		invIndexVirtualCols[srcOrd] = append(invIndexVirtualCols[srcOrd], col.Ordinal())
+		invIndexArtificialCols[srcOrd] = append(invIndexArtificialCols[srcOrd], col.Ordinal())
 	}
 
 	// Make now and annotate the metadata table with it for next time.
@@ -568,13 +568,13 @@ func (sb *statisticsBuilder) makeTableStatistics(tabID opt.TableID) *props.Stati
 					// If this column is invertable, the histogram describes the inverted index
 					// entries, and we need to create a new stat for it, and not apply a histogram
 					// to the source column.
-					virtualColOrds := invIndexVirtualCols[stat.ColumnOrdinal(0)]
-					if len(virtualColOrds) == 0 {
+					artificialColOrds := invIndexArtificialCols[stat.ColumnOrdinal(0)]
+					if len(artificialColOrds) == 0 {
 						colStat.Histogram = &props.Histogram{}
 						colStat.Histogram.Init(sb.evalCtx, col, stat.Histogram())
 					} else {
-						for _, virtualColOrd := range virtualColOrds {
-							invCol := tabID.ColumnID(virtualColOrd)
+						for _, artificialColOrd := range artificialColOrds {
+							invCol := tabID.ColumnID(artificialColOrd)
 							invCols := opt.MakeColSet(invCol)
 							if invColStat, ok := stats.ColStats.Add(invCols); ok {
 								invColStat.Histogram = &props.Histogram{}
@@ -735,10 +735,10 @@ func (sb *statisticsBuilder) constrainScan(
 	// Calculate distinct counts and histograms for inverted constrained columns
 	// -------------------------------------------------------------------------
 	if scan.InvertedConstraint != nil {
-		// The constrained column is the virtual inverted column in the inverted
-		// index. Using scan.Cols here would also include the PK, which we don't
-		// want.
-		invertedConstrainedCol := scan.Table.ColumnID(idx.VirtualInvertedColumn().Ordinal())
+		// The constrained column is the artificial inverted column in the
+		// inverted index. Using scan.Cols here would also include the PK, which
+		// we don't want.
+		invertedConstrainedCol := scan.Table.ColumnID(idx.ArtificialInvertedColumn().Ordinal())
 		constrainedCols.Add(invertedConstrainedCol)
 		if sb.shouldUseHistogram(relProps) {
 			// TODO(mjibson): set distinctCount to something correct. Max is

--- a/pkg/sql/opt/metadata_test.go
+++ b/pkg/sql/opt/metadata_test.go
@@ -238,7 +238,7 @@ func TestMetadataTables(t *testing.T) {
 
 	mkCol := func(ordinal int, name string) cat.Column {
 		var c cat.Column
-		c.InitNonVirtual(
+		c.Init(
 			ordinal,
 			cat.StableID(ordinal+1),
 			tree.Name(name),

--- a/pkg/sql/opt/norm/mutation_funcs.go
+++ b/pkg/sql/opt/norm/mutation_funcs.go
@@ -79,7 +79,7 @@ func (c *CustomFuncs) SimplifiablePartialIndexProjectCols(
 		// are never part of the updated columns. Updates to source columns
 		// trigger index changes.
 		predFilters := *pred.(*memo.FiltersExpr)
-		indexAndPredCols := tabMeta.IndexColumnsMapVirtual(i)
+		indexAndPredCols := tabMeta.IndexColumnsMapArtificial(i)
 		indexAndPredCols.UnionWith(predFilters.OuterCols())
 		if indexAndPredCols.Intersects(updateCols) {
 			continue

--- a/pkg/sql/opt/norm/prune_cols_funcs.go
+++ b/pkg/sql/opt/norm/prune_cols_funcs.go
@@ -175,7 +175,7 @@ func (c *CustomFuncs) NeededMutationFetchCols(
 			// columns have been mapped to their source columns. Virtual columns
 			// are never part of the updated columns. Updates to source columns
 			// trigger index changes.
-			indexCols := tabMeta.IndexColumnsMapVirtual(i)
+			indexCols := tabMeta.IndexColumnsMapArtificial(i)
 			pred, isPartialIndex := tabMeta.PartialIndexPredicate(i)
 			indexAndPredCols := indexCols.Copy()
 			if isPartialIndex {
@@ -188,7 +188,7 @@ func (c *CustomFuncs) NeededMutationFetchCols(
 
 			// Always add index strict key columns, since these are needed to fetch
 			// existing rows from the store.
-			keyCols := tabMeta.IndexKeyColumnsMapVirtual(i)
+			keyCols := tabMeta.IndexKeyColumnsMapArtificial(i)
 			cols.UnionWith(keyCols)
 
 			// Add all columns in any family that includes an update column.
@@ -228,7 +228,7 @@ func (c *CustomFuncs) NeededMutationFetchCols(
 		// it is necessary to delete rows even from indexes that are being added
 		// or dropped.
 		for i, n := 0, tabMeta.Table.DeletableIndexCount(); i < n; i++ {
-			cols.UnionWith(tabMeta.IndexKeyColumnsMapVirtual(i))
+			cols.UnionWith(tabMeta.IndexKeyColumnsMapArtificial(i))
 		}
 
 		// Add inbound foreign keys that may require a check or cascade.

--- a/pkg/sql/opt/optbuilder/fk_cascade.go
+++ b/pkg/sql/opt/optbuilder/fk_cascade.go
@@ -283,10 +283,10 @@ func (cb *onDeleteFastCascadeBuilder) Build(
 		mb.fetchScope = b.buildScan(
 			b.addTable(cb.childTable, &mb.alias),
 			tableOrdinals(cb.childTable, columnKinds{
-				includeMutations:       false,
-				includeSystem:          false,
-				includeVirtualInverted: false,
-				includeVirtualComputed: false,
+				includeMutations:          false,
+				includeSystem:             false,
+				includeArtificialInverted: false,
+				includeVirtualComputed:    false,
 			}),
 			nil, /* indexFlags */
 			noRowLocking,
@@ -512,10 +512,10 @@ func (b *Builder) buildDeleteCascadeMutationInput(
 	outScope = b.buildScan(
 		b.addTable(childTable, childTableAlias),
 		tableOrdinals(childTable, columnKinds{
-			includeMutations:       false,
-			includeSystem:          false,
-			includeVirtualInverted: false,
-			includeVirtualComputed: fetchVirtualComputedCols,
+			includeMutations:          false,
+			includeSystem:             false,
+			includeArtificialInverted: false,
+			includeVirtualComputed:    fetchVirtualComputedCols,
 		}),
 		nil, /* indexFlags */
 		noRowLocking,
@@ -756,10 +756,10 @@ func (b *Builder) buildUpdateCascadeMutationInput(
 	outScope = b.buildScan(
 		b.addTable(childTable, childTableAlias),
 		tableOrdinals(childTable, columnKinds{
-			includeMutations:       false,
-			includeSystem:          false,
-			includeVirtualInverted: false,
-			includeVirtualComputed: true,
+			includeMutations:          false,
+			includeSystem:             false,
+			includeArtificialInverted: false,
+			includeVirtualComputed:    true,
 		}),
 		nil, /* indexFlags */
 		noRowLocking,

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -378,8 +378,8 @@ func (mb *mutationBuilder) needExistingRows() bool {
 			// #1: Don't consider key columns.
 			continue
 		}
-		if kind := mb.tab.Column(i).Kind(); kind == cat.System || kind == cat.VirtualInverted {
-			// #2: Don't consider system or virtual inverted columns.
+		if kind := mb.tab.Column(i).Kind(); kind == cat.System || kind == cat.ArtificialInverted {
+			// #2: Don't consider system or artificial inverted columns.
 			continue
 		}
 		insertColID := mb.insertColIDs[i]

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -278,10 +278,10 @@ func (mb *mutationBuilder) buildInputForUpdate(
 	mb.fetchScope = mb.b.buildScan(
 		mb.b.addTable(mb.tab, &mb.alias),
 		tableOrdinals(mb.tab, columnKinds{
-			includeMutations:       true,
-			includeSystem:          true,
-			includeVirtualInverted: false,
-			includeVirtualComputed: true,
+			includeMutations:          true,
+			includeSystem:             true,
+			includeArtificialInverted: false,
+			includeVirtualComputed:    true,
 		}),
 		indexFlags,
 		noRowLocking,
@@ -394,10 +394,10 @@ func (mb *mutationBuilder) buildInputForDelete(
 	mb.fetchScope = mb.b.buildScan(
 		mb.b.addTable(mb.tab, &mb.alias),
 		tableOrdinals(mb.tab, columnKinds{
-			includeMutations:       true,
-			includeSystem:          true,
-			includeVirtualInverted: false,
-			includeVirtualComputed: true,
+			includeMutations:          true,
+			includeSystem:             true,
+			includeArtificialInverted: false,
+			includeVirtualComputed:    true,
 		}),
 		indexFlags,
 		noRowLocking,

--- a/pkg/sql/opt/optbuilder/mutation_builder_arbiter.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder_arbiter.go
@@ -206,10 +206,10 @@ func (mb *mutationBuilder) buildAntiJoinForDoNothingArbiter(
 	fetchScope := mb.b.buildScan(
 		mb.b.addTable(mb.tab, &mb.alias),
 		tableOrdinals(mb.tab, columnKinds{
-			includeMutations:       false,
-			includeSystem:          false,
-			includeVirtualInverted: false,
-			includeVirtualComputed: true,
+			includeMutations:          false,
+			includeSystem:             false,
+			includeArtificialInverted: false,
+			includeVirtualComputed:    true,
 		}),
 		nil, /* indexFlags */
 		noRowLocking,
@@ -292,10 +292,10 @@ func (mb *mutationBuilder) buildLeftJoinForUpsertArbiter(
 	mb.fetchScope = mb.b.buildScan(
 		mb.b.addTable(mb.tab, &mb.alias),
 		tableOrdinals(mb.tab, columnKinds{
-			includeMutations:       true,
-			includeSystem:          true,
-			includeVirtualInverted: false,
-			includeVirtualComputed: true,
+			includeMutations:          true,
+			includeSystem:             true,
+			includeArtificialInverted: false,
+			includeVirtualComputed:    true,
 		}),
 		nil, /* indexFlags */
 		noRowLocking,
@@ -500,10 +500,10 @@ func (h *arbiterPredicateHelper) tableScope() *scope {
 	if h.tableScopeLazy == nil {
 		h.tableScopeLazy = h.mb.b.buildScan(
 			h.tabMeta, tableOrdinals(h.tabMeta.Table, columnKinds{
-				includeMutations:       false,
-				includeSystem:          false,
-				includeVirtualInverted: false,
-				includeVirtualComputed: true,
+				includeMutations:          false,
+				includeSystem:             false,
+				includeArtificialInverted: false,
+				includeVirtualComputed:    true,
 			}),
 			nil, /* indexFlags */
 			noRowLocking,

--- a/pkg/sql/opt/optbuilder/mutation_builder_unique.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder_unique.go
@@ -398,10 +398,10 @@ func (h *uniqueCheckHelper) buildInsertionCheck() memo.UniqueChecksItem {
 func (h *uniqueCheckHelper) buildTableScan() (outScope *scope, ordinals []int) {
 	tabMeta := h.mb.b.addTable(h.mb.tab, tree.NewUnqualifiedTableName(h.mb.tab.Name()))
 	ordinals = tableOrdinals(tabMeta.Table, columnKinds{
-		includeMutations:       false,
-		includeSystem:          false,
-		includeVirtualInverted: false,
-		includeVirtualComputed: true,
+		includeMutations:          false,
+		includeSystem:             false,
+		includeArtificialInverted: false,
+		includeVirtualComputed:    true,
 	})
 	return h.mb.b.buildScan(
 		tabMeta,

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -114,10 +114,10 @@ func (b *Builder) buildDataSource(
 			return b.buildScan(
 				tabMeta,
 				tableOrdinals(t, columnKinds{
-					includeMutations:       false,
-					includeSystem:          true,
-					includeVirtualInverted: false,
-					includeVirtualComputed: true,
+					includeMutations:          false,
+					includeSystem:             true,
+					includeArtificialInverted: false,
+					includeVirtualComputed:    true,
 				}),
 				indexFlags, locking, inScope,
 			)
@@ -398,10 +398,10 @@ func (b *Builder) buildScanFromTableRef(
 		ordinals = resolveNumericColumnRefs(tab, ref.Columns)
 	} else {
 		ordinals = tableOrdinals(tab, columnKinds{
-			includeMutations:       false,
-			includeSystem:          true,
-			includeVirtualInverted: false,
-			includeVirtualComputed: true,
+			includeMutations:          false,
+			includeSystem:             true,
+			includeArtificialInverted: false,
+			includeVirtualComputed:    true,
 		})
 	}
 

--- a/pkg/sql/opt/optbuilder/testdata/inverted-indexes
+++ b/pkg/sql/opt/optbuilder/testdata/inverted-indexes
@@ -26,11 +26,11 @@ TABLE kj
  ├── j jsonb
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── tableoid oid [hidden] [system]
- ├── j_inverted_key jsonb not null [virtual-inverted]
+ ├── j_inverted_key jsonb not null [artificial-inverted]
  ├── PRIMARY INDEX primary
  │    └── k int not null
  └── INVERTED INDEX secondary
-      ├── j_inverted_key jsonb not null [virtual-inverted]
+      ├── j_inverted_key jsonb not null [artificial-inverted]
       └── k int not null
 
 build

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -673,8 +673,8 @@ type columnKinds struct {
 	// If true, include system columns.
 	includeSystem bool
 
-	// If true, include virtual inverted index columns.
-	includeVirtualInverted bool
+	// If true, include artificial inverted index columns.
+	includeArtificialInverted bool
 
 	// If true, include virtual computed columns.
 	includeVirtualComputed bool
@@ -685,11 +685,11 @@ type columnKinds struct {
 func tableOrdinals(tab cat.Table, k columnKinds) []int {
 	n := tab.ColumnCount()
 	shouldInclude := [...]bool{
-		cat.Ordinary:        true,
-		cat.WriteOnly:       k.includeMutations,
-		cat.DeleteOnly:      k.includeMutations,
-		cat.System:          k.includeSystem,
-		cat.VirtualInverted: k.includeVirtualInverted,
+		cat.Ordinary:           true,
+		cat.WriteOnly:          k.includeMutations,
+		cat.DeleteOnly:         k.includeMutations,
+		cat.System:             k.includeSystem,
+		cat.ArtificialInverted: k.includeArtificialInverted,
 	}
 	ordinals := make([]int, 0, n)
 	for i := 0; i < n; i++ {

--- a/pkg/sql/opt/table_meta.go
+++ b/pkg/sql/opt/table_meta.go
@@ -217,16 +217,16 @@ func (tm *TableMeta) IndexColumns(indexOrd int) ColSet {
 	return indexCols
 }
 
-// IndexColumnsMapVirtual returns the set of table columns in the given index.
-// Virtual inverted index columns are mapped to their source column.
-func (tm *TableMeta) IndexColumnsMapVirtual(indexOrd int) ColSet {
+// IndexColumnsMapArtificial returns the set of table columns in the given
+// index. Artificial inverted index columns are mapped to their source column.
+func (tm *TableMeta) IndexColumnsMapArtificial(indexOrd int) ColSet {
 	index := tm.Table.Index(indexOrd)
 
 	var indexCols ColSet
 	for i, n := 0, index.ColumnCount(); i < n; i++ {
 		col := index.Column(i)
 		ord := col.Ordinal()
-		if col.Kind() == cat.VirtualInverted {
+		if col.Kind() == cat.ArtificialInverted {
 			ord = col.InvertedSourceColumnOrdinal()
 		}
 		indexCols.Add(tm.MetaID.ColumnID(ord))
@@ -246,16 +246,17 @@ func (tm *TableMeta) IndexKeyColumns(indexOrd int) ColSet {
 	return indexCols
 }
 
-// IndexKeyColumnsMapVirtual returns the set of strict key columns in the given
-// index. Inverted index columns are mapped to their source column.
-func (tm *TableMeta) IndexKeyColumnsMapVirtual(indexOrd int) ColSet {
+// IndexKeyColumnsMapArtificial returns the set of strict key columns in the
+// given index. Artificial inverted index columns are mapped to their source
+// column.
+func (tm *TableMeta) IndexKeyColumnsMapArtificial(indexOrd int) ColSet {
 	index := tm.Table.Index(indexOrd)
 
 	var indexCols ColSet
 	for i, n := 0, index.KeyColumnCount(); i < n; i++ {
 		col := index.Column(i)
 		ord := col.Ordinal()
-		if col.Kind() == cat.VirtualInverted {
+		if col.Kind() == cat.ArtificialInverted {
 			ord = col.InvertedSourceColumnOrdinal()
 		}
 		indexCols.Add(tm.MetaID.ColumnID(ord))

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -1832,7 +1832,7 @@ func (ot *OptTester) createTableAs(name tree.TableName, rel memo.RelExpr) (*test
 		colMeta := rel.Memo().Metadata().ColumnMeta(col)
 		colName := colNameGen.GenerateName(col)
 
-		columns[i].InitNonVirtual(
+		columns[i].Init(
 			i,
 			cat.StableID(i+1),
 			tree.Name(colName),

--- a/pkg/sql/opt/testutils/testcat/create_table.go
+++ b/pkg/sql/opt/testutils/testcat/create_table.go
@@ -115,7 +115,7 @@ func (tc *Catalog) CreateTable(stmt *tree.CreateTable) *Table {
 	if !hasPrimaryIndex {
 		var rowid cat.Column
 		ordinal := len(tab.Columns)
-		rowid.InitNonVirtual(
+		rowid.Init(
 			ordinal,
 			cat.StableID(1+ordinal),
 			"rowid",
@@ -142,7 +142,7 @@ func (tc *Catalog) CreateTable(stmt *tree.CreateTable) *Table {
 	// Add the MVCC timestamp system column.
 	var mvcc cat.Column
 	ordinal := len(tab.Columns)
-	mvcc.InitNonVirtual(
+	mvcc.Init(
 		ordinal,
 		cat.StableID(1+ordinal),
 		colinfo.MVCCTimestampColumnName,
@@ -158,7 +158,7 @@ func (tc *Catalog) CreateTable(stmt *tree.CreateTable) *Table {
 	// Add the tableoid system column.
 	var tableoid cat.Column
 	ordinal = len(tab.Columns)
-	tableoid.InitNonVirtual(
+	tableoid.Init(
 		ordinal,
 		cat.StableID(1+ordinal),
 		colinfo.TableOIDColumnName,
@@ -290,7 +290,7 @@ func (tc *Catalog) createVirtualTable(stmt *tree.CreateTable) *Table {
 
 	// Add the dummy PK column.
 	var pk cat.Column
-	pk.InitNonVirtual(
+	pk.Init(
 		0, /* ordinal */
 		0, /* stableID */
 		"crdb_internal_vtable_pk",
@@ -346,7 +346,7 @@ func (tc *Catalog) CreateTableAs(name tree.TableName, columns []cat.Column) *Tab
 
 	var rowid cat.Column
 	ordinal := len(columns)
-	rowid.InitNonVirtual(
+	rowid.Init(
 		ordinal,
 		cat.StableID(1+ordinal),
 		"rowid",
@@ -605,7 +605,7 @@ func (tt *Table) addColumn(def *tree.ColumnTableDef) {
 			*computedExpr,
 		)
 	} else {
-		col.InitNonVirtual(
+		col.Init(
 			ordinal,
 			cat.StableID(1+ordinal),
 			name,
@@ -742,7 +742,7 @@ func (tt *Table) addIndexWithVersion(
 		}
 		// Add the rest of the columns in the table.
 		for i, col := range tt.Columns {
-			if !pkOrdinals.Contains(i) && col.Kind() != cat.VirtualInverted && !col.IsVirtualComputed() {
+			if !pkOrdinals.Contains(i) && col.Kind() != cat.ArtificialInverted && !col.IsVirtualComputed() {
 				idx.addColumnByOrdinal(tt, i, tree.Ascending, nonKeyCol)
 			}
 		}
@@ -921,7 +921,7 @@ func (ti *Index) addColumn(
 		// TODO(radu,mjibson): update this when the corresponding type in the real
 		// catalog is fixed (see sql.newOptTable).
 		typ := tt.Columns[ordinal].DatumType()
-		col.InitVirtualInverted(
+		col.InitArtificialInverted(
 			len(tt.Columns),
 			colName+"_inverted_key",
 			typ,
@@ -975,7 +975,7 @@ func (ti *Index) addColumnByOrdinal(
 	col := tt.Column(ord)
 	if colType == keyCol || colType == strictKeyCol {
 		typ := col.DatumType()
-		if col.Kind() == cat.VirtualInverted {
+		if col.Kind() == cat.ArtificialInverted {
 			if !colinfo.ColumnTypeIsInvertedIndexable(typ) {
 				panic(fmt.Errorf(
 					"column %s of type %s is not allowed as the last column of an inverted index",

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -841,7 +841,7 @@ type Index struct {
 	// predicate is the partial index predicate expression, if it exists.
 	predicate string
 
-	// invertedOrd is the ordinal of the VirtualInverted column, if the index is
+	// invertedOrd is the ordinal of the ArtificialInverted column, if the index is
 	// an inverted index.
 	invertedOrd int
 
@@ -911,10 +911,10 @@ func (ti *Index) Column(i int) cat.IndexColumn {
 	return ti.Columns[i]
 }
 
-// VirtualInvertedColumn is part of the cat.Index interface.
-func (ti *Index) VirtualInvertedColumn() cat.IndexColumn {
+// ArtificialInvertedColumn is part of the cat.Index interface.
+func (ti *Index) ArtificialInvertedColumn() cat.IndexColumn {
 	if !ti.IsInverted() {
-		panic("non-inverted indexes do not have inverted virtual columns")
+		panic("non-inverted indexes do not have artificial inverted columns")
 	}
 	return ti.Column(ti.invertedOrd)
 }

--- a/pkg/sql/opt/testutils/testcat/testdata/index
+++ b/pkg/sql/opt/testutils/testcat/testdata/index
@@ -83,18 +83,18 @@ TABLE g
  ├── geog geography
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── tableoid oid [hidden] [system]
- ├── geog_inverted_key geography not null [virtual-inverted]
- ├── geog_inverted_key geography not null [virtual-inverted]
+ ├── geog_inverted_key geography not null [artificial-inverted]
+ ├── geog_inverted_key geography not null [artificial-inverted]
  ├── PRIMARY INDEX primary
  │    └── k int not null
  ├── INVERTED INDEX secondary
  │    ├── a int
- │    ├── geog_inverted_key geography not null [virtual-inverted]
+ │    ├── geog_inverted_key geography not null [artificial-inverted]
  │    └── k int not null
  └── INVERTED INDEX secondary
       ├── a int
       ├── b int
-      ├── geog_inverted_key geography not null [virtual-inverted]
+      ├── geog_inverted_key geography not null [artificial-inverted]
       └── k int not null
 
 # Test for expression index columns.
@@ -135,13 +135,13 @@ TABLE xyz
  ├── crdb_internal_idx_expr_3 int as (y + 1) virtual [hidden]
  ├── crdb_internal_idx_expr_4 string as (lower(z)) virtual [hidden]
  ├── crdb_internal_idx_expr_5 jsonb as (j->'a') virtual [hidden]
- ├── crdb_internal_idx_expr_5_inverted_key jsonb not null [virtual-inverted]
+ ├── crdb_internal_idx_expr_5_inverted_key jsonb not null [artificial-inverted]
  ├── crdb_internal_idx_expr_6 jsonb as (j->'a') virtual [hidden]
- ├── crdb_internal_idx_expr_6_inverted_key jsonb not null [virtual-inverted]
+ ├── crdb_internal_idx_expr_6_inverted_key jsonb not null [artificial-inverted]
  ├── crdb_internal_idx_expr_7 int as (x + y) virtual [hidden]
  ├── crdb_internal_idx_expr_8 int as (x + y) virtual [hidden]
  ├── crdb_internal_idx_expr_9 jsonb as (j->'a') virtual [hidden]
- ├── crdb_internal_idx_expr_9_inverted_key jsonb not null [virtual-inverted]
+ ├── crdb_internal_idx_expr_9_inverted_key jsonb not null [artificial-inverted]
  ├── PRIMARY INDEX primary
  │    └── x int not null
  ├── INDEX idx1
@@ -156,12 +156,12 @@ TABLE xyz
  │    ├── crdb_internal_idx_expr_4 string as (lower(z)) virtual [hidden]
  │    └── x int not null
  ├── INVERTED INDEX idx4
- │    ├── crdb_internal_idx_expr_5_inverted_key jsonb not null [virtual-inverted]
+ │    ├── crdb_internal_idx_expr_5_inverted_key jsonb not null [artificial-inverted]
  │    └── x int not null
  ├── INVERTED INDEX idx5
  │    ├── y int
  │    ├── z string
- │    ├── crdb_internal_idx_expr_6_inverted_key jsonb not null [virtual-inverted]
+ │    ├── crdb_internal_idx_expr_6_inverted_key jsonb not null [artificial-inverted]
  │    └── x int not null
  ├── INDEX idx6
  │    ├── crdb_internal_idx_expr_7 int as (x + y) virtual [hidden]
@@ -171,6 +171,6 @@ TABLE xyz
  │    └── WHERE v > 1
  └── INVERTED INDEX idx7
       ├── crdb_internal_idx_expr_8 int as (x + y) virtual [hidden]
-      ├── crdb_internal_idx_expr_9_inverted_key jsonb not null [virtual-inverted]
+      ├── crdb_internal_idx_expr_9_inverted_key jsonb not null [artificial-inverted]
       ├── x int not null
       └── WHERE v > 1

--- a/pkg/sql/opt/testutils/testcat/testdata/table
+++ b/pkg/sql/opt/testutils/testcat/testdata/table
@@ -202,15 +202,15 @@ TABLE inv
  ├── g geometry
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── tableoid oid [hidden] [system]
- ├── j_inverted_key jsonb not null [virtual-inverted]
- ├── g_inverted_key geometry not null [virtual-inverted]
+ ├── j_inverted_key jsonb not null [artificial-inverted]
+ ├── g_inverted_key geometry not null [artificial-inverted]
  ├── PRIMARY INDEX primary
  │    └── k int not null
  ├── INVERTED INDEX secondary
- │    ├── j_inverted_key jsonb not null [virtual-inverted]
+ │    ├── j_inverted_key jsonb not null [artificial-inverted]
  │    └── k int not null
  └── INVERTED INDEX secondary
-      ├── g_inverted_key geometry not null [virtual-inverted]
+      ├── g_inverted_key geometry not null [artificial-inverted]
       └── k int not null
 
 # Table with inverted indexes and implicit primary index.
@@ -234,15 +234,15 @@ TABLE inv2
  ├── rowid int not null default (unique_rowid()) [hidden]
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── tableoid oid [hidden] [system]
- ├── j_inverted_key jsonb not null [virtual-inverted]
- ├── g_inverted_key geometry not null [virtual-inverted]
+ ├── j_inverted_key jsonb not null [artificial-inverted]
+ ├── g_inverted_key geometry not null [artificial-inverted]
  ├── PRIMARY INDEX primary
  │    └── rowid int not null default (unique_rowid()) [hidden]
  ├── INVERTED INDEX secondary
- │    ├── j_inverted_key jsonb not null [virtual-inverted]
+ │    ├── j_inverted_key jsonb not null [artificial-inverted]
  │    └── rowid int not null default (unique_rowid()) [hidden]
  └── INVERTED INDEX secondary
-      ├── g_inverted_key geometry not null [virtual-inverted]
+      ├── g_inverted_key geometry not null [artificial-inverted]
       └── rowid int not null default (unique_rowid()) [hidden]
 
 # Table with unique constraints.

--- a/pkg/sql/opt/xform/join_funcs.go
+++ b/pkg/sql/opt/xform/join_funcs.go
@@ -925,7 +925,7 @@ func (c *CustomFuncs) mapInvertedJoin(
 	// columns, which will be used in the invertedExpr.
 	srcCols := indexCols.Copy()
 	dstCols := newIndexCols.Copy()
-	ord := index.VirtualInvertedColumn().InvertedSourceColumnOrdinal()
+	ord := index.ArtificialInvertedColumn().InvertedSourceColumnOrdinal()
 	invertedSourceCol := tabID.ColumnID(ord)
 	newInvertedSourceCol := newTabID.ColumnID(ord)
 	srcCols.Add(invertedSourceCol)

--- a/pkg/sql/opt/xform/select_funcs.go
+++ b/pkg/sql/opt/xform/select_funcs.go
@@ -792,7 +792,7 @@ func (c *CustomFuncs) GenerateInvertedIndexScans(
 		newScanPrivate.Cols = pkCols.Copy()
 		var invertedCol opt.ColumnID
 		if needInvertedFilter {
-			invertedCol = scanPrivate.Table.ColumnID(index.VirtualInvertedColumn().Ordinal())
+			invertedCol = scanPrivate.Table.ColumnID(index.ArtificialInvertedColumn().Ordinal())
 			newScanPrivate.Cols.Add(invertedCol)
 		}
 
@@ -1386,7 +1386,7 @@ func (c *CustomFuncs) GenerateInvertedIndexZigzagJoins(
 		leftTypes[invertedColIdx] = leftVal.ResolvedType()
 		rightVals[invertedColIdx] = c.e.f.ConstructConstVal(&rightVal, rightVal.ResolvedType())
 		rightTypes[invertedColIdx] = rightVal.ResolvedType()
-		invertedCol := scanPrivate.Table.ColumnID(index.VirtualInvertedColumn().Ordinal())
+		invertedCol := scanPrivate.Table.ColumnID(index.ArtificialInvertedColumn().Ordinal())
 		zigzagJoin.LeftFixedCols[invertedColIdx] = invertedCol
 		zigzagJoin.RightFixedCols[invertedColIdx] = invertedCol
 
@@ -1632,7 +1632,7 @@ func (c *CustomFuncs) canMaybeConstrainIndexWithCols(
 		for j, n := 0, index.KeyColumnCount(); j < n; j++ {
 			col := index.Column(j)
 			ord := col.Ordinal()
-			if col.Kind() == cat.VirtualInverted {
+			if col.Kind() == cat.ArtificialInverted {
 				ord = col.InvertedSourceColumnOrdinal()
 			}
 			if cols.Contains(tabMeta.MetaID.ColumnID(ord)) {

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -591,7 +591,7 @@ type optTable struct {
 	// columns contains all the columns presented to the catalog. This includes:
 	//  - ordinary table columns (those in the table descriptor)
 	//  - MVCC timestamp system column
-	//  - virtual columns (for inverted indexes).
+	//  - artificial columns (for inverted indexes).
 	// They are stored in this order, though we shouldn't rely on that anywhere.
 	columns []cat.Column
 
@@ -655,7 +655,7 @@ func newOptTable(
 	// First, determine how many columns we will potentially need.
 	cols := ot.desc.DeletableColumns()
 	numCols := len(ot.desc.AllColumns())
-	// One for each inverted index virtual column.
+	// Add one for each inverted index artificial column.
 	secondaryIndexes := ot.desc.DeletableNonPrimaryIndexes()
 	for _, index := range secondaryIndexes {
 		if index.GetType() == descpb.IndexDescriptor_INVERTED {
@@ -683,7 +683,7 @@ func newOptTable(
 			visibility = cat.Inaccessible
 		}
 		if !col.IsVirtual() {
-			ot.columns[col.Ordinal()].InitNonVirtual(
+			ot.columns[col.Ordinal()].Init(
 				col.Ordinal(),
 				cat.StableID(col.GetID()),
 				col.ColName(),
@@ -724,7 +724,7 @@ func newOptTable(
 		found, _ := desc.FindColumnWithName(sysCol.ColName())
 		if found == nil || found.IsSystemColumn() {
 			col, ord := newColumn()
-			col.InitNonVirtual(
+			col.Init(
 				ord,
 				cat.StableID(sysCol.GetID()),
 				sysCol.ColName(),
@@ -795,24 +795,24 @@ func newOptTable(
 			// descriptors, it looks as if the table column is part of the
 			// index; in fact the key contains values *derived* from that
 			// column. In the catalog, we refer to this key as a separate,
-			// virtual column.
+			// artificial column.
 			invertedSourceColOrdinal, _ := ot.lookupColumnOrdinal(idx.GetKeyColumnID(idx.NumKeyColumns() - 1))
 
-			// Add a virtual column that refers to the inverted index key.
-			virtualCol, virtualColOrd := newColumn()
+			// Add a artificial column that refers to the inverted index key.
+			artificialCol, artificialColOrd := newColumn()
 
-			// All virtual inverted columns have type bytes.
+			// All artificial inverted columns have type bytes.
 			typ := types.Bytes
-			virtualCol.InitVirtualInverted(
-				virtualColOrd,
+			artificialCol.InitArtificialInverted(
+				artificialColOrd,
 				tree.Name(string(ot.Column(invertedSourceColOrdinal).ColName())+"_inverted_key"),
 				typ,
 				false, /* nullable */
 				invertedSourceColOrdinal,
 			)
-			ot.indexes[i].init(ot, i, idx, idxZone, partZones, virtualColOrd)
+			ot.indexes[i].init(ot, i, idx, idxZone, partZones, artificialColOrd)
 		} else {
-			ot.indexes[i].init(ot, i, idx, idxZone, partZones, -1 /* virtualColOrd */)
+			ot.indexes[i].init(ot, i, idx, idxZone, partZones, -1 /* invertedArtificialColOrd */)
 		}
 
 		// Add unique constraints for implicitly partitioned unique indexes.
@@ -1161,10 +1161,10 @@ type optIndex struct {
 	// partitions.
 	partitions []optPartition
 
-	// invertedVirtualColOrd is used if this is an inverted index; it stores the
-	// ordinal of the virtual column created to refer to the key of this index.
-	// It is -1 if this is not an inverted index.
-	invertedVirtualColOrd int
+	// invertedArtificalColOrd is used if this is an inverted index; it stores
+	// the ordinal of the artificial column created to refer to the key of this
+	// index. It is -1 if this is not an inverted index.
+	invertedArtificalColOrd int
 }
 
 var _ cat.Index = &optIndex{}
@@ -1177,13 +1177,13 @@ func (oi *optIndex) init(
 	idx catalog.Index,
 	zone *zonepb.ZoneConfig,
 	partZones map[string]*zonepb.ZoneConfig,
-	invertedVirtualColOrd int,
+	invertedArtificialColOrd int,
 ) {
 	oi.tab = tab
 	oi.idx = idx
 	oi.zone = zone
 	oi.indexOrdinal = indexOrdinal
-	oi.invertedVirtualColOrd = invertedVirtualColOrd
+	oi.invertedArtificalColOrd = invertedArtificialColOrd
 	if idx.Primary() {
 		// Although the primary index contains all columns in the table, the index
 		// descriptor does not contain columns that are not explicitly part of the
@@ -1195,7 +1195,7 @@ func (oi *optIndex) init(
 			pkCols.Add(int(id))
 		}
 		for i, n := 0, tab.ColumnCount(); i < n; i++ {
-			if col := tab.Column(i); col.Kind() != cat.VirtualInverted && !col.IsVirtualComputed() {
+			if col := tab.Column(i); col.Kind() != cat.ArtificialInverted && !col.IsVirtualComputed() {
 				if id := col.ColID(); !pkCols.Contains(int(id)) {
 					oi.storedCols = append(oi.storedCols, descpb.ColumnID(id))
 				}
@@ -1283,7 +1283,7 @@ func (oi *optIndex) init(
 		var ord int
 		switch {
 		case inverted && i == numKeyCols-1:
-			ord = oi.invertedVirtualColOrd
+			ord = oi.invertedArtificalColOrd
 		case i < numKeyCols:
 			ord, _ = oi.tab.lookupColumnOrdinal(oi.idx.GetKeyColumnID(i))
 		case i < numKeyCols+numKeySuffixCols:
@@ -1349,10 +1349,10 @@ func (oi *optIndex) Column(i int) cat.IndexColumn {
 	}
 }
 
-// VirtualInvertedColumn is part of the cat.Index interface.
-func (oi *optIndex) VirtualInvertedColumn() cat.IndexColumn {
+// ArtificialInvertedColumn is part of the cat.Index interface.
+func (oi *optIndex) ArtificialInvertedColumn() cat.IndexColumn {
 	if !oi.IsInverted() {
-		panic(errors.AssertionFailedf("non-inverted indexes do not have inverted virtual columns"))
+		panic(errors.AssertionFailedf("non-inverted indexes do not have artificial inverted columns"))
 	}
 	ord := oi.idx.NumKeyColumns() - 1
 	return oi.Column(ord)
@@ -1799,7 +1799,7 @@ func newOptVirtualTable(
 
 	ot.columns = make([]cat.Column, len(desc.PublicColumns())+1)
 	// Init dummy PK column.
-	ot.columns[0].InitNonVirtual(
+	ot.columns[0].Init(
 		0,
 		math.MaxInt64, /* stableID */
 		"crdb_internal_vtable_pk",
@@ -1811,7 +1811,7 @@ func newOptVirtualTable(
 		nil,        /* computedExpr */
 	)
 	for i, d := range desc.PublicColumns() {
-		ot.columns[i+1].InitNonVirtual(
+		ot.columns[i+1].Init(
 			i+1,
 			cat.StableID(d.GetID()),
 			tree.Name(d.GetName()),
@@ -1984,7 +1984,7 @@ func (ot *optVirtualTable) OutboundForeignKeyCount() int {
 	return 0
 }
 
-// OutboundForeignKeyCount is part of the cat.Table interface.
+// OutboundForeignKey is part of the cat.Table interface.
 func (ot *optVirtualTable) OutboundForeignKey(i int) cat.ForeignKeyConstraint {
 	panic(errors.AssertionFailedf("no FKs"))
 }
@@ -2124,8 +2124,8 @@ func (oi *optVirtualIndex) Column(i int) cat.IndexColumn {
 	return cat.IndexColumn{Column: oi.tab.Column(ord)}
 }
 
-// VirtualInvertedColumn is part of the cat.Index interface.
-func (oi *optVirtualIndex) VirtualInvertedColumn() cat.IndexColumn {
+// ArtificialInvertedColumn is part of the cat.Index interface.
+func (oi *optVirtualIndex) ArtificialInvertedColumn() cat.IndexColumn {
 	panic(errors.AssertionFailedf("virtual indexes are not inverted"))
 }
 

--- a/pkg/sql/rowexec/inverted_filterer.go
+++ b/pkg/sql/rowexec/inverted_filterer.go
@@ -227,7 +227,7 @@ func (ifr *invertedFilterer) readInput() (invertedFiltererState, *execinfrapb.Pr
 			return ifrStateUnknown, ifr.DrainHelper()
 		}
 		if row[ifr.invertedColIdx].Datum.ResolvedType().Family() != types.BytesFamily {
-			ifr.MoveToDraining(errors.New("virtual inverted column should have type bytes"))
+			ifr.MoveToDraining(errors.New("artificial inverted column should have type bytes"))
 			return ifrStateUnknown, ifr.DrainHelper()
 		}
 		enc = []byte(*row[ifr.invertedColIdx].Datum.(*tree.DBytes))


### PR DESCRIPTION
The term "virtual" is overloaded. It can refer to virtual tables,
virtual indexes, and virtual computed columns. It was also used in
"virtual inverted columns" to describe pseudo-columns containing
inverted index keys, which have values different than the indexed
column. To prevent confusion with virtual computed columns, these
columns are now called "artificial inverted columns".

Release note: None
