### PR TITLE
kv/rangefeed: avoid race between new registration and processor shutdown

### DIFF
--- a/pkg/kv/kvserver/rangefeed/registry.go
+++ b/pkg/kv/kvserver/rangefeed/registry.go
@@ -266,6 +266,11 @@ func (r *registration) outputLoop(ctx context.Context) error {
 
 func (r *registration) runOutputLoop(ctx context.Context, _forStacks roachpb.RangeID) {
 	r.mu.Lock()
+	if r.mu.disconnected {
+		// The registration has already been disconnected.
+		r.mu.Unlock()
+		return
+	}
 	ctx, r.mu.outputLoopCancelFn = context.WithCancel(ctx)
 	r.mu.Unlock()
 	err := r.outputLoop(ctx)

--- a/pkg/kv/kvserver/rangefeed/registry_test.go
+++ b/pkg/kv/kvserver/rangefeed/registry_test.go
@@ -177,6 +177,17 @@ func TestRegistrationBasic(t *testing.T) {
 	disconnectReg.disconnect(discErr)
 	err := <-disconnectReg.errC
 	require.Equal(t, discErr, err)
+	require.Equal(t, 2, len(disconnectReg.stream.Events()))
+
+	// External Disconnect before output loop.
+	disconnectEarlyReg := newTestRegistration(spAB, hlc.Timestamp{}, nil, false)
+	disconnectEarlyReg.publish(ev1)
+	disconnectEarlyReg.publish(ev2)
+	disconnectEarlyReg.disconnect(discErr)
+	go disconnectEarlyReg.runOutputLoop(context.Background(), 0)
+	err = <-disconnectEarlyReg.errC
+	require.Equal(t, discErr, err)
+	require.Equal(t, 0, len(disconnectEarlyReg.stream.Events()))
 
 	// Overflow.
 	overflowReg := newTestRegistration(spAB, hlc.Timestamp{}, nil, false)


### PR DESCRIPTION
This commit resolves a race between rangefeed registration connection
and disconnection which could have resulted in a leaked goroutine. The
call to `registration.runOutputLoop` is done in an async task, so it is
not synchronized with the calls to `registration.disconnect` from the
rangefeed processor (from `DisconnectWithErr`). Because these calls were
not synchronized, it was possible for `disconnect` to see a nil
`outputLoopCancelFn` and then shut down the stream. Then `runOutputLoop`
could set `outputLoopCancelFn` and enter `registration.outputLoop`. I
believe this could allow the output loop goroutine to leak, especially
if it never sent anything on the stream.

I don't think this relates to the resolved timestamp stall we're
currently investigating because `registration.disconnect` would have
still returned and error to the rangefeed stream during this race, so it
would not have resulted in a rangefeed getting stalled indefinitely.
Instead, only the outputLoop goroutine could have stalled, but we saw no
indication of this in goroutine dumps.