### PR TITLE
sql: fix show syntax re-parse issue

### DIFF
--- a/pkg/sql/parser/testdata/show
+++ b/pkg/sql/parser/testdata/show
@@ -1530,18 +1530,16 @@ SHOW SYNTAX 'select 1'
 ----
 SHOW SYNTAX 'select 1'
 SHOW SYNTAX 'select 1' -- fully parenthesized
-SHOW SYNTAX _ -- literals removed
-REPARSE WITHOUT LITERALS FAILS: at or near "_": syntax error
-SHOW SYNTAX _ -- identifiers removed
+SHOW SYNTAX '_' -- literals removed
+SHOW SYNTAX '_' -- identifiers removed
 
 parse
 EXPLAIN SHOW SYNTAX 'select 1'
 ----
 EXPLAIN SHOW SYNTAX 'select 1'
 EXPLAIN SHOW SYNTAX 'select 1' -- fully parenthesized
-EXPLAIN SHOW SYNTAX _ -- literals removed
-REPARSE WITHOUT LITERALS FAILS: at or near "_": syntax error
-EXPLAIN SHOW SYNTAX _ -- identifiers removed
+EXPLAIN SHOW SYNTAX '_' -- literals removed
+EXPLAIN SHOW SYNTAX '_' -- identifiers removed
 
 parse
 SHOW CREATE TABLE t

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -557,7 +557,7 @@ type ShowSyntax struct {
 func (node *ShowSyntax) Format(ctx *FmtCtx) {
 	ctx.WriteString("SHOW SYNTAX ")
 	if ctx.flags.HasFlags(FmtAnonymize) || ctx.flags.HasFlags(FmtHideConstants) {
-		ctx.WriteByte('_')
+		ctx.WriteString("'_'")
 	} else {
 		ctx.WriteString(lexbase.EscapeSQLString(node.Statement))
 	}


### PR DESCRIPTION
Related to: #60722

Show test were having re-parse issues due to a type error. This change replaces the underscore with a string value.

Release note: None