### PR TITLE
roachtest: re-enable cdc/bank

### DIFF
--- a/pkg/ccl/changefeedccl/cdctest/validator.go
+++ b/pkg/ccl/changefeedccl/cdctest/validator.go
@@ -56,8 +56,24 @@ type orderValidator struct {
 	failures []string
 }
 
+// NoOpValidator is a validator that does nothing. Useful for
+// composition.
+var NoOpValidator = &noOpValidator{}
+
 var _ Validator = &orderValidator{}
+var _ Validator = &noOpValidator{}
 var _ StreamValidator = &orderValidator{}
+
+type noOpValidator struct{}
+
+// NoteRow accepts a changed row entry.
+func (v *noOpValidator) NoteRow(string, string, string, hlc.Timestamp) error { return nil }
+
+// NoteResolved accepts a resolved timestamp entry.
+func (v *noOpValidator) NoteResolved(string, hlc.Timestamp) error { return nil }
+
+// Failures returns any violations seen so far.
+func (v *noOpValidator) Failures() []string { return nil }
 
 // NewOrderValidator returns a Validator that checks the row and resolved
 // timestamp ordering guarantees. It also asserts that keys have an affinity to


### PR DESCRIPTION
cdc/bank was disabled in #68167 because it timed out.  Unfortunately,
no logs were collected during the timeout.

I've run this many times locally and while it was slow it typically
completes much faster than the 60m timeout that it hit in CI.

However, one cause of slowness is that the validation we do is rather
expensive and we do it inline with reading messages from kafka. Until
we get to 100 verified resolved timestamps, we keep generating
workload traffic. But, this workload traffic makes it even harder to
do the expensive verification that is happening on the same machine.

To help with this a bit, we now read messages from kafka on one
go-routine and process them in another, with a large buffer between
them. The hope is that this will allow us to receive 100 resolved
timestamps and shut down the workload more quickly -- leaving more CPU
and disk to perform the validations.

I've also added a test-level timeout of 30 minutes. I believe if the
test times out in this way we are more likely to get logs. 30 minutes
is 3x longer than the longest time I've seen this test run locally
with the above changes.

Release note: None