### PR TITLE
bazel: swap order of interfaces in generated mocks in `pkg/roachpb`

### DIFF
--- a/pkg/roachpb/BUILD.bazel
+++ b/pkg/roachpb/BUILD.bazel
@@ -111,8 +111,8 @@ gomock(
     name = "mock_roachpb",
     out = "mocks_generated.go",
     interfaces = [
-        "Internal_RangeFeedClient",
         "InternalClient",
+        "Internal_RangeFeedClient",
     ],
     library = ":roachpb",
     package = "roachpb",


### PR DESCRIPTION
This makes the order match up to what we have in the checked-in
generated code, quashing a diff when you
`dev build --hoist-generated-code`.

Release note: None