### PR TITLE
changefeedccl: option to load sarama config from JSON file

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -102,6 +102,8 @@ go_library(
         "//pkg/util/timeutil",
         "//pkg/util/tracing",
         "//pkg/util/uuid",
+        "@com_github_aws_aws_sdk_go//aws/session",
+        "@com_github_aws_aws_sdk_go//service/s3",
         "@com_github_cockroachdb_apd_v2//:apd",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",
@@ -109,6 +111,7 @@ go_library(
         "@com_github_linkedin_goavro_v2//:goavro",
         "@com_github_shopify_sarama//:sarama",
         "@com_github_xdg_scram//:scram",
+        "@com_google_cloud_go_storage//:storage",
     ],
 )
 

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -2647,6 +2647,22 @@ func TestChangefeedErrors(t *testing.T) {
 		t, `client has run out of available brokers`,
 		`CREATE CHANGEFEED FOR foo INTO 'kafka://nope/' WITH kafka_sink_config='{"Flush": {"Messages": 100, "Frequency": "1s"}}'`,
 	)
+	sqlDB.ExpectErr(
+		t, `cannot specify both kafka_sink_config and kafka_sink_config_file`,
+		`CREATE CHANGEFEED FOR foo INTO 'kafka://nope/' WITH kafka_sink_config='{"Flush": {"Messages": 100, "Frequency": "1s"}}', kafka_sink_config_file='cfg.json'`,
+	)
+	sqlDB.ExpectErr(
+		t, `failed to parse sarama config; check kafka_sink_config_file option: 'not a file' could not be recognized as a valid filepath, S3 path or GCS path`,
+		`CREATE CHANGEFEED FOR foo INTO 'kafka://nope/' WITH kafka_sink_config_file='not a file'`,
+	)
+	sqlDB.ExpectErr(
+		t, `failed to parse sarama config; check kafka_sink_config_file option: 'invalid-scheme://nope' could not be recognized as a valid filepath, S3 path or GCS path`,
+		`CREATE CHANGEFEED FOR foo INTO 'kafka://nope/' WITH kafka_sink_config_file='invalid-scheme://nope'`,
+	)
+	sqlDB.ExpectErr(
+		t, `failed to parse sarama config; check kafka_sink_config_file option: 'file_dne.json' could not be recognized as a valid filepath, S3 path or GCS path`,
+		`CREATE CHANGEFEED FOR foo INTO 'kafka://nope/' WITH kafka_sink_config_file='file_dne.json'`,
+	)
 	// The avro format doesn't support key_in_value or topic_in_value yet.
 	sqlDB.ExpectErr(
 		t, `key_in_value is not supported with format=experimental_avro`,

--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -89,7 +89,8 @@ const (
 	OptFormatNative FormatType = `native`
 
 	// OptKafkaSinkConfig is a JSON configuration for kafka sink (kafkaSinkConfig).
-	OptKafkaSinkConfig = `kafka_sink_config`
+	OptKafkaSinkConfig     = `kafka_sink_config`
+	OptKafkaSinkConfigFile = `kafka_sink_config_file`
 
 	SinkParamCACert                 = `ca_cert`
 	SinkParamClientCert             = `client_cert`
@@ -110,8 +111,10 @@ const (
 	SinkSchemeExperimentalSQL       = `experimental-sql`
 	SinkSchemeHTTP                  = `http`
 	SinkSchemeHTTPS                 = `https`
+	SinkSchemeGCS                   = `gs`
 	SinkSchemeKafka                 = `kafka`
 	SinkSchemeNull                  = `null`
+	SinkSchemeS3                    = `s3`
 	SinkSchemeWebhookHTTP           = `webhook-http`
 	SinkSchemeWebhookHTTPS          = `webhook-https`
 	SinkParamSASLEnabled            = `sasl_enabled`
@@ -145,6 +148,7 @@ var ChangefeedOptionExpectValues = map[string]sql.KVStringOptValidate{
 	OptNoInitialScan:            sql.KVStringOptRequireNoValue,
 	OptProtectDataFromGCOnPause: sql.KVStringOptRequireNoValue,
 	OptKafkaSinkConfig:          sql.KVStringOptRequireValue,
+	OptKafkaSinkConfigFile:      sql.KVStringOptRequireValue,
 	OptWebhookAuthHeader:        sql.KVStringOptRequireValue,
 	OptWebhookClientTimeout:     sql.KVStringOptRequireValue,
 }

--- a/pkg/ccl/changefeedccl/sink_kafka.go
+++ b/pkg/ccl/changefeedccl/sink_kafka.go
@@ -14,11 +14,16 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
 
+	"cloud.google.com/go/storage"
 	"github.com/Shopify/sarama"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -468,10 +473,110 @@ func parseRequiredAcks(a string) (sarama.RequiredAcks, error) {
 	}
 }
 
+func parseBucketURL(path string, scheme string) (bool, string, string, error) {
+	u, err := url.Parse(path)
+	if err != nil || u.Scheme != scheme {
+		return false, "", "", err
+	}
+	// trim the leading slash to get the object/key of the bucket
+	return true, u.Host, strings.TrimLeft(u.Path, "/"), nil
+}
+
+func getSaramaConfigFromS3(bucket string, key string, config *saramaConfig) error {
+	// load default AWS config (credentials, region) from disk
+	sess := session.Must(session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+	}))
+
+	s3Client := s3.New(sess)
+	res, err := s3Client.GetObject(&s3.GetObjectInput{
+		Bucket: &bucket,
+		Key:    &key,
+	})
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	configBytes, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(configBytes, config)
+}
+
+func getSaramaConfigFromGCS(bucket string, object string, config *saramaConfig) error {
+	ctx := context.Background()
+	gcsClient, err := storage.NewClient(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err := gcsClient.Close()
+		if err != nil {
+			log.Warningf(ctx, "error encountered while closing GCS client: %v", err)
+		}
+	}()
+
+	reader, err := gcsClient.Bucket(bucket).Object(object).NewReader(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err := reader.Close()
+		if err != nil {
+			log.Warningf(ctx, "error encountered while closing GCS reader: %v", err)
+		}
+	}()
+
+	configBytes, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(configBytes, config)
+}
+
+// getSaramaConfigFromFile reads a sarama config from JSON contained at path
+// and stores it in config.
+func getSaramaConfigFromFile(path string, config *saramaConfig) error {
+	var err error
+	var configBytes []byte
+	var bucket, key, object string
+	var isS3, isGCS bool
+	if configBytes, err = ioutil.ReadFile(path); err == nil {
+		err = json.Unmarshal(configBytes, config)
+	} else if isS3, bucket, key, err = parseBucketURL(path, changefeedbase.SinkSchemeS3); isS3 {
+		if err == nil {
+			err = getSaramaConfigFromS3(bucket, key, config)
+		}
+	} else if isGCS, bucket, object, err = parseBucketURL(path, changefeedbase.SinkSchemeGCS); isGCS {
+		if err == nil {
+			err = getSaramaConfigFromGCS(bucket, object, config)
+		}
+	} else {
+		err = fmt.Errorf("'%s' could not be recognized as a valid filepath, S3 path or GCS path", path)
+	}
+	return err
+}
+
 func getSaramaConfig(opts map[string]string) (config *saramaConfig, err error) {
 	config = defaultSaramaConfig()
-	if configStr, haveOverride := opts[changefeedbase.OptKafkaSinkConfig]; haveOverride {
+	configStr, haveOverride := opts[changefeedbase.OptKafkaSinkConfig]
+	configStrFile, haveOverrideFile := opts[changefeedbase.OptKafkaSinkConfigFile]
+	if haveOverride && haveOverrideFile {
+		err = fmt.Errorf("cannot specify both %s and %s", changefeedbase.OptKafkaSinkConfig, changefeedbase.OptKafkaSinkConfigFile)
+	} else if haveOverride {
 		err = json.Unmarshal([]byte(configStr), config)
+		if err != nil {
+			err = errors.Wrapf(err,
+				"failed to parse sarama config; check %s option", changefeedbase.OptKafkaSinkConfig)
+		}
+	} else if haveOverrideFile {
+		err = getSaramaConfigFromFile(configStrFile, config)
+		if err != nil {
+			err = errors.Wrapf(err,
+				"failed to parse sarama config; check %s option", changefeedbase.OptKafkaSinkConfigFile)
+		}
 	}
 	return
 }
@@ -610,8 +715,7 @@ func buildKafkaConfig(u sinkURL, opts map[string]string) (*sarama.Config, error)
 	// Apply statement level overrides.
 	saramaCfg, err := getSaramaConfig(opts)
 	if err != nil {
-		return nil, errors.Wrapf(err,
-			"failed to parse sarama config; check %s option", changefeedbase.OptKafkaSinkConfig)
+		return nil, err
 	}
 
 	if err := saramaCfg.Validate(); err != nil {


### PR DESCRIPTION
Previously, the option `kafka_sink_config` only allowed passing
JSON over the command line. This change adds a new option
`kafka_sink_config_file` to pass a filename containing the sarama
config. Both local files and cloud storage files (S3/GCS) are
supported.

Release note: Adds option `kafka_sink_config_file` to pass sarama
config via JSON file (local/S3/GCS).