### PR TITLE
changefeedccl: remove fatals

### DIFF
--- a/pkg/ccl/changefeedccl/kvevent/event.go
+++ b/pkg/ccl/changefeedccl/kvevent/event.go
@@ -53,6 +53,9 @@ const (
 	// TypeResolved indicates that the Resolved method on the Event will be
 	// meaningful.
 	TypeResolved
+
+	// TypeUnknown indicates the event could not be parsed. Will fail the feed.
+	TypeUnknown
 )
 
 // Event represents an event emitted by a kvfeed. It is either a KV or a
@@ -73,8 +76,7 @@ func (b *Event) Type() Type {
 	if b.resolved != nil {
 		return TypeResolved
 	}
-	log.Fatalf(context.TODO(), "found event with unknown type: %+v", *b)
-	return 0 // unreachable
+	return TypeUnknown
 }
 
 // ApproximateSize returns events approximate size in bytes.
@@ -132,8 +134,9 @@ func (b *Event) Timestamp() hlc.Timestamp {
 		}
 		return b.kv.Value.Timestamp
 	default:
-		log.Fatalf(context.TODO(), "unknown event type")
-		return hlc.Timestamp{} // unreachable
+		log.Warningf(context.TODO(),
+			"setting empty timestamp for unknown event type")
+		return hlc.Timestamp{}
 	}
 }
 
@@ -147,8 +150,9 @@ func (b *Event) MVCCTimestamp() hlc.Timestamp {
 	case TypeKV:
 		return b.kv.Value.Timestamp
 	default:
-		log.Fatalf(context.TODO(), "unknown event type")
-		return hlc.Timestamp{} // unreachable
+		log.Warningf(context.TODO(),
+			"setting empty timestamp for unknown event type")
+		return hlc.Timestamp{}
 	}
 }
 

--- a/pkg/ccl/changefeedccl/kvfeed/physical_kv_feed.go
+++ b/pkg/ccl/changefeedccl/kvfeed/physical_kv_feed.go
@@ -16,7 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
 )
 
 // physicalFeedFactory constructs a physical feed which writes into sink and
@@ -106,7 +106,7 @@ func (p *rangefeed) addEventsToBuffer(ctx context.Context) error {
 					return err
 				}
 			default:
-				log.Fatalf(ctx, "unexpected RangeFeedEvent variant %v", t)
+				return errors.Errorf("unexpected RangeFeedEvent variant %v", t)
 			}
 		case <-ctx.Done():
 			return ctx.Err()


### PR DESCRIPTION
All events we get from a kvfeed are currently one of two types,
so in a bunch of places we call log.Fatalf if we can't categorize
an event into one of those two. This kills the entire server, which
seems like an overreaction. Let's preemptively change this to a
normal error so that new event types can be more safely added in the
future.

Release note: None