### PR TITLE
release-20.2: sql: fix accidental FK check skips

### DIFF
--- a/pkg/sql/insert_fast_path.go
+++ b/pkg/sql/insert_fast_path.go
@@ -173,8 +173,8 @@ func (r *insertFastPathRun) addFKChecks(
 				return c.errorForRow(inputRow)
 			}
 			// We have a row with only NULLS, or a row with some NULLs and match
-			// method PARTIAL. We can ignore this row.
-			return nil
+			// method PARTIAL. We can skip this FK check for this row.
+			continue
 		}
 
 		span, err := c.generateSpan(inputRow)

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -3635,3 +3635,20 @@ CREATE TABLE partial_parent (p INT, UNIQUE INDEX (p) WHERE p > 100)
 
 statement error there is no unique constraint matching given keys for referenced table partial_parent
 CREATE TABLE partial_child (p INT REFERENCES partial_parent (p))
+
+# Regression test for #68307.
+statement ok
+CREATE TABLE t1 (a INT8 PRIMARY KEY);
+CREATE TABLE t2 (a INT8 PRIMARY KEY);
+CREATE TABLE t3 (a INT8 PRIMARY KEY, b INT8 REFERENCES t1 (a), c INT8 REFERENCES t2 (a));
+INSERT INTO t1 VALUES (1);
+INSERT INTO t2 VALUES (1);
+
+statement error violates foreign key constraint "fk_b_ref_t1"
+INSERT INTO t3 VALUES (1, 1, 1), (2, 2, NULL)
+
+statement error violates foreign key constraint "fk_c_ref_t2"
+INSERT INTO t3 VALUES (1, 1, 1), (2, NULL, 2)
+
+statement ok
+DROP TABLE t3, t1, t2


### PR DESCRIPTION
Backport 1/1 commits from #68486.

Release justification: trivial code change that fixes a correctness issue.

/cc @cockroachdb/release

---

This change fixes a bug in the insert fast path where we accidentally
skip subsequent FK checks when a FK check can be skipped due to NULL
value.

Note that this bug does not manifest when optbuilder can determine
that the check can be elided entirely; notably, this is always the
case for non-prepared statements which insert a single row.

Fixes #68307.

Release note (bug fix): fixed missing foreign key checks in some cases
when there are multiple checks and the inserted data contains a NULL
for one of the checks.
