### PR TITLE
keys/kvprober: introduce a range-local key for probing, use from kvprober

### DIFF
--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -137,6 +137,8 @@ var (
 	// key info, such as the txn ID in the case of a transaction record.
 	LocalRangePrefix = roachpb.Key(makeKey(LocalPrefix, roachpb.RKey("k")))
 	LocalRangeMax    = LocalRangePrefix.PrefixEnd()
+	// LocalRangeProbeSuffix is the suffix for keys for probing.
+	LocalRangeProbeSuffix = roachpb.RKey("prbe")
 	// LocalQueueLastProcessedSuffix is the suffix for replica queue state keys.
 	LocalQueueLastProcessedSuffix = roachpb.RKey("qlpt")
 	// LocalRangeDescriptorSuffix is the suffix for keys storing

--- a/pkg/keys/doc.go
+++ b/pkg/keys/doc.go
@@ -210,6 +210,7 @@ var _ = [...]interface{}{
 	//   as a whole. They are replicated and addressable. Typical examples are
 	//   the range descriptor and transaction records. They all share
 	//   `LocalRangePrefix`.
+	RangeProbeKey,         // "prbe"
 	QueueLastProcessedKey, // "qlpt"
 	RangeDescriptorKey,    // "rdsc"
 	TransactionKey,        // "txn-"

--- a/pkg/keys/keys.go
+++ b/pkg/keys/keys.go
@@ -417,6 +417,13 @@ func QueueLastProcessedKey(key roachpb.RKey, queue string) roachpb.Key {
 	return MakeRangeKey(key, LocalQueueLastProcessedSuffix, roachpb.RKey(queue))
 }
 
+// RangeProbeKey returns a range-local key for probing. The
+// purpose of the key is to test CRDB in production; if any data is present at
+// the key, it has no purpose except in allowing testing CRDB in production.
+func RangeProbeKey(key roachpb.RKey) roachpb.Key {
+	return MakeRangeKey(key, LocalRangeProbeSuffix, nil)
+}
+
 // LockTableSingleKey creates a key under which all single-key locks for the
 // given key can be found. buf is used as scratch-space, up to its capacity,
 // to avoid allocations -- its contents will be overwritten and not appended

--- a/pkg/keys/printer.go
+++ b/pkg/keys/printer.go
@@ -183,6 +183,7 @@ var (
 		{name: "RangeDescriptor", suffix: LocalRangeDescriptorSuffix, atEnd: true},
 		{name: "Transaction", suffix: LocalTransactionSuffix, atEnd: false},
 		{name: "QueueLastProcessed", suffix: LocalQueueLastProcessedSuffix, atEnd: false},
+		{name: "RangeProbe", suffix: LocalRangeProbeSuffix, atEnd: true},
 	}
 )
 

--- a/pkg/keys/printer_test.go
+++ b/pkg/keys/printer_test.go
@@ -87,6 +87,7 @@ func TestPrettyPrint(t *testing.T) {
 		{keys.MakeRangeKeyPrefix(roachpb.RKey(tenSysCodec.TablePrefix(42))), `/Local/Range/Table/42`, revertSupportUnknown},
 		{keys.RangeDescriptorKey(roachpb.RKey(tenSysCodec.TablePrefix(42))), `/Local/Range/Table/42/RangeDescriptor`, revertSupportUnknown},
 		{keys.TransactionKey(tenSysCodec.TablePrefix(42), txnID), fmt.Sprintf(`/Local/Range/Table/42/Transaction/%q`, txnID), revertSupportUnknown},
+		{keys.RangeProbeKey(roachpb.RKey(tenSysCodec.TablePrefix(42))), `/Local/Range/Table/42/RangeProbe`, revertSupportUnknown},
 		{keys.QueueLastProcessedKey(roachpb.RKey(tenSysCodec.TablePrefix(42)), "foo"), `/Local/Range/Table/42/QueueLastProcessed/"foo"`, revertSupportUnknown},
 		{lockTableKey(keys.RangeDescriptorKey(roachpb.RKey(tenSysCodec.TablePrefix(42)))), `/Local/Lock/Intent/Local/Range/Table/42/RangeDescriptor`, revertSupportUnknown},
 		{lockTableKey(tenSysCodec.TablePrefix(111)), "/Local/Lock/Intent/Table/111", revertSupportUnknown},

--- a/pkg/kv/kvprober/kvprober.go
+++ b/pkg/kv/kvprober/kvprober.go
@@ -22,6 +22,7 @@ import (
 	"math/rand"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
@@ -198,11 +199,11 @@ func (p *Prober) probe(ctx context.Context, db dbGet) {
 	// perspective of the user.
 	timeout := readTimeout.Get(&p.settings.SV)
 	err = contextutil.RunWithTimeout(ctx, "db.Get", timeout, func(ctx context.Context) error {
-		// We read the start key for the range. There may be no data at the key,
-		// but that is okay. Even if there is no data at the key, the prober still
-		// executes a basic read operation on the range.
+		// We read a "range-local" key dedicated to probing. See pkg/keys for more.
+		// There is no data at the key, but that is okay. Even tho there is no data
+		// at the key, the prober still executes a read operation on the range.
 		// TODO(josh): Trace the probes.
-		_, err = db.Get(ctx, step.StartKey)
+		_, err = db.Get(ctx, keys.RangeProbeKey(step.StartKey))
 		return err
 	})
 	if err != nil {


### PR DESCRIPTION
This work sets the stage for extending `kvprober` to do writes as is discussed in detail with @tbg at https://github.com/cockroachdb/cockroach/issues/67112.

**keys: add a range-local key for probing**

This commit introduces a range-local key for probing. The key will
only be used by probing components like kvprober. This means no
contention with user-traffic or other CRDB components. This key also provides
a safe place to write to in order to test write availabilty. A kvprober that
does writes is coming soon.

Release note: None.

**kvprober: probe the range-local key dedicated to probing**

Before this commit, kvprober probed the start key of a range. This worked okay,
as kvprober only did reads, and contention issues leading to false positive
pages haven't happened in practice. But contention issues are possible,
as there may be data located at the start key of the range.

With this commit, kvprober probes the range-local key dedicated to
probing. No contention issues are possible, as that key is only for
probing. This key is also needed for write probes, which are coming soon.

Release note: None.