### PR TITLE
kv: toy implementation of single-key mvcc-ful revert operation

### DIFF
--- a/pkg/kv/rangemvcc/mvcc.go
+++ b/pkg/kv/rangemvcc/mvcc.go
@@ -1,0 +1,100 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package rangemvcc
+
+type version struct {
+	ts int
+	v  string
+}
+
+type rangeVersion struct {
+	ts       int
+	revertTo int // if 0, deletion
+}
+
+type mvccHistory struct {
+	vs  []version      // ascending ts order
+	rvs []rangeVersion // ascending ts order
+
+	seq int // timestamp allocator for write ops
+}
+
+func (h *mvccHistory) Get(ts int) version {
+	vs := h.vs
+	rvs := h.rvs
+	for {
+		if len(vs) == 0 {
+			return version{} // not found
+		}
+		var vIdx int // -1 if no version visible
+		for i := len(vs) - 1; i >= -1; i-- {
+			if i >= 0 && vs[i].ts > ts {
+				continue // not visible
+			}
+			vIdx = i
+			break
+		}
+
+		if vIdx < 0 {
+			// No suitable version to return exists at all, so no reversion could come
+			// up with any visible version neither. Return empty-handed.
+			return version{}
+		}
+
+		var rIdx int
+		for i := len(rvs) - 1; i >= -1; i-- {
+			if i >= 0 && rvs[i].ts > ts {
+				continue // not visible
+			}
+			rIdx = i
+			break
+		}
+
+		if rIdx < 0 || rvs[rIdx].ts < vs[vIdx].ts {
+			// No ranged op affects the current candidate version, so
+			// we can return it.
+			return vs[vIdx]
+		}
+		// We're getting redirected by a range op, either to timestamp
+		// zero (i.e. a deletion) or to a nonzero timestamp. It's all
+		// the same, just update the timestamp and loop around.
+		ts = rvs[rIdx].revertTo
+
+		// Any version that was in the future now will be in the future forever, so
+		// help out the next iteration of this loop by making them disappear. Note
+		// that the current version might still be returned in a future iteration of
+		// the loop, for example if we're initially reading at ts=5, there is a
+		// version at ts=3, and there is a reversion that redirects ts=5 to ts=3. In
+		// that case, we'll see the version at ts=3 in the first loop reading at
+		// ts=5, loop around to handle the revert range, and then see it again at
+		// ts=3 and return it.
+		vs = vs[:vIdx+1]
+		// Optimize by removing range ops that will never again be visible. This
+		// notably includes the current range op, since it will redirect us to a
+		// timestamp at which it is no longer visible.
+		rvs = rvs[:rIdx]
+	}
+}
+
+func (h *mvccHistory) allocTS() int {
+	h.seq++
+	return h.seq
+}
+
+func (h *mvccHistory) Revert(to int) int {
+	h.rvs = append(h.rvs, rangeVersion{ts: h.allocTS(), revertTo: to})
+	return h.seq
+}
+
+func (h *mvccHistory) Put(v string) int {
+	h.vs = append(h.vs, version{ts: h.allocTS(), v: v})
+	return h.seq
+}

--- a/pkg/kv/rangemvcc/mvcc_test.go
+++ b/pkg/kv/rangemvcc/mvcc_test.go
@@ -1,0 +1,74 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package rangemvcc
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/datadriven"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDataDriven(t *testing.T) {
+	datadriven.Walk(t, "testdata", func(t *testing.T, path string) {
+		var h mvccHistory
+		var breakpoint bool
+		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
+			if breakpoint {
+				breakpoint = false // set your breakpoint on this line
+			}
+			switch d.Cmd {
+			case "breakpoint":
+				breakpoint = true
+			case "nop":
+				h.allocTS()
+				return fmt.Sprintf("ts=%d", h.seq)
+			case "put":
+				seq := h.seq + 1
+				v := fmt.Sprintf("v%d", seq)
+				require.Equal(t, seq, h.Put(v))
+				return fmt.Sprintf("ts=%d", seq)
+			case "get":
+				lo := 1
+				hi := h.seq
+				if len(d.CmdArgs) > 0 {
+					d.CmdArgs[0].Scan(t, 0, &hi)
+					lo = hi
+				}
+				var buf bytes.Buffer
+				for i := lo; i <= hi; i++ {
+					if lo != hi {
+						fmt.Fprintf(&buf, "get(%d): ", i)
+					}
+					s := h.Get(i).v
+					if s == "" {
+						s = "-"
+					}
+					buf.WriteString(s)
+					if lo != hi {
+						fmt.Fprint(&buf, "\n")
+					}
+				}
+				return buf.String()
+			case "revert_to":
+				var ts int
+				d.CmdArgs[0].Scan(t, 0, &ts)
+				seq := h.Revert(ts)
+				return fmt.Sprintf("ts=%d", seq)
+			default:
+				return "unknown command"
+			}
+			return ""
+		})
+	})
+}

--- a/pkg/kv/rangemvcc/testdata/example1.txt
+++ b/pkg/kv/rangemvcc/testdata/example1.txt
@@ -1,0 +1,37 @@
+# Top half of https://cockroachlabs.slack.com/archives/C021WMUML04/p1626436063054000
+
+# Setup
+
+put
+----
+ts=1
+
+revert_to ts=0
+----
+ts=2
+
+put
+----
+ts=3
+
+revert_to ts=1
+----
+ts=4
+
+put
+----
+ts=5
+
+revert_to ts=3
+----
+ts=6
+
+# Verification
+get
+----
+get(1): v1
+get(2): -
+get(3): v3
+get(4): v1
+get(5): v5
+get(6): v3

--- a/pkg/kv/rangemvcc/testdata/example2.txt
+++ b/pkg/kv/rangemvcc/testdata/example2.txt
@@ -1,0 +1,38 @@
+# Bottom half of https://cockroachlabs.slack.com/archives/C021WMUML04/p1626436063054000
+
+# Setup
+
+put
+----
+ts=1
+
+revert_to ts=0
+----
+ts=2
+
+put
+----
+ts=3
+
+revert_to ts=2
+----
+ts=4
+
+revert_to ts=4
+----
+ts=5
+
+revert_to ts=3
+----
+ts=6
+
+# Verification
+
+get
+----
+get(1): v1
+get(2): -
+get(3): v3
+get(4): -
+get(5): -
+get(6): v3

--- a/pkg/kv/rangemvcc/testdata/put-get.txt
+++ b/pkg/kv/rangemvcc/testdata/put-get.txt
@@ -1,0 +1,31 @@
+get ts=1
+----
+-
+
+put
+----
+ts=1
+
+get ts=1
+----
+v1
+
+nop
+----
+ts=2
+
+get ts=2
+----
+v1
+
+get ts=3
+----
+v1
+
+put
+----
+ts=3
+
+get ts=3
+----
+v3

--- a/pkg/kv/rangemvcc/testdata/revert.txt
+++ b/pkg/kv/rangemvcc/testdata/revert.txt
@@ -1,0 +1,50 @@
+put
+----
+ts=1
+
+nop
+----
+ts=2
+
+put
+----
+ts=3
+
+get ts=3
+----
+v3
+
+revert_to ts=2
+----
+ts=4
+
+get ts=4
+----
+v1
+
+get ts=3
+----
+v3
+
+get ts=2
+----
+v1
+
+get ts=1
+----
+v1
+
+revert_to ts=3
+----
+ts=5
+
+breakpoint
+----
+
+get ts=5
+----
+v3
+
+get ts=4
+----
+v1


### PR DESCRIPTION
This is a toy implementation of an MVCC-compliant version of RevertRange
when operating on a single key. It also covers DeleteRange, which is
simply a RevertRange with a target timestamp of zero. Of course the
"Range" part isn't really evident here since this is a single-key model,
however the implementation purposefully separates these operations from
point operations internally to make clear what it would look like to
apply them on actual ranges.

My feeling is that there is not a ton of conceptual complexity here.
There will certainly be complexity involved in implementing this
efficiently (i.e. making sure MVCC iterators don't compute intersections
of ranged MVCC ops to determine which ones apply to the current key),
but I feel that most of that will be well within the realm of what we
already understand due to our support of ranged tombstones below the
MVCC layer.

A topic that I want to add to the toy are stats. We are likely to want
to make RevertRange a fast operation, since it's in the hot path of
aborting an `IMPORT INTO` as well as cutting over to the secondary
during streaming cluster replication. The naive approach for RevertRange
requires a full stats recomputation on each reversion, meaning a full
scan of all data. This is very expensive.

There is however a fast path if the reversion targets a timestamp
for which we know the correct stats (for the same key range). In
that case, we should be able to compute everything we need to know
from that and the MVCC timestamp at which the reversion becomes
effective to correctly update the live counts and GC bytes age.

This can be explored using a single-key model just fine, and the
findings will generalize to the case in which the spans for the
known historical stats and the reversion match, which is commonly
the path we expect to hit when we use RevertRange in practice.

cc @cockroachdb/kv

Release note: None
