### PR TITLE
release-21.1: sql: fix COPY bugs for binary/csv formats

### DIFF
--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -247,7 +247,6 @@ func (c *copyMachine) run(ctx context.Context) error {
 	case tree.CopyFormatCSV:
 		c.csvInput.Reset()
 		c.csvReader = csv.NewReader(&c.csvInput)
-		//c.csvReader = csv.NewReader(&c.buf)
 		c.csvReader.Comma = rune(c.delimiter)
 		c.csvReader.ReuseRecord = true
 		c.csvReader.FieldsPerRecord = len(c.resultColumns)

--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -68,6 +68,7 @@ type copyMachine struct {
 	// NULL. The spec says this is only supported for CSV, and also must specify
 	// which columns it applies to.
 	forceNotNull bool
+	csvInput     bytes.Buffer
 	csvReader    *csv.Reader
 	// buf is used to parse input data into rows. It also accumulates a partial
 	// row between protocol messages.
@@ -244,7 +245,9 @@ func (c *copyMachine) run(ctx context.Context) error {
 	case tree.CopyFormatText:
 		c.textDelim = []byte{c.delimiter}
 	case tree.CopyFormatCSV:
-		c.csvReader = csv.NewReader(&c.buf)
+		c.csvInput.Reset()
+		c.csvReader = csv.NewReader(&c.csvInput)
+		//c.csvReader = csv.NewReader(&c.buf)
 		c.csvReader.Comma = rune(c.delimiter)
 		c.csvReader.ReuseRecord = true
 		c.csvReader.FieldsPerRecord = len(c.resultColumns)
@@ -327,25 +330,17 @@ func (c *copyMachine) processCopyData(ctx context.Context, data string, final bo
 	}
 	c.buf.WriteString(data)
 	var readFn func(ctx context.Context, final bool) (brk bool, err error)
-	var checkLoopFn func() bool
 	switch c.format {
 	case tree.CopyFormatText:
 		readFn = c.readTextData
-		checkLoopFn = func() bool { return c.buf.Len() > 0 }
 	case tree.CopyFormatBinary:
 		readFn = c.readBinaryData
-		checkLoopFn = func() bool { return c.buf.Len() > 0 }
 	case tree.CopyFormatCSV:
 		readFn = c.readCSVData
-		// Never exit the loop from this check. Instead, it's up to the readCSVData
-		// function to break when it's done reading. This is because the csv.Reader
-		// consumes all of c.buf in one shot, so checking if c.buf is empty would
-		// cause us to exit the loop early.
-		checkLoopFn = func() bool { return true }
 	default:
 		panic("unknown copy format")
 	}
-	for checkLoopFn() {
+	for c.buf.Len() > 0 {
 		brk, err := readFn(ctx, final)
 		if err != nil {
 			return err
@@ -387,12 +382,47 @@ func (c *copyMachine) readTextData(ctx context.Context, final bool) (brk bool, e
 }
 
 func (c *copyMachine) readCSVData(ctx context.Context, final bool) (brk bool, err error) {
+	var fullLine []byte
+	quoteCharsSeen := 0
+	// Keep reading lines until we encounter a newline that is not inside a
+	// quoted field, and therefore signifies the end of a CSV record.
+	for {
+		line, err := c.buf.ReadBytes(lineDelim)
+		fullLine = append(fullLine, line...)
+		if err != nil {
+			if err == io.EOF {
+				if final {
+					// If we reached EOF and this is the final chunk of input data, then
+					// try to process it.
+					break
+				} else {
+					// If there's more CopyData, put the incomplete row back in the
+					// buffer, to be processed next time.
+					c.buf.Write(fullLine)
+					return true, nil
+				}
+			} else {
+				return false, err
+			}
+		}
+		// At this point, we know fullLine ends in '\n'. Keep track of the total
+		// number of QUOTE chars in fullLine -- if it is even, then it means that
+		// the quotes are balanced and '\n' is not in a quoted field.
+		// Currently, the QUOTE char and ESCAPE char are both always equal to '"'
+		// and are not configurable. As per the COPY spec, any appearance of the
+		// QUOTE or ESCAPE characters in an actual value must be preceded by an
+		// ESCAPE character. This means that an escaped '"' also results in an even
+		// number of '"' characters.
+		quoteCharsSeen += bytes.Count(line, []byte{'"'})
+		if quoteCharsSeen%2 == 0 {
+			break
+		}
+	}
+
+	c.csvInput.Write(fullLine)
 	record, err := c.csvReader.Read()
 	// Look for end of data before checking for errors, since a field count
 	// error will still return record data.
-	if record == nil && err == io.EOF {
-		return true, nil
-	}
 	if len(record) == 1 && record[0] == endOfData && c.buf.Len() == 0 {
 		return true, nil
 	}

--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -445,7 +445,7 @@ func (c *copyMachine) readCSVTuple(ctx context.Context, record []string) error {
 			exprs[i] = tree.DNull
 			continue
 		}
-		d, err := rowenc.ParseDatumStringAsWithRawBytes(c.resultColumns[i].Typ, s, c.parsingEvalCtx)
+		d, err := rowenc.ParseDatumStringAs(c.resultColumns[i].Typ, s, c.parsingEvalCtx)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -226,8 +226,12 @@ func (c *copyMachine) run(ctx context.Context) error {
 	defer c.rowsMemAcc.Close(ctx)
 	defer c.bufMemAcc.Close(ctx)
 
+	format := pgwirebase.FormatText
+	if c.format == tree.CopyFormatBinary {
+		format = pgwirebase.FormatBinary
+	}
 	// Send the message describing the columns to the client.
-	if err := c.conn.BeginCopyIn(ctx, c.resultColumns); err != nil {
+	if err := c.conn.BeginCopyIn(ctx, c.resultColumns, format); err != nil {
 		return err
 	}
 

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -1086,12 +1086,14 @@ func (c *conn) handleFlush(ctx context.Context) error {
 }
 
 // BeginCopyIn is part of the pgwirebase.Conn interface.
-func (c *conn) BeginCopyIn(ctx context.Context, columns []colinfo.ResultColumn) error {
+func (c *conn) BeginCopyIn(
+	ctx context.Context, columns []colinfo.ResultColumn, format pgwirebase.FormatCode,
+) error {
 	c.msgBuilder.initMsg(pgwirebase.ServerMsgCopyInResponse)
-	c.msgBuilder.writeByte(byte(pgwirebase.FormatText))
+	c.msgBuilder.writeByte(byte(format))
 	c.msgBuilder.putInt16(int16(len(columns)))
 	for range columns {
-		c.msgBuilder.putInt16(int16(pgwirebase.FormatText))
+		c.msgBuilder.putInt16(int16(format))
 	}
 	return c.msgBuilder.finishMsg(c.conn)
 }

--- a/pkg/sql/pgwire/pgwirebase/conn.go
+++ b/pkg/sql/pgwire/pgwirebase/conn.go
@@ -29,10 +29,7 @@ type Conn interface {
 	// BeginCopyIn sends the message server message initiating the Copy-in
 	// subprotocol (COPY ... FROM STDIN). This message informs the client about
 	// the columns that are expected for the rows to be inserted.
-	//
-	// Currently, we only support the "text" format for COPY IN.
-	// See: https://www.postgresql.org/docs/current/static/protocol-flow.html#PROTOCOL-COPY
-	BeginCopyIn(ctx context.Context, columns []colinfo.ResultColumn) error
+	BeginCopyIn(ctx context.Context, columns []colinfo.ResultColumn, format FormatCode) error
 
 	// SendCommandComplete sends a serverMsgCommandComplete with the given
 	// payload.

--- a/pkg/sql/pgwire/testdata/pgtest/copy
+++ b/pkg/sql/pgwire/testdata/pgtest/copy
@@ -498,3 +498,32 @@ ReadyForQuery
 {"Type":"DataRow","Values":[{"text":"3"},{"text":"6162096364"},{"text":"ab\\011\\143d"}]}
 {"Type":"CommandComplete","CommandTag":"SELECT 3"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Test error cases for COPY CSV.
+send
+Query {"String": "COPY t FROM STDIN WITH CSV"}
+CopyData {"Data": "10,\"ten\"\n\n\n11,eleven"}
+CopyDone
+----
+
+until
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"CopyInResponse","ColumnFormatCodes":[0,0]}
+{"Type":"ErrorResponse","Code":"22P04"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "COPY t FROM STDIN WITH CSV"}
+CopyData {"Data": "1,\"one\n"}
+CopyDone
+----
+
+until
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"CopyInResponse","ColumnFormatCodes":[0,0]}
+{"Type":"ErrorResponse","Code":"22P04"}
+{"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/sql/pgwire/testdata/pgtest/copy
+++ b/pkg/sql/pgwire/testdata/pgtest/copy
@@ -310,3 +310,30 @@ ReadyForQuery
 {"Type":"DataRow","Values":[{"text":"3"},{"text":"three"}]}
 {"Type":"CommandComplete","CommandTag":"SELECT 3"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Verify that the format code is reported as binary.
+# This also verifies that the protocol checks for the correct
+# binary signature.
+send
+Query {"String": "DELETE FROM t"}
+Query {"String": "COPY t FROM STDIN WITH BINARY"}
+CopyData {"BinaryData": "UEdDT1BZCv8NCgAAAAAAAAAAAAACAAAACAAAAAAAAAABAAAAA2NhdAACAAAACAAAAAAAAAACAAAAA2RvZw=="}
+CopyDone
+Query {"String": "SELECT * FROM t ORDER BY i"}
+----
+
+until ignore=RowDescription
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"DELETE 3"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+{"Type":"CopyInResponse","ColumnFormatCodes":[1,1]}
+{"Type":"CommandComplete","CommandTag":"COPY 2"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+{"Type":"DataRow","Values":[{"text":"1"},{"text":"cat"}]}
+{"Type":"DataRow","Values":[{"text":"2"},{"text":"dog"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 2"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+

--- a/pkg/sql/pgwire/testdata/pgtest/copy
+++ b/pkg/sql/pgwire/testdata/pgtest/copy
@@ -337,3 +337,53 @@ ReadyForQuery
 {"Type":"CommandComplete","CommandTag":"SELECT 2"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
+# Verify that COPY binary input can be split up at an arbitrary point.
+send
+Query {"String": "DELETE FROM t"}
+Query {"String": "COPY t FROM STDIN WITH BINARY"}
+CopyData {"BinaryData": "UEdDT1BZCv8NCgAAAAAAAAAA"}
+CopyData {"BinaryData": "AAACAAAACAAAAAAAAAABAAAAA2NhdAACAAAACAAAAAAAAAACAAAAA2RvZw=="}
+CopyDone
+Query {"String": "SELECT * FROM t ORDER BY i"}
+----
+
+until ignore=RowDescription
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"DELETE 2"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+{"Type":"CopyInResponse","ColumnFormatCodes":[1,1]}
+{"Type":"CommandComplete","CommandTag":"COPY 2"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+{"Type":"DataRow","Values":[{"text":"1"},{"text":"cat"}]}
+{"Type":"DataRow","Values":[{"text":"2"},{"text":"dog"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 2"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Verify that COPY binary input can be split up at another arbitrary point.
+send
+Query {"String": "DELETE FROM t"}
+Query {"String": "COPY t FROM STDIN WITH BINARY"}
+CopyData {"BinaryData": "UEdDT1BZCv8NCgAAAAAAAAAAAAACAAAACAAA"}
+CopyData {"BinaryData": "AAAAAAABAAAAA2NhdAACAAAACAAAAAAAAAAC"}
+CopyData {"BinaryData": "AAAAA2RvZw=="}
+CopyDone
+Query {"String": "SELECT * FROM t ORDER BY i"}
+----
+
+until ignore=RowDescription
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"DELETE 2"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+{"Type":"CopyInResponse","ColumnFormatCodes":[1,1]}
+{"Type":"CommandComplete","CommandTag":"COPY 2"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+{"Type":"DataRow","Values":[{"text":"1"},{"text":"cat"}]}
+{"Type":"DataRow","Values":[{"text":"2"},{"text":"dog"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 2"}
+{"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/sql/pgwire/testdata/pgtest/copy
+++ b/pkg/sql/pgwire/testdata/pgtest/copy
@@ -387,3 +387,47 @@ ReadyForQuery
 {"Type":"DataRow","Values":[{"text":"2"},{"text":"dog"}]}
 {"Type":"CommandComplete","CommandTag":"SELECT 2"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Verify that COPY CSV input can be split up at arbitrary points.
+send
+Query {"String": "DELETE FROM t"}
+Query {"String": "COPY t FROM STDIN WITH CSV"}
+CopyData {"Data": "1,o"}
+CopyData {"Data": "ne\n2,"}
+CopyData {"Data": "tw"}
+CopyData {"Data": "o\n"}
+CopyData {"Data": "3,\""}
+CopyData {"Data": "three\""}
+CopyData {"Data": "\"e"}
+CopyData {"Data": "e\"\n4,\"four\n"}
+CopyData {"Data": "r\nr"}
+CopyData {"Data": "\"\n5,\"f\n\"\"ive\"\n6,\"six"}
+CopyData {"Data": "\""}
+CopyData {"Data": "\n7,seven\n8,eight\n9,\"n\nii"}
+CopyData {"Data": "ii\n"}
+CopyData {"Data": "ne\""}
+CopyDone
+Query {"String": "SELECT * FROM t ORDER BY i"}
+----
+
+until ignore=NoticeResponse ignore=RowDescription
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"DELETE 2"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+{"Type":"CopyInResponse","ColumnFormatCodes":[0,0]}
+{"Type":"CommandComplete","CommandTag":"COPY 9"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+{"Type":"DataRow","Values":[{"text":"1"},{"text":"one"}]}
+{"Type":"DataRow","Values":[{"text":"2"},{"text":"two"}]}
+{"Type":"DataRow","Values":[{"text":"3"},{"text":"three\"ee"}]}
+{"Type":"DataRow","Values":[{"text":"4"},{"binary":"666f75720a720a72"}]}
+{"Type":"DataRow","Values":[{"text":"5"},{"binary":"660a22697665"}]}
+{"Type":"DataRow","Values":[{"text":"6"},{"text":"six"}]}
+{"Type":"DataRow","Values":[{"text":"7"},{"text":"seven"}]}
+{"Type":"DataRow","Values":[{"text":"8"},{"text":"eight"}]}
+{"Type":"DataRow","Values":[{"text":"9"},{"binary":"6e0a696969690a6e65"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 9"}
+{"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/sql/pgwire/testdata/pgtest/copy
+++ b/pkg/sql/pgwire/testdata/pgtest/copy
@@ -431,3 +431,70 @@ ReadyForQuery
 {"Type":"DataRow","Values":[{"text":"9"},{"binary":"6e0a696969690a6e65"}]}
 {"Type":"CommandComplete","CommandTag":"SELECT 9"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Verify that byte-escape sequences are processed in TEXT mode.
+send
+Query {"String": "DROP TABLE IF EXISTS tb"}
+Query {"String": "CREATE TABLE tb (i INT, b BYTEA, c TEXT)"}
+Query {"String": "COPY tb FROM STDIN DELIMITER ',' NULL ''"}
+CopyData {"Data": "1,one,one\n"}
+CopyData {"Data": "2,two\\x54,two\\x54\n"}
+CopyData {"Data": "3,ab\\011\\143d,ab\\011\\143d"}
+CopyDone
+Query {"String": "SELECT i, encode(b, 'hex'), c FROM tb ORDER BY i"}
+----
+
+until ignore=RowDescription ignore=NoticeResponse
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"DROP TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+{"Type":"CommandComplete","CommandTag":"CREATE TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+{"Type":"CopyInResponse","ColumnFormatCodes":[0,0,0]}
+{"Type":"CommandComplete","CommandTag":"COPY 3"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+{"Type":"DataRow","Values":[{"text":"1"},{"text":"6f6e65"},{"text":"one"}]}
+{"Type":"DataRow","Values":[{"text":"2"},{"text":"74776f54"},{"text":"twoT"}]}
+{"Type":"DataRow","Values":[{"text":"3"},{"text":"6162096364"},{"binary":"6162096364"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 3"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Verify that byte-escape sequences are NOT processed in CSV mode. Note that
+# the octal-encoded input for the bytea column is properly decoded -- that is
+# because of the way CRDB and PG process bytea literals, and *not* because of
+# CSV escaping.
+# Because of https://github.com/cockroachdb/cockroach/issues/26128 we cannot
+# test the `\xAA` escape style with a bytea column.
+send
+Query {"String": "DROP TABLE IF EXISTS tb"}
+Query {"String": "CREATE TABLE tb (i INT, b BYTEA, c TEXT)"}
+Query {"String": "COPY tb FROM STDIN WITH CSV"}
+CopyData {"Data": "1,one,one\n"}
+CopyData {"Data": "2,two,two\\x54\n"}
+CopyData {"Data": "3,ab\\011\\143d,ab\\011\\143d"}
+CopyDone
+Query {"String": "SELECT i, encode(b, 'hex'), c FROM tb ORDER BY i"}
+----
+
+until ignore=RowDescription ignore=NoticeResponse
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"DROP TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+{"Type":"CommandComplete","CommandTag":"CREATE TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+{"Type":"CopyInResponse","ColumnFormatCodes":[0,0,0]}
+{"Type":"CommandComplete","CommandTag":"COPY 3"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+{"Type":"DataRow","Values":[{"text":"1"},{"text":"6f6e65"},{"text":"one"}]}
+{"Type":"DataRow","Values":[{"text":"2"},{"text":"74776f"},{"text":"two\\x54"}]}
+{"Type":"DataRow","Values":[{"text":"3"},{"text":"6162096364"},{"text":"ab\\011\\143d"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 3"}
+{"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/testutils/lint/passes/errcmp/errcmp.go
+++ b/pkg/testutils/lint/passes/errcmp/errcmp.go
@@ -103,7 +103,7 @@ Alternatives:
 func isEOFError(e ast.Expr) bool {
 	if s, ok := e.(*ast.SelectorExpr); ok {
 		if io, ok := s.X.(*ast.Ident); ok && io.Name == "io" && io.Obj == (*ast.Object)(nil) {
-			if s.Sel.Name == "EOF" {
+			if s.Sel.Name == "EOF" || s.Sel.Name == "ErrUnexpectedEOF" {
 				return true
 			}
 		}
@@ -116,9 +116,9 @@ func checkErrCmp(pass *analysis.Pass, binaryExpr *ast.BinaryExpr) {
 	case token.NEQ, token.EQL:
 		if pass.TypesInfo.Types[binaryExpr.X].Type == errorType &&
 			!pass.TypesInfo.Types[binaryExpr.Y].IsNil() {
-			// We have a special case: when the RHS is io.EOF.
-			// This is nearly always used with APIs that return
-			// it undecorated.
+			// We have a special case: when the RHS is io.EOF or io.ErrUnexpectedEOF.
+			// They are nearly always used with APIs that return
+			// an undecorated error.
 			if isEOFError(binaryExpr.Y) {
 				return
 			}

--- a/pkg/testutils/pgtest/datadriven.go
+++ b/pkg/testutils/pgtest/datadriven.go
@@ -48,7 +48,10 @@ func WalkWithNewServer(
 // "send": Sends messages to a server. Takes a newline-delimited list of
 // pgproto3.FrontendMessage types. Can fill in values by adding a space then
 // a JSON object. No output. Messages with a []byte type (like CopyData) should
-// not base64 encode the data, instead use Go-escaped strings.
+// not base64 encode the data, instead use Go-escaped strings. If the input
+// data actually has binary input or characters not allowed in JSON strings
+// (like '\n'), then a base64-encoded value should be used as the `BinaryData`
+// field.
 //
 // "until": Receives all messages from a server until messages of the given
 // types have been seen. Converts them to JSON one per line as output. Takes

--- a/pkg/testutils/pgtest/pgtest.go
+++ b/pkg/testutils/pgtest/pgtest.go
@@ -103,11 +103,18 @@ func (p *PGTest) SendOneLine(line string) error {
 		msgBytes := []byte(sp[1])
 		switch msg := msg.(type) {
 		case *pgproto3.CopyData:
-			var data struct{ Data string }
+			var data struct {
+				Data       string
+				BinaryData []byte
+			}
 			if err := json.Unmarshal(msgBytes, &data); err != nil {
 				return err
 			}
-			msg.Data = []byte(data.Data)
+			if data.BinaryData != nil {
+				msg.Data = data.BinaryData
+			} else {
+				msg.Data = []byte(data.Data)
+			}
 		default:
 			if err := json.Unmarshal(msgBytes, msg); err != nil {
 				return err


### PR DESCRIPTION
Backport 5/5 commits from #69066.

/cc @cockroachdb/release

---

See individual commits:

sql: return correct format code for COPY
fixes #63235 

sql: COPY BINARY messages can be split at arbitrary boundaries 
fixes #68805 

sql: COPY CSV handles arbitrary message boundaries
refs #68805 

sql: fix byte escaping in COPY CSV input 
fixes #68804 

Release justification: Fixes for high-priority bugs in existing functionality. ("Another rule of thumb to consider: if a customer hit this bug after releasing, would we patch the release to fix it? If we would patch the release later to fix the bug, then usually it's best to fix the bug now.")
