### PR TITLE
colexec: fix bytes corruption for disk-spilled window functions

### DIFF
--- a/pkg/col/coldata/bytes.go
+++ b/pkg/col/coldata/bytes.go
@@ -492,6 +492,9 @@ func (b *Bytes) Truncate(length int) {
 		// This is a no-op.
 		return
 	}
+	// Ensure that calling Truncate with a length greater than maxSetLength does
+	// not invalidate the non-decreasing invariant.
+	b.UpdateOffsetsToBeNonDecreasing(length)
 	b.data = b.data[:b.offsets[length]]
 	b.maxSetLength = length
 }

--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -4279,3 +4279,25 @@ NULL  NULL  NULL
 
 statement ok
 RESET vectorize;
+
+# Regression test for incorrect bytes results when spilling to disk when there
+# are multiple partitions and one of the earlier partitions has trailing NULL
+# values.
+statement ok
+DROP TABLE IF EXISTS t;
+CREATE TABLE t (x INT, y STRING);
+INSERT INTO t VALUES (1, 'NotNull'), (1, NULL), (1, NULL),
+(2, 'NotNull'), (2, 'NotNull'), (2, 'NotNull'), (2, 'NotNull');
+
+# Loading a batch with trailing nulls onto disk and then unloading it to
+# continue processing should not corrupt the output bytes.
+query ITT rowsort
+SELECT x, y, first_value(y) OVER (PARTITION BY x ROWS BETWEEN CURRENT ROW AND CURRENT ROW) FROM t;
+----
+1  NotNull  NotNull
+1  NULL     NULL
+1  NULL     NULL
+2  NotNull  NotNull
+2  NotNull  NotNull
+2  NotNull  NotNull
+2  NotNull  NotNull


### PR DESCRIPTION
This patch fixes the `Truncate` method for bytes columns so that it
updates the offsets to be non-decreasing up to the new `maxSetLength`.
This is necessary in the case when the new `maxSetLength` is greater
than the old one.

This can happen when a window function has a bytes output column and
the `SpillingQueue` that buffers input batches spills to disk. If a
batch has trailing nulls up to the last processed index, and it is
immediately enqueued to disk, `SpillingQueue` does not call `SetLength`
on the batch, so the offsets still need to be updated (in this case by
`Truncate`).

Fixes #60824

Release note: None