### PR TITLE
stop, kvclient: include DistSender partial batches in traces

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -1358,9 +1359,13 @@ func (ds *DistSender) sendPartialBatchAsync(
 	batchIdx int,
 	responseCh chan response,
 ) bool {
-	if err := ds.rpcContext.Stopper.RunLimitedAsyncTask(
-		ctx, "kv.DistSender: sending partial batch",
-		ds.asyncSenderSem, false, /* wait */
+	if err := ds.rpcContext.Stopper.RunAsyncTaskEx(
+		ctx,
+		stop.TaskOpts{
+			TaskName:   "kv.DistSender: sending partial batch",
+			Sem:        ds.asyncSenderSem,
+			WaitForSem: false,
+		},
 		func(ctx context.Context) {
 			ds.metrics.AsyncSentCount.Inc(1)
 			responseCh <- ds.sendPartialBatch(

--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -1363,6 +1363,7 @@ func (ds *DistSender) sendPartialBatchAsync(
 		ctx,
 		stop.TaskOpts{
 			TaskName:   "kv.DistSender: sending partial batch",
+			ChildSpan:  true,
 			Sem:        ds.asyncSenderSem,
 			WaitForSem: false,
 		},

--- a/pkg/kv/kvserver/queue.go
+++ b/pkg/kv/kvserver/queue.go
@@ -576,7 +576,12 @@ func (bq *baseQueue) Async(
 		log.InfofDepth(ctx, 2, "%s", log.Safe(opName))
 	}
 	opName += " (" + bq.name + ")"
-	if err := bq.store.stopper.RunLimitedAsyncTask(context.Background(), opName, bq.addOrMaybeAddSem, wait,
+	if err := bq.store.stopper.RunAsyncTaskEx(context.Background(),
+		stop.TaskOpts{
+			TaskName:   opName,
+			Sem:        bq.addOrMaybeAddSem,
+			WaitForSem: wait,
+		},
 		func(ctx context.Context) {
 			fn(ctx, baseQueueHelper{bq})
 		}); err != nil && bq.addLogN.ShouldLog() {

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -2023,9 +2023,13 @@ func (s *statusServer) iterateNodes(
 	defer cancel()
 	for nodeID := range nodeStatuses {
 		nodeID := nodeID // needed to ensure the closure below captures a copy.
-		if err := s.stopper.RunLimitedAsyncTask(
-			ctx, fmt.Sprintf("server.statusServer: requesting %s", errorCtx),
-			sem, true, /* wait */
+		if err := s.stopper.RunAsyncTaskEx(
+			ctx,
+			stop.TaskOpts{
+				TaskName:   fmt.Sprintf("server.statusServer: requesting %s", errorCtx),
+				Sem:        sem,
+				WaitForSem: true,
+			},
 			func(ctx context.Context) { nodeQuery(ctx, nodeID) },
 		); err != nil {
 			return err
@@ -2114,9 +2118,13 @@ func (s *statusServer) paginatedIterateNodes(
 	for idx, nodeID := range nodeIDs {
 		nodeID := nodeID // needed to ensure the closure below captures a copy.
 		idx := idx
-		if err := s.stopper.RunLimitedAsyncTask(
-			ctx, fmt.Sprintf("server.statusServer: requesting %s", errorCtx),
-			sem, true, /* wait */
+		if err := s.stopper.RunAsyncTaskEx(
+			ctx,
+			stop.TaskOpts{
+				TaskName:   fmt.Sprintf("server.statusServer: requesting %s", errorCtx),
+				Sem:        sem,
+				WaitForSem: true,
+			},
 			func(ctx context.Context) { paginator.queryNode(ctx, nodeID, idx) },
 		); err != nil {
 			return pagState, err

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -1775,6 +1775,7 @@ WHERE message LIKE 'querying next range at /Table/74/1%' OR
       message = '=== SPAN START: kv.DistSender: sending partial batch ==='
 ----
 querying next range at /Table/74/1/0/0
+=== SPAN START: kv.DistSender: sending partial batch ===
 querying next range at /Table/74/1/10/0
 
 # Test for 42202 -- ensure filters can get pushed down through project-set.

--- a/pkg/sql/opt/exec/execbuilder/testdata/show_trace_nonmetamorphic
+++ b/pkg/sql/opt/exec/execbuilder/testdata/show_trace_nonmetamorphic
@@ -73,7 +73,7 @@ SET tracing = on,kv,results; INSERT INTO t.kv(k, v) VALUES (1,2); SET tracing = 
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
- WHERE operation != 'dist sender send'
+ WHERE operation != 'dist sender send' AND operation != 'kv.DistSender: sending partial batch'
 ----
 batch flow coordinator  CPut /Table/54/1/1/0 -> /TUPLE/2:2:Int/2
 batch flow coordinator  InitPut /Table/54/2/2/0 -> /BYTES/0x89
@@ -87,7 +87,7 @@ SET tracing = on,kv,results; INSERT INTO t.kv(k, v) VALUES (1,2); SET tracing = 
 query TT
 set tracing=off;
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
- WHERE operation != 'dist sender send'
+ WHERE operation != 'dist sender send' AND operation != 'kv.DistSender: sending partial batch'
 ----
 batch flow coordinator  CPut /Table/54/1/1/0 -> /TUPLE/2:2:Int/2
 batch flow coordinator  InitPut /Table/54/2/2/0 -> /BYTES/0x89
@@ -99,7 +99,7 @@ SET tracing = on,kv,results; INSERT INTO t.kv(k, v) VALUES (2,2); SET tracing = 
 query TT
 set tracing=off;
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
- WHERE operation != 'dist sender send'
+ WHERE operation != 'dist sender send' AND operation != 'kv.DistSender: sending partial batch'
 ----
 batch flow coordinator  CPut /Table/54/1/2/0 -> /TUPLE/2:2:Int/2
 batch flow coordinator  InitPut /Table/54/2/2/0 -> /BYTES/0x8a
@@ -176,7 +176,7 @@ SET tracing = on,kv,results; DELETE FROM t.kv; SET tracing = off
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
- WHERE operation != 'dist sender send'
+ WHERE operation != 'dist sender send' AND operation != 'kv.DistSender: sending partial batch'
 ----
 colbatchscan            Scan /Table/54/{1-2}
 colbatchscan            fetched: /kv/primary/1/v -> /2

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert_nonmetamorphic
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert_nonmetamorphic
@@ -36,7 +36,7 @@ SET tracing = on,kv,results; UPSERT INTO t.kv(k, v) VALUES (2,3); SET tracing = 
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
- WHERE operation != 'dist sender send'
+ WHERE operation != 'dist sender send' AND operation != 'kv.DistSender: sending partial batch'
 ----
 colbatchscan            Scan /Table/55/1/2/0
 batch flow coordinator  CPut /Table/55/1/2/0 -> /TUPLE/2:2:Int/3
@@ -49,7 +49,7 @@ SET tracing = on,kv,results; UPSERT INTO t.kv(k, v) VALUES (1,2); SET tracing = 
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
- WHERE operation != 'dist sender send'
+ WHERE operation != 'dist sender send' AND operation != 'kv.DistSender: sending partial batch'
 ----
 colbatchscan            Scan /Table/55/1/1/0
 batch flow coordinator  CPut /Table/55/1/1/0 -> /TUPLE/2:2:Int/2
@@ -63,7 +63,7 @@ SET tracing = on,kv,results; UPSERT INTO t.kv(k, v) VALUES (2,2); SET tracing = 
 query TT
 set tracing=off;
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
- WHERE operation != 'dist sender send'
+ WHERE operation != 'dist sender send' AND operation != 'kv.DistSender: sending partial batch'
 ----
 colbatchscan            Scan /Table/55/1/2/0
 colbatchscan            fetched: /kv/primary/2/v -> /3

--- a/pkg/sql/trace_test.go
+++ b/pkg/sql/trace_test.go
@@ -41,9 +41,9 @@ func TestTrace(t *testing.T) {
 
 	// These are always appended, even without the test specifying it.
 	alwaysOptionalSpans := []string{
-		"[async] drain",
-		"[async] storage.pendingLeaseRequest: requesting lease",
-		"[async] storage.Store: gossip on capacity change",
+		"drain",
+		"storage.pendingLeaseRequest: requesting lease",
+		"storage.Store: gossip on capacity change",
 		"outbox",
 		"request range lease",
 		"range lookup",

--- a/pkg/util/stop/BUILD.bazel
+++ b/pkg/util/stop/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
         "//pkg/util/log",
         "//pkg/util/quotapool",
         "//pkg/util/syncutil",
+        "//pkg/util/tracing",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/util/stop/stopper.go
+++ b/pkg/util/stop/stopper.go
@@ -334,6 +334,7 @@ func (s *Stopper) RunAsyncTask(
 	return s.RunAsyncTaskEx(ctx,
 		TaskOpts{
 			TaskName:   taskName,
+			ChildSpan:  false,
 			Sem:        nil,
 			WaitForSem: false,
 		},
@@ -345,6 +346,26 @@ type TaskOpts struct {
 	// TaskName is a human-readable name for the operation. Used as the name of
 	// the tracing span.
 	TaskName string
+
+	// ChildSpan, if set, creates the tracing span for the task via
+	// tracing.ChildSpan() instead of tracing.ForkSpan. This makes the task's span
+	// be part of the parent span's recording (it is created with the
+	// WithParentAndAutoCollection option instead of
+	// WithParentAndManualCollection). It also leads to a ChildOf relationship
+	// instead of a FollowsFrom relationship to be used for the task's span, which
+	// typically implies a non-binding expectation that the parent span will
+	// outlive the task's span, i.e. that the parent will wait for the task to
+	// complete.
+	//
+	// Regardless of this setting, if the caller doesn't have a span, the task
+	// doesn't get a span either.
+	//
+	// Setting ChildSpan can have consequences on memory usage. The lifetime of
+	// the task's span becomes tied to the lifetime of the parent. Generally
+	// ChildSpan should be used when the parent waits for the task to complete,
+	// and the parent is not a long-running process.
+	ChildSpan bool
+
 	// If set, Sem is used as a semaphore limiting the concurrency (each task has
 	// weight 1).
 	//
@@ -400,7 +421,13 @@ func (s *Stopper) RunAsyncTaskEx(ctx context.Context, opt TaskOpts, f func(conte
 		return ErrUnavailable
 	}
 
-	ctx, span := tracing.ForkSpan(ctx, opt.TaskName)
+	// If the caller has a span, the task gets a child span.
+	var span *tracing.Span
+	if opt.ChildSpan {
+		ctx, span = tracing.ChildSpan(ctx, opt.TaskName)
+	} else {
+		ctx, span = tracing.ForkSpan(ctx, opt.TaskName)
+	}
 
 	// Call f on another goroutine.
 	taskStarted = true // Another goroutine now takes ownership of the alloc, if any.

--- a/pkg/util/stop/stopper.go
+++ b/pkg/util/stop/stopper.go
@@ -35,9 +35,7 @@ func init() {
 	leaktest.PrintLeakedStoppers = PrintLeakedStoppers
 }
 
-const asyncTaskNamePrefix = "[async] "
-
-// ErrThrottled is returned from RunLimitedAsyncTask in the event that there
+// ErrThrottled is returned from RunAsyncTaskEx in the event that there
 // is no more capacity for async tasks, as limited by the semaphore.
 var ErrThrottled = errors.New("throttled on async limiting semaphore")
 
@@ -328,77 +326,94 @@ func (s *Stopper) RunTaskWithErr(
 
 // RunAsyncTask is like RunTask, except the callback is run in a goroutine. The
 // method doesn't block for the callback to finish execution.
+//
+// See also RunAsyncTaskEx for a version with more options.
 func (s *Stopper) RunAsyncTask(
 	ctx context.Context, taskName string, f func(context.Context),
 ) error {
-	taskName = asyncTaskNamePrefix + taskName
+	return s.RunAsyncTaskEx(ctx,
+		TaskOpts{
+			TaskName:   taskName,
+			Sem:        nil,
+			WaitForSem: false,
+		},
+		f)
+}
+
+// TaskOpts groups the task execution options for RunAsyncTaskEx.
+type TaskOpts struct {
+	// TaskName is a human-readable name for the operation. Used as the name of
+	// the tracing span.
+	TaskName string
+	// If set, Sem is used as a semaphore limiting the concurrency (each task has
+	// weight 1).
+	//
+	// It is the caller's responsibility to ensure that Sem is closed when the
+	// stopper is quiesced. For quotapools which live for the lifetime of the
+	// stopper, it is generally best to register the sem with the stopper using
+	// AddCloser.
+	Sem *quotapool.IntPool
+	// If Sem is not nil, WaitForSem specifies whether the call blocks or not when
+	// the semaphore is full. If true, the call blocks until the semaphore is
+	// available in order to push back on callers that may be trying to create
+	// many tasks. If false, returns immediately with an error if the semaphore is
+	// not available.
+	WaitForSem bool
+}
+
+// RunAsyncTaskEx is like RunTask, except the callback f is run in a goroutine.
+// The call doesn't block for the callback to finish execution.
+func (s *Stopper) RunAsyncTaskEx(ctx context.Context, opt TaskOpts, f func(context.Context)) error {
+	var alloc *quotapool.IntAlloc
+	taskStarted := false
+	if opt.Sem != nil {
+		// Wait for permission to run from the semaphore.
+		var err error
+		if opt.WaitForSem {
+			alloc, err = opt.Sem.Acquire(ctx, 1)
+		} else {
+			alloc, err = opt.Sem.TryAcquire(ctx, 1)
+		}
+		if errors.Is(err, quotapool.ErrNotEnoughQuota) {
+			err = ErrThrottled
+		} else if quotapool.HasErrClosed(err) {
+			err = ErrUnavailable
+		}
+		if err != nil {
+			return err
+		}
+		defer func() {
+			// If the task is started, the alloc will be released async.
+			if !taskStarted {
+				alloc.Release()
+			}
+		}()
+
+		// Check for canceled context: it's possible to get the semaphore even
+		// if the context is canceled.
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+	}
+
 	if !s.runPrelude() {
 		return ErrUnavailable
 	}
 
-	ctx, span := tracing.ForkSpan(ctx, taskName)
+	ctx, span := tracing.ForkSpan(ctx, opt.TaskName)
 
-	// Call f.
+	// Call f on another goroutine.
+	taskStarted = true // Another goroutine now takes ownership of the alloc, if any.
 	go func() {
 		defer s.Recover(ctx)
 		defer s.runPostlude()
 		defer span.Finish()
-
-		f(ctx)
-	}()
-	return nil
-}
-
-// RunLimitedAsyncTask runs function f in a goroutine, using the given
-// channel as a semaphore to limit the number of tasks that are run
-// concurrently to the channel's capacity. If wait is true, blocks
-// until the semaphore is available in order to push back on callers
-// that may be trying to create many tasks. If wait is false, returns
-// immediately with an error if the semaphore is not
-// available. It is the caller's responsibility to ensure that sem is
-// closed when the stopper is quiesced. For quotapools which live for the
-// lifetime of the stopper, it is generally best to register the sem with the
-// stopper using AddCloser.
-func (s *Stopper) RunLimitedAsyncTask(
-	ctx context.Context, taskName string, sem *quotapool.IntPool, wait bool, f func(context.Context),
-) error {
-	// Wait for permission to run from the semaphore.
-	var alloc *quotapool.IntAlloc
-	var err error
-	if wait {
-		alloc, err = sem.Acquire(ctx, 1)
-	} else {
-		alloc, err = sem.TryAcquire(ctx, 1)
-	}
-	if errors.Is(err, quotapool.ErrNotEnoughQuota) {
-		err = ErrThrottled
-	} else if quotapool.HasErrClosed(err) {
-		err = ErrUnavailable
-	}
-	if err != nil {
-		return err
-	}
-	taskStarted := false
-	defer func() {
-		// If the task is started, the alloc will be released async.
-		if !taskStarted {
-			alloc.Release()
+		if alloc != nil {
+			defer alloc.Release()
 		}
-	}()
 
-	// Check for canceled context: it's possible to get the semaphore even
-	// if the context is canceled.
-	if ctx.Err() != nil {
-		return ctx.Err()
-	}
-
-	if err := s.RunAsyncTask(ctx, taskName, func(ctx context.Context) {
-		defer alloc.Release()
 		f(ctx)
-	}); err != nil {
-		return err
-	}
-	taskStarted = true
+	}()
 	return nil
 }
 


### PR DESCRIPTION
These are the first few patches from #66387 - extracting the non-contentious prefix dealing with DistSender tracing.

----

Before this patch, since fairly recently, the spans created for
Stopper.RunAsyncTask[Ex]() were not included in the recording of the
caller's span because these spans were created with the ForkSpan(). This
patch adds an option to RunAsyncEx to make the task's span a child of
the caller's, and thus to be included in the caller's recording. This
option is used by the DistSender when sending partial batch requests,
therefore re-including these requests in higher-level traces (as they
used to be).

The reason why async tasks were detached from the caller's span
in #59815 was because of concerns about parent and children spans with
very different lifetimes becoming tied through a trace, delaying the
garbage collection of the whole trace until the last span in it
finishes. This patch gives the caller of RunAsyncTaskEx control over
this behavior; in the particular case of the DistSender, the traces are
not too long lived and the DistSender waits for the async tasks it
spawns to finish. In such circumstances, tying the allocations of the
child spans to the whole trace should be fine.

Release note (general change): A recent release removed parts of some
queries from the debugging traces of those queries. This information
(i.e. the execution of some low-level RPCs) has been re-included in the
traces.