### PR TITLE
release-21.1: opt: fix over-estimation of rows due to multi-column stats

### DIFF
--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -806,13 +806,16 @@ func (sb *statisticsBuilder) constrainScan(
 
 	// Calculate row count and selectivity
 	// -----------------------------------
-	s.ApplySelectivity(sb.selectivityFromHistograms(histCols, scan, s))
+	histSelectivity, selectivityUpperBound := sb.selectivityFromHistograms(histCols, scan, s)
+	s.ApplySelectivity(histSelectivity)
 	s.ApplySelectivity(sb.selectivityFromMultiColDistinctCounts(constrainedCols, scan, s))
 	s.ApplySelectivity(sb.selectivityFromUnappliedConjuncts(numUnappliedConjuncts))
 	s.ApplySelectivity(sb.selectivityFromNullsRemoved(scan, notNullCols, constrainedCols))
 
-	// Adjust the selectivity so we don't double-count the histogram columns.
+	// Adjust the selectivity so we don't double-count the histogram columns, but
+	// make sure it does not exceed the upper bound based on the histograms.
 	s.UnapplySelectivity(sb.selectivityFromSingleColDistinctCounts(histCols, scan, s))
+	s.LimitSelectivity(selectivityUpperBound)
 }
 
 func (sb *statisticsBuilder) colStatScan(colSet opt.ColSet, scan *ScanExpr) *props.ColumnStatistic {
@@ -993,12 +996,15 @@ func (sb *statisticsBuilder) buildInvertedFilter(
 	// -----------------------------------
 	inputStats := &invFilter.Input.Relational().Stats
 	s.RowCount = inputStats.RowCount
-	s.ApplySelectivity(sb.selectivityFromHistograms(histCols, invFilter, s))
+	histSelectivity, selectivityUpperBound := sb.selectivityFromHistograms(histCols, invFilter, s)
+	s.ApplySelectivity(histSelectivity)
 	s.ApplySelectivity(sb.selectivityFromMultiColDistinctCounts(constrainedCols, invFilter, s))
 	s.ApplySelectivity(sb.selectivityFromNullsRemoved(invFilter, relProps.NotNullCols, constrainedCols))
 
-	// Adjust the selectivity so we don't double-count the histogram columns.
+	// Adjust the selectivity so we don't double-count the histogram columns, but
+	// make sure it does not exceed the upper bound based on the histograms.
 	s.UnapplySelectivity(sb.selectivityFromSingleColDistinctCounts(histCols, invFilter, s))
+	s.LimitSelectivity(selectivityUpperBound)
 
 	sb.finalizeFromCardinality(relProps)
 }
@@ -1159,7 +1165,8 @@ func (sb *statisticsBuilder) buildJoin(
 	if join.Op() == opt.InvertedJoinOp || hasInvertedJoinCond(h.filters) {
 		s.ApplySelectivity(sb.selectivityFromInvertedJoinCondition(join, s))
 	}
-	s.ApplySelectivity(sb.selectivityFromHistograms(histCols, join, s))
+	histSelectivity, selectivityUpperBound := sb.selectivityFromHistograms(histCols, join, s)
+	s.ApplySelectivity(histSelectivity)
 	s.ApplySelectivity(sb.selectivityFromMultiColDistinctCounts(
 		constrainedCols.Intersection(leftCols), join, s,
 	))
@@ -1169,8 +1176,10 @@ func (sb *statisticsBuilder) buildJoin(
 	s.ApplySelectivity(sb.selectivityFromUnappliedConjuncts(numUnappliedConjuncts))
 	s.ApplySelectivity(sb.selectivityFromNullsRemoved(join, relProps.NotNullCols, constrainedCols))
 
-	// Adjust the selectivity so we don't double-count the histogram columns.
+	// Adjust the selectivity so we don't double-count the histogram columns, but
+	// make sure it does not exceed the upper bound based on the histograms.
 	s.UnapplySelectivity(sb.selectivityFromSingleColDistinctCounts(histCols, join, s))
+	s.LimitSelectivity(selectivityUpperBound)
 
 	// Update distinct counts based on equivalencies; this should happen after
 	// selectivityFromMultiColDistinctCounts and selectivityFromEquivalencies.
@@ -2856,14 +2865,17 @@ func (sb *statisticsBuilder) filterRelExpr(
 
 	// Calculate row count and selectivity
 	// -----------------------------------
-	s.ApplySelectivity(sb.selectivityFromHistograms(histCols, e, s))
+	histSelectivity, selectivityUpperBound := sb.selectivityFromHistograms(histCols, e, s)
+	s.ApplySelectivity(histSelectivity)
 	s.ApplySelectivity(sb.selectivityFromMultiColDistinctCounts(constrainedCols, e, s))
 	s.ApplySelectivity(sb.selectivityFromEquivalencies(equivReps, &relProps.FuncDeps, e, s))
 	s.ApplySelectivity(sb.selectivityFromUnappliedConjuncts(numUnappliedConjuncts))
 	s.ApplySelectivity(sb.selectivityFromNullsRemoved(e, notNullCols, constrainedCols))
 
-	// Adjust the selectivity so we don't double-count the histogram columns.
+	// Adjust the selectivity so we don't double-count the histogram columns, but
+	// make sure it does not exceed the upper bound based on the histograms.
 	s.UnapplySelectivity(sb.selectivityFromSingleColDistinctCounts(histCols, e, s))
+	s.LimitSelectivity(selectivityUpperBound)
 
 	// Update distinct and null counts based on equivalencies; this should
 	// happen after selectivityFromMultiColDistinctCounts and
@@ -3097,12 +3109,15 @@ func (sb *statisticsBuilder) constrainExpr(
 
 	// Calculate row count and selectivity
 	// -----------------------------------
-	s.ApplySelectivity(sb.selectivityFromHistograms(histCols, e, s))
+	histSelectivity, selectivityUpperBound := sb.selectivityFromHistograms(histCols, e, s)
+	s.ApplySelectivity(histSelectivity)
 	s.ApplySelectivity(sb.selectivityFromMultiColDistinctCounts(constrainedCols, e, s))
 	s.ApplySelectivity(sb.selectivityFromNullsRemoved(e, notNullCols, constrainedCols))
 
-	// Adjust the selectivity so we don't double-count the histogram columns.
+	// Adjust the selectivity so we don't double-count the histogram columns, but
+	// make sure it does not exceed the upper bound based on the histograms.
 	s.UnapplySelectivity(sb.selectivityFromSingleColDistinctCounts(histCols, e, s))
+	s.LimitSelectivity(selectivityUpperBound)
 }
 
 // applyIndexConstraint is used to update the distinct counts and histograms
@@ -3765,10 +3780,17 @@ func (sb *statisticsBuilder) selectivityFromDistinctCount(
 //
 // For histograms, the selectivity of a constrained column is calculated as
 // (# values in histogram after filter) / (# values in histogram before filter).
+//
+// In addition to returning the product of selectivities,
+// selectivityFromHistograms returns the selectivity of the most selective
+// predicate (i.e., the predicate with minimum selectivity) as
+// selectivityUpperBound, since it is an upper bound on the selectivity of the
+// entire expression.
 func (sb *statisticsBuilder) selectivityFromHistograms(
 	cols opt.ColSet, e RelExpr, s *props.Statistics,
-) (selectivity props.Selectivity) {
+) (selectivity props.Selectivity, selectivityUpperBound props.Selectivity) {
 	selectivity = props.OneSelectivity
+	selectivityUpperBound = props.OneSelectivity
 	for col, ok := cols.Next(0); ok; col, ok = cols.Next(col + 1) {
 		colStat, ok := s.ColStats.Lookup(opt.MakeColSet(col))
 		if !ok {
@@ -3788,12 +3810,18 @@ func (sb *statisticsBuilder) selectivityFromHistograms(
 		// Calculate the selectivity of the predicate.
 		nonNullSelectivity := props.MakeSelectivityFromFraction(newCount, oldCount)
 		nullSelectivity := props.MakeSelectivityFromFraction(colStat.NullCount, inputColStat.NullCount)
-		selectivity.Multiply(sb.predicateSelectivity(
+		predicateSelectivity := sb.predicateSelectivity(
 			nonNullSelectivity, nullSelectivity, inputColStat.NullCount, inputStats.RowCount,
-		))
+		)
+
+		// The maximum possible selectivity of the entire expression is the minimum
+		// selectivity of all individual predicates.
+		selectivityUpperBound = props.MinSelectivity(selectivityUpperBound, predicateSelectivity)
+
+		selectivity.Multiply(predicateSelectivity)
 	}
 
-	return selectivity
+	return selectivity, selectivityUpperBound
 }
 
 // selectivityFromNullsRemoved calculates the selectivity from null-rejecting

--- a/pkg/sql/opt/memo/testdata/stats/inverted-geo
+++ b/pkg/sql/opt/memo/testdata/stats/inverted-geo
@@ -165,12 +165,12 @@ project
       │    ├── limit hint: 1.00
       │    ├── sort
       │    │    ├── columns: i:1(int) g:2(geometry)
-      │    │    ├── stats: [rows=7e-07]
+      │    │    ├── stats: [rows=1e-07]
       │    │    ├── ordering: +1
       │    │    ├── limit hint: 0.00
       │    │    └── index-join t
       │    │         ├── columns: i:1(int) g:2(geometry)
-      │    │         ├── stats: [rows=7e-07]
+      │    │         ├── stats: [rows=1e-07]
       │    │         └── inverted-filter
       │    │              ├── columns: rowid:3(int!null)
       │    │              ├── inverted expression: /5
@@ -178,13 +178,13 @@ project
       │    │              │    └── union spans: ["B\xfd\xff\xff\xff\xff\xff\xff\xff\xff", "B\xfd\xff\xff\xff\xff\xff\xff\xff\xff"]
       │    │              ├── pre-filterer expression
       │    │              │    └── st_intersects('010200000002000000000000000000594000000000000059400000000000C062400000000000C06240', g:2) [type=bool]
-      │    │              ├── stats: [rows=7e-07]
+      │    │              ├── stats: [rows=1e-07]
       │    │              ├── key: (3)
       │    │              └── scan t@secondary
       │    │                   ├── columns: rowid:3(int!null) g_inverted_key:5(geometry!null)
       │    │                   ├── inverted constraint: /5/3
       │    │                   │    └── spans: ["B\xfd\xff\xff\xff\xff\xff\xff\xff\xff", "B\xfd\xff\xff\xff\xff\xff\xff\xff\xff"]
-      │    │                   ├── stats: [rows=7e-07, distinct(3)=7e-07, null(3)=0, distinct(5)=7e-07, null(5)=0]
+      │    │                   ├── stats: [rows=1e-07, distinct(3)=1e-07, null(3)=0, distinct(5)=1e-07, null(5)=0]
       │    │                   │   histogram(5)=
       │    │                   ├── key: (3)
       │    │                   └── fd: (3)-->(5)
@@ -385,12 +385,12 @@ project
       │    ├── limit hint: 1.00
       │    ├── sort
       │    │    ├── columns: i:1(int) g:2(geometry)
-      │    │    ├── stats: [rows=7e-07]
+      │    │    ├── stats: [rows=1e-07]
       │    │    ├── ordering: +1
       │    │    ├── limit hint: 0.00
       │    │    └── index-join t
       │    │         ├── columns: i:1(int) g:2(geometry)
-      │    │         ├── stats: [rows=7e-07]
+      │    │         ├── stats: [rows=1e-07]
       │    │         └── inverted-filter
       │    │              ├── columns: rowid:3(int!null)
       │    │              ├── inverted expression: /5
@@ -398,13 +398,13 @@ project
       │    │              │    └── union spans: ["B\xfd\xff\xff\xff\xff\xff\xff\xff\xff", "B\xfd\xff\xff\xff\xff\xff\xff\xff\xff"]
       │    │              ├── pre-filterer expression
       │    │              │    └── st_intersects('010200000002000000000000000000594000000000000059400000000000C062400000000000C06240', g:2) [type=bool]
-      │    │              ├── stats: [rows=7e-07]
+      │    │              ├── stats: [rows=1e-07]
       │    │              ├── key: (3)
       │    │              └── scan t@secondary
       │    │                   ├── columns: rowid:3(int!null) g_inverted_key:5(geometry!null)
       │    │                   ├── inverted constraint: /5/3
       │    │                   │    └── spans: ["B\xfd\xff\xff\xff\xff\xff\xff\xff\xff", "B\xfd\xff\xff\xff\xff\xff\xff\xff\xff"]
-      │    │                   ├── stats: [rows=7e-07, distinct(3)=7e-07, null(3)=0, distinct(5)=7e-07, null(5)=0]
+      │    │                   ├── stats: [rows=1e-07, distinct(3)=1e-07, null(3)=0, distinct(5)=1e-07, null(5)=0]
       │    │                   │   histogram(5)=
       │    │                   ├── key: (3)
       │    │                   └── fd: (3)-->(5)

--- a/pkg/sql/opt/memo/testdata/stats/inverted-json
+++ b/pkg/sql/opt/memo/testdata/stats/inverted-json
@@ -397,14 +397,14 @@ select
  ├── fd: (1)-->(2)
  ├── index-join t
  │    ├── columns: k:1(int!null) j:2(jsonb)
- │    ├── stats: [rows=2e-07]
+ │    ├── stats: [rows=4e-08]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2)
  │    └── scan t@j_idx
  │         ├── columns: k:1(int!null)
  │         ├── inverted constraint: /4/1
  │         │    └── spans: ["7a\x00\x02b\x00\x01\x12c\x00\x01", "7a\x00\x02b\x00\x01\x12c\x00\x01"]
- │         ├── stats: [rows=2e-07, distinct(4)=2e-07, null(4)=0]
+ │         ├── stats: [rows=4e-08, distinct(4)=4e-08, null(4)=0]
  │         │   histogram(4)=
  │         └── key: (1)
  └── filters
@@ -423,14 +423,14 @@ select
  ├── fd: (1)-->(2)
  ├── index-join t
  │    ├── columns: k:1(int!null) j:2(jsonb)
- │    ├── stats: [rows=2e-07]
+ │    ├── stats: [rows=4e-08]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2)
  │    └── scan t@j_idx
  │         ├── columns: k:1(int!null)
  │         ├── inverted constraint: /4/1
  │         │    └── spans: ["7a\x00\x02b\x00\x02c\x00\x01\x12d\x00\x01", "7a\x00\x02b\x00\x02c\x00\x01\x12d\x00\x01"]
- │         ├── stats: [rows=2e-07, distinct(4)=2e-07, null(4)=0]
+ │         ├── stats: [rows=4e-08, distinct(4)=4e-08, null(4)=0]
  │         │   histogram(4)=
  │         └── key: (1)
  └── filters
@@ -450,7 +450,7 @@ select
  ├── fd: (1)-->(2)
  ├── index-join t
  │    ├── columns: k:1(int!null) j:2(jsonb)
- │    ├── stats: [rows=2e-07]
+ │    ├── stats: [rows=4e-08]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2)
  │    └── inverted-filter
@@ -465,7 +465,7 @@ select
  │         │         └── span expression
  │         │              ├── tight: true, unique: true
  │         │              └── union spans: ["7a\x00\x02d\x00\x01\x12e\x00\x01", "7a\x00\x02d\x00\x01\x12e\x00\x01"]
- │         ├── stats: [rows=2e-07]
+ │         ├── stats: [rows=4e-08]
  │         ├── key: (1)
  │         └── scan t@j_idx
  │              ├── columns: k:1(int!null) j_inverted_key:4(jsonb!null)
@@ -473,7 +473,7 @@ select
  │              │    └── spans
  │              │         ├── ["7a\x00\x02b\x00\x01\x12c\x00\x01", "7a\x00\x02b\x00\x01\x12c\x00\x01"]
  │              │         └── ["7a\x00\x02d\x00\x01\x12e\x00\x01", "7a\x00\x02d\x00\x01\x12e\x00\x01"]
- │              ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(4)=2e-07, null(4)=0]
+ │              ├── stats: [rows=4e-08, distinct(1)=4e-08, null(1)=0, distinct(4)=4e-08, null(4)=0]
  │              │   histogram(4)=
  │              ├── key: (1)
  │              └── fd: (1)-->(4)
@@ -493,7 +493,7 @@ select
  ├── fd: (1)-->(2)
  ├── index-join t
  │    ├── columns: k:1(int!null) j:2(jsonb)
- │    ├── stats: [rows=2e-07]
+ │    ├── stats: [rows=4e-08]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2)
  │    └── inverted-filter
@@ -522,7 +522,7 @@ select
  │         │         └── span expression
  │         │              ├── tight: true, unique: true
  │         │              └── union spans: ["7a\x00\x02\x00\x03\x00\x01\x12e\x00\x01", "7a\x00\x02\x00\x03\x00\x01\x12e\x00\x01"]
- │         ├── stats: [rows=2e-07]
+ │         ├── stats: [rows=4e-08]
  │         ├── key: (1)
  │         └── scan t@j_idx
  │              ├── columns: k:1(int!null) j_inverted_key:4(jsonb!null)
@@ -532,7 +532,7 @@ select
  │              │         ├── ["7a\x00\x02\x00\x03\x00\x01\x12c\x00\x01", "7a\x00\x02\x00\x03\x00\x01\x12c\x00\x01"]
  │              │         ├── ["7a\x00\x02\x00\x03\x00\x01\x12d\x00\x01", "7a\x00\x02\x00\x03\x00\x01\x12d\x00\x01"]
  │              │         └── ["7a\x00\x02\x00\x03\x00\x01\x12e\x00\x01", "7a\x00\x02\x00\x03\x00\x01\x12e\x00\x01"]
- │              ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(4)=2e-07, null(4)=0]
+ │              ├── stats: [rows=4e-08, distinct(1)=4e-08, null(1)=0, distinct(4)=4e-08, null(4)=0]
  │              │   histogram(4)=
  │              ├── key: (1)
  │              └── fd: (1)-->(4)
@@ -553,7 +553,7 @@ select
  ├── fd: (1)-->(2)
  ├── index-join t
  │    ├── columns: k:1(int!null) j:2(jsonb)
- │    ├── stats: [rows=2e-07]
+ │    ├── stats: [rows=4e-08]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2)
  │    └── inverted-filter
@@ -575,7 +575,7 @@ select
  │         │         └── span expression
  │         │              ├── tight: true, unique: true
  │         │              └── union spans: ["7a\x00\x02b\x00\x02\x00\x03\x00\x01\x12e\x00\x01", "7a\x00\x02b\x00\x02\x00\x03\x00\x01\x12e\x00\x01"]
- │         ├── stats: [rows=2e-07]
+ │         ├── stats: [rows=4e-08]
  │         ├── key: (1)
  │         └── scan t@j_idx
  │              ├── columns: k:1(int!null) j_inverted_key:4(jsonb!null)
@@ -584,7 +584,7 @@ select
  │              │         ├── ["7a\x00\x02b\x00\x02\x00\x03\x00\x01\x12c\x00\x01", "7a\x00\x02b\x00\x02\x00\x03\x00\x01\x12c\x00\x01"]
  │              │         ├── ["7a\x00\x02b\x00\x02\x00\x03\x00\x01\x12d\x00\x01", "7a\x00\x02b\x00\x02\x00\x03\x00\x01\x12d\x00\x01"]
  │              │         └── ["7a\x00\x02b\x00\x02\x00\x03\x00\x01\x12e\x00\x01", "7a\x00\x02b\x00\x02\x00\x03\x00\x01\x12e\x00\x01"]
- │              ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(4)=2e-07, null(4)=0]
+ │              ├── stats: [rows=4e-08, distinct(1)=4e-08, null(1)=0, distinct(4)=4e-08, null(4)=0]
  │              │   histogram(4)=
  │              ├── key: (1)
  │              └── fd: (1)-->(4)
@@ -604,7 +604,7 @@ select
  ├── fd: (1)-->(2)
  ├── index-join t
  │    ├── columns: k:1(int!null) j:2(jsonb)
- │    ├── stats: [rows=2e-07]
+ │    ├── stats: [rows=4e-08]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2)
  │    └── inverted-filter
@@ -614,7 +614,7 @@ select
  │         │    └── union spans
  │         │         ├── ["7a\x00\x018", "7a\x00\x018"]
  │         │         └── ["7a\x00\x02\x00\x03", "7a\x00\x02\x00\x03"]
- │         ├── stats: [rows=2e-07]
+ │         ├── stats: [rows=4e-08]
  │         ├── key: (1)
  │         └── scan t@j_idx
  │              ├── columns: k:1(int!null) j_inverted_key:4(jsonb!null)
@@ -622,7 +622,7 @@ select
  │              │    └── spans
  │              │         ├── ["7a\x00\x018", "7a\x00\x018"]
  │              │         └── ["7a\x00\x02\x00\x03", "7a\x00\x02\x00\x03"]
- │              ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(4)=2e-07, null(4)=0]
+ │              ├── stats: [rows=4e-08, distinct(1)=4e-08, null(1)=0, distinct(4)=4e-08, null(4)=0]
  │              │   histogram(4)=
  │              ├── key: (1)
  │              └── fd: (1)-->(4)
@@ -642,7 +642,7 @@ select
  ├── fd: (1)-->(2)
  ├── index-join t
  │    ├── columns: k:1(int!null) j:2(jsonb)
- │    ├── stats: [rows=2e-07]
+ │    ├── stats: [rows=4e-08]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2)
  │    └── inverted-filter
@@ -652,7 +652,7 @@ select
  │         │    └── union spans
  │         │         ├── ["7a\x00\x019", "7a\x00\x019"]
  │         │         └── ["7a\x00\x02\x00\xff", "7a\x00\x03")
- │         ├── stats: [rows=2e-07]
+ │         ├── stats: [rows=4e-08]
  │         ├── key: (1)
  │         └── scan t@j_idx
  │              ├── columns: k:1(int!null) j_inverted_key:4(jsonb!null)
@@ -660,7 +660,7 @@ select
  │              │    └── spans
  │              │         ├── ["7a\x00\x019", "7a\x00\x019"]
  │              │         └── ["7a\x00\x02\x00\xff", "7a\x00\x03")
- │              ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(4)=2e-07, null(4)=0]
+ │              ├── stats: [rows=4e-08, distinct(1)=4e-08, null(1)=0, distinct(4)=4e-08, null(4)=0]
  │              │   histogram(4)=
  │              ├── key: (1)
  │              └── fd: (1)-->(4)

--- a/pkg/sql/opt/memo/testdata/stats/partial-index-scan
+++ b/pkg/sql/opt/memo/testdata/stats/partial-index-scan
@@ -1031,11 +1031,11 @@ project
       ├── inverted constraint: /6/1
       │    └── spans: ["7g\x00\x01*\x0e\x00", "7g\x00\x01*\x0e\x00"]
       ├── flags: force-index=partial
-      ├── stats: [rows=183.217822, distinct(4)=2, null(4)=0, distinct(6)=50.5, null(6)=0, distinct(4,6)=101, null(4,6)=0]
-      │   histogram(4)=  0   91.609   0   91.609
+      ├── stats: [rows=160, distinct(4)=2, null(4)=0, distinct(6)=50.5, null(6)=0, distinct(4,6)=101, null(4,6)=0]
+      │   histogram(4)=  0     80     0     80
       │                <--- 'banana' --- 'cherry'
-      │   histogram(6)=  0        73.287        109.93          0
-      │                <--- '\x376700012a0e00' -------- '\x376700012a0e01'
+      │   histogram(6)=  0          64          96          0
+      │                <--- '\x376700012a0e00' ---- '\x376700012a0e01'
       └── key: (1)
 
 opt
@@ -1054,11 +1054,11 @@ index-join inv_hist
       ├── inverted constraint: /6/1
       │    └── spans: ["7g\x00\x01*\x0e\x00", "7g\x00\x01*\x0e\x00"]
       ├── flags: force-index=partial
-      ├── stats: [rows=183.217822, distinct(4)=2, null(4)=0, distinct(6)=50.5, null(6)=0, distinct(4,6)=101, null(4,6)=0]
-      │   histogram(4)=  0   91.609   0   91.609
+      ├── stats: [rows=160, distinct(4)=2, null(4)=0, distinct(6)=50.5, null(6)=0, distinct(4,6)=101, null(4,6)=0]
+      │   histogram(4)=  0     80     0     80
       │                <--- 'banana' --- 'cherry'
-      │   histogram(6)=  0        73.287        109.93          0
-      │                <--- '\x376700012a0e00' -------- '\x376700012a0e01'
+      │   histogram(6)=  0          64          96          0
+      │                <--- '\x376700012a0e00' ---- '\x376700012a0e01'
       └── key: (1)
 
 opt
@@ -1079,7 +1079,7 @@ project
       ├── fd: ()-->(4), (1)-->(3)
       ├── index-join inv_hist
       │    ├── columns: k:1(int!null) j:3(jsonb) s:4(string)
-      │    ├── stats: [rows=183.217822]
+      │    ├── stats: [rows=160]
       │    ├── key: (1)
       │    ├── fd: (1)-->(3,4)
       │    └── scan inv_hist@partial,partial
@@ -1087,11 +1087,11 @@ project
       │         ├── inverted constraint: /6/1
       │         │    └── spans: ["7g\x00\x01*\x0e\x00", "7g\x00\x01*\x0e\x00"]
       │         ├── flags: force-index=partial
-      │         ├── stats: [rows=183.217822, distinct(4)=2, null(4)=0, distinct(6)=50.5, null(6)=0, distinct(4,6)=101, null(4,6)=0]
-      │         │   histogram(4)=  0   91.609   0   91.609
+      │         ├── stats: [rows=160, distinct(4)=2, null(4)=0, distinct(6)=50.5, null(6)=0, distinct(4,6)=101, null(4,6)=0]
+      │         │   histogram(4)=  0     80     0     80
       │         │                <--- 'banana' --- 'cherry'
-      │         │   histogram(6)=  0        73.287        109.93          0
-      │         │                <--- '\x376700012a0e00' -------- '\x376700012a0e01'
+      │         │   histogram(6)=  0          64          96          0
+      │         │                <--- '\x376700012a0e00' ---- '\x376700012a0e01'
       │         └── key: (1)
       └── filters
            └── s:4 = 'banana' [type=bool, outer=(4), constraints=(/4: [/'banana' - /'banana']; tight), fd=()-->(4)]
@@ -1109,7 +1109,7 @@ select
  ├── fd: ()-->(4), (1)-->(2,3)
  ├── index-join inv_hist
  │    ├── columns: k:1(int!null) i:2(int) j:3(jsonb) s:4(string)
- │    ├── stats: [rows=183.217822]
+ │    ├── stats: [rows=160]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4)
  │    └── scan inv_hist@partial,partial
@@ -1117,11 +1117,11 @@ select
  │         ├── inverted constraint: /6/1
  │         │    └── spans: ["7g\x00\x01*\x0e\x00", "7g\x00\x01*\x0e\x00"]
  │         ├── flags: force-index=partial
- │         ├── stats: [rows=183.217822, distinct(4)=2, null(4)=0, distinct(6)=50.5, null(6)=0, distinct(4,6)=101, null(4,6)=0]
- │         │   histogram(4)=  0   91.609   0   91.609
+ │         ├── stats: [rows=160, distinct(4)=2, null(4)=0, distinct(6)=50.5, null(6)=0, distinct(4,6)=101, null(4,6)=0]
+ │         │   histogram(4)=  0     80     0     80
  │         │                <--- 'banana' --- 'cherry'
- │         │   histogram(6)=  0        73.287        109.93          0
- │         │                <--- '\x376700012a0e00' -------- '\x376700012a0e01'
+ │         │   histogram(6)=  0          64          96          0
+ │         │                <--- '\x376700012a0e00' ---- '\x376700012a0e01'
  │         └── key: (1)
  └── filters
       └── s:4 = 'banana' [type=bool, outer=(4), constraints=(/4: [/'banana' - /'banana']; tight), fd=()-->(4)]
@@ -1141,7 +1141,7 @@ select
  ├── fd: (1)-->(2-4)
  ├── index-join inv_hist
  │    ├── columns: k:1(int!null) i:2(int) j:3(jsonb) s:4(string)
- │    ├── stats: [rows=183.217822]
+ │    ├── stats: [rows=160]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4)
  │    └── scan inv_hist@partial,partial
@@ -1149,11 +1149,11 @@ select
  │         ├── inverted constraint: /6/1
  │         │    └── spans: ["7g\x00\x01*\x0e\x00", "7g\x00\x01*\x0e\x00"]
  │         ├── flags: force-index=partial
- │         ├── stats: [rows=183.217822, distinct(4)=2, null(4)=0, distinct(6)=50.5, null(6)=0, distinct(4,6)=101, null(4,6)=0]
- │         │   histogram(4)=  0   91.609   0   91.609
+ │         ├── stats: [rows=160, distinct(4)=2, null(4)=0, distinct(6)=50.5, null(6)=0, distinct(4,6)=101, null(4,6)=0]
+ │         │   histogram(4)=  0     80     0     80
  │         │                <--- 'banana' --- 'cherry'
- │         │   histogram(6)=  0        73.287        109.93          0
- │         │                <--- '\x376700012a0e00' -------- '\x376700012a0e01'
+ │         │   histogram(6)=  0          64          96          0
+ │         │                <--- '\x376700012a0e00' ---- '\x376700012a0e01'
  │         └── key: (1)
  └── filters
       └── (i:2 > 0) AND (i:2 <= 100) [type=bool, outer=(2), constraints=(/2: [/1 - /100]; tight)]

--- a/pkg/sql/opt/memo/testdata/stats/scan
+++ b/pkg/sql/opt/memo/testdata/stats/scan
@@ -815,13 +815,13 @@ SELECT * FROM hist WHERE f = '2019-10-30 23:00:00'::TIMESTAMPTZ
 ----
 index-join hist
  ├── columns: a:1(int) b:2(date) c:3(decimal) d:4(float) e:5(timestamp) f:6(timestamptz!null) g:7(string)
- ├── stats: [rows=1e-07, distinct(6)=1e-07, null(6)=0]
+ ├── stats: [rows=5e-10, distinct(6)=5e-10, null(6)=0]
  │   histogram(6)=
  ├── fd: ()-->(6)
  └── scan hist@idx_f
       ├── columns: f:6(timestamptz!null) rowid:8(int!null)
       ├── constraint: /6/8: [/'2019-10-30 23:00:00+00:00' - /'2019-10-30 23:00:00+00:00']
-      ├── stats: [rows=1e-07, distinct(6)=1e-07, null(6)=0]
+      ├── stats: [rows=5e-10, distinct(6)=5e-10, null(6)=0]
       │   histogram(6)=
       ├── key: (8)
       └── fd: ()-->(6)

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -2521,3 +2521,103 @@ select
       ├── c31:31 = 1 [type=bool, outer=(31), constraints=(/31: [/1 - /1]; tight), fd=()-->(31)]
       ├── c32:32 = 1 [type=bool, outer=(32), constraints=(/32: [/1 - /1]; tight), fd=()-->(32)]
       └── c33:33 = 1 [type=bool, outer=(33), constraints=(/33: [/1 - /1]; tight), fd=()-->(33)]
+
+# Regression test for #67573. Do not over-estimate row counts when columns
+# are highly correlated and selected values are very common according to the
+# histograms.
+exec-ddl
+CREATE TABLE ab (
+  a INT,
+  b INT,
+  c INT,
+  PRIMARY KEY (a,b,c)
+)
+----
+
+exec-ddl
+ALTER TABLE ab INJECT STATISTICS '[
+    {
+        "columns": [ "a" ],
+        "created_at": "2021-07-13 14:04:42.014148",
+        "distinct_count": 20000,
+        "histo_buckets": [
+            {
+                "distinct_range": 0,
+                "num_eq": 60000,
+                "num_range": 0,
+                "upper_bound": "1"
+            },
+            {
+                "distinct_range": 20000,
+                "num_eq": 20000,
+                "num_range": 20000,
+                "upper_bound": "40000"
+            }
+        ],
+        "histo_col_type": "INT8",
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 100000
+    },
+    {
+        "columns": [ "b" ],
+        "created_at": "2021-07-13 14:04:42.014148",
+        "distinct_count": 7000,
+        "histo_col_type": "",
+        "name": "__auto__",
+        "histo_buckets": [
+            {
+                "distinct_range": 0,
+                "num_eq": 7000,
+                "num_range": 0,
+                "upper_bound": "1"
+            },
+            {
+                "distinct_range": 7000,
+                "num_eq": 86000,
+                "num_range": 7000,
+                "upper_bound": "10000"
+            }
+        ],
+        "histo_col_type": "INT8",
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 100000
+    },
+    {
+        "columns": [ "a", "b" ],
+        "created_at": "2021-07-13 14:04:42.014148",
+        "distinct_count": 20000,
+        "histo_col_type": "",
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 100000
+    }
+]';
+----
+
+# Make sure the row count for the outer select is less than the row count
+# for the scan.
+norm
+SELECT * FROM ab WHERE a=1 AND b=1
+----
+select
+ ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ ├── stats: [rows=7000, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(1,2)=1, null(1,2)=0]
+ │   histogram(1)=  0 7000
+ │                <--- 1 -
+ │   histogram(2)=  0 7000
+ │                <--- 1 -
+ ├── key: (3)
+ ├── fd: ()-->(1,2)
+ ├── scan ab
+ │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── stats: [rows=100000, distinct(1)=20000, null(1)=0, distinct(2)=7000, null(2)=0, distinct(3)=10000, null(3)=0, distinct(1,2)=20000, null(1,2)=0]
+ │    │   histogram(1)=  0 60000 20000  20000
+ │    │                <---- 1 -------- 40000
+ │    │   histogram(2)=  0 7000 7000  86000
+ │    │                <--- 1 ------- 10000
+ │    └── key: (1-3)
+ └── filters
+      ├── a:1 = 1 [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
+      └── b:2 = 1 [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q20
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q20
@@ -62,27 +62,27 @@ sort
  ├── save-table-name: q20_sort_1
  ├── columns: s_name:2(char!null) s_address:3(varchar!null)
  ├── immutable
- ├── stats: [rows=2.01612903e-05, distinct(2)=2.01612903e-05, null(2)=0, distinct(3)=2.01612903e-05, null(3)=0]
+ ├── stats: [rows=1e-06, distinct(2)=1e-06, null(2)=0, distinct(3)=1e-06, null(3)=0]
  ├── ordering: +2
  └── project
       ├── save-table-name: q20_project_2
       ├── columns: s_name:2(char!null) s_address:3(varchar!null)
       ├── immutable
-      ├── stats: [rows=2.01612903e-05, distinct(2)=2.01612903e-05, null(2)=0, distinct(3)=2.01612903e-05, null(3)=0]
+      ├── stats: [rows=1e-06, distinct(2)=1e-06, null(2)=0, distinct(3)=1e-06, null(3)=0]
       └── inner-join (lookup nation)
            ├── save-table-name: q20_lookup_join_3
            ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_address:3(varchar!null) s_nationkey:4(int!null) n_nationkey:9(int!null) n_name:10(char!null)
            ├── key columns: [4] = [9]
            ├── lookup columns are key
            ├── immutable
-           ├── stats: [rows=2.01612903e-05, distinct(1)=2e-05, null(1)=0, distinct(2)=2.01612903e-05, null(2)=0, distinct(3)=2.01612903e-05, null(3)=0, distinct(4)=2.01612824e-05, null(4)=0, distinct(9)=2.01612824e-05, null(9)=0, distinct(10)=2.01612903e-05, null(10)=0]
+           ├── stats: [rows=1e-06, distinct(1)=1.24917659e-08, null(1)=0, distinct(2)=1e-06, null(2)=0, distinct(3)=1e-06, null(3)=0, distinct(4)=1e-06, null(4)=0, distinct(9)=1e-06, null(9)=0, distinct(10)=1e-06, null(10)=0]
            ├── key: (1)
            ├── fd: ()-->(10), (1)-->(2-4), (4)==(9), (9)==(4)
            ├── project
            │    ├── save-table-name: q20_project_4
            │    ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_address:3(varchar!null) s_nationkey:4(int!null)
            │    ├── immutable
-           │    ├── stats: [rows=2.01612903e-05, distinct(1)=2e-05, null(1)=0, distinct(2)=2.01612903e-05, null(2)=0, distinct(3)=2.01612903e-05, null(3)=0, distinct(4)=2.01612824e-05, null(4)=0]
+           │    ├── stats: [rows=1e-06, distinct(1)=1.24917659e-08, null(1)=0, distinct(2)=1e-06, null(2)=0, distinct(3)=1e-06, null(3)=0, distinct(4)=1e-06, null(4)=0]
            │    ├── key: (1)
            │    ├── fd: (1)-->(2-4)
            │    └── inner-join (lookup supplier)
@@ -91,7 +91,7 @@ sort
            │         ├── key columns: [15] = [1]
            │         ├── lookup columns are key
            │         ├── immutable
-           │         ├── stats: [rows=0.2, distinct(1)=2e-05, null(1)=0, distinct(2)=0.2, null(2)=0, distinct(3)=0.2, null(3)=0, distinct(4)=0.2, null(4)=0, distinct(15)=2e-05, null(15)=0]
+           │         ├── stats: [rows=0.000124917659, distinct(1)=1.24917659e-08, null(1)=0, distinct(2)=0.000124917659, null(2)=0, distinct(3)=0.000124917659, null(3)=0, distinct(4)=0.000124917659, null(4)=0, distinct(15)=1.24917659e-08, null(15)=0]
            │         ├── key: (15)
            │         ├── fd: (1)-->(2-4), (1)==(15), (15)==(1)
            │         ├── distinct-on
@@ -99,19 +99,19 @@ sort
            │         │    ├── columns: ps_suppkey:15(int!null)
            │         │    ├── grouping columns: ps_suppkey:15(int!null)
            │         │    ├── immutable
-           │         │    ├── stats: [rows=2e-05, distinct(15)=2e-05, null(15)=0]
+           │         │    ├── stats: [rows=1.24917659e-08, distinct(15)=1.24917659e-08, null(15)=0]
            │         │    ├── key: (15)
            │         │    └── project
            │         │         ├── save-table-name: q20_project_7
            │         │         ├── columns: ps_partkey:14(int!null) ps_suppkey:15(int!null)
            │         │         ├── immutable
-           │         │         ├── stats: [rows=2e-05, distinct(14)=2e-05, null(14)=0, distinct(15)=2e-05, null(15)=0]
+           │         │         ├── stats: [rows=1.24917659e-08, distinct(14)=2e-15, null(14)=0, distinct(15)=1.24917659e-08, null(15)=0]
            │         │         ├── key: (14,15)
            │         │         └── project
            │         │              ├── save-table-name: q20_project_8
            │         │              ├── columns: ps_partkey:14(int!null) ps_suppkey:15(int!null) p_partkey:20(int!null)
            │         │              ├── immutable
-           │         │              ├── stats: [rows=0.00249835317, distinct(14)=2e-05, null(14)=0, distinct(15)=0.00249835317, null(15)=0, distinct(20)=2e-05, null(20)=0]
+           │         │              ├── stats: [rows=2.49835317e-13, distinct(14)=2e-15, null(14)=0, distinct(15)=2.49835317e-13, null(15)=0, distinct(20)=2e-15, null(20)=0]
            │         │              ├── key: (15,20)
            │         │              ├── fd: (14)==(20), (20)==(14)
            │         │              └── inner-join (lookup part)
@@ -120,7 +120,7 @@ sort
            │         │                   ├── key columns: [14] = [20]
            │         │                   ├── lookup columns are key
            │         │                   ├── immutable
-           │         │                   ├── stats: [rows=0.00249835317, distinct(14)=2e-05, null(14)=0, distinct(15)=0.00249835317, null(15)=0, distinct(16)=0.00249835317, null(16)=0, distinct(20)=2e-05, null(20)=0, distinct(21)=7.51678871e-09, null(21)=0, distinct(47)=0.00249835317, null(47)=0]
+           │         │                   ├── stats: [rows=2.49835317e-13, distinct(14)=2e-15, null(14)=0, distinct(15)=2.49835317e-13, null(15)=0, distinct(16)=2.49835317e-13, null(16)=0, distinct(20)=2e-15, null(20)=0, distinct(21)=2e-15, null(21)=0, distinct(47)=2.49835317e-13, null(47)=0]
            │         │                   ├── key: (15,20)
            │         │                   ├── fd: (14,15)-->(16,47), (20)-->(21), (14)==(20), (20)==(14)
            │         │                   ├── select

--- a/pkg/sql/opt/props/selectivity.go
+++ b/pkg/sql/opt/props/selectivity.go
@@ -67,7 +67,7 @@ func (s *Selectivity) Divide(other Selectivity) {
 	s.selectivity = selectivityInRange(s.selectivity / other.selectivity)
 }
 
-// MinSelectivity returns the smaller value of two selectivities
+// MinSelectivity returns the smaller value of two selectivities.
 func MinSelectivity(a, b Selectivity) Selectivity {
 	if a.selectivity < b.selectivity {
 		return a

--- a/pkg/sql/opt/xform/testdata/external/fittings
+++ b/pkg/sql/opt/xform/testdata/external/fittings
@@ -2622,12 +2622,12 @@ project
            ├── columns: killmail:1!null
            ├── internal-ordering: -1
            ├── cardinality: [0 - 100]
-           ├── stats: [rows=0.0023556407]
+           ├── stats: [rows=5.22083488e-07]
            ├── key: (1)
            ├── ordering: -1
            ├── sort
            │    ├── columns: killmail:1!null
-           │    ├── stats: [rows=0.0023556407, distinct(12)=0.0023556407, null(12)=0]
+           │    ├── stats: [rows=5.22083488e-07, distinct(12)=5.22083488e-07, null(12)=0]
            │    │   histogram(12)=
            │    ├── key: (1)
            │    ├── ordering: -1
@@ -2636,7 +2636,7 @@ project
            │         ├── columns: killmail:1!null
            │         ├── inverted constraint: /12/1
            │         │    └── spans: ["7\x00\x03\x00\x01,\v_>\x00", "7\x00\x03\x00\x01,\v_>\x00"]
-           │         ├── stats: [rows=0.0023556407, distinct(12)=0.0023556407, null(12)=0]
+           │         ├── stats: [rows=5.22083488e-07, distinct(12)=5.22083488e-07, null(12)=0]
            │         │   histogram(12)=
            │         └── key: (1)
            └── 100

--- a/pkg/sql/opt/xform/testdata/external/tpce
+++ b/pkg/sql/opt/xform/testdata/external/tpce
@@ -2962,37 +2962,37 @@ project
  ├── key: (1)
  ├── fd: (1)-->(2,6,7,10,18,21,28,43,50), (6)-->(28,43)
  ├── ordering: -2
- ├── inner-join (lookup exchange)
+ ├── inner-join (lookup status_type)
  │    ├── columns: t_id:1!null t_dts:2!null t_st_id:3!null t_tt_id:4!null t_s_symb:6!null t_qty:7!null t_ca_id:9!null t_exec_name:10!null trade.t_chrg:12!null st_id:17!null st_name:18!null tt_id:20!null tt_name:21!null s_symb:25!null s_name:28!null s_ex_id:29!null ex_id:42!null ex_name:43!null
- │    ├── key columns: [29] = [42]
+ │    ├── key columns: [3] = [17]
  │    ├── lookup columns are key
  │    ├── cardinality: [0 - 50]
  │    ├── key: (1)
  │    ├── fd: ()-->(9), (1)-->(2-4,6,7,10,12), (17)-->(18), (3)==(17), (17)==(3), (20)-->(21), (4)==(20), (20)==(4), (25)-->(28,29), (42)-->(43), (29)==(42), (42)==(29), (6)==(25), (25)==(6)
  │    ├── ordering: -2 opt(9) [actual: -2]
- │    ├── inner-join (lookup security)
- │    │    ├── columns: t_id:1!null t_dts:2!null t_st_id:3!null t_tt_id:4!null t_s_symb:6!null t_qty:7!null t_ca_id:9!null t_exec_name:10!null trade.t_chrg:12!null st_id:17!null st_name:18!null tt_id:20!null tt_name:21!null s_symb:25!null s_name:28!null s_ex_id:29!null
- │    │    ├── key columns: [6] = [25]
+ │    ├── inner-join (lookup trade_type)
+ │    │    ├── columns: t_id:1!null t_dts:2!null t_st_id:3!null t_tt_id:4!null t_s_symb:6!null t_qty:7!null t_ca_id:9!null t_exec_name:10!null trade.t_chrg:12!null tt_id:20!null tt_name:21!null s_symb:25!null s_name:28!null s_ex_id:29!null ex_id:42!null ex_name:43!null
+ │    │    ├── key columns: [4] = [20]
  │    │    ├── lookup columns are key
  │    │    ├── cardinality: [0 - 50]
  │    │    ├── key: (1)
- │    │    ├── fd: ()-->(9), (17)-->(18), (20)-->(21), (1)-->(2-4,6,7,10,12), (25)-->(28,29), (6)==(25), (25)==(6), (4)==(20), (20)==(4), (3)==(17), (17)==(3)
+ │    │    ├── fd: ()-->(9), (20)-->(21), (1)-->(2-4,6,7,10,12), (25)-->(28,29), (42)-->(43), (29)==(42), (42)==(29), (6)==(25), (25)==(6), (4)==(20), (20)==(4)
  │    │    ├── ordering: -2 opt(9) [actual: -2]
- │    │    ├── inner-join (lookup status_type)
- │    │    │    ├── columns: t_id:1!null t_dts:2!null t_st_id:3!null t_tt_id:4!null t_s_symb:6!null t_qty:7!null t_ca_id:9!null t_exec_name:10!null trade.t_chrg:12!null st_id:17!null st_name:18!null tt_id:20!null tt_name:21!null
- │    │    │    ├── key columns: [3] = [17]
+ │    │    ├── inner-join (lookup exchange)
+ │    │    │    ├── columns: t_id:1!null t_dts:2!null t_st_id:3!null t_tt_id:4!null t_s_symb:6!null t_qty:7!null t_ca_id:9!null t_exec_name:10!null trade.t_chrg:12!null s_symb:25!null s_name:28!null s_ex_id:29!null ex_id:42!null ex_name:43!null
+ │    │    │    ├── key columns: [29] = [42]
  │    │    │    ├── lookup columns are key
  │    │    │    ├── cardinality: [0 - 50]
  │    │    │    ├── key: (1)
- │    │    │    ├── fd: ()-->(9), (1)-->(2-4,6,7,10,12), (17)-->(18), (3)==(17), (17)==(3), (20)-->(21), (4)==(20), (20)==(4)
+ │    │    │    ├── fd: ()-->(9), (1)-->(2-4,6,7,10,12), (25)-->(28,29), (42)-->(43), (29)==(42), (42)==(29), (6)==(25), (25)==(6)
  │    │    │    ├── ordering: -2 opt(9) [actual: -2]
- │    │    │    ├── inner-join (lookup trade_type)
- │    │    │    │    ├── columns: t_id:1!null t_dts:2!null t_st_id:3!null t_tt_id:4!null t_s_symb:6!null t_qty:7!null t_ca_id:9!null t_exec_name:10!null trade.t_chrg:12!null tt_id:20!null tt_name:21!null
- │    │    │    │    ├── key columns: [4] = [20]
+ │    │    │    ├── inner-join (lookup security)
+ │    │    │    │    ├── columns: t_id:1!null t_dts:2!null t_st_id:3!null t_tt_id:4!null t_s_symb:6!null t_qty:7!null t_ca_id:9!null t_exec_name:10!null trade.t_chrg:12!null s_symb:25!null s_name:28!null s_ex_id:29!null
+ │    │    │    │    ├── key columns: [6] = [25]
  │    │    │    │    ├── lookup columns are key
  │    │    │    │    ├── cardinality: [0 - 50]
  │    │    │    │    ├── key: (1)
- │    │    │    │    ├── fd: ()-->(9), (1)-->(2-4,6,7,10,12), (20)-->(21), (4)==(20), (20)==(4)
+ │    │    │    │    ├── fd: ()-->(9), (1)-->(2-4,6,7,10,12), (25)-->(28,29), (6)==(25), (25)==(6)
  │    │    │    │    ├── ordering: -2 opt(9) [actual: -2]
  │    │    │    │    ├── scan trade@secondary
  │    │    │    │    │    ├── columns: t_id:1!null t_dts:2!null t_st_id:3!null t_tt_id:4!null t_s_symb:6!null t_qty:7!null t_ca_id:9!null t_exec_name:10!null trade.t_chrg:12!null
@@ -3365,9 +3365,15 @@ project
  │    │    ├── limit hint: 20.00
  │    │    └── inner-join (cross)
  │    │         ├── columns: t_id:1!null t_dts:2!null t_tt_id:4!null t_is_cash:5!null t_s_symb:6!null t_qty:7!null t_ca_id:9!null t_exec_name:10!null trade.t_trade_price:11 tt_id:17!null tt_name:18!null s_symb:22!null s_name:25!null
- │    │         ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ │    │         ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
  │    │         ├── key: (1)
  │    │         ├── fd: ()-->(6,22,25), (1)-->(2,4,5,7,9-11), (17)-->(18), (4)==(17), (17)==(4)
+ │    │         ├── scan security
+ │    │         │    ├── columns: s_symb:22!null s_name:25!null
+ │    │         │    ├── constraint: /22: [/'SYMB' - /'SYMB']
+ │    │         │    ├── cardinality: [0 - 1]
+ │    │         │    ├── key: ()
+ │    │         │    └── fd: ()-->(22,25)
  │    │         ├── inner-join (lookup trade_type)
  │    │         │    ├── columns: t_id:1!null t_dts:2!null t_tt_id:4!null t_is_cash:5!null t_s_symb:6!null t_qty:7!null t_ca_id:9!null t_exec_name:10!null trade.t_trade_price:11 tt_id:17!null tt_name:18!null
  │    │         │    ├── key columns: [4] = [17]
@@ -3380,12 +3386,6 @@ project
  │    │         │    │    ├── key: (1)
  │    │         │    │    └── fd: ()-->(6), (1)-->(2,4,5,7,9-11)
  │    │         │    └── filters (true)
- │    │         ├── scan security
- │    │         │    ├── columns: s_symb:22!null s_name:25!null
- │    │         │    ├── constraint: /22: [/'SYMB' - /'SYMB']
- │    │         │    ├── cardinality: [0 - 1]
- │    │         │    ├── key: ()
- │    │         │    └── fd: ()-->(22,25)
  │    │         └── filters (true)
  │    └── 20
  └── projections

--- a/pkg/sql/opt/xform/testdata/external/trading
+++ b/pkg/sql/opt/xform/testdata/external/trading
@@ -550,7 +550,7 @@ FROM CardsView WHERE Version > 1584421773604892000.0000000000
 project
  ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null buyprice:10!null sellprice:11!null desiredinventory:13!null actualinventory:14!null version:16!null discount:12!null maxinventory:15!null
  ├── immutable
- ├── stats: [rows=1]
+ ├── stats: [rows=0.0115557548]
  ├── key: (16)
  ├── fd: (1)-->(2-6,10-16), (2,4,5)~~>(1,3,6), (16)-->(1-6,10-15)
  └── inner-join (lookup cards)
@@ -558,23 +558,23 @@ project
       ├── key columns: [9] = [1]
       ├── lookup columns are key
       ├── immutable
-      ├── stats: [rows=1, distinct(1)=0.0201621393, null(1)=0, distinct(9)=0.0201621393, null(9)=0]
+      ├── stats: [rows=0.0115557548, distinct(1)=2.02732541e-07, null(1)=0, distinct(9)=2.02732541e-07, null(9)=0]
       ├── key: (9)
       ├── fd: ()-->(8), (1)-->(2-6), (2,4,5)~~>(1,3,6), (9)-->(10-16), (16)-->(9-15), (1)==(9), (9)==(1)
       ├── index-join cardsinfo
       │    ├── columns: dealerid:8!null cardid:9!null buyprice:10!null sellprice:11!null discount:12!null desiredinventory:13!null actualinventory:14!null maxinventory:15!null version:16!null
       │    ├── immutable
-      │    ├── stats: [rows=0.0201621426, distinct(8)=0.0201621426, null(8)=0, distinct(9)=0.0201621393, null(9)=0, distinct(10)=0.02016214, null(10)=0, distinct(11)=0.02016214, null(11)=0, distinct(12)=0.02016214, null(12)=0, distinct(13)=0.02016214, null(13)=0, distinct(14)=0.02016214, null(14)=0, distinct(15)=0.02016214, null(15)=0, distinct(16)=0.0201621426, null(16)=0, distinct(8,16)=0.0201621426, null(8,16)=0]
-      │    │   histogram(16)=  0                0                 0.020162           0
-      │    │                 <--- 1584421773604892000.0000000000 ---------- 1584421778604892000
+      │    ├── stats: [rows=2.02732541e-07, distinct(8)=2.02732541e-07, null(8)=0, distinct(9)=2.02732541e-07, null(9)=0, distinct(10)=2.02732541e-07, null(10)=0, distinct(11)=2.02732541e-07, null(11)=0, distinct(12)=2.02732541e-07, null(12)=0, distinct(13)=2.02732541e-07, null(13)=0, distinct(14)=2.02732541e-07, null(14)=0, distinct(15)=2.02732541e-07, null(15)=0, distinct(16)=2.02732541e-07, null(16)=0, distinct(8,16)=2.02732541e-07, null(8,16)=0]
+      │    │   histogram(16)=  0                0                 2.0273e-07           0
+      │    │                 <--- 1584421773604892000.0000000000 ------------ 1584421778604892000
       │    ├── key: (9)
       │    ├── fd: ()-->(8), (9)-->(10-16), (16)-->(9-15)
       │    └── scan cardsinfo@cardsinfoversionindex
       │         ├── columns: dealerid:8!null cardid:9!null version:16!null
       │         ├── constraint: /8/16: (/1/1584421773604892000.0000000000 - /1]
-      │         ├── stats: [rows=0.0201621426, distinct(8)=0.0201621426, null(8)=0, distinct(9)=0.0201621426, null(9)=0, distinct(16)=0.0201621426, null(16)=0, distinct(8,16)=0.0201621426, null(8,16)=0]
-      │         │   histogram(16)=  0                0                 0.020162           0
-      │         │                 <--- 1584421773604892000.0000000000 ---------- 1584421778604892000
+      │         ├── stats: [rows=2.02732541e-07, distinct(8)=2.02732541e-07, null(8)=0, distinct(9)=2.02732541e-07, null(9)=0, distinct(16)=2.02732541e-07, null(16)=0, distinct(8,16)=2.02732541e-07, null(8,16)=0]
+      │         │   histogram(16)=  0                0                 2.0273e-07           0
+      │         │                 <--- 1584421773604892000.0000000000 ------------ 1584421778604892000
       │         ├── key: (9)
       │         └── fd: ()-->(8), (9)-->(16), (16)-->(9)
       └── filters (true)

--- a/pkg/sql/opt/xform/testdata/external/trading-mutation
+++ b/pkg/sql/opt/xform/testdata/external/trading-mutation
@@ -558,7 +558,7 @@ FROM CardsView WHERE Version > 1584421773604892000.0000000000
 project
  ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null buyprice:10!null sellprice:11!null desiredinventory:13!null actualinventory:14!null version:16!null discount:12!null maxinventory:15!null
  ├── immutable
- ├── stats: [rows=1]
+ ├── stats: [rows=5.1775e-06]
  ├── key: (16)
  ├── fd: (1)-->(2-6,10-16), (2,4,5)~~>(1,3,6), (16)-->(1-6,10-15)
  └── inner-join (lookup cards)
@@ -566,20 +566,20 @@ project
       ├── key columns: [9] = [1]
       ├── lookup columns are key
       ├── immutable
-      ├── stats: [rows=1, distinct(1)=6.35833333e-05, null(1)=0, distinct(9)=6.35833333e-05, null(9)=0]
+      ├── stats: [rows=5.1775e-06, distinct(1)=9.08333333e-11, null(1)=0, distinct(9)=9.08333333e-11, null(9)=0]
       ├── key: (9)
       ├── fd: ()-->(8), (1)-->(2-6), (2,4,5)~~>(1,3,6), (9)-->(10-16), (16)-->(9-15), (1)==(9), (9)==(1)
       ├── index-join cardsinfo
       │    ├── columns: dealerid:8!null cardid:9!null buyprice:10!null sellprice:11!null discount:12!null desiredinventory:13!null actualinventory:14!null maxinventory:15!null version:16!null
       │    ├── immutable
-      │    ├── stats: [rows=6.35833333e-05, distinct(8)=6.35833333e-05, null(8)=0, distinct(9)=6.35833333e-05, null(9)=0, distinct(10)=6.35833333e-05, null(10)=0, distinct(11)=6.35833333e-05, null(11)=0, distinct(12)=6.35833333e-05, null(12)=0, distinct(13)=6.35833333e-05, null(13)=0, distinct(14)=6.35833333e-05, null(14)=0, distinct(15)=6.35833333e-05, null(15)=0, distinct(16)=6.35833333e-05, null(16)=0, distinct(8,16)=6.35833333e-05, null(8,16)=0]
+      │    ├── stats: [rows=9.08333333e-11, distinct(8)=9.08333333e-11, null(8)=0, distinct(9)=9.08333333e-11, null(9)=0, distinct(10)=9.08333333e-11, null(10)=0, distinct(11)=9.08333333e-11, null(11)=0, distinct(12)=9.08333333e-11, null(12)=0, distinct(13)=9.08333333e-11, null(13)=0, distinct(14)=9.08333333e-11, null(14)=0, distinct(15)=9.08333333e-11, null(15)=0, distinct(16)=9.08333333e-11, null(16)=0, distinct(8,16)=9.08333333e-11, null(8,16)=0]
       │    │   histogram(16)=
       │    ├── key: (9)
       │    ├── fd: ()-->(8), (9)-->(10-16), (16)-->(9-15)
       │    └── scan cardsinfo@cardsinfoversionindex
       │         ├── columns: dealerid:8!null cardid:9!null version:16!null
       │         ├── constraint: /8/16: (/1/1584421773604892000.0000000000 - /1]
-      │         ├── stats: [rows=6.35833333e-05, distinct(8)=6.35833333e-05, null(8)=0, distinct(9)=6.35833333e-05, null(9)=0, distinct(16)=6.35833333e-05, null(16)=0, distinct(8,16)=6.35833333e-05, null(8,16)=0]
+      │         ├── stats: [rows=9.08333333e-11, distinct(8)=9.08333333e-11, null(8)=0, distinct(9)=9.08333333e-11, null(9)=0, distinct(16)=9.08333333e-11, null(16)=0, distinct(8,16)=9.08333333e-11, null(8,16)=0]
       │         │   histogram(16)=
       │         ├── key: (9)
       │         └── fd: ()-->(8), (9)-->(16), (16)-->(9)


### PR DESCRIPTION
Backport 1/1 commits from #67940.

/cc @cockroachdb/release

Release justification: This fixes a serious issue encountered by several customers that causes plans to significantly regress when using multi-column statistics.

---

This commit fixes row count estimation in cases where the predicate
has conditions on two or more columns that are highly correlated, and
the selected values are very common according to the histograms.

Fixes #67573

Release note (bug fix): Fixed an issue with statistics estimation in the
optimizer that could cause it to over-estimate the number of rows for some
expressions and thus choose a sub-optimal plan. This issue could happen
when multi-column statistics were used in combination with histograms, the
query contained a predicate on two or more columns where the columns were
hightly correlated, and the selected values were very common according to
the histograms.
