### PR TITLE
sql: more aggressive releasing of memory while collecting histograms

### DIFF
--- a/pkg/sql/stats/row_sampling.go
+++ b/pkg/sql/stats/row_sampling.go
@@ -14,7 +14,6 @@ import (
 	"container/heap"
 	"context"
 
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/memsize"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -265,8 +264,7 @@ func (sr *SampleReservoir) copyRow(
 			dst[i].Datum = truncateDatum(evalCtx, dst[i].Datum, maxBytesPerSample)
 			afterSize = dst[i].Size()
 		} else {
-			if enc, ok := src[i].Encoding(); ok && enc != descpb.DatumEncoding_VALUE {
-				// Only datums that were key-encoded might reference the kv batch.
+			if _, ok := src[i].Encoding(); ok {
 				dst[i].Datum = deepCopyDatum(evalCtx, dst[i].Datum)
 			}
 		}


### PR DESCRIPTION
We added a deep copy in some cases when sampling rows to avoid hanging
onto a KV batch. This fixed some large OOMs during table statistics
collection. But when we don't deep copy, we are hanging onto DatumAlloc
arrays, which could be the cause of some small OOMs. So let's always
deep copy when sampling rows.

Release note (performance improvement): reduce memory usage slightly
during ANALYZE or CREATE STATISTICS statements.