### PR TITLE
sql: move AsOfSystemTime to EvalContext

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -2347,6 +2347,7 @@ func (ex *connExecutor) resetEvalCtx(evalCtx *extendedEvalContext, txn *kv.Txn, 
 	evalCtx.TxnImplicit = ex.implicitTxn()
 	evalCtx.StmtTimestamp = stmtTS
 	evalCtx.TxnTimestamp = ex.state.sqlTimestamp
+	evalCtx.AsOfSystemTime = nil
 	evalCtx.Placeholders = nil
 	evalCtx.Annotations = nil
 	evalCtx.IVarContainer = nil
@@ -2402,7 +2403,6 @@ func (ex *connExecutor) resetPlanner(
 	p.semaCtx = tree.MakeSemaContext()
 	p.semaCtx.SearchPath = ex.sessionData.SearchPath
 	p.semaCtx.IntervalStyleEnabled = ex.sessionData.IntervalStyleEnabled
-	p.semaCtx.AsOfSystemTime = nil
 	p.semaCtx.Annotations = nil
 	p.semaCtx.TypeResolver = p
 	p.semaCtx.TableNameResolver = p

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -586,7 +586,7 @@ func (ex *connExecutor) execStmtInOpenState(
 			return makeErrEvent(err)
 		}
 		if asOf != nil {
-			p.semaCtx.AsOfSystemTime = asOf
+			p.extendedEvalCtx.AsOfSystemTime = asOf
 			p.extendedEvalCtx.SetTxnTimestamp(asOf.Timestamp.GoTime())
 			ex.state.setHistoricalTimestamp(ctx, asOf.Timestamp)
 		}
@@ -614,7 +614,7 @@ func (ex *connExecutor) execStmtInOpenState(
 				err = errors.WithHint(err, "try SET TRANSACTION AS OF SYSTEM TIME")
 				return makeErrEvent(err)
 			}
-			p.semaCtx.AsOfSystemTime = asOf
+			p.extendedEvalCtx.AsOfSystemTime = asOf
 		}
 	}
 

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -268,7 +268,7 @@ func (ex *connExecutor) populatePrepared(
 		return 0, err
 	}
 	if asOf != nil {
-		p.semaCtx.AsOfSystemTime = asOf
+		p.extendedEvalCtx.AsOfSystemTime = asOf
 		if asOf.BoundedStaleness {
 			return 0, unimplemented.NewWithIssuef(
 				67562,

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -512,7 +512,7 @@ func (r *createStatsResumer) Resume(ctx context.Context, execCtx interface{}) er
 		evalCtx.Txn = txn
 
 		if details.AsOf != nil {
-			p.SemaCtx().AsOfSystemTime = &tree.AsOfSystemTime{Timestamp: *details.AsOf}
+			p.ExtendedEvalContext().AsOfSystemTime = &tree.AsOfSystemTime{Timestamp: *details.AsOf}
 			p.ExtendedEvalContext().SetTxnTimestamp(details.AsOf.GoTime())
 			txn.SetFixedTimestamp(ctx, *details.AsOf)
 		}

--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -484,7 +484,6 @@ func (h *harness) runSimple(tb testing.TB, query benchQuery, phase Phase) {
 		execMemo,
 		nil, /* catalog */
 		root,
-		&h.semaCtx,
 		&h.evalCtx,
 		true, /* allowAutoCommit */
 	)
@@ -538,7 +537,6 @@ func (h *harness) runPrepared(tb testing.TB, phase Phase) {
 		execMemo,
 		nil, /* catalog */
 		root,
-		&h.semaCtx,
 		&h.evalCtx,
 		true, /* allowAutoCommit */
 	)

--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -38,7 +38,6 @@ type Builder struct {
 	catalog          cat.Catalog
 	e                opt.Expr
 	disableTelemetry bool
-	semaCtx          *tree.SemaContext
 	evalCtx          *tree.EvalContext
 
 	// subqueries accumulates information about subqueries that are part of scalar
@@ -116,7 +115,6 @@ func New(
 	mem *memo.Memo,
 	catalog cat.Catalog,
 	e opt.Expr,
-	semaCtx *tree.SemaContext,
 	evalCtx *tree.EvalContext,
 	allowAutoCommit bool,
 ) *Builder {
@@ -126,7 +124,6 @@ func New(
 		mem:                    mem,
 		catalog:                catalog,
 		e:                      e,
-		semaCtx:                semaCtx,
 		evalCtx:                evalCtx,
 		allowAutoCommit:        allowAutoCommit,
 		initialAllowAutoCommit: allowAutoCommit,

--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -232,8 +232,8 @@ func (b *Builder) findBuiltWithExpr(id opt.WithID) *builtWithExpr {
 
 // boundedStaleness returns true if this query uses bounded staleness.
 func (b *Builder) boundedStaleness() bool {
-	return b.semaCtx != nil && b.semaCtx.AsOfSystemTime != nil &&
-		b.semaCtx.AsOfSystemTime.BoundedStaleness
+	return b.evalCtx != nil && b.evalCtx.AsOfSystemTime != nil &&
+		b.evalCtx.AsOfSystemTime.BoundedStaleness
 }
 
 // mdVarContainer is an IndexedVarContainer implementation used by BuildScalar -

--- a/pkg/sql/opt/exec/execbuilder/cascades.go
+++ b/pkg/sql/opt/exec/execbuilder/cascades.go
@@ -293,9 +293,7 @@ func (cb *cascadeBuilder) planCascade(
 	}
 
 	// 5. Execbuild the optimized expression.
-	eb := New(
-		execFactory, &o, factory.Memo(), cb.b.catalog, optimizedExpr, semaCtx, evalCtx, allowAutoCommit,
-	)
+	eb := New(execFactory, &o, factory.Memo(), cb.b.catalog, optimizedExpr, evalCtx, allowAutoCommit)
 	if bufferRef != nil {
 		// Set up the With binding.
 		eb.addBuiltWithExpr(cascadeInputWithID, bufferColMap, bufferRef)

--- a/pkg/sql/opt/exec/execbuilder/format.go
+++ b/pkg/sql/opt/exec/execbuilder/format.go
@@ -41,7 +41,6 @@ func fmtInterceptor(f *memo.ExprFmtCtx, scalar opt.ScalarExpr) string {
 		f.Memo,
 		nil, /* catalog */
 		scalar,
-		nil,   /* semaCtx */
 		nil,   /* evalCtx */
 		false, /* allowAutoCommit */
 	)

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -948,9 +948,7 @@ func (b *Builder) buildApplyJoin(join memo.RelExpr) (execPlan, error) {
 			return nil, err
 		}
 
-		eb := New(
-			ef, &o, f.Memo(), b.catalog, newRightSide, b.semaCtx, b.evalCtx, false, /* allowAutoCommit */
-		)
+		eb := New(ef, &o, f.Memo(), b.catalog, newRightSide, b.evalCtx, false /* allowAutoCommit */)
 		eb.disableTelemetry = true
 		eb.withExprs = withExprs
 		plan, err := eb.Build()

--- a/pkg/sql/opt/exec/execbuilder/statement.go
+++ b/pkg/sql/opt/exec/execbuilder/statement.go
@@ -130,14 +130,7 @@ func (b *Builder) buildExplain(explain *memo.ExplainExpr) (execPlan, error) {
 		func(ef exec.ExplainFactory) (exec.Plan, error) {
 			// Create a separate builder for the explain query.
 			explainBld := New(
-				ef,
-				b.optimizer,
-				b.mem,
-				b.catalog,
-				explain.Input,
-				b.semaCtx,
-				b.evalCtx,
-				b.initialAllowAutoCommit,
+				ef, b.optimizer, b.mem, b.catalog, explain.Input, b.evalCtx, b.initialAllowAutoCommit,
 			)
 			explainBld.disableTelemetry = true
 			return explainBld.Build()

--- a/pkg/sql/opt/idxconstraint/index_constraints_test.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints_test.go
@@ -135,7 +135,7 @@ func TestIndexConstraints(t *testing.T) {
 				if !remainingFilter.IsTrue() {
 					execBld := execbuilder.New(
 						nil /* execFactory */, nil /* optimizer */, f.Memo(), nil, /* catalog */
-						&remainingFilter, &semaCtx, &evalCtx, false, /* allowAutoCommit */
+						&remainingFilter, &evalCtx, false, /* allowAutoCommit */
 					)
 					expr, err := execBld.BuildScalar()
 					if err != nil {

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -539,7 +539,7 @@ func (b *Builder) buildScan(
 	if locking.isSet() {
 		private.Locking = locking.get()
 	}
-	if b.semaCtx.AsOfSystemTime != nil && b.semaCtx.AsOfSystemTime.BoundedStaleness {
+	if b.evalCtx.AsOfSystemTime != nil && b.evalCtx.AsOfSystemTime.BoundedStaleness {
 		private.Flags.NoIndexJoin = true
 		private.Flags.NoZigzagJoin = true
 	}
@@ -1197,12 +1197,12 @@ func (b *Builder) validateAsOf(asOfClause tree.AsOfClause) {
 		panic(err)
 	}
 
-	if b.semaCtx.AsOfSystemTime == nil {
+	if b.evalCtx.AsOfSystemTime == nil {
 		panic(pgerror.Newf(pgcode.Syntax,
 			"AS OF SYSTEM TIME must be provided on a top-level statement"))
 	}
 
-	if *b.semaCtx.AsOfSystemTime != asOf {
+	if *b.evalCtx.AsOfSystemTime != asOf {
 		panic(unimplementedWithIssueDetailf(35712, "",
 			"cannot specify AS OF SYSTEM TIME with different timestamps"))
 	}

--- a/pkg/sql/opt/partialidx/implicator_test.go
+++ b/pkg/sql/opt/partialidx/implicator_test.go
@@ -113,7 +113,7 @@ func TestImplicator(t *testing.T) {
 			} else {
 				execBld := execbuilder.New(
 					nil /* factory */, nil /* optimizer */, f.Memo(), nil, /* catalog */
-					&remainingFilters, &semaCtx, &evalCtx, false, /* allowAutoCommit */
+					&remainingFilters, &evalCtx, false, /* allowAutoCommit */
 				)
 				expr, err := execBld.BuildScalar()
 				if err != nil {

--- a/pkg/sql/render.go
+++ b/pkg/sql/render.go
@@ -103,7 +103,7 @@ func (p *planner) getTimestamp(
 		// table readers at arbitrary timestamps, and each FROM clause
 		// can have its own timestamp. In that case, the timestamp
 		// would not be set globally for the entire txn.
-		if p.semaCtx.AsOfSystemTime == nil {
+		if p.EvalContext().AsOfSystemTime == nil {
 			return hlc.MaxTimestamp, false,
 				pgerror.Newf(pgcode.Syntax,
 					"AS OF SYSTEM TIME must be provided on a top-level statement")
@@ -117,7 +117,7 @@ func (p *planner) getTimestamp(
 		if err != nil {
 			return hlc.MaxTimestamp, false, err
 		}
-		if asOf != *p.semaCtx.AsOfSystemTime {
+		if asOf != *p.EvalContext().AsOfSystemTime {
 			return hlc.MaxTimestamp, false,
 				unimplemented.NewWithIssue(35712,
 					"cannot specify AS OF SYSTEM TIME with different timestamps")

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3467,6 +3467,15 @@ type EvalContext struct {
 	// transaction_timestamp() and the like.
 	TxnTimestamp time.Time
 
+	// AsOfSystemTime denotes the explicit AS OF SYSTEM TIME timestamp for the
+	// query, if any. If the query is not an AS OF SYSTEM TIME query,
+	// AsOfSystemTime is nil.
+	// TODO(knz): we may want to support table readers at arbitrary
+	// timestamps, so that each FROM clause can have its own
+	// timestamp. In that case, the timestamp would not be set
+	// globally for the entire txn and this field would not be needed.
+	AsOfSystemTime *AsOfSystemTime
+
 	// Placeholders relates placeholder names to their type and, later, value.
 	// This pointer should always be set to the location of the PlaceholderInfo
 	// in the corresponding SemaContext during normal execution. Placeholders are

--- a/pkg/sql/sem/tree/eval_test.go
+++ b/pkg/sql/sem/tree/eval_test.go
@@ -104,7 +104,7 @@ func optBuildScalar(evalCtx *tree.EvalContext, e tree.Expr) (tree.TypedExpr, err
 
 	bld := execbuilder.New(
 		nil /* factory */, &o, o.Memo(), nil /* catalog */, o.Memo().RootExpr(),
-		&semaCtx, evalCtx, false, /* allowAutoCommit */
+		evalCtx, false, /* allowAutoCommit */
 	)
 	expr, err := bld.BuildScalar()
 	if err != nil {

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -47,15 +47,6 @@ type SemaContext struct {
 	// TypeResolver manages resolving type names into *types.T's.
 	TypeResolver TypeReferenceResolver
 
-	// AsOfSystemTime denotes the explicit AS OF SYSTEM TIME timestamp for the
-	// query, if any. If the query is not an AS OF SYSTEM TIME query,
-	// AsOfSystemTime is nil.
-	// TODO(knz): we may want to support table readers at arbitrary
-	// timestamps, so that each FROM clause can have its own
-	// timestamp. In that case, the timestamp would not be set
-	// globally for the entire txn and this field would not be needed.
-	AsOfSystemTime *AsOfSystemTime
-
 	// TableNameResolver is used to resolve the fully qualified
 	// name of a table given its ID.
 	TableNameResolver QualifiedNameResolver

--- a/pkg/sql/set_transaction.go
+++ b/pkg/sql/set_transaction.go
@@ -27,7 +27,7 @@ func (p *planner) SetTransaction(ctx context.Context, n *tree.SetTransaction) (p
 		if err != nil {
 			return nil, err
 		}
-		p.semaCtx.AsOfSystemTime = &asOf
+		p.extendedEvalCtx.AsOfSystemTime = &asOf
 		asOfTs = asOf.Timestamp
 	}
 	if n.Modes.Deferrable == tree.Deferrable {

--- a/pkg/sql/show_fingerprints.go
+++ b/pkg/sql/show_fingerprints.go
@@ -150,7 +150,7 @@ func (n *showFingerprintsNode) Next(params runParams) (bool, error) {
 	// If were'in in an AOST context, propagate it to the inner statement so that
 	// the inner statement gets planned with planner.avoidCachedDescriptors set,
 	// like the outter one.
-	if params.p.semaCtx.AsOfSystemTime != nil {
+	if params.p.EvalContext().AsOfSystemTime != nil {
 		ts := params.p.txn.ReadTimestamp()
 		sql = sql + " AS OF SYSTEM TIME " + ts.AsOfSystemTime()
 	}


### PR DESCRIPTION
Previously, AsOfSystemTime was on the SemaCtx. With the bounded
staleness work needing this in the EvalContext, and all other contexts
accessing this variable have access to EvalContext, move
AsOfSystemTime from SemaContext to EvalContext.

Release note: None