### PR TITLE
pkg/server: add --advertise-addr to mt start-sql

### DIFF
--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -967,6 +967,7 @@ func init() {
 		// NB: this also gets PreRun treatment via extraServerFlagInit to populate BaseCfg.SQLAddr.
 		varFlag(f, addrSetter{&serverSQLAddr, &serverSQLPort}, cliflags.ListenSQLAddr)
 		varFlag(f, addrSetter{&serverHTTPAddr, &serverHTTPPort}, cliflags.ListenHTTPAddr)
+		varFlag(f, addrSetter{&serverAdvertiseAddr, &serverAdvertisePort}, cliflags.AdvertiseAddr)
 
 		stringFlag(f, &startCtx.geoLibsDir, cliflags.GeoLibsDir)
 

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -185,8 +185,9 @@ type sqlServerOptionalKVArgs struct {
 type sqlServerOptionalTenantArgs struct {
 	tenantConnect kvtenant.Connector
 
-	// addr stores the SQL address binding for the pod.
-	addr string
+	// advertiseAddr stores the SQL address that is advertised to other servers
+	// of the same tenant.
+	advertiseAddr string
 }
 
 type sqlServerArgs struct {
@@ -348,7 +349,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		cfg.stopper, cfg.clock, cfg.db, codec, cfg.Settings,
 	)
 	cfg.sqlInstanceProvider = instanceprovider.New(
-		cfg.stopper, cfg.db, codec, cfg.sqlLivenessProvider, cfg.addr,
+		cfg.stopper, cfg.db, codec, cfg.sqlLivenessProvider, cfg.advertiseAddr,
 	)
 
 	jobRegistry := cfg.circularJobRegistry

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -131,7 +131,7 @@ func StartTenant(
 	}
 	pgLAddr := pgL.Addr().String()
 	httpLAddr := httpL.Addr().String()
-	args.addr = pgLAddr
+	args.advertiseAddr = baseCfg.AdvertiseAddr
 	s, err := newSQLServer(ctx, args)
 	if err != nil {
 		return nil, "", "", err


### PR DESCRIPTION
    Previously, mt start-sql did not have an --advertise-addr flag. This
    resulted in the server advertising its server as ::1. This resulted
    in difficulty of verifying TLS certificates as well as breaking pod
    to pod communication if :<port> was used to start the server. This
    commit properly connects the --advertise-addr flag, which enables
    pod to pod communication over DNS and makes TLS verification with
    DNS SANs possible.

Release note (cli change): cockroach mt start-sql now supports
--advertise-addr in the same fashion that cockroach start does.