### PR TITLE
ci: install bazelisk in teamcity agents

### DIFF
--- a/build/packer/teamcity-agent.sh
+++ b/build/packer/teamcity-agent.sh
@@ -63,6 +63,14 @@ for f in `ls /usr/local/go/bin`; do
     ln -s /usr/local/go/bin/$f /usr/bin
 done
 
+# Install Bazelisk.
+curl -fsSL https://github.com/bazelbuild/bazelisk/releases/download/v1.10.1/bazelisk-linux-amd64 > /tmp/bazelisk
+sha256sum -c - <<EOF
+4cb534c52cdd47a6223d4596d530e7c9c785438ab3b0a49ff347e991c210b2cd /tmp/bazelisk
+EOF
+chmod +x /tmp/bazelisk
+mv /tmp/bazelisk /usr/bin/bazel
+
 # Installing gnome-keyring prevents the error described in
 # https://github.com/moby/moby/issues/34048
 


### PR DESCRIPTION
We'll want this so we can run the acceptance tests (which don't run in
a Docker image, but still need Bazel to run).

Release note: None