### PR TITLE
ui: fix awkward display of statements in transaction detail page

### DIFF
--- a/pkg/ui/cluster-ui/src/statementsTable/statementsTable.tsx
+++ b/pkg/ui/cluster-ui/src/statementsTable/statementsTable.tsx
@@ -215,6 +215,22 @@ export function shortStatement(summary: StatementSummary, original: string) {
   }
 }
 
+export function makeStatementFingerprintColumn(
+  statType: StatisticType,
+  selectedApp: string,
+  search?: string,
+  onStatementClick?: (statement: string) => void,
+): ColumnDescriptor<AggregateStatistics> {
+  return {
+    name: "statements",
+    title: statisticsTableTitles.statements(statType),
+    className: cx("cl-table__col-query-text"),
+    cell: StatementTableCell.statements(search, selectedApp, onStatementClick),
+    sort: stmt => stmt.label,
+    alwaysShow: true,
+  };
+}
+
 export function makeStatementsColumns(
   statements: AggregateStatistics[],
   selectedApp: string,
@@ -228,18 +244,12 @@ export function makeStatementsColumns(
   onStatementClick?: (statement: string) => void,
 ): ColumnDescriptor<AggregateStatistics>[] {
   const columns: ColumnDescriptor<AggregateStatistics>[] = [
-    {
-      name: "statements",
-      title: statisticsTableTitles.statements(statType),
-      className: cx("cl-table__col-query-text"),
-      cell: StatementTableCell.statements(
-        search,
-        selectedApp,
-        onStatementClick,
-      ),
-      sort: stmt => stmt.label,
-      alwaysShow: true,
-    },
+    makeStatementFingerprintColumn(
+      statType,
+      selectedApp,
+      search,
+      onStatementClick,
+    ),
   ];
   columns.push(
     ...makeCommonColumns(statements, totalWorkload, nodeRegions, statType),

--- a/pkg/ui/cluster-ui/src/transactionDetails/transactionDetails.stories.tsx
+++ b/pkg/ui/cluster-ui/src/transactionDetails/transactionDetails.stories.tsx
@@ -24,6 +24,9 @@ storiesOf("Transactions Details", module)
   ))
   .add("with data", () => (
     <TransactionDetails
+      transactionText={data.statements
+        .map(s => s.key.key_data.query)
+        .join("\n")}
       statements={data.statements as any}
       nodeRegions={nodeRegions}
       lastReset={Date().toString()}
@@ -33,6 +36,7 @@ storiesOf("Transactions Details", module)
   ))
   .add("with loading indicator", () => (
     <TransactionDetails
+      transactionText={""}
       statements={undefined}
       nodeRegions={nodeRegions}
       lastReset={Date().toString()}
@@ -42,6 +46,7 @@ storiesOf("Transactions Details", module)
   ))
   .add("with error alert", () => (
     <TransactionDetails
+      transactionText={""}
       statements={undefined}
       nodeRegions={nodeRegions}
       error={error}

--- a/pkg/ui/cluster-ui/src/transactionDetails/transactionDetails.tsx
+++ b/pkg/ui/cluster-ui/src/transactionDetails/transactionDetails.tsx
@@ -23,10 +23,6 @@ import { Pagination } from "../pagination";
 import { TableStatistics } from "../tableStatistics";
 import { baseHeadingClasses } from "../transactionsPage/transactionsPageClasses";
 import { Button } from "../button";
-import {
-  collectStatementsText,
-  generateRegionNode,
-} from "src/transactionsPage/utils";
 import { tableClasses } from "../transactionsTable/transactionsTableClasses";
 import { SqlBox } from "../sql";
 import { aggregateStatements } from "../transactionsPage/utils";
@@ -48,7 +44,7 @@ import { formatTwoPlaces } from "../barCharts";
 import { ArrowLeft } from "@cockroachlabs/icons";
 import {
   populateRegionNodeForStatements,
-  makeStatementsColumns,
+  makeStatementFingerprintColumn,
 } from "src/statementsTable/statementsTable";
 
 const { containerClass } = tableClasses;
@@ -61,6 +57,7 @@ const summaryCardStylesCx = classNames.bind(summaryCardStyles);
 const transactionDetailsStylesCx = classNames.bind(transactionDetailsStyles);
 
 interface TransactionDetailsProps {
+  transactionText: string;
   statements?: Statement[];
   nodeRegions: { [nodeId: string]: string };
   transactionStats?: TransactionStats;
@@ -107,6 +104,7 @@ export class TransactionDetails extends React.Component<
 
   render() {
     const {
+      transactionText,
       statements,
       transactionStats,
       handleDetails,
@@ -134,7 +132,6 @@ export class TransactionDetails extends React.Component<
           render={() => {
             const { statements, transactionStats, lastReset } = this.props;
             const { sortSetting, pagination } = this.state;
-            const statementsSummary = collectStatementsText(statements);
             const aggregatedStatements = aggregateStatements(statements);
             const totalWorkload = calculateTotalWorkload(statements);
             populateRegionNodeForStatements(aggregatedStatements, nodeRegions);
@@ -148,7 +145,7 @@ export class TransactionDetails extends React.Component<
                   >
                     <Col span={16}>
                       <SqlBox
-                        value={statementsSummary}
+                        value={transactionText}
                         className={transactionDetailsStylesCx("summary-card")}
                       />
                     </Col>
@@ -239,20 +236,21 @@ export class TransactionDetails extends React.Component<
                     pagination={pagination}
                     totalCount={statements.length}
                     lastReset={lastReset}
-                    arrayItemName={"statements for this transaction"}
+                    arrayItemName={
+                      "statement fingerprints for this transaction"
+                    }
                     activeFilters={0}
                     resetSQLStats={resetSQLStats}
                   />
                   <div className={cx("table-area")}>
                     <SortedTable
                       data={aggregatedStatements}
-                      columns={makeStatementsColumns(
-                        aggregatedStatements,
-                        "",
-                        totalWorkload,
-                        nodeRegions,
-                        "transactionDetails",
-                      )}
+                      columns={[
+                        makeStatementFingerprintColumn(
+                          "transactionDetails",
+                          "",
+                        ),
+                      ]}
                       className={cx("statements-table")}
                       sortSetting={sortSetting}
                       onChangeSortSetting={this.onChangeSortSetting}

--- a/pkg/ui/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -26,6 +26,7 @@ import {
   aggregateAcrossNodeIDs,
   generateRegionNode,
   getTrxAppFilterOptions,
+  statementFingerprintIdsToText,
 } from "./utils";
 import {
   searchTransactionsData,
@@ -34,7 +35,7 @@ import {
 } from "./utils";
 import { forIn } from "lodash";
 import Long from "long";
-import { aggregateStatementStats, getSearchParams, unique } from "src/util";
+import { getSearchParams, unique } from "src/util";
 import { EmptyTransactionsPlaceholder } from "./emptyTransactionsPlaceholder";
 import { Loading } from "../loading";
 import { PageConfig, PageConfigItem } from "../pageConfig";
@@ -329,10 +330,14 @@ export class TransactionsPage extends React.Component<
     const transactionDetails =
       statementFingerprintIds &&
       getStatementsByFingerprintId(statementFingerprintIds, statements);
+    const transactionText =
+      statementFingerprintIds &&
+      statementFingerprintIdsToText(statementFingerprintIds, statements);
 
     return (
       <TransactionDetails
-        statements={aggregateStatementStats(transactionDetails)}
+        transactionText={transactionText}
+        statements={transactionDetails}
         nodeRegions={this.props.nodeRegions}
         transactionStats={this.state.transactionStats}
         lastReset={this.lastReset()}

--- a/pkg/ui/cluster-ui/src/transactionsPage/utils.spec.ts
+++ b/pkg/ui/cluster-ui/src/transactionsPage/utils.spec.ts
@@ -9,7 +9,11 @@
 // licenses/APL.txt.
 
 import { assert } from "chai";
-import { filterTransactions, getStatementsByFingerprintId } from "./utils";
+import {
+  filterTransactions,
+  getStatementsByFingerprintId,
+  statementFingerprintIdsToText,
+} from "./utils";
 import { Filters } from "../queryFilter/filter";
 import { data, nodeRegions } from "./transactions.fixture";
 import Long from "long";
@@ -213,6 +217,45 @@ describe("Filter transactions", () => {
         nodeRegions,
       ).transactions.length,
       9,
+    );
+  });
+});
+
+describe("statementFingerprintIdsToText", () => {
+  it("translate statement fingerprint IDs into queries", () => {
+    const statements = [
+      {
+        id: Long.fromInt(4104049045071304794),
+        key: {
+          // eslint-disable-next-line @typescript-eslint/camelcase
+          key_data: {
+            query: "SELECT _",
+          },
+        },
+      },
+      {
+        id: Long.fromInt(5104049045071304794),
+        key: {
+          // eslint-disable-next-line @typescript-eslint/camelcase
+          key_data: {
+            query: "SELECT _, _",
+          },
+        },
+      },
+    ];
+    const statementFingerprintIds = [
+      Long.fromInt(4104049045071304794),
+      Long.fromInt(5104049045071304794),
+      Long.fromInt(4104049045071304794),
+      Long.fromInt(4104049045071304794),
+    ];
+
+    assert.equal(
+      statementFingerprintIdsToText(statementFingerprintIds, statements),
+      `SELECT _
+SELECT _, _
+SELECT _
+SELECT _`,
     );
   });
 });

--- a/pkg/ui/cluster-ui/src/transactionsPage/utils.ts
+++ b/pkg/ui/cluster-ui/src/transactionsPage/utils.ts
@@ -62,6 +62,15 @@ export const getStatementsByFingerprintId = (
   );
 };
 
+export const statementFingerprintIdsToText = (
+  statementFingerprintIds: Long[],
+  statements: Statement[],
+): string => {
+  return statementFingerprintIds
+    .map(s => statements.find(stmt => stmt.id.eq(s)).key.key_data.query)
+    .join("\n");
+};
+
 export const aggregateStatements = (
   statements: Statement[],
 ): AggregateStatistics[] =>
@@ -217,11 +226,9 @@ const withFingerprint = function(
 ): TransactionWithFingerprint {
   return {
     ...t,
-    fingerprint: collectStatementsText(
-      getStatementsByFingerprintId(
-        t.stats_data.statement_fingerprint_ids,
-        stmts,
-      ),
+    fingerprint: statementFingerprintIdsToText(
+      t.stats_data.statement_fingerprint_ids,
+      stmts,
     ),
   };
 };

--- a/pkg/ui/cluster-ui/src/transactionsTable/transactionsTable.tsx
+++ b/pkg/ui/cluster-ui/src/transactionsTable/transactionsTable.tsx
@@ -33,6 +33,7 @@ import { SortSetting } from "../sortedtable";
 import {
   getStatementsByFingerprintId,
   collectStatementsText,
+  statementFingerprintIdsToText,
 } from "../transactionsPage/utils";
 import Long from "long";
 import classNames from "classnames/bind";
@@ -113,11 +114,9 @@ export const TransactionsTable: React.FC<TransactionsTable> = props => {
       title: <>Transactions</>,
       cell: (item: TransactionInfo) =>
         textCell({
-          transactionText: collectStatementsText(
-            getStatementsByFingerprintId(
-              item.stats_data.statement_fingerprint_ids,
-              statements,
-            ),
+          transactionText: statementFingerprintIdsToText(
+            item.stats_data.statement_fingerprint_ids,
+            statements,
           ),
           transactionFingerprintIds: item.stats_data.statement_fingerprint_ids,
           transactionStats: item.stats_data.stats,

--- a/pkg/ui/cluster-ui/src/util/appStats/appStats.ts
+++ b/pkg/ui/cluster-ui/src/util/appStats/appStats.ts
@@ -167,7 +167,7 @@ export function addStatementStats(
 
 export function aggregateStatementStats(
   statementStats: CollectedStatementStatistics[],
-) {
+): CollectedStatementStatistics[] {
   const statementsMap: {
     [statement: string]: CollectedStatementStatistics[];
   } = {};


### PR DESCRIPTION
Previously, we aggregate the statement texts in transaction detail
page. However, this can be misleading in the case when a statement
is executed multiple times in a transaction. Also, different
transactions with same statements but different execution count and
execution order are also incorrectly grouped into a single entry.
This commit removes the aggregation when rendering the SQL Statement
Box in the transaction detail page and correctly groups the different
transactions into different entries in the Transaction Page.
This commit also removes the statement statistics table in the
transaction detail page since this can be misleading.

Release note (ui change): Transaction Detail Page's SQL Box
now shows all of transaction's statements in the order that
they were executed. Transaction Detail Page also no longer
display statement statistics.