### PR TITLE
jobs: always retry non-cancelable reverting jobs

### DIFF
--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -1155,6 +1155,20 @@ func (r retryJobError) Error() string {
 	return string(r)
 }
 
+// Registry does not retry a job that fails due to a permanent error.
+var errJobPermanentSentinel = errors.New("permanent job-error")
+
+// MarkAsPermanentJobError marks an error as a permanent job error, which indicates
+// Registry to not retry the job when it fails due to this error.
+func MarkAsPermanentJobError(err error) error {
+	return errors.Mark(err, errJobPermanentSentinel)
+}
+
+// IsPermanentJobError checks whether the given error is a permanent error.
+func IsPermanentJobError(err error) bool {
+	return errors.Is(err, errJobPermanentSentinel)
+}
+
 // stepThroughStateMachine implements the state machine of the job lifecycle.
 // The job is executed with the ctx, so ctx must only be canceled if the job
 // should also be canceled. resultsCh is passed to the resumable func and should
@@ -1275,6 +1289,11 @@ func (r *Registry) stepThroughStateMachine(
 		if errors.Is(err, retryJobErrorSentinel) {
 			jm.FailOrCancelRetryError.Inc(1)
 			return errors.Errorf("job %d: %s: restarting in background", job.ID(), err)
+		}
+		// A non-cancelable job is always retried while reverting unless the error is marked as permanent.
+		if job.Payload().Noncancelable && !IsPermanentJobError(err) {
+			jm.FailOrCancelRetryError.Inc(1)
+			return errors.Wrapf(err, "job %d: job is non-cancelable, restarting in background", job.ID())
 		}
 		jm.FailOrCancelFailed.Inc(1)
 		if sErr := (*InvalidStatusError)(nil); errors.As(err, &sErr) {

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -740,7 +740,8 @@ func (sc *SchemaChanger) handlePermanentSchemaChangeError(
 		// than tables. For jobs intended to drop other types of descriptors, we do
 		// nothing.
 		if _, ok := desc.(catalog.TableDescriptor); !ok {
-			return errors.Newf("schema change jobs on databases and schemas cannot be reverted")
+			// Mark the error as permanent so that is not retried in reverting state.
+			return jobs.MarkAsPermanentJobError(errors.Newf("schema change jobs on databases and schemas cannot be reverted"))
 		}
 
 		// Check that we aren't queued behind another schema changer.
@@ -2263,7 +2264,8 @@ func (r schemaChangeResumer) OnFailOrCancel(ctx context.Context, execCtx interfa
 	// unset. We cannot revert such schema changes, so just exit early with an
 	// error.
 	if details.DescID == descpb.InvalidID {
-		return errors.Newf("schema change jobs on databases and schemas cannot be reverted")
+		// Mark the error as permanent so that is not retried in reverting state.
+		return jobs.MarkAsPermanentJobError(errors.Newf("schema change jobs on databases and schemas cannot be reverted"))
 	}
 	sc := SchemaChanger{
 		descID:               details.DescID,


### PR DESCRIPTION
In the previous implementation, non-cancelable jobs can be failed
due to a non-retryable error, finishing in revert-failed state.
However, some non-cancelable jobs should be retried if they fail
while reverting. This commit makes a non-cancelable job to always
retry in reverting state unless its error is marked as permanent.

Release justification: This commit makes non-cancelable jobs retry
when they are reverting. Non-cancelable jobs, such as schema-change
jobs, perform cleanup when reverting and should not fail. Instead,
such jobs should be retried if they fail due to transient errors.
As the functionality to retry jobs with exponential-backoff is
already merged, this commit adds a small change that makes a good
use of existing functionality. Therefore, it should be included
in this release.

Release note (general change): Previously, non-cancelable jobs,
such as schema-change jobs, can fail while reverting due to
transient errors, which leads to unexpected results. This commit adds
a mechanism to retry non-cancelable reverting jobs instead of failing
when transient errors are encountered. As a result, this change
mitigates the impact of temporary failures on non-cancelable reverting
jobs.