### PR TITLE
*: replace erroneous uses of `Newf`/`Errorf` by `Wrap`/`Wrapf`

### DIFF
--- a/pkg/ccl/cliccl/debug.go
+++ b/pkg/ccl/cliccl/debug.go
@@ -330,7 +330,7 @@ func getActiveEncryptionkey(dir string) (string, string, error) {
 
 	var setting enginepbccl.EncryptionSettings
 	if err := protoutil.Unmarshal(entry.EncryptionSettings, &setting); err != nil {
-		return "", "", fmt.Errorf("could not unmarshal encryption settings for %s: %v", keyRegistryFilename, err)
+		return "", "", errors.Wrapf(err, "could not unmarshal encryption settings for %s", keyRegistryFilename)
 	}
 
 	return setting.EncryptionType.String(), setting.KeyId, nil

--- a/pkg/ccl/cmdccl/enc_utils/main.go
+++ b/pkg/ccl/cmdccl/enc_utils/main.go
@@ -183,7 +183,7 @@ func readFile(filename string) ([]byte, error) {
 
 	data, err := ioutil.ReadFile(absPath)
 	if err != nil {
-		return nil, errors.Errorf("could not read %s: %v", absPath, err)
+		return nil, errors.Wrapf(err, "could not read %s", absPath)
 	}
 
 	reg, ok := fileRegistry[filename]
@@ -202,7 +202,7 @@ func readFile(filename string) ([]byte, error) {
 
 	cipher, err := aes.NewCipher(key.rawKey)
 	if err != nil {
-		return nil, errors.Errorf("could not build AES cipher for file %s: %v", absPath, err)
+		return nil, errors.Wrapf(err, "could not build AES cipher for file %s", absPath)
 	}
 
 	size := len(data)

--- a/pkg/ccl/sqlproxyccl/denylist/watcher.go
+++ b/pkg/ccl/sqlproxyccl/denylist/watcher.go
@@ -174,11 +174,11 @@ func (l *listener) Less(than btree.Item) bool {
 func checkConnection(connection ConnectionTags, list *Denylist) error {
 	ip := DenyEntity{Item: connection.IP, Type: IPAddrType}
 	if err := list.Denied(ip); err != nil {
-		return errors.Errorf("connection ip '%v' denied: %v", connection.IP, err)
+		return errors.Wrapf(err, "connection ip '%v' denied", connection.IP)
 	}
 	cluster := DenyEntity{Item: connection.Cluster, Type: ClusterType}
 	if err := list.Denied(cluster); err != nil {
-		return errors.Errorf("connection cluster '%v' denied: %v", connection.Cluster, err)
+		return errors.Wrapf(err, "connection cluster '%v' denied", connection.Cluster)
 	}
 	return nil
 }

--- a/pkg/cli/clisqlclient/conn.go
+++ b/pkg/cli/clisqlclient/conn.go
@@ -267,7 +267,7 @@ func (c *sqlConn) GetServerMetadata() (nodeID int32, version, clusterID string, 
 			c.clusterOrganization = row[2]
 			id, err := strconv.Atoi(row[0])
 			if err != nil {
-				return 0, "", "", errors.Newf("incorrect data while retrieving node id: %v", err)
+				return 0, "", "", errors.Wrap(err, "incorrect data while retrieving node id")
 			}
 			nodeID = int32(id)
 

--- a/pkg/cli/doctor.go
+++ b/pkg/cli/doctor.go
@@ -344,12 +344,12 @@ func fromZipDir(
 		last := len(fields) - 1
 		i, err := strconv.Atoi(fields[0])
 		if err != nil {
-			return errors.Errorf("failed to parse descriptor id %s: %v", fields[0], err)
+			return errors.Wrapf(err, "failed to parse descriptor id %s", fields[0])
 		}
 
 		descBytes, err := hx.DecodeString(fields[last])
 		if err != nil {
-			return errors.Errorf("failed to decode hex descriptor %d: %v", i, err)
+			return errors.Wrapf(err, "failed to decode hex descriptor %d", i)
 		}
 		ts := hlc.Timestamp{WallTime: timeutil.Now().UnixNano()}
 		descTable = append(descTable, doctor.DescriptorTableRow{ID: int64(i), DescBytes: descBytes, ModTime: ts})
@@ -375,18 +375,18 @@ func fromZipDir(
 		fields := strings.Fields(row)
 		parID, err := strconv.Atoi(fields[0])
 		if err != nil {
-			return errors.Errorf("failed to parse parent id %s: %v", fields[0], err)
+			return errors.Wrapf(err, "failed to parse parent id %s", fields[0])
 		}
 		parSchemaID, err := strconv.Atoi(fields[1])
 		if err != nil {
-			return errors.Errorf("failed to parse parent schema id %s: %v", fields[1], err)
+			return errors.Wrapf(err, "failed to parse parent schema id %s", fields[1])
 		}
 		id, err := strconv.Atoi(fields[3])
 		if err != nil {
 			if fields[3] == "NULL" {
 				id = int(descpb.InvalidID)
 			} else {
-				return errors.Errorf("failed to parse id %s: %v", fields[3], err)
+				return errors.Wrapf(err, "failed to parse id %s", fields[3])
 			}
 		}
 
@@ -415,14 +415,14 @@ func fromZipDir(
 
 		id, err := strconv.Atoi(fields[0])
 		if err != nil {
-			return errors.Errorf("failed to parse job id %s: %v", fields[0], err)
+			return errors.Wrapf(err, "failed to parse job id %s", fields[0])
 		}
 		md.ID = jobspb.JobID(id)
 
 		last := len(fields) - 1
 		payloadBytes, err := hx.DecodeString(fields[last-1])
 		if err != nil {
-			return errors.Errorf("job %d: failed to decode hex payload: %v", id, err)
+			return errors.Wrapf(err, "job %d: failed to decode hex payload", id)
 		}
 		md.Payload = &jobspb.Payload{}
 		if err := protoutil.Unmarshal(payloadBytes, md.Payload); err != nil {
@@ -430,7 +430,7 @@ func fromZipDir(
 		}
 		progressBytes, err := hx.DecodeString(fields[last])
 		if err != nil {
-			return errors.Errorf("job %d: failed to decode hex progress: %v", id, err)
+			return errors.Wrapf(err, "job %d: failed to decode hex progress", id)
 		}
 		md.Progress = &jobspb.Progress{}
 		if err := protoutil.Unmarshal(progressBytes, md.Progress); err != nil {

--- a/pkg/geo/parse.go
+++ b/pkg/geo/parse.go
@@ -20,7 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/errors"
 	"github.com/pierrre/geohash"
-	"github.com/twpayne/go-geom"
+	geom "github.com/twpayne/go-geom"
 	"github.com/twpayne/go-geom/encoding/ewkb"
 	"github.com/twpayne/go-geom/encoding/ewkbhex"
 	"github.com/twpayne/go-geom/encoding/geojson"
@@ -247,7 +247,7 @@ func parseGeoHash(g string, precision int) (geohash.Box, error) {
 func GeometryToEncodedPolyline(g Geometry, p int) (string, error) {
 	gt, err := g.AsGeomT()
 	if err != nil {
-		return "", fmt.Errorf("error parsing input geometry: %v", err)
+		return "", errors.Wrap(err, "error parsing input geometry")
 	}
 	if gt.SRID() != 4326 {
 		return "", errors.New("only SRID 4326 is supported")
@@ -263,7 +263,7 @@ func ParseEncodedPolyline(encodedPolyline string, precision int) (Geometry, erro
 
 	g, err := MakeGeometryFromGeomT(ls)
 	if err != nil {
-		return Geometry{}, fmt.Errorf("parsing geography error: %v", err)
+		return Geometry{}, errors.Wrap(err, "parsing geography error")
 	}
 	return g, nil
 }

--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -404,7 +404,7 @@ func (g *Gossip) SetNodeDescriptor(desc *roachpb.NodeDescriptor) error {
 		log.Fatalf(ctx, "n%d address is empty", desc.NodeID)
 	}
 	if err := g.AddInfoProto(MakeNodeIDKey(desc.NodeID), desc, NodeDescriptorTTL); err != nil {
-		return errors.Errorf("n%d: couldn't gossip descriptor: %v", desc.NodeID, err)
+		return errors.Wrapf(err, "n%d: couldn't gossip descriptor", desc.NodeID)
 	}
 	g.updateClients()
 	return nil

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -1155,7 +1155,10 @@ func sendSnapshot(
 	// completed (such as defers that might be run after the previous message was
 	// received).
 	if unexpectedResp, err := stream.Recv(); err != io.EOF {
-		return errors.Errorf("%s: expected EOF, got resp=%v err=%v", to, unexpectedResp, err)
+		if err != nil {
+			return errors.Wrapf(err, "%s: expected EOF, got resp=%v with error", to, unexpectedResp)
+		}
+		return errors.Newf("%s: expected EOF, got resp=%v", to, unexpectedResp)
 	}
 	switch resp.Status {
 	case SnapshotResponse_ERROR:

--- a/pkg/kv/kvserver/store_split.go
+++ b/pkg/kv/kvserver/store_split.go
@@ -21,7 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
-	"go.etcd.io/etcd/raft/v3"
+	raft "go.etcd.io/etcd/raft/v3"
 	"go.etcd.io/etcd/raft/v3/raftpb"
 )
 
@@ -335,7 +335,7 @@ func (s *Store) SplitRange(
 		rightRepl := rightReplOrNil
 		leftRepl.writeStats.splitRequestCounts(rightRepl.writeStats)
 		if err := s.addReplicaInternalLocked(rightRepl); err != nil {
-			return errors.Errorf("unable to add replica %v: %s", rightRepl, err)
+			return errors.Wrapf(err, "unable to add replica %v", rightRepl)
 		}
 
 		// Update the replica's cached byte thresholds. This is a no-op if the system

--- a/pkg/security/certificate_loader.go
+++ b/pkg/security/certificate_loader.go
@@ -380,7 +380,7 @@ func (cl *CertificateLoader) findKey(ci *CertInfo) error {
 	// Stat the file. This follows symlinks.
 	info, err := assetLoaderImpl.Stat(fullKeyPath)
 	if err != nil {
-		return errors.Errorf("could not stat key file %s: %v", fullKeyPath, err)
+		return errors.Wrapf(err, "could not stat key file %s", fullKeyPath)
 	}
 
 	// Only regular files are supported (after following symlinks).
@@ -399,7 +399,7 @@ func (cl *CertificateLoader) findKey(ci *CertInfo) error {
 	// Read key file.
 	keyPEMBlock, err := assetLoaderImpl.ReadFile(fullKeyPath)
 	if err != nil {
-		return errors.Errorf("could not read key file %s: %v", fullKeyPath, err)
+		return errors.Wrapf(err, "could not read key file %s", fullKeyPath)
 	}
 
 	ci.KeyFilename = keyFilename

--- a/pkg/security/certs.go
+++ b/pkg/security/certs.go
@@ -168,18 +168,18 @@ func createCACertAndKey(
 	var key crypto.PrivateKey
 	if _, err := os.Stat(caKeyPath); err != nil {
 		if !oserror.IsNotExist(err) {
-			return errors.Errorf("could not stat CA key file %s: %v", caKeyPath, err)
+			return errors.Wrapf(err, "could not stat CA key file %s", caKeyPath)
 		}
 
 		// The key does not exist: create it.
 		key, err = rsa.GenerateKey(rand.Reader, keySize)
 		if err != nil {
-			return errors.Errorf("could not generate new CA key: %v", err)
+			return errors.Wrap(err, "could not generate new CA key")
 		}
 
 		// overwrite is not technically needed here, but use it in case something else created it.
 		if err := writeKeyToFile(caKeyPath, key, overwrite); err != nil {
-			return errors.Errorf("could not write CA key to file %s: %v", caKeyPath, err)
+			return errors.Wrapf(err, "could not write CA key to file %s", caKeyPath)
 		}
 
 		log.Infof(context.Background(), "generated CA key %s", caKeyPath)
@@ -190,12 +190,12 @@ func createCACertAndKey(
 		// The key exists, parse it.
 		contents, err := ioutil.ReadFile(caKeyPath)
 		if err != nil {
-			return errors.Errorf("could not read CA key file %s: %v", caKeyPath, err)
+			return errors.Wrapf(err, "could not read CA key file %s", caKeyPath)
 		}
 
 		key, err = PEMToPrivateKey(contents)
 		if err != nil {
-			return errors.Errorf("could not parse CA key file %s: %v", caKeyPath, err)
+			return errors.Wrapf(err, "could not parse CA key file %s", caKeyPath)
 		}
 
 		log.Infof(context.Background(), "using CA key from file %s", caKeyPath)
@@ -204,7 +204,7 @@ func createCACertAndKey(
 	// Generate certificate.
 	certContents, err := GenerateCA(key.(crypto.Signer), lifetime)
 	if err != nil {
-		return errors.Errorf("could not generate CA certificate: %v", err)
+		return errors.Wrap(err, "could not generate CA certificate")
 	}
 
 	var certPath string
@@ -227,17 +227,17 @@ func createCACertAndKey(
 		// The cert file already exists, load certificates.
 		contents, err := ioutil.ReadFile(certPath)
 		if err != nil {
-			return errors.Errorf("could not read existing CA cert file %s: %v", certPath, err)
+			return errors.Wrapf(err, "could not read existing CA cert file %s", certPath)
 		}
 
 		existingCertificates, err = PEMToCertificates(contents)
 		if err != nil {
-			return errors.Errorf("could not parse existing CA cert file %s: %v", certPath, err)
+			return errors.Wrapf(err, "could not parse existing CA cert file %s", certPath)
 		}
 		log.Infof(context.Background(), "found %d certificates in %s",
 			len(existingCertificates), certPath)
 	} else if !oserror.IsNotExist(err) {
-		return errors.Errorf("could not stat CA cert file %s: %v", certPath, err)
+		return errors.Wrapf(err, "could not stat CA cert file %s", certPath)
 	}
 
 	// Always place the new certificate first.
@@ -245,7 +245,7 @@ func createCACertAndKey(
 	certificates = append(certificates, existingCertificates...)
 
 	if err := WritePEMToFile(certPath, certFileMode, overwrite, certificates...); err != nil {
-		return errors.Errorf("could not write CA certificate file %s: %v", certPath, err)
+		return errors.Wrapf(err, "could not write CA certificate file %s", certPath)
 	}
 
 	log.Infof(context.Background(), "wrote %d certificates to %s", len(certificates), certPath)
@@ -285,7 +285,7 @@ func CreateNodePair(
 	// Generate certificates and keys.
 	nodeKey, err := rsa.GenerateKey(rand.Reader, keySize)
 	if err != nil {
-		return errors.Errorf("could not generate new node key: %v", err)
+		return errors.Wrap(err, "could not generate new node key")
 	}
 
 	// Allow control of the principal to place in the cert via an env var. This
@@ -302,13 +302,13 @@ func CreateNodePair(
 
 	certPath := cm.NodeCertPath()
 	if err := writeCertificateToFile(certPath, nodeCert, overwrite); err != nil {
-		return errors.Errorf("error writing node server certificate to %s: %v", certPath, err)
+		return errors.Wrapf(err, "error writing node server certificate to %s", certPath)
 	}
 	log.Infof(context.Background(), "generated node certificate: %s", certPath)
 
 	keyPath := cm.NodeKeyPath()
 	if err := writeKeyToFile(keyPath, nodeKey, overwrite); err != nil {
-		return errors.Errorf("error writing node server key to %s: %v", keyPath, err)
+		return errors.Wrapf(err, "error writing node server key to %s", keyPath)
 	}
 	log.Infof(context.Background(), "generated node key: %s", keyPath)
 
@@ -347,7 +347,7 @@ func CreateUIPair(
 	// Generate certificates and keys.
 	uiKey, err := rsa.GenerateKey(rand.Reader, keySize)
 	if err != nil {
-		return errors.Errorf("could not generate new UI key: %v", err)
+		return errors.Wrap(err, "could not generate new UI key")
 	}
 
 	uiCert, err := GenerateUIServerCert(caCert, caPrivateKey, uiKey.Public(), lifetime, hosts)
@@ -357,13 +357,13 @@ func CreateUIPair(
 
 	certPath := cm.UICertPath()
 	if err := writeCertificateToFile(certPath, uiCert, overwrite); err != nil {
-		return errors.Errorf("error writing UI server certificate to %s: %v", certPath, err)
+		return errors.Wrapf(err, "error writing UI server certificate to %s", certPath)
 	}
 	log.Infof(context.Background(), "generated UI certificate: %s", certPath)
 
 	keyPath := cm.UIKeyPath()
 	if err := writeKeyToFile(keyPath, uiKey, overwrite); err != nil {
-		return errors.Errorf("error writing UI server key to %s: %v", keyPath, err)
+		return errors.Wrapf(err, "error writing UI server key to %s", keyPath)
 	}
 	log.Infof(context.Background(), "generated UI key: %s", keyPath)
 
@@ -418,7 +418,7 @@ func CreateClientPair(
 	// Generate certificates and keys.
 	clientKey, err := rsa.GenerateKey(rand.Reader, keySize)
 	if err != nil {
-		return errors.Errorf("could not generate new client key: %v", err)
+		return errors.Wrap(err, "could not generate new client key")
 	}
 
 	clientCert, err := GenerateClientCert(caCert, caPrivateKey, clientKey.Public(), lifetime, user)
@@ -428,20 +428,20 @@ func CreateClientPair(
 
 	certPath := cm.ClientCertPath(user)
 	if err := writeCertificateToFile(certPath, clientCert, overwrite); err != nil {
-		return errors.Errorf("error writing client certificate to %s: %v", certPath, err)
+		return errors.Wrapf(err, "error writing client certificate to %s", certPath)
 	}
 	log.Infof(context.Background(), "generated client certificate: %s", certPath)
 
 	keyPath := cm.ClientKeyPath(user)
 	if err := writeKeyToFile(keyPath, clientKey, overwrite); err != nil {
-		return errors.Errorf("error writing client key to %s: %v", keyPath, err)
+		return errors.Wrapf(err, "error writing client key to %s", keyPath)
 	}
 	log.Infof(context.Background(), "generated client key: %s", keyPath)
 
 	if wantPKCS8Key {
 		pkcs8KeyPath := keyPath + ".pk8"
 		if err := writePKCS8KeyToFile(pkcs8KeyPath, clientKey, overwrite); err != nil {
-			return errors.Errorf("error writing client PKCS8 key to %s: %v", pkcs8KeyPath, err)
+			return errors.Wrapf(err, "error writing client PKCS8 key to %s", pkcs8KeyPath)
 		}
 		log.Infof(context.Background(), "generated PKCS8 client key: %s", pkcs8KeyPath)
 	}
@@ -497,7 +497,7 @@ func CreateTenantClientPair(
 	// Generate certificates and keys.
 	clientKey, err := rsa.GenerateKey(rand.Reader, keySize)
 	if err != nil {
-		return nil, errors.Errorf("could not generate new tenant key: %v", err)
+		return nil, errors.Wrap(err, "could not generate new tenant key")
 	}
 
 	clientCert, err := GenerateTenantClientCert(
@@ -525,13 +525,13 @@ func WriteTenantClientPair(certsDir string, cp *TenantClientPair, overwrite bool
 	tenantIdentifier := cert.Subject.CommonName
 	certPath := cm.TenantClientCertPath(tenantIdentifier)
 	if err := writeCertificateToFile(certPath, cp.Cert, overwrite); err != nil {
-		return errors.Errorf("error writing tenant certificate to %s: %v", certPath, err)
+		return errors.Wrapf(err, "error writing tenant certificate to %s", certPath)
 	}
 	log.Infof(context.Background(), "wrote SQL tenant client certificate: %s", certPath)
 
 	keyPath := cm.TenantClientKeyPath(tenantIdentifier)
 	if err := writeKeyToFile(keyPath, cp.PrivateKey, overwrite); err != nil {
-		return errors.Errorf("error writing tenant key to %s: %v", keyPath, err)
+		return errors.Wrapf(err, "error writing tenant key to %s", keyPath)
 	}
 	log.Infof(context.Background(), "generated tenant key: %s", keyPath)
 	return nil

--- a/pkg/security/pem.go
+++ b/pkg/security/pem.go
@@ -38,7 +38,7 @@ func WritePEMToFile(path string, mode os.FileMode, overwrite bool, blocks ...*pe
 
 	for _, p := range blocks {
 		if err := pem.Encode(f, p); err != nil {
-			return errors.Errorf("could not encode PEM block: %v", err)
+			return errors.Wrap(err, "could not encode PEM block")
 		}
 	}
 

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -1500,8 +1500,12 @@ func (s *adminServer) getUIData(
 		query.Append("$", tree.NewDString(makeUIKey(userName, key)))
 	}
 	query.Append(");")
-	if err := query.Errors(); err != nil {
-		return nil, errors.Errorf("error constructing query: %v", err)
+	if errs := query.Errors(); len(errs) > 0 {
+		var err error
+		for _, e := range errs {
+			err = errors.CombineErrors(err, e)
+		}
+		return nil, errors.Wrap(err, "error constructing query")
 	}
 	it, err := s.server.sqlServer.internalExecutor.QueryIteratorEx(
 		ctx, "admin-getUIData", nil, /* txn */

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1238,13 +1238,13 @@ func (n *Node) GossipSubscription(
 				// or system tenant-specific information to leak.
 				var ents config.SystemConfigEntries
 				if err := content.GetProto(&ents); err != nil {
-					return roachpb.Value{}, errors.Errorf("could not unmarshal system config: %v", err)
+					return roachpb.Value{}, errors.Wrap(err, "could not unmarshal system config")
 				}
 
 				var newContent roachpb.Value
 				newEnts := kvtenant.GossipSubscriptionSystemConfigMask.Apply(ents)
 				if err := newContent.SetProto(&newEnts); err != nil {
-					return roachpb.Value{}, errors.Errorf("could not marshal system config: %v", err)
+					return roachpb.Value{}, errors.Wrap(err, "could not marshal system config")
 				}
 				return newContent, nil
 			default:

--- a/pkg/server/tracedumper/tracedumper.go
+++ b/pkg/server/tracedumper/tracedumper.go
@@ -89,12 +89,12 @@ func (t *TraceDumper) Dump(
 		z := zipper.MakeInternalExecutorInflightTraceZipper(ie)
 		zipBytes, err := z.Zip(ctx, traceID)
 		if err != nil {
-			return errors.Newf("failed to collect inflight trace zip: %v", err)
+			return errors.Wrap(err, "failed to collect inflight trace zip")
 		}
 		path := t.store.GetFullPath(traceZipFile)
 		f, err := os.Create(path)
 		if err != nil {
-			return errors.Newf("error creating file %q for trace dump: %v", path, err)
+			return errors.Wrapf(err, "error creating file %q for trace dump", path)
 		}
 		defer f.Close()
 		_, err = f.Write(zipBytes)

--- a/pkg/sql/catalog/tabledesc/validate.go
+++ b/pkg/sql/catalog/tabledesc/validate.go
@@ -11,7 +11,6 @@
 package tabledesc
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -672,7 +671,7 @@ func (desc *wrapper) validateColumns(
 		columnNames[column.GetName()] = column.GetID()
 
 		if other, ok := columnIDs[column.GetID()]; ok {
-			return fmt.Errorf("column %q duplicate ID of column %q: %d",
+			return errors.Newf("column %q duplicate ID of column %q: %d",
 				column.GetName(), other.Name, column.GetID())
 		}
 		columnIDs[column.GetID()] = column.ColumnDesc()
@@ -693,15 +692,15 @@ func (desc *wrapper) validateColumns(
 				return err
 			}
 			if !valid {
-				return fmt.Errorf("computed column %q refers to unknown columns in expression: %s",
+				return errors.Newf("computed column %q refers to unknown columns in expression: %s",
 					column.GetName(), column.GetComputeExpr())
 			}
 		} else if column.IsVirtual() {
-			return fmt.Errorf("virtual column %q is not computed", column.GetName())
+			return errors.Newf("virtual column %q is not computed", column.GetName())
 		}
 
 		if column.IsHidden() && column.IsInaccessible() {
-			return fmt.Errorf("column %q cannot be hidden and inaccessible", column.GetName())
+			return errors.Newf("column %q cannot be hidden and inaccessible", column.GetName())
 		}
 	}
 	return nil
@@ -711,10 +710,10 @@ func (desc *wrapper) validateColumnFamilies(
 	columnIDs map[descpb.ColumnID]*descpb.ColumnDescriptor,
 ) error {
 	if len(desc.Families) < 1 {
-		return fmt.Errorf("at least 1 column family must be specified")
+		return errors.Newf("at least 1 column family must be specified")
 	}
 	if desc.Families[0].ID != descpb.FamilyID(0) {
-		return fmt.Errorf("the 0th family must have ID 0")
+		return errors.Newf("the 0th family must have ID 0")
 	}
 
 	familyNames := map[string]struct{}{}
@@ -736,43 +735,43 @@ func (desc *wrapper) validateColumnFamilies(
 		}
 
 		if _, ok := familyNames[family.Name]; ok {
-			return fmt.Errorf("duplicate family name: %q", family.Name)
+			return errors.Newf("duplicate family name: %q", family.Name)
 		}
 		familyNames[family.Name] = struct{}{}
 
 		if other, ok := familyIDs[family.ID]; ok {
-			return fmt.Errorf("family %q duplicate ID of family %q: %d",
+			return errors.Newf("family %q duplicate ID of family %q: %d",
 				family.Name, other, family.ID)
 		}
 		familyIDs[family.ID] = family.Name
 
 		if family.ID >= desc.NextFamilyID {
-			return fmt.Errorf("family %q invalid family ID (%d) > next family ID (%d)",
+			return errors.Newf("family %q invalid family ID (%d) > next family ID (%d)",
 				family.Name, family.ID, desc.NextFamilyID)
 		}
 
 		if len(family.ColumnIDs) != len(family.ColumnNames) {
-			return fmt.Errorf("mismatched column ID size (%d) and name size (%d)",
+			return errors.Newf("mismatched column ID size (%d) and name size (%d)",
 				len(family.ColumnIDs), len(family.ColumnNames))
 		}
 
 		for i, colID := range family.ColumnIDs {
 			col, ok := columnIDs[colID]
 			if !ok {
-				return fmt.Errorf("family %q contains unknown column \"%d\"", family.Name, colID)
+				return errors.Newf("family %q contains unknown column \"%d\"", family.Name, colID)
 			}
 			if col.Name != family.ColumnNames[i] {
-				return fmt.Errorf("family %q column %d should have name %q, but found name %q",
+				return errors.Newf("family %q column %d should have name %q, but found name %q",
 					family.Name, colID, col.Name, family.ColumnNames[i])
 			}
 			if col.Virtual {
-				return fmt.Errorf("virtual computed column %q cannot be part of a family", col.Name)
+				return errors.Newf("virtual computed column %q cannot be part of a family", col.Name)
 			}
 		}
 
 		for _, colID := range family.ColumnIDs {
 			if famID, ok := colIDToFamilyID[colID]; ok {
-				return fmt.Errorf("column %d is in both family %d and %d", colID, famID, family.ID)
+				return errors.Newf("column %d is in both family %d and %d", colID, famID, family.ID)
 			}
 			colIDToFamilyID[colID] = family.ID
 		}
@@ -780,7 +779,7 @@ func (desc *wrapper) validateColumnFamilies(
 	for colID, colDesc := range columnIDs {
 		if !colDesc.Virtual {
 			if _, ok := colIDToFamilyID[colID]; !ok {
-				return fmt.Errorf("column %q is not in any column family", colDesc.Name)
+				return errors.Newf("column %q is not in any column family", colDesc.Name)
 			}
 		}
 	}
@@ -798,7 +797,7 @@ func (desc *wrapper) validateCheckConstraints(
 		for _, colID := range chk.ColumnIDs {
 			_, ok := columnIDs[colID]
 			if !ok {
-				return fmt.Errorf("check constraint %q contains unknown column \"%d\"", chk.Name, colID)
+				return errors.Newf("check constraint %q contains unknown column \"%d\"", chk.Name, colID)
 			}
 		}
 
@@ -812,7 +811,7 @@ func (desc *wrapper) validateCheckConstraints(
 			return err
 		}
 		if !valid {
-			return fmt.Errorf("check constraint %q refers to unknown columns in expression: %s",
+			return errors.Newf("check constraint %q refers to unknown columns in expression: %s",
 				chk.Name, chk.Expr)
 		}
 	}
@@ -832,7 +831,7 @@ func (desc *wrapper) validateUniqueWithoutIndexConstraints(
 
 		// Verify that the table ID is valid.
 		if c.TableID != desc.ID {
-			return fmt.Errorf(
+			return errors.Newf(
 				"TableID mismatch for unique without index constraint %q: \"%d\" doesn't match descriptor: \"%d\"",
 				c.Name, c.TableID, desc.ID,
 			)
@@ -843,12 +842,12 @@ func (desc *wrapper) validateUniqueWithoutIndexConstraints(
 		for _, colID := range c.ColumnIDs {
 			_, ok := columnIDs[colID]
 			if !ok {
-				return fmt.Errorf(
+				return errors.Newf(
 					"unique without index constraint %q contains unknown column \"%d\"", c.Name, colID,
 				)
 			}
 			if seen.Contains(int(colID)) {
-				return fmt.Errorf(
+				return errors.Newf(
 					"unique without index constraint %q contains duplicate column \"%d\"", c.Name, colID,
 				)
 			}
@@ -865,7 +864,7 @@ func (desc *wrapper) validateUniqueWithoutIndexConstraints(
 				return err
 			}
 			if !valid {
-				return fmt.Errorf(
+				return errors.Newf(
 					"partial unique without index constraint %q refers to unknown columns in predicate: %s",
 					c.Name,
 					c.Predicate,
@@ -895,7 +894,7 @@ func (desc *wrapper) validateTableIndexes(columnNames map[string]descpb.ColumnID
 	// Verify that the primary index columns are not virtual.
 	for _, pkID := range desc.PrimaryIndex.KeyColumnIDs {
 		if col := columnsByID[pkID]; col != nil && col.IsVirtual() {
-			return fmt.Errorf("primary index column %q cannot be virtual", col.GetName())
+			return errors.Newf("primary index column %q cannot be virtual", col.GetName())
 		}
 	}
 
@@ -906,60 +905,60 @@ func (desc *wrapper) validateTableIndexes(columnNames map[string]descpb.ColumnID
 			return err
 		}
 		if idx.GetID() == 0 {
-			return fmt.Errorf("invalid index ID %d", idx.GetID())
+			return errors.Newf("invalid index ID %d", idx.GetID())
 		}
 
 		if _, indexNameExists := indexNames[idx.GetName()]; indexNameExists {
 			for i := range desc.Indexes {
 				if desc.Indexes[i].Name == idx.GetName() {
 					// This error should be caught in MakeIndexDescriptor or NewTableDesc.
-					return errors.HandleAsAssertionFailure(fmt.Errorf("duplicate index name: %q", idx.GetName()))
+					return errors.HandleAsAssertionFailure(errors.Newf("duplicate index name: %q", idx.GetName()))
 				}
 			}
 			// This error should be caught in MakeIndexDescriptor.
-			return errors.HandleAsAssertionFailure(fmt.Errorf(
+			return errors.HandleAsAssertionFailure(errors.Newf(
 				"duplicate: index %q in the middle of being added, not yet public", idx.GetName()))
 		}
 		indexNames[idx.GetName()] = struct{}{}
 
 		if other, ok := indexIDs[idx.GetID()]; ok {
-			return fmt.Errorf("index %q duplicate ID of index %q: %d",
+			return errors.Newf("index %q duplicate ID of index %q: %d",
 				idx.GetName(), other, idx.GetID())
 		}
 		indexIDs[idx.GetID()] = idx.GetName()
 
 		if idx.GetID() >= desc.NextIndexID {
-			return fmt.Errorf("index %q invalid index ID (%d) > next index ID (%d)",
+			return errors.Newf("index %q invalid index ID (%d) > next index ID (%d)",
 				idx.GetName(), idx.GetID(), desc.NextIndexID)
 		}
 
 		if len(idx.IndexDesc().KeyColumnIDs) != len(idx.IndexDesc().KeyColumnNames) {
-			return fmt.Errorf("mismatched column IDs (%d) and names (%d)",
+			return errors.Newf("mismatched column IDs (%d) and names (%d)",
 				len(idx.IndexDesc().KeyColumnIDs), len(idx.IndexDesc().KeyColumnNames))
 		}
 		if len(idx.IndexDesc().KeyColumnIDs) != len(idx.IndexDesc().KeyColumnDirections) {
-			return fmt.Errorf("mismatched column IDs (%d) and directions (%d)",
+			return errors.Newf("mismatched column IDs (%d) and directions (%d)",
 				len(idx.IndexDesc().KeyColumnIDs), len(idx.IndexDesc().KeyColumnDirections))
 		}
 		// In the old STORING encoding, stored columns are in ExtraColumnIDs;
 		// tolerate a longer list of column names.
 		if len(idx.IndexDesc().StoreColumnIDs) > len(idx.IndexDesc().StoreColumnNames) {
-			return fmt.Errorf("mismatched STORING column IDs (%d) and names (%d)",
+			return errors.Newf("mismatched STORING column IDs (%d) and names (%d)",
 				len(idx.IndexDesc().StoreColumnIDs), len(idx.IndexDesc().StoreColumnNames))
 		}
 
 		if len(idx.IndexDesc().KeyColumnIDs) == 0 {
-			return fmt.Errorf("index %q must contain at least 1 column", idx.GetName())
+			return errors.Newf("index %q must contain at least 1 column", idx.GetName())
 		}
 
 		var validateIndexDup catalog.TableColSet
 		for i, name := range idx.IndexDesc().KeyColumnNames {
 			colID, ok := columnNames[name]
 			if !ok {
-				return fmt.Errorf("index %q contains unknown column %q", idx.GetName(), name)
+				return errors.Newf("index %q contains unknown column %q", idx.GetName(), name)
 			}
 			if colID != idx.IndexDesc().KeyColumnIDs[i] {
-				return fmt.Errorf("index %q column %q should have ID %d, but found ID %d",
+				return errors.Newf("index %q column %q should have ID %d, but found ID %d",
 					idx.GetName(), name, colID, idx.IndexDesc().KeyColumnIDs[i])
 			}
 			if validateIndexDup.Contains(colID) {
@@ -972,7 +971,7 @@ func (desc *wrapper) validateTableIndexes(columnNames map[string]descpb.ColumnID
 				return err
 			}
 			if _, exists := columnNames[idx.GetSharded().Name]; !exists {
-				return fmt.Errorf("index %q refers to non-existent shard column %q",
+				return errors.Newf("index %q refers to non-existent shard column %q",
 					idx.GetName(), idx.GetSharded().Name)
 			}
 		}
@@ -986,19 +985,19 @@ func (desc *wrapper) validateTableIndexes(columnNames map[string]descpb.ColumnID
 				return err
 			}
 			if !valid {
-				return fmt.Errorf("partial index %q refers to unknown columns in predicate: %s",
+				return errors.Newf("partial index %q refers to unknown columns in predicate: %s",
 					idx.GetName(), idx.GetPredicate())
 			}
 		}
 		// Ensure that indexes do not STORE virtual columns.
 		for _, colID := range idx.IndexDesc().KeySuffixColumnIDs {
 			if col := columnsByID[colID]; col != nil && col.IsVirtual() {
-				return fmt.Errorf("index %q cannot store virtual column %d", idx.GetName(), col)
+				return errors.Newf("index %q cannot store virtual column %d", idx.GetName(), col)
 			}
 		}
 		for i, colID := range idx.IndexDesc().StoreColumnIDs {
 			if col := columnsByID[colID]; col != nil && col.IsVirtual() {
-				return fmt.Errorf("index %q cannot store virtual column %q",
+				return errors.Newf("index %q cannot store virtual column %q",
 					idx.GetName(), idx.IndexDesc().StoreColumnNames[i])
 			}
 		}
@@ -1128,10 +1127,10 @@ func (desc *wrapper) validatePartitioningDescriptor(
 	}
 
 	if part.NumLists() == 0 && part.NumRanges() == 0 {
-		return fmt.Errorf("at least one of LIST or RANGE partitioning must be used")
+		return errors.Newf("at least one of LIST or RANGE partitioning must be used")
 	}
 	if part.NumLists() > 0 && part.NumRanges() > 0 {
-		return fmt.Errorf("only one LIST or RANGE partitioning may used")
+		return errors.Newf("only one LIST or RANGE partitioning may used")
 	}
 
 	// Do not validate partitions which use unhydrated user-defined types.
@@ -1157,11 +1156,11 @@ func (desc *wrapper) validatePartitioningDescriptor(
 
 	checkName := func(name string) error {
 		if len(name) == 0 {
-			return fmt.Errorf("PARTITION name must be non-empty")
+			return errors.Newf("PARTITION name must be non-empty")
 		}
 		if indexName, exists := partitionNames[name]; exists {
 			if indexName == idx.GetName() {
-				return fmt.Errorf("PARTITION %s: name must be unique (used twice in index %q)",
+				return errors.Newf("PARTITION %s: name must be unique (used twice in index %q)",
 					name, indexName)
 			}
 		}
@@ -1182,7 +1181,7 @@ func (desc *wrapper) validatePartitioningDescriptor(
 			}
 
 			if len(values) == 0 {
-				return fmt.Errorf("PARTITION %s: must contain values", name)
+				return errors.Newf("PARTITION %s: must contain values", name)
 			}
 			// NB: key encoding is used to check uniqueness because it has
 			// to match the behavior of the value when indexed.
@@ -1190,10 +1189,10 @@ func (desc *wrapper) validatePartitioningDescriptor(
 				tuple, keyPrefix, err := rowenc.DecodePartitionTuple(
 					a, codec, desc, idx, part, valueEncBuf, fakePrefixDatums)
 				if err != nil {
-					return fmt.Errorf("PARTITION %s: %v", name, err)
+					return errors.Wrapf(err, "PARTITION %s", name)
 				}
 				if _, exists := listValues[string(keyPrefix)]; exists {
-					return fmt.Errorf("%s cannot be present in more than one partition", tuple)
+					return errors.Newf("%s cannot be present in more than one partition", tuple)
 				}
 				listValues[string(keyPrefix)] = struct{}{}
 			}
@@ -1220,23 +1219,23 @@ func (desc *wrapper) validatePartitioningDescriptor(
 			fromDatums, fromKey, err := rowenc.DecodePartitionTuple(
 				a, codec, desc, idx, part, from, fakePrefixDatums)
 			if err != nil {
-				return fmt.Errorf("PARTITION %s: %v", name, err)
+				return errors.Wrapf(err, "PARTITION %s", name)
 			}
 			toDatums, toKey, err := rowenc.DecodePartitionTuple(
 				a, codec, desc, idx, part, to, fakePrefixDatums)
 			if err != nil {
-				return fmt.Errorf("PARTITION %s: %v", name, err)
+				return errors.Wrapf(err, "PARTITION %s", name)
 			}
 			pi := partitionInterval{name, fromKey, toKey}
 			if overlaps := tree.Get(pi.Range()); len(overlaps) > 0 {
-				return fmt.Errorf("partitions %s and %s overlap",
+				return errors.Newf("partitions %s and %s overlap",
 					overlaps[0].(partitionInterval).name, name)
 			}
 			if err := tree.Insert(pi, false /* fast */); errors.Is(err, interval.ErrEmptyRange) {
-				return fmt.Errorf("PARTITION %s: empty range: lower bound %s is equal to upper bound %s",
+				return errors.Newf("PARTITION %s: empty range: lower bound %s is equal to upper bound %s",
 					name, fromDatums, toDatums)
 			} else if errors.Is(err, interval.ErrInvertedRange) {
-				return fmt.Errorf("PARTITION %s: empty range: lower bound %s is greater than upper bound %s",
+				return errors.Newf("PARTITION %s: empty range: lower bound %s is greater than upper bound %s",
 					name, fromDatums, toDatums)
 			} else if err != nil {
 				return errors.Wrapf(err, "PARTITION %s", name)

--- a/pkg/sql/gcjob/index_garbage_collection.go
+++ b/pkg/sql/gcjob/index_garbage_collection.go
@@ -111,11 +111,11 @@ func clearIndex(
 	sp := tableDesc.IndexSpan(execCfg.Codec, indexID)
 	start, err := keys.Addr(sp.Key)
 	if err != nil {
-		return errors.Errorf("failed to addr index start: %v", err)
+		return errors.Wrap(err, "failed to addr index start")
 	}
 	end, err := keys.Addr(sp.EndKey)
 	if err != nil {
-		return errors.Errorf("failed to addr index end: %v", err)
+		return errors.Wrap(err, "failed to addr index end")
 	}
 	rSpan := roachpb.RSpan{Key: start, EndKey: end}
 	return clearSpanData(ctx, execCfg.DB, execCfg.DistSender, rSpan)

--- a/pkg/sql/sqlliveness/slinstance/slinstance.go
+++ b/pkg/sql/sqlliveness/slinstance/slinstance.go
@@ -156,7 +156,7 @@ func (l *Instance) createSession(ctx context.Context) (*session, error) {
 				break
 			}
 			if everySecond.ShouldLog() {
-				log.Errorf(ctx, "failed to create a session at %d-th attempt: %v", i, err.Error())
+				log.Errorf(ctx, "failed to create a session at %d-th attempt: %v", i, err)
 			}
 			continue
 		}

--- a/pkg/storage/pebble_merge.go
+++ b/pkg/storage/pebble_merge.go
@@ -202,7 +202,7 @@ func (t *MVCCValueMerger) ensureOrder(oldToNew bool) {
 
 func (t *MVCCValueMerger) deserializeMVCCValueAndAppend(value []byte) error {
 	if err := protoutil.Unmarshal(value, &t.meta); err != nil {
-		return errors.Errorf("corrupted operand value: %v", err)
+		return errors.Wrap(err, "corrupted operand value")
 	}
 	if len(t.meta.RawBytes) < mvccHeaderSize {
 		return errors.Errorf("operand value too short")
@@ -214,7 +214,7 @@ func (t *MVCCValueMerger) deserializeMVCCValueAndAppend(value []byte) error {
 		t.timeSeriesOps = append(t.timeSeriesOps, roachpb.InternalTimeSeriesData{})
 		ts := &t.timeSeriesOps[len(t.timeSeriesOps)-1]
 		if err := protoutil.Unmarshal(t.meta.RawBytes[mvccHeaderSize:], ts); err != nil {
-			return errors.Errorf("corrupted timeseries: %v", err)
+			return errors.Wrap(err, "corrupted timeseries")
 		}
 	} else {
 		if t.timeSeriesOps != nil {


### PR DESCRIPTION
This is an omnibus PR touching code by multiple teams. To be reviewed as follows:

- [x] @adityamaru for the trace dumper changes
- [x] @JeffSwenson @cockroachdb/sqlproxy-prs for the sql proxy code
- [x] @jbowens @cockroachdb/storage for the pebble changes
- [x] @mberhault @cockroachdb/storage  for the store encryption code
- [x] @miretskiy for the doctor changes
- [x] @nvanbenschoten @cockroachdb/kv for the KV changes
- [x] @otan @cockroachdb/sql-experience for the GEO changes
- [x] @postamar @cockroachdb/sql-schema  for the SQL catalog, index GC and SQL liveness changes
- [x] @cockroachdb/server-prs for the changes to the "security" and "server" packages

 See the description below for an explanation.


---

When constructing an error from another error, it is generally
erroneous to use `Errorf("...%v", err)`: this deconstructs the
original error back to a simple string and loses all its details.

It also makes the original error opaque to redactability, to be
considered an unsafe string, even if the original error already
contained a mix of safe and unsafe strings.

The proper approach is to use `errors.Wrap` / `errors.Wrapf`.
This preserves any embedded details inside the error object and its
redactability attributes.

This change was obtained by running the following command and fixing
up the results (i.e. test code was ignored):

```
git grep -E '(errors|fmt)\.(Errorf|Newf).*%v.*[eE]rr'|grep -v _test.go
```

Release note: None