### PR TITLE
bazci: default to `ci` config if none specified

### DIFF
--- a/pkg/cmd/bazci/bazci.go
+++ b/pkg/cmd/bazci/bazci.go
@@ -61,7 +61,7 @@ func init() {
 	rootCmd.Flags().StringSliceVar(
 		&configs,
 		"config",
-		[]string{},
+		[]string{"ci"},
 		"list of build configs to apply to bazel calls")
 }
 


### PR DESCRIPTION
I struggled a bit today because I forgot to pass this flag. It's a
sensible default though, so we might as well set it appropriately.

Release note: None