### PR TITLE
roachtest: fix node range of connection_latency test

### DIFF
--- a/pkg/cmd/roachtest/tests/connection_latency.go
+++ b/pkg/cmd/roachtest/tests/connection_latency.go
@@ -107,7 +107,7 @@ func runConnectionLatencyTest(
 		runWorkload(loadGroups[2].roachNodes, cockroachEuWest, regionEuWest)
 	} else {
 		// Run only on the load node.
-		runWorkload(c.Range(0, numNodes), c.Node(numNodes+1), regionUsCentral)
+		runWorkload(c.Range(1, numNodes), c.Node(numNodes+1), regionUsCentral)
 	}
 }
 


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/68364

They are 1-indexed, not 0-indexed.

Release note: None