### PR TITLE
sql: Reduce fragility of multi_region_zone_config test

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
@@ -1721,9 +1721,9 @@ DATABASE rebuild_zc_db ALTER DATABASE rebuild_zc_db CONFIGURE ZONE USING
 statement ok
 SELECT crdb_internal.validate_multi_region_zone_configs()
 
-let $null_table_id
-SELECT table_id FROM crdb_internal.tables WHERE schema_name = 'crdb_internal' AND name = 'tables'
+let $descriptor_table_id
+SELECT table_id FROM crdb_internal.tables WHERE schema_name = 'public' AND name = 'descriptor'
 
 # Validate that builtin errors if called on a table id
-query error pq: crdb_internal\.reset_multi_region_zone_configs_for_database\(\): database "\[4294967248\]" does not exist
-SELECT crdb_internal.reset_multi_region_zone_configs_for_database($null_table_id)
+query error pq: crdb_internal\.reset_multi_region_zone_configs_for_database\(\): database "\[3\]" does not exist
+SELECT crdb_internal.reset_multi_region_zone_configs_for_database($descriptor_table_id)


### PR DESCRIPTION
Before this test relied on the stability of the table ID for a virtual
table. This made the test fragile as any new virtual table could break
the test. Changing this to use a system table ID, which should be
stable.

Release note: None