### PR TITLE
kvserver: consider suspect stores "live" for computing quorum

### DIFF
--- a/pkg/kv/kvserver/allocator_test.go
+++ b/pkg/kv/kvserver/allocator_test.go
@@ -5641,12 +5641,14 @@ func TestAllocatorComputeActionSuspect(t *testing.T) {
 			suspect:        []roachpb.StoreID{3},
 			expectedAction: AllocatorConsiderRebalance,
 		},
-		// Needs three replicas, two are suspect (i.e. the range lacks a quorum).
 		{
+			// When trying to determine whether a range can achieve quorum, we count
+			// suspect nodes as live because they _currently_ have a "live" node
+			// liveness record.
 			desc:           threeReplDesc,
 			live:           []roachpb.StoreID{1, 4},
 			suspect:        []roachpb.StoreID{2, 3},
-			expectedAction: AllocatorRangeUnavailable,
+			expectedAction: AllocatorConsiderRebalance,
 		},
 	}
 

--- a/pkg/kv/kvserver/client_lease_test.go
+++ b/pkg/kv/kvserver/client_lease_test.go
@@ -889,12 +889,12 @@ func TestLeasesDontThrashWhenNodeBecomesSuspect(t *testing.T) {
 
 	testutils.SucceedsSoon(t, func() error {
 		for _, i := range []int{2, 3} {
-			suspect, err := tc.GetFirstStoreFromServer(t, i).GetStoreConfig().StorePool.IsSuspect(tc.Target(1).StoreID)
+			suspect, err := tc.GetFirstStoreFromServer(t, i).GetStoreConfig().StorePool.IsUnknown(tc.Target(1).StoreID)
 			if err != nil {
 				return err
 			}
 			if !suspect {
-				return errors.Errorf("Expected server 1 to be suspect on server %d", i)
+				return errors.Errorf("Expected server 1 to be in `storeStatusUnknown` on server %d", i)
 			}
 		}
 		return nil

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -368,12 +368,16 @@ func (rq *replicateQueue) processOneChange(
 	// range descriptor.
 	desc, zone := repl.DescAndZone()
 
-	// Avoid taking action if the range has too many dead replicas to make
-	// quorum.
+	// Avoid taking action if the range has too many dead replicas to make quorum.
+	// Consider stores marked suspect as live in order to make this determination.
 	voterReplicas := desc.Replicas().VoterDescriptors()
 	nonVoterReplicas := desc.Replicas().NonVoterDescriptors()
-	liveVoterReplicas, deadVoterReplicas := rq.allocator.storePool.liveAndDeadReplicas(voterReplicas)
-	liveNonVoterReplicas, deadNonVoterReplicas := rq.allocator.storePool.liveAndDeadReplicas(nonVoterReplicas)
+	liveVoterReplicas, deadVoterReplicas := rq.allocator.storePool.liveAndDeadReplicas(
+		voterReplicas, true, /* includeSuspectStores */
+	)
+	liveNonVoterReplicas, deadNonVoterReplicas := rq.allocator.storePool.liveAndDeadReplicas(
+		nonVoterReplicas, true, /* includeSuspectStores */
+	)
 
 	// NB: the replication layer ensures that the below operations don't cause
 	// unavailability; see:

--- a/pkg/kv/kvserver/store_pool.go
+++ b/pkg/kv/kvserver/store_pool.go
@@ -244,6 +244,26 @@ const (
 func (sd *storeDetail) status(
 	now time.Time, threshold time.Duration, nl NodeLivenessFunc, suspectDuration time.Duration,
 ) storeStatus {
+	// During normal operation, we expect the state transitions for stores to look like the following:
+	//
+	//                                           Successful heartbeats
+	//                                          throughout the suspect
+	//       +-----------------------+                 duration
+	//       | storeStatusAvailable  |<-+------------------------------------+
+	//       +-----------------------+  |                                    |
+	//                                  |                                    |
+	//                                  |                         +--------------------+
+	//                                  |                         | storeStatusSuspect |
+	//      +---------------------------+                         +--------------------+
+	//      |      Failed liveness                                           ^
+	//      |         heartbeat                                              |
+	//      |                                                                |
+	//      |                                                                |
+	//      |  +----------------------+                                      |
+	//      +->|  storeStatusUnknown  |--------------------------------------+
+	//         +----------------------+          Successful liveness
+	//                                                heartbeat
+	//
 	// The store is considered dead if it hasn't been updated via gossip
 	// within the liveness threshold. Note that lastUpdatedTime is set
 	// when the store detail is created and will have a non-zero value
@@ -270,11 +290,9 @@ func (sd *storeDetail) status(
 		return storeStatusDecommissioning
 	case livenesspb.NodeLivenessStatus_UNAVAILABLE:
 		// We don't want to suspect a node on startup or when it's first added to a
-		// cluster, because we dont know it's liveness yet. A node is only considered
-		// suspect if it's been alive and fails to heartbeat liveness.
+		// cluster, because we dont know its liveness yet.
 		if !sd.lastAvailable.IsZero() {
 			sd.lastUnavailable = now
-			return storeStatusSuspect
 		}
 		return storeStatusUnknown
 	case livenesspb.NodeLivenessStatus_UNKNOWN:
@@ -605,14 +623,16 @@ func (sp *StorePool) IsDead(storeID roachpb.StoreID) (bool, time.Duration, error
 	return false, deadAsOf.Sub(now), nil
 }
 
-// IsSuspect returns true if the node is suspected by the store pool or an error
-// if the store is not found in the pool.
-func (sp *StorePool) IsSuspect(storeID roachpb.StoreID) (bool, error) {
+// IsUnknown returns true if the given store's status is `storeStatusUnknown`
+// (i.e. it just failed a liveness heartbeat and we cannot ascertain its
+// liveness or deadness at the moment) or an error if the store is not found in
+// the pool.
+func (sp *StorePool) IsUnknown(storeID roachpb.StoreID) (bool, error) {
 	status, err := sp.storeStatus(storeID)
 	if err != nil {
 		return false, err
 	}
-	return status == storeStatusSuspect, nil
+	return status == storeStatusUnknown, nil
 }
 
 // IsLive returns true if the node is considered alive by the store pool or an error
@@ -643,11 +663,17 @@ func (sp *StorePool) storeStatus(storeID roachpb.StoreID) (storeStatus, error) {
 
 // liveAndDeadReplicas divides the provided repls slice into two slices: the
 // first for live replicas, and the second for dead replicas.
-// Replicas for which liveness or deadness cannot be ascertained are excluded
-// from the returned slices.  Replicas on decommissioning node/store are
-// considered live.
+//
+// - Replicas for which liveness or deadness cannot be ascertained
+// (storeStatusUnknown) are excluded from the returned slices.
+//
+// - Replicas on decommissioning node/store are considered live.
+//
+// - If `includeSuspectStores` is true, stores that are marked suspect (i.e.
+// stores that have failed a liveness heartbeat in the recent past) are
+// considered live. Otherwise, they are excluded from the returned slices.
 func (sp *StorePool) liveAndDeadReplicas(
-	repls []roachpb.ReplicaDescriptor,
+	repls []roachpb.ReplicaDescriptor, includeSuspectStores bool,
 ) (liveReplicas, deadReplicas []roachpb.ReplicaDescriptor) {
 	sp.detailsMu.Lock()
 	defer sp.detailsMu.Unlock()
@@ -669,8 +695,12 @@ func (sp *StorePool) liveAndDeadReplicas(
 			// We count decommissioning replicas to be alive because they are readable
 			// and should be used for up-replication if necessary.
 			liveReplicas = append(liveReplicas, repl)
-		case storeStatusUnknown, storeStatusSuspect:
+		case storeStatusUnknown:
 		// No-op.
+		case storeStatusSuspect:
+			if includeSuspectStores {
+				liveReplicas = append(liveReplicas, repl)
+			}
 		default:
 			log.Fatalf(context.TODO(), "unknown store status %d", status)
 		}


### PR DESCRIPTION
Previously, when making the determination of whether a range could achieve
quorum, the allocator ignored "suspect" stores. In other words, a range with 3
replicas would be considered unavailable for rebalancing decisions if it had 2
or more replicas on stores that are marked suspect.

This meant that if a given cluster had multiple nodes missing their liveness
heartbeats intermittently, operations like node decommissioning would never
make progress past a certain point (the replicate queue would never decide to
move replicas away because it would think their ranges are unavailable, even
though they're really not).

This patch fixes this by slightly altering the state transitions for how stores
go in and out of "suspect" and by having the replica rebalancing code
specifically ask for suspect stores to be included in the set of "live"
replicas when it makes the determination of whether a given range can achieve
quorum.

Release note (bug fix): A bug that was introduced in 21.1.5, which prevented
nodes from decommissioning in a cluster if it had multiple nodes intermittently
missing their liveness heartbeats has been fixed.