### PR TITLE
acceptance: explicitly specify binary path

### DIFF
--- a/build/teamcity-acceptance.sh
+++ b/build/teamcity-acceptance.sh
@@ -22,7 +22,6 @@ tc_start_block "Compile CockroachDB"
 # Buffer noisy output and only print it on failure.
 run pkg/acceptance/prepare.sh &> artifacts/acceptance-compile.log || (cat artifacts/acceptance-compile.log && false)
 rm artifacts/acceptance-compile.log
-run ln -s cockroach-linux-2.6.32-gnu-amd64 cockroach  # For the tests that run without Docker.
 tc_end_block "Compile CockroachDB"
 
 # We need to compile the test binary because we can't invoke it in builder.sh (recursive use of Docker, though
@@ -44,5 +43,5 @@ tc_start_block "Run acceptance tests"
 run_json_test env TZ=America/New_York stdbuf -eL -oL go test \
   -mod=vendor -json -timeout 30m -v \
 	-exec "../../build/teamcity-go-test-precompiled.sh ./pkg/acceptance/acceptance.test" ./pkg/acceptance \
-	-l "$TMPDIR"
+	-l "$TMPDIR" -b "$PWD/cockroach-linux-2.6.32-gnu-amd64"
 tc_end_block "Run acceptance tests"

--- a/pkg/acceptance/cluster/dockercluster.go
+++ b/pkg/acceptance/cluster/dockercluster.go
@@ -17,7 +17,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"go/build"
 	"io"
 	"io/ioutil"
 	"net"
@@ -70,15 +69,7 @@ var waitOnStop = flag.Bool("w", false, "wait for the user to interrupt before te
 var maxRangeBytes = *zonepb.DefaultZoneConfig().RangeMaxBytes
 
 // CockroachBinary is the path to the host-side binary to use.
-var CockroachBinary = flag.String("b", func() string {
-	rootPkg, err := build.Import("github.com/cockroachdb/cockroach", "", build.FindOnly)
-	if err != nil {
-		panic(err)
-	}
-	// NB: This is the binary produced by our linux-gnu build target. Changes
-	// to the Makefile must be reflected here.
-	return filepath.Join(rootPkg.Dir, "cockroach-linux-2.6.32-gnu-amd64")
-}(), "the host-side binary to run")
+var CockroachBinary = flag.String("b", "", "the host-side binary to run")
 
 func exists(path string) bool {
 	if _, err := os.Stat(path); oserror.IsNotExist(err) {

--- a/pkg/acceptance/run.sh
+++ b/pkg/acceptance/run.sh
@@ -12,4 +12,4 @@ export TMPDIR=$PWD/artifacts/acceptance
 
 # For the acceptance tests that run without Docker.
 make build
-make test PKG=./pkg/acceptance TESTTIMEOUT="${TESTTIMEOUT-30m}" TAGS=acceptance TESTFLAGS="${TESTFLAGS--v} -l $TMPDIR"
+make test PKG=./pkg/acceptance TESTTIMEOUT="${TESTTIMEOUT-30m}" TAGS=acceptance TESTFLAGS="${TESTFLAGS--v} -b $PWD/cockroach-linux-2.6.32-gnu-amd64 -l $TMPDIR"


### PR DESCRIPTION
Touches #59446

Previously, in order to run the acceptance test we were implicitly
identifying the `cockroach` binary to the acceptance test. This is a bit
problematic under bazel, where the binary location may be in different
places.

This patch explicitly passes the location if the cockroach binary to the
acceptance test.

Release note: None