### PR TITLE
sql: reserve none and pg_* roles

### DIFF
--- a/pkg/sql/create_role.go
+++ b/pkg/sql/create_role.go
@@ -110,9 +110,13 @@ func (n *CreateRoleNode) startExec(params runParams) error {
 	if err != nil {
 		return err
 	}
-	// Reject the "public" role. It does not have an entry in the users table but is reserved.
-	if normalizedUsername.IsPublicRole() {
-		return pgerror.Newf(pgcode.ReservedName, "role name %q is reserved", security.PublicRole)
+	// Reject the reserved roles.
+	if normalizedUsername.IsReserved() {
+		return pgerror.Newf(
+			pgcode.ReservedName,
+			"role name %q is reserved",
+			normalizedUsername.Normalized(),
+		)
 	}
 
 	var hashedPassword []byte

--- a/pkg/sql/logictest/testdata/logic_test/role
+++ b/pkg/sql/logictest/testdata/logic_test/role
@@ -784,6 +784,15 @@ CREATE USER public
 statement error role name "public" is reserved
 CREATE ROLE public
 
+statement error role name "none" is reserved
+CREATE ROLE none
+
+statement error role name "pg_otan" is reserved
+CREATE ROLE pg_otan
+
+statement error role name "crdb_internal_otan" is reserved
+CREATE ROLE crdb_internal_otan
+
 statement error cannot drop role/user public: grants still exist on system.public.comments
 DROP USER public
 


### PR DESCRIPTION
Release note (sql change, backward-incompatible change): Roles with the
name `none` and starting with `pg_` can no longer be created. Any
existing roles with these names may continue to work, but they may be
broken when new features (e.g. SET ROLE) is introduced.