### PR TITLE
ui: Align db console logical plan with sql shell

### DIFF
--- a/pkg/ui/cluster-ui/src/core/colors.module.scss
+++ b/pkg/ui/cluster-ui/src/core/colors.module.scss
@@ -1,5 +1,5 @@
 $colors--neutral-0: #ffffff;
-$colors--neutral-1: #F5F7FA;
+$colors--neutral-1: #f5f7fa;
 $colors--neutral-2: #e7ecf3;
 $colors--neutral-3: #d6dbe7;
 $colors--neutral-4: #c0c6d9;
@@ -9,14 +9,14 @@ $colors--neutral-7: #394455;
 $colors--neutral-8: #242a35;
 $colors--neutral-9: #060c12;
 $colors--neutral-10: #0c1628;
-$colors--neutral-11: #C4C4C4;
-
+$colors--neutral-11: #c4c4c4;
 
 $colors--primary-blue-1: #e0eefb;
 $colors--primary-blue-2: #74bdfd;
-$colors--primary-blue-3: #0055FF;
+$colors--primary-blue-3: #0055ff;
 $colors--primary-blue-4: #005fb3;
 $colors--primary-blue-5: #00294d;
+$colors--primary-blue-6: #89b0ff;
 
 $colors--primary-green-0: #daf8d4;
 $colors--primary-green-1: #b4f1aa;
@@ -25,8 +25,8 @@ $colors--primary-green-3: #37a806;
 $colors--primary-green-4: #237300;
 $colors--primary-green-5: #123d00;
 
-$colors--primary-purple-2: #CBBCFC;
-$colors--primary-purple-3: #6933FF;
+$colors--primary-purple-2: #cbbcfc;
+$colors--primary-purple-3: #6933ff;
 
 $colors--info-4: #0037a5;
 

--- a/pkg/ui/cluster-ui/src/core/typography.module.scss
+++ b/pkg/ui/cluster-ui/src/core/typography.module.scss
@@ -14,11 +14,13 @@
 @include font-face("SourceSansPro-SemiBold");
 @include font-face("SFMono-Semibold");
 @include font-face("RobotoMono-Medium");
+@include font-face("RobotoMono-Regular");
 
 $font-family--base: SourceSansPro-Regular;
 $font-family--bold: SourceSansPro-Bold;
 $font-family--semi-bold: SourceSansPro-SemiBold;
 $font-family--monospace: RobotoMono-Medium;
+$font-family--mono-regular: RobotoMono-Regular;
 $font-family--sf-mono: SFMono-Semibold;
 
 $font-weight--extra-bold: 900;

--- a/pkg/ui/cluster-ui/src/statementDetails/planView/planView.fixtures.tsx
+++ b/pkg/ui/cluster-ui/src/statementDetails/planView/planView.fixtures.tsx
@@ -9,8 +9,14 @@
 // licenses/APL.txt.
 
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+import { GlobalPropertiesType } from "./planView";
 
 type IExplainTreePlanNode = cockroach.sql.IExplainTreePlanNode;
+
+export const globalProperties: GlobalPropertiesType = {
+  distribution: { numerator: 0, denominator: 0 },
+  vectorized: { numerator: 0, denominator: 0 },
+};
 
 export const logicalPlan: IExplainTreePlanNode = {
   name: "root",

--- a/pkg/ui/cluster-ui/src/statementDetails/planView/planView.module.scss
+++ b/pkg/ui/cluster-ui/src/statementDetails/planView/planView.module.scss
@@ -1,5 +1,5 @@
 @import "src/core/index.module";
-@import 'src/sortedtable/table.module.scss';
+@import "src/sortedtable/table.module.scss";
 
 .base-heading {
   padding: 12px 0;
@@ -28,10 +28,11 @@
 
   &__row {
     &--body {
+      background-color: $colors--neutral-10;
       border-top: none;
 
       &:hover {
-        background-color: $adminui-white;
+        background-color: $colors--neutral-10;
       }
     }
   }
@@ -50,7 +51,6 @@
     height: 16px;
     display: inline-block;
 
-
     text-transform: none;
     font-weight: normal;
     white-space: normal;
@@ -68,7 +68,7 @@
     height: 16px;
     border-radius: 50%;
     border: 1px solid $tooltip-color;
-    font-size: 12px;
+    font-size: 14px;
     line-height: 14px;
     text-align: center;
     color: $tooltip-color;
@@ -88,6 +88,7 @@
     height: 100%;
     max-height: 100%;
     overflow: hidden;
+    padding: 24px 32px;
 
     .plan-view-container-scroll {
       max-height: 400px;
@@ -104,27 +105,15 @@
   }
 
   .node-icon {
-    margin: 0 10px 0 0;
-    color: $grey-light;
-  }
-
-  .warning-icon {
-    margin: 0 4px 0 4px;
-    position: relative;
-    top: 3px;
-
-    path {
-      fill: $colors--functional-orange-4;
-    }
+    font-size: 14px;
+    margin: 0 4px 0 0;
+    color: $chip-grey;
   }
 
   .warn {
-    position: relative;
-    left: -5px;
     color: $colors--functional-orange-4;
-    background-color: rgba(209, 135, 55, 0.06);
-    border-radius: 2px;
-    padding: 2px;
+    text-transform: uppercase;
+    border-bottom: 1px dashed $adminui-white;
   }
 
   .nodeDetails {
@@ -133,27 +122,45 @@
     border: 1px solid transparent;
 
     b {
-      font-family: $font-family--semi-bold;
-      font-size: 12px;
-      font-weight: 600;
+      font-family: $font-family--monospace;
+      border-bottom: 1px dashed $adminui-white;
+      font-size: 14px;
+      font-weight: 500;
       line-height: 1.67;
       letter-spacing: 0.3px;
-      color: $text-color;
+      color: $chip-grey;
+    }
+
+    &:only-child {
+      .nodeAttributes {
+        border-left: 1px solid transparent;
+      }
+    }
+  }
+
+  .nodeAttributes.globalAttributes {
+    margin-bottom: 40px;
+    padding: 0 0 40px 0;
+    border-left: none;
+    border-bottom: 1px solid $colors--neutral-5;
+
+    .nodeAttributeKey {
+      border-bottom: 1px dashed $adminui-white;
     }
   }
 
   .nodeAttributes {
-    color: $adminui-grey-2;
-    padding: 7px 16px 0px 18px;
-    margin-left: 3px;
-    border-left: 1px solid $grey-light;
-    font-family: $font-family--monospace;
-    font-size: 12px;
+    color: $chip-grey;
+    padding: 3px 14px 12px 8px;
+    margin-left: 2px;
+    border-left: 1px solid $chip-grey;
+    font-family: $font-family--mono-regular;
+    font-size: 14px;
     font-weight: 500;
     line-height: 1.83;
 
     .nodeAttributeKey {
-      color: $colors--primary-green-3;
+      color: $colors--primary-blue-6;
     }
   }
 
@@ -162,85 +169,37 @@
     margin: 0;
 
     li {
-      padding: 0;
+      padding: 0 0 0 8px;
       margin: 0;
       position: relative;
       list-style-type: none;
 
-      &:not(:first-child):after {
-        content: '';
+      &:not(:last-child):before {
+        content: "";
         width: 1px;
-        height: 19px;
-        background-color: $grey-light;
+        height: 100%;
+        background-color: $chip-grey;
         position: absolute;
-        top: -10px;
-        left: 4px;
+        left: 3px;
       }
 
       ul {
-        padding-left: 27px;
+        padding-left: 32px;
         position: relative;
 
-        &:last-child {
-          &:before {
-            content: '';
-            width: 28px;
-            height: 29px;
-            position: absolute;
-            border-left: 1px solid $grey-light;
-            border-bottom: 1px solid $grey-light;
-            top: -10px;
-            left: 4px;
-            border-bottom-left-radius: 10px;
-          }
-
-          li {
-            &:before {
-              content: none;
-            }
-
-            &:first-child:after {
-              content: none;
-            }
-          }
+        &:before {
+          content: "";
+          width: 28px;
+          height: 29px;
+          position: absolute;
+          border-left: 1px solid $chip-grey;
+          border-bottom: 1px solid $chip-grey;
+          top: -10px;
+          left: -5px;
         }
 
-        li {
-          .nodeDetails {
-            margin-left: 12px;
-          }
-
-          &:not(:first-child):after {
-            left: 16px;
-          }
-
-          &:last-child {
-            .nodeAttributes {
-              border-color: transparent;
-            }
-          }
-
-          &:first-child {
-            &:after {
-              content: '';
-              height: 1px;
-              width: 27px;
-              background-color: $grey-light;
-              position: absolute;
-              top: 18px;
-              left: -22px;
-            }
-          }
-
-          &:before {
-            content: '';
-            width: 1px;
-            height: 100%;
-            background-color: $grey-light;
-            position: absolute;
-            top: -10px;
-            left: -23px;
-          }
+        li:only-child:before {
+          content: none;
         }
       }
     }

--- a/pkg/ui/cluster-ui/src/statementDetails/planView/planView.spec.tsx
+++ b/pkg/ui/cluster-ui/src/statementDetails/planView/planView.spec.tsx
@@ -14,13 +14,42 @@ import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import {
   FlatPlanNode,
   FlatPlanNodeAttribute,
-  flattenTree,
+  flattenTreeAttributes,
   flattenAttributes,
 } from "./planView";
 import IAttr = cockroach.sql.ExplainTreePlanNode.IAttr;
-import IExplainTreePlanNode = cockroach.sql.IExplainTreePlanNode;
 
-const testAttrs1: IAttr[] = [
+type IExplainTreePlanNode = cockroach.sql.IExplainTreePlanNode;
+
+const testAttrsDuplicatedKeys: IAttr[] = [
+  {
+    key: "key1",
+    value: "key1-value1",
+  },
+  {
+    key: "key2",
+    value: "key2-value1",
+  },
+  {
+    key: "key1",
+    value: "key1-value2",
+  },
+];
+
+const expectedTestAttrsFlattened: FlatPlanNodeAttribute[] = [
+  {
+    key: "key1",
+    values: ["key1-value1", "key1-value2"],
+    warn: false,
+  },
+  {
+    key: "key2",
+    values: ["key2-value1"],
+    warn: false,
+  },
+];
+
+const testAttrsDistinctKeys: IAttr[] = [
   {
     key: "key1",
     value: "value1",
@@ -31,18 +60,7 @@ const testAttrs1: IAttr[] = [
   },
 ];
 
-const testAttrs2: IAttr[] = [
-  {
-    key: "key3",
-    value: "value3",
-  },
-  {
-    key: "key4",
-    value: "value4",
-  },
-];
-
-const testFlatAttrs1: FlatPlanNodeAttribute[] = [
+const expectedTestAttrsDistinctKeys: FlatPlanNodeAttribute[] = [
   {
     key: "key1",
     values: ["value1"],
@@ -55,229 +73,87 @@ const testFlatAttrs1: FlatPlanNodeAttribute[] = [
   },
 ];
 
-const testFlatAttrs2: FlatPlanNodeAttribute[] = [
-  {
-    key: "key3",
-    values: ["value3"],
-    warn: false,
-  },
-  {
-    key: "key4",
-    values: ["value4"],
-    warn: false,
-  },
-];
+describe("flattenTreeAttributes", () => {
+  describe("when all nodes have attributes with different keys", () => {
+    it("creates array with exactly one value for each attribute for each node", () => {
+      const node: IExplainTreePlanNode = {
+        name: "root",
+        attrs: testAttrsDistinctKeys,
+        children: [
+          {
+            name: "child",
+            attrs: testAttrsDistinctKeys,
+            children: [
+              {
+                name: "grandchild",
+                attrs: testAttrsDistinctKeys,
+                children: [],
+              },
+            ],
+          },
+        ],
+      };
 
-const treePlanWithSingleChildPaths: IExplainTreePlanNode = {
-  name: "root",
-  attrs: null,
-  children: [
-    {
-      name: "single_grandparent",
-      attrs: testAttrs1,
-      children: [
-        {
-          name: "single_parent",
-          attrs: null,
-          children: [
-            {
-              name: "single_child",
-              attrs: testAttrs2,
-              children: [],
-            },
-          ],
-        },
-      ],
-    },
-  ],
-};
+      const nodeFlattened: FlatPlanNode = {
+        name: "root",
+        attrs: expectedTestAttrsDistinctKeys,
+        children: [
+          {
+            name: "child",
+            attrs: expectedTestAttrsDistinctKeys,
+            children: [
+              {
+                name: "grandchild",
+                attrs: expectedTestAttrsDistinctKeys,
+                children: [],
+              },
+            ],
+          },
+        ],
+      };
 
-const expectedFlatPlanWithSingleChildPaths: FlatPlanNode[] = [
-  {
-    name: "root",
-    attrs: [],
-    children: [],
-  },
-  {
-    name: "single_grandparent",
-    attrs: testFlatAttrs1,
-    children: [],
-  },
-  {
-    name: "single_parent",
-    attrs: [],
-    children: [],
-  },
-  {
-    name: "single_child",
-    attrs: testFlatAttrs2,
-    children: [],
-  },
-];
-
-const treePlanWithChildren1: IExplainTreePlanNode = {
-  name: "root",
-  attrs: testAttrs1,
-  children: [
-    {
-      name: "single_grandparent",
-      attrs: testAttrs1,
-      children: [
-        {
-          name: "parent_1",
-          attrs: null,
-          children: [
-            {
-              name: "single_child",
-              attrs: testAttrs2,
-              children: [],
-            },
-          ],
-        },
-        {
-          name: "parent_2",
-          attrs: null,
-          children: [],
-        },
-      ],
-    },
-  ],
-};
-
-const expectedFlatPlanWithChildren1: FlatPlanNode[] = [
-  {
-    name: "root",
-    attrs: testFlatAttrs1,
-    children: [],
-  },
-  {
-    name: "single_grandparent",
-    attrs: testFlatAttrs1,
-    children: [
-      [
-        {
-          name: "parent_1",
-          attrs: [],
-          children: [],
-        },
-        {
-          name: "single_child",
-          attrs: testFlatAttrs2,
-          children: [],
-        },
-      ],
-      [
-        {
-          name: "parent_2",
-          attrs: [],
-          children: [],
-        },
-      ],
-    ],
-  },
-];
-
-const treePlanWithChildren2: IExplainTreePlanNode = {
-  name: "root",
-  attrs: null,
-  children: [
-    {
-      name: "single_grandparent",
-      attrs: null,
-      children: [
-        {
-          name: "single_parent",
-          attrs: null,
-          children: [
-            {
-              name: "child_1",
-              attrs: testAttrs1,
-              children: [],
-            },
-            {
-              name: "child_2",
-              attrs: testAttrs2,
-              children: [],
-            },
-          ],
-        },
-      ],
-    },
-  ],
-};
-
-const expectedFlatPlanWithChildren2: FlatPlanNode[] = [
-  {
-    name: "root",
-    attrs: [],
-    children: [],
-  },
-  {
-    name: "single_grandparent",
-    attrs: [],
-    children: [],
-  },
-  {
-    name: "single_parent",
-    attrs: [],
-    children: [
-      [
-        {
-          name: "child_1",
-          attrs: testFlatAttrs1,
-          children: [],
-        },
-      ],
-      [
-        {
-          name: "child_2",
-          attrs: testFlatAttrs2,
-          children: [],
-        },
-      ],
-    ],
-  },
-];
-
-const treePlanWithNoChildren: IExplainTreePlanNode = {
-  name: "root",
-  attrs: testAttrs1,
-  children: [],
-};
-
-const expectedFlatPlanWithNoChildren: FlatPlanNode[] = [
-  {
-    name: "root",
-    attrs: testFlatAttrs1,
-    children: [],
-  },
-];
-
-describe("flattenTree", () => {
-  describe("when node has children", () => {
-    it("flattens single child paths.", () => {
-      assert.deepEqual(
-        flattenTree(treePlanWithSingleChildPaths),
-        expectedFlatPlanWithSingleChildPaths,
-      );
-    });
-    it("increases level if multiple children.", () => {
-      assert.deepEqual(
-        flattenTree(treePlanWithChildren1),
-        expectedFlatPlanWithChildren1,
-      );
-      assert.deepEqual(
-        flattenTree(treePlanWithChildren2),
-        expectedFlatPlanWithChildren2,
-      );
+      assert.deepEqual(flattenTreeAttributes(node), nodeFlattened);
     });
   });
-  describe("when node has no children", () => {
-    it("returns valid flattened plan.", () => {
-      assert.deepEqual(
-        flattenTree(treePlanWithNoChildren),
-        expectedFlatPlanWithNoChildren,
-      );
+  describe("when there are nodes with multiple attributes with the same key", () => {
+    it("flattens attributes for each node having multiple attributes with the same key", () => {
+      const node: IExplainTreePlanNode = {
+        name: "root",
+        attrs: testAttrsDuplicatedKeys,
+        children: [
+          {
+            name: "child",
+            attrs: testAttrsDuplicatedKeys,
+            children: [
+              {
+                name: "grandchild",
+                attrs: testAttrsDuplicatedKeys,
+                children: [],
+              },
+            ],
+          },
+        ],
+      };
+
+      const nodeFlattened: FlatPlanNode = {
+        name: "root",
+        attrs: expectedTestAttrsFlattened,
+        children: [
+          {
+            name: "child",
+            attrs: expectedTestAttrsFlattened,
+            children: [
+              {
+                name: "grandchild",
+                attrs: expectedTestAttrsFlattened,
+                children: [],
+              },
+            ],
+          },
+        ],
+      };
+
+      assert.deepEqual(flattenTreeAttributes(node), nodeFlattened);
     });
   });
 });
@@ -285,62 +161,18 @@ describe("flattenTree", () => {
 describe("flattenAttributes", () => {
   describe("when all attributes have different keys", () => {
     it("creates array with exactly one value for each attribute", () => {
-      const testAttrs: IAttr[] = [
-        {
-          key: "key1",
-          value: "value1",
-        },
-        {
-          key: "key2",
-          value: "value2",
-        },
-      ];
-      const expectedTestAttrs: FlatPlanNodeAttribute[] = [
-        {
-          key: "key1",
-          values: ["value1"],
-          warn: false,
-        },
-        {
-          key: "key2",
-          values: ["value2"],
-          warn: false,
-        },
-      ];
-
-      assert.deepEqual(flattenAttributes(testAttrs), expectedTestAttrs);
+      assert.deepEqual(
+        flattenAttributes(testAttrsDistinctKeys),
+        expectedTestAttrsDistinctKeys,
+      );
     });
   });
   describe("when there are multiple attributes with same key", () => {
     it("collects values into one array for same key", () => {
-      const testAttrs: IAttr[] = [
-        {
-          key: "key1",
-          value: "key1-value1",
-        },
-        {
-          key: "key2",
-          value: "key2-value1",
-        },
-        {
-          key: "key1",
-          value: "key1-value2",
-        },
-      ];
-      const expectedTestAttrs: FlatPlanNodeAttribute[] = [
-        {
-          key: "key1",
-          values: ["key1-value1", "key1-value2"],
-          warn: false,
-        },
-        {
-          key: "key2",
-          values: ["key2-value1"],
-          warn: false,
-        },
-      ];
-
-      assert.deepEqual(flattenAttributes(testAttrs), expectedTestAttrs);
+      assert.deepEqual(
+        flattenAttributes(testAttrsDuplicatedKeys),
+        expectedTestAttrsFlattened,
+      );
     });
   });
   describe("when attribute key/value is `spans FULL SCAN`", () => {

--- a/pkg/ui/cluster-ui/src/statementDetails/planView/planView.stories.tsx
+++ b/pkg/ui/cluster-ui/src/statementDetails/planView/planView.stories.tsx
@@ -11,8 +11,12 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
 import { PlanView } from "./planView";
-import { logicalPlan } from "./planView.fixtures";
+import { logicalPlan, globalProperties } from "./planView.fixtures";
 
 storiesOf("PlanView", module).add("default", () => (
-  <PlanView title="Logical Plan" plan={logicalPlan} />
+  <PlanView
+    title="Explain Plan"
+    globalProperties={globalProperties}
+    plan={logicalPlan}
+  />
 ));

--- a/pkg/ui/cluster-ui/src/statementDetails/statementDetails.stories.tsx
+++ b/pkg/ui/cluster-ui/src/statementDetails/statementDetails.stories.tsx
@@ -68,10 +68,10 @@ storiesOf("StatementDetails", module)
     props.uiConfig.showStatementDiagnosticsLink = false;
     return <StatementDetails {...props} />;
   })
-  .add("Logical Plan tab", () => {
+  .add("Explain Plan tab", () => {
     const props = getStatementDetailsPropsFixture();
     props.history.location.search = new URLSearchParams([
-      ["tab", "logical-plan"],
+      ["tab", "explain-plan"],
     ]).toString();
     return <StatementDetails {...props} />;
   })

--- a/pkg/ui/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -467,8 +467,9 @@ export class StatementDetails extends React.Component<
     const regions = unique(
       stats.nodes.map(node => nodeRegions[node.toString()]),
     ).sort();
-    const logicalPlan =
+    const explainPlan =
       stats.sensitive_info && stats.sensitive_info.most_recent_plan_description;
+    const explainGlobalProps = { distribution: distSQL, vectorized: vec };
     const duration = (v: number) => Duration(v * 1e9);
     const hasDiagnosticReports = diagnosticsReports.length > 0;
     const lastExec = moment(stats.last_exec_timestamp.seconds.low * 1e3).format(
@@ -692,9 +693,13 @@ export class StatementDetails extends React.Component<
             onSortingChange={this.props.onSortingChange}
           />
         </TabPane>
-        <TabPane tab="Logical Plan" key="logical-plan">
+        <TabPane tab="Explain Plan" key="explain-plan">
           <SummaryCard>
-            <PlanView title="Logical Plan" plan={logicalPlan} />
+            <PlanView
+              title="Explain Plan"
+              plan={explainPlan}
+              globalProperties={explainGlobalProps}
+            />
           </SummaryCard>
         </TabPane>
         <TabPane

--- a/pkg/ui/src/components/core/colors.styl
+++ b/pkg/ui/src/components/core/colors.styl
@@ -39,6 +39,7 @@ $colors--primary-blue-2 = #74bdfd
 $colors--primary-blue-3 = #0055FF
 $colors--primary-blue-4 = #005fb3
 $colors--primary-blue-5 = #00294d
+$colors--primary-blue-6 = #89b0ff
 
 $colors--primary-green-0 = #daf8d4
 $colors--primary-green-1 = #b4f1aa


### PR DESCRIPTION
Resolves: #67328

Release note (ui change): The 'Logical Plan' tab in db console
has been renamed 'Explain Plan' and the plan format displayed
has been updated to match the output of the EXPLAIN command in
the SQL shell. Global EXPLAIN properties have been added to
the logical plan in db-console which were previously missing.

The EXPLAIN format shown below should now be be reflected in db console:

```
  distribution: full
  vectorized: true

  • hash join
  │ estimated row count: 503
  │ equality: (rider_id) = (id)
  │
  ├── • scan
  │     estimated row count: 513 (100% of the table; stats collected 9 seconds ago)
  │     table: rides@primary
  │     spans: FULL SCAN
  │
  └── • scan
        estimated row count: 50 (100% of the table; stats collected 1 minute ago)
        table: users@primary
        spans: FULL SCAN
```

---------------
previous db-console view:
![image](https://user-images.githubusercontent.com/20136951/128762673-eff3f353-0b5c-4dcf-99f4-13466b45b07c.png)

updated db-console Explain Tab of above:
![image](https://user-images.githubusercontent.com/20136951/128725278-00124028-c83e-40ad-9f91-f4aaed9057e4.png)
