### PR TITLE
catalog: calm down a spammy log message

### DIFF
--- a/pkg/sql/catalog/lease/descriptor_version_state.go
+++ b/pkg/sql/catalog/lease/descriptor_version_state.go
@@ -122,7 +122,7 @@ func (s *descriptorVersionState) incRefCount(ctx context.Context) {
 func (s *descriptorVersionState) incRefCountLocked(ctx context.Context) {
 	s.mu.refcount++
 	if log.ExpensiveLogEnabled(ctx, 2) {
-		log.Infof(ctx, "descriptorVersionState.incRefCount: %s", s.stringLocked())
+		log.VEventf(ctx, 2, "descriptorVersionState.incRefCount: %s", s.stringLocked())
 	}
 }
 


### PR DESCRIPTION
The following pattern is not the best:

if log.ExpensiveLogEnabled(ctx, 2) {
  log.Infof(ctx, "descriptorVersionState.incRefCount: %s", s.stringLocked())
}

Even with the ExpensiveLogEnabled guard, you generally still want to us
log.VEventf instead of Infof. Otherwise, whenever tracing is generally
enabled, this message spams the log file. What you want is for the
message to only be part of the trace (and not part of the log), unless
the vmodule for the file has been explicitly set.

Release note: None