### PR TITLE
colmem: fix recent accounting leak in the cfetcher

### DIFF
--- a/pkg/sql/colexec/colexecutils/utils.go
+++ b/pkg/sql/colexec/colexecutils/utils.go
@@ -175,11 +175,6 @@ func (b *AppendOnlyBufferedBatch) ReplaceCol(coldata.Vec, int) {
 	colexecerror.InternalError(errors.AssertionFailedf("ReplaceCol is prohibited on AppendOnlyBufferedBatch"))
 }
 
-// BytesLikeTotalSize implements the coldata.Batch interface.
-func (b *AppendOnlyBufferedBatch) BytesLikeTotalSize() int64 {
-	return b.batch.BytesLikeTotalSize()
-}
-
 // Reset implements the coldata.Batch interface.
 func (b *AppendOnlyBufferedBatch) Reset([]*types.T, int, coldata.ColumnFactory) {
 	colexecerror.InternalError(errors.AssertionFailedf("Reset is prohibited on AppendOnlyBufferedBatch"))

--- a/pkg/sql/colmem/BUILD.bazel
+++ b/pkg/sql/colmem/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//pkg/sql/memsize",
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
+        "//pkg/util",
         "//pkg/util/mon",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
@@ -28,6 +29,7 @@ go_test(
         "//pkg/col/coldata",
         "//pkg/col/coldataext",
         "//pkg/settings/cluster",
+        "//pkg/sql/colconv",
         "//pkg/sql/colexec/colexecutils",
         "//pkg/sql/colexecerror",
         "//pkg/sql/execinfra",
@@ -38,6 +40,7 @@ go_test(
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/randutil",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],
 )


### PR DESCRIPTION
We have recently refactored the memory accounting in the cFetcher to be
on a row granularity. During that refactor we introduced a "leak":
namely, for decimals and datum-backed types we forgot to shrink the
account by the old values' size when a batch is reused and is simply
reset. This is now fixed by introducing a helper that is responsible for
carefully managing the allocations, accounting, and resets.

Fixes: #68175.
Fixes: #68170.
Fixes: #68151.
Fixes: #68165.
Fixes: #68147.
Fixes: #68146.

Release note: None