### PR TITLE
reduce: add chunk reduction

### DIFF
--- a/pkg/testutils/reduce/datadriven.go
+++ b/pkg/testutils/reduce/datadriven.go
@@ -22,13 +22,14 @@ import (
 func Walk(
 	t *testing.T,
 	path string,
-	filter func([]byte) ([]byte, error),
+	filter func(string) (string, error),
 	interesting func(contains string) InterestingFn,
 	mode Mode,
+	cr ChunkReducer,
 	passes []Pass,
 ) {
 	datadriven.Walk(t, path, func(t *testing.T, path string) {
-		RunTest(t, path, filter, interesting, mode, passes)
+		RunTest(t, path, filter, interesting, mode, cr, passes)
 	})
 }
 
@@ -45,9 +46,10 @@ func Walk(
 func RunTest(
 	t *testing.T,
 	path string,
-	filter func([]byte) ([]byte, error),
+	filter func(string) (string, error),
 	interesting func(contains string) InterestingFn,
 	mode Mode,
+	cr ChunkReducer,
 	passes []Pass,
 ) {
 	var contains string
@@ -61,7 +63,7 @@ func RunTest(
 			contains = d.Input
 			return ""
 		case "reduce":
-			input := []byte(d.Input)
+			input := d.Input
 			if filter != nil {
 				var err error
 				input, err = filter(input)
@@ -69,11 +71,11 @@ func RunTest(
 					t.Fatal(err)
 				}
 			}
-			output, err := Reduce(log, File(input), interesting(contains), 0, mode, passes...)
+			output, err := Reduce(log, input, interesting(contains), 0, mode, cr, passes...)
 			if err != nil {
 				t.Fatal(err)
 			}
-			return string(output) + "\n"
+			return output + "\n"
 		default:
 			t.Fatalf("unknown command: %s", d.Cmd)
 			return ""

--- a/pkg/testutils/reduce/pass.go
+++ b/pkg/testutils/reduce/pass.go
@@ -39,20 +39,20 @@ func (p intPass) Name() string {
 	return p.name
 }
 
-func (p intPass) New(File) State {
+func (p intPass) New(string) State {
 	return 0
 }
 
-func (p intPass) Transform(f File, s State) (File, Result, error) {
+func (p intPass) Transform(f string, s State) (string, Result, error) {
 	i := s.(int)
-	data, ok, err := p.fn(string(f), i)
+	data, ok, err := p.fn(f, i)
 	res := OK
 	if !ok {
 		res = STOP
 	}
-	return File(data), res, err
+	return data, res, err
 }
 
-func (p intPass) Advance(f File, s State) State {
+func (p intPass) Advance(f string, s State) State {
 	return s.(int) + 1
 }

--- a/pkg/testutils/reduce/reduce.go
+++ b/pkg/testutils/reduce/reduce.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math/rand"
 	"runtime"
 
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
@@ -27,16 +28,16 @@ import (
 
 // Pass defines a reduce pass.
 type Pass interface {
-	// New creates a new opaque state object for the input File.
-	New(File) State
-	// Transform applies this transformation pass to the input File using
+	// New creates a new opaque state object for the input string.
+	New(string) State
+	// Transform applies this transformation pass to the input string using
 	// State to determine which occurrence to transform. It returns the
-	// transformed File, a Result indicating whether to proceed or not, and
+	// transformed string, a Result indicating whether to proceed or not, and
 	// an error if the transformation could not be performed.
-	Transform(File, State) (File, Result, error)
+	Transform(string, State) (string, Result, error)
 	// Advance moves State to the next occurrence of a transformation in
-	// the given input File and returns the new State.
-	Advance(File, State) State
+	// the given input string and returns the new State.
+	Advance(string, State) State
 	// Name returns the name of the Pass.
 	Name() string
 }
@@ -54,17 +55,9 @@ const (
 // State is opaque state for a Pass.
 type State interface{}
 
-// File contains the contents of a file.
-type File string
-
-// Size returns the size of the file in bytes.
-func (f File) Size() int {
-	return len(f)
-}
-
-// InterestingFn returns true if File triggers the target test failure. It
+// InterestingFn returns true if the string triggers the target test failure. It
 // should be context-aware and stop work if the context is canceled.
-type InterestingFn func(context.Context, File) bool
+type InterestingFn func(context.Context, string) bool
 
 // Mode is an enum specifying how to determine if forward progress was made.
 type Mode int
@@ -84,18 +77,13 @@ const (
 // for GOMAXPROCS.
 func Reduce(
 	logger io.Writer,
-	originalTestCase File,
+	originalTestCase string,
 	isInteresting InterestingFn,
 	numGoroutines int,
 	mode Mode,
+	chunkReducer ChunkReducer,
 	passList ...Pass,
-) (File, error) {
-	log := func(format string, args ...interface{}) {
-		if logger == nil {
-			return
-		}
-		fmt.Fprintf(logger, format, args...)
-	}
+) (string, error) {
 	if numGoroutines < 1 {
 		numGoroutines = runtime.GOMAXPROCS(0)
 	}
@@ -103,6 +91,11 @@ func Reduce(
 	defer cancel()
 	if !isInteresting(ctx, originalTestCase) {
 		return "", errors.New("original test case not interesting")
+	}
+
+	chunkReducedTestCase, err := attemptChunkReduction(logger, originalTestCase, isInteresting, chunkReducer)
+	if err != nil {
+		return "", err
 	}
 
 	// findNextInteresting finds the next interesting result. It does this
@@ -117,15 +110,14 @@ func Reduce(
 		g := ctxgroup.WithContext(ctx)
 		variants := make(chan varState)
 		g.GoCtx(func(ctx context.Context) error {
-			// This goroutine generates all variants from passes
-			// and sends them on a chan for testing. It closes
-			// the variants chan when there are no more. Since
-			// numGoroutines are working at one time, this
-			// goroutine will block until one is available. If an
-			// interesting variant is found, ctx will close and
-			// this goroutine will shut down.
+			// This goroutine generates all variants from passList and sends
+			// them on a chan for testing. It closes the variants chan when
+			// there are no more. Since numGoroutines are working at one time,
+			// this goroutine will block until one is available. If an
+			// interesting variant is found, ctx will close and this goroutine
+			// will shut down.
 			defer close(variants)
-			current := vs.f
+			current := vs.file
 			state := vs.s
 			var done, prev chan struct{}
 			// Pre-populate the first prev.
@@ -145,16 +137,14 @@ func Reduce(
 						state = nil
 						break
 					}
-					// Done must be buffered because it
-					// will only be received from if the
-					// following variant was interesting,
-					// and in other cases the send must
-					// not block.
+					// Done must be buffered because it will only be received
+					// from if the following variant was interesting, and in
+					// other cases the send must not block.
 					done = make(chan struct{}, 1)
 					select {
 					case variants <- varState{
 						pi:   pi,
-						f:    variant,
+						file: variant,
 						s:    state,
 						done: done,
 						prev: prev,
@@ -172,7 +162,7 @@ func Reduce(
 		for i := 0; i < numGoroutines; i++ {
 			g.GoCtx(func(ctx context.Context) error {
 				for vs := range variants {
-					if isInteresting(ctx, vs.f) {
+					if isInteresting(ctx, vs.file) {
 						// Wait for the previous test to finish.
 						select {
 						case <-ctx.Done():
@@ -203,7 +193,8 @@ func Reduce(
 			var ierr errInteresting
 			if errors.As(err, &ierr) {
 				vs := varState(ierr)
-				log("\tpass %d of %d (%s): %d bytes\n", vs.pi+1, len(passList), passList[vs.pi].Name(), vs.f.Size())
+				log(logger, "\tpass %d of %d (%s): %d bytes\n", vs.pi+1, len(passList),
+					passList[vs.pi].Name(), len(vs.file))
 				return &vs, nil
 			}
 			return nil, err
@@ -213,11 +204,11 @@ func Reduce(
 
 	start := timeutil.Now()
 	vs := varState{
-		f: originalTestCase,
+		file: chunkReducedTestCase,
 	}
-	log("size: %d\n", vs.f.Size())
+	log(logger, "size: %d\n", len(vs.file))
 	for {
-		sizeAtStart := vs.f.Size()
+		sizeAtStart := len(vs.file)
 		foundInteresting := false
 		for {
 			next, err := findNextInteresting(vs)
@@ -234,7 +225,7 @@ func Reduce(
 		done := false
 		switch mode {
 		case ModeSize:
-			if vs.f.Size() >= sizeAtStart {
+			if len(vs.file) >= sizeAtStart {
 				done = true
 			}
 		case ModeInteresting:
@@ -247,14 +238,24 @@ func Reduce(
 		}
 		// Need to do another round. Clear pi and state.
 		vs = varState{
-			f: vs.f,
+			file: vs.file,
 		}
 	}
-	log("total time: %v\n", timeutil.Since(start))
-	log("original size: %v\n", originalTestCase.Size())
-	log("final size: %v\n", vs.f.Size())
-	log("reduction: %v%%\n", 100-int(100*float64(vs.f.Size())/float64(originalTestCase.Size())))
-	return vs.f, nil
+	log(logger, "total time: %v\n", timeutil.Since(start))
+	log(logger, "original size: %v\n", len(originalTestCase))
+	if chunkReducer != nil {
+		log(logger, "chunk-reduced size: %v\n", len(chunkReducedTestCase))
+	}
+	log(logger, "final size: %v\n", len(vs.file))
+	log(logger, "reduction: %v%%\n", 100-int(100*float64(len(vs.file))/float64(len(originalTestCase))))
+	return vs.file, nil
+}
+
+func log(logger io.Writer, format string, args ...interface{}) {
+	if logger == nil {
+		return
+	}
+	fmt.Fprintf(logger, format, args...)
 }
 
 // errInteresting is an error version of varState that is a special sentinel
@@ -269,13 +270,71 @@ func (e errInteresting) Error() string {
 // varState tracks the current variant state, which is a tuple of the current
 // pass, file, and state.
 type varState struct {
-	pi int
-	f  File
-	s  State
+	pi   int
+	file string
+	s    State
 
 	// done and prev are used to synchronize work between variant
 	// testing. A variant sends on done when it has verified its test is
 	// uninteresting. If its test was interesting, it receives on prev,
 	// which thus guarantees that it was the first interesting variant.
 	done, prev chan struct{}
+}
+
+// A ChunkReducer can eliminate large chunks of a test case before performing
+// the more granular and expensive reduction algorithm. It breaks a test case
+// into segments. Segments can be grouped into chunks than can be removed
+// entirely from the test case if they aren't required to produce an interesting
+// result.
+type ChunkReducer interface {
+	// HaltAfter returns the number of consecutive failed reduction attempts
+	// allowed before chunk reduction is halted.
+	HaltAfter() int
+	// Init the ChunkReducer with the given string.
+	Init(string) error
+	// NumSegments returns the total number of segments that are eligible to be
+	// reduced en masse.
+	NumSegments() int
+	// DeleteSegments returns a string with segments [start, end) removed from
+	// the original string.
+	DeleteSegments(start, end int) string
+}
+
+// attemptChunkReduction attempts to reduce chunks of originalTestCase en masse
+// using the provided ChunkReducer. It randomly deletes a range of segments and
+// tests if the remaining segments satisfy isInteresting. It will continually
+// reduce segments until it fails to reduce chunkReducer.HaltAfter() times in a
+// row.
+func attemptChunkReduction(
+	logger io.Writer, originalTestCase string, isInteresting InterestingFn, chunkReducer ChunkReducer,
+) (string, error) {
+	if chunkReducer == nil {
+		return originalTestCase, nil
+	}
+
+	ctx := context.Background()
+	reduced := originalTestCase
+
+	failedAttempts := 0
+	for failedAttempts < chunkReducer.HaltAfter() {
+		err := chunkReducer.Init(reduced)
+		if err != nil {
+			return "", err
+		}
+
+		// Pick two random indexes and remove all statements between them.
+		start := rand.Intn(chunkReducer.NumSegments())
+		end := rand.Intn(chunkReducer.NumSegments()-start) + start + 1
+
+		localReduced := chunkReducer.DeleteSegments(start, end)
+		if isInteresting(ctx, localReduced) {
+			reduced = localReduced
+			log(logger, "\tchunk reduction: %d bytes\n", len(reduced))
+			failedAttempts = 0
+		} else {
+			failedAttempts++
+		}
+	}
+
+	return reduced, nil
 }

--- a/pkg/testutils/reduce/reduce_test.go
+++ b/pkg/testutils/reduce/reduce_test.go
@@ -21,7 +21,8 @@ import (
 )
 
 func TestReduceGo(t *testing.T) {
-	reduce.Walk(t, "testdata", nil /* filter */, isInterestingGo, reduce.ModeInteresting, goPasses)
+	reduce.Walk(t, "testdata", nil /* filter */, isInterestingGo, reduce.ModeInteresting,
+		nil /* chunkReducer */, goPasses)
 }
 
 var (
@@ -51,7 +52,7 @@ var (
 )
 
 func isInterestingGo(contains string) reduce.InterestingFn {
-	return func(ctx context.Context, f reduce.File) bool {
+	return func(ctx context.Context, f string) bool {
 		_, err := parser.ParseExpr(string(f))
 		if err == nil {
 			return false

--- a/pkg/testutils/reduce/reducesql/reducesql_test.go
+++ b/pkg/testutils/reduce/reducesql/reducesql_test.go
@@ -33,11 +33,12 @@ func TestReduceSQL(t *testing.T) {
 	skip.IgnoreLint(t, "unnecessary")
 	reducesql.LogUnknown = *printUnknown
 
-	reduce.Walk(t, "testdata", reducesql.Pretty, isInterestingSQL, reduce.ModeInteresting, reducesql.SQLPasses)
+	reduce.Walk(t, "testdata", reducesql.Pretty, isInterestingSQL, reduce.ModeInteresting,
+		nil /* chunkReducer */, reducesql.SQLPasses)
 }
 
 func isInterestingSQL(contains string) reduce.InterestingFn {
-	return func(ctx context.Context, f reduce.File) bool {
+	return func(ctx context.Context, f string) bool {
 		args := base.TestServerArgs{
 			Insecure: true,
 		}


### PR DESCRIPTION
A new feature has been added to the `reduce` utility which attempts to
reduce random, large chunks of SQL statements from a test case, while
still producing an error containing the given regex.

To enable this feature, the `-chunk` argument must be given with a value
greater than `0` (`0` is the default). This value is the number of
consecutive chunk reduction failures allowed before halting chunk
reduction. For example, if `-chunk 12` is given, then chunk reduction
will continue until there are 12 consecutive attempts where the error is
not reproduced after removing a random group of SQL statements.

Chunk reduction is performed before the more granular and expensive
reduce algorithm. This can drastically decrease the time to reduce a set
of SQL statements in cases where just a few statements of a large log
file are responsible for reproducing an error. This is often the case in
a `sqlsmith` log. Anecdotally, the `sqlsmith` log file from #68975 was
reduced in ~30 minutes without chunk reduction enabled and ~2 minutes
with the option `-chunk 12`.

Note that behavior of `reduce` with a `-chunk` setting above `0` can be
unpredictable because the chunks of statements to reduce are chosen at
random.

Release note: None
