### PR TITLE
bazel: bazelfy logging documentation

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -114,6 +114,8 @@ load("@bazel_gazelle//:def.bzl", "gazelle")
 # gazelle:exclude pkg/sql/schemachanger/scop/mutation_visitor_generated.go
 # gazelle:exclude pkg/sql/schemachanger/scop/validation_visitor_generated.go
 # gazelle:exclude pkg/util/log/channel/channel_generated.go
+# gazelle:exclude pkg/util/log/eventpb/eventlog_channels_generated.go
+# gazelle:exclude pkg/util/log/eventpb/json_encode_generated.go
 # gazelle:exclude pkg/util/log/log_channels_generated.go
 # gazelle:exclude pkg/util/log/severity/severity_generated.go
 # gazelle:exclude pkg/util/timeutil/lowercase_timezones_generated.go

--- a/docs/generated/BUILD.bazel
+++ b/docs/generated/BUILD.bazel
@@ -1,3 +1,5 @@
+load("//pkg/util/log/eventpb:PROTOS.bzl", _EVENTPB_PROTO_LOCATIONS = "EVENTPB_PROTO_LOCATIONS")
+
 genrule(
     name = "gen-logging-md",
     srcs = [
@@ -11,4 +13,51 @@ genrule(
     exec_tools = [
         "//pkg/util/log/gen",
     ],
+)
+
+genrule(
+    name = "gen-logsinks-md",
+    srcs = [
+        "//pkg/util/log/logconfig:config.go",
+    ],
+    outs = ["logsinks.md"],
+    cmd = """
+    $(location //pkg/util/log/logconfig:gen) < $(location //pkg/util/log/logconfig:config.go) > $(location logsinks.md)
+    """,
+    exec_tools = [
+        "//pkg/util/log/logconfig:gen",
+    ],
+)
+
+genrule(
+    name = "gen-eventlog-md",
+    srcs = [
+        "//pkg/util/log/eventpb:cluster_events.proto",
+        "//pkg/util/log/eventpb:ddl_events.proto",
+        "//pkg/util/log/eventpb:events.proto",
+        "//pkg/util/log/eventpb:health_events.proto",
+        "//pkg/util/log/eventpb:job_events.proto",
+        "//pkg/util/log/eventpb:misc_sql_events.proto",
+        "//pkg/util/log/eventpb:privilege_events.proto",
+        "//pkg/util/log/eventpb:role_events.proto",
+        "//pkg/util/log/eventpb:session_events.proto",
+        "//pkg/util/log/eventpb:sql_audit_events.proto",
+        "//pkg/util/log/eventpb:zone_events.proto",
+    ],
+    outs = ["eventlog.md"],
+    cmd = """
+    $(location //pkg/util/log/eventpb:gen) eventlog.md \
+        {} \
+        >$(location eventlog.md)
+    """.format(_EVENTPB_PROTO_LOCATIONS),
+    exec_tools = [
+        "//pkg/util/log/eventpb:gen",
+    ],
+)
+
+genrule(
+    name = "gen-logformats-md",
+    outs = ["logformats.md"],
+    cmd = "$(location //pkg/cmd/docgen) logformats $(location logformats.md)",
+    exec_tools = ["//pkg/cmd/docgen"],
 )

--- a/pkg/util/log/eventpb/BUILD.bazel
+++ b/pkg/util/log/eventpb/BUILD.bazel
@@ -1,20 +1,48 @@
+load("//pkg/util/log/eventpb:PROTOS.bzl", _EVENTPB_PROTO_LOCATIONS = "EVENTPB_PROTO_LOCATIONS")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+
+exports_files([
+    "cluster_events.proto",
+    "ddl_events.proto",
+    "events.proto",
+    "health_events.proto",
+    "job_events.proto",
+    "misc_sql_events.proto",
+    "privilege_events.proto",
+    "role_events.proto",
+    "session_events.proto",
+    "sql_audit_events.proto",
+    "zone_events.proto",
+])
+
+go_binary(
+    name = "gen",
+    srcs = ["gen.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/util/log/eventpb",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/cli/exit",
+        "//pkg/util/log/logpb",
+        "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_gostdlib//go/format",
+    ],
+)
 
 go_library(
     name = "eventpb",
     srcs = [
         "doc.go",
-        "eventlog_channels_generated.go",
         "events.go",
-        "json_encode_generated.go",
+        ":gen-eventlog-channels-generated-go",  # keep
+        ":gen-json-encode-generated-go",  # keep
     ],
     embed = [":eventpb_go_proto"],
     importpath = "github.com/cockroachdb/cockroach/pkg/util/log/eventpb",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/util/jsonbytes",
+        "//pkg/util/jsonbytes",  # keep
         "//pkg/util/log/logpb",
         "@com_github_cockroachdb_redact//:redact",
     ],
@@ -61,4 +89,56 @@ go_proto_library(
     proto = ":eventpb_proto",
     visibility = ["//visibility:public"],
     deps = ["@com_github_gogo_protobuf//gogoproto"],
+)
+
+genrule(
+    name = "gen-eventlog-channels-generated-go",
+    srcs = [
+        "//pkg/util/log/eventpb:cluster_events.proto",
+        "//pkg/util/log/eventpb:ddl_events.proto",
+        "//pkg/util/log/eventpb:events.proto",
+        "//pkg/util/log/eventpb:health_events.proto",
+        "//pkg/util/log/eventpb:job_events.proto",
+        "//pkg/util/log/eventpb:misc_sql_events.proto",
+        "//pkg/util/log/eventpb:privilege_events.proto",
+        "//pkg/util/log/eventpb:role_events.proto",
+        "//pkg/util/log/eventpb:session_events.proto",
+        "//pkg/util/log/eventpb:sql_audit_events.proto",
+        "//pkg/util/log/eventpb:zone_events.proto",
+    ],
+    outs = ["eventlog_channels_generated.go"],
+    cmd = """
+    $(location //pkg/util/log/eventpb:gen) eventlog_channels_go \
+        {} \
+        >$(location eventlog_channels_generated.go)
+    """.format(_EVENTPB_PROTO_LOCATIONS),
+    exec_tools = [
+        "//pkg/util/log/eventpb:gen",
+    ],
+)
+
+genrule(
+    name = "gen-json-encode-generated-go",
+    srcs = [
+        "//pkg/util/log/eventpb:cluster_events.proto",
+        "//pkg/util/log/eventpb:ddl_events.proto",
+        "//pkg/util/log/eventpb:events.proto",
+        "//pkg/util/log/eventpb:health_events.proto",
+        "//pkg/util/log/eventpb:job_events.proto",
+        "//pkg/util/log/eventpb:misc_sql_events.proto",
+        "//pkg/util/log/eventpb:privilege_events.proto",
+        "//pkg/util/log/eventpb:role_events.proto",
+        "//pkg/util/log/eventpb:session_events.proto",
+        "//pkg/util/log/eventpb:sql_audit_events.proto",
+        "//pkg/util/log/eventpb:zone_events.proto",
+    ],
+    outs = ["json_encode_generated.go"],
+    cmd = """
+    $(location //pkg/util/log/eventpb:gen) json_encode_go \
+        {} \
+        >$(location json_encode_generated.go)
+    """.format(_EVENTPB_PROTO_LOCATIONS),
+    exec_tools = [
+        "//pkg/util/log/eventpb:gen",
+    ],
 )

--- a/pkg/util/log/eventpb/PROTOS.bzl
+++ b/pkg/util/log/eventpb/PROTOS.bzl
@@ -1,0 +1,6 @@
+# NOTE(ricky): Unfortunately multiple doc rules need this list of protos in a
+# very specific order or else builds will fail or produce incorrect results. I
+# capture that list here so we only have one thing to update when a new proto is
+# added to this directory.
+
+EVENTPB_PROTO_LOCATIONS = """$(location //pkg/util/log/eventpb:events.proto) $(location //pkg/util/log/eventpb:ddl_events.proto) $(location //pkg/util/log/eventpb:misc_sql_events.proto) $(location //pkg/util/log/eventpb:privilege_events.proto) $(location //pkg/util/log/eventpb:role_events.proto) $(location //pkg/util/log/eventpb:zone_events.proto) $(location //pkg/util/log/eventpb:session_events.proto) $(location //pkg/util/log/eventpb:sql_audit_events.proto) $(location //pkg/util/log/eventpb:cluster_events.proto) $(location //pkg/util/log/eventpb:job_events.proto) $(location //pkg/util/log/eventpb:health_events.proto)"""

--- a/pkg/util/log/eventpb/gen.go
+++ b/pkg/util/log/eventpb/gen.go
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-// +build ignore
+// +build bazel
 
 package main
 

--- a/pkg/util/log/logconfig/BUILD.bazel
+++ b/pkg/util/log/logconfig/BUILD.bazel
@@ -1,4 +1,17 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+
+exports_files(["config.go"])
+
+go_binary(
+    name = "gen",
+    srcs = ["gen.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/util/log/logconfig",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/cli/exit",
+        "@com_github_cockroachdb_errors//:errors",
+    ],
+)
 
 go_library(
     name = "logconfig",

--- a/pkg/util/log/logconfig/gen.go
+++ b/pkg/util/log/logconfig/gen.go
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-// +build ignore
+// +build bazel
 
 package main
 


### PR DESCRIPTION
In doing so, I also noticed a couple generated `.go` files that weren't
yet bazelfied, so I took care of them too.

Closes #65812.

Release note: None