### PR TITLE
ccl/changefeedccl: skip TestChangefeedPrimaryKeyChangeWorksWithMultip…

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -3710,6 +3710,7 @@ INSERT INTO foo VALUES (1, 'f');
 // will.
 func TestChangefeedPrimaryKeyChangeWorksWithMultipleTables(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 67586, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	skip.UnderRace(t)


### PR DESCRIPTION
…leTables

Refs: #67586

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None