### PR TITLE
release-20.2: colexec: fix LIKE operators when patterns have escape characters

### DIFF
--- a/pkg/sql/colexec/like_ops.go
+++ b/pkg/sql/colexec/like_ops.go
@@ -52,10 +52,19 @@ func getLikeOperatorType(pattern string, negate bool) (likeOpType, string, error
 		}
 		return likeAlwaysMatch, "", nil
 	}
-	if len(pattern) > 1 && !strings.ContainsAny(pattern[1:len(pattern)-1], "_%") {
-		// There are no wildcards in the middle of the string, so we only need to
-		// use a regular expression if both the first and last characters are
+	hasEscape := strings.Contains(pattern, `\`)
+	if len(pattern) > 1 && !strings.ContainsAny(pattern[1:len(pattern)-1], "_%") && !hasEscape {
+		// There are no wildcards in the middle of the string as well as no
+		// escape characters in the whole string, so we only need to use a
+		// regular expression if both the first and last characters are
 		// wildcards.
+		//
+		// The presence of the escape characters breaks the assumptions of the
+		// optimized versions since we no longer could just use the string for a
+		// direct match - we'd need to do some preprocessing here to remove the
+		// escape characters.
+		// TODO(yuzefovich): add that preprocessing (for example, `\\` needs to
+		// be replaced with `\`).
 		firstChar := pattern[0]
 		lastChar := pattern[len(pattern)-1]
 		if !isWildcard(firstChar) && !isWildcard(lastChar) {

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -1323,3 +1323,14 @@ bar
 
 statement ok
 RESET vectorize
+
+# Regression test for ignoring the escaping in the LIKE pattern (#68040).
+statement ok
+RESET vectorize;
+CREATE TABLE t68040 (c) AS SELECT 'string with \ backslash';
+SET vectorize = experimental_always
+
+query T
+SELECT c FROM t68040 WHERE c LIKE '%\\%'
+----
+string with \ backslash


### PR DESCRIPTION
Backport 1/2 commits from #68289.

/cc @cockroachdb/release

Release justification: low risk bug fix.

---

**colexec: fix LIKE operators when patterns have escape characters**

Fixes: #68040.

Release note (bug fix): Previously, CockroachDB could incorrectly
evaluate LIKE expressions when the pattern contained the escape
characters `\` if the expressions were executed via the vectorized
engine.