### PR TITLE
lint: add a linter for the cockroach-sql imports

### DIFF
--- a/pkg/cmd/dev/build.go
+++ b/pkg/cmd/dev/build.go
@@ -68,6 +68,7 @@ var buildTargetMapping = map[string]string{
 	"buildifier":       "@com_github_bazelbuild_buildtools//buildifier:buildifier",
 	"buildozer":        "@com_github_bazelbuild_buildtools//buildozer:buildozer",
 	"cockroach":        "//pkg/cmd/cockroach:cockroach",
+	"cockroach-sql":    "//pkg/cmd/cockroach-sql:cockroach-sql",
 	"cockroach-oss":    "//pkg/cmd/cockroach-oss:cockroach-oss",
 	"cockroach-short":  "//pkg/cmd/cockroach-short:cockroach-short",
 	"crlfmt":           "@com_github_cockroachdb_crlfmt//:crlfmt",

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1518,6 +1518,54 @@ func TestLint(t *testing.T) {
 		}
 	})
 
+	t.Run("TestForbiddenImportsSQLShell", func(t *testing.T) {
+		t.Parallel()
+
+		cmd, stderr, filter, err := dirCmd(crdb.Dir, "go", "list", "-deps",
+			filepath.Join(cockroachDB, "./pkg/cmd/cockroach-sql"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := cmd.Start(); err != nil {
+			t.Fatal(err)
+		}
+
+		// forbiddenImportPkg
+		forbiddenImports := map[string]struct{}{
+			"github.com/cockroachdb/pebble":                     {},
+			"github.com/cockroachdb/cockroach/pkg/cli":          {},
+			"github.com/cockroachdb/cockroach/pkg/kv/kvserver":  {},
+			"github.com/cockroachdb/cockroach/pkg/roachpb":      {},
+			"github.com/cockroachdb/cockroach/pkg/server":       {},
+			"github.com/cockroachdb/cockroach/pkg/sql":          {},
+			"github.com/cockroachdb/cockroach/pkg/sql/catalog":  {},
+			"github.com/cockroachdb/cockroach/pkg/sql/parser":   {},
+			"github.com/cockroachdb/cockroach/pkg/sql/sem/tree": {},
+			"github.com/cockroachdb/cockroach/pkg/storage":      {},
+			"github.com/cockroachdb/cockroach/pkg/util/log":     {},
+			"github.com/cockroachdb/cockroach/pkg/util/stop":    {},
+			"github.com/cockroachdb/cockroach/pkg/util/tracing": {},
+		}
+
+		if err := stream.ForEach(
+			stream.Sequence(
+				filter,
+				stream.Sort(),
+				stream.Uniq()),
+			func(s string) {
+				if _, ok := forbiddenImports[s]; ok {
+					t.Errorf("\ncockroach-sql depends on %s <- forbidden, this import makes the SQL shell too large", s)
+				}
+			}); err != nil {
+			t.Error(err)
+		}
+		if err := cmd.Wait(); err != nil {
+			if out := stderr.String(); len(out) > 0 {
+				t.Fatalf("err=%s, stderr=%s", err, out)
+			}
+		}
+	})
+
 	// TODO(tamird): replace this with errcheck.NewChecker() when
 	// https://github.com/dominikh/go-tools/issues/57 is fixed.
 	t.Run("TestErrCheck", func(t *testing.T) {


### PR DESCRIPTION
This linter prevents the re-addition of unwanted dependencies.

