### PR TITLE
cli/demo: make `demo` recognize `--listening-url-file`

### DIFF
--- a/pkg/cli/democluster/context.go
+++ b/pkg/cli/democluster/context.go
@@ -88,6 +88,10 @@ type Context struct {
 	// HTTPPort is the first HTTP port number to use when instantiating
 	// servers. Use zero for auto-allocated random ports.
 	HTTPPort int
+
+	// ListeningURLFile can be set to a file which is written to after
+	// the demo cluster has started, to contain a valid connection URL.
+	ListeningURLFile string
 }
 
 // IsInteractive returns true if the demo cluster configuration

--- a/pkg/cli/democluster/demo_cluster.go
+++ b/pkg/cli/democluster/demo_cluster.go
@@ -381,6 +381,14 @@ func (c *transientCluster) Start(
 		}
 		c.connURL = purl.ToPQ().String()
 
+		// Write the URL to a file if this was requested by configuration.
+		if c.demoCtx.ListeningURLFile != "" {
+			c.infoLog(ctx, "listening URL file: %s", c.demoCtx.ListeningURLFile)
+			if err = ioutil.WriteFile(c.demoCtx.ListeningURLFile, []byte(fmt.Sprintf("%s\n", c.connURL)), 0644); err != nil {
+				c.warnLog(ctx, "failed writing the URL: %v", err)
+			}
+		}
+
 		// Start up the update check loop.
 		// We don't do this in (*server.Server).Start() because we don't want this
 		// overhead and possible interference in tests.

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -857,6 +857,7 @@ func init() {
 
 		intFlag(f, &demoCtx.SQLPort, cliflags.DemoSQLPort)
 		intFlag(f, &demoCtx.HTTPPort, cliflags.DemoHTTPPort)
+		stringFlag(f, &demoCtx.ListeningURLFile, cliflags.ListeningURLFile)
 	}
 
 	// statement-diag command.

--- a/pkg/cli/interactive_tests/test_demo.tcl
+++ b/pkg/cli/interactive_tests/test_demo.tcl
@@ -213,3 +213,29 @@ eexpect eof
 
 
 end_test
+
+start_test "Check that demo populates the connection URL in a configured file"
+
+spawn $argv demo --no-example-database --listening-url-file=test.url
+eexpect "Welcome"
+eexpect "defaultdb>"
+
+# Check the URL is valid. If the connection fails, the system command will fail too.
+system "$argv sql --url `cat test.url` -e 'select 1'"
+
+interrupt
+eexpect eof
+
+# Ditto, insecure
+spawn $argv demo --no-example-database --listening-url-file=test.url --insecure
+eexpect "Welcome"
+eexpect "defaultdb>"
+
+# Check the URL is valid. If the connection fails, the system command will fail too.
+system "$argv sql --url `cat test.url` -e 'select 1'"
+
+interrupt
+eexpect eof
+
+
+end_test


### PR DESCRIPTION
Informs #68437.

When building automation, it is useful to start a `demo` cluster in
such a way that another command can subsequently connect without
manual steps. Prior to this patch, this was not possible, as
the connection credentials would only be displayed in the
informational messages. This patch fixes it.

Release note (cli change): `cockroach demo` now recognizes the
command-line flag `--listening-url-file` like `start` and
`start-single-node`. When specified, the `demo` utility will write a
valid connection URL to that file after the test cluster has been
initialized.

This facility also makes it possible to automatically wait until the
demo cluster has been initialized in automation, for example by
passing the name of a unix named FIFO via the new flag.