### PR TITLE
kvserver: skip `TestStoreRangeMergeConcurrentRequests` under `stress`

### DIFF
--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -2262,6 +2262,7 @@ func TestStoreRangeMergeCheckConsistencyAfterSubsumption(t *testing.T) {
 func TestStoreRangeMergeConcurrentRequests(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.UnderStress(t, "falls apart with timeouts under high concurrency")
 
 	var store *kvserver.Store
 	manualClock := hlc.NewHybridManualClock()


### PR DESCRIPTION
The test can fall apart under high concurrency due to timeouts, so skip
it under `stress`.

Resolves #68703.

Release note: None