### PR TITLE
release-21.1: Skip schemachange/random-load before 21.2

### DIFF
--- a/pkg/cmd/roachtest/schemachange_random_load.go
+++ b/pkg/cmd/roachtest/schemachange_random_load.go
@@ -29,6 +29,7 @@ func registerSchemaChangeRandomLoad(r *testRegistry) {
 		Name:       "schemachange/random-load",
 		Owner:      OwnerSQLSchema,
 		Cluster:    makeClusterSpec(3),
+		Skip:       "Skipped until 21.2 due to stability issues",
 		MinVersion: "v20.1.0",
 		// This is set while development is still happening on the workload and we
 		// fix (or bypass) minor schema change bugs that are discovered.


### PR DESCRIPTION
The schemachange/random-load roachtest is broken in 20.2 and 21.1.
Rather than backport the (rather invovled) changes required to make the
test run clean in these releases, we're skipping it with the hopes of
getting it clean in 21.2.

Release note: None

Release justification: Test-only change. Skipping failed test case.