### PR TITLE
bazel: start building generated documentation using bazel in ci

### DIFF
--- a/build/bazelutil/bazelbuild.sh
+++ b/build/bazelutil/bazelbuild.sh
@@ -8,7 +8,15 @@ then
     exit 1
 fi
 
+CONFIG="$1"
+
+DOC_TARGETS=
+if [ "$CONFIG" == "crosslinux" ]
+then
+   DOC_TARGETS="//docs/generated:gen-logging-md //docs/generated/settings:settings //docs/generated/settings:settings_for_tenants //docs/generated/sql"
+fi
+
 bazel build //pkg/cmd/bazci --config=ci
 $(bazel info bazel-bin)/pkg/cmd/bazci/bazci_/bazci --compilation_mode opt \
-		       --config "$1" \
-		       build //pkg/cmd/cockroach-short //c-deps:libgeos
+		       --config "$CONFIG" \
+		       build //pkg/cmd/cockroach-short //c-deps:libgeos $DOC_TARGETS

--- a/build/teamcity-bazel.sh
+++ b/build/teamcity-bazel.sh
@@ -10,3 +10,24 @@ tc_prepare
 tc_start_block "Run Bazel build"
 run_bazel build/bazelutil/bazelbuild.sh crosslinux
 tc_end_block "Run Bazel build"
+
+set +e
+
+tc_start_block "Ensure generated files match"
+FAILED=
+for FILE in $(find $root/artifacts/bazel-bin/docs -type f)
+do
+    RESULT=$(diff $FILE $root/${FILE##$root/artifacts/bazel-bin/})
+    if [[ ! $? -eq 0 ]]
+    then
+        echo "File $FILE does not match with checked-in version. Got diff:"
+        echo "$RESULT"
+        FAILED=1
+    fi
+done
+if [[ ! -z "$FAILED" ]]
+then
+    echo 'Generated files do not match! Are the checked-in generated files up-to-date?'
+    exit 1
+fi
+tc_end_block "Ensure generated files match"

--- a/docs/generated/settings/BUILD.bazel
+++ b/docs/generated/settings/BUILD.bazel
@@ -1,7 +1,7 @@
 genrule(
     name = "settings",
     outs = ["settings.html"],
-    cmd = "$(location //pkg/cmd/cockroach-short) gen settings-list --format=html > $@",
+    cmd = "$(location //pkg/cmd/cockroach-short) gen settings-list --format=rawhtml > $@",
     exec_tools = ["//pkg/cmd/cockroach-short"],
 )
 

--- a/pkg/cmd/bazci/bazci.go
+++ b/pkg/cmd/bazci/bazci.go
@@ -124,6 +124,8 @@ type buildInfo struct {
 	goBinaries []string
 	// Expanded list of cmake targets to be built.
 	cmakeTargets []string
+	// Expanded list of genrule targets to be built.
+	genruleTargets []string
 	// Expanded list of Go test targets to be run. Test suites are split up
 	// into their component tests and all put in this list, so this may be
 	// considerably longer than the argument list.
@@ -175,6 +177,8 @@ func getBuildInfo(args parsedArgs) (buildInfo, error) {
 		switch targetKind {
 		case "cmake":
 			ret.cmakeTargets = append(ret.cmakeTargets, fullTarget)
+		case "genrule":
+			ret.genruleTargets = append(ret.genruleTargets, fullTarget)
 		case "go_binary":
 			ret.goBinaries = append(ret.goBinaries, fullTarget)
 		case "go_test":


### PR DESCRIPTION
In the Linux CI job, build the documentation and ensure it's byte-for-
byte identical with what we have in tree.

Also make a quick change to generate `settings.html` correctly.

Part of #68130.

Release note: None