### PR TITLE
streamingccl: fix flaky frontier processor test

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_test.go
@@ -110,7 +110,7 @@ func (m *mockStreamClient) ConsumePartition(
 		}
 	}()
 
-	return eventCh, nil, nil
+	return eventCh, errCh, nil
 }
 
 // RegisterInterception implements the InterceptableStreamClient interface.


### PR DESCRIPTION
Currently, TestStreamIngestionFrontierProcessor fails under `make stressrace` due to a leaked goroutine from `stream_ingestion_frontier_processor_test.go`. This commit fixes a blocking write operation so that the goroutine is guaranteed to exit.

Informs: #68704

Release note: None