### PR TITLE
[wip] sql: stop granting privileges to admin for all new database

### DIFF
--- a/pkg/sql/catalog/descpb/privilege.go
+++ b/pkg/sql/catalog/descpb/privilege.go
@@ -104,27 +104,6 @@ func (p *PrivilegeDescriptor) RemoveUser(user security.SQLUsername) {
 	p.Users = append(p.Users[:idx], p.Users[idx+1:]...)
 }
 
-// NewCustomSuperuserPrivilegeDescriptor returns a privilege descriptor for the root user
-// and the admin role with specified privileges.
-func NewCustomSuperuserPrivilegeDescriptor(
-	priv privilege.List, owner security.SQLUsername,
-) *PrivilegeDescriptor {
-	return &PrivilegeDescriptor{
-		OwnerProto: owner.EncodeProto(),
-		Users: []UserPrivileges{
-			{
-				UserProto:  security.AdminRoleName().EncodeProto(),
-				Privileges: priv.ToBitField(),
-			},
-			{
-				UserProto:  security.RootUserName().EncodeProto(),
-				Privileges: priv.ToBitField(),
-			},
-		},
-		Version: Version21_2,
-	}
-}
-
 // NewPublicSelectPrivilegeDescriptor is used to construct a privilege descriptor
 // owned by the node user which has SELECT privilege for the public role. It is
 // used for virtual tables.
@@ -163,7 +142,11 @@ var DefaultSuperuserPrivileges = privilege.List{privilege.ALL}
 // with ALL privileges for the root user and admin role.
 // NOTE: use NewBaseDatabasePrivilegeDescriptor for databases.
 func NewBasePrivilegeDescriptor(owner security.SQLUsername) *PrivilegeDescriptor {
-	return NewCustomSuperuserPrivilegeDescriptor(DefaultSuperuserPrivileges, owner)
+	return &PrivilegeDescriptor{
+		OwnerProto: owner.EncodeProto(),
+		Users:      []UserPrivileges{},
+		Version:    Version21_2,
+	}
 }
 
 // NewBaseDatabasePrivilegeDescriptor creates defaults privileges for a database.

--- a/pkg/sql/catalog/descpb/privilege.go
+++ b/pkg/sql/catalog/descpb/privilege.go
@@ -309,17 +309,18 @@ func (p PrivilegeDescriptor) ValidateSuperuserPrivileges(
 	} {
 		superPriv, ok := p.FindUser(user)
 		if !ok {
-			return fmt.Errorf(
-				"user %s does not have privileges over %s",
-				user,
-				privilegeObject(parentID, objectType, objectName),
-			)
+			return nil
+			//return fmt.Errorf(
+			//	"user %s does not have privileges over %s",
+			//	user,
+			//	privilegeObject(parentID, objectType, objectName),
+			//)
 		}
 
-		// The super users must match the allowed privilege set exactly.
-		if superPriv.Privileges != allowedSuperuserPrivileges.ToBitField() {
+		// The super users must have at most the allowed privilege set.
+		if (superPriv.Privileges | allowedSuperuserPrivileges.ToBitField()) != allowedSuperuserPrivileges.ToBitField() {
 			return fmt.Errorf(
-				"user %s must have exactly %s privileges on %s",
+				"user %s must have at most %s privileges on %s",
 				user,
 				allowedSuperuserPrivileges,
 				privilegeObject(parentID, objectType, objectName),

--- a/pkg/sql/catalog/descpb/privilege_test.go
+++ b/pkg/sql/catalog/descpb/privilege_test.go
@@ -346,9 +346,9 @@ func TestSystemPrivilegeValidate(t *testing.T) {
 		return descriptor.Validate(keys.SystemDatabaseID, privilege.Table, "whatever", privilege.ReadData)
 	}
 
-	rootWrongPrivilegesErr := "user root must have exactly GRANT, SELECT " +
+	rootWrongPrivilegesErr := "user root must have at most GRANT, SELECT " +
 		`privileges on (system )?table "whatever"`
-	adminWrongPrivilegesErr := "user admin must have exactly GRANT, SELECT " +
+	adminWrongPrivilegesErr := "user admin must have at most GRANT, SELECT " +
 		`privileges on (system )?table "whatever"`
 
 	{
@@ -401,6 +401,8 @@ func TestSystemPrivilegeValidate(t *testing.T) {
 	{
 		// Invalid: root has a non-allowable privilege set.
 		descriptor := NewBasePrivilegeDescriptor(security.AdminRoleName())
+		descriptor.Grant(security.RootUserName(), privilege.List{privilege.UPDATE}, false)
+		descriptor.Grant(security.AdminRoleName(), privilege.List{privilege.UPDATE}, false)
 		if err := validate(descriptor); !testutils.IsError(err, rootWrongPrivilegesErr) {
 			t.Fatalf("expected err=%s, got err=%v", rootWrongPrivilegesErr, err)
 		}

--- a/pkg/sql/catalog/descpb/privilege_test.go
+++ b/pkg/sql/catalog/descpb/privilege_test.go
@@ -353,10 +353,7 @@ func TestSystemPrivilegeValidate(t *testing.T) {
 
 	{
 		// Valid: root user has one of the allowable privilege sets.
-		descriptor := NewCustomSuperuserPrivilegeDescriptor(
-			privilege.List{privilege.SELECT, privilege.GRANT},
-			security.AdminRoleName(),
-		)
+		descriptor := NewBasePrivilegeDescriptor(security.AdminRoleName())
 		if err := validate(descriptor); err != nil {
 			t.Fatal(err)
 		}
@@ -376,10 +373,10 @@ func TestSystemPrivilegeValidate(t *testing.T) {
 
 	{
 		// Valid: root has exactly the allowed privileges.
-		descriptor := NewCustomSuperuserPrivilegeDescriptor(
-			privilege.List{privilege.SELECT, privilege.GRANT},
-			security.AdminRoleName(),
-		)
+		descriptor := NewBasePrivilegeDescriptor(security.AdminRoleName())
+		if err := validate(descriptor); err != nil {
+			t.Fatal(err)
+		}
 
 		// Valid: foo has a subset of the allowed privileges.
 		descriptor.Grant(testUser, privilege.List{privilege.GRANT}, false)
@@ -403,8 +400,7 @@ func TestSystemPrivilegeValidate(t *testing.T) {
 
 	{
 		// Invalid: root has a non-allowable privilege set.
-		descriptor := NewCustomSuperuserPrivilegeDescriptor(privilege.List{privilege.UPDATE},
-			security.AdminRoleName())
+		descriptor := NewBasePrivilegeDescriptor(security.AdminRoleName())
 		if err := validate(descriptor); !testutils.IsError(err, rootWrongPrivilegesErr) {
 			t.Fatalf("expected err=%s, got err=%v", rootWrongPrivilegesErr, err)
 		}

--- a/pkg/sql/catalog/systemschema/system.go
+++ b/pkg/sql/catalog/systemschema/system.go
@@ -687,14 +687,14 @@ const SystemDatabaseName = catconstants.SystemDatabaseName
 // MakeSystemDatabaseDesc constructs a copy of the system database
 // descriptor.
 func MakeSystemDatabaseDesc() catalog.DatabaseDescriptor {
-	priv := privilege.ReadData
+	//priv := privilege.ReadData
 	return dbdesc.NewBuilder(&descpb.DatabaseDescriptor{
 		Name:    SystemDatabaseName,
 		ID:      keys.SystemDatabaseID,
 		Version: 1,
-		// Assign max privileges to root user.
-		Privileges: descpb.NewCustomSuperuserPrivilegeDescriptor(
-			priv, security.NodeUserName()),
+		//Privileges: descpb.NewCustomSuperuserPrivilegeDescriptor(
+		//	priv, security.NodeUserName()),
+		Privileges: descpb.NewBaseDatabasePrivilegeDescriptor(security.NodeUserName()),
 	}).BuildImmutableDatabase()
 }
 

--- a/pkg/sql/catalog/systemschema/system.go
+++ b/pkg/sql/catalog/systemschema/system.go
@@ -753,7 +753,8 @@ func registerSystemTable(
 		if privs == nil {
 			log.Fatalf(ctx, "No superuser privileges found when building descriptor of system table %q", tbl.Name)
 		}
-		tbl.Privileges = descpb.NewCustomSuperuserPrivilegeDescriptor(privs, security.NodeUserName())
+		//tbl.Privileges = descpb.NewCustomSuperuserPrivilegeDescriptor(privs, security.NodeUserName())
+		tbl.Privileges = descpb.NewBasePrivilegeDescriptor(security.NodeUserName())
 	}
 	for _, fn := range fns {
 		fn(&tbl)

--- a/pkg/sql/doctor/doctor_test.go
+++ b/pkg/sql/doctor/doctor_test.go
@@ -57,8 +57,9 @@ var validTableDesc = &descpb.Descriptor{
 				EncodingType:        descpb.PrimaryIndexEncoding,
 			},
 			NextIndexID: 2,
-			Privileges: descpb.NewCustomSuperuserPrivilegeDescriptor(
-				privilege.ReadWriteData, security.NodeUserName()),
+			//Privileges: descpb.NewCustomSuperuserPrivilegeDescriptor(
+			//	privilege.ReadWriteData, security.NodeUserName()),
+			Privileges:     descpb.NewBasePrivilegeDescriptor(security.NodeUserName()),
 			FormatVersion:  descpb.InterleavedFormatVersion,
 			NextMutationID: 1,
 		},


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/44118

There is no need to do this, since admins automatically bypass privilege
checks. This is also more compatible with Postgres.

Release note: None