### PR TITLE
importccl: fail PGDUMP IMPORT if we see a UDT

### DIFF
--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -880,8 +880,12 @@ func importPlanHook(
 						"IMPORT to REGIONAL BY ROW table not supported",
 					)
 				}
+				// IMPORT TABLE do not support user defined types, and so we nil out the
+				// type resolver to protect against unexpected behavior on UDT
+				// resolution.
+				semaCtxPtr := makeSemaCtxWithoutTypeResolver(p.SemaCtx())
 				tbl, err := MakeSimpleTableDescriptor(
-					ctx, p.SemaCtx(), p.ExecCfg().Settings, create, db, sc, defaultCSVTableID, NoFKs, walltime)
+					ctx, semaCtxPtr, p.ExecCfg().Settings, create, db, sc, defaultCSVTableID, NoFKs, walltime)
 				if err != nil {
 					return err
 				}

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -1075,6 +1075,30 @@ CREATE INDEX i ON t USING btree (a) WHERE (b > 10);
 			`,
 			err: "cannot import a table with partial indexes",
 		},
+		{
+			name: "user defined type",
+			typ:  "PGDUMP",
+			data: `
+CREATE TYPE duration AS ENUM (
+    'YESTERDAY',
+    'LAST_7_DAYS',
+    'LAST_28_DAYS',
+    'LAST_90_DAYS',
+    'LAST_365_DAYS',
+    'LIFE_TIME'
+);
+CREATE TABLE t (a duration);
+			`,
+			err: "IMPORT PGDUMP does not support user defined types",
+		},
+		{
+			name: "user defined type without create",
+			typ:  "PGDUMP",
+			data: `
+CREATE TABLE t (a duration);
+			`,
+			err: "type \"duration\" does not exist",
+		},
 
 		// Error
 		{

--- a/pkg/ccl/importccl/import_table_creation.go
+++ b/pkg/ccl/importccl/import_table_creation.go
@@ -122,6 +122,12 @@ func MakeTestingSimpleTableDescriptor(
 	return MakeSimpleTableDescriptor(ctx, semaCtx, st, create, db, sc, tableID, fks, walltime)
 }
 
+func makeSemaCtxWithoutTypeResolver(semaCtx *tree.SemaContext) *tree.SemaContext {
+	semaCtxCopy := *semaCtx
+	semaCtxCopy.TypeResolver = nil
+	return &semaCtxCopy
+}
+
 // MakeSimpleTableDescriptor creates a tabledesc.Mutable from a CreateTable
 // parse node without the full machinery. Many parts of the syntax are
 // unsupported (see the implementation and TestMakeSimpleTableDescriptorErrors

--- a/pkg/ccl/importccl/read_import_mysql.go
+++ b/pkg/ccl/importccl/read_import_mysql.go
@@ -508,6 +508,10 @@ func mysqlTableToCockroach(
 	if p != nil {
 		semaCtxPtr = p.SemaCtx()
 	}
+
+	// Bundle imports do not support user defined types, and so we nil out the
+	// type resolver to protect against unexpected behavior on UDT resolution.
+	semaCtxPtr = makeSemaCtxWithoutTypeResolver(semaCtxPtr)
 	desc, err := MakeSimpleTableDescriptor(
 		ctx, semaCtxPtr, evalCtx.Settings, stmt, parentDB,
 		schemadesc.GetPublicSchema(), id, fks, time.WallTime,

--- a/pkg/ccl/importccl/read_import_pgdump.go
+++ b/pkg/ccl/importccl/read_import_pgdump.go
@@ -373,7 +373,10 @@ func createPostgresTables(
 			return nil, err
 		}
 		removeDefaultRegclass(create)
-		desc, err := MakeSimpleTableDescriptor(evalCtx.Ctx(), p.SemaCtx(), p.ExecCfg().Settings,
+		// Bundle imports do not support user defined types, and so we nil out the
+		// type resolver to protect against unexpected behavior on UDT resolution.
+		semaCtxPtr := makeSemaCtxWithoutTypeResolver(p.SemaCtx())
+		desc, err := MakeSimpleTableDescriptor(evalCtx.Ctx(), semaCtxPtr, p.ExecCfg().Settings,
 			create, parentDB, schema, getNextPlaceholderDescID(), fks, walltime)
 		if err != nil {
 			return nil, err
@@ -861,6 +864,9 @@ func readPostgresStmt(
 			return unsupportedStmtLogger.log(fmt.Sprintf("%s", stmt), false /* isParseError */)
 		}
 		return wrapErrorWithUnsupportedHint(errors.Errorf("unsupported %T statement: %s", stmt, stmt))
+	case *tree.CreateType:
+		return errors.New("IMPORT PGDUMP does not support user defined types; please" +
+			" remove all CREATE TYPE statements and their usages from the dump file")
 	case error:
 		if !errors.Is(stmt, errCopyDone) {
 			return stmt


### PR DESCRIPTION
In 21.1 we added `ignore_unsupported_statements` that ignored
all statements that we didnt support while parsing the PGDUMP
file. We don't support `CREATE TYPE` and its subsequent usage,
and this currently causes a NPE.

While we work on adding UDT support to PGDUMP we should make
an exception to the ignore option and fail the import instead.

Informs: #67983

Release note (bug fix): IMPORT PGDUMP with a UDT would result
in a nil pointer exception. This change makes it fail gracefully.