### PR TITLE
kvclient: when retrying transaction bump ts to now

### DIFF
--- a/pkg/kv/kvclient/kvcoord/BUILD.bazel
+++ b/pkg/kv/kvclient/kvcoord/BUILD.bazel
@@ -148,6 +148,7 @@ go_test(
         "//pkg/kv/kvbase",
         "//pkg/kv/kvclient/rangecache:with-mocks",
         "//pkg/kv/kvserver",
+        "//pkg/kv/kvserver/closedts",
         "//pkg/kv/kvserver/concurrency/lock",
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/kv/kvserver/tscache",

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -1457,9 +1457,28 @@ func PrepareTransactionForRetry(
 		txn.WriteTimestamp.Forward(tErr.PusheeTxn.WriteTimestamp)
 		txn.UpgradePriority(tErr.PusheeTxn.Priority - 1)
 	case *TransactionRetryError:
-		// Nothing to do. Transaction.Timestamp has already been forwarded to be
-		// ahead of any timestamp cache entries or newer versions which caused
-		// the restart.
+		// Transaction.Timestamp has already been forwarded to be ahead of any
+		// timestamp cache entries or newer versions which caused the restart.
+		if tErr.Reason == RETRY_SERIALIZABLE {
+			// For RETRY_SERIALIZABLE case, we want to bump timestamp further than
+			// timestamp cache.
+			// This helps transactions that had their commit timestamp fixed (See
+			// roachpb.Transaction.CommitTimestampFixed for details on when it happens)
+			// or transactions that hit read-write contention and can't bump
+			// read timestamp because of later writes.
+			// Upon retry, we want those transactions to restart on now() instead of
+			// closed ts to give them some time to complete without a need to refresh
+			// read spans yet again and possibly fail.
+			// The tradeoff here is that transactions that failed because they were
+			// waiting on locks or were slowed down in their first epoch for any other
+			// reason (e.g. lease transfers, network congestion, node failure, etc.)
+			// would have a chance to retry and succeed, but transactions that are
+			// just slow would still retry indefinitely and delay transactions that
+			// try to write to the keys this transaction reads because reads are not
+			// in the past anymore.
+			now := clock.Now()
+			txn.WriteTimestamp.Forward(now)
+		}
 	case *WriteTooOldError:
 		// Increase the timestamp to the ts at which we've actually written.
 		txn.WriteTimestamp.Forward(writeTooOldRetryTimestamp(tErr))

--- a/pkg/sql/tests/monotonic_insert_test.go
+++ b/pkg/sql/tests/monotonic_insert_test.go
@@ -77,7 +77,6 @@ type mtClient struct {
 //   https://github.com/jepsen-io/jepsen/blob/master/cockroachdb/src/jepsen/cockroach/monotonic.clj
 func TestMonotonicInserts(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.WithIssue(t, 67802, "flaky test")
 
 	for _, distSQLMode := range []sessiondatapb.DistSQLExecMode{
 		sessiondatapb.DistSQLOff, sessiondatapb.DistSQLOn,


### PR DESCRIPTION
Previously, when transaction failed with retryable error its timestamp
was bumped by whatever event caused it like a push.
If transaction timestamp becomes fixed to closed timestamp because
transaction takes more than 3 sec to complete it enters infinite retry
loop. Refresh is now impossible and transaction restarts with the same
failure after performing its actions. This behaviour is more visible
as we are updating closed timestamp more eagerly.
To prevent such outcome, this patch changes restart timestamp to now.

Release note: None

Fixes #67802