### PR TITLE
sql: remove table backrefs when dropping views in new schema changer

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/new_schema_changer
+++ b/pkg/sql/logictest/testdata/logic_test/new_schema_changer
@@ -665,8 +665,3 @@ CREATE TABLE public.trewrite (
    CONSTRAINT new_primary_key PRIMARY KEY (k ASC),
    FAMILY fam_0_k_ts (k, ts, c)
 )
-
-# Works around view back references to tables not being cleaned up.
-# see issue #66677
-statement ok
-SET experimental_use_new_schema_changer = 'off'

--- a/pkg/sql/schemachanger/scbuild/testdata/drop_database
+++ b/pkg/sql/schemachanger/scbuild/testdata/drop_database
@@ -103,6 +103,36 @@ DROP DATABASE db1 CASCADE
   details:
     dependedOn: 56
     tableId: 55
+- DROP RelationDependedOnBy:{DescID: 56, ReferencedDescID: 58}
+  state: PUBLIC
+  details:
+    dependedOn: 58
+    tableId: 56
+- DROP RelationDependedOnBy:{DescID: 58, ReferencedDescID: 59}
+  state: PUBLIC
+  details:
+    dependedOn: 59
+    tableId: 58
+- DROP RelationDependedOnBy:{DescID: 58, ReferencedDescID: 60}
+  state: PUBLIC
+  details:
+    dependedOn: 60
+    tableId: 58
+- DROP RelationDependedOnBy:{DescID: 59, ReferencedDescID: 60}
+  state: PUBLIC
+  details:
+    dependedOn: 60
+    tableId: 59
+- DROP RelationDependedOnBy:{DescID: 59, ReferencedDescID: 61}
+  state: PUBLIC
+  details:
+    dependedOn: 61
+    tableId: 59
+- DROP RelationDependedOnBy:{DescID: 61, ReferencedDescID: 64}
+  state: PUBLIC
+  details:
+    dependedOn: 64
+    tableId: 61
 - DROP Schema:{DescID: 53}
   state: PUBLIC
   details:

--- a/pkg/sql/schemachanger/scbuild/testdata/drop_schema
+++ b/pkg/sql/schemachanger/scbuild/testdata/drop_schema
@@ -67,6 +67,41 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   details:
     dependedOn: 55
     tableId: 54
+- DROP RelationDependedOnBy:{DescID: 55, ReferencedDescID: 56}
+  state: PUBLIC
+  details:
+    dependedOn: 56
+    tableId: 55
+- DROP RelationDependedOnBy:{DescID: 56, ReferencedDescID: 57}
+  state: PUBLIC
+  details:
+    dependedOn: 57
+    tableId: 56
+- DROP RelationDependedOnBy:{DescID: 56, ReferencedDescID: 58}
+  state: PUBLIC
+  details:
+    dependedOn: 58
+    tableId: 56
+- DROP RelationDependedOnBy:{DescID: 57, ReferencedDescID: 58}
+  state: PUBLIC
+  details:
+    dependedOn: 58
+    tableId: 57
+- DROP RelationDependedOnBy:{DescID: 57, ReferencedDescID: 59}
+  state: PUBLIC
+  details:
+    dependedOn: 59
+    tableId: 57
+- DROP RelationDependedOnBy:{DescID: 59, ReferencedDescID: 62}
+  state: PUBLIC
+  details:
+    dependedOn: 62
+    tableId: 59
+- DROP RelationDependedOnBy:{DescID: 59, ReferencedDescID: 63}
+  state: PUBLIC
+  details:
+    dependedOn: 63
+    tableId: 59
 - DROP Schema:{DescID: 52}
   state: PUBLIC
   details:

--- a/pkg/sql/schemachanger/scbuild/testdata/drop_table
+++ b/pkg/sql/schemachanger/scbuild/testdata/drop_table
@@ -122,6 +122,11 @@ DROP TABLE defaultdb.shipments CASCADE;
   details:
     dependedOn: 57
     tableId: 54
+- DROP RelationDependedOnBy:{DescID: 57, ReferencedDescID: 59}
+  state: PUBLIC
+  details:
+    dependedOn: 59
+    tableId: 57
 - DROP Sequence:{DescID: 58}
   state: PUBLIC
   details:

--- a/pkg/sql/schemachanger/scbuild/testdata/drop_view
+++ b/pkg/sql/schemachanger/scbuild/testdata/drop_view
@@ -9,6 +9,11 @@ CREATE VIEW defaultdb.v1 AS (SELECT name FROM defaultdb.t1)
 build
 DROP VIEW defaultdb.v1
 ----
+- DROP RelationDependedOnBy:{DescID: 52, ReferencedDescID: 53}
+  state: PUBLIC
+  details:
+    dependedOn: 53
+    tableId: 52
 - DROP View:{DescID: 53}
   state: PUBLIC
   details:
@@ -40,6 +45,36 @@ CREATE VIEW v5 AS (SELECT 'a'::defaultdb.typ::string AS k, n2, n1 from defaultdb
 build
 DROP VIEW defaultdb.v1 CASCADE
 ----
+- DROP RelationDependedOnBy:{DescID: 52, ReferencedDescID: 53}
+  state: PUBLIC
+  details:
+    dependedOn: 53
+    tableId: 52
+- DROP RelationDependedOnBy:{DescID: 53, ReferencedDescID: 54}
+  state: PUBLIC
+  details:
+    dependedOn: 54
+    tableId: 53
+- DROP RelationDependedOnBy:{DescID: 53, ReferencedDescID: 55}
+  state: PUBLIC
+  details:
+    dependedOn: 55
+    tableId: 53
+- DROP RelationDependedOnBy:{DescID: 54, ReferencedDescID: 55}
+  state: PUBLIC
+  details:
+    dependedOn: 55
+    tableId: 54
+- DROP RelationDependedOnBy:{DescID: 54, ReferencedDescID: 56}
+  state: PUBLIC
+  details:
+    dependedOn: 56
+    tableId: 54
+- DROP RelationDependedOnBy:{DescID: 56, ReferencedDescID: 59}
+  state: PUBLIC
+  details:
+    dependedOn: 59
+    tableId: 56
 - DROP TypeReference:{DescID: 59, ReferencedDescID: 57}
   state: PUBLIC
   details:

--- a/pkg/sql/schemachanger/scbuild/view.go
+++ b/pkg/sql/schemachanger/scbuild/view.go
@@ -36,13 +36,13 @@ func (b *buildContext) maybeDropViewAndDependents(
 	if err != nil {
 		panic(err)
 	}
-	// Create a node for the view we are going to drop
+	// Create a node for the view we are going to drop.
 	viewNode := &scpb.View{
 		TableID:      view.GetID(),
 		DependedOnBy: make([]descpb.ID, 0, len(view.GetDependedOnBy())),
 		DependsOn:    make([]descpb.ID, 0, len(view.TableDesc().DependsOn)),
 	}
-	// Add dependencies in a order manner for reliable
+	// Add dependencies in an ordered manner for reliable
 	// unit testing.
 	for _, dep := range view.GetDependedOnBy() {
 		viewNode.DependedOnBy = append(viewNode.DependedOnBy, dep.ID)
@@ -54,6 +54,17 @@ func (b *buildContext) maybeDropViewAndDependents(
 	sort.SliceStable(viewNode.DependedOnBy, func(i, j int) bool {
 		return viewNode.DependedOnBy[i] < viewNode.DependedOnBy[j]
 	})
+	// Clean up any back references to the tables.
+	for _, dep := range viewNode.DependsOn {
+		tableBackRef := &scpb.RelationDependedOnBy{
+			TableID:      dep,
+			DependedOnBy: viewNode.TableID,
+		}
+		if exists, _ := b.checkIfNodeExists(scpb.Target_DROP, tableBackRef); !exists {
+			b.addNode(scpb.Target_DROP,
+				tableBackRef)
+		}
+	}
 	// Only add the node if it wasn't added to avoid cycles.
 	if exists, _ := b.checkIfNodeExists(scpb.Target_DROP, viewNode); exists {
 		return

--- a/pkg/sql/schemachanger/scplan/testdata/drop_database
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_database
@@ -74,6 +74,24 @@ Stage 0
     TableID: 56
   *scop.UpdateRelationDeps
     TableID: 56
+  *scop.RemoveRelationDependedOnBy
+    DependedOnBy: 58
+    TableID: 56
+  *scop.RemoveRelationDependedOnBy
+    DependedOnBy: 59
+    TableID: 58
+  *scop.RemoveRelationDependedOnBy
+    DependedOnBy: 60
+    TableID: 58
+  *scop.RemoveRelationDependedOnBy
+    DependedOnBy: 60
+    TableID: 59
+  *scop.RemoveRelationDependedOnBy
+    DependedOnBy: 61
+    TableID: 59
+  *scop.RemoveRelationDependedOnBy
+    DependedOnBy: 64
+    TableID: 61
   *scop.RemoveTypeBackRef
     DescID: 64
     TypeID: 62

--- a/pkg/sql/schemachanger/scplan/testdata/drop_schema
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_schema
@@ -95,6 +95,24 @@ Stage 0
     TableID: 54
   *scop.UpdateRelationDeps
     TableID: 54
+  *scop.RemoveRelationDependedOnBy
+    DependedOnBy: 55
+    TableID: 54
+  *scop.RemoveRelationDependedOnBy
+    DependedOnBy: 56
+    TableID: 55
+  *scop.RemoveRelationDependedOnBy
+    DependedOnBy: 57
+    TableID: 55
+  *scop.RemoveRelationDependedOnBy
+    DependedOnBy: 57
+    TableID: 56
+  *scop.RemoveRelationDependedOnBy
+    DependedOnBy: 58
+    TableID: 56
+  *scop.RemoveRelationDependedOnBy
+    DependedOnBy: 61
+    TableID: 58
   *scop.RemoveTypeBackRef
     DescID: 61
     TypeID: 59

--- a/pkg/sql/schemachanger/scplan/testdata/drop_table
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_table
@@ -39,6 +39,9 @@ ops
 DROP TABLE defaultdb.shipments CASCADE;
 ----
 Stage 0
+  *scop.RemoveRelationDependedOnBy
+    DependedOnBy: 57
+    TableID: 55
   *scop.DropForeignKeyRef
     Name: fk_customers
     Outbound: true

--- a/pkg/sql/schemachanger/scplan/testdata/drop_view
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_view
@@ -10,6 +10,10 @@ ops
 DROP VIEW defaultdb.v1
 ----
 Stage 0
+  *scop.RemoveRelationDependedOnBy
+    DependedOnBy: 53
+    TableID: 52
+Stage 1
   *scop.MarkDescriptorAsDropped
     TableID: 53
   *scop.DrainDescriptorName
@@ -45,6 +49,24 @@ ops
 DROP VIEW defaultdb.v1 CASCADE
 ----
 Stage 0
+  *scop.RemoveRelationDependedOnBy
+    DependedOnBy: 53
+    TableID: 52
+  *scop.RemoveRelationDependedOnBy
+    DependedOnBy: 54
+    TableID: 53
+  *scop.RemoveRelationDependedOnBy
+    DependedOnBy: 55
+    TableID: 53
+  *scop.RemoveRelationDependedOnBy
+    DependedOnBy: 55
+    TableID: 54
+  *scop.RemoveRelationDependedOnBy
+    DependedOnBy: 56
+    TableID: 54
+  *scop.RemoveRelationDependedOnBy
+    DependedOnBy: 59
+    TableID: 56
   *scop.RemoveTypeBackRef
     DescID: 59
     TypeID: 57


### PR DESCRIPTION
Previously, when dropping a view in the new schema changer
the table back refs weren't properly cleaned up. This was
inadequate because we left back references to views inside
table descriptors, which could lead to errors when dropping.
To address this, this patch adds logic to clean up view back
references to tables.

Release note: None