### PR TITLE
tree: make min and max ignore nulls with non-default EXCLUDE

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -3932,3 +3932,18 @@ SELECT k, first_value(k) OVER (ORDER BY v GROUPS BETWEEN 0 PRECEDING AND 2 PRECE
 9   NULL
 10  NULL
 11  NULL
+
+# Regression test for incorrectly choosing NULL values as the minimum when
+# EXCLUDE clause is non-default (#68024).
+query I rowsort
+SELECT min(x)
+OVER
+(
+  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+  EXCLUDE CURRENT ROW
+)
+FROM (VALUES (NULL::INT), (NULL::INT), (1)) v(x);
+----
+1
+1
+NULL

--- a/pkg/sql/sem/builtins/window_frame_builtins.go
+++ b/pkg/sql/sem/builtins/window_frame_builtins.go
@@ -123,6 +123,12 @@ func (w *slidingWindowFunc) Compute(
 			if err != nil {
 				return nil, err
 			}
+			if args[0] == tree.DNull {
+				// Null value can neither be minimum nor maximum over a window frame
+				// with non-null values, so we're not adding them to the sliding window.
+				// The case of a window frame with no non-null values is handled below.
+				continue
+			}
 			if res == nil {
 				res = args[0]
 			} else {


### PR DESCRIPTION
Previously, `min` and `max` would include null input values in their
aggregation when the window frame EXCLUDE clause was non-default.
This lead to cases where `min` would incorrectly return `NULL` values,
because `NULL` orders before any other value. This patch modifies the
`min` and `max` implementations to ignore `NULL` input values.

Fixes #68024

Release note (bug fix): Fixed a bug that could cause the min window
function to incorrectly return null when executed with a non-default
EXCLUDE clause, because min and max did not ignore null input values.