### PR TITLE
bazel: globally disable caching for `autom4te` in bazel builder image

### DIFF
--- a/build/bazelbuilder/Dockerfile
+++ b/build/bazelbuilder/Dockerfile
@@ -61,5 +61,6 @@ RUN rm -rf /tmp/* /var/lib/apt/lists/*
 RUN ln -s /usr/bin/bazel-4.0.0 /usr/bin/bazel
 
 COPY entrypoint.sh /usr/bin
+COPY autom4te /usr/local/sbin
 ENTRYPOINT ["/usr/bin/entrypoint.sh"]
 CMD ["/usr/bin/bash"]

--- a/build/bazelbuilder/autom4te
+++ b/build/bazelbuilder/autom4te
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Autom4te's default caching behavior breaks the Bazel sandbox sometimes. This
+# shim script just invokes the actual `autom4te` script disabling caching.
+/usr/bin/autom4te --no-cache "$@"

--- a/build/teamcity-bazel-support.sh
+++ b/build/teamcity-bazel-support.sh
@@ -1,7 +1,7 @@
 # FYI: You can run `./dev builder` to run this Docker image. :)
 # `dev` depends on this variable! Don't change the name or format unless you
 # also update `dev` accordingly.
-BAZEL_IMAGE=cockroachdb/bazel:20210528-135020
+BAZEL_IMAGE=cockroachdb/bazel:20210723-114244
 
 # Call `run_bazel $NAME_OF_SCRIPT` to start an appropriately-configured Docker
 # container with the `cockroachdb/bazel` image running the given script.

--- a/c-deps/BUILD.bazel
+++ b/c-deps/BUILD.bazel
@@ -124,6 +124,9 @@ configure_make(
     name = "libkrb5",
     autoreconf = True,
     autoreconf_directory = "src",
+    autoreconf_env_vars = {
+        "AUTOM4TE": "autom4te",
+    },
     configure_command = "src/configure",
     configure_in_place = True,
     configure_options = [


### PR DESCRIPTION
`autoreconf` (which is now invoked by the `cockroach-short` build via
`krb5`) calls into `autom4te`, but unfortunately `autom4te`'s default
caching behavior breaks the Bazel build on my machine:

    autom4te: cannot open autom4te.cache/requests: Read-only file system
    autom4te: cannot open autom4te.cache/requests: Read-only file system
    autoreconf: /usr/bin/autoconf failed with exit status: 1

Unfortunately we can't simply set an environment variable to turn this
behavior off, so instead I add a shim `autom4te` binary that implicitly
adds `--no-cache`.

Release note: None