### PR TITLE
bazel: add bazel testrace CI job

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,7 @@
 build --symlink_prefix=_bazel/ --ui_event_filters=-DEBUG --define gotags=bazel,crdb_test_off,gss --experimental_proto_descriptor_sets_include_source_info
 test --config=test
 build:test --define gotags=bazel,crdb_test,gss --test_env=TZ=
+build:race --@io_bazel_rules_go//go/config:race --test_env=GORACE=halt_on_error=1
 query --ui_event_filters=-DEBUG
 
 try-import %workspace%/.bazelrc.user

--- a/build/teamcity/cockroach/ci/tests/testrace.sh
+++ b/build/teamcity/cockroach/ci/tests/testrace.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
+
+source "$dir/teamcity-support.sh"  # For $root
+source "$dir/teamcity-bazel-support.sh"  # For run_bazel
+
+tc_prepare
+
+tc_start_block "Determine changed packages"
+if tc_release_branch; then
+  pkgspec=./pkg/...
+  echo "On release branch ($TC_BUILD_BRANCH), so running testrace on all packages ($pkgspec)"
+else
+  pkgspec=$(changed_go_pkgs)
+  if [[ $(echo "$pkgspec" | wc -w) -gt 10 ]]; then
+    echo "PR #$TC_BUILD_BRANCH changed many packages; skipping race detector tests"
+    exit 0
+  elif [[ -z "$pkgspec" ]]; then
+    echo "PR #$TC_BUILD_BRANCH has no changed packages; skipping race detector tests"
+    exit 0
+  fi
+  if [[ $pkgspec == *"./pkg/sql/opt"* ]]; then
+    # If one opt package was changed, run all opt packages (the optimizer puts
+    # various checks behind the race flag to keep them out of release builds).
+    echo "$pkgspec" | sed 's$./pkg/sql/opt/[^ ]*$$g'
+    pkgspec=$(echo "$pkgspec" | sed 's$./pkg/sql/opt[^ ]*$$g')
+    pkgspec="$pkgspec ./pkg/sql/opt/..."
+  fi
+  echo "PR #$TC_BUILD_BRANCH has changed packages; running race detector tests on $pkgspec"
+fi
+tc_end_block "Determine changed packages"
+
+tc_start_block "Run race detector tests"
+run_bazel build/teamcity/cockroach/ci/tests/testrace_impl.sh $pkgspec
+tc_end_block "Run race detector tests"

--- a/build/teamcity/cockroach/ci/tests/testrace_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/testrace_impl.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -xeuo pipefail
+
+# Usage: testrace_impl.sh PKG1 [PKG2 PKG3 PKG4...]
+# packages are expected to be formatted as go-style, e.g. ./pkg/cmd/bazci.
+
+bazel build //pkg/cmd/bazci --config=ci
+for pkg in "$@"
+do
+    # Query to list all affected tests.
+    pkg=${pkg#"./"}
+    if [[ $(basename $pkg) != ... ]]
+    then
+        pkg="$pkg:all"
+    fi
+    tests=$(bazel query "kind(go_test, $pkg)" --output=label)
+
+    # Run affected tests.
+    for test in "$tests"
+    do
+        $(bazel info bazel-bin)/pkg/cmd/bazci/bazci_/bazci --config ci --config race test "$test" -- \
+                               --test_env=COCKROACH_LOGIC_TESTS_SKIP=true \
+                               --test_env=GOMAXPROCS=8
+    done
+done
+

--- a/pkg/cmd/dev/test.go
+++ b/pkg/cmd/dev/test.go
@@ -102,7 +102,7 @@ func (d *dev) runUnitTest(cmd *cobra.Command, pkgs []string) error {
 		args = append(args, fmt.Sprintf("--local_cpu_resources=%d", numCPUs))
 	}
 	if race {
-		args = append(args, "--@io_bazel_rules_go//go/config:race")
+		args = append(args, "--config=race")
 	}
 
 	for _, pkg := range pkgs {

--- a/pkg/cmd/github-pull-request-make/main.go
+++ b/pkg/cmd/github-pull-request-make/main.go
@@ -257,7 +257,7 @@ func main() {
 				// NB: stress and bazci are expected to be put in `PATH` by the caller.
 				args = append(args, "--run_under", fmt.Sprintf("stress -stderr -maxfails 1 -maxtime %s -p %d", duration, parallelism))
 				if target == "stressrace" {
-					args = append(args, "--@io_bazel_rules_go//go/config:race")
+					args = append(args, "--config=race")
 				}
 				cmd := exec.Command("bazci", args...)
 				cmd.Stdout = os.Stdout


### PR DESCRIPTION
Also some light refactoring: add a `--config race` and use that instead
of directly referencing the `--@io_bazel_rules_go//go/config:race` flag.
Also add `GORACE=halt_on_error=1` to the test environment when running
under `--config race` -- this makes the behavior match up more closely
to the `Makefile`.

Closes #67145.

Release note: None