### PR TITLE
backupccl: add option to display descriptor ids to SHOW BACKUP

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -61,6 +61,7 @@ const (
 	backupOptEncKMS             = "kms"
 	backupOptWithPrivileges     = "privileges"
 	backupOptAsJSON             = "as_json"
+	backupOptWithDebugIDs       = "debug_ids"
 	localityURLParam            = "COCKROACH_LOCALITY"
 	defaultLocalityValue        = "default"
 )


### PR DESCRIPTION
Previously there weren't any descriptor ID information displayed by SHOW BACKUP. These IDs provide
useful information during triage and general debugging. To address this, a WITH option debug_ids
was added to populate additional columns in SHOW BACKUP with descriptor IDS of all objects along
with the IDs of its database and parent schema.

Release note (enterprise change): Descriptor IDs of every object are now visible in SHOW BACKUP,
along with the descriptor IDs of the object's database and parent schema. SHOW BACKUP will display
these IDs if the `WITH debug_ids` option is specified.