### PR TITLE
sql: crdb_internal.reset_sql_stats() now resets persisted SQL Stats 

### DIFF
--- a/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
+++ b/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
@@ -76,6 +76,8 @@ func TestFullClusterBackup(t *testing.T) {
 SELECT id, status, created, payload, progress, created_by_type, created_by_id, claim_instance_id
 FROM system.jobs
 	`
+	// Pause SQL Stats compaction job to ensure the test is deterministic.
+	sqlDB.Exec(t, `PAUSE SCHEDULES SELECT id FROM [SHOW SCHEDULES FOR SQL STATISTICS]`)
 
 	// Disable automatic stats collection on the backup and restoring clusters to ensure
 	// the test is deterministic.

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -5104,6 +5104,7 @@ CREATE TABLE crdb_internal.statement_statistics (
 			InternalExecutor: execCfg.InternalExecutor,
 			KvDB:             execCfg.DB,
 			SQLIDContainer:   execCfg.NodeID,
+			Knobs:            execCfg.SQLStatsTestingKnobs,
 		}, memSQLStats)
 
 		row := make(tree.Datums, 7 /* number of columns for this virtual table */)
@@ -5242,6 +5243,7 @@ CREATE TABLE crdb_internal.transaction_statistics (
 			InternalExecutor: execCfg.InternalExecutor,
 			KvDB:             execCfg.DB,
 			SQLIDContainer:   execCfg.NodeID,
+			Knobs:            execCfg.SQLStatsTestingKnobs,
 		}, memSQLStats)
 
 		row := make(tree.Datums, 5 /* number of columns for this virtual table */)

--- a/pkg/sql/logictest/testdata/logic_test/distsql_crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_crdb_internal
@@ -37,11 +37,18 @@ NULL       /1       {1}       1
 /9         NULL     {5}       5
 
 
+# As of #69273, crdb_internal.reset_sql_stats()'s behavior changes from in-memory
+# only to truncating system table. Hence, we create a small table here to
+# to ensure that this test doesn't run for a very long time.
+statement ok
+CREATE TABLE smalldata (a INT, PRIMARY KEY (a))
+
+statement ok
+INSERT INTO smalldata VALUES (1), (2), (3)
+
 query II
-SELECT a, count(*) AS cnt FROM data GROUP BY a HAVING crdb_internal.reset_sql_stats() ORDER BY a LIMIT 5
+SELECT a, count(*) AS cnt FROM smalldata GROUP BY a HAVING crdb_internal.reset_sql_stats() ORDER BY a
 ----
-1 1000
-2 1000
-3 1000
-4 1000
-5 1000
+1 1
+2 1
+3 1

--- a/pkg/sql/sqlstats/persistedsqlstats/BUILD.bazel
+++ b/pkg/sql/sqlstats/persistedsqlstats/BUILD.bazel
@@ -57,6 +57,7 @@ go_test(
     name = "persistedsqlstats_test",
     srcs = [
         "compaction_test.go",
+        "controller_test.go",
         "flush_test.go",
         "main_test.go",
         "reader_test.go",

--- a/pkg/sql/sqlstats/persistedsqlstats/controller_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/controller_test.go
@@ -1,0 +1,164 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+//
+// Package sqlstats is a subsystem that is responsible for tracking the
+// statistics of statements and transactions.
+
+package persistedsqlstats_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats"
+	"github.com/cockroachdb/cockroach/pkg/sql/tests"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPersistedSQLStatsReset(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	params, _ := tests.CreateTestServerParams()
+
+	cluster := serverutils.StartNewTestCluster(t, 3 /* numNodes */, base.TestClusterArgs{
+		ServerArgs: params,
+	})
+
+	server := cluster.Server(0 /* idx */)
+
+	// Open two connections so that we can run statements without messing up
+	// the SQL stats.
+	testConn := cluster.ServerConn(0 /* idx */)
+	observerConn := cluster.ServerConn(1 /* idx */)
+
+	sqlDB := sqlutils.MakeSQLRunner(testConn)
+	observer := sqlutils.MakeSQLRunner(observerConn)
+	defer cluster.Stopper().Stop(ctx)
+
+	testCasesForDisk := map[string]string{
+		"SELECT _":       "SELECT 1",
+		"SELECT _, _":    "SELECT 1, 1",
+		"SELECT _, _, _": "SELECT 1, 1, 1",
+	}
+
+	testCasesForMem := map[string]string{
+		"SELECT _, _":          "SELECT 1, 1",
+		"SELECT _, _, _":       "SELECT 1, 1, 1",
+		"SELECT _, _, _, _":    "SELECT 1, 1, 1, 1",
+		"SELECT _, _, _, _, _": "SELECT 1, 1, 1, 1, 1",
+	}
+
+	appName := "controller_test"
+	sqlDB.Exec(t, "SET application_name = $1", appName)
+
+	expectedStmtFingerprintToFingerprintID := make(map[string]string)
+	for fingerprint, query := range testCasesForDisk {
+		// We will populate the fingerprint ID later.
+		expectedStmtFingerprintToFingerprintID[fingerprint] = ""
+		sqlDB.Exec(t, query)
+	}
+
+	sqlStats := server.SQLServer().(*sql.Server).GetSQLStatsProvider()
+	sqlStats.(*persistedsqlstats.PersistedSQLStats).Flush(ctx)
+
+	checkInsertedStmtStatsAndUpdateFingerprintIDs(t, appName, observer, expectedStmtFingerprintToFingerprintID)
+	checkInsertedTxnStats(t, appName, observer, expectedStmtFingerprintToFingerprintID)
+
+	// Run few additional queries, so we would also have some SQL stats in-memory.
+	for fingerprint, query := range testCasesForMem {
+		sqlDB.Exec(t, query)
+		if _, ok := expectedStmtFingerprintToFingerprintID[fingerprint]; !ok {
+			expectedStmtFingerprintToFingerprintID[fingerprint] = ""
+		}
+	}
+
+	// Sanity check that we still have the same count since we are still within
+	// the same aggregation interval.
+	checkInsertedStmtStatsAndUpdateFingerprintIDs(t, appName, observer, expectedStmtFingerprintToFingerprintID)
+	checkInsertedTxnStats(t, appName, observer, expectedStmtFingerprintToFingerprintID)
+
+	// Resets cluster wide SQL stats.
+	sqlStatsController := server.SQLServer().(*sql.Server).GetSQLStatsController()
+	require.NoError(t, sqlStatsController.ResetClusterSQLStats(ctx))
+
+	var count int
+	observer.QueryRow(t,
+		"SELECT count(*) FROM crdb_internal.statement_statistics WHERE app_name = $1", appName).
+		Scan(&count)
+	require.Equal(t, 0 /* expected */, count)
+
+	observer.QueryRow(t,
+		"SELECT count(*) FROM crdb_internal.transaction_statistics WHERE app_name = $1", appName).
+		Scan(&count)
+	require.Equal(t, 0 /* expected */, count)
+}
+
+func checkInsertedStmtStatsAndUpdateFingerprintIDs(
+	t *testing.T,
+	appName string,
+	observer *sqlutils.SQLRunner,
+	expectedStmtFingerprintToFingerprintID map[string]string,
+) {
+	result := observer.QueryStr(t,
+		`
+SELECT encode(fingerprint_id, 'hex'), metadata ->> 'query'
+FROM crdb_internal.statement_statistics
+WHERE app_name = $1`, appName)
+
+	for expectedFingerprint := range expectedStmtFingerprintToFingerprintID {
+		var found bool
+		for _, row := range result {
+			if expectedFingerprint == row[1] {
+				found = true
+
+				// Populate fingerprintID.
+				expectedStmtFingerprintToFingerprintID[expectedFingerprint] = row[0]
+			}
+		}
+		require.True(t, found, "expect %s to be found, but it was not", expectedFingerprint)
+	}
+}
+
+func checkInsertedTxnStats(
+	t *testing.T,
+	appName string,
+	observer *sqlutils.SQLRunner,
+	expectedStmtFingerprintToFingerprintID map[string]string,
+) {
+	result := observer.QueryStr(t,
+		`
+SELECT metadata -> 'stmtFingerprintIDs' ->> 0
+FROM crdb_internal.transaction_statistics
+WHERE app_name = $1
+ AND metadata -> 'stmtFingerprintIDs' ->> 0 IN (
+   SELECT encode(fingerprint_id, 'hex')
+   FROM crdb_internal.statement_statistics
+   WHERE app_name = $2
+ )
+`, appName, appName)
+	for query, fingerprintID := range expectedStmtFingerprintToFingerprintID {
+		var found bool
+		for _, row := range result {
+			if row[0] == fingerprintID {
+				found = true
+			}
+		}
+		require.True(t, found,
+			`expected %s to be found in txn stats, but it was not.`, query)
+	}
+}


### PR DESCRIPTION
Depends on #68401 and #68434

Previously, crdb_internal.reset_sql_stats() builtin only resets
cluster-wide in-memory sql stats.
This patch updated the builtin to be able to reset persisted
sql stats as well.

Release justification: category 4

Release note (sql change): crdb_internal.reset_sql_stats() now resets
 persisted SQL Stats.

