### PR TITLE
storage: don't report resume timestamps when unnecessary

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -6797,7 +6797,7 @@ func TestPaginatedBackupTenant(t *testing.T) {
 
 	// Single ExportRequest with no resume span.
 	systemDB.Exec(t, `SET CLUSTER SETTING kv.bulk_sst.target_size='10b'`)
-	systemDB.Exec(t, `SET CLUSTER SETTING kv.bulk_sst.max_allowed_overage='0b'`)
+	systemDB.Exec(t, `SET CLUSTER SETTING kv.bulk_sst.max_allowed_overage='10b'`)
 
 	// Allow mid key breaks for the tennant to verify timestamps on resume.
 	tenant10.Exec(t, `SET CLUSTER SETTING bulkio.backup.split_keys_on_timestamps = true`)
@@ -6807,12 +6807,12 @@ func TestPaginatedBackupTenant(t *testing.T) {
 	for _, resume := range []exportResumePoint{
 		{[]byte("/Tenant/10/Table/3"), []byte("/Tenant/10/Table/4"), withoutTS},
 		{[]byte("/Tenant/10/Table/57/1"), []byte("/Tenant/10/Table/57/2"), withoutTS},
-		{[]byte("/Tenant/10/Table/57/1/210/0"), []byte("/Tenant/10/Table/57/2"), withTS},
+		{[]byte("/Tenant/10/Table/57/1/210/0"), []byte("/Tenant/10/Table/57/2"), withoutTS},
 		// We have two entries for 210 because of history and super small table size
 		{[]byte("/Tenant/10/Table/57/1/210/0"), []byte("/Tenant/10/Table/57/2"), withTS},
-		{[]byte("/Tenant/10/Table/57/1/310/0"), []byte("/Tenant/10/Table/57/2"), withTS},
-		{[]byte("/Tenant/10/Table/57/1/410/0"), []byte("/Tenant/10/Table/57/2"), withTS},
-		{[]byte("/Tenant/10/Table/57/1/510/0"), []byte("/Tenant/10/Table/57/2"), withTS},
+		{[]byte("/Tenant/10/Table/57/1/310/0"), []byte("/Tenant/10/Table/57/2"), withoutTS},
+		{[]byte("/Tenant/10/Table/57/1/410/0"), []byte("/Tenant/10/Table/57/2"), withoutTS},
+		{[]byte("/Tenant/10/Table/57/1/510/0"), []byte("/Tenant/10/Table/57/2"), withoutTS},
 	} {
 		expected = append(expected, requestSpanStr(roachpb.Span{resume.key, resume.endKey}, resume.timestamp))
 	}

--- a/pkg/storage/pebble_test.go
+++ b/pkg/storage/pebble_test.go
@@ -662,3 +662,75 @@ func TestSstExportFailureIntentBatching(t *testing.T) {
 	}
 	t.Run("Receive no more than limit intents", checkReportedErrors(testData, expectedErrors[:MaxIntentsPerWriteIntentError.Default()]))
 }
+
+// TestExportSplitMidKey verifies that split mid key in exports will omit
+// resume timestamps where they are unnecessary e.g. when we split at the
+// new key. In this case we can safely use the SST as is without the need
+// to merge with the remaining versions of the key.
+func TestExportSplitMidKey(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+
+	engine := createTestPebbleEngine()
+	defer engine.Close()
+
+	const keyValueSize = 11
+
+	var testData = []testValue{
+		value(key(1), "value1", ts(1000)),
+		value(key(2), "value2", ts(1000)),
+		value(key(2), "value3", ts(2000)),
+		value(key(3), "value4", ts(2000)),
+	}
+	require.NoError(t, fillInData(ctx, engine, testData))
+
+	for _, test := range []struct {
+		exportAll    bool
+		useTBI       bool
+		stopMidKey   bool
+		useMaxSize   bool
+		resumeCount  int
+		resumeWithTs int
+	}{
+		{false, true, false, false, 3, 0},
+		{true, true, false, false, 3, 0},
+		{false, true, true, false, 3, 0},
+		// No resume timestamps since we fall under max size criteria
+		{true, true, true, false, 3, 0},
+		{true, true, true, true, 4, 1},
+		{false, false, false, false, 3, 0},
+		{true, false, false, false, 3, 0},
+		{false, false, true, false, 3, 0},
+		// No resume timestamps since we fall under max size criteria
+		{true, false, true, false, 3, 0},
+		{true, false, true, true, 4, 1},
+	} {
+		t.Run(
+			fmt.Sprintf(
+				"exportAll=%t,useTBI=%t,stopMidKey=%t,useMaxSize=%t",
+				test.exportAll, test.useTBI, test.stopMidKey, test.useMaxSize),
+			func(t *testing.T) {
+				firstKeyTS := hlc.Timestamp{}
+				resumeKey := key(1)
+				resumeWithTs := 0
+				resumeCount := 0
+				var maxSize uint64 = 0
+				if test.useMaxSize {
+					maxSize = keyValueSize * 2
+				}
+				for !resumeKey.Equal(roachpb.Key{}) {
+					dest := &MemFile{}
+					_, resumeKey, firstKeyTS, _ = engine.ExportMVCCToSst(
+						ctx, resumeKey, key(3).Next(), hlc.Timestamp{}, hlc.Timestamp{WallTime: 9999},
+						firstKeyTS, test.exportAll, 1, maxSize, test.stopMidKey, test.useTBI, dest)
+					if !firstKeyTS.IsEmpty() {
+						resumeWithTs++
+					}
+					resumeCount++
+				}
+				require.Equal(t, test.resumeCount, resumeCount)
+				require.Equal(t, test.resumeWithTs, resumeWithTs)
+			})
+	}
+}


### PR DESCRIPTION
Storage export request always returned timestamp in resume span when
when stop mid key is requested. If export stops on the key boundary
this is unnecessary and also prevents caller from processing partial
result as it can not determine if all versions of the key were
returned. This is particularly bad if we have ranges with only a
single version for most keys.
This patch changes this behaviour to omit timestamp if export stopped
on the new key.

Release note: None