### PR TITLE
sql: implemented pg_shadow at pg_catalog

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -4574,25 +4574,25 @@ CREATE TABLE pg_catalog.pg_settings (
    pending_restart BOOL NULL
 )  {}  {}
 CREATE TABLE pg_catalog.pg_shadow (
-   useconfig STRING[] NULL,
-   usecreatedb BOOL NULL,
-   userepl BOOL NULL,
-   usesuper BOOL NULL,
-   usesysid OID NULL,
-   valuntil TIMESTAMPTZ NULL,
-   passwd STRING NULL,
    usename NAME NULL,
-   usebypassrls BOOL NULL
+   usesysid OID NULL,
+   usecreatedb BOOL NULL,
+   usesuper BOOL NULL,
+   userepl BOOL NULL,
+   usebypassrls BOOL NULL,
+   passwd STRING NULL,
+   valuntil TIMESTAMPTZ NULL,
+   useconfig STRING[] NULL
 )  CREATE TABLE pg_catalog.pg_shadow (
-   useconfig STRING[] NULL,
-   usecreatedb BOOL NULL,
-   userepl BOOL NULL,
-   usesuper BOOL NULL,
-   usesysid OID NULL,
-   valuntil TIMESTAMPTZ NULL,
-   passwd STRING NULL,
    usename NAME NULL,
-   usebypassrls BOOL NULL
+   usesysid OID NULL,
+   usecreatedb BOOL NULL,
+   usesuper BOOL NULL,
+   userepl BOOL NULL,
+   usebypassrls BOOL NULL,
+   passwd STRING NULL,
+   valuntil TIMESTAMPTZ NULL,
+   useconfig STRING[] NULL
 )  {}  {}
 CREATE TABLE pg_catalog.pg_shdepend (
    dbid OID NULL,

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3773,7 +3773,7 @@ objoid      classoid    objsubid  description
 4294967082  4294967133  0         sequences (see also information_schema.sequences)
 4294967081  4294967133  0         pg_sequences is very similar as pg_sequence.
 4294967080  4294967133  0         session variables (incomplete)
-4294967079  4294967133  0         pg_shadow was created for compatibility and is currently unimplemented
+4294967079  4294967133  0         pg_shadow lists properties for roles that are marked as rolcanlogin in pg_authid
 4294967076  4294967133  0         Shared Dependencies (Roles depending on objects).
 4294967078  4294967133  0         shared object comments
 4294967075  4294967133  0         pg_shmem_allocations was created for compatibility and is currently unimplemented
@@ -5358,3 +5358,44 @@ JOIN pg_class ON pg_statistic_ext.stxrelid = pg_class.oid
 ----
 relname  stxname  stxnamespace  stxowner  stxstattarget  stxkeys  stxkind
 stxtbl   stxobj   NULL          NULL      NULL           {2,3}    NULL
+
+# Test that pg_shadow doesn't include roles that can't login
+query B colnames
+SELECT (count(1) = 0) AS PASSED
+FROM pg_shadow
+WHERE EXISTS (
+  SELECT 1 FROM pg_authid WHERE oid = usesysid AND NOT rolcanlogin
+)
+----
+passed
+true
+
+# Test pg_shadow contents
+query TOBBBBTTT colnames
+SELECT * FROM pg_shadow ORDER BY usename;
+----
+usename                       usesysid    usecreatedb  usesuper  userepl  usebypassrls  passwd    valuntil                       useconfig
+admin                         2310524507  true         true      false    false         ********  NULL                           NULL
+anyuser                       2525089181  false        false     false    false         ********  NULL                           NULL
+regression_70180              2066478618  false        false     false    false         ********  NULL                           NULL
+regular_user                  3044356792  false        false     false    false         ********  NULL                           NULL
+role_test_login               2531829827  false        false     false    false         ********  NULL                           NULL
+role_test_nodate              1492950893  false        false     false    false         ********  NULL                           NULL
+role_test_with_date           1212615927  false        false     false    false         ********  2021-01-01 00:00:00 +0000 UTC  NULL
+role_test_with_date_timezone  1682504215  false        false     false    false         ********  2020-12-31 22:00:00 +0000 UTC  NULL
+root                          1546506610  true         true      false    false         ********  NULL                           NULL
+sh_owner                      2488412215  false        false     false    false         ********  NULL                           NULL
+sh_user                       2387559583  false        false     false    false         ********  NULL                           NULL
+super_user                    2430969455  false        true      false    false         ********  NULL                           NULL
+testuser                      2264919399  false        false     false    false         ********  NULL                           NULL
+testuser1                     3957504276  true         false     false    false         ********  NULL                           {timezone=America/Los_Angeles,application_name=a}
+testuser2                     3957504279  false        false     false    false         ********  3022-01-01 00:00:00 +0000 UTC  NULL
+
+# Testing oids references the same roles in pg_shadow and pg_authid
+query B colnames
+SELECT bool_and(usename = rolname) PASSED
+FROM pg_shadow
+JOIN pg_authid ON usesysid = oid
+----
+passed
+true

--- a/pkg/sql/vtable/pg_catalog.go
+++ b/pkg/sql/vtable/pg_catalog.go
@@ -709,7 +709,7 @@ CREATE TABLE pg_catalog.pg_settings (
     pending_restart BOOL
 )`
 
-// PGCatalogShdepend describes the schema of the pg_catalog.pg_shdepend table.
+// PGCatalogShdepend describes the schema of the pg_catalog. table.
 // https://www.postgresql.org/docs/9.6/catalog-pg-shdepend.html,
 const PGCatalogShdepend = `
 CREATE TABLE pg_catalog.pg_shdepend (
@@ -1051,19 +1051,19 @@ CREATE TABLE pg_catalog.pg_rules (
 	tablename NAME
 )`
 
-// PgCatalogShadow is an empty table created by pg_catalog_test
-// and is currently unimplemented.
+// PgCatalogShadow is the implementation of pg_catalog.pg_shadow
+// see https://www.postgresql.org/docs/13/view-pg-shadow.html
 const PgCatalogShadow = `
 CREATE TABLE pg_catalog.pg_shadow (
-	useconfig STRING[],
-	usecreatedb BOOL,
-	userepl BOOL,
-	usesuper BOOL,
-	usesysid OID,
-	valuntil TIMESTAMPTZ,
-	passwd STRING,
 	usename NAME,
-	usebypassrls BOOL
+	usesysid OID,
+	usecreatedb BOOL,
+	usesuper BOOL,
+  userepl BOOL,
+  usebypassrls BOOL,
+	passwd STRING,
+  valuntil TIMESTAMPTZ,
+	useconfig STRING[]
 )`
 
 // PgCatalogPublication is an empty table created by pg_catalog_test


### PR DESCRIPTION
Previously, pg_shadow was defined but unimplemented
This was inadequate because telemetry stated that this table has been
queried by a tool or ORM
To address this, this patch implements pg_shadow table at pg_catalog

Release note (sql change): implemented pg_shadow at pg_catalog

Solves #68133

Release Justification: low risk, high benefit changes to existing functionality