### PR TITLE
dev: rip recording logic out of `dev` datadriven tests

### DIFF
--- a/pkg/cmd/dev/BUILD.bazel
+++ b/pkg/cmd/dev/BUILD.bazel
@@ -38,7 +38,7 @@ go_test(
     deps = [
         "//pkg/cmd/dev/io/exec",
         "//pkg/cmd/dev/io/os",
-        "//pkg/cmd/dev/recorder",
+        "//pkg/cmd/dev/recording",
         "//pkg/testutils",
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_stretchr_testify//require",

--- a/pkg/cmd/dev/bench.go
+++ b/pkg/cmd/dev/bench.go
@@ -104,7 +104,7 @@ func (d *dev) bench(cmd *cobra.Command, pkgs []string) error {
 		if timeout > 0 {
 			args = append(args, fmt.Sprintf("-test.timeout=%s", timeout.String()))
 		}
-		err := d.exec.CommandContextNoRecord(ctx, "bazel", args...)
+		err := d.exec.CommandContextInheritingStdStreams(ctx, "bazel", args...)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/dev/build.go
+++ b/pkg/cmd/dev/build.go
@@ -81,7 +81,7 @@ func (d *dev) build(cmd *cobra.Command, targets []string) error {
 
 	if cross == "" {
 		args = append(args, getConfigFlags()...)
-		if err := d.exec.CommandContextNoRecord(ctx, "bazel", args...); err != nil {
+		if err := d.exec.CommandContextInheritingStdStreams(ctx, "bazel", args...); err != nil {
 			return err
 		}
 		return d.symlinkBinaries(ctx, fullTargets)

--- a/pkg/cmd/dev/builder.go
+++ b/pkg/cmd/dev/builder.go
@@ -43,7 +43,7 @@ func (d *dev) builder(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	return d.exec.CommandContextNoRecord(ctx, "docker", args...)
+	return d.exec.CommandContextInheritingStdStreams(ctx, "docker", args...)
 }
 
 func (d *dev) ensureDockerVolume(ctx context.Context, volume string) error {

--- a/pkg/cmd/dev/io/exec/BUILD.bazel
+++ b/pkg/cmd/dev/io/exec/BUILD.bazel
@@ -5,8 +5,5 @@ go_library(
     srcs = ["exec.go"],
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/dev/io/exec",
     visibility = ["//visibility:public"],
-    deps = [
-        "//pkg/cmd/dev/recorder",
-        "@com_github_cockroachdb_errors//:errors",
-    ],
+    deps = ["//pkg/cmd/dev/recording"],
 )

--- a/pkg/cmd/dev/io/os/BUILD.bazel
+++ b/pkg/cmd/dev/io/os/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/dev/io/os",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/cmd/dev/recorder",
+        "//pkg/cmd/dev/recording",
         "@com_github_cockroachdb_errors//oserror",
     ],
 )

--- a/pkg/cmd/dev/recording/BUILD.bazel
+++ b/pkg/cmd/dev/recording/BUILD.bazel
@@ -1,12 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "recorder",
+    name = "recording",
     srcs = [
         "operation.go",
-        "recorder.go",
+        "recording.go",
         "scanner.go",
     ],
-    importpath = "github.com/cockroachdb/cockroach/pkg/cmd/dev/recorder",
+    importpath = "github.com/cockroachdb/cockroach/pkg/cmd/dev/recording",
     visibility = ["//visibility:public"],
 )

--- a/pkg/cmd/dev/recording/operation.go
+++ b/pkg/cmd/dev/recording/operation.go
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package recorder
+package recording
 
 import "strings"
 

--- a/pkg/cmd/dev/recording/recording.go
+++ b/pkg/cmd/dev/recording/recording.go
@@ -8,79 +8,37 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package recorder
+package recording
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"io"
 	"strings"
 )
 
-// Recorder can be used to record a set of operations (defined only by a
-// "command" and an "expected output"). These recordings can then be played
-// back, which provides a handy way to mock out the components being recorded.
-type Recorder struct {
-	// writer is set if we're in recording mode, and is where operations are
-	// recorded.
-	writer io.Writer
-
-	// scanner and op are set if we're in replay mode. It's where we're
-	// replaying the recording from. op is the scratch space used to
-	// parse out the current operation being read.
+// Recording can be used to play back a set of operations (defined only by a
+// "command" and an "expected output"). It provides a handy way to mock out the
+// components being recorded.
+type Recording struct {
+	// scanner is where we're replaying the recording from. op is the
+	// scratch space used to parse out the current operation being read.
 	scanner *scanner
 	op      Operation
 }
 
-// New constructs a Recorder, using the specified configuration option (one of
-// WithReplayFrom or WithRecordingTo).
-func New(opt func(r *Recorder)) *Recorder {
-	r := &Recorder{}
-	opt(r)
-	return r
-}
-
-// WithReplayFrom is used to configure a Recorder to play back from the given
+// WithReplayFrom is used to configure a Recording to play back from the given
 // reader. The provided name is used only for diagnostic purposes, it's
 // typically the name of the file being read.
-func WithReplayFrom(r io.Reader, name string) func(*Recorder) {
-	return func(re *Recorder) {
-		re.scanner = newScanner(r, name)
-	}
-}
-
-// WithRecordingTo is used to configure a Recorder to record into the given
-// writer.
-func WithRecordingTo(w io.Writer) func(*Recorder) {
-	return func(r *Recorder) {
-		r.writer = w
-	}
-}
-
-// Recording returns whether or not the recorder is configured to record (as
-// opposed to replay from a recording).
-func (r *Recorder) Recording() bool {
-	return r.writer != nil
-}
-
-// Record is used to record the given operation.
-func (r *Recorder) Record(o Operation) error {
-	if !r.Recording() {
-		return errors.New("misconfigured recorder; not set to record")
-	}
-
-	_, err := r.writer.Write([]byte(o.String()))
-	return err
+func WithReplayFrom(r io.Reader, name string) *Recording {
+	re := &Recording{}
+	re.scanner = newScanner(r, name)
+	return re
 }
 
 // Next is used to step through the next operation found in the recording, if
 // any.
-func (r *Recorder) Next(f func(Operation) error) (found bool, err error) {
-	if r.Recording() {
-		return false, errors.New("misconfigured recorder; set to record, not replay")
-	}
-
+func (r *Recording) Next(f func(Operation) error) (found bool, err error) {
 	parsed, err := r.parseOperation()
 	if err != nil {
 		return false, err
@@ -99,7 +57,7 @@ func (r *Recorder) Next(f func(Operation) error) (found bool, err error) {
 // parseOperation parses out the next Operation from the internal scanner. See
 // type-level comment on Operation to understand the grammar we're parsing
 // against.
-func (r *Recorder) parseOperation() (parsed bool, err error) {
+func (r *Recording) parseOperation() (parsed bool, err error) {
 	for r.scanner.Scan() {
 		r.op = Operation{}
 		line := r.scanner.Text()
@@ -144,7 +102,7 @@ func (r *Recorder) parseOperation() (parsed bool, err error) {
 // parseCommand parses a <command> line and returns it if parsed correctly. See
 // type-level comment on Operation to understand the grammar we're parsing
 // against.
-func (r *Recorder) parseCommand(line string) (cmd string, err error) {
+func (r *Recording) parseCommand(line string) (cmd string, err error) {
 	line = strings.TrimSpace(line)
 	if line == "" {
 		return "", nil
@@ -162,7 +120,7 @@ func (r *Recorder) parseCommand(line string) (cmd string, err error) {
 // parseSeparator parses a separator ('----'), erroring out if it's not parsed
 // correctly. See type-level comment on Operation to understand the grammar
 // we're parsing against.
-func (r *Recorder) parseSeparator() error {
+func (r *Recording) parseSeparator() error {
 	if !r.scanner.Scan() {
 		return fmt.Errorf("%s: expected to find separator after command", r.scanner.pos())
 	}
@@ -175,7 +133,7 @@ func (r *Recorder) parseSeparator() error {
 
 // parseOutput parses an <output>. See type-level comment on Operation to
 // understand the grammar we're parsing against.
-func (r *Recorder) parseOutput() error {
+func (r *Recording) parseOutput() error {
 	var buf bytes.Buffer
 	var line string
 

--- a/pkg/cmd/dev/recording/scanner.go
+++ b/pkg/cmd/dev/recording/scanner.go
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package recorder
+package recording
 
 import (
 	"bufio"

--- a/pkg/cmd/dev/test.go
+++ b/pkg/cmd/dev/test.go
@@ -186,7 +186,7 @@ func (d *dev) runUnitTest(cmd *cobra.Command, pkgs []string) error {
 		args = append(args, "--test_output", "errors")
 	}
 
-	err := d.exec.CommandContextNoRecord(ctx, "bazel", args...)
+	err := d.exec.CommandContextInheritingStdStreams(ctx, "bazel", args...)
 	return err
 }
 


### PR DESCRIPTION
This feature isn't used by anyone that currently works on `dev`, and
manually updating the recording files seems to be the most convenient
way to work on these tests.

In the future we may consider migrating to a proper mocking framework
for `dev`, but for now this structure is fine.

Also rename recorder -> recording for accuracy.

Release note: None