### PR TITLE
release-21.1: opt: add GenerateLookupJoinsWithVirtualCols exploration rule

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -2641,6 +2641,198 @@ DROP TABLE regional_by_row;
 DROP TABLE regional_by_row_as;
 ALTER DATABASE drop_regions DROP REGION "ca-central-1";
 
+subtest virtual_columns
+
+statement ok
+USE multi_region_test_db
+
+statement ok
+CREATE TABLE regional_by_row_table_virt (
+  pk int PRIMARY KEY,
+  a int NOT NULL,
+  b int NOT NULL,
+  v INT AS (a + b) VIRTUAL,
+  v2 INT AS (a + 10) VIRTUAL,
+  UNIQUE (v),
+  UNIQUE INDEX (v2),
+  FAMILY (pk, a, b)
+) LOCALITY REGIONAL BY ROW
+
+# Uniqueness checks for virtual columns should be efficient.
+query T
+SELECT * FROM [EXPLAIN INSERT INTO regional_by_row_table_virt (pk, a, b) VALUES (1, 1, 1)] OFFSET 2
+----
+·
+• root
+│
+├── • insert
+│   │ into: regional_by_row_table_virt(pk, a, b, v, v2, crdb_region)
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • values
+│             size: 7 columns, 1 row
+│
+├── • constraint-check
+│   │
+│   └── • error if rows
+│       │
+│       └── • lookup join (semi)
+│           │ table: regional_by_row_table_virt@primary
+│           │ equality: (lookup_join_const_col_@21, column1) = (crdb_region,pk)
+│           │ equality cols are key
+│           │ pred: column12 != crdb_region
+│           │
+│           └── • cross join
+│               │ estimated row count: 3
+│               │
+│               ├── • values
+│               │     size: 1 column, 3 rows
+│               │
+│               └── • scan buffer
+│                     label: buffer 1
+│
+├── • constraint-check
+│   │
+│   └── • error if rows
+│       │
+│       └── • limit
+│           │ count: 1
+│           │
+│           └── • lookup join
+│               │ table: regional_by_row_table_virt@regional_by_row_table_virt_v_key
+│               │ equality: (lookup_join_const_col_@35, column13) = (crdb_region,v)
+│               │ equality cols are key
+│               │ pred: (column1 != pk) OR (column12 != crdb_region)
+│               │
+│               └── • cross join
+│                   │ estimated row count: 3
+│                   │
+│                   ├── • values
+│                   │     size: 1 column, 3 rows
+│                   │
+│                   └── • scan buffer
+│                         label: buffer 1
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │
+        └── • limit
+            │ count: 1
+            │
+            └── • lookup join
+                │ table: regional_by_row_table_virt@regional_by_row_table_virt_v2_key
+                │ equality: (lookup_join_const_col_@49, column14) = (crdb_region,v2)
+                │ equality cols are key
+                │ pred: (column1 != pk) OR (column12 != crdb_region)
+                │
+                └── • cross join
+                    │ estimated row count: 3
+                    │
+                    ├── • values
+                    │     size: 1 column, 3 rows
+                    │
+                    └── • scan buffer
+                          label: buffer 1
+
+query T
+SELECT * FROM [EXPLAIN UPSERT INTO regional_by_row_table_virt (pk, a, b) VALUES (1, 1, 1)] OFFSET 2
+----
+·
+• root
+│
+├── • upsert
+│   │ into: regional_by_row_table_virt(pk, a, b, v, v2, crdb_region)
+│   │ arbiter constraints: primary
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │
+│           └── • render
+│               │
+│               └── • cross join (left outer)
+│                   │
+│                   ├── • values
+│                   │     size: 6 columns, 1 row
+│                   │
+│                   └── • render
+│                       │
+│                       └── • union all
+│                           │ limit: 1
+│                           │
+│                           ├── • scan
+│                           │     missing stats
+│                           │     table: regional_by_row_table_virt@primary
+│                           │     spans: [/'ap-southeast-2'/1 - /'ap-southeast-2'/1]
+│                           │
+│                           └── • scan
+│                                 missing stats
+│                                 table: regional_by_row_table_virt@primary
+│                                 spans: [/'ca-central-1'/1 - /'ca-central-1'/1] [/'us-east-1'/1 - /'us-east-1'/1]
+│
+├── • constraint-check
+│   │
+│   └── • error if rows
+│       │
+│       └── • limit
+│           │ count: 1
+│           │
+│           └── • lookup join
+│               │ table: regional_by_row_table_virt@regional_by_row_table_virt_v_key
+│               │ equality: (lookup_join_const_col_@31, column13) = (crdb_region,v)
+│               │ equality cols are key
+│               │ pred: (upsert_pk != pk) OR (upsert_crdb_region != crdb_region)
+│               │
+│               └── • cross join
+│                   │
+│                   ├── • values
+│                   │     size: 1 column, 3 rows
+│                   │
+│                   └── • scan buffer
+│                         label: buffer 1
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │
+        └── • limit
+            │ count: 1
+            │
+            └── • lookup join
+                │ table: regional_by_row_table_virt@regional_by_row_table_virt_v2_key
+                │ equality: (lookup_join_const_col_@45, column14) = (crdb_region,v2)
+                │ equality cols are key
+                │ pred: (upsert_pk != pk) OR (upsert_crdb_region != crdb_region)
+                │
+                └── • cross join
+                    │
+                    ├── • values
+                    │     size: 1 column, 3 rows
+                    │
+                    └── • scan buffer
+                          label: buffer 1
+
+statement ok
+INSERT INTO regional_by_row_table_virt (pk, a, b) VALUES (1, 1, 1)
+
+statement error pq: duplicate key value violates unique constraint "regional_by_row_table_virt_v_key"\nDETAIL: Key \(v\)=\(2\) already exists\.
+INSERT INTO regional_by_row_table_virt (pk, a, b) VALUES (2, 2, 0)
+
+statement error pq: duplicate key value violates unique constraint "regional_by_row_table_virt_v_key"\nDETAIL: Key \(v\)=\(2\) already exists\.
+UPSERT INTO regional_by_row_table_virt (pk, a, b) VALUES (2, 2, 0)
+
+statement error pq: duplicate key value violates unique constraint "regional_by_row_table_virt_v2_key"\nDETAIL: Key \(v2\)=\(11\) already exists\.
+INSERT INTO regional_by_row_table_virt (pk, a, b) VALUES (2, 1, 3)
+
+statement error pq: duplicate key value violates unique constraint "regional_by_row_table_virt_v2_key"\nDETAIL: Key \(v2\)=\(11\) already exists\.
+UPSERT INTO regional_by_row_table_virt (pk, a, b) VALUES (2, 1, 3)
+
+subtest regressions
+
 # Regression test for #63109. UPSERT should not cause the error
 # ERROR: missing "crdb_region" primary key column.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/virtual_columns
+++ b/pkg/sql/logictest/testdata/logic_test/virtual_columns
@@ -149,6 +149,24 @@ SELECT a FROM t_idx WHERE w IN (4,6)
 3
 5
 
+# Covering lookup join.
+query II
+SELECT v, x FROM (VALUES (1), (2), (10), (5)) AS u(x) INNER LOOKUP JOIN t_idx@t_idx_v_idx ON u.x = t_idx.v
+----
+2   2
+5   5
+10  10
+10  10
+
+# Non-covering lookup join that requires a second join on the primary index.
+query IIII
+SELECT a, b, v, x FROM (VALUES (1), (2), (10), (5)) AS u(x) INNER LOOKUP JOIN t_idx@t_idx_v_idx ON u.x = t_idx.v
+----
+1  1  2   2
+2  8  10  10
+4  6  10  10
+5  0  5   5
+
 statement ok
 DELETE FROM t_idx WHERE v = 6
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/virtual_columns
+++ b/pkg/sql/opt/exec/execbuilder/testdata/virtual_columns
@@ -144,6 +144,53 @@ vectorized: true
           table: t_idx@t_idx_v_idx
           spans: /1-/2
 
+# Covering lookup join.
+query T
+EXPLAIN (VERBOSE) SELECT v, x FROM (VALUES (1), (10), (5)) AS u(x) INNER JOIN t_idx ON u.x = t_idx.v
+----
+distribution: local
+vectorized: true
+·
+• lookup join (inner)
+│ columns: (v, x)
+│ estimated row count: 3 (missing stats)
+│ table: t_idx@t_idx_v_idx
+│ equality: (column1) = (v)
+│
+└── • values
+      columns: (column1)
+      size: 1 column, 3 rows
+      row 0, expr 0: 1
+      row 1, expr 0: 10
+      row 2, expr 0: 5
+
+# Non-covering lookup join that requires a second join on the primary index.
+query T
+EXPLAIN (VERBOSE) SELECT a, b, v, x FROM (VALUES (1), (10), (5)) AS u(x) INNER JOIN t_idx ON u.x = t_idx.v
+----
+distribution: local
+vectorized: true
+·
+• lookup join (inner)
+│ columns: (a, b, v, x)
+│ estimated row count: 3 (missing stats)
+│ table: t_idx@primary
+│ equality: (a) = (a)
+│ equality cols are key
+│
+└── • lookup join (inner)
+    │ columns: (column1, a, v)
+    │ estimated row count: 30 (missing stats)
+    │ table: t_idx@t_idx_v_idx
+    │ equality: (column1) = (v)
+    │
+    └── • values
+          columns: (column1)
+          size: 1 column, 3 rows
+          row 0, expr 0: 1
+          row 1, expr 0: 10
+          row 2, expr 0: 5
+
 subtest Insert
 
 # TODO(radu): we shouldn't need to synthesize v here.

--- a/pkg/sql/opt/xform/join_funcs.go
+++ b/pkg/sql/opt/xform/join_funcs.go
@@ -209,13 +209,90 @@ func (c *CustomFuncs) GenerateLookupJoins(
 	on memo.FiltersExpr,
 	joinPrivate *memo.JoinPrivate,
 ) {
+	c.generateLookupJoinsImpl(
+		grp, joinType,
+		input,
+		scanPrivate.Cols,
+		opt.ColSet{}, /* projectedVirtualCols */
+		scanPrivate,
+		on,
+		joinPrivate,
+	)
+}
+
+// GenerateLookupJoinsWithVirtualCols is similar to GenerateLookupJoins but
+// generates lookup joins into indexes that contain virtual columns.
+//
+// In a canonical plan a virtual column is produced with a Project expression on
+// top of a Scan. This is necessary because virtual columns aren't stored in the
+// primary index. When a virtual column is indexed, a lookup join can be
+// generated that both uses the virtual column as a lookup column and produces
+// the column directly from the index without a Project.
+//
+// For example:
+//
+//         Join                       LookupJoin(t@idx)
+//         /   \                           |
+//        /     \            ->            |
+//      Input  Project                   Input
+//               |
+//               |
+//             Scan(t)
+//
+// This function and its associated rule currently require that:
+//
+//   1. The join is an inner join.
+//   2. The right side projects only virtual computed columns.
+//   3. All the projected virtual columns are covered by a single index.
+//
+// It should be possible to support semi- and anti- joins. Left joins may be
+// possible with additional complexity.
+//
+// It should also be possible to support cases where all the virtual columns are
+// not covered by a single index by wrapping the lookup join in a Project that
+// produces the non-covered virtual columns.
+func (c *CustomFuncs) GenerateLookupJoinsWithVirtualCols(
+	grp memo.RelExpr,
+	joinType opt.Operator,
+	input memo.RelExpr,
+	rightCols opt.ColSet,
+	projectedVirtualCols opt.ColSet,
+	scanPrivate *memo.ScanPrivate,
+	on memo.FiltersExpr,
+	joinPrivate *memo.JoinPrivate,
+) {
+	c.generateLookupJoinsImpl(
+		grp, joinType,
+		input,
+		rightCols,
+		projectedVirtualCols,
+		scanPrivate,
+		on,
+		joinPrivate,
+	)
+}
+
+// generateLookupJoinsImpl is the general implementation for generating lookup
+// joins. See GenerateLookupJoins and GenerateLookupJoinsWithVirtualCols for
+// more details.
+func (c *CustomFuncs) generateLookupJoinsImpl(
+	grp memo.RelExpr,
+	joinType opt.Operator,
+	input memo.RelExpr,
+	rightCols opt.ColSet,
+	projectedVirtualCols opt.ColSet,
+	scanPrivate *memo.ScanPrivate,
+	on memo.FiltersExpr,
+	joinPrivate *memo.JoinPrivate,
+) {
+
 	if joinPrivate.Flags.Has(memo.DisallowLookupJoinIntoRight) {
 		return
 	}
 	md := c.e.mem.Metadata()
 	inputProps := input.Relational()
 
-	leftEq, rightEq := memo.ExtractJoinEqualityColumns(inputProps.OutputCols, scanPrivate.Cols, on)
+	leftEq, rightEq := memo.ExtractJoinEqualityColumns(inputProps.OutputCols, rightCols, on)
 	n := len(leftEq)
 	if n == 0 {
 		return
@@ -230,7 +307,18 @@ func (c *CustomFuncs) GenerateLookupJoins(
 	var pkCols opt.ColList
 	var iter scanIndexIter
 	iter.Init(c.e.mem, &c.im, scanPrivate, on, rejectInvertedIndexes)
-	iter.ForEach(func(index cat.Index, onFilters memo.FiltersExpr, indexCols opt.ColSet, isCovering bool) {
+	iter.ForEach(func(index cat.Index, onFilters memo.FiltersExpr, indexCols opt.ColSet, _ bool) {
+		// Skip indexes that do no cover all virtual projection columns, if
+		// there are any. This can happen when there are multiple virtual
+		// columns indexed in different indexes.
+		//
+		// TODO(mgartner): It should be possible to plan a lookup join in this
+		// case by producing the covered virtual columns from the lookup join
+		// and producing the rest in a Project that wraps the join.
+		if !projectedVirtualCols.SubsetOf(indexCols) {
+			return
+		}
+
 		// Find the longest prefix of index key columns that are constrained by
 		// an equality with another column or a constant.
 		numIndexKeyCols := index.LaxKeyColumnCount()
@@ -327,7 +415,7 @@ func (c *CustomFuncs) GenerateLookupJoins(
 			var eqFilters memo.FiltersExpr
 			extractEqualityFilter := func(leftCol, rightCol opt.ColumnID) memo.FiltersItem {
 				return memo.ExtractJoinEqualityFilter(
-					leftCol, rightCol, inputProps.OutputCols, scanPrivate.Cols, on,
+					leftCol, rightCol, inputProps.OutputCols, rightCols, on,
 				)
 			}
 			eqFilters, constFilters, rightSideCols = c.findFiltersForIndexLookup(
@@ -364,9 +452,10 @@ func (c *CustomFuncs) GenerateLookupJoins(
 		lookupJoin.Cols = lookupJoin.LookupExpr.OuterCols()
 		lookupJoin.Cols.UnionWith(inputProps.OutputCols)
 
+		isCovering := rightCols.SubsetOf(indexCols)
 		if isCovering {
 			// Case 1 (see function comment).
-			lookupJoin.Cols.UnionWith(scanPrivate.Cols)
+			lookupJoin.Cols.UnionWith(rightCols)
 
 			// If some optional filters were used to build the lookup expression, we may
 			// need to wrap the final expression with a project. We only need to do this
@@ -417,7 +506,7 @@ func (c *CustomFuncs) GenerateLookupJoins(
 			// right side in their output columns, so even if the ON filters no
 			// longer reference an un-covered column, they must be fetched (case
 			// 2, see function comment).
-			filterColsFromRight := scanPrivate.Cols.Intersection(onFilters.OuterCols())
+			filterColsFromRight := rightCols.Intersection(onFilters.OuterCols())
 			if filterColsFromRight.SubsetOf(indexCols) {
 				lookupJoin.Cols.UnionWith(filterColsFromRight)
 				c.e.mem.AddLookupJoinToGroup(&lookupJoin, grp)
@@ -448,7 +537,7 @@ func (c *CustomFuncs) GenerateLookupJoins(
 
 		// The lower LookupJoin must return all PK columns (they are needed as key
 		// columns for the index join).
-		lookupJoin.Cols.UnionWith(scanPrivate.Cols.Intersection(indexCols))
+		lookupJoin.Cols.UnionWith(rightCols.Intersection(indexCols))
 		for i := range pkCols {
 			lookupJoin.Cols.Add(pkCols[i])
 		}
@@ -497,7 +586,7 @@ func (c *CustomFuncs) GenerateLookupJoins(
 		indexJoin.Table = scanPrivate.Table
 		indexJoin.Index = cat.PrimaryIndex
 		indexJoin.KeyCols = pkCols
-		indexJoin.Cols = scanPrivate.Cols.Union(inputProps.OutputCols)
+		indexJoin.Cols = rightCols.Union(inputProps.OutputCols)
 		indexJoin.LookupColsAreTableKey = true
 
 		// Create the LookupJoin for the index join in the same group.

--- a/pkg/sql/opt/xform/rules/join.opt
+++ b/pkg/sql/opt/xform/rules/join.opt
@@ -208,6 +208,45 @@
     $private
 )
 
+# GenerateLookupJoinsWithVirtualCols is similar to GenerateLookupJoins but
+# applies when the input is a Project that produces virtual computed columns.
+# See the GenerateLookupJoinsWithVirtualCols custom function for more details.
+#
+# TODO(mgartner): Generate lookup joins with virtual columns for semi- and
+# anti-joins. This may also be possible for left joins, but could be tricky.
+#
+# TODO(mgartner): Generate lookup joins with virtual columns and additional
+# filters where the right side is of the form (Project (Select (Scan))). This
+# will enable lookup joins into partial indexes on virtual columns.
+[GenerateLookupJoinsWithVirtualCols, Explore]
+(InnerJoin
+    $left:*
+    $project:(Project
+            (Scan $scanPrivate:*) &
+                (IsCanonicalScan $scanPrivate) &
+                ^(ColsAreEmpty
+                    $virtualCols:(VirtualColumns $scanPrivate)
+                )
+            $projections:*
+        ) &
+        (ColsAreSubset
+            $projectedVirtualCols:(ProjectionCols $projections)
+            $virtualCols
+        )
+    $on:*
+    $private:*
+)
+=>
+(GenerateLookupJoinsWithVirtualCols
+    (OpName)
+    $left
+    (OutputCols $project)
+    $projectedVirtualCols
+    $scanPrivate
+    $on
+    $private
+)
+
 # PushJoinIntoIndexJoin pushes an InnerJoin into an IndexJoin. The IndexJoin is
 # replaced with a LookupJoin, since it now must output columns from the right
 # side of the InnerJoin as well as from the original lookup table. This can

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -58,6 +58,17 @@ CREATE TABLE zz (
 ----
 
 exec-ddl
+CREATE TABLE virt (
+  k INT PRIMARY KEY,
+  i INT,
+  j INT NOT NULL,
+  v1 INT AS (i + 10) VIRTUAL,
+  v2 INT AS (i + 100) VIRTUAL,
+  CHECK (j IN (10, 20, 30))
+)
+----
+
+exec-ddl
 CREATE TABLE large (m INT, n INT)
 ----
 
@@ -4455,6 +4466,515 @@ inner-join (lookup t63735)
  └── filters
       └── y:6 = 15 [outer=(6), constraints=(/6: [/15 - /15]; tight), fd=()-->(6)]
 
+
+# --------------------------------------------------
+# GenerateLookupJoinsWithVirtualCols
+# --------------------------------------------------
+
+exec-ddl
+CREATE INDEX v1 ON virt (v1)
+----
+
+exec-ddl
+CREATE INDEX v2 ON virt (v2)
+----
+
+# Covering case. Join on virtual column but do not produce it.
+opt expect=GenerateLookupJoinsWithVirtualCols
+SELECT m, virt.k FROM small INNER LOOKUP JOIN virt ON m = virt.v1
+----
+project
+ ├── columns: m:1!null k:5!null
+ ├── immutable
+ ├── fd: (5)-->(1)
+ └── inner-join (lookup virt@v1)
+      ├── columns: m:1!null k:5!null v1:8!null
+      ├── flags: force lookup join (into right side)
+      ├── key columns: [1] = [8]
+      ├── immutable
+      ├── fd: (5)-->(8), (1)==(8), (8)==(1)
+      ├── scan small
+      │    └── columns: m:1
+      └── filters (true)
+
+# Covering case. Produce virtual column.
+opt expect=GenerateLookupJoinsWithVirtualCols
+SELECT m, virt.k, virt.v1 FROM small INNER LOOKUP JOIN virt ON m = virt.v1
+----
+inner-join (lookup virt@v1)
+ ├── columns: m:1!null k:5!null v1:8!null
+ ├── flags: force lookup join (into right side)
+ ├── key columns: [1] = [8]
+ ├── immutable
+ ├── fd: (5)-->(8), (1)==(8), (8)==(1)
+ ├── scan small
+ │    └── columns: m:1
+ └── filters (true)
+
+# Non-covering.
+opt expect=GenerateLookupJoinsWithVirtualCols
+SELECT m, virt.i, virt.v1 FROM small INNER LOOKUP JOIN virt ON m = virt.v1
+----
+inner-join (lookup virt)
+ ├── columns: m:1!null i:6 v1:8!null
+ ├── key columns: [5] = [5]
+ ├── lookup columns are key
+ ├── immutable
+ ├── fd: (6)-->(8), (1)==(8), (8)==(1)
+ ├── inner-join (lookup virt@v1)
+ │    ├── columns: m:1!null k:5!null v1:8!null
+ │    ├── flags: force lookup join (into right side)
+ │    ├── key columns: [1] = [8]
+ │    ├── fd: (5)-->(8), (1)==(8), (8)==(1)
+ │    ├── scan small
+ │    │    └── columns: m:1
+ │    └── filters (true)
+ └── filters (true)
+
+# Non-covering. Extra filter on non-covered column. We do not support this yet.
+# TODO(mgartner): Generate lookup joins with virtual columns and extra filters
+# by handling the (Project (Select (Scan))) pattern on the right side of the
+# join.
+opt format=hide-all
+SELECT m, virt.i, virt.v1 FROM small INNER LOOKUP JOIN virt ON m = virt.v1 AND i > 0
+----
+inner-join (hash)
+ ├── flags: force lookup join (into right side)
+ ├── scan small
+ ├── project
+ │    ├── select
+ │    │    ├── scan virt
+ │    │    │    ├── check constraint expressions
+ │    │    │    │    └── j IN (10, 20, 30)
+ │    │    │    └── computed column expressions
+ │    │    │         ├── v1
+ │    │    │         │    └── i + 10
+ │    │    │         └── v2
+ │    │    │              └── i + 100
+ │    │    └── filters
+ │    │         └── i > 0
+ │    └── projections
+ │         └── i + 10
+ └── filters
+      └── m = v1
+
+# Do not generate a lookup join when the right side projects a column that is
+# not a virtual computed column.
+opt expect-not=GenerateLookupJoinsWithVirtualCols
+SELECT m, tmp.p
+FROM small INNER LOOKUP JOIN (
+  SELECT v1, i + 5 AS p FROM virt
+) tmp ON m = tmp.v1
+----
+project
+ ├── columns: m:1!null p:11
+ ├── immutable
+ └── inner-join (hash)
+      ├── columns: m:1!null v1:8!null p:11
+      ├── flags: force lookup join (into right side)
+      ├── immutable
+      ├── fd: (1)==(8), (8)==(1)
+      ├── scan small
+      │    └── columns: m:1
+      ├── project
+      │    ├── columns: p:11 v1:8
+      │    ├── immutable
+      │    ├── scan virt
+      │    │    ├── columns: i:6
+      │    │    ├── check constraint expressions
+      │    │    │    └── j:7 IN (10, 20, 30) [outer=(7), constraints=(/7: [/10 - /10] [/20 - /20] [/30 - /30]; tight)]
+      │    │    └── computed column expressions
+      │    │         ├── v1:8
+      │    │         │    └── i:6 + 10
+      │    │         └── v2:9
+      │    │              └── i:6 + 100
+      │    └── projections
+      │         ├── i:6 + 5 [as=p:11, outer=(6), immutable]
+      │         └── i:6 + 10 [as=v1:8, outer=(6), immutable]
+      └── filters
+           └── m:1 = v1:8 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
+
+# Do not generate a lookup join when all the projected virtual columns cannot
+# be produced from a single index.
+opt expect-not=GenerateLookupJoinsWithVirtualCols
+SELECT m, virt.v1, virt.v2 FROM small INNER LOOKUP JOIN virt ON m = virt.v1
+----
+inner-join (hash)
+ ├── columns: m:1!null v1:8!null v2:9
+ ├── flags: force lookup join (into right side)
+ ├── immutable
+ ├── fd: (1)==(8), (8)==(1)
+ ├── scan small
+ │    └── columns: m:1
+ ├── project
+ │    ├── columns: v1:8 v2:9
+ │    ├── immutable
+ │    ├── scan virt
+ │    │    ├── columns: i:6
+ │    │    ├── check constraint expressions
+ │    │    │    └── j:7 IN (10, 20, 30) [outer=(7), constraints=(/7: [/10 - /10] [/20 - /20] [/30 - /30]; tight)]
+ │    │    └── computed column expressions
+ │    │         ├── v1:8
+ │    │         │    └── i:6 + 10
+ │    │         └── v2:9
+ │    │              └── i:6 + 100
+ │    └── projections
+ │         ├── i:6 + 10 [as=v1:8, outer=(6), immutable]
+ │         └── i:6 + 100 [as=v2:9, outer=(6), immutable]
+ └── filters
+      └── m:1 = v1:8 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
+
+# Do not generate lookup joins with virtual columns for left joins.
+opt expect-not=GenerateLookupJoinsWithVirtualCols format=hide-all
+SELECT m, virt.k FROM small LEFT LOOKUP JOIN virt ON m = virt.v1
+----
+project
+ └── left-join (hash)
+      ├── flags: force lookup join (into right side)
+      ├── scan small
+      ├── project
+      │    ├── scan virt
+      │    │    ├── check constraint expressions
+      │    │    │    └── j IN (10, 20, 30)
+      │    │    └── computed column expressions
+      │    │         ├── v1
+      │    │         │    └── i + 10
+      │    │         └── v2
+      │    │              └── i + 100
+      │    └── projections
+      │         └── i + 10
+      └── filters
+           └── m = v1
+
+# Do not generate lookup joins with virtual columns for semi-joins.
+opt expect-not=GenerateLookupJoinsWithVirtualCols format=hide-all
+SELECT m FROM small WHERE EXISTS (SELECT * FROM virt WHERE m = virt.v1)
+----
+semi-join (hash)
+ ├── scan small
+ ├── project
+ │    ├── scan virt
+ │    │    ├── check constraint expressions
+ │    │    │    └── j IN (10, 20, 30)
+ │    │    └── computed column expressions
+ │    │         ├── v1
+ │    │         │    └── i + 10
+ │    │         └── v2
+ │    │              └── i + 100
+ │    └── projections
+ │         └── i + 10
+ └── filters
+      └── m = column11
+
+# Do not generate lookup joins with virtual columns for anti-joins.
+opt expect-not=GenerateLookupJoinsWithVirtualCols format=hide-all
+SELECT m FROM small WHERE NOT EXISTS (SELECT * FROM virt WHERE m = virt.v1)
+----
+anti-join (hash)
+ ├── scan small
+ ├── project
+ │    ├── scan virt
+ │    │    ├── check constraint expressions
+ │    │    │    └── j IN (10, 20, 30)
+ │    │    └── computed column expressions
+ │    │         ├── v1
+ │    │         │    └── i + 10
+ │    │         └── v2
+ │    │              └── i + 100
+ │    └── projections
+ │         └── i + 10
+ └── filters
+      └── m = column11
+
+exec-ddl
+DROP INDEX v1
+----
+
+exec-ddl
+DROP INDEX v2
+----
+
+exec-ddl
+CREATE INDEX v1_v2 ON virt (v1, v2)
+----
+
+# Covering case. Single key column in index with multiple virtual columns.
+opt expect=GenerateLookupJoinsWithVirtualCols
+SELECT m, virt.k, virt.v1, virt.v2 FROM small INNER LOOKUP JOIN virt ON m = virt.v1
+----
+inner-join (lookup virt@v1_v2)
+ ├── columns: m:1!null k:5!null v1:8!null v2:9
+ ├── flags: force lookup join (into right side)
+ ├── key columns: [1] = [8]
+ ├── immutable
+ ├── fd: (5)-->(8,9), (1)==(8), (8)==(1)
+ ├── scan small
+ │    └── columns: m:1
+ └── filters (true)
+
+# Covering case. Multiple key columns in index with multiple virtual columns.
+opt expect=GenerateLookupJoinsWithVirtualCols
+SELECT m, virt.k, virt.v1, virt.v2 FROM small INNER LOOKUP JOIN virt ON m = virt.v1 AND n = virt.v2
+----
+project
+ ├── columns: m:1!null k:5!null v1:8!null v2:9!null
+ ├── immutable
+ ├── fd: (5)-->(8,9), (1)==(8), (8)==(1)
+ └── inner-join (lookup virt@v1_v2)
+      ├── columns: m:1!null n:2!null k:5!null v1:8!null v2:9!null
+      ├── flags: force lookup join (into right side)
+      ├── key columns: [1 2] = [8 9]
+      ├── immutable
+      ├── fd: (5)-->(8,9), (1)==(8), (8)==(1), (2)==(9), (9)==(2)
+      ├── scan small
+      │    └── columns: m:1 n:2
+      └── filters (true)
+
+exec-ddl
+DROP INDEX v1_v2
+----
+
+exec-ddl
+CREATE INDEX i_v1 ON virt (i, v1)
+----
+
+exec-ddl
+CREATE INDEX v2_i ON virt (v2, i)
+----
+
+# Covering case. One of the lookup columns is a virtual column.
+opt expect=GenerateLookupJoinsWithVirtualCols
+SELECT m, virt.k, virt.v1 FROM small INNER LOOKUP JOIN virt ON m = virt.i AND n = virt.v1
+----
+project
+ ├── columns: m:1!null k:5!null v1:8!null
+ ├── immutable
+ ├── fd: (5)-->(1,8), (1)-->(8)
+ └── inner-join (lookup virt@i_v1)
+      ├── columns: m:1!null n:2!null k:5!null i:6!null v1:8!null
+      ├── flags: force lookup join (into right side)
+      ├── key columns: [1 2] = [6 8]
+      ├── immutable
+      ├── fd: (5)-->(6), (6)-->(8), (1)==(6), (6)==(1), (2)==(8), (8)==(2)
+      ├── scan small
+      │    └── columns: m:1 n:2
+      └── filters (true)
+
+# Covering case. A non-virtual column is the lookup column and the virtual
+# column can be produced.
+opt expect=GenerateLookupJoinsWithVirtualCols
+SELECT m, virt.k, virt.v1 FROM small INNER LOOKUP JOIN virt ON m = virt.i
+----
+project
+ ├── columns: m:1!null k:5!null v1:8
+ ├── immutable
+ ├── fd: (5)-->(1,8), (1)-->(8)
+ └── inner-join (lookup virt@i_v1)
+      ├── columns: m:1!null k:5!null i:6!null v1:8
+      ├── flags: force lookup join (into right side)
+      ├── key columns: [1] = [6]
+      ├── immutable
+      ├── fd: (5)-->(6), (6)-->(8), (1)==(6), (6)==(1)
+      ├── scan small
+      │    └── columns: m:1
+      └── filters (true)
+
+# Covering case. A virtual column is the lookup column and the non-virtual
+# column can be produced.
+opt expect=GenerateLookupJoinsWithVirtualCols
+SELECT m, virt.i, virt.v2 FROM small INNER LOOKUP JOIN virt ON m = virt.v2
+----
+inner-join (lookup virt@v2_i)
+ ├── columns: m:1!null i:6 v2:9!null
+ ├── flags: force lookup join (into right side)
+ ├── key columns: [1] = [9]
+ ├── immutable
+ ├── fd: (6)-->(9), (1)==(9), (9)==(1)
+ ├── scan small
+ │    └── columns: m:1
+ └── filters (true)
+
+# Covering case with a cross join for multiple constant values for the leading
+# lookup column. We do not support this yet.
+# TODO(mgartner): Generate lookup joins with virtual columns and extra filters
+# by handling the (Project (Select (Scan))) pattern on the right side of the
+# join.
+opt
+SELECT m, virt.k, virt.v1 FROM small INNER LOOKUP JOIN virt ON virt.i IN (1, 2, 3) AND m = virt.v1
+----
+inner-join (hash)
+ ├── columns: m:1!null k:5!null v1:8!null
+ ├── flags: force lookup join (into right side)
+ ├── immutable
+ ├── fd: (5)-->(8), (1)==(8), (8)==(1)
+ ├── scan small
+ │    └── columns: m:1
+ ├── project
+ │    ├── columns: v1:8!null k:5!null
+ │    ├── immutable
+ │    ├── key: (5)
+ │    ├── fd: (5)-->(8)
+ │    ├── scan virt@i_v1
+ │    │    ├── columns: k:5!null i:6!null
+ │    │    ├── constraint: /6/8/5: [/1 - /3]
+ │    │    ├── key: (5)
+ │    │    └── fd: (5)-->(6)
+ │    └── projections
+ │         └── i:6 + 10 [as=v1:8, outer=(6), immutable]
+ └── filters
+      └── m:1 = v1:8 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
+
+exec-ddl
+DROP INDEX i_v1
+----
+
+exec-ddl
+DROP INDEX v2_i
+----
+
+exec-ddl
+CREATE INDEX j_v1 ON virt (j, v1)
+----
+
+# Covering case with a cross join for multiple constant values based on optional
+# filters.
+opt
+SELECT m, virt.k, virt.v1 FROM small INNER LOOKUP JOIN virt ON m = virt.v1
+----
+inner-join (lookup virt@j_v1)
+ ├── columns: m:1!null k:5!null v1:8!null
+ ├── flags: force lookup join (into right side)
+ ├── key columns: [11 1] = [7 8]
+ ├── immutable
+ ├── fd: (5)-->(8), (1)==(8), (8)==(1)
+ ├── inner-join (cross)
+ │    ├── columns: m:1 "lookup_join_const_col_@7":11!null
+ │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
+ │    ├── scan small
+ │    │    └── columns: m:1
+ │    ├── values
+ │    │    ├── columns: "lookup_join_const_col_@7":11!null
+ │    │    ├── cardinality: [3 - 3]
+ │    │    ├── (10,)
+ │    │    ├── (20,)
+ │    │    └── (30,)
+ │    └── filters (true)
+ └── filters (true)
+
+# Non-covering case with a cross join for multiple constant values based on optional
+# filters.
+opt
+SELECT m, virt.i, virt.k, virt.v1 FROM small INNER LOOKUP JOIN virt ON m = virt.v1
+----
+inner-join (lookup virt)
+ ├── columns: m:1!null i:6 k:5!null v1:8!null
+ ├── key columns: [5] = [5]
+ ├── lookup columns are key
+ ├── immutable
+ ├── fd: (5)-->(6), (6)-->(8), (1)==(8), (8)==(1)
+ ├── inner-join (lookup virt@j_v1)
+ │    ├── columns: m:1!null k:5!null v1:8!null
+ │    ├── flags: force lookup join (into right side)
+ │    ├── key columns: [11 1] = [7 8]
+ │    ├── fd: (5)-->(1,8), (1)==(8), (8)==(1)
+ │    ├── inner-join (cross)
+ │    │    ├── columns: m:1 "lookup_join_const_col_@7":11!null
+ │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
+ │    │    ├── scan small
+ │    │    │    └── columns: m:1
+ │    │    ├── values
+ │    │    │    ├── columns: "lookup_join_const_col_@7":11!null
+ │    │    │    ├── cardinality: [3 - 3]
+ │    │    │    ├── (10,)
+ │    │    │    ├── (20,)
+ │    │    │    └── (30,)
+ │    │    └── filters (true)
+ │    └── filters (true)
+ └── filters (true)
+
+exec-ddl
+DROP INDEX j_v1
+----
+
+exec-ddl
+CREATE INDEX v1_storing_i ON virt (v1) STORING (i)
+----
+
+# Covering case. Virtual column is the lookup column and there is an extra
+# filter on the non-virtual column. We do not support this yet.
+# TODO(mgartner): Generate lookup joins with virtual columns and extra filters
+# by handling the (Project (Select (Scan))) pattern on the right side of the
+# join.
+opt format=hide-all
+SELECT m, virt.i, virt.v2 FROM small INNER LOOKUP JOIN virt ON m = virt.v1 AND i > 0
+----
+project
+ └── inner-join (hash)
+      ├── flags: force lookup join (into right side)
+      ├── scan small
+      ├── project
+      │    ├── select
+      │    │    ├── scan virt
+      │    │    │    ├── check constraint expressions
+      │    │    │    │    └── j IN (10, 20, 30)
+      │    │    │    └── computed column expressions
+      │    │    │         ├── v1
+      │    │    │         │    └── i + 10
+      │    │    │         └── v2
+      │    │    │              └── i + 100
+      │    │    └── filters
+      │    │         └── i > 0
+      │    └── projections
+      │         ├── i + 10
+      │         └── i + 100
+      └── filters
+           └── m = v1
+
+exec-ddl
+DROP INDEX v1_storing_i
+----
+
+exec-ddl
+CREATE INDEX v1_partial ON virt (v1) WHERE k > 0
+----
+
+# Covering case with partial index. We do not support this yet.
+# TODO(mgartner): Generate lookup joins with virtual columns indexed by partial
+# indexes by handling the (Project (Select (Scan))) pattern on the right side of
+# the join.
+opt format=hide-all
+SELECT m, virt.v1 FROM small INNER LOOKUP JOIN virt ON m = virt.v1 AND k > 0
+----
+inner-join (hash)
+ ├── flags: force lookup join (into right side)
+ ├── scan small
+ ├── project
+ │    ├── scan virt
+ │    │    └── constraint: /5: [/1 - ]
+ │    └── projections
+ │         └── i + 10
+ └── filters
+      └── m = v1
+
+# Non-covering case with partial index. We do not support this yet.
+# TODO(mgartner): Generate lookup joins with virtual columns indexed by partial
+# indexes by handling the (Project (Select (Scan))) pattern on the right side of
+# the join.
+opt format=hide-all
+SELECT m, virt.i, virt.v1 FROM small INNER LOOKUP JOIN virt ON m = virt.v1 AND k > 0
+----
+inner-join (hash)
+ ├── flags: force lookup join (into right side)
+ ├── scan small
+ ├── project
+ │    ├── scan virt
+ │    │    └── constraint: /5: [/1 - ]
+ │    └── projections
+ │         └── i + 10
+ └── filters
+      └── m = v1
+
+
 # -------------------------------------------------------
 # GenerateInvertedJoins + GenerateInvertedJoinsFromSelect
 # -------------------------------------------------------
@@ -7106,7 +7626,7 @@ inner-join (lookup abc@ab)
 
 # No-op case because the right side of the InnerJoin has outer columns.
 opt expect-not=PushJoinIntoIndexJoin disable=(TryDecorrelateProject,HoistProjectFromInnerJoin)
-SELECT * 
+SELECT *
 FROM stu
 INNER JOIN LATERAL (
    SELECT *


### PR DESCRIPTION
Backport 1/1 commits from #68311.

/cc @cockroachdb/release

Release justification: Unique constraints on virtual columns in multi-region
tables are unusable in their current state because every INSERT performs a full
table scan to ensure uniqueness. This backport makes the uniqueness checks
efficient.

---

The GenerateLookupJoinsWithVirtualCols exploration rule has been added
to the optimizer.

GenerateLookupJoinsWithVirtualCols is similar to GenerateLookupJoins but
generates lookup joins into indexes that contain virtual columns.

In a canonical plan a virtual column is produced with a Project
expression on top of a Scan. This is necessary because virtual columns
aren't stored in the primary index. When a virtual column is indexed, a
lookup join can be generated that both uses the virtual column as a
lookup column and produces the column directly from the index without a
Project.

For example:

        Join                       LookupJoin(t@idx)
        /   \                           |
       /     \            ->            |
     Input  Project                   Input
              |
              |
            Scan(t)

This function and its associated rule currently require that:

  1. The join is an inner join.
  2. The right side projects only virtual computed columns.
  3. All the projected virtual columns are covered by a single index.

It should be possible to support semi- and anti- joins. Left joins may
be possible with additional complexity.

It should also be possible to support cases where all the virtual
columns are not covered by a single index by wrapping the lookup join in
a Project that produces the non-covered virtual columns.

This rule is required to make multi-region uniqueness checks for unique
indexes on virtual columns and unique expression indexes efficient.
Without this rule, the optimizer resorts to a full table scan for these
uniqueness checks, making these types of indexes unusable in
multi-region clusters.

There is additional work required to make uniqueness checks efficient
for unique partial indexes on virtual columns. This will be addressed
in a future commit.

Informs #68132

Release note (performance improvement): Lookup joins on indexes with
virtual columns are now considered by the optimizer. This should result
in more efficient queries in many cases. Most notably, post-query
uniqueness checks for unique indexes on virtual columns in
`REGIONAL BY ROW` tables can now utilize the unique index rather than
perform a full table scan.
