### PR TITLE
util/log: use v1 log parser in case it is undefined

### DIFF
--- a/pkg/util/log/log_decoder.go
+++ b/pkg/util/log/log_decoder.go
@@ -21,6 +21,10 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+// fallbackEntryDecoderFormat is used when log file doesn't contain
+// explicit config entry for log format and no format option was specified.
+const fallbackEntryDecoderFormat = "crdb-v1"
+
 // EntryDecoder is used to decode log entries.
 type EntryDecoder interface {
 	Decode(entry *logpb.Entry) error
@@ -55,7 +59,7 @@ func NewEntryDecoderWithFormat(
 			header = header[:n]
 			logFormat, err = getLogFormat(header)
 			if err != nil {
-				return nil, errors.Wrap(err, "decoding format")
+				logFormat = fallbackEntryDecoderFormat
 			}
 		}
 		in = io.MultiReader(&buf, rest)


### PR DESCRIPTION
Previously merge-logs were failing to read file if it doesn't contain
log format config string and no --format command line option was
specified.
This is not convenient as most of logs that require merging  are still
from older versions of cockroach. And for newer versions we should be
able to use config string to autodetect.
This diff changes the behaviour to use crdb-v1 format by default.

Release note: None

Fixes #68278