### PR TITLE
cli: skip TestZip under race

### DIFF
--- a/pkg/cli/zip_test.go
+++ b/pkg/cli/zip_test.go
@@ -121,6 +121,8 @@ ORDER BY name ASC`)
 func TestZip(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
+	skip.UnderRace(t, "test too slow under race")
+
 	dir, cleanupFn := testutils.TempDir(t)
 	defer cleanupFn()
 


### PR DESCRIPTION
Fixes #68837.

When running with the race detector enabled, the generator for the
CREATE statements in crdb_internal.create_statements is running for
more than 10 seconds, which is the per-query timeout in the zip
command.

Release note: None