### PR TITLE
server,tracedumper: reducing logging when failing to create dumper

### DIFF
--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -300,10 +300,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		if cfg.TestingKnobs.JobsTestingKnobs != nil {
 			jobsKnobs = cfg.TestingKnobs.JobsTestingKnobs.(*jobs.TestingKnobs)
 		}
-		td, err := tracedumper.NewTraceDumper(ctx, cfg.InflightTraceDirName, cfg.Settings)
-		if err != nil {
-			log.Errorf(ctx, "failed to initialize trace dumper: %+v", err)
-		}
+		td := tracedumper.NewTraceDumper(ctx, cfg.InflightTraceDirName, cfg.Settings)
 		*jobRegistry = *jobs.MakeRegistry(
 			cfg.AmbientCtx,
 			cfg.stopper,

--- a/pkg/server/tracedumper/tracedumper.go
+++ b/pkg/server/tracedumper/tracedumper.go
@@ -111,9 +111,10 @@ func (t *TraceDumper) Dump(
 // NewTraceDumper returns a TraceDumper.
 //
 // dir is the directory in which dumps are stored.
-func NewTraceDumper(ctx context.Context, dir string, st *cluster.Settings) (*TraceDumper, error) {
+func NewTraceDumper(ctx context.Context, dir string, st *cluster.Settings) *TraceDumper {
 	if dir == "" {
-		return nil, errors.New("directory to store dumps could not be determined")
+		log.Warning(ctx, "not collecting trace dumps since dump directory is not specified")
+		return nil
 	}
 
 	log.Infof(ctx, "writing job trace dumps to %s", dir)
@@ -122,5 +123,5 @@ func NewTraceDumper(ctx context.Context, dir string, st *cluster.Settings) (*Tra
 		currentTime: timeutil.Now,
 		store:       dumpstore.NewStore(dir, totalDumpSizeLimit, st),
 	}
-	return td, nil
+	return td
 }


### PR DESCRIPTION
A trace dumper may fail to be created during tests when the directory to
which the dumps should be written is not specified. Instead of emitting
a verbose log, emit a warning the traces will not be dumped.

Release note: None