### PR TITLE
cli,backup: resolve settings as default

### DIFF
--- a/pkg/ccl/cliccl/debug_backup.go
+++ b/pkg/ccl/cliccl/debug_backup.go
@@ -281,8 +281,10 @@ func newBlobFactory(ctx context.Context, dialing roachpb.NodeID) (blobs.BlobClie
 func externalStorageFromURIFactory(
 	ctx context.Context, uri string, user security.SQLUsername,
 ) (cloud.ExternalStorage, error) {
+	defaultSettings := &cluster.Settings{}
+	defaultSettings.SV.Init(ctx, nil /* opaque */)
 	return cloud.ExternalStorageFromURI(ctx, uri, base.ExternalIODirConfig{},
-		cluster.NoSettings, newBlobFactory, user, nil /*Internal Executor*/, nil /*kvDB*/)
+		defaultSettings, newBlobFactory, user, nil /*Internal Executor*/, nil /*kvDB*/)
 }
 
 func getManifestFromURI(ctx context.Context, path string) (backupccl.BackupManifest, error) {


### PR DESCRIPTION
Previously, CLI backup inspection could result in an NPE when resolving
cluster settings (as these are not available through the CLI as no
cluster is running). Rather than crashing with an NPE, the tool users
the default values of the cluster settings.

Fixes https://github.com/cockroachdb/cockroach/issues/69090.

Release note (bug fix): Fix a crash when using the `cockroach backup
debug` tool.

Release justification: Bug fix.  Fix a crash when using the `cockroach backup
debug` tool.