### PR TITLE
Revert "backupccl: protect entire keyspan during cluster backup"

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -168,7 +168,6 @@ go_test(
         "//pkg/kv/kvclient/kvcoord:with-mocks",
         "//pkg/kv/kvserver",
         "//pkg/kv/kvserver/kvserverbase",
-        "//pkg/kv/kvserver/protectedts/ptstorage",
         "//pkg/roachpb:with-mocks",
         "//pkg/scheduledjobs",
         "//pkg/security",

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -26,7 +26,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -50,7 +49,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts/ptstorage"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -6179,59 +6177,6 @@ func TestProtectedTimestampsDuringBackup(t *testing.T) {
 func getTableID(db *kv.DB, dbName, tableName string) descpb.ID {
 	desc := catalogkv.TestingGetTableDescriptor(db, keys.SystemSQLCodec, dbName, tableName)
 	return desc.GetID()
-}
-
-func TestProtectedTimestampSpanSelectionClusterBackup(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
-	const numAccounts = 1
-	serverArgs := base.TestServerArgs{Knobs: base.TestingKnobs{JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals()}}
-	params := base.TestClusterArgs{ServerArgs: serverArgs}
-	allowRequest := make(chan struct{})
-	params.ServerArgs.Knobs.Store = &kvserver.StoreTestingKnobs{
-		TestingRequestFilter: func(ctx context.Context, request roachpb.BatchRequest) *roachpb.Error {
-			for _, ru := range request.Requests {
-				switch ru.GetInner().(type) {
-				case *roachpb.ExportRequest:
-					<-allowRequest
-				}
-			}
-			return nil
-		},
-	}
-
-	_, tc, sqlDB, _, cleanupFn := backupRestoreTestSetupWithParams(t, singleNode, numAccounts,
-		InitManualReplication, params)
-	defer cleanupFn()
-
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		sqlDB.Exec(t, `BACKUP TO 'nodelocal://self/foo'`)
-	}()
-
-	var jobID string
-	conn := tc.Conns[0]
-	testutils.SucceedsSoon(t, func() error {
-		row := conn.QueryRow("SELECT job_id FROM [SHOW JOBS] ORDER BY created DESC LIMIT 1")
-		return row.Scan(&jobID)
-	})
-
-	// Check protected timestamp record to ensure we are protecting the clusters
-	// key-span.
-	var spans []byte
-	sqlDB.QueryRow(t, `SELECT spans FROM system.protected_ts_records LIMIT 1`).Scan(&spans)
-	var protectedSpans ptstorage.Spans
-	require.NoError(t, protoutil.Unmarshal(spans, &protectedSpans))
-
-	expectedSpans := ptstorage.Spans{
-		Spans: []roachpb.Span{{Key: keys.TableDataMin, EndKey: keys.TableDataMax}},
-	}
-	require.Equal(t, expectedSpans, protectedSpans)
-	close(allowRequest)
-	wg.Wait()
 }
 
 // TestSpanSelectionDuringBackup tests the method spansForAllTableIndexes which


### PR DESCRIPTION
This reverts commit 1b5fd4f000cfd8e5085b0b67e6db0d9fa5feb69b.

The commit above laid a pts record over the entire table keyspace.
This did not account for two things (with the potential of there being
more):

1. System tables that we do not backup could have a short GC TTL, and
so incremental backups that attempt to protect from `StartTime` of the
previous backup would fail.

2. Dropped tables often have a short GC TTL to clear data once they have
been dropped. This change would also attempt to protect "dropped but not
gc'ed tables" even though we exclude them from the backup, and fail on
pts verification.

One suggested approach is to exclude all objects we do not backup by
subtracting these spans from {TableDataMin, TableDataMax}. This works
for system tables, and dropped but not gc'ed tables, but breaks for
dropped and gc'ed tables. A pts verification would still find the leaseholder
of the empty span and attempt to protect below the gc threshold.

In conclusion, we need to think about the semantics a little more before
we rush to protect a single key span.