### PR TITLE
sql, opt: support hint to disallow zigzag join, support bounded staleness checks

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -972,6 +972,7 @@ unreserved_keyword ::=
 	| 'NO'
 	| 'NORMAL'
 	| 'NO_INDEX_JOIN'
+	| 'NO_ZIGZAG_JOIN'
 	| 'NOCREATEDB'
 	| 'NOCREATELOGIN'
 	| 'NOCANCELQUERY'
@@ -2734,6 +2735,7 @@ materialize_clause ::=
 index_flags_param ::=
 	'FORCE_INDEX' '=' index_name
 	| 'NO_INDEX_JOIN'
+	| 'NO_ZIGZAG_JOIN'
 
 opt_asc_desc ::=
 	'ASC'

--- a/pkg/ccl/logictestccl/testdata/logic_test/as_of
+++ b/pkg/ccl/logictestccl/testdata/logic_test/as_of
@@ -1,7 +1,7 @@
 # LogicTest: local
 
 statement ok
-CREATE TABLE t (i INT)
+CREATE TABLE t (i INT PRIMARY KEY, j INT UNIQUE, k INT, UNIQUE (k) STORING (j))
 
 statement ok
 INSERT INTO t VALUES (2)
@@ -114,11 +114,142 @@ true
 statement error interval duration for with_max_staleness must be greater or equal to 0
 SELECT with_max_staleness(-'1s')
 
-statement ok
+#
+# Tests for optimizer bounded staleness checks.
+#
+
+statement error unimplemented: cannot use bounded staleness for queries that may touch more than one range or require an index join
 SELECT * FROM t AS OF SYSTEM TIME with_max_staleness('1ms')
 
-statement ok
+statement error unimplemented: cannot use bounded staleness for queries that may touch more than one range or require an index join
 SELECT * FROM t AS OF SYSTEM TIME with_min_timestamp(statement_timestamp() - '1ms')
+
+statement error unimplemented: cannot use bounded staleness for MERGE JOIN
+SELECT * FROM t AS t1 JOIN t AS t2 ON t1.i = t2.i AS OF SYSTEM TIME with_max_staleness('1ms')
+
+statement error unimplemented: cannot use bounded staleness for INNER JOIN
+SELECT * FROM t AS t1 INNER HASH JOIN t AS t2 ON t1.i = t2.i AS OF SYSTEM TIME with_min_timestamp(statement_timestamp() - '1ms')
+
+statement error unimplemented: cannot use bounded staleness for LOOKUP JOIN
+SELECT * FROM t AS t1 LEFT LOOKUP JOIN t AS t2 ON t1.i = t2.i AS OF SYSTEM TIME with_max_staleness('1ms')
+
+statement error unimplemented: cannot use bounded staleness for UNION
+SELECT * FROM (SELECT * FROM t UNION SELECT * FROM t) AS OF SYSTEM TIME with_max_staleness('1ms')
+
+statement error unimplemented: cannot use bounded staleness for INTERSECT ALL
+SELECT * FROM (SELECT * FROM t INTERSECT ALL SELECT * FROM t) AS OF SYSTEM TIME with_min_timestamp(statement_timestamp() - '1ms')
+
+statement ok
+SELECT * FROM t AS OF SYSTEM TIME with_max_staleness('1ms') WHERE i = 2
+
+statement ok
+SELECT * FROM t AS OF SYSTEM TIME with_min_timestamp(statement_timestamp() - '1ms') WHERE i = 1
+
+# Projections are supported.
+statement ok
+SELECT i+2 FROM t AS OF SYSTEM TIME with_max_staleness('1ms') WHERE i = 1
+
+# Select is supported.
+statement ok
+SELECT * FROM t AS OF SYSTEM TIME with_max_staleness('1ms') WHERE i = 2 AND j > 5
+
+# Aggregations are supported.
+statement ok
+SELECT sum(i) FROM t AS OF SYSTEM TIME with_min_timestamp(statement_timestamp() - '1ms') WHERE i = 2
+
+# Scan from a secondary index is supported.
+statement ok
+SELECT * FROM t AS OF SYSTEM TIME with_max_staleness('1ms') WHERE k = 2
+
+# Scan from a secondary index is not supported if it requires an index join.
+statement error unimplemented: cannot use bounded staleness for queries that may touch more than one range or require an index join
+SELECT * FROM t AS OF SYSTEM TIME with_max_staleness('1ms') WHERE j = 2
+
+# No index join or zigzag join is produced.
+query T
+EXPLAIN (OPT, MEMO) SELECT * FROM t AS OF SYSTEM TIME with_max_staleness('1ms') WHERE j = 2 AND i = 1
+----
+memo (optimized, ~7KB, required=[presentation: info:6])
+ ├── G1: (explain G2 [presentation: i:1,j:2,k:3])
+ │    └── [presentation: info:6]
+ │         ├── best: (explain G2="[presentation: i:1,j:2,k:3]" [presentation: i:1,j:2,k:3])
+ │         └── cost: 5.17
+ ├── G2: (select G3 G4) (select G5 G6)
+ │    └── [presentation: i:1,j:2,k:3]
+ │         ├── best: (select G5 G6)
+ │         └── cost: 5.16
+ ├── G3: (scan t,cols=(1-3)) (scan t@t_k_key,cols=(1-3))
+ │    └── []
+ │         ├── best: (scan t,cols=(1-3))
+ │         └── cost: 1146.41
+ ├── G4: (filters G7 G8)
+ ├── G5: (scan t,cols=(1-3),constrained)
+ │    └── []
+ │         ├── best: (scan t,cols=(1-3),constrained)
+ │         └── cost: 5.13
+ ├── G6: (filters G7)
+ ├── G7: (eq G9 G10)
+ ├── G8: (eq G11 G12)
+ ├── G9: (variable j)
+ ├── G10: (const 2)
+ ├── G11: (variable i)
+ └── G12: (const 1)
+select
+ ├── scan t
+ │    ├── constraint: /1: [/1 - /1]
+ │    └── flags: no-index-join no-zigzag-join
+ └── filters
+      └── j = 2
+
+# Scan may produce multiple rows.
+statement error unimplemented: cannot use bounded staleness for queries that may touch more than one range or require an index join
+SELECT * FROM t AS OF SYSTEM TIME with_max_staleness('1ms') WHERE k IS NULL
+
+# Scan may produce multiple rows.
+statement error unimplemented: cannot use bounded staleness for queries that may touch more than one range or require an index join
+SELECT * FROM t AS OF SYSTEM TIME with_max_staleness('1ms') WHERE k IS NULL LIMIT 10
+
+# Even though the scan is limited to 1 row, from KV's perspective, this is a
+# multi-row scan with a limit. That means that the scan can span multiple
+# ranges, but we expect it to short-circuit once it hits the first row. In
+# practice, we expect that to very often be in the first range we hit, but
+# there's no guarantee of that - we could have empty ranges.
+statement error unimplemented: cannot use bounded staleness for queries that may touch more than one range or require an index join
+SELECT * FROM t AS OF SYSTEM TIME with_max_staleness('1ms') WHERE k IS NULL LIMIT 1
+
+# Subquery contains the only scan, so it succeeds.
+statement ok
+SELECT (SELECT k FROM t WHERE i = 1) FROM generate_series(1, 100) AS OF SYSTEM TIME with_max_staleness('1ms')
+
+# Subquery does not scan data, so it succeeds.
+statement ok
+SELECT (SELECT random()) FROM t AS OF SYSTEM TIME with_max_staleness('1ms') WHERE k = 1
+
+# Subqueries that perform an additional scan are not supported.
+statement error unimplemented: cannot use bounded staleness for queries that may touch more than one range or require an index join
+SELECT (SELECT k FROM t WHERE i = 1) FROM t AS OF SYSTEM TIME with_max_staleness('1ms') WHERE k = 1
+
+# Bounded staleness function must match outer query if used in subquery.
+statement ok
+SELECT (
+  SELECT k FROM t AS OF SYSTEM TIME with_max_staleness('1ms') WHERE i = 1
+) FROM generate_series(1, 100) AS OF SYSTEM TIME with_max_staleness('1ms')
+
+# Bounded staleness function must match outer query if used in subquery.
+statement error unimplemented: cannot specify AS OF SYSTEM TIME with different timestamps
+SELECT (
+  SELECT k FROM t AS OF SYSTEM TIME with_max_staleness('2ms') WHERE i = 1
+) FROM generate_series(1, 100) AS OF SYSTEM TIME with_max_staleness('1ms')
+
+# Bounded staleness function must match outer query if used in subquery.
+statement error AS OF SYSTEM TIME must be provided on a top-level statement
+SELECT (
+  SELECT k FROM t AS OF SYSTEM TIME with_max_staleness('1ms') WHERE i = 1
+) FROM generate_series(1, 100)
+
+#
+# Tests for nearest_only argument.
+#
 
 statement error with_max_staleness: expected bool argument for nearest_only
 SELECT * FROM t AS OF SYSTEM TIME with_max_staleness('1ms', 5)
@@ -127,16 +258,20 @@ statement error with_min_timestamp: expected bool argument for nearest_only
 SELECT * FROM t AS OF SYSTEM TIME with_min_timestamp(statement_timestamp(), 5)
 
 statement ok
-SELECT * FROM t AS OF SYSTEM TIME with_max_staleness('1ms', false)
+SELECT * FROM t AS OF SYSTEM TIME with_max_staleness('1ms', false) WHERE i = 2
 
 statement ok
-SELECT * FROM t AS OF SYSTEM TIME with_min_timestamp(statement_timestamp() - '1ms', false)
+SELECT * FROM t AS OF SYSTEM TIME with_min_timestamp(statement_timestamp() - '1ms', false) WHERE i = 2
 
 statement ok
-SELECT * FROM t AS OF SYSTEM TIME with_max_staleness('1ms', true)
+SELECT * FROM t AS OF SYSTEM TIME with_max_staleness('1ms', true) WHERE i = 2
 
 statement ok
-SELECT * FROM t AS OF SYSTEM TIME with_min_timestamp(statement_timestamp() - '1ms', true)
+SELECT * FROM t AS OF SYSTEM TIME with_min_timestamp(statement_timestamp() - '1ms', true) WHERE i = 2
+
+#
+# Tests for running bounded staleness queries in an explicit transaction.
+#
 
 statement error AS OF SYSTEM TIME: only constant expressions or follower_read_timestamp are allowed
 BEGIN AS OF SYSTEM TIME with_max_staleness('1ms')
@@ -146,6 +281,10 @@ BEGIN; SELECT * FROM t AS OF SYSTEM TIME with_max_staleness('1ms')
 
 statement ok
 ROLLBACK
+
+#
+# Tests for bounded staleness with prepared statements.
+#
 
 statement error bounded staleness queries do not yet work with prepared statements
 PREPARE prep_stmt AS SELECT * FROM t AS OF SYSTEM TIME with_min_timestamp(statement_timestamp() - '10s'::interval)

--- a/pkg/sql/logictest/testdata/logic_test/zigzag_join
+++ b/pkg/sql/logictest/testdata/logic_test/zigzag_join
@@ -31,7 +31,13 @@ SELECT * FROM a WHERE a = 5 AND b = 2 AND c = 'foo'
 ----
 5  5  2  foo
 
-# Turn off zigzag joins and verify output.
+# Turn off zigzag joins and verify output. First with a hint, then with the
+# session variable.
+query III rowsort
+SELECT n,a,b FROM a@{NO_ZIGZAG_JOIN} WHERE a = 4 AND b = 1
+----
+4  4  1
+
 statement ok
 SET enable_zigzag_join = false
 

--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -484,6 +484,7 @@ func (h *harness) runSimple(tb testing.TB, query benchQuery, phase Phase) {
 		execMemo,
 		nil, /* catalog */
 		root,
+		&h.semaCtx,
 		&h.evalCtx,
 		true, /* allowAutoCommit */
 	)
@@ -537,6 +538,7 @@ func (h *harness) runPrepared(tb testing.TB, phase Phase) {
 		execMemo,
 		nil, /* catalog */
 		root,
+		&h.semaCtx,
 		&h.evalCtx,
 		true, /* allowAutoCommit */
 	)

--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -94,6 +94,10 @@ type Builder struct {
 	// containsFullIndexScan is set to true if the statement contains a secondary
 	// index scan.
 	ContainsFullIndexScan bool
+
+	// containsBoundedStalenessScan is true if the query uses bounded
+	// staleness and contains a scan.
+	containsBoundedStalenessScan bool
 }
 
 // New constructs an instance of the execution node builder using the
@@ -224,6 +228,12 @@ func (b *Builder) findBuiltWithExpr(id opt.WithID) *builtWithExpr {
 		}
 	}
 	return nil
+}
+
+// boundedStaleness returns true if this query uses bounded staleness.
+func (b *Builder) boundedStaleness() bool {
+	return b.semaCtx != nil && b.semaCtx.AsOfSystemTime != nil &&
+		b.semaCtx.AsOfSystemTime.BoundedStaleness
 }
 
 // mdVarContainer is an IndexedVarContainer implementation used by BuildScalar -

--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -38,6 +38,7 @@ type Builder struct {
 	catalog          cat.Catalog
 	e                opt.Expr
 	disableTelemetry bool
+	semaCtx          *tree.SemaContext
 	evalCtx          *tree.EvalContext
 
 	// subqueries accumulates information about subqueries that are part of scalar
@@ -111,6 +112,7 @@ func New(
 	mem *memo.Memo,
 	catalog cat.Catalog,
 	e opt.Expr,
+	semaCtx *tree.SemaContext,
 	evalCtx *tree.EvalContext,
 	allowAutoCommit bool,
 ) *Builder {
@@ -120,6 +122,7 @@ func New(
 		mem:                    mem,
 		catalog:                catalog,
 		e:                      e,
+		semaCtx:                semaCtx,
 		evalCtx:                evalCtx,
 		allowAutoCommit:        allowAutoCommit,
 		initialAllowAutoCommit: allowAutoCommit,

--- a/pkg/sql/opt/exec/execbuilder/cascades.go
+++ b/pkg/sql/opt/exec/execbuilder/cascades.go
@@ -293,7 +293,9 @@ func (cb *cascadeBuilder) planCascade(
 	}
 
 	// 5. Execbuild the optimized expression.
-	eb := New(execFactory, &o, factory.Memo(), cb.b.catalog, optimizedExpr, evalCtx, allowAutoCommit)
+	eb := New(
+		execFactory, &o, factory.Memo(), cb.b.catalog, optimizedExpr, semaCtx, evalCtx, allowAutoCommit,
+	)
 	if bufferRef != nil {
 		// Set up the With binding.
 		eb.addBuiltWithExpr(cascadeInputWithID, bufferColMap, bufferRef)

--- a/pkg/sql/opt/exec/execbuilder/format.go
+++ b/pkg/sql/opt/exec/execbuilder/format.go
@@ -41,6 +41,7 @@ func fmtInterceptor(f *memo.ExprFmtCtx, scalar opt.ScalarExpr) string {
 		f.Memo,
 		nil, /* catalog */
 		scalar,
+		nil,   /* semaCtx */
 		nil,   /* evalCtx */
 		false, /* allowAutoCommit */
 	)

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -915,7 +915,9 @@ func (b *Builder) buildApplyJoin(join memo.RelExpr) (execPlan, error) {
 			return nil, err
 		}
 
-		eb := New(ef, &o, f.Memo(), b.catalog, newRightSide, b.evalCtx, false /* allowAutoCommit */)
+		eb := New(
+			ef, &o, f.Memo(), b.catalog, newRightSide, b.semaCtx, b.evalCtx, false, /* allowAutoCommit */
+		)
 		eb.disableTelemetry = true
 		eb.withExprs = withExprs
 		plan, err := eb.Build()

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -170,6 +170,15 @@ func (b *Builder) buildRelational(e memo.RelExpr) (execPlan, error) {
 			"cannot execute %s in a read-only transaction", b.statementTag(e))
 	}
 
+	// Raise error if bounded staleness is used incorrectly.
+	if b.boundedStaleness() {
+		if _, ok := boundedStalenessAllowList[e.Op()]; !ok {
+			return execPlan{}, unimplemented.NewWithIssuef(67562,
+				"cannot use bounded staleness for %s", b.statementTag(e),
+			)
+		}
+	}
+
 	// Collect usage telemetry for relational node, if appropriate.
 	if !b.disableTelemetry {
 		if c := opt.OpTelemetryCounters[e.Op()]; c != nil {
@@ -561,6 +570,30 @@ func (b *Builder) scanParams(
 
 	softLimit := int64(math.Ceil(reqProps.LimitHint))
 	hardLimit := scan.HardLimit.RowCount()
+
+	// If this is a bounded staleness query, check that it touches at most one
+	// range.
+	if b.boundedStaleness() {
+		valid := true
+		if b.containsBoundedStalenessScan {
+			// We already planned a scan, perhaps as part of a subquery.
+			valid = false
+		} else if hardLimit != 0 {
+			// If hardLimit is not 0, from KV's perspective, this is a multi-row scan
+			// with a limit. That means that even if the limit is 1, the scan can span
+			// multiple ranges if the first range is empty.
+			valid = false
+		} else {
+			maxResults, ok := b.indexConstraintMaxResults(scan, relProps)
+			valid = ok && maxResults == 1
+		}
+		if !valid {
+			return exec.ScanParams{}, opt.ColMap{}, unimplemented.NewWithIssuef(67562,
+				"cannot use bounded staleness for queries that may touch more than one range or require an index join",
+			)
+		}
+		b.containsBoundedStalenessScan = true
+	}
 
 	parallelize := false
 	if hardLimit == 0 && softLimit == 0 {
@@ -2471,4 +2504,26 @@ func (b *Builder) statementTag(expr memo.RelExpr) string {
 	default:
 		return expr.Op().SyntaxTag()
 	}
+}
+
+// boundedStalenessAllowList contains the operators that may be used with
+// bounded staleness queries.
+var boundedStalenessAllowList = map[opt.Operator]struct{}{
+	opt.ValuesOp:           {},
+	opt.ScanOp:             {},
+	opt.PlaceholderScanOp:  {},
+	opt.SelectOp:           {},
+	opt.ProjectOp:          {},
+	opt.GroupByOp:          {},
+	opt.ScalarGroupByOp:    {},
+	opt.DistinctOnOp:       {},
+	opt.EnsureDistinctOnOp: {},
+	opt.LimitOp:            {},
+	opt.OffsetOp:           {},
+	opt.SortOp:             {},
+	opt.OrdinalityOp:       {},
+	opt.Max1RowOp:          {},
+	opt.ProjectSetOp:       {},
+	opt.WindowOp:           {},
+	opt.ExplainOp:          {},
 }

--- a/pkg/sql/opt/exec/execbuilder/statement.go
+++ b/pkg/sql/opt/exec/execbuilder/statement.go
@@ -130,7 +130,14 @@ func (b *Builder) buildExplain(explain *memo.ExplainExpr) (execPlan, error) {
 		func(ef exec.ExplainFactory) (exec.Plan, error) {
 			// Create a separate builder for the explain query.
 			explainBld := New(
-				ef, b.optimizer, b.mem, b.catalog, explain.Input, b.evalCtx, b.initialAllowAutoCommit,
+				ef,
+				b.optimizer,
+				b.mem,
+				b.catalog,
+				explain.Input,
+				b.semaCtx,
+				b.evalCtx,
+				b.initialAllowAutoCommit,
 			)
 			explainBld.disableTelemetry = true
 			return explainBld.Build()

--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -2033,7 +2033,25 @@ CREATE TABLE zigzag (
   INDEX c_idx(c)
 )
 
-# No zigzag join should be planned if enable_zigzag_join is false.
+# No zigzag join should be planned if there is a hint or enable_zigzag_join is
+# false.
+query T
+EXPLAIN SELECT a,b,c FROM zigzag@{NO_ZIGZAG_JOIN} WHERE b = 5 AND c = 6.0
+----
+distribution: local
+vectorized: true
+·
+• filter
+│ filter: c = 6.0
+│
+└── • index join
+    │ table: zigzag@primary
+    │
+    └── • scan
+          missing stats
+          table: zigzag@b_idx
+          spans: [/5 - /5]
+
 statement ok
 SET enable_zigzag_join = false
 

--- a/pkg/sql/opt/idxconstraint/index_constraints_test.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints_test.go
@@ -135,7 +135,7 @@ func TestIndexConstraints(t *testing.T) {
 				if !remainingFilter.IsTrue() {
 					execBld := execbuilder.New(
 						nil /* execFactory */, nil /* optimizer */, f.Memo(), nil, /* catalog */
-						&remainingFilter, &evalCtx, false, /* allowAutoCommit */
+						&remainingFilter, &semaCtx, &evalCtx, false, /* allowAutoCommit */
 					)
 					expr, err := execBld.BuildScalar()
 					if err != nil {

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -349,6 +349,9 @@ type ScanFlags struct {
 	// this table.
 	NoIndexJoin bool
 
+	// NoZigzagJoin disallows use of a zigzag join for scanning this table.
+	NoZigzagJoin bool
+
 	// ForceIndex forces the use of a specific index (specified in Index).
 	// ForceIndex and NoIndexJoin cannot both be set at the same time.
 	ForceIndex bool
@@ -358,7 +361,7 @@ type ScanFlags struct {
 
 // Empty returns true if there are no flags set.
 func (sf *ScanFlags) Empty() bool {
-	return !sf.NoIndexJoin && !sf.ForceIndex
+	return !sf.NoIndexJoin && !sf.NoZigzagJoin && !sf.ForceIndex
 }
 
 // JoinFlags stores restrictions on the join execution method, derived from

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -397,9 +397,12 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 			tp.Childf("limit: %s", private.HardLimit)
 		}
 		if !private.Flags.Empty() {
+			var b strings.Builder
+			b.WriteString("flags:")
 			if private.Flags.NoIndexJoin {
-				tp.Childf("flags: no-index-join")
-			} else if private.Flags.ForceIndex {
+				b.WriteString(" no-index-join")
+			}
+			if private.Flags.ForceIndex {
 				idx := md.Table(private.Table).Index(private.Flags.Index)
 				dir := ""
 				switch private.Flags.Direction {
@@ -409,8 +412,12 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 				case tree.Descending:
 					dir = ",rev"
 				}
-				tp.Childf("flags: force-index=%s%s", idx.Name(), dir)
+				b.WriteString(fmt.Sprintf(" force-index=%s%s", idx.Name(), dir))
 			}
+			if private.Flags.NoZigzagJoin {
+				b.WriteString(" no-zigzag-join")
+			}
+			tp.Child(b.String())
 		}
 		if private.Locking != nil {
 			strength := ""

--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -487,6 +487,7 @@ func (h *hasher) HashScanLimit(val ScanLimit) {
 
 func (h *hasher) HashScanFlags(val ScanFlags) {
 	h.HashBool(val.NoIndexJoin)
+	h.HashBool(val.NoZigzagJoin)
 	h.HashBool(val.ForceIndex)
 	h.HashInt(int(val.Direction))
 	h.HashUint64(uint64(val.Index))

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -510,6 +510,7 @@ func (b *Builder) buildScan(
 	private := memo.ScanPrivate{Table: tabID, Cols: scanColIDs}
 	if indexFlags != nil {
 		private.Flags.NoIndexJoin = indexFlags.NoIndexJoin
+		private.Flags.NoZigzagJoin = indexFlags.NoZigzagJoin
 		if indexFlags.Index != "" || indexFlags.IndexID != 0 {
 			idx := -1
 			for i := 0; i < tab.IndexCount(); i++ {

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -539,6 +539,10 @@ func (b *Builder) buildScan(
 	if locking.isSet() {
 		private.Locking = locking.get()
 	}
+	if b.semaCtx.AsOfSystemTime != nil && b.semaCtx.AsOfSystemTime.BoundedStaleness {
+		private.Flags.NoIndexJoin = true
+		private.Flags.NoZigzagJoin = true
+	}
 
 	b.addCheckConstraintsForTable(tabMeta)
 	b.addComputedColsForTable(tabMeta)
@@ -1182,7 +1186,6 @@ func (b *Builder) buildFromWithLateral(
 // validateAsOf ensures that any AS OF SYSTEM TIME timestamp is consistent with
 // that of the root statement.
 func (b *Builder) validateAsOf(asOfClause tree.AsOfClause) {
-	// TODO(#67558): prohibit bounded staleness in subqueries.
 	asOf, err := tree.EvalAsOfTimestamp(
 		b.ctx,
 		asOfClause,

--- a/pkg/sql/opt/partialidx/implicator_test.go
+++ b/pkg/sql/opt/partialidx/implicator_test.go
@@ -113,7 +113,7 @@ func TestImplicator(t *testing.T) {
 			} else {
 				execBld := execbuilder.New(
 					nil /* factory */, nil /* optimizer */, f.Memo(), nil, /* catalog */
-					&remainingFilters, &evalCtx, false, /* allowAutoCommit */
+					&remainingFilters, &semaCtx, &evalCtx, false, /* allowAutoCommit */
 				)
 				expr, err := execBld.BuildScalar()
 				if err != nil {

--- a/pkg/sql/opt/xform/select_funcs.go
+++ b/pkg/sql/opt/xform/select_funcs.go
@@ -913,19 +913,18 @@ func (c *CustomFuncs) canMaybeConstrainNonInvertedIndex(
 func (c *CustomFuncs) GenerateZigzagJoins(
 	grp memo.RelExpr, scanPrivate *memo.ScanPrivate, filters memo.FiltersExpr,
 ) {
-	tab := c.e.mem.Metadata().Table(scanPrivate.Table)
-
 	// Short circuit unless zigzag joins are explicitly enabled.
-	if !c.e.evalCtx.SessionData.ZigzagJoinEnabled {
+	if !c.e.evalCtx.SessionData.ZigzagJoinEnabled || scanPrivate.Flags.NoZigzagJoin {
 		return
 	}
 
 	fixedCols := memo.ExtractConstColumns(filters, c.e.evalCtx)
-
 	if fixedCols.Len() < 2 {
 		// Zigzagging requires at least 2 columns to have fixed values.
 		return
 	}
+
+	tab := c.e.mem.Metadata().Table(scanPrivate.Table)
 
 	// Zigzag joins aren't currently equipped to produce system columns, so
 	// don't generate any if some system columns are requested.
@@ -1271,7 +1270,7 @@ func (c *CustomFuncs) GenerateInvertedIndexZigzagJoins(
 	grp memo.RelExpr, scanPrivate *memo.ScanPrivate, filters memo.FiltersExpr,
 ) {
 	// Short circuit unless zigzag joins are explicitly enabled.
-	if !c.e.evalCtx.SessionData.ZigzagJoinEnabled {
+	if !c.e.evalCtx.SessionData.ZigzagJoinEnabled || scanPrivate.Flags.NoZigzagJoin {
 		return
 	}
 

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -5232,7 +5232,7 @@ CREATE TABLE zz_redundant (
 
 # Simple zigzag case - where all requested columns are in the indexes being
 # joined.
-opt
+opt expect=GenerateZigzagJoins
 SELECT q,r FROM pqr WHERE q = 1 AND r = 2
 ----
 inner-join (zigzag pqr@q pqr@r)
@@ -5245,7 +5245,7 @@ inner-join (zigzag pqr@q pqr@r)
       ├── q:2 = 1 [outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
       └── r:3 = 2 [outer=(3), constraints=(/3: [/2 - /2]; tight), fd=()-->(3)]
 
-opt
+opt expect=GenerateZigzagJoins
 SELECT q,r FROM pqr WHERE q = 1 AND r IS NULL
 ----
 inner-join (zigzag pqr@q pqr@r)
@@ -5258,7 +5258,7 @@ inner-join (zigzag pqr@q pqr@r)
       ├── q:2 = 1 [outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
       └── r:3 IS NULL [outer=(3), constraints=(/3: [/NULL - /NULL]; tight), fd=()-->(3)]
 
-memo
+memo expect=GenerateZigzagJoins
 SELECT q,r FROM pqr WHERE q = 1 AND r = 2
 ----
 memo (optimized, ~13KB, required=[presentation: q:2,r:3])
@@ -5305,7 +5305,7 @@ memo (optimized, ~13KB, required=[presentation: q:2,r:3])
  └── G17: (const 2)
 
 # Case where the fixed columns are extracted from a complicated expression.
-opt
+opt expect=GenerateZigzagJoins
 SELECT q,r FROM pqr WHERE q = 1 AND ((r < 1 AND r > 1) OR (r >= 2 AND r <= 2))
 ----
 inner-join (zigzag pqr@q pqr@r)
@@ -5320,7 +5320,7 @@ inner-join (zigzag pqr@q pqr@r)
 
 # Nested zigzag case - zigzag join needs to be wrapped in a lookup join to
 # satisfy required columns.
-opt
+opt expect=GenerateZigzagJoins
 SELECT q,r,s FROM pqr WHERE q = 1 AND r = 2
 ----
 inner-join (lookup pqr)
@@ -5339,7 +5339,7 @@ inner-join (lookup pqr)
  │         └── r:3 = 2 [outer=(3), constraints=(/3: [/2 - /2]; tight), fd=()-->(3)]
  └── filters (true)
 
-memo
+memo expect=GenerateZigzagJoins
 SELECT q,r,s FROM pqr WHERE q = 1 AND r = 2
 ----
 memo (optimized, ~15KB, required=[presentation: q:2,r:3,s:4])
@@ -5391,7 +5391,7 @@ memo (optimized, ~15KB, required=[presentation: q:2,r:3,s:4])
  └── G19: (const 2)
 
 # Zigzag with fixed columns of different types.
-opt
+opt expect=GenerateZigzagJoins
 SELECT q,s FROM pqr WHERE q = 1 AND s = 'foo'
 ----
 inner-join (zigzag pqr@q pqr@s)
@@ -5404,7 +5404,7 @@ inner-join (zigzag pqr@q pqr@s)
       ├── q:2 = 1 [outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
       └── s:4 = 'foo' [outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
 
-memo
+memo expect=GenerateZigzagJoins
 SELECT q,s FROM pqr WHERE q = 1 AND s = 'foo'
 ----
 memo (optimized, ~11KB, required=[presentation: q:2,s:4])
@@ -5445,7 +5445,7 @@ memo (optimized, ~11KB, required=[presentation: q:2,s:4])
 # Zigzag with implicit equality column in addition to primary key:
 # indexes on (r,s) and (t,s) should be chosen even though s is not being fixed
 # in the ON clause.
-opt
+opt expect=GenerateZigzagJoins
 SELECT r,t FROM pqr WHERE r = 1 AND t = 'foo'
 ----
 inner-join (zigzag pqr@rs pqr@ts)
@@ -5458,7 +5458,7 @@ inner-join (zigzag pqr@rs pqr@ts)
       ├── r:3 = 1 [outer=(3), constraints=(/3: [/1 - /1]; tight), fd=()-->(3)]
       └── t:5 = 'foo' [outer=(5), constraints=(/5: [/'foo' - /'foo']; tight), fd=()-->(5)]
 
-memo
+memo expect=GenerateZigzagJoins
 SELECT r,t FROM pqr WHERE r = 1 AND t = 'foo'
 ----
 memo (optimized, ~13KB, required=[presentation: r:3,t:5])
@@ -5505,7 +5505,7 @@ memo (optimized, ~13KB, required=[presentation: r:3,t:5])
  └── G17: (const 'foo')
 
 # Zigzag with choice between indexes for multiple equality predicates.
-opt
+opt expect=GenerateZigzagJoins
 SELECT p,q,r,s FROM pqr WHERE q = 1 AND r = 1 AND s = 'foo'
 ----
 inner-join (zigzag pqr@q pqr@s)
@@ -5519,6 +5519,25 @@ inner-join (zigzag pqr@q pqr@s)
       ├── q:2 = 1 [outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
       ├── r:3 = 1 [outer=(3), constraints=(/3: [/1 - /1]; tight), fd=()-->(3)]
       └── s:4 = 'foo' [outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
+
+# Zigzag join should not be produced when there is a NO_ZIGZAG_JOIN hint.
+opt expect-not=GenerateZigzagJoins
+SELECT q,r FROM pqr@{NO_ZIGZAG_JOIN} WHERE q = 1 AND r = 2
+----
+select
+ ├── columns: q:2!null r:3!null
+ ├── fd: ()-->(2,3)
+ ├── index-join pqr
+ │    ├── columns: q:2 r:3
+ │    ├── fd: ()-->(2)
+ │    └── scan pqr@q
+ │         ├── columns: p:1!null q:2!null
+ │         ├── constraint: /2/1: [/1 - /1]
+ │         ├── flags: no-zigzag-join
+ │         ├── key: (1)
+ │         └── fd: ()-->(2)
+ └── filters
+      └── r:3 = 2 [outer=(3), constraints=(/3: [/2 - /2]; tight), fd=()-->(3)]
 
 # Tests for zigzag joins over partial indexes.
 
@@ -6250,6 +6269,37 @@ index-join b
            │         └── ["7c\x00\x01*\x04\x00", "7c\x00\x01*\x04\x00"]
            ├── locking: for-update
            ├── volatile
+           ├── key: (1)
+           └── fd: (1)-->(9)
+
+# Zigzag join should not be produced when there is a NO_ZIGZAG_JOIN hint.
+opt expect-not=GenerateInvertedIndexZigzagJoins
+SELECT k FROM b@{NO_ZIGZAG_JOIN} WHERE j @> '{"a": "b", "c": "d"}'
+----
+project
+ ├── columns: k:1!null
+ ├── immutable
+ ├── key: (1)
+ └── inverted-filter
+      ├── columns: k:1!null
+      ├── inverted expression: /9
+      │    ├── tight: true, unique: true
+      │    ├── union spans: empty
+      │    └── INTERSECTION
+      │         ├── span expression
+      │         │    ├── tight: true, unique: true
+      │         │    └── union spans: ["7a\x00\x01\x12b\x00\x01", "7a\x00\x01\x12b\x00\x01"]
+      │         └── span expression
+      │              ├── tight: true, unique: true
+      │              └── union spans: ["7c\x00\x01\x12d\x00\x01", "7c\x00\x01\x12d\x00\x01"]
+      ├── key: (1)
+      └── scan b@j_inv_idx
+           ├── columns: k:1!null j_inverted_key:9!null
+           ├── inverted constraint: /9/1
+           │    └── spans
+           │         ├── ["7a\x00\x01\x12b\x00\x01", "7a\x00\x01\x12b\x00\x01"]
+           │         └── ["7c\x00\x01\x12d\x00\x01", "7c\x00\x01\x12d\x00\x01"]
+           ├── flags: no-zigzag-join
            ├── key: (1)
            └── fd: (1)-->(9)
 

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -790,7 +790,7 @@ func (u *sqlSymUnion) alterDefaultPrivilegesTargetObject() tree.AlterDefaultPriv
 %token <str> MULTIPOLYGON MULTIPOLYGONM MULTIPOLYGONZ MULTIPOLYGONZM
 
 %token <str> NAN NAME NAMES NATURAL NEVER NEXT NO NOCANCELQUERY NOCONTROLCHANGEFEED NOCONTROLJOB
-%token <str> NOCREATEDB NOCREATELOGIN NOCREATEROLE NOLOGIN NOMODIFYCLUSTERSETTING NO_INDEX_JOIN
+%token <str> NOCREATEDB NOCREATELOGIN NOCREATEROLE NOLOGIN NOMODIFYCLUSTERSETTING NO_INDEX_JOIN NO_ZIGZAG_JOIN
 %token <str> NONE NON_VOTERS NORMAL NOT NOTHING NOTNULL NOVIEWACTIVITY NOWAIT NULL NULLIF NULLS NUMERIC
 
 %token <str> OF OFF OFFSET OID OIDS OIDVECTOR ON ONLY OPT OPTION OPTIONS OR
@@ -9436,6 +9436,11 @@ index_flags_param:
     $$.val = &tree.IndexFlags{NoIndexJoin: true}
   }
 |
+  NO_ZIGZAG_JOIN
+  {
+    $$.val = &tree.IndexFlags{NoZigzagJoin: true}
+  }
+|
   IGNORE_FOREIGN_KEYS
   {
     /* SKIP DOC */
@@ -9499,6 +9504,7 @@ opt_index_flags:
 // Index flags:
 //   '{' FORCE_INDEX = <idxname> [, ...] '}'
 //   '{' NO_INDEX_JOIN [, ...] '}'
+//   '{' NO_ZIGZAG_JOIN [, ...] '}'
 //   '{' IGNORE_FOREIGN_KEYS [, ...] '}'
 //
 // Join types:
@@ -12939,6 +12945,7 @@ unreserved_keyword:
 | NO
 | NORMAL
 | NO_INDEX_JOIN
+| NO_ZIGZAG_JOIN
 | NOCREATEDB
 | NOCREATELOGIN
 | NOCANCELQUERY

--- a/pkg/sql/parser/testdata/select_clauses
+++ b/pkg/sql/parser/testdata/select_clauses
@@ -319,6 +319,14 @@ SELECT _ FROM t@{NO_INDEX_JOIN} -- literals removed
 SELECT 'a' FROM _@{NO_INDEX_JOIN} -- identifiers removed
 
 parse
+SELECT 'a' FROM t@{NO_ZIGZAG_JOIN}
+----
+SELECT 'a' FROM t@{NO_ZIGZAG_JOIN}
+SELECT ('a') FROM t@{NO_ZIGZAG_JOIN} -- fully parenthesized
+SELECT _ FROM t@{NO_ZIGZAG_JOIN} -- literals removed
+SELECT 'a' FROM _@{NO_ZIGZAG_JOIN} -- identifiers removed
+
+parse
 SELECT 'a' FROM t@{IGNORE_FOREIGN_KEYS}
 ----
 SELECT 'a' FROM t@{IGNORE_FOREIGN_KEYS}
@@ -335,12 +343,12 @@ SELECT _ FROM t@{FORCE_INDEX=idx,ASC} -- literals removed
 SELECT 'a' FROM _@{FORCE_INDEX=_,ASC} -- identifiers removed
 
 parse
-SELECT 'a' FROM t@{FORCE_INDEX=idx,DESC,IGNORE_FOREIGN_KEYS}
+SELECT 'a' FROM t@{FORCE_INDEX=idx,DESC,IGNORE_FOREIGN_KEYS,NO_ZIGZAG_JOIN}
 ----
-SELECT 'a' FROM t@{FORCE_INDEX=idx,DESC,IGNORE_FOREIGN_KEYS}
-SELECT ('a') FROM t@{FORCE_INDEX=idx,DESC,IGNORE_FOREIGN_KEYS} -- fully parenthesized
-SELECT _ FROM t@{FORCE_INDEX=idx,DESC,IGNORE_FOREIGN_KEYS} -- literals removed
-SELECT 'a' FROM _@{FORCE_INDEX=_,DESC,IGNORE_FOREIGN_KEYS} -- identifiers removed
+SELECT 'a' FROM t@{FORCE_INDEX=idx,DESC,NO_ZIGZAG_JOIN,IGNORE_FOREIGN_KEYS} -- normalized!
+SELECT ('a') FROM t@{FORCE_INDEX=idx,DESC,NO_ZIGZAG_JOIN,IGNORE_FOREIGN_KEYS} -- fully parenthesized
+SELECT _ FROM t@{FORCE_INDEX=idx,DESC,NO_ZIGZAG_JOIN,IGNORE_FOREIGN_KEYS} -- literals removed
+SELECT 'a' FROM _@{FORCE_INDEX=_,DESC,NO_ZIGZAG_JOIN,IGNORE_FOREIGN_KEYS} -- identifiers removed
 
 error
 SELECT a FROM foo@{FORCE_INDEX}

--- a/pkg/sql/sem/tree/eval_test.go
+++ b/pkg/sql/sem/tree/eval_test.go
@@ -104,7 +104,7 @@ func optBuildScalar(evalCtx *tree.EvalContext, e tree.Expr) (tree.TypedExpr, err
 
 	bld := execbuilder.New(
 		nil /* factory */, &o, o.Memo(), nil /* catalog */, o.Memo().RootExpr(),
-		evalCtx, false, /* allowAutoCommit */
+		&semaCtx, evalCtx, false, /* allowAutoCommit */
 	)
 	expr, err := bld.BuildScalar()
 	if err != nil {


### PR DESCRIPTION
**opt,sql: support hint to disallow zigzag join**

Release note (sql change): Added support for a new index hint,
`NO_ZIGZAG_JOIN`, which will prevent the optimizer from planning a
zigzag join for the specified table. The hint can be used in the
same way as other existing index hints. For example,
`SELECT * FROM table_name@{NO_ZIGZAG_JOIN};`.

**sql,opt: pass tree.SemaContext to the execbuilder**

This commit updates the execbuilder to include the `tree.SemaContext`
as one of its arguments. This will allow it to use the `AsOfSystemTime`
information in a following commit.

Release note: None

**opt: add execbuilder checks for bounded staleness queries**

This commit adds checks in the execbuilder to ensure that bounded staleness
can only be used with queries that touch at most one row. It also applies
hints for such queries in the optbuilder to ensure that an invalid plan is
not produced. In particular, the hints ensure that no plans with an index
join or zigzag join will be produced.

Fixes #67558

Release note: None