### PR TITLE
dev: add `dev builder` command to boot up the builder image

### DIFF
--- a/build/bazelbuilder/README.md
+++ b/build/bazelbuilder/README.md
@@ -1,0 +1,2 @@
+To run the current version of this Docker image, you can do `./dev builder` from
+the root of the repository.

--- a/build/teamcity-bazel-support.sh
+++ b/build/teamcity-bazel-support.sh
@@ -1,3 +1,6 @@
+# FYI: You can run `./dev builder` to run this Docker image. :)
+# `dev` depends on this variable! Don't change the name or format unless you
+# also update `dev` accordingly.
 BAZEL_IMAGE=cockroachdb/bazel:20210528-135020
 
 # Call `run_bazel $NAME_OF_SCRIPT` to start an appropriately-configured Docker

--- a/pkg/cmd/dev/BUILD.bazel
+++ b/pkg/cmd/dev/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "bench.go",
         "build.go",
+        "builder.go",
         "dev.go",
         "generate.go",
         "lint.go",

--- a/pkg/cmd/dev/bench.go
+++ b/pkg/cmd/dev/bench.go
@@ -104,7 +104,7 @@ func (d *dev) bench(cmd *cobra.Command, pkgs []string) error {
 		if timeout > 0 {
 			args = append(args, fmt.Sprintf("-test.timeout=%s", timeout.String()))
 		}
-		_, err := d.exec.CommandContext(ctx, "bazel", args...)
+		err := d.exec.CommandContextNoRecord(ctx, "bazel", args...)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/dev/build.go
+++ b/pkg/cmd/dev/build.go
@@ -97,7 +97,7 @@ func (d *dev) build(cmd *cobra.Command, targets []string) (err error) {
 		args = append(args, buildTarget)
 	}
 
-	if _, err := d.exec.CommandContext(ctx, "bazel", args...); err != nil {
+	if err := d.exec.CommandContextNoRecord(ctx, "bazel", args...); err != nil {
 		return err
 	}
 

--- a/pkg/cmd/dev/builder.go
+++ b/pkg/cmd/dev/builder.go
@@ -1,0 +1,94 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"log"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+	"github.com/spf13/cobra"
+)
+
+const volumeFlag = "volume"
+
+// MakeBuilderCmd constructs the subcommand used to run
+func makeBuilderCmd(runE func(cmd *cobra.Command, args []string) error) *cobra.Command {
+	builderCmd := &cobra.Command{
+		Use:     "builder",
+		Short:   "Run the Bazel builder image.",
+		Long:    "Run the Bazel builder image.",
+		Example: `dev builder`,
+		Args:    cobra.ExactArgs(0),
+		RunE:    runE,
+	}
+	builderCmd.Flags().String(volumeFlag, "bzlcache", "the Docker volume to use as the Bazel cache")
+	return builderCmd
+}
+
+func (d *dev) builder(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+
+	volume := mustGetFlagString(cmd, volumeFlag)
+	if !isTesting {
+		if _, err := exec.LookPath("docker"); err != nil {
+			return errors.New("Could not find docker in PATH")
+		}
+	}
+
+	// Ensure the volume to use exists.
+	_, err := d.exec.CommandContextSilent(ctx, "docker", "volume", "inspect", volume)
+	if err != nil {
+		log.Printf("Creating volume %s with Docker...", volume)
+		_, err := d.exec.CommandContextSilent(ctx, "docker", "volume", "create", volume)
+		if err != nil {
+			return err
+		}
+	}
+
+	var args []string
+	args = append(args, "run", "--rm", "-it")
+	workspace, err := d.getWorkspace(ctx)
+	if err != nil {
+		return err
+	}
+	args = append(args, "-v", workspace+":/cockroach:ro")
+	args = append(args, "--workdir=/cockroach")
+	// Create the artifacts directory.
+	artifacts := filepath.Join(workspace, "artifacts")
+	if err = d.os.MkdirAll(artifacts); err != nil {
+		return err
+	}
+	args = append(args, "-v", artifacts+":/artifacts")
+	// The `delegated` switch ensures that the container's view of the cache
+	// is authoritative. This can result in writes to the actual underlying
+	// filesystem to be lost, but it's a cache so we don't care about that.
+	args = append(args, "-v", volume+":/root/.cache/bazel:delegated")
+	// Read the Docker image from build/teamcity-bazel-support.sh.
+	buf, err := d.os.ReadFile(filepath.Join(workspace, "build/teamcity-bazel-support.sh"))
+	if err != nil {
+		return err
+	}
+	var bazelImage string
+	for _, line := range strings.Split(buf, "\n") {
+		if strings.HasPrefix(line, "BAZEL_IMAGE=") {
+			bazelImage = strings.Trim(strings.TrimPrefix(line, "BAZEL_IMAGE="), "\n ")
+		}
+	}
+	if bazelImage == "" {
+		return errors.New("Could not find BAZEL_IMAGE in build/teamcity-bazel-support.sh")
+	}
+	args = append(args, bazelImage)
+
+	return d.exec.CommandContextNoRecord(ctx, "docker", args...)
+}

--- a/pkg/cmd/dev/datadriven_test.go
+++ b/pkg/cmd/dev/datadriven_test.go
@@ -44,7 +44,7 @@ var (
 )
 
 func init() {
-	predictableDevProfile = true
+	isTesting = true
 }
 
 // TestDatadriven makes use of datadriven and recorder to capture all operations

--- a/pkg/cmd/dev/dev.go
+++ b/pkg/cmd/dev/dev.go
@@ -73,6 +73,7 @@ lets engineers do a few things:
 	ret.cli.AddCommand(
 		makeBenchCmd(ret.bench),
 		makeBuildCmd(ret.build),
+		makeBuilderCmd(ret.builder),
 		makeGenerateCmd(ret.generate),
 		makeLintCmd(ret.lint),
 		makeTestCmd(ret.test),

--- a/pkg/cmd/dev/io/exec/BUILD.bazel
+++ b/pkg/cmd/dev/io/exec/BUILD.bazel
@@ -5,5 +5,8 @@ go_library(
     srcs = ["exec.go"],
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/dev/io/exec",
     visibility = ["//visibility:public"],
-    deps = ["//pkg/cmd/dev/recorder"],
+    deps = [
+        "//pkg/cmd/dev/recorder",
+        "@com_github_cockroachdb_errors//:errors",
+    ],
 )

--- a/pkg/cmd/dev/test.go
+++ b/pkg/cmd/dev/test.go
@@ -186,7 +186,7 @@ func (d *dev) runUnitTest(cmd *cobra.Command, pkgs []string) error {
 		args = append(args, "--test_output", "errors")
 	}
 
-	_, err := d.exec.CommandContext(ctx, "bazel", args...)
+	err := d.exec.CommandContextNoRecord(ctx, "bazel", args...)
 	return err
 }
 

--- a/pkg/cmd/dev/testdata/builder.txt
+++ b/pkg/cmd/dev/testdata/builder.txt
@@ -1,0 +1,7 @@
+dev builder
+----
+docker volume inspect bzlcache
+bazel info workspace --color=no --config=dev
+mkdir go/src/github.com/cockroachdb/cockroach/artifacts
+cat go/src/github.com/cockroachdb/cockroach/build/teamcity-bazel-support.sh
+docker run --rm -it -v go/src/github.com/cockroachdb/cockroach:/cockroach:ro --workdir=/cockroach -v go/src/github.com/cockroachdb/cockroach/artifacts:/artifacts -v bzlcache:/root/.cache/bazel:delegated mock_bazel_image:1234

--- a/pkg/cmd/dev/testdata/recording/builder.txt
+++ b/pkg/cmd/dev/testdata/recording/builder.txt
@@ -1,0 +1,16 @@
+docker volume inspect bzlcache
+----
+
+bazel info workspace --color=no --config=dev
+----
+go/src/github.com/cockroachdb/cockroach
+
+mkdir go/src/github.com/cockroachdb/cockroach/artifacts
+----
+
+cat go/src/github.com/cockroachdb/cockroach/build/teamcity-bazel-support.sh
+----
+BAZEL_IMAGE=mock_bazel_image:1234
+
+docker run --rm -it -v go/src/github.com/cockroachdb/cockroach:/cockroach:ro --workdir=/cockroach -v go/src/github.com/cockroachdb/cockroach/artifacts:/artifacts -v bzlcache:/root/.cache/bazel:delegated mock_bazel_image:1234
+----

--- a/pkg/cmd/dev/util.go
+++ b/pkg/cmd/dev/util.go
@@ -24,7 +24,7 @@ import (
 )
 
 // To be turned on for tests.
-var predictableDevProfile bool
+var isTesting bool
 
 func mustGetFlagString(cmd *cobra.Command, name string) string {
 	val, err := cmd.Flags().GetString(name)
@@ -93,7 +93,7 @@ func getConfigFlags() []string {
 	if skipDevConfig {
 		return []string{}
 	}
-	if !predictableDevProfile && runtime.GOOS == "darwin" && runtime.GOARCH == "amd64" {
+	if !isTesting && runtime.GOOS == "darwin" && runtime.GOARCH == "amd64" {
 		return []string{"--config=devdarwinx86_64"}
 	}
 	return []string{"--config=dev"}


### PR DESCRIPTION
This is the `dev` analogue for `build/builder.sh`.

To support the `tty`, I add a new `CommandContextNoRecord` method that
explicitly passes through `stdin`/`stdout`/`stderr` to the child process
without recording.

Release note: None