### PR TITLE
release-21.1: rowexec: improve memory accounting in joinReader

### DIFF
--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unsafe"
 
 	"github.com/cockroachdb/apd/v2"
 	"github.com/cockroachdb/cockroach/pkg/geo"
@@ -2300,6 +2301,15 @@ func (s Span) Valid() bool {
 	return true
 }
 
+// SpanOverhead is the overhead of Span in bytes.
+const SpanOverhead = int64(unsafe.Sizeof(Span{}))
+
+// MemUsage returns the size of the Span in bytes for memory accounting
+// purposes.
+func (s Span) MemUsage() int64 {
+	return SpanOverhead + int64(cap(s.Key)) + int64(cap(s.EndKey))
+}
+
 // Spans is a slice of spans.
 type Spans []Span
 
@@ -2318,6 +2328,22 @@ func (a Spans) ContainsKey(key Key) bool {
 	}
 
 	return false
+}
+
+// SpansOverhead is the overhead of Spans in bytes.
+const SpansOverhead = int64(unsafe.Sizeof(Spans{}))
+
+// MemUsage returns the size of the Spans in bytes for memory accounting
+// purposes.
+func (a Spans) MemUsage() int64 {
+	// Slice the full capacity of a so we can account for the memory
+	// used by spans past the length of a.
+	aCap := a[:cap(a)]
+	size := SpansOverhead
+	for i := range aCap {
+		size += aCap[i].MemUsage()
+	}
+	return size
 }
 
 // RSpan is a key range with an inclusive start RKey and an exclusive end RKey.

--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -977,6 +977,20 @@ func NewLimitedMonitor(
 	return limitedMon
 }
 
+// NewLimitedMonitorNoDiskSpill is a utility function used by processors to
+// create a new limited memory monitor with the given name and start it. The
+// returned monitor must be closed. The limit is determined by
+// SessionData.WorkMemLimit (stored inside of the flowCtx) but overridden to
+// ServerConfig.TestingKnobs.MemoryLimitBytes if that knob is set.
+// ServerConfig.TestingKnobs.ForceDiskSpill is ignored by this function.
+func NewLimitedMonitorNoDiskSpill(
+	ctx context.Context, parent *mon.BytesMonitor, config *ServerConfig, name string,
+) *mon.BytesMonitor {
+	limitedMon := mon.NewMonitorInheritWithLimit(name, GetWorkMemLimitNoDiskSpill(config), parent)
+	limitedMon.Start(ctx, parent, mon.BoundAccount{})
+	return limitedMon
+}
+
 // LocalProcessor is a RowSourcedProcessor that needs to be initialized with
 // its post processing spec and output row receiver. Most processors can accept
 // these objects at creation time.

--- a/pkg/sql/execinfra/server_config.go
+++ b/pkg/sql/execinfra/server_config.go
@@ -267,7 +267,16 @@ func GetWorkMemLimit(config *ServerConfig) int64 {
 	}
 	if config.TestingKnobs.ForceDiskSpill {
 		return 1
-	} else if config.TestingKnobs.MemoryLimitBytes != 0 {
+	}
+	return GetWorkMemLimitNoDiskSpill(config)
+}
+
+// GetWorkMemLimitNoDiskSpill returns the number of bytes determining the amount
+// of RAM available to a single processor or operator. This function should be
+// used instead of GetWorkMemLimit if the processor cannot spill to disk,
+// since ServerConfig.TestingKnobs.ForceDiskSpill is ignored by this function.
+func GetWorkMemLimitNoDiskSpill(config *ServerConfig) int64 {
+	if config.TestingKnobs.MemoryLimitBytes != 0 {
 		return config.TestingKnobs.MemoryLimitBytes
 	}
 	return SettingWorkMemBytes.Get(&config.Settings.SV)

--- a/pkg/sql/rowexec/BUILD.bazel
+++ b/pkg/sql/rowexec/BUILD.bazel
@@ -157,6 +157,7 @@ go_test(
         "//pkg/sql/rowcontainer",
         "//pkg/sql/rowenc",
         "//pkg/sql/sem/tree",
+        "//pkg/sql/sqlerrors",
         "//pkg/sql/sqlutil",
         "//pkg/sql/stats",
         "//pkg/sql/types",

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -13,6 +13,7 @@ package rowexec
 import (
 	"context"
 	"sort"
+	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
@@ -71,7 +72,16 @@ type joinReader struct {
 	// ProcessorBase.State == StateRunning.
 	runningState joinReaderState
 
-	diskMonitor *mon.BytesMonitor
+	// memAcc is used to account for the memory used by the in-memory data structures
+	// used by the joinReader and different joinReader strategies.
+	memAcc mon.BoundAccount
+
+	// limitedMemMonitor is a limited memory monitor to account for the memory
+	// used by buffered rows in joinReaderOrderingStrategy. If the memory limit is
+	// exceeded, the joinReader will spill to disk. diskMonitor is used to monitor
+	// the disk utilization in this case.
+	limitedMemMonitor *mon.BytesMonitor
+	diskMonitor       *mon.BytesMonitor
 
 	desc             catalog.TableDescriptor
 	index            *descpb.IndexDescriptor
@@ -332,6 +342,12 @@ func newJoinReader(
 		}
 	}
 
+	// Initialize memory monitors and bound account for data structures in the joinReader.
+	jr.MemMonitor = execinfra.NewLimitedMonitorNoDiskSpill(
+		flowCtx.EvalCtx.Ctx(), flowCtx.EvalCtx.Mon, flowCtx.Cfg, "joinreader-mem",
+	)
+	jr.memAcc = jr.MemMonitor.MakeBoundAccount()
+
 	if err := jr.initJoinReaderStrategy(flowCtx, columnTypes, len(columnIDs), rightCols, readerType); err != nil {
 		return nil, err
 	}
@@ -365,6 +381,7 @@ func (jr *joinReader) initJoinReaderStrategy(
 			keyToInputRowIndices: keyToInputRowIndices,
 			numKeyCols:           numKeyCols,
 			lookupCols:           jr.lookupCols,
+			memAcc:               &jr.memAcc,
 		}
 	} else {
 		// Since jr.lookupExpr is set, we need to use multiSpanGenerator, which
@@ -384,6 +401,7 @@ func (jr *joinReader) initJoinReaderStrategy(
 			keyToInputRowIndices,
 			&jr.lookupExpr,
 			tableOrdToIndexOrd,
+			&jr.memAcc,
 		); err != nil {
 			return err
 		}
@@ -404,6 +422,7 @@ func (jr *joinReader) initJoinReaderStrategy(
 			joinReaderSpanGenerator: generator,
 			isPartialJoin:           jr.joinType == descpb.LeftSemiJoin || jr.joinType == descpb.LeftAntiJoin,
 			groupingState:           jr.groupingState,
+			memAcc:                  &jr.memAcc,
 		}
 		return nil
 	}
@@ -413,14 +432,14 @@ func (jr *joinReader) initJoinReaderStrategy(
 	// joinReader will overflow to disk if this limit is not enough.
 	limit := execinfra.GetWorkMemLimit(flowCtx.Cfg)
 	// Initialize memory monitors and row container for looked up rows.
-	jr.MemMonitor = execinfra.NewLimitedMonitor(ctx, flowCtx.EvalCtx.Mon, flowCtx.Cfg, "joinreader-limited")
+	jr.limitedMemMonitor = execinfra.NewLimitedMonitor(ctx, jr.MemMonitor, flowCtx.Cfg, "joinreader-limited")
 	jr.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.DiskMonitor, "joinreader-disk")
 	drc := rowcontainer.NewDiskBackedNumberedRowContainer(
 		false, /* deDup */
 		typs,
 		jr.EvalCtx,
 		jr.FlowCtx.Cfg.TempStorage,
-		jr.MemMonitor,
+		jr.limitedMemMonitor,
 		jr.diskMonitor,
 	)
 	if limit < mon.DefaultPoolAllocationSize {
@@ -435,6 +454,7 @@ func (jr *joinReader) initJoinReaderStrategy(
 		lookedUpRows:                      drc,
 		groupingState:                     jr.groupingState,
 		outputGroupContinuationForLeftRow: jr.outputGroupContinuationForLeftRow,
+		memAcc:                            &jr.memAcc,
 	}
 	return nil
 }
@@ -557,6 +577,9 @@ func (jr *joinReader) readInput() (
 		// Else, returning meta interrupted reading the input batch, so we already
 		// did the reset for this batch.
 	}
+
+	sizeBefore := jr.memUsage()
+
 	// Read the next batch of input rows.
 	for jr.curBatchSizeBytes < jr.batchSizeBytes {
 		row, meta := jr.input.Next()
@@ -565,6 +588,14 @@ func (jr *joinReader) readInput() (
 				jr.MoveToDraining(nil /* err */)
 				return jrStateUnknown, nil, meta
 			}
+
+			// Perform memory accounting.
+			sizeAfter := jr.memUsage()
+			if err := jr.memAcc.Resize(jr.Ctx, sizeBefore, sizeAfter); err != nil {
+				jr.MoveToDraining(err)
+				return jrStateUnknown, nil, meta
+			}
+
 			return jrReadingInput, nil, meta
 		}
 		if row == nil {
@@ -580,6 +611,14 @@ func (jr *joinReader) readInput() (
 		}
 		jr.scratchInputRows = append(jr.scratchInputRows, jr.rowAlloc.CopyRow(row))
 	}
+
+	// Perform memory accounting.
+	sizeAfter := jr.memUsage()
+	if err := jr.memAcc.Resize(jr.Ctx, sizeBefore, sizeAfter); err != nil {
+		jr.MoveToDraining(err)
+		return jrStateUnknown, nil, jr.DrainHelper()
+	}
+
 	var outRow rowenc.EncDatumRow
 	// Finished reading the input batch.
 	if jr.groupingState != nil {
@@ -718,6 +757,10 @@ func (jr *joinReader) close() {
 			jr.fetcher.Close(jr.Ctx)
 		}
 		jr.strategy.close(jr.Ctx)
+		jr.memAcc.Close(jr.Ctx)
+		if jr.limitedMemMonitor != nil {
+			jr.limitedMemMonitor.Stop(jr.Ctx)
+		}
 		if jr.MemMonitor != nil {
 			jr.MemMonitor.Stop(jr.Ctx)
 		}
@@ -852,6 +895,26 @@ func (jr *joinReader) updateGroupingStateForNonEmptyBatch() {
 			jr.groupingState.setFirstGroupMatched()
 		}
 	}
+}
+
+// memUsage returns the size of the data structures in the joinReader for memory
+// accounting purposes.
+func (jr *joinReader) memUsage() int64 {
+	var size int64
+
+	// Account for scratchInputRows. Slice the full capacity so we can account for
+	// the memory used by rows past the length of scratchInputRows.
+	rowsCap := jr.scratchInputRows[:cap(jr.scratchInputRows)]
+	for i := range rowsCap {
+		size += int64(rowsCap[i].Size())
+	}
+
+	// Account for groupingState.
+	if jr.groupingState != nil {
+		size += int64(cap(jr.groupingState.groupState)) * int64(unsafe.Sizeof(groupState{}))
+		size += int64(cap(jr.groupingState.batchRowToGroupIndex)) * sizeOfInt
+	}
+	return size
 }
 
 // inputBatchGroupingState encapsulates the state needed for all the

--- a/pkg/sql/rowexec/joinreader_strategies.go
+++ b/pkg/sql/rowexec/joinreader_strategies.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 )
 
 type joinReaderStrategy interface {
@@ -86,6 +87,8 @@ type joinReaderNoOrderingStrategy struct {
 	}
 
 	groupingState *inputBatchGroupingState
+
+	memAcc *mon.BoundAccount
 }
 
 // getLookupRowsBatchSizeHint returns the batch size for the join reader no
@@ -106,7 +109,7 @@ func (s *joinReaderNoOrderingStrategy) processLookupRows(
 ) (roachpb.Spans, error) {
 	s.inputRows = rows
 	s.emitState.unmatchedInputRowIndicesInitialized = false
-	return s.generateSpans(s.inputRows)
+	return s.generateSpans(s.Ctx, s.inputRows)
 }
 
 func (s *joinReaderNoOrderingStrategy) processLookedUpRow(
@@ -114,6 +117,9 @@ func (s *joinReaderNoOrderingStrategy) processLookedUpRow(
 ) (joinReaderState, error) {
 	matchingInputRowIndices := s.getMatchingRowIndices(key)
 	if s.isPartialJoin {
+		// Perform memory accounting.
+		beforeSize := s.memUsage()
+
 		// In the case of partial joins, only process input rows that have not been
 		// matched yet. Make a copy of the matching input row indices to avoid
 		// overwriting the caller's slice.
@@ -124,6 +130,12 @@ func (s *joinReaderNoOrderingStrategy) processLookedUpRow(
 			}
 		}
 		matchingInputRowIndices = s.scratchMatchingInputRowIndices
+
+		// Perform memory accounting.
+		afterSize := s.memUsage()
+		if err := s.memAcc.Resize(s.Ctx, beforeSize, afterSize); err != nil {
+			return jrStateUnknown, err
+		}
 	}
 	s.emitState.processingLookupRow = true
 	s.emitState.lookedUpRow = row
@@ -147,6 +159,9 @@ func (s *joinReaderNoOrderingStrategy) nextRowToEmit(
 		}
 
 		if !s.emitState.unmatchedInputRowIndicesInitialized {
+			// Perform memory accounting.
+			beforeSize := s.memUsage()
+
 			s.emitState.unmatchedInputRowIndices = s.emitState.unmatchedInputRowIndices[:0]
 			for inputRowIdx := range s.inputRows {
 				if s.groupingState.isUnmatched(inputRowIdx) {
@@ -155,6 +170,12 @@ func (s *joinReaderNoOrderingStrategy) nextRowToEmit(
 			}
 			s.emitState.unmatchedInputRowIndicesInitialized = true
 			s.emitState.unmatchedInputRowIndicesCursor = 0
+
+			// Perform memory accounting.
+			afterSize := s.memUsage()
+			if err := s.memAcc.Resize(s.Ctx, beforeSize, afterSize); err != nil {
+				return nil, jrStateUnknown, err
+			}
 		}
 
 		if s.emitState.unmatchedInputRowIndicesCursor >= len(s.emitState.unmatchedInputRowIndices) {
@@ -215,6 +236,17 @@ func (s *joinReaderNoOrderingStrategy) spilled() bool { return false }
 
 func (s *joinReaderNoOrderingStrategy) close(_ context.Context) {}
 
+// memUsage returns the size of the data structures in the
+// joinReaderNoOrderingStrategy for memory accounting purposes.
+func (s *joinReaderNoOrderingStrategy) memUsage() int64 {
+	// Account for scratchMatchingInputRowIndices.
+	size := sliceOfIntsOverhead + sizeOfInt*int64(cap(s.scratchMatchingInputRowIndices))
+
+	// Account for emitState.unmatchedInputRowIndices.
+	size += sliceOfIntsOverhead + sizeOfInt*int64(cap(s.emitState.unmatchedInputRowIndices))
+	return size
+}
+
 // joinReaderIndexJoinStrategy is a joinReaderStrategy that executes an index
 // join. It does not maintain the ordering.
 type joinReaderIndexJoinStrategy struct {
@@ -251,7 +283,7 @@ func (s *joinReaderIndexJoinStrategy) processLookupRows(
 	rows []rowenc.EncDatumRow,
 ) (roachpb.Spans, error) {
 	s.inputRows = rows
-	return s.generateSpans(s.inputRows)
+	return s.generateSpans(s.Ctx, s.inputRows)
 }
 
 func (s *joinReaderIndexJoinStrategy) processLookedUpRow(
@@ -325,6 +357,8 @@ type joinReaderOrderingStrategy struct {
 	// always be of size 1 (real input batching only happens when this join is
 	// the second join in paired-joins).
 	outputGroupContinuationForLeftRow bool
+
+	memAcc *mon.BoundAccount
 }
 
 func (s *joinReaderOrderingStrategy) getLookupRowsBatchSizeHint() int64 {
@@ -350,11 +384,16 @@ func (s *joinReaderOrderingStrategy) processLookupRows(
 			s.inputRowIdxToLookedUpRowIndices[i] = s.inputRowIdxToLookedUpRowIndices[i][:0]
 		}
 	} else {
+		beforeSize := s.memUsage(nil)
 		s.inputRowIdxToLookedUpRowIndices = make([][]int, len(rows))
+		afterSize := s.memUsage(nil)
+		if err := s.memAcc.Resize(s.Ctx, beforeSize, afterSize); err != nil {
+			return nil, err
+		}
 	}
 
 	s.inputRows = rows
-	return s.generateSpans(s.inputRows)
+	return s.generateSpans(s.Ctx, s.inputRows)
 }
 
 func (s *joinReaderOrderingStrategy) processLookedUpRow(
@@ -374,6 +413,7 @@ func (s *joinReaderOrderingStrategy) processLookedUpRow(
 	}
 
 	// Update our map from input rows to looked up rows.
+	beforeSize := s.memUsage(matchingInputRowIndices)
 	for _, inputRowIdx := range matchingInputRowIndices {
 		if !s.isPartialJoin {
 			s.inputRowIdxToLookedUpRowIndices[inputRowIdx] = append(
@@ -400,6 +440,12 @@ func (s *joinReaderOrderingStrategy) processLookedUpRow(
 		}
 	}
 	s.lookedUpRowIdx++
+
+	// Perform memory accounting.
+	afterSize := s.memUsage(matchingInputRowIndices)
+	if err := s.memAcc.Resize(s.Ctx, beforeSize, afterSize); err != nil {
+		return jrStateUnknown, err
+	}
 
 	return jrPerformingLookup, nil
 }
@@ -498,4 +544,32 @@ func (s *joinReaderOrderingStrategy) close(ctx context.Context) {
 	if s.lookedUpRows != nil {
 		s.lookedUpRows.Close(ctx)
 	}
+}
+
+// memUsage returns the size of inputRowIdxToLookedUpRowIndices in bytes, to
+// be used for memory accounting.
+//
+// If matchingInputRowIndices is non-nil, memUsage will only account for the
+// the slices in inputRowIdxToLookedUpRowIndices at the indexes corresponding to
+// matchingInputRowIndices. Otherwise, it will account for all slices.
+func (s *joinReaderOrderingStrategy) memUsage(matchingInputRowIndices []int) int64 {
+	// Account for the memory used by the outer slice.
+	size := sliceOfIntsOverhead * int64(cap(s.inputRowIdxToLookedUpRowIndices))
+
+	// Account for the memory used by the inner slices.
+	if matchingInputRowIndices != nil {
+		// We only need to account for a subset of the rows.
+		for _, idx := range matchingInputRowIndices {
+			size += sizeOfInt * int64(cap(s.inputRowIdxToLookedUpRowIndices[idx]))
+		}
+	} else {
+		// Slice the full capacity so we can account for the memory used past the
+		// length of inputRowIdxToLookedUpRowIndices.
+		fullCap := s.inputRowIdxToLookedUpRowIndices[:cap(s.inputRowIdxToLookedUpRowIndices)]
+		for i := range fullCap {
+			size += sizeOfInt * int64(cap(fullCap[i]))
+		}
+	}
+
+	return size
 }

--- a/pkg/sql/rowexec/joinreader_test.go
+++ b/pkg/sql/rowexec/joinreader_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -750,130 +751,154 @@ func TestJoinReader(t *testing.T) {
 				// paired joins, so do both.
 				for _, smallBatch := range []bool{true, false} {
 					for _, outputContinuation := range []bool{false, true} {
-						if outputContinuation && c.secondJoinInPairedJoin {
-							// outputContinuation is for the first join in paired-joins, so
-							// can't do that when this test case is for the second join in
-							// paired-joins.
-							continue
-						}
-						if outputContinuation && !reqOrdering {
-							// The first join in paired-joins must preserve ordering.
-							continue
-						}
-						if outputContinuation && len(c.expectedWithContinuation) == 0 {
-							continue
-						}
-						t.Run(fmt.Sprintf("%d/reqOrdering=%t/%s/smallBatch=%t/cont=%t",
-							i, reqOrdering, c.description, smallBatch, outputContinuation), func(t *testing.T) {
-							evalCtx := tree.MakeTestingEvalContext(st)
-							defer evalCtx.Stop(ctx)
-							flowCtx := execinfra.FlowCtx{
-								EvalCtx: &evalCtx,
-								Cfg: &execinfra.ServerConfig{
-									Settings:    st,
-									TempStorage: tempEngine,
-								},
-								Txn:         kv.NewTxn(ctx, s.DB(), s.NodeID()),
-								DiskMonitor: diskMonitor,
+						for _, lowMemory := range []bool{false, true} {
+							if outputContinuation && c.secondJoinInPairedJoin {
+								// outputContinuation is for the first join in paired-joins, so
+								// can't do that when this test case is for the second join in
+								// paired-joins.
+								continue
 							}
-							encRows := make(rowenc.EncDatumRows, len(c.input))
-							for rowIdx, row := range c.input {
-								encRow := make(rowenc.EncDatumRow, len(row))
-								for i, d := range row {
-									encRow[i] = rowenc.DatumToEncDatum(c.inputTypes[i], d)
+							if outputContinuation && !reqOrdering {
+								// The first join in paired-joins must preserve ordering.
+								continue
+							}
+							if outputContinuation && len(c.expectedWithContinuation) == 0 {
+								continue
+							}
+							if smallBatch && lowMemory {
+								continue
+							}
+							t.Run(fmt.Sprintf("%d/reqOrdering=%t/%s/smallBatch=%t/cont=%t/lowMem=%t",
+								i, reqOrdering, c.description, smallBatch, outputContinuation, lowMemory), func(t *testing.T) {
+								evalCtx := tree.MakeTestingEvalContext(st)
+								defer evalCtx.Stop(ctx)
+								flowCtx := execinfra.FlowCtx{
+									EvalCtx: &evalCtx,
+									Cfg: &execinfra.ServerConfig{
+										Settings:    st,
+										TempStorage: tempEngine,
+									},
+									Txn:         kv.NewTxn(ctx, s.DB(), s.NodeID()),
+									DiskMonitor: diskMonitor,
 								}
-								encRows[rowIdx] = encRow
-							}
-							in := distsqlutils.NewRowBuffer(c.inputTypes, encRows, distsqlutils.RowBufferArgs{})
-
-							out := &distsqlutils.RowBuffer{}
-							post := c.post
-							if outputContinuation {
-								post.OutputColumns = append(post.OutputColumns, c.outputColumnForContinuation)
-							}
-							jr, err := newJoinReader(
-								&flowCtx,
-								0, /* processorID */
-								&execinfrapb.JoinReaderSpec{
-									Table:                             *td.TableDesc(),
-									IndexIdx:                          c.indexIdx,
-									LookupColumns:                     c.lookupCols,
-									LookupExpr:                        execinfrapb.Expression{Expr: c.lookupExpr},
-									OnExpr:                            execinfrapb.Expression{Expr: c.onExpr},
-									Type:                              c.joinType,
-									MaintainOrdering:                  reqOrdering,
-									LeftJoinWithPairedJoiner:          c.secondJoinInPairedJoin,
-									OutputGroupContinuationForLeftRow: outputContinuation,
-								},
-								in,
-								&post,
-								out,
-								lookupJoinReaderType,
-							)
-							if err != nil {
-								t.Fatal(err)
-							}
-
-							if smallBatch {
-								// Set a lower batch size to force multiple batches.
-								jr.(*joinReader).SetBatchSizeBytes(int64(encRows[0].Size() * 2))
-							}
-							// Else, use the default.
-
-							jr.Run(ctx)
-
-							if !in.Done {
-								t.Fatal("joinReader didn't consume all the rows")
-							}
-							if !out.ProducerClosed() {
-								t.Fatalf("output RowReceiver not closed")
-							}
-
-							var res rowenc.EncDatumRows
-							for {
-								row, meta := out.Next()
-								if meta != nil && meta.Metrics == nil {
-									t.Fatalf("unexpected metadata %+v", meta)
+								encRows := make(rowenc.EncDatumRows, len(c.input))
+								for rowIdx, row := range c.input {
+									encRow := make(rowenc.EncDatumRow, len(row))
+									for i, d := range row {
+										encRow[i] = rowenc.DatumToEncDatum(c.inputTypes[i], d)
+									}
+									encRows[rowIdx] = encRow
 								}
-								if row == nil {
-									break
+								in := distsqlutils.NewRowBuffer(c.inputTypes, encRows, distsqlutils.RowBufferArgs{})
+
+								if lowMemory {
+									flowCtx.Cfg.TestingKnobs.MemoryLimitBytes = int64(encRows[0].Size() * 2)
 								}
-								res = append(res, row)
-							}
 
-							// processOutputRows is a helper function that takes a stringified
-							// EncDatumRows output (e.g. [[1 2] [3 1]]) and returns a slice of
-							// stringified rows without brackets (e.g. []string{"1 2", "3 1"}).
-							processOutputRows := func(output string) []string {
-								// Comma-separate the rows.
-								output = strings.ReplaceAll(output, "] [", ",")
-								// Remove leading and trailing bracket.
-								output = strings.Trim(output, "[]")
-								// Split on the commas that were introduced and return that.
-								return strings.Split(output, ",")
-							}
+								out := &distsqlutils.RowBuffer{}
+								post := c.post
+								if outputContinuation {
+									post.OutputColumns = append(post.OutputColumns, c.outputColumnForContinuation)
+								}
+								jr, err := newJoinReader(
+									&flowCtx,
+									0, /* processorID */
+									&execinfrapb.JoinReaderSpec{
+										Table:                             *td.TableDesc(),
+										IndexIdx:                          c.indexIdx,
+										LookupColumns:                     c.lookupCols,
+										LookupExpr:                        execinfrapb.Expression{Expr: c.lookupExpr},
+										OnExpr:                            execinfrapb.Expression{Expr: c.onExpr},
+										Type:                              c.joinType,
+										MaintainOrdering:                  reqOrdering,
+										LeftJoinWithPairedJoiner:          c.secondJoinInPairedJoin,
+										OutputGroupContinuationForLeftRow: outputContinuation,
+									},
+									in,
+									&post,
+									out,
+									lookupJoinReaderType,
+								)
+								if err != nil {
+									t.Fatal(err)
+								}
 
-							outputTypes := c.outputTypes
-							if outputContinuation {
-								outputTypes = append(outputTypes, types.Bool)
-							}
-							result := processOutputRows(res.String(outputTypes))
-							var expected []string
-							if outputContinuation {
-								expected = processOutputRows(c.expectedWithContinuation)
-							} else {
-								expected = processOutputRows(c.expected)
-							}
+								if smallBatch {
+									// Set a lower batch size to force multiple batches.
+									jr.(*joinReader).SetBatchSizeBytes(int64(encRows[0].Size() * 2))
+								}
+								// Else, use the default.
 
-							if !reqOrdering {
-								// An ordering was not required, so sort both the result and
-								// expected slice to reuse equality comparison.
-								sort.Strings(result)
-								sort.Strings(expected)
-							}
+								jr.Run(ctx)
 
-							require.Equal(t, expected, result)
-						})
+								if !in.Done {
+									t.Fatal("joinReader didn't consume all the rows")
+								}
+								if !out.ProducerClosed() {
+									t.Fatalf("output RowReceiver not closed")
+								}
+
+								var res rowenc.EncDatumRows
+								var gotOutOfMemoryError bool
+								for {
+									row, meta := out.Next()
+									if meta != nil {
+										if lowMemory && meta.Err != nil {
+											if !sqlerrors.IsOutOfMemoryError(meta.Err) {
+												t.Fatalf("unexpected metadata %+v", meta)
+											}
+											gotOutOfMemoryError = true
+										} else if meta.Metrics == nil {
+											t.Fatalf("unexpected metadata %+v", meta)
+										}
+									}
+									if row == nil {
+										break
+									}
+									res = append(res, row)
+								}
+
+								if lowMemory {
+									if gotOutOfMemoryError {
+										return
+									}
+									t.Fatal("expected out of memory error but it did not occur")
+								}
+
+								// processOutputRows is a helper function that takes a stringified
+								// EncDatumRows output (e.g. [[1 2] [3 1]]) and returns a slice of
+								// stringified rows without brackets (e.g. []string{"1 2", "3 1"}).
+								processOutputRows := func(output string) []string {
+									// Comma-separate the rows.
+									output = strings.ReplaceAll(output, "] [", ",")
+									// Remove leading and trailing bracket.
+									output = strings.Trim(output, "[]")
+									// Split on the commas that were introduced and return that.
+									return strings.Split(output, ",")
+								}
+
+								outputTypes := c.outputTypes
+								if outputContinuation {
+									outputTypes = append(outputTypes, types.Bool)
+								}
+								result := processOutputRows(res.String(outputTypes))
+								var expected []string
+								if outputContinuation {
+									expected = processOutputRows(c.expectedWithContinuation)
+								} else {
+									expected = processOutputRows(c.expected)
+								}
+
+								if !reqOrdering {
+									// An ordering was not required, so sort both the result and
+									// expected slice to reuse equality comparison.
+									sort.Strings(result)
+									sort.Strings(expected)
+								}
+
+								require.Equal(t, expected, result)
+							})
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Note to reviewers: this was not a clean backport, so please review carefully.

Backport 1/2 commits from #67771.

/cc @cockroachdb/release

Release justification: This PR aims to fix a critical problem of insufficient memory accounting leading to OOM crashes.

---

**rowexec: improve memory accounting in `joinReader`**

This commit improves memory accounting in `joinReader` by accounting
for the in-memory data structures used throughout execution.

Fixes #65904

Release note: None
