### PR TITLE
sql: add information about retries to statement trace

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1033,6 +1033,9 @@ type ExecutorTestingKnobs struct {
 	// AfterExecCmd is called after successful execution of any command.
 	AfterExecCmd func(ctx context.Context, cmd Command, buf *StmtBuf)
 
+	// BeforeRestart is called before a transaction restarts.
+	BeforeRestart func(ctx context.Context, reason error)
+
 	// DisableAutoCommit, if set, disables the auto-commit functionality of some
 	// SQL statements. That functionality allows some statements to commit
 	// directly when they're executed in an implicit SQL txn, without waiting for
@@ -1939,6 +1942,11 @@ func (st *SessionTracing) TracePlanCheckEnd(ctx context.Context, err error, dist
 	} else {
 		log.VEventfDepth(ctx, 2, 1, "will distribute plan: %v", dist)
 	}
+}
+
+// TraceRetryInformation conditionally emits a trace message for retry information.
+func (st *SessionTracing) TraceRetryInformation(ctx context.Context, retries int, err error) {
+	log.VEventfDepth(ctx, 2, 1, "executing after %d retries, last retry reason: %v", retries, err)
 }
 
 // TraceExecStart conditionally emits a trace message at the moment


### PR DESCRIPTION
Currently, statement diagnostic bundles reflect the last,
successful run of the query. While we already track the number
of times a transaciton has been automatically retried, we do
not record errors causing the retry. This addition allows
us to access the last error causing an automatic retry
during statement execution, adding it to the statement
trace and diagnostic bundle.

Resolves: cockroachdb#65146

Release note (sql change):  Retry information has been added
to the statement trace under the 'exec stmt' operation.

The trace message is in the format:
"executing after <int> retries, last retry reason: <err>"

This message will appear in any operations that show the
statement trace, which is included in operations such as
SHOW TRACE FOR SESSION and is also exported in the statement
diagnostics bundle.

--------

Sample message in the trace after forcing a retry:
```
"sql/conn_executor_exec.go:690 [n1,client=127.0.0.1:54187,hostnossl,user=root] executing after 4 retries, last retry reason: crdb_internal.force_retry(): TransactionRetryWithProtoRefreshError: forced by crdb_internal.force_retry()"
```