### PR TITLE
migration,startupmigrations: make AlterSystemWebSessionsCreateIndexes migration async

### DIFF
--- a/pkg/migration/migrations/BUILD.bazel
+++ b/pkg/migration/migrations/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "migrations",
     srcs = [
+        "alter_web_sessions_create_indexes.go",
         "database_role_settings.go",
         "delete_deprecated_namespace_tabledesc.go",
         "fix_descriptor_migration.go",
@@ -11,6 +12,7 @@ go_library(
         "migrations.go",
         "records_based_registry.go",
         "retry_jobs_with_exponential_backoff.go",
+        "schema_changes.go",
         "separated_intents.go",
         "span_configurations.go",
         "sql_instances.go",
@@ -54,6 +56,7 @@ go_library(
         "//pkg/util/syncutil",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_kr_pretty//:pretty",
     ],
 )
@@ -61,6 +64,7 @@ go_library(
 go_test(
     name = "migrations_test",
     srcs = [
+        "alter_web_sessions_create_indexes_test.go",
         "delete_deprecated_namespace_tabledesc_external_test.go",
         "fix_descriptor_migration_external_test.go",
         "helpers_test.go",

--- a/pkg/migration/migrations/alter_web_sessions_create_indexes.go
+++ b/pkg/migration/migrations/alter_web_sessions_create_indexes.go
@@ -1,0 +1,60 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package migrations
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/migration"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
+)
+
+// Target schema changes in the system.web_sessions table, adding indexes on two columns
+// for deleting old web sessions.
+const (
+	addIdxRevokedAtStmt = `
+CREATE INDEX IF NOT EXISTS "web_sessions_revokedAt_idx" 
+ON system.web_sessions ("revokedAt")
+`
+	addIdxLastUsedAtStmt = `
+CREATE INDEX IF NOT EXISTS "web_sessions_lastUsedAt_idx" 
+ON system.web_sessions ("lastUsedAt")
+`
+)
+
+// alterSystemWebSessionsCreateIndexes changes the schema of the system.web_sessions table.
+// It adds two indexes.
+func alterSystemWebSessionsCreateIndexes(
+	ctx context.Context, cs clusterversion.ClusterVersion, d migration.TenantDeps, _ *jobs.Job,
+) error {
+	for _, op := range []operation{
+		{
+			name:           "add-web-sessions-revokedAt-idx",
+			schemaList:     []string{"web_sessions_revokedAt_idx"},
+			query:          addIdxRevokedAtStmt,
+			schemaExistsFn: hasIndex,
+		},
+		{
+			name:           "add-web-sessions-lastUsedAt-idx",
+			schemaList:     []string{"web_sessions_lastUsedAt_idx"},
+			query:          addIdxLastUsedAtStmt,
+			schemaExistsFn: hasIndex,
+		},
+	} {
+		if err := migrateTable(ctx, cs, d, op, keys.WebSessionsTableID, systemschema.WebSessionsTable); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/migration/migrations/alter_web_sessions_create_indexes_test.go
+++ b/pkg/migration/migrations/alter_web_sessions_create_indexes_test.go
@@ -1,0 +1,181 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package migrations_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/migration/migrations"
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+)
+
+func TestAlterSystemWebSessionsTable(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	clusterArgs := base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				Server: &server.TestingKnobs{
+					DisableAutomaticVersionUpgrade: 1,
+					BinaryVersionOverride: clusterversion.ByKey(
+						clusterversion.AlterSystemWebSessionsCreateIndexes - 1),
+				},
+			},
+		},
+	}
+
+	var (
+		ctx = context.Background()
+
+		tc    = testcluster.StartTestCluster(t, 1, clusterArgs)
+		s     = tc.Server(0)
+		sqlDB = tc.ServerConn(0)
+	)
+	defer tc.Stopper().Stop(ctx)
+
+	var (
+		validationStmts = []string{
+			`SELECT 1 from system.web_sessions@"web_sessions_revokedAt_idx" LIMIT 0`,
+			`SELECT 1 from system.web_sessions@"web_sessions_lastUsedAt_idx" LIMIT 0`,
+		}
+		validationSchemas = []migrations.Schema{
+			{Name: "web_sessions_revokedAt_idx", ValidationFn: migrations.HasIndex},
+			{Name: "web_sessions_lastUsedAt_idx", ValidationFn: migrations.HasIndex},
+		}
+	)
+
+	// Inject the old copy of the descriptor.
+	migrations.InjectLegacyTable(ctx, t, s, systemschema.WebSessionsTable, getDeprecatedWebSessionsDescriptor)
+	// Validate that the web sessions table has the old schema.
+	migrations.ValidateSchemaExists(
+		ctx,
+		t,
+		s,
+		sqlDB,
+		keys.WebSessionsTableID,
+		systemschema.WebSessionsTable,
+		validationStmts,
+		validationSchemas,
+		false, /* expectExists */
+	)
+	// Run the migration.
+	migrations.Migrate(
+		t,
+		sqlDB,
+		clusterversion.AlterSystemWebSessionsCreateIndexes,
+		nil,   /* done */
+		false, /* expectError */
+	)
+	// Validate that the table has new schema.
+	migrations.ValidateSchemaExists(
+		ctx,
+		t,
+		s,
+		sqlDB,
+		keys.WebSessionsTableID,
+		systemschema.WebSessionsTable,
+		validationStmts,
+		validationSchemas,
+		true, /* expectExists */
+	)
+}
+
+// getDeprecatedWebSessionsDescriptor returns the system.web_sessions table descriptor that was being used
+// before adding two new indexes in the current version.
+func getDeprecatedWebSessionsDescriptor() *descpb.TableDescriptor {
+	uniqueRowIDString := "unique_rowid()"
+	nowString := "now():::TIMESTAMP"
+
+	return &descpb.TableDescriptor{
+		Name:                    "web_sessions",
+		ID:                      keys.WebSessionsTableID,
+		ParentID:                keys.SystemDatabaseID,
+		UnexposedParentSchemaID: keys.PublicSchemaID,
+		Version:                 1,
+		Columns: []descpb.ColumnDescriptor{
+			{Name: "id", ID: 1, Type: types.Int, DefaultExpr: &uniqueRowIDString},
+			{Name: "hashedSecret", ID: 2, Type: types.Bytes},
+			{Name: "username", ID: 3, Type: types.String},
+			{Name: "createdAt", ID: 4, Type: types.Timestamp, DefaultExpr: &nowString},
+			{Name: "expiresAt", ID: 5, Type: types.Timestamp},
+			{Name: "revokedAt", ID: 6, Type: types.Timestamp, Nullable: true},
+			{Name: "lastUsedAt", ID: 7, Type: types.Timestamp, DefaultExpr: &nowString},
+			{Name: "auditInfo", ID: 8, Type: types.String, Nullable: true},
+		},
+		NextColumnID: 9,
+		Families: []descpb.ColumnFamilyDescriptor{
+			{
+				Name: "fam_0_id_hashedSecret_username_createdAt_expiresAt_revokedAt_lastUsedAt_auditInfo",
+				ID:   0,
+				ColumnNames: []string{
+					"id",
+					"hashedSecret",
+					"username",
+					"createdAt",
+					"expiresAt",
+					"revokedAt",
+					"lastUsedAt",
+					"auditInfo",
+				},
+				ColumnIDs: []descpb.ColumnID{1, 2, 3, 4, 5, 6, 7, 8},
+			},
+		},
+		NextFamilyID: 1,
+		PrimaryIndex: descpb.IndexDescriptor{
+			Name:                tabledesc.PrimaryKeyIndexName,
+			ID:                  1,
+			Unique:              true,
+			KeyColumnNames:      []string{"id"},
+			KeyColumnDirections: []descpb.IndexDescriptor_Direction{descpb.IndexDescriptor_ASC},
+			KeyColumnIDs:        []descpb.ColumnID{1},
+		},
+		Indexes: []descpb.IndexDescriptor{
+			{
+				Name:                "web_sessions_expiresAt_idx",
+				ID:                  2,
+				Unique:              false,
+				KeyColumnNames:      []string{"expiresAt"},
+				KeyColumnDirections: []descpb.IndexDescriptor_Direction{descpb.IndexDescriptor_ASC},
+				KeyColumnIDs:        []descpb.ColumnID{5},
+				KeySuffixColumnIDs:  []descpb.ColumnID{1},
+				Version:             descpb.StrictIndexColumnIDGuaranteesVersion,
+			},
+			{
+				Name:                "web_sessions_createdAt_idx",
+				ID:                  3,
+				Unique:              false,
+				KeyColumnNames:      []string{"createdAt"},
+				KeyColumnDirections: []descpb.IndexDescriptor_Direction{descpb.IndexDescriptor_ASC},
+				KeyColumnIDs:        []descpb.ColumnID{4},
+				KeySuffixColumnIDs:  []descpb.ColumnID{1},
+				Version:             descpb.StrictIndexColumnIDGuaranteesVersion,
+			},
+		},
+		NextIndexID:    4,
+		Privileges:     descpb.NewCustomSuperuserPrivilegeDescriptor(privilege.ReadWriteData, security.NodeUserName()),
+		NextMutationID: 1,
+		FormatVersion:  3,
+	}
+}

--- a/pkg/migration/migrations/helpers_test.go
+++ b/pkg/migration/migrations/helpers_test.go
@@ -10,15 +10,140 @@
 
 package migrations
 
-import "github.com/cockroachdb/cockroach/pkg/sql/catalog"
+import (
+	"context"
+	gosql "database/sql"
+	"testing"
 
-func HasBackoffCols(storedTable, expectedTable catalog.TableDescriptor, col string) (bool, error) {
-	return hasColumn(storedTable, expectedTable, col)
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	HasColumn = hasColumn
+	HasIndex  = hasIndex
+)
+
+type Schema struct {
+	// Schema name.
+	Name string
+	// Function that validates the schema.
+	ValidationFn func(catalog.TableDescriptor, catalog.TableDescriptor, string) (bool, error)
 }
 
-func HasBackoffIndex(jobsTable, expectedTable catalog.TableDescriptor, index string) (bool, error) {
-	return hasIndex(jobsTable, expectedTable, index)
+// Migrate runs cluster migration by changing the 'version' cluster setting.
+func Migrate(
+	t *testing.T, sqlDB *gosql.DB, key clusterversion.Key, done chan struct{}, expectError bool,
+) {
+	defer func() {
+		if done != nil {
+			done <- struct{}{}
+		}
+	}()
+	_, err := sqlDB.Exec(`SET CLUSTER SETTING version = $1`,
+		clusterversion.ByKey(key).String())
+	if expectError {
+		assert.Error(t, err)
+		return
+	}
+	assert.NoError(t, err)
 }
 
-const AddColsQuery = addColsQuery
-const AddIndexQuery = addIndexQuery
+// InjectLegacyTable overwrites the existing table descriptor with the previous table descriptor.
+func InjectLegacyTable(
+	ctx context.Context,
+	t *testing.T,
+	s serverutils.TestServerInterface,
+	table catalog.TableDescriptor,
+	getDeprecatedDescriptor func() *descpb.TableDescriptor,
+) {
+	err := s.CollectionFactory().(*descs.CollectionFactory).Txn(
+		ctx,
+		s.InternalExecutor().(sqlutil.InternalExecutor),
+		s.DB(),
+		func(ctx context.Context, txn *kv.Txn, descriptors *descs.Collection) error {
+			id := table.GetID()
+			tab, err := descriptors.GetMutableTableByID(ctx, txn, id, tree.ObjectLookupFlagsWithRequired())
+			if err != nil {
+				return err
+			}
+			builder := tabledesc.NewBuilder(getDeprecatedDescriptor())
+			require.NoError(t, builder.RunPostDeserializationChanges(ctx, nil))
+			tab.TableDescriptor = builder.BuildCreatedMutableTable().TableDescriptor
+			tab.Version = tab.ClusterVersion.Version + 1
+			return descriptors.WriteDesc(ctx, false /* kvTrace */, tab, txn)
+		})
+	require.NoError(t, err)
+}
+
+// ValidateSchemaExists validates whether the schema changes of the system table exist or not.
+func ValidateSchemaExists(
+	ctx context.Context,
+	t *testing.T,
+	s serverutils.TestServerInterface,
+	sqlDB *gosql.DB,
+	storedTableID descpb.ID,
+	expectedTable catalog.TableDescriptor,
+	stmts []string,
+	schemas []Schema,
+	expectExists bool,
+) {
+	// First validate by reading the columns and the index.
+	for _, stmt := range stmts {
+		_, err := sqlDB.Exec(stmt)
+		if expectExists {
+			require.NoError(
+				t, err, "expected schema to exist, but unable to query it, using statement: %s", stmt,
+			)
+		} else {
+			require.Error(
+				t, err, "expected schema to not exist, but queried it successfully, using statement: %s", stmt,
+			)
+		}
+	}
+
+	// Manually verify the table descriptor.
+	storedTable := GetTable(ctx, t, s, storedTableID)
+	str := "not have"
+	if expectExists {
+		str = "have"
+	}
+	for _, schema := range schemas {
+		updated, err := schema.ValidationFn(storedTable, expectedTable, schema.Name)
+		require.NoError(t, err)
+		require.Equal(t, expectExists, updated,
+			"expected table to %s %s", str, schema)
+	}
+}
+
+// GetTable returns the system table descriptor, reading it from storage.
+func GetTable(
+	ctx context.Context, t *testing.T, s serverutils.TestServerInterface, tableID descpb.ID,
+) catalog.TableDescriptor {
+	var table catalog.TableDescriptor
+	// Retrieve the table.
+	err := s.CollectionFactory().(*descs.CollectionFactory).Txn(
+		ctx,
+		s.InternalExecutor().(sqlutil.InternalExecutor),
+		s.DB(),
+		func(ctx context.Context, txn *kv.Txn, descriptors *descs.Collection) (err error) {
+			table, err = descriptors.GetImmutableTableByID(ctx, txn, tableID, tree.ObjectLookupFlags{
+				CommonLookupFlags: tree.CommonLookupFlags{
+					AvoidCached: true,
+					Required:    true,
+				},
+			})
+			return err
+		})
+	require.NoError(t, err)
+	return table
+}

--- a/pkg/migration/migrations/migrations.go
+++ b/pkg/migration/migrations/migrations.go
@@ -133,6 +133,12 @@ var migrations = []migration.Migration{
 		NoPrecondition,
 		spanConfigurationsTableMigration,
 	),
+	migration.NewTenantMigration(
+		"create indexes on revokedAt and lastUsedAt columns from system.web_sessions",
+		toCV(clusterversion.AlterSystemWebSessionsCreateIndexes),
+		NoPrecondition,
+		alterSystemWebSessionsCreateIndexes,
+	),
 }
 
 func init() {

--- a/pkg/migration/migrations/retry_jobs_with_exponential_backoff.go
+++ b/pkg/migration/migrations/retry_jobs_with_exponential_backoff.go
@@ -11,28 +11,13 @@
 package migrations
 
 import (
-	"bytes"
 	"context"
-	"fmt"
-	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
-	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
-	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/migration"
-	"github.com/cockroachdb/cockroach/pkg/security"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
-	"github.com/cockroachdb/errors"
-	"github.com/kr/pretty"
 )
 
 // Target schema changes in the system.jobs table, adding two columns and an
@@ -54,234 +39,23 @@ CREATE INDEX jobs_run_stats_idx
 func retryJobsWithExponentialBackoff(
 	ctx context.Context, cs clusterversion.ClusterVersion, d migration.TenantDeps, _ *jobs.Job,
 ) error {
-	jobsTable := systemschema.JobsTable
-	ops := [...]struct {
-		// Operation name.
-		name string
-		// List of schema names, e.g., column names, which are modified in the query.
-		schemaList []string
-		// Schema change query.
-		query string
-		// Function to check existing schema.
-		schemaExistsFn func(catalog.TableDescriptor, catalog.TableDescriptor, string) (bool, error)
-	}{
-		{"jobs-add-columns", []string{"num_runs", "last_run"}, addColsQuery, hasColumn},
-		{"jobs-add-index", []string{"jobs_run_stats_idx"}, addIndexQuery, hasIndex},
-	}
-	for _, op := range ops {
-		if err := migrateTable(ctx, cs, d, op.name, keys.JobsTableID, op.query,
-			func(storedTable catalog.TableDescriptor) (bool, error) {
-				// Expect all or none.
-				var exists bool
-				for i, schemaName := range op.schemaList {
-					hasSchema, err := op.schemaExistsFn(storedTable, jobsTable, schemaName)
-					if err != nil {
-						return false, err
-					}
-					if i > 0 && exists != hasSchema {
-						return false, errors.Errorf("observed partial schema exists while performing %v", op.name)
-					}
-					exists = hasSchema
-				}
-				return exists, nil
-			}); err != nil {
+	for _, op := range []operation{
+		{
+			name:           "jobs-add-columns",
+			schemaList:     []string{"num_runs", "last_run"},
+			query:          addColsQuery,
+			schemaExistsFn: hasColumn,
+		},
+		{
+			name:           "jobs-add-index",
+			schemaList:     []string{"jobs_run_stats_idx"},
+			query:          addIndexQuery,
+			schemaExistsFn: hasIndex,
+		},
+	} {
+		if err := migrateTable(ctx, cs, d, op, keys.JobsTableID, systemschema.JobsTable); err != nil {
 			return err
 		}
 	}
 	return nil
-}
-
-// migrateTable is run during a migration to a new version and changes an existing
-// table's schema based on schemaChangeQuery. The schema-change is ignored if the
-// table already has the required changes.
-//
-// This function reads the existing table descriptor from storage and passes it
-// to schemaExists function to verify whether the schema-change already exists or
-// not. If the change is already done, the function does not perform the change
-// again, which makes migrateTable idempotent.
-//
-// schemaExists function should be customized based on the table being modified,
-// ignoring the fields in the descriptor that do not
-//
-// If multiple changes are done in the same query, e.g., if multiple columns are
-// added, the function should check all changes to exist or absent, returning
-// an error if changes exist partially.
-func migrateTable(
-	ctx context.Context,
-	_ clusterversion.ClusterVersion,
-	d migration.TenantDeps,
-	opTag string,
-	tableID descpb.ID,
-	schemaChangeQuery string,
-	schemaExists func(descriptor catalog.TableDescriptor) (bool, error),
-) error {
-	for {
-		// - Fetch the table, reading its descriptor from storage.
-		// - Check if any mutation jobs exist for the table. These mutations can
-		//   belong to a previous migration attempt that failed.
-		// - If any mutation job exists:
-		//   - Wait for the ongoing mutations to complete.
-		// 	 - Continue to the beginning of the loop to cater for the mutations
-		//	   that may have started while waiting for existing mutations to complete.
-		// - Check if the intended schema-changes already exist.
-		//   - If the changes already exist, skip the schema-change and return as
-		//     the changes are already done in a previous migration attempt.
-		//   - Otherwise, perform the schema-change and return.
-
-		log.Infof(ctx, "performing table migration operation %v", opTag)
-		// Retrieve the table.
-		jt, err := readTableDescriptor(ctx, d, tableID)
-		if err != nil {
-			return err
-		}
-		// Wait for any in-flight schema changes to complete.
-		if mutations := jt.GetMutationJobs(); len(mutations) > 0 {
-			for _, mutation := range mutations {
-				log.Infof(ctx, "waiting for the mutation job %v to complete", mutation.JobID)
-				if d.TestingKnobs.BeforeWaitInRetryJobsWithExponentialBackoffMigration != nil {
-					d.TestingKnobs.BeforeWaitInRetryJobsWithExponentialBackoffMigration(jobspb.JobID(mutation.JobID))
-				}
-				if _, err := d.InternalExecutor.Exec(ctx, "migration-mutations-wait",
-					nil, "SHOW JOB WHEN COMPLETE $1", mutation.JobID); err != nil {
-					return err
-				}
-			}
-			continue
-		}
-
-		// Ignore the schema change if the table already has the required schema.
-		if ok, err := schemaExists(jt); err != nil {
-			return errors.Wrapf(err, "error while validating descriptors during"+
-				" operation %s", opTag)
-		} else if ok {
-			log.Infof(ctx, "skipping %s operation as the schema change already exists.", opTag)
-			if d.TestingKnobs != nil && d.TestingKnobs.SkippedMutation != nil {
-				d.TestingKnobs.SkippedMutation()
-			}
-			return nil
-		}
-
-		// Modify the table.
-		log.Infof(ctx, "performing operation: %s", opTag)
-		if _, err := d.InternalExecutor.ExecEx(
-			ctx,
-			fmt.Sprintf("migration-alter-table-%d", tableID),
-			nil, /* txn */
-			sessiondata.InternalExecutorOverride{User: security.NodeUserName()},
-			schemaChangeQuery); err != nil {
-			return err
-		}
-		return nil
-	}
-}
-
-func readTableDescriptor(
-	ctx context.Context, d migration.TenantDeps, tableID descpb.ID,
-) (catalog.TableDescriptor, error) {
-	var jt catalog.TableDescriptor
-
-	if err := d.CollectionFactory.Txn(ctx, d.InternalExecutor, d.DB, func(
-		ctx context.Context, txn *kv.Txn, descriptors *descs.Collection,
-	) (err error) {
-		jt, err = descriptors.GetImmutableTableByID(ctx, txn, tableID, tree.ObjectLookupFlags{
-			CommonLookupFlags: tree.CommonLookupFlags{
-				AvoidCached: true,
-				Required:    true,
-			},
-		})
-		return err
-	}); err != nil {
-		return nil, err
-	}
-	return jt, nil
-}
-
-// hasColumn returns true if storedTable already has the given column, comparing
-// with expectedTable.
-// storedTable descriptor must be read from system storage as compared to reading
-// from the systemschema package. On the contrary, expectedTable must be accessed
-// directly from systemschema package.
-// This function returns an error if the column exists but doesn't match with the
-// expectedTable descriptor. The comparison is not strict as several descriptor
-// fields are ignored.
-func hasColumn(storedTable, expectedTable catalog.TableDescriptor, colName string) (bool, error) {
-	storedCol, err := storedTable.FindColumnWithName(tree.Name(colName))
-	if err != nil {
-		if strings.Contains(err.Error(), "does not exist") {
-			return false, nil
-		}
-		return false, err
-	}
-
-	expectedCol, err := expectedTable.FindColumnWithName(tree.Name(colName))
-	if err != nil {
-		return false, errors.Wrapf(err, "columns name %s is invalid.", colName)
-	}
-
-	expectedCopy := expectedCol.ColumnDescDeepCopy()
-	storedCopy := storedCol.ColumnDescDeepCopy()
-
-	storedCopy.ID = 0
-	expectedCopy.ID = 0
-
-	if err = ensureProtoMessagesAreEqual(&expectedCopy, &storedCopy); err != nil {
-		return false, err
-	}
-	return true, nil
-}
-
-// hasIndex returns true if storedTable already has the given index, comparing
-// with expectedTable.
-// storedTable descriptor must be read from system storage as compared to reading
-// from the systemschema package. On the contrary, expectedTable must be accessed
-// directly from systemschema package.
-// This function returns an error if the index exists but doesn't match with the
-// expectedTable descriptor. The comparison is not strict as several descriptor
-// fields are ignored.
-func hasIndex(storedTable, expectedTable catalog.TableDescriptor, indexName string) (bool, error) {
-	storedIdx, err := storedTable.FindIndexWithName(indexName)
-	if err != nil {
-		if strings.Contains(err.Error(), "does not exist") {
-			return false, nil
-		}
-		return false, err
-	}
-	expectedIdx, err := expectedTable.FindIndexWithName(indexName)
-	if err != nil {
-		return false, errors.Wrapf(err, "index name %s is invalid", indexName)
-	}
-	storedCopy := storedIdx.IndexDescDeepCopy()
-	expectedCopy := expectedIdx.IndexDescDeepCopy()
-	// Ignore the fields that don't matter in the comparison.
-	storedCopy.ID = 0
-	expectedCopy.ID = 0
-	storedCopy.Version = 0
-	expectedCopy.Version = 0
-	storedCopy.CreatedExplicitly = false
-	expectedCopy.CreatedExplicitly = false
-	storedCopy.StoreColumnIDs = []descpb.ColumnID{0, 0, 0}
-	expectedCopy.StoreColumnIDs = []descpb.ColumnID{0, 0, 0}
-
-	if err = ensureProtoMessagesAreEqual(&expectedCopy, &storedCopy); err != nil {
-		return false, err
-	}
-	return true, nil
-}
-
-// ensureProtoMessagesAreEqual verifies whether the given protobufs are equal or
-// not, returning an error if they are not equal.
-func ensureProtoMessagesAreEqual(expected, found protoutil.Message) error {
-	expectedBytes, err := protoutil.Marshal(expected)
-	if err != nil {
-		return err
-	}
-	foundBytes, err := protoutil.Marshal(found)
-	if err != nil {
-		return err
-	}
-	if bytes.Equal(expectedBytes, foundBytes) {
-		return nil
-	}
-	return errors.Errorf("expected descriptor doesn't match "+
-		"with found descriptor: %s", strings.Join(pretty.Diff(expected, found), "\n"))
 }

--- a/pkg/migration/migrations/schema_changes.go
+++ b/pkg/migration/migrations/schema_changes.go
@@ -1,0 +1,257 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package migrations
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/migration"
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
+	"github.com/kr/pretty"
+)
+
+type operation struct {
+	// Operation name.
+	name redact.RedactableString
+	// List of schema names, e.g., column names, which are modified in the query.
+	schemaList []string
+	// Schema change query.
+	query string
+	// Function to check existing schema.
+	schemaExistsFn func(catalog.TableDescriptor, catalog.TableDescriptor, string) (bool, error)
+}
+
+// migrateTable is run during a migration to a new version and changes an existing
+// table's schema based on schemaChangeQuery. The schema-change is ignored if the
+// table already has the required changes.
+//
+// This function reads the existing table descriptor from storage and passes it
+// to schemaExists function to verify whether the schema-change already exists or
+// not. If the change is already done, the function does not perform the change
+// again, which makes migrateTable idempotent.
+//
+// schemaExists function should be customized based on the table being modified,
+// ignoring the fields that do not matter while comparing with an existing descriptor.
+//
+// If multiple changes are done in the same query, e.g., if multiple columns are
+// added, the function should check all changes to exist or absent, returning
+// an error if changes exist partially.
+func migrateTable(
+	ctx context.Context,
+	_ clusterversion.ClusterVersion,
+	d migration.TenantDeps,
+	op operation,
+	storedTableID descpb.ID,
+	expectedTable catalog.TableDescriptor,
+) error {
+	for {
+		// - Fetch the table, reading its descriptor from storage.
+		// - Check if any mutation jobs exist for the table. These mutations can
+		//   belong to a previous migration attempt that failed.
+		// - If any mutation job exists:
+		//   - Wait for the ongoing mutations to complete.
+		// 	 - Continue to the beginning of the loop to cater for the mutations
+		//	   that may have started while waiting for existing mutations to complete.
+		// - Check if the intended schema-changes already exist.
+		//   - If the changes already exist, skip the schema-change and return as
+		//     the changes are already done in a previous migration attempt.
+		//   - Otherwise, perform the schema-change and return.
+
+		log.Infof(ctx, "performing table migration operation %v", op.name)
+
+		// Retrieve the table.
+		storedTable, err := readTableDescriptor(ctx, d, storedTableID)
+		if err != nil {
+			return err
+		}
+
+		// Wait for any in-flight schema changes to complete.
+		if mutations := storedTable.GetMutationJobs(); len(mutations) > 0 {
+			for _, mutation := range mutations {
+				log.Infof(ctx, "waiting for the mutation job %v to complete", mutation.JobID)
+				// TODO(cameron): Remove this knob conditional once the related migration code has been removed.
+				// See pkg/migration/testing_knobs.go for more details.
+				if d.TestingKnobs.BeforeWaitInRetryJobsWithExponentialBackoffMigration != nil {
+					d.TestingKnobs.BeforeWaitInRetryJobsWithExponentialBackoffMigration(jobspb.JobID(mutation.JobID))
+				}
+				if _, err := d.InternalExecutor.Exec(ctx, "migration-mutations-wait",
+					nil, "SHOW JOB WHEN COMPLETE $1", mutation.JobID); err != nil {
+					return err
+				}
+			}
+			continue
+		}
+
+		// Ignore the schema change if the table already has the required schema.
+		// Expect all or none.
+		var exists bool
+		for i, schemaName := range op.schemaList {
+			hasSchema, err := op.schemaExistsFn(storedTable, expectedTable, schemaName)
+			if err != nil {
+				return errors.Wrapf(err, "error while validating descriptors during"+
+					" operation %s", op.name)
+			}
+			if i > 0 && exists != hasSchema {
+				return errors.Errorf("error while validating descriptors. observed"+
+					" partial schema exists while performing %v", op.name)
+			}
+			exists = hasSchema
+		}
+		if exists {
+			log.Infof(ctx, "skipping %s operation as the schema change already exists.", op.name)
+			if d.TestingKnobs != nil && d.TestingKnobs.SkippedMutation != nil {
+				d.TestingKnobs.SkippedMutation()
+			}
+			return nil
+		}
+
+		// Modify the table.
+		log.Infof(ctx, "performing operation: %s", op.name)
+		if _, err := d.InternalExecutor.ExecEx(
+			ctx,
+			fmt.Sprintf("migration-alter-table-%d", storedTableID),
+			nil, /* txn */
+			sessiondata.InternalExecutorOverride{User: security.NodeUserName()},
+			op.query); err != nil {
+			return err
+		}
+		return nil
+	}
+}
+
+func readTableDescriptor(
+	ctx context.Context, d migration.TenantDeps, tableID descpb.ID,
+) (catalog.TableDescriptor, error) {
+	var t catalog.TableDescriptor
+
+	if err := d.CollectionFactory.Txn(ctx, d.InternalExecutor, d.DB, func(
+		ctx context.Context, txn *kv.Txn, descriptors *descs.Collection,
+	) (err error) {
+		t, err = descriptors.GetImmutableTableByID(ctx, txn, tableID, tree.ObjectLookupFlags{
+			CommonLookupFlags: tree.CommonLookupFlags{
+				AvoidCached: true,
+				Required:    true,
+			},
+		})
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	return t, nil
+}
+
+// ensureProtoMessagesAreEqual verifies whether the given protobufs are equal or
+// not, returning an error if they are not equal.
+func ensureProtoMessagesAreEqual(expected, found protoutil.Message) error {
+	expectedBytes, err := protoutil.Marshal(expected)
+	if err != nil {
+		return err
+	}
+	foundBytes, err := protoutil.Marshal(found)
+	if err != nil {
+		return err
+	}
+	if bytes.Equal(expectedBytes, foundBytes) {
+		return nil
+	}
+	return errors.Errorf("expected descriptor doesn't match "+
+		"with found descriptor: %s", strings.Join(pretty.Diff(expected, found), "\n"))
+}
+
+// hasColumn returns true if storedTable already has the given column, comparing
+// with expectedTable.
+// storedTable descriptor must be read from system storage as compared to reading
+// from the systemschema package. On the contrary, expectedTable must be accessed
+// directly from systemschema package.
+// This function returns an error if the column exists but doesn't match with the
+// expectedTable descriptor. The comparison is not strict as several descriptor
+// fields are ignored.
+func hasColumn(storedTable, expectedTable catalog.TableDescriptor, colName string) (bool, error) {
+	storedCol, err := storedTable.FindColumnWithName(tree.Name(colName))
+	if err != nil {
+		if strings.Contains(err.Error(), "does not exist") {
+			return false, nil
+		}
+		return false, err
+	}
+
+	expectedCol, err := expectedTable.FindColumnWithName(tree.Name(colName))
+	if err != nil {
+		return false, errors.Wrapf(err, "columns name %s is invalid.", colName)
+	}
+
+	expectedCopy := expectedCol.ColumnDescDeepCopy()
+	storedCopy := storedCol.ColumnDescDeepCopy()
+
+	storedCopy.ID = 0
+	expectedCopy.ID = 0
+
+	if err = ensureProtoMessagesAreEqual(&expectedCopy, &storedCopy); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// hasIndex returns true if storedTable already has the given index, comparing
+// with expectedTable.
+// storedTable descriptor must be read from system storage as compared to reading
+// from the systemschema package. On the contrary, expectedTable must be accessed
+// directly from systemschema package.
+// This function returns an error if the index exists but doesn't match with the
+// expectedTable descriptor. The comparison is not strict as several descriptor
+// fields are ignored.
+func hasIndex(storedTable, expectedTable catalog.TableDescriptor, indexName string) (bool, error) {
+	storedIdx, err := storedTable.FindIndexWithName(indexName)
+	if err != nil {
+		if strings.Contains(err.Error(), "does not exist") {
+			return false, nil
+		}
+		return false, err
+	}
+	expectedIdx, err := expectedTable.FindIndexWithName(indexName)
+	if err != nil {
+		return false, errors.Wrapf(err, "index name %s is invalid", indexName)
+	}
+	storedCopy := storedIdx.IndexDescDeepCopy()
+	expectedCopy := expectedIdx.IndexDescDeepCopy()
+	// Ignore the fields that don't matter in the comparison.
+	storedCopy.ID = 0
+	expectedCopy.ID = 0
+	storedCopy.Version = 0
+	expectedCopy.Version = 0
+	// CreatedExplicitly is an ignored field because there exists an inconsistency
+	// between CREATE TABLE (... INDEX) and CREATE INDEX.
+	// See https://github.com/cockroachdb/cockroach/issues/65929.
+	storedCopy.CreatedExplicitly = false
+	expectedCopy.CreatedExplicitly = false
+	storedCopy.StoreColumnIDs = []descpb.ColumnID{0, 0, 0}
+	expectedCopy.StoreColumnIDs = []descpb.ColumnID{0, 0, 0}
+
+	if err = ensureProtoMessagesAreEqual(&expectedCopy, &storedCopy); err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/pkg/server/purge_auth_session.go
+++ b/pkg/server/purge_auth_session.go
@@ -15,6 +15,7 @@ import (
 	math_rand "math/rand"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -65,7 +66,10 @@ func startPurgeOldSessions(ctx context.Context, s *authenticationServer) error {
 			select {
 			case <-timer.C:
 				timer.Read = true
-				s.purgeOldSessions(ctx)
+				// TODO(cameron): Remove this version gate once the web sessions migration code has been removed.
+				if s.server.cfg.Settings.Version.IsActive(ctx, clusterversion.AlterSystemWebSessionsCreateIndexes) {
+					s.purgeOldSessions(ctx)
+				}
 			case <-s.server.stopper.ShouldQuiesce():
 				return
 			case <-ctx.Done():

--- a/pkg/startupmigrations/BUILD.bazel
+++ b/pkg/startupmigrations/BUILD.bazel
@@ -55,7 +55,6 @@ go_test(
         "//pkg/server",
         "//pkg/sql",
         "//pkg/sql/catalog/catalogkeys",
-        "//pkg/sql/catalog/catalogkv",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/systemschema",
         "//pkg/sql/catalog/tabledesc",

--- a/pkg/startupmigrations/migrations.go
+++ b/pkg/startupmigrations/migrations.go
@@ -300,12 +300,6 @@ var backwardCompatibleMigrations = []migrationDescriptor{
 		// Introduced in v20.2.
 		name: "mark non-terminal schema change jobs with a pre-20.1 format version as failed",
 	},
-	{
-		// Introduced in v21.2.
-		name:                "add indexes on columns revokedAt and lastUsedAt for system.web_sessions table",
-		workFn:              alterSystemWebSessionsCreateIndexes,
-		includedInBootstrap: clusterversion.ByKey(clusterversion.AlterSystemWebSessionsCreateIndexes),
-	},
 }
 
 func staticIDs(
@@ -968,27 +962,4 @@ func updateSystemLocationData(ctx context.Context, r runner) error {
 		}
 	}
 	return nil
-}
-
-func alterSystemWebSessionsCreateIndexes(ctx context.Context, r runner) (err error) {
-	addIdxRevokedAtStmt := `
-CREATE INDEX IF NOT EXISTS "web_sessions_revokedAt_idx" 
-ON system.web_sessions ("revokedAt")
-`
-	addIdxLastUsedAtStmt := `
-CREATE INDEX IF NOT EXISTS "web_sessions_lastUsedAt_idx" 
-ON system.web_sessions ("lastUsedAt")
-`
-
-	asNode := sessiondata.InternalExecutorOverride{
-		User: security.NodeUserName(),
-	}
-
-	if _, err = r.sqlExecutor.ExecEx(ctx, "add-web-sessions-revoked-at-idx", nil /* txn */, asNode, addIdxRevokedAtStmt); err != nil {
-		return err
-	}
-
-	_, err = r.sqlExecutor.ExecEx(ctx, "add-web-sessions-last-used-at-idx", nil /* txn */, asNode, addIdxLastUsedAtStmt)
-
-	return err
 }

--- a/pkg/startupmigrations/migrations_test.go
+++ b/pkg/startupmigrations/migrations_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
@@ -752,66 +751,4 @@ func TestUpdateSystemLocationData(t *testing.T) {
 	if count != len(roachpb.DefaultLocationInformation) {
 		t.Fatalf("Exected to find 0 rows in system.locations. Found  %d instead", count)
 	}
-}
-
-func TestAlterSystemWebSessionsTable(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	ctx := context.Background()
-
-	// oldWebSessionsTableSchema is the system.web_sessions definition prior to 21.2 (without newly added indexes)
-	// It is used in order to test migration.
-	oldWebSessionsTableSchema := `
-CREATE TABLE system.web_sessions (
-	id             INT8       NOT NULL DEFAULT unique_rowid() PRIMARY KEY,
-	"hashedSecret" BYTES      NOT NULL,
-	username       STRING     NOT NULL,
-	"createdAt"    TIMESTAMP  NOT NULL DEFAULT now(),
-	"expiresAt"    TIMESTAMP  NOT NULL,
-	"revokedAt"    TIMESTAMP,
-	"lastUsedAt"   TIMESTAMP  NOT NULL DEFAULT now(),
-	"auditInfo"    STRING,
-	INDEX ("expiresAt"),
-	INDEX ("createdAt"),
-	FAMILY (id, "hashedSecret", username, "createdAt", "expiresAt", "revokedAt", "lastUsedAt", "auditInfo")
-)
-`
-	oldWebSessionsTable, err := sql.CreateTestTableDescriptor(
-		context.Background(),
-		keys.SystemDatabaseID,
-		systemschema.WebSessionsTable.GetID(),
-		oldWebSessionsTableSchema,
-		systemschema.WebSessionsTable.GetPrivileges(),
-	)
-	require.NoError(t, err)
-
-	// Sanity check oldWebSessionsTable does not have new indexes.
-	require.Equal(t, 2, len(oldWebSessionsTable.Indexes))
-
-	webSessionsTable := systemschema.WebSessionsTable
-	systemschema.WebSessionsTable = oldWebSessionsTable
-	defer func() {
-		systemschema.WebSessionsTable = webSessionsTable
-	}()
-
-	mt := makeMigrationTest(ctx, t)
-	defer mt.close(ctx)
-
-	migration := mt.pop(t, "add indexes on columns revokedAt and lastUsedAt for system.web_sessions table")
-	mt.start(t, base.TestServerArgs{})
-
-	// Run migration and verify we have added indexes.
-	require.NoError(t, mt.runMigration(ctx, migration))
-
-	newWebSessionsTable := catalogkv.TestingGetTableDescriptor(
-		mt.kvDB, keys.SystemSQLCodec, "system", "web_sessions")
-	indexes := newWebSessionsTable.AllIndexes()
-	require.Equal(t, 5, len(indexes))
-	require.Equal(t, "web_sessions_revokedAt_idx", indexes[3].GetName())
-	require.Equal(t, "web_sessions_lastUsedAt_idx", indexes[4].GetName())
-
-	// Run the migration again and verify that the result is the same.
-	require.NoError(t, mt.runMigration(ctx, migration))
-	newWebSessionsTableAgain := catalogkv.TestingGetTableDescriptor(
-		mt.kvDB, keys.SystemSQLCodec, "system", "web_sessions")
-	require.True(t, newWebSessionsTable.TableDesc().Equal(newWebSessionsTableAgain.TableDesc()))
 }


### PR DESCRIPTION
Fixes [#69145](https://github.com/cockroachdb/cockroach/issues/69145).

`AlterSystemWebSessionsCreateIndexes` is a startup migration yet it creates 
indexes on potentially large tables. This might cause significant time delays and 
lead to other issues. This patch makes this migration long-running. 

Release note (bug fix): The `AlterSystemWebSessionsCreateIndexes` migration 
is now async in case there are large tables it creates indexes over. 

Release justification: bug fix