### PR TITLE
ui: add date range selector in stmts and txns pages

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/fetchData.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/fetchData.spec.ts
@@ -1,0 +1,39 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { propsToQueryString } from "./fetchData";
+
+describe("fetchData functions", () => {
+  describe("propsToQueryString", () => {
+    it("creates query string from object", () => {
+      const obj = {
+        start: 100,
+        end: 200,
+        strParam: "hello",
+        bool: false,
+      };
+      const expected = "start=100&end=200&strParam=hello&bool=false";
+      const res = propsToQueryString(obj);
+      expect(res).toEqual(expected);
+    });
+
+    it("skips entries with nullish values", () => {
+      const obj = {
+        start: 100,
+        end: 200,
+        strParam: null as any,
+        hello: undefined as any,
+      };
+      const expected = "start=100&end=200";
+      const res = propsToQueryString(obj);
+      expect(res).toEqual(expected);
+    });
+  });
+});

--- a/pkg/ui/workspaces/cluster-ui/src/api/fetchData.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/fetchData.ts
@@ -11,6 +11,7 @@
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import { RequestError } from "../util";
 import { getBasePath } from "./basePath";
+import { stringify } from "querystring";
 
 interface ProtoBuilder<
   P extends ConstructorType,
@@ -27,6 +28,18 @@ export function toArrayBuffer(encodedRequest: Uint8Array): ArrayBuffer {
     encodedRequest.byteOffset,
     encodedRequest.byteOffset + encodedRequest.byteLength,
   );
+}
+
+// propsToQueryString is a helper function that converts a set of object
+// properties to a query string
+// - keys with null or undefined values will be skipped
+// - non-string values will be toString'd
+export function propsToQueryString(props: { [k: string]: any }) {
+  const params = new URLSearchParams();
+  Object.entries(props).forEach(
+    ([k, v]: [string, any]) => v != null && params.set(k, v.toString()),
+  );
+  return params.toString();
 }
 
 /**

--- a/pkg/ui/workspaces/cluster-ui/src/api/statementsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/statementsApi.ts
@@ -9,7 +9,7 @@
 // licenses/APL.txt.
 
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
-import { fetchData } from "src/api";
+import { fetchData, propsToQueryString } from "src/api";
 
 const STATEMENTS_PATH = "/_status/statements";
 
@@ -17,5 +17,21 @@ export const getStatements = (): Promise<cockroach.server.serverpb.StatementsRes
   return fetchData(
     cockroach.server.serverpb.StatementsResponse,
     STATEMENTS_PATH,
+  );
+};
+
+export type StatementsRequest = cockroach.server.serverpb.StatementsRequest;
+
+export const getCombinedStatements = (
+  req: StatementsRequest,
+): Promise<cockroach.server.serverpb.StatementsResponse> => {
+  const queryStr = propsToQueryString({
+    start: req.start.toInt(),
+    end: req.end.toInt(),
+    combined: true,
+  });
+  return fetchData(
+    cockroach.server.serverpb.StatementsResponse,
+    `${STATEMENTS_PATH}?${queryStr}`,
   );
 };

--- a/pkg/ui/workspaces/cluster-ui/src/dateRange/dateRange.fixtures.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/dateRange/dateRange.fixtures.tsx
@@ -1,0 +1,16 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import moment, { Moment } from "moment";
+
+export const start = moment.utc("2021.08.08");
+export const end = moment.utc("2021.08.12");
+
+export const allowedInterval: [Moment, Moment] = [start, end];

--- a/pkg/ui/workspaces/cluster-ui/src/dateRange/dateRange.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/dateRange/dateRange.module.scss
@@ -1,0 +1,57 @@
+@import "../core/index.module";
+
+.popup-container {
+  width: 506px;
+  height: 240px;
+
+  .label {
+    display: block;
+    margin-bottom: 1rem;
+  }
+
+  .popup-content {
+    :global(.ant-calendar-picker) {
+      width: 290px;
+      margin-right: 14px;
+      input {
+        padding-left: 34px;
+      }
+    }
+
+    :global(.ant-time-picker-icon),
+    :global(.ant-calendar-picker-icon) {
+      left: 12px;
+    }
+
+    :global(.ant-time-picker) {
+      width: 150px;
+    }
+  }
+
+  .popup-footer {
+    margin-top: 24px;
+    text-align: right;
+    button {
+      margin-left: 8px;
+    }
+  }
+
+  :global(.ant-popover-arrow) {
+    display: none;
+  }
+}
+
+.date-range-form {
+  width: 300px;
+  height: 40px;
+
+  :global(.ant-input-affix-wrapper) {
+    height: 40px;
+    &:hover {
+      :global(.ant-input:not(.ant-input-disabled)) {
+        border-color: $colors--primary-blue-3;
+        border-right-width: 2px !important;
+      }
+    }
+  }
+}

--- a/pkg/ui/workspaces/cluster-ui/src/dateRange/dateRange.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/dateRange/dateRange.stories.tsx
@@ -1,0 +1,32 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import { start, end, allowedInterval } from "./dateRange.fixtures";
+import { DateRange } from "./index";
+
+storiesOf("DateRange", module)
+  .add("default", () => (
+    <DateRange
+      allowedInterval={allowedInterval}
+      end={end}
+      onSubmit={() => {}}
+      start={start}
+    />
+  ))
+  .add("with invalid date range", () => (
+    <DateRange
+      allowedInterval={allowedInterval}
+      end={start}
+      onSubmit={() => {}}
+      start={end}
+    />
+  ));

--- a/pkg/ui/workspaces/cluster-ui/src/dateRange/dateRange.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/dateRange/dateRange.tsx
@@ -1,0 +1,190 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React, { useState } from "react";
+import { Alert, DatePicker, Form, Input, Popover, TimePicker } from "antd";
+import { Moment } from "moment";
+import classNames from "classnames/bind";
+import { Time as TimeIcon, ErrorCircleFilled } from "@cockroachlabs/icons";
+import { Button } from "src/button";
+import { Text, TextTypes } from "src/text";
+
+import styles from "./dateRange.module.scss";
+
+const cx = classNames.bind(styles);
+
+function rangeToString(start: Moment, end: Moment): string {
+  const formatStr = "MMM D, H:mm";
+  const formatStrSameDay = "H:mm";
+
+  const isSameDay = start.isSame(end, "day");
+  return `${start.utc().format(formatStr)} - ${end
+    .utc()
+    .format(isSameDay ? formatStrSameDay : formatStr)} (UTC)`;
+}
+
+type DateRangeMenuProps = {
+  start: Moment;
+  end: Moment;
+  allowedInterval?: [Moment, Moment];
+  closeMenu: () => void;
+  onSubmit: (start: Moment, end: Moment) => void;
+};
+
+function DateRangeMenu({
+  start,
+  end,
+  allowedInterval,
+  closeMenu,
+  onSubmit,
+}: DateRangeMenuProps): React.ReactElement {
+  const dateFormat = "MMMM D, YYYY";
+  const timeFormat = "H:mm [(UTC)]";
+  const [startMoment, setStartMoment] = useState<Moment>(start);
+  const [endMoment, setEndMoment] = useState<Moment>(end);
+
+  const onChangeStart = (m?: Moment) => {
+    m && setStartMoment(m);
+  };
+
+  const onChangeEnd = (m?: Moment) => {
+    m && setEndMoment(m);
+  };
+
+  const isDisabled = allowedInterval
+    ? (date: Moment): boolean => {
+        return (
+          date.isBefore(allowedInterval[0]) || date.isAfter(allowedInterval[1])
+        );
+      }
+    : null;
+
+  const isValid = startMoment.isBefore(endMoment);
+
+  const onApply = (): void => {
+    onSubmit(startMoment, endMoment);
+    closeMenu();
+  };
+
+  return (
+    <div className={cx("popup-content")}>
+      <Text className={cx("label")} textType={TextTypes.CaptionStrong}>
+        From
+      </Text>
+      <DatePicker
+        disabledDate={isDisabled}
+        allowClear={false}
+        format={dateFormat}
+        onChange={onChangeStart}
+        suffixIcon={<TimeIcon />}
+        value={startMoment}
+      />
+      <TimePicker
+        allowClear={false}
+        format={timeFormat}
+        onChange={onChangeStart}
+        suffixIcon={<span />}
+        value={startMoment}
+      />
+      <Text className={cx("label")} textType={TextTypes.CaptionStrong}>
+        To
+      </Text>
+      <DatePicker
+        allowClear={false}
+        disabledDate={isDisabled}
+        format={dateFormat}
+        onChange={onChangeEnd}
+        suffixIcon={<TimeIcon />}
+        value={endMoment}
+      />
+      <TimePicker
+        allowClear={false}
+        format={timeFormat}
+        onChange={onChangeEnd}
+        suffixIcon={<span />}
+        value={endMoment}
+      />
+      {!isValid && (
+        <Alert
+          icon={<ErrorCircleFilled fill="#FF3B4E" />}
+          message="Date interval not valid"
+          type="error"
+          showIcon
+        />
+      )}
+      <div className={cx("popup-footer")}>
+        <Button onClick={closeMenu} type="secondary" textAlign="center">
+          Cancel
+        </Button>
+        <Button
+          disabled={!isValid}
+          onClick={onApply}
+          type="primary"
+          textAlign="center"
+        >
+          Apply
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+type DateRangeProps = {
+  start: Moment;
+  end: Moment;
+  allowedInterval?: [Moment, Moment];
+  onSubmit: (start: Moment, end: Moment) => void;
+};
+
+export function DateRange({
+  allowedInterval,
+  start,
+  end,
+  onSubmit,
+}: DateRangeProps): React.ReactElement {
+  const [menuVisible, setMenuVisible] = useState<boolean>(false);
+  const displayStr = rangeToString(start, end);
+
+  const onVisibleChange = (visible: boolean): void => {
+    setMenuVisible(visible);
+  };
+
+  const closeMenu = (): void => {
+    setMenuVisible(false);
+  };
+
+  const menu = (
+    <DateRangeMenu
+      allowedInterval={allowedInterval}
+      start={start}
+      end={end}
+      closeMenu={closeMenu}
+      onSubmit={onSubmit}
+    />
+  );
+
+  return (
+    <Form className={cx("date-range-form")}>
+      <Form.Item>
+        <Popover
+          destroyTooltipOnHide
+          content={menu}
+          overlayClassName={cx("popup-container")}
+          placement="bottomLeft"
+          visible={menuVisible}
+          onVisibleChange={onVisibleChange}
+          trigger="click"
+        >
+          <Input value={displayStr} prefix={<TimeIcon />} />
+        </Popover>
+      </Form.Item>
+    </Form>
+  );
+}

--- a/pkg/ui/workspaces/cluster-ui/src/dateRange/index.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/dateRange/index.tsx
@@ -1,0 +1,11 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+export * from "./dateRange";

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetailsConnected.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetailsConnected.ts
@@ -26,7 +26,7 @@ import {
   nodeDisplayNameByIDSelector,
   nodeRegionsByIDSelector,
 } from "../store/nodes";
-import { actions as statementActions } from "src/store/statements";
+import { actions as statementsActions } from "src/store/statements";
 import {
   actions as statementDiagnosticsActions,
   selectDiagnosticsReportsByStatementFingerprint,
@@ -35,6 +35,7 @@ import { actions as analyticsActions } from "src/store/analytics";
 import { actions as localStorageActions } from "src/store/localStorage";
 import { actions as nodesActions } from "../store/nodes";
 import { actions as nodeLivenessActions } from "../store/liveness";
+import { selectDateRange } from "../statementsPage/statementsPage.selectors";
 
 const mapStateToProps = (state: AppState, props: StatementDetailsProps) => {
   const statement = selectStatement(state, props);
@@ -42,6 +43,7 @@ const mapStateToProps = (state: AppState, props: StatementDetailsProps) => {
   return {
     statement,
     statementsError: state.adminUI.statements.lastError,
+    dateRange: selectIsTenant(state) ? null : selectDateRange(state),
     nodeNames: nodeDisplayNameByIDSelector(state),
     nodeRegions: nodeRegionsByIDSelector(state),
     diagnosticsReports: selectDiagnosticsReportsByStatementFingerprint(
@@ -56,7 +58,7 @@ const mapStateToProps = (state: AppState, props: StatementDetailsProps) => {
 const mapDispatchToProps = (
   dispatch: Dispatch,
 ): StatementDetailsDispatchProps => ({
-  refreshStatements: () => dispatch(statementActions.refresh()),
+  refreshStatements: () => dispatch(statementsActions.refresh()),
   refreshStatementDiagnosticsRequests: () =>
     dispatch(statementDiagnosticsActions.refresh()),
   refreshNodes: () => dispatch(nodesActions.refresh()),

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
@@ -10,6 +10,7 @@
 
 /* eslint-disable prettier/prettier */
 import { StatementsPageProps } from "./statementsPage";
+import moment from "moment";
 import { createMemoryHistory } from "history";
 import Long from "long";
 import { noop } from "lodash";
@@ -21,177 +22,179 @@ type IStatementDiagnosticsReport = cockroach.server.serverpb.IStatementDiagnosti
 type IStatementStatistics = protos.cockroach.sql.IStatementStatistics;
 type IExecStats = protos.cockroach.sql.IExecStats;
 
-const history = createMemoryHistory({ initialEntries: ["/statements"]});
+const history = createMemoryHistory({ initialEntries: ["/statements"] });
 
 const execStats: Required<IExecStats> = {
-  "count": Long.fromNumber(180),
-  "network_bytes": {
-    "mean": 80,
-    "squared_diffs": 0.01,
+  count: Long.fromNumber(180),
+  network_bytes: {
+    mean: 80,
+    squared_diffs: 0.01,
   },
-  "max_mem_usage": {
-    "mean": 80,
-    "squared_diffs": 0.01,
+  max_mem_usage: {
+    mean: 80,
+    squared_diffs: 0.01,
   },
-  "contention_time": {
-    "mean": 80,
-    "squared_diffs": 0.01,
+  contention_time: {
+    mean: 80,
+    squared_diffs: 0.01,
   },
-  "network_messages": {
-    "mean": 80,
-    "squared_diffs": 0.01,
+  network_messages: {
+    mean: 80,
+    squared_diffs: 0.01,
   },
-  "max_disk_usage": {
-    "mean": 80,
-    "squared_diffs": 0.01,
+  max_disk_usage: {
+    mean: 80,
+    squared_diffs: 0.01,
   },
 };
 
 const statementStats: Required<IStatementStatistics> = {
-  "count": Long.fromNumber(180000),
-  "first_attempt_count": Long.fromNumber(50000),
-  "max_retries": Long.fromNumber(10),
-  "sql_type": "DDL",
-  "nodes": [Long.fromNumber(1), Long.fromNumber(2)],
-  "num_rows": {
-    "mean": 1,
-    "squared_diffs": 0,
+  count: Long.fromNumber(180000),
+  first_attempt_count: Long.fromNumber(50000),
+  max_retries: Long.fromNumber(10),
+  sql_type: "DDL",
+  nodes: [Long.fromNumber(1), Long.fromNumber(2)],
+  num_rows: {
+    mean: 1,
+    squared_diffs: 0,
   },
-  "legacy_last_err": "",
-  "legacy_last_err_redacted": "",
-  "parse_lat": {
-    "mean": 0,
-    "squared_diffs": 0,
+  legacy_last_err: "",
+  legacy_last_err_redacted: "",
+  parse_lat: {
+    mean: 0,
+    squared_diffs: 0,
   },
-  "plan_lat": {
-    "mean": 0.00018,
-    "squared_diffs": 5.4319999999999994e-9,
+  plan_lat: {
+    mean: 0.00018,
+    squared_diffs: 5.4319999999999994e-9,
   },
-  "run_lat": {
-    "mean": 0.0022536666666666664,
-    "squared_diffs": 0.0000020303526666666667,
+  run_lat: {
+    mean: 0.0022536666666666664,
+    squared_diffs: 0.0000020303526666666667,
   },
-  "service_lat": {
-    "mean": 0.002496,
-    "squared_diffs": 0.000002308794,
+  service_lat: {
+    mean: 0.002496,
+    squared_diffs: 0.000002308794,
   },
-  "overhead_lat": {
-    "mean": 0.00006233333333333315,
-    "squared_diffs": 5.786666666666667e-10,
+  overhead_lat: {
+    mean: 0.00006233333333333315,
+    squared_diffs: 5.786666666666667e-10,
   },
-  "bytes_read": {
-    "mean": 80,
-    "squared_diffs": 0.01,
+  bytes_read: {
+    mean: 80,
+    squared_diffs: 0.01,
   },
-  "rows_read": {
-    "mean": 10,
-    "squared_diffs": 1,
+  rows_read: {
+    mean: 10,
+    squared_diffs: 1,
   },
   exec_stats: execStats,
-  "last_exec_timestamp": {
+  last_exec_timestamp: {
     seconds: Long.fromInt(1599670292),
     nanos: 111613000,
   },
-  "sensitive_info": {
-    "last_err": "",
-    "most_recent_plan_description": {
-      "name": "root",
-      "children": [
+  sensitive_info: {
+    last_err: "",
+    most_recent_plan_description: {
+      name: "root",
+      children: [
         {
-          "name": "render",
-          "attrs": [
+          name: "render",
+          attrs: [
             {
-              "key": "render",
-              "value": "COALESCE(a, b)",
+              key: "render",
+              value: "COALESCE(a, b)",
             },
           ],
-          "children": [
+          children: [
             {
-              "name": "values",
-              "attrs": [
+              name: "values",
+              attrs: [
                 {
-                  "key": "size",
-                  "value": "2 columns, 1 row",
+                  key: "size",
+                  value: "2 columns, 1 row",
                 },
                 {
-                  "key": "row 0, expr",
-                  "value": "(SELECT code FROM promo_codes WHERE code > $1 ORDER BY code LIMIT _)",
+                  key: "row 0, expr",
+                  value:
+                    "(SELECT code FROM promo_codes WHERE code > $1 ORDER BY code LIMIT _)",
                 },
                 {
-                  "key": "row 0, expr",
-                  "value": "(SELECT code FROM promo_codes ORDER BY code LIMIT _)",
+                  key: "row 0, expr",
+                  value: "(SELECT code FROM promo_codes ORDER BY code LIMIT _)",
                 },
               ],
             },
           ],
         },
         {
-          "name": "subquery",
-          "attrs": [
+          name: "subquery",
+          attrs: [
             {
-              "key": "id",
-              "value": "@S1",
+              key: "id",
+              value: "@S1",
             },
             {
-              "key": "original sql",
-              "value": "(SELECT code FROM promo_codes WHERE code > $1 ORDER BY code LIMIT _)",
+              key: "original sql",
+              value:
+                "(SELECT code FROM promo_codes WHERE code > $1 ORDER BY code LIMIT _)",
             },
             {
-              "key": "exec mode",
-              "value": "one row",
+              key: "exec mode",
+              value: "one row",
             },
           ],
-          "children": [
+          children: [
             {
-              "name": "scan",
-              "attrs": [
+              name: "scan",
+              attrs: [
                 {
-                  "key": "table",
-                  "value": "promo_codes@primary",
+                  key: "table",
+                  value: "promo_codes@primary",
                 },
                 {
-                  "key": "spans",
-                  "value": "1 span",
+                  key: "spans",
+                  value: "1 span",
                 },
                 {
-                  "key": "limit",
-                  "value": "1",
+                  key: "limit",
+                  value: "1",
                 },
               ],
             },
           ],
         },
         {
-          "name": "subquery",
-          "attrs": [
+          name: "subquery",
+          attrs: [
             {
-              "key": "id",
-              "value": "@S2",
+              key: "id",
+              value: "@S2",
             },
             {
-              "key": "original sql",
-              "value": "(SELECT code FROM promo_codes ORDER BY code LIMIT _)",
+              key: "original sql",
+              value: "(SELECT code FROM promo_codes ORDER BY code LIMIT _)",
             },
             {
-              "key": "exec mode",
-              "value": "one row",
+              key: "exec mode",
+              value: "one row",
             },
           ],
-          "children": [
+          children: [
             {
-              "name": "scan",
-              "attrs": [
+              name: "scan",
+              attrs: [
                 {
-                  "key": "table",
-                  "value": "promo_codes@primary",
+                  key: "table",
+                  value: "promo_codes@primary",
                 },
                 {
-                  "key": "spans",
-                  "value": "ALL",
+                  key: "spans",
+                  value: "ALL",
                 },
                 {
-                  "key": "limit",
-                  "value": "1",
+                  key: "limit",
+                  value: "1",
                 },
               ],
             },
@@ -204,370 +207,389 @@ const statementStats: Required<IStatementStatistics> = {
 
 const diagnosticsReports: IStatementDiagnosticsReport[] = [
   {
-    "id": Long.fromNumber(594413966918975489),
-    "completed": true,
-    "statement_fingerprint": "SHOW database",
-    "statement_diagnostics_id": Long.fromNumber(594413981435920385),
-    "requested_at": {"seconds": Long.fromNumber(1601471146), "nanos": 737251000}
+    id: Long.fromNumber(594413966918975489),
+    completed: true,
+    statement_fingerprint: "SHOW database",
+    statement_diagnostics_id: Long.fromNumber(594413981435920385),
+    requested_at: { seconds: Long.fromNumber(1601471146), nanos: 737251000 },
   },
   {
-    "id": Long.fromNumber(594413966918975429),
-    "completed": true,
-    "statement_fingerprint": "SHOW database",
-    "statement_diagnostics_id": Long.fromNumber(594413281435920385),
-    "requested_at": {"seconds": Long.fromNumber(1601491146), "nanos": 737251000}
-  }
-]
+    id: Long.fromNumber(594413966918975429),
+    completed: true,
+    statement_fingerprint: "SHOW database",
+    statement_diagnostics_id: Long.fromNumber(594413281435920385),
+    requested_at: { seconds: Long.fromNumber(1601491146), nanos: 737251000 },
+  },
+];
 
 const diagnosticsReportsInProgress: IStatementDiagnosticsReport[] = [
   {
-    "id": Long.fromNumber(594413966918975489),
-    "completed": false,
-    "statement_fingerprint": "SHOW database",
-    "statement_diagnostics_id": Long.fromNumber(594413981435920385),
-    "requested_at": {"seconds": Long.fromNumber(1601471146), "nanos": 737251000}
+    id: Long.fromNumber(594413966918975489),
+    completed: false,
+    statement_fingerprint: "SHOW database",
+    statement_diagnostics_id: Long.fromNumber(594413981435920385),
+    requested_at: { seconds: Long.fromNumber(1601471146), nanos: 737251000 },
   },
   {
-    "id": Long.fromNumber(594413966918975429),
-    "completed": true,
-    "statement_fingerprint": "SHOW database",
-    "statement_diagnostics_id": Long.fromNumber(594413281435920385),
-    "requested_at": {"seconds": Long.fromNumber(1601491146), "nanos": 737251000}
-  }
-]
+    id: Long.fromNumber(594413966918975429),
+    completed: true,
+    statement_fingerprint: "SHOW database",
+    statement_diagnostics_id: Long.fromNumber(594413281435920385),
+    requested_at: { seconds: Long.fromNumber(1601491146), nanos: 737251000 },
+  },
+];
 
 const statementsPagePropsFixture: StatementsPageProps = {
   history,
   location: {
-    "pathname": "/statements",
-    "search": "",
-    "hash": "",
-    "state": null,
+    pathname: "/statements",
+    search: "",
+    hash: "",
+    state: null,
   },
-  "match": {
-    "path": "/statements",
-    "url": "/statements",
-    "isExact": true,
-    "params": {},
+  match: {
+    path: "/statements",
+    url: "/statements",
+    isExact: true,
+    params: {},
   },
-  "databases": ["defaultdb","foo","system"],
-  "nodeRegions": {
+  databases: ["defaultdb", "foo", "system"],
+  nodeRegions: {
     "1": "gcp-us-east1",
     "2": "gcp-us-east1",
     "3": "gcp-us-west1",
     "4": "gcp-europe-west1",
   },
-  "statements": [
+  statements: [
     {
-      "label": "SELECT IFNULL(a, b) FROM (SELECT (SELECT code FROM promo_codes WHERE code > $1 ORDER BY code LIMIT _) AS a, (SELECT code FROM promo_codes ORDER BY code LIMIT _) AS b)",
-      "implicitTxn": true,
-      "database": "defaultdb",
-      "fullScan": false,
-      "stats": statementStats,
+      label:
+        "SELECT IFNULL(a, b) FROM (SELECT (SELECT code FROM promo_codes WHERE code > $1 ORDER BY code LIMIT _) AS a, (SELECT code FROM promo_codes ORDER BY code LIMIT _) AS b)",
+      implicitTxn: true,
+      database: "defaultdb",
+      fullScan: false,
+      stats: statementStats,
     },
     {
-      "label": "INSERT INTO vehicles VALUES ($1, $2, __more6__)",
-      "implicitTxn": true,
-      "database": "defaultdb",
-      "fullScan": false,
-      "stats": statementStats,
+      label: "INSERT INTO vehicles VALUES ($1, $2, __more6__)",
+      implicitTxn: true,
+      database: "defaultdb",
+      fullScan: false,
+      stats: statementStats,
     },
     {
-      "label": "SELECT IFNULL(a, b) FROM (SELECT (SELECT id FROM users WHERE (city = $1) AND (id > $2) ORDER BY id LIMIT _) AS a, (SELECT id FROM users WHERE city = $1 ORDER BY id LIMIT _) AS b)",
-      "implicitTxn": true,
-      "database": "defaultdb",
-      "fullScan": false,
-      "stats": statementStats,
+      label:
+        "SELECT IFNULL(a, b) FROM (SELECT (SELECT id FROM users WHERE (city = $1) AND (id > $2) ORDER BY id LIMIT _) AS a, (SELECT id FROM users WHERE city = $1 ORDER BY id LIMIT _) AS b)",
+      implicitTxn: true,
+      database: "defaultdb",
+      fullScan: false,
+      stats: statementStats,
     },
     {
-      "label": "UPSERT INTO vehicle_location_histories VALUES ($1, $2, now(), $3, $4)",
-      "implicitTxn": true,
-      "database": "defaultdb",
-      "fullScan": false,
-      "stats": statementStats,
+      label:
+        "UPSERT INTO vehicle_location_histories VALUES ($1, $2, now(), $3, $4)",
+      implicitTxn: true,
+      database: "defaultdb",
+      fullScan: false,
+      stats: statementStats,
     },
     {
-      "label": "INSERT INTO user_promo_codes VALUES ($1, $2, $3, now(), _)",
-      "implicitTxn": true,
-      "database": "defaultdb",
-      "fullScan": false,
-      "stats": statementStats,
+      label: "INSERT INTO user_promo_codes VALUES ($1, $2, $3, now(), _)",
+      implicitTxn: true,
+      database: "defaultdb",
+      fullScan: false,
+      stats: statementStats,
     },
     {
-      "label": "SELECT city, id FROM vehicles WHERE city = $1",
-      "implicitTxn": true,
-      "database": "defaultdb",
-      "fullScan": true,
-      "stats": statementStats,
+      label: "SELECT city, id FROM vehicles WHERE city = $1",
+      implicitTxn: true,
+      database: "defaultdb",
+      fullScan: true,
+      stats: statementStats,
     },
     {
-      "label": "INSERT INTO rides VALUES ($1, $2, $2, $3, $4, $5, _, now(), _, $6)",
-      "implicitTxn": true,
-      "database": "defaultdb",
-      "fullScan": false,
-      "stats": statementStats,
+      label:
+        "INSERT INTO rides VALUES ($1, $2, $2, $3, $4, $5, _, now(), _, $6)",
+      implicitTxn: true,
+      database: "defaultdb",
+      fullScan: false,
+      stats: statementStats,
     },
     {
-      "label": "SELECT IFNULL(a, b) FROM (SELECT (SELECT id FROM vehicles WHERE (city = $1) AND (id > $2) ORDER BY id LIMIT _) AS a, (SELECT id FROM vehicles WHERE city = $1 ORDER BY id LIMIT _) AS b)",
-      "implicitTxn": true,
-      "database": "defaultdb",
-      "fullScan": false,
-      "stats": statementStats,
+      label:
+        "SELECT IFNULL(a, b) FROM (SELECT (SELECT id FROM vehicles WHERE (city = $1) AND (id > $2) ORDER BY id LIMIT _) AS a, (SELECT id FROM vehicles WHERE city = $1 ORDER BY id LIMIT _) AS b)",
+      implicitTxn: true,
+      database: "defaultdb",
+      fullScan: false,
+      stats: statementStats,
     },
     {
-      "label": "UPDATE rides SET end_address = $3, end_time = now() WHERE (city = $1) AND (id = $2)",
-      "implicitTxn": true,
-      "database": "defaultdb",
-      "fullScan": false,
-      "stats": statementStats,
+      label:
+        "UPDATE rides SET end_address = $3, end_time = now() WHERE (city = $1) AND (id = $2)",
+      implicitTxn: true,
+      database: "defaultdb",
+      fullScan: false,
+      stats: statementStats,
     },
     {
-      "label": "INSERT INTO users VALUES ($1, $2, __more3__)",
-      "implicitTxn": true,
-      "database": "defaultdb",
-      "fullScan": false,
-      "stats": statementStats,
+      label: "INSERT INTO users VALUES ($1, $2, __more3__)",
+      implicitTxn: true,
+      database: "defaultdb",
+      fullScan: false,
+      stats: statementStats,
     },
     {
-      "label": "SELECT count(*) FROM user_promo_codes WHERE ((city = $1) AND (user_id = $2)) AND (code = $3)",
-      "implicitTxn": true,
-      "database": "defaultdb",
-      "fullScan": true,
-      "stats": statementStats,
+      label:
+        "SELECT count(*) FROM user_promo_codes WHERE ((city = $1) AND (user_id = $2)) AND (code = $3)",
+      implicitTxn: true,
+      database: "defaultdb",
+      fullScan: true,
+      stats: statementStats,
     },
     {
-      "label": "INSERT INTO promo_codes VALUES ($1, $2, __more3__)",
-      "implicitTxn": true,
-      "database": "defaultdb",
-      "fullScan": false,
-      "stats": statementStats,
+      label: "INSERT INTO promo_codes VALUES ($1, $2, __more3__)",
+      implicitTxn: true,
+      database: "defaultdb",
+      fullScan: false,
+      stats: statementStats,
     },
     {
-      "label": "ALTER TABLE users SCATTER FROM (_, _) TO (_, _)",
-      "implicitTxn": true,
-      "database": "defaultdb",
-      "fullScan": false,
-      "stats": statementStats,
+      label: "ALTER TABLE users SCATTER FROM (_, _) TO (_, _)",
+      implicitTxn: true,
+      database: "defaultdb",
+      fullScan: false,
+      stats: statementStats,
     },
     {
-      "label": "ALTER TABLE rides ADD FOREIGN KEY (vehicle_city, vehicle_id) REFERENCES vehicles (city, id)",
-      "implicitTxn": true,
-      "database": "defaultdb",
-      "fullScan": false,
-      "stats": statementStats,
+      label:
+        "ALTER TABLE rides ADD FOREIGN KEY (vehicle_city, vehicle_id) REFERENCES vehicles (city, id)",
+      implicitTxn: true,
+      database: "defaultdb",
+      fullScan: false,
+      stats: statementStats,
     },
     {
-      "label": "SHOW database",
-      "implicitTxn": true,
-      "database": "defaultdb",
-      "fullScan": false,
-      "stats": statementStats,
+      label: "SHOW database",
+      implicitTxn: true,
+      database: "defaultdb",
+      fullScan: false,
+      stats: statementStats,
       diagnosticsReports,
     },
     {
-      "label": "CREATE TABLE IF NOT EXISTS promo_codes (code VARCHAR NOT NULL, description VARCHAR NULL, creation_time TIMESTAMP NULL, expiration_time TIMESTAMP NULL, rules JSONB NULL, PRIMARY KEY (code ASC))",
-      "implicitTxn": true,
-      "database": "defaultdb",
-      "fullScan": false,
-      "stats": statementStats,
+      label:
+        "CREATE TABLE IF NOT EXISTS promo_codes (code VARCHAR NOT NULL, description VARCHAR NULL, creation_time TIMESTAMP NULL, expiration_time TIMESTAMP NULL, rules JSONB NULL, PRIMARY KEY (code ASC))",
+      implicitTxn: true,
+      database: "defaultdb",
+      fullScan: false,
+      stats: statementStats,
     },
     {
-      "label": "ALTER TABLE users SPLIT AT VALUES (_, _)",
-      "implicitTxn": true,
-      "database": "defaultdb",
-      "fullScan": false,
-      "stats": statementStats,
+      label: "ALTER TABLE users SPLIT AT VALUES (_, _)",
+      implicitTxn: true,
+      database: "defaultdb",
+      fullScan: false,
+      stats: statementStats,
     },
     {
-      "label": "ALTER TABLE vehicles SCATTER FROM (_, _) TO (_, _)",
-      "implicitTxn": true,
-      "database": "defaultdb",
-      "fullScan": false,
-      "stats": statementStats,
+      label: "ALTER TABLE vehicles SCATTER FROM (_, _) TO (_, _)",
+      implicitTxn: true,
+      database: "defaultdb",
+      fullScan: false,
+      stats: statementStats,
     },
     {
-      "label": "ALTER TABLE vehicle_location_histories ADD FOREIGN KEY (city, ride_id) REFERENCES rides (city, id)",
-      "implicitTxn": true,
-      "database": "defaultdb",
-      "fullScan": false,
-      "stats": statementStats,
+      label:
+        "ALTER TABLE vehicle_location_histories ADD FOREIGN KEY (city, ride_id) REFERENCES rides (city, id)",
+      implicitTxn: true,
+      database: "defaultdb",
+      fullScan: false,
+      stats: statementStats,
     },
     {
-      "label": "CREATE TABLE IF NOT EXISTS user_promo_codes (city VARCHAR NOT NULL, user_id UUID NOT NULL, code VARCHAR NOT NULL, \"timestamp\" TIMESTAMP NULL, usage_count INT8 NULL, PRIMARY KEY (city ASC, user_id ASC, code ASC))",
-      "implicitTxn": true,
-      "database": "defaultdb",
-      "fullScan": false,
-      "stats": statementStats,
+      label:
+        'CREATE TABLE IF NOT EXISTS user_promo_codes (city VARCHAR NOT NULL, user_id UUID NOT NULL, code VARCHAR NOT NULL, "timestamp" TIMESTAMP NULL, usage_count INT8 NULL, PRIMARY KEY (city ASC, user_id ASC, code ASC))',
+      implicitTxn: true,
+      database: "defaultdb",
+      fullScan: false,
+      stats: statementStats,
     },
     {
-      "label": "INSERT INTO users VALUES ($1, $2, __more3__), (__more40__)",
-      "implicitTxn": true,
-      "database": "defaultdb",
-      "fullScan": false,
-      "stats": statementStats,
+      label: "INSERT INTO users VALUES ($1, $2, __more3__), (__more40__)",
+      implicitTxn: true,
+      database: "defaultdb",
+      fullScan: false,
+      stats: statementStats,
     },
     {
-      "label": "ALTER TABLE rides SCATTER FROM (_, _) TO (_, _)",
-      "implicitTxn": true,
-      "database": "defaultdb",
-      "fullScan": false,
-      "stats": statementStats,
+      label: "ALTER TABLE rides SCATTER FROM (_, _) TO (_, _)",
+      implicitTxn: true,
+      database: "defaultdb",
+      fullScan: false,
+      stats: statementStats,
     },
     {
-      "label": "SET CLUSTER SETTING \"cluster.organization\" = $1",
-      "implicitTxn": true,
-      "database": "defaultdb",
-      "fullScan": false,
-      "stats": statementStats,
+      label: 'SET CLUSTER SETTING "cluster.organization" = $1',
+      implicitTxn: true,
+      database: "defaultdb",
+      fullScan: false,
+      stats: statementStats,
     },
     {
-      "label": "ALTER TABLE vehicles ADD FOREIGN KEY (city, owner_id) REFERENCES users (city, id)",
-      "implicitTxn": true,
-      "database": "defaultdb",
-      "fullScan": false,
-      "stats": statementStats,
+      label:
+        "ALTER TABLE vehicles ADD FOREIGN KEY (city, owner_id) REFERENCES users (city, id)",
+      implicitTxn: true,
+      database: "defaultdb",
+      fullScan: false,
+      stats: statementStats,
     },
     {
-      "label": "CREATE TABLE IF NOT EXISTS rides (id UUID NOT NULL, city VARCHAR NOT NULL, vehicle_city VARCHAR NULL, rider_id UUID NULL, vehicle_id UUID NULL, start_address VARCHAR NULL, end_address VARCHAR NULL, start_time TIMESTAMP NULL, end_time TIMESTAMP NULL, revenue DECIMAL(10,2) NULL, PRIMARY KEY (city ASC, id ASC), INDEX rides_auto_index_fk_city_ref_users (city ASC, rider_id ASC), INDEX rides_auto_index_fk_vehicle_city_ref_vehicles (vehicle_city ASC, vehicle_id ASC), CONSTRAINT check_vehicle_city_city CHECK (vehicle_city = city))",
-      "implicitTxn": true,
-      "database": "defaultdb",
-      "fullScan": false,
-      "stats": statementStats,
+      label:
+        "CREATE TABLE IF NOT EXISTS rides (id UUID NOT NULL, city VARCHAR NOT NULL, vehicle_city VARCHAR NULL, rider_id UUID NULL, vehicle_id UUID NULL, start_address VARCHAR NULL, end_address VARCHAR NULL, start_time TIMESTAMP NULL, end_time TIMESTAMP NULL, revenue DECIMAL(10,2) NULL, PRIMARY KEY (city ASC, id ASC), INDEX rides_auto_index_fk_city_ref_users (city ASC, rider_id ASC), INDEX rides_auto_index_fk_vehicle_city_ref_vehicles (vehicle_city ASC, vehicle_id ASC), CONSTRAINT check_vehicle_city_city CHECK (vehicle_city = city))",
+      implicitTxn: true,
+      database: "defaultdb",
+      fullScan: false,
+      stats: statementStats,
     },
     {
-      "label": "CREATE TABLE IF NOT EXISTS vehicles (id UUID NOT NULL, city VARCHAR NOT NULL, type VARCHAR NULL, owner_id UUID NULL, creation_time TIMESTAMP NULL, status VARCHAR NULL, current_location VARCHAR NULL, ext JSONB NULL, PRIMARY KEY (city ASC, id ASC), INDEX vehicles_auto_index_fk_city_ref_users (city ASC, owner_id ASC))",
-      "implicitTxn": true,
-      "database": "defaultdb",
-      "fullScan": false,
-      "stats": statementStats,
+      label:
+        "CREATE TABLE IF NOT EXISTS vehicles (id UUID NOT NULL, city VARCHAR NOT NULL, type VARCHAR NULL, owner_id UUID NULL, creation_time TIMESTAMP NULL, status VARCHAR NULL, current_location VARCHAR NULL, ext JSONB NULL, PRIMARY KEY (city ASC, id ASC), INDEX vehicles_auto_index_fk_city_ref_users (city ASC, owner_id ASC))",
+      implicitTxn: true,
+      database: "defaultdb",
+      fullScan: false,
+      stats: statementStats,
     },
     {
-      "label": "INSERT INTO rides VALUES ($1, $2, __more8__), (__more400__)",
-      "implicitTxn": true,
-      "database": "defaultdb",
-      "fullScan": false,
-      "stats": statementStats,
+      label: "INSERT INTO rides VALUES ($1, $2, __more8__), (__more400__)",
+      implicitTxn: true,
+      database: "defaultdb",
+      fullScan: false,
+      stats: statementStats,
     },
     {
-      "label": "ALTER TABLE vehicles SPLIT AT VALUES (_, _)",
-      "implicitTxn": true,
-      "database": "defaultdb",
-      "fullScan": false,
-      "stats": statementStats,
+      label: "ALTER TABLE vehicles SPLIT AT VALUES (_, _)",
+      implicitTxn: true,
+      database: "defaultdb",
+      fullScan: false,
+      stats: statementStats,
     },
     {
-      "label": "SET sql_safe_updates = _",
-      "implicitTxn": true,
-      "database": "defaultdb",
-      "fullScan": false,
-      "stats": statementStats,
+      label: "SET sql_safe_updates = _",
+      implicitTxn: true,
+      database: "defaultdb",
+      fullScan: false,
+      stats: statementStats,
     },
     {
-      "label": "CREATE TABLE IF NOT EXISTS users (id UUID NOT NULL, city VARCHAR NOT NULL, name VARCHAR NULL, address VARCHAR NULL, credit_card VARCHAR NULL, PRIMARY KEY (city ASC, id ASC))",
-      "implicitTxn": true,
-      "database": "defaultdb",
-      "fullScan": false,
-      "stats": statementStats,
+      label:
+        "CREATE TABLE IF NOT EXISTS users (id UUID NOT NULL, city VARCHAR NOT NULL, name VARCHAR NULL, address VARCHAR NULL, credit_card VARCHAR NULL, PRIMARY KEY (city ASC, id ASC))",
+      implicitTxn: true,
+      database: "defaultdb",
+      fullScan: false,
+      stats: statementStats,
     },
     {
-      "label": "CREATE TABLE IF NOT EXISTS vehicle_location_histories (city VARCHAR NOT NULL, ride_id UUID NOT NULL, \"timestamp\" TIMESTAMP NOT NULL, lat FLOAT8 NULL, long FLOAT8 NULL, PRIMARY KEY (city ASC, ride_id ASC, \"timestamp\" ASC))",
-      "implicitTxn": true,
-      "database": "defaultdb",
-      "fullScan": false,
-      "stats": statementStats,
+      label:
+        'CREATE TABLE IF NOT EXISTS vehicle_location_histories (city VARCHAR NOT NULL, ride_id UUID NOT NULL, "timestamp" TIMESTAMP NOT NULL, lat FLOAT8 NULL, long FLOAT8 NULL, PRIMARY KEY (city ASC, ride_id ASC, "timestamp" ASC))',
+      implicitTxn: true,
+      database: "defaultdb",
+      fullScan: false,
+      stats: statementStats,
     },
     {
-      "label": "SELECT * FROM crdb_internal.node_build_info",
-      "implicitTxn": true,
-      "database": "defaultdb",
-      "fullScan": false,
-      "stats": statementStats,
+      label: "SELECT * FROM crdb_internal.node_build_info",
+      implicitTxn: true,
+      database: "defaultdb",
+      fullScan: false,
+      stats: statementStats,
     },
     {
-      "label": "CREATE DATABASE movr",
-      "implicitTxn": true,
-      "database": "defaultdb",
-      "fullScan": false,
-      "stats": statementStats,
-      diagnosticsReports: diagnosticsReportsInProgress
+      label: "CREATE DATABASE movr",
+      implicitTxn: true,
+      database: "defaultdb",
+      fullScan: false,
+      stats: statementStats,
+      diagnosticsReports: diagnosticsReportsInProgress,
     },
     {
-      "label": "SELECT count(*) > _ FROM [SHOW ALL CLUSTER SETTINGS] AS _ (v) WHERE v = _",
-      "implicitTxn": true,
-      "database": "defaultdb",
-      "fullScan": false,
-      "stats": statementStats,
+      label:
+        "SELECT count(*) > _ FROM [SHOW ALL CLUSTER SETTINGS] AS _ (v) WHERE v = _",
+      implicitTxn: true,
+      database: "defaultdb",
+      fullScan: false,
+      stats: statementStats,
     },
     {
-      "label": "SET CLUSTER SETTING \"enterprise.license\" = $1",
-      "implicitTxn": true,
-      "database": "defaultdb",
-      "fullScan": false,
-      "stats": statementStats,
+      label: 'SET CLUSTER SETTING "enterprise.license" = $1',
+      implicitTxn: true,
+      database: "defaultdb",
+      fullScan: false,
+      stats: statementStats,
     },
     {
-      "label": "ALTER TABLE rides ADD FOREIGN KEY (city, rider_id) REFERENCES users (city, id)",
-      "implicitTxn": true,
-      "database": "defaultdb",
-      "fullScan": false,
-      "stats": statementStats,
+      label:
+        "ALTER TABLE rides ADD FOREIGN KEY (city, rider_id) REFERENCES users (city, id)",
+      implicitTxn: true,
+      database: "defaultdb",
+      fullScan: false,
+      stats: statementStats,
     },
     {
-      "label": "ALTER TABLE user_promo_codes ADD FOREIGN KEY (city, user_id) REFERENCES users (city, id)",
-      "implicitTxn": true,
-      "database": "defaultdb",
-      "fullScan": false,
-      "stats": statementStats,
+      label:
+        "ALTER TABLE user_promo_codes ADD FOREIGN KEY (city, user_id) REFERENCES users (city, id)",
+      implicitTxn: true,
+      database: "defaultdb",
+      fullScan: false,
+      stats: statementStats,
     },
     {
-      "label": "INSERT INTO promo_codes VALUES ($1, $2, __more3__), (__more900__)",
-      "implicitTxn": true,
-      "database": "defaultdb",
-      "fullScan": false,
-      "stats": statementStats,
+      label:
+        "INSERT INTO promo_codes VALUES ($1, $2, __more3__), (__more900__)",
+      implicitTxn: true,
+      database: "defaultdb",
+      fullScan: false,
+      stats: statementStats,
     },
     {
-      "label": "ALTER TABLE rides SPLIT AT VALUES (_, _)",
-      "implicitTxn": true,
-      "database": "defaultdb",
-      "fullScan": false,
-      "stats": statementStats,
+      label: "ALTER TABLE rides SPLIT AT VALUES (_, _)",
+      implicitTxn: true,
+      database: "defaultdb",
+      fullScan: false,
+      stats: statementStats,
     },
     {
-      "label": "SELECT value FROM crdb_internal.node_build_info WHERE field = _",
-      "implicitTxn": true,
-      "database": "defaultdb",
-      "fullScan": false,
-      "stats": statementStats,
+      label: "SELECT value FROM crdb_internal.node_build_info WHERE field = _",
+      implicitTxn: true,
+      database: "defaultdb",
+      fullScan: false,
+      stats: statementStats,
     },
     {
-      "label": "INSERT INTO vehicle_location_histories VALUES ($1, $2, __more3__), (__more900__)",
-      "implicitTxn": true,
-      "database": "defaultdb",
-      "fullScan": false,
-      "stats": statementStats,
+      label:
+        "INSERT INTO vehicle_location_histories VALUES ($1, $2, __more3__), (__more900__)",
+      implicitTxn: true,
+      database: "defaultdb",
+      fullScan: false,
+      stats: statementStats,
     },
     {
-      "label": "INSERT INTO vehicles VALUES ($1, $2, __more6__), (__more10__)",
-      "implicitTxn": true,
-      "database": "defaultdb",
-      "fullScan": false,
-      "stats": statementStats,
+      label: "INSERT INTO vehicles VALUES ($1, $2, __more6__), (__more10__)",
+      implicitTxn: true,
+      database: "defaultdb",
+      fullScan: false,
+      stats: statementStats,
     },
   ],
-  "statementsError": null,
-  "apps": [
-    "(internal)",
-    "movr",
-    "$ cockroach demo",
-  ],
-  "totalFingerprints": 95,
-  "lastReset": "2020-04-13 07:22:23",
-  "columns": null,
+  statementsError: null,
+  dateRange: [moment.utc("2021.08.08"), moment.utc("2021.08.12")],
+  apps: ["(internal)", "movr", "$ cockroach demo"],
+  totalFingerprints: 95,
+  lastReset: "2020-04-13 07:22:23",
+  columns: null,
   dismissAlertMessage: noop,
   refreshStatementDiagnosticsRequests: noop,
   refreshStatements: noop,
   resetSQLStats: noop,
+  onDateRangeChange: noop,
   onActivateStatementDiagnostics: noop,
   onDiagnosticsModalOpen: noop,
   onSearchComplete: noop,
@@ -577,7 +599,11 @@ const statementsPagePropsFixture: StatementsPageProps = {
 
 export const statementsPagePropsWithRequestError: StatementsPageProps = {
   ...statementsPagePropsFixture,
-  statementsError: new RequestError("request_error", 403, "this operation requires admin privilege")
-}
+  statementsError: new RequestError(
+    "request_error",
+    403,
+    "this operation requires admin privilege",
+  ),
+};
 
 export default statementsPagePropsFixture;

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.module.scss
@@ -80,3 +80,14 @@ h2.base-heading {
   font-size: 14px;
   color: $colors--title;
 }
+
+.reset-btn {
+  background: transparent;
+  border: none;
+  color: $colors--primary-blue-3;
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
@@ -9,6 +9,7 @@
 // licenses/APL.txt.
 
 import { createSelector } from "reselect";
+import moment, { Moment } from "moment";
 import {
   aggregateStatementStats,
   appAttr,
@@ -203,4 +204,18 @@ export const selectColumns = createSelector(
     localStorage["showColumns/StatementsPage"]
       ? localStorage["showColumns/StatementsPage"].split(",")
       : null,
+);
+
+export const selectLocalStorageDateRange = createSelector(
+  localStorageSelector,
+  localStorage => localStorage["dateRange/StatementsPage"],
+);
+
+export const selectDateRange = createSelector(
+  selectLocalStorageDateRange,
+  dateRange =>
+    [moment.unix(dateRange.start).utc(), moment.unix(dateRange.end).utc()] as [
+      Moment,
+      Moment,
+    ],
 );

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
@@ -11,9 +11,10 @@
 import { connect } from "react-redux";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 import { Dispatch } from "redux";
+import moment, { Moment } from "moment";
 
 import { AppState } from "src/store";
-import { actions as statementActions } from "src/store/statements";
+import { actions as statementsActions } from "src/store/statements";
 import { actions as statementDiagnosticsActions } from "src/store/statementDiagnostics";
 import { actions as analyticsActions } from "src/store/analytics";
 import { actions as localStorageActions } from "src/store/localStorage";
@@ -32,10 +33,12 @@ import {
   selectStatementsLastError,
   selectTotalFingerprints,
   selectColumns,
+  selectDateRange,
 } from "./statementsPage.selectors";
 import { selectIsTenant } from "../store/uiConfig";
 import { AggregateStatistics } from "../statementsTable";
 import { nodeRegionsByIDSelector } from "../store/nodes";
+import { StatementsRequest } from "src/api/statementsApi";
 
 export const ConnectedStatementsPage = withRouter(
   connect<
@@ -53,9 +56,19 @@ export const ConnectedStatementsPage = withRouter(
       columns: selectColumns(state),
       nodeRegions: nodeRegionsByIDSelector(state),
       isTenant: selectIsTenant(state),
+      dateRange: selectIsTenant(state) ? null : selectDateRange(state),
     }),
     (dispatch: Dispatch) => ({
-      refreshStatements: () => dispatch(statementActions.refresh()),
+      refreshStatements: (req?: StatementsRequest) =>
+        dispatch(statementsActions.refresh(req)),
+      onDateRangeChange: (start: Moment, end: Moment) => {
+        dispatch(
+          statementsActions.updateDateRange({
+            start: start.unix(),
+            end: end.unix(),
+          }),
+        );
+      },
       refreshStatementDiagnosticsRequests: () =>
         dispatch(statementDiagnosticsActions.refresh()),
       resetSQLStats: () => dispatch(resetSQLStatsActions.request()),

--- a/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.reducer.ts
@@ -8,12 +8,19 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+import moment from "moment";
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { DOMAIN_NAME } from "../utils";
+
+type StatementsDateRangeState = {
+  start: number;
+  end: number;
+};
 
 export type LocalStorageState = {
   "adminUi/showDiagnosticsModal": boolean;
   "showColumns/StatementsPage": string;
+  "dateRange/StatementsPage": StatementsDateRangeState;
 };
 
 type Payload = {
@@ -21,12 +28,24 @@ type Payload = {
   value: any;
 };
 
+const defaultDateRange: StatementsDateRangeState = {
+  start: moment
+    .utc()
+    .subtract(1, "hours")
+    .unix(),
+  end: moment.utc().unix() + 60, // Add 1 minute to account for potential lag.
+};
+
 // TODO (koorosh): initial state should be restored from preserved keys in LocalStorage
 const initialState: LocalStorageState = {
   "adminUi/showDiagnosticsModal":
-    Boolean(localStorage.getItem("adminUi/showDiagnosticsModal")) || false,
+    Boolean(JSON.parse(localStorage.getItem("adminUi/showDiagnosticsModal"))) ||
+    false,
   "showColumns/StatementsPage":
-    localStorage.getItem("showColumns/StatementsPage") || "default",
+    JSON.parse(localStorage.getItem("showColumns/StatementsPage")) || "default",
+  "dateRange/StatementsPage":
+    JSON.parse(localStorage.getItem("dateRange/StatementsPage")) ||
+    defaultDateRange,
 };
 
 const localStorageSlice = createSlice({

--- a/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.saga.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.saga.ts
@@ -14,7 +14,11 @@ import { actions } from "./localStorage.reducer";
 
 export function* updateLocalStorageItemSaga(action: AnyAction) {
   const { key, value } = action.payload;
-  yield call({ context: localStorage, fn: localStorage.setItem }, key, value);
+  yield call(
+    { context: localStorage, fn: localStorage.setItem },
+    key,
+    JSON.stringify(value),
+  );
 }
 
 export function* localStorageSaga() {

--- a/pkg/ui/workspaces/cluster-ui/src/store/sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/sagas.ts
@@ -29,7 +29,6 @@ export function* sagas(cacheInvalidationPeriod?: number) {
     fork(nodesSaga, cacheInvalidationPeriod),
     fork(livenessSaga, cacheInvalidationPeriod),
     fork(sessionsSaga),
-    fork(terminateSaga),
     fork(transactionsSaga),
     fork(notifificationsSaga),
     fork(sqlStatsSaga),

--- a/pkg/ui/workspaces/cluster-ui/src/store/statements/statements.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/statements/statements.reducer.ts
@@ -11,6 +11,7 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import { DOMAIN_NAME, noopReducer } from "../utils";
+import { StatementsRequest } from "src/api/statementsApi";
 
 type StatementsResponse = cockroach.server.serverpb.StatementsResponse;
 
@@ -24,6 +25,11 @@ const initialState: StatementsState = {
   data: null,
   lastError: null,
   valid: true,
+};
+
+export type UpdateDateRangePayload = {
+  start: number;
+  end: number;
 };
 
 const statementsSlice = createSlice({
@@ -42,9 +48,9 @@ const statementsSlice = createSlice({
     invalidated: state => {
       state.valid = false;
     },
-    // Define actions that don't change state
-    refresh: noopReducer,
-    request: noopReducer,
+    refresh: (_, action?: PayloadAction<StatementsRequest>) => {},
+    request: (_, action?: PayloadAction<StatementsRequest>) => {},
+    updateDateRange: (_, action: PayloadAction<UpdateDateRangePayload>) => {},
   },
 });
 

--- a/pkg/ui/workspaces/cluster-ui/src/store/statements/statements.sagas.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/statements/statements.sagas.spec.ts
@@ -13,7 +13,7 @@ import { throwError } from "redux-saga-test-plan/providers";
 import * as matchers from "redux-saga-test-plan/matchers";
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 
-import { getStatements } from "src/api/statementsApi";
+import { getStatements, getCombinedStatements } from "src/api/statementsApi";
 import {
   receivedStatementsSaga,
   refreshStatementsSaga,
@@ -39,6 +39,24 @@ describe("StatementsPage sagas", () => {
     it("successfully requests statements list", () => {
       expectSaga(requestStatementsSaga)
         .provide([[matchers.call.fn(getStatements), statements]])
+        .put(actions.received(statements))
+        .withReducer(reducer)
+        .hasFinalState<StatementsState>({
+          data: statements,
+          lastError: null,
+          valid: true,
+        })
+        .run();
+    });
+
+    it("requests combined statements if combined=true in the request message", () => {
+      const req = {
+        payload: new cockroach.server.serverpb.StatementsRequest({
+          combined: true,
+        }),
+      };
+      expectSaga(requestStatementsSaga, req)
+        .provide([[matchers.call.fn(getCombinedStatements), statements]])
         .put(actions.received(statements))
         .withReducer(reducer)
         .hasFinalState<StatementsState>({

--- a/pkg/ui/workspaces/cluster-ui/src/store/transactions/transactions.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/transactions/transactions.reducer.ts
@@ -11,6 +11,7 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import { DOMAIN_NAME, noopReducer } from "../utils";
+import { StatementsRequest } from "src/api/statementsApi";
 
 type StatementsResponse = cockroach.server.serverpb.StatementsResponse;
 
@@ -43,8 +44,8 @@ const transactionsSlice = createSlice({
       state.valid = false;
     },
     // Define actions that don't change state
-    refresh: noopReducer,
-    request: noopReducer,
+    refresh: (_, action?: PayloadAction<StatementsRequest>) => {},
+    request: (_, action?: PayloadAction<StatementsRequest>) => {},
   },
 });
 

--- a/pkg/ui/workspaces/cluster-ui/src/store/transactions/transactions.sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/transactions/transactions.sagas.ts
@@ -8,20 +8,31 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+import { PayloadAction } from "@reduxjs/toolkit";
 import { all, call, put, delay, takeLatest } from "redux-saga/effects";
-import { getStatements } from "src/api/statementsApi";
+import {
+  getStatements,
+  getCombinedStatements,
+  StatementsRequest,
+} from "src/api/statementsApi";
 import { actions } from "./transactions.reducer";
 import { rootActions } from "../reducers";
 
 import { CACHE_INVALIDATION_PERIOD, throttleWithReset } from "src/store/utils";
 
-export function* refreshTransactionsSaga() {
-  yield put(actions.request());
+export function* refreshTransactionsSaga(
+  action?: PayloadAction<StatementsRequest>,
+) {
+  yield put(actions.request(action?.payload));
 }
 
-export function* requestTransactionsSaga(): any {
+export function* requestTransactionsSaga(
+  action?: PayloadAction<StatementsRequest>,
+): any {
   try {
-    const result = yield call(getStatements);
+    const result = yield action?.payload?.combined
+      ? call(getCombinedStatements, action.payload)
+      : call(getStatements);
     yield put(actions.received(result));
   } catch (e) {
     yield put(actions.failed(e));

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageConnected.tsx
@@ -11,10 +11,12 @@
 import { connect } from "react-redux";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 import { Dispatch } from "redux";
+import { Moment } from "moment";
 
 import { AppState } from "src/store";
 import { actions as transactionsActions } from "src/store/transactions";
 import { actions as resetSQLStatsActions } from "src/store/sqlStats";
+import { actions as statementsActions } from "src/store/statements";
 import { TransactionsPage } from "./transactionsPage";
 import {
   TransactionsPageStateProps,
@@ -26,6 +28,8 @@ import {
 } from "./transactionsPage.selectors";
 import { selectIsTenant } from "../store/uiConfig";
 import { nodeRegionsByIDSelector } from "../store/nodes";
+import { selectDateRange } from "src/statementsPage/statementsPage.selectors";
+import { StatementsRequest } from "src/api/statementsApi";
 
 export const TransactionsPageConnected = withRouter(
   connect<
@@ -38,10 +42,20 @@ export const TransactionsPageConnected = withRouter(
       nodeRegions: nodeRegionsByIDSelector(state),
       error: selectTransactionsLastError(state),
       isTenant: selectIsTenant(state),
+      dateRange: selectIsTenant(state) ? null : selectDateRange(state),
     }),
     (dispatch: Dispatch) => ({
-      refreshData: () => dispatch(transactionsActions.refresh()),
+      refreshData: (req?: StatementsRequest) =>
+        dispatch(transactionsActions.refresh(req)),
       resetSQLStats: () => dispatch(resetSQLStatsActions.request()),
+      onDateRangeChange: (start: Moment, end: Moment) => {
+        dispatch(
+          statementsActions.updateDateRange({
+            start: start.unix(),
+            end: end.unix(),
+          }),
+        );
+      },
     }),
   )(TransactionsPage),
 );

--- a/pkg/ui/workspaces/db-console/src/redux/statements/statementsActions.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/statements/statementsActions.ts
@@ -10,6 +10,7 @@
 
 import { Action } from "redux";
 import { PayloadAction } from "src/interfaces/action";
+import { Moment } from "moment";
 
 export const CREATE_STATEMENT_DIAGNOSTICS_REPORT =
   "cockroachui/statements/CREATE_STATEMENT_DIAGNOSTICS_REPORT";
@@ -54,6 +55,31 @@ export function createOpenDiagnosticsModalAction(
     type: OPEN_STATEMENT_DIAGNOSTICS_MODAL,
     payload: {
       statementFingerprint,
+    },
+  };
+}
+
+/***************************************
+        Combined Stats Actions
+****************************************/
+
+export const SET_COMBINED_STATEMENTS_RANGE =
+  "cockroachui/statements/SET_COMBINED_STATEMENTS_RANGE";
+
+export type CombinedStatementsPayload = {
+  start: Moment;
+  end: Moment;
+};
+
+export function setCombinedStatementsDateRangeAction(
+  start: Moment,
+  end: Moment,
+): PayloadAction<CombinedStatementsPayload> {
+  return {
+    type: SET_COMBINED_STATEMENTS_RANGE,
+    payload: {
+      start,
+      end,
     },
   };
 }

--- a/pkg/ui/workspaces/db-console/src/redux/statements/statementsSagas.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/statements/statementsSagas.ts
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import { all, call, put, takeEvery } from "redux-saga/effects";
+import { all, call, put, takeEvery, takeLatest } from "redux-saga/effects";
 import { PayloadAction } from "src/interfaces/action";
 
 import { createStatementDiagnosticsReport } from "src/util/api";
@@ -17,14 +17,21 @@ import {
   DiagnosticsReportPayload,
   createStatementDiagnosticsReportCompleteAction,
   createStatementDiagnosticsReportFailedAction,
+  CombinedStatementsPayload,
+  SET_COMBINED_STATEMENTS_RANGE,
 } from "./statementsActions";
 import { cockroach } from "src/js/protos";
 import CreateStatementDiagnosticsReportRequest = cockroach.server.serverpb.CreateStatementDiagnosticsReportRequest;
+import CombinedStatementsRequest = cockroach.server.serverpb.StatementsRequest;
 import {
   invalidateStatementDiagnosticsRequests,
   refreshStatementDiagnosticsRequests,
+  invalidateStatements,
+  refreshStatements,
 } from "src/redux/apiReducers";
 import { createStatementDiagnosticsAlertLocalSetting } from "src/redux/alerts";
+import { statementsDateRangeLocalSetting } from "src/redux/statementsDateRange";
+import Long from "long";
 
 export function* createDiagnosticsReportSaga(
   action: PayloadAction<DiagnosticsReportPayload>,
@@ -56,8 +63,30 @@ export function* createDiagnosticsReportSaga(
   }
 }
 
+export function* setCombinedStatementsDateRangeSaga(
+  action: PayloadAction<CombinedStatementsPayload>,
+) {
+  const { start, end } = action.payload;
+  yield put(
+    statementsDateRangeLocalSetting.set({
+      start: start.unix(),
+      end: end.unix(),
+    }),
+  );
+  const req = new CombinedStatementsRequest({
+    start: Long.fromNumber(start.unix()),
+    end: Long.fromNumber(end.unix()),
+  });
+  yield put(invalidateStatements());
+  yield put(refreshStatements(req) as any);
+}
+
 export function* statementsSaga() {
   yield all([
     takeEvery(CREATE_STATEMENT_DIAGNOSTICS_REPORT, createDiagnosticsReportSaga),
+    takeLatest(
+      SET_COMBINED_STATEMENTS_RANGE,
+      setCombinedStatementsDateRangeSaga,
+    ),
   ]);
 }

--- a/pkg/ui/workspaces/db-console/src/redux/statementsDateRange.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/statementsDateRange.ts
@@ -1,0 +1,34 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import moment from "moment";
+import { LocalSetting } from "./localsettings";
+import { AdminUIState } from "./state";
+
+export type CombinedStatementsDateRangePayload = {
+  start: number;
+  end: number;
+};
+
+const localSettingsSelector = (state: AdminUIState) => state.localSettings;
+
+// The default range for statements to display is one hour ago.
+const oneHourAgo = {
+  start: moment
+    .utc()
+    .subtract(1, "hours")
+    .unix(),
+  end: moment.utc().unix() + 60, // Add 1 minute to account for potential lag
+};
+
+export const statementsDateRangeLocalSetting = new LocalSetting<
+  AdminUIState,
+  CombinedStatementsDateRangePayload
+>("statements_date_range", localSettingsSelector, oneHourAgo);

--- a/pkg/ui/workspaces/db-console/src/util/api.ts
+++ b/pkg/ui/workspaces/db-console/src/util/api.ts
@@ -129,6 +129,8 @@ export type CreateStatementDiagnosticsReportResponseMessage = protos.cockroach.s
 export type StatementDiagnosticsRequestMessage = protos.cockroach.server.serverpb.StatementDiagnosticsRequest;
 export type StatementDiagnosticsResponseMessage = protos.cockroach.server.serverpb.StatementDiagnosticsResponse;
 
+export type StatementsRequestMessage = protos.cockroach.server.serverpb.StatementsRequest;
+
 export type ResetSQLStatsRequestMessage = protos.cockroach.server.serverpb.ResetSQLStatsRequest;
 export type ResetSQLStatsResponseMessage = protos.cockroach.server.serverpb.ResetSQLStatsResponse;
 
@@ -670,11 +672,17 @@ export function getStores(
 
 // getStatements returns statements the cluster has recently executed, and some stats about them.
 export function getStatements(
+  req: StatementsRequestMessage,
   timeout?: moment.Duration,
 ): Promise<StatementsResponseMessage> {
+  const queryStr = propsToQueryString({
+    combined: true,
+    start: req.start.toInt(),
+    end: req.end.toInt(),
+  });
   return timeoutFetch(
     serverpb.StatementsResponse,
-    `${STATUS_PREFIX}/statements`,
+    `${STATUS_PREFIX}/statements?${queryStr}`,
     null,
     timeout,
   );

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementDetails.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementDetails.tsx
@@ -56,6 +56,7 @@ import {
   trackDownloadDiagnosticsBundleAction,
   trackStatementDetailsSubnavSelectionAction,
 } from "src/redux/analyticsActions";
+import { selectDateRange } from "src/views/statements/statementsPage";
 
 interface Fraction {
   numerator: number;
@@ -154,6 +155,7 @@ export const selectStatement = createSelector(
   (_state: AdminUIState, props: RouteComponentProps) => props,
   (statementsState, props) => {
     const statements = statementsState.data?.statements;
+
     if (!statements) {
       return null;
     }
@@ -192,6 +194,7 @@ const mapStateToProps = (
   return {
     statement,
     statementsError: state.cachedData.statements.lastError,
+    dateRange: selectDateRange(state),
     nodeNames: nodeDisplayNameByIDSelector(state),
     nodeRegions: nodeRegionsByIDSelector(state),
     diagnosticsReports: selectDiagnosticsReportsByStatementFingerprint(

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.fixture.ts
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.fixture.ts
@@ -10,12 +10,14 @@
 
 import { StatementsPageProps } from "@cockroachlabs/cluster-ui";
 import { createMemoryHistory } from "history";
+import moment from "moment";
 import Long from "long";
 import * as protos from "src/js/protos";
 import {
   refreshStatementDiagnosticsRequests,
   refreshStatements,
 } from "src/redux/apiReducers";
+
 type IStatementStatistics = protos.cockroach.sql.IStatementStatistics;
 
 const history = createMemoryHistory({ initialEntries: ["/statements"] });
@@ -503,9 +505,11 @@ const statementsPagePropsFixture: StatementsPageProps = {
   apps: ["(internal)", "movr", "$ cockroach demo"],
   totalFingerprints: 95,
   lastReset: "2020-04-13 07:22:23",
+  dateRange: [moment.utc("2021.08.08"), moment.utc("2021.08.12")],
   dismissAlertMessage: () => {},
   refreshStatementDiagnosticsRequests: (() => {}) as typeof refreshStatementDiagnosticsRequests,
   refreshStatements: (() => {}) as typeof refreshStatements,
+  onDateRangeChange: () => {},
   onActivateStatementDiagnostics: _ => {},
   onDiagnosticsModalOpen: _ => {},
   onPageChanged: _ => {},


### PR DESCRIPTION
Resolves cockroachdb#68089, cockroachdb#69474

This commit adds date range state
properties and a date range selector component to the DB
console's statements and transactions pages. This change
is necessary to support surfacing persisted
statistics in the DB console.

This commit adds date range state
properties and a date range selector component to the DB
console's statements and transactions pages. This change
is necessary to support surfacing persisted
statistics in the DB console.

The date range query parameters used by the api to fetch
data is stored in localSettings on db console and
localStorage in cluster-ui. The default date range
is set to 1 hour ago, and is used as the value when user's
reset the date range.

The user is able to select dates as far back as 1 year ago,
this does not mean there is data available.

Release justification: category 4 low risk, high benefit
changes to existing functionality

Release note (ui change): New date range selector component
to the DB console's statements page with the ability to show
historical data. The default date range is set to 1 hour ago,
and is used as the value when user's reset the date range.

------------------
![image](https://user-images.githubusercontent.com/20136951/131007768-9a7bfeb6-a0f0-417a-8160-51f8d636f73b.png)
![image](https://user-images.githubusercontent.com/20136951/131007809-ff98359e-bfcc-4cb1-9b0b-eb34f8d04cd0.png)
![image](https://user-images.githubusercontent.com/20136951/131036176-11b03aa6-16e5-4601-b92e-e13dd0dc03df.png)
![image](https://user-images.githubusercontent.com/20136951/131198830-6b727e68-0983-483e-9385-f23e16cde705.png)

Transactions page:
![image](https://user-images.githubusercontent.com/20136951/131222215-bb2b013c-034e-40bf-8d83-7f5d9784065a.png)
