### PR TITLE
opt: fix panic in findJoinFilterRange

### DIFF
--- a/pkg/sql/opt/xform/join_funcs.go
+++ b/pkg/sql/opt/xform/join_funcs.go
@@ -1181,7 +1181,7 @@ func (c *CustomFuncs) findJoinFilterRange(
 ) (filterIdx int, ok bool) {
 	for filterIdx := range filters {
 		props := filters[filterIdx].ScalarProps()
-		if props.TightConstraints && !props.Constraints.IsUnconstrained() {
+		if props.TightConstraints && props.Constraints.Length() > 0 {
 			constraint := props.Constraints.Constraint(0)
 			constraintCol := constraint.Columns.Get(0).ID()
 			// See comment in findFiltersForIndexLookup for why we check filter here.

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -9849,3 +9849,36 @@ left-join (lookup metric_values)
  │    └── fd: (1)-->(2)
  └── filters
       └── name:2 = 'cpu' [outer=(2), constraints=(/2: [/'cpu' - /'cpu']; tight), fd=()-->(2)]
+
+# Regression test for #68975. Ensure that findJoinFilterRange does not panic
+# from trying to access the 0-th constraint in an empty constraint set.
+exec-ddl
+CREATE TABLE t68975 (
+    s STRING,
+    i INT CHECK (false),
+    INDEX (s DESC)
+);
+----
+
+opt
+SELECT NULL
+FROM t68975 AS t1 JOIN t68975 AS t2
+ON t1.s = t2.s;
+----
+project
+ ├── columns: "?column?":11
+ ├── fd: ()-->(11)
+ ├── inner-join (merge)
+ │    ├── columns: t1.s:1!null t2.s:6!null
+ │    ├── left ordering: -1
+ │    ├── right ordering: -6
+ │    ├── fd: (1)==(6), (6)==(1)
+ │    ├── scan t68975@secondary [as=t1]
+ │    │    ├── columns: t1.s:1
+ │    │    └── ordering: -1
+ │    ├── scan t68975@secondary [as=t2]
+ │    │    ├── columns: t2.s:6
+ │    │    └── ordering: -6
+ │    └── filters (true)
+ └── projections
+      └── NULL [as="?column?":11]


### PR DESCRIPTION
This commit fixes a panic produced in `findJoinFilterRange` when
attempting to access the 0-th constraint in an empty constraint set.

Fixes #68975

There is no release note because the bug is not present in any releases.

Release note: None