### PR TITLE
release-20.2: Wait() for backup/restore on err return

### DIFF
--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -269,16 +269,17 @@ func backup(
 		return nil
 	})
 
-	if err := distBackup(
-		ctx,
-		execCtx,
-		planCtx,
-		dsp,
-		progCh,
-		backupSpecs,
-	); err != nil {
-		return RowCount{}, err
-	}
+	g.GoCtx(func(ctx context.Context) error {
+		defer close(progCh)
+		return distBackup(
+			ctx,
+			execCtx,
+			planCtx,
+			dsp,
+			progCh,
+			backupSpecs,
+		)
+	})
 
 	if err := g.Wait(); err != nil {
 		return RowCount{}, errors.Wrapf(err, "exporting %d ranges", errors.Safe(numTotalSpans))

--- a/pkg/ccl/backupccl/backup_processor_planning.go
+++ b/pkg/ccl/backupccl/backup_processor_planning.go
@@ -70,7 +70,6 @@ func distBackup(
 	var noTxn *kv.Txn
 
 	if len(backupSpecs) == 0 {
-		close(progCh)
 		return nil
 	}
 
@@ -116,7 +115,6 @@ func distBackup(
 	)
 	defer recv.Release()
 
-	defer close(progCh)
 	// Copy the evalCtx, as dsp.Run() might change it.
 	evalCtxCopy := *evalCtx
 	dsp.Run(planCtx, noTxn, &p, recv, &evalCtxCopy, nil /* finishedSetupFn */)()

--- a/pkg/ccl/backupccl/restore_processor_planning.go
+++ b/pkg/ccl/backupccl/restore_processor_planning.go
@@ -47,7 +47,6 @@ func distRestore(
 	progCh chan *execinfrapb.RemoteProducerMetadata_BulkProcessorProgress,
 ) error {
 	ctx = logtags.AddTag(ctx, "restore-distsql", nil)
-	defer close(progCh)
 	var noTxn *kv.Txn
 
 	dsp := phs.DistSQLPlanner()


### PR DESCRIPTION
This was fixed on master and 21.1 via https://github.com/cockroachdb/cockroach/pull/65797.
However that change includes a little more refactor than strictly required to avoid the
race, which was intended to prevent a similar issue happening again. This change simply
removes the current issue, without the churn of the long-term improvement, as it is against the older branch.

Release justification: fixes a node crash.

Release note (bug fix): Fix a rare crash when a backup writing to Google Cloud Storage failed while writing a file.