### PR TITLE
release-21.1: sql: make a session setting for improving disjunction selectivity

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -304,6 +304,17 @@ var optUseMultiColStatsClusterMode = settings.RegisterBoolSetting(
 	true,
 )
 
+// improveDisjunctionSelectivityEnabled controls the cluster default for whether
+// we should try to improve selectivity calculations for filters with
+// disjunctions by unioning the selectivity of each side of the disjunction.
+// This may lead to more efficient query plans in some cases.
+var optImproveDisjunctionSelectivityEnabled = settings.RegisterBoolSetting(
+	"sql.defaults.optimizer_improve_disjunction_selectivity.enabled",
+	"default value for optimizer_improve_disjunction_selectivity session setting; "+
+		"enables improved selectivity calculations for queries with disjunctions",
+	false,
+)
+
 // localityOptimizedSearchMode controls the cluster default for the use of
 // locality optimized search. If enabled, the optimizer will try to plan scans
 // and lookup joins in which local nodes (i.e., nodes in the gateway region) are
@@ -2304,6 +2315,10 @@ func (m *sessionDataMutator) SetOptimizerUseHistograms(val bool) {
 
 func (m *sessionDataMutator) SetOptimizerUseMultiColStats(val bool) {
 	m.data.OptimizerUseMultiColStats = val
+}
+
+func (m *sessionDataMutator) SetOptimizerImproveDisjunctionSelectivity(val bool) {
+	m.data.OptimizerImproveDisjunctionSelectivity = val
 }
 
 func (m *sessionDataMutator) SetLocalityOptimizedSearch(val bool) {

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -3640,6 +3640,7 @@ max_identifier_length                                 128
 max_index_keys                                        32
 node_id                                               1
 optimizer                                             on
+optimizer_improve_disjunction_selectivity             off
 optimizer_use_histograms                              on
 optimizer_use_multicol_stats                          on
 override_multi_region_zone_config                     off

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2131,6 +2131,7 @@ lock_timeout                                          0                   NULL  
 max_identifier_length                                 128                 NULL      NULL        NULL        string
 max_index_keys                                        32                  NULL      NULL        NULL        string
 node_id                                               1                   NULL      NULL        NULL        string
+optimizer_improve_disjunction_selectivity             off                 NULL      NULL        NULL        string
 optimizer_use_histograms                              on                  NULL      NULL        NULL        string
 optimizer_use_multicol_stats                          on                  NULL      NULL        NULL        string
 override_multi_region_zone_config                     off                 NULL      NULL        NULL        string
@@ -2148,7 +2149,7 @@ session_user                                          root                NULL  
 sql_safe_updates                                      off                 NULL      NULL        NULL        string
 standard_conforming_strings                           on                  NULL      NULL        NULL        string
 statement_timeout                                     0                   NULL      NULL        NULL        string
-stub_catalog_tables                           on                  NULL      NULL        NULL        string
+stub_catalog_tables                                   on                  NULL      NULL        NULL        string
 synchronize_seqscans                                  on                  NULL      NULL        NULL        string
 synchronous_commit                                    on                  NULL      NULL        NULL        string
 testing_vectorize_inject_panics                       off                 NULL      NULL        NULL        string
@@ -2212,6 +2213,7 @@ lock_timeout                                          0                   NULL  
 max_identifier_length                                 128                 NULL  user     NULL      128                 128
 max_index_keys                                        32                  NULL  user     NULL      32                  32
 node_id                                               1                   NULL  user     NULL      1                   1
+optimizer_improve_disjunction_selectivity             off                 NULL  user     NULL      off                 off
 optimizer_use_histograms                              on                  NULL  user     NULL      on                  on
 optimizer_use_multicol_stats                          on                  NULL  user     NULL      on                  on
 override_multi_region_zone_config                     off                 NULL  user     NULL      off                 off
@@ -2229,7 +2231,7 @@ session_user                                          root                NULL  
 sql_safe_updates                                      off                 NULL  user     NULL      off                 off
 standard_conforming_strings                           on                  NULL  user     NULL      on                  on
 statement_timeout                                     0                   NULL  user     NULL      0s                  0s
-stub_catalog_tables                           on                  NULL  user     NULL      on                  on
+stub_catalog_tables                                   on                  NULL  user     NULL      on                  on
 synchronize_seqscans                                  on                  NULL  user     NULL      on                  on
 synchronous_commit                                    on                  NULL  user     NULL      on                  on
 testing_vectorize_inject_panics                       off                 NULL  user     NULL      off                 off
@@ -2290,6 +2292,7 @@ max_identifier_length                                 NULL    NULL     NULL     
 max_index_keys                                        NULL    NULL     NULL     NULL        NULL
 node_id                                               NULL    NULL     NULL     NULL        NULL
 optimizer                                             NULL    NULL     NULL     NULL        NULL
+optimizer_improve_disjunction_selectivity             NULL    NULL     NULL     NULL        NULL
 optimizer_use_histograms                              NULL    NULL     NULL     NULL        NULL
 optimizer_use_multicol_stats                          NULL    NULL     NULL     NULL        NULL
 override_multi_region_zone_config                     NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -68,6 +68,7 @@ lock_timeout                                          0
 max_identifier_length                                 128
 max_index_keys                                        32
 node_id                                               1
+optimizer_improve_disjunction_selectivity             off
 optimizer_use_histograms                              on
 optimizer_use_multicol_stats                          on
 override_multi_region_zone_config                     off

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -1870,7 +1870,7 @@ vectorized: true
 # More accurate estimation of the disjunction's selectivity leads to a plan with
 # a union of constrained scans. See #58744.
 statement ok
-SET CLUSTER SETTING sql.optimizer_improve_disjunction_selectivity.enabled = true
+SET optimizer_improve_disjunction_selectivity = true
 
 # Single disjunction.
 query T
@@ -1982,4 +1982,4 @@ vectorized: true
           spans: FULL SCAN
 
 statement ok
-RESET CLUSTER SETTING sql.optimizer_improve_disjunction_selectivity.enabled
+SET optimizer_improve_disjunction_selectivity = false

--- a/pkg/sql/opt/memo/BUILD.bazel
+++ b/pkg/sql/opt/memo/BUILD.bazel
@@ -24,7 +24,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/geo/geoindex",
-        "//pkg/settings",
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/inverted",

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -131,14 +131,15 @@ type Memo struct {
 
 	// The following are selected fields from SessionData which can affect
 	// planning. We need to cross-check these before reusing a cached memo.
-	reorderJoinsLimit       int
-	zigzagJoinEnabled       bool
-	useHistograms           bool
-	useMultiColStats        bool
-	localityOptimizedSearch bool
-	safeUpdates             bool
-	preferLookupJoinsForFKs bool
-	saveTablesPrefix        string
+	reorderJoinsLimit             int
+	zigzagJoinEnabled             bool
+	useHistograms                 bool
+	useMultiColStats              bool
+	localityOptimizedSearch       bool
+	safeUpdates                   bool
+	preferLookupJoinsForFKs       bool
+	saveTablesPrefix              string
+	improveDisjunctionSelectivity bool
 
 	// curID is the highest currently in-use scalar expression ID.
 	curID opt.ScalarID
@@ -168,15 +169,16 @@ func (m *Memo) Init(evalCtx *tree.EvalContext) {
 	// This initialization pattern ensures that fields are not unwittingly
 	// reused. Field reuse must be explicit.
 	*m = Memo{
-		metadata:                m.metadata,
-		reorderJoinsLimit:       evalCtx.SessionData.ReorderJoinsLimit,
-		zigzagJoinEnabled:       evalCtx.SessionData.ZigzagJoinEnabled,
-		useHistograms:           evalCtx.SessionData.OptimizerUseHistograms,
-		useMultiColStats:        evalCtx.SessionData.OptimizerUseMultiColStats,
-		localityOptimizedSearch: evalCtx.SessionData.LocalityOptimizedSearch,
-		safeUpdates:             evalCtx.SessionData.SafeUpdates,
-		preferLookupJoinsForFKs: evalCtx.SessionData.PreferLookupJoinsForFKs,
-		saveTablesPrefix:        evalCtx.SessionData.SaveTablesPrefix,
+		metadata:                      m.metadata,
+		reorderJoinsLimit:             evalCtx.SessionData.ReorderJoinsLimit,
+		zigzagJoinEnabled:             evalCtx.SessionData.ZigzagJoinEnabled,
+		useHistograms:                 evalCtx.SessionData.OptimizerUseHistograms,
+		useMultiColStats:              evalCtx.SessionData.OptimizerUseMultiColStats,
+		localityOptimizedSearch:       evalCtx.SessionData.LocalityOptimizedSearch,
+		safeUpdates:                   evalCtx.SessionData.SafeUpdates,
+		preferLookupJoinsForFKs:       evalCtx.SessionData.PreferLookupJoinsForFKs,
+		saveTablesPrefix:              evalCtx.SessionData.SaveTablesPrefix,
+		improveDisjunctionSelectivity: evalCtx.SessionData.OptimizerImproveDisjunctionSelectivity,
 	}
 	m.metadata.Init()
 	m.logPropsBuilder.init(evalCtx, m)
@@ -284,7 +286,8 @@ func (m *Memo) IsStale(
 		m.localityOptimizedSearch != evalCtx.SessionData.LocalityOptimizedSearch ||
 		m.safeUpdates != evalCtx.SessionData.SafeUpdates ||
 		m.preferLookupJoinsForFKs != evalCtx.SessionData.PreferLookupJoinsForFKs ||
-		m.saveTablesPrefix != evalCtx.SessionData.SaveTablesPrefix {
+		m.saveTablesPrefix != evalCtx.SessionData.SaveTablesPrefix ||
+		m.improveDisjunctionSelectivity != evalCtx.SessionData.OptimizerImproveDisjunctionSelectivity {
 		return true, nil
 	}
 

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -222,6 +222,12 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData.PreferLookupJoinsForFKs = false
 	notStale()
 
+	// Stale improve disjunction selectivity.
+	evalCtx.SessionData.OptimizerImproveDisjunctionSelectivity = true
+	stale()
+	evalCtx.SessionData.OptimizerImproveDisjunctionSelectivity = false
+	notStale()
+
 	// Stale data sources and schema. Create new catalog so that data sources are
 	// recreated and can be modified independently.
 	catalog = testcat.New()

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -15,7 +15,6 @@ import (
 	"reflect"
 
 	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
-	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
@@ -24,16 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
-)
-
-// improveDisjunctionSelectivityEnabled indicates whether we should try to
-// improve selectivity calculations for filters with disjunctions by unioning
-// the selectivity of each side of the disjunction. This may lead to more
-// efficient query plans in some cases.
-var improveDisjunctionSelectivityEnabled = settings.RegisterBoolSetting(
-	"sql.optimizer_improve_disjunction_selectivity.enabled",
-	"enables improved selectivity calculations for queries with disjunctions",
-	false,
 )
 
 var statsAnnID = opt.NewTableAnnID()
@@ -2995,7 +2984,7 @@ func (sb *statisticsBuilder) applyFiltersItem(
 				numUnappliedConjuncts++
 			}
 		}
-	case improveDisjunctionSelectivityEnabled.Get(&sb.evalCtx.Settings.SV):
+	case e.Memo().improveDisjunctionSelectivity:
 		if constraintUnion := sb.buildDisjunctionConstraints(filter); len(constraintUnion) > 0 {
 			// The filters are one or more disjunctions and tight constraint sets
 			// could be built for each.

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -178,6 +178,9 @@ type LocalOnlySessionData struct {
 	// OptimizerUseMultiColStats indicates whether we should use multi-column
 	// statistics for cardinality estimation in the optimizer.
 	OptimizerUseMultiColStats bool
+	// OptimizerImproveDisjunctionSelectivity indicates whether we try to
+	// calculate more accurate selectivities for filters with disjunctions.
+	OptimizerImproveDisjunctionSelectivity bool
 	// LocalityOptimizedSearch indicates that the optimizer will try to plan scans
 	// and lookup joins in which local nodes (i.e., nodes in the gateway region)
 	// are searched for matching rows before remote nodes, in the hope that the

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -654,6 +654,25 @@ var varGen = map[string]sessionVar{
 	},
 
 	// CockroachDB extension.
+	`optimizer_improve_disjunction_selectivity`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`optimizer_improve_disjunction_selectivity`),
+		Set: func(_ context.Context, m *sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("optimizer_improve_disjunction_selectivity", s)
+			if err != nil {
+				return err
+			}
+			m.SetOptimizerImproveDisjunctionSelectivity(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext) string {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData.OptimizerImproveDisjunctionSelectivity)
+		},
+		GlobalDefault: func(sv *settings.Values) string {
+			return formatBoolAsPostgresSetting(optImproveDisjunctionSelectivityEnabled.Get(sv))
+		},
+	},
+
+	// CockroachDB extension.
 	`locality_optimized_partitioned_index_scan`: {
 		GetStringVal: makePostgresBoolGetStringValFn(`locality_optimized_partitioned_index_scan`),
 		Set: func(_ context.Context, m *sessionDataMutator, s string) error {


### PR DESCRIPTION
Previously, only a cluster setting could enable improved optimizer
calculations for the selectivity of filters with disjunctions. This
prevented the optimizer from detecting stale memos in the cache. See
https://github.com/cockroachdb/cockroach/pull/67730#issuecomment-883643778.

This commit adds the `optimizer_improve_disjunction_selectivity` session
setting to fix this. The cluster setting, which is now called
`sql.defaults.optimizer_improve_disjunction_selectivity.enable` controls
the default value of the session setting.

Release note: None

Release justification: This is a minor fix to add a session setting instead
of just a cluster setting related to the recent backport #67730.