### PR TITLE
kvprober: extend kvprober to test KV's write codepaths

### DIFF
--- a/pkg/kv/kvprober/kvprober.go
+++ b/pkg/kv/kvprober/kvprober.go
@@ -22,8 +22,8 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -33,13 +33,20 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
+const putValue = "thekvproberwrotethis"
+
 // Prober sends queries to KV in a loop. See package docstring for more.
 type Prober struct {
 	ambientCtx log.AmbientContext
 	db         *kv.DB
 	settings   *cluster.Settings
-	// planner is an interface for selecting a range to probe.
-	planner planner
+	// planner is an interface for selecting a range to probe. There are
+	// separate planners for the read & write probe loops, so as to achieve
+	// a balanced probing of the keyspace, regardless of differences in the rate
+	// at which Prober sends different probes. Also note that planner is
+	// NOT thread-safe.
+	readPlanner  planner
+	writePlanner planner
 	// metrics wraps up the set of prometheus metrics that the prober sets; the
 	// goal of the prober IS to populate these metrics.
 	metrics Metrics
@@ -58,13 +65,13 @@ type Opts struct {
 var (
 	metaReadProbeAttempts = metric.Metadata{
 		Name:        "kv.prober.read.attempts",
-		Help:        "Number of attempts made to probe KV, regardless of outcome",
+		Help:        "Number of attempts made to read probe KV, regardless of outcome",
 		Measurement: "Queries",
 		Unit:        metric.Unit_COUNT,
 	}
 	metaReadProbeFailures = metric.Metadata{
 		Name: "kv.prober.read.failures",
-		Help: "Number of attempts made to probe KV that failed, " +
+		Help: "Number of attempts made to read probe KV that failed, " +
 			"whether due to error or timeout",
 		Measurement: "Queries",
 		Unit:        metric.Unit_COUNT,
@@ -72,6 +79,25 @@ var (
 	metaReadProbeLatency = metric.Metadata{
 		Name:        "kv.prober.read.latency",
 		Help:        "Latency of successful KV read probes",
+		Measurement: "Latency",
+		Unit:        metric.Unit_NANOSECONDS,
+	}
+	metaWriteProbeAttempts = metric.Metadata{
+		Name:        "kv.prober.write.attempts",
+		Help:        "Number of attempts made to write probe KV, regardless of outcome",
+		Measurement: "Queries",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaWriteProbeFailures = metric.Metadata{
+		Name: "kv.prober.write.failures",
+		Help: "Number of attempts made to write probe KV that failed, " +
+			"whether due to error or timeout",
+		Measurement: "Queries",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaWriteProbeLatency = metric.Metadata{
+		Name:        "kv.prober.write.latency",
+		Help:        "Latency of successful KV write probes",
 		Measurement: "Latency",
 		Unit:        metric.Unit_NANOSECONDS,
 	}
@@ -98,11 +124,14 @@ var (
 
 // Metrics groups together the metrics that kvprober exports.
 type Metrics struct {
-	ReadProbeAttempts *metric.Counter
-	ReadProbeFailures *metric.Counter
-	ReadProbeLatency  *metric.Histogram
-	ProbePlanAttempts *metric.Counter
-	ProbePlanFailures *metric.Counter
+	ReadProbeAttempts  *metric.Counter
+	ReadProbeFailures  *metric.Counter
+	ReadProbeLatency   *metric.Histogram
+	WriteProbeAttempts *metric.Counter
+	WriteProbeFailures *metric.Counter
+	WriteProbeLatency  *metric.Histogram
+	ProbePlanAttempts  *metric.Counter
+	ProbePlanFailures  *metric.Counter
 }
 
 // NewProber creates a Prober from Opts.
@@ -112,13 +141,18 @@ func NewProber(opts Opts) *Prober {
 		db:         opts.DB,
 		settings:   opts.Settings,
 
-		planner: newMeta2Planner(opts.DB, opts.Settings),
+		readPlanner:  newMeta2Planner(opts.DB, opts.Settings, func() time.Duration { return readInterval.Get(&opts.Settings.SV) }),
+		writePlanner: newMeta2Planner(opts.DB, opts.Settings, func() time.Duration { return writeInterval.Get(&opts.Settings.SV) }),
+
 		metrics: Metrics{
-			ReadProbeAttempts: metric.NewCounter(metaReadProbeAttempts),
-			ReadProbeFailures: metric.NewCounter(metaReadProbeFailures),
-			ReadProbeLatency:  metric.NewLatency(metaReadProbeLatency, opts.HistogramWindowInterval),
-			ProbePlanAttempts: metric.NewCounter(metaProbePlanAttempts),
-			ProbePlanFailures: metric.NewCounter(metaProbePlanFailures),
+			ReadProbeAttempts:  metric.NewCounter(metaReadProbeAttempts),
+			ReadProbeFailures:  metric.NewCounter(metaReadProbeFailures),
+			ReadProbeLatency:   metric.NewLatency(metaReadProbeLatency, opts.HistogramWindowInterval),
+			WriteProbeAttempts: metric.NewCounter(metaWriteProbeAttempts),
+			WriteProbeFailures: metric.NewCounter(metaWriteProbeFailures),
+			WriteProbeLatency:  metric.NewLatency(metaWriteProbeLatency, opts.HistogramWindowInterval),
+			ProbePlanAttempts:  metric.NewCounter(metaProbePlanAttempts),
+			ProbePlanFailures:  metric.NewCounter(metaProbePlanFailures),
 		},
 	}
 }
@@ -131,53 +165,64 @@ func (p *Prober) Metrics() Metrics {
 // Start causes kvprober to start probing KV. Start returns immediately. Start
 // returns an error only if stopper.RunAsyncTask returns an error.
 func (p *Prober) Start(ctx context.Context, stopper *stop.Stopper) error {
-	return stopper.RunAsyncTask(ctx, "probe loop", func(ctx context.Context) {
-		ambient := p.ambientCtx
-		ambient.AddLogTag("kvprober", nil)
+	ambient := p.ambientCtx
+	ambient.AddLogTag("kvprober", nil)
 
-		ctx, sp := ambient.AnnotateCtxWithSpan(ctx, "probe loop")
-		defer sp.Finish()
+	startLoop := func(ctx context.Context, desc string, pf func(context.Context, *kv.DB, planner), pl planner, interval *settings.DurationSetting) error {
+		return stopper.RunAsyncTask(ctx, desc, func(ctx context.Context) {
+			defer logcrash.RecoverAndReportNonfatalPanic(ctx, &p.settings.SV)
 
-		ctx, cancel := stopper.WithCancelOnQuiesce(ctx)
-		defer cancel()
-
-		d := func() time.Duration {
-			return withJitter(readInterval.Get(&p.settings.SV), rand.Int63n)
-		}
-		t := timeutil.NewTimer()
-		t.Reset(d())
-		defer t.Stop()
-
-		for {
-			select {
-			case <-t.C:
-				t.Read = true
-				// Jitter added to de-synchronize different nodes' probe loops.
-				t.Reset(d())
-			case <-stopper.ShouldQuiesce():
-				return
+			d := func() time.Duration {
+				return withJitter(interval.Get(&p.settings.SV), rand.Int63n)
 			}
+			t := timeutil.NewTimer()
+			defer t.Stop()
+			t.Reset(d())
 
-			p.probe(ctx, p.db)
-		}
-	})
-}
+			ctx, sp := ambient.AnnotateCtxWithSpan(ctx, desc)
+			defer sp.Finish()
 
-type dbGet interface {
-	Get(ctx context.Context, key interface{}) (kv.KeyValue, error)
+			ctx, cancel := stopper.WithCancelOnQuiesce(ctx)
+			defer cancel()
+
+			for {
+				select {
+				case <-t.C:
+					t.Read = true
+					// Jitter added to de-synchronize different nodes' probe loops.
+					t.Reset(d())
+				case <-stopper.ShouldQuiesce():
+					return
+				}
+
+				pf(ctx, p.db, pl)
+			}
+		})
+	}
+
+	if err := startLoop(ctx, "read probe loop", p.readProbe, p.readPlanner, readInterval); err != nil {
+		return err
+	}
+	return startLoop(ctx, "write probe loop", p.writeProbe, p.writePlanner, writeInterval)
 }
 
 // Doesn't return an error. Instead increments error type specific metrics.
-func (p *Prober) probe(ctx context.Context, db dbGet) {
-	defer logcrash.RecoverAndReportNonfatalPanic(ctx, &p.settings.SV)
+func (p *Prober) readProbe(ctx context.Context, db *kv.DB, pl planner) {
+	p.readProbeImpl(ctx, db, pl)
+}
 
+type dbGetter interface {
+	Get(ctx context.Context, key interface{}) (kv.KeyValue, error)
+}
+
+func (p *Prober) readProbeImpl(ctx context.Context, db dbGetter, pl planner) {
 	if !readEnabled.Get(&p.settings.SV) {
 		return
 	}
 
 	p.metrics.ProbePlanAttempts.Inc(1)
 
-	step, err := p.planner.next(ctx)
+	step, err := pl.next(ctx)
 	if err != nil {
 		log.Health.Errorf(ctx, "can't make a plan: %v", err)
 		p.metrics.ProbePlanFailures.Inc(1)
@@ -198,26 +243,85 @@ func (p *Prober) probe(ctx context.Context, db dbGet) {
 	// Slow enough response times are not different than errors from the
 	// perspective of the user.
 	timeout := readTimeout.Get(&p.settings.SV)
-	err = contextutil.RunWithTimeout(ctx, "db.Get", timeout, func(ctx context.Context) error {
+	err = contextutil.RunWithTimeout(ctx, "read probe", timeout, func(ctx context.Context) error {
 		// We read a "range-local" key dedicated to probing. See pkg/keys for more.
 		// There is no data at the key, but that is okay. Even tho there is no data
 		// at the key, the prober still executes a read operation on the range.
 		// TODO(josh): Trace the probes.
-		_, err = db.Get(ctx, keys.RangeProbeKey(step.StartKey))
+		_, err = db.Get(ctx, step.Key)
 		return err
 	})
 	if err != nil {
 		// TODO(josh): Write structured events with log.Structured.
-		log.Health.Errorf(ctx, "kv.Get(%s), r=%v failed with: %v", step.StartKey, step.RangeID, err)
+		log.Health.Errorf(ctx, "kv.Get(%s), r=%v failed with: %v", step.Key, step.RangeID, err)
 		p.metrics.ReadProbeFailures.Inc(1)
 		return
 	}
 
 	d := timeutil.Since(start)
-	log.Health.Infof(ctx, "kv.Get(%s), r=%v returned success in %v", step.StartKey, step.RangeID, d)
+	log.Health.Infof(ctx, "kv.Get(%s), r=%v returned success in %v", step.Key, step.RangeID, d)
 
 	// Latency of failures is not recorded. They are counted as failures tho.
 	p.metrics.ReadProbeLatency.RecordValue(d.Nanoseconds())
+}
+
+// Doesn't return an error. Instead increments error type specific metrics.
+func (p *Prober) writeProbe(ctx context.Context, db *kv.DB, pl planner) {
+	p.writeProbeImpl(ctx, db, pl)
+}
+
+type dbTxner interface {
+	Txn(ctx context.Context, f func(ctx context.Context, txn *kv.Txn) error) error
+}
+
+func (p *Prober) writeProbeImpl(ctx context.Context, db dbTxner, pl planner) {
+	if !writeEnabled.Get(&p.settings.SV) {
+		return
+	}
+
+	p.metrics.ProbePlanAttempts.Inc(1)
+
+	step, err := pl.next(ctx)
+	if err != nil {
+		log.Health.Errorf(ctx, "can't make a plan: %v", err)
+		p.metrics.ProbePlanFailures.Inc(1)
+		return
+	}
+
+	p.metrics.WriteProbeAttempts.Inc(1)
+
+	start := timeutil.Now()
+
+	// Slow enough response times are not different than errors from the
+	// perspective of the user.
+	timeout := writeTimeout.Get(&p.settings.SV)
+	err = contextutil.RunWithTimeout(ctx, "write probe", timeout, func(ctx context.Context) error {
+		// We attempt to commit a txn that puts some data at the key then
+		// deletes it. The test of the write code paths is good: We get
+		// a raft command that goes thru consensus and is written to the
+		// pebble log. Importantly, no *live* data is left at the key,
+		// which simplifies the kvprober, as then there is no need to clean
+		// up data at the key post range split / merge. Note that MVCC
+		// tombstones may be left by the probe, but this is okay, as GC will
+		// clean it up.
+		return db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+			if err := txn.Put(ctx, step.Key, putValue); err != nil {
+				return err
+			}
+			return txn.Del(ctx, step.Key)
+		})
+	})
+	if err != nil {
+		log.Health.Errorf(ctx, "kv.Txn(Put(%s); Del(-)), r=%v failed with: %v", step.Key, step.RangeID, err)
+		p.metrics.WriteProbeFailures.Inc(1)
+		return
+	}
+
+	d := timeutil.Since(start)
+	log.Health.Infof(ctx, "kv.Txn(Put(%s); Del(-)), r=%v returned success in %v", step.Key, step.RangeID, d)
+
+	// Latency of failures is not recorded. They are counted as failures tho.
+	p.metrics.WriteProbeLatency.RecordValue(d.Nanoseconds())
 }
 
 // Returns a random duration pulled from the uniform distribution given below:

--- a/pkg/kv/kvprober/kvprober_test.go
+++ b/pkg/kv/kvprober/kvprober_test.go
@@ -27,7 +27,7 @@ import (
 // setting up gomock? We use it a lot in CC; it is quite nice; I think it makes
 // for more readable tests than ones that use a custom mock. I see this issue:
 // https://github.com/cockroachdb/cockroach/issues/6933
-func TestProbe(t *testing.T) {
+func TestReadProbe(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("disabled by default", func(t *testing.T) {
@@ -38,7 +38,7 @@ func TestProbe(t *testing.T) {
 		}
 		p := initTestProber(m)
 
-		p.probe(ctx, m)
+		p.readProbeImpl(ctx, m, m)
 
 		require.Zero(t, p.Metrics().ProbePlanAttempts.Count())
 		require.Zero(t, p.Metrics().ReadProbeAttempts.Count())
@@ -51,7 +51,7 @@ func TestProbe(t *testing.T) {
 		p := initTestProber(m)
 		readEnabled.Override(ctx, &p.settings.SV, true)
 
-		p.probe(ctx, m)
+		p.readProbeImpl(ctx, m, m)
 
 		require.Equal(t, int64(1), p.Metrics().ProbePlanAttempts.Count())
 		require.Equal(t, int64(1), p.Metrics().ReadProbeAttempts.Count())
@@ -68,7 +68,7 @@ func TestProbe(t *testing.T) {
 		p := initTestProber(m)
 		readEnabled.Override(ctx, &p.settings.SV, true)
 
-		p.probe(ctx, m)
+		p.readProbeImpl(ctx, m, m)
 
 		require.Equal(t, int64(1), p.Metrics().ProbePlanAttempts.Count())
 		require.Zero(t, p.Metrics().ReadProbeAttempts.Count())
@@ -84,13 +84,80 @@ func TestProbe(t *testing.T) {
 		p := initTestProber(m)
 		readEnabled.Override(ctx, &p.settings.SV, true)
 
-		p.probe(ctx, m)
+		p.readProbeImpl(ctx, m, m)
 
 		require.Equal(t, int64(1), p.Metrics().ProbePlanAttempts.Count())
 		require.Equal(t, int64(1), p.Metrics().ReadProbeAttempts.Count())
 		require.Zero(t, p.Metrics().ProbePlanFailures.Count())
 		require.Equal(t, int64(1), p.Metrics().ReadProbeFailures.Count())
 	})
+}
+
+func TestWriteProbe(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("disabled by default", func(t *testing.T) {
+		m := &mock{
+			t:      t,
+			noPlan: true,
+			noGet:  true,
+		}
+		p := initTestProber(m)
+
+		p.writeProbeImpl(ctx, m, m)
+
+		require.Zero(t, p.Metrics().ProbePlanAttempts.Count())
+		require.Zero(t, p.Metrics().WriteProbeAttempts.Count())
+		require.Zero(t, p.Metrics().ProbePlanFailures.Count())
+		require.Zero(t, p.Metrics().WriteProbeFailures.Count())
+	})
+
+	t.Run("happy path", func(t *testing.T) {
+		m := &mock{t: t}
+		p := initTestProber(m)
+		writeEnabled.Override(ctx, &p.settings.SV, true)
+
+		p.writeProbeImpl(ctx, m, m)
+
+		require.Equal(t, int64(1), p.Metrics().ProbePlanAttempts.Count())
+		require.Equal(t, int64(1), p.Metrics().WriteProbeAttempts.Count())
+		require.Zero(t, p.Metrics().ProbePlanFailures.Count())
+		require.Zero(t, p.Metrics().WriteProbeFailures.Count())
+	})
+
+	t.Run("planning fails", func(t *testing.T) {
+		m := &mock{
+			t:       t,
+			planErr: fmt.Errorf("inject plan failure"),
+			noGet:   true,
+		}
+		p := initTestProber(m)
+		writeEnabled.Override(ctx, &p.settings.SV, true)
+
+		p.writeProbeImpl(ctx, m, m)
+
+		require.Equal(t, int64(1), p.Metrics().ProbePlanAttempts.Count())
+		require.Zero(t, p.Metrics().WriteProbeAttempts.Count())
+		require.Equal(t, int64(1), p.Metrics().ProbePlanFailures.Count())
+		require.Zero(t, p.Metrics().WriteProbeFailures.Count())
+	})
+
+	t.Run("open txn fails", func(t *testing.T) {
+		m := &mock{
+			t:      t,
+			txnErr: fmt.Errorf("inject txn failure"),
+		}
+		p := initTestProber(m)
+		writeEnabled.Override(ctx, &p.settings.SV, true)
+
+		p.writeProbeImpl(ctx, m, m)
+
+		require.Equal(t, int64(1), p.Metrics().ProbePlanAttempts.Count())
+		require.Equal(t, int64(1), p.Metrics().WriteProbeAttempts.Count())
+		require.Zero(t, p.Metrics().ProbePlanFailures.Count())
+		require.Equal(t, int64(1), p.Metrics().WriteProbeFailures.Count())
+	})
+	// TODO(josh): Add cases for put & del failures.
 }
 
 func initTestProber(m *mock) *Prober {
@@ -101,7 +168,7 @@ func initTestProber(m *mock) *Prober {
 		HistogramWindowInterval: time.Minute, // actual value not important to test
 		Settings:                cluster.MakeTestingClusterSettings(),
 	})
-	p.planner = m
+	p.readPlanner = m
 	return p
 }
 
@@ -113,6 +180,7 @@ type mock struct {
 
 	noGet  bool
 	getErr error
+	txnErr error
 }
 
 func (m *mock) next(ctx context.Context) (Step, error) {
@@ -127,6 +195,10 @@ func (m *mock) Get(ctx context.Context, key interface{}) (kv.KeyValue, error) {
 		m.t.Errorf("get call made but not expected")
 	}
 	return kv.KeyValue{}, m.getErr
+}
+
+func (m *mock) Txn(ctx context.Context, f func(ctx context.Context, txn *kv.Txn) error) error {
+	return m.txnErr
 }
 
 func TestWithJitter(t *testing.T) {

--- a/pkg/kv/kvprober/settings.go
+++ b/pkg/kv/kvprober/settings.go
@@ -50,6 +50,37 @@ var readTimeout = settings.RegisterDurationSetting(
 		return nil
 	})
 
+var writeEnabled = settings.RegisterBoolSetting(
+	"kv.prober.write.enabled",
+	"whether the KV write prober is enabled",
+	false)
+
+var writeInterval = settings.RegisterDurationSetting(
+	"kv.prober.write.interval",
+	"how often each node sends a write probe to the KV layer on average (jitter is added); "+
+		"note that a very slow read can block kvprober from sending additional probes; "+
+		"kv.prober.write.timeout controls the max time kvprober can be blocked",
+	10*time.Second, func(duration time.Duration) error {
+		if duration <= 0 {
+			return errors.New("param must be >0")
+		}
+		return nil
+	})
+
+var writeTimeout = settings.RegisterDurationSetting(
+	"kv.prober.write.timeout",
+	// Slow enough response times are not different than errors from the
+	// perspective of the user.
+	"if this much time elapses without success, a KV write probe will be treated as an error; "+
+		"note that a very slow read can block kvprober from sending additional probes"+
+		"this setting controls the max time kvprober can be blocked",
+	4*time.Second, func(duration time.Duration) error {
+		if duration <= 0 {
+			return errors.New("param must be >0")
+		}
+		return nil
+	})
+
 var scanMeta2Timeout = settings.RegisterDurationSetting(
 	"kv.prober.planner.scan_meta2.timeout",
 	"timeout on scanning meta2 via db.Scan with max rows set to "+

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -589,6 +589,8 @@ var charts = []sectionDescription{
 					"kv.prober.planning_failures",
 					"kv.prober.read.attempts",
 					"kv.prober.read.failures",
+					"kv.prober.write.attempts",
+					"kv.prober.write.failures",
 				},
 				AxisLabel: "Probes",
 			},
@@ -596,6 +598,7 @@ var charts = []sectionDescription{
 				Title: "Latency",
 				Metrics: []string{
 					"kv.prober.read.latency",
+					"kv.prober.write.latency",
 				},
 			},
 		},


### PR DESCRIPTION
Design discussed in detail at https://github.com/cockroachdb/cockroach/issues/67112.

**kvprober: extend kvprober to test KV's write codepaths**

Before this commit, kvprober did point reads of range-local keys dedicated to
probing. kvprober did not exercise KV's write codepaths.

With this commit, kvprober exercises KV's write codepaths. kvprober has two
probe loops, one that does point reads & another that commits a txn that puts
and deletes a key, leaving no live data but exercising the write codepaths.

Release justification: Improvement to observability used only by CC SREs.

Release note: None.

