### PR TITLE
release: update 21.1 mapping in PredecessorVersion()

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1217,7 +1217,7 @@ func PredecessorVersion(buildVersion version.Version) (string, error) {
 	// (see runVersionUpgrade). The same is true for adding a new key to this
 	// map.
 	verMap := map[string]string{
-		"21.1": "20.2.11",
+		"21.1": "20.2.14",
 		"20.2": "20.1.13",
 		"20.1": "19.2.11",
 		"19.2": "19.1.11",


### PR DESCRIPTION
This updates the version mapping of the `21.1` branch to point to the
latest version (`20.2.14`).