### PR TITLE
bazel: set `--include_source_info` when generating protobuf code

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,6 @@
-build --symlink_prefix=_bazel/ --ui_event_filters=-DEBUG --define gotags=bazel,crdb_test_off,gss
+build --symlink_prefix=_bazel/ --ui_event_filters=-DEBUG --define gotags=bazel,crdb_test_off,gss --experimental_proto_descriptor_sets_include_source_info
 test --config=test
-build:test --symlink_prefix=_bazel/ --define gotags=bazel,crdb_test,gss --test_env=TZ=
+build:test --define gotags=bazel,crdb_test,gss --test_env=TZ=
 query --ui_event_filters=-DEBUG
 
 try-import %workspace%/.bazelrc.user


### PR DESCRIPTION
This flag [instructs Bazel](https://github.com/bazelbuild/rules_proto/issues/56#issuecomment-627860112)
to set a [command-line flag](https://github.com/protocolbuffers/protobuf/issues/7623#issuecomment-644266669)
when invoking `protoc` that causes the generated proto descriptor sets
to contain extra info:

```
  --include_source_info       When using --descriptor_set_out, do not strip
                              SourceCodeInfo from the FileDescriptorProto.
                              This results in vastly larger descriptors that
                              include information about the original
                              location of each decl in the source file as
                              well as surrounding comments.
```

Setting this solves two problems:

1. We need the descriptor sets to have comments for #65814.
2. Without this change, generated `.pb.go` files from the sandbox won't
   contain comments. This makes the files more difficult to read and
   dirties the files in your checkout if you copy those `.pb.go` files
   to your workspace.

Also delete an unnecessary `--symlink_prefix=_bazel/` from the `test`
configuration (it's inherited from the `build` configuration so it's
redundant).

Release note: None