### PR TITLE
cluster-ui: bump package.json version

### DIFF
--- a/pkg/ui/cluster-ui/package.json
+++ b/pkg/ui/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "21.2.0-prerelease-2",
+  "version": "21.2.0-prerelease-3",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",


### PR DESCRIPTION
In #67722, we updated peerDependencies, but forgot to bump
the version in package.json.

This fast-follow PR bumps the version for #67722.

Note: this has been preemptively backported to 21.1 and 20.2, in #67981 and #67982 respectively.


Release note: None