### PR TITLE
sql: add crdb_internal.default_privileges table

### DIFF
--- a/pkg/sql/catalog/catconstants/constants.go
+++ b/pkg/sql/catalog/catconstants/constants.go
@@ -90,6 +90,7 @@ const (
 	CrdbInternalLostTableDescriptors
 	CrdbInternalClusterInflightTracesTable
 	CrdbInternalRegionsTable
+	CrdbInternalDefaultPrivilegesTable
 	InformationSchemaID
 	InformationSchemaAdministrableRoleAuthorizationsID
 	InformationSchemaApplicableRolesID

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -143,6 +143,7 @@ var crdbInternal = virtualSchema{
 		catconstants.CrdbInternalLostTableDescriptors:             crdbLostTableDescriptors,
 		catconstants.CrdbInternalClusterInflightTracesTable:       crdbInternalClusterInflightTracesTable,
 		catconstants.CrdbInternalRegionsTable:                     crdbInternalRegionsTable,
+		catconstants.CrdbInternalDefaultPrivilegesTable:           crdbInternalDefaultPrivilegesTable,
 	},
 	validWithNoDatabaseContext: true,
 }
@@ -4856,6 +4857,49 @@ CREATE TABLE crdb_internal.lost_descriptors_with_data (
 		if err != nil {
 			return err
 		}
+		return nil
+	},
+}
+
+var crdbInternalDefaultPrivilegesTable = virtualSchemaTable{
+	comment: `virtual table with default privileges`,
+	schema: `
+CREATE TABLE crdb_internal.default_privileges (
+	database_name   STRING NOT NULL,
+	schema_name     STRING,
+	role            STRING NOT NULL,
+	object_type     STRING NOT NULL,
+	grantee         STRING NOT NULL,
+	privilege_type  STRING NOT NULL
+);`,
+	populate: func(ctx context.Context, p *planner, dbContext catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
+		return forEachDatabaseDesc(ctx, p, nil /* all databases */, true, /* requiresPrivileges */
+			func(descriptor catalog.DatabaseDescriptor) error {
+				if descriptor.GetDefaultPrivileges() == nil {
+					return nil
+				}
+				for _, defaultPrivs := range descriptor.GetDefaultPrivileges().DefaultPrivileges {
+					for objectType, privs := range defaultPrivs.DefaultPrivilegesPerObject {
+						privilegeObjectType := targetObjectToPrivilegeObject[objectType]
+						for _, userPrivs := range privs.Users {
+							privList := privilege.ListFromBitField(userPrivs.Privileges, privilegeObjectType)
+							for _, priv := range privList {
+								if err := addRow(
+									tree.NewDString(descriptor.GetName()),
+									tree.DNull, /* schema is currently always nil. See: #67376 */
+									tree.NewDString(defaultPrivs.UserProto.Decode().Normalized()),
+									tree.NewDString(objectType.String()),
+									tree.NewDString(userPrivs.User().Normalized()),
+									tree.NewDString(priv.String()),
+								); err != nil {
+									return err
+								}
+							}
+						}
+					}
+				}
+				return nil
+			})
 		return nil
 	},
 }

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal_default_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal_default_privileges
@@ -1,0 +1,164 @@
+statement ok
+ALTER DEFAULT PRIVILEGES GRANT SELECT ON TABLES TO PUBLIC;
+ALTER DEFAULT PRIVILEGES GRANT USAGE ON TYPES TO PUBLIC;
+ALTER DEFAULT PRIVILEGES GRANT USAGE ON SCHEMAS TO PUBLIC;
+ALTER DEFAULT PRIVILEGES GRANT SELECT ON SEQUENCES TO PUBLIC;
+
+query TTTTTT colnames,rowsort
+SELECT * FROM crdb_internal.default_privileges
+----
+database_name  schema_name  role  object_type  grantee  privilege_type
+test           NULL         root  sequences    public   SELECT
+test           NULL         root  types        public   USAGE
+test           NULL         root  schemas      public   USAGE
+test           NULL         root  tables       public   SELECT
+
+statement ok
+CREATE USER foo
+
+statement ok
+CREATE USER bar
+
+statement ok
+ALTER DEFAULT PRIVILEGES GRANT ALL ON TABLES TO foo, bar;
+ALTER DEFAULT PRIVILEGES GRANT ALL ON TYPES TO foo, bar;
+ALTER DEFAULT PRIVILEGES GRANT ALL ON SCHEMAS TO foo, bar;
+ALTER DEFAULT PRIVILEGES GRANT ALL ON SEQUENCES TO foo, bar;
+
+query TTTTTT colnames,rowsort
+SELECT * FROM crdb_internal.default_privileges
+----
+database_name  schema_name  role  object_type  grantee  privilege_type
+test           NULL         root  sequences    bar      ALL
+test           NULL         root  sequences    foo      ALL
+test           NULL         root  sequences    public   SELECT
+test           NULL         root  types        bar      ALL
+test           NULL         root  types        foo      ALL
+test           NULL         root  types        public   USAGE
+test           NULL         root  schemas      bar      ALL
+test           NULL         root  schemas      foo      ALL
+test           NULL         root  schemas      public   USAGE
+test           NULL         root  tables       bar      ALL
+test           NULL         root  tables       foo      ALL
+test           NULL         root  tables       public   SELECT
+
+statement ok
+GRANT foo, bar TO root;
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar GRANT ALL ON TABLES TO foo, bar;
+ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar GRANT ALL ON TYPES TO foo, bar;
+ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar GRANT ALL ON SCHEMAS TO foo, bar;
+ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar GRANT ALL ON SEQUENCES TO foo, bar;
+
+query TTTTTT colnames,rowsort
+SELECT * FROM crdb_internal.default_privileges
+----
+database_name  schema_name  role  object_type  grantee  privilege_type
+test           NULL         bar   schemas      bar      ALL
+test           NULL         bar   schemas      foo      ALL
+test           NULL         bar   tables       bar      ALL
+test           NULL         bar   tables       foo      ALL
+test           NULL         bar   sequences    bar      ALL
+test           NULL         bar   sequences    foo      ALL
+test           NULL         bar   types        bar      ALL
+test           NULL         bar   types        foo      ALL
+test           NULL         foo   sequences    bar      ALL
+test           NULL         foo   sequences    foo      ALL
+test           NULL         foo   types        bar      ALL
+test           NULL         foo   types        foo      ALL
+test           NULL         foo   schemas      bar      ALL
+test           NULL         foo   schemas      foo      ALL
+test           NULL         foo   tables       bar      ALL
+test           NULL         foo   tables       foo      ALL
+test           NULL         root  tables       bar      ALL
+test           NULL         root  tables       foo      ALL
+test           NULL         root  tables       public   SELECT
+test           NULL         root  sequences    bar      ALL
+test           NULL         root  sequences    foo      ALL
+test           NULL         root  sequences    public   SELECT
+test           NULL         root  types        bar      ALL
+test           NULL         root  types        foo      ALL
+test           NULL         root  types        public   USAGE
+test           NULL         root  schemas      bar      ALL
+test           NULL         root  schemas      foo      ALL
+test           NULL         root  schemas      public   USAGE
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar REVOKE ALL ON TABLES FROM foo, bar;
+ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar REVOKE ALL ON TYPES FROM foo, bar;
+ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar REVOKE ALL ON SCHEMAS FROM foo, bar;
+ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar REVOKE ALL ON SEQUENCES FROM foo, bar;
+
+query TTTTTT colnames,rowsort
+SELECT * FROM crdb_internal.default_privileges
+----
+database_name  schema_name  role  object_type  grantee  privilege_type
+test           NULL         root  schemas      bar      ALL
+test           NULL         root  schemas      foo      ALL
+test           NULL         root  schemas      public   USAGE
+test           NULL         root  tables       bar      ALL
+test           NULL         root  tables       foo      ALL
+test           NULL         root  tables       public   SELECT
+test           NULL         root  sequences    bar      ALL
+test           NULL         root  sequences    foo      ALL
+test           NULL         root  sequences    public   SELECT
+test           NULL         root  types        bar      ALL
+test           NULL         root  types        foo      ALL
+test           NULL         root  types        public   USAGE
+
+statement ok
+ALTER DEFAULT PRIVILEGES REVOKE SELECT ON TABLES FROM foo, bar, public;
+ALTER DEFAULT PRIVILEGES REVOKE ALL ON TYPES FROM foo, bar, public;
+ALTER DEFAULT PRIVILEGES REVOKE ALL ON SCHEMAS FROM foo, bar, public;
+ALTER DEFAULT PRIVILEGES REVOKE ALL ON SEQUENCES FROM foo, bar, public;
+
+query TTTTTT colnames,rowsort
+SELECT * FROM crdb_internal.default_privileges
+----
+database_name  schema_name  role  object_type  grantee  privilege_type
+test           NULL         root  tables       bar      CREATE
+test           NULL         root  tables       bar      DROP
+test           NULL         root  tables       bar      GRANT
+test           NULL         root  tables       bar      INSERT
+test           NULL         root  tables       bar      DELETE
+test           NULL         root  tables       bar      UPDATE
+test           NULL         root  tables       bar      ZONECONFIG
+test           NULL         root  tables       foo      CREATE
+test           NULL         root  tables       foo      DROP
+test           NULL         root  tables       foo      GRANT
+test           NULL         root  tables       foo      INSERT
+test           NULL         root  tables       foo      DELETE
+test           NULL         root  tables       foo      UPDATE
+test           NULL         root  tables       foo      ZONECONFIG
+
+statement ok
+ALTER DEFAULT PRIVILEGES REVOKE ALL ON TABLES FROM foo, bar, public;
+ALTER DEFAULT PRIVILEGES GRANT GRANT, DROP, ZONECONFIG ON TABLES TO foo;
+
+query TTTTTT colnames,rowsort
+SELECT * FROM crdb_internal.default_privileges
+----
+database_name  schema_name  role  object_type  grantee  privilege_type
+test           NULL         root  tables       foo      DROP
+test           NULL         root  tables       foo      GRANT
+test           NULL         root  tables       foo      ZONECONFIG
+
+# Create a second database.
+statement ok
+CREATE DATABASE test2;
+use test2;
+
+statement ok
+ALTER DEFAULT PRIVILEGES GRANT GRANT, DROP, ZONECONFIG ON TABLES TO foo;
+
+query TTTTTT colnames,rowsort
+SELECT * FROM crdb_internal.default_privileges
+----
+database_name  schema_name  role  object_type  grantee  privilege_type
+test           NULL         root  tables       foo      DROP
+test           NULL         root  tables       foo      GRANT
+test           NULL         root  tables       foo      ZONECONFIG
+test2          NULL         root  tables       foo      DROP
+test2          NULL         root  tables       foo      GRANT
+test2          NULL         root  tables       foo      ZONECONFIG

--- a/pkg/sql/sem/tree/alter_default_privileges.go
+++ b/pkg/sql/sem/tree/alter_default_privileges.go
@@ -10,7 +10,11 @@
 
 package tree
 
-import "github.com/cockroachdb/cockroach/pkg/sql/privilege"
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
+)
 
 // AlterDefaultPrivileges represents an ALTER DEFAULT PRIVILEGES statement.
 type AlterDefaultPrivileges struct {
@@ -64,6 +68,21 @@ const (
 	Types     AlterDefaultPrivilegesTargetObject = 3
 	Schemas   AlterDefaultPrivilegesTargetObject = 4
 )
+
+func (t AlterDefaultPrivilegesTargetObject) String() string {
+	switch t {
+	case Tables:
+		return "tables"
+	case Sequences:
+		return "sequences"
+	case Types:
+		return "types"
+	case Schemas:
+		return "schemas"
+	default:
+		panic(fmt.Sprintf("unknown AlterDefaultPrivilegesTargetObject value: %d", t))
+	}
+}
 
 // AbbreviatedGrant represents an the GRANT part of an
 // ALTER DEFAULT PRIVILEGES statement.


### PR DESCRIPTION
Useful for getting a human readable way of examining
default privileges.

Will be used to implement SHOW DEFAULT PRIVILEGES

Release note: None