### PR TITLE
sql: copy hidden columns in CREATE TABLE LIKE

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -2715,6 +2715,57 @@ DATABASE add_regions_in_txn  ALTER DATABASE add_regions_in_txn CONFIGURE ZONE US
                              voter_constraints = '[+region=ca-central-1]',
                              lease_preferences = '[[+region=ca-central-1]]'
 
+statement ok
+CREATE TABLE regional_by_row_like (LIKE regional_by_row)
+
+query TT
+SHOW CREATE TABLE regional_by_row_like
+----
+regional_by_row_like                            CREATE TABLE public.regional_by_row_like (
+                                                pk INT8 NOT NULL,
+                                                i INT8 NULL,
+                                                crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL,
+                                                rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                                                CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
+                                                FAMILY "primary" (pk, i, crdb_region, rowid)
+) LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
+
+statement ok
+DROP TABLE regional_by_row_like;
+CREATE TABLE regional_by_row_like (LIKE regional_by_row INCLUDING INDEXES)
+
+query TT
+SHOW CREATE TABLE regional_by_row_like
+----
+regional_by_row_like                            CREATE TABLE public.regional_by_row_like (
+                                                pk INT8 NOT NULL,
+                                                i INT8 NULL,
+                                                crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
+                                                CONSTRAINT "primary" PRIMARY KEY (crdb_region ASC, pk ASC),
+                                                INDEX regional_by_row_i_idx (crdb_region ASC, i ASC),
+                                                FAMILY "primary" (pk, i, crdb_region)
+) LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
+
+
+statement ok
+DROP TABLE regional_by_row_like;
+CREATE TABLE regional_by_row_like (LIKE regional_by_row INCLUDING ALL)
+
+query TT
+SHOW CREATE TABLE regional_by_row_like
+----
+regional_by_row_like                            CREATE TABLE public.regional_by_row_like (
+                                                pk INT8 NOT NULL,
+                                                i INT8 NULL,
+                                                crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
+                                                CONSTRAINT "primary" PRIMARY KEY (crdb_region ASC, pk ASC),
+                                                INDEX regional_by_row_i_idx (crdb_region ASC, i ASC),
+                                                FAMILY "primary" (pk, i, crdb_region)
+) LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
+
+statement ok
+DROP TABLE regional_by_row_like
+
 query TT
 SHOW CREATE TABLE regional_by_row_as
 ----

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -2549,18 +2549,43 @@ func replaceLikeTableOpts(n *tree.CreateTable, params runParams) (tree.TableDefs
 			}
 		}
 
+		// Copy defaults of implicitly created columns if they are needed by indexes.
+		// This is required to ensure the newly created table still works as expected
+		// as these columns are required for certain features to work when used
+		// as an index.
+		shouldCopyColumnDefaultSet := make(map[string]struct{})
+		if opts.Has(tree.LikeTableOptIndexes) {
+			for _, idx := range td.NonDropIndexes() {
+				// Copy the rowid default if it was created implicitly by not specifying
+				// PRIMARY KEY.
+				if idx.Primary() && td.IsPrimaryIndexDefaultRowID() {
+					for i := 0; i < idx.NumKeyColumns(); i++ {
+						shouldCopyColumnDefaultSet[idx.GetKeyColumnName(i)] = struct{}{}
+					}
+				}
+				// Copy any implicitly created columns (e.g. hash-sharded indexes,
+				// REGIONAL BY ROW).
+				for i := 0; i < idx.ExplicitColumnStartIdx(); i++ {
+					for i := 0; i < idx.NumKeyColumns(); i++ {
+						shouldCopyColumnDefaultSet[idx.GetKeyColumnName(i)] = struct{}{}
+					}
+				}
+			}
+		}
+
 		defs := make(tree.TableDefs, 0)
 		// Add all columns. Columns are always added.
 		for i := range td.Columns {
 			c := &td.Columns[i]
-			if c.Hidden || c.Inaccessible {
-				// Hidden and inaccessible columns automatically get added by
+			if c.Inaccessible {
+				// Inaccessible columns automatically get added by
 				// the system; we don't need to add them ourselves here.
 				continue
 			}
 			def := tree.ColumnTableDef{
-				Name: tree.Name(c.Name),
-				Type: c.Type,
+				Name:   tree.Name(c.Name),
+				Type:   c.Type,
+				Hidden: c.Hidden,
 			}
 			if c.Nullable {
 				def.Nullable.Nullability = tree.Null
@@ -2568,7 +2593,8 @@ func replaceLikeTableOpts(n *tree.CreateTable, params runParams) (tree.TableDefs
 				def.Nullable.Nullability = tree.NotNull
 			}
 			if c.DefaultExpr != nil {
-				if opts.Has(tree.LikeTableOptDefaults) {
+				_, shouldCopyColumnDefault := shouldCopyColumnDefaultSet[c.Name]
+				if opts.Has(tree.LikeTableOptDefaults) || shouldCopyColumnDefault {
 					def.DefaultExpr.Expr, err = parser.ParseExpr(*c.DefaultExpr)
 					if err != nil {
 						return nil, err
@@ -2668,10 +2694,6 @@ func replaceLikeTableOpts(n *tree.CreateTable, params runParams) (tree.TableDefs
 				}
 				var def tree.TableDef = &indexDef
 				if idx.IsUnique() {
-					if idx.Primary() && td.IsPrimaryIndexDefaultRowID() {
-						continue
-					}
-
 					def = &tree.UniqueConstraintTableDef{
 						IndexTableDef: indexDef,
 						PrimaryKey:    idx.Primary(),

--- a/pkg/sql/logictest/testdata/logic_test/create_table
+++ b/pkg/sql/logictest/testdata/logic_test/create_table
@@ -323,10 +323,11 @@ like_more_specifiers  CREATE TABLE public.like_more_specifiers (
                       k INT8 NULL,
                       z DECIMAL NULL,
                       blah INT8 NULL,
-                      rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-                      CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
+                      rowid INT8 NOT VISIBLE NOT NULL,
+                      rowid_1 INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                      CONSTRAINT "primary" PRIMARY KEY (rowid_1 ASC),
                       INDEX like_more_specifiers_a_blah_z_idx (a ASC, blah ASC, z ASC),
-                      FAMILY "primary" (a, b, c, h, j, k, z, blah, rowid)
+                      FAMILY "primary" (a, b, c, h, j, k, z, blah, rowid, rowid_1)
 )
 
 statement ok
@@ -340,11 +341,41 @@ SHOW CREATE TABLE like_hash
 ----
 like_hash  CREATE TABLE public.like_hash (
            a INT8 NULL,
+           crdb_internal_a_shard_4 INT4 NOT VISIBLE NOT NULL,
+           rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+           CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
+           INDEX like_hash_base_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 4,
+           FAMILY "primary" (a, crdb_internal_a_shard_4, rowid)
+)
+
+statement ok
+DROP TABLE like_hash; CREATE TABLE like_hash (LIKE like_hash_base INCLUDING ALL)
+
+query TT
+SHOW CREATE TABLE like_hash
+----
+like_hash  CREATE TABLE public.like_hash (
+           a INT8 NULL,
            crdb_internal_a_shard_4 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(a AS STRING), '':::STRING)), 4:::INT8)) STORED,
            rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
            CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
            INDEX like_hash_base_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 4,
            FAMILY "primary" (a, crdb_internal_a_shard_4, rowid)
+)
+
+statement ok
+CREATE TABLE regression_67196 (pk INT PRIMARY KEY, hidden INT NOT VISIBLE);
+CREATE TABLE regression_67196_like (LIKE regression_67196)
+
+query TT
+SHOW CREATE TABLE regression_67196_like
+----
+regression_67196_like  CREATE TABLE public.regression_67196_like (
+                       pk INT8 NOT NULL,
+                       hidden INT8 NOT VISIBLE NULL,
+                       rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                       CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
+                       FAMILY "primary" (pk, hidden, rowid)
 )
 
 statement error unimplemented


### PR DESCRIPTION
Resolves #67196

Release note (sql change): CREATE TABLE LIKE now copies hidden columns
over.