### PR TITLE
release-21.1: changefeedccl: allow configuring changefeeds to wait for all replicas

### DIFF
--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -400,6 +400,7 @@ type saramaConfig struct {
 		Frequency   jsonDuration `json:",omitempty"`
 		MaxMessages int          `json:",omitempty"`
 	}
+	RequiredAcks string `json:",omitempty"`
 
 	Version string `json:",omitempty"`
 }
@@ -418,7 +419,28 @@ func (c *saramaConfig) Apply(kafka *sarama.Config) error {
 		}
 		kafka.Version = parsedVersion
 	}
+	if c.RequiredAcks != "" {
+		parsedAcks, err := parseRequiredAcks(c.RequiredAcks)
+		if err != nil {
+			return err
+		}
+		kafka.Producer.RequiredAcks = parsedAcks
+	}
 	return nil
+}
+
+func parseRequiredAcks(a string) (sarama.RequiredAcks, error) {
+	switch a {
+	case "0", "NONE":
+		return sarama.NoResponse, nil
+	case "1", "ONE":
+		return sarama.WaitForLocal, nil
+	case "-1", "ALL":
+		return sarama.WaitForAll, nil
+	default:
+		return sarama.WaitForLocal,
+			fmt.Errorf(`invalid acks value "%s", must be "NONE"/"0", "ONE"/"1", or "ALL"/"-1"`, a)
+	}
 }
 
 func (c saramaConfig) Validate() error {

--- a/pkg/ccl/changefeedccl/sink_test.go
+++ b/pkg/ccl/changefeedccl/sink_test.go
@@ -418,7 +418,7 @@ func TestSaramaConfigOptionParsing(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, cfg.Validate())
 	})
-	t.Run("validate returns error for bad flush configurationg", func(t *testing.T) {
+	t.Run("validate returns error for bad flush configuration", func(t *testing.T) {
 		opts := make(map[string]string)
 		opts[changefeedbase.OptKafkaSinkConfig] = `{"Flush": {"Messages": 1000}}`
 
@@ -477,6 +477,41 @@ func TestSaramaConfigOptionParsing(t *testing.T) {
 		saramaCfg := &sarama.Config{}
 		err = cfg.Apply(saramaCfg)
 		require.Error(t, err)
+	})
+	t.Run("apply parses RequiredAcks", func(t *testing.T) {
+		opts := make(map[string]string)
+		opts[changefeedbase.OptKafkaSinkConfig] = `{"RequiredAcks": "ALL"}`
+
+		cfg, err := getSaramaConfig(opts)
+		require.NoError(t, err)
+
+		saramaCfg := &sarama.Config{}
+		err = cfg.Apply(saramaCfg)
+		require.NoError(t, err)
+		require.Equal(t, sarama.WaitForAll, saramaCfg.Producer.RequiredAcks)
+
+		opts[changefeedbase.OptKafkaSinkConfig] = `{"RequiredAcks": "-1"}`
+
+		cfg, err = getSaramaConfig(opts)
+		require.NoError(t, err)
+
+		saramaCfg = &sarama.Config{}
+		err = cfg.Apply(saramaCfg)
+		require.NoError(t, err)
+		require.Equal(t, sarama.WaitForAll, saramaCfg.Producer.RequiredAcks)
+
+	})
+	t.Run("apply errors if RequiredAcks is invalid", func(t *testing.T) {
+		opts := make(map[string]string)
+		opts[changefeedbase.OptKafkaSinkConfig] = `{"RequiredAcks": "LocalQuorum"}`
+
+		cfg, err := getSaramaConfig(opts)
+		require.NoError(t, err)
+
+		saramaCfg := &sarama.Config{}
+		err = cfg.Apply(saramaCfg)
+		require.Error(t, err)
+
 	})
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #67504.

/cc @cockroachdb/release

---

… to ack

Changefeeds use Sarama's default config of `RequiredAcks: WaitForLocal`,
meaning it considers a write to Kafka successful once the leader node has
acked it. This carries a risk of dropped messages if the leader node acks
before replicating to a quorum of other Kafka nodes, then fails.
This PR allows overriding the config like so:

`CREATE CHANGEFEED ...  WITH kafka_sink_config='{"RequiredAcks": "ALL"}';`

It's also now possible to increase throughput by decreasing consistency:

`CREATE CHANGEFEED ...  WITH kafka_sink_config='{"RequiredAcks": "NONE"}';`

Release note (enterprise change): kafka_sink_config can include RequiredAcks

Closes #67368

Release justification: Urgently requested feature, purely additive