### PR TITLE
roachtest: fix acceptance/multitenant

### DIFF
--- a/pkg/cmd/roachtest/tests/multitenant_upgrade.go
+++ b/pkg/cmd/roachtest/tests/multitenant_upgrade.go
@@ -115,7 +115,7 @@ func (tn *tenantNode) start(ctx context.Context, t test.Test, c cluster.Cluster,
 		select {
 		case <-ctx.Done():
 			t.Fatal(ctx.Err())
-		case <-tn.errCh:
+		case err := <-tn.errCh:
 			t.Fatal(err)
 		default:
 		}


### PR DESCRIPTION
Or make it fail reliably, we will see in CI. Either way, we were passing
the wrong `err` object to `t.Fatal` and that is now fixed.

Closes #66803.

Release note: None
