### PR TITLE
sql: support decode ExplainTreePlanNode from JSON format

### DIFF
--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_decoding.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_decoding.go
@@ -13,6 +13,7 @@ package sqlstatsutil
 import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
+	"github.com/cockroachdb/errors"
 )
 
 // DecodeTxnStatsMetadataJSON decodes the 'metadata' field of the JSON
@@ -47,4 +48,65 @@ func DecodeStmtStatsMetadataJSON(
 // roachpb.StatementStatistics.
 func DecodeStmtStatsStatisticsJSON(jsonVal json.JSON, result *roachpb.StatementStatistics) error {
 	return (*stmtStats)(result).decodeJSON(jsonVal)
+}
+
+// JSONToExplainTreePlanNode decodes the JSON-formatted ExplainTreePlanNode
+// produced by ExplainTreePlanNodeToJSON.
+func JSONToExplainTreePlanNode(jsonVal json.JSON) (*roachpb.ExplainTreePlanNode, error) {
+	node := roachpb.ExplainTreePlanNode{}
+
+	nameAttr, err := safeFetchVal(jsonVal, "Name")
+	if err != nil {
+		return nil, err
+	}
+
+	str, err := nameAttr.AsText()
+	if err != nil {
+		return nil, err
+	}
+	node.Name = *str
+
+	iter, err := jsonVal.ObjectIter()
+	if err != nil {
+		return nil, err
+	}
+
+	if iter == nil {
+		return nil, errors.New("unable to deconstruct json object")
+	}
+
+	for iter.Next() {
+		key := iter.Key()
+		value := iter.Value()
+
+		if key == "Name" {
+			// We already handled the name, so we skip it.
+			continue
+		}
+
+		if key == "Children" {
+			for childIdx := 0; childIdx < value.Len(); childIdx++ {
+				childJSON, err := safeFetchValIdx(value, childIdx)
+				if err != nil {
+					return nil, err
+				}
+				child, err := JSONToExplainTreePlanNode(childJSON)
+				if err != nil {
+					return nil, err
+				}
+				node.Children = append(node.Children, child)
+			}
+		} else {
+			str, err := value.AsText()
+			if err != nil {
+				return nil, err
+			}
+			node.Attrs = append(node.Attrs, &roachpb.ExplainTreePlanNode_Attr{
+				Key:   key,
+				Value: *str,
+			})
+		}
+	}
+
+	return &node, nil
 }

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
@@ -409,7 +409,18 @@ func safeFetchVal(jsonVal json.JSON, key string) (json.JSON, error) {
 		return nil, err
 	}
 	if field == nil {
-		return nil, errors.Errorf("%s field is not found in the JSON payload", key)
+		return nil, errors.Newf("%s field is not found in the JSON payload", key)
+	}
+	return field, nil
+}
+
+func safeFetchValIdx(jsonVal json.JSON, idx int) (json.JSON, error) {
+	field, err := jsonVal.FetchValIdx(idx)
+	if err != nil {
+		return nil, err
+	}
+	if field == nil {
+		return nil, errors.Newf("%dth element is not found in the JSON payload", idx)
 	}
 	return field, nil
 }


### PR DESCRIPTION
Previously, we do not have support for decoding the
JSON-formatted ExplainTreePlanNode into the protobuf
format. This is required for us in order to implement
a crdb_internal virtual table that aggregates the cluster-wide
in-memory SQL stats and persisted SQL stats.

Related to #64743
Required for #68193

Release note: None