### PR TITLE
sql: removed pg_stat exclusion for pg_catalog

### DIFF
--- a/pkg/cmd/generate-metadata-tables/rdbms/postgres.go
+++ b/pkg/cmd/generate-metadata-tables/rdbms/postgres.go
@@ -44,16 +44,7 @@ var unimplementedEquivalencies = map[oid.Oid]oid.Oid{
 	oid.T_pg_lsn:       oid.T_text,
 }
 
-var emptyStruct = struct{}{}
-
 var postgresExclusions = []*excludePattern{
-	{
-		pattern: regexp.MustCompile(`^pg_stat.+$`),
-		except: map[string]struct{}{
-			"pg_stat_database":           emptyStruct,
-			"pg_stat_database_conflicts": emptyStruct,
-		},
-	},
 	{
 		pattern: regexp.MustCompile(`^_pg_.+$`),
 		except:  make(map[string]struct{}),

--- a/pkg/sql/testdata/pg_catalog_tables_from_postgres.json
+++ b/pkg/sql/testdata/pg_catalog_tables_from_postgres.json
@@ -3664,6 +3664,436 @@
         "expectedDataType": null
       }
     },
+    "pg_stat_activity": {
+      "application_name": {
+        "oid": 25,
+        "dataType": "text",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "backend_start": {
+        "oid": 1184,
+        "dataType": "timestamptz",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "backend_type": {
+        "oid": 25,
+        "dataType": "text",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "backend_xid": {
+        "oid": 20,
+        "dataType": "INT8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "backend_xmin": {
+        "oid": 20,
+        "dataType": "INT8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "client_addr": {
+        "oid": 869,
+        "dataType": "inet",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "client_hostname": {
+        "oid": 25,
+        "dataType": "text",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "client_port": {
+        "oid": 23,
+        "dataType": "int4",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "datid": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "datname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "leader_pid": {
+        "oid": 23,
+        "dataType": "int4",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "pid": {
+        "oid": 23,
+        "dataType": "int4",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "query": {
+        "oid": 25,
+        "dataType": "text",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "query_start": {
+        "oid": 1184,
+        "dataType": "timestamptz",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "state": {
+        "oid": 25,
+        "dataType": "text",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "state_change": {
+        "oid": 1184,
+        "dataType": "timestamptz",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "usename": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "usesysid": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "wait_event": {
+        "oid": 25,
+        "dataType": "text",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "wait_event_type": {
+        "oid": 25,
+        "dataType": "text",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "xact_start": {
+        "oid": 1184,
+        "dataType": "timestamptz",
+        "expectedOid": null,
+        "expectedDataType": null
+      }
+    },
+    "pg_stat_all_indexes": {
+      "idx_scan": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "idx_tup_fetch": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "idx_tup_read": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "indexrelid": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "indexrelname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "relid": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "relname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "schemaname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      }
+    },
+    "pg_stat_all_tables": {
+      "analyze_count": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "autoanalyze_count": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "autovacuum_count": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "idx_scan": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "idx_tup_fetch": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "last_analyze": {
+        "oid": 1184,
+        "dataType": "timestamptz",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "last_autoanalyze": {
+        "oid": 1184,
+        "dataType": "timestamptz",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "last_autovacuum": {
+        "oid": 1184,
+        "dataType": "timestamptz",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "last_vacuum": {
+        "oid": 1184,
+        "dataType": "timestamptz",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "n_dead_tup": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "n_ins_since_vacuum": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "n_live_tup": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "n_mod_since_analyze": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "n_tup_del": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "n_tup_hot_upd": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "n_tup_ins": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "n_tup_upd": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "relid": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "relname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "schemaname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "seq_scan": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "seq_tup_read": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "vacuum_count": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      }
+    },
+    "pg_stat_archiver": {
+      "archived_count": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "failed_count": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "last_archived_time": {
+        "oid": 1184,
+        "dataType": "timestamptz",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "last_archived_wal": {
+        "oid": 25,
+        "dataType": "text",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "last_failed_time": {
+        "oid": 1184,
+        "dataType": "timestamptz",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "last_failed_wal": {
+        "oid": 25,
+        "dataType": "text",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "stats_reset": {
+        "oid": 1184,
+        "dataType": "timestamptz",
+        "expectedOid": null,
+        "expectedDataType": null
+      }
+    },
+    "pg_stat_bgwriter": {
+      "buffers_alloc": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "buffers_backend": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "buffers_backend_fsync": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "buffers_checkpoint": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "buffers_clean": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "checkpoint_sync_time": {
+        "oid": 701,
+        "dataType": "float8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "checkpoint_write_time": {
+        "oid": 701,
+        "dataType": "float8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "checkpoints_req": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "checkpoints_timed": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "maxwritten_clean": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "stats_reset": {
+        "oid": 1184,
+        "dataType": "timestamptz",
+        "expectedOid": null,
+        "expectedDataType": null
+      }
+    },
     "pg_stat_database": {
       "blk_read_time": {
         "oid": 701,
@@ -3830,6 +4260,2288 @@
         "expectedDataType": null
       },
       "datname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      }
+    },
+    "pg_stat_gssapi": {
+      "encrypted": {
+        "oid": 16,
+        "dataType": "bool",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "gss_authenticated": {
+        "oid": 16,
+        "dataType": "bool",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "pid": {
+        "oid": 23,
+        "dataType": "int4",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "principal": {
+        "oid": 25,
+        "dataType": "text",
+        "expectedOid": null,
+        "expectedDataType": null
+      }
+    },
+    "pg_stat_progress_analyze": {
+      "child_tables_done": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "child_tables_total": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "current_child_table_relid": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "datid": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "datname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "ext_stats_computed": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "ext_stats_total": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "phase": {
+        "oid": 25,
+        "dataType": "text",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "pid": {
+        "oid": 23,
+        "dataType": "int4",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "relid": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "sample_blks_scanned": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "sample_blks_total": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      }
+    },
+    "pg_stat_progress_basebackup": {
+      "backup_streamed": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "backup_total": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "phase": {
+        "oid": 25,
+        "dataType": "text",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "pid": {
+        "oid": 23,
+        "dataType": "int4",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "tablespaces_streamed": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "tablespaces_total": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      }
+    },
+    "pg_stat_progress_cluster": {
+      "cluster_index_relid": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "command": {
+        "oid": 25,
+        "dataType": "text",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "datid": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "datname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "heap_blks_scanned": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "heap_blks_total": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "heap_tuples_scanned": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "heap_tuples_written": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "index_rebuild_count": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "phase": {
+        "oid": 25,
+        "dataType": "text",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "pid": {
+        "oid": 23,
+        "dataType": "int4",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "relid": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      }
+    },
+    "pg_stat_progress_create_index": {
+      "blocks_done": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "blocks_total": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "command": {
+        "oid": 25,
+        "dataType": "text",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "current_locker_pid": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "datid": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "datname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "index_relid": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "lockers_done": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "lockers_total": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "partitions_done": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "partitions_total": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "phase": {
+        "oid": 25,
+        "dataType": "text",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "pid": {
+        "oid": 23,
+        "dataType": "int4",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "relid": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "tuples_done": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "tuples_total": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      }
+    },
+    "pg_stat_progress_vacuum": {
+      "datid": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "datname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "heap_blks_scanned": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "heap_blks_total": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "heap_blks_vacuumed": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "index_vacuum_count": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "max_dead_tuples": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "num_dead_tuples": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "phase": {
+        "oid": 25,
+        "dataType": "text",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "pid": {
+        "oid": 23,
+        "dataType": "int4",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "relid": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      }
+    },
+    "pg_stat_replication": {
+      "application_name": {
+        "oid": 25,
+        "dataType": "text",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "backend_start": {
+        "oid": 1184,
+        "dataType": "timestamptz",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "backend_xmin": {
+        "oid": 20,
+        "dataType": "INT8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "client_addr": {
+        "oid": 869,
+        "dataType": "inet",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "client_hostname": {
+        "oid": 25,
+        "dataType": "text",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "client_port": {
+        "oid": 23,
+        "dataType": "int4",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "flush_lag": {
+        "oid": 1186,
+        "dataType": "interval",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "flush_lsn": {
+        "oid": 25,
+        "dataType": "TEXT",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "pid": {
+        "oid": 23,
+        "dataType": "int4",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "replay_lag": {
+        "oid": 1186,
+        "dataType": "interval",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "replay_lsn": {
+        "oid": 25,
+        "dataType": "TEXT",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "reply_time": {
+        "oid": 1184,
+        "dataType": "timestamptz",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "sent_lsn": {
+        "oid": 25,
+        "dataType": "TEXT",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "state": {
+        "oid": 25,
+        "dataType": "text",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "sync_priority": {
+        "oid": 23,
+        "dataType": "int4",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "sync_state": {
+        "oid": 25,
+        "dataType": "text",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "usename": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "usesysid": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "write_lag": {
+        "oid": 1186,
+        "dataType": "interval",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "write_lsn": {
+        "oid": 25,
+        "dataType": "TEXT",
+        "expectedOid": null,
+        "expectedDataType": null
+      }
+    },
+    "pg_stat_slru": {
+      "blks_exists": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "blks_hit": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "blks_read": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "blks_written": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "blks_zeroed": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "flushes": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "name": {
+        "oid": 25,
+        "dataType": "text",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "stats_reset": {
+        "oid": 1184,
+        "dataType": "timestamptz",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "truncates": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      }
+    },
+    "pg_stat_ssl": {
+      "bits": {
+        "oid": 23,
+        "dataType": "int4",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "cipher": {
+        "oid": 25,
+        "dataType": "text",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "client_dn": {
+        "oid": 25,
+        "dataType": "text",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "client_serial": {
+        "oid": 1700,
+        "dataType": "numeric",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "compression": {
+        "oid": 16,
+        "dataType": "bool",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "issuer_dn": {
+        "oid": 25,
+        "dataType": "text",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "pid": {
+        "oid": 23,
+        "dataType": "int4",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "ssl": {
+        "oid": 16,
+        "dataType": "bool",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "version": {
+        "oid": 25,
+        "dataType": "text",
+        "expectedOid": null,
+        "expectedDataType": null
+      }
+    },
+    "pg_stat_subscription": {
+      "last_msg_receipt_time": {
+        "oid": 1184,
+        "dataType": "timestamptz",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "last_msg_send_time": {
+        "oid": 1184,
+        "dataType": "timestamptz",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "latest_end_lsn": {
+        "oid": 25,
+        "dataType": "TEXT",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "latest_end_time": {
+        "oid": 1184,
+        "dataType": "timestamptz",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "pid": {
+        "oid": 23,
+        "dataType": "int4",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "received_lsn": {
+        "oid": 25,
+        "dataType": "TEXT",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "relid": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "subid": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "subname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      }
+    },
+    "pg_stat_sys_indexes": {
+      "idx_scan": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "idx_tup_fetch": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "idx_tup_read": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "indexrelid": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "indexrelname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "relid": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "relname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "schemaname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      }
+    },
+    "pg_stat_sys_tables": {
+      "analyze_count": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "autoanalyze_count": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "autovacuum_count": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "idx_scan": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "idx_tup_fetch": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "last_analyze": {
+        "oid": 1184,
+        "dataType": "timestamptz",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "last_autoanalyze": {
+        "oid": 1184,
+        "dataType": "timestamptz",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "last_autovacuum": {
+        "oid": 1184,
+        "dataType": "timestamptz",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "last_vacuum": {
+        "oid": 1184,
+        "dataType": "timestamptz",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "n_dead_tup": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "n_ins_since_vacuum": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "n_live_tup": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "n_mod_since_analyze": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "n_tup_del": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "n_tup_hot_upd": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "n_tup_ins": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "n_tup_upd": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "relid": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "relname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "schemaname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "seq_scan": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "seq_tup_read": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "vacuum_count": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      }
+    },
+    "pg_stat_user_functions": {
+      "calls": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "funcid": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "funcname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "schemaname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "self_time": {
+        "oid": 701,
+        "dataType": "float8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "total_time": {
+        "oid": 701,
+        "dataType": "float8",
+        "expectedOid": null,
+        "expectedDataType": null
+      }
+    },
+    "pg_stat_user_indexes": {
+      "idx_scan": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "idx_tup_fetch": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "idx_tup_read": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "indexrelid": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "indexrelname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "relid": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "relname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "schemaname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      }
+    },
+    "pg_stat_user_tables": {
+      "analyze_count": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "autoanalyze_count": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "autovacuum_count": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "idx_scan": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "idx_tup_fetch": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "last_analyze": {
+        "oid": 1184,
+        "dataType": "timestamptz",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "last_autoanalyze": {
+        "oid": 1184,
+        "dataType": "timestamptz",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "last_autovacuum": {
+        "oid": 1184,
+        "dataType": "timestamptz",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "last_vacuum": {
+        "oid": 1184,
+        "dataType": "timestamptz",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "n_dead_tup": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "n_ins_since_vacuum": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "n_live_tup": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "n_mod_since_analyze": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "n_tup_del": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "n_tup_hot_upd": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "n_tup_ins": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "n_tup_upd": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "relid": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "relname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "schemaname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "seq_scan": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "seq_tup_read": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "vacuum_count": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      }
+    },
+    "pg_stat_wal_receiver": {
+      "conninfo": {
+        "oid": 25,
+        "dataType": "text",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "flushed_lsn": {
+        "oid": 25,
+        "dataType": "TEXT",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "last_msg_receipt_time": {
+        "oid": 1184,
+        "dataType": "timestamptz",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "last_msg_send_time": {
+        "oid": 1184,
+        "dataType": "timestamptz",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "latest_end_lsn": {
+        "oid": 25,
+        "dataType": "TEXT",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "latest_end_time": {
+        "oid": 1184,
+        "dataType": "timestamptz",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "pid": {
+        "oid": 23,
+        "dataType": "int4",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "receive_start_lsn": {
+        "oid": 25,
+        "dataType": "TEXT",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "receive_start_tli": {
+        "oid": 23,
+        "dataType": "int4",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "received_tli": {
+        "oid": 23,
+        "dataType": "int4",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "sender_host": {
+        "oid": 25,
+        "dataType": "text",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "sender_port": {
+        "oid": 23,
+        "dataType": "int4",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "slot_name": {
+        "oid": 25,
+        "dataType": "text",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "status": {
+        "oid": 25,
+        "dataType": "text",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "written_lsn": {
+        "oid": 25,
+        "dataType": "TEXT",
+        "expectedOid": null,
+        "expectedDataType": null
+      }
+    },
+    "pg_stat_xact_all_tables": {
+      "idx_scan": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "idx_tup_fetch": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "n_tup_del": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "n_tup_hot_upd": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "n_tup_ins": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "n_tup_upd": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "relid": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "relname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "schemaname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "seq_scan": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "seq_tup_read": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      }
+    },
+    "pg_stat_xact_sys_tables": {
+      "idx_scan": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "idx_tup_fetch": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "n_tup_del": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "n_tup_hot_upd": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "n_tup_ins": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "n_tup_upd": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "relid": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "relname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "schemaname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "seq_scan": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "seq_tup_read": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      }
+    },
+    "pg_stat_xact_user_functions": {
+      "calls": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "funcid": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "funcname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "schemaname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "self_time": {
+        "oid": 701,
+        "dataType": "float8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "total_time": {
+        "oid": 701,
+        "dataType": "float8",
+        "expectedOid": null,
+        "expectedDataType": null
+      }
+    },
+    "pg_stat_xact_user_tables": {
+      "idx_scan": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "idx_tup_fetch": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "n_tup_del": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "n_tup_hot_upd": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "n_tup_ins": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "n_tup_upd": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "relid": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "relname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "schemaname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "seq_scan": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "seq_tup_read": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      }
+    },
+    "pg_statio_all_indexes": {
+      "idx_blks_hit": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "idx_blks_read": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "indexrelid": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "indexrelname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "relid": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "relname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "schemaname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      }
+    },
+    "pg_statio_all_sequences": {
+      "blks_hit": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "blks_read": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "relid": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "relname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "schemaname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      }
+    },
+    "pg_statio_all_tables": {
+      "heap_blks_hit": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "heap_blks_read": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "idx_blks_hit": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "idx_blks_read": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "relid": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "relname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "schemaname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "tidx_blks_hit": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "tidx_blks_read": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "toast_blks_hit": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "toast_blks_read": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      }
+    },
+    "pg_statio_sys_indexes": {
+      "idx_blks_hit": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "idx_blks_read": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "indexrelid": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "indexrelname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "relid": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "relname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "schemaname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      }
+    },
+    "pg_statio_sys_sequences": {
+      "blks_hit": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "blks_read": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "relid": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "relname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "schemaname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      }
+    },
+    "pg_statio_sys_tables": {
+      "heap_blks_hit": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "heap_blks_read": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "idx_blks_hit": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "idx_blks_read": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "relid": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "relname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "schemaname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "tidx_blks_hit": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "tidx_blks_read": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "toast_blks_hit": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "toast_blks_read": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      }
+    },
+    "pg_statio_user_indexes": {
+      "idx_blks_hit": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "idx_blks_read": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "indexrelid": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "indexrelname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "relid": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "relname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "schemaname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      }
+    },
+    "pg_statio_user_sequences": {
+      "blks_hit": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "blks_read": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "relid": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "relname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "schemaname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      }
+    },
+    "pg_statio_user_tables": {
+      "heap_blks_hit": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "heap_blks_read": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "idx_blks_hit": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "idx_blks_read": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "relid": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "relname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "schemaname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "tidx_blks_hit": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "tidx_blks_read": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "toast_blks_hit": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "toast_blks_read": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": null,
+        "expectedDataType": null
+      }
+    },
+    "pg_statistic": {
+      "staattnum": {
+        "oid": 21,
+        "dataType": "int2",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "stacoll1": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "stacoll2": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "stacoll3": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "stacoll4": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "stacoll5": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "stadistinct": {
+        "oid": 700,
+        "dataType": "float4",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "stainherit": {
+        "oid": 16,
+        "dataType": "bool",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "stakind1": {
+        "oid": 21,
+        "dataType": "int2",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "stakind2": {
+        "oid": 21,
+        "dataType": "int2",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "stakind3": {
+        "oid": 21,
+        "dataType": "int2",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "stakind4": {
+        "oid": 21,
+        "dataType": "int2",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "stakind5": {
+        "oid": 21,
+        "dataType": "int2",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "stanullfrac": {
+        "oid": 700,
+        "dataType": "float4",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "stanumbers1": {
+        "oid": 1021,
+        "dataType": "_float4",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "stanumbers2": {
+        "oid": 1021,
+        "dataType": "_float4",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "stanumbers3": {
+        "oid": 1021,
+        "dataType": "_float4",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "stanumbers4": {
+        "oid": 1021,
+        "dataType": "_float4",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "stanumbers5": {
+        "oid": 1021,
+        "dataType": "_float4",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "staop1": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "staop2": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "staop3": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "staop4": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "staop5": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "starelid": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "stavalues1": {
+        "oid": 2277,
+        "dataType": "anyarray",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "stavalues2": {
+        "oid": 2277,
+        "dataType": "anyarray",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "stavalues3": {
+        "oid": 2277,
+        "dataType": "anyarray",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "stavalues4": {
+        "oid": 2277,
+        "dataType": "anyarray",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "stavalues5": {
+        "oid": 2277,
+        "dataType": "anyarray",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "stawidth": {
+        "oid": 23,
+        "dataType": "int4",
+        "expectedOid": null,
+        "expectedDataType": null
+      }
+    },
+    "pg_statistic_ext": {
+      "oid": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "stxkeys": {
+        "oid": 22,
+        "dataType": "int2vector",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "stxkind": {
+        "oid": 1002,
+        "dataType": "_char",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "stxname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "stxnamespace": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "stxowner": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "stxrelid": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "stxstattarget": {
+        "oid": 23,
+        "dataType": "int4",
+        "expectedOid": null,
+        "expectedDataType": null
+      }
+    },
+    "pg_statistic_ext_data": {
+      "stxddependencies": {
+        "oid": 3402,
+        "dataType": "pg_dependencies",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "stxdmcv": {
+        "oid": 5017,
+        "dataType": "pg_mcv_list",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "stxdndistinct": {
+        "oid": 3361,
+        "dataType": "pg_ndistinct",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "stxoid": {
+        "oid": 26,
+        "dataType": "oid",
+        "expectedOid": null,
+        "expectedDataType": null
+      }
+    },
+    "pg_stats": {
+      "attname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "avg_width": {
+        "oid": 23,
+        "dataType": "int4",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "correlation": {
+        "oid": 700,
+        "dataType": "float4",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "elem_count_histogram": {
+        "oid": 1021,
+        "dataType": "_float4",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "histogram_bounds": {
+        "oid": 2277,
+        "dataType": "anyarray",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "inherited": {
+        "oid": 16,
+        "dataType": "bool",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "most_common_elem_freqs": {
+        "oid": 1021,
+        "dataType": "_float4",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "most_common_elems": {
+        "oid": 2277,
+        "dataType": "anyarray",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "most_common_freqs": {
+        "oid": 1021,
+        "dataType": "_float4",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "most_common_vals": {
+        "oid": 2277,
+        "dataType": "anyarray",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "n_distinct": {
+        "oid": 700,
+        "dataType": "float4",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "null_frac": {
+        "oid": 700,
+        "dataType": "float4",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "schemaname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "tablename": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      }
+    },
+    "pg_stats_ext": {
+      "attnames": {
+        "oid": 1003,
+        "dataType": "_name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "dependencies": {
+        "oid": 3402,
+        "dataType": "pg_dependencies",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "kinds": {
+        "oid": 1002,
+        "dataType": "_char",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "most_common_base_freqs": {
+        "oid": 1022,
+        "dataType": "_float8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "most_common_freqs": {
+        "oid": 1022,
+        "dataType": "_float8",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "most_common_val_nulls": {
+        "oid": 1000,
+        "dataType": "_bool",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "most_common_vals": {
+        "oid": 1009,
+        "dataType": "_text",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "n_distinct": {
+        "oid": 3361,
+        "dataType": "pg_ndistinct",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "schemaname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "statistics_name": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "statistics_owner": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "statistics_schemaname": {
+        "oid": 19,
+        "dataType": "name",
+        "expectedOid": null,
+        "expectedDataType": null
+      },
+      "tablename": {
         "oid": 19,
         "dataType": "name",
         "expectedOid": null,
@@ -4708,6 +7420,9 @@
     }
   },
   "unimplementedTypes": {
-    "2277": "anyarray"
+    "2277": "anyarray",
+    "3361": "pg_ndistinct",
+    "3402": "pg_dependencies",
+    "5017": "pg_mcv_list"
   }
 }

--- a/pkg/sql/testdata/postgres_test_expected_diffs_on_pg_catalog.json
+++ b/pkg/sql/testdata/postgres_test_expected_diffs_on_pg_catalog.json
@@ -1,11 +1,11 @@
 {
   "pgVersion": "13.3",
   "diffSummary": {
-    "TotalTables": 90,
-    "TotalColumns": 753,
-    "MissingTables": 0,
+    "TotalTables": 129,
+    "TotalColumns": 782,
+    "MissingTables": 37,
     "MissingColumns": 1,
-    "DatatypeMismatches": 18
+    "DatatypeMismatches": 20
   },
   "pgMetadata": {
     "pg_am": {
@@ -133,6 +133,57 @@
         "expectedDataType": "_text"
       }
     },
+    "pg_stat_activity": {
+      "client_port": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": 23,
+        "expectedDataType": "int4"
+      },
+      "pid": {
+        "oid": 20,
+        "dataType": "int8",
+        "expectedOid": 23,
+        "expectedDataType": "int4"
+      }
+    },
+    "pg_stat_all_indexes": {},
+    "pg_stat_all_tables": {},
+    "pg_stat_archiver": {},
+    "pg_stat_bgwriter": {},
+    "pg_stat_gssapi": {},
+    "pg_stat_progress_analyze": {},
+    "pg_stat_progress_basebackup": {},
+    "pg_stat_progress_cluster": {},
+    "pg_stat_progress_create_index": {},
+    "pg_stat_progress_vacuum": {},
+    "pg_stat_replication": {},
+    "pg_stat_slru": {},
+    "pg_stat_ssl": {},
+    "pg_stat_subscription": {},
+    "pg_stat_sys_indexes": {},
+    "pg_stat_sys_tables": {},
+    "pg_stat_user_functions": {},
+    "pg_stat_user_indexes": {},
+    "pg_stat_user_tables": {},
+    "pg_stat_wal_receiver": {},
+    "pg_stat_xact_all_tables": {},
+    "pg_stat_xact_sys_tables": {},
+    "pg_stat_xact_user_functions": {},
+    "pg_stat_xact_user_tables": {},
+    "pg_statio_all_indexes": {},
+    "pg_statio_all_sequences": {},
+    "pg_statio_all_tables": {},
+    "pg_statio_sys_indexes": {},
+    "pg_statio_sys_sequences": {},
+    "pg_statio_sys_tables": {},
+    "pg_statio_user_indexes": {},
+    "pg_statio_user_sequences": {},
+    "pg_statio_user_tables": {},
+    "pg_statistic": {},
+    "pg_statistic_ext_data": {},
+    "pg_stats": {},
+    "pg_stats_ext": {},
     "pg_user": {
       "valuntil": {
         "oid": 1114,
@@ -143,6 +194,9 @@
     }
   },
   "unimplementedTypes": {
-    "2277": "anyarray"
+    "2277": "anyarray",
+    "3361": "pg_ndistinct",
+    "3402": "pg_dependencies",
+    "5017": "pg_mcv_list"
   }
 }


### PR DESCRIPTION
Previously, we excluded pg_stat* tables from difftool
This was inadequate because we were unable to add missing empty tables
To address this, this patch removes the exclusion

Release note: None