### PR TITLE
roachtest: skip jobs/mixed-version

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_jobs.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_jobs.go
@@ -326,6 +326,7 @@ func registerJobsMixedVersions(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:  "jobs/mixed-versions",
 		Owner: registry.OwnerBulkIO,
+		Skip:  "#67587",
 		// Jobs infrastructure was unstable prior to 20.1 in terms of the behavior
 		// of `PAUSE/CANCEL JOB` commands which were best effort and relied on the
 		// job itself to detect the request. These were fixed by introducing new job


### PR DESCRIPTION
This test was unskipped and was passing locally, but it turns out that
the test wasn't even running any IMPORT jobs locally. This test will
need further investigation to see if IMPORTing a workload between
versions is supported.

Release note: None