### PR TITLE
server: add verbose logging when graceful drain range lease transfer stalls

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -5426,6 +5426,7 @@ DrainRequest instructs the receiving node to drain.
 | shutdown | [bool](#cockroach.server.serverpb.DrainRequest-bool) |  | When true, terminates the process after the server has started draining. Setting both shutdown and do_drain to false causes the request to only operate as a probe. Setting do_drain to false and shutdown to true causes the server to shut down immediately without first draining. | [reserved](#support-status) |
 | do_drain | [bool](#cockroach.server.serverpb.DrainRequest-bool) |  | When true, perform the drain phase. See the comment above on shutdown for an explanation of the interaction between the two. do_drain is also implied by a non-nil deprecated_probe_indicator. | [reserved](#support-status) |
 | node_id | [string](#cockroach.server.serverpb.DrainRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. For compatibility with v21.2 nodes, an empty node_id is interpreted as "local". This behavior might be removed in subsequent versions. | [reserved](#support-status) |
+| verbose | [bool](#cockroach.server.serverpb.DrainRequest-bool) |  | When true, more detailed information is logged during the range lease drain phase. | [reserved](#support-status) |
 
 
 

--- a/pkg/cli/quit.go
+++ b/pkg/cli/quit.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cli/clierrorplus"
@@ -147,8 +148,12 @@ func doDrainNoTimeout(
 		}
 	}()
 
-	remainingWork = true
-	for {
+	var (
+		remaining     = uint64(math.MaxUint64)
+		prevRemaining = uint64(math.MaxUint64)
+		verbose       = false
+	)
+	for ; ; prevRemaining = remaining {
 		// Tell the user we're starting to drain. This enables the user to
 		// mentally prepare for something to take some time, as opposed to
 		// wondering why nothing is happening.
@@ -160,10 +165,11 @@ func doDrainNoTimeout(
 			DoDrain:  true,
 			Shutdown: false,
 			NodeId:   targetNode,
+			Verbose:  verbose,
 		})
 		if err != nil {
 			fmt.Fprintf(stderr, "\n") // finish the line started above.
-			return !grpcutil.IsTimeout(err), remainingWork, errors.Wrap(err, "error sending drain request")
+			return !grpcutil.IsTimeout(err), remaining > 0, errors.Wrap(err, "error sending drain request")
 		}
 		for {
 			resp, err := stream.Recv()
@@ -175,28 +181,28 @@ func doDrainNoTimeout(
 				// Unexpected error.
 				fmt.Fprintf(stderr, "\n") // finish the line started above.
 				log.Infof(ctx, "graceful shutdown failed: %v", err)
-				return false, remainingWork, err
+				return false, remaining > 0, err
 			}
 
 			if resp.IsDraining {
 				// We want to assert that the node is quitting, and tell the
 				// story about how much work was performed in logs for
 				// debugging.
+				remaining = resp.DrainRemainingIndicator
 				finalString := ""
-				if resp.DrainRemainingIndicator == 0 {
+				if remaining == 0 {
 					finalString = " (complete)"
 				}
+
 				// We use stderr so that 'cockroach quit''s stdout remains a
 				// simple 'ok' in case of success (for compatibility with
 				// scripts).
-				fmt.Fprintf(stderr, "remaining: %d%s\n",
-					resp.DrainRemainingIndicator, finalString)
-				remainingWork = resp.DrainRemainingIndicator > 0
+				fmt.Fprintf(stderr, "remaining: %d%s\n", remaining, finalString)
 			} else {
 				// Either the server has decided it wanted to stop quitting; or
 				// we're running a pre-20.1 node which doesn't populate IsDraining.
 				// In either case, we need to stop sending drain requests.
-				remainingWork = false
+				remaining = 0
 				fmt.Fprintf(stderr, "done\n")
 			}
 
@@ -209,14 +215,22 @@ func doDrainNoTimeout(
 			// Iterate until end of stream, which indicates the drain is
 			// complete.
 		}
-		if !remainingWork {
+		if remaining == 0 {
+			// No more work to do.
 			break
 		}
+
+		// If range lease transfer stalls or the number of remaining leases
+		// somehow increases, verbosity is set to help with troubleshooting.
+		if remaining >= prevRemaining {
+			verbose = true
+		}
+
 		// Avoid a busy wait with high CPU/network usage if the server
 		// replies with an incomplete drain too quickly.
 		time.Sleep(200 * time.Millisecond)
 	}
-	return false, remainingWork, nil
+	return false, remaining > 0, nil
 }
 
 // doShutdown attempts to trigger a server shutdown *without*

--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -117,6 +117,7 @@ go_library(
         "scrub.go",
         "secondary_indexes.go",
         "sequelize.go",
+        "slow_drain.go",
         "smoketest_secure.go",
         "split.go",
         "sqlalchemy.go",

--- a/pkg/cmd/roachtest/tests/registry.go
+++ b/pkg/cmd/roachtest/tests/registry.go
@@ -102,6 +102,7 @@ func RegisterTests(r registry.Registry) {
 	registerSecondaryIndexesMultiVersionCluster(r)
 	registerSecure(r)
 	registerSequelize(r)
+	registerSlowDrain(r)
 	registerSQLAlchemy(r)
 	registerSQLSmith(r)
 	registerSSTableCorruption(r)

--- a/pkg/cmd/roachtest/tests/slow_drain.go
+++ b/pkg/cmd/roachtest/tests/slow_drain.go
@@ -1,0 +1,141 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tests
+
+import (
+	"context"
+	gosql "database/sql"
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/stretchr/testify/require"
+)
+
+func registerSlowDrain(r registry.Registry) {
+	numNodes := 6
+	duration := 30 * time.Minute
+
+	r.Add(registry.TestSpec{
+		Name:    fmt.Sprintf("slow-drain/duration=%s", duration),
+		Owner:   registry.OwnerServer,
+		Cluster: r.MakeClusterSpec(numNodes),
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			runSlowDrain(ctx, t, c, duration)
+		},
+	})
+}
+
+// runSlowDrain drains 5 nodes in a test cluster of 6 (with a replication factor of 5),
+// which will guarantee a lease transfer stall. This test is meant to ensure that more
+// verbose logging occurs during lease transfer stalls.
+func runSlowDrain(ctx context.Context, t test.Test, c cluster.Cluster, duration time.Duration) {
+	const (
+		numNodes          = 6
+		pinnedNodeID      = 1
+		replicationFactor = 5
+	)
+
+	var verboseStoreLogRe = regexp.MustCompile("failed to transfer lease")
+
+	err := c.PutE(ctx, t.L(), t.Cockroach(), "./cockroach", c.All())
+	require.NoError(t, err)
+
+	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.All())
+	c.Run(ctx, c.Node(pinnedNodeID), `./cockroach workload init kv --drop --splits 1000`)
+
+	run := func(stmt string) {
+		db := c.Conn(ctx, t.L(), pinnedNodeID)
+		defer db.Close()
+
+		_, err = db.ExecContext(ctx, stmt)
+		require.NoError(t, err)
+
+		t.L().Printf("run: %s\n", stmt)
+	}
+
+	waitForReplication := func(db *gosql.DB) {
+		t.Status("waiting for initial up-replication")
+		for {
+			fullReplicated := false
+
+			err = db.QueryRow(
+				// Check if all ranges are fully replicated.
+				"SELECT min(array_length(replicas, 1)) >= $1 FROM crdb_internal.ranges",
+				replicationFactor,
+			).Scan(&fullReplicated)
+			require.NoError(t, err)
+
+			if fullReplicated {
+				break
+			}
+
+			time.Sleep(time.Second)
+		}
+	}
+
+	run(fmt.Sprintf(`ALTER RANGE default CONFIGURE ZONE USING num_replicas=%d`, replicationFactor))
+	run(fmt.Sprintf(`ALTER DATABASE system CONFIGURE ZONE USING num_replicas=%d`, replicationFactor))
+
+	db := c.Conn(ctx, t.L(), pinnedNodeID)
+	defer db.Close()
+
+	waitForReplication(db)
+
+	m := c.NewMonitor(ctx)
+	m.Go(func(ctx context.Context) error {
+		return c.RunE(ctx, c.Node(pinnedNodeID),
+			fmt.Sprintf("./cockroach workload run kv --max-rate 500 --tolerate-errors --duration=%s {pgurl:1-6}",
+				duration.String(),
+			),
+		)
+	},
+	)
+
+	// Let the workload run for a small amount of time.
+	time.Sleep(1 * time.Minute)
+
+	// Drain the last 5 nodes from the cluster, resulting in immovable leases on at least one of the nodes.
+	for nodeID := 2; nodeID <= numNodes; nodeID++ {
+		id := nodeID
+		m.Go(func(ctx context.Context) error {
+			drain := func(id int) error {
+				t.Status(fmt.Sprintf("draining node %d", id))
+				return c.RunE(ctx, c.Node(id), fmt.Sprintf("./cockroach node drain %d --insecure", id))
+			}
+			return drain(id)
+		})
+	}
+
+	// Let the drain commands run for a small amount of time.
+	time.Sleep(30 * time.Second)
+
+	// Check for more verbose logging concerning lease transfer stalls.
+	// The extra logging should exist on the logs of at least one of the nodes.
+	found := false
+	for nodeID := 2; nodeID <= numNodes; nodeID++ {
+		if err := c.RunE(ctx, c.Node(nodeID),
+			fmt.Sprintf("grep -q '%s' logs/cockroach.log", verboseStoreLogRe),
+		); err == nil {
+			found = true
+		}
+	}
+	require.True(t, found)
+
+	// Expect a failed drain.
+	err = m.WaitE()
+	require.Error(t, err)
+}

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -1189,7 +1189,7 @@ func TestLeaseExpirationBasedDrainTransfer(t *testing.T) {
 	// caught up to replica0 as draining code doesn't transfer leases to
 	// behind replicas.
 	l.ensureLeaderAndRaftState(t, l.replica0, l.replica1Desc)
-	l.tc.GetFirstStoreFromServer(t, 0).SetDraining(true, nil /* reporter */)
+	l.tc.GetFirstStoreFromServer(t, 0).SetDraining(true, nil /* reporter */, false /* verbose */)
 
 	// Check that replica0 doesn't serve reads any more.
 	pErr := l.sendRead(t, 0)
@@ -1205,7 +1205,7 @@ func TestLeaseExpirationBasedDrainTransfer(t *testing.T) {
 	// Check that replica1 now has the lease.
 	l.checkHasLease(t, 1)
 
-	l.tc.GetFirstStoreFromServer(t, 0).SetDraining(false, nil /* reporter */)
+	l.tc.GetFirstStoreFromServer(t, 0).SetDraining(false, nil /* reporter */, false /* verbose */)
 }
 
 // TestLeaseExpirationBasedDrainTransferWithExtension verifies that
@@ -1242,7 +1242,7 @@ func TestLeaseExpirationBasedDrainTransferWithExtension(t *testing.T) {
 
 	// Drain node 1 with an extension in progress.
 	go func() {
-		l.tc.GetFirstStoreFromServer(t, 1).SetDraining(true, nil /* reporter */)
+		l.tc.GetFirstStoreFromServer(t, 1).SetDraining(true, nil /* reporter */, false /* verbose */)
 	}()
 	// Now unblock the extension.
 	extensionSem <- struct{}{}
@@ -2011,7 +2011,7 @@ func TestDrainRangeRejection(t *testing.T) {
 	repl := tc.GetFirstStoreFromServer(t, 0).LookupReplica(roachpb.RKey(key))
 
 	drainingIdx := 1
-	tc.GetFirstStoreFromServer(t, 1).SetDraining(true, nil /* reporter */)
+	tc.GetFirstStoreFromServer(t, 1).SetDraining(true, nil /* reporter */, false /* verbose */)
 	chgs := roachpb.MakeReplicationChanges(roachpb.ADD_VOTER, tc.Target(drainingIdx))
 	if _, err := repl.ChangeReplicas(context.Background(), repl.Desc(), kvserver.SnapshotRequest_REBALANCE, kvserverpb.ReasonRangeUnderReplicated, "", chgs); !testutils.IsError(err, "store is draining") {
 		t.Fatalf("unexpected error: %+v", err)

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1367,7 +1367,7 @@ func (s *Store) AnnotateCtx(ctx context.Context) context.Context {
 // to report work that needed to be done and which may or may not have
 // been done by the time this call returns. See the explanation in
 // pkg/server/drain.go for details.
-func (s *Store) SetDraining(drain bool, reporter func(int, redact.SafeString)) {
+func (s *Store) SetDraining(drain bool, reporter func(int, redact.SafeString), verbose bool) {
 	s.draining.Store(drain)
 	if !drain {
 		return
@@ -1438,7 +1438,7 @@ func (s *Store) SetDraining(drain bool, reporter func(int, redact.SafeString)) {
 						// We need this check here because each call of
 						// transferAllAway() traverses all stores/replicas without
 						// checking for the timeout otherwise.
-						if log.V(1) {
+						if verbose || log.V(1) {
 							log.Infof(ctx, "lease transfer aborted due to exceeded timeout")
 						}
 						return
@@ -1477,39 +1477,55 @@ func (s *Store) SetDraining(drain bool, reporter func(int, redact.SafeString)) {
 					// manually to a non-draining replica.
 
 					if !needsLeaseTransfer {
-						if log.V(1) {
+						if verbose || log.V(1) {
 							// This logging is useful to troubleshoot incomplete drains.
 							log.Info(ctx, "not moving out")
 						}
 						atomic.AddInt32(&numTransfersAttempted, -1)
 						return
 					}
-					if log.V(1) {
+
+					desc, conf := r.DescAndSpanConfig()
+
+					if verbose || log.V(1) {
 						// This logging is useful to troubleshoot incomplete drains.
-						log.Infof(ctx, "trying to move replica out")
+						log.Infof(ctx, "attempting to transfer lease %v for range %s", drainingLeaseStatus.Lease, desc)
 					}
 
-					if needsLeaseTransfer {
-						desc, conf := r.DescAndSpanConfig()
-						transferStatus, err := s.replicateQueue.shedLease(
-							ctx,
-							r,
+					start := timeutil.Now()
+					transferStatus, err := s.replicateQueue.shedLease(
+						ctx,
+						r,
+						desc,
+						conf,
+						transferLeaseOptions{},
+					)
+					duration := timeutil.Since(start).Microseconds()
+
+					if transferStatus != transferOK {
+						const failFormat = "failed to transfer lease %s for range %s when draining: %v"
+						const durationFailFormat = "blocked for %d microseconds on transfer attempt"
+
+						infoArgs := []interface{}{
+							drainingLeaseStatus.Lease,
 							desc,
-							conf,
-							transferLeaseOptions{},
-						)
-						if transferStatus != transferOK {
-							if err != nil {
-								log.VErrEventf(ctx, 1, "failed to transfer lease %s for range %s when draining: %s",
-									drainingLeaseStatus.Lease, desc, err)
-							} else {
-								log.VErrEventf(ctx, 1, "failed to transfer lease %s for range %s when draining: %s",
-									drainingLeaseStatus.Lease, desc, transferStatus)
-							}
+						}
+						if err != nil {
+							infoArgs = append(infoArgs, err)
+						} else {
+							infoArgs = append(infoArgs, transferStatus)
+						}
+
+						if verbose {
+							log.Dev.Infof(ctx, failFormat, infoArgs...)
+							log.Dev.Infof(ctx, durationFailFormat, duration)
+						} else {
+							log.VErrEventf(ctx, 1 /* level */, failFormat, infoArgs...)
+							log.VErrEventf(ctx, 1 /* level */, durationFailFormat, duration)
 						}
 					}
 				}); err != nil {
-				if log.V(1) {
+				if verbose || log.V(1) {
 					log.Errorf(ctx, "error running draining task: %+v", err)
 				}
 				wg.Done()

--- a/pkg/server/drain.go
+++ b/pkg/server/drain.go
@@ -111,7 +111,7 @@ func (s *adminServer) Drain(req *serverpb.DrainRequest, stream serverpb.Admin_Dr
 
 	res := serverpb.DrainResponse{}
 	if doDrain {
-		remaining, info, err := s.server.Drain(ctx)
+		remaining, info, err := s.server.Drain(ctx, req.Verbose)
 		if err != nil {
 			log.Ops.Errorf(ctx, "drain failed: %v", err)
 			return err
@@ -186,7 +186,7 @@ func (s *adminServer) Drain(req *serverpb.DrainRequest, stream serverpb.Admin_Dr
 // shutdown code in cli/start.go; however, this is a mis-design. The
 // start code should use the Drain() RPC like quit does.
 func (s *Server) Drain(
-	ctx context.Context,
+	ctx context.Context, verbose bool,
 ) (remaining uint64, info redact.RedactableString, err error) {
 	reports := make(map[redact.SafeString]int)
 	var mu syncutil.Mutex
@@ -213,21 +213,23 @@ func (s *Server) Drain(
 		}
 	}()
 
-	if err := s.doDrain(ctx, reporter); err != nil {
+	if err = s.doDrain(ctx, reporter, verbose); err != nil {
 		return 0, "", err
 	}
 
 	return
 }
 
-func (s *Server) doDrain(ctx context.Context, reporter func(int, redact.SafeString)) error {
+func (s *Server) doDrain(
+	ctx context.Context, reporter func(int, redact.SafeString), verbose bool,
+) (err error) {
 	// First drain all clients and SQL leases.
-	if err := s.drainClients(ctx, reporter); err != nil {
+	if err = s.drainClients(ctx, reporter); err != nil {
 		return err
 	}
 	// Finally, mark the node as draining in liveness and drain the
 	// range leases.
-	return s.drainNode(ctx, reporter)
+	return s.drainNode(ctx, reporter, verbose)
 }
 
 // isDraining returns true if either clients are being drained
@@ -268,9 +270,11 @@ func (s *Server) drainClients(ctx context.Context, reporter func(int, redact.Saf
 
 // drainNode initiates the draining mode for the node, which
 // starts draining range leases.
-func (s *Server) drainNode(ctx context.Context, reporter func(int, redact.SafeString)) error {
-	if err := s.nodeLiveness.SetDraining(ctx, true /* drain */, reporter); err != nil {
+func (s *Server) drainNode(
+	ctx context.Context, reporter func(int, redact.SafeString), verbose bool,
+) (err error) {
+	if err = s.nodeLiveness.SetDraining(ctx, true /* drain */, reporter); err != nil {
 		return err
 	}
-	return s.node.SetDraining(true /* drain */, reporter)
+	return s.node.SetDraining(true /* drain */, reporter, verbose)
 }

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -557,9 +557,9 @@ func (n *Node) IsDraining() bool {
 // to report work that needed to be done and which may or may not have
 // been done by the time this call returns. See the explanation in
 // pkg/server/drain.go for details.
-func (n *Node) SetDraining(drain bool, reporter func(int, redact.SafeString)) error {
+func (n *Node) SetDraining(drain bool, reporter func(int, redact.SafeString), verbose bool) error {
 	return n.stores.VisitStores(func(s *kvserver.Store) error {
-		s.SetDraining(drain, reporter)
+		s.SetDraining(drain, reporter, verbose)
 		return nil
 	})
 }

--- a/pkg/server/serverpb/admin.proto
+++ b/pkg/server/serverpb/admin.proto
@@ -399,13 +399,14 @@ message DrainRequest {
   // shutdown for an explanation of the interaction between the two.
   // do_drain is also implied by a non-nil deprecated_probe_indicator.
   bool do_drain = 4;
-
   // node_id is a string so that "local" can be used to specify that no
   // forwarding is necessary.
   // For compatibility with v21.2 nodes, an empty node_id is
   // interpreted as "local". This behavior might be removed
   // in subsequent versions.
   string node_id = 5;
+  // When true, more detailed information is logged during the range lease drain phase.
+  bool verbose = 6;
 }
 
 // DrainResponse is the response to a successful DrainRequest.


### PR DESCRIPTION
Informs #65659.

Debugging graceful drain is challenging due to limited information. It is not clear what
is going wrong from the logs. This patch adds more detailed logging when graceful drain
range lease transfer encounters issues. Specifically, range lease transfer attempt
information (when an attempt occurs, duration blocked on transfer attempt, and the lease
that is being transferred) is logged.

The reason behind the failure of the transfer attempt may not be logged on the
draining node. This is because this information lies on the node that serves the draining
request. Currently, we do not have logging that aggregates all of this information
in one place. See #74158.

Release note (cli change): If graceful drain range lease transfer encounters issues,
verbose logging is automatically set to help with troubleshooting.