### PR TITLE
changefeedccl: Propagate pushback throughout changefeed pipeline.

### DIFF
--- a/pkg/ccl/changefeedccl/bench_test.go
+++ b/pkg/ccl/changefeedccl/bench_test.go
@@ -132,8 +132,13 @@ func makeBenchSink() *benchSink {
 }
 
 func (s *benchSink) EmitRow(
-	ctx context.Context, topicDescr TopicDescriptor, key, value []byte, updated hlc.Timestamp,
+	ctx context.Context,
+	topicDescr TopicDescriptor,
+	key, value []byte,
+	updated hlc.Timestamp,
+	alloc kvevent.Alloc,
 ) error {
+	defer alloc.Release(ctx)
 	return s.emit(int64(len(key) + len(value)))
 }
 func (s *benchSink) EmitResolvedTimestamp(ctx context.Context, e Encoder, ts hlc.Timestamp) error {

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -50,7 +50,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -332,8 +331,7 @@ func changefeedPlanHook(
 		{
 			var nilOracle timestampLowerBoundOracle
 			canarySink, err := getSink(
-				ctx, &p.ExecCfg().DistSQLSrv.ServerConfig, details, nilOracle, p.User(), mon.BoundAccount{},
-				jobspb.InvalidJobID,
+				ctx, &p.ExecCfg().DistSQLSrv.ServerConfig, details, nilOracle, p.User(), jobspb.InvalidJobID,
 			)
 			if err != nil {
 				return changefeedbase.MaybeStripRetryableErrorMarker(err)

--- a/pkg/ccl/changefeedccl/changefeedbase/settings.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/settings.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/errors"
 )
 
 // TableDescriptorPollInterval controls how fast table descriptors are polled. A
@@ -138,4 +139,22 @@ var MinHighWaterMarkCheckpointAdvance = settings.RegisterDurationSetting(
 		"advances, as long as the rate of checkpointing keeps up with the rate of frontier changes",
 	0,
 	settings.NonNegativeDuration,
+)
+
+// EventMemoryMultiplier is the multiplier for the amount of memory needed to process an event.
+//
+// Memory accounting is hard.  Furthermore, during the lifetime of the event, the
+// amount of resources used to process such event varies. So, instead of coming up
+// with complex schemes to accurately measure and adjust current memory usage,
+// we'll request the amount of memory multiplied by this fudge factor.
+var EventMemoryMultiplier = settings.RegisterFloatSetting(
+	"changefeed.event_memory_multiplier",
+	"the amount of memory required to process an event is multiplied by this factor",
+	3,
+	func(v float64) error {
+		if v < 1 {
+			return errors.New("changefeed.event_memory_multiplier must be at least 1")
+		}
+		return nil
+	},
 )

--- a/pkg/ccl/changefeedccl/kvevent/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/kvevent/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "kvevent",
     srcs = [
+        "alloc.go",
         "blocking_buffer.go",
         "chan_buffer.go",
         "err_buffer.go",
@@ -17,13 +18,16 @@ go_library(
         "//pkg/ccl/changefeedccl/changefeedbase",
         "//pkg/jobs/jobspb",
         "//pkg/roachpb:with-mocks",
+        "//pkg/settings",
         "//pkg/util/hlc",
         "//pkg/util/log",
+        "//pkg/util/log/logcrash",
         "//pkg/util/metric",
         "//pkg/util/mon",
         "//pkg/util/quotapool",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
+        "@com_github_cockroachdb_errors//:errors",
     ],
 )
 

--- a/pkg/ccl/changefeedccl/kvevent/alloc.go
+++ b/pkg/ccl/changefeedccl/kvevent/alloc.go
@@ -1,0 +1,57 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package kvevent
+
+import "context"
+
+// Alloc describes the resources allocated on behalf of an event.
+// Allocations should eventually be released.
+// However, it is allowed not to release an allocation due to an error.  In such cases,
+// all active allocations will be released when changefeed shuts down.
+type Alloc struct {
+	bytes   int64 // memory allocated for this request.
+	entries int64 // number of entries using those bytes, usually 1.
+	ap      pool  // pool where those resources ought to be released.
+}
+
+// Release releases resources associated with this allocation.
+func (a Alloc) Release(ctx context.Context) {
+	if a.ap != nil {
+		a.ap.Release(ctx, a.bytes, a.entries)
+	}
+}
+
+// Merge merges other resources into this allocation.
+func (a *Alloc) Merge(other *Alloc) {
+	if a.ap == nil {
+		// Okay to merge into nil allocation -- just use the other.
+		*a = *other
+		return
+	}
+
+	if a.ap != other.ap {
+		panic("cannot merge allocations from two different pools")
+	}
+	a.bytes += other.bytes
+	a.entries += other.entries
+	other.bytes = 0
+	other.entries = 0
+}
+
+// pool is an allocation pool responsible for freeing up previously acquired resources.
+type pool interface {
+	// Release releases resources to this pool.
+	Release(ctx context.Context, bytes, entries int64)
+}
+
+// TestingMakeAlloc creates allocation for the specified number of bytes
+// in a single message using allocation pool 'p'.
+func TestingMakeAlloc(bytes int64, p pool) Alloc {
+	return Alloc{bytes: bytes, entries: 1, ap: p}
+}

--- a/pkg/ccl/changefeedccl/kvevent/blocking_buffer.go
+++ b/pkg/ccl/changefeedccl/kvevent/blocking_buffer.go
@@ -10,25 +10,29 @@ package kvevent
 
 import (
 	"context"
+	"io"
 	"sync"
 	"time"
-	"unsafe"
 
-	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
+	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
 )
 
 // blockingBuffer is an implementation of Buffer which allocates memory
 // from a mon.BoundAccount and blocks if no resources are available.
 type blockingBuffer struct {
-	blockingBufferQuotaPool
-	signalCh chan struct{}
-	mu       struct {
+	sv       *settings.Values
+	metrics  *Metrics
+	qp       allocPool     // Pool for memory allocations.
+	signalCh chan struct{} // Signal when new events are available.
+
+	mu struct {
 		syncutil.Mutex
 		closed bool
 		queue  bufferEntryQueue
@@ -39,50 +43,51 @@ type blockingBuffer struct {
 // It will grow the bound account to buffer more messages but will block if it
 // runs out of space. If ever any entry exceeds the allocatable size of the
 // account, an error will be returned when attempting to buffer it.
-func NewMemBuffer(acc mon.BoundAccount, metrics *Metrics, opts ...quotapool.Option) Buffer {
-	bb := &blockingBuffer{
-		signalCh: make(chan struct{}, 1),
-	}
-	bb.acc = acc
-	bb.metrics = metrics
-
+func NewMemBuffer(
+	acc mon.BoundAccount, sv *settings.Values, metrics *Metrics, opts ...quotapool.Option,
+) Buffer {
 	opts = append(opts,
+		quotapool.OnSlowAcquisition(5*time.Second, quotapool.LogSlowAcquisition),
 		quotapool.OnWaitFinish(
 			func(ctx context.Context, poolName string, r quotapool.Request, start time.Time) {
 				metrics.BufferPushbackNanos.Inc(timeutil.Since(start).Nanoseconds())
 			}))
 
-	bb.qp = quotapool.New("changefeed", &bb.blockingBufferQuotaPool, opts...)
-	return bb
+	return &blockingBuffer{
+		signalCh: make(chan struct{}, 1),
+		metrics:  metrics,
+		sv:       sv,
+		qp: allocPool{
+			AbstractPool: quotapool.New("changefeed", &memQuota{acc: acc}, opts...),
+			metrics:      metrics,
+		},
+	}
 }
 
 var _ Buffer = (*blockingBuffer)(nil)
 
-func (b *blockingBuffer) pop() (e *bufferEntry, closed bool) {
+func (b *blockingBuffer) pop() (e *bufferEntry, err error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if b.mu.closed {
-		return nil, true
+		return nil, io.EOF
 	}
-	return b.mu.queue.dequeue(), false
+	return b.mu.queue.dequeue(), nil
 }
 
 // Get implements kvevent.Reader interface.
 func (b *blockingBuffer) Get(ctx context.Context) (ev Event, err error) {
 	for {
-		got, closed := b.pop()
-		if closed {
-			return Event{}, nil
+		got, err := b.pop()
+		if err != nil {
+			return Event{}, err
 		}
 
 		if got != nil {
+			b.metrics.BufferEntriesOut.Inc(1)
 			e := got.e
 			e.bufferGetTimestamp = timeutil.Now()
-			b.qp.Update(func(r quotapool.Resource) (shouldNotify bool) {
-				res := r.(*blockingBufferQuotaPool)
-				res.release(got)
-				return true
-			})
+			bufferEntryPool.Put(got)
 			return e, nil
 		}
 
@@ -94,55 +99,53 @@ func (b *blockingBuffer) Get(ctx context.Context) (ev Event, err error) {
 	}
 }
 
-// AddKV implements kvevent.Writer interface.
-func (b *blockingBuffer) AddKV(
-	ctx context.Context, kv roachpb.KeyValue, prevVal roachpb.Value, backfillTimestamp hlc.Timestamp,
-) error {
-	size := kv.Size() + prevVal.Size() + backfillTimestamp.Size() + int(unsafe.Sizeof(bufferEntry{}))
-	e := makeKVEvent(kv, prevVal, backfillTimestamp)
-	return b.addEvent(ctx, e, size)
+func (b *blockingBuffer) ensureOpened(ctx context.Context) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.ensureOpenedLocked(ctx)
 }
 
-// AddResolved implements kvevent.Writer interface.
-func (b *blockingBuffer) AddResolved(
-	ctx context.Context,
-	span roachpb.Span,
-	ts hlc.Timestamp,
-	boundaryType jobspb.ResolvedSpan_BoundaryType,
-) error {
-	size := span.Size() + ts.Size() + 4 + int(unsafe.Sizeof(bufferEntry{}))
-	e := makeResolvedEvent(span, ts, boundaryType)
-	return b.addEvent(ctx, e, size)
+func (b *blockingBuffer) ensureOpenedLocked(ctx context.Context) error {
+	if b.mu.closed {
+		logcrash.ReportOrPanic(ctx, b.sv, "buffer unexpectedly closed")
+		return errors.AssertionFailedf("buffer unexpectedly closed")
+	}
+
+	return nil
 }
 
-func (b *blockingBuffer) addEvent(ctx context.Context, e Event, size int) error {
-	be := bufferEntryPool.Get().(*bufferEntry)
-	be.e = e
-	be.alloc = int64(size)
+// Add implements Writer interface.
+func (b *blockingBuffer) Add(ctx context.Context, e Event) error {
+	if e.alloc.ap != nil {
+		return errors.AssertionFailedf("event unexpectedly has a alloc associated with it")
+	}
 
-	// Acquire the quota first.
-	err := b.qp.Acquire(ctx, be)
-	if err != nil {
+	if err := b.ensureOpened(ctx); err != nil {
 		return err
 	}
-	if be.err != nil {
-		return be.err
+
+	// Acquire the quota first.
+	alloc := int64(changefeedbase.EventMemoryMultiplier.Get(b.sv) * float64(e.approxSize))
+	if l := changefeedbase.PerChangefeedMemLimit.Get(b.sv); alloc > l {
+		return errors.Newf("event size %d exceeds per changefeed limit %d", alloc, l)
 	}
 
+	be := newBufferEntry(e, &b.qp, alloc)
+	if err := b.qp.Acquire(ctx, be); err != nil {
+		bufferEntryPool.Put(be)
+		return err
+	}
+	b.metrics.BufferEntriesMemAcquired.Inc(alloc)
+
+	// Enqueue message, and signal if anybody is waiting.
 	b.mu.Lock()
-	closed := b.mu.closed
-	if !closed {
-		b.mu.queue.enqueue(be)
+	defer b.mu.Unlock()
+	if err := b.ensureOpenedLocked(ctx); err != nil {
+		return err
 	}
-	b.mu.Unlock()
+	b.metrics.BufferEntriesIn.Inc(1)
+	b.mu.queue.enqueue(be)
 
-	if closed {
-		b.qp.Update(func(r quotapool.Resource) (shouldNotify bool) {
-			r.(*blockingBufferQuotaPool).release(be)
-			return false
-		})
-		return nil
-	}
 	select {
 	case b.signalCh <- struct{}{}:
 	default:
@@ -150,25 +153,61 @@ func (b *blockingBuffer) addEvent(ctx context.Context, e Event, size int) error 
 	return nil
 }
 
-func (b *blockingBuffer) Close(ctx context.Context) {
+func (b *blockingBuffer) Close(ctx context.Context) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	if !b.mu.closed {
-		b.mu.closed = true
-		b.qp.Close("")
-		for be := b.mu.queue.dequeue(); be != nil; be = b.mu.queue.dequeue() {
-			b.release(be)
-		}
-		b.acc.Close(ctx)
-		close(b.signalCh)
+
+	if b.mu.closed {
+		logcrash.ReportOrPanic(ctx, b.sv, "close called multiple times")
+		return errors.AssertionFailedf("close called multiple times")
 	}
+
+	b.mu.closed = true
+	close(b.signalCh)
+
+	// Close quota pool -- any requests waiting to acquire will receive an error.
+	// It would be nice if we can logcrash if anybody was waiting.
+	b.qp.Close("blocking buffer closing")
+
+	// Release all resources we have queued up.
+	var alloc Alloc
+	for be := b.mu.queue.dequeue(); be != nil; be = b.mu.queue.dequeue() {
+		alloc.Merge(&be.e.alloc)
+	}
+	alloc.Release(ctx)
+
+	// Mark memory quota closed, and close the underlying bound account,
+	// releasing all of its allocated resources at once.
+	//
+	// Note: we might be releasing memory prematurely, and that there could still
+	// be some resources batched up in the sink.  We could try to wait for all
+	// the resources to be releases (e.g. memQuota.alllocated reaching 0); however
+	// it is unlikely to work correctly, and can block Close from ever completing.
+	// That's because the shutdown is often accomplished via context cancellation,
+	// and in those cases we may not even get a notification that a alloc
+	// is no longer in use (e.g. asynchronous kafka flush may not deliver notification at all).
+	// So, instead, we just mark memQuota closed; there is a short period of time
+	// before shutdown completes when we are under counting resources
+	// (if we run out of memory here, it probably means we're way too tight on memory anyway.
+	// After all it is not much different from memory counting against program memory usage
+	// until GC loop runs).
+	b.qp.Update(func(r quotapool.Resource) (shouldNotify bool) {
+		quota := r.(*memQuota)
+		quota.closed = true
+		quota.acc.Close(ctx)
+		return false
+	})
+
+	return nil
 }
 
-type blockingBufferQuotaPool struct {
-	qp      *quotapool.AbstractPool
-	metrics *Metrics
+// memQuota represents memory quota alloc.
+type memQuota struct {
+	// Below fields accessed underneath the quotapool lock.
 
-	// Below fields accessed underneath the quotapool.
+	// closed indicates this memory quota is closed.
+	// Attempts to release against this quota should be ignored.
+	closed bool
 
 	// allocated is the number of bytes currently allocated.
 	allocated int64
@@ -181,27 +220,14 @@ type blockingBufferQuotaPool struct {
 	acc mon.BoundAccount
 }
 
-var _ quotapool.Resource = (*blockingBufferQuotaPool)(nil)
-
-// release releases resources allocated for buffer entry, and puts this entry
-// back into the entry pool.
-func (b *blockingBufferQuotaPool) release(e *bufferEntry) {
-	b.acc.Shrink(context.TODO(), e.alloc)
-	b.allocated -= e.alloc
-	*e = bufferEntry{}
-	bufferEntryPool.Put(e)
-	b.metrics.BufferEntriesOut.Inc(1)
-}
+var _ quotapool.Resource = (*memQuota)(nil)
 
 // bufferEntry forms a linked list of elements in the buffer.
-// It also implements quotapool.Request and is used to acquire quota.
 // These entries are pooled to eliminate allocations.
+// bufferEntry also implements quotapool.Request interface for resource acquisition.
 type bufferEntry struct {
-	e Event
-
-	alloc int64        // bytes allocated from the quotapool
-	err   error        // error populated from under the quotapool
-	next  *bufferEntry // linked-list element
+	e    Event
+	next *bufferEntry // linked-list element
 }
 
 var bufferEntryPool = sync.Pool{
@@ -210,39 +236,55 @@ var bufferEntryPool = sync.Pool{
 	},
 }
 
+func newBufferEntry(e Event, ap *allocPool, alloc int64) *bufferEntry {
+	be := bufferEntryPool.Get().(*bufferEntry)
+	e.alloc = Alloc{
+		bytes:   alloc,
+		entries: 1,
+		ap:      ap,
+	}
+	be.e = e
+	be.next = nil
+	return be
+}
+
 var _ quotapool.Request = (*bufferEntry)(nil)
 
 // Acquire implements quotapool.Request interface.
-func (r *bufferEntry) Acquire(
+func (be *bufferEntry) Acquire(
 	ctx context.Context, resource quotapool.Resource,
 ) (fulfilled bool, tryAgainAfter time.Duration) {
-	res := resource.(*blockingBufferQuotaPool)
-	if res.canAllocateBelow > 0 {
-		if res.allocated > res.canAllocateBelow {
+	quota := resource.(*memQuota)
+	if quota.canAllocateBelow > 0 {
+		if quota.allocated > quota.canAllocateBelow {
 			return false, 0
 		}
-		res.canAllocateBelow = 0
+		quota.canAllocateBelow = 0
 	}
-	if err := res.acc.Grow(ctx, r.alloc); err != nil {
-		if res.allocated == 0 {
-			// We've failed but there's nothing outstanding, that means we're doomed
-			// to fail forever and should propagate the error.
-			r.err = err
-			return true, 0
+
+	if err := quota.acc.Grow(ctx, be.e.alloc.bytes); err != nil {
+		if quota.allocated == 0 {
+			// We've failed but there's nothing outstanding.  It seems that this request
+			// is doomed to fail forever. However, that's not the case since our memory
+			// quota is tied to a larger memory pool.  We failed to allocate memory for this
+			// single request, but we may succeed if we try again later since some other
+			// process may release it into the pool.
+			// TODO(yevgeniy): Consider making retry configurable; possibly with backoff.
+			return true, time.Second
 		}
 
 		// Back off on allocating until we've cleared up half of our usage.
-		res.canAllocateBelow = res.allocated/2 + 1
+		quota.canAllocateBelow = quota.allocated/2 + 1
 		return false, 0
 	}
-	res.metrics.BufferEntriesIn.Inc(1)
-	res.allocated += r.alloc
-	res.canAllocateBelow = 0
+
+	quota.allocated += be.e.alloc.bytes
+	quota.canAllocateBelow = 0
 	return true, 0
 }
 
 // ShouldWait implements quotapool.Request interface.
-func (r *bufferEntry) ShouldWait() bool {
+func (be *bufferEntry) ShouldWait() bool {
 	return true
 }
 
@@ -269,4 +311,23 @@ func (l *bufferEntryQueue) dequeue() *bufferEntry {
 		l.tail = nil
 	}
 	return ret
+}
+
+type allocPool struct {
+	*quotapool.AbstractPool
+	metrics *Metrics
+}
+
+func (ap allocPool) Release(ctx context.Context, bytes, entries int64) {
+	ap.AbstractPool.Update(func(r quotapool.Resource) (shouldNotify bool) {
+		quota := r.(*memQuota)
+		if quota.closed {
+			return false
+		}
+		quota.acc.Shrink(ctx, bytes)
+		quota.allocated -= bytes
+		ap.metrics.BufferEntriesMemReleased.Inc(bytes)
+		ap.metrics.BufferEntriesReleased.Inc(entries)
+		return true
+	})
 }

--- a/pkg/ccl/changefeedccl/kvevent/chan_buffer.go
+++ b/pkg/ccl/changefeedccl/kvevent/chan_buffer.go
@@ -11,9 +11,6 @@ package kvevent
 import (
 	"context"
 
-	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
@@ -32,35 +29,19 @@ func MakeChanBuffer() Buffer {
 	return &chanBuffer{entriesCh: make(chan Event)}
 }
 
-// AddKV inserts a changed KV into the buffer. Individual keys must be added in
-// increasing mvcc order.
-func (b *chanBuffer) AddKV(
-	ctx context.Context, kv roachpb.KeyValue, prevVal roachpb.Value, backfillTimestamp hlc.Timestamp,
-) error {
-	return b.addEvent(ctx, makeKVEvent(kv, prevVal, backfillTimestamp))
-}
-
-// AddResolved inserts a Resolved timestamp notification in the buffer.
-func (b *chanBuffer) AddResolved(
-	ctx context.Context,
-	span roachpb.Span,
-	ts hlc.Timestamp,
-	boundaryType jobspb.ResolvedSpan_BoundaryType,
-) error {
-	return b.addEvent(ctx, makeResolvedEvent(span, ts, boundaryType))
-}
-
-func (b *chanBuffer) Close(_ context.Context) {
-	close(b.entriesCh)
-}
-
-func (b *chanBuffer) addEvent(ctx context.Context, e Event) error {
+// Add implements Writer interface.
+func (b *chanBuffer) Add(ctx context.Context, event Event) error {
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
-	case b.entriesCh <- e:
+	case b.entriesCh <- event:
 		return nil
 	}
+}
+
+func (b *chanBuffer) Close(_ context.Context) error {
+	close(b.entriesCh)
+	return nil
 }
 
 // Get returns an entry from the buffer. They are handed out in an order that

--- a/pkg/ccl/changefeedccl/kvevent/err_buffer.go
+++ b/pkg/ccl/changefeedccl/kvevent/err_buffer.go
@@ -12,9 +12,6 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
-	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )
 
 type errorWrapperEventBuffer struct {
@@ -27,24 +24,9 @@ func NewErrorWrapperEventBuffer(b Buffer) Buffer {
 	return &errorWrapperEventBuffer{b}
 }
 
-// AddKV implements kvevent.Writer interface.
-func (e errorWrapperEventBuffer) AddKV(
-	ctx context.Context, kv roachpb.KeyValue, prevVal roachpb.Value, backfillTimestamp hlc.Timestamp,
-) error {
-	if err := e.Buffer.AddKV(ctx, kv, prevVal, backfillTimestamp); err != nil {
-		return changefeedbase.MarkRetryableError(err)
-	}
-	return nil
-}
-
-// AddResolved implements kvevent.Writer interface.
-func (e errorWrapperEventBuffer) AddResolved(
-	ctx context.Context,
-	span roachpb.Span,
-	ts hlc.Timestamp,
-	boundaryType jobspb.ResolvedSpan_BoundaryType,
-) error {
-	if err := e.Buffer.AddResolved(ctx, span, ts, boundaryType); err != nil {
+// Add implements Writer interface.
+func (e errorWrapperEventBuffer) Add(ctx context.Context, event Event) error {
+	if err := e.Buffer.Add(ctx, event); err != nil {
 		return changefeedbase.MarkRetryableError(err)
 	}
 	return nil

--- a/pkg/ccl/changefeedccl/kvevent/event.go
+++ b/pkg/ccl/changefeedccl/kvevent/event.go
@@ -34,9 +34,10 @@ type Reader interface {
 
 // Writer is the write portion of the Buffer interface.
 type Writer interface {
-	AddKV(ctx context.Context, kv roachpb.KeyValue, prevVal roachpb.Value, backfillTimestamp hlc.Timestamp) error
-	AddResolved(ctx context.Context, span roachpb.Span, ts hlc.Timestamp, boundaryType jobspb.ResolvedSpan_BoundaryType) error
-	Close(ctx context.Context)
+	// Add adds event to this writer.
+	Add(ctx context.Context, event Event) error
+	// Close closes this writer.
+	Close(ctx context.Context) error
 }
 
 // Type indicates the type of the event.
@@ -63,6 +64,8 @@ type Event struct {
 	resolved           *jobspb.ResolvedSpan
 	backfillTimestamp  hlc.Timestamp
 	bufferGetTimestamp time.Time
+	approxSize         int
+	alloc              Alloc
 }
 
 // Type returns the event's Type.
@@ -79,10 +82,7 @@ func (b *Event) Type() Type {
 
 // ApproximateSize returns events approximate size in bytes.
 func (b *Event) ApproximateSize() int {
-	if b.kv.Key != nil {
-		return b.kv.Size() + b.prevVal.Size()
-	}
-	return b.resolved.Size()
+	return b.approxSize
 }
 
 // KV is populated if this event returns true for IsKV().
@@ -152,7 +152,16 @@ func (b *Event) MVCCTimestamp() hlc.Timestamp {
 	}
 }
 
-func makeResolvedEvent(
+// DetachAlloc detaches and returns allocation associated with this event.
+func (b *Event) DetachAlloc() Alloc {
+	a := b.alloc
+	b.alloc.entries = 0
+	b.alloc.bytes = 0
+	return a
+}
+
+// MakeResolvedEvent returns resolved event.
+func MakeResolvedEvent(
 	span roachpb.Span, ts hlc.Timestamp, boundaryType jobspb.ResolvedSpan_BoundaryType,
 ) Event {
 	return Event{
@@ -161,15 +170,18 @@ func makeResolvedEvent(
 			Timestamp:    ts,
 			BoundaryType: boundaryType,
 		},
+		approxSize: span.Size() + ts.Size() + 4,
 	}
 }
 
-func makeKVEvent(
+// MakeKVEvent returns KV event.
+func MakeKVEvent(
 	kv roachpb.KeyValue, prevVal roachpb.Value, backfillTimestamp hlc.Timestamp,
 ) Event {
 	return Event{
 		kv:                kv,
 		prevVal:           prevVal,
 		backfillTimestamp: backfillTimestamp,
+		approxSize:        kv.Size() + prevVal.Size() + backfillTimestamp.Size(),
 	}
 }

--- a/pkg/ccl/changefeedccl/kvevent/metrics.go
+++ b/pkg/ccl/changefeedccl/kvevent/metrics.go
@@ -27,6 +27,24 @@ var (
 		Measurement: "Entries",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaChangefeedBufferEntriesReleased = metric.Metadata{
+		Name:        "changefeed.buffer_entries.released",
+		Help:        "Total entries processed, emitted and acknowledged by the sinks",
+		Measurement: "Entries",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaChangefeedBufferMemAcquired = metric.Metadata{
+		Name:        "changefeed.buffer_entries_mem.acquired",
+		Help:        "Total amount of memory acquired for entries as they enter the system",
+		Measurement: "Entries",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaChangefeedBufferMemReleased = metric.Metadata{
+		Name:        "changefeed.buffer_entries_mem.released",
+		Help:        "Total amount of memory released by the entries after they have been emitted",
+		Measurement: "Entries",
+		Unit:        metric.Unit_COUNT,
+	}
 	metaChangefeedBufferPushbackNanos = metric.Metadata{
 		Name:        "changefeed.buffer_pushback_nanos",
 		Help:        "Total time spent waiting while the buffer was full",
@@ -37,17 +55,23 @@ var (
 
 // Metrics is a metric.Struct for kvfeed metrics.
 type Metrics struct {
-	BufferEntriesIn     *metric.Counter
-	BufferEntriesOut    *metric.Counter
-	BufferPushbackNanos *metric.Counter
+	BufferEntriesIn          *metric.Counter
+	BufferEntriesOut         *metric.Counter
+	BufferEntriesReleased    *metric.Counter
+	BufferPushbackNanos      *metric.Counter
+	BufferEntriesMemAcquired *metric.Counter
+	BufferEntriesMemReleased *metric.Counter
 }
 
 // MakeMetrics constructs a Metrics struct with the provided histogram window.
 func MakeMetrics(histogramWindow time.Duration) Metrics {
 	return Metrics{
-		BufferEntriesIn:     metric.NewCounter(metaChangefeedBufferEntriesIn),
-		BufferEntriesOut:    metric.NewCounter(metaChangefeedBufferEntriesOut),
-		BufferPushbackNanos: metric.NewCounter(metaChangefeedBufferPushbackNanos),
+		BufferEntriesIn:          metric.NewCounter(metaChangefeedBufferEntriesIn),
+		BufferEntriesOut:         metric.NewCounter(metaChangefeedBufferEntriesOut),
+		BufferEntriesReleased:    metric.NewCounter(metaChangefeedBufferEntriesReleased),
+		BufferEntriesMemAcquired: metric.NewCounter(metaChangefeedBufferMemAcquired),
+		BufferEntriesMemReleased: metric.NewCounter(metaChangefeedBufferMemReleased),
+		BufferPushbackNanos:      metric.NewCounter(metaChangefeedBufferPushbackNanos),
 	}
 }
 

--- a/pkg/ccl/changefeedccl/kvevent/throttling_buffer.go
+++ b/pkg/ccl/changefeedccl/kvevent/throttling_buffer.go
@@ -29,10 +29,12 @@ func NewThrottlingBuffer(b Buffer, throttle *cdcutils.Throttler) Buffer {
 func (b *throttlingBuffer) Get(ctx context.Context) (Event, error) {
 	evt, err := b.Buffer.Get(ctx)
 	if err != nil {
-		return Event{}, err
+		return evt, err
 	}
+
 	if err := b.throttle.AcquireMessageQuota(ctx, evt.ApproximateSize()); err != nil {
 		return Event{}, err
 	}
+
 	return evt, nil
 }

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
@@ -86,7 +86,8 @@ func Run(ctx context.Context, cfg Config) error {
 	}
 
 	bf := func() kvevent.Buffer {
-		return kvevent.NewErrorWrapperEventBuffer(kvevent.NewMemBuffer(cfg.MM.MakeBoundAccount(), cfg.Metrics))
+		return kvevent.NewErrorWrapperEventBuffer(
+			kvevent.NewMemBuffer(cfg.MM.MakeBoundAccount(), &cfg.Settings.SV, cfg.Metrics))
 	}
 
 	f := newKVFeed(
@@ -207,7 +208,10 @@ func (f *kvFeed) run(ctx context.Context) (err error) {
 		if f.schemaChangePolicy != changefeedbase.OptSchemaChangePolicyNoBackfill ||
 			boundaryType == jobspb.ResolvedSpan_RESTART {
 			for _, sp := range f.spans {
-				if err := f.sink.AddResolved(ctx, sp, highWater, boundaryType); err != nil {
+				if err := f.sink.Add(
+					ctx,
+					kvevent.MakeResolvedEvent(sp, highWater, boundaryType),
+				); err != nil {
 					return err
 				}
 			}
@@ -326,7 +330,9 @@ func (f *kvFeed) runUntilTableEvent(
 	}
 
 	memBuf := f.bufferFactory()
-	defer memBuf.Close(ctx)
+	defer func() {
+		err = errors.CombineErrors(err, memBuf.Close(ctx))
+	}()
 
 	g := ctxgroup.WithContext(ctx)
 	physicalCfg := physicalConfig{
@@ -434,7 +440,7 @@ func copyFromSourceToSinkUntilTableEvent(
 		addEntry = func(e kvevent.Event) error {
 			switch e.Type() {
 			case kvevent.TypeKV:
-				return sink.AddKV(ctx, e.KV(), e.PrevValue(), e.BackfillTimestamp())
+				return sink.Add(ctx, e)
 			case kvevent.TypeResolved:
 				// TODO(ajwerner): technically this doesn't need to happen for most
 				// events - we just need to make sure we forward for events which are
@@ -444,34 +450,38 @@ func copyFromSourceToSinkUntilTableEvent(
 				if _, err := frontier.Forward(resolved.Span, resolved.Timestamp); err != nil {
 					return err
 				}
-				return sink.AddResolved(ctx, resolved.Span, resolved.Timestamp, jobspb.ResolvedSpan_NONE)
+				return sink.Add(ctx, e)
 			default:
 				log.Fatal(ctx, "unknown event type")
 				return nil
 			}
 		}
+		copyEvent = func(e kvevent.Event) error {
+			if err := checkForScanBoundary(e.Timestamp()); err != nil {
+				return err
+			}
+			skipEntry, scanBoundaryReached, err := applyScanBoundary(e)
+			if err != nil {
+				return err
+			}
+			if scanBoundaryReached {
+				// All component rangefeeds are now at the boundary.
+				// Break out of the ctxgroup by returning the sentinel error.
+				return scanBoundary
+			}
+			if skipEntry {
+				return nil
+			}
+			return addEntry(e)
+		}
 	)
+
 	for {
 		e, err := source.Get(ctx)
 		if err != nil {
 			return err
 		}
-		if err := checkForScanBoundary(e.Timestamp()); err != nil {
-			return err
-		}
-		skipEntry, scanBoundaryReached, err := applyScanBoundary(e)
-		if err != nil {
-			return err
-		}
-		if scanBoundaryReached {
-			// All component rangefeeds are now at the boundary.
-			// Break out of the ctxgroup by returning the sentinel error.
-			return scanBoundary
-		}
-		if skipEntry {
-			continue
-		}
-		if err := addEntry(e); err != nil {
+		if err := copyEvent(e); err != nil {
 			return err
 		}
 	}

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed_test.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed_test.go
@@ -95,6 +95,7 @@ func TestKVFeed(t *testing.T) {
 		expEvents int
 		expErrRE  string
 	}
+	st := cluster.MakeTestingClusterSettings()
 	runTest := func(t *testing.T, tc testCase) {
 		settings := cluster.MakeTestingClusterSettings()
 		buf := kvevent.MakeChanBuffer()
@@ -104,7 +105,7 @@ func TestKVFeed(t *testing.T) {
 		)
 		metrics := kvevent.MakeMetrics(time.Minute)
 		bufferFactory := func() kvevent.Buffer {
-			return kvevent.NewMemBuffer(mm.MakeBoundAccount(), &metrics)
+			return kvevent.NewMemBuffer(mm.MakeBoundAccount(), &st.SV, &metrics)
 		}
 		scans := make(chan physicalConfig)
 		sf := scannerFunc(func(ctx context.Context, sink kvevent.Writer, cfg physicalConfig) error {

--- a/pkg/ccl/changefeedccl/kvfeed/physical_kv_feed.go
+++ b/pkg/ccl/changefeedccl/kvfeed/physical_kv_feed.go
@@ -92,7 +92,10 @@ func (p *rangefeed) addEventsToBuffer(ctx context.Context) error {
 				if p.cfg.WithDiff {
 					prevVal = t.PrevValue
 				}
-				if err := p.memBuf.AddKV(ctx, kv, prevVal, backfillTimestamp); err != nil {
+				if err := p.memBuf.Add(
+					ctx,
+					kvevent.MakeKVEvent(kv, prevVal, backfillTimestamp),
+				); err != nil {
 					return err
 				}
 			case *roachpb.RangeFeedCheckpoint:
@@ -102,7 +105,10 @@ func (p *rangefeed) addEventsToBuffer(ctx context.Context) error {
 					// Changefeeds don't care about these at all, so throw them out.
 					continue
 				}
-				if err := p.memBuf.AddResolved(ctx, t.Span, t.ResolvedTS, jobspb.ResolvedSpan_NONE); err != nil {
+				if err := p.memBuf.Add(
+					ctx,
+					kvevent.MakeResolvedEvent(t.Span, t.ResolvedTS, jobspb.ResolvedSpan_NONE),
+				); err != nil {
 					return err
 				}
 			default:

--- a/pkg/ccl/changefeedccl/kvfeed/scanner.go
+++ b/pkg/ccl/changefeedccl/kvfeed/scanner.go
@@ -136,14 +136,18 @@ func (p *scanRequestScanner) exportSpan(
 		bufferDuration += afterBuffer.Sub(afterScan)
 		if res.ResumeSpan != nil {
 			consumed := roachpb.Span{Key: remaining.Key, EndKey: res.ResumeSpan.Key}
-			if err := sink.AddResolved(ctx, consumed, ts, jobspb.ResolvedSpan_NONE); err != nil {
+			if err := sink.Add(
+				ctx, kvevent.MakeResolvedEvent(consumed, ts, jobspb.ResolvedSpan_NONE),
+			); err != nil {
 				return err
 			}
 		}
 		remaining = res.ResumeSpan
 	}
 	// p.metrics.PollRequestNanosHist.RecordValue(scanDuration.Nanoseconds())
-	if err := sink.AddResolved(ctx, span, ts, jobspb.ResolvedSpan_NONE); err != nil {
+	if err := sink.Add(
+		ctx, kvevent.MakeResolvedEvent(span, ts, jobspb.ResolvedSpan_NONE),
+	); err != nil {
 		return err
 	}
 	if log.V(2) {
@@ -222,7 +226,7 @@ func slurpScanResponse(
 				// change. This is handled in kvsToRows.
 				prevVal = kv.Value
 			}
-			if err = sink.AddKV(ctx, kv, prevVal, ts); err != nil {
+			if err = sink.Add(ctx, kvevent.MakeKVEvent(kv, prevVal, ts)); err != nil {
 				return errors.Wrapf(err, `buffering changes for %s`, span)
 			}
 		}

--- a/pkg/ccl/changefeedccl/metrics.go
+++ b/pkg/ccl/changefeedccl/metrics.go
@@ -36,10 +36,14 @@ func makeMetricsSink(metrics *Metrics, s Sink) *metricsSink {
 
 // EmitRow implements Sink interface.
 func (s *metricsSink) EmitRow(
-	ctx context.Context, topic TopicDescriptor, key, value []byte, updated hlc.Timestamp,
+	ctx context.Context,
+	topic TopicDescriptor,
+	key, value []byte,
+	updated hlc.Timestamp,
+	r kvevent.Alloc,
 ) error {
 	start := timeutil.Now()
-	err := s.wrapped.EmitRow(ctx, topic, key, value, updated)
+	err := s.wrapped.EmitRow(ctx, topic, key, value, updated, r)
 	if err == nil {
 		emitNanos := timeutil.Since(start).Nanoseconds()
 		s.metrics.EmittedMessages.Inc(1)

--- a/pkg/ccl/changefeedccl/sink_sql.go
+++ b/pkg/ccl/changefeedccl/sink_sql.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/kvevent"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
@@ -120,8 +121,14 @@ func (s *sqlSink) Dial() error {
 
 // EmitRow implements the Sink interface.
 func (s *sqlSink) EmitRow(
-	ctx context.Context, topicDescr TopicDescriptor, key, value []byte, updated hlc.Timestamp,
+	ctx context.Context,
+	topicDescr TopicDescriptor,
+	key, value []byte,
+	updated hlc.Timestamp,
+	alloc kvevent.Alloc,
 ) error {
+	defer alloc.Release(ctx)
+
 	topic := s.targetNames[topicDescr.GetID()]
 	if _, ok := s.topics[topic]; !ok {
 		return errors.Errorf(`cannot emit to undeclared topic: %s`, topic)

--- a/pkg/ccl/changefeedccl/sink_test.go
+++ b/pkg/ccl/changefeedccl/sink_test.go
@@ -10,7 +10,6 @@ package changefeedccl
 
 import (
 	"context"
-	"math"
 	"net/url"
 	"strconv"
 	"sync"
@@ -19,11 +18,10 @@ import (
 
 	"github.com/Shopify/sarama"
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdctest"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/kvevent"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/security"
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -32,7 +30,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
@@ -152,29 +149,46 @@ func topic(name string) tableDescriptorTopic {
 	return tableDescriptorTopic{tabledesc.NewBuilder(&descpb.TableDescriptor{Name: name}).BuildImmutableTable()}
 }
 
-const memoryUnlimited int64 = math.MaxInt64
 const noTopicPrefix = ""
 const defaultTopicName = ""
 
-func getBoundAccountWithBudget(budget int64) (account mon.BoundAccount, cleanup func()) {
-	mm := mon.NewMonitorWithLimit(
-		"test-mm", mon.MemoryResource, budget,
-		nil, nil, mon.DefaultPoolAllocationSize, 100,
-		cluster.MakeTestingClusterSettings())
-	mm.Start(context.Background(), nil, mon.MakeStandaloneBudget(budget))
-	return mm.MakeBoundAccount(), func() { mm.Stop(context.Background()) }
+type testAllocPool struct {
+	syncutil.Mutex
+	n int64
 }
+
+// Release implements kvevent.pool interface.
+func (ap *testAllocPool) Release(ctx context.Context, bytes, entries int64) {
+	ap.Lock()
+	defer ap.Unlock()
+	if ap.n == 0 {
+		panic("can't release zero resources")
+	}
+	ap.n -= bytes
+}
+
+func (ap *testAllocPool) alloc() kvevent.Alloc {
+	ap.Lock()
+	defer ap.Unlock()
+	ap.n++
+	return kvevent.TestingMakeAlloc(1, ap)
+}
+
+func (ap *testAllocPool) used() int64 {
+	ap.Lock()
+	defer ap.Unlock()
+	return ap.n
+}
+
+var zeroAlloc kvevent.Alloc
 
 func makeTestKafkaSink(
 	t testing.TB,
 	topicPrefix string,
 	topicNameOverride string,
 	p sarama.AsyncProducer,
-	budget int64,
 	targetNames ...string,
 ) (s *kafkaSink, cleanup func()) {
-	mem, release := getBoundAccountWithBudget(budget)
-
 	targets := makeChangefeedTargets(targetNames...)
 
 	s = &kafkaSink{
@@ -182,12 +196,10 @@ func makeTestKafkaSink(
 		topics:   makeTopicsMap(topicPrefix, topicNameOverride, targets),
 		producer: p,
 	}
-	s.mu.mem = mem
 	s.start()
 
 	return s, func() {
 		require.NoError(t, s.Close())
-		release()
 	}
 }
 
@@ -206,7 +218,7 @@ func TestKafkaSink(t *testing.T) {
 	ctx := context.Background()
 	p := newAsyncProducerMock(1)
 	sink, cleanup := makeTestKafkaSink(
-		t, noTopicPrefix, defaultTopicName, p, memoryUnlimited, "t")
+		t, noTopicPrefix, defaultTopicName, p, "t")
 	defer cleanup()
 
 	// No inflight
@@ -215,7 +227,7 @@ func TestKafkaSink(t *testing.T) {
 	}
 
 	// Timeout
-	if err := sink.EmitRow(ctx, topic(`t`), []byte(`1`), nil, zeroTS); err != nil {
+	if err := sink.EmitRow(ctx, topic(`t`), []byte(`1`), nil, zeroTS, zeroAlloc); err != nil {
 		t.Fatal(err)
 	}
 	m1 := <-p.inputCh
@@ -239,15 +251,16 @@ func TestKafkaSink(t *testing.T) {
 	}
 
 	// Mixed success and error.
-	if err := sink.EmitRow(ctx, topic(`t`), []byte(`2`), nil, zeroTS); err != nil {
+	var pool testAllocPool
+	if err := sink.EmitRow(ctx, topic(`t`), []byte(`2`), nil, zeroTS, pool.alloc()); err != nil {
 		t.Fatal(err)
 	}
 	m2 := <-p.inputCh
-	if err := sink.EmitRow(ctx, topic(`t`), []byte(`3`), nil, zeroTS); err != nil {
+	if err := sink.EmitRow(ctx, topic(`t`), []byte(`3`), nil, zeroTS, pool.alloc()); err != nil {
 		t.Fatal(err)
 	}
 	m3 := <-p.inputCh
-	if err := sink.EmitRow(ctx, topic(`t`), []byte(`4`), nil, zeroTS); err != nil {
+	if err := sink.EmitRow(ctx, topic(`t`), []byte(`4`), nil, zeroTS, pool.alloc()); err != nil {
 		t.Fatal(err)
 	}
 	m4 := <-p.inputCh
@@ -264,7 +277,7 @@ func TestKafkaSink(t *testing.T) {
 	}
 
 	// Check simple success again after error
-	if err := sink.EmitRow(ctx, topic(`t`), []byte(`5`), nil, zeroTS); err != nil {
+	if err := sink.EmitRow(ctx, topic(`t`), []byte(`5`), nil, zeroTS, pool.alloc()); err != nil {
 		t.Fatal(err)
 	}
 	m5 := <-p.inputCh
@@ -272,6 +285,8 @@ func TestKafkaSink(t *testing.T) {
 	if err := sink.Flush(ctx); err != nil {
 		t.Fatal(err)
 	}
+	// At the end, all of the resources has been released
+	require.EqualValues(t, 0, pool.used())
 }
 
 func TestKafkaSinkEscaping(t *testing.T) {
@@ -280,11 +295,10 @@ func TestKafkaSinkEscaping(t *testing.T) {
 
 	ctx := context.Background()
 	p := newAsyncProducerMock(1)
-	sink, cleanup := makeTestKafkaSink(
-		t, noTopicPrefix, defaultTopicName, p, memoryUnlimited, `☃`)
+	sink, cleanup := makeTestKafkaSink(t, noTopicPrefix, defaultTopicName, p, `☃`)
 	defer cleanup()
 
-	if err := sink.EmitRow(ctx, topic(`☃`), []byte(`k☃`), []byte(`v☃`), zeroTS); err != nil {
+	if err := sink.EmitRow(ctx, topic(`☃`), []byte(`k☃`), []byte(`v☃`), zeroTS, zeroAlloc); err != nil {
 		t.Fatal(err)
 	}
 	m := <-p.inputCh
@@ -301,11 +315,11 @@ func TestKafkaTopicNameProvided(t *testing.T) {
 	const topicOverride = "general"
 	p := newAsyncProducerMock(1)
 	sink, cleanup := makeTestKafkaSink(
-		t, noTopicPrefix, topicOverride, p, memoryUnlimited, "particular0", "particular1")
+		t, noTopicPrefix, topicOverride, p, "particular0", "particular1")
 	defer cleanup()
 
 	//all messages go to the general topic
-	require.NoError(t, sink.EmitRow(ctx, topic("particular0"), []byte(`k☃`), []byte(`v☃`), zeroTS))
+	require.NoError(t, sink.EmitRow(ctx, topic("particular0"), []byte(`k☃`), []byte(`v☃`), zeroTS, zeroAlloc))
 	m := <-p.inputCh
 	require.Equal(t, topicOverride, m.Topic)
 }
@@ -319,11 +333,11 @@ func TestKafkaTopicNameWithPrefix(t *testing.T) {
 	const topicPrefix = "prefix-"
 	const topicOverride = "☃"
 	sink, clenaup := makeTestKafkaSink(
-		t, topicPrefix, topicOverride, p, memoryUnlimited, "particular0", "particular1")
+		t, topicPrefix, topicOverride, p, "particular0", "particular1")
 	defer clenaup()
 
 	//the prefix is applied and the name is escaped
-	require.NoError(t, sink.EmitRow(ctx, topic("particular0"), []byte(`k☃`), []byte(`v☃`), zeroTS))
+	require.NoError(t, sink.EmitRow(ctx, topic("particular0"), []byte(`k☃`), []byte(`v☃`), zeroTS, zeroAlloc))
 	m := <-p.inputCh
 	require.Equal(t, `prefix-_u2603_`, m.Topic)
 }
@@ -341,7 +355,7 @@ func BenchmarkEmitRow(b *testing.B) {
 	p := newAsyncProducerMock(unbuffered)
 	const tableName = `defaultdb.public.funky_table☃`
 	topic := topic(tableName)
-	sink, cleanup := makeTestKafkaSink(b, noTopicPrefix, defaultTopicName, p, memoryUnlimited, tableName)
+	sink, cleanup := makeTestKafkaSink(b, noTopicPrefix, defaultTopicName, p, tableName)
 	stopConsume := p.consumeAndSucceed()
 	defer func() {
 		stopConsume()
@@ -350,7 +364,7 @@ func BenchmarkEmitRow(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		require.NoError(b, sink.EmitRow(ctx, topic, []byte(`k☃`), []byte(`v☃`), hlc.Timestamp{}))
+		require.NoError(b, sink.EmitRow(ctx, topic, []byte(`k☃`), []byte(`v☃`), hlc.Timestamp{}, zeroAlloc))
 	}
 
 	b.ReportAllocs()
@@ -403,10 +417,11 @@ func TestSQLSink(t *testing.T) {
 
 	// Undeclared topic
 	require.EqualError(t,
-		sink.EmitRow(ctx, overrideTopic(`nope`), nil, nil, zeroTS), `cannot emit to undeclared topic: `)
+		sink.EmitRow(ctx, overrideTopic(`nope`), nil, nil, zeroTS, zeroAlloc),
+		`cannot emit to undeclared topic: `)
 
 	// With one row, nothing flushes until Flush is called.
-	require.NoError(t, sink.EmitRow(ctx, fooTopic, []byte(`k1`), []byte(`v0`), zeroTS))
+	require.NoError(t, sink.EmitRow(ctx, fooTopic, []byte(`k1`), []byte(`v0`), zeroTS, zeroAlloc))
 	sqlDB.CheckQueryResults(t, `SELECT key, value FROM sink ORDER BY PRIMARY KEY sink`,
 		[][]string{},
 	)
@@ -420,7 +435,7 @@ func TestSQLSink(t *testing.T) {
 	sqlDB.CheckQueryResults(t, `SELECT count(*) FROM sink`, [][]string{{`0`}})
 	for i := 0; i < sqlSinkRowBatchSize+1; i++ {
 		require.NoError(t,
-			sink.EmitRow(ctx, fooTopic, []byte(`k1`), []byte(`v`+strconv.Itoa(i)), zeroTS))
+			sink.EmitRow(ctx, fooTopic, []byte(`k1`), []byte(`v`+strconv.Itoa(i)), zeroTS, zeroAlloc))
 	}
 	// Should have auto flushed after sqlSinkRowBatchSize
 	sqlDB.CheckQueryResults(t, `SELECT count(*) FROM sink`, [][]string{{`3`}})
@@ -429,10 +444,12 @@ func TestSQLSink(t *testing.T) {
 	sqlDB.Exec(t, `TRUNCATE sink`)
 
 	// Two tables interleaved in time
-	require.NoError(t, sink.EmitRow(ctx, fooTopic, []byte(`kfoo`), []byte(`v0`), zeroTS))
-	require.NoError(t, sink.EmitRow(ctx, barTopic, []byte(`kbar`), []byte(`v0`), zeroTS))
-	require.NoError(t, sink.EmitRow(ctx, fooTopic, []byte(`kfoo`), []byte(`v1`), zeroTS))
+	var pool testAllocPool
+	require.NoError(t, sink.EmitRow(ctx, fooTopic, []byte(`kfoo`), []byte(`v0`), zeroTS, pool.alloc()))
+	require.NoError(t, sink.EmitRow(ctx, barTopic, []byte(`kbar`), []byte(`v0`), zeroTS, pool.alloc()))
+	require.NoError(t, sink.EmitRow(ctx, fooTopic, []byte(`kfoo`), []byte(`v1`), zeroTS, pool.alloc()))
 	require.NoError(t, sink.Flush(ctx))
+	require.EqualValues(t, 0, pool.used())
 	sqlDB.CheckQueryResults(t, `SELECT topic, key, value FROM sink ORDER BY PRIMARY KEY sink`,
 		[][]string{{`bar`, `kbar`, `v0`}, {`foo`, `kfoo`, `v0`}, {`foo`, `kfoo`, `v1`}},
 	)
@@ -442,11 +459,11 @@ func TestSQLSink(t *testing.T) {
 	// guarantee that at lease two of them end up in the same partition.
 	for i := 0; i < sqlSinkNumPartitions+1; i++ {
 		require.NoError(t,
-			sink.EmitRow(ctx, fooTopic, []byte(`v`+strconv.Itoa(i)), []byte(`v0`), zeroTS))
+			sink.EmitRow(ctx, fooTopic, []byte(`v`+strconv.Itoa(i)), []byte(`v0`), zeroTS, zeroAlloc))
 	}
 	for i := 0; i < sqlSinkNumPartitions+1; i++ {
 		require.NoError(t,
-			sink.EmitRow(ctx, fooTopic, []byte(`v`+strconv.Itoa(i)), []byte(`v1`), zeroTS))
+			sink.EmitRow(ctx, fooTopic, []byte(`v`+strconv.Itoa(i)), []byte(`v1`), zeroTS, zeroAlloc))
 	}
 	require.NoError(t, sink.Flush(ctx))
 	sqlDB.CheckQueryResults(t, `SELECT partition, key, value FROM sink ORDER BY PRIMARY KEY sink`,
@@ -466,7 +483,7 @@ func TestSQLSink(t *testing.T) {
 	// Emit resolved
 	var e testEncoder
 	require.NoError(t, sink.EmitResolvedTimestamp(ctx, e, zeroTS))
-	require.NoError(t, sink.EmitRow(ctx, fooTopic, []byte(`foo0`), []byte(`v0`), zeroTS))
+	require.NoError(t, sink.EmitRow(ctx, fooTopic, []byte(`foo0`), []byte(`v0`), zeroTS, zeroAlloc))
 	require.NoError(t, sink.EmitResolvedTimestamp(ctx, e, hlc.Timestamp{WallTime: 1}))
 	require.NoError(t, sink.Flush(ctx))
 	sqlDB.CheckQueryResults(t,
@@ -617,7 +634,6 @@ func TestKafkaSinkTracksMemory(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	memCapacity := mon.DefaultPoolAllocationSize
 
 	// Use fake kafka sink which "consumes" all messages on its input channel,
 	// but does not acknowledge them automatically (i.e. slow sink)
@@ -625,7 +641,7 @@ func TestKafkaSinkTracksMemory(t *testing.T) {
 	stopConsume := p.consume()
 
 	sink, cleanup := makeTestKafkaSink(
-		t, noTopicPrefix, defaultTopicName, p, memCapacity, "t")
+		t, noTopicPrefix, defaultTopicName, p, "t")
 	defer func() {
 		stopConsume()
 		cleanup()
@@ -638,57 +654,17 @@ func TestKafkaSinkTracksMemory(t *testing.T) {
 	rnd, _ := randutil.NewTestPseudoRand()
 	key := randutil.RandBytes(rnd, 1+rnd.Intn(64))
 	val := randutil.RandBytes(rnd, 1+rnd.Intn(512))
-	kvLen := int64(len(key)) + int64(len(val))
 
 	testTopic := topic(`t`)
+	var pool testAllocPool
 	for i := 0; i < 10; i++ {
-		require.NoError(t, sink.EmitRow(ctx, testTopic, key, val, zeroTS))
+		require.NoError(t, sink.EmitRow(ctx, testTopic, key, val, zeroTS, pool.alloc()))
 	}
-
-	memUsed := func() int64 {
-		sink.mu.Lock()
-		defer sink.mu.Unlock()
-		return sink.mu.mem.Used()
-	}
-	require.Equal(t, 10*kvLen, memUsed())
+	require.EqualValues(t, 10, pool.used())
 
 	// Acknowledge outstanding messages, and flush.
 	p.acknowledge(10, p.successesCh)
 	require.NoError(t, sink.Flush(ctx))
 	require.EqualValues(t, 0, p.outstanding())
-
-	// Try emitting resolved timestamp.  This message type is different from the
-	// regular messages since it doesn't have Key set.
-	// We bypass majority of EmitResolvedTimestamp logic since we don't have
-	// a real kafka client instantiated.  Instead, we call emitMessage directly.
-	reg := cdctest.StartTestSchemaRegistry()
-	defer reg.Close()
-	opts := map[string]string{
-		changefeedbase.OptEnvelope:                string(changefeedbase.OptEnvelopeWrapped),
-		changefeedbase.OptConfluentSchemaRegistry: reg.URL(),
-	}
-	encoder, err := newConfluentAvroEncoder(ctx, opts, makeChangefeedTargets("t"))
-	require.NoError(t, err)
-	payload, err := encoder.EncodeResolvedTimestamp(ctx, "t", hlc.Timestamp{})
-	require.NoError(t, err)
-	msg := &sarama.ProducerMessage{
-		Topic: "t",
-		Key:   nil,
-		Value: sarama.ByteEncoder(payload),
-	}
-	require.NoError(t, sink.emitMessage(ctx, msg))
-	p.acknowledge(1, p.successesCh)
-	require.NoError(t, sink.Flush(ctx))
-	require.EqualValues(t, 0, p.outstanding())
-
-	// Try to emit more than we can handle.
-	expectOverflow := memCapacity / kvLen
-	for err == nil {
-		err = sink.EmitRow(ctx, testTopic, key, val, zeroTS)
-	}
-
-	require.Regexp(t, `memory budget exceeded`, err)
-	// We failed to allocate more memory, but we should have used
-	// memory for the expectOverflow key/values.
-	require.EqualValues(t, expectOverflow*kvLen, memUsed())
+	require.EqualValues(t, 0, pool.used())
 }


### PR DESCRIPTION
Propagate pushback information throughout changefeed pipeline.

The pushback propagation is accomplished by associating a `Resource`
with each event that is processed by changefeed system.  The resource is
propagated throughout changefeed, and is released when the event
has been written to the sink.

This change also updates and simplifies event memory accounting.
Prior to this PR, memory accounting was incomplete and was error prone.
This PR simplifies memory accounting by allocating resources once when
the event arrives (blocking buffer), and releasing resources
when event is written to the sink.  Dynamic modifications to the amount
of allocated memory are, in general, not safe (without additional
complexity).  To accommodate the fact that during event processing we
use more memory (e.g. to parse and convert this event), we over-allocate
resources to the the event.

Release Notes: Enterprise change; changefeed will slow down correctly
whenever there is a slow down in the system (i.e. downstream sink is
slow).