### PR TITLE
security: allow colons in cert-principal-map principals

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -771,7 +771,7 @@ such as "node" or "root"). If multiple mappings are provided for the same
 principal not specified in the map is passed through as-is via the identity
 function. A cert is allowed to authenticate a DB principal if the DB principal
 name is contained in the mapped CommonName or DNS-type SubjectAlternateName
-fields.
+fields. It is permissible for the <cert-principal> string to contain colons.
 `,
 	}
 

--- a/pkg/security/auth.go
+++ b/pkg/security/auth.go
@@ -33,18 +33,19 @@ type UserAuthHook func(context.Context, SQLUsername, bool) (connClose func(), _ 
 // SetCertPrincipalMap sets the global principal map. Each entry in the mapping
 // list must either be empty or have the format <source>:<dest>. The principal
 // map is used to transform principal names found in the Subject.CommonName or
-// DNS-type SubjectAlternateNames fields of certificates.
+// DNS-type SubjectAlternateNames fields of certificates. This function splits
+// each list entry on the final colon, allowing <source> to contain colons.
 func SetCertPrincipalMap(mappings []string) error {
 	m := make(map[string]string, len(mappings))
 	for _, v := range mappings {
 		if v == "" {
 			continue
 		}
-		parts := strings.Split(v, ":")
-		if len(parts) != 2 {
+		idx := strings.LastIndexByte(v, ':')
+		if idx == -1 {
 			return errors.Errorf("invalid <cert-principal>:<db-principal> mapping: %q", v)
 		}
-		m[parts[0]] = parts[1]
+		m[v[:idx]] = v[idx+1:]
 	}
 	certPrincipalMap.Lock()
 	certPrincipalMap.m = m

--- a/pkg/security/auth_test.go
+++ b/pkg/security/auth_test.go
@@ -150,6 +150,8 @@ func TestGetCertificateUsersMapped(t *testing.T) {
 		{"bar,foo", "foo:blah", "bar,blah"},
 		// Both principals mapped.
 		{"foo,bar", "foo:bar,bar:foo", "bar,foo"},
+		// Verify desired string splits.
+		{"foo:has:colon", "foo:has:colon:bar", "bar"},
 	}
 	for _, c := range testCases {
 		t.Run("", func(t *testing.T) {


### PR DESCRIPTION
Customers whose internal certificate authority issues certificates with colons
in the principal name were unable to use the cert-principal-map flag.

This change makes the flag-parsing logic split each mapping on the last colon
in the mapping. This does not change the interpretation of existing uses of the
flag, but allows principal names with colons to be used without any need for
escape sequences.

Fixes #66435

Release note (cli change): The cert-principal-map flag now allows the
certificate principal name to contain colons.