### PR TITLE
changefeedccl: allow changefeeds on regional by row tables

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -143,6 +143,7 @@ go_test(
         "//pkg/ccl/importccl",
         "//pkg/ccl/kvccl/kvtenantccl",
         "//pkg/ccl/multiregionccl",
+        "//pkg/ccl/multiregionccl/multiregionccltestutils",
         "//pkg/ccl/partitionccl",
         "//pkg/ccl/storageccl",
         "//pkg/ccl/utilccl",

--- a/pkg/ccl/changefeedccl/changefeedbase/validate.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/validate.go
@@ -39,9 +39,6 @@ func ValidateTable(targets jobspb.ChangefeedTargets, tableDesc catalog.TableDesc
 	if tableDesc.IsSequence() {
 		return errors.Errorf(`CHANGEFEED cannot target sequences: %s`, tableDesc.GetName())
 	}
-	if tableDesc.IsLocalityRegionalByRow() {
-		return errors.Errorf(`CHANGEFEED cannot target REGIONAL BY ROW tables: %s`, tableDesc.GetName())
-	}
 	if len(tableDesc.GetFamilies()) != 1 {
 		return errors.Errorf(
 			`CHANGEFEEDs are currently supported on tables with exactly 1 column family: %s has %d`,

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
@@ -125,15 +125,6 @@ func (e schemaChangeDetectedError) Error() string {
 	return fmt.Sprintf("schema change detected at %v", e.ts)
 }
 
-type unsupportedSchemaChangeDetected struct {
-	desc string
-	ts   hlc.Timestamp
-}
-
-func (e unsupportedSchemaChangeDetected) Error() string {
-	return fmt.Sprintf("unsupported schema change %s detected at %s", e.desc, e.ts.AsOfSystemTime())
-}
-
 type kvFeed struct {
 	spans               []roachpb.Span
 	checkpoint          []roachpb.Span
@@ -206,17 +197,7 @@ func (f *kvFeed) run(ctx context.Context) (err error) {
 		boundaryType := jobspb.ResolvedSpan_BACKFILL
 		if f.schemaChangePolicy == changefeedbase.OptSchemaChangePolicyStop {
 			boundaryType = jobspb.ResolvedSpan_EXIT
-		} else if events, err := f.tableFeed.Peek(ctx, highWater.Next()); err == nil && isRegionalByRowChange(events) {
-			// NOTE(ssd): The user is unlikely to see this
-			// error. The schemafeed will fail with an
-			// non-retriable error, meaning we likely
-			// return right after runUntilTableEvent
-			// above.
-			return unsupportedSchemaChangeDetected{
-				desc: "SET REGIONAL BY ROW",
-				ts:   highWater.Next(),
-			}
-		} else if err == nil && isPrimaryKeyChange(events) {
+		} else if events, err := f.tableFeed.Peek(ctx, highWater.Next()); err == nil && isPrimaryKeyChange(events) {
 			boundaryType = jobspb.ResolvedSpan_RESTART
 		} else if err != nil {
 			return err
@@ -241,15 +222,6 @@ func (f *kvFeed) run(ctx context.Context) (err error) {
 func isPrimaryKeyChange(events []schemafeed.TableEvent) bool {
 	for _, ev := range events {
 		if schemafeed.IsPrimaryIndexChange(ev) {
-			return true
-		}
-	}
-	return false
-}
-
-func isRegionalByRowChange(events []schemafeed.TableEvent) bool {
-	for _, ev := range events {
-		if schemafeed.IsRegionalByRowChange(ev) {
 			return true
 		}
 	}

--- a/pkg/ccl/multiregionccl/multiregionccltestutils/testutils.go
+++ b/pkg/ccl/multiregionccl/multiregionccltestutils/testutils.go
@@ -23,6 +23,7 @@ import (
 type multiRegionTestClusterParams struct {
 	baseDir         string
 	replicationMode base.TestClusterReplicationMode
+	useDatabase     string
 }
 
 // MultiRegionTestClusterParamsOption is an option that can be passed to
@@ -44,6 +45,13 @@ func WithReplicationMode(
 ) MultiRegionTestClusterParamsOption {
 	return func(params *multiRegionTestClusterParams) {
 		params.replicationMode = replicationMode
+	}
+}
+
+// WithUseDatabase is an option to set the UseDatabase server option.
+func WithUseDatabase(db string) MultiRegionTestClusterParamsOption {
+	return func(params *multiRegionTestClusterParams) {
+		params.useDatabase = db
 	}
 }
 
@@ -69,6 +77,7 @@ func TestingCreateMultiRegionCluster(
 		serverArgs[i] = base.TestServerArgs{
 			Knobs:         knobs,
 			ExternalIODir: params.baseDir,
+			UseDatabase:   params.useDatabase,
 			Locality: roachpb.Locality{
 				Tiers: []roachpb.Tier{{Key: "region", Value: regionNames[i]}},
 			},


### PR DESCRIPTION
Previously we explicitly disallowed changefeeds on regional by row
tables because:

1) the Avro encoder lacked enum support,
2) the schema feed did not correctly identify RBR schema changes as
   both a column addition and a primary key change, and
3) we were unsure whether users would be OK seeing the new crdb_region
   column in their changefeed output.

Both (1) and (2) have since been fixed in
8113beda91a6c3791208632ecad075f6ca0a95b6 and
cd687ded12d717032f0966eca37b9c0845ee8d57, respectively.

For (3) we've decided that changefeeds should rather faithfully emit
what KV tells us about. Future work to support projections and
predicate filtering may allow _users_ to filter what gets output, but
until then we want to err on the side of avoiding ad-hoc modifications
to the changefeed output. Thus, we are OK emitting the crdb_region
column as-is both in the row data and as part of the primary key.

Release note (enterprise change): CHANGEFEEDs no longer fail when
started on REGIONAL BY ROW tables. Note that in REGION BY ROW tables,
the crdb_region column becomes part of the primary index. Thus,
changing an existing table to REGIONAL BY ROW will trigger a
changefeed backfill with new messages emitted using the new composite
primary key.