### PR TITLE
sql/colexec: skip TestExternalHashAggregatorReusesBuckets

### DIFF
--- a/pkg/sql/colexec/external_hash_aggregator_buckets_test.go
+++ b/pkg/sql/colexec/external_hash_aggregator_buckets_test.go
@@ -34,6 +34,7 @@ import (
 // serverutils package (which would create import cycle with colexec).
 func TestExternalHashAggregatorReusesBuckets(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 69074, "flaky test")
 	defer log.Scope(t).Close(t)
 	skip.UnderStress(t, "takes too long")
 	skip.UnderRace(t, "takes too long")


### PR DESCRIPTION
Refs: #69074

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None