### PR TITLE
workload: fix kv95 runner to ignore txn rollback errors

### DIFF
--- a/pkg/workload/kv/kv.go
+++ b/pkg/workload/kv/kv.go
@@ -441,7 +441,10 @@ func (o *kvOp) run(ctx context.Context) (retErr error) {
 			return err
 		}
 		defer func() {
-			retErr = errors.CombineErrors(retErr, tx.Rollback(ctx))
+			rollbackErr := tx.Rollback(ctx)
+			if !errors.Is(rollbackErr, pgx.ErrTxClosed) {
+				retErr = errors.CombineErrors(retErr, rollbackErr)
+			}
 		}()
 		rows, err := o.sfuStmt.QueryTx(ctx, tx, sfuArgs...)
 		if err != nil {


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/69079

Commit https://github.com/cockroachdb/cockroach/commit/fb8fb52b30572722eeca196ddb62602d6a9ca0c5#diff-14c2f81863974c96bcd4bc66549fa33af83aa890550ed1edd5eeb6c6dbefbbe8R444 updated to pgx4
and in the process added logic to return the error from tx.Rollback.

Turns out pgx will return ErrTxClosed is the txn has already been
committed. Update the check to only combine the rollback err if it is
not ErrTxClosed.

Release note: None