### PR TITLE
cluster-ui: update peer dependencies

### DIFF
--- a/pkg/ui/cluster-ui/package.json
+++ b/pkg/ui/cluster-ui/package.json
@@ -132,13 +132,12 @@
     "webpackbar": "^4.0.0"
   },
   "peerDependencies": {
-    "protobufjs": "6.8.6",
-    "react": "^16.12.0",
-    "react-dom": "^16.12.0",
-    "react-redux": "7.1.3",
-    "react-router-dom": "^5.1.2",
-    "redux": "4.0.5",
-    "redux-saga": "1.1.3"
+    "react": ">=16.12.0",
+    "react-dom": ">=16.12.0",
+    "react-redux": ">=7.1.3",
+    "react-router-dom": ">=5.1.2",
+    "redux": ">=4.0.5",
+    "redux-saga": ">=1.1.3"
   },
   "resolutions": {
     "node-fetch": "~2.6.1",


### PR DESCRIPTION
Previously, running yarn for CC console service would output
peer dependency warnings for cluster-ui dependency.

This change updates peer dependencies to remove warnings.

Note: this will also be backported to 21.1 and 20.2, for
respective cluster-ui-21-1 and cluster-ui-20-2 packages.

Release note: None

Before: (run from `<path-of-cockroach-cloud-repo>/console`)

<img width="600" src="https://user-images.githubusercontent.com/3051672/126002005-43233905-0651-4449-a472-46a9b17c4ae1.png">

After:

<img width="600" src="https://user-images.githubusercontent.com/3051672/126002144-0ae66ba1-b9a7-4d90-a645-c9d0db5fae7a.png">
