### PR TITLE
importccl: disallow IMPORT TABLE with expression indexes

### DIFF
--- a/pkg/ccl/importccl/csv_internal_test.go
+++ b/pkg/ccl/importccl/csv_internal_test.go
@@ -54,6 +54,10 @@ func TestMakeSimpleTableDescriptorErrors(t *testing.T) {
 			error: `to import into a table with virtual computed columns, use IMPORT INTO`,
 		},
 		{
+			stmt:  "create table a (i int, index ((i + 1)))",
+			error: `to import into a table with expression indexes, use IMPORT INTO`,
+		},
+		{
 			stmt: `create table a (
 				i int check (i > 0),
 				b int default 1,

--- a/pkg/ccl/importccl/import_table_creation.go
+++ b/pkg/ccl/importccl/import_table_creation.go
@@ -157,9 +157,16 @@ func MakeSimpleTableDescriptor(
 		switch def := create.Defs[i].(type) {
 		case *tree.CheckConstraintTableDef,
 			*tree.FamilyTableDef,
-			*tree.IndexTableDef,
 			*tree.UniqueConstraintTableDef:
 			// ignore
+		case *tree.IndexTableDef:
+			for i := range def.Columns {
+				if def.Columns[i].Expr != nil {
+					return nil, unimplemented.NewWithIssueDetail(56002, "import.expression-index",
+						"to import into a table with expression indexes, use IMPORT INTO")
+				}
+			}
+
 		case *tree.ColumnTableDef:
 			if def.IsComputed() && def.IsVirtual() {
 				return nil, unimplemented.NewWithIssueDetail(56002, "import.computed",


### PR DESCRIPTION
This commit adds an explanatory error message when a user tries to
execute an `IMPORT TABLE` statement with an expression index.
Previously, the error confusingly read "unimplemented: only simple
columns are supported as index elements". Now it reads "unimplemented:
to import into a table with expression indexes, use IMPORT INTO".

Release note: None