### PR TITLE
release-20.2: tree: fix cast of null JSON value to geo-types

### DIFF
--- a/pkg/sql/sem/tree/casts.go
+++ b/pkg/sql/sem/tree/casts.go
@@ -789,6 +789,9 @@ func PerformCast(ctx *EvalContext, d Datum, t *types.T) (Datum, error) {
 			if err != nil {
 				return nil, err
 			}
+			if t == nil {
+				return DNull, nil
+			}
 			g, err := geo.ParseGeographyFromGeoJSON([]byte(*t))
 			if err != nil {
 				return nil, err
@@ -833,6 +836,9 @@ func PerformCast(ctx *EvalContext, d Datum, t *types.T) (Datum, error) {
 			t, err := d.AsText()
 			if err != nil {
 				return nil, err
+			}
+			if t == nil {
+				return DNull, nil
 			}
 			g, err := geo.ParseGeometryFromGeoJSON([]byte(*t))
 			if err != nil {

--- a/pkg/sql/sem/tree/testdata/eval/cast
+++ b/pkg/sql/sem/tree/testdata/eval/cast
@@ -1132,3 +1132,13 @@ eval
 'hello t'::string::char(100)
 ----
 'hello t'
+
+eval
+'null'::jsonb::geography
+----
+NULL
+
+eval
+'null'::jsonb::geometry
+----
+NULL


### PR DESCRIPTION
Backport 1/1 commits from #67843.

/cc @cockroachdb/release

Release justification: extremely low risk fix to an edge case bug.

---

Fixes: #67842.

Release note (bug fix): Previously, CockroachDB could encounter an
internal error or crash when performing a cast of NULL JSON value to
Geography or Geometry types. Now this is fixed.
