### PR TITLE
sql: prevent dropping enum values used in index partitioning or predicates

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_drop_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_drop_region
@@ -1,0 +1,18 @@
+# LogicTest: multiregion-9node-3region-3azs
+
+query TTTT
+SHOW REGIONS
+----
+ap-southeast-2  {ap-az1,ap-az2,ap-az3}  {}  {}
+ca-central-1    {ca-az1,ca-az2,ca-az3}  {}  {}
+us-east-1       {us-az1,us-az2,us-az3}  {}  {}
+
+statement ok
+CREATE DATABASE mr primary region "ca-central-1" regions "ap-southeast-2", "us-east-1"
+
+statement ok
+USE mr;
+CREATE TABLE kv (k INT PRIMARY KEY, v INT) LOCALITY REGIONAL BY ROW
+
+statement ok
+ALTER DATABASE mr DROP REGION "us-east-1"

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_enum
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_enum
@@ -55,3 +55,47 @@ ALTER TABLE partitioned_table_3 PARTITION BY RANGE (place)
 
 statement ok
 SELECT * FROM crdb_internal.tables
+
+
+subtest drop_enum_partitioning_value
+
+statement ok
+drop table if exists tbl;
+drop type if exists t;
+set enable_drop_enum_value = true;
+create type t as enum('a', 'b', 'c');
+create table tbl (pk t PRIMARY KEY) PARTITION BY LIST (pk) (PARTITION "a" VALUES IN ('a'))
+
+statement error pgcode 2BP01 could not remove enum value "a" as it is being used in the partitioning of index tbl@primary
+alter type t drop value 'a'
+
+statement ok
+drop table if exists tbl;
+drop type if exists t;
+set enable_drop_enum_value = true;
+create type t as enum('a', 'b', 'c');
+create table tbl (i INT, k t,  PRIMARY KEY (i, k)) PARTITION BY LIST (i) (PARTITION "one" VALUES IN (1) PARTITION BY RANGE (k) (PARTITION "a" VALUES FROM ('a') TO ('b')))
+
+statement error pgcode 2BP01 could not remove enum value "a" as it is being used in the partitioning of index tbl@primary
+alter type t drop value 'a'
+
+statement ok
+drop table if exists tbl;
+drop type if exists t;
+set enable_drop_enum_value = true;
+create type t as enum('a', 'b', 'c');
+create table tbl (i INT, k t,  PRIMARY KEY (i, k), INDEX idx (k) PARTITION BY RANGE (k) (PARTITION "a" VALUES FROM ('a') TO ('b')))
+
+statement error pgcode 2BP01 could not remove enum value "a" as it is being used in the partitioning of index tbl@idx
+alter type t drop value 'a';
+
+# We want to fail even if the index is being dropped. The reason is that it
+# would be bad if we rolled back the dropping of the index.
+statement error pgcode XXA00 could not remove enum value "a" as it is being used in the partitioning of index tbl@idx
+begin;
+drop index tbl@idx;
+alter type t drop value 'a';
+commit
+
+statement ok
+alter type t drop value 'c';

--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -1530,3 +1530,16 @@ query T
 SELECT typname FROM pg_type WHERE oid = $oid
 ----
 typ2
+
+subtest drop_enum_value_index_predicate
+
+statement ok
+SET enable_drop_enum_value = true;
+
+statement ok
+DROP TYPE IF EXISTS enum_for_predicate;
+CREATE TYPE enum_for_predicate AS ENUM ('a', 'b');
+CREATE TABLE uses_in_index_predicate (i INT PRIMARY KEY, t enum_for_predicate, INDEX (t) WHERE (t = 'a'))
+
+statement error pgcode 2BP01 could not remove enum value "a" as it is being used in a predicate of index uses_in_index_predicate@uses_in_index_predicate_t_idx
+ALTER TYPE enum_for_predicate DROP VALUE 'a'


### PR DESCRIPTION
This commit adds logic to detect usages of enum values in partitioning clauses
and in index predicates.

Fixes #63366.

Release note (bug fix): Fixed a bug which permitted the dropping of enum values
which were in use in index predicates or partitioning values.