### PR TITLE
changefeedccl: Add resolved spans metric.

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -567,6 +567,7 @@ func (ca *changeAggregator) emitResolved(
 		rowenc.EncDatum{Datum: tree.DNull}, // key
 		rowenc.EncDatum{Datum: tree.DNull}, // value
 	})
+	ca.metrics.ResolvedMessages.Inc(1)
 	return nil
 }
 

--- a/pkg/ccl/changefeedccl/metrics.go
+++ b/pkg/ccl/changefeedccl/metrics.go
@@ -105,6 +105,12 @@ var (
 		Measurement: "Messages",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaChangefeedForwardedResolvedMessages = metric.Metadata{
+		Name:        "changefeed.forwarded_resolved_messages",
+		Help:        "Resolved timestamps forwarded from the change aggregator to the change frontier",
+		Measurement: "Messages",
+		Unit:        metric.Unit_COUNT,
+	}
 	metaChangefeedEmittedBytes = metric.Metadata{
 		Name:        "changefeed.emitted_bytes",
 		Help:        "Bytes emitted by all feeds",
@@ -205,11 +211,12 @@ type Metrics struct {
 	KVFeedMetrics     kvevent.Metrics
 	SchemaFeedMetrics schemafeed.Metrics
 
-	EmittedMessages *metric.Counter
-	EmittedBytes    *metric.Counter
-	Flushes         *metric.Counter
-	ErrorRetries    *metric.Counter
-	Failures        *metric.Counter
+	EmittedMessages  *metric.Counter
+	ResolvedMessages *metric.Counter
+	EmittedBytes     *metric.Counter
+	Flushes          *metric.Counter
+	ErrorRetries     *metric.Counter
+	Failures         *metric.Counter
 
 	ProcessingNanos *metric.Counter
 	EmitNanos       *metric.Counter
@@ -240,6 +247,7 @@ func MakeMetrics(histogramWindow time.Duration) metric.Struct {
 		KVFeedMetrics:     kvevent.MakeMetrics(histogramWindow),
 		SchemaFeedMetrics: schemafeed.MakeMetrics(histogramWindow),
 		EmittedMessages:   metric.NewCounter(metaChangefeedEmittedMessages),
+		ResolvedMessages:  metric.NewCounter(metaChangefeedForwardedResolvedMessages),
 		EmittedBytes:      metric.NewCounter(metaChangefeedEmittedBytes),
 		Flushes:           metric.NewCounter(metaChangefeedFlushes),
 		ErrorRetries:      metric.NewCounter(metaChangefeedErrorRetries),


### PR DESCRIPTION
Add a metric to keep track of the number of the resolved
span events emitted between aggregator and the frontier.

Release Notes: None