### PR TITLE
roachtest: remove local TLS certs during cluster wipe

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1517,6 +1517,12 @@ func (c *clusterImpl) doDestroy(ctx context.Context, l *logger.Logger) <-chan st
 			if err := execCmd(ctx, l, roachprod, "wipe", c.name); err != nil {
 				l.Errorf("%s", err)
 			}
+			if c.localCertsDir != "" {
+				if err := os.RemoveAll(c.localCertsDir); err != nil {
+					l.Errorf("failed to remove local certs in %s: %s", c.localCertsDir, err)
+				}
+				c.localCertsDir = ""
+			}
 		}
 	} else {
 		l.Printf("skipping cluster wipe\n")

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1075,6 +1075,13 @@ func (r *testRunner) getWork(
 		if err := c.RunL(ctx, l, c.All(), "rm -rf "+perfArtifactsDir); err != nil {
 			return testToRunRes{}, nil, errors.Wrapf(err, "failed to remove perf artifacts dir")
 		}
+		if c.localCertsDir != "" {
+			if err := os.RemoveAll(c.localCertsDir); err != nil {
+				return testToRunRes{}, nil, errors.Wrapf(err,
+					"failed to remove local certs in %s", c.localCertsDir)
+			}
+			c.localCertsDir = ""
+		}
 		// Overwrite the spec of the cluster with the one coming from the test. In
 		// particular, this overwrites the reuse policy to reflect what the test
 		// intends to do with it.


### PR DESCRIPTION
In #68101, `roachtest` gained rudimentary support for using secure
clusters, including setting up local TLS client certificates. However,
these local certificates were not removed when a cluster was wiped and
reused, causing the client to fail with an authentication error when
attempting to contact the new insecure cluster (as seen in e.g. #68261).

This patch makes sure the local certificates are removed whenever
`roachtest` wipes a cluster.

Resolves #68261.
Resolves #68264.

Release note: None