### PR TITLE
vendor: bump Pebble to 8c3bd06debb5

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -628,8 +628,8 @@ def go_deps():
         name = "com_github_cockroachdb_pebble",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/cockroachdb/pebble",
-        sum = "h1:5qIOzg4DH0pJqNFV5KyqtfIJalHGorKbsMQlog8sO1g=",
-        version = "v0.0.0-20210712141052-2215b8d4c8ab",
+        sum = "h1:Igd6YmtOZ77EgLAIaE9+mHl7+sAKaZ5m4iMI0Dz/J2A=",
+        version = "v0.0.0-20210719141320-8c3bd06debb5",
     )
 
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f
-	github.com/cockroachdb/pebble v0.0.0-20210712141052-2215b8d4c8ab
+	github.com/cockroachdb/pebble v0.0.0-20210719141320-8c3bd06debb5
 	github.com/cockroachdb/redact v1.1.3
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2

--- a/go.sum
+++ b/go.sum
@@ -263,8 +263,8 @@ github.com/cockroachdb/gostdlib v1.13.0 h1:TzSEPYgkKDNei3gbLc0rrHu4iHyBp7/+NxPOF
 github.com/cockroachdb/gostdlib v1.13.0/go.mod h1:eXX95p9QDrYwJfJ6AgeN9QnRa/lqqid9LAzWz/l5OgA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f h1:o/kfcElHqOiXqcou5a3rIlMc7oJbMQkeLk0VQJ7zgqY=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/cockroachdb/pebble v0.0.0-20210712141052-2215b8d4c8ab h1:5qIOzg4DH0pJqNFV5KyqtfIJalHGorKbsMQlog8sO1g=
-github.com/cockroachdb/pebble v0.0.0-20210712141052-2215b8d4c8ab/go.mod h1:JXfQr3d+XO4bL1pxGwKKo09xylQSdZ/mpZ9b2wfVcPs=
+github.com/cockroachdb/pebble v0.0.0-20210719141320-8c3bd06debb5 h1:Igd6YmtOZ77EgLAIaE9+mHl7+sAKaZ5m4iMI0Dz/J2A=
+github.com/cockroachdb/pebble v0.0.0-20210719141320-8c3bd06debb5/go.mod h1:JXfQr3d+XO4bL1pxGwKKo09xylQSdZ/mpZ9b2wfVcPs=
 github.com/cockroachdb/pq v0.0.0-20210517091544-990dd3347596 h1:xTc0ViFhuelzQZAYQOxMR2J5QDO9/C+0L0fkPXIcoMI=
 github.com/cockroachdb/pq v0.0.0-20210517091544-990dd3347596/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/cockroachdb/redact v1.0.8/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=


### PR DESCRIPTION
```
8c3bd06d vfs: export ErrUnsupported
b8b89851 tool: add manifest summarize command
8ac9797e internal/manifest: Move Atomic field in the FileMetaData struct to the top.
b8f537d8 compaction: remove nonzero-seqnum splitting logic
5c39ff26 benchmarks: infrastructure to set up file system benchmarks
```

Release note: None