### PR TITLE
kv: deflake TestTxnCoordSenderPipelining

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_factory.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_factory.go
@@ -50,6 +50,7 @@ type TxnCoordSenderFactoryConfig struct {
 	Clock    *hlc.Clock
 	Stopper  *stop.Stopper
 
+	// -1 to disable transaction heartbeats.
 	HeartbeatInterval time.Duration
 	Linearizable      bool
 	Metrics           TxnMetrics

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
@@ -2216,6 +2216,9 @@ func TestTxnCoordSenderPipelining(t *testing.T) {
 		Settings:   s.Cfg.Settings,
 		Clock:      s.Clock,
 		Stopper:    s.Stopper(),
+		// Disable transaction heartbeats so that they don't disrupt our attempt to
+		// track the requests issued by the transactions.
+		HeartbeatInterval: -1,
 	}, senderFn)
 	db := kv.NewDB(ambientCtx, tsf, s.Clock, s.Stopper())
 

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_heartbeater.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_heartbeater.go
@@ -282,6 +282,10 @@ func (h *txnHeartbeater) closeLocked() {
 
 // startHeartbeatLoopLocked starts a heartbeat loop in a different goroutine.
 func (h *txnHeartbeater) startHeartbeatLoopLocked(ctx context.Context) {
+	if h.loopInterval < 0 {
+		log.Infof(ctx, "coordinator heartbeat loop disabled")
+		return
+	}
 	if h.mu.loopStarted {
 		log.Fatal(ctx, "attempting to start a second heartbeat loop")
 	}


### PR DESCRIPTION
Fixes #68948.

This commit disables the transaction heartbeat loop in the test, which
removes a dependency on timing.

However, this doesn't explain why the test became slower over the past
few days. We see in CI that on the two separate occasions where the
test flaked, it took 1.08s and 1.41s, both above the 1s necessary for
the test to flake.