### PR TITLE
colexec: fix ordered aggregator in an edge case

### DIFF
--- a/pkg/sql/colexec/ordered_aggregator.go
+++ b/pkg/sql/colexec/ordered_aggregator.go
@@ -288,7 +288,8 @@ func (a *orderedAggregator) Next() coldata.Batch {
 				// capacity, so we choose to instantiate the batch with fixed
 				// maximal capacity that can be needed by the aggregator.
 				a.allocator.ReleaseMemory(colmem.GetBatchMemSize(a.scratch.Batch))
-				a.scratch.Batch = a.allocator.NewMemBatchWithFixedCapacity(a.outputTypes, 2*coldata.BatchSize())
+				newMinCapacity = 2 * coldata.BatchSize()
+				a.scratch.Batch = a.allocator.NewMemBatchWithFixedCapacity(a.outputTypes, newMinCapacity)
 			} else {
 				a.scratch.Batch, _ = a.allocator.ResetMaybeReallocate(
 					a.outputTypes, a.scratch.Batch, newMinCapacity, maxBatchMemSize,


### PR DESCRIPTION
During 21.1 release we refactored the ordered aggregator slightly:
namely, we introduced a temporary buffer to copy the overflow results of
aggregation into before resetting the working batch. However, we
introduced a bug of not instantiating the buffer of sufficient capacity
in all cases. I think if we get a batch with length in [512, 1023) range
first, we allocate the working batch of 2 x 1024 (maximum ever needed),
but the temporary buffer will be of the length of the input batch. If
later we get the batch with 1024 rows, an internal error might occur.

I was able to reproduce the problem on the TPCH dataset (and confirmed
the fix works), but for some reason I can't seem to trigger the problem
via a unit test, thus, there is no regression test in this commit.

Fixes: #69025.

Release note (bug fix): Previously, CockroachDB could return an internal
error when performing the streaming aggregation in some edge cases, and
this is now fixed. The bug has been present since 21.1.