### PR TITLE
builtins: introduce with_min_timestamp and with_max_staleness

### DIFF
--- a/docs/RFCS/20210519_bounded_staleness_reads.md
+++ b/docs/RFCS/20210519_bounded_staleness_reads.md
@@ -30,7 +30,7 @@ Bounded staleness queries are limited in use to single-statement read-only
 queries, and only a subset of read-only queries at that. They will be accessed
 similarly to exact bounded staleness reads - through a pair of new functions
 that can be passed to an `AS OF SYSTEM TIME` clause:
-- `SELECT ... FROM ... AS OF SYSTEM TIME with_min_timestamp(TIMESTAMP)`
+- `SELECT ... FROM ... AS OF SYSTEM TIME with_min_timestamp(TIMESTAMPTZ)`
 - `SELECT ... FROM ... AS OF SYSTEM TIME with_max_staleness(INTERVAL)`
 
 The approach discussed in this RFC has a prototype in
@@ -71,10 +71,10 @@ locally without blocking is used.
 
 Bounded staleness reads will be exposed through a pair of new functions that can
 be passed to an `AS OF SYSTEM TIME` clause:
-- `SELECT ... FROM ... AS OF SYSTEM TIME with_min_timestamp(TIMESTAMP)`
+- `SELECT ... FROM ... AS OF SYSTEM TIME with_min_timestamp(TIMESTAMPTZ)`
 - `SELECT ... FROM ... AS OF SYSTEM TIME with_max_staleness(INTERVAL)`
 
-`with_min_timestamp(TIMESTAMP)` defines a minimum timestamp to perform the
+`with_min_timestamp(TIMESTAMPTZ)` defines a minimum timestamp to perform the
 bounded staleness read at. The actual timestamp of the read may be equal to or
 later than the provided timestamp, but can not be before the provided timestamp.
 This is useful to request a read from nearby followers, if possible, while
@@ -452,8 +452,8 @@ read.
 ### SQL Parser
 
 The change will introduce two new SQL builtin functions: 
-- `with_min_timestamp(TIMESTAMP) -> TIMESTAMP`
-- `with_max_staleness(INTERVAL) -> INTERVAL`
+- `with_min_timestamp(TIMESTAMPTZ) -> TIMESTAMPTZ
+- `with_max_staleness(INTERVAL) -> TIMESTAMPTZ`
 
 These functions will need special casing in `tree.EvalAsOfTimestamp`.
 

--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -529,6 +529,16 @@ has no relationship with the commit order of concurrent transactions.</p>
 and which stays constant throughout the transaction. This timestamp
 has no relationship with the commit order of concurrent transactions.</p>
 <p>This function is the preferred overload and will be evaluated by default.</p>
+</span></td></tr>
+<tr><td><a name="with_max_staleness"></a><code>with_max_staleness(max_staleness: <a href="interval.html">interval</a>) &rarr; <a href="timestamp.html">timestamptz</a></code></td><td><span class="funcdesc"><p>When used in the AS OF SYSTEM TIME clause of an single-statement,
+read-only transaction, CockroachDB chooses the newest timestamp within the staleness
+bound that allows execution of the reads at the closest available replica without blocking.</p>
+<p>Note this function requires an enterprise license on a CCL distribution.</p>
+</span></td></tr>
+<tr><td><a name="with_min_timestamp"></a><code>with_min_timestamp(min_timestamp: <a href="timestamp.html">timestamptz</a>) &rarr; <a href="timestamp.html">timestamptz</a></code></td><td><span class="funcdesc"><p>When used in the AS OF SYSTEM TIME clause of an single-statement,
+read-only transaction, CockroachDB chooses the newest timestamp before the min_timestamp
+that allows execution of the reads at the closest available replica without blocking.</p>
+<p>Note this function requires an enterprise license on a CCL distribution.</p>
 </span></td></tr></tbody>
 </table>
 

--- a/pkg/ccl/kvccl/kvfollowerreadsccl/BUILD.bazel
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "kvfollowerreadsccl",
-    srcs = ["followerreads.go"],
+    srcs = [
+        "boundedstaleness.go",
+        "followerreads.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/ccl/kvccl/kvfollowerreadsccl",
     visibility = ["//visibility:public"],
     deps = [
@@ -16,10 +19,15 @@ go_library(
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/sql",
+        "//pkg/sql/pgwire/pgcode",
+        "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/physicalplan/replicaoracle",
         "//pkg/sql/sem/builtins",
+        "//pkg/sql/sem/tree",
+        "//pkg/util/duration",
         "//pkg/util/hlc",
         "//pkg/util/uuid",
+        "@com_github_cockroachdb_errors//:errors",
     ],
 )
 
@@ -27,6 +35,7 @@ go_test(
     name = "kvfollowerreadsccl_test",
     size = "medium",
     srcs = [
+        "boundedstaleness_test.go",
         "followerreads_test.go",
         "main_test.go",
     ],

--- a/pkg/ccl/kvccl/kvfollowerreadsccl/boundedstaleness.go
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/boundedstaleness.go
@@ -1,0 +1,64 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package kvfollowerreadsccl
+
+import (
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/duration"
+)
+
+func checkEnterpriseEnabledForBoundedStaleness(ctx *tree.EvalContext) error {
+	st := ctx.Settings
+	return utilccl.CheckEnterpriseEnabled(
+		st,
+		ctx.ClusterID,
+		sql.ClusterOrganization.Get(&st.SV),
+		"bounded staleness",
+	)
+}
+
+func evalMaxStaleness(ctx *tree.EvalContext, d duration.Duration) (time.Time, error) {
+	if err := checkEnterpriseEnabledForBoundedStaleness(ctx); err != nil {
+		return time.Time{}, err
+	}
+	if d.Compare(duration.FromInt64(0)) < 0 {
+		return time.Time{}, pgerror.Newf(
+			pgcode.InvalidParameterValue,
+			"interval duration for %s must be greater or equal to 0",
+			tree.WithMaxStalenessFunctionName,
+		)
+	}
+	return duration.Add(ctx.GetTxnTimestamp(time.Microsecond).Time, d.Mul(-1)), nil
+}
+
+func evalMinTimestamp(ctx *tree.EvalContext, t time.Time) (time.Time, error) {
+	if err := checkEnterpriseEnabledForBoundedStaleness(ctx); err != nil {
+		return time.Time{}, err
+	}
+	if t.After(ctx.GetTxnTimestamp(time.Microsecond).Time) {
+		return time.Time{}, pgerror.Newf(
+			pgcode.InvalidParameterValue,
+			"timestamp for %s must be less than or equal to now()",
+			tree.WithMinTimestampFunctionName,
+		)
+	}
+	return t, nil
+}
+
+func init() {
+	builtins.WithMinTimestamp = evalMinTimestamp
+	builtins.WithMaxStaleness = evalMaxStaleness
+}

--- a/pkg/ccl/kvccl/kvfollowerreadsccl/boundedstaleness.go
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/boundedstaleness.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
+	"github.com/cockroachdb/errors"
 )
 
 func checkEnterpriseEnabledForBoundedStaleness(ctx *tree.EvalContext) error {
@@ -41,18 +42,24 @@ func evalMaxStaleness(ctx *tree.EvalContext, d duration.Duration) (time.Time, er
 			tree.WithMaxStalenessFunctionName,
 		)
 	}
-	return duration.Add(ctx.GetTxnTimestamp(time.Microsecond).Time, d.Mul(-1)), nil
+	return duration.Add(ctx.GetStmtTimestamp(), d.Mul(-1)), nil
 }
 
 func evalMinTimestamp(ctx *tree.EvalContext, t time.Time) (time.Time, error) {
 	if err := checkEnterpriseEnabledForBoundedStaleness(ctx); err != nil {
 		return time.Time{}, err
 	}
-	if t.After(ctx.GetTxnTimestamp(time.Microsecond).Time) {
-		return time.Time{}, pgerror.Newf(
-			pgcode.InvalidParameterValue,
-			"timestamp for %s must be less than or equal to now()",
-			tree.WithMinTimestampFunctionName,
+	t = t.Round(time.Microsecond)
+	if stmtTimestamp := ctx.GetStmtTimestamp().Round(time.Microsecond); t.After(stmtTimestamp) {
+		return time.Time{}, errors.WithDetailf(
+			pgerror.Newf(
+				pgcode.InvalidParameterValue,
+				"timestamp for %s must be less than or equal to statement_timestamp()",
+				tree.WithMinTimestampFunctionName,
+			),
+			"statement timestamp: %d, min_timestamp: %d",
+			stmtTimestamp.UnixNano(),
+			t.UnixNano(),
 		)
 	}
 	return t, nil

--- a/pkg/ccl/kvccl/kvfollowerreadsccl/boundedstaleness_test.go
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/boundedstaleness_test.go
@@ -1,0 +1,57 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package kvfollowerreadsccl_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBoundedStalenessEnterpriseLicense(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
+	defer tc.Stopper().Stop(ctx)
+
+	queries := []string{
+		`SELECT with_max_staleness('10s')`,
+		`SELECT with_min_timestamp(now())`,
+	}
+
+	defer utilccl.TestingDisableEnterprise()()
+	t.Run("disabled", func(t *testing.T) {
+		for _, q := range queries {
+			t.Run(q, func(t *testing.T) {
+				_, err := tc.Conns[0].QueryContext(ctx, q)
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "use of bounded staleness requires an enterprise license")
+			})
+		}
+	})
+
+	t.Run("enabled", func(t *testing.T) {
+		defer utilccl.TestingEnableEnterprise()()
+		for _, q := range queries {
+			t.Run(q, func(t *testing.T) {
+				r, err := tc.Conns[0].QueryContext(ctx, q)
+				require.NoError(t, err)
+				require.NoError(t, r.Close())
+			})
+		}
+	})
+}

--- a/pkg/ccl/kvccl/kvfollowerreadsccl/boundedstaleness_test.go
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/boundedstaleness_test.go
@@ -30,7 +30,7 @@ func TestBoundedStalenessEnterpriseLicense(t *testing.T) {
 
 	queries := []string{
 		`SELECT with_max_staleness('10s')`,
-		`SELECT with_min_timestamp(now())`,
+		`SELECT with_min_timestamp(statement_timestamp())`,
 	}
 
 	defer utilccl.TestingDisableEnterprise()()

--- a/pkg/ccl/logictestccl/testdata/logic_test/as_of
+++ b/pkg/ccl/logictestccl/testdata/logic_test/as_of
@@ -94,20 +94,20 @@ statement ok
 SET DEFAULT_TRANSACTION_USE_FOLLOWER_READS TO FALSE
 
 query B
-SELECT with_min_timestamp(now()) = now()
+SELECT with_min_timestamp(statement_timestamp()) = statement_timestamp()
 ----
 true
 
 query B
-SELECT with_min_timestamp(now() - '5s'::interval) = now() - '5s'::interval
+SELECT with_min_timestamp(statement_timestamp() - '5s'::interval) = statement_timestamp() - '5s'::interval
 ----
 true
 
-statement error timestamp for with_min_timestamp must be less than or equal to now\(\)
-SELECT with_min_timestamp(now() + '5s'::interval) = now()
+statement error timestamp for with_min_timestamp must be less than or equal to statement_timestamp\(\)
+SELECT with_min_timestamp(statement_timestamp() + '5s'::interval) = statement_timestamp()
 
 query B
-SELECT with_max_staleness('10s') = now() - '10s'::interval
+SELECT with_max_staleness('10s') = statement_timestamp() - '10s'::interval
 ----
 true
 

--- a/pkg/ccl/logictestccl/testdata/logic_test/as_of
+++ b/pkg/ccl/logictestccl/testdata/logic_test/as_of
@@ -92,3 +92,24 @@ ROLLBACK
 
 statement ok
 SET DEFAULT_TRANSACTION_USE_FOLLOWER_READS TO FALSE
+
+query B
+SELECT with_min_timestamp(now()) = now()
+----
+true
+
+query B
+SELECT with_min_timestamp(now() - '5s'::interval) = now() - '5s'::interval
+----
+true
+
+statement error timestamp for with_min_timestamp must be less than or equal to now\(\)
+SELECT with_min_timestamp(now() + '5s'::interval) = now()
+
+query B
+SELECT with_max_staleness('10s') = now() - '10s'::interval
+----
+true
+
+statement error interval duration for with_max_staleness must be greater or equal to 0
+SELECT with_max_staleness(-'1s')

--- a/pkg/sql/logictest/testdata/logic_test/as_of
+++ b/pkg/sql/logictest/testdata/logic_test/as_of
@@ -91,7 +91,7 @@ statement error pgcode XXC01 with_min_timestamp can only be used with a CCL dist
 SELECT with_min_timestamp('2020-01-15 15:16:17')
 
 statement error pgcode XXC01 with_min_timestamp can only be used with a CCL distribution
-SELECT with_min_timestamp(now())
+SELECT with_min_timestamp(statement_timestamp())
 
 statement error pgcode XXC01 with_max_staleness can only be used with a CCL distribution
 SELECT with_max_staleness('1s')

--- a/pkg/sql/logictest/testdata/logic_test/as_of
+++ b/pkg/sql/logictest/testdata/logic_test/as_of
@@ -86,3 +86,12 @@ EXPLAIN SELECT * FROM t AS OF SYSTEM TIME '-1us'
 # a placeholder (#56488).
 statement error pq: no value provided for placeholder: \$1
 SELECT * FROM t AS OF SYSTEM TIME $1
+
+statement error pgcode XXC01 with_min_timestamp can only be used with a CCL distribution
+SELECT with_min_timestamp('2020-01-15 15:16:17')
+
+statement error pgcode XXC01 with_min_timestamp can only be used with a CCL distribution
+SELECT with_min_timestamp(now())
+
+statement error pgcode XXC01 with_max_staleness can only be used with a CCL distribution
+SELECT with_max_staleness('1s')

--- a/pkg/sql/sem/tree/as_of.go
+++ b/pkg/sql/sem/tree/as_of.go
@@ -36,6 +36,14 @@ const FollowerReadTimestampFunctionName = "follower_read_timestamp"
 // "experimental_" function, which we keep for backwards compatibility.
 const FollowerReadTimestampExperimentalFunctionName = "experimental_follower_read_timestamp"
 
+// WithMinTimestampFunctionName is the name of the function that can be used
+// with AOST clauses to generate a bounded staleness at a fixed timestamp.
+const WithMinTimestampFunctionName = "with_min_timestamp"
+
+// WithMaxStalenessFunctionName is the name of the function that can be used
+// with AOST clauses to generate a bounded staleness at a maximum interval.
+const WithMaxStalenessFunctionName = "with_max_staleness"
+
 var errInvalidExprForAsOf = errors.Errorf("AS OF SYSTEM TIME: only constant expressions or " +
 	FollowerReadTimestampFunctionName + " are allowed")
 


### PR DESCRIPTION
Introduce the `with_min_timestamp` and `with_max_staleness` builtins,
both returning a TimestampTZ of the minimum bound. The RFC has been
updated accordingly.

These functions are gated by a CCL enterprice license, and the relevant
dependency injections have been added to account for that.

The "fail fast" method discussed I plan to add in a later PR.

Refs: #67555

Release note (sql change): Introduce `with_min_timestamp` and
`with_max_staleness` builtins. In a SELECT clause, they return the same
timestamp and (now() - interval), but are intended for use in AS OF
SYSTEM TIME which will appear in an upcoming update.