### PR TITLE
server/debug: aggregate debug LSM endpoints

### DIFF
--- a/pkg/server/debug/BUILD.bazel
+++ b/pkg/server/debug/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/base",
         "//pkg/kv/kvserver",
         "//pkg/kv/kvserver/closedts/sidetransport",
+        "//pkg/roachpb:with-mocks",
         "//pkg/server/debug/goroutineui",
         "//pkg/server/debug/pprofui",
         "//pkg/settings",

--- a/pkg/ui/src/views/reports/containers/debug/index.tsx
+++ b/pkg/ui/src/views/reports/containers/debug/index.tsx
@@ -171,8 +171,8 @@ export default function Debug() {
           />
           <DebugTableLink
             name="Store LSM details on this node"
-            url="/debug/lsm/1"
-            note="/debug/lsm/[store_id]"
+            url="/debug/lsm"
+            note="/debug/lsm"
           />
         </DebugTableRow>
         <DebugTableRow title="Security">


### PR DESCRIPTION
Previously, there was a `/debug/lsm/<storeID>` endpoint per store that
printed a store's LSM stats. This was difficult to use, because it
required knowing the store IDs. This change aggregates the endpoints
into a single /debug/lsm endpoint that prints all the node's stores' LSM
stats.

Release note: None