### PR TITLE
CODEOWNERS: own catalog package to obs-inf-prs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -189,6 +189,7 @@
 /pkg/streaming/              @cockroachdb/bulk-prs
 /pkg/testutils/              @cockroachdb/test-eng
 /pkg/ts/                     @cockroachdb/kv
+/pkg/ts/catalog/             @cockroachdb/obs-inf-prs
 /pkg/util/                   @cockroachdb/unowned
 /pkg/util/log                @cockroachdb/server-prs
 /pkg/util/metric             @cockroachdb/obs-inf-prs


### PR DESCRIPTION
Noticed in #67866.

Release note: None
