### PR TITLE
rowexec: fix bug in min and max window functions

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -3961,3 +3961,22 @@ SELECT first_value(x) OVER (ORDER BY x RANGE BETWEEN CURRENT ROW AND '0 YEAR'::I
 
 statement ok
 RESET vectorize;
+
+# Regression test for incorrect results for min and max when the window frame
+# shrinks.
+statement ok
+DROP TABLE IF EXISTS t;
+CREATE TABLE t (a INT);
+INSERT INTO t VALUES (1), (-1), (NULL);
+SET vectorize=off;
+
+query III rowsort
+SELECT a, max(a) OVER w, min(a) OVER w FROM t
+WINDOW w AS (ORDER BY a DESC RANGE BETWEEN 10 PRECEDING AND UNBOUNDED FOLLOWING);
+----
+1     1     -1
+-1    1     -1
+NULL  NULL  NULL
+
+statement ok
+RESET vectorize;

--- a/pkg/sql/sem/builtins/window_frame_builtins.go
+++ b/pkg/sql/sem/builtins/window_frame_builtins.go
@@ -69,10 +69,7 @@ func (sw *slidingWindow) add(iv *indexedValue) {
 // indices smaller than given 'idx'. This operation corresponds to shifting the
 // start of the frame up to 'idx'.
 func (sw *slidingWindow) removeAllBefore(idx int) {
-	for i := 0; i < sw.values.Len() && i < idx; i++ {
-		if sw.values.Get(i).(*indexedValue).idx >= idx {
-			break
-		}
+	for sw.values.Len() > 0 && sw.values.Get(0).(*indexedValue).idx < idx {
 		sw.values.RemoveFirst()
 	}
 }


### PR DESCRIPTION
This patch fixes a bug that caused the `min` and `max` window functions
to return incorrect values in some cases when the window frame shrunk
from row to row in the same partition. This occurred because the
sliding window approach for `min` and `max` requires that the aggregate
is stored in a ring buffer that grows and shrinks depending on how the
window frame changes between rows. In particular, the method that was
used to remove values from the buffer could exit early, because the
loop that iterated through values to-be-removed did not account for
the effect of removing a value.

Fixes #68309

Release note (bug fix): Fixed a bug that could cause the `min` and
`max` window functions to return incorrect results when the window
frame for a row was smaller than the frame for the previous row.