### PR TITLE
release-21.1: sqlsmith: avoid reg* casts in postgres mode

### DIFF
--- a/pkg/cmd/cmpconn/compare.go
+++ b/pkg/cmd/cmpconn/compare.go
@@ -108,7 +108,11 @@ var (
 					// Postgres sometimes adds spaces to the end of a string.
 					t = strings.TrimSpace(t)
 					v = strings.Replace(t, "T00:00:00+00:00", "T00:00:00Z", 1)
-					v = strings.Replace(t, ":00+00:00", ":00", 1)
+
+					// Postgres only shows the minutes offset of a timezone if it is
+					// non-zero.
+					// See https://github.com/cockroachdb/cockroach/issues/41563
+					v = strings.Replace(t, ":00+00:00", ":00+00", 1)
 				case *pgtype.Numeric:
 					if t.Status == pgtype.Present {
 						v = apd.NewWithBigInt(t.Int, t.Exp)

--- a/pkg/cmd/roachtest/tpcdsvec.go
+++ b/pkg/cmd/roachtest/tpcdsvec.go
@@ -100,7 +100,7 @@ func registerTPCDSVec(r *testRegistry) {
 			// A sanity check that we have different values of 'vectorize'
 			// session variable on two connections and that the comparator will
 			// emit an error because of that difference.
-			if err := cmpconn.CompareConns(
+			if _, err := cmpconn.CompareConns(
 				ctx, timeout, conns, "", "SHOW vectorize;", false, /* ignoreSQLErrors */
 			); err == nil {
 				t.Fatal("unexpectedly SHOW vectorize didn't trigger an error on comparison")
@@ -133,7 +133,7 @@ func registerTPCDSVec(r *testRegistry) {
 				// around issues with cancellation.
 				conns, cleanup := openNewConnections()
 				start := timeutil.Now()
-				if err := cmpconn.CompareConns(
+				if _, err := cmpconn.CompareConns(
 					ctx, 3*timeout, conns, "", query, false, /* ignoreSQLErrors */
 				); err != nil {
 					t.Status(fmt.Sprintf("encountered an error: %s\n", err))

--- a/pkg/cmd/smithcmp/main.go
+++ b/pkg/cmd/smithcmp/main.go
@@ -165,9 +165,10 @@ func main() {
 	var prep, exec string
 	ctx := context.Background()
 	done := time.After(timeout)
-	for i := 0; true; i++ {
+	for i, ignoredErrCount := 0, 0; true; i++ {
 		select {
 		case <-done:
+			fmt.Printf("executed query count: %d\nignored error count: %d\n", i, ignoredErrCount)
 			return
 		default:
 		}
@@ -198,11 +199,13 @@ func main() {
 			fmt.Println(exec)
 		}
 		if compare {
-			if err := cmpconn.CompareConns(
+			if ignoredErr, err := cmpconn.CompareConns(
 				ctx, stmtTimeout, conns, prep, exec, true, /* ignoreSQLErrors */
 			); err != nil {
 				fmt.Printf("prep:\n%s;\nexec:\n%s;\nERR: %s\n\n", prep, exec, err)
 				os.Exit(1)
+			} else if ignoredErr {
+				ignoredErrCount++
 			}
 		} else {
 			for _, conn := range conns {

--- a/pkg/compose/compare/compare/compare_test.go
+++ b/pkg/compose/compare/compare/compare_test.go
@@ -157,16 +157,20 @@ func TestCompare(t *testing.T) {
 				t.Fatal(err)
 			}
 
+			ignoredErrCount := 0
+			totalQueryCount := 0
 			until := time.After(*flagEach)
 			for {
 				select {
 				case <-until:
-					t.Logf("done with test: %s", confName)
+					t.Logf("done with test. totalQueryCount=%d ignoredErrCount=%d test=%s",
+						totalQueryCount, ignoredErrCount, confName,
+					)
 					return
 				default:
 				}
 				query := smither.Generate()
-				if err := cmpconn.CompareConns(
+				if ignoredErr, err := cmpconn.CompareConns(
 					ctx, time.Second*30, conns, "" /* prep */, query, config.ignoreSQLErrors,
 				); err != nil {
 					path := filepath.Join(*flagArtifacts, confName+".log")
@@ -174,7 +178,10 @@ func TestCompare(t *testing.T) {
 						t.Log(err)
 					}
 					t.Fatal(err)
+				} else if ignoredErr {
+					ignoredErrCount++
 				}
+				totalQueryCount++
 				// Make sure we can still ping on a connection. If we can't we may have
 				// crashed something.
 				for name, conn := range conns {

--- a/pkg/compose/compare/docker-compose.yml
+++ b/pkg/compose/compare/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   postgres:
     image: postgis/postgis:13-3.1
     environment:
-      - POSTGRES_INITDB_ARGS=--locale=C
+      - POSTGRES_INITDB_ARGS=--locale=C --encoding=UTF8
       - POSTGRES_HOST_AUTH_METHOD=trust
   cockroach1:
     image: ubuntu:xenial-20170214


### PR DESCRIPTION
Backport 3/3 commits from #67718.

/cc @cockroachdb/release

Release justification: test only change

---

These casts are not deterministic, so cause flaky tests.

After adding this, I ran https://github.com/cockroachdb/cockroach/issues/56845 locally for 10 minutes
and it passed.

Release note: None
