### PR TITLE
sqlliveness/slstorage: record and log when deleting a session

### DIFF
--- a/pkg/sql/sqlliveness/slstorage/slstorage_test.go
+++ b/pkg/sql/sqlliveness/slstorage/slstorage_test.go
@@ -241,6 +241,7 @@ func TestStorage(t *testing.T) {
 			require.True(t, isAlive)
 			require.Equal(t, int64(1), metrics.IsAliveCacheMisses.Count())
 			require.Equal(t, int64(0), metrics.IsAliveCacheHits.Count())
+			require.Equal(t, int64(0), metrics.SessionsDeleted.Count())
 		}
 		// Advance to the point where the session is expired.
 		timeSource.Advance(time.Second + time.Nanosecond)
@@ -251,6 +252,7 @@ func TestStorage(t *testing.T) {
 			require.False(t, isAlive)
 			require.Equal(t, int64(2), metrics.IsAliveCacheMisses.Count())
 			require.Equal(t, int64(0), metrics.IsAliveCacheHits.Count())
+			require.Equal(t, int64(1), metrics.SessionsDeleted.Count())
 		}
 		// Ensure that the fact that it is no longer alive is cached.
 		{
@@ -259,6 +261,7 @@ func TestStorage(t *testing.T) {
 			require.False(t, isAlive)
 			require.Equal(t, int64(2), metrics.IsAliveCacheMisses.Count())
 			require.Equal(t, int64(1), metrics.IsAliveCacheHits.Count())
+			require.Equal(t, int64(1), metrics.SessionsDeleted.Count())
 		}
 		// Ensure it cannot be updated.
 		{


### PR DESCRIPTION
There are two paths which delete sessions: a background job and on demand
when there's a cache miss. The second one, added later, and more commonly hit
did not log or record metrics.

Release note (ops change): Record a log event and counter increment when
removing an expired session.