### PR TITLE
roachprod: delete EBS volumes on termination

### DIFF
--- a/pkg/cmd/roachprod/vm/aws/aws.go
+++ b/pkg/cmd/roachprod/vm/aws/aws.go
@@ -862,12 +862,14 @@ func (p *Provider) runInstance(name string, zone string, opts vm.CreateOpts) err
 	if !opts.SSDOpts.UseLocalSSD {
 		if len(p.opts.EBSVolumes) == 0 && p.opts.DefaultEBSVolume.Disk.VolumeType == "" {
 			p.opts.DefaultEBSVolume.Disk.VolumeType = defaultEBSVolumeType
+			p.opts.DefaultEBSVolume.Disk.DeleteOnTermination = true
 		}
 
 		if p.opts.DefaultEBSVolume.Disk.VolumeType != "" {
 			// Add default volume to the list of volumes we'll setup.
 			v := p.opts.EBSVolumes.newVolume()
 			v.Disk = p.opts.DefaultEBSVolume.Disk
+			v.Disk.DeleteOnTermination = true
 			p.opts.EBSVolumes = append(p.opts.EBSVolumes, v)
 		}
 	}


### PR DESCRIPTION
Fixes #67932

Previously, when a cluster was generated with `--local-ssd=false`, the
EBS volume was created with `deleteOnTermination` set to `false`. As a
result we ended up with many dangling volumes.

The patch explicitly sets the `DeleteOnTermination` property for the
`--local-ssd=false` case.

Release note: None