### PR TITLE
admission: enable admission control

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -1,7 +1,7 @@
 Setting	Type	Default	Description
-admission.kv.enabled	boolean	false	when true, work performed by the KV layer is subject to admission control
-admission.sql_kv_response.enabled	boolean	false	when true, work performed by the SQL layer when receiving a KV response is subject to admission control
-admission.sql_sql_response.enabled	boolean	false	when true, work performed by the SQL layer when receiving a DistSQL response is subject to admission control
+admission.kv.enabled	boolean	true	when true, work performed by the KV layer is subject to admission control
+admission.sql_kv_response.enabled	boolean	true	when true, work performed by the SQL layer when receiving a KV response is subject to admission control
+admission.sql_sql_response.enabled	boolean	true	when true, work performed by the SQL layer when receiving a DistSQL response is subject to admission control
 bulkio.backup.file_size	byte size	128 MiB	target size for individual data files produced during BACKUP
 bulkio.backup.read_timeout	duration	5m0s	amount of time after which a read attempt is considered timed out, which causes the backup to fail
 bulkio.backup.read_with_priority_after	duration	1m0s	amount of time since the read-as-of time above which a BACKUP should use priority when retrying reads

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -1,9 +1,9 @@
 <table>
 <thead><tr><th>Setting</th><th>Type</th><th>Default</th><th>Description</th></tr></thead>
 <tbody>
-<tr><td><code>admission.kv.enabled</code></td><td>boolean</td><td><code>false</code></td><td>when true, work performed by the KV layer is subject to admission control</td></tr>
-<tr><td><code>admission.sql_kv_response.enabled</code></td><td>boolean</td><td><code>false</code></td><td>when true, work performed by the SQL layer when receiving a KV response is subject to admission control</td></tr>
-<tr><td><code>admission.sql_sql_response.enabled</code></td><td>boolean</td><td><code>false</code></td><td>when true, work performed by the SQL layer when receiving a DistSQL response is subject to admission control</td></tr>
+<tr><td><code>admission.kv.enabled</code></td><td>boolean</td><td><code>true</code></td><td>when true, work performed by the KV layer is subject to admission control</td></tr>
+<tr><td><code>admission.sql_kv_response.enabled</code></td><td>boolean</td><td><code>true</code></td><td>when true, work performed by the SQL layer when receiving a KV response is subject to admission control</td></tr>
+<tr><td><code>admission.sql_sql_response.enabled</code></td><td>boolean</td><td><code>true</code></td><td>when true, work performed by the SQL layer when receiving a DistSQL response is subject to admission control</td></tr>
 <tr><td><code>bulkio.backup.file_size</code></td><td>byte size</td><td><code>128 MiB</code></td><td>target size for individual data files produced during BACKUP</td></tr>
 <tr><td><code>bulkio.backup.read_timeout</code></td><td>duration</td><td><code>5m0s</code></td><td>amount of time after which a read attempt is considered timed out, which causes the backup to fail</td></tr>
 <tr><td><code>bulkio.backup.read_with_priority_after</code></td><td>duration</td><td><code>1m0s</code></td><td>amount of time since the read-as-of time above which a BACKUP should use priority when retrying reads</td></tr>

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -693,9 +693,9 @@ func registerTPCC(r registry.Registry) {
 		EstimatedMax:   gceOrAws(cloud, 2400, 3000),
 	})
 	registerTPCCBenchSpec(r, tpccBenchSpec{
-		Nodes:                   3,
-		CPUs:                    16,
-		AdmissionControlEnabled: true,
+		Nodes:                    3,
+		CPUs:                     16,
+		AdmissionControlDisabled: true,
 
 		LoadWarehouses: gceOrAws(cloud, 3000, 3500),
 		EstimatedMax:   gceOrAws(cloud, 2400, 3000),
@@ -801,12 +801,12 @@ func (l tpccBenchLoadConfig) numLoadNodes(d tpccBenchDistribution) int {
 }
 
 type tpccBenchSpec struct {
-	Nodes                   int
-	CPUs                    int
-	Chaos                   bool
-	AdmissionControlEnabled bool
-	Distribution            tpccBenchDistribution
-	LoadConfig              tpccBenchLoadConfig
+	Nodes                    int
+	CPUs                     int
+	Chaos                    bool
+	AdmissionControlDisabled bool
+	Distribution             tpccBenchDistribution
+	LoadConfig               tpccBenchLoadConfig
 
 	// The number of warehouses to load into the cluster before beginning
 	// benchmarking. Should be larger than EstimatedMax and should be a
@@ -857,8 +857,8 @@ func registerTPCCBenchSpec(r registry.Registry, b tpccBenchSpec) {
 	if b.Chaos {
 		nameParts = append(nameParts, "chaos")
 	}
-	if b.AdmissionControlEnabled {
-		nameParts = append(nameParts, "admission")
+	if b.AdmissionControlDisabled {
+		nameParts = append(nameParts, "no-admission")
 	}
 
 	opts := []spec.Option{spec.CPU(b.CPUs)}
@@ -1034,9 +1034,7 @@ func runTPCCBench(ctx context.Context, t test.Test, c cluster.Cluster, b tpccBen
 	c.EncryptDefault(false)
 	c.EncryptAtRandom(false)
 	c.Start(ctx, append(b.startOpts(), roachNodes)...)
-	if b.AdmissionControlEnabled {
-		EnableAdmissionControl(ctx, t, c)
-	}
+	SetAdmissionControl(ctx, t, c, !b.AdmissionControlDisabled)
 	useHAProxy := b.Chaos
 	const restartWait = 15 * time.Second
 	{
@@ -1125,9 +1123,7 @@ func runTPCCBench(ctx context.Context, t test.Test, c cluster.Cluster, b tpccBen
 		}
 
 		c.Start(ctx, append(b.startOpts(), roachNodes)...)
-		if b.AdmissionControlEnabled {
-			EnableAdmissionControl(ctx, t, c)
-		}
+		SetAdmissionControl(ctx, t, c, !b.AdmissionControlDisabled)
 	}
 
 	s := search.NewLineSearcher(1, b.LoadWarehouses, b.EstimatedMax, initStepSize, precision)

--- a/pkg/cmd/roachtest/tests/util.go
+++ b/pkg/cmd/roachtest/tests/util.go
@@ -94,16 +94,20 @@ func WaitForUpdatedReplicationReport(ctx context.Context, t test.Test, db *gosql
 	}
 }
 
-// EnableAdmissionControl enables the admission control cluster settings on
-// the given cluster.
-func EnableAdmissionControl(ctx context.Context, t test.Test, c cluster.Cluster) {
+// SetAdmissionControl sets the admission control cluster settings on the
+// given cluster.
+func SetAdmissionControl(ctx context.Context, t test.Test, c cluster.Cluster, enabled bool) {
 	db := c.Conn(ctx, 1)
 	defer db.Close()
+	val := "true"
+	if !enabled {
+		val = "false"
+	}
 	for _, setting := range []string{"admission.kv.enabled", "admission.sql_kv_response.enabled",
 		"admission.sql_sql_response.enabled"} {
 		if _, err := db.ExecContext(
-			ctx, "SET CLUSTER SETTING "+setting+" = 'true'"); err != nil {
-			t.Fatalf("failed to enable admission control: %v", err)
+			ctx, "SET CLUSTER SETTING "+setting+" = '"+val+"'"); err != nil {
+			t.Fatalf("failed to set admission control to %t: %v", enabled, err)
 		}
 	}
 }

--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -36,7 +36,7 @@ import (
 var KVAdmissionControlEnabled = settings.RegisterBoolSetting(
 	"admission.kv.enabled",
 	"when true, work performed by the KV layer is subject to admission control",
-	false).WithPublic()
+	true).WithPublic()
 
 // SQLKVResponseAdmissionControlEnabled controls whether response processing
 // in SQL, for KV requests, is enabled.
@@ -44,7 +44,7 @@ var SQLKVResponseAdmissionControlEnabled = settings.RegisterBoolSetting(
 	"admission.sql_kv_response.enabled",
 	"when true, work performed by the SQL layer when receiving a KV response is subject to "+
 		"admission control",
-	false).WithPublic()
+	true).WithPublic()
 
 // SQLSQLResponseAdmissionControlEnabled controls whether response processing
 // in SQL, for DistSQL requests, is enabled.
@@ -52,7 +52,7 @@ var SQLSQLResponseAdmissionControlEnabled = settings.RegisterBoolSetting(
 	"admission.sql_sql_response.enabled",
 	"when true, work performed by the SQL layer when receiving a DistSQL response is subject "+
 		"to admission control",
-	false).WithPublic()
+	true).WithPublic()
 
 var admissionControlEnabledSettings = [numWorkKinds]*settings.BoolSetting{
 	KVWork:             KVAdmissionControlEnabled,


### PR DESCRIPTION
Also updated existing roachtests that explicitly enabled
admission control to now disable admission control, so
that we can continue to compare performance of the two
settings.

Release note (ops change): The cluster settings affecting
the admission control system enablement are now set to
defaults that enable admission control.