### PR TITLE
sql: validate constraints when secondary tenants set zone configs

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/zone_config
+++ b/pkg/sql/logictest/testdata/logic_test/zone_config
@@ -276,6 +276,11 @@ SELECT zone_id, raw_config_sql FROM [SHOW ZONE CONFIGURATION FOR TABLE a]
     voter_constraints = '{+region=test: 1}',
     lease_preferences = '[]'
 
+# Different error based on if the test is being run in the system tenant or
+# a secondary tenant.
+statement error pq: (.* matches no existing nodes within the cluster)|(region "shouldFail" not found)
+ALTER TABLE a CONFIGURE ZONE USING voter_constraints = '{"+region=shouldFail": 1}'
+
 # Check entities for which we can set zone configs.
 subtest test_entity_validity
 

--- a/pkg/sql/logictest/testdata/logic_test/zone_config_system_tenant
+++ b/pkg/sql/logictest/testdata/logic_test/zone_config_system_tenant
@@ -17,11 +17,6 @@ ALTER TABLE t CONFIGURE ZONE USING num_replicas = 3;
 statement ok
 CREATE TABLE a(id INT PRIMARY KEY)
 
-# TODO(arul): move this back to `zone_config` once we validate cluster regions
-# for tenants.
-statement error pq: constraint "\+region=shouldFail" matches no existing nodes within the cluster - did you enter it correctly\?
-ALTER TABLE a CONFIGURE ZONE USING voter_constraints = '{"+region=shouldFail": 1}'
-
 # Check that global_reads cannot be set without a CCL binary and enterprise license.
 statement error OSS binaries do not include enterprise features
 ALTER TABLE a CONFIGURE ZONE USING global_reads = true


### PR DESCRIPTION
Previousl, we would validate constraints/voter_constraints/
lease_preferences fields only for the system tenant. This patch extends
this validation for secondary tenants as well.

Crucially, the validation of these fields differs for secondary tenants
in a couple of ways. Firstly, secondary tenants are only allowed to set
locality attributes in their constraints clause. Even then, they're
only allowed to set zone/region tiers. All other constraints
(such as disk type, or rack locality) are rejected. This is because
secondary tenants have a very narrow view of the cluster via the
`RegionServer`.

Secondly, we validate both positive and negative constraints for
secondary tenants (unlike the system tenant where we validate only
positive constraints). This follows from the "narrow view" secondary
tenants get -- we don't want them configuring arbitrary constraints,
positive or negative.

Closes #69199

Release justification: Non production code change
Release note: None