### PR TITLE
release-21.1: sql: fix accidental FK check skips

### DIFF
--- a/pkg/sql/insert_fast_path.go
+++ b/pkg/sql/insert_fast_path.go
@@ -162,8 +162,8 @@ func (r *insertFastPathRun) addFKChecks(
 				return c.errorForRow(inputRow)
 			}
 			// We have a row with only NULLS, or a row with some NULLs and match
-			// method PARTIAL. We can ignore this row.
-			return nil
+			// method PARTIAL. We can skip this FK check for this row.
+			continue
 		}
 
 		span, err := c.generateSpan(inputRow)

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -3723,3 +3723,20 @@ INSERT INTO t65890_c SELECT 1, 2, 2
 
 statement ok
 SET enable_insert_fast_path = $enable_insert_fast_path
+
+# Regression test for #68307.
+statement ok
+CREATE TABLE t1 (a INT8 PRIMARY KEY);
+CREATE TABLE t2 (a INT8 PRIMARY KEY);
+CREATE TABLE t3 (a INT8 PRIMARY KEY, b INT8 REFERENCES t1 (a), c INT8 REFERENCES t2 (a));
+INSERT INTO t1 VALUES (1);
+INSERT INTO t2 VALUES (1);
+
+statement error violates foreign key constraint "fk_b_ref_t1"
+INSERT INTO t3 VALUES (1, 1, 1), (2, 2, NULL)
+
+statement error violates foreign key constraint "fk_c_ref_t2"
+INSERT INTO t3 VALUES (1, 1, 1), (2, NULL, 2)
+
+statement ok
+DROP TABLE t3, t1, t2


### PR DESCRIPTION
Backport 1/1 commits from #68486.

Release justification: trivial code change that fixes a correctness issue.

/cc @cockroachdb/release

---

This change fixes a bug in the insert fast path where we accidentally
skip subsequent FK checks when a FK check can be skipped due to NULL
value.

Note that this bug does not manifest when optbuilder can determine
that the check can be elided entirely; notably, this is always the
case for non-prepared statements which insert a single row.

Fixes #68307.

Release note (bug fix): fixed missing foreign key checks in some cases
when there are multiple checks and the inserted data contains a NULL
for one of the checks.
