### PR TITLE
builtins: implement a separate session_user() builtin

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -3141,6 +3141,7 @@ special_function ::=
 	| 'LOCALTIME' '(' ')'
 	| 'LOCALTIME' '(' a_expr ')'
 	| 'CURRENT_USER' '(' ')'
+	| 'SESSION_USER' '(' ')'
 	| 'EXTRACT' '(' extract_list ')'
 	| 'EXTRACT_DURATION' '(' extract_list ')'
 	| 'OVERLAY' '(' overlay_list ')'

--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -2876,6 +2876,8 @@ SELECT * FROM crdb_internal.check_consistency(true, ‘\x02’, ‘\x04’)</p>
 </span></td></tr>
 <tr><td><a name="current_user"></a><code>current_user() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the current user. This function is provided for compatibility with PostgreSQL.</p>
 </span></td></tr>
+<tr><td><a name="session_user"></a><code>session_user() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the session user. This function is provided for compatibility with PostgreSQL.</p>
+</span></td></tr>
 <tr><td><a name="version"></a><code>version() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the node’s version of CockroachDB.</p>
 </span></td></tr></tbody>
 </table>

--- a/pkg/sql/logictest/testdata/logic_test/user
+++ b/pkg/sql/logictest/testdata/logic_test/user
@@ -93,10 +93,10 @@ user3     ·        {}
 statement error no username specified
 CREATE USER ""
 
-query TTT
-SELECT current_user, session_user, user
+query TTTTT
+SELECT current_user, current_user(), session_user, session_user(), user
 ----
-root  root  root
+root  root  root  root  root
 
 user testuser
 
@@ -109,10 +109,10 @@ UPSERT INTO system.users VALUES (user1, 'newpassword', false)
 statement error pq: user testuser does not have SELECT privilege on relation user
 SHOW USERS
 
-query TTT
-SELECT current_user, session_user, user
+query TTTTT
+SELECT current_user, current_user(), session_user, session_user(), user
 ----
-testuser  testuser  testuser
+testuser  testuser  testuser  testuser  testuser
 
 statement ok
 SET SESSION AUTHORIZATION DEFAULT

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -11657,6 +11657,11 @@ special_function:
     $$.val = &tree.FuncExpr{Func: tree.WrapFunction($1)}
   }
 | CURRENT_USER '(' error { return helpWithFunctionByName(sqllex, $1) }
+| SESSION_USER '(' ')'
+  {
+    $$.val = &tree.FuncExpr{Func: tree.WrapFunction($1)}
+  }
+| SESSION_USER '(' error { return helpWithFunctionByName(sqllex, $1) }
 | EXTRACT '(' extract_list ')'
   {
     $$.val = &tree.FuncExpr{Func: tree.WrapFunction($1), Exprs: $3.exprs()}

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -4197,6 +4197,23 @@ value if you rely on the HLC for accuracy.`,
 		},
 	),
 
+	"session_user": makeBuiltin(
+		tree.FunctionProperties{Category: categorySystemInfo},
+		tree.Overload{
+			Types:      tree.ArgTypes{},
+			ReturnType: tree.FixedReturnType(types.String),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				if ctx.SessionData.User().Undefined() {
+					return tree.DNull, nil
+				}
+				return tree.NewDString(ctx.SessionData.User().Normalized()), nil
+			},
+			Info: "Returns the session user. This function is provided for " +
+				"compatibility with PostgreSQL.",
+			Volatility: tree.VolatilityStable,
+		},
+	),
+
 	// https://www.postgresql.org/docs/10/functions-info.html#FUNCTIONS-INFO-CATALOG-TABLE
 	"pg_collation_for": makeBuiltin(
 		tree.FunctionProperties{Category: categoryString},


### PR DESCRIPTION
This is needed groundwork to separate current_user and session_user.

Refs: #15005

Release note (sql change): Add a session_user() builtin function, which
currently returns the same thing as current_user() as we do not
implement `SET ROLE`.