### PR TITLE
changefeedccl: signal changeAggregator shutdown from the kvfeed

### DIFF
--- a/pkg/ccl/changefeedccl/bench_test.go
+++ b/pkg/ccl/changefeedccl/bench_test.go
@@ -229,7 +229,7 @@ func createBenchmarkChangefeed(
 		Gossip:           gossip.MakeOptionalGossip(s.GossipI().(*gossip.Gossip)),
 		Spans:            spans,
 		Targets:          details.Targets,
-		Sink:             buf,
+		Writer:           buf,
 		Metrics:          &metrics.KVFeedMetrics,
 		MM:               mm,
 		InitialHighWater: initialHighWater,

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -333,7 +333,7 @@ func makeKVFeedCfg(
 	initialHighWater, needsInitialScan := getKVFeedInitialParameters(spec)
 
 	return kvfeed.Config{
-		Sink:               buf,
+		Writer:             buf,
 		Settings:           cfg.Settings,
 		DB:                 cfg.DB,
 		Codec:              cfg.Codec,
@@ -443,6 +443,12 @@ func (ca *changeAggregator) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMet
 			return ca.ProcessRowHelper(ca.resolvedSpanBuf.Pop()), nil
 		}
 		if err := ca.tick(); err != nil {
+			if errors.Is(err, kvevent.ErrBufferClosed) {
+				// ErrBufferClosed is a signal that
+				// our kvfeed has exited expectedly.
+				err = nil
+			}
+
 			select {
 			// If the poller errored first, that's the
 			// interesting one, so overwrite `err`.

--- a/pkg/ccl/changefeedccl/kvevent/chan_buffer.go
+++ b/pkg/ccl/changefeedccl/kvevent/chan_buffer.go
@@ -50,7 +50,12 @@ func (b *chanBuffer) Get(ctx context.Context) (Event, error) {
 	select {
 	case <-ctx.Done():
 		return Event{}, ctx.Err()
-	case e := <-b.entriesCh:
+	case e, ok := <-b.entriesCh:
+		if !ok {
+			// Our channel has been closed by the
+			// Writer. No more events will be returned.
+			return e, ErrBufferClosed
+		}
 		e.bufferGetTimestamp = timeutil.Now()
 		return e, nil
 	}

--- a/pkg/ccl/changefeedccl/kvevent/event.go
+++ b/pkg/ccl/changefeedccl/kvevent/event.go
@@ -18,7 +18,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
 )
+
+// ErrBufferClosed is returned by Readers when no more values will be
+// returned from the buffer.
+var ErrBufferClosed = errors.New("buffer closed")
 
 // Buffer is an interface for communicating kvfeed entries between processors.
 type Buffer interface {

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
@@ -44,7 +44,7 @@ type Config struct {
 	Spans              []roachpb.Span
 	BackfillCheckpoint []roachpb.Span
 	Targets            jobspb.ChangefeedTargets
-	Sink               kvevent.Writer
+	Writer             kvevent.Writer
 	Metrics            *kvevent.Metrics
 	MM                 *mon.BytesMonitor
 	WithDiff           bool
@@ -91,7 +91,7 @@ func Run(ctx context.Context, cfg Config) error {
 	}
 
 	f := newKVFeed(
-		cfg.Sink, cfg.Spans, cfg.BackfillCheckpoint,
+		cfg.Writer, cfg.Spans, cfg.BackfillCheckpoint,
 		cfg.SchemaChangeEvents, cfg.SchemaChangePolicy,
 		cfg.NeedsInitialScan, cfg.WithDiff,
 		cfg.InitialHighWater,
@@ -104,11 +104,21 @@ func Run(ctx context.Context, cfg Config) error {
 	g.GoCtx(f.run)
 	err := g.Wait()
 	// NB: The higher layers of the changefeed should detect the boundary and the
-	// policy and tear everything down. Returning before the higher layers tear
-	// down the changefeed exposes synchronization challenges.
+	// policy and tear everything down. Returning before the higher layers tear down
+	// the changefeed exposes synchronization challenges if the provided writer is
+	// buffered. Errors returned from this function will cause the
+	// changefeedAggregator to exit even if all values haven't been read out of the
+	// provided buffer.
 	var scErr schemaChangeDetectedError
 	if errors.As(err, &scErr) {
-		log.Infof(ctx, "stopping changefeed due to schema change at %v", scErr.ts)
+		log.Infof(ctx, "stopping kv feed due to schema change at %v", scErr.ts)
+		// Close the buffer so the consumer (changeAggregator) knows no more
+		// writes are expected and can transition to a draining state.
+		if err := f.writer.Close(ctx); err != nil {
+			return errors.Wrap(err, "failed to close kv event writer")
+		}
+		// This context is canceled by the change aggregator when it receives
+		// ErrBufferClosed from the kv buffer that we closed above.
 		<-ctx.Done()
 		err = nil
 	}
@@ -132,7 +142,7 @@ type kvFeed struct {
 	withDiff            bool
 	withInitialBackfill bool
 	initialHighWater    hlc.Timestamp
-	sink                kvevent.Writer
+	writer              kvevent.Writer
 	codec               keys.SQLCodec
 
 	schemaChangeEvents changefeedbase.SchemaChangeEventClass
@@ -148,7 +158,7 @@ type kvFeed struct {
 
 // TODO(yevgeniy): This method is a kitchen sink. Refactor.
 func newKVFeed(
-	sink kvevent.Writer,
+	writer kvevent.Writer,
 	spans []roachpb.Span,
 	checkpoint []roachpb.Span,
 	schemaChangeEvents changefeedbase.SchemaChangeEventClass,
@@ -163,7 +173,7 @@ func newKVFeed(
 	knobs TestingKnobs,
 ) *kvFeed {
 	return &kvFeed{
-		sink:                sink,
+		writer:              writer,
 		spans:               spans,
 		checkpoint:          checkpoint,
 		withInitialBackfill: withInitialBackfill,
@@ -208,7 +218,7 @@ func (f *kvFeed) run(ctx context.Context) (err error) {
 		if f.schemaChangePolicy != changefeedbase.OptSchemaChangePolicyNoBackfill ||
 			boundaryType == jobspb.ResolvedSpan_RESTART {
 			for _, sp := range f.spans {
-				if err := f.sink.Add(
+				if err := f.writer.Add(
 					ctx,
 					kvevent.MakeResolvedEvent(sp, highWater, boundaryType),
 				); err != nil {
@@ -216,6 +226,7 @@ func (f *kvFeed) run(ctx context.Context) (err error) {
 				}
 			}
 		}
+
 		// Exit if the policy says we should.
 		if boundaryType == jobspb.ResolvedSpan_RESTART || boundaryType == jobspb.ResolvedSpan_EXIT {
 			return schemaChangeDetectedError{highWater.Next()}
@@ -305,7 +316,7 @@ func (f *kvFeed) scanIfShould(
 		return nil
 	}
 
-	if err := f.scanner.Scan(ctx, f.sink, physicalConfig{
+	if err := f.scanner.Scan(ctx, f.writer, physicalConfig{
 		Spans:     spansToBackfill,
 		Timestamp: scanTime,
 		WithDiff:  !isInitialScan && f.withDiff,
@@ -342,7 +353,7 @@ func (f *kvFeed) runUntilTableEvent(
 		Knobs:     f.knobs,
 	}
 	g.GoCtx(func(ctx context.Context) error {
-		return copyFromSourceToSinkUntilTableEvent(ctx, f.sink, memBuf, physicalCfg, f.tableFeed)
+		return copyFromSourceToDestUntilTableEvent(ctx, f.writer, memBuf, physicalCfg, f.tableFeed)
 	})
 	g.GoCtx(func(ctx context.Context) error {
 		return f.physicalFeed.Run(ctx, memBuf, physicalCfg)
@@ -382,14 +393,14 @@ func (e *errUnknownEvent) Error() string {
 	return "unknown event type"
 }
 
-// copyFromSourceToSinkUntilTableEvents will pull read entries from source and
-// publish them to sink if there is no table event from the SchemaFeed. If a
+// copyFromSourceToDestUntilTableEvents will pull read entries from source and
+// publish them to the destination if there is no table event from the SchemaFeed. If a
 // tableEvent occurs then the function will return once all of the spans have
 // been resolved up to the event. The first such event will be returned as
 // *errBoundaryReached. A nil error will never be returned.
-func copyFromSourceToSinkUntilTableEvent(
+func copyFromSourceToDestUntilTableEvent(
 	ctx context.Context,
-	sink kvevent.Writer,
+	dest kvevent.Writer,
 	source kvevent.Reader,
 	cfg physicalConfig,
 	tables schemafeed.SchemaFeed,
@@ -447,7 +458,7 @@ func copyFromSourceToSinkUntilTableEvent(
 		addEntry = func(e kvevent.Event) error {
 			switch e.Type() {
 			case kvevent.TypeKV:
-				return sink.Add(ctx, e)
+				return dest.Add(ctx, e)
 			case kvevent.TypeResolved:
 				// TODO(ajwerner): technically this doesn't need to happen for most
 				// events - we just need to make sure we forward for events which are
@@ -457,7 +468,7 @@ func copyFromSourceToSinkUntilTableEvent(
 				if _, err := frontier.Forward(resolved.Span, resolved.Timestamp); err != nil {
 					return err
 				}
-				return sink.Add(ctx, e)
+				return dest.Add(ctx, e)
 			default:
 				return &errUnknownEvent{e}
 			}

--- a/pkg/testutils/BUILD.bazel
+++ b/pkg/testutils/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//pkg/roachpb:with-mocks",
         "//pkg/security",
         "//pkg/sql/pgwire/pgerror",
+        "//pkg/util",
         "//pkg/util/fileutil",
         "//pkg/util/log",
         "//pkg/util/retry",


### PR DESCRIPTION
During acceptance testing, we observed that changefeeds did not
correctly restart on primary key changes and did not correctly stop
when schema_change_policy was set to 'stop' when the changeFrontier
and changeAggregator were running on different nodes (most production
changefeeds).

The root cause of this was a bad assumption in the changeAggregator
shutdown logic. Namely, we assumed that the changeAggregator (and kv
feed) would see context cancellations as a result of the
changeFrontier moving to draining. However, this is not guaranteed.

When the changeFrontier moves to draining, all of its inputs will be
drained. But, a DrainRequest message is only sent to the input lazily
when the next message is received from that input.

In this case of a schema change, the kv feed would stop sending
messages to the changeAggregator and thus no further messages will be
sent to the changeFrontier and the drain request is not triggered.

With this change, we now shut down the changeAggregator when the
kvfeed indicates that no more messages will be returned.

Fixes #68791

Release note (enterprise change): Fixed a bug where CHANGEFEEDs would
fail to correctly handle a primary key change.