### PR TITLE
opt: remove stale comment

### DIFF
--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -579,8 +579,6 @@ func (b *Builder) buildScan(
 
 	// Add the partial indexes after constructing the scan so we can use the
 	// logical properties of the scan to fully normalize the index predicates.
-	// We don't need to add deletable partial index predicates in the context of
-	// a scan.
 	b.addPartialIndexPredicatesForTable(tabMeta, outScope.expr)
 
 	if !virtualColIDs.Empty() {


### PR DESCRIPTION
This commit removes a stale comment that should have been removed in
a previous commit (see #58714).

Release note: None