### PR TITLE
roachtest: use port outside ephemeral range for `acceptance/multitenant`

### DIFF
--- a/pkg/cmd/roachtest/tests/multitenant.go
+++ b/pkg/cmd/roachtest/tests/multitenant.go
@@ -38,7 +38,7 @@ func runAcceptanceMultitenant(ctx context.Context, t test.Test, c cluster.Cluste
 	defer cancel()
 	const (
 		tenantHTTPPort = 8081
-		tenantSQLPort  = 36258
+		tenantSQLPort  = 30258
 	)
 	const tenantNode = 1
 	tenant := createTenantNode(tenantCtx, t, c, "./cockroach", kvAddrs,


### PR DESCRIPTION
`acceptance/multitenant` starts a tenant server listening on port 36258.
This port number falls within Linux' default ephemeral port range of
32768-60999 (see `/proc/sys/net/ipv4/ip_local_port_range`) which TCP
clients pick source ports from when establishing outbound connections.
This can cause the server to attempt to bind to a port already being
used for a client connection, preventing server startup and failing the
test (as seen in #68250).

This patch changes the port number to the arbitrarily chosen 30258
outside of the ephemeral port range, thus avoiding these collisions.

Resolves #68250.

Release note: None