### PR TITLE
release-21.1: opt: fix histogram selectivity calculation when nulls present

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -1984,3 +1984,52 @@ vectorized: true
 
 statement ok
 SET optimizer_improve_disjunction_selectivity = false
+
+# Check that we have a sane row count estimate when there are a lot of null
+# values.
+statement ok
+CREATE TABLE nulls (x INT, y INT);
+ALTER TABLE nulls INJECT STATISTICS '[
+    {
+        "columns": [
+            "x"
+        ],
+        "created_at": "2021-06-15 02:06:48.036389",
+        "distinct_count": 3000,
+        "histo_buckets": [
+            {
+                "distinct_range": 0,
+                "num_eq": 5000,
+                "num_range": 0,
+                "upper_bound": "0"
+            },
+            {
+                "distinct_range": 0,
+                "num_eq": 5000,
+                "num_range": 0,
+                "upper_bound": "1"
+            }
+        ],
+        "histo_col_type": "INT8",
+        "name": "__auto__",
+        "null_count": 11100000,
+        "row_count": 11110000
+    }
+]'
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM nulls WHERE x IS NULL
+----
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (x, y)
+│ estimated row count: 11,100,000
+│ filter: x IS NULL
+│
+└── • scan
+      columns: (x, y)
+      estimated row count: 11,110,000 (100% of the table; stats collected <hidden> ago)
+      table: nulls@primary
+      spans: FULL SCAN

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -3797,7 +3797,7 @@ func (sb *statisticsBuilder) selectivityFromHistograms(
 			continue
 		}
 
-		inputColStat, inputStats := sb.colStatFromInput(colStat.Cols, e)
+		inputColStat, _ := sb.colStatFromInput(colStat.Cols, e)
 		newHist := colStat.Histogram
 		oldHist := inputColStat.Histogram
 		if newHist == nil || oldHist == nil {
@@ -3807,12 +3807,9 @@ func (sb *statisticsBuilder) selectivityFromHistograms(
 		newCount := newHist.ValuesCount()
 		oldCount := oldHist.ValuesCount()
 
-		// Calculate the selectivity of the predicate.
-		nonNullSelectivity := props.MakeSelectivityFromFraction(newCount, oldCount)
-		nullSelectivity := props.MakeSelectivityFromFraction(colStat.NullCount, inputColStat.NullCount)
-		predicateSelectivity := sb.predicateSelectivity(
-			nonNullSelectivity, nullSelectivity, inputColStat.NullCount, inputStats.RowCount,
-		)
+		// Calculate the selectivity of the predicate. Nulls are already included
+		// in the histogram, so we do not need to account for them separately.
+		predicateSelectivity := props.MakeSelectivityFromFraction(newCount, oldCount)
 
 		// The maximum possible selectivity of the entire expression is the minimum
 		// selectivity of all individual predicates.

--- a/pkg/sql/opt/memo/testdata/stats/inverted-geo
+++ b/pkg/sql/opt/memo/testdata/stats/inverted-geo
@@ -385,12 +385,12 @@ project
       │    ├── limit hint: 1.00
       │    ├── sort
       │    │    ├── columns: i:1(int) g:2(geometry)
-      │    │    ├── stats: [rows=1e-07]
+      │    │    ├── stats: [rows=8.875e-08]
       │    │    ├── ordering: +1
       │    │    ├── limit hint: 0.00
       │    │    └── index-join t
       │    │         ├── columns: i:1(int) g:2(geometry)
-      │    │         ├── stats: [rows=1e-07]
+      │    │         ├── stats: [rows=8.875e-08]
       │    │         └── inverted-filter
       │    │              ├── columns: rowid:3(int!null)
       │    │              ├── inverted expression: /5
@@ -398,13 +398,13 @@ project
       │    │              │    └── union spans: ["B\xfd\xff\xff\xff\xff\xff\xff\xff\xff", "B\xfd\xff\xff\xff\xff\xff\xff\xff\xff"]
       │    │              ├── pre-filterer expression
       │    │              │    └── st_intersects('010200000002000000000000000000594000000000000059400000000000C062400000000000C06240', g:2) [type=bool]
-      │    │              ├── stats: [rows=1e-07]
+      │    │              ├── stats: [rows=8.875e-08]
       │    │              ├── key: (3)
       │    │              └── scan t@secondary
       │    │                   ├── columns: rowid:3(int!null) g_inverted_key:5(geometry!null)
       │    │                   ├── inverted constraint: /5/3
       │    │                   │    └── spans: ["B\xfd\xff\xff\xff\xff\xff\xff\xff\xff", "B\xfd\xff\xff\xff\xff\xff\xff\xff\xff"]
-      │    │                   ├── stats: [rows=1e-07, distinct(3)=1e-07, null(3)=0, distinct(5)=1e-07, null(5)=0]
+      │    │                   ├── stats: [rows=8.875e-08, distinct(3)=8.875e-08, null(3)=0, distinct(5)=8.875e-08, null(5)=0]
       │    │                   │   histogram(5)=
       │    │                   ├── key: (3)
       │    │                   └── fd: (3)-->(5)
@@ -486,7 +486,7 @@ select
  │              │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]
  │              │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x01", "B\xfd\x12\x00\x00\x00\x00\x00\x00\x00")
  │              │         └── ["B\xfd\x14\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x14\x00\x00\x00\x00\x00\x00\x00"]
- │              ├── stats: [rows=100, distinct(3)=100, null(3)=0, distinct(5)=1, null(5)=0]
+ │              ├── stats: [rows=100, distinct(3)=76.9230769, null(3)=0, distinct(5)=1, null(5)=0]
  │              │   histogram(5)=  0            100             0             0
  │              │                <--- '\x42fd1000000100000000' --- '\x42fd1400000000000001'
  │              ├── key: (3)
@@ -529,7 +529,7 @@ project
       │              │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x01", "B\xfd\x12\x00\x00\x00\x00\x00\x00\x00")
       │              │         └── ["B\xfd\x14\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x14\x00\x00\x00\x00\x00\x00\x00"]
       │              ├── flags: force-index=secondary
-      │              ├── stats: [rows=100, distinct(3)=100, null(3)=0, distinct(5)=1, null(5)=0]
+      │              ├── stats: [rows=100, distinct(3)=76.9230769, null(3)=0, distinct(5)=1, null(5)=0]
       │              │   histogram(5)=  0            100             0             0
       │              │                <--- '\x42fd1000000100000000' --- '\x42fd1400000000000001'
       │              ├── key: (3)

--- a/pkg/sql/opt/memo/testdata/stats/partial-index-scan
+++ b/pkg/sql/opt/memo/testdata/stats/partial-index-scan
@@ -1031,11 +1031,11 @@ project
       ├── inverted constraint: /6/1
       │    └── spans: ["7g\x00\x01*\x0e\x00", "7g\x00\x01*\x0e\x00"]
       ├── flags: force-index=partial
-      ├── stats: [rows=160, distinct(4)=2, null(4)=0, distinct(6)=50.5, null(6)=0, distinct(4,6)=101, null(4,6)=0]
-      │   histogram(4)=  0     80     0     80
+      ├── stats: [rows=184.108911, distinct(4)=2, null(4)=0, distinct(6)=50.5, null(6)=0, distinct(4,6)=101, null(4,6)=0]
+      │   histogram(4)=  0   92.054   0   92.054
       │                <--- 'banana' --- 'cherry'
-      │   histogram(6)=  0          64          96          0
-      │                <--- '\x376700012a0e00' ---- '\x376700012a0e01'
+      │   histogram(6)=  0        73.644        110.47          0
+      │                <--- '\x376700012a0e00' -------- '\x376700012a0e01'
       └── key: (1)
 
 opt
@@ -1054,11 +1054,11 @@ index-join inv_hist
       ├── inverted constraint: /6/1
       │    └── spans: ["7g\x00\x01*\x0e\x00", "7g\x00\x01*\x0e\x00"]
       ├── flags: force-index=partial
-      ├── stats: [rows=160, distinct(4)=2, null(4)=0, distinct(6)=50.5, null(6)=0, distinct(4,6)=101, null(4,6)=0]
-      │   histogram(4)=  0     80     0     80
+      ├── stats: [rows=184.108911, distinct(4)=2, null(4)=0, distinct(6)=50.5, null(6)=0, distinct(4,6)=101, null(4,6)=0]
+      │   histogram(4)=  0   92.054   0   92.054
       │                <--- 'banana' --- 'cherry'
-      │   histogram(6)=  0          64          96          0
-      │                <--- '\x376700012a0e00' ---- '\x376700012a0e01'
+      │   histogram(6)=  0        73.644        110.47          0
+      │                <--- '\x376700012a0e00' -------- '\x376700012a0e01'
       └── key: (1)
 
 opt
@@ -1079,7 +1079,7 @@ project
       ├── fd: ()-->(4), (1)-->(3)
       ├── index-join inv_hist
       │    ├── columns: k:1(int!null) j:3(jsonb) s:4(string)
-      │    ├── stats: [rows=160]
+      │    ├── stats: [rows=184.108911]
       │    ├── key: (1)
       │    ├── fd: (1)-->(3,4)
       │    └── scan inv_hist@partial,partial
@@ -1087,11 +1087,11 @@ project
       │         ├── inverted constraint: /6/1
       │         │    └── spans: ["7g\x00\x01*\x0e\x00", "7g\x00\x01*\x0e\x00"]
       │         ├── flags: force-index=partial
-      │         ├── stats: [rows=160, distinct(4)=2, null(4)=0, distinct(6)=50.5, null(6)=0, distinct(4,6)=101, null(4,6)=0]
-      │         │   histogram(4)=  0     80     0     80
+      │         ├── stats: [rows=184.108911, distinct(4)=2, null(4)=0, distinct(6)=50.5, null(6)=0, distinct(4,6)=101, null(4,6)=0]
+      │         │   histogram(4)=  0   92.054   0   92.054
       │         │                <--- 'banana' --- 'cherry'
-      │         │   histogram(6)=  0          64          96          0
-      │         │                <--- '\x376700012a0e00' ---- '\x376700012a0e01'
+      │         │   histogram(6)=  0        73.644        110.47          0
+      │         │                <--- '\x376700012a0e00' -------- '\x376700012a0e01'
       │         └── key: (1)
       └── filters
            └── s:4 = 'banana' [type=bool, outer=(4), constraints=(/4: [/'banana' - /'banana']; tight), fd=()-->(4)]
@@ -1109,7 +1109,7 @@ select
  ├── fd: ()-->(4), (1)-->(2,3)
  ├── index-join inv_hist
  │    ├── columns: k:1(int!null) i:2(int) j:3(jsonb) s:4(string)
- │    ├── stats: [rows=160]
+ │    ├── stats: [rows=184.108911]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4)
  │    └── scan inv_hist@partial,partial
@@ -1117,11 +1117,11 @@ select
  │         ├── inverted constraint: /6/1
  │         │    └── spans: ["7g\x00\x01*\x0e\x00", "7g\x00\x01*\x0e\x00"]
  │         ├── flags: force-index=partial
- │         ├── stats: [rows=160, distinct(4)=2, null(4)=0, distinct(6)=50.5, null(6)=0, distinct(4,6)=101, null(4,6)=0]
- │         │   histogram(4)=  0     80     0     80
+ │         ├── stats: [rows=184.108911, distinct(4)=2, null(4)=0, distinct(6)=50.5, null(6)=0, distinct(4,6)=101, null(4,6)=0]
+ │         │   histogram(4)=  0   92.054   0   92.054
  │         │                <--- 'banana' --- 'cherry'
- │         │   histogram(6)=  0          64          96          0
- │         │                <--- '\x376700012a0e00' ---- '\x376700012a0e01'
+ │         │   histogram(6)=  0        73.644        110.47          0
+ │         │                <--- '\x376700012a0e00' -------- '\x376700012a0e01'
  │         └── key: (1)
  └── filters
       └── s:4 = 'banana' [type=bool, outer=(4), constraints=(/4: [/'banana' - /'banana']; tight), fd=()-->(4)]
@@ -1141,7 +1141,7 @@ select
  ├── fd: (1)-->(2-4)
  ├── index-join inv_hist
  │    ├── columns: k:1(int!null) i:2(int) j:3(jsonb) s:4(string)
- │    ├── stats: [rows=160]
+ │    ├── stats: [rows=184.108911]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4)
  │    └── scan inv_hist@partial,partial
@@ -1149,11 +1149,11 @@ select
  │         ├── inverted constraint: /6/1
  │         │    └── spans: ["7g\x00\x01*\x0e\x00", "7g\x00\x01*\x0e\x00"]
  │         ├── flags: force-index=partial
- │         ├── stats: [rows=160, distinct(4)=2, null(4)=0, distinct(6)=50.5, null(6)=0, distinct(4,6)=101, null(4,6)=0]
- │         │   histogram(4)=  0     80     0     80
+ │         ├── stats: [rows=184.108911, distinct(4)=2, null(4)=0, distinct(6)=50.5, null(6)=0, distinct(4,6)=101, null(4,6)=0]
+ │         │   histogram(4)=  0   92.054   0   92.054
  │         │                <--- 'banana' --- 'cherry'
- │         │   histogram(6)=  0          64          96          0
- │         │                <--- '\x376700012a0e00' ---- '\x376700012a0e01'
+ │         │   histogram(6)=  0        73.644        110.47          0
+ │         │                <--- '\x376700012a0e00' -------- '\x376700012a0e01'
  │         └── key: (1)
  └── filters
       └── (i:2 > 0) AND (i:2 <= 100) [type=bool, outer=(2), constraints=(/2: [/1 - /100]; tight)]

--- a/pkg/sql/opt/memo/testdata/stats/scan
+++ b/pkg/sql/opt/memo/testdata/stats/scan
@@ -1037,20 +1037,20 @@ SELECT a, b::string FROM t47742 WHERE b = true
 project
  ├── columns: a:1(int) b:5(string!null)
  ├── immutable
- ├── stats: [rows=2640.64496]
+ ├── stats: [rows=3063.49984]
  ├── fd: ()-->(5)
  ├── index-join t47742
  │    ├── columns: a:1(int) t47742.b:2(bool!null)
- │    ├── stats: [rows=2640.64496, distinct(2)=1.00246926, null(2)=0]
- │    │   histogram(2)=  0    0    0.0021284 2640.6
+ │    ├── stats: [rows=3063.49984, distinct(2)=1.00246926, null(2)=0]
+ │    │   histogram(2)=  0    0    0.0024693 3063.5
  │    │                <--- false ----------- true
  │    ├── fd: ()-->(2)
  │    └── scan t47742@b_idx
  │         ├── columns: t47742.b:2(bool!null) rowid:3(int!null)
  │         ├── constraint: /-2/3: [/true - /true]
- │         ├── stats: [rows=2640.64496, distinct(2)=11, null(2)=0]
- │         │   histogram(2)=  0    0    0.0021284 2640.6
- │         │                <--- false ----------- true
+ │         ├── stats: [rows=3063.49984, distinct(2)=11, null(2)=0]
+ │         │   histogram(2)=  0   0    0.0024693 3063.5
+ │         │                <--- NULL ----------- true
  │         ├── key: (3)
  │         └── fd: ()-->(2)
  └── projections
@@ -1969,7 +1969,7 @@ AND f = 0
 ----
 select
  ├── columns: a:1(uuid!null) b:2(bool!null) c:3(int) d:4(string!null) e:5(int!null) f:6(float!null)
- ├── stats: [rows=3.6000022e-07, distinct(1)=3.6000022e-07, null(1)=0, distinct(2)=3.6000022e-07, null(2)=0, distinct(4)=3.6000022e-07, null(4)=0, distinct(5)=3.6000022e-07, null(5)=0, distinct(6)=3.6000022e-07, null(6)=0, distinct(1,2,4-6)=3.6000022e-07, null(1,2,4-6)=0]
+ ├── stats: [rows=3.6000004e-07, distinct(1)=3.6000004e-07, null(1)=0, distinct(2)=3.6000004e-07, null(2)=0, distinct(4)=3.6000004e-07, null(4)=0, distinct(5)=3.6000004e-07, null(5)=0, distinct(6)=3.6000004e-07, null(6)=0, distinct(1,2,4-6)=3.6000004e-07, null(1,2,4-6)=0]
  │   histogram(2)=  0 3.6e-07
  │                <--- false
  │   histogram(4)=  0 3.6e-07
@@ -1977,12 +1977,12 @@ select
  ├── fd: ()-->(1,2,4-6)
  ├── index-join multi_col
  │    ├── columns: a:1(uuid) b:2(bool) c:3(int) d:4(string) e:5(int) f:6(float)
- │    ├── stats: [rows=3.6100018e-07]
+ │    ├── stats: [rows=3.61e-07]
  │    ├── fd: ()-->(1,2,4)
  │    └── scan multi_col@bad_idx
  │         ├── columns: a:1(uuid!null) b:2(bool!null) d:4(string!null) rowid:7(int!null)
  │         ├── constraint: /2/-1/4/7: [/false/'37685f26-4b07-40ba-9bbf-42916ed9bc61'/'bar' - /false/'37685f26-4b07-40ba-9bbf-42916ed9bc61'/'bar']
- │         ├── stats: [rows=3.6100018e-07, distinct(1)=3.6100018e-07, null(1)=0, distinct(2)=3.6100018e-07, null(2)=0, distinct(4)=3.6100018e-07, null(4)=0, distinct(1,2,4)=3.6100018e-07, null(1,2,4)=0]
+ │         ├── stats: [rows=3.61e-07, distinct(1)=3.61e-07, null(1)=0, distinct(2)=3.61e-07, null(2)=0, distinct(4)=3.61e-07, null(4)=0, distinct(1,2,4)=3.61e-07, null(1,2,4)=0]
  │         │   histogram(2)=  0 3.61e-07
  │         │                <--- false -
  │         │   histogram(4)=  0 3.61e-07
@@ -2003,7 +2003,7 @@ AND f = 0
 ----
 select
  ├── columns: a:1(uuid!null) b:2(bool!null) c:3(int) d:4(string!null) e:5(int!null) f:6(float!null)
- ├── stats: [rows=0.0035964022, distinct(1)=0.0035964022, null(1)=0, distinct(2)=0.0035964022, null(2)=0, distinct(4)=0.0035964022, null(4)=0, distinct(5)=0.0035964022, null(5)=0, distinct(6)=0.0035964022, null(6)=0, distinct(1,2,4-6)=0.0035964022, null(1,2,4-6)=0]
+ ├── stats: [rows=0.0035964004, distinct(1)=0.0035964004, null(1)=0, distinct(2)=0.0035964004, null(2)=0, distinct(4)=0.0035964004, null(4)=0, distinct(5)=0.0035964004, null(5)=0, distinct(6)=0.0035964004, null(6)=0, distinct(1,2,4-6)=0.0035964004, null(1,2,4-6)=0]
  │   histogram(2)=  0 0.0035964
  │                <---- false -
  │   histogram(4)=  0 0.0035964
@@ -2011,12 +2011,12 @@ select
  ├── fd: ()-->(1,2,4-6)
  ├── index-join multi_col
  │    ├── columns: a:1(uuid) b:2(bool) c:3(int) d:4(string) e:5(int) f:6(float)
- │    ├── stats: [rows=0.000398224464]
+ │    ├── stats: [rows=0.000398224265]
  │    ├── fd: ()-->(2,5,6)
  │    └── scan multi_col@bef_idx
  │         ├── columns: b:2(bool!null) e:5(int!null) f:6(float!null) rowid:7(int!null)
  │         ├── constraint: /2/5/6/7: [/false/5/0.0 - /false/5/0.0]
- │         ├── stats: [rows=0.000398224464, distinct(2)=0.000398224464, null(2)=0, distinct(5)=0.000398224464, null(5)=0, distinct(6)=0.000398224464, null(6)=0, distinct(2,5,6)=0.000398224464, null(2,5,6)=0]
+ │         ├── stats: [rows=0.000398224265, distinct(2)=0.000398224265, null(2)=0, distinct(5)=0.000398224265, null(5)=0, distinct(6)=0.000398224265, null(6)=0, distinct(2,5,6)=0.000398224265, null(2,5,6)=0]
  │         │   histogram(2)=  0 0.00039822
  │         │                <---- false --
  │         ├── key: (7)

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -2621,3 +2621,60 @@ select
  └── filters
       ├── a:1 = 1 [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
       └── b:2 = 1 [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
+
+# Check that we have a sane row count estimate when there are a lot of null
+# values.
+exec-ddl
+DROP TABLE nulls
+----
+
+exec-ddl
+CREATE TABLE nulls (x INT, y INT)
+----
+
+exec-ddl
+ALTER TABLE nulls INJECT STATISTICS '[
+    {
+        "columns": [
+            "x"
+        ],
+        "created_at": "2021-06-15 02:06:48.036389",
+        "distinct_count": 3000,
+        "histo_buckets": [
+            {
+                "distinct_range": 0,
+                "num_eq": 5000,
+                "num_range": 0,
+                "upper_bound": "0"
+            },
+            {
+                "distinct_range": 0,
+                "num_eq": 5000,
+                "num_range": 0,
+                "upper_bound": "1"
+            }
+        ],
+        "histo_col_type": "INT8",
+        "name": "__auto__",
+        "null_count": 11100000,
+        "row_count": 11110000
+    }
+]'
+----
+
+norm
+SELECT * FROM nulls WHERE x IS NULL
+----
+select
+ ├── columns: x:1(int) y:2(int)
+ ├── stats: [rows=11100000, distinct(1)=1, null(1)=11100000]
+ │   histogram(1)=  0 1.11e+07
+ │                <---- NULL -
+ ├── fd: ()-->(1)
+ ├── scan nulls
+ │    ├── columns: x:1(int) y:2(int)
+ │    └── stats: [rows=11110000, distinct(1)=3000, null(1)=11100000]
+ │        histogram(1)=  0 1.11e+07 0 5000 0 5000
+ │                     <---- NULL ---- 0 ---- 1 -
+ └── filters
+      └── x:1 IS NULL [type=bool, outer=(1), constraints=(/1: [/NULL - /NULL]; tight), fd=()-->(1)]

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpcc
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpcc
@@ -1191,13 +1191,14 @@ except-all
  └── project
       ├── save-table-name: consistency_08_project_3
       ├── columns: o_id:5(int!null) o_d_id:6(int!null) o_w_id:7(int!null)
-      ├── stats: [rows=90000, distinct(5)=2999, null(5)=0, distinct(6)=10, null(6)=0, distinct(7)=10, null(7)=0]
+      ├── stats: [rows=90000.6, distinct(5)=2999, null(5)=0, distinct(6)=10, null(6)=0, distinct(7)=10, null(7)=0]
       ├── key: (5-7)
       └── select
            ├── save-table-name: consistency_08_select_4
            ├── columns: o_id:5(int!null) o_d_id:6(int!null) o_w_id:7(int!null) o_carrier_id:10(int)
-           ├── stats: [rows=90000, distinct(5)=2999, null(5)=0, distinct(6)=10, null(6)=0, distinct(7)=10, null(7)=0, distinct(10)=1, null(10)=90000]
-           │   histogram(10)=
+           ├── stats: [rows=90000.6, distinct(5)=2999, null(5)=0, distinct(6)=10, null(6)=0, distinct(7)=10, null(7)=0, distinct(10)=1, null(10)=90000]
+           │   histogram(10)=  0 90000
+           │                 <--- NULL
            ├── key: (5-7)
            ├── fd: ()-->(10)
            ├── scan order@order_idx
@@ -1210,8 +1211,8 @@ except-all
            │    │                <---- 1 ----- 2 ----- 3 ----- 4 ----- 5 ----- 6 ----- 7 ----- 8 ----- 9 ---- 10 -
            │    │   histogram(7)=  0 30030 0 30000 0 30720 0 30360 0 30390 0 30360 0 28320 0 31410 0 28680 0 29730
            │    │                <---- 0 ----- 1 ----- 2 ----- 3 ----- 4 ----- 5 ----- 6 ----- 7 ----- 8 ----- 9 -
-           │    │   histogram(10)=  0 21332 1.6802e+05 20649
-           │    │                 <---- 1 ------------- 10 -
+           │    │   histogram(10)=  0 90000  0 21332 1.6802e+05 20649
+           │    │                 <--- NULL ---- 1 ------------- 10 -
            │    ├── key: (5-7)
            │    └── fd: (5-7)-->(10)
            └── filters
@@ -1246,9 +1247,9 @@ column_names  row_count  distinct_count  null_count
 {o_w_id}      90000      10              0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{o_d_id}      90000.00       1.00           10.00               1.00                0.00            1.00
-{o_id}        90000.00       1.00           2999.00             3.33 <==            0.00            1.00
-{o_w_id}      90000.00       1.00           10.00               1.00                0.00            1.00
+{o_d_id}      90001.00       1.00           10.00               1.00                0.00            1.00
+{o_id}        90001.00       1.00           2999.00             3.33 <==            0.00            1.00
+{o_w_id}      90001.00       1.00           10.00               1.00                0.00            1.00
 
 ----Stats for consistency_08_select_4----
 column_names    row_count  distinct_count  null_count
@@ -1258,10 +1259,10 @@ column_names    row_count  distinct_count  null_count
 {o_w_id}        90000      10              0
 ~~~~
 column_names    row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{o_carrier_id}  90000.00       1.00           1.00                1.00                90000.00        1.00
-{o_d_id}        90000.00       1.00           10.00               1.00                0.00            1.00
-{o_id}          90000.00       1.00           2999.00             3.33 <==            0.00            1.00
-{o_w_id}        90000.00       1.00           10.00               1.00                0.00            1.00
+{o_carrier_id}  90001.00       1.00           1.00                1.00                90000.00        1.00
+{o_d_id}        90001.00       1.00           10.00               1.00                0.00            1.00
+{o_id}          90001.00       1.00           2999.00             3.33 <==            0.00            1.00
+{o_w_id}        90001.00       1.00           10.00               1.00                0.00            1.00
 
 ----Stats for consistency_08_scan_5----
 column_names    row_count  distinct_count  null_count
@@ -1289,17 +1290,18 @@ except-all
  ├── columns: o_w_id:3(int!null) o_d_id:2(int!null) o_id:1(int!null)
  ├── left columns: o_w_id:3(int!null) o_d_id:2(int!null) o_id:1(int!null)
  ├── right columns: no_w_id:12(int) no_d_id:11(int) no_o_id:10(int)
- ├── stats: [rows=90000, distinct(1)=2999, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=0]
+ ├── stats: [rows=90000.6, distinct(1)=2999, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=0]
  ├── project
  │    ├── save-table-name: consistency_09_project_2
  │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null)
- │    ├── stats: [rows=90000, distinct(1)=2999, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=0]
+ │    ├── stats: [rows=90000.6, distinct(1)=2999, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=0]
  │    ├── key: (1-3)
  │    └── select
  │         ├── save-table-name: consistency_09_select_3
  │         ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
- │         ├── stats: [rows=90000, distinct(1)=2999, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=0, distinct(6)=1, null(6)=90000]
- │         │   histogram(6)=
+ │         ├── stats: [rows=90000.6, distinct(1)=2999, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=0, distinct(6)=1, null(6)=90000]
+ │         │   histogram(6)=  0 90000
+ │         │                <--- NULL
  │         ├── key: (1-3)
  │         ├── fd: ()-->(6)
  │         ├── scan order@order_idx
@@ -1312,8 +1314,8 @@ except-all
  │         │    │                <---- 1 ----- 2 ----- 3 ----- 4 ----- 5 ----- 6 ----- 7 ----- 8 ----- 9 ---- 10 -
  │         │    │   histogram(3)=  0 30030 0 30000 0 30720 0 30360 0 30390 0 30360 0 28320 0 31410 0 28680 0 29730
  │         │    │                <---- 0 ----- 1 ----- 2 ----- 3 ----- 4 ----- 5 ----- 6 ----- 7 ----- 8 ----- 9 -
- │         │    │   histogram(6)=  0 21332 1.6802e+05 20649
- │         │    │                <---- 1 ------------- 10 -
+ │         │    │   histogram(6)=  0 90000  0 21332 1.6802e+05 20649
+ │         │    │                <--- NULL ---- 1 ------------- 10 -
  │         │    ├── key: (1-3)
  │         │    └── fd: (1-3)-->(6)
  │         └── filters
@@ -1337,9 +1339,9 @@ column_names  row_count  distinct_count  null_count
 {o_w_id}      0          0               0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{o_d_id}      90000.00       +Inf <==       10.00               +Inf <==            0.00            1.00
-{o_id}        90000.00       +Inf <==       2999.00             +Inf <==            0.00            1.00
-{o_w_id}      90000.00       +Inf <==       10.00               +Inf <==            0.00            1.00
+{o_d_id}      90001.00       +Inf <==       10.00               +Inf <==            0.00            1.00
+{o_id}        90001.00       +Inf <==       2999.00             +Inf <==            0.00            1.00
+{o_w_id}      90001.00       +Inf <==       10.00               +Inf <==            0.00            1.00
 
 ----Stats for consistency_09_project_2----
 column_names  row_count  distinct_count  null_count
@@ -1348,9 +1350,9 @@ column_names  row_count  distinct_count  null_count
 {o_w_id}      90000      10              0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{o_d_id}      90000.00       1.00           10.00               1.00                0.00            1.00
-{o_id}        90000.00       1.00           2999.00             3.33 <==            0.00            1.00
-{o_w_id}      90000.00       1.00           10.00               1.00                0.00            1.00
+{o_d_id}      90001.00       1.00           10.00               1.00                0.00            1.00
+{o_id}        90001.00       1.00           2999.00             3.33 <==            0.00            1.00
+{o_w_id}      90001.00       1.00           10.00               1.00                0.00            1.00
 
 ----Stats for consistency_09_select_3----
 column_names    row_count  distinct_count  null_count
@@ -1360,10 +1362,10 @@ column_names    row_count  distinct_count  null_count
 {o_w_id}        90000      10              0
 ~~~~
 column_names    row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{o_carrier_id}  90000.00       1.00           1.00                1.00                90000.00        1.00
-{o_d_id}        90000.00       1.00           10.00               1.00                0.00            1.00
-{o_id}          90000.00       1.00           2999.00             3.33 <==            0.00            1.00
-{o_w_id}        90000.00       1.00           10.00               1.00                0.00            1.00
+{o_carrier_id}  90001.00       1.00           1.00                1.00                90000.00        1.00
+{o_d_id}        90001.00       1.00           10.00               1.00                0.00            1.00
+{o_id}          90001.00       1.00           2999.00             3.33 <==            0.00            1.00
+{o_w_id}        90001.00       1.00           10.00               1.00                0.00            1.00
 
 ----Stats for consistency_09_scan_4----
 column_names    row_count  distinct_count  null_count
@@ -1637,12 +1639,12 @@ scalar-group-by
  ├── select
  │    ├── save-table-name: consistency_12_select_2
  │    ├── columns: o_id:1(int) o_d_id:2(int) o_w_id:3(int) ol_o_id:10(int) ol_d_id:11(int) ol_w_id:12(int)
- │    ├── stats: [rows=299711.333, distinct(1)=2999, null(1)=209767.952, distinct(2)=10, null(2)=209767.952, distinct(3)=10, null(3)=209767.952, distinct(10)=2999, null(10)=0, distinct(11)=10, null(11)=0, distinct(12)=10, null(12)=0]
+ │    ├── stats: [rows=299711.333, distinct(1)=2999, null(1)=209767.353, distinct(2)=10, null(2)=209767.353, distinct(3)=10, null(3)=209767.353, distinct(10)=2999, null(10)=0, distinct(11)=10, null(11)=0, distinct(12)=10, null(12)=0]
  │    ├── full-join (hash)
  │    │    ├── save-table-name: consistency_12_full_join_3
  │    │    ├── columns: o_id:1(int) o_d_id:2(int) o_w_id:3(int) ol_o_id:10(int) ol_d_id:11(int) ol_w_id:12(int)
  │    │    ├── multiplicity: left-rows(exactly-one), right-rows(one-or-more)
- │    │    ├── stats: [rows=899134, distinct(1)=2999, null(1)=629303.857, distinct(2)=10, null(2)=629303.857, distinct(3)=10, null(3)=629303.857, distinct(10)=2999, null(10)=0, distinct(11)=10, null(11)=0, distinct(12)=10, null(12)=0]
+ │    │    ├── stats: [rows=899134, distinct(1)=2999, null(1)=629302.058, distinct(2)=10, null(2)=629302.058, distinct(3)=10, null(3)=629302.058, distinct(10)=2999, null(10)=0, distinct(11)=10, null(11)=0, distinct(12)=10, null(12)=0]
  │    │    ├── project
  │    │    │    ├── save-table-name: consistency_12_project_4
  │    │    │    ├── columns: ol_o_id:10(int!null) ol_d_id:11(int!null) ol_w_id:12(int!null)
@@ -1651,7 +1653,8 @@ scalar-group-by
  │    │    │         ├── save-table-name: consistency_12_select_5
  │    │    │         ├── columns: ol_o_id:10(int!null) ol_d_id:11(int!null) ol_w_id:12(int!null) ol_delivery_d:16(timestamp)
  │    │    │         ├── stats: [rows=899134, distinct(10)=2999, null(10)=0, distinct(11)=10, null(11)=0, distinct(12)=10, null(12)=0, distinct(16)=1, null(16)=899134]
- │    │    │         │   histogram(16)=
+ │    │    │         │   histogram(16)=  0 8.9913e+05
+ │    │    │         │                 <----- NULL --
  │    │    │         ├── fd: ()-->(16)
  │    │    │         ├── scan order_line
  │    │    │         │    ├── save-table-name: consistency_12_scan_6
@@ -1663,20 +1666,21 @@ scalar-group-by
  │    │    │         │                      <------ 1 ---------- 2 ---------- 3 ---------- 4 ---------- 5 ---------- 6 ---------- 7 ---------- 8 ---------- 9 ---------- 10 ---
  │    │    │         │        histogram(12)=  0 2.9772e+05 0 3.1123e+05 0 2.9982e+05 0 3.0042e+05 0 3.0492e+05 0 3.0012e+05 0 2.8452e+05 0 3.0132e+05 0 3.0612e+05 0 2.9502e+05
  │    │    │         │                      <------ 0 ---------- 1 ---------- 2 ---------- 3 ---------- 4 ---------- 5 ---------- 6 ---------- 7 ---------- 8 ---------- 9 ----
- │    │    │         │        histogram(16)=  0       2.1021e+06
- │    │    │         │                      <--- '2006-01-02 15:04:05'
+ │    │    │         │        histogram(16)=  0 8.9913e+05 0       2.1021e+06
+ │    │    │         │                      <----- NULL ----- '2006-01-02 15:04:05'
  │    │    │         └── filters
  │    │    │              └── ol_delivery_d:16 IS NULL [type=bool, outer=(16), constraints=(/16: [/NULL - /NULL]; tight), fd=()-->(16)]
  │    │    ├── project
  │    │    │    ├── save-table-name: consistency_12_project_7
  │    │    │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null)
- │    │    │    ├── stats: [rows=90000, distinct(1)=2999, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=0]
+ │    │    │    ├── stats: [rows=90000.6, distinct(1)=2999, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=0]
  │    │    │    ├── key: (1-3)
  │    │    │    └── select
  │    │    │         ├── save-table-name: consistency_12_select_8
  │    │    │         ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
- │    │    │         ├── stats: [rows=90000, distinct(1)=2999, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=0, distinct(6)=1, null(6)=90000]
- │    │    │         │   histogram(6)=
+ │    │    │         ├── stats: [rows=90000.6, distinct(1)=2999, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=0, distinct(6)=1, null(6)=90000]
+ │    │    │         │   histogram(6)=  0 90000
+ │    │    │         │                <--- NULL
  │    │    │         ├── key: (1-3)
  │    │    │         ├── fd: ()-->(6)
  │    │    │         ├── scan order@order_idx
@@ -1689,8 +1693,8 @@ scalar-group-by
  │    │    │         │    │                <---- 1 ----- 2 ----- 3 ----- 4 ----- 5 ----- 6 ----- 7 ----- 8 ----- 9 ---- 10 -
  │    │    │         │    │   histogram(3)=  0 30030 0 30000 0 30720 0 30360 0 30390 0 30360 0 28320 0 31410 0 28680 0 29730
  │    │    │         │    │                <---- 0 ----- 1 ----- 2 ----- 3 ----- 4 ----- 5 ----- 6 ----- 7 ----- 8 ----- 9 -
- │    │    │         │    │   histogram(6)=  0 21332 1.6802e+05 20649
- │    │    │         │    │                <---- 1 ------------- 10 -
+ │    │    │         │    │   histogram(6)=  0 90000  0 21332 1.6802e+05 20649
+ │    │    │         │    │                <--- NULL ---- 1 ------------- 10 -
  │    │    │         │    ├── key: (1-3)
  │    │    │         │    └── fd: (1-3)-->(6)
  │    │    │         └── filters
@@ -1721,9 +1725,9 @@ column_names  row_count  distinct_count  null_count
 {ol_w_id}     0          0               0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{o_d_id}      299711.00      +Inf <==       10.00               +Inf <==            209768.00       +Inf <==
-{o_id}        299711.00      +Inf <==       2999.00             +Inf <==            209768.00       +Inf <==
-{o_w_id}      299711.00      +Inf <==       10.00               +Inf <==            209768.00       +Inf <==
+{o_d_id}      299711.00      +Inf <==       10.00               +Inf <==            209767.00       +Inf <==
+{o_id}        299711.00      +Inf <==       2999.00             +Inf <==            209767.00       +Inf <==
+{o_w_id}      299711.00      +Inf <==       10.00               +Inf <==            209767.00       +Inf <==
 {ol_d_id}     299711.00      +Inf <==       10.00               +Inf <==            0.00            1.00
 {ol_o_id}     299711.00      +Inf <==       2999.00             +Inf <==            0.00            1.00
 {ol_w_id}     299711.00      +Inf <==       10.00               +Inf <==            0.00            1.00
@@ -1738,9 +1742,9 @@ column_names  row_count  distinct_count  null_count
 {ol_w_id}     899134     10              0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{o_d_id}      899134.00      1.00           10.00               1.00                629304.00       +Inf <==
-{o_id}        899134.00      1.00           2999.00             3.33 <==            629304.00       +Inf <==
-{o_w_id}      899134.00      1.00           10.00               1.00                629304.00       +Inf <==
+{o_d_id}      899134.00      1.00           10.00               1.00                629302.00       +Inf <==
+{o_id}        899134.00      1.00           2999.00             3.33 <==            629302.00       +Inf <==
+{o_w_id}      899134.00      1.00           10.00               1.00                629302.00       +Inf <==
 {ol_d_id}     899134.00      1.00           10.00               1.00                0.00            1.00
 {ol_o_id}     899134.00      1.00           2999.00             3.33 <==            0.00            1.00
 {ol_w_id}     899134.00      1.00           10.00               1.00                0.00            1.00
@@ -1789,9 +1793,9 @@ column_names  row_count  distinct_count  null_count
 {o_w_id}      90000      10              0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{o_d_id}      90000.00       1.00           10.00               1.00                0.00            1.00
-{o_id}        90000.00       1.00           2999.00             3.33 <==            0.00            1.00
-{o_w_id}      90000.00       1.00           10.00               1.00                0.00            1.00
+{o_d_id}      90001.00       1.00           10.00               1.00                0.00            1.00
+{o_id}        90001.00       1.00           2999.00             3.33 <==            0.00            1.00
+{o_w_id}      90001.00       1.00           10.00               1.00                0.00            1.00
 
 ----Stats for consistency_12_select_8----
 column_names    row_count  distinct_count  null_count
@@ -1801,10 +1805,10 @@ column_names    row_count  distinct_count  null_count
 {o_w_id}        90000      10              0
 ~~~~
 column_names    row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{o_carrier_id}  90000.00       1.00           1.00                1.00                90000.00        1.00
-{o_d_id}        90000.00       1.00           10.00               1.00                0.00            1.00
-{o_id}          90000.00       1.00           2999.00             3.33 <==            0.00            1.00
-{o_w_id}        90000.00       1.00           10.00               1.00                0.00            1.00
+{o_carrier_id}  90001.00       1.00           1.00                1.00                90000.00        1.00
+{o_d_id}        90001.00       1.00           10.00               1.00                0.00            1.00
+{o_id}          90001.00       1.00           2999.00             3.33 <==            0.00            1.00
+{o_w_id}        90001.00       1.00           10.00               1.00                0.00            1.00
 
 ----Stats for consistency_12_scan_9----
 column_names    row_count  distinct_count  null_count

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -1009,9 +1009,29 @@ func (ts *TableStat) Histogram() []cat.HistogramBucket {
 		panic(err)
 	}
 	colType := tree.MustBeStaticallyKnownType(colTypeRef)
-	histogram := make([]cat.HistogramBucket, len(ts.js.HistogramBuckets))
-	for i := range histogram {
-		bucket := &ts.js.HistogramBuckets[i]
+
+	var histogram []cat.HistogramBucket
+	var offset int
+	if ts.js.NullCount > 0 {
+		// A bucket for NULL is not persisted, but we create a fake one to
+		// make histograms easier to work with. The length of histogram
+		// is therefore 1 greater than the length of ts.js.HistogramBuckets.
+		// NOTE: This matches the logic in the TableStatisticsCache.
+		histogram = make([]cat.HistogramBucket, len(ts.js.HistogramBuckets)+1)
+		histogram[0] = cat.HistogramBucket{
+			NumEq:         float64(ts.js.NullCount),
+			NumRange:      0,
+			DistinctRange: 0,
+			UpperBound:    tree.DNull,
+		}
+		offset = 1
+	} else {
+		histogram = make([]cat.HistogramBucket, len(ts.js.HistogramBuckets))
+		offset = 0
+	}
+
+	for i := offset; i < len(histogram); i++ {
+		bucket := &ts.js.HistogramBuckets[i-offset]
 		datum, err := rowenc.ParseDatumStringAs(colType, bucket.UpperBound, &evalCtx)
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
Backport 1/1 commits from #69070.

/cc @cockroachdb/release

Release justification: This is a low-risk fix to a performance regression in 21.1.x, and brings the test catalog in line with the stats cache.

---

Prior to this commit, we were not accounting for the fact that
histograms included a bucket for null values when calculating the
selectivity. As a result, the row count estimate could be inaccurate
when a column had a large number of null values. This commit fixes
that oversight.

Additionally, part of the reason this bug was not caught earlier was
that the test catalog did not add a null bucket to histograms. The
null bucket was only added in the table statistics cache, which is not
used in opt tests. This commit fixes the test catalog so it adds a null
bucket to histograms to match the behavior of the stats cache.

Release note (bug fix): Fixed a bug with cardinality estimation in the
optimizer that was introduced in 21.1.0. This bug could cause inaccurate
row count estimates in queries involving tables with a large number of
null values. As a result, it was possible that the optimizer could
choose a suboptimal plan. This issue has now been fixed.
