### PR TITLE
vendor: bump Pebble to 5e4468e97817

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -648,8 +648,8 @@ def go_deps():
         name = "com_github_cockroachdb_pebble",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/cockroachdb/pebble",
-        sum = "h1:Igd6YmtOZ77EgLAIaE9+mHl7+sAKaZ5m4iMI0Dz/J2A=",
-        version = "v0.0.0-20210719141320-8c3bd06debb5",
+        sum = "h1:icLlV0p22w7vepuNCF4h8Qvo5hcpoi0ORSIfCqaTYPc=",
+        version = "v0.0.0-20210817201821-5e4468e97817",
     )
 
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f
-	github.com/cockroachdb/pebble v0.0.0-20210719141320-8c3bd06debb5
+	github.com/cockroachdb/pebble v0.0.0-20210817201821-5e4468e97817
 	github.com/cockroachdb/redact v1.1.3
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2

--- a/go.sum
+++ b/go.sum
@@ -279,8 +279,8 @@ github.com/cockroachdb/gostdlib v1.13.0 h1:TzSEPYgkKDNei3gbLc0rrHu4iHyBp7/+NxPOF
 github.com/cockroachdb/gostdlib v1.13.0/go.mod h1:eXX95p9QDrYwJfJ6AgeN9QnRa/lqqid9LAzWz/l5OgA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f h1:o/kfcElHqOiXqcou5a3rIlMc7oJbMQkeLk0VQJ7zgqY=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/cockroachdb/pebble v0.0.0-20210719141320-8c3bd06debb5 h1:Igd6YmtOZ77EgLAIaE9+mHl7+sAKaZ5m4iMI0Dz/J2A=
-github.com/cockroachdb/pebble v0.0.0-20210719141320-8c3bd06debb5/go.mod h1:JXfQr3d+XO4bL1pxGwKKo09xylQSdZ/mpZ9b2wfVcPs=
+github.com/cockroachdb/pebble v0.0.0-20210817201821-5e4468e97817 h1:icLlV0p22w7vepuNCF4h8Qvo5hcpoi0ORSIfCqaTYPc=
+github.com/cockroachdb/pebble v0.0.0-20210817201821-5e4468e97817/go.mod h1:JXfQr3d+XO4bL1pxGwKKo09xylQSdZ/mpZ9b2wfVcPs=
 github.com/cockroachdb/redact v1.0.8/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/redact v1.1.0/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/redact v1.1.3 h1:AKZds10rFSIj7qADf0g46UixK8NNLwWTNdCIGS5wfSQ=


### PR DESCRIPTION
```
ffe7c8e compaction: add key validation for compacted files
00aa1b9 workload: Fix NewSource race in the ycsb workload.
31d5cf4 vfs: modify Create to remove and create existing files
b86194f internal/manifest: add test coverage for L0-sublevel examples
61318a0 Fix word repetition
0cae417 internal/manifest: remove redundant `files` field
07228a5 internal/manifest: remove superfluous for-loop
3e0b8e6 pebble: Preserve one previous manifest
5c776d6 db: write manifest before creating WAL during Open
5f4e863 internal/errorfs: allow more granular error injection
1306f1b build: fix mod-update target
```

Release note: none