### PR TITLE
opt: improve CanBeCompositeSensitive

### DIFF
--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -1605,7 +1605,6 @@ SELECT (SELECT m FROM
 with &1
  ├── columns: m:29(int)
  ├── volatile, mutations
- ├── fd: ()-->(29)
  ├── prune: (29)
  ├── project
  │    ├── columns: uv.u:6(int!null) uv.v:7(int!null)
@@ -1637,7 +1636,6 @@ with &1
  │                   └── function: unique_rowid [type=int]
  └── project
       ├── columns: m:29(int)
-      ├── fd: ()-->(29)
       ├── prune: (29)
       ├── scan uv
       └── projections

--- a/pkg/sql/opt/memo/testdata/logprops/project
+++ b/pkg/sql/opt/memo/testdata/logprops/project
@@ -284,7 +284,6 @@ project
            └── project
                 ├── columns: exists:18(bool)
                 ├── outer: (1)
-                ├── fd: ()-->(18)
                 ├── prune: (18)
                 ├── scan xysd
                 │    ├── columns: x:6(int!null) y:7(int) s:8(string) d:9(decimal!null) xysd.crdb_internal_mvcc_timestamp:10(decimal) xysd.tableoid:11(oid)

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -4241,7 +4241,7 @@ FROM a
 ----
 project
  ├── columns: a:29!null x:30 y:31 b:32 exists:33 count:34!null
- ├── fd: ()-->(29,31-33)
+ ├── fd: ()-->(29)
  ├── group-by
  │    ├── columns: k:1!null xy.x:8 count_rows:28!null
  │    ├── grouping columns: k:1!null

--- a/pkg/sql/opt/norm/testdata/rules/inline
+++ b/pkg/sql/opt/norm/testdata/rules/inline
@@ -986,7 +986,6 @@ SELECT EXISTS(SELECT * FROM xy WHERE x=1 OR x=2), expr*2 AS r FROM (SELECT k+1 A
 project
  ├── columns: exists:13 r:14!null
  ├── immutable
- ├── fd: ()-->(13)
  ├── scan a
  │    ├── columns: k:1!null
  │    └── key: (1)

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -1433,7 +1433,6 @@ SELECT (SELECT i_name FROM item LIMIT 1)
 ----
 project
  ├── columns: i_name:57
- ├── fd: ()-->(57)
  ├── inner-join (hash)
  │    ├── columns: h_data:9!null ol_o_id:12!null ol_d_id:13!null ol_w_id:14!null ol_number:15!null ol_dist_info:21!null true_agg:48
  │    ├── fd: (12-15)-->(21,48), (9)==(21), (21)==(9)

--- a/pkg/sql/opt/norm/testdata/rules/project
+++ b/pkg/sql/opt/norm/testdata/rules/project
@@ -950,7 +950,6 @@ SELECT (SELECT x FROM (VALUES (1), (2)) f(x)) FROM (VALUES (2), (3))
 project
  ├── columns: x:3
  ├── cardinality: [2 - 2]
- ├── fd: ()-->(3)
  ├── values
  │    ├── cardinality: [2 - 2]
  │    ├── ()

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -1691,14 +1691,14 @@ project
  │    │    ├── columns: c.k:1!null b.k:8!null array:22 canary:25!null
  │    │    ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
  │    │    ├── key: (8)
- │    │    ├── fd: ()-->(22,25), (1)==(8), (8)==(1)
+ │    │    ├── fd: ()-->(25), (8)-->(22), (1)==(8), (8)==(1)
  │    │    ├── scan a [as=c]
  │    │    │    ├── columns: c.k:1!null
  │    │    │    └── key: (1)
  │    │    ├── project
  │    │    │    ├── columns: canary:25!null array:22 b.k:8!null
  │    │    │    ├── key: (8)
- │    │    │    ├── fd: ()-->(22,25)
+ │    │    │    ├── fd: ()-->(25), (8)-->(22)
  │    │    │    ├── scan a [as=b]
  │    │    │    │    ├── columns: b.k:8!null
  │    │    │    │    └── key: (8)
@@ -1796,7 +1796,6 @@ SELECT ARRAY(SELECT k FROM a) FROM a
 ----
 project
  ├── columns: array:15
- ├── fd: ()-->(15)
  ├── scan a
  └── projections
       └── array-flatten [as=array:15, subquery]

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -1664,162 +1664,79 @@ union
 
 norm expect=PushFilterIntoSetOp
 SELECT * FROM
-  (SELECT k FROM b
-    UNION ALL
-  SELECT k FROM b) t1
-  WHERE EXISTS(
-  SELECT * FROM a WHERE k=1)
-----
-union-all
- ├── columns: k:15!null
- ├── left columns: b.k:1
- ├── right columns: b.k:8
- ├── select
- │    ├── columns: b.k:1!null
- │    ├── key: (1)
- │    ├── scan b
- │    │    ├── columns: b.k:1!null
- │    │    └── key: (1)
- │    └── filters
- │         └── exists [subquery]
- │              └── select
- │                   ├── columns: a.k:16!null a.i:17 a.f:18 a.s:19 a.j:20
- │                   ├── cardinality: [0 - 1]
- │                   ├── key: ()
- │                   ├── fd: ()-->(16-20)
- │                   ├── scan a
- │                   │    ├── columns: a.k:16!null a.i:17 a.f:18 a.s:19 a.j:20
- │                   │    ├── key: (16)
- │                   │    └── fd: (16)-->(17-20)
- │                   └── filters
- │                        └── a.k:16 = 1 [outer=(16), constraints=(/16: [/1 - /1]; tight), fd=()-->(16)]
- └── select
-      ├── columns: b.k:8!null
-      ├── key: (8)
-      ├── scan b
-      │    ├── columns: b.k:8!null
-      │    └── key: (8)
-      └── filters
-           └── exists [subquery]
-                └── select
-                     ├── columns: a.k:16!null a.i:17 a.f:18 a.s:19 a.j:20
-                     ├── cardinality: [0 - 1]
-                     ├── key: ()
-                     ├── fd: ()-->(16-20)
-                     ├── scan a
-                     │    ├── columns: a.k:16!null a.i:17 a.f:18 a.s:19 a.j:20
-                     │    ├── key: (16)
-                     │    └── fd: (16)-->(17-20)
-                     └── filters
-                          └── a.k:16 = 1 [outer=(16), constraints=(/16: [/1 - /1]; tight), fd=()-->(16)]
-
-norm expect=PushFilterIntoSetOp
-SELECT * FROM
 (SELECT k FROM (SELECT k FROM b UNION ALL SELECT k FROM b)
   UNION ALL
   SELECT k FROM (SELECT k FROM b UNION ALL SELECT k FROM b)) t1
 WHERE EXISTS(
   SELECT * FROM a WHERE k=1) AND random() < 0.5
 ----
-union-all
+select
  ├── columns: k:31!null
- ├── left columns: k:15
- ├── right columns: k:30
  ├── volatile
  ├── union-all
- │    ├── columns: k:15!null
- │    ├── left columns: b.k:1
- │    ├── right columns: b.k:8
+ │    ├── columns: k:31!null
+ │    ├── left columns: k:15
+ │    ├── right columns: k:30
  │    ├── volatile
- │    ├── select
- │    │    ├── columns: b.k:1!null
+ │    ├── union-all
+ │    │    ├── columns: k:15!null
+ │    │    ├── left columns: b.k:1
+ │    │    ├── right columns: b.k:8
  │    │    ├── volatile
- │    │    ├── key: (1)
- │    │    ├── scan b
+ │    │    ├── select
  │    │    │    ├── columns: b.k:1!null
- │    │    │    └── key: (1)
- │    │    └── filters
- │    │         ├── exists [subquery]
- │    │         │    └── select
- │    │         │         ├── columns: a.k:32!null a.i:33 a.f:34 a.s:35 a.j:36
- │    │         │         ├── cardinality: [0 - 1]
- │    │         │         ├── key: ()
- │    │         │         ├── fd: ()-->(32-36)
- │    │         │         ├── scan a
- │    │         │         │    ├── columns: a.k:32!null a.i:33 a.f:34 a.s:35 a.j:36
- │    │         │         │    ├── key: (32)
- │    │         │         │    └── fd: (32)-->(33-36)
- │    │         │         └── filters
- │    │         │              └── a.k:32 = 1 [outer=(32), constraints=(/32: [/1 - /1]; tight), fd=()-->(32)]
- │    │         └── random() < 0.5 [volatile]
- │    └── select
- │         ├── columns: b.k:8!null
+ │    │    │    ├── volatile
+ │    │    │    ├── key: (1)
+ │    │    │    ├── scan b
+ │    │    │    │    ├── columns: b.k:1!null
+ │    │    │    │    └── key: (1)
+ │    │    │    └── filters
+ │    │    │         └── random() < 0.5 [volatile]
+ │    │    └── select
+ │    │         ├── columns: b.k:8!null
+ │    │         ├── volatile
+ │    │         ├── key: (8)
+ │    │         ├── scan b
+ │    │         │    ├── columns: b.k:8!null
+ │    │         │    └── key: (8)
+ │    │         └── filters
+ │    │              └── random() < 0.5 [volatile]
+ │    └── union-all
+ │         ├── columns: k:30!null
+ │         ├── left columns: b.k:16
+ │         ├── right columns: b.k:23
  │         ├── volatile
- │         ├── key: (8)
- │         ├── scan b
- │         │    ├── columns: b.k:8!null
- │         │    └── key: (8)
- │         └── filters
- │              ├── exists [subquery]
- │              │    └── select
- │              │         ├── columns: a.k:32!null a.i:33 a.f:34 a.s:35 a.j:36
- │              │         ├── cardinality: [0 - 1]
- │              │         ├── key: ()
- │              │         ├── fd: ()-->(32-36)
- │              │         ├── scan a
- │              │         │    ├── columns: a.k:32!null a.i:33 a.f:34 a.s:35 a.j:36
- │              │         │    ├── key: (32)
- │              │         │    └── fd: (32)-->(33-36)
- │              │         └── filters
- │              │              └── a.k:32 = 1 [outer=(32), constraints=(/32: [/1 - /1]; tight), fd=()-->(32)]
- │              └── random() < 0.5 [volatile]
- └── union-all
-      ├── columns: k:30!null
-      ├── left columns: b.k:16
-      ├── right columns: b.k:23
-      ├── volatile
-      ├── select
-      │    ├── columns: b.k:16!null
-      │    ├── volatile
-      │    ├── key: (16)
-      │    ├── scan b
-      │    │    ├── columns: b.k:16!null
-      │    │    └── key: (16)
-      │    └── filters
-      │         ├── exists [subquery]
-      │         │    └── select
-      │         │         ├── columns: a.k:32!null a.i:33 a.f:34 a.s:35 a.j:36
-      │         │         ├── cardinality: [0 - 1]
-      │         │         ├── key: ()
-      │         │         ├── fd: ()-->(32-36)
-      │         │         ├── scan a
-      │         │         │    ├── columns: a.k:32!null a.i:33 a.f:34 a.s:35 a.j:36
-      │         │         │    ├── key: (32)
-      │         │         │    └── fd: (32)-->(33-36)
-      │         │         └── filters
-      │         │              └── a.k:32 = 1 [outer=(32), constraints=(/32: [/1 - /1]; tight), fd=()-->(32)]
-      │         └── random() < 0.5 [volatile]
-      └── select
-           ├── columns: b.k:23!null
-           ├── volatile
-           ├── key: (23)
-           ├── scan b
-           │    ├── columns: b.k:23!null
-           │    └── key: (23)
-           └── filters
-                ├── exists [subquery]
-                │    └── select
-                │         ├── columns: a.k:32!null a.i:33 a.f:34 a.s:35 a.j:36
-                │         ├── cardinality: [0 - 1]
-                │         ├── key: ()
-                │         ├── fd: ()-->(32-36)
-                │         ├── scan a
-                │         │    ├── columns: a.k:32!null a.i:33 a.f:34 a.s:35 a.j:36
-                │         │    ├── key: (32)
-                │         │    └── fd: (32)-->(33-36)
-                │         └── filters
-                │              └── a.k:32 = 1 [outer=(32), constraints=(/32: [/1 - /1]; tight), fd=()-->(32)]
-                └── random() < 0.5 [volatile]
+ │         ├── select
+ │         │    ├── columns: b.k:16!null
+ │         │    ├── volatile
+ │         │    ├── key: (16)
+ │         │    ├── scan b
+ │         │    │    ├── columns: b.k:16!null
+ │         │    │    └── key: (16)
+ │         │    └── filters
+ │         │         └── random() < 0.5 [volatile]
+ │         └── select
+ │              ├── columns: b.k:23!null
+ │              ├── volatile
+ │              ├── key: (23)
+ │              ├── scan b
+ │              │    ├── columns: b.k:23!null
+ │              │    └── key: (23)
+ │              └── filters
+ │                   └── random() < 0.5 [volatile]
+ └── filters
+      └── exists [subquery]
+           └── select
+                ├── columns: a.k:32!null a.i:33 a.f:34 a.s:35 a.j:36
+                ├── cardinality: [0 - 1]
+                ├── key: ()
+                ├── fd: ()-->(32-36)
+                ├── scan a
+                │    ├── columns: a.k:32!null a.i:33 a.f:34 a.s:35 a.j:36
+                │    ├── key: (32)
+                │    └── fd: (32)-->(33-36)
+                └── filters
+                     └── a.k:32 = 1 [outer=(32), constraints=(/32: [/1 - /1]; tight), fd=()-->(32)]
 
 # No-op case because the filter references outer columns.
 norm expect-not=PushFilterIntoSetOp

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -4832,7 +4832,6 @@ SELECT count(*), (SELECT count(*) FROM q) FROM (
 with &1 (q)
  ├── columns: count:31!null count:43
  ├── immutable
- ├── fd: ()-->(43)
  ├── select
  │    ├── columns: nyc_census_blocks.gid:1!null nyc_census_blocks.blkid:2 nyc_census_blocks.popn_total:3 nyc_census_blocks.popn_white:4 nyc_census_blocks.popn_black:5 nyc_census_blocks.popn_nativ:6 nyc_census_blocks.popn_asian:7 nyc_census_blocks.popn_other:8 nyc_census_blocks.boroname:9!null nyc_census_blocks.geom:10
  │    ├── key: (1)
@@ -4846,7 +4845,6 @@ with &1 (q)
  └── project
       ├── columns: count:43 count_rows:31!null
       ├── immutable
-      ├── fd: ()-->(43)
       ├── group-by
       │    ├── columns: n.boroname:25 count_rows:31!null
       │    ├── grouping columns: n.boroname:25


### PR DESCRIPTION
The current implementation of CanBeCompositeSensitive can be quadratic
in the expression size because each node builds the entire set of
outer columns for that subtree.

This change reworks the code and defines the logical property that we
were approximating by checking the outer cols directly. This also
reveals a bug in the previous version which did not detect relational
subtrees when there are no outer columns.

Release note: None