### PR TITLE
streamingccl: fix double close in test feed source

### DIFF
--- a/pkg/ccl/streamingccl/streamclient/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamclient/BUILD.bazel
@@ -53,7 +53,6 @@ go_test(
         "//pkg/server",
         "//pkg/sql/catalog/catalogkv",
         "//pkg/testutils/serverutils",
-        "//pkg/testutils/skip",
         "//pkg/testutils/testcluster",
         "//pkg/util/hlc",
         "//pkg/util/leaktest",

--- a/pkg/ccl/streamingccl/streamclient/cockroach_sinkless_replication_client_test.go
+++ b/pkg/ccl/streamingccl/streamclient/cockroach_sinkless_replication_client_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/streamingccl/streamingtest"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/streamingccl/streamproducer" // Ensure we can start replication stream.
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/stretchr/testify/require"
@@ -27,9 +26,10 @@ import (
 // channelFeedSource wraps the eventsCh returned from a client. It expects that
 // no errors are returned from the client.
 type channelFeedSource struct {
-	t       *testing.T
-	eventCh chan streamingccl.Event
-	errCh   chan error
+	t               *testing.T
+	cancelIngestion context.CancelFunc
+	eventCh         chan streamingccl.Event
+	errCh           chan error
 }
 
 var _ streamingtest.FeedSource = (*channelFeedSource)(nil)
@@ -50,14 +50,11 @@ func (f *channelFeedSource) Next() (streamingccl.Event, bool) {
 
 // Close implements the streamingtest.FeedSource interface.
 func (f *channelFeedSource) Close() {
-	close(f.eventCh)
+	f.cancelIngestion()
 }
 
 func TestSinklessReplicationClient(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-
-	// channel usage error in this test
-	skip.WithIssue(t, 68168)
 
 	defer log.Scope(t).Close(t)
 	h, cleanup := streamingtest.NewReplicationHelper(t)
@@ -99,7 +96,7 @@ INSERT INTO d.t2 VALUES (2);
 		clientCtx, cancelIngestion := context.WithCancel(ctx)
 		eventCh, errCh, err := client.ConsumePartition(clientCtx, pa, startTime)
 		require.NoError(t, err)
-		feedSource := &channelFeedSource{eventCh: eventCh, errCh: errCh}
+		feedSource := &channelFeedSource{cancelIngestion: cancelIngestion, eventCh: eventCh, errCh: errCh}
 		feed := streamingtest.MakeReplicationFeed(t, feedSource)
 
 		// We should observe 2 versions of this key: one with ("привет", "world"), and a later

--- a/pkg/ccl/streamingccl/streamingtest/replication_helpers.go
+++ b/pkg/ccl/streamingccl/streamingtest/replication_helpers.go
@@ -98,7 +98,7 @@ func (rf *ReplicationFeed) Close() {
 }
 
 func (rf *ReplicationFeed) consumeUntil(pred FeedPredicate) error {
-	const maxWait = 10 * time.Second
+	const maxWait = 20 * time.Second
 	doneCh := make(chan struct{})
 	mu := struct {
 		syncutil.Mutex


### PR DESCRIPTION
Previously, the close implementation of channelFeedSource
closed the `eventCh` as a means of shutting down the client.
This seems wrong since the client is the "owner" of this
channel and should be the only one responsible for closing
it. In cases where the method `consumeUntil` hit an error
(max wait timeout in our case) we would close the eventCh
as part of calling channelFeedSource's Close(), and we would
attempt a double close in the sinkless client itself.

This change switches to cancelling the sinkless client's
context to indicate to the client that it should shutdown.

I was not able to reproduce this error (5000 stress runs),
but I bumped the timeout from 10 seconds to 20 seconds
based on stack traces in the failed builds.

Fixes: #68168
Fixes: #67592

Release note: None