### PR TITLE
[prototype] spanconfig: carve out spanconfig.Storage

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -160,6 +160,7 @@ ALL_TESTS = [
     "//pkg/spanconfig/spanconfigkvwatcher:spanconfigkvwatcher_test",
     "//pkg/spanconfig/spanconfigmanager:spanconfigmanager_test",
     "//pkg/spanconfig/spanconfigsqlwatcher:spanconfigsqlwatcher_test",
+    "//pkg/spanconfig/spanconfigstore:spanconfigstore_test",
     "//pkg/sql/catalog/catalogkeys:catalogkeys_test",
     "//pkg/sql/catalog/catalogkv:catalogkv_test",
     "//pkg/sql/catalog/catformat:catformat_test",

--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -150,6 +150,7 @@ go_library(
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/spanconfig",
+        "//pkg/spanconfig/spanconfigstore",
         "//pkg/sql/sessiondata",
         "//pkg/sql/sqlutil",
         "//pkg/storage",

--- a/pkg/kv/kvserver/queue.go
+++ b/pkg/kv/kvserver/queue.go
@@ -609,6 +609,9 @@ func (bq *baseQueue) maybeAdd(ctx context.Context, repl replicaInQueue, now hlc.
 	// Load the system config if it's needed.
 	var cfg *config.SystemConfig
 	if bq.needsSystemConfig {
+		// TODO(zcfgs-pod): instead accessing the system config directly, we'll
+		// want to expose a thin read-only interface into the per-store
+		// spanconfig.Store.
 		cfg = bq.gossip.GetSystemConfig()
 		if cfg == nil {
 			if log.V(1) {

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -367,6 +367,9 @@ type Replica struct {
 		// used, if they eventually apply.
 		minLeaseProposedTS hlc.ClockTimestamp
 		// A pointer to the zone config for this replica.
+		//
+		// TODO(zcfgs-pod): Audit uses, and migrate over to using SpanConfigs
+		// instead.
 		zone *zonepb.ZoneConfig
 		// proposalBuf buffers Raft commands as they are passed to the Raft
 		// replication subsystem. The buffer is populated by requests after

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -697,6 +697,10 @@ func (r *Replica) updateRangeInfo(desc *roachpb.RangeDescriptor) error {
 	}
 
 	r.SetZoneConfig(zone)
+	// TODO(zcfgs-pod): This is called post-range-split. We'll want to similarly
+	// install the right span config sourced from the embedding store's local
+	// spanconfig.Storage. What if there's yet another split? How's that to be
+	// handled?
 	return nil
 }
 

--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -1527,3 +1527,8 @@ func (c *ContentionEvent) SafeFormat(w redact.SafePrinter, _ rune) {
 func (c *ContentionEvent) String() string {
 	return redact.StringWithoutMarkers(c)
 }
+
+// IsEmpty returns true if s is an empty SpanConfig.
+func (s SpanConfig) IsEmpty() bool {
+	return s.Equal(SpanConfig{})
+}

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1449,7 +1449,7 @@ func (n *Node) UpdateSpanConfigs(
 	})
 
 	// TODO(zcfgs-pod): Instead of simply upserting/deleting into the table, we
-	// could "merge" into the existing state -- it would make for simpler
+	// could "absorb" into the existing state -- it would make for simpler
 	// client-side operations. Given an initial state, and sets of span configs
 	// to delete and upsert, we could do the following:
 	//

--- a/pkg/spanconfig/spanconfigstore/BUILD.bazel
+++ b/pkg/spanconfig/spanconfigstore/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "spanconfigstore",
+    srcs = ["store.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigstore",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/roachpb",
+        "//pkg/spanconfig",
+        "//pkg/util/cache",
+        "//pkg/util/syncutil",
+        "@com_github_biogo_store//llrb",
+    ],
+)
+
+go_test(
+    name = "spanconfigstore_test",
+    srcs = ["store_test.go"],
+    data = glob(["testdata/**"]),
+    deps = [
+        ":spanconfigstore",
+        "//pkg/roachpb",
+        "//pkg/util/leaktest",
+        "//pkg/util/randutil",
+        "@com_github_cockroachdb_datadriven//:datadriven",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/spanconfig/spanconfigstore/store.go
+++ b/pkg/spanconfig/spanconfigstore/store.go
@@ -1,0 +1,294 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package spanconfigstore
+
+import (
+	"bytes"
+
+	"github.com/biogo/store/llrb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/spanconfig"
+	"github.com/cockroachdb/cockroach/pkg/util/cache"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+)
+
+// Store is an in-memory data structure to store and retrieve span configs.
+// Internally it makes use of a left-leaning red-black tree to store
+// non-overlapping span configs, and ensures that adjacent spans with the same
+// config are coalesced.
+//
+// TODO(zcfgs-pod): Switch over to using util/interval.Tree instead, which does
+// most of what we want. We'd still have to over-write existing spans, and
+// coalesce adjacent ones, but seems more appropriate than the OrderedCache.
+type Store struct {
+	mu struct {
+		syncutil.RWMutex
+		cache *cache.OrderedCache
+	}
+}
+
+var _ spanconfig.Store = &Store{}
+
+// New instantiates a span config store.
+func New() *Store {
+	s := &Store{}
+	s.mu.cache = cache.NewOrderedCache(cache.Config{
+		Policy: cache.CacheNone,
+	})
+	return s
+}
+
+// storeKey is the key type used to store and sort values in the span config
+// storage.
+type storeKey roachpb.Key
+
+var _ llrb.Comparable = storeKey{}
+
+var minCacheKey interface{} = storeKey(roachpb.KeyMin)
+var maxCacheKey interface{} = storeKey(roachpb.KeyMax)
+
+func (a storeKey) String() string {
+	return roachpb.Key(a).String()
+}
+
+// Compare implements the llrb.Comparable interface for storeKey, so that
+// it can be used as a key for util.OrderedCache.
+func (a storeKey) Compare(b llrb.Comparable) int {
+	return bytes.Compare(a, b.(storeKey))
+}
+
+// SetSpanConfig is part of the spanconfig.Store interface.
+func (s *Store) SetSpanConfig(sp roachpb.Span, conf roachpb.SpanConfig) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !sp.Valid() {
+		panic("invalid span")
+	}
+
+	// Clear out all existing span configs overlapping with our own.
+	s.clearLocked(sp)
+
+	if conf.IsEmpty() {
+		// Nothing to do; empty span configs are delete operations.
+		return
+	}
+
+	// Check to see if the adjacent span configs can be coalesced into.
+	startKey, endKey := sp.Key, sp.EndKey
+
+	next, found := s.getCeilEntryLocked(sp.EndKey) // check the span config to our right
+	if found && next.Span.Key.Equal(sp.EndKey) && next.Config.Equal(conf) {
+		s.clearLocked(next.Span)
+		endKey = next.Span.EndKey
+	}
+
+	prev, found := s.getFloorEntryLocked(sp.Key) // check the span config to our left
+	if found && prev.Span.EndKey.Equal(sp.Key) && prev.Config.Equal(conf) {
+		s.clearLocked(prev.Span)
+		startKey = prev.Span.Key
+	}
+
+	// Finally, write the span config entry.
+	s.mu.cache.AddEntry(&cache.Entry{
+		Key: storeKey(startKey),
+		Value: roachpb.SpanConfigEntry{
+			Span: roachpb.Span{
+				Key:    startKey,
+				EndKey: endKey,
+			},
+			Config: conf,
+		},
+	})
+}
+
+// GetConfigsForSpan is part of the spanconfig.Store interface.
+func (s *Store) GetConfigsForSpan(sp roachpb.Span) []roachpb.SpanConfigEntry {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if !sp.Valid() {
+		panic("invalid span")
+	}
+
+	// Iterate over all overlapping ranges, return corresponding span
+	// config entries.
+	var res []roachpb.SpanConfigEntry
+	searchStartKey, searchEndKey := s.getSearchBoundsLocked(sp)
+	s.mu.cache.DoRangeEntry(func(e *cache.Entry) bool {
+		entry, _ := e.Value.(roachpb.SpanConfigEntry)
+		if !entry.Span.Overlaps(sp) {
+			// Skip non-overlapping entries.
+			return false
+		}
+
+		res = append(res, roachpb.SpanConfigEntry{
+			Span:   entry.Span,
+			Config: entry.Config,
+		})
+
+		return false
+	}, searchStartKey, searchEndKey)
+	return res
+}
+
+// GetSplitsBetween is part of the spanconfig.Store interface.
+func (s *Store) GetSplitsBetween(start, end roachpb.Key) []roachpb.Key {
+	panic("unimplemented")
+	// TODO(zcfgs-pod): Need to make sure we populate static splits/span configs as startup
+	// migration. All splits in KV done through the system config span needs to
+	// be done here as well.
+}
+
+// clearLocked is used to clear out a given span from the underlying storage. At
+// a high-level, we'll find all overlapping spans and delete the intersections.
+// We do this by deleting each overlapping span in its entirety and re-adding
+// the non-overlapping components (if any). Pseudo-code:
+//
+// 	for each entry in storage.overlapping(sp):
+// 		union, intersection = union(sp, entry), intersection(sp, entry)
+// 		pre, post = span{union.start_key, intersection.start_key}, span{intersection.end_key, union.end_key}
+//
+// 		delete entry
+// 		if entry.contains(sp.start_key):
+// 			add pre=entry.conf
+// 		if entry.contains(sp.end_key):
+// 			add post=entry.conf
+//
+func (s *Store) clearLocked(sp roachpb.Span) {
+	searchStartKey, searchEndKey := s.getSearchBoundsLocked(sp)
+	var toDelete, toAdd []cache.Entry
+	s.mu.cache.DoRangeEntry(func(e *cache.Entry) bool { // keyed by span start key, storing value span config entry
+		entry, _ := e.Value.(roachpb.SpanConfigEntry)
+		oldSpan, newSpan := entry.Span, sp
+		if !oldSpan.Overlaps(newSpan) { // skip non-overlapping ranges
+			return false
+		}
+
+		// A:		[----------------------)
+		// B:	            [--------------------)
+		//
+		// union:	[----------------------------)
+		// inter:	        [--------------)
+		// pre: 	[-------)
+		// post:	                       [-----)
+		union, intersection := oldSpan.Combine(newSpan), oldSpan.Intersect(newSpan)
+		pre := roachpb.Span{Key: union.Key, EndKey: intersection.Key}
+		post := roachpb.Span{Key: intersection.EndKey, EndKey: union.EndKey}
+
+		// Delete the overlapping span in its entirety. Below we'll re-add the
+		// non-intersecting parts of the span.
+		toDelete = append(toDelete, cache.Entry{
+			Key:   storeKey(entry.Span.Key),
+			Value: entry,
+		})
+
+		if entry.Span.ContainsKey(sp.Key) { // entry contains the given span's start key
+			// entry:  [-----------------)
+			//
+			// sp:         [-------)
+			// sp:         [-------------)
+			// sp:         [--------------
+			// sp:     [-------)
+			// sp:     [-----------------)
+			// sp:     [------------------
+
+			// Re-add the non-intersecting spans, if any.
+			if pre.Valid() {
+				toAdd = append(toAdd, cache.Entry{
+					Key:   storeKey(pre.Key),
+					Value: roachpb.SpanConfigEntry{Span: pre, Config: entry.Config},
+				})
+			}
+		}
+
+		if entry.Span.ContainsKey(sp.EndKey) { // entry contains the given span's end key
+			// entry:  [-----------------)
+			//
+			// sp:     ------------------)
+			// sp:     [-----------------)
+			// sp:               [-------)
+			// sp:     -------------)
+			// sp:     [------------)
+			// sp:        [---------)
+
+			// Re-add the non-intersecting spans, if any.
+			if post.Valid() {
+				toAdd = append(toAdd, cache.Entry{
+					Key:   storeKey(post.Key),
+					Value: roachpb.SpanConfigEntry{Span: post, Config: entry.Config},
+				})
+			}
+		}
+
+		return false
+	}, searchStartKey, searchEndKey)
+
+	// Execute the accumulated operations.
+	for _, entry := range toDelete {
+		entry := entry // copy out of loop variable
+		s.mu.cache.DelEntry(&entry)
+	}
+
+	for _, entry := range toAdd {
+		entry := entry // copy out of loop variable
+		s.mu.cache.AddEntry(&entry)
+	}
+}
+
+// getCeilEntryLocked returns the span config entry keyed using a key greater than or
+// equal to the one provided.
+func (s *Store) getCeilEntryLocked(k roachpb.Key) (_ roachpb.SpanConfigEntry, found bool) {
+	var cacheEntry *cache.Entry
+	cacheEntry, found = s.mu.cache.CeilEntry(storeKey(k))
+	if !found {
+		return roachpb.SpanConfigEntry{}, false
+	}
+
+	entry, _ := cacheEntry.Value.(roachpb.SpanConfigEntry)
+	return entry, true
+}
+
+// getFloorEntryLocked returns the span config entry keyed using a key less than or
+// equal to the one provided.
+func (s *Store) getFloorEntryLocked(k roachpb.Key) (_ roachpb.SpanConfigEntry, found bool) {
+	var cacheEntry *cache.Entry
+	cacheEntry, found = s.mu.cache.FloorEntry(storeKey(k))
+	if !found {
+		return roachpb.SpanConfigEntry{}, false
+	}
+
+	entry, _ := cacheEntry.Value.(roachpb.SpanConfigEntry)
+	return entry, true
+}
+
+// getSearchBoundsLocked constructs the search bounds to find all spans that possibly
+// overlap with the given one. It's possible that spans retrieved using these
+// search bounds don't overlap with the requested span. Since spans are keyed
+// using their start key, it's possible the search is started at a span whose
+// end key precedes our own.
+func (s *Store) getSearchBoundsLocked(sp roachpb.Span) (searchStartKey, searchEndKey interface{}) {
+	floorEntry, found := s.mu.cache.FloorEntry(storeKey(sp.Key))
+	if found {
+		searchStartKey = floorEntry.Key
+	} else {
+		searchStartKey = minCacheKey
+	}
+
+	ceilEntry, found := s.mu.cache.CeilEntry(storeKey(sp.EndKey))
+	if found {
+		searchEndKey = ceilEntry.Key
+	} else {
+		searchEndKey = maxCacheKey
+	}
+
+	return searchStartKey, searchEndKey
+}

--- a/pkg/spanconfig/spanconfigstore/store_test.go
+++ b/pkg/spanconfig/spanconfigstore/store_test.go
@@ -1,0 +1,254 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package spanconfigstore_test
+
+import (
+	"fmt"
+	"math/rand"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigstore"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/datadriven"
+	"github.com/stretchr/testify/require"
+)
+
+// spanRe matches strings of the form "[start, end)", capturing both "start" and
+// "end" key.
+var spanRe = regexp.MustCompile(`^\[(\w+),\s??(\w+)\)$`)
+
+// confRe matches a single word.
+var configRe = regexp.MustCompile(`^(\w+)$`)
+
+func TestSpanRe(t *testing.T) {
+	for _, tc := range []struct {
+		input            string
+		expMatch         bool
+		expStart, expEnd string
+	}{
+		{"[a, b)", true, "a", "b"},
+		{"[acd, bfg)", true, "acd", "bfg"}, // multi character keys allowed
+		{"[a,b)", true, "a", "b"},          // separating space is optional
+		{"[ a,b) ", false, "", ""},         // extraneous spaces disallowed
+		{"[a,b ) ", false, "", ""},         // extraneous spaces disallowed
+		{"[a,, b)", false, "", ""},         // only single comma allowed
+		{" [a, b)", false, "", ""},         // need to start with '['
+		{"[a,b)x", false, "", ""},          // need to end with ')'
+	} {
+		require.Equalf(t, tc.expMatch, spanRe.MatchString(tc.input), "input = %s", tc.input)
+		if !tc.expMatch {
+			continue
+		}
+
+		matches := spanRe.FindStringSubmatch(tc.input)
+		require.Len(t, matches, 3)
+		start, end := matches[1], matches[2]
+		require.Equal(t, tc.expStart, start)
+		require.Equal(t, tc.expEnd, end)
+	}
+}
+
+// parseSpan is helper function that constructs a roachpb.Span from a string of the
+// form "[start, end)".
+func parseSpan(t *testing.T, sp string) roachpb.Span {
+	if !spanRe.MatchString(sp) {
+		t.Fatalf("expected %s to match span regex", sp)
+	}
+
+	matches := spanRe.FindStringSubmatch(sp)
+	start, end := matches[1], matches[2]
+	return roachpb.Span{
+		Key:    roachpb.Key(start),
+		EndKey: roachpb.Key(end),
+	}
+}
+
+// parseConfig is helper function that constructs a roachpb.SpanConfig with
+// "tagged" with the given string.
+func parseConfig(t *testing.T, conf string) roachpb.SpanConfig {
+	if !configRe.MatchString(conf) {
+		t.Fatalf("expected %s to match config regex", conf)
+	}
+	return roachpb.SpanConfig{
+		Constraints: []roachpb.ConstraintsConjunction{
+			{
+				Constraints: []roachpb.Constraint{
+					{
+						Key: conf,
+					},
+				},
+			},
+		},
+	}
+}
+
+// printSpan is a helper function that transforms roachpb.Span into a string of
+// the form "[start,end)". The span is assumed to have been constructed by the
+// parseSpan helper above.
+func printSpan(sp roachpb.Span) string {
+	return fmt.Sprintf("[%s,%s)", string(sp.Key), string(sp.EndKey))
+}
+
+// printSpanConfig is a helper function that transforms roachpb.SpanConfig into
+// a readable string. The span config is assumed to have been constructed by the
+// parseSpanConfig helper above.
+func printSpanConfig(conf roachpb.SpanConfig) string {
+	return conf.Constraints[0].Constraints[0].Key // see parseConfig for what a "tagged" roachpb.SpanConfig translates to
+}
+
+// printSpanConfigEntry is a helper function that transforms
+// roachpb.SpanConfigEntry into a string of the form "[start,end):config". The
+// embedded span config is assumed to have been constructed by the parseConfig
+// helper above.
+func printSpanConfigEntry(entry roachpb.SpanConfigEntry) string {
+	return fmt.Sprintf("%s:%s", printSpan(entry.Span), printSpanConfig(entry.Config))
+}
+
+func TestDatadriven(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	datadriven.Walk(t, "testdata", func(t *testing.T, path string) {
+		storage := spanconfigstore.New()
+		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
+			var spanStr, confStr string
+			switch d.Cmd {
+			case "get":
+				d.ScanArgs(t, "span", &spanStr)
+				span := parseSpan(t, spanStr)
+				entries := storage.GetConfigsForSpan(span)
+				var results []string
+				for _, entry := range entries {
+					results = append(results, printSpanConfigEntry(entry))
+				}
+				return strings.Join(results, "\n")
+
+			case "set":
+				d.ScanArgs(t, "span", &spanStr)
+				d.ScanArgs(t, "conf", &confStr)
+				span, config := parseSpan(t, spanStr), parseConfig(t, confStr)
+				storage.SetSpanConfig(span, config)
+				return ""
+
+			case "del":
+				d.ScanArgs(t, "span", &spanStr)
+				span := parseSpan(t, spanStr)
+				storage.SetSpanConfig(span, roachpb.SpanConfig{})
+				return ""
+
+			default:
+				return "unknown command"
+			}
+		})
+	})
+}
+
+// TestRandomized randomly sets/deletes span configs for arbitrary keyspans
+// within some alphabet. For a test span, it then asserts that the config we
+// retrieve is what we expect to find from the store. It also ensures that all
+// ranges are non-overlapping, and that adjacent ranges have different span
+// configs.
+func TestRandomized(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	randutil.SeedForTests()
+
+	storage := spanconfigstore.New()
+	alphabet := "abcdefghijklmnopqrstuvwxyz"
+	configs := "ABCDEF"
+	ops := []string{"set", "del"}
+
+	var expConfig roachpb.SpanConfig
+	var expFound bool
+
+	getRandomSpan := func() roachpb.Span {
+		for {
+			startIdx, endIdx := rand.Intn(len(alphabet)-1), 1+rand.Intn(len(alphabet)-1)
+			if endIdx < startIdx {
+				startIdx, endIdx = endIdx, startIdx
+			}
+			spanStr := fmt.Sprintf("[%s, %s)", string(alphabet[startIdx]), string(alphabet[endIdx]))
+			if sp := parseSpan(t, spanStr); sp.Valid() {
+				return sp
+			}
+		}
+	}
+
+	getRandomConf := func() roachpb.SpanConfig {
+		confStr := fmt.Sprintf("conf%s", string(configs[rand.Intn(len(configs))]))
+		return parseConfig(t, confStr)
+	}
+
+	const numOps = 5000
+	testSpan := parseSpan(t, "[f,g)") // pin a single character span to test with.
+	for i := 0; i < numOps; i++ {
+		sp, conf := getRandomSpan(), getRandomConf()
+		op := ops[rand.Intn(2)]
+
+		switch op {
+		case "set":
+			t.Logf("set sp=%s conf=%s", printSpan(sp), printSpanConfig(conf))
+			storage.SetSpanConfig(sp, conf)
+			if testSpan.Overlaps(sp) {
+				expConfig, expFound = conf, true
+			}
+		case "del":
+			t.Logf("del sp=%s", printSpan(sp))
+			storage.SetSpanConfig(sp, roachpb.SpanConfig{})
+			if testSpan.Overlaps(sp) {
+				expConfig, expFound = roachpb.SpanConfig{}, false
+			}
+		default:
+			t.Fatalf("unexpected op: %s", op)
+		}
+	}
+
+	gotConfigs := storage.GetConfigsForSpan(testSpan)
+	if !expFound {
+		require.Len(t, gotConfigs, 0)
+	} else {
+		require.Len(t, gotConfigs, 1)
+		gotSpan, gotConfig := gotConfigs[0].Span, gotConfigs[0].Config
+		require.Truef(t, gotSpan.Contains(testSpan), "improper result: expected got-sp=%s to contain test-sp=%s",
+			printSpan(gotSpan), printSpan(testSpan))
+		require.Truef(t, expConfig.Equal(gotConfig), "mismatched configs: expected=%s got=%s",
+			printSpanConfig(expConfig), printSpanConfig(gotConfig))
+	}
+
+	var last roachpb.SpanConfigEntry
+	for i, cur := range storage.GetConfigsForSpan(parseSpan(t, "[a,z)")) {
+		if i == 0 {
+			last = cur
+			continue
+		}
+
+		// Span configs are returned in strictly sorted order.
+		require.True(t, last.Span.Key.Compare(cur.Span.Key) < 0,
+			"expected to find spans in strictly sorted order, found %s then %s",
+			printSpan(last.Span), printSpan(cur.Span))
+
+		// All span configs must also be non-overlapping.
+		require.Falsef(t, last.Span.Overlaps(cur.Span),
+			"expected non-overlapping spans, found %s and %s",
+			printSpan(last.Span), printSpan(cur.Span))
+
+		// If two span configs are found to adjacent to one another, they must
+		// have differing configs.
+		if last.Span.EndKey.Equal(cur.Span.Key) {
+			require.Falsef(t, last.Config.Equal(cur.Config),
+				"expected adjacent spans %s and %s to have different configs, found %s for both",
+				printSpan(last.Span), printSpan(cur.Span), printSpanConfig(cur.Config))
+		}
+	}
+}

--- a/pkg/spanconfig/spanconfigstore/testdata/basic
+++ b/pkg/spanconfig/spanconfigstore/testdata/basic
@@ -1,0 +1,39 @@
+# Test basic get/set/del operations where the spans retrieved are identical to the
+# ones stored.
+
+get span=[a,z)
+----
+
+set span=[b,d) conf=A
+----
+
+get span=[b,d)
+----
+[b,d):A
+
+set span=[f,g) conf=B
+----
+
+get span=[b,d)
+----
+[b,d):A
+
+get span=[b,g)
+----
+[b,d):A
+[f,g):B
+
+get span=[b,j)
+----
+[b,d):A
+[f,g):B
+
+del span=[f,g)
+----
+
+get span=[f,g)
+----
+
+get span=[b,j)
+----
+[b,d):A

--- a/pkg/spanconfig/spanconfigstore/testdata/overlap
+++ b/pkg/spanconfig/spanconfigstore/testdata/overlap
@@ -1,0 +1,47 @@
+# Test get/set/del operations where the spans overlap with the existing ones.
+
+set span=[b,h) conf=A
+----
+
+get span=[b,h)
+----
+[b,h):A
+
+set span=[d,f) conf=B
+----
+
+get span=[d,f)
+----
+[d,f):B
+
+get span=[b,h)
+----
+[b,d):A
+[d,f):B
+[f,h):A
+
+set span=[c,e) conf=C
+----
+
+get span=[b,h)
+----
+[b,c):A
+[c,e):C
+[e,f):B
+[f,h):A
+
+del span=[d,g)
+----
+
+get span=[b,h)
+----
+[b,c):A
+[c,d):C
+[g,h):A
+
+set span=[b,g) conf=A
+----
+
+get span=[b,h)
+----
+[b,h):A


### PR DESCRIPTION
Use a left-leaning rb-tree for the span config cache. Looks like I've re-invented util/interval.Tree without realizing. I'll swap it out later.

Release note: None
