### PR TITLE
changefeedccl: webhook_sink_config option to configure batching and retries

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -2831,7 +2831,7 @@ func TestChangefeedErrors(t *testing.T) {
 		`kafka://nope`, `https://schemareg-nope/?ca_cert=Zm9v`,
 	)
 
-	// Sanity check http sink options.
+	// Sanity check webhook sink options.
 	sqlDB.ExpectErr(
 		t, `unsupported sink: https. HTTP endpoints can be used with webhook-https and experimental-https`,
 		`CREATE CHANGEFEED FOR foo INTO $1`, `https://fake-host`,
@@ -2881,6 +2881,31 @@ func TestChangefeedErrors(t *testing.T) {
 	sqlDB.ExpectErr(
 		t, `this sink is incompatible with envelope=row`,
 		`CREATE CHANGEFEED FOR foo INTO $1 WITH envelope='row'`,
+		`webhook-https://fake-host`,
+	)
+	sqlDB.ExpectErr(
+		t, `invalid option value webhook_sink_config, all config values must be non-negative`,
+		`CREATE CHANGEFEED FOR foo INTO $1 WITH webhook_sink_config='{"Flush": {"Messages": -100, "Frequency": "1s"}}'`,
+		`webhook-https://fake-host`,
+	)
+	sqlDB.ExpectErr(
+		t, `invalid option value webhook_sink_config, all config values must be non-negative`,
+		`CREATE CHANGEFEED FOR foo INTO $1 WITH webhook_sink_config='{"Flush": {"Messages": 100, "Frequency": "-1s"}}'`,
+		`webhook-https://fake-host`,
+	)
+	sqlDB.ExpectErr(
+		t, `invalid option value webhook_sink_config, flush frequency is not set, messages may never be sent`,
+		`CREATE CHANGEFEED FOR foo INTO $1 WITH webhook_sink_config='{"Flush": {"Messages": 100}}'`,
+		`webhook-https://fake-host`,
+	)
+	sqlDB.ExpectErr(
+		t, `error unmarshalling json: time: invalid duration "Zm9v"`,
+		`CREATE CHANGEFEED FOR foo INTO $1 WITH webhook_sink_config='{"Flush": {"Frequency": "Zm9v"}}'`,
+		`webhook-https://fake-host`,
+	)
+	sqlDB.ExpectErr(
+		t, `error unmarshalling json: invalid character`,
+		`CREATE CHANGEFEED FOR foo INTO $1 WITH webhook_sink_config='not json'`,
 		`webhook-https://fake-host`,
 	)
 

--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -99,7 +99,8 @@ const (
 	DeprecatedOptFormatAvro = `experimental_avro`
 
 	// OptKafkaSinkConfig is a JSON configuration for kafka sink (kafkaSinkConfig).
-	OptKafkaSinkConfig = `kafka_sink_config`
+	OptKafkaSinkConfig   = `kafka_sink_config`
+	OptWebhookSinkConfig = `webhook_sink_config`
 
 	SinkParamCACert                 = `ca_cert`
 	SinkParamClientCert             = `client_cert`
@@ -154,6 +155,7 @@ var ChangefeedOptionExpectValues = map[string]sql.KVStringOptValidate{
 	OptNoInitialScan:            sql.KVStringOptRequireNoValue,
 	OptProtectDataFromGCOnPause: sql.KVStringOptRequireNoValue,
 	OptKafkaSinkConfig:          sql.KVStringOptRequireValue,
+	OptWebhookSinkConfig:        sql.KVStringOptRequireValue,
 	OptWebhookAuthHeader:        sql.KVStringOptRequireValue,
 	OptWebhookClientTimeout:     sql.KVStringOptRequireValue,
 	OptOnError:                  sql.KVStringOptRequireValue,

--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -89,7 +90,7 @@ func getSink(
 		case u.Scheme == changefeedbase.SinkSchemeKafka:
 			return makeKafkaSink(ctx, sinkURL{URL: u}, feedCfg.Targets, feedCfg.Opts)
 		case isWebhookSink(u):
-			return makeWebhookSink(ctx, sinkURL{URL: u}, feedCfg.Opts, defaultWorkerCount(), defaultRetryConfig())
+			return makeWebhookSink(ctx, sinkURL{URL: u}, feedCfg.Opts, defaultWorkerCount(), timeutil.DefaultTimeSource{})
 		case isCloudStorageSink(u):
 			return makeCloudStorageSink(
 				ctx, sinkURL{URL: u}, serverCfg.NodeID.SQLInstanceID(), serverCfg.Settings,

--- a/pkg/ccl/changefeedccl/testfeed_test.go
+++ b/pkg/ccl/changefeedccl/testfeed_test.go
@@ -1352,14 +1352,19 @@ func extractTopicFromJSONValue(wrapped []byte) (topic string, value []byte, _ er
 	return topic, value, nil
 }
 
+type webhookSinkTestfeedPayload struct {
+	Payload []interface{} `json:"payload"`
+	Length  int           `json:"length"`
+}
+
 // extractValueFromJSONMessage extracts the value of the first element of
 // the payload array from an webhook sink JSON message.
 func extractValueFromJSONMessage(message []byte) ([]byte, error) {
-	parsed := make(map[string][]interface{})
+	var parsed webhookSinkTestfeedPayload
 	if err := gojson.Unmarshal(message, &parsed); err != nil {
 		return nil, err
 	}
-	keyParsed := parsed[`payload`]
+	keyParsed := parsed.Payload
 	if len(keyParsed) <= 0 {
 		return nil, fmt.Errorf("payload value in json message contains no elements")
 	}
@@ -1392,7 +1397,7 @@ func (f *webhookFeed) Next() (*cdctest.TestFeedMessage, error) {
 					if err != nil {
 						return nil, err
 					}
-					if m.Key, m.Value, err = extractKeyFromJSONValue([]byte(wrappedValue)); err != nil {
+					if m.Key, m.Value, err = extractKeyFromJSONValue(wrappedValue); err != nil {
 						return nil, err
 					}
 					if m.Topic, m.Value, err = extractTopicFromJSONValue(m.Value); err != nil {


### PR DESCRIPTION
Previously, retry behavior was preset and batching was not supported. This
change adds configuration JSON to change retry behavior and batch sink
messages by count, bytes, and timeouts.

Resolves #67804

Release note (enterprise change): webhook_sink_config JSON option to
configure retry and batching behavior for webhook sink changefeed messages