### PR TITLE
builtins: mark statement_timestamp as volatile

### DIFF
--- a/docs/RFCS/20210519_bounded_staleness_reads.md
+++ b/docs/RFCS/20210519_bounded_staleness_reads.md
@@ -30,7 +30,7 @@ Bounded staleness queries are limited in use to single-statement read-only
 queries, and only a subset of read-only queries at that. They will be accessed
 similarly to exact bounded staleness reads - through a pair of new functions
 that can be passed to an `AS OF SYSTEM TIME` clause:
-- `SELECT ... FROM ... AS OF SYSTEM TIME with_min_timestamp(TIMESTAMP)`
+- `SELECT ... FROM ... AS OF SYSTEM TIME with_min_timestamp(TIMESTAMPTZ)`
 - `SELECT ... FROM ... AS OF SYSTEM TIME with_max_staleness(INTERVAL)`
 
 The approach discussed in this RFC has a prototype in
@@ -71,10 +71,10 @@ locally without blocking is used.
 
 Bounded staleness reads will be exposed through a pair of new functions that can
 be passed to an `AS OF SYSTEM TIME` clause:
-- `SELECT ... FROM ... AS OF SYSTEM TIME with_min_timestamp(TIMESTAMP)`
+- `SELECT ... FROM ... AS OF SYSTEM TIME with_min_timestamp(TIMESTAMPTZ)`
 - `SELECT ... FROM ... AS OF SYSTEM TIME with_max_staleness(INTERVAL)`
 
-`with_min_timestamp(TIMESTAMP)` defines a minimum timestamp to perform the
+`with_min_timestamp(TIMESTAMPTZ)` defines a minimum timestamp to perform the
 bounded staleness read at. The actual timestamp of the read may be equal to or
 later than the provided timestamp, but can not be before the provided timestamp.
 This is useful to request a read from nearby followers, if possible, while
@@ -452,8 +452,8 @@ read.
 ### SQL Parser
 
 The change will introduce two new SQL builtin functions: 
-- `with_min_timestamp(TIMESTAMP) -> TIMESTAMP`
-- `with_max_staleness(INTERVAL) -> INTERVAL`
+- `with_min_timestamp(TIMESTAMPTZ) -> TIMESTAMPTZ
+- `with_max_staleness(INTERVAL) -> TIMESTAMPTZ`
 
 These functions will need special casing in `tree.EvalAsOfTimestamp`.
 

--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -529,6 +529,16 @@ has no relationship with the commit order of concurrent transactions.</p>
 and which stays constant throughout the transaction. This timestamp
 has no relationship with the commit order of concurrent transactions.</p>
 <p>This function is the preferred overload and will be evaluated by default.</p>
+</span></td></tr>
+<tr><td><a name="with_max_staleness"></a><code>with_max_staleness(max_staleness: <a href="interval.html">interval</a>) &rarr; <a href="timestamp.html">timestamptz</a></code></td><td><span class="funcdesc"><p>When used in the AS OF SYSTEM TIME clause of an single-statement,
+read-only transaction, CockroachDB chooses the newest timestamp within the staleness
+bound that allows execution of the reads at the closest available replica without blocking.</p>
+<p>Note this function requires an enterprise license on a CCL distribution.</p>
+</span></td></tr>
+<tr><td><a name="with_min_timestamp"></a><code>with_min_timestamp(min_timestamp: <a href="timestamp.html">timestamptz</a>) &rarr; <a href="timestamp.html">timestamptz</a></code></td><td><span class="funcdesc"><p>When used in the AS OF SYSTEM TIME clause of an single-statement,
+read-only transaction, CockroachDB chooses the newest timestamp before the min_timestamp
+that allows execution of the reads at the closest available replica without blocking.</p>
+<p>Note this function requires an enterprise license on a CCL distribution.</p>
 </span></td></tr></tbody>
 </table>
 

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -18,6 +18,7 @@ ALL_TESTS = [
     "//pkg/ccl/changefeedccl:changefeedccl_test",
     "//pkg/ccl/cliccl:cliccl_test",
     "//pkg/ccl/importccl:importccl_test",
+    "//pkg/ccl/kvccl/kvboundedstalenessccl:kvboundedstalenessccl_test",
     "//pkg/ccl/kvccl/kvfollowerreadsccl:kvfollowerreadsccl_test",
     "//pkg/ccl/kvccl/kvtenantccl:kvtenantccl_test",
     "//pkg/ccl/logictestccl:logictestccl_test",

--- a/pkg/ccl/kvccl/BUILD.bazel
+++ b/pkg/ccl/kvccl/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/ccl/kvccl",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/ccl/kvccl/kvboundedstalenessccl",
         "//pkg/ccl/kvccl/kvfollowerreadsccl",
         "//pkg/ccl/kvccl/kvtenantccl",
     ],

--- a/pkg/ccl/kvccl/kvboundedstalenessccl/BUILD.bazel
+++ b/pkg/ccl/kvccl/kvboundedstalenessccl/BUILD.bazel
@@ -1,0 +1,39 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "kvboundedstalenessccl",
+    srcs = ["kvboundedstalenessccl.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/ccl/kvccl/kvboundedstalenessccl",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/ccl/utilccl",
+        "//pkg/sql",
+        "//pkg/sql/pgwire/pgcode",
+        "//pkg/sql/pgwire/pgerror",
+        "//pkg/sql/sem/builtins",
+        "//pkg/sql/sem/tree",
+        "//pkg/util/duration",
+    ],
+)
+
+go_test(
+    name = "kvboundedstalenessccl_test",
+    srcs = [
+        "kvboundedstalenessccl_test.go",
+        "main_test.go",
+    ],
+    embed = [":kvboundedstalenessccl"],
+    deps = [
+        "//pkg/base",
+        "//pkg/ccl/utilccl",
+        "//pkg/security",
+        "//pkg/security/securitytest",
+        "//pkg/server",
+        "//pkg/testutils/serverutils",
+        "//pkg/testutils/testcluster",
+        "//pkg/util/leaktest",
+        "//pkg/util/log",
+        "//pkg/util/randutil",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/ccl/kvccl/kvboundedstalenessccl/kvboundedstalenessccl.go
+++ b/pkg/ccl/kvccl/kvboundedstalenessccl/kvboundedstalenessccl.go
@@ -1,0 +1,64 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package kvboundedstalenessccl
+
+import (
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/duration"
+)
+
+func checkEnterpriseEnabled(ctx *tree.EvalContext) error {
+	st := ctx.Settings
+	return utilccl.CheckEnterpriseEnabled(
+		st,
+		ctx.ClusterID,
+		sql.ClusterOrganization.Get(&st.SV),
+		"bounded staleness",
+	)
+}
+
+func evalMaxStaleness(ctx *tree.EvalContext, d duration.Duration) (time.Time, error) {
+	if err := checkEnterpriseEnabled(ctx); err != nil {
+		return time.Time{}, err
+	}
+	if d.Compare(duration.FromInt64(0)) < 0 {
+		return time.Time{}, pgerror.Newf(
+			pgcode.InvalidParameterValue,
+			"interval duration for %s must be greater or equal to 0",
+			tree.WithMaxStalenessFunctionName,
+		)
+	}
+	return duration.Add(ctx.GetTxnTimestamp(time.Microsecond).Time, d.Mul(-1)), nil
+}
+
+func evalMinTimestamp(ctx *tree.EvalContext, t time.Time) (time.Time, error) {
+	if err := checkEnterpriseEnabled(ctx); err != nil {
+		return time.Time{}, err
+	}
+	if t.After(ctx.GetTxnTimestamp(time.Microsecond).Time) {
+		return time.Time{}, pgerror.Newf(
+			pgcode.InvalidParameterValue,
+			"timestamp for %s must be less than or equal to now()",
+			tree.WithMinTimestampFunctionName,
+		)
+	}
+	return t, nil
+}
+
+func init() {
+	builtins.WithMinTimestamp = evalMinTimestamp
+	builtins.WithMaxStaleness = evalMaxStaleness
+}

--- a/pkg/ccl/kvccl/kvboundedstalenessccl/kvboundedstalenessccl_test.go
+++ b/pkg/ccl/kvccl/kvboundedstalenessccl/kvboundedstalenessccl_test.go
@@ -1,0 +1,43 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package kvboundedstalenessccl_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNoEnterpriseLicense(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	defer utilccl.TestingDisableEnterprise()()
+
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
+	defer tc.Stopper().Stop(ctx)
+
+	for _, q := range []string{
+		`SELECT with_max_staleness('10s')`,
+		`SELECT with_min_timestamp(now())`,
+	} {
+		t.Run(q, func(t *testing.T) {
+			_, err := tc.Conns[0].QueryContext(ctx, q)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "use of bounded staleness requires an enterprise license")
+		})
+	}
+}

--- a/pkg/ccl/kvccl/kvboundedstalenessccl/main_test.go
+++ b/pkg/ccl/kvccl/kvboundedstalenessccl/main_test.go
@@ -1,0 +1,31 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package kvboundedstalenessccl
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+//go:generate ../../../util/leaktest/add-leaktest.sh *_test.go
+
+func TestMain(m *testing.M) {
+	security.SetAssetLoader(securitytest.EmbeddedAssets)
+	randutil.SeedForTests()
+	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
+	os.Exit(m.Run())
+}

--- a/pkg/ccl/kvccl/kvccl.go
+++ b/pkg/ccl/kvccl/kvccl.go
@@ -10,6 +10,7 @@ package kvccl
 
 import (
 	// ccl init hooks.
+	_ "github.com/cockroachdb/cockroach/pkg/ccl/kvccl/kvboundedstalenessccl"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/kvccl/kvfollowerreadsccl"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/kvccl/kvtenantccl"
 )

--- a/pkg/ccl/kvccl/kvfollowerreadsccl/BUILD.bazel
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "kvfollowerreadsccl",
-    srcs = ["followerreads.go"],
+    srcs = [
+        "boundedstaleness.go",
+        "followerreads.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/ccl/kvccl/kvfollowerreadsccl",
     visibility = ["//visibility:public"],
     deps = [
@@ -16,10 +19,15 @@ go_library(
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/sql",
+        "//pkg/sql/pgwire/pgcode",
+        "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/physicalplan/replicaoracle",
         "//pkg/sql/sem/builtins",
+        "//pkg/sql/sem/tree",
+        "//pkg/util/duration",
         "//pkg/util/hlc",
         "//pkg/util/uuid",
+        "@com_github_cockroachdb_errors//:errors",
     ],
 )
 
@@ -27,6 +35,7 @@ go_test(
     name = "kvfollowerreadsccl_test",
     size = "medium",
     srcs = [
+        "boundedstaleness_test.go",
         "followerreads_test.go",
         "main_test.go",
     ],

--- a/pkg/ccl/kvccl/kvfollowerreadsccl/boundedstaleness.go
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/boundedstaleness.go
@@ -1,0 +1,64 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package kvfollowerreadsccl
+
+import (
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/duration"
+)
+
+func checkEnterpriseEnabledForBoundedStaleness(ctx *tree.EvalContext) error {
+	st := ctx.Settings
+	return utilccl.CheckEnterpriseEnabled(
+		st,
+		ctx.ClusterID,
+		sql.ClusterOrganization.Get(&st.SV),
+		"bounded staleness",
+	)
+}
+
+func evalMaxStaleness(ctx *tree.EvalContext, d duration.Duration) (time.Time, error) {
+	if err := checkEnterpriseEnabledForBoundedStaleness(ctx); err != nil {
+		return time.Time{}, err
+	}
+	if d.Compare(duration.FromInt64(0)) < 0 {
+		return time.Time{}, pgerror.Newf(
+			pgcode.InvalidParameterValue,
+			"interval duration for %s must be greater or equal to 0",
+			tree.WithMaxStalenessFunctionName,
+		)
+	}
+	return duration.Add(ctx.GetTxnTimestamp(time.Microsecond).Time, d.Mul(-1)), nil
+}
+
+func evalMinTimestamp(ctx *tree.EvalContext, t time.Time) (time.Time, error) {
+	if err := checkEnterpriseEnabledForBoundedStaleness(ctx); err != nil {
+		return time.Time{}, err
+	}
+	if t.After(ctx.GetTxnTimestamp(time.Microsecond).Time) {
+		return time.Time{}, pgerror.Newf(
+			pgcode.InvalidParameterValue,
+			"timestamp for %s must be less than or equal to now()",
+			tree.WithMinTimestampFunctionName,
+		)
+	}
+	return t, nil
+}
+
+func init() {
+	builtins.WithMinTimestamp = evalMinTimestamp
+	builtins.WithMaxStaleness = evalMaxStaleness
+}

--- a/pkg/ccl/kvccl/kvfollowerreadsccl/boundedstaleness_test.go
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/boundedstaleness_test.go
@@ -1,0 +1,57 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package kvfollowerreadsccl_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBoundedStalenessEnterpriseLicense(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
+	defer tc.Stopper().Stop(ctx)
+
+	queries := []string{
+		`SELECT with_max_staleness('10s')`,
+		`SELECT with_min_timestamp(now())`,
+	}
+
+	defer utilccl.TestingDisableEnterprise()()
+	t.Run("disabled", func(t *testing.T) {
+		for _, q := range queries {
+			t.Run(q, func(t *testing.T) {
+				_, err := tc.Conns[0].QueryContext(ctx, q)
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "use of bounded staleness requires an enterprise license")
+			})
+		}
+	})
+
+	t.Run("enabled", func(t *testing.T) {
+		defer utilccl.TestingEnableEnterprise()()
+		for _, q := range queries {
+			t.Run(q, func(t *testing.T) {
+				r, err := tc.Conns[0].QueryContext(ctx, q)
+				require.NoError(t, err)
+				require.NoError(t, r.Close())
+			})
+		}
+	})
+}

--- a/pkg/ccl/kvccl/kvfollowerreadsccl/boundedstaleness_test.go
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/boundedstaleness_test.go
@@ -30,7 +30,7 @@ func TestBoundedStalenessEnterpriseLicense(t *testing.T) {
 
 	queries := []string{
 		`SELECT with_max_staleness('10s')`,
-		`SELECT with_min_timestamp(now())`,
+		`SELECT with_min_timestamp(statement_timestamp())`,
 	}
 
 	defer utilccl.TestingDisableEnterprise()()

--- a/pkg/ccl/logictestccl/testdata/logic_test/bounded_staleness
+++ b/pkg/ccl/logictestccl/testdata/logic_test/bounded_staleness
@@ -1,0 +1,20 @@
+query B
+SELECT with_min_timestamp(now()) = now()
+----
+true
+
+query B
+SELECT with_min_timestamp(now() - '5s'::interval) = now() - '5s'::interval
+----
+true
+
+statement error timestamp for with_min_timestamp must be less than or equal to now\(\)
+SELECT with_min_timestamp(now() + '5s'::interval) = now()
+
+query B
+SELECT with_max_staleness('10s') = now() - '10s'::interval
+----
+true
+
+statement error interval duration for with_max_staleness must be greater or equal to 0
+SELECT with_max_staleness(-'1s')

--- a/pkg/ccl/logictestccl/testdata/logic_test/bounded_staleness
+++ b/pkg/ccl/logictestccl/testdata/logic_test/bounded_staleness
@@ -1,18 +1,18 @@
 query B
-SELECT with_min_timestamp(now()) = now()
+SELECT with_min_timestamp(statement_timestamp()) = statement_timestamp()
 ----
 true
 
 query B
-SELECT with_min_timestamp(now() - '5s'::interval) = now() - '5s'::interval
+SELECT with_min_timestamp(statement_timestamp() - '5s'::interval) = statement_timestamp() - '5s'::interval
 ----
 true
 
-statement error timestamp for with_min_timestamp must be less than or equal to now\(\)
-SELECT with_min_timestamp(now() + '5s'::interval) = now()
+statement error timestamp for with_min_timestamp must be less than or equal to statement_timestamp\(\)
+SELECT with_min_timestamp(statement_timestamp() + '5s'::interval) = statement_timestamp()
 
 query B
-SELECT with_max_staleness('10s') = now() - '10s'::interval
+SELECT with_max_staleness('10s') = statement_timestamp() - '10s'::interval
 ----
 true
 

--- a/pkg/sql/logictest/testdata/logic_test/bounded_staleness
+++ b/pkg/sql/logictest/testdata/logic_test/bounded_staleness
@@ -1,0 +1,10 @@
+# LogicTest: !3node-tenant
+
+statement error pgcode XXC01 with_min_timestamp can only be used with a CCL distribution
+SELECT with_min_timestamp('2020-01-15 15:16:17')
+
+statement error pgcode XXC01 with_min_timestamp can only be used with a CCL distribution
+SELECT with_min_timestamp(now())
+
+statement error pgcode XXC01 with_max_staleness can only be used with a CCL distribution
+SELECT with_max_staleness('1s'::interval)

--- a/pkg/sql/logictest/testdata/logic_test/bounded_staleness
+++ b/pkg/sql/logictest/testdata/logic_test/bounded_staleness
@@ -4,7 +4,7 @@ statement error pgcode XXC01 with_min_timestamp can only be used with a CCL dist
 SELECT with_min_timestamp('2020-01-15 15:16:17')
 
 statement error pgcode XXC01 with_min_timestamp can only be used with a CCL distribution
-SELECT with_min_timestamp(now())
+SELECT with_min_timestamp(statement_timestamp())
 
 statement error pgcode XXC01 with_max_staleness can only be used with a CCL distribution
 SELECT with_max_staleness('1s'::interval)

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -2415,7 +2415,7 @@ months and years, use the timestamptz subtraction operator.`,
 				return tree.MakeDTimestampTZ(ctx.GetStmtTimestamp(), time.Microsecond)
 			},
 			Info:       "Returns the start time of the current statement.",
-			Volatility: tree.VolatilityStable,
+			Volatility: tree.VolatilityVolatile,
 		},
 		tree.Overload{
 			Types:      tree.ArgTypes{},
@@ -2424,7 +2424,7 @@ months and years, use the timestamptz subtraction operator.`,
 				return tree.MakeDTimestamp(ctx.GetStmtTimestamp(), time.Microsecond)
 			},
 			Info:       "Returns the start time of the current statement.",
-			Volatility: tree.VolatilityStable,
+			Volatility: tree.VolatilityVolatile,
 		},
 	),
 

--- a/pkg/sql/sem/tree/as_of.go
+++ b/pkg/sql/sem/tree/as_of.go
@@ -36,6 +36,14 @@ const FollowerReadTimestampFunctionName = "follower_read_timestamp"
 // "experimental_" function, which we keep for backwards compatibility.
 const FollowerReadTimestampExperimentalFunctionName = "experimental_follower_read_timestamp"
 
+// WithMinTimestampFunctionName is the name of the function that can be used
+// with AOST clauses to generate a bounded staleness at a fixed timestamp.
+const WithMinTimestampFunctionName = "with_min_timestamp"
+
+// WithMaxStalenessFunctionName is the name of the function that can be used
+// with AOST clauses to generate a bounded staleness at a maximum interval.
+const WithMaxStalenessFunctionName = "with_max_staleness"
+
 var errInvalidExprForAsOf = errors.Errorf("AS OF SYSTEM TIME: only constant expressions or " +
 	FollowerReadTimestampFunctionName + " are allowed")
 


### PR DESCRIPTION
Release note (sql change): Mark statement_timestamp as volatile instead
of stable. This is because statement_timestamp can change between
transaction restarts, but the optimizer already normalized the values to
the old statement_timestamp.