### PR TITLE
kvserver: fix buglet around error injection

### DIFF
--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -201,7 +201,7 @@ func (r *Replica) evalAndPropose(
 			CmdID: idKey,
 			Req:   *ba,
 		}
-		if pErr := filter(filterArgs); pErr != nil {
+		if pErr = filter(filterArgs); pErr != nil {
 			return nil, nil, 0, pErr
 		}
 	}


### PR DESCRIPTION
When TestingProposalFilter returned an error, the defer above it looking
to release quota was not firing because the error was not assigned
properly.

Release note: None