### PR TITLE
changefeedccl: return verbose error upon webhook sink context cancellation

### DIFF
--- a/pkg/ccl/changefeedccl/sink_webhook.go
+++ b/pkg/ccl/changefeedccl/sink_webhook.go
@@ -583,6 +583,11 @@ func (s *webhookSink) EmitRow(
 	select {
 	// check the webhook sink context in case workers have been terminated
 	case <-s.workerCtx.Done():
+		// check again for error in case it triggered since last check
+		// will return more verbose error instead of "context canceled"
+		if err = s.inflight.hasError(); err != nil {
+			return err
+		}
 		return s.workerCtx.Err()
 	case <-ctx.Done():
 		return ctx.Err()

--- a/pkg/ccl/changefeedccl/sink_webhook_test.go
+++ b/pkg/ccl/changefeedccl/sink_webhook_test.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -180,9 +181,29 @@ func TestWebhookSink(t *testing.T) {
 		require.EqualError(t, sinkSrc.EmitRow(context.Background(), nil, nil, nil, hlc.Timestamp{}, zeroAlloc),
 			`context canceled`)
 
+		sinkDestHTTP, err := cdctest.StartMockWebhookSinkInsecure()
+		require.NoError(t, err)
+		details.SinkURI = fmt.Sprintf("webhook-https://%s", strings.TrimPrefix(sinkDestHTTP.URL(), "http://"))
+
+		sinkSrcWrongProtocol, err := setupWebhookSinkWithDetails(context.Background(), details, parallelism, timeutil.DefaultTimeSource{})
+		require.NoError(t, err)
+
+		// sink's client should not accept the endpoint's use of HTTP (expects HTTPS)
+		require.NoError(t, sinkSrcWrongProtocol.EmitRow(context.Background(), nil, []byte("[1001]"),
+			[]byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"}"),
+			hlc.Timestamp{}, zeroAlloc))
+
+		require.EqualError(t, sinkSrcWrongProtocol.Flush(context.Background()),
+			fmt.Sprintf(`Post "%s": http: server gave HTTP response to HTTPS client`, fmt.Sprintf("https://%s", strings.TrimPrefix(sinkDestHTTP.URL(),
+				"http://"))))
+		require.EqualError(t, sinkSrcWrongProtocol.EmitRow(context.Background(), nil, nil, nil, hlc.Timestamp{}, zeroAlloc),
+			`context canceled`)
+
 		require.NoError(t, sinkSrc.Close())
 		require.NoError(t, sinkSrcNoCert.Close())
 		require.NoError(t, sinkSrcInsecure.Close())
+		require.NoError(t, sinkSrcWrongProtocol.Close())
+		sinkDestHTTP.Close()
 	}
 
 	// run tests with parallelism from 1-4


### PR DESCRIPTION
Previously, when the webhook sink workers were canceled (via context),
the sink returned a `context canceled` error. This change adds a check
to the inflight tracker for the HTTP error which will be clearer to
the user.

Release note: None

Specifically, this check is done within `EmitRow()`. We do this check at the top of the function, but there is a possibility that context cancellation will occur between the initial check and the batch channel send, so we re-check the error to make sure the user sees a proper reason for the changefeed failure, as opposed to `context canceled`.

Also added a test for the failure where an HTTP server is used (vs HTTPS) which was a failure a user experienced.