### PR TITLE
colbuilder: fix expr planning when RHS is a non-constant tuple

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/vectorize_local
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_local
@@ -403,3 +403,21 @@ EXPLAIN (VEC) INSERT INTO t66568 VALUES (1) ON CONFLICT DO NOTHING
     └ *colexecjoin.crossJoiner
       ├ *sql.planNodeToRowSource
       └ *colfetcher.ColBatchScan
+
+statement ok
+CREATE TABLE t_string (a STRING);
+INSERT INTO t_string VALUES (NULL)
+
+# Check that IN expression with non-constant right-hand side is handled via the
+# default comparison operator.
+query T
+EXPLAIN (VEC) SELECT 'b' IN ('b', a, 'a') FROM t_string
+----
+│
+└ Node 1
+  └ *colexecproj.defaultCmpProjOp
+    └ *colexec.tupleProjOp
+      └ *colexecbase.constBytesOp
+        └ *colexecbase.constBytesOp
+          └ *colexecbase.constBytesOp
+            └ *colfetcher.ColBatchScan


### PR DESCRIPTION
During the expression planning, if the RHS is a tuple, we attempt to
evaluate it if it is a constant tuple (i.e. it only contains constant
expressions). Previously, if this pre-evaluation failed, we would bail
on the vectorized planning and fall back to wrapping a row-execution
processor. This is suboptimal because we have default operators for such
scenarios. This commit refactors the code slightly so that we
pre-evaluate tuples only if they are constant.

It is not a bug fix per se (thus, there is no release note), and it
won't be backported, yet I think it is beneficial to get it into 21.2.

Release note: None

Release justification: low-risk performance fix.