### PR TITLE
utilccl: add ErrBreakerOpen to bulk retryable error

### DIFF
--- a/pkg/ccl/utilccl/BUILD.bazel
+++ b/pkg/ccl/utilccl/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/util/grpcutil",
         "//pkg/util/timeutil",
         "//pkg/util/uuid",
+        "@com_github_cockroachdb_circuitbreaker//:circuitbreaker",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
     ],


### PR DESCRIPTION
In https://github.com/cockroachdb/cockroach/issues/68787
we saw a backup job failing on retry because of attempting
to plan a flow on a node that has been shutdown. This should
not usually happen since everytime we plan the flow we fetch
the nodes that can participate in the distsql flow.

In case we do encounter a `breaker open` error we can retry
hoping that the next time the flow is planned it doesn't
attempt to dial the dead node.

Release note: None