### PR TITLE
sql: warn users that sequences are slower than using UUID

### DIFF
--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/docs"
 	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
@@ -209,9 +210,73 @@ func getSchemaForCreateTable(
 
 	return schema, nil
 }
+func hasPrimaryKeySerialType(params runParams, colDef *tree.ColumnTableDef) (bool, error) {
+	if colDef.IsSerial || colDef.GeneratedIdentity.IsGeneratedAsIdentity {
+		return true, nil
+	}
+
+	if funcExpr, ok := colDef.DefaultExpr.Expr.(*tree.FuncExpr); ok {
+		var name string
+
+		switch t := funcExpr.Func.FunctionReference.(type) {
+		case *tree.FunctionDefinition:
+			name = t.Name
+		case *tree.UnresolvedName:
+			fn, err := t.ResolveFunction(params.SessionData().SearchPath)
+			if err != nil {
+				return false, err
+			}
+			name = fn.Name
+		}
+
+		if name == "nextval" {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
 
 func (n *createTableNode) startExec(params runParams) error {
 	telemetry.Inc(sqltelemetry.SchemaChangeCreateCounter("table"))
+
+	colsWithPrimaryKeyConstraint := make(map[tree.Name]bool)
+
+	for _, def := range n.n.Defs {
+		switch v := def.(type) {
+		case *tree.UniqueConstraintTableDef:
+			if v.PrimaryKey {
+				for _, indexEle := range v.IndexTableDef.Columns {
+					colsWithPrimaryKeyConstraint[indexEle.Column] = true
+				}
+			}
+
+		case *tree.ColumnTableDef:
+			if v.PrimaryKey.IsPrimaryKey {
+				colsWithPrimaryKeyConstraint[v.Name] = true
+			}
+		}
+	}
+
+	for _, def := range n.n.Defs {
+		switch v := def.(type) {
+		case *tree.ColumnTableDef:
+			if _, ok := colsWithPrimaryKeyConstraint[v.Name]; ok {
+				primaryKeySerial, err := hasPrimaryKeySerialType(params, v)
+				if err != nil {
+					return err
+				}
+
+				if primaryKeySerial {
+					params.p.BufferClientNotice(
+						params.ctx,
+						pgnotice.Newf("using sequential values in a primary key does not perform as well as using random UUIDs. See %s", docs.URL("serial.html")),
+					)
+					break
+				}
+			}
+		}
+	}
 
 	schema, err := getSchemaForCreateTable(params, n.dbDesc, n.n.Persistence, &n.n.Table,
 		tree.ResolveRequireTableDesc, n.n.IfNotExists)

--- a/pkg/sql/logictest/testdata/logic_test/create_table
+++ b/pkg/sql/logictest/testdata/logic_test/create_table
@@ -598,3 +598,15 @@ gen_by_default_as_id_seqopt_cache  CREATE TABLE public.gen_by_default_as_id_seqo
                                    UNIQUE INDEX gen_by_default_as_id_seqopt_cache_a_key (a ASC),
                                    FAMILY f1 (a, b, rowid)
 )
+
+statement ok
+CREATE SEQUENCE serial_test_sequence start 1 increment 1
+
+statement notice NOTICE: using sequential values in a primary key does not perform as well as using random UUIDs. See https://www.cockroachlabs.com/docs/(v\d+\.\d+)|(dev)/serial.html
+CREATE TABLE serial_test1 (id INT PRIMARY KEY DEFAULT nextval('serial_test_sequence'), temp string)
+
+statement notice NOTICE: using sequential values in a primary key does not perform as well as using random UUIDs. See https://www.cockroachlabs.com/docs/(v\d+\.\d+)|(dev)/serial.html
+CREATE TABLE serial_test2 (id SERIAL PRIMARY KEY, temp string)
+
+statement notice NOTICE: using sequential values in a primary key does not perform as well as using random UUIDs. See https://www.cockroachlabs.com/docs/(v\d+\.\d+)|(dev)/serial.html
+CREATE TABLE serial_test3 (id SERIAL , temp string, PRIMARY KEY (id))


### PR DESCRIPTION
Even though the documentation tells the user to use
UUIDs for auto-generating unique IDs, many users might
not read the docs. This warning  will make users aware of
better alternatives than using sequences.

Release note (sql change): Warn users that sequences are
slower than using UUID.

Fixes #41258