### PR TITLE
kv: deflake and unskip TestMergeQueue/sticky-bit-expiration

### DIFF
--- a/pkg/util/hlc/hlc.go
+++ b/pkg/util/hlc/hlc.go
@@ -172,6 +172,14 @@ func (m *HybridManualClock) Pause() {
 	m.mu.Unlock()
 }
 
+// Resume resumes the hybrid manual clock; the passage of time continues to
+// cause clock to tick.
+func (m *HybridManualClock) Resume() {
+	m.mu.Lock()
+	m.mu.nanosAtPause = 0
+	m.mu.Unlock()
+}
+
 // UnixNano returns the local machine's physical nanosecond
 // unix epoch timestamp as a convenience to create a HLC via
 // c := hlc.NewClock(hlc.UnixNano, ...).

--- a/pkg/util/hlc/hlc_test.go
+++ b/pkg/util/hlc/hlc_test.go
@@ -373,9 +373,10 @@ func TestHybridManualClock(t *testing.T) {
 	require.LessOrEqual(t, c.Now().WallTime, UnixNano())
 	require.LessOrEqual(t, UnixNano(), c.Now().WallTime)
 
-	m.Increment(10)
-	require.LessOrEqual(t, c.Now().WallTime, UnixNano()+10)
-	require.LessOrEqual(t, UnixNano()+10, c.Now().WallTime)
+	inc := time.Second.Nanoseconds()
+	m.Increment(inc)
+	require.LessOrEqual(t, c.Now().WallTime, UnixNano()+inc)
+	require.LessOrEqual(t, UnixNano()+inc, c.Now().WallTime)
 }
 
 // TestHybridManualClockPause test the Pause() functionality of the
@@ -391,8 +392,14 @@ func TestHybridManualClockPause(t *testing.T) {
 	require.Equal(t, now, c.Now().WallTime)
 	time.Sleep(10 * time.Millisecond)
 	require.Equal(t, now, c.Now().WallTime)
-	m.Increment(10)
-	require.Equal(t, now+10, c.Now().WallTime)
+	inc := time.Second.Nanoseconds()
+	m.Increment(inc)
+	require.Equal(t, now+inc, c.Now().WallTime)
+	m.Resume()
+	trueNow := UnixNano()
+	require.LessOrEqual(t, trueNow+inc, c.Now().WallTime)
+	time.Sleep(10 * time.Millisecond)
+	require.Less(t, trueNow+inc, c.Now().WallTime)
 }
 
 func TestHLCMonotonicityCheck(t *testing.T) {


### PR DESCRIPTION
Fixes #66942.

This was broken by 78078b8, which switched the test from using a `ManualClock` to using a `HybridManualClock`.