### PR TITLE
release-21.1: kvserver: fix bug causing stuck closed timestamps

### DIFF
--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/docs"
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/intentresolver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
@@ -27,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -661,38 +663,54 @@ func (r *Replica) handleClosedTimestampUpdateRaftMuLocked(ctx context.Context) {
 }
 
 // ensureClosedTimestampStarted does its best to make sure that this node is
-// receiving closed timestamp updated for this replica's range. Note that this
+// receiving closed timestamp updates for this replica's range. Note that this
 // forces a valid lease to exist on the range and so can be reasonably expensive
 // if there is not already a valid lease.
 func (r *Replica) ensureClosedTimestampStarted(ctx context.Context) *roachpb.Error {
-	// Make sure there's a leaseholder. If there's no leaseholder, there's no
+	// Make sure there's a valid lease. If there's no lease, nobody's sending
 	// closed timestamp updates.
-	var leaseholderNodeID roachpb.NodeID
-	_, err := r.redirectOnOrAcquireLease(ctx)
-	if err == nil {
-		if !r.store.cfg.Settings.Version.IsActive(ctx, clusterversion.ClosedTimestampsRaftTransport) {
-			// We have the lease. Request is essentially a wrapper for calling EmitMLAI
-			// on a remote node, so cut out the middleman.
-			r.EmitMLAI()
+	lease := r.CurrentLeaseStatus(ctx)
+
+	if !lease.IsValid() {
+		// Send a cheap request that needs a leaseholder, in order to ensure a
+		// lease. We don't care about the request's result, only its routing. We're
+		// employing higher-level machinery here (the DistSender); there's no better
+		// way to ensure that someone (potentially another replica) takes a lease.
+		// In particular, r.redirectOnOrAcquireLease() doesn't work because, if the
+		// current lease is invalid and the current replica is not a leader, the
+		// current replica will not take a lease.
+		log.VEventf(ctx, 2, "ensuring lease for rangefeed range. current lease invalid: %s", lease.Lease)
+		err := contextutil.RunWithTimeout(ctx, "read forcing lease acquisition", 5*time.Second,
+			func(ctx context.Context) error {
+				var b kv.Batch
+				liReq := &roachpb.LeaseInfoRequest{}
+				liReq.Key = r.Desc().StartKey.AsRawKey()
+				b.AddRawRequest(liReq)
+				return r.store.DB().Run(ctx, &b)
+			})
+		if err != nil {
+			return roachpb.NewError(err)
 		}
-		return nil
-	} else if lErr, ok := err.GetDetail().(*roachpb.NotLeaseHolderError); ok {
-		if lErr.LeaseHolder == nil {
-			// It's possible for redirectOnOrAcquireLease to return
-			// NotLeaseHolderErrors with LeaseHolder unset, but these should be
-			// transient conditions. If this method is being called by RangeFeed to
-			// nudge a stuck closedts, then essentially all we can do here is nothing
-			// and assume that redirectOnOrAcquireLease will do something different
-			// the next time it's called.
-			return nil
-		}
-		leaseholderNodeID = lErr.LeaseHolder.NodeID
-		// Request fixes any issues where we've missed a closed timestamp update or
-		// where we're not connected to receive them from this node in the first
-		// place.
-		r.store.cfg.ClosedTimestamp.Clients.Request(leaseholderNodeID, r.RangeID)
-		return nil
-	} else {
-		return err
 	}
+
+	if r.store.cfg.Settings.Version.IsActive(ctx, clusterversion.ClosedTimestampsRaftTransport) {
+		// In the "new closed timestamps subsystem", there's nothing more to do.
+		// Once there's a leaseholder, that node will connect to us and inform us of
+		// updates.
+		return nil
+	}
+
+	lease = r.CurrentLeaseStatus(ctx)
+	if lease.OwnedBy(r.StoreID()) {
+		// We have the lease. Request is essentially a wrapper for calling EmitMLAI
+		// on a remote node, so cut out the middleman.
+		r.EmitMLAI()
+		return nil
+	}
+	leaseholderNodeID := lease.Lease.Replica.NodeID
+	// Request fixes any issues where we've missed a closed timestamp update or
+	// where we're not connected to receive them from this node in the first
+	// place.
+	r.store.cfg.ClosedTimestamp.Clients.Request(leaseholderNodeID, r.RangeID)
+	return nil
 }

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -687,12 +687,12 @@ func (r *Replica) ensureClosedTimestampStarted(ctx context.Context) *roachpb.Err
 			return nil
 		}
 		leaseholderNodeID = lErr.LeaseHolder.NodeID
+		// Request fixes any issues where we've missed a closed timestamp update or
+		// where we're not connected to receive them from this node in the first
+		// place.
+		r.store.cfg.ClosedTimestamp.Clients.Request(leaseholderNodeID, r.RangeID)
+		return nil
 	} else {
 		return err
 	}
-	// Request fixes any issues where we've missed a closed timestamp update or
-	// where we're not connected to receive them from this node in the first
-	// place.
-	r.store.cfg.ClosedTimestamp.Clients.Request(leaseholderNodeID, r.RangeID)
-	return nil
 }

--- a/pkg/kv/kvserver/replica_rangefeed_test.go
+++ b/pkg/kv/kvserver/replica_rangefeed_test.go
@@ -13,6 +13,7 @@ package kvserver_test
 import (
 	"context"
 	"reflect"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -22,7 +23,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -980,6 +983,168 @@ func TestReplicaRangefeedNudgeSlowClosedTimestamp(t *testing.T) {
 	waitForCheckpoint(ts2)
 
 	// Make sure the RangeFeed hasn't errored yet.
+	select {
+	case err := <-rangeFeedErrC:
+		t.Fatal(err)
+	default:
+	}
+	// Now cancel it and wait for it to shut down.
+	rangeFeedCancel()
+}
+
+// Test that a rangefeed registration receives checkpoints even if the lease
+// expires at some point. In other words, test that the rangefeed forces the
+// range to maintain a lease (i.e. renew the lease when the old one expires). In
+// particular, this test orchestrates a particularly tricky scenario - the
+// current lease expiring and the replica with the rangefeed registration not
+// being the Raft leader. In this case, the leader replica needs to acquire the
+// lease, and it does so because of a read performed by
+// r.ensureClosedTimestampStarted().
+func TestRangefeedCheckpointsRecoverFromLeaseExpiration(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	var scratchRangeID int64 // accessed atomically
+	// nudgeSeen will be set if a request filter sees the signature of the
+	// rangefeed nudger, as proof that the expected mechanism kicked in.
+	var nudgeSeen bool
+	// At some point, the test will require full control over the requests
+	// evaluating on the scratch range.
+	var rejectExtraneousRequests int64 // accessed atomically
+
+	cargs := aggressiveResolvedTimestampClusterArgs
+	cargs.ReplicationMode = base.ReplicationManual
+	manualClock := hlc.NewHybridManualClock()
+	cargs.ServerArgs = base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			Server: &server.TestingKnobs{
+				ClockSource: manualClock.UnixNano,
+			},
+			Store: &kvserver.StoreTestingKnobs{
+				TestingRequestFilter: func(ctx context.Context, ba roachpb.BatchRequest) *roachpb.Error {
+					// Once reject is set, the test wants full control over the requests
+					// evaluating on the scratch range. On that range, we'll reject
+					// everything that's not triggered by the test because we want to only
+					// allow the rangefeed nudging mechanism to trigger a lease
+					// acquisition (which it does through a LeaseInfoRequests). Allowing
+					// other randos to trigger a lease acquisition would make the test
+					// inconclusive.
+					reject := atomic.LoadInt64(&rejectExtraneousRequests)
+					if reject == 0 {
+						return nil
+					}
+					scratch := atomic.LoadInt64(&scratchRangeID)
+					if roachpb.RangeID(scratch) != ba.RangeID {
+						return nil
+					}
+					if ba.IsSingleLeaseInfoRequest() {
+						nudgeSeen = true
+						return nil
+					}
+					if ba.IsLeaseRequest() && nudgeSeen {
+						return nil
+					}
+					log.Infof(ctx, "test rejecting request: %s", ba)
+					return roachpb.NewErrorf("test injected error")
+				},
+			},
+		},
+	}
+	tci, _, _ := setupClusterForClosedTSTesting(ctx, t, testingTargetDuration,
+		testingCloseFraction, cargs, "cttest", "kv")
+	tc := tci.(*testcluster.TestCluster)
+	defer tc.Stopper().Stop(ctx)
+
+	scratchKey := tc.ScratchRange(t)
+	// Add a replica; we're going to move the lease to it below.
+	desc := tc.AddVotersOrFatal(t, scratchKey, tc.Target(1))
+	atomic.StoreInt64(&scratchRangeID, int64(desc.RangeID))
+
+	sqlDB := sqlutils.MakeSQLRunner(tc.ServerConn(0))
+	sqlDB.Exec(t, `SET CLUSTER SETTING kv.rangefeed.enabled = true`)
+	// Drop the target closedts duration. This was set to testingTargetDuration
+	// above, but this is higher then it needs to be now that cluster and schema
+	// setup is complete.
+	sqlDB.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '10ms'`)
+
+	n1 := tc.Server(0)
+	n2 := tc.Server(1)
+	n2Target := tc.Target(1)
+	ts1 := n1.Clock().Now()
+	rangeFeedCtx, rangeFeedCancel := context.WithCancel(ctx)
+	defer rangeFeedCancel()
+	ds := tc.Server(0).DistSenderI().(*kvcoord.DistSender)
+	rangeFeedCh := make(chan *roachpb.RangeFeedEvent)
+	rangeFeedErrC := make(chan error, 1)
+	go func() {
+		span := roachpb.Span{
+			Key: desc.StartKey.AsRawKey(), EndKey: desc.EndKey.AsRawKey(),
+		}
+		rangeFeedErrC <- ds.RangeFeed(rangeFeedCtx, span, ts1, false /* withDiff */, rangeFeedCh)
+	}()
+
+	// Wait for a checkpoint above ts.
+	waitForCheckpoint := func(ts hlc.Timestamp) {
+		t.Helper()
+		checkpointed := false
+		timeout := time.After(60 * time.Second)
+		for !checkpointed {
+			select {
+			case event := <-rangeFeedCh:
+				if c := event.Checkpoint; c != nil && ts.Less(c.ResolvedTS) {
+					checkpointed = true
+				}
+			case err := <-rangeFeedErrC:
+				t.Fatal(err)
+			case <-timeout:
+				t.Fatal("timed out waiting for checkpoint")
+			}
+		}
+	}
+	// Wait for a RangeFeed checkpoint after the RangeFeed initial scan time (ts1)
+	// to make sure everything is set up. We intentionally don't care about the
+	// spans in the checkpoints, just verifying that something has made it past
+	// the initial scan and is running.
+	waitForCheckpoint(ts1)
+
+	// Move the lease from n1 to n2 in order for the Raft leadership to move with
+	// it.
+	tc.TransferRangeLeaseOrFatal(t, desc, n2Target)
+	testutils.SucceedsSoon(t, func() error {
+		leader := tc.GetRaftLeader(t, desc.StartKey).NodeID()
+		if tc.Target(1).NodeID != leader {
+			return errors.Errorf("leader still on n%d", leader)
+		}
+		return nil
+	})
+
+	// Expire the lease. Given that the Raft leadership is on n2, only n2 will be
+	// eligible to acquire a new lease.
+	log.Infof(ctx, "test expiring lease")
+	nl := n2.NodeLiveness().(*liveness.NodeLiveness)
+	resumeHeartbeats := nl.PauseAllHeartbeatsForTest()
+	n2Liveness, ok := nl.Self()
+	require.True(t, ok)
+	manualClock.Increment(n2Liveness.Expiration.ToTimestamp().Add(1, 0).WallTime - manualClock.UnixNano())
+	atomic.StoreInt64(&rejectExtraneousRequests, 1)
+	// Ask another node to increment n2's liveness record.
+	require.NoError(t, n1.NodeLiveness().(*liveness.NodeLiveness).IncrementEpoch(ctx, n2Liveness))
+	resumeHeartbeats()
+
+	// Wait for another RangeFeed checkpoint after the lease expired.
+	log.Infof(ctx, "test waiting for another checkpoint")
+	ts2 := n1.Clock().Now()
+	waitForCheckpoint(ts2)
+	require.True(t, nudgeSeen)
+
+	// Check that n2 renewed its lease, like the test intended.
+	li, _, err := tc.FindRangeLeaseEx(ctx, desc, &n2Target)
+	require.NoError(t, err)
+	require.True(t, li.Current().OwnedBy(n2.GetFirstStoreID()))
+	require.Equal(t, int64(2), li.Current().Epoch)
+
+	// Make sure the RangeFeed hasn't errored.
 	select {
 	case err := <-rangeFeedErrC:
 		t.Fatal(err)

--- a/pkg/roachpb/batch.go
+++ b/pkg/roachpb/batch.go
@@ -194,6 +194,12 @@ func (ba *BatchRequest) IsSingleTransferLeaseRequest() bool {
 	return ba.isSingleRequestWithMethod(TransferLease)
 }
 
+// IsSingleLeaseInfoRequest returns true iff the batch contains a single
+// request, and that request is a LeaseInfoRequest.
+func (ba *BatchRequest) IsSingleLeaseInfoRequest() bool {
+	return ba.isSingleRequestWithMethod(LeaseInfo)
+}
+
 // IsSinglePushTxnRequest returns true iff the batch contains a single
 // request, and that request is a PushTxn.
 func (ba *BatchRequest) IsSinglePushTxnRequest() bool {


### PR DESCRIPTION
Backport 2/2 commits from #67952.

/cc @cockroachdb/release

---

r.ensureClosedTimestampStarted() was broken when we made non-leader
replicas refuse to acquire leases. This function was relying on a lease
being acquire if there's no valid lease, and in the case where the
leader was elsewhere it wasn't getting what it wanted. As a result,
rangefeeds (which use this method to "nudge" the range into sending
closed timestamp updates) were stuck because closed timestamp updates
were not generated - timestamps are not closed when there's no lease.
Because they weren't getting closed timestamp updates, rangefeeds were
not generating resolved timestamp updates, and so data (from other
ranges) was being endlessly buffered.

The fix is to force a lease acquisition by performing a read on the
respective range.

It's unclear whether this broken before 21.1. With the "old" closed
timestamp code, ensureClosedTimestampStarted() was doing an extra RPC
which perhaps hid the problem - although it's unclear how. We've only
seen the issue on 21.1 though.

Release note (bug fix): A bug causing changefeeds to sometimes get stuck
was fixed.
