### PR TITLE
release-20.2: sql: improve pg_table_is_visible performance

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -2733,6 +2733,8 @@ SELECT * FROM crdb_internal.check_consistency(true, ‘\x02’, ‘\x04’)</p>
 </span></td></tr>
 <tr><td><a name="pg_sleep"></a><code>pg_sleep(seconds: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>pg_sleep makes the current session’s process sleep until seconds seconds have elapsed. seconds is a value of type double precision, so fractional-second delays can be specified.</p>
 </span></td></tr>
+<tr><td><a name="pg_table_is_visible"></a><code>pg_table_is_visible(oid: oid) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns whether the table with the given OID belongs to one of the schemas on the search path.</p>
+</span></td></tr>
 <tr><td><a name="pg_type_is_visible"></a><code>pg_type_is_visible(oid: oid) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns whether the type with the given OID belongs to one of the schemas on the search path.</p>
 </span></td></tr></tbody>
 </table>

--- a/pkg/bench/ddl_analysis/orm_queries_bench_test.go
+++ b/pkg/bench/ddl_analysis/orm_queries_bench_test.go
@@ -1,0 +1,86 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package bench
+
+import "testing"
+
+func BenchmarkORMQueries(b *testing.B) {
+	tests := []RoundTripBenchTestCase{
+		{
+			name:  "django table introspection 1 table",
+			setup: `CREATE TABLE t1(a int primary key, b int);`,
+			stmt: `SELECT
+    a.attname AS column_name,
+    NOT (a.attnotnull OR ((t.typtype = 'd') AND t.typnotnull)) AS is_nullable,
+    pg_get_expr(ad.adbin, ad.adrelid) AS column_default
+FROM pg_attribute AS a
+LEFT JOIN pg_attrdef AS ad ON (a.attrelid = ad.adrelid) AND (a.attnum = ad.adnum)
+JOIN pg_type AS t ON a.atttypid = t.oid JOIN pg_class AS c ON a.attrelid = c.oid
+JOIN pg_namespace AS n ON c.relnamespace = n.oid
+WHERE (
+    (
+        (c.relkind IN ('f', 'm', 'p', 'r', 'v')) AND
+        (c.relname = '<target table>')
+    ) AND (n.nspname NOT IN ('pg_catalog', 'pg_toast'))
+) AND pg_table_is_visible(c.oid)`,
+		},
+
+		{
+			name: "django table introspection 4 tables",
+			setup: `CREATE TABLE t1(a int primary key, b int);
+CREATE TABLE t2(a int primary key, b int);
+CREATE TABLE t3(a int primary key, b int);
+CREATE TABLE t4(a int primary key, b int);`,
+			stmt: `SELECT
+    a.attname AS column_name,
+    NOT (a.attnotnull OR ((t.typtype = 'd') AND t.typnotnull)) AS is_nullable,
+    pg_get_expr(ad.adbin, ad.adrelid) AS column_default
+FROM pg_attribute AS a
+LEFT JOIN pg_attrdef AS ad ON (a.attrelid = ad.adrelid) AND (a.attnum = ad.adnum)
+JOIN pg_type AS t ON a.atttypid = t.oid JOIN pg_class AS c ON a.attrelid = c.oid
+JOIN pg_namespace AS n ON c.relnamespace = n.oid
+WHERE (
+    (
+        (c.relkind IN ('f', 'm', 'p', 'r', 'v')) AND
+        (c.relname = '<target table>')
+    ) AND (n.nspname NOT IN ('pg_catalog', 'pg_toast'))
+) AND pg_table_is_visible(c.oid)`,
+		},
+
+		{
+			name: "django table introspection 8 tables",
+			setup: `CREATE TABLE t1(a int primary key, b int);
+CREATE TABLE t2(a int primary key, b int);
+CREATE TABLE t3(a int primary key, b int);
+CREATE TABLE t4(a int primary key, b int);
+CREATE TABLE t5(a int primary key, b int);
+CREATE TABLE t6(a int primary key, b int);
+CREATE TABLE t7(a int primary key, b int);
+CREATE TABLE t8(a int primary key, b int);`,
+			stmt: `SELECT
+    a.attname AS column_name,
+    NOT (a.attnotnull OR ((t.typtype = 'd') AND t.typnotnull)) AS is_nullable,
+    pg_get_expr(ad.adbin, ad.adrelid) AS column_default
+FROM pg_attribute AS a
+LEFT JOIN pg_attrdef AS ad ON (a.attrelid = ad.adrelid) AND (a.attnum = ad.adnum)
+JOIN pg_type AS t ON a.atttypid = t.oid JOIN pg_class AS c ON a.attrelid = c.oid
+JOIN pg_namespace AS n ON c.relnamespace = n.oid
+WHERE (
+    (
+        (c.relkind IN ('f', 'm', 'p', 'r', 'v')) AND
+        (c.relname = '<target table>')
+    ) AND (n.nspname NOT IN ('pg_catalog', 'pg_toast'))
+) AND pg_table_is_visible(c.oid)`,
+		},
+	}
+
+	RunRoundTripBenchmark(b, tests)
+}

--- a/pkg/ccl/importccl/import_table_creation.go
+++ b/pkg/ccl/importccl/import_table_creation.go
@@ -237,6 +237,13 @@ func (so *importSequenceOperators) IsTypeVisible(
 	return false, false, errors.WithStack(errSequenceOperators)
 }
 
+// IsTableVisible is part of the tree.EvalDatabase interface.
+func (so *importSequenceOperators) IsTableVisible(
+	ctx context.Context, curDB string, searchPath sessiondata.SearchPath, tableID int64,
+) (bool, bool, error) {
+	return false, false, errors.WithStack(errSequenceOperators)
+}
+
 // Implements the tree.SequenceOperators interface.
 func (so *importSequenceOperators) IncrementSequence(
 	ctx context.Context, seqName *tree.TableName,

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -68,6 +68,13 @@ func (so *DummySequenceOperators) IsTypeVisible(
 	return false, false, errors.WithStack(errEvalPlanner)
 }
 
+// IsTableVisible is part of the tree.EvalDatabase interface.
+func (so *DummySequenceOperators) IsTableVisible(
+	ctx context.Context, curDB string, searchPath sessiondata.SearchPath, tableID int64,
+) (bool, bool, error) {
+	return false, false, errors.WithStack(errSequenceOperators)
+}
+
 // IncrementSequence is part of the tree.SequenceOperators interface.
 func (so *DummySequenceOperators) IncrementSequence(
 	ctx context.Context, seqName *tree.TableName,
@@ -156,6 +163,13 @@ func (ep *DummyEvalPlanner) LookupSchema(
 // IsTypeVisible is part of the tree.EvalDatabase interface.
 func (ep *DummyEvalPlanner) IsTypeVisible(
 	ctx context.Context, curDB string, searchPath sessiondata.SearchPath, typeID oid.Oid,
+) (bool, bool, error) {
+	return false, false, errors.WithStack(errEvalPlanner)
+}
+
+// IsTableVisible is part of the tree.EvalDatabase interface.
+func (ep *DummyEvalPlanner) IsTableVisible(
+	ctx context.Context, curDB string, searchPath sessiondata.SearchPath, tableID int64,
 ) (bool, bool, error) {
 	return false, false, errors.WithStack(errEvalPlanner)
 }

--- a/pkg/sql/logictest/testdata/logic_test/pg_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/pg_builtins
@@ -35,18 +35,49 @@ SELECT format_type(152100, 0)
 unknown (OID=152100)
 
 statement ok
+CREATE TABLE is_visible(a int primary key);
 CREATE TYPE visible_type AS ENUM('a');
 CREATE SCHEMA other;
+CREATE TABLE other.not_visible(a int primary key);
 CREATE TYPE other.not_visible_type AS ENUM('b');
 CREATE DATABASE db2;
 SET DATABASE = db2;
+CREATE TABLE table_in_db2(a int primary key);
 CREATE TYPE type_in_db2 AS ENUM('c');
+
+let $table_in_db2_id
+SELECT c.oid FROM pg_class c WHERE c.relname = 'table_in_db2';
 
 let $type_in_db2_id
 SELECT t.oid FROM pg_type t WHERE t.typname = 'type_in_db2';
 
 statement ok
 SET DATABASE = test;
+
+query TB rowsort
+SELECT c.relname, pg_table_is_visible(c.oid)
+FROM pg_class c
+WHERE c.relname IN ('is_visible', 'not_visible')
+----
+is_visible   true
+not_visible  false
+
+# Looking up a table in a different database should return NULL.
+query B
+SELECT pg_table_is_visible($table_in_db2_id)
+----
+NULL
+
+# Looking up a non-existent OID should return NULL.
+query B
+SELECT pg_table_is_visible(1010101010)
+----
+NULL
+
+query B
+SELECT pg_table_is_visible(NULL)
+----
+NULL
 
 query TB rowsort
 SELECT t.typname, pg_type_is_visible(t.oid)

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -1067,25 +1067,26 @@ SELECT description
 		},
 	),
 	// pg_table_is_visible returns true if the input oid corresponds to a table
-	// that is part of the databases on the search path.
+	// that is part of the schemas on the search path.
 	// https://www.postgresql.org/docs/9.6/static/functions-info.html
 	"pg_table_is_visible": makeBuiltin(defProps(),
 		tree.Overload{
 			Types:      tree.ArgTypes{{"oid", types.Oid}},
 			ReturnType: tree.FixedReturnType(types.Bool),
 			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
-				oid := args[0]
-				t, err := ctx.InternalExecutor.QueryRow(
-					ctx.Ctx(), "pg_table_is_visible",
-					ctx.Txn,
-					"SELECT nspname FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON c.relnamespace=n.oid "+
-						"WHERE c.oid=$1 AND nspname=ANY(current_schemas(true))", oid)
+				oid := tree.MustBeDOid(args[0])
+				isVisible, exists, err := ctx.Planner.IsTableVisible(
+					ctx.Context, ctx.SessionData.Database, ctx.SessionData.SearchPath, int64(oid.DInt),
+				)
 				if err != nil {
 					return nil, err
 				}
-				return tree.MakeDBool(tree.DBool(t != nil)), nil
+				if !exists {
+					return tree.DNull, nil
+				}
+				return tree.MakeDBool(tree.DBool(isVisible)), nil
 			},
-			Info:       notUsableInfo,
+			Info:       "Returns whether the table with the given OID belongs to one of the schemas on the search path.",
 			Volatility: tree.VolatilityStable,
 		},
 	),

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2979,6 +2979,15 @@ type EvalDatabase interface {
 	IsTypeVisible(
 		ctx context.Context, curDB string, searchPath sessiondata.SearchPath, typeID oid.Oid,
 	) (isVisible bool, exists bool, err error)
+
+	// IsTableVisible checks if the table with the given ID belongs to a schema
+	// on the given sessiondata.SearchPath.
+	IsTableVisible(
+		ctx context.Context,
+		curDB string,
+		searchPath sessiondata.SearchPath,
+		tableID int64,
+	) (isVisible bool, exists bool, err error)
 }
 
 // EvalPlanner is a limited planner that can be used from EvalContext.


### PR DESCRIPTION
Backport 1/1 commits from #59880.

/cc @cockroachdb/release

Release justification: performance improvement that is only isolated to one builtin function.

---

This is motivated by a query that Django makes in order to retrieve all
the tables visible in the current session. The query uses the
pg_table_is_visible function. Previously this was implemented by using
the internal executor to inspect the pg_catalog. This was expensive
because the internal executor does not share the same descriptor
collection as the external context, so it ended up fetching every single
table descriptor one-by-one.

Now, we avoid the internal executor and lookup the table descriptor
directly.

There are other builtins that use the internal executor that may face
the same problem. Perhaps an approach for the future is to allow builtin
functions to be implemented using user-defined scalar functions.

I added a benchmark that shows the original Django query performing a
constant number of descriptor lookups with this new implementation.

fixes #57924 

Release note (performance improvement): Improve performance of the
pg_table_is_visible builtin function.
