### PR TITLE
kvserver: include queue errors in queue trace

### DIFF
--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2840,7 +2840,7 @@ func (s *Store) ManuallyEnqueue(
 
 	log.Eventf(ctx, "running %s.process", queueName)
 	processed, processErr := queue.process(ctx, repl, sysCfg)
-	log.Eventf(ctx, "processed: %t", processed)
+	log.Eventf(ctx, "processed: %t (err: %v)", processed, processErr)
 	return collect(), processErr, nil
 }
 


### PR DESCRIPTION
Without this, the trace would show that a queue didn't successfully
process a range, but it wouldn't say why.

Release note: None