### PR TITLE
sql: add entries for default privileges for all roles in pg_default_acl

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog_pg_default_acl
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog_pg_default_acl
@@ -102,3 +102,33 @@ SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
 4149409857  1546506610  0                r              {foo=/}
+
+# Check that entries show up for default privileges defined for all roles.
+# The defaclrole oid should be 0.
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ALL ROLES GRANT ALL ON TABLES TO foo, bar;
+ALTER DEFAULT PRIVILEGES FOR ALL ROLES GRANT ALL ON TYPES TO foo, bar;
+ALTER DEFAULT PRIVILEGES FOR ALL ROLES GRANT ALL ON SCHEMAS TO foo, bar;
+ALTER DEFAULT PRIVILEGES FOR ALL ROLES GRANT ALL ON SEQUENCES TO foo, bar;
+
+query OOOTT colnames,rowsort
+SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
+----
+oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
+4149409857  1546506610  0                r              {foo=/}
+2946850069  0           0                n              {bar=CU/,foo=CU/}
+2946850069  0           0                r              {bar=Cadrw/,foo=Cadrw/}
+2946850069  0           0                S              {bar=Cadrw/,foo=Cadrw/}
+2946850069  0           0                T              {bar=U/,foo=U/}
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ALL ROLES REVOKE ALL ON TABLES FROM foo, bar;
+ALTER DEFAULT PRIVILEGES FOR ALL ROLES REVOKE ALL ON TYPES FROM foo, bar;
+ALTER DEFAULT PRIVILEGES FOR ALL ROLES REVOKE ALL ON SCHEMAS FROM foo, bar;
+ALTER DEFAULT PRIVILEGES FOR ALL ROLES REVOKE ALL ON SEQUENCES FROM foo, bar;
+
+query OOOTT colnames,rowsort
+SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
+----
+oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
+4149409857  1546506610  0                r              {foo=/}


### PR DESCRIPTION
Release note (sql change): Add entries for default privileges defined
for all users in pg_default_acl.

If the default privileges are defined for all roles, the defaclrole oid is
0.