### PR TITLE
ci: enlarge boot disks for `roachtest` clusters from 10GiB->32GiB

### DIFF
--- a/build/teamcity-roachtest-invoke.sh
+++ b/build/teamcity-roachtest-invoke.sh
@@ -8,6 +8,7 @@ bin/roachtest run \
   --teamcity \
   --roachprod="${PWD}/bin/roachprod" \
   --workload="${PWD}/bin/workload" \
+  --create-args=--os-volume-size=32 \
   "$@"
 code=$?
 set -e


### PR DESCRIPTION
These tests are sometimes failing due to running out of storage space on
the `roachprod` clusters used by `roachtest` (see #68166). Try to
resolve it by bumping up the size of the boot disks.

Release note: None