### PR TITLE
release: update cockroach-cloud-images repository location

### DIFF
--- a/build/release/teamcity-make-and-publish-build.sh
+++ b/build/release/teamcity-make-and-publish-build.sh
@@ -16,17 +16,17 @@ is_custom_build="$(echo "$TC_BUILD_BRANCH" | grep -Eo "^custombuild-" || echo ""
 
 if [[ -z "${DRY_RUN}" ]] ; then
   bucket="${BUCKET-cockroach-builds}"
-  google_credentials=$GOOGLE_COCKROACH_CLOUD_IMAGES_CREDENTIALS
-  gcr_repository="us.gcr.io/cockroach-cloud-images/cockroach"
+  google_credentials=$GOOGLE_COCKROACH_CLOUD_IMAGES_COCKROACHDB_CREDENTIALS
+  gcr_repository="us-docker.pkg.dev/cockroach-cloud-images/cockroachdb/cockroach"
+  # Used for docker login for gcloud
+  gcr_hostname="us-docker.pkg.dev"
 else
   bucket="${BUCKET:-cockroach-builds-test}"
   google_credentials="$GOOGLE_COCKROACH_RELEASE_CREDENTIALS"
   gcr_repository="us.gcr.io/cockroach-release/cockroach-test"
   build_name="${build_name}.dryrun"
+  gcr_hostname="us.gcr.io"
 fi
-
-# Used for docker login for gcloud
-gcr_hostname="us.gcr.io"
 
 cat << EOF
 

--- a/build/release/teamcity-mark-build.sh
+++ b/build/release/teamcity-mark-build.sh
@@ -13,8 +13,8 @@ mark_build() {
   release_branch="$(echo "$TC_BUILD_BRANCH" | grep -Eo "^v[0-9]+\.[0-9]+" || echo"")"
 
   if [[ -z "${DRY_RUN}" ]] ; then
-    google_credentials=$GOOGLE_COCKROACH_CLOUD_IMAGES_CREDENTIALS
-    gcr_repository="us.gcr.io/cockroach-cloud-images/cockroach"
+    google_credentials=$GOOGLE_COCKROACH_CLOUD_IMAGES_COCKROACHDB_CREDENTIALS
+    gcr_repository="us-docker.pkg.dev/cockroach-cloud-images/cockroachdb/cockroach"
   else
     google_credentials=$GOOGLE_COCKROACH_RELEASE_CREDENTIALS
     gcr_repository="us.gcr.io/cockroach-release/cockroach-test"

--- a/build/release/teamcity-publish-release.sh
+++ b/build/release/teamcity-publish-release.sh
@@ -24,13 +24,15 @@ release_branch=$(echo ${build_name} | grep -E -o '^v[0-9]+\.[0-9]+')
 
 if [[ -z "${DRY_RUN}" ]] ; then
   bucket="${BUCKET:-binaries.cockroachdb.com}"
-  google_credentials="$GOOGLE_COCKROACH_CLOUD_IMAGES_CREDENTIALS"
+  google_credentials="$GOOGLE_COCKROACH_CLOUD_IMAGES_COCKROACHDB_CREDENTIALS"
   if [[ -z "${PRE_RELEASE}" ]] ; then
     dockerhub_repository="docker.io/cockroachdb/cockroach"
   else
     dockerhub_repository="docker.io/cockroachdb/cockroach-unstable"
   fi
-  gcr_repository="us.gcr.io/cockroach-cloud-images/cockroach"
+  gcr_repository="us-docker.pkg.dev/cockroach-cloud-images/cockroachdb/cockroach"
+  # Used for docker login for gcloud
+  gcr_hostname="us-docker.pkg.dev"
   s3_download_hostname="${bucket}"
   git_repo_for_tag="cockroachdb/cockroach"
 else
@@ -38,6 +40,7 @@ else
   google_credentials="$GOOGLE_COCKROACH_RELEASE_CREDENTIALS"
   dockerhub_repository="docker.io/cockroachdb/cockroach-misc"
   gcr_repository="us.gcr.io/cockroach-release/cockroach-test"
+  gcr_hostname="us.gcr.io"
   s3_download_hostname="${bucket}.s3.amazonaws.com"
   git_repo_for_tag="cockroachlabs/release-staging"
   if [[ -z "$(echo ${build_name} | grep -E -o '^v[0-9]+\.[0-9]+\.[0-9]+$')" ]] ; then
@@ -51,9 +54,6 @@ else
     build_name="${build_name}-dryrun"
   fi
 fi
-
-# Used for docker login for gcloud
-gcr_hostname="us.gcr.io"
 
 tc_end_block "Variable Setup"
 


### PR DESCRIPTION
This commit updates the location of the cockroach-cloud-images Docker
repository. For reasons described in https://cockroachlabs.atlassian.net/browse/CC-4667,
we are switching our internal CockroachDB Docker repository to this location,
which is build on top of Google Artifact Registry.

Release note: None