### PR TITLE
draft: opt: do not include projected cols in lax key column

### DIFF
--- a/pkg/sql/opt/memo/testdata/logprops/scan
+++ b/pkg/sql/opt/memo/testdata/logprops/scan
@@ -6,6 +6,15 @@ exec-ddl
 CREATE TABLE b (x INT, z INT NOT NULL)
 ----
 
+exec-ddl
+CREATE TABLE uniq (
+  a INT,
+  b INT,
+  c INT,
+  UNIQUE (a, b)
+)
+----
+
 build
 SELECT * FROM a
 ----
@@ -57,6 +66,31 @@ scan a
  ├── key: ()
  ├── fd: ()-->(1,3)
  └── prune: (3)
+
+# Test that a nullable column projected from a scan does not become part of a
+# lax key of the scan.
+norm
+SELECT a, b, c FROM uniq WHERE a = 1 AND b = 2
+----
+select
+ ├── columns: a:1(int!null) b:2(int!null) c:3(int)
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1-3)
+ ├── prune: (3)
+ ├── scan uniq
+ │    ├── columns: a:1(int) b:2(int) c:3(int)
+ │    ├── lax-key: (1,2)
+ │    ├── fd: (1,2)~~>(3)
+ │    ├── prune: (1-3)
+ │    └── interesting orderings: (+1,+2)
+ └── filters
+      ├── eq [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
+      │    ├── variable: a:1 [type=int]
+      │    └── const: 1 [type=int]
+      └── eq [type=bool, outer=(2), constraints=(/2: [/2 - /2]; tight), fd=()-->(2)]
+           ├── variable: b:2 [type=int]
+           └── const: 2 [type=int]
 
 # Test partial index scan not null columns.
 exec-ddl

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -567,7 +567,7 @@ select
  ├── scan c
  │    ├── columns: x:1(int) z:2(int!null)
  │    ├── stats: [rows=1000, distinct(1)=991, null(1)=10, distinct(2)=100, null(2)=0]
- │    ├── lax-key: (1,2)
+ │    ├── lax-key: (1)
  │    └── fd: (1)~~>(2)
  └── filters
       └── (x:1 >= 0) AND (x:1 < 100) [type=bool, outer=(1), constraints=(/1: [/0 - /99]; tight)]
@@ -1100,7 +1100,7 @@ select
  ├── scan c
  │    ├── columns: x:1(int) z:2(int!null)
  │    ├── stats: [rows=10000, distinct(1)=5000, null(1)=5000, distinct(2)=10000, null(2)=0]
- │    ├── lax-key: (1,2)
+ │    ├── lax-key: (1)
  │    └── fd: (1)~~>(2)
  └── filters
       └── (x:1 >= 0) AND (x:1 < 100) [type=bool, outer=(1), constraints=(/1: [/0 - /99]; tight)]

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -3428,7 +3428,7 @@ scalar-group-by
  ├── fd: ()-->(7)
  ├── scan nullablecols
  │    ├── columns: c1:1 c2:2
- │    ├── lax-key: (1,2)
+ │    ├── lax-key: (1)
  │    └── fd: (1)~~>(2)
  └── aggregations
       └── regression-count [as=regr_count:7, outer=(1,2)]

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -4012,7 +4012,7 @@ delete uniq_fk_parent
       │         │    └── fd: ()-->(15,16)
       │         ├── scan uniq_fk_child
       │         │    ├── columns: uniq_fk_child.b:18 uniq_fk_child.c:19
-      │         │    ├── lax-key: (18,19)
+      │         │    ├── lax-key: (19)
       │         │    └── fd: (19)~~>(18)
       │         └── filters
       │              ├── b:15 = uniq_fk_child.b:18 [outer=(15,18), constraints=(/15: (/NULL - ]; /18: (/NULL - ]), fd=(15)==(18), (18)==(15)]
@@ -4329,7 +4329,7 @@ UPDATE returning_test SET d = a + d RETURNING a, d
 project
  ├── columns: a:1 d:4
  ├── volatile, mutations
- ├── lax-key: (1,4)
+ ├── lax-key: (1)
  ├── fd: (1)~~>(4)
  └── update returning_test
       ├── columns: a:1 d:4 rowid:8!null
@@ -4385,7 +4385,7 @@ UPDATE returning_test SET (b, a) = (a, a + b) RETURNING a, b, c
 project
  ├── columns: a:1 b:2 c:3
  ├── volatile, mutations
- ├── lax-key: (1-3)
+ ├── lax-key: (2)
  ├── fd: (2)~~>(1,3)
  └── update returning_test
       ├── columns: a:1 b:2 c:3 rowid:8!null
@@ -4533,11 +4533,11 @@ with &2
       ├── fd: (11)~~>(12)
       ├── project
       │    ├── columns: a:11 b:12
-      │    ├── lax-key: (11,12)
+      │    ├── lax-key: (11)
       │    ├── fd: (11)~~>(12)
       │    ├── scan returning_test
       │    │    ├── columns: returning_test.a:1 returning_test.b:2
-      │    │    ├── lax-key: (1,2)
+      │    │    ├── lax-key: (1)
       │    │    └── fd: (1)~~>(2)
       │    └── projections
       │         ├── returning_test.a:1 [as=a:11, outer=(1)]

--- a/pkg/sql/opt/norm/testdata/rules/set
+++ b/pkg/sql/opt/norm/testdata/rules/set
@@ -886,7 +886,7 @@ union
            ├── fd: ()-->(7)
            ├── scan t2
            │    ├── columns: a:7!null t2.d:10
-           │    ├── lax-key: (7,10)
+           │    ├── lax-key: (10)
            │    └── fd: (10)~~>(7)
            └── filters
                 └── a:7 = 1 [outer=(7), constraints=(/7: [/1 - /1]; tight), fd=()-->(7)]

--- a/pkg/sql/opt/xform/testdata/ruleprops/orderings
+++ b/pkg/sql/opt/xform/testdata/ruleprops/orderings
@@ -10,7 +10,7 @@ SELECT * FROM abc
 ----
 scan abc
  ├── columns: a:1 b:2 c:3
- ├── lax-key: (1-3)
+ ├── lax-key: (3)
  ├── fd: (3)~~>(1,2)
  ├── prune: (1-3)
  └── interesting orderings: (+1,+2) (+3)
@@ -20,7 +20,7 @@ SELECT a, c FROM abc
 ----
 scan abc
  ├── columns: a:1 c:3
- ├── lax-key: (1,3)
+ ├── lax-key: (3)
  ├── fd: (3)~~>(1)
  ├── prune: (1,3)
  └── interesting orderings: (+1) (+3)
@@ -30,7 +30,7 @@ SELECT b, c FROM abc
 ----
 scan abc
  ├── columns: b:2 c:3
- ├── lax-key: (2,3)
+ ├── lax-key: (3)
  ├── fd: (3)~~>(2)
  ├── prune: (2,3)
  └── interesting orderings: (+3)
@@ -42,7 +42,7 @@ SELECT a, c FROM abc
 ----
 project
  ├── columns: a:1 c:3
- ├── lax-key: (1,3)
+ ├── lax-key: (3)
  ├── fd: (3)~~>(1)
  ├── prune: (1,3)
  ├── interesting orderings: (+1) (+3)
@@ -58,7 +58,7 @@ SELECT b, c FROM abc
 ----
 project
  ├── columns: b:2 c:3
- ├── lax-key: (2,3)
+ ├── lax-key: (3)
  ├── fd: (3)~~>(2)
  ├── prune: (2,3)
  ├── interesting orderings: (+3)
@@ -102,7 +102,7 @@ group-by
  ├── interesting orderings: (+3)
  ├── scan abc
  │    ├── columns: b:2 c:3
- │    ├── lax-key: (2,3)
+ │    ├── lax-key: (3)
  │    ├── fd: (3)~~>(2)
  │    ├── prune: (2,3)
  │    └── interesting orderings: (+3)
@@ -119,18 +119,18 @@ group-by
  ├── grouping columns: b:2 c:3
  ├── internal-ordering: +1 opt(2,3)
  ├── key: (2,3)
- ├── fd: (3)~~>(2), (2,3)-->(7)
+ ├── fd: (3)~~>(2,7), (2,3)-->(7)
  ├── prune: (7)
  ├── sort
  │    ├── columns: a:1 b:2 c:3
- │    ├── lax-key: (1-3)
+ │    ├── lax-key: (3)
  │    ├── fd: (3)~~>(1,2)
  │    ├── ordering: +1 opt(2,3) [actual: +1]
  │    ├── prune: (1-3)
  │    ├── interesting orderings: (+1,+2) (+3)
  │    └── scan abc
  │         ├── columns: a:1 b:2 c:3
- │         ├── lax-key: (1-3)
+ │         ├── lax-key: (3)
  │         ├── fd: (3)~~>(1,2)
  │         ├── prune: (1-3)
  │         └── interesting orderings: (+1,+2) (+3)
@@ -150,7 +150,7 @@ scalar-group-by
  ├── prune: (7-9)
  ├── scan abc
  │    ├── columns: a:1 b:2 c:3
- │    ├── lax-key: (1-3)
+ │    ├── lax-key: (3)
  │    ├── fd: (3)~~>(1,2)
  │    ├── prune: (1-3)
  │    └── interesting orderings: (+1,+2) (+3)
@@ -168,7 +168,7 @@ SELECT * FROM abc WHERE a = 1
 ----
 index-join abc
  ├── columns: a:1!null b:2 c:3
- ├── lax-key: (2,3)
+ ├── lax-key: (3)
  ├── fd: ()-->(1), (3)~~>(2)
  ├── prune: (2,3)
  ├── interesting orderings: (+2 opt(1)) (+3 opt(1))
@@ -187,7 +187,7 @@ SELECT * FROM abc ORDER BY a LIMIT 10
 index-join abc
  ├── columns: a:1 b:2 c:3
  ├── cardinality: [0 - 10]
- ├── lax-key: (1-3)
+ ├── lax-key: (3)
  ├── fd: (3)~~>(1,2)
  ├── ordering: +1
  ├── prune: (2,3)
@@ -208,14 +208,14 @@ limit
  ├── columns: a:1 b:2 c:3
  ├── internal-ordering: +2
  ├── cardinality: [0 - 10]
- ├── lax-key: (1-3)
+ ├── lax-key: (3)
  ├── fd: (3)~~>(1,2)
  ├── ordering: +2
  ├── prune: (1,3)
  ├── interesting orderings: (+2)
  ├── sort
  │    ├── columns: a:1 b:2 c:3
- │    ├── lax-key: (1-3)
+ │    ├── lax-key: (3)
  │    ├── fd: (3)~~>(1,2)
  │    ├── ordering: +2
  │    ├── limit hint: 10.00
@@ -223,7 +223,7 @@ limit
  │    ├── interesting orderings: (+1,+2) (+3)
  │    └── scan abc
  │         ├── columns: a:1 b:2 c:3
- │         ├── lax-key: (1-3)
+ │         ├── lax-key: (3)
  │         ├── fd: (3)~~>(1,2)
  │         ├── prune: (1-3)
  │         └── interesting orderings: (+1,+2) (+3)
@@ -235,21 +235,21 @@ SELECT * FROM abc ORDER BY a OFFSET 10
 offset
  ├── columns: a:1 b:2 c:3
  ├── internal-ordering: +1
- ├── lax-key: (1-3)
+ ├── lax-key: (3)
  ├── fd: (3)~~>(1,2)
  ├── ordering: +1
  ├── prune: (2,3)
  ├── interesting orderings: (+1,+2)
  ├── sort
  │    ├── columns: a:1 b:2 c:3
- │    ├── lax-key: (1-3)
+ │    ├── lax-key: (3)
  │    ├── fd: (3)~~>(1,2)
  │    ├── ordering: +1
  │    ├── prune: (1-3)
  │    ├── interesting orderings: (+1,+2) (+3)
  │    └── scan abc
  │         ├── columns: a:1 b:2 c:3
- │         ├── lax-key: (1-3)
+ │         ├── lax-key: (3)
  │         ├── fd: (3)~~>(1,2)
  │         ├── prune: (1-3)
  │         └── interesting orderings: (+1,+2) (+3)
@@ -265,20 +265,20 @@ SELECT * FROM abc JOIN xyz ON a=x
 ----
 inner-join (hash)
  ├── columns: a:1!null b:2 c:3 x:7!null y:8 z:9
- ├── lax-key: (2,3,7-9)
- ├── fd: (3)~~>(1,2), (7,8)~~>(9), (1)==(7), (7)==(1)
+ ├── lax-key: (3,7,8)
+ ├── fd: (3)~~>(1,2), (7,8)~~>(9), (1)==(7), (7)==(1), (3,7,8)~~>(2,9)
  ├── prune: (2,3,8,9)
  ├── interesting orderings: (+1,+2) (+3) (+9) (+7,+8)
  ├── scan abc
  │    ├── columns: a:1 b:2 c:3
- │    ├── lax-key: (1-3)
+ │    ├── lax-key: (3)
  │    ├── fd: (3)~~>(1,2)
  │    ├── prune: (1-3)
  │    ├── interesting orderings: (+1,+2) (+3)
  │    └── unfiltered-cols: (1-6)
  ├── scan xyz
  │    ├── columns: x:7 y:8 z:9
- │    ├── lax-key: (7-9)
+ │    ├── lax-key: (7,8)
  │    ├── fd: (7,8)~~>(9)
  │    ├── prune: (7-9)
  │    ├── interesting orderings: (+9) (+7,+8)

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -8868,7 +8868,7 @@ SELECT u, v FROM a@{NO_INDEX_JOIN} WHERE u = 1 OR v = 1
 ----
 project
  ├── columns: u:2 v:3
- ├── lax-key: (2,3)
+ ├── lax-key: (3)
  ├── fd: (3)~~>(2)
  └── distinct-on
       ├── columns: k:1!null u:2 v:3


### PR DESCRIPTION
This is an attempt to prevent all projected columns from being included
in a FD's lax key. Ideally, the lax key would be reduced to a minimal
set of columns, rather than growing due to a projection.

This is currently breaking a bunch of tests, and I don't think it's
correct.

See the discussion in https://github.com/cockroachdb/cockroach/issues/67959
for more context.

Release note: None