### PR TITLE
sql: fix comment reparse error

### DIFF
--- a/pkg/sql/parser/testdata/comment
+++ b/pkg/sql/parser/testdata/comment
@@ -4,8 +4,7 @@ COMMENT ON COLUMN a.b IS 'a'
 ----
 COMMENT ON COLUMN a.b IS 'a'
 (COMMENT ON COLUMN (a.b) IS 'a') -- fully parenthesized
-COMMENT ON COLUMN a.b IS _ -- literals removed
-REPARSE WITHOUT LITERALS FAILS: at or near "_": syntax error
+COMMENT ON COLUMN a.b IS '_' -- literals removed
 COMMENT ON COLUMN _._ IS 'a' -- identifiers removed
 
 parse
@@ -21,8 +20,7 @@ COMMENT ON COLUMN a.b.c IS 'a'
 ----
 COMMENT ON COLUMN a.b.c IS 'a'
 (COMMENT ON COLUMN (a.b.c) IS 'a') -- fully parenthesized
-COMMENT ON COLUMN a.b.c IS _ -- literals removed
-REPARSE WITHOUT LITERALS FAILS: at or near "_": syntax error
+COMMENT ON COLUMN a.b.c IS '_' -- literals removed
 COMMENT ON COLUMN _._._ IS 'a' -- identifiers removed
 
 parse
@@ -30,8 +28,7 @@ COMMENT ON COLUMN a.b.c.d IS 'a'
 ----
 COMMENT ON COLUMN a.b.c.d IS 'a'
 (COMMENT ON COLUMN (a.b.c.d) IS 'a') -- fully parenthesized
-COMMENT ON COLUMN a.b.c.d IS _ -- literals removed
-REPARSE WITHOUT LITERALS FAILS: at or near "_": syntax error
+COMMENT ON COLUMN a.b.c.d IS '_' -- literals removed
 COMMENT ON COLUMN _._._._ IS 'a' -- identifiers removed
 
 parse

--- a/pkg/sql/sem/tree/comment_on_column.go
+++ b/pkg/sql/sem/tree/comment_on_column.go
@@ -27,7 +27,7 @@ func (n *CommentOnColumn) Format(ctx *FmtCtx) {
 		// TODO(knz): Replace all this with ctx.FormatNode
 		// when COMMENT supports expressions.
 		if ctx.flags.HasFlags(FmtHideConstants) {
-			ctx.WriteByte('_')
+			ctx.WriteString("'_'")
 		} else {
 			lexbase.EncodeSQLStringWithFlags(&ctx.Buffer, *n.Comment, ctx.flags.EncodeFlags())
 		}


### PR DESCRIPTION
Related to: #60722

Comment statement was dealing with reparse issues due
to string syntax. This change alters the comment statements
format function.

Release note: None