### PR TITLE
coldataext: remove a wrapper and use tree.Datum directly

### DIFF
--- a/pkg/col/coldataext/datum_vec.go
+++ b/pkg/col/coldataext/datum_vec.go
@@ -74,18 +74,6 @@ func (d *Datum) CompareDatum(dVec, other interface{}) int {
 	return d.Datum.Compare(dVec.(*datumVec).evalCtx, maybeUnwrapDatum(other))
 }
 
-// Cast returns the result of casting d to the type toType. dVec is the
-// datumVec that stores d and is used to supply the eval context.
-func (d *Datum) Cast(dVec interface{}, toType *types.T) (tree.Datum, error) {
-	return PerformCast(dVec, d.Datum, toType)
-}
-
-// PerformCast returns the result of casting d to the type toType. dVec is a
-// datumVec that is used to supply the eval context.
-func PerformCast(dVec interface{}, d tree.Datum, toType *types.T) (tree.Datum, error) {
-	return tree.PerformCast(dVec.(*datumVec).evalCtx, d, toType)
-}
-
 // Hash returns the hash of the datum as a byte slice.
 func (d *Datum) Hash(da *rowenc.DatumAlloc) []byte {
 	ed := rowenc.EncDatum{Datum: maybeUnwrapDatum(d)}

--- a/pkg/col/coldataext/datum_vec.go
+++ b/pkg/col/coldataext/datum_vec.go
@@ -24,14 +24,6 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// Datum wraps a tree.Datum. This is the struct that datumVec.Get() returns.
-type Datum struct {
-	tree.Datum
-}
-
-var _ coldata.Datum = &Datum{}
-var _ tree.Datum = &Datum{}
-
 // datumVec is a vector of tree.Datums of the same type.
 type datumVec struct {
 	// t is the type of the tree.Datums that datumVec stores.
@@ -56,27 +48,19 @@ func newDatumVec(t *types.T, n int, evalCtx *tree.EvalContext) coldata.DatumVec 
 	}
 }
 
-// BinFn evaluates the provided binary function between the receiver and other.
-// other can either be nil, tree.Datum, or *Datum.
-func (d *Datum) BinFn(
-	binFn tree.TwoArgFn, evalCtx *tree.EvalContext, other interface{},
-) (tree.Datum, error) {
-	return binFn(evalCtx, d.Datum, maybeUnwrapDatum(other))
-}
-
 // CompareDatum returns the comparison between d and other. The other is
 // assumed to be tree.Datum. dVec is the datumVec that stores either d or other
 // (it doesn't matter which one because it is used only to supply the eval
 // context).
 // Note that the method is named differently from "Compare" so that we do not
 // overload tree.Datum.Compare method.
-func (d *Datum) CompareDatum(dVec, other interface{}) int {
-	return d.Datum.Compare(dVec.(*datumVec).evalCtx, maybeUnwrapDatum(other))
+func CompareDatum(d, dVec, other interface{}) int {
+	return d.(tree.Datum).Compare(dVec.(*datumVec).evalCtx, convertToDatum(other))
 }
 
 // Hash returns the hash of the datum as a byte slice.
-func (d *Datum) Hash(da *rowenc.DatumAlloc) []byte {
-	ed := rowenc.EncDatum{Datum: maybeUnwrapDatum(d)}
+func Hash(d tree.Datum, da *rowenc.DatumAlloc) []byte {
+	ed := rowenc.EncDatum{Datum: convertToDatum(d)}
 	// We know that we have tree.Datum, so there will definitely be no need to
 	// decode ed for fingerprinting, so we pass in nil memory account.
 	b, err := ed.Fingerprint(context.TODO(), d.ResolvedType(), da, nil /* appendTo */, nil /* acc */)
@@ -89,24 +73,15 @@ func (d *Datum) Hash(da *rowenc.DatumAlloc) []byte {
 	return b
 }
 
-// Size returns a lower bound on the total size of the receiver in bytes,
-// including memory that is pointed at (even if shared between Datum
-// instances) but excluding allocation overhead.
-//
-// It is assumed that d was obtained via datumVec.Get().
-func (d *Datum) Size() uintptr {
-	return d.Datum.Size()
-}
-
 // Get implements coldata.DatumVec interface.
 func (dv *datumVec) Get(i int) coldata.Datum {
 	dv.maybeSetDNull(i)
-	return &Datum{Datum: dv.data[i]}
+	return dv.data[i]
 }
 
 // Set implements coldata.DatumVec interface.
 func (dv *datumVec) Set(i int, v coldata.Datum) {
-	datum := maybeUnwrapDatum(v)
+	datum := convertToDatum(v)
 	dv.assertValidDatum(datum)
 	dv.data[i] = datum
 }
@@ -136,7 +111,7 @@ func (dv *datumVec) AppendSlice(src coldata.DatumVec, destIdx, srcStartIdx, srcE
 
 // AppendVal implements coldata.DatumVec interface.
 func (dv *datumVec) AppendVal(v coldata.Datum) {
-	datum := maybeUnwrapDatum(v)
+	datum := convertToDatum(v)
 	dv.assertValidDatum(datum)
 	dv.data = append(dv.data, datum)
 }
@@ -230,15 +205,12 @@ func (dv *datumVec) maybeSetDNull(i int) {
 	}
 }
 
-// maybeUnwrapDatum possibly unwraps tree.Datum from inside of Datum. It also
-// checks whether v is nil and returns tree.DNull if it is.
-func maybeUnwrapDatum(v coldata.Datum) tree.Datum {
+// convertToDatum converts v to the corresponding tree.Datum.
+func convertToDatum(v coldata.Datum) tree.Datum {
 	if v == nil {
 		return tree.DNull
 	}
-	if datum, ok := v.(*Datum); ok {
-		return datum.Datum
-	} else if datum, ok := v.(tree.Datum); ok {
+	if datum, ok := v.(tree.Datum); ok {
 		return datum
 	}
 	colexecerror.InternalError(errors.AssertionFailedf("unexpected value: %v", v))

--- a/pkg/col/coldataext/datum_vec_test.go
+++ b/pkg/col/coldataext/datum_vec_test.go
@@ -21,40 +21,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDatum(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	dv := &datumVec{evalCtx: &tree.EvalContext{}}
-	var d1 *Datum
-	var d2 tree.Datum
-	d1 = &Datum{Datum: &tree.DJSON{JSON: json.FromString("string")}}
-	d2 = &tree.DJSON{JSON: json.FromString("string")}
-
-	// Datum can be compared with regular datum.
-	require.True(t, d1.CompareDatum(dv, d2) == 0)
-
-	d2 = &Datum{Datum: d2}
-
-	// Datum can be compared with another Datum.
-	require.True(t, d1.CompareDatum(dv, d2) == 0)
-
-	// Datum implicitly views nil as tree.DNull.
-	require.True(t, d1.CompareDatum(dv, tree.DNull) == d1.CompareDatum(dv, nil /* other */))
-
-	// Datum panics if compared with incompatible type.
-	d2 = tree.NewDString("s")
-	require.Panics(t,
-		func() { d1.CompareDatum(dv, d2) },
-		"different datum type should have caused panic when compared",
-	)
-
-	d2 = &Datum{Datum: d2}
-	require.Panics(t,
-		func() { d1.CompareDatum(dv, d2) },
-		"different datum type should have caused panic when compared",
-	)
-}
-
 func TestDatumVec(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 

--- a/pkg/sql/colconv/vec_to_datum.eg.go
+++ b/pkg/sql/colconv/vec_to_datum.eg.go
@@ -14,7 +14,6 @@ import (
 	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
-	"github.com/cockroachdb/cockroach/pkg/col/coldataext"
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
@@ -666,7 +665,7 @@ func ColVecToDatumAndDeselect(
 							continue
 						}
 						v := typedCol.Get(srcIdx)
-						_converted := v.(*coldataext.Datum).Datum
+						_converted := v.(tree.Datum)
 						//gcassert:bce
 						converted[destIdx] = _converted
 					}
@@ -1010,7 +1009,7 @@ func ColVecToDatumAndDeselect(
 							srcIdx = sel[idx]
 						}
 						v := typedCol.Get(srcIdx)
-						_converted := v.(*coldataext.Datum).Datum
+						_converted := v.(tree.Datum)
 						//gcassert:bce
 						converted[destIdx] = _converted
 					}
@@ -1433,7 +1432,7 @@ func ColVecToDatum(
 								continue
 							}
 							v := typedCol.Get(srcIdx)
-							_converted := v.(*coldataext.Datum).Datum
+							_converted := v.(tree.Datum)
 							converted[destIdx] = _converted
 						}
 					}
@@ -1859,7 +1858,7 @@ func ColVecToDatum(
 								continue
 							}
 							v := typedCol.Get(srcIdx)
-							_converted := v.(*coldataext.Datum).Datum
+							_converted := v.(tree.Datum)
 							//gcassert:bce
 							converted[destIdx] = _converted
 						}
@@ -2205,7 +2204,7 @@ func ColVecToDatum(
 								srcIdx = sel[idx]
 							}
 							v := typedCol.Get(srcIdx)
-							_converted := v.(*coldataext.Datum).Datum
+							_converted := v.(tree.Datum)
 							converted[destIdx] = _converted
 						}
 					}
@@ -2551,7 +2550,7 @@ func ColVecToDatum(
 								srcIdx = idx
 							}
 							v := typedCol.Get(srcIdx)
-							_converted := v.(*coldataext.Datum).Datum
+							_converted := v.(tree.Datum)
 							//gcassert:bce
 							converted[destIdx] = _converted
 						}

--- a/pkg/sql/colexec/colexecagg/any_not_null_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/any_not_null_agg_tmpl.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/cockroachdb/apd/v2"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
-	"github.com/cockroachdb/cockroach/pkg/col/coldataext"
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
@@ -44,7 +43,6 @@ var (
 	_ duration.Duration
 	_ json.JSON
 	_ colexecerror.StorageError
-	_ coldataext.Datum
 )
 
 // {{/*

--- a/pkg/sql/colexec/colexecagg/hash_any_not_null_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_any_not_null_agg.eg.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/cockroachdb/apd/v2"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
-	"github.com/cockroachdb/cockroach/pkg/col/coldataext"
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
@@ -34,7 +33,6 @@ var (
 	_ duration.Duration
 	_ json.JSON
 	_ colexecerror.StorageError
-	_ coldataext.Datum
 )
 
 func newAnyNotNullHashAggAlloc(
@@ -1301,7 +1299,7 @@ func (a *anyNotNullDatumHashAgg) Compute(
 
 	var oldCurAggSize uintptr
 	if a.curAgg != nil {
-		oldCurAggSize = a.curAgg.(*coldataext.Datum).Size()
+		oldCurAggSize = a.curAgg.(tree.Datum).Size()
 	}
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Datum(), vec.Nulls()
@@ -1351,7 +1349,7 @@ func (a *anyNotNullDatumHashAgg) Compute(
 
 	var newCurAggSize uintptr
 	if a.curAgg != nil {
-		newCurAggSize = a.curAgg.(*coldataext.Datum).Size()
+		newCurAggSize = a.curAgg.(tree.Datum).Size()
 	}
 	if newCurAggSize != oldCurAggSize {
 		a.allocator.AdjustMemoryUsage(int64(newCurAggSize - oldCurAggSize))
@@ -1370,7 +1368,7 @@ func (a *anyNotNullDatumHashAgg) Flush(outputIdx int) {
 
 	var oldCurAggSize uintptr
 	if a.curAgg != nil {
-		oldCurAggSize = a.curAgg.(*coldataext.Datum).Size()
+		oldCurAggSize = a.curAgg.(tree.Datum).Size()
 	}
 	a.allocator.AdjustMemoryUsage(-int64(oldCurAggSize))
 	a.curAgg = nil

--- a/pkg/sql/colexec/colexecagg/hash_min_max_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_min_max_agg.eg.go
@@ -35,7 +35,7 @@ var (
 	_ apd.Context
 	_ duration.Duration
 	_ json.JSON
-	_ coldataext.Datum
+	_ = coldataext.CompareDatum
 )
 
 // Remove unused warning.
@@ -1613,7 +1613,7 @@ func (a *minDatumHashAgg) Compute(
 
 	var oldCurAggSize uintptr
 	if a.curAgg != nil {
-		oldCurAggSize = a.curAgg.(*coldataext.Datum).Size()
+		oldCurAggSize = a.curAgg.(tree.Datum).Size()
 	}
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Datum(), vec.Nulls()
@@ -1637,7 +1637,7 @@ func (a *minDatumHashAgg) Compute(
 							{
 								var cmpResult int
 
-								cmpResult = candidate.(*coldataext.Datum).CompareDatum(col, a.curAgg)
+								cmpResult = coldataext.CompareDatum(candidate, col, a.curAgg)
 
 								cmp = cmpResult < 0
 							}
@@ -1665,7 +1665,7 @@ func (a *minDatumHashAgg) Compute(
 							{
 								var cmpResult int
 
-								cmpResult = candidate.(*coldataext.Datum).CompareDatum(col, a.curAgg)
+								cmpResult = coldataext.CompareDatum(candidate, col, a.curAgg)
 
 								cmp = cmpResult < 0
 							}
@@ -1683,7 +1683,7 @@ func (a *minDatumHashAgg) Compute(
 
 	var newCurAggSize uintptr
 	if a.curAgg != nil {
-		newCurAggSize = a.curAgg.(*coldataext.Datum).Size()
+		newCurAggSize = a.curAgg.(tree.Datum).Size()
 	}
 	if newCurAggSize != oldCurAggSize {
 		a.allocator.AdjustMemoryUsage(int64(newCurAggSize - oldCurAggSize))
@@ -1702,7 +1702,7 @@ func (a *minDatumHashAgg) Flush(outputIdx int) {
 
 	var oldCurAggSize uintptr
 	if a.curAgg != nil {
-		oldCurAggSize = a.curAgg.(*coldataext.Datum).Size()
+		oldCurAggSize = a.curAgg.(tree.Datum).Size()
 	}
 	// Release the reference to curAgg eagerly.
 	a.allocator.AdjustMemoryUsage(-int64(oldCurAggSize))
@@ -3306,7 +3306,7 @@ func (a *maxDatumHashAgg) Compute(
 
 	var oldCurAggSize uintptr
 	if a.curAgg != nil {
-		oldCurAggSize = a.curAgg.(*coldataext.Datum).Size()
+		oldCurAggSize = a.curAgg.(tree.Datum).Size()
 	}
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Datum(), vec.Nulls()
@@ -3330,7 +3330,7 @@ func (a *maxDatumHashAgg) Compute(
 							{
 								var cmpResult int
 
-								cmpResult = candidate.(*coldataext.Datum).CompareDatum(col, a.curAgg)
+								cmpResult = coldataext.CompareDatum(candidate, col, a.curAgg)
 
 								cmp = cmpResult > 0
 							}
@@ -3358,7 +3358,7 @@ func (a *maxDatumHashAgg) Compute(
 							{
 								var cmpResult int
 
-								cmpResult = candidate.(*coldataext.Datum).CompareDatum(col, a.curAgg)
+								cmpResult = coldataext.CompareDatum(candidate, col, a.curAgg)
 
 								cmp = cmpResult > 0
 							}
@@ -3376,7 +3376,7 @@ func (a *maxDatumHashAgg) Compute(
 
 	var newCurAggSize uintptr
 	if a.curAgg != nil {
-		newCurAggSize = a.curAgg.(*coldataext.Datum).Size()
+		newCurAggSize = a.curAgg.(tree.Datum).Size()
 	}
 	if newCurAggSize != oldCurAggSize {
 		a.allocator.AdjustMemoryUsage(int64(newCurAggSize - oldCurAggSize))
@@ -3395,7 +3395,7 @@ func (a *maxDatumHashAgg) Flush(outputIdx int) {
 
 	var oldCurAggSize uintptr
 	if a.curAgg != nil {
-		oldCurAggSize = a.curAgg.(*coldataext.Datum).Size()
+		oldCurAggSize = a.curAgg.(tree.Datum).Size()
 	}
 	// Release the reference to curAgg eagerly.
 	a.allocator.AdjustMemoryUsage(-int64(oldCurAggSize))

--- a/pkg/sql/colexec/colexecagg/min_max_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/min_max_agg_tmpl.go
@@ -43,7 +43,7 @@ var (
 	_ apd.Context
 	_ duration.Duration
 	_ json.JSON
-	_ coldataext.Datum
+	_ = coldataext.CompareDatum
 )
 
 // Remove unused warning.

--- a/pkg/sql/colexec/colexecagg/ordered_any_not_null_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_any_not_null_agg.eg.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/cockroachdb/apd/v2"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
-	"github.com/cockroachdb/cockroach/pkg/col/coldataext"
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
@@ -34,7 +33,6 @@ var (
 	_ duration.Duration
 	_ json.JSON
 	_ colexecerror.StorageError
-	_ coldataext.Datum
 )
 
 func newAnyNotNullOrderedAggAlloc(
@@ -2167,7 +2165,7 @@ func (a *anyNotNullDatumOrderedAgg) Compute(
 
 	var oldCurAggSize uintptr
 	if a.curAgg != nil {
-		oldCurAggSize = a.curAgg.(*coldataext.Datum).Size()
+		oldCurAggSize = a.curAgg.(tree.Datum).Size()
 	}
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Datum(), vec.Nulls()
@@ -2303,7 +2301,7 @@ func (a *anyNotNullDatumOrderedAgg) Compute(
 
 	var newCurAggSize uintptr
 	if a.curAgg != nil {
-		newCurAggSize = a.curAgg.(*coldataext.Datum).Size()
+		newCurAggSize = a.curAgg.(tree.Datum).Size()
 	}
 	if newCurAggSize != oldCurAggSize {
 		a.allocator.AdjustMemoryUsage(int64(newCurAggSize - oldCurAggSize))
@@ -2326,7 +2324,7 @@ func (a *anyNotNullDatumOrderedAgg) Flush(outputIdx int) {
 
 	var oldCurAggSize uintptr
 	if a.curAgg != nil {
-		oldCurAggSize = a.curAgg.(*coldataext.Datum).Size()
+		oldCurAggSize = a.curAgg.(tree.Datum).Size()
 	}
 	a.allocator.AdjustMemoryUsage(-int64(oldCurAggSize))
 	a.curAgg = nil

--- a/pkg/sql/colexec/colexecagg/ordered_min_max_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_min_max_agg.eg.go
@@ -35,7 +35,7 @@ var (
 	_ apd.Context
 	_ duration.Duration
 	_ json.JSON
-	_ coldataext.Datum
+	_ = coldataext.CompareDatum
 )
 
 // Remove unused warning.
@@ -3073,7 +3073,7 @@ func (a *minDatumOrderedAgg) Compute(
 
 	var oldCurAggSize uintptr
 	if a.curAgg != nil {
-		oldCurAggSize = a.curAgg.(*coldataext.Datum).Size()
+		oldCurAggSize = a.curAgg.(tree.Datum).Size()
 	}
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Datum(), vec.Nulls()
@@ -3118,7 +3118,7 @@ func (a *minDatumOrderedAgg) Compute(
 							{
 								var cmpResult int
 
-								cmpResult = candidate.(*coldataext.Datum).CompareDatum(col, a.curAgg)
+								cmpResult = coldataext.CompareDatum(candidate, col, a.curAgg)
 
 								cmp = cmpResult < 0
 							}
@@ -3162,7 +3162,7 @@ func (a *minDatumOrderedAgg) Compute(
 							{
 								var cmpResult int
 
-								cmpResult = candidate.(*coldataext.Datum).CompareDatum(col, a.curAgg)
+								cmpResult = coldataext.CompareDatum(candidate, col, a.curAgg)
 
 								cmp = cmpResult < 0
 							}
@@ -3208,7 +3208,7 @@ func (a *minDatumOrderedAgg) Compute(
 							{
 								var cmpResult int
 
-								cmpResult = candidate.(*coldataext.Datum).CompareDatum(col, a.curAgg)
+								cmpResult = coldataext.CompareDatum(candidate, col, a.curAgg)
 
 								cmp = cmpResult < 0
 							}
@@ -3251,7 +3251,7 @@ func (a *minDatumOrderedAgg) Compute(
 							{
 								var cmpResult int
 
-								cmpResult = candidate.(*coldataext.Datum).CompareDatum(col, a.curAgg)
+								cmpResult = coldataext.CompareDatum(candidate, col, a.curAgg)
 
 								cmp = cmpResult < 0
 							}
@@ -3269,7 +3269,7 @@ func (a *minDatumOrderedAgg) Compute(
 
 	var newCurAggSize uintptr
 	if a.curAgg != nil {
-		newCurAggSize = a.curAgg.(*coldataext.Datum).Size()
+		newCurAggSize = a.curAgg.(tree.Datum).Size()
 	}
 	if newCurAggSize != oldCurAggSize {
 		a.allocator.AdjustMemoryUsage(int64(newCurAggSize - oldCurAggSize))
@@ -3292,7 +3292,7 @@ func (a *minDatumOrderedAgg) Flush(outputIdx int) {
 
 	var oldCurAggSize uintptr
 	if a.curAgg != nil {
-		oldCurAggSize = a.curAgg.(*coldataext.Datum).Size()
+		oldCurAggSize = a.curAgg.(tree.Datum).Size()
 	}
 	// Release the reference to curAgg eagerly.
 	a.allocator.AdjustMemoryUsage(-int64(oldCurAggSize))
@@ -6357,7 +6357,7 @@ func (a *maxDatumOrderedAgg) Compute(
 
 	var oldCurAggSize uintptr
 	if a.curAgg != nil {
-		oldCurAggSize = a.curAgg.(*coldataext.Datum).Size()
+		oldCurAggSize = a.curAgg.(tree.Datum).Size()
 	}
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Datum(), vec.Nulls()
@@ -6402,7 +6402,7 @@ func (a *maxDatumOrderedAgg) Compute(
 							{
 								var cmpResult int
 
-								cmpResult = candidate.(*coldataext.Datum).CompareDatum(col, a.curAgg)
+								cmpResult = coldataext.CompareDatum(candidate, col, a.curAgg)
 
 								cmp = cmpResult > 0
 							}
@@ -6446,7 +6446,7 @@ func (a *maxDatumOrderedAgg) Compute(
 							{
 								var cmpResult int
 
-								cmpResult = candidate.(*coldataext.Datum).CompareDatum(col, a.curAgg)
+								cmpResult = coldataext.CompareDatum(candidate, col, a.curAgg)
 
 								cmp = cmpResult > 0
 							}
@@ -6492,7 +6492,7 @@ func (a *maxDatumOrderedAgg) Compute(
 							{
 								var cmpResult int
 
-								cmpResult = candidate.(*coldataext.Datum).CompareDatum(col, a.curAgg)
+								cmpResult = coldataext.CompareDatum(candidate, col, a.curAgg)
 
 								cmp = cmpResult > 0
 							}
@@ -6535,7 +6535,7 @@ func (a *maxDatumOrderedAgg) Compute(
 							{
 								var cmpResult int
 
-								cmpResult = candidate.(*coldataext.Datum).CompareDatum(col, a.curAgg)
+								cmpResult = coldataext.CompareDatum(candidate, col, a.curAgg)
 
 								cmp = cmpResult > 0
 							}
@@ -6553,7 +6553,7 @@ func (a *maxDatumOrderedAgg) Compute(
 
 	var newCurAggSize uintptr
 	if a.curAgg != nil {
-		newCurAggSize = a.curAgg.(*coldataext.Datum).Size()
+		newCurAggSize = a.curAgg.(tree.Datum).Size()
 	}
 	if newCurAggSize != oldCurAggSize {
 		a.allocator.AdjustMemoryUsage(int64(newCurAggSize - oldCurAggSize))
@@ -6576,7 +6576,7 @@ func (a *maxDatumOrderedAgg) Flush(outputIdx int) {
 
 	var oldCurAggSize uintptr
 	if a.curAgg != nil {
-		oldCurAggSize = a.curAgg.(*coldataext.Datum).Size()
+		oldCurAggSize = a.curAgg.(tree.Datum).Size()
 	}
 	// Release the reference to curAgg eagerly.
 	a.allocator.AdjustMemoryUsage(-int64(oldCurAggSize))

--- a/pkg/sql/colexec/colexecagg/window_min_max_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/window_min_max_agg.eg.go
@@ -35,7 +35,7 @@ var (
 	_ apd.Context
 	_ duration.Duration
 	_ json.JSON
-	_ coldataext.Datum
+	_ = coldataext.CompareDatum
 )
 
 // Remove unused warning.
@@ -1593,7 +1593,7 @@ func (a *minDatumWindowAgg) Compute(
 
 	var oldCurAggSize uintptr
 	if a.curAgg != nil {
-		oldCurAggSize = a.curAgg.(*coldataext.Datum).Size()
+		oldCurAggSize = a.curAgg.(tree.Datum).Size()
 	}
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Datum(), vec.Nulls()
@@ -1618,7 +1618,7 @@ func (a *minDatumWindowAgg) Compute(
 					{
 						var cmpResult int
 
-						cmpResult = candidate.(*coldataext.Datum).CompareDatum(col, a.curAgg)
+						cmpResult = coldataext.CompareDatum(candidate, col, a.curAgg)
 
 						cmp = cmpResult < 0
 					}
@@ -1646,7 +1646,7 @@ func (a *minDatumWindowAgg) Compute(
 					{
 						var cmpResult int
 
-						cmpResult = candidate.(*coldataext.Datum).CompareDatum(col, a.curAgg)
+						cmpResult = coldataext.CompareDatum(candidate, col, a.curAgg)
 
 						cmp = cmpResult < 0
 					}
@@ -1661,7 +1661,7 @@ func (a *minDatumWindowAgg) Compute(
 
 	var newCurAggSize uintptr
 	if a.curAgg != nil {
-		newCurAggSize = a.curAgg.(*coldataext.Datum).Size()
+		newCurAggSize = a.curAgg.(tree.Datum).Size()
 	}
 	if newCurAggSize != oldCurAggSize {
 		a.allocator.AdjustMemoryUsage(int64(newCurAggSize - oldCurAggSize))
@@ -1680,7 +1680,7 @@ func (a *minDatumWindowAgg) Flush(outputIdx int) {
 
 	var oldCurAggSize uintptr
 	if a.curAgg != nil {
-		oldCurAggSize = a.curAgg.(*coldataext.Datum).Size()
+		oldCurAggSize = a.curAgg.(tree.Datum).Size()
 	}
 	// Release the reference to curAgg eagerly.
 	a.allocator.AdjustMemoryUsage(-int64(oldCurAggSize))
@@ -3264,7 +3264,7 @@ func (a *maxDatumWindowAgg) Compute(
 
 	var oldCurAggSize uintptr
 	if a.curAgg != nil {
-		oldCurAggSize = a.curAgg.(*coldataext.Datum).Size()
+		oldCurAggSize = a.curAgg.(tree.Datum).Size()
 	}
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Datum(), vec.Nulls()
@@ -3289,7 +3289,7 @@ func (a *maxDatumWindowAgg) Compute(
 					{
 						var cmpResult int
 
-						cmpResult = candidate.(*coldataext.Datum).CompareDatum(col, a.curAgg)
+						cmpResult = coldataext.CompareDatum(candidate, col, a.curAgg)
 
 						cmp = cmpResult > 0
 					}
@@ -3317,7 +3317,7 @@ func (a *maxDatumWindowAgg) Compute(
 					{
 						var cmpResult int
 
-						cmpResult = candidate.(*coldataext.Datum).CompareDatum(col, a.curAgg)
+						cmpResult = coldataext.CompareDatum(candidate, col, a.curAgg)
 
 						cmp = cmpResult > 0
 					}
@@ -3332,7 +3332,7 @@ func (a *maxDatumWindowAgg) Compute(
 
 	var newCurAggSize uintptr
 	if a.curAgg != nil {
-		newCurAggSize = a.curAgg.(*coldataext.Datum).Size()
+		newCurAggSize = a.curAgg.(tree.Datum).Size()
 	}
 	if newCurAggSize != oldCurAggSize {
 		a.allocator.AdjustMemoryUsage(int64(newCurAggSize - oldCurAggSize))
@@ -3351,7 +3351,7 @@ func (a *maxDatumWindowAgg) Flush(outputIdx int) {
 
 	var oldCurAggSize uintptr
 	if a.curAgg != nil {
-		oldCurAggSize = a.curAgg.(*coldataext.Datum).Size()
+		oldCurAggSize = a.curAgg.(tree.Datum).Size()
 	}
 	// Release the reference to curAgg eagerly.
 	a.allocator.AdjustMemoryUsage(-int64(oldCurAggSize))

--- a/pkg/sql/colexec/colexecbase/cast.eg.go
+++ b/pkg/sql/colexec/colexecbase/cast.eg.go
@@ -75,6 +75,7 @@ func GetCastOperator(
 	resultIdx int,
 	fromType *types.T,
 	toType *types.T,
+	evalCtx *tree.EvalContext,
 ) (colexecop.Operator, error) {
 	input = colexecutils.NewVectorTypeEnforcer(allocator, input, toType, resultIdx)
 	base := castOpBase{
@@ -82,6 +83,7 @@ func GetCastOperator(
 		allocator:                allocator,
 		colIdx:                   colIdx,
 		outputIdx:                resultIdx,
+		evalCtx:                  evalCtx,
 	}
 	if fromType.Family() == types.UnknownFamily {
 		return &castOpNullAny{castOpBase: base}, nil
@@ -816,6 +818,7 @@ type castOpBase struct {
 	allocator *colmem.Allocator
 	colIdx    int
 	outputIdx int
+	evalCtx   *tree.EvalContext
 }
 
 func (c *castOpBase) Reset(ctx context.Context) {
@@ -943,12 +946,13 @@ func (c *castNativeToDatumOp) Next() coldata.Batch {
 			if inputVec.Nulls().MaybeHasNulls() {
 				for scratchIdx, outputIdx := range sel[:n] {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
 						converted := scratch[scratchIdx]
 						if true && converted == tree.DNull {
 							outputNulls.SetNull(outputIdx)
 							continue
 						}
-						res, err := coldataext.PerformCast(outputCol, converted, toType)
+						res, err := tree.PerformCast(evalCtx, converted, toType)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -958,12 +962,13 @@ func (c *castNativeToDatumOp) Next() coldata.Batch {
 			} else {
 				for scratchIdx, outputIdx := range sel[:n] {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
 						converted := scratch[scratchIdx]
 						if false && converted == tree.DNull {
 							outputNulls.SetNull(outputIdx)
 							continue
 						}
-						res, err := coldataext.PerformCast(outputCol, converted, toType)
+						res, err := tree.PerformCast(evalCtx, converted, toType)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -977,8 +982,9 @@ func (c *castNativeToDatumOp) Next() coldata.Batch {
 				for idx := 0; idx < n; idx++ {
 					{
 						var (
-							scratchIdx int = idx
-							outputIdx  int = idx
+							scratchIdx int               = idx
+							outputIdx  int               = idx
+							evalCtx    *tree.EvalContext = c.evalCtx
 						)
 						//gcassert:bce
 						converted := scratch[scratchIdx]
@@ -986,7 +992,7 @@ func (c *castNativeToDatumOp) Next() coldata.Batch {
 							outputNulls.SetNull(outputIdx)
 							continue
 						}
-						res, err := coldataext.PerformCast(outputCol, converted, toType)
+						res, err := tree.PerformCast(evalCtx, converted, toType)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -997,8 +1003,9 @@ func (c *castNativeToDatumOp) Next() coldata.Batch {
 				for idx := 0; idx < n; idx++ {
 					{
 						var (
-							scratchIdx int = idx
-							outputIdx  int = idx
+							scratchIdx int               = idx
+							outputIdx  int               = idx
+							evalCtx    *tree.EvalContext = c.evalCtx
 						)
 						//gcassert:bce
 						converted := scratch[scratchIdx]
@@ -1006,7 +1013,7 @@ func (c *castNativeToDatumOp) Next() coldata.Batch {
 							outputNulls.SetNull(outputIdx)
 							continue
 						}
-						res, err := coldataext.PerformCast(outputCol, converted, toType)
+						res, err := tree.PerformCast(evalCtx, converted, toType)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -1054,6 +1061,9 @@ func (c *castBoolFloatOp) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -1073,6 +1083,9 @@ func (c *castBoolFloatOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -1101,6 +1114,9 @@ func (c *castBoolFloatOp) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -1120,6 +1136,9 @@ func (c *castBoolFloatOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -1178,6 +1197,9 @@ func (c *castBoolInt2Op) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -1197,6 +1219,9 @@ func (c *castBoolInt2Op) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -1225,6 +1250,9 @@ func (c *castBoolInt2Op) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -1244,6 +1272,9 @@ func (c *castBoolInt2Op) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -1302,6 +1333,9 @@ func (c *castBoolInt4Op) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -1321,6 +1355,9 @@ func (c *castBoolInt4Op) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -1349,6 +1386,9 @@ func (c *castBoolInt4Op) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -1368,6 +1408,9 @@ func (c *castBoolInt4Op) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -1426,6 +1469,9 @@ func (c *castBoolIntOp) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -1445,6 +1491,9 @@ func (c *castBoolIntOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -1473,6 +1522,9 @@ func (c *castBoolIntOp) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -1492,6 +1544,9 @@ func (c *castBoolIntOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -1550,6 +1605,9 @@ func (c *castDecimalBoolOp) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -1564,6 +1622,9 @@ func (c *castDecimalBoolOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -1587,6 +1648,9 @@ func (c *castDecimalBoolOp) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -1601,6 +1665,9 @@ func (c *castDecimalBoolOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -1659,6 +1726,9 @@ func (c *castDecimalInt2Op) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -1692,6 +1762,9 @@ func (c *castDecimalInt2Op) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -1734,6 +1807,9 @@ func (c *castDecimalInt2Op) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -1767,6 +1843,9 @@ func (c *castDecimalInt2Op) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -1844,6 +1923,9 @@ func (c *castDecimalInt4Op) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -1877,6 +1959,9 @@ func (c *castDecimalInt4Op) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -1919,6 +2004,9 @@ func (c *castDecimalInt4Op) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -1952,6 +2040,9 @@ func (c *castDecimalInt4Op) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -2029,6 +2120,9 @@ func (c *castDecimalIntOp) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -2056,6 +2150,9 @@ func (c *castDecimalIntOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -2092,6 +2189,9 @@ func (c *castDecimalIntOp) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -2119,6 +2219,9 @@ func (c *castDecimalIntOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -2185,6 +2288,9 @@ func (c *castDecimalFloatOp) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -2207,6 +2313,9 @@ func (c *castDecimalFloatOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -2238,6 +2347,9 @@ func (c *castDecimalFloatOp) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -2260,6 +2372,9 @@ func (c *castDecimalFloatOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -2321,6 +2436,9 @@ func (c *castDecimalDecimalOp) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -2340,6 +2458,9 @@ func (c *castDecimalDecimalOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -2368,6 +2489,9 @@ func (c *castDecimalDecimalOp) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -2387,6 +2511,9 @@ func (c *castDecimalDecimalOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -2445,6 +2572,9 @@ func (c *castInt2Int4Op) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -2459,6 +2589,9 @@ func (c *castInt2Int4Op) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -2482,6 +2615,9 @@ func (c *castInt2Int4Op) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -2496,6 +2632,9 @@ func (c *castInt2Int4Op) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -2549,6 +2688,9 @@ func (c *castInt2IntOp) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -2563,6 +2705,9 @@ func (c *castInt2IntOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -2586,6 +2731,9 @@ func (c *castInt2IntOp) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -2600,6 +2748,9 @@ func (c *castInt2IntOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -2653,6 +2804,9 @@ func (c *castInt2BoolOp) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -2669,6 +2823,9 @@ func (c *castInt2BoolOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -2694,6 +2851,9 @@ func (c *castInt2BoolOp) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -2710,6 +2870,9 @@ func (c *castInt2BoolOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -2765,6 +2928,9 @@ func (c *castInt2DecimalOp) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -2785,6 +2951,9 @@ func (c *castInt2DecimalOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -2814,6 +2983,9 @@ func (c *castInt2DecimalOp) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -2834,6 +3006,9 @@ func (c *castInt2DecimalOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -2893,6 +3068,9 @@ func (c *castInt2FloatOp) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -2909,6 +3087,9 @@ func (c *castInt2FloatOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -2934,6 +3115,9 @@ func (c *castInt2FloatOp) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -2950,6 +3134,9 @@ func (c *castInt2FloatOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -3005,6 +3192,9 @@ func (c *castInt4Int2Op) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -3025,6 +3215,9 @@ func (c *castInt4Int2Op) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -3054,6 +3247,9 @@ func (c *castInt4Int2Op) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -3074,6 +3270,9 @@ func (c *castInt4Int2Op) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -3133,6 +3332,9 @@ func (c *castInt4IntOp) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -3147,6 +3349,9 @@ func (c *castInt4IntOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -3170,6 +3375,9 @@ func (c *castInt4IntOp) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -3184,6 +3392,9 @@ func (c *castInt4IntOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -3237,6 +3448,9 @@ func (c *castInt4BoolOp) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -3253,6 +3467,9 @@ func (c *castInt4BoolOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -3278,6 +3495,9 @@ func (c *castInt4BoolOp) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -3294,6 +3514,9 @@ func (c *castInt4BoolOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -3349,6 +3572,9 @@ func (c *castInt4DecimalOp) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -3369,6 +3595,9 @@ func (c *castInt4DecimalOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -3398,6 +3627,9 @@ func (c *castInt4DecimalOp) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -3418,6 +3650,9 @@ func (c *castInt4DecimalOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -3477,6 +3712,9 @@ func (c *castInt4FloatOp) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -3493,6 +3731,9 @@ func (c *castInt4FloatOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -3518,6 +3759,9 @@ func (c *castInt4FloatOp) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -3534,6 +3778,9 @@ func (c *castInt4FloatOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -3589,6 +3836,9 @@ func (c *castIntInt2Op) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -3609,6 +3859,9 @@ func (c *castIntInt2Op) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -3638,6 +3891,9 @@ func (c *castIntInt2Op) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -3658,6 +3914,9 @@ func (c *castIntInt2Op) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -3717,6 +3976,9 @@ func (c *castIntInt4Op) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -3737,6 +3999,9 @@ func (c *castIntInt4Op) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -3766,6 +4031,9 @@ func (c *castIntInt4Op) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -3786,6 +4054,9 @@ func (c *castIntInt4Op) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -3845,6 +4116,9 @@ func (c *castIntBoolOp) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -3861,6 +4135,9 @@ func (c *castIntBoolOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -3886,6 +4163,9 @@ func (c *castIntBoolOp) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -3902,6 +4182,9 @@ func (c *castIntBoolOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -3957,6 +4240,9 @@ func (c *castIntDecimalOp) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -3977,6 +4263,9 @@ func (c *castIntDecimalOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -4006,6 +4295,9 @@ func (c *castIntDecimalOp) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -4026,6 +4318,9 @@ func (c *castIntDecimalOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -4085,6 +4380,9 @@ func (c *castIntFloatOp) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -4101,6 +4399,9 @@ func (c *castIntFloatOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -4126,6 +4427,9 @@ func (c *castIntFloatOp) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -4142,6 +4446,9 @@ func (c *castIntFloatOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -4197,6 +4504,9 @@ func (c *castFloatBoolOp) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -4213,6 +4523,9 @@ func (c *castFloatBoolOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -4238,6 +4551,9 @@ func (c *castFloatBoolOp) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -4254,6 +4570,9 @@ func (c *castFloatBoolOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -4309,6 +4628,9 @@ func (c *castFloatDecimalOp) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -4331,6 +4653,9 @@ func (c *castFloatDecimalOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -4362,6 +4687,9 @@ func (c *castFloatDecimalOp) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -4384,6 +4712,9 @@ func (c *castFloatDecimalOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -4445,6 +4776,9 @@ func (c *castFloatInt2Op) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -4464,6 +4798,9 @@ func (c *castFloatInt2Op) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -4492,6 +4829,9 @@ func (c *castFloatInt2Op) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -4511,6 +4851,9 @@ func (c *castFloatInt2Op) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -4569,6 +4912,9 @@ func (c *castFloatInt4Op) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -4588,6 +4934,9 @@ func (c *castFloatInt4Op) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -4616,6 +4965,9 @@ func (c *castFloatInt4Op) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -4635,6 +4987,9 @@ func (c *castFloatInt4Op) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -4693,6 +5048,9 @@ func (c *castFloatIntOp) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -4712,6 +5070,9 @@ func (c *castFloatIntOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -4740,6 +5101,9 @@ func (c *castFloatIntOp) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -4759,6 +5123,9 @@ func (c *castFloatIntOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -4817,6 +5184,9 @@ func (c *castDateInt2Op) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -4837,6 +5207,9 @@ func (c *castDateInt2Op) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -4866,6 +5239,9 @@ func (c *castDateInt2Op) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -4886,6 +5262,9 @@ func (c *castDateInt2Op) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -4945,6 +5324,9 @@ func (c *castDateInt4Op) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -4965,6 +5347,9 @@ func (c *castDateInt4Op) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -4994,6 +5379,9 @@ func (c *castDateInt4Op) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -5014,6 +5402,9 @@ func (c *castDateInt4Op) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -5073,6 +5464,9 @@ func (c *castDateIntOp) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -5087,6 +5481,9 @@ func (c *castDateIntOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -5110,6 +5507,9 @@ func (c *castDateIntOp) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -5124,6 +5524,9 @@ func (c *castDateIntOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -5177,6 +5580,9 @@ func (c *castDateFloatOp) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -5193,6 +5599,9 @@ func (c *castDateFloatOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -5218,6 +5627,9 @@ func (c *castDateFloatOp) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -5234,6 +5646,9 @@ func (c *castDateFloatOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -5289,6 +5704,9 @@ func (c *castDateDecimalOp) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -5309,6 +5727,9 @@ func (c *castDateDecimalOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -5338,6 +5759,9 @@ func (c *castDateDecimalOp) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -5358,6 +5782,9 @@ func (c *castDateDecimalOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = inputCol.Get(n - 1)
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
@@ -5417,6 +5844,9 @@ func (c *castBytesUuidOp) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -5437,6 +5867,9 @@ func (c *castBytesUuidOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = i
@@ -5462,6 +5895,9 @@ func (c *castBytesUuidOp) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -5482,6 +5918,9 @@ func (c *castBytesUuidOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = i
@@ -5537,6 +5976,9 @@ func (c *castStringBoolOp) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -5557,6 +5999,9 @@ func (c *castStringBoolOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
 						for i := 0; i < n; i++ {
@@ -5584,6 +6029,9 @@ func (c *castStringBoolOp) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -5604,6 +6052,9 @@ func (c *castStringBoolOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
 						for i := 0; i < n; i++ {
@@ -5661,6 +6112,9 @@ func (c *castStringBytesOp) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -5681,6 +6135,9 @@ func (c *castStringBytesOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = i
@@ -5706,6 +6163,9 @@ func (c *castStringBytesOp) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -5726,6 +6186,9 @@ func (c *castStringBytesOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = i
@@ -5781,6 +6244,9 @@ func (c *castStringStringOp) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -5821,6 +6287,9 @@ func (c *castStringStringOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = i
@@ -5866,6 +6335,9 @@ func (c *castStringStringOp) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -5906,6 +6378,9 @@ func (c *castStringStringOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = i
@@ -5981,6 +6456,9 @@ func (c *castStringUuidOp) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -6001,6 +6479,9 @@ func (c *castStringUuidOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = i
@@ -6026,6 +6507,9 @@ func (c *castStringUuidOp) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -6046,6 +6530,9 @@ func (c *castStringUuidOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = i
@@ -6101,6 +6588,9 @@ func (c *castJsonbStringOp) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -6126,6 +6616,9 @@ func (c *castJsonbStringOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = i
@@ -6156,6 +6649,9 @@ func (c *castJsonbStringOp) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -6181,6 +6677,9 @@ func (c *castJsonbStringOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = i
@@ -6242,6 +6741,9 @@ func (c *castDatumBoolOp) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -6252,7 +6754,7 @@ func (c *castDatumBoolOp) Next() coldata.Batch {
 							var r bool
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -6264,6 +6766,9 @@ func (c *castDatumBoolOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
 						for i := 0; i < n; i++ {
@@ -6275,7 +6780,7 @@ func (c *castDatumBoolOp) Next() coldata.Batch {
 							var r bool
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -6293,6 +6798,9 @@ func (c *castDatumBoolOp) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -6303,7 +6811,7 @@ func (c *castDatumBoolOp) Next() coldata.Batch {
 							var r bool
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -6315,6 +6823,9 @@ func (c *castDatumBoolOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
 						for i := 0; i < n; i++ {
@@ -6326,7 +6837,7 @@ func (c *castDatumBoolOp) Next() coldata.Batch {
 							var r bool
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -6375,6 +6886,9 @@ func (c *castDatumInt2Op) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -6385,7 +6899,7 @@ func (c *castDatumInt2Op) Next() coldata.Batch {
 							var r int16
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -6397,6 +6911,9 @@ func (c *castDatumInt2Op) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
 						for i := 0; i < n; i++ {
@@ -6408,7 +6925,7 @@ func (c *castDatumInt2Op) Next() coldata.Batch {
 							var r int16
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -6426,6 +6943,9 @@ func (c *castDatumInt2Op) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -6436,7 +6956,7 @@ func (c *castDatumInt2Op) Next() coldata.Batch {
 							var r int16
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -6448,6 +6968,9 @@ func (c *castDatumInt2Op) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
 						for i := 0; i < n; i++ {
@@ -6459,7 +6982,7 @@ func (c *castDatumInt2Op) Next() coldata.Batch {
 							var r int16
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -6508,6 +7031,9 @@ func (c *castDatumInt4Op) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -6518,7 +7044,7 @@ func (c *castDatumInt4Op) Next() coldata.Batch {
 							var r int32
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -6530,6 +7056,9 @@ func (c *castDatumInt4Op) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
 						for i := 0; i < n; i++ {
@@ -6541,7 +7070,7 @@ func (c *castDatumInt4Op) Next() coldata.Batch {
 							var r int32
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -6559,6 +7088,9 @@ func (c *castDatumInt4Op) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -6569,7 +7101,7 @@ func (c *castDatumInt4Op) Next() coldata.Batch {
 							var r int32
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -6581,6 +7113,9 @@ func (c *castDatumInt4Op) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
 						for i := 0; i < n; i++ {
@@ -6592,7 +7127,7 @@ func (c *castDatumInt4Op) Next() coldata.Batch {
 							var r int32
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -6641,6 +7176,9 @@ func (c *castDatumIntOp) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -6651,7 +7189,7 @@ func (c *castDatumIntOp) Next() coldata.Batch {
 							var r int64
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -6663,6 +7201,9 @@ func (c *castDatumIntOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
 						for i := 0; i < n; i++ {
@@ -6674,7 +7215,7 @@ func (c *castDatumIntOp) Next() coldata.Batch {
 							var r int64
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -6692,6 +7233,9 @@ func (c *castDatumIntOp) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -6702,7 +7246,7 @@ func (c *castDatumIntOp) Next() coldata.Batch {
 							var r int64
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -6714,6 +7258,9 @@ func (c *castDatumIntOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
 						for i := 0; i < n; i++ {
@@ -6725,7 +7272,7 @@ func (c *castDatumIntOp) Next() coldata.Batch {
 							var r int64
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -6774,6 +7321,9 @@ func (c *castDatumFloatOp) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -6784,7 +7334,7 @@ func (c *castDatumFloatOp) Next() coldata.Batch {
 							var r float64
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -6796,6 +7346,9 @@ func (c *castDatumFloatOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
 						for i := 0; i < n; i++ {
@@ -6807,7 +7360,7 @@ func (c *castDatumFloatOp) Next() coldata.Batch {
 							var r float64
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -6825,6 +7378,9 @@ func (c *castDatumFloatOp) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -6835,7 +7391,7 @@ func (c *castDatumFloatOp) Next() coldata.Batch {
 							var r float64
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -6847,6 +7403,9 @@ func (c *castDatumFloatOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
 						for i := 0; i < n; i++ {
@@ -6858,7 +7417,7 @@ func (c *castDatumFloatOp) Next() coldata.Batch {
 							var r float64
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -6907,6 +7466,9 @@ func (c *castDatumDecimalOp) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -6917,7 +7479,7 @@ func (c *castDatumDecimalOp) Next() coldata.Batch {
 							var r apd.Decimal
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -6929,6 +7491,9 @@ func (c *castDatumDecimalOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
 						for i := 0; i < n; i++ {
@@ -6940,7 +7505,7 @@ func (c *castDatumDecimalOp) Next() coldata.Batch {
 							var r apd.Decimal
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -6958,6 +7523,9 @@ func (c *castDatumDecimalOp) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -6968,7 +7536,7 @@ func (c *castDatumDecimalOp) Next() coldata.Batch {
 							var r apd.Decimal
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -6980,6 +7548,9 @@ func (c *castDatumDecimalOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
 						for i := 0; i < n; i++ {
@@ -6991,7 +7562,7 @@ func (c *castDatumDecimalOp) Next() coldata.Batch {
 							var r apd.Decimal
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7040,6 +7611,9 @@ func (c *castDatumDateOp) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -7050,7 +7624,7 @@ func (c *castDatumDateOp) Next() coldata.Batch {
 							var r int64
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7062,6 +7636,9 @@ func (c *castDatumDateOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
 						for i := 0; i < n; i++ {
@@ -7073,7 +7650,7 @@ func (c *castDatumDateOp) Next() coldata.Batch {
 							var r int64
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7091,6 +7668,9 @@ func (c *castDatumDateOp) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -7101,7 +7681,7 @@ func (c *castDatumDateOp) Next() coldata.Batch {
 							var r int64
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7113,6 +7693,9 @@ func (c *castDatumDateOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
 						for i := 0; i < n; i++ {
@@ -7124,7 +7707,7 @@ func (c *castDatumDateOp) Next() coldata.Batch {
 							var r int64
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7173,6 +7756,9 @@ func (c *castDatumTimestampOp) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -7183,7 +7769,7 @@ func (c *castDatumTimestampOp) Next() coldata.Batch {
 							var r time.Time
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7195,6 +7781,9 @@ func (c *castDatumTimestampOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
 						for i := 0; i < n; i++ {
@@ -7206,7 +7795,7 @@ func (c *castDatumTimestampOp) Next() coldata.Batch {
 							var r time.Time
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7224,6 +7813,9 @@ func (c *castDatumTimestampOp) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -7234,7 +7826,7 @@ func (c *castDatumTimestampOp) Next() coldata.Batch {
 							var r time.Time
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7246,6 +7838,9 @@ func (c *castDatumTimestampOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
 						for i := 0; i < n; i++ {
@@ -7257,7 +7852,7 @@ func (c *castDatumTimestampOp) Next() coldata.Batch {
 							var r time.Time
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7306,6 +7901,9 @@ func (c *castDatumIntervalOp) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -7316,7 +7914,7 @@ func (c *castDatumIntervalOp) Next() coldata.Batch {
 							var r duration.Duration
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7328,6 +7926,9 @@ func (c *castDatumIntervalOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
 						for i := 0; i < n; i++ {
@@ -7339,7 +7940,7 @@ func (c *castDatumIntervalOp) Next() coldata.Batch {
 							var r duration.Duration
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7357,6 +7958,9 @@ func (c *castDatumIntervalOp) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -7367,7 +7971,7 @@ func (c *castDatumIntervalOp) Next() coldata.Batch {
 							var r duration.Duration
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7379,6 +7983,9 @@ func (c *castDatumIntervalOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
 						for i := 0; i < n; i++ {
@@ -7390,7 +7997,7 @@ func (c *castDatumIntervalOp) Next() coldata.Batch {
 							var r duration.Duration
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7439,6 +8046,9 @@ func (c *castDatumStringOp) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -7449,7 +8059,7 @@ func (c *castDatumStringOp) Next() coldata.Batch {
 							var r []byte
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7461,6 +8071,9 @@ func (c *castDatumStringOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = i
@@ -7471,7 +8084,7 @@ func (c *castDatumStringOp) Next() coldata.Batch {
 							var r []byte
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7488,6 +8101,9 @@ func (c *castDatumStringOp) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -7498,7 +8114,7 @@ func (c *castDatumStringOp) Next() coldata.Batch {
 							var r []byte
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7510,6 +8126,9 @@ func (c *castDatumStringOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = i
@@ -7520,7 +8139,7 @@ func (c *castDatumStringOp) Next() coldata.Batch {
 							var r []byte
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7568,6 +8187,9 @@ func (c *castDatumBytesOp) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -7578,7 +8200,7 @@ func (c *castDatumBytesOp) Next() coldata.Batch {
 							var r []byte
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7590,6 +8212,9 @@ func (c *castDatumBytesOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = i
@@ -7600,7 +8225,7 @@ func (c *castDatumBytesOp) Next() coldata.Batch {
 							var r []byte
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7617,6 +8242,9 @@ func (c *castDatumBytesOp) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -7627,7 +8255,7 @@ func (c *castDatumBytesOp) Next() coldata.Batch {
 							var r []byte
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7639,6 +8267,9 @@ func (c *castDatumBytesOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = i
@@ -7649,7 +8280,7 @@ func (c *castDatumBytesOp) Next() coldata.Batch {
 							var r []byte
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7697,6 +8328,9 @@ func (c *castDatumTimestamptzOp) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -7707,7 +8341,7 @@ func (c *castDatumTimestamptzOp) Next() coldata.Batch {
 							var r time.Time
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7719,6 +8353,9 @@ func (c *castDatumTimestamptzOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
 						for i := 0; i < n; i++ {
@@ -7730,7 +8367,7 @@ func (c *castDatumTimestamptzOp) Next() coldata.Batch {
 							var r time.Time
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7748,6 +8385,9 @@ func (c *castDatumTimestamptzOp) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -7758,7 +8398,7 @@ func (c *castDatumTimestamptzOp) Next() coldata.Batch {
 							var r time.Time
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7770,6 +8410,9 @@ func (c *castDatumTimestamptzOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						_ = outputCol.Get(n - 1)
 						var tupleIdx int
 						for i := 0; i < n; i++ {
@@ -7781,7 +8424,7 @@ func (c *castDatumTimestamptzOp) Next() coldata.Batch {
 							var r time.Time
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7830,6 +8473,9 @@ func (c *castDatumUuidOp) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -7840,7 +8486,7 @@ func (c *castDatumUuidOp) Next() coldata.Batch {
 							var r []byte
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7852,6 +8498,9 @@ func (c *castDatumUuidOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = i
@@ -7862,7 +8511,7 @@ func (c *castDatumUuidOp) Next() coldata.Batch {
 							var r []byte
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7879,6 +8528,9 @@ func (c *castDatumUuidOp) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -7889,7 +8541,7 @@ func (c *castDatumUuidOp) Next() coldata.Batch {
 							var r []byte
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7901,6 +8553,9 @@ func (c *castDatumUuidOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = i
@@ -7911,7 +8566,7 @@ func (c *castDatumUuidOp) Next() coldata.Batch {
 							var r []byte
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7959,6 +8614,9 @@ func (c *castDatumJsonbOp) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -7969,7 +8627,7 @@ func (c *castDatumJsonbOp) Next() coldata.Batch {
 							var r json.JSON
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7981,6 +8639,9 @@ func (c *castDatumJsonbOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = i
@@ -7991,7 +8652,7 @@ func (c *castDatumJsonbOp) Next() coldata.Batch {
 							var r json.JSON
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -8008,6 +8669,9 @@ func (c *castDatumJsonbOp) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -8018,7 +8682,7 @@ func (c *castDatumJsonbOp) Next() coldata.Batch {
 							var r json.JSON
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -8030,6 +8694,9 @@ func (c *castDatumJsonbOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = i
@@ -8040,7 +8707,7 @@ func (c *castDatumJsonbOp) Next() coldata.Batch {
 							var r json.JSON
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -8087,6 +8754,9 @@ func (c *castDatumDatumOp) Next() coldata.Batch {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -8097,7 +8767,7 @@ func (c *castDatumDatumOp) Next() coldata.Batch {
 							var r interface{}
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -8115,6 +8785,9 @@ func (c *castDatumDatumOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = i
@@ -8125,7 +8798,7 @@ func (c *castDatumDatumOp) Next() coldata.Batch {
 							var r interface{}
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -8148,6 +8821,9 @@ func (c *castDatumDatumOp) Next() coldata.Batch {
 				outputNulls.UnsetNulls()
 				if sel != nil {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = sel[i]
@@ -8158,7 +8834,7 @@ func (c *castDatumDatumOp) Next() coldata.Batch {
 							var r interface{}
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -8176,6 +8852,9 @@ func (c *castDatumDatumOp) Next() coldata.Batch {
 					}
 				} else {
 					{
+						var evalCtx *tree.EvalContext = c.evalCtx
+						// Silence unused warning.
+						_ = evalCtx
 						var tupleIdx int
 						for i := 0; i < n; i++ {
 							tupleIdx = i
@@ -8186,7 +8865,7 @@ func (c *castDatumDatumOp) Next() coldata.Batch {
 							var r interface{}
 
 							{
-								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}

--- a/pkg/sql/colexec/colexecbase/cast.eg.go
+++ b/pkg/sql/colexec/colexecbase/cast.eg.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/cockroachdb/apd/v2"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
-	"github.com/cockroachdb/cockroach/pkg/col/coldataext"
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecutils"
@@ -42,7 +41,6 @@ import (
 // Workaround for bazel auto-generated code. goimports does not automatically
 // pick up the right packages when run within the bazel sandbox.
 var (
-	_ coldataext.Datum
 	_ duration.Duration
 	_ json.JSON
 	_ = lex.DecodeRawBytesToByteArrayAuto
@@ -6754,7 +6752,7 @@ func (c *castDatumBoolOp) Next() coldata.Batch {
 							var r bool
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -6780,7 +6778,7 @@ func (c *castDatumBoolOp) Next() coldata.Batch {
 							var r bool
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -6811,7 +6809,7 @@ func (c *castDatumBoolOp) Next() coldata.Batch {
 							var r bool
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -6837,7 +6835,7 @@ func (c *castDatumBoolOp) Next() coldata.Batch {
 							var r bool
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -6899,7 +6897,7 @@ func (c *castDatumInt2Op) Next() coldata.Batch {
 							var r int16
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -6925,7 +6923,7 @@ func (c *castDatumInt2Op) Next() coldata.Batch {
 							var r int16
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -6956,7 +6954,7 @@ func (c *castDatumInt2Op) Next() coldata.Batch {
 							var r int16
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -6982,7 +6980,7 @@ func (c *castDatumInt2Op) Next() coldata.Batch {
 							var r int16
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7044,7 +7042,7 @@ func (c *castDatumInt4Op) Next() coldata.Batch {
 							var r int32
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7070,7 +7068,7 @@ func (c *castDatumInt4Op) Next() coldata.Batch {
 							var r int32
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7101,7 +7099,7 @@ func (c *castDatumInt4Op) Next() coldata.Batch {
 							var r int32
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7127,7 +7125,7 @@ func (c *castDatumInt4Op) Next() coldata.Batch {
 							var r int32
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7189,7 +7187,7 @@ func (c *castDatumIntOp) Next() coldata.Batch {
 							var r int64
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7215,7 +7213,7 @@ func (c *castDatumIntOp) Next() coldata.Batch {
 							var r int64
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7246,7 +7244,7 @@ func (c *castDatumIntOp) Next() coldata.Batch {
 							var r int64
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7272,7 +7270,7 @@ func (c *castDatumIntOp) Next() coldata.Batch {
 							var r int64
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7334,7 +7332,7 @@ func (c *castDatumFloatOp) Next() coldata.Batch {
 							var r float64
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7360,7 +7358,7 @@ func (c *castDatumFloatOp) Next() coldata.Batch {
 							var r float64
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7391,7 +7389,7 @@ func (c *castDatumFloatOp) Next() coldata.Batch {
 							var r float64
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7417,7 +7415,7 @@ func (c *castDatumFloatOp) Next() coldata.Batch {
 							var r float64
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7479,7 +7477,7 @@ func (c *castDatumDecimalOp) Next() coldata.Batch {
 							var r apd.Decimal
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7505,7 +7503,7 @@ func (c *castDatumDecimalOp) Next() coldata.Batch {
 							var r apd.Decimal
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7536,7 +7534,7 @@ func (c *castDatumDecimalOp) Next() coldata.Batch {
 							var r apd.Decimal
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7562,7 +7560,7 @@ func (c *castDatumDecimalOp) Next() coldata.Batch {
 							var r apd.Decimal
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7624,7 +7622,7 @@ func (c *castDatumDateOp) Next() coldata.Batch {
 							var r int64
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7650,7 +7648,7 @@ func (c *castDatumDateOp) Next() coldata.Batch {
 							var r int64
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7681,7 +7679,7 @@ func (c *castDatumDateOp) Next() coldata.Batch {
 							var r int64
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7707,7 +7705,7 @@ func (c *castDatumDateOp) Next() coldata.Batch {
 							var r int64
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7769,7 +7767,7 @@ func (c *castDatumTimestampOp) Next() coldata.Batch {
 							var r time.Time
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7795,7 +7793,7 @@ func (c *castDatumTimestampOp) Next() coldata.Batch {
 							var r time.Time
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7826,7 +7824,7 @@ func (c *castDatumTimestampOp) Next() coldata.Batch {
 							var r time.Time
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7852,7 +7850,7 @@ func (c *castDatumTimestampOp) Next() coldata.Batch {
 							var r time.Time
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7914,7 +7912,7 @@ func (c *castDatumIntervalOp) Next() coldata.Batch {
 							var r duration.Duration
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7940,7 +7938,7 @@ func (c *castDatumIntervalOp) Next() coldata.Batch {
 							var r duration.Duration
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7971,7 +7969,7 @@ func (c *castDatumIntervalOp) Next() coldata.Batch {
 							var r duration.Duration
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -7997,7 +7995,7 @@ func (c *castDatumIntervalOp) Next() coldata.Batch {
 							var r duration.Duration
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -8059,7 +8057,7 @@ func (c *castDatumStringOp) Next() coldata.Batch {
 							var r []byte
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -8084,7 +8082,7 @@ func (c *castDatumStringOp) Next() coldata.Batch {
 							var r []byte
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -8114,7 +8112,7 @@ func (c *castDatumStringOp) Next() coldata.Batch {
 							var r []byte
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -8139,7 +8137,7 @@ func (c *castDatumStringOp) Next() coldata.Batch {
 							var r []byte
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -8200,7 +8198,7 @@ func (c *castDatumBytesOp) Next() coldata.Batch {
 							var r []byte
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -8225,7 +8223,7 @@ func (c *castDatumBytesOp) Next() coldata.Batch {
 							var r []byte
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -8255,7 +8253,7 @@ func (c *castDatumBytesOp) Next() coldata.Batch {
 							var r []byte
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -8280,7 +8278,7 @@ func (c *castDatumBytesOp) Next() coldata.Batch {
 							var r []byte
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -8341,7 +8339,7 @@ func (c *castDatumTimestamptzOp) Next() coldata.Batch {
 							var r time.Time
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -8367,7 +8365,7 @@ func (c *castDatumTimestamptzOp) Next() coldata.Batch {
 							var r time.Time
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -8398,7 +8396,7 @@ func (c *castDatumTimestamptzOp) Next() coldata.Batch {
 							var r time.Time
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -8424,7 +8422,7 @@ func (c *castDatumTimestamptzOp) Next() coldata.Batch {
 							var r time.Time
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -8486,7 +8484,7 @@ func (c *castDatumUuidOp) Next() coldata.Batch {
 							var r []byte
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -8511,7 +8509,7 @@ func (c *castDatumUuidOp) Next() coldata.Batch {
 							var r []byte
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -8541,7 +8539,7 @@ func (c *castDatumUuidOp) Next() coldata.Batch {
 							var r []byte
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -8566,7 +8564,7 @@ func (c *castDatumUuidOp) Next() coldata.Batch {
 							var r []byte
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -8627,7 +8625,7 @@ func (c *castDatumJsonbOp) Next() coldata.Batch {
 							var r json.JSON
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -8652,7 +8650,7 @@ func (c *castDatumJsonbOp) Next() coldata.Batch {
 							var r json.JSON
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -8682,7 +8680,7 @@ func (c *castDatumJsonbOp) Next() coldata.Batch {
 							var r json.JSON
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -8707,7 +8705,7 @@ func (c *castDatumJsonbOp) Next() coldata.Batch {
 							var r json.JSON
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -8767,7 +8765,7 @@ func (c *castDatumDatumOp) Next() coldata.Batch {
 							var r interface{}
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -8798,7 +8796,7 @@ func (c *castDatumDatumOp) Next() coldata.Batch {
 							var r interface{}
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -8834,7 +8832,7 @@ func (c *castDatumDatumOp) Next() coldata.Batch {
 							var r interface{}
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -8865,7 +8863,7 @@ func (c *castDatumDatumOp) Next() coldata.Batch {
 							var r interface{}
 
 							{
-								_castedDatum, err := tree.PerformCast(evalCtx, v.(*coldataext.Datum).Datum, toType)
+								_castedDatum, err := tree.PerformCast(evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}

--- a/pkg/sql/colexec/colexecbase/cast_test.go
+++ b/pkg/sql/colexec/colexecbase/cast_test.go
@@ -94,7 +94,7 @@ func TestRandomizedCast(t *testing.T) {
 		colexectestutils.RunTestsWithoutAllNullsInjectionWithErrorHandler(
 			t, testAllocator, []colexectestutils.Tuples{input}, [][]*types.T{{from}}, output, colexectestutils.OrderedVerifier,
 			func(input []colexecop.Operator) (colexecop.Operator, error) {
-				return colexecbase.GetCastOperator(testAllocator, input[0], 0, 1, from, to)
+				return colexecbase.GetCastOperator(testAllocator, input[0], 0, 1, from, to, &evalCtx)
 			},
 			func(err error) {
 				if !errorExpected {
@@ -137,7 +137,7 @@ func BenchmarkCastOp(b *testing.B) {
 							coldata.BatchSize(), nullProbability, selectivity,
 						)
 						source := colexecop.NewRepeatableBatchSource(testAllocator, batch, typs)
-						op, err := colexecbase.GetCastOperator(testAllocator, source, 0, 1, typePair[0], typePair[1])
+						op, err := colexecbase.GetCastOperator(testAllocator, source, 0, 1, typePair[0], typePair[1], &evalCtx)
 						require.NoError(b, err)
 						b.SetBytes(int64(8 * coldata.BatchSize()))
 						b.ResetTimer()

--- a/pkg/sql/colexec/colexecbase/cast_tmpl.go
+++ b/pkg/sql/colexec/colexecbase/cast_tmpl.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/cockroachdb/apd/v2"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
-	"github.com/cockroachdb/cockroach/pkg/col/coldataext"
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecutils"
@@ -49,7 +48,6 @@ import (
 // Workaround for bazel auto-generated code. goimports does not automatically
 // pick up the right packages when run within the bazel sandbox.
 var (
-	_ coldataext.Datum
 	_ duration.Duration
 	_ json.JSON
 	_ = lex.DecodeRawBytesToByteArrayAuto

--- a/pkg/sql/colexec/colexecbase/cast_tmpl.go
+++ b/pkg/sql/colexec/colexecbase/cast_tmpl.go
@@ -106,6 +106,7 @@ func GetCastOperator(
 	resultIdx int,
 	fromType *types.T,
 	toType *types.T,
+	evalCtx *tree.EvalContext,
 ) (colexecop.Operator, error) {
 	input = colexecutils.NewVectorTypeEnforcer(allocator, input, toType, resultIdx)
 	base := castOpBase{
@@ -113,6 +114,7 @@ func GetCastOperator(
 		allocator:                allocator,
 		colIdx:                   colIdx,
 		outputIdx:                resultIdx,
+		evalCtx:                  evalCtx,
 	}
 	if fromType.Family() == types.UnknownFamily {
 		return &castOpNullAny{castOpBase: base}, nil
@@ -227,6 +229,7 @@ type castOpBase struct {
 	allocator *colmem.Allocator
 	colIdx    int
 	outputIdx int
+	evalCtx   *tree.EvalContext
 }
 
 func (c *castOpBase) Reset(ctx context.Context) {
@@ -353,22 +356,22 @@ func (c *castNativeToDatumOp) Next() coldata.Batch {
 		if sel != nil {
 			if inputVec.Nulls().MaybeHasNulls() {
 				for scratchIdx, outputIdx := range sel[:n] {
-					setNativeToDatumCast(outputCol, outputNulls, scratch, scratchIdx, outputIdx, toType, true, false)
+					setNativeToDatumCast(outputCol, outputNulls, scratch, scratchIdx, outputIdx, toType, c.evalCtx, true, false)
 				}
 			} else {
 				for scratchIdx, outputIdx := range sel[:n] {
-					setNativeToDatumCast(outputCol, outputNulls, scratch, scratchIdx, outputIdx, toType, false, false)
+					setNativeToDatumCast(outputCol, outputNulls, scratch, scratchIdx, outputIdx, toType, c.evalCtx, false, false)
 				}
 			}
 		} else {
 			_ = scratch[n-1]
 			if inputVec.Nulls().MaybeHasNulls() {
 				for idx := 0; idx < n; idx++ {
-					setNativeToDatumCast(outputCol, outputNulls, scratch, idx, idx, toType, true, true)
+					setNativeToDatumCast(outputCol, outputNulls, scratch, idx, idx, toType, c.evalCtx, true, true)
 				}
 			} else {
 				for idx := 0; idx < n; idx++ {
-					setNativeToDatumCast(outputCol, outputNulls, scratch, idx, idx, toType, false, true)
+					setNativeToDatumCast(outputCol, outputNulls, scratch, idx, idx, toType, c.evalCtx, false, true)
 				}
 			}
 		}
@@ -388,6 +391,7 @@ func setNativeToDatumCast(
 	scratchIdx int,
 	outputIdx int,
 	toType *types.T,
+	evalCtx *tree.EvalContext,
 	hasNulls bool,
 	scratchBCE bool,
 ) {
@@ -399,7 +403,7 @@ func setNativeToDatumCast(
 		outputNulls.SetNull(outputIdx)
 		continue
 	}
-	res, err := coldataext.PerformCast(outputCol, converted, toType)
+	res, err := tree.PerformCast(evalCtx, converted, toType)
 	if err != nil {
 		colexecerror.ExpectedError(err)
 	}
@@ -457,18 +461,18 @@ func (c *cast_NAMEOp) Next() coldata.Batch {
 			if inputVec.MaybeHasNulls() {
 				outputNulls.Copy(inputNulls)
 				if sel != nil {
-					castTuples(inputCol, inputNulls, outputCol, outputNulls, toType, n, sel, true, true)
+					castTuples(inputCol, inputNulls, outputCol, outputNulls, toType, n, sel, c.evalCtx, true, true)
 				} else {
-					castTuples(inputCol, inputNulls, outputCol, outputNulls, toType, n, sel, true, false)
+					castTuples(inputCol, inputNulls, outputCol, outputNulls, toType, n, sel, c.evalCtx, true, false)
 				}
 			} else {
 				// We need to make sure that there are no left over null values
 				// in the output vector.
 				outputNulls.UnsetNulls()
 				if sel != nil {
-					castTuples(inputCol, inputNulls, outputCol, outputNulls, toType, n, sel, false, true)
+					castTuples(inputCol, inputNulls, outputCol, outputNulls, toType, n, sel, c.evalCtx, false, true)
 				} else {
-					castTuples(inputCol, inputNulls, outputCol, outputNulls, toType, n, sel, false, false)
+					castTuples(inputCol, inputNulls, outputCol, outputNulls, toType, n, sel, c.evalCtx, false, false)
 				}
 			}
 			// {{/*
@@ -533,9 +537,12 @@ func castTuples(
 	toType *types.T,
 	n int,
 	sel []int,
+	evalCtx *tree.EvalContext,
 	hasNulls bool,
 	hasSel bool,
 ) {
+	// Silence unused warning.
+	_ = evalCtx
 	if !hasSel {
 		// {{if $fromInfo.Sliceable}}
 		_ = inputCol.Get(n - 1)
@@ -561,7 +568,7 @@ func castTuples(
 		}
 		v := inputCol.Get(tupleIdx)
 		var r _TO_GO_TYPE
-		_CAST(r, v, inputCol, toType)
+		_CAST(r, v, evalCtx, toType)
 		if !hasSel {
 			// {{if .Sliceable}}
 			//gcassert:bce

--- a/pkg/sql/colexec/colexecbase/distinct.eg.go
+++ b/pkg/sql/colexec/colexecbase/distinct.eg.go
@@ -3020,7 +3020,7 @@ func (p *distinctDatumOp) Next() coldata.Batch {
 								{
 									var cmpResult int
 
-									cmpResult = v.(*coldataext.Datum).CompareDatum(col, lastVal)
+									cmpResult = coldataext.CompareDatum(v, col, lastVal)
 
 									unique = cmpResult != 0
 								}
@@ -3052,7 +3052,7 @@ func (p *distinctDatumOp) Next() coldata.Batch {
 						{
 							var cmpResult int
 
-							cmpResult = v.(*coldataext.Datum).CompareDatum(col, lastVal)
+							cmpResult = coldataext.CompareDatum(v, col, lastVal)
 
 							unique = cmpResult != 0
 						}
@@ -3106,7 +3106,7 @@ func (p *distinctDatumOp) Next() coldata.Batch {
 								{
 									var cmpResult int
 
-									cmpResult = v.(*coldataext.Datum).CompareDatum(col, lastVal)
+									cmpResult = coldataext.CompareDatum(v, col, lastVal)
 
 									unique = cmpResult != 0
 								}
@@ -3139,7 +3139,7 @@ func (p *distinctDatumOp) Next() coldata.Batch {
 						{
 							var cmpResult int
 
-							cmpResult = v.(*coldataext.Datum).CompareDatum(col, lastVal)
+							cmpResult = coldataext.CompareDatum(v, col, lastVal)
 
 							unique = cmpResult != 0
 						}

--- a/pkg/sql/colexec/colexechash/hash_utils.eg.go
+++ b/pkg/sql/colexec/colexechash/hash_utils.eg.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/errors"
@@ -30,8 +31,9 @@ import (
 // pick up the right packages when run within the bazel sandbox.
 var (
 	_ = typeconv.DatumVecCanonicalTypeFamily
-	_ coldataext.Datum
+	_ = coldataext.Hash
 	_ json.JSON
+	_ tree.Datum
 )
 
 // rehash takes an element of a key (tuple representing a row of equality
@@ -1044,7 +1046,7 @@ func rehash(
 						v := keys.Get(selIdx)
 						//gcassert:bce
 						p := uintptr(buckets[i])
-						b := v.(*coldataext.Datum).Hash(datumAlloc)
+						b := coldataext.Hash(v.(tree.Datum), datumAlloc)
 						sh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(b)))
 
@@ -1064,7 +1066,7 @@ func rehash(
 						v := keys.Get(selIdx)
 						//gcassert:bce
 						p := uintptr(buckets[i])
-						b := v.(*coldataext.Datum).Hash(datumAlloc)
+						b := coldataext.Hash(v.(tree.Datum), datumAlloc)
 						sh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(b)))
 
@@ -1085,7 +1087,7 @@ func rehash(
 						v := keys.Get(selIdx)
 						//gcassert:bce
 						p := uintptr(buckets[i])
-						b := v.(*coldataext.Datum).Hash(datumAlloc)
+						b := coldataext.Hash(v.(tree.Datum), datumAlloc)
 						sh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(b)))
 
@@ -1102,7 +1104,7 @@ func rehash(
 						v := keys.Get(selIdx)
 						//gcassert:bce
 						p := uintptr(buckets[i])
-						b := v.(*coldataext.Datum).Hash(datumAlloc)
+						b := coldataext.Hash(v.(tree.Datum), datumAlloc)
 						sh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(b)))
 

--- a/pkg/sql/colexec/colexechash/hash_utils_tmpl.go
+++ b/pkg/sql/colexec/colexechash/hash_utils_tmpl.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/errors"
@@ -36,8 +37,9 @@ import (
 // pick up the right packages when run within the bazel sandbox.
 var (
 	_ = typeconv.DatumVecCanonicalTypeFamily
-	_ coldataext.Datum
+	_ = coldataext.Hash
 	_ json.JSON
+	_ tree.Datum
 )
 
 // {{/*

--- a/pkg/sql/colexec/colexechash/hashtable_distinct.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_distinct.eg.go
@@ -26,7 +26,7 @@ import (
 // pick up the right packages when run within the bazel sandbox.
 var (
 	_ = typeconv.DatumVecCanonicalTypeFamily
-	_ coldataext.Datum
+	_ = coldataext.CompareDatum
 	_ tree.AggType
 )
 
@@ -5099,7 +5099,7 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											{
 												var cmpResult int
 
-												cmpResult = probeVal.(*coldataext.Datum).CompareDatum(probeKeys, buildVal)
+												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
 
 												unique = cmpResult != 0
 											}
@@ -5154,7 +5154,7 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											{
 												var cmpResult int
 
-												cmpResult = probeVal.(*coldataext.Datum).CompareDatum(probeKeys, buildVal)
+												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
 
 												unique = cmpResult != 0
 											}
@@ -5211,7 +5211,7 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											{
 												var cmpResult int
 
-												cmpResult = probeVal.(*coldataext.Datum).CompareDatum(probeKeys, buildVal)
+												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
 
 												unique = cmpResult != 0
 											}
@@ -5265,7 +5265,7 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											{
 												var cmpResult int
 
-												cmpResult = probeVal.(*coldataext.Datum).CompareDatum(probeKeys, buildVal)
+												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
 
 												unique = cmpResult != 0
 											}
@@ -5323,7 +5323,7 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											{
 												var cmpResult int
 
-												cmpResult = probeVal.(*coldataext.Datum).CompareDatum(probeKeys, buildVal)
+												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
 
 												unique = cmpResult != 0
 											}
@@ -5376,7 +5376,7 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											{
 												var cmpResult int
 
-												cmpResult = probeVal.(*coldataext.Datum).CompareDatum(probeKeys, buildVal)
+												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
 
 												unique = cmpResult != 0
 											}
@@ -5431,7 +5431,7 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											{
 												var cmpResult int
 
-												cmpResult = probeVal.(*coldataext.Datum).CompareDatum(probeKeys, buildVal)
+												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
 
 												unique = cmpResult != 0
 											}
@@ -5483,7 +5483,7 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											{
 												var cmpResult int
 
-												cmpResult = probeVal.(*coldataext.Datum).CompareDatum(probeKeys, buildVal)
+												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
 
 												unique = cmpResult != 0
 											}
@@ -10777,7 +10777,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 											{
 												var cmpResult int
 
-												cmpResult = probeVal.(*coldataext.Datum).CompareDatum(probeKeys, buildVal)
+												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
 
 												unique = cmpResult != 0
 											}
@@ -10833,7 +10833,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 											{
 												var cmpResult int
 
-												cmpResult = probeVal.(*coldataext.Datum).CompareDatum(probeKeys, buildVal)
+												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
 
 												unique = cmpResult != 0
 											}
@@ -10891,7 +10891,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 											{
 												var cmpResult int
 
-												cmpResult = probeVal.(*coldataext.Datum).CompareDatum(probeKeys, buildVal)
+												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
 
 												unique = cmpResult != 0
 											}
@@ -10946,7 +10946,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 											{
 												var cmpResult int
 
-												cmpResult = probeVal.(*coldataext.Datum).CompareDatum(probeKeys, buildVal)
+												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
 
 												unique = cmpResult != 0
 											}
@@ -11008,7 +11008,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 											{
 												var cmpResult int
 
-												cmpResult = probeVal.(*coldataext.Datum).CompareDatum(probeKeys, buildVal)
+												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
 
 												unique = cmpResult != 0
 											}
@@ -11064,7 +11064,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 											{
 												var cmpResult int
 
-												cmpResult = probeVal.(*coldataext.Datum).CompareDatum(probeKeys, buildVal)
+												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
 
 												unique = cmpResult != 0
 											}
@@ -11122,7 +11122,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 											{
 												var cmpResult int
 
-												cmpResult = probeVal.(*coldataext.Datum).CompareDatum(probeKeys, buildVal)
+												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
 
 												unique = cmpResult != 0
 											}
@@ -11177,7 +11177,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 											{
 												var cmpResult int
 
-												cmpResult = probeVal.(*coldataext.Datum).CompareDatum(probeKeys, buildVal)
+												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
 
 												unique = cmpResult != 0
 											}

--- a/pkg/sql/colexec/colexechash/hashtable_full_default.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_full_default.eg.go
@@ -25,7 +25,7 @@ import (
 // pick up the right packages when run within the bazel sandbox.
 var (
 	_ = typeconv.DatumVecCanonicalTypeFamily
-	_ coldataext.Datum
+	_ = coldataext.CompareDatum
 	_ tree.AggType
 )
 
@@ -7965,7 +7965,7 @@ func (ht *HashTable) checkCol(
 											{
 												var cmpResult int
 
-												cmpResult = probeVal.(*coldataext.Datum).CompareDatum(probeKeys, buildVal)
+												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
 
 												unique = cmpResult != 0
 											}
@@ -8017,7 +8017,7 @@ func (ht *HashTable) checkCol(
 											{
 												var cmpResult int
 
-												cmpResult = probeVal.(*coldataext.Datum).CompareDatum(probeKeys, buildVal)
+												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
 
 												unique = cmpResult != 0
 											}
@@ -8071,7 +8071,7 @@ func (ht *HashTable) checkCol(
 											{
 												var cmpResult int
 
-												cmpResult = probeVal.(*coldataext.Datum).CompareDatum(probeKeys, buildVal)
+												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
 
 												unique = cmpResult != 0
 											}
@@ -8122,7 +8122,7 @@ func (ht *HashTable) checkCol(
 											{
 												var cmpResult int
 
-												cmpResult = probeVal.(*coldataext.Datum).CompareDatum(probeKeys, buildVal)
+												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
 
 												unique = cmpResult != 0
 											}
@@ -8179,7 +8179,7 @@ func (ht *HashTable) checkCol(
 											{
 												var cmpResult int
 
-												cmpResult = probeVal.(*coldataext.Datum).CompareDatum(probeKeys, buildVal)
+												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
 
 												unique = cmpResult != 0
 											}
@@ -8231,7 +8231,7 @@ func (ht *HashTable) checkCol(
 											{
 												var cmpResult int
 
-												cmpResult = probeVal.(*coldataext.Datum).CompareDatum(probeKeys, buildVal)
+												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
 
 												unique = cmpResult != 0
 											}
@@ -8285,7 +8285,7 @@ func (ht *HashTable) checkCol(
 											{
 												var cmpResult int
 
-												cmpResult = probeVal.(*coldataext.Datum).CompareDatum(probeKeys, buildVal)
+												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
 
 												unique = cmpResult != 0
 											}
@@ -8336,7 +8336,7 @@ func (ht *HashTable) checkCol(
 											{
 												var cmpResult int
 
-												cmpResult = probeVal.(*coldataext.Datum).CompareDatum(probeKeys, buildVal)
+												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
 
 												unique = cmpResult != 0
 											}

--- a/pkg/sql/colexec/colexechash/hashtable_full_deleting.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_full_deleting.eg.go
@@ -26,7 +26,7 @@ import (
 // pick up the right packages when run within the bazel sandbox.
 var (
 	_ = typeconv.DatumVecCanonicalTypeFamily
-	_ coldataext.Datum
+	_ = coldataext.CompareDatum
 	_ tree.AggType
 )
 
@@ -8740,7 +8740,7 @@ func (ht *HashTable) checkColDeleting(
 											{
 												var cmpResult int
 
-												cmpResult = probeVal.(*coldataext.Datum).CompareDatum(probeKeys, buildVal)
+												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
 
 												unique = cmpResult != 0
 											}
@@ -8798,7 +8798,7 @@ func (ht *HashTable) checkColDeleting(
 											{
 												var cmpResult int
 
-												cmpResult = probeVal.(*coldataext.Datum).CompareDatum(probeKeys, buildVal)
+												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
 
 												unique = cmpResult != 0
 											}
@@ -8858,7 +8858,7 @@ func (ht *HashTable) checkColDeleting(
 											{
 												var cmpResult int
 
-												cmpResult = probeVal.(*coldataext.Datum).CompareDatum(probeKeys, buildVal)
+												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
 
 												unique = cmpResult != 0
 											}
@@ -8915,7 +8915,7 @@ func (ht *HashTable) checkColDeleting(
 											{
 												var cmpResult int
 
-												cmpResult = probeVal.(*coldataext.Datum).CompareDatum(probeKeys, buildVal)
+												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
 
 												unique = cmpResult != 0
 											}
@@ -8978,7 +8978,7 @@ func (ht *HashTable) checkColDeleting(
 											{
 												var cmpResult int
 
-												cmpResult = probeVal.(*coldataext.Datum).CompareDatum(probeKeys, buildVal)
+												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
 
 												unique = cmpResult != 0
 											}
@@ -9036,7 +9036,7 @@ func (ht *HashTable) checkColDeleting(
 											{
 												var cmpResult int
 
-												cmpResult = probeVal.(*coldataext.Datum).CompareDatum(probeKeys, buildVal)
+												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
 
 												unique = cmpResult != 0
 											}
@@ -9096,7 +9096,7 @@ func (ht *HashTable) checkColDeleting(
 											{
 												var cmpResult int
 
-												cmpResult = probeVal.(*coldataext.Datum).CompareDatum(probeKeys, buildVal)
+												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
 
 												unique = cmpResult != 0
 											}
@@ -9153,7 +9153,7 @@ func (ht *HashTable) checkColDeleting(
 											{
 												var cmpResult int
 
-												cmpResult = probeVal.(*coldataext.Datum).CompareDatum(probeKeys, buildVal)
+												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
 
 												unique = cmpResult != 0
 											}

--- a/pkg/sql/colexec/colexechash/hashtable_tmpl.go
+++ b/pkg/sql/colexec/colexechash/hashtable_tmpl.go
@@ -34,7 +34,7 @@ import (
 // pick up the right packages when run within the bazel sandbox.
 var (
 	_ = typeconv.DatumVecCanonicalTypeFamily
-	_ coldataext.Datum
+	_ = coldataext.CompareDatum
 	_ tree.AggType
 )
 

--- a/pkg/sql/colexec/colexecjoin/mergejoinbase.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoinbase.eg.go
@@ -26,7 +26,7 @@ import (
 // pick up the right packages when run within the bazel sandbox.
 var (
 	_ = typeconv.DatumVecCanonicalTypeFamily
-	_ coldataext.Datum
+	_ = coldataext.CompareDatum
 	_ tree.AggType
 )
 
@@ -517,7 +517,7 @@ func (o *mergeJoinBase) isBufferedGroupFinished(
 				{
 					var cmpResult int
 
-					cmpResult = prevVal.(*coldataext.Datum).CompareDatum(bufferedCol, curVal)
+					cmpResult = coldataext.CompareDatum(prevVal, bufferedCol, curVal)
 
 					match = cmpResult == 0
 				}

--- a/pkg/sql/colexec/colexecjoin/mergejoinbase_tmpl.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoinbase_tmpl.go
@@ -33,7 +33,7 @@ import (
 // pick up the right packages when run within the bazel sandbox.
 var (
 	_ = typeconv.DatumVecCanonicalTypeFamily
-	_ coldataext.Datum
+	_ = coldataext.CompareDatum
 	_ tree.AggType
 )
 

--- a/pkg/sql/colexec/colexecjoin/mergejoiner.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/errors"
@@ -224,6 +225,7 @@ func NewMergeJoinOp(
 	leftOrdering []execinfrapb.Ordering_Column,
 	rightOrdering []execinfrapb.Ordering_Column,
 	diskAcc *mon.BoundAccount,
+	evalCtx *tree.EvalContext,
 ) (colexecop.ResettableOperator, error) {
 	// Merge joiner only supports the case when the physical types in the
 	// equality columns in both inputs are the same. We, however, also need to
@@ -273,7 +275,7 @@ func NewMergeJoinOp(
 			}
 			if castLeftToRight {
 				castColumnIdx := len(actualLeftTypes)
-				left, err = colexecbase.GetCastOperator(unlimitedAllocator, left, int(leftColIdx), castColumnIdx, leftType, rightType)
+				left, err = colexecbase.GetCastOperator(unlimitedAllocator, left, int(leftColIdx), castColumnIdx, leftType, rightType, evalCtx)
 				if err != nil {
 					return nil, err
 				}
@@ -281,7 +283,7 @@ func NewMergeJoinOp(
 				actualLeftOrdering[i].ColIdx = uint32(castColumnIdx)
 			} else {
 				castColumnIdx := len(actualRightTypes)
-				right, err = colexecbase.GetCastOperator(unlimitedAllocator, right, int(rightColIdx), castColumnIdx, rightType, leftType)
+				right, err = colexecbase.GetCastOperator(unlimitedAllocator, right, int(rightColIdx), castColumnIdx, rightType, leftType, evalCtx)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_exceptall.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_exceptall.eg.go
@@ -33,7 +33,7 @@ import (
 var (
 	_ = typeconv.DatumVecCanonicalTypeFamily
 	_ apd.Context
-	_ coldataext.Datum
+	_ = coldataext.CompareDatum
 	_ duration.Duration
 	_ tree.AggType
 	_ json.JSON
@@ -2551,7 +2551,7 @@ EqLoop:
 							rSelIdx = rSel[curRIdx]
 							rVal = rKeys.Get(rSelIdx)
 
-							cmp = lVal.(*coldataext.Datum).CompareDatum(lKeys, rVal)
+							cmp = coldataext.CompareDatum(lVal, lKeys, rVal)
 
 						}
 
@@ -2584,7 +2584,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -2616,7 +2616,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}
@@ -2682,7 +2682,7 @@ EqLoop:
 										{
 											var cmpResult int
 
-											cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+											cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 											match = cmpResult == 0
 										}
@@ -5230,7 +5230,7 @@ EqLoop:
 							rSelIdx = curRIdx
 							rVal = rKeys.Get(rSelIdx)
 
-							cmp = lVal.(*coldataext.Datum).CompareDatum(lKeys, rVal)
+							cmp = coldataext.CompareDatum(lVal, lKeys, rVal)
 
 						}
 
@@ -5263,7 +5263,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -5295,7 +5295,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}
@@ -5361,7 +5361,7 @@ EqLoop:
 										{
 											var cmpResult int
 
-											cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+											cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 											match = cmpResult == 0
 										}
@@ -7909,7 +7909,7 @@ EqLoop:
 							rSelIdx = rSel[curRIdx]
 							rVal = rKeys.Get(rSelIdx)
 
-							cmp = lVal.(*coldataext.Datum).CompareDatum(lKeys, rVal)
+							cmp = coldataext.CompareDatum(lVal, lKeys, rVal)
 
 						}
 
@@ -7942,7 +7942,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -7974,7 +7974,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}
@@ -8040,7 +8040,7 @@ EqLoop:
 										{
 											var cmpResult int
 
-											cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+											cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 											match = cmpResult == 0
 										}
@@ -10588,7 +10588,7 @@ EqLoop:
 							rSelIdx = curRIdx
 							rVal = rKeys.Get(rSelIdx)
 
-							cmp = lVal.(*coldataext.Datum).CompareDatum(lKeys, rVal)
+							cmp = coldataext.CompareDatum(lVal, lKeys, rVal)
 
 						}
 
@@ -10621,7 +10621,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -10653,7 +10653,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}
@@ -10719,7 +10719,7 @@ EqLoop:
 										{
 											var cmpResult int
 
-											cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+											cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 											match = cmpResult == 0
 										}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_fullouter.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_fullouter.eg.go
@@ -33,7 +33,7 @@ import (
 var (
 	_ = typeconv.DatumVecCanonicalTypeFamily
 	_ apd.Context
-	_ coldataext.Datum
+	_ = coldataext.CompareDatum
 	_ duration.Duration
 	_ tree.AggType
 	_ json.JSON
@@ -2801,7 +2801,7 @@ EqLoop:
 							rSelIdx = rSel[curRIdx]
 							rVal = rKeys.Get(rSelIdx)
 
-							cmp = lVal.(*coldataext.Datum).CompareDatum(lKeys, rVal)
+							cmp = coldataext.CompareDatum(lVal, lKeys, rVal)
 
 						}
 
@@ -2829,7 +2829,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -2856,7 +2856,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}
@@ -2911,7 +2911,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -2937,7 +2937,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}
@@ -5742,7 +5742,7 @@ EqLoop:
 							rSelIdx = curRIdx
 							rVal = rKeys.Get(rSelIdx)
 
-							cmp = lVal.(*coldataext.Datum).CompareDatum(lKeys, rVal)
+							cmp = coldataext.CompareDatum(lVal, lKeys, rVal)
 
 						}
 
@@ -5770,7 +5770,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -5797,7 +5797,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}
@@ -5852,7 +5852,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -5878,7 +5878,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}
@@ -8683,7 +8683,7 @@ EqLoop:
 							rSelIdx = rSel[curRIdx]
 							rVal = rKeys.Get(rSelIdx)
 
-							cmp = lVal.(*coldataext.Datum).CompareDatum(lKeys, rVal)
+							cmp = coldataext.CompareDatum(lVal, lKeys, rVal)
 
 						}
 
@@ -8711,7 +8711,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -8738,7 +8738,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}
@@ -8793,7 +8793,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -8819,7 +8819,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}
@@ -11624,7 +11624,7 @@ EqLoop:
 							rSelIdx = curRIdx
 							rVal = rKeys.Get(rSelIdx)
 
-							cmp = lVal.(*coldataext.Datum).CompareDatum(lKeys, rVal)
+							cmp = coldataext.CompareDatum(lVal, lKeys, rVal)
 
 						}
 
@@ -11652,7 +11652,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -11679,7 +11679,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}
@@ -11734,7 +11734,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -11760,7 +11760,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_inner.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_inner.eg.go
@@ -33,7 +33,7 @@ import (
 var (
 	_ = typeconv.DatumVecCanonicalTypeFamily
 	_ apd.Context
-	_ coldataext.Datum
+	_ = coldataext.CompareDatum
 	_ duration.Duration
 	_ tree.AggType
 	_ json.JSON
@@ -1763,7 +1763,7 @@ EqLoop:
 							rSelIdx = rSel[curRIdx]
 							rVal = rKeys.Get(rSelIdx)
 
-							cmp = lVal.(*coldataext.Datum).CompareDatum(lKeys, rVal)
+							cmp = coldataext.CompareDatum(lVal, lKeys, rVal)
 
 						}
 
@@ -1791,7 +1791,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -1818,7 +1818,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}
@@ -3597,7 +3597,7 @@ EqLoop:
 							rSelIdx = curRIdx
 							rVal = rKeys.Get(rSelIdx)
 
-							cmp = lVal.(*coldataext.Datum).CompareDatum(lKeys, rVal)
+							cmp = coldataext.CompareDatum(lVal, lKeys, rVal)
 
 						}
 
@@ -3625,7 +3625,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -3652,7 +3652,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}
@@ -5431,7 +5431,7 @@ EqLoop:
 							rSelIdx = rSel[curRIdx]
 							rVal = rKeys.Get(rSelIdx)
 
-							cmp = lVal.(*coldataext.Datum).CompareDatum(lKeys, rVal)
+							cmp = coldataext.CompareDatum(lVal, lKeys, rVal)
 
 						}
 
@@ -5459,7 +5459,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -5486,7 +5486,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}
@@ -7265,7 +7265,7 @@ EqLoop:
 							rSelIdx = curRIdx
 							rVal = rKeys.Get(rSelIdx)
 
-							cmp = lVal.(*coldataext.Datum).CompareDatum(lKeys, rVal)
+							cmp = coldataext.CompareDatum(lVal, lKeys, rVal)
 
 						}
 
@@ -7293,7 +7293,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -7320,7 +7320,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_intersectall.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_intersectall.eg.go
@@ -33,7 +33,7 @@ import (
 var (
 	_ = typeconv.DatumVecCanonicalTypeFamily
 	_ apd.Context
-	_ coldataext.Datum
+	_ = coldataext.CompareDatum
 	_ duration.Duration
 	_ tree.AggType
 	_ json.JSON
@@ -1958,7 +1958,7 @@ EqLoop:
 							rSelIdx = rSel[curRIdx]
 							rVal = rKeys.Get(rSelIdx)
 
-							cmp = lVal.(*coldataext.Datum).CompareDatum(lKeys, rVal)
+							cmp = coldataext.CompareDatum(lVal, lKeys, rVal)
 
 						}
 
@@ -1991,7 +1991,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -2023,7 +2023,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}
@@ -4001,7 +4001,7 @@ EqLoop:
 							rSelIdx = curRIdx
 							rVal = rKeys.Get(rSelIdx)
 
-							cmp = lVal.(*coldataext.Datum).CompareDatum(lKeys, rVal)
+							cmp = coldataext.CompareDatum(lVal, lKeys, rVal)
 
 						}
 
@@ -4034,7 +4034,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -4066,7 +4066,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}
@@ -6044,7 +6044,7 @@ EqLoop:
 							rSelIdx = rSel[curRIdx]
 							rVal = rKeys.Get(rSelIdx)
 
-							cmp = lVal.(*coldataext.Datum).CompareDatum(lKeys, rVal)
+							cmp = coldataext.CompareDatum(lVal, lKeys, rVal)
 
 						}
 
@@ -6077,7 +6077,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -6109,7 +6109,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}
@@ -8087,7 +8087,7 @@ EqLoop:
 							rSelIdx = curRIdx
 							rVal = rKeys.Get(rSelIdx)
 
-							cmp = lVal.(*coldataext.Datum).CompareDatum(lKeys, rVal)
+							cmp = coldataext.CompareDatum(lVal, lKeys, rVal)
 
 						}
 
@@ -8120,7 +8120,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -8152,7 +8152,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_leftanti.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_leftanti.eg.go
@@ -33,7 +33,7 @@ import (
 var (
 	_ = typeconv.DatumVecCanonicalTypeFamily
 	_ apd.Context
-	_ coldataext.Datum
+	_ = coldataext.CompareDatum
 	_ duration.Duration
 	_ tree.AggType
 	_ json.JSON
@@ -2277,7 +2277,7 @@ EqLoop:
 							rSelIdx = rSel[curRIdx]
 							rVal = rKeys.Get(rSelIdx)
 
-							cmp = lVal.(*coldataext.Datum).CompareDatum(lKeys, rVal)
+							cmp = coldataext.CompareDatum(lVal, lKeys, rVal)
 
 						}
 
@@ -2305,7 +2305,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -2332,7 +2332,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}
@@ -2386,7 +2386,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -4659,7 +4659,7 @@ EqLoop:
 							rSelIdx = curRIdx
 							rVal = rKeys.Get(rSelIdx)
 
-							cmp = lVal.(*coldataext.Datum).CompareDatum(lKeys, rVal)
+							cmp = coldataext.CompareDatum(lVal, lKeys, rVal)
 
 						}
 
@@ -4687,7 +4687,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -4714,7 +4714,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}
@@ -4768,7 +4768,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -7041,7 +7041,7 @@ EqLoop:
 							rSelIdx = rSel[curRIdx]
 							rVal = rKeys.Get(rSelIdx)
 
-							cmp = lVal.(*coldataext.Datum).CompareDatum(lKeys, rVal)
+							cmp = coldataext.CompareDatum(lVal, lKeys, rVal)
 
 						}
 
@@ -7069,7 +7069,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -7096,7 +7096,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}
@@ -7150,7 +7150,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -9423,7 +9423,7 @@ EqLoop:
 							rSelIdx = curRIdx
 							rVal = rKeys.Get(rSelIdx)
 
-							cmp = lVal.(*coldataext.Datum).CompareDatum(lKeys, rVal)
+							cmp = coldataext.CompareDatum(lVal, lKeys, rVal)
 
 						}
 
@@ -9451,7 +9451,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -9478,7 +9478,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}
@@ -9532,7 +9532,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_leftouter.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_leftouter.eg.go
@@ -33,7 +33,7 @@ import (
 var (
 	_ = typeconv.DatumVecCanonicalTypeFamily
 	_ apd.Context
-	_ coldataext.Datum
+	_ = coldataext.CompareDatum
 	_ duration.Duration
 	_ tree.AggType
 	_ json.JSON
@@ -2287,7 +2287,7 @@ EqLoop:
 							rSelIdx = rSel[curRIdx]
 							rVal = rKeys.Get(rSelIdx)
 
-							cmp = lVal.(*coldataext.Datum).CompareDatum(lKeys, rVal)
+							cmp = coldataext.CompareDatum(lVal, lKeys, rVal)
 
 						}
 
@@ -2315,7 +2315,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -2342,7 +2342,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}
@@ -2397,7 +2397,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -4680,7 +4680,7 @@ EqLoop:
 							rSelIdx = curRIdx
 							rVal = rKeys.Get(rSelIdx)
 
-							cmp = lVal.(*coldataext.Datum).CompareDatum(lKeys, rVal)
+							cmp = coldataext.CompareDatum(lVal, lKeys, rVal)
 
 						}
 
@@ -4708,7 +4708,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -4735,7 +4735,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}
@@ -4790,7 +4790,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -7073,7 +7073,7 @@ EqLoop:
 							rSelIdx = rSel[curRIdx]
 							rVal = rKeys.Get(rSelIdx)
 
-							cmp = lVal.(*coldataext.Datum).CompareDatum(lKeys, rVal)
+							cmp = coldataext.CompareDatum(lVal, lKeys, rVal)
 
 						}
 
@@ -7101,7 +7101,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -7128,7 +7128,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}
@@ -7183,7 +7183,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -9466,7 +9466,7 @@ EqLoop:
 							rSelIdx = curRIdx
 							rVal = rKeys.Get(rSelIdx)
 
-							cmp = lVal.(*coldataext.Datum).CompareDatum(lKeys, rVal)
+							cmp = coldataext.CompareDatum(lVal, lKeys, rVal)
 
 						}
 
@@ -9494,7 +9494,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -9521,7 +9521,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}
@@ -9576,7 +9576,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_leftsemi.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_leftsemi.eg.go
@@ -33,7 +33,7 @@ import (
 var (
 	_ = typeconv.DatumVecCanonicalTypeFamily
 	_ apd.Context
-	_ coldataext.Datum
+	_ = coldataext.CompareDatum
 	_ duration.Duration
 	_ tree.AggType
 	_ json.JSON
@@ -1753,7 +1753,7 @@ EqLoop:
 							rSelIdx = rSel[curRIdx]
 							rVal = rKeys.Get(rSelIdx)
 
-							cmp = lVal.(*coldataext.Datum).CompareDatum(lKeys, rVal)
+							cmp = coldataext.CompareDatum(lVal, lKeys, rVal)
 
 						}
 
@@ -1781,7 +1781,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -1808,7 +1808,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}
@@ -3576,7 +3576,7 @@ EqLoop:
 							rSelIdx = curRIdx
 							rVal = rKeys.Get(rSelIdx)
 
-							cmp = lVal.(*coldataext.Datum).CompareDatum(lKeys, rVal)
+							cmp = coldataext.CompareDatum(lVal, lKeys, rVal)
 
 						}
 
@@ -3604,7 +3604,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -3631,7 +3631,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}
@@ -5399,7 +5399,7 @@ EqLoop:
 							rSelIdx = rSel[curRIdx]
 							rVal = rKeys.Get(rSelIdx)
 
-							cmp = lVal.(*coldataext.Datum).CompareDatum(lKeys, rVal)
+							cmp = coldataext.CompareDatum(lVal, lKeys, rVal)
 
 						}
 
@@ -5427,7 +5427,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -5454,7 +5454,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}
@@ -7222,7 +7222,7 @@ EqLoop:
 							rSelIdx = curRIdx
 							rVal = rKeys.Get(rSelIdx)
 
-							cmp = lVal.(*coldataext.Datum).CompareDatum(lKeys, rVal)
+							cmp = coldataext.CompareDatum(lVal, lKeys, rVal)
 
 						}
 
@@ -7250,7 +7250,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -7277,7 +7277,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_rightanti.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_rightanti.eg.go
@@ -33,7 +33,7 @@ import (
 var (
 	_ = typeconv.DatumVecCanonicalTypeFamily
 	_ apd.Context
-	_ coldataext.Datum
+	_ = coldataext.CompareDatum
 	_ duration.Duration
 	_ tree.AggType
 	_ json.JSON
@@ -2267,7 +2267,7 @@ EqLoop:
 							rSelIdx = rSel[curRIdx]
 							rVal = rKeys.Get(rSelIdx)
 
-							cmp = lVal.(*coldataext.Datum).CompareDatum(lKeys, rVal)
+							cmp = coldataext.CompareDatum(lVal, lKeys, rVal)
 
 						}
 
@@ -2295,7 +2295,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -2322,7 +2322,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}
@@ -2377,7 +2377,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}
@@ -4638,7 +4638,7 @@ EqLoop:
 							rSelIdx = curRIdx
 							rVal = rKeys.Get(rSelIdx)
 
-							cmp = lVal.(*coldataext.Datum).CompareDatum(lKeys, rVal)
+							cmp = coldataext.CompareDatum(lVal, lKeys, rVal)
 
 						}
 
@@ -4666,7 +4666,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -4693,7 +4693,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}
@@ -4748,7 +4748,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}
@@ -7009,7 +7009,7 @@ EqLoop:
 							rSelIdx = rSel[curRIdx]
 							rVal = rKeys.Get(rSelIdx)
 
-							cmp = lVal.(*coldataext.Datum).CompareDatum(lKeys, rVal)
+							cmp = coldataext.CompareDatum(lVal, lKeys, rVal)
 
 						}
 
@@ -7037,7 +7037,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -7064,7 +7064,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}
@@ -7119,7 +7119,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}
@@ -9380,7 +9380,7 @@ EqLoop:
 							rSelIdx = curRIdx
 							rVal = rKeys.Get(rSelIdx)
 
-							cmp = lVal.(*coldataext.Datum).CompareDatum(lKeys, rVal)
+							cmp = coldataext.CompareDatum(lVal, lKeys, rVal)
 
 						}
 
@@ -9408,7 +9408,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -9435,7 +9435,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}
@@ -9490,7 +9490,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_rightouter.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_rightouter.eg.go
@@ -33,7 +33,7 @@ import (
 var (
 	_ = typeconv.DatumVecCanonicalTypeFamily
 	_ apd.Context
-	_ coldataext.Datum
+	_ = coldataext.CompareDatum
 	_ duration.Duration
 	_ tree.AggType
 	_ json.JSON
@@ -2277,7 +2277,7 @@ EqLoop:
 							rSelIdx = rSel[curRIdx]
 							rVal = rKeys.Get(rSelIdx)
 
-							cmp = lVal.(*coldataext.Datum).CompareDatum(lKeys, rVal)
+							cmp = coldataext.CompareDatum(lVal, lKeys, rVal)
 
 						}
 
@@ -2305,7 +2305,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -2332,7 +2332,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}
@@ -2388,7 +2388,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}
@@ -4659,7 +4659,7 @@ EqLoop:
 							rSelIdx = curRIdx
 							rVal = rKeys.Get(rSelIdx)
 
-							cmp = lVal.(*coldataext.Datum).CompareDatum(lKeys, rVal)
+							cmp = coldataext.CompareDatum(lVal, lKeys, rVal)
 
 						}
 
@@ -4687,7 +4687,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -4714,7 +4714,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}
@@ -4770,7 +4770,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}
@@ -7041,7 +7041,7 @@ EqLoop:
 							rSelIdx = rSel[curRIdx]
 							rVal = rKeys.Get(rSelIdx)
 
-							cmp = lVal.(*coldataext.Datum).CompareDatum(lKeys, rVal)
+							cmp = coldataext.CompareDatum(lVal, lKeys, rVal)
 
 						}
 
@@ -7069,7 +7069,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -7096,7 +7096,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}
@@ -7152,7 +7152,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}
@@ -9423,7 +9423,7 @@ EqLoop:
 							rSelIdx = curRIdx
 							rVal = rKeys.Get(rSelIdx)
 
-							cmp = lVal.(*coldataext.Datum).CompareDatum(lKeys, rVal)
+							cmp = coldataext.CompareDatum(lVal, lKeys, rVal)
 
 						}
 
@@ -9451,7 +9451,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -9478,7 +9478,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}
@@ -9534,7 +9534,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_rightsemi.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_rightsemi.eg.go
@@ -33,7 +33,7 @@ import (
 var (
 	_ = typeconv.DatumVecCanonicalTypeFamily
 	_ apd.Context
-	_ coldataext.Datum
+	_ = coldataext.CompareDatum
 	_ duration.Duration
 	_ tree.AggType
 	_ json.JSON
@@ -1743,7 +1743,7 @@ EqLoop:
 							rSelIdx = rSel[curRIdx]
 							rVal = rKeys.Get(rSelIdx)
 
-							cmp = lVal.(*coldataext.Datum).CompareDatum(lKeys, rVal)
+							cmp = coldataext.CompareDatum(lVal, lKeys, rVal)
 
 						}
 
@@ -1771,7 +1771,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -1798,7 +1798,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}
@@ -3555,7 +3555,7 @@ EqLoop:
 							rSelIdx = curRIdx
 							rVal = rKeys.Get(rSelIdx)
 
-							cmp = lVal.(*coldataext.Datum).CompareDatum(lKeys, rVal)
+							cmp = coldataext.CompareDatum(lVal, lKeys, rVal)
 
 						}
 
@@ -3583,7 +3583,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -3610,7 +3610,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}
@@ -5367,7 +5367,7 @@ EqLoop:
 							rSelIdx = rSel[curRIdx]
 							rVal = rKeys.Get(rSelIdx)
 
-							cmp = lVal.(*coldataext.Datum).CompareDatum(lKeys, rVal)
+							cmp = coldataext.CompareDatum(lVal, lKeys, rVal)
 
 						}
 
@@ -5395,7 +5395,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -5422,7 +5422,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}
@@ -7179,7 +7179,7 @@ EqLoop:
 							rSelIdx = curRIdx
 							rVal = rKeys.Get(rSelIdx)
 
-							cmp = lVal.(*coldataext.Datum).CompareDatum(lKeys, rVal)
+							cmp = coldataext.CompareDatum(lVal, lKeys, rVal)
 
 						}
 
@@ -7207,7 +7207,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newLVal.(*coldataext.Datum).CompareDatum(lKeys, lVal)
+										cmpResult = coldataext.CompareDatum(newLVal, lKeys, lVal)
 
 										match = cmpResult == 0
 									}
@@ -7234,7 +7234,7 @@ EqLoop:
 									{
 										var cmpResult int
 
-										cmpResult = newRVal.(*coldataext.Datum).CompareDatum(rKeys, rVal)
+										cmpResult = coldataext.CompareDatum(newRVal, rKeys, rVal)
 
 										match = cmpResult == 0
 									}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_test.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_test.go
@@ -101,7 +101,7 @@ func TestMergeJoinCrossProduct(t *testing.T) {
 		leftMJSource, rightMJSource, typs, typs,
 		[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
 		[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
-		testDiskAcc,
+		testDiskAcc, evalCtx,
 	)
 	if err != nil {
 		t.Fatal("error in merge join op constructor", err)

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_tmpl.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_tmpl.go
@@ -39,7 +39,7 @@ import (
 var (
 	_ = typeconv.DatumVecCanonicalTypeFamily
 	_ apd.Context
-	_ coldataext.Datum
+	_ = coldataext.CompareDatum
 	_ duration.Duration
 	_ tree.AggType
 	_ json.JSON

--- a/pkg/sql/colexec/colexecproj/proj_const_left_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/proj_const_left_ops.eg.go
@@ -41,6 +41,7 @@ var (
 	_ sqltelemetry.EnumTelemetryType
 	_ telemetry.Counter
 	_ json.JSON
+	_ = coldataext.CompareDatum
 )
 
 type projBitandInt16ConstInt16Op struct {
@@ -1006,7 +1007,7 @@ func (p projBitandDatumConstDatumOp) Next() coldata.Batch {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
-						_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -1025,7 +1026,7 @@ func (p projBitandDatumConstDatumOp) Next() coldata.Batch {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
-						_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -1049,7 +1050,7 @@ func (p projBitandDatumConstDatumOp) Next() coldata.Batch {
 				for _, i := range sel {
 					arg := col.Get(i)
 
-					_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -1065,7 +1066,7 @@ func (p projBitandDatumConstDatumOp) Next() coldata.Batch {
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
-					_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -2052,7 +2053,7 @@ func (p projBitorDatumConstDatumOp) Next() coldata.Batch {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
-						_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -2071,7 +2072,7 @@ func (p projBitorDatumConstDatumOp) Next() coldata.Batch {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
-						_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -2095,7 +2096,7 @@ func (p projBitorDatumConstDatumOp) Next() coldata.Batch {
 				for _, i := range sel {
 					arg := col.Get(i)
 
-					_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -2111,7 +2112,7 @@ func (p projBitorDatumConstDatumOp) Next() coldata.Batch {
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
-					_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -3098,7 +3099,7 @@ func (p projBitxorDatumConstDatumOp) Next() coldata.Batch {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
-						_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -3117,7 +3118,7 @@ func (p projBitxorDatumConstDatumOp) Next() coldata.Batch {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
-						_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -3141,7 +3142,7 @@ func (p projBitxorDatumConstDatumOp) Next() coldata.Batch {
 				for _, i := range sel {
 					arg := col.Get(i)
 
-					_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -3157,7 +3158,7 @@ func (p projBitxorDatumConstDatumOp) Next() coldata.Batch {
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
-					_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -4258,9 +4259,7 @@ func (p projPlusInt16ConstDatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-						_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -4284,9 +4283,7 @@ func (p projPlusInt16ConstDatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-						_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -4314,9 +4311,7 @@ func (p projPlusInt16ConstDatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-					_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -4337,9 +4332,7 @@ func (p projPlusInt16ConstDatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-					_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -4924,9 +4917,7 @@ func (p projPlusInt32ConstDatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-						_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -4950,9 +4941,7 @@ func (p projPlusInt32ConstDatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-						_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -4980,9 +4969,7 @@ func (p projPlusInt32ConstDatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-					_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -5003,9 +4990,7 @@ func (p projPlusInt32ConstDatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-					_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -5590,9 +5575,7 @@ func (p projPlusInt64ConstDatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-						_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -5616,9 +5599,7 @@ func (p projPlusInt64ConstDatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-						_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -5646,9 +5627,7 @@ func (p projPlusInt64ConstDatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-					_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -5669,9 +5648,7 @@ func (p projPlusInt64ConstDatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-					_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -6180,9 +6157,7 @@ func (p projPlusIntervalConstDatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-						_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -6206,9 +6181,7 @@ func (p projPlusIntervalConstDatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-						_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -6236,9 +6209,7 @@ func (p projPlusIntervalConstDatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-					_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -6259,9 +6230,7 @@ func (p projPlusIntervalConstDatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-					_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -6334,7 +6303,7 @@ func (p projPlusDatumConstIntervalOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -6357,7 +6326,7 @@ func (p projPlusDatumConstIntervalOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -6385,7 +6354,7 @@ func (p projPlusDatumConstIntervalOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -6405,7 +6374,7 @@ func (p projPlusDatumConstIntervalOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -6478,7 +6447,7 @@ func (p projPlusDatumConstInt16Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -6501,7 +6470,7 @@ func (p projPlusDatumConstInt16Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -6529,7 +6498,7 @@ func (p projPlusDatumConstInt16Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -6549,7 +6518,7 @@ func (p projPlusDatumConstInt16Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -6622,7 +6591,7 @@ func (p projPlusDatumConstInt32Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -6645,7 +6614,7 @@ func (p projPlusDatumConstInt32Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -6673,7 +6642,7 @@ func (p projPlusDatumConstInt32Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -6693,7 +6662,7 @@ func (p projPlusDatumConstInt32Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -6766,7 +6735,7 @@ func (p projPlusDatumConstInt64Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -6789,7 +6758,7 @@ func (p projPlusDatumConstInt64Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -6817,7 +6786,7 @@ func (p projPlusDatumConstInt64Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -6837,7 +6806,7 @@ func (p projPlusDatumConstInt64Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -7938,9 +7907,7 @@ func (p projMinusInt16ConstDatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-						_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -7964,9 +7931,7 @@ func (p projMinusInt16ConstDatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-						_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -7994,9 +7959,7 @@ func (p projMinusInt16ConstDatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-					_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -8017,9 +7980,7 @@ func (p projMinusInt16ConstDatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-					_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -8604,9 +8565,7 @@ func (p projMinusInt32ConstDatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-						_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -8630,9 +8589,7 @@ func (p projMinusInt32ConstDatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-						_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -8660,9 +8617,7 @@ func (p projMinusInt32ConstDatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-					_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -8683,9 +8638,7 @@ func (p projMinusInt32ConstDatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-					_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -9270,9 +9223,7 @@ func (p projMinusInt64ConstDatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-						_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -9296,9 +9247,7 @@ func (p projMinusInt64ConstDatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-						_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -9326,9 +9275,7 @@ func (p projMinusInt64ConstDatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-					_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -9349,9 +9296,7 @@ func (p projMinusInt64ConstDatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-					_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -9852,9 +9797,7 @@ func (p projMinusIntervalConstDatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-						_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -9878,9 +9821,7 @@ func (p projMinusIntervalConstDatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-						_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -9908,9 +9849,7 @@ func (p projMinusIntervalConstDatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-					_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -9931,9 +9870,7 @@ func (p projMinusIntervalConstDatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-					_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -10466,7 +10403,7 @@ func (p projMinusDatumConstDatumOp) Next() coldata.Batch {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
-						_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -10485,7 +10422,7 @@ func (p projMinusDatumConstDatumOp) Next() coldata.Batch {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
-						_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -10509,7 +10446,7 @@ func (p projMinusDatumConstDatumOp) Next() coldata.Batch {
 				for _, i := range sel {
 					arg := col.Get(i)
 
-					_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -10525,7 +10462,7 @@ func (p projMinusDatumConstDatumOp) Next() coldata.Batch {
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
-					_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -10598,7 +10535,7 @@ func (p projMinusDatumConstIntervalOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -10621,7 +10558,7 @@ func (p projMinusDatumConstIntervalOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -10649,7 +10586,7 @@ func (p projMinusDatumConstIntervalOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -10669,7 +10606,7 @@ func (p projMinusDatumConstIntervalOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -10742,7 +10679,7 @@ func (p projMinusDatumConstBytesOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -10765,7 +10702,7 @@ func (p projMinusDatumConstBytesOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -10793,7 +10730,7 @@ func (p projMinusDatumConstBytesOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -10813,7 +10750,7 @@ func (p projMinusDatumConstBytesOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -10886,7 +10823,7 @@ func (p projMinusDatumConstInt16Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -10909,7 +10846,7 @@ func (p projMinusDatumConstInt16Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -10937,7 +10874,7 @@ func (p projMinusDatumConstInt16Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -10957,7 +10894,7 @@ func (p projMinusDatumConstInt16Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -11030,7 +10967,7 @@ func (p projMinusDatumConstInt32Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -11053,7 +10990,7 @@ func (p projMinusDatumConstInt32Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -11081,7 +11018,7 @@ func (p projMinusDatumConstInt32Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -11101,7 +11038,7 @@ func (p projMinusDatumConstInt32Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -11174,7 +11111,7 @@ func (p projMinusDatumConstInt64Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -11197,7 +11134,7 @@ func (p projMinusDatumConstInt64Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -11225,7 +11162,7 @@ func (p projMinusDatumConstInt64Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -11245,7 +11182,7 @@ func (p projMinusDatumConstInt64Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -24540,7 +24477,7 @@ func (p projConcatDatumConstDatumOp) Next() coldata.Batch {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
-						_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -24559,7 +24496,7 @@ func (p projConcatDatumConstDatumOp) Next() coldata.Batch {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
-						_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -24583,7 +24520,7 @@ func (p projConcatDatumConstDatumOp) Next() coldata.Batch {
 				for _, i := range sel {
 					arg := col.Get(i)
 
-					_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -24599,7 +24536,7 @@ func (p projConcatDatumConstDatumOp) Next() coldata.Batch {
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
-					_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -25806,7 +25743,7 @@ func (p projLShiftDatumConstInt16Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -25829,7 +25766,7 @@ func (p projLShiftDatumConstInt16Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -25857,7 +25794,7 @@ func (p projLShiftDatumConstInt16Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -25877,7 +25814,7 @@ func (p projLShiftDatumConstInt16Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -25950,7 +25887,7 @@ func (p projLShiftDatumConstInt32Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -25973,7 +25910,7 @@ func (p projLShiftDatumConstInt32Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -26001,7 +25938,7 @@ func (p projLShiftDatumConstInt32Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -26021,7 +25958,7 @@ func (p projLShiftDatumConstInt32Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -26094,7 +26031,7 @@ func (p projLShiftDatumConstInt64Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -26117,7 +26054,7 @@ func (p projLShiftDatumConstInt64Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -26145,7 +26082,7 @@ func (p projLShiftDatumConstInt64Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -26165,7 +26102,7 @@ func (p projLShiftDatumConstInt64Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -27372,7 +27309,7 @@ func (p projRShiftDatumConstInt16Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -27395,7 +27332,7 @@ func (p projRShiftDatumConstInt16Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -27423,7 +27360,7 @@ func (p projRShiftDatumConstInt16Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -27443,7 +27380,7 @@ func (p projRShiftDatumConstInt16Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -27516,7 +27453,7 @@ func (p projRShiftDatumConstInt32Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -27539,7 +27476,7 @@ func (p projRShiftDatumConstInt32Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -27567,7 +27504,7 @@ func (p projRShiftDatumConstInt32Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -27587,7 +27524,7 @@ func (p projRShiftDatumConstInt32Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -27660,7 +27597,7 @@ func (p projRShiftDatumConstInt64Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -27683,7 +27620,7 @@ func (p projRShiftDatumConstInt64Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -27711,7 +27648,7 @@ func (p projRShiftDatumConstInt64Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -27731,7 +27668,7 @@ func (p projRShiftDatumConstInt64Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := p.constArg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -28992,7 +28929,7 @@ func (p projJSONFetchValPathJSONConstDatumOp) Next() coldata.Batch {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
-						_path, _err := tree.GetJSONPath(p.constArg, *tree.MustBeDArray(arg.(*coldataext.Datum).Datum))
+						_path, _err := tree.GetJSONPath(p.constArg, *tree.MustBeDArray(arg.(tree.Datum)))
 						if _err != nil {
 							colexecerror.ExpectedError(_err)
 						}
@@ -29011,7 +28948,7 @@ func (p projJSONFetchValPathJSONConstDatumOp) Next() coldata.Batch {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
-						_path, _err := tree.GetJSONPath(p.constArg, *tree.MustBeDArray(arg.(*coldataext.Datum).Datum))
+						_path, _err := tree.GetJSONPath(p.constArg, *tree.MustBeDArray(arg.(tree.Datum)))
 						if _err != nil {
 							colexecerror.ExpectedError(_err)
 						}
@@ -29035,7 +28972,7 @@ func (p projJSONFetchValPathJSONConstDatumOp) Next() coldata.Batch {
 				for _, i := range sel {
 					arg := col.Get(i)
 
-					_path, _err := tree.GetJSONPath(p.constArg, *tree.MustBeDArray(arg.(*coldataext.Datum).Datum))
+					_path, _err := tree.GetJSONPath(p.constArg, *tree.MustBeDArray(arg.(tree.Datum)))
 					if _err != nil {
 						colexecerror.ExpectedError(_err)
 					}
@@ -29051,7 +28988,7 @@ func (p projJSONFetchValPathJSONConstDatumOp) Next() coldata.Batch {
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
-					_path, _err := tree.GetJSONPath(p.constArg, *tree.MustBeDArray(arg.(*coldataext.Datum).Datum))
+					_path, _err := tree.GetJSONPath(p.constArg, *tree.MustBeDArray(arg.(tree.Datum)))
 					if _err != nil {
 						colexecerror.ExpectedError(_err)
 					}
@@ -29120,7 +29057,7 @@ func (p projJSONFetchTextPathJSONConstDatumOp) Next() coldata.Batch {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
-						_path, _err := tree.GetJSONPath(p.constArg, *tree.MustBeDArray(arg.(*coldataext.Datum).Datum))
+						_path, _err := tree.GetJSONPath(p.constArg, *tree.MustBeDArray(arg.(tree.Datum)))
 						if _err != nil {
 							colexecerror.ExpectedError(_err)
 						}
@@ -29149,7 +29086,7 @@ func (p projJSONFetchTextPathJSONConstDatumOp) Next() coldata.Batch {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
-						_path, _err := tree.GetJSONPath(p.constArg, *tree.MustBeDArray(arg.(*coldataext.Datum).Datum))
+						_path, _err := tree.GetJSONPath(p.constArg, *tree.MustBeDArray(arg.(tree.Datum)))
 						if _err != nil {
 							colexecerror.ExpectedError(_err)
 						}
@@ -29183,7 +29120,7 @@ func (p projJSONFetchTextPathJSONConstDatumOp) Next() coldata.Batch {
 				for _, i := range sel {
 					arg := col.Get(i)
 
-					_path, _err := tree.GetJSONPath(p.constArg, *tree.MustBeDArray(arg.(*coldataext.Datum).Datum))
+					_path, _err := tree.GetJSONPath(p.constArg, *tree.MustBeDArray(arg.(tree.Datum)))
 					if _err != nil {
 						colexecerror.ExpectedError(_err)
 					}
@@ -29209,7 +29146,7 @@ func (p projJSONFetchTextPathJSONConstDatumOp) Next() coldata.Batch {
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
-					_path, _err := tree.GetJSONPath(p.constArg, *tree.MustBeDArray(arg.(*coldataext.Datum).Datum))
+					_path, _err := tree.GetJSONPath(p.constArg, *tree.MustBeDArray(arg.(tree.Datum)))
 					if _err != nil {
 						colexecerror.ExpectedError(_err)
 					}
@@ -29355,7 +29292,7 @@ func GetProjectionLConstOperator(
 						default:
 							return &projBitandDatumConstDatumOp{
 								projConstOpBase: projConstOpBase,
-								constArg:        &coldataext.Datum{Datum: c.(tree.Datum)},
+								constArg:        constArg,
 							}, nil
 						}
 					}
@@ -29444,7 +29381,7 @@ func GetProjectionLConstOperator(
 						default:
 							return &projBitorDatumConstDatumOp{
 								projConstOpBase: projConstOpBase,
-								constArg:        &coldataext.Datum{Datum: c.(tree.Datum)},
+								constArg:        constArg,
 							}, nil
 						}
 					}
@@ -29533,7 +29470,7 @@ func GetProjectionLConstOperator(
 						default:
 							return &projBitxorDatumConstDatumOp{
 								projConstOpBase: projConstOpBase,
-								constArg:        &coldataext.Datum{Datum: c.(tree.Datum)},
+								constArg:        constArg,
 							}, nil
 						}
 					}
@@ -29777,7 +29714,7 @@ func GetProjectionLConstOperator(
 						default:
 							return &projPlusDatumConstIntervalOp{
 								projConstOpBase: projConstOpBase,
-								constArg:        &coldataext.Datum{Datum: c.(tree.Datum)},
+								constArg:        constArg,
 							}, nil
 						}
 					case types.IntFamily:
@@ -29785,18 +29722,18 @@ func GetProjectionLConstOperator(
 						case 16:
 							return &projPlusDatumConstInt16Op{
 								projConstOpBase: projConstOpBase,
-								constArg:        &coldataext.Datum{Datum: c.(tree.Datum)},
+								constArg:        constArg,
 							}, nil
 						case 32:
 							return &projPlusDatumConstInt32Op{
 								projConstOpBase: projConstOpBase,
-								constArg:        &coldataext.Datum{Datum: c.(tree.Datum)},
+								constArg:        constArg,
 							}, nil
 						case -1:
 						default:
 							return &projPlusDatumConstInt64Op{
 								projConstOpBase: projConstOpBase,
-								constArg:        &coldataext.Datum{Datum: c.(tree.Datum)},
+								constArg:        constArg,
 							}, nil
 						}
 					}
@@ -30075,7 +30012,7 @@ func GetProjectionLConstOperator(
 						default:
 							return &projMinusDatumConstDatumOp{
 								projConstOpBase: projConstOpBase,
-								constArg:        &coldataext.Datum{Datum: c.(tree.Datum)},
+								constArg:        constArg,
 							}, nil
 						}
 					case types.IntervalFamily:
@@ -30084,7 +30021,7 @@ func GetProjectionLConstOperator(
 						default:
 							return &projMinusDatumConstIntervalOp{
 								projConstOpBase: projConstOpBase,
-								constArg:        &coldataext.Datum{Datum: c.(tree.Datum)},
+								constArg:        constArg,
 							}, nil
 						}
 					case types.BytesFamily:
@@ -30093,7 +30030,7 @@ func GetProjectionLConstOperator(
 						default:
 							return &projMinusDatumConstBytesOp{
 								projConstOpBase: projConstOpBase,
-								constArg:        &coldataext.Datum{Datum: c.(tree.Datum)},
+								constArg:        constArg,
 							}, nil
 						}
 					case types.IntFamily:
@@ -30101,18 +30038,18 @@ func GetProjectionLConstOperator(
 						case 16:
 							return &projMinusDatumConstInt16Op{
 								projConstOpBase: projConstOpBase,
-								constArg:        &coldataext.Datum{Datum: c.(tree.Datum)},
+								constArg:        constArg,
 							}, nil
 						case 32:
 							return &projMinusDatumConstInt32Op{
 								projConstOpBase: projConstOpBase,
-								constArg:        &coldataext.Datum{Datum: c.(tree.Datum)},
+								constArg:        constArg,
 							}, nil
 						case -1:
 						default:
 							return &projMinusDatumConstInt64Op{
 								projConstOpBase: projConstOpBase,
-								constArg:        &coldataext.Datum{Datum: c.(tree.Datum)},
+								constArg:        constArg,
 							}, nil
 						}
 					}
@@ -31032,7 +30969,7 @@ func GetProjectionLConstOperator(
 						default:
 							return &projConcatDatumConstDatumOp{
 								projConstOpBase: projConstOpBase,
-								constArg:        &coldataext.Datum{Datum: c.(tree.Datum)},
+								constArg:        constArg,
 							}, nil
 						}
 					}
@@ -31120,18 +31057,18 @@ func GetProjectionLConstOperator(
 						case 16:
 							return &projLShiftDatumConstInt16Op{
 								projConstOpBase: projConstOpBase,
-								constArg:        &coldataext.Datum{Datum: c.(tree.Datum)},
+								constArg:        constArg,
 							}, nil
 						case 32:
 							return &projLShiftDatumConstInt32Op{
 								projConstOpBase: projConstOpBase,
-								constArg:        &coldataext.Datum{Datum: c.(tree.Datum)},
+								constArg:        constArg,
 							}, nil
 						case -1:
 						default:
 							return &projLShiftDatumConstInt64Op{
 								projConstOpBase: projConstOpBase,
-								constArg:        &coldataext.Datum{Datum: c.(tree.Datum)},
+								constArg:        constArg,
 							}, nil
 						}
 					}
@@ -31219,18 +31156,18 @@ func GetProjectionLConstOperator(
 						case 16:
 							return &projRShiftDatumConstInt16Op{
 								projConstOpBase: projConstOpBase,
-								constArg:        &coldataext.Datum{Datum: c.(tree.Datum)},
+								constArg:        constArg,
 							}, nil
 						case 32:
 							return &projRShiftDatumConstInt32Op{
 								projConstOpBase: projConstOpBase,
-								constArg:        &coldataext.Datum{Datum: c.(tree.Datum)},
+								constArg:        constArg,
 							}, nil
 						case -1:
 						default:
 							return &projRShiftDatumConstInt64Op{
 								projConstOpBase: projConstOpBase,
-								constArg:        &coldataext.Datum{Datum: c.(tree.Datum)},
+								constArg:        constArg,
 							}, nil
 						}
 					}

--- a/pkg/sql/colexec/colexecproj/proj_const_ops_tmpl.go
+++ b/pkg/sql/colexec/colexecproj/proj_const_ops_tmpl.go
@@ -48,6 +48,7 @@ var (
 	_ sqltelemetry.EnumTelemetryType
 	_ telemetry.Counter
 	_ json.JSON
+	_ = coldataext.CompareDatum
 )
 
 // {{/*
@@ -297,24 +298,13 @@ func GetProjection_CONST_SIDEConstOperator(
 								projConstOpBase: projConstOpBase,
 								// {{if _IS_CONST_LEFT}}
 								// {{if eq $leftFamilyStr "typeconv.DatumVecCanonicalTypeFamily"}}
-								// {{/*
-								//     Binary operations are evaluated using coldataext.Datum.BinFn
-								//     method which requires that we have *coldataext.Datum on the
-								//     left, so we create that at the operator construction time to
-								//     avoid runtime conversion.
-								// */}}
-								constArg: &coldataext.Datum{Datum: c.(tree.Datum)},
+								constArg: constArg,
 								// {{else}}
 								constArg: c.(_L_GO_TYPE),
 								// {{end}}
 								// {{else}}
 								// {{if eq $rightFamilyStr "typeconv.DatumVecCanonicalTypeFamily"}}
-								// {{/*
-								//     Binary operations with a datum-backed value on the right side
-								//     require that we have *coldataext.Datum on the right (this is
-								//     what we get in non-constant case).
-								// */}}
-								constArg: &coldataext.Datum{Datum: c.(tree.Datum)},
+								constArg: constArg,
 								// {{else}}
 								constArg: c.(_R_GO_TYPE),
 								// {{end}}

--- a/pkg/sql/colexec/colexecproj/proj_const_right_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/proj_const_right_ops.eg.go
@@ -43,6 +43,7 @@ var (
 	_ sqltelemetry.EnumTelemetryType
 	_ telemetry.Counter
 	_ json.JSON
+	_ = coldataext.CompareDatum
 )
 
 type projBitandInt16Int16ConstOp struct {
@@ -1008,7 +1009,7 @@ func (p projBitandDatumDatumConstOp) Next() coldata.Batch {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
-						_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -1027,7 +1028,7 @@ func (p projBitandDatumDatumConstOp) Next() coldata.Batch {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
-						_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -1051,7 +1052,7 @@ func (p projBitandDatumDatumConstOp) Next() coldata.Batch {
 				for _, i := range sel {
 					arg := col.Get(i)
 
-					_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -1067,7 +1068,7 @@ func (p projBitandDatumDatumConstOp) Next() coldata.Batch {
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
-					_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -2054,7 +2055,7 @@ func (p projBitorDatumDatumConstOp) Next() coldata.Batch {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
-						_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -2073,7 +2074,7 @@ func (p projBitorDatumDatumConstOp) Next() coldata.Batch {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
-						_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -2097,7 +2098,7 @@ func (p projBitorDatumDatumConstOp) Next() coldata.Batch {
 				for _, i := range sel {
 					arg := col.Get(i)
 
-					_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -2113,7 +2114,7 @@ func (p projBitorDatumDatumConstOp) Next() coldata.Batch {
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
-					_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -3100,7 +3101,7 @@ func (p projBitxorDatumDatumConstOp) Next() coldata.Batch {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
-						_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -3119,7 +3120,7 @@ func (p projBitxorDatumDatumConstOp) Next() coldata.Batch {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
-						_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -3143,7 +3144,7 @@ func (p projBitxorDatumDatumConstOp) Next() coldata.Batch {
 				for _, i := range sel {
 					arg := col.Get(i)
 
-					_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -3159,7 +3160,7 @@ func (p projBitxorDatumDatumConstOp) Next() coldata.Batch {
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
-					_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -4260,9 +4261,7 @@ func (p projPlusInt16DatumConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-						_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -4285,9 +4284,7 @@ func (p projPlusInt16DatumConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-						_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -4315,9 +4312,7 @@ func (p projPlusInt16DatumConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-					_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -4337,9 +4332,7 @@ func (p projPlusInt16DatumConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-					_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -4924,9 +4917,7 @@ func (p projPlusInt32DatumConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-						_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -4949,9 +4940,7 @@ func (p projPlusInt32DatumConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-						_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -4979,9 +4968,7 @@ func (p projPlusInt32DatumConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-					_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -5001,9 +4988,7 @@ func (p projPlusInt32DatumConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-					_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -5588,9 +5573,7 @@ func (p projPlusInt64DatumConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-						_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -5613,9 +5596,7 @@ func (p projPlusInt64DatumConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-						_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -5643,9 +5624,7 @@ func (p projPlusInt64DatumConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-					_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -5665,9 +5644,7 @@ func (p projPlusInt64DatumConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-					_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -6176,9 +6153,7 @@ func (p projPlusIntervalDatumConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-						_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -6201,9 +6176,7 @@ func (p projPlusIntervalDatumConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-						_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -6231,9 +6204,7 @@ func (p projPlusIntervalDatumConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-					_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -6253,9 +6224,7 @@ func (p projPlusIntervalDatumConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-					_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -6328,7 +6297,7 @@ func (p projPlusDatumIntervalConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -6352,7 +6321,7 @@ func (p projPlusDatumIntervalConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -6380,7 +6349,7 @@ func (p projPlusDatumIntervalConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -6401,7 +6370,7 @@ func (p projPlusDatumIntervalConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -6474,7 +6443,7 @@ func (p projPlusDatumInt16ConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -6498,7 +6467,7 @@ func (p projPlusDatumInt16ConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -6526,7 +6495,7 @@ func (p projPlusDatumInt16ConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -6547,7 +6516,7 @@ func (p projPlusDatumInt16ConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -6620,7 +6589,7 @@ func (p projPlusDatumInt32ConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -6644,7 +6613,7 @@ func (p projPlusDatumInt32ConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -6672,7 +6641,7 @@ func (p projPlusDatumInt32ConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -6693,7 +6662,7 @@ func (p projPlusDatumInt32ConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -6766,7 +6735,7 @@ func (p projPlusDatumInt64ConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -6790,7 +6759,7 @@ func (p projPlusDatumInt64ConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -6818,7 +6787,7 @@ func (p projPlusDatumInt64ConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -6839,7 +6808,7 @@ func (p projPlusDatumInt64ConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -7940,9 +7909,7 @@ func (p projMinusInt16DatumConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-						_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -7965,9 +7932,7 @@ func (p projMinusInt16DatumConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-						_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -7995,9 +7960,7 @@ func (p projMinusInt16DatumConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-					_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -8017,9 +7980,7 @@ func (p projMinusInt16DatumConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-					_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -8604,9 +8565,7 @@ func (p projMinusInt32DatumConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-						_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -8629,9 +8588,7 @@ func (p projMinusInt32DatumConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-						_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -8659,9 +8616,7 @@ func (p projMinusInt32DatumConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-					_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -8681,9 +8636,7 @@ func (p projMinusInt32DatumConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-					_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -9268,9 +9221,7 @@ func (p projMinusInt64DatumConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-						_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -9293,9 +9244,7 @@ func (p projMinusInt64DatumConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-						_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -9323,9 +9272,7 @@ func (p projMinusInt64DatumConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-					_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -9345,9 +9292,7 @@ func (p projMinusInt64DatumConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-					_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -9848,9 +9793,7 @@ func (p projMinusIntervalDatumConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-						_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -9873,9 +9816,7 @@ func (p projMinusIntervalDatumConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-						_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -9903,9 +9844,7 @@ func (p projMinusIntervalDatumConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-					_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -9925,9 +9864,7 @@ func (p projMinusIntervalDatumConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-					_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -10466,7 +10403,7 @@ func (p projMinusDatumDatumConstOp) Next() coldata.Batch {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
-						_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -10485,7 +10422,7 @@ func (p projMinusDatumDatumConstOp) Next() coldata.Batch {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
-						_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -10509,7 +10446,7 @@ func (p projMinusDatumDatumConstOp) Next() coldata.Batch {
 				for _, i := range sel {
 					arg := col.Get(i)
 
-					_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -10525,7 +10462,7 @@ func (p projMinusDatumDatumConstOp) Next() coldata.Batch {
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
-					_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -10598,7 +10535,7 @@ func (p projMinusDatumIntervalConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -10622,7 +10559,7 @@ func (p projMinusDatumIntervalConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -10650,7 +10587,7 @@ func (p projMinusDatumIntervalConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -10671,7 +10608,7 @@ func (p projMinusDatumIntervalConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -10744,7 +10681,7 @@ func (p projMinusDatumBytesConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -10767,7 +10704,7 @@ func (p projMinusDatumBytesConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -10795,7 +10732,7 @@ func (p projMinusDatumBytesConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -10815,7 +10752,7 @@ func (p projMinusDatumBytesConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -10888,7 +10825,7 @@ func (p projMinusDatumInt16ConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -10912,7 +10849,7 @@ func (p projMinusDatumInt16ConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -10940,7 +10877,7 @@ func (p projMinusDatumInt16ConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -10961,7 +10898,7 @@ func (p projMinusDatumInt16ConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -11034,7 +10971,7 @@ func (p projMinusDatumInt32ConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -11058,7 +10995,7 @@ func (p projMinusDatumInt32ConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -11086,7 +11023,7 @@ func (p projMinusDatumInt32ConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -11107,7 +11044,7 @@ func (p projMinusDatumInt32ConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -11180,7 +11117,7 @@ func (p projMinusDatumInt64ConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -11204,7 +11141,7 @@ func (p projMinusDatumInt64ConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -11232,7 +11169,7 @@ func (p projMinusDatumInt64ConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -11253,7 +11190,7 @@ func (p projMinusDatumInt64ConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -24548,7 +24485,7 @@ func (p projConcatDatumDatumConstOp) Next() coldata.Batch {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
-						_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -24567,7 +24504,7 @@ func (p projConcatDatumDatumConstOp) Next() coldata.Batch {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
-						_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -24591,7 +24528,7 @@ func (p projConcatDatumDatumConstOp) Next() coldata.Batch {
 				for _, i := range sel {
 					arg := col.Get(i)
 
-					_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -24607,7 +24544,7 @@ func (p projConcatDatumDatumConstOp) Next() coldata.Batch {
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
-					_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, p.constArg)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -25814,7 +25751,7 @@ func (p projLShiftDatumInt16ConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -25838,7 +25775,7 @@ func (p projLShiftDatumInt16ConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -25866,7 +25803,7 @@ func (p projLShiftDatumInt16ConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -25887,7 +25824,7 @@ func (p projLShiftDatumInt16ConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -25960,7 +25897,7 @@ func (p projLShiftDatumInt32ConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -25984,7 +25921,7 @@ func (p projLShiftDatumInt32ConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -26012,7 +25949,7 @@ func (p projLShiftDatumInt32ConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -26033,7 +25970,7 @@ func (p projLShiftDatumInt32ConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -26106,7 +26043,7 @@ func (p projLShiftDatumInt64ConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -26130,7 +26067,7 @@ func (p projLShiftDatumInt64ConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -26158,7 +26095,7 @@ func (p projLShiftDatumInt64ConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -26179,7 +26116,7 @@ func (p projLShiftDatumInt64ConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -27386,7 +27323,7 @@ func (p projRShiftDatumInt16ConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -27410,7 +27347,7 @@ func (p projRShiftDatumInt16ConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -27438,7 +27375,7 @@ func (p projRShiftDatumInt16ConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -27459,7 +27396,7 @@ func (p projRShiftDatumInt16ConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -27532,7 +27469,7 @@ func (p projRShiftDatumInt32ConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -27556,7 +27493,7 @@ func (p projRShiftDatumInt32ConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -27584,7 +27521,7 @@ func (p projRShiftDatumInt32ConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -27605,7 +27542,7 @@ func (p projRShiftDatumInt32ConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -27678,7 +27615,7 @@ func (p projRShiftDatumInt64ConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -27702,7 +27639,7 @@ func (p projRShiftDatumInt64ConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -27730,7 +27667,7 @@ func (p projRShiftDatumInt64ConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -27751,7 +27688,7 @@ func (p projRShiftDatumInt64ConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -29024,7 +28961,7 @@ func (p projJSONFetchValPathJSONDatumConstOp) Next() coldata.Batch {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
-						_path, _err := tree.GetJSONPath(arg, *tree.MustBeDArray(p.constArg.(*coldataext.Datum).Datum))
+						_path, _err := tree.GetJSONPath(arg, *tree.MustBeDArray(p.constArg.(tree.Datum)))
 						if _err != nil {
 							colexecerror.ExpectedError(_err)
 						}
@@ -29043,7 +28980,7 @@ func (p projJSONFetchValPathJSONDatumConstOp) Next() coldata.Batch {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
-						_path, _err := tree.GetJSONPath(arg, *tree.MustBeDArray(p.constArg.(*coldataext.Datum).Datum))
+						_path, _err := tree.GetJSONPath(arg, *tree.MustBeDArray(p.constArg.(tree.Datum)))
 						if _err != nil {
 							colexecerror.ExpectedError(_err)
 						}
@@ -29067,7 +29004,7 @@ func (p projJSONFetchValPathJSONDatumConstOp) Next() coldata.Batch {
 				for _, i := range sel {
 					arg := col.Get(i)
 
-					_path, _err := tree.GetJSONPath(arg, *tree.MustBeDArray(p.constArg.(*coldataext.Datum).Datum))
+					_path, _err := tree.GetJSONPath(arg, *tree.MustBeDArray(p.constArg.(tree.Datum)))
 					if _err != nil {
 						colexecerror.ExpectedError(_err)
 					}
@@ -29083,7 +29020,7 @@ func (p projJSONFetchValPathJSONDatumConstOp) Next() coldata.Batch {
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
-					_path, _err := tree.GetJSONPath(arg, *tree.MustBeDArray(p.constArg.(*coldataext.Datum).Datum))
+					_path, _err := tree.GetJSONPath(arg, *tree.MustBeDArray(p.constArg.(tree.Datum)))
 					if _err != nil {
 						colexecerror.ExpectedError(_err)
 					}
@@ -29152,7 +29089,7 @@ func (p projJSONFetchTextPathJSONDatumConstOp) Next() coldata.Batch {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
-						_path, _err := tree.GetJSONPath(arg, *tree.MustBeDArray(p.constArg.(*coldataext.Datum).Datum))
+						_path, _err := tree.GetJSONPath(arg, *tree.MustBeDArray(p.constArg.(tree.Datum)))
 						if _err != nil {
 							colexecerror.ExpectedError(_err)
 						}
@@ -29181,7 +29118,7 @@ func (p projJSONFetchTextPathJSONDatumConstOp) Next() coldata.Batch {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
-						_path, _err := tree.GetJSONPath(arg, *tree.MustBeDArray(p.constArg.(*coldataext.Datum).Datum))
+						_path, _err := tree.GetJSONPath(arg, *tree.MustBeDArray(p.constArg.(tree.Datum)))
 						if _err != nil {
 							colexecerror.ExpectedError(_err)
 						}
@@ -29215,7 +29152,7 @@ func (p projJSONFetchTextPathJSONDatumConstOp) Next() coldata.Batch {
 				for _, i := range sel {
 					arg := col.Get(i)
 
-					_path, _err := tree.GetJSONPath(arg, *tree.MustBeDArray(p.constArg.(*coldataext.Datum).Datum))
+					_path, _err := tree.GetJSONPath(arg, *tree.MustBeDArray(p.constArg.(tree.Datum)))
 					if _err != nil {
 						colexecerror.ExpectedError(_err)
 					}
@@ -29241,7 +29178,7 @@ func (p projJSONFetchTextPathJSONDatumConstOp) Next() coldata.Batch {
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
-					_path, _err := tree.GetJSONPath(arg, *tree.MustBeDArray(p.constArg.(*coldataext.Datum).Datum))
+					_path, _err := tree.GetJSONPath(arg, *tree.MustBeDArray(p.constArg.(tree.Datum)))
 					if _err != nil {
 						colexecerror.ExpectedError(_err)
 					}
@@ -34079,7 +34016,7 @@ func (p projEQDatumDatumConstOp) Next() coldata.Batch {
 						{
 							var cmpResult int
 
-							cmpResult = arg.(*coldataext.Datum).CompareDatum(col, p.constArg)
+							cmpResult = coldataext.CompareDatum(arg, col, p.constArg)
 
 							projCol[i] = cmpResult == 0
 						}
@@ -34097,7 +34034,7 @@ func (p projEQDatumDatumConstOp) Next() coldata.Batch {
 						{
 							var cmpResult int
 
-							cmpResult = arg.(*coldataext.Datum).CompareDatum(col, p.constArg)
+							cmpResult = coldataext.CompareDatum(arg, col, p.constArg)
 
 							projCol[i] = cmpResult == 0
 						}
@@ -34120,7 +34057,7 @@ func (p projEQDatumDatumConstOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg.(*coldataext.Datum).CompareDatum(col, p.constArg)
+						cmpResult = coldataext.CompareDatum(arg, col, p.constArg)
 
 						projCol[i] = cmpResult == 0
 					}
@@ -34135,7 +34072,7 @@ func (p projEQDatumDatumConstOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg.(*coldataext.Datum).CompareDatum(col, p.constArg)
+						cmpResult = coldataext.CompareDatum(arg, col, p.constArg)
 
 						projCol[i] = cmpResult == 0
 					}
@@ -38959,7 +38896,7 @@ func (p projNEDatumDatumConstOp) Next() coldata.Batch {
 						{
 							var cmpResult int
 
-							cmpResult = arg.(*coldataext.Datum).CompareDatum(col, p.constArg)
+							cmpResult = coldataext.CompareDatum(arg, col, p.constArg)
 
 							projCol[i] = cmpResult != 0
 						}
@@ -38977,7 +38914,7 @@ func (p projNEDatumDatumConstOp) Next() coldata.Batch {
 						{
 							var cmpResult int
 
-							cmpResult = arg.(*coldataext.Datum).CompareDatum(col, p.constArg)
+							cmpResult = coldataext.CompareDatum(arg, col, p.constArg)
 
 							projCol[i] = cmpResult != 0
 						}
@@ -39000,7 +38937,7 @@ func (p projNEDatumDatumConstOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg.(*coldataext.Datum).CompareDatum(col, p.constArg)
+						cmpResult = coldataext.CompareDatum(arg, col, p.constArg)
 
 						projCol[i] = cmpResult != 0
 					}
@@ -39015,7 +38952,7 @@ func (p projNEDatumDatumConstOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg.(*coldataext.Datum).CompareDatum(col, p.constArg)
+						cmpResult = coldataext.CompareDatum(arg, col, p.constArg)
 
 						projCol[i] = cmpResult != 0
 					}
@@ -43839,7 +43776,7 @@ func (p projLTDatumDatumConstOp) Next() coldata.Batch {
 						{
 							var cmpResult int
 
-							cmpResult = arg.(*coldataext.Datum).CompareDatum(col, p.constArg)
+							cmpResult = coldataext.CompareDatum(arg, col, p.constArg)
 
 							projCol[i] = cmpResult < 0
 						}
@@ -43857,7 +43794,7 @@ func (p projLTDatumDatumConstOp) Next() coldata.Batch {
 						{
 							var cmpResult int
 
-							cmpResult = arg.(*coldataext.Datum).CompareDatum(col, p.constArg)
+							cmpResult = coldataext.CompareDatum(arg, col, p.constArg)
 
 							projCol[i] = cmpResult < 0
 						}
@@ -43880,7 +43817,7 @@ func (p projLTDatumDatumConstOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg.(*coldataext.Datum).CompareDatum(col, p.constArg)
+						cmpResult = coldataext.CompareDatum(arg, col, p.constArg)
 
 						projCol[i] = cmpResult < 0
 					}
@@ -43895,7 +43832,7 @@ func (p projLTDatumDatumConstOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg.(*coldataext.Datum).CompareDatum(col, p.constArg)
+						cmpResult = coldataext.CompareDatum(arg, col, p.constArg)
 
 						projCol[i] = cmpResult < 0
 					}
@@ -48719,7 +48656,7 @@ func (p projLEDatumDatumConstOp) Next() coldata.Batch {
 						{
 							var cmpResult int
 
-							cmpResult = arg.(*coldataext.Datum).CompareDatum(col, p.constArg)
+							cmpResult = coldataext.CompareDatum(arg, col, p.constArg)
 
 							projCol[i] = cmpResult <= 0
 						}
@@ -48737,7 +48674,7 @@ func (p projLEDatumDatumConstOp) Next() coldata.Batch {
 						{
 							var cmpResult int
 
-							cmpResult = arg.(*coldataext.Datum).CompareDatum(col, p.constArg)
+							cmpResult = coldataext.CompareDatum(arg, col, p.constArg)
 
 							projCol[i] = cmpResult <= 0
 						}
@@ -48760,7 +48697,7 @@ func (p projLEDatumDatumConstOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg.(*coldataext.Datum).CompareDatum(col, p.constArg)
+						cmpResult = coldataext.CompareDatum(arg, col, p.constArg)
 
 						projCol[i] = cmpResult <= 0
 					}
@@ -48775,7 +48712,7 @@ func (p projLEDatumDatumConstOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg.(*coldataext.Datum).CompareDatum(col, p.constArg)
+						cmpResult = coldataext.CompareDatum(arg, col, p.constArg)
 
 						projCol[i] = cmpResult <= 0
 					}
@@ -53599,7 +53536,7 @@ func (p projGTDatumDatumConstOp) Next() coldata.Batch {
 						{
 							var cmpResult int
 
-							cmpResult = arg.(*coldataext.Datum).CompareDatum(col, p.constArg)
+							cmpResult = coldataext.CompareDatum(arg, col, p.constArg)
 
 							projCol[i] = cmpResult > 0
 						}
@@ -53617,7 +53554,7 @@ func (p projGTDatumDatumConstOp) Next() coldata.Batch {
 						{
 							var cmpResult int
 
-							cmpResult = arg.(*coldataext.Datum).CompareDatum(col, p.constArg)
+							cmpResult = coldataext.CompareDatum(arg, col, p.constArg)
 
 							projCol[i] = cmpResult > 0
 						}
@@ -53640,7 +53577,7 @@ func (p projGTDatumDatumConstOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg.(*coldataext.Datum).CompareDatum(col, p.constArg)
+						cmpResult = coldataext.CompareDatum(arg, col, p.constArg)
 
 						projCol[i] = cmpResult > 0
 					}
@@ -53655,7 +53592,7 @@ func (p projGTDatumDatumConstOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg.(*coldataext.Datum).CompareDatum(col, p.constArg)
+						cmpResult = coldataext.CompareDatum(arg, col, p.constArg)
 
 						projCol[i] = cmpResult > 0
 					}
@@ -58479,7 +58416,7 @@ func (p projGEDatumDatumConstOp) Next() coldata.Batch {
 						{
 							var cmpResult int
 
-							cmpResult = arg.(*coldataext.Datum).CompareDatum(col, p.constArg)
+							cmpResult = coldataext.CompareDatum(arg, col, p.constArg)
 
 							projCol[i] = cmpResult >= 0
 						}
@@ -58497,7 +58434,7 @@ func (p projGEDatumDatumConstOp) Next() coldata.Batch {
 						{
 							var cmpResult int
 
-							cmpResult = arg.(*coldataext.Datum).CompareDatum(col, p.constArg)
+							cmpResult = coldataext.CompareDatum(arg, col, p.constArg)
 
 							projCol[i] = cmpResult >= 0
 						}
@@ -58520,7 +58457,7 @@ func (p projGEDatumDatumConstOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg.(*coldataext.Datum).CompareDatum(col, p.constArg)
+						cmpResult = coldataext.CompareDatum(arg, col, p.constArg)
 
 						projCol[i] = cmpResult >= 0
 					}
@@ -58535,7 +58472,7 @@ func (p projGEDatumDatumConstOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg.(*coldataext.Datum).CompareDatum(col, p.constArg)
+						cmpResult = coldataext.CompareDatum(arg, col, p.constArg)
 
 						projCol[i] = cmpResult >= 0
 					}
@@ -58667,7 +58604,7 @@ func GetProjectionRConstOperator(
 						default:
 							return &projBitandDatumDatumConstOp{
 								projConstOpBase: projConstOpBase,
-								constArg:        &coldataext.Datum{Datum: c.(tree.Datum)},
+								constArg:        constArg,
 							}, nil
 						}
 					}
@@ -58756,7 +58693,7 @@ func GetProjectionRConstOperator(
 						default:
 							return &projBitorDatumDatumConstOp{
 								projConstOpBase: projConstOpBase,
-								constArg:        &coldataext.Datum{Datum: c.(tree.Datum)},
+								constArg:        constArg,
 							}, nil
 						}
 					}
@@ -58845,7 +58782,7 @@ func GetProjectionRConstOperator(
 						default:
 							return &projBitxorDatumDatumConstOp{
 								projConstOpBase: projConstOpBase,
-								constArg:        &coldataext.Datum{Datum: c.(tree.Datum)},
+								constArg:        constArg,
 							}, nil
 						}
 					}
@@ -58926,7 +58863,7 @@ func GetProjectionRConstOperator(
 						default:
 							return &projPlusInt16DatumConstOp{
 								projConstOpBase: projConstOpBase,
-								constArg:        &coldataext.Datum{Datum: c.(tree.Datum)},
+								constArg:        constArg,
 							}, nil
 						}
 					}
@@ -58966,7 +58903,7 @@ func GetProjectionRConstOperator(
 						default:
 							return &projPlusInt32DatumConstOp{
 								projConstOpBase: projConstOpBase,
-								constArg:        &coldataext.Datum{Datum: c.(tree.Datum)},
+								constArg:        constArg,
 							}, nil
 						}
 					}
@@ -59007,7 +58944,7 @@ func GetProjectionRConstOperator(
 						default:
 							return &projPlusInt64DatumConstOp{
 								projConstOpBase: projConstOpBase,
-								constArg:        &coldataext.Datum{Datum: c.(tree.Datum)},
+								constArg:        constArg,
 							}, nil
 						}
 					}
@@ -59073,7 +59010,7 @@ func GetProjectionRConstOperator(
 						default:
 							return &projPlusIntervalDatumConstOp{
 								projConstOpBase: projConstOpBase,
-								constArg:        &coldataext.Datum{Datum: c.(tree.Datum)},
+								constArg:        constArg,
 							}, nil
 						}
 					}
@@ -59189,7 +59126,7 @@ func GetProjectionRConstOperator(
 						default:
 							return &projMinusInt16DatumConstOp{
 								projConstOpBase: projConstOpBase,
-								constArg:        &coldataext.Datum{Datum: c.(tree.Datum)},
+								constArg:        constArg,
 							}, nil
 						}
 					}
@@ -59229,7 +59166,7 @@ func GetProjectionRConstOperator(
 						default:
 							return &projMinusInt32DatumConstOp{
 								projConstOpBase: projConstOpBase,
-								constArg:        &coldataext.Datum{Datum: c.(tree.Datum)},
+								constArg:        constArg,
 							}, nil
 						}
 					}
@@ -59270,7 +59207,7 @@ func GetProjectionRConstOperator(
 						default:
 							return &projMinusInt64DatumConstOp{
 								projConstOpBase: projConstOpBase,
-								constArg:        &coldataext.Datum{Datum: c.(tree.Datum)},
+								constArg:        constArg,
 							}, nil
 						}
 					}
@@ -59336,7 +59273,7 @@ func GetProjectionRConstOperator(
 						default:
 							return &projMinusIntervalDatumConstOp{
 								projConstOpBase: projConstOpBase,
-								constArg:        &coldataext.Datum{Datum: c.(tree.Datum)},
+								constArg:        constArg,
 							}, nil
 						}
 					}
@@ -59387,7 +59324,7 @@ func GetProjectionRConstOperator(
 						default:
 							return &projMinusDatumDatumConstOp{
 								projConstOpBase: projConstOpBase,
-								constArg:        &coldataext.Datum{Datum: c.(tree.Datum)},
+								constArg:        constArg,
 							}, nil
 						}
 					case types.IntervalFamily:
@@ -60344,7 +60281,7 @@ func GetProjectionRConstOperator(
 						default:
 							return &projConcatDatumDatumConstOp{
 								projConstOpBase: projConstOpBase,
-								constArg:        &coldataext.Datum{Datum: c.(tree.Datum)},
+								constArg:        constArg,
 							}, nil
 						}
 					}
@@ -60637,7 +60574,7 @@ func GetProjectionRConstOperator(
 						default:
 							return &projJSONFetchValPathJSONDatumConstOp{
 								projConstOpBase: projConstOpBase,
-								constArg:        &coldataext.Datum{Datum: c.(tree.Datum)},
+								constArg:        constArg,
 							}, nil
 						}
 					}
@@ -60656,7 +60593,7 @@ func GetProjectionRConstOperator(
 						default:
 							return &projJSONFetchTextPathJSONDatumConstOp{
 								projConstOpBase: projConstOpBase,
-								constArg:        &coldataext.Datum{Datum: c.(tree.Datum)},
+								constArg:        constArg,
 							}, nil
 						}
 					}

--- a/pkg/sql/colexec/colexecproj/proj_non_const_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/proj_non_const_ops.eg.go
@@ -37,7 +37,7 @@ import (
 // pick up the right packages when run within the bazel sandbox.
 var (
 	_ duration.Duration
-	_ coldataext.Datum
+	_ = coldataext.CompareDatum
 	_ sqltelemetry.EnumTelemetryType
 	_ telemetry.Counter
 )
@@ -1100,7 +1100,7 @@ func (p projBitandDatumDatumOp) Next() coldata.Batch {
 						arg1 := col1.Get(i)
 						arg2 := col2.Get(i)
 
-						_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -1122,7 +1122,7 @@ func (p projBitandDatumDatumOp) Next() coldata.Batch {
 						arg1 := col1.Get(i)
 						arg2 := col2.Get(i)
 
-						_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -1147,7 +1147,7 @@ func (p projBitandDatumDatumOp) Next() coldata.Batch {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
-					_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -1165,7 +1165,7 @@ func (p projBitandDatumDatumOp) Next() coldata.Batch {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
-					_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -2224,7 +2224,7 @@ func (p projBitorDatumDatumOp) Next() coldata.Batch {
 						arg1 := col1.Get(i)
 						arg2 := col2.Get(i)
 
-						_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -2246,7 +2246,7 @@ func (p projBitorDatumDatumOp) Next() coldata.Batch {
 						arg1 := col1.Get(i)
 						arg2 := col2.Get(i)
 
-						_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -2271,7 +2271,7 @@ func (p projBitorDatumDatumOp) Next() coldata.Batch {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
-					_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -2289,7 +2289,7 @@ func (p projBitorDatumDatumOp) Next() coldata.Batch {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
-					_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -3348,7 +3348,7 @@ func (p projBitxorDatumDatumOp) Next() coldata.Batch {
 						arg1 := col1.Get(i)
 						arg2 := col2.Get(i)
 
-						_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -3370,7 +3370,7 @@ func (p projBitxorDatumDatumOp) Next() coldata.Batch {
 						arg1 := col1.Get(i)
 						arg2 := col2.Get(i)
 
-						_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -3395,7 +3395,7 @@ func (p projBitxorDatumDatumOp) Next() coldata.Batch {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
-					_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -3413,7 +3413,7 @@ func (p projBitxorDatumDatumOp) Next() coldata.Batch {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
-					_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -4578,9 +4578,7 @@ func (p projPlusInt16DatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-						_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -4607,9 +4605,7 @@ func (p projPlusInt16DatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-						_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -4638,9 +4634,7 @@ func (p projPlusInt16DatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-					_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -4663,9 +4657,7 @@ func (p projPlusInt16DatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-					_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -5282,9 +5274,7 @@ func (p projPlusInt32DatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-						_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -5311,9 +5301,7 @@ func (p projPlusInt32DatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-						_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -5342,9 +5330,7 @@ func (p projPlusInt32DatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-					_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -5367,9 +5353,7 @@ func (p projPlusInt32DatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-					_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -5986,9 +5970,7 @@ func (p projPlusInt64DatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-						_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -6015,9 +5997,7 @@ func (p projPlusInt64DatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-						_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -6046,9 +6026,7 @@ func (p projPlusInt64DatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-					_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -6071,9 +6049,7 @@ func (p projPlusInt64DatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-					_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -6614,9 +6590,7 @@ func (p projPlusIntervalDatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-						_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -6643,9 +6617,7 @@ func (p projPlusIntervalDatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-						_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -6674,9 +6646,7 @@ func (p projPlusIntervalDatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-					_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -6699,9 +6669,7 @@ func (p projPlusIntervalDatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-					_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -6774,7 +6742,7 @@ func (p projPlusDatumIntervalOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -6801,7 +6769,7 @@ func (p projPlusDatumIntervalOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -6830,7 +6798,7 @@ func (p projPlusDatumIntervalOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -6853,7 +6821,7 @@ func (p projPlusDatumIntervalOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -6926,7 +6894,7 @@ func (p projPlusDatumInt16Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -6953,7 +6921,7 @@ func (p projPlusDatumInt16Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -6982,7 +6950,7 @@ func (p projPlusDatumInt16Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -7005,7 +6973,7 @@ func (p projPlusDatumInt16Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -7078,7 +7046,7 @@ func (p projPlusDatumInt32Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -7105,7 +7073,7 @@ func (p projPlusDatumInt32Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -7134,7 +7102,7 @@ func (p projPlusDatumInt32Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -7157,7 +7125,7 @@ func (p projPlusDatumInt32Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -7230,7 +7198,7 @@ func (p projPlusDatumInt64Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -7257,7 +7225,7 @@ func (p projPlusDatumInt64Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -7286,7 +7254,7 @@ func (p projPlusDatumInt64Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -7309,7 +7277,7 @@ func (p projPlusDatumInt64Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -8474,9 +8442,7 @@ func (p projMinusInt16DatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-						_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -8503,9 +8469,7 @@ func (p projMinusInt16DatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-						_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -8534,9 +8498,7 @@ func (p projMinusInt16DatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-					_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -8559,9 +8521,7 @@ func (p projMinusInt16DatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-					_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -9178,9 +9138,7 @@ func (p projMinusInt32DatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-						_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -9207,9 +9165,7 @@ func (p projMinusInt32DatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-						_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -9238,9 +9194,7 @@ func (p projMinusInt32DatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-					_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -9263,9 +9217,7 @@ func (p projMinusInt32DatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-					_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -9882,9 +9834,7 @@ func (p projMinusInt64DatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-						_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -9911,9 +9861,7 @@ func (p projMinusInt64DatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-						_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -9942,9 +9890,7 @@ func (p projMinusInt64DatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-					_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -9967,9 +9913,7 @@ func (p projMinusInt64DatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-					_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -10502,9 +10446,7 @@ func (p projMinusIntervalDatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-						_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -10531,9 +10473,7 @@ func (p projMinusIntervalDatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-						_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -10562,9 +10502,7 @@ func (p projMinusIntervalDatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-					_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -10587,9 +10525,7 @@ func (p projMinusIntervalDatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_nonDatumArgAsColdataExtDatum := &coldataext.Datum{Datum: _nonDatumArgAsDatum}
-
-					_res, err := _nonDatumArgAsColdataExtDatum.BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -11152,7 +11088,7 @@ func (p projMinusDatumDatumOp) Next() coldata.Batch {
 						arg1 := col1.Get(i)
 						arg2 := col2.Get(i)
 
-						_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -11174,7 +11110,7 @@ func (p projMinusDatumDatumOp) Next() coldata.Batch {
 						arg1 := col1.Get(i)
 						arg2 := col2.Get(i)
 
-						_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -11199,7 +11135,7 @@ func (p projMinusDatumDatumOp) Next() coldata.Batch {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
-					_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -11217,7 +11153,7 @@ func (p projMinusDatumDatumOp) Next() coldata.Batch {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
-					_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -11290,7 +11226,7 @@ func (p projMinusDatumIntervalOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -11317,7 +11253,7 @@ func (p projMinusDatumIntervalOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -11346,7 +11282,7 @@ func (p projMinusDatumIntervalOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -11369,7 +11305,7 @@ func (p projMinusDatumIntervalOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -11442,7 +11378,7 @@ func (p projMinusDatumBytesOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -11468,7 +11404,7 @@ func (p projMinusDatumBytesOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -11497,7 +11433,7 @@ func (p projMinusDatumBytesOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -11519,7 +11455,7 @@ func (p projMinusDatumBytesOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -11592,7 +11528,7 @@ func (p projMinusDatumInt16Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -11619,7 +11555,7 @@ func (p projMinusDatumInt16Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -11648,7 +11584,7 @@ func (p projMinusDatumInt16Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -11671,7 +11607,7 @@ func (p projMinusDatumInt16Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -11744,7 +11680,7 @@ func (p projMinusDatumInt32Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -11771,7 +11707,7 @@ func (p projMinusDatumInt32Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -11800,7 +11736,7 @@ func (p projMinusDatumInt32Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -11823,7 +11759,7 @@ func (p projMinusDatumInt32Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -11896,7 +11832,7 @@ func (p projMinusDatumInt64Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -11923,7 +11859,7 @@ func (p projMinusDatumInt64Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -11952,7 +11888,7 @@ func (p projMinusDatumInt64Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -11975,7 +11911,7 @@ func (p projMinusDatumInt64Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -26058,7 +25994,7 @@ func (p projConcatDatumDatumOp) Next() coldata.Batch {
 						arg1 := col1.Get(i)
 						arg2 := col2.Get(i)
 
-						_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -26080,7 +26016,7 @@ func (p projConcatDatumDatumOp) Next() coldata.Batch {
 						arg1 := col1.Get(i)
 						arg2 := col2.Get(i)
 
-						_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -26105,7 +26041,7 @@ func (p projConcatDatumDatumOp) Next() coldata.Batch {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
-					_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -26123,7 +26059,7 @@ func (p projConcatDatumDatumOp) Next() coldata.Batch {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
-					_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, arg2)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -27402,7 +27338,7 @@ func (p projLShiftDatumInt16Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -27429,7 +27365,7 @@ func (p projLShiftDatumInt16Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -27458,7 +27394,7 @@ func (p projLShiftDatumInt16Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -27481,7 +27417,7 @@ func (p projLShiftDatumInt16Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -27554,7 +27490,7 @@ func (p projLShiftDatumInt32Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -27581,7 +27517,7 @@ func (p projLShiftDatumInt32Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -27610,7 +27546,7 @@ func (p projLShiftDatumInt32Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -27633,7 +27569,7 @@ func (p projLShiftDatumInt32Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -27706,7 +27642,7 @@ func (p projLShiftDatumInt64Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -27733,7 +27669,7 @@ func (p projLShiftDatumInt64Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -27762,7 +27698,7 @@ func (p projLShiftDatumInt64Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -27785,7 +27721,7 @@ func (p projLShiftDatumInt64Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -29064,7 +29000,7 @@ func (p projRShiftDatumInt16Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -29091,7 +29027,7 @@ func (p projRShiftDatumInt16Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -29120,7 +29056,7 @@ func (p projRShiftDatumInt16Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -29143,7 +29079,7 @@ func (p projRShiftDatumInt16Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -29216,7 +29152,7 @@ func (p projRShiftDatumInt32Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -29243,7 +29179,7 @@ func (p projRShiftDatumInt32Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -29272,7 +29208,7 @@ func (p projRShiftDatumInt32Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -29295,7 +29231,7 @@ func (p projRShiftDatumInt32Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -29368,7 +29304,7 @@ func (p projRShiftDatumInt64Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -29395,7 +29331,7 @@ func (p projRShiftDatumInt64Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -29424,7 +29360,7 @@ func (p projRShiftDatumInt64Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -29447,7 +29383,7 @@ func (p projRShiftDatumInt64Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := arg1.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, _nonDatumArgAsDatum)
+					_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -30768,7 +30704,7 @@ func (p projJSONFetchValPathJSONDatumOp) Next() coldata.Batch {
 						arg1 := col1.Get(i)
 						arg2 := col2.Get(i)
 
-						_path, _err := tree.GetJSONPath(arg1, *tree.MustBeDArray(arg2.(*coldataext.Datum).Datum))
+						_path, _err := tree.GetJSONPath(arg1, *tree.MustBeDArray(arg2.(tree.Datum)))
 						if _err != nil {
 							colexecerror.ExpectedError(_err)
 						}
@@ -30790,7 +30726,7 @@ func (p projJSONFetchValPathJSONDatumOp) Next() coldata.Batch {
 						arg1 := col1.Get(i)
 						arg2 := col2.Get(i)
 
-						_path, _err := tree.GetJSONPath(arg1, *tree.MustBeDArray(arg2.(*coldataext.Datum).Datum))
+						_path, _err := tree.GetJSONPath(arg1, *tree.MustBeDArray(arg2.(tree.Datum)))
 						if _err != nil {
 							colexecerror.ExpectedError(_err)
 						}
@@ -30815,7 +30751,7 @@ func (p projJSONFetchValPathJSONDatumOp) Next() coldata.Batch {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
-					_path, _err := tree.GetJSONPath(arg1, *tree.MustBeDArray(arg2.(*coldataext.Datum).Datum))
+					_path, _err := tree.GetJSONPath(arg1, *tree.MustBeDArray(arg2.(tree.Datum)))
 					if _err != nil {
 						colexecerror.ExpectedError(_err)
 					}
@@ -30833,7 +30769,7 @@ func (p projJSONFetchValPathJSONDatumOp) Next() coldata.Batch {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
-					_path, _err := tree.GetJSONPath(arg1, *tree.MustBeDArray(arg2.(*coldataext.Datum).Datum))
+					_path, _err := tree.GetJSONPath(arg1, *tree.MustBeDArray(arg2.(tree.Datum)))
 					if _err != nil {
 						colexecerror.ExpectedError(_err)
 					}
@@ -30902,7 +30838,7 @@ func (p projJSONFetchTextPathJSONDatumOp) Next() coldata.Batch {
 						arg1 := col1.Get(i)
 						arg2 := col2.Get(i)
 
-						_path, _err := tree.GetJSONPath(arg1, *tree.MustBeDArray(arg2.(*coldataext.Datum).Datum))
+						_path, _err := tree.GetJSONPath(arg1, *tree.MustBeDArray(arg2.(tree.Datum)))
 						if _err != nil {
 							colexecerror.ExpectedError(_err)
 						}
@@ -30934,7 +30870,7 @@ func (p projJSONFetchTextPathJSONDatumOp) Next() coldata.Batch {
 						arg1 := col1.Get(i)
 						arg2 := col2.Get(i)
 
-						_path, _err := tree.GetJSONPath(arg1, *tree.MustBeDArray(arg2.(*coldataext.Datum).Datum))
+						_path, _err := tree.GetJSONPath(arg1, *tree.MustBeDArray(arg2.(tree.Datum)))
 						if _err != nil {
 							colexecerror.ExpectedError(_err)
 						}
@@ -30969,7 +30905,7 @@ func (p projJSONFetchTextPathJSONDatumOp) Next() coldata.Batch {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
-					_path, _err := tree.GetJSONPath(arg1, *tree.MustBeDArray(arg2.(*coldataext.Datum).Datum))
+					_path, _err := tree.GetJSONPath(arg1, *tree.MustBeDArray(arg2.(tree.Datum)))
 					if _err != nil {
 						colexecerror.ExpectedError(_err)
 					}
@@ -30997,7 +30933,7 @@ func (p projJSONFetchTextPathJSONDatumOp) Next() coldata.Batch {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
-					_path, _err := tree.GetJSONPath(arg1, *tree.MustBeDArray(arg2.(*coldataext.Datum).Datum))
+					_path, _err := tree.GetJSONPath(arg1, *tree.MustBeDArray(arg2.(tree.Datum)))
 					if _err != nil {
 						colexecerror.ExpectedError(_err)
 					}
@@ -36071,7 +36007,7 @@ func (p projEQDatumDatumOp) Next() coldata.Batch {
 						{
 							var cmpResult int
 
-							cmpResult = arg1.(*coldataext.Datum).CompareDatum(col1, arg2)
+							cmpResult = coldataext.CompareDatum(arg1, col1, arg2)
 
 							projCol[i] = cmpResult == 0
 						}
@@ -36092,7 +36028,7 @@ func (p projEQDatumDatumOp) Next() coldata.Batch {
 						{
 							var cmpResult int
 
-							cmpResult = arg1.(*coldataext.Datum).CompareDatum(col1, arg2)
+							cmpResult = coldataext.CompareDatum(arg1, col1, arg2)
 
 							projCol[i] = cmpResult == 0
 						}
@@ -36116,7 +36052,7 @@ func (p projEQDatumDatumOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg1.(*coldataext.Datum).CompareDatum(col1, arg2)
+						cmpResult = coldataext.CompareDatum(arg1, col1, arg2)
 
 						projCol[i] = cmpResult == 0
 					}
@@ -36133,7 +36069,7 @@ func (p projEQDatumDatumOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg1.(*coldataext.Datum).CompareDatum(col1, arg2)
+						cmpResult = coldataext.CompareDatum(arg1, col1, arg2)
 
 						projCol[i] = cmpResult == 0
 					}
@@ -41193,7 +41129,7 @@ func (p projNEDatumDatumOp) Next() coldata.Batch {
 						{
 							var cmpResult int
 
-							cmpResult = arg1.(*coldataext.Datum).CompareDatum(col1, arg2)
+							cmpResult = coldataext.CompareDatum(arg1, col1, arg2)
 
 							projCol[i] = cmpResult != 0
 						}
@@ -41214,7 +41150,7 @@ func (p projNEDatumDatumOp) Next() coldata.Batch {
 						{
 							var cmpResult int
 
-							cmpResult = arg1.(*coldataext.Datum).CompareDatum(col1, arg2)
+							cmpResult = coldataext.CompareDatum(arg1, col1, arg2)
 
 							projCol[i] = cmpResult != 0
 						}
@@ -41238,7 +41174,7 @@ func (p projNEDatumDatumOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg1.(*coldataext.Datum).CompareDatum(col1, arg2)
+						cmpResult = coldataext.CompareDatum(arg1, col1, arg2)
 
 						projCol[i] = cmpResult != 0
 					}
@@ -41255,7 +41191,7 @@ func (p projNEDatumDatumOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg1.(*coldataext.Datum).CompareDatum(col1, arg2)
+						cmpResult = coldataext.CompareDatum(arg1, col1, arg2)
 
 						projCol[i] = cmpResult != 0
 					}
@@ -46315,7 +46251,7 @@ func (p projLTDatumDatumOp) Next() coldata.Batch {
 						{
 							var cmpResult int
 
-							cmpResult = arg1.(*coldataext.Datum).CompareDatum(col1, arg2)
+							cmpResult = coldataext.CompareDatum(arg1, col1, arg2)
 
 							projCol[i] = cmpResult < 0
 						}
@@ -46336,7 +46272,7 @@ func (p projLTDatumDatumOp) Next() coldata.Batch {
 						{
 							var cmpResult int
 
-							cmpResult = arg1.(*coldataext.Datum).CompareDatum(col1, arg2)
+							cmpResult = coldataext.CompareDatum(arg1, col1, arg2)
 
 							projCol[i] = cmpResult < 0
 						}
@@ -46360,7 +46296,7 @@ func (p projLTDatumDatumOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg1.(*coldataext.Datum).CompareDatum(col1, arg2)
+						cmpResult = coldataext.CompareDatum(arg1, col1, arg2)
 
 						projCol[i] = cmpResult < 0
 					}
@@ -46377,7 +46313,7 @@ func (p projLTDatumDatumOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg1.(*coldataext.Datum).CompareDatum(col1, arg2)
+						cmpResult = coldataext.CompareDatum(arg1, col1, arg2)
 
 						projCol[i] = cmpResult < 0
 					}
@@ -51437,7 +51373,7 @@ func (p projLEDatumDatumOp) Next() coldata.Batch {
 						{
 							var cmpResult int
 
-							cmpResult = arg1.(*coldataext.Datum).CompareDatum(col1, arg2)
+							cmpResult = coldataext.CompareDatum(arg1, col1, arg2)
 
 							projCol[i] = cmpResult <= 0
 						}
@@ -51458,7 +51394,7 @@ func (p projLEDatumDatumOp) Next() coldata.Batch {
 						{
 							var cmpResult int
 
-							cmpResult = arg1.(*coldataext.Datum).CompareDatum(col1, arg2)
+							cmpResult = coldataext.CompareDatum(arg1, col1, arg2)
 
 							projCol[i] = cmpResult <= 0
 						}
@@ -51482,7 +51418,7 @@ func (p projLEDatumDatumOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg1.(*coldataext.Datum).CompareDatum(col1, arg2)
+						cmpResult = coldataext.CompareDatum(arg1, col1, arg2)
 
 						projCol[i] = cmpResult <= 0
 					}
@@ -51499,7 +51435,7 @@ func (p projLEDatumDatumOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg1.(*coldataext.Datum).CompareDatum(col1, arg2)
+						cmpResult = coldataext.CompareDatum(arg1, col1, arg2)
 
 						projCol[i] = cmpResult <= 0
 					}
@@ -56559,7 +56495,7 @@ func (p projGTDatumDatumOp) Next() coldata.Batch {
 						{
 							var cmpResult int
 
-							cmpResult = arg1.(*coldataext.Datum).CompareDatum(col1, arg2)
+							cmpResult = coldataext.CompareDatum(arg1, col1, arg2)
 
 							projCol[i] = cmpResult > 0
 						}
@@ -56580,7 +56516,7 @@ func (p projGTDatumDatumOp) Next() coldata.Batch {
 						{
 							var cmpResult int
 
-							cmpResult = arg1.(*coldataext.Datum).CompareDatum(col1, arg2)
+							cmpResult = coldataext.CompareDatum(arg1, col1, arg2)
 
 							projCol[i] = cmpResult > 0
 						}
@@ -56604,7 +56540,7 @@ func (p projGTDatumDatumOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg1.(*coldataext.Datum).CompareDatum(col1, arg2)
+						cmpResult = coldataext.CompareDatum(arg1, col1, arg2)
 
 						projCol[i] = cmpResult > 0
 					}
@@ -56621,7 +56557,7 @@ func (p projGTDatumDatumOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg1.(*coldataext.Datum).CompareDatum(col1, arg2)
+						cmpResult = coldataext.CompareDatum(arg1, col1, arg2)
 
 						projCol[i] = cmpResult > 0
 					}
@@ -61681,7 +61617,7 @@ func (p projGEDatumDatumOp) Next() coldata.Batch {
 						{
 							var cmpResult int
 
-							cmpResult = arg1.(*coldataext.Datum).CompareDatum(col1, arg2)
+							cmpResult = coldataext.CompareDatum(arg1, col1, arg2)
 
 							projCol[i] = cmpResult >= 0
 						}
@@ -61702,7 +61638,7 @@ func (p projGEDatumDatumOp) Next() coldata.Batch {
 						{
 							var cmpResult int
 
-							cmpResult = arg1.(*coldataext.Datum).CompareDatum(col1, arg2)
+							cmpResult = coldataext.CompareDatum(arg1, col1, arg2)
 
 							projCol[i] = cmpResult >= 0
 						}
@@ -61726,7 +61662,7 @@ func (p projGEDatumDatumOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg1.(*coldataext.Datum).CompareDatum(col1, arg2)
+						cmpResult = coldataext.CompareDatum(arg1, col1, arg2)
 
 						projCol[i] = cmpResult >= 0
 					}
@@ -61743,7 +61679,7 @@ func (p projGEDatumDatumOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg1.(*coldataext.Datum).CompareDatum(col1, arg2)
+						cmpResult = coldataext.CompareDatum(arg1, col1, arg2)
 
 						projCol[i] = cmpResult >= 0
 					}

--- a/pkg/sql/colexec/colexecproj/proj_non_const_ops_tmpl.go
+++ b/pkg/sql/colexec/colexecproj/proj_non_const_ops_tmpl.go
@@ -42,7 +42,7 @@ import (
 // pick up the right packages when run within the bazel sandbox.
 var (
 	_ duration.Duration
-	_ coldataext.Datum
+	_ = coldataext.CompareDatum
 	_ sqltelemetry.EnumTelemetryType
 	_ telemetry.Counter
 )

--- a/pkg/sql/colexec/colexecsel/selection_ops.eg.go
+++ b/pkg/sql/colexec/colexecsel/selection_ops.eg.go
@@ -34,7 +34,7 @@ import (
 var (
 	_ apd.Context
 	_ duration.Duration
-	_ coldataext.Datum
+	_ = coldataext.CompareDatum
 	_ json.JSON
 )
 
@@ -9718,7 +9718,7 @@ func (p *selEQDatumDatumConstOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg.(*coldataext.Datum).CompareDatum(col, p.constArg)
+						cmpResult = coldataext.CompareDatum(arg, col, p.constArg)
 
 						cmp = cmpResult == 0
 					}
@@ -9742,7 +9742,7 @@ func (p *selEQDatumDatumConstOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg.(*coldataext.Datum).CompareDatum(col, p.constArg)
+						cmpResult = coldataext.CompareDatum(arg, col, p.constArg)
 
 						cmp = cmpResult == 0
 					}
@@ -9763,7 +9763,7 @@ func (p *selEQDatumDatumConstOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg.(*coldataext.Datum).CompareDatum(col, p.constArg)
+						cmpResult = coldataext.CompareDatum(arg, col, p.constArg)
 
 						cmp = cmpResult == 0
 					}
@@ -9784,7 +9784,7 @@ func (p *selEQDatumDatumConstOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg.(*coldataext.Datum).CompareDatum(col, p.constArg)
+						cmpResult = coldataext.CompareDatum(arg, col, p.constArg)
 
 						cmp = cmpResult == 0
 					}
@@ -9842,7 +9842,7 @@ func (p *selEQDatumDatumOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg1.(*coldataext.Datum).CompareDatum(col1, arg2)
+						cmpResult = coldataext.CompareDatum(arg1, col1, arg2)
 
 						cmp = cmpResult == 0
 					}
@@ -9868,7 +9868,7 @@ func (p *selEQDatumDatumOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg1.(*coldataext.Datum).CompareDatum(col1, arg2)
+						cmpResult = coldataext.CompareDatum(arg1, col1, arg2)
 
 						cmp = cmpResult == 0
 					}
@@ -9890,7 +9890,7 @@ func (p *selEQDatumDatumOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg1.(*coldataext.Datum).CompareDatum(col1, arg2)
+						cmpResult = coldataext.CompareDatum(arg1, col1, arg2)
 
 						cmp = cmpResult == 0
 					}
@@ -9913,7 +9913,7 @@ func (p *selEQDatumDatumOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg1.(*coldataext.Datum).CompareDatum(col1, arg2)
+						cmpResult = coldataext.CompareDatum(arg1, col1, arg2)
 
 						cmp = cmpResult == 0
 					}
@@ -19596,7 +19596,7 @@ func (p *selNEDatumDatumConstOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg.(*coldataext.Datum).CompareDatum(col, p.constArg)
+						cmpResult = coldataext.CompareDatum(arg, col, p.constArg)
 
 						cmp = cmpResult != 0
 					}
@@ -19620,7 +19620,7 @@ func (p *selNEDatumDatumConstOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg.(*coldataext.Datum).CompareDatum(col, p.constArg)
+						cmpResult = coldataext.CompareDatum(arg, col, p.constArg)
 
 						cmp = cmpResult != 0
 					}
@@ -19641,7 +19641,7 @@ func (p *selNEDatumDatumConstOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg.(*coldataext.Datum).CompareDatum(col, p.constArg)
+						cmpResult = coldataext.CompareDatum(arg, col, p.constArg)
 
 						cmp = cmpResult != 0
 					}
@@ -19662,7 +19662,7 @@ func (p *selNEDatumDatumConstOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg.(*coldataext.Datum).CompareDatum(col, p.constArg)
+						cmpResult = coldataext.CompareDatum(arg, col, p.constArg)
 
 						cmp = cmpResult != 0
 					}
@@ -19720,7 +19720,7 @@ func (p *selNEDatumDatumOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg1.(*coldataext.Datum).CompareDatum(col1, arg2)
+						cmpResult = coldataext.CompareDatum(arg1, col1, arg2)
 
 						cmp = cmpResult != 0
 					}
@@ -19746,7 +19746,7 @@ func (p *selNEDatumDatumOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg1.(*coldataext.Datum).CompareDatum(col1, arg2)
+						cmpResult = coldataext.CompareDatum(arg1, col1, arg2)
 
 						cmp = cmpResult != 0
 					}
@@ -19768,7 +19768,7 @@ func (p *selNEDatumDatumOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg1.(*coldataext.Datum).CompareDatum(col1, arg2)
+						cmpResult = coldataext.CompareDatum(arg1, col1, arg2)
 
 						cmp = cmpResult != 0
 					}
@@ -19791,7 +19791,7 @@ func (p *selNEDatumDatumOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg1.(*coldataext.Datum).CompareDatum(col1, arg2)
+						cmpResult = coldataext.CompareDatum(arg1, col1, arg2)
 
 						cmp = cmpResult != 0
 					}
@@ -29474,7 +29474,7 @@ func (p *selLTDatumDatumConstOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg.(*coldataext.Datum).CompareDatum(col, p.constArg)
+						cmpResult = coldataext.CompareDatum(arg, col, p.constArg)
 
 						cmp = cmpResult < 0
 					}
@@ -29498,7 +29498,7 @@ func (p *selLTDatumDatumConstOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg.(*coldataext.Datum).CompareDatum(col, p.constArg)
+						cmpResult = coldataext.CompareDatum(arg, col, p.constArg)
 
 						cmp = cmpResult < 0
 					}
@@ -29519,7 +29519,7 @@ func (p *selLTDatumDatumConstOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg.(*coldataext.Datum).CompareDatum(col, p.constArg)
+						cmpResult = coldataext.CompareDatum(arg, col, p.constArg)
 
 						cmp = cmpResult < 0
 					}
@@ -29540,7 +29540,7 @@ func (p *selLTDatumDatumConstOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg.(*coldataext.Datum).CompareDatum(col, p.constArg)
+						cmpResult = coldataext.CompareDatum(arg, col, p.constArg)
 
 						cmp = cmpResult < 0
 					}
@@ -29598,7 +29598,7 @@ func (p *selLTDatumDatumOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg1.(*coldataext.Datum).CompareDatum(col1, arg2)
+						cmpResult = coldataext.CompareDatum(arg1, col1, arg2)
 
 						cmp = cmpResult < 0
 					}
@@ -29624,7 +29624,7 @@ func (p *selLTDatumDatumOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg1.(*coldataext.Datum).CompareDatum(col1, arg2)
+						cmpResult = coldataext.CompareDatum(arg1, col1, arg2)
 
 						cmp = cmpResult < 0
 					}
@@ -29646,7 +29646,7 @@ func (p *selLTDatumDatumOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg1.(*coldataext.Datum).CompareDatum(col1, arg2)
+						cmpResult = coldataext.CompareDatum(arg1, col1, arg2)
 
 						cmp = cmpResult < 0
 					}
@@ -29669,7 +29669,7 @@ func (p *selLTDatumDatumOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg1.(*coldataext.Datum).CompareDatum(col1, arg2)
+						cmpResult = coldataext.CompareDatum(arg1, col1, arg2)
 
 						cmp = cmpResult < 0
 					}
@@ -39352,7 +39352,7 @@ func (p *selLEDatumDatumConstOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg.(*coldataext.Datum).CompareDatum(col, p.constArg)
+						cmpResult = coldataext.CompareDatum(arg, col, p.constArg)
 
 						cmp = cmpResult <= 0
 					}
@@ -39376,7 +39376,7 @@ func (p *selLEDatumDatumConstOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg.(*coldataext.Datum).CompareDatum(col, p.constArg)
+						cmpResult = coldataext.CompareDatum(arg, col, p.constArg)
 
 						cmp = cmpResult <= 0
 					}
@@ -39397,7 +39397,7 @@ func (p *selLEDatumDatumConstOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg.(*coldataext.Datum).CompareDatum(col, p.constArg)
+						cmpResult = coldataext.CompareDatum(arg, col, p.constArg)
 
 						cmp = cmpResult <= 0
 					}
@@ -39418,7 +39418,7 @@ func (p *selLEDatumDatumConstOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg.(*coldataext.Datum).CompareDatum(col, p.constArg)
+						cmpResult = coldataext.CompareDatum(arg, col, p.constArg)
 
 						cmp = cmpResult <= 0
 					}
@@ -39476,7 +39476,7 @@ func (p *selLEDatumDatumOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg1.(*coldataext.Datum).CompareDatum(col1, arg2)
+						cmpResult = coldataext.CompareDatum(arg1, col1, arg2)
 
 						cmp = cmpResult <= 0
 					}
@@ -39502,7 +39502,7 @@ func (p *selLEDatumDatumOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg1.(*coldataext.Datum).CompareDatum(col1, arg2)
+						cmpResult = coldataext.CompareDatum(arg1, col1, arg2)
 
 						cmp = cmpResult <= 0
 					}
@@ -39524,7 +39524,7 @@ func (p *selLEDatumDatumOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg1.(*coldataext.Datum).CompareDatum(col1, arg2)
+						cmpResult = coldataext.CompareDatum(arg1, col1, arg2)
 
 						cmp = cmpResult <= 0
 					}
@@ -39547,7 +39547,7 @@ func (p *selLEDatumDatumOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg1.(*coldataext.Datum).CompareDatum(col1, arg2)
+						cmpResult = coldataext.CompareDatum(arg1, col1, arg2)
 
 						cmp = cmpResult <= 0
 					}
@@ -49230,7 +49230,7 @@ func (p *selGTDatumDatumConstOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg.(*coldataext.Datum).CompareDatum(col, p.constArg)
+						cmpResult = coldataext.CompareDatum(arg, col, p.constArg)
 
 						cmp = cmpResult > 0
 					}
@@ -49254,7 +49254,7 @@ func (p *selGTDatumDatumConstOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg.(*coldataext.Datum).CompareDatum(col, p.constArg)
+						cmpResult = coldataext.CompareDatum(arg, col, p.constArg)
 
 						cmp = cmpResult > 0
 					}
@@ -49275,7 +49275,7 @@ func (p *selGTDatumDatumConstOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg.(*coldataext.Datum).CompareDatum(col, p.constArg)
+						cmpResult = coldataext.CompareDatum(arg, col, p.constArg)
 
 						cmp = cmpResult > 0
 					}
@@ -49296,7 +49296,7 @@ func (p *selGTDatumDatumConstOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg.(*coldataext.Datum).CompareDatum(col, p.constArg)
+						cmpResult = coldataext.CompareDatum(arg, col, p.constArg)
 
 						cmp = cmpResult > 0
 					}
@@ -49354,7 +49354,7 @@ func (p *selGTDatumDatumOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg1.(*coldataext.Datum).CompareDatum(col1, arg2)
+						cmpResult = coldataext.CompareDatum(arg1, col1, arg2)
 
 						cmp = cmpResult > 0
 					}
@@ -49380,7 +49380,7 @@ func (p *selGTDatumDatumOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg1.(*coldataext.Datum).CompareDatum(col1, arg2)
+						cmpResult = coldataext.CompareDatum(arg1, col1, arg2)
 
 						cmp = cmpResult > 0
 					}
@@ -49402,7 +49402,7 @@ func (p *selGTDatumDatumOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg1.(*coldataext.Datum).CompareDatum(col1, arg2)
+						cmpResult = coldataext.CompareDatum(arg1, col1, arg2)
 
 						cmp = cmpResult > 0
 					}
@@ -49425,7 +49425,7 @@ func (p *selGTDatumDatumOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg1.(*coldataext.Datum).CompareDatum(col1, arg2)
+						cmpResult = coldataext.CompareDatum(arg1, col1, arg2)
 
 						cmp = cmpResult > 0
 					}
@@ -59108,7 +59108,7 @@ func (p *selGEDatumDatumConstOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg.(*coldataext.Datum).CompareDatum(col, p.constArg)
+						cmpResult = coldataext.CompareDatum(arg, col, p.constArg)
 
 						cmp = cmpResult >= 0
 					}
@@ -59132,7 +59132,7 @@ func (p *selGEDatumDatumConstOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg.(*coldataext.Datum).CompareDatum(col, p.constArg)
+						cmpResult = coldataext.CompareDatum(arg, col, p.constArg)
 
 						cmp = cmpResult >= 0
 					}
@@ -59153,7 +59153,7 @@ func (p *selGEDatumDatumConstOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg.(*coldataext.Datum).CompareDatum(col, p.constArg)
+						cmpResult = coldataext.CompareDatum(arg, col, p.constArg)
 
 						cmp = cmpResult >= 0
 					}
@@ -59174,7 +59174,7 @@ func (p *selGEDatumDatumConstOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg.(*coldataext.Datum).CompareDatum(col, p.constArg)
+						cmpResult = coldataext.CompareDatum(arg, col, p.constArg)
 
 						cmp = cmpResult >= 0
 					}
@@ -59232,7 +59232,7 @@ func (p *selGEDatumDatumOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg1.(*coldataext.Datum).CompareDatum(col1, arg2)
+						cmpResult = coldataext.CompareDatum(arg1, col1, arg2)
 
 						cmp = cmpResult >= 0
 					}
@@ -59258,7 +59258,7 @@ func (p *selGEDatumDatumOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg1.(*coldataext.Datum).CompareDatum(col1, arg2)
+						cmpResult = coldataext.CompareDatum(arg1, col1, arg2)
 
 						cmp = cmpResult >= 0
 					}
@@ -59280,7 +59280,7 @@ func (p *selGEDatumDatumOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg1.(*coldataext.Datum).CompareDatum(col1, arg2)
+						cmpResult = coldataext.CompareDatum(arg1, col1, arg2)
 
 						cmp = cmpResult >= 0
 					}
@@ -59303,7 +59303,7 @@ func (p *selGEDatumDatumOp) Next() coldata.Batch {
 					{
 						var cmpResult int
 
-						cmpResult = arg1.(*coldataext.Datum).CompareDatum(col1, arg2)
+						cmpResult = coldataext.CompareDatum(arg1, col1, arg2)
 
 						cmp = cmpResult >= 0
 					}

--- a/pkg/sql/colexec/colexecsel/selection_ops_tmpl.go
+++ b/pkg/sql/colexec/colexecsel/selection_ops_tmpl.go
@@ -41,7 +41,7 @@ import (
 var (
 	_ apd.Context
 	_ duration.Duration
-	_ coldataext.Datum
+	_ = coldataext.CompareDatum
 	_ json.JSON
 )
 

--- a/pkg/sql/colexec/colexectestutils/BUILD.bazel
+++ b/pkg/sql/colexec/colexectestutils/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/col/coldata",
-        "//pkg/col/coldataext",
         "//pkg/col/typeconv",
         "//pkg/settings/cluster",
         "//pkg/sql/colexec/colexecargs",

--- a/pkg/sql/colexec/colexectestutils/utils.go
+++ b/pkg/sql/colexec/colexectestutils/utils.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/cockroachdb/apd/v2"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
-	"github.com/cockroachdb/cockroach/pkg/col/coldataext"
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
@@ -748,8 +747,6 @@ func setColVal(vec coldata.Vec, idx int, val interface{}, evalCtx *tree.EvalCont
 		vec.JSON().Set(idx, j)
 	case typeconv.DatumVecCanonicalTypeFamily:
 		switch v := val.(type) {
-		case *coldataext.Datum:
-			vec.Datum().Set(idx, v)
 		case tree.Datum:
 			vec.Datum().Set(idx, v)
 		case string:
@@ -1201,7 +1198,7 @@ func GetTupleFromBatch(batch coldata.Batch, tupleIdx int) Tuple {
 				}
 				val = reflect.ValueOf(j)
 			} else if family == typeconv.DatumVecCanonicalTypeFamily {
-				val = reflect.ValueOf(vec.Datum().Get(tupleIdx).(*coldataext.Datum).Datum)
+				val = reflect.ValueOf(vec.Datum().Get(tupleIdx).(tree.Datum))
 			} else {
 				val = reflect.ValueOf(vec.Col()).Index(tupleIdx)
 			}
@@ -1338,13 +1335,8 @@ func tupleEquals(expected Tuple, actual Tuple, evalCtx *tree.EvalContext) bool {
 			}
 			// Special case for datum-backed types.
 			if d1, ok := actual[i].(tree.Datum); ok {
-				if d, ok := d1.(*coldataext.Datum); ok {
-					d1 = d.Datum
-				}
 				var d2 tree.Datum
 				switch d := expected[i].(type) {
-				case *coldataext.Datum:
-					d2 = d.Datum
 				case tree.Datum:
 					d2 = d
 				case string:

--- a/pkg/sql/colexec/colexecwindow/range_offset_handler.eg.go
+++ b/pkg/sql/colexec/colexecwindow/range_offset_handler.eg.go
@@ -36,7 +36,7 @@ import (
 // pick up the right packages when run within the bazel sandbox.
 var (
 	_ apd.Context
-	_ coldataext.Datum
+	_ = coldataext.CompareDatum
 	_ duration.Duration
 	_ pgdate.Date
 )
@@ -2156,7 +2156,7 @@ func (h *rangeHandlerOffsetPrecedingStartAscDatum) getIdx(ctx context.Context, c
 	col := vec.Datum()
 	currRowVal := col.Get(vecIdx)
 
-	_res, err := currRowVal.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, h.offset)
+	_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, currRowVal.(tree.Datum), h.offset.(tree.Datum))
 	if err != nil {
 		colexecerror.ExpectedError(err)
 	}
@@ -2217,7 +2217,7 @@ func (h *rangeHandlerOffsetPrecedingStartAscDatum) getIdx(ctx context.Context, c
 			if peersCol[vecIdx] {
 				cmpVal := col.Get(vecIdx)
 
-				cmpResult = cmpVal.(*coldataext.Datum).CompareDatum(col, seekVal)
+				cmpResult = coldataext.CompareDatum(cmpVal, col, seekVal)
 
 				if cmpResult >= 0 {
 					return idx
@@ -3252,7 +3252,7 @@ func (h *rangeHandlerOffsetPrecedingStartDescDatum) getIdx(ctx context.Context, 
 	col := vec.Datum()
 	currRowVal := col.Get(vecIdx)
 
-	_res, err := currRowVal.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, h.offset)
+	_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, currRowVal.(tree.Datum), h.offset.(tree.Datum))
 	if err != nil {
 		colexecerror.ExpectedError(err)
 	}
@@ -3286,7 +3286,7 @@ func (h *rangeHandlerOffsetPrecedingStartDescDatum) getIdx(ctx context.Context, 
 				}
 				cmpVal := col.Get(vecIdx)
 
-				cmpResult = cmpVal.(*coldataext.Datum).CompareDatum(col, seekVal)
+				cmpResult = coldataext.CompareDatum(cmpVal, col, seekVal)
 
 				if cmpResult <= 0 {
 					return idx
@@ -4690,7 +4690,7 @@ func (h *rangeHandlerOffsetPrecedingEndAscDatum) getIdx(ctx context.Context, cur
 	col := vec.Datum()
 	currRowVal := col.Get(vecIdx)
 
-	_res, err := currRowVal.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, h.offset)
+	_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, currRowVal.(tree.Datum), h.offset.(tree.Datum))
 	if err != nil {
 		colexecerror.ExpectedError(err)
 	}
@@ -4751,7 +4751,7 @@ func (h *rangeHandlerOffsetPrecedingEndAscDatum) getIdx(ctx context.Context, cur
 			if peersCol[vecIdx] {
 				cmpVal := col.Get(vecIdx)
 
-				cmpResult = cmpVal.(*coldataext.Datum).CompareDatum(col, seekVal)
+				cmpResult = coldataext.CompareDatum(cmpVal, col, seekVal)
 
 				if cmpResult > 0 {
 					return idx
@@ -5939,7 +5939,7 @@ func (h *rangeHandlerOffsetPrecedingEndDescDatum) getIdx(ctx context.Context, cu
 	col := vec.Datum()
 	currRowVal := col.Get(vecIdx)
 
-	_res, err := currRowVal.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, h.offset)
+	_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, currRowVal.(tree.Datum), h.offset.(tree.Datum))
 	if err != nil {
 		colexecerror.ExpectedError(err)
 	}
@@ -5973,7 +5973,7 @@ func (h *rangeHandlerOffsetPrecedingEndDescDatum) getIdx(ctx context.Context, cu
 				}
 				cmpVal := col.Get(vecIdx)
 
-				cmpResult = cmpVal.(*coldataext.Datum).CompareDatum(col, seekVal)
+				cmpResult = coldataext.CompareDatum(cmpVal, col, seekVal)
 
 				if cmpResult < 0 {
 					return idx
@@ -7224,7 +7224,7 @@ func (h *rangeHandlerOffsetFollowingStartAscDatum) getIdx(ctx context.Context, c
 	col := vec.Datum()
 	currRowVal := col.Get(vecIdx)
 
-	_res, err := currRowVal.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, h.offset)
+	_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, currRowVal.(tree.Datum), h.offset.(tree.Datum))
 	if err != nil {
 		colexecerror.ExpectedError(err)
 	}
@@ -7285,7 +7285,7 @@ func (h *rangeHandlerOffsetFollowingStartAscDatum) getIdx(ctx context.Context, c
 			if peersCol[vecIdx] {
 				cmpVal := col.Get(vecIdx)
 
-				cmpResult = cmpVal.(*coldataext.Datum).CompareDatum(col, seekVal)
+				cmpResult = coldataext.CompareDatum(cmpVal, col, seekVal)
 
 				if cmpResult >= 0 {
 					return idx
@@ -8320,7 +8320,7 @@ func (h *rangeHandlerOffsetFollowingStartDescDatum) getIdx(ctx context.Context, 
 	col := vec.Datum()
 	currRowVal := col.Get(vecIdx)
 
-	_res, err := currRowVal.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, h.offset)
+	_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, currRowVal.(tree.Datum), h.offset.(tree.Datum))
 	if err != nil {
 		colexecerror.ExpectedError(err)
 	}
@@ -8354,7 +8354,7 @@ func (h *rangeHandlerOffsetFollowingStartDescDatum) getIdx(ctx context.Context, 
 				}
 				cmpVal := col.Get(vecIdx)
 
-				cmpResult = cmpVal.(*coldataext.Datum).CompareDatum(col, seekVal)
+				cmpResult = coldataext.CompareDatum(cmpVal, col, seekVal)
 
 				if cmpResult <= 0 {
 					return idx
@@ -9758,7 +9758,7 @@ func (h *rangeHandlerOffsetFollowingEndAscDatum) getIdx(ctx context.Context, cur
 	col := vec.Datum()
 	currRowVal := col.Get(vecIdx)
 
-	_res, err := currRowVal.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, h.offset)
+	_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, currRowVal.(tree.Datum), h.offset.(tree.Datum))
 	if err != nil {
 		colexecerror.ExpectedError(err)
 	}
@@ -9819,7 +9819,7 @@ func (h *rangeHandlerOffsetFollowingEndAscDatum) getIdx(ctx context.Context, cur
 			if peersCol[vecIdx] {
 				cmpVal := col.Get(vecIdx)
 
-				cmpResult = cmpVal.(*coldataext.Datum).CompareDatum(col, seekVal)
+				cmpResult = coldataext.CompareDatum(cmpVal, col, seekVal)
 
 				if cmpResult > 0 {
 					return idx
@@ -11007,7 +11007,7 @@ func (h *rangeHandlerOffsetFollowingEndDescDatum) getIdx(ctx context.Context, cu
 	col := vec.Datum()
 	currRowVal := col.Get(vecIdx)
 
-	_res, err := currRowVal.(*coldataext.Datum).BinFn(_overloadHelper.BinFn, _overloadHelper.EvalCtx, h.offset)
+	_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, currRowVal.(tree.Datum), h.offset.(tree.Datum))
 	if err != nil {
 		colexecerror.ExpectedError(err)
 	}
@@ -11041,7 +11041,7 @@ func (h *rangeHandlerOffsetFollowingEndDescDatum) getIdx(ctx context.Context, cu
 				}
 				cmpVal := col.Get(vecIdx)
 
-				cmpResult = cmpVal.(*coldataext.Datum).CompareDatum(col, seekVal)
+				cmpResult = coldataext.CompareDatum(cmpVal, col, seekVal)
 
 				if cmpResult < 0 {
 					return idx

--- a/pkg/sql/colexec/colexecwindow/range_offset_handler_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/range_offset_handler_tmpl.go
@@ -44,7 +44,7 @@ import (
 // pick up the right packages when run within the bazel sandbox.
 var (
 	_ apd.Context
-	_ coldataext.Datum
+	_ = coldataext.CompareDatum
 	_ duration.Duration
 	_ pgdate.Date
 )

--- a/pkg/sql/colexec/execgen/cmd/execgen/cast_gen_util.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/cast_gen_util.go
@@ -366,7 +366,7 @@ func getDatumToNativeCastFunc(
 	return func(to, from, evalCtx, toType string) string {
 		convStr := `
 		{
-			_castedDatum, err := tree.PerformCast(%[3]s, %[2]s.(*coldataext.Datum).Datum, %[4]s)
+			_castedDatum, err := tree.PerformCast(%[3]s, %[2]s.(tree.Datum), %[4]s)
 			if err != nil {
 				colexecerror.ExpectedError(err)
 			}
@@ -380,7 +380,7 @@ func getDatumToNativeCastFunc(
 func datumToDatum(to, from, evalCtx, toType string) string {
 	convStr := `
 		{
-			_castedDatum, err := tree.PerformCast(%[3]s, %[2]s.(*coldataext.Datum).Datum, %[4]s)
+			_castedDatum, err := tree.PerformCast(%[3]s, %[2]s.(tree.Datum), %[4]s)
 			if err != nil {
 				colexecerror.ExpectedError(err)
 			}

--- a/pkg/sql/colexec/execgen/cmd/execgen/cast_gen_util.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/cast_gen_util.go
@@ -115,7 +115,7 @@ func getDecimalToIntCastFunc(toIntWidth int32) castFunc {
 	if toIntWidth == anyWidth {
 		toIntWidth = 64
 	}
-	return func(to, from, fromCol, toType string) string {
+	return func(to, from, evalCtx, toType string) string {
 		// convStr is a format string expecting three arguments:
 		// 1. the code snippet that performs an assigment of int64 local
 		//    variable named '_i' to the result, possibly performing the bounds
@@ -146,7 +146,7 @@ func getDecimalToIntCastFunc(toIntWidth int32) castFunc {
 		}
 		return fmt.Sprintf(
 			convStr,
-			getIntToIntCastFunc(64 /* fromWidth */, toIntWidth)(to, "_i" /* from */, fromCol, toType),
+			getIntToIntCastFunc(64 /* fromWidth */, toIntWidth)(to, "_i" /* from */, evalCtx, toType),
 			from,
 			errOutOfRange,
 		)
@@ -363,31 +363,31 @@ func jsonToString(to, from, _, toType string) string {
 func getDatumToNativeCastFunc(
 	nonDatumPhysicalRepresentation string,
 ) func(string, string, string, string) string {
-	return func(to, from, fromCol, toType string) string {
+	return func(to, from, evalCtx, toType string) string {
 		convStr := `
 		{
-			_castedDatum, err := %[2]s.(*coldataext.Datum).Cast(%[3]s, %[4]s)
+			_castedDatum, err := tree.PerformCast(%[3]s, %[2]s.(*coldataext.Datum).Datum, %[4]s)
 			if err != nil {
 				colexecerror.ExpectedError(err)
 			}
 			%[1]s = converter(_castedDatum).(%[5]s)
 		}
 	`
-		return fmt.Sprintf(convStr, to, from, fromCol, toType, nonDatumPhysicalRepresentation)
+		return fmt.Sprintf(convStr, to, from, evalCtx, toType, nonDatumPhysicalRepresentation)
 	}
 }
 
-func datumToDatum(to, from, fromCol, toType string) string {
+func datumToDatum(to, from, evalCtx, toType string) string {
 	convStr := `
 		{
-			_castedDatum, err := %[2]s.(*coldataext.Datum).Cast(%[3]s, %[4]s)
+			_castedDatum, err := tree.PerformCast(%[3]s, %[2]s.(*coldataext.Datum).Datum, %[4]s)
 			if err != nil {
 				colexecerror.ExpectedError(err)
 			}
 			%[1]s = _castedDatum
 		}
 	`
-	return fmt.Sprintf(convStr, to, from, fromCol, toType)
+	return fmt.Sprintf(convStr, to, from, evalCtx, toType)
 }
 
 // The structs below form 4-leveled hierarchy (similar to two-argument
@@ -499,8 +499,8 @@ func (i castToWidthTmplInfo) TypeName() string {
 	return getTypeName(i.toType)
 }
 
-func (i castToWidthTmplInfo) Cast(to, from, fromCol, toType string) string {
-	return i.CastFn(to, from, fromCol, toType)
+func (i castToWidthTmplInfo) Cast(to, from, evalCtx, toType string) string {
+	return i.CastFn(to, from, evalCtx, toType)
 }
 
 func (i castToWidthTmplInfo) Sliceable() bool {
@@ -523,8 +523,8 @@ func (i castDatumToWidthTmplInfo) TypeName() string {
 	return getTypeName(i.toType)
 }
 
-func (i castDatumToWidthTmplInfo) Cast(to, from, fromCol, toType string) string {
-	return i.CastFn(to, from, fromCol, toType)
+func (i castDatumToWidthTmplInfo) Cast(to, from, evalCtx, toType string) string {
+	return i.CastFn(to, from, evalCtx, toType)
 }
 
 func (i castDatumToWidthTmplInfo) Sliceable() bool {
@@ -535,8 +535,8 @@ func (i castBetweenDatumsTmplInfo) TypeName() string {
 	return datumVecTypeName
 }
 
-func (i castBetweenDatumsTmplInfo) Cast(to, from, fromCol, toType string) string {
-	return datumToDatum(to, from, fromCol, toType)
+func (i castBetweenDatumsTmplInfo) Cast(to, from, evalCtx, toType string) string {
+	return datumToDatum(to, from, evalCtx, toType)
 }
 
 func (i castBetweenDatumsTmplInfo) Sliceable() bool {

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_base.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_base.go
@@ -351,7 +351,7 @@ type twoArgsResolvedOverloadRightWidthInfo struct {
 
 type assignFunc func(op *lastArgWidthOverload, targetElem, leftElem, rightElem, targetCol, leftCol, rightCol string) string
 type compareFunc func(targetElem, leftElem, rightElem, leftCol, rightCol string) string
-type castFunc func(to, from, fromCol, toType string) string
+type castFunc func(to, from, evalCtx, toType string) string
 
 // Assign produces a Go source string that assigns the "targetElem" variable to
 // the result of applying the overload to the two inputs, "leftElem" and

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_base.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_base.go
@@ -573,7 +573,7 @@ if %[2]s != nil {
 		return fmt.Sprintf(`
 		var %[1]s uintptr
 		if %[2]s != nil {
-			%[1]s = %[2]s.(*coldataext.Datum).Size()
+			%[1]s = %[2]s.(tree.Datum).Size()
 		}`, target, value)
 	default:
 		return fmt.Sprintf(`var %s uintptr`, target)

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_cmp.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_cmp.go
@@ -358,7 +358,7 @@ func (c datumCustomizer) getCmpOpCompareFunc() compareFunc {
 	return func(targetElem, leftElem, rightElem, leftCol, rightCol string) string {
 		datumVecVariableName := getDatumVecVariableName(leftCol, rightCol)
 		return fmt.Sprintf(`
-			%s = %s.(*coldataext.Datum).CompareDatum(%s, %s)
+			%s = coldataext.CompareDatum(%s, %s, %s)
 		`, targetElem, leftElem, datumVecVariableName, rightElem)
 	}
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_hash.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_hash.go
@@ -166,7 +166,7 @@ func (c datumCustomizer) getHashAssignFunc() assignFunc {
 		// Note that this overload assumes that there exists
 		//   var datumAlloc *rowenc.DatumAlloc.
 		// in the scope.
-		return fmt.Sprintf(`b := %s.(*coldataext.Datum).Hash(datumAlloc)`, vElem) +
+		return fmt.Sprintf(`b := coldataext.Hash(%s.(tree.Datum), datumAlloc)`, vElem) +
 			fmt.Sprintf(hashByteSliceString, targetElem, "b")
 	}
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/vec_to_datum_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/vec_to_datum_gen.go
@@ -102,7 +102,7 @@ var vecToDatumConversionTmpls = map[types.Family]string{
 	types.TimestampFamily:                `%[1]s := %[3]s.NewDTimestamp(tree.DTimestamp{Time: %[2]s})`,
 	types.TimestampTZFamily:              `%[1]s := %[3]s.NewDTimestampTZ(tree.DTimestampTZ{Time: %[2]s})`,
 	types.IntervalFamily:                 `%[1]s := %[3]s.NewDInterval(tree.DInterval{Duration: %[2]s})`,
-	typeconv.DatumVecCanonicalTypeFamily: `%[1]s := %[2]s.(*coldataext.Datum).Datum`,
+	typeconv.DatumVecCanonicalTypeFamily: `%[1]s := %[2]s.(tree.Datum)`,
 }
 
 const vecToDatumTmpl = "pkg/sql/colconv/vec_to_datum_tmpl.go"

--- a/pkg/sql/colexec/external_hash_joiner.go
+++ b/pkg/sql/colexec/external_hash_joiner.go
@@ -133,7 +133,7 @@ func NewExternalHashJoiner(
 		diskBackedSortMerge, err := colexecjoin.NewMergeJoinOp(
 			unlimitedAllocator, memoryLimit, args.DiskQueueCfg, fdSemaphore, spec.JoinType,
 			leftPartitionSorter, rightPartitionSorter, spec.Left.SourceTypes,
-			spec.Right.SourceTypes, leftOrdering, rightOrdering, diskAcc,
+			spec.Right.SourceTypes, leftOrdering, rightOrdering, diskAcc, flowCtx.EvalCtx,
 		)
 		if err != nil {
 			colexecerror.InternalError(err)

--- a/pkg/sql/colexec/is_null_ops.eg.go
+++ b/pkg/sql/colexec/is_null_ops.eg.go
@@ -11,7 +11,6 @@ package colexec
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
-	"github.com/cockroachdb/cockroach/pkg/col/coldataext"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
@@ -147,7 +146,7 @@ func (o *isTupleNullProjOp) Next() coldata.Batch {
 				if nulls.NullAt(i) {
 					projCol[i] = !o.negate
 				} else {
-					projCol[i] = isTupleNull(datums.Get(i).(*coldataext.Datum).Datum, o.negate)
+					projCol[i] = isTupleNull(datums.Get(i).(tree.Datum), o.negate)
 				}
 
 			}
@@ -157,7 +156,7 @@ func (o *isTupleNullProjOp) Next() coldata.Batch {
 				if nulls.NullAt(i) {
 					projCol[i] = !o.negate
 				} else {
-					projCol[i] = isTupleNull(datums.Get(i).(*coldataext.Datum).Datum, o.negate)
+					projCol[i] = isTupleNull(datums.Get(i).(tree.Datum), o.negate)
 				}
 
 			}
@@ -169,7 +168,7 @@ func (o *isTupleNullProjOp) Next() coldata.Batch {
 				if nulls.NullAt(i) {
 					projCol[i] = !o.negate
 				} else {
-					projCol[i] = isTupleNull(datums.Get(i).(*coldataext.Datum).Datum, o.negate)
+					projCol[i] = isTupleNull(datums.Get(i).(tree.Datum), o.negate)
 				}
 
 			}
@@ -179,7 +178,7 @@ func (o *isTupleNullProjOp) Next() coldata.Batch {
 				if nulls.NullAt(i) {
 					projCol[i] = !o.negate
 				} else {
-					projCol[i] = isTupleNull(datums.Get(i).(*coldataext.Datum).Datum, o.negate)
+					projCol[i] = isTupleNull(datums.Get(i).(tree.Datum), o.negate)
 				}
 
 			}
@@ -299,7 +298,7 @@ func (o *isTupleNullSelOp) Next() coldata.Batch {
 			for _, i := range sel {
 				selectTuple := nulls.NullAt(i) != o.negate
 				if !selectTuple {
-					selectTuple = isTupleNull(datums.Get(i).(*coldataext.Datum).Datum, o.negate)
+					selectTuple = isTupleNull(datums.Get(i).(tree.Datum), o.negate)
 				}
 				if selectTuple {
 					sel[idx] = i
@@ -313,7 +312,7 @@ func (o *isTupleNullSelOp) Next() coldata.Batch {
 			for i := range sel {
 				selectTuple := nulls.NullAt(i) != o.negate
 				if !selectTuple {
-					selectTuple = isTupleNull(datums.Get(i).(*coldataext.Datum).Datum, o.negate)
+					selectTuple = isTupleNull(datums.Get(i).(tree.Datum), o.negate)
 				}
 				if selectTuple {
 					sel[idx] = i

--- a/pkg/sql/colexec/is_null_ops_tmpl.go
+++ b/pkg/sql/colexec/is_null_ops_tmpl.go
@@ -21,7 +21,6 @@ package colexec
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
-	"github.com/cockroachdb/cockroach/pkg/col/coldataext"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
@@ -137,7 +136,7 @@ func _COMPUTE_IS_NULL(
 	if nulls.NullAt(i) {
 		projCol[i] = !o.negate
 	} else {
-		projCol[i] = isTupleNull(datums.Get(i).(*coldataext.Datum).Datum, o.negate)
+		projCol[i] = isTupleNull(datums.Get(i).(tree.Datum), o.negate)
 	}
 	// {{else}}
 	// {{if .HasNulls}}
@@ -250,7 +249,7 @@ func _MAYBE_SELECT(
 	// {{if .IsTuple}}
 	selectTuple := nulls.NullAt(i) != o.negate
 	if !selectTuple {
-		selectTuple = isTupleNull(datums.Get(i).(*coldataext.Datum).Datum, o.negate)
+		selectTuple = isTupleNull(datums.Get(i).(tree.Datum), o.negate)
 	}
 	if selectTuple {
 		sel[idx] = i

--- a/pkg/sql/colexec/mergejoiner_test.go
+++ b/pkg/sql/colexec/mergejoiner_test.go
@@ -1702,6 +1702,8 @@ func TestFullOuterMergeJoinWithMaximumNumberOfGroups(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
+	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
+	defer evalCtx.Stop(ctx)
 	nTuples := coldata.BatchSize() * 4
 	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(t, true /* inMem */)
 	defer cleanup()
@@ -1722,7 +1724,7 @@ func TestFullOuterMergeJoinWithMaximumNumberOfGroups(t *testing.T) {
 		leftSource, rightSource, typs, typs,
 		[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
 		[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
-		testDiskAcc,
+		testDiskAcc, &evalCtx,
 	)
 	if err != nil {
 		t.Fatal("error in merge join op constructor", err)
@@ -1773,6 +1775,8 @@ func TestMergeJoinerMultiBatch(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
+	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
+	defer evalCtx.Stop(ctx)
 	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(t, true /* inMem */)
 	defer cleanup()
 	for _, numInputBatches := range []int{1, 2, 16} {
@@ -1793,7 +1797,7 @@ func TestMergeJoinerMultiBatch(t *testing.T) {
 					leftSource, rightSource, typs, typs,
 					[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
 					[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
-					testDiskAcc,
+					testDiskAcc, &evalCtx,
 				)
 				if err != nil {
 					t.Fatal("error in merge join op constructor", err)
@@ -1830,6 +1834,8 @@ func TestMergeJoinerMultiBatchRuns(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
+	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
+	defer evalCtx.Stop(ctx)
 	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(t, true /* inMem */)
 	defer cleanup()
 	for _, groupSize := range []int{coldata.BatchSize() / 8, coldata.BatchSize() / 4, coldata.BatchSize() / 2} {
@@ -1869,7 +1875,7 @@ func TestMergeJoinerMultiBatchRuns(t *testing.T) {
 						leftSource, rightSource, typs, typs,
 						[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}, {ColIdx: 1, Direction: execinfrapb.Ordering_Column_ASC}},
 						[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}, {ColIdx: 1, Direction: execinfrapb.Ordering_Column_ASC}},
-						testDiskAcc,
+						testDiskAcc, &evalCtx,
 					)
 					if err != nil {
 						t.Fatal("error in merge join op constructor", err)
@@ -1978,6 +1984,8 @@ func TestMergeJoinerRandomized(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
+	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
+	defer evalCtx.Stop(ctx)
 	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(t, true /* inMem */)
 	defer cleanup()
 	for _, numInputBatches := range []int{1, 2, 16, 256} {
@@ -1997,7 +2005,7 @@ func TestMergeJoinerRandomized(t *testing.T) {
 						leftSource, rightSource, typs, typs,
 						[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
 						[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
-						testDiskAcc,
+						testDiskAcc, &evalCtx,
 					)
 					if err != nil {
 						t.Fatal("error in merge join op constructor", err)

--- a/pkg/sql/colexec/select_in.eg.go
+++ b/pkg/sql/colexec/select_in.eg.go
@@ -35,7 +35,7 @@ import (
 var (
 	_ apd.Context
 	_ duration.Duration
-	_ coldataext.Datum
+	_ = coldataext.CompareDatum
 	_ json.JSON
 )
 
@@ -2720,7 +2720,7 @@ func cmpInDatum(
 		i := (lo + hi) / 2
 		var cmpResult int
 
-		cmpResult = targetElem.(*coldataext.Datum).CompareDatum(targetCol, filterRow[i])
+		cmpResult = coldataext.CompareDatum(targetElem, targetCol, filterRow[i])
 
 		if cmpResult == 0 {
 			return siTrue

--- a/pkg/sql/colexec/select_in_tmpl.go
+++ b/pkg/sql/colexec/select_in_tmpl.go
@@ -41,7 +41,7 @@ import (
 var (
 	_ apd.Context
 	_ duration.Duration
-	_ coldataext.Datum
+	_ = coldataext.CompareDatum
 	_ json.JSON
 )
 

--- a/pkg/sql/colexec/sort.eg.go
+++ b/pkg/sql/colexec/sort.eg.go
@@ -28,7 +28,7 @@ import (
 // Workaround for bazel auto-generated code. goimports does not automatically
 // pick up the right packages when run within the bazel sandbox.
 var (
-	_ coldataext.Datum
+	_ = coldataext.CompareDatum
 	_ tree.AggType
 )
 
@@ -1259,7 +1259,7 @@ func (s *sortDatumAscWithNullsOp) Less(i, j int) bool {
 	{
 		var cmpResult int
 
-		cmpResult = arg1.(*coldataext.Datum).CompareDatum(s.sortCol, arg2)
+		cmpResult = coldataext.CompareDatum(arg1, s.sortCol, arg2)
 
 		lt = cmpResult < 0
 	}
@@ -2115,7 +2115,7 @@ func (s *sortDatumDescWithNullsOp) Less(i, j int) bool {
 	{
 		var cmpResult int
 
-		cmpResult = arg1.(*coldataext.Datum).CompareDatum(s.sortCol, arg2)
+		cmpResult = coldataext.CompareDatum(arg1, s.sortCol, arg2)
 
 		lt = cmpResult > 0
 	}
@@ -2861,7 +2861,7 @@ func (s *sortDatumAscOp) Less(i, j int) bool {
 	{
 		var cmpResult int
 
-		cmpResult = arg1.(*coldataext.Datum).CompareDatum(s.sortCol, arg2)
+		cmpResult = coldataext.CompareDatum(arg1, s.sortCol, arg2)
 
 		lt = cmpResult < 0
 	}
@@ -3607,7 +3607,7 @@ func (s *sortDatumDescOp) Less(i, j int) bool {
 	{
 		var cmpResult int
 
-		cmpResult = arg1.(*coldataext.Datum).CompareDatum(s.sortCol, arg2)
+		cmpResult = coldataext.CompareDatum(arg1, s.sortCol, arg2)
 
 		lt = cmpResult > 0
 	}

--- a/pkg/sql/colexec/sort_partitioner.eg.go
+++ b/pkg/sql/colexec/sort_partitioner.eg.go
@@ -2463,7 +2463,7 @@ func (p partitionerDatum) partitionWithOrder(
 							{
 								var cmpResult int
 
-								cmpResult = v.(*coldataext.Datum).CompareDatum(col, lastVal)
+								cmpResult = coldataext.CompareDatum(v, col, lastVal)
 
 								unique = cmpResult != 0
 							}
@@ -2494,7 +2494,7 @@ func (p partitionerDatum) partitionWithOrder(
 					{
 						var cmpResult int
 
-						cmpResult = v.(*coldataext.Datum).CompareDatum(col, lastVal)
+						cmpResult = coldataext.CompareDatum(v, col, lastVal)
 
 						unique = cmpResult != 0
 					}
@@ -2561,7 +2561,7 @@ func (p partitionerDatum) partition(colVec coldata.Vec, outputCol []bool, n int)
 							{
 								var cmpResult int
 
-								cmpResult = v.(*coldataext.Datum).CompareDatum(col, lastVal)
+								cmpResult = coldataext.CompareDatum(v, col, lastVal)
 
 								unique = cmpResult != 0
 							}
@@ -2594,7 +2594,7 @@ func (p partitionerDatum) partition(colVec coldata.Vec, outputCol []bool, n int)
 					{
 						var cmpResult int
 
-						cmpResult = v.(*coldataext.Datum).CompareDatum(col, lastVal)
+						cmpResult = coldataext.CompareDatum(v, col, lastVal)
 
 						unique = cmpResult != 0
 					}

--- a/pkg/sql/colexec/sort_tmpl.go
+++ b/pkg/sql/colexec/sort_tmpl.go
@@ -36,7 +36,7 @@ import (
 // Workaround for bazel auto-generated code. goimports does not automatically
 // pick up the right packages when run within the bazel sandbox.
 var (
-	_ coldataext.Datum
+	_ = coldataext.CompareDatum
 	_ tree.AggType
 )
 

--- a/pkg/sql/colexec/values_differ.eg.go
+++ b/pkg/sql/colexec/values_differ.eg.go
@@ -26,7 +26,7 @@ import (
 // pick up the right packages when run within the bazel sandbox.
 var (
 	_ = typeconv.DatumVecCanonicalTypeFamily
-	_ coldataext.Datum
+	_ = coldataext.CompareDatum
 	_ tree.AggType
 )
 
@@ -393,7 +393,7 @@ func valuesDiffer(
 			{
 				var cmpResult int
 
-				cmpResult = arg1.(*coldataext.Datum).CompareDatum(aCol, arg2)
+				cmpResult = coldataext.CompareDatum(arg1, aCol, arg2)
 
 				unique = cmpResult != 0
 			}

--- a/pkg/sql/colexec/values_differ_tmpl.go
+++ b/pkg/sql/colexec/values_differ_tmpl.go
@@ -33,7 +33,7 @@ import (
 // pick up the right packages when run within the bazel sandbox.
 var (
 	_ = typeconv.DatumVecCanonicalTypeFamily
-	_ coldataext.Datum
+	_ = coldataext.CompareDatum
 	_ tree.AggType
 )
 

--- a/pkg/sql/colexec/vec_comparators.eg.go
+++ b/pkg/sql/colexec/vec_comparators.eg.go
@@ -25,7 +25,7 @@ import (
 // Workaround for bazel auto-generated code. goimports does not automatically
 // pick up the right packages when run within the bazel sandbox.
 var (
-	_ coldataext.Datum
+	_ = coldataext.CompareDatum
 	_ tree.AggType
 )
 
@@ -520,7 +520,7 @@ func (c *DatumVecComparator) compare(vecIdx1, vecIdx2 int, valIdx1, valIdx2 int)
 	right := c.vecs[vecIdx2].Get(valIdx2)
 	var cmp int
 
-	cmp = left.(*coldataext.Datum).CompareDatum(c.vecs[vecIdx1], right)
+	cmp = coldataext.CompareDatum(left, c.vecs[vecIdx1], right)
 
 	return cmp
 }

--- a/pkg/sql/colexec/vec_comparators_tmpl.go
+++ b/pkg/sql/colexec/vec_comparators_tmpl.go
@@ -32,7 +32,7 @@ import (
 // Workaround for bazel auto-generated code. goimports does not automatically
 // pick up the right packages when run within the bazel sandbox.
 var (
-	_ coldataext.Datum
+	_ = coldataext.CompareDatum
 	_ tree.AggType
 )
 

--- a/pkg/sql/colflow/routers_test.go
+++ b/pkg/sql/colflow/routers_test.go
@@ -51,6 +51,7 @@ type testUtils struct {
 	// testAllocator is an Allocator with an unlimited budget for use in tests.
 	testAllocator     *colmem.Allocator
 	testColumnFactory coldata.ColumnFactory
+	evalCtx           *tree.EvalContext
 
 	// testMemMonitor and testMemAcc are a test monitor with an unlimited budget
 	// and a memory account bound to it for use in tests.
@@ -75,6 +76,7 @@ func newTestUtils(ctx context.Context) *testUtils {
 	return &testUtils{
 		testAllocator:     testAllocator,
 		testColumnFactory: testColumnFactory,
+		evalCtx:           &evalCtx,
 		testMemMonitor:    testMemMonitor,
 		testMemAcc:        &memAcc,
 		testDiskMonitor:   testDiskMonitor,

--- a/pkg/sql/colflow/stats_test.go
+++ b/pkg/sql/colflow/stats_test.go
@@ -122,7 +122,7 @@ func TestVectorizedStatsCollector(t *testing.T) {
 			[]*types.T{types.Int}, []*types.T{types.Int},
 			[]execinfrapb.Ordering_Column{{ColIdx: 0}},
 			[]execinfrapb.Ordering_Column{{ColIdx: 0}},
-			tu.testDiskAcc,
+			tu.testDiskAcc, tu.evalCtx,
 		)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/sql/colmem/BUILD.bazel
+++ b/pkg/sql/colmem/BUILD.bazel
@@ -7,7 +7,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/col/coldata",
-        "//pkg/col/coldataext",
         "//pkg/col/typeconv",
         "//pkg/sql/colexecerror",
         "//pkg/sql/memsize",

--- a/pkg/sql/colmem/allocator.go
+++ b/pkg/sql/colmem/allocator.go
@@ -14,7 +14,6 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
-	"github.com/cockroachdb/cockroach/pkg/col/coldataext"
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/memsize"
@@ -652,7 +651,7 @@ func (h *SetAccountingHelper) AccountForSet(rowIdx int) {
 			newVarLengthDatumSize += int64(tree.SizeOfDecimal(&d))
 		}
 		for _, datumVec := range h.datumVecs {
-			datumSize := datumVec.Get(rowIdx).(*coldataext.Datum).Size()
+			datumSize := datumVec.Get(rowIdx).(tree.Datum).Size()
 			newVarLengthDatumSize += int64(datumSize) + memsize.DatumOverhead
 		}
 		h.Allocator.AdjustMemoryUsage(newVarLengthDatumSize - h.varSizeDatumSizes[rowIdx])

--- a/pkg/sql/pgwire/BUILD.bazel
+++ b/pkg/sql/pgwire/BUILD.bazel
@@ -18,7 +18,6 @@ go_library(
         "//pkg/base",
         "//pkg/clusterversion",
         "//pkg/col/coldata",
-        "//pkg/col/coldataext",
         "//pkg/security",
         "//pkg/server/telemetry",
         "//pkg/settings",

--- a/pkg/sql/pgwire/types.go
+++ b/pkg/sql/pgwire/types.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/cockroachdb/apd/v2"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
-	"github.com/cockroachdb/cockroach/pkg/col/coldataext"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
@@ -344,7 +343,7 @@ func (b *writeBuffer) writeTextColumnarElement(
 
 			default:
 				// All other types are represented via the datum-backed vector.
-				writeTextDatumNotNull(b, vec.Datum().Get(idx).(*coldataext.Datum).Datum, conv, sessionLoc, vec.Type())
+				writeTextDatumNotNull(b, vec.Datum().Get(idx).(tree.Datum), conv, sessionLoc, vec.Type())
 			}
 		},
 	)
@@ -790,7 +789,7 @@ func (b *writeBuffer) writeBinaryColumnarElement(
 
 	default:
 		// All other types are represented via the datum-backed vector.
-		writeBinaryDatumNotNull(ctx, b, vec.Datum().Get(idx).(*coldataext.Datum).Datum, sessionLoc, vec.Type())
+		writeBinaryDatumNotNull(ctx, b, vec.Datum().Get(idx).(tree.Datum), sessionLoc, vec.Type())
 	}
 }
 


### PR DESCRIPTION
**coldataext: propagate evalCtx directly for casts**

This commit removes the reliance on propagating `datumVec` objects to
supply the cast function with an eval context. All casts in the datum
land have been refactored to use `tree.PerformCast` for simplicity.

Note that the eval context is not removed from the `datumVec` because it
is used by `CompareDatum` method which is a lot more common (and, thus,
would require more plumbing to get rid off).

Release note: None

**coldataext: remove a wrapper and use tree.Datum directly**

Previously, we had separate `coldataext.Datum` wrapper around
`tree.Datum`. I don't remember what was the reasoning behind introducing
it (probably so that we could define methods with the wrapper as the
receiver in `coldataext` package), but it seems unnecessary. It also has
some performance cost because on every `DatumVec.Get` we are currently
allocating a new object on the heap. This commit removes the wrapper in
favor of working with `tree.Datum`s directly. This work was prompted by
looking at some profiles around the memory accounting for datum-backed
types in the cFetcher.

Release note: None