### PR TITLE
backupccl: fix progress test deadlock

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -1566,7 +1566,7 @@ WHERE
 			allowResponse <- struct{}{}
 		}
 
-		testutils.SucceedsSoon(t, func() error {
+		err := retry.ForDuration(testutils.DefaultSucceedsSoonDuration, func() error {
 			return check(ctx, inProgressState{
 				DB:            conn,
 				backupTableID: backupTableID,
@@ -1582,6 +1582,10 @@ WHERE
 
 		if err := <-jobDone; err != nil {
 			t.Fatalf("%q: %+v", query, err)
+		}
+
+		if err != nil {
+			t.Fatal(err)
 		}
 	}
 


### PR DESCRIPTION
TestBackupRestoreSystemJobsProgress would deadlock when it failed.

Release note: None