### PR TITLE
util/log: fix log buffer pooling

### DIFF
--- a/pkg/util/log/clog_test.go
+++ b/pkg/util/log/clog_test.go
@@ -607,6 +607,25 @@ func BenchmarkVDepthWithVModule(b *testing.B) {
 	})
 }
 
+func BenchmarkOutputLogEntry(b *testing.B) {
+	b.ReportAllocs()
+
+	entry := makeEntry(context.Background(), severity.INFO, logpb.Channel_DEV, 1)
+
+	var infos []*sinkInfo
+	for _, ptr := range debugLog.sinkInfos {
+		cpy := *ptr
+		cpy.sink = &mockSink{}
+		cpy.formatter = &mockLogFormatter{}
+		infos = append(infos, &cpy)
+	}
+	l := loggerT{sinkInfos: infos}
+
+	for i := 0; i < b.N; i++ {
+		l.outputLogEntry(entry)
+	}
+}
+
 // TestLogEntryPropagation ensures that a log entry is written
 // to file even when stderr is not available.
 func TestLogEntryPropagation(t *testing.T) {

--- a/pkg/util/log/log_buffer.go
+++ b/pkg/util/log/log_buffer.go
@@ -31,38 +31,6 @@ func getBuffer() *buffer {
 	return b
 }
 
-const stdNumSinksPerChannel = 5
-
-type bufferSlice struct {
-	b        []*buffer
-	prealloc [stdNumSinksPerChannel]*buffer
-}
-
-// getBufferSlice returns a new ready-to-use slice of buffers.
-func getBufferSlice(numBuffers int) *bufferSlice {
-	bs := logging.bufSlicePool.Get().(*bufferSlice)
-	if numBuffers > stdNumSinksPerChannel {
-		bs.b = make([]*buffer, numBuffers)
-	} else {
-		bs.b = bs.prealloc[:numBuffers]
-	}
-	return bs
-}
-
-// newBufferSlice is the constructor for the sync.Pool.
-func newBufferSlice() interface{} { return &bufferSlice{} }
-
-// putSlice returns a buffer slice to the free list.
-// It also releases the buffers if there are any remaining.
-func putBufferSlice(bs *bufferSlice) {
-	for i := range bs.b {
-		putBuffer(bs.b[i])
-		bs.b[i] = nil
-	}
-	bs.b = nil
-	logging.bufSlicePool.Put(bs)
-}
-
 // putBuffer returns a buffer to the free list.
 func putBuffer(b *buffer) {
 	if b == nil {

--- a/pkg/util/log/mocks_test.go
+++ b/pkg/util/log/mocks_test.go
@@ -1,0 +1,47 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package log
+
+import "github.com/cockroachdb/cockroach/pkg/cli/exit"
+
+type mockSink struct{}
+
+var _ logSink = (*mockSink)(nil)
+
+func (*mockSink) active() bool {
+	return true
+}
+func (*mockSink) attachHints(b []byte) []byte {
+	return b
+}
+func (*mockSink) output(extraSync bool, b []byte) error {
+	return nil
+}
+func (*mockSink) exitCode() exit.Code {
+	return exit.Success()
+}
+func (*mockSink) emergencyOutput([]byte) {}
+
+type mockLogFormatter struct{}
+
+var _ logFormatter = (*mockLogFormatter)(nil)
+
+func (*mockLogFormatter) formatterName() string {
+	return "mock"
+}
+func (*mockLogFormatter) doc() string {
+	return "mock"
+}
+func (*mockLogFormatter) formatEntry(entry logEntry) *buffer {
+	buf := getBuffer()
+	buf.WriteString(entry.payload.message)
+	return buf
+}


### PR DESCRIPTION
Previously, outputLogEntry took a buffer from the pool for each sink,
and the formatter for each sink also took a buffer from the pool.  We
replaced the original pointer with the one from the formatter, leaking
it to be garbage collected and returning the formatter's buffer to the
pool. So we were taking out twice as many buffers as we put back in,
undermining efforts to reuse them and forcing the pool to allocate new
buffers frequently.

Release note: None