### PR TITLE
colexecbase: bring back an identity cast between floats

### DIFF
--- a/pkg/sql/colexec/colexecbase/cast.eg.go
+++ b/pkg/sql/colexec/colexecbase/cast.eg.go
@@ -50,8 +50,11 @@ func GetCastOperator(
 	if fromType.Family() == types.UnknownFamily {
 		return &castOpNullAny{castOpBase: base}, nil
 	}
-	if toType.Identical(fromType) {
-		// We have an identity cast, so we use a custom identity cast operator.
+	if toType.Identical(fromType) || (fromType.Family() == types.FloatFamily && toType.Family() == types.FloatFamily) {
+		// We either have an identity cast or we have a cast between floats (and
+		// all floats are represented by float64 physically, so they are
+		// essentially identical too), so we use a custom identity cast
+		// operator.
 		return &castIdentityOp{castOpBase: base}, nil
 	}
 	isFromDatum := typeconv.TypeFamilyToCanonicalTypeFamily(fromType.Family()) == typeconv.DatumVecCanonicalTypeFamily
@@ -287,7 +290,7 @@ func IsCastSupported(fromType, toType *types.T) bool {
 	if fromType.Family() == types.UnknownFamily {
 		return true
 	}
-	if toType.Identical(fromType) {
+	if toType.Identical(fromType) || (fromType.Family() == types.FloatFamily && toType.Family() == types.FloatFamily) {
 		return true
 	}
 	isFromDatum := typeconv.TypeFamilyToCanonicalTypeFamily(fromType.Family()) == typeconv.DatumVecCanonicalTypeFamily

--- a/pkg/sql/colexec/colexecbase/cast_tmpl.go
+++ b/pkg/sql/colexec/colexecbase/cast_tmpl.go
@@ -84,8 +84,11 @@ func GetCastOperator(
 	if fromType.Family() == types.UnknownFamily {
 		return &castOpNullAny{castOpBase: base}, nil
 	}
-	if toType.Identical(fromType) {
-		// We have an identity cast, so we use a custom identity cast operator.
+	if toType.Identical(fromType) || (fromType.Family() == types.FloatFamily && toType.Family() == types.FloatFamily) {
+		// We either have an identity cast or we have a cast between floats (and
+		// all floats are represented by float64 physically, so they are
+		// essentially identical too), so we use a custom identity cast
+		// operator.
 		return &castIdentityOp{castOpBase: base}, nil
 	}
 	isFromDatum := typeconv.TypeFamilyToCanonicalTypeFamily(fromType.Family()) == typeconv.DatumVecCanonicalTypeFamily
@@ -139,7 +142,7 @@ func IsCastSupported(fromType, toType *types.T) bool {
 	if fromType.Family() == types.UnknownFamily {
 		return true
 	}
-	if toType.Identical(fromType) {
+	if toType.Identical(fromType) || (fromType.Family() == types.FloatFamily && toType.Family() == types.FloatFamily) {
 		return true
 	}
 	isFromDatum := typeconv.TypeFamilyToCanonicalTypeFamily(fromType.Family()) == typeconv.DatumVecCanonicalTypeFamily

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -1231,3 +1231,21 @@ SELECT CASE WHEN _bool THEN _string ELSE _string END FROM t64793;
 4
 5
 NULL
+
+# Regression test for not supporting casts between FLOAT4 and FLOAT8 (which have
+# the same physical representation in the vectorized engine) (#67793).
+statement ok
+CREATE TABLE t67793 (_float4 FLOAT4, _float8 FLOAT8);
+INSERT INTO t67793 VALUES (1, 2), (2, 1);
+
+query RR rowsort
+SELECT t1._float8, t2._float4 FROM t67793 AS t1, t67793 AS t2 WHERE t1._float4 = t2._float8
+----
+1  1
+2  2
+
+query RR rowsort
+SELECT _float4::FLOAT8, _float8::FLOAT4 FROM t67793
+----
+1  2
+2  1


### PR DESCRIPTION
We recently by mistake removed the support of identity casts between
floats. In the vectorized engine both FLOAT4 and FLOAT8 are represented
as float64, so we just need to special case the cast between floats of
any width to be resolved as an "identity" cast.

Fixes: #67793

Release note: None