### PR TITLE
sql: do not ignore unique partial predicate in ALTER TABLE

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -279,6 +279,16 @@ func (n *alterTableNode) startExec(params runParams) error {
 					return err
 				}
 
+				if d.Predicate != nil {
+					expr, err := schemaexpr.ValidatePartialIndexPredicate(
+						params.ctx, n.tableDesc, d.Predicate, tableName, params.p.SemaCtx(),
+					)
+					if err != nil {
+						return err
+					}
+					idx.Predicate = expr
+				}
+
 				idx, err = params.p.configureIndexDescForNewIndexPartitioning(
 					params.ctx,
 					n.tableDesc,

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -1839,3 +1839,24 @@ INSERT INTO t VALUES (1, 0)
 
 statement ok
 DROP TABLE t;
+
+# Ensure unique constraint partial predicates are not ignored.
+subtest regression_67234
+
+statement ok
+CREATE TABLE t67234 (k INT PRIMARY KEY, a INT, b INT, FAMILY (k, a, b));
+ALTER TABLE t67234 ADD CONSTRAINT t67234_c1 UNIQUE (a) WHERE b > 0;
+ALTER TABLE t67234 ADD CONSTRAINT t67234_c2 UNIQUE WITHOUT INDEX (b) WHERE a > 0
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE t67234]
+----
+CREATE TABLE public.t67234 (
+   k INT8 NOT NULL,
+   a INT8 NULL,
+   b INT8 NULL,
+   CONSTRAINT "primary" PRIMARY KEY (k ASC),
+   UNIQUE INDEX t67234_c1 (a ASC) WHERE b > 0:::INT8,
+   FAMILY fam_0_k_a_b (k, a, b),
+   CONSTRAINT t67234_c2 UNIQUE WITHOUT INDEX (b) WHERE a > 0:::INT8
+)


### PR DESCRIPTION
Previously, a `WHERE` clause in `ALTER TABLE .. ADD CONSTRAINT .. UNIQUE`
statements was parsed successfully but ignored so that the resulting
unique constraint was not partial. This commit fixes this bug.

Fixes #67234

Release note (bug fix): A bug has been fixed that created non-partial
unique constraints when a user attempted to create a partial unique
constraint in `ALTER TABLE` statements.