### PR TITLE
kvserver: simplify a test 

### DIFF
--- a/pkg/kv/kvserver/replica_rangefeed_test.go
+++ b/pkg/kv/kvserver/replica_rangefeed_test.go
@@ -1014,7 +1014,7 @@ func TestRangefeedCheckpointsRecoverFromLeaseExpiration(t *testing.T) {
 	var scratchRangeID int64 // accessed atomically
 	// nudgeSeen will be set if a request filter sees the signature of the
 	// rangefeed nudger, as proof that the expected mechanism kicked in.
-	var nudgeSeen bool
+	var nudgeSeen int64 // accessed atomically
 	// At some point, the test will require full control over the requests
 	// evaluating on the scratch range.
 	var rejectExtraneousRequests int64 // accessed atomically
@@ -1045,10 +1045,11 @@ func TestRangefeedCheckpointsRecoverFromLeaseExpiration(t *testing.T) {
 						return nil
 					}
 					if ba.IsSingleLeaseInfoRequest() {
-						nudgeSeen = true
+						atomic.StoreInt64(&nudgeSeen, 1)
 						return nil
 					}
-					if ba.IsLeaseRequest() {
+					nudged := atomic.LoadInt64(&nudgeSeen)
+					if ba.IsLeaseRequest() && (nudged == 1) {
 						return nil
 					}
 					log.Infof(ctx, "test rejecting request: %s", ba)
@@ -1142,7 +1143,8 @@ func TestRangefeedCheckpointsRecoverFromLeaseExpiration(t *testing.T) {
 	log.Infof(ctx, "test waiting for another checkpoint")
 	ts2 := n1.Clock().Now()
 	waitForCheckpoint(ts2)
-	require.True(t, nudgeSeen)
+	nudged := atomic.LoadInt64(&nudgeSeen)
+	require.Equal(t, int64(1), nudged)
 
 	// Check that n2 renewed its lease, like the test intended.
 	li, _, err := tc.FindRangeLeaseEx(ctx, desc, &n2Target)

--- a/pkg/kv/kvserver/replica_rangefeed_test.go
+++ b/pkg/kv/kvserver/replica_rangefeed_test.go
@@ -1058,8 +1058,7 @@ func TestRangefeedCheckpointsRecoverFromLeaseExpiration(t *testing.T) {
 			},
 		},
 	}
-	tci, _, _ := setupClusterForClosedTSTesting(ctx, t, testingTargetDuration,
-		testingCloseFraction, cargs, "cttest", "kv")
+	tci := serverutils.StartNewTestCluster(t, 2, cargs)
 	tc := tci.(*testcluster.TestCluster)
 	defer tc.Stopper().Stop(ctx)
 
@@ -1070,9 +1069,8 @@ func TestRangefeedCheckpointsRecoverFromLeaseExpiration(t *testing.T) {
 
 	sqlDB := sqlutils.MakeSQLRunner(tc.ServerConn(0))
 	sqlDB.Exec(t, `SET CLUSTER SETTING kv.rangefeed.enabled = true`)
-	// Drop the target closedts duration. This was set to testingTargetDuration
-	// above, but this is higher then it needs to be now that cluster and schema
-	// setup is complete.
+	// Drop the target closedts duration in order to speed up the rangefeed
+	// "nudging" once the range loses its lease.
 	sqlDB.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '10ms'`)
 
 	n1 := tc.Server(0)


### PR DESCRIPTION
The new TestRangefeedCheckpointsRecoverFromLeaseExpiration was using
unnecessary scaffolding. This change also makes it easier to backport to
20.2.

Release note: None