### PR TITLE
sql: clarify multi-column inverted index stats collection

### DIFF
--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -350,10 +350,9 @@ func createStatsDefaultColumns(
 		}
 		colStats = append(colStats, colStat)
 
-		// Generate histograms for inverted indexes. The above
-		// colStat append is still needed for a basic sketch of
-		// the column. The following colStat is needed for the
-		// sampling and sketch of the inverted index keys of
+		// Generate histograms for inverted indexes. The above colStat append is
+		// still needed for a basic sketch of the column. The following colStat
+		// is needed for the sampling and sketch of the inverted index keys of
 		// the column.
 		if isInverted {
 			colStat.Inverted = true

--- a/pkg/sql/distsql_plan_stats.go
+++ b/pkg/sql/distsql_plan_stats.go
@@ -126,22 +126,29 @@ func (dsp *DistSQLPlanner) createStatsPlan(
 			sampledColumnIDs[streamColIdx] = colID
 		}
 		if s.inverted {
-			// Find the first inverted index on the first column. Although there may be
-			// more, we don't currently have a way of using more than one or deciding which
-			// one is better.
-			// TODO(mjibson): allow multiple inverted indexes on the same column (i.e.,
-			// with different configurations). See #50655.
-			col := s.columns[0]
-			for _, index := range desc.PublicNonPrimaryIndexes() {
-				if index.GetType() == descpb.IndexDescriptor_INVERTED && index.InvertedColumnID() == col {
-					spec.Index = index.IndexDesc()
-					break
+			// Find the first inverted index on the first column for collecting
+			// histograms. Although there may be more than one index, we don't
+			// currently have a way of using more than one or deciding which one
+			// is better.
+			//
+			// We do not generate multi-column stats with histograms, so there
+			// is no need to find an index for multi-column stats here.
+			//
+			// TODO(mjibson): allow multiple inverted indexes on the same column
+			// (i.e., with different configurations). See #50655.
+			if len(s.columns) == 1 {
+				col := s.columns[0]
+				for _, index := range desc.PublicNonPrimaryIndexes() {
+					if index.GetType() == descpb.IndexDescriptor_INVERTED && index.InvertedColumnID() == col {
+						spec.Index = index.IndexDesc()
+						break
+					}
 				}
 			}
-			// Even if spec.Index is nil because there isn't an inverted index on
-			// the requested stats column, we can still proceed. We aren't generating
-			// histograms in that case so we don't need an index descriptor to generate the
-			// inverted index entries.
+			// Even if spec.Index is nil because there isn't an inverted index
+			// on the requested stats column, we can still proceed. We aren't
+			// generating histograms in that case so we don't need an index
+			// descriptor to generate the inverted index entries.
 			invSketchSpecs = append(invSketchSpecs, spec)
 		} else {
 			sketchSpecs = append(sketchSpecs, spec)

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -1014,6 +1014,31 @@ column_names  has_histogram
 {j}           true
 {s}           true
 
+statement ok
+SET CLUSTER SETTING sql.stats.multi_column_collection.enabled = true
+
+statement ok
+CREATE STATISTICS s FROM multi_col;
+
+# Do not create multi-column stats with an invertable column.
+query TB colnames
+SELECT
+  column_names,
+  histogram_id IS NOT NULL AS has_histogram
+FROM
+  [SHOW STATISTICS FOR TABLE multi_col]
+ORDER BY
+  column_names::STRING, created
+----
+column_names  has_histogram
+{id}          true
+{j}           true
+{s,j}         false
+{s}           true
+
+statement ok
+SET CLUSTER SETTING sql.stats.multi_column_collection.enabled = false
+
 # Regression test for #56356. Histograms on all-null columns should not cause
 # an error.
 statement ok


### PR DESCRIPTION
This commit clarifies the behavior of multi-column stats collection for
multi-column inverted indexes with comments and tests.

Release note: None