### PR TITLE
roachtest/tests: adjust sqlsmith slightly

### DIFF
--- a/pkg/cmd/roachtest/tests/sqlsmith.go
+++ b/pkg/cmd/roachtest/tests/sqlsmith.go
@@ -132,11 +132,17 @@ func registerSQLSmith(r registry.Registry) {
 		// other setup queries have already completed, including the smither
 		// instantiation (otherwise, the setup might fail because of the
 		// injected panics).
-		injectPanicsStmt := "SET testing_vectorize_inject_panics=true;"
-		if _, err := conn.Exec(injectPanicsStmt); err != nil {
-			t.Fatal(err)
+		if rng.Float64() < 0.5 {
+			// TODO(yuzefovich): at the moment we're only injecting panics with
+			// 50% probability in order to test the hypothesis that this panic
+			// injection is the root cause of the inbox communication errors we
+			// have been seeing sporadically.
+			injectPanicsStmt := "SET testing_vectorize_inject_panics=true;"
+			if _, err := conn.Exec(injectPanicsStmt); err != nil {
+				t.Fatal(err)
+			}
+			logStmt(injectPanicsStmt)
 		}
-		logStmt(injectPanicsStmt)
 
 		t.Status("smithing")
 		until := time.After(t.Spec().(*registry.TestSpec).Timeout / 2)


### PR DESCRIPTION
This commit adjusts `sqlsmith` roachtest slightly so that vectorized
panic injection occurs with 50% probability (instead of 100%). This is
done to check whether the panic injection is the root cause of the inbox
communication errors we have been seeing sporadically.

Informs: #66174.

Release note: None