### PR TITLE
opt: adjust streaming GroupBy cost and propagate limit hint

### DIFF
--- a/pkg/sql/opt/ordering/group_by.go
+++ b/pkg/sql/opt/ordering/group_by.go
@@ -99,7 +99,7 @@ func distinctOnBuildProvided(expr memo.RelExpr, required *props.OrderingChoice) 
 
 // StreamingGroupingColOrdering returns an ordering on grouping columns that is
 // guaranteed on the input of an aggregation operator. This ordering can be used
-// perform a streaming aggregation.
+// to perform a streaming aggregation.
 func StreamingGroupingColOrdering(
 	g *memo.GroupingPrivate, required *props.OrderingChoice,
 ) opt.Ordering {

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -1125,29 +1125,36 @@ func (c *coster) computeGroupingCost(grouping memo.RelExpr, required *physical.R
 	outputRowCount := grouping.Relational().Stats.RowCount
 	cost += memo.Cost(outputRowCount) * cpuCostFactor
 
-	// GroupBy must process each input row once. Cost per row depends on the
-	// number of grouping columns and the number of aggregates.
-	inputRowCount := grouping.Child(0).(memo.RelExpr).Relational().Stats.RowCount
-	aggsCount := grouping.Child(1).ChildCount()
 	private := grouping.Private().(*memo.GroupingPrivate)
 	groupingColCount := private.GroupingCols.Len()
+	aggsCount := grouping.Child(1).ChildCount()
+
+	// Normally, a grouping expression must process each input row once.
+	inputRowCount := grouping.Child(0).(memo.RelExpr).Relational().Stats.RowCount
+
+	// If this is a streaming GroupBy with a limit hint, l, we only need to
+	// process enough input rows to output l rows.
+	isStreaming := isStreamingAggregation(private, required)
+	if isStreaming && grouping.Op() == opt.GroupByOp && required.LimitHint > 0 {
+		inputRowCount = streamingGroupByInputLimitHint(inputRowCount, outputRowCount, required.LimitHint)
+	}
+
+	// Cost per row depends on the number of grouping columns and the number of
+	// aggregates.
 	cost += memo.Cost(inputRowCount) * memo.Cost(aggsCount+groupingColCount) * cpuCostFactor
 
-	if groupingColCount > 0 {
-		// Add a cost that reflects the use of a hash table - unless we are doing a
-		// streaming aggregation where all the grouping columns are ordered.
-		//
-		// The cost is chosen so that it's always less than the cost to sort the
-		// input.
-		n := len(ordering.StreamingGroupingColOrdering(private, &required.Ordering))
-		if groupingColCount > n {
-			// Add the cost to build the hash table.
-			cost += memo.Cost(inputRowCount) * cpuCostFactor
+	// Add a cost that reflects the use of a hash table - unless we are doing a
+	// streaming aggregation.
+	//
+	// The cost is chosen so that it's always less than the cost to sort the
+	// input.
+	if groupingColCount > 0 && !isStreaming {
+		// Add the cost to build the hash table.
+		cost += memo.Cost(inputRowCount) * cpuCostFactor
 
-			// Add a cost for buffering rows that takes into account increased memory
-			// pressure and the possibility of spilling to disk.
-			cost += c.rowBufferCost(outputRowCount)
-		}
+		// Add a cost for buffering rows that takes into account increased memory
+		// pressure and the possibility of spilling to disk.
+		cost += c.rowBufferCost(outputRowCount)
 	}
 
 	return cost
@@ -1462,6 +1469,31 @@ func localityMatchScore(zone cat.Zone, locality roachpb.Locality) float64 {
 
 	// Weight the constraintScore twice as much as the lease score.
 	return (constraintScore*2 + leaseScore) / 3
+}
+
+// isStreamingAggregation returns true if the GroupingPrivate indicates that
+// streaming aggregation will be performed during execution with the required
+// physical properties. Currently, streaming aggregation is performed when all
+// the grouping columns are ordered. The execution engine does not support
+// streaming aggregation with partially ordered grouping columns.
+func isStreamingAggregation(g *memo.GroupingPrivate, required *physical.Required) bool {
+	groupingColCount := g.GroupingCols.Len()
+	return groupingColCount > 0 &&
+		groupingColCount == len(ordering.StreamingGroupingColOrdering(g, &required.Ordering))
+}
+
+// streamingGroupByLimitHint calculates an appropriate limit hint for the input
+// to a streaming GroupBy expression.
+func streamingGroupByInputLimitHint(
+	inputRowCount, outputRowCount, outputLimitHint float64,
+) float64 {
+	if outputRowCount == 0 {
+		return 0
+	}
+
+	// Estimate the number of input rows needed to output LimitHint rows.
+	inputLimitHint := outputLimitHint * inputRowCount / outputRowCount
+	return math.Min(inputRowCount, inputLimitHint)
 }
 
 // lookupJoinInputLimitHint calculates an appropriate limit hint for the input

--- a/pkg/sql/opt/xform/physical_props.go
+++ b/pkg/sql/opt/xform/physical_props.go
@@ -111,7 +111,34 @@ func BuildChildPhysicalProps(
 	case opt.DistinctOnOp:
 		distinctCount := parent.(memo.RelExpr).Relational().Stats.RowCount
 		if parentProps.LimitHint > 0 {
+			// TODO(mgartner): If the expression is a streaming DistinctOn, this
+			// estimated limit hint is much lower than it should be.
 			childProps.LimitHint = distinctOnLimitHint(distinctCount, parentProps.LimitHint)
+		}
+
+	case opt.GroupByOp:
+		if parentProps.LimitHint == 0 {
+			break
+		}
+
+		private := parent.Private().(*memo.GroupingPrivate)
+		groupingColCount := private.GroupingCols.Len()
+		if groupingColCount == 0 {
+			break
+		}
+
+		outputRows := parent.(memo.RelExpr).Relational().Stats.RowCount
+		if outputRows == 0 || outputRows < parentProps.LimitHint {
+			break
+		}
+
+		// For streaming GroupBy expressions we can estimate the number of input
+		// rows needed to produce LimitHint output rows.
+		if isStreamingAggregation(private, parentProps) {
+			if input, ok := parent.Child(nth).(memo.RelExpr); ok {
+				inputRows := input.Relational().Stats.RowCount
+				childProps.LimitHint = streamingGroupByInputLimitHint(inputRows, outputRows, parentProps.LimitHint)
+			}
 		}
 
 	case opt.SelectOp, opt.LookupJoinOp:

--- a/pkg/sql/opt/xform/testdata/coster/groupby
+++ b/pkg/sql/opt/xform/testdata/coster/groupby
@@ -2,6 +2,10 @@ exec-ddl
 CREATE TABLE a (k INT PRIMARY KEY, i INT, s STRING, d DECIMAL NOT NULL)
 ----
 
+exec-ddl
+CREATE TABLE b (k INT PRIMARY KEY, a INT, b INT, c INT, INDEX (a, b))
+----
+
 opt
 SELECT max(k), min(k), i, s FROM a GROUP BY i, s
 ----
@@ -23,3 +27,100 @@ group-by
       │    └── k:1
       └── min [as=min:8, outer=(1)]
            └── k:1
+
+opt
+SELECT a, count(*) FROM b GROUP BY a
+----
+group-by
+ ├── columns: a:2 count:7!null
+ ├── grouping columns: a:2
+ ├── internal-ordering: +2
+ ├── stats: [rows=100, distinct(2)=100, null(2)=1]
+ ├── cost: 1085.43
+ ├── key: (2)
+ ├── fd: (2)-->(7)
+ ├── scan b@secondary
+ │    ├── columns: a:2
+ │    ├── stats: [rows=1000, distinct(2)=100, null(2)=10]
+ │    ├── cost: 1064.41
+ │    └── ordering: +2
+ └── aggregations
+      └── count-rows [as=count_rows:7]
+
+opt
+SELECT a, b, count(*) FROM b GROUP BY a, b
+----
+group-by
+ ├── columns: a:2 b:3 count:7!null
+ ├── grouping columns: a:2 b:3
+ ├── internal-ordering: +2,+3
+ ├── stats: [rows=1000, distinct(2,3)=1000, null(2,3)=0.1]
+ ├── cost: 1114.53
+ ├── key: (2,3)
+ ├── fd: (2,3)-->(7)
+ ├── scan b@secondary
+ │    ├── columns: a:2 b:3
+ │    ├── stats: [rows=1000, distinct(2,3)=1000, null(2,3)=0.1]
+ │    ├── cost: 1074.51
+ │    └── ordering: +2,+3
+ └── aggregations
+      └── count-rows [as=count_rows:7]
+
+# Consider a limit hint when costing streaming GroupBy expressions.
+opt
+SELECT a, count(*) FROM b GROUP BY a LIMIT 10
+----
+limit
+ ├── columns: a:2 count:7!null
+ ├── cardinality: [0 - 10]
+ ├── stats: [rows=10]
+ ├── cost: 121.14
+ ├── key: (2)
+ ├── fd: (2)-->(7)
+ ├── group-by
+ │    ├── columns: a:2 count_rows:7!null
+ │    ├── grouping columns: a:2
+ │    ├── internal-ordering: +2
+ │    ├── stats: [rows=100, distinct(2)=100, null(2)=1]
+ │    ├── cost: 121.03
+ │    ├── key: (2)
+ │    ├── fd: (2)-->(7)
+ │    ├── limit hint: 10.00
+ │    ├── scan b@secondary
+ │    │    ├── columns: a:2
+ │    │    ├── stats: [rows=1000, distinct(2)=100, null(2)=10]
+ │    │    ├── cost: 118.01
+ │    │    ├── ordering: +2
+ │    │    └── limit hint: 100.00
+ │    └── aggregations
+ │         └── count-rows [as=count_rows:7]
+ └── 10
+
+opt
+SELECT a, b, count(*) FROM b GROUP BY a, b LIMIT 10
+----
+limit
+ ├── columns: a:2 b:3 count:7!null
+ ├── cardinality: [0 - 10]
+ ├── stats: [rows=10]
+ ├── cost: 34.94
+ ├── key: (2,3)
+ ├── fd: (2,3)-->(7)
+ ├── group-by
+ │    ├── columns: a:2 b:3 count_rows:7!null
+ │    ├── grouping columns: a:2 b:3
+ │    ├── internal-ordering: +2,+3
+ │    ├── stats: [rows=1000, distinct(2,3)=1000, null(2,3)=0.1]
+ │    ├── cost: 34.83
+ │    ├── key: (2,3)
+ │    ├── fd: (2,3)-->(7)
+ │    ├── limit hint: 10.00
+ │    ├── scan b@secondary
+ │    │    ├── columns: a:2 b:3
+ │    │    ├── stats: [rows=1000, distinct(2,3)=1000, null(2,3)=0.1]
+ │    │    ├── cost: 24.51
+ │    │    ├── ordering: +2,+3
+ │    │    └── limit hint: 10.00
+ │    └── aggregations
+ │         └── count-rows [as=count_rows:7]
+ └── 10

--- a/pkg/sql/opt/xform/testdata/physprops/limit_hint
+++ b/pkg/sql/opt/xform/testdata/physprops/limit_hint
@@ -1,5 +1,5 @@
 exec-ddl
-CREATE TABLE t (x INT PRIMARY KEY, y INT, z INT, index y_idx (y))
+CREATE TABLE t (x INT PRIMARY KEY, y INT, z INT, INDEX y_idx (y))
 ----
 
 # t has 200 rows where z=0, 200 where z=1, and 600 where z=2.
@@ -278,6 +278,89 @@ limit
  │    └── scan t
  │         └── columns: z:3
  └── 10
+
+# GroupBy operator.
+opt
+SELECT y, count(*) FROM t GROUP BY y LIMIT 1
+----
+limit
+ ├── columns: y:2 count:6!null
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ ├── fd: ()-->(2,6)
+ ├── group-by
+ │    ├── columns: y:2 count_rows:6!null
+ │    ├── grouping columns: y:2
+ │    ├── internal-ordering: +2
+ │    ├── key: (2)
+ │    ├── fd: (2)-->(6)
+ │    ├── limit hint: 1.00
+ │    ├── scan t@y_idx
+ │    │    ├── columns: y:2
+ │    │    ├── ordering: +2
+ │    │    └── limit hint: 10.00
+ │    └── aggregations
+ │         └── count-rows [as=count_rows:6]
+ └── 1
+
+exec-ddl
+CREATE INDEX zy_idx ON t (z, y)
+----
+
+# Do not propagate a limit hint when the output rows are less than the limit
+# hint.
+opt format=show-stats
+SELECT y, count(*) FROM t WHERE z = 3 GROUP BY y LIMIT 10
+----
+limit
+ ├── columns: y:2 count:6!null
+ ├── cardinality: [0 - 10]
+ ├── stats: [rows=3.33333333e-08]
+ ├── key: (2)
+ ├── fd: (2)-->(6)
+ ├── group-by
+ │    ├── columns: y:2 count_rows:6!null
+ │    ├── grouping columns: y:2
+ │    ├── internal-ordering: +2 opt(3)
+ │    ├── stats: [rows=3.33333333e-08, distinct(2)=3.33333333e-08, null(2)=1e-09]
+ │    ├── key: (2)
+ │    ├── fd: (2)-->(6)
+ │    ├── limit hint: 10.00
+ │    ├── scan t@zy_idx
+ │    │    ├── columns: y:2 z:3!null
+ │    │    ├── constraint: /3/2/1: [/3 - /3]
+ │    │    ├── stats: [rows=3.33333333e-08, distinct(2)=3.33333333e-08, null(2)=1e-09, distinct(3)=3.33333333e-08, null(3)=0]
+ │    │    │   histogram(3)=
+ │    │    ├── fd: ()-->(3)
+ │    │    └── ordering: +2 opt(3) [actual: +2]
+ │    └── aggregations
+ │         └── count-rows [as=count_rows:6]
+ └── 10
+
+exec-ddl
+DROP INDEX zy_idx
+----
+
+# Do not propagate limit hints for a non-streaming GroupBy.
+opt
+SELECT z, count(*) FROM t GROUP BY z LIMIT 1
+----
+limit
+ ├── columns: z:3 count:6!null
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ ├── fd: ()-->(3,6)
+ ├── group-by
+ │    ├── columns: z:3 count_rows:6!null
+ │    ├── grouping columns: z:3
+ │    ├── key: (3)
+ │    ├── fd: (3)-->(6)
+ │    ├── limit hint: 1.00
+ │    ├── scan t
+ │    │    └── columns: z:3
+ │    └── aggregations
+ │         └── count-rows [as=count_rows:6]
+ └── 1
 
 opt
 SELECT * FROM t WHERE z=4 LIMIT 10

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -2010,16 +2010,19 @@ project
       │    │    │    ├── left columns: a:12 b:13
       │    │    │    ├── right columns: a:21 b:22
       │    │    │    ├── ordering: +2,+3
+      │    │    │    ├── limit hint: 3.00
       │    │    │    ├── scan regional@secondary
       │    │    │    │    ├── columns: a:12!null b:13!null
       │    │    │    │    ├── constraint: /11/12/13: [/'east' - /'east']
       │    │    │    │    ├── key: (12,13)
-      │    │    │    │    └── ordering: +12,+13
+      │    │    │    │    ├── ordering: +12,+13
+      │    │    │    │    └── limit hint: 3.00
       │    │    │    └── scan regional@secondary
       │    │    │         ├── columns: a:21!null b:22!null
       │    │    │         ├── constraint: /20/21/22: [/'west' - /'west']
       │    │    │         ├── key: (21,22)
-      │    │    │         └── ordering: +21,+22
+      │    │    │         ├── ordering: +21,+22
+      │    │    │         └── limit hint: 3.00
       │    │    └── aggregations
       │    │         └── count-rows [as=count_rows:10]
       │    └── filters
@@ -2063,22 +2066,27 @@ project
       │    │    │    ├── left columns: d:33 e:34
       │    │    │    ├── right columns: d:42 e:43
       │    │    │    ├── ordering: +5,+6
+      │    │    │    ├── limit hint: 3.00
       │    │    │    ├── select
       │    │    │    │    ├── columns: d:33!null e:34!null
       │    │    │    │    ├── ordering: +33,+34
+      │    │    │    │    ├── limit hint: 3.00
       │    │    │    │    ├── scan regional@secondary
       │    │    │    │    │    ├── columns: d:33!null e:34
       │    │    │    │    │    ├── constraint: /29/33/34: (/'east'/NULL - /'east']
-      │    │    │    │    │    └── ordering: +33,+34
+      │    │    │    │    │    ├── ordering: +33,+34
+      │    │    │    │    │    └── limit hint: 3.00
       │    │    │    │    └── filters
       │    │    │    │         └── e:34 IS NOT NULL [outer=(34), constraints=(/34: (/NULL - ]; tight)]
       │    │    │    └── select
       │    │    │         ├── columns: d:42!null e:43!null
       │    │    │         ├── ordering: +42,+43
+      │    │    │         ├── limit hint: 3.00
       │    │    │         ├── scan regional@secondary
       │    │    │         │    ├── columns: d:42!null e:43
       │    │    │         │    ├── constraint: /38/42/43: (/'west'/NULL - /'west']
-      │    │    │         │    └── ordering: +42,+43
+      │    │    │         │    ├── ordering: +42,+43
+      │    │    │         │    └── limit hint: 3.00
       │    │    │         └── filters
       │    │    │              └── e:43 IS NOT NULL [outer=(43), constraints=(/43: (/NULL - ]; tight)]
       │    │    └── aggregations
@@ -2124,18 +2132,21 @@ project
       │    │    │    ├── left columns: a:48 rowid:53
       │    │    │    ├── right columns: a:57 rowid:62
       │    │    │    ├── ordering: +2
+      │    │    │    ├── limit hint: 3.00
       │    │    │    ├── scan regional@partial_a,partial
       │    │    │    │    ├── columns: a:48!null rowid:53!null
       │    │    │    │    ├── constraint: /47/48: [/'east' - /'east']
       │    │    │    │    ├── key: (53)
       │    │    │    │    ├── fd: (53)-->(48), (48)-->(53)
-      │    │    │    │    └── ordering: +48
+      │    │    │    │    ├── ordering: +48
+      │    │    │    │    └── limit hint: 3.00
       │    │    │    └── scan regional@partial_a,partial
       │    │    │         ├── columns: a:57!null rowid:62!null
       │    │    │         ├── constraint: /56/57: [/'west' - /'west']
       │    │    │         ├── key: (62)
       │    │    │         ├── fd: (62)-->(57), (57)-->(62)
-      │    │    │         └── ordering: +57
+      │    │    │         ├── ordering: +57
+      │    │    │         └── limit hint: 3.00
       │    │    └── aggregations
       │    │         └── count-rows [as=count_rows:10]
       │    └── filters
@@ -2179,14 +2190,17 @@ project
       │    │    │    ├── left columns: d:51
       │    │    │    ├── right columns: d:60
       │    │    │    ├── ordering: +5
+      │    │    │    ├── limit hint: 3.00
       │    │    │    ├── scan regional@partial_d,partial
       │    │    │    │    ├── columns: d:51!null
       │    │    │    │    ├── constraint: /47/51: (/'east'/NULL - /'east']
-      │    │    │    │    └── ordering: +51
+      │    │    │    │    ├── ordering: +51
+      │    │    │    │    └── limit hint: 3.00
       │    │    │    └── scan regional@partial_d,partial
       │    │    │         ├── columns: d:60!null
       │    │    │         ├── constraint: /56/60: (/'west'/NULL - /'west']
-      │    │    │         └── ordering: +60
+      │    │    │         ├── ordering: +60
+      │    │    │         └── limit hint: 3.00
       │    │    └── aggregations
       │    │         └── count-rows [as=count_rows:10]
       │    └── filters


### PR DESCRIPTION
When a limit hint `l` exists for a streaming GroupBy expression, we can
estimate the number of rows that we will need to fetch from the input in
order to output `l` rows from the GroupBy. The coster now takes this
into account.

Additionally, this estimated number of rows to fetch is passed as a
limit hint to the GroupBy's input expression.

Note that this commit only affects GroupBy expressions, not any other
aggregate expressions. The current costing and limit hint propagation
for DistinctOn expressions does not seem accurate and needs to be
revisited before we can adjust the costs of streaming DistinctOn
expressions.

Fixes #63122

Release note (performance improvement): The optimizer more accurately
costs streaming group-by operators. As a result, more efficient query
plans should be chosen in some cases.