### PR TITLE
[CRDB-7715] Change date times on jobs page to use 24 hr utc

### DIFF
--- a/pkg/ui/src/views/jobs/jobTable.tsx
+++ b/pkg/ui/src/views/jobs/jobTable.tsx
@@ -12,7 +12,7 @@ import React, { MouseEvent } from "react";
 import _ from "lodash";
 import { cockroach } from "src/js/protos";
 import { TimestampToMoment } from "src/util/convert";
-import { DATE_FORMAT } from "src/util/format";
+import { DATE_FORMAT_24_UTC } from "src/util/format";
 import { JobStatusCell } from "src/views/jobs/jobStatusCell";
 import { SortSetting } from "src/views/shared/components/sortabletable";
 import { CachedDataReducerState } from "src/redux/cachedDataReducer";
@@ -59,7 +59,7 @@ const jobsTableColumns: ColumnDescriptor<Job>[] = [
   {
     name: "creationTime",
     title: "Creation Time",
-    cell: (job) => TimestampToMoment(job?.created).format(DATE_FORMAT),
+    cell: (job) => TimestampToMoment(job?.created).format(DATE_FORMAT_24_UTC),
     sort: (job) => TimestampToMoment(job?.created).valueOf(),
   },
   {


### PR DESCRIPTION
This change updates the date time format used on the jobs page from 12 hr to 24 hr utc. This change is needed since the rest of crdb uses 24 hr utc time.

Release note (ui change): change date times on jobs page to use 24 hr utc

Screenshot:
![Screen Shot 2021-08-13 at 1 08 06 PM](https://user-images.githubusercontent.com/17861665/129413228-74ec5e0b-9804-405a-b180-1386ad017525.png)
