### PR TITLE
release-20.2: kvserver: fix bug causing stuck closed timestamps

### DIFF
--- a/pkg/roachpb/batch.go
+++ b/pkg/roachpb/batch.go
@@ -207,6 +207,16 @@ func (ba *BatchRequest) IsSingleAbortTxnRequest() bool {
 	return false
 }
 
+func (ba *BatchRequest) isSingleRequestWithMethod(m Method) bool {
+	return ba.IsSingleRequest() && ba.Requests[0].GetInner().Method() == m
+}
+
+// IsSingleLeaseInfoRequest returns true iff the batch contains a single
+// request, and that request is a LeaseInfoRequest.
+func (ba *BatchRequest) IsSingleLeaseInfoRequest() bool {
+	return ba.isSingleRequestWithMethod(LeaseInfo)
+}
+
 // IsSingleSubsumeRequest returns true iff the batch contains a single request,
 // and that request is an SubsumeRequest.
 func (ba *BatchRequest) IsSingleSubsumeRequest() bool {


### PR DESCRIPTION
Backport 1/2 commits from #67952.

/cc @cockroachdb/release

----

r.ensureClosedTimestampStarted() was broken when we made non-leader
replicas refuse to acquire leases. This function was relying on a lease
being acquire if there's no valid lease, and in the case where the
leader was elsewhere it wasn't getting what it wanted. As a result,
rangefeeds (which use this method to "nudge" the range into sending
closed timestamp updates) were stuck because closed timestamp updates
were not generated - timestamps are not closed when there's no lease.
Because they weren't getting closed timestamp updates, rangefeeds were
not generating resolved timestamp updates, and so data (from other
ranges) was being endlessly buffered.

The fix is to force a lease acquisition by performing a read on the
respective range.

Release note (bug fix): A bug causing changefeeds to sometimes get stuck
was fixed.