### PR TITLE
sqlproxy: deflake test

### DIFF
--- a/pkg/ccl/sqlproxyccl/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/BUILD.bazel
@@ -69,7 +69,6 @@ go_test(
         "//pkg/sql/pgwire",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
-        "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",

--- a/pkg/ccl/sqlproxyccl/proxy_handler.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler.go
@@ -208,7 +208,8 @@ func (handler *proxyHandler) handle(ctx context.Context, incomingConn *proxyConn
 	}
 
 	// This currently only happens for CancelRequest type of startup messages
-	// that we don't support.
+	// that we don't support. Return nil to the server, which simply closes the
+	// connection.
 	if msg == nil {
 		return nil
 	}


### PR DESCRIPTION
Deflake the TestDirectoryConnect test, which was failing when the PGX client
sent a CancelRequest during connection closing and triggered a server error.
Update the server to not return an error on CancelRequest in the non-TLS
case (which is what this test uses). This fixes the flakiness, since there
is no longer a server error in rare cases. Also tighten up the test a bit so
that connections are only drained once.

Fixes #67729

Release note: None