### PR TITLE
colexec: refactor dynamic batching to pay attention to memory footprint

### DIFF
--- a/pkg/sql/colexec/aggregators_test.go
+++ b/pkg/sql/colexec/aggregators_test.go
@@ -13,6 +13,7 @@ package colexec
 import (
 	"context"
 	"fmt"
+	"math"
 	"strings"
 	"testing"
 
@@ -70,7 +71,7 @@ var aggTypes = []aggType{
 		// This is a wrapper around NewHashAggregator so its signature is
 		// compatible with NewOrderedAggregator.
 		new: func(args *colexecagg.NewAggregatorArgs) (colexecop.ResettableOperator, error) {
-			return NewHashAggregator(args, nil /* newSpillingQueueArgs */)
+			return NewHashAggregator(args, nil /* newSpillingQueueArgs */, testAllocator, math.MaxInt64)
 		},
 		name: "hash",
 	},

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -848,6 +848,11 @@ func NewColOperator(
 
 			if needHash {
 				opName := "hash-aggregator"
+				outputUnlimitedAllocator := colmem.NewAllocator(
+					ctx,
+					result.createUnlimitedMemAccount(ctx, flowCtx, opName+"-output", spec.ProcessorID),
+					factory,
+				)
 				// We have separate unit tests that instantiate the in-memory
 				// hash aggregators, so we don't need to look at
 				// args.TestingKnobs.DiskSpillingDisabled and always instantiate
@@ -865,16 +870,23 @@ func NewColOperator(
 					)
 					newAggArgs.MemAccount = hashAggregatorUnlimitedMemAccount
 					evalCtx.SingleDatumAggMemAccount = hashAggregatorUnlimitedMemAccount
+					maxOutputBatchMemSize := execinfra.GetWorkMemLimit(flowCtx)
 					// The second argument is nil because we disable the
 					// tracking of the input tuples.
-					result.Root, err = colexec.NewHashAggregator(newAggArgs, nil /* newSpillingQueueArgs */)
+					result.Root, err = colexec.NewHashAggregator(
+						newAggArgs, nil, /* newSpillingQueueArgs */
+						outputUnlimitedAllocator, maxOutputBatchMemSize,
+					)
 				} else {
 					// We will divide the available memory equally between the
 					// two usages - the hash aggregation itself and the input
 					// tuples tracking.
 					totalMemLimit := execinfra.GetWorkMemLimit(flowCtx)
+					// We will give 20% of the hash aggregation budget to the
+					// output batch.
+					maxOutputBatchMemSize := totalMemLimit / 10
 					hashAggregatorMemAccount, hashAggregatorMemMonitorName := result.createMemAccountForSpillStrategyWithLimit(
-						ctx, flowCtx, totalMemLimit/2, opName, spec.ProcessorID,
+						ctx, flowCtx, totalMemLimit/2-maxOutputBatchMemSize, opName, spec.ProcessorID,
 					)
 					spillingQueueMemMonitorName := hashAggregatorMemMonitorName + "-spilling-queue"
 					// We need to create a separate memory account for the
@@ -899,6 +911,8 @@ func NewColOperator(
 							FDSemaphore:        args.FDSemaphore,
 							DiskAcc:            result.createDiskAccount(ctx, flowCtx, spillingQueueMemMonitorName, spec.ProcessorID),
 						},
+						outputUnlimitedAllocator,
+						maxOutputBatchMemSize,
 					)
 					if err != nil {
 						return r, err
@@ -930,6 +944,13 @@ func NewColOperator(
 								&newAggArgs,
 								result.makeDiskBackedSorterConstructor(ctx, flowCtx, args, ehaOpName, factory),
 								result.createDiskAccount(ctx, flowCtx, ehaOpName, spec.ProcessorID),
+								// Note that here we can use the same allocator
+								// object as we passed to the in-memory hash
+								// aggregator because only one (either in-memory
+								// or external) operator will reach the output
+								// state.
+								outputUnlimitedAllocator,
+								maxOutputBatchMemSize,
 							)
 						},
 						args.TestingKnobs.SpillingCallbackFn,

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -352,6 +352,9 @@ func (r opResult) createDiskBackedSort(
 		// The input is already fully ordered, so there is nothing to sort.
 		return input, nil
 	}
+	totalMemLimit := execinfra.GetWorkMemLimit(flowCtx)
+	spoolMemLimit := totalMemLimit * 4 / 5
+	maxOutputBatchMemSize := totalMemLimit - spoolMemLimit
 	if matchLen > 0 {
 		// The input is already partially ordered. Use a chunks sorter to avoid
 		// loading all the rows into memory.
@@ -359,13 +362,13 @@ func (r opResult) createDiskBackedSort(
 		if useStreamingMemAccountForBuffering {
 			sortChunksMemAccount = streamingMemAccount
 		} else {
-			sortChunksMemAccount, sorterMemMonitorName = r.createMemAccountForSpillStrategy(
-				ctx, flowCtx, opNamePrefix+"sort-chunks", processorID,
+			sortChunksMemAccount, sorterMemMonitorName = r.createMemAccountForSpillStrategyWithLimit(
+				ctx, flowCtx, spoolMemLimit, opNamePrefix+"sort-chunks", processorID,
 			)
 		}
 		inMemorySorter, err = colexec.NewSortChunks(
 			colmem.NewAllocator(ctx, sortChunksMemAccount, factory), input, inputTypes,
-			ordering.Columns, int(matchLen),
+			ordering.Columns, int(matchLen), maxOutputBatchMemSize,
 		)
 	} else if post.Limit != 0 && post.Limit < math.MaxUint64-post.Offset {
 		// There is a limit specified, so we know exactly how many rows the
@@ -381,14 +384,14 @@ func (r opResult) createDiskBackedSort(
 		if useStreamingMemAccountForBuffering {
 			topKSorterMemAccount = streamingMemAccount
 		} else {
-			topKSorterMemAccount, sorterMemMonitorName = r.createMemAccountForSpillStrategy(
-				ctx, flowCtx, opNamePrefix+"topk-sort", processorID,
+			topKSorterMemAccount, sorterMemMonitorName = r.createMemAccountForSpillStrategyWithLimit(
+				ctx, flowCtx, spoolMemLimit, opNamePrefix+"topk-sort", processorID,
 			)
 		}
 		topK = post.Limit + post.Offset
 		inMemorySorter = colexec.NewTopKSorter(
-			colmem.NewAllocator(ctx, topKSorterMemAccount, factory), input, inputTypes,
-			ordering.Columns, topK,
+			colmem.NewAllocator(ctx, topKSorterMemAccount, factory), input,
+			inputTypes, ordering.Columns, topK, maxOutputBatchMemSize,
 		)
 	} else {
 		// No optimizations possible. Default to the standard sort operator.
@@ -396,12 +399,13 @@ func (r opResult) createDiskBackedSort(
 		if useStreamingMemAccountForBuffering {
 			sorterMemAccount = streamingMemAccount
 		} else {
-			sorterMemAccount, sorterMemMonitorName = r.createMemAccountForSpillStrategy(
-				ctx, flowCtx, opNamePrefix+"sort-all", processorID,
+			sorterMemAccount, sorterMemMonitorName = r.createMemAccountForSpillStrategyWithLimit(
+				ctx, flowCtx, spoolMemLimit, opNamePrefix+"sort-all", processorID,
 			)
 		}
 		inMemorySorter, err = colexec.NewSorter(
-			colmem.NewAllocator(ctx, sorterMemAccount, factory), input, inputTypes, ordering.Columns,
+			colmem.NewAllocator(ctx, sorterMemAccount, factory), input,
+			inputTypes, ordering.Columns, maxOutputBatchMemSize,
 		)
 	}
 	if err != nil {
@@ -1056,7 +1060,7 @@ func NewColOperator(
 				inMemoryHashJoiner := colexecjoin.NewHashJoiner(
 					colmem.NewAllocator(ctx, hashJoinerMemAccount, factory),
 					hashJoinerUnlimitedAllocator, hjSpec, inputs[0].Root, inputs[1].Root,
-					colexecjoin.HashJoinerInitialNumBuckets, memoryLimit,
+					colexecjoin.HashJoinerInitialNumBuckets,
 				)
 				if useStreamingMemAccountForBuffering || args.TestingKnobs.DiskSpillingDisabled {
 					// We will not be creating a disk-backed hash joiner because

--- a/pkg/sql/colexec/colexecjoin/crossjoiner.go
+++ b/pkg/sql/colexec/colexecjoin/crossjoiner.go
@@ -98,15 +98,13 @@ func (c *crossJoiner) Next() coldata.Batch {
 		}
 		return coldata.ZeroBatch
 	}
-	// TODO(yuzefovich): refactor willEmit calculation when ResetMaybeReallocate
-	// is updated.
 	willEmit := c.numTotalOutputTuples - c.numAlreadyEmitted
-	if willEmit > coldata.BatchSize() {
-		willEmit = coldata.BatchSize()
-	}
 	c.output, _ = c.unlimitedAllocator.ResetMaybeReallocate(
 		c.outputTypes, c.output, willEmit, c.maxOutputBatchMemSize,
 	)
+	if willEmit > c.output.Capacity() {
+		willEmit = c.output.Capacity()
+	}
 	if c.joinType.ShouldIncludeLeftColsInOutput() {
 		if c.isLeftAllNulls {
 			setAllNulls(c.output.ColVecs()[:len(c.left.types)], willEmit)

--- a/pkg/sql/colexec/colexecjoin/mergejoiner.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner.go
@@ -599,8 +599,8 @@ func (o *mergeJoinBase) appendToBufferedGroup(
 		})
 	}
 
-	// For now, we don't enforce any footprint-based memory limit.
-	// TODO(yuzefovich): refactor this.
+	// We don't impose any memory limits on the scratch batch because we rely on
+	// the inputs to the merge joiner to produce reasonably sized batches.
 	const maxBatchMemSize = math.MaxInt64
 	bufferedGroup.scratchBatch, _ = o.unlimitedAllocator.ResetMaybeReallocate(
 		input.sourceTypes, bufferedGroup.scratchBatch, groupLength, maxBatchMemSize,

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_exceptall.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_exceptall.eg.go
@@ -13885,7 +13885,7 @@ func (o *mergeJoinExceptAllOp) build() {
 
 func (o *mergeJoinExceptAllOp) Next() coldata.Batch {
 	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
-		o.outputTypes, o.output, 1 /* minCapacity */, o.memoryLimit,
+		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
 	)
 	o.bufferedGroup.helper.output = o.output
 	for {

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_fullouter.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_fullouter.eg.go
@@ -14999,7 +14999,7 @@ func (o *mergeJoinFullOuterOp) build() {
 
 func (o *mergeJoinFullOuterOp) Next() coldata.Batch {
 	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
-		o.outputTypes, o.output, 1 /* minCapacity */, o.memoryLimit,
+		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
 	)
 	o.bufferedGroup.helper.output = o.output
 	for {

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_inner.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_inner.eg.go
@@ -10423,7 +10423,7 @@ func (o *mergeJoinInnerOp) build() {
 
 func (o *mergeJoinInnerOp) Next() coldata.Batch {
 	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
-		o.outputTypes, o.output, 1 /* minCapacity */, o.memoryLimit,
+		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
 	)
 	o.bufferedGroup.helper.output = o.output
 	for {

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_intersectall.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_intersectall.eg.go
@@ -11257,7 +11257,7 @@ func (o *mergeJoinIntersectAllOp) build() {
 
 func (o *mergeJoinIntersectAllOp) Next() coldata.Batch {
 	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
-		o.outputTypes, o.output, 1 /* minCapacity */, o.memoryLimit,
+		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
 	)
 	o.bufferedGroup.helper.output = o.output
 	for {

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_leftanti.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_leftanti.eg.go
@@ -12697,7 +12697,7 @@ func (o *mergeJoinLeftAntiOp) build() {
 
 func (o *mergeJoinLeftAntiOp) Next() coldata.Batch {
 	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
-		o.outputTypes, o.output, 1 /* minCapacity */, o.memoryLimit,
+		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
 	)
 	o.bufferedGroup.helper.output = o.output
 	for {

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_leftouter.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_leftouter.eg.go
@@ -12723,7 +12723,7 @@ func (o *mergeJoinLeftOuterOp) build() {
 
 func (o *mergeJoinLeftOuterOp) Next() coldata.Batch {
 	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
-		o.outputTypes, o.output, 1 /* minCapacity */, o.memoryLimit,
+		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
 	)
 	o.bufferedGroup.helper.output = o.output
 	for {

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_leftsemi.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_leftsemi.eg.go
@@ -10377,7 +10377,7 @@ func (o *mergeJoinLeftSemiOp) build() {
 
 func (o *mergeJoinLeftSemiOp) Next() coldata.Batch {
 	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
-		o.outputTypes, o.output, 1 /* minCapacity */, o.memoryLimit,
+		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
 	)
 	o.bufferedGroup.helper.output = o.output
 	for {

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_rightanti.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_rightanti.eg.go
@@ -12649,7 +12649,7 @@ func (o *mergeJoinRightAntiOp) build() {
 
 func (o *mergeJoinRightAntiOp) Next() coldata.Batch {
 	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
-		o.outputTypes, o.output, 1 /* minCapacity */, o.memoryLimit,
+		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
 	)
 	o.bufferedGroup.helper.output = o.output
 	for {

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_rightouter.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_rightouter.eg.go
@@ -12699,7 +12699,7 @@ func (o *mergeJoinRightOuterOp) build() {
 
 func (o *mergeJoinRightOuterOp) Next() coldata.Batch {
 	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
-		o.outputTypes, o.output, 1 /* minCapacity */, o.memoryLimit,
+		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
 	)
 	o.bufferedGroup.helper.output = o.output
 	for {

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_rightsemi.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_rightsemi.eg.go
@@ -10331,7 +10331,7 @@ func (o *mergeJoinRightSemiOp) build() {
 
 func (o *mergeJoinRightSemiOp) Next() coldata.Batch {
 	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
-		o.outputTypes, o.output, 1 /* minCapacity */, o.memoryLimit,
+		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
 	)
 	o.bufferedGroup.helper.output = o.output
 	for {

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_test.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_test.go
@@ -116,7 +116,7 @@ func TestMergeJoinCrossProduct(t *testing.T) {
 			Right: hashJoinerSourceSpec{
 				EqCols: []uint32{0}, SourceTypes: typs,
 			},
-		}, leftHJSource, rightHJSource, HashJoinerInitialNumBuckets, execinfra.DefaultMemoryLimit,
+		}, leftHJSource, rightHJSource, HashJoinerInitialNumBuckets,
 	)
 	hj.Init(ctx)
 

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_tmpl.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_tmpl.go
@@ -1211,7 +1211,7 @@ func _SOURCE_FINISHED_SWITCH(_JOIN_TYPE joinTypeInfo) { // */}}
 
 func (o *mergeJoin_JOIN_TYPE_STRINGOp) Next() coldata.Batch {
 	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
-		o.outputTypes, o.output, 1 /* minCapacity */, o.memoryLimit,
+		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
 	)
 	o.bufferedGroup.helper.output = o.output
 	for {

--- a/pkg/sql/colexec/colexecutils/spilling_queue_test.go
+++ b/pkg/sql/colexec/colexecutils/spilling_queue_test.go
@@ -174,7 +174,7 @@ func TestSpillingQueue(t *testing.T) {
 				// the desired value and restore it below.
 				numTuples := tuples.Length()
 				tuples.SetLength(numAlreadyDequeuedTuples + windowLen)
-				MakeWindowIntoBatch(windowedBatch, tuples, numAlreadyDequeuedTuples, typs)
+				MakeWindowIntoBatch(windowedBatch, tuples, numAlreadyDequeuedTuples, numAlreadyDequeuedTuples+windowLen, typs)
 				tuples.SetLength(numTuples)
 				numAlreadyDequeuedTuples += windowLen
 				return windowedBatch

--- a/pkg/sql/colexec/colexecutils/utils.go
+++ b/pkg/sql/colexec/colexecutils/utils.go
@@ -20,30 +20,32 @@ import (
 )
 
 // MakeWindowIntoBatch updates windowedBatch so that it provides a "window"
-// into inputBatch starting at tuple index startIdx. It handles selection
-// vectors on inputBatch as well (in which case windowedBatch will also have a
-// "windowed" selection vector).
+// into inputBatch that contains tuples in [startIdx, endIdx) range. It handles
+// selection vectors on inputBatch as well (in which case windowedBatch will
+// also have a "windowed" selection vector).
+//
+// Note: this method assumes that startIdx < endIdx.
 func MakeWindowIntoBatch(
-	windowedBatch, inputBatch coldata.Batch, startIdx int, inputTypes []*types.T,
+	windowedBatch, inputBatch coldata.Batch, startIdx, endIdx int, inputTypes []*types.T,
 ) {
-	inputBatchLen := inputBatch.Length()
 	windowStart := startIdx
-	windowEnd := inputBatchLen
+	windowEnd := endIdx
 	if sel := inputBatch.Selection(); sel != nil {
 		// We have a selection vector on the input batch, and in order to avoid
 		// deselecting (i.e. moving the data over), we will provide an adjusted
 		// selection vector to the windowed batch as well.
 		windowedBatch.SetSelection(true)
-		windowIntoSel := sel[startIdx:inputBatchLen]
+		windowIntoSel := sel[startIdx:endIdx]
 		copy(windowedBatch.Selection(), windowIntoSel)
-		maxSelIdx := 0
-		for _, selIdx := range windowIntoSel {
-			if selIdx > maxSelIdx {
-				maxSelIdx = selIdx
-			}
-		}
+		// We have to adjust the indices of our window based on the selection
+		// vector. The window needs to start from the zeroth tuple (even if it
+		// is not included in the selection vector) so that we don't have to
+		// shift the selection vector on the windowed batch.
 		windowStart = 0
-		windowEnd = maxSelIdx + 1
+		// The window also needs to include the very last tuple that is selected
+		// to be in the window. Here we rely on the invariant that the selection
+		// vectors are increasing sequences.
+		windowEnd = windowIntoSel[len(windowIntoSel)-1] + 1
 	} else {
 		windowedBatch.SetSelection(false)
 	}
@@ -51,7 +53,7 @@ func MakeWindowIntoBatch(
 		window := inputBatch.ColVec(i).Window(windowStart, windowEnd)
 		windowedBatch.ReplaceCol(window, i)
 	}
-	windowedBatch.SetLength(inputBatchLen - startIdx)
+	windowedBatch.SetLength(endIdx - startIdx)
 }
 
 // NewAppendOnlyBufferedBatch returns a new AppendOnlyBufferedBatch that has

--- a/pkg/sql/colexec/colexecwindow/buffered_window.go
+++ b/pkg/sql/colexec/colexecwindow/buffered_window.go
@@ -243,8 +243,12 @@ func (b *bufferedWindowOp) Next() coldata.Batch {
 			// a selection vector.
 			n := batch.Length()
 			sel := batch.Selection()
+			// We don't limit the batches based on the memory footprint because
+			// we assume that the input is producing reasonably sized batches.
+			const maxBatchMemSize = math.MaxInt64
 			b.currentBatch, _ = b.allocator.ResetMaybeReallocate(
-				b.outputTypes, b.currentBatch, batch.Length(), math.MaxInt64)
+				b.outputTypes, b.currentBatch, batch.Length(), maxBatchMemSize,
+			)
 			b.allocator.PerformOperation(b.currentBatch.ColVecs(), func() {
 				for colIdx, vec := range batch.ColVecs() {
 					if colIdx == b.outputColIdx {

--- a/pkg/sql/colexec/columnarizer.go
+++ b/pkg/sql/colexec/columnarizer.go
@@ -190,7 +190,7 @@ func (c *Columnarizer) Next() coldata.Batch {
 	switch c.mode {
 	case columnarizerBufferingMode:
 		c.batch, reallocated = c.allocator.ResetMaybeReallocate(
-			c.typs, c.batch, 1 /* minCapacity */, c.maxBatchMemSize,
+			c.typs, c.batch, 1 /* minDesiredCapacity */, c.maxBatchMemSize,
 		)
 	case columnarizerStreamingMode:
 		// Note that we're not using ResetMaybeReallocate because we will

--- a/pkg/sql/colexec/external_hash_joiner.go
+++ b/pkg/sql/colexec/external_hash_joiner.go
@@ -110,7 +110,7 @@ func NewExternalHashJoiner(
 			unlimitedAllocator, unlimitedAllocator, spec, partitionedInputs[0], partitionedInputs[1],
 			// We start with relatively large initial number of buckets since we
 			// expect each partition to be of significant size.
-			uint64(coldata.BatchSize()), memoryLimit,
+			uint64(coldata.BatchSize()),
 		)
 	}
 	diskBackedFallbackOpConstructor := func(

--- a/pkg/sql/colexec/external_sort.go
+++ b/pkg/sql/colexec/external_sort.go
@@ -266,7 +266,7 @@ func NewExternalSorter(
 		inMemSortOutputLimit = 1
 		mergeMemoryLimit = 1
 	}
-	inputPartitioner := newInputPartitioningOperator(input, inMemSortPartitionLimit)
+	inputPartitioner := newInputPartitioningOperator(sortUnlimitedAllocator, input, inputTypes, inMemSortPartitionLimit)
 	var inMemSorter colexecop.ResettableOperator
 	if topK > 0 {
 		inMemSorter = NewTopKSorter(sortUnlimitedAllocator, inputPartitioner, inputTypes, ordering.Columns, topK, inMemSortOutputLimit)
@@ -594,19 +594,17 @@ func (s *externalSorter) Close() error {
 	}
 	ctx := s.EnsureCtx()
 	log.VEvent(ctx, 1, "external sorter is closed")
-	var lastErr error
+	var err error
 	if s.partitioner != nil {
-		lastErr = s.partitioner.Close(ctx)
+		err = s.partitioner.Close(ctx)
 		s.partitioner = nil
 	}
-	if err := s.inMemSorterInput.Close(); err != nil {
-		lastErr = err
-	}
+	s.inMemSorterInput.close()
 	if !s.testingKnobs.delegateFDAcquisitions && s.fdState.fdSemaphore != nil && s.fdState.acquiredFDs > 0 {
 		s.fdState.fdSemaphore.Release(s.fdState.acquiredFDs)
 		s.fdState.acquiredFDs = 0
 	}
-	return lastErr
+	return err
 }
 
 // createPartitionerToOperators updates s.partitionerToOperators to correspond
@@ -675,11 +673,13 @@ func (s *externalSorter) createMergerForPartitions(n int) colexecop.Operator {
 }
 
 func newInputPartitioningOperator(
-	input colexecop.Operator, memoryLimit int64,
+	allocator *colmem.Allocator, input colexecop.Operator, typs []*types.T, memoryLimit int64,
 ) colexecop.ResettableOperator {
 	return &inputPartitioningOperator{
 		OneInputHelper: colexecop.MakeOneInputHelper(input),
 		memoryLimit:    memoryLimit,
+		allocator:      allocator,
+		typs:           typs,
 	}
 }
 
@@ -695,6 +695,25 @@ type inputPartitioningOperator struct {
 	memoryLimit int64
 	// alreadyUsedMemory tracks the size of the current partition so far.
 	alreadyUsedMemory int64
+	// lastBatchState keeps track of the state around emitting rows from the
+	// last batch we read from input. This is needed in case a single batch
+	// needs to be divided between different partitions (possibly more than
+	// two).
+	lastBatchState struct {
+		// batch is non-nil only if there are more rows to be emitted from the
+		// last read batch.
+		batch coldata.Batch
+		// avgRowSize is an estimate about the size of each row in batch, in
+		// bytes.
+		avgRowSize int64
+		// emitted is the number of rows already emitted from batch.
+		emitted int
+	}
+
+	allocator     *colmem.Allocator
+	windowedBatch coldata.Batch
+	typs          []*types.T
+
 	// interceptReset determines whether the reset method will be called on
 	// the input to this operator when the latter is being reset. This field is
 	// managed by externalSorter.
@@ -716,14 +735,18 @@ type inputPartitioningOperator struct {
 }
 
 var _ colexecop.ResettableOperator = &inputPartitioningOperator{}
-var _ colexecop.ClosableOperator = &inputPartitioningOperator{}
 
 func (o *inputPartitioningOperator) Next() coldata.Batch {
 	if o.alreadyUsedMemory >= o.memoryLimit {
 		return coldata.ZeroBatch
 	}
+	if o.lastBatchState.batch != nil {
+		// We still have some rows from the last batch.
+		return o.emitWindowIntoLastBatch()
+	}
 	b := o.Input.Next()
-	if b.Length() == 0 {
+	n := b.Length()
+	if n == 0 {
 		return b
 	}
 	// This operator is an input to sortOp which will spool all the tuples and
@@ -732,8 +755,51 @@ func (o *inputPartitioningOperator) Next() coldata.Batch {
 	// exactly true for Bytes type, but it's ok if we have some deviation. This
 	// numbers matter only to understand when to start a new partition, and the
 	// memory will be actually accounted for correctly.)
-	o.alreadyUsedMemory += colmem.GetProportionalBatchMemSize(b, int64(b.Length()))
+	proportionalBatchMemSize := colmem.GetProportionalBatchMemSize(b, int64(n))
+	if o.alreadyUsedMemory+proportionalBatchMemSize >= o.memoryLimit {
+		// Emitting this batch as is will make the current partition exceed the
+		// memory limit, so we will actually "split" this batch between multiple
+		// partitions.
+		o.lastBatchState.batch = b
+		o.lastBatchState.emitted = 0
+		o.lastBatchState.avgRowSize = proportionalBatchMemSize / int64(n)
+		return o.emitWindowIntoLastBatch()
+	}
+	o.alreadyUsedMemory += proportionalBatchMemSize
+	o.lastBatchState.batch = nil
 	return b
+}
+
+// emitWindowIntoLastBatch returns a window into the last batch such that either
+// all remaining rows are emitted or this window batch barely puts the current
+// partition above the memory limit. The method assumes that the last batch is
+// not nil and not all rows have been emitted from it.
+func (o *inputPartitioningOperator) emitWindowIntoLastBatch() coldata.Batch {
+	// We use plus one so that this windowed batch reaches the memory limit if
+	// possible.
+	toEmit := (o.memoryLimit-o.alreadyUsedMemory)/o.lastBatchState.avgRowSize + 1
+	// But do not try to emit more than there are rows remaining.
+	n := o.lastBatchState.batch.Length()
+	if toEmit > int64(n-o.lastBatchState.emitted) {
+		toEmit = int64(n - o.lastBatchState.emitted)
+	}
+	if o.windowedBatch == nil {
+		// The columns will be replaced into this windowed batch, but we do need
+		// to support a selection vector of an arbitrary length.
+		o.windowedBatch = o.allocator.NewMemBatchNoCols(o.typs, coldata.BatchSize())
+	}
+	colexecutils.MakeWindowIntoBatch(
+		o.windowedBatch, o.lastBatchState.batch, o.lastBatchState.emitted,
+		o.lastBatchState.emitted+int(toEmit), o.typs,
+	)
+	o.alreadyUsedMemory += o.lastBatchState.avgRowSize * toEmit
+	o.lastBatchState.emitted += int(toEmit)
+	if o.lastBatchState.emitted == n {
+		// This batch is now fully emitted, so we will need to fetch a new one
+		// from the input.
+		o.lastBatchState.batch = nil
+	}
+	return o.windowedBatch
 }
 
 func (o *inputPartitioningOperator) Reset(ctx context.Context) {
@@ -746,7 +812,15 @@ func (o *inputPartitioningOperator) Reset(ctx context.Context) {
 	o.alreadyUsedMemory = 0
 }
 
-func (o *inputPartitioningOperator) Close() error {
+func (o *inputPartitioningOperator) close() {
 	o.alreadyUsedMemory = 0
-	return nil
+	o.lastBatchState.batch = nil
+	o.lastBatchState.avgRowSize = 0
+	o.lastBatchState.emitted = 0
+	// Nil out the windowed batch in order to lose the references to the vectors
+	// of the last batch. We need to shrink the account accordingly and will
+	// allocate a new windowed batch if necessary (which might be the case for
+	// the fallback strategy of the users of the hash-based partitioner).
+	o.windowedBatch = nil
+	o.allocator.ReleaseMemory(colmem.SizeOfBatchSizeSelVector)
 }

--- a/pkg/sql/colexec/hash_aggregator_test.go
+++ b/pkg/sql/colexec/hash_aggregator_test.go
@@ -12,6 +12,7 @@ package colexec
 
 import (
 	"context"
+	"math"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
@@ -142,6 +143,8 @@ func TestHashAggregator(t *testing.T) {
 				OutputTypes:    outputTypes,
 			},
 				nil, /* newSpillingQueueArgs */
+				testAllocator,
+				math.MaxInt64,
 			)
 		})
 	}
@@ -173,7 +176,7 @@ func BenchmarkHashAggregatorInputTuplesTracking(b *testing.B) {
 			for _, agg := range []aggType{
 				{
 					new: func(args *colexecagg.NewAggregatorArgs) (colexecop.ResettableOperator, error) {
-						return NewHashAggregator(args, nil /* newSpillingQueueArgs */)
+						return NewHashAggregator(args, nil /* newSpillingQueueArgs */, testAllocator, math.MaxInt64)
 					},
 					name: "tracking=false",
 				},
@@ -188,7 +191,7 @@ func BenchmarkHashAggregatorInputTuplesTracking(b *testing.B) {
 							DiskQueueCfg:       queueCfg,
 							FDSemaphore:        &colexecop.TestingSemaphore{},
 							DiskAcc:            testDiskAcc,
-						})
+						}, testAllocator, math.MaxInt64)
 					},
 					name: "tracking=true",
 				},

--- a/pkg/sql/colexec/hashjoiner_test.go
+++ b/pkg/sql/colexec/hashjoiner_test.go
@@ -1093,7 +1093,7 @@ func BenchmarkHashJoiner(b *testing.B) {
 										hj := colexecjoin.NewHashJoiner(
 											testAllocator, testAllocator, hjSpec,
 											leftSource, rightSource,
-											colexecjoin.HashJoinerInitialNumBuckets, execinfra.DefaultMemoryLimit,
+											colexecjoin.HashJoinerInitialNumBuckets,
 										)
 										hj.Init(ctx)
 

--- a/pkg/sql/colexec/ordered_aggregator.go
+++ b/pkg/sql/colexec/ordered_aggregator.go
@@ -282,11 +282,6 @@ func (a *orderedAggregator) Next() coldata.Batch {
 			// Twice the batchSize is allocated to avoid having to check for
 			// overflow when outputting.
 			newMinCapacity := 2 * a.lastReadBatch.Length()
-			if newMinCapacity == 0 {
-				// If batchLength is 0, we still need to flush the last group,
-				// so we need to have the capacity of at least 1.
-				newMinCapacity = 1
-			}
 			if newMinCapacity > coldata.BatchSize() {
 				// ResetMaybeReallocate truncates the capacity to
 				// coldata.BatchSize(), but we actually want a batch with larger
@@ -302,12 +297,8 @@ func (a *orderedAggregator) Next() coldata.Batch {
 			// We will never copy more than coldata.BatchSize() into the
 			// temporary buffer, so a half of the scratch's capacity will always
 			// be sufficient.
-			tempBufferCapacity := newMinCapacity / 2
-			if tempBufferCapacity == 0 {
-				tempBufferCapacity = 1
-			}
 			a.scratch.tempBuffer, _ = a.allocator.ResetMaybeReallocate(
-				a.outputTypes, a.scratch.tempBuffer, tempBufferCapacity, maxBatchMemSize,
+				a.outputTypes, a.scratch.tempBuffer, newMinCapacity/2, maxBatchMemSize,
 			)
 			for fnIdx, fn := range a.bucket.fns {
 				fn.SetOutput(a.scratch.ColVec(fnIdx))

--- a/pkg/sql/colexec/ordered_synchronizer.eg.go
+++ b/pkg/sql/colexec/ordered_synchronizer.eg.go
@@ -275,7 +275,7 @@ func (o *OrderedSynchronizer) Next() coldata.Batch {
 func (o *OrderedSynchronizer) resetOutput() {
 	var reallocated bool
 	o.output, reallocated = o.allocator.ResetMaybeReallocate(
-		o.typs, o.output, 1 /* minCapacity */, o.memoryLimit,
+		o.typs, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
 	)
 	if reallocated {
 		o.outBoolCols = o.outBoolCols[:0]

--- a/pkg/sql/colexec/ordered_synchronizer.eg.go
+++ b/pkg/sql/colexec/ordered_synchronizer.eg.go
@@ -35,7 +35,7 @@ type OrderedSynchronizer struct {
 	colexecop.InitHelper
 	span *tracing.Span
 
-	allocator             *colmem.Allocator
+	accountingHelper      colmem.SetAccountingHelper
 	memoryLimit           int64
 	inputs                []colexecargs.OpWithMetaInfo
 	ordering              colinfo.ColumnOrdering
@@ -53,6 +53,10 @@ type OrderedSynchronizer struct {
 	heap []int
 	// comparators stores one comparator per ordering column.
 	comparators []vecComparator
+	// maxCapacity if non-zero indicates the target capacity of the output
+	// batch. It is set when, after setting a row, we realize that the output
+	// batch has exceeded the memory limit.
+	maxCapacity int
 	output      coldata.Batch
 	outNulls    []*coldata.Nulls
 	// In order to reduce the number of interface conversions, we will get access
@@ -107,14 +111,15 @@ func NewOrderedSynchronizer(
 	typs []*types.T,
 	ordering colinfo.ColumnOrdering,
 ) *OrderedSynchronizer {
-	return &OrderedSynchronizer{
-		allocator:             allocator,
+	os := &OrderedSynchronizer{
 		memoryLimit:           memoryLimit,
 		inputs:                inputs,
 		ordering:              ordering,
 		typs:                  typs,
 		canonicalTypeFamilies: typeconv.ToCanonicalTypeFamilies(typs),
 	}
+	os.accountingHelper.Init(allocator, typs, nil /* notNeededVecIdxs */)
+	return os
 }
 
 // Next is part of the Operator interface.
@@ -133,140 +138,143 @@ func (o *OrderedSynchronizer) Next() coldata.Batch {
 	}
 	o.resetOutput()
 	outputIdx := 0
-	o.allocator.PerformOperation(o.output.ColVecs(), func() {
-		for outputIdx < o.output.Capacity() {
-			if o.Len() == 0 {
-				// All inputs exhausted.
-				break
-			}
+	for outputIdx < o.output.Capacity() && (o.maxCapacity == 0 || outputIdx < o.maxCapacity) {
+		if o.Len() == 0 {
+			// All inputs exhausted.
+			break
+		}
 
-			minBatch := o.heap[0]
-			// Copy the min row into the output.
-			batch := o.inputBatches[minBatch]
-			srcRowIdx := o.inputIndices[minBatch]
-			if sel := batch.Selection(); sel != nil {
-				srcRowIdx = sel[srcRowIdx]
-			}
-			for i := range o.typs {
-				vec := batch.ColVec(i)
-				if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(srcRowIdx) {
-					o.outNulls[i].SetNull(outputIdx)
-				} else {
-					switch o.canonicalTypeFamilies[i] {
-					case types.BoolFamily:
-						switch o.typs[i].Width() {
-						case -1:
-						default:
-							srcCol := vec.Bool()
-							outCol := o.outBoolCols[o.outColsMap[i]]
-							v := srcCol.Get(srcRowIdx)
-							outCol.Set(outputIdx, v)
-						}
-					case types.BytesFamily:
-						switch o.typs[i].Width() {
-						case -1:
-						default:
-							srcCol := vec.Bytes()
-							outCol := o.outBytesCols[o.outColsMap[i]]
-							v := srcCol.Get(srcRowIdx)
-							outCol.Set(outputIdx, v)
-						}
-					case types.DecimalFamily:
-						switch o.typs[i].Width() {
-						case -1:
-						default:
-							srcCol := vec.Decimal()
-							outCol := o.outDecimalCols[o.outColsMap[i]]
-							v := srcCol.Get(srcRowIdx)
-							outCol.Set(outputIdx, v)
-						}
-					case types.IntFamily:
-						switch o.typs[i].Width() {
-						case 16:
-							srcCol := vec.Int16()
-							outCol := o.outInt16Cols[o.outColsMap[i]]
-							v := srcCol.Get(srcRowIdx)
-							outCol.Set(outputIdx, v)
-						case 32:
-							srcCol := vec.Int32()
-							outCol := o.outInt32Cols[o.outColsMap[i]]
-							v := srcCol.Get(srcRowIdx)
-							outCol.Set(outputIdx, v)
-						case -1:
-						default:
-							srcCol := vec.Int64()
-							outCol := o.outInt64Cols[o.outColsMap[i]]
-							v := srcCol.Get(srcRowIdx)
-							outCol.Set(outputIdx, v)
-						}
-					case types.FloatFamily:
-						switch o.typs[i].Width() {
-						case -1:
-						default:
-							srcCol := vec.Float64()
-							outCol := o.outFloat64Cols[o.outColsMap[i]]
-							v := srcCol.Get(srcRowIdx)
-							outCol.Set(outputIdx, v)
-						}
-					case types.TimestampTZFamily:
-						switch o.typs[i].Width() {
-						case -1:
-						default:
-							srcCol := vec.Timestamp()
-							outCol := o.outTimestampCols[o.outColsMap[i]]
-							v := srcCol.Get(srcRowIdx)
-							outCol.Set(outputIdx, v)
-						}
-					case types.IntervalFamily:
-						switch o.typs[i].Width() {
-						case -1:
-						default:
-							srcCol := vec.Interval()
-							outCol := o.outIntervalCols[o.outColsMap[i]]
-							v := srcCol.Get(srcRowIdx)
-							outCol.Set(outputIdx, v)
-						}
-					case types.JsonFamily:
-						switch o.typs[i].Width() {
-						case -1:
-						default:
-							srcCol := vec.JSON()
-							outCol := o.outJSONCols[o.outColsMap[i]]
-							v := srcCol.Get(srcRowIdx)
-							outCol.Set(outputIdx, v)
-						}
-					case typeconv.DatumVecCanonicalTypeFamily:
-						switch o.typs[i].Width() {
-						case -1:
-						default:
-							srcCol := vec.Datum()
-							outCol := o.outDatumCols[o.outColsMap[i]]
-							v := srcCol.Get(srcRowIdx)
-							outCol.Set(outputIdx, v)
-						}
+		minBatch := o.heap[0]
+		// Copy the min row into the output.
+		batch := o.inputBatches[minBatch]
+		srcRowIdx := o.inputIndices[minBatch]
+		if sel := batch.Selection(); sel != nil {
+			srcRowIdx = sel[srcRowIdx]
+		}
+		for i := range o.typs {
+			vec := batch.ColVec(i)
+			if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(srcRowIdx) {
+				o.outNulls[i].SetNull(outputIdx)
+			} else {
+				switch o.canonicalTypeFamilies[i] {
+				case types.BoolFamily:
+					switch o.typs[i].Width() {
+					case -1:
 					default:
-						colexecerror.InternalError(errors.AssertionFailedf("unhandled type %s", o.typs[i].String()))
+						srcCol := vec.Bool()
+						outCol := o.outBoolCols[o.outColsMap[i]]
+						v := srcCol.Get(srcRowIdx)
+						outCol.Set(outputIdx, v)
 					}
+				case types.BytesFamily:
+					switch o.typs[i].Width() {
+					case -1:
+					default:
+						srcCol := vec.Bytes()
+						outCol := o.outBytesCols[o.outColsMap[i]]
+						v := srcCol.Get(srcRowIdx)
+						outCol.Set(outputIdx, v)
+					}
+				case types.DecimalFamily:
+					switch o.typs[i].Width() {
+					case -1:
+					default:
+						srcCol := vec.Decimal()
+						outCol := o.outDecimalCols[o.outColsMap[i]]
+						v := srcCol.Get(srcRowIdx)
+						outCol.Set(outputIdx, v)
+					}
+				case types.IntFamily:
+					switch o.typs[i].Width() {
+					case 16:
+						srcCol := vec.Int16()
+						outCol := o.outInt16Cols[o.outColsMap[i]]
+						v := srcCol.Get(srcRowIdx)
+						outCol.Set(outputIdx, v)
+					case 32:
+						srcCol := vec.Int32()
+						outCol := o.outInt32Cols[o.outColsMap[i]]
+						v := srcCol.Get(srcRowIdx)
+						outCol.Set(outputIdx, v)
+					case -1:
+					default:
+						srcCol := vec.Int64()
+						outCol := o.outInt64Cols[o.outColsMap[i]]
+						v := srcCol.Get(srcRowIdx)
+						outCol.Set(outputIdx, v)
+					}
+				case types.FloatFamily:
+					switch o.typs[i].Width() {
+					case -1:
+					default:
+						srcCol := vec.Float64()
+						outCol := o.outFloat64Cols[o.outColsMap[i]]
+						v := srcCol.Get(srcRowIdx)
+						outCol.Set(outputIdx, v)
+					}
+				case types.TimestampTZFamily:
+					switch o.typs[i].Width() {
+					case -1:
+					default:
+						srcCol := vec.Timestamp()
+						outCol := o.outTimestampCols[o.outColsMap[i]]
+						v := srcCol.Get(srcRowIdx)
+						outCol.Set(outputIdx, v)
+					}
+				case types.IntervalFamily:
+					switch o.typs[i].Width() {
+					case -1:
+					default:
+						srcCol := vec.Interval()
+						outCol := o.outIntervalCols[o.outColsMap[i]]
+						v := srcCol.Get(srcRowIdx)
+						outCol.Set(outputIdx, v)
+					}
+				case types.JsonFamily:
+					switch o.typs[i].Width() {
+					case -1:
+					default:
+						srcCol := vec.JSON()
+						outCol := o.outJSONCols[o.outColsMap[i]]
+						v := srcCol.Get(srcRowIdx)
+						outCol.Set(outputIdx, v)
+					}
+				case typeconv.DatumVecCanonicalTypeFamily:
+					switch o.typs[i].Width() {
+					case -1:
+					default:
+						srcCol := vec.Datum()
+						outCol := o.outDatumCols[o.outColsMap[i]]
+						v := srcCol.Get(srcRowIdx)
+						outCol.Set(outputIdx, v)
+					}
+				default:
+					colexecerror.InternalError(errors.AssertionFailedf("unhandled type %s", o.typs[i].String()))
 				}
 			}
-
-			// Advance the input batch, fetching a new batch if necessary.
-			if o.inputIndices[minBatch]+1 < o.inputBatches[minBatch].Length() {
-				o.inputIndices[minBatch]++
-			} else {
-				o.inputBatches[minBatch] = o.inputs[minBatch].Root.Next()
-				o.inputIndices[minBatch] = 0
-				o.updateComparators(minBatch)
-			}
-			if o.inputBatches[minBatch].Length() == 0 {
-				heap.Remove(o, 0)
-			} else {
-				heap.Fix(o, 0)
-			}
-
-			outputIdx++
 		}
-	})
+
+		// Advance the input batch, fetching a new batch if necessary.
+		if o.inputIndices[minBatch]+1 < o.inputBatches[minBatch].Length() {
+			o.inputIndices[minBatch]++
+		} else {
+			o.inputBatches[minBatch] = o.inputs[minBatch].Root.Next()
+			o.inputIndices[minBatch] = 0
+			o.updateComparators(minBatch)
+		}
+		if o.inputBatches[minBatch].Length() == 0 {
+			heap.Remove(o, 0)
+		} else {
+			heap.Fix(o, 0)
+		}
+
+		// Account for the memory of the row we have just set.
+		o.accountingHelper.AccountForSet(outputIdx)
+		outputIdx++
+		if o.maxCapacity == 0 && o.accountingHelper.Allocator.Used() >= o.memoryLimit {
+			o.maxCapacity = outputIdx
+		}
+	}
 
 	o.output.SetLength(outputIdx)
 	return o.output
@@ -274,7 +282,7 @@ func (o *OrderedSynchronizer) Next() coldata.Batch {
 
 func (o *OrderedSynchronizer) resetOutput() {
 	var reallocated bool
-	o.output, reallocated = o.allocator.ResetMaybeReallocate(
+	o.output, reallocated = o.accountingHelper.ResetMaybeReallocate(
 		o.typs, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
 	)
 	if reallocated {
@@ -406,12 +414,14 @@ func (o *OrderedSynchronizer) DrainMeta() []execinfrapb.ProducerMetadata {
 }
 
 func (o *OrderedSynchronizer) Close() error {
+	o.accountingHelper.Close()
 	for _, input := range o.inputs {
 		input.ToClose.CloseAndLogOnErr(o.EnsureCtx(), "ordered synchronizer")
 	}
 	if o.span != nil {
 		o.span.Finish()
 	}
+	*o = OrderedSynchronizer{}
 	return nil
 }
 

--- a/pkg/sql/colexec/ordered_synchronizer_tmpl.go
+++ b/pkg/sql/colexec/ordered_synchronizer_tmpl.go
@@ -59,7 +59,7 @@ type OrderedSynchronizer struct {
 	colexecop.InitHelper
 	span *tracing.Span
 
-	allocator             *colmem.Allocator
+	accountingHelper      colmem.SetAccountingHelper
 	memoryLimit           int64
 	inputs                []colexecargs.OpWithMetaInfo
 	ordering              colinfo.ColumnOrdering
@@ -77,6 +77,10 @@ type OrderedSynchronizer struct {
 	heap []int
 	// comparators stores one comparator per ordering column.
 	comparators []vecComparator
+	// maxCapacity if non-zero indicates the target capacity of the output
+	// batch. It is set when, after setting a row, we realize that the output
+	// batch has exceeded the memory limit.
+	maxCapacity int
 	output      coldata.Batch
 	outNulls    []*coldata.Nulls
 	// In order to reduce the number of interface conversions, we will get access
@@ -125,14 +129,15 @@ func NewOrderedSynchronizer(
 	typs []*types.T,
 	ordering colinfo.ColumnOrdering,
 ) *OrderedSynchronizer {
-	return &OrderedSynchronizer{
-		allocator:             allocator,
+	os := &OrderedSynchronizer{
 		memoryLimit:           memoryLimit,
 		inputs:                inputs,
 		ordering:              ordering,
 		typs:                  typs,
 		canonicalTypeFamilies: typeconv.ToCanonicalTypeFamilies(typs),
 	}
+	os.accountingHelper.Init(allocator, typs, nil /* notNeededVecIdxs */)
+	return os
 }
 
 // Next is part of the Operator interface.
@@ -151,61 +156,64 @@ func (o *OrderedSynchronizer) Next() coldata.Batch {
 	}
 	o.resetOutput()
 	outputIdx := 0
-	o.allocator.PerformOperation(o.output.ColVecs(), func() {
-		for outputIdx < o.output.Capacity() {
-			if o.Len() == 0 {
-				// All inputs exhausted.
-				break
-			}
+	for outputIdx < o.output.Capacity() && (o.maxCapacity == 0 || outputIdx < o.maxCapacity) {
+		if o.Len() == 0 {
+			// All inputs exhausted.
+			break
+		}
 
-			minBatch := o.heap[0]
-			// Copy the min row into the output.
-			batch := o.inputBatches[minBatch]
-			srcRowIdx := o.inputIndices[minBatch]
-			if sel := batch.Selection(); sel != nil {
-				srcRowIdx = sel[srcRowIdx]
-			}
-			for i := range o.typs {
-				vec := batch.ColVec(i)
-				if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(srcRowIdx) {
-					o.outNulls[i].SetNull(outputIdx)
-				} else {
-					switch o.canonicalTypeFamilies[i] {
-					// {{range .}}
-					case _CANONICAL_TYPE_FAMILY:
-						switch o.typs[i].Width() {
-						// {{range .WidthOverloads}}
-						case _TYPE_WIDTH:
-							srcCol := vec._TYPE()
-							outCol := o.out_TYPECols[o.outColsMap[i]]
-							v := srcCol.Get(srcRowIdx)
-							outCol.Set(outputIdx, v)
-							// {{end}}
-						}
+		minBatch := o.heap[0]
+		// Copy the min row into the output.
+		batch := o.inputBatches[minBatch]
+		srcRowIdx := o.inputIndices[minBatch]
+		if sel := batch.Selection(); sel != nil {
+			srcRowIdx = sel[srcRowIdx]
+		}
+		for i := range o.typs {
+			vec := batch.ColVec(i)
+			if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(srcRowIdx) {
+				o.outNulls[i].SetNull(outputIdx)
+			} else {
+				switch o.canonicalTypeFamilies[i] {
+				// {{range .}}
+				case _CANONICAL_TYPE_FAMILY:
+					switch o.typs[i].Width() {
+					// {{range .WidthOverloads}}
+					case _TYPE_WIDTH:
+						srcCol := vec._TYPE()
+						outCol := o.out_TYPECols[o.outColsMap[i]]
+						v := srcCol.Get(srcRowIdx)
+						outCol.Set(outputIdx, v)
 						// {{end}}
-					default:
-						colexecerror.InternalError(errors.AssertionFailedf("unhandled type %s", o.typs[i].String()))
 					}
+					// {{end}}
+				default:
+					colexecerror.InternalError(errors.AssertionFailedf("unhandled type %s", o.typs[i].String()))
 				}
 			}
-
-			// Advance the input batch, fetching a new batch if necessary.
-			if o.inputIndices[minBatch]+1 < o.inputBatches[minBatch].Length() {
-				o.inputIndices[minBatch]++
-			} else {
-				o.inputBatches[minBatch] = o.inputs[minBatch].Root.Next()
-				o.inputIndices[minBatch] = 0
-				o.updateComparators(minBatch)
-			}
-			if o.inputBatches[minBatch].Length() == 0 {
-				heap.Remove(o, 0)
-			} else {
-				heap.Fix(o, 0)
-			}
-
-			outputIdx++
 		}
-	})
+
+		// Advance the input batch, fetching a new batch if necessary.
+		if o.inputIndices[minBatch]+1 < o.inputBatches[minBatch].Length() {
+			o.inputIndices[minBatch]++
+		} else {
+			o.inputBatches[minBatch] = o.inputs[minBatch].Root.Next()
+			o.inputIndices[minBatch] = 0
+			o.updateComparators(minBatch)
+		}
+		if o.inputBatches[minBatch].Length() == 0 {
+			heap.Remove(o, 0)
+		} else {
+			heap.Fix(o, 0)
+		}
+
+		// Account for the memory of the row we have just set.
+		o.accountingHelper.AccountForSet(outputIdx)
+		outputIdx++
+		if o.maxCapacity == 0 && o.accountingHelper.Allocator.Used() >= o.memoryLimit {
+			o.maxCapacity = outputIdx
+		}
+	}
 
 	o.output.SetLength(outputIdx)
 	return o.output
@@ -213,7 +221,7 @@ func (o *OrderedSynchronizer) Next() coldata.Batch {
 
 func (o *OrderedSynchronizer) resetOutput() {
 	var reallocated bool
-	o.output, reallocated = o.allocator.ResetMaybeReallocate(
+	o.output, reallocated = o.accountingHelper.ResetMaybeReallocate(
 		o.typs, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
 	)
 	if reallocated {
@@ -280,12 +288,14 @@ func (o *OrderedSynchronizer) DrainMeta() []execinfrapb.ProducerMetadata {
 }
 
 func (o *OrderedSynchronizer) Close() error {
+	o.accountingHelper.Close()
 	for _, input := range o.inputs {
 		input.ToClose.CloseAndLogOnErr(o.EnsureCtx(), "ordered synchronizer")
 	}
 	if o.span != nil {
 		o.span.Finish()
 	}
+	*o = OrderedSynchronizer{}
 	return nil
 }
 

--- a/pkg/sql/colexec/ordered_synchronizer_tmpl.go
+++ b/pkg/sql/colexec/ordered_synchronizer_tmpl.go
@@ -214,7 +214,7 @@ func (o *OrderedSynchronizer) Next() coldata.Batch {
 func (o *OrderedSynchronizer) resetOutput() {
 	var reallocated bool
 	o.output, reallocated = o.allocator.ResetMaybeReallocate(
-		o.typs, o.output, 1 /* minCapacity */, o.memoryLimit,
+		o.typs, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
 	)
 	if reallocated {
 		// {{range .}}

--- a/pkg/sql/colexec/sort_chunks.go
+++ b/pkg/sql/colexec/sort_chunks.go
@@ -34,6 +34,7 @@ func NewSortChunks(
 	inputTypes []*types.T,
 	orderingCols []execinfrapb.Ordering_Column,
 	matchLen int,
+	maxOutputBatchMemSize int64,
 ) (colexecop.Operator, error) {
 	if matchLen < 1 || matchLen == len(orderingCols) {
 		colexecerror.InternalError(errors.AssertionFailedf(
@@ -49,7 +50,7 @@ func NewSortChunks(
 	if err != nil {
 		return nil, err
 	}
-	sorter, err := newSorter(allocator, chunker, inputTypes, orderingCols[matchLen:])
+	sorter, err := newSorter(allocator, chunker, inputTypes, orderingCols[matchLen:], maxOutputBatchMemSize)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/colexec/sort_chunks.go
+++ b/pkg/sql/colexec/sort_chunks.go
@@ -141,7 +141,9 @@ func (c *sortChunksOp) ExportBuffered(colexecop.Operator) coldata.Batch {
 	// batch that hasn't been "processed" and should be the first to be exported.
 	firstTupleIdx := c.input.exportState.numProcessedTuplesFromBatch
 	if c.input.batch != nil && firstTupleIdx+c.exportedFromBatch < c.input.batch.Length() {
-		colexecutils.MakeWindowIntoBatch(c.windowedBatch, c.input.batch, firstTupleIdx, c.input.inputTypes)
+		colexecutils.MakeWindowIntoBatch(
+			c.windowedBatch, c.input.batch, firstTupleIdx, c.input.batch.Length(), c.input.inputTypes,
+		)
 		c.exportedFromBatch = c.windowedBatch.Length()
 		return c.windowedBatch
 	}

--- a/pkg/sql/colexec/sort_chunks_test.go
+++ b/pkg/sql/colexec/sort_chunks_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexectestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -188,7 +189,7 @@ func TestSortChunks(t *testing.T) {
 
 	for _, tc := range sortChunksTestCases {
 		colexectestutils.RunTests(t, testAllocator, []colexectestutils.Tuples{tc.tuples}, tc.expected, colexectestutils.OrderedVerifier, func(input []colexecop.Operator) (colexecop.Operator, error) {
-			return NewSortChunks(testAllocator, input[0], tc.typs, tc.ordCols, tc.matchLen)
+			return NewSortChunks(testAllocator, input[0], tc.typs, tc.ordCols, tc.matchLen, execinfra.DefaultMemoryLimit)
 		})
 	}
 }
@@ -230,7 +231,7 @@ func TestSortChunksRandomized(t *testing.T) {
 				sort.Slice(expected, less(expected, ordCols))
 
 				colexectestutils.RunTests(t, testAllocator, []colexectestutils.Tuples{sortedTups}, expected, colexectestutils.OrderedVerifier, func(input []colexecop.Operator) (colexecop.Operator, error) {
-					return NewSortChunks(testAllocator, input[0], typs[:nCols], ordCols, matchLen)
+					return NewSortChunks(testAllocator, input[0], typs[:nCols], ordCols, matchLen, execinfra.DefaultMemoryLimit)
 				})
 			}
 		}
@@ -242,10 +243,10 @@ func BenchmarkSortChunks(b *testing.B) {
 	rng, _ := randutil.NewPseudoRand()
 	ctx := context.Background()
 
-	sorterConstructors := []func(*colmem.Allocator, colexecop.Operator, []*types.T, []execinfrapb.Ordering_Column, int) (colexecop.Operator, error){
+	sorterConstructors := []func(*colmem.Allocator, colexecop.Operator, []*types.T, []execinfrapb.Ordering_Column, int, int64) (colexecop.Operator, error){
 		NewSortChunks,
-		func(allocator *colmem.Allocator, input colexecop.Operator, inputTypes []*types.T, orderingCols []execinfrapb.Ordering_Column, _ int) (colexecop.Operator, error) {
-			return NewSorter(allocator, input, inputTypes, orderingCols)
+		func(allocator *colmem.Allocator, input colexecop.Operator, inputTypes []*types.T, orderingCols []execinfrapb.Ordering_Column, _ int, maxOutputBatchMemSize int64) (colexecop.Operator, error) {
+			return NewSorter(allocator, input, inputTypes, orderingCols, maxOutputBatchMemSize)
 		},
 	}
 	sorterNames := []string{"CHUNKS", "ALL"}
@@ -295,7 +296,7 @@ func BenchmarkSortChunks(b *testing.B) {
 								b.ResetTimer()
 								for n := 0; n < b.N; n++ {
 									source := colexectestutils.NewFiniteChunksSource(testAllocator, batch, typs, nBatches, matchLen)
-									sorter, err := sorterConstructor(testAllocator, source, typs, ordCols, matchLen)
+									sorter, err := sorterConstructor(testAllocator, source, typs, ordCols, matchLen, execinfra.DefaultMemoryLimit)
 									if err != nil {
 										b.Fatal(err)
 									}

--- a/pkg/sql/colexec/sorttopk.go
+++ b/pkg/sql/colexec/sorttopk.go
@@ -303,7 +303,9 @@ func (t *topKSorter) ExportBuffered(colexecop.Operator) coldata.Batch {
 	// Next, we check whether we have exported all tuples from the last read
 	// batch.
 	if t.inputBatch != nil && t.firstUnprocessedTupleIdx+t.exportedFromBatch < t.inputBatch.Length() {
-		colexecutils.MakeWindowIntoBatch(t.windowedBatch, t.inputBatch, t.firstUnprocessedTupleIdx, t.inputTypes)
+		colexecutils.MakeWindowIntoBatch(
+			t.windowedBatch, t.inputBatch, t.firstUnprocessedTupleIdx, t.inputBatch.Length(), t.inputTypes,
+		)
 		t.exportedFromBatch = t.windowedBatch.Length()
 		return t.windowedBatch
 	}

--- a/pkg/sql/colexec/sorttopk.go
+++ b/pkg/sql/colexec/sorttopk.go
@@ -13,7 +13,6 @@ package colexec
 import (
 	"container/heap"
 	"context"
-	"math"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecutils"
@@ -39,13 +38,15 @@ func NewTopKSorter(
 	inputTypes []*types.T,
 	orderingCols []execinfrapb.Ordering_Column,
 	k uint64,
+	maxOutputBatchMemSize int64,
 ) colexecop.ResettableOperator {
 	return &topKSorter{
-		allocator:    allocator,
-		OneInputNode: colexecop.NewOneInputNode(input),
-		inputTypes:   inputTypes,
-		orderingCols: orderingCols,
-		k:            k,
+		allocator:             allocator,
+		OneInputNode:          colexecop.NewOneInputNode(input),
+		inputTypes:            inputTypes,
+		orderingCols:          orderingCols,
+		k:                     k,
+		maxOutputBatchMemSize: maxOutputBatchMemSize,
 	}
 }
 
@@ -92,8 +93,9 @@ type topKSorter struct {
 	// sel is a selection vector which specifies an ordering on topK.
 	sel []int
 	// emitted is the count of rows which have been emitted so far.
-	emitted int
-	output  coldata.Batch
+	emitted               int
+	output                coldata.Batch
+	maxOutputBatchMemSize int64
 
 	exportedFromTopK  int
 	exportedFromBatch int
@@ -232,13 +234,10 @@ func (t *topKSorter) emit() coldata.Batch {
 		// We're done.
 		return coldata.ZeroBatch
 	}
-	if toEmit > coldata.BatchSize() {
-		toEmit = coldata.BatchSize()
+	t.output, _ = t.allocator.ResetMaybeReallocate(t.inputTypes, t.output, toEmit, t.maxOutputBatchMemSize)
+	if toEmit > t.output.Capacity() {
+		toEmit = t.output.Capacity()
 	}
-	// For now, we don't enforce any footprint-based memory limit.
-	// TODO(yuzefovich): refactor this.
-	const maxBatchMemSize = math.MaxInt64
-	t.output, _ = t.allocator.ResetMaybeReallocate(t.inputTypes, t.output, toEmit, maxBatchMemSize)
 	for i := range t.inputTypes {
 		vec := t.output.ColVec(i)
 		// At this point, we have already fully sorted the input. It is ok to do

--- a/pkg/sql/colexec/sorttopk_test.go
+++ b/pkg/sql/colexec/sorttopk_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexectestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -71,7 +72,7 @@ func TestTopKSorter(t *testing.T) {
 	for _, tc := range topKSortTestCases {
 		log.Infof(context.Background(), "%s", tc.description)
 		colexectestutils.RunTests(t, testAllocator, []colexectestutils.Tuples{tc.tuples}, tc.expected, colexectestutils.OrderedVerifier, func(input []colexecop.Operator) (colexecop.Operator, error) {
-			return NewTopKSorter(testAllocator, input[0], tc.typs, tc.ordCols, tc.k), nil
+			return NewTopKSorter(testAllocator, input[0], tc.typs, tc.ordCols, tc.k, execinfra.DefaultMemoryLimit), nil
 		})
 	}
 }

--- a/pkg/sql/colflow/colrpc/inbox.go
+++ b/pkg/sql/colflow/colrpc/inbox.go
@@ -371,8 +371,7 @@ func (i *Inbox) Next() coldata.Batch {
 		if err != nil {
 			colexecerror.InternalError(err)
 		}
-		// For now, we don't enforce any footprint-based memory limit.
-		// TODO(yuzefovich): refactor this.
+		// We rely on the outboxes to produce reasonably sized batches.
 		const maxBatchMemSize = math.MaxInt64
 		i.scratch.b, _ = i.allocator.ResetMaybeReallocate(i.typs, i.scratch.b, batchLength, maxBatchMemSize)
 		i.allocator.PerformOperation(i.scratch.b.ColVecs(), func() {


### PR DESCRIPTION
**colexec: refactor dynamic batching to pay attention to memory footprint**

We use `Allocator.ResetMaybeReallocate` method in order to get the
"dynamic batch" behavior - meaning that the batches are of "dynamic"
size. Previously, the capacity argument to the method was the most
important - the contract of the method guaranteed that the batch will
have the requested capacity. This commit changes the contract so that if
we see that the old batch has already exceeded the specified maximum
memory footprint, then that batch will be reused, even if the desired
capacity is not satisfied.

This commit then updates the code in several places (all sorters and the
cross joiner) to take advantage of the new contract. In some places
I believe we don't want/need to use the limiting. A couple of other
places (the hash aggregator and the ordered synchronizer) will be
refactored in a follow-up commit.

Release note: None

**colexec: use SetAccountingHelper in the ordered sync and hash aggregator**

This commit refactors the ordered synchronizer and the hash aggregator
to take advantage of the recently introduced `SetAccountingHelper` in
order to have precise control on the output batch capacity based on the
memory footprint.

Release note: None

**colexec: improve partitioning logic in external sort**

Previously, `inputPartitioningOperator` - which decides when to start
a new partition for the external sort - operated on a batch granularity.
That meant that if the input batch significantly exceeded the target
memory limit, the operator would do nothing about it and return the
batch as is. This is suboptimal, and this commit changes the behavior so
that operator creates "windows" into an input batch if it notices that
returning the input batch as is would overshoot the target.

Release note: None

Fixes: #68008.