### PR TITLE
settings: retire sql.defaults.optimizer_improve_disjunction_selectivity.enabled

### DIFF
--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -90,16 +90,17 @@ var retiredSettings = map[string]struct{}{
 	"kv.tenant_rate_limiter.write_bytes.burst_limit":    {},
 
 	// removed as of 21.2.
-	"sql.defaults.vectorize_row_count_threshold":                 {},
-	"cloudstorage.gs.default.key":                                {},
-	"storage.sst_export.max_intents_per_error":                   {},
-	"jobs.registry.leniency":                                     {},
-	"sql.defaults.experimental_expression_based_indexes.enabled": {},
-	"kv.tenant_rate_limiter.read_request_cost":                   {},
-	"kv.tenant_rate_limiter.read_cost_per_megabyte":              {},
-	"kv.tenant_rate_limiter.write_request_cost":                  {},
-	"kv.tenant_rate_limiter.write_cost_per_megabyte":             {},
-	"kv.transaction.write_pipelining_max_outstanding_size":       {},
+	"sql.defaults.vectorize_row_count_threshold":                     {},
+	"cloudstorage.gs.default.key":                                    {},
+	"storage.sst_export.max_intents_per_error":                       {},
+	"jobs.registry.leniency":                                         {},
+	"sql.defaults.experimental_expression_based_indexes.enabled":     {},
+	"kv.tenant_rate_limiter.read_request_cost":                       {},
+	"kv.tenant_rate_limiter.read_cost_per_megabyte":                  {},
+	"kv.tenant_rate_limiter.write_request_cost":                      {},
+	"kv.tenant_rate_limiter.write_cost_per_megabyte":                 {},
+	"kv.transaction.write_pipelining_max_outstanding_size":           {},
+	"sql.defaults.optimizer_improve_disjunction_selectivity.enabled": {},
 }
 
 // register adds a setting to the registry.


### PR DESCRIPTION
This commit marks the
`sql.defaults.optimizer_improve_disjunction_selectivity.enabled` cluster
setting as retired in 21.2. The setting was added in #67836 to gate new
logic behind a feature flag. The logic it gates is always enabled on the
main branch after the release-21.1 fork.

Release note (sql change): The session setting
`optimizer_improve_disjunction_selectivity` and its associated cluster
setting `sql.defaults.optimizer_improve_disjunction_selectivity.enabled`
are no longer supported. They were added in version 21.1.7 to enable
better optimizer selectivity calculations for disjunctions. This logic
is now always enabled.