### PR TITLE
sql: add interface/wrapper for default privileges access

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -2401,10 +2401,9 @@ func getRestoringPrivileges(
 			}
 
 			// TODO(dt): Make this more configurable.
-			updatedPrivileges = descpb.CreatePrivilegesFromDefaultPrivileges(
-				parentDB.GetID(), parentDB.GetDefaultPrivileges(), user, tree.Tables,
-				parentDB.GetPrivileges(),
-			)
+			immutableDefaultPrivileges := parentDB.GetDefaultPrivilegeDescriptor()
+			updatedPrivileges = immutableDefaultPrivileges.CreatePrivilegesFromDefaultPrivileges(
+				parentDB.GetID(), user, tree.Tables, parentDB.GetPrivileges())
 		}
 	case catalog.TypeDescriptor, catalog.DatabaseDescriptor:
 		if descCoverage == tree.RequestedDescriptors {

--- a/pkg/sql/alter_default_privileges.go
+++ b/pkg/sql/alter_default_privileges.go
@@ -133,7 +133,7 @@ func (n *alterDefaultPrivilegesNode) startExec(params runParams) error {
 		n.dbDesc.SetDefaultPrivilegeDescriptor(descpb.InitDefaultPrivilegeDescriptor())
 	}
 
-	defaultPrivs := n.dbDesc.GetDefaultPrivileges()
+	defaultPrivs := n.dbDesc.GetMutableDefaultPrivilegeDescriptor()
 
 	var roles []descpb.DefaultPrivilegesRole
 	if n.n.ForAllRoles {

--- a/pkg/sql/catalog/BUILD.bazel
+++ b/pkg/sql/catalog/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/keys",
         "//pkg/kv",
         "//pkg/roachpb:with-mocks",
+        "//pkg/security",
         "//pkg/server/telemetry",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/pgwire/pgcode",

--- a/pkg/sql/catalog/dbdesc/BUILD.bazel
+++ b/pkg/sql/catalog/dbdesc/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//pkg/keys",
         "//pkg/security",
         "//pkg/sql/catalog",
+        "//pkg/sql/catalog/defaultprivilegedesc",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/multiregion",
         "//pkg/sql/privilege",

--- a/pkg/sql/catalog/dbdesc/database_desc.go
+++ b/pkg/sql/catalog/dbdesc/database_desc.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/defaultprivilegedesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/multiregion"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
@@ -409,6 +410,24 @@ func (desc *Mutable) SetRegionConfig(cfg *descpb.DatabaseDescriptor_RegionConfig
 // RunPostDeserializationChanges.
 func (desc *Mutable) HasPostDeserializationChanges() bool {
 	return desc.changed
+}
+
+// GetDefaultPrivilegeDescriptor returns a DefaultPrivilegeDescriptor.
+func (desc *immutable) GetDefaultPrivilegeDescriptor() catalog.DefaultPrivilegeDescriptor {
+	defaultPrivilegeDescriptor := desc.GetDefaultPrivileges()
+	if defaultPrivilegeDescriptor == nil {
+		defaultPrivilegeDescriptor = descpb.InitDefaultPrivilegeDescriptor()
+	}
+	return defaultprivilegedesc.MakeDefaultPrivileges(defaultPrivilegeDescriptor)
+}
+
+// GetMutableDefaultPrivilegeDescriptor returns a defaultprivilegedesc.Mutable.
+func (desc *Mutable) GetMutableDefaultPrivilegeDescriptor() *defaultprivilegedesc.Mutable {
+	defaultPrivilegeDescriptor := desc.GetDefaultPrivileges()
+	if defaultPrivilegeDescriptor == nil {
+		defaultPrivilegeDescriptor = descpb.InitDefaultPrivilegeDescriptor()
+	}
+	return defaultprivilegedesc.NewMutableDefaultPrivileges(defaultPrivilegeDescriptor)
 }
 
 // SetDefaultPrivilegeDescriptor sets the default privilege descriptor

--- a/pkg/sql/catalog/defaultprivilegedesc/BUILD.bazel
+++ b/pkg/sql/catalog/defaultprivilegedesc/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "defaultprivilegedesc",
+    srcs = ["default_privilege.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/sql/catalog/defaultprivilegedesc",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/keys",
+        "//pkg/security",
+        "//pkg/sql/catalog",
+        "//pkg/sql/catalog/descpb",
+        "//pkg/sql/privilege",
+        "//pkg/sql/sem/tree",
+    ],
+)

--- a/pkg/sql/catalog/defaultprivilegedesc/default_privilege.go
+++ b/pkg/sql/catalog/defaultprivilegedesc/default_privilege.go
@@ -1,0 +1,200 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package defaultprivilegedesc
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+var _ catalog.DefaultPrivilegeDescriptor = &immutable{}
+var _ catalog.DefaultPrivilegeDescriptor = &Mutable{}
+
+// immutable is a wrapper for a DefaultPrivilegeDescriptor
+// that only exposes getters.
+type immutable struct {
+	defaultPrivilegeDescriptor *descpb.DefaultPrivilegeDescriptor
+}
+
+// Mutable is a wrapper for a DefaultPrivilegeDescriptor
+// that exposes getters and setters.
+type Mutable struct {
+	immutable
+}
+
+// MakeDefaultPrivileges returns an immutable
+// given a defaultPrivilegeDescriptor.
+func MakeDefaultPrivileges(
+	defaultPrivilegeDescriptor *descpb.DefaultPrivilegeDescriptor,
+) catalog.DefaultPrivilegeDescriptor {
+	return &immutable{
+		defaultPrivilegeDescriptor: defaultPrivilegeDescriptor,
+	}
+}
+
+// NewMutableDefaultPrivileges returns a Mutable
+// given a defaultPrivilegeDescriptor.
+func NewMutableDefaultPrivileges(
+	defaultPrivilegeDescriptor *descpb.DefaultPrivilegeDescriptor,
+) *Mutable {
+	return &Mutable{
+		immutable{
+			defaultPrivilegeDescriptor: defaultPrivilegeDescriptor,
+		}}
+}
+
+// GrantDefaultPrivileges grants privileges for the specified users.
+func (d *Mutable) GrantDefaultPrivileges(
+	role descpb.DefaultPrivilegesRole,
+	privileges privilege.List,
+	grantees tree.NameList,
+	targetObject tree.AlterDefaultPrivilegesTargetObject,
+) {
+	defaultPrivilegesPerObject := d.defaultPrivilegeDescriptor.
+		FindOrCreateUser(role).DefaultPrivilegesPerObject
+	for _, grantee := range grantees {
+		defaultPrivileges := defaultPrivilegesPerObject[targetObject]
+		defaultPrivileges.Grant(
+			security.MakeSQLUsernameFromPreNormalizedString(string(grantee)),
+			privileges,
+		)
+		defaultPrivilegesPerObject[targetObject] = defaultPrivileges
+	}
+}
+
+// RevokeDefaultPrivileges revokes privileges for the specified users.
+func (d *Mutable) RevokeDefaultPrivileges(
+	role descpb.DefaultPrivilegesRole,
+	privileges privilege.List,
+	grantees tree.NameList,
+	targetObject tree.AlterDefaultPrivilegesTargetObject,
+) {
+	defaultPrivilegesPerObject := d.defaultPrivilegeDescriptor.
+		FindOrCreateUser(role).DefaultPrivilegesPerObject
+	for _, grantee := range grantees {
+		defaultPrivileges := defaultPrivilegesPerObject[targetObject]
+		defaultPrivileges.Revoke(
+			security.MakeSQLUsernameFromPreNormalizedString(string(grantee)),
+			privileges,
+			targetObject.ToPrivilegeObjectType(),
+		)
+
+		defaultPrivilegesPerObject[targetObject] = defaultPrivileges
+	}
+}
+
+// CreatePrivilegesFromDefaultPrivileges implements the
+// catalog.DefaultPrivilegeDescriptor interface.
+// CreatePrivilegesFromDefaultPrivileges creates privileges for a
+// the specified object with the corresponding default privileges and
+// the appropriate owner (node for system, the restoring user otherwise.)
+func (d *immutable) CreatePrivilegesFromDefaultPrivileges(
+	dbID descpb.ID,
+	user security.SQLUsername,
+	targetObject tree.AlterDefaultPrivilegesTargetObject,
+	databasePrivileges *descpb.PrivilegeDescriptor,
+) *descpb.PrivilegeDescriptor {
+	// If a new system table is being created (which should only be doable by
+	// an internal user account), make sure it gets the correct privileges.
+	if dbID == keys.SystemDatabaseID {
+		return descpb.NewDefaultPrivilegeDescriptor(security.NodeUserName())
+	}
+
+	// The privileges for the object are the union of the default privileges
+	// defined for the object for the object creator and the default privileges
+	// defined for all roles.
+	newPrivs := descpb.NewDefaultPrivilegeDescriptor(user)
+	defaultPrivilegesForAllRoles, found := d.GetDefaultPrivilegesForRole(
+		descpb.DefaultPrivilegesRole{
+			ForAllRoles: true,
+		},
+	)
+	if found {
+		defaultPrivileges, descriptorExists := defaultPrivilegesForAllRoles.DefaultPrivilegesPerObject[targetObject]
+		if descriptorExists {
+			for _, user := range defaultPrivileges.Users {
+				newPrivs.Grant(
+					user.UserProto.Decode(),
+					privilege.ListFromBitField(user.Privileges, targetObject.ToPrivilegeObjectType()),
+				)
+			}
+		}
+	}
+
+	defaultPrivilegesForCreator, defaultPrivilegesDefinedForCreator := d.GetDefaultPrivilegesForRole(
+		descpb.DefaultPrivilegesRole{
+			Role: user,
+		})
+	if defaultPrivilegesDefinedForCreator {
+		defaultPrivileges, descriptorExists := defaultPrivilegesForCreator.DefaultPrivilegesPerObject[targetObject]
+		if descriptorExists {
+			for _, user := range defaultPrivileges.Users {
+				newPrivs.Grant(
+					user.UserProto.Decode(),
+					privilege.ListFromBitField(user.Privileges, targetObject.ToPrivilegeObjectType()),
+				)
+			}
+		}
+	}
+
+	newPrivs.SetOwner(user)
+	newPrivs.Version = descpb.Version21_2
+
+	// TODO(richardjcai): Remove this depending on how we handle the migration.
+	//   For backwards compatibility, also "inherit" privileges from the dbDesc.
+	//   Issue #67378.
+	if targetObject == tree.Tables || targetObject == tree.Sequences {
+		for _, u := range databasePrivileges.Users {
+			newPrivs.Grant(u.UserProto.Decode(), privilege.ListFromBitField(u.Privileges, privilege.Table))
+		}
+	} else if targetObject == tree.Schemas {
+		for _, u := range databasePrivileges.Users {
+			newPrivs.Grant(u.UserProto.Decode(), privilege.ListFromBitField(u.Privileges, privilege.Schema))
+		}
+	}
+	return newPrivs
+}
+
+// ForEachDefaultPrivilegeForRole implements the
+// catalog.DefaultPrivilegeDescriptor interface.
+// ForEachDefaultPrivilegeForRole loops through the DefaultPrivilegeDescriptior's
+// DefaultPrivilegePerRole entry and calls f on it.
+func (d *immutable) ForEachDefaultPrivilegeForRole(
+	f func(defaultPrivilegesForRole descpb.DefaultPrivilegesForRole) error,
+) error {
+	if d.defaultPrivilegeDescriptor == nil {
+		return nil
+	}
+	for _, defaultPrivilegesForRole := range d.defaultPrivilegeDescriptor.DefaultPrivilegesPerRole {
+		if err := f(defaultPrivilegesForRole); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// GetDefaultPrivilegesForRole implements the
+// catalog.DefaultPrivilegeDescriptor interface.
+// GetDefaultPrivilegesForRole looks for a specific user in the list.
+// Returns (nil, false) if not found, or (ptr, true) if found.
+func (d *immutable) GetDefaultPrivilegesForRole(
+	role descpb.DefaultPrivilegesRole,
+) (*descpb.DefaultPrivilegesForRole, bool) {
+	idx := d.defaultPrivilegeDescriptor.FindUserIndex(role)
+	if idx == -1 {
+		return nil, false
+	}
+	return &d.defaultPrivilegeDescriptor.DefaultPrivilegesPerRole[idx], true
+}

--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -178,7 +179,7 @@ type DatabaseDescriptor interface {
 	ForEachSchemaInfo(func(id descpb.ID, name string, isDropped bool) error) error
 	GetSchemaID(name string) descpb.ID
 	GetNonDroppedSchemaName(schemaID descpb.ID) string
-	GetDefaultPrivileges() *descpb.DefaultPrivilegeDescriptor
+	GetDefaultPrivilegeDescriptor() DefaultPrivilegeDescriptor
 }
 
 // TableDescriptor is an interface around the table descriptor types.
@@ -389,6 +390,20 @@ type TypeDescriptor interface {
 type TypeDescriptorResolver interface {
 	// GetTypeDescriptor returns the type descriptor for the input ID.
 	GetTypeDescriptor(ctx context.Context, id descpb.ID) (tree.TypeName, TypeDescriptor, error)
+}
+
+// DefaultPrivilegeDescriptor is an interface for default privileges to ensure
+// DefaultPrivilegeDescriptor protos are not accessed and interacted
+// with directly.
+type DefaultPrivilegeDescriptor interface {
+	CreatePrivilegesFromDefaultPrivileges(
+		dbID descpb.ID,
+		user security.SQLUsername,
+		targetObject tree.AlterDefaultPrivilegesTargetObject,
+		databasePrivileges *descpb.PrivilegeDescriptor,
+	) *descpb.PrivilegeDescriptor
+	GetDefaultPrivilegesForRole(descpb.DefaultPrivilegesRole) (*descpb.DefaultPrivilegesForRole, bool)
+	ForEachDefaultPrivilegeForRole(func(descpb.DefaultPrivilegesForRole) error) error
 }
 
 // FilterDescriptorState inspects the state of a given descriptor and returns an

--- a/pkg/sql/create_schema.go
+++ b/pkg/sql/create_schema.go
@@ -104,8 +104,8 @@ func CreateUserDefinedSchemaDescriptor(
 		}
 	}
 
-	privs := descpb.CreatePrivilegesFromDefaultPrivileges(
-		db.GetID(), db.GetDefaultPrivileges(), user, tree.Schemas, db.GetPrivileges(),
+	privs := db.GetDefaultPrivilegeDescriptor().CreatePrivilegesFromDefaultPrivileges(
+		db.GetID(), user, tree.Schemas, db.GetPrivileges(),
 	)
 
 	if !n.AuthRole.Undefined() {

--- a/pkg/sql/create_sequence.go
+++ b/pkg/sql/create_sequence.go
@@ -100,8 +100,8 @@ func doCreateSequence(
 		return err
 	}
 
-	privs := descpb.CreatePrivilegesFromDefaultPrivileges(
-		dbDesc.GetID(), dbDesc.GetDefaultPrivileges(),
+	privs := dbDesc.GetDefaultPrivilegeDescriptor().CreatePrivilegesFromDefaultPrivileges(
+		dbDesc.GetID(),
 		params.SessionData().User(), tree.Sequences, dbDesc.GetPrivileges(),
 	)
 

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -274,8 +274,8 @@ func (n *createTableNode) startExec(params runParams) error {
 		return err
 	}
 
-	privs := descpb.CreatePrivilegesFromDefaultPrivileges(
-		n.dbDesc.GetID(), n.dbDesc.GetDefaultPrivileges(),
+	privs := n.dbDesc.GetDefaultPrivilegeDescriptor().CreatePrivilegesFromDefaultPrivileges(
+		n.dbDesc.GetID(),
 		params.SessionData().User(), tree.Tables, n.dbDesc.GetPrivileges(),
 	)
 	var desc *tabledesc.Mutable

--- a/pkg/sql/create_type.go
+++ b/pkg/sql/create_type.go
@@ -345,8 +345,8 @@ func CreateEnumTypeDesc(
 		}
 	}
 
-	privs := descpb.CreatePrivilegesFromDefaultPrivileges(
-		dbDesc.GetID(), dbDesc.GetDefaultPrivileges(),
+	privs := dbDesc.GetDefaultPrivilegeDescriptor().CreatePrivilegesFromDefaultPrivileges(
+		dbDesc.GetID(),
 		params.p.User(), tree.Types, dbDesc.GetPrivileges(),
 	)
 

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -160,8 +160,8 @@ func (n *createViewNode) startExec(params runParams) error {
 		telemetry.Inc(sqltelemetry.CreateTempViewCounter)
 	}
 
-	privs := descpb.CreatePrivilegesFromDefaultPrivileges(
-		n.dbDesc.GetID(), n.dbDesc.GetDefaultPrivileges(),
+	privs := n.dbDesc.GetDefaultPrivilegeDescriptor().CreatePrivilegesFromDefaultPrivileges(
+		n.dbDesc.GetID(),
 		params.SessionData().User(), tree.Tables, n.dbDesc.GetPrivileges(),
 	)
 


### PR DESCRIPTION
Added to ensure users don't access default privileges and read
from or access the protos directly.

Release note: None