### PR TITLE
server: stop ticker on exit to prevent leaks 

### DIFF
--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -622,8 +622,12 @@ func (n *Node) startGossiping(ctx context.Context, stopper *stop.Stopper) {
 		statusTicker := time.NewTicker(gossipStatusInterval)
 		storesTicker := time.NewTicker(gossip.StoresInterval)
 		nodeTicker := time.NewTicker(gossip.NodeDescriptorInterval)
-		defer storesTicker.Stop()
-		defer nodeTicker.Stop()
+		defer func() {
+			nodeTicker.Stop()
+			storesTicker.Stop()
+			statusTicker.Stop()
+		}()
+
 		n.gossipStores(ctx) // one-off run before going to sleep
 		for {
 			select {


### PR DESCRIPTION
`statusTicker` inside `startGossiping` function was never stopped. This MR fixes it and combines all ticker `Stop`s into a single `defer`.