### PR TITLE
kvcoord: Add a mechanism to restart seeming stuck range feeds.

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -124,6 +124,12 @@ var (
 		Measurement: "Errors",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaDistSenderSlowRangefeedRanges = metric.Metadata{
+		Name:        "distsender.rangefeed.slow_range_restarts",
+		Help:        "Number of ranges for which rangefeed restarted due to slow responsiveness",
+		Measurement: "Ranges",
+		Unit:        metric.Unit_COUNT,
+	}
 )
 
 // CanSendToFollower is used by the DistSender to determine if it needs to look
@@ -185,6 +191,7 @@ type DistSenderMetrics struct {
 	SlowRPCs                *metric.Gauge
 	MethodCounts            [roachpb.NumMethods]*metric.Counter
 	ErrCounts               [roachpb.NumErrors]*metric.Counter
+	SlowRangeFeedRanges     *metric.Counter
 }
 
 func makeDistSenderMetrics() DistSenderMetrics {
@@ -200,6 +207,7 @@ func makeDistSenderMetrics() DistSenderMetrics {
 		InLeaseTransferBackoffs: metric.NewCounter(metaDistSenderInLeaseTransferBackoffsCount),
 		RangeLookups:            metric.NewCounter(metaDistSenderRangeLookups),
 		SlowRPCs:                metric.NewGauge(metaDistSenderSlowRPCs),
+		SlowRangeFeedRanges:     metric.NewCounter(metaDistSenderSlowRangefeedRanges),
 	}
 	for i := range m.MethodCounts {
 		method := roachpb.Method(i).String()

--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed_test.go
@@ -152,3 +152,106 @@ func TestDistSenderRangeFeedRetryOnTransportErrors(t *testing.T) {
 		})
 	}
 }
+
+func TestDistSenderRangeFeedRestartsStuckRanges(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
+	rangefeedCtx, cancelRangefeed := context.WithCancel(context.Background())
+	defer cancelRangefeed()
+
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.Background())
+	rpcContext := rpc.NewInsecureTestingContext(clock, stopper)
+	g := makeGossip(t, stopper, rpcContext)
+
+	desc := roachpb.RangeDescriptor{
+		RangeID:    1,
+		Generation: 1,
+		StartKey:   roachpb.RKeyMin,
+		EndKey:     roachpb.RKeyMax,
+		InternalReplicas: []roachpb.ReplicaDescriptor{
+			{NodeID: 1, StoreID: 1, ReplicaID: 1},
+			{NodeID: 2, StoreID: 2, ReplicaID: 2},
+		},
+	}
+	for _, repl := range desc.InternalReplicas {
+		require.NoError(t, g.AddInfoProto(
+			gossip.MakeNodeIDKey(repl.NodeID),
+			newNodeDesc(repl.NodeID),
+			gossip.NodeDescriptorTTL,
+		))
+	}
+
+	// Enable rangefeed watchdog and make it run very frequently.
+	st := cluster.MakeTestingClusterSettings()
+	enableRangefeedWatchdog.Override(rangefeedCtx, &st.SV, true)
+	restartRangefeedThreshold.Override(rangefeedCtx, &st.SV, 5*time.Millisecond)
+	watchdogPace.Override(rangefeedCtx, &st.SV, 10*time.Millisecond)
+
+	ctrl := gomock.NewController(t)
+	transport := NewMockTransport(ctrl)
+	transport.EXPECT().IsExhausted().Return(false).Times(2)
+	transport.EXPECT().NextReplica().Return(desc.InternalReplicas[0]).Times(2)
+
+	// 2 attempts to create RPC client are made -- the first one will fail
+	// (its context will be canceled, and the second call succeeds).
+	var streamCtx context.Context
+	client := roachpb.NewMockInternalClient(ctrl)
+	transport.EXPECT().NextInternalClient(gomock.Any()).DoAndReturn(
+		func(arg interface{}) (context.Context, roachpb.InternalClient, error) {
+			streamCtx = arg.(context.Context)
+			return streamCtx, client, nil
+		},
+	).Times(2)
+	transport.EXPECT().Release().Times(2)
+
+	stream := roachpb.NewMockInternal_RangeFeedClient(ctrl)
+	gomock.InOrder(
+		// The first time we call Recv, we'll block, waiting for stream context cancellation.
+		stream.EXPECT().Recv().DoAndReturn(func() (*roachpb.RangeFeedEvent, error) {
+			// Once we've seen our cancellation, slow down watchdog so that it doesn't
+			// keep killing streamCtx.
+			<-streamCtx.Done()
+			restartRangefeedThreshold.Override(rangefeedCtx, &st.SV, 10*time.Minute)
+			return nil, streamCtx.Err()
+		}),
+
+		// The second time, we'll just succeed immediately and indicate the end of the stream.
+		stream.EXPECT().Recv().Do(cancelRangefeed).Return(nil, io.EOF),
+	)
+
+	// Each call to client/transport/etc expected to happen twice -- once when we
+	// cancel the stream due to "slow" range feed, and the second time when we return io.EOF
+	client.EXPECT().RangeFeed(gomock.Any(), gomock.Any()).Return(stream, nil).Times(2)
+
+	rangeDB := rangecache.NewMockRangeDescriptorDB(ctrl)
+	cachedLease := roachpb.Lease{
+		Replica:  desc.InternalReplicas[0],
+		Sequence: 1,
+	}
+
+	ds := NewDistSender(DistSenderConfig{
+		AmbientCtx:      log.AmbientContext{Tracer: tracing.NewTracer()},
+		Clock:           clock,
+		NodeDescs:       g,
+		RPCRetryOptions: &retry.Options{MaxRetries: 10},
+		RPCContext:      rpcContext,
+		TestingKnobs: ClientTestingKnobs{
+			TransportFactory: func(SendOptions, *nodedialer.Dialer, ReplicaSlice) (Transport, error) {
+				return transport, nil
+			},
+		},
+		RangeDescriptorDB: rangeDB,
+		NodeDialer:        nodedialer.New(rpcContext, gossip.AddressResolver(g)),
+		Settings:          st,
+	})
+	ds.rangeCache.Insert(rangefeedCtx, roachpb.RangeInfo{
+		Desc:  desc,
+		Lease: cachedLease,
+	})
+
+	err := ds.RangeFeed(rangefeedCtx, roachpb.Span{Key: keys.MinKey, EndKey: keys.MaxKey}, clock.Now(), false, nil)
+	require.Error(t, err)
+}

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_heartbeater.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_heartbeater.go
@@ -352,7 +352,7 @@ func (h *txnHeartbeater) heartbeatLoop(ctx context.Context) {
 		return
 	}
 
-	// Loop with ticker for periodic heartbeats.
+	// Loop with timer for periodic heartbeats.
 	for {
 		select {
 		case <-tickChan:

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -829,6 +829,12 @@ var charts = []sectionDescription{
 				Percentiles: false,
 				Metrics:     []string{"requests.slow.distsender"},
 			},
+			{
+				Title:       "Stuck rangefeed ranges",
+				Downsampler: DescribeAggregator_MAX,
+				Percentiles: false,
+				Metrics:     []string{"distsender.rangefeed.slow_range_restarts"},
+			},
 		},
 	},
 	{


### PR DESCRIPTION
Add a process that watches over started rangefeeds and restarts
those rangefeeds which have not received checkpoints (closed timestamps)
in a long time.

While adding a auto-timeout feature seems to "paper over" problems,
the reality is that we want to protect against potential bugs in
the systems that must work correctly for changefeeds to function
(closed timestamp, etc).

By default, the "watchdog" process is disabled, and must be enabled
via the `kv.dist_sender.enable_rangefeed_watchdog`

Fixes #68342

Release Notes: Add a mechanism for watching over rangefeeds, and
restarting them automatically if they appear to be stuck.