### PR TITLE
storage: add function to validate `EngineKey`s

### DIFF
--- a/pkg/storage/engine_key.go
+++ b/pkg/storage/engine_key.go
@@ -180,6 +180,16 @@ func (k EngineKey) ToLockTableKey() (LockTableKey, error) {
 	return key, nil
 }
 
+// Validate checks if the EngineKey is a valid MVCCKey or LockTableKey.
+func (k EngineKey) Validate() error {
+	_, errMVCC := k.ToMVCCKey()
+	_, errLock := k.ToLockTableKey()
+	if errMVCC != nil && errLock != nil {
+		return errors.Newf("key %s is neither an MVCCKey or LockTableKey", k)
+	}
+	return nil
+}
+
 // DecodeEngineKey decodes the given bytes as an EngineKey. This function is
 // similar to enginepb.SplitMVCCKey.
 // TODO(sumeer): consider removing SplitMVCCKey.


### PR DESCRIPTION
To aid in testing wether an `EngineKey` is invalid - defined as being
parseable _neither_ as an `MVCCKey` or `LockTableKey` - add an
`(EngineKey).Validate` function.

Release note: None