### PR TITLE
sql: make TestFailureToMarkCanceledReversalLeadsToCanceledStatus faster

### DIFF
--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -6671,7 +6671,16 @@ func TestFailureToMarkCanceledReversalLeadsToCanceledStatus(t *testing.T) {
 		defer jobCancellationsToFail.Unlock()
 		f(jobCancellationsToFail.jobs)
 	}
-	jobInterval := 100 * time.Millisecond
+	jobKnobs := jobs.NewTestingKnobsWithShortIntervals()
+	jobKnobs.BeforeUpdate = func(orig, updated jobs.JobMetadata) (err error) {
+		withJobsToFail(func(m map[jobspb.JobID]struct{}) {
+			if _, ok := m[orig.ID]; ok && updated.Status == jobs.StatusCanceled {
+				delete(m, orig.ID)
+				err = errors.Errorf("boom")
+			}
+		})
+		return err
+	}
 	params.Knobs = base.TestingKnobs{
 		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
 			RunBeforeBackfill: func() error {
@@ -6679,22 +6688,7 @@ func TestFailureToMarkCanceledReversalLeadsToCanceledStatus(t *testing.T) {
 				return nil
 			},
 		},
-		JobsTestingKnobs: &jobs.TestingKnobs{
-			BeforeUpdate: func(orig, updated jobs.JobMetadata) (err error) {
-				withJobsToFail(func(m map[jobspb.JobID]struct{}) {
-					if _, ok := m[orig.ID]; ok && updated.Status == jobs.StatusCanceled {
-						delete(m, orig.ID)
-						err = errors.Errorf("boom")
-					}
-				})
-				return err
-			},
-			// Decrease the adopt loop interval so that retries happen quickly.
-			IntervalOverrides: jobs.TestingIntervalOverrides{
-				Adopt:  &jobInterval,
-				Cancel: &jobInterval,
-			},
-		},
+		JobsTestingKnobs: jobKnobs,
 	}
 
 	s, sqlDB, _ := serverutils.StartServer(t, params)


### PR DESCRIPTION
This test was made slow by #66889.

Release note: None