### PR TITLE
storage: update min version with store cluster version

### DIFF
--- a/pkg/ccl/migrationccl/migrationsccl/records_based_registry_external_test.go
+++ b/pkg/ccl/migrationccl/migrationsccl/records_based_registry_external_test.go
@@ -121,7 +121,7 @@ func TestRecordsBasedRegistryMigration(t *testing.T) {
 		svr := tc.Server(0)
 		for _, eng := range svr.Engines() {
 			target := clusterversion.ByKey(clusterversion.RecordsBasedRegistry)
-			ok, err := eng.MinVersionIsAtLeastTargetVersion(&target)
+			ok, err := eng.MinVersionIsAtLeastTargetVersion(target)
 			require.NoError(t, err)
 			require.True(t, ok)
 			ok, err = eng.UsingRecordsEncryptionRegistry()

--- a/pkg/cli/interactive_tests/test_encryption.tcl
+++ b/pkg/cli/interactive_tests/test_encryption.tcl
@@ -21,6 +21,13 @@ proc file_has_size {filepath size} {
 	}
 }
 
+proc file_exists {filepath} {
+  if {! [ file exist $filepath]} {
+    report "MISSING EXPECTED FILE: $filepath"
+    exit 1
+  }
+}
+
 start_test "Generate encryption keys."
 send "mkdir -p $keydir\n"
 send "$argv gen encryption-key -s 128 $keydir/aes-128.key\r"
@@ -67,6 +74,7 @@ send "$argv start-single-node --insecure --store=$storedir --enterprise-encrypti
 eexpect "node starting"
 interrupt
 eexpect "shutdown completed"
+file_exists "$storedir/COCKROACHDB_ENCRYPTION_REGISTRY"
 send "$argv debug encryption-status $storedir --enterprise-encryption=path=$storedir,key=$keydir/aes-128.key,old-key=plain\r"
 eexpect "    \"Active\": true,\r\n    \"Type\": \"AES128_CTR\","
 # Try starting without the encryption flag.

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2936,7 +2936,29 @@ func (s *Store) getRootMemoryMonitorForKV() *mon.BytesMonitor {
 func WriteClusterVersion(
 	ctx context.Context, eng storage.Engine, cv clusterversion.ClusterVersion,
 ) error {
-	return storage.MVCCPutProto(ctx, eng, nil, keys.StoreClusterVersionKey(), hlc.Timestamp{}, nil, &cv)
+	err := storage.MVCCPutProto(ctx, eng, nil, keys.StoreClusterVersionKey(), hlc.Timestamp{}, nil, &cv)
+	if err != nil {
+		return err
+	}
+
+	// The storage engine sometimes must make backwards incompatible
+	// changes. However, the store cluster version key is a key stored
+	// within the storage engine, so it's unavailable when the store is
+	// opened.
+	//
+	// The storage engine maintains its own minimum version on disk that
+	// it may consult it before opening the Engine. This version is
+	// stored in a separate file on the filesystem. For now, write to
+	// this file in combination with the store cluster version key.
+	//
+	// This parallel version state is a bit of a wart and an eventual
+	// goal is to replace the store cluster version key with the storage
+	// engine's flat file. This requires that there are no writes to the
+	// engine until either bootstrapping or joining an existing cluster.
+	// Writing the version to this file would happen before opening the
+	// engine for completing the rest of bootstrapping/joining the
+	// cluster.
+	return eng.SetMinVersion(cv.Version)
 }
 
 // ReadClusterVersion reads the cluster version from the store-local version

--- a/pkg/server/migration.go
+++ b/pkg/server/migration.go
@@ -227,7 +227,7 @@ func (m *migrationServer) DeprecateBaseEncryptionRegistry(
 		m.server.node.waitForAdditionalStoreInit()
 
 		for _, eng := range m.server.engines {
-			if err := eng.DeprecateBaseEncryptionRegistry(req.Version); err != nil {
+			if err := eng.SetMinVersion(*req.Version); err != nil {
 				return err
 			}
 		}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1231,3 +1231,25 @@ func TestSQLDecommissioned(t *testing.T) {
 		return err != nil
 	}, 10*time.Second, 100*time.Millisecond, "timed out waiting for queries to error")
 }
+
+func TestAssertEnginesEmpty(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	eng, err := storage.Open(ctx, storage.InMemory())
+	require.NoError(t, err)
+	defer eng.Close()
+
+	require.NoError(t, assertEnginesEmpty([]storage.Engine{eng}))
+
+	require.NoError(t, storage.MVCCPutProto(ctx, eng, nil, keys.StoreClusterVersionKey(),
+		hlc.Timestamp{}, nil, &roachpb.Version{Major: 21, Minor: 1, Internal: 122}))
+	require.NoError(t, assertEnginesEmpty([]storage.Engine{eng}))
+
+	batch := eng.NewBatch()
+	key := storage.MVCCKey{[]byte{0xde, 0xad, 0xbe, 0xef}, hlc.Timestamp{WallTime: 100}}
+	require.NoError(t, batch.PutMVCC(key, []byte("foo")))
+	require.NoError(t, batch.Commit(false))
+	require.Error(t, assertEnginesEmpty([]storage.Engine{eng}))
+}

--- a/pkg/storage/BUILD.bazel
+++ b/pkg/storage/BUILD.bazel
@@ -150,7 +150,6 @@ go_test(
         "@com_github_cockroachdb_errors//oserror",
         "@com_github_cockroachdb_pebble//:pebble",
         "@com_github_cockroachdb_pebble//vfs",
-        "@com_github_gogo_protobuf//proto",
         "@com_github_kr_pretty//:pretty",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -789,9 +789,9 @@ type Engine interface {
 	// adjust their expectations.
 	IsSeparatedIntentsEnabledForTesting(ctx context.Context) bool
 
-	// DeprecateBaseEncryptionRegistry is used to signal to the engine that it
-	// should stop using the Base version monolithic encryption-at-rest registry.
-	DeprecateBaseEncryptionRegistry(version *roachpb.Version) error
+	// SetMinVersion is used to signal to the engine the current minimum
+	// version that it must maintain compatibility with.
+	SetMinVersion(version roachpb.Version) error
 
 	// UsingRecordsEncryptionRegistry returns whether the engine is using the
 	// Records version incremental encryption-at-rest registry.
@@ -799,7 +799,7 @@ type Engine interface {
 
 	// MinVersionIsAtLeastTargetVersion returns whether the engine's recorded
 	// storage min version is at least the target version.
-	MinVersionIsAtLeastTargetVersion(target *roachpb.Version) (bool, error)
+	MinVersionIsAtLeastTargetVersion(target roachpb.Version) (bool, error)
 }
 
 // Batch is the interface for batch specific operations.

--- a/pkg/storage/pebble_file_registry.go
+++ b/pkg/storage/pebble_file_registry.go
@@ -166,7 +166,7 @@ func (r *PebbleFileRegistry) loadRegistryFromFile() error {
 	// If encryption-at-rest was not previously enabled, we check the storage min
 	// version to determine whether we still need to create an old base registry.
 	target := clusterversion.ByKey(clusterversion.RecordsBasedRegistry)
-	ok, err = MinVersionIsAtLeastTargetVersion(r.FS, r.DBDir, &target)
+	ok, err = MinVersionIsAtLeastTargetVersion(r.FS, r.DBDir, target)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Whenever the store cluster version key is updated, update the minimum
storage version too.

Fix #69116.

Release note: None