### PR TITLE
colflow: use proper NodeDialer for EXPLAIN (VEC)

### DIFF
--- a/pkg/sql/colflow/explain_vec.go
+++ b/pkg/sql/colflow/explain_vec.go
@@ -56,7 +56,7 @@ func convertToVecTree(
 	// creator.
 	creator := newVectorizedFlowCreator(
 		newNoopFlowCreatorHelper(), vectorizedRemoteComponentCreator{}, false, false,
-		nil, &execinfra.RowChannel{}, &fakeBatchReceiver{}, nil, execinfrapb.FlowID{}, colcontainer.DiskQueueCfg{},
+		nil, &execinfra.RowChannel{}, &fakeBatchReceiver{}, flowCtx.Cfg.NodeDialer, execinfrapb.FlowID{}, colcontainer.DiskQueueCfg{},
 		flowCtx.Cfg.VecFDSemaphore, flowCtx.TypeResolverFactory.NewTypeResolver(flowCtx.EvalCtx.Txn),
 		admission.WorkInfo{},
 	)

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -715,7 +715,7 @@ func (p *PlanningCtx) getDefaultSaveFlowsFunc(
 		var explainVec []string
 		var explainVecVerbose []string
 		if planner.instrumentation.collectBundle && planner.curPlan.flags.IsSet(planFlagVectorized) {
-			flowCtx := newFlowCtxForExplainPurposes(p, planner, &planner.extendedEvalCtx.DistSQLPlanner.rpcCtx.ClusterID)
+			flowCtx := newFlowCtxForExplainPurposes(p, planner)
 			getExplain := func(verbose bool) []string {
 				explain, err := colflow.ExplainVec(
 					ctx, flowCtx, flows, p.infra.LocalProcessors, opChains,

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -82,7 +82,7 @@ func (e *explainPlanNode) startExec(params runParams) error {
 		// cause an error or panic, so swallow the error. See #40677 for example.
 		distSQLPlanner.FinalizePlan(planCtx, physicalPlan)
 		flows := physicalPlan.GenerateFlowSpecs()
-		flowCtx := newFlowCtxForExplainPurposes(planCtx, params.p, &distSQLPlanner.rpcCtx.ClusterID)
+		flowCtx := newFlowCtxForExplainPurposes(planCtx, params.p)
 
 		ctxSessionData := flowCtx.EvalCtx.SessionData
 		var willVectorize bool


### PR DESCRIPTION
Previously, we were using a nil dialer for `EXPLAIN (VEC)` which
resulted in an error in the trace because we couldn't retain the latency
to the remote nodes (if the plan is distributed). For example, we would
see two errors when collecting the statement bundle because we include
both `EXPLAIN (VEC)` and `EXPLAIN (VEC, VERBOSE)`. This commit fixes
the oversight.

Release note: None