### PR TITLE
admission,server: scope store overload admission control to write ope…

### DIFF
--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -2678,6 +2678,9 @@ var charts = []sectionDescription{
 					"admission.requested.kv",
 					"admission.admitted.kv",
 					"admission.errored.kv",
+					"admission.requested.kv-stores",
+					"admission.admitted.kv-stores",
+					"admission.errored.kv-stores",
 					"admission.requested.sql-kv-response",
 					"admission.admitted.sql-kv-response",
 					"admission.errored.sql-kv-response",
@@ -2696,6 +2699,7 @@ var charts = []sectionDescription{
 				Title: "Work Queue Length",
 				Metrics: []string{
 					"admission.wait_queue_length.kv",
+					"admission.wait_queue_length.kv-stores",
 					"admission.wait_queue_length.sql-kv-response",
 					"admission.wait_queue_length.sql-sql-response",
 					"admission.wait_queue_length.sql-leaf-start",
@@ -2706,6 +2710,7 @@ var charts = []sectionDescription{
 				Title: "Work Queue Admission Latency Sum",
 				Metrics: []string{
 					"admission.wait_sum.kv",
+					"admission.wait_sum.kv-stores",
 					"admission.wait_sum.sql-kv-response",
 					"admission.wait_sum.sql-sql-response",
 					"admission.wait_sum.sql-leaf-start",
@@ -2716,6 +2721,7 @@ var charts = []sectionDescription{
 				Title: "Work Queue Latency Distribution",
 				Metrics: []string{
 					"admission.wait_durations.kv",
+					"admission.wait_durations.kv-stores",
 					"admission.wait_durations.sql-kv-response",
 					"admission.wait_durations.sql-sql-response",
 					"admission.wait_durations.sql-leaf-start",

--- a/pkg/util/admission/BUILD.bazel
+++ b/pkg/util/admission/BUILD.bazel
@@ -38,7 +38,6 @@ go_test(
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/syncutil",
-        "//pkg/util/timeutil",
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_cockroachdb_pebble//:pebble",
         "@com_github_stretchr_testify//require",

--- a/pkg/util/admission/granter_test.go
+++ b/pkg/util/admission/granter_test.go
@@ -13,15 +13,14 @@ package admission
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/pebble"
 	"github.com/stretchr/testify/require"
@@ -113,19 +112,19 @@ func TestGranterBasic(t *testing.T) {
 			d.ScanArgs(t, "sql-leaf", &opts.SQLStatementLeafStartWorkSlots)
 			d.ScanArgs(t, "sql-root", &opts.SQLStatementRootStartWorkSlots)
 			opts.makeRequesterFunc = func(
-				workKind WorkKind, granter granter, usesTokens bool, tiedToRange bool,
-				_ *cluster.Settings) requester {
+				workKind WorkKind, granter granter, _ *cluster.Settings, opts workQueueOptions) requester {
 				req := &testRequester{
 					workKind:   workKind,
 					granter:    granter,
-					usesTokens: usesTokens,
+					usesTokens: opts.usesTokens,
 					buf:        &buf,
 				}
 				requesters[workKind] = req
 				return req
 			}
 			delayForGrantChainTermination = 0
-			coord, _ = NewGrantCoordinator(opts)
+			coords, _ := NewGrantCoordinators(opts)
+			coord = coords.Regular
 			return flushAndReset()
 
 		case "set-has-waiting-requests":
@@ -171,6 +170,7 @@ func TestGranterBasic(t *testing.T) {
 			coord.mu.Lock()
 			coord.granters[KVWork].(*kvGranter).setAvailableIOTokensLocked(int64(tokens))
 			coord.mu.Unlock()
+			coord.testingTryGrant()
 			return flushAndReset()
 
 		default:
@@ -197,12 +197,82 @@ func scanWorkKind(t *testing.T, d *datadriven.TestData) WorkKind {
 	panic("unknown WorkKind")
 }
 
-type testPebbleMetricsProvider struct {
-	metrics []*pebble.Metrics
+type testMetricsProvider struct {
+	metrics []StoreMetrics
 }
 
-func (m *testPebbleMetricsProvider) GetPebbleMetrics() []*pebble.Metrics {
+func (m *testMetricsProvider) GetPebbleMetrics() []StoreMetrics {
 	return m.metrics
+}
+
+func (m *testMetricsProvider) setMetricsForStores(stores []int32, metrics pebble.Metrics) {
+	m.metrics = m.metrics[:0]
+	for _, s := range stores {
+		m.metrics = append(m.metrics, StoreMetrics{
+			StoreID: s,
+			Metrics: &metrics,
+		})
+	}
+}
+
+// TestStoreCoordinators tests only the setup of GrantCoordinators per store.
+// Testing of IO load functionality happens in TestIOLoadListener.
+func TestStoreCoordinators(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	var buf strings.Builder
+	settings := cluster.MakeTestingClusterSettings()
+	// All the KVWork requesters. The first one is for all KVWork and the
+	// remaining are the per-store ones.
+	var requesters []*testRequester
+	opts := Options{
+		Settings: settings,
+		makeRequesterFunc: func(
+			workKind WorkKind, granter granter, _ *cluster.Settings, opts workQueueOptions) requester {
+			req := &testRequester{
+				workKind:   workKind,
+				granter:    granter,
+				usesTokens: opts.usesTokens,
+				buf:        &buf,
+			}
+			if workKind == KVWork {
+				requesters = append(requesters, req)
+			}
+			return req
+		},
+	}
+	coords, _ := NewGrantCoordinators(opts)
+	// There is only 1 KVWork requester at this point in initialization, for the
+	// Regular GrantCoordinator.
+	require.Equal(t, 1, len(requesters))
+	storeCoords := coords.Stores
+	metrics := pebble.Metrics{}
+	mp := testMetricsProvider{}
+	mp.setMetricsForStores([]int32{10, 20}, metrics)
+	// Setting the metrics provider will cause the initialization of two
+	// GrantCoordinators for the two stores.
+	storeCoords.SetPebbleMetricsProvider(&mp)
+	// Now we have 1+2 = 3 KVWork requesters.
+	require.Equal(t, 3, len(requesters))
+	// Confirm that the store IDs are as expected.
+	var actualStores []int32
+	for s := range storeCoords.gcMap {
+		actualStores = append(actualStores, s)
+	}
+	sort.Slice(actualStores, func(i, j int) bool { return actualStores[i] < actualStores[j] })
+	require.Equal(t, []int32{10, 20}, actualStores)
+	// Do tryGet on all requesters. The requester for the Regular
+	// GrantCoordinator will return false since it has 0 CPU slots. We are
+	// interested in the other ones, which have unlimited slots at this point in
+	// time, so will return true.
+	for i := range requesters {
+		requesters[i].tryGet()
+	}
+	require.Equal(t,
+		"kv: tryGet returned false\nkv: tryGet returned true\nkv: tryGet returned true\n",
+		buf.String())
+	coords.Close()
 }
 
 type testRequesterForIOLL struct {
@@ -222,25 +292,11 @@ func (r *testRequesterForIOLL) getAdmittedCount() uint64 {
 }
 
 type testGranterWithIOTokens struct {
-	buf         strings.Builder
-	tokensSetCh chan struct{}
+	buf strings.Builder
 }
 
 func (g *testGranterWithIOTokens) setAvailableIOTokensLocked(tokens int64) {
 	fmt.Fprintf(&g.buf, "setAvailableIOTokens: %s", tokensFor1sToString(tokens))
-	g.tokensSetCh <- struct{}{}
-}
-
-type testTicker struct {
-	ch chan time.Time
-}
-
-func (tt *testTicker) tickChannel() <-chan time.Time {
-	return tt.ch
-}
-
-func (tt *testTicker) stop() {
-	close(tt.ch)
 }
 
 func tokensFor60sToString(tokens int64) string {
@@ -260,20 +316,12 @@ func tokensFor1sToString(tokens int64) string {
 }
 
 // TestIOLoadListener is a datadriven test with the following command that
-// sets the state for token calculation and then runs the timeTickerInterface 60 times to
-// cause tokens to be set in the testGranterWithIOTokens:
+// sets the state for token calculation and then ticks 60 times to cause
+// tokens to be set in the testGranterWithIOTokens:
 // set-state admitted=<int> l0-bytes=<int> l0-added=<int> l0-files=<int> l0-sublevels=<int>
 func TestIOLoadListener(t *testing.T) {
-	pmp := &testPebbleMetricsProvider{}
 	req := &testRequesterForIOLL{}
-	kvGranter := &testGranterWithIOTokens{
-		tokensSetCh: make(chan struct{}, 1),
-	}
-	tickerCh := make(chan time.Time)
-	newTestTicker := func(d time.Duration) timeTickerInterface {
-		require.Equal(t, time.Second, d)
-		return &testTicker{ch: tickerCh}
-	}
+	kvGranter := &testGranterWithIOTokens{}
 	var ioll *ioLoadListener
 
 	datadriven.RunTest(t, "testdata/io_load_listener",
@@ -298,15 +346,10 @@ func TestIOLoadListener(t *testing.T) {
 				var l0SubLevels int
 				d.ScanArgs(t, "l0-sublevels", &l0SubLevels)
 				metrics.Levels[0].Sublevels = int32(l0SubLevels)
-				pmp.metrics = []*pebble.Metrics{&metrics}
-
-				created := false
 				if ioll == nil {
-					created = true
 					ioll = &ioLoadListener{
 						l0FileCountOverloadThreshold:     l0FileCountOverloadThreshold,
 						l0SubLevelCountOverloadThreshold: l0SubLevelCountOverloadThreshold,
-						pebbleMetricsProvider:            pmp,
 						kvRequester:                      req,
 						// The mutex is needed by ioLoadListener but is not useful in this
 						// test -- the channels provide synchronization and prevent this
@@ -315,24 +358,17 @@ func TestIOLoadListener(t *testing.T) {
 						mu:        &syncutil.Mutex{},
 						kvGranter: kvGranter,
 					}
-					ioll.start(newTestTicker)
 				}
+				ioll.pebbleMetricsTick(metrics)
 				// Do the ticks until just before next adjustment.
 				var buf strings.Builder
+				fmt.Fprintf(&buf, "admitted: %d, bytes: %d, added-bytes: %d,\nsmoothed-removed: %d, "+
+					"smoothed-admit: %d,\ntokens: %s, tokens-allocated: %s\n", ioll.admittedCount,
+					ioll.l0Bytes, ioll.l0AddedBytes, ioll.smoothedBytesRemoved,
+					int64(ioll.smoothedNumAdmit), tokensFor60sToString(ioll.totalTokens),
+					tokensFor1sToString(ioll.tokensAllocated))
 				for i := 0; i < adjustmentInterval; i++ {
-					if i != 0 || !created {
-						tickerCh <- timeutil.Now()
-					}
-					// Else, skip first tick for created ioLoadListener, since it reads
-					// state and sets tokens immediately.
-					<-kvGranter.tokensSetCh
-					if i == 0 {
-						fmt.Fprintf(&buf, "admitted: %d, bytes: %d, added-bytes: %d,\nsmoothed-removed: %d, "+
-							"smoothed-admit: %d,\ntokens: %s, tokens-allocated: %s\n", ioll.admittedCount,
-							ioll.l0Bytes, ioll.l0AddedBytes, ioll.smoothedBytesRemoved,
-							int64(ioll.smoothedNumAdmit), tokensFor60sToString(ioll.totalTokens),
-							tokensFor1sToString(ioll.tokensAllocated))
-					}
+					ioll.allocateTokensTick()
 					fmt.Fprintf(&buf, "tick: %d, %s\n", i, kvGranter.buf.String())
 					kvGranter.buf.Reset()
 				}
@@ -341,7 +377,6 @@ func TestIOLoadListener(t *testing.T) {
 				return fmt.Sprintf("unknown command: %s", d.Cmd)
 			}
 		})
-	ioll.close()
 }
 
 // TODO(sumeer):

--- a/pkg/util/admission/testdata/io_load_listener
+++ b/pkg/util/admission/testdata/io_load_listener
@@ -3,7 +3,7 @@ set-state admitted=0 l0-bytes=10000 l0-added=1000 l0-files=11 l0-sublevels=11
 ----
 admitted: 0, bytes: 10000, added-bytes: 1000,
 smoothed-removed: 0, smoothed-admit: 0,
-tokens: unlimited, tokens-allocated: unlimited
+tokens: unlimited, tokens-allocated: 0
 tick: 0, setAvailableIOTokens: unlimited
 tick: 1, setAvailableIOTokens: unlimited
 tick: 2, setAvailableIOTokens: unlimited
@@ -73,7 +73,7 @@ set-state admitted=10000 l0-bytes=10000 l0-added=101000 l0-files=11 l0-sublevels
 ----
 admitted: 10000, bytes: 10000, added-bytes: 101000,
 smoothed-removed: 50000, smoothed-admit: 1250,
-tokens: 1250, tokens-allocated: 21
+tokens: 1250, tokens-allocated: 0
 tick: 0, setAvailableIOTokens: 21
 tick: 1, setAvailableIOTokens: 21
 tick: 2, setAvailableIOTokens: 21
@@ -140,7 +140,7 @@ set-state admitted=20000 l0-bytes=10000 l0-added=201000 l0-files=11 l0-sublevels
 ----
 admitted: 20000, bytes: 10000, added-bytes: 201000,
 smoothed-removed: 75000, smoothed-admit: 2500,
-tokens: 2500, tokens-allocated: 42
+tokens: 2500, tokens-allocated: 0
 tick: 0, setAvailableIOTokens: 42
 tick: 1, setAvailableIOTokens: 42
 tick: 2, setAvailableIOTokens: 42
@@ -208,7 +208,7 @@ set-state admitted=30000 l0-bytes=10000 l0-added=301000 l0-files=11 l0-sublevels
 ----
 admitted: 30000, bytes: 10000, added-bytes: 301000,
 smoothed-removed: 87500, smoothed-admit: 6250,
-tokens: unlimited, tokens-allocated: unlimited
+tokens: unlimited, tokens-allocated: 0
 tick: 0, setAvailableIOTokens: unlimited
 tick: 1, setAvailableIOTokens: unlimited
 tick: 2, setAvailableIOTokens: unlimited

--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -168,17 +168,44 @@ type WorkQueue struct {
 
 var _ requester = &WorkQueue{}
 
+type workQueueOptions struct {
+	usesTokens  bool
+	tiedToRange bool
+	// If non-nil, the WorkQueue should use the supplied metrics instead of
+	// creating its own.
+	metrics *WorkQueueMetrics
+}
+
+func makeWorkQueueOptions(workKind WorkKind) workQueueOptions {
+	switch workKind {
+	case KVWork:
+		return workQueueOptions{usesTokens: false, tiedToRange: true}
+	case SQLKVResponseWork, SQLSQLResponseWork:
+		return workQueueOptions{usesTokens: true, tiedToRange: false}
+	case SQLStatementLeafStartWork, SQLStatementRootStartWork:
+		return workQueueOptions{usesTokens: false, tiedToRange: false}
+	default:
+		panic(errors.AssertionFailedf("unexpected workKind %d", workKind))
+	}
+}
+
 func makeWorkQueue(
-	workKind WorkKind, granter granter, usesTokens bool, tiedToRange bool, settings *cluster.Settings,
+	workKind WorkKind, granter granter, settings *cluster.Settings, opts workQueueOptions,
 ) requester {
 	gcStopCh := make(chan struct{})
+	var metrics WorkQueueMetrics
+	if opts.metrics == nil {
+		metrics = makeWorkQueueMetrics(string(workKindString(workKind)))
+	} else {
+		metrics = *opts.metrics
+	}
 	q := &WorkQueue{
 		workKind:    workKind,
 		granter:     granter,
-		usesTokens:  usesTokens,
-		tiedToRange: tiedToRange,
+		usesTokens:  opts.usesTokens,
+		tiedToRange: opts.tiedToRange,
 		settings:    settings,
-		metrics:     makeWorkQueueMetrics(string(workKindString(workKind))),
+		metrics:     metrics,
 		gcStopCh:    gcStopCh,
 	}
 	q.mu.tenants = make(map[uint64]*tenantInfo)
@@ -681,7 +708,9 @@ func addName(name string, meta metric.Metadata) metric.Metadata {
 	return rv
 }
 
-// WorkQueueMetrics are metrics associated with a WorkQueue.
+// WorkQueueMetrics are metrics associated with a WorkQueue. These can be
+// shared across WorkQueues, so Gauges should only be updated using deltas
+// instead of by setting values.
 type WorkQueueMetrics struct {
 	Requested       *metric.Counter
 	Admitted        *metric.Counter

--- a/pkg/util/admission/work_queue_test.go
+++ b/pkg/util/admission/work_queue_test.go
@@ -143,7 +143,7 @@ func TestWorkQueueBasic(t *testing.T) {
 			switch d.Cmd {
 			case "init":
 				tg = &testGranter{buf: &buf}
-				q = makeWorkQueue(KVWork, tg, false, true, nil).(*WorkQueue)
+				q = makeWorkQueue(KVWork, tg, nil, makeWorkQueueOptions(KVWork)).(*WorkQueue)
 				tg.r = q
 				workMap.workMap = make(map[int]*testWork)
 				return ""


### PR DESCRIPTION
…rations on the overloaded store

Previously KVWork was all admitted through a single WorkQueue, and this
WorkQueue was paired with a GrantCoordinator that took into account
both CPU overload and storage overload. This meant a single overloaded
store (in a multi-store setting) would slow down all KV operations
including reads, and those on stores that were fine.

We now have multiple WorkQueue's, one per store, that KV writes go
through, and then get to the shared WorkQueue that all operations go
through. The per-store WorkQueues are associated with their own
GrantCoordinators that listen to health state for their respective
stores. The per-store queues do not care about CPU and therefore do not
do grant chaining. Since admission through these per-store queues
happens before the shared queue, a store bottleneck will not cause KV
slots in the shared queue to be taken by requests that are still waiting
for admission elsewhere. The reverse can happen, and is considered
acceptable -- per-store tokens, when a store is overloaded, can be used
by requests that are now waiting for admission in the shared WorkQueue
because of a cpu bottleneck.

The code is significantly refactored for the above:
NewGrantCoordinators returns a container called StoreGrantCoordinators
which lazily initializes the relevant per-store GrantCoordinators when
it first fetches Pebble metrics, in addition to the shared
GrantCoordinator. The server code now integrates with both types and
the code in Node.Batch will sometimes subject a request to two
WorkQueues. The PebbleMetricsProvider now includes StoreIDs, and the
periodic ticking that fetches these metrics at 1min intervals, and does
1s ticks, is moved to StoreGrantCoordinators. This simplifies the
ioLoadListener which no longer does the periodic ticking and eliminates
a some testing-only abstractions. The per-store WorkQueues share the
same metrics, which represent an aggregate across these queues.

Informs #65957

Release note: None