### PR TITLE
release-20.1: roachtest: skip jobs/mixed-version

### DIFF
--- a/pkg/cmd/roachtest/mixed_version_jobs.go
+++ b/pkg/cmd/roachtest/mixed_version_jobs.go
@@ -316,6 +316,7 @@ func registerJobsMixedVersions(r *testRegistry) {
 		// is to to test the state transitions of jobs from paused to resumed and
 		// vice versa in order to detect regressions in the work done for 20.1.
 		MinVersion: "v20.1.0",
+		Skip:       "#54387",
 		Cluster:    makeClusterSpec(4),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			predV, err := PredecessorVersion(r.buildVersion)


### PR DESCRIPTION
This is a roachtest that has been failing for a long time since IMPORT
in general does not support running in mixed verison clusters in this
version.

Closes https://github.com/cockroachdb/cockroach/issues/54387.

Release justification: test only change.

Release note: None