### PR TITLE
release-21.1: kvserver: consider suspect stores "live" for computing quorum

### DIFF
--- a/pkg/kv/kvserver/allocator.go
+++ b/pkg/kv/kvserver/allocator.go
@@ -544,7 +544,14 @@ func (a *Allocator) computeAction(
 		return action, adjustedPriority
 	}
 
-	liveVoters, deadVoters := a.storePool.liveAndDeadReplicas(voterReplicas)
+	// NB: For the purposes of determining whether a range has quorum, we
+	// consider stores marked as "suspect" to be live. This is necessary because
+	// we would otherwise spuriously consider ranges with replicas on suspect
+	// stores to be unavailable, just because their nodes have failed a liveness
+	// heartbeat in the recent past. This means we won't move those replicas
+	// elsewhere (for a regular rebalance or for decommissioning).
+	const includeSuspectStores = true
+	liveVoters, deadVoters := a.storePool.liveAndDeadReplicas(voterReplicas, includeSuspectStores)
 
 	if len(liveVoters) < quorum {
 		// Do not take any replacement/removal action if we do not have a quorum of
@@ -623,7 +630,9 @@ func (a *Allocator) computeAction(
 		return action, action.Priority()
 	}
 
-	liveNonVoters, deadNonVoters := a.storePool.liveAndDeadReplicas(nonVoterReplicas)
+	liveNonVoters, deadNonVoters := a.storePool.liveAndDeadReplicas(
+		nonVoterReplicas, includeSuspectStores,
+	)
 	if haveNonVoters == neededNonVoters && len(deadNonVoters) > 0 {
 		// The range has non-voter(s) on a dead node that we should replace.
 		action = AllocatorReplaceDeadNonVoter
@@ -1309,7 +1318,7 @@ func (a *Allocator) TransferLeaseTarget(
 			return roachpb.ReplicaDescriptor{}
 		}
 		// Verify that the preferred replica is eligible to receive the lease.
-		preferred, _ = a.storePool.liveAndDeadReplicas(preferred)
+		preferred, _ = a.storePool.liveAndDeadReplicas(preferred, false /* includeSuspectStores */)
 		if len(preferred) == 1 {
 			return preferred[0]
 		}
@@ -1323,8 +1332,8 @@ func (a *Allocator) TransferLeaseTarget(
 		}
 	}
 
-	// Only consider live, non-draining replicas.
-	existing, _ = a.storePool.liveAndDeadReplicas(existing)
+	// Only consider live, non-draining, non-suspect replicas.
+	existing, _ = a.storePool.liveAndDeadReplicas(existing, false /* includeSuspectStores */)
 
 	// Short-circuit if there are no valid targets out there.
 	if len(existing) == 0 || (len(existing) == 1 && existing[0].StoreID == leaseStoreID) {
@@ -1427,8 +1436,8 @@ func (a *Allocator) ShouldTransferLease(
 	sl = sl.filter(zone.Constraints)
 	log.VEventf(ctx, 3, "ShouldTransferLease (lease-holder=%d):\n%s", leaseStoreID, sl)
 
-	// Only consider live, non-draining replicas.
-	existing, _ = a.storePool.liveAndDeadReplicas(existing)
+	// Only consider live, non-draining, non-suspect replicas.
+	existing, _ = a.storePool.liveAndDeadReplicas(existing, false /* includeSuspectNodes */)
 
 	// Short-circuit if there are no valid targets out there.
 	if len(existing) == 0 || (len(existing) == 1 && existing[0].StoreID == source.StoreID) {

--- a/pkg/kv/kvserver/allocator_test.go
+++ b/pkg/kv/kvserver/allocator_test.go
@@ -5612,12 +5612,14 @@ func TestAllocatorComputeActionSuspect(t *testing.T) {
 			suspect:        []roachpb.StoreID{3},
 			expectedAction: AllocatorConsiderRebalance,
 		},
-		// Needs three replicas, two are suspect (i.e. the range lacks a quorum).
 		{
+			// When trying to determine whether a range can achieve quorum, we count
+			// suspect nodes as live because they _currently_ have a "live" node
+			// liveness record.
 			desc:           threeReplDesc,
 			live:           []roachpb.StoreID{1, 4},
 			suspect:        []roachpb.StoreID{2, 3},
-			expectedAction: AllocatorRangeUnavailable,
+			expectedAction: AllocatorConsiderRebalance,
 		},
 	}
 

--- a/pkg/kv/kvserver/client_lease_test.go
+++ b/pkg/kv/kvserver/client_lease_test.go
@@ -627,12 +627,12 @@ func TestLeasesDontThrashWhenNodeBecomesSuspect(t *testing.T) {
 
 	testutils.SucceedsSoon(t, func() error {
 		for _, i := range []int{2, 3} {
-			suspect, err := tc.GetFirstStoreFromServer(t, i).GetStoreConfig().StorePool.IsSuspect(tc.Target(1).StoreID)
+			suspect, err := tc.GetFirstStoreFromServer(t, i).GetStoreConfig().StorePool.IsUnknown(tc.Target(1).StoreID)
 			if err != nil {
 				return err
 			}
 			if !suspect {
-				return errors.Errorf("Expected server 1 to be suspect on server %d", i)
+				return errors.Errorf("Expected server 1 to be in `storeStatusUnknown` on server %d", i)
 			}
 		}
 		return nil

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -365,12 +365,16 @@ func (rq *replicateQueue) processOneChange(
 	// range descriptor.
 	desc, zone := repl.DescAndZone()
 
-	// Avoid taking action if the range has too many dead replicas to make
-	// quorum.
+	// Avoid taking action if the range has too many dead replicas to make quorum.
+	// Consider stores marked suspect as live in order to make this determination.
 	voterReplicas := desc.Replicas().VoterDescriptors()
 	nonVoterReplicas := desc.Replicas().NonVoterDescriptors()
-	liveVoterReplicas, deadVoterReplicas := rq.allocator.storePool.liveAndDeadReplicas(voterReplicas)
-	liveNonVoterReplicas, deadNonVoterReplicas := rq.allocator.storePool.liveAndDeadReplicas(nonVoterReplicas)
+	liveVoterReplicas, deadVoterReplicas := rq.allocator.storePool.liveAndDeadReplicas(
+		voterReplicas, true, /* includeSuspectStores */
+	)
+	liveNonVoterReplicas, deadNonVoterReplicas := rq.allocator.storePool.liveAndDeadReplicas(
+		nonVoterReplicas, true, /* includeSuspectStores */
+	)
 
 	// NB: the replication layer ensures that the below operations don't cause
 	// unavailability; see:


### PR DESCRIPTION
Backport 1/1 commits from #67714.

/cc @cockroachdb/release

---

Previously, when making the determination of whether a range could achieve
quorum, the allocator ignored "suspect" stores. In other words, a range with 3
replicas would be considered unavailable for rebalancing decisions if it had 2
or more replicas on stores that are marked suspect.

This meant that if a given cluster had multiple nodes missing their liveness
heartbeats intermittently, operations like node decommissioning would never
make progress past a certain point (the replicate queue would never decide to
move replicas away because it would think their ranges are unavailable, even
though they're really not).

This patch fixes this by slightly altering the state transitions for how stores
go in and out of "suspect" and by having the replica rebalancing code
specifically ask for suspect stores to be included in the set of "live"
replicas when it makes the determination of whether a given range can achieve
quorum.

Release note (bug fix): A bug that was introduced in 21.1.5, which prevented
nodes from decommissioning in a cluster if it had multiple nodes intermittently
missing their liveness heartbeats has been fixed.
