### PR TITLE
sql: fix panic using Reset() when using sqlstats iterator

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -298,6 +298,7 @@ ALL_TESTS = [
     "//pkg/sql/sqlliveness/slstorage:slstorage_test",
     "//pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil:sqlstatsutil_test",
     "//pkg/sql/sqlstats/persistedsqlstats:persistedsqlstats_test",
+    "//pkg/sql/sqlstats/sslocal:sslocal_test",
     "//pkg/sql/stats:stats_test",
     "//pkg/sql/stmtdiagnostics:stmtdiagnostics_test",
     "//pkg/sql/tests:tests_test",

--- a/pkg/sql/sqlstats/sslocal/BUILD.bazel
+++ b/pkg/sql/sqlstats/sslocal/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "sslocal",
@@ -28,5 +28,28 @@ go_library(
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
+    ],
+)
+
+go_test(
+    name = "sslocal_test",
+    srcs = [
+        "iterator_test.go",
+        "main_test.go",
+    ],
+    deps = [
+        "//pkg/base",
+        "//pkg/roachpb:with-mocks",
+        "//pkg/security",
+        "//pkg/security/securitytest",
+        "//pkg/server",
+        "//pkg/sql",
+        "//pkg/sql/sqlstats",
+        "//pkg/testutils/serverutils",
+        "//pkg/testutils/sqlutils",
+        "//pkg/testutils/testcluster",
+        "//pkg/util/leaktest",
+        "//pkg/util/log",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/sql/sqlstats/sslocal/iterator_test.go
+++ b/pkg/sql/sqlstats/sslocal/iterator_test.go
@@ -1,0 +1,94 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sslocal_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSQLStatsIteratorWithTelemetryFlush(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	s, goDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+
+	testCases := map[string]string{
+		"SELECT _":    "SELECT 1",
+		"SELECT _, _": "SELECT 1, 1",
+	}
+
+	sqlConn := sqlutils.MakeSQLRunner(goDB)
+
+	for _, stmt := range testCases {
+		sqlConn.Exec(t, stmt)
+	}
+
+	sqlStats := s.SQLServer().(*sql.Server).GetSQLStatsProvider()
+
+	// We collect all the statement fingerprint IDs so that we can test the
+	// transaction stats later.
+	fingerprintIDs := make(map[roachpb.StmtFingerprintID]struct{})
+	require.NoError(t,
+		sqlStats.IterateStatementStats(ctx, &sqlstats.IteratorOptions{},
+			func(_ context.Context, statistics *roachpb.CollectedStatementStatistics) error {
+				fingerprintIDs[statistics.ID] = struct{}{}
+				return nil
+			}))
+
+	t.Run("statement_iterator", func(t *testing.T) {
+		require.NoError(t,
+			sqlStats.IterateStatementStats(
+				ctx,
+				&sqlstats.IteratorOptions{},
+				func(_ context.Context, statistics *roachpb.CollectedStatementStatistics) error {
+					require.NotNil(t, statistics)
+					// If we are running our test case, we reset the SQL Stats. The iterator
+					// should gracefully handle that.
+					if _, ok := testCases[statistics.Key.Query]; ok {
+						require.NoError(t, sqlStats.Reset(ctx))
+					}
+					return nil
+				}))
+	})
+
+	t.Run("transaction_iterator", func(t *testing.T) {
+		for _, stmt := range testCases {
+			sqlConn.Exec(t, stmt)
+		}
+		require.NoError(t,
+			sqlStats.IterateTransactionStats(
+				ctx,
+				&sqlstats.IteratorOptions{},
+				func(ctx context.Context, id roachpb.TransactionFingerprintID, statistics *roachpb.CollectedTransactionStatistics) error {
+					require.NotNil(t, statistics)
+
+					for _, stmtFingerprintID := range statistics.StatementFingerprintIDs {
+						if _, ok := fingerprintIDs[stmtFingerprintID]; ok {
+							require.NoError(t, sqlStats.Reset(ctx))
+						}
+					}
+					return nil
+				}))
+	})
+}

--- a/pkg/sql/sqlstats/sslocal/main_test.go
+++ b/pkg/sql/sqlstats/sslocal/main_test.go
@@ -1,0 +1,29 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sslocal_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+)
+
+func TestMain(m *testing.M) {
+	security.SetAssetLoader(securitytest.EmbeddedAssets)
+	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
+	os.Exit(m.Run())
+}

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_iterator.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_iterator.go
@@ -26,7 +26,8 @@ type baseIterator struct {
 // inside of a ssmemstorage.Container.
 type StmtStatsIterator struct {
 	baseIterator
-	stmtKeys stmtList
+	stmtKeys     stmtList
+	currentValue *roachpb.CollectedStatementStatistics
 }
 
 // NewStmtStatsIterator returns a StmtStatsIterator.
@@ -52,16 +53,14 @@ func NewStmtStatsIterator(
 	}
 }
 
-// Next increments the internal counter of the StmtStatsIterator. It returns
-// true if the following Cur() call is valid, false otherwise.
+// Next updates the current value returned by the subsequent Cur() call. Next()
+// returns true if the following Cur() call is valid, false otherwise.
 func (s *StmtStatsIterator) Next() bool {
 	s.idx++
-	return s.idx < len(s.stmtKeys)
-}
+	if s.idx >= len(s.stmtKeys) {
+		return false
+	}
 
-// Cur returns the roachpb.CollectedStatementStatistics at the current internal
-// counter.
-func (s *StmtStatsIterator) Cur() *roachpb.CollectedStatementStatistics {
 	stmtKey := s.stmtKeys[s.idx]
 
 	stmtFingerprintID := constructStatementFingerprintIDFromStmtKey(stmtKey)
@@ -70,9 +69,9 @@ func (s *StmtStatsIterator) Cur() *roachpb.CollectedStatementStatistics {
 
 	// If the key is not found (and we expected to find it), the table must
 	// have been cleared between now and the time we read all the keys. In
-	// that case we simply skip this key as there are no metrics to report.
+	// that case we simply skip this key and keep advancing the iterator.
 	if statementStats == nil {
-		return nil
+		return s.Next()
 	}
 
 	statementStats.mu.Lock()
@@ -83,7 +82,7 @@ func (s *StmtStatsIterator) Cur() *roachpb.CollectedStatementStatistics {
 	database := statementStats.mu.database
 	statementStats.mu.Unlock()
 
-	collectedStats := roachpb.CollectedStatementStatistics{
+	s.currentValue = &roachpb.CollectedStatementStatistics{
 		Key: roachpb.StatementStatisticsKey{
 			Query:       stmtKey.anonymizedStmt,
 			DistSQL:     distSQLUsed,
@@ -99,14 +98,22 @@ func (s *StmtStatsIterator) Cur() *roachpb.CollectedStatementStatistics {
 		Stats: data,
 	}
 
-	return &collectedStats
+	return true
+}
+
+// Cur returns the roachpb.CollectedStatementStatistics at the current internal
+// counter.
+func (s *StmtStatsIterator) Cur() *roachpb.CollectedStatementStatistics {
+	return s.currentValue
 }
 
 // TxnStatsIterator is an iterator that iterates over the transaction statistics
-// inside of a ssmemstorage.Container.
+// inside a ssmemstorage.Container.
 type TxnStatsIterator struct {
 	baseIterator
-	txnKeys txnList
+	txnKeys  txnList
+	curValue *roachpb.CollectedTransactionStatistics
+	curKey   roachpb.TransactionFingerprintID
 }
 
 // NewTxnStatsIterator returns a new instance of TxnStatsIterator.
@@ -132,11 +139,39 @@ func NewTxnStatsIterator(
 	}
 }
 
-// Next increments the internal counter of the TxnStatsIterator. It returns
-// true if the following Cur() call is valid, false otherwise.
+// Next updates the current value returned by the subsequent Cur() call. Next()
+// returns true if the following Cur() call is valid, false otherwise.
 func (t *TxnStatsIterator) Next() bool {
 	t.idx++
-	return t.idx < len(t.txnKeys)
+	if t.idx >= len(t.txnKeys) {
+		return false
+	}
+
+	txnKey := t.txnKeys[t.idx]
+
+	// We don't want to create the key if it doesn't exist, so it's okay to
+	// pass nil for the statementFingerprintIDs, as they are only set when a key is
+	// constructed.
+	txnStats, _, _ := t.container.getStatsForTxnWithKey(txnKey, nil /* stmtFingerprintIDs */, false /* createIfNonexistent */)
+
+	// If the key is not found (and we expected to find it), the table must
+	// have been cleared between now and the time we read all the keys. In
+	// that case we simply skip this key and advance the iterator.
+	if txnStats == nil {
+		return t.Next()
+	}
+
+	txnStats.mu.Lock()
+	defer txnStats.mu.Unlock()
+
+	t.curKey = txnKey
+	t.curValue = &roachpb.CollectedTransactionStatistics{
+		StatementFingerprintIDs: txnStats.statementFingerprintIDs,
+		App:                     t.container.appName,
+		Stats:                   txnStats.mu.data,
+	}
+
+	return true
 }
 
 // Cur returns the roachpb.CollectedTransactionStatistics at the current internal
@@ -145,25 +180,5 @@ func (t *TxnStatsIterator) Cur() (
 	roachpb.TransactionFingerprintID,
 	*roachpb.CollectedTransactionStatistics,
 ) {
-	txnKey := t.txnKeys[t.idx]
-
-	// We don't want to create the key if it doesn't exist, so it's okay to
-	// pass nil for the statementFingerprintIDs, as they are only set when a key is
-	// constructed.
-	txnStats, _, _ := t.container.getStatsForTxnWithKey(txnKey, nil /* stmtFingerprintIDs */, false /* createIfNonexistent */)
-	// If the key is not found (and we expected to find it), the table must
-	// have been cleared between now and the time we read all the keys. In
-	// that case we simply skip this key as there are no metrics to report.
-	if txnStats == nil {
-		return 0, nil
-	}
-
-	txnStats.mu.Lock()
-	defer txnStats.mu.Unlock()
-	collectedStats := roachpb.CollectedTransactionStatistics{
-		StatementFingerprintIDs: txnStats.statementFingerprintIDs,
-		App:                     t.container.appName,
-		Stats:                   txnStats.mu.data,
-	}
-	return txnKey, &collectedStats
+	return t.curKey, t.curValue
 }


### PR DESCRIPTION
Previously, when if SQLStats.Reset() is called while iterating
through an iterator, this will cause panics since the iterator
will then return a nil pointer.

This commit changed the iterator to gracefully handle this situation
and prevents panic.

Resolves #68785

Release note: None