### PR TITLE
release-20.2: cli/sql: ensure compatibility with v21.1+ servers

### DIFF
--- a/pkg/cli/sql_util.go
+++ b/pkg/cli/sql_util.go
@@ -405,7 +405,7 @@ func (c *sqlConn) getLastQueryStatistics() (
 		err = errors.CombineErrors(err, closeErr)
 	}()
 
-	if len(rows.Columns()) != 4 {
+	if len(rows.Columns()) < 4 {
 		return 0, 0, 0, 0,
 			errors.New("unexpected number of columns in SHOW LAST QUERY STATISTICS")
 	}


### PR DESCRIPTION
cc @cockroachdb/release 

Release justification: this is a feature-neutral change within a 20.2 deployment and increases operator flexibility in mixed-versions clusters.

Release note (bug fix): A v20.2 SQL shell can now properly
report detailed execution timings (via the client-side
configuration setting `verbose_times`) when ran
against a v21.1+ server.