### PR TITLE
release-21.1: roachtest: use activerecord 6.1.3

### DIFF
--- a/pkg/cmd/roachtest/activerecord.go
+++ b/pkg/cmd/roachtest/activerecord.go
@@ -21,7 +21,7 @@ import (
 var activerecordResultRegex = regexp.MustCompile(`^(?P<test>[^\s]+#[^\s]+) = (?P<timing>\d+\.\d+ s) = (?P<result>.)$`)
 var railsReleaseTagRegex = regexp.MustCompile(`^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)\.?(?P<subpoint>\d*)$`)
 var supportedRailsVersion = "6.1"
-var activerecordAdapterVersion = "v6.1.2"
+var activerecordAdapterVersion = "v6.1.3"
 
 // This test runs activerecord's full test suite against a single cockroach node.
 


### PR DESCRIPTION
Backport 1/1 commits from #68329 

/cc @cockroachdb/release

Release justification: test-only change

---

This should resolve the failure where the test cannot run right now

Release note: None