### PR TITLE
Fix the spatial code paths to be owned by @cockroachdb/spatial

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -102,7 +102,7 @@
 /pkg/cloud/                  @cockroachdb/bulk-prs
 /pkg/sql/distsql_plan_csv.go @cockroachdb/bulk-prs
 
-/pkg/geo/                    @cockroachdb/geospatial
+/pkg/geo/                    @cockroachdb/spatial
 
 /pkg/kv/                     @cockroachdb/kv-prs
 
@@ -165,10 +165,10 @@
 /pkg/cmd/fuzz/               @cockroachdb/test-eng
 /pkg/cmd/generate-binary/    @cockroachdb/sql-experience
 /pkg/cmd/generate-metadata-tables/ @cockroachdb/sql-experience
-/pkg/cmd/generate-spatial-ref-sys/ @cockroachdb/geospatial
+/pkg/cmd/generate-spatial-ref-sys/ @cockroachdb/spatial
 /pkg/cmd/generate-test-suites/ @cockroachdb/dev-inf
 /pkg/cmd/generate-staticcheck/ @cockroachdb/dev-inf
-/pkg/cmd/geoviz/             @cockroachdb/geospatial
+/pkg/cmd/geoviz/             @cockroachdb/spatial
 /pkg/cmd/github-post/        @cockroachdb/test-eng
 /pkg/cmd/github-pull-request-make/ @cockroachdb/dev-inf
 /pkg/cmd/gossipsim/          @cockroachdb/kv-prs


### PR DESCRIPTION
They were still owned by @cockroachdb/geospatial.

Release note: None