### PR TITLE
CODEOWNERS: prevent ping to dev-inf on modification

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,6 +18,7 @@
 # [3]: pkg/internal/codeowners
 
 /.github/                    @cockroachdb/dev-inf
+/.github/CODEOWNERS          @cockroachdb/unowned
 
 /build/                      @cockroachdb/dev-inf
 


### PR DESCRIPTION
dev-inf doesn't need to be pinged on each PR against the CODEOWNERS
file.

Release note: None
