### PR TITLE
sql: prevent internal error when altering database placement

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_database_placement
+++ b/pkg/sql/logictest/testdata/logic_test/alter_database_placement
@@ -1,0 +1,8 @@
+statement ok
+CREATE DATABASE d;
+
+statement error altering database placement is not yet supported
+ALTER DATABASE d SET PLACEMENT DEFAULT
+
+statement error altering database placement is not yet supported
+ALTER DATABASE d SET PLACEMENT RESTRICTED

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -339,6 +339,9 @@ func (b *Builder) buildStmt(
 	case *tree.Export:
 		return b.buildExport(stmt, inScope)
 
+	case *tree.AlterDatabasePlacement:
+		panic(pgerror.New(pgcode.FeatureNotSupported, "altering database placement is not yet supported"))
+
 	default:
 		// See if this statement can be rewritten to another statement using the
 		// delegate functionality.


### PR DESCRIPTION
The parser was updated in #68068 to support a new syntax for altering
database placement:

    ALTER DATABASE d SET PLACEMENT DEFAULT
    ALTER DATABASE d SET PLACEMENT RESTRICTED

Running these statements causes internal errors because there is no
execution support for them yet. This commit prevents an internal error
when they are executed, and returns a user-friendly error instead.

Informs #65475

Release note: None