### PR TITLE
multitenant: expose consumption metrics

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -23,6 +23,7 @@ ALL_TESTS = [
     "//pkg/ccl/kvccl/kvtenantccl:kvtenantccl_test",
     "//pkg/ccl/logictestccl:logictestccl_test",
     "//pkg/ccl/multiregionccl:multiregionccl_test",
+    "//pkg/ccl/multitenantccl/tenantcostserver:tenantcostserver_test",
     "//pkg/ccl/oidcccl:oidcccl_test",
     "//pkg/ccl/partitionccl:partitionccl_test",
     "//pkg/ccl/serverccl:serverccl_test",

--- a/pkg/ccl/multitenantccl/tenantcostserver/BUILD.bazel
+++ b/pkg/ccl/multitenantccl/tenantcostserver/BUILD.bazel
@@ -1,9 +1,10 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "tenantcostserver",
     srcs = [
         "configure.go",
+        "metrics.go",
         "server.go",
         "token_bucket.go",
     ],
@@ -20,7 +21,38 @@ go_library(
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
+        "//pkg/util/metric",
+        "//pkg/util/metric/aggmetric",
+        "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
+    ],
+)
+
+go_test(
+    name = "tenantcostserver_test",
+    srcs = [
+        "main_test.go",
+        "server_test.go",
+    ],
+    data = glob(["testdata/**"]),
+    deps = [
+        ":tenantcostserver",
+        "//pkg/base",
+        "//pkg/roachpb:with-mocks",
+        "//pkg/security",
+        "//pkg/security/securitytest",
+        "//pkg/server",
+        "//pkg/sql",
+        "//pkg/testutils/metrictestutils",
+        "//pkg/testutils/serverutils",
+        "//pkg/testutils/sqlutils",
+        "//pkg/testutils/testcluster",
+        "//pkg/util/leaktest",
+        "//pkg/util/log",
+        "//pkg/util/metric",
+        "//pkg/util/randutil",
+        "@com_github_cockroachdb_datadriven//:datadriven",
+        "@in_gopkg_yaml_v2//:yaml_v2",
     ],
 )

--- a/pkg/ccl/multitenantccl/tenantcostserver/main_test.go
+++ b/pkg/ccl/multitenantccl/tenantcostserver/main_test.go
@@ -1,0 +1,33 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package tenantcostserver_test
+
+import (
+	"os"
+	"testing"
+
+	_ "github.com/cockroachdb/cockroach/pkg/ccl/multitenantccl/tenantcostserver"
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+//go:generate ../../../util/leaktest/add-leaktest.sh *_test.go
+
+func TestMain(m *testing.M) {
+	security.SetAssetLoader(securitytest.EmbeddedAssets)
+	randutil.SeedForTests()
+	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
+
+	os.Exit(m.Run())
+}

--- a/pkg/ccl/multitenantccl/tenantcostserver/metrics.go
+++ b/pkg/ccl/multitenantccl/tenantcostserver/metrics.go
@@ -1,0 +1,129 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package tenantcostserver
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/multitenant"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/cockroach/pkg/util/metric/aggmetric"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+)
+
+// Metrics is a metric.Struct for reporting tenant resource consumption.
+//
+// All metrics are aggregate metrics, containing child metrics for all tenants
+// that have communicated with this node. The metrics report cumulative usage
+// for the tenant; the current value for a given tenant is the most recent (or,
+// equivalently the largest) value reported across all nodes.  The top-level
+// aggregated value for a metric is not useful (it sums up the consumption for
+// each tenant, as last reported to this node).
+type Metrics struct {
+	TotalRU                *aggmetric.AggGaugeFloat64
+	TotalReadRequests      *aggmetric.AggGauge
+	TotalReadBytes         *aggmetric.AggGauge
+	TotalWriteRequests     *aggmetric.AggGauge
+	TotalWriteBytes        *aggmetric.AggGauge
+	TotalSQLPodsCPUSeconds *aggmetric.AggGaugeFloat64
+
+	mu struct {
+		syncutil.Mutex
+		// tenantMetrics stores the tenantMetrics for all tenants that have
+		// sent TokenBucketRequests to this node.
+		// TODO(radu): add garbage collection to remove inactive tenants.
+		tenantMetrics map[roachpb.TenantID]tenantMetrics
+	}
+}
+
+var _ metric.Struct = (*Metrics)(nil)
+
+// MetricStruct indicates that Metrics is a metric.Struct
+func (m *Metrics) MetricStruct() {}
+
+var (
+	metaTotalRU = metric.Metadata{
+		Name:        "tenant.consumption.request_units",
+		Help:        "Total RU consumption",
+		Measurement: "Request Units",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaTotalReadRequests = metric.Metadata{
+		Name:        "tenant.consumption.read_requests",
+		Help:        "Total number of KV read requests",
+		Measurement: "Requests",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaTotalReadBytes = metric.Metadata{
+		Name:        "tenant.consumption.read_bytes",
+		Help:        "Total number of bytes read from KV",
+		Measurement: "Bytes",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaTotalWriteRequests = metric.Metadata{
+		Name:        "tenant.consumption.write_requests",
+		Help:        "Total number of KV write requests",
+		Measurement: "Requests",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaTotalWriteBytes = metric.Metadata{
+		Name:        "tenant.consumption.write_bytes",
+		Help:        "Total number of bytes written to KV",
+		Measurement: "Bytes",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaTotalSQLPodsCPUSeconds = metric.Metadata{
+		Name:        "tenant.consumption.sql_pods_cpu_seconds",
+		Help:        "Total number of bytes written to KV",
+		Measurement: "CPU Seconds",
+		Unit:        metric.Unit_SECONDS,
+	}
+)
+
+func (m *Metrics) init() {
+	b := aggmetric.MakeBuilder(multitenant.TenantIDLabel)
+	*m = Metrics{
+		TotalRU:                b.GaugeFloat64(metaTotalRU),
+		TotalReadRequests:      b.Gauge(metaTotalReadRequests),
+		TotalReadBytes:         b.Gauge(metaTotalReadBytes),
+		TotalWriteRequests:     b.Gauge(metaTotalWriteRequests),
+		TotalWriteBytes:        b.Gauge(metaTotalWriteBytes),
+		TotalSQLPodsCPUSeconds: b.GaugeFloat64(metaTotalSQLPodsCPUSeconds),
+	}
+	m.mu.tenantMetrics = make(map[roachpb.TenantID]tenantMetrics)
+}
+
+// tenantMetrics represent metrics for an individual tenant.
+type tenantMetrics struct {
+	totalRU                *aggmetric.GaugeFloat64
+	totalReadRequests      *aggmetric.Gauge
+	totalReadBytes         *aggmetric.Gauge
+	totalWriteRequests     *aggmetric.Gauge
+	totalWriteBytes        *aggmetric.Gauge
+	totalSQLPodsCPUSeconds *aggmetric.GaugeFloat64
+}
+
+// getTenantMetrics returns the metrics for a tenant.
+func (m *Metrics) getTenantMetrics(tenantID roachpb.TenantID) tenantMetrics {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	tm, ok := m.mu.tenantMetrics[tenantID]
+	if !ok {
+		tid := tenantID.String()
+		tm = tenantMetrics{
+			totalRU:                m.TotalRU.AddChild(tid),
+			totalReadRequests:      m.TotalReadRequests.AddChild(tid),
+			totalReadBytes:         m.TotalReadBytes.AddChild(tid),
+			totalWriteRequests:     m.TotalWriteRequests.AddChild(tid),
+			totalWriteBytes:        m.TotalWriteBytes.AddChild(tid),
+			totalSQLPodsCPUSeconds: m.TotalSQLPodsCPUSeconds.AddChild(tid),
+		}
+		m.mu.tenantMetrics[tenantID] = tm
+	}
+	return tm
+}

--- a/pkg/ccl/multitenantccl/tenantcostserver/server.go
+++ b/pkg/ccl/multitenantccl/tenantcostserver/server.go
@@ -13,18 +13,27 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/multitenant"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
 )
 
 type instance struct {
 	db       *kv.DB
 	executor *sql.InternalExecutor
+	metrics  Metrics
 }
 
 func newInstance(db *kv.DB, executor *sql.InternalExecutor) *instance {
-	return &instance{
+	res := &instance{
 		db:       db,
 		executor: executor,
 	}
+	res.metrics.init()
+	return res
+}
+
+// Metrics is part of the multitenant.TenantUsageServer.
+func (s *instance) Metrics() metric.Struct {
+	return &s.metrics
 }
 
 var _ multitenant.TenantUsageServer = (*instance)(nil)

--- a/pkg/ccl/multitenantccl/tenantcostserver/server_test.go
+++ b/pkg/ccl/multitenantccl/tenantcostserver/server_test.go
@@ -1,0 +1,112 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package tenantcostserver_test
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/testutils/metrictestutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/datadriven"
+	"gopkg.in/yaml.v2"
+)
+
+func TestDataDriven(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	datadriven.Walk(t, "testdata", func(t *testing.T, path string) {
+		defer leaktest.AfterTest(t)()
+
+		// Set up a server that we use only for the system tables.
+		ctx := context.Background()
+		s, db, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+		defer s.Stopper().Stop(ctx)
+		r := sqlutils.MakeSQLRunner(db)
+
+		tenantUsage := server.NewTenantUsageServer(kvDB, s.InternalExecutor().(*sql.InternalExecutor))
+		metricsReg := metric.NewRegistry()
+		metricsReg.AddMetricStruct(tenantUsage.Metrics())
+
+		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
+			switch d.Cmd {
+			case "create-tenant":
+				if len(d.CmdArgs) != 1 {
+					d.Fatalf(t, "expected tenant number")
+				}
+				r.Exec(t, fmt.Sprintf("SELECT crdb_internal.create_tenant(%s)", d.CmdArgs[0].Key))
+				return ""
+
+			case "token-bucket-request":
+				if len(d.CmdArgs) != 1 {
+					d.Fatalf(t, "expected tenant number")
+				}
+				tenantID, err := strconv.Atoi(d.CmdArgs[0].Key)
+				if err != nil {
+					d.Fatalf(t, "%v", err)
+				}
+				var args struct {
+					Consumption struct {
+						RU              float64 `yaml:"ru"`
+						ReadReq         uint64  `yaml:"read_req"`
+						ReadBytes       uint64  `yaml:"read_bytes"`
+						WriteReq        uint64  `yaml:"write_req"`
+						WriteBytes      uint64  `yaml:"write_bytes"`
+						SQLPodsCPUUsage float64 `yaml:"sql_pods_cpu_usage"`
+					}
+				}
+				if err := yaml.UnmarshalStrict([]byte(d.Input), &args); err != nil {
+					d.Fatalf(t, "failed to parse request yaml: %v", err)
+				}
+				req := roachpb.TokenBucketRequest{
+					ConsumptionSinceLastRequest: roachpb.TokenBucketRequest_Consumption{
+						RU:               args.Consumption.RU,
+						ReadRequests:     args.Consumption.ReadReq,
+						ReadBytes:        args.Consumption.ReadBytes,
+						WriteRequests:    args.Consumption.WriteReq,
+						WriteBytes:       args.Consumption.WriteBytes,
+						SQLPodCPUSeconds: args.Consumption.SQLPodsCPUUsage,
+					},
+				}
+				_, err = tenantUsage.TokenBucketRequest(ctx, roachpb.MakeTenantID(uint64(tenantID)), &req)
+				if err != nil {
+					return fmt.Sprintf("error: %v", err)
+				}
+				return ""
+
+			case "metrics":
+				re, err := regexp.Compile(d.Input)
+				if err != nil {
+					d.Fatalf(t, "failed to compile pattern: %v", err)
+				}
+				str, err := metrictestutils.GetMetricsText(metricsReg, re)
+				if err != nil {
+					d.Fatalf(t, "failed to scrape metrics: %v", err)
+				}
+				return str
+
+			default:
+				d.Fatalf(t, "unknown command %q", d.Cmd)
+				return ""
+			}
+		})
+	})
+}

--- a/pkg/ccl/multitenantccl/tenantcostserver/testdata/metrics
+++ b/pkg/ccl/multitenantccl/tenantcostserver/testdata/metrics
@@ -1,0 +1,22 @@
+create-tenant 5
+----
+
+token-bucket-request 5
+consumption:
+  ru: 10
+  read_req: 20
+  read_bytes: 30
+  write_req: 40
+  write_bytes: 50
+  sql_pods_cpu_usage: 60
+----
+
+metrics
+tenant_id="5"
+----
+tenant_consumption_read_bytes{tenant_id="5"} 30
+tenant_consumption_read_requests{tenant_id="5"} 20
+tenant_consumption_request_units{tenant_id="5"} 10
+tenant_consumption_sql_pods_cpu_seconds{tenant_id="5"} 60
+tenant_consumption_write_bytes{tenant_id="5"} 50
+tenant_consumption_write_requests{tenant_id="5"} 40

--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -142,6 +142,7 @@ go_library(
         "//pkg/kv/kvserver/tscache",
         "//pkg/kv/kvserver/txnrecovery",
         "//pkg/kv/kvserver/txnwait",
+        "//pkg/multitenant",
         "//pkg/roachpb:with-mocks",
         "//pkg/rpc",
         "//pkg/rpc/nodedialer",

--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rangefeed"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/tenantrate"
+	"github.com/cockroachdb/cockroach/pkg/multitenant"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
@@ -1482,7 +1482,7 @@ type tenantStorageMetrics struct {
 }
 
 func newTenantsStorageMetrics() *TenantsStorageMetrics {
-	b := aggmetric.MakeBuilder(tenantrate.TenantIDLabel)
+	b := aggmetric.MakeBuilder(multitenant.TenantIDLabel)
 	sm := &TenantsStorageMetrics{
 		LiveBytes:      b.Gauge(metaLiveBytes),
 		KeyBytes:       b.Gauge(metaKeyBytes),

--- a/pkg/kv/kvserver/tenantrate/BUILD.bazel
+++ b/pkg/kv/kvserver/tenantrate/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/tenantrate",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/multitenant",
         "//pkg/roachpb:with-mocks",
         "//pkg/settings",
         "//pkg/util/metric",
@@ -35,6 +36,7 @@ go_test(
         "//pkg/roachpb:with-mocks",
         "//pkg/settings/cluster",
         "//pkg/testutils",
+        "//pkg/testutils/metrictestutils",
         "//pkg/util/leaktest",
         "//pkg/util/metric",
         "//pkg/util/tenantcostmodel",

--- a/pkg/kv/kvserver/tenantrate/metrics.go
+++ b/pkg/kv/kvserver/tenantrate/metrics.go
@@ -11,6 +11,7 @@
 package tenantrate
 
 import (
+	"github.com/cockroachdb/cockroach/pkg/multitenant"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/metric/aggmetric"
@@ -67,12 +68,8 @@ var (
 	}
 )
 
-// TenantIDLabel is the label used with metrics associated with a tenant.
-// The value will be the integer tenant ID.
-const TenantIDLabel = "tenant_id"
-
 func makeMetrics() Metrics {
-	b := aggmetric.MakeBuilder(TenantIDLabel)
+	b := aggmetric.MakeBuilder(multitenant.TenantIDLabel)
 	return Metrics{
 		Tenants:               metric.NewGauge(metaTenants),
 		CurrentBlocked:        b.Gauge(metaCurrentBlocked),

--- a/pkg/multitenant/BUILD.bazel
+++ b/pkg/multitenant/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "multitenant",
     srcs = [
+        "constants.go",
         "cost_controller.go",
         "doc.go",
         "tenant_usage.go",
@@ -12,6 +13,7 @@ go_library(
     deps = [
         "//pkg/kv",
         "//pkg/roachpb:with-mocks",
+        "//pkg/util/metric",
         "//pkg/util/stop",
     ],
 )

--- a/pkg/multitenant/constants.go
+++ b/pkg/multitenant/constants.go
@@ -1,0 +1,15 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package multitenant
+
+// TenantIDLabel is the label used with metrics associated with a tenant.
+// The value will be the integer tenant ID.
+const TenantIDLabel = "tenant_id"

--- a/pkg/multitenant/tenant_usage.go
+++ b/pkg/multitenant/tenant_usage.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
 )
 
 // TenantUsageServer is an interface through which tenant usage is reported and
@@ -61,4 +62,7 @@ type TenantUsageServer interface {
 		asOf time.Time,
 		asOfConsumedRequestUnits float64,
 	) error
+
+	// Metrics returns the top-level metrics.
+	Metrics() metric.Struct
 }

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1365,7 +1365,7 @@ func (dummyTenantUsageServer) TokenBucketRequest(
 	return nil, errors.Errorf("tenant usage requires a CCL binary")
 }
 
-// TokenBucketRequest is defined in the TenantUsageServer interface.
+// ReconfigureTokenBucket is defined in the TenantUsageServer interface.
 func (dummyTenantUsageServer) ReconfigureTokenBucket(
 	ctx context.Context,
 	txn *kv.Txn,
@@ -1378,3 +1378,14 @@ func (dummyTenantUsageServer) ReconfigureTokenBucket(
 ) error {
 	return errors.Errorf("tenant resource limits require a CCL binary")
 }
+
+// Metrics is defined in the TenantUsageServer interface.
+func (dummyTenantUsageServer) Metrics() metric.Struct {
+	return emptyMetricStruct{}
+}
+
+type emptyMetricStruct struct{}
+
+var _ metric.Struct = emptyMetricStruct{}
+
+func (emptyMetricStruct) MetricStruct() {}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -630,6 +630,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	}
 
 	tenantUsage := NewTenantUsageServer(db, internalExecutor)
+	registry.AddMetricStruct(tenantUsage.Metrics())
 	node := NewNode(
 		storeCfg, recorder, registry, stopper,
 		txnMetrics, stores, nil /* execCfg */, &rpcContext.ClusterID,

--- a/pkg/testutils/metrictestutils/BUILD.bazel
+++ b/pkg/testutils/metrictestutils/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "metrictestutils",
+    srcs = ["metrics_text.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/testutils/metrictestutils",
+    visibility = ["//visibility:public"],
+    deps = ["//pkg/util/metric"],
+)

--- a/pkg/testutils/metrictestutils/metrics_text.go
+++ b/pkg/testutils/metrictestutils/metrics_text.go
@@ -1,0 +1,46 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package metrictestutils
+
+import (
+	"bufio"
+	"bytes"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
+)
+
+// GetMetricsText scrapes a metrics registry, filters out the metrics according
+// to the given regexp, sorts them, and returns them in a multi-line string.
+func GetMetricsText(registry *metric.Registry, re *regexp.Regexp) (string, error) {
+	ex := metric.MakePrometheusExporter()
+	ex.ScrapeRegistry(registry, true /* includeChildMetrics */)
+	var in bytes.Buffer
+	if err := ex.PrintAsText(&in); err != nil {
+		return "", err
+	}
+	sc := bufio.NewScanner(&in)
+	var outLines []string
+	for sc.Scan() {
+		if bytes.HasPrefix(sc.Bytes(), []byte{'#'}) || !re.Match(sc.Bytes()) {
+			continue
+		}
+		outLines = append(outLines, sc.Text())
+	}
+	if err := sc.Err(); err != nil {
+		return "", err
+	}
+	sort.Strings(outLines)
+	metricsText := strings.Join(outLines, "\n")
+	return metricsText, nil
+}

--- a/pkg/util/metric/aggmetric/agg_metric.go
+++ b/pkg/util/metric/aggmetric/agg_metric.go
@@ -38,6 +38,11 @@ func (b Builder) Gauge(metadata metric.Metadata) *AggGauge {
 	return NewGauge(metadata, b.labels...)
 }
 
+// GaugeFloat64 constructs a new AggGaugeFloat64 with the Builder's labels.
+func (b Builder) GaugeFloat64(metadata metric.Metadata) *AggGaugeFloat64 {
+	return NewGaugeFloat64(metadata, b.labels...)
+}
+
 // Counter constructs a new AggCounter with the Builder's labels.
 func (b Builder) Counter(metadata metric.Metadata) *AggCounter {
 	return NewCounter(metadata, b.labels...)

--- a/pkg/util/metric/aggmetric/gauge.go
+++ b/pkg/util/metric/aggmetric/gauge.go
@@ -11,6 +11,7 @@
 package aggmetric
 
 import (
+	"math"
 	"sync/atomic"
 
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
@@ -109,7 +110,7 @@ func (g *Gauge) ToPrometheusMetric() *io_prometheus_client.Metric {
 // Destroy is used to destroy the gauge associated with this child. The value of
 // the Gauge will be decremented from its parent.
 func (g *Gauge) Destroy() {
-	g.parent.g.Dec(atomic.SwapInt64(&g.value, 0))
+	g.Update(0)
 	g.parent.remove(g)
 }
 
@@ -127,4 +128,116 @@ func (g *Gauge) Inc(i int64) {
 // Dec decrements the gauge's value.
 func (g *Gauge) Dec(i int64) {
 	g.Inc(-i)
+}
+
+// Update sets the gauge's value.
+func (g *Gauge) Update(val int64) {
+	old := atomic.SwapInt64(&g.value, val)
+	g.parent.g.Inc(val - old)
+}
+
+// AggGaugeFloat64 maintains a value as the sum of its children. The gauge will
+// report to crdb-internal time series only the aggregate sum of all of its
+// children, while its children are additionally exported to prometheus via the
+// PrometheusIterable interface.
+type AggGaugeFloat64 struct {
+	g metric.GaugeFloat64
+	childSet
+}
+
+var _ metric.Iterable = (*AggGaugeFloat64)(nil)
+var _ metric.PrometheusIterable = (*AggGaugeFloat64)(nil)
+var _ metric.PrometheusExportable = (*AggGaugeFloat64)(nil)
+
+// NewGaugeFloat64 constructs a new AggGaugeFloat64.
+func NewGaugeFloat64(metadata metric.Metadata, childLabels ...string) *AggGaugeFloat64 {
+	g := &AggGaugeFloat64{g: *metric.NewGaugeFloat64(metadata)}
+	g.init(childLabels)
+	return g
+}
+
+// GetName is part of the metric.Iterable interface.
+func (g *AggGaugeFloat64) GetName() string { return g.g.GetName() }
+
+// GetHelp is part of the metric.Iterable interface.
+func (g *AggGaugeFloat64) GetHelp() string { return g.g.GetHelp() }
+
+// GetMeasurement is part of the metric.Iterable interface.
+func (g *AggGaugeFloat64) GetMeasurement() string { return g.g.GetMeasurement() }
+
+// GetUnit is part of the metric.Iterable interface.
+func (g *AggGaugeFloat64) GetUnit() metric.Unit { return g.g.GetUnit() }
+
+// GetMetadata is part of the metric.Iterable interface.
+func (g *AggGaugeFloat64) GetMetadata() metric.Metadata { return g.g.GetMetadata() }
+
+// Inspect is part of the metric.Iterable interface.
+func (g *AggGaugeFloat64) Inspect(f func(interface{})) { f(g) }
+
+// GetType is part of the metric.PrometheusExportable interface.
+func (g *AggGaugeFloat64) GetType() *io_prometheus_client.MetricType {
+	return g.g.GetType()
+}
+
+// GetLabels is part of the metric.PrometheusExportable interface.
+func (g *AggGaugeFloat64) GetLabels() []*io_prometheus_client.LabelPair {
+	return g.g.GetLabels()
+}
+
+// ToPrometheusMetric is part of the metric.PrometheusExportable interface.
+func (g *AggGaugeFloat64) ToPrometheusMetric() *io_prometheus_client.Metric {
+	return g.g.ToPrometheusMetric()
+}
+
+// Value returns the aggregate sum of all of its current children.
+func (g *AggGaugeFloat64) Value() float64 {
+	return g.g.Value()
+}
+
+// AddChild adds a GaugeFloat64 to this AggGaugeFloat64. This method panics if a GaugeFloat64
+// already exists for this set of labelVals.
+func (g *AggGaugeFloat64) AddChild(labelVals ...string) *GaugeFloat64 {
+	child := &GaugeFloat64{
+		parent:           g,
+		labelValuesSlice: labelValuesSlice(labelVals),
+	}
+	g.add(child)
+	return child
+}
+
+// GaugeFloat64 is a child of a AggGaugeFloat64. When it is incremented or
+// decremented, so too is the parent. When metrics are collected by prometheus,
+// each of the children will appear with a distinct label, however, when
+// cockroach internally collects metrics, only the parent is collected.
+type GaugeFloat64 struct {
+	labelValuesSlice
+	parent *AggGaugeFloat64
+	bits   uint64
+}
+
+// ToPrometheusMetric constructs a prometheus metric for this GaugeFloat64.
+func (g *GaugeFloat64) ToPrometheusMetric() *io_prometheus_client.Metric {
+	return &io_prometheus_client.Metric{
+		Gauge: &io_prometheus_client.Gauge{
+			Value: proto.Float64(g.Value()),
+		},
+	}
+}
+
+// Destroy is used to destroy the gauge associated with this child. The value of
+// the GaugeFloat64 will be decremented from its parent.
+func (g *GaugeFloat64) Destroy() {
+	g.Update(0)
+	g.parent.remove(g)
+}
+
+// Value returns the gauge's current value.
+func (g *GaugeFloat64) Value() float64 {
+	return math.Float64frombits(atomic.LoadUint64(&g.bits))
+}
+
+// Update sets the gauge's value.
+func (g *GaugeFloat64) Update(v float64) {
+	oldBits := atomic.SwapUint64(&g.bits, math.Float64bits(v))
+	g.parent.g.Inc(v - math.Float64frombits(oldBits))
 }

--- a/pkg/util/metric/metric_test.go
+++ b/pkg/util/metric/metric_test.go
@@ -13,6 +13,7 @@ package metric
 import (
 	"bytes"
 	"encoding/json"
+	"math"
 	"reflect"
 	"sync"
 	"testing"
@@ -69,6 +70,17 @@ func TestGaugeFloat64(t *testing.T) {
 		t.Fatalf("unexpected value: %f", v)
 	}
 	testMarshal(t, g, "10.4")
+
+	var wg sync.WaitGroup
+	for i := int64(0); i < 10; i++ {
+		wg.Add(2)
+		go func(i int64) { g.Inc(float64(i)); wg.Done() }(i)
+		go func(i int64) { g.Dec(float64(i)); wg.Done() }(i)
+	}
+	wg.Wait()
+	if v := g.Value(); math.Abs(v-10.4) > 0.001 {
+		t.Fatalf("unexpected value: %g", v)
+	}
 }
 
 func TestRate(t *testing.T) {


### PR DESCRIPTION
This PR is for the top two commits. The rest is #67768.

#### util: add AggGaugeFloat64

This commit adds a float aggregate gauge. We also add support for
incrementing a GaugeFloat64 (required for the aggregate gauge).

Release note: None

#### multitenant: expose consumption metrics

This commit adds per-tenant consumption metrics. Each node presents
the latest consumption value that it knows about, for each tenant. The
higher-level logic will take the Max value across all nodes.

The metrics are:
 - tenant.consumption.request_units
 - tenant.consumption.read_requests
 - tenant.consumption.read_bytes
 - tenant.consumption.write_requests
 - tenant.consumption.write_bytes
 - tenant.consumption.sql_pods_cpu_seconds

Note that these are aggregate metrics, meaning that we export a
separate value for each tenant, and also a sum across all tenants. The
sums are not meaningful in this case and should not be used.

Release note: None
