### PR TITLE
opt: add GenerateLookupJoinsWithVirtualCols exploration rule

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -3137,6 +3137,194 @@ DROP TABLE regional_by_row;
 DROP TABLE regional_by_row_as;
 ALTER DATABASE drop_regions DROP REGION "ca-central-1";
 
+subtest virtual_columns
+
+statement ok
+SET experimental_enable_expression_indexes=true
+
+statement ok
+USE multi_region_test_db
+
+statement ok
+CREATE TABLE regional_by_row_table_virt (
+  pk int PRIMARY KEY,
+  a int NOT NULL,
+  b int NOT NULL,
+  v INT AS (a + b) VIRTUAL,
+  UNIQUE (v),
+  UNIQUE INDEX ((a + 10)),
+  FAMILY (pk, a, b)
+) LOCALITY REGIONAL BY ROW
+
+# Uniqueness checks for virtual columns should be efficient.
+query T
+SELECT * FROM [EXPLAIN INSERT INTO regional_by_row_table_virt (pk, a, b) VALUES (1, 1, 1)] OFFSET 2
+----
+·
+• root
+│
+├── • insert
+│   │ into: regional_by_row_table_virt(pk, a, b, v, crdb_region, crdb_internal_idx_expr)
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • values
+│             size: 7 columns, 1 row
+│
+├── • constraint-check
+│   │
+│   └── • error if rows
+│       │
+│       └── • lookup join (semi)
+│           │ table: regional_by_row_table_virt@primary
+│           │ lookup condition: (column1 = pk) AND (crdb_region = 'ap-southeast-2')
+│           │ remote lookup condition: (column1 = pk) AND (crdb_region IN ('ca-central-1', 'us-east-1'))
+│           │ pred: crdb_region_default != crdb_region
+│           │
+│           └── • scan buffer
+│                 label: buffer 1
+│
+├── • constraint-check
+│   │
+│   └── • error if rows
+│       │
+│       └── • limit
+│           │ count: 1
+│           │
+│           └── • lookup join
+│               │ table: regional_by_row_table_virt@regional_by_row_table_virt_v_key
+│               │ equality: (lookup_join_const_col_@34, v_comp) = (crdb_region,v)
+│               │ equality cols are key
+│               │ pred: (column1 != pk) OR (crdb_region_default != crdb_region)
+│               │
+│               └── • cross join
+│                   │ estimated row count: 3
+│                   │
+│                   ├── • values
+│                   │     size: 1 column, 3 rows
+│                   │
+│                   └── • scan buffer
+│                         label: buffer 1
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │
+        └── • limit
+            │ count: 1
+            │
+            └── • lookup join
+                │ table: regional_by_row_table_virt@regional_by_row_table_virt_expr_key
+                │ equality: (lookup_join_const_col_@48, crdb_internal_idx_expr_comp) = (crdb_region,crdb_internal_idx_expr)
+                │ equality cols are key
+                │ pred: (column1 != pk) OR (crdb_region_default != crdb_region)
+                │
+                └── • cross join
+                    │ estimated row count: 3
+                    │
+                    ├── • values
+                    │     size: 1 column, 3 rows
+                    │
+                    └── • scan buffer
+                          label: buffer 1
+
+query T
+SELECT * FROM [EXPLAIN UPSERT INTO regional_by_row_table_virt (pk, a, b) VALUES (1, 1, 1)] OFFSET 2
+----
+·
+• root
+│
+├── • upsert
+│   │ into: regional_by_row_table_virt(pk, a, b, v, crdb_region, crdb_internal_idx_expr)
+│   │ arbiter constraints: primary
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │
+│           └── • render
+│               │
+│               └── • cross join (left outer)
+│                   │
+│                   ├── • values
+│                   │     size: 6 columns, 1 row
+│                   │
+│                   └── • render
+│                       │
+│                       └── • union all
+│                           │ limit: 1
+│                           │
+│                           ├── • scan
+│                           │     missing stats
+│                           │     table: regional_by_row_table_virt@primary
+│                           │     spans: [/'ap-southeast-2'/1 - /'ap-southeast-2'/1]
+│                           │
+│                           └── • scan
+│                                 missing stats
+│                                 table: regional_by_row_table_virt@primary
+│                                 spans: [/'ca-central-1'/1 - /'ca-central-1'/1] [/'us-east-1'/1 - /'us-east-1'/1]
+│
+├── • constraint-check
+│   │
+│   └── • error if rows
+│       │
+│       └── • limit
+│           │ count: 1
+│           │
+│           └── • lookup join
+│               │ table: regional_by_row_table_virt@regional_by_row_table_virt_v_key
+│               │ equality: (lookup_join_const_col_@30, v_comp) = (crdb_region,v)
+│               │ equality cols are key
+│               │ pred: (upsert_pk != pk) OR (upsert_crdb_region != crdb_region)
+│               │
+│               └── • cross join
+│                   │
+│                   ├── • values
+│                   │     size: 1 column, 3 rows
+│                   │
+│                   └── • scan buffer
+│                         label: buffer 1
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │
+        └── • limit
+            │ count: 1
+            │
+            └── • lookup join
+                │ table: regional_by_row_table_virt@regional_by_row_table_virt_expr_key
+                │ equality: (lookup_join_const_col_@44, crdb_internal_idx_expr_comp) = (crdb_region,crdb_internal_idx_expr)
+                │ equality cols are key
+                │ pred: (upsert_pk != pk) OR (upsert_crdb_region != crdb_region)
+                │
+                └── • cross join
+                    │
+                    ├── • values
+                    │     size: 1 column, 3 rows
+                    │
+                    └── • scan buffer
+                          label: buffer 1
+
+statement ok
+INSERT INTO regional_by_row_table_virt (pk, a, b) VALUES (1, 1, 1)
+
+statement error pq: duplicate key value violates unique constraint "regional_by_row_table_virt_v_key"\nDETAIL: Key \(v\)=\(2\) already exists\.
+INSERT INTO regional_by_row_table_virt (pk, a, b) VALUES (2, 2, 0)
+
+statement error pq: duplicate key value violates unique constraint "regional_by_row_table_virt_v_key"\nDETAIL: Key \(v\)=\(2\) already exists\.
+UPSERT INTO regional_by_row_table_virt (pk, a, b) VALUES (2, 2, 0)
+
+statement error pq: duplicate key value violates unique constraint "regional_by_row_table_virt_expr_key"\nDETAIL: Key \(a \+ 10:::INT8\)=\(11\) already exists\.
+INSERT INTO regional_by_row_table_virt (pk, a, b) VALUES (2, 1, 3)
+
+statement error pq: duplicate key value violates unique constraint "regional_by_row_table_virt_expr_key"\nDETAIL: Key \(a \+ 10:::INT8\)=\(11\) already exists\.
+UPSERT INTO regional_by_row_table_virt (pk, a, b) VALUES (2, 1, 3)
+
+subtest regressions
+
 # Regression test for #63109. UPSERT should not cause the error
 # ERROR: missing "crdb_region" primary key column.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/virtual_columns
+++ b/pkg/sql/logictest/testdata/logic_test/virtual_columns
@@ -149,6 +149,24 @@ SELECT a FROM t_idx WHERE w IN (4,6)
 3
 5
 
+# Covering lookup join.
+query II
+SELECT v, x FROM (VALUES (1), (2), (10), (5)) AS u(x) INNER LOOKUP JOIN t_idx@t_idx_v_idx ON u.x = t_idx.v
+----
+2   2
+5   5
+10  10
+10  10
+
+# Non-covering lookup join that requires a second join on the primary index.
+query IIII
+SELECT a, b, v, x FROM (VALUES (1), (2), (10), (5)) AS u(x) INNER LOOKUP JOIN t_idx@t_idx_v_idx ON u.x = t_idx.v
+----
+1  1  2   2
+2  8  10  10
+4  6  10  10
+5  0  5   5
+
 statement ok
 DELETE FROM t_idx WHERE v = 6
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/virtual_columns
+++ b/pkg/sql/opt/exec/execbuilder/testdata/virtual_columns
@@ -144,6 +144,53 @@ vectorized: true
           table: t_idx@t_idx_v_idx
           spans: /1-/2
 
+# Covering lookup join.
+query T
+EXPLAIN (VERBOSE) SELECT v, x FROM (VALUES (1), (10), (5)) AS u(x) INNER JOIN t_idx ON u.x = t_idx.v
+----
+distribution: local
+vectorized: true
+·
+• lookup join (inner)
+│ columns: (v, x)
+│ estimated row count: 3 (missing stats)
+│ table: t_idx@t_idx_v_idx
+│ equality: (column1) = (v)
+│
+└── • values
+      columns: (column1)
+      size: 1 column, 3 rows
+      row 0, expr 0: 1
+      row 1, expr 0: 10
+      row 2, expr 0: 5
+
+# Non-covering lookup join that requires a second join on the primary index.
+query T
+EXPLAIN (VERBOSE) SELECT a, b, v, x FROM (VALUES (1), (10), (5)) AS u(x) INNER JOIN t_idx ON u.x = t_idx.v
+----
+distribution: local
+vectorized: true
+·
+• lookup join (inner)
+│ columns: (a, b, v, x)
+│ estimated row count: 3 (missing stats)
+│ table: t_idx@primary
+│ equality: (a) = (a)
+│ equality cols are key
+│
+└── • lookup join (inner)
+    │ columns: (column1, a, v)
+    │ estimated row count: 30 (missing stats)
+    │ table: t_idx@t_idx_v_idx
+    │ equality: (column1) = (v)
+    │
+    └── • values
+          columns: (column1)
+          size: 1 column, 3 rows
+          row 0, expr 0: 1
+          row 1, expr 0: 10
+          row 2, expr 0: 5
+
 subtest Insert
 
 # TODO(radu): we shouldn't need to synthesize v here.

--- a/pkg/sql/opt/xform/rules/join.opt
+++ b/pkg/sql/opt/xform/rules/join.opt
@@ -208,6 +208,45 @@
     $private
 )
 
+# GenerateLookupJoinsWithVirtualCols is similar to GenerateLookupJoins but
+# applies when the input is a Project that produces virtual computed columns.
+# See the GenerateLookupJoinsWithVirtualCols custom function for more details.
+#
+# TODO(mgartner): Generate lookup joins with virtual columns for semi- and
+# anti-joins. This may also be possible for left joins, but could be tricky.
+#
+# TODO(mgartner): Generate lookup joins with virtual columns and additional
+# filters where the right side is of the form (Project (Select (Scan))). This
+# will enable lookup joins into partial indexes on virtual columns.
+[GenerateLookupJoinsWithVirtualCols, Explore]
+(InnerJoin
+    $left:*
+    $project:(Project
+            (Scan $scanPrivate:*) &
+                (IsCanonicalScan $scanPrivate) &
+                ^(ColsAreEmpty
+                    $virtualCols:(VirtualColumns $scanPrivate)
+                )
+            $projections:*
+        ) &
+        (ColsAreSubset
+            $projectedVirtualCols:(ProjectionCols $projections)
+            $virtualCols
+        )
+    $on:*
+    $private:*
+)
+=>
+(GenerateLookupJoinsWithVirtualCols
+    (OpName)
+    $left
+    (OutputCols $project)
+    $projectedVirtualCols
+    $scanPrivate
+    $on
+    $private
+)
+
 # PushJoinIntoIndexJoin pushes an InnerJoin into an IndexJoin. The IndexJoin is
 # replaced with a LookupJoin, since it now must output columns from the right
 # side of the InnerJoin as well as from the original lookup table. This can

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -58,6 +58,17 @@ CREATE TABLE zz (
 ----
 
 exec-ddl
+CREATE TABLE virt (
+  k INT PRIMARY KEY,
+  i INT,
+  j INT NOT NULL,
+  v1 INT AS (i + 10) VIRTUAL,
+  v2 INT AS (i + 100) VIRTUAL,
+  CHECK (j IN (10, 20, 30))
+)
+----
+
+exec-ddl
 CREATE TABLE large (m INT, n INT)
 ----
 
@@ -4161,6 +4172,515 @@ inner-join (lookup t63735)
  └── filters
       └── y:7 = 15 [outer=(7), constraints=(/7: [/15 - /15]; tight), fd=()-->(7)]
 
+
+# --------------------------------------------------
+# GenerateLookupJoinsWithVirtualCols
+# --------------------------------------------------
+
+exec-ddl
+CREATE INDEX v1 ON virt (v1)
+----
+
+exec-ddl
+CREATE INDEX v2 ON virt (v2)
+----
+
+# Covering case. Join on virtual column but do not produce it.
+opt expect=GenerateLookupJoinsWithVirtualCols
+SELECT m, virt.k FROM small INNER LOOKUP JOIN virt ON m = virt.v1
+----
+project
+ ├── columns: m:1!null k:6!null
+ ├── immutable
+ ├── fd: (6)-->(1)
+ └── inner-join (lookup virt@v1)
+      ├── columns: m:1!null k:6!null v1:9!null
+      ├── flags: force lookup join (into right side)
+      ├── key columns: [1] = [9]
+      ├── immutable
+      ├── fd: (6)-->(9), (1)==(9), (9)==(1)
+      ├── scan small
+      │    └── columns: m:1
+      └── filters (true)
+
+# Covering case. Produce virtual column.
+opt expect=GenerateLookupJoinsWithVirtualCols
+SELECT m, virt.k, virt.v1 FROM small INNER LOOKUP JOIN virt ON m = virt.v1
+----
+inner-join (lookup virt@v1)
+ ├── columns: m:1!null k:6!null v1:9!null
+ ├── flags: force lookup join (into right side)
+ ├── key columns: [1] = [9]
+ ├── immutable
+ ├── fd: (6)-->(9), (1)==(9), (9)==(1)
+ ├── scan small
+ │    └── columns: m:1
+ └── filters (true)
+
+# Non-covering.
+opt expect=GenerateLookupJoinsWithVirtualCols
+SELECT m, virt.i, virt.v1 FROM small INNER LOOKUP JOIN virt ON m = virt.v1
+----
+inner-join (lookup virt)
+ ├── columns: m:1!null i:7 v1:9!null
+ ├── key columns: [6] = [6]
+ ├── lookup columns are key
+ ├── immutable
+ ├── fd: (7)-->(9), (1)==(9), (9)==(1)
+ ├── inner-join (lookup virt@v1)
+ │    ├── columns: m:1!null k:6!null v1:9!null
+ │    ├── flags: force lookup join (into right side)
+ │    ├── key columns: [1] = [9]
+ │    ├── fd: (6)-->(9), (1)==(9), (9)==(1)
+ │    ├── scan small
+ │    │    └── columns: m:1
+ │    └── filters (true)
+ └── filters (true)
+
+# Non-covering. Extra filter on non-covered column. We do not support this yet.
+# TODO(mgartner): Generate lookup joins with virtual columns and extra filters
+# by handling the (Project (Select (Scan))) pattern on the right side of the
+# join.
+opt format=hide-all
+SELECT m, virt.i, virt.v1 FROM small INNER LOOKUP JOIN virt ON m = virt.v1 AND i > 0
+----
+inner-join (hash)
+ ├── flags: force lookup join (into right side)
+ ├── scan small
+ ├── project
+ │    ├── select
+ │    │    ├── scan virt
+ │    │    │    ├── check constraint expressions
+ │    │    │    │    └── j IN (10, 20, 30)
+ │    │    │    └── computed column expressions
+ │    │    │         ├── v1
+ │    │    │         │    └── i + 10
+ │    │    │         └── v2
+ │    │    │              └── i + 100
+ │    │    └── filters
+ │    │         └── i > 0
+ │    └── projections
+ │         └── i + 10
+ └── filters
+      └── m = v1
+
+# Do not generate a lookup join when the right side projects a column that is
+# not a virtual computed column.
+opt expect-not=GenerateLookupJoinsWithVirtualCols
+SELECT m, tmp.p
+FROM small INNER LOOKUP JOIN (
+  SELECT v1, i + 5 AS p FROM virt
+) tmp ON m = tmp.v1
+----
+project
+ ├── columns: m:1!null p:13
+ ├── immutable
+ └── inner-join (hash)
+      ├── columns: m:1!null v1:9!null p:13
+      ├── flags: force lookup join (into right side)
+      ├── immutable
+      ├── fd: (1)==(9), (9)==(1)
+      ├── scan small
+      │    └── columns: m:1
+      ├── project
+      │    ├── columns: p:13 v1:9
+      │    ├── immutable
+      │    ├── scan virt
+      │    │    ├── columns: i:7
+      │    │    ├── check constraint expressions
+      │    │    │    └── j:8 IN (10, 20, 30) [outer=(8), constraints=(/8: [/10 - /10] [/20 - /20] [/30 - /30]; tight)]
+      │    │    └── computed column expressions
+      │    │         ├── v1:9
+      │    │         │    └── i:7 + 10
+      │    │         └── v2:10
+      │    │              └── i:7 + 100
+      │    └── projections
+      │         ├── i:7 + 5 [as=p:13, outer=(7), immutable]
+      │         └── i:7 + 10 [as=v1:9, outer=(7), immutable]
+      └── filters
+           └── m:1 = v1:9 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
+
+# Do not generate a lookup join when all the projected virtual columns cannot
+# be produced from a single index.
+opt expect-not=GenerateLookupJoinsWithVirtualCols
+SELECT m, virt.v1, virt.v2 FROM small INNER LOOKUP JOIN virt ON m = virt.v1
+----
+inner-join (hash)
+ ├── columns: m:1!null v1:9!null v2:10
+ ├── flags: force lookup join (into right side)
+ ├── immutable
+ ├── fd: (1)==(9), (9)==(1)
+ ├── scan small
+ │    └── columns: m:1
+ ├── project
+ │    ├── columns: v1:9 v2:10
+ │    ├── immutable
+ │    ├── scan virt
+ │    │    ├── columns: i:7
+ │    │    ├── check constraint expressions
+ │    │    │    └── j:8 IN (10, 20, 30) [outer=(8), constraints=(/8: [/10 - /10] [/20 - /20] [/30 - /30]; tight)]
+ │    │    └── computed column expressions
+ │    │         ├── v1:9
+ │    │         │    └── i:7 + 10
+ │    │         └── v2:10
+ │    │              └── i:7 + 100
+ │    └── projections
+ │         ├── i:7 + 10 [as=v1:9, outer=(7), immutable]
+ │         └── i:7 + 100 [as=v2:10, outer=(7), immutable]
+ └── filters
+      └── m:1 = v1:9 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
+
+# Do not generate lookup joins with virtual columns for left joins.
+opt expect-not=GenerateLookupJoinsWithVirtualCols format=hide-all
+SELECT m, virt.k FROM small LEFT LOOKUP JOIN virt ON m = virt.v1
+----
+project
+ └── left-join (hash)
+      ├── flags: force lookup join (into right side)
+      ├── scan small
+      ├── project
+      │    ├── scan virt
+      │    │    ├── check constraint expressions
+      │    │    │    └── j IN (10, 20, 30)
+      │    │    └── computed column expressions
+      │    │         ├── v1
+      │    │         │    └── i + 10
+      │    │         └── v2
+      │    │              └── i + 100
+      │    └── projections
+      │         └── i + 10
+      └── filters
+           └── m = v1
+
+# Do not generate lookup joins with virtual columns for semi-joins.
+opt expect-not=GenerateLookupJoinsWithVirtualCols format=hide-all
+SELECT m FROM small WHERE EXISTS (SELECT * FROM virt WHERE m = virt.v1)
+----
+semi-join (hash)
+ ├── scan small
+ ├── project
+ │    ├── scan virt
+ │    │    ├── check constraint expressions
+ │    │    │    └── j IN (10, 20, 30)
+ │    │    └── computed column expressions
+ │    │         ├── v1
+ │    │         │    └── i + 10
+ │    │         └── v2
+ │    │              └── i + 100
+ │    └── projections
+ │         └── i + 10
+ └── filters
+      └── m = column13
+
+# Do not generate lookup joins with virtual columns for anti-joins.
+opt expect-not=GenerateLookupJoinsWithVirtualCols format=hide-all
+SELECT m FROM small WHERE NOT EXISTS (SELECT * FROM virt WHERE m = virt.v1)
+----
+anti-join (hash)
+ ├── scan small
+ ├── project
+ │    ├── scan virt
+ │    │    ├── check constraint expressions
+ │    │    │    └── j IN (10, 20, 30)
+ │    │    └── computed column expressions
+ │    │         ├── v1
+ │    │         │    └── i + 10
+ │    │         └── v2
+ │    │              └── i + 100
+ │    └── projections
+ │         └── i + 10
+ └── filters
+      └── m = column13
+
+exec-ddl
+DROP INDEX v1
+----
+
+exec-ddl
+DROP INDEX v2
+----
+
+exec-ddl
+CREATE INDEX v1_v2 ON virt (v1, v2)
+----
+
+# Covering case. Single key column in index with multiple virtual columns.
+opt expect=GenerateLookupJoinsWithVirtualCols
+SELECT m, virt.k, virt.v1, virt.v2 FROM small INNER LOOKUP JOIN virt ON m = virt.v1
+----
+inner-join (lookup virt@v1_v2)
+ ├── columns: m:1!null k:6!null v1:9!null v2:10
+ ├── flags: force lookup join (into right side)
+ ├── key columns: [1] = [9]
+ ├── immutable
+ ├── fd: (6)-->(9,10), (1)==(9), (9)==(1)
+ ├── scan small
+ │    └── columns: m:1
+ └── filters (true)
+
+# Covering case. Multiple key columns in index with multiple virtual columns.
+opt expect=GenerateLookupJoinsWithVirtualCols
+SELECT m, virt.k, virt.v1, virt.v2 FROM small INNER LOOKUP JOIN virt ON m = virt.v1 AND n = virt.v2
+----
+project
+ ├── columns: m:1!null k:6!null v1:9!null v2:10!null
+ ├── immutable
+ ├── fd: (6)-->(9,10), (1)==(9), (9)==(1)
+ └── inner-join (lookup virt@v1_v2)
+      ├── columns: m:1!null n:2!null k:6!null v1:9!null v2:10!null
+      ├── flags: force lookup join (into right side)
+      ├── key columns: [1 2] = [9 10]
+      ├── immutable
+      ├── fd: (6)-->(9,10), (1)==(9), (9)==(1), (2)==(10), (10)==(2)
+      ├── scan small
+      │    └── columns: m:1 n:2
+      └── filters (true)
+
+exec-ddl
+DROP INDEX v1_v2
+----
+
+exec-ddl
+CREATE INDEX i_v1 ON virt (i, v1)
+----
+
+exec-ddl
+CREATE INDEX v2_i ON virt (v2, i)
+----
+
+# Covering case. One of the lookup columns is a virtual column.
+opt expect=GenerateLookupJoinsWithVirtualCols
+SELECT m, virt.k, virt.v1 FROM small INNER LOOKUP JOIN virt ON m = virt.i AND n = virt.v1
+----
+project
+ ├── columns: m:1!null k:6!null v1:9!null
+ ├── immutable
+ ├── fd: (6)-->(1,9), (1)-->(9)
+ └── inner-join (lookup virt@i_v1)
+      ├── columns: m:1!null n:2!null k:6!null i:7!null v1:9!null
+      ├── flags: force lookup join (into right side)
+      ├── key columns: [1 2] = [7 9]
+      ├── immutable
+      ├── fd: (6)-->(7), (7)-->(9), (1)==(7), (7)==(1), (2)==(9), (9)==(2)
+      ├── scan small
+      │    └── columns: m:1 n:2
+      └── filters (true)
+
+# Covering case. A non-virtual column is the lookup column and the virtual
+# column can be produced.
+opt expect=GenerateLookupJoinsWithVirtualCols
+SELECT m, virt.k, virt.v1 FROM small INNER LOOKUP JOIN virt ON m = virt.i
+----
+project
+ ├── columns: m:1!null k:6!null v1:9
+ ├── immutable
+ ├── fd: (6)-->(1,9), (1)-->(9)
+ └── inner-join (lookup virt@i_v1)
+      ├── columns: m:1!null k:6!null i:7!null v1:9
+      ├── flags: force lookup join (into right side)
+      ├── key columns: [1] = [7]
+      ├── immutable
+      ├── fd: (6)-->(7), (7)-->(9), (1)==(7), (7)==(1)
+      ├── scan small
+      │    └── columns: m:1
+      └── filters (true)
+
+# Covering case. A virtual column is the lookup column and the non-virtual
+# column can be produced.
+opt expect=GenerateLookupJoinsWithVirtualCols
+SELECT m, virt.i, virt.v2 FROM small INNER LOOKUP JOIN virt ON m = virt.v2
+----
+inner-join (lookup virt@v2_i)
+ ├── columns: m:1!null i:7 v2:10!null
+ ├── flags: force lookup join (into right side)
+ ├── key columns: [1] = [10]
+ ├── immutable
+ ├── fd: (7)-->(10), (1)==(10), (10)==(1)
+ ├── scan small
+ │    └── columns: m:1
+ └── filters (true)
+
+# Covering case with a cross join for multiple constant values for the leading
+# lookup column. We do not support this yet.
+# TODO(mgartner): Generate lookup joins with virtual columns and extra filters
+# by handling the (Project (Select (Scan))) pattern on the right side of the
+# join.
+opt
+SELECT m, virt.k, virt.v1 FROM small INNER LOOKUP JOIN virt ON virt.i IN (1, 2, 3) AND m = virt.v1
+----
+inner-join (hash)
+ ├── columns: m:1!null k:6!null v1:9!null
+ ├── flags: force lookup join (into right side)
+ ├── immutable
+ ├── fd: (6)-->(9), (1)==(9), (9)==(1)
+ ├── scan small
+ │    └── columns: m:1
+ ├── project
+ │    ├── columns: v1:9!null k:6!null
+ │    ├── immutable
+ │    ├── key: (6)
+ │    ├── fd: (6)-->(9)
+ │    ├── scan virt@i_v1
+ │    │    ├── columns: k:6!null i:7!null
+ │    │    ├── constraint: /7/9/6: [/1 - /3]
+ │    │    ├── key: (6)
+ │    │    └── fd: (6)-->(7)
+ │    └── projections
+ │         └── i:7 + 10 [as=v1:9, outer=(7), immutable]
+ └── filters
+      └── m:1 = v1:9 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
+
+exec-ddl
+DROP INDEX i_v1
+----
+
+exec-ddl
+DROP INDEX v2_i
+----
+
+exec-ddl
+CREATE INDEX j_v1 ON virt (j, v1)
+----
+
+# Covering case with a cross join for multiple constant values based on optional
+# filters.
+opt
+SELECT m, virt.k, virt.v1 FROM small INNER LOOKUP JOIN virt ON m = virt.v1
+----
+inner-join (lookup virt@j_v1)
+ ├── columns: m:1!null k:6!null v1:9!null
+ ├── flags: force lookup join (into right side)
+ ├── key columns: [13 1] = [8 9]
+ ├── immutable
+ ├── fd: (6)-->(9), (1)==(9), (9)==(1)
+ ├── inner-join (cross)
+ │    ├── columns: m:1 "lookup_join_const_col_@8":13!null
+ │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
+ │    ├── scan small
+ │    │    └── columns: m:1
+ │    ├── values
+ │    │    ├── columns: "lookup_join_const_col_@8":13!null
+ │    │    ├── cardinality: [3 - 3]
+ │    │    ├── (10,)
+ │    │    ├── (20,)
+ │    │    └── (30,)
+ │    └── filters (true)
+ └── filters (true)
+
+# Non-covering case with a cross join for multiple constant values based on optional
+# filters.
+opt
+SELECT m, virt.i, virt.k, virt.v1 FROM small INNER LOOKUP JOIN virt ON m = virt.v1
+----
+inner-join (lookup virt)
+ ├── columns: m:1!null i:7 k:6!null v1:9!null
+ ├── key columns: [6] = [6]
+ ├── lookup columns are key
+ ├── immutable
+ ├── fd: (6)-->(7), (7)-->(9), (1)==(9), (9)==(1)
+ ├── inner-join (lookup virt@j_v1)
+ │    ├── columns: m:1!null k:6!null v1:9!null
+ │    ├── flags: force lookup join (into right side)
+ │    ├── key columns: [13 1] = [8 9]
+ │    ├── fd: (6)-->(1,9), (1)==(9), (9)==(1)
+ │    ├── inner-join (cross)
+ │    │    ├── columns: m:1 "lookup_join_const_col_@8":13!null
+ │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
+ │    │    ├── scan small
+ │    │    │    └── columns: m:1
+ │    │    ├── values
+ │    │    │    ├── columns: "lookup_join_const_col_@8":13!null
+ │    │    │    ├── cardinality: [3 - 3]
+ │    │    │    ├── (10,)
+ │    │    │    ├── (20,)
+ │    │    │    └── (30,)
+ │    │    └── filters (true)
+ │    └── filters (true)
+ └── filters (true)
+
+exec-ddl
+DROP INDEX j_v1
+----
+
+exec-ddl
+CREATE INDEX v1_storing_i ON virt (v1) STORING (i)
+----
+
+# Covering case. Virtual column is the lookup column and there is an extra
+# filter on the non-virtual column. We do not support this yet.
+# TODO(mgartner): Generate lookup joins with virtual columns and extra filters
+# by handling the (Project (Select (Scan))) pattern on the right side of the
+# join.
+opt format=hide-all
+SELECT m, virt.i, virt.v2 FROM small INNER LOOKUP JOIN virt ON m = virt.v1 AND i > 0
+----
+project
+ └── inner-join (hash)
+      ├── flags: force lookup join (into right side)
+      ├── scan small
+      ├── project
+      │    ├── select
+      │    │    ├── scan virt
+      │    │    │    ├── check constraint expressions
+      │    │    │    │    └── j IN (10, 20, 30)
+      │    │    │    └── computed column expressions
+      │    │    │         ├── v1
+      │    │    │         │    └── i + 10
+      │    │    │         └── v2
+      │    │    │              └── i + 100
+      │    │    └── filters
+      │    │         └── i > 0
+      │    └── projections
+      │         ├── i + 10
+      │         └── i + 100
+      └── filters
+           └── m = v1
+
+exec-ddl
+DROP INDEX v1_storing_i
+----
+
+exec-ddl
+CREATE INDEX v1_partial ON virt (v1) WHERE k > 0
+----
+
+# Covering case with partial index. We do not support this yet.
+# TODO(mgartner): Generate lookup joins with virtual columns indexed by partial
+# indexes by handling the (Project (Select (Scan))) pattern on the right side of
+# the join.
+opt format=hide-all
+SELECT m, virt.v1 FROM small INNER LOOKUP JOIN virt ON m = virt.v1 AND k > 0
+----
+inner-join (hash)
+ ├── flags: force lookup join (into right side)
+ ├── scan small
+ ├── project
+ │    ├── scan virt
+ │    │    └── constraint: /6: [/1 - ]
+ │    └── projections
+ │         └── i + 10
+ └── filters
+      └── m = v1
+
+# Non-covering case with partial index. We do not support this yet.
+# TODO(mgartner): Generate lookup joins with virtual columns indexed by partial
+# indexes by handling the (Project (Select (Scan))) pattern on the right side of
+# the join.
+opt format=hide-all
+SELECT m, virt.i, virt.v1 FROM small INNER LOOKUP JOIN virt ON m = virt.v1 AND k > 0
+----
+inner-join (hash)
+ ├── flags: force lookup join (into right side)
+ ├── scan small
+ ├── project
+ │    ├── scan virt
+ │    │    └── constraint: /6: [/1 - ]
+ │    └── projections
+ │         └── i + 10
+ └── filters
+      └── m = v1
+
+
 # -------------------------------------------------------
 # GenerateInvertedJoins + GenerateInvertedJoinsFromSelect
 # -------------------------------------------------------
@@ -7039,7 +7559,7 @@ inner-join (lookup abc@ab)
 
 # No-op case because the right side of the InnerJoin has outer columns.
 opt expect-not=PushJoinIntoIndexJoin disable=(TryDecorrelateProject,HoistProjectFromInnerJoin)
-SELECT * 
+SELECT *
 FROM stu
 INNER JOIN LATERAL (
    SELECT *


### PR DESCRIPTION
The GenerateLookupJoinsWithVirtualCols exploration rule has been added
to the optimizer.

GenerateLookupJoinsWithVirtualCols is similar to GenerateLookupJoins but
generates lookup joins into indexes that contain virtual columns.

In a canonical plan a virtual column is produced with a Project
expression on top of a Scan. This is necessary because virtual columns
aren't stored in the primary index. When a virtual column is indexed, a
lookup join can be generated that both uses the virtual column as a
lookup column and produces the column directly from the index without a
Project.

For example:

        Join                       LookupJoin(t@idx)
        /   \                           |
       /     \            ->            |
     Input  Project                   Input
              |
              |
            Scan(t)

This function and its associated rule currently require that:

  1. The join is an inner join.
  2. The right side projects only virtual computed columns.
  3. All the projected virtual columns are covered by a single index.

It should be possible to support semi- and anti- joins. Left joins may
be possible with additional complexity.

It should also be possible to support cases where all the virtual
columns are not covered by a single index by wrapping the lookup join in
a Project that produces the non-covered virtual columns.

This rule is required to make multi-region uniqueness checks for unique
indexes on virtual columns and unique expression indexes efficient.
Without this rule, the optimizer resorts to a full table scan for these
uniqueness checks, making these types of indexes unusable in
multi-region clusters.

There is additional work required to make uniqueness checks efficient
for unique partial indexes on virtual columns. This will be addressed
in a future commit.

Informs #68132

Release note (performance improvement): Lookup joins on indexes with
virtual columns are now considered by the optimizer. This should result
in more efficient queries in many cases. Most notably, post-query
uniqueness checks for unique indexes on virtual columns in
`REGIONAL BY ROW` tables can now utilize the unique index rather than
perform a full table scan.