### PR TITLE
sql: fix cast from unknown to unknown

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/tuple
+++ b/pkg/sql/logictest/testdata/logic_test/tuple
@@ -968,3 +968,14 @@ SELECT (ARRAY[t58439.*][2]).* FROM t58439
 NULL  NULL
 NULL  NULL
 NULL  NULL
+
+# Regression test for #68308. Do not internally error with a cast of unknown to
+# unknown in a tuple.
+subtest regression_68308
+
+query T
+SELECT (1::INT2, NULL)
+UNION
+SELECT (1::INT, NULL)
+----
+(1,)

--- a/pkg/sql/sem/tree/casts.go
+++ b/pkg/sql/sem/tree/casts.go
@@ -335,6 +335,9 @@ var validCasts = []castInfo{
 	{from: types.IntFamily, to: types.OidFamily, volatility: VolatilityStable, ignoreVolatilityCheck: true},
 	{from: types.OidFamily, to: types.OidFamily, volatility: VolatilityStable},
 
+	// Casts to UnknownFamily.
+	{from: types.UnknownFamily, to: types.UnknownFamily, volatility: VolatilityImmutable},
+
 	// Casts to UuidFamily.
 	{from: types.UnknownFamily, to: types.UuidFamily, volatility: VolatilityImmutable},
 	{from: types.StringFamily, to: types.UuidFamily, volatility: VolatilityImmutable},


### PR DESCRIPTION
Previously, an implicit cast performed in a set operation, like `UNION`,
on a tuple type with an unknown inner type would cause an internal
error. The cast failed because the volatility of a cast from unknown to
unknown was not specified in the `validCasts` list. This commit fixes
the issue by marking a such a cast as immutable.

Fixes #68308

Release note (bug fix): A bug has been fixed that caused internal errors
with set operations, like `UNION`, and columns with tuple types that
contained constant `NULL` values. This bug was introduced in version
20.2.