### PR TITLE
release-21.1: sql: fix misuse of tracing API for enabling slow txn tracing

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -462,3 +462,11 @@ SET standard_conforming_strings='true'
 
 statement ok
 SET standard_conforming_strings='on'
+
+# Regression test for not being able to set sql.trace.txn.enable_threshold
+# cluster setting to non-zero value (#68005).
+statement ok
+SET cluster setting sql.trace.txn.enable_threshold='1s'
+
+statement ok
+SET cluster setting sql.trace.txn.enable_threshold='0s'


### PR DESCRIPTION
Backport 1/1 commits from #68002.

/cc @cockroachdb/release

Release justification: low risk bug fix.

---

We were misusing the tracing API a bit when performing the tracing of
the slow txns. Namely, it was possible that the context has a Noop
tracing span attached to it and we would try to make that span verbose.
This is prohibited which resulted in a crash of the node. The fix is
simple - force the real span all the time whenever the slow txn
tracing is enabled.

Fixes: https://github.com/cockroachlabs/support/issues/1117.
Fixes: #68005.

Release note (bug fix): Previously, CockroachDB node would crash whenever
the cluster setting `sql.trace.txn.enable_threshold` was changed to
non-zero value. The bug was introduced in 21.1.
