### PR TITLE
release-20.2: opt,sql: add EXPLAIN (OPT, MEMO) to show optimizer memo

### DIFF
--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -574,7 +574,13 @@ func (h *harness) runUsingAPI(tb testing.TB, bmType BenchmarkType, usePrepared b
 
 	root := execMemo.RootExpr()
 	eb := execbuilder.New(
-		exec.StubFactory{}, execMemo, nil /* catalog */, root, &h.evalCtx, true, /* allowAutoCommit */
+		exec.StubFactory{},
+		&h.optimizer,
+		execMemo,
+		nil, /* catalog */
+		root,
+		&h.evalCtx,
+		true, /* allowAutoCommit */
 	)
 	if _, err = eb.Build(); err != nil {
 		tb.Fatalf("%v", err)

--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/xform"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -31,6 +32,7 @@ const ParallelScanResultThreshold = 10000
 // expression tree (opt.Expr).
 type Builder struct {
 	factory          exec.Factory
+	optimizer        *xform.Optimizer
 	mem              *memo.Memo
 	catalog          cat.Catalog
 	e                opt.Expr
@@ -106,6 +108,7 @@ type Builder struct {
 // transaction.
 func New(
 	factory exec.Factory,
+	optimizer *xform.Optimizer,
 	mem *memo.Memo,
 	catalog cat.Catalog,
 	e opt.Expr,
@@ -114,6 +117,7 @@ func New(
 ) *Builder {
 	b := &Builder{
 		factory:                factory,
+		optimizer:              optimizer,
 		mem:                    mem,
 		catalog:                catalog,
 		e:                      e,

--- a/pkg/sql/opt/exec/execbuilder/cascades.go
+++ b/pkg/sql/opt/exec/execbuilder/cascades.go
@@ -257,7 +257,7 @@ func (cb *cascadeBuilder) planCascade(
 	}
 
 	// 4. Execbuild the optimized expression.
-	eb := New(execFactory, factory.Memo(), cb.b.catalog, optimizedExpr, evalCtx, allowAutoCommit)
+	eb := New(execFactory, &o, factory.Memo(), cb.b.catalog, optimizedExpr, evalCtx, allowAutoCommit)
 	// Set up the With binding.
 	eb.addBuiltWithExpr(cascadeInputWithID, bufferColMap, bufferRef)
 	plan, err := eb.Build()

--- a/pkg/sql/opt/exec/execbuilder/format.go
+++ b/pkg/sql/opt/exec/execbuilder/format.go
@@ -35,7 +35,15 @@ func fmtInterceptor(f *memo.ExprFmtCtx, scalar opt.ScalarExpr) string {
 	}
 
 	// Build the scalar expression and format it as a single string.
-	bld := New(nil /* factory */, f.Memo, nil /* catalog */, scalar, nil /* evalCtx */, false /* allowAutoCommit */)
+	bld := New(
+		nil, /* factory */
+		nil, /* optimizer */
+		f.Memo,
+		nil, /* catalog */
+		scalar,
+		nil,   /* evalCtx */
+		false, /* allowAutoCommit */
+	)
 	md := f.Memo.Metadata()
 	ivh := tree.MakeIndexedVarHelper(nil /* container */, md.NumColumns())
 	expr, err := bld.BuildScalar(&ivh)

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -762,7 +762,7 @@ func (b *Builder) buildApplyJoin(join memo.RelExpr) (execPlan, error) {
 			return nil, err
 		}
 
-		eb := New(ef, f.Memo(), b.catalog, newRightSide, b.evalCtx, false /* allowAutoCommit */)
+		eb := New(ef, &o, f.Memo(), b.catalog, newRightSide, b.evalCtx, false /* allowAutoCommit */)
 		eb.disableTelemetry = true
 		plan, err := eb.Build()
 		if err != nil {

--- a/pkg/sql/opt/exec/execbuilder/statement.go
+++ b/pkg/sql/opt/exec/execbuilder/statement.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/xform"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/util/treeprinter"
@@ -93,6 +94,11 @@ func (b *Builder) buildExplainOpt(explain *memo.ExplainExpr) (execPlan, error) {
 		// TODO(radu): add views, sequences
 	}
 
+	// If MEMO option was passed, show the memo.
+	if explain.Options.Flags[tree.ExplainFlagMemo] {
+		planText.WriteString(b.optimizer.FormatMemo(xform.FmtPretty))
+	}
+
 	f := memo.MakeExprFmtCtx(fmtFlags, b.mem, b.catalog)
 	f.FormatExpr(explain.Input)
 	planText.WriteString(f.Buffer.String())
@@ -122,7 +128,7 @@ func (b *Builder) buildExplain(explain *memo.ExplainExpr) (execPlan, error) {
 			&explain.Options,
 			func(ef exec.ExplainFactory) (exec.Plan, error) {
 				// Create a separate builder for the explain query.
-				explainBld := New(ef, b.mem, b.catalog, explain.Input, b.evalCtx, b.initialAllowAutoCommit)
+				explainBld := New(ef, b.optimizer, b.mem, b.catalog, explain.Input, b.evalCtx, b.initialAllowAutoCommit)
 				explainBld.disableTelemetry = true
 				return explainBld.Build()
 			},
@@ -134,7 +140,7 @@ func (b *Builder) buildExplain(explain *memo.ExplainExpr) (execPlan, error) {
 	}
 
 	// Create a separate builder for the explain query.
-	explainBld := New(b.factory, b.mem, b.catalog, explain.Input, b.evalCtx, b.initialAllowAutoCommit)
+	explainBld := New(b.factory, b.optimizer, b.mem, b.catalog, explain.Input, b.evalCtx, b.initialAllowAutoCommit)
 	explainBld.disableTelemetry = true
 	plan, err := explainBld.Build()
 	if err != nil {

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -1233,3 +1233,124 @@ EXPLAIN INSERT INTO t2 SELECT x FROM t2 WHERE false
 insert fast path  ·             ·
 ·                 into          t2(x)
 ·                 auto commit   ·
+
+# Tests for EXPLAIN (OPT, MEMO).
+query T
+EXPLAIN (OPT, MEMO) SELECT * FROM tc JOIN t ON k=a
+----
+memo (optimized, ~16KB, required=[presentation: text:10])
+ ├── G1: (explain G2 [presentation: a:1,b:2,k:6,v:7])
+ │    └── [presentation: text:10]
+ │         ├── best: (explain G2="[presentation: a:1,b:2,k:6,v:7]" [presentation: a:1,b:2,k:6,v:7])
+ │         └── cost: 2227.97
+ ├── G2: (inner-join G3 G4 G5) (inner-join G3 G4 G5) (inner-join G4 G3 G5) (merge-join G3 G4 G6 inner-join,+1,+6) (lookup-join G3 G6 t,keyCols=[1],outCols=(1,2,6,7)) (merge-join G3 G4 G6 inner-join,+1,+6) (lookup-join G3 G6 t,keyCols=[1],outCols=(1,2,6,7)) (merge-join G4 G3 G6 inner-join,+6,+1) (lookup-join G7 G6 tc,keyCols=[3],outCols=(1,2,6,7))
+ │    └── [presentation: a:1,b:2,k:6,v:7]
+ │         ├── best: (inner-join G3 G4 G5)
+ │         └── cost: 2227.96
+ ├── G3: (scan tc,cols=(1,2))
+ │    ├── [ordering: +1]
+ │    │    ├── best: (sort G3)
+ │    │    └── cost: 1323.35
+ │    └── []
+ │         ├── best: (scan tc,cols=(1,2))
+ │         └── cost: 1104.02
+ ├── G4: (scan t,cols=(6,7))
+ │    ├── [ordering: +6]
+ │    │    ├── best: (scan t,cols=(6,7))
+ │    │    └── cost: 1084.02
+ │    └── []
+ │         ├── best: (scan t,cols=(6,7))
+ │         └── cost: 1084.02
+ ├── G5: (filters G8)
+ ├── G6: (filters)
+ ├── G7: (lookup-join G4 G6 tc@c,keyCols=[6],outCols=(1,3,6,7))
+ │    └── []
+ │         ├── best: (lookup-join G4 G6 tc@c,keyCols=[6],outCols=(1,3,6,7))
+ │         └── cost: 23153.13
+ ├── G8: (eq G9 G10)
+ ├── G9: (variable k)
+ └── G10: (variable a)
+inner-join (hash)
+ ├── scan tc
+ ├── scan t
+ └── filters
+      └── k = a
+
+query T
+EXPLAIN (OPT, MEMO, VERBOSE, CATALOG) SELECT * FROM tc JOIN t ON k=a
+----
+TABLE tc
+ ├── a int
+ ├── b int
+ ├── rowid int not null default (unique_rowid()) [hidden]
+ ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
+ ├── tableoid oid [hidden] [system]
+ ├── INDEX primary
+ │    └── rowid int not null default (unique_rowid()) [hidden]
+ └── INDEX c
+      ├── a int
+      └── rowid int not null default (unique_rowid()) [hidden]
+TABLE t
+ ├── k int not null
+ ├── v int
+ ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
+ ├── tableoid oid [hidden] [system]
+ └── INDEX primary
+      └── k int not null
+memo (optimized, ~16KB, required=[presentation: text:10])
+ ├── G1: (explain G2 [presentation: a:1,b:2,k:6,v:7])
+ │    └── [presentation: text:10]
+ │         ├── best: (explain G2="[presentation: a:1,b:2,k:6,v:7]" [presentation: a:1,b:2,k:6,v:7])
+ │         └── cost: 2227.97
+ ├── G2: (inner-join G3 G4 G5) (inner-join G3 G4 G5) (inner-join G4 G3 G5) (merge-join G3 G4 G6 inner-join,+1,+6) (lookup-join G3 G6 t,keyCols=[1],outCols=(1,2,6,7)) (merge-join G3 G4 G6 inner-join,+1,+6) (lookup-join G3 G6 t,keyCols=[1],outCols=(1,2,6,7)) (merge-join G4 G3 G6 inner-join,+6,+1) (lookup-join G7 G6 tc,keyCols=[3],outCols=(1,2,6,7))
+ │    └── [presentation: a:1,b:2,k:6,v:7]
+ │         ├── best: (inner-join G3 G4 G5)
+ │         └── cost: 2227.96
+ ├── G3: (scan tc,cols=(1,2))
+ │    ├── [ordering: +1]
+ │    │    ├── best: (sort G3)
+ │    │    └── cost: 1323.35
+ │    └── []
+ │         ├── best: (scan tc,cols=(1,2))
+ │         └── cost: 1104.02
+ ├── G4: (scan t,cols=(6,7))
+ │    ├── [ordering: +6]
+ │    │    ├── best: (scan t,cols=(6,7))
+ │    │    └── cost: 1084.02
+ │    └── []
+ │         ├── best: (scan t,cols=(6,7))
+ │         └── cost: 1084.02
+ ├── G5: (filters G8)
+ ├── G6: (filters)
+ ├── G7: (lookup-join G4 G6 tc@c,keyCols=[6],outCols=(1,3,6,7))
+ │    └── []
+ │         ├── best: (lookup-join G4 G6 tc@c,keyCols=[6],outCols=(1,3,6,7))
+ │         └── cost: 23153.13
+ ├── G8: (eq G9 G10)
+ ├── G9: (variable k)
+ └── G10: (variable a)
+inner-join (hash)
+ ├── columns: a:1 b:2 k:6 v:7
+ ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ ├── stats: [rows=990, distinct(1)=99, null(1)=0, distinct(6)=99, null(6)=0]
+ ├── cost: 2227.96
+ ├── fd: (6)-->(7), (1)==(6), (6)==(1)
+ ├── prune: (2,7)
+ ├── scan tc
+ │    ├── columns: a:1 b:2
+ │    ├── stats: [rows=1000, distinct(1)=100, null(1)=10]
+ │    ├── cost: 1104.02
+ │    ├── prune: (1,2)
+ │    ├── interesting orderings: (+1)
+ │    └── unfiltered-cols: (1-5)
+ ├── scan t
+ │    ├── columns: k:6 v:7
+ │    ├── stats: [rows=1000, distinct(6)=1000, null(6)=0]
+ │    ├── cost: 1084.02
+ │    ├── key: (6)
+ │    ├── fd: (6)-->(7)
+ │    ├── prune: (6,7)
+ │    ├── interesting orderings: (+6)
+ │    └── unfiltered-cols: (6-9)
+ └── filters
+      └── k:6 = a:1 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]

--- a/pkg/sql/opt/idxconstraint/index_constraints_test.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints_test.go
@@ -143,8 +143,8 @@ func TestIndexConstraints(t *testing.T) {
 				remainingFilter := ic.RemainingFilters()
 				if !remainingFilter.IsTrue() {
 					execBld := execbuilder.New(
-						nil /* execFactory */, f.Memo(), nil /* catalog */, &remainingFilter,
-						&evalCtx, false, /* allowAutoCommit */
+						nil /* execFactory */, nil /* optimizer */, f.Memo(), nil, /* catalog */
+						&remainingFilter, &evalCtx, false, /* allowAutoCommit */
 					)
 					expr, err := execBld.BuildScalar(&iVarHelper)
 					if err != nil {

--- a/pkg/sql/opt/partialidx/implicator_test.go
+++ b/pkg/sql/opt/partialidx/implicator_test.go
@@ -119,8 +119,8 @@ func TestImplicator(t *testing.T) {
 				buf.WriteString("none")
 			} else {
 				execBld := execbuilder.New(
-					nil /* factory */, f.Memo(), nil /* catalog */, &remainingFilters,
-					&evalCtx, false, /* allowAutoCommit */
+					nil /* factory */, nil /* optimizer */, f.Memo(), nil, /* catalog */
+					&remainingFilters, &evalCtx, false, /* allowAutoCommit */
 				)
 				expr, err := execBld.BuildScalar(&iVarHelper)
 				if err != nil {

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -565,7 +565,7 @@ func (opc *optPlanningCtx) runExecBuilder(
 	}
 	if !planTop.savePlanString && !planTop.savePlanForStats {
 		// No instrumentation.
-		bld := execbuilder.New(f, mem, &opc.catalog, mem.RootExpr(), evalCtx, allowAutoCommit)
+		bld := execbuilder.New(f, &opc.optimizer, mem, &opc.catalog, mem.RootExpr(), evalCtx, allowAutoCommit)
 		plan, err := bld.Build()
 		if err != nil {
 			return err
@@ -577,7 +577,9 @@ func (opc *optPlanningCtx) runExecBuilder(
 	} else {
 		// Create an explain factory and record the explain.Plan.
 		explainFactory := explain.NewFactory(f)
-		bld := execbuilder.New(explainFactory, mem, &opc.catalog, mem.RootExpr(), evalCtx, allowAutoCommit)
+		bld := execbuilder.New(
+			explainFactory, &opc.optimizer, mem, &opc.catalog, mem.RootExpr(), evalCtx, allowAutoCommit,
+		)
 		plan, err := bld.Build()
 		if err != nil {
 			return err

--- a/pkg/sql/sem/tree/eval_test.go
+++ b/pkg/sql/sem/tree/eval_test.go
@@ -103,7 +103,7 @@ func optBuildScalar(evalCtx *tree.EvalContext, e tree.Expr) (tree.TypedExpr, err
 	}
 
 	bld := execbuilder.New(
-		nil /* factory */, o.Memo(), nil /* catalog */, o.Memo().RootExpr(),
+		nil /* factory */, &o, o.Memo(), nil /* catalog */, o.Memo().RootExpr(),
 		evalCtx, false, /* allowAutoCommit */
 	)
 	ivh := tree.MakeIndexedVarHelper(nil /* container */, 0)

--- a/pkg/sql/sem/tree/explain.go
+++ b/pkg/sql/sem/tree/explain.go
@@ -92,6 +92,7 @@ const (
 	ExplainFlagEnv
 	ExplainFlagCatalog
 	ExplainFlagDebug
+	ExplainFlagMemo
 	numExplainFlags = iota
 )
 
@@ -102,6 +103,7 @@ var explainFlagStrings = [...]string{
 	ExplainFlagEnv:     "ENV",
 	ExplainFlagCatalog: "CATALOG",
 	ExplainFlagDebug:   "DEBUG",
+	ExplainFlagMemo:    "MEMO",
 }
 
 var explainFlagStringMap = func() map[string]ExplainFlag {


### PR DESCRIPTION
Backport 1/1 commits from #67702.

/cc @cockroachdb/release

Release justification: This adds a new debugging tool that we can use to help understand issues in the 20.2 release branch. It is a minimal change to EXPLAIN functionality.

I will wait two weeks before merging.

---

Release note (sql change): Added a new EXPLAIN flag, MEMO, to be used
with `EXPLAIN (OPT)`. When the MEMO flag is passed, a representation of the
optimizer memo will be printed along with the best plan. The MEMO flag
can be used in combination with other flags such as CATALOG and VERBOSE.
For example, `EXPLAIN (OPT, MEMO, VERBOSE)` will print the memo along with
verbose output for the best plan.
