### PR TITLE
sql: fix misuse of tracing API for enabling slow txn tracing

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -493,3 +493,11 @@ SET backslash_quote = 'off';
 
 statement error invalid value for parameter "backslash_quote"
 SET backslash_quote = '123';
+
+# Regression test for not being able to set sql.trace.txn.enable_threshold
+# cluster setting to non-zero value (#68005).
+statement ok
+SET cluster setting sql.trace.txn.enable_threshold='1s'
+
+statement ok
+SET cluster setting sql.trace.txn.enable_threshold='0s'

--- a/pkg/sql/txn_state.go
+++ b/pkg/sql/txn_state.go
@@ -164,9 +164,11 @@ func (ts *txnState) resetForNewSQLTxn(
 
 	var txnCtx context.Context
 	var sp *tracing.Span
-	if alreadyRecording || ts.testingForceRealTracingSpans {
+	duration := traceTxnThreshold.Get(&tranCtx.settings.SV)
+	if alreadyRecording || ts.testingForceRealTracingSpans || duration > 0 {
 		// WithForceRealSpan is used to support the use of session tracing,
-		// which will start recording on this span.
+		// which will start recording on this span. Similarly, it enables the
+		// tracing of the txns that exceed the duration threshold.
 		txnCtx, sp = createRootOrChildSpan(connCtx, opName, tranCtx.tracer, tracing.WithForceRealSpan())
 	} else {
 		txnCtx, sp = createRootOrChildSpan(connCtx, opName, tranCtx.tracer)
@@ -175,7 +177,6 @@ func (ts *txnState) resetForNewSQLTxn(
 		sp.SetTag("implicit", "true")
 	}
 
-	duration := traceTxnThreshold.Get(&tranCtx.settings.SV)
 	if !alreadyRecording && (duration > 0) {
 		sp.SetVerbose(true)
 		ts.recordingThreshold = duration


### PR DESCRIPTION
We were misusing the tracing API a bit when performing the tracing of
the slow txns. Namely, it was possible that the context has a Noop
tracing span attached to it and we would try to make that span verbose.
This is prohibited which resulted in a crash of the node. The fix is
simple - force the real span all the time whenever the slow txn
tracing is enabled.

Fixes: https://github.com/cockroachlabs/support/issues/1117.
Fixes: #68005.

Release note (bug fix): Previously, CockroachDB node would crash whenever
the cluster setting `sql.trace.txn.enable_threshold` was changed to
non-zero value. The bug was introduced in 21.1.