### PR TITLE
release-21.1: importccl: fail PGDUMP IMPORT if we see a UDT

### DIFF
--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -850,8 +850,13 @@ func importPlanHook(
 						"IMPORT to REGIONAL BY ROW table not supported",
 					)
 				}
+				// IMPORT TABLE do not support user defined types, and so we nil out the
+				// type resolver to protect against unexpected behavior on UDT
+				// resolution.
+				semaCtxPtr := makeSemaCtxWithoutTypeResolver(p.SemaCtx())
 				tbl, err := MakeSimpleTableDescriptor(
-					ctx, p.SemaCtx(), p.ExecCfg().Settings, create, parentID, parentSchemaID, defaultCSVTableID, NoFKs, walltime)
+					ctx, semaCtxPtr, p.ExecCfg().Settings, create, parentID, parentSchemaID, defaultCSVTableID, NoFKs,
+					walltime)
 				if err != nil {
 					return err
 				}

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -1076,6 +1076,30 @@ CREATE INDEX i ON t USING btree (a) WHERE (b > 10);
 			`,
 			err: "cannot import a table with partial indexes",
 		},
+		{
+			name: "user defined type",
+			typ:  "PGDUMP",
+			data: `
+CREATE TYPE duration AS ENUM (
+    'YESTERDAY',
+    'LAST_7_DAYS',
+    'LAST_28_DAYS',
+    'LAST_90_DAYS',
+    'LAST_365_DAYS',
+    'LIFE_TIME'
+);
+CREATE TABLE t (a duration);
+			`,
+			err: "IMPORT PGDUMP does not support user defined types",
+		},
+		{
+			name: "user defined type without create",
+			typ:  "PGDUMP",
+			data: `
+CREATE TABLE t (a duration);
+			`,
+			err: "type \"duration\" does not exist",
+		},
 
 		// Error
 		{

--- a/pkg/ccl/importccl/import_table_creation.go
+++ b/pkg/ccl/importccl/import_table_creation.go
@@ -88,6 +88,12 @@ var NoFKs = fkHandler{resolver: fkResolver{
 	tableNameToDesc: make(map[string]*tabledesc.Mutable),
 }}
 
+func makeSemaCtxWithoutTypeResolver(semaCtx *tree.SemaContext) *tree.SemaContext {
+	semaCtxCopy := *semaCtx
+	semaCtxCopy.TypeResolver = nil
+	return &semaCtxCopy
+}
+
 // MakeSimpleTableDescriptor creates a Mutable from a CreateTable parse
 // node without the full machinery. Many parts of the syntax are unsupported
 // (see the implementation and TestMakeSimpleTableDescriptorErrors for details),

--- a/pkg/ccl/importccl/read_import_mysql.go
+++ b/pkg/ccl/importccl/read_import_mysql.go
@@ -504,6 +504,10 @@ func mysqlTableToCockroach(
 	if p != nil {
 		semaCtxPtr = p.SemaCtx()
 	}
+
+	// Bundle imports do not support user defined types, and so we nil out the
+	// type resolver to protect against unexpected behavior on UDT resolution.
+	semaCtxPtr = makeSemaCtxWithoutTypeResolver(semaCtxPtr)
 	desc, err := MakeSimpleTableDescriptor(ctx, semaCtxPtr, evalCtx.Settings, stmt, parentID, keys.PublicSchemaID, id, fks, time.WallTime)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
Backport 1/1 commits from #67994.

In 21.1 we added `ignore_unsupported_statements` that ignored
all statements that we didnt support while parsing the PGDUMP
file. We don't support `CREATE TYPE` and its subsequent usage,
and this currently causes a NPE.

While we work on adding UDT support to PGDUMP we should make
an exception to the ignore option and fail the import instead.

This change also nils out the type resolver on the semaCtx that we
use during import table creation. This ensures that we do not
attempt to resolve UDTs but instead fail gracefully.

IMPORT TABLE and bundle imports do not support UDTs and so this
is an improvement over the NPEs import would hit prior to this patch.

Release note (bug fix): IMPORT PGDUMP with a UDT would result
in a nil pointer exception. This change makes it fail gracefully.

Release justification: bug fix - IMPORT PGDUMP with a UDT would result
in a nil pointer exception. This change makes it fail gracefully.