### PR TITLE
jobs: make TestPauseReason faster

### DIFF
--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -3129,7 +3129,11 @@ func TestPauseReason(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+		},
+	})
 	registry := s.JobRegistry().(*jobs.Registry)
 	defer s.Stopper().Stop(ctx)
 


### PR DESCRIPTION
TestPauseReason waits for a job to be paused, which is slow because
job-registry's cancel-loop interval is 10s by default. This commit
uses a testing knob in the test to shorten cancel-loop interval,
which results in shorter test time.

Release note: None