### PR TITLE
base: drop SlowRequestThreshold to 15s

### DIFF
--- a/pkg/base/constants.go
+++ b/pkg/base/constants.go
@@ -28,7 +28,7 @@ const (
 
 	// SlowRequestThreshold is the amount of time to wait before considering a
 	// request to be "slow".
-	SlowRequestThreshold = 60 * time.Second
+	SlowRequestThreshold = 15 * time.Second
 
 	// ChunkRaftCommandThresholdBytes is the threshold in bytes at which
 	// to chunk or otherwise limit commands being sent to Raft.


### PR DESCRIPTION
This commit drops `SlowRequestThreshold` from 60s to 15s. This constant
dictates the delay before we consider the following four operations to
be slow enough to log and/or increment "slow request" metrics:
- raft proposals
- raft proposal quota acquisition
- lease acquisition
- latch acquisition