### PR TITLE
release-21.1: cluster-ui: update peer dependencies

### DIFF
--- a/pkg/ui/cluster-ui/package.json
+++ b/pkg/ui/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "21.1.2",
+  "version": "21.1.3",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",
@@ -132,13 +132,12 @@
     "webpackbar": "^4.0.0"
   },
   "peerDependencies": {
-    "protobufjs": "6.8.6",
-    "react": "^16.12.0",
-    "react-dom": "^16.12.0",
-    "react-redux": "7.1.3",
-    "react-router-dom": "^5.1.2",
-    "redux": "4.0.5",
-    "redux-saga": "1.1.3"
+    "react": ">=16.12.0",
+    "react-dom": ">=16.12.0",
+    "react-redux": ">=7.1.3",
+    "react-router-dom": ">=5.1.2",
+    "redux": ">=4.0.5",
+    "redux-saga": ">=1.1.3"
   },
   "resolutions": {
     "node-fetch": "~2.6.1",


### PR DESCRIPTION
Backport 1/1 commits from #67722 and #67989.

/cc @cockroachdb/release

Note for reviewers: 
- Blathers [check](https://github.com/cockroachdb/cockroach/pull/67981/checks) is failing because this hasn't been in master for the "14 day baking duration". This in an internal-facing change, so this feels okay to merge before the baking duration.
- All other checks pass.

Release justification: Internal-facing only change.