### PR TITLE
sql: Create a builtin to reset the zone configs of a multi-region table

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -906,6 +906,10 @@ SQL statement omitting multi-region related zone configuration fields.
 If the CONFIGURE ZONE statement can be inferred by the database’s or
 table’s zone configuration this will return NULL.</p>
 </span></td></tr>
+<tr><td><a name="crdb_internal.reset_multi_region_zone_configs_for_table"></a><code>crdb_internal.reset_multi_region_zone_configs_for_table(id: <a href="int.html">int</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Resets the zone configuration for a multi-region table to
+match its original state. No-ops if the given table ID is not a multi-region
+table</p>
+</span></td></tr>
 <tr><td><a name="crdb_internal.validate_multi_region_zone_configs"></a><code>crdb_internal.validate_multi_region_zone_configs() &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Validates all multi-region zone configurations are correctly setup
 for the current database, including all tables, indexes and partitions underneath.
 Returns an error if validation fails. This builtin uses un-leased versions of the

--- a/pkg/ccl/importccl/import_table_creation.go
+++ b/pkg/ccl/importccl/import_table_creation.go
@@ -280,6 +280,14 @@ func (so *importSequenceOperators) ValidateAllMultiRegionZoneConfigsInCurrentDat
 	return errors.WithStack(errSequenceOperators)
 }
 
+// ResetMultiRegionZoneConfigsForTable is part of the tree.EvalDatabase
+// interface.
+func (so *importSequenceOperators) ResetMultiRegionZoneConfigsForTable(
+	_ context.Context, _ int64,
+) error {
+	return errors.WithStack(errSequenceOperators)
+}
+
 // ParseQualifiedTableName implements the tree.EvalDatabase interface.
 func (so *importSequenceOperators) ParseQualifiedTableName(sql string) (*tree.TableName, error) {
 	name, err := parser.ParseTableName(sql)

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
@@ -1345,3 +1345,283 @@ ALTER INDEX tbl7@tbl7_i_idx CONFIGURE ZONE USING num_replicas = COPY FROM PARENT
 
 statement error attempting to modify protected field "num_replicas" of a multi-region zone configuration
 ALTER PARTITION "us-east-1" OF INDEX tbl7@tbl7_i_idx CONFIGURE ZONE USING num_replicas = COPY FROM PARENT
+
+# Validate crdb_internal.reset_multi_region_zone_configs_for_table builtin
+subtest reset_multi_region_zone_configs
+
+statement ok
+CREATE TABLE tbl8 (
+  pk INT PRIMARY KEY,
+  i INT,
+  INDEX(i)
+) LOCALITY REGIONAL BY ROW
+
+query TT
+SHOW ZONE CONFIGURATION FOR PARTITION "us-east-1" of INDEX tbl8@primary
+----
+PARTITION "us-east-1" OF INDEX tbl8@primary  ALTER PARTITION "us-east-1" OF INDEX tbl8@primary CONFIGURE ZONE USING
+                                             range_min_bytes = 134217728,
+                                             range_max_bytes = 536870912,
+                                             gc.ttlseconds = 90000,
+                                             num_replicas = 3,
+                                             num_voters = 3,
+                                             constraints = '{+region=us-east-1: 1}',
+                                             voter_constraints = '[+region=us-east-1]',
+                                             lease_preferences = '[[+region=us-east-1]]'
+
+statement ok
+SET override_multi_region_zone_config = true;
+ALTER PARTITION "us-east-1" OF INDEX tbl8@primary CONFIGURE ZONE DISCARD;
+SET override_multi_region_zone_config = false
+
+query TT
+SHOW ZONE CONFIGURATION FOR PARTITION "us-east-1" of INDEX tbl8@primary
+----
+DATABASE initial_multiregion_db  ALTER DATABASE initial_multiregion_db CONFIGURE ZONE USING
+                                 range_min_bytes = 134217728,
+                                 range_max_bytes = 536870912,
+                                 gc.ttlseconds = 90000,
+                                 num_replicas = 3,
+                                 num_voters = 3,
+                                 constraints = '{+region=us-east-1: 1}',
+                                 voter_constraints = '[+region=us-east-1]',
+                                 lease_preferences = '[[+region=us-east-1]]'
+
+statement error missing zone configuration for partition "us-east-1" of tbl8@"primary"
+SELECT crdb_internal.validate_multi_region_zone_configs()
+
+let $tbl8_id
+select table_id from crdb_internal.tables where name = 'tbl8'
+
+statement ok
+SELECT crdb_internal.crdb_internal.reset_multi_region_zone_configs_for_table($tbl8_id)
+
+query TT
+SHOW ZONE CONFIGURATION FOR PARTITION "us-east-1" of INDEX tbl8@primary
+----
+PARTITION "us-east-1" OF INDEX tbl8@primary  ALTER PARTITION "us-east-1" OF INDEX tbl8@primary CONFIGURE ZONE USING
+                                             range_min_bytes = 134217728,
+                                             range_max_bytes = 536870912,
+                                             gc.ttlseconds = 90000,
+                                             num_replicas = 3,
+                                             num_voters = 3,
+                                             constraints = '{+region=us-east-1: 1}',
+                                             voter_constraints = '[+region=us-east-1]',
+                                             lease_preferences = '[[+region=us-east-1]]'
+
+statement ok
+SELECT crdb_internal.validate_multi_region_zone_configs()
+
+statement ok
+CREATE TABLE tbl9 (
+  pk INT PRIMARY KEY,
+  i INT,
+  INDEX(i)
+) LOCALITY REGIONAL IN PRIMARY REGION
+
+# Set gc.ttlseconds. Since this isn't a multi-region protected field, the reset
+# should no-op.
+statement ok
+ALTER table tbl9 CONFIGURE ZONE USING gc.ttlseconds = 5
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE tbl9
+----
+TABLE tbl9  ALTER TABLE tbl9 CONFIGURE ZONE USING
+            range_min_bytes = 134217728,
+            range_max_bytes = 536870912,
+            gc.ttlseconds = 5,
+            num_replicas = 3,
+            num_voters = 3,
+            constraints = '{+region=us-east-1: 1}',
+            voter_constraints = '[+region=us-east-1]',
+            lease_preferences = '[[+region=us-east-1]]'
+
+statement ok
+SELECT crdb_internal.validate_multi_region_zone_configs()
+
+let $tbl9_id
+select table_id from crdb_internal.tables where name = 'tbl9'
+
+statement ok
+SELECT crdb_internal.crdb_internal.reset_multi_region_zone_configs_for_table($tbl9_id)
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE tbl9
+----
+TABLE tbl9  ALTER TABLE tbl9 CONFIGURE ZONE USING
+            range_min_bytes = 134217728,
+            range_max_bytes = 536870912,
+            gc.ttlseconds = 5,
+            num_replicas = 3,
+            num_voters = 3,
+            constraints = '{+region=us-east-1: 1}',
+            voter_constraints = '[+region=us-east-1]',
+            lease_preferences = '[[+region=us-east-1]]'
+
+statement ok
+SELECT crdb_internal.validate_multi_region_zone_configs()
+
+statement ok
+SET override_multi_region_zone_config = true;
+ALTER TABLE tbl9 CONFIGURE ZONE USING num_replicas = 5;
+SET override_multi_region_zone_config = false
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE tbl9
+----
+TABLE tbl9  ALTER TABLE tbl9 CONFIGURE ZONE USING
+            range_min_bytes = 134217728,
+            range_max_bytes = 536870912,
+            gc.ttlseconds = 5,
+            num_replicas = 5,
+            num_voters = 3,
+            constraints = '{+region=us-east-1: 1}',
+            voter_constraints = '[+region=us-east-1]',
+            lease_preferences = '[[+region=us-east-1]]'
+
+statement ok
+SELECT crdb_internal.crdb_internal.reset_multi_region_zone_configs_for_table($tbl9_id)
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE tbl9
+----
+TABLE tbl9  ALTER TABLE tbl9 CONFIGURE ZONE USING
+            range_min_bytes = 134217728,
+            range_max_bytes = 536870912,
+            gc.ttlseconds = 5,
+            num_replicas = 3,
+            num_voters = 3,
+            constraints = '{+region=us-east-1: 1}',
+            voter_constraints = '[+region=us-east-1]',
+            lease_preferences = '[[+region=us-east-1]]'
+
+statement ok
+CREATE TABLE tbl10 (
+  pk INT PRIMARY KEY,
+  i INT,
+  INDEX(i)
+) LOCALITY REGIONAL IN "us-east-1"
+
+statement ok
+SET override_multi_region_zone_config = true;
+ALTER table tbl10 CONFIGURE ZONE DISCARD;
+SET override_multi_region_zone_config = false
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE tbl10
+----
+DATABASE initial_multiregion_db  ALTER DATABASE initial_multiregion_db CONFIGURE ZONE USING
+                                 range_min_bytes = 134217728,
+                                 range_max_bytes = 536870912,
+                                 gc.ttlseconds = 90000,
+                                 num_replicas = 3,
+                                 num_voters = 3,
+                                 constraints = '{+region=us-east-1: 1}',
+                                 voter_constraints = '[+region=us-east-1]',
+                                 lease_preferences = '[[+region=us-east-1]]'
+
+statement error zone configuration for table tbl10 contains incorrectly configured field "num_voters"
+SELECT crdb_internal.validate_multi_region_zone_configs()
+
+let $tbl10_id
+select table_id from crdb_internal.tables where name = 'tbl10'
+
+statement ok
+SELECT crdb_internal.crdb_internal.reset_multi_region_zone_configs_for_table($tbl10_id)
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE tbl10
+----
+TABLE tbl10  ALTER TABLE tbl10 CONFIGURE ZONE USING
+             range_min_bytes = 134217728,
+             range_max_bytes = 536870912,
+             gc.ttlseconds = 90000,
+             num_replicas = 3,
+             num_voters = 3,
+             constraints = '{+region=us-east-1: 1}',
+             voter_constraints = '[+region=us-east-1]',
+             lease_preferences = '[[+region=us-east-1]]'
+
+statement ok
+SELECT crdb_internal.validate_multi_region_zone_configs()
+
+statement ok
+SET override_multi_region_zone_config = true;
+ALTER TABLE tbl10 CONFIGURE ZONE USING num_replicas = 5;
+SET override_multi_region_zone_config = false
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE tbl10
+----
+TABLE tbl10  ALTER TABLE tbl10 CONFIGURE ZONE USING
+             range_min_bytes = 134217728,
+             range_max_bytes = 536870912,
+             gc.ttlseconds = 90000,
+             num_replicas = 5,
+             num_voters = 3,
+             constraints = '{+region=us-east-1: 1}',
+             voter_constraints = '[+region=us-east-1]',
+             lease_preferences = '[[+region=us-east-1]]'
+
+statement ok
+SELECT crdb_internal.crdb_internal.reset_multi_region_zone_configs_for_table($tbl10_id)
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE tbl10
+----
+TABLE tbl10  ALTER TABLE tbl10 CONFIGURE ZONE USING
+             range_min_bytes = 134217728,
+             range_max_bytes = 536870912,
+             gc.ttlseconds = 90000,
+             num_replicas = 3,
+             num_voters = 3,
+             constraints = '{+region=us-east-1: 1}',
+             voter_constraints = '[+region=us-east-1]',
+             lease_preferences = '[[+region=us-east-1]]'
+
+# Ensure that built-in no-ops on non-multi-region tables.
+statement ok
+CREATE DATABASE not_multi_region;
+USE not_multi_region
+
+statement ok
+CREATE TABLE tbl11 (
+  pk INT PRIMARY KEY,
+  i INT,
+  INDEX(i)
+)
+
+statement ok
+ALTER table tbl11 CONFIGURE ZONE USING num_replicas=10
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE tbl11
+----
+TABLE tbl11  ALTER TABLE tbl11 CONFIGURE ZONE USING
+             range_min_bytes = 134217728,
+             range_max_bytes = 536870912,
+             gc.ttlseconds = 90000,
+             num_replicas = 10,
+             constraints = '[]',
+             lease_preferences = '[]'
+
+let $tbl11_id
+select table_id from crdb_internal.tables where name = 'tbl11'
+
+statement ok
+SELECT crdb_internal.crdb_internal.reset_multi_region_zone_configs_for_table($tbl11_id)
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE tbl11
+----
+TABLE tbl11  ALTER TABLE tbl11 CONFIGURE ZONE USING
+             range_min_bytes = 134217728,
+             range_max_bytes = 536870912,
+             gc.ttlseconds = 90000,
+             num_replicas = 10,
+             constraints = '[]',
+             lease_preferences = '[]'
+
+query error pq: crdb_internal\.reset_multi_region_zone_configs_for_table\(\): error resolving referenced table ID 1: relation "\[1\]" does not exist
+SELECT crdb_internal.crdb_internal.reset_multi_region_zone_configs_for_table(1)

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -60,6 +60,14 @@ func (so *DummySequenceOperators) ValidateAllMultiRegionZoneConfigsInCurrentData
 	return errors.WithStack(errSequenceOperators)
 }
 
+// ResetMultiRegionZoneConfigsForTable is part of the tree.EvalDatabase
+// interface.
+func (so *DummySequenceOperators) ResetMultiRegionZoneConfigsForTable(
+	_ context.Context, id int64,
+) error {
+	return errors.WithStack(errSequenceOperators)
+}
+
 // ParseQualifiedTableName is part of the tree.EvalDatabase interface.
 func (so *DummySequenceOperators) ParseQualifiedTableName(sql string) (*tree.TableName, error) {
 	return nil, errors.WithStack(errSequenceOperators)
@@ -233,6 +241,12 @@ func (ep *DummyEvalPlanner) CurrentDatabaseRegionConfig(
 	_ context.Context,
 ) (tree.DatabaseRegionConfig, error) {
 	return nil, errors.WithStack(errEvalPlanner)
+}
+
+// ResetMultiRegionZoneConfigsForTable is part of the tree.EvalDatabase
+// interface.
+func (ep *DummyEvalPlanner) ResetMultiRegionZoneConfigsForTable(_ context.Context, _ int64) error {
+	return errors.WithStack(errEvalPlanner)
 }
 
 // ValidateAllMultiRegionZoneConfigsInCurrentDatabase is part of the tree.EvalDatabase interface.

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -854,6 +854,32 @@ func (p *planner) ValidateAllMultiRegionZoneConfigsInCurrentDatabase(ctx context
 	)
 }
 
+// ResetMultiRegionZoneConfigsForTable is part of the tree.EvalDatabase
+// interface.
+func (p *planner) ResetMultiRegionZoneConfigsForTable(ctx context.Context, id int64) error {
+	desc, err := p.Descriptors().GetMutableTableVersionByID(ctx, descpb.ID(id), p.txn)
+	if err != nil {
+		return errors.Wrapf(err, "error resolving referenced table ID %d", id)
+	}
+	// If the table is not a multi-region table, there's no work to be done
+	// here.
+	if desc.LocalityConfig == nil {
+		return nil
+	}
+	regionConfig, err := SynthesizeRegionConfig(ctx, p.txn, desc.GetParentID(), p.Descriptors())
+	if err != nil {
+		return err
+	}
+	return ApplyZoneConfigForMultiRegionTable(
+		ctx,
+		p.txn,
+		p.ExecCfg(),
+		regionConfig,
+		desc,
+		ApplyZoneConfigForMultiRegionTableOptionTableAndIndexes,
+	)
+}
+
 func (p *planner) validateAllMultiRegionZoneConfigsInDatabase(
 	ctx context.Context,
 	dbDesc catalog.DatabaseDescriptor,

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -5392,6 +5392,28 @@ the locality flag on node startup. Returns an error if no region is set.`,
 			Volatility: tree.VolatilityVolatile,
 		},
 	),
+	"crdb_internal.reset_multi_region_zone_configs_for_table": makeBuiltin(
+		tree.FunctionProperties{Category: categoryMultiRegion},
+		tree.Overload{
+			Types:      tree.ArgTypes{{"id", types.Int}},
+			ReturnType: tree.FixedReturnType(types.Bool),
+			Fn: func(evalCtx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				id := int64(*args[0].(*tree.DInt))
+
+				if err := evalCtx.Sequence.ResetMultiRegionZoneConfigsForTable(
+					evalCtx.Context,
+					id,
+				); err != nil {
+					return nil, err
+				}
+				return tree.MakeDBool(true), nil
+			},
+			Info: `Resets the zone configuration for a multi-region table to 
+match its original state. No-ops if the given table ID is not a multi-region 
+table`,
+			Volatility: tree.VolatilityVolatile,
+		},
+	),
 	"crdb_internal.filter_multiregion_fields_from_zone_config_sql": makeBuiltin(
 		tree.FunctionProperties{Category: categoryMultiRegion},
 		stringOverload1(

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3038,6 +3038,10 @@ type EvalDatabase interface {
 	// all tables within the database.
 	ValidateAllMultiRegionZoneConfigsInCurrentDatabase(ctx context.Context) error
 
+	// ResetMultiRegionZoneConfigsForTable resets the given table's zone
+	// configuration to its multi-region default.
+	ResetMultiRegionZoneConfigsForTable(ctx context.Context, id int64) error
+
 	// ParseQualifiedTableName parses a SQL string of the form
 	// `[ database_name . ] [ schema_name . ] table_name`.
 	// NB: this is deprecated! Use parser.ParseQualifiedTableName when possible.


### PR DESCRIPTION
The new(ish) multi-region syntax introduced in 21.1 sets zone
configurations at the table or partition level for most of the table
localities. These zone configurations can diverge from their original
state either because the user has manually overridden them, or because
the system hasn't kept them up to date as the table has evolved (e.g.
with issue #66637). In either case, the user may wish to revert the zone
configurations for a given table back to its original state.

The new builtin takes a table ID, and resets its underlying zone
configurations to their original state (as specified by the assigned
table locality). For non-multi-region tables, the builtin no-ops.

This issue partially addresses #66855. An additional PR will follow to
add database level zone configuration resetting.

Release note (sql change): Creates a builtin to reset the zone
configurations of multi-region tables. This builtin can be helpful in
cases where the user has overridden the zone configuration for a given
table and wishes to revert back to the original system-specified state.