### PR TITLE
kv: avoid regressions in closed timestamp sidetransportAccess

### DIFF
--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1197,8 +1197,8 @@ func (r *Replica) State(ctx context.Context) kvserverpb.RangeInfo {
 	}
 	ri.ClosedTimestampPolicy = r.closedTimestampPolicyRLocked()
 	r.sideTransportClosedTimestamp.mu.Lock()
-	ri.ClosedTimestampSideTransportInfo.ReplicaClosed = r.sideTransportClosedTimestamp.mu.closedTimestamp
-	ri.ClosedTimestampSideTransportInfo.ReplicaLAI = r.sideTransportClosedTimestamp.mu.lai
+	ri.ClosedTimestampSideTransportInfo.ReplicaClosed = r.sideTransportClosedTimestamp.mu.cur.ts
+	ri.ClosedTimestampSideTransportInfo.ReplicaLAI = r.sideTransportClosedTimestamp.mu.cur.lai
 	r.sideTransportClosedTimestamp.mu.Unlock()
 	centralClosed, centralLAI := r.store.cfg.ClosedTimestampReceiver.GetClosedTimestamp(
 		ctx, r.RangeID, r.mu.state.Lease.Replica.NodeID)

--- a/pkg/kv/kvserver/replica_closedts_internal_test.go
+++ b/pkg/kv/kvserver/replica_closedts_internal_test.go
@@ -12,6 +12,8 @@ package kvserver
 
 import (
 	"context"
+	"math/rand"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -24,7 +26,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 )
 
 func TestSideTransportClosed(t *testing.T) {
@@ -32,107 +37,458 @@ func TestSideTransportClosed(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 
-	ts1 := hlc.Timestamp{WallTime: 1}
-	ts2 := hlc.Timestamp{WallTime: 2}
-	ts3 := hlc.Timestamp{WallTime: 3}
+	// cur < next < rec
+	cur := closedTimestamp{hlc.Timestamp{WallTime: 1}, 1}
+	next := closedTimestamp{hlc.Timestamp{WallTime: 2}, 2}
+	rec := closedTimestamp{hlc.Timestamp{WallTime: 3}, 3}
 
 	tests := []struct {
-		name           string
-		applied        ctpb.LAI
-		localClosed    hlc.Timestamp
-		localLAI       ctpb.LAI
-		receiverClosed hlc.Timestamp
-		receiverLAI    ctpb.LAI
-		sufficient     hlc.Timestamp
+		name       string
+		curSet     bool
+		nextSet    bool
+		recSet     bool
+		applied    ctpb.LAI
+		sufficient hlc.Timestamp
 
-		expectedLocalUpdate bool
-		expectedClosed      hlc.Timestamp
+		expClosed          hlc.Timestamp
+		expCurUpdateToNext bool
+		expCurUpdateToRec  bool
+		expNextCleared     bool
+		expNextUpdateToRec bool
 	}{
 		{
-			name:                "all empty",
-			expectedClosed:      hlc.Timestamp{},
-			expectedLocalUpdate: false,
+			name:      "all empty",
+			expClosed: hlc.Timestamp{},
 		},
 		{
-			name:           "only local",
-			applied:        100,
-			localClosed:    ts1,
-			localLAI:       1,
-			expectedClosed: ts1,
+			name:      "current set",
+			curSet:    true,
+			applied:   cur.lai,
+			expClosed: cur.ts,
 		},
 		{
-			name:                "only receiver",
-			applied:             100,
-			receiverClosed:      ts1,
-			receiverLAI:         1,
-			expectedClosed:      ts1,
-			expectedLocalUpdate: true,
+			name:      "next set, next not reached",
+			nextSet:   true,
+			applied:   cur.lai,
+			expClosed: hlc.Timestamp{},
 		},
 		{
-			name:           "local sufficient",
-			applied:        100,
-			localClosed:    ts1,
-			localLAI:       1,
-			receiverClosed: ts2,
-			receiverLAI:    2,
-			// The caller won't need a closed timestamp > ts1, so we expect the
-			// receiver to not be consulted.
-			sufficient:          ts1,
-			expectedClosed:      ts1,
-			expectedLocalUpdate: false,
+			name:               "next set, next reached",
+			nextSet:            true,
+			applied:            next.lai,
+			expClosed:          next.ts,
+			expCurUpdateToNext: true,
+			expNextCleared:     true,
 		},
 		{
-			name:                "local insufficient",
-			applied:             100,
-			localClosed:         ts1,
-			localLAI:            1,
-			receiverClosed:      ts2,
-			receiverLAI:         2,
-			sufficient:          ts3,
-			expectedClosed:      ts2,
-			expectedLocalUpdate: true,
+			name:      "current + next set, next not reached",
+			curSet:    true,
+			nextSet:   true,
+			applied:   cur.lai,
+			expClosed: cur.ts,
 		},
 		{
-			name:           "replication not caught up",
-			applied:        0,
-			localClosed:    ts1,
-			localLAI:       1,
-			receiverClosed: ts2,
-			receiverLAI:    2,
-			sufficient:     ts3,
-			// We expect no usable closed timestamp to be returned. And also we expect
-			// the local state to not be updated because the LAI from the receiver has
-			// not been applied by the replica.
-			expectedClosed:      hlc.Timestamp{},
-			expectedLocalUpdate: false,
+			name:               "current + next set, next reached",
+			curSet:             true,
+			nextSet:            true,
+			applied:            next.lai,
+			expClosed:          next.ts,
+			expCurUpdateToNext: true,
+			expNextCleared:     true,
+		},
+		{
+			name:               "receiver set, receiver not reached",
+			recSet:             true,
+			applied:            next.lai,
+			expClosed:          hlc.Timestamp{},
+			expNextUpdateToRec: true,
+		},
+		{
+			name:              "receiver set, receiver reached",
+			recSet:            true,
+			applied:           rec.lai,
+			expClosed:         rec.ts,
+			expCurUpdateToRec: true,
+		},
+		{
+			name:               "current + receiver set, receiver not reached",
+			curSet:             true,
+			recSet:             true,
+			applied:            next.lai,
+			expClosed:          cur.ts,
+			expNextUpdateToRec: true,
+		},
+		{
+			name:              "current + receiver set, receiver reached",
+			curSet:            true,
+			recSet:            true,
+			applied:           rec.lai,
+			expClosed:         rec.ts,
+			expCurUpdateToRec: true,
+		},
+		{
+			name:      "next + receiver, next not reached, receiver not reached",
+			nextSet:   true,
+			recSet:    true,
+			applied:   cur.lai,
+			expClosed: hlc.Timestamp{},
+		},
+		{
+			name:               "next + receiver, next reached, receiver not reached",
+			nextSet:            true,
+			recSet:             true,
+			applied:            next.lai,
+			expClosed:          next.ts,
+			expCurUpdateToNext: true,
+			expNextUpdateToRec: true,
+		},
+		{
+			name:              "next + receiver, next reached, receiver reached",
+			nextSet:           true,
+			recSet:            true,
+			applied:           rec.lai,
+			expClosed:         rec.ts,
+			expCurUpdateToRec: true,
+			expNextCleared:    true,
+		},
+		{
+			name:      "current + next + receiver set, next not reached, receiver not reached",
+			curSet:    true,
+			nextSet:   true,
+			recSet:    true,
+			applied:   cur.lai,
+			expClosed: cur.ts,
+		},
+		{
+			name:               "current + next + receiver set, next reached, receiver not reached",
+			curSet:             true,
+			nextSet:            true,
+			recSet:             true,
+			applied:            next.lai,
+			expClosed:          next.ts,
+			expCurUpdateToNext: true,
+			expNextUpdateToRec: true,
+		},
+		{
+			name:              "current + next + receiver set, next reached, receiver reached",
+			curSet:            true,
+			nextSet:           true,
+			recSet:            true,
+			applied:           rec.lai,
+			expClosed:         rec.ts,
+			expCurUpdateToRec: true,
+			expNextCleared:    true,
+		},
+		// Cases where current is sufficient.
+		{
+			name:       "current set, current sufficient",
+			curSet:     true,
+			applied:    cur.lai,
+			sufficient: cur.ts,
+			expClosed:  cur.ts,
+		},
+		{
+			name:       "current + next set, next not reached, current sufficient",
+			curSet:     true,
+			nextSet:    true,
+			applied:    cur.lai,
+			sufficient: cur.ts,
+			expClosed:  cur.ts,
+		},
+		{
+			name:       "current + next set, next reached, current sufficient",
+			curSet:     true,
+			nextSet:    true,
+			applied:    next.lai,
+			sufficient: cur.ts,
+			expClosed:  cur.ts,
+		},
+		{
+			name:       "current + receiver set, receiver not reached, current sufficient",
+			curSet:     true,
+			recSet:     true,
+			applied:    next.lai,
+			sufficient: cur.ts,
+			expClosed:  cur.ts,
+		},
+		{
+			name:       "current + receiver set, receiver reached, current sufficient",
+			curSet:     true,
+			nextSet:    true,
+			recSet:     true,
+			applied:    rec.lai,
+			sufficient: cur.ts,
+			expClosed:  cur.ts,
+		},
+		{
+			name:       "current + next + receiver set, next not reached, receiver not reached, current sufficient",
+			curSet:     true,
+			nextSet:    true,
+			recSet:     true,
+			applied:    cur.lai,
+			sufficient: cur.ts,
+			expClosed:  cur.ts,
+		},
+		{
+			name:       "current + next + receiver set, next reached, receiver not reached, current sufficient",
+			curSet:     true,
+			nextSet:    true,
+			recSet:     true,
+			applied:    next.lai,
+			sufficient: cur.ts,
+			expClosed:  cur.ts,
+		},
+		{
+			name:       "current + next + receiver set, next reached, receiver reached, current sufficient",
+			curSet:     true,
+			nextSet:    true,
+			recSet:     true,
+			applied:    rec.lai,
+			sufficient: cur.ts,
+			expClosed:  cur.ts,
+		},
+		// Cases where next is sufficient.
+		{
+			name:       "next set, next not reached, next sufficient",
+			nextSet:    true,
+			applied:    cur.lai,
+			sufficient: next.ts,
+			expClosed:  hlc.Timestamp{},
+		},
+		{
+			name:               "next set, next reached, next sufficient",
+			nextSet:            true,
+			applied:            next.lai,
+			sufficient:         next.ts,
+			expClosed:          next.ts,
+			expCurUpdateToNext: true,
+			expNextCleared:     true,
+		},
+		{
+			name:       "current + next set, next not reached, next sufficient",
+			curSet:     true,
+			nextSet:    true,
+			applied:    cur.lai,
+			sufficient: next.ts,
+			expClosed:  cur.ts,
+		},
+		{
+			name:               "current + next set, next reached, next sufficient",
+			curSet:             true,
+			nextSet:            true,
+			applied:            next.lai,
+			sufficient:         next.ts,
+			expClosed:          next.ts,
+			expCurUpdateToNext: true,
+			expNextCleared:     true,
+		},
+		{
+			name:       "next + receiver, next not reached, receiver not reached, next sufficient",
+			nextSet:    true,
+			recSet:     true,
+			applied:    cur.lai,
+			sufficient: next.ts,
+			expClosed:  hlc.Timestamp{},
+		},
+		{
+			name:               "next + receiver, next reached, receiver not reached, next sufficient",
+			nextSet:            true,
+			recSet:             true,
+			applied:            next.lai,
+			sufficient:         next.ts,
+			expClosed:          next.ts,
+			expCurUpdateToNext: true,
+			expNextCleared:     true,
+		},
+		{
+			name:               "next + receiver, next reached, receiver reached, next sufficient",
+			nextSet:            true,
+			recSet:             true,
+			applied:            rec.lai,
+			sufficient:         next.ts,
+			expClosed:          next.ts,
+			expCurUpdateToNext: true,
+			expNextCleared:     true,
+		},
+		{
+			name:       "current + next + receiver set, next not reached, receiver not reached, next sufficient",
+			curSet:     true,
+			nextSet:    true,
+			recSet:     true,
+			applied:    cur.lai,
+			sufficient: next.ts,
+			expClosed:  cur.ts,
+		},
+		{
+			name:               "current + next + receiver set, next reached, receiver not reached, next sufficient",
+			curSet:             true,
+			nextSet:            true,
+			recSet:             true,
+			applied:            next.lai,
+			sufficient:         next.ts,
+			expClosed:          next.ts,
+			expCurUpdateToNext: true,
+			expNextCleared:     true,
+		},
+		{
+			name:               "current + next + receiver set, next reached, receiver reached, next sufficient",
+			curSet:             true,
+			nextSet:            true,
+			recSet:             true,
+			applied:            rec.lai,
+			sufficient:         next.ts,
+			expClosed:          next.ts,
+			expCurUpdateToNext: true,
+			expNextCleared:     true,
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			r := mockReceiver{
-				closed: tc.receiverClosed,
-				lai:    tc.receiverLAI,
-			}
+			require.False(t, tc.expCurUpdateToNext && tc.expCurUpdateToRec)
+			require.False(t, tc.expNextCleared && tc.expNextUpdateToRec)
+
+			var r mockReceiver
 			var s sidetransportAccess
 			s.receiver = &r
-			s.mu.closedTimestamp = tc.localClosed
-			s.mu.lai = tc.localLAI
-			closed := s.get(ctx, roachpb.NodeID(1), tc.applied, tc.sufficient)
-			require.Equal(t, tc.expectedClosed, closed)
-			if tc.expectedLocalUpdate {
-				require.Equal(t, tc.receiverClosed, s.mu.closedTimestamp)
-				require.Equal(t, tc.receiverLAI, s.mu.lai)
-			} else {
-				require.Equal(t, tc.localClosed, s.mu.closedTimestamp)
-				require.Equal(t, tc.localLAI, s.mu.lai)
+			if tc.curSet {
+				s.mu.cur = cur
 			}
+			if tc.nextSet {
+				s.mu.next = next
+			}
+			if tc.recSet {
+				r.closedTimestamp = rec
+			}
+			curOrig, nextOrig := s.mu.cur, s.mu.next
+			closed := s.get(ctx, roachpb.NodeID(1), tc.applied, tc.sufficient)
+			require.Equal(t, tc.expClosed, closed)
+
+			expCur, expNext := curOrig, nextOrig
+			if tc.expCurUpdateToNext {
+				expCur = next
+			} else if tc.expCurUpdateToRec {
+				expCur = rec
+			}
+			if tc.expNextCleared {
+				expNext = closedTimestamp{}
+			} else if tc.expNextUpdateToRec {
+				expNext = rec
+			}
+			require.Equal(t, expCur, s.mu.cur)
+			require.Equal(t, expNext, s.mu.next)
 		})
 	}
 }
 
+// TestSideTransportClosedMonotonic tests that sequential calls to
+// sidetransportAccess.get return monotonically increasing timestamps.
+func TestSideTransportClosedMonotonic(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const testTime = 1 * time.Second
+	ctx := context.Background()
+
+	var truth struct {
+		syncutil.Mutex
+		closedTimestamp
+	}
+	var r mockReceiver
+	var s sidetransportAccess
+	s.receiver = &r
+
+	var g errgroup.Group
+	var done int32
+
+	// Receiver goroutine: periodically modify the true closed timestamp and the
+	// closed timestamp stored in the side transport receiver.
+	g.Go(func() error {
+		for atomic.LoadInt32(&done) == 0 {
+			// Update the truth.
+			truth.Lock()
+			truth.ts = truth.ts.Next()
+			if rand.Intn(2) == 0 {
+				truth.lai++
+			}
+			cur := truth.closedTimestamp
+			truth.Unlock()
+
+			// Optionally update receiver.
+			if rand.Intn(2) == 0 {
+				r.Lock()
+				r.closedTimestamp = cur
+				r.Unlock()
+			}
+
+			// Rarely flush and clear receiver.
+			if rand.Intn(10) == 0 {
+				knownApplied := rand.Intn(2) == 0
+				r.Lock()
+				s.forward(ctx, r.ts, r.lai, knownApplied)
+				r.closedTimestamp = closedTimestamp{}
+				r.Unlock()
+			}
+		}
+		return nil
+	})
+
+	// Observer goroutines: periodically read the closed timestamp from the side
+	// transport access, with small variations in the parameters provided to get.
+	// Regardless of what's provided, two sequential calls should never observe a
+	// regression in the returned timestamp.
+	const observers = 3
+	for i := 0; i < observers; i++ {
+		g.Go(func() error {
+			var lastTS hlc.Timestamp
+			var lastLAI ctpb.LAI
+			for atomic.LoadInt32(&done) == 0 {
+				// Determine which lease applied index to use.
+				var lai ctpb.LAI
+				switch rand.Intn(3) {
+				case 0:
+					lai = lastLAI
+				case 1:
+					lai = lastLAI - 1
+				case 2:
+					truth.Lock()
+					lai = truth.lai
+					truth.Unlock()
+				}
+
+				// Optionally provide a sufficient timestamp.
+				var sufficient hlc.Timestamp
+				if !lastTS.IsEmpty() {
+					switch rand.Intn(4) {
+					case 0:
+					// No sufficient timestamp.
+					case 1:
+						sufficient = lastTS.Prev()
+					case 2:
+						sufficient = lastTS
+					case 3:
+						sufficient = lastTS.Next()
+					}
+				}
+
+				curTS := s.get(ctx, roachpb.NodeID(1), lai, sufficient)
+				if curTS.Less(lastTS) {
+					return errors.Errorf("closed timestamp regression: %s -> %s", lastTS, curTS)
+				}
+
+				lastTS = curTS
+				lastLAI = lai
+			}
+			return nil
+		})
+	}
+
+	time.Sleep(testTime)
+	atomic.StoreInt32(&done, 1)
+	require.NoError(t, g.Wait())
+}
+
 type mockReceiver struct {
-	closed hlc.Timestamp
-	lai    ctpb.LAI
+	syncutil.Mutex
+	closedTimestamp
 }
 
 var _ sidetransportReceiver = &mockReceiver{}
@@ -141,7 +497,9 @@ var _ sidetransportReceiver = &mockReceiver{}
 func (r *mockReceiver) GetClosedTimestamp(
 	ctx context.Context, rangeID roachpb.RangeID, leaseholderNode roachpb.NodeID,
 ) (hlc.Timestamp, ctpb.LAI) {
-	return r.closed, r.lai
+	r.Lock()
+	defer r.Unlock()
+	return r.ts, r.lai
 }
 
 // HTML is part of the sidetransportReceiver interface.
@@ -194,15 +552,14 @@ func TestReplicaClosedTimestampV2(t *testing.T) {
 			stopper := stop.NewStopper()
 			defer stopper.Stop(ctx)
 
-			receiver := &mockReceiver{
-				closed: test.sidetransportClosed,
-				lai:    test.sidetransportLAI,
-			}
+			var r mockReceiver
+			r.ts = test.sidetransportClosed
+			r.lai = test.sidetransportLAI
 			var tc testContext
 			tc.manualClock = hlc.NewManualClock(123) // required by StartWithStoreConfig
 			cfg := TestStoreConfig(hlc.NewClock(tc.manualClock.UnixNano, time.Nanosecond))
 			cfg.TestingKnobs.DontCloseTimestamps = true
-			cfg.ClosedTimestampReceiver = receiver
+			cfg.ClosedTimestampReceiver = &r
 			tc.StartWithStoreConfig(t, stopper, cfg)
 			tc.repl.mu.Lock()
 			tc.repl.mu.state.RaftClosedTimestamp = test.raftClosed


### PR DESCRIPTION
This commit strengthens the guarantees of the `sidetransportAccess`, which now promises that the returned timestamp from its get method will never regress across sequential calls. This is made possible by retaining two closed timestamps in the access - a `cur` closed timestamp that is known to be applied and an optional `next` closed timestamp that is not yet applied. Using two timestamps ensures that we never lose information about an applied closed timestamp, so we can make the stronger guarantee to users of the abstraction that returned timestamp will always increase monotonically across consecutive calls.

This was causing flakiness in tests added in #68194. The property-based tests in that PR were asserting (in one form or another) that after a `QueryResolvedTimestamp` request returns a resolved timestamp, a subsequent read-only request at that timestamp will never block on replication (i.e. the closed timestamp) or on conflicting transactions when executed. These tests were very rarely finding this not to be the case. The reason for this was that it was possible for the `sidetransportAccess` to regress across two sequential calls.

cc. @andreimatei, but not assigning because you're away.