### PR TITLE
protectedts,kvserver: add UpdateTimestamp method to the storage interface

### DIFF
--- a/pkg/kv/kvserver/protectedts/protectedts.go
+++ b/pkg/kv/kvserver/protectedts/protectedts.go
@@ -95,6 +95,10 @@ type Storage interface {
 	// GetState retreives the entire state of protectedts.Storage with the
 	// provided Txn.
 	GetState(context.Context, *kv.Txn) (ptpb.State, error)
+
+	// UpdateTimestamp updates the timestamp protected by the record with the
+	// specified UUID.
+	UpdateTimestamp(ctx context.Context, txn *kv.Txn, id uuid.UUID, timestamp hlc.Timestamp) error
 }
 
 // Iterator iterates records in a cache until wantMore is false or all Records

--- a/pkg/kv/kvserver/protectedts/ptstorage/BUILD.bazel
+++ b/pkg/kv/kvserver/protectedts/ptstorage/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/sql/sqlutil",
+        "//pkg/util/hlc",
         "//pkg/util/log",
         "//pkg/util/protoutil",
         "//pkg/util/uuid",

--- a/pkg/kv/kvserver/protectedts/ptstorage/sql.go
+++ b/pkg/kv/kvserver/protectedts/ptstorage/sql.go
@@ -165,6 +165,44 @@ RETURNING
     1
 `
 
+	updateTimestampQuery = `
+WITH
+    current_meta AS (` + currentMetaCTE + `),
+    updated_meta AS (` + updateTimestampUpsertMetaCTE + `),
+    updated_record AS (` + updateTimestampUpsertRecordCTE + `)
+SELECT
+    id
+FROM
+    updated_record;`
+
+	updateTimestampUpsertMetaCTE = `
+UPSERT
+INTO
+    system.protected_ts_meta (version, num_records, num_spans, total_bytes)
+(
+    SELECT
+        version + 1,
+        num_records,
+        num_spans,
+        total_bytes
+    FROM
+        current_meta
+)
+RETURNING
+    NULL
+`
+
+	updateTimestampUpsertRecordCTE = `
+UPDATE
+    system.protected_ts_records
+SET
+    ts = $2
+WHERE
+    id = $1
+RETURNING
+    id
+`
+
 	getMetadataQuery = `
 WITH
     current_meta AS (` + currentMetaCTE + `)

--- a/pkg/kv/kvserver/protectedts/ptstorage/storage_with_database.go
+++ b/pkg/kv/kvserver/protectedts/ptstorage/storage_with_database.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts/ptpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
 
@@ -94,4 +95,16 @@ func (s *storageWithDatabase) GetState(
 		return state, err
 	}
 	return s.s.GetState(ctx, txn)
+}
+
+func (s *storageWithDatabase) UpdateTimestamp(
+	ctx context.Context, txn *kv.Txn, id uuid.UUID, timestamp hlc.Timestamp,
+) (err error) {
+	if txn == nil {
+		err = s.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+			return s.s.UpdateTimestamp(ctx, txn, id, timestamp)
+		})
+		return err
+	}
+	return s.s.UpdateTimestamp(ctx, txn, id, timestamp)
 }

--- a/pkg/kv/kvserver/replica_protected_timestamp.go
+++ b/pkg/kv/kvserver/replica_protected_timestamp.go
@@ -214,7 +214,12 @@ func (r *Replica) protectedTimestampRecordCurrentlyApplies(
 
 	var seen bool
 	read = r.readProtectedTimestampsRLocked(ctx, func(r *ptpb.Record) {
-		if r.ID == args.RecordID {
+		// Comparing record ID and the timestamp ensures that we find the record
+		// that we are verifying.
+		// A PTS record can be updated with a new Timestamp to protect, and so we
+		// need to ensure that we are not seeing the old version of the record in
+		// case the cache has not been updated.
+		if r.ID == args.RecordID && args.Protected.LessEq(r.Timestamp) {
 			seen = true
 		}
 	})


### PR DESCRIPTION
This change introduces a UpdateTimestamp method that can be used to
update timestamp protected by a protected time stamp record.

A next commit will add some logic to the verification code to ensure
that an update is picked up correctly during the Verify() call.

Release note: None

kvserver: modify pts verification to check Timestamp as well

Previously, when verifying a pts record we would find the record
we are attempting to verify from the cache on the basis of the
record ID. This was correct until we added a way to update a records
Timestamp in the previous commit.

If a record is updated with a new ts, and a verification request
is sent for this updated record, then we want to ensure that
request is not serviced on the basis of the old record. This
is possible if the cache is too stale.

To prevent this we now match both the record ID and the timestamp
to protect after, when finding the cache entry corresponding to
the request. In this way, if we do see the older record then the
verification will fail the first time around, the cache will refresh,
and we will see the new record the second time around.

Release note: None