### PR TITLE
colexecwindow: minor cleanup of benchmarks

### DIFF
--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -217,10 +217,6 @@ func supportedNatively(spec *execinfrapb.ProcessorSpec) error {
 			if wf.Func.AggregateFunc != nil {
 				return errors.Newf("aggregate functions used as window functions are not supported")
 			}
-
-			if _, supported := colexecwindow.SupportedWindowFns[*wf.Func.WindowFunc]; !supported {
-				return errors.Newf("window function %s is not supported", wf.String())
-			}
 		}
 		return nil
 

--- a/pkg/sql/colexec/colexecwindow/window_functions_util.go
+++ b/pkg/sql/colexec/colexecwindow/window_functions_util.go
@@ -26,20 +26,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// SupportedWindowFns contains all window functions supported by the
-// vectorized engine.
-var SupportedWindowFns = map[execinfrapb.WindowerSpec_WindowFunc]struct{}{
-	execinfrapb.WindowerSpec_ROW_NUMBER:   {},
-	execinfrapb.WindowerSpec_RANK:         {},
-	execinfrapb.WindowerSpec_DENSE_RANK:   {},
-	execinfrapb.WindowerSpec_PERCENT_RANK: {},
-	execinfrapb.WindowerSpec_CUME_DIST:    {},
-	execinfrapb.WindowerSpec_NTILE:        {},
-	execinfrapb.WindowerSpec_LAG:          {},
-	execinfrapb.WindowerSpec_LEAD:         {},
-	execinfrapb.WindowerSpec_FIRST_VALUE:  {},
-	execinfrapb.WindowerSpec_LAST_VALUE:   {},
-	execinfrapb.WindowerSpec_NTH_VALUE:    {},
+// windowFnMaxNumArgs is a mapping from the window function to the maximum
+// number of arguments it takes.
+var windowFnMaxNumArgs = map[execinfrapb.WindowerSpec_WindowFunc]int{
+	execinfrapb.WindowerSpec_ROW_NUMBER:   0,
+	execinfrapb.WindowerSpec_RANK:         0,
+	execinfrapb.WindowerSpec_DENSE_RANK:   0,
+	execinfrapb.WindowerSpec_PERCENT_RANK: 0,
+	execinfrapb.WindowerSpec_CUME_DIST:    0,
+	execinfrapb.WindowerSpec_NTILE:        1,
+	execinfrapb.WindowerSpec_LAG:          3,
+	execinfrapb.WindowerSpec_LEAD:         3,
+	execinfrapb.WindowerSpec_FIRST_VALUE:  1,
+	execinfrapb.WindowerSpec_LAST_VALUE:   1,
+	execinfrapb.WindowerSpec_NTH_VALUE:    2,
 }
 
 // WindowFnNeedsPeersInfo returns whether a window function pays attention to

--- a/pkg/sql/distsql/columnar_operators_test.go
+++ b/pkg/sql/distsql/columnar_operators_test.go
@@ -1091,7 +1091,8 @@ func TestWindowFunctionsAgainstProcessor(t *testing.T) {
 	for i := range typs {
 		typs[i] = types.Int
 	}
-	for windowFn := range colexecwindow.SupportedWindowFns {
+	for windowFnIdx := 0; windowFnIdx < len(execinfrapb.WindowerSpec_WindowFunc_name); windowFnIdx++ {
+		windowFn := execinfrapb.WindowerSpec_WindowFunc(windowFnIdx)
 		var argTypes []*types.T
 		useRandomTypes := rand.Float64() < randTypesProbability
 		randArgType := types.Int


### PR DESCRIPTION
Previously, the window functions benchmarks didn't report the throughput
in MB because we were setting the number of bytes processed in the outer
`b.Run` call. This is now fixed. This commit also begins counting only
the argument columns as well as the output towards the throughput
(because all other columns are internal and aren't exposed to the user,
and in some cases they aren't used at all - this would lead to inflated
numbers).

Additionally, this commit simplifies a few things now that we support
all pure window functions.

Release note: None