### PR TITLE
sysutil: wrap IO calls to allow the use of the umask

### DIFF
--- a/pkg/cli/debug_job_trace.go
+++ b/pkg/cli/debug_job_trace.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/cli/clierrorplus"
 	"github.com/cockroachdb/cockroach/pkg/cli/clisqlclient"
+	"github.com/cockroachdb/cockroach/pkg/util/sysutil"
 	tracezipper "github.com/cockroachdb/cockroach/pkg/util/tracing/zipper"
 	"github.com/cockroachdb/errors"
 	"github.com/spf13/cobra"
@@ -108,7 +109,7 @@ func constructJobTraceZipBundle(ctx context.Context, sqlConn clisqlclient.Conn, 
 
 	var f *os.File
 	filename := fmt.Sprintf("%d-%s", jobID, jobTraceZipSuffix)
-	if f, err = os.Create(filename); err != nil {
+	if f, err = sysutil.Create(filename); err != nil {
 		return err
 	}
 	_, err = f.Write(zipBytes)

--- a/pkg/cli/gen.go
+++ b/pkg/cli/gen.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/startupmigrations"
+	"github.com/cockroachdb/cockroach/pkg/util/sysutil"
 	"github.com/cockroachdb/errors/oserror"
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
@@ -168,7 +169,7 @@ The resulting key file will be 32 bytes (random key ID) + key_size in bytes.
 			openMode |= os.O_EXCL
 		}
 
-		f, err := os.OpenFile(encryptionKeyPath, openMode, 0600)
+		f, err := sysutil.OpenFile(encryptionKeyPath, openMode, 0600)
 		if err != nil {
 			return err
 		}

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -14,7 +14,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/url"
 	"os"
@@ -489,7 +488,7 @@ func runStart(cmd *cobra.Command, args []string, startSingleNode bool) (returnEr
 		// this is when we can tell them the node has started listening.
 		if startCtx.pidFile != "" {
 			log.Ops.Infof(ctx, "PID file: %s", startCtx.pidFile)
-			if err := ioutil.WriteFile(startCtx.pidFile, []byte(fmt.Sprintf("%d\n", os.Getpid())), 0644); err != nil {
+			if err := sysutil.WriteFile(startCtx.pidFile, []byte(fmt.Sprintf("%d\n", os.Getpid())), 0644); err != nil {
 				log.Ops.Errorf(ctx, "failed writing the PID: %v", err)
 			}
 		}
@@ -515,7 +514,7 @@ func runStart(cmd *cobra.Command, args []string, startSingleNode bool) (returnEr
 				return
 			}
 
-			if err = ioutil.WriteFile(startCtx.listeningURLFile, []byte(fmt.Sprintf("%s\n", pgURL.ToPQ())), 0644); err != nil {
+			if err = sysutil.WriteFile(startCtx.listeningURLFile, []byte(fmt.Sprintf("%s\n", pgURL.ToPQ())), 0644); err != nil {
 				log.Ops.Errorf(ctx, "failed writing the URL: %v", err)
 			}
 		}

--- a/pkg/cli/userfile.go
+++ b/pkg/cli/userfile.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/sysutil"
 	"github.com/cockroachdb/errors"
 	"github.com/spf13/cobra"
 )
@@ -470,8 +471,8 @@ func downloadUserfile(
 		return 0, err
 	}
 
-	// os.Create uses a permissive 0666 mode so use OpenFile directly.
-	localFile, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0600)
+	// os.Create uses a permissive 0666 mode so use sysutil.OpenFile directly.
+	localFile, err := sysutil.OpenFile(dst, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0600)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/kv/kvserver/syncing_write.go
+++ b/pkg/kv/kvserver/syncing_write.go
@@ -67,7 +67,8 @@ var sstWriteSyncRate = settings.RegisterByteSizeSetting(
 // named by filename -- but with rate limiting and periodic fsyncing controlled
 // by settings and the passed limiter (should be the store's limiter). Periodic
 // fsync provides smooths out disk IO, as mentioned in #20352 and #20279, and
-// provides back-pressure, along with the explicit rate limiting. If the file
+// provides back-pressure, along with the explicit rate limiting.
+// (TODO: catj, is this true because `perm` is used nowhere) If the file
 // does not exist, WriteFile creates it with permissions perm; otherwise
 // WriteFile truncates it before writing.
 func writeFileSyncing(
@@ -75,7 +76,7 @@ func writeFileSyncing(
 	filename string,
 	data []byte,
 	eng storage.Engine,
-	perm os.FileMode,
+	_ os.FileMode,
 	settings *cluster.Settings,
 	limiter *rate.Limiter,
 ) error {

--- a/pkg/security/pem.go
+++ b/pkg/security/pem.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/util/sysutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -31,7 +32,7 @@ func WritePEMToFile(path string, mode os.FileMode, overwrite bool, blocks ...*pe
 	if !overwrite {
 		flags |= os.O_EXCL
 	}
-	f, err := os.OpenFile(path, flags, mode)
+	f, err := sysutil.OpenFile(path, flags, mode)
 	if err != nil {
 		return err
 	}
@@ -53,7 +54,7 @@ func SafeWriteToFile(path string, mode os.FileMode, overwrite bool, contents []b
 	if !overwrite {
 		flags |= os.O_EXCL
 	}
-	f, err := os.OpenFile(path, flags, mode)
+	f, err := sysutil.OpenFile(path, flags, mode)
 	if err != nil {
 		return err
 	}

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -184,6 +184,7 @@ go_library(
         "//pkg/util/retry",
         "//pkg/util/stop",
         "//pkg/util/syncutil",
+        "//pkg/util/sysutil",
         "//pkg/util/timeutil",
         "//pkg/util/tracing",
         "//pkg/util/tracing/collector",

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -17,7 +17,6 @@ import (
 	"encoding/gob"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -96,6 +95,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/sysutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -1436,7 +1436,7 @@ func (s *Server) PreStart(ctx context.Context) error {
 
 		for name, val := range listenerFiles {
 			file := filepath.Join(storeSpec.Path, name)
-			if err := ioutil.WriteFile(file, []byte(val), 0644); err != nil {
+			if err := sysutil.WriteFile(file, []byte(val), 0644); err != nil {
 				return errors.Wrapf(err, "failed to write %s", file)
 			}
 		}

--- a/pkg/storage/metamorphic/BUILD.bazel
+++ b/pkg/storage/metamorphic/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/storage/enginepb",
         "//pkg/util/hlc",
         "//pkg/util/syncutil",
+        "//pkg/util/sysutil",
         "//pkg/util/uint128",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_pebble//:pebble",

--- a/pkg/storage/metamorphic/operations.go
+++ b/pkg/storage/metamorphic/operations.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"os"
 	"path/filepath"
 	"sort"
 
@@ -23,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/sysutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uint128"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
@@ -618,7 +618,7 @@ type ingestOp struct {
 
 func (i ingestOp) run(ctx context.Context) string {
 	sstPath := filepath.Join(i.m.path, "ingest.sst")
-	f, err := os.Create(sstPath)
+	f, err := sysutil.Create(sstPath)
 	if err != nil {
 		return fmt.Sprintf("error = %s", err.Error())
 	}

--- a/pkg/storage/temp_dir.go
+++ b/pkg/storage/temp_dir.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/sysutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/oserror"
 	"github.com/cockroachdb/pebble/vfs"
@@ -88,7 +89,7 @@ func CreateTempDir(parentDir, prefix string, stopper *stop.Stopper) (string, err
 // facilitate cleanup of the temporary directory on subsequent startups.
 func RecordTempDir(recordPath, tempPath string) error {
 	// If the file does not exist, create it, or append to the file.
-	f, err := os.OpenFile(recordPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	f, err := sysutil.OpenFile(recordPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return err
 	}
@@ -109,7 +110,7 @@ func CleanupTempDirs(recordPath string) error {
 	// Reading the entire file into memory shouldn't be a problem since
 	// it is extremely rare for this record file to contain more than a few
 	// entries.
-	f, err := os.OpenFile(recordPath, os.O_RDWR, 0644)
+	f, err := sysutil.OpenFile(recordPath, os.O_RDWR, 0644)
 	// There is no existing record file and thus nothing to clean up.
 	if oserror.IsNotExist(err) {
 		return nil

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1548,6 +1548,123 @@ func TestLint(t *testing.T) {
 		}
 	})
 
+	// Test for the use of file IO functions that should be wrapped by `sysutil`'s file io
+	// functions.
+	t.Run("TestNoFileIOInCode", func(t *testing.T) {
+		t.Parallel()
+
+		forbiddenIOFuncs := map[string]string{
+			"os.OpenFile":      "sysutil.OpenFile",
+			"os.Create":        "sysutil.Create",
+			"ioutil.WriteFile": "sysutil.WriteFile",
+		}
+
+		// grepBuf creates a grep string that matches any forbidden import pkgs.
+		var grepBuf bytes.Buffer
+		grepBuf.WriteByte('(')
+		i := 0
+		for forbiddenFunc := range forbiddenIOFuncs {
+			if i != 0 {
+				grepBuf.WriteByte('|')
+			}
+			grepBuf.WriteString(regexp.QuoteMeta(forbiddenFunc))
+			i++
+		}
+		grepBuf.WriteString(")")
+
+		cmd, stderr, filter, err := dirCmd(
+			pkgDir,
+			"git",
+			"grep",
+			"-nE",
+			grepBuf.String(),
+			"--",
+			"*.go",
+			// Test-only code is not subject to server-side restrictions on file permissions.
+			":!testutils/",
+			":!*/*_test.go",
+			":!acceptance/",
+			":!bench/",
+			":!*test/*",
+			// Standalone helper commands are not subject to the server-side constraints on file permissions.
+			":!cli/",
+			":!cmd/generate-metadata-tables/main.go",
+			":!cmd/generate-spatial-ref-sys/main.go",
+			":!cmd/github-post/main.go",
+			":!cmd/gossipsim/main.go",
+			":!cmd/roachprod/cloud/gc.go",
+			":!cmd/roachprod/hosts.go",
+			":!cmd/roachprod/install/cluster_synced.go",
+			":!cmd/roachprod/main.go",
+			":!cmd/roachprod/vm/aws/terraformgen/terraformgen.go",
+			":!cmd/roachprod/vm/local/local.go",
+			":!cmd/wraprules/wraprules.go",
+			":!cmd/bazci/",
+			":!cmd/dev/",
+			":!cmd/docgen/",
+			":!sql/opt/optgen/cmd/",
+			":!sql/schemachanger/scop/generate_visitor.go",
+			":!util/binfetcher/binfetcher.go",
+			// The "workload" package is intended for client-side code and is not subject to the server-side restrictions.
+			":!workload/",
+			// Log files implements its own file permission logic.
+			":!util/log/",
+			// The fileutil package implements file copying and moving, and changing file permissions during those operations would result in unexpected behavior.
+			":!util/fileutil/",
+			// These two files implement the server-side restrictions and contain the logic wrapping the standard library IO functions.
+			":!util/sysutil/io.go",
+			":!util/sysutil/io_*.go",
+			// (TODO catj: update the functions in these these packages)
+			":!roachpb/gen/main.go",
+			":!server/goroutinedumper/goroutinedumper.go",
+			":!server/heapprofiler/heapprofiler.go",
+			":!server/heapprofiler/statsprofiler.go",
+			":!server/tracedumper/tracedumper.go",
+			":!sql/opt_catalog.go",
+			":!sql/pg_metadata_diff.go",
+			":!util/timeutil/gen/main.go",
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := cmd.Start(); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := stream.ForEach(filter, func(s string) {
+			if strings.HasPrefix(s, "Binary file") {
+				return
+			}
+
+			found := false
+			errPieces := strings.Split(s, ":")
+			if len(errPieces) >= 3 {
+				file, number, line := errPieces[0], errPieces[1], errPieces[2]
+				for forbiddenFunc, expectedFunc := range forbiddenIOFuncs {
+					if strings.HasPrefix(line, "//") {
+						found = true
+						continue
+					}
+					if strings.Contains(line, forbiddenFunc) {
+						found = true
+						t.Errorf("\n%s:%s using %s, please use sysutil.%s instead", file, number, forbiddenFunc, expectedFunc)
+					}
+				}
+			}
+			if !found {
+				t.Errorf("\n%s <- using an unsupported File IO function, please use sysutil equivalent instead", s)
+			}
+		}); err != nil {
+			t.Error(err)
+		}
+		if err := cmd.Wait(); err != nil {
+			if out := stderr.String(); len(out) > 0 {
+				t.Fatalf("err=%s, stderr=%s", err, out)
+			}
+		}
+	})
+
 	// TODO(tamird): replace this with errcheck.NewChecker() when
 	// https://github.com/dominikh/go-tools/issues/57 is fixed.
 	t.Run("TestErrCheck", func(t *testing.T) {

--- a/pkg/util/sysutil/BUILD.bazel
+++ b/pkg/util/sysutil/BUILD.bazel
@@ -6,6 +6,9 @@ go_library(
         "acl_unix.go",
         "acl_windows.go",
         "aclinfo.go",
+        "io.go",
+        "io_unix.go",
+        "io_windows.go",
         "large_file.go",
         "large_file_linux.go",
         "large_file_nonlinux.go",
@@ -66,6 +69,7 @@ go_test(
     size = "small",
     srcs = [
         "acl_unix_test.go",
+        "io_unix_test.go",
         "large_file_test.go",
         "sysutil_test.go",
         "sysutil_unix_test.go",

--- a/pkg/util/sysutil/io.go
+++ b/pkg/util/sysutil/io.go
@@ -1,0 +1,46 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sysutil
+
+import "os"
+
+// DefaultCreateMode is the default os.FileMode that the IO functions in
+// this package will create new files with.
+const DefaultCreateMode = os.FileMode(0660)
+
+// ModeAfterMask returns a bitwise AND NOT of the passed FileMode mask.
+// This function, when using the umask as the mask, will show the permissions
+// new files will be created with.
+//
+// So for example (focusing on only one permission value):
+//
+// 0b111
+//     ^ execute (0x1)
+//    ^ write (0x2)
+//   ^ read (0x4)
+//
+// A umask of 0x2 (block writes) will be:
+//
+// 0b010
+//
+// To apply the umask, we do a bitwise AND NOT with the input (for example,
+// 0b111, or "rwx").
+//
+//    0b111
+// &^ 0b010
+//    -----
+//    0b101
+//
+// Which as a result, means that the end result is without the write
+// permission.
+func ModeAfterMask(perm, mask os.FileMode) os.FileMode {
+	return perm &^ mask
+}

--- a/pkg/util/sysutil/io_unix.go
+++ b/pkg/util/sysutil/io_unix.go
@@ -1,0 +1,66 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// +build !windows
+// +build !plan9
+
+package sysutil
+
+import "os"
+
+// OpenFile wraps os.OpenFile, but will mask the passed os.FileMode to
+// prevent the creation of files with world access permissions. This means
+// that files created by this function will only be accessible by the user
+// and group that the CockroachDB process runs as.
+//
+// Note that the umask will still be applied to the filemode before
+// creation.
+func OpenFile(filename string, flag int, perm os.FileMode) (*os.File, error) {
+	perm = ModeAfterMask(perm, 0007)
+
+	file, err := os.OpenFile(filename, flag, perm)
+	if err != nil {
+		return nil, err
+	}
+
+	return file, nil
+}
+
+// Create wraps os.Create. On UNIX-like systems, this function uses more
+// limited permissions than the
+func Create(filename string) (*os.File, error) {
+	file, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE|os.O_TRUNC, DefaultCreateMode)
+	if err != nil {
+		return nil, err
+	}
+
+	return file, nil
+}
+
+// WriteFile works identically to ioutil.WriteFile, except that it uses the OpenFile
+// function in this package (which means that files created by it do not have
+// world-readable permissions on UNIX-like systems).
+func WriteFile(filename string, data []byte, perm os.FileMode) error {
+	// OpenFile will handle permission updating for us.
+	file, err := OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+	if err != nil {
+		return err
+	}
+
+	_, err = file.Write(data)
+	if err != nil {
+		return err
+	}
+
+	if closeErr := file.Close(); closeErr != nil && err == nil {
+		err = closeErr
+	}
+	return err
+}

--- a/pkg/util/sysutil/io_unix_test.go
+++ b/pkg/util/sysutil/io_unix_test.go
@@ -1,0 +1,187 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// +build !windows
+// +build !plan9
+
+package sysutil
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/unix"
+)
+
+func TestModeAfterMask(t *testing.T) {
+	for _, test := range []struct {
+		in       os.FileMode
+		expected os.FileMode
+		mask     os.FileMode
+	}{
+		{
+			in:       0666,
+			expected: 0640,
+			mask:     0027,
+		},
+		{
+			in:       0600,
+			expected: 0600,
+			mask:     0022,
+		},
+		{
+			in:       0622,
+			expected: 0600,
+			mask:     0022,
+		},
+		{
+			in:       0000,
+			expected: 0000,
+			mask:     0022,
+		},
+	} {
+
+		actual := ModeAfterMask(test.in, test.mask)
+		assert.Equal(t, test.expected, actual, "when masking %s with %s, got %s instead of expected %ss", test.in, test.mask, actual, test.expected)
+	}
+}
+
+func TestOpenFile(t *testing.T) {
+	originalUmask := unix.Umask(0000)
+
+	testIODir, err := ioutil.TempDir("", "iowrapper_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = unix.Umask(originalUmask)
+		if err := os.RemoveAll(testIODir); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	type testFile struct {
+		filename     string
+		inputMode    os.FileMode
+		expectedMode os.FileMode
+	}
+
+	for testNum, f := range []testFile{
+		{
+			filename:     "test.txt",
+			inputMode:    0777,
+			expectedMode: 0770,
+		},
+	} {
+		filename := filepath.Join(testIODir, f.filename)
+
+		file, err := OpenFile(filename, os.O_CREATE, f.inputMode)
+		if err != nil {
+			t.Fatalf("#%d: could not create file %s: %v", testNum, f.filename, err)
+		}
+		_ = file.Close()
+
+		info, err := os.Stat(filename)
+		if nil != err {
+			t.Errorf("#%d: failed to stat new test file %s: %v", testNum, f.filename, err)
+		}
+		assert.Equal(t, f.expectedMode.String(), info.Mode().String())
+	}
+}
+
+func TestCreate(t *testing.T) {
+	originalUmask := unix.Umask(0000)
+
+	testIODir, err := ioutil.TempDir("", "iowrapper_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = unix.Umask(originalUmask)
+		if err := os.RemoveAll(testIODir); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	type testFile struct {
+		filename string
+	}
+
+	for testNum, f := range []testFile{
+		{
+			filename: "test.txt",
+		},
+	} {
+		filename := filepath.Join(testIODir, f.filename)
+
+		file, err := Create(filename)
+		if err != nil {
+			t.Fatalf("#%d: could not create file %s: %v", testNum, f.filename, err)
+		}
+		_ = file.Close()
+
+		info, err := os.Stat(filename)
+		if nil != err {
+			t.Errorf("#%d: failed to stat new test file %s: %v", testNum, f.filename, err)
+		}
+		assert.Equal(t, DefaultCreateMode.String(), info.Mode().String())
+	}
+}
+
+func TestWriteFile(t *testing.T) {
+	originalUmask := unix.Umask(0000)
+
+	testIODir, err := ioutil.TempDir("", "iowrapper_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = unix.Umask(originalUmask)
+		if err := os.RemoveAll(testIODir); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	type testFile struct {
+		filename     string
+		inputMode    os.FileMode
+		expectedMode os.FileMode
+	}
+
+	for testNum, f := range []testFile{
+		{
+			filename:     "test.txt",
+			inputMode:    0666,
+			expectedMode: 0660,
+		},
+	} {
+		filename := filepath.Join(testIODir, f.filename)
+
+		err := WriteFile(filename, []byte(filename), f.inputMode)
+		if err != nil {
+			t.Fatalf("#%d: could not WriteFile %s: %v", testNum, f.filename, err)
+		}
+
+		info, err := os.Stat(filename)
+		if nil != err {
+			t.Errorf("#%d: failed to stat new test file %s: %v", testNum, f.filename, err)
+		}
+		assert.Equal(t, f.expectedMode.String(), info.Mode().String())
+
+		b, err := ioutil.ReadFile(filename)
+		if err != nil {
+			t.Fatalf("#%d: could not read file created by WriteFile %s: %v", testNum, f.filename, err)
+		}
+		assert.Equal(t, []byte(filename), b)
+	}
+}

--- a/pkg/util/sysutil/io_windows.go
+++ b/pkg/util/sysutil/io_windows.go
@@ -1,0 +1,38 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sysutil
+
+import (
+	"io/fs"
+	"io/ioutil"
+	"os"
+)
+
+// OpenFile wraps os.OpenFile. On UNIX-like systems this function
+// modifies the passed permissions to prevent new files from being
+// world-accessible.
+func OpenFile(name string, flag int, perm os.FileMode) (*os.File, error) {
+	return os.OpenFile(name, flag, perm)
+}
+
+// Create wraps os.Create. On UNIX-like systems this function
+// modifies the passed permissions to prevent new files from being
+// world-accessible.
+func Create(name string) (*os.File, error) {
+	return os.Create(name)
+}
+
+// WriteFile wraps ioutil.WriteFile. On UNIX-like systems this function
+// modifies the passed permissions to prevent new files from being
+// world-accessible.
+func WriteFile(filename string, data []byte, perm fs.FileMode) error {
+	return ioutil.WriteFile(filename, data, perm)
+}

--- a/pkg/util/sysutil/large_file.go
+++ b/pkg/util/sysutil/large_file.go
@@ -17,7 +17,7 @@ import (
 )
 
 func resizeLargeFileNaive(path string, bytes int64) error {
-	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
+	f, err := OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
 	if err != nil {
 		return err
 	}

--- a/pkg/util/sysutil/large_file_linux.go
+++ b/pkg/util/sysutil/large_file_linux.go
@@ -29,7 +29,7 @@ import (
 // On other platforms, it naively writes the specified number of bytes, which
 // can take a long time.
 func ResizeLargeFile(path string, bytes int64) error {
-	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE, 0666)
+	f, err := OpenFile(path, os.O_WRONLY|os.O_CREATE, 0666)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
sysutil: wrap IO calls to allow the use of the umask                                  
                                                                                      
Previously, CockroachDB overrode the Umask at startup time to prevent                 
the creation of world readable files, to ensure that sensitive files                  
are not accessible by other uses on UNIX-like systems.                                
                                                                                      
This causes problems for the log files that are created by CockroachDB                
as very often they need to be world readable.                                         
                                                                                      
To address this, this change wraps common IO functions that create                    
files (os.Create, os.OpenFile, ioutil.WriteFile) and modifies the                     
permissions that they use to ensure that that new files are not
created with world-readable permissions.
                                                                                      

> Release note (security update): UNIX-like systems will now use custom                 
> IO functions when creating sensitive files (storage, certificates, etc)               
> that prevent those files from being created with permissions that allow               
> them to be world-accessible (readable/writable/executable). This will                 
> allow the use of the umask to control the permissions of non-sensitive                
> files (log files, etc).