### PR TITLE
release-21.1: sql: do not ignore unique partial predicate in ALTER TABLE

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -248,6 +248,15 @@ func (n *alterTableNode) startExec(params runParams) error {
 					return err
 				}
 
+				if d.Predicate != nil {
+					idxValidator := schemaexpr.MakeIndexPredicateValidator(params.ctx, *tn, n.tableDesc, &params.p.semaCtx)
+					expr, err := idxValidator.Validate(d.Predicate)
+					if err != nil {
+						return err
+					}
+					idx.Predicate = expr
+				}
+
 				var err error
 				idx, err = params.p.configureIndexDescForNewIndexPartitioning(
 					params.ctx,

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -1812,3 +1812,24 @@ CREATE TABLE duplicate_index_test (k INT PRIMARY KEY, v INT, INDEX idx (v));
 
 statement error pgcode 42P07 duplicate index name: \"idx\"
 ALTER TABLE duplicate_index_test ADD CONSTRAINT idx UNIQUE (v)
+
+# Ensure unique constraint partial predicates are not ignored.
+subtest regression_67234
+
+statement ok
+CREATE TABLE t67234 (k INT PRIMARY KEY, a INT, b INT, FAMILY (k, a, b));
+ALTER TABLE t67234 ADD CONSTRAINT t67234_c1 UNIQUE (a) WHERE b > 0;
+ALTER TABLE t67234 ADD CONSTRAINT t67234_c2 UNIQUE WITHOUT INDEX (b) WHERE a > 0
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE t67234]
+----
+CREATE TABLE public.t67234 (
+   k INT8 NOT NULL,
+   a INT8 NULL,
+   b INT8 NULL,
+   CONSTRAINT "primary" PRIMARY KEY (k ASC),
+   UNIQUE INDEX t67234_c1 (a ASC) WHERE b > 0:::INT8,
+   FAMILY fam_0_k_a_b (k, a, b),
+   CONSTRAINT t67234_c2 UNIQUE WITHOUT INDEX (b) WHERE a > 0:::INT8
+)


### PR DESCRIPTION
Backport 1/1 commits from #68629. 

/cc @cockroachdb/release

Release justification: This is a low-risk change to fix an existing feature.

---

Previously, a `WHERE` clause in `ALTER TABLE .. ADD CONSTRAINT .. UNIQUE`
statements was parsed successfully but ignored so that the resulting
unique constraint was not partial. This commit fixes this bug.

Fixes #67234

Release note (bug fix): A bug has been fixed that created non-partial
unique constraints when a user attempted to create a partial unique
constraint in `ALTER TABLE` statements.
