### PR TITLE
ci: separate out "check generated files up-to-date" into separate ci job

### DIFF
--- a/build/teamcity-bazel-support.sh
+++ b/build/teamcity-bazel-support.sh
@@ -6,9 +6,9 @@ BAZEL_IMAGE=cockroachdb/bazel:20210729-154657
 # Call `run_bazel $NAME_OF_SCRIPT` to start an appropriately-configured Docker
 # container with the `cockroachdb/bazel` image running the given script.
 #
-# Set the TEAMCITY_BAZEL_SUPPORT_LINT variable for lints -- this will mount the
-# workspace as writeable in the Docker container, will avoid setting up the
-# artifacts directory, etc.
+# Set the TEAMCITY_BAZEL_SUPPORT_GENERATE variable for scripts that generate
+# files in the workspace -- this will mount the workspace as writeable in the
+# Docker container, will avoid setting up the artifacts directory, etc.
 run_bazel() {
     if [ -z "${root:-}" ]
     then
@@ -20,7 +20,7 @@ run_bazel() {
     vols="--volume /home/agent/.bazelcache:/root/.cache/bazel"
 
     workspace_vol="--volume ${root}:/go/src/github.com/cockroachdb/cockroach"
-    if [ -z "${TEAMCITY_BAZEL_SUPPORT_LINT:-}" ]
+    if [ -z "${TEAMCITY_BAZEL_SUPPORT_GENERATE:-}" ]
     then
         artifacts_dir=$root/artifacts
         mkdir -p "$artifacts_dir"

--- a/build/teamcity-check-genfiles.sh
+++ b/build/teamcity-check-genfiles.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source "$(dirname "${0}")/teamcity-support.sh"
+source "$(dirname "${0}")/teamcity-bazel-support.sh"  # For run_bazel
+
+function check_clean() {
+  # The workspace is clean iff `git status --porcelain` produces no output. Any
+  # output is either an error message or a listing of an untracked/dirty file.
+  if [[ "$(git status --porcelain 2>&1)" != "" ]]; then
+    git status >&2 || true
+    git diff -a >&2 || true
+    echo "====================================================" >&2
+    echo "Some automatically generated code is not up to date." >&2
+    echo $1 >&2
+    exit 1
+  fi
+}
+
+tc_prepare
+
+tc_start_block "Ensure generated code is up-to-date"
+# Buffer noisy output and only print it on failure.
+if ! run run_bazel build/bazelutil/check.sh &> artifacts/buildshort.log || (cat artifacts/buildshort.log && false); then
+    # The command will output instructions on how to fix the error.
+    exit 1
+fi
+rm artifacts/buildshort.log
+TEAMCITY_BAZEL_SUPPORT_GENERATE=1  # See teamcity-bazel-support.sh.
+run run_bazel build/bazelutil/bazel-generate.sh &> artifacts/buildshort.log || (cat artifacts/buildshort.log && false)
+rm artifacts/buildshort.log
+check_clean "Run \`make bazel-generate\` to automatically regenerate these."
+run build/builder.sh make generate &> artifacts/generate.log || (cat artifacts/generate.log && false)
+rm artifacts/generate.log
+check_clean "Run \`make generate\` to automatically regenerate these."
+run build/builder.sh make buildshort &> artifacts/buildshort.log || (cat artifacts/buildshort.log && false)
+rm artifacts/buildshort.log
+check_clean "Run \`make buildshort\` to automatically regenerate these."
+tc_end_block "Ensure generated code is up-to-date"
+
+# generated code can generate new dependencies; check dependencies after generated code.
+tc_start_block "Ensure dependencies are up-to-date"
+# Run go mod tidy and `make -k vendor_rebuild` and ensure nothing changes.
+run build/builder.sh go mod tidy
+check_clean "Run \`go mod tidy\` and \`make -k vendor_rebuild\` to automatically regenerate these."
+run build/builder.sh make -k vendor_rebuild
+cd vendor
+check_clean "Run \`make -k vendor_rebuild\` to automatically regenerate these."
+cd ..
+tc_end_block "Ensure dependencies are up-to-date"
+
+tc_start_block "Test web UI"
+# Run the UI tests. This logically belongs in teamcity-test.sh, but we do it
+# here to minimize total build time since this build has already generated the
+# UI.
+run build/builder.sh make -C pkg/ui
+tc_end_block "Test web UI"

--- a/build/teamcity-check.sh
+++ b/build/teamcity-check.sh
@@ -7,20 +7,6 @@ require_justification=0
 set -euo pipefail
 
 source "$(dirname "${0}")/teamcity-support.sh"
-source "$(dirname "${0}")/teamcity-bazel-support.sh"  # For run_bazel
-
-function check_clean() {
-  # The workspace is clean iff `git status --porcelain` produces no output. Any
-  # output is either an error message or a listing of an untracked/dirty file.
-  if [[ "$(git status --porcelain 2>&1)" != "" ]]; then
-    git status >&2 || true
-    git diff -a >&2 || true
-    echo "====================================================" >&2
-    echo "Some automatically generated code is not up to date." >&2
-    echo $1 >&2
-    exit 1
-  fi
-}
 
 tc_prepare
 
@@ -36,36 +22,6 @@ if [ "$require_justification" = 1 ]; then
   tc_end_block "Ensure commit message contains a release justification"
 fi
 
-tc_start_block "Ensure generated code is up-to-date"
-# Buffer noisy output and only print it on failure.
-if ! run run_bazel build/bazelutil/check.sh &> artifacts/buildshort.log || (cat artifacts/buildshort.log && false); then
-    # The command will output instructions on how to fix the error.
-    exit 1
-fi
-rm artifacts/buildshort.log
-TEAMCITY_BAZEL_SUPPORT_LINT=1  # See teamcity-bazel-support.sh.
-run run_bazel build/bazelutil/bazel-generate.sh &> artifacts/buildshort.log || (cat artifacts/buildshort.log && false)
-rm artifacts/buildshort.log
-check_clean "Run \`make bazel-generate\` to automatically regenerate these."
-run build/builder.sh make generate &> artifacts/generate.log || (cat artifacts/generate.log && false)
-rm artifacts/generate.log
-check_clean "Run \`make generate\` to automatically regenerate these."
-run build/builder.sh make buildshort &> artifacts/buildshort.log || (cat artifacts/buildshort.log && false)
-rm artifacts/buildshort.log
-check_clean "Run \`make buildshort\` to automatically regenerate these."
-tc_end_block "Ensure generated code is up-to-date"
-
-# generated code can generate new dependencies; check dependencies after generated code.
-tc_start_block "Ensure dependencies are up-to-date"
-# Run go mod tidy and `make -k vendor_rebuild` and ensure nothing changes.
-run build/builder.sh go mod tidy
-check_clean "Run \`go mod tidy\` and \`make -k vendor_rebuild\` to automatically regenerate these."
-run build/builder.sh make -k vendor_rebuild
-cd vendor
-check_clean "Run \`make -k vendor_rebuild\` to automatically regenerate these."
-cd ..
-tc_end_block "Ensure dependencies are up-to-date"
-
 tc_start_block "Lint"
 # Disable ccache so that Go doesn't try to install dependencies into GOROOT,
 # where it doesn't have write permissions. (Using ccache busts the Go package
@@ -78,10 +34,3 @@ tc_start_block "Lint"
 run_json_test env COCKROACH_BUILDER_CCACHE= \
   build/builder.sh stdbuf -eL -oL make GOTESTFLAGS=-json lint
 tc_end_block "Lint"
-
-tc_start_block "Test web UI"
-# Run the UI tests. This logically belongs in teamcity-test.sh, but we do it
-# here to minimize total build time since this build has already generated the
-# UI.
-run build/builder.sh make -C pkg/ui
-tc_end_block "Test web UI"


### PR DESCRIPTION
This splits the lint build configuration roughly in half. The lint build
config is one of the longer-running ones we see in CI, so this should
save quite a lot of time.

Release note: None