### PR TITLE
ccl/backupccl: skip TestBackupRestoreSystemJobsProgress

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -1589,6 +1589,7 @@ WHERE
 
 func TestBackupRestoreSystemJobsProgress(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 68571, "flaky test")
 	defer log.Scope(t).Close(t)
 	defer jobs.TestingSetProgressThresholds()()
 


### PR DESCRIPTION
Refs: #68571

Reason: flaky test (this is flaking regularly on PRs)

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None