### PR TITLE
opt: fix show_trace_nonmetamorphic flake

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/show_trace_nonmetamorphic
+++ b/pkg/sql/opt/exec/execbuilder/testdata/show_trace_nonmetamorphic
@@ -351,7 +351,7 @@ dist sender send  r40: sending batch 1 EndTxn to (n1,s1):1
 
 # make a table with some big strings in it.
 statement ok
-CREATE TABLE blobs (i INT PRIMARY KEY, j STRING)
+CREATE TABLE blobs (i INT PRIMARY KEY, j STRING, FAMILY (i, j))
 
 # make a table with some big (1mb) strings in it.
 statement ok


### PR DESCRIPTION
A new test involving traces was added to this file and it is flaky
because of column family randomization. Fixing by specifying the
family explicitly.

Informs #63655.

Release note: None