### PR TITLE
dev: strip out trailing slashes in targets/packages

### DIFF
--- a/pkg/cmd/dev/build.go
+++ b/pkg/cmd/dev/build.go
@@ -239,6 +239,7 @@ func getBasicBuildArgs(targets []string) (args, fullTargets []string, err error)
 	}
 
 	for _, target := range targets {
+		target = strings.TrimRight(target, "/")
 		// Assume that targets beginning with `//` or containing `/`
 		// don't need to be munged.
 		if strings.HasPrefix(target, "//") || strings.Contains(target, "/") {

--- a/pkg/cmd/dev/test.go
+++ b/pkg/cmd/dev/test.go
@@ -123,6 +123,7 @@ func (d *dev) runUnitTest(cmd *cobra.Command, pkgs []string) error {
 
 	for _, pkg := range pkgs {
 		pkg = strings.TrimPrefix(pkg, "//")
+		pkg = strings.TrimRight(pkg, "/")
 
 		if !strings.HasPrefix(pkg, "pkg/") {
 			return errors.Newf("malformed package %q, expecting %q", pkg, "pkg/{...}")


### PR DESCRIPTION
Bash auto-complete often puts these trailing slashes in, but we can
strip them out before we pass them on to `bazel` (which will throw an
error if package names end with a slash).

Release note: None