### PR TITLE
release-21.1: workload/tpcc: add multiregion TPC-C setup

### DIFF
--- a/pkg/workload/tpcc/ddls.go
+++ b/pkg/workload/tpcc/ddls.go
@@ -13,6 +13,7 @@ package tpcc
 import (
 	gosql "database/sql"
 	"fmt"
+	"strings"
 
 	"github.com/cockroachdb/errors"
 	"golang.org/x/sync/errgroup"
@@ -30,7 +31,7 @@ const (
 		w_zip       char(9)       not null,
 		w_tax       decimal(4,4)  not null,
 		w_ytd       decimal(12,2) not null`
-	tpccWarehouseColumnFamiliesSuffix = `, 
+	tpccWarehouseColumnFamiliesSuffix = `
 		family      f1 (w_id, w_name, w_street_1, w_street_2, w_city, w_state, w_zip, w_ytd),
 		family      f2 (w_tax)`
 
@@ -48,7 +49,7 @@ const (
 		d_ytd        decimal(12,2) not null,
 		d_next_o_id  integer       not null,
 		primary key  (d_w_id, d_id)`
-	tpccDistrictColumnFamiliesSuffix = `,
+	tpccDistrictColumnFamiliesSuffix = `
 		family       static    (d_w_id, d_id, d_name, d_street_1, d_street_2, d_city, d_state, d_zip),
 		family       dynamic_1 (d_ytd),
 		family       dynamic_2 (d_next_o_id, d_tax)`
@@ -80,7 +81,7 @@ const (
 		c_data         varchar(500)  not null,
 		primary key        (c_w_id, c_d_id, c_id),
 		index customer_idx (c_w_id, c_d_id, c_last, c_first)`
-	tpccCustomerColumnFamiliesSuffix = `, 
+	tpccCustomerColumnFamiliesSuffix = `
 		family static      (
 			c_id, c_d_id, c_w_id, c_first, c_middle, c_last, c_street_1, c_street_2,
 			c_city, c_state, c_zip, c_phone, c_since, c_credit, c_credit_lim, c_discount
@@ -117,7 +118,7 @@ const (
 		o_all_local  integer,
 		primary key  (o_w_id, o_d_id, o_id DESC),
 		unique index order_idx (o_w_id, o_d_id, o_c_id, o_id DESC) storing (o_entry_d, o_carrier_id)
-	)`
+	`
 	tpccOrderSchemaInterleaveSuffix = `
 		interleave in parent district (o_w_id, o_d_id)`
 
@@ -127,7 +128,7 @@ const (
 		no_d_id  integer   not null,
 		no_w_id  integer   not null,
 		primary key (no_w_id, no_d_id, no_o_id)
-	)`
+	`
 	// This natural-seeming interleave makes performance worse, because this
 	// table has a ton of churn and produces a lot of MVCC tombstones, which
 	// then will gum up the works of scans over the parent table.
@@ -142,7 +143,7 @@ const (
 		i_price  decimal(5,2),
 		i_data   varchar(50),
 		primary key (i_id)
-	)`
+	`
 
 	// STOCK table.
 	tpccStockSchemaBase = `(
@@ -187,28 +188,97 @@ const (
 	tpccOrderLineSchemaInterleaveSuffix = `
 		interleave in parent "order" (ol_w_id, ol_d_id, ol_o_id)`
 
+	localityRegionalByRowSuffix = `
+		locality regional by row`
+	localityGlobalSuffix = `
+		locality global`
+
 	endSchema = "\n\t)"
 )
 
-func maybeAddFkSuffix(fks bool, base, suffix string) string {
-	if !fks {
-		return base + endSchema
-	}
-	return base + "," + suffix + endSchema
+type schemaOptions struct {
+	fkClause         string
+	familyClause     string
+	columnClause     string
+	localityClause   string
+	interleaveClause string
 }
 
-func maybeAddColumnFamiliesSuffix(separateColumnFamilies bool, base, suffix string) string {
-	if !separateColumnFamilies {
-		return base + endSchema
+type makeSchemaOption func(o *schemaOptions)
+
+func maybeAddFkSuffix(fks bool, suffix string) makeSchemaOption {
+	return func(o *schemaOptions) {
+		if fks {
+			o.fkClause = suffix
+		}
 	}
-	return base + suffix + endSchema
 }
 
-func maybeAddInterleaveSuffix(interleave bool, base, suffix string) string {
-	if !interleave {
-		return base
+func maybeAddColumnFamiliesSuffix(separateColumnFamilies bool, suffix string) makeSchemaOption {
+	return func(o *schemaOptions) {
+		if separateColumnFamilies {
+			o.familyClause = suffix
+		}
 	}
-	return base + suffix
+}
+
+func maybeAddInterleaveSuffix(interleave bool, suffix string) makeSchemaOption {
+	return func(o *schemaOptions) {
+		if interleave {
+			o.interleaveClause = suffix
+		}
+	}
+}
+
+func maybeAddLocalityRegionalByRow(
+	multiRegionCfg multiRegionConfig, partColName string,
+) makeSchemaOption {
+	return func(o *schemaOptions) {
+		if len(multiRegionCfg.regions) > 0 {
+			// We mod the ID by the number of partitions.
+			// This gives an even distribution of rows in each region.
+			// Note new regions being added after initialization time
+			// will not automatically have any data in its partitions.
+			var b strings.Builder
+			fmt.Fprintf(&b, `
+               crdb_region crdb_internal_region NOT VISIBLE NOT NULL AS (
+                       CASE %s %% %d`, partColName, len(multiRegionCfg.regions))
+			for i, region := range multiRegionCfg.regions {
+				fmt.Fprintf(&b, `
+                       WHEN %d THEN '%s'`, i, region)
+			}
+			b.WriteString(`
+                       END
+               ) STORED`)
+			o.columnClause = b.String()
+			o.localityClause = localityRegionalByRowSuffix
+		}
+	}
+}
+
+func makeSchema(base string, opts ...makeSchemaOption) string {
+	var o schemaOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
+	ret := base
+	if o.fkClause != "" {
+		ret += "," + o.fkClause
+	}
+	if o.familyClause != "" {
+		ret += "," + o.familyClause
+	}
+	if o.columnClause != "" {
+		ret += "," + o.columnClause
+	}
+	if o.interleaveClause != "" {
+		ret += "," + o.interleaveClause
+	}
+	ret += endSchema
+	if o.localityClause != "" {
+		ret += o.localityClause
+	}
+	return ret
 }
 
 func scatterRanges(db *gosql.DB) error {

--- a/pkg/workload/tpcc/partition.go
+++ b/pkg/workload/tpcc/partition.go
@@ -116,6 +116,47 @@ type zoneConfig struct {
 	strategy partitionStrategy
 }
 
+type survivalGoal int
+
+const (
+	survivalGoalZone survivalGoal = iota
+	survivalGoalRegion
+)
+
+// Part of pflag's Value interface.
+func (s survivalGoal) String() string {
+	switch s {
+	case survivalGoalZone:
+		return "zone"
+	case survivalGoalRegion:
+		return "region"
+	}
+	panic("unexpected")
+}
+
+// Part of pflag's Value interface.
+func (s *survivalGoal) Set(value string) error {
+	switch value {
+	case "zone":
+		*s = survivalGoalZone
+	case "region":
+		*s = survivalGoalRegion
+	default:
+		return errors.Errorf("unknown survival goal %q", value)
+	}
+	return nil
+}
+
+// Part of pflag's Value interface.
+func (s survivalGoal) Type() string {
+	return "survival_goal"
+}
+
+type multiRegionConfig struct {
+	regions      []string
+	survivalGoal survivalGoal
+}
+
 // partitioner encapsulates all logic related to partitioning discrete numbers
 // of warehouses into disjoint sets of roughly equal sizes. Partitions are then
 // evenly assigned "active" warehouses, which allows for an even split of live


### PR DESCRIPTION
Backport 1/2 commits from #65600.

/cc @cockroachdb/release

Resolves #68472

---

Introduce a tpcc workload for multi-region, which can be triggered by
specifying `--regions comma-separated-list-of-regions`. I've preserved
the existing TPC-C options in case we want to test legacy
configurations.

The schema creation was changed to something using the options pattern
which makes it a lot cleaner to specify the schema.

Release note: None

Release justification: change to non critical path (workload) that is opt-in only.