### PR TITLE
release-20.2: Skip schemachange/random-load before 21.2

### DIFF
--- a/pkg/cmd/roachtest/schemachange_random_load.go
+++ b/pkg/cmd/roachtest/schemachange_random_load.go
@@ -27,6 +27,7 @@ func registerSchemaChangeRandomLoad(r *testRegistry) {
 		Name:       "schemachange/random-load",
 		Owner:      OwnerSQLSchema,
 		Cluster:    makeClusterSpec(3),
+		Skip:       "Skipped until 21.2 due to stability issues",
 		MinVersion: "v20.1.0",
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			maxOps := 5000
@@ -67,6 +68,7 @@ func registerRandomLoadBenchSpec(r *testRegistry, b randomLoadBenchSpec) {
 		Name:       name,
 		Owner:      OwnerSQLSchema,
 		Cluster:    makeClusterSpec(b.Nodes),
+		Skip:       "Skipped until 21.2 due to stability issues",
 		MinVersion: "v20.1.0",
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runSchemaChangeRandomLoad(ctx, t, c, b.Ops, b.Concurrency)


### PR DESCRIPTION
The schemachange/random-load roachtest is broken in 20.2 and 21.1.
Rather than backport the (rather invovled) changes required to make the
test run clean in these releases, we're skipping it with the hopes of
getting it clean in 21.2.

Release note: None

Release justification: Test-only change. Skipping failed test case.