### PR TITLE
sql: support `nearest_only` argument for with_min_timestamp/max_staleness

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -532,12 +532,26 @@ has no relationship with the commit order of concurrent transactions.</p>
 </span></td></tr>
 <tr><td><a name="with_max_staleness"></a><code>with_max_staleness(max_staleness: <a href="interval.html">interval</a>) &rarr; <a href="timestamp.html">timestamptz</a></code></td><td><span class="funcdesc"><p>When used in the AS OF SYSTEM TIME clause of an single-statement,
 read-only transaction, CockroachDB chooses the newest timestamp within the staleness
-bound that allows execution of the reads at the closest available replica without blocking.</p>
+bound that allows execution of the reads at the nearest available replica without blocking.</p>
+<p>Note this function requires an enterprise license on a CCL distribution.</p>
+</span></td></tr>
+<tr><td><a name="with_max_staleness"></a><code>with_max_staleness(max_staleness: <a href="interval.html">interval</a>, nearest_only: <a href="bool.html">bool</a>) &rarr; <a href="timestamp.html">timestamptz</a></code></td><td><span class="funcdesc"><p>When used in the AS OF SYSTEM TIME clause of an single-statement,
+read-only transaction, CockroachDB chooses the newest timestamp within the staleness
+bound that allows execution of the reads at the nearest available replica without blocking.</p>
+<p>If nearest_only is set to true, reads that cannot be served using the nearest
+available replica will error.</p>
 <p>Note this function requires an enterprise license on a CCL distribution.</p>
 </span></td></tr>
 <tr><td><a name="with_min_timestamp"></a><code>with_min_timestamp(min_timestamp: <a href="timestamp.html">timestamptz</a>) &rarr; <a href="timestamp.html">timestamptz</a></code></td><td><span class="funcdesc"><p>When used in the AS OF SYSTEM TIME clause of an single-statement,
 read-only transaction, CockroachDB chooses the newest timestamp before the min_timestamp
-that allows execution of the reads at the closest available replica without blocking.</p>
+that allows execution of the reads at the nearest available replica without blocking.</p>
+<p>Note this function requires an enterprise license on a CCL distribution.</p>
+</span></td></tr>
+<tr><td><a name="with_min_timestamp"></a><code>with_min_timestamp(min_timestamp: <a href="timestamp.html">timestamptz</a>, nearest_only: <a href="bool.html">bool</a>) &rarr; <a href="timestamp.html">timestamptz</a></code></td><td><span class="funcdesc"><p>When used in the AS OF SYSTEM TIME clause of an single-statement,
+read-only transaction, CockroachDB chooses the newest timestamp before the min_timestamp
+that allows execution of the reads at the nearest available replica without blocking.</p>
+<p>If nearest_only is set to true, reads that cannot be served using the nearest
+available replica will error.</p>
 <p>Note this function requires an enterprise license on a CCL distribution.</p>
 </span></td></tr></tbody>
 </table>

--- a/pkg/ccl/logictestccl/testdata/logic_test/as_of
+++ b/pkg/ccl/logictestccl/testdata/logic_test/as_of
@@ -120,6 +120,24 @@ SELECT * FROM t AS OF SYSTEM TIME with_max_staleness('1ms')
 statement ok
 SELECT * FROM t AS OF SYSTEM TIME with_min_timestamp(statement_timestamp() - '1ms')
 
+statement error with_max_staleness: expected bool argument for nearest_only
+SELECT * FROM t AS OF SYSTEM TIME with_max_staleness('1ms', 5)
+
+statement error with_min_timestamp: expected bool argument for nearest_only
+SELECT * FROM t AS OF SYSTEM TIME with_min_timestamp(statement_timestamp(), 5)
+
+statement ok
+SELECT * FROM t AS OF SYSTEM TIME with_max_staleness('1ms', false)
+
+statement ok
+SELECT * FROM t AS OF SYSTEM TIME with_min_timestamp(statement_timestamp() - '1ms', false)
+
+statement ok
+SELECT * FROM t AS OF SYSTEM TIME with_max_staleness('1ms', true)
+
+statement ok
+SELECT * FROM t AS OF SYSTEM TIME with_min_timestamp(statement_timestamp() - '1ms', true)
+
 statement error AS OF SYSTEM TIME: only constant expressions or follower_read_timestamp are allowed
 BEGIN AS OF SYSTEM TIME with_max_staleness('1ms')
 

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -2471,9 +2471,20 @@ nearest replica.`, defaultFollowerReadDuration),
 			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
 				return withMinTimestamp(ctx, tree.MustBeDTimestampTZ(args[0]).Time)
 			},
-			PreferredOverload: true,
-			Info:              withMinTimestampInfo,
-			Volatility:        tree.VolatilityVolatile,
+			Info:       withMinTimestampInfo(false /* nearestOnly */),
+			Volatility: tree.VolatilityVolatile,
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"min_timestamp", types.TimestampTZ},
+				{"nearest_only", types.Bool},
+			},
+			ReturnType: tree.FixedReturnType(types.TimestampTZ),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				return withMinTimestamp(ctx, tree.MustBeDTimestampTZ(args[0]).Time)
+			},
+			Info:       withMinTimestampInfo(true /* nearestOnly */),
+			Volatility: tree.VolatilityVolatile,
 		},
 	),
 
@@ -2487,7 +2498,19 @@ nearest replica.`, defaultFollowerReadDuration),
 			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
 				return withMaxStaleness(ctx, tree.MustBeDInterval(args[0]).Duration)
 			},
-			Info:       withMaxStalenessInfo,
+			Info:       withMaxStalenessInfo(false /* nearestOnly */),
+			Volatility: tree.VolatilityVolatile,
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"max_staleness", types.Interval},
+				{"nearest_only", types.Bool},
+			},
+			ReturnType: tree.FixedReturnType(types.TimestampTZ),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				return withMaxStaleness(ctx, tree.MustBeDInterval(args[0]).Duration)
+			},
+			Info:       withMaxStalenessInfo(true /* nearestOnly */),
 			Volatility: tree.VolatilityVolatile,
 		},
 	),
@@ -7621,17 +7644,41 @@ var (
 	}
 )
 
-const withMinTimestampInfo = `When used in the AS OF SYSTEM TIME clause of an single-statement,
+const nearestOnlyInfo = `
+
+If nearest_only is set to true, reads that cannot be served using the nearest
+available replica will error.
+`
+
+func withMinTimestampInfo(nearestOnly bool) string {
+	var nearestOnlyText string
+	if nearestOnly {
+		nearestOnlyText = nearestOnlyInfo
+	}
+	return fmt.Sprintf(
+		`When used in the AS OF SYSTEM TIME clause of an single-statement,
 read-only transaction, CockroachDB chooses the newest timestamp before the min_timestamp
-that allows execution of the reads at the closest available replica without blocking.
+that allows execution of the reads at the nearest available replica without blocking.%s
 
-Note this function requires an enterprise license on a CCL distribution.`
+Note this function requires an enterprise license on a CCL distribution.`,
+		nearestOnlyText,
+	)
+}
 
-const withMaxStalenessInfo = `When used in the AS OF SYSTEM TIME clause of an single-statement,
+func withMaxStalenessInfo(nearestOnly bool) string {
+	var nearestOnlyText string
+	if nearestOnly {
+		nearestOnlyText = nearestOnlyInfo
+	}
+	return fmt.Sprintf(
+		`When used in the AS OF SYSTEM TIME clause of an single-statement,
 read-only transaction, CockroachDB chooses the newest timestamp within the staleness
-bound that allows execution of the reads at the closest available replica without blocking.
+bound that allows execution of the reads at the nearest available replica without blocking.%s
 
-Note this function requires an enterprise license on a CCL distribution.`
+Note this function requires an enterprise license on a CCL distribution.`,
+		nearestOnlyText,
+	)
+}
 
 func withMinTimestamp(ctx *tree.EvalContext, t time.Time) (tree.Datum, error) {
 	t, err := WithMinTimestamp(ctx, t)


### PR DESCRIPTION
Release note (sql change): Introduced a `nearest_only` argument for
`with_min_timestamp`/`with_max_staleness`, which enforces bounded
staleness reads only talk to the nearest replica.

