### PR TITLE
sql: fix a bug where $user is not properly quoted in search_path

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/discard
+++ b/pkg/sql/logictest/testdata/logic_test/discard
@@ -12,7 +12,7 @@ DISCARD ALL
 query T
 SHOW SEARCH_PATH
 ----
-$user,public
+"$user", public
 
 query T
 SET timezone = 'Europe/Amsterdam'; SHOW TIMEZONE

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4322,7 +4322,7 @@ require_explicit_primary_keys                          off
 results_buffer_size                                    16384
 row_security                                           off
 save_tables_prefix                                     ·
-search_path                                            $user,public
+search_path                                            "$user", public
 serial_normalization                                   rowid
 server_encoding                                        UTF8
 server_version                                         13.0.0

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3603,7 +3603,7 @@ reorder_joins_limit                                    8                   NULL 
 require_explicit_primary_keys                          off                 NULL      NULL        NULL        string
 results_buffer_size                                    16384               NULL      NULL        NULL        string
 row_security                                           off                 NULL      NULL        NULL        string
-search_path                                            $user,public        NULL      NULL        NULL        string
+search_path                                            "$user", public     NULL      NULL        NULL        string
 serial_normalization                                   rowid               NULL      NULL        NULL        string
 server_encoding                                        UTF8                NULL      NULL        NULL        string
 server_version                                         13.0.0              NULL      NULL        NULL        string
@@ -3688,7 +3688,7 @@ reorder_joins_limit                                    8                   NULL 
 require_explicit_primary_keys                          off                 NULL  user     NULL      off                 off
 results_buffer_size                                    16384               NULL  user     NULL      16384               16384
 row_security                                           off                 NULL  user     NULL      off                 off
-search_path                                            $user,public        NULL  user     NULL      $user,public        $user,public
+search_path                                            "$user", public     NULL  user     NULL      $user,public        $user,public
 serial_normalization                                   rowid               NULL  user     NULL      rowid               rowid
 server_encoding                                        UTF8                NULL  user     NULL      UTF8                UTF8
 server_version                                         13.0.0              NULL  user     NULL      13.0.0              13.0.0

--- a/pkg/sql/logictest/testdata/logic_test/reset
+++ b/pkg/sql/logictest/testdata/logic_test/reset
@@ -15,7 +15,7 @@ RESET SEARCH_PATH
 query T
 SHOW SEARCH_PATH
 ----
-$user,public
+"$user", public
 
 statement error parameter "server_version" cannot be changed
 RESET SERVER_VERSION
@@ -39,7 +39,7 @@ RESET search_path
 query T
 SHOW search_path
 ----
-$user,public
+"$user", public
 
 statement ok
 RESET client_encoding; RESET NAMES

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -81,7 +81,7 @@ reorder_joins_limit                                    8
 require_explicit_primary_keys                          off
 results_buffer_size                                    16384
 row_security                                           off
-search_path                                            $user,public
+search_path                                            "$user", public
 serial_normalization                                   rowid
 server_encoding                                        UTF8
 server_version                                         13.0.0

--- a/pkg/sql/pgwire/conn_test.go
+++ b/pkg/sql/pgwire/conn_test.go
@@ -1519,7 +1519,7 @@ func TestSetSessionArguments(t *testing.T) {
 	}
 
 	expectedOptions := map[string]string{
-		"search_path": "public,testsp",
+		"search_path": "public, testsp",
 		// setting an isolation level is a noop:
 		// all transactions execute with serializable isolation.
 		"default_transaction_isolation": "serializable",

--- a/pkg/sql/sessiondata/BUILD.bazel
+++ b/pkg/sql/sessiondata/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     deps = [
         "//pkg/security",
         "//pkg/sql/catalog/catconstants",
+        "//pkg/sql/lexbase",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/pgwire/pgnotice",

--- a/pkg/sql/sessiondata/search_path.go
+++ b/pkg/sql/sessiondata/search_path.go
@@ -11,10 +11,12 @@
 package sessiondata
 
 import (
+	"bytes"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catconstants"
+	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 )
@@ -206,6 +208,18 @@ func (s SearchPath) Equals(other *SearchPath) bool {
 		}
 	}
 	return true
+}
+
+// SQLIdentifiers returns quotes for string starting with special characters.
+func (s SearchPath) SQLIdentifiers() string {
+	var buf bytes.Buffer
+	for i, path := range s.paths {
+		if i > 0 {
+			buf.WriteString(", ")
+		}
+		lexbase.EncodeRestrictedSQLIdent(&buf, path, lexbase.EncNoFlags)
+	}
+	return buf.String()
 }
 
 func (s SearchPath) String() string {

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -967,7 +967,7 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 		Get: func(evalCtx *extendedEvalContext) string {
-			return evalCtx.SessionData.SearchPath.String()
+			return evalCtx.SessionData.SearchPath.SQLIdentifiers()
 		},
 		GlobalDefault: func(sv *settings.Values) string {
 			return sessiondata.DefaultSearchPath.String()


### PR DESCRIPTION
Updated version of this PR 
https://github.com/cockroachdb/cockroach/pull/61849
@ajwerner @rafiss 

Fixes #61730

Release note (sql change): fix a bug where $user is not properly quoted in search_path