### PR TITLE
streamingccl: add cluster streaming metrics

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamingest/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "streamingest",
     srcs = [
+        "metrics.go",
         "stream_ingestion_frontier_processor.go",
         "stream_ingestion_job.go",
         "stream_ingestion_planning.go",
@@ -40,6 +41,7 @@ go_library(
         "//pkg/storage",
         "//pkg/util/hlc",
         "//pkg/util/log",
+        "//pkg/util/metric",
         "//pkg/util/protoutil",
         "//pkg/util/span",
         "//pkg/util/syncutil",

--- a/pkg/ccl/streamingccl/streamingest/metrics.go
+++ b/pkg/ccl/streamingccl/streamingest/metrics.go
@@ -1,0 +1,69 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package streamingest
+
+import (
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
+)
+
+var (
+	metaStreamingEventsIngested = metric.Metadata{
+		Name:        "streaming.events_ingested",
+		Help:        "Events ingested by all ingestion jobs",
+		Measurement: "Events",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaStreamingResolvedEventsIngested = metric.Metadata{
+		Name:        "streaming.resolved_events_ingested",
+		Help:        "Resolved events ingested by all ingestion jobs",
+		Measurement: "Events",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaStreamingIngestedBytes = metric.Metadata{
+		Name:        "streaming.ingested_bytes",
+		Help:        "Bytes ingested by all ingestion jobs",
+		Measurement: "Bytes",
+		Unit:        metric.Unit_BYTES,
+	}
+	metaStreamingFlushes = metric.Metadata{
+		Name:        "streaming.flushes",
+		Help:        "Total flushes across all ingestion jobs",
+		Measurement: "Flushes",
+		Unit:        metric.Unit_COUNT,
+	}
+)
+
+// Metrics are for production monitoring of stream ingestion jobs.
+type Metrics struct {
+	IngestedEvents *metric.Counter
+	IngestedBytes  *metric.Counter
+	Flushes        *metric.Counter
+	ResolvedEvents *metric.Counter
+}
+
+// MetricStruct implements the metric.Struct interface.
+func (*Metrics) MetricStruct() {}
+
+// MakeMetrics makes the metrics for stream ingestion job monitoring.
+func MakeMetrics(histogramWindow time.Duration) metric.Struct {
+	m := &Metrics{
+		IngestedEvents: metric.NewCounter(metaStreamingEventsIngested),
+		IngestedBytes:  metric.NewCounter(metaStreamingIngestedBytes),
+		Flushes:        metric.NewCounter(metaStreamingFlushes),
+		ResolvedEvents: metric.NewCounter(metaStreamingResolvedEventsIngested),
+	}
+	return m
+}
+
+func init() {
+	jobs.MakeStreamIngestMetricsHook = MakeMetrics
+}

--- a/pkg/jobs/metrics.go
+++ b/pkg/jobs/metrics.go
@@ -25,7 +25,8 @@ import (
 type Metrics struct {
 	JobMetrics [jobspb.NumJobTypes]*JobTypeMetrics
 
-	Changefeed metric.Struct
+	Changefeed   metric.Struct
+	StreamIngest metric.Struct
 
 	// AdoptIterations counts the number of adopt loops executed by Registry.
 	AdoptIterations *metric.Counter
@@ -167,6 +168,9 @@ func (m *Metrics) init(histogramWindowInterval time.Duration) {
 	if MakeChangefeedMetricsHook != nil {
 		m.Changefeed = MakeChangefeedMetricsHook(histogramWindowInterval)
 	}
+	if MakeStreamIngestMetricsHook != nil {
+		m.StreamIngest = MakeStreamIngestMetricsHook(histogramWindowInterval)
+	}
 	m.AdoptIterations = metric.NewCounter(metaAdoptIterations)
 	m.ClaimedJobs = metric.NewCounter(metaClaimedJobs)
 	m.ResumedJobs = metric.NewCounter(metaResumedClaimedJobs)
@@ -191,6 +195,10 @@ func (m *Metrics) init(histogramWindowInterval time.Duration) {
 // MakeChangefeedMetricsHook allows for registration of changefeed metrics from
 // ccl code.
 var MakeChangefeedMetricsHook func(time.Duration) metric.Struct
+
+// MakeStreamIngestMetricsHook allows for registration of streaming metrics from
+// ccl code.
+var MakeStreamIngestMetricsHook func(duration time.Duration) metric.Struct
 
 // JobTelemetryMetrics is a telemetry metrics for individual job types.
 type JobTelemetryMetrics struct {


### PR DESCRIPTION
Add basic per-processor streaming metrics to the stream ingestion job.

Release note: None

Release justification: low-risk observability improvement.