### PR TITLE
bazel: bump size of `kvtenantccl` test

### DIFF
--- a/pkg/ccl/kvccl/kvtenantccl/BUILD.bazel
+++ b/pkg/ccl/kvccl/kvtenantccl/BUILD.bazel
@@ -32,7 +32,7 @@ go_library(
 
 go_test(
     name = "kvtenantccl_test",
-    size = "small",
+    size = "medium",
     srcs = [
         "connector_test.go",
         "main_test.go",


### PR DESCRIPTION
This has timed out in CI: https://teamcity.cockroachdb.com/buildConfiguration/Cockroach_UnitTests_BazelUnitTests/3328294?buildTab=tests
Release note: None