### PR TITLE
rowexec: improve memory accounting in joinReader

### DIFF
--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -949,6 +949,20 @@ func NewLimitedMonitor(
 	return limitedMon
 }
 
+// NewLimitedMonitorNoDiskSpill is a utility function used by processors to
+// create a new limited memory monitor with the given name and start it. The
+// returned monitor must be closed. The limit is determined by
+// SessionData.WorkMemLimit (stored inside of the flowCtx) but overridden to
+// ServerConfig.TestingKnobs.MemoryLimitBytes if that knob is set.
+// ServerConfig.TestingKnobs.ForceDiskSpill is ignored by this function.
+func NewLimitedMonitorNoDiskSpill(
+	ctx context.Context, parent *mon.BytesMonitor, flowCtx *FlowCtx, name string,
+) *mon.BytesMonitor {
+	limitedMon := mon.NewMonitorInheritWithLimit(name, GetWorkMemLimitNoDiskSpill(flowCtx), parent)
+	limitedMon.Start(ctx, parent, mon.BoundAccount{})
+	return limitedMon
+}
+
 // NewLimitedMonitorNoFlowCtx is the same as NewLimitedMonitor and should be
 // used when the caller doesn't have an access to *FlowCtx.
 func NewLimitedMonitorNoFlowCtx(

--- a/pkg/sql/execinfra/server_config.go
+++ b/pkg/sql/execinfra/server_config.go
@@ -267,7 +267,16 @@ func GetWorkMemLimit(flowCtx *FlowCtx) int64 {
 	}
 	if flowCtx.Cfg.TestingKnobs.ForceDiskSpill {
 		return 1
-	} else if flowCtx.Cfg.TestingKnobs.MemoryLimitBytes != 0 {
+	}
+	return GetWorkMemLimitNoDiskSpill(flowCtx)
+}
+
+// GetWorkMemLimitNoDiskSpill returns the number of bytes determining the amount
+// of RAM available to a single processor or operator. This function should be
+// used instead of GetWorkMemLimit if the processor cannot spill to disk,
+// since ServerConfig.TestingKnobs.ForceDiskSpill is ignored by this function.
+func GetWorkMemLimitNoDiskSpill(flowCtx *FlowCtx) int64 {
+	if flowCtx.Cfg.TestingKnobs.MemoryLimitBytes != 0 {
 		return flowCtx.Cfg.TestingKnobs.MemoryLimitBytes
 	}
 	if flowCtx.EvalCtx.SessionData.WorkMemLimit <= 0 {

--- a/pkg/sql/memsize/constants.go
+++ b/pkg/sql/memsize/constants.go
@@ -70,4 +70,11 @@ const (
 	// RowsSliceOverhead is the in-memory overhead of a [][][]tree.Datum in
 	// bytes.
 	RowsSliceOverhead = int64(unsafe.Sizeof([][][]tree.Datum{}))
+
+	// MapEntryOverhead is an estimate of the size of each item in a map in
+	// addition to the space occupied by the key and value. This value was
+	// determined empirically using runtime.GC() and runtime.ReadMemStats() to
+	// analyze the memory used by a map. This overhead appears to be independent
+	// of the key and value data types.
+	MapEntryOverhead = 64
 )

--- a/pkg/sql/memsize/constants.go
+++ b/pkg/sql/memsize/constants.go
@@ -49,6 +49,9 @@ const (
 	// Decimal is the in-memory size of an apd.Decimal in bytes.
 	Decimal = int64(unsafe.Sizeof(apd.Decimal{}))
 
+	// String is the in-memory size of an empty string in bytes.
+	String = int64(unsafe.Sizeof(""))
+
 	// BoolSliceOverhead is the in-memory overhead of a []bool in bytes.
 	BoolSliceOverhead = int64(unsafe.Sizeof([]bool{}))
 

--- a/pkg/sql/rowexec/BUILD.bazel
+++ b/pkg/sql/rowexec/BUILD.bazel
@@ -158,6 +158,7 @@ go_test(
         "//pkg/sql/rowcontainer",
         "//pkg/sql/rowenc",
         "//pkg/sql/sem/tree",
+        "//pkg/sql/sqlerrors",
         "//pkg/sql/sqlutil",
         "//pkg/sql/stats",
         "//pkg/sql/types",

--- a/pkg/sql/rowexec/aggregator.go
+++ b/pkg/sql/rowexec/aggregator.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/memsize"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -457,7 +458,7 @@ func (ag *hashAggregator) accumulateRows() (
 
 	// Note that, for simplicity, we're ignoring the overhead of the slice of
 	// strings.
-	if err := ag.bucketsAcc.Grow(ag.Ctx, int64(len(ag.buckets))*sizeOfString); err != nil {
+	if err := ag.bucketsAcc.Grow(ag.Ctx, int64(len(ag.buckets))*memsize.String); err != nil {
 		ag.MoveToDraining(err)
 		return aggStateUnknown, nil, nil
 	}
@@ -588,7 +589,7 @@ func (ag *hashAggregator) emitRow() (
 		ag.bucketsAcc.Shrink(ag.Ctx, int64(ag.alreadyAccountedFor)*hashAggregatorSizeOfBucketsItem)
 		// Note that, for simplicity, we're ignoring the overhead of the slice of
 		// strings.
-		ag.bucketsAcc.Shrink(ag.Ctx, int64(len(ag.buckets))*sizeOfString)
+		ag.bucketsAcc.Shrink(ag.Ctx, int64(len(ag.buckets))*memsize.String)
 		ag.bucketsIter = nil
 		ag.buckets = make(map[string]aggregateFuncs)
 		ag.bucketsLenGrowThreshold = hashAggregatorBucketsInitialLen
@@ -889,7 +890,6 @@ type aggregateFuncHolder struct {
 }
 
 const (
-	sizeOfString         = int64(unsafe.Sizeof(""))
 	sizeOfAggregateFuncs = int64(unsafe.Sizeof(aggregateFuncs{}))
 	sizeOfAggregateFunc  = int64(unsafe.Sizeof(tree.AggregateFunc(nil)))
 )

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -13,12 +13,14 @@ package rowexec
 import (
 	"context"
 	"sort"
+	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/memsize"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
@@ -71,7 +73,16 @@ type joinReader struct {
 	// ProcessorBase.State == StateRunning.
 	runningState joinReaderState
 
-	diskMonitor *mon.BytesMonitor
+	// memAcc is used to account for the memory used by the in-memory data structures
+	// used by the joinReader and different joinReader strategies.
+	memAcc mon.BoundAccount
+
+	// limitedMemMonitor is a limited memory monitor to account for the memory
+	// used by buffered rows in joinReaderOrderingStrategy. If the memory limit is
+	// exceeded, the joinReader will spill to disk. diskMonitor is used to monitor
+	// the disk utilization in this case.
+	limitedMemMonitor *mon.BytesMonitor
+	diskMonitor       *mon.BytesMonitor
 
 	desc      catalog.TableDescriptor
 	index     catalog.Index
@@ -362,6 +373,12 @@ func newJoinReader(
 		}
 	}
 
+	// Initialize memory monitors and bound account for data structures in the joinReader.
+	jr.MemMonitor = execinfra.NewLimitedMonitorNoDiskSpill(
+		flowCtx.EvalCtx.Ctx(), flowCtx.EvalCtx.Mon, flowCtx, "joinreader-mem",
+	)
+	jr.memAcc = jr.MemMonitor.MakeBoundAccount()
+
 	if err := jr.initJoinReaderStrategy(flowCtx, columnTypes, len(columnIDs), rightCols, readerType); err != nil {
 		return nil, err
 	}
@@ -394,6 +411,7 @@ func (jr *joinReader) initJoinReaderStrategy(
 			keyToInputRowIndices: keyToInputRowIndices,
 			numKeyCols:           numKeyCols,
 			lookupCols:           jr.lookupCols,
+			memAcc:               &jr.memAcc,
 		}
 	} else {
 		// Since jr.lookupExpr is set, we need to use either multiSpanGenerator or
@@ -416,6 +434,7 @@ func (jr *joinReader) initJoinReaderStrategy(
 				len(jr.input.OutputTypes()),
 				&jr.lookupExpr,
 				tableOrdToIndexOrd,
+				&jr.memAcc,
 			); err != nil {
 				return err
 			}
@@ -429,6 +448,7 @@ func (jr *joinReader) initJoinReaderStrategy(
 				&jr.lookupExpr,
 				&jr.remoteLookupExpr,
 				tableOrdToIndexOrd,
+				&jr.memAcc,
 			); err != nil {
 				return err
 			}
@@ -450,6 +470,7 @@ func (jr *joinReader) initJoinReaderStrategy(
 			joinReaderSpanGenerator: generator,
 			isPartialJoin:           jr.joinType == descpb.LeftSemiJoin || jr.joinType == descpb.LeftAntiJoin,
 			groupingState:           jr.groupingState,
+			memAcc:                  &jr.memAcc,
 		}
 		return nil
 	}
@@ -459,14 +480,14 @@ func (jr *joinReader) initJoinReaderStrategy(
 	// joinReader will overflow to disk if this limit is not enough.
 	limit := execinfra.GetWorkMemLimit(flowCtx)
 	// Initialize memory monitors and row container for looked up rows.
-	jr.MemMonitor = execinfra.NewLimitedMonitor(ctx, flowCtx.EvalCtx.Mon, flowCtx, "joinreader-limited")
+	jr.limitedMemMonitor = execinfra.NewLimitedMonitor(ctx, jr.MemMonitor, flowCtx, "joinreader-limited")
 	jr.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.DiskMonitor, "joinreader-disk")
 	drc := rowcontainer.NewDiskBackedNumberedRowContainer(
 		false, /* deDup */
 		typs,
 		jr.EvalCtx,
 		jr.FlowCtx.Cfg.TempStorage,
-		jr.MemMonitor,
+		jr.limitedMemMonitor,
 		jr.diskMonitor,
 	)
 	if limit < mon.DefaultPoolAllocationSize {
@@ -481,6 +502,7 @@ func (jr *joinReader) initJoinReaderStrategy(
 		lookedUpRows:                      drc,
 		groupingState:                     jr.groupingState,
 		outputGroupContinuationForLeftRow: jr.outputGroupContinuationForLeftRow,
+		memAcc:                            &jr.memAcc,
 	}
 	return nil
 }
@@ -605,6 +627,9 @@ func (jr *joinReader) readInput() (
 		// Else, returning meta interrupted reading the input batch, so we already
 		// did the reset for this batch.
 	}
+
+	sizeBefore := jr.memUsage()
+
 	// Read the next batch of input rows.
 	for jr.curBatchSizeBytes < jr.batchSizeBytes {
 		row, meta := jr.input.Next()
@@ -613,6 +638,14 @@ func (jr *joinReader) readInput() (
 				jr.MoveToDraining(nil /* err */)
 				return jrStateUnknown, nil, meta
 			}
+
+			// Perform memory accounting.
+			sizeAfter := jr.memUsage()
+			if err := jr.memAcc.Resize(jr.Ctx, sizeBefore, sizeAfter); err != nil {
+				jr.MoveToDraining(err)
+				return jrStateUnknown, nil, meta
+			}
+
 			return jrReadingInput, nil, meta
 		}
 		if row == nil {
@@ -628,6 +661,14 @@ func (jr *joinReader) readInput() (
 		}
 		jr.scratchInputRows = append(jr.scratchInputRows, jr.rowAlloc.CopyRow(row))
 	}
+
+	// Perform memory accounting.
+	sizeAfter := jr.memUsage()
+	if err := jr.memAcc.Resize(jr.Ctx, sizeBefore, sizeAfter); err != nil {
+		jr.MoveToDraining(err)
+		return jrStateUnknown, nil, jr.DrainHelper()
+	}
+
 	var outRow rowenc.EncDatumRow
 	// Finished reading the input batch.
 	if jr.groupingState != nil {
@@ -812,6 +853,10 @@ func (jr *joinReader) close() {
 			jr.fetcher.Close(jr.Ctx)
 		}
 		jr.strategy.close(jr.Ctx)
+		jr.memAcc.Close(jr.Ctx)
+		if jr.limitedMemMonitor != nil {
+			jr.limitedMemMonitor.Stop(jr.Ctx)
+		}
 		if jr.MemMonitor != nil {
 			jr.MemMonitor.Stop(jr.Ctx)
 		}
@@ -941,6 +986,26 @@ func (jr *joinReader) updateGroupingStateForNonEmptyBatch() {
 			jr.groupingState.setFirstGroupMatched()
 		}
 	}
+}
+
+// memUsage returns the size of the data structures in the joinReader for memory
+// accounting purposes.
+func (jr *joinReader) memUsage() int64 {
+	var size int64
+
+	// Account for scratchInputRows. Slice the full capacity so we can account for
+	// the memory used by rows past the length of scratchInputRows.
+	rowsCap := jr.scratchInputRows[:cap(jr.scratchInputRows)]
+	for i := range rowsCap {
+		size += int64(rowsCap[i].Size())
+	}
+
+	// Account for groupingState.
+	if jr.groupingState != nil {
+		size += int64(cap(jr.groupingState.groupState)) * int64(unsafe.Sizeof(groupState{}))
+		size += int64(cap(jr.groupingState.batchRowToGroupIndex)) * memsize.Int
+	}
+	return size
 }
 
 // inputBatchGroupingState encapsulates the state needed for all the


### PR DESCRIPTION
**memsize,rowexec: add `String` to `memsize` constants**

Add `String` to the `memsize` constants and remove the `sizeOfString`
constant from `aggregator.go`.

Release note: None

**rowexec: improve memory accounting in `joinReader`**

This commit improves memory accounting in `joinReader` by accounting
for the in-memory data structures used throughout execution.

Fixes #65904

Release note: None