### PR TITLE
build,ccl: quash a few outdated references to `libroach`

### DIFF
--- a/build/builder/Dockerfile
+++ b/build/builder/Dockerfile
@@ -10,7 +10,7 @@ FROM ubuntu:focal-20210119
 # autopoint - sed build
 # bison - CRDB build system
 # clang-10 - compiler
-# cmake - c-deps: libroach, protobuf, et al.
+# cmake - c-deps: geos, protobuf, et al.
 # gcc/g++ - host builds
 # gettext - sed build
 # gnupg2 - for apt

--- a/c-deps/REPOSITORIES.bzl
+++ b/c-deps/REPOSITORIES.bzl
@@ -6,10 +6,7 @@ BUILD_ALL_CONTENT = """filegroup(name = "all", srcs = glob(["**"]), visibility =
 
 # Each of these c-dependencies map to one or more library definitions in the
 # top-level BUILD.bazel. Library definitions will list the following
-# definitions as sources. For certain libraries (like `libroachccl`), the
-# repository definitions are also listed as tool dependencies. This is because
-# building those libraries require certain checked out repositories being
-# placed relative to the source tree of the library itself.
+# definitions as sources.
 
 # This is essentially the same above, we elide a generated file to avoid
 # permission issues when building jemalloc within the bazel sandbox.

--- a/pkg/ccl/README.md
+++ b/pkg/ccl/README.md
@@ -5,5 +5,3 @@ convention, all packages under this tree have the suffix `ccl`.
 Grouping CCL packages into one tree and clearly labeling all CCL packages
 with a recognizable suffix will hopefully make it easier to identify and prevent
 introducing any accidental dependencies on ccl from Apache2 packages.
-
-C++ CCL code lives in [c-deps/libroach/ccl](/c-deps/libroach/ccl).


### PR DESCRIPTION
`libroach` doesn't exist any more.

Release justification: Non-production code change
Release note: None