### PR TITLE
release-21.1: importccl: fail PGDUMP IMPORT if we see a UDT

### DIFF
--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -1076,6 +1076,22 @@ CREATE INDEX i ON t USING btree (a) WHERE (b > 10);
 			`,
 			err: "cannot import a table with partial indexes",
 		},
+		{
+			name: "user defined type",
+			typ:  "PGDUMP",
+			data: `
+CREATE TYPE duration AS ENUM (
+    'YESTERDAY',
+    'LAST_7_DAYS',
+    'LAST_28_DAYS',
+    'LAST_90_DAYS',
+    'LAST_365_DAYS',
+    'LIFE_TIME'
+);
+CREATE TABLE t (a duration);
+			`,
+			err: "IMPORT PGDUMP does not support user defined types",
+		},
 
 		// Error
 		{

--- a/pkg/ccl/importccl/read_import_pgdump.go
+++ b/pkg/ccl/importccl/read_import_pgdump.go
@@ -826,6 +826,9 @@ func readPostgresStmt(
 			return unsupportedStmtLogger.log(fmt.Sprintf("%s", stmt), false /* isParseError */)
 		}
 		return wrapErrorWithUnsupportedHint(errors.Errorf("unsupported %T statement: %s", stmt, stmt))
+	case *tree.CreateType:
+		return errors.New("IMPORT PGDUMP does not support user defined types; please" +
+			" remove all CREATE TYPE statements and their usages from the dump file")
 	case error:
 		if !errors.Is(stmt, errCopyDone) {
 			return stmt


### PR DESCRIPTION
Backport 1/1 commits from #67994.

/cc @cockroachdb/release

---

In 21.1 we added `ignore_unsupported_statements` that ignored
all statements that we didnt support while parsing the PGDUMP
file. We don't support `CREATE TYPE` and its subsequent usage,
and this currently causes a NPE.

While we work on adding UDT support to PGDUMP we should make
an exception to the ignore option and fail the import instead.

Informs: #67983

Release note (bug fix): IMPORT PGDUMP with a UDT would result
in a nil pointer exception. This change makes it fail gracefully.
