### PR TITLE
sql: prevent users from being dropped if they have default privileges defined for

### DIFF
--- a/pkg/sql/catalog/defaultprivilegedesc/default_privilege.go
+++ b/pkg/sql/catalog/defaultprivilegedesc/default_privilege.go
@@ -93,6 +93,20 @@ func (d *Mutable) RevokeDefaultPrivileges(
 
 		defaultPrivilegesPerObject[targetObject] = defaultPrivileges
 	}
+
+	// If ForAllRoles was specified, we do not have to remove any users.
+	if role.ForAllRoles {
+		return
+	}
+	// Check if there are any default privileges remaining on the descriptor.
+	// If empty we will remove the map entry.
+	for _, defaultPrivs := range defaultPrivilegesPerObject {
+		if len(defaultPrivs.Users) != 0 {
+			return
+		}
+	}
+	// There no entries remaining, remove the entry for the role.
+	d.defaultPrivilegeDescriptor.RemoveUser(role)
 }
 
 // CreatePrivilegesFromDefaultPrivileges implements the

--- a/pkg/sql/catalog/descpb/default_privilege.go
+++ b/pkg/sql/catalog/descpb/default_privilege.go
@@ -109,6 +109,16 @@ func (p *DefaultPrivilegeDescriptor) FindOrCreateUser(
 	return &p.DefaultPrivilegesPerRole[idx]
 }
 
+// RemoveUser looks for a given user in the list and removes it if present.
+func (p *DefaultPrivilegeDescriptor) RemoveUser(role DefaultPrivilegesRole) {
+	idx := p.FindUserIndex(role)
+	if idx == -1 {
+		// Not found.
+		return
+	}
+	p.DefaultPrivilegesPerRole = append(p.DefaultPrivilegesPerRole[:idx], p.DefaultPrivilegesPerRole[idx+1:]...)
+}
+
 // Validate returns an assertion error if the default privilege descriptor
 // is invalid.
 func (p *DefaultPrivilegeDescriptor) Validate() error {

--- a/pkg/sql/drop_role.go
+++ b/pkg/sql/drop_role.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/roleoption"
@@ -63,6 +64,22 @@ func (p *planner) DropRoleNode(
 	}, nil
 }
 
+type objectType string
+
+const (
+	database         objectType = "database"
+	table            objectType = "table"
+	schema           objectType = "schema"
+	typeObject       objectType = "type"
+	defaultPrivilege objectType = "default_privilege"
+)
+
+type objectAndType struct {
+	ObjectType   objectType
+	ObjectName   string
+	ErrorMessage error
+}
+
 func (n *DropRoleNode) startExec(params runParams) error {
 	var opName string
 	if n.isRole {
@@ -80,10 +97,6 @@ func (n *DropRoleNode) startExec(params runParams) error {
 
 	// Now check whether the user still has permission or ownership on any
 	// object in the database.
-	type objectAndType struct {
-		ObjectType string
-		ObjectName string
-	}
 
 	// userNames maps users to the objects they own
 	userNames := make(map[security.SQLUsername][]objectAndType)
@@ -118,8 +131,8 @@ func (n *DropRoleNode) startExec(params runParams) error {
 		}
 	}
 
-	f := tree.NewFmtCtx(tree.FmtSimple)
-	defer f.Close()
+	privilegeObjectFormatter := tree.NewFmtCtx(tree.FmtSimple)
+	defer privilegeObjectFormatter.Close()
 
 	// First check all the databases.
 	if err := forEachDatabaseDesc(params.ctx, params.p, nil /*nil prefix = all databases*/, true, /* requiresPrivileges */
@@ -128,20 +141,20 @@ func (n *DropRoleNode) startExec(params runParams) error {
 				userNames[db.GetPrivileges().Owner()] = append(
 					userNames[db.GetPrivileges().Owner()],
 					objectAndType{
-						ObjectType: "database",
+						ObjectType: database,
 						ObjectName: db.GetName(),
 					})
 			}
 			for _, u := range db.GetPrivileges().Users {
 				if _, ok := userNames[u.User()]; ok {
-					if f.Len() > 0 {
-						f.WriteString(", ")
+					if privilegeObjectFormatter.Len() > 0 {
+						privilegeObjectFormatter.WriteString(", ")
 					}
-					f.FormatName(db.GetName())
+					privilegeObjectFormatter.FormatName(db.GetName())
 					break
 				}
 			}
-			return nil
+			return accumulateDependentDefaultPrivileges(db, userNames)
 		}); err != nil {
 		return err
 	}
@@ -160,31 +173,31 @@ func (n *DropRoleNode) startExec(params runParams) error {
 	lCtx := newInternalLookupCtx(params.ctx, descs, nil /*prefix - we want all descriptors */, nil /* fallback */)
 	// privileges are added.
 	for _, tbID := range lCtx.tbIDs {
-		table := lCtx.tbDescs[tbID]
-		if !descriptorIsVisible(table, true /*allowAdding*/) {
+		tableDescriptor := lCtx.tbDescs[tbID]
+		if !descriptorIsVisible(tableDescriptor, true /*allowAdding*/) {
 			continue
 		}
-		if _, ok := userNames[table.GetPrivileges().Owner()]; ok {
-			tn, err := getTableNameFromTableDescriptor(lCtx, table, "")
+		if _, ok := userNames[tableDescriptor.GetPrivileges().Owner()]; ok {
+			tn, err := getTableNameFromTableDescriptor(lCtx, tableDescriptor, "")
 			if err != nil {
 				return err
 			}
-			userNames[table.GetPrivileges().Owner()] = append(
-				userNames[table.GetPrivileges().Owner()],
+			userNames[tableDescriptor.GetPrivileges().Owner()] = append(
+				userNames[tableDescriptor.GetPrivileges().Owner()],
 				objectAndType{
-					ObjectType: "table",
+					ObjectType: table,
 					ObjectName: tn.String(),
 				})
 		}
-		for _, u := range table.GetPrivileges().Users {
+		for _, u := range tableDescriptor.GetPrivileges().Users {
 			if _, ok := userNames[u.User()]; ok {
-				if f.Len() > 0 {
-					f.WriteString(", ")
+				if privilegeObjectFormatter.Len() > 0 {
+					privilegeObjectFormatter.WriteString(", ")
 				}
-				parentName := lCtx.getDatabaseName(table)
-				schemaName := lCtx.getSchemaName(table)
-				tn := tree.MakeTableNameWithSchema(tree.Name(parentName), tree.Name(schemaName), tree.Name(table.GetName()))
-				f.FormatNode(&tn)
+				parentName := lCtx.getDatabaseName(tableDescriptor)
+				schemaName := lCtx.getSchemaName(tableDescriptor)
+				tn := tree.MakeTableNameWithSchema(tree.Name(parentName), tree.Name(schemaName), tree.Name(tableDescriptor.GetName()))
+				privilegeObjectFormatter.FormatNode(&tn)
 				break
 			}
 		}
@@ -200,7 +213,7 @@ func (n *DropRoleNode) startExec(params runParams) error {
 			userNames[schemaDesc.GetPrivileges().Owner()] = append(
 				userNames[schemaDesc.GetPrivileges().Owner()],
 				objectAndType{
-					ObjectType: "schema",
+					ObjectType: schema,
 					ObjectName: schemaDesc.GetName(),
 				})
 		}
@@ -217,14 +230,14 @@ func (n *DropRoleNode) startExec(params runParams) error {
 			userNames[typDesc.GetPrivileges().Owner()] = append(
 				userNames[typDesc.GetPrivileges().Owner()],
 				objectAndType{
-					ObjectType: "type",
+					ObjectType: typeObject,
 					ObjectName: tn.String(),
 				})
 		}
 	}
 
 	// Was there any object depending on that user?
-	if f.Len() > 0 {
+	if privilegeObjectFormatter.Len() > 0 {
 		fnl := tree.NewFmtCtx(tree.FmtSimple)
 		defer fnl.Close()
 		for i, name := range names {
@@ -236,24 +249,40 @@ func (n *DropRoleNode) startExec(params runParams) error {
 		return pgerror.Newf(pgcode.DependentObjectsStillExist,
 			"cannot drop role%s/user%s %s: grants still exist on %s",
 			util.Pluralize(int64(len(names))), util.Pluralize(int64(len(names))),
-			fnl.String(), f.String(),
+			fnl.String(), privilegeObjectFormatter.String(),
 		)
 	}
 
+	hasDependentDefaultPrivilege := false
 	for i := range names {
 		// Name already normalized above.
 		name := security.MakeSQLUsernameFromPreNormalizedString(names[i])
 		// Did the user own any objects?
-		ownedObjects := userNames[name]
-		if len(ownedObjects) > 0 {
+		dependentObjects := userNames[name]
+		if len(dependentObjects) > 0 {
 			objectsMsg := tree.NewFmtCtx(tree.FmtSimple)
-			for _, obj := range ownedObjects {
-				objectsMsg.WriteString(fmt.Sprintf("\nowner of %s %s", obj.ObjectType, obj.ObjectName))
+			for _, obj := range dependentObjects {
+				switch obj.ObjectType {
+				case database, table, schema, typeObject:
+					objectsMsg.WriteString(fmt.Sprintf("\nowner of %s %s", obj.ObjectType, obj.ObjectName))
+				case defaultPrivilege:
+					hasDependentDefaultPrivilege = true
+					objectsMsg.WriteString(fmt.Sprintf("\n%s", obj.ErrorMessage))
+				}
 			}
 			objects := objectsMsg.CloseAndGetString()
-			return pgerror.Newf(pgcode.DependentObjectsStillExist,
+			err := pgerror.Newf(pgcode.DependentObjectsStillExist,
 				"role %s cannot be dropped because some objects depend on it%s",
 				name, objects)
+			if hasDependentDefaultPrivilege {
+				err = errors.WithHint(err,
+					"use SHOW DEFAULT PRIVILEGES FOR ROLE to find existing default privileges"+
+						" and execute ALTER DEFAULT PRIVILEGES {FOR ROLE ... / FOR ALL ROLES} "+
+						"REVOKE ... ON ... FROM ... to remove them"+
+						"\nsee: SHOW DEFAULT PRIVILEGES and ALTER DEFAULT PRIVILEGES",
+				)
+			}
+			return err
 		}
 	}
 
@@ -394,3 +423,72 @@ func (*DropRoleNode) Values() tree.Datums { return tree.Datums{} }
 
 // Close implements the planNode interface.
 func (*DropRoleNode) Close(context.Context) {}
+
+// accumulateDependentDefaultPrivileges checks for any default privileges
+// that the users in userNames have and append them to the objectAndType array.
+func accumulateDependentDefaultPrivileges(
+	db catalog.DatabaseDescriptor, userNames map[security.SQLUsername][]objectAndType,
+) error {
+	addDependentPrivileges := func(object tree.AlterDefaultPrivilegesTargetObject, defaultPrivs descpb.PrivilegeDescriptor, role descpb.DefaultPrivilegesRole) {
+		var objectType string
+		switch object {
+		case tree.Tables:
+			objectType = "relations"
+		case tree.Sequences:
+			objectType = "sequences"
+		case tree.Types:
+			objectType = "types"
+		case tree.Schemas:
+			objectType = "schemas"
+		}
+
+		for _, privs := range defaultPrivs.Users {
+			if !role.ForAllRoles {
+				if _, ok := userNames[role.Role]; ok {
+					userNames[role.Role] = append(userNames[role.Role],
+						objectAndType{
+							ObjectType: defaultPrivilege,
+							ErrorMessage: errors.Newf(
+								"owner of default privileges on new %s belonging to role %s",
+								objectType, role.Role,
+							),
+						})
+				}
+			}
+			grantee := privs.User()
+			if _, ok := userNames[grantee]; ok {
+				var err error
+				if role.ForAllRoles {
+					err = errors.Newf(
+						"privileges for default privileges on new %s for all roles",
+						objectType,
+					)
+				} else {
+					err = errors.Newf(
+						"privileges for default privileges on new %s belonging to role %s",
+						objectType, role.Role,
+					)
+				}
+				userNames[grantee] = append(userNames[grantee],
+					objectAndType{
+						ObjectType:   defaultPrivilege,
+						ErrorMessage: err,
+					})
+			}
+		}
+	}
+	// No error is returned.
+	return db.GetDefaultPrivilegeDescriptor().ForEachDefaultPrivilegeForRole(func(
+		defaultPrivilegesForRole descpb.DefaultPrivilegesForRole) error {
+		role := descpb.DefaultPrivilegesRole{}
+		if defaultPrivilegesForRole.GetForAllRoles() {
+			role.ForAllRoles = true
+		} else {
+			role.Role = defaultPrivilegesForRole.GetUserProto().Decode()
+		}
+		for object, defaultPrivs := range defaultPrivilegesForRole.DefaultPrivilegesPerObject {
+			addDependentPrivileges(object, defaultPrivs, role)
+		}
+		return nil
+	})
+}

--- a/pkg/sql/logictest/testdata/logic_test/drop_role_with_default_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/drop_role_with_default_privileges
@@ -1,0 +1,85 @@
+statement ok
+CREATE USER test1;
+CREATE USER test2;
+GRANT test1 TO ROOT;
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE test1 GRANT SELECT ON TABLES TO test2;
+
+statement error pq: role test1 cannot be dropped because some objects depend on it\nowner of default privileges on new relations belonging to role test1
+DROP ROLE test1
+
+statement error pq: role test2 cannot be dropped because some objects depend on it\nprivileges for default privileges on new relations belonging to role test1
+DROP ROLE test2;
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE test1 REVOKE SELECT ON TABLES FROM test2;
+ALTER DEFAULT PRIVILEGES FOR ROLE test1 GRANT USAGE ON SCHEMAS TO test2;
+
+statement error pq: role test1 cannot be dropped because some objects depend on it\nowner of default privileges on new schemas belonging to role test1
+DROP ROLE test1
+
+statement error pq: role test2 cannot be dropped because some objects depend on it\nprivileges for default privileges on new schemas belonging to role test1
+DROP ROLE test2;
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE test1 REVOKE USAGE ON SCHEMAS FROM test2;
+ALTER DEFAULT PRIVILEGES FOR ROLE test1 GRANT USAGE ON TYPES TO test2;
+
+statement error pq: role test1 cannot be dropped because some objects depend on it\nowner of default privileges on new types belonging to role test1
+DROP ROLE test1
+
+statement error pq: role test2 cannot be dropped because some objects depend on it\nprivileges for default privileges on new types belonging to role test1
+DROP ROLE test2;
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE test1 REVOKE USAGE ON TYPES FROM test2;
+ALTER DEFAULT PRIVILEGES FOR ROLE test1 GRANT SELECT ON SEQUENCES TO test2;
+
+statement error pq: role test1 cannot be dropped because some objects depend on it\nowner of default privileges on new sequences belonging to role test1
+DROP ROLE test1
+
+statement error pq: role test2 cannot be dropped because some objects depend on it\nprivileges for default privileges on new sequences belonging to role test1
+DROP ROLE test2;
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE test1 REVOKE SELECT ON TABLES FROM test2;
+ALTER DEFAULT PRIVILEGES FOR ROLE test1 REVOKE USAGE ON SCHEMAS FROM test2;
+ALTER DEFAULT PRIVILEGES FOR ROLE test1 REVOKE USAGE ON TYPES FROM test2;
+ALTER DEFAULT PRIVILEGES FOR ROLE test1 REVOKE SELECT ON SEQUENCES FROM test2;
+
+statement ok
+DROP ROLE test1;
+
+statement ok
+DROP ROLE test2;
+
+statement ok
+CREATE USER test2
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ALL ROLES GRANT SELECT ON TABLES TO test2
+
+statement error pq: role test2 cannot be dropped because some objects depend on it\nprivileges for default privileges on new relations for all roles
+DROP ROLE test2;
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ALL ROLES REVOKE SELECT ON TABLES FROM test2;
+ALTER DEFAULT PRIVILEGES FOR ALL ROLES GRANT USAGE ON SCHEMAS TO test2;
+
+statement error pq: role test2 cannot be dropped because some objects depend on it\nprivileges for default privileges on new schemas for all roles
+DROP ROLE test2;
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ALL ROLES REVOKE USAGE ON SCHEMAS FROM test2;
+ALTER DEFAULT PRIVILEGES FOR ALL ROLES GRANT USAGE ON TYPES TO test2;
+
+statement error pq: role test2 cannot be dropped because some objects depend on it\nprivileges for default privileges on new types for all roles
+DROP ROLE test2
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ALL ROLES REVOKE USAGE ON TYPES FROM test2;
+ALTER DEFAULT PRIVILEGES FOR ALL ROLES GRANT SELECT ON SEQUENCES TO test2;
+
+statement error pq: role test2 cannot be dropped because some objects depend on it\nprivileges for default privileges on new sequences for all roles
+DROP ROLE test2


### PR DESCRIPTION
Release note (sql change): If a user has a default privilege defined for, they cannot
be dropped until the default privilege is removed.

Example:
ALTER DEFAULT PRIVILEGES FOR ROLE test1 GRANT SELECT ON TABLES TO test2;

Neither test1 or test2 can be dropped until performing
ALTER DEFAULT PRIVILEGES FOR ROLE test1 REVOKE SELECT ON TABLES FROM test2;

Trying to drop test1 will error with:
role test1 cannot be dropped because some objects depend on it
owner of default privileges on new relations belonging to role test1

Trying to drop test2 will error with:
role test2 cannot be dropped because some objects depend on it
privileges for default privileges on new relations belonging to role test1

fixes #67880