### PR TITLE
sql implement the pg_db_role_setting table

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_role_set
+++ b/pkg/sql/logictest/testdata/logic_test/alter_role_set
@@ -22,6 +22,20 @@ database_id  role_name      settings
 53           ·              {application_name=c}
 53           test_set_role  {application_name=b}
 
+# Defaults should be in pg_catalog too.
+query OOTTT colnames
+SELECT setdatabase, setrole, d.datname, r.rolname, setconfig
+FROM pg_catalog.pg_db_role_setting
+LEFT JOIN pg_catalog.pg_database d ON setdatabase = d.oid
+LEFT JOIN pg_catalog.pg_roles r ON setrole = r.oid
+ORDER BY 1, 2
+----
+setdatabase  setrole    datname      rolname        setconfig
+0            0          NULL         NULL           {application_name=d}
+0            265380634  NULL         test_set_role  {application_name=a}
+53           0          test_set_db  NULL           {application_name=c}
+53           265380634  test_set_db  test_set_role  {application_name=b}
+
 statement ok
 ALTER ROLE test_set_role SET backslash_quote = 'safe_encoding'
 

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3642,7 +3642,7 @@ objoid      classoid    objsubid  description
 4294967133  4294967137  0         encoding conversions (empty - unimplemented)
 4294967132  4294967137  0         pg_cursors was created for compatibility and is currently unimplemented
 4294967131  4294967137  0         available databases (incomplete)
-4294967130  4294967137  0         pg_db_role_setting was created for compatibility and is currently unimplemented
+4294967130  4294967137  0         contains the default values that have been configured for session variables
 4294967129  4294967137  0         default ACLs; these are the privileges that will be assigned to newly created objects
 4294967128  4294967137  0         dependency relationships (incomplete)
 4294967127  4294967137  0         object comments

--- a/pkg/sql/vtable/pg_catalog.go
+++ b/pkg/sql/vtable/pg_catalog.go
@@ -989,8 +989,9 @@ CREATE TABLE pg_catalog.pg_shmem_allocations (
 	allocated_size INT
 )`
 
-// PgCatalogDbRoleSetting is an empty table created by pg_catalog_test
-// and is currently unimplemented.
+// PgCatalogDbRoleSetting contains the default values that have been configured
+// for session variables, for each role and database combination. This table
+// contains the same data no matter which database the current session is using.
 const PgCatalogDbRoleSetting = `
 CREATE TABLE pg_catalog.pg_db_role_setting (
 	setconfig STRING[],


### PR DESCRIPTION
touches https://github.com/cockroachdb/cockroach/issues/21151

Release note (sql change): The pg_db_role_setting table of the
pg_catalog is now implemented. When `ALTER ROLE ... SET var`
is used to configure per-role defaults, these default settings will be
populated in pg_db_role_setting. This table contains the same data no
matter which database the current session is using.

See https://www.postgresql.org/docs/13/catalog-pg-db-role-setting.html