### PR TITLE
ui: embed UI assets with go:embed directive

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -1043,13 +1043,7 @@ def go_deps():
         sum = "h1:bPIzW1Qkut7n9uwvPAXbnLDVEd45TV5ZwxYZAVX/zEQ=",
         version = "v0.10.0",
     )
-    go_repository(
-        name = "com_github_elazarl_go_bindata_assetfs",
-        build_file_proto_mode = "disable_global",
-        importpath = "github.com/elazarl/go-bindata-assetfs",
-        sum = "h1:G/bYguwHIzWq9ZoyUQqrjTmJbbYn3j3CKKpKinvZLFk=",
-        version = "v1.0.0",
-    )
+
     go_repository(
         name = "com_github_elazarl_goproxy",
         build_file_proto_mode = "disable_global",

--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,6 @@ require (
 	github.com/dustin/go-humanize v1.0.0
 	github.com/edsrzf/mmap-go v1.0.0
 	github.com/elastic/gosigar v0.10.0
-	github.com/elazarl/go-bindata-assetfs v1.0.0
 	github.com/emicklei/dot v0.15.0
 	github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a
 	github.com/ghemawat/stream v0.0.0-20171120220530-696b145b53b9

--- a/go.sum
+++ b/go.sum
@@ -381,8 +381,6 @@ github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaB
 github.com/eknkc/amber v0.0.0-20171010120322-cdade1c07385/go.mod h1:0vRUJqYpeSZifjYj7uP3BG/gKcuzL9xWVV/Y+cK33KM=
 github.com/elastic/gosigar v0.10.0 h1:bPIzW1Qkut7n9uwvPAXbnLDVEd45TV5ZwxYZAVX/zEQ=
 github.com/elastic/gosigar v0.10.0/go.mod h1:cdorVVzy1fhmEqmtgqkoE3bYtCfSCkVyjTyCIo22xvs=
-github.com/elazarl/go-bindata-assetfs v1.0.0 h1:G/bYguwHIzWq9ZoyUQqrjTmJbbYn3j3CKKpKinvZLFk=
-github.com/elazarl/go-bindata-assetfs v1.0.0/go.mod h1:v+YaWX3bdea5J/mo8dSETolEo7R71Vk1u8bnjau5yw4=
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/dot v0.15.0 h1:XDBW0Xco1QNyRb33cqLe10cT04yMWL1XpCZfa98Q6Og=
 github.com/emicklei/dot v0.15.0/go.mod h1:DeV7GvQtIw4h2u73RKBkkFdvVAz0D9fzeJrgPW6gy/s=

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -20,7 +20,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -980,14 +979,10 @@ func TestServeIndexHTML(t *testing.T) {
 `
 
 	linkInFakeUI := func() {
-		ui.Asset = func(string) (_ []byte, _ error) { return }
-		ui.AssetDir = func(name string) (_ []string, _ error) { return }
-		ui.AssetInfo = func(name string) (_ os.FileInfo, _ error) { return }
+		ui.HaveUI = true
 	}
 	unlinkFakeUI := func() {
-		ui.Asset = nil
-		ui.AssetDir = nil
-		ui.AssetInfo = nil
+		ui.HaveUI = false
 	}
 
 	t.Run("Insecure mode", func(t *testing.T) {

--- a/pkg/ui/.gitignore
+++ b/pkg/ui/.gitignore
@@ -8,10 +8,13 @@ yarn.opt.installed
 yarn.cluster-ui.installed
 yarn.protobuf.installed
 yarn-error.log
+assets.ccl.installed
+assets.oss.installed
 
 # Generated intermediates
 .cache-loader
 dist*/**
+!dist*/index.html
 !distccl/distccl.go
 !distoss/distoss.go
 *manifest.json

--- a/pkg/ui/BUILD.bazel
+++ b/pkg/ui/BUILD.bazel
@@ -10,6 +10,5 @@ go_library(
         "//pkg/build",
         "//pkg/util/log",
         "@com_github_cockroachdb_errors//:errors",
-        "@com_github_elazarl_go_bindata_assetfs//:go-bindata-assetfs",
     ],
 )

--- a/pkg/ui/distccl/assets/index.html
+++ b/pkg/ui/distccl/assets/index.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<title>CockroachDB</title>
+Binary built without web UI.
+<hr>
+<em>%s</em>

--- a/pkg/ui/distccl/distccl.go
+++ b/pkg/ui/distccl/distccl.go
@@ -9,3 +9,17 @@
 // Package distccl embeds the assets for the CCL version of the web UI into the
 // Cockroach binary.
 package distccl
+
+import (
+	"embed"
+
+	"github.com/cockroachdb/cockroach/pkg/ui"
+)
+
+//go:embed assets
+var assets embed.FS
+
+func init() {
+	ui.Assets = assets
+	ui.HaveUI = true
+}

--- a/pkg/ui/distoss/assets/index.html
+++ b/pkg/ui/distoss/assets/index.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<title>CockroachDB</title>
+Binary built without web UI.
+<hr>
+<em>%s</em>

--- a/pkg/ui/distoss/distoss.go
+++ b/pkg/ui/distoss/distoss.go
@@ -11,3 +11,17 @@
 // Package distoss embeds the assets for the OSS version of the web UI into the
 // Cockroach binary.
 package distoss
+
+import (
+	"embed"
+
+	"github.com/cockroachdb/cockroach/pkg/ui"
+)
+
+//go:embed assets
+var assets embed.FS
+
+func init() {
+	ui.Assets = assets
+	ui.HaveUI = true
+}

--- a/pkg/ui/workspaces/db-console/webpack.app.js
+++ b/pkg/ui/workspaces/db-console/webpack.app.js
@@ -51,7 +51,7 @@ module.exports = (env, argv) => {
     entry: ["./src/index.tsx"],
     output: {
       filename: "bundle.js",
-      path: path.resolve(__dirname, "../..", `dist${env.dist}`),
+      path: path.resolve(__dirname, "../..", `dist${env.dist}`, "assets"),
     },
 
     mode: argv.mode || "production",
@@ -164,7 +164,7 @@ module.exports = (env, argv) => {
         manifest: require("./vendor.oss.manifest.json"),
       }),
       new CopyWebpackPlugin([{ from: "favicon.ico", to: "favicon.ico" }]),
-      new VisualizerPlugin({ filename: `../dist/stats.${env.dist}.html` }),
+      new VisualizerPlugin({ filename: `../../dist/stats.${env.dist}.html` }),
       // use WebpackBar instead of webpack dashboard to fit multiple webpack dev server outputs (db-console and cluster-ui)
       new WebpackBar({
         name: "db-console",


### PR DESCRIPTION
Purpose of this change is to simplify build process for both
`make` and `bazel` builds.
Initially, ui assets were linked into go binaries by go-bindata
and required additional steps to format and
append extra data in auto-generated file that does not
work well with bazel builds.
To avoid these complications during build, new go:embed directive
is used instead.

Following gotchas required to make it work:
- all generated JS assets are placed into `assets` subdirectory
which is then linked as embedded dir.
- go:embed doesn't allow to point on empty or non-existing dir
 so `assets` dir includes dummy `index.html` file (the same as
 template for short builds without UI and .gitkeep file for
 convention to make it clear that this dir should be checked in
 repository.

Release note: none

Release justification: non-production code changes