### PR TITLE
release-21.1: colexec: fix CASE operator a bit

### DIFF
--- a/pkg/col/coldata/batch.go
+++ b/pkg/col/coldata/batch.go
@@ -28,7 +28,9 @@ import (
 type Batch interface {
 	// Length returns the number of values in the columns in the batch.
 	Length() int
-	// SetLength sets the number of values in the columns in the batch.
+	// SetLength sets the number of values in the columns in the batch. Note
+	// that if the selection vector will be set or updated on the batch, it must
+	// be set **before** setting the length.
 	SetLength(int)
 	// Capacity returns the maximum number of values that can be stored in the
 	// columns in the batch. Note that it could be a lower bound meaning some

--- a/pkg/sql/colexec/aggregators_util.go
+++ b/pkg/sql/colexec/aggregators_util.go
@@ -529,11 +529,11 @@ func (o *singleBatchOperator) reset(vecs []coldata.Vec, inputLen int, sel []int)
 	for i, vec := range vecs {
 		o.batch.ReplaceCol(vec, i)
 	}
-	o.batch.SetLength(inputLen)
 	o.batch.SetSelection(sel != nil)
 	if sel != nil {
 		copy(o.batch.Selection(), sel[:inputLen])
 	}
+	o.batch.SetLength(inputLen)
 }
 
 // aggBucket stores the aggregation functions for the corresponding aggregation

--- a/pkg/sql/colexec/case.go
+++ b/pkg/sql/colexec/case.go
@@ -214,21 +214,21 @@ func (c *caseOp) Next(ctx context.Context) coldata.Batch {
 					}
 				}
 				// Set the buffered batch into the desired state.
-				c.buffer.batch.SetLength(curIdx)
-				prevLen = curIdx
 				c.buffer.batch.SetSelection(true)
 				prevHasSel = true
 				copy(c.buffer.batch.Selection()[:curIdx], c.prevSel)
 				c.prevSel = c.prevSel[:curIdx]
+				c.buffer.batch.SetLength(curIdx)
+				prevLen = curIdx
 			} else {
 				// There were no matches with the current WHEN arm, so we simply need
 				// to restore the buffered batch into the previous state.
-				c.buffer.batch.SetLength(prevLen)
 				c.buffer.batch.SetSelection(prevHasSel)
 				if prevHasSel {
 					copy(c.buffer.batch.Selection()[:prevLen], c.prevSel)
 					c.prevSel = c.prevSel[:prevLen]
 				}
+				c.buffer.batch.SetLength(prevLen)
 			}
 			// Now our selection vector is set to exclude all the things that have
 			// matched so far. Reset the buffer and run the next case arm.
@@ -253,10 +253,10 @@ func (c *caseOp) Next(ctx context.Context) coldata.Batch {
 		}
 	})
 	// Restore the original state of the buffered batch.
-	c.buffer.batch.SetLength(origLen)
 	c.buffer.batch.SetSelection(origHasSel)
 	if origHasSel {
 		copy(c.buffer.batch.Selection()[:origLen], c.origSel[:origLen])
 	}
+	c.buffer.batch.SetLength(origLen)
 	return c.buffer.batch
 }


### PR DESCRIPTION
Backport 1/1 commits from #67757.

/cc @cockroachdb/release

Release justification: extremely low risk fix to an edge case bug that was hit
a few times in the wild.

---

Whenever we're updating the length on the batch containing bytes-like
vectors, we are updating those vectors to have non-decreasing offsets.
In case the batch has a selection vector set, we're using the largest
index in the selection to update the offsets. This logic relies on the
assumption that the selection vector is set on the batch **before**
setting the length which wasn't the case in a couple of places.

Note that there is no regression test because I cannot quite pin down
the exact conditions for the bug to occur (we need a bytes-like vector
in the batch but also such a selection vector that has garbage values
beyond the current length of the batch).

Fixes: #67744.

Release note (bug fix): Fixed very rare unexpected error from the
vectorized engine (index out of bounds) when evaluating CASE operator.