### PR TITLE
sql: enhance diagnostics to determine root cause missing typeID

### DIFF
--- a/pkg/sql/catalog/descs/type.go
+++ b/pkg/sql/catalog/descs/type.go
@@ -12,6 +12,7 @@ package descs
 
 import (
 	"context"
+	"runtime/debug"
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
@@ -20,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
 
@@ -107,6 +109,8 @@ func (tc *Collection) getTypeByID(
 	desc, err := tc.getDescriptorByID(ctx, txn, typeID, flags.CommonLookupFlags)
 	if err != nil {
 		if errors.Is(err, catalog.ErrDescriptorNotFound) {
+			log.Infof(ctx, "type ID %d does not exist for txn %s, dumping stack %s",
+				typeID, txn, string(debug.Stack()))
 			return nil, pgerror.Newf(
 				pgcode.UndefinedObject, "type with ID %d does not exist", typeID)
 		}


### PR DESCRIPTION
Previously, trying to diagnose issue #63527 which has been
hit at least once a month we haven't been able to determine
where the missing typeID is derived from. Based on the logs
we do not see anything other than a table or database object
using the problematic ID (after the error). To address this
and improve diagnostics, this patch adds additional logic to
dump out the stack and TXN information inside getTypeID
when the typeID can't be found.

Release note: None