### PR TITLE
backupccl: skip TestBackupRestoreSystemJobProgress under stressrace

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -1632,6 +1632,8 @@ func TestBackupRestoreSystemJobsProgress(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	defer jobs.TestingSetProgressThresholds()()
 
+	skip.UnderStressRace(t, "test takes too long to run under stressrace")
+
 	checkFraction := func(ctx context.Context, ip inProgressState) error {
 		jobID, err := ip.latestJobID()
 		if err != nil {


### PR DESCRIPTION
The test times out under stressrace. It runs without flaking under `stress` after https://github.com/cockroachdb/cockroach/pull/68961.

Release note: None