### PR TITLE
changefeedccl: make options values case insensitive

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -15,6 +15,7 @@ import (
 	"math/rand"
 	"net/url"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl/backupresolver"
@@ -152,6 +153,13 @@ func changefeedPlanHook(
 		opts, err := optsFn()
 		if err != nil {
 			return err
+		}
+
+		for key, value := range opts {
+			// if option is case insensitive then convert its value to lower case
+			if _, ok := changefeedbase.CaseInsensitiveOpts[key]; ok {
+				opts[key] = strings.ToLower(value)
+			}
 		}
 
 		if opts[changefeedbase.OptFormat] == changefeedbase.DeprecatedOptFormatAvro {

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -4405,3 +4405,42 @@ CREATE CHANGEFEED FOR tbl INTO 'null://';
 		tableID)
 	sqlDB.CheckQueryResultsRetry(t, numRangesQuery, [][]string{{"1"}})
 }
+
+func TestChangefeedCaseInsensitiveOpts(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// Sanity check for case insensitive options
+	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		// Set up a type and table.
+		sqlDB.Exec(t, `CREATE TABLE insensitive (x INT PRIMARY KEY, y string)`)
+		sqlDB.Exec(t, `INSERT INTO insensitive VALUES (0, 'hello')`)
+
+		t.Run(`format=JSON`, func(t *testing.T) {
+			cf := feed(t, f, `CREATE CHANGEFEED FOR TABLE insensitive WITH format=JSON`)
+			defer closeFeed(t, cf)
+			assertPayloads(t, cf, []string{`insensitive: [0]->{"after": {"x": 0, "y": "hello"}}`})
+		})
+
+		t.Run(`envelope=ROW`, func(t *testing.T) {
+			cf := feed(t, f, `CREATE CHANGEFEED FOR insensitive WITH envelope='ROW'`)
+			defer closeFeed(t, cf)
+			assertPayloads(t, cf, []string{`insensitive: [0]->{"x": 0, "y": "hello"}`})
+		})
+
+		t.Run(`schema_change_events=COLUMN_CHANGES, schema_change_policy=STOP`, func(t *testing.T) {
+			cf := feed(t, f, `CREATE CHANGEFEED FOR insensitive `+
+				`WITH schema_change_events=COLUMN_CHANGES, schema_change_policy=STOP`)
+			defer closeFeed(t, cf)
+			assertPayloads(t, cf, []string{`insensitive: [0]->{"after": {"x": 0, "y": "hello"}}`})
+		})
+
+		t.Run(`on_error=FAIL`, func(t *testing.T) {
+			cf := feed(t, f, `CREATE CHANGEFEED FOR insensitive WITH on_error=FAIL`)
+			defer closeFeed(t, cf)
+			assertPayloads(t, cf, []string{`insensitive: [0]->{"after": {"x": 0, "y": "hello"}}`})
+		})
+	}
+	t.Run(`sinkless`, sinklessTest(testFn))
+}

--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -190,3 +190,6 @@ var CloudStorageValidOptions = makeStringSet(OptCompression)
 
 // WebhookValidOptions is options exclusive to webhook sink
 var WebhookValidOptions = makeStringSet(OptWebhookAuthHeader, OptWebhookClientTimeout, OptWebhookSinkConfig)
+
+// CaseInsensitiveOpts options which supports case Insensitive value
+var CaseInsensitiveOpts = makeStringSet(OptFormat, OptEnvelope, OptCompression, OptSchemaChangeEvents, OptSchemaChangePolicy, OptOnError)


### PR DESCRIPTION
changefeedccl: Make options values case insensitive

Treat changefeed option values as case insensitive.

Fixes #69154

Release Justification: Low danger, UX performance improvement.
Release note (enterprise change): changefeed option values are case insensitive.