### PR TITLE
release-21.1: stop, kvclient: include DistSender partial batches in traces

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -1376,6 +1376,7 @@ func (ds *DistSender) sendPartialBatchAsync(
 		ctx,
 		stop.TaskOpts{
 			TaskName:   "kv.DistSender: sending partial batch",
+			ChildSpan:  true,
 			Sem:        ds.asyncSenderSem,
 			WaitForSem: false,
 		},

--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -1371,9 +1372,13 @@ func (ds *DistSender) sendPartialBatchAsync(
 	batchIdx int,
 	responseCh chan response,
 ) bool {
-	if err := ds.rpcContext.Stopper.RunLimitedAsyncTask(
-		ctx, "kv.DistSender: sending partial batch",
-		ds.asyncSenderSem, false, /* wait */
+	if err := ds.rpcContext.Stopper.RunAsyncTaskEx(
+		ctx,
+		stop.TaskOpts{
+			TaskName:   "kv.DistSender: sending partial batch",
+			Sem:        ds.asyncSenderSem,
+			WaitForSem: false,
+		},
 		func(ctx context.Context) {
 			ds.metrics.AsyncSentCount.Inc(1)
 			responseCh <- ds.sendPartialBatch(

--- a/pkg/kv/kvserver/queue.go
+++ b/pkg/kv/kvserver/queue.go
@@ -576,7 +576,12 @@ func (bq *baseQueue) Async(
 		log.InfofDepth(ctx, 2, "%s", log.Safe(opName))
 	}
 	opName += " (" + bq.name + ")"
-	if err := bq.store.stopper.RunLimitedAsyncTask(context.Background(), opName, bq.addOrMaybeAddSem, wait,
+	if err := bq.store.stopper.RunAsyncTaskEx(context.Background(),
+		stop.TaskOpts{
+			TaskName:   opName,
+			Sem:        bq.addOrMaybeAddSem,
+			WaitForSem: wait,
+		},
 		func(ctx context.Context) {
 			fn(ctx, baseQueueHelper{bq})
 		}); err != nil && bq.addLogN.ShouldLog() {

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1054,7 +1054,7 @@ func (s *Store) SetDraining(drain bool, reporter func(int, redact.SafeString)) {
 		newStoreReplicaVisitor(s).Visit(func(r *Replica) bool {
 			//
 			// We need to be careful about the case where the ctx has been canceled
-			// prior to the call to (*Stopper).RunLimitedAsyncTask(). In that case,
+			// prior to the call to (*Stopper).RunAsyncTaskEx(). In that case,
 			// the goroutine is not even spawned. However, we don't want to
 			// mis-count the missing goroutine as the lack of transfer attempted.
 			// So what we do here is immediately increase numTransfersAttempted
@@ -1063,8 +1063,13 @@ func (s *Store) SetDraining(drain bool, reporter func(int, redact.SafeString)) {
 			// not raft leader).
 			atomic.AddInt32(&numTransfersAttempted, 1)
 			wg.Add(1)
-			if err := s.stopper.RunLimitedAsyncTask(
-				r.AnnotateCtx(ctx), "storage.Store: draining replica", sem, true, /* wait */
+			if err := s.stopper.RunAsyncTaskEx(
+				r.AnnotateCtx(ctx),
+				stop.TaskOpts{
+					TaskName:   "storage.Store: draining replica",
+					Sem:        sem,
+					WaitForSem: true,
+				},
 				func(ctx context.Context) {
 					defer wg.Done()
 

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -1990,9 +1990,13 @@ func (s *statusServer) iterateNodes(
 	defer cancel()
 	for nodeID := range nodeStatuses {
 		nodeID := nodeID // needed to ensure the closure below captures a copy.
-		if err := s.stopper.RunLimitedAsyncTask(
-			ctx, fmt.Sprintf("server.statusServer: requesting %s", errorCtx),
-			sem, true, /* wait */
+		if err := s.stopper.RunAsyncTaskEx(
+			ctx,
+			stop.TaskOpts{
+				TaskName:   fmt.Sprintf("server.statusServer: requesting %s", errorCtx),
+				Sem:        sem,
+				WaitForSem: true,
+			},
 			func(ctx context.Context) { nodeQuery(ctx, nodeID) },
 		); err != nil {
 			return err
@@ -2081,9 +2085,13 @@ func (s *statusServer) paginatedIterateNodes(
 	for idx, nodeID := range nodeIDs {
 		nodeID := nodeID // needed to ensure the closure below captures a copy.
 		idx := idx
-		if err := s.stopper.RunLimitedAsyncTask(
-			ctx, fmt.Sprintf("server.statusServer: requesting %s", errorCtx),
-			sem, true, /* wait */
+		if err := s.stopper.RunAsyncTaskEx(
+			ctx,
+			stop.TaskOpts{
+				TaskName:   fmt.Sprintf("server.statusServer: requesting %s", errorCtx),
+				Sem:        sem,
+				WaitForSem: true,
+			},
 			func(ctx context.Context) { paginator.queryNode(ctx, nodeID, idx) },
 		); err != nil {
 			return pagState, err

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -1867,8 +1867,14 @@ func (m *Manager) refreshSomeLeases(ctx context.Context) {
 	for i := range ids {
 		id := ids[i]
 		wg.Add(1)
-		if err := m.stopper.RunLimitedAsyncTask(
-			ctx, fmt.Sprintf("refresh descriptor: %d lease", id), m.sem, true /*wait*/, func(ctx context.Context) {
+		if err := m.stopper.RunAsyncTaskEx(
+			ctx,
+			stop.TaskOpts{
+				TaskName:   fmt.Sprintf("refresh descriptor: %d lease", id),
+				Sem:        m.sem,
+				WaitForSem: true,
+			},
+			func(ctx context.Context) {
 				defer wg.Done()
 				if _, err := acquireNodeLease(ctx, m, id); err != nil {
 					log.Infof(ctx, "refreshing descriptor: %d lease failed: %s", id, err)
@@ -1931,8 +1937,14 @@ SELECT "descID", version, expiration FROM system.public.lease AS OF SYSTEM TIME 
 				version:    int(tree.MustBeDInt(row[1])),
 				expiration: tree.MustBeDTimestamp(row[2]),
 			}
-			if err := m.stopper.RunLimitedAsyncTask(
-				ctx, fmt.Sprintf("release lease %+v", lease), m.sem, true /*wait*/, func(ctx context.Context) {
+			if err := m.stopper.RunAsyncTaskEx(
+				ctx,
+				stop.TaskOpts{
+					TaskName:   fmt.Sprintf("release lease %+v", lease),
+					Sem:        m.sem,
+					WaitForSem: true,
+				},
+				func(ctx context.Context) {
 					m.storage.release(ctx, m.stopper, &lease)
 					log.Infof(ctx, "released orphaned lease: %+v", lease)
 					wg.Done()

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -1758,6 +1758,7 @@ WHERE message IN
     )
 ----
 querying next range at /Table/73/1/0
+=== SPAN START: kv.DistSender: sending partial batch ===
 querying next range at /Table/73/1/10
 
 # Test for 42202 -- ensure filters can get pushed down through project-set.

--- a/pkg/sql/opt/exec/execbuilder/testdata/show_trace_nonmetamorphic
+++ b/pkg/sql/opt/exec/execbuilder/testdata/show_trace_nonmetamorphic
@@ -73,7 +73,7 @@ SET tracing = on,kv,results; INSERT INTO t.kv(k, v) VALUES (1,2); SET tracing = 
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
- WHERE operation != 'dist sender send'
+ WHERE operation != 'dist sender send' AND operation != 'kv.DistSender: sending partial batch'
 ----
 flow       CPut /Table/54/1/1/0 -> /TUPLE/2:2:Int/2
 flow       InitPut /Table/54/2/2/0 -> /BYTES/0x89
@@ -87,7 +87,7 @@ SET tracing = on,kv,results; INSERT INTO t.kv(k, v) VALUES (1,2); SET tracing = 
 query TT
 set tracing=off;
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
- WHERE operation != 'dist sender send'
+ WHERE operation != 'dist sender send' AND operation != 'kv.DistSender: sending partial batch'
 ----
 flow       CPut /Table/54/1/1/0 -> /TUPLE/2:2:Int/2
 flow       InitPut /Table/54/2/2/0 -> /BYTES/0x89
@@ -99,7 +99,7 @@ SET tracing = on,kv,results; INSERT INTO t.kv(k, v) VALUES (2,2); SET tracing = 
 query TT
 set tracing=off;
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
- WHERE operation != 'dist sender send'
+ WHERE operation != 'dist sender send' AND operation != 'kv.DistSender: sending partial batch'
 ----
 flow       CPut /Table/54/1/2/0 -> /TUPLE/2:2:Int/2
 flow       InitPut /Table/54/2/2/0 -> /BYTES/0x8a
@@ -176,7 +176,7 @@ SET tracing = on,kv,results; DELETE FROM t.kv; SET tracing = off
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
- WHERE operation != 'dist sender send'
+ WHERE operation != 'dist sender send' AND operation != 'kv.DistSender: sending partial batch'
 ----
 colbatchscan  Scan /Table/54/{1-2}
 colbatchscan  fetched: /kv/primary/1/v -> /2

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert_nonmetamorphic
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert_nonmetamorphic
@@ -36,7 +36,7 @@ SET tracing = on,kv,results; UPSERT INTO t.kv(k, v) VALUES (2,3); SET tracing = 
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
- WHERE operation != 'dist sender send'
+ WHERE operation != 'dist sender send' AND operation != 'kv.DistSender: sending partial batch'
 ----
 colbatchscan  Scan /Table/55/1/2{-/#}
 flow          CPut /Table/55/1/2/0 -> /TUPLE/2:2:Int/3
@@ -49,7 +49,7 @@ SET tracing = on,kv,results; UPSERT INTO t.kv(k, v) VALUES (1,2); SET tracing = 
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
- WHERE operation != 'dist sender send'
+ WHERE operation != 'dist sender send' AND operation != 'kv.DistSender: sending partial batch'
 ----
 colbatchscan  Scan /Table/55/1/1{-/#}
 flow          CPut /Table/55/1/1/0 -> /TUPLE/2:2:Int/2
@@ -63,7 +63,7 @@ SET tracing = on,kv,results; UPSERT INTO t.kv(k, v) VALUES (2,2); SET tracing = 
 query TT
 set tracing=off;
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
- WHERE operation != 'dist sender send'
+ WHERE operation != 'dist sender send' AND operation != 'kv.DistSender: sending partial batch'
 ----
 colbatchscan  Scan /Table/55/1/2{-/#}
 colbatchscan  fetched: /kv/primary/2/v -> /3

--- a/pkg/sql/trace_test.go
+++ b/pkg/sql/trace_test.go
@@ -41,9 +41,9 @@ func TestTrace(t *testing.T) {
 
 	// These are always appended, even without the test specifying it.
 	alwaysOptionalSpans := []string{
-		"[async] drain",
-		"[async] storage.pendingLeaseRequest: requesting lease",
-		"[async] storage.Store: gossip on capacity change",
+		"drain",
+		"storage.pendingLeaseRequest: requesting lease",
+		"storage.Store: gossip on capacity change",
 		"outbox",
 		"request range lease",
 		"range lookup",

--- a/pkg/util/stop/BUILD.bazel
+++ b/pkg/util/stop/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
         "//pkg/util/log",
         "//pkg/util/quotapool",
         "//pkg/util/syncutil",
+        "//pkg/util/tracing",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/util/stop/stopper.go
+++ b/pkg/util/stop/stopper.go
@@ -365,9 +365,10 @@ func (s *Stopper) RunAsyncTask(
 // stopper using AddCloser.
 func (s *Stopper) RunLimitedAsyncTask(
 	ctx context.Context, taskName string, sem *quotapool.IntPool, wait bool, f func(context.Context),
-) (err error) {
+) error {
 	// Wait for permission to run from the semaphore.
 	var alloc *quotapool.IntAlloc
+	var err error
 	if wait {
 		alloc, err = sem.Acquire(ctx, 1)
 	} else {
@@ -381,11 +382,10 @@ func (s *Stopper) RunLimitedAsyncTask(
 	if err != nil {
 		return err
 	}
+	taskStarted := false
 	defer func() {
-		// If the err is non-nil then we know that we did not start the async task
-		// and thus we need to release the acquired quota. If it is nil then we
-		// did start the task and it will release the quota.
-		if err != nil {
+		// If the task is started, the alloc will be released async.
+		if !taskStarted {
 			alloc.Release()
 		}
 	}()
@@ -395,20 +395,14 @@ func (s *Stopper) RunLimitedAsyncTask(
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
-	if !s.runPrelude() {
-		return ErrUnavailable
-	}
 
-	ctx, span := tracing.ForkSpan(ctx, taskName)
-
-	go func() {
-		defer s.Recover(ctx)
-		defer s.runPostlude()
+	if err := s.RunAsyncTask(ctx, taskName, func(ctx context.Context) {
 		defer alloc.Release()
-		defer span.Finish()
-
 		f(ctx)
-	}()
+	}); err != nil {
+		return err
+	}
+	taskStarted = true
 	return nil
 }
 


### PR DESCRIPTION
Backport 3/3 commits from #67713.

/cc @cockroachdb/release

---

These are the first few patches from #66387 - extracting the non-contentious prefix dealing with DistSender tracing.

----

Before this patch, since fairly recently, the spans created for
Stopper.RunAsyncTask[Ex]() were not included in the recording of the
caller's span because these spans were created with the ForkSpan(). This
patch adds an option to RunAsyncEx to make the task's span a child of
the caller's, and thus to be included in the caller's recording. This
option is used by the DistSender when sending partial batch requests,
therefore re-including these requests in higher-level traces (as they
used to be).

The reason why async tasks were detached from the caller's span
in #59815 was because of concerns about parent and children spans with
very different lifetimes becoming tied through a trace, delaying the
garbage collection of the whole trace until the last span in it
finishes. This patch gives the caller of RunAsyncTaskEx control over
this behavior; in the particular case of the DistSender, the traces are
not too long lived and the DistSender waits for the async tasks it
spawns to finish. In such circumstances, tying the allocations of the
child spans to the whole trace should be fine.

Release note (general change): A recent release removed parts of some
queries from the debugging traces of those queries. This information
(i.e. the execution of some low-level RPCs) has been re-included in the
traces.
