### PR TITLE
util/quotapool: fix flakey TestRateLimiterBasic

### DIFF
--- a/pkg/util/quotapool/BUILD.bazel
+++ b/pkg/util/quotapool/BUILD.bazel
@@ -35,7 +35,6 @@ go_test(
     embed = [":quotapool"],
     deps = [
         "//pkg/testutils",
-        "//pkg/testutils/skip",
         "//pkg/util/ctxgroup",
         "//pkg/util/leaktest",
         "//pkg/util/timeutil",


### PR DESCRIPTION
The test had a race where the updated timer calculation would happen after
the advancing of the time, which was not the intention of the test. The
flake is fixed by waiting for the update calculation to propagate to the
waiting goroutine before advancing time.

Fixes #63823.

Release note: None