### PR TITLE
sql: fix show_create_all_tables in explicit transactions

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/show_create_all_tables_builtin
+++ b/pkg/sql/logictest/testdata/logic_test/show_create_all_tables_builtin
@@ -369,3 +369,45 @@ query T
 SELECT crdb_internal.show_create_all_tables('test_sequence')
 ----
 CREATE SEQUENCE public.s1 MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 123 START 1;
+
+# Ensure that the builtin can be run in unused and used transactions.
+
+statement ok
+USE test_schema;
+
+query T
+BEGIN;
+SELECT crdb_internal.show_create_all_tables('test_schema');
+COMMIT;
+----
+CREATE TABLE sc1.t (
+    x INT8 NULL,
+    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
+    FAMILY "primary" (x, rowid)
+);
+CREATE TABLE sc2.t (
+    x INT8 NULL,
+    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
+    FAMILY "primary" (x, rowid)
+);
+
+query T
+BEGIN;
+SELECT * FROM sc1.t;
+SELECT crdb_internal.show_create_all_tables('test_schema');
+COMMIT;
+----
+CREATE TABLE sc1.t (
+    x INT8 NULL,
+    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
+    FAMILY "primary" (x, rowid)
+);
+CREATE TABLE sc2.t (
+    x INT8 NULL,
+    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
+    FAMILY "primary" (x, rowid)
+);


### PR DESCRIPTION
Related to #68216.

Previously, running `crdb_internal.show_create_all_tables` in an existing explicit transaction would crash for the reasons discussed in #68216. This should not have crashed but it should have thrown an error. This revealed that the internal executor in the `showCreateAllTablesGenerator` was a little confused. It was issuing AS OF SYSTEM TIME queries, but also supplying its parent transaction. So it wanted to execute in the context of its parent transaction, but also to run at a very specific timestamp - contradictory desires.

This commit fixes this by removing the AS OF SYSTEM TIME clauses from the internal executor queries. This has the effect of making this builtin transactional.

Example crash:
```
➜ ./cockroach demo --insecure

> BEGIN;

OPEN> SELECT count(*) FROM rides;
  count
---------
    500

OPEN> SELECT crdb_internal.show_create_all_tables('movr');
ERROR: internal error: crdb_internal.show_create_all_tables: unexpected batch read timestamp: 1627529007.202325000,0. Expected refreshed timestamp: 1627528898.793460000,0. ba: Scan [/Table/3/1,/Table/3/2), [txn: 3565aed1]. txn: "sql txn" meta={id=3565aed1 pri=0.05136598 epo=0 ts=1627529007.202325000,0 min=1627528898.793460000,0 seq=0} lock=false stat=PENDING rts=1627529007.202325000,0 wto=false gul=1627529007.202325000,0
SQLSTATE: XX000
DETAIL: stack trace:
github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher.go:160: SendLocked()
github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner.go:285: SendLocked()
github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord/txn_interceptor_seq_num_allocator.go:105: SendLocked()
github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord/txn_interceptor_heartbeater.go:240: SendLocked()
github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord/txn_coord_sender.go:513: Send()
github.com/cockroachdb/cockroach/pkg/kv/db.go:831: sendUsingSender()
github.com/cockroachdb/cockroach/pkg/kv/txn.go:982: Send()
github.com/cockroachdb/cockroach/pkg/kv/db.go:742: sendAndFill()
github.com/cockroachdb/cockroach/pkg/kv/txn.go:635: Run()
github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv/catalogkv.go:281: getAllDescriptorsAndMaybeNamespaceEntriesUnvalidated()
github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv/catalogkv.go:343: GetAllDescriptors()
github.com/cockroachdb/cockroach/pkg/sql/catalog/descs/kv_descriptors.go:265: getAllDescriptors()
github.com/cockroachdb/cockroach/pkg/sql/catalog/descs/collection.go:270: GetAllDescriptors()
github.com/cockroachdb/cockroach/pkg/sql/information_schema.go:2335: forEachTableDescWithTableLookupInternal()
github.com/cockroachdb/cockroach/pkg/sql/information_schema.go:2289: forEachTableDescWithTableLookup()
github.com/cockroachdb/cockroach/pkg/sql/pg_catalog.go:964: func1()
github.com/cockroachdb/cockroach/pkg/sql/virtual_schema.go:533: 1()
github.com/cockroachdb/cockroach/pkg/sql/virtual_table.go:120: func3()
github.com/cockroachdb/cockroach/pkg/util/stop/stopper.go:442: func2()
runtime/asm_amd64.s:1371: goexit()

HINT: You have encountered an unexpected error.

Please check the public issue tracker to check whether this problem is
already tracked. If you cannot find it there, please report the error
with details by creating a new issue.

If you would rather not post publicly, please contact us directly
using the support form.

We appreciate your feedback.
```