### PR TITLE
settings: retire a setting only present on 21.1 branch

### DIFF
--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -102,6 +102,7 @@ var retiredSettings = map[string]struct{}{
 	"kv.transaction.write_pipelining_max_outstanding_size":           {},
 	"sql.defaults.optimizer_improve_disjunction_selectivity.enabled": {},
 	"bulkio.backup.proxy_file_writes.enabled":                        {},
+	"sql.distsql.prefer_local_execution.enabled":                     {},
 }
 
 // register adds a setting to the registry.


### PR DESCRIPTION
`sql.distsql.prefer_local_execution.enabled` was introduced during
a backport to 21.1 branch and is only present on that branch. This
commit is retiring that setting on 21.2 branch.

Retiring a setting introduced in #68613.

Release note: None

Release justification: This commit is safe for this release because it
is kinda non-production code change.