### PR TITLE
workload: fix pgx error cast in kv95 and schemachange

### DIFF
--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -789,7 +789,7 @@ func TestErrorDuringPrepareInExplicitTransactionPropagates(t *testing.T) {
 	require.Regexp(t,
 		`restart transaction: TransactionRetryWithProtoRefreshError: TransactionRetryError: retry txn \(RETRY_REASON_UNKNOWN - boom\)`,
 		err)
-	var pgErr = &pgconn.PgError{}
+	var pgErr = new(pgconn.PgError)
 	require.True(t, errors.As(err, &pgErr))
 	require.Equal(t, pgcode.SerializationFailure, pgcode.MakeCode(pgErr.Code))
 

--- a/pkg/workload/kv/kv.go
+++ b/pkg/workload/kv/kv.go
@@ -474,8 +474,8 @@ func (o *kvOp) run(ctx context.Context) (retErr error) {
 }
 
 func (o *kvOp) tryHandleWriteErr(name string, start time.Time, err error) error {
-	// If the error not an instance of pgx.PgError, then it is unexpected.
-	pgErr := pgconn.PgError{}
+	// If the error is not an instance of pgconn.PgError, then it is unexpected.
+	pgErr := new(pgconn.PgError)
 	if !errors.As(err, &pgErr) {
 		return err
 	}

--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -324,7 +324,7 @@ func (w *schemaChangeWorker) runInTxn(ctx context.Context, tx pgx.Tx) error {
 
 		op, err := w.opGen.randOp(ctx, tx)
 
-		if pgErr := (pgconn.PgError{}); errors.As(err, &pgErr) && pgcode.MakeCode(pgErr.Code) == pgcode.SerializationFailure {
+		if pgErr := new(pgconn.PgError); errors.As(err, &pgErr) && pgcode.MakeCode(pgErr.Code) == pgcode.SerializationFailure {
 			return errors.Mark(err, errRunInTxnRbkSentinel)
 		} else if err != nil {
 			return errors.Mark(
@@ -340,7 +340,7 @@ func (w *schemaChangeWorker) runInTxn(ctx context.Context, tx pgx.Tx) error {
 
 			if _, err = tx.Exec(ctx, op); err != nil {
 				// If the error not an instance of pgconn.PgError, then it is unexpected.
-				pgErr := pgconn.PgError{}
+				pgErr := new(pgconn.PgError)
 				if !errors.As(err, &pgErr) {
 					return errors.Mark(
 						errors.Wrap(err, "***UNEXPECTED ERROR; Received a non pg error"),
@@ -425,7 +425,7 @@ func (w *schemaChangeWorker) run(ctx context.Context) error {
 	w.logger.writeLog("COMMIT")
 	if err = tx.Commit(ctx); err != nil {
 		// If the error not an instance of pgconn.PgError, then it is unexpected.
-		pgErr := pgconn.PgError{}
+		pgErr := new(pgconn.PgError)
 		if !errors.As(err, &pgErr) {
 			err = errors.Mark(
 				errors.Wrap(err, "***UNEXPECTED COMMIT ERROR; Received a non pg error"),


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/69189
https://github.com/cockroachdb/cockroach/issues/69100 is failing but i'm not sure if this is the cause. (cc @ajwerner)

This was done incorrectly after the recent upgrade to pgx4.
`pgconn.PgError` does not implement `error`, but `*pgconn.PgError`
does.

Release justification: test only change
Release note: None