### PR TITLE
base: make ClusterIDContainer lock-free

### DIFF
--- a/pkg/base/BUILD.bazel
+++ b/pkg/base/BUILD.bazel
@@ -32,7 +32,6 @@ go_library(
         "//pkg/util/netutil/addr",
         "//pkg/util/retry",
         "//pkg/util/stop",
-        "//pkg/util/syncutil",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//oserror",


### PR DESCRIPTION
This commit replaces the use of a `sync.Mutex` in `ClusterIDContainer`
with an `atomic.Value`. This eliminates synchronization between CPUs
when reading from this container. In all likelihood, this doesn't matter
and we'll never be able to measure a performance difference with this.
The justification for this change is mostly just because synchronizing
on a mutex a few times per request in order to access a read-only memory
location (outside of process initialization) feels wrong.