### PR TITLE
sql: require ADMIN to alter another admin

### DIFF
--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -1,7 +1,7 @@
 exp,benchmark
-18,AlterRole/alter_role_with_1_option
-19,AlterRole/alter_role_with_2_options
-25,AlterRole/alter_role_with_3_options
+19,AlterRole/alter_role_with_1_option
+20,AlterRole/alter_role_with_2_options
+26,AlterRole/alter_role_with_3_options
 17,AlterTableAddCheckConstraint/alter_table_add_1_check_constraint
 17,AlterTableAddCheckConstraint/alter_table_add_2_check_constraints
 17,AlterTableAddCheckConstraint/alter_table_add_3_check_constraints

--- a/pkg/sql/logictest/testdata/logic_test/alter_role_set
+++ b/pkg/sql/logictest/testdata/logic_test/alter_role_set
@@ -156,6 +156,10 @@ ALTER ROLE test_set_role RESET application_name
 statement error only users with the admin role are allowed to ALTER ROLE ALL
 ALTER ROLE ALL IN DATABASE test_set_db RESET application_name
 
+# Verify that testuser can't edit an ADMIN, even after getting CREATEROLE.
+statement error only users with the admin role are allowed to ALTER ROLE admin
+ALTER ROLE other_admin SET application_name = 'abc'
+
 user root
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/role
+++ b/pkg/sql/logictest/testdata/logic_test/role
@@ -1363,3 +1363,19 @@ CREATE ROLE otherrole4 NOCREATELOGIN
 
 statement error user testuser does not have CREATELOGIN privilege
 CREATE ROLE otherrole4 LOGIN
+
+user root
+
+# Verify that root is allowed to edit some other role that has ADMIN.
+statement ok
+CREATE ROLE other_admin;
+GRANT admin TO other_admin;
+ALTER ROLE other_admin CREATEDB
+
+user testuser
+
+# Verify that testuser is not allowed to edit some other role that has ADMIN.
+# The error message is important for this test -- we want to make sure it fails
+# because of a missing ADMIN power, not because of a missing CREATEROLE option.
+statement error only users with the admin role are allowed to ALTER ROLE admin
+ALTER ROLE other_admin NOCREATEDB


### PR DESCRIPTION
Only the last commit is for this PR.

Release note (sql change): Running ALTER ROLE on any role that is a
member of "admin" now requires the "admin" role. Previously, any user
with the CREATEROLE option could ALTER an "admin".

