### PR TITLE
colexec: interrupt parallel unordered sync local inputs when draining

### DIFF
--- a/pkg/sql/colexec/BUILD.bazel
+++ b/pkg/sql/colexec/BUILD.bazel
@@ -61,6 +61,7 @@ go_library(
         "//pkg/sql/colexec/execgen",  # keep
         "//pkg/sql/colexecerror",
         "//pkg/sql/colexecop",
+        "//pkg/sql/colflow/colrpc",
         "//pkg/sql/colmem",
         "//pkg/sql/execinfra",
         "//pkg/sql/execinfrapb",
@@ -71,6 +72,7 @@ go_library(
         "//pkg/sql/sqltelemetry",  # keep
         "//pkg/sql/types",
         "//pkg/util",
+        "//pkg/util/cancelchecker",
         "//pkg/util/duration",  # keep
         "//pkg/util/encoding",  # keep
         "//pkg/util/humanizeutil",

--- a/pkg/sql/colexec/invariants_checker.go
+++ b/pkg/sql/colexec/invariants_checker.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/errors"
 )
 
@@ -36,6 +37,11 @@ var _ colexecop.ClosableOperator = &InvariantsChecker{}
 
 // NewInvariantsChecker creates a new InvariantsChecker.
 func NewInvariantsChecker(input colexecop.Operator) *InvariantsChecker {
+	if !util.CrdbTestBuild {
+		colexecerror.InternalError(errors.AssertionFailedf(
+			"an InvariantsChecker is attempted to be created in non-test build",
+		))
+	}
 	c := &InvariantsChecker{
 		OneInputNode: colexecop.OneInputNode{Input: input},
 	}

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -954,6 +954,7 @@ func (s *vectorizedFlowCreator) setupInput(
 			// must use the serial unordered sync above in order to remove any
 			// concurrency.
 			sync := colexec.NewParallelUnorderedSynchronizer(inputStreamOps, s.waitGroup)
+			sync.UsesFakeSpanResolver = flowCtx.TestingKnobs().UsesFakeSpanResolver
 			opWithMetaInfo = colexecargs.OpWithMetaInfo{
 				Root:            sync,
 				MetadataSources: colexecop.MetadataSources{sync},

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -195,6 +195,7 @@ func (dsp *DistSQLPlanner) GatewayID() roachpb.NodeID {
 // responsibility to make sure the DistSQLPlanner is not in use.
 func (dsp *DistSQLPlanner) SetSpanResolver(spanResolver physicalplan.SpanResolver) {
 	dsp.spanResolver = spanResolver
+	dsp.distSQLSrv.TestingKnobs.UsesFakeSpanResolver = physicalplan.IsFakeSpanResolver(spanResolver)
 }
 
 // distSQLExprCheckVisitor is a tree.Visitor that checks if expressions

--- a/pkg/sql/execinfra/server_config.go
+++ b/pkg/sql/execinfra/server_config.go
@@ -234,6 +234,10 @@ type TestingKnobs struct {
 
 	// BackupRestoreTestingKnobs are backup and restore specific testing knobs.
 	BackupRestoreTestingKnobs base.ModuleTestingKnobs
+
+	// UsesFakeSpanResolver indicates whether the DistSQLPlanner uses a fake
+	// span resolver.
+	UsesFakeSpanResolver bool
 }
 
 // MetadataTestLevel represents the types of queries where metadata test

--- a/pkg/sql/physicalplan/fake_span_resolver.go
+++ b/pkg/sql/physicalplan/fake_span_resolver.go
@@ -40,6 +40,12 @@ func NewFakeSpanResolver(nodes []*roachpb.NodeDescriptor) SpanResolver {
 	}
 }
 
+// IsFakeSpanResolver returns whether s is a fakeSpanResolver.
+func IsFakeSpanResolver(s SpanResolver) bool {
+	_, ok := s.(*fakeSpanResolver)
+	return ok
+}
+
 // fakeRange indicates that a range between startKey and endKey is owned by a
 // certain node.
 type fakeRange struct {


### PR DESCRIPTION
This commit updates the parallel unordered synchronizer to interrupt
each local input when the synchronizer transitions into the draining
state. This is implemented by deriving a separate child context for each
local input with the corresponding context cancellation function. This
commit also treats all inputs as "remote" whenever we're using the
`fakeSpanResolver` (which is the case in `fakedist*` logic test
configs).

Previously, whenever the synchronizer started draining, it would have
to wait for each input goroutine to finish the current `Next` call
before actually draining the metadata; now we won't have to wait for
local inputs anymore.

We cannot perform the context cancellation for the remote inputs (i.e.
those with `colrpc.Inbox` as a leaf) because the context cancellation
would break the gRPC stream making it impossible to fetch the remote
metadata. We thought that using the DrainSignal message sent by the
inbox to the outbox would solve the problem, but the difficulty is that
the main goroutine of the inbox is blocked on `stream.Recv` which
doesn't take a separate context object. Therefore, the only two ways to
unblock the main inbox goroutine are to cancel the stream context (thus
breaking the gRPC stream and making it unusable) or to wait for the
outbox to actually send something on the stream (like a non-zero length
batch or metadata, or actually close the stream for good). In any case,
it doesn't seem possible at the moment.

However, the existing change seems beneficial as is (we might reduce the
amount of work the local node will perform) and is sufficient for the
use case of parallel scans with the locality optimized search.

The usage of the context cancellation comes with a little bit of risk
because several operations in the local input trees will still use it
after the synchronizer transitions to draining. Namely, we still need to
collect the stats, propagate the metadata, and close the `Closer`s;
however, I think the canceled context should work ok in all of those
cases.

Release note: None