### PR TITLE
ci: split maybe_stress, maybe_stressrace into their own build configs

### DIFF
--- a/build/teamcity-maybe-stress.sh
+++ b/build/teamcity-maybe-stress.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source "$(dirname "${0}")/teamcity-support.sh"
+
+tc_prepare
+
+export TMPDIR=$PWD/artifacts/test
+mkdir -p "$TMPDIR"
+
+if would_stress; then
+  tc_start_block "Compile C dependencies"
+  # Buffer noisy output and only print it on failure.
+  run build/builder.sh make -Otarget c-deps &> artifacts/c-build.log || (cat artifacts/c-build.log && false)
+  rm artifacts/c-build.log
+  tc_end_block "Compile C dependencies"
+
+  maybe_stress stress
+fi

--- a/build/teamcity-maybe-stressrace.sh
+++ b/build/teamcity-maybe-stressrace.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source "$(dirname "${0}")/teamcity-support.sh"
+
+tc_prepare
+
+export TMPDIR=$PWD/artifacts/test
+mkdir -p "$TMPDIR"
+
+if would_stress; then
+  tc_start_block "Compile C dependencies"
+  # Buffer noisy output and only print it on failure.
+  run build/builder.sh make -Otarget c-deps &> artifacts/c-build.log || (cat artifacts/c-build.log && false)
+  rm artifacts/c-build.log
+  tc_end_block "Compile C dependencies"
+
+  maybe_stress stressrace
+fi

--- a/build/teamcity-support.sh
+++ b/build/teamcity-support.sh
@@ -112,13 +112,21 @@ function run_json_test() {
   return $status
 }
 
-function maybe_stress() {
+function would_stress() {
   # Don't stressrace on the release branches; we only want that to happen on the
   # PRs. There's no need in making master flakier than it needs to be; nightly
   # stress will weed out the flaky tests.
-  # NB: as a consequence of the above, this code doesn't know about posting
-  # Github issues.
   if tc_release_branch; then
+    return 1
+  else
+    return 0
+  fi
+}
+
+function maybe_stress() {
+   # NB: This code doesn't know about posting Github issues as we don't stress on
+   # the release branches.
+  if ! would_stress; then
     return 0
   fi
 

--- a/build/teamcity-test.sh
+++ b/build/teamcity-test.sh
@@ -15,8 +15,6 @@ run build/builder.sh make -Otarget c-deps &> artifacts/c-build.log || (cat artif
 rm artifacts/c-build.log
 tc_end_block "Compile C dependencies"
 
-maybe_stress stress
-
 tc_start_block "Run Go tests"
 run_json_test build/builder.sh stdbuf -oL -eL make test GOTESTFLAGS=-json TESTFLAGS='-v'
 tc_end_block "Run Go tests"

--- a/build/teamcity-testrace.sh
+++ b/build/teamcity-testrace.sh
@@ -39,8 +39,6 @@ run build/builder.sh make -Otarget c-deps GOFLAGS=-race &> artifacts/race-c-buil
 rm artifacts/race-c-build.log
 tc_end_block "Compile C dependencies"
 
-maybe_stress "stressrace"
-
 # Expect the timeout to come from the TC environment.
 TESTTIMEOUT=${TESTTIMEOUT:-45m}
 


### PR DESCRIPTION
Closes #68380
Closes #68381

Release note: None