### PR TITLE
sql: change column in tenant_usage table

### DIFF
--- a/pkg/sql/catalog/systemschema/system.go
+++ b/pkg/sql/catalog/systemschema/system.go
@@ -547,6 +547,11 @@ CREATE TABLE system.tenant_usage (
 	-- instance 0 acting as a sentinel (always the head of the list).
 	next_instance_id INT NOT NULL,
 
+	-- Time when we last interacted with this row. For the per-tenant row, this
+	-- is the time of the last update from any instance. For instance rows, this
+	-- is the time of the last update from that particular instance.
+	last_update TIMESTAMP NOT NULL,
+
 	-- -------------------------------------------------------------------
 	--  The following fields are used only for the per-tenant state, when
 	--  instance_id = 0.
@@ -587,15 +592,12 @@ CREATE TABLE system.tenant_usage (
 	-- Current shares value for this instance.
   instance_shares FLOAT,
 
-	-- Time when we last heard from this instance.
-	instance_last_update TIMESTAMP,
-
 	FAMILY "primary" (
-	  tenant_id, instance_id, next_instance_id,
+	  tenant_id, instance_id, next_instance_id, last_update,
 	  ru_burst_limit, ru_refill_rate, ru_current, current_share_sum,
 	  total_ru_usage, total_read_requests, total_read_bytes, total_write_requests,
 	  total_write_bytes, total_sql_pod_cpu_seconds,
-	  instance_lease, instance_seq, instance_shares, instance_last_update
+	  instance_lease, instance_seq, instance_shares
 	),
 
   PRIMARY KEY (tenant_id, instance_id)
@@ -2126,31 +2128,31 @@ var (
 				{Name: "tenant_id", ID: 1, Type: types.Int, Nullable: false},
 				{Name: "instance_id", ID: 2, Type: types.Int, Nullable: false},
 				{Name: "next_instance_id", ID: 3, Type: types.Int, Nullable: false},
-				{Name: "ru_burst_limit", ID: 4, Type: types.Float, Nullable: true},
-				{Name: "ru_refill_rate", ID: 5, Type: types.Float, Nullable: true},
-				{Name: "ru_current", ID: 6, Type: types.Float, Nullable: true},
-				{Name: "current_share_sum", ID: 7, Type: types.Float, Nullable: true},
-				{Name: "total_ru_usage", ID: 8, Type: types.Float, Nullable: true},
-				{Name: "total_read_requests", ID: 9, Type: types.Int, Nullable: true},
-				{Name: "total_read_bytes", ID: 10, Type: types.Int, Nullable: true},
-				{Name: "total_write_requests", ID: 11, Type: types.Int, Nullable: true},
-				{Name: "total_write_bytes", ID: 12, Type: types.Int, Nullable: true},
-				{Name: "total_sql_pod_cpu_seconds", ID: 13, Type: types.Float, Nullable: true},
-				{Name: "instance_lease", ID: 14, Type: types.Bytes, Nullable: true},
-				{Name: "instance_seq", ID: 15, Type: types.Int, Nullable: true},
-				{Name: "instance_shares", ID: 16, Type: types.Float, Nullable: true},
-				{Name: "instance_last_update", ID: 17, Type: types.Timestamp, Nullable: true},
+				{Name: "last_update", ID: 4, Type: types.Timestamp, Nullable: false},
+				{Name: "ru_burst_limit", ID: 5, Type: types.Float, Nullable: true},
+				{Name: "ru_refill_rate", ID: 6, Type: types.Float, Nullable: true},
+				{Name: "ru_current", ID: 7, Type: types.Float, Nullable: true},
+				{Name: "current_share_sum", ID: 8, Type: types.Float, Nullable: true},
+				{Name: "total_ru_usage", ID: 9, Type: types.Float, Nullable: true},
+				{Name: "total_read_requests", ID: 10, Type: types.Int, Nullable: true},
+				{Name: "total_read_bytes", ID: 11, Type: types.Int, Nullable: true},
+				{Name: "total_write_requests", ID: 12, Type: types.Int, Nullable: true},
+				{Name: "total_write_bytes", ID: 13, Type: types.Int, Nullable: true},
+				{Name: "total_sql_pod_cpu_seconds", ID: 14, Type: types.Float, Nullable: true},
+				{Name: "instance_lease", ID: 15, Type: types.Bytes, Nullable: true},
+				{Name: "instance_seq", ID: 16, Type: types.Int, Nullable: true},
+				{Name: "instance_shares", ID: 17, Type: types.Float, Nullable: true},
 			},
 			[]descpb.ColumnFamilyDescriptor{
 				{
 					Name: "primary",
 					ID:   0,
 					ColumnNames: []string{
-						"tenant_id", "instance_id", "next_instance_id",
+						"tenant_id", "instance_id", "next_instance_id", "last_update",
 						"ru_burst_limit", "ru_refill_rate", "ru_current", "current_share_sum",
 						"total_ru_usage", "total_read_requests", "total_read_bytes", "total_write_requests",
 						"total_write_bytes", "total_sql_pod_cpu_seconds",
-						"instance_lease", "instance_seq", "instance_shares", "instance_last_update",
+						"instance_lease", "instance_seq", "instance_shares",
 					},
 					ColumnIDs:       []descpb.ColumnID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17},
 					DefaultColumnID: 0,

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -1571,6 +1571,7 @@ system              public             primary                                  
 system              public             630200280_45_1_not_null                                                              system         public        tenant_usage                     CHECK            NO             NO
 system              public             630200280_45_2_not_null                                                              system         public        tenant_usage                     CHECK            NO             NO
 system              public             630200280_45_3_not_null                                                              system         public        tenant_usage                     CHECK            NO             NO
+system              public             630200280_45_4_not_null                                                              system         public        tenant_usage                     CHECK            NO             NO
 system              public             primary                                                                              system         public        tenant_usage                     PRIMARY KEY      NO             NO
 system              public             630200280_8_1_not_null                                                               system         public        tenants                          CHECK            NO             NO
 system              public             630200280_8_2_not_null                                                               system         public        tenants                          CHECK            NO             NO
@@ -1747,6 +1748,7 @@ system              public             630200280_44_3_not_null                  
 system              public             630200280_45_1_not_null                                                              tenant_id IS NOT NULL
 system              public             630200280_45_2_not_null                                                              instance_id IS NOT NULL
 system              public             630200280_45_3_not_null                                                              next_instance_id IS NOT NULL
+system              public             630200280_45_4_not_null                                                              last_update IS NOT NULL
 system              public             630200280_46_1_not_null                                                              id IS NOT NULL
 system              public             630200280_4_1_not_null                                                               username IS NOT NULL
 system              public             630200280_4_3_not_null                                                               isRole IS NOT NULL
@@ -2046,7 +2048,7 @@ system         pg_extension  spatial_ref_sys                  auth_srid         
 system         pg_extension  spatial_ref_sys                  proj4text                                                                      5
 system         pg_extension  spatial_ref_sys                  srid                                                                           1
 system         pg_extension  spatial_ref_sys                  srtext                                                                         4
-system         public        sql_instances                    addr                                                                      2
+system         public        sql_instances                    addr                                                                           2
 system         public        sql_instances                    id                                                                             1
 system         public        sql_instances                    session_id                                                                     3
 system         public        sqlliveness                      expiration                                                                     2
@@ -2085,23 +2087,23 @@ system         public        table_statistics                 nullCount         
 system         public        table_statistics                 rowCount                                                                       6
 system         public        table_statistics                 statisticID                                                                    2
 system         public        table_statistics                 tableID                                                                        1
-system         public        tenant_usage                     current_share_sum                                                              7
+system         public        tenant_usage                     current_share_sum                                                              8
 system         public        tenant_usage                     instance_id                                                                    2
-system         public        tenant_usage                     instance_last_update                                                           17
-system         public        tenant_usage                     instance_lease                                                                 14
-system         public        tenant_usage                     instance_seq                                                                   15
-system         public        tenant_usage                     instance_shares                                                                16
+system         public        tenant_usage                     instance_lease                                                                 15
+system         public        tenant_usage                     instance_seq                                                                   16
+system         public        tenant_usage                     instance_shares                                                                17
+system         public        tenant_usage                     last_update                                                                    4
 system         public        tenant_usage                     next_instance_id                                                               3
-system         public        tenant_usage                     ru_burst_limit                                                                 4
-system         public        tenant_usage                     ru_current                                                                     6
-system         public        tenant_usage                     ru_refill_rate                                                                 5
+system         public        tenant_usage                     ru_burst_limit                                                                 5
+system         public        tenant_usage                     ru_current                                                                     7
+system         public        tenant_usage                     ru_refill_rate                                                                 6
 system         public        tenant_usage                     tenant_id                                                                      1
-system         public        tenant_usage                     total_read_bytes                                                               10
-system         public        tenant_usage                     total_read_requests                                                            9
-system         public        tenant_usage                     total_ru_usage                                                                 8
-system         public        tenant_usage                     total_sql_pod_cpu_seconds                                                      13
-system         public        tenant_usage                     total_write_bytes                                                              12
-system         public        tenant_usage                     total_write_requests                                                           11
+system         public        tenant_usage                     total_read_bytes                                                               11
+system         public        tenant_usage                     total_read_requests                                                            10
+system         public        tenant_usage                     total_ru_usage                                                                 9
+system         public        tenant_usage                     total_sql_pod_cpu_seconds                                                      14
+system         public        tenant_usage                     total_write_bytes                                                              13
+system         public        tenant_usage                     total_write_requests                                                           12
 system         public        tenants                          active                                                                         2
 system         public        tenants                          id                                                                             1
 system         public        tenants                          info                                                                           3


### PR DESCRIPTION
The tenant usage table currently has the "last update" timestamp as an
instance-only field. This field is necessary for the per-tenant state
as well (it corresponds to the current bucket level).

This change renames the `instance_last_update` column to `last_update`
and moves it up to the group of columns that apply to all rows.

Since this table was introduced only on `master`, we don't add a new
migration.

Release justification: category 2, code only used for Serverless.

Release note: None