### PR TITLE
sql: support show default privileges for all roles

### DIFF
--- a/docs/generated/sql/bnf/show_default_privileges_stmt.bnf
+++ b/docs/generated/sql/bnf/show_default_privileges_stmt.bnf
@@ -1,2 +1,3 @@
 show_default_privileges_stmt ::=
 	'SHOW' 'DEFAULT' 'PRIVILEGES' opt_for_roles
+	| 'SHOW' 'DEFAULT' 'PRIVILEGES' 'FOR' 'ALL' 'ROLES'

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -755,6 +755,7 @@ show_zone_stmt ::=
 
 show_default_privileges_stmt ::=
 	'SHOW' 'DEFAULT' 'PRIVILEGES' opt_for_roles
+	| 'SHOW' 'DEFAULT' 'PRIVILEGES' 'FOR' 'ALL' 'ROLES'
 
 opt_table ::=
 	'TABLE'

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal_default_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal_default_privileges
@@ -4,14 +4,14 @@ ALTER DEFAULT PRIVILEGES GRANT USAGE ON TYPES TO PUBLIC;
 ALTER DEFAULT PRIVILEGES GRANT USAGE ON SCHEMAS TO PUBLIC;
 ALTER DEFAULT PRIVILEGES GRANT SELECT ON SEQUENCES TO PUBLIC;
 
-query TTTTTT colnames,rowsort
+query TTTBTTT colnames,rowsort
 SELECT * FROM crdb_internal.default_privileges
 ----
-database_name  schema_name  role  object_type  grantee  privilege_type
-test           NULL         root  sequences    public   SELECT
-test           NULL         root  types        public   USAGE
-test           NULL         root  schemas      public   USAGE
-test           NULL         root  tables       public   SELECT
+database_name  schema_name  role  for_all_roles  object_type  grantee  privilege_type
+test           NULL         root  false          types        public   USAGE
+test           NULL         root  false          schemas      public   USAGE
+test           NULL         root  false          tables       public   SELECT
+test           NULL         root  false          sequences    public   SELECT
 
 statement ok
 CREATE USER foo
@@ -25,18 +25,18 @@ ALTER DEFAULT PRIVILEGES GRANT ALL ON TYPES TO foo, bar;
 ALTER DEFAULT PRIVILEGES GRANT ALL ON SCHEMAS TO foo, bar;
 ALTER DEFAULT PRIVILEGES GRANT ALL ON SEQUENCES TO foo, bar;
 
-query TTTTTT colnames,rowsort
+query TTTBTTT colnames,rowsort
 SELECT * FROM crdb_internal.default_privileges WHERE grantee='foo' OR grantee='bar'
 ----
-database_name  schema_name  role  object_type  grantee  privilege_type
-test           NULL         root  sequences    bar      ALL
-test           NULL         root  sequences    foo      ALL
-test           NULL         root  types        bar      ALL
-test           NULL         root  types        foo      ALL
-test           NULL         root  schemas      bar      ALL
-test           NULL         root  schemas      foo      ALL
-test           NULL         root  tables       bar      ALL
-test           NULL         root  tables       foo      ALL
+database_name  schema_name  role  for_all_roles  object_type  grantee  privilege_type
+test           NULL         root  false          tables       bar      ALL
+test           NULL         root  false          tables       foo      ALL
+test           NULL         root  false          sequences    bar      ALL
+test           NULL         root  false          sequences    foo      ALL
+test           NULL         root  false          types        bar      ALL
+test           NULL         root  false          types        foo      ALL
+test           NULL         root  false          schemas      bar      ALL
+test           NULL         root  false          schemas      foo      ALL
 
 statement ok
 GRANT foo, bar TO root;
@@ -47,26 +47,26 @@ ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar GRANT ALL ON TYPES TO foo, bar;
 ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar GRANT ALL ON SCHEMAS TO foo, bar;
 ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar GRANT ALL ON SEQUENCES TO foo, bar;
 
-query TTTTTT colnames,rowsort
+query TTTBTTT colnames,rowsort
 SELECT * FROM crdb_internal.default_privileges WHERE role='foo' OR role='bar'
 ----
-database_name  schema_name  role  object_type  grantee  privilege_type
-test           NULL         bar   tables       bar      ALL
-test           NULL         bar   tables       foo      ALL
-test           NULL         bar   sequences    bar      ALL
-test           NULL         bar   sequences    foo      ALL
-test           NULL         bar   types        bar      ALL
-test           NULL         bar   types        foo      ALL
-test           NULL         bar   schemas      bar      ALL
-test           NULL         bar   schemas      foo      ALL
-test           NULL         foo   sequences    bar      ALL
-test           NULL         foo   sequences    foo      ALL
-test           NULL         foo   types        bar      ALL
-test           NULL         foo   types        foo      ALL
-test           NULL         foo   schemas      bar      ALL
-test           NULL         foo   schemas      foo      ALL
-test           NULL         foo   tables       bar      ALL
-test           NULL         foo   tables       foo      ALL
+database_name  schema_name  role  for_all_roles  object_type  grantee  privilege_type
+test           NULL         bar   false          types        bar      ALL
+test           NULL         bar   false          types        foo      ALL
+test           NULL         bar   false          schemas      bar      ALL
+test           NULL         bar   false          schemas      foo      ALL
+test           NULL         bar   false          tables       bar      ALL
+test           NULL         bar   false          tables       foo      ALL
+test           NULL         bar   false          sequences    bar      ALL
+test           NULL         bar   false          sequences    foo      ALL
+test           NULL         foo   false          sequences    bar      ALL
+test           NULL         foo   false          sequences    foo      ALL
+test           NULL         foo   false          types        bar      ALL
+test           NULL         foo   false          types        foo      ALL
+test           NULL         foo   false          schemas      bar      ALL
+test           NULL         foo   false          schemas      foo      ALL
+test           NULL         foo   false          tables       bar      ALL
+test           NULL         foo   false          tables       foo      ALL
 
 statement ok
 ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar REVOKE ALL ON TABLES FROM foo, bar;
@@ -74,22 +74,22 @@ ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar REVOKE ALL ON TYPES FROM foo, bar;
 ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar REVOKE ALL ON SCHEMAS FROM foo, bar;
 ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar REVOKE ALL ON SEQUENCES FROM foo, bar;
 
-query TTTTTT colnames,rowsort
+query TTTBTTT colnames,rowsort
 SELECT * FROM crdb_internal.default_privileges
 ----
-database_name  schema_name  role  object_type  grantee  privilege_type
-test           NULL         root  schemas      bar      ALL
-test           NULL         root  schemas      foo      ALL
-test           NULL         root  schemas      public   USAGE
-test           NULL         root  tables       bar      ALL
-test           NULL         root  tables       foo      ALL
-test           NULL         root  tables       public   SELECT
-test           NULL         root  sequences    bar      ALL
-test           NULL         root  sequences    foo      ALL
-test           NULL         root  sequences    public   SELECT
-test           NULL         root  types        bar      ALL
-test           NULL         root  types        foo      ALL
-test           NULL         root  types        public   USAGE
+database_name  schema_name  role  for_all_roles  object_type  grantee  privilege_type
+test           NULL         root  false          types        bar      ALL
+test           NULL         root  false          types        foo      ALL
+test           NULL         root  false          types        public   USAGE
+test           NULL         root  false          schemas      bar      ALL
+test           NULL         root  false          schemas      foo      ALL
+test           NULL         root  false          schemas      public   USAGE
+test           NULL         root  false          tables       bar      ALL
+test           NULL         root  false          tables       foo      ALL
+test           NULL         root  false          tables       public   SELECT
+test           NULL         root  false          sequences    bar      ALL
+test           NULL         root  false          sequences    foo      ALL
+test           NULL         root  false          sequences    public   SELECT
 
 statement ok
 ALTER DEFAULT PRIVILEGES REVOKE SELECT ON TABLES FROM foo, bar, public;
@@ -97,36 +97,36 @@ ALTER DEFAULT PRIVILEGES REVOKE ALL ON TYPES FROM foo, bar, public;
 ALTER DEFAULT PRIVILEGES REVOKE ALL ON SCHEMAS FROM foo, bar, public;
 ALTER DEFAULT PRIVILEGES REVOKE ALL ON SEQUENCES FROM foo, bar, public;
 
-query TTTTTT colnames,rowsort
+query TTTBTTT colnames,rowsort
 SELECT * FROM crdb_internal.default_privileges
 ----
-database_name  schema_name  role  object_type  grantee  privilege_type
-test           NULL         root  tables       bar      CREATE
-test           NULL         root  tables       bar      DROP
-test           NULL         root  tables       bar      GRANT
-test           NULL         root  tables       bar      INSERT
-test           NULL         root  tables       bar      DELETE
-test           NULL         root  tables       bar      UPDATE
-test           NULL         root  tables       bar      ZONECONFIG
-test           NULL         root  tables       foo      CREATE
-test           NULL         root  tables       foo      DROP
-test           NULL         root  tables       foo      GRANT
-test           NULL         root  tables       foo      INSERT
-test           NULL         root  tables       foo      DELETE
-test           NULL         root  tables       foo      UPDATE
-test           NULL         root  tables       foo      ZONECONFIG
+database_name  schema_name  role  for_all_roles  object_type  grantee  privilege_type
+test           NULL         root  false          tables       bar      CREATE
+test           NULL         root  false          tables       bar      DROP
+test           NULL         root  false          tables       bar      GRANT
+test           NULL         root  false          tables       bar      INSERT
+test           NULL         root  false          tables       bar      DELETE
+test           NULL         root  false          tables       bar      UPDATE
+test           NULL         root  false          tables       bar      ZONECONFIG
+test           NULL         root  false          tables       foo      CREATE
+test           NULL         root  false          tables       foo      DROP
+test           NULL         root  false          tables       foo      GRANT
+test           NULL         root  false          tables       foo      INSERT
+test           NULL         root  false          tables       foo      DELETE
+test           NULL         root  false          tables       foo      UPDATE
+test           NULL         root  false          tables       foo      ZONECONFIG
 
 statement ok
 ALTER DEFAULT PRIVILEGES REVOKE ALL ON TABLES FROM foo, bar, public;
 ALTER DEFAULT PRIVILEGES GRANT GRANT, DROP, ZONECONFIG ON TABLES TO foo;
 
-query TTTTTT colnames,rowsort
+query TTTBTTT colnames,rowsort
 SELECT * FROM crdb_internal.default_privileges
 ----
-database_name  schema_name  role  object_type  grantee  privilege_type
-test           NULL         root  tables       foo      DROP
-test           NULL         root  tables       foo      GRANT
-test           NULL         root  tables       foo      ZONECONFIG
+database_name  schema_name  role  for_all_roles  object_type  grantee  privilege_type
+test           NULL         root  false          tables       foo      DROP
+test           NULL         root  false          tables       foo      GRANT
+test           NULL         root  false          tables       foo      ZONECONFIG
 
 # Create a second database.
 statement ok
@@ -136,13 +136,28 @@ use test2;
 statement ok
 ALTER DEFAULT PRIVILEGES GRANT GRANT, DROP, ZONECONFIG ON TABLES TO foo;
 
-query TTTTTT colnames,rowsort
+query TTTBTTT colnames,rowsort
 SELECT * FROM crdb_internal.default_privileges
 ----
-database_name  schema_name  role  object_type  grantee  privilege_type
-test           NULL         root  tables       foo      DROP
-test           NULL         root  tables       foo      GRANT
-test           NULL         root  tables       foo      ZONECONFIG
-test2          NULL         root  tables       foo      DROP
-test2          NULL         root  tables       foo      GRANT
-test2          NULL         root  tables       foo      ZONECONFIG
+database_name  schema_name  role  for_all_roles  object_type  grantee  privilege_type
+test           NULL         root  false          tables       foo      DROP
+test           NULL         root  false          tables       foo      GRANT
+test           NULL         root  false          tables       foo      ZONECONFIG
+test2          NULL         root  false          tables       foo      DROP
+test2          NULL         root  false          tables       foo      GRANT
+test2          NULL         root  false          tables       foo      ZONECONFIG
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ALL ROLES GRANT SELECT ON TABLES TO foo;
+
+query TTTBTTT colnames,rowsort
+SELECT * FROM crdb_internal.default_privileges
+----
+database_name  schema_name  role  for_all_roles  object_type  grantee  privilege_type
+test           NULL         root  false          tables       foo      DROP
+test           NULL         root  false          tables       foo      GRANT
+test           NULL         root  false          tables       foo      ZONECONFIG
+test2          NULL         root  false          tables       foo      DROP
+test2          NULL         root  false          tables       foo      GRANT
+test2          NULL         root  false          tables       foo      ZONECONFIG
+test2          NULL         NULL  true           tables       foo      SELECT

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -296,14 +296,16 @@ CREATE TABLE crdb_internal.databases (
 CREATE TABLE crdb_internal.default_privileges (
    database_name STRING NOT NULL,
    schema_name STRING NULL,
-   "role" STRING NOT NULL,
+   "role" STRING NULL,
+   for_all_roles BOOL NULL,
    object_type STRING NOT NULL,
    grantee STRING NOT NULL,
    privilege_type STRING NOT NULL
 )  CREATE TABLE crdb_internal.default_privileges (
    database_name STRING NOT NULL,
    schema_name STRING NULL,
-   "role" STRING NOT NULL,
+   "role" STRING NULL,
+   for_all_roles BOOL NULL,
    object_type STRING NOT NULL,
    grantee STRING NOT NULL,
    privilege_type STRING NOT NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_default_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/show_default_privileges
@@ -4,13 +4,13 @@ ALTER DEFAULT PRIVILEGES GRANT USAGE ON TYPES TO PUBLIC;
 ALTER DEFAULT PRIVILEGES GRANT USAGE ON SCHEMAS TO PUBLIC;
 ALTER DEFAULT PRIVILEGES GRANT SELECT ON SEQUENCES TO PUBLIC;
 
-query TTTT
+query TBTTT
 SHOW DEFAULT PRIVILEGES
 ----
-root  schemas    public  USAGE
-root  sequences  public  SELECT
-root  tables     public  SELECT
-root  types      public  USAGE
+root  false  schemas    public  USAGE
+root  false  sequences  public  SELECT
+root  false  tables     public  SELECT
+root  false  types      public  USAGE
 
 statement ok
 CREATE USER foo
@@ -24,21 +24,21 @@ ALTER DEFAULT PRIVILEGES GRANT ALL ON TYPES TO foo, bar;
 ALTER DEFAULT PRIVILEGES GRANT ALL ON SCHEMAS TO foo, bar;
 ALTER DEFAULT PRIVILEGES GRANT ALL ON SEQUENCES TO foo, bar;
 
-query TTTT
-SHOW DEFAULT PRIVILEGES
+query TBTTT
+SHOW DEFAULT PRIVILEGES FOR ROLE foo, bar, root
 ----
-root  schemas    bar     ALL
-root  schemas    foo     ALL
-root  schemas    public  USAGE
-root  sequences  bar     ALL
-root  sequences  foo     ALL
-root  sequences  public  SELECT
-root  tables     bar     ALL
-root  tables     foo     ALL
-root  tables     public  SELECT
-root  types      bar     ALL
-root  types      foo     ALL
-root  types      public  USAGE
+root  false  schemas    bar     ALL
+root  false  schemas    foo     ALL
+root  false  schemas    public  USAGE
+root  false  sequences  bar     ALL
+root  false  sequences  foo     ALL
+root  false  sequences  public  SELECT
+root  false  tables     bar     ALL
+root  false  tables     foo     ALL
+root  false  tables     public  SELECT
+root  false  types      bar     ALL
+root  false  types      foo     ALL
+root  false  types      public  USAGE
 
 statement ok
 GRANT foo, bar TO root;
@@ -49,21 +49,21 @@ ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar GRANT ALL ON TYPES TO foo, bar;
 ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar GRANT ALL ON SCHEMAS TO foo, bar;
 ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar GRANT ALL ON SEQUENCES TO foo, bar;
 
-query TTTT
+query TBTTT
 SHOW DEFAULT PRIVILEGES
 ----
-root  schemas    bar     ALL
-root  schemas    foo     ALL
-root  schemas    public  USAGE
-root  sequences  bar     ALL
-root  sequences  foo     ALL
-root  sequences  public  SELECT
-root  tables     bar     ALL
-root  tables     foo     ALL
-root  tables     public  SELECT
-root  types      bar     ALL
-root  types      foo     ALL
-root  types      public  USAGE
+root  false  schemas    bar     ALL
+root  false  schemas    foo     ALL
+root  false  schemas    public  USAGE
+root  false  sequences  bar     ALL
+root  false  sequences  foo     ALL
+root  false  sequences  public  SELECT
+root  false  tables     bar     ALL
+root  false  tables     foo     ALL
+root  false  tables     public  SELECT
+root  false  types      bar     ALL
+root  false  types      foo     ALL
+root  false  types      public  USAGE
 
 statement ok
 ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar REVOKE ALL ON TABLES FROM foo, bar;
@@ -71,21 +71,21 @@ ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar REVOKE ALL ON TYPES FROM foo, bar;
 ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar REVOKE ALL ON SCHEMAS FROM foo, bar;
 ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar REVOKE ALL ON SEQUENCES FROM foo, bar;
 
-query TTTT
+query TBTTT
 SHOW DEFAULT PRIVILEGES
 ----
-root  schemas    bar     ALL
-root  schemas    foo     ALL
-root  schemas    public  USAGE
-root  sequences  bar     ALL
-root  sequences  foo     ALL
-root  sequences  public  SELECT
-root  tables     bar     ALL
-root  tables     foo     ALL
-root  tables     public  SELECT
-root  types      bar     ALL
-root  types      foo     ALL
-root  types      public  USAGE
+root  false  schemas    bar     ALL
+root  false  schemas    foo     ALL
+root  false  schemas    public  USAGE
+root  false  sequences  bar     ALL
+root  false  sequences  foo     ALL
+root  false  sequences  public  SELECT
+root  false  tables     bar     ALL
+root  false  tables     foo     ALL
+root  false  tables     public  SELECT
+root  false  types      bar     ALL
+root  false  types      foo     ALL
+root  false  types      public  USAGE
 
 statement ok
 ALTER DEFAULT PRIVILEGES REVOKE SELECT ON TABLES FROM foo, bar, public;
@@ -93,34 +93,34 @@ ALTER DEFAULT PRIVILEGES REVOKE ALL ON TYPES FROM foo, bar, public;
 ALTER DEFAULT PRIVILEGES REVOKE ALL ON SCHEMAS FROM foo, bar, public;
 ALTER DEFAULT PRIVILEGES REVOKE ALL ON SEQUENCES FROM foo, bar, public;
 
-query TTTT
+query TBTTT
 SHOW DEFAULT PRIVILEGES
 ----
-root  tables  bar  CREATE
-root  tables  bar  DELETE
-root  tables  bar  DROP
-root  tables  bar  GRANT
-root  tables  bar  INSERT
-root  tables  bar  UPDATE
-root  tables  bar  ZONECONFIG
-root  tables  foo  CREATE
-root  tables  foo  DELETE
-root  tables  foo  DROP
-root  tables  foo  GRANT
-root  tables  foo  INSERT
-root  tables  foo  UPDATE
-root  tables  foo  ZONECONFIG
+root  false  tables  bar  CREATE
+root  false  tables  bar  DROP
+root  false  tables  bar  GRANT
+root  false  tables  bar  INSERT
+root  false  tables  bar  DELETE
+root  false  tables  bar  UPDATE
+root  false  tables  bar  ZONECONFIG
+root  false  tables  foo  CREATE
+root  false  tables  foo  DROP
+root  false  tables  foo  GRANT
+root  false  tables  foo  INSERT
+root  false  tables  foo  DELETE
+root  false  tables  foo  UPDATE
+root  false  tables  foo  ZONECONFIG
 
 statement ok
 ALTER DEFAULT PRIVILEGES REVOKE ALL ON TABLES FROM foo, bar, public;
 ALTER DEFAULT PRIVILEGES GRANT GRANT, DROP, ZONECONFIG ON TABLES TO foo;
 
-query TTTT
+query TBTTT
 SHOW DEFAULT PRIVILEGES
 ----
-root  tables  foo  DROP
-root  tables  foo  GRANT
-root  tables  foo  ZONECONFIG
+root  false  tables  foo  DROP
+root  false  tables  foo  GRANT
+root  false  tables  foo  ZONECONFIG
 
 # Create a second database.
 statement ok
@@ -132,26 +132,47 @@ statement ok
 GRANT testuser TO root;
 ALTER DEFAULT PRIVILEGES FOR ROLE testuser GRANT GRANT, DROP, ZONECONFIG ON TABLES TO foo;
 
-query TTTT
+query TBTTT
+SHOW DEFAULT PRIVILEGES FOR ROLE testuser
+----
+testuser  false  tables  foo  DROP
+testuser  false  tables  foo  GRANT
+testuser  false  tables  foo  ZONECONFIG
+
+# SHOW DEFAULT PRIVILEGES should show default privileges for the current role.
+user testuser
+query TBTTT
 SHOW DEFAULT PRIVILEGES
 ----
 
-query TTTT
+user root
+
+query TBTTT
 SHOW DEFAULT PRIVILEGES FOR ROLE testuser
 ----
-testuser  tables  foo  DROP
-testuser  tables  foo  GRANT
-testuser  tables  foo  ZONECONFIG
+testuser  false  tables  foo  DROP
+testuser  false  tables  foo  GRANT
+testuser  false  tables  foo  ZONECONFIG
 
 statement ok
 ALTER DEFAULT PRIVILEGES FOR ROLE root GRANT GRANT, DROP, ZONECONFIG ON TABLES TO foo;
 
-query TTTT
+query TBTTT
 SHOW DEFAULT PRIVILEGES FOR ROLE root, testuser
 ----
-root      tables  foo  DROP
-root      tables  foo  GRANT
-root      tables  foo  ZONECONFIG
-testuser  tables  foo  DROP
-testuser  tables  foo  GRANT
-testuser  tables  foo  ZONECONFIG
+root      false  tables  foo  DROP
+root      false  tables  foo  GRANT
+root      false  tables  foo  ZONECONFIG
+testuser  false  tables  foo  DROP
+testuser  false  tables  foo  GRANT
+testuser  false  tables  foo  ZONECONFIG
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ALL ROLES GRANT GRANT, DROP, ZONECONFIG ON TABLES TO foo;
+
+query TBTTT
+SHOW DEFAULT PRIVILEGES FOR ALL ROLES
+----
+NULL  true  tables  foo  DROP
+NULL  true  tables  foo  GRANT
+NULL  true  tables  foo  ZONECONFIG

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -5061,7 +5061,12 @@ show_default_privileges_stmt:
     $$.val = &tree.ShowDefaultPrivileges{
       Roles: $4.nameList(),
     }
-}
+  }
+| SHOW DEFAULT PRIVILEGES FOR ALL ROLES {
+    $$.val = &tree.ShowDefaultPrivileges{
+      ForAllRoles: true,
+    }
+  }
 | SHOW DEFAULT PRIVILEGES error // SHOW HELP: SHOW DEFAULT PRIVILEGES
 
 // %Help: SHOW ENUMS - list enums

--- a/pkg/sql/parser/testdata/show_default_privileges
+++ b/pkg/sql/parser/testdata/show_default_privileges
@@ -37,3 +37,11 @@ SHOW DEFAULT PRIVILEGES FOR ROLE "fOo", "baR"  -- normalized!
 SHOW DEFAULT PRIVILEGES FOR ROLE "fOo", "baR"  -- fully parenthesized
 SHOW DEFAULT PRIVILEGES FOR ROLE "fOo", "baR"  -- literals removed
 SHOW DEFAULT PRIVILEGES FOR ROLE _, _  -- identifiers removed
+
+parse
+SHOW DEFAULT PRIVILEGES FOR ALL ROLES
+----
+SHOW DEFAULT PRIVILEGES FOR ALL ROLES  -- normalized!
+SHOW DEFAULT PRIVILEGES FOR ALL ROLES  -- fully parenthesized
+SHOW DEFAULT PRIVILEGES FOR ALL ROLES  -- literals removed
+SHOW DEFAULT PRIVILEGES FOR ALL ROLES  -- identifiers removed

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -835,7 +835,8 @@ func (n *ShowSchedules) Format(ctx *FmtCtx) {
 
 // ShowDefaultPrivileges represents a SHOW DEFAULT PRIVILEGES statement.
 type ShowDefaultPrivileges struct {
-	Roles NameList
+	Roles       NameList
+	ForAllRoles bool
 }
 
 var _ Statement = &ShowDefaultPrivileges{}
@@ -852,5 +853,7 @@ func (n *ShowDefaultPrivileges) Format(ctx *FmtCtx) {
 			ctx.FormatNode(&role)
 		}
 		ctx.WriteString(" ")
+	} else if n.ForAllRoles {
+		ctx.WriteString("FOR ALL ROLES ")
 	}
 }


### PR DESCRIPTION
Release note (sql change): SHOW DEFAULT PRIVILEGES FOR ALL ROLES
is now supported as a syntax.

Show default privileges returns a second column for_all_roles bool
which indicates whether or not the default privileges shown are
for all roles.

Sample output:
(columns are role, for_all_roles, relation type, grantee, privilege)

```
SHOW DEFAULT PRIVILEGES FOR ALL ROLES
----
NULL  true  tables  foo  DROP
NULL  true  tables  foo  GRANT
NULL  true  tables  foo  ZONECONFIG
```