### PR TITLE
kv: revive slow Raft proposal quota acquisition logging

### DIFF
--- a/pkg/util/quotapool/config.go
+++ b/pkg/util/quotapool/config.go
@@ -66,10 +66,10 @@ func OnSlowAcquisition(threshold time.Duration, f SlowAcquisitionFunc) Option {
 // LogSlowAcquisition is a SlowAcquisitionFunc.
 func LogSlowAcquisition(ctx context.Context, poolName string, r Request, start time.Time) func() {
 	log.Warningf(ctx, "have been waiting %s attempting to acquire %s quota",
-		timeutil.Since(start), poolName)
+		timeutil.Since(start), log.Safe(poolName))
 	return func() {
 		log.Infof(ctx, "acquired %s quota after %s",
-			poolName, timeutil.Since(start))
+			log.Safe(poolName), timeutil.Since(start))
 	}
 }
 


### PR DESCRIPTION
This was unintentionally (I assume) lost in 0013508.

The change also marks the pool name as safe for the purposes of log
redaction. This leads to log messages that look like:

```
W210720 16:53:39.242581 588 util/quotapool/config.go:68 ⋮ [n1,s1,r40/1:‹/{Table/53-Max}›] 696  have been waiting 60.0s attempting to acquire raft proposal quota
I210720 16:53:39.279603 251 util/quotapool/config.go:71 ⋮ [n1,s1,r40/1:‹/{Table/53-Max}›] 696  acquired raft proposal quota after 120.0s
```