### PR TITLE
opt: add AOST to ANALYZE

### DIFF
--- a/pkg/sql/distsql_plan_stats.go
+++ b/pkg/sql/distsql_plan_stats.go
@@ -44,7 +44,7 @@ const histogramSamples = 10000
 // stats collection, used when creating statistics AS OF SYSTEM TIME. The
 // timestamp is advanced during long operations as needed. See TableReaderSpec.
 //
-// The lowest TTL we recommend is 10 minutes. This value must be be lower than
+// The lowest TTL we recommend is 10 minutes. This value must be lower than
 // that.
 var maxTimestampAge = settings.RegisterDurationSetting(
 	"sql.stats.max_timestamp_age",

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -333,8 +333,18 @@ func (b *Builder) buildStmt(
 		return b.buildCreateStatistics(stmt, inScope)
 
 	case *tree.Analyze:
-		// ANALYZE is syntactic sugar for CREATE STATISTICS.
-		return b.buildCreateStatistics(&tree.CreateStats{Table: stmt.Table}, inScope)
+		// ANALYZE is syntactic sugar for CREATE STATISTICS. We add AS OF SYSTEM
+		// TIME '-0.001ms' to trigger use of inconsistent scans. This prevents
+		// GC TTL errors during ANALYZE. See the sql.stats.max_timestamp_age
+		// setting.
+		return b.buildCreateStatistics(&tree.CreateStats{
+			Table: stmt.Table,
+			Options: tree.CreateStatsOptions{
+				AsOf: tree.AsOfClause{
+					Expr: tree.NewStrVal("-0.001ms"),
+				},
+			},
+		}, inScope)
 
 	case *tree.Export:
 		return b.buildExport(stmt, inScope)

--- a/pkg/sql/opt/optbuilder/testdata/misc_statements
+++ b/pkg/sql/opt/optbuilder/testdata/misc_statements
@@ -189,4 +189,4 @@ build
 ANALYZE ab
 ----
 create-statistics
- └── CREATE STATISTICS "" FROM ab
+ └── CREATE STATISTICS "" FROM ab WITH OPTIONS AS OF SYSTEM TIME '-0.001ms'


### PR DESCRIPTION
A long running `ANALYZE` can result in a GC TTL error like:

    batch timestamp 1628283892.315459871,0 must be after replica GC threshold 1628283892.326056946,0

This commit prevents this error by adding `AS OF SYSTEM TIME '-0.001ms'`
automatically to all `ANALYZE` statements. This triggers use of
inconsistent scans. See the sql.stats.max_timestamp_age setting.

Fixes #68590

Release note (bug fix): Long running `ANALYZE` statements will no longer
result in GC TTL errors.

Release justification: This is a low-risk fix for the `ANALYZE`
statement.
