### PR TITLE
testcluster: add missing nil check

### DIFF
--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -969,7 +969,7 @@ func (tc *TestCluster) MoveRangeLeaseNonCooperatively(
 		ls, err := r.TestingAcquireLease(ctx)
 		if err != nil {
 			log.Infof(ctx, "TestingAcquireLease failed: %s", err)
-			if lErr := (*roachpb.NotLeaseHolderError)(nil); errors.As(err, &lErr) {
+			if lErr := (*roachpb.NotLeaseHolderError)(nil); errors.As(err, &lErr) && lErr.Lease != nil {
 				newLease = lErr.Lease
 			} else {
 				return err


### PR DESCRIPTION
When moving a lease, when waiting for the new lease to show up,
we weren't accounting for the fact that a NotLeaseholderError
can be emitted without pointing at the correct lease. In such
a case, `MoveRangeNonCooperatively` would panic.

Fixes #67752.

Release note: None
