### PR TITLE
sql: implemented placement restricted syntax for domiciling

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/global_placement_restricted
+++ b/pkg/ccl/logictestccl/testdata/logic_test/global_placement_restricted
@@ -1,0 +1,121 @@
+# LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-vec-off
+
+statement ok
+CREATE DATABASE testdb PRIMARY REGION "ca-central-1" REGIONS "ap-southeast-2", "us-east-1"
+
+statement ok
+USE testdb
+
+statement ok
+CREATE TABLE test () LOCALITY GLOBAL
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE test
+----
+TABLE test  ALTER TABLE test CONFIGURE ZONE USING
+            range_min_bytes = 134217728,
+            range_max_bytes = 536870912,
+            gc.ttlseconds = 90000,
+            global_reads = true,
+            num_replicas = 5,
+            num_voters = 3,
+            constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+            voter_constraints = '[+region=ca-central-1]',
+            lease_preferences = '[[+region=ca-central-1]]'
+
+# Alter to RESTRICTED and see that our non-voter constraints remain.
+statement ok
+ALTER DATABASE testdb SET PLACEMENT RESTRICTED
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE test
+----
+TABLE test  ALTER TABLE test CONFIGURE ZONE USING
+            range_min_bytes = 134217728,
+            range_max_bytes = 536870912,
+            gc.ttlseconds = 90000,
+            global_reads = true,
+            num_replicas = 5,
+            num_voters = 3,
+            constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+            voter_constraints = '[+region=ca-central-1]',
+            lease_preferences = '[[+region=ca-central-1]]'
+
+# Make sure placement restricted doesn't invalidate zone configs.
+statement ok
+SELECT * FROM crdb_internal.validate_multi_region_zone_configs()
+
+statement ok
+ALTER DATABASE testdb DROP REGION "us-east-1"
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE test
+----
+TABLE test  ALTER TABLE test CONFIGURE ZONE USING
+            range_min_bytes = 134217728,
+            range_max_bytes = 536870912,
+            gc.ttlseconds = 90000,
+            global_reads = true,
+            num_replicas = 4,
+            num_voters = 3,
+            constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1}',
+            voter_constraints = '[+region=ca-central-1]',
+            lease_preferences = '[[+region=ca-central-1]]'
+
+statement ok
+ALTER DATABASE testdb ADD REGION "us-east-1"
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE test
+----
+TABLE test  ALTER TABLE test CONFIGURE ZONE USING
+            range_min_bytes = 134217728,
+            range_max_bytes = 536870912,
+            gc.ttlseconds = 90000,
+            global_reads = true,
+            num_replicas = 5,
+            num_voters = 3,
+            constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+            voter_constraints = '[+region=ca-central-1]',
+            lease_preferences = '[[+region=ca-central-1]]'
+
+# Change primary region to ensure zone config is rebuilt on table changes.
+statement ok
+ALTER DATABASE testdb SET PRIMARY REGION "ap-southeast-2"
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE test
+----
+TABLE test  ALTER TABLE test CONFIGURE ZONE USING
+            range_min_bytes = 134217728,
+            range_max_bytes = 536870912,
+            gc.ttlseconds = 90000,
+            global_reads = true,
+            num_replicas = 5,
+            num_voters = 3,
+            constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+            voter_constraints = '[+region=ap-southeast-2]',
+            lease_preferences = '[[+region=ap-southeast-2]]'
+
+# Alter to DEFAULT and see that our zone config is unchanged.
+statement ok
+ALTER DATABASE testdb SET PLACEMENT DEFAULT
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE test
+----
+TABLE test  ALTER TABLE test CONFIGURE ZONE USING
+            range_min_bytes = 134217728,
+            range_max_bytes = 536870912,
+            gc.ttlseconds = 90000,
+            global_reads = true,
+            num_replicas = 5,
+            num_voters = 3,
+            constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+            voter_constraints = '[+region=ap-southeast-2]',
+            lease_preferences = '[[+region=ap-southeast-2]]'
+
+# Check that coming back from placement restricted results in a valid zone
+# config.
+statement ok
+SELECT * FROM crdb_internal.validate_multi_region_zone_configs()

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_show
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_show
@@ -45,5 +45,14 @@ SHOW CREATE DATABASE multi_region_test_explicit_primary_region_db
 database_name                                     create_statement
 multi_region_test_explicit_primary_region_db      CREATE DATABASE multi_region_test_explicit_primary_region_db PRIMARY REGION "ap-southeast-2" REGIONS = "ap-southeast-2", "ca-central-1", "us-east-1" SURVIVE REGION FAILURE
 
+statement ok
+CREATE DATABASE multi_region_test_placement_restricted_db PRIMARY REGION "ap-southeast-2" REGIONS "ap-southeast-2", "ca-central-1", "us-east-1" PLACEMENT RESTRICTED
+
+query TT colnames
+SHOW CREATE DATABASE multi_region_test_placement_restricted_db
+----
+database_name                                     create_statement
+multi_region_test_placement_restricted_db         CREATE DATABASE multi_region_test_placement_restricted_db PRIMARY REGION "ap-southeast-2" REGIONS = "ap-southeast-2", "ca-central-1", "us-east-1" SURVIVE ZONE FAILURE PLACEMENT RESTRICTED
+
 statement error target database or schema does not exist
 SHOW CREATE DATABASE foo

--- a/pkg/ccl/logictestccl/testdata/logic_test/placement
+++ b/pkg/ccl/logictestccl/testdata/logic_test/placement
@@ -1,0 +1,33 @@
+# LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-vec-off
+
+statement error PRIMARY REGION must be specified when using PLACEMENT
+CREATE DATABASE no_region_placement PLACEMENT RESTRICTED
+
+statement ok
+CREATE DATABASE no_region_placement
+
+statement error database must have associated regions before a placement policy can be set
+ALTER DATABASE no_region_placement SET PLACEMENT RESTRICTED
+
+statement ok
+CREATE DATABASE to_be_altered PRIMARY REGION "ca-central-1" REGIONS "ap-southeast-2", "us-east-1"
+
+statement error PLACEMENT RESTRICTED can only be used with SURVIVE ZONE FAILURE
+CREATE DATABASE region_survivable_strict PRIMARY REGION "ca-central-1" REGIONS "ap-southeast-2", "us-east-1" SURVIVE REGION FAILURE PLACEMENT RESTRICTED
+
+statement ok
+CREATE DATABASE zone_survivable_strict PRIMARY REGION "ca-central-1" REGIONS "ap-southeast-2", "us-east-1" PLACEMENT RESTRICTED
+
+statement error a region-survivable database cannot also have a restricted placement policy
+ALTER DATABASE zone_survivable_strict SURVIVE REGION FAILURE
+
+statement ok
+CREATE DATABASE region_survivable_default PRIMARY REGION "ca-central-1" REGIONS "ap-southeast-2", "us-east-1" SURVIVE REGION FAILURE
+
+statement ok
+SELECT * FROM crdb_internal.validate_multi_region_zone_configs()
+
+statement error a region-survivable database cannot also have a restricted placement policy
+ALTER DATABASE region_survivable_default SET PLACEMENT RESTRICTED
+
+

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_placement_restricted
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_placement_restricted
@@ -1,0 +1,170 @@
+# LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-vec-off
+
+statement ok
+CREATE DATABASE testdb PRIMARY REGION "ca-central-1" REGIONS "ap-southeast-2", "us-east-1"
+
+statement ok
+USE testdb
+
+statement ok
+CREATE TABLE test () LOCALITY REGIONAL BY ROW
+
+query TT
+SELECT partition_name, full_zone_config FROM [SHOW PARTITIONS FROM TABLE test]
+ORDER BY partition_name
+----
+ap-southeast-2  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
+gc.ttlseconds = 90000,
+num_replicas = 5,
+num_voters = 3,
+constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'
+ca-central-1                                      range_min_bytes = 134217728,
+range_max_bytes = 536870912,
+gc.ttlseconds = 90000,
+num_replicas = 5,
+num_voters = 3,
+constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'
+us-east-1                                       range_min_bytes = 134217728,
+range_max_bytes = 536870912,
+gc.ttlseconds = 90000,
+num_replicas = 5,
+num_voters = 3,
+constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'
+
+# Alter to RESTRICTED and see that we have no non-voter constraints.
+statement ok
+ALTER DATABASE testdb SET PLACEMENT RESTRICTED
+
+query TT
+SELECT partition_name, full_zone_config FROM [SHOW PARTITIONS FROM TABLE test]
+ORDER BY partition_name
+----
+ap-southeast-2  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
+gc.ttlseconds = 90000,
+num_replicas = 3,
+num_voters = 3,
+constraints = '[]',
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'
+ca-central-1                                      range_min_bytes = 134217728,
+range_max_bytes = 536870912,
+gc.ttlseconds = 90000,
+num_replicas = 3,
+num_voters = 3,
+constraints = '[]',
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'
+us-east-1                                       range_min_bytes = 134217728,
+range_max_bytes = 536870912,
+gc.ttlseconds = 90000,
+num_replicas = 3,
+num_voters = 3,
+constraints = '[]',
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'
+
+# Make sure placement restricted doesn't invalidate zone configs.
+statement ok
+SELECT * FROM crdb_internal.validate_multi_region_zone_configs()
+
+statement ok
+ALTER DATABASE testdb DROP REGION "us-east-1"
+
+query TT
+SELECT partition_name, full_zone_config FROM [SHOW PARTITIONS FROM TABLE test]
+ORDER BY partition_name
+----
+ap-southeast-2  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
+gc.ttlseconds = 90000,
+num_replicas = 3,
+num_voters = 3,
+constraints = '[]',
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'
+ca-central-1                                      range_min_bytes = 134217728,
+range_max_bytes = 536870912,
+gc.ttlseconds = 90000,
+num_replicas = 3,
+num_voters = 3,
+constraints = '[]',
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'
+
+statement ok
+ALTER DATABASE testdb ADD REGION "us-east-1"
+
+query TT
+SELECT partition_name, full_zone_config FROM [SHOW PARTITIONS FROM TABLE test]
+ORDER BY partition_name
+----
+ap-southeast-2  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
+gc.ttlseconds = 90000,
+num_replicas = 3,
+num_voters = 3,
+constraints = '[]',
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'
+ca-central-1                                      range_min_bytes = 134217728,
+range_max_bytes = 536870912,
+gc.ttlseconds = 90000,
+num_replicas = 3,
+num_voters = 3,
+constraints = '[]',
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'
+us-east-1                                       range_min_bytes = 134217728,
+range_max_bytes = 536870912,
+gc.ttlseconds = 90000,
+num_replicas = 3,
+num_voters = 3,
+constraints = '[]',
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'
+
+# Alter to DEFAULT and see that our constraints are back.
+statement ok
+ALTER DATABASE testdb SET PLACEMENT DEFAULT
+
+# Check that coming back from placement restricted results in a valid zone
+# config.
+statement ok
+SELECT * FROM crdb_internal.validate_multi_region_zone_configs()
+
+query TT
+SELECT partition_name, full_zone_config FROM [SHOW PARTITIONS FROM TABLE test]
+ORDER BY partition_name
+----
+ap-southeast-2  range_min_bytes = 134217728,
+range_max_bytes = 536870912,
+gc.ttlseconds = 90000,
+num_replicas = 5,
+num_voters = 3,
+constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'
+ca-central-1                                      range_min_bytes = 134217728,
+range_max_bytes = 536870912,
+gc.ttlseconds = 90000,
+num_replicas = 5,
+num_voters = 3,
+constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'
+us-east-1                                       range_min_bytes = 134217728,
+range_max_bytes = 536870912,
+gc.ttlseconds = 90000,
+num_replicas = 5,
+num_voters = 3,
+constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_table_placement_restricted
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_table_placement_restricted
@@ -1,0 +1,186 @@
+# LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-vec-off
+
+statement ok
+CREATE DATABASE testdb PRIMARY REGION "ca-central-1" REGIONS "ap-southeast-2", "us-east-1"
+
+statement ok
+USE testdb
+
+statement ok
+CREATE TABLE test () LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
+
+statement ok
+CREATE TABLE test_explicit_region () LOCALITY REGIONAL BY TABLE IN "ap-southeast-2"
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE test
+----
+DATABASE testdb  ALTER DATABASE testdb CONFIGURE ZONE USING
+                 range_min_bytes = 134217728,
+                 range_max_bytes = 536870912,
+                 gc.ttlseconds = 90000,
+                 num_replicas = 5,
+                 num_voters = 3,
+                 constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                 voter_constraints = '[+region=ca-central-1]',
+                 lease_preferences = '[[+region=ca-central-1]]'
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE test_explicit_region
+----
+TABLE test_explicit_region  ALTER TABLE test_explicit_region CONFIGURE ZONE USING
+                            range_min_bytes = 134217728,
+                            range_max_bytes = 536870912,
+                            gc.ttlseconds = 90000,
+                            num_replicas = 5,
+                            num_voters = 3,
+                            constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                            voter_constraints = '[+region=ap-southeast-2]',
+                            lease_preferences = '[[+region=ap-southeast-2]]'
+
+# Alter to RESTRICTED and see that we have no non-voter constraints.
+statement ok
+ALTER DATABASE testdb SET PLACEMENT RESTRICTED
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE test
+----
+DATABASE testdb  ALTER DATABASE testdb CONFIGURE ZONE USING
+                 range_min_bytes = 134217728,
+                 range_max_bytes = 536870912,
+                 gc.ttlseconds = 90000,
+                 num_replicas = 3,
+                 num_voters = 3,
+                 constraints = '[]',
+                 voter_constraints = '[+region=ca-central-1]',
+                 lease_preferences = '[[+region=ca-central-1]]'
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE test_explicit_region
+----
+TABLE test_explicit_region  ALTER TABLE test_explicit_region CONFIGURE ZONE USING
+                            range_min_bytes = 134217728,
+                            range_max_bytes = 536870912,
+                            gc.ttlseconds = 90000,
+                            num_replicas = 3,
+                            num_voters = 3,
+                            constraints = '[]',
+                            voter_constraints = '[+region=ap-southeast-2]',
+                            lease_preferences = '[[+region=ap-southeast-2]]'
+
+# Make sure placement restricted doesn't invalidate zone configs.
+statement ok
+SELECT * FROM crdb_internal.validate_multi_region_zone_configs()
+
+statement ok
+ALTER DATABASE testdb DROP REGION "us-east-1"
+
+# Since we have no non-voters, dropping a non-primary region should not change
+# our zone configs.
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE test
+----
+DATABASE testdb  ALTER DATABASE testdb CONFIGURE ZONE USING
+                 range_min_bytes = 134217728,
+                 range_max_bytes = 536870912,
+                 gc.ttlseconds = 90000,
+                 num_replicas = 3,
+                 num_voters = 3,
+                 constraints = '[]',
+                 voter_constraints = '[+region=ca-central-1]',
+                 lease_preferences = '[[+region=ca-central-1]]'
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE test_explicit_region
+----
+TABLE test_explicit_region  ALTER TABLE test_explicit_region CONFIGURE ZONE USING
+                            range_min_bytes = 134217728,
+                            range_max_bytes = 536870912,
+                            gc.ttlseconds = 90000,
+                            num_replicas = 3,
+                            num_voters = 3,
+                            constraints = '[]',
+                            voter_constraints = '[+region=ap-southeast-2]',
+                            lease_preferences = '[[+region=ap-southeast-2]]'
+
+statement ok
+ALTER DATABASE testdb ADD REGION "us-east-1"
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE test
+----
+DATABASE testdb  ALTER DATABASE testdb CONFIGURE ZONE USING
+                 range_min_bytes = 134217728,
+                 range_max_bytes = 536870912,
+                 gc.ttlseconds = 90000,
+                 num_replicas = 3,
+                 num_voters = 3,
+                 constraints = '[]',
+                 voter_constraints = '[+region=ca-central-1]',
+                 lease_preferences = '[[+region=ca-central-1]]'
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE test_explicit_region
+----
+TABLE test_explicit_region  ALTER TABLE test_explicit_region CONFIGURE ZONE USING
+                            range_min_bytes = 134217728,
+                            range_max_bytes = 536870912,
+                            gc.ttlseconds = 90000,
+                            num_replicas = 3,
+                            num_voters = 3,
+                            constraints = '[]',
+                            voter_constraints = '[+region=ap-southeast-2]',
+                            lease_preferences = '[[+region=ap-southeast-2]]'
+
+# Change primary region to ensure zone config is rebuilt on table changes.
+statement ok
+ALTER DATABASE testdb SET PRIMARY REGION "ap-southeast-2"
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE test
+----
+DATABASE testdb  ALTER DATABASE testdb CONFIGURE ZONE USING
+                 range_min_bytes = 134217728,
+                 range_max_bytes = 536870912,
+                 gc.ttlseconds = 90000,
+                 num_replicas = 3,
+                 num_voters = 3,
+                 constraints = '[]',
+                 voter_constraints = '[+region=ap-southeast-2]',
+                 lease_preferences = '[[+region=ap-southeast-2]]'
+
+# Alter to DEFAULT and see that our constraints are back.
+statement ok
+ALTER DATABASE testdb SET PLACEMENT DEFAULT
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE test
+----
+DATABASE testdb  ALTER DATABASE testdb CONFIGURE ZONE USING
+                 range_min_bytes = 134217728,
+                 range_max_bytes = 536870912,
+                 gc.ttlseconds = 90000,
+                 num_replicas = 5,
+                 num_voters = 3,
+                 constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                 voter_constraints = '[+region=ap-southeast-2]',
+                 lease_preferences = '[[+region=ap-southeast-2]]'
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE test_explicit_region
+----
+TABLE test_explicit_region  ALTER TABLE test_explicit_region CONFIGURE ZONE USING
+                            range_min_bytes = 134217728,
+                            range_max_bytes = 536870912,
+                            gc.ttlseconds = 90000,
+                            num_replicas = 5,
+                            num_voters = 3,
+                            constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                            voter_constraints = '[+region=ap-southeast-2]',
+                            lease_preferences = '[[+region=ap-southeast-2]]'
+
+# Check that coming back from placement restricted results in a valid zone
+# config.
+statement ok
+SELECT * FROM crdb_internal.validate_multi_region_zone_configs()
+

--- a/pkg/ccl/multiregionccl/multiregion.go
+++ b/pkg/ccl/multiregionccl/multiregion.go
@@ -35,12 +35,17 @@ func initializeMultiRegionMetadata(
 	goal tree.SurvivalGoal,
 	primaryRegion descpb.RegionName,
 	regions []tree.Name,
+	dataPlacement tree.DataPlacement,
 ) (*multiregion.RegionConfig, error) {
 	if err := CheckClusterSupportsMultiRegion(execCfg); err != nil {
 		return nil, err
 	}
 
 	survivalGoal, err := sql.TranslateSurvivalGoal(goal)
+	if err != nil {
+		return nil, err
+	}
+	placement, err := sql.TranslateDataPlacement(dataPlacement)
 	if err != nil {
 		return nil, err
 	}
@@ -96,9 +101,7 @@ func initializeMultiRegionMetadata(
 		primaryRegion,
 		survivalGoal,
 		regionEnumID,
-		// TODO(pawalt): Using default placement for now until this gets stitched
-		// together with the proper SQL statements.
-		descpb.DataPlacement_DEFAULT,
+		placement,
 	)
 	if err := multiregion.ValidateRegionConfig(regionConfig); err != nil {
 		return nil, err

--- a/pkg/ccl/multiregionccl/region_test.go
+++ b/pkg/ccl/multiregionccl/region_test.go
@@ -10,6 +10,7 @@ package multiregionccl_test
 
 import (
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -320,6 +321,118 @@ CREATE TABLE db.rbr(k INT PRIMARY KEY, v INT NOT NULL) LOCALITY REGIONAL BY ROW;
 	}
 }
 
+// TestSettingPlacementAmidstAddDrop starts a region add/drop and alters the
+// database to PLACEMENT RESTRICTED before enum promotion in the add/drop. This
+// is required to ensure that global tables are refreshed as a result of the
+// add/drop.
+// This test is built to protect against cases where PLACEMENT RESTRICTED is
+// applied but the database finalizer doesn't realize, meaning that global
+// tables don't have their constraints refreshed. This is only a problem in the
+// DEFAULT -> RESTRICTED path as in the RESTRICTED -> DEFAULT path, global
+// tables will always be refreshed, either by virtue of inheriting the database
+// zone config or being explicitly refreshed under RESTRICTED.
+func TestSettingPlacementAmidstAddDrop(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testCases := []struct {
+		name         string
+		placementOp  string
+		regionOp     string
+		expectedZcfg string
+	}{
+		{
+			name:        "add then set restricted",
+			placementOp: "ALTER DATABASE db SET PLACEMENT RESTRICTED",
+			regionOp:    `ALTER DATABASE db ADD REGION "us-east3"`,
+			expectedZcfg: `
+ALTER TABLE db.public.global CONFIGURE ZONE USING
+	range_min_bytes = 134217728,
+	range_max_bytes = 536870912,
+	gc.ttlseconds = 90000,
+	global_reads = true,
+	num_replicas = 5,
+	num_voters = 3,
+	constraints = '{+region=us-east1: 1, +region=us-east2: 1, +region=us-east3: 1}',
+	voter_constraints = '[+region=us-east1]',
+	lease_preferences = '[[+region=us-east1]]'`,
+		},
+		{
+			name:        "drop then set restricted",
+			placementOp: "ALTER DATABASE db SET PLACEMENT RESTRICTED",
+			regionOp:    `ALTER DATABASE db DROP REGION "us-east2"`,
+			expectedZcfg: `
+ALTER TABLE db.public.global CONFIGURE ZONE USING
+	range_min_bytes = 134217728,
+	range_max_bytes = 536870912,
+	gc.ttlseconds = 90000,
+	global_reads = true,
+	num_replicas = 3,
+	num_voters = 3,
+	constraints = '{+region=us-east1: 1}',
+	voter_constraints = '[+region=us-east1]',
+	lease_preferences = '[[+region=us-east1]]'`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			regionOpStarted := make(chan struct{})
+			regionOpFinished := make(chan struct{})
+			placementOpFinished := make(chan struct{})
+
+			knobs := base.TestingKnobs{
+				SQLTypeSchemaChanger: &sql.TypeSchemaChangerTestingKnobs{
+					RunBeforeEnumMemberPromotion: func() error {
+						close(regionOpStarted)
+						<-placementOpFinished
+						return nil
+					},
+				},
+				// Decrease the adopt loop interval so that retries happen quickly.
+				JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+			}
+
+			_, sqlDB, cleanup := multiregionccltestutils.TestingCreateMultiRegionCluster(
+				t, 3 /* numServers */, knobs,
+			)
+			defer cleanup()
+
+			_, err := sqlDB.Exec(`
+CREATE DATABASE db PRIMARY REGION "us-east1" REGIONS "us-east2";
+CREATE TABLE db.global () LOCALITY GLOBAL;`)
+			require.NoError(t, err)
+
+			go func() {
+				defer func() {
+					close(regionOpFinished)
+				}()
+
+				_, err := sqlDB.Exec(tc.regionOp)
+				require.NoError(t, err)
+			}()
+
+			<-regionOpStarted
+			_, err = sqlDB.Exec(tc.placementOp)
+			require.NoError(t, err)
+			close(placementOpFinished)
+
+			<-regionOpFinished
+			var actualZoneConfig string
+			res := sqlDB.QueryRow(
+				`SELECT raw_config_sql FROM [SHOW ZONE CONFIGURATION FOR TABLE db.global]`,
+			)
+			err = res.Scan(&actualZoneConfig)
+			require.NoError(t, err)
+
+			expectedZcfg := strings.TrimSpace(tc.expectedZcfg)
+			if expectedZcfg != actualZoneConfig {
+				t.Fatalf("expected zone config %q but got %q", expectedZcfg, actualZoneConfig)
+			}
+		})
+	}
+}
+
 func TestSettingPrimaryRegionAmidstDrop(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -550,6 +663,100 @@ func TestRollbackDuringAddDropRegionAsyncJobFailure(t *testing.T) {
 			// Ensure the zone configuration didn't change.
 			var newZoneConfig string
 			res = sqlDB.QueryRow(`SELECT raw_config_sql FROM [SHOW ZONE CONFIGURATION FOR DATABASE db]`)
+			err = res.Scan(&newZoneConfig)
+			require.NoError(t, err)
+
+			if newZoneConfig != originalZoneConfig {
+				t.Fatalf("expected zone config to not have changed, expected %q found %q",
+					originalZoneConfig,
+					newZoneConfig,
+				)
+			}
+		})
+	}
+}
+
+// TestRollbackDuringAddDropRegionPlacementRestricted ensures that rollback when
+// an ADD REGION/DROP REGION fails asynchronously is handled appropriately when
+// the database has been configured with PLACEMENT RESTRICTED.
+// This also ensures that zone configuration changes on the database are
+// transactional.
+func TestRollbackDuringAddDropRegionPlacementRestricted(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	skip.UnderRace(t, "times out under race")
+
+	knobs := base.TestingKnobs{
+		SQLTypeSchemaChanger: &sql.TypeSchemaChangerTestingKnobs{
+			RunBeforeMultiRegionUpdates: func() error {
+				return errors.New("boom")
+			},
+		},
+		// Decrease the adopt loop interval so that retries happen quickly.
+		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+	}
+
+	// Setup.
+	_, sqlDB, cleanup := multiregionccltestutils.TestingCreateMultiRegionCluster(
+		t, 3 /* numServers */, knobs,
+	)
+	defer cleanup()
+	_, err := sqlDB.Exec(
+		`CREATE DATABASE db WITH PRIMARY REGION "us-east1" REGIONS "us-east2" PLACEMENT RESTRICTED`,
+	)
+	require.NoError(t, err)
+
+	_, err = sqlDB.Exec(`CREATE TABLE db.test_global () LOCALITY GLOBAL`)
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name  string
+		query string
+	}{
+		{
+			"add-region",
+			`ALTER DATABASE db ADD REGION "us-east3"`,
+		},
+		{
+			"drop-region",
+			`ALTER DATABASE db DROP REGION "us-east2"`,
+		},
+		{
+			"add-drop-region-in-txn",
+			`BEGIN;
+	ALTER DATABASE db DROP REGION "us-east2";
+	ALTER DATABASE db ADD REGION "us-east3";
+	COMMIT`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var originalZoneConfig string
+			res := sqlDB.QueryRow(
+				`SELECT raw_config_sql FROM [SHOW ZONE CONFIGURATION FOR TABLE db.test_global]`,
+			)
+			err = res.Scan(&originalZoneConfig)
+			require.NoError(t, err)
+
+			_, err = sqlDB.Exec(tc.query)
+			testutils.IsError(err, "boom")
+
+			var jobStatus string
+			var jobErr string
+			row := sqlDB.QueryRow(
+				"SELECT status, error FROM [SHOW JOBS] WHERE job_type = 'TYPEDESC SCHEMA CHANGE'",
+			)
+			require.NoError(t, row.Scan(&jobStatus, &jobErr))
+			require.Contains(t, "boom", jobErr)
+			require.Contains(t, "failed", jobStatus)
+
+			// Ensure the zone configuration didn't change.
+			var newZoneConfig string
+			res = sqlDB.QueryRow(
+				`SELECT raw_config_sql FROM [SHOW ZONE CONFIGURATION FOR TABLE db.test_global]`,
+			)
 			err = res.Scan(&newZoneConfig)
 			require.NoError(t, err)
 

--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -748,6 +748,19 @@ func (n *alterDatabasePrimaryRegionNode) switchPrimaryRegion(params runParams) e
 		return err
 	}
 
+	// Update all GLOBAL tables' zone configurations. This is required as if
+	// LOCALITY GLOBAL is used with PLACEMENT RESTRICTED, the global tables' zone
+	// configs must be explicitly rebuilt so as to move their primary region.
+	if updatedRegionConfig.IsPlacementRestricted() {
+		if err := params.p.updateZoneConfigsForTables(
+			params.ctx,
+			n.desc,
+			WithOnlyGlobalTables,
+		); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -844,6 +857,7 @@ func (n *alterDatabasePrimaryRegionNode) setInitialPrimaryRegion(params runParam
 		tree.SurvivalGoalDefault,
 		n.n.PrimaryRegion,
 		[]tree.Name{n.n.PrimaryRegion},
+		tree.DataPlacementUnspecified,
 	)
 	if err != nil {
 		return err
@@ -999,6 +1013,15 @@ func (n *alterDatabaseSurvivalGoalNode) startExec(params runParams) error {
 		)
 	}
 
+	if n.n.SurvivalGoal == tree.SurvivalGoalRegionFailure &&
+		n.desc.RegionConfig.Placement == descpb.DataPlacement_RESTRICTED {
+		return errors.WithDetailf(
+			pgerror.New(pgcode.InvalidParameterValue,
+				"a region-survivable database cannot also have a restricted placement policy"),
+			"PLACEMENT RESTRICTED may only be used with SURVIVE ZONE FAILURE",
+		)
+	}
+
 	if err := params.p.validateZoneConfigForMultiRegionDatabaseWasNotModifiedByUser(
 		params.ctx,
 		n.desc,
@@ -1045,7 +1068,7 @@ func (n *alterDatabaseSurvivalGoalNode) startExec(params runParams) error {
 
 	// Update all REGIONAL BY TABLE tables' zone configurations. This is required as replica
 	// placement for REGIONAL BY TABLE tables is dependant on the survival goal.
-	if err := params.p.updateZoneConfigsForAllTables(params.ctx, n.desc); err != nil {
+	if err := params.p.updateZoneConfigsForTables(params.ctx, n.desc); err != nil {
 		return err
 	}
 
@@ -1064,3 +1087,120 @@ func (n *alterDatabaseSurvivalGoalNode) startExec(params runParams) error {
 func (n *alterDatabaseSurvivalGoalNode) Next(runParams) (bool, error) { return false, nil }
 func (n *alterDatabaseSurvivalGoalNode) Values() tree.Datums          { return tree.Datums{} }
 func (n *alterDatabaseSurvivalGoalNode) Close(context.Context)        {}
+
+type alterDatabasePlacementNode struct {
+	n    *tree.AlterDatabasePlacement
+	desc *dbdesc.Mutable
+}
+
+// AlterDatabasePlacement transforms a tree.AlterDatabasePlacement into a plan node.
+func (p *planner) AlterDatabasePlacement(
+	ctx context.Context, n *tree.AlterDatabasePlacement,
+) (planNode, error) {
+	if err := checkSchemaChangeEnabled(
+		ctx,
+		p.ExecCfg(),
+		"ALTER DATABASE",
+	); err != nil {
+		return nil, err
+	}
+
+	// TODO(pawalt): #68598 add a check for placement enabled cluster setting
+
+	dbDesc, err := p.Descriptors().GetMutableDatabaseByName(ctx, p.txn, string(n.Name),
+		tree.DatabaseLookupFlags{Required: true},
+	)
+	if err != nil {
+		return nil, err
+	}
+	if err := p.checkPrivilegesForMultiRegionOp(ctx, dbDesc); err != nil {
+		return nil, err
+	}
+
+	return &alterDatabasePlacementNode{n: n, desc: dbDesc}, nil
+}
+
+func (n *alterDatabasePlacementNode) startExec(params runParams) error {
+	// If the database is not a multi-region database, the survival goal cannot be changed.
+	if !n.desc.IsMultiRegion() {
+		return errors.WithHintf(
+			pgerror.New(pgcode.InvalidName,
+				"database must have associated regions before a placement policy can be set",
+			),
+			"you must first add a primary region to the database using "+
+				"ALTER DATABASE %s PRIMARY REGION <region_name>",
+			n.n.Name.String(),
+		)
+	}
+
+	if n.n.Placement == tree.DataPlacementRestricted &&
+		n.desc.RegionConfig.SurvivalGoal == descpb.SurvivalGoal_REGION_FAILURE {
+		return errors.WithDetailf(
+			pgerror.New(pgcode.InvalidParameterValue,
+				"a region-survivable database cannot also have a restricted placement policy"),
+			"PLACEMENT RESTRICTED may only be used with SURVIVE ZONE FAILURE",
+		)
+	}
+
+	if err := params.p.validateZoneConfigForMultiRegionDatabaseWasNotModifiedByUser(
+		params.ctx,
+		n.desc,
+	); err != nil {
+		return err
+	}
+
+	// Update the placement strategy in the database descriptor
+	newPlacement, err := TranslateDataPlacement(n.n.Placement)
+	if err != nil {
+		return err
+	}
+	n.desc.SetPlacement(newPlacement)
+
+	if err := params.p.writeNonDropDatabaseChange(
+		params.ctx,
+		n.desc,
+		tree.AsStringWithFQNames(n.n, params.Ann()),
+	); err != nil {
+		return err
+	}
+
+	regionConfig, err := SynthesizeRegionConfig(params.ctx, params.p.txn, n.desc.ID, params.p.Descriptors())
+	if err != nil {
+		return err
+	}
+
+	// Update the database's zone configuration.
+	if err := ApplyZoneConfigFromDatabaseRegionConfig(
+		params.ctx,
+		n.desc.ID,
+		regionConfig,
+		params.p.txn,
+		params.p.execCfg,
+	); err != nil {
+		return err
+	}
+
+	// Update all GLOBAL tables' zone configurations. This is required because
+	// GLOBAL table's can inherit the database's zone configuration under the
+	// DEFAULT placement policy. However, under the RESTRICTED placement policy,
+	// non-voters are removed from the database. But global tables need non-voters
+	// to behave properly, and as such, need a bespoke zone configuration.
+	// Regardless of the transition direction (DEFAULT -> RESTRICTED, RESTRICTED
+	// -> DEFAULT), we need to refresh the zone configuration of all GLOBAL
+	// table's inside the database to either carry a bespoke configuration or go
+	// back to inheriting it from the database.
+	if err := params.p.updateZoneConfigsForTables(
+		params.ctx,
+		n.desc,
+		WithOnlyGlobalTables,
+	); err != nil {
+		return err
+	}
+
+	// TODO(pawalt): #68597 add telemetry/logging for PLACEMENT events.
+	return nil
+}
+
+func (n *alterDatabasePlacementNode) Next(runParams) (bool, error) { return false, nil }
+func (n *alterDatabasePlacementNode) Values() tree.Datums          { return tree.Datums{} }
+func (n *alterDatabasePlacementNode) Close(context.Context)        {}

--- a/pkg/sql/catalog/dbdesc/database_desc.go
+++ b/pkg/sql/catalog/dbdesc/database_desc.go
@@ -406,6 +406,12 @@ func (desc *Mutable) SetRegionConfig(cfg *descpb.DatabaseDescriptor_RegionConfig
 	desc.RegionConfig = cfg
 }
 
+// SetPlacement sets the placement on the region config for a database
+// descriptor.
+func (desc *Mutable) SetPlacement(placement descpb.DataPlacement) {
+	desc.RegionConfig.Placement = placement
+}
+
 // HasPostDeserializationChanges returns if the MutableDescriptor was changed after running
 // RunPostDeserializationChanges.
 func (desc *Mutable) HasPostDeserializationChanges() bool {

--- a/pkg/sql/catalog/dbdesc/database_desc_builder.go
+++ b/pkg/sql/catalog/dbdesc/database_desc_builder.go
@@ -128,6 +128,7 @@ func MaybeWithDatabaseRegionConfig(regionConfig *multiregion.RegionConfig) NewIn
 			SurvivalGoal:  regionConfig.SurvivalGoal(),
 			PrimaryRegion: regionConfig.PrimaryRegion(),
 			RegionEnumID:  regionConfig.RegionEnumID(),
+			Placement:     regionConfig.Placement(),
 		}
 	}
 }

--- a/pkg/sql/catalog/multiregion/region_config.go
+++ b/pkg/sql/catalog/multiregion/region_config.go
@@ -78,6 +78,11 @@ func (r *RegionConfig) RegionEnumID() descpb.ID {
 	return r.regionEnumID
 }
 
+// Placement returns the data placement strategy for the region config.
+func (r *RegionConfig) Placement() descpb.DataPlacement {
+	return r.placement
+}
+
 // IsPlacementRestricted returns true if the database is in restricted
 // placement, false otherwise.
 func (r *RegionConfig) IsPlacementRestricted() bool {

--- a/pkg/sql/logictest/testdata/logic_test/alter_database_placement
+++ b/pkg/sql/logictest/testdata/logic_test/alter_database_placement
@@ -1,8 +1,0 @@
-statement ok
-CREATE DATABASE d;
-
-statement error altering database placement is not yet supported
-ALTER DATABASE d SET PLACEMENT DEFAULT
-
-statement error altering database placement is not yet supported
-ALTER DATABASE d SET PLACEMENT RESTRICTED

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -283,6 +283,7 @@ CREATE TABLE crdb_internal.databases (
    primary_region STRING NULL,
    regions STRING[] NULL,
    survival_goal STRING NULL,
+   placement_policy STRING NULL,
    create_statement STRING NOT NULL
 )  CREATE TABLE crdb_internal.databases (
    id INT8 NOT NULL,
@@ -291,6 +292,7 @@ CREATE TABLE crdb_internal.databases (
    primary_region STRING NULL,
    regions STRING[] NULL,
    survival_goal STRING NULL,
+   placement_policy STRING NULL,
    create_statement STRING NOT NULL
 )  {}  {}
 CREATE TABLE crdb_internal.default_privileges (

--- a/pkg/sql/opaque.go
+++ b/pkg/sql/opaque.go
@@ -84,6 +84,8 @@ func planOpaque(ctx context.Context, p *planner, stmt tree.Statement) (planNode,
 		return p.AlterDatabaseDropRegion(ctx, n)
 	case *tree.AlterDatabasePrimaryRegion:
 		return p.AlterDatabasePrimaryRegion(ctx, n)
+	case *tree.AlterDatabasePlacement:
+		return p.AlterDatabasePlacement(ctx, n)
 	case *tree.AlterDatabaseSurvivalGoal:
 		return p.AlterDatabaseSurvivalGoal(ctx, n)
 	case *tree.AlterDefaultPrivileges:
@@ -224,6 +226,7 @@ func init() {
 		&tree.AlterDatabaseDropRegion{},
 		&tree.AlterDatabaseOwner{},
 		&tree.AlterDatabasePrimaryRegion{},
+		&tree.AlterDatabasePlacement{},
 		&tree.AlterDatabaseSurvivalGoal{},
 		&tree.AlterDefaultPrivileges{},
 		&tree.AlterIndex{},

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -339,9 +339,6 @@ func (b *Builder) buildStmt(
 	case *tree.Export:
 		return b.buildExport(stmt, inScope)
 
-	case *tree.AlterDatabasePlacement:
-		panic(pgerror.New(pgcode.FeatureNotSupported, "altering database placement is not yet supported"))
-
 	default:
 		// See if this statement can be rewritten to another statement using the
 		// delegate functionality.

--- a/pkg/sql/region_util_test.go
+++ b/pkg/sql/region_util_test.go
@@ -362,7 +362,7 @@ func TestZoneConfigForMultiRegionDatabase(t *testing.T) {
 						},
 					},
 				},
-				Constraints:                 []zonepb.ConstraintsConjunction{},
+				Constraints:                 nil,
 				NullVoterConstraintsIsEmpty: true,
 				VoterConstraints: []zonepb.ConstraintsConjunction{
 					{
@@ -397,7 +397,7 @@ func TestZoneConfigForMultiRegionDatabase(t *testing.T) {
 						},
 					},
 				},
-				Constraints:                 []zonepb.ConstraintsConjunction{},
+				Constraints:                 nil,
 				NullVoterConstraintsIsEmpty: true,
 				VoterConstraints: []zonepb.ConstraintsConjunction{
 					{

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -336,6 +336,7 @@ var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&alterDatabaseOwnerNode{}):         "alter database owner",
 	reflect.TypeOf(&alterDatabaseAddRegionNode{}):     "alter database add region",
 	reflect.TypeOf(&alterDatabasePrimaryRegionNode{}): "alter database primary region",
+	reflect.TypeOf(&alterDatabasePlacementNode{}):     "alter database placement",
 	reflect.TypeOf(&alterDatabaseSurvivalGoalNode{}):  "alter database survive",
 	reflect.TypeOf(&alterDatabaseDropRegionNode{}):    "alter database drop region",
 	reflect.TypeOf(&alterDefaultPrivilegesNode{}):     "alter default privileges",


### PR DESCRIPTION
This PR combines the existing restricted placement zone config logic
with the stubbed syntax to create an end-to-end PLACEMENT RESTRICTED
implementation.

Release note: None

Note that the cluster setting for domiciling and telemetry will be added in a later PR.