### PR TITLE
backfill: reduce checkpoint interval

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -81,6 +81,14 @@ var indexBackfillBatchSize = settings.RegisterIntSetting(
 	settings.NonNegativeInt, /* validateFn */
 )
 
+// indexBackfillCheckpointInterval is the duration between backfill detail updates.
+var indexBackfillCheckpointInterval = settings.RegisterDurationSetting(
+	"bulkio.index_backfill.checkpoint_interval",
+	"the amount of time between index backfill checkpoint updates",
+	30*time.Second,
+	settings.NonNegativeDuration,
+)
+
 // columnBackfillBatchSize is the maximum number of rows we update at once when
 // adding or removing columns.
 var columnBackfillBatchSize = settings.RegisterIntSetting(
@@ -1217,7 +1225,7 @@ func (sc *SchemaChanger) distIndexBackfill(
 
 	// Setup periodic job details update.
 	stopJobDetailsUpdate := make(chan struct{})
-	detailsDuration := 10 * time.Second
+	detailsDuration := indexBackfillCheckpointInterval.Get(&sc.settings.SV)
 	g.GoCtx(func(ctx context.Context) error {
 		tick := time.NewTicker(detailsDuration)
 		defer tick.Stop()


### PR DESCRIPTION
Informs https://github.com/cockroachdb/cockroach/issues/67523.

This commit introduces a cluster setting as well as reduces the default
checkpoint progress interval. Backfill progress is checkpointed by
writing the set of spans that are left TODO. However, this set of spans
could get quite large so each update to this job record can quickly fill
a range on backfills of large tables.

This change is a start to improving the situation by introducing a knob
that can be tuned back for large backfills. Ideally, the schema change
would rate limit itself based on the size of the progress updates.

Release note (ops change): Introduce a cluster setting,
bulkio.index_backfill.checkpoint_interval to control the rate at which
backfills checkpoint their progress. Useful when needed to be dialed
back on backfills of large tables.