### PR TITLE
roachtest: use activerecord 6.1.3

### DIFF
--- a/pkg/cmd/roachtest/tests/activerecord.go
+++ b/pkg/cmd/roachtest/tests/activerecord.go
@@ -25,7 +25,7 @@ import (
 var activerecordResultRegex = regexp.MustCompile(`^(?P<test>[^\s]+#[^\s]+) = (?P<timing>\d+\.\d+ s) = (?P<result>.)$`)
 var railsReleaseTagRegex = regexp.MustCompile(`^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)\.?(?P<subpoint>\d*)$`)
 var supportedRailsVersion = "6.1"
-var activerecordAdapterVersion = "v6.1.2"
+var activerecordAdapterVersion = "v6.1.3"
 
 // This test runs activerecord's full test suite against a single cockroach node.
 


### PR DESCRIPTION
This should resolve the failure where the test cannot run right now.

fixes https://github.com/cockroachdb/cockroach/issues/66827

Release note: None