### PR TITLE
cli: debug merge-log print filename on error

### DIFF
--- a/pkg/cli/debug_merge_logs.go
+++ b/pkg/cli/debug_merge_logs.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logpb"
+	"github.com/cockroachdb/errors"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -579,13 +580,13 @@ func seekToFirstAfterFrom(
 		var e logpb.Entry
 		d, err := log.NewEntryDecoderWithFormat(f, editMode, format)
 		if err != nil {
-			panic(err)
+			panic(errors.WithMessagef(err, "error while processing file %s", f.Name()))
 		}
 		if err := d.Decode(&e); err != nil {
 			if err == io.EOF {
 				return true
 			}
-			panic(err)
+			panic(errors.WithMessagef(err, "error while processing file %s", f.Name()))
 		}
 		return e.Time >= from.UnixNano()
 	})


### PR DESCRIPTION
Previously when debug merge-logs failed to find log format it paniced
with error but without a reference to filename that failed.
This diff adds filename to panic messages.

Release note: None