### PR TITLE
backupccl: add prototype metadata.sst

### DIFF
--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -371,6 +371,16 @@ func backup(
 		return RowCount{}, err
 	}
 
+	if writeMetadataSST.Get(&settings.SV) {
+		if err := writeBackupMetadataSST(ctx, defaultStore, encryption, backupManifest, tableStatistics); err != nil {
+			err = errors.Wrap(err, "writing forward-compat metadata sst")
+			if !build.IsRelease() {
+				return RowCount{}, err
+			}
+			log.Warningf(ctx, "%+v", err)
+		}
+	}
+
 	return backupManifest.EntryCounts, nil
 }
 

--- a/pkg/ccl/backupccl/backup_metadata.go
+++ b/pkg/ccl/backupccl/backup_metadata.go
@@ -1,0 +1,411 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package backupccl
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
+	"github.com/cockroachdb/cockroach/pkg/cloud"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/protoreflect"
+	"github.com/cockroachdb/cockroach/pkg/sql/stats"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/json"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/errors"
+)
+
+const (
+	metadataSSTName = "metadata.sst"
+
+	sstBackupKey     = "backup"
+	sstDescsPrefix   = "desc/"
+	sstFilesPrefix   = "file/"
+	sstNamesPrefix   = "name/"
+	sstSpansPrefix   = "span/"
+	sstStatsPrefix   = "stats/"
+	sstTenantsPrefix = "tenant/"
+)
+
+func writeBackupMetadataSST(
+	ctx context.Context,
+	dest cloud.ExternalStorage,
+	enc *jobspb.BackupEncryptionOptions,
+	manifest *BackupManifest,
+	stats []*stats.TableStatisticProto,
+) error {
+	var w io.WriteCloser
+	ctx, cancel := context.WithCancel(ctx)
+	defer func() {
+		cancel() // cancel before Close() to abort write on err returns.
+		if w != nil {
+			w.Close()
+		}
+	}()
+
+	w, err := dest.Writer(ctx, metadataSSTName)
+	if err != nil {
+		return err
+	}
+
+	if enc != nil {
+		key, err := getEncryptionKey(ctx, enc, dest.Settings(), dest.ExternalIOConf())
+		if err != nil {
+			return err
+		}
+		encW, err := storageccl.EncryptingWriter(w, key)
+		if err != nil {
+			return err
+		}
+		w = encW
+	}
+
+	if err := constructMetadataSST(ctx, w, manifest, stats); err != nil {
+		return err
+	}
+
+	// Explicitly close to flush and check for errors do so before defer's cancel
+	// which would abort. Then nil out w to avoid defer double-closing.
+	err = w.Close()
+	w = nil
+	return err
+}
+
+func constructMetadataSST(ctx context.Context,
+	w io.Writer,
+	m *BackupManifest,
+	stats []*stats.TableStatisticProto,
+) error {
+	// TODO(dt): use a seek-optimized SST writer instead.
+	sst := storage.MakeBackupSSTWriter(w)
+	defer sst.Close()
+
+	// The following steps must be done in-order, by key prefix.
+
+	if err := writeManifestToMetadata(ctx, sst, m); err != nil {
+		return err
+	}
+
+	if err := writeDescsToMetadata(ctx, sst, m); err != nil {
+		return err
+	}
+
+	if err := writeFilesToMetadata(ctx, sst, m); err != nil {
+		return err
+	}
+
+	if err := writeNamesToMetadata(ctx, sst, m); err != nil {
+		return err
+	}
+
+	if err := writeSpansToMetadata(ctx, sst, m); err != nil {
+		return err
+	}
+
+	if err := writeStatsToMetadata(ctx, sst, stats); err != nil {
+		return err
+	}
+
+	if err := writeTenantsToMetadata(ctx, sst, m); err != nil {
+		return err
+	}
+
+	return sst.Finish()
+}
+
+func writeManifestToMetadata(ctx context.Context, sst storage.SSTWriter, m *BackupManifest) error {
+	info := *m
+	info.Descriptors = nil
+	info.DescriptorChanges = nil
+	info.Files = nil
+	info.Spans = nil
+	info.StatisticsFilenames = nil
+	info.IntroducedSpans = nil
+	info.Tenants = nil
+
+	b, err := protoutil.Marshal(&info)
+	if err != nil {
+		return err
+	}
+	return sst.PutUnversioned(roachpb.Key(sstBackupKey), b)
+}
+
+func writeDescsToMetadata(ctx context.Context, sst storage.SSTWriter, m *BackupManifest) error {
+	// Add descriptors from revisions if available, Descriptors if not.
+	if len(m.DescriptorChanges) > 0 {
+		sort.Slice(m.DescriptorChanges, func(i, j int) bool {
+			if m.DescriptorChanges[i].ID < m.DescriptorChanges[j].ID {
+				return true
+			} else if m.DescriptorChanges[i].ID == m.DescriptorChanges[j].ID {
+				return !m.DescriptorChanges[i].Time.Less(m.DescriptorChanges[j].Time)
+			}
+			return false
+		})
+		for _, i := range m.DescriptorChanges {
+			k := encodeDescSSTKey(i.ID)
+			var b []byte
+			if i.Desc != nil {
+				if t := i.Desc.GetTable(); t == nil || !t.Dropped() {
+					bytes, err := protoutil.Marshal(i.Desc)
+					if err != nil {
+						return err
+					}
+					b = bytes
+				}
+			}
+			sst.PutMVCC(storage.MVCCKey{Key: k, Timestamp: i.Time}, b)
+		}
+	} else {
+		sort.Slice(m.Descriptors, func(i, j int) bool {
+			return descID(m.Descriptors[i]) < descID(m.Descriptors[j])
+		})
+		for _, i := range m.Descriptors {
+			id := descID(i)
+			k := encodeDescSSTKey(id)
+			b, err := protoutil.Marshal(&i)
+			if err != nil {
+				return err
+			}
+			// It does not really matter what time we put the descriptors at for a
+			// non-rev-history backup -- we could put them at 0 or at end-time, since
+			// any RESTORE will be reading as of end-time which would be >= both.
+			sst.PutMVCC(storage.MVCCKey{Key: k, Timestamp: m.EndTime}, b)
+		}
+	}
+	return nil
+}
+
+func writeFilesToMetadata(ctx context.Context, sst storage.SSTWriter, m *BackupManifest) error {
+	sort.Slice(m.Files, func(i, j int) bool {
+		cmp := m.Files[i].Span.Key.Compare(m.Files[j].Span.Key)
+		return cmp < 0 || (cmp == 0 && strings.Compare(m.Files[i].Path, m.Files[j].Path) < 0)
+	})
+
+	for _, i := range m.Files {
+		b, err := protoutil.Marshal(&i)
+		if err != nil {
+			return err
+		}
+		if err := sst.PutUnversioned(encodeFileSSTKey(i.Span.Key, i.Path), b); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type name struct {
+	parent, parentSchema descpb.ID
+	name                 string
+	id                   descpb.ID
+	ts                   hlc.Timestamp
+}
+
+type namespace []name
+
+func (a namespace) Len() int      { return len(a) }
+func (a namespace) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a namespace) Less(i, j int) bool {
+	if a[i].parent == a[j].parent {
+		if a[i].parentSchema == a[j].parentSchema {
+			cmp := strings.Compare(a[i].name, a[j].name)
+			return cmp < 0 || (cmp == 0 && (a[i].ts.IsEmpty() || a[j].ts.Less(a[i].ts)))
+		}
+		return a[i].parentSchema < a[j].parentSchema
+	}
+	return a[i].parent < a[j].parent
+}
+
+func writeNamesToMetadata(ctx context.Context, sst storage.SSTWriter, m *BackupManifest) error {
+	revs := m.DescriptorChanges
+	if len(revs) == 0 {
+		revs := make([]BackupManifest_DescriptorRevision, len(m.Descriptors))
+		for i := range m.Descriptors {
+			revs[i].Desc = &m.Descriptors[i]
+			revs[i].Time = m.EndTime
+			revs[i].ID = descID(m.Descriptors[i])
+		}
+	}
+
+	names := make(namespace, len(revs))
+
+	for i, rev := range revs {
+		names[i].id = rev.ID
+		names[i].ts = rev.Time
+		if db := rev.Desc.GetDatabase(); db != nil {
+			names[i].name = db.Name
+		} else if sc := rev.Desc.GetSchema(); sc != nil {
+			names[i].name = sc.Name
+			names[i].parent = sc.ParentID
+		} else if tb := rev.Desc.GetTable(); tb != nil {
+			names[i].name = tb.Name
+			names[i].parent = tb.ParentID
+			names[i].parentSchema = keys.PublicSchemaID
+			if s := tb.UnexposedParentSchemaID; s != descpb.InvalidID {
+				names[i].parentSchema = s
+			}
+			if tb.Dropped() {
+				names[i].id = 0
+			}
+		} else if typ := rev.Desc.GetType(); typ != nil {
+			names[i].name = typ.Name
+			names[i].parent = typ.ParentID
+			names[i].parentSchema = typ.ParentSchemaID
+		}
+	}
+	sort.Sort(names)
+
+	for i, rev := range names {
+		if i > 0 {
+			prev := names[i-1]
+			prev.ts = rev.ts
+			if prev == rev {
+				continue
+			}
+		}
+		k := encodeNameSSTKey(rev.parent, rev.parentSchema, rev.name)
+		v := encoding.EncodeUvarintAscending(nil, uint64(rev.id))
+		if err := sst.PutMVCC(storage.MVCCKey{Key: k, Timestamp: rev.ts}, v); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func writeSpansToMetadata(ctx context.Context, sst storage.SSTWriter, m *BackupManifest) error {
+	sort.Sort(roachpb.Spans(m.Spans))
+	sort.Sort(roachpb.Spans(m.IntroducedSpans))
+
+	for i, j := 0, 0; i < len(m.Spans) || j < len(m.IntroducedSpans); {
+		var sp roachpb.Span
+		var ts hlc.Timestamp
+
+		// Merge spans and introduced spans into one series of spans where the ts on
+		// each is 0 if it was introduced or the backup start time otherwise.
+		if j >= len(m.IntroducedSpans) {
+			sp = m.Spans[i]
+			ts = m.StartTime
+			i++
+		} else if i >= len(m.Spans) {
+			sp = m.IntroducedSpans[j]
+			ts = hlc.Timestamp{}
+			j++
+		} else {
+			cmp := m.Spans[i].Key.Compare(m.IntroducedSpans[j].Key)
+			if cmp < 0 {
+				sp = m.Spans[i]
+				ts = m.StartTime
+				i++
+			} else {
+				sp = m.IntroducedSpans[j]
+				ts = hlc.Timestamp{}
+				j++
+			}
+		}
+		if ts.IsEmpty() {
+			if err := sst.PutUnversioned(encodeSpanSSTKey(sp), nil); err != nil {
+				return err
+			}
+		} else {
+			k := storage.MVCCKey{Key: encodeSpanSSTKey(sp), Timestamp: ts}
+			if err := sst.PutMVCC(k, nil); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func writeStatsToMetadata(ctx context.Context, sst storage.SSTWriter, stats []*stats.TableStatisticProto) error {
+	sort.Slice(stats, func(i, j int) bool {
+		return stats[i].TableID < stats[j].TableID || (stats[i].TableID == stats[j].TableID && stats[i].StatisticID < stats[j].StatisticID)
+	})
+
+	for _, i := range stats {
+		b, err := protoutil.Marshal(i)
+		if err != nil {
+			return err
+		}
+		if err := sst.PutUnversioned(encodeStatSSTKey(i.TableID, i.StatisticID), b); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeTenantsToMetadata(ctx context.Context, sst storage.SSTWriter, m *BackupManifest) error {
+	sort.Slice(m.Tenants, func(i, j int) bool { return m.Tenants[i].ID < m.Tenants[j].ID })
+	for _, i := range m.Tenants {
+		b, err := protoutil.Marshal(&i)
+		if err != nil {
+			return err
+		}
+		if err := sst.PutUnversioned(encodeTenantSSTKey(i.ID), b); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func descID(in descpb.Descriptor) descpb.ID {
+	switch i := in.Union.(type) {
+	case *descpb.Descriptor_Table:
+		return i.Table.ID
+	case *descpb.Descriptor_Database:
+		return i.Database.ID
+	case *descpb.Descriptor_Type:
+		return i.Type.ID
+	case *descpb.Descriptor_Schema:
+		return i.Schema.ID
+	default:
+		panic(fmt.Sprintf("unknown desc %T", in))
+	}
+}
+
+func encodeDescSSTKey(id descpb.ID) roachpb.Key {
+	return roachpb.Key(encoding.EncodeUvarintAscending([]byte(sstDescsPrefix), uint64(id)))
+}
+
+func encodeFileSSTKey(spanStart roachpb.Key, filename string) roachpb.Key {
+	buf := encoding.EncodeBytesAscending([]byte(sstFilesPrefix), spanStart)
+	return roachpb.Key(encoding.EncodeStringAscending(buf, filename))
+}
+
+func encodeNameSSTKey(parentDB, parentSchema descpb.ID, name string) roachpb.Key {
+	buf := []byte(sstNamesPrefix)
+	buf = encoding.EncodeUvarintAscending(buf, uint64(parentDB))
+	buf = encoding.EncodeUvarintAscending(buf, uint64(parentSchema))
+	return roachpb.Key(encoding.EncodeStringAscending(buf, name))
+}
+
+func encodeSpanSSTKey(span roachpb.Span) roachpb.Key {
+	buf := encoding.EncodeBytesAscending([]byte(sstSpansPrefix), span.Key)
+	return roachpb.Key(encoding.EncodeBytesAscending(buf, span.EndKey))
+}
+
+func encodeStatSSTKey(id descpb.ID, statID uint64) roachpb.Key {
+	buf := encoding.EncodeUvarintAscending([]byte(sstStatsPrefix), uint64(id))
+	return roachpb.Key(encoding.EncodeUvarintAscending(buf, statID))
+}
+
+func encodeTenantSSTKey(id uint64) roachpb.Key {
+	return encoding.EncodeUvarintAscending([]byte(sstTenantsPrefix), id)
+}
+

--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -61,6 +61,7 @@ const (
 	backupOptEncKMS             = "kms"
 	backupOptWithPrivileges     = "privileges"
 	backupOptAsJSON             = "as_json"
+	backupOptDebugMetadataSST   = "debug_dump_metadata_sst"
 	backupOptWithDebugIDs       = "debug_ids"
 	localityURLParam            = "COCKROACH_LOCALITY"
 	defaultLocalityValue        = "default"

--- a/pkg/ccl/backupccl/manifest_handling.go
+++ b/pkg/ccl/backupccl/manifest_handling.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
@@ -80,6 +81,12 @@ const (
 	// Also exported for testing backup inspection tooling.
 	DateBasedIntoFolderName = "/2006/01/02-150405.00"
 	latestFileName          = "LATEST"
+)
+
+var writeMetadataSST = settings.RegisterBoolSetting(
+	"kv.bulkio.write_metadata_sst.enabled",
+	"write experimental new format BACKUP metadata file",
+	true,
 )
 
 // isGZipped detects whether the given bytes represent GZipped data. This check

--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
@@ -134,6 +135,52 @@ func (m manifestInfoReader) showBackup(
 	return nil
 }
 
+type metadataSSTInfoReader struct{}
+
+var _ backupInfoReader = manifestInfoReader{}
+
+func (m metadataSSTInfoReader) header() colinfo.ResultColumns {
+	return colinfo.ResultColumns{
+		{Name: "file", Typ: types.String},
+		{Name: "key", Typ: types.String},
+		{Name: "detail", Typ: types.Jsonb},
+	}
+}
+
+func (m metadataSSTInfoReader) showBackup(
+	ctx context.Context,
+	store cloud.ExternalStorage,
+	enc *jobspb.BackupEncryptionOptions,
+	incPaths []string,
+	resultsCh chan<- tree.Datums,
+) error {
+	filename := metadataSSTName
+	push := func(_, readable string, value json.JSON) error {
+		val := tree.DNull
+		if value != nil {
+			val = tree.NewDJSON(value)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case resultsCh <- []tree.Datum{tree.NewDString(filename), tree.NewDString(readable), val}:
+			return nil
+		}
+	}
+
+	if err := DebugDumpMetadataSST(ctx, store, filename, enc, push); err != nil {
+		return err
+	}
+
+	for _, i := range incPaths {
+		filename = strings.TrimSuffix(i, backupManifestName) + metadataSSTName
+		if err := DebugDumpMetadataSST(ctx, store, filename, enc, push); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // showBackupPlanHook implements PlanHookFn.
 func showBackupPlanHook(
 	ctx context.Context, stmt tree.Statement, p sql.PlanHookState,
@@ -161,11 +208,12 @@ func showBackupPlanHook(
 	}
 
 	expected := map[string]sql.KVStringOptValidate{
-		backupOptEncPassphrase:  sql.KVStringOptRequireValue,
-		backupOptEncKMS:         sql.KVStringOptRequireValue,
-		backupOptWithPrivileges: sql.KVStringOptRequireNoValue,
-		backupOptAsJSON:         sql.KVStringOptRequireNoValue,
-		backupOptWithDebugIDs:   sql.KVStringOptRequireNoValue,
+		backupOptEncPassphrase:    sql.KVStringOptRequireValue,
+		backupOptEncKMS:           sql.KVStringOptRequireValue,
+		backupOptWithPrivileges:   sql.KVStringOptRequireNoValue,
+		backupOptAsJSON:           sql.KVStringOptRequireNoValue,
+		backupOptWithDebugIDs:     sql.KVStringOptRequireNoValue,
+		backupOptDebugMetadataSST: sql.KVStringOptRequireNoValue,
 	}
 	optsFn, err := p.TypeAsStringOpts(ctx, backup.Options, expected)
 	if err != nil {
@@ -181,18 +229,22 @@ func showBackupPlanHook(
 	}
 
 	var infoReader backupInfoReader
-	var shower backupShower
-	switch backup.Details {
-	case tree.BackupRangeDetails:
-		shower = backupShowerRanges
-	case tree.BackupFileDetails:
-		shower = backupShowerFiles
-	case tree.BackupManifestAsJSON:
-		shower = jsonShower
-	default:
-		shower = backupShowerDefault(ctx, p, backup.ShouldIncludeSchemas, opts)
+	if _, dumpSST := opts[backupOptDebugMetadataSST]; dumpSST {
+		infoReader = metadataSSTInfoReader{}
+	} else {
+		var shower backupShower
+		switch backup.Details {
+		case tree.BackupRangeDetails:
+			shower = backupShowerRanges
+		case tree.BackupFileDetails:
+			shower = backupShowerFiles
+		case tree.BackupManifestAsJSON:
+			shower = jsonShower
+		default:
+			shower = backupShowerDefault(ctx, p, backup.ShouldIncludeSchemas, opts)
+		}
+		infoReader = manifestInfoReader{shower}
 	}
-	infoReader = manifestInfoReader{shower}
 
 	fn := func(ctx context.Context, _ []sql.PlanNode, resultsCh chan<- tree.Datums) error {
 		// TODO(dan): Move this span into sql.


### PR DESCRIPTION
This adds writing of an additional file to the completion of BACKUP. This new file
is an sstable that contains the same metadata currently stored in the BACKUP_MANIFEST
file and statistics files, but organizes that data differently.

The current BACKUP_MANIFEST file contains a single binary-encoded protobuf message
of type BackupManifest, that in turn has several fields some of which are repeated
to contain e.g. the TableDescriptor for every table backed up, or every revision to
every table descriptor backed up. This can result in these manifests being quite large
in some cases, which is potentially concerning because as a single protobuf message,
one has to read and unmarshal the entire struct into memory to read any field(s) of it.

Organizing this metadata into an SSTable where repeated fields are instead stored as
separate messages under separate keys should instead allow reading it incrementally:
one can seek to a particular key or key prefix and then scan, acting on whatever data
is found as it is read, without loading the entire file at once (when opened using the
same seek-ing remote SST reader we use to read backup data ssts).

Thi initial prototype adds only the writer -- RESTORE does not rely on, or even open,
this new file at this time.

Release note: none.