### PR TITLE
dev: standardize short flag for test targets

### DIFF
--- a/build/teamcity-support.sh
+++ b/build/teamcity-support.sh
@@ -4,6 +4,7 @@
 root="$(dirname $(cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd ))"
 
 source "$root/build/teamcity-common-support.sh"
+source "$root/build/teamcity/util.sh"
 
 remove_files_on_exit() {
   rm -f ~/.ssh/id_rsa{,.pub}
@@ -284,18 +285,11 @@ tc_release_branch() {
   [[ "$TC_BUILD_BRANCH" == master || "$TC_BUILD_BRANCH" == release-* || "$TC_BUILD_BRANCH" == provisional_* ]]
 }
 
-tc_start_block() {
-  echo "##teamcity[blockOpened name='$1']"
-}
 
 if_tc() {
   if [[ "${TC_BUILD_ID-}" ]]; then
     "$@"
   fi
-}
-
-tc_end_block() {
-  echo "##teamcity[blockClosed name='$1']"
 }
 
 tc_prepare() {

--- a/build/teamcity/cockroach/ci/tests/bench.sh
+++ b/build/teamcity/cockroach/ci/tests/bench.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
+
+source "$dir/teamcity-support.sh"  # For $root
+source "$dir/teamcity-bazel-support.sh"  # For run_bazel
+
+tc_prepare
+
+tc_start_block "Run benchmark tests"
+run_bazel build/teamcity/cockroach/ci/tests/bench_impl.sh
+tc_end_block "Run benchmark tests"

--- a/build/teamcity/cockroach/ci/tests/bench_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/bench_impl.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
+source "$dir/teamcity/util.sh"
+
+# Enumerate test targets that have benchmarks.
+all_tests=$(bazel query 'kind(go_test, //pkg/...)' --output=label)
+pkgs=$(git grep -l '^func Benchmark' -- 'pkg/*_test.go' | rev | cut -d/ -f2- | rev | sort | uniq)
+targets=$(for pkg in $pkgs
+          do
+              pkg=$(echo $pkg | sed 's|^|\^//|' | sed 's|$|:|')
+              grep $pkg <<< $all_tests || true
+          done | sort | uniq)
+
+set -x
+# Run all tests serially.
+for target in $targets
+do
+    tc_start_block "Bench $target"
+    # We need the `test_sharding_strategy` flag or else the benchmarks will
+    # fail to run sharded tests like //pkg/ccl/importccl:importccl_test.
+    bazel run --config=test --config=crosslinux --test_sharding_strategy=disabled $target -- \
+          -test.bench=. -test.benchtime=1ns -test.short -test.run=-
+    tc_end_block "Bench $target"
+done

--- a/build/teamcity/util.sh
+++ b/build/teamcity/util.sh
@@ -1,0 +1,9 @@
+# Some common utilities also used by Bazel build configs.
+
+tc_start_block() {
+  echo "##teamcity[blockOpened name='$1']"
+}
+
+tc_end_block() {
+  echo "##teamcity[blockClosed name='$1']"
+}

--- a/pkg/cmd/dev/bench.go
+++ b/pkg/cmd/dev/bench.go
@@ -51,6 +51,7 @@ func (d *dev) bench(cmd *cobra.Command, pkgs []string) error {
 	benchesMap := make(map[string]bool)
 	for _, pkg := range pkgs {
 		pkg = strings.TrimPrefix(pkg, "//")
+		pkg = strings.TrimRight(pkg, "/")
 
 		if !strings.HasPrefix(pkg, "pkg/") {
 			return errors.Newf("malformed package %q, expecting %q", pkg, "pkg/{...}")
@@ -83,7 +84,12 @@ func (d *dev) bench(cmd *cobra.Command, pkgs []string) error {
 	var argsBase []string
 	// NOTE the --config=test here. It's very important we compile the test binary with the
 	// appropriate stuff (gotags, etc.)
-	argsBase = append(argsBase, "run", "--color=yes", "--experimental_convenience_symlinks=ignore", "--config=test")
+	argsBase = append(argsBase,
+		"run",
+		"--color=yes",
+		"--experimental_convenience_symlinks=ignore",
+		"--config=test",
+		"--test_sharding_strategy=disabled")
 	argsBase = append(argsBase, getConfigFlags()...)
 	argsBase = append(argsBase, mustGetRemoteCacheArgs(remoteCacheAddr)...)
 	if numCPUs != 0 {
@@ -95,7 +101,7 @@ func (d *dev) bench(cmd *cobra.Command, pkgs []string) error {
 		copy(args, argsBase)
 		base := filepath.Base(bench)
 		target := "//" + bench + ":" + base + "_test"
-		args = append(args, target, "--")
+		args = append(args, target, "--", "-test.run=-")
 		if filter == "" {
 			args = append(args, "-test.bench=.")
 		} else {

--- a/pkg/cmd/dev/bench.go
+++ b/pkg/cmd/dev/bench.go
@@ -42,6 +42,7 @@ func (d *dev) bench(cmd *cobra.Command, pkgs []string) error {
 	ctx := cmd.Context()
 	filter := mustGetFlagString(cmd, filterFlag)
 	timeout := mustGetFlagDuration(cmd, timeoutFlag)
+	short := mustGetFlagBool(cmd, shortFlag)
 
 	// Enumerate all benches to run.
 	if len(pkgs) == 0 {
@@ -109,6 +110,9 @@ func (d *dev) bench(cmd *cobra.Command, pkgs []string) error {
 		}
 		if timeout > 0 {
 			args = append(args, fmt.Sprintf("-test.timeout=%s", timeout.String()))
+		}
+		if short {
+			args = append(args, "-test.short", "-test.benchtime=1ns")
 		}
 		err := d.exec.CommandContextInheritingStdStreams(ctx, "bazel", args...)
 		if err != nil {

--- a/pkg/cmd/dev/lint.go
+++ b/pkg/cmd/dev/lint.go
@@ -12,8 +12,6 @@ package main
 
 import "github.com/spf13/cobra"
 
-const shortFlag = "short"
-
 // makeLintCmd constructs the subcommand used to run the specified linters.
 func makeLintCmd(runE func(cmd *cobra.Command, args []string) error) *cobra.Command {
 	lintCmd := &cobra.Command{
@@ -26,7 +24,6 @@ func makeLintCmd(runE func(cmd *cobra.Command, args []string) error) *cobra.Comm
 		RunE: runE,
 	}
 	addCommonTestFlags(lintCmd)
-	lintCmd.Flags().Bool(shortFlag, false, "run only short lints")
 	return lintCmd
 }
 

--- a/pkg/cmd/dev/test.go
+++ b/pkg/cmd/dev/test.go
@@ -23,8 +23,6 @@ const (
 	stressTarget = "@com_github_cockroachdb_stress//:stress"
 
 	// General testing flags.
-	filterFlag      = "filter"
-	timeoutFlag     = "timeout"
 	vFlag           = "verbose"
 	stressFlag      = "stress"
 	stressArgsFlag  = "stress-args"
@@ -86,6 +84,7 @@ func (d *dev) runUnitTest(cmd *cobra.Command, pkgs []string) error {
 	race := mustGetFlagBool(cmd, raceFlag)
 	filter := mustGetFlagString(cmd, filterFlag)
 	timeout := mustGetFlagDuration(cmd, timeoutFlag)
+	short := mustGetFlagBool(cmd, shortFlag)
 	ignoreCache := mustGetFlagBool(cmd, ignoreCacheFlag)
 	verbose := mustGetFlagBool(cmd, vFlag)
 
@@ -169,6 +168,9 @@ func (d *dev) runUnitTest(cmd *cobra.Command, pkgs []string) error {
 	}
 	if filter != "" {
 		args = append(args, fmt.Sprintf("--test_filter=%s", filter))
+	}
+	if short {
+		args = append(args, "--test_arg", "-test.short")
 	}
 	if verbose {
 		args = append(args, "--test_output", "all", "--test_arg", "-test.v")

--- a/pkg/cmd/dev/testdata/bench.txt
+++ b/pkg/cmd/dev/testdata/bench.txt
@@ -5,8 +5,8 @@ which cc
 readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 git grep -l ^func Benchmark -- pkg/util/*_test.go
-bazel run --color=yes --experimental_convenience_symlinks=ignore --config=test --config=dev //pkg/util:util_test -- -test.bench=.
-bazel run --color=yes --experimental_convenience_symlinks=ignore --config=test --config=dev //pkg/util/uuid:uuid_test -- -test.bench=.
+bazel run --color=yes --experimental_convenience_symlinks=ignore --config=test --test_sharding_strategy=disabled --config=dev //pkg/util:util_test -- -test.run=- -test.bench=.
+bazel run --color=yes --experimental_convenience_symlinks=ignore --config=test --test_sharding_strategy=disabled --config=dev //pkg/util/uuid:uuid_test -- -test.run=- -test.bench=.
 
 dev bench pkg/sql/parser --filter=BenchmarkParse
 ----
@@ -14,4 +14,4 @@ getenv PATH
 which cc
 readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-bazel run --color=yes --experimental_convenience_symlinks=ignore --config=test --config=dev //pkg/sql/parser:parser_test -- -test.bench=BenchmarkParse
+bazel run --color=yes --experimental_convenience_symlinks=ignore --config=test --test_sharding_strategy=disabled --config=dev //pkg/sql/parser:parser_test -- -test.run=- -test.bench=BenchmarkParse

--- a/pkg/cmd/dev/testdata/recording/bench.txt
+++ b/pkg/cmd/dev/testdata/recording/bench.txt
@@ -20,10 +20,10 @@ pkg/util/uuid/benchmark_fast_test.go
 pkg/util/uuid/codec_test.go
 pkg/util/uuid/generator_test.go
 
-bazel run --color=yes --experimental_convenience_symlinks=ignore --config=test --config=dev //pkg/util:util_test -- -test.bench=.
+bazel run --color=yes --experimental_convenience_symlinks=ignore --config=test --test_sharding_strategy=disabled --config=dev //pkg/util:util_test -- -test.run=- -test.bench=.
 ----
 
-bazel run --color=yes --experimental_convenience_symlinks=ignore --config=test --config=dev //pkg/util/uuid:uuid_test -- -test.bench=.
+bazel run --color=yes --experimental_convenience_symlinks=ignore --config=test --test_sharding_strategy=disabled --config=dev //pkg/util/uuid:uuid_test -- -test.run=- -test.bench=.
 ----
 
 getenv PATH
@@ -41,5 +41,5 @@ readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 ----
 
-bazel run --color=yes --experimental_convenience_symlinks=ignore --config=test --config=dev //pkg/sql/parser:parser_test -- -test.bench=BenchmarkParse
+bazel run --color=yes --experimental_convenience_symlinks=ignore --config=test --test_sharding_strategy=disabled --config=dev //pkg/sql/parser:parser_test -- -test.run=- -test.bench=BenchmarkParse
 ----

--- a/pkg/cmd/dev/util.go
+++ b/pkg/cmd/dev/util.go
@@ -26,6 +26,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Common testing flags.
+const (
+	filterFlag  = "filter"
+	timeoutFlag = "timeout"
+	shortFlag   = "short"
+)
+
 // To be turned on for tests. Turns off some deeper checks for reproducibility.
 var isTesting bool
 
@@ -114,6 +121,7 @@ func getConfigFlags() []string {
 func addCommonTestFlags(cmd *cobra.Command) {
 	cmd.Flags().StringP(filterFlag, "f", "", "run unit tests matching this regex")
 	cmd.Flags().Duration(timeoutFlag, 0*time.Minute, "timeout for test")
+	cmd.Flags().Bool(shortFlag, false, "run only short tests")
 }
 
 func (d *dev) ensureBinaryInPath(bin string) error {

--- a/pkg/sql/sem/tree/BUILD.bazel
+++ b/pkg/sql/sem/tree/BUILD.bazel
@@ -209,9 +209,10 @@ go_test(
         "type_name_test.go",
         "window_funcs_test.go",
     ],
-    data = glob(["testdata/**"]),
+    data = glob(["testdata/**"]) + ["//pkg/sql/parser:sql.y"],
     embed = [":tree"],
     deps = [
+        "//pkg/build/bazel",
         "//pkg/internal/rsg",
         "//pkg/kv",
         "//pkg/roachpb:with-mocks",

--- a/pkg/sql/sem/tree/format_test.go
+++ b/pkg/sql/sem/tree/format_test.go
@@ -17,6 +17,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/build/bazel"
 	"github.com/cockroachdb/cockroach/pkg/internal/rsg"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
@@ -433,7 +434,17 @@ func TestFormatPgwireText(t *testing.T) {
 // 1000 random statements.
 func BenchmarkFormatRandomStatements(b *testing.B) {
 	// Generate a bunch of random statements.
-	yBytes, err := ioutil.ReadFile(filepath.Join("..", "..", "parser", "sql.y"))
+	var runfile string
+	if bazel.BuiltWithBazel() {
+		var err error
+		runfile, err = bazel.Runfile("pkg/sql/parser/sql.y")
+		if err != nil {
+			panic(err)
+		}
+	} else {
+		runfile = filepath.Join("..", "..", "parser", "sql.y")
+	}
+	yBytes, err := ioutil.ReadFile(runfile)
 	if err != nil {
 		b.Fatalf("error reading grammar: %v", err)
 	}


### PR DESCRIPTION
(Only the first commit applies for this review, the other is from #69166.)

Now the `--short` flag works for `dev test`, `bench`, and `lint`, with
semantics that match up to the `Makefile`.

Release note: None