### PR TITLE
release-20.2: colfetcher: fix error message for null value in non-nullable column

### DIFF
--- a/pkg/sql/colfetcher/cfetcher.go
+++ b/pkg/sql/colfetcher/cfetcher.go
@@ -1328,11 +1328,11 @@ func (rf *cFetcher) fillNulls() error {
 				} else {
 					indexColValues = append(indexColValues, "?")
 				}
-				return scrub.WrapError(scrub.UnexpectedNullValueError, errors.Errorf(
-					"non-nullable column \"%s:%s\" with no value! Index scanned was %q with the index key columns (%s) and the values (%s)",
-					table.desc.GetName(), table.cols[i].Name, table.index.Name,
-					strings.Join(table.index.ColumnNames, ","), strings.Join(indexColValues, ",")))
 			}
+			return scrub.WrapError(scrub.UnexpectedNullValueError, errors.Errorf(
+				"non-nullable column \"%s:%s\" with no value! Index scanned was %q with the index key columns (%s) and the values (%s)",
+				table.desc.GetName(), table.cols[i].Name, table.index.Name,
+				strings.Join(table.index.ColumnNames, ","), strings.Join(indexColValues, ",")))
 		}
 		rf.machine.colvecs[i].Nulls().SetNull(rf.machine.rowIdx)
 	}


### PR DESCRIPTION
Backport 1/1 commits from #67957.

/cc @cockroachdb/release

---

The exit point from which the error was returned was mistakenly nested
in a loop. This made the error message nonsensical. This patch moves
the return to the correct place.

Release justification: very low-risk change which fixes a broken error
message.

Release note: None
