### PR TITLE
sql: actually make OPERATOR(+) unary work

### DIFF
--- a/pkg/sql/opt/operator.go
+++ b/pkg/sql/opt/operator.go
@@ -174,6 +174,7 @@ var UnaryOpReverseMap = map[Operator]tree.UnaryOperatorSymbol{
 	UnaryComplementOp: tree.UnaryComplement,
 	UnarySqrtOp:       tree.UnarySqrt,
 	UnaryCbrtOp:       tree.UnaryCbrt,
+	UnaryPlusOp:       tree.UnaryPlus,
 }
 
 // AggregateOpReverseMap maps from an optimizer operator type to the name of an

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -610,6 +610,11 @@ define UnaryMinus {
     Input ScalarExpr
 }
 
+[Scalar, Unary, CompositeInsensitive]
+define UnaryPlus {
+    Input ScalarExpr
+}
+
 [Scalar, Unary]
 define UnaryComplement {
     Input ScalarExpr

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -768,6 +768,8 @@ func (b *Builder) constructUnary(
 	un tree.UnaryOperator, input opt.ScalarExpr, typ *types.T,
 ) opt.ScalarExpr {
 	switch un.Symbol {
+	case tree.UnaryPlus:
+		return b.factory.ConstructUnaryPlus(input)
 	case tree.UnaryMinus:
 		return b.factory.ConstructUnaryMinus(input)
 	case tree.UnaryComplement:

--- a/pkg/sql/sem/tree/testdata/eval/unary
+++ b/pkg/sql/sem/tree/testdata/eval/unary
@@ -89,3 +89,8 @@ eval
 ||/ decimal 'NaN'
 ----
 NaN
+
+eval
+OPERATOR(+) 1
+----
+1


### PR DESCRIPTION
Even though OPERATOR(+) as a unary operator parses, it should also work!
This commit makes this operator work end-to-end, with a regression test.

Release note: None