### PR TITLE
jobs: fix race which permitted concurrent execution

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -2984,7 +2984,7 @@ func TestBackupRestoreDuringUserDefinedTypeChange(t *testing.T) {
 				ServerArgs: base.TestServerArgs{
 					Knobs: base.TestingKnobs{
 						SQLTypeSchemaChanger: &sql.TypeSchemaChangerTestingKnobs{
-							RunBeforeEnumMemberPromotion: func() error {
+							RunBeforeEnumMemberPromotion: func(context.Context) error {
 								mu.Lock()
 								if numTypeChangesStarted < len(tc.queries) {
 									numTypeChangesStarted++

--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -168,6 +168,7 @@ go_test(
         "//pkg/server/status",
         "//pkg/server/telemetry",
         "//pkg/settings/cluster",
+        "//pkg/spanconfig",
         "//pkg/sql",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/catalogkv",

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -3177,6 +3177,7 @@ func TestChangefeedProtectedTimestamps(t *testing.T) {
 				select {
 				case <-waitUntilClosed:
 				case <-done:
+				case <-ctx.Done():
 				}
 			default:
 			}
@@ -3286,11 +3287,10 @@ func TestChangefeedProtectedTimestamps(t *testing.T) {
 				// canceled.
 				waitForBlocked = requestBlockedScan()
 				sqlDB.Exec(t, `ALTER TABLE foo ADD COLUMN d INT NOT NULL DEFAULT 2`)
-				unblock := waitForBlocked()
+				_ = waitForBlocked()
 				waitForRecord()
 				sqlDB.Exec(t, `CANCEL JOB $1`, foo.(cdctest.EnterpriseTestFeed).JobID())
 				waitForNoRecord()
-				unblock()
 			}
 		}, feedTestNoTenants, withArgsFn(func(args *base.TestServerArgs) {
 			storeKnobs := &kvserver.StoreTestingKnobs{}

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -326,6 +327,7 @@ func startTestFullServer(
 	knobs := base.TestingKnobs{
 		DistSQL:          &execinfra.TestingKnobs{Changefeed: &TestingKnobs{}},
 		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+		SpanConfig:       &spanconfig.TestingKnobs{ManagerDisableJobCreation: true},
 	}
 	if options.knobsFn != nil {
 		options.knobsFn(&knobs)

--- a/pkg/ccl/multiregionccl/region_test.go
+++ b/pkg/ccl/multiregionccl/region_test.go
@@ -9,6 +9,7 @@
 package multiregionccl_test
 
 import (
+	"context"
 	"sort"
 	"strings"
 	"testing"
@@ -119,7 +120,7 @@ func TestConcurrentAddDropRegions(t *testing.T) {
 
 			knobs := base.TestingKnobs{
 				SQLTypeSchemaChanger: &sql.TypeSchemaChangerTestingKnobs{
-					RunBeforeEnumMemberPromotion: func() error {
+					RunBeforeEnumMemberPromotion: func(context.Context) error {
 						mu.Lock()
 						if firstOp {
 							firstOp = false
@@ -258,7 +259,7 @@ func TestRegionAddDropEnclosingRegionalByRowOps(t *testing.T) {
 
 				knobs := base.TestingKnobs{
 					SQLTypeSchemaChanger: &sql.TypeSchemaChangerTestingKnobs{
-						RunBeforeEnumMemberPromotion: func() error {
+						RunBeforeEnumMemberPromotion: func(ctx context.Context) error {
 							mu.Lock()
 							defer mu.Unlock()
 							close(typeChangeStarted)
@@ -383,7 +384,7 @@ ALTER TABLE db.public.global CONFIGURE ZONE USING
 
 			knobs := base.TestingKnobs{
 				SQLTypeSchemaChanger: &sql.TypeSchemaChangerTestingKnobs{
-					RunBeforeEnumMemberPromotion: func() error {
+					RunBeforeEnumMemberPromotion: func(context.Context) error {
 						close(regionOpStarted)
 						<-placementOpFinished
 						return nil
@@ -444,7 +445,7 @@ func TestSettingPrimaryRegionAmidstDrop(t *testing.T) {
 	dropRegionFinished := make(chan struct{})
 	knobs := base.TestingKnobs{
 		SQLTypeSchemaChanger: &sql.TypeSchemaChangerTestingKnobs{
-			RunBeforeEnumMemberPromotion: func() error {
+			RunBeforeEnumMemberPromotion: func(context.Context) error {
 				mu.Lock()
 				defer mu.Unlock()
 				if dropRegionStarted != nil {
@@ -845,7 +846,7 @@ func TestRegionAddDropWithConcurrentBackupOps(t *testing.T) {
 
 				backupKnobs := base.TestingKnobs{
 					SQLTypeSchemaChanger: &sql.TypeSchemaChangerTestingKnobs{
-						RunBeforeEnumMemberPromotion: func() error {
+						RunBeforeEnumMemberPromotion: func(ctx context.Context) error {
 							mu.Lock()
 							defer mu.Unlock()
 							if waitInTypeSchemaChangerDuringBackup {
@@ -902,7 +903,7 @@ INSERT INTO db.rbr VALUES (1,1),(2,2),(3,3);
 
 				restoreKnobs := base.TestingKnobs{
 					SQLTypeSchemaChanger: &sql.TypeSchemaChangerTestingKnobs{
-						RunBeforeEnumMemberPromotion: func() error {
+						RunBeforeEnumMemberPromotion: func(context.Context) error {
 							mu.Lock()
 							defer mu.Unlock()
 							if !regionAlterCmd.shouldSucceed {

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -862,7 +862,7 @@ func (j *Job) getRunStats() (rs RunStats) {
 // and nothing will be send on errCh. Clients must not start jobs more than
 // once.
 func (sj *StartableJob) Start(ctx context.Context) (err error) {
-	if starts := atomic.AddInt64(&sj.starts, 1); starts != 1 {
+	if alreadyStarted := sj.recordStart(); alreadyStarted {
 		return errors.AssertionFailedf(
 			"StartableJob %d cannot be started more than once", sj.ID())
 	}
@@ -960,8 +960,19 @@ func (sj *StartableJob) CleanupOnRollback(ctx context.Context) error {
 // Cancel will mark the job as canceled and release its resources in the
 // Registry.
 func (sj *StartableJob) Cancel(ctx context.Context) error {
-	defer sj.registry.unregister(sj.ID())
+	alreadyStarted := sj.recordStart() // prevent future start attempts
+	defer func() {
+		if alreadyStarted {
+			sj.registry.cancelRegisteredJobContext(sj.ID())
+		} else {
+			sj.registry.unregister(sj.ID())
+		}
+	}()
 	return sj.registry.CancelRequested(ctx, nil, sj.ID())
+}
+
+func (sj *StartableJob) recordStart() (alreadyStarted bool) {
+	return atomic.AddInt64(&sj.starts, 1) != 1
 }
 
 // FormatRetriableExecutionErrorLogToStringArray extracts the events

--- a/pkg/sql/type_change.go
+++ b/pkg/sql/type_change.go
@@ -180,7 +180,7 @@ type TypeSchemaChangerTestingKnobs struct {
 	RunBeforeExec func() error
 	// RunBeforeEnumMemberPromotion runs before enum members are promoted from
 	// readable to all permissions in the typeSchemaChanger.
-	RunBeforeEnumMemberPromotion func() error
+	RunBeforeEnumMemberPromotion func(ctx context.Context) error
 	// RunAfterOnFailOrCancel runs after OnFailOrCancel completes, if
 	// OnFailOrCancel is triggered.
 	RunAfterOnFailOrCancel func() error
@@ -272,7 +272,7 @@ func (t *typeSchemaChanger) exec(ctx context.Context) error {
 		typeDesc.GetKind() == descpb.TypeDescriptor_MULTIREGION_ENUM) &&
 		len(t.transitioningMembers) != 0 {
 		if fn := t.execCfg.TypeSchemaChangerTestingKnobs.RunBeforeEnumMemberPromotion; fn != nil {
-			if err := fn(); err != nil {
+			if err := fn(ctx); err != nil {
 				return err
 			}
 		}

--- a/pkg/util/tracing/collector/collector.go
+++ b/pkg/util/tracing/collector/collector.go
@@ -87,11 +87,12 @@ type Iterator struct {
 
 // StartIter fetches the live nodes in the cluster, and configures the underlying
 // Iterator that is used to access recorded spans in a streaming fashion.
-func (t *TraceCollector) StartIter(ctx context.Context, traceID uint64) *Iterator {
+func (t *TraceCollector) StartIter(ctx context.Context, traceID uint64) (*Iterator, error) {
 	tc := &Iterator{ctx: ctx, traceID: traceID, collector: t}
-	tc.liveNodes, tc.iterErr = nodesFromNodeLiveness(ctx, t.nodeliveness)
-	if tc.iterErr != nil {
-		return nil
+	var err error
+	tc.liveNodes, err = nodesFromNodeLiveness(ctx, t.nodeliveness)
+	if err != nil {
+		return nil, err
 	}
 
 	// Calling Next() positions the Iterator in a valid state. It will fetch the
@@ -99,7 +100,7 @@ func (t *TraceCollector) StartIter(ctx context.Context, traceID uint64) *Iterato
 	// nodes.
 	tc.Next()
 
-	return tc
+	return tc, nil
 }
 
 // Valid returns whether the Iterator is in a valid state to read values from.

--- a/pkg/util/tracing/collector/collector_test.go
+++ b/pkg/util/tracing/collector/collector_test.go
@@ -133,10 +133,12 @@ func TestTracingCollectorGetSpanRecordings(t *testing.T) {
 		res := make(map[roachpb.NodeID][]tracing.Recording)
 
 		var iter *collector.Iterator
-		for iter = traceCollector.StartIter(ctx, traceID); iter.Valid(); iter.Next() {
+		var err error
+		for iter, err = traceCollector.StartIter(ctx, traceID); err == nil && iter.Valid(); iter.Next() {
 			nodeID, recording := iter.Value()
 			res[nodeID] = append(res[nodeID], recording)
 		}
+		require.NoError(t, err)
 		require.NoError(t, iter.Error())
 		return res
 	}


### PR DESCRIPTION
The race was that we'd unregister a job from the `adoptedJobs` map while
processing the pause or cancel requests. This is problematic because the
job also unregisters itself in such cases. However, because the job was
already unregistered, the entry which the now canceled job removes may in
fact correspond to a new execution. We remove this hazard by centralizing
the location where the entry is actually removed. Instead, we have the
cancelation/pause processing only cancel the context of the relevant
execution.

Fixes #68593

Release note: None

Release justification: bug fixes and low-risk updates to new functionality

Previously, TraceCollector.StartIter would return a nil object
if we failed to resolve nodeliveness during initialization. This
led to a NPE.

This change now return a TraceCollector instance with the error field
set to the appropriate error, so that the validity check on the iterator
can correctly handle this scenario.

This change also reworks the dump trace on job cancellation test.
Job cancellation semantics under stress are slightly indeterministic in
terms of how many times the execution of OnFailOrCancel is resumed. This makes
it hard to coordinate when to check and how many trace files to expect.

Fixes: #68315

Release note: None

Release justification: low risk, high benefit changes to existing functionality