### PR TITLE
bazel: tweak arguments to `bindata` from bazel

### DIFF
--- a/pkg/cmd/roachprod/vm/aws/BUILD.bazel
+++ b/pkg/cmd/roachprod/vm/aws/BUILD.bazel
@@ -40,6 +40,12 @@ bindata(
         "config.json",
         "old.json",
     ],
-    extra_args = ["."],
+    extra_args = [
+        "-mode",
+        "0600",
+        "-modtime",
+        "1400000000",
+    ],
+    metadata = True,
     package = "aws",
 )

--- a/pkg/security/securitytest/BUILD.bazel
+++ b/pkg/security/securitytest/BUILD.bazel
@@ -25,6 +25,12 @@ bindata(
             "test_certs/regenerate.sh",
         ],
     ),
-    extra_args = ["."],
+    extra_args = [
+        "-mode",
+        "0600",
+        "-modtime",
+        "1400000000",
+    ],
+    metadata = True,
     package = "securitytest",
 )


### PR DESCRIPTION
This gets rid of a few diffs -- the files that we have checked-in to
tree contain metadata we probably don't want to lose (file size/mode).

Closes #68994.

Release note: None