### PR TITLE
[WIP] auth: create cluster setting for maximum password expiration delay

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -66,6 +66,7 @@ server.shutdown.drain_wait	duration	0s	the amount of time a server waits in an u
 server.shutdown.lease_transfer_wait	duration	5s	the amount of time a server waits to transfer range leases before proceeding with the rest of the shutdown process
 server.shutdown.query_wait	duration	10s	the server will wait for at least this amount of time for active queries to finish
 server.time_until_store_dead	duration	5m0s	the time after which if there is no new gossiped information about a store, it is considered dead
+server.user_login.max_password_expiration_delay	duration	1h0m0s	maximum duration that passwords are valid
 server.user_login.timeout	duration	10s	timeout after which client authentication times out if some system range is unavailable (0 = no timeout)
 server.web_session.auto_logout.timeout	duration	168h0m0s	the duration that web sessions will survive before being periodically purged, since they were last used
 server.web_session.purge.max_deletions_per_cycle	integer	10	the maximum number of old sessions to delete for each purge
@@ -103,6 +104,7 @@ sql.defaults.lock_timeout	duration	0s	default value for the lock_timeout; defaul
 sql.defaults.optimizer_use_histograms.enabled	boolean	true	default value for optimizer_use_histograms session setting; enables usage of histograms in the optimizer by default
 sql.defaults.optimizer_use_multicol_stats.enabled	boolean	true	default value for optimizer_use_multicol_stats session setting; enables usage of multi-column stats in the optimizer by default
 sql.defaults.override_multi_region_zone_config.enabled	boolean	false	default value for override_multi_region_zone_config; allows for overriding the zone configs of a multi-region table or database
+sql.defaults.password_expiration_delay	duration	1h0m0s	default duration after which passwords expire
 sql.defaults.prefer_lookup_joins_for_fks.enabled	boolean	false	default value for prefer_lookup_joins_for_fks session setting; causes foreign key operations to use lookup joins when possible
 sql.defaults.primary_region	string		if not empty, all databases created without a PRIMARY REGION will implicitly have the given PRIMARY REGION
 sql.defaults.require_explicit_primary_keys.enabled	boolean	false	default value for requiring explicit primary keys in CREATE TABLE statements

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -70,6 +70,7 @@
 <tr><td><code>server.shutdown.lease_transfer_wait</code></td><td>duration</td><td><code>5s</code></td><td>the amount of time a server waits to transfer range leases before proceeding with the rest of the shutdown process</td></tr>
 <tr><td><code>server.shutdown.query_wait</code></td><td>duration</td><td><code>10s</code></td><td>the server will wait for at least this amount of time for active queries to finish</td></tr>
 <tr><td><code>server.time_until_store_dead</code></td><td>duration</td><td><code>5m0s</code></td><td>the time after which if there is no new gossiped information about a store, it is considered dead</td></tr>
+<tr><td><code>server.user_login.max_password_expiration_delay</code></td><td>duration</td><td><code>1h0m0s</code></td><td>maximum duration that passwords are valid</td></tr>
 <tr><td><code>server.user_login.timeout</code></td><td>duration</td><td><code>10s</code></td><td>timeout after which client authentication times out if some system range is unavailable (0 = no timeout)</td></tr>
 <tr><td><code>server.web_session.auto_logout.timeout</code></td><td>duration</td><td><code>168h0m0s</code></td><td>the duration that web sessions will survive before being periodically purged, since they were last used</td></tr>
 <tr><td><code>server.web_session.purge.max_deletions_per_cycle</code></td><td>integer</td><td><code>10</code></td><td>the maximum number of old sessions to delete for each purge</td></tr>
@@ -107,6 +108,7 @@
 <tr><td><code>sql.defaults.optimizer_use_histograms.enabled</code></td><td>boolean</td><td><code>true</code></td><td>default value for optimizer_use_histograms session setting; enables usage of histograms in the optimizer by default</td></tr>
 <tr><td><code>sql.defaults.optimizer_use_multicol_stats.enabled</code></td><td>boolean</td><td><code>true</code></td><td>default value for optimizer_use_multicol_stats session setting; enables usage of multi-column stats in the optimizer by default</td></tr>
 <tr><td><code>sql.defaults.override_multi_region_zone_config.enabled</code></td><td>boolean</td><td><code>false</code></td><td>default value for override_multi_region_zone_config; allows for overriding the zone configs of a multi-region table or database</td></tr>
+<tr><td><code>sql.defaults.password_expiration_delay</code></td><td>duration</td><td><code>1h0m0s</code></td><td>default duration after which passwords expire</td></tr>
 <tr><td><code>sql.defaults.prefer_lookup_joins_for_fks.enabled</code></td><td>boolean</td><td><code>false</code></td><td>default value for prefer_lookup_joins_for_fks session setting; causes foreign key operations to use lookup joins when possible</td></tr>
 <tr><td><code>sql.defaults.primary_region</code></td><td>string</td><td><code></code></td><td>if not empty, all databases created without a PRIMARY REGION will implicitly have the given PRIMARY REGION</td></tr>
 <tr><td><code>sql.defaults.require_explicit_primary_keys.enabled</code></td><td>boolean</td><td><code>false</code></td><td>default value for requiring explicit primary keys in CREATE TABLE statements</td></tr>

--- a/pkg/security/password.go
+++ b/pkg/security/password.go
@@ -80,14 +80,27 @@ func HashPassword(ctx context.Context, password string) ([]byte, error) {
 	return bcrypt.GenerateFromPassword(appendEmptySha256(password), BcryptCost)
 }
 
-// MinPasswordLength is the cluster setting that configures the
-// minimum SQL password length.
-var MinPasswordLength = settings.RegisterIntSetting(
-	"server.user_login.min_password_length",
-	"the minimum length accepted for passwords set in cleartext via SQL. "+
-		"Note that a value lower than 1 is ignored: passwords cannot be empty in any case.",
-	1,
-	settings.NonNegativeInt,
+var (
+	MinPasswordLength = settings.RegisterIntSetting(
+		"server.user_login.min_password_length",
+		"the minimum length accepted for passwords set in cleartext via SQL. "+
+			"Note that a value lower than 1 is ignored: passwords cannot be empty in any case.",
+		1,
+		settings.NonNegativeInt,
+	)
+	MaxPasswordExpirationDelay = settings.RegisterDurationSetting(
+		"server.user_login.max_password_expiration_delay",
+		"maximum duration that passwords are valid. If zero, there is no upper "+
+			"limit on the expiration delay.",
+		0,
+	).WithPublic()
+	DefaultPasswordExpirationDelay = settings.RegisterDurationSetting(
+		"server.user_login.default_password_expiration_delay",
+		"default duration after which passwords expire. If zero and the user "+
+			"does not specify an expiration delay, there is no password timeout.",
+		0,
+		settings.NonNegativeDuration,
+	).WithPublic()
 )
 
 // bcryptSemOnce wraps a semaphore that limits the number of concurrent calls

--- a/pkg/server/authentication.go
+++ b/pkg/server/authentication.go
@@ -435,7 +435,7 @@ func (s *authenticationServer) verifyPassword(
 		return false, false, err
 	}
 
-	if validUntil != nil {
+	if validUntil != nil && !username.IsRootUser() {
 		if validUntil.Time.Sub(timeutil.Now()) < 0 {
 			return false, true, nil
 		}

--- a/pkg/sql/sessioninit/cache.go
+++ b/pkg/sql/sessioninit/cache.go
@@ -101,12 +101,13 @@ func (a *Cache) GetAuthInfo(
 	readFromSystemTables func(
 		ctx context.Context,
 		txn *kv.Txn,
+		settings *cluster.Settings,
 		ie sqlutil.InternalExecutor,
 		username security.SQLUsername,
 	) (AuthInfo, error),
 ) (aInfo AuthInfo, err error) {
 	if !CacheEnabled.Get(&settings.SV) {
-		return readFromSystemTables(ctx, nil /* txn */, ie, username)
+		return readFromSystemTables(ctx, nil /* txn */, settings, ie, username)
 	}
 	err = f.Txn(ctx, ie, db, func(
 		ctx context.Context, txn *kv.Txn, descriptors *descs.Collection,
@@ -138,6 +139,7 @@ func (a *Cache) GetAuthInfo(
 			aInfo, err = readFromSystemTables(
 				ctx,
 				txn,
+				settings,
 				ie,
 				username,
 			)
@@ -161,6 +163,7 @@ func (a *Cache) GetAuthInfo(
 			aInfo, err = readFromSystemTables(
 				ctx,
 				txn,
+				settings,
 				ie,
 				username,
 			)

--- a/pkg/sql/user.go
+++ b/pkg/sql/user.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -171,7 +172,11 @@ func retrieveSessionInitInfoWithCache(
 }
 
 func retrieveAuthInfo(
-	ctx context.Context, txn *kv.Txn, ie sqlutil.InternalExecutor, username security.SQLUsername,
+	ctx context.Context,
+	txn *kv.Txn,
+	settings *cluster.Settings,
+	ie sqlutil.InternalExecutor,
+	username security.SQLUsername,
 ) (aInfo sessioninit.AuthInfo, retErr error) {
 	// Use fully qualified table name to avoid looking up "".system.users.
 	const getHashedPassword = `SELECT "hashedPassword" FROM system.public.users ` +


### PR DESCRIPTION
Fixes [#62080](https://github.com/cockroachdb/cockroach/issues/62080).

This patch adds a cluster setting that establishes an
upper limit on password expiration delay. This patch
also adds a default password timeout. This allows for a
global password timeout for all users of a cluster.

Release note (security update): There is now a default
password expiration delay. Now possible to set a
maximum password expiration delay to limit password
timeouts that are too long. Refer to the reference
docs for details about the new cluster setting for
password expiration.