### PR TITLE
sql,server: refactor SQL Stats control to sqlstats package

### DIFF
--- a/pkg/server/diagnostics/reporter.go
+++ b/pkg/server/diagnostics/reporter.go
@@ -159,7 +159,7 @@ func (r *Reporter) ReportDiagnostics(ctx context.Context) {
 			"error: %v", res.Status, b, err)
 		return
 	}
-	r.SQLServer.ResetReportedStats(ctx)
+	r.SQLServer.GetReportedSQLStatsController().ResetLocalSQLStats(ctx)
 }
 
 // CreateReport generates a new diagnostics report containing information about

--- a/pkg/server/diagnostics/reporter_test.go
+++ b/pkg/server/diagnostics/reporter_test.go
@@ -65,7 +65,7 @@ func TestTenantReport(t *testing.T) {
 	setupCluster(t, tenantDB)
 
 	// Clear the SQL stat pool before getting diagnostics.
-	rt.server.SQLServer().(*sql.Server).ResetSQLStats(ctx)
+	rt.server.SQLServer().(*sql.Server).GetSQLStatsController().ResetLocalSQLStats(ctx)
 	reporter.ReportDiagnostics(ctx)
 
 	require.Equal(t, 1, rt.diagServer.NumRequests())
@@ -137,7 +137,7 @@ func TestServerReport(t *testing.T) {
 
 		node := rt.server.MetricsRecorder().GenerateNodeStatus(ctx)
 		// Clear the SQL stat pool before getting diagnostics.
-		rt.server.SQLServer().(*sql.Server).ResetSQLStats(ctx)
+		rt.server.SQLServer().(*sql.Server).GetSQLStatsController().ResetLocalSQLStats(ctx)
 		rt.server.DiagnosticsReporter().(*diagnostics.Reporter).ReportDiagnostics(ctx)
 
 		keyCounts := make(map[roachpb.StoreID]int64)
@@ -334,7 +334,7 @@ func TestUsageQuantization(t *testing.T) {
 	}
 
 	// Flush the SQL stat pool.
-	ts.SQLServer().(*sql.Server).ResetSQLStats(ctx)
+	ts.SQLServer().(*sql.Server).GetSQLStatsController().ResetLocalSQLStats(ctx)
 
 	// Collect a round of statistics.
 	ts.DiagnosticsReporter().(*diagnostics.Reporter).ReportDiagnostics(ctx)

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -698,7 +698,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		execCfg,
 	)
 
-	distSQLServer.ServerConfig.SQLStatsResetter = pgServer.SQLServer
+	distSQLServer.ServerConfig.SQLStatsController = pgServer.SQLServer.GetSQLStatsController()
 
 	// Now that we have a pgwire.Server (which has a sql.Server), we can close a
 	// circular dependency between the rowexec.Server and sql.Server and set

--- a/pkg/server/sql_stats.go
+++ b/pkg/server/sql_stats.go
@@ -42,7 +42,8 @@ func (s *statusServer) ResetSQLStats(
 			return nil, status.Errorf(codes.InvalidArgument, err.Error())
 		}
 		if local {
-			s.admin.server.sqlServer.pgServer.SQLServer.ResetSQLStats(ctx)
+			controller := s.sqlServer.pgServer.SQLServer.GetSQLStatsController()
+			controller.ResetLocalSQLStats(ctx)
 			return response, nil
 		}
 		status, err := s.dialNode(ctx, requestedNodeID)

--- a/pkg/server/stats_test.go
+++ b/pkg/server/stats_test.go
@@ -65,8 +65,8 @@ CREATE TABLE t.test (x INT PRIMARY KEY);
 	sqlServer := s.(*TestServer).Server.sqlServer.pgServer.SQLServer
 
 	// Flush stats at the beginning of the test.
-	sqlServer.ResetSQLStats(ctx)
-	sqlServer.ResetReportedStats(ctx)
+	sqlServer.GetSQLStatsController().ResetLocalSQLStats(ctx)
+	sqlServer.GetReportedSQLStatsController().ResetLocalSQLStats(ctx)
 
 	// Run some queries mixed with diagnostics, and ensure that the statistics
 	// are unnaffected by the calls to report diagnostics.
@@ -167,8 +167,8 @@ func TestSQLStatCollection(t *testing.T) {
 	sqlServer := s.(*TestServer).Server.sqlServer.pgServer.SQLServer
 
 	// Flush stats at the beginning of the test.
-	sqlServer.ResetSQLStats(ctx)
-	sqlServer.ResetReportedStats(ctx)
+	sqlServer.GetSQLStatsController().ResetLocalSQLStats(ctx)
+	sqlServer.GetReportedSQLStatsController().ResetLocalSQLStats(ctx)
 
 	// Execute some queries against the sqlDB to build up some stats.
 	if _, err := sqlDB.Exec(`
@@ -202,7 +202,7 @@ func TestSQLStatCollection(t *testing.T) {
 
 	// Reset the SQL statistics, which will dump stats into the
 	// reported statistics pool.
-	sqlServer.ResetSQLStats(ctx)
+	sqlServer.GetSQLStatsController().ResetLocalSQLStats(ctx)
 
 	// Query the reported statistics.
 	stats, err = sqlServer.GetScrubbedReportingStats(ctx)
@@ -248,7 +248,7 @@ func TestSQLStatCollection(t *testing.T) {
 	}
 
 	// Flush the SQL stats again.
-	sqlServer.ResetSQLStats(ctx)
+	sqlServer.GetSQLStatsController().ResetLocalSQLStats(ctx)
 
 	// Find our statement stat from the reported stats pool.
 	stats, err = sqlServer.GetScrubbedReportingStats(ctx)

--- a/pkg/server/tenant_status.go
+++ b/pkg/server/tenant_status.go
@@ -114,7 +114,8 @@ func (t *tenantStatusServer) ListContentionEvents(
 func (t *tenantStatusServer) ResetSQLStats(
 	ctx context.Context, _ *serverpb.ResetSQLStatsRequest,
 ) (*serverpb.ResetSQLStatsResponse, error) {
-	t.sqlServer.pgServer.SQLServer.ResetSQLStats(ctx)
+	controller := t.sqlServer.pgServer.SQLServer.GetSQLStatsController()
+	controller.ResetLocalSQLStats(ctx)
 	return &serverpb.ResetSQLStatsResponse{}, nil
 }
 

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -330,7 +330,7 @@ func (ds *ServerImpl) setupFlow(
 			InternalExecutor:   ie,
 			Txn:                leafTxn,
 			SQLLivenessReader:  ds.ServerConfig.SQLLivenessReader,
-			SQLStatsResetter:   ds.ServerConfig.SQLStatsResetter,
+			SQLStatsController: ds.ServerConfig.SQLStatsController,
 		}
 		evalCtx.SetStmtTimestamp(timeutil.Unix(0 /* sec */, req.EvalContext.StmtTimestampNanos))
 		evalCtx.SetTxnTimestamp(timeutil.Unix(0 /* sec */, req.EvalContext.TxnTimestampNanos))

--- a/pkg/sql/execinfra/server_config.go
+++ b/pkg/sql/execinfra/server_config.go
@@ -141,9 +141,9 @@ type ServerConfig struct {
 	// gateway.
 	RangeCache *rangecache.RangeCache
 
-	// SQLStatsResetter is an interface used to reset SQL stats without the need to
+	// SQLStatsController is an interface used to reset SQL stats without the need to
 	// introduce dependency on the sql package.
-	SQLStatsResetter tree.SQLStatsResetter
+	SQLStatsController tree.SQLStatsController
 
 	// SQLSQLResponseAdmissionQ is the admission queue to use for
 	// SQLSQLResponseWork.

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -5540,11 +5540,11 @@ table's zone configuration this will return NULL.`,
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.Bool),
 			Fn: func(evalCtx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
-				if evalCtx.SQLStatsResetter == nil {
+				if evalCtx.SQLStatsController == nil {
 					return nil, errors.AssertionFailedf("sql stats resetter not set")
 				}
 				ctx := evalCtx.Ctx()
-				if err := evalCtx.SQLStatsResetter.ResetClusterSQLStats(ctx); err != nil {
+				if err := evalCtx.SQLStatsController.ResetClusterSQLStats(ctx); err != nil {
 					return nil, err
 				}
 				return tree.MakeDBool(true), nil

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3418,10 +3418,10 @@ var _ base.ModuleTestingKnobs = &EvalContextTestingKnobs{}
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.
 func (*EvalContextTestingKnobs) ModuleTestingKnobs() {}
 
-// SQLStatsResetter is an interface embedded in EvalCtx which can be used by
+// SQLStatsController is an interface embedded in EvalCtx which can be used by
 // the builtins to reset SQL stats in the cluster. This interface is introduced
 // to avoid circular dependency.
-type SQLStatsResetter interface {
+type SQLStatsController interface {
 	ResetClusterSQLStats(ctx context.Context) error
 }
 
@@ -3559,7 +3559,7 @@ type EvalContext struct {
 
 	SQLLivenessReader sqlliveness.Reader
 
-	SQLStatsResetter SQLStatsResetter
+	SQLStatsController SQLStatsController
 
 	// CompactEngineSpan is used to force compaction of a span in a store.
 	CompactEngineSpan CompactEngineSpanFunc

--- a/pkg/sql/sqlstats/sslocal/BUILD.bazel
+++ b/pkg/sql/sqlstats/sslocal/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "sslocal",
     srcs = [
         "sql_stats.go",
+        "sql_stats_controller.go",
         "sslocal_provider.go",
         "sslocal_sink.go",
         "sslocal_stats_collector.go",
@@ -12,8 +13,10 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/roachpb:with-mocks",
+        "//pkg/server/serverpb",
         "//pkg/settings",
         "//pkg/settings/cluster",
+        "//pkg/sql/sem/tree",
         "//pkg/sql/sessionphase",
         "//pkg/sql/sqlstats",
         "//pkg/sql/sqlstats/ssmemstorage",

--- a/pkg/sql/sqlstats/sslocal/sql_stats_controller.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats_controller.go
@@ -1,0 +1,58 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sslocal
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+)
+
+// Controller implements the SQL Stats subsystem control plane. This exposes
+// administrative interfaces that can be consumed by other parts of the database
+// (e.g. status server, builtins) to control the behavior of the SQL Stats
+// subsystem.
+type Controller struct {
+	sqlStats     *SQLStats
+	statusServer serverpb.SQLStatusServer
+}
+
+var _ tree.SQLStatsController = &Controller{}
+
+// NewController returns a new instance of sqlstats.Controller.
+func NewController(sqlStats *SQLStats, status serverpb.SQLStatusServer) *Controller {
+	return &Controller{
+		sqlStats:     sqlStats,
+		statusServer: status,
+	}
+}
+
+// ResetClusterSQLStats implements the tree.SQLStatsController interface.
+func (s *Controller) ResetClusterSQLStats(ctx context.Context) error {
+	req := &serverpb.ResetSQLStatsRequest{}
+	_, err := s.statusServer.ResetSQLStats(ctx, req)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// ResetLocalSQLStats resets the node-local sql stats.
+func (s *Controller) ResetLocalSQLStats(ctx context.Context) {
+	err := s.sqlStats.Reset(ctx)
+	if err != nil {
+		if log.V(1) {
+			log.Warningf(ctx, "reported SQL stats memory limit has been exceeded, some fingerprints stats are discarded: %s", err)
+		}
+	}
+}

--- a/pkg/sql/sqlstats/sslocal/sslocal_provider.go
+++ b/pkg/sql/sqlstats/sslocal/sslocal_provider.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
@@ -45,6 +46,12 @@ func New(
 }
 
 var _ sqlstats.Provider = &SQLStats{}
+
+// GetController returns a sqlstats.Controller responsible for the current
+// SQLStats.
+func (s *SQLStats) GetController(server serverpb.SQLStatusServer) *Controller {
+	return NewController(s, server)
+}
 
 // Start implements sqlstats.Provider interface.
 func (s *SQLStats) Start(ctx context.Context, stopper *stop.Stopper) {

--- a/pkg/sql/sqltestutils/telemetry.go
+++ b/pkg/sql/sqltestutils/telemetry.go
@@ -246,7 +246,7 @@ func (tt *telemetryTest) RunTest(
 
 	case "sql-stats":
 		// Report diagnostics once to reset the stats.
-		sqlServer.ResetSQLStats(ctx)
+		sqlServer.GetSQLStatsController().ResetLocalSQLStats(ctx)
 		reportDiags(ctx)
 
 		_, err := db.Exec(td.Input)
@@ -254,7 +254,7 @@ func (tt *telemetryTest) RunTest(
 		if err != nil {
 			fmt.Fprintf(&buf, "error: %v\n", err)
 		}
-		sqlServer.ResetSQLStats(ctx)
+		sqlServer.GetSQLStatsController().ResetLocalSQLStats(ctx)
 		reportDiags(ctx)
 		last := tt.diagSrv.LastRequestData()
 		buf.WriteString(formatSQLStats(last.SqlStats))


### PR DESCRIPTION
sql,server: refactor SQL Stats control to sqlstats package

Previsouly, the administrative actions on SQL Stats subsystem
(e.g. reset sql stats) is directly implements on the sql.Server.
The implication of this is that various parts of the system
needs to maintain a reference of sql.Server one way or another.
As SQL Stats subsystem grows in complexity, it's no longer
feasible to piggyback off sql.Server for implementing the
control logic.
This commit refactors those logics into a new sslocal.Controller
struct. This struct will be reponsible for all the control actions.

Release note: None