### PR TITLE
release-21.1: roachtest: fix apt-get upgrade in Jepsen tests

### DIFF
--- a/pkg/cmd/roachtest/jepsen.go
+++ b/pkg/cmd/roachtest/jepsen.go
@@ -85,7 +85,7 @@ func initJepsen(ctx context.Context, t *test, c *cluster) {
 	// TODO(bdarnell): Create a new base image with the packages we need
 	// instead of installing them on every run.
 	c.Run(ctx, c.All(), "sh", "-c", `"sudo apt-get -y update > logs/apt-upgrade.log 2>&1"`)
-	c.Run(ctx, c.All(), "sh", "-c", `"sudo apt-get -y upgrade -o Dpkg::Options::='--force-confold' > logs/apt-upgrade.log 2>&1"`)
+	c.Run(ctx, c.All(), "sh", "-c", `"sudo DEBIAN_FRONTEND=noninteractive apt-get -y upgrade -o Dpkg::Options::='--force-confold' -o DPkg::options::='--force-confdef' > logs/apt-upgrade.log 2>&1"`)
 
 	// Install the binary on all nodes and package it as jepsen expects.
 	// TODO(bdarnell): copying the raw binary and compressing it on the
@@ -101,7 +101,7 @@ func initJepsen(ctx context.Context, t *test, c *cluster) {
 	// Install Jepsen's prereqs on the controller.
 	if out, err := c.RunWithBuffer(
 		ctx, t.l, controller, "sh", "-c",
-		`"sudo apt-get -qqy install openjdk-8-jre openjdk-8-jre-headless libjna-java gnuplot > /dev/null 2>&1"`,
+		`"sudo DEBIAN_FRONTEND=noninteractive apt-get -qqy install openjdk-8-jre openjdk-8-jre-headless libjna-java gnuplot > /dev/null 2>&1"`,
 	); err != nil {
 		if strings.Contains(string(out), "exit status 100") {
 			t.Skip("apt-get failure (#31944)", string(out))


### PR DESCRIPTION
Backport 1/1 commits from #68794.

Release justification: test fix.

/cc @cockroachdb/release

---

An `apt-get upgrade` command blocked on:

```
Setting up openssh-server (1:8.2p1-4ubuntu0.3) ...
debconf: unable to initialize frontend: Dialog
debconf: (Dialog frontend will not work on a dumb terminal, an emacs shell buffer, or without a controlling terminal.)
debconf: falling back to frontend: Readline
Configuring openssh-server
--------------------------

A new version (/tmp/fileMcydAr) of configuration file /etc/ssh/sshd_config is
available, but the version installed currently has been locally modified.

  1. install the package maintainer's version
  2. keep the local version currently installed
  3. show the differences between the versions
  4. show a side-by-side difference between the versions
  5. show a 3-way difference between available versions
  6. do a 3-way merge between available versions
  7. start a new shell to examine the situation

What do you want to do about modified configuration file sshd_config?
```

This patch sets `DEBIAN_FRONTEND=noninteractive` to avoid this.

Resolves #68783.
Resolves #68782.
Resolves #68781.
Resolves #68780.
Resolves #68779.
Resolves #68778.
Resolves #68777.
Resolves #68776.
Resolves #68775.
Resolves #68774.
Resolves #68773.
Resolves #68772.
Resolves #68771.
Resolves #68770.
Resolves #68769.
Resolves #68768.
Resolves #68767.
Resolves #68766.
Resolves #68765.
Resolves #68764.
Resolves #68763.
Resolves #68762.
Resolves #68761.
Resolves #68760.
Resolves #68759.
Resolves #68758.
Resolves #68757.
Resolves #68756.
Resolves #68755.
Resolves #68754.
Resolves #68753.
Resolves #68752.
Resolves #68744.
Resolves #68726.
Resolves #68724.
Resolves #68722.
Resolves #68720.
Resolves #68719.
Resolves #68718.


Release note: None
