### PR TITLE
storage: refactor export request params into struct

### DIFF
--- a/pkg/ccl/storageccl/export.go
+++ b/pkg/ccl/storageccl/export.go
@@ -189,8 +189,17 @@ func evalExport(
 	var curSizeOfExportedSSTs int64
 	for start := args.Key; start != nil; {
 		destFile := &storage.MemFile{}
-		summary, resume, resumeTS, err := reader.ExportMVCCToSst(ctx, start, args.EndKey, args.StartTime,
-			h.Timestamp, resumeKeyTS, exportAllRevisions, targetSize, maxSize, args.SplitMidKey, useTBI, destFile)
+		summary, resume, resumeTS, err := reader.ExportMVCCToSst(ctx, storage.ExportOptions{
+			StartKey:           storage.MVCCKey{Key: start, Timestamp: resumeKeyTS},
+			EndKey:             args.EndKey,
+			StartTS:            args.StartTime,
+			EndTS:              h.Timestamp,
+			ExportAllRevisions: exportAllRevisions,
+			TargetSize:         targetSize,
+			MaxSize:            maxSize,
+			StopMidKey:         args.SplitMidKey,
+			UseTBI:             useTBI,
+		}, destFile)
 		if err != nil {
 			if errors.HasType(err, (*storage.ExceedMaxSizeError)(nil)) {
 				err = errors.WithHintf(err,

--- a/pkg/ccl/storageccl/export_test.go
+++ b/pkg/ccl/storageccl/export_test.go
@@ -592,8 +592,17 @@ func assertEqualKVs(
 			prevStart := start
 			prevTs := resumeTs
 			sstFile := &storage.MemFile{}
-			summary, start, resumeTs, err = e.ExportMVCCToSst(ctx, start, endKey, startTime, endTime, resumeTs,
-				bool(exportAllRevisions), targetSize, maxSize, bool(stopMidKey), bool(enableTimeBoundIteratorOptimization), sstFile)
+			summary, start, resumeTs, err = e.ExportMVCCToSst(ctx, storage.ExportOptions{
+				StartKey:           storage.MVCCKey{Key: start, Timestamp: resumeTs},
+				EndKey:             endKey,
+				StartTS:            startTime,
+				EndTS:              endTime,
+				ExportAllRevisions: bool(exportAllRevisions),
+				TargetSize:         targetSize,
+				MaxSize:            maxSize,
+				StopMidKey:         bool(stopMidKey),
+				UseTBI:             bool(enableTimeBoundIteratorOptimization),
+			}, sstFile)
 			require.NoError(t, err)
 			sst = sstFile.Data()
 			loaded := loadSST(t, sst, startKey, endKey)
@@ -632,8 +641,17 @@ func assertEqualKVs(
 				if dataSizeWhenExceeded == maxSize {
 					maxSize--
 				}
-				_, _, _, err = e.ExportMVCCToSst(ctx, prevStart, endKey, startTime, endTime, prevTs,
-					bool(exportAllRevisions), targetSize, maxSize, false, bool(enableTimeBoundIteratorOptimization), &storage.MemFile{})
+				_, _, _, err = e.ExportMVCCToSst(ctx, storage.ExportOptions{
+					StartKey:           storage.MVCCKey{Key: prevStart, Timestamp: prevTs},
+					EndKey:             endKey,
+					StartTS:            startTime,
+					EndTS:              endTime,
+					ExportAllRevisions: bool(exportAllRevisions),
+					TargetSize:         targetSize,
+					MaxSize:            maxSize,
+					StopMidKey:         false,
+					UseTBI:             bool(enableTimeBoundIteratorOptimization),
+				}, &storage.MemFile{})
 				require.Regexp(t, fmt.Sprintf("export size \\(%d bytes\\) exceeds max size \\(%d bytes\\)",
 					dataSizeWhenExceeded, maxSize), err)
 			}

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -418,16 +418,9 @@ func (s spanSetReader) Closed() bool {
 
 // ExportMVCCToSst is part of the storage.Reader interface.
 func (s spanSetReader) ExportMVCCToSst(
-	ctx context.Context,
-	startKey, endKey roachpb.Key,
-	startTS, endTS, firstKeyTS hlc.Timestamp,
-	exportAllRevisions bool,
-	targetSize, maxSize uint64,
-	stopMidKey, useTBI bool,
-	dest io.Writer,
+	ctx context.Context, exportOptions storage.ExportOptions, dest io.Writer,
 ) (roachpb.BulkOpSummary, roachpb.Key, hlc.Timestamp, error) {
-	return s.r.ExportMVCCToSst(ctx, startKey, endKey, startTS, endTS, firstKeyTS, exportAllRevisions, targetSize,
-		maxSize, stopMidKey, useTBI, dest)
+	return s.r.ExportMVCCToSst(ctx, exportOptions, dest)
 }
 
 func (s spanSetReader) MVCCGet(key storage.MVCCKey) ([]byte, error) {

--- a/pkg/storage/bench_test.go
+++ b/pkg/storage/bench_test.go
@@ -1423,8 +1423,17 @@ func runExportToSst(
 	for i := 0; i < b.N; i++ {
 		startTS := hlc.Timestamp{WallTime: int64(numRevisions / 2)}
 		endTS := hlc.Timestamp{WallTime: int64(numRevisions + 2)}
-		_, _, _, err := engine.ExportMVCCToSst(context.Background(), keys.LocalMax, roachpb.KeyMax, startTS, endTS, hlc.Timestamp{},
-			exportAllRevisions, 0 /* targetSize */, 0 /* maxSize */, false, useTBI, noopWriter{})
+		_, _, _, err := engine.ExportMVCCToSst(context.Background(), ExportOptions{
+			StartKey:           MVCCKey{Key: keys.LocalMax},
+			EndKey:             roachpb.KeyMax,
+			StartTS:            startTS,
+			EndTS:              endTS,
+			ExportAllRevisions: exportAllRevisions,
+			TargetSize:         0,
+			MaxSize:            0,
+			StopMidKey:         false,
+			UseTBI:             useTBI,
+		}, noopWriter{})
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -357,6 +357,43 @@ const (
 	MVCCKeyIterKind
 )
 
+// ExportOptions contains options provided to export operation.
+type ExportOptions struct {
+	// StartKey determines start of the exported interval (inclusive).
+	// StartKey.Timestamp is either empty which represent starting from a potential
+	// intent and continuing to versions or non-empty, which represents starting
+	// from a particular version.
+	StartKey MVCCKey
+	// EndKey determines the end of exported interval (exclusive).
+	EndKey roachpb.Key
+	// StartTS and EndTS determine exported time range as (startTS, endTS].
+	StartTS, EndTS hlc.Timestamp
+	// If ExportAllRevisions is true export every revision of a key for the interval,
+	// otherwise only the latest value within the interval is exported.
+	ExportAllRevisions bool
+	// If TargetSize is positive, it indicates that the export should produce SSTs
+	// which are roughly target size. Specifically, it will return an SST such that
+	// the last key is responsible for meeting or exceeding the targetSize. If the
+	// resumeKey is non-nil then the data size of the returned sst will be greater
+	// than or equal to the targetSize.
+	TargetSize uint64
+	// If MaxSize is positive, it is an absolute maximum on byte size for the
+	// returned sst. If it is the case that the versions of the last key will lead
+	// to an SST that exceeds maxSize, an error will be returned. This parameter
+	// exists to prevent creating SSTs which are too large to be used.
+	MaxSize uint64
+	// If StopMidKey is false, once function reaches targetSize it would continue
+	// adding all versions until it reaches next key or end of range. If true, it
+	// would stop immediately when targetSize is reached and return the next versions
+	// timestamp in resumeTs so that subsequent operation can pass it to firstKeyTs.
+	StopMidKey bool
+	// If UseTBI is true, the backing MVCCIncrementalIterator will initialize a
+	// time-bound iterator along with its regular iterator. The TBI will be used
+	// as an optimization to skip over swaths of uninteresting keys i.e. keys
+	// outside our time bounds, while locating the KVs to export.
+	UseTBI bool
+}
+
 // Reader is the read interface to an engine's data. Certain implementations
 // of Reader guarantee consistency of the underlying engine state across the
 // different iterators created by NewMVCCIterator, NewEngineIterator:
@@ -382,39 +419,14 @@ type Reader interface {
 	// that they are not using a closed engine. Intended for use within package
 	// engine; exported to enable wrappers to exist in other packages.
 	Closed() bool
-	// ExportMVCCToSst exports changes to the keyrange [startKey, endKey) over the
-	// interval (startTS, endTS]. Passing exportAllRevisions exports
-	// every revision of a key for the interval, otherwise only the latest value
-	// within the interval is exported. Deletions are included if all revisions are
-	// requested or if the start.Timestamp is non-zero.
-	//
-	// firstKeyTS is either empty which represent starting from potential intent
-	// and continuing to versions or non-empty, which represents starting from
-	// particular version. firstKeyTS will always be empty when !stopMidKey
-	//
-	// If targetSize is positive, it indicates that the export should produce SSTs
-	// which are roughly target size. Specifically, it will return an SST such that
-	// the last key is responsible for meeting or exceeding the targetSize. If the
-	// resumeKey is non-nil then the data size of the returned sst will be greater
-	// than or equal to the targetSize.
-	//
-	// If maxSize is positive, it is an absolute maximum on byte size for the
-	// returned sst. If it is the case that the versions of the last key will lead
-	// to an SST that exceeds maxSize, an error will be returned. This parameter
-	// exists to prevent creating SSTs which are too large to be used.
-	//
-	// If stopMidKey is false, once function reaches targetSize it would continue
-	// adding all versions until it reaches next key or end of range. If true, it
-	// would stop immediately when targetSize is reached and return a next versions
-	// timestamp in resumeTs so that subsequent operation can pass it to firstKeyTs.
-	//
-	// If useTBI is true, the backing MVCCIncrementalIterator will initialize a
-	// time-bound iterator along with its regular iterator. The TBI will be used
-	// as an optimization to skip over swaths of uninteresting keys i.e. keys
-	// outside our time bounds, while locating the KVs to export.
-	//
+	// ExportMVCCToSst exports changes to the keyrange [StartKey, EndKey) over the
+	// interval (StartTS, EndTS].
+	// Deletions are included if all revisions are requested or if the StartTS
+	// is non-zero.
 	// This function looks at MVCC versions and intents, and returns an error if an
 	// intent is found.
+	// exportOptions determine ranges as well as additional export options. See
+	// struct definition for details.
 	//
 	// Data is written to dest as it is collected. If error is returned content of
 	// dest is undefined.
@@ -423,9 +435,7 @@ type Reader interface {
 	// that allow resuming export if it was cut short because it reached limits or
 	// an error if export failed for some reason.
 	ExportMVCCToSst(
-		ctx context.Context, startKey, endKey roachpb.Key, startTS, endTS, firstKeyTS hlc.Timestamp,
-		exportAllRevisions bool, targetSize uint64, maxSize uint64, stopMidKey bool, useTBI bool,
-		dest io.Writer,
+		ctx context.Context, exportOptions ExportOptions, dest io.Writer,
 	) (_ roachpb.BulkOpSummary, resumeKey roachpb.Key, resumeTS hlc.Timestamp, _ error)
 	// MVCCGet returns the value for the given key, nil otherwise. Semantically, it
 	// behaves as if an iterator with MVCCKeyAndIntentsIterKind was used.

--- a/pkg/storage/mvcc_incremental_iterator_test.go
+++ b/pkg/storage/mvcc_incremental_iterator_test.go
@@ -153,8 +153,17 @@ func assertExportedErrs(
 ) {
 	const big = 1 << 30
 	sstFile := &MemFile{}
-	_, _, _, err := e.ExportMVCCToSst(context.Background(), startKey, endKey, startTime, endTime, hlc.Timestamp{},
-		revisions, big, big, false, useTBI, sstFile)
+	_, _, _, err := e.ExportMVCCToSst(context.Background(), ExportOptions{
+		StartKey:           MVCCKey{Key: startKey},
+		EndKey:             endKey,
+		StartTS:            startTime,
+		EndTS:              endTime,
+		ExportAllRevisions: revisions,
+		TargetSize:         big,
+		MaxSize:            big,
+		StopMidKey:         false,
+		UseTBI:             useTBI,
+	}, sstFile)
 	require.Error(t, err)
 
 	if intentErr := (*roachpb.WriteIntentError)(nil); errors.As(err, &intentErr) {
@@ -182,8 +191,17 @@ func assertExportedKVs(
 ) {
 	const big = 1 << 30
 	sstFile := &MemFile{}
-	_, _, _, err := e.ExportMVCCToSst(context.Background(), startKey, endKey, startTime, endTime, hlc.Timestamp{},
-		revisions, big, big, false, useTBI, sstFile)
+	_, _, _, err := e.ExportMVCCToSst(context.Background(), ExportOptions{
+		StartKey:           MVCCKey{Key: startKey},
+		EndKey:             endKey,
+		StartTS:            startTime,
+		EndTS:              endTime,
+		ExportAllRevisions: revisions,
+		TargetSize:         big,
+		MaxSize:            big,
+		StopMidKey:         false,
+		UseTBI:             useTBI,
+	}, sstFile)
 	require.NoError(t, err)
 	data := sstFile.Data()
 	if data == nil {

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -705,21 +705,12 @@ func (p *Pebble) Closed() bool {
 
 // ExportMVCCToSst is part of the engine.Reader interface.
 func (p *Pebble) ExportMVCCToSst(
-	ctx context.Context,
-	startKey, endKey roachpb.Key,
-	startTS, endTS hlc.Timestamp,
-	firstKeyTS hlc.Timestamp,
-	exportAllRevisions bool,
-	targetSize, maxSize uint64,
-	stopMidKey bool,
-	useTBI bool,
-	dest io.Writer,
+	ctx context.Context, exportOptions ExportOptions, dest io.Writer,
 ) (roachpb.BulkOpSummary, roachpb.Key, hlc.Timestamp, error) {
 	r := wrapReader(p)
 	// Doing defer r.Free() does not inline.
 	maxIntentCount := MaxIntentsPerWriteIntentError.Get(&p.settings.SV)
-	summary, k, err := pebbleExportToSst(ctx, r, MVCCKey{Key: startKey, Timestamp: firstKeyTS}, endKey, startTS, endTS,
-		exportAllRevisions, targetSize, maxSize, stopMidKey, useTBI, dest, maxIntentCount)
+	summary, k, err := pebbleExportToSst(ctx, r, exportOptions, dest, maxIntentCount)
 	r.Free()
 	return summary, k.Key, k.Timestamp, err
 }
@@ -1474,21 +1465,12 @@ func (p *pebbleReadOnly) Closed() bool {
 
 // ExportMVCCToSst is part of the engine.Reader interface.
 func (p *pebbleReadOnly) ExportMVCCToSst(
-	ctx context.Context,
-	startKey, endKey roachpb.Key,
-	startTS, endTS hlc.Timestamp,
-	firstKeyTS hlc.Timestamp,
-	exportAllRevisions bool,
-	targetSize, maxSize uint64,
-	stopMidKey bool,
-	useTBI bool,
-	dest io.Writer,
+	ctx context.Context, exportOptions ExportOptions, dest io.Writer,
 ) (roachpb.BulkOpSummary, roachpb.Key, hlc.Timestamp, error) {
 	r := wrapReader(p)
 	// Doing defer r.Free() does not inline.
 	maxIntentCount := MaxIntentsPerWriteIntentError.Get(&p.parent.settings.SV)
-	summary, k, err := pebbleExportToSst(ctx, r, MVCCKey{Key: startKey, Timestamp: firstKeyTS}, endKey, startTS, endTS,
-		exportAllRevisions, targetSize, maxSize, stopMidKey, useTBI, dest, maxIntentCount)
+	summary, k, err := pebbleExportToSst(ctx, r, exportOptions, dest, maxIntentCount)
 	r.Free()
 	return summary, k.Key, k.Timestamp, err
 }
@@ -1746,21 +1728,12 @@ func (p *pebbleSnapshot) Closed() bool {
 
 // ExportMVCCToSst is part of the engine.Reader interface.
 func (p *pebbleSnapshot) ExportMVCCToSst(
-	ctx context.Context,
-	startKey, endKey roachpb.Key,
-	startTS, endTS hlc.Timestamp,
-	firstKeyTS hlc.Timestamp,
-	exportAllRevisions bool,
-	targetSize, maxSize uint64,
-	stopMidKey bool,
-	useTBI bool,
-	dest io.Writer,
+	ctx context.Context, exportOptions ExportOptions, dest io.Writer,
 ) (roachpb.BulkOpSummary, roachpb.Key, hlc.Timestamp, error) {
 	r := wrapReader(p)
 	// Doing defer r.Free() does not inline.
 	maxIntentCount := MaxIntentsPerWriteIntentError.Get(&p.settings.SV)
-	summary, k, err := pebbleExportToSst(ctx, r, MVCCKey{Key: startKey, Timestamp: firstKeyTS}, endKey, startTS, endTS,
-		exportAllRevisions, targetSize, maxSize, stopMidKey, useTBI, dest, maxIntentCount)
+	summary, k, err := pebbleExportToSst(ctx, r, exportOptions, dest, maxIntentCount)
 	r.Free()
 	return summary, k.Key, k.Timestamp, err
 }
@@ -1881,17 +1854,7 @@ func (e *ExceedMaxSizeError) Error() string {
 }
 
 func pebbleExportToSst(
-	ctx context.Context,
-	reader Reader,
-	startKey MVCCKey,
-	endKey roachpb.Key,
-	startTS, endTS hlc.Timestamp,
-	exportAllRevisions bool,
-	targetSize, maxSize uint64,
-	stopMidKey bool,
-	useTBI bool,
-	dest io.Writer,
-	maxIntentCount int64,
+	ctx context.Context, reader Reader, options ExportOptions, dest io.Writer, maxIntentCount int64,
 ) (roachpb.BulkOpSummary, MVCCKey, error) {
 	var span *tracing.Span
 	ctx, span = tracing.ChildSpan(ctx, "pebbleExportToSst")
@@ -1904,18 +1867,18 @@ func pebbleExportToSst(
 	iter := NewMVCCIncrementalIterator(
 		reader,
 		MVCCIncrementalIterOptions{
-			EndKey:                              endKey,
-			EnableTimeBoundIteratorOptimization: useTBI,
-			StartTime:                           startTS,
-			EndTime:                             endTS,
+			EndKey:                              options.EndKey,
+			EnableTimeBoundIteratorOptimization: options.UseTBI,
+			StartTime:                           options.StartTS,
+			EndTime:                             options.EndTS,
 			EnableWriteIntentAggregation:        true,
 		})
 	defer iter.Close()
 	var curKey roachpb.Key // only used if exportAllRevisions
 	var resumeKey roachpb.Key
 	var resumeTS hlc.Timestamp
-	paginated := targetSize > 0
-	for iter.SeekGE(startKey); ; {
+	paginated := options.TargetSize > 0
+	for iter.SeekGE(options.StartKey); ; {
 		ok, err := iter.Valid()
 		if err != nil {
 			// This is an underlying iterator error, return it to the caller to deal
@@ -1926,7 +1889,7 @@ func pebbleExportToSst(
 			break
 		}
 		unsafeKey := iter.UnsafeKey()
-		if unsafeKey.Key.Compare(endKey) >= 0 {
+		if unsafeKey.Key.Compare(options.EndKey) >= 0 {
 			break
 		}
 
@@ -1935,35 +1898,35 @@ func pebbleExportToSst(
 		}
 
 		unsafeValue := iter.UnsafeValue()
-		isNewKey := !exportAllRevisions || !unsafeKey.Key.Equal(curKey)
-		if paginated && exportAllRevisions && isNewKey {
+		isNewKey := !options.ExportAllRevisions || !unsafeKey.Key.Equal(curKey)
+		if paginated && options.ExportAllRevisions && isNewKey {
 			curKey = append(curKey[:0], unsafeKey.Key...)
 		}
 
 		// Skip tombstone (len=0) records when start time is zero (non-incremental)
 		// and we are not exporting all versions.
-		skipTombstones := !exportAllRevisions && startTS.IsEmpty()
+		skipTombstones := !options.ExportAllRevisions && options.StartTS.IsEmpty()
 		if len(unsafeValue) > 0 || !skipTombstones {
 			if err := rows.Count(unsafeKey.Key); err != nil {
 				return roachpb.BulkOpSummary{}, MVCCKey{}, errors.Wrapf(err, "decoding %s", unsafeKey)
 			}
 			curSize := rows.BulkOpSummary.DataSize
-			reachedTargetSize := curSize > 0 && uint64(curSize) >= targetSize
+			reachedTargetSize := curSize > 0 && uint64(curSize) >= options.TargetSize
 			newSize := curSize + int64(len(unsafeKey.Key)+len(unsafeValue))
-			reachedMaxSize := maxSize > 0 && newSize > int64(maxSize)
+			reachedMaxSize := options.MaxSize > 0 && newSize > int64(options.MaxSize)
 			// When paginating we stop writing in two cases:
 			// - target size is reached and we wrote all versions of a key
 			// - maximum size reached and we are allowed to stop mid key
-			if paginated && (isNewKey && reachedTargetSize || stopMidKey && reachedMaxSize) {
+			if paginated && (isNewKey && reachedTargetSize || options.StopMidKey && reachedMaxSize) {
 				// Allocate the right size for resumeKey rather than using curKey.
 				resumeKey = append(make(roachpb.Key, 0, len(unsafeKey.Key)), unsafeKey.Key...)
-				if stopMidKey && !isNewKey {
+				if options.StopMidKey && !isNewKey {
 					resumeTS = unsafeKey.Timestamp
 				}
 				break
 			}
 			if reachedMaxSize {
-				return roachpb.BulkOpSummary{}, MVCCKey{}, &ExceedMaxSizeError{reached: newSize, maxSize: maxSize}
+				return roachpb.BulkOpSummary{}, MVCCKey{}, &ExceedMaxSizeError{reached: newSize, maxSize: options.MaxSize}
 			}
 			if unsafeKey.Timestamp.IsEmpty() {
 				// This should never be an intent since the incremental iterator returns
@@ -1979,7 +1942,7 @@ func pebbleExportToSst(
 			rows.BulkOpSummary.DataSize = newSize
 		}
 
-		if exportAllRevisions {
+		if options.ExportAllRevisions {
 			iter.Next()
 		} else {
 			iter.NextKey()

--- a/pkg/storage/pebble_batch.go
+++ b/pkg/storage/pebble_batch.go
@@ -128,15 +128,7 @@ func (p *pebbleBatch) Closed() bool {
 
 // ExportMVCCToSst is part of the engine.Reader interface.
 func (p *pebbleBatch) ExportMVCCToSst(
-	ctx context.Context,
-	startKey, endKey roachpb.Key,
-	startTS, endTS hlc.Timestamp,
-	firstKeyTS hlc.Timestamp,
-	exportAllRevisions bool,
-	targetSize, maxSize uint64,
-	stopMidKey bool,
-	useTBI bool,
-	dest io.Writer,
+	ctx context.Context, exportOptions ExportOptions, dest io.Writer,
 ) (roachpb.BulkOpSummary, roachpb.Key, hlc.Timestamp, error) {
 	panic("unimplemented")
 }

--- a/pkg/storage/pebble_test.go
+++ b/pkg/storage/pebble_test.go
@@ -633,8 +633,17 @@ func TestSstExportFailureIntentBatching(t *testing.T) {
 			require.NoError(t, fillInData(ctx, engine, data))
 
 			destination := &MemFile{}
-			_, _, _, err := engine.ExportMVCCToSst(ctx, key(10), key(20000), ts(999), ts(2000), hlc.Timestamp{},
-				true, 0, 0, false, true, destination)
+			_, _, _, err := engine.ExportMVCCToSst(ctx, ExportOptions{
+				StartKey:           MVCCKey{Key: key(10)},
+				EndKey:             key(20000),
+				StartTS:            ts(999),
+				EndTS:              ts(2000),
+				ExportAllRevisions: true,
+				TargetSize:         0,
+				MaxSize:            0,
+				StopMidKey:         false,
+				UseTBI:             true,
+			}, destination)
 			if len(expectedIntentIndices) == 0 {
 				require.NoError(t, err)
 			} else {


### PR DESCRIPTION
Number of arguments to ExportMVCCToSst is too large. This diff moves
them into a struct to improve readability.

Release note: None