### PR TITLE
sql: support "default" default privileges

### DIFF
--- a/pkg/ccl/backupccl/show_test.go
+++ b/pkg/ccl/backupccl/show_test.go
@@ -356,8 +356,8 @@ GRANT UPDATE ON top_secret TO agent_bond;
 				`SELECT, ZONECONFIG ON mi5 TO agents; GRANT ALL ON mi5 TO root; `, `root`},
 			{`locator`, `schema`, `GRANT ALL ON locator TO admin; GRANT CREATE, GRANT ON locator TO agent_bond; GRANT ALL ON locator TO m; ` +
 				`GRANT ALL ON locator TO root; `, `root`},
-			{`continent`, `type`, `GRANT ALL ON continent TO admin; GRANT GRANT ON continent TO agent_bond; GRANT ALL ON continent TO m; GRANT ALL ON continent TO root; `, `root`},
-			{`_continent`, `type`, `GRANT ALL ON _continent TO admin; GRANT ALL ON _continent TO root; `, `root`},
+			{`continent`, `type`, `GRANT ALL ON continent TO admin; GRANT GRANT ON continent TO agent_bond; GRANT ALL ON continent TO m; GRANT USAGE ON continent TO public; GRANT ALL ON continent TO root; `, `root`},
+			{`_continent`, `type`, `GRANT ALL ON _continent TO admin; GRANT USAGE ON _continent TO public; GRANT ALL ON _continent TO root; `, `root`},
 			{`agent_locations`, `table`, `GRANT ALL ON agent_locations TO admin; ` +
 				`GRANT SELECT ON agent_locations TO agent_bond; GRANT UPDATE ON agent_locations TO agents; ` +
 				`GRANT ALL ON agent_locations TO m; GRANT ALL ON agent_locations TO root; `, `root`},

--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-grants
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-grants
@@ -177,14 +177,14 @@ SHOW GRANTS ON testuser_db.sc.othertable
 ----
 testuser_db sc othertable admin ALL
 testuser_db sc othertable root ALL
-testuser_db sc othertable testuser CREATE
+testuser_db sc othertable testuser ALL
 
 query-sql
 SHOW GRANTS ON testuser_db.testtable_greeting_usage
 ----
 testuser_db public testtable_greeting_usage admin ALL
 testuser_db public testtable_greeting_usage root ALL
-testuser_db public testtable_greeting_usage testuser CREATE
+testuser_db public testtable_greeting_usage testuser ALL
 
 # testuser should be owner, and therefore have SELECT privs too.
 exec-sql user=testuser

--- a/pkg/cloud/userfile/filetable/filetabletest/file_table_read_writer_test.go
+++ b/pkg/cloud/userfile/filetable/filetabletest/file_table_read_writer_test.go
@@ -436,14 +436,15 @@ func TestDifferentUserDisallowed(t *testing.T) {
 	// payload tables created by john above. FileToTableSystem should have revoked
 	// these privileges.
 	//
-	// Only grantees on the table should be admin, root and john (5 privileges).
+	// Only grantees on the table should be admin, root and john
+	// (each user has ALL).
 	grantees, err := getTableGrantees(ctx, fileTableReadWriter.GetFQFileTableName(), conn)
 	require.NoError(t, err)
-	require.Equal(t, []string{"admin", "john", "john", "john", "john", "john", "root"}, grantees)
+	require.Equal(t, []string{"admin", "john", "root"}, grantees)
 
 	grantees, err = getTableGrantees(ctx, fileTableReadWriter.GetFQPayloadTableName(), conn)
 	require.NoError(t, err)
-	require.Equal(t, []string{"admin", "john", "john", "john", "john", "john", "root"}, grantees)
+	require.Equal(t, []string{"admin", "john", "root"}, grantees)
 }
 
 // TestDifferentRoleDisallowed tests that a user who does not own the file and
@@ -493,14 +494,15 @@ func TestDifferentRoleDisallowed(t *testing.T) {
 	// payload tables created by john above. FileToTableSystem should have
 	// revoked these privileges.
 	//
-	// Only grantees on the table should be admin, root and john (5 privileges).
+	// Only grantees on the table should be admin, root and john
+	// (each user has ALL).
 	grantees, err := getTableGrantees(ctx, fileTableReadWriter.GetFQFileTableName(), conn)
 	require.NoError(t, err)
-	require.Equal(t, []string{"admin", "john", "john", "john", "john", "john", "root"}, grantees)
+	require.Equal(t, []string{"admin", "john", "root"}, grantees)
 
 	grantees, err = getTableGrantees(ctx, fileTableReadWriter.GetFQPayloadTableName(), conn)
 	require.NoError(t, err)
-	require.Equal(t, []string{"admin", "john", "john", "john", "john", "john", "root"}, grantees)
+	require.Equal(t, []string{"admin", "john", "root"}, grantees)
 }
 
 // TestDatabaseScope tests that the FileToTableSystem executes all of its

--- a/pkg/sql/alter_default_privileges.go
+++ b/pkg/sql/alter_default_privileges.go
@@ -14,6 +14,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catprivilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/dbdesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -134,7 +135,7 @@ func (n *alterDefaultPrivilegesNode) startExec(params runParams) error {
 	}
 
 	if n.dbDesc.GetDefaultPrivileges() == nil {
-		n.dbDesc.SetDefaultPrivilegeDescriptor(descpb.InitDefaultPrivilegeDescriptor())
+		n.dbDesc.SetDefaultPrivilegeDescriptor(catprivilege.MakeNewDefaultPrivilegeDescriptor())
 	}
 
 	defaultPrivs := n.dbDesc.GetMutableDefaultPrivilegeDescriptor()

--- a/pkg/sql/catalog/catprivilege/BUILD.bazel
+++ b/pkg/sql/catalog/catprivilege/BUILD.bazel
@@ -23,13 +23,17 @@ go_library(
 
 go_test(
     name = "catprivilege_test",
-    srcs = ["fix_test.go"],
+    srcs = [
+        "default_privilege_test.go",
+        "fix_test.go",
+    ],
     embed = [":catprivilege"],
     deps = [
         "//pkg/keys",
         "//pkg/security",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/privilege",
+        "//pkg/sql/sem/tree",
         "//pkg/util/leaktest",
     ],
 )

--- a/pkg/sql/catalog/catprivilege/default_privilege_test.go
+++ b/pkg/sql/catalog/catprivilege/default_privilege_test.go
@@ -1,0 +1,448 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package catprivilege
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+const nonSystemDatabaseID = 51
+
+func TestGrantDefaultPrivileges(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	fooUser := security.MakeSQLUsernameFromPreNormalizedString("foo")
+	barUser := security.MakeSQLUsernameFromPreNormalizedString("bar")
+	bazUser := security.MakeSQLUsernameFromPreNormalizedString("baz")
+	creatorUser := security.MakeSQLUsernameFromPreNormalizedString("creator")
+
+	testCases := []struct {
+		defaultPrivilegesRole descpb.DefaultPrivilegesRole
+		privileges            privilege.List
+		grantees              []security.SQLUsername
+		targetObject          tree.AlterDefaultPrivilegesTargetObject
+		objectCreator         security.SQLUsername
+	}{
+		{
+			defaultPrivilegesRole: descpb.DefaultPrivilegesRole{Role: creatorUser},
+			privileges:            privilege.List{privilege.ALL},
+			grantees:              []security.SQLUsername{fooUser},
+			targetObject:          tree.Tables,
+			objectCreator:         creatorUser,
+		},
+		{
+			defaultPrivilegesRole: descpb.DefaultPrivilegesRole{Role: creatorUser},
+			privileges:            privilege.List{privilege.ALL},
+			grantees:              []security.SQLUsername{fooUser, barUser, bazUser},
+			targetObject:          tree.Tables,
+			objectCreator:         creatorUser,
+		},
+		{
+			defaultPrivilegesRole: descpb.DefaultPrivilegesRole{Role: creatorUser},
+			privileges:            privilege.List{privilege.ALL},
+			grantees:              []security.SQLUsername{fooUser, barUser, bazUser},
+			targetObject:          tree.Sequences,
+			objectCreator:         creatorUser,
+		},
+		{
+			defaultPrivilegesRole: descpb.DefaultPrivilegesRole{Role: creatorUser},
+			privileges:            privilege.List{privilege.ALL},
+			grantees:              []security.SQLUsername{fooUser, barUser, bazUser},
+			targetObject:          tree.Types,
+			objectCreator:         creatorUser,
+		},
+		{
+			defaultPrivilegesRole: descpb.DefaultPrivilegesRole{Role: creatorUser},
+			privileges:            privilege.List{privilege.ALL},
+			grantees:              []security.SQLUsername{fooUser, barUser, bazUser},
+			targetObject:          tree.Schemas,
+			objectCreator:         creatorUser,
+		},
+		{
+			defaultPrivilegesRole: descpb.DefaultPrivilegesRole{Role: creatorUser},
+			privileges:            privilege.List{privilege.SELECT, privilege.DELETE},
+			grantees:              []security.SQLUsername{fooUser, barUser, bazUser},
+			targetObject:          tree.Tables,
+			objectCreator:         creatorUser,
+		},
+		{
+			defaultPrivilegesRole: descpb.DefaultPrivilegesRole{Role: creatorUser},
+			privileges:            privilege.List{privilege.SELECT, privilege.DELETE},
+			grantees:              []security.SQLUsername{fooUser, barUser, bazUser},
+			targetObject:          tree.Sequences,
+			objectCreator:         creatorUser,
+		},
+		{
+			defaultPrivilegesRole: descpb.DefaultPrivilegesRole{Role: creatorUser},
+			privileges:            privilege.List{privilege.USAGE},
+			grantees:              []security.SQLUsername{fooUser, barUser, bazUser},
+			targetObject:          tree.Types,
+			objectCreator:         creatorUser,
+		},
+		{
+			defaultPrivilegesRole: descpb.DefaultPrivilegesRole{Role: creatorUser},
+			privileges:            privilege.List{privilege.USAGE},
+			grantees:              []security.SQLUsername{fooUser, barUser, bazUser},
+			targetObject:          tree.Schemas,
+			objectCreator:         creatorUser,
+		},
+		/* Test cases for ForAllRoles */
+		{
+			defaultPrivilegesRole: descpb.DefaultPrivilegesRole{ForAllRoles: true},
+			privileges:            privilege.List{privilege.ALL},
+			grantees:              []security.SQLUsername{fooUser, barUser, bazUser},
+			targetObject:          tree.Tables,
+			objectCreator:         creatorUser,
+		},
+		{
+			defaultPrivilegesRole: descpb.DefaultPrivilegesRole{ForAllRoles: true},
+			privileges:            privilege.List{privilege.ALL},
+			grantees:              []security.SQLUsername{fooUser, barUser, bazUser},
+			targetObject:          tree.Sequences,
+			objectCreator:         creatorUser,
+		},
+		{
+			defaultPrivilegesRole: descpb.DefaultPrivilegesRole{ForAllRoles: true},
+			privileges:            privilege.List{privilege.ALL},
+			grantees:              []security.SQLUsername{fooUser, barUser, bazUser},
+			targetObject:          tree.Types,
+			objectCreator:         creatorUser,
+		},
+		{
+			defaultPrivilegesRole: descpb.DefaultPrivilegesRole{ForAllRoles: true},
+			privileges:            privilege.List{privilege.ALL},
+			grantees:              []security.SQLUsername{fooUser, barUser, bazUser},
+			targetObject:          tree.Schemas,
+			objectCreator:         creatorUser,
+		},
+		{
+			defaultPrivilegesRole: descpb.DefaultPrivilegesRole{ForAllRoles: true},
+			privileges:            privilege.List{privilege.SELECT, privilege.DELETE},
+			grantees:              []security.SQLUsername{fooUser, barUser, bazUser},
+			targetObject:          tree.Tables,
+			objectCreator:         creatorUser,
+		},
+		{
+			defaultPrivilegesRole: descpb.DefaultPrivilegesRole{ForAllRoles: true},
+			privileges:            privilege.List{privilege.SELECT, privilege.DELETE},
+			grantees:              []security.SQLUsername{fooUser, barUser, bazUser},
+			targetObject:          tree.Sequences,
+			objectCreator:         creatorUser,
+		},
+		{
+			defaultPrivilegesRole: descpb.DefaultPrivilegesRole{ForAllRoles: true},
+			privileges:            privilege.List{privilege.USAGE},
+			grantees:              []security.SQLUsername{fooUser, barUser, bazUser},
+			targetObject:          tree.Types,
+			objectCreator:         creatorUser,
+		},
+		{
+			defaultPrivilegesRole: descpb.DefaultPrivilegesRole{ForAllRoles: true},
+			privileges:            privilege.List{privilege.USAGE},
+			grantees:              []security.SQLUsername{fooUser, barUser, bazUser},
+			targetObject:          tree.Schemas,
+			objectCreator:         creatorUser,
+		},
+	}
+
+	for _, tc := range testCases {
+		defaultPrivilegeDescriptor := MakeNewDefaultPrivilegeDescriptor()
+		defaultPrivileges := NewMutableDefaultPrivileges(defaultPrivilegeDescriptor)
+
+		defaultPrivileges.GrantDefaultPrivileges(tc.defaultPrivilegesRole, tc.privileges, tc.grantees, tc.targetObject)
+
+		newPrivileges := defaultPrivileges.CreatePrivilegesFromDefaultPrivileges(
+			nonSystemDatabaseID, tc.objectCreator, tc.targetObject, &descpb.PrivilegeDescriptor{},
+		)
+
+		for _, grantee := range tc.grantees {
+			for _, privilege := range tc.privileges {
+				if !newPrivileges.CheckPrivilege(grantee, privilege) {
+					t.Errorf("expected %s to have %s privilege", grantee, privilege)
+				}
+			}
+		}
+	}
+}
+
+func TestRevokeDefaultPrivileges(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	fooUser := security.MakeSQLUsernameFromPreNormalizedString("foo")
+	barUser := security.MakeSQLUsernameFromPreNormalizedString("bar")
+	bazUser := security.MakeSQLUsernameFromPreNormalizedString("baz")
+	creatorUser := security.MakeSQLUsernameFromPreNormalizedString("creator")
+
+	testCases := []struct {
+		defaultPrivilegesRole                                 descpb.DefaultPrivilegesRole
+		grantPrivileges, revokePrivileges, expectedPrivileges privilege.List
+		grantees                                              []security.SQLUsername
+		targetObject                                          tree.AlterDefaultPrivilegesTargetObject
+		objectCreator                                         security.SQLUsername
+	}{
+		{
+			defaultPrivilegesRole: descpb.DefaultPrivilegesRole{Role: creatorUser},
+			grantPrivileges:       privilege.List{privilege.ALL},
+			revokePrivileges:      privilege.List{privilege.SELECT},
+			expectedPrivileges: privilege.List{
+				privilege.CREATE, privilege.DROP, privilege.GRANT, privilege.INSERT,
+				privilege.DELETE, privilege.UPDATE, privilege.ZONECONFIG,
+			},
+			grantees:      []security.SQLUsername{fooUser, barUser, bazUser},
+			targetObject:  tree.Tables,
+			objectCreator: creatorUser,
+		},
+		{
+			defaultPrivilegesRole: descpb.DefaultPrivilegesRole{Role: creatorUser},
+			grantPrivileges:       privilege.List{privilege.ALL},
+			revokePrivileges:      privilege.List{privilege.SELECT},
+			expectedPrivileges: privilege.List{
+				privilege.CREATE, privilege.DROP, privilege.GRANT, privilege.INSERT,
+				privilege.DELETE, privilege.UPDATE, privilege.ZONECONFIG,
+			},
+			grantees:      []security.SQLUsername{fooUser, barUser, bazUser},
+			targetObject:  tree.Sequences,
+			objectCreator: creatorUser,
+		},
+		{
+			defaultPrivilegesRole: descpb.DefaultPrivilegesRole{Role: creatorUser},
+			grantPrivileges:       privilege.List{privilege.ALL},
+			revokePrivileges:      privilege.List{privilege.USAGE},
+			expectedPrivileges: privilege.List{
+				privilege.GRANT,
+			},
+			grantees:      []security.SQLUsername{fooUser, barUser, bazUser},
+			targetObject:  tree.Types,
+			objectCreator: creatorUser,
+		},
+		{
+			defaultPrivilegesRole: descpb.DefaultPrivilegesRole{Role: creatorUser},
+			grantPrivileges:       privilege.List{privilege.ALL},
+			revokePrivileges:      privilege.List{privilege.USAGE},
+			expectedPrivileges: privilege.List{
+				privilege.CREATE, privilege.GRANT,
+			},
+			grantees:      []security.SQLUsername{fooUser, barUser, bazUser},
+			targetObject:  tree.Schemas,
+			objectCreator: creatorUser,
+		},
+		/* Test cases for ForAllRoles */
+		{
+			defaultPrivilegesRole: descpb.DefaultPrivilegesRole{ForAllRoles: true},
+			grantPrivileges:       privilege.List{privilege.ALL},
+			revokePrivileges:      privilege.List{privilege.SELECT},
+			expectedPrivileges: privilege.List{
+				privilege.CREATE, privilege.DROP, privilege.GRANT, privilege.INSERT,
+				privilege.DELETE, privilege.UPDATE, privilege.ZONECONFIG,
+			},
+			grantees:      []security.SQLUsername{fooUser, barUser, bazUser},
+			targetObject:  tree.Sequences,
+			objectCreator: creatorUser,
+		},
+		{
+			defaultPrivilegesRole: descpb.DefaultPrivilegesRole{ForAllRoles: true},
+			grantPrivileges:       privilege.List{privilege.ALL},
+			revokePrivileges:      privilege.List{privilege.USAGE},
+			expectedPrivileges: privilege.List{
+				privilege.GRANT,
+			},
+			grantees:      []security.SQLUsername{fooUser, barUser, bazUser},
+			targetObject:  tree.Types,
+			objectCreator: creatorUser,
+		},
+		{
+			defaultPrivilegesRole: descpb.DefaultPrivilegesRole{ForAllRoles: true},
+			grantPrivileges:       privilege.List{privilege.ALL},
+			revokePrivileges:      privilege.List{privilege.USAGE},
+			expectedPrivileges: privilege.List{
+				privilege.CREATE, privilege.GRANT,
+			},
+			grantees:      []security.SQLUsername{fooUser, barUser, bazUser},
+			targetObject:  tree.Schemas,
+			objectCreator: creatorUser,
+		},
+	}
+
+	for _, tc := range testCases {
+		defaultPrivilegeDescriptor := MakeNewDefaultPrivilegeDescriptor()
+		defaultPrivileges := NewMutableDefaultPrivileges(defaultPrivilegeDescriptor)
+
+		defaultPrivileges.GrantDefaultPrivileges(tc.defaultPrivilegesRole, tc.grantPrivileges, tc.grantees, tc.targetObject)
+		defaultPrivileges.RevokeDefaultPrivileges(tc.defaultPrivilegesRole, tc.revokePrivileges, tc.grantees, tc.targetObject)
+
+		newPrivileges := defaultPrivileges.CreatePrivilegesFromDefaultPrivileges(
+			nonSystemDatabaseID, tc.objectCreator, tc.targetObject, &descpb.PrivilegeDescriptor{},
+		)
+
+		for _, grantee := range tc.grantees {
+			for _, privilege := range tc.expectedPrivileges {
+				if !newPrivileges.CheckPrivilege(grantee, privilege) {
+					t.Errorf("expected %s to have %s privilege", grantee, privilege)
+				}
+			}
+		}
+	}
+}
+
+func TestRevokeDefaultPrivilegesFromEmptyList(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	defaultPrivilegeDescriptor := MakeNewDefaultPrivilegeDescriptor()
+	defaultPrivileges := NewMutableDefaultPrivileges(defaultPrivilegeDescriptor)
+	creatorUser := security.MakeSQLUsernameFromPreNormalizedString("creator")
+	fooUser := security.MakeSQLUsernameFromPreNormalizedString("foo")
+	defaultPrivileges.RevokeDefaultPrivileges(descpb.DefaultPrivilegesRole{
+		Role: creatorUser,
+	}, privilege.List{privilege.ALL}, []security.SQLUsername{fooUser}, tree.Tables)
+
+	newPrivileges := defaultPrivileges.CreatePrivilegesFromDefaultPrivileges(
+		nonSystemDatabaseID, creatorUser, tree.Tables, &descpb.PrivilegeDescriptor{},
+	)
+
+	if newPrivileges.AnyPrivilege(fooUser) {
+		t.Errorf("expected %s to not have any privileges", fooUser)
+	}
+}
+
+func TestCreatePrivilegesFromDefaultPrivilegesForSystemDatabase(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	defaultPrivilegeDescriptor := MakeNewDefaultPrivilegeDescriptor()
+	defaultPrivileges := NewMutableDefaultPrivileges(defaultPrivilegeDescriptor)
+	creatorUser := security.MakeSQLUsernameFromPreNormalizedString("creator")
+	newPrivileges := defaultPrivileges.CreatePrivilegesFromDefaultPrivileges(
+		keys.SystemDatabaseID, creatorUser, tree.Tables, &descpb.PrivilegeDescriptor{},
+	)
+
+	if !newPrivileges.Owner().IsNodeUser() {
+		t.Errorf("expected owner to be node, owner was %s", newPrivileges.Owner())
+	}
+}
+
+func TestDefaultDefaultPrivileges(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	defaultPrivilegeDescriptor := MakeNewDefaultPrivilegeDescriptor()
+	defaultPrivileges := NewMutableDefaultPrivileges(defaultPrivilegeDescriptor)
+	creatorUser := security.MakeSQLUsernameFromPreNormalizedString("creator")
+
+	targetObjectTypes := tree.GetAlterDefaultPrivilegesTargetObjects()
+	for _, targetObject := range targetObjectTypes {
+		newPrivileges := defaultPrivileges.CreatePrivilegesFromDefaultPrivileges(
+			nonSystemDatabaseID, creatorUser, targetObject, &descpb.PrivilegeDescriptor{},
+		)
+
+		if !newPrivileges.CheckPrivilege(creatorUser, privilege.ALL) {
+			t.Errorf("expected creator to have ALL privileges on %s", targetObject)
+		}
+
+		if targetObject == tree.Types {
+			if !newPrivileges.CheckPrivilege(security.PublicRoleName(), privilege.USAGE) {
+				t.Errorf("expected %s to have %s on types", security.PublicRoleName(), privilege.USAGE)
+			}
+		}
+	}
+}
+
+func TestModifyDefaultDefaultPrivileges(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testCases := []struct {
+		targetObject             tree.AlterDefaultPrivilegesTargetObject
+		revokeAndGrantPrivileges privilege.List
+	}{
+		{
+			targetObject:             tree.Tables,
+			revokeAndGrantPrivileges: privilege.List{privilege.SELECT},
+		},
+		{
+			targetObject:             tree.Sequences,
+			revokeAndGrantPrivileges: privilege.List{privilege.SELECT},
+		},
+		{
+			targetObject:             tree.Types,
+			revokeAndGrantPrivileges: privilege.List{privilege.USAGE},
+		},
+		{
+			targetObject:             tree.Schemas,
+			revokeAndGrantPrivileges: privilege.List{privilege.USAGE},
+		},
+	}
+
+	for _, tc := range testCases {
+		defaultPrivilegeDescriptor := MakeNewDefaultPrivilegeDescriptor()
+		defaultPrivileges := NewMutableDefaultPrivileges(defaultPrivilegeDescriptor)
+		creatorUser := security.MakeSQLUsernameFromPreNormalizedString("creator")
+
+		defaultPrivilegesForCreator := defaultPrivileges.defaultPrivilegeDescriptor.
+			FindOrCreateUser(descpb.DefaultPrivilegesRole{
+				Role: creatorUser,
+			})
+
+		defaultPrivileges.RevokeDefaultPrivileges(
+			descpb.DefaultPrivilegesRole{Role: creatorUser},
+			tc.revokeAndGrantPrivileges,
+			[]security.SQLUsername{creatorUser},
+			tc.targetObject,
+		)
+		if GetRoleHasAllPrivilegesOnTargetObject(defaultPrivilegesForCreator, tc.targetObject) {
+			t.Errorf("expected role to not have ALL privileges on %s", tc.targetObject)
+		}
+		defaultPrivileges.GrantDefaultPrivileges(
+			descpb.DefaultPrivilegesRole{Role: creatorUser},
+			tc.revokeAndGrantPrivileges,
+			[]security.SQLUsername{creatorUser},
+			tc.targetObject,
+		)
+		if !GetRoleHasAllPrivilegesOnTargetObject(defaultPrivilegesForCreator, tc.targetObject) {
+			t.Errorf("expected role to have ALL privileges on %s", tc.targetObject)
+		}
+	}
+}
+
+func TestModifyDefaultDefaultPrivilegesForPublic(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	defaultPrivilegeDescriptor := MakeNewDefaultPrivilegeDescriptor()
+	defaultPrivileges := NewMutableDefaultPrivileges(defaultPrivilegeDescriptor)
+	creatorUser := security.MakeSQLUsernameFromPreNormalizedString("creator")
+
+	defaultPrivilegesForCreator := defaultPrivileges.defaultPrivilegeDescriptor.
+		FindOrCreateUser(descpb.DefaultPrivilegesRole{
+			Role: creatorUser,
+		})
+
+	defaultPrivileges.RevokeDefaultPrivileges(
+		descpb.DefaultPrivilegesRole{Role: creatorUser},
+		privilege.List{privilege.USAGE},
+		[]security.SQLUsername{security.PublicRoleName()},
+		tree.Types,
+	)
+	if GetPublicHasUsageOnTypes(defaultPrivilegesForCreator) {
+		t.Errorf("expected public to not have USAGE privilege on types")
+	}
+	defaultPrivileges.GrantDefaultPrivileges(
+		descpb.DefaultPrivilegesRole{Role: creatorUser},
+		privilege.List{privilege.USAGE},
+		[]security.SQLUsername{security.PublicRoleName()},
+		tree.Types,
+	)
+	if !GetPublicHasUsageOnTypes(defaultPrivilegesForCreator) {
+		t.Errorf("expected public to have USAGE privilege on types")
+	}
+}

--- a/pkg/sql/catalog/catprivilege/validate.go
+++ b/pkg/sql/catalog/catprivilege/validate.go
@@ -40,6 +40,11 @@ func ValidateSuperuserPrivileges(
 	)
 }
 
+// ValidateDefaultPrivileges validates default privileges.
+func ValidateDefaultPrivileges(p descpb.DefaultPrivilegeDescriptor) error {
+	return p.Validate()
+}
+
 func allowedSuperuserPrivileges(objectNameKey catalog.NameKey) privilege.List {
 	privs := SystemSuperuserPrivileges(objectNameKey)
 	if privs != nil {

--- a/pkg/sql/catalog/dbdesc/database_desc.go
+++ b/pkg/sql/catalog/dbdesc/database_desc.go
@@ -217,7 +217,7 @@ func (desc *immutable) ValidateSelf(vea catalog.ValidationErrorAccumulator) {
 	// The DefaultPrivilegeDescriptor may be nil.
 	if desc.GetDefaultPrivileges() != nil {
 		// Validate the default privilege descriptor.
-		vea.Report(desc.GetDefaultPrivileges().Validate())
+		vea.Report(catprivilege.ValidateDefaultPrivileges(*desc.GetDefaultPrivileges()))
 	}
 
 	if desc.IsMultiRegion() {
@@ -421,7 +421,7 @@ func (desc *Mutable) HasPostDeserializationChanges() bool {
 func (desc *immutable) GetDefaultPrivilegeDescriptor() catalog.DefaultPrivilegeDescriptor {
 	defaultPrivilegeDescriptor := desc.GetDefaultPrivileges()
 	if defaultPrivilegeDescriptor == nil {
-		defaultPrivilegeDescriptor = descpb.InitDefaultPrivilegeDescriptor()
+		defaultPrivilegeDescriptor = catprivilege.MakeNewDefaultPrivilegeDescriptor()
 	}
 	return catprivilege.MakeDefaultPrivileges(defaultPrivilegeDescriptor)
 }
@@ -430,7 +430,7 @@ func (desc *immutable) GetDefaultPrivilegeDescriptor() catalog.DefaultPrivilegeD
 func (desc *Mutable) GetMutableDefaultPrivilegeDescriptor() *catprivilege.Mutable {
 	defaultPrivilegeDescriptor := desc.GetDefaultPrivileges()
 	if defaultPrivilegeDescriptor == nil {
-		defaultPrivilegeDescriptor = descpb.InitDefaultPrivilegeDescriptor()
+		defaultPrivilegeDescriptor = catprivilege.MakeNewDefaultPrivilegeDescriptor()
 	}
 	return catprivilege.NewMutableDefaultPrivileges(defaultPrivilegeDescriptor)
 }

--- a/pkg/sql/catalog/dbdesc/database_desc_builder.go
+++ b/pkg/sql/catalog/dbdesc/database_desc_builder.go
@@ -150,7 +150,7 @@ func NewInitial(
 		id,
 		name,
 		descpb.NewDefaultPrivilegeDescriptor(owner),
-		descpb.InitDefaultPrivilegeDescriptor(),
+		catprivilege.MakeNewDefaultPrivilegeDescriptor(),
 		options...,
 	)
 }

--- a/pkg/sql/catalog/descpb/privilege.proto
+++ b/pkg/sql/catalog/descpb/privilege.proto
@@ -48,11 +48,38 @@ message PrivilegeDescriptor {
 // the list of UserPrivileges for that object.
 message DefaultPrivilegesForRole {
   option (gogoproto.equal) = true;
-  oneof role {
-    string user_proto = 1 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/security.SQLUsernameProto"];
-    bool for_all_roles = 2;
+  // ExplicitRole represents when default privileges are defined for an
+  // explicit role.
+  message ExplicitRole {
+    option (gogoproto.equal) = true;
+    optional string user_proto = 1 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/security.SQLUsernameProto", (gogoproto.nullable) = false];
+    // These are special cases in Postgres. Public has USAGE on types and
+    // the creator role has ALL privileges by default.
+    // Under the default cases where all these bools are true, the role can be
+    // dropped, however for example alter default privileges revoke SELECT on tables
+    // for the role causes it to "own" default privileges as it is no longer
+    // the "default" case and the role cannot be dropped until the default case
+    // is met.
+    optional bool public_has_usage_on_types = 4 [(gogoproto.nullable) = false];
+    optional bool role_has_all_privileges_on_tables = 5 [(gogoproto.nullable) = false];
+    optional bool role_has_all_privileges_on_sequences = 6 [(gogoproto.nullable) = false];
+    optional bool role_has_all_privileges_on_schemas = 7 [(gogoproto.nullable) = false];
+    optional bool role_has_all_privileges_on_types = 8 [(gogoproto.nullable) = false];
   }
-  map<uint32, PrivilegeDescriptor> default_privileges_per_object = 3 [(gogoproto.nullable) = false,
+  // ForAllRoles represents when default privileges are defined
+  // using FOR ALL ROLES.
+  message ForAllRolesPseudoRole {
+    option (gogoproto.equal) = true;
+    // If for_all_roles is specified, we do not need flags to track if the
+    // role has privileges on tables/sequences/schemas and types as
+    // for_all_roles is not a real role and cannot have grants.
+    optional bool public_has_usage_on_types = 11 [(gogoproto.nullable) = false];
+  }
+  oneof role {
+    ExplicitRole explicit_role = 12;
+    ForAllRolesPseudoRole for_all_roles = 13;
+  }
+  map<uint32, PrivilegeDescriptor> default_privileges_per_object = 14 [(gogoproto.nullable) = false,
     (gogoproto.castkey) = "github.com/cockroachdb/cockroach/pkg/sql/sem/tree.AlterDefaultPrivilegesTargetObject"];
 }
 

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -4886,8 +4886,8 @@ CREATE TABLE crdb_internal.default_privileges (
 							for _, priv := range privList {
 								role := tree.DNull
 								forAllRoles := tree.DBoolTrue
-								if !defaultPrivilegesForRole.GetForAllRoles() {
-									role = tree.NewDString(defaultPrivilegesForRole.GetUserProto().Decode().Normalized())
+								if defaultPrivilegesForRole.IsExplicitRole() {
+									role = tree.NewDString(defaultPrivilegesForRole.GetExplicitRole().UserProto.Decode().Normalized())
 									forAllRoles = tree.DBoolFalse
 								}
 								if err := addRow(

--- a/pkg/sql/drop_role.go
+++ b/pkg/sql/drop_role.go
@@ -481,10 +481,10 @@ func accumulateDependentDefaultPrivileges(
 	return db.GetDefaultPrivilegeDescriptor().ForEachDefaultPrivilegeForRole(func(
 		defaultPrivilegesForRole descpb.DefaultPrivilegesForRole) error {
 		role := descpb.DefaultPrivilegesRole{}
-		if defaultPrivilegesForRole.GetForAllRoles() {
-			role.ForAllRoles = true
+		if defaultPrivilegesForRole.IsExplicitRole() {
+			role.Role = defaultPrivilegesForRole.GetExplicitRole().UserProto.Decode()
 		} else {
-			role.Role = defaultPrivilegesForRole.GetUserProto().Decode()
+			role.ForAllRoles = true
 		}
 		for object, defaultPrivs := range defaultPrivilegesForRole.DefaultPrivilegesPerObject {
 			addDependentPrivileges(object, defaultPrivs, role)

--- a/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_schema
+++ b/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_schema
@@ -1,5 +1,45 @@
 statement ok
-CREATE DATABASE d
+CREATE DATABASE d;
+GRANT CREATE ON DATABASE d TO testuser
+
+# By default, testuser should have ALL privileges on a schema it creates.
+user testuser
+
+statement ok
+USE d;
+
+statement ok
+CREATE SCHEMA testuser_s;
+
+query TTTT colnames
+SHOW GRANTS ON SCHEMA testuser_s;
+----
+database_name  schema_name  grantee   privilege_type
+d              testuser_s   admin     ALL
+d              testuser_s   root      ALL
+d              testuser_s   testuser  ALL
+
+statement ok
+ALTER DEFAULT PRIVILEGES REVOKE ALL ON SCHEMAS FROM testuser;
+
+statement ok
+CREATE SCHEMA testuser_s2;
+
+# Note that CREATE is still present for testuser due to our current inheritance
+# behavior.
+# TODO(richardjcai): Remove this when we remove our current inheritance logic.
+query TTTT colnames
+SHOW GRANTS ON SCHEMA testuser_s2
+----
+database_name  schema_name  grantee   privilege_type
+d              testuser_s2  admin     ALL
+d              testuser_s2  root      ALL
+d              testuser_s2  testuser  CREATE
+
+user root
+
+statement ok
+USE test;
 
 statement ok
 CREATE USER testuser2

--- a/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_sequence
+++ b/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_sequence
@@ -1,5 +1,45 @@
 statement ok
-CREATE DATABASE d
+CREATE DATABASE d;
+GRANT CREATE ON DATABASE d TO testuser
+
+# By default, testuser should have ALL privileges on a sequences it creates.
+user testuser
+
+statement ok
+USE d;
+
+statement ok
+CREATE SEQUENCE testuser_s;
+
+query TTTTT colnames
+SHOW GRANTS ON testuser_s;
+----
+database_name  schema_name  table_name  grantee   privilege_type
+d              public       testuser_s  admin     ALL
+d              public       testuser_s  root      ALL
+d              public       testuser_s  testuser  ALL
+
+statement ok
+ALTER DEFAULT PRIVILEGES REVOKE ALL ON SEQUENCES FROM testuser;
+
+statement ok
+CREATE SEQUENCE testuser_s2;
+
+# Note that CREATE is still present for testuser due to our current inheritance
+# behavior.
+# TODO(richardjcai): Remove this when we remove our current inheritance logic.
+query TTTTT colnames
+SHOW GRANTS ON testuser_s2
+----
+database_name  schema_name  table_name   grantee   privilege_type
+d              public       testuser_s2  admin     ALL
+d              public       testuser_s2  root      ALL
+d              public       testuser_s2  testuser  CREATE
+
+user root
+
+statement ok
+USE test;
 
 statement ok
 CREATE USER testuser2

--- a/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_table
@@ -18,7 +18,43 @@ ALTER DEFAULT PRIVILEGES GRANT USAGE ON TABLES to testuser
 # For Tables.
 statement ok
 CREATE DATABASE d;
+GRANT CREATE ON DATABASE d TO testuser;
+
+# By default, testuser should have ALL privileges on a table it creates.
+user testuser
+
+statement ok
 USE d;
+
+statement ok
+CREATE TABLE testuser_t();
+
+query TTTTT colnames
+SHOW GRANTS ON testuser_t
+----
+database_name  schema_name  table_name  grantee   privilege_type
+d              public       testuser_t  admin     ALL
+d              public       testuser_t  root      ALL
+d              public       testuser_t  testuser  ALL
+
+statement ok
+ALTER DEFAULT PRIVILEGES REVOKE ALL ON TABLES FROM testuser;
+
+statement ok
+CREATE TABLE testuser_t2();
+
+query TTTTT colnames
+SHOW GRANTS ON testuser_t2
+----
+database_name  schema_name  table_name   grantee   privilege_type
+d              public       testuser_t2  admin     ALL
+d              public       testuser_t2  root      ALL
+d              public       testuser_t2  testuser  CREATE
+
+user root
+
+statement ok
+USE test;
 
 statement ok
 ALTER DEFAULT PRIVILEGES GRANT SELECT ON TABLES to testuser
@@ -30,9 +66,9 @@ query TTTTT colnames
 SHOW GRANTS ON t
 ----
 database_name  schema_name  table_name  grantee   privilege_type
-d              public       t           admin     ALL
-d              public       t           root      ALL
-d              public       t           testuser  SELECT
+test           public       t           admin     ALL
+test           public       t           root      ALL
+test           public       t           testuser  SELECT
 
 statement ok
 CREATE SEQUENCE s
@@ -44,16 +80,16 @@ query TTTTT colnames
 SHOW GRANTS ON s
 ----
 database_name  schema_name  table_name  grantee  privilege_type
-d              public       s           admin    ALL
-d              public       s           root     ALL
+test           public       s           admin    ALL
+test           public       s           root     ALL
 
 query TTTTT colnames
 SHOW GRANTS ON vx
 ----
 database_name  schema_name  table_name  grantee   privilege_type
-d              public       vx          admin     ALL
-d              public       vx          root      ALL
-d              public       vx          testuser  SELECT
+test           public       vx          admin     ALL
+test           public       vx          root      ALL
+test           public       vx          testuser  SELECT
 
 statement ok
 ALTER DEFAULT PRIVILEGES REVOKE SELECT ON TABLES FROM testuser
@@ -65,8 +101,8 @@ query TTTTT colnames
 SHOW GRANTS ON t2
 ----
 database_name  schema_name  table_name  grantee  privilege_type
-d              public       t2          admin    ALL
-d              public       t2          root     ALL
+test           public       t2          admin    ALL
+test           public       t2          root     ALL
 
 statement ok
 CREATE SEQUENCE s2
@@ -75,8 +111,8 @@ query TTTTT colnames
 SHOW GRANTS ON s2
 ----
 database_name  schema_name  table_name  grantee  privilege_type
-d              public       s2          admin    ALL
-d              public       s2          root     ALL
+test           public       s2          admin    ALL
+test           public       s2          root     ALL
 
 
 # Multiple users.
@@ -93,10 +129,10 @@ query TTTTT colnames
 SHOW GRANTS ON t3
 ----
 database_name  schema_name  table_name  grantee    privilege_type
-d              public       t3          admin      ALL
-d              public       t3          root       ALL
-d              public       t3          testuser   SELECT
-d              public       t3          testuser2  SELECT
+test           public       t3          admin      ALL
+test           public       t3          root       ALL
+test           public       t3          testuser   SELECT
+test           public       t3          testuser2  SELECT
 
 statement ok
 CREATE SEQUENCE s3
@@ -105,8 +141,8 @@ query TTTTT colnames
 SHOW GRANTS ON s3
 ----
 database_name  schema_name  table_name  grantee  privilege_type
-d              public       s3          admin    ALL
-d              public       s3          root     ALL
+test           public       s3          admin    ALL
+test           public       s3          root     ALL
 
 statement ok
 ALTER DEFAULT PRIVILEGES REVOKE SELECT ON TABLES FROM testuser, testuser2
@@ -118,8 +154,8 @@ query TTTTT colnames
 SHOW GRANTS ON t4
 ----
 database_name  schema_name  table_name  grantee  privilege_type
-d              public       t4          admin    ALL
-d              public       t4          root     ALL
+test           public       t4          admin    ALL
+test           public       t4          root     ALL
 
 statement ok
 CREATE SEQUENCE s4
@@ -128,8 +164,8 @@ query TTTTT colnames
 SHOW GRANTS ON s4
 ----
 database_name  schema_name  table_name  grantee  privilege_type
-d              public       s4          admin    ALL
-d              public       s4          root     ALL
+test           public       s4          admin    ALL
+test           public       s4          root     ALL
 
 # ALTER DEFAULT PRIVILEGES FOR ROLE.
 
@@ -150,15 +186,15 @@ USE d;
 statement ok
 CREATE TABLE t5()
 
+# testuser has ALL privileges since by default, ALL is defined as a default
+# privilege for the creator role of an object..
 query TTTTT colnames
 SHOW GRANTS ON t5
 ----
-database_name  schema_name  table_name  grantee    privilege_type
-d              public       t5          admin      ALL
-d              public       t5          root       ALL
-d              public       t5          testuser   CREATE
-d              public       t5          testuser   SELECT
-d              public       t5          testuser2  SELECT
+database_name  schema_name  table_name  grantee   privilege_type
+d              public       t5          admin     ALL
+d              public       t5          root      ALL
+d              public       t5          testuser  CREATE
 
 user root
 

--- a/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_type
@@ -1,5 +1,44 @@
 statement ok
-CREATE DATABASE d
+CREATE DATABASE d;
+GRANT CREATE ON DATABASE d TO testuser;
+
+# By default, testuser should have ALL privileges on a types it creates and
+# Public should have usage.
+user testuser
+
+statement ok
+USE d;
+
+statement ok
+CREATE TYPE testuser_t AS ENUM();
+
+query TTTTT colnames
+SHOW GRANTS ON TYPE testuser_t;
+----
+database_name  schema_name  type_name   grantee   privilege_type
+d              public       testuser_t  admin     ALL
+d              public       testuser_t  public    USAGE
+d              public       testuser_t  root      ALL
+d              public       testuser_t  testuser  ALL
+
+statement ok
+ALTER DEFAULT PRIVILEGES REVOKE ALL ON TYPES FROM testuser;
+ALTER DEFAULT PRIVILEGES REVOKE USAGE ON TYPES FROM public;
+
+statement ok
+CREATE TYPE testuser_t2 AS ENUM();
+
+query TTTTT colnames
+SHOW GRANTS ON TYPE testuser_t2
+----
+database_name  schema_name  type_name    grantee  privilege_type
+d              public       testuser_t2  admin    ALL
+d              public       testuser_t2  root     ALL
+
+user root
+
+statement ok
+USE test;
 
 statement ok
 CREATE USER testuser2
@@ -68,7 +107,6 @@ SHOW GRANTS ON TYPE t4
 ----
 database_name  schema_name  type_name  grantee  privilege_type
 d              public       t4         admin    ALL
-d              public       t4         public   USAGE
 d              public       t4         root     ALL
 
 user root
@@ -93,5 +131,4 @@ SHOW GRANTS ON TYPE t5
 ----
 database_name  schema_name  type_name  grantee  privilege_type
 d              public       t5         admin    ALL
-d              public       t5         public   USAGE
 d              public       t5         root     ALL

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal_default_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal_default_privileges
@@ -8,10 +8,9 @@ query TTTBTTT colnames,rowsort
 SELECT * FROM crdb_internal.default_privileges
 ----
 database_name  schema_name  role  for_all_roles  object_type  grantee  privilege_type
-test           NULL         root  false          types        public   USAGE
+test           NULL         root  false          sequences    public   SELECT
 test           NULL         root  false          schemas      public   USAGE
 test           NULL         root  false          tables       public   SELECT
-test           NULL         root  false          sequences    public   SELECT
 
 statement ok
 CREATE USER foo
@@ -51,22 +50,14 @@ query TTTBTTT colnames,rowsort
 SELECT * FROM crdb_internal.default_privileges WHERE role='foo' OR role='bar'
 ----
 database_name  schema_name  role  for_all_roles  object_type  grantee  privilege_type
-test           NULL         bar   false          types        bar      ALL
-test           NULL         bar   false          types        foo      ALL
-test           NULL         bar   false          schemas      bar      ALL
 test           NULL         bar   false          schemas      foo      ALL
-test           NULL         bar   false          tables       bar      ALL
 test           NULL         bar   false          tables       foo      ALL
-test           NULL         bar   false          sequences    bar      ALL
 test           NULL         bar   false          sequences    foo      ALL
-test           NULL         foo   false          sequences    bar      ALL
-test           NULL         foo   false          sequences    foo      ALL
-test           NULL         foo   false          types        bar      ALL
-test           NULL         foo   false          types        foo      ALL
+test           NULL         bar   false          types        foo      ALL
 test           NULL         foo   false          schemas      bar      ALL
-test           NULL         foo   false          schemas      foo      ALL
 test           NULL         foo   false          tables       bar      ALL
-test           NULL         foo   false          tables       foo      ALL
+test           NULL         foo   false          sequences    bar      ALL
+test           NULL         foo   false          types        bar      ALL
 
 statement ok
 ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar REVOKE ALL ON TABLES FROM foo, bar;
@@ -78,9 +69,6 @@ query TTTBTTT colnames,rowsort
 SELECT * FROM crdb_internal.default_privileges
 ----
 database_name  schema_name  role  for_all_roles  object_type  grantee  privilege_type
-test           NULL         root  false          types        bar      ALL
-test           NULL         root  false          types        foo      ALL
-test           NULL         root  false          types        public   USAGE
 test           NULL         root  false          schemas      bar      ALL
 test           NULL         root  false          schemas      foo      ALL
 test           NULL         root  false          schemas      public   USAGE
@@ -90,6 +78,8 @@ test           NULL         root  false          tables       public   SELECT
 test           NULL         root  false          sequences    bar      ALL
 test           NULL         root  false          sequences    foo      ALL
 test           NULL         root  false          sequences    public   SELECT
+test           NULL         root  false          types        bar      ALL
+test           NULL         root  false          types        foo      ALL
 
 statement ok
 ALTER DEFAULT PRIVILEGES REVOKE SELECT ON TABLES FROM foo, bar, public;

--- a/pkg/sql/logictest/testdata/logic_test/grant_database
+++ b/pkg/sql/logictest/testdata/logic_test/grant_database
@@ -183,4 +183,4 @@ SHOW GRANTS ON b.t
 database_name  schema_name  table_name  grantee   privilege_type
 b              public       t           admin     ALL
 b              public       t           root      ALL
-b              public       t           testuser  CREATE
+b              public       t           testuser  ALL

--- a/pkg/sql/logictest/testdata/logic_test/grant_type
+++ b/pkg/sql/logictest/testdata/logic_test/grant_type
@@ -34,6 +34,7 @@ test           public       enum_a+b   public   USAGE
 test           public       enum_a+b   root     ALL
 test           public       enum_a+b   user1    USAGE
 test           schema_a     enum_b     admin    ALL
+test           schema_a     enum_b     public   USAGE
 test           schema_a     enum_b     root     ALL
 test           schema_a     enum_b     user1    ALL
 

--- a/pkg/sql/logictest/testdata/logic_test/owner
+++ b/pkg/sql/logictest/testdata/logic_test/owner
@@ -199,7 +199,8 @@ user root
 # ownership.
 
 statement ok
-REVOKE ALL ON DATABASE test FROM testuser
+REVOKE ALL ON DATABASE test FROM testuser;
+REVOKE ALL ON TABLE d.t FROM testuser;
 
 statement error pq: role testuser cannot be dropped because some objects depend on it.*\n.*owner of database d.*\n.*owner of table test.public.t.*\n.*owner of table d.public.t
 DROP ROLE testuser
@@ -212,6 +213,9 @@ user testuser2
 
 statement ok
 CREATE TABLE t2()
+
+statement ok
+REVOKE ALL ON TABLE t2 FROM testuser2
 
 statement error pq: role testuser2 cannot be dropped because some objects depend on it.*\n.*owner of table test.public.t2
 DROP ROLE testuser2, testuser
@@ -235,7 +239,10 @@ CREATE TABLE s.t()
 user root
 
 statement ok
-REVOKE ALL ON DATABASE test FROM testuser
+REVOKE ALL ON DATABASE test FROM testuser;
+REVOKE ALL ON SCHEMA d.s FROM testuser;
+REVOKE ALL ON TYPE d.typ FROM testuser;
+REVOKE ALL ON TABLE d.s.t FROM testuser;
 
 user testuser
 

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog_pg_default_acl
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog_pg_default_acl
@@ -1,6 +1,5 @@
 statement ok
 ALTER DEFAULT PRIVILEGES GRANT SELECT ON TABLES TO PUBLIC;
-ALTER DEFAULT PRIVILEGES GRANT USAGE ON TYPES TO PUBLIC;
 ALTER DEFAULT PRIVILEGES GRANT USAGE ON SCHEMAS TO PUBLIC;
 ALTER DEFAULT PRIVILEGES GRANT SELECT ON SEQUENCES TO PUBLIC;
 
@@ -9,10 +8,9 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-4149409857  1546506610  0                T              {=U/}
-4149409857  1546506610  0                n              {=U/}
 4149409857  1546506610  0                r              {=r/}
 4149409857  1546506610  0                S              {=r/}
+4149409857  1546506610  0                n              {=U/}
 
 statement ok
 CREATE USER foo
@@ -30,10 +28,10 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-4149409857  1546506610  0                T              {bar=U/,foo=U/,=U/}
-4149409857  1546506610  0                n              {bar=CU/,foo=CU/,=U/}
 4149409857  1546506610  0                r              {bar=Cadrw/,foo=Cadrw/,=r/}
 4149409857  1546506610  0                S              {bar=Cadrw/,foo=Cadrw/,=r/}
+4149409857  1546506610  0                T              {bar=U/,foo=U/}
+4149409857  1546506610  0                n              {bar=CU/,foo=CU/,=U/}
 
 statement ok
 GRANT foo, bar TO root;
@@ -49,18 +47,18 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-542080048   1791217281  0                n              {bar=CU/,foo=CU/}
-542080048   1791217281  0                r              {bar=Cadrw/,foo=Cadrw/}
-542080048   1791217281  0                S              {bar=Cadrw/,foo=Cadrw/}
-542080048   1791217281  0                T              {bar=U/,foo=U/}
-38059971    2026795574  0                r              {bar=Cadrw/,foo=Cadrw/}
-38059971    2026795574  0                S              {bar=Cadrw/,foo=Cadrw/}
-38059971    2026795574  0                T              {bar=U/,foo=U/}
-38059971    2026795574  0                n              {bar=CU/,foo=CU/}
-4149409857  1546506610  0                n              {bar=CU/,foo=CU/,=U/}
+542080048   1791217281  0                r              {foo=Cadrw/}
+542080048   1791217281  0                S              {foo=Cadrw/}
+542080048   1791217281  0                T              {foo=U/}
+542080048   1791217281  0                n              {foo=CU/}
+38059971    2026795574  0                r              {bar=Cadrw/}
+38059971    2026795574  0                S              {bar=Cadrw/}
+38059971    2026795574  0                T              {bar=U/}
+38059971    2026795574  0                n              {bar=CU/}
 4149409857  1546506610  0                r              {bar=Cadrw/,foo=Cadrw/,=r/}
 4149409857  1546506610  0                S              {bar=Cadrw/,foo=Cadrw/,=r/}
-4149409857  1546506610  0                T              {bar=U/,foo=U/,=U/}
+4149409857  1546506610  0                T              {bar=U/,foo=U/}
+4149409857  1546506610  0                n              {bar=CU/,foo=CU/,=U/}
 
 statement ok
 ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar REVOKE ALL ON TABLES FROM foo, bar;
@@ -68,24 +66,81 @@ ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar REVOKE ALL ON TYPES FROM foo, bar;
 ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar REVOKE ALL ON SCHEMAS FROM foo, bar;
 ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar REVOKE ALL ON SEQUENCES FROM foo, bar;
 
-# Revoking all should remove 8 rows, 4 for each foo and bar.
+# Revoking all will result in rows with empty privileges since the privileges
+# are revoked from the creator role.
 query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-4149409857  1546506610  0                T              {bar=U/,foo=U/,=U/}
-4149409857  1546506610  0                n              {bar=CU/,foo=CU/,=U/}
+542080048   1791217281  0                r              {}
+542080048   1791217281  0                S              {}
+542080048   1791217281  0                T              {=U/}
+542080048   1791217281  0                n              {}
+38059971    2026795574  0                r              {}
+38059971    2026795574  0                S              {}
+38059971    2026795574  0                T              {=U/}
+38059971    2026795574  0                n              {}
 4149409857  1546506610  0                r              {bar=Cadrw/,foo=Cadrw/,=r/}
 4149409857  1546506610  0                S              {bar=Cadrw/,foo=Cadrw/,=r/}
+4149409857  1546506610  0                T              {bar=U/,foo=U/}
+4149409857  1546506610  0                n              {bar=CU/,foo=CU/,=U/}
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE foo GRANT ALL ON TABLES TO foo;
+ALTER DEFAULT PRIVILEGES FOR ROLE foo GRANT ALL ON SEQUENCES TO foo;
+ALTER DEFAULT PRIVILEGES FOR ROLE foo GRANT ALL ON SCHEMAS TO foo;
+ALTER DEFAULT PRIVILEGES FOR ROLE foo GRANT ALL ON TYPES TO foo;
+ALTER DEFAULT PRIVILEGES FOR ROLE bar GRANT ALL ON TABLES TO bar;
+ALTER DEFAULT PRIVILEGES FOR ROLE bar GRANT ALL ON SEQUENCES TO bar;
+ALTER DEFAULT PRIVILEGES FOR ROLE bar GRANT ALL ON SCHEMAS TO bar;
+ALTER DEFAULT PRIVILEGES FOR ROLE bar GRANT ALL ON TYPES TO bar;
+
+# Entries should disappear since the previous ALTER DEFAULT PRIVILEGE commands
+# revert the default privileges to the default state.
+query OOOTT colnames,rowsort
+SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
+----
+oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
+4149409857  1546506610  0                r              {bar=Cadrw/,foo=Cadrw/,=r/}
+4149409857  1546506610  0                S              {bar=Cadrw/,foo=Cadrw/,=r/}
+4149409857  1546506610  0                T              {bar=U/,foo=U/}
+4149409857  1546506610  0                n              {bar=CU/,foo=CU/,=U/}
+
+# Revoke SELECT from foo and GRANT it back with foo being the creator role.
+# Ensure revoking a single privilege reflects correctly.
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE foo REVOKE SELECT ON TABLES FROM foo;
+
+query OOOTT colnames,rowsort
+SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
+----
+oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
+38059971    2026795574  0                r              {foo=Cadw/}
+4149409857  1546506610  0                r              {bar=Cadrw/,foo=Cadrw/,=r/}
+4149409857  1546506610  0                S              {bar=Cadrw/,foo=Cadrw/,=r/}
+4149409857  1546506610  0                T              {bar=U/,foo=U/}
+4149409857  1546506610  0                n              {bar=CU/,foo=CU/,=U/}
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE foo GRANT SELECT ON TABLES TO foo;
+
+query OOOTT colnames,rowsort
+SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
+----
+oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
+4149409857  1546506610  0                r              {bar=Cadrw/,foo=Cadrw/,=r/}
+4149409857  1546506610  0                S              {bar=Cadrw/,foo=Cadrw/,=r/}
+4149409857  1546506610  0                T              {bar=U/,foo=U/}
+4149409857  1546506610  0                n              {bar=CU/,foo=CU/,=U/}
 
 statement ok
 ALTER DEFAULT PRIVILEGES REVOKE SELECT ON TABLES FROM foo, bar, public;
-ALTER DEFAULT PRIVILEGES REVOKE ALL ON TYPES FROM foo, bar, public;
 ALTER DEFAULT PRIVILEGES REVOKE ALL ON SCHEMAS FROM foo, bar, public;
 ALTER DEFAULT PRIVILEGES REVOKE ALL ON SEQUENCES FROM foo, bar, public;
 
-# Revoke ALL from types, schemas, sequences and select from tables.
-# Only one entry should be left, for tables and 'r' should not be present.
+statement ok
+ALTER DEFAULT PRIVILEGES REVOKE ALL ON TYPES FROM foo, bar;
+
 query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
@@ -103,6 +158,9 @@ SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
 4149409857  1546506610  0                r              {foo=/}
 
+statement ok
+ALTER DEFAULT PRIVILEGES REVOKE GRANT, DROP, ZONECONFIG ON TABLES FROM foo;
+
 # Check that entries show up for default privileges defined for all roles.
 # The defaclrole oid should be 0.
 statement ok
@@ -115,11 +173,10 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-4149409857  1546506610  0                r              {foo=/}
-2946850069  0           0                n              {bar=CU/,foo=CU/}
 2946850069  0           0                r              {bar=Cadrw/,foo=Cadrw/}
 2946850069  0           0                S              {bar=Cadrw/,foo=Cadrw/}
 2946850069  0           0                T              {bar=U/,foo=U/}
+2946850069  0           0                n              {bar=CU/,foo=CU/}
 
 statement ok
 ALTER DEFAULT PRIVILEGES FOR ALL ROLES REVOKE ALL ON TABLES FROM foo, bar;
@@ -130,5 +187,68 @@ ALTER DEFAULT PRIVILEGES FOR ALL ROLES REVOKE ALL ON SEQUENCES FROM foo, bar;
 query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
+oid  defaclrole  defaclnamespace  defaclobjtype  defaclacl
+
+user testuser
+
+statement ok
+ALTER DEFAULT PRIVILEGES REVOKE ALL ON TABLES FROM testuser;
+ALTER DEFAULT PRIVILEGES REVOKE ALL ON SEQUENCES FROM testuser;
+ALTER DEFAULT PRIVILEGES REVOKE ALL ON SCHEMAS FROM testuser;
+ALTER DEFAULT PRIVILEGES REVOKE ALL ON TYPES FROM testuser;
+
+# Empty entries should appear for testuser indicating that testuser
+# has no default privileges.
+query OOOTT colnames,rowsort
+SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
+----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-4149409857  1546506610  0                r              {foo=/}
+3084847592  2264919399  0                r              {}
+3084847592  2264919399  0                S              {}
+3084847592  2264919399  0                T              {=U/}
+3084847592  2264919399  0                n              {}
+
+statement ok
+ALTER DEFAULT PRIVILEGES REVOKE USAGE ON TYPES FROM public;
+
+# Revoking privileges from Public should make the entry for T empty.
+query OOOTT colnames,rowsort
+SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
+----
+oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
+3084847592  2264919399  0                r              {}
+3084847592  2264919399  0                S              {}
+3084847592  2264919399  0                T              {}
+3084847592  2264919399  0                n              {}
+
+
+statement ok
+ALTER DEFAULT PRIVILEGES GRANT ALL ON TYPES TO testuser;
+
+# Now that Public does not have USAGE on type but testuser has ALL on types,
+# the defaclacl array should show the default privileges for testuser.
+query OOOTT colnames,rowsort
+SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
+----
+oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
+3084847592  2264919399  0                r              {}
+3084847592  2264919399  0                S              {}
+3084847592  2264919399  0                T              {testuser=U/}
+3084847592  2264919399  0                n              {}
+
+statement ok
+ALTER DEFAULT PRIVILEGES GRANT ALL ON TABLES TO foo;
+ALTER DEFAULT PRIVILEGES GRANT ALL ON SEQUENCES TO foo;
+ALTER DEFAULT PRIVILEGES GRANT ALL ON SCHEMAS TO foo;
+ALTER DEFAULT PRIVILEGES GRANT ALL ON TYPES TO foo;
+
+# Ensure that the empty arrays are populated with the default privileges
+# for foo.
+query OOOTT colnames,rowsort
+SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
+----
+oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
+3084847592  2264919399  0                r              {foo=Cadrw/}
+3084847592  2264919399  0                S              {foo=Cadrw/}
+3084847592  2264919399  0                T              {foo=U/,testuser=U/}
+3084847592  2264919399  0                n              {foo=CU/}

--- a/pkg/sql/logictest/testdata/logic_test/privilege_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/privilege_builtins
@@ -1129,6 +1129,10 @@ SELECT has_schema_privilege('testuser', 's', 'create')
 ----
 true
 
+
+statement ok
+REVOKE USAGE ON SCHEMA s FROM testuser;
+
 # Privilege check on direct member of role without USAGE privilege granted.
 query B
 SELECT has_schema_privilege('testuser', 's', 'usage')

--- a/pkg/sql/logictest/testdata/logic_test/show_default_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/show_default_privileges
@@ -10,7 +10,6 @@ SHOW DEFAULT PRIVILEGES
 root  false  schemas    public  USAGE
 root  false  sequences  public  SELECT
 root  false  tables     public  SELECT
-root  false  types      public  USAGE
 
 statement ok
 CREATE USER foo
@@ -38,7 +37,6 @@ root  false  tables     foo     ALL
 root  false  tables     public  SELECT
 root  false  types      bar     ALL
 root  false  types      foo     ALL
-root  false  types      public  USAGE
 
 statement ok
 GRANT foo, bar TO root;
@@ -63,7 +61,6 @@ root  false  tables     foo     ALL
 root  false  tables     public  SELECT
 root  false  types      bar     ALL
 root  false  types      foo     ALL
-root  false  types      public  USAGE
 
 statement ok
 ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar REVOKE ALL ON TABLES FROM foo, bar;
@@ -85,7 +82,6 @@ root  false  tables     foo     ALL
 root  false  tables     public  SELECT
 root  false  types      bar     ALL
 root  false  types      foo     ALL
-root  false  types      public  USAGE
 
 statement ok
 ALTER DEFAULT PRIVILEGES REVOKE SELECT ON TABLES FROM foo, bar, public;

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catformat"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catprivilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
@@ -1117,7 +1118,34 @@ https://www.postgresql.org/docs/13/catalog-pg-default-acl.html`,
 	populate: func(ctx context.Context, p *planner, dbContext catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
 		f := func(defaultPrivilegesForRole descpb.DefaultPrivilegesForRole) error {
-			for objectType, privs := range defaultPrivilegesForRole.DefaultPrivilegesPerObject {
+			objectTypes := tree.GetAlterDefaultPrivilegesTargetObjects()
+			for _, objectType := range objectTypes {
+				privs, ok := defaultPrivilegesForRole.DefaultPrivilegesPerObject[objectType]
+				if !ok || len(privs.Users) == 0 {
+					// If the default privileges default state has been altered,
+					// we use an empty entry to signify that the user has no privileges.
+					// We only omit the row entirely if the default privileges are
+					// in its default state. This is PG's behavior.
+					// Note that if ForAllRoles is true, we can skip adding an entry
+					// since ForAllRoles cannot be a grantee - therefore we can ignore
+					// the RoleHasAllPrivilegesOnX flag and skip. We still have to take
+					// into consideration the PublicHasUsageOnTypes flag.
+					if objectType == tree.Types {
+						// if the objectType is tree.Types, we only omit the entry
+						// if both the role has ALL privileges AND public has USAGE.
+						// This is the "default" state for default privileges on types
+						// in Postgres.
+						if (!defaultPrivilegesForRole.IsExplicitRole() ||
+							catprivilege.GetRoleHasAllPrivilegesOnTargetObject(&defaultPrivilegesForRole, tree.Types)) &&
+							catprivilege.GetPublicHasUsageOnTypes(&defaultPrivilegesForRole) {
+							continue
+						}
+					} else if !defaultPrivilegesForRole.IsExplicitRole() ||
+						catprivilege.GetRoleHasAllPrivilegesOnTargetObject(&defaultPrivilegesForRole, objectType) {
+						continue
+					}
+				}
+
 				// Type of object this entry is for:
 				// r = relation (table, view), S = sequence, f = function, T = type, n = schema.
 				var c string
@@ -1145,26 +1173,40 @@ https://www.postgresql.org/docs/13/catalog-pg-default-acl.html`,
 					privileges := privilege.ListFromBitField(
 						userPrivs.Privileges, privilegeObjectType,
 					)
-					defaclItem := fmt.Sprintf(`%s=%s/%s`,
-						user,
-						privileges.ListToACL(
-							privilegeObjectType,
-						),
-						// TODO(richardjcai): CockroachDB currently does not track grantors
-						//    See: https://github.com/cockroachdb/cockroach/issues/67442.
-						"", /* grantor */
-					)
-
-					if len(defaclItem) != 0 {
-						if err := arr.Append(
-							tree.NewDString(defaclItem)); err != nil {
-							return err
-						}
+					defaclItem := createDefACLItem(user, privileges, privilegeObjectType)
+					if err := arr.Append(
+						tree.NewDString(defaclItem)); err != nil {
+						return err
 					}
 				}
 
-				if len(arr.Array) == 0 {
-					continue
+				// Special cases to handle for types.
+				// If one of RoleHasAllPrivilegesOnTypes or PublicHasUsageOnTypes is false
+				// and the other is true, we do not omit the entry since the default
+				// state has changed. We have to produce an entry by expanding the
+				// privileges.
+				if defaultPrivilegesForRole.IsExplicitRole() {
+					if objectType == tree.Types {
+						if !catprivilege.GetRoleHasAllPrivilegesOnTargetObject(&defaultPrivilegesForRole, tree.Types) &&
+							catprivilege.GetPublicHasUsageOnTypes(&defaultPrivilegesForRole) {
+							defaclItem := createDefACLItem(
+								"" /* public role */, privilege.List{privilege.USAGE}, privilegeObjectType,
+							)
+							if err := arr.Append(tree.NewDString(defaclItem)); err != nil {
+								return err
+							}
+						}
+						if !catprivilege.GetPublicHasUsageOnTypes(&defaultPrivilegesForRole) &&
+							defaultPrivilegesForRole.GetExplicitRole().RoleHasAllPrivilegesOnTypes {
+							defaclItem := createDefACLItem(
+								defaultPrivilegesForRole.GetExplicitRole().UserProto.Decode().Normalized(),
+								privilege.List{privilege.ALL}, privilegeObjectType,
+							)
+							if err := arr.Append(tree.NewDString(defaclItem)); err != nil {
+								return err
+							}
+						}
+					}
 				}
 
 				// TODO(richardjcai): Update this logic once default privileges on
@@ -1175,9 +1217,9 @@ https://www.postgresql.org/docs/13/catalog-pg-default-acl.html`,
 				// role name to create the row hash.
 				normalizedName := ""
 				roleOid := oidZero
-				if !defaultPrivilegesForRole.GetForAllRoles() {
-					roleOid = h.UserOid(defaultPrivilegesForRole.GetUserProto().Decode())
-					normalizedName = defaultPrivilegesForRole.GetUserProto().Decode().Normalized()
+				if defaultPrivilegesForRole.IsExplicitRole() {
+					roleOid = h.UserOid(defaultPrivilegesForRole.GetExplicitRole().UserProto.Decode())
+					normalizedName = defaultPrivilegesForRole.GetExplicitRole().UserProto.Decode().Normalized()
 				}
 				rowOid := h.DBSchemaRoleOid(
 					dbContext.GetID(),
@@ -1198,6 +1240,20 @@ https://www.postgresql.org/docs/13/catalog-pg-default-acl.html`,
 		}
 		return dbContext.GetDefaultPrivilegeDescriptor().ForEachDefaultPrivilegeForRole(f)
 	},
+}
+
+func createDefACLItem(
+	user string, privileges privilege.List, privilegeObjectType privilege.ObjectType,
+) string {
+	return fmt.Sprintf(`%s=%s/%s`,
+		user,
+		privileges.ListToACL(
+			privilegeObjectType,
+		),
+		// TODO(richardjcai): CockroachDB currently does not track grantors
+		//    See: https://github.com/cockroachdb/cockroach/issues/67442.
+		"", /* grantor */
+	)
 }
 
 var (

--- a/pkg/sql/sem/tree/alter_default_privileges.go
+++ b/pkg/sql/sem/tree/alter_default_privileges.go
@@ -87,6 +87,17 @@ const (
 	Schemas   AlterDefaultPrivilegesTargetObject = 4
 )
 
+// GetAlterDefaultPrivilegesTargetObjects returns a slice of all the
+// AlterDefaultPrivilegesTargetObjects.
+func GetAlterDefaultPrivilegesTargetObjects() []AlterDefaultPrivilegesTargetObject {
+	return []AlterDefaultPrivilegesTargetObject{
+		Tables,
+		Sequences,
+		Types,
+		Schemas,
+	}
+}
+
 func (t AlterDefaultPrivilegesTargetObject) String() string {
 	switch t {
 	case Tables:


### PR DESCRIPTION
sql: support "default" default privileges

Release note (sql change): Roles have a default set of default privileges
for example, a role has ALL privileges on all objects as it's default privileges
when it creates the object. Additionally the public role having Usage is a default
privilege.

This is important as now when a user creates an table, sequence, type or schema, it will
automatically have ALL privileges on it, and Public will have USAGE on types.

This can be altered, ALTER DEFAULT PRIVILEGE FOR ROLE rolea REVOKE ALL ON ... FROM rolea
will remove the default set of default privileges on the specified object from the role.

Resolves https://github.com/cockroachdb/cockroach/issues/67377

Release justification: Bug fix / enhancement to new feature that is not yet in production.
Default privileges are being added in 21.2, this is an enhancement to match
postgres' behaviour.