### PR TITLE
roachtest: add repro link to roachtest stress CI build

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -944,10 +944,22 @@ func (r *testRunner) maybePostGithubIssue(
 		Message:         msg,
 		Artifacts:       artifacts,
 		ExtraLabels:     labels,
-		ReproductionCommand: issues.ReproductionAsLink(
-			"roachtest README",
-			"https://github.com/cockroachdb/cockroach/tree/master/pkg/cmd/roachtest",
-		),
+		ReproductionCommand: func(renderer *issues.Renderer) {
+			issues.ReproductionAsLink(
+				"roachtest README",
+				"https://github.com/cockroachdb/cockroach/tree/master/pkg/cmd/roachtest",
+			)(renderer)
+			issues.ReproductionAsLink(
+				"CI job to stress roachtests",
+				"https://teamcity.cockroachdb.com/buildConfiguration/Cockroach_Nightlies_RoachtestStress",
+			)(renderer)
+			renderer.P(func() {
+				renderer.Escaped("For the CI stress job, click the ellipsis (...) next to the Run button and fill in:\n")
+				renderer.Escaped(fmt.Sprintf("* Changes / Build branch: %s\n", branch))
+				renderer.Escaped(fmt.Sprintf("* Parameters / `env.TESTS`: `^%s$`\n", t.Name()))
+				renderer.Escaped("* Parameters / `env.COUNT`: <number of runs>\n")
+			})
+		},
 	}
 	if err := issues.Post(
 		context.Background(),


### PR DESCRIPTION
Release note: None

---

Unfortunately, there doesn't appear to be a way to get a link to the actual "Custom Build" form in TeamCity, so we have to provide instructions for people to manually click and fill in stuff. 😕 We could instead provide a `curl` command that would trigger a build with appropriate parameters via a REST API call, but that would require the user to set up API authentication tokens, so it's not clear that it's any more convenient. Ideas for improvements are welcome.