### PR TITLE
sql: fix possible race for a telemetry counter

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -295,6 +295,7 @@ go_library(
         "//pkg/sql/catalog/systemschema",
         "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/catalog/typedesc",
+        "//pkg/sql/colexec",
         "//pkg/sql/colflow",
         "//pkg/sql/contention",
         "//pkg/sql/covering",

--- a/pkg/sql/colexec/external_hash_aggregator.go
+++ b/pkg/sql/colexec/external_hash_aggregator.go
@@ -106,10 +106,14 @@ func NewExternalHashAggregator(
 	return createDiskBackedSorter(eha, newAggArgs.OutputTypes, outputOrdering.Columns, maxNumberActivePartitions)
 }
 
+// HashAggregationDiskSpillingEnabledSettingName is the cluster setting name for
+// HashAggregationDiskSpillingEnabled.
+const HashAggregationDiskSpillingEnabledSettingName = "sql.distsql.temp_storage.hash_agg.enabled"
+
 // HashAggregationDiskSpillingEnabled is a cluster setting that allows to
 // disable hash aggregator disk spilling.
 var HashAggregationDiskSpillingEnabled = settings.RegisterBoolSetting(
-	"sql.distsql.temp_storage.hash_agg.enabled",
+	HashAggregationDiskSpillingEnabledSettingName,
 	"set to false to disable hash aggregator disk spilling "+
 		"(this will improve performance, but the query might hit the memory limit)",
 	true,

--- a/pkg/sql/distsql/BUILD.bazel
+++ b/pkg/sql/distsql/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
         "//pkg/roachpb:with-mocks",
         "//pkg/server/telemetry",
         "//pkg/sql/catalog/descs",
-        "//pkg/sql/colexec",
         "//pkg/sql/colflow",
         "//pkg/sql/execinfra",
         "//pkg/sql/execinfrapb",

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
-	"github.com/cockroachdb/cockroach/pkg/sql/colexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/colflow"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
@@ -92,12 +91,6 @@ func NewServer(
 	// right away, so the RPCs might start coming in pretty much right after the
 	// current method returns. See #66330.
 	ds.flowScheduler.Init(ds.Metrics)
-
-	colexec.HashAggregationDiskSpillingEnabled.SetOnChange(&cfg.Settings.SV, func(ctx context.Context) {
-		if !colexec.HashAggregationDiskSpillingEnabled.Get(&cfg.Settings.SV) {
-			telemetry.Inc(sqltelemetry.HashAggregationDiskSpillingDisabled)
-		}
-	})
 
 	return ds
 }

--- a/pkg/sql/set_cluster_setting.go
+++ b/pkg/sql/set_cluster_setting.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/paramparse"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -343,6 +344,10 @@ func (n *setClusterSettingNode) startExec(params runParams) error {
 				break
 			}
 			telemetry.Inc(sqltelemetry.VecModeCounter(validatedExecMode.String()))
+		case colexec.HashAggregationDiskSpillingEnabledSettingName:
+			if expectedEncodedValue == "false" {
+				telemetry.Inc(sqltelemetry.HashAggregationDiskSpillingDisabled)
+			}
 		}
 
 		return params.p.logEvent(ctx,


### PR DESCRIPTION
This commit fixes a possible race for the telemetry counter for when
`sql.distsql.temp_storage.hash_agg.enabled` cluster setting is set to
`false`.

Addresses: #61674.

Release note: None