### PR TITLE
storage: add config option for enabling encryption-at-rest

### DIFF
--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -521,6 +521,7 @@ func (cfg *Config) CreateEngines(ctx context.Context) (Engines, error) {
 					storage.Attributes(spec.Attributes),
 					storage.CacheSize(cfg.CacheSize),
 					storage.MaxSize(sizeInBytes),
+					storage.EncryptionAtRest(spec.EncryptionOptions),
 					storage.Settings(cfg.Settings))
 				if err != nil {
 					return Engines{}, err

--- a/pkg/server/sticky_engine.go
+++ b/pkg/server/sticky_engine.go
@@ -112,6 +112,7 @@ func (registry *stickyInMemEnginesRegistryImpl) GetOrCreateStickyInMemEngine(
 		storage.Attributes(spec.Attributes),
 		storage.CacheSize(cfg.CacheSize),
 		storage.MaxSize(spec.Size.InBytes),
+		storage.EncryptionAtRest(spec.EncryptionOptions),
 		storage.ForTesting)
 
 	engineEntry := &stickyInMemEngine{

--- a/pkg/storage/open.go
+++ b/pkg/storage/open.go
@@ -106,6 +106,19 @@ func CacheSize(size int64) ConfigOption {
 	}
 }
 
+// EncryptionAtRest configures an engine to use encryption-at-rest. It is used
+// for configuring in-memory engines, which are used in tests. It is not safe
+// to modify the given slice afterwards as it is captured by reference.
+func EncryptionAtRest(encryptionOptions []byte) ConfigOption {
+	return func(cfg *engineConfig) error {
+		if len(encryptionOptions) > 0 {
+			cfg.UseFileRegistry = true
+			cfg.EncryptionOptions = encryptionOptions
+		}
+		return nil
+	}
+}
+
 // Hook configures a hook to initialize additional storage options. It's used
 // to initialize encryption-at-rest details in CCL builds.
 func Hook(hookFunc func(*base.StorageConfig) error) ConfigOption {


### PR DESCRIPTION
This patch adds the ability to configure encryption-at-rest for
in-memory engines, which are used in tests.

Release note: None