### PR TITLE
release-20.2: jobs: register scheduled jobs executors metrics at startup

### DIFF
--- a/pkg/jobs/scheduled_job_executor_test.go
+++ b/pkg/jobs/scheduled_job_executor_test.go
@@ -72,10 +72,9 @@ func TestScheduledJobExecutorRegistration(t *testing.T) {
 	instance := newStatusTrackingExecutor()
 	defer registerScopedScheduledJobExecutor(executorName, instance)()
 
-	registered, created, err := GetScheduledJobExecutor(executorName)
+	registered, err := GetScheduledJobExecutor(executorName)
 	require.NoError(t, err)
 	require.Equal(t, instance, registered)
-	require.True(t, created)
 }
 
 func TestJobTerminationNotification(t *testing.T) {


### PR DESCRIPTION
Backport 1/1 commits from #67855.

/cc @cockroachdb/release

---

Fixes https://github.com/cockroachdb/cockroach/issues/62792.

Previously, scheduled job executors were initialized lazily as each
daemon processed a schedule of that executor type. By initializtion, I
mean created and have their metrics registered with the SQL server's
metric registry.

Consider the following scenario before any schedules have been processed
on a cluster:
- Node 1's scheduler daemon finds a schedule to process
- Node 1 initializes an executor and registers that executor's metrics
with the SQL server's metrics registry.
- Node 1 creates the job record
- Node 2 adopts the created job
- Node 2 completes the job and creates a new executor to handle the
NotifyJobTermination callback. (Note: that when creating this executor,
it did not register it's metrics yet since Node 2 has not processed a
schedule yet.)
- Node 2 updates its metrics, but the incrementing is not visible.

This change creates and registers the metrics for all executors when the
scheduler daemon starts on each node, ensuring that the appropriate
metrics are registered.

Release note (bug fix): Fix a bug where the schedules.backup.succeeded
and schedules.backup.failed metrics would sometimes not be updated.

Release justification: Bug fix. Fix a bug where the schedules.backup.succeeded
and schedules.backup.failed metrics would sometimes not be updated.
