### PR TITLE
sql: populate pg_catalog.pg_default_acl table 

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog_pg_default_acl
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog_pg_default_acl
@@ -1,0 +1,104 @@
+statement ok
+ALTER DEFAULT PRIVILEGES GRANT SELECT ON TABLES TO PUBLIC;
+ALTER DEFAULT PRIVILEGES GRANT USAGE ON TYPES TO PUBLIC;
+ALTER DEFAULT PRIVILEGES GRANT USAGE ON SCHEMAS TO PUBLIC;
+ALTER DEFAULT PRIVILEGES GRANT SELECT ON SEQUENCES TO PUBLIC;
+
+# Public should appear as an empty string with privileges.
+query OOOTT colnames,rowsort
+SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
+----
+oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
+4149409857  1546506610  0                T              {=U/}
+4149409857  1546506610  0                n              {=U/}
+4149409857  1546506610  0                r              {=r/}
+4149409857  1546506610  0                S              {=r/}
+
+statement ok
+CREATE USER foo
+
+statement ok
+CREATE USER bar
+
+statement ok
+ALTER DEFAULT PRIVILEGES GRANT ALL ON TABLES TO foo, bar;
+ALTER DEFAULT PRIVILEGES GRANT ALL ON TYPES TO foo, bar;
+ALTER DEFAULT PRIVILEGES GRANT ALL ON SCHEMAS TO foo, bar;
+ALTER DEFAULT PRIVILEGES GRANT ALL ON SEQUENCES TO foo, bar;
+
+query OOOTT colnames,rowsort
+SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
+----
+oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
+4149409857  1546506610  0                T              {bar=U/,foo=U/,=U/}
+4149409857  1546506610  0                n              {bar=CU/,foo=CU/,=U/}
+4149409857  1546506610  0                r              {bar=Cadrw/,foo=Cadrw/,=r/}
+4149409857  1546506610  0                S              {bar=Cadrw/,foo=Cadrw/,=r/}
+
+statement ok
+GRANT foo, bar TO root;
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar GRANT ALL ON TABLES TO foo, bar;
+ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar GRANT ALL ON TYPES TO foo, bar;
+ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar GRANT ALL ON SCHEMAS TO foo, bar;
+ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar GRANT ALL ON SEQUENCES TO foo, bar;
+
+# 12 rows should exist, 4 for each role, root, foo and bar.
+query OOOTT colnames,rowsort
+SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
+----
+oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
+542080048   1791217281  0                n              {bar=CU/,foo=CU/}
+542080048   1791217281  0                r              {bar=Cadrw/,foo=Cadrw/}
+542080048   1791217281  0                S              {bar=Cadrw/,foo=Cadrw/}
+542080048   1791217281  0                T              {bar=U/,foo=U/}
+38059971    2026795574  0                r              {bar=Cadrw/,foo=Cadrw/}
+38059971    2026795574  0                S              {bar=Cadrw/,foo=Cadrw/}
+38059971    2026795574  0                T              {bar=U/,foo=U/}
+38059971    2026795574  0                n              {bar=CU/,foo=CU/}
+4149409857  1546506610  0                n              {bar=CU/,foo=CU/,=U/}
+4149409857  1546506610  0                r              {bar=Cadrw/,foo=Cadrw/,=r/}
+4149409857  1546506610  0                S              {bar=Cadrw/,foo=Cadrw/,=r/}
+4149409857  1546506610  0                T              {bar=U/,foo=U/,=U/}
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar REVOKE ALL ON TABLES FROM foo, bar;
+ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar REVOKE ALL ON TYPES FROM foo, bar;
+ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar REVOKE ALL ON SCHEMAS FROM foo, bar;
+ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar REVOKE ALL ON SEQUENCES FROM foo, bar;
+
+# Revoking all should remove 8 rows, 4 for each foo and bar.
+query OOOTT colnames,rowsort
+SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
+----
+oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
+4149409857  1546506610  0                T              {bar=U/,foo=U/,=U/}
+4149409857  1546506610  0                n              {bar=CU/,foo=CU/,=U/}
+4149409857  1546506610  0                r              {bar=Cadrw/,foo=Cadrw/,=r/}
+4149409857  1546506610  0                S              {bar=Cadrw/,foo=Cadrw/,=r/}
+
+statement ok
+ALTER DEFAULT PRIVILEGES REVOKE SELECT ON TABLES FROM foo, bar, public;
+ALTER DEFAULT PRIVILEGES REVOKE ALL ON TYPES FROM foo, bar, public;
+ALTER DEFAULT PRIVILEGES REVOKE ALL ON SCHEMAS FROM foo, bar, public;
+ALTER DEFAULT PRIVILEGES REVOKE ALL ON SEQUENCES FROM foo, bar, public;
+
+# Revoke ALL from types, schemas, sequences and select from tables.
+# Only one entry should be left, for tables and 'r' should not be present.
+query OOOTT colnames,rowsort
+SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
+----
+oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
+4149409857  1546506610  0                r              {bar=Cadw/,foo=Cadw/}
+
+# GRANT, DROP and ZONECONFIG should not show up in defaclacl.
+statement ok
+ALTER DEFAULT PRIVILEGES REVOKE ALL ON TABLES FROM foo, bar, public;
+ALTER DEFAULT PRIVILEGES GRANT GRANT, DROP, ZONECONFIG ON TABLES TO foo;
+
+query OOOTT colnames,rowsort
+SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
+----
+oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
+4149409857  1546506610  0                r              {foo=/}

--- a/pkg/sql/privilege/privilege.go
+++ b/pkg/sql/privilege/privilege.go
@@ -113,7 +113,7 @@ func (pl List) Less(i, j int) bool {
 }
 
 // names returns a list of privilege names in the same
-// order as 'pl'.
+// order as "pl".
 func (pl List) names() []string {
 	ret := make([]string, len(pl))
 	for i, p := range pl {
@@ -235,4 +235,37 @@ func GetValidPrivilegesForObject(objectType ObjectType) List {
 	default:
 		panic(errors.AssertionFailedf("unknown object type %s", objectType))
 	}
+}
+
+// ListToACL converts a list of privileges to a list of Postgres
+// ACL items.
+// See: https://www.postgresql.org/docs/13/ddl-priv.html#PRIVILEGE-ABBREVS-TABLE
+//     for privileges and their ACL abbreviations.
+func (pl List) ListToACL(objectType ObjectType) string {
+	privileges := pl
+	// If ALL is present, explode ALL into the underlying privileges.
+	if pl.Contains(ALL) {
+		privileges = GetValidPrivilegesForObject(objectType)
+	}
+	chars := make([]string, len(privileges))
+	for _, privilege := range privileges {
+		switch privilege {
+		case CREATE:
+			chars = append(chars, "C")
+		case SELECT:
+			chars = append(chars, "r")
+		case INSERT:
+			chars = append(chars, "a")
+		case DELETE:
+			chars = append(chars, "d")
+		case UPDATE:
+			chars = append(chars, "w")
+		case USAGE:
+			chars = append(chars, "U")
+		case CONNECT:
+			chars = append(chars, "c")
+		}
+	}
+	sort.Strings(chars)
+	return strings.Join(chars, "")
 }


### PR DESCRIPTION
Release note (sql change): Populate pg_catalog.pg_default_acl.
This is important for tracking which default privileges are defined
in the database.

pg_catalog.pg_default_acl has 5 columns.
oid oid - row identifier
defaclrole oid - oid of the role the default privileges are defined for
defaclnamespace oid - oid of the schema the default privileges are defined in
defaclobjtype char - r = relation (table, view), S = sequence, f = function, T = type, n = schema
defaclacl aclitem[] - string representation of default privileges, following the format
    "$1=$2/$3" where $1 is the grantee's username, $2 is a list of characters representing
    the privileges and $3 is the grantor (which is currently always an empty string in CRDB).

Privileges are represented by chars in the aclitem[] representation.
CREATE = 'C'
SELECT = 'r'
INSERT = 'a'
DELETE = 'd'
UPDATE = 'w'
USAGE = 'U'
CONNECT = 'c'


See: https://www.postgresql.org/docs/current/ddl-priv.html#PRIVILEGES-SUMMARY-TABLE
for the table of Postgres supported privileges and their char representations.

See: https://www.postgresql.org/docs/13/catalog-pg-default-acl.html for postgres' definition
of pg_catalog.pg_default_acl.