### PR TITLE
roachtest: create perf dir for bulk roachtests

### DIFF
--- a/pkg/cmd/roachtest/tests/backup.go
+++ b/pkg/cmd/roachtest/tests/backup.go
@@ -197,6 +197,9 @@ func registerBackup(r registry.Registry) {
 				// Upload the perf artifacts to any one of the nodes so that the test
 				// runner copies it into an appropriate directory path.
 				dest := filepath.Join(t.PerfArtifactsDir(), "stats.json")
+				if err := c.RunE(ctx, c.Node(1), "mkdir -p "+filepath.Dir(dest)); err != nil {
+					log.Errorf(ctx, "failed to create perf dir: %+v", err)
+				}
 				if err := c.PutString(ctx, perfBuf.String(), dest, 755, c.Node(1)); err != nil {
 					log.Errorf(ctx, "failed to upload perf artifacts to node: %s", err.Error())
 				}

--- a/pkg/cmd/roachtest/tests/backup.go
+++ b/pkg/cmd/roachtest/tests/backup.go
@@ -200,7 +200,7 @@ func registerBackup(r registry.Registry) {
 				if err := c.RunE(ctx, c.Node(1), "mkdir -p "+filepath.Dir(dest)); err != nil {
 					log.Errorf(ctx, "failed to create perf dir: %+v", err)
 				}
-				if err := c.PutString(ctx, perfBuf.String(), dest, 755, c.Node(1)); err != nil {
+				if err := c.PutString(ctx, perfBuf.String(), dest, 0755, c.Node(1)); err != nil {
 					log.Errorf(ctx, "failed to upload perf artifacts to node: %s", err.Error())
 				}
 				return nil

--- a/pkg/cmd/roachtest/tests/import.go
+++ b/pkg/cmd/roachtest/tests/import.go
@@ -126,7 +126,7 @@ func registerImportTPCC(r registry.Registry) {
 			if err := c.RunE(ctx, c.Node(1), "mkdir -p "+filepath.Dir(dest)); err != nil {
 				log.Errorf(ctx, "failed to create perf dir: %+v", err)
 			}
-			if err := c.PutString(ctx, perfBuf.String(), dest, 755, c.Node(1)); err != nil {
+			if err := c.PutString(ctx, perfBuf.String(), dest, 0755, c.Node(1)); err != nil {
 				log.Errorf(ctx, "failed to upload perf artifacts to node: %s", err.Error())
 			}
 			return nil
@@ -266,7 +266,7 @@ func registerImportTPCH(r registry.Registry) {
 					if err := c.RunE(ctx, c.Node(1), "mkdir -p "+filepath.Dir(dest)); err != nil {
 						log.Errorf(ctx, "failed to create perf dir: %+v", err)
 					}
-					if err := c.PutString(ctx, perfBuf.String(), dest, 755, c.Node(1)); err != nil {
+					if err := c.PutString(ctx, perfBuf.String(), dest, 0755, c.Node(1)); err != nil {
 						log.Errorf(ctx, "failed to upload perf artifacts to node: %s", err.Error())
 					}
 					return nil

--- a/pkg/cmd/roachtest/tests/import.go
+++ b/pkg/cmd/roachtest/tests/import.go
@@ -123,6 +123,9 @@ func registerImportTPCC(r registry.Registry) {
 			// Upload the perf artifacts to any one of the nodes so that the test
 			// runner copies it into an appropriate directory path.
 			dest := filepath.Join(t.PerfArtifactsDir(), "stats.json")
+			if err := c.RunE(ctx, c.Node(1), "mkdir -p "+filepath.Dir(dest)); err != nil {
+				log.Errorf(ctx, "failed to create perf dir: %+v", err)
+			}
 			if err := c.PutString(ctx, perfBuf.String(), dest, 755, c.Node(1)); err != nil {
 				log.Errorf(ctx, "failed to upload perf artifacts to node: %s", err.Error())
 			}
@@ -260,6 +263,9 @@ func registerImportTPCH(r registry.Registry) {
 					// Upload the perf artifacts to any one of the nodes so that the test
 					// runner copies it into an appropriate directory path.
 					dest := filepath.Join(t.PerfArtifactsDir(), "stats.json")
+					if err := c.RunE(ctx, c.Node(1), "mkdir -p "+filepath.Dir(dest)); err != nil {
+						log.Errorf(ctx, "failed to create perf dir: %+v", err)
+					}
 					if err := c.PutString(ctx, perfBuf.String(), dest, 755, c.Node(1)); err != nil {
 						log.Errorf(ctx, "failed to upload perf artifacts to node: %s", err.Error())
 					}

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -441,7 +441,7 @@ func registerRestore(r registry.Registry) {
 					if err := c.RunE(ctx, c.Node(1), "mkdir -p "+filepath.Dir(dest)); err != nil {
 						log.Errorf(ctx, "failed to create perf dir: %+v", err)
 					}
-					if err := c.PutString(ctx, perfBuf.String(), dest, 755, c.Node(1)); err != nil {
+					if err := c.PutString(ctx, perfBuf.String(), dest, 0755, c.Node(1)); err != nil {
 						log.Errorf(ctx, "failed to upload perf artifacts to node: %s", err.Error())
 					}
 					return nil

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -438,6 +438,9 @@ func registerRestore(r registry.Registry) {
 					// Upload the perf artifacts to any one of the nodes so that the test
 					// runner copies it into an appropriate directory path.
 					dest := filepath.Join(t.PerfArtifactsDir(), "stats.json")
+					if err := c.RunE(ctx, c.Node(1), "mkdir -p "+filepath.Dir(dest)); err != nil {
+						log.Errorf(ctx, "failed to create perf dir: %+v", err)
+					}
 					if err := c.PutString(ctx, perfBuf.String(), dest, 755, c.Node(1)); err != nil {
 						log.Errorf(ctx, "failed to upload perf artifacts to node: %s", err.Error())
 					}


### PR DESCRIPTION
When the bulk op roachtests were updated to avoid racing when writing
their stats files, the creation of the perf directory itself was
removed. This adds it back.

There was some consideration to update PutString to create the
filepath.Dir of its destination but that refactor was left for a
potential follow up since it applies to other tests as well.

Fixes https://github.com/cockroachdb/cockroach/issues/67870.

Release note: None