### PR TITLE
SQL: Reset database zone configuration builtin

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -908,9 +908,13 @@ SQL statement omitting multi-region related zone configuration fields.
 If the CONFIGURE ZONE statement can be inferred by the database’s or
 table’s zone configuration this will return NULL.</p>
 </span></td></tr>
+<tr><td><a name="crdb_internal.reset_multi_region_zone_configs_for_database"></a><code>crdb_internal.reset_multi_region_zone_configs_for_database(id: <a href="int.html">int</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Resets the zone configuration for a multi-region database to
+match its original state. No-ops if the given database ID is not multi-region
+enabled.</p>
+</span></td></tr>
 <tr><td><a name="crdb_internal.reset_multi_region_zone_configs_for_table"></a><code>crdb_internal.reset_multi_region_zone_configs_for_table(id: <a href="int.html">int</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Resets the zone configuration for a multi-region table to
 match its original state. No-ops if the given table ID is not a multi-region
-table</p>
+table.</p>
 </span></td></tr>
 <tr><td><a name="crdb_internal.validate_multi_region_zone_configs"></a><code>crdb_internal.validate_multi_region_zone_configs() &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Validates all multi-region zone configurations are correctly setup
 for the current database, including all tables, indexes and partitions underneath.

--- a/pkg/ccl/importccl/import_table_creation.go
+++ b/pkg/ccl/importccl/import_table_creation.go
@@ -288,6 +288,14 @@ func (so *importSequenceOperators) ResetMultiRegionZoneConfigsForTable(
 	return errors.WithStack(errSequenceOperators)
 }
 
+// ResetMultiRegionZoneConfigsForDatabase is part of the tree.EvalDatabase
+// interface.
+func (so *importSequenceOperators) ResetMultiRegionZoneConfigsForDatabase(
+	_ context.Context, _ int64,
+) error {
+	return errors.WithStack(errSequenceOperators)
+}
+
 // ParseQualifiedTableName implements the tree.EvalDatabase interface.
 func (so *importSequenceOperators) ParseQualifiedTableName(sql string) (*tree.TableName, error) {
 	name, err := parser.ParseTableName(sql)

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
@@ -1625,3 +1625,105 @@ TABLE tbl11  ALTER TABLE tbl11 CONFIGURE ZONE USING
 
 query error pq: crdb_internal\.reset_multi_region_zone_configs_for_table\(\): error resolving referenced table ID 1: relation "\[1\]" does not exist
 SELECT crdb_internal.crdb_internal.reset_multi_region_zone_configs_for_table(1)
+
+subtest reset_multi_region_zone_configs_database
+
+statement ok
+CREATE DATABASE "rebuild_zc_db" primary region "ca-central-1" regions "ap-southeast-2", "us-east-1";
+USE "rebuild_zc_db"
+
+query TT
+SHOW ZONE CONFIGURATION FOR DATABASE "rebuild_zc_db"
+----
+DATABASE rebuild_zc_db ALTER DATABASE rebuild_zc_db CONFIGURE ZONE USING
+ range_min_bytes = 134217728,
+ range_max_bytes = 536870912,
+ gc.ttlseconds = 90000,
+ num_replicas = 5,
+ num_voters = 3,
+ constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+ voter_constraints = '[+region=ca-central-1]',
+ lease_preferences = '[[+region=ca-central-1]]'
+
+
+statement ok
+SET override_multi_region_zone_config = true;
+ALTER DATABASE "rebuild_zc_db" CONFIGURE ZONE USING num_replicas = 10;
+SET override_multi_region_zone_config = false
+
+query TT
+SHOW ZONE CONFIGURATION FOR DATABASE "rebuild_zc_db"
+----
+DATABASE rebuild_zc_db ALTER DATABASE rebuild_zc_db CONFIGURE ZONE USING
+ range_min_bytes = 134217728,
+ range_max_bytes = 536870912,
+ gc.ttlseconds = 90000,
+ num_replicas = 10,
+ num_voters = 3,
+ constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+ voter_constraints = '[+region=ca-central-1]',
+ lease_preferences = '[[+region=ca-central-1]]'
+
+let $rebuild_db_id
+select id from crdb_internal.databases where name = 'rebuild_zc_db'
+
+statement ok
+SELECT crdb_internal.crdb_internal.reset_multi_region_zone_configs_for_database($rebuild_db_id)
+
+query TT
+SHOW ZONE CONFIGURATION FOR DATABASE "rebuild_zc_db"
+----
+DATABASE rebuild_zc_db ALTER DATABASE rebuild_zc_db CONFIGURE ZONE USING
+ range_min_bytes = 134217728,
+ range_max_bytes = 536870912,
+ gc.ttlseconds = 90000,
+ num_replicas = 5,
+ num_voters = 3,
+ constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+ voter_constraints = '[+region=ca-central-1]',
+ lease_preferences = '[[+region=ca-central-1]]'
+
+statement ok
+SELECT crdb_internal.validate_multi_region_zone_configs()
+
+statement ok
+SET override_multi_region_zone_config = true;
+ALTER DATABASE "rebuild_zc_db" CONFIGURE ZONE DISCARD;
+SET override_multi_region_zone_config = false
+
+query TT
+SHOW ZONE CONFIGURATION FOR DATABASE "rebuild_zc_db"
+----
+RANGE default ALTER RANGE default CONFIGURE ZONE USING
+ range_min_bytes = 134217728,
+ range_max_bytes = 536870912,
+ gc.ttlseconds = 90000,
+ num_replicas = 3,
+ constraints = '[]',
+ lease_preferences = '[]'
+
+statement ok
+SELECT crdb_internal.reset_multi_region_zone_configs_for_database($rebuild_db_id)
+
+query TT
+SHOW ZONE CONFIGURATION FOR DATABASE "rebuild_zc_db"
+----
+DATABASE rebuild_zc_db ALTER DATABASE rebuild_zc_db CONFIGURE ZONE USING
+ range_min_bytes = 134217728,
+ range_max_bytes = 536870912,
+ gc.ttlseconds = 90000,
+ num_replicas = 5,
+ num_voters = 3,
+ constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+ voter_constraints = '[+region=ca-central-1]',
+ lease_preferences = '[[+region=ca-central-1]]'
+
+statement ok
+SELECT crdb_internal.validate_multi_region_zone_configs()
+
+let $null_table_id
+SELECT table_id FROM crdb_internal.tables WHERE schema_name = 'crdb_internal' AND name = 'tables'
+
+# Validate that builtin errors if called on a table id
+query error pq: crdb_internal\.reset_multi_region_zone_configs_for_database\(\): database "\[4294967249\]" does not exist
+SELECT crdb_internal.reset_multi_region_zone_configs_for_database($null_table_id)

--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -1032,10 +1032,6 @@ func (n *alterDatabaseSurvivalGoalNode) startExec(params runParams) error {
 		return err
 	}
 
-	if err := multiregion.ValidateRegionConfig(regionConfig); err != nil {
-		return err
-	}
-
 	// Update the database's zone configuration.
 	if err := ApplyZoneConfigFromDatabaseRegionConfig(
 		params.ctx,

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -68,6 +68,14 @@ func (so *DummySequenceOperators) ResetMultiRegionZoneConfigsForTable(
 	return errors.WithStack(errSequenceOperators)
 }
 
+// ResetMultiRegionZoneConfigsForDatabase is part of the tree.EvalDatabase
+// interface.
+func (so *DummySequenceOperators) ResetMultiRegionZoneConfigsForDatabase(
+	_ context.Context, id int64,
+) error {
+	return errors.WithStack(errSequenceOperators)
+}
+
 // ParseQualifiedTableName is part of the tree.EvalDatabase interface.
 func (so *DummySequenceOperators) ParseQualifiedTableName(sql string) (*tree.TableName, error) {
 	return nil, errors.WithStack(errSequenceOperators)
@@ -246,6 +254,14 @@ func (ep *DummyEvalPlanner) CurrentDatabaseRegionConfig(
 // ResetMultiRegionZoneConfigsForTable is part of the tree.EvalDatabase
 // interface.
 func (ep *DummyEvalPlanner) ResetMultiRegionZoneConfigsForTable(_ context.Context, _ int64) error {
+	return errors.WithStack(errEvalPlanner)
+}
+
+// ResetMultiRegionZoneConfigsForDatabase is part of the tree.EvalDatabase
+// interface.
+func (ep *DummyEvalPlanner) ResetMultiRegionZoneConfigsForDatabase(
+	_ context.Context, _ int64,
+) error {
 	return errors.WithStack(errEvalPlanner)
 }
 

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -854,8 +854,9 @@ func (p *planner) ValidateAllMultiRegionZoneConfigsInCurrentDatabase(ctx context
 	)
 }
 
-// ResetMultiRegionZoneConfigsForTable is part of the tree.EvalDatabase
-// interface.
+// ResetMultiRegionZoneConfigsForTable takes a table ID and resets that table's
+// zone configurations to match what would have originally been set by the
+// multi-region syntax.
 func (p *planner) ResetMultiRegionZoneConfigsForTable(ctx context.Context, id int64) error {
 	desc, err := p.Descriptors().GetMutableTableVersionByID(ctx, descpb.ID(id), p.txn)
 	if err != nil {
@@ -870,6 +871,7 @@ func (p *planner) ResetMultiRegionZoneConfigsForTable(ctx context.Context, id in
 	if err != nil {
 		return err
 	}
+
 	return ApplyZoneConfigForMultiRegionTable(
 		ctx,
 		p.txn,
@@ -878,6 +880,44 @@ func (p *planner) ResetMultiRegionZoneConfigsForTable(ctx context.Context, id in
 		desc,
 		ApplyZoneConfigForMultiRegionTableOptionTableAndIndexes,
 	)
+}
+
+// ResetMultiRegionZoneConfigsForDatabase takes a database ID and resets that
+// database's zone configuration to match what would have originally been set by
+// the multi-region syntax.
+func (p *planner) ResetMultiRegionZoneConfigsForDatabase(ctx context.Context, id int64) error {
+	_, dbDesc, err := p.Descriptors().GetImmutableDatabaseByID(
+		p.EvalContext().Ctx(),
+		p.txn,
+		descpb.ID(id),
+		tree.DatabaseLookupFlags{
+			Required: true,
+		},
+	)
+	if err != nil {
+		return err
+	}
+	if !dbDesc.IsMultiRegion() {
+		// Nothing to do.
+		return nil
+	}
+
+	regionConfig, err := SynthesizeRegionConfig(ctx, p.txn, dbDesc.GetID(), p.Descriptors())
+	if err != nil {
+		return err
+	}
+
+	// Update the database's zone configuration.
+	if err := ApplyZoneConfigFromDatabaseRegionConfig(
+		ctx,
+		dbDesc.GetID(),
+		regionConfig,
+		p.txn,
+		p.execCfg,
+	); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (p *planner) validateAllMultiRegionZoneConfigsInDatabase(

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -5457,7 +5457,29 @@ the locality flag on node startup. Returns an error if no region is set.`,
 			},
 			Info: `Resets the zone configuration for a multi-region table to 
 match its original state. No-ops if the given table ID is not a multi-region 
-table`,
+table.`,
+			Volatility: tree.VolatilityVolatile,
+		},
+	),
+	"crdb_internal.reset_multi_region_zone_configs_for_database": makeBuiltin(
+		tree.FunctionProperties{Category: categoryMultiRegion},
+		tree.Overload{
+			Types:      tree.ArgTypes{{"id", types.Int}},
+			ReturnType: tree.FixedReturnType(types.Bool),
+			Fn: func(evalCtx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				id := int64(*args[0].(*tree.DInt))
+
+				if err := evalCtx.Sequence.ResetMultiRegionZoneConfigsForDatabase(
+					evalCtx.Context,
+					id,
+				); err != nil {
+					return nil, err
+				}
+				return tree.MakeDBool(true), nil
+			},
+			Info: `Resets the zone configuration for a multi-region database to 
+match its original state. No-ops if the given database ID is not multi-region 
+enabled.`,
 			Volatility: tree.VolatilityVolatile,
 		},
 	),

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3077,6 +3077,10 @@ type EvalDatabase interface {
 	// configuration to its multi-region default.
 	ResetMultiRegionZoneConfigsForTable(ctx context.Context, id int64) error
 
+	// ResetMultiRegionZoneConfigsForDatabase resets the given database's zone
+	// configuration to its multi-region default.
+	ResetMultiRegionZoneConfigsForDatabase(ctx context.Context, id int64) error
+
 	// ParseQualifiedTableName parses a SQL string of the form
 	// `[ database_name . ] [ schema_name . ] table_name`.
 	// NB: this is deprecated! Use parser.ParseQualifiedTableName when possible.


### PR DESCRIPTION
The new(ish) multi-region syntax introduced in 21.1 sets a zone
configuration at the database level. This zone configuration
can diverge from its original state either because the user has
manually overridden it, or because the system hasn't kept it up
to date as the database has evolved (though there are no known
issues where this occurs). In either case, the user may wish to
revert the zone configurations for a given databases back to its
original state.

The new builtin takes a database ID, and resets its underlying zone
configuration to its original state (as specified by the underlying
RegionConfig). For non-multi-region databases, the builtin no-ops.

Resolves #66855.

Release note (sql change): Creates a builtin to reset the zone configuration
of a multi-region database. This builtin can be helpful in
cases where the user has overridden the zone configuration for a given
database and wishes to revert back to the original system-specified
state.