### PR TITLE
sql: add cluster setting to preserve subquery and cte ordering

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -432,6 +432,12 @@ var copyPartitioningWhenDeinterleavingTable = settings.RegisterBoolSetting(
 	false,
 ).WithPublic()
 
+var propagateInputOrdering = settings.RegisterBoolSetting(
+	`sql.defaults.propagate_input_ordering.enabled`,
+	`default value for the experimental propagate_input_ordering session variable`,
+	false,
+)
+
 // settingWorkMemBytes is a cluster setting that determines the maximum amount
 // of RAM that a processor can use.
 var settingWorkMemBytes = settings.RegisterByteSizeSetting(
@@ -2635,6 +2641,10 @@ func (m *sessionDataMutator) SetCopyPartitioningWhenDeinterleavingTable(b bool) 
 
 func (m *sessionDataMutator) SetExperimentalComputedColumnRewrites(val string) {
 	m.data.ExperimentalComputedColumnRewrites = val
+}
+
+func (m *sessionDataMutator) SetPropagateInputOrdering(b bool) {
+	m.data.PropagateInputOrdering = b
 }
 
 // Utility functions related to scrubbing sensitive information on SQL Stats.

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4561,6 +4561,7 @@ optimizer_use_histograms                               on
 optimizer_use_multicol_stats                           on
 override_multi_region_zone_config                      off
 prefer_lookup_joins_for_fks                            off
+propagate_input_ordering                               off
 reorder_joins_limit                                    8
 require_explicit_primary_keys                          off
 results_buffer_size                                    16384

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3880,6 +3880,7 @@ optimizer_use_histograms                               on                  NULL 
 optimizer_use_multicol_stats                           on                  NULL      NULL        NULL        string
 override_multi_region_zone_config                      off                 NULL      NULL        NULL        string
 prefer_lookup_joins_for_fks                            off                 NULL      NULL        NULL        string
+propagate_input_ordering                               off                 NULL      NULL        NULL        string
 reorder_joins_limit                                    8                   NULL      NULL        NULL        string
 require_explicit_primary_keys                          off                 NULL      NULL        NULL        string
 results_buffer_size                                    16384               NULL      NULL        NULL        string
@@ -3965,6 +3966,7 @@ optimizer_use_histograms                               on                  NULL 
 optimizer_use_multicol_stats                           on                  NULL  user     NULL      on                  on
 override_multi_region_zone_config                      off                 NULL  user     NULL      off                 off
 prefer_lookup_joins_for_fks                            off                 NULL  user     NULL      off                 off
+propagate_input_ordering                               off                 NULL  user     NULL      off                 off
 reorder_joins_limit                                    8                   NULL  user     NULL      8                   8
 require_explicit_primary_keys                          off                 NULL  user     NULL      off                 off
 results_buffer_size                                    16384               NULL  user     NULL      16384               16384
@@ -4047,6 +4049,7 @@ optimizer_use_histograms                               NULL    NULL     NULL    
 optimizer_use_multicol_stats                           NULL    NULL     NULL     NULL        NULL
 override_multi_region_zone_config                      NULL    NULL     NULL     NULL        NULL
 prefer_lookup_joins_for_fks                            NULL    NULL     NULL     NULL        NULL
+propagate_input_ordering                               NULL    NULL     NULL     NULL        NULL
 reorder_joins_limit                                    NULL    NULL     NULL     NULL        NULL
 require_explicit_primary_keys                          NULL    NULL     NULL     NULL        NULL
 results_buffer_size                                    NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/preserve_input_order
+++ b/pkg/sql/logictest/testdata/logic_test/preserve_input_order
@@ -1,0 +1,137 @@
+statement ok
+SET propagate_input_ordering=true;
+
+query I
+WITH tmp AS (SELECT * FROM generate_series(1, 10) i ORDER BY i % 5 ASC, i ASC) SELECT * FROM tmp;
+----
+5
+10
+1
+6
+2
+7
+3
+8
+4
+9
+
+query I
+WITH tmp AS (SELECT * FROM generate_series(1, 10) i ORDER BY i % 5 ASC, i ASC) SELECT * FROM tmp;
+----
+5
+10
+1
+6
+2
+7
+3
+8
+4
+9
+
+# The internal ordering column for i%5 should not be present in the output.
+query T
+SELECT foo FROM (SELECT i, i%2 FROM generate_series(1, 10) i ORDER BY i % 5 ASC, i ASC) AS foo
+----
+(5,1)
+(10,0)
+(1,1)
+(6,0)
+(2,0)
+(7,1)
+(3,1)
+(8,0)
+(4,0)
+(9,1)
+
+# The internal ordering column for i%5 should not be present in the output.
+query II
+SELECT foo.* FROM (SELECT i, i%2 FROM generate_series(1, 10) i ORDER BY i % 5 ASC, i ASC) AS foo
+----
+5   1
+10  0
+1   1
+6   0
+2   0
+7   1
+3   1
+8   0
+4   0
+9   1
+
+# The subquery ordering is propagated to the aggregation.
+query T
+SELECT array_agg(i) FROM (SELECT * FROM generate_series(1, 5) i ORDER BY i%2 DESC, i)
+----
+{1,3,5,2,4}
+
+# The input ordering is not propagated through joins.
+query II
+WITH tmp AS (SELECT * FROM generate_series(1, 2) x),
+     tmp2 AS (SELECT * FROM generate_series(8, 12) i ORDER BY i % 5 ASC, i ASC)
+SELECT * FROM tmp, tmp2;
+----
+1  8
+1  9
+1  10
+1  11
+1  12
+2  8
+2  9
+2  10
+2  11
+2  12
+
+# The input ordering is not propagated through joins.
+query II
+SELECT *
+FROM (SELECT * FROM generate_series(1, 2) x) tmp,
+     (SELECT * FROM generate_series(8, 12) i ORDER BY i % 5 ASC, i ASC) tmp2;
+----
+1  8
+1  9
+1  10
+1  11
+1  12
+2  8
+2  9
+2  10
+2  11
+2  12
+
+# Do not preserve the subquery ordering because the parent scope has its own
+# ordering.
+query I
+WITH tmp AS (SELECT * FROM generate_series(1, 10) i ORDER BY i % 5 ASC, i ASC)
+SELECT * FROM tmp ORDER BY i DESC;
+----
+10
+9
+8
+7
+6
+5
+4
+3
+2
+1
+
+# Do not preserve the subquery ordering because the parent scope has its own
+# ordering.
+query I
+WITH tmp AS (SELECT * FROM generate_series(1, 10) i ORDER BY i % 5 ASC, i ASC)
+SELECT * FROM tmp ORDER BY i DESC;
+----
+10
+9
+8
+7
+6
+5
+4
+3
+2
+1
+
+statement ok
+RESET propagate_input_ordering;

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -77,6 +77,7 @@ optimizer_use_histograms                               on
 optimizer_use_multicol_stats                           on
 override_multi_region_zone_config                      off
 prefer_lookup_joins_for_fks                            off
+propagate_input_ordering                               off
 reorder_joins_limit                                    8
 require_explicit_primary_keys                          off
 results_buffer_size                                    16384

--- a/pkg/sql/opt/optbuilder/project.go
+++ b/pkg/sql/opt/optbuilder/project.go
@@ -24,6 +24,11 @@ import (
 // different set of columns than its input. Either way, it updates
 // projectionsScope.group with the output memo group ID.
 func (b *Builder) constructProjectForScope(inScope, projectionsScope *scope) {
+	if b.evalCtx.SessionData.PropagateInputOrdering && len(projectionsScope.ordering) == 0 {
+		// Preserve the input ordering.
+		projectionsScope.copyOrdering(inScope)
+	}
+
 	// Don't add an unnecessary "pass through" project.
 	if projectionsScope.hasSameColumns(inScope) {
 		projectionsScope.expr = inScope.expr

--- a/pkg/sql/opt/optbuilder/testdata/preserve_input_order
+++ b/pkg/sql/opt/optbuilder/testdata/preserve_input_order
@@ -1,0 +1,241 @@
+# tests adapted from logictest -- preserve_input_order
+
+build preserve-input-order
+WITH tmp AS (SELECT * FROM generate_series(1, 10) i ORDER BY i % 5 ASC, i ASC) SELECT * FROM tmp;
+----
+sort
+ ├── columns: i:3  [hidden: order_column2:4]
+ ├── ordering: +4,+3
+ └── with &1 (tmp)
+      ├── columns: i:3 order_column2:4
+      ├── project
+      │    ├── columns: column2:2 generate_series:1
+      │    ├── project-set
+      │    │    ├── columns: generate_series:1
+      │    │    ├── values
+      │    │    │    └── ()
+      │    │    └── zip
+      │    │         └── generate_series(1, 10)
+      │    └── projections
+      │         └── generate_series:1 % 5 [as=column2:2]
+      └── with-scan &1 (tmp)
+           ├── columns: i:3 order_column2:4
+           └── mapping:
+                ├──  generate_series:1 => i:3
+                └──  column2:2 => order_column2:4
+
+build preserve-input-order
+WITH tmp AS (SELECT * FROM generate_series(1, 10) i ORDER BY i % 5 ASC, i ASC) SELECT * FROM tmp;
+----
+sort
+ ├── columns: i:3  [hidden: order_column2:4]
+ ├── ordering: +4,+3
+ └── with &1 (tmp)
+      ├── columns: i:3 order_column2:4
+      ├── project
+      │    ├── columns: column2:2 generate_series:1
+      │    ├── project-set
+      │    │    ├── columns: generate_series:1
+      │    │    ├── values
+      │    │    │    └── ()
+      │    │    └── zip
+      │    │         └── generate_series(1, 10)
+      │    └── projections
+      │         └── generate_series:1 % 5 [as=column2:2]
+      └── with-scan &1 (tmp)
+           ├── columns: i:3 order_column2:4
+           └── mapping:
+                ├──  generate_series:1 => i:3
+                └──  column2:2 => order_column2:4
+
+# The internal ordering column for i%5 should not be present in the output.
+build preserve-input-order
+SELECT foo FROM (SELECT i, i%2 FROM generate_series(1, 10) i ORDER BY i % 5 ASC, i ASC) AS foo
+----
+sort
+ ├── columns: foo:4  [hidden: generate_series:1 column3:3]
+ ├── ordering: +3,+1
+ └── project
+      ├── columns: foo:4 generate_series:1 column3:3
+      ├── project
+      │    ├── columns: "?column?":2 column3:3 generate_series:1
+      │    ├── project-set
+      │    │    ├── columns: generate_series:1
+      │    │    ├── values
+      │    │    │    └── ()
+      │    │    └── zip
+      │    │         └── generate_series(1, 10)
+      │    └── projections
+      │         ├── generate_series:1 % 2 [as="?column?":2]
+      │         └── generate_series:1 % 5 [as=column3:3]
+      └── projections
+           └── ((generate_series:1, "?column?":2) AS i, "?column?") [as=foo:4]
+
+# The internal ordering column for i%5 should not be present in the output.
+build preserve-input-order
+SELECT foo.* FROM (SELECT i, i%2 FROM generate_series(1, 10) i ORDER BY i % 5 ASC, i ASC) AS foo
+----
+sort
+ ├── columns: i:1 "?column?":2  [hidden: column3:3]
+ ├── ordering: +3,+1
+ └── project
+      ├── columns: "?column?":2 column3:3 generate_series:1
+      ├── project-set
+      │    ├── columns: generate_series:1
+      │    ├── values
+      │    │    └── ()
+      │    └── zip
+      │         └── generate_series(1, 10)
+      └── projections
+           ├── generate_series:1 % 2 [as="?column?":2]
+           └── generate_series:1 % 5 [as=column3:3]
+
+# The subquery ordering is propagated to the aggregation.
+build preserve-input-order
+SELECT array_agg(i) FROM (SELECT * FROM generate_series(1, 5) i ORDER BY i%2 DESC, i)
+----
+scalar-group-by
+ ├── columns: array_agg:3
+ ├── internal-ordering: -2,+1
+ ├── sort
+ │    ├── columns: generate_series:1 column2:2
+ │    ├── ordering: -2,+1
+ │    └── project
+ │         ├── columns: column2:2 generate_series:1
+ │         ├── project-set
+ │         │    ├── columns: generate_series:1
+ │         │    ├── values
+ │         │    │    └── ()
+ │         │    └── zip
+ │         │         └── generate_series(1, 5)
+ │         └── projections
+ │              └── generate_series:1 % 2 [as=column2:2]
+ └── aggregations
+      └── array-agg [as=array_agg:3]
+           └── generate_series:1
+
+# The input ordering is not propagated through joins.
+build preserve-input-order
+WITH tmp AS (SELECT * FROM generate_series(1, 2) x),
+     tmp2 AS (SELECT * FROM generate_series(8, 12) i ORDER BY i % 5 ASC, i ASC)
+SELECT * FROM tmp INNER JOIN tmp2 ON True;
+----
+with &1 (tmp)
+ ├── columns: x:4 i:7  [hidden: order_column3:5 order_generate_series:6 order_column3:8]
+ ├── project-set
+ │    ├── columns: generate_series:1
+ │    ├── values
+ │    │    └── ()
+ │    └── zip
+ │         └── generate_series(1, 2)
+ └── with &2 (tmp2)
+      ├── columns: x:4 order_column3:5 order_generate_series:6 i:7 order_column3:8
+      ├── project
+      │    ├── columns: column3:3 generate_series:2
+      │    ├── project-set
+      │    │    ├── columns: generate_series:2
+      │    │    ├── values
+      │    │    │    └── ()
+      │    │    └── zip
+      │    │         └── generate_series(8, 12)
+      │    └── projections
+      │         └── generate_series:2 % 5 [as=column3:3]
+      └── inner-join (cross)
+           ├── columns: x:4 order_column3:5 order_generate_series:6 i:7 order_column3:8
+           ├── with-scan &1 (tmp)
+           │    ├── columns: x:4 order_column3:5 order_generate_series:6
+           │    └── mapping:
+           │         ├──  generate_series:1 => x:4
+           │         ├──  column3:3 => order_column3:5
+           │         └──  generate_series:2 => order_generate_series:6
+           ├── with-scan &2 (tmp2)
+           │    ├── columns: i:7 order_column3:8
+           │    └── mapping:
+           │         ├──  generate_series:2 => i:7
+           │         └──  column3:3 => order_column3:8
+           └── filters
+                └── true
+
+# The input ordering is not propagated through joins.
+build preserve-input-order
+SELECT *
+FROM (SELECT * FROM generate_series(1, 2) x) tmp,
+     (SELECT * FROM generate_series(8, 12) i ORDER BY i % 5 ASC, i ASC) tmp2;
+----
+inner-join (cross)
+ ├── columns: x:1 i:2  [hidden: column3:3]
+ ├── project-set
+ │    ├── columns: generate_series:1
+ │    ├── values
+ │    │    └── ()
+ │    └── zip
+ │         └── generate_series(1, 2)
+ ├── project
+ │    ├── columns: column3:3 generate_series:2
+ │    ├── project-set
+ │    │    ├── columns: generate_series:2
+ │    │    ├── values
+ │    │    │    └── ()
+ │    │    └── zip
+ │    │         └── generate_series(8, 12)
+ │    └── projections
+ │         └── generate_series:2 % 5 [as=column3:3]
+ └── filters (true)
+
+# Do not preserve the subquery ordering because the parent scope has its own
+# ordering.
+build preserve-input-order
+WITH tmp AS (SELECT * FROM generate_series(1, 10) i ORDER BY i % 5 ASC, i ASC)
+SELECT * FROM tmp ORDER BY i DESC;
+----
+sort
+ ├── columns: i:3
+ ├── ordering: -3
+ └── with &1 (tmp)
+      ├── columns: i:3
+      ├── project
+      │    ├── columns: column2:2 generate_series:1
+      │    ├── project-set
+      │    │    ├── columns: generate_series:1
+      │    │    ├── values
+      │    │    │    └── ()
+      │    │    └── zip
+      │    │         └── generate_series(1, 10)
+      │    └── projections
+      │         └── generate_series:1 % 5 [as=column2:2]
+      └── project
+           ├── columns: i:3
+           └── with-scan &1 (tmp)
+                ├── columns: i:3 order_column2:4
+                └── mapping:
+                     ├──  generate_series:1 => i:3
+                     └──  column2:2 => order_column2:4
+
+# Do not preserve the subquery ordering because the parent scope has its own
+# ordering.
+build preserve-input-order
+WITH tmp AS (SELECT * FROM generate_series(1, 10) i ORDER BY i % 5 ASC, i ASC)
+SELECT * FROM tmp ORDER BY i DESC;
+----
+sort
+ ├── columns: i:3
+ ├── ordering: -3
+ └── with &1 (tmp)
+      ├── columns: i:3
+      ├── project
+      │    ├── columns: column2:2 generate_series:1
+      │    ├── project-set
+      │    │    ├── columns: generate_series:1
+      │    │    ├── values
+      │    │    │    └── ()
+      │    │    └── zip
+      │    │         └── generate_series(1, 10)
+      │    └── projections
+      │         └── generate_series:1 % 5 [as=column2:2]
+      └── project
+           ├── columns: i:3
+           └── with-scan &1 (tmp)
+                ├── columns: i:3 order_column2:4
+                └── mapping:
+                     ├──  generate_series:1 => i:3
+                     └──  column2:2 => order_column2:4

--- a/pkg/sql/opt/optbuilder/with.go
+++ b/pkg/sql/opt/optbuilder/with.go
@@ -186,7 +186,12 @@ func (b *Builder) buildCTE(
 	if !isRecursive {
 		cteScope := b.buildStmt(cte.Stmt, nil /* desiredTypes */, inScope)
 		cteScope.removeHiddenCols()
-		b.dropOrderingAndExtraCols(cteScope)
+		if b.evalCtx.SessionData.PropagateInputOrdering && len(inScope.ordering) == 0 {
+			// Preserve the CTE ordering.
+			inScope.copyOrdering(cteScope)
+		} else {
+			b.dropOrderingAndExtraCols(cteScope)
+		}
 		return cteScope.expr, b.getCTECols(cteScope, cte.Name)
 	}
 

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -173,6 +173,10 @@ type Flags struct {
 	// SessionData.PreferLookupJoinsForFKs.
 	PreferLookupJoinsForFKs bool
 
+	// PropagateInputOrdering is the default value for
+	// SessionData.PropagateInputOrdering
+	PropagateInputOrdering bool
+
 	// Locality specifies the location of the planning node as a set of user-
 	// defined key/value pairs, ordered from most inclusive to least inclusive.
 	// If there are no tiers, then the node's location is not known. Examples:
@@ -477,6 +481,7 @@ func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 
 	ot.evalCtx.SessionData.ReorderJoinsLimit = ot.Flags.JoinLimit
 	ot.evalCtx.SessionData.PreferLookupJoinsForFKs = ot.Flags.PreferLookupJoinsForFKs
+	ot.evalCtx.SessionData.PropagateInputOrdering = ot.Flags.PropagateInputOrdering
 
 	ot.evalCtx.TestingKnobs.OptimizerCostPerturbation = ot.Flags.PerturbCost
 	ot.evalCtx.Locality = ot.Flags.Locality
@@ -987,6 +992,9 @@ func (f *Flags) Set(arg datadriven.CmdArg) error {
 
 	case "query-args":
 		f.QueryArgs = arg.Vals
+
+	case "preserve-input-order":
+		f.PropagateInputOrdering = true
 
 	default:
 		return fmt.Errorf("unknown argument: %s", arg.Key)

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -285,6 +285,11 @@ type LocalOnlySessionData struct {
 	// of that interleave should be applied to the new primary index.
 	CopyPartitioningWhenDeinterleavingTable bool
 
+	// PropagateInputOrdering indicates that when planning a subquery or CTE, the
+	// inner ordering should be propagated to the outer scope if the outer scope
+	// is unordered. PropagateInputOrdering is currently experimental.
+	PropagateInputOrdering bool
+
 	///////////////////////////////////////////////////////////////////////////
 	// WARNING: consider whether a session parameter you're adding needs to  //
 	// be propagated to the remote nodes. If so, that parameter should live  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -1437,6 +1437,24 @@ var varGen = map[string]sessionVar{
 			return formatBoolAsPostgresSetting(copyPartitioningWhenDeinterleavingTable.Get(sv))
 		},
 	},
+
+	`propagate_input_ordering`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`propagate_input_ordering`),
+		Set: func(_ context.Context, m *sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar(`propagate_input_ordering`, s)
+			if err != nil {
+				return err
+			}
+			m.SetPropagateInputOrdering(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext) string {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData.PropagateInputOrdering)
+		},
+		GlobalDefault: func(sv *settings.Values) string {
+			return formatBoolAsPostgresSetting(propagateInputOrdering.Get(sv))
+		},
+	},
 }
 
 const compatErrMsg = "this parameter is currently recognized only for compatibility and has no effect in CockroachDB."


### PR DESCRIPTION
This patch adds an experimental cluster setting `propagate_input_ordering`
that indicates whether subqueries and CTEs should propagate their orderings
to their parent scopes, when the parent scope is unordered. As an example,
the following two queries should produce the following result when the
cluster setting is true:
```
select * from (select * from generate_series(1, 10) i order by i % 5 asc, i asc) tmp;
with tmp as (select * from generate_series(1, 10) i order by i % 5 asc, i asc) select * from tmp;
----
   5
  10
   1
   6
   2
   7
   3
   8
   4
   9
```
This allows cockroach to imitate postgres behavior - while postgres
does not guarantee to maintain ordering on subqueries, it does in
practice. Some existing applications take advantage of this fact,
and so the ability to toggle this setting can help resolve
incompatibilities in some cases.

Fixes #68211

Release note: None