### PR TITLE
backupccl: update restore concurrency knob to use metamorphic value

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -90,6 +90,7 @@ go_library(
         "//pkg/storage",
         "//pkg/storage/cloud",
         "//pkg/testutils",
+        "//pkg/util",
         "//pkg/util/contextutil",
         "//pkg/util/ctxgroup",
         "//pkg/util/encoding",

--- a/pkg/ccl/backupccl/restore_data_processor.go
+++ b/pkg/ccl/backupccl/restore_data_processor.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -74,6 +75,13 @@ const restoreDataProcName = "restoreDataProcessor"
 
 const maxConcurrentRestoreWorkers = 32
 
+var defaultNumWorkers = util.ConstantWithMetamorphicTestRange(
+	"restore-worker-concurrency",
+	1, /* defaultValue */
+	1, /* metamorphic min */
+	8, /* metamorphic max */
+)
+
 // TODO(pbardea): It may be worthwhile to combine this setting with the one that
 // controls the number of concurrent AddSSTable requests if each restore worker
 // spends all if its time sending AddSSTable requests.
@@ -84,7 +92,7 @@ var numRestoreWorkers = settings.RegisterIntSetting(
 	"kv.bulk_io_write.restore_node_concurrency",
 	fmt.Sprintf("the number of workers processing a restore per job per node; maximum %d",
 		maxConcurrentRestoreWorkers),
-	1, /* default */
+	int64(defaultNumWorkers),
 	settings.PositiveInt,
 )
 


### PR DESCRIPTION
This increases coverage under testing.

Release note: None