### PR TITLE
jobs: register scheduled jobs executors metrics at startup

### DIFF
--- a/pkg/ccl/backupccl/create_scheduled_backup_test.go
+++ b/pkg/ccl/backupccl/create_scheduled_backup_test.go
@@ -826,7 +826,7 @@ INSERT INTO t values (1), (10), (100);
 	})
 
 	metrics := func() *jobs.ExecutorMetrics {
-		ex, _, err := jobs.GetScheduledJobExecutor(tree.ScheduledBackupExecutor.InternalName())
+		ex, err := jobs.GetScheduledJobExecutor(tree.ScheduledBackupExecutor.InternalName())
 		require.NoError(t, err)
 		require.NotNil(t, ex.Metrics())
 		return ex.Metrics().(*backupMetrics).ExecutorMetrics

--- a/pkg/jobs/job_scheduler.go
+++ b/pkg/jobs/job_scheduler.go
@@ -169,7 +169,7 @@ func (s *jobScheduler) processSchedule(
 		return err
 	}
 
-	executor, err := s.lookupExecutor(schedule.ExecutorType())
+	executor, err := GetScheduledJobExecutor(schedule.ExecutorType())
 	if err != nil {
 		return err
 	}
@@ -188,17 +188,6 @@ func (s *jobScheduler) processSchedule(
 
 	// Persist any mutations to the underlying schedule.
 	return schedule.Update(ctx, s.InternalExecutor, txn)
-}
-
-func (s *jobScheduler) lookupExecutor(name string) (ScheduledJobExecutor, error) {
-	ex, wasCreated, err := GetScheduledJobExecutor(name)
-	if err != nil {
-		return nil, err
-	}
-	if m := ex.Metrics(); wasCreated && m != nil {
-		s.registry.AddMetricStruct(m)
-	}
-	return ex, nil
 }
 
 // TODO(yevgeniy): Re-evaluate if we need to have per-loop execution statistics.
@@ -358,6 +347,10 @@ func (s *jobScheduler) runDaemon(ctx context.Context, stopper *stop.Stopper) {
 	_ = stopper.RunAsyncTask(ctx, "job-scheduler", func(ctx context.Context) {
 		initialDelay := getInitialScanDelay(s.TestingKnobs)
 		log.Infof(ctx, "waiting %v before scheduled jobs daemon start", initialDelay)
+
+		if err := RegisterExecutorsMetrics(s.registry); err != nil {
+			log.Errorf(ctx, "error registering executor metrics: %+v", err)
+		}
 
 		for timer := time.NewTimer(initialDelay); ; timer.Reset(
 			getWaitPeriod(&s.Settings.SV, s.TestingKnobs)) {

--- a/pkg/jobs/scheduled_job_executor.go
+++ b/pkg/jobs/scheduled_job_executor.go
@@ -90,21 +90,43 @@ func newScheduledJobExecutorLocked(name string) (ScheduledJobExecutor, error) {
 
 // GetScheduledJobExecutor returns a singleton instance of
 // ScheduledJobExecutor and a flag indicating if that instance was just created.
-func GetScheduledJobExecutor(name string) (ScheduledJobExecutor, bool, error) {
+func GetScheduledJobExecutor(name string) (ScheduledJobExecutor, error) {
 	executorRegistry.Lock()
 	defer executorRegistry.Unlock()
+	return getScheduledJobExecutorLocked(name)
+}
+
+func getScheduledJobExecutorLocked(name string) (ScheduledJobExecutor, error) {
 	if executorRegistry.executors == nil {
 		executorRegistry.executors = make(map[string]ScheduledJobExecutor)
 	}
 	if ex, ok := executorRegistry.executors[name]; ok {
-		return ex, false, nil
+		return ex, nil
 	}
 	ex, err := newScheduledJobExecutorLocked(name)
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
 	executorRegistry.executors[name] = ex
-	return ex, true, nil
+	return ex, nil
+}
+
+// RegisterExecutorsMetrics registered the metrics updated by each executor.
+func RegisterExecutorsMetrics(registry *metric.Registry) error {
+	executorRegistry.Lock()
+	defer executorRegistry.Unlock()
+
+	for executorType := range executorRegistry.factories {
+		ex, err := getScheduledJobExecutorLocked(executorType)
+		if err != nil {
+			return err
+		}
+		if m := ex.Metrics(); m != nil {
+			registry.AddMetricStruct(m)
+		}
+	}
+
+	return nil
 }
 
 // DefaultHandleFailedRun is a default implementation for handling failed run
@@ -147,7 +169,7 @@ func NotifyJobTermination(
 	if err != nil {
 		return err
 	}
-	executor, _, err := GetScheduledJobExecutor(schedule.ExecutorType())
+	executor, err := GetScheduledJobExecutor(schedule.ExecutorType())
 	if err != nil {
 		return err
 	}

--- a/pkg/jobs/scheduled_job_executor_test.go
+++ b/pkg/jobs/scheduled_job_executor_test.go
@@ -77,10 +77,9 @@ func TestScheduledJobExecutorRegistration(t *testing.T) {
 	instance := newStatusTrackingExecutor()
 	defer registerScopedScheduledJobExecutor(executorName, instance)()
 
-	registered, created, err := GetScheduledJobExecutor(executorName)
+	registered, err := GetScheduledJobExecutor(executorName)
 	require.NoError(t, err)
 	require.Equal(t, instance, registered)
-	require.True(t, created)
 }
 
 func TestJobTerminationNotification(t *testing.T) {

--- a/pkg/sql/show_create_schedule.go
+++ b/pkg/sql/show_create_schedule.go
@@ -107,7 +107,7 @@ func (p *planner) ShowCreateSchedule(
 
 			var rows []tree.Datums
 			for _, sj := range scheduledJobs {
-				ex, _, err := jobs.GetScheduledJobExecutor(sj.ExecutorType())
+				ex, err := jobs.GetScheduledJobExecutor(sj.ExecutorType())
 				if err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/cockroach/issues/62792.

Previously, scheduled job executors were initialized lazily as each
daemon processed a schedule of that executor type. By initializtion, I
mean created and have their metrics registered with the SQL server's
metric registry.

Consider the following scenario before any schedules have been processed
on a cluster:
- Node 1's scheduler daemon finds a schedule to process
- Node 1 initializes an executor and registers that executor's metrics
with the SQL server's metrics registry.
- Node 1 creates the job record
- Node 2 adopts the created job
- Node 2 completes the job and creates a new executor to handle the
NotifyJobTermination callback. (Note: that when creating this executor,
it did not register it's metrics yet since Node 2 has not processed a
schedule yet.)
- Node 2 updates its metrics, but the incrementing is not visible.

This change creates and registers the metrics for all executors when the
scheduler daemon starts on each node, ensuring that the appropriate
metrics are registered.

Release note (bug fix): Fix a bug where the schedules.backup.succeeded
and schedules.backup.failed metrics would sometimes not be updated.