### PR TITLE
sql: add running transactions and active sessions to stmt diagnostics…

### DIFF
--- a/pkg/sql/explain_bundle_test.go
+++ b/pkg/sql/explain_bundle_test.go
@@ -46,7 +46,7 @@ func TestExplainAnalyzeDebug(t *testing.T) {
 CREATE SCHEMA s;
 CREATE TABLE s.a (a INT PRIMARY KEY);`)
 
-	base := "statement.txt trace.json trace.txt trace-jaeger.json env.sql"
+	base := "statement.txt trace.json trace.txt trace-jaeger.json env.sql running_transactions.txt"
 	plans := "schema.sql opt.txt opt-v.txt opt-vv.txt plan.txt"
 
 	// Set a small chunk size to test splitting into chunks. The bundle files are


### PR DESCRIPTION
… bundles

Resolves: cockroachdb#65144

A list of active sessions and transaction information can help determine
the source of contention for a slow-running query. This commit puts
information about executed transactions and active session information
from crdb_internal cluster tables into stmt diag bundles, similar
to the table dumps included in `debug.zip`.

Release note (sql change): Running transsactions and active
session information has been added to the statement diagnostics
bundle generated by EXPLAIN ANALYZE (DEBUG).

The new file `running_transactions.txt` contains the results
of a JOIN on session_id and txn_id on rows from
`crdb_internal.cluster_sessions`, `crdb_internal.cluster_transactions`
and `crdb_internal.cluster_queries`.

As a result, users should be aware that statement bundles might
contain PII from anything running on the cluster and not just
queries and tables relevant to the statement.

An example of the output of `running_transactions.txt`:

```
(node_id, session_id, session_start, application_name, user_name, client_address, oldest_query_start, alloc_bytes, max_alloc_bytes, active_queries, last_active_query, id, start, txn_string, num_stmts, num_retries, num_auto_retries, query_id, start, query, phase)
(1, '16964cdbab80e1400000000000000001', '2021-07-29 15:33:41.699063', '$ cockroach sql', 'root', '127.0.0.1:59177', '2021-07-29 15:33:46.915165', 20480, 30720, 'EXPLAIN ANALYZE (DEBUG) SELECT 42', 'SHOW database', 'aa377e52-494b-49f1-9f8e-07fdbe30ad11', '2021-07-29 15:33:46.915213', '"sql txn" meta={id=aa377e52 key=/Min pri=0.05974257 epo=0 ts=1627572826.915207000,0 min=1627572826.915207000,0 seq=0} lock=false stat=COMMITTED rts=1627572826.915207000,0 wto=false gul=1627572827.415207000,0', 1, 0, 0, '16964cdce25c31f00000000000000001', '2021-07-29 15:33:46.915165', 'EXPLAIN ANALYZE (DEBUG) SELECT 42', 'executing')
(1, '16964cdce2ff19100000000000000001', '2021-07-29 15:33:46.925889', '$ cockroach sql', 'root', '127.0.0.1:59177', '2021-07-29 15:33:46.9257', 153600, 153600, 'SELECT s.node_id, s.session_id, s.session_start, s.application_name, s.user_name, s.client_address, s.oldest_query_start, s.alloc_bytes, s.max_alloc_bytes, s.active_queries, s.last_active_query, t.id, t.start, t.txn_string, t.num_stmts, t.num_retries, t.num_auto_retries, q.query_id, q.start, q.query, q.phase FROM crdb_internal.cluster_sessions AS s JOIN crdb_internal.cluster_transactions AS t ON s.session_id = t.session_id JOIN crdb_internal.cluster_queries AS q ON q.txn_id = t.id', '', '2044cae9-5df7-42a8-86ae-51d772372ac9', '2021-07-29 15:33:46.925909', '"sql txn" meta={id=2044cae9 key=/Min pri=0.00951043 epo=0 ts=1627572826.925907000,0 min=1627572826.925907000,0 seq=0} lock=false stat=PENDING rts=1627572826.925907000,0 wto=false gul=1627572827.425907000,0', 1, 0, 0, '16964cdce2ff4fc00000000000000001', '2021-07-29 15:33:46.9257', 'SELECT s.node_id, s.session_id, s.session_start, s.application_name, s.user_name, s.client_address, s.oldest_query_start, s.alloc_bytes, s.max_alloc_bytes, s.active_queries, s.last_active_query, t.id, t.start, t.txn_string, t.num_stmts, t.num_retries, t.num_auto_retries, q.query_id, q.start, q.query, q.phase FROM crdb_internal.cluster_sessions AS s JOIN crdb_internal.cluster_transactions AS t ON s.session_id = t.session_id JOIN crdb_internal.cluster_queries AS q ON q.txn_id = t.id', 'executing')
```