### PR TITLE
opt: fix over-estimation of rows due to multi-column stats

### DIFF
--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -804,13 +804,16 @@ func (sb *statisticsBuilder) constrainScan(
 
 	// Calculate row count and selectivity
 	// -----------------------------------
-	s.ApplySelectivity(sb.selectivityFromHistograms(histCols, scan, s))
+	histSelectivity, selectivityUpperBound := sb.selectivityFromHistograms(histCols, scan, s)
+	s.ApplySelectivity(histSelectivity)
 	s.ApplySelectivity(sb.selectivityFromMultiColDistinctCounts(constrainedCols, scan, s))
 	s.ApplySelectivity(sb.selectivityFromUnappliedConjuncts(numUnappliedConjuncts))
 	s.ApplySelectivity(sb.selectivityFromNullsRemoved(scan, notNullCols, constrainedCols))
 
-	// Adjust the selectivity so we don't double-count the histogram columns.
+	// Adjust the selectivity so we don't double-count the histogram columns, but
+	// make sure it does not exceed the upper bound based on the histograms.
 	s.UnapplySelectivity(sb.selectivityFromSingleColDistinctCounts(histCols, scan, s))
+	s.LimitSelectivity(selectivityUpperBound)
 }
 
 func (sb *statisticsBuilder) colStatScan(colSet opt.ColSet, scan *ScanExpr) *props.ColumnStatistic {
@@ -991,12 +994,15 @@ func (sb *statisticsBuilder) buildInvertedFilter(
 	// -----------------------------------
 	inputStats := &invFilter.Input.Relational().Stats
 	s.RowCount = inputStats.RowCount
-	s.ApplySelectivity(sb.selectivityFromHistograms(histCols, invFilter, s))
+	histSelectivity, selectivityUpperBound := sb.selectivityFromHistograms(histCols, invFilter, s)
+	s.ApplySelectivity(histSelectivity)
 	s.ApplySelectivity(sb.selectivityFromMultiColDistinctCounts(constrainedCols, invFilter, s))
 	s.ApplySelectivity(sb.selectivityFromNullsRemoved(invFilter, relProps.NotNullCols, constrainedCols))
 
-	// Adjust the selectivity so we don't double-count the histogram columns.
+	// Adjust the selectivity so we don't double-count the histogram columns, but
+	// make sure it does not exceed the upper bound based on the histograms.
 	s.UnapplySelectivity(sb.selectivityFromSingleColDistinctCounts(histCols, invFilter, s))
+	s.LimitSelectivity(selectivityUpperBound)
 
 	sb.finalizeFromCardinality(relProps)
 }
@@ -1157,7 +1163,8 @@ func (sb *statisticsBuilder) buildJoin(
 	if join.Op() == opt.InvertedJoinOp || hasInvertedJoinCond(h.filters) {
 		s.ApplySelectivity(sb.selectivityFromInvertedJoinCondition(join, s))
 	}
-	s.ApplySelectivity(sb.selectivityFromHistograms(histCols, join, s))
+	histSelectivity, selectivityUpperBound := sb.selectivityFromHistograms(histCols, join, s)
+	s.ApplySelectivity(histSelectivity)
 	s.ApplySelectivity(sb.selectivityFromMultiColDistinctCounts(
 		constrainedCols.Intersection(leftCols), join, s,
 	))
@@ -1167,8 +1174,10 @@ func (sb *statisticsBuilder) buildJoin(
 	s.ApplySelectivity(sb.selectivityFromUnappliedConjuncts(numUnappliedConjuncts))
 	s.ApplySelectivity(sb.selectivityFromNullsRemoved(join, relProps.NotNullCols, constrainedCols))
 
-	// Adjust the selectivity so we don't double-count the histogram columns.
+	// Adjust the selectivity so we don't double-count the histogram columns, but
+	// make sure it does not exceed the upper bound based on the histograms.
 	s.UnapplySelectivity(sb.selectivityFromSingleColDistinctCounts(histCols, join, s))
+	s.LimitSelectivity(selectivityUpperBound)
 
 	// Update distinct counts based on equivalencies; this should happen after
 	// selectivityFromMultiColDistinctCounts and selectivityFromEquivalencies.
@@ -2854,14 +2863,17 @@ func (sb *statisticsBuilder) filterRelExpr(
 
 	// Calculate row count and selectivity
 	// -----------------------------------
-	s.ApplySelectivity(sb.selectivityFromHistograms(histCols, e, s))
+	histSelectivity, selectivityUpperBound := sb.selectivityFromHistograms(histCols, e, s)
+	s.ApplySelectivity(histSelectivity)
 	s.ApplySelectivity(sb.selectivityFromMultiColDistinctCounts(constrainedCols, e, s))
 	s.ApplySelectivity(sb.selectivityFromEquivalencies(equivReps, &relProps.FuncDeps, e, s))
 	s.ApplySelectivity(sb.selectivityFromUnappliedConjuncts(numUnappliedConjuncts))
 	s.ApplySelectivity(sb.selectivityFromNullsRemoved(e, notNullCols, constrainedCols))
 
-	// Adjust the selectivity so we don't double-count the histogram columns.
+	// Adjust the selectivity so we don't double-count the histogram columns, but
+	// make sure it does not exceed the upper bound based on the histograms.
 	s.UnapplySelectivity(sb.selectivityFromSingleColDistinctCounts(histCols, e, s))
+	s.LimitSelectivity(selectivityUpperBound)
 
 	// Update distinct and null counts based on equivalencies; this should
 	// happen after selectivityFromMultiColDistinctCounts and
@@ -3090,12 +3102,15 @@ func (sb *statisticsBuilder) constrainExpr(
 
 	// Calculate row count and selectivity
 	// -----------------------------------
-	s.ApplySelectivity(sb.selectivityFromHistograms(histCols, e, s))
+	histSelectivity, selectivityUpperBound := sb.selectivityFromHistograms(histCols, e, s)
+	s.ApplySelectivity(histSelectivity)
 	s.ApplySelectivity(sb.selectivityFromMultiColDistinctCounts(constrainedCols, e, s))
 	s.ApplySelectivity(sb.selectivityFromNullsRemoved(e, notNullCols, constrainedCols))
 
-	// Adjust the selectivity so we don't double-count the histogram columns.
+	// Adjust the selectivity so we don't double-count the histogram columns, but
+	// make sure it does not exceed the upper bound based on the histograms.
 	s.UnapplySelectivity(sb.selectivityFromSingleColDistinctCounts(histCols, e, s))
+	s.LimitSelectivity(selectivityUpperBound)
 }
 
 // applyIndexConstraint is used to update the distinct counts and histograms
@@ -3727,10 +3742,17 @@ func (sb *statisticsBuilder) selectivityFromDistinctCount(
 //
 // For histograms, the selectivity of a constrained column is calculated as
 // (# values in histogram after filter) / (# values in histogram before filter).
+//
+// In addition to returning the product of selectivities,
+// selectivityFromHistograms returns the selectivity of the most selective
+// predicate (i.e., the predicate with minimum selectivity) as
+// selectivityUpperBound, since it is an upper bound on the selectivity of the
+// entire expression.
 func (sb *statisticsBuilder) selectivityFromHistograms(
 	cols opt.ColSet, e RelExpr, s *props.Statistics,
-) (selectivity props.Selectivity) {
+) (selectivity props.Selectivity, selectivityUpperBound props.Selectivity) {
 	selectivity = props.OneSelectivity
+	selectivityUpperBound = props.OneSelectivity
 	for col, ok := cols.Next(0); ok; col, ok = cols.Next(col + 1) {
 		colStat, ok := s.ColStats.Lookup(opt.MakeColSet(col))
 		if !ok {
@@ -3750,12 +3772,18 @@ func (sb *statisticsBuilder) selectivityFromHistograms(
 		// Calculate the selectivity of the predicate.
 		nonNullSelectivity := props.MakeSelectivityFromFraction(newCount, oldCount)
 		nullSelectivity := props.MakeSelectivityFromFraction(colStat.NullCount, inputColStat.NullCount)
-		selectivity.Multiply(sb.predicateSelectivity(
+		predicateSelectivity := sb.predicateSelectivity(
 			nonNullSelectivity, nullSelectivity, inputColStat.NullCount, inputStats.RowCount,
-		))
+		)
+
+		// The maximum possible selectivity of the entire expression is the minimum
+		// selectivity of all individual predicates.
+		selectivityUpperBound = props.MinSelectivity(selectivityUpperBound, predicateSelectivity)
+
+		selectivity.Multiply(predicateSelectivity)
 	}
 
-	return selectivity
+	return selectivity, selectivityUpperBound
 }
 
 // selectivityFromNullsRemoved calculates the selectivity from null-rejecting

--- a/pkg/sql/opt/memo/testdata/stats/inverted-geo
+++ b/pkg/sql/opt/memo/testdata/stats/inverted-geo
@@ -165,12 +165,12 @@ project
       │    ├── limit hint: 1.00
       │    ├── sort
       │    │    ├── columns: i:1(int) g:2(geometry)
-      │    │    ├── stats: [rows=7e-07]
+      │    │    ├── stats: [rows=1e-07]
       │    │    ├── ordering: +1
       │    │    ├── limit hint: 0.00
       │    │    └── index-join t
       │    │         ├── columns: i:1(int) g:2(geometry)
-      │    │         ├── stats: [rows=7e-07]
+      │    │         ├── stats: [rows=1e-07]
       │    │         └── inverted-filter
       │    │              ├── columns: rowid:3(int!null)
       │    │              ├── inverted expression: /6
@@ -178,13 +178,13 @@ project
       │    │              │    └── union spans: ["B\xfd\xff\xff\xff\xff\xff\xff\xff\xff", "B\xfd\xff\xff\xff\xff\xff\xff\xff\xff"]
       │    │              ├── pre-filterer expression
       │    │              │    └── st_intersects('010200000002000000000000000000594000000000000059400000000000C062400000000000C06240', g:2) [type=bool]
-      │    │              ├── stats: [rows=7e-07]
+      │    │              ├── stats: [rows=1e-07]
       │    │              ├── key: (3)
       │    │              └── scan t@secondary
       │    │                   ├── columns: rowid:3(int!null) g_inverted_key:6(geometry!null)
       │    │                   ├── inverted constraint: /6/3
       │    │                   │    └── spans: ["B\xfd\xff\xff\xff\xff\xff\xff\xff\xff", "B\xfd\xff\xff\xff\xff\xff\xff\xff\xff"]
-      │    │                   ├── stats: [rows=7e-07, distinct(3)=7e-07, null(3)=0, distinct(6)=7e-07, null(6)=0]
+      │    │                   ├── stats: [rows=1e-07, distinct(3)=1e-07, null(3)=0, distinct(6)=1e-07, null(6)=0]
       │    │                   │   histogram(6)=
       │    │                   ├── key: (3)
       │    │                   └── fd: (3)-->(6)
@@ -385,12 +385,12 @@ project
       │    ├── limit hint: 1.00
       │    ├── sort
       │    │    ├── columns: i:1(int) g:2(geometry)
-      │    │    ├── stats: [rows=7e-07]
+      │    │    ├── stats: [rows=1e-07]
       │    │    ├── ordering: +1
       │    │    ├── limit hint: 0.00
       │    │    └── index-join t
       │    │         ├── columns: i:1(int) g:2(geometry)
-      │    │         ├── stats: [rows=7e-07]
+      │    │         ├── stats: [rows=1e-07]
       │    │         └── inverted-filter
       │    │              ├── columns: rowid:3(int!null)
       │    │              ├── inverted expression: /6
@@ -398,13 +398,13 @@ project
       │    │              │    └── union spans: ["B\xfd\xff\xff\xff\xff\xff\xff\xff\xff", "B\xfd\xff\xff\xff\xff\xff\xff\xff\xff"]
       │    │              ├── pre-filterer expression
       │    │              │    └── st_intersects('010200000002000000000000000000594000000000000059400000000000C062400000000000C06240', g:2) [type=bool]
-      │    │              ├── stats: [rows=7e-07]
+      │    │              ├── stats: [rows=1e-07]
       │    │              ├── key: (3)
       │    │              └── scan t@secondary
       │    │                   ├── columns: rowid:3(int!null) g_inverted_key:6(geometry!null)
       │    │                   ├── inverted constraint: /6/3
       │    │                   │    └── spans: ["B\xfd\xff\xff\xff\xff\xff\xff\xff\xff", "B\xfd\xff\xff\xff\xff\xff\xff\xff\xff"]
-      │    │                   ├── stats: [rows=7e-07, distinct(3)=7e-07, null(3)=0, distinct(6)=7e-07, null(6)=0]
+      │    │                   ├── stats: [rows=1e-07, distinct(3)=1e-07, null(3)=0, distinct(6)=1e-07, null(6)=0]
       │    │                   │   histogram(6)=
       │    │                   ├── key: (3)
       │    │                   └── fd: (3)-->(6)

--- a/pkg/sql/opt/memo/testdata/stats/inverted-json
+++ b/pkg/sql/opt/memo/testdata/stats/inverted-json
@@ -715,14 +715,14 @@ select
  ├── fd: (1)-->(2)
  ├── index-join t
  │    ├── columns: k:1(int!null) j:2(jsonb)
- │    ├── stats: [rows=2e-07]
+ │    ├── stats: [rows=4e-08]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2)
  │    └── scan t@j_idx
  │         ├── columns: k:1(int!null)
  │         ├── inverted constraint: /5/1
  │         │    └── spans: ["7a\x00\x02b\x00\x01\x12c\x00\x01", "7a\x00\x02b\x00\x01\x12c\x00\x01"]
- │         ├── stats: [rows=2e-07, distinct(5)=2e-07, null(5)=0]
+ │         ├── stats: [rows=4e-08, distinct(5)=4e-08, null(5)=0]
  │         │   histogram(5)=
  │         └── key: (1)
  └── filters
@@ -741,14 +741,14 @@ select
  ├── fd: (1)-->(2)
  ├── index-join t
  │    ├── columns: k:1(int!null) j:2(jsonb)
- │    ├── stats: [rows=2e-07]
+ │    ├── stats: [rows=4e-08]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2)
  │    └── scan t@j_idx
  │         ├── columns: k:1(int!null)
  │         ├── inverted constraint: /5/1
  │         │    └── spans: ["7a\x00\x02b\x00\x02c\x00\x01\x12d\x00\x01", "7a\x00\x02b\x00\x02c\x00\x01\x12d\x00\x01"]
- │         ├── stats: [rows=2e-07, distinct(5)=2e-07, null(5)=0]
+ │         ├── stats: [rows=4e-08, distinct(5)=4e-08, null(5)=0]
  │         │   histogram(5)=
  │         └── key: (1)
  └── filters
@@ -768,7 +768,7 @@ select
  ├── fd: (1)-->(2)
  ├── index-join t
  │    ├── columns: k:1(int!null) j:2(jsonb)
- │    ├── stats: [rows=2e-07]
+ │    ├── stats: [rows=4e-08]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2)
  │    └── inverted-filter
@@ -783,7 +783,7 @@ select
  │         │         └── span expression
  │         │              ├── tight: true, unique: true
  │         │              └── union spans: ["7a\x00\x02d\x00\x01\x12e\x00\x01", "7a\x00\x02d\x00\x01\x12e\x00\x01"]
- │         ├── stats: [rows=2e-07]
+ │         ├── stats: [rows=4e-08]
  │         ├── key: (1)
  │         └── scan t@j_idx
  │              ├── columns: k:1(int!null) j_inverted_key:5(jsonb!null)
@@ -791,7 +791,7 @@ select
  │              │    └── spans
  │              │         ├── ["7a\x00\x02b\x00\x01\x12c\x00\x01", "7a\x00\x02b\x00\x01\x12c\x00\x01"]
  │              │         └── ["7a\x00\x02d\x00\x01\x12e\x00\x01", "7a\x00\x02d\x00\x01\x12e\x00\x01"]
- │              ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(5)=2e-07, null(5)=0]
+ │              ├── stats: [rows=4e-08, distinct(1)=4e-08, null(1)=0, distinct(5)=4e-08, null(5)=0]
  │              │   histogram(5)=
  │              ├── key: (1)
  │              └── fd: (1)-->(5)
@@ -811,7 +811,7 @@ select
  ├── fd: (1)-->(2)
  ├── index-join t
  │    ├── columns: k:1(int!null) j:2(jsonb)
- │    ├── stats: [rows=2e-07]
+ │    ├── stats: [rows=4e-08]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2)
  │    └── inverted-filter
@@ -840,7 +840,7 @@ select
  │         │         └── span expression
  │         │              ├── tight: true, unique: true
  │         │              └── union spans: ["7a\x00\x02\x00\x03\x00\x01\x12e\x00\x01", "7a\x00\x02\x00\x03\x00\x01\x12e\x00\x01"]
- │         ├── stats: [rows=2e-07]
+ │         ├── stats: [rows=4e-08]
  │         ├── key: (1)
  │         └── scan t@j_idx
  │              ├── columns: k:1(int!null) j_inverted_key:5(jsonb!null)
@@ -850,7 +850,7 @@ select
  │              │         ├── ["7a\x00\x02\x00\x03\x00\x01\x12c\x00\x01", "7a\x00\x02\x00\x03\x00\x01\x12c\x00\x01"]
  │              │         ├── ["7a\x00\x02\x00\x03\x00\x01\x12d\x00\x01", "7a\x00\x02\x00\x03\x00\x01\x12d\x00\x01"]
  │              │         └── ["7a\x00\x02\x00\x03\x00\x01\x12e\x00\x01", "7a\x00\x02\x00\x03\x00\x01\x12e\x00\x01"]
- │              ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(5)=2e-07, null(5)=0]
+ │              ├── stats: [rows=4e-08, distinct(1)=4e-08, null(1)=0, distinct(5)=4e-08, null(5)=0]
  │              │   histogram(5)=
  │              ├── key: (1)
  │              └── fd: (1)-->(5)
@@ -871,7 +871,7 @@ select
  ├── fd: (1)-->(2)
  ├── index-join t
  │    ├── columns: k:1(int!null) j:2(jsonb)
- │    ├── stats: [rows=2e-07]
+ │    ├── stats: [rows=4e-08]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2)
  │    └── inverted-filter
@@ -893,7 +893,7 @@ select
  │         │         └── span expression
  │         │              ├── tight: true, unique: true
  │         │              └── union spans: ["7a\x00\x02b\x00\x02\x00\x03\x00\x01\x12e\x00\x01", "7a\x00\x02b\x00\x02\x00\x03\x00\x01\x12e\x00\x01"]
- │         ├── stats: [rows=2e-07]
+ │         ├── stats: [rows=4e-08]
  │         ├── key: (1)
  │         └── scan t@j_idx
  │              ├── columns: k:1(int!null) j_inverted_key:5(jsonb!null)
@@ -902,7 +902,7 @@ select
  │              │         ├── ["7a\x00\x02b\x00\x02\x00\x03\x00\x01\x12c\x00\x01", "7a\x00\x02b\x00\x02\x00\x03\x00\x01\x12c\x00\x01"]
  │              │         ├── ["7a\x00\x02b\x00\x02\x00\x03\x00\x01\x12d\x00\x01", "7a\x00\x02b\x00\x02\x00\x03\x00\x01\x12d\x00\x01"]
  │              │         └── ["7a\x00\x02b\x00\x02\x00\x03\x00\x01\x12e\x00\x01", "7a\x00\x02b\x00\x02\x00\x03\x00\x01\x12e\x00\x01"]
- │              ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(5)=2e-07, null(5)=0]
+ │              ├── stats: [rows=4e-08, distinct(1)=4e-08, null(1)=0, distinct(5)=4e-08, null(5)=0]
  │              │   histogram(5)=
  │              ├── key: (1)
  │              └── fd: (1)-->(5)
@@ -922,7 +922,7 @@ select
  ├── fd: (1)-->(2)
  ├── index-join t
  │    ├── columns: k:1(int!null) j:2(jsonb)
- │    ├── stats: [rows=2e-07]
+ │    ├── stats: [rows=4e-08]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2)
  │    └── inverted-filter
@@ -932,7 +932,7 @@ select
  │         │    └── union spans
  │         │         ├── ["7a\x00\x018", "7a\x00\x018"]
  │         │         └── ["7a\x00\x02\x00\x03", "7a\x00\x02\x00\x03"]
- │         ├── stats: [rows=2e-07]
+ │         ├── stats: [rows=4e-08]
  │         ├── key: (1)
  │         └── scan t@j_idx
  │              ├── columns: k:1(int!null) j_inverted_key:5(jsonb!null)
@@ -940,7 +940,7 @@ select
  │              │    └── spans
  │              │         ├── ["7a\x00\x018", "7a\x00\x018"]
  │              │         └── ["7a\x00\x02\x00\x03", "7a\x00\x02\x00\x03"]
- │              ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(5)=2e-07, null(5)=0]
+ │              ├── stats: [rows=4e-08, distinct(1)=4e-08, null(1)=0, distinct(5)=4e-08, null(5)=0]
  │              │   histogram(5)=
  │              ├── key: (1)
  │              └── fd: (1)-->(5)
@@ -960,7 +960,7 @@ select
  ├── fd: (1)-->(2)
  ├── index-join t
  │    ├── columns: k:1(int!null) j:2(jsonb)
- │    ├── stats: [rows=2e-07]
+ │    ├── stats: [rows=4e-08]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2)
  │    └── inverted-filter
@@ -970,7 +970,7 @@ select
  │         │    └── union spans
  │         │         ├── ["7a\x00\x019", "7a\x00\x019"]
  │         │         └── ["7a\x00\x02\x00\xff", "7a\x00\x03")
- │         ├── stats: [rows=2e-07]
+ │         ├── stats: [rows=4e-08]
  │         ├── key: (1)
  │         └── scan t@j_idx
  │              ├── columns: k:1(int!null) j_inverted_key:5(jsonb!null)
@@ -978,7 +978,7 @@ select
  │              │    └── spans
  │              │         ├── ["7a\x00\x019", "7a\x00\x019"]
  │              │         └── ["7a\x00\x02\x00\xff", "7a\x00\x03")
- │              ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(5)=2e-07, null(5)=0]
+ │              ├── stats: [rows=4e-08, distinct(1)=4e-08, null(1)=0, distinct(5)=4e-08, null(5)=0]
  │              │   histogram(5)=
  │              ├── key: (1)
  │              └── fd: (1)-->(5)
@@ -1002,7 +1002,7 @@ index-join t
       │    └── union spans
       │         ├── ["7a\x00\x01*\x02\x00", "7a\x00\x01*\x02\x00"]
       │         └── ["7a\x00\x02\x00\x03\x00\x01*\x02\x00", "7a\x00\x02\x00\x03\x00\x01*\x02\x00"]
-      ├── stats: [rows=2e-07]
+      ├── stats: [rows=4e-08]
       ├── key: (1)
       └── scan t@j_idx
            ├── columns: k:1(int!null) j_inverted_key:5(jsonb!null)
@@ -1010,7 +1010,7 @@ index-join t
            │    └── spans
            │         ├── ["7a\x00\x01*\x02\x00", "7a\x00\x01*\x02\x00"]
            │         └── ["7a\x00\x02\x00\x03\x00\x01*\x02\x00", "7a\x00\x02\x00\x03\x00\x01*\x02\x00"]
-           ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(5)=2e-07, null(5)=0]
+           ├── stats: [rows=4e-08, distinct(1)=4e-08, null(1)=0, distinct(5)=4e-08, null(5)=0]
            │   histogram(5)=
            ├── key: (1)
            └── fd: (1)-->(5)
@@ -1071,7 +1071,7 @@ index-join t
       │    └── union spans
       │         ├── ["7a\x00\x02b\x00\x01\x12c\x00\x01", "7a\x00\x02b\x00\x01\x12c\x00\x01"]
       │         └── ["7a\x00\x02b\x00\x02\x00\x03\x00\x01\x12c\x00\x01", "7a\x00\x02b\x00\x02\x00\x03\x00\x01\x12c\x00\x01"]
-      ├── stats: [rows=2e-07]
+      ├── stats: [rows=4e-08]
       ├── key: (1)
       └── scan t@j_idx
            ├── columns: k:1(int!null) j_inverted_key:5(jsonb!null)
@@ -1079,7 +1079,7 @@ index-join t
            │    └── spans
            │         ├── ["7a\x00\x02b\x00\x01\x12c\x00\x01", "7a\x00\x02b\x00\x01\x12c\x00\x01"]
            │         └── ["7a\x00\x02b\x00\x02\x00\x03\x00\x01\x12c\x00\x01", "7a\x00\x02b\x00\x02\x00\x03\x00\x01\x12c\x00\x01"]
-           ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(5)=2e-07, null(5)=0]
+           ├── stats: [rows=4e-08, distinct(1)=4e-08, null(1)=0, distinct(5)=4e-08, null(5)=0]
            │   histogram(5)=
            ├── key: (1)
            └── fd: (1)-->(5)
@@ -1140,7 +1140,7 @@ index-join t
       ├── columns: k:1(int!null)
       ├── inverted constraint: /5/1
       │    └── spans: ["7a\x00\x02b\x00\x01\x12c\x00\x01", "7a\x00\x02b\x00\x01\x12c\x00\x01"]
-      ├── stats: [rows=2e-07, distinct(5)=2e-07, null(5)=0]
+      ├── stats: [rows=4e-08, distinct(5)=4e-08, null(5)=0]
       │   histogram(5)=
       └── key: (1)
 
@@ -1198,7 +1198,7 @@ select
  ├── fd: (1)-->(2)
  ├── index-join t
  │    ├── columns: k:1(int!null) j:2(jsonb)
- │    ├── stats: [rows=2e-07]
+ │    ├── stats: [rows=4e-08]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2)
  │    └── inverted-filter
@@ -1213,7 +1213,7 @@ select
  │         │         └── span expression
  │         │              ├── tight: true, unique: true
  │         │              └── union spans: ["7a\x00\x02\x00\x03\x00\x01*\x04\x00", "7a\x00\x02\x00\x03\x00\x01*\x04\x00"]
- │         ├── stats: [rows=2e-07]
+ │         ├── stats: [rows=4e-08]
  │         ├── key: (1)
  │         └── scan t@j_idx
  │              ├── columns: k:1(int!null) j_inverted_key:5(jsonb!null)
@@ -1221,7 +1221,7 @@ select
  │              │    └── spans
  │              │         ├── ["7a\x00\x02\x00\x03\x00\x01*\x02\x00", "7a\x00\x02\x00\x03\x00\x01*\x02\x00"]
  │              │         └── ["7a\x00\x02\x00\x03\x00\x01*\x04\x00", "7a\x00\x02\x00\x03\x00\x01*\x04\x00"]
- │              ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(5)=2e-07, null(5)=0]
+ │              ├── stats: [rows=4e-08, distinct(1)=4e-08, null(1)=0, distinct(5)=4e-08, null(5)=0]
  │              │   histogram(5)=
  │              ├── key: (1)
  │              └── fd: (1)-->(5)
@@ -1293,7 +1293,7 @@ index-join t
       │    └── union spans
       │         ├── ["7a\x00\x02b\x00\x01\x12c\x00\x01", "7a\x00\x02b\x00\x01\x12c\x00\x01"]
       │         └── ["7a\x00\x02b\x00\x02\x00\x03\x00\x01\x12c\x00\x01", "7a\x00\x02b\x00\x02\x00\x03\x00\x01\x12c\x00\x01"]
-      ├── stats: [rows=2e-07]
+      ├── stats: [rows=4e-08]
       ├── key: (1)
       └── scan t@j_idx
            ├── columns: k:1(int!null) j_inverted_key:5(jsonb!null)
@@ -1301,7 +1301,7 @@ index-join t
            │    └── spans
            │         ├── ["7a\x00\x02b\x00\x01\x12c\x00\x01", "7a\x00\x02b\x00\x01\x12c\x00\x01"]
            │         └── ["7a\x00\x02b\x00\x02\x00\x03\x00\x01\x12c\x00\x01", "7a\x00\x02b\x00\x02\x00\x03\x00\x01\x12c\x00\x01"]
-           ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(5)=2e-07, null(5)=0]
+           ├── stats: [rows=4e-08, distinct(1)=4e-08, null(1)=0, distinct(5)=4e-08, null(5)=0]
            │   histogram(5)=
            ├── key: (1)
            └── fd: (1)-->(5)

--- a/pkg/sql/opt/memo/testdata/stats/partial-index-scan
+++ b/pkg/sql/opt/memo/testdata/stats/partial-index-scan
@@ -1036,11 +1036,11 @@ project
       ├── inverted constraint: /7/1
       │    └── spans: ["7g\x00\x01*\x0e\x00", "7g\x00\x01*\x0e\x00"]
       ├── flags: force-index=partial
-      ├── stats: [rows=183.217822, distinct(4)=2, null(4)=0, distinct(7)=50.5, null(7)=0, distinct(4,7)=101, null(4,7)=0]
-      │   histogram(4)=  0   91.609   0   91.609
+      ├── stats: [rows=160, distinct(4)=2, null(4)=0, distinct(7)=50.5, null(7)=0, distinct(4,7)=101, null(4,7)=0]
+      │   histogram(4)=  0     80     0     80
       │                <--- 'banana' --- 'cherry'
-      │   histogram(7)=  0        73.287        109.93          0
-      │                <--- '\x376700012a0e00' -------- '\x376700012a0e01'
+      │   histogram(7)=  0          64          96          0
+      │                <--- '\x376700012a0e00' ---- '\x376700012a0e01'
       └── key: (1)
 
 opt
@@ -1059,11 +1059,11 @@ index-join inv_hist
       ├── inverted constraint: /7/1
       │    └── spans: ["7g\x00\x01*\x0e\x00", "7g\x00\x01*\x0e\x00"]
       ├── flags: force-index=partial
-      ├── stats: [rows=183.217822, distinct(4)=2, null(4)=0, distinct(7)=50.5, null(7)=0, distinct(4,7)=101, null(4,7)=0]
-      │   histogram(4)=  0   91.609   0   91.609
+      ├── stats: [rows=160, distinct(4)=2, null(4)=0, distinct(7)=50.5, null(7)=0, distinct(4,7)=101, null(4,7)=0]
+      │   histogram(4)=  0     80     0     80
       │                <--- 'banana' --- 'cherry'
-      │   histogram(7)=  0        73.287        109.93          0
-      │                <--- '\x376700012a0e00' -------- '\x376700012a0e01'
+      │   histogram(7)=  0          64          96          0
+      │                <--- '\x376700012a0e00' ---- '\x376700012a0e01'
       └── key: (1)
 
 opt
@@ -1084,7 +1084,7 @@ project
       ├── fd: ()-->(4), (1)-->(3)
       ├── index-join inv_hist
       │    ├── columns: k:1(int!null) j:3(jsonb) s:4(string)
-      │    ├── stats: [rows=183.217822]
+      │    ├── stats: [rows=160]
       │    ├── key: (1)
       │    ├── fd: (1)-->(3,4)
       │    └── scan inv_hist@partial,partial
@@ -1092,11 +1092,11 @@ project
       │         ├── inverted constraint: /7/1
       │         │    └── spans: ["7g\x00\x01*\x0e\x00", "7g\x00\x01*\x0e\x00"]
       │         ├── flags: force-index=partial
-      │         ├── stats: [rows=183.217822, distinct(4)=2, null(4)=0, distinct(7)=50.5, null(7)=0, distinct(4,7)=101, null(4,7)=0]
-      │         │   histogram(4)=  0   91.609   0   91.609
+      │         ├── stats: [rows=160, distinct(4)=2, null(4)=0, distinct(7)=50.5, null(7)=0, distinct(4,7)=101, null(4,7)=0]
+      │         │   histogram(4)=  0     80     0     80
       │         │                <--- 'banana' --- 'cherry'
-      │         │   histogram(7)=  0        73.287        109.93          0
-      │         │                <--- '\x376700012a0e00' -------- '\x376700012a0e01'
+      │         │   histogram(7)=  0          64          96          0
+      │         │                <--- '\x376700012a0e00' ---- '\x376700012a0e01'
       │         └── key: (1)
       └── filters
            └── s:4 = 'banana' [type=bool, outer=(4), constraints=(/4: [/'banana' - /'banana']; tight), fd=()-->(4)]
@@ -1114,7 +1114,7 @@ select
  ├── fd: ()-->(4), (1)-->(2,3)
  ├── index-join inv_hist
  │    ├── columns: k:1(int!null) i:2(int) j:3(jsonb) s:4(string)
- │    ├── stats: [rows=183.217822]
+ │    ├── stats: [rows=160]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4)
  │    └── scan inv_hist@partial,partial
@@ -1122,11 +1122,11 @@ select
  │         ├── inverted constraint: /7/1
  │         │    └── spans: ["7g\x00\x01*\x0e\x00", "7g\x00\x01*\x0e\x00"]
  │         ├── flags: force-index=partial
- │         ├── stats: [rows=183.217822, distinct(4)=2, null(4)=0, distinct(7)=50.5, null(7)=0, distinct(4,7)=101, null(4,7)=0]
- │         │   histogram(4)=  0   91.609   0   91.609
+ │         ├── stats: [rows=160, distinct(4)=2, null(4)=0, distinct(7)=50.5, null(7)=0, distinct(4,7)=101, null(4,7)=0]
+ │         │   histogram(4)=  0     80     0     80
  │         │                <--- 'banana' --- 'cherry'
- │         │   histogram(7)=  0        73.287        109.93          0
- │         │                <--- '\x376700012a0e00' -------- '\x376700012a0e01'
+ │         │   histogram(7)=  0          64          96          0
+ │         │                <--- '\x376700012a0e00' ---- '\x376700012a0e01'
  │         └── key: (1)
  └── filters
       └── s:4 = 'banana' [type=bool, outer=(4), constraints=(/4: [/'banana' - /'banana']; tight), fd=()-->(4)]
@@ -1146,7 +1146,7 @@ select
  ├── fd: (1)-->(2-4)
  ├── index-join inv_hist
  │    ├── columns: k:1(int!null) i:2(int) j:3(jsonb) s:4(string)
- │    ├── stats: [rows=183.217822]
+ │    ├── stats: [rows=160]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4)
  │    └── scan inv_hist@partial,partial
@@ -1154,11 +1154,11 @@ select
  │         ├── inverted constraint: /7/1
  │         │    └── spans: ["7g\x00\x01*\x0e\x00", "7g\x00\x01*\x0e\x00"]
  │         ├── flags: force-index=partial
- │         ├── stats: [rows=183.217822, distinct(4)=2, null(4)=0, distinct(7)=50.5, null(7)=0, distinct(4,7)=101, null(4,7)=0]
- │         │   histogram(4)=  0   91.609   0   91.609
+ │         ├── stats: [rows=160, distinct(4)=2, null(4)=0, distinct(7)=50.5, null(7)=0, distinct(4,7)=101, null(4,7)=0]
+ │         │   histogram(4)=  0     80     0     80
  │         │                <--- 'banana' --- 'cherry'
- │         │   histogram(7)=  0        73.287        109.93          0
- │         │                <--- '\x376700012a0e00' -------- '\x376700012a0e01'
+ │         │   histogram(7)=  0          64          96          0
+ │         │                <--- '\x376700012a0e00' ---- '\x376700012a0e01'
  │         └── key: (1)
  └── filters
       └── (i:2 > 0) AND (i:2 <= 100) [type=bool, outer=(2), constraints=(/2: [/1 - /100]; tight)]

--- a/pkg/sql/opt/memo/testdata/stats/scan
+++ b/pkg/sql/opt/memo/testdata/stats/scan
@@ -817,13 +817,13 @@ SELECT * FROM hist WHERE f = '2019-10-30 23:00:00'::TIMESTAMPTZ
 ----
 index-join hist
  ├── columns: a:1(int) b:2(date) c:3(decimal) d:4(float) e:5(timestamp) f:6(timestamptz!null) g:7(string)
- ├── stats: [rows=1e-07, distinct(6)=1e-07, null(6)=0]
+ ├── stats: [rows=5e-10, distinct(6)=5e-10, null(6)=0]
  │   histogram(6)=
  ├── fd: ()-->(6)
  └── scan hist@idx_f
       ├── columns: f:6(timestamptz!null) rowid:8(int!null)
       ├── constraint: /6/8: [/'2019-10-30 23:00:00+00:00' - /'2019-10-30 23:00:00+00:00']
-      ├── stats: [rows=1e-07, distinct(6)=1e-07, null(6)=0]
+      ├── stats: [rows=5e-10, distinct(6)=5e-10, null(6)=0]
       │   histogram(6)=
       ├── key: (8)
       └── fd: ()-->(6)

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -3023,3 +3023,103 @@ limit
  │    └── filters
  │         └── ((a:2 > 'fop') OR (b:3 > 'fop')) OR (c:4 > 'fop') [type=bool, outer=(2-4)]
  └── 5 [type=int]
+
+# Regression test for #67573. Do not over-estimate row counts when columns
+# are highly correlated and selected values are very common according to the
+# histograms.
+exec-ddl
+CREATE TABLE ab (
+  a INT,
+  b INT,
+  c INT,
+  PRIMARY KEY (a,b,c)
+)
+----
+
+exec-ddl
+ALTER TABLE ab INJECT STATISTICS '[
+    {
+        "columns": [ "a" ],
+        "created_at": "2021-07-13 14:04:42.014148",
+        "distinct_count": 20000,
+        "histo_buckets": [
+            {
+                "distinct_range": 0,
+                "num_eq": 60000,
+                "num_range": 0,
+                "upper_bound": "1"
+            },
+            {
+                "distinct_range": 20000,
+                "num_eq": 20000,
+                "num_range": 20000,
+                "upper_bound": "40000"
+            }
+        ],
+        "histo_col_type": "INT8",
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 100000
+    },
+    {
+        "columns": [ "b" ],
+        "created_at": "2021-07-13 14:04:42.014148",
+        "distinct_count": 7000,
+        "histo_col_type": "",
+        "name": "__auto__",
+        "histo_buckets": [
+            {
+                "distinct_range": 0,
+                "num_eq": 7000,
+                "num_range": 0,
+                "upper_bound": "1"
+            },
+            {
+                "distinct_range": 7000,
+                "num_eq": 86000,
+                "num_range": 7000,
+                "upper_bound": "10000"
+            }
+        ],
+        "histo_col_type": "INT8",
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 100000
+    },
+    {
+        "columns": [ "a", "b" ],
+        "created_at": "2021-07-13 14:04:42.014148",
+        "distinct_count": 20000,
+        "histo_col_type": "",
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 100000
+    }
+]';
+----
+
+# Make sure the row count for the outer select is less than the row count
+# for the scan.
+norm
+SELECT * FROM ab WHERE a=1 AND b=1
+----
+select
+ ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ ├── stats: [rows=7000, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(1,2)=1, null(1,2)=0]
+ │   histogram(1)=  0 7000
+ │                <--- 1 -
+ │   histogram(2)=  0 7000
+ │                <--- 1 -
+ ├── key: (3)
+ ├── fd: ()-->(1,2)
+ ├── scan ab
+ │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── stats: [rows=100000, distinct(1)=20000, null(1)=0, distinct(2)=7000, null(2)=0, distinct(3)=10000, null(3)=0, distinct(1,2)=20000, null(1,2)=0]
+ │    │   histogram(1)=  0 60000 20000  20000
+ │    │                <---- 1 -------- 40000
+ │    │   histogram(2)=  0 7000 7000  86000
+ │    │                <--- 1 ------- 10000
+ │    └── key: (1-3)
+ └── filters
+      ├── a:1 = 1 [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
+      └── b:2 = 1 [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q20
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q20
@@ -62,27 +62,27 @@ sort
  ├── save-table-name: q20_sort_1
  ├── columns: s_name:2(char!null) s_address:3(varchar!null)
  ├── immutable
- ├── stats: [rows=2.01612903e-05, distinct(2)=2.01612903e-05, null(2)=0, distinct(3)=2.01612903e-05, null(3)=0]
+ ├── stats: [rows=1e-06, distinct(2)=1e-06, null(2)=0, distinct(3)=1e-06, null(3)=0]
  ├── ordering: +2
  └── project
       ├── save-table-name: q20_project_2
       ├── columns: s_name:2(char!null) s_address:3(varchar!null)
       ├── immutable
-      ├── stats: [rows=2.01612903e-05, distinct(2)=2.01612903e-05, null(2)=0, distinct(3)=2.01612903e-05, null(3)=0]
+      ├── stats: [rows=1e-06, distinct(2)=1e-06, null(2)=0, distinct(3)=1e-06, null(3)=0]
       └── inner-join (lookup nation)
            ├── save-table-name: q20_lookup_join_3
            ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_address:3(varchar!null) s_nationkey:4(int!null) n_nationkey:10(int!null) n_name:11(char!null)
            ├── key columns: [4] = [10]
            ├── lookup columns are key
            ├── immutable
-           ├── stats: [rows=2.01612903e-05, distinct(1)=2e-05, null(1)=0, distinct(2)=2.01612903e-05, null(2)=0, distinct(3)=2.01612903e-05, null(3)=0, distinct(4)=2.01612824e-05, null(4)=0, distinct(10)=2.01612824e-05, null(10)=0, distinct(11)=2.01612903e-05, null(11)=0]
+           ├── stats: [rows=1e-06, distinct(1)=1.24917659e-08, null(1)=0, distinct(2)=1e-06, null(2)=0, distinct(3)=1e-06, null(3)=0, distinct(4)=1e-06, null(4)=0, distinct(10)=1e-06, null(10)=0, distinct(11)=1e-06, null(11)=0]
            ├── key: (1)
            ├── fd: ()-->(11), (1)-->(2-4), (4)==(10), (10)==(4)
            ├── project
            │    ├── save-table-name: q20_project_4
            │    ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_address:3(varchar!null) s_nationkey:4(int!null)
            │    ├── immutable
-           │    ├── stats: [rows=2.01612903e-05, distinct(1)=2e-05, null(1)=0, distinct(2)=2.01612903e-05, null(2)=0, distinct(3)=2.01612903e-05, null(3)=0, distinct(4)=2.01612824e-05, null(4)=0]
+           │    ├── stats: [rows=1e-06, distinct(1)=1.24917659e-08, null(1)=0, distinct(2)=1e-06, null(2)=0, distinct(3)=1e-06, null(3)=0, distinct(4)=1e-06, null(4)=0]
            │    ├── key: (1)
            │    ├── fd: (1)-->(2-4)
            │    └── inner-join (lookup supplier)
@@ -91,7 +91,7 @@ sort
            │         ├── key columns: [17] = [1]
            │         ├── lookup columns are key
            │         ├── immutable
-           │         ├── stats: [rows=0.2, distinct(1)=2e-05, null(1)=0, distinct(2)=0.2, null(2)=0, distinct(3)=0.2, null(3)=0, distinct(4)=0.2, null(4)=0, distinct(17)=2e-05, null(17)=0]
+           │         ├── stats: [rows=0.000124917659, distinct(1)=1.24917659e-08, null(1)=0, distinct(2)=0.000124917659, null(2)=0, distinct(3)=0.000124917659, null(3)=0, distinct(4)=0.000124917659, null(4)=0, distinct(17)=1.24917659e-08, null(17)=0]
            │         ├── key: (17)
            │         ├── fd: (1)-->(2-4), (1)==(17), (17)==(1)
            │         ├── distinct-on
@@ -99,7 +99,7 @@ sort
            │         │    ├── columns: ps_suppkey:17(int!null)
            │         │    ├── grouping columns: ps_suppkey:17(int!null)
            │         │    ├── immutable
-           │         │    ├── stats: [rows=2e-05, distinct(17)=2e-05, null(17)=0]
+           │         │    ├── stats: [rows=1.24917659e-08, distinct(17)=1.24917659e-08, null(17)=0]
            │         │    ├── key: (17)
            │         │    └── inner-join (lookup part)
            │         │         ├── save-table-name: q20_lookup_join_7
@@ -107,7 +107,7 @@ sort
            │         │         ├── key columns: [16] = [23]
            │         │         ├── lookup columns are key
            │         │         ├── immutable
-           │         │         ├── stats: [rows=0.00249835317, distinct(16)=2e-05, null(16)=0, distinct(17)=0.00249835317, null(17)=0, distinct(18)=0.00249835317, null(18)=0, distinct(23)=2e-05, null(23)=0, distinct(24)=7.51678871e-09, null(24)=0, distinct(52)=0.00249835317, null(52)=0]
+           │         │         ├── stats: [rows=2.49835317e-13, distinct(16)=2e-15, null(16)=0, distinct(17)=2.49835317e-13, null(17)=0, distinct(18)=2.49835317e-13, null(18)=0, distinct(23)=2e-15, null(23)=0, distinct(24)=2e-15, null(24)=0, distinct(52)=2.49835317e-13, null(52)=0]
            │         │         ├── key: (17,23)
            │         │         ├── fd: (16,17)-->(18,52), (23)-->(24), (16)==(23), (23)==(16)
            │         │         ├── select

--- a/pkg/sql/opt/props/selectivity.go
+++ b/pkg/sql/opt/props/selectivity.go
@@ -67,7 +67,7 @@ func (s *Selectivity) Divide(other Selectivity) {
 	s.selectivity = selectivityInRange(s.selectivity / other.selectivity)
 }
 
-// MinSelectivity returns the smaller value of two selectivities
+// MinSelectivity returns the smaller value of two selectivities.
 func MinSelectivity(a, b Selectivity) Selectivity {
 	if a.selectivity < b.selectivity {
 		return a

--- a/pkg/sql/opt/xform/testdata/external/fittings
+++ b/pkg/sql/opt/xform/testdata/external/fittings
@@ -2622,12 +2622,12 @@ project
            ├── columns: killmail:1!null
            ├── internal-ordering: -1
            ├── cardinality: [0 - 100]
-           ├── stats: [rows=0.0023556407]
+           ├── stats: [rows=5.22083488e-07]
            ├── key: (1)
            ├── ordering: -1
            ├── sort
            │    ├── columns: killmail:1!null
-           │    ├── stats: [rows=0.0023556407, distinct(13)=0.0023556407, null(13)=0]
+           │    ├── stats: [rows=5.22083488e-07, distinct(13)=5.22083488e-07, null(13)=0]
            │    │   histogram(13)=
            │    ├── key: (1)
            │    ├── ordering: -1
@@ -2636,7 +2636,7 @@ project
            │         ├── columns: killmail:1!null
            │         ├── inverted constraint: /13/1
            │         │    └── spans: ["7\x00\x03\x00\x01,\v_>\x00", "7\x00\x03\x00\x01,\v_>\x00"]
-           │         ├── stats: [rows=0.0023556407, distinct(13)=0.0023556407, null(13)=0]
+           │         ├── stats: [rows=5.22083488e-07, distinct(13)=5.22083488e-07, null(13)=0]
            │         │   histogram(13)=
            │         └── key: (1)
            └── 100

--- a/pkg/sql/opt/xform/testdata/external/tpce
+++ b/pkg/sql/opt/xform/testdata/external/tpce
@@ -55,43 +55,43 @@ sort
       │    ├── project
       │    │    ├── columns: column54:54!null b_name:49!null
       │    │    ├── immutable
-      │    │    ├── inner-join (hash)
+      │    │    ├── inner-join (lookup sector@secondary)
       │    │    │    ├── columns: sc_id:1!null sc_name:2!null in_id:5!null in_sc_id:7!null co_id:10!null co_in_id:13!null s_symb:21!null s_co_id:26!null tr_s_symb:41!null tr_qty:42!null tr_bid_price:43!null tr_b_id:44!null b_id:47!null b_name:49!null
-      │    │    │    ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
+      │    │    │    ├── key columns: [65] = [2]
+      │    │    │    ├── lookup columns are key
       │    │    │    ├── fd: ()-->(1,2,7), (10)-->(13), (21)-->(26), (47)-->(49), (44)==(47), (47)==(44), (21)==(41), (41)==(21), (10)==(26), (26)==(10), (5)==(13), (13)==(5), (1)==(7), (7)==(1)
-      │    │    │    ├── scan sector@secondary
-      │    │    │    │    ├── columns: sc_id:1!null sc_name:2!null
-      │    │    │    │    ├── constraint: /2: [/'Energy' - /'Energy']
-      │    │    │    │    ├── cardinality: [0 - 1]
-      │    │    │    │    ├── key: ()
-      │    │    │    │    └── fd: ()-->(1,2)
-      │    │    │    ├── inner-join (lookup industry)
-      │    │    │    │    ├── columns: in_id:5!null in_sc_id:7!null co_id:10!null co_in_id:13!null s_symb:21!null s_co_id:26!null tr_s_symb:41!null tr_qty:42!null tr_bid_price:43!null tr_b_id:44!null b_id:47!null b_name:49!null
-      │    │    │    │    ├── key columns: [13] = [5]
-      │    │    │    │    ├── lookup columns are key
-      │    │    │    │    ├── fd: (5)-->(7), (10)-->(13), (21)-->(26), (47)-->(49), (44)==(47), (47)==(44), (21)==(41), (41)==(21), (10)==(26), (26)==(10), (5)==(13), (13)==(5)
-      │    │    │    │    ├── inner-join (lookup company)
-      │    │    │    │    │    ├── columns: co_id:10!null co_in_id:13!null s_symb:21!null s_co_id:26!null tr_s_symb:41!null tr_qty:42!null tr_bid_price:43!null tr_b_id:44!null b_id:47!null b_name:49!null
-      │    │    │    │    │    ├── key columns: [26] = [10]
+      │    │    │    ├── project
+      │    │    │    │    ├── columns: "lookup_join_const_col_@2":65!null in_id:5!null in_sc_id:7!null co_id:10!null co_in_id:13!null s_symb:21!null s_co_id:26!null tr_s_symb:41!null tr_qty:42!null tr_bid_price:43!null tr_b_id:44!null b_id:47!null b_name:49!null
+      │    │    │    │    ├── fd: ()-->(65), (5)-->(7), (10)-->(13), (21)-->(26), (47)-->(49), (44)==(47), (47)==(44), (21)==(41), (41)==(21), (10)==(26), (26)==(10), (5)==(13), (13)==(5)
+      │    │    │    │    ├── inner-join (lookup industry)
+      │    │    │    │    │    ├── columns: in_id:5!null in_sc_id:7!null co_id:10!null co_in_id:13!null s_symb:21!null s_co_id:26!null tr_s_symb:41!null tr_qty:42!null tr_bid_price:43!null tr_b_id:44!null b_id:47!null b_name:49!null
+      │    │    │    │    │    ├── key columns: [13] = [5]
       │    │    │    │    │    ├── lookup columns are key
-      │    │    │    │    │    ├── fd: (10)-->(13), (21)-->(26), (47)-->(49), (44)==(47), (47)==(44), (21)==(41), (41)==(21), (10)==(26), (26)==(10)
-      │    │    │    │    │    ├── inner-join (lookup security)
-      │    │    │    │    │    │    ├── columns: s_symb:21!null s_co_id:26!null tr_s_symb:41!null tr_qty:42!null tr_bid_price:43!null tr_b_id:44!null b_id:47!null b_name:49!null
-      │    │    │    │    │    │    ├── key columns: [41] = [21]
+      │    │    │    │    │    ├── fd: (5)-->(7), (10)-->(13), (21)-->(26), (47)-->(49), (44)==(47), (47)==(44), (21)==(41), (41)==(21), (10)==(26), (26)==(10), (5)==(13), (13)==(5)
+      │    │    │    │    │    ├── inner-join (lookup company)
+      │    │    │    │    │    │    ├── columns: co_id:10!null co_in_id:13!null s_symb:21!null s_co_id:26!null tr_s_symb:41!null tr_qty:42!null tr_bid_price:43!null tr_b_id:44!null b_id:47!null b_name:49!null
+      │    │    │    │    │    │    ├── key columns: [26] = [10]
       │    │    │    │    │    │    ├── lookup columns are key
-      │    │    │    │    │    │    ├── fd: (21)-->(26), (47)-->(49), (44)==(47), (47)==(44), (21)==(41), (41)==(21)
-      │    │    │    │    │    │    ├── inner-join (lookup broker)
-      │    │    │    │    │    │    │    ├── columns: tr_s_symb:41!null tr_qty:42!null tr_bid_price:43!null tr_b_id:44!null b_id:47!null b_name:49!null
-      │    │    │    │    │    │    │    ├── key columns: [44] = [47]
+      │    │    │    │    │    │    ├── fd: (10)-->(13), (21)-->(26), (47)-->(49), (44)==(47), (47)==(44), (21)==(41), (41)==(21), (10)==(26), (26)==(10)
+      │    │    │    │    │    │    ├── inner-join (lookup security)
+      │    │    │    │    │    │    │    ├── columns: s_symb:21!null s_co_id:26!null tr_s_symb:41!null tr_qty:42!null tr_bid_price:43!null tr_b_id:44!null b_id:47!null b_name:49!null
+      │    │    │    │    │    │    │    ├── key columns: [41] = [21]
       │    │    │    │    │    │    │    ├── lookup columns are key
-      │    │    │    │    │    │    │    ├── fd: (47)-->(49), (44)==(47), (47)==(44)
-      │    │    │    │    │    │    │    ├── scan trade_request@secondary
-      │    │    │    │    │    │    │    │    └── columns: tr_s_symb:41!null tr_qty:42!null tr_bid_price:43!null tr_b_id:44!null
-      │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │         └── b_name:49 IN ('Broker1', 'Broker10', 'Broker11', 'Broker12', 'Broker13', 'Broker14', 'Broker15', 'Broker16', 'Broker17', 'Broker18', 'Broker19', 'Broker2', 'Broker20', 'Broker21', 'Broker22', 'Broker23', 'Broker24', 'Broker25', 'Broker26', 'Broker27', 'Broker28', 'Broker29', 'Broker3', 'Broker30', 'Broker4', 'Broker5', 'Broker6', 'Broker7', 'Broker8', 'Broker9') [outer=(49), constraints=(/49: [/'Broker1' - /'Broker1'] [/'Broker10' - /'Broker10'] [/'Broker11' - /'Broker11'] [/'Broker12' - /'Broker12'] [/'Broker13' - /'Broker13'] [/'Broker14' - /'Broker14'] [/'Broker15' - /'Broker15'] [/'Broker16' - /'Broker16'] [/'Broker17' - /'Broker17'] [/'Broker18' - /'Broker18'] [/'Broker19' - /'Broker19'] [/'Broker2' - /'Broker2'] [/'Broker20' - /'Broker20'] [/'Broker21' - /'Broker21'] [/'Broker22' - /'Broker22'] [/'Broker23' - /'Broker23'] [/'Broker24' - /'Broker24'] [/'Broker25' - /'Broker25'] [/'Broker26' - /'Broker26'] [/'Broker27' - /'Broker27'] [/'Broker28' - /'Broker28'] [/'Broker29' - /'Broker29'] [/'Broker3' - /'Broker3'] [/'Broker30' - /'Broker30'] [/'Broker4' - /'Broker4'] [/'Broker5' - /'Broker5'] [/'Broker6' - /'Broker6'] [/'Broker7' - /'Broker7'] [/'Broker8' - /'Broker8'] [/'Broker9' - /'Broker9']; tight)]
+      │    │    │    │    │    │    │    ├── fd: (21)-->(26), (47)-->(49), (44)==(47), (47)==(44), (21)==(41), (41)==(21)
+      │    │    │    │    │    │    │    ├── inner-join (lookup broker)
+      │    │    │    │    │    │    │    │    ├── columns: tr_s_symb:41!null tr_qty:42!null tr_bid_price:43!null tr_b_id:44!null b_id:47!null b_name:49!null
+      │    │    │    │    │    │    │    │    ├── key columns: [44] = [47]
+      │    │    │    │    │    │    │    │    ├── lookup columns are key
+      │    │    │    │    │    │    │    │    ├── fd: (47)-->(49), (44)==(47), (47)==(44)
+      │    │    │    │    │    │    │    │    ├── scan trade_request@secondary
+      │    │    │    │    │    │    │    │    │    └── columns: tr_s_symb:41!null tr_qty:42!null tr_bid_price:43!null tr_b_id:44!null
+      │    │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │    │    │         └── b_name:49 IN ('Broker1', 'Broker10', 'Broker11', 'Broker12', 'Broker13', 'Broker14', 'Broker15', 'Broker16', 'Broker17', 'Broker18', 'Broker19', 'Broker2', 'Broker20', 'Broker21', 'Broker22', 'Broker23', 'Broker24', 'Broker25', 'Broker26', 'Broker27', 'Broker28', 'Broker29', 'Broker3', 'Broker30', 'Broker4', 'Broker5', 'Broker6', 'Broker7', 'Broker8', 'Broker9') [outer=(49), constraints=(/49: [/'Broker1' - /'Broker1'] [/'Broker10' - /'Broker10'] [/'Broker11' - /'Broker11'] [/'Broker12' - /'Broker12'] [/'Broker13' - /'Broker13'] [/'Broker14' - /'Broker14'] [/'Broker15' - /'Broker15'] [/'Broker16' - /'Broker16'] [/'Broker17' - /'Broker17'] [/'Broker18' - /'Broker18'] [/'Broker19' - /'Broker19'] [/'Broker2' - /'Broker2'] [/'Broker20' - /'Broker20'] [/'Broker21' - /'Broker21'] [/'Broker22' - /'Broker22'] [/'Broker23' - /'Broker23'] [/'Broker24' - /'Broker24'] [/'Broker25' - /'Broker25'] [/'Broker26' - /'Broker26'] [/'Broker27' - /'Broker27'] [/'Broker28' - /'Broker28'] [/'Broker29' - /'Broker29'] [/'Broker3' - /'Broker3'] [/'Broker30' - /'Broker30'] [/'Broker4' - /'Broker4'] [/'Broker5' - /'Broker5'] [/'Broker6' - /'Broker6'] [/'Broker7' - /'Broker7'] [/'Broker8' - /'Broker8'] [/'Broker9' - /'Broker9']; tight)]
+      │    │    │    │    │    │    │    └── filters (true)
       │    │    │    │    │    │    └── filters (true)
       │    │    │    │    │    └── filters (true)
-      │    │    │    │    └── filters (true)
+      │    │    │    │    └── projections
+      │    │    │    │         └── 'Energy' [as="lookup_join_const_col_@2":65]
       │    │    │    └── filters
       │    │    │         └── sc_id:1 = in_sc_id:7 [outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
       │    │    └── projections

--- a/pkg/sql/opt/xform/testdata/external/trading
+++ b/pkg/sql/opt/xform/testdata/external/trading
@@ -550,7 +550,7 @@ FROM CardsView WHERE Version > 1584421773604892000.0000000000
 project
  ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null buyprice:11!null sellprice:12!null desiredinventory:14!null actualinventory:15!null version:17!null discount:13!null maxinventory:16!null
  ├── immutable
- ├── stats: [rows=1]
+ ├── stats: [rows=0.0115557548]
  ├── key: (17)
  ├── fd: (1)-->(2-6,11-17), (2,4,5)~~>(1,3,6), (17)-->(1-6,11-16)
  └── inner-join (lookup cards)
@@ -558,23 +558,23 @@ project
       ├── key columns: [10] = [1]
       ├── lookup columns are key
       ├── immutable
-      ├── stats: [rows=1, distinct(1)=0.0201621393, null(1)=0, distinct(10)=0.0201621393, null(10)=0]
+      ├── stats: [rows=0.0115557548, distinct(1)=2.02732541e-07, null(1)=0, distinct(10)=2.02732541e-07, null(10)=0]
       ├── key: (10)
       ├── fd: ()-->(9), (1)-->(2-6), (2,4,5)~~>(1,3,6), (10)-->(11-17), (17)-->(10-16), (1)==(10), (10)==(1)
       ├── index-join cardsinfo
       │    ├── columns: dealerid:9!null cardid:10!null buyprice:11!null sellprice:12!null discount:13!null desiredinventory:14!null actualinventory:15!null maxinventory:16!null version:17!null
       │    ├── immutable
-      │    ├── stats: [rows=0.0201621426, distinct(9)=0.0201621426, null(9)=0, distinct(10)=0.0201621393, null(10)=0, distinct(11)=0.02016214, null(11)=0, distinct(12)=0.02016214, null(12)=0, distinct(13)=0.02016214, null(13)=0, distinct(14)=0.02016214, null(14)=0, distinct(15)=0.02016214, null(15)=0, distinct(16)=0.02016214, null(16)=0, distinct(17)=0.0201621426, null(17)=0, distinct(9,17)=0.0201621426, null(9,17)=0]
-      │    │   histogram(17)=  0                0                 0.020162           0
-      │    │                 <--- 1584421773604892000.0000000000 ---------- 1584421778604892000
+      │    ├── stats: [rows=2.02732541e-07, distinct(9)=2.02732541e-07, null(9)=0, distinct(10)=2.02732541e-07, null(10)=0, distinct(11)=2.02732541e-07, null(11)=0, distinct(12)=2.02732541e-07, null(12)=0, distinct(13)=2.02732541e-07, null(13)=0, distinct(14)=2.02732541e-07, null(14)=0, distinct(15)=2.02732541e-07, null(15)=0, distinct(16)=2.02732541e-07, null(16)=0, distinct(17)=2.02732541e-07, null(17)=0, distinct(9,17)=2.02732541e-07, null(9,17)=0]
+      │    │   histogram(17)=  0                0                 2.0273e-07           0
+      │    │                 <--- 1584421773604892000.0000000000 ------------ 1584421778604892000
       │    ├── key: (10)
       │    ├── fd: ()-->(9), (10)-->(11-17), (17)-->(10-16)
       │    └── scan cardsinfo@cardsinfoversionindex
       │         ├── columns: dealerid:9!null cardid:10!null version:17!null
       │         ├── constraint: /9/17: (/1/1584421773604892000.0000000000 - /1]
-      │         ├── stats: [rows=0.0201621426, distinct(9)=0.0201621426, null(9)=0, distinct(10)=0.0201621426, null(10)=0, distinct(17)=0.0201621426, null(17)=0, distinct(9,17)=0.0201621426, null(9,17)=0]
-      │         │   histogram(17)=  0                0                 0.020162           0
-      │         │                 <--- 1584421773604892000.0000000000 ---------- 1584421778604892000
+      │         ├── stats: [rows=2.02732541e-07, distinct(9)=2.02732541e-07, null(9)=0, distinct(10)=2.02732541e-07, null(10)=0, distinct(17)=2.02732541e-07, null(17)=0, distinct(9,17)=2.02732541e-07, null(9,17)=0]
+      │         │   histogram(17)=  0                0                 2.0273e-07           0
+      │         │                 <--- 1584421773604892000.0000000000 ------------ 1584421778604892000
       │         ├── key: (10)
       │         └── fd: ()-->(9), (10)-->(17), (17)-->(10)
       └── filters (true)

--- a/pkg/sql/opt/xform/testdata/external/trading-mutation
+++ b/pkg/sql/opt/xform/testdata/external/trading-mutation
@@ -558,7 +558,7 @@ FROM CardsView WHERE Version > 1584421773604892000.0000000000
 project
  ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null buyprice:11!null sellprice:12!null desiredinventory:14!null actualinventory:15!null version:17!null discount:13!null maxinventory:16!null
  ├── immutable
- ├── stats: [rows=1]
+ ├── stats: [rows=5.1775e-06]
  ├── key: (17)
  ├── fd: (1)-->(2-6,11-17), (2,4,5)~~>(1,3,6), (17)-->(1-6,11-16)
  └── inner-join (lookup cards)
@@ -566,20 +566,20 @@ project
       ├── key columns: [10] = [1]
       ├── lookup columns are key
       ├── immutable
-      ├── stats: [rows=1, distinct(1)=6.35833333e-05, null(1)=0, distinct(10)=6.35833333e-05, null(10)=0]
+      ├── stats: [rows=5.1775e-06, distinct(1)=9.08333333e-11, null(1)=0, distinct(10)=9.08333333e-11, null(10)=0]
       ├── key: (10)
       ├── fd: ()-->(9), (1)-->(2-6), (2,4,5)~~>(1,3,6), (10)-->(11-17), (17)-->(10-16), (1)==(10), (10)==(1)
       ├── index-join cardsinfo
       │    ├── columns: dealerid:9!null cardid:10!null buyprice:11!null sellprice:12!null discount:13!null desiredinventory:14!null actualinventory:15!null maxinventory:16!null version:17!null
       │    ├── immutable
-      │    ├── stats: [rows=6.35833333e-05, distinct(9)=6.35833333e-05, null(9)=0, distinct(10)=6.35833333e-05, null(10)=0, distinct(11)=6.35833333e-05, null(11)=0, distinct(12)=6.35833333e-05, null(12)=0, distinct(13)=6.35833333e-05, null(13)=0, distinct(14)=6.35833333e-05, null(14)=0, distinct(15)=6.35833333e-05, null(15)=0, distinct(16)=6.35833333e-05, null(16)=0, distinct(17)=6.35833333e-05, null(17)=0, distinct(9,17)=6.35833333e-05, null(9,17)=0]
+      │    ├── stats: [rows=9.08333333e-11, distinct(9)=9.08333333e-11, null(9)=0, distinct(10)=9.08333333e-11, null(10)=0, distinct(11)=9.08333333e-11, null(11)=0, distinct(12)=9.08333333e-11, null(12)=0, distinct(13)=9.08333333e-11, null(13)=0, distinct(14)=9.08333333e-11, null(14)=0, distinct(15)=9.08333333e-11, null(15)=0, distinct(16)=9.08333333e-11, null(16)=0, distinct(17)=9.08333333e-11, null(17)=0, distinct(9,17)=9.08333333e-11, null(9,17)=0]
       │    │   histogram(17)=
       │    ├── key: (10)
       │    ├── fd: ()-->(9), (10)-->(11-17), (17)-->(10-16)
       │    └── scan cardsinfo@cardsinfoversionindex
       │         ├── columns: dealerid:9!null cardid:10!null version:17!null
       │         ├── constraint: /9/17: (/1/1584421773604892000.0000000000 - /1]
-      │         ├── stats: [rows=6.35833333e-05, distinct(9)=6.35833333e-05, null(9)=0, distinct(10)=6.35833333e-05, null(10)=0, distinct(17)=6.35833333e-05, null(17)=0, distinct(9,17)=6.35833333e-05, null(9,17)=0]
+      │         ├── stats: [rows=9.08333333e-11, distinct(9)=9.08333333e-11, null(9)=0, distinct(10)=9.08333333e-11, null(10)=0, distinct(17)=9.08333333e-11, null(17)=0, distinct(9,17)=9.08333333e-11, null(9,17)=0]
       │         │   histogram(17)=
       │         ├── key: (10)
       │         └── fd: ()-->(9), (10)-->(17), (17)-->(10)


### PR DESCRIPTION
This commit fixes row count estimation in cases where the predicate
has conditions on two or more columns that are highly correlated, and
the selected values are very common according to the histograms.

Fixes #67573

Release note (bug fix): Fixed an issue with statistics estimation in the
optimizer that could cause it to over-estimate the number of rows for some
expressions and thus choose a sub-optimal plan. This issue could happen
when multi-column statistics were used in combination with histograms, the
query contained a predicate on two or more columns where the columns were
hightly correlated, and the selected values were very common according to
the histograms.