### PR TITLE
ui: fix redirect to requested page after login [backport 21.1]

### DIFF
--- a/pkg/ui/src/redux/login.ts
+++ b/pkg/ui/src/redux/login.ts
@@ -130,17 +130,15 @@ function shouldRedirect(location: Location) {
 }
 
 export function getLoginPage(location: Location) {
-  const query = !shouldRedirect(location)
+  const redirectTo = !shouldRedirect(location)
     ? undefined
-    : {
-        redirectTo: createPath({
-          pathname: location.pathname,
-          search: location.search,
-        }),
-      };
+    : createPath({
+        pathname: location.pathname,
+        search: location.search,
+      });
   return {
     pathname: LOGIN_PAGE,
-    query: query,
+    search: `?redirectTo=${encodeURIComponent(redirectTo)}`,
   };
 }
 

--- a/pkg/ui/src/views/login/loginPage.tsx
+++ b/pkg/ui/src/views/login/loginPage.tsx
@@ -124,7 +124,7 @@ export class LoginPage extends React.Component<Props> {
       const { location, history } = this.props;
       const params = new URLSearchParams(location.search);
       if (params.has("redirectTo")) {
-        history.push(params.get("redirectTo"));
+        history.push(decodeURIComponent(params.get("redirectTo")));
       } else {
         history.push("/");
       }


### PR DESCRIPTION
if not logged user try to open some specific page it will be
redirected to it after login. eventually we had this in place
before, but it become not working due to bracking changes
in react router library.

Resolves: #67329

Release note(ui): fix redirect to originaly requested page after user login