### PR TITLE
sql: show hash-sharded column CHECK constraints in SHOW CREATE TABLE

### DIFF
--- a/pkg/sql/catalog/descpb/structured.pb.go
+++ b/pkg/sql/catalog/descpb/structured.pb.go
@@ -2569,8 +2569,10 @@ type TableDescriptor_CheckConstraint struct {
 	// An ordered list of column IDs used by the check constraint.
 	ColumnIDs           []ColumnID `protobuf:"varint,5,rep,name=column_ids,json=columnIds,casttype=ColumnID" json:"column_ids,omitempty"`
 	IsNonNullConstraint bool       `protobuf:"varint,6,opt,name=is_non_null_constraint,json=isNonNullConstraint" json:"is_non_null_constraint"`
-	// Whether the check constraint should show up in the result of a `SHOW CREATE
-	// TABLE..` statement.
+	// Hidden is set to true for hash-sharded column check constraints.
+	// Previously, this field was used to hide these constraints in the output
+	// of SHOW CREATE TABLE. We no longer them in order to make the output to be
+	// round-trippable, but we still set this field for now. See #68031.
 	Hidden bool `protobuf:"varint,7,opt,name=hidden" json:"hidden"`
 }
 

--- a/pkg/sql/catalog/descpb/structured.proto
+++ b/pkg/sql/catalog/descpb/structured.proto
@@ -938,8 +938,10 @@ message TableDescriptor {
     repeated uint32 column_ids = 5 [(gogoproto.customname) = "ColumnIDs",
       (gogoproto.casttype) = "ColumnID"];
     optional bool is_non_null_constraint = 6 [(gogoproto.nullable) = false];
-    // Whether the check constraint should show up in the result of a `SHOW CREATE
-    // TABLE..` statement.
+    // Hidden is set to true for hash-sharded column check constraints.
+    // Previously, this field was used to hide these constraints in the output
+    // of SHOW CREATE TABLE. We no longer them in order to make the output to be
+    // round-trippable, but we still set this field for now. See #68031.
     optional bool hidden = 7 [(gogoproto.nullable) = false];
   }
 

--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -372,7 +372,8 @@ t  CREATE TABLE public.t (
    UNIQUE INDEX i5 (w ASC) STORING (y),
    INVERTED INDEX i6 (v),
    INDEX i7 (z ASC) USING HASH WITH BUCKET_COUNT = 4,
-   FAMILY fam_0_x_y_z_w_v_crdb_internal_z_shard_4 (x, y, z, w, v, crdb_internal_z_shard_4)
+   FAMILY fam_0_x_y_z_w_v_crdb_internal_z_shard_4 (x, y, z, w, v, crdb_internal_z_shard_4),
+   CONSTRAINT check_crdb_internal_z_shard_4 CHECK (crdb_internal_z_shard_4 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8))
 )
 
 # Test that the indexes we expect got rewritten. All but i3 should have been rewritten,
@@ -521,7 +522,9 @@ t  CREATE TABLE public.t (
    CONSTRAINT "primary" PRIMARY KEY (y ASC) USING HASH WITH BUCKET_COUNT = 10,
    UNIQUE INDEX t_x_key (x ASC),
    INDEX i1 (z ASC) USING HASH WITH BUCKET_COUNT = 5,
-   FAMILY fam_0_x_y_z_crdb_internal_z_shard_5 (x, y, z, crdb_internal_z_shard_5, crdb_internal_y_shard_10)
+   FAMILY fam_0_x_y_z_crdb_internal_z_shard_5 (x, y, z, crdb_internal_z_shard_5, crdb_internal_y_shard_10),
+   CONSTRAINT check_crdb_internal_z_shard_5 CHECK (crdb_internal_z_shard_5 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8)),
+   CONSTRAINT check_crdb_internal_y_shard_10 CHECK (crdb_internal_y_shard_10 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8, 8:::INT8, 9:::INT8))
 )
 
 query T
@@ -585,7 +588,8 @@ t  CREATE TABLE public.t (
    CONSTRAINT "primary" PRIMARY KEY (y ASC),
    UNIQUE INDEX t_x_key (x ASC) USING HASH WITH BUCKET_COUNT = 5,
    INDEX i (z ASC),
-   FAMILY fam_0_x_y_z_crdb_internal_x_shard_5 (x, y, z, crdb_internal_x_shard_5)
+   FAMILY fam_0_x_y_z_crdb_internal_x_shard_5 (x, y, z, crdb_internal_x_shard_5),
+   CONSTRAINT check_crdb_internal_x_shard_5 CHECK (crdb_internal_x_shard_5 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8))
 )
 
 query III
@@ -748,7 +752,8 @@ t  CREATE TABLE public.t (
    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
    crdb_internal_x_shard_4 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(x AS STRING), '':::STRING)), 4:::INT8)) STORED,
    CONSTRAINT "primary" PRIMARY KEY (x ASC) USING HASH WITH BUCKET_COUNT = 4,
-   FAMILY "primary" (x, rowid, crdb_internal_x_shard_4)
+   FAMILY "primary" (x, rowid, crdb_internal_x_shard_4),
+   CONSTRAINT check_crdb_internal_x_shard_4 CHECK (crdb_internal_x_shard_4 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8))
 )
 
 statement ok
@@ -1205,7 +1210,9 @@ t  CREATE TABLE public.t (
    x INT8 NOT NULL,
    crdb_internal_x_shard_3 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(x AS STRING), '':::STRING)), 3:::INT8)) STORED,
    CONSTRAINT "primary" PRIMARY KEY (x ASC) USING HASH WITH BUCKET_COUNT = 3,
-   FAMILY "primary" (crdb_internal_x_shard_2, x, crdb_internal_x_shard_3)
+   FAMILY "primary" (crdb_internal_x_shard_2, x, crdb_internal_x_shard_3),
+   CONSTRAINT check_crdb_internal_x_shard_2 CHECK (crdb_internal_x_shard_2 IN (0:::INT8, 1:::INT8)),
+   CONSTRAINT check_crdb_internal_x_shard_3 CHECK (crdb_internal_x_shard_3 IN (0:::INT8, 1:::INT8, 2:::INT8))
 )
 
 # Changes on a hash sharded index that change the columns will cause the old
@@ -1225,7 +1232,9 @@ t  CREATE TABLE public.t (
    crdb_internal_y_shard_2 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(y AS STRING), '':::STRING)), 2:::INT8)) STORED,
    CONSTRAINT "primary" PRIMARY KEY (y ASC) USING HASH WITH BUCKET_COUNT = 2,
    UNIQUE INDEX t_x_key (x ASC) USING HASH WITH BUCKET_COUNT = 2,
-   FAMILY fam_0_x_y_crdb_internal_x_shard_2 (x, y, crdb_internal_x_shard_2, crdb_internal_y_shard_2)
+   FAMILY fam_0_x_y_crdb_internal_x_shard_2 (x, y, crdb_internal_x_shard_2, crdb_internal_y_shard_2),
+   CONSTRAINT check_crdb_internal_x_shard_2 CHECK (crdb_internal_x_shard_2 IN (0:::INT8, 1:::INT8)),
+   CONSTRAINT check_crdb_internal_y_shard_2 CHECK (crdb_internal_y_shard_2 IN (0:::INT8, 1:::INT8))
 )
 
 # Regression for #49079.

--- a/pkg/sql/logictest/testdata/logic_test/create_table
+++ b/pkg/sql/logictest/testdata/logic_test/create_table
@@ -360,7 +360,8 @@ like_hash  CREATE TABLE public.like_hash (
            rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
            CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
            INDEX like_hash_base_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 4,
-           FAMILY "primary" (a, crdb_internal_a_shard_4, rowid)
+           FAMILY "primary" (a, crdb_internal_a_shard_4, rowid),
+           CONSTRAINT check_crdb_internal_a_shard_4 CHECK (crdb_internal_a_shard_4 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8))
 )
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
+++ b/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
@@ -12,7 +12,8 @@ sharded_primary  CREATE TABLE public.sharded_primary (
                  crdb_internal_a_shard_10 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(a AS STRING), '':::STRING)), 10:::INT8)) STORED,
                  a INT8 NOT NULL,
                  CONSTRAINT "primary" PRIMARY KEY (a ASC) USING HASH WITH BUCKET_COUNT = 10,
-                 FAMILY "primary" (crdb_internal_a_shard_10, a)
+                 FAMILY "primary" (crdb_internal_a_shard_10, a),
+                 CONSTRAINT check_crdb_internal_a_shard_10 CHECK (crdb_internal_a_shard_10 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8, 8:::INT8, 9:::INT8))
 )
 
 statement error pgcode 22023 BUCKET_COUNT must be an integer greater than 1
@@ -45,7 +46,8 @@ sharded_primary  CREATE TABLE public.sharded_primary (
                  a INT8 NOT NULL,
                  crdb_internal_a_shard_10 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(a AS STRING), '':::STRING)), 10:::INT8)) STORED,
                  CONSTRAINT "primary" PRIMARY KEY (a ASC) USING HASH WITH BUCKET_COUNT = 10,
-                 FAMILY "primary" (crdb_internal_a_shard_10, a)
+                 FAMILY "primary" (crdb_internal_a_shard_10, a),
+                 CONSTRAINT check_crdb_internal_a_shard_10 CHECK (crdb_internal_a_shard_10 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8, 8:::INT8, 9:::INT8))
 )
 
 query TTT colnames
@@ -102,7 +104,8 @@ specific_family  CREATE TABLE public.specific_family (
                  CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                  INDEX specific_family_b_idx (b ASC) USING HASH WITH BUCKET_COUNT = 10,
                  FAMILY a_family (a, rowid),
-                 FAMILY b_family (b, crdb_internal_b_shard_10)
+                 FAMILY b_family (b, crdb_internal_b_shard_10),
+                 CONSTRAINT check_crdb_internal_b_shard_10 CHECK (crdb_internal_b_shard_10 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8, 8:::INT8, 9:::INT8))
 )
 
 # Tests for secondary sharded indexes
@@ -118,7 +121,8 @@ sharded_secondary  CREATE TABLE public.sharded_secondary (
                    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
                    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                    INDEX sharded_secondary_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 4,
-                   FAMILY "primary" (a, crdb_internal_a_shard_4, rowid)
+                   FAMILY "primary" (a, crdb_internal_a_shard_4, rowid),
+                   CONSTRAINT check_crdb_internal_a_shard_4 CHECK (crdb_internal_a_shard_4 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8))
 )
 
 statement ok
@@ -140,7 +144,8 @@ sharded_secondary  CREATE TABLE public.sharded_secondary (
                    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
                    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                    INDEX sharded_secondary_crdb_internal_a_shard_4_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 4,
-                   FAMILY "primary" (a, crdb_internal_a_shard_4, rowid)
+                   FAMILY "primary" (a, crdb_internal_a_shard_4, rowid),
+                   CONSTRAINT check_crdb_internal_a_shard_4 CHECK (crdb_internal_a_shard_4 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8))
 )
 
 statement ok
@@ -169,7 +174,8 @@ sharded_secondary  CREATE TABLE public.sharded_secondary (
                    crdb_internal_a_shard_10 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(a AS STRING), '':::STRING)), 10:::INT8)) STORED,
                    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                    INDEX sharded_secondary_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 10,
-                   FAMILY "primary" (a, rowid, crdb_internal_a_shard_10)
+                   FAMILY "primary" (a, rowid, crdb_internal_a_shard_10),
+                   CONSTRAINT check_crdb_internal_a_shard_10 CHECK (crdb_internal_a_shard_10 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8, 8:::INT8, 9:::INT8))
 )
 
 statement ok
@@ -190,7 +196,9 @@ sharded_secondary  CREATE TABLE public.sharded_secondary (
                    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                    INDEX sharded_secondary_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 10,
                    INDEX sharded_secondary_a_idx1 (a ASC) USING HASH WITH BUCKET_COUNT = 4,
-                   FAMILY "primary" (a, rowid, crdb_internal_a_shard_10, crdb_internal_a_shard_4)
+                   FAMILY "primary" (a, rowid, crdb_internal_a_shard_10, crdb_internal_a_shard_4),
+                   CONSTRAINT check_crdb_internal_a_shard_10 CHECK (crdb_internal_a_shard_10 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8, 8:::INT8, 9:::INT8)),
+                   CONSTRAINT check_crdb_internal_a_shard_4 CHECK (crdb_internal_a_shard_4 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8))
 )
 
 # Drop a sharded index and ensure that the shard column is dropped with it.
@@ -206,7 +214,8 @@ sharded_secondary  CREATE TABLE public.sharded_secondary (
                    crdb_internal_a_shard_4 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(a AS STRING), '':::STRING)), 4:::INT8)) STORED,
                    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                    INDEX sharded_secondary_a_idx1 (a ASC) USING HASH WITH BUCKET_COUNT = 4,
-                   FAMILY "primary" (a, rowid, crdb_internal_a_shard_4)
+                   FAMILY "primary" (a, rowid, crdb_internal_a_shard_4),
+                   CONSTRAINT check_crdb_internal_a_shard_4 CHECK (crdb_internal_a_shard_4 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8))
 )
 
 statement ok
@@ -267,7 +276,8 @@ sharded_secondary  CREATE TABLE public.sharded_secondary (
                    INDEX sharded_secondary_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 10,
                    INDEX sharded_secondary_a_idx1 (a ASC) USING HASH WITH BUCKET_COUNT = 10,
                    INDEX sharded_secondary_a_idx2 (a ASC) USING HASH WITH BUCKET_COUNT = 10,
-                   FAMILY "primary" (a, rowid, crdb_internal_a_shard_10)
+                   FAMILY "primary" (a, rowid, crdb_internal_a_shard_10),
+                   CONSTRAINT check_crdb_internal_a_shard_10 CHECK (crdb_internal_a_shard_10 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8, 8:::INT8, 9:::INT8))
 )
 
 
@@ -289,7 +299,9 @@ sharded_primary  CREATE TABLE public.sharded_primary (
                  crdb_internal_a_shard_4 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(a AS STRING), '':::STRING)), 4:::INT8)) STORED,
                  CONSTRAINT "primary" PRIMARY KEY (a ASC) USING HASH WITH BUCKET_COUNT = 10,
                  INDEX sharded_primary_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 4,
-                 FAMILY "primary" (crdb_internal_a_shard_10, a, crdb_internal_a_shard_4)
+                 FAMILY "primary" (crdb_internal_a_shard_10, a, crdb_internal_a_shard_4),
+                 CONSTRAINT check_crdb_internal_a_shard_10 CHECK (crdb_internal_a_shard_10 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8, 8:::INT8, 9:::INT8)),
+                 CONSTRAINT check_crdb_internal_a_shard_4 CHECK (crdb_internal_a_shard_4 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8))
 )
 
 statement ok
@@ -305,7 +317,8 @@ sharded_primary  CREATE TABLE public.sharded_primary (
                  a INT8 NOT NULL,
                  crdb_internal_a_shard_10 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(a AS STRING), '':::STRING)), 10:::INT8)) STORED,
                  CONSTRAINT "primary" PRIMARY KEY (a ASC) USING HASH WITH BUCKET_COUNT = 10,
-                 FAMILY "primary" (crdb_internal_a_shard_10, a)
+                 FAMILY "primary" (crdb_internal_a_shard_10, a),
+                 CONSTRAINT check_crdb_internal_a_shard_10 CHECK (crdb_internal_a_shard_10 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8, 8:::INT8, 9:::INT8))
 )
 
 statement ok
@@ -319,7 +332,8 @@ sharded_primary  CREATE TABLE public.sharded_primary (
                  crdb_internal_a_shard_10 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(a AS STRING), '':::STRING)), 10:::INT8)) STORED,
                  CONSTRAINT "primary" PRIMARY KEY (a ASC) USING HASH WITH BUCKET_COUNT = 10,
                  INDEX sharded_primary_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 10,
-                 FAMILY "primary" (crdb_internal_a_shard_10, a)
+                 FAMILY "primary" (crdb_internal_a_shard_10, a),
+                 CONSTRAINT check_crdb_internal_a_shard_10 CHECK (crdb_internal_a_shard_10 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8, 8:::INT8, 9:::INT8))
 )
 
 statement ok
@@ -399,7 +413,8 @@ column_used_on_unsharded  CREATE TABLE public.column_used_on_unsharded (
                           rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
                           CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                           INDEX column_used_on_unsharded_crdb_internal_a_shard_10_idx (crdb_internal_a_shard_10 ASC),
-                          FAMILY "primary" (a, crdb_internal_a_shard_10, rowid)
+                          FAMILY "primary" (a, crdb_internal_a_shard_10, rowid),
+                          CONSTRAINT check_crdb_internal_a_shard_10 CHECK (crdb_internal_a_shard_10 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8, 8:::INT8, 9:::INT8))
 )
 
 statement ok
@@ -424,7 +439,8 @@ column_used_on_unsharded_create_table  CREATE TABLE public.column_used_on_unshar
                                        rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
                                        CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                                        INDEX column_used_on_unsharded_create_table_crdb_internal_a_shard_10_idx (crdb_internal_a_shard_10 ASC),
-                                       FAMILY "primary" (a, crdb_internal_a_shard_10, rowid)
+                                       FAMILY "primary" (a, crdb_internal_a_shard_10, rowid),
+                                       CONSTRAINT check_crdb_internal_a_shard_10 CHECK (crdb_internal_a_shard_10 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8, 8:::INT8, 9:::INT8))
 )
 
 statement ok
@@ -480,7 +496,9 @@ weird_names  CREATE TABLE public.weird_names (
              "crdb_internal_'quotes' in the column's name_shard_4" INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST("'quotes' in the column's name" AS STRING), '':::STRING)), 4:::INT8)) STORED,
              CONSTRAINT "primary" PRIMARY KEY ("I am a column with spaces" ASC) USING HASH WITH BUCKET_COUNT = 12,
              INDEX foo ("'quotes' in the column's name" ASC) USING HASH WITH BUCKET_COUNT = 4,
-             FAMILY "primary" ("I am a column with spaces", "'quotes' in the column's name", "crdb_internal_I am a column with spaces_shard_12", "crdb_internal_'quotes' in the column's name_shard_4")
+             FAMILY "primary" ("I am a column with spaces", "'quotes' in the column's name", "crdb_internal_I am a column with spaces_shard_12", "crdb_internal_'quotes' in the column's name_shard_4"),
+             CONSTRAINT "check_crdb_internal_I am a column with spaces_shard_12" CHECK ("crdb_internal_I am a column with spaces_shard_12" IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8, 8:::INT8, 9:::INT8, 10:::INT8, 11:::INT8)),
+             CONSTRAINT "check_crdb_internal_'quotes' in the column's name_shard_4" CHECK ("crdb_internal_'quotes' in the column's name_shard_4" IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8))
 )
 
 subtest interleave_disabled
@@ -575,7 +593,9 @@ rename_column  CREATE TABLE public.rename_column (
                crdb_internal_c2_shard_8 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(c2 AS STRING), '':::STRING)), 8:::INT8)) STORED,
                CONSTRAINT "primary" PRIMARY KEY (c0 ASC, c1 ASC) USING HASH WITH BUCKET_COUNT = 8,
                INDEX rename_column_c2_idx (c2 ASC) USING HASH WITH BUCKET_COUNT = 8,
-               FAMILY "primary" (c0, c1, c2, crdb_internal_c0_c1_shard_8, crdb_internal_c2_shard_8)
+               FAMILY "primary" (c0, c1, c2, crdb_internal_c0_c1_shard_8, crdb_internal_c2_shard_8),
+               CONSTRAINT check_crdb_internal_c0_c1_shard_8 CHECK (crdb_internal_c0_c1_shard_8 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8)),
+               CONSTRAINT check_crdb_internal_c2_shard_8 CHECK (crdb_internal_c2_shard_8 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8))
 )
 
 statement ok
@@ -599,7 +619,9 @@ rename_column  CREATE TABLE public.rename_column (
                crdb_internal_c3_shard_8 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(c3 AS STRING), '':::STRING)), 8:::INT8)) STORED,
                CONSTRAINT "primary" PRIMARY KEY (c1 ASC, c2 ASC) USING HASH WITH BUCKET_COUNT = 8,
                INDEX rename_column_c2_idx (c3 ASC) USING HASH WITH BUCKET_COUNT = 8,
-               FAMILY "primary" (c1, c2, c3, crdb_internal_c1_c2_shard_8, crdb_internal_c3_shard_8)
+               FAMILY "primary" (c1, c2, c3, crdb_internal_c1_c2_shard_8, crdb_internal_c3_shard_8),
+               CONSTRAINT check_crdb_internal_c0_c1_shard_8 CHECK (crdb_internal_c1_c2_shard_8 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8)),
+               CONSTRAINT check_crdb_internal_c2_shard_8 CHECK (crdb_internal_c3_shard_8 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8))
 )
 
 query III
@@ -622,7 +644,9 @@ rename_column  CREATE TABLE public.rename_column (
                crdb_internal_c2_shard_8 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(c2 AS STRING), '':::STRING)), 8:::INT8)) STORED,
                CONSTRAINT "primary" PRIMARY KEY (c0 ASC, c1 ASC) USING HASH WITH BUCKET_COUNT = 8,
                INDEX rename_column_c2_idx (c2 ASC) USING HASH WITH BUCKET_COUNT = 8,
-               FAMILY "primary" (c0, c1, c2, crdb_internal_c0_c1_shard_8, crdb_internal_c2_shard_8)
+               FAMILY "primary" (c0, c1, c2, crdb_internal_c0_c1_shard_8, crdb_internal_c2_shard_8),
+               CONSTRAINT check_crdb_internal_c0_c1_shard_8 CHECK (crdb_internal_c0_c1_shard_8 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8)),
+               CONSTRAINT check_crdb_internal_c2_shard_8 CHECK (crdb_internal_c2_shard_8 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8))
 )
 
 query III

--- a/pkg/sql/show_create_clauses.go
+++ b/pkg/sql/show_create_clauses.go
@@ -556,9 +556,6 @@ func showConstraintClause(
 	ctx context.Context, desc catalog.TableDescriptor, semaCtx *tree.SemaContext, f *tree.FmtCtx,
 ) error {
 	for _, e := range desc.AllActiveAndInactiveChecks() {
-		if e.Hidden {
-			continue
-		}
 		f.WriteString(",\n\t")
 		if len(e.Name) > 0 {
 			f.WriteString("CONSTRAINT ")

--- a/pkg/sql/show_test.go
+++ b/pkg/sql/show_test.go
@@ -297,7 +297,8 @@ func TestShowCreateTable(t *testing.T) {
 	rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
 	CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
 	INDEX t14_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 8,
-	FAMILY "primary" (a, crdb_internal_a_shard_8, rowid)
+	FAMILY "primary" (a, crdb_internal_a_shard_8, rowid),
+	CONSTRAINT check_crdb_internal_a_shard_8 CHECK (crdb_internal_a_shard_8 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8))
 )`,
 		},
 	}


### PR DESCRIPTION
Showing hash-sharded column CHECK constraints makes the output of SHOW
CREATE TABLE round-trippable.

Informs #68031

Release note (bug fix): Given a table with hash-sharded indexes, the
output of SHOW CREATE TABLE was not round-trippable - executing the
output would not create an identical table. This has been fixed by
showing CHECK constraints that are automatically created for these
indexes in the output of SHOW CREATE TABLE. The bug existed since
version 21.1.