### PR TITLE
kvserver/closedts: fix nil dereference in HTML generation

### DIFF
--- a/pkg/kv/kvserver/closedts/sidetransport/debug.go
+++ b/pkg/kv/kvserver/closedts/sidetransport/debug.go
@@ -148,6 +148,8 @@ func (s *Sender) HTML() string {
 	header("Last message")
 	lastMsg, ok := s.buf.GetBySeq(context.Background(), lastMsgSeq)
 	if !ok {
+		fmt.Fprint(sb, "Buffer has been closed.\n")
+	} else if lastMsg == nil {
 		fmt.Fprint(sb, "Buffer no longer has the message. This is unexpected.\n")
 	} else {
 		sb.WriteString(escape(lastMsg.String()))


### PR DESCRIPTION
The `/debug/closedts-{sender,receiver}` endpoints could panic due to a
nil dereference if the last update in the sidetransport buffer was
removed by the time it was rendered. This patch adds a `nil` check to
avoid that panic.

Release note (bug fix): Fixed a crash in the
`/debug/closedts-{sender,receiver}` advanced debug pages if the last
message of the closed timestamp side transport buffer was removed before
rendering.