### PR TITLE
opt: zigzag scan hints

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -916,6 +916,7 @@ unreserved_keyword ::=
 	| 'FOLLOWING'
 	| 'FORCE'
 	| 'FORCE_INDEX'
+	| 'FORCE_ZIGZAG'
 	| 'FUNCTION'
 	| 'FUNCTIONS'
 	| 'GENERATED'
@@ -2784,6 +2785,8 @@ index_flags_param ::=
 	'FORCE_INDEX' '=' index_name
 	| 'NO_INDEX_JOIN'
 	| 'NO_ZIGZAG_JOIN'
+	| 'FORCE_ZIGZAG'
+	| 'FORCE_ZIGZAG' '=' index_name
 
 opt_asc_desc ::=
 	'ASC'

--- a/pkg/sql/logictest/testdata/logic_test/zigzag_join
+++ b/pkg/sql/logictest/testdata/logic_test/zigzag_join
@@ -3,7 +3,7 @@
 # ------------------------------------------------------------------------------
 
 statement ok
-CREATE TABLE a (n INT PRIMARY KEY, a INT, b INT, c STRING, INDEX a_idx(a), INDEX b_idx(b));
+CREATE TABLE a (n INT PRIMARY KEY, a INT, b INT, c STRING, INDEX a_idx(a), INDEX b_idx(b), INDEX bc_idx(b,c));
 INSERT INTO a SELECT a,a,a%3,'foo' FROM generate_series(1,10) AS g(a) ;
 SET enable_zigzag_join = true
 
@@ -59,8 +59,8 @@ statement ok
 DROP INDEX a@a_idx;
 DROP INDEX a@b_idx;
 CREATE INDEX c_idx ON a(c);
-CREATE INDEX a_idx_2 ON a(a);
-CREATE INDEX b_idx_2 ON a(b);
+CREATE INDEX a_idx ON a(a);
+CREATE INDEX b_idx ON a(b);
 SELECT n,a,b FROM a WHERE a = 4 AND b = 1;
 
 # Regression test for 48003 ("non-values node passed as fixed value to zigzag
@@ -190,3 +190,63 @@ query IT
 SELECT * from d where b @> '[{"a": {"b": [[2]]}}, "d"]'
 ----
 16  [{"a": {"b": [1, [2]]}}, "d"]
+
+# Zigzag hinting tests, functional tests in opt.xform coster tests, syntax tests
+# in parser select_clauses.
+
+statement error index "foo" not found
+SELECT * FROM a@{FORCE_ZIGZAG=foo} WHERE a = 3 AND b = 7
+
+# c_idx can't be used to zigzag so this is an error.
+statement error could not produce a query plan conforming to the FORCE_ZIGZAG hint
+SELECT * FROM a@{FORCE_ZIGZAG=a_idx,FORCE_ZIGZAG=c_idx} WHERE a = 3 AND b = 7
+
+# Need two equalities to plan a zigzag.
+statement error could not produce a query plan conforming to the FORCE_ZIGZAG hint
+SELECT * FROM a@{FORCE_ZIGZAG=a_idx,FORCE_ZIGZAG=b_idx} WHERE a = 3
+
+# Need two suitable indexes to plan a zigzag.
+statement error could not produce a query plan conforming to the FORCE_ZIGZAG hint
+SELECT * FROM a@{FORCE_ZIGZAG=a_idx,FORCE_ZIGZAG=bc_idx} WHERE a = 3 AND b = 7
+
+# Basic form w/o indexes.
+statement ok
+SELECT * FROM a@{FORCE_ZIGZAG} WHERE a = 3 AND b = 7
+
+# Consider this an error, certainly its a typo.
+statement error FORCE_ZIGZAG hints not distinct
+SELECT * FROM a@{FORCE_ZIGZAG,FORCE_ZIGZAG=a_idx} WHERE a = 3 AND b = 7
+
+# Dupes are an error.
+statement error FORCE_ZIGZAG index duplicated
+SELECT * FROM a@{FORCE_ZIGZAG=a_idx,FORCE_ZIGZAG=a_idx} WHERE a = 3 AND b = 7
+
+# Full indexes specified.
+statement ok
+SELECT * FROM a@{FORCE_ZIGZAG=a_idx,FORCE_ZIGZAG=b_idx} WHERE a = 3 AND b = 7
+
+statement ok
+DROP INDEX a@c_idx
+
+# Check error if no index.
+statement error could not produce a query plan conforming to the FORCE_ZIGZAG hint
+SELECT * FROM a@{FORCE_ZIGZAG} WHERE a = 3 AND c = 'foo'
+
+# Dupes are an error.
+statement error FORCE_ZIGZAG index duplicated
+SELECT * FROM a@{FORCE_ZIGZAG=[1],FORCE_ZIGZAG=[1]} WHERE a = 3 AND b = 7
+
+# Full indexes specified. 6 is a_idx and 7 is b_idx.
+statement ok
+SELECT * FROM a@{FORCE_ZIGZAG=[6],FORCE_ZIGZAG=[7]} WHERE a = 3 AND b = 7
+
+# Combining name and id is allowed.
+statement ok
+SELECT * FROM a@{FORCE_ZIGZAG=[6],FORCE_ZIGZAG=b_idx} WHERE a = 3 AND b = 7
+
+# Duplicate name and id is not allowed.
+statement error FORCE_ZIGZAG index duplicated
+SELECT * FROM a@{FORCE_ZIGZAG=[6],FORCE_ZIGZAG=a_idx} WHERE a = 3 AND b = 7
+
+statement error FORCE_ZIGZAG cannot be specified in conjunction with NO_ZIGZAG_JOIN
+SELECT * FROM a@{FORCE_ZIGZAG,NO_ZIGZAG_JOIN} WHERE a = 3 AND b = 7

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -660,6 +660,10 @@ func (b *Builder) buildScan(scan *memo.ScanExpr) (execPlan, error) {
 		return execPlan{}, err
 	}
 
+	if scan.Flags.ForceZigzag {
+		return execPlan{}, fmt.Errorf("could not produce a query plan conforming to the FORCE_ZIGZAG hint")
+	}
+
 	// Save if we planned a full table/index scan on the builder so that the
 	// planner can be made aware later. We only do this for non-virtual tables.
 	if !tab.IsVirtualTable() && scan.Constraint == nil && scan.InvertedConstraint == nil && !scan.HardLimit.IsSet() {

--- a/pkg/sql/opt/memo/BUILD.bazel
+++ b/pkg/sql/opt/memo/BUILD.bazel
@@ -39,6 +39,7 @@ go_library(
         "//pkg/sql/sem/builtins",
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
+        "//pkg/util",
         "//pkg/util/duration",
         "//pkg/util/encoding",
         "//pkg/util/json",

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
@@ -354,14 +355,19 @@ type ScanFlags struct {
 
 	// ForceIndex forces the use of a specific index (specified in Index).
 	// ForceIndex and NoIndexJoin cannot both be set at the same time.
-	ForceIndex bool
-	Direction  tree.Direction
-	Index      int
+	ForceIndex  bool
+	ForceZigzag bool
+	Direction   tree.Direction
+	Index       int
+
+	// ZigzagIndexes makes planner prefer a zigzag with particular indexes.
+	// ForceZigzag must also be true.
+	ZigzagIndexes util.FastIntSet
 }
 
 // Empty returns true if there are no flags set.
 func (sf *ScanFlags) Empty() bool {
-	return !sf.NoIndexJoin && !sf.NoZigzagJoin && !sf.ForceIndex
+	return *sf == ScanFlags{}
 }
 
 // JoinFlags stores restrictions on the join execution method, derived from

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -422,6 +422,23 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 			if private.Flags.NoZigzagJoin {
 				b.WriteString(" no-zigzag-join")
 			}
+			if private.Flags.ForceZigzag {
+				if private.Flags.ZigzagIndexes.Empty() {
+					b.WriteString(" force-zigzag")
+				} else {
+					b.WriteString(" force-zigzag=")
+					s := private.Flags.ZigzagIndexes
+					needComma := false
+					for i, ok := s.Next(0); ok; i, ok = s.Next(i + 1) {
+						idx := md.Table(private.Table).Index(i)
+						if needComma {
+							b.WriteByte(',')
+						}
+						b.WriteString(string(idx.Name()))
+						needComma = true
+					}
+				}
+			}
 			tp.Child(b.String())
 		}
 		if private.Locking != nil {

--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -489,8 +489,15 @@ func (h *hasher) HashScanFlags(val ScanFlags) {
 	h.HashBool(val.NoIndexJoin)
 	h.HashBool(val.NoZigzagJoin)
 	h.HashBool(val.ForceIndex)
+	h.HashBool(val.ForceZigzag)
 	h.HashInt(int(val.Direction))
 	h.HashUint64(uint64(val.Index))
+	if !val.ZigzagIndexes.Empty() {
+		s := val.ZigzagIndexes
+		for i, ok := s.Next(0); ok; i, ok = s.Next(i + 1) {
+			h.HashInt(i)
+		}
+	}
 }
 
 func (h *hasher) HashJoinFlags(val JoinFlags) {

--- a/pkg/sql/opt/memo/testdata/format
+++ b/pkg/sql/opt/memo/testdata/format
@@ -570,3 +570,127 @@ project
       └── plus [as="?column?":7, type=int, outer=(1), immutable]
            ├── variable: t.public.t.a:1 [type=int]
            └── const: 1 [type=int]
+
+
+exec-ddl
+CREATE TABLE zigzag (n INT PRIMARY KEY, a INT, b INT, c STRING, INDEX a_idx(a), INDEX b_idx(b), UNIQUE INDEX c_idx(b,c), INDEX ba_idx(b));
+----
+
+# Verify naked hint.
+norm
+SELECT * FROM zigzag@{FORCE_ZIGZAG} WHERE a = 3 AND b = 7;
+----
+select
+ ├── columns: n:1(int!null) a:2(int!null) b:3(int!null) c:4(string)
+ ├── stats: [rows=0.910810811, distinct(2)=0.910810811, null(2)=0, distinct(3)=0.910810811, null(3)=0, distinct(2,3)=0.910810811, null(2,3)=0]
+ ├── cost: 1e+100
+ ├── key: (1)
+ ├── fd: ()-->(2,3), (1)-->(4), (3,4)~~>(1)
+ ├── prune: (1,4)
+ ├── interesting orderings: (+1 opt(2,3)) (+4,+1 opt(2,3))
+ ├── scan t.public.zigzag
+ │    ├── columns: t.public.zigzag.n:1(int!null) t.public.zigzag.a:2(int) t.public.zigzag.b:3(int) t.public.zigzag.c:4(string)
+ │    ├── flags: force-zigzag
+ │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0, distinct(2)=100, null(2)=10, distinct(3)=100, null(3)=10, distinct(2,3)=1000, null(2,3)=0.1]
+ │    ├── cost: 1e+100
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
+ │    ├── prune: (1-4)
+ │    └── interesting orderings: (+1) (+2,+1) (+3,+1) (+3,+4,+1)
+ └── filters
+      ├── eq [type=bool, outer=(2), constraints=(/2: [/3 - /3]; tight), fd=()-->(2)]
+      │    ├── variable: t.public.zigzag.a:2 [type=int]
+      │    └── const: 3 [type=int]
+      └── eq [type=bool, outer=(3), constraints=(/3: [/7 - /7]; tight), fd=()-->(3)]
+           ├── variable: t.public.zigzag.b:3 [type=int]
+           └── const: 7 [type=int]
+
+
+# Verify plan with one index.
+norm
+SELECT * FROM zigzag@{FORCE_ZIGZAG=a_idx} WHERE a = 3 AND b = 7;
+----
+select
+ ├── columns: n:1(int!null) a:2(int!null) b:3(int!null) c:4(string)
+ ├── stats: [rows=0.910810811, distinct(2)=0.910810811, null(2)=0, distinct(3)=0.910810811, null(3)=0, distinct(2,3)=0.910810811, null(2,3)=0]
+ ├── cost: 1e+100
+ ├── key: (1)
+ ├── fd: ()-->(2,3), (1)-->(4), (3,4)~~>(1)
+ ├── prune: (1,4)
+ ├── interesting orderings: (+1 opt(2,3)) (+4,+1 opt(2,3))
+ ├── scan t.public.zigzag
+ │    ├── columns: t.public.zigzag.n:1(int!null) t.public.zigzag.a:2(int) t.public.zigzag.b:3(int) t.public.zigzag.c:4(string)
+ │    ├── flags: force-zigzag=a_idx
+ │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0, distinct(2)=100, null(2)=10, distinct(3)=100, null(3)=10, distinct(2,3)=1000, null(2,3)=0.1]
+ │    ├── cost: 1e+100
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
+ │    ├── prune: (1-4)
+ │    └── interesting orderings: (+1) (+2,+1) (+3,+1) (+3,+4,+1)
+ └── filters
+      ├── eq [type=bool, outer=(2), constraints=(/2: [/3 - /3]; tight), fd=()-->(2)]
+      │    ├── variable: t.public.zigzag.a:2 [type=int]
+      │    └── const: 3 [type=int]
+      └── eq [type=bool, outer=(3), constraints=(/3: [/7 - /7]; tight), fd=()-->(3)]
+           ├── variable: t.public.zigzag.b:3 [type=int]
+           └── const: 7 [type=int]
+
+
+# Verify plan with other index.
+norm
+SELECT * FROM zigzag@{FORCE_ZIGZAG=b_idx} WHERE a = 3 AND b = 7;
+----
+select
+ ├── columns: n:1(int!null) a:2(int!null) b:3(int!null) c:4(string)
+ ├── stats: [rows=0.910810811, distinct(2)=0.910810811, null(2)=0, distinct(3)=0.910810811, null(3)=0, distinct(2,3)=0.910810811, null(2,3)=0]
+ ├── cost: 1e+100
+ ├── key: (1)
+ ├── fd: ()-->(2,3), (1)-->(4), (3,4)~~>(1)
+ ├── prune: (1,4)
+ ├── interesting orderings: (+1 opt(2,3)) (+4,+1 opt(2,3))
+ ├── scan t.public.zigzag
+ │    ├── columns: t.public.zigzag.n:1(int!null) t.public.zigzag.a:2(int) t.public.zigzag.b:3(int) t.public.zigzag.c:4(string)
+ │    ├── flags: force-zigzag=b_idx
+ │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0, distinct(2)=100, null(2)=10, distinct(3)=100, null(3)=10, distinct(2,3)=1000, null(2,3)=0.1]
+ │    ├── cost: 1e+100
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
+ │    ├── prune: (1-4)
+ │    └── interesting orderings: (+1) (+2,+1) (+3,+1) (+3,+4,+1)
+ └── filters
+      ├── eq [type=bool, outer=(2), constraints=(/2: [/3 - /3]; tight), fd=()-->(2)]
+      │    ├── variable: t.public.zigzag.a:2 [type=int]
+      │    └── const: 3 [type=int]
+      └── eq [type=bool, outer=(3), constraints=(/3: [/7 - /7]; tight), fd=()-->(3)]
+           ├── variable: t.public.zigzag.b:3 [type=int]
+           └── const: 7 [type=int]
+
+
+# Verify plan with both indexes hinted.
+norm
+SELECT * FROM zigzag@{FORCE_ZIGZAG=a_idx,FORCE_ZIGZAG=b_idx} WHERE a = 3 AND b = 7;
+----
+select
+ ├── columns: n:1(int!null) a:2(int!null) b:3(int!null) c:4(string)
+ ├── stats: [rows=0.910810811, distinct(2)=0.910810811, null(2)=0, distinct(3)=0.910810811, null(3)=0, distinct(2,3)=0.910810811, null(2,3)=0]
+ ├── cost: 1e+100
+ ├── key: (1)
+ ├── fd: ()-->(2,3), (1)-->(4), (3,4)~~>(1)
+ ├── prune: (1,4)
+ ├── interesting orderings: (+1 opt(2,3)) (+4,+1 opt(2,3))
+ ├── scan t.public.zigzag
+ │    ├── columns: t.public.zigzag.n:1(int!null) t.public.zigzag.a:2(int) t.public.zigzag.b:3(int) t.public.zigzag.c:4(string)
+ │    ├── flags: force-zigzag=a_idx,b_idx
+ │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0, distinct(2)=100, null(2)=10, distinct(3)=100, null(3)=10, distinct(2,3)=1000, null(2,3)=0.1]
+ │    ├── cost: 1e+100
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
+ │    ├── prune: (1-4)
+ │    └── interesting orderings: (+1) (+2,+1) (+3,+1) (+3,+4,+1)
+ └── filters
+      ├── eq [type=bool, outer=(2), constraints=(/2: [/3 - /3]; tight), fd=()-->(2)]
+      │    ├── variable: t.public.zigzag.a:2 [type=int]
+      │    └── const: 3 [type=int]
+      └── eq [type=bool, outer=(3), constraints=(/3: [/7 - /7]; tight), fd=()-->(3)]
+           ├── variable: t.public.zigzag.b:3 [type=int]
+           └── const: 7 [type=int]

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -610,7 +610,7 @@ func (c *coster) computeScanCost(scan *memo.ScanExpr, required *physical.Require
 	// Scanning an index with a few columns is faster than scanning an index with
 	// many columns. Ideally, we would want to use statistics about the size of
 	// each column. In lieu of that, use the number of columns.
-	if scan.Flags.ForceIndex && scan.Flags.Index != scan.Index {
+	if scan.Flags.ForceIndex && scan.Flags.Index != scan.Index || scan.Flags.ForceZigzag {
 		// If we are forcing an index, any other index has a very high cost. In
 		// practice, this will only happen when this is a primary index scan.
 		return hugeCost

--- a/pkg/sql/opt/xform/rules/select.opt
+++ b/pkg/sql/opt/xform/rules/select.opt
@@ -56,7 +56,7 @@
 # GenerateZigzagJoins creates ZigzagJoin operators for all index pairs (of the
 # Scan table) where the prefix column(s) of both indexes is/are fixed to
 # constant values in the filters. See comments in GenerateZigzagJoin and
-# distsqlrun/zigzagjoiner.go for more details on when a zigzag join can be
+# sql.rowexec.zigzagJoiner for more details on when a zigzag join can be
 # planned.
 #
 # Zigzag joins are prohibited when the source Scan operator has been configured

--- a/pkg/sql/opt/xform/testdata/coster/select
+++ b/pkg/sql/opt/xform/testdata/coster/select
@@ -121,3 +121,49 @@ limit
  │         └── filters
  │              └── false [constraints=(contradiction; tight)]
  └── 10
+
+exec-ddl
+CREATE TABLE zigzag (n INT PRIMARY KEY, a INT, b INT, c STRING, INDEX a_idx(a), INDEX b_idx(b), UNIQUE INDEX c_idx(b,c));
+----
+
+# Verify huge cost on scan operator when there is a zigzag join hint.
+opt
+SELECT * FROM zigzag@{FORCE_ZIGZAG=a_idx,FORCE_ZIGZAG=c_idx} WHERE a = 3 AND b = 7;
+----
+select
+ ├── columns: n:1!null a:2!null b:3!null c:4
+ ├── stats: [rows=0.910810811, distinct(2)=0.910810811, null(2)=0, distinct(3)=0.910810811, null(3)=0, distinct(2,3)=0.910810811, null(2,3)=0]
+ ├── cost: 1e+100
+ ├── key: (1)
+ ├── fd: ()-->(2,3), (1)-->(4), (3,4)~~>(1)
+ ├── scan zigzag
+ │    ├── columns: n:1!null a:2 b:3 c:4
+ │    ├── flags: force-zigzag=a_idx,c_idx
+ │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0, distinct(2)=100, null(2)=10, distinct(3)=100, null(3)=10, distinct(2,3)=1000, null(2,3)=0.1]
+ │    ├── cost: 1e+100
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-4), (3,4)~~>(1,2)
+ └── filters
+      ├── a:2 = 3 [outer=(2), constraints=(/2: [/3 - /3]; tight), fd=()-->(2)]
+      └── b:3 = 7 [outer=(3), constraints=(/3: [/7 - /7]; tight), fd=()-->(3)]
+
+# Test formating when mixing names/ids.
+opt
+SELECT * FROM zigzag@{FORCE_ZIGZAG=[2],FORCE_ZIGZAG=c_idx} WHERE a = 3 AND b = 7;
+----
+select
+ ├── columns: n:1!null a:2!null b:3!null c:4
+ ├── stats: [rows=0.910810811, distinct(2)=0.910810811, null(2)=0, distinct(3)=0.910810811, null(3)=0, distinct(2,3)=0.910810811, null(2,3)=0]
+ ├── cost: 1e+100
+ ├── key: (1)
+ ├── fd: ()-->(2,3), (1)-->(4), (3,4)~~>(1)
+ ├── scan zigzag
+ │    ├── columns: n:1!null a:2 b:3 c:4
+ │    ├── flags: force-zigzag=a_idx,c_idx
+ │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0, distinct(2)=100, null(2)=10, distinct(3)=100, null(3)=10, distinct(2,3)=1000, null(2,3)=0.1]
+ │    ├── cost: 1e+100
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-4), (3,4)~~>(1,2)
+ └── filters
+      ├── a:2 = 3 [outer=(2), constraints=(/2: [/3 - /3]; tight), fd=()-->(2)]
+      └── b:3 = 7 [outer=(3), constraints=(/3: [/7 - /7]; tight), fd=()-->(3)]

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -1120,7 +1120,7 @@ group-by
 memo
 SELECT array_agg(w) FROM (SELECT * FROM kuvw ORDER BY w) GROUP BY u,v
 ----
-memo (optimized, ~7KB, required=[presentation: array_agg:7])
+memo (optimized, ~8KB, required=[presentation: array_agg:7])
  ├── G1: (project G2 G3 array_agg)
  │    └── [presentation: array_agg:7]
  │         ├── best: (project G2 G3 array_agg)
@@ -1385,7 +1385,7 @@ memo (optimized, ~12KB, required=[presentation: sum:7])
 memo
 SELECT array_agg(w) FROM (SELECT * FROM kuvw ORDER BY w DESC) GROUP BY u,v
 ----
-memo (optimized, ~6KB, required=[presentation: array_agg:7])
+memo (optimized, ~7KB, required=[presentation: array_agg:7])
  ├── G1: (project G2 G3 array_agg)
  │    └── [presentation: array_agg:7]
  │         ├── best: (project G2 G3 array_agg)

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -182,7 +182,7 @@ inner-join (merge)
 memo expect=ReorderJoins
 SELECT * FROM abc, stu, xyz WHERE abc.a=stu.s AND stu.s=xyz.x
 ----
-memo (optimized, ~36KB, required=[presentation: a:1,b:2,c:3,s:7,t:8,u:9,x:12,y:13,z:14])
+memo (optimized, ~37KB, required=[presentation: a:1,b:2,c:3,s:7,t:8,u:9,x:12,y:13,z:14])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (inner-join G5 G6 G7) (inner-join G6 G5 G7) (inner-join G8 G9 G7) (inner-join G9 G8 G7) (merge-join G2 G3 G10 inner-join,+1,+7) (merge-join G3 G2 G10 inner-join,+7,+1) (lookup-join G3 G10 abc@ab,keyCols=[7],outCols=(1-3,7-9,12-14)) (merge-join G5 G6 G10 inner-join,+7,+12) (merge-join G6 G5 G10 inner-join,+12,+7) (lookup-join G6 G10 stu,keyCols=[12],outCols=(1-3,7-9,12-14)) (merge-join G8 G9 G10 inner-join,+7,+12) (lookup-join G8 G10 xyz@xy,keyCols=[7],outCols=(1-3,7-9,12-14)) (merge-join G9 G8 G10 inner-join,+12,+7)
  │    └── [presentation: a:1,b:2,c:3,s:7,t:8,u:9,x:12,y:13,z:14]
  │         ├── best: (merge-join G5="[ordering: +7]" G6="[ordering: +(1|12)]" G10 inner-join,+7,+12)
@@ -1350,7 +1350,7 @@ New expression 2 of 2:
 memo expect=ReorderJoins
 SELECT * FROM abc JOIN xyz ON a=z
 ----
-memo (optimized, ~10KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
+memo (optimized, ~11KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (merge-join G2 G3 G5 inner-join,+1,+9) (lookup-join G3 G5 abc@ab,keyCols=[9],outCols=(1-3,7-9))
  │    └── [presentation: a:1,b:2,c:3,x:7,y:8,z:9]
  │         ├── best: (inner-join G2 G3 G4)
@@ -1594,7 +1594,7 @@ right-join (hash)
 memo
 SELECT * FROM abc RIGHT OUTER JOIN xyz ON a=z
 ----
-memo (optimized, ~10KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
+memo (optimized, ~11KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
  ├── G1: (left-join G2 G3 G4) (right-join G3 G2 G4) (lookup-join G2 G5 abc@ab,keyCols=[9],outCols=(1-3,7-9)) (merge-join G3 G2 G5 right-join,+1,+9)
  │    └── [presentation: a:1,b:2,c:3,x:7,y:8,z:9]
  │         ├── best: (left-join G2 G3 G4)
@@ -1977,7 +1977,7 @@ inner-join (lookup xyz@xy)
 memo
 SELECT * FROM stu AS l JOIN stu AS r ON (l.s, l.t, l.u) = (r.s, r.t, r.u)
 ----
-memo (optimized, ~15KB, required=[presentation: s:1,t:2,u:3,s:6,t:7,u:8])
+memo (optimized, ~16KB, required=[presentation: s:1,t:2,u:3,s:6,t:7,u:8])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (merge-join G2 G3 G5 inner-join,+1,+2,+3,+6,+7,+8) (merge-join G2 G3 G5 inner-join,+3,+2,+1,+8,+7,+6) (lookup-join G2 G5 stu [as=r],keyCols=[1 2 3],outCols=(1-3,6-8)) (lookup-join G2 G5 stu@uts [as=r],keyCols=[3 2 1],outCols=(1-3,6-8)) (merge-join G3 G2 G5 inner-join,+6,+7,+8,+1,+2,+3) (merge-join G3 G2 G5 inner-join,+8,+7,+6,+3,+2,+1) (lookup-join G3 G5 stu [as=l],keyCols=[6 7 8],outCols=(1-3,6-8)) (lookup-join G3 G5 stu@uts [as=l],keyCols=[8 7 6],outCols=(1-3,6-8))
  │    └── [presentation: s:1,t:2,u:3,s:6,t:7,u:8]
  │         ├── best: (merge-join G2="[ordering: +1,+2,+3]" G3="[ordering: +6,+7,+8]" G5 inner-join,+1,+2,+3,+6,+7,+8)
@@ -2184,7 +2184,7 @@ left-join (merge)
 memo
 SELECT * FROM abc JOIN xyz ON a=b
 ----
-memo (optimized, ~13KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
+memo (optimized, ~14KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4)
  │    └── [presentation: a:1,b:2,c:3,x:7,y:8,z:9]
  │         ├── best: (inner-join G3 G2 G4)
@@ -5500,7 +5500,7 @@ WHERE n.name = 'Upper West Side'
 OR n.name = 'Upper East Side'
 GROUP BY n.name, n.geom
 ----
-memo (optimized, ~28KB, required=[presentation: name:16,popn_per_sqkm:22])
+memo (optimized, ~29KB, required=[presentation: name:16,popn_per_sqkm:22])
  ├── G1: (project G2 G3 name)
  │    └── [presentation: name:16,popn_per_sqkm:22]
  │         ├── best: (project G2 G3 name)

--- a/pkg/sql/opt/xform/testdata/rules/join_order
+++ b/pkg/sql/opt/xform/testdata/rules/join_order
@@ -535,7 +535,7 @@ inner-join (cross)
 memo join-limit=0
 SELECT * FROM bx, cy, dz, abc WHERE x = y AND y = z AND z = a
 ----
-memo (optimized, ~24KB, required=[presentation: b:1,x:2,c:5,y:6,d:9,z:10,a:13,b:14,c:15,d:16])
+memo (optimized, ~25KB, required=[presentation: b:1,x:2,c:5,y:6,d:9,z:10,a:13,b:14,c:15,d:16])
  ├── G1: (inner-join G2 G3 G4) (merge-join G2 G3 G5 inner-join,+2,+6)
  │    └── [presentation: b:1,x:2,c:5,y:6,d:9,z:10,a:13,b:14,c:15,d:16]
  │         ├── best: (inner-join G2 G3 G4)

--- a/pkg/sql/opt/xform/testdata/rules/scan
+++ b/pkg/sql/opt/xform/testdata/rules/scan
@@ -53,7 +53,7 @@ scan a,rev
 memo
 SELECT k,f FROM a ORDER BY k DESC LIMIT 10
 ----
-memo (optimized, ~3KB, required=[presentation: k:1,f:3] [ordering: -1])
+memo (optimized, ~4KB, required=[presentation: k:1,f:3] [ordering: -1])
  ├── G1: (limit G2 G3 ordering=-1) (scan a,rev,cols=(1,3),lim=10(rev))
  │    ├── [presentation: k:1,f:3] [ordering: -1]
  │    │    ├── best: (scan a,rev,cols=(1,3),lim=10(rev))

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -1784,7 +1784,7 @@ CREATE INDEX idx ON p (i) WHERE s = 'foo'
 memo expect-not=GenerateConstrainedScans
 SELECT i FROM p WHERE s = 'bar' AND i = 5
 ----
-memo (optimized, ~7KB, required=[presentation: i:2])
+memo (optimized, ~8KB, required=[presentation: i:2])
  ├── G1: (project G2 G3 i)
  │    └── [presentation: i:2]
  │         ├── best: (project G2 G3 i)
@@ -6067,6 +6067,122 @@ select
  └── filters
       └── r:3 = 2 [outer=(3), constraints=(/3: [/2 - /2]; tight), fd=()-->(3)]
 
+# Zigzag join hinting tests
+exec-ddl
+CREATE TABLE zigzag
+(
+    n INT PRIMARY KEY,
+    a INT,
+    b INT,
+    c STRING,
+    INDEX a_idx(a),
+    INDEX b_idx(b),
+    UNIQUE INDEX c_idx(b,c),
+    INDEX bc_idx(b,c)
+)
+----
+
+# Verify naked hint.
+opt
+SELECT * FROM zigzag@{FORCE_ZIGZAG} WHERE a = 3 AND b = 7;
+----
+inner-join (lookup zigzag)
+ ├── columns: n:1!null a:2!null b:3!null c:4
+ ├── key columns: [1] = [1]
+ ├── lookup columns are key
+ ├── key: (1)
+ ├── fd: ()-->(2,3), (1)-->(4), (3,4)~~>(1)
+ ├── inner-join (zigzag zigzag@a_idx zigzag@b_idx)
+ │    ├── columns: n:1!null a:2!null b:3!null
+ │    ├── eq columns: [1] = [1]
+ │    ├── left fixed columns: [2] = [3]
+ │    ├── right fixed columns: [3] = [7]
+ │    ├── fd: ()-->(2,3)
+ │    └── filters
+ │         ├── a:2 = 3 [outer=(2), constraints=(/2: [/3 - /3]; tight), fd=()-->(2)]
+ │         └── b:3 = 7 [outer=(3), constraints=(/3: [/7 - /7]; tight), fd=()-->(3)]
+ └── filters (true)
+
+# Verify plan with one index.
+opt
+SELECT * FROM zigzag@{FORCE_ZIGZAG=a_idx} WHERE a = 3 AND b = 7;
+----
+inner-join (lookup zigzag)
+ ├── columns: n:1!null a:2!null b:3!null c:4
+ ├── key columns: [1] = [1]
+ ├── lookup columns are key
+ ├── key: (1)
+ ├── fd: ()-->(2,3), (1)-->(4), (3,4)~~>(1)
+ ├── inner-join (zigzag zigzag@a_idx zigzag@b_idx)
+ │    ├── columns: n:1!null a:2!null b:3!null
+ │    ├── eq columns: [1] = [1]
+ │    ├── left fixed columns: [2] = [3]
+ │    ├── right fixed columns: [3] = [7]
+ │    ├── fd: ()-->(2,3)
+ │    └── filters
+ │         ├── a:2 = 3 [outer=(2), constraints=(/2: [/3 - /3]; tight), fd=()-->(2)]
+ │         └── b:3 = 7 [outer=(3), constraints=(/3: [/7 - /7]; tight), fd=()-->(3)]
+ └── filters (true)
+
+# Verify plan with other index.
+opt
+SELECT * FROM zigzag@{FORCE_ZIGZAG=b_idx} WHERE a = 3 AND b = 7;
+----
+inner-join (lookup zigzag)
+ ├── columns: n:1!null a:2!null b:3!null c:4
+ ├── key columns: [1] = [1]
+ ├── lookup columns are key
+ ├── key: (1)
+ ├── fd: ()-->(2,3), (1)-->(4), (3,4)~~>(1)
+ ├── inner-join (zigzag zigzag@a_idx zigzag@b_idx)
+ │    ├── columns: n:1!null a:2!null b:3!null
+ │    ├── eq columns: [1] = [1]
+ │    ├── left fixed columns: [2] = [3]
+ │    ├── right fixed columns: [3] = [7]
+ │    ├── fd: ()-->(2,3)
+ │    └── filters
+ │         ├── a:2 = 3 [outer=(2), constraints=(/2: [/3 - /3]; tight), fd=()-->(2)]
+ │         └── b:3 = 7 [outer=(3), constraints=(/3: [/7 - /7]; tight), fd=()-->(3)]
+ └── filters (true)
+
+# Verify plan with both indexes hinted.
+opt
+SELECT * FROM zigzag@{FORCE_ZIGZAG=a_idx,FORCE_ZIGZAG=b_idx} WHERE a = 3 AND b = 7;
+----
+inner-join (lookup zigzag)
+ ├── columns: n:1!null a:2!null b:3!null c:4
+ ├── key columns: [1] = [1]
+ ├── lookup columns are key
+ ├── key: (1)
+ ├── fd: ()-->(2,3), (1)-->(4), (3,4)~~>(1)
+ ├── inner-join (zigzag zigzag@a_idx zigzag@b_idx)
+ │    ├── columns: n:1!null a:2!null b:3!null
+ │    ├── eq columns: [1] = [1]
+ │    ├── left fixed columns: [2] = [3]
+ │    ├── right fixed columns: [3] = [7]
+ │    ├── fd: ()-->(2,3)
+ │    └── filters
+ │         ├── a:2 = 3 [outer=(2), constraints=(/2: [/3 - /3]; tight), fd=()-->(2)]
+ │         └── b:3 = 7 [outer=(3), constraints=(/3: [/7 - /7]; tight), fd=()-->(3)]
+ └── filters (true)
+
+# Verify force selection when there's multiple valid choices.
+opt
+SELECT * FROM zigzag@{FORCE_ZIGZAG=a_idx,FORCE_ZIGZAG=bc_idx} WHERE a = 3 AND b = 7;
+----
+select
+ ├── columns: n:1!null a:2!null b:3!null c:4
+ ├── key: (1)
+ ├── fd: ()-->(2,3), (1)-->(4), (3,4)~~>(1)
+ ├── scan zigzag
+ │    ├── columns: n:1!null a:2 b:3 c:4
+ │    ├── flags: force-zigzag=a_idx,bc_idx
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-4), (3,4)~~>(1,2)
+ └── filters
+      ├── a:2 = 3 [outer=(2), constraints=(/2: [/3 - /3]; tight), fd=()-->(2)]
+      └── b:3 = 7 [outer=(3), constraints=(/3: [/7 - /7]; tight), fd=()-->(3)]
+
 # --------------------------------------------------
 # GenerateInvertedIndexZigzagJoins
 # --------------------------------------------------
@@ -6383,6 +6499,56 @@ project
       │              └── b
       └── filters
            └── j @> '{"a": 1, "b": 2}'
+
+# Generate a zigzag join with a hint.
+opt expect=GenerateInvertedIndexZigzagJoins
+SELECT k FROM inv_zz_partial@{FORCE_ZIGZAG} WHERE j @> '{"a": 1, "b": 2}' AND b AND s = 'foo'
+----
+project
+ ├── columns: k:1!null
+ ├── immutable
+ ├── key: (1)
+ └── inner-join (lookup inv_zz_partial)
+      ├── columns: k:1!null j:2!null b:3!null s:4!null
+      ├── key columns: [1] = [1]
+      ├── lookup columns are key
+      ├── immutable
+      ├── key: (1)
+      ├── fd: ()-->(3,4), (1)-->(2)
+      ├── inner-join (zigzag inv_zz_partial@zz_idx,partial inv_zz_partial@zz_idx,partial)
+      │    ├── columns: k:1!null
+      │    ├── eq columns: [1] = [1]
+      │    ├── left fixed columns: [7] = ['\x376100012a0200']
+      │    ├── right fixed columns: [7] = ['\x376200012a0400']
+      │    └── filters (true)
+      └── filters
+           ├── j:2 @> '{"a": 1, "b": 2}' [outer=(2), immutable, constraints=(/2: (/NULL - ])]
+           └── s:4 = 'foo' [outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
+
+# Generate an inverted zigzag join with a hint.
+opt expect=GenerateInvertedIndexZigzagJoins
+SELECT k FROM inv_zz_partial@{FORCE_ZIGZAG=zz_idx} WHERE j @> '{"a": 1, "b": 2}' AND b AND s = 'foo'
+----
+project
+ ├── columns: k:1!null
+ ├── immutable
+ ├── key: (1)
+ └── inner-join (lookup inv_zz_partial)
+      ├── columns: k:1!null j:2!null b:3!null s:4!null
+      ├── key columns: [1] = [1]
+      ├── lookup columns are key
+      ├── immutable
+      ├── key: (1)
+      ├── fd: ()-->(3,4), (1)-->(2)
+      ├── inner-join (zigzag inv_zz_partial@zz_idx,partial inv_zz_partial@zz_idx,partial)
+      │    ├── columns: k:1!null
+      │    ├── eq columns: [1] = [1]
+      │    ├── left fixed columns: [7] = ['\x376100012a0200']
+      │    ├── right fixed columns: [7] = ['\x376200012a0400']
+      │    └── filters (true)
+      └── filters
+           ├── j:2 @> '{"a": 1, "b": 2}' [outer=(2), immutable, constraints=(/2: (/NULL - ])]
+           └── s:4 = 'foo' [outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
 
 exec-ddl
 DROP INDEX zz_idx
@@ -7738,7 +7904,7 @@ JOIN t61795 AS t2 ON t1.c = t1.b AND t1.b = t2.b
 WHERE t1.a = 10 OR t2.b != abs(t2.b)
 ORDER BY t1.b ASC
 ----
-memo (optimized, ~28KB, required=[presentation: a:1] [ordering: +2])
+memo (optimized, ~29KB, required=[presentation: a:1] [ordering: +2])
  ├── G1: (project G2 G3 a b)
  │    ├── [presentation: a:1] [ordering: +2]
  │    │    ├── best: (sort G1)

--- a/pkg/sql/opt/xform/testdata/rules/set
+++ b/pkg/sql/opt/xform/testdata/rules/set
@@ -21,7 +21,7 @@ CREATE TABLE kuvw (
 memo expect=GenerateStreamingSetOp
 SELECT * FROM kuvw UNION SELECT * FROM kuvw
 ----
-memo (optimized, ~9KB, required=[presentation: k:13,u:14,v:15,w:16])
+memo (optimized, ~10KB, required=[presentation: k:13,u:14,v:15,w:16])
  ├── G1: (distinct-on G2 G3 cols=(13)) (distinct-on G2 G3 cols=(13),ordering=+13)
  │    └── [presentation: k:13,u:14,v:15,w:16]
  │         ├── best: (distinct-on G2="[ordering: +13]" G3 cols=(13),ordering=+13)
@@ -58,7 +58,7 @@ memo (optimized, ~9KB, required=[presentation: k:13,u:14,v:15,w:16])
 memo expect=GenerateStreamingSetOp
 SELECT * FROM kuvw INTERSECT SELECT * FROM kuvw
 ----
-memo (optimized, ~9KB, required=[presentation: k:1,u:2,v:3,w:4])
+memo (optimized, ~10KB, required=[presentation: k:1,u:2,v:3,w:4])
  ├── G1: (intersect-all G2 G3) (intersect-all G2 G3 ordering=+1,+2,+3,+4) (intersect-all G2 G3 ordering=+2,+3,+4,+1) (intersect-all G2 G3 ordering=+4,+3,+2,+1) (intersect-all G2 G3 ordering=+3,+4,+1,+2) (intersect-all G2 G3 ordering=+4,+1,+2,+3)
  │    └── [presentation: k:1,u:2,v:3,w:4]
  │         ├── best: (intersect-all G2="[ordering: +1]" G3="[ordering: +7]" ordering=+1,+2,+3,+4)
@@ -105,7 +105,7 @@ memo (optimized, ~9KB, required=[presentation: k:1,u:2,v:3,w:4])
 memo expect=GenerateStreamingSetOp
 SELECT * FROM kuvw INTERSECT ALL SELECT * FROM kuvw
 ----
-memo (optimized, ~9KB, required=[presentation: k:1,u:2,v:3,w:4])
+memo (optimized, ~10KB, required=[presentation: k:1,u:2,v:3,w:4])
  ├── G1: (intersect-all G2 G3) (intersect-all G2 G3 ordering=+1,+2,+3,+4) (intersect-all G2 G3 ordering=+2,+3,+4,+1) (intersect-all G2 G3 ordering=+4,+3,+2,+1) (intersect-all G2 G3 ordering=+3,+4,+1,+2) (intersect-all G2 G3 ordering=+4,+1,+2,+3)
  │    └── [presentation: k:1,u:2,v:3,w:4]
  │         ├── best: (intersect-all G2="[ordering: +1]" G3="[ordering: +7]" ordering=+1,+2,+3,+4)
@@ -152,7 +152,7 @@ memo (optimized, ~9KB, required=[presentation: k:1,u:2,v:3,w:4])
 memo expect=GenerateStreamingSetOp
 SELECT * FROM kuvw EXCEPT SELECT * FROM kuvw
 ----
-memo (optimized, ~9KB, required=[presentation: k:1,u:2,v:3,w:4])
+memo (optimized, ~10KB, required=[presentation: k:1,u:2,v:3,w:4])
  ├── G1: (except-all G2 G3) (except-all G2 G3 ordering=+1,+2,+3,+4) (except-all G2 G3 ordering=+2,+3,+4,+1) (except-all G2 G3 ordering=+4,+3,+2,+1) (except-all G2 G3 ordering=+3,+4,+1,+2) (except-all G2 G3 ordering=+4,+1,+2,+3)
  │    └── [presentation: k:1,u:2,v:3,w:4]
  │         ├── best: (except-all G2="[ordering: +1]" G3="[ordering: +7]" ordering=+1,+2,+3,+4)
@@ -199,7 +199,7 @@ memo (optimized, ~9KB, required=[presentation: k:1,u:2,v:3,w:4])
 memo expect=GenerateStreamingSetOp
 SELECT * FROM kuvw EXCEPT ALL SELECT * FROM kuvw
 ----
-memo (optimized, ~9KB, required=[presentation: k:1,u:2,v:3,w:4])
+memo (optimized, ~10KB, required=[presentation: k:1,u:2,v:3,w:4])
  ├── G1: (except-all G2 G3) (except-all G2 G3 ordering=+1,+2,+3,+4) (except-all G2 G3 ordering=+2,+3,+4,+1) (except-all G2 G3 ordering=+4,+3,+2,+1) (except-all G2 G3 ordering=+3,+4,+1,+2) (except-all G2 G3 ordering=+4,+1,+2,+3)
  │    └── [presentation: k:1,u:2,v:3,w:4]
  │         ├── best: (except-all G2="[ordering: +1]" G3="[ordering: +7]" ordering=+1,+2,+3,+4)

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -780,7 +780,7 @@ func (u *sqlSymUnion) setVar() *tree.SetVar {
 
 %token <str> FAILURE FALSE FAMILY FETCH FETCHVAL FETCHTEXT FETCHVAL_PATH FETCHTEXT_PATH
 %token <str> FILES FILTER
-%token <str> FIRST FLOAT FLOAT4 FLOAT8 FLOORDIV FOLLOWING FOR FORCE FORCE_INDEX FOREIGN FROM FULL FUNCTION FUNCTIONS
+%token <str> FIRST FLOAT FLOAT4 FLOAT8 FLOORDIV FOLLOWING FOR FORCE FORCE_INDEX FORCE_ZIGZAG FOREIGN FROM FULL FUNCTION FUNCTIONS
 
 %token <str> GENERATED GEOGRAPHY GEOMETRY GEOMETRYM GEOMETRYZ GEOMETRYZM
 %token <str> GEOMETRYCOLLECTION GEOMETRYCOLLECTIONM GEOMETRYCOLLECTIONZ GEOMETRYCOLLECTIONZM
@@ -9767,6 +9767,22 @@ index_flags_param:
     /* SKIP DOC */
     $$.val = &tree.IndexFlags{IgnoreForeignKeys: true}
   }
+|
+  FORCE_ZIGZAG
+  {
+     $$.val = &tree.IndexFlags{ForceZigzag: true}
+  }
+|
+  FORCE_ZIGZAG '=' index_name
+  {
+     $$.val = &tree.IndexFlags{ZigzagIndexes: []tree.UnrestrictedName{tree.UnrestrictedName($3)}}
+  }
+|
+  FORCE_ZIGZAG '=' '[' iconst64 ']'
+  {
+    /* SKIP DOC */
+     $$.val = &tree.IndexFlags{ZigzagIndexIDs: []tree.IndexID{tree.IndexID($4.int64())}}
+  }
 
 index_flags_param_list:
   index_flags_param
@@ -9827,6 +9843,7 @@ opt_index_flags:
 //   '{' NO_INDEX_JOIN [, ...] '}'
 //   '{' NO_ZIGZAG_JOIN [, ...] '}'
 //   '{' IGNORE_FOREIGN_KEYS [, ...] '}'
+//   '{' FORCE_ZIGZAG = <idxname> [, ...]  '}'
 //
 // Join types:
 //   { INNER | { LEFT | RIGHT | FULL } [OUTER] } [ { HASH | MERGE | LOOKUP | INVERTED } ]
@@ -13187,6 +13204,7 @@ unreserved_keyword:
 | FOLLOWING
 | FORCE
 | FORCE_INDEX
+| FORCE_ZIGZAG
 | FUNCTION
 | FUNCTIONS
 | GENERATED

--- a/pkg/sql/parser/testdata/select_clauses
+++ b/pkg/sql/parser/testdata/select_clauses
@@ -400,6 +400,131 @@ DETAIL: source SQL:
 SELECT a FROM foo@{IGNORE_FOREIGN_KEYS,IGNORE_FOREIGN_KEYS}
                                        ^
 
+parse
+SELECT 'a' FROM t@{FORCE_ZIGZAG}
+----
+SELECT 'a' FROM t@{FORCE_ZIGZAG}
+SELECT ('a') FROM t@{FORCE_ZIGZAG} -- fully parenthesized
+SELECT '_' FROM t@{FORCE_ZIGZAG} -- literals removed
+SELECT 'a' FROM _@{FORCE_ZIGZAG} -- identifiers removed
+
+parse
+SELECT 'a' FROM t@{FORCE_ZIGZAG=idx}
+----
+SELECT 'a' FROM t@{FORCE_ZIGZAG=idx}
+SELECT ('a') FROM t@{FORCE_ZIGZAG=idx} -- fully parenthesized
+SELECT '_' FROM t@{FORCE_ZIGZAG=idx} -- literals removed
+SELECT 'a' FROM _@{FORCE_ZIGZAG=_} -- identifiers removed
+
+parse
+SELECT 'a' FROM t@{FORCE_ZIGZAG=idxa,FORCE_ZIGZAG=idxb}
+----
+SELECT 'a' FROM t@{FORCE_ZIGZAG=idxa,FORCE_ZIGZAG=idxb}
+SELECT ('a') FROM t@{FORCE_ZIGZAG=idxa,FORCE_ZIGZAG=idxb} -- fully parenthesized
+SELECT '_' FROM t@{FORCE_ZIGZAG=idxa,FORCE_ZIGZAG=idxb} -- literals removed
+SELECT 'a' FROM _@{FORCE_ZIGZAG=_,FORCE_ZIGZAG=_} -- identifiers removed
+
+error
+SELECT 'a' FROM t@{FORCE_ZIGZAG=1}
+----
+at or near "1": syntax error
+DETAIL: source SQL:
+SELECT 'a' FROM t@{FORCE_ZIGZAG=1}
+                                ^
+HINT: try \h <SOURCE>
+
+parse
+SELECT 'a' FROM t@{FORCE_ZIGZAG=[1]}
+----
+SELECT 'a' FROM t@{FORCE_ZIGZAG=[1]}
+SELECT ('a') FROM t@{FORCE_ZIGZAG=[1]} -- fully parenthesized
+SELECT '_' FROM t@{FORCE_ZIGZAG=[1]} -- literals removed
+SELECT 'a' FROM _@{FORCE_ZIGZAG=[1]} -- identifiers removed
+
+parse
+SELECT 'a' FROM t@{FORCE_ZIGZAG=[1],FORCE_ZIGZAG=[2]}
+----
+SELECT 'a' FROM t@{FORCE_ZIGZAG=[1],FORCE_ZIGZAG=[2]}
+SELECT ('a') FROM t@{FORCE_ZIGZAG=[1],FORCE_ZIGZAG=[2]} -- fully parenthesized
+SELECT '_' FROM t@{FORCE_ZIGZAG=[1],FORCE_ZIGZAG=[2]} -- literals removed
+SELECT 'a' FROM _@{FORCE_ZIGZAG=[1],FORCE_ZIGZAG=[2]} -- identifiers removed
+
+error
+SELECT a FROM foo@{FORCE_ZIGZAG,NO_INDEX_JOIN}
+----
+at or near "}": syntax error: FORCE_ZIGZAG cannot be specified in conjunction with NO_INDEX_JOIN
+DETAIL: source SQL:
+SELECT a FROM foo@{FORCE_ZIGZAG,NO_INDEX_JOIN}
+                                             ^
+
+error
+SELECT a FROM foo@{FORCE_ZIGZAG,FORCE_INDEX=a}
+----
+at or near "}": syntax error: FORCE_ZIGZAG cannot be specified in conjunction with FORCE_INDEX
+DETAIL: source SQL:
+SELECT a FROM foo@{FORCE_ZIGZAG,FORCE_INDEX=a}
+                                             ^
+
+error
+SELECT a FROM foo@{FORCE_ZIGZAG,FORCE_ZIGZAG}
+----
+at or near "}": syntax error: FORCE_ZIGZAG specified multiple times
+DETAIL: source SQL:
+SELECT a FROM foo@{FORCE_ZIGZAG,FORCE_ZIGZAG}
+                                            ^
+
+error
+SELECT 'a' FROM t@{FORCE_ZIGZAG="",IGNORE_FOREIGN_KEYS}
+----
+at or near "}": syntax error: FORCE_ZIGZAG index name cannot be empty string
+DETAIL: source SQL:
+SELECT 'a' FROM t@{FORCE_ZIGZAG="",IGNORE_FOREIGN_KEYS}
+                                                      ^
+
+error
+SELECT 'a' FROM t@{FORCE_ZIGZAG=[],IGNORE_FOREIGN_KEYS}
+----
+at or near "]": syntax error
+DETAIL: source SQL:
+SELECT 'a' FROM t@{FORCE_ZIGZAG=[],IGNORE_FOREIGN_KEYS}
+                                 ^
+HINT: try \h <SOURCE>
+
+parse
+SELECT 'a' FROM t@{FORCE_ZIGZAG=a,IGNORE_FOREIGN_KEYS}
+----
+SELECT 'a' FROM t@{IGNORE_FOREIGN_KEYS,FORCE_ZIGZAG=a} -- normalized!
+SELECT ('a') FROM t@{IGNORE_FOREIGN_KEYS,FORCE_ZIGZAG=a} -- fully parenthesized
+SELECT '_' FROM t@{IGNORE_FOREIGN_KEYS,FORCE_ZIGZAG=a} -- literals removed
+SELECT 'a' FROM _@{IGNORE_FOREIGN_KEYS,FORCE_ZIGZAG=_} -- identifiers removed
+
+parse
+SELECT 'a' FROM t@{FORCE_ZIGZAG=a,FORCE_ZIGZAG=b,IGNORE_FOREIGN_KEYS}
+----
+SELECT 'a' FROM t@{IGNORE_FOREIGN_KEYS,FORCE_ZIGZAG=a,FORCE_ZIGZAG=b} -- normalized!
+SELECT ('a') FROM t@{IGNORE_FOREIGN_KEYS,FORCE_ZIGZAG=a,FORCE_ZIGZAG=b} -- fully parenthesized
+SELECT '_' FROM t@{IGNORE_FOREIGN_KEYS,FORCE_ZIGZAG=a,FORCE_ZIGZAG=b} -- literals removed
+SELECT 'a' FROM _@{IGNORE_FOREIGN_KEYS,FORCE_ZIGZAG=_,FORCE_ZIGZAG=_} -- identifiers removed
+
+error
+SELECT * FROM a@{FORCE_ZIGZAG=} WHERE a = 3 AND b = 7
+----
+at or near "}": syntax error
+DETAIL: source SQL:
+SELECT * FROM a@{FORCE_ZIGZAG=} WHERE a = 3 AND b = 7
+                              ^
+HINT: try \h <SOURCE>
+
+error
+SELECT * FROM a@{FORCE_ZIGZAG=foo,bar} WHERE a = 3 AND b = 7
+----
+at or near "bar": syntax error
+DETAIL: source SQL:
+SELECT * FROM a@{FORCE_ZIGZAG=foo,bar} WHERE a = 3 AND b = 7
+                                  ^
+HINT: try \h <SOURCE>
+
+
 error
 SELECT a FROM foo@{ASC}
 ----

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -55,7 +55,7 @@ import (
 //
 // To see how this query would be executed, consider the equivalent query:
 //
-// SELECT t1.* FROM abcd@c_idx AS t1 JOIN abcd@d_idx ON t1.a = t2.a AND
+// SELECT t1.* FROM abcd@c_idx AS t1 JOIN abcd@d_idx AS t2 ON t1.a = t2.a AND
 // t1.b = t2.b WHERE t1.c = 2 AND t2.d = 3;
 //
 // A zigzag joiner takes 2 sides as input. In the example above, the join would

--- a/pkg/sql/sem/tree/select.go
+++ b/pkg/sql/sem/tree/select.go
@@ -270,6 +270,8 @@ type IndexID uint32
 //  - NO_INDEX_JOIN
 //  - NO_ZIGZAG_JOIN
 //  - IGNORE_FOREIGN_KEYS
+//  - FORCE_ZIGZAG
+//  - FORCE_ZIGZAG=<index_name|index_id>*
 // It is used optionally after a table name in SELECT statements.
 type IndexFlags struct {
 	Index   UnrestrictedName
@@ -288,6 +290,14 @@ type IndexFlags struct {
 	// IgnoreUniqueWithoutIndexKeys disables optimizations based on unique without
 	// index constraints.
 	IgnoreUniqueWithoutIndexKeys bool
+	// Zigzag hinting fields are distinct:
+	// ForceZigzag means we saw a TABLE@{FORCE_ZIGZAG}
+	// ZigzagIndexes means we saw TABLE@{FORCE_ZIGZAG=name}
+	// ZigzagIndexIDs means we saw TABLE@{FORCE_ZIGZAG=[ID]}
+	// The only allowable combinations are when a valid id and name are combined.
+	ForceZigzag    bool
+	ZigzagIndexes  []UnrestrictedName
+	ZigzagIndexIDs []IndexID
 }
 
 // ForceIndex returns true if a forced index was specified, either using a name
@@ -333,6 +343,29 @@ func (ih *IndexFlags) CombineWith(other *IndexFlags) error {
 		result.IndexID = other.IndexID
 	}
 
+	if other.ForceZigzag {
+		if ih.ForceZigzag {
+			return errors.New("FORCE_ZIGZAG specified multiple times")
+		}
+		result.ForceZigzag = true
+	}
+
+	// We can have N zigzag indexes (in theory, we only support 2 now).
+	if len(other.ZigzagIndexes) > 0 {
+		if result.ForceZigzag {
+			return errors.New("FORCE_ZIGZAG hints not distinct")
+		}
+		result.ZigzagIndexes = append(result.ZigzagIndexes, other.ZigzagIndexes...)
+	}
+
+	// We can have N zigzag indexes (in theory, we only support 2 now).
+	if len(other.ZigzagIndexIDs) > 0 {
+		if result.ForceZigzag {
+			return errors.New("FORCE_ZIGZAG hints not distinct")
+		}
+		result.ZigzagIndexIDs = append(result.ZigzagIndexIDs, other.ZigzagIndexIDs...)
+	}
+
 	// We only set at the end to avoid a partially changed structure in one of the
 	// error cases above.
 	*ih = result
@@ -349,6 +382,21 @@ func (ih *IndexFlags) Check() error {
 	if ih.Direction != 0 && !ih.ForceIndex() {
 		return errors.New("ASC/DESC must be specified in conjunction with an index")
 	}
+	if ih.zigzagForced() && ih.NoIndexJoin {
+		return errors.New("FORCE_ZIGZAG cannot be specified in conjunction with NO_INDEX_JOIN")
+	}
+	if ih.zigzagForced() && ih.ForceIndex() {
+		return errors.New("FORCE_ZIGZAG cannot be specified in conjunction with FORCE_INDEX")
+	}
+	if ih.zigzagForced() && ih.NoZigzagJoin {
+		return errors.New("FORCE_ZIGZAG cannot be specified in conjunction with NO_ZIGZAG_JOIN")
+	}
+	for _, name := range ih.ZigzagIndexes {
+		if len(string(name)) == 0 {
+			return errors.New("FORCE_ZIGZAG index name cannot be empty string")
+		}
+	}
+
 	return nil
 }
 
@@ -356,7 +404,7 @@ func (ih *IndexFlags) Check() error {
 func (ih *IndexFlags) Format(ctx *FmtCtx) {
 	ctx.WriteByte('@')
 	if !ih.NoIndexJoin && !ih.NoZigzagJoin && !ih.IgnoreForeignKeys &&
-		!ih.IgnoreUniqueWithoutIndexKeys && ih.Direction == 0 {
+		!ih.IgnoreUniqueWithoutIndexKeys && ih.Direction == 0 && !ih.zigzagForced() {
 		if ih.Index != "" {
 			ctx.FormatNode(&ih.Index)
 		} else {
@@ -400,8 +448,37 @@ func (ih *IndexFlags) Format(ctx *FmtCtx) {
 			sep()
 			ctx.WriteString("IGNORE_UNIQUE_WITHOUT_INDEX_KEYS")
 		}
+
+		if ih.ForceZigzag || len(ih.ZigzagIndexes) > 0 || len(ih.ZigzagIndexIDs) > 0 {
+			sep()
+			if ih.ForceZigzag {
+				ctx.WriteString("FORCE_ZIGZAG")
+			} else {
+				needSep := false
+				for _, name := range ih.ZigzagIndexes {
+					if needSep {
+						sep()
+					}
+					ctx.WriteString("FORCE_ZIGZAG=")
+					ctx.FormatNode(&name)
+					needSep = true
+				}
+				for _, id := range ih.ZigzagIndexIDs {
+					if needSep {
+						sep()
+					}
+					ctx.WriteString("FORCE_ZIGZAG=")
+					ctx.Printf("[%d]", id)
+					needSep = true
+				}
+			}
+		}
 		ctx.WriteString("}")
 	}
+}
+
+func (ih *IndexFlags) zigzagForced() bool {
+	return ih.ForceZigzag || len(ih.ZigzagIndexes) > 0 || len(ih.ZigzagIndexIDs) > 0
 }
 
 // AliasedTableExpr represents a table expression coupled with an optional


### PR DESCRIPTION
Fixes #35814

Enable table@{FORCE_ZIGZAG} and table@{FORCE_ZIGZAG=index} hints to lower the cost
of zigzag plans to that they will be preferred over other plans.

Note that this is a breaking change, if customer has an index called
FORCE_ZIGZAG and is hinting with table@{FORCE_ZIGZAG} that will no longer do what
it did before. Not sure what the ramifications of that are.

Release note (sql change): Extend index scan hint to allow zigzag joins to be preferred.
