### PR TITLE
bazel: build krb5 w/ Bazel

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,6 @@
-build --symlink_prefix=_bazel/ --ui_event_filters=-DEBUG --define gotags=bazel,crdb_test_off
+build --symlink_prefix=_bazel/ --ui_event_filters=-DEBUG --define gotags=bazel,crdb_test_off,gss
 test --config=test
-build:test --symlink_prefix=_bazel/ --define gotags=bazel,crdb_test --test_env=TZ=
+build:test --symlink_prefix=_bazel/ --define gotags=bazel,crdb_test,gss --test_env=TZ=
 query --ui_event_filters=-DEBUG
 
 try-import %workspace%/.bazelrc.user

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -12,7 +12,7 @@ load("@bazel_gazelle//:def.bzl", "gazelle")
 #
 # gazelle:prefix github.com/cockroachdb/cockroach
 # gazelle:build_file_name BUILD.bazel
-# gazelle:build_tags bazel,crdb_test,crdb_test_off
+# gazelle:build_tags bazel,crdb_test,crdb_test_off,gss
 
 # Enable protobuf generation.
 #
@@ -36,6 +36,7 @@ load("@bazel_gazelle//:def.bzl", "gazelle")
 # gazelle:resolve proto io/prometheus/client/metrics.proto @com_github_prometheus_client_model//io/prometheus/client:client_proto
 # gazelle:resolve proto go io/prometheus/client/metrics.proto @com_github_prometheus_client_model//go
 # gazelle:resolve go github.com/prometheus/client_model/go @com_github_prometheus_client_model//go
+# gazelle:resolve go github.com/cockroachdb/cockroach/pkg/ccl/gssapiccl @cockroach//pkg/ccl/gssapiccl
 # gazelle:resolve go github.com/cockroachdb/cockroach/pkg/cli_test @cockroach//pkg/cli:cli_test
 # gazelle:resolve go github.com/cockroachdb/cockroach/pkg/sql/colflow_test @cockroach//pkg/sql/colflow:colflow_test
 # gazelle:resolve go github.com/cockroachdb/cockroach/pkg/util/caller_test @cockroach//pkg/util/caller:caller_test
@@ -86,6 +87,7 @@ load("@bazel_gazelle//:def.bzl", "gazelle")
 # gazelle:exclude _bazel
 # gazelle:exclude c-deps/krb5
 # gazelle:exclude artifacts
+# gazelle:exclude pkg/ccl/gssapiccl
 # gazelle:exclude vendor
 # gazelle:exclude .vendor.tmp.*
 # gazelle:exclude **/zcgo_flags.go

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -167,7 +167,7 @@ c_deps()
 # aforementioned PRs.
 git_repository(
     name = "rules_foreign_cc",
-    commit = "a3b0e5eaa723259458f5c85285f58e46ae7f25a2",
+    commit = "67211f9083234f51ef1d9c21a791ee93bc538143",
     remote = "https://github.com/cockroachdb/rules_foreign_cc",
 )
 

--- a/c-deps/BUILD.bazel
+++ b/c-deps/BUILD.bazel
@@ -120,30 +120,35 @@ cmake(
 )
 
 # Define the build target for kerberos.
-#
-# TODO(irfansharif): Kerboros is not used for anything other than Linux.
-# The following has not been tested as yet.
 configure_make(
     name = "libkrb5",
     autoreconf = True,
+    autoreconf_directory = "src",
     configure_command = "src/configure",
-    configure_env_vars = {
-        "CPFLAGS": "",
-        "CXXFLAGS": "",
-    },
+    configure_in_place = True,
     configure_options = [
         "--enable-static",
         "--disable-shared",
-    ] + select({
-        "//conditions:default": ["AR=/usr/bin/ar"],
-    }),
+    ],
     lib_source = "@krb5//:all",
     make_commands = [
         "make",
         "mkdir -p libkrb5/lib",
-        "cp libkrb5/libgssapi_krb5.a libkrb5/lib",
+        "cp lib/libcom_err.a libkrb5/lib",
+        "cp lib/libgssapi_krb5.a libkrb5/lib",
+        "cp lib/libkrb5.a libkrb5/lib",
+        "cp lib/libkrb5support.a libkrb5/lib",
+        "cp lib/libk5crypto.a libkrb5/lib",
+        "mkdir -p libkrb5/include/gssapi",
+        "cp include/gssapi/gssapi.h libkrb5/include/gssapi",
     ],
-    out_static_libs = ["libgssapi_krb5.a"],
+    out_static_libs = [
+        "libgssapi_krb5.a",
+        "libkrb5.a",
+        "libkrb5support.a",
+        "libk5crypto.a",
+        "libcom_err.a",
+    ],
     visibility = ["//visibility:public"],
 )
 

--- a/c-deps/REPOSITORIES.bzl
+++ b/c-deps/REPOSITORIES.bzl
@@ -18,11 +18,6 @@ BUILD_JEMALLOC_CONTENT = """filegroup(name = "all", srcs = glob(["**"], exclude=
 # We do need to add native as new_local_repository is defined in Bazel core.
 def c_deps():
     native.new_local_repository(
-        name = "proj",
-        path = "c-deps/proj",
-        build_file_content = BUILD_ALL_CONTENT,
-    )
-    native.new_local_repository(
         name = "geos",
         path = "c-deps/geos",
         build_file_content = BUILD_ALL_CONTENT,
@@ -31,4 +26,14 @@ def c_deps():
         name = "jemalloc",
         path = "c-deps/jemalloc",
         build_file_content = BUILD_JEMALLOC_CONTENT,
+    )
+    native.new_local_repository(
+        name = "krb5",
+        path = "c-deps/krb5",
+        build_file_content = BUILD_ALL_CONTENT,
+    )
+    native.new_local_repository(
+        name = "proj",
+        path = "c-deps/proj",
+        build_file_content = BUILD_ALL_CONTENT,
     )

--- a/pkg/ccl/gssapiccl/BUILD.bazel
+++ b/pkg/ccl/gssapiccl/BUILD.bazel
@@ -1,12 +1,32 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+# keep
 go_library(
     name = "gssapiccl",
-    # keep
-    srcs = ["empty.go"],
+    srcs = select({
+        "@io_bazel_rules_go//go/platform:linux_amd64": ["gssapi.go"],
+        "//conditions:default": ["empty.go"],
+    }),
+    cdeps = select({
+        "@io_bazel_rules_go//go/platform:linux_amd64": ["@cockroach//c-deps:libkrb5"],
+        "//conditions:default": [],
+    }),
     cgo = True,
-    clinkopts = [],  # keep
-    cppopts = [],  # keep
+    clinkopts = select({
+        "@io_bazel_rules_go//go/platform:linux_amd64": ["-ldl -lresolv"],
+        "//conditions:default": [],
+    }),
     importpath = "github.com/cockroachdb/cockroach/pkg/ccl/gssapiccl",
     visibility = ["//visibility:public"],
+    deps = select({
+        "@io_bazel_rules_go//go/platform:linux_amd64": [
+            "//pkg/ccl/utilccl",
+            "//pkg/security",
+            "//pkg/sql",
+            "//pkg/sql/pgwire",
+            "//pkg/sql/pgwire/hba",
+            "@com_github_cockroachdb_errors//:errors",
+        ],
+        "//conditions:default": [],
+    }),
 )


### PR DESCRIPTION
The `autoreconf` call actually happens within the `src` sub-directory of
`krb5`, so I had to hack support for this into `rules_foreign_cc`.

Closes #56063.

Release note: None