### PR TITLE
cmd/roachprod: create roachprod gce nodes with zfs

### DIFF
--- a/pkg/cmd/roachprod/vm/gce/gcloud.go
+++ b/pkg/cmd/roachprod/vm/gce/gcloud.go
@@ -427,7 +427,7 @@ func (p *Provider) Create(names []string, opts vm.CreateOpts) error {
 	}
 
 	// Create GCE startup script file.
-	filename, err := writeStartupScript(extraMountOpts)
+	filename, err := writeStartupScript(extraMountOpts, opts.SSDOpts.FileSystem)
 	if err != nil {
 		return errors.Wrapf(err, "could not write GCE startup script to temp file")
 	}

--- a/pkg/cmd/roachprod/vm/vm.go
+++ b/pkg/cmd/roachprod/vm/vm.go
@@ -128,6 +128,13 @@ func (vl List) ProviderIDs() []string {
 	return ret
 }
 
+const (
+	// Zfs refers to the zfs file system.
+	Zfs = "zfs"
+	// Ext4 refers to the ext4 file system.
+	Ext4 = "ext4"
+)
+
 // CreateOpts is the set of options when creating VMs.
 type CreateOpts struct {
 	ClusterName    string
@@ -139,6 +146,8 @@ type CreateOpts struct {
 		// NoExt4Barrier, if set, makes the "-o nobarrier" flag be used when
 		// mounting the SSD. Ignored if UseLocalSSD is not set.
 		NoExt4Barrier bool
+		// The file system to be used. This is set to "ext4" by default.
+		FileSystem string
 	}
 	OsVolumeSize int
 }


### PR DESCRIPTION
We want the ability to run some roachtests on zfs. Prior to this commit,
we didn't have a way to create roachprod instances which use the zfs
file system, if they also use a local-ssd.

Release note: None