### PR TITLE
[WIP, prototype] spanconfigccl: add datadriven test framework for SQLWatcher

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -23,6 +23,7 @@ ALL_TESTS = [
     "//pkg/ccl/oidcccl:oidcccl_test",
     "//pkg/ccl/partitionccl:partitionccl_test",
     "//pkg/ccl/serverccl:serverccl_test",
+    "//pkg/ccl/spanconfigccl:spanconfigccl_test",
     "//pkg/ccl/sqlproxyccl/cache:cache_test",
     "//pkg/ccl/sqlproxyccl/denylist:denylist_test",
     "//pkg/ccl/sqlproxyccl/idle:idle_test",

--- a/pkg/ccl/spanconfigccl/BUILD.bazel
+++ b/pkg/ccl/spanconfigccl/BUILD.bazel
@@ -1,0 +1,36 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "spanconfigccl_test",
+    srcs = [
+        "datadriven_test.go",
+        "main_test.go",
+    ],
+    data = glob(["testdata/**"]),
+    deps = [
+        "//pkg/base",
+        "//pkg/ccl/partitionccl",
+        "//pkg/ccl/utilccl",
+        "//pkg/jobs",
+        "//pkg/keys",
+        "//pkg/kv",
+        "//pkg/kv/kvclient/rangefeed",
+        "//pkg/roachpb",
+        "//pkg/security",
+        "//pkg/security/securitytest",
+        "//pkg/server",
+        "//pkg/spanconfig",
+        "//pkg/spanconfig/spanconfigsqlwatcher",
+        "//pkg/sql",
+        "//pkg/sql/catalog/catalogkv",
+        "//pkg/sql/catalog/lease",
+        "//pkg/testutils/serverutils",
+        "//pkg/testutils/testcluster",
+        "//pkg/util/leaktest",
+        "//pkg/util/log",
+        "//pkg/util/randutil",
+        "@com_github_cockroachdb_datadriven//:datadriven",
+        "@com_github_stretchr_testify//require",
+        "@in_gopkg_yaml_v2//:yaml_v2",
+    ],
+)

--- a/pkg/ccl/spanconfigccl/datadriven_test.go
+++ b/pkg/ccl/spanconfigccl/datadriven_test.go
@@ -1,0 +1,187 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package spanconfigccl_test
+
+import (
+	"context"
+	gosql "database/sql"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	_ "github.com/cockroachdb/cockroach/pkg/ccl/partitionccl"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/spanconfig"
+	"github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigsqlwatcher"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/datadriven"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+func TestSpanConfigsDataDriven(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	datadriven.Walk(t, "testdata/", func(t *testing.T, path string) {
+
+		tc := testcluster.StartTestCluster(t, 3, base.TestClusterArgs{
+			ServerArgs: base.TestServerArgs{
+				Knobs: base.TestingKnobs{
+					SpanConfig: &spanconfig.TestingKnobs{
+						ManagerDisableJobCreation: true,
+					},
+					JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+				},
+			},
+		})
+		ds := newDataDrivenTestState(tc)
+		defer ds.cleanup(ctx)
+
+		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
+			switch d.Cmd {
+			case "exec-sql":
+				_, err := ds.sqlDB.Exec(d.Input)
+				if err != nil {
+					return err.Error()
+				}
+			case "query-sql":
+				rows, err := ds.sqlDB.Query(d.Input)
+				if err != nil {
+					return err.Error()
+				}
+				cols, err := rows.Columns()
+				if err != nil {
+					t.Fatal(err)
+				}
+				// Allocate a buffer of *interface{} to write results into.
+				elemsI := make([]interface{}, len(cols))
+				for i := range elemsI {
+					elemsI[i] = new(interface{})
+				}
+				elems := make([]string, len(cols))
+
+				// Build string output of the row data.
+				var output strings.Builder
+				for rows.Next() {
+					if err := rows.Scan(elemsI...); err != nil {
+						t.Fatal(err)
+					}
+					for i, elem := range elemsI {
+						val := *(elem.(*interface{}))
+						elems[i] = fmt.Sprintf("%v", val)
+					}
+					output.WriteString(strings.Join(elems, " "))
+					output.WriteString("\n")
+				}
+				if err := rows.Err(); err != nil {
+					t.Fatal(err)
+				}
+				return output.String()
+			case "generate-span-configs":
+				mustHaveArgOrFatal(t, d, tableName)
+				mustHaveArgOrFatal(t, d, databaseName)
+
+				var tbName string
+				var dbName string
+				d.ScanArgs(t, tableName, &tbName)
+				d.ScanArgs(t, databaseName, &dbName)
+				tableDesc := catalogkv.TestingGetTableDescriptor(
+					ds.tc.Server(0).DB(), keys.SystemSQLCodec, dbName, tbName,
+				)
+				var spanConfigEntries []roachpb.SpanConfigEntry
+				err := ds.tc.Server(0).DB().Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+					var err error
+					spanConfigEntries, err = ds.sqlWatcher.GenerateSpanConfigurationsForTable(ctx, txn, tableDesc.GetID())
+					return err
+				})
+				require.NoError(t, err)
+
+				// Build string output of the row data.
+				var output strings.Builder
+				for _, entry := range spanConfigEntries {
+					span := keys.PrettyPrintRange(entry.Span.Key, entry.Span.EndKey, 1000)
+					output.WriteString("Span: ")
+					output.WriteString(span)
+					output.WriteString("\n")
+
+					yamlConfig, err := yaml.Marshal(entry.Config)
+					require.NoError(t, err)
+
+					output.WriteString(string(yamlConfig))
+					output.WriteString("-----------------------")
+					output.WriteString("\n")
+				}
+				return output.String()
+			default:
+				t.Fatalf("unknown command: %s", d.Cmd)
+			}
+
+			return ""
+		})
+	})
+}
+
+const (
+	tableName    = "table-name"
+	databaseName = "database-name"
+)
+
+func mustHaveArgOrFatal(t *testing.T, d *datadriven.TestData, arg string) {
+	if !d.HasArg(arg) {
+		t.Fatalf("no %q provided", arg)
+	}
+}
+
+type dataDrivenTestState struct {
+	tc         serverutils.TestClusterInterface
+	sqlDB      *gosql.DB
+	sqlWatcher *spanconfigsqlwatcher.SQLWatcher
+}
+
+func newDataDrivenTestState(tc serverutils.TestClusterInterface) *dataDrivenTestState {
+	ts := tc.Server(0)
+	sqlWatcher := spanconfigsqlwatcher.New(
+		keys.SystemSQLCodec,
+		ts.DB(),
+		ts.ClusterSettings(),
+		ts.RangeFeedFactory().(*rangefeed.Factory),
+		ts.Clock(),
+		ts.InternalExecutor().(*sql.InternalExecutor),
+		ts.LeaseManager().(*lease.Manager),
+		tc.Stopper(),
+		&spanconfig.TestingKnobs{
+			SQLWatcherDisableInitialScan: true,
+		},
+	)
+	return &dataDrivenTestState{
+		tc:         tc,
+		sqlDB:      tc.ServerConn(0),
+		sqlWatcher: sqlWatcher,
+	}
+}
+
+func (d *dataDrivenTestState) cleanup(ctx context.Context) {
+	if d.tc != nil {
+		d.tc.Stopper().Stop(ctx)
+	}
+	d.tc = nil
+}

--- a/pkg/ccl/spanconfigccl/main_test.go
+++ b/pkg/ccl/spanconfigccl/main_test.go
@@ -1,0 +1,33 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package spanconfigccl_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+//go:generate ../../util/leaktest/add-leaktest.sh *_test.go
+
+func TestMain(m *testing.M) {
+	defer utilccl.TestingEnableEnterprise()()
+	security.SetAssetLoader(securitytest.EmbeddedAssets)
+	randutil.SeedForTests()
+	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
+	os.Exit(m.Run())
+}

--- a/pkg/ccl/spanconfigccl/testdata/partitions_simple
+++ b/pkg/ccl/spanconfigccl/testdata/partitions_simple
@@ -1,0 +1,282 @@
+exec-sql
+CREATE DATABASE db;
+CREATE TABLE db.t(i INT PRIMARY KEY, j INT) PARTITION BY LIST (i) (
+PARTITION pi_1_2 VALUES IN (1, 2),
+PARTITION pi_3_4 VALUES IN (3, 4),
+PARTITION default VALUES IN (default)
+);
+ALTER DATABASE db CONFIGURE ZONE USING num_replicas=7;
+ALTER TABLE db.t CONFIGURE ZONE USING num_voters=5;
+----
+
+query-sql
+SHOW ZONE CONFIGURATION FOR DATABASE db
+----
+DATABASE db ALTER DATABASE db CONFIGURE ZONE USING
+	range_min_bytes = 134217728,
+	range_max_bytes = 536870912,
+	gc.ttlseconds = 90000,
+	num_replicas = 7,
+	constraints = '[]',
+	lease_preferences = '[]'
+
+query-sql
+SHOW ZONE CONFIGURATION FOR TABLE db.t
+----
+TABLE db.public.t ALTER TABLE db.public.t CONFIGURE ZONE USING
+	range_min_bytes = 134217728,
+	range_max_bytes = 536870912,
+	gc.ttlseconds = 90000,
+	num_replicas = 7,
+	num_voters = 5,
+	constraints = '[]',
+	voter_constraints = '[]',
+	lease_preferences = '[]'
+
+query-sql
+SHOW ZONE CONFIGURATION FOR PARTITION pi_1_2 OF TABLE db.t
+----
+TABLE db.public.t ALTER TABLE db.public.t CONFIGURE ZONE USING
+	range_min_bytes = 134217728,
+	range_max_bytes = 536870912,
+	gc.ttlseconds = 90000,
+	num_replicas = 7,
+	num_voters = 5,
+	constraints = '[]',
+	voter_constraints = '[]',
+	lease_preferences = '[]'
+
+generate-span-configs database-name=db table-name=t
+----
+Span: /Table/5{3-4}
+rangeminbytes: 134217728
+rangemaxbytes: 536870912
+gcttl: 90000
+globalreads: false
+numreplicas: 7
+numvoters: 5
+constraints: []
+voterconstraints: []
+leasepreferences: []
+-----------------------
+
+
+exec-sql
+ALTER PARTITION pi_1_2 OF TABLE db.t CONFIGURE ZONE USING global_reads=true
+----
+
+generate-span-configs database-name=db table-name=t
+----
+Span: /Table/53{-/1/1}
+rangeminbytes: 134217728
+rangemaxbytes: 536870912
+gcttl: 90000
+globalreads: false
+numreplicas: 7
+numvoters: 5
+constraints: []
+voterconstraints: []
+leasepreferences: []
+-----------------------
+Span: /Table/53/1/{1-2}
+rangeminbytes: 134217728
+rangemaxbytes: 536870912
+gcttl: 90000
+globalreads: true
+numreplicas: 7
+numvoters: 5
+constraints: []
+voterconstraints: []
+leasepreferences: []
+-----------------------
+Span: /Table/53/1/{2-3}
+rangeminbytes: 134217728
+rangemaxbytes: 536870912
+gcttl: 90000
+globalreads: true
+numreplicas: 7
+numvoters: 5
+constraints: []
+voterconstraints: []
+leasepreferences: []
+-----------------------
+Span: /Table/5{3/1/3-4}
+rangeminbytes: 134217728
+rangemaxbytes: 536870912
+gcttl: 90000
+globalreads: false
+numreplicas: 7
+numvoters: 5
+constraints: []
+voterconstraints: []
+leasepreferences: []
+-----------------------
+
+exec-sql
+ALTER PARTITION pi_3_4 OF TABLE db.t CONFIGURE ZONE USING gc.ttlseconds=5;
+ALTER PARTITION pi_3_4 OF TABLE db.t CONFIGURE ZONE USING num_voters=3
+----
+
+generate-span-configs database-name=db table-name=t
+----
+Span: /Table/53{-/1/1}
+rangeminbytes: 134217728
+rangemaxbytes: 536870912
+gcttl: 90000
+globalreads: false
+numreplicas: 7
+numvoters: 5
+constraints: []
+voterconstraints: []
+leasepreferences: []
+-----------------------
+Span: /Table/53/1/{1-2}
+rangeminbytes: 134217728
+rangemaxbytes: 536870912
+gcttl: 90000
+globalreads: true
+numreplicas: 7
+numvoters: 5
+constraints: []
+voterconstraints: []
+leasepreferences: []
+-----------------------
+Span: /Table/53/1/{2-3}
+rangeminbytes: 134217728
+rangemaxbytes: 536870912
+gcttl: 90000
+globalreads: true
+numreplicas: 7
+numvoters: 5
+constraints: []
+voterconstraints: []
+leasepreferences: []
+-----------------------
+Span: /Table/53/1/{3-4}
+rangeminbytes: 134217728
+rangemaxbytes: 536870912
+gcttl: 5
+globalreads: false
+numreplicas: 7
+numvoters: 3
+constraints: []
+voterconstraints: []
+leasepreferences: []
+-----------------------
+Span: /Table/53/1/{4-5}
+rangeminbytes: 134217728
+rangemaxbytes: 536870912
+gcttl: 5
+globalreads: false
+numreplicas: 7
+numvoters: 3
+constraints: []
+voterconstraints: []
+leasepreferences: []
+-----------------------
+Span: /Table/5{3/1/5-4}
+rangeminbytes: 134217728
+rangemaxbytes: 536870912
+gcttl: 90000
+globalreads: false
+numreplicas: 7
+numvoters: 5
+constraints: []
+voterconstraints: []
+leasepreferences: []
+-----------------------
+
+exec-sql
+ALTER PARTITION default OF TABLE db.t CONFIGURE ZONE USING num_voters=6
+----
+
+generate-span-configs database-name=db table-name=t
+----
+Span: /Table/53{-/1}
+rangeminbytes: 134217728
+rangemaxbytes: 536870912
+gcttl: 90000
+globalreads: false
+numreplicas: 7
+numvoters: 5
+constraints: []
+voterconstraints: []
+leasepreferences: []
+-----------------------
+Span: /Table/53/1{-/1}
+rangeminbytes: 134217728
+rangemaxbytes: 536870912
+gcttl: 90000
+globalreads: false
+numreplicas: 7
+numvoters: 6
+constraints: []
+voterconstraints: []
+leasepreferences: []
+-----------------------
+Span: /Table/53/1/{1-2}
+rangeminbytes: 134217728
+rangemaxbytes: 536870912
+gcttl: 90000
+globalreads: true
+numreplicas: 7
+numvoters: 5
+constraints: []
+voterconstraints: []
+leasepreferences: []
+-----------------------
+Span: /Table/53/1/{2-3}
+rangeminbytes: 134217728
+rangemaxbytes: 536870912
+gcttl: 90000
+globalreads: true
+numreplicas: 7
+numvoters: 5
+constraints: []
+voterconstraints: []
+leasepreferences: []
+-----------------------
+Span: /Table/53/1/{3-4}
+rangeminbytes: 134217728
+rangemaxbytes: 536870912
+gcttl: 5
+globalreads: false
+numreplicas: 7
+numvoters: 3
+constraints: []
+voterconstraints: []
+leasepreferences: []
+-----------------------
+Span: /Table/53/1/{4-5}
+rangeminbytes: 134217728
+rangemaxbytes: 536870912
+gcttl: 5
+globalreads: false
+numreplicas: 7
+numvoters: 3
+constraints: []
+voterconstraints: []
+leasepreferences: []
+-----------------------
+Span: /Table/53/{1/5-2}
+rangeminbytes: 134217728
+rangemaxbytes: 536870912
+gcttl: 90000
+globalreads: false
+numreplicas: 7
+numvoters: 6
+constraints: []
+voterconstraints: []
+leasepreferences: []
+-----------------------
+Span: /Table/5{3/2-4}
+rangeminbytes: 134217728
+rangemaxbytes: 536870912
+gcttl: 90000
+globalreads: false
+numreplicas: 7
+numvoters: 5
+constraints: []
+voterconstraints: []
+leasepreferences: []
+-----------------------


### PR DESCRIPTION
WIP

This patch adds a datadriven test framework to test SQLWatcher's
GenerateSpanConfigurations method.

Release note: None