### PR TITLE
roachtest: remove mention of 'roachstress'

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -928,8 +928,13 @@ func (r *testRunner) maybePostGithubIssue(
 		Artifacts:       artifacts,
 		ExtraLabels:     labels,
 		ReproductionCommand: fmt.Sprintf(
-			`# From https://go.crdb.dev/p/roachstress, perhaps edited lightly.
-caffeinate ./roachstress.sh %s
+			`## Simple repro (linux-only):
+  $ make cockroachshort bin/worklaod bin/roachprod bin/roachtest
+  $ PATH=$PWD/bin:$PATH roachtest run %[1]s --local
+
+## Proper repro probably needs more roachtest flags, or running
+## the programs remotely on GCE. For more details, refer to
+## pkg/cmd/roachtest/README.md.
 `, t.Name()),
 	}
 	if err := issues.Post(


### PR DESCRIPTION
The proposed 'roachstress' script linked from the repro steps at
https://gist.github.com/tbg/fc4409e06b4ddc9abc58838cf5c0fe8b is
utterly broken: it confuses local with remote execution.

The correct steps must clarify that `roachprod` and `roachtest`
binaries must be built for the local platform, and the `cockroach` and
`workload` binaries must be built for the remote platform. Someone
trying to run this on macos, or with a linux without the old glibc,
gets inscrutable error messages with the current script.

Additionally, the proposed roachstress script uses a `--cpu-quota`
parameter that's incoherent with `roachtest`'s own default.

Finally, I (@knz) directly witnessed a new hire who was utterly
confused by the amount of automation and assumptions made in the
roachtest script. (Should they install caffeinate? Why? How to
customize the roachtest flags? How to change the number of runs? Can
the test run locally  on my computer?)

In summary, the `roachstress` script is just too magical and actively
hostile to newcomers.

This patch removes it and replaces it by clearer instructiosn.

Release note: None