### PR TITLE
ci: add ci bazel jobs for maybe_stress{,race}

### DIFF
--- a/build/teamcity/cockroach/ci/tests/maybe_stress.sh
+++ b/build/teamcity/cockroach/ci/tests/maybe_stress.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
+
+source "$dir/teamcity-support.sh"  # For $root, would_stress
+source "$dir/teamcity-bazel-support.sh"  # For run_bazel
+
+tc_prepare
+
+if would_stress; then
+    tc_start_block "Run stress tests"
+    run_bazel env BUILD_VCS_NUMBER="$BUILD_VCS_NUMBER" build/teamcity/cockroach/ci/tests/maybe_stress_impl.sh stress
+    tc_end_block "Run stress tests"
+fi

--- a/build/teamcity/cockroach/ci/tests/maybe_stress_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/maybe_stress_impl.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -exuo pipefail
+
+if [ -z "$1" ]
+then
+    echo 'Usage: maybe_stress_impl.sh stress|stressrace'
+    exit 1
+fi
+
+TARGET="$1"
+
+bazel build //pkg/cmd/github-pull-request-make //pkg/cmd/bazci @com_github_cockroachdb_stress//:stress --config=ci
+BAZEL_BIN=$(bazel info bazel-bin)
+PATH=$PATH:$BAZEL_BIN/pkg/cmd/bazci/bazci_:$BAZEL_BIN/external/com_github_cockroachdb_stress/stress_ TARGET=$TARGET \
+    $BAZEL_BIN/pkg/cmd/github-pull-request-make/github-pull-request-make_/github-pull-request-make

--- a/build/teamcity/cockroach/ci/tests/maybe_stressrace.sh
+++ b/build/teamcity/cockroach/ci/tests/maybe_stressrace.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
+
+source "$dir/teamcity-support.sh"  # For $root, would_stress
+source "$dir/teamcity-bazel-support.sh"  # For run_bazel
+
+tc_prepare
+
+if would_stress; then
+    tc_start_block "Run stress tests"
+    run_bazel env BUILD_VCS_NUMBER="$BUILD_VCS_NUMBER" build/teamcity/cockroach/ci/tests/maybe_stress_impl.sh stressrace
+    tc_end_block "Run stress tests"
+fi

--- a/pkg/cmd/github-pull-request-make/BUILD.bazel
+++ b/pkg/cmd/github-pull-request-make/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/github-pull-request-make",
     visibility = ["//visibility:private"],
     deps = [
+        "//pkg/build/bazel",
         "//pkg/testutils/buildutil",
         "@com_github_google_go_github//github",
         "@org_golang_x_oauth2//:oauth2",


### PR DESCRIPTION
* Rip benchmark support out of `github-pull-request-make` (it's not
  currently used).
* Add support for Bazel builds in `github-pull-request-make`.
* Add scripts to invoke `github-pull-request-make` appropriately.

Closes #68388.
Closes #68389.

Release note: None