### PR TITLE
tree: tag RESET statements as RESET

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -583,10 +583,10 @@ ORDER BY key, f
 ----
 CREATE SEQUENCE s                                                     0  false
 DROP SEQUENCE s                                                       0  false
+RESET application_name                                                0  false
 SELECT IF(nextval(_) < _, crdb_internal.force_retry(_), _)            2  false
 SELECT IF(nextval(_) < _, crdb_internal.force_retry(_), _)            1  true
 SELECT IF(nextval(_) < _, crdb_internal.force_retry(_::INTERVAL), _)  0  true
-SET application_name = DEFAULT                                        0  false
 
 query T
 SELECT database_name FROM crdb_internal.node_statement_statistics limit 1

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal_tenant
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal_tenant
@@ -485,10 +485,10 @@ ORDER BY key, f
 ----
 CREATE SEQUENCE s                                                     0  false
 DROP SEQUENCE s                                                       0  false
+RESET application_name                                                0  false
 SELECT IF(nextval(_) < _, crdb_internal.force_retry(_), _)            2  false
 SELECT IF(nextval(_) < _, crdb_internal.force_retry(_), _)            1  true
 SELECT IF(nextval(_) < _, crdb_internal.force_retry(_::INTERVAL), _)  0  true
-SET application_name = DEFAULT                                        0  false
 
 query T
 SELECT crdb_internal.cluster_name()

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -4381,11 +4381,11 @@ reset_stmt:
 reset_session_stmt:
   RESET session_var
   {
-    $$.val = &tree.SetVar{Name: $2, Values:tree.Exprs{tree.DefaultVal{}}}
+    $$.val = &tree.SetVar{Name: $2, Values:tree.Exprs{tree.DefaultVal{}}, Reset: true}
   }
 | RESET SESSION session_var
   {
-    $$.val = &tree.SetVar{Name: $3, Values:tree.Exprs{tree.DefaultVal{}}}
+    $$.val = &tree.SetVar{Name: $3, Values:tree.Exprs{tree.DefaultVal{}}, Reset: true}
   }
 | RESET error // SHOW HELP: RESET
 

--- a/pkg/sql/parser/testdata/set
+++ b/pkg/sql/parser/testdata/set
@@ -471,10 +471,10 @@ SET client_encoding = DEFAULT -- identifiers removed
 parse
 RESET a
 ----
-SET a = DEFAULT -- normalized!
-SET a = (DEFAULT) -- fully parenthesized
-SET a = DEFAULT -- literals removed
-SET a = DEFAULT -- identifiers removed
+RESET a
+RESET a -- fully parenthesized
+RESET a -- literals removed
+RESET a -- identifiers removed
 
 parse
 RESET CLUSTER SETTING a
@@ -487,7 +487,7 @@ SET CLUSTER SETTING a = DEFAULT -- identifiers removed
 parse
 RESET NAMES
 ----
-SET client_encoding = DEFAULT -- normalized!
-SET client_encoding = (DEFAULT) -- fully parenthesized
-SET client_encoding = DEFAULT -- literals removed
-SET client_encoding = DEFAULT -- identifiers removed
+RESET client_encoding -- normalized!
+RESET client_encoding -- fully parenthesized
+RESET client_encoding -- literals removed
+RESET client_encoding -- identifiers removed

--- a/pkg/sql/pgwire/testdata/pgtest/set
+++ b/pkg/sql/pgwire/testdata/pgtest/set
@@ -1,0 +1,10 @@
+send
+Query {"String": "RESET intervalstyle"}
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParameterStatus","Name":"IntervalStyle","Value":"postgres"}
+{"Type":"CommandComplete","CommandTag":"RESET"}
+{"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/sql/sem/tree/set.go
+++ b/pkg/sql/sem/tree/set.go
@@ -23,6 +23,7 @@ package tree
 type SetVar struct {
 	Name     string
 	Values   Exprs
+	Reset    bool
 	ResetAll bool
 }
 
@@ -30,6 +31,15 @@ type SetVar struct {
 func (node *SetVar) Format(ctx *FmtCtx) {
 	if node.ResetAll {
 		ctx.WriteString("RESET ALL")
+		return
+	}
+	if node.Reset {
+		ctx.WriteString("RESET ")
+		ctx.WithFlags(ctx.flags & ^FmtAnonymize & ^FmtMarkRedactionNode, func() {
+			// Session var names never contain PII and should be distinguished
+			// for feature tracking purposes.
+			ctx.FormatNameP(&node.Name)
+		})
 		return
 	}
 	ctx.WriteString("SET ")

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -1059,7 +1059,12 @@ func (*SetVar) StatementReturnType() StatementReturnType { return Ack }
 func (*SetVar) StatementType() StatementType { return TypeDCL }
 
 // StatementTag returns a short string identifying the type of statement.
-func (*SetVar) StatementTag() string { return "SET" }
+func (n *SetVar) StatementTag() string {
+	if n.Reset || n.ResetAll {
+		return "RESET"
+	}
+	return "SET"
+}
 
 // StatementReturnType implements the Statement interface.
 func (*SetClusterSetting) StatementReturnType() StatementReturnType { return Ack }


### PR DESCRIPTION
Release note (sql change): We now correctly send the RESET tag instead
of the SET tag when a RESET statement is run.