### PR TITLE
roachtest: avoid NPE on cluster creation retries exceeded

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -856,7 +856,11 @@ func (f *clusterFactory) newCluster(
 		}
 
 		// Logs for creating a new cluster go to a dedicated log file.
-		logPath := filepath.Join(f.artifactsDir, runnerLogsDir, "cluster-create", c.name+".log")
+		var retryStr string
+		if i > 0 {
+			retryStr = "-retry" + strconv.Itoa(i)
+		}
+		logPath := filepath.Join(f.artifactsDir, runnerLogsDir, "cluster-create", c.name+retryStr+".log")
 		l, err := logger.RootLogger(logPath, teeOpt)
 		if err != nil {
 			log.Fatalf(ctx, "%v", err)

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -886,7 +886,7 @@ func (f *clusterFactory) newCluster(
 		c.Destroy(ctx, closeLogger, l)
 		if i > maxAttempts {
 			// Here we have to release the alloc, as we are giving up.
-			c.destroyState.alloc.Release()
+			cfg.alloc.Release()
 			return nil, err
 		}
 		// Try again to create the cluster.


### PR DESCRIPTION
When this branch was hit (as it was recently on AWS due to quota issues)
roachtest was giving up anyway, but it wasn't nice that it exploded prematurely
instead of shutting down in an orderly fashion.

Release note: None
