### PR TITLE
security: fixes CertificateLoader tests when running as root

### DIFF
--- a/pkg/util/sysutil/acl_unix_test.go
+++ b/pkg/util/sysutil/acl_unix_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestGetFileACLInfo(t *testing.T) {
-	certsDir, err := ioutil.TempDir("", "certs_test")
+	certsDir, err := ioutil.TempDir("", "acl_test")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This change fixes the CertificateLoader tests when running as the
root user, since the acceptable permissions change depending on
what user owns the certificate files (which is root since the tests
create the certificate files).

Closes #68485

Release note: None