### PR TITLE
logic_test/as_of: deflake test

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/as_of
+++ b/pkg/ccl/logictestccl/testdata/logic_test/as_of
@@ -1,7 +1,14 @@
 # LogicTest: local
 
 statement ok
-CREATE TABLE t (i INT PRIMARY KEY, j INT UNIQUE, k INT, UNIQUE (k) STORING (j))
+CREATE TABLE t (
+  i INT PRIMARY KEY,
+  j INT UNIQUE,
+  k INT,
+  UNIQUE (k) STORING (j),
+  -- this is in a single family as multi-family fetches are not yet supported.
+  FAMILY (i, j, k)
+)
 
 statement ok
 INSERT INTO t VALUES (2)


### PR DESCRIPTION
Logic tests randomize column families, and in the case of bounded
staleness results in multi-batch fetches in the execution layer calling
NegotiateAndSend, which means they could get different bounded staleness
results. To alleviate the flaky tests for now, we set the same family
for the given table.

Release note: None