### PR TITLE
tree: fix cast of null JSON value to geo-types

### DIFF
--- a/pkg/sql/sem/tree/casts.go
+++ b/pkg/sql/sem/tree/casts.go
@@ -1047,6 +1047,9 @@ func performCastWithoutPrecisionTruncation(ctx *EvalContext, d Datum, t *types.T
 			if err != nil {
 				return nil, err
 			}
+			if t == nil {
+				return DNull, nil
+			}
 			g, err := geo.ParseGeographyFromGeoJSON([]byte(*t))
 			if err != nil {
 				return nil, err
@@ -1091,6 +1094,9 @@ func performCastWithoutPrecisionTruncation(ctx *EvalContext, d Datum, t *types.T
 			t, err := d.AsText()
 			if err != nil {
 				return nil, err
+			}
+			if t == nil {
+				return DNull, nil
 			}
 			g, err := geo.ParseGeometryFromGeoJSON([]byte(*t))
 			if err != nil {

--- a/pkg/sql/sem/tree/testdata/eval/cast
+++ b/pkg/sql/sem/tree/testdata/eval/cast
@@ -1214,3 +1214,13 @@ eval
 'abc'::string::"char"
 ----
 'a'
+
+eval
+'null'::jsonb::geography
+----
+NULL
+
+eval
+'null'::jsonb::geometry
+----
+NULL


### PR DESCRIPTION
Fixes: #67842.

Release note (bug fix): Previously, CockroachDB could encounter an
internal error or crash when performing a cast of NULL JSON value to
Geography or Geometry types. Now this is fixed.