### PR TITLE
clisqlshell: remove an implicit dependency on os.Stdout

### DIFF
--- a/pkg/cli/clisqlshell/sql.go
+++ b/pkg/cli/clisqlshell/sql.go
@@ -690,7 +690,7 @@ func (c *cliState) runSyscmd(line string, nextState, errState cliStateEnum) cliS
 		return errState
 	}
 
-	fmt.Print(cmdOut)
+	fmt.Fprint(c.iCtx.stdout, cmdOut)
 	return nextState
 }
 


### PR DESCRIPTION
This is currently somewhat undertested but that's because the current implementation of `\|` and `\!` are broken anyway. We'll need to rewrite them entirely.