### PR TITLE
sql/resolver: wrong error when db does not exist for virtual schemas

### DIFF
--- a/pkg/cli/interactive_tests/test_connect_cmd.tcl
+++ b/pkg/cli/interactive_tests/test_connect_cmd.tcl
@@ -132,7 +132,7 @@ start_test "Check that the client-side connect cmd can change users with certs u
 # first test that it can recover from an invalid database
 send "\\c postgres://root@localhost:26257/invaliddb?sslmode=require&sslcert=$certs_dir%2Fclient.root.crt&sslkey=$certs_dir%2Fclient.root.key&sslrootcert=$certs_dir%2Fca.crt\r"
 eexpect "using new connection URL"
-eexpect "error retrieving the database name"
+eexpect "error retrieving the database name: pq: database \"invaliddb\" does not exist"
 eexpect root@
 eexpect "?>"
 

--- a/pkg/sql/logictest/testdata/logic_test/database
+++ b/pkg/sql/logictest/testdata/logic_test/database
@@ -239,3 +239,20 @@ END
 
 statement ok
 DROP DATABASE d1
+
+subtest missing-db-error-issue-68060
+
+statement ok
+CREATE DATABASE db1;
+
+statement ok;
+USE db1;
+
+statement ok
+SET sql_safe_updates=false;
+
+statement ok
+DROP DATABASE db1;
+
+statement error pq: database "db1" does not exist
+SELECT * FROM crdb_internal.session_variables;


### PR DESCRIPTION
Fixes: #68060

Previously, when a database did not exist under a virtual
schema the code would fall through do a normal look up.
Before a recent refactor of the some of the internals,
we accidentally changed behavior, so that an undefined
relation error was returned. To address this, this patch
adds a check inside the resolver layer to return the correct
error instead of falling through.

Release note: None