### PR TITLE
server: initialize trace dumper conditionally

### DIFF
--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -301,10 +301,8 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		if cfg.TestingKnobs.JobsTestingKnobs != nil {
 			jobsKnobs = cfg.TestingKnobs.JobsTestingKnobs.(*jobs.TestingKnobs)
 		}
-		td, err := tracedumper.NewTraceDumper(ctx, cfg.InflightTraceDirName, cfg.Settings)
-		if err != nil {
-			log.Errorf(ctx, "failed to initialize trace dumper: %+v", err)
-		}
+
+		td := tracedumper.NewTraceDumper(ctx, cfg.InflightTraceDirName, cfg.Settings)
 		*jobRegistry = *jobs.MakeRegistry(
 			cfg.AmbientCtx,
 			cfg.stopper,

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -256,6 +256,9 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 			if cfg.GoroutineDumpDirName == "" {
 				cfg.GoroutineDumpDirName = filepath.Join(storeSpec.Path, "logs", base.GoroutineDumpDir)
 			}
+			if cfg.InflightTraceDirName == "" {
+				cfg.InflightTraceDirName = filepath.Join(storeSpec.Path, "logs", base.InflightTraceDir)
+			}
 		}
 	}
 	cfg.Stores = base.StoreSpecList{Specs: params.StoreSpecs}

--- a/pkg/server/tracedumper/tracedumper.go
+++ b/pkg/server/tracedumper/tracedumper.go
@@ -111,9 +111,9 @@ func (t *TraceDumper) Dump(
 // NewTraceDumper returns a TraceDumper.
 //
 // dir is the directory in which dumps are stored.
-func NewTraceDumper(ctx context.Context, dir string, st *cluster.Settings) (*TraceDumper, error) {
+func NewTraceDumper(ctx context.Context, dir string, st *cluster.Settings) *TraceDumper {
 	if dir == "" {
-		return nil, errors.New("directory to store dumps could not be determined")
+		return nil
 	}
 
 	log.Infof(ctx, "writing job trace dumps to %s", dir)
@@ -122,5 +122,5 @@ func NewTraceDumper(ctx context.Context, dir string, st *cluster.Settings) (*Tra
 		currentTime: timeutil.Now,
 		store:       dumpstore.NewStore(dir, totalDumpSizeLimit, st),
 	}
-	return td, nil
+	return td
 }


### PR DESCRIPTION
This change ensures that a trace dumper is initialized only
if the corresponding trace dump directory was configured when
setting up logging, during node start.

Fixes: #68356

Release note: None