### PR TITLE
logictest: skip > 3 node logic tests in bazel

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -3265,6 +3265,9 @@ func RunLogicTestWithDefaultConfig(
 			if logicTestsConfigFilter != "" && cfg.name != logicTestsConfigFilter {
 				skip.IgnoreLint(t, "config does not match env var")
 			}
+			if cfg.numNodes > 3 {
+				skip.UnderBazelWithIssue(t, 69276, "multi-node tests fail")
+			}
 			for i, path := range paths {
 				path := path // Rebind range variable.
 				onlyNonMetamorphic := nonMetamorphic[i]


### PR DESCRIPTION
Bazel fails pretty opaquely in CI under multi-region tests regularly,
but the logs for the server (which is available under Github CI) is not
available here. For now, skip these logic tests in bazel setup.

Refs: #69276

Release justification: test only change

Release note: None