### PR TITLE
sql/pgwire: Use InvalidAuthorizationSpecification code on failed auth

### DIFF
--- a/pkg/sql/pgwire/conn_test.go
+++ b/pkg/sql/pgwire/conn_test.go
@@ -1723,7 +1723,5 @@ func TestRoleDefaultSettings(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedSearchPath, actual)
 		})
-
 	}
-
 }

--- a/pkg/sql/pgwire/testdata/auth/conn_log
+++ b/pkg/sql/pgwire/testdata/auth/conn_log
@@ -69,7 +69,7 @@ authlog 6
 
 connect user=root password=badpass sslmode=require sslcert= sslkey=
 ----
-ERROR: password authentication failed for user root
+ERROR: password authentication failed for user root (SQLSTATE 28000)
 
 authlog 6
 .*client_connection_end
@@ -119,7 +119,7 @@ authlog 6
 
 connect user=userpw password=badpass
 ----
-ERROR: password authentication failed for user userpw
+ERROR: password authentication failed for user userpw (SQLSTATE 28000)
 
 authlog 6
 .*client_connection_end
@@ -137,7 +137,7 @@ subtest conn_tls/no_password
 
 connect user=usernopw
 ----
-ERROR: password authentication failed for user usernopw
+ERROR: password authentication failed for user usernopw (SQLSTATE 28000)
 
 authlog 7
 .*client_connection_end
@@ -175,7 +175,7 @@ authlog 5
 
 connect_unix user=root password=badpass
 ----
-ERROR: password authentication failed for user root
+ERROR: password authentication failed for user root (SQLSTATE 28000)
 
 authlog 5
 .*client_connection_end
@@ -193,7 +193,7 @@ subtest conn_unix/trusted_user
 
 connect_unix user=trusted
 ----
-ERROR: authentication rejected by configuration
+ERROR: authentication rejected by configuration (SQLSTATE 28000)
 
 authlog 5
 .*client_connection_end
@@ -223,7 +223,7 @@ authlog 5
 
 connect_unix user=userpw password=badpass
 ----
-ERROR: password authentication failed for user userpw
+ERROR: password authentication failed for user userpw (SQLSTATE 28000)
 
 authlog 5
 .*client_connection_end
@@ -240,7 +240,7 @@ subtest conn_unix/nologin_expired_password
 
 connect_unix user=usernologin password=123
 ----
-ERROR: usernologin does not have login privilege
+ERROR: usernologin does not have login privilege (SQLSTATE 28000)
 
 authlog 4
 .*client_connection_end
@@ -253,7 +253,7 @@ authlog 4
 
 connect_unix user=userexpired password=123
 ----
-ERROR: password is expired
+ERROR: password is expired (SQLSTATE 28000)
 
 authlog 6
 .*client_connection_end

--- a/pkg/sql/pgwire/testdata/auth/empty_hba
+++ b/pkg/sql/pgwire/testdata/auth/empty_hba
@@ -42,13 +42,13 @@ ok defaultdb
 # because it does not have a password.
 connect_unix user=root
 ----
-ERROR: password authentication failed for user root
+ERROR: password authentication failed for user root (SQLSTATE 28000)
 
 # When no client cert is presented, the server would otherwise require
 # password auth. However, root does not have a password.
 connect user=root password=foo sslmode=verify-ca sslcert=
 ----
-ERROR: password authentication failed for user root
+ERROR: password authentication failed for user root (SQLSTATE 28000)
 
 subtest end root
 
@@ -64,7 +64,7 @@ ok defaultdb
 # present a cert so auth fails.
 connect_unix user=testuser
 ----
-ERROR: password authentication failed for user testuser
+ERROR: password authentication failed for user testuser (SQLSTATE 28000)
 
 # Make the user need a password.
 sql
@@ -80,7 +80,7 @@ ok defaultdb
 # If we don't present the client certificate, the password is required.
 connect user=testuser password=invalid sslmode=verify-ca sslcert=
 ----
-ERROR: password authentication failed for user testuser
+ERROR: password authentication failed for user testuser (SQLSTATE 28000)
 
 connect user=testuser password=pass sslmode=verify-ca sslcert=
 ----
@@ -110,13 +110,13 @@ ok
 # and password auth becomes required.
 connect user=testuser_nocert
 ----
-ERROR: password authentication failed for user testuser_nocert
+ERROR: password authentication failed for user testuser_nocert (SQLSTATE 28000)
 
 # Even though the user has no password, trying to present the
 # empty password fails. The user simply cannot log in.
 connect user=testuser_nocert password=
 ----
-ERROR: password authentication failed for user testuser_nocert
+ERROR: password authentication failed for user testuser_nocert (SQLSTATE 28000)
 
 sql
 DROP USER testuser_nocert
@@ -147,7 +147,7 @@ ok defaultdb
 #
 connect user=(Ὀδυσσεύς) password=
 ----
-ERROR: password authentication failed for user ὀδυσσεύς
+ERROR: password authentication failed for user ὀδυσσεύς (SQLSTATE 28000)
 
 # The unicode password succeeds, with user normalization.
 connect user=(Ὀδυσσεύς) password=(蟑♫螂)

--- a/pkg/sql/pgwire/testdata/auth/hba_default_equivalence
+++ b/pkg/sql/pgwire/testdata/auth/hba_default_equivalence
@@ -37,13 +37,13 @@ ok defaultdb
 # they do not have a password by default.
 connect_unix user=root
 ----
-ERROR: password authentication failed for user root
+ERROR: password authentication failed for user root (SQLSTATE 28000)
 
 # When no client cert is presented, the server would otherwise require
 # password auth. However, root does not have a password.
 connect user=root password=foo sslmode=verify-ca sslcert=
 ----
-ERROR: password authentication failed for user root
+ERROR: password authentication failed for user root (SQLSTATE 28000)
 
 subtest end root
 
@@ -58,7 +58,7 @@ ok defaultdb
 # present a cert so auth fails.
 connect_unix user=testuser
 ----
-ERROR: password authentication failed for user testuser
+ERROR: password authentication failed for user testuser (SQLSTATE 28000)
 
 # Make the user need a password.
 sql
@@ -78,7 +78,7 @@ ok defaultdb
 # If we don't present the client certificate, the password is required.
 connect user=testuser password=invalid sslmode=verify-ca sslcert=
 ----
-ERROR: password authentication failed for user testuser
+ERROR: password authentication failed for user testuser (SQLSTATE 28000)
 
 connect user=testuser password=pass sslmode=verify-ca sslcert=
 ----
@@ -104,13 +104,13 @@ ok
 # and password auth becomes required.
 connect user=testuser_nocert
 ----
-ERROR: password authentication failed for user testuser_nocert
+ERROR: password authentication failed for user testuser_nocert (SQLSTATE 28000)
 
 # Even though the user has no password, trying to present the
 # empty password fails. The user simply cannot log in.
 connect user=testuser_nocert password=
 ----
-ERROR: password authentication failed for user testuser_nocert
+ERROR: password authentication failed for user testuser_nocert (SQLSTATE 28000)
 
 sql
 DROP USER testuser_nocert

--- a/pkg/sql/pgwire/testdata/auth/hba_host_selection
+++ b/pkg/sql/pgwire/testdata/auth/hba_host_selection
@@ -22,7 +22,7 @@ host   all      all  0.0.0.0/32 cert
 
 connect user=testuser
 ----
-ERROR: no server.host_based_authentication.configuration entry for host "127.0.0.1", user "testuser"
+ERROR: no server.host_based_authentication.configuration entry for host "127.0.0.1", user "testuser" (SQLSTATE 28000)
 
 subtest nomatch/root_override
 

--- a/pkg/sql/pgwire/testdata/auth/hba_user_selection
+++ b/pkg/sql/pgwire/testdata/auth/hba_user_selection
@@ -37,11 +37,11 @@ ok defaultdb
 
 connect user=testuser
 ----
-ERROR: no server.host_based_authentication.configuration entry for host "127.0.0.1", user "testuser"
+ERROR: no server.host_based_authentication.configuration entry for host "127.0.0.1", user "testuser" (SQLSTATE 28000)
 
 connect user=passworduser password=pass
 ----
-ERROR: no server.host_based_authentication.configuration entry for host "127.0.0.1", user "passworduser"
+ERROR: no server.host_based_authentication.configuration entry for host "127.0.0.1", user "passworduser" (SQLSTATE 28000)
 
 subtest end root
 
@@ -71,7 +71,7 @@ ok defaultdb
 
 connect user=passworduser password=pass
 ----
-ERROR: no server.host_based_authentication.configuration entry for host "127.0.0.1", user "passworduser"
+ERROR: no server.host_based_authentication.configuration entry for host "127.0.0.1", user "passworduser" (SQLSTATE 28000)
 
 # Although this is not completely true. "root" can always log in nonetheless.
 
@@ -204,7 +204,7 @@ ok defaultdb
 
 connect user=passworduser password=pass
 ----
-ERROR: no TLS peer certificates, but required for auth
+ERROR: no TLS peer certificates, but required for auth (SQLSTATE 28000)
 
 # The special keyword "all" only matches when it is unquoted.
 

--- a/pkg/sql/pgwire/testdata/auth/insecure
+++ b/pkg/sql/pgwire/testdata/auth/insecure
@@ -52,6 +52,6 @@ subtest user_does_not_exist
 
 connect user=nonexistent sslmode=disable
 ----
-ERROR: password authentication failed for user nonexistent
+ERROR: password authentication failed for user nonexistent (SQLSTATE 28000)
 
 subtest end

--- a/pkg/sql/pgwire/testdata/auth/password_change
+++ b/pkg/sql/pgwire/testdata/auth/password_change
@@ -14,7 +14,7 @@ ok
 # sanity check: without a password, auth is denied.
 connect user=userpw
 ----
-ERROR: password authentication failed for user userpw
+ERROR: password authentication failed for user userpw (SQLSTATE 28000)
 
 # with the proper pass, auth succeeds.
 connect user=userpw password=pass
@@ -31,7 +31,7 @@ ok
 
 connect user=userpw password=pass
 ----
-ERROR: password authentication failed for user userpw
+ERROR: password authentication failed for user userpw (SQLSTATE 28000)
 
 connect user=userpw password=pass2
 ----
@@ -47,11 +47,11 @@ ok
 
 connect user=userpw password=pass2
 ----
-ERROR: password authentication failed for user userpw
+ERROR: password authentication failed for user userpw (SQLSTATE 28000)
 
 connect user=userpw
 ----
-ERROR: password authentication failed for user userpw
+ERROR: password authentication failed for user userpw (SQLSTATE 28000)
 
 subtest end
 
@@ -60,11 +60,11 @@ subtest root_pw
 # By default root cannot log in with a password.
 connect user=root sslmode=require sslcert= sslkey=
 ----
-ERROR: password authentication failed for user root
+ERROR: password authentication failed for user root (SQLSTATE 28000)
 
 connect_unix user=root
 ----
-ERROR: password authentication failed for user root
+ERROR: password authentication failed for user root (SQLSTATE 28000)
 
 
 # However if we give them a password, they can log in with password.

--- a/pkg/sql/pgwire/testdata/auth/secure_non_tls
+++ b/pkg/sql/pgwire/testdata/auth/secure_non_tls
@@ -20,11 +20,11 @@ accept_sql_without_tls
 
 connect user=root sslmode=disable
 ----
-ERROR: password authentication failed for user root
+ERROR: password authentication failed for user root (SQLSTATE 28000)
 
 connect user=testuser sslmode=disable
 ----
-ERROR: password authentication failed for user testuser
+ERROR: password authentication failed for user testuser (SQLSTATE 28000)
 
 # set the password for testuser.
 sql
@@ -42,7 +42,7 @@ ok defaultdb
 
 connect password=wrongpass user=testuser sslmode=disable
 ----
-ERROR: password authentication failed for user testuser
+ERROR: password authentication failed for user testuser (SQLSTATE 28000)
 
 # Now disable all non-TLS conns via HBA.
 set_hba
@@ -68,4 +68,4 @@ local     all      all          password
 
 connect password=abc user=testuser sslmode=disable
 ----
-ERROR: authentication rejected by configuration
+ERROR: authentication rejected by configuration (SQLSTATE 28000)

--- a/pkg/sql/pgwire/testdata/auth/special_cases
+++ b/pkg/sql/pgwire/testdata/auth/special_cases
@@ -29,7 +29,7 @@ host   all      root 0.0.0.0/0 password
 
 connect user=root password=abc sslmode=verify-ca sslcert=
 ----
-ERROR: password authentication failed for user root
+ERROR: password authentication failed for user root (SQLSTATE 28000)
 
 subtest end root_user_cannot_use_password
 
@@ -61,7 +61,7 @@ host   all      testuser 0.0.0.0/0 cert
 
 connect user=testuser password=pass sslmode=verify-ca sslcert=
 ----
-ERROR: no TLS peer certificates, but required for auth
+ERROR: no TLS peer certificates, but required for auth (SQLSTATE 28000)
 
 subtest end user_has_both_cert_and_passwd/only_cert_implies_reject_password
 
@@ -82,7 +82,7 @@ host   all      testuser 0.0.0.0/0 password
 
 connect user=testuser
 ----
-ERROR: password authentication failed for user testuser
+ERROR: password authentication failed for user testuser (SQLSTATE 28000)
 
 subtest end user_has_both_cert_and_passwd/only_password_implies_reject_cert
 
@@ -121,6 +121,6 @@ host   all      nopassword 0.0.0.0/0 password
 
 connect user=nopassword
 ----
-ERROR: password authentication failed for user nopassword
+ERROR: password authentication failed for user nopassword (SQLSTATE 28000)
 
 subtest end user_has_null_hashed_password_column

--- a/pkg/sql/pgwire/testdata/auth/trust_reject
+++ b/pkg/sql/pgwire/testdata/auth/trust_reject
@@ -28,7 +28,7 @@ host   all      all      all     cert-password
 
 connect user=testuser
 ----
-ERROR: authentication rejected by configuration
+ERROR: authentication rejected by configuration (SQLSTATE 28000)
 
 subtest end
 
@@ -76,7 +76,7 @@ ok
 
 connect user=nocert sslcert= sslmode=require
 ----
-ERROR: password authentication failed for user nocert
+ERROR: password authentication failed for user nocert (SQLSTATE 28000)
 
 
 subtest end


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/41551

This matches the Postgres behavior, and helps clients react better to
failed authentication attempts.

Postgres actually uses the InvalidPassword error if the password
entered during authentication is incorrect, but this change does not
match that behavior. Returning InvalidPassword would reveal extra information
to a potentially malicious party who is guessing users/passwords.

Release note (security update): The error returned during a failed
authentication attempt will now include the
"InvalidAuthorizationSpecification" PG error code (28000).