### PR TITLE
kv,changefeedccl: do not fatal or panic on unrecognized retry errors

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
@@ -176,7 +176,7 @@ func (ds *DistSender) partialRangeFeed(
 			case errors.HasType(err, (*roachpb.RangeFeedRetryError)(nil)):
 				var t *roachpb.RangeFeedRetryError
 				if ok := errors.As(err, &t); !ok {
-					panic(errors.AssertionFailedf("wrong error type: %T", err))
+					return errors.AssertionFailedf("wrong error type: %T", err)
 				}
 				switch t.Reason {
 				case roachpb.RangeFeedRetryError_REASON_REPLICA_REMOVED,
@@ -193,7 +193,7 @@ func (ds *DistSender) partialRangeFeed(
 					rangeInfo.token.Evict(ctx)
 					return ds.divideAndSendRangeFeedToRanges(ctx, rangeInfo.rs, ts, rangeCh)
 				default:
-					log.Fatalf(ctx, "unexpected RangeFeedRetryError reason %v", t.Reason)
+					return errors.AssertionFailedf("unrecognized retriable error type: %T", err)
 				}
 			default:
 				return err


### PR DESCRIPTION
Change a panic and a log.Fatalf to just return an AssertionFailed error
instead, which should be less catastrophic in a mixed-version situation.

Honestly we could probably just default to ignoring these entirely
but that's potentially an infinite retry bug.

Closes #68469

Release note: None