### PR TITLE
release-21.1: util/log: start garbage collection routines for old log files

### DIFF
--- a/pkg/util/log/flags.go
+++ b/pkg/util/log/flags.go
@@ -250,7 +250,7 @@ func ApplyConfig(config logconfig.Config) (cleanupFn func(), err error) {
 		if prefix == "default" {
 			prefix = ""
 		}
-		fileSinkInfo, _, err := newFileSinkInfo(prefix, *fc)
+		fileSinkInfo, fileSink, err := newFileSinkInfo(prefix, *fc)
 		if err != nil {
 			cleanupFn()
 			return nil, err
@@ -263,6 +263,10 @@ func ApplyConfig(config logconfig.Config) (cleanupFn func(), err error) {
 			l := chans[ch]
 			l.sinkInfos = append(l.sinkInfos, fileSinkInfo)
 		}
+
+		// Start the GC process. This ensures that old capture files get
+		// erased as new files get created.
+		go fileSink.gcDaemon(secLoggersCtx)
 	}
 
 	// Create the fluent sinks.


### PR DESCRIPTION
Backport 1/1 commits from #68553.

/cc @cockroachdb/release

---

Fixes #68259

This fixes a regression.  The call the routine that deletes old log
files when max-group-size is configured was incorrectly removed in a
refactor, so that functionality was disabled.  This change reinstates
it.

Release note (bug fix): File logs respect max-group-size configuration.
