### PR TITLE
storage: reduce allocations in MVCCIncrementalIterator

### DIFF
--- a/pkg/storage/mvcc_incremental_iterator.go
+++ b/pkg/storage/mvcc_incremental_iterator.go
@@ -237,8 +237,8 @@ func (i *MVCCIncrementalIterator) maybeSkipKeys() {
 		// If there is no time bound iterator, we cannot skip any keys.
 		return
 	}
-	tbiKey := i.timeBoundIter.Key().Key
-	iterKey := i.iter.Key().Key
+	tbiKey := i.timeBoundIter.UnsafeKey().Key
+	iterKey := i.iter.UnsafeKey().Key
 	if iterKey.Compare(tbiKey) > 0 {
 		// If the iterKey got ahead of the TBI key, advance the TBI Key.
 		//
@@ -258,7 +258,7 @@ func (i *MVCCIncrementalIterator) maybeSkipKeys() {
 			i.valid = false
 			return
 		}
-		tbiKey = i.timeBoundIter.Key().Key
+		tbiKey = i.timeBoundIter.UnsafeKey().Key
 
 		cmp := iterKey.Compare(tbiKey)
 
@@ -274,7 +274,7 @@ func (i *MVCCIncrementalIterator) maybeSkipKeys() {
 				i.valid = false
 				return
 			}
-			tbiKey = i.timeBoundIter.Key().Key
+			tbiKey = i.timeBoundIter.UnsafeKey().Key
 			cmp = iterKey.Compare(tbiKey)
 		}
 

--- a/pkg/storage/mvcc_incremental_iterator_test.go
+++ b/pkg/storage/mvcc_incremental_iterator_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -1090,6 +1091,64 @@ func TestMVCCIterateTimeBound(t *testing.T) {
 			}
 
 			assertEqualKVs(eng, keys.LocalMax, keys.MaxKey, testCase.start, testCase.end, latest, expectedKVs)(t)
+		})
+	}
+}
+
+func runIncrementalBenchmark(
+	b *testing.B, emk engineMaker, useTBI bool, ts hlc.Timestamp, opts benchDataOptions,
+) {
+	eng, _ := setupMVCCData(context.Background(), b, emk, opts)
+	{
+		// Pull all of the sstables into the cache.  This
+		// probably defeates a lot of the benefits of the
+		// time-based optimization.
+		iter := eng.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{UpperBound: roachpb.KeyMax})
+		_, _ = iter.ComputeStats(keys.LocalMax, roachpb.KeyMax, 0)
+		iter.Close()
+	}
+	defer eng.Close()
+
+	startKey := roachpb.Key(encoding.EncodeUvarintAscending([]byte("key-"), uint64(0)))
+	endKey := roachpb.Key(encoding.EncodeUvarintAscending([]byte("key-"), uint64(opts.numKeys)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		it := NewMVCCIncrementalIterator(eng, MVCCIncrementalIterOptions{
+			EnableTimeBoundIteratorOptimization: useTBI,
+			EndKey:                              endKey,
+			StartTime:                           ts,
+			EndTime:                             hlc.MaxTimestamp,
+		})
+		it.SeekGE(MVCCKey{Key: startKey})
+		for {
+			if ok, err := it.Valid(); err != nil {
+				b.Fatalf("failed incremental iteration: %+v", err)
+			} else if !ok {
+				break
+			}
+			it.Next()
+		}
+	}
+}
+
+func BenchmarkMVCCIncrementalIterator(b *testing.B) {
+	numVersions := 100
+	numKeys := 1000
+	valueBytes := 64
+
+	for _, useTBI := range []bool{true, false} {
+		b.Run(fmt.Sprintf("useTBI=%v", useTBI), func(b *testing.B) {
+			for _, tsExcludePercent := range []float64{0, 0.95} {
+				wallTime := int64((5 * (float64(numVersions)*tsExcludePercent + 1)))
+				ts := hlc.Timestamp{WallTime: wallTime}
+				b.Run(fmt.Sprintf("ts=%d", ts.WallTime), func(b *testing.B) {
+					runIncrementalBenchmark(b, setupMVCCPebble, useTBI, ts, benchDataOptions{
+						numVersions: numVersions,
+						numKeys:     numKeys,
+						valueBytes:  valueBytes,
+					})
+				})
+			}
 		})
 	}
 }


### PR DESCRIPTION
This changes some uses of Key() to UnsafeKey() to avoid unnecessary
allocations.  I've added a small benchmark that shows the decreased
number of allocations when iterating.

```
name                                            old time/op    new time/op    delta
MVCCIncrementalIterator/useTBI=true/ts=5-16       12.5ms ± 7%     9.0ms ± 7%  -28.02%  (p=0.000 n=57+26)
MVCCIncrementalIterator/useTBI=true/ts=480-16     2.36ms ± 8%    2.27ms ±13%   -4.12%  (p=0.000 n=52+25)
MVCCIncrementalIterator/useTBI=false/ts=5-16      6.32ms ± 7%    6.44ms ±11%     ~     (p=0.083 n=55+24)
MVCCIncrementalIterator/useTBI=false/ts=480-16    1.14ms ±10%    1.15ms ± 6%     ~     (p=0.390 n=54+25)

name                                            old alloc/op   new alloc/op   delta
MVCCIncrementalIterator/useTBI=true/ts=5-16        831kB ± 0%      32kB ± 0%  -96.20%  (p=0.000 n=57+23)
MVCCIncrementalIterator/useTBI=true/ts=480-16     60.5kB ± 0%    35.7kB ± 0%  -41.00%  (p=0.000 n=56+26)
MVCCIncrementalIterator/useTBI=false/ts=5-16      17.7kB ± 0%    17.7kB ± 0%     ~     (p=0.127 n=50+25)
MVCCIncrementalIterator/useTBI=false/ts=480-16    21.8kB ± 0%    21.8kB ± 0%     ~     (p=0.469 n=57+26)

name                                            old allocs/op  new allocs/op  delta
MVCCIncrementalIterator/useTBI=true/ts=5-16         103k ± 0%        0k ± 0%  -99.71%  (p=0.000 n=57+26)
MVCCIncrementalIterator/useTBI=true/ts=480-16      3.76k ± 0%     0.55k ± 0%  -85.28%  (p=0.000 n=57+26)
MVCCIncrementalIterator/useTBI=false/ts=5-16        22.0 ± 0%      22.0 ± 0%     ~     (all equal)
MVCCIncrementalIterator/useTBI=false/ts=480-16       277 ± 0%       277 ± 0%     ~     (all equal)
```

The benchmark uses data that I believe fits entirely into the cache,
which may explain why the TBI optimization is slower even when using a
timestamp that should exclude a large portion of the data.

Release note: None