### PR TITLE
importccl: use unique ID for export file naming

### DIFF
--- a/pkg/ccl/importccl/BUILD.bazel
+++ b/pkg/ccl/importccl/BUILD.bazel
@@ -62,6 +62,7 @@ go_library(
         "//pkg/sql/row",
         "//pkg/sql/rowenc",
         "//pkg/sql/rowexec",
+        "//pkg/sql/sem/builtins",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/sql/sqltelemetry",

--- a/pkg/ccl/importccl/exportcsv_test.go
+++ b/pkg/ccl/importccl/exportcsv_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -37,6 +38,8 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/require"
 )
+
+const exportFilePattern = "export*-n*.0.csv"
 
 func setupExportableBank(t *testing.T, nodes, rows int) (*sqlutils.SQLRunner, string, func()) {
 	ctx := context.Background()
@@ -147,11 +150,11 @@ func TestExportNullWithEmptyNullAs(t *testing.T) {
 	// Case when `nullas` option is specified: operation is successful and NULLs are encoded to "None"
 	const stmtWithNullas = `EXPORT INTO CSV 'nodelocal://0/t' WITH nullas="None" FROM SELECT * FROM accounts`
 	db.Exec(t, stmtWithNullas)
-	contents := readFileByGlob(t, filepath.Join(dir, "t", "export*-n1.0.csv"))
+	contents := readFileByGlob(t, filepath.Join(dir, "t", exportFilePattern))
 	require.Equal(t, "1,None\n2,8\n", string(contents))
 
 	// Verify successful IMPORT statement `WITH nullif="None"` to complete round trip
-	const importStmt = `IMPORT TABLE accounts2(id INT PRIMARY KEY, balance INT) CSV DATA ('nodelocal://0/t/export*-n1.0.csv') WITH nullif="None"`
+	const importStmt = `IMPORT TABLE accounts2(id INT PRIMARY KEY, balance INT) CSV DATA ('nodelocal://0/t/export*-n*.0.csv') WITH nullif="None"`
 	db.Exec(t, importStmt)
 	db.CheckQueryResults(t,
 		"SELECT * FROM accounts2", db.QueryStr(t, "SELECT * FROM accounts"),
@@ -252,7 +255,7 @@ func TestExportOrder(t *testing.T) {
 	sqlDB.Exec(t, `INSERT INTO foo VALUES (1, 12, 3, 14), (2, 22, 2, 24), (3, 32, 1, 34)`)
 
 	sqlDB.Exec(t, `EXPORT INTO CSV 'nodelocal://0/order' FROM SELECT * FROM foo ORDER BY y ASC LIMIT 2`)
-	content := readFileByGlob(t, filepath.Join(dir, "order", "export*-n1.0.csv"))
+	content := readFileByGlob(t, filepath.Join(dir, "order", exportFilePattern))
 
 	if expected, got := "3,32,1,34\n2,22,2,24\n", string(content); expected != got {
 		t.Fatalf("expected %q, got %q", expected, got)
@@ -330,7 +333,7 @@ INSERT INTO greeting_table VALUES ('hello', 'hello'), ('hi', 'hi');
 		sqlDB.Exec(t, stmt)
 
 		// Read the dumped file.
-		contents := readFileByGlob(t, filepath.Join(dir, path, "export*-n1.0.csv"))
+		contents := readFileByGlob(t, filepath.Join(dir, path, exportFilePattern))
 
 		require.Equal(t, test.expected, string(contents))
 	}
@@ -356,7 +359,7 @@ func TestExportOrderCompressed(t *testing.T) {
 	sqlDB.Exec(t, `INSERT INTO foo VALUES (1, 12, 3, 14), (2, 22, 2, 24), (3, 32, 1, 34)`)
 
 	sqlDB.Exec(t, `EXPORT INTO CSV 'nodelocal://0/order' with compression = gzip from select * from foo order by y asc limit 2`)
-	compressed := readFileByGlob(t, filepath.Join(dir, "order", "export*-n1.0.csv.gz"))
+	compressed := readFileByGlob(t, filepath.Join(dir, "order", exportFilePattern+".gz"))
 
 	gzipReader, err := gzip.NewReader(bytes.NewReader(compressed))
 	defer close(gzipReader)
@@ -384,7 +387,7 @@ func TestExportShow(t *testing.T) {
 	sqlDB := sqlutils.MakeSQLRunner(db)
 
 	sqlDB.Exec(t, `EXPORT INTO CSV 'nodelocal://0/show' FROM SELECT database_name, owner FROM [SHOW DATABASES] ORDER BY database_name`)
-	content := readFileByGlob(t, filepath.Join(dir, "show", "export*-n1.0.csv"))
+	content := readFileByGlob(t, filepath.Join(dir, "show", exportFilePattern))
 
 	if expected, got := "defaultdb,"+security.RootUser+"\npostgres,"+security.RootUser+"\nsystem,"+
 		security.NodeUser+"\n", string(content); expected != got {
@@ -507,4 +510,30 @@ func TestExportTargetFileSizeSetting(t *testing.T) {
 	zipFiles, err := ioutil.ReadDir(filepath.Join(dir, "foo-compressed"))
 	require.NoError(t, err)
 	require.GreaterOrEqual(t, len(zipFiles), 6)
+}
+
+func TestExportInsideTenant(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	dir, cleanupDir := testutils.TempDir(t)
+	defer cleanupDir()
+
+	srv, _, _ := serverutils.StartServer(t, base.TestServerArgs{ExternalIODir: dir})
+	defer srv.Stopper().Stop(context.Background())
+
+	_, conn10 := serverutils.StartTenant(t, srv, base.TestTenantArgs{TenantID: roachpb.MakeTenantID(10)})
+	defer conn10.Close()
+	tenant10 := sqlutils.MakeSQLRunner(conn10)
+
+	tenant10.Exec(t, `CREATE TABLE foo (i INT PRIMARY KEY, x INT, y INT, z INT, INDEX (y))`)
+	tenant10.Exec(t, `INSERT INTO foo VALUES (1, 12, 3, 14), (2, 22, 2, 24), (3, 32, 1, 34)`)
+
+	tenant10.Exec(t, `EXPORT INTO CSV 'userfile:///order' FROM SELECT * FROM foo ORDER BY y ASC LIMIT 2`)
+	csvFileIDs := tenant10.QueryStr(t, `SELECT file_id FROM userfiles_root_upload_files WHERE filename LIKE '%csv'`)
+	require.Len(t, csvFileIDs, 1)
+	filePayloads := tenant10.QueryStr(t, `
+SELECT payload FROM userfiles_root_upload_payload WHERE file_id = $1`, csvFileIDs[0][0])
+	require.Len(t, filePayloads, 1)
+
+	require.Equal(t, filePayloads[0][0], "3,32,1,34\n2,22,2,24\n")
 }

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -2597,19 +2597,19 @@ func TestExportImportRoundTrip(t *testing.T) {
 		// with a unique directory name per run.
 		{
 			stmts: `EXPORT INTO CSV 'nodelocal://0/%[1]s' FROM SELECT ARRAY['a', 'b', 'c'];
-							IMPORT TABLE t (x TEXT[]) CSV DATA ('nodelocal://0/%[1]s/export*-n1.0.csv')`,
+							IMPORT TABLE t (x TEXT[]) CSV DATA ('nodelocal://0/%[1]s/export*-n*.0.csv')`,
 			tbl:      "t",
 			expected: `SELECT ARRAY['a', 'b', 'c']`,
 		},
 		{
 			stmts: `EXPORT INTO CSV 'nodelocal://0/%[1]s' FROM SELECT ARRAY[b'abc', b'\141\142\143', b'\x61\x62\x63'];
-							IMPORT TABLE t (x BYTES[]) CSV DATA ('nodelocal://0/%[1]s/export*-n1.0.csv')`,
+							IMPORT TABLE t (x BYTES[]) CSV DATA ('nodelocal://0/%[1]s/export*-n*.0.csv')`,
 			tbl:      "t",
 			expected: `SELECT ARRAY[b'abc', b'\141\142\143', b'\x61\x62\x63']`,
 		},
 		{
 			stmts: `EXPORT INTO CSV 'nodelocal://0/%[1]s' FROM SELECT 'dog' COLLATE en;
-							IMPORT TABLE t (x STRING COLLATE en) CSV DATA ('nodelocal://0/%[1]s/export*-n1.0.csv')`,
+							IMPORT TABLE t (x STRING COLLATE en) CSV DATA ('nodelocal://0/%[1]s/export*-n*.0.csv')`,
 			tbl:      "t",
 			expected: `SELECT 'dog' COLLATE en`,
 		},


### PR DESCRIPTION
Previously, EXPORT would name its files based on the node ID the export
processor was running. This could be problematic if multiple exports are
running on the same node (and writing to the same directory). This
commit replaces the node ID with a unique identifier (generated based on
the instance ID).

As a side-effect this also enables tenants to use EXPORT.
Fixes https://github.com/cockroachdb/cockroach/issues/67878.

Release note (bug fix): Fix a bug in EXPORT where concurrent exports
could overwrite eachother.