### PR TITLE
ci: fix bazel `testrace` script

### DIFF
--- a/build/teamcity/cockroach/ci/tests/testrace_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/testrace_impl.sh
@@ -17,7 +17,7 @@ do
     tests=$(bazel query "kind(go_test, $pkg)" --output=label)
 
     # Run affected tests.
-    for test in "$tests"
+    for test in $tests
     do
         $(bazel info bazel-bin)/pkg/cmd/bazci/bazci_/bazci --config ci --config race test "$test" -- \
                                --test_env=COCKROACH_LOGIC_TESTS_SKIP=true \


### PR DESCRIPTION
Fixes errors such as we see [here](https://teamcity.cockroachdb.com/buildConfiguration/Cockroach_Ci_Tests_Testrace/3326173?buildTab=log&focusLine=0).

Release note: None