### PR TITLE
roachtest,workload,roachprod: add version command and --version flag

### DIFF
--- a/pkg/build/info.go
+++ b/pkg/build/info.go
@@ -11,8 +11,10 @@
 package build
 
 import (
+	"bytes"
 	"fmt"
 	"runtime"
+	"text/tabwriter"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
@@ -75,6 +77,26 @@ func (b Info) Short() string {
 	}
 	return fmt.Sprintf("CockroachDB %s %s (%s, built %s, %s)",
 		b.Distribution, b.Tag, plat, b.Time, b.GoVersion)
+}
+
+// Long returns a pretty printed build summary
+func (b Info) Long() string {
+	var buf bytes.Buffer
+	tw := tabwriter.NewWriter(&buf, 2, 1, 2, ' ', 0)
+	fmt.Fprintf(tw, "Build Tag:        %s\n", b.Tag)
+	fmt.Fprintf(tw, "Build Time:       %s\n", b.Time)
+	fmt.Fprintf(tw, "Distribution:     %s\n", b.Distribution)
+	fmt.Fprintf(tw, "Platform:         %s", b.Platform)
+	if b.CgoTargetTriple != "" {
+		fmt.Fprintf(tw, " (%s)", b.CgoTargetTriple)
+	}
+	fmt.Fprintln(tw)
+	fmt.Fprintf(tw, "Go Version:       %s\n", b.GoVersion)
+	fmt.Fprintf(tw, "C Compiler:       %s\n", b.CgoCompiler)
+	fmt.Fprintf(tw, "Build Commit ID:  %s\n", b.Revision)
+	fmt.Fprintf(tw, "Build Type:       %s", b.Type) // No final newline: cobra prints one for us.
+	_ = tw.Flush()
+	return buf.String()
 }
 
 // GoTime parses the utcTime string and returns a time.Time.

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -11,13 +11,11 @@
 package cli
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"math/rand"
 	"os"
 	"strings"
-	"text/tabwriter"
 
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/cli/clierror"
@@ -183,22 +181,7 @@ Output build version information.
 
 func fullVersionString() string {
 	info := build.GetInfo()
-	var buf bytes.Buffer
-	tw := tabwriter.NewWriter(&buf, 2, 1, 2, ' ', 0)
-	fmt.Fprintf(tw, "Build Tag:        %s\n", info.Tag)
-	fmt.Fprintf(tw, "Build Time:       %s\n", info.Time)
-	fmt.Fprintf(tw, "Distribution:     %s\n", info.Distribution)
-	fmt.Fprintf(tw, "Platform:         %s", info.Platform)
-	if info.CgoTargetTriple != "" {
-		fmt.Fprintf(tw, " (%s)", info.CgoTargetTriple)
-	}
-	fmt.Fprintln(tw)
-	fmt.Fprintf(tw, "Go Version:       %s\n", info.GoVersion)
-	fmt.Fprintf(tw, "C Compiler:       %s\n", info.CgoCompiler)
-	fmt.Fprintf(tw, "Build Commit ID:  %s\n", info.Revision)
-	fmt.Fprintf(tw, "Build Type:       %s", info.Type) // No final newline: cobra prints one for us.
-	_ = tw.Flush()
-	return buf.String()
+	return info.Long()
 }
 
 var cockroachCmd = &cobra.Command{

--- a/pkg/cmd/roachprod/BUILD.bazel
+++ b/pkg/cmd/roachprod/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/roachprod",
     visibility = ["//visibility:private"],
     deps = [
+        "//pkg/build",
         "//pkg/cmd/roachprod/cloud",
         "//pkg/cmd/roachprod/config",
         "//pkg/cmd/roachprod/errors",

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -31,6 +31,7 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/build"
 	cld "github.com/cockroachdb/cockroach/pkg/cmd/roachprod/cloud"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachprod/config"
 	rperrors "github.com/cockroachdb/cockroach/pkg/cmd/roachprod/errors"
@@ -74,6 +75,7 @@ The above commands will create a "local" 3 node cluster, start a cockroach
 cluster on these nodes, run a sql command on the 2nd node, stop, wipe and
 destroy the cluster.
 `,
+	Version: "details:\n" + build.GetInfo().Long(),
 }
 
 var (
@@ -1801,6 +1803,16 @@ var ipCmd = &cobra.Command{
 	}),
 }
 
+var versionCmd = &cobra.Command{
+	Use:   `version`,
+	Short: `print version information`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		info := build.GetInfo()
+		fmt.Println(info.Long())
+		return nil
+	},
+}
+
 func main() {
 	// The commands are displayed in the order they are added to rootCmd. Note
 	// that gcCmd and adminurlCmd contain a trailing \n in their Short help in
@@ -1837,6 +1849,7 @@ func main() {
 		logsCmd,
 		pprofCmd,
 		cachedHostsCmd,
+		versionCmd,
 	)
 	rootCmd.BashCompletionFunction = fmt.Sprintf(`__custom_func()
 	{

--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/roachtest",
     visibility = ["//visibility:private"],
     deps = [
+        "//pkg/build",
         "//pkg/cmd/internal/issues",
         "//pkg/cmd/roachtest/cluster",
         "//pkg/cmd/roachtest/logger",

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/logger"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/tests"
@@ -59,7 +60,7 @@ func main() {
 		Short: "roachtest tool for testing cockroach clusters",
 		Long: `roachtest is a tool for testing cockroach clusters.
 `,
-
+		Version: "details:\n" + build.GetInfo().Long(),
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			// Don't bother checking flags for the default help command.
 			if cmd.Name() == "help" {
@@ -98,6 +99,16 @@ func main() {
 	f := rootCmd.PersistentFlags().VarPF(
 		&encrypt, "encrypt", "", "start cluster with encryption at rest turned on")
 	f.NoOptDefVal = "true"
+
+	rootCmd.AddCommand(&cobra.Command{
+		Use:   `version`,
+		Short: `print version information`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			info := build.GetInfo()
+			fmt.Println(info.Long())
+			return nil
+		}},
+	)
 
 	var listBench bool
 

--- a/pkg/workload/cli/BUILD.bazel
+++ b/pkg/workload/cli/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/workload/cli",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/build",
         "//pkg/cli/exit",
         "//pkg/util/envutil",
         "//pkg/util/log",

--- a/pkg/workload/cli/cli.go
+++ b/pkg/workload/cli/cli.go
@@ -11,6 +11,9 @@
 package cli
 
 import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/cli/exit"
 	"github.com/cockroachdb/cockroach/pkg/workload"
 	"github.com/cockroachdb/errors"
@@ -21,9 +24,20 @@ import (
 // command tree.
 func WorkloadCmd(userFacing bool) *cobra.Command {
 	rootCmd := SetCmdDefaults(&cobra.Command{
-		Use:   `workload`,
-		Short: `generators for data and query loads`,
+		Use:     `workload`,
+		Short:   `generators for data and query loads`,
+		Version: "details:\n" + build.GetInfo().Long(),
 	})
+	rootCmd.AddCommand(&cobra.Command{
+		Use:   `version`,
+		Short: `print version information`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			info := build.GetInfo()
+			fmt.Println(info.Long())
+			return nil
+		}},
+	)
+
 	for _, subCmdFn := range subCmdFns {
 		rootCmd.AddCommand(subCmdFn(userFacing))
 	}


### PR DESCRIPTION
It is often important to capture the versions of these tools used
during a test.  To help facilitate this, each command now supports a
`version` command that outputs build information captured at link
time.

This information is also available via the `build` package, which will
be useful for outputting it in other forms in the future as well.

Release note: None