### PR TITLE
storage: wire up pebble key validation func

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
@@ -39,7 +39,7 @@ import (
 
 var engineImpls = []struct {
 	name   string
-	create func() storage.Engine
+	create func(...storage.ConfigOption) storage.Engine
 }{
 	{"pebble", storage.NewDefaultInMemForTesting},
 }

--- a/pkg/storage/in_mem.go
+++ b/pkg/storage/in_mem.go
@@ -45,8 +45,8 @@ func InMemFromFS(ctx context.Context, fs vfs.FS, dir string, opts ...ConfigOptio
 // NewDefaultInMemForTesting allocates and returns a new, opened in-memory engine with
 // the default configuration. The caller must call the engine's Close method
 // when the engine is no longer needed.
-func NewDefaultInMemForTesting() Engine {
-	eng, err := Open(context.Background(), InMemory(), ForTesting, MaxSize(1<<20))
+func NewDefaultInMemForTesting(opts ...ConfigOption) Engine {
+	eng, err := Open(context.Background(), InMemory(), ForTesting, MaxSize(1<<20), CombineOptions(opts...))
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -79,8 +79,8 @@ var (
 )
 
 // createTestPebbleEngine returns a new in-memory Pebble storage engine.
-func createTestPebbleEngine() Engine {
-	return NewDefaultInMemForTesting()
+func createTestPebbleEngine(opts ...ConfigOption) Engine {
+	return NewDefaultInMemForTesting(opts...)
 }
 
 // TODO(sumeer): the following is legacy from when we had multiple engine
@@ -89,7 +89,7 @@ func createTestPebbleEngine() Engine {
 // the rest and remove this.
 var mvccEngineImpls = []struct {
 	name   string
-	create func() Engine
+	create func(opts ...ConfigOption) Engine
 }{
 	{"pebble", createTestPebbleEngine},
 }

--- a/pkg/storage/temp_engine.go
+++ b/pkg/storage/temp_engine.go
@@ -81,6 +81,7 @@ func newPebbleTempEngine(
 			cfg.Opts.Comparer = pebble.DefaultComparer
 			cfg.Opts.DisableWAL = true
 			cfg.Opts.TablePropertyCollectors = nil
+			cfg.Opts.Experimental.KeyValidationFunc = nil
 			return nil
 		},
 	)


### PR DESCRIPTION
To guard against invalid keys being written to the storage engine, make
use of the experimental `KeyValidationFunc` Pebble option. The
validation func checks that the key can be decoded as an `EngineKey` in
addition to also being a valid `MVCCKey` (i.e. the engine key version
has a valid version length).

See cockroachdb/pebble#1202.

Release note: None