### PR TITLE
sql: regression test for pg's INET format

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/inet
+++ b/pkg/sql/logictest/testdata/logic_test/inet
@@ -877,3 +877,14 @@ query T
 SELECT host(max('192.168.0.2/24'::INET)) FROM (VALUES (1)) AS t(x)
 ----
 192.168.0.2
+
+subtest regression_68578
+
+# These address formats are valid in pg, even though they are not valid in Go.
+# This test ensures that they remain recognized even when Go does not support them any more.
+query TTT
+SELECT '127.001.002.003'::INET, '127.001.002.003/016'::INET, '010.001.002.003'::INET
+----
+127.1.2.3 127.1.2.3/16 10.1.2.3
+
+subtest end


### PR DESCRIPTION
Informs #68578

PostgreSQL and CockroachDB recognize `10.0.0.017` as `10.0.0.17` when
interpreted using SQL type INET.

However, Go 1.17's IP address parser will soon change to prevent
this. We do not want a change in Go to surrepticiously change crdb's
behavior. So this commit adds a test to validate the behavior.

Release note: None