### PR TITLE
.github: update CODEOWNERs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -135,7 +135,7 @@
 /pkg/ccl/telemetryccl/       @cockroachdb/obs-inf-prs
 /pkg/ccl/testccl/sqlccl/     @cockroachdb/sql-queries
 /pkg/ccl/testccl/workload/schemachange/ @cockroachdb/sql-schema
-/pkg/ccl/testutilsccl/       @cockroachdb/test-eng
+/pkg/ccl/testutilsccl/       @cockroachdb/test-eng-noreview
 /pkg/ccl/utilccl/            @cockroachdb/server-prs
 /pkg/ccl/workloadccl/        @cockroachdb/sql-experience
 /pkg/ccl/benchccl/rttanalysisccl/     @cockroachdb/sql-experience
@@ -173,6 +173,12 @@
 /pkg/cmd/roachprod/          @cockroachdb/dev-inf
 /pkg/cmd/roachprod-stress/   @cockroachdb/test-eng
 /pkg/cmd/roachtest/          @cockroachdb/test-eng
+# This isn't quite right, each file should ideally be owned
+# by a team (or at least most of them), namely the team that
+# is the Owner for the roachtest, but until we unify these
+# two concepts of ownership we don't want to ping test-eng
+# on each test change.
+/pkg/cmd/roachtest/tests     @cockroachdb/test-eng-noreview
 /pkg/cmd/roachvet/           @cockroachdb/dev-inf
 /pkg/cmd/skip-test/          @cockroachdb/test-eng
 /pkg/cmd/skiperrs/           @cockroachdb/sql-experience
@@ -201,6 +207,8 @@
 /pkg/internal/team/          @cockroachdb/test-eng
 /pkg/jobs/                   @cockroachdb/sql-schema
 /pkg/keys/                   @cockroachdb/kv-prs
+# Don't ping KV on updates to reserved descriptor IDs and such.
+/pkg/keys/constants.go       @cockroachdb/kv-prs-noreview
 /pkg/migration/              @cockroachdb/kv-prs @cockroachdb/sql-schema
 /pkg/multitenant             @cockroachdb/unowned
 /pkg/release/                @cockroachdb/dev-inf
@@ -211,7 +219,9 @@
 /pkg/settings/               @cockroachdb/server-prs
 /pkg/startupmigrations/      @cockroachdb/server-prs @cockroachdb/sql-schema
 /pkg/streaming/              @cockroachdb/bulk-prs
-/pkg/testutils/              @cockroachdb/test-eng
+/pkg/testutils/              @cockroachdb/test-eng-noreview
+/pkg/testutils/reduce/       @cockroachdb/sql-queries
+/pkg/testutils/sqlutils/     @cockroachdb/sql-queries
 /pkg/ts/                     @cockroachdb/kv-prs
 /pkg/ts/catalog/             @cockroachdb/obs-inf-prs
 /pkg/util/                   @cockroachdb/unowned
@@ -220,3 +230,14 @@
 /pkg/util/stop               @cockroachdb/server-prs
 /pkg/util/tracing            @cockroachdb/obs-inf-prs
 /pkg/workload/               @cockroachdb/sql-experience
+
+# Own all bazel files to dev-inf, but don't request reviews for them
+# as they are mostly - but not only - generated code that changes with
+# changes to the Go code in the package.
+**/BUILD.bazel               @cockroachdb/dev-inf-noreview
+# Avoid mass pings when updating proto tooling.
+# For some reason, **/*.pb.go does not work (in the
+# sense that ./pkg/cmd/whoownsit will not match this
+# pattern to any files).
+**.pb.go                     @cockroachdb/unowned
+**.pb.gw.go                  @cockroachdb/unowned


### PR DESCRIPTION
I went through "recent commits" via

```

files=()
for f in $(git log -n 100 --pretty="format:" --name-only); do
    if [ -e "${f}" ]; then files+=("${f}"); fi
done
go run ./pkg/cmd/whoownsit ${files[@]} > out.txt
```

and looked at the files owned by @cockroachdb/kv and
@cockroachdb/test-eng in order to motivate some tweaks to the rules.

This should hopefully make the notifications more relevant.

Release note: None
