### PR TITLE
sql/parser: add syntax for ALTER ROLE ... SET

### DIFF
--- a/docs/generated/sql/bnf/alter_role_stmt.bnf
+++ b/docs/generated/sql/bnf/alter_role_stmt.bnf
@@ -7,3 +7,9 @@ alter_role_stmt ::=
 	| 'ALTER' 'ROLE' 'IF' 'EXISTS' name 
 	| 'ALTER' 'USER' 'IF' 'EXISTS' name opt_with role_options
 	| 'ALTER' 'USER' 'IF' 'EXISTS' name 
+	| 'ALTER' 'ROLE' name opt_in_database set_or_reset_clause
+	| 'ALTER' 'USER' name opt_in_database set_or_reset_clause
+	| 'ALTER' 'ROLE' 'IF' 'EXISTS' name opt_in_database set_or_reset_clause
+	| 'ALTER' 'USER' 'IF' 'EXISTS' name opt_in_database set_or_reset_clause
+	| 'ALTER' 'ROLE_ALL' 'ALL' opt_in_database set_or_reset_clause
+	| 'ALTER' 'USER_ALL' 'ALL' opt_in_database set_or_reset_clause

--- a/docs/generated/sql/bnf/set_rest.bnf
+++ b/docs/generated/sql/bnf/set_rest.bnf
@@ -1,0 +1,2 @@
+set_rest ::=
+	generic_set

--- a/docs/generated/sql/bnf/set_rest_more.bnf
+++ b/docs/generated/sql/bnf/set_rest_more.bnf
@@ -1,2 +1,2 @@
 set_rest_more ::=
-	generic_set
+	set_rest

--- a/docs/generated/sql/bnf/set_var.bnf
+++ b/docs/generated/sql/bnf/set_var.bnf
@@ -1,5 +1,5 @@
 preparable_set_stmt ::=
-	'SET' ( 'SESSION' | ) var_name '=' var_value ( ( ',' var_value ) )*
-	| 'SET' ( 'SESSION' | ) var_name 'TO' var_value ( ( ',' var_value ) )*
+	'SET' 'SESSION' set_rest
+	| 'SET' set_rest
 	| set_csetting_stmt
 	| use_stmt

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -384,6 +384,10 @@ alter_ddl_stmt ::=
 alter_role_stmt ::=
 	'ALTER' role_or_group_or_user string_or_placeholder opt_role_options
 	| 'ALTER' role_or_group_or_user 'IF' 'EXISTS' string_or_placeholder opt_role_options
+	| 'ALTER' role_or_group_or_user string_or_placeholder opt_in_database set_or_reset_clause
+	| 'ALTER' role_or_group_or_user 'IF' 'EXISTS' string_or_placeholder opt_in_database set_or_reset_clause
+	| 'ALTER' 'ROLE_ALL' 'ALL' opt_in_database set_or_reset_clause
+	| 'ALTER' 'USER_ALL' 'ALL' opt_in_database set_or_reset_clause
 
 opt_backup_targets ::=
 	targets
@@ -1324,6 +1328,15 @@ opt_role_options ::=
 	opt_with role_options
 	| 
 
+opt_in_database ::=
+	'IN' 'DATABASE' database_name
+	| 
+
+set_or_reset_clause ::=
+	'SET' set_rest
+	| 'RESET_ALL' 'ALL'
+	| 'RESET' session_var
+
 as_of_clause ::=
 	'AS' 'OF' 'SYSTEM' 'TIME' a_expr
 
@@ -1536,7 +1549,7 @@ opt_for_locking_clause ::=
 	| 
 
 set_rest_more ::=
-	generic_set
+	set_rest
 
 to_or_eq ::=
 	'='
@@ -1804,6 +1817,9 @@ abbreviated_revoke_stmt ::=
 
 role_options ::=
 	( role_option ) ( ( role_option ) )*
+
+set_rest ::=
+	generic_set
 
 backup_options ::=
 	'ENCRYPTION_PASSPHRASE' '=' string_or_placeholder
@@ -2088,9 +2104,6 @@ offset_clause ::=
 	'OFFSET' a_expr
 	| 'OFFSET' select_fetch_first_value row_or_rows
 
-generic_set ::=
-	var_name to_or_eq var_list
-
 extra_var_value ::=
 	'ON'
 	| cockroachdb_extra_reserved_keyword
@@ -2304,6 +2317,9 @@ role_option ::=
 	| password_clause
 	| valid_until_clause
 
+generic_set ::=
+	var_name to_or_eq var_list
+
 d_expr ::=
 	'ICONST'
 	| 'FCONST'
@@ -2513,9 +2529,6 @@ all_or_distinct ::=
 for_locking_item ::=
 	for_locking_strength opt_locked_rels opt_nowait_or_skip
 
-var_list ::=
-	( var_value ) ( ( ',' var_value ) )*
-
 opt_ordinality ::=
 	'WITH' 'ORDINALITY'
 	| 
@@ -2654,6 +2667,9 @@ password_clause ::=
 valid_until_clause ::=
 	'VALID' 'UNTIL' string_or_placeholder
 	| 'VALID' 'UNTIL' 'NULL'
+
+var_list ::=
+	( var_value ) ( ( ',' var_value ) )*
 
 typed_literal ::=
 	func_name_no_crdb_extra 'SCONST'

--- a/pkg/sql/lexbase/predicates.go
+++ b/pkg/sql/lexbase/predicates.go
@@ -55,6 +55,9 @@ func init() {
 		"similar",
 		"time",
 		"generated",
+		"reset",
+		"role",
+		"user",
 	} {
 		reservedOrLookaheadKeywords[s] = struct{}{}
 	}

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -521,7 +521,7 @@ vectorized: true
         │ group by: username
         │
         └── • sort
-            │ order: +role
+            │ order: +"role"
             │
             └── • hash join (left outer)
                 │ equality: (username) = (member)

--- a/pkg/sql/parser/lexer.go
+++ b/pkg/sql/parser/lexer.go
@@ -80,7 +80,7 @@ func (l *lexer) Lex(lval *sqlSymType) int {
 	*lval = l.tokens[l.lastPos]
 
 	switch lval.id {
-	case NOT, WITH, AS, GENERATED, NULLS:
+	case NOT, WITH, AS, GENERATED, NULLS, RESET, ROLE, USER:
 		nextID := int32(0)
 		if l.lastPos+1 < len(l.tokens) {
 			nextID = l.tokens[l.lastPos+1].id
@@ -113,6 +113,21 @@ func (l *lexer) Lex(lval *sqlSymType) int {
 			switch nextID {
 			case FIRST, LAST:
 				lval.id = NULLS_LA
+			}
+		case RESET:
+			switch nextID {
+			case ALL:
+				lval.id = RESET_ALL
+			}
+		case ROLE:
+			switch nextID {
+			case ALL:
+				lval.id = ROLE_ALL
+			}
+		case USER:
+			switch nextID {
+			case ALL:
+				lval.id = USER_ALL
 			}
 		}
 	}

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -711,6 +711,9 @@ func (u *sqlSymUnion) abbreviatedRevoke() tree.AbbreviatedRevoke {
 func (u *sqlSymUnion) alterDefaultPrivilegesTargetObject() tree.AlterDefaultPrivilegesTargetObject {
   return u.val.(tree.AlterDefaultPrivilegesTargetObject)
 }
+func (u *sqlSymUnion) setVar() *tree.SetVar {
+    return u.val.(*tree.SetVar)
+}
 %}
 
 // NB: the %token definitions must come before the %type definitions in this
@@ -843,8 +846,10 @@ func (u *sqlSymUnion) alterDefaultPrivilegesTargetObject() tree.AlterDefaultPriv
 // NOT, at least with respect to their left-hand subexpression. WITH_LA is
 // needed to make the grammar LALR(1). GENERATED_ALWAYS is needed to support
 // the Postgres syntax for computed columns along with our family related
-// extensions (CREATE FAMILY/CREATE FAMILY family_name).
-%token NOT_LA NULLS_LA WITH_LA AS_LA GENERATED_ALWAYS
+// extensions (CREATE FAMILY/CREATE FAMILY family_name). RESET_ALL is used
+// to differentiate `RESET var` from `RESET ALL`. ROLE_ALL and USER_ALL are
+// used in ALTER ROLE statements that affect all roles.
+%token NOT_LA NULLS_LA WITH_LA AS_LA GENERATED_ALWAYS RESET_ALL ROLE_ALL USER_ALL
 
 %union {
   id    int32
@@ -867,6 +872,7 @@ func (u *sqlSymUnion) alterDefaultPrivilegesTargetObject() tree.AlterDefaultPriv
 %type <tree.Statement> alter_range_stmt
 %type <tree.Statement> alter_partition_stmt
 %type <tree.Statement> alter_role_stmt
+%type <*tree.SetVar> set_or_reset_clause
 %type <tree.Statement> alter_type_stmt
 %type <tree.Statement> alter_schema_stmt
 %type <tree.Statement> alter_unsupported_stmt
@@ -1015,6 +1021,7 @@ func (u *sqlSymUnion) alterDefaultPrivilegesTargetObject() tree.AlterDefaultPriv
 %type <tree.Statement> set_exprs_internal
 %type <tree.Statement> generic_set
 %type <tree.Statement> set_rest_more
+%type <tree.Statement> set_rest
 %type <tree.Statement> set_names
 
 %type <tree.Statement> show_stmt
@@ -1124,7 +1131,7 @@ func (u *sqlSymUnion) alterDefaultPrivilegesTargetObject() tree.AlterDefaultPriv
 %type <*tree.UnresolvedName> func_name func_name_no_crdb_extra
 %type <str> opt_class opt_collate
 
-%type <str> cursor_name database_name index_name opt_index_name column_name insert_column_item statistics_name window_name
+%type <str> cursor_name database_name index_name opt_index_name column_name insert_column_item statistics_name window_name opt_in_database
 %type <str> family_name opt_family_name table_alias_name constraint_name target_name zone_name partition_name collation_name
 %type <str> db_object_name_component
 %type <*tree.UnresolvedObjectName> table_name db_name standalone_index_name sequence_name type_name view_name db_object_name simple_db_object_name complex_db_object_name
@@ -4564,7 +4571,7 @@ generic_set:
     }
   }
 
-set_rest_more:
+set_rest:
 // Generic SET syntaxes:
    generic_set
 // Special SET syntax forms in addition to the generic form.
@@ -4576,6 +4583,7 @@ set_rest_more:
     /* SKIP DOC */
     $$.val = &tree.SetVar{Name: "timezone", Values: tree.Exprs{$3.expr()}}
   }
+| var_name FROM CURRENT { return unimplemented(sqllex, "set from current") }
 // "SET SCHEMA 'value' is an alias for SET search_path TO value. Only
 // one schema can be specified using this syntax."
 | SCHEMA var_value
@@ -4583,6 +4591,10 @@ set_rest_more:
     /* SKIP DOC */
     $$.val = &tree.SetVar{Name: "search_path", Values: tree.Exprs{$2.expr()}}
   }
+
+set_rest_more:
+// SET syntaxes supported as a clause of other statements:
+  set_rest
 | SESSION AUTHORIZATION DEFAULT
   {
     /* SKIP DOC */
@@ -4594,7 +4606,6 @@ set_rest_more:
   }
 // See comment for the non-terminal for SET NAMES below.
 | set_names
-| var_name FROM CURRENT { return unimplemented(sqllex, "set from current") }
 | error // SHOW HELP: SET SESSION
 
 // SET NAMES is the SQL standard syntax for SET client_encoding.
@@ -7136,7 +7147,10 @@ create_role_stmt:
 
 // %Help: ALTER ROLE - alter a role
 // %Category: Priv
-// %Text: ALTER ROLE <name> [WITH] <options...>
+// %Text:
+// ALTER ROLE <name> [WITH] <options...>
+// ALTER ROLE { name | ALL } [ IN DATABASE database_name ] SET var { TO | = } { value | DEFAULT }
+// ALTER ROLE { name | ALL } [ IN DATABASE database_name ] RESET { var | ALL }
 // %SeeAlso: CREATE ROLE, DROP ROLE, SHOW ROLES
 alter_role_stmt:
   ALTER role_or_group_or_user string_or_placeholder opt_role_options
@@ -7147,7 +7161,47 @@ alter_role_stmt:
 {
   $$.val = &tree.AlterRole{Name: $5.expr(), IfExists: true, KVOptions: $6.kvOptions(), IsRole: $2.bool()}
 }
+| ALTER role_or_group_or_user string_or_placeholder opt_in_database set_or_reset_clause
+  {
+    $$.val = &tree.AlterRoleSet{RoleName: $3.expr(), DatabaseName: tree.Name($4), IsRole: $2.bool(), SetOrReset: $5.setVar()}
+  }
+| ALTER role_or_group_or_user IF EXISTS string_or_placeholder opt_in_database set_or_reset_clause
+  {
+    $$.val = &tree.AlterRoleSet{RoleName: $5.expr(), IfExists: true, DatabaseName: tree.Name($6), IsRole: $2.bool(), SetOrReset: $7.setVar()}
+  }
+| ALTER ROLE_ALL ALL opt_in_database set_or_reset_clause
+  {
+    $$.val = &tree.AlterRoleSet{AllRoles: true, DatabaseName: tree.Name($4), IsRole: true, SetOrReset: $5.setVar()}
+  }
+| ALTER USER_ALL ALL opt_in_database set_or_reset_clause
+  {
+    $$.val = &tree.AlterRoleSet{AllRoles: true, DatabaseName: tree.Name($4), IsRole: false, SetOrReset: $5.setVar()}
+  }
 | ALTER role_or_group_or_user error // SHOW HELP: ALTER ROLE
+
+opt_in_database:
+  IN DATABASE database_name
+  {
+    $$ = $3
+  }
+| /* EMPTY */
+  {
+    $$ = ""
+  }
+
+set_or_reset_clause:
+  SET set_rest
+  {
+    $$.val = $2.setVar()
+  }
+| RESET_ALL ALL
+  {
+    $$.val = &tree.SetVar{ResetAll: true}
+  }
+| RESET session_var
+  {
+    $$.val = &tree.SetVar{Name: $2, Values:tree.Exprs{tree.DefaultVal{}}}
+  }
 
 // "CREATE GROUP is now an alias for CREATE ROLE"
 // https://www.postgresql.org/docs/10/static/sql-creategroup.html

--- a/pkg/sql/parser/testdata/alter_user
+++ b/pkg/sql/parser/testdata/alter_user
@@ -80,3 +80,224 @@ ALTER ROLE ('foo') WITH NOCREATELOGIN -- fully parenthesized
 ALTER ROLE _ WITH NOCREATELOGIN -- literals removed
 ALTER ROLE '_' WITH NOCREATELOGIN -- UNEXPECTED REPARSED AST WITHOUT LITERALS
 ALTER ROLE 'foo' WITH NOCREATELOGIN -- identifiers removed
+
+parse
+ALTER USER foo SET search_path = 'abc'
+----
+ALTER USER 'foo' SET search_path = 'abc' -- normalized!
+ALTER USER ('foo') SET search_path = ('abc') -- fully parenthesized
+ALTER USER _ SET search_path = _ -- literals removed
+ALTER USER '_' SET search_path = _ -- UNEXPECTED REPARSED AST WITHOUT LITERALS
+ALTER USER 'foo' SET search_path = 'abc' -- identifiers removed
+
+parse
+ALTER USER foo SET application_name TO DEFAULT
+----
+ALTER USER 'foo' SET application_name = DEFAULT -- normalized!
+ALTER USER ('foo') SET application_name = (DEFAULT) -- fully parenthesized
+ALTER USER _ SET application_name = DEFAULT -- literals removed
+ALTER USER '_' SET application_name = DEFAULT -- UNEXPECTED REPARSED AST WITHOUT LITERALS
+ALTER USER 'foo' SET application_name = DEFAULT -- identifiers removed
+
+parse
+ALTER USER foo RESET server_encoding
+----
+ALTER USER 'foo' SET server_encoding = DEFAULT -- normalized!
+ALTER USER ('foo') SET server_encoding = (DEFAULT) -- fully parenthesized
+ALTER USER _ SET server_encoding = DEFAULT -- literals removed
+ALTER USER '_' SET server_encoding = DEFAULT -- UNEXPECTED REPARSED AST WITHOUT LITERALS
+ALTER USER 'foo' SET server_encoding = DEFAULT -- identifiers removed
+
+parse
+ALTER USER foo RESET ALL
+----
+ALTER USER 'foo' RESET ALL -- normalized!
+ALTER USER ('foo') RESET ALL -- fully parenthesized
+ALTER USER _ RESET ALL -- literals removed
+ALTER USER '_' RESET ALL -- UNEXPECTED REPARSED AST WITHOUT LITERALS
+ALTER USER 'foo' RESET ALL -- identifiers removed
+
+parse
+ALTER USER foo IN DATABASE d SET search_path = 'abc'
+----
+ALTER USER 'foo' IN DATABASE d SET search_path = 'abc' -- normalized!
+ALTER USER ('foo') IN DATABASE d SET search_path = ('abc') -- fully parenthesized
+ALTER USER _ IN DATABASE d SET search_path = _ -- literals removed
+ALTER USER '_' IN DATABASE d SET search_path = _ -- UNEXPECTED REPARSED AST WITHOUT LITERALS
+ALTER USER 'foo' IN DATABASE _ SET search_path = 'abc' -- identifiers removed
+
+parse
+ALTER USER foo IN DATABASE d SET application_name = DEFAULT
+----
+ALTER USER 'foo' IN DATABASE d SET application_name = DEFAULT -- normalized!
+ALTER USER ('foo') IN DATABASE d SET application_name = (DEFAULT) -- fully parenthesized
+ALTER USER _ IN DATABASE d SET application_name = DEFAULT -- literals removed
+ALTER USER '_' IN DATABASE d SET application_name = DEFAULT -- UNEXPECTED REPARSED AST WITHOUT LITERALS
+ALTER USER 'foo' IN DATABASE _ SET application_name = DEFAULT -- identifiers removed
+
+parse
+ALTER USER foo IN DATABASE d RESET server_encoding
+----
+ALTER USER 'foo' IN DATABASE d SET server_encoding = DEFAULT -- normalized!
+ALTER USER ('foo') IN DATABASE d SET server_encoding = (DEFAULT) -- fully parenthesized
+ALTER USER _ IN DATABASE d SET server_encoding = DEFAULT -- literals removed
+ALTER USER '_' IN DATABASE d SET server_encoding = DEFAULT -- UNEXPECTED REPARSED AST WITHOUT LITERALS
+ALTER USER 'foo' IN DATABASE _ SET server_encoding = DEFAULT -- identifiers removed
+
+parse
+ALTER USER foo IN DATABASE d RESET ALL
+----
+ALTER USER 'foo' IN DATABASE d RESET ALL -- normalized!
+ALTER USER ('foo') IN DATABASE d RESET ALL -- fully parenthesized
+ALTER USER _ IN DATABASE d RESET ALL -- literals removed
+ALTER USER '_' IN DATABASE d RESET ALL -- UNEXPECTED REPARSED AST WITHOUT LITERALS
+ALTER USER 'foo' IN DATABASE _ RESET ALL -- identifiers removed
+
+parse
+ALTER ROLE foo SET search_path = 'abc'
+----
+ALTER ROLE 'foo' SET search_path = 'abc' -- normalized!
+ALTER ROLE ('foo') SET search_path = ('abc') -- fully parenthesized
+ALTER ROLE _ SET search_path = _ -- literals removed
+ALTER ROLE '_' SET search_path = _ -- UNEXPECTED REPARSED AST WITHOUT LITERALS
+ALTER ROLE 'foo' SET search_path = 'abc' -- identifiers removed
+
+parse
+ALTER ROLE foo SET application_name = DEFAULT
+----
+ALTER ROLE 'foo' SET application_name = DEFAULT -- normalized!
+ALTER ROLE ('foo') SET application_name = (DEFAULT) -- fully parenthesized
+ALTER ROLE _ SET application_name = DEFAULT -- literals removed
+ALTER ROLE '_' SET application_name = DEFAULT -- UNEXPECTED REPARSED AST WITHOUT LITERALS
+ALTER ROLE 'foo' SET application_name = DEFAULT -- identifiers removed
+
+parse
+ALTER ROLE foo RESET server_encoding
+----
+ALTER ROLE 'foo' SET server_encoding = DEFAULT -- normalized!
+ALTER ROLE ('foo') SET server_encoding = (DEFAULT) -- fully parenthesized
+ALTER ROLE _ SET server_encoding = DEFAULT -- literals removed
+ALTER ROLE '_' SET server_encoding = DEFAULT -- UNEXPECTED REPARSED AST WITHOUT LITERALS
+ALTER ROLE 'foo' SET server_encoding = DEFAULT -- identifiers removed
+
+parse
+ALTER ROLE foo RESET ALL
+----
+ALTER ROLE 'foo' RESET ALL -- normalized!
+ALTER ROLE ('foo') RESET ALL -- fully parenthesized
+ALTER ROLE _ RESET ALL -- literals removed
+ALTER ROLE '_' RESET ALL -- UNEXPECTED REPARSED AST WITHOUT LITERALS
+ALTER ROLE 'foo' RESET ALL -- identifiers removed
+
+parse
+ALTER ROLE foo IN DATABASE d SET search_path = 'abc'
+----
+ALTER ROLE 'foo' IN DATABASE d SET search_path = 'abc' -- normalized!
+ALTER ROLE ('foo') IN DATABASE d SET search_path = ('abc') -- fully parenthesized
+ALTER ROLE _ IN DATABASE d SET search_path = _ -- literals removed
+ALTER ROLE '_' IN DATABASE d SET search_path = _ -- UNEXPECTED REPARSED AST WITHOUT LITERALS
+ALTER ROLE 'foo' IN DATABASE _ SET search_path = 'abc' -- identifiers removed
+
+parse
+ALTER ROLE foo IN DATABASE d SET application_name TO DEFAULT
+----
+ALTER ROLE 'foo' IN DATABASE d SET application_name = DEFAULT -- normalized!
+ALTER ROLE ('foo') IN DATABASE d SET application_name = (DEFAULT) -- fully parenthesized
+ALTER ROLE _ IN DATABASE d SET application_name = DEFAULT -- literals removed
+ALTER ROLE '_' IN DATABASE d SET application_name = DEFAULT -- UNEXPECTED REPARSED AST WITHOUT LITERALS
+ALTER ROLE 'foo' IN DATABASE _ SET application_name = DEFAULT -- identifiers removed
+
+parse
+ALTER ROLE foo IN DATABASE d RESET server_encoding
+----
+ALTER ROLE 'foo' IN DATABASE d SET server_encoding = DEFAULT -- normalized!
+ALTER ROLE ('foo') IN DATABASE d SET server_encoding = (DEFAULT) -- fully parenthesized
+ALTER ROLE _ IN DATABASE d SET server_encoding = DEFAULT -- literals removed
+ALTER ROLE '_' IN DATABASE d SET server_encoding = DEFAULT -- UNEXPECTED REPARSED AST WITHOUT LITERALS
+ALTER ROLE 'foo' IN DATABASE _ SET server_encoding = DEFAULT -- identifiers removed
+
+parse
+ALTER ROLE foo IN DATABASE d RESET ALL
+----
+ALTER ROLE 'foo' IN DATABASE d RESET ALL -- normalized!
+ALTER ROLE ('foo') IN DATABASE d RESET ALL -- fully parenthesized
+ALTER ROLE _ IN DATABASE d RESET ALL -- literals removed
+ALTER ROLE '_' IN DATABASE d RESET ALL -- UNEXPECTED REPARSED AST WITHOUT LITERALS
+ALTER ROLE 'foo' IN DATABASE _ RESET ALL -- identifiers removed
+
+parse
+ALTER ROLE IF EXISTS foo IN DATABASE d SET search_path = 'abc'
+----
+ALTER ROLE IF EXISTS 'foo' IN DATABASE d SET search_path = 'abc' -- normalized!
+ALTER ROLE IF EXISTS ('foo') IN DATABASE d SET search_path = ('abc') -- fully parenthesized
+ALTER ROLE IF EXISTS _ IN DATABASE d SET search_path = _ -- literals removed
+ALTER ROLE IF EXISTS '_' IN DATABASE d SET search_path = _ -- UNEXPECTED REPARSED AST WITHOUT LITERALS
+ALTER ROLE IF EXISTS 'foo' IN DATABASE _ SET search_path = 'abc' -- identifiers removed
+
+parse
+ALTER USER IF EXISTS foo SET application_name TO DEFAULT
+----
+ALTER USER IF EXISTS 'foo' SET application_name = DEFAULT -- normalized!
+ALTER USER IF EXISTS ('foo') SET application_name = (DEFAULT) -- fully parenthesized
+ALTER USER IF EXISTS _ SET application_name = DEFAULT -- literals removed
+ALTER USER IF EXISTS '_' SET application_name = DEFAULT -- UNEXPECTED REPARSED AST WITHOUT LITERALS
+ALTER USER IF EXISTS 'foo' SET application_name = DEFAULT -- identifiers removed
+
+parse
+ALTER ROLE IF EXISTS foo IN DATABASE d SET TIME ZONE 'UTC'
+----
+ALTER ROLE IF EXISTS 'foo' IN DATABASE d SET timezone = 'UTC' -- normalized!
+ALTER ROLE IF EXISTS ('foo') IN DATABASE d SET timezone = ('UTC') -- fully parenthesized
+ALTER ROLE IF EXISTS _ IN DATABASE d SET timezone = _ -- literals removed
+ALTER ROLE IF EXISTS '_' IN DATABASE d SET timezone = _ -- UNEXPECTED REPARSED AST WITHOUT LITERALS
+ALTER ROLE IF EXISTS 'foo' IN DATABASE _ SET timezone = 'UTC' -- identifiers removed
+
+parse
+ALTER USER IF EXISTS foo SET SCHEMA DEFAULT
+----
+ALTER USER IF EXISTS 'foo' SET search_path = DEFAULT -- normalized!
+ALTER USER IF EXISTS ('foo') SET search_path = (DEFAULT) -- fully parenthesized
+ALTER USER IF EXISTS _ SET search_path = DEFAULT -- literals removed
+ALTER USER IF EXISTS '_' SET search_path = DEFAULT -- UNEXPECTED REPARSED AST WITHOUT LITERALS
+ALTER USER IF EXISTS 'foo' SET search_path = DEFAULT -- identifiers removed
+
+parse
+ALTER ROLE IF EXISTS foo IN DATABASE d RESET TIME ZONE
+----
+ALTER ROLE IF EXISTS 'foo' IN DATABASE d SET timezone = DEFAULT -- normalized!
+ALTER ROLE IF EXISTS ('foo') IN DATABASE d SET timezone = (DEFAULT) -- fully parenthesized
+ALTER ROLE IF EXISTS _ IN DATABASE d SET timezone = DEFAULT -- literals removed
+ALTER ROLE IF EXISTS '_' IN DATABASE d SET timezone = DEFAULT -- UNEXPECTED REPARSED AST WITHOUT LITERALS
+ALTER ROLE IF EXISTS 'foo' IN DATABASE _ SET timezone = DEFAULT -- identifiers removed
+
+parse
+ALTER USER ALL SET application_name = 'app'
+----
+ALTER USER ALL SET application_name = 'app'
+ALTER USER ALL SET application_name = ('app') -- fully parenthesized
+ALTER USER ALL SET application_name = _ -- literals removed
+ALTER USER ALL SET application_name = 'app' -- identifiers removed
+
+parse
+ALTER USER ALL IN DATABASE d SET application_name = DEFAULT
+----
+ALTER USER ALL IN DATABASE d SET application_name = DEFAULT
+ALTER USER ALL IN DATABASE d SET application_name = (DEFAULT) -- fully parenthesized
+ALTER USER ALL IN DATABASE d SET application_name = DEFAULT -- literals removed
+ALTER USER ALL IN DATABASE _ SET application_name = DEFAULT -- identifiers removed
+
+parse
+ALTER ROLE ALL IN DATABASE d SET application_name = 'app'
+----
+ALTER ROLE ALL IN DATABASE d SET application_name = 'app'
+ALTER ROLE ALL IN DATABASE d SET application_name = ('app') -- fully parenthesized
+ALTER ROLE ALL IN DATABASE d SET application_name = _ -- literals removed
+ALTER ROLE ALL IN DATABASE _ SET application_name = 'app' -- identifiers removed
+
+parse
+ALTER ROLE ALL RESET ALL
+----
+ALTER ROLE ALL RESET ALL
+ALTER ROLE ALL RESET ALL -- fully parenthesized
+ALTER ROLE ALL RESET ALL -- literals removed
+ALTER ROLE ALL RESET ALL -- identifiers removed

--- a/pkg/sql/parser/testdata/backup_restore
+++ b/pkg/sql/parser/testdata/backup_restore
@@ -28,10 +28,10 @@ BACKUP TO 'bar' -- identifiers removed
 parse
 BACKUP role TO 'bar'
 ----
-BACKUP TABLE role TO 'bar' -- normalized!
-BACKUP TABLE (role) TO ('bar') -- fully parenthesized
-BACKUP TABLE role TO _ -- literals removed
-BACKUP TABLE role TO '_' -- UNEXPECTED REPARSED AST WITHOUT LITERALS
+BACKUP TABLE "role" TO 'bar' -- normalized!
+BACKUP TABLE ("role") TO ('bar') -- fully parenthesized
+BACKUP TABLE "role" TO _ -- literals removed
+BACKUP TABLE "role" TO '_' -- UNEXPECTED REPARSED AST WITHOUT LITERALS
 BACKUP TABLE _ TO 'bar' -- identifiers removed
 
 parse

--- a/pkg/sql/parser/testdata/grant_revoke
+++ b/pkg/sql/parser/testdata/grant_revoke
@@ -37,9 +37,9 @@ GRANT SELECT, DELETE, UPDATE ON TABLE _, _._ TO _, _ -- identifiers removed
 parse
 GRANT SELECT ON role TO root
 ----
-GRANT SELECT ON TABLE role TO root -- normalized!
-GRANT SELECT ON TABLE (role) TO root -- fully parenthesized
-GRANT SELECT ON TABLE role TO root -- literals removed
+GRANT SELECT ON TABLE "role" TO root -- normalized!
+GRANT SELECT ON TABLE ("role") TO root -- fully parenthesized
+GRANT SELECT ON TABLE "role" TO root -- literals removed
 GRANT SELECT ON TABLE _ TO _ -- identifiers removed
 
 parse

--- a/pkg/sql/parser/testdata/show
+++ b/pkg/sql/parser/testdata/show
@@ -1253,18 +1253,18 @@ SHOW GRANTS ON TABLE _ -- identifiers removed
 parse
 SHOW GRANTS ON "role"
 ----
-SHOW GRANTS ON TABLE role -- normalized!
-SHOW GRANTS ON TABLE (role) -- fully parenthesized
-SHOW GRANTS ON TABLE role -- literals removed
+SHOW GRANTS ON TABLE "role" -- normalized!
+SHOW GRANTS ON TABLE ("role") -- fully parenthesized
+SHOW GRANTS ON TABLE "role" -- literals removed
 SHOW GRANTS ON TABLE _ -- identifiers removed
 
 
 parse
 SHOW GRANTS ON role, foo
 ----
-SHOW GRANTS ON TABLE role, foo -- normalized!
-SHOW GRANTS ON TABLE (role), (foo) -- fully parenthesized
-SHOW GRANTS ON TABLE role, foo -- literals removed
+SHOW GRANTS ON TABLE "role", foo -- normalized!
+SHOW GRANTS ON TABLE ("role"), (foo) -- fully parenthesized
+SHOW GRANTS ON TABLE "role", foo -- literals removed
 SHOW GRANTS ON TABLE _, _ -- identifiers removed
 
 parse
@@ -1286,33 +1286,33 @@ SHOW GRANTS ON TABLE _, _._ -- identifiers removed
 parse
 SHOW GRANTS ON "role", foo
 ----
-SHOW GRANTS ON TABLE role, foo -- normalized!
-SHOW GRANTS ON TABLE (role), (foo) -- fully parenthesized
-SHOW GRANTS ON TABLE role, foo -- literals removed
+SHOW GRANTS ON TABLE "role", foo -- normalized!
+SHOW GRANTS ON TABLE ("role"), (foo) -- fully parenthesized
+SHOW GRANTS ON TABLE "role", foo -- literals removed
 SHOW GRANTS ON TABLE _, _ -- identifiers removed
 
 parse
 SHOW GRANTS ON "role".foo
 ----
-SHOW GRANTS ON TABLE role.foo -- normalized!
-SHOW GRANTS ON TABLE (role.foo) -- fully parenthesized
-SHOW GRANTS ON TABLE role.foo -- literals removed
+SHOW GRANTS ON TABLE "role".foo -- normalized!
+SHOW GRANTS ON TABLE ("role".foo) -- fully parenthesized
+SHOW GRANTS ON TABLE "role".foo -- literals removed
 SHOW GRANTS ON TABLE _._ -- identifiers removed
 
 parse
 SHOW GRANTS ON role.foo
 ----
-SHOW GRANTS ON TABLE role.foo -- normalized!
-SHOW GRANTS ON TABLE (role.foo) -- fully parenthesized
-SHOW GRANTS ON TABLE role.foo -- literals removed
+SHOW GRANTS ON TABLE "role".foo -- normalized!
+SHOW GRANTS ON TABLE ("role".foo) -- fully parenthesized
+SHOW GRANTS ON TABLE "role".foo -- literals removed
 SHOW GRANTS ON TABLE _._ -- identifiers removed
 
 parse
 SHOW GRANTS ON role.*
 ----
-SHOW GRANTS ON TABLE role.* -- normalized!
-SHOW GRANTS ON TABLE (role.*) -- fully parenthesized
-SHOW GRANTS ON TABLE role.* -- literals removed
+SHOW GRANTS ON TABLE "role".* -- normalized!
+SHOW GRANTS ON TABLE ("role".*) -- fully parenthesized
+SHOW GRANTS ON TABLE "role".* -- literals removed
 SHOW GRANTS ON TABLE _.* -- identifiers removed
 
 parse

--- a/pkg/sql/sem/tree/BUILD.bazel
+++ b/pkg/sql/sem/tree/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "alter_database.go",
         "alter_default_privileges.go",
         "alter_index.go",
+        "alter_role.go",
         "alter_schema.go",
         "alter_sequence.go",
         "alter_table.go",

--- a/pkg/sql/sem/tree/alter_role.go
+++ b/pkg/sql/sem/tree/alter_role.go
@@ -1,0 +1,73 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tree
+
+// AlterRole represents an `ALTER ROLE ... WITH options` statement.
+type AlterRole struct {
+	Name      Expr
+	IfExists  bool
+	IsRole    bool
+	KVOptions KVOptions
+}
+
+// Format implements the NodeFormatter interface.
+func (node *AlterRole) Format(ctx *FmtCtx) {
+	ctx.WriteString("ALTER")
+	if node.IsRole {
+		ctx.WriteString(" ROLE ")
+	} else {
+		ctx.WriteString(" USER ")
+	}
+	if node.IfExists {
+		ctx.WriteString("IF EXISTS ")
+	}
+	ctx.FormatNode(node.Name)
+
+	if len(node.KVOptions) > 0 {
+		ctx.WriteString(" WITH")
+		node.KVOptions.formatAsRoleOptions(ctx)
+	}
+}
+
+// AlterRoleSet represents an `ALTER ROLE ... SET` statement.
+type AlterRoleSet struct {
+	RoleName     Expr
+	IfExists     bool
+	IsRole       bool
+	AllRoles     bool
+	DatabaseName Name
+	SetOrReset   *SetVar
+}
+
+// Format implements the NodeFormatter interface.
+func (node *AlterRoleSet) Format(ctx *FmtCtx) {
+	ctx.WriteString("ALTER")
+	if node.IsRole {
+		ctx.WriteString(" ROLE ")
+	} else {
+		ctx.WriteString(" USER ")
+	}
+	if node.IfExists {
+		ctx.WriteString("IF EXISTS ")
+	}
+	if node.AllRoles {
+		ctx.WriteString("ALL ")
+	} else {
+		ctx.FormatNode(node.RoleName)
+		ctx.WriteString(" ")
+	}
+	if node.DatabaseName != "" {
+		ctx.WriteString("IN DATABASE ")
+		ctx.FormatNode(&node.DatabaseName)
+		ctx.WriteString(" ")
+	}
+	ctx.FormatNode(node.SetOrReset)
+}

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -1771,33 +1771,6 @@ func (node *CreateRole) Format(ctx *FmtCtx) {
 	}
 }
 
-// AlterRole represents an ALTER ROLE statement.
-type AlterRole struct {
-	Name      Expr
-	IfExists  bool
-	IsRole    bool
-	KVOptions KVOptions
-}
-
-// Format implements the NodeFormatter interface.
-func (node *AlterRole) Format(ctx *FmtCtx) {
-	ctx.WriteString("ALTER")
-	if node.IsRole {
-		ctx.WriteString(" ROLE ")
-	} else {
-		ctx.WriteString(" USER ")
-	}
-	if node.IfExists {
-		ctx.WriteString("IF EXISTS ")
-	}
-	ctx.FormatNode(node.Name)
-
-	if len(node.KVOptions) > 0 {
-		ctx.WriteString(" WITH")
-		node.KVOptions.formatAsRoleOptions(ctx)
-	}
-}
-
 // CreateView represents a CREATE VIEW statement.
 type CreateView struct {
 	Name         TableName

--- a/pkg/sql/sem/tree/set.go
+++ b/pkg/sql/sem/tree/set.go
@@ -21,12 +21,17 @@ package tree
 
 // SetVar represents a SET or RESET statement.
 type SetVar struct {
-	Name   string
-	Values Exprs
+	Name     string
+	Values   Exprs
+	ResetAll bool
 }
 
 // Format implements the NodeFormatter interface.
 func (node *SetVar) Format(ctx *FmtCtx) {
+	if node.ResetAll {
+		ctx.WriteString("RESET ALL")
+		return
+	}
 	ctx.WriteString("SET ")
 	if node.Name == "" {
 		ctx.WriteString("ROW (")

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -333,9 +333,18 @@ func (*AlterRole) StatementType() StatementType { return TypeDDL }
 // StatementTag returns a short string identifying the type of statement.
 func (*AlterRole) StatementTag() string { return "ALTER ROLE" }
 
-func (*AlterRole) cclOnlyStatement() {}
-
 func (*AlterRole) hiddenFromShowQueries() {}
+
+// StatementReturnType implements the Statement interface.
+func (*AlterRoleSet) StatementReturnType() StatementReturnType { return Ack }
+
+// StatementType implements the Statement interface.
+func (*AlterRoleSet) StatementType() StatementType { return TypeDDL }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*AlterRoleSet) StatementTag() string { return "ALTER ROLE" }
+
+func (*AlterRoleSet) hiddenFromShowQueries() {}
 
 // StatementReturnType implements the Statement interface.
 func (*Analyze) StatementReturnType() StatementReturnType { return DDL }
@@ -1570,6 +1579,7 @@ func (n *AlterTableOwner) String() string                { return AsString(n) }
 func (n *AlterTableSetSchema) String() string            { return AsString(n) }
 func (n *AlterType) String() string                      { return AsString(n) }
 func (n *AlterRole) String() string                      { return AsString(n) }
+func (n *AlterRoleSet) String() string                   { return AsString(n) }
 func (n *AlterSequence) String() string                  { return AsString(n) }
 func (n *Analyze) String() string                        { return AsString(n) }
 func (n *Backup) String() string                         { return AsString(n) }


### PR DESCRIPTION
touches https://github.com/cockroachdb/cockroach/issues/21151

Note that the telemetry re-parsing logic does not work. This is
consistent with the existing ALTER ROLE statement, and should be fixed
separately.

Release note (sql change): Add syntax for `ALTER ROLE ... SET`
statements. The business logic for these statements is not implemented
yet, but a later commit will add it. The following forms are supported:

- ALTER ROLE { name | ALL } [ IN DATABASE database_name ] SET var { TO | = } { value | DEFAULT }
- ALTER ROLE { name | ALL } [ IN DATABASE database_name ] RESET var
- ALTER ROLE { name | ALL } [ IN DATABASE database_name ] RESET ALL

As with other statements, the keywords ROLE and USER are interchangeable.

This matches the PostgreSQL syntax: https://www.postgresql.org/docs/13/sql-alterrole.html