### PR TITLE
workload: fix generation of part table column values in TPC-H

### DIFF
--- a/pkg/ccl/workloadccl/allccl/all_test.go
+++ b/pkg/ccl/workloadccl/allccl/all_test.go
@@ -270,7 +270,7 @@ func TestDeterministicInitialData(t *testing.T) {
 		`sqlsmith`:   0xcbf29ce484222325,
 		`startrek`:   0xa0249fbdf612734c,
 		`tpcc`:       0xab32e4f5e899eb2f,
-		`tpch`:       0xdd952207e22aa577,
+		`tpch`:       0x65a1e18ddf4e59aa,
 		`ycsb`:       0x1244ea1c29ef67f6,
 	}
 

--- a/pkg/workload/tpch/random.go
+++ b/pkg/workload/tpch/random.go
@@ -220,8 +220,8 @@ func randSyllables(
 	for i, syl := range syllables {
 		if i != 0 {
 			buf = append(buf, ' ')
-			buf = append(buf, syl[rng.Intn(len(syl))]...)
 		}
+		buf = append(buf, syl[rng.Intn(len(syl))]...)
 	}
 	return buf
 }


### PR DESCRIPTION
Release note (bug fix): Fixed an oversight in the data generator for TPC-H
which was causing a smaller number of distinct values to be generated
for `p_type` and `p_container` in the `part` table than the spec calls for.