### PR TITLE
release-21.1: tree: fix cast of null JSON value to geo-types

### DIFF
--- a/pkg/sql/sem/tree/casts.go
+++ b/pkg/sql/sem/tree/casts.go
@@ -1023,6 +1023,9 @@ func performCastWithoutPrecisionTruncation(ctx *EvalContext, d Datum, t *types.T
 			if err != nil {
 				return nil, err
 			}
+			if t == nil {
+				return DNull, nil
+			}
 			g, err := geo.ParseGeographyFromGeoJSON([]byte(*t))
 			if err != nil {
 				return nil, err
@@ -1067,6 +1070,9 @@ func performCastWithoutPrecisionTruncation(ctx *EvalContext, d Datum, t *types.T
 			t, err := d.AsText()
 			if err != nil {
 				return nil, err
+			}
+			if t == nil {
+				return DNull, nil
 			}
 			g, err := geo.ParseGeometryFromGeoJSON([]byte(*t))
 			if err != nil {

--- a/pkg/sql/sem/tree/testdata/eval/cast
+++ b/pkg/sql/sem/tree/testdata/eval/cast
@@ -1203,3 +1203,13 @@ eval
 '[]'::jsonb::float
 ----
 invalid cast: jsonb -> float
+
+eval
+'null'::jsonb::geography
+----
+NULL
+
+eval
+'null'::jsonb::geometry
+----
+NULL


### PR DESCRIPTION
Backport 1/1 commits from #67843.

/cc @cockroachdb/release

Release justification: extremely low risk fix to an edge case bug.

---

Fixes: #67842.

Release note (bug fix): Previously, CockroachDB could encounter an
internal error or crash when performing a cast of NULL JSON value to
Geography or Geometry types. Now this is fixed.
