### PR TITLE
release-21.1: roachtest: fix acceptance/multitenant

### DIFF
--- a/pkg/cmd/roachtest/multitenant_upgrade.go
+++ b/pkg/cmd/roachtest/multitenant_upgrade.go
@@ -108,7 +108,7 @@ func (tn *tenantNode) start(ctx context.Context, t *test, c *cluster, binary str
 		select {
 		case <-ctx.Done():
 			t.Fatal(ctx.Err())
-		case <-tn.errCh:
+		case err := <-tn.errCh:
 			t.Fatal(err)
 		default:
 		}


### PR DESCRIPTION
Backport 1/1 commits from #67796.

Release justification: test fix.

/cc @cockroachdb/release

---

Or make it fail reliably, we will see in CI. Either way, we were passing
the wrong `err` object to `t.Fatal` and that is now fixed.

Closes #66803.

Release note: None

