### PR TITLE
codeowners: fix sql catch-all rule

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,6 +27,8 @@
 
 /Makefile                    @cockroachdb/dev-inf
 
+/pkg/sql/                    @cockroachdb/sql-queries-noreview
+
 /pkg/sql/opt/                @cockroachdb/sql-opt-prs
 /pkg/sql/stats/              @cockroachdb/sql-opt-prs
 
@@ -206,8 +208,7 @@
 /pkg/scheduledjobs/          @cockroachdb/bulk-prs
 /pkg/security/               @cockroachdb/server-prs
 /pkg/settings/               @cockroachdb/server-prs
-/pkg/sql/                    @cockroachdb/sql-queries-noreview
-/pkg/startupmigrations/      @cockroachdb/sql-queries-noreview
+/pkg/startupmigrations/      @cockroachdb/server-prs @cockroachdb/sql-schema
 /pkg/streaming/              @cockroachdb/bulk-prs
 /pkg/testutils/              @cockroachdb/test-eng
 /pkg/ts/                     @cockroachdb/kv


### PR DESCRIPTION
Previously, there was a rule assigning ownership of `pkg/sql` and all
subdirectories to a -noreview group. This rule was near the bottom of
the CODEOWNERS file and because of "last rule wins" would override any
previous rules.

This commit therefore moves this rule to the top, to serve instead as
a default rule.

This commit also assigns ownership to `pkg/startupmigrations`.

Release note: None