### PR TITLE
changefeedccl: check compatibility between sinks and changefeed options

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -2704,6 +2704,11 @@ func TestChangefeedErrors(t *testing.T) {
 		t, `client has run out of available brokers`,
 		`CREATE CHANGEFEED FOR foo INTO 'kafka://nope/' WITH kafka_sink_config='{"Flush": {"Messages": 100, "Frequency": "1s"}}'`,
 	)
+	sqlDB.ExpectErr(
+		t, `this sink is incompatible with option webhook_client_timeout`,
+		`CREATE CHANGEFEED FOR foo INTO $1 WITH webhook_client_timeout=''`,
+		`kafka://nope/`,
+	)
 	// The avro format doesn't support key_in_value or topic_in_value yet.
 	sqlDB.ExpectErr(
 		t, `key_in_value is not supported with format=avro`,
@@ -2718,7 +2723,7 @@ func TestChangefeedErrors(t *testing.T) {
 
 	// The cloudStorageSink is particular about the options it will work with.
 	sqlDB.ExpectErr(
-		t, `this sink is incompatible with format=avro`,
+		t, `this sink is incompatible with option confluent_schema_registry`,
 		`CREATE CHANGEFEED FOR foo INTO $1 WITH format='avro', confluent_schema_registry=$2`,
 		`experimental-nodelocal://0/bar`, schemaReg.URL(),
 	)
@@ -2802,7 +2807,7 @@ func TestChangefeedErrors(t *testing.T) {
 		`CREATE CHANGEFEED FOR foo INTO $1`, `webhook-http://fake-host`,
 	)
 	sqlDB.ExpectErr(
-		t, `this sink is incompatible with format=avro`,
+		t, `this sink is incompatible with option confluent_schema_registry`,
 		`CREATE CHANGEFEED FOR foo INTO $1 WITH format='avro', confluent_schema_registry=$2`,
 		`webhook-https://fake-host`, schemaReg.URL(),
 	)
@@ -2855,6 +2860,11 @@ func TestChangefeedErrors(t *testing.T) {
 	sqlDB.ExpectErr(
 		t, `error unmarshalling json: invalid character`,
 		`CREATE CHANGEFEED FOR foo INTO $1 WITH webhook_sink_config='not json'`,
+		`webhook-https://fake-host`,
+	)
+	sqlDB.ExpectErr(
+		t, `this sink is incompatible with option compression`,
+		`CREATE CHANGEFEED FOR foo INTO $1 WITH compression='gzip'`,
 		`webhook-https://fake-host`,
 	)
 

--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -160,3 +160,33 @@ var ChangefeedOptionExpectValues = map[string]sql.KVStringOptValidate{
 	OptWebhookClientTimeout:     sql.KVStringOptRequireValue,
 	OptOnError:                  sql.KVStringOptRequireValue,
 }
+
+func makeStringSet(opts ...string) map[string]struct{} {
+	res := make(map[string]struct{}, len(opts))
+	for _, opt := range opts {
+		res[opt] = struct{}{}
+	}
+	return res
+}
+
+// CommonOptions is options common to all sinks
+var CommonOptions = makeStringSet(OptCursor, OptEnvelope,
+	OptFormat, OptFullTableName,
+	OptKeyInValue, OptTopicInValue,
+	OptResolvedTimestamps, OptUpdatedTimestamps,
+	OptMVCCTimestamps, OptDiff,
+	OptSchemaChangeEvents, OptSchemaChangePolicy,
+	OptProtectDataFromGCOnPause, OptOnError,
+	OptInitialScan, OptNoInitialScan)
+
+// SQLValidOptions is options exclusive to SQL sink
+var SQLValidOptions map[string]struct{} = nil
+
+// KafkaValidOptions is options exclusive to Kafka sink
+var KafkaValidOptions = makeStringSet(OptAvroSchemaPrefix, OptConfluentSchemaRegistry, OptKafkaSinkConfig)
+
+// CloudStorageValidOptions is options exclusive to cloud storage sink
+var CloudStorageValidOptions = makeStringSet(OptCompression)
+
+// WebhookValidOptions is options exclusive to webhook sink
+var WebhookValidOptions = makeStringSet(OptWebhookAuthHeader, OptWebhookClientTimeout, OptWebhookSinkConfig)


### PR DESCRIPTION
Add checks for option compatibility with sinks (separated into global
options and sink-specific options).

Also converted the avro encoder tests to use Kafka sink, removes the
need to create separate schema registries and convert Avro payloads to
JSON within tests, since Kafka testfeed does this automatically.

Resolves cockroachdb#68647

Release note (enterprise change): Changefeeds will now error if an
option is used with an incompatible sink.