### PR TITLE
debug: add the statement-bundle recreate <bundledir> command

### DIFF
--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -51,6 +51,7 @@ go_library(
         "start_jemalloc.go",
         "start_unix.go",
         "start_windows.go",
+        "statement_bundle.go",
         "statement_diag.go",
         "swappable_fs.go",
         "testutils.go",

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -272,7 +272,7 @@ func isWorkloadCmd(cmd *cobra.Command) bool {
 
 // isDemoCmd returns true iff cmd is a sub-command of `demo`.
 func isDemoCmd(cmd *cobra.Command) bool {
-	return hasParentCmd(cmd, demoCmd)
+	return hasParentCmd(cmd, demoCmd) || hasParentCmd(cmd, debugStatementBundleCmd)
 }
 
 // hasParentCmd returns true iff cmd is a sub-command of refParent.

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -1427,6 +1427,9 @@ func init() {
 	debugDoctorCmd.AddCommand(doctorExamineCmd, doctorRecreateCmd, doctorExamineFallbackClusterCmd, doctorExamineFallbackZipDirCmd)
 	DebugCmd.AddCommand(debugDoctorCmd)
 
+	debugStatementBundleCmd.AddCommand(statementBundleRecreateCmd)
+	DebugCmd.AddCommand(debugStatementBundleCmd)
+
 	DebugCmd.AddCommand(debugJobTraceFromClusterCmd)
 
 	f := debugSyncBenchCmd.Flags()

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -732,6 +732,7 @@ func init() {
 		doctorExamineClusterCmd,
 		doctorExamineFallbackClusterCmd,
 		doctorRecreateClusterCmd,
+		statementBundleRecreateCmd,
 		lsNodesCmd,
 		statusNodeCmd,
 	}
@@ -793,6 +794,7 @@ func init() {
 			sqlShellCmd,
 			genSettingsListCmd,
 			demoCmd,
+			statementBundleRecreateCmd,
 			debugListFilesCmd,
 			debugJobTraceFromClusterCmd,
 		},

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -120,7 +120,7 @@ var serverCmds = append(StartCmds, mtStartSQLCmd)
 // customLoggingSetupCmds lists the commands that call setupLogging()
 // after other types of configuration.
 var customLoggingSetupCmds = append(
-	serverCmds, debugCheckLogConfigCmd, demoCmd, mtStartSQLProxyCmd, mtTestDirectorySvr,
+	serverCmds, debugCheckLogConfigCmd, demoCmd, mtStartSQLProxyCmd, mtTestDirectorySvr, statementBundleRecreateCmd,
 )
 
 func initBlockProfile() {

--- a/pkg/cli/statement_bundle.go
+++ b/pkg/cli/statement_bundle.go
@@ -1,0 +1,159 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cli
+
+import (
+	"context"
+	"io/fs"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/cli/democluster"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/errors"
+	"github.com/spf13/cobra"
+)
+
+var debugStatementBundleCmd = &cobra.Command{
+	Use:     "statement-bundle [command]",
+	Aliases: []string{"sb"},
+	Short:   "run a cockroach debug statement-bundle tool command",
+	Long: `
+debug statement-bundle is a suite of tools for debugging and manipulating statement
+bundles created with EXPLAIN ANALYZE (DEBUG).
+`,
+}
+
+var statementBundleRecreateCmd = &cobra.Command{
+	Use:   "recreate <stmt bundle zipdir>",
+	Short: "recreate the statement bundle in a demo cluster",
+	Long: `
+Run the recreate tool to populate a demo cluster with the environment, schema,
+and stats in an unzipped statement bundle directory.
+`,
+	Args: cobra.ExactArgs(1),
+}
+
+func init() {
+	statementBundleRecreateCmd.RunE = MaybeDecorateGRPCError(func(cmd *cobra.Command, args []string) error {
+		return runBundleRecreate(cmd, args)
+	})
+}
+
+type statementBundle struct {
+	env       []byte
+	schema    []byte
+	statement []byte
+	stats     [][]byte
+}
+
+func loadStatementBundle(zipdir string) (*statementBundle, error) {
+	ret := &statementBundle{}
+	var err error
+	ret.env, err = ioutil.ReadFile(filepath.Join(zipdir, "env.sql"))
+	if err != nil {
+		return ret, err
+	}
+	ret.schema, err = ioutil.ReadFile(filepath.Join(zipdir, "schema.sql"))
+	if err != nil {
+		return ret, err
+	}
+	ret.statement, err = ioutil.ReadFile(filepath.Join(zipdir, "statement.txt"))
+	if err != nil {
+		return ret, err
+	}
+
+	return ret, filepath.WalkDir(zipdir, func(path string, d fs.DirEntry, _ error) error {
+		if d.IsDir() {
+			return nil
+		}
+		if !strings.HasPrefix(d.Name(), "stats-") {
+			return nil
+		}
+		f, err := ioutil.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		ret.stats = append(ret.stats, f)
+		return nil
+	})
+}
+
+func runBundleRecreate(cmd *cobra.Command, args []string) error {
+	zipdir := args[0]
+	bundle, err := loadStatementBundle(zipdir)
+	if err != nil {
+		return err
+	}
+
+	closeFn, err := sqlCtx.Open(os.Stdin)
+	if err != nil {
+		return err
+	}
+	defer closeFn()
+	ctx := context.Background()
+	c, err := democluster.NewDemoCluster(ctx, &demoCtx,
+		log.Infof,
+		log.Warningf,
+		log.Ops.Shoutf,
+		func(ctx context.Context) (*stop.Stopper, error) {
+			// Override the default server store spec.
+			//
+			// This is needed because the logging setup code peeks into this to
+			// decide how to enable logging.
+			serverCfg.Stores.Specs = nil
+			return setupAndInitializeLoggingAndProfiling(ctx, cmd, false /* isServerCmd */)
+		},
+		getAdminClient,
+		drainAndShutdown,
+	)
+	if err != nil {
+		c.Close(ctx)
+		return err
+	}
+	defer c.Close(ctx)
+
+	initGEOS(ctx)
+
+	if err := c.Start(ctx, runInitialSQL); err != nil {
+		return CheckAndMaybeShout(err)
+	}
+	conn, err := sqlCtx.MakeConn(c.GetConnURL())
+	if err != nil {
+		return err
+	}
+	// Disable autostats collection, which will override the injected stats.
+	if err := conn.Exec(`SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false`, nil); err != nil {
+		return err
+	}
+	var initStmts = [][]byte{bundle.env, bundle.schema}
+	initStmts = append(initStmts, bundle.stats...)
+	for _, a := range initStmts {
+		if err := conn.Exec(string(a), nil); err != nil {
+			return errors.Wrapf(err, "failed to run %s", a)
+		}
+	}
+
+	cliCtx.PrintfUnlessEmbedded(`#
+# Statement bundle %s loaded.
+# Autostats disabled.
+#
+# Statement was:
+#
+# %s
+`, zipdir, bundle.statement)
+
+	sqlCtx.ShellCtx.DemoCluster = c
+	return sqlCtx.Run(conn)
+}


### PR DESCRIPTION
This command loads the environment, schema, and stats from an unzipped
statement bundle into a demo cluster for inspection.

Release note (cli change): add the debug statement-bundle recreate <zipdir>
command, which allows users to load a statement bundle into an in-memory
database for inspection.