### PR TITLE
rowexec: improve mem accounting in the join reader

### DIFF
--- a/pkg/sql/rowcontainer/numbered_row_container.go
+++ b/pkg/sql/rowcontainer/numbered_row_container.go
@@ -216,6 +216,7 @@ func (d *DiskBackedNumberedRowContainer) Close(ctx context.Context) {
 	if d.deduper != nil {
 		d.deduper.Close(ctx)
 	}
+	d.cacheMap = nil
 }
 
 // numberedDiskRowIterator wraps a numberedRowIterator and adds two pieces

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -74,9 +74,19 @@ type joinReader struct {
 	// ProcessorBase.State == StateRunning.
 	runningState joinReaderState
 
-	// memAcc is used to account for the memory used by the in-memory data structures
-	// used by the joinReader and different joinReader strategies.
+	// memAcc is used to account for the memory used by the in-memory data
+	// structures used directly by the joinReader. Note that the joinReader
+	// strategies and span generators have separate accounts.
 	memAcc mon.BoundAccount
+
+	// accountedFor tracks the memory usage of scratchInputRows and
+	// groupingState that is currently registered with memAcc.
+	accountedFor struct {
+		// scratchInputRows accounts only for the slice of scratchInputRows, not
+		// the actual rows.
+		scratchInputRows int64
+		groupingState    int64
+	}
 
 	// limitedMemMonitor is a limited memory monitor to account for the memory
 	// used by buffered rows in joinReaderOrderingStrategy. If the memory limit is
@@ -147,6 +157,9 @@ type joinReader struct {
 
 	// State variables for each batch of input rows.
 	scratchInputRows rowenc.EncDatumRows
+	// resetScratchWhenReadingInput tracks whether scratchInputRows needs to be
+	// reset the next time the joinReader is in the jrReadingInput state.
+	resetScratchWhenReadingInput bool
 
 	// Fields used when this is the second join in a pair of joins that are
 	// together implementing left {outer,semi,anti} joins where the first join
@@ -420,6 +433,8 @@ func (jr *joinReader) initJoinReaderStrategy(
 	spanBuilder := span.MakeBuilder(flowCtx.EvalCtx, flowCtx.Codec(), jr.desc, jr.index)
 	spanBuilder.SetNeededColumns(neededRightCols)
 
+	strategyMemAcc := jr.MemMonitor.MakeBoundAccount()
+	spanGeneratorMemAcc := jr.MemMonitor.MakeBoundAccount()
 	var generator joinReaderSpanGenerator
 	if jr.lookupExpr.Expr == nil {
 		var keyToInputRowIndices map[string][]int
@@ -433,7 +448,7 @@ func (jr *joinReader) initJoinReaderStrategy(
 			keyToInputRowIndices: keyToInputRowIndices,
 			numKeyCols:           numKeyCols,
 			lookupCols:           jr.lookupCols,
-			memAcc:               &jr.memAcc,
+			memAcc:               &spanGeneratorMemAcc,
 		}
 	} else {
 		// Since jr.lookupExpr is set, we need to use either multiSpanGenerator or
@@ -456,13 +471,14 @@ func (jr *joinReader) initJoinReaderStrategy(
 				len(jr.input.OutputTypes()),
 				&jr.lookupExpr,
 				tableOrdToIndexOrd,
-				&jr.memAcc,
+				&spanGeneratorMemAcc,
 			); err != nil {
 				return err
 			}
 			generator = multiSpanGen
 		} else {
 			localityOptSpanGen := &localityOptimizedSpanGenerator{}
+			remoteSpanGenMemAcc := jr.MemMonitor.MakeBoundAccount()
 			if err := localityOptSpanGen.init(
 				spanBuilder,
 				numKeyCols,
@@ -470,7 +486,8 @@ func (jr *joinReader) initJoinReaderStrategy(
 				&jr.lookupExpr,
 				&jr.remoteLookupExpr,
 				tableOrdToIndexOrd,
-				&jr.memAcc,
+				&spanGeneratorMemAcc,
+				&remoteSpanGenMemAcc,
 			); err != nil {
 				return err
 			}
@@ -482,6 +499,7 @@ func (jr *joinReader) initJoinReaderStrategy(
 		jr.strategy = &joinReaderIndexJoinStrategy{
 			joinerBase:              &jr.joinerBase,
 			joinReaderSpanGenerator: generator,
+			memAcc:                  &strategyMemAcc,
 		}
 		return nil
 	}
@@ -492,7 +510,7 @@ func (jr *joinReader) initJoinReaderStrategy(
 			joinReaderSpanGenerator: generator,
 			isPartialJoin:           jr.joinType == descpb.LeftSemiJoin || jr.joinType == descpb.LeftAntiJoin,
 			groupingState:           jr.groupingState,
-			memAcc:                  &jr.memAcc,
+			memAcc:                  &strategyMemAcc,
 		}
 		return nil
 	}
@@ -524,7 +542,7 @@ func (jr *joinReader) initJoinReaderStrategy(
 		lookedUpRows:                      drc,
 		groupingState:                     jr.groupingState,
 		outputGroupContinuationForLeftRow: jr.outputGroupContinuationForLeftRow,
-		memAcc:                            &jr.memAcc,
+		memAcc:                            &strategyMemAcc,
 	}
 	return nil
 }
@@ -650,7 +668,21 @@ func (jr *joinReader) readInput() (
 		// did the reset for this batch.
 	}
 
-	sizeBefore := jr.memUsage()
+	if jr.resetScratchWhenReadingInput {
+		// Deeply reset the rows from the previous input batch.
+		for i := range jr.scratchInputRows {
+			jr.scratchInputRows[i] = nil
+		}
+		// We've just discarded the old rows, so we have to update the memory
+		// accounting accordingly.
+		newSz := jr.accountedFor.scratchInputRows + jr.accountedFor.groupingState
+		if err := jr.memAcc.ResizeTo(jr.Ctx, newSz); err != nil {
+			jr.MoveToDraining(err)
+			return jrStateUnknown, nil, jr.DrainHelper()
+		}
+		jr.scratchInputRows = jr.scratchInputRows[:0]
+		jr.resetScratchWhenReadingInput = false
+	}
 
 	// Read the next batch of input rows.
 	for jr.curBatchSizeBytes < jr.batchSizeBytes {
@@ -661,9 +693,7 @@ func (jr *joinReader) readInput() (
 				return jrStateUnknown, nil, meta
 			}
 
-			// Perform memory accounting.
-			sizeAfter := jr.memUsage()
-			if err := jr.memAcc.Resize(jr.Ctx, sizeBefore, sizeAfter); err != nil {
+			if err := jr.performMemoryAccounting(); err != nil {
 				jr.MoveToDraining(err)
 				return jrStateUnknown, nil, meta
 			}
@@ -681,12 +711,19 @@ func (jr *joinReader) readInput() (
 				return jrStateUnknown, nil, jr.DrainHelper()
 			}
 		}
+		// Keep the copy of the row after accounting for its memory usage.
+		//
+		// We need to subtract the EncDatumRowOverhead because that is already
+		// tracked in jr.accountedFor.scratchInputRows.
+		rowSize := int64(row.Size() - rowenc.EncDatumRowOverhead)
+		if err := jr.memAcc.Grow(jr.Ctx, rowSize); err != nil {
+			jr.MoveToDraining(err)
+			return jrStateUnknown, nil, jr.DrainHelper()
+		}
 		jr.scratchInputRows = append(jr.scratchInputRows, jr.rowAlloc.CopyRow(row))
 	}
 
-	// Perform memory accounting.
-	sizeAfter := jr.memUsage()
-	if err := jr.memAcc.Resize(jr.Ctx, sizeBefore, sizeAfter); err != nil {
+	if err := jr.performMemoryAccounting(); err != nil {
 		jr.MoveToDraining(err)
 		return jrStateUnknown, nil, jr.DrainHelper()
 	}
@@ -720,7 +757,7 @@ func (jr *joinReader) readInput() (
 		return jrStateUnknown, nil, jr.DrainHelper()
 	}
 	jr.curBatchInputRowCount = int64(len(jr.scratchInputRows))
-	jr.scratchInputRows = jr.scratchInputRows[:0]
+	jr.resetScratchWhenReadingInput = true
 	jr.curBatchSizeBytes = 0
 	jr.curBatchRowsRead = 0
 	if len(spans) == 0 {
@@ -867,6 +904,14 @@ func (jr *joinReader) emitRow() (
 		return jrStateUnknown, nil, jr.DrainHelper()
 	}
 	return nextState, rowToEmit, nil
+}
+
+func (jr *joinReader) performMemoryAccounting() error {
+	oldSz := jr.accountedFor.scratchInputRows + jr.accountedFor.groupingState
+	jr.accountedFor.scratchInputRows = int64(cap(jr.scratchInputRows)) * int64(rowenc.EncDatumRowOverhead)
+	jr.accountedFor.groupingState = jr.groupingState.memUsage()
+	newSz := jr.accountedFor.scratchInputRows + jr.accountedFor.groupingState
+	return jr.memAcc.Resize(jr.Ctx, oldSz, newSz)
 }
 
 // Start is part of the RowSource interface.
@@ -1026,26 +1071,6 @@ func (jr *joinReader) updateGroupingStateForNonEmptyBatch() {
 	}
 }
 
-// memUsage returns the size of the data structures in the joinReader for memory
-// accounting purposes.
-func (jr *joinReader) memUsage() int64 {
-	var size int64
-
-	// Account for scratchInputRows. Slice the full capacity so we can account for
-	// the memory used by rows past the length of scratchInputRows.
-	rowsCap := jr.scratchInputRows[:cap(jr.scratchInputRows)]
-	for i := range rowsCap {
-		size += int64(rowsCap[i].Size())
-	}
-
-	// Account for groupingState.
-	if jr.groupingState != nil {
-		size += int64(cap(jr.groupingState.groupState)) * int64(unsafe.Sizeof(groupState{}))
-		size += int64(cap(jr.groupingState.batchRowToGroupIndex)) * memsize.Int
-	}
-	return size
-}
-
 // inputBatchGroupingState encapsulates the state needed for all the
 // groups in an input batch, for lookup joins (not used for index
 // joins).
@@ -1151,4 +1176,12 @@ func (ib *inputBatchGroupingState) isUnmatched(rowIndex int) bool {
 	// group since for earlier rows, when at step (b), one does not know the
 	// match state of later rows in the group.
 	return !ib.groupState[groupIndex].matched && ib.groupState[groupIndex].lastRow == rowIndex
+}
+
+func (ib *inputBatchGroupingState) memUsage() int64 {
+	if ib == nil {
+		return 0
+	}
+	return int64(cap(ib.groupState))*int64(unsafe.Sizeof(groupState{})) +
+		int64(cap(ib.batchRowToGroupIndex))*memsize.Int
 }

--- a/pkg/sql/rowexec/joinreader_blackbox_test.go
+++ b/pkg/sql/rowexec/joinreader_blackbox_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/stretchr/testify/require"
 )
@@ -31,6 +32,7 @@ import (
 // Check that the join reader uses bytes limits on its lookups.
 func TestJoinReaderUsesBatchLimit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
 	recCh := make(chan tracing.Recording, 1)

--- a/pkg/sql/rowexec/joinreader_strategies.go
+++ b/pkg/sql/rowexec/joinreader_strategies.go
@@ -137,6 +137,9 @@ type joinReaderNoOrderingStrategy struct {
 
 	groupingState *inputBatchGroupingState
 
+	// memAcc is owned by this strategy and is closed when the strategy is
+	// closed. inputRows are owned by the joinReader, so they aren't accounted
+	// for with this memory account.
 	memAcc *mon.BoundAccount
 }
 
@@ -180,9 +183,6 @@ func (s *joinReaderNoOrderingStrategy) processLookedUpRow(
 ) (joinReaderState, error) {
 	matchingInputRowIndices := s.getMatchingRowIndices(key)
 	if s.isPartialJoin {
-		// Perform memory accounting.
-		beforeSize := s.memUsage()
-
 		// In the case of partial joins, only process input rows that have not been
 		// matched yet. Make a copy of the matching input row indices to avoid
 		// overwriting the caller's slice.
@@ -195,8 +195,7 @@ func (s *joinReaderNoOrderingStrategy) processLookedUpRow(
 		matchingInputRowIndices = s.scratchMatchingInputRowIndices
 
 		// Perform memory accounting.
-		afterSize := s.memUsage()
-		if err := s.memAcc.Resize(s.Ctx, beforeSize, afterSize); err != nil {
+		if err := s.memAcc.ResizeTo(s.Ctx, s.memUsage()); err != nil {
 			return jrStateUnknown, err
 		}
 	}
@@ -222,9 +221,6 @@ func (s *joinReaderNoOrderingStrategy) nextRowToEmit(
 		}
 
 		if !s.emitState.unmatchedInputRowIndicesInitialized {
-			// Perform memory accounting.
-			beforeSize := s.memUsage()
-
 			s.emitState.unmatchedInputRowIndices = s.emitState.unmatchedInputRowIndices[:0]
 			for inputRowIdx := range s.inputRows {
 				if s.groupingState.isUnmatched(inputRowIdx) {
@@ -235,8 +231,7 @@ func (s *joinReaderNoOrderingStrategy) nextRowToEmit(
 			s.emitState.unmatchedInputRowIndicesCursor = 0
 
 			// Perform memory accounting.
-			afterSize := s.memUsage()
-			if err := s.memAcc.Resize(s.Ctx, beforeSize, afterSize); err != nil {
+			if err := s.memAcc.ResizeTo(s.Ctx, s.memUsage()); err != nil {
 				return nil, jrStateUnknown, err
 			}
 		}
@@ -297,7 +292,11 @@ func (s *joinReaderNoOrderingStrategy) nextRowToEmit(
 
 func (s *joinReaderNoOrderingStrategy) spilled() bool { return false }
 
-func (s *joinReaderNoOrderingStrategy) close(_ context.Context) {}
+func (s *joinReaderNoOrderingStrategy) close(ctx context.Context) {
+	s.memAcc.Close(ctx)
+	s.joinReaderSpanGenerator.close(ctx)
+	*s = joinReaderNoOrderingStrategy{}
+}
 
 // memUsage returns the size of the data structures in the
 // joinReaderNoOrderingStrategy for memory accounting purposes.
@@ -341,6 +340,14 @@ type joinReaderIndexJoinStrategy struct {
 		processingLookupRow bool
 		lookedUpRow         rowenc.EncDatumRow
 	}
+
+	// memAcc is owned by this strategy and is closed when the strategy is
+	// closed. inputRows are owned by the joinReader, so they aren't accounted
+	// for with this memory account.
+	//
+	// Note that joinReaderIndexJoinStrategy doesn't actually need a
+	// memory account, and it's only responsible for closing it.
+	memAcc *mon.BoundAccount
 }
 
 // getLookupRowsBatchSizeHint returns the batch size for the join reader index
@@ -395,7 +402,11 @@ func (s *joinReaderIndexJoinStrategy) spilled() bool {
 	return false
 }
 
-func (s *joinReaderIndexJoinStrategy) close(ctx context.Context) {}
+func (s *joinReaderIndexJoinStrategy) close(ctx context.Context) {
+	s.memAcc.Close(ctx)
+	s.joinReaderSpanGenerator.close(ctx)
+	*s = joinReaderIndexJoinStrategy{}
+}
 
 // partialJoinSentinel is used as the inputRowIdxToLookedUpRowIndices value for
 // semi- and anti-joins, where we only need to know about the existence of a
@@ -477,7 +488,14 @@ type joinReaderOrderingStrategy struct {
 	// the second join in paired-joins).
 	outputGroupContinuationForLeftRow bool
 
+	// memAcc is owned by this strategy and is closed when the strategy is
+	// closed. inputRows are owned by the joinReader, so they aren't accounted
+	// for with this memory account.
 	memAcc *mon.BoundAccount
+
+	// testingInfoSpilled is set when the strategy is closed to indicate whether
+	// it has spilled to disk during its lifetime. Used only in tests.
+	testingInfoSpilled bool
 }
 
 func (s *joinReaderOrderingStrategy) getLookupRowsBatchSizeHint() int64 {
@@ -515,10 +533,8 @@ func (s *joinReaderOrderingStrategy) processLookupRows(
 			s.inputRowIdxToLookedUpRowIndices[i] = s.inputRowIdxToLookedUpRowIndices[i][:0]
 		}
 	} else {
-		beforeSize := s.memUsage(nil)
 		s.inputRowIdxToLookedUpRowIndices = make([][]int, len(rows))
-		afterSize := s.memUsage(nil)
-		if err := s.memAcc.Resize(s.Ctx, beforeSize, afterSize); err != nil {
+		if err := s.memAcc.ResizeTo(s.Ctx, s.memUsage(nil /* matchingInputRowIndices */)); err != nil {
 			return nil, err
 		}
 	}
@@ -548,7 +564,6 @@ func (s *joinReaderOrderingStrategy) processLookedUpRow(
 	}
 
 	// Update our map from input rows to looked up rows.
-	beforeSize := s.memUsage(matchingInputRowIndices)
 	for _, inputRowIdx := range matchingInputRowIndices {
 		if !s.isPartialJoin {
 			s.inputRowIdxToLookedUpRowIndices[inputRowIdx] = append(
@@ -576,8 +591,7 @@ func (s *joinReaderOrderingStrategy) processLookedUpRow(
 	}
 
 	// Perform memory accounting.
-	afterSize := s.memUsage(matchingInputRowIndices)
-	if err := s.memAcc.Resize(s.Ctx, beforeSize, afterSize); err != nil {
+	if err := s.memAcc.ResizeTo(s.Ctx, s.memUsage(matchingInputRowIndices)); err != nil {
 		return jrStateUnknown, err
 	}
 
@@ -670,12 +684,21 @@ func (s *joinReaderOrderingStrategy) nextRowToEmit(
 }
 
 func (s *joinReaderOrderingStrategy) spilled() bool {
-	return s.lookedUpRows.Spilled()
+	if s.lookedUpRows != nil {
+		return s.lookedUpRows.Spilled()
+	}
+	// The strategy must have been closed.
+	return s.testingInfoSpilled
 }
 
 func (s *joinReaderOrderingStrategy) close(ctx context.Context) {
+	s.memAcc.Close(ctx)
+	s.joinReaderSpanGenerator.close(ctx)
 	if s.lookedUpRows != nil {
 		s.lookedUpRows.Close(ctx)
+	}
+	*s = joinReaderOrderingStrategy{
+		testingInfoSpilled: s.lookedUpRows.Spilled(),
 	}
 }
 

--- a/pkg/sql/rowexec/joinreader_test.go
+++ b/pkg/sql/rowexec/joinreader_test.go
@@ -55,6 +55,8 @@ var sixIntColsAndStringCol = []*types.T{
 
 func TestJoinReader(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
 	ctx := context.Background()
 
 	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
@@ -977,6 +979,8 @@ func TestJoinReader(t *testing.T) {
 
 func TestJoinReaderDiskSpill(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
 	ctx := context.Background()
 
 	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
@@ -1203,6 +1207,7 @@ func TestJoinReaderDrain(t *testing.T) {
 
 func TestIndexJoiner(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())


### PR DESCRIPTION
This commit separates out three memory usages in the join reader code
(the processor itself, the join reader strategy, and the span generator)
by introducing additional memory accounts. This allows us to use
`ResizeTo` method and get the memory usage once, instead of twice.

Additionally, it refactors the way the memory accounting is done in the
join reader - we now update the memory account before each row is copied
rather than in bulk, after all rows have been copied. It also deeply
resets the scratch rows space as well as nils out some things eagerly.

Release note: None