### PR TITLE
logictest: bump SET CLUSTER TIMEOUT wait setting for tests

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1193,6 +1193,10 @@ type ExecutorTestingKnobs struct {
 	// tracing spans for every statement.
 	ForceRealTracingSpans bool
 
+	// ClusterSettingUpdateTimeout, if set, controls the time to wait for a
+	// CLUSTER SETTING to update across all nodes.
+	ClusterSettingUpdateTimeout time.Duration
+
 	// DistSQLReceiverPushCallbackFactory, if set, will be called every time a
 	// DistSQLReceiver is created for a new query execution, and it should
 	// return, possibly nil, a callback that will be called every time

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1341,6 +1341,10 @@ func (t *logicTest) newCluster(serverArgs TestServerArgs) {
 				},
 				SQLExecutor: &sql.ExecutorTestingKnobs{
 					DeterministicExplain: true,
+					// Bump to a larger timeout as multi-node tests in CI take a while longer
+					// to update.
+					// TODO(#69227): lower this timeout.
+					ClusterSettingUpdateTimeout: 30 * time.Second,
 				},
 			},
 			ClusterName:   "testclustername",

--- a/pkg/sql/set_cluster_setting.go
+++ b/pkg/sql/set_cluster_setting.go
@@ -367,7 +367,11 @@ func (n *setClusterSettingNode) startExec(params runParams) error {
 	}
 	errNotReady := errors.New("setting updated but timed out waiting to read new value")
 	var observed string
-	err := retry.ForDuration(10*time.Second, func() error {
+	retryDuration := 10 * time.Second
+	if override := params.p.ExecCfg().TestingKnobs.ClusterSettingUpdateTimeout; override != 0 {
+		retryDuration = override
+	}
+	err := retry.ForDuration(retryDuration, func() error {
 		observed = n.setting.Encoded(&execCfg.Settings.SV)
 		if observed != expectedEncodedValue {
 			return errNotReady


### PR DESCRIPTION
This will alleviate the `setting updated but timed out waiting to read
new value` we see somewhat frequently in logic tests for multi-node
clusters.

Release note: None