### PR TITLE
kvfollowerreadsccl: make PREPARE work with bounded staleness

### DIFF
--- a/pkg/ccl/kvccl/kvfollowerreadsccl/boundedstaleness_test.go
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/boundedstaleness_test.go
@@ -284,7 +284,21 @@ func TestBoundedStalenessDataDriven(t *testing.T) {
 		tc := testcluster.StartTestCluster(t, 3, clusterArgs)
 		defer tc.Stopper().Stop(ctx)
 
+		savedTraceStmt := ""
 		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
+			// Early exit non-query execution related commands.
+			switch d.Cmd {
+			// override-matching-stmt-for-tracing forces the next trace of events to
+			// only  look for the given query instead of using d.Input. This is useful
+			//for traces of prepared statements.
+			case "override-matching-stmt-for-tracing":
+				savedTraceStmt = d.Input
+				return ""
+			case "reset-matching-stmt-for-tracing":
+				savedTraceStmt = ""
+				return ""
+			}
+
 			var showEvents bool
 			var waitUntilFollowerReads bool
 			var waitUntilMatch bool
@@ -292,10 +306,14 @@ func TestBoundedStalenessDataDriven(t *testing.T) {
 				bse.reset()
 			}()
 			dbConn := tc.ServerConn(0)
+			traceStmt := savedTraceStmt
+			if traceStmt == "" {
+				traceStmt = d.Input
+			}
 			for _, arg := range d.CmdArgs {
 				switch arg.Key {
 				case "wait-until-follower-read":
-					bse.setStmt(d.Input)
+					bse.setStmt(traceStmt)
 					waitUntilFollowerReads = true
 				case "wait-until-match":
 					// We support both wait-until-match and wait-until-follower-read,
@@ -326,7 +344,7 @@ func TestBoundedStalenessDataDriven(t *testing.T) {
 					return ""
 				case "query":
 					// Always show events.
-					bse.setStmt(d.Input)
+					bse.setStmt(traceStmt)
 					showEvents = true
 					rows, err := dbConn.Query(d.Input)
 					if err != nil {

--- a/pkg/ccl/kvccl/kvfollowerreadsccl/testdata/boundedstaleness/single_row
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/testdata/boundedstaleness/single_row
@@ -103,6 +103,37 @@ SELECT * FROM t AS OF SYSTEM TIME with_min_timestamp(now() - '10s', true) WHERE 
 events (1 found):
  * event 1: colbatchscan trace on node_idx 2: local follower read
 
+exec idx=2
+PREPARE max_staleness_prep AS SELECT pk FROM t AS OF SYSTEM TIME with_max_staleness('10s') WHERE pk = 1;
+PREPARE min_timestamp_prep AS SELECT pk FROM t AS OF SYSTEM TIME with_min_timestamp(now() - '10s') WHERE pk = 1
+----
+
+override-matching-stmt-for-tracing
+SELECT pk FROM t AS OF SYSTEM TIME with_max_staleness('10s') WHERE pk = 1
+----
+
+query idx=2
+EXECUTE max_staleness_prep
+----
+1
+events (1 found):
+ * event 1: colbatchscan trace on node_idx 2: local follower read
+
+override-matching-stmt-for-tracing
+SELECT pk FROM t AS OF SYSTEM TIME with_min_timestamp(now() - '10s') WHERE pk = 1
+----
+
+query idx=2
+EXECUTE min_timestamp_prep
+----
+1
+events (1 found):
+ * event 1: colbatchscan trace on node_idx 2: local follower read
+
+reset-matching-stmt-for-tracing
+----
+
+
 # Set a super high closed bounded staleness target and execute a schema change.
 exec
 SET CLUSTER SETTING kv.closed_timestamp.target_duration = '1hr';

--- a/pkg/ccl/logictestccl/testdata/logic_test/as_of
+++ b/pkg/ccl/logictestccl/testdata/logic_test/as_of
@@ -293,8 +293,26 @@ ROLLBACK
 # Tests for bounded staleness with prepared statements.
 #
 
-statement error bounded staleness queries do not yet work with prepared statements
-PREPARE prep_stmt AS SELECT * FROM t AS OF SYSTEM TIME with_min_timestamp(statement_timestamp() - '10s'::interval)
+statement ok
+PREPARE with_min_timestamp_prep AS SELECT * FROM t AS OF SYSTEM TIME with_min_timestamp(statement_timestamp() - '10s'::interval) WHERE i = 2
 
-statement error bounded staleness queries do not yet work with prepared statements
-PREPARE prep_stmt AS SELECT * FROM t AS OF SYSTEM TIME with_max_staleness('1ms')
+statement ok
+EXECUTE with_min_timestamp_prep
+
+statement ok
+PREPARE with_max_staleness_prep AS SELECT * FROM t AS OF SYSTEM TIME with_max_staleness('10s') WHERE i = 2
+
+statement ok
+EXECUTE with_max_staleness_prep
+
+statement ok
+PREPARE bad_max_staleness_stmt AS SELECT * FROM t AS OF SYSTEM TIME with_max_staleness('1ms')
+
+statement error unimplemented: cannot use bounded staleness for queries that may touch more than one range or require an index join
+EXECUTE bad_max_staleness_stmt
+
+statement ok
+PREPARE bad_min_timestamp_stmt AS SELECT * FROM t AS OF SYSTEM TIME with_min_timestamp(statement_timestamp() - '1ms')
+
+statement error unimplemented: cannot use bounded staleness for queries that may touch more than one range or require an index join
+EXECUTE bad_min_timestamp_stmt


### PR DESCRIPTION
Prepared statements now work with bounded staleness reads.

In tests, we need to force trace statements for PREPARE as the EXECUTE
stmt shows up as the prepared statement during tracing.

Release note: None