### PR TITLE
roachtest: bump import/tpch/nodes=8 timeout to 10h

### DIFF
--- a/pkg/cmd/roachtest/tests/import.go
+++ b/pkg/cmd/roachtest/tests/import.go
@@ -172,8 +172,10 @@ func registerImportTPCH(r registry.Registry) {
 		// is required to confirm this. Until then, the 4 and 32 node configurations
 		// are removed (4 is too slow and 32 is pretty expensive) while 8-node is
 		// given a 50% longer timeout (which running by hand suggests should be OK).
-		// (10/30/19) The timeout was increased again to 8 hours.
-		{8, 8 * time.Hour},
+		// (07/27/21) The timeout was increased again to 10 hours. The test runs in
+		// ~7 hours which causes it to occasionally exceed the previous timeout of 8
+		// hours.
+		{8, 10 * time.Hour},
 	} {
 		item := item
 		r.Add(registry.TestSpec{


### PR DESCRIPTION
Previously, the roachtest had a timeout of 8h. The test
usually runs in ~7hrs but occasionally tips over the
configured time out. While we investigate the slowness
of this import as tracked in https://github.com/cockroachdb/cockroach/issues/68117,
we are bumping the timeout to 10h.

Release note: None