### PR TITLE
colexec: fix recent change to the parallel unordered synchronizer

### DIFF
--- a/pkg/sql/colexec/BUILD.bazel
+++ b/pkg/sql/colexec/BUILD.bazel
@@ -61,7 +61,6 @@ go_library(
         "//pkg/sql/colexec/execgen",  # keep
         "//pkg/sql/colexecerror",
         "//pkg/sql/colexecop",
-        "//pkg/sql/colflow/colrpc",
         "//pkg/sql/colmem",
         "//pkg/sql/execinfra",
         "//pkg/sql/execinfrapb",

--- a/pkg/sql/colexec/parallel_unordered_synchronizer_test.go
+++ b/pkg/sql/colexec/parallel_unordered_synchronizer_test.go
@@ -127,6 +127,7 @@ func TestParallelUnorderedSynchronizer(t *testing.T) {
 
 	var wg sync.WaitGroup
 	s := NewParallelUnorderedSynchronizer(inputs, &wg)
+	s.LocalPlan = true
 	s.Init(ctx)
 
 	t.Run(fmt.Sprintf("numInputs=%d/numBatches=%d/terminationScenario=%d", numInputs, numBatches, terminationScenario), func(t *testing.T) {

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -954,7 +954,7 @@ func (s *vectorizedFlowCreator) setupInput(
 			// must use the serial unordered sync above in order to remove any
 			// concurrency.
 			sync := colexec.NewParallelUnorderedSynchronizer(inputStreamOps, s.waitGroup)
-			sync.UsesFakeSpanResolver = flowCtx.TestingKnobs().UsesFakeSpanResolver
+			sync.LocalPlan = flowCtx.Local
 			opWithMetaInfo = colexecargs.OpWithMetaInfo{
 				Root:            sync,
 				MetadataSources: colexecop.MetadataSources{sync},

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -195,7 +195,6 @@ func (dsp *DistSQLPlanner) GatewayID() roachpb.NodeID {
 // responsibility to make sure the DistSQLPlanner is not in use.
 func (dsp *DistSQLPlanner) SetSpanResolver(spanResolver physicalplan.SpanResolver) {
 	dsp.spanResolver = spanResolver
-	dsp.distSQLSrv.TestingKnobs.UsesFakeSpanResolver = physicalplan.IsFakeSpanResolver(spanResolver)
 }
 
 // distSQLExprCheckVisitor is a tree.Visitor that checks if expressions

--- a/pkg/sql/execinfra/server_config.go
+++ b/pkg/sql/execinfra/server_config.go
@@ -234,10 +234,6 @@ type TestingKnobs struct {
 
 	// BackupRestoreTestingKnobs are backup and restore specific testing knobs.
 	BackupRestoreTestingKnobs base.ModuleTestingKnobs
-
-	// UsesFakeSpanResolver indicates whether the DistSQLPlanner uses a fake
-	// span resolver.
-	UsesFakeSpanResolver bool
 }
 
 // MetadataTestLevel represents the types of queries where metadata test

--- a/pkg/sql/physicalplan/fake_span_resolver.go
+++ b/pkg/sql/physicalplan/fake_span_resolver.go
@@ -40,12 +40,6 @@ func NewFakeSpanResolver(nodes []*roachpb.NodeDescriptor) SpanResolver {
 	}
 }
 
-// IsFakeSpanResolver returns whether s is a fakeSpanResolver.
-func IsFakeSpanResolver(s SpanResolver) bool {
-	_, ok := s.(*fakeSpanResolver)
-	return ok
-}
-
 // fakeRange indicates that a range between startKey and endKey is owned by a
 // certain node.
 type fakeRange struct {


### PR DESCRIPTION
We recently made the parallel unordered synchronizer cancel its local
inputs eagerly whenever the sync transitions into the draining state.
However, we currently incorrectly calculate whether the input is
"local": essentially we look only at the children of each input tree
root but not deeper.

In order to fix it we could have implemented a proper input tree
traversal, but it has its complications because we sometimes wrap
operators with another, and in order to perform the type check, we would
need to unwrap the operator first. That could be error-prone.

Instead, this commit chooses a more safe option of using the eager
cancellation only if the plan is fully local - in this case we know for
sure that aren't any inboxes. This is still sufficient for the use case
of parallel TableReaders in the local flows that this eager cancellation
was introduced for.

Fixes: #68884.

Release note: None (no stable release with this bug)