### PR TITLE
kvserver: add GC intent resolution timeout

### DIFF
--- a/pkg/kv/kvserver/gc/BUILD.bazel
+++ b/pkg/kv/kvserver/gc/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/storage",
         "//pkg/storage/enginepb",
         "//pkg/util/bufalloc",
+        "//pkg/util/contextutil",
         "//pkg/util/hlc",
         "//pkg/util/log",
         "//pkg/util/protoutil",

--- a/pkg/kv/kvserver/gc_queue.go
+++ b/pkg/kv/kvserver/gc_queue.go
@@ -39,6 +39,12 @@ const (
 	gcQueueTimerDuration = 1 * time.Second
 	// gcQueueTimeout is the timeout for a single GC run.
 	gcQueueTimeout = 10 * time.Minute
+	// gcQueueIntentBatchTimeout is the timeout for resolving a single batch of
+	// intents. It is used to ensure progress in the face of unavailable ranges
+	// (since intent resolution may touch other ranges), but can prevent progress
+	// for ranged intent resolution if it exceeds the timeout.
+	gcQueueIntentBatchTimeout = 2 * time.Minute
+
 	// gcQueueIntentCooldownDuration is the duration to wait between GC attempts
 	// of the same range when triggered solely by intents. This is to prevent
 	// continually spinning on intents that belong to active transactions, which
@@ -519,6 +525,7 @@ func (gcq *gcQueue) process(
 			MaxIntentsPerIntentCleanupBatch:        maxIntentsPerCleanupBatch,
 			MaxIntentKeyBytesPerIntentCleanupBatch: maxIntentKeyBytesPerCleanupBatch,
 			MaxTxnsPerIntentCleanupBatch:           intentresolver.MaxTxnsPerIntentCleanupBatch,
+			IntentCleanupBatchTimeout:              gcQueueIntentBatchTimeout,
 		},
 		*zone.GC,
 		&replicaGCer{repl: repl},


### PR DESCRIPTION
This patch adds a 2-minute timeout for GC intent resolution batches, to
ensure progress even when encountering a stuck range (recall that intent
GC will attempt to remove intents on other ranges that belong to a txn
anchored on the current range).

Resolves #67296.

Release note: None

/cc @cockroachdb/kv 