### PR TITLE
multitenant: report SQL pod CPU usage

### DIFF
--- a/pkg/ccl/multitenantccl/tenantcostclient/BUILD.bazel
+++ b/pkg/ccl/multitenantccl/tenantcostclient/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//pkg/util/log",
         "//pkg/util/stop",
         "//pkg/util/syncutil",
+        "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )
@@ -41,6 +42,7 @@ go_test(
         "//pkg/server",
         "//pkg/settings/cluster",
         "//pkg/sql",
+        "//pkg/testutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",

--- a/pkg/ccl/multitenantccl/tenantcostclient/testdata/consumption
+++ b/pkg/ccl/multitenantccl/tenantcostclient/testdata/consumption
@@ -37,6 +37,17 @@ Reads:  1 requests (1024000 bytes)
 Writes:  1 requests (1024 bytes)
 SQL Pods CPU seconds:  0.00
 
+cpu
+1s
+----
+
+usage
+----
+RU:  1011.86
+Reads:  1 requests (1024000 bytes)
+Writes:  1 requests (1024 bytes)
+SQL Pods CPU seconds:  1.00
+
 write-request bytes=4096
 ----
 
@@ -51,7 +62,18 @@ write-request bytes=4096
 
 usage
 ----
-RU:  18.31
+RU:  1018.31
 Reads:  2 requests (1089536 bytes)
 Writes:  3 requests (9216 bytes)
-SQL Pods CPU seconds:  0.00
+SQL Pods CPU seconds:  1.00
+
+cpu
+1h
+----
+
+usage
+----
+RU:  3601018.31
+Reads:  2 requests (1089536 bytes)
+Writes:  3 requests (9216 bytes)
+SQL Pods CPU seconds:  3601.00

--- a/pkg/multitenant/cost_controller.go
+++ b/pkg/multitenant/cost_controller.go
@@ -21,10 +21,14 @@ import (
 // and throttles resource usage. Its implementation lives in the
 // tenantcostclient CCL package.
 type TenantSideCostController interface {
-	Start(ctx context.Context, stopper *stop.Stopper) error
+	Start(ctx context.Context, stopper *stop.Stopper, cpuSecsFn CPUSecsFn) error
 
 	TenantSideKVInterceptor
 }
+
+// CPUSecsFn is a function used to get the cumulative CPU usage in seconds for
+// the SQL instance.
+type CPUSecsFn func(ctx context.Context) float64
 
 // TenantSideKVInterceptor intercepts KV requests and responses, accounting
 // for resource usage and potentially throttling requests.

--- a/pkg/server/status/runtime.go
+++ b/pkg/server/status/runtime.go
@@ -687,3 +687,15 @@ func subtractNetworkCounters(from *net.IOCountersStat, sub net.IOCountersStat) {
 	from.PacketsRecv -= sub.PacketsRecv
 	from.PacketsSent -= sub.PacketsSent
 }
+
+// GetUserCPUSeconds returns the cumulative User CPU time for this process, in
+// seconds.
+func GetUserCPUSeconds(ctx context.Context) float64 {
+	pid := os.Getpid()
+	cpuTime := gosigar.ProcTime{}
+	if err := cpuTime.Get(pid); err != nil {
+		log.Ops.Errorf(ctx, "unable to get cpu usage: %v", err)
+	}
+	// cpuTime.User is in milliseconds; convert to seconds.
+	return float64(cpuTime.User) * 1e-3
+}

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -195,7 +195,7 @@ func StartTenant(
 	log.SetNodeIDs(clusterID, 0 /* nodeID is not known for a SQL-only server. */)
 	log.SetTenantIDs(args.TenantID.String(), int32(s.SQLInstanceID()))
 
-	if err := args.costController.Start(ctx, args.stopper); err != nil {
+	if err := args.costController.Start(ctx, args.stopper, status.GetUserCPUSeconds); err != nil {
 		return nil, "", "", err
 	}
 
@@ -412,7 +412,9 @@ type noopTenantSideCostController struct{}
 
 var _ multitenant.TenantSideCostController = noopTenantSideCostController{}
 
-func (noopTenantSideCostController) Start(ctx context.Context, stopper *stop.Stopper) error {
+func (noopTenantSideCostController) Start(
+	ctx context.Context, stopper *stop.Stopper, cpuSecsFn multitenant.CPUSecsFn,
+) error {
 	return nil
 }
 


### PR DESCRIPTION
The tenant cost controller now reports the user CPU time.

We have a built-in allowance of `1%` of a CPU core, to account for
background activity; only usage above that counts toward consumption.

Release note: None