### PR TITLE
sql: add descriptions of jobs that are created during DROP CASCADE

### DIFF
--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -575,8 +575,17 @@ func (p *planner) removeFKForBackReference(
 	if err := removeFKForBackReferenceFromTable(originTableDesc, ref, tableDesc); err != nil {
 		return err
 	}
-	// No job description, since this is presumably part of some larger schema change.
-	return p.writeSchemaChange(ctx, originTableDesc, descpb.InvalidMutationID, "")
+	thisTableName, err := p.getQualifiedTableName(ctx, tableDesc)
+	if err != nil {
+		return err
+	}
+	originTableName, err := p.getQualifiedTableName(ctx, originTableDesc)
+	if err != nil {
+		return err
+	}
+	jobDesc := fmt.Sprintf("removing inbound FK %s from table %s referenced by table %s",
+		ref.Name, thisTableName.FQString(), originTableName.FQString())
+	return p.writeSchemaChange(ctx, originTableDesc, descpb.InvalidMutationID, jobDesc)
 }
 
 // removeFKBackReferenceFromTable edits the supplied originTableDesc to
@@ -633,8 +642,17 @@ func (p *planner) removeFKBackReference(
 	if err := removeFKBackReferenceFromTable(referencedTableDesc, ref.Name, tableDesc); err != nil {
 		return err
 	}
-	// No job description, since this is presumably part of some larger schema change.
-	return p.writeSchemaChange(ctx, referencedTableDesc, descpb.InvalidMutationID, "")
+	thisTableName, err := p.getQualifiedTableName(ctx, tableDesc)
+	if err != nil {
+		return err
+	}
+	referencedTableName, err := p.getQualifiedTableName(ctx, referencedTableDesc)
+	if err != nil {
+		return err
+	}
+	jobDesc := fmt.Sprintf("removing outbound FK %s from table %s referencing table %s",
+		ref.Name, thisTableName.FQString(), referencedTableName.FQString())
+	return p.writeSchemaChange(ctx, referencedTableDesc, descpb.InvalidMutationID, jobDesc)
 }
 
 // removeFKBackReferenceFromTable edits the supplied referencedTableDesc to

--- a/pkg/sql/drop_test.go
+++ b/pkg/sql/drop_test.go
@@ -1380,7 +1380,7 @@ CREATE TABLE t.child(k INT PRIMARY KEY REFERENCES t.parent);
 	// for updating the referenced table has an empty description.
 	testutils.SucceedsSoon(t, func() error {
 		var count int
-		sqlRun.QueryRow(t, `SELECT count(*) FROM [SHOW JOBS] WHERE description = 'GC for ' AND status = 'succeeded'`).Scan(&count)
+		sqlRun.QueryRow(t, `SELECT count(*) FROM [SHOW JOBS] WHERE description LIKE 'removing outbound FK %' AND status = 'succeeded'`).Scan(&count)
 		if count != 1 {
 			return errors.Newf("expected 1 result, got %d", count)
 		}
@@ -1458,4 +1458,41 @@ func TestDropPhysicalTableGC(t *testing.T) {
 			require.Zerof(t, actualZoneConfigs, "Zone config for '%s' was not deleted as expected.", table.name)
 		}
 	}
+}
+
+// TestDescriptionInDropCascade tests for a description message to be not empty for jobs
+// that are created while removing a foreign key in DROP DATABASE CASCADE.
+func TestDescriptionInDropCascade(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	tdb := sqlutils.MakeSQLRunner(sqlDB)
+	defer s.Stopper().Stop(context.Background())
+
+	// Create a child_child table to have FK inbound to child table.
+	tdb.Exec(t, `
+CREATE DATABASE t;
+CREATE TABLE t.parent (a INT PRIMARY KEY);
+CREATE TABLE t.child (
+  b INT PRIMARY KEY,
+  CONSTRAINT fk_b_a FOREIGN KEY (b) REFERENCES t.parent (a)
+);
+CREATE TABLE t.child_child (
+  c INT PRIMARY KEY,
+  CONSTRAINT fk_c_b FOREIGN KEY (c) REFERENCES t.child (b)
+);
+DROP DATABASE t CASCADE`)
+
+	query := `
+SELECT count(*) FROM [SHOW JOBS]
+WHERE job_type = 'SCHEMA CHANGE GC'
+  AND description LIKE '% removing outbound FK fk_b_a %'`
+	tdb.CheckQueryResults(t, query, [][]string{{"1"}})
+
+	query = `
+SELECT count(*) FROM [SHOW JOBS]
+WHERE job_type = 'SCHEMA CHANGE GC'
+  AND description LIKE '% removing inbound FK fk_c_b %'`
+	tdb.CheckQueryResults(t, query, [][]string{{"1"}})
 }


### PR DESCRIPTION
Previously, job descriptions were empty for the jobs that were
created while removing foreign keys in DROP CASCADE. This commit
adds job descriptions.

Release justification: fixes a bug

Release note: None

Fixes: #59221