### PR TITLE
importccl: pipeline EXPORT string encoding and csv writing

### DIFF
--- a/pkg/ccl/importccl/exportcsv_test.go
+++ b/pkg/ccl/importccl/exportcsv_test.go
@@ -424,11 +424,11 @@ func TestExportFeatureFlag(t *testing.T) {
 	sqlDB.Exec(t, `SET CLUSTER SETTING feature.export.enabled = FALSE`)
 	sqlDB.Exec(t, `CREATE TABLE feature_flags (a INT PRIMARY KEY)`)
 	sqlDB.ExpectErr(t, `feature EXPORT was disabled by the database administrator`,
-		`EXPORT INTO CSV 'nodelocal://0/%s/' FROM TABLE feature_flags`)
+		`EXPORT INTO CSV 'nodelocal://0/abc/' FROM TABLE feature_flags`)
 
 	// Feature flag is on — test that EXPORT does not error.
 	sqlDB.Exec(t, `SET CLUSTER SETTING feature.export.enabled = TRUE`)
-	sqlDB.Exec(t, `EXPORT INTO CSV 'nodelocal://0/%s/' FROM TABLE feature_flags`)
+	sqlDB.Exec(t, `EXPORT INTO CSV 'nodelocal://0/abc/' FROM TABLE feature_flags`)
 }
 
 func TestExportPrivileges(t *testing.T) {


### PR DESCRIPTION
This adds some parallelism to the EXPORT processor, namely splitting it into two
parts, the first which reads and decodes incoming rows and formats them into the
strings that will be placed the CSV cells, and then a second phase that receives
batches of those strings from the first half and writes them to CSVs that it then
uploads to cloud storage. This hopefully improves performance of EXPORTs of data
that is expensive to encode as strings, such as JSON, which can then be expensive
to write as (compressed) CSV. A subsequent change could stream or parallelize the
actual upload to external storage relatively easily in the second phase with this
split.

Release note (performance improvement): EXPORT encodes exported rows in parallel with writing them to CSVs.