### PR TITLE
sql: re-enable test TestImportPgDumpSchemas/inject-error-ensure-cleanup

### DIFF
--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -5996,7 +5996,6 @@ table_name FROM [SHOW TABLES] ORDER BY (schema_name, table_name)`,
 	})
 
 	t.Run("inject-error-ensure-cleanup", func(t *testing.T) {
-		skip.WithIssue(t, 65878, "flaky test")
 		defer gcjob.SetSmallMaxGCIntervalForTest()()
 		tc := testcluster.StartTestCluster(t, nodes, base.TestClusterArgs{ServerArgs: args})
 		defer tc.Stopper().Stop(ctx)


### PR DESCRIPTION
Fixes: #65878

Previously, this test was disable because it was acting flaky
and failing in a fairly consistent manner. This was inadequate
because the flaky failures have disappeared. To address this, this
patch re-enables the test since we can't reproduce the failure
after multiple attempts.
Release note: None