### PR TITLE
release-21.1: colexec: fix LIKE operators when patterns have escape characters

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -1195,3 +1195,12 @@ SELECT b FROM t66706@u WHERE NOT (b = 'foo')
 ----
 bar
 bar
+
+# Regression test for ignoring the escaping in the LIKE pattern (#68040).
+statement ok
+CREATE TABLE t68040 (c) AS SELECT 'string with \ backslash'
+
+query T
+SELECT c FROM t68040 WHERE c LIKE '%\\%'
+----
+string with \ backslash


### PR DESCRIPTION
Backport 1/2 commits from #68289.

/cc @cockroachdb/release

Release justification: low risk bug fix.

---

**colexec: fix LIKE operators when patterns have escape characters**

Fixes: #68040.

Release note (bug fix): Previously, CockroachDB could incorrectly
evaluate LIKE expressions when the pattern contained the escape
characters `\` if the expressions were executed via the vectorized
engine.