### PR TITLE
changefeedccl: Reduce the rate of changefeed progress checkpoints.

### DIFF
--- a/pkg/ccl/changefeedccl/changefeedbase/settings.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/settings.go
@@ -128,3 +128,14 @@ func validateSinkThrottleConfig(values *settings.Values, configStr string) error
 	var config = &SinkThrottleConfig{}
 	return json.Unmarshal([]byte(configStr), config)
 }
+
+// MinHighWaterMarkCheckpointAdvance specifies the minimum amount of time the
+// changefeed high water mark must advance for it to be eligible for checkpointing.
+var MinHighWaterMarkCheckpointAdvance = settings.RegisterDurationSetting(
+	"changefeed.min_highwater_advance",
+	`minimum amount of time the changefeed high water mark must advance 
+for it to be eligible for checkpointing; Default of 0 will checkpoint every time frontier advances,
+as long as the rate of checkpointing keeps up with the rate of frontier changes`,
+	0,
+	settings.NonNegativeDuration,
+)


### PR DESCRIPTION
Reduce the rate of changefdeed high water mark checkpoints.
This is accomplished by keeping track of the duration of the job
progress update.  If the frontier advances more rapidly than the time
it takes to update job progress, then, some of those updates are
skipped.

In addition, we introduce a `changefeed.min_highwater_advance` cluster
setting which specifies the minimum amount of time that must elapse
since the previous job progress update.  This allows an operator
who does not necessarrily need to have every frontier update
checkpointed, to further reduce the rate of such checkpoints.

Informs #49720

Release Notes: Improve changefeed scalability, particularly when running
against large tables, by reducing the rate of job progress updates.