### PR TITLE
sqlsmith: avoid reg* casts in postgres mode

### DIFF
--- a/pkg/cmd/cmpconn/conn.go
+++ b/pkg/cmd/cmpconn/conn.go
@@ -174,7 +174,7 @@ func CompareConns(
 	conns map[string]Conn,
 	prep, exec string,
 	ignoreSQLErrors bool,
-) (err error) {
+) (ignoredErr bool, err error) {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	connRows := make(map[string]*pgx.Rows)
@@ -186,7 +186,7 @@ func CompareConns(
 		}
 		rows, err := conn.Values(ctx, prep, connExecs[name])
 		if err != nil {
-			return nil //nolint:returnerrcheck
+			return true, nil //nolint:returnerrcheck
 		}
 		defer rows.Close()
 		connRows[name] = rows
@@ -219,7 +219,9 @@ func CompareConns(
 // It always returns an error if there are any differences. Additionally,
 // ignoreSQLErrors specifies whether SQL errors should be ignored (in which
 // case the function returns nil if SQL error occurs).
-func compareRows(connRows map[string]*pgx.Rows, ignoreSQLErrors bool) error {
+func compareRows(
+	connRows map[string]*pgx.Rows, ignoreSQLErrors bool,
+) (ignoredErr bool, retErr error) {
 	var first []interface{}
 	var firstName string
 	var minCount int
@@ -240,16 +242,16 @@ ReadRows:
 					// This function can fail if, for example,
 					// a number doesn't fit into a float64. Ignore
 					// them and move along to another query.
-					err = nil
+					return true, nil
 				}
-				return err
+				return false, err
 			}
 			if firstName == "" {
 				firstName = name
 				first = vals
 			} else {
 				if err := CompareVals(first, vals); err != nil {
-					return fmt.Errorf("compare %s to %s:\n%v", firstName, name, err)
+					return false, fmt.Errorf("compare %s to %s:\n%v", firstName, name, err)
 				}
 			}
 		}
@@ -263,16 +265,16 @@ ReadRows:
 			if ignoreSQLErrors {
 				// Aww someone had a SQL error maybe, so we can't use this
 				// query.
-				err = nil
+				return true, nil
 			}
-			return err
+			return false, err
 		}
 	}
 	// Ensure each connection returned the same number of rows.
 	for name, count := range rowCounts {
 		if minCount != count {
-			return fmt.Errorf("%s had %d rows, expected %d", name, count, minCount)
+			return false, fmt.Errorf("%s had %d rows, expected %d", name, count, minCount)
 		}
 	}
-	return nil
+	return false, nil
 }

--- a/pkg/cmd/roachtest/tests/tpcdsvec.go
+++ b/pkg/cmd/roachtest/tests/tpcdsvec.go
@@ -106,7 +106,7 @@ func registerTPCDSVec(r registry.Registry) {
 			// A sanity check that we have different values of 'vectorize'
 			// session variable on two connections and that the comparator will
 			// emit an error because of that difference.
-			if err := cmpconn.CompareConns(
+			if _, err := cmpconn.CompareConns(
 				ctx, timeout, conns, "", "SHOW vectorize;", false, /* ignoreSQLErrors */
 			); err == nil {
 				t.Fatal("unexpectedly SHOW vectorize didn't trigger an error on comparison")
@@ -139,7 +139,7 @@ func registerTPCDSVec(r registry.Registry) {
 				// around issues with cancellation.
 				conns, cleanup := openNewConnections()
 				start := timeutil.Now()
-				if err := cmpconn.CompareConns(
+				if _, err := cmpconn.CompareConns(
 					ctx, 3*timeout, conns, "", query, false, /* ignoreSQLErrors */
 				); err != nil {
 					t.Status(fmt.Sprintf("encountered an error: %s\n", err))

--- a/pkg/cmd/smithcmp/main.go
+++ b/pkg/cmd/smithcmp/main.go
@@ -164,9 +164,10 @@ func main() {
 	var prep, exec string
 	ctx := context.Background()
 	done := time.After(timeout)
-	for i := 0; true; i++ {
+	for i, ignoredErrCount := 0, 0; true; i++ {
 		select {
 		case <-done:
+			fmt.Printf("executed query count: %d\nignored error count: %d\n", i, ignoredErrCount)
 			return
 		default:
 		}
@@ -197,11 +198,13 @@ func main() {
 			fmt.Println(exec)
 		}
 		if compare {
-			if err := cmpconn.CompareConns(
+			if ignoredErr, err := cmpconn.CompareConns(
 				ctx, stmtTimeout, conns, prep, exec, true, /* ignoreSQLErrors */
 			); err != nil {
 				fmt.Printf("prep:\n%s;\nexec:\n%s;\nERR: %s\n\n", prep, exec, err)
 				os.Exit(1)
+			} else if ignoredErr {
+				ignoredErrCount++
 			}
 		} else {
 			for _, conn := range conns {

--- a/pkg/compose/compare/compare/compare_test.go
+++ b/pkg/compose/compare/compare/compare_test.go
@@ -156,16 +156,20 @@ func TestCompare(t *testing.T) {
 				t.Fatal(err)
 			}
 
+			ignoredErrCount := 0
+			totalQueryCount := 0
 			until := time.After(*flagEach)
 			for {
 				select {
 				case <-until:
-					t.Logf("done with test: %s", confName)
+					t.Logf("done with test. totalQueryCount=%d ignoredErrCount=%d test=%s",
+						totalQueryCount, ignoredErrCount, confName,
+					)
 					return
 				default:
 				}
 				query := smither.Generate()
-				if err := cmpconn.CompareConns(
+				if ignoredErr, err := cmpconn.CompareConns(
 					ctx, time.Second*30, conns, "" /* prep */, query, config.ignoreSQLErrors,
 				); err != nil {
 					path := filepath.Join(*flagArtifacts, confName+".log")
@@ -173,7 +177,10 @@ func TestCompare(t *testing.T) {
 						t.Log(err)
 					}
 					t.Fatal(err)
+				} else if ignoredErr {
+					ignoredErrCount++
 				}
+				totalQueryCount++
 				// Make sure we can still ping on a connection. If we can't we may have
 				// crashed something.
 				for name, conn := range conns {

--- a/pkg/compose/compare/docker-compose.yml
+++ b/pkg/compose/compare/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   postgres:
     image: postgis/postgis:13-3.1
     environment:
-      - POSTGRES_INITDB_ARGS=--locale=C
+      - POSTGRES_INITDB_ARGS=--locale=C --encoding=UTF8
       - POSTGRES_HOST_AUTH_METHOD=trust
   cockroach1:
     image: ubuntu:xenial-20170214

--- a/pkg/internal/sqlsmith/scalar.go
+++ b/pkg/internal/sqlsmith/scalar.go
@@ -152,6 +152,12 @@ func makeConstExpr(s *Smither, typ *types.T, refs colRefs) tree.TypedExpr {
 	// In Postgres mode, make sure the datum is resolved as the type we want.
 	// CockroachDB and Postgres differ in how constants are typed otherwise.
 	if s.postgres {
+		// Casts to REGTYPE, REGCLASS, etc are not deterministic since they
+		// involve OID->name resolution, and the OIDs will not match across
+		// two different databases.
+		if typ.Family() == types.OidFamily {
+			typ = types.Oid
+		}
 		expr = tree.NewTypedCastExpr(expr, typ)
 	}
 	return expr


### PR DESCRIPTION
These casts are not deterministic, so cause flaky tests.

After adding this, I ran https://github.com/cockroachdb/cockroach/issues/56845 locally for 10 minutes
and it passed.

Release note: None