### PR TITLE
jobs: retry non-cancelable running and all reverting jobs

### DIFF
--- a/pkg/ccl/multiregionccl/region_test.go
+++ b/pkg/ccl/multiregionccl/region_test.go
@@ -266,7 +266,7 @@ func TestRegionAddDropEnclosingRegionalByRowOps(t *testing.T) {
 							<-rbrOpFinished
 							if !regionAlterCmd.shouldSucceed {
 								// Trigger a roll-back.
-								return errors.New("boom")
+								return jobs.MarkAsPermanentJobError(errors.New("boom"))
 							}
 							// Trod on.
 							return nil
@@ -544,7 +544,7 @@ func TestDroppingPrimaryRegionAsyncJobFailure(t *testing.T) {
 	knobs := base.TestingKnobs{
 		SQLTypeSchemaChanger: &sql.TypeSchemaChangerTestingKnobs{
 			RunBeforeExec: func() error {
-				return errors.New("yikes")
+				return jobs.MarkAsPermanentJobError(errors.New("yikes"))
 			},
 			RunAfterOnFailOrCancel: func() error {
 				mu.Lock()
@@ -609,7 +609,7 @@ func TestRollbackDuringAddDropRegionAsyncJobFailure(t *testing.T) {
 	knobs := base.TestingKnobs{
 		SQLTypeSchemaChanger: &sql.TypeSchemaChangerTestingKnobs{
 			RunBeforeMultiRegionUpdates: func() error {
-				return errors.New("boom")
+				return jobs.MarkAsPermanentJobError(errors.New("boom"))
 			},
 		},
 		// Decrease the adopt loop interval so that retries happen quickly.
@@ -692,7 +692,7 @@ func TestRollbackDuringAddDropRegionPlacementRestricted(t *testing.T) {
 	knobs := base.TestingKnobs{
 		SQLTypeSchemaChanger: &sql.TypeSchemaChangerTestingKnobs{
 			RunBeforeMultiRegionUpdates: func() error {
-				return errors.New("boom")
+				return jobs.MarkAsPermanentJobError(errors.New("boom"))
 			},
 		},
 		// Decrease the adopt loop interval so that retries happen quickly.

--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -305,7 +305,7 @@ func (rts *registryTestSuite) setUp(t *testing.T) {
 					rts.mu.Lock()
 					rts.mu.a.OnFailOrCancelExit = true
 					rts.mu.Unlock()
-					t.Log("Exiting OnFailOrCancel")
+					t.Log("Exiting FailOrCancel")
 					return err
 				}
 			},
@@ -744,17 +744,20 @@ func TestRegistryLifecycle(t *testing.T) {
 	})
 
 	// Attempt to mark success, but fail, but fail that also.
-	// TODO(ajwerner): This test seems a bit stale in that it really
-	// fails the resume rather than succeeding but failing to mark success.
-	// I think this is due to changes in responsibilities of the jobs
-	// lifecycle.
 	t.Run("fail marking success and fail OnFailOrCancel", func(t *testing.T) {
-		rts := registryTestSuite{}
+		var triedToMarkSucceeded atomic.Value
+		triedToMarkSucceeded.Store(false)
+		rts := registryTestSuite{beforeUpdate: func(orig, updated jobs.JobMetadata) error {
+			// Fail marking succeeded.
+			if updated.Status == jobs.StatusSucceeded {
+				triedToMarkSucceeded.Store(true)
+				return errors.New("injected failure at marking as succeeded")
+			}
+			return nil
+		}}
 		rts.setUp(t)
 		defer rts.tearDown()
 
-		// Make marking success fail.
-		rts.successErr = errors.New("injected failure at marking as succeeded")
 		j, err := jobs.TestingCreateAndStartJob(rts.ctx, rts.registry, rts.s.DB(), rts.mockJob)
 		if err != nil {
 			t.Fatal(err)
@@ -764,20 +767,47 @@ func TestRegistryLifecycle(t *testing.T) {
 		rts.mu.e.ResumeStart = true
 		rts.resumeCheckCh <- struct{}{}
 		rts.check(t, jobs.StatusRunning)
-
+		// Let the resumer complete without error.
 		rts.resumeCh <- nil
 		rts.mu.e.ResumeExit++
 		rts.mu.e.Success = true
-		rts.mu.e.OnFailOrCancelStart = true
+
+		// The job is retried as we failed to mark the job successful.
+		rts.mu.e.ResumeStart = true
+		rts.resumeCheckCh <- struct{}{}
+		rts.check(t, jobs.StatusRunning)
+		// Fail the resumer to transition to reverting state.
+		rts.resumeCh <- errors.New("injected error in resume")
+		rts.mu.e.ResumeExit++
 
 		// The job is now in state reverting and will never resume again because
 		// OnFailOrCancel also fails.
-		rts.check(t, jobs.StatusReverting)
+		//
+		// First retry.
+		rts.mu.e.OnFailOrCancelStart = true
 		rts.failOrCancelCheckCh <- struct{}{}
-		rts.mu.e.OnFailOrCancelExit = true
-		close(rts.failOrCancelCheckCh)
+		require.True(t, triedToMarkSucceeded.Load().(bool))
+		rts.check(t, jobs.StatusReverting)
 		rts.failOrCancelCh <- errors.New("injected failure while blocked in reverting")
-		rts.check(t, jobs.StatusRevertFailed)
+		rts.mu.e.OnFailOrCancelExit = true
+
+		// The job will be retried as all reverting jobs are retried.
+		//
+		// Second retry.
+		rts.mu.e.OnFailOrCancelStart = true
+		rts.failOrCancelCheckCh <- struct{}{}
+		rts.check(t, jobs.StatusReverting)
+		rts.failOrCancelCh <- errors.New("injected failure while blocked in reverting")
+		rts.mu.e.OnFailOrCancelExit = true
+
+		// The job will stay in reverting state. Let it fail to exit the test.
+		rts.mu.e.OnFailOrCancelStart = true
+		rts.failOrCancelCheckCh <- struct{}{}
+		rts.check(t, jobs.StatusReverting)
+		close(rts.failOrCancelCh)
+		rts.mu.e.OnFailOrCancelExit = true
+
+		rts.check(t, jobs.StatusFailed)
 	})
 	// Succeed the job but inject an error actually marking the jobs successful.
 	// This could happen due to a transient network error or something like that.
@@ -827,12 +857,22 @@ func TestRegistryLifecycle(t *testing.T) {
 
 	// Fail the job, but also fail to mark it failed.
 	t.Run("fail marking failed", func(t *testing.T) {
-		rts := registryTestSuite{}
+		var triedToMarkFailed atomic.Value
+		triedToMarkFailed.Store(false)
+		rts := registryTestSuite{beforeUpdate: func(orig, updated jobs.JobMetadata) error {
+			if triedToMarkFailed.Load().(bool) == true {
+				return nil
+			}
+			if updated.Status == jobs.StatusFailed {
+				triedToMarkFailed.Store(true)
+				return errors.New("injected error while marking as failed")
+			}
+			return nil
+		}}
 		rts.setUp(t)
 		defer rts.tearDown()
 
 		// Make marking success fail.
-		rts.successErr = errors.New("resume failed")
 		j, err := jobs.TestingCreateAndStartJob(rts.ctx, rts.registry, rts.s.DB(), rts.mockJob)
 		if err != nil {
 			t.Fatal(err)
@@ -845,16 +885,24 @@ func TestRegistryLifecycle(t *testing.T) {
 
 		rts.resumeCh <- errors.New("resume failed")
 		rts.mu.e.ResumeExit++
+
 		rts.mu.e.OnFailOrCancelStart = true
 		rts.failOrCancelCheckCh <- struct{}{}
-		close(rts.failOrCancelCheckCh)
-		// The job is now in state reverting and will never resume again.
 		rts.check(t, jobs.StatusReverting)
-
-		// But let it fail.
+		// The job is now in state reverting and will never resume again.
+		// Let revert complete without error so that the job is attempted to mark as failed.
+		rts.failOrCancelCh <- nil
 		rts.mu.e.OnFailOrCancelExit = true
-		rts.failOrCancelCh <- errors.New("resume failed")
-		rts.check(t, jobs.StatusRevertFailed)
+
+		// We failed to mark the jobs as failed, resulting in the job to be retried.
+		rts.mu.e.OnFailOrCancelStart = true
+		rts.failOrCancelCheckCh <- struct{}{}
+		rts.check(t, jobs.StatusReverting)
+		require.True(t, triedToMarkFailed.Load().(bool))
+		// Let the job complete to exit the test.
+		close(rts.failOrCancelCh)
+		rts.mu.e.OnFailOrCancelExit = true
+		rts.check(t, jobs.StatusFailed)
 	})
 
 	t.Run("OnPauseRequest", func(t *testing.T) {
@@ -3210,53 +3258,141 @@ func TestPauseReason(t *testing.T) {
 	}
 }
 
-// TestNonCancelableJobsRetry tests that a non-cancelable job is retried when
-// failed with a non-retryable error.
-func TestNonCancelableJobsRetry(t *testing.T) {
+// TestJobsRetry tests that (1) non-cancelable jobs retry if they fail with an
+// error marked as permanent, (2) reverting job always retry instead of failing.
+func TestJobsRetry(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	// Create a non-cancelable job.
-	// Fail the job in resume to cause the job to revert.
-	// Fail the job in revert state using a non-retryable error.
-	// Make sure that the jobs is retried and is again in the revert state.
-	rts := registryTestSuite{}
-	rts.setUp(t)
-	defer rts.tearDown()
-	// Make mockJob non-cancelable.
-	rts.mockJob.SetNonCancelable(rts.ctx, func(ctx context.Context, nonCancelable bool) bool {
-		return true
+
+	t.Run("retry non-cancelable running", func(t *testing.T) {
+		rts := registryTestSuite{}
+		rts.setUp(t)
+		defer rts.tearDown()
+		// Make mockJob non-cancelable, ensuring that non-cancelable jobs are retried in running state.
+		rts.mockJob.SetNonCancelable(rts.ctx, func(ctx context.Context, nonCancelable bool) bool {
+			return true
+		})
+		j, err := jobs.TestingCreateAndStartJob(rts.ctx, rts.registry, rts.s.DB(), rts.mockJob)
+		if err != nil {
+			t.Fatal(err)
+		}
+		rts.job = j
+
+		// First job run in running state.
+		rts.mu.e.ResumeStart = true
+		rts.resumeCheckCh <- struct{}{}
+		rts.check(t, jobs.StatusRunning)
+		// Make Resume fail.
+		rts.resumeCh <- errors.New("non-permanent error")
+		rts.mu.e.ResumeExit++
+
+		// Job should be retried in running state.
+		rts.mu.e.ResumeStart = true
+		rts.resumeCheckCh <- struct{}{}
+		rts.check(t, jobs.StatusRunning)
+		rts.resumeCh <- jobs.MarkAsPermanentJobError(errors.New("permanent error"))
+		rts.mu.e.ResumeExit++
+
+		// Job should now revert.
+		rts.mu.e.OnFailOrCancelStart = true
+		rts.failOrCancelCheckCh <- struct{}{}
+		rts.check(t, jobs.StatusReverting)
+		rts.failOrCancelCh <- nil
+		rts.mu.e.OnFailOrCancelExit = true
+
+		close(rts.failOrCancelCh)
+		close(rts.failOrCancelCheckCh)
+		rts.check(t, jobs.StatusFailed)
 	})
-	j, err := jobs.TestingCreateAndStartJob(rts.ctx, rts.registry, rts.s.DB(), rts.mockJob)
-	if err != nil {
-		t.Fatal(err)
-	}
-	rts.job = j
 
-	rts.mu.e.ResumeStart = true
-	rts.resumeCheckCh <- struct{}{}
-	rts.check(t, jobs.StatusRunning)
+	t.Run("retry reverting", func(t *testing.T) {
+		// - Create a job.
+		// - Fail the job in resume to cause the job to revert.
+		// - Fail the job in revert state using a non-retryable error.
+		// - Make sure that the jobs is retried and is again in the revert state.
+		rts := registryTestSuite{}
+		rts.setUp(t)
+		defer rts.tearDown()
+		j, err := jobs.TestingCreateAndStartJob(rts.ctx, rts.registry, rts.s.DB(), rts.mockJob)
+		if err != nil {
+			t.Fatal(err)
+		}
+		rts.job = j
 
-	// Make Resume fail.
-	rts.resumeCh <- errors.New("failing resume to revert")
-	rts.mu.e.ResumeExit++
+		rts.mu.e.ResumeStart = true
+		rts.resumeCheckCh <- struct{}{}
+		rts.check(t, jobs.StatusRunning)
 
-	// Job is now reverting.
-	rts.mu.e.OnFailOrCancelStart = true
-	rts.failOrCancelCheckCh <- struct{}{}
-	rts.check(t, jobs.StatusReverting)
+		// Make Resume fail.
+		rts.resumeCh <- errors.New("failing resume to revert")
+		rts.mu.e.ResumeExit++
 
-	// Fail the job in reverting state without a retryable error.
-	rts.failOrCancelCh <- errors.New("failing with non-retryable error")
-	rts.mu.e.OnFailOrCancelExit = true
+		// Job is now reverting.
+		rts.mu.e.OnFailOrCancelStart = true
+		rts.failOrCancelCheckCh <- struct{}{}
+		rts.check(t, jobs.StatusReverting)
 
-	// Job should be retried even though it is non-cancelable.
-	rts.mu.e.OnFailOrCancelStart = true
-	rts.failOrCancelCheckCh <- struct{}{}
-	rts.check(t, jobs.StatusReverting)
-	rts.failOrCancelCh <- nil
-	rts.mu.e.OnFailOrCancelExit = true
+		// Fail the job in reverting state without a retryable error.
+		rts.failOrCancelCh <- errors.New("failing with a non-retryable error")
+		rts.mu.e.OnFailOrCancelExit = true
 
-	close(rts.failOrCancelCh)
-	close(rts.failOrCancelCheckCh)
-	rts.check(t, jobs.StatusFailed)
+		// Job should be retried.
+		rts.mu.e.OnFailOrCancelStart = true
+		rts.failOrCancelCheckCh <- struct{}{}
+		rts.check(t, jobs.StatusReverting)
+		rts.failOrCancelCh <- nil
+		rts.mu.e.OnFailOrCancelExit = true
+
+		close(rts.failOrCancelCh)
+		close(rts.failOrCancelCheckCh)
+		rts.check(t, jobs.StatusFailed)
+	})
+
+	t.Run("retry non-cancelable reverting", func(t *testing.T) {
+		// - Create a non-cancelable job.
+		// - Fail the job in resume with a permanent error to cause the job to revert.
+		// - Fail the job in revert state using a permanent error to ensure that the
+		//   retries with a permanent error as well.
+		// - Make sure that the jobs is retried and is again in the revert state.
+		rts := registryTestSuite{}
+		rts.setUp(t)
+		defer rts.tearDown()
+		// Make mockJob non-cancelable, ensuring that non-cancelable jobs are retried in reverting state.
+		rts.mockJob.SetNonCancelable(rts.ctx, func(ctx context.Context, nonCancelable bool) bool {
+			return true
+		})
+		j, err := jobs.TestingCreateAndStartJob(rts.ctx, rts.registry, rts.s.DB(), rts.mockJob)
+		if err != nil {
+			t.Fatal(err)
+		}
+		rts.job = j
+
+		rts.mu.e.ResumeStart = true
+		rts.resumeCheckCh <- struct{}{}
+		rts.check(t, jobs.StatusRunning)
+
+		// Make Resume fail with a permanent error.
+		rts.resumeCh <- jobs.MarkAsPermanentJobError(errors.New("permanent error"))
+		rts.mu.e.ResumeExit++
+
+		// Job is now reverting.
+		rts.mu.e.OnFailOrCancelStart = true
+		rts.failOrCancelCheckCh <- struct{}{}
+		rts.check(t, jobs.StatusReverting)
+
+		// Fail the job in reverting state with a permanent error a retryable error.
+		rts.failOrCancelCh <- jobs.MarkAsPermanentJobError(errors.New("permanent error"))
+		rts.mu.e.OnFailOrCancelExit = true
+
+		// Job should be retried.
+		rts.mu.e.OnFailOrCancelStart = true
+		rts.failOrCancelCheckCh <- struct{}{}
+		rts.check(t, jobs.StatusReverting)
+		rts.failOrCancelCh <- nil
+		rts.mu.e.OnFailOrCancelExit = true
+
+		close(rts.failOrCancelCh)
+		close(rts.failOrCancelCheckCh)
+		rts.check(t, jobs.StatusFailed)
+	})
 }

--- a/pkg/jobs/metrics.go
+++ b/pkg/jobs/metrics.go
@@ -48,7 +48,9 @@ type JobTypeMetrics struct {
 	ResumeFailed           *metric.Counter
 	FailOrCancelCompleted  *metric.Counter
 	FailOrCancelRetryError *metric.Counter
-	FailOrCancelFailed     *metric.Counter
+	// TODO (sajjad): FailOrCancelFailed metric is not updated after the modification
+	// of retrying all reverting jobs. Remove this metric in v22.1.
+	FailOrCancelFailed *metric.Counter
 }
 
 // MetricStruct implements the metric.Struct interface.

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -1193,10 +1193,16 @@ func (r *Registry) stepThroughStateMachine(
 			return errors.Errorf("job %d: node liveness error: restarting in background", job.ID())
 		}
 		// TODO(spaskob): enforce a limit on retries.
-		if errors.Is(err, errRetryJobSentinel) {
+
+		if nonCancelableRetry := job.Payload().Noncancelable && !IsPermanentJobError(err); nonCancelableRetry ||
+			errors.Is(err, errRetryJobSentinel) {
 			jm.ResumeRetryError.Inc(1)
+			if nonCancelableRetry {
+				err = errors.Wrapf(err, "non-cancelable")
+			}
 			return onExecutionFailed(err)
 		}
+
 		jm.ResumeFailed.Inc(1)
 		if sErr := (*InvalidStatusError)(nil); errors.As(err, &sErr) {
 			if sErr.status != StatusCancelRequested && sErr.status != StatusPauseRequested {
@@ -1259,31 +1265,14 @@ func (r *Registry) stepThroughStateMachine(
 			}
 			return r.stepThroughStateMachine(ctx, execCtx, resumer, job, nextStatus, jobErr)
 		}
+		jm.FailOrCancelRetryError.Inc(1)
 		if onFailOrCancelCtx.Err() != nil {
-			jm.FailOrCancelRetryError.Inc(1)
 			// The context was canceled. Tell the user, but don't attempt to
 			// mark the job as failed because it can be resumed by another node.
 			return errors.Errorf("job %d: node liveness error: restarting in background", job.ID())
 		}
-		if errors.Is(err, errRetryJobSentinel) {
-			jm.FailOrCancelRetryError.Inc(1)
-			return onExecutionFailed(err)
-		}
-		// A non-cancelable job is always retried while reverting unless the error is marked as permanent.
-		if job.Payload().Noncancelable && !IsPermanentJobError(err) {
-			jm.FailOrCancelRetryError.Inc(1)
-			return errors.Wrapf(err, "job %d: job is non-cancelable, restarting in background", job.ID())
-		}
-		jm.FailOrCancelFailed.Inc(1)
-		if sErr := (*InvalidStatusError)(nil); errors.As(err, &sErr) {
-			if sErr.status != StatusPauseRequested {
-				return errors.NewAssertionErrorWithWrappedErrf(jobErr,
-					"job %d: unexpected status %s provided for a reverting job", job.ID(), sErr.status)
-			}
-			return sErr
-		}
-		return r.stepThroughStateMachine(ctx, execCtx, resumer, job, StatusRevertFailed,
-			errors.Wrapf(err, "job %d: cannot be reverted, manual cleanup may be required", job.ID()))
+		// All reverting jobs are retried.
+		return onExecutionFailed(err)
 	case StatusFailed:
 		if jobErr == nil {
 			return errors.AssertionFailedf("job %d: has StatusFailed but no error was provided", job.ID())
@@ -1296,6 +1285,9 @@ func (r *Registry) stepThroughStateMachine(
 		telemetry.Inc(TelemetryMetrics[jobType].Failed)
 		return jobErr
 	case StatusRevertFailed:
+		// TODO(sajjad): Remove StatusRevertFailed and related code in other places in v22.1.
+		// v21.2 modified all reverting jobs to retry instead of go to revert-failed. Therefore,
+		// revert-failed state is not reachable after 21.2.
 		if jobErr == nil {
 			return errors.AssertionFailedf("job %d: has StatusRevertFailed but no error was provided",
 				job.ID())

--- a/pkg/migration/migrationmanager/manager_external_test.go
+++ b/pkg/migration/migrationmanager/manager_external_test.go
@@ -142,7 +142,7 @@ RETURNING id;`).Scan(&secondID))
 	require.Regexp(t, "found multiple non-terminal jobs for version", err)
 
 	// Let the fake, erroneous job finish with an error.
-	fakeJobBlockChan <- errors.New("boom")
+	fakeJobBlockChan <- jobs.MarkAsPermanentJobError(errors.New("boom"))
 	require.Regexp(t, "boom", <-runErr)
 
 	// Launch a second migration which later we'll ensure does not kick off
@@ -504,7 +504,7 @@ func TestPrecondition(t *testing.T) {
 		) error {
 			atomic.AddInt64(run, 1)
 			if err.Load().(bool) {
-				return errors.New("boom")
+				return jobs.MarkAsPermanentJobError(errors.New("boom"))
 			}
 			return nil
 		}

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -740,7 +740,6 @@ func (sc *SchemaChanger) handlePermanentSchemaChangeError(
 		// than tables. For jobs intended to drop other types of descriptors, we do
 		// nothing.
 		if _, ok := desc.(catalog.TableDescriptor); !ok {
-			// Mark the error as permanent so that is not retried in reverting state.
 			return jobs.MarkAsPermanentJobError(errors.Newf("schema change jobs on databases and schemas cannot be reverted"))
 		}
 
@@ -2262,12 +2261,17 @@ func (r schemaChangeResumer) OnFailOrCancel(ctx context.Context, execCtx interfa
 	p := execCtx.(JobExecContext)
 	details := r.job.Details().(jobspb.SchemaChangeDetails)
 
+	if fn := p.ExecCfg().SchemaChangerTestingKnobs.RunBeforeOnFailOrCancel; fn != nil {
+		if err := fn(r.job.ID()); err != nil {
+			return err
+		}
+	}
+
 	// If this is a schema change to drop a database or schema, DescID will be
 	// unset. We cannot revert such schema changes, so just exit early with an
 	// error.
 	if details.DescID == descpb.InvalidID {
-		// Mark the error as permanent so that is not retried in reverting state.
-		return jobs.MarkAsPermanentJobError(errors.Newf("schema change jobs on databases and schemas cannot be reverted"))
+		return errors.Newf("schema change jobs on databases and schemas cannot be reverted")
 	}
 	sc := SchemaChanger{
 		descID:               details.DescID,
@@ -2286,12 +2290,6 @@ func (r schemaChangeResumer) OnFailOrCancel(ctx context.Context, execCtx interfa
 		ieFactory: func(ctx context.Context, sd *sessiondata.SessionData) sqlutil.InternalExecutor {
 			return r.job.MakeSessionBoundInternalExecutor(ctx, sd)
 		},
-	}
-
-	if fn := sc.testingKnobs.RunBeforeOnFailOrCancel; fn != nil {
-		if err := fn(r.job.ID()); err != nil {
-			return err
-		}
 	}
 
 	if r.job.Payload().FinalResumeError == nil {

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -428,7 +428,7 @@ func TestRollbackOfAddingTable(t *testing.T) {
 				defer mu.Unlock()
 				if shouldError {
 					shouldError = false
-					return errors.New("boom")
+					return jobs.MarkAsPermanentJobError(errors.New("boom"))
 				}
 				return nil
 			},
@@ -2147,6 +2147,7 @@ CREATE TABLE t.test (
 func TestSchemaUniqueColumnDropFailure(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	waitUntilRevert := make(chan struct{})
 	params, _ := tests.CreateTestServerParams()
 	const chunkSize = 200
 	attempts := 0
@@ -2168,6 +2169,11 @@ func TestSchemaUniqueColumnDropFailure(t *testing.T) {
 			// Aggressively checkpoint, so that a schema change
 			// failure happens after a checkpoint has been written.
 			WriteCheckpointInterval: time.Nanosecond,
+			RunBeforeOnFailOrCancel: func(jobID jobspb.JobID) error {
+				waitUntilRevert <- struct{}{}
+				<-waitUntilRevert
+				return nil
+			},
 		},
 		// Disable GC job.
 		GCJob: &sql.GCJobTestingKnobs{RunBeforeResume: func(_ jobspb.JobID) error { select {} }},
@@ -2187,6 +2193,7 @@ func TestSchemaUniqueColumnDropFailure(t *testing.T) {
 		StartupMigrationManager: &startupmigrations.MigrationManagerTestingKnobs{
 			DisableBackfillMigrations: true,
 		},
+		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 	}
 	server, sqlDB, kvDB := serverutils.StartServer(t, params)
 	defer server.Stopper().Stop(context.Background())
@@ -2208,9 +2215,13 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT UNIQUE DEFAULT 23 CREATE FAMILY F3
 	}
 
 	// A schema change that fails.
-	if _, err := sqlDB.Exec(`ALTER TABLE t.test DROP column v`); !testutils.IsError(err, `permanent failure`) {
-		t.Fatalf("err = %s", err)
-	}
+	go func() {
+		// This query stays blocked until the end of the test.
+		_, _ = sqlDB.Exec(`ALTER TABLE t.test DROP column v`)
+	}()
+
+	// Wait until the job is reverted.
+	<-waitUntilRevert
 
 	// The index is not regenerated.
 	tableDesc := catalogkv.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "t", "test")
@@ -2230,6 +2241,8 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT UNIQUE DEFAULT 23 CREATE FAMILY F3
 	} else if len(tableDesc.AllMutations()) != 2 {
 		t.Fatalf("mutations %+v", tableDesc.AllMutations())
 	}
+
+	close(waitUntilRevert)
 }
 
 // TestVisibilityDuringPrimaryKeyChange tests visibility of different indexes
@@ -6365,10 +6378,10 @@ SELECT status, error FROM crdb_internal.jobs WHERE description LIKE '%CREATE UNI
 	require.Regexp(t, "violates unique constraint", jobError)
 }
 
-// TestPermanentErrorDuringRollback tests that a permanent error while rolling
-// back a schema change causes the job to fail, and that the appropriate error
+// TestRetryOnAllErrorsWhenReverting tests that a permanent error while rolling
+// back a schema change causes the job to revert, and that the appropriate error
 // is displayed in the jobs table.
-func TestPermanentErrorDuringRollback(t *testing.T) {
+func TestRetryOnAllErrorsWhenReverting(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
@@ -6394,7 +6407,7 @@ CREATE UNIQUE INDEX i ON t.test(v);
 		var jobErr string
 		row := sqlDB.QueryRow("SELECT job_id, error FROM [SHOW JOBS] WHERE job_type = 'SCHEMA CHANGE'")
 		require.NoError(t, row.Scan(&jobID, &jobErr))
-		require.Regexp(t, "cannot be reverted, manual cleanup may be required: permanent error", jobErr)
+		require.Regexp(t, `violates unique constraint "i"`, jobErr)
 
 		if gcJobRecord {
 			_, err := sqlDB.Exec(`DELETE FROM system.jobs WHERE id = $1`, jobID)
@@ -6916,6 +6929,7 @@ func TestRevertingJobsOnDatabasesAndSchemas(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("failed due to injected error", func(t *testing.T) {
+		var injectedError bool
 		var s serverutils.TestServerInterface
 		params, _ := tests.CreateTestServerParams()
 		params.Knobs = base.TestingKnobs{
@@ -6932,15 +6946,24 @@ func TestRevertingJobsOnDatabasesAndSchemas(t *testing.T) {
 					}
 					for _, s := range []string{"DROP", "RENAME", "updating privileges"} {
 						if strings.Contains(pl.Description, s) {
-							return errors.New("injected permanent error")
+							if !injectedError {
+								injectedError = true
+								// Return a non-permanent error. The job will be retried in
+								// running state as the job is non-cancelable.
+								return errors.New("injected error")
+							} else {
+								// Return a permanent error to transition to reverting.
+								return jobs.MarkAsPermanentJobError(errors.New("injected permanent error"))
+							}
 						}
 					}
 					return nil
 				},
 			},
-			// Decrease the adopt loop interval so that retries happen quickly.
+			// Decrease the adopt-loop interval so that retries happen quickly.
 			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 		}
+
 		var db *gosql.DB
 		s, db, _ = serverutils.StartServer(t, params)
 		defer s.Stopper().Stop(ctx)
@@ -6948,18 +6971,17 @@ func TestRevertingJobsOnDatabasesAndSchemas(t *testing.T) {
 
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
+				injectedError = false
 				sqlDB.Exec(t, tc.setupStmts)
-				sqlDB.ExpectErr(t, "injected permanent error", tc.scStmt)
-				result := sqlDB.QueryStr(t,
-					`SELECT status, error FROM crdb_internal.jobs WHERE description ~ $1`,
-					tc.jobRegex)
-				require.Len(t, result, 1)
-				status, jobError := result[0][0], result[0][1]
-				require.Equal(t, string(jobs.StatusRevertFailed), status)
-				require.Regexp(t,
-					"cannot be reverted, manual cleanup may be required: "+
-						"schema change jobs on databases and schemas cannot be reverted",
-					jobError)
+
+				go func() {
+					// This transaction will not return until the server is shutdown. Therefore,
+					// we run it in a separate goroutine and don't check the returned error.
+					_, _ = db.Exec(tc.scStmt)
+				}()
+				// Verify that the job is in retry state while reverting.
+				const query = `SELECT num_runs > 3 FROM crdb_internal.jobs WHERE status = '` + string(jobs.StatusReverting) + `' AND description ~ '%s'`
+				sqlDB.CheckQueryResultsRetry(t, fmt.Sprintf(query, tc.jobRegex), [][]string{{"true"}})
 			})
 		}
 	})
@@ -7015,7 +7037,7 @@ func TestRevertingJobsOnDatabasesAndSchemas(t *testing.T) {
 					return nil
 				},
 			},
-			// Decrease the adopt loop interval so that retries happen quickly.
+			// Decrease the adopt-loop interval so that retries happen quickly.
 			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 		}
 		var db *gosql.DB
@@ -7045,8 +7067,8 @@ func TestRevertingJobsOnDatabasesAndSchemas(t *testing.T) {
 	})
 }
 
-// TestDropColumnAfterMutations tests the imapct of a drop column
-// after an existing a mutation on the column
+// TestDropColumnAfterMutations tests the impact of a drop column
+// after an existing mutation on the column.
 func TestDropColumnAfterMutations(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -7055,12 +7077,14 @@ func TestDropColumnAfterMutations(t *testing.T) {
 	var delayJobList []string
 	var delayJobChannels []chan struct{}
 	delayNotify := make(chan struct{})
+	jobIDs := make([]jobspb.JobID, 2)
 
 	proceedBeforeBackfill := make(chan error)
 	params, _ := tests.CreateTestServerParams()
 
 	var s serverutils.TestServerInterface
 	params.Knobs = base.TestingKnobs{
+		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
 			RunBeforeResume: func(jobID jobspb.JobID) error {
 				lockHeld := true
@@ -7070,9 +7094,10 @@ func TestDropColumnAfterMutations(t *testing.T) {
 					return err
 				}
 				pl := scJob.Payload()
-				// Check if we are blocking the correct job
+				// Check if we are blocking the correct job.
 				for idx, s := range delayJobList {
 					if strings.Contains(pl.Description, s) {
+						jobIDs[idx] = jobID
 						delayNotify <- struct{}{}
 						channel := delayJobChannels[idx]
 						jobControlMu.Unlock()
@@ -7090,8 +7115,6 @@ func TestDropColumnAfterMutations(t *testing.T) {
 				return <-proceedBeforeBackfill
 			},
 		},
-		// Decrease the adopt loop interval so that retries happen quickly.
-		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 	}
 
 	s, sqlDB, _ := serverutils.StartServer(t, params)
@@ -7106,7 +7129,7 @@ CREATE TABLE t (i INT8 PRIMARY KEY, j INT8);
 INSERT INTO t VALUES (1, 1);
 `)
 
-	// Test 1: with concurrent drop and mutations
+	// Test 1: with concurrent drop and mutations.
 	t.Run("basic-concurrent-drop-mutations", func(t *testing.T) {
 		jobControlMu.Lock()
 		delayJobList = []string{"ALTER TABLE defaultdb.public.t ADD COLUMN k INT8 NOT NULL UNIQUE DEFAULT 42",
@@ -7148,11 +7171,11 @@ COMMIT;
 
 		// Allow jobs to proceed once both are concurrent.
 		delayJobChannels[0] <- struct{}{}
-		// Allow both back fill jobs to proceed
+		// Allow both backfill jobs to proceed.
 		proceedBeforeBackfill <- nil
-		// Allow the second job to proceed
+		// Allow the second job to proceed.
 		delayJobChannels[1] <- struct{}{}
-		// Second job will also do back fill next
+		// Second job will also do backfill next.
 		proceedBeforeBackfill <- nil
 
 		schemaChangeWaitGroup.Wait()
@@ -7161,7 +7184,7 @@ COMMIT;
 	})
 
 	// Test 2: with concurrent drop and mutations, where
-	// the drop column will be failed intentionally
+	// the drop column will be failed intentionally.
 	t.Run("failed-concurrent-drop-mutations", func(t *testing.T) {
 		jobControlMu.Lock()
 		delayJobList = []string{"ALTER TABLE defaultdb.public.t ALTER COLUMN j SET NOT NULL",
@@ -7174,32 +7197,23 @@ COMMIT;
 	   CREATE TABLE t (i INT8 PRIMARY KEY, j INT8);
 	   INSERT INTO t VALUES (1, 1);
 	   `)
-		schemaChangeWaitGroup.Add(1)
 		go func() {
-			defer schemaChangeWaitGroup.Done()
-			_, err := conn2.DB.ExecContext(context.Background(),
+			// This transaction will not complete. Therefore, we don't check the returned error.
+			_, _ = conn2.DB.ExecContext(context.Background(),
 				`
 	   BEGIN;
 	   ALTER TABLE t ALTER COLUMN j SET NOT NULL;
 	   ALTER TABLE t ADD COLUMN k INT8 DEFAULT 42 NOT NULL UNIQUE;
 	   COMMIT;
 	   `)
-			failureError := "pq: transaction committed but schema change aborted with error: (XXUUU): A dependent transaction failed for this schema change: Bogus error for drop column transaction"
-			if err != nil &&
-				!strings.Contains(err.Error(), failureError) {
-				t.Error(err.Error())
-			} else if err == nil {
-				t.Error("Expected error was not hit")
-			}
 		}()
 
-		// Wait for the alter to get submitted first
+		// Wait for the alter to get submitted first.
 		<-delayNotify
 
-		schemaChangeWaitGroup.Add(1)
 		go func() {
-			defer schemaChangeWaitGroup.Done()
-			_, err := conn1.DB.ExecContext(context.Background(),
+			// This transaction will not complete. Therefore, we don't check the returned error.
+			_, _ = conn1.DB.ExecContext(context.Background(),
 				`
 	   SET sql_safe_updates = false;
 	   BEGIN;
@@ -7209,13 +7223,6 @@ COMMIT;
 	   ALTER TABLE t ADD COLUMN o INT8 DEFAULT 42 NOT NULL UNIQUE;
 	   COMMIT;
 	   `)
-			failureError := "pq: transaction committed but schema change aborted with error: (XXUUU): Bogus error for drop column transaction"
-			if err != nil &&
-				!strings.Contains(err.Error(), failureError) {
-				t.Error(err.Error())
-			} else if err == nil {
-				t.Error("Expected error was not hit")
-			}
 		}()
 		<-delayNotify
 
@@ -7228,10 +7235,26 @@ COMMIT;
 		delayJobChannels[1] <- struct{}{}
 		// Second job will also do backfill next
 		proceedBeforeBackfill <- errors.Newf("Bogus error for drop column transaction")
-		// Rollback attempt after failure
-		proceedBeforeBackfill <- nil
 
-		schemaChangeWaitGroup.Wait()
+		// We expect the first job to be stuck in running state.
+		// At this point, first job is now waiting for second to complete. However, first job
+		// is in an infinite-loop due to retries while reverting. Therefore, we don't wait
+		// for the jobs to complete. Instead, we validate their current status before completing
+		// the test.
+
+		// Second job should be in reverting state and retrying.
+		conn1.CheckQueryResultsRetry(t,
+			fmt.Sprintf("SELECT num_runs > 3 FROM system.jobs WHERE id = %d AND status = '%s'", jobIDs[1], jobs.StatusReverting),
+			[][]string{{"true"}},
+		)
+		// First job should be in running state.
+		conn1.CheckQueryResults(t, fmt.Sprintf("SELECT status from system.jobs WHERE id = %d", jobIDs[0]), [][]string{{string(jobs.StatusRunning)}})
+		// Both jobs should be stuck in COMMIT, waiting for jobs to complete.
+		conn1.CheckQueryResults(t,
+			"SELECT count(*) FROM [SHOW SESSIONS] WHERE last_active_query LIKE '%COMMIT%' AND session_id != (SELECT * FROM [SHOW session_id])",
+			[][]string{{"2"}},
+		)
+
 		close(delayJobChannels[0])
 		close(delayJobChannels[1])
 	})
@@ -7251,32 +7274,24 @@ COMMIT;
 	   INSERT INTO t VALUES (1, 1);
 	   `)
 
-		schemaChangeWaitGroup.Add(1)
 		go func() {
-			defer schemaChangeWaitGroup.Done()
-			_, err := conn2.DB.ExecContext(context.Background(),
+			// Two possibilities exist based on timing, either the following transaction
+			// will fail during backfill or the dependent one with the drop will fail.
+
+			// This transaction will not complete. Therefore, we don't check the returned error.
+			_, _ = conn2.DB.ExecContext(context.Background(),
 				`
 	   BEGIN;
 	   ALTER TABLE t ALTER COLUMN j SET NOT NULL;
 	   ALTER TABLE t ADD COLUMN k INT8 DEFAULT 42 NOT NULL;
 	   COMMIT;
 	   	   `)
-			// Two possibilities exist based on timing, either the current transaction
-			// will fail during backfill or the dependent one with the drop will fail.
-			failureError := "pq: transaction committed but schema change aborted with error: (23505): A dependent transaction failed for this schema change: failed to ingest index entries during backfill: duplicate key value violates unique constraint \"t_o_key\""
-			if err != nil &&
-				!strings.Contains(err.Error(), failureError) {
-				t.Error(err.Error())
-			} else if err == nil {
-				t.Error("Expected error was not hit")
-			}
 		}()
 		<-delayNotify
 
-		schemaChangeWaitGroup.Add(1)
 		go func() {
-			defer schemaChangeWaitGroup.Done()
-			_, err := conn1.DB.ExecContext(context.Background(),
+			// This transaction will not complete. Therefore, we don't check the returned error.
+			_, _ = conn1.DB.ExecContext(context.Background(),
 				`
 	   SET sql_safe_updates = false;
 	   BEGIN;
@@ -7287,13 +7302,6 @@ COMMIT;
 	   INSERT INTO t VALUES (2);
 	   COMMIT;
 	   	   `)
-			failureError := "pq: transaction committed but schema change aborted with error: (23505): failed to ingest index entries during backfill: duplicate key value violates unique constraint \"t_o_key\""
-			if err != nil &&
-				!strings.Contains(err.Error(), failureError) {
-				t.Error(err.Error())
-			} else if err == nil {
-				t.Error("Expected error was not hit")
-			}
 		}()
 		<-delayNotify
 
@@ -7305,9 +7313,39 @@ COMMIT;
 		proceedBeforeBackfill <- nil
 		// Allow the second job to proceed
 		delayJobChannels[1] <- struct{}{}
-		// Second job will also do backfill next
-		proceedBeforeBackfill <- nil
-		schemaChangeWaitGroup.Wait()
+
+		var revertingJobID jobspb.JobID
+		testutils.SucceedsSoon(t, func() error {
+			// In this test, depending on the concurrent execution schedule, one of the jobs
+			// will be stuck in running state while the other job will be stuck in reverting state.
+			// Here we check that this statement is valid. Moreover, we also get the ID of the
+			// reverting job to ensure that it is retrying. Furthermore, we prevent the running
+			// job to backfill to validate this test's correctness assumptions.
+			firstJobID := jobIDs[0]
+			secondJobID := jobIDs[1]
+			res := conn1.QueryStr(t, "SELECT status from system.jobs where id in ($1, $2)", firstJobID, secondJobID)
+			require.Len(t, res, 2)
+			firstJobStatus := jobs.Status(res[0][0])
+			secondJobStatus := jobs.Status(res[1][0])
+			if firstJobStatus == jobs.StatusRunning && secondJobStatus == jobs.StatusReverting {
+				revertingJobID = secondJobID
+				return nil
+			} else if firstJobStatus == jobs.StatusReverting && secondJobStatus == jobs.StatusRunning {
+				revertingJobID = firstJobID
+				return nil
+			}
+			return errors.New("one job should be running while the other job should be reverting")
+		})
+		// Ensure that the reverting job is retrying.
+		conn1.CheckQueryResultsRetry(t,
+			fmt.Sprintf("SELECT num_runs > 3 FROM system.jobs WHERE id = %d", revertingJobID),
+			[][]string{{"true"}},
+		)
+		// Both jobs should be stuck in COMMIT, waiting for jobs to complete.
+		conn1.CheckQueryResults(t,
+			"SELECT count(*) FROM [SHOW SESSIONS] WHERE last_active_query LIKE '%COMMIT%' AND session_id != (SELECT * FROM [SHOW session_id])",
+			[][]string{{"2"}},
+		)
 
 		close(delayJobChannels[0])
 		close(delayJobChannels[1])

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -150,7 +150,10 @@ func (p *planner) createOrUpdateSchemaChangeJob(
 			Progress: jobspb.SchemaChangeProgress{},
 			// Mark jobs without a mutation ID as non-cancellable,
 			// since we expect these to be trivial.
-			NonCancelable: mutationID == descpb.InvalidMutationID,
+			//
+			// The job should be cancelable when we are adding a table that doesn't
+			// have mutations, e.g., in CREATE TABLE AS VALUES.
+			NonCancelable: mutationID == descpb.InvalidMutationID && !tableDesc.Adding(),
 		}
 		p.extendedEvalCtx.SchemaChangeJobRecords[tableDesc.ID] = &newRecord
 		// Only add a MutationJob if there's an associated mutation.

--- a/pkg/sql/type_change_test.go
+++ b/pkg/sql/type_change_test.go
@@ -40,7 +40,9 @@ func TestDrainingNamesAreCleanedOnTypeChangeFailure(t *testing.T) {
 	params, _ := tests.CreateTestServerParams()
 	params.Knobs.SQLTypeSchemaChanger = &sql.TypeSchemaChangerTestingKnobs{
 		RunBeforeExec: func() error {
-			return errors.New("boom")
+			// As the job is non-cancelable, return a permanent-marked error so that
+			// the job can revert.
+			return jobs.MarkAsPermanentJobError(errors.New("boom"))
 		},
 	}
 	// Decrease the adopt loop interval so that retries happen quickly.
@@ -174,7 +176,7 @@ func TestFailedTypeSchemaChangeRetriesTransparently(t *testing.T) {
 	cleanupSuccessfullyFinished := make(chan struct{})
 	params.Knobs.SQLTypeSchemaChanger = &sql.TypeSchemaChangerTestingKnobs{
 		RunBeforeExec: func() error {
-			return errors.New("yikes")
+			return jobs.MarkAsPermanentJobError(errors.New("yikes"))
 		},
 		RunAfterOnFailOrCancel: func() error {
 			mu.Lock()


### PR DESCRIPTION
Previously, non-cancelable jobs were retried in running state
only if their errors were marked as retryable. Moreover,  only 
non-cancelable reverting jobs were retried by default. This 
commit makes non-cancelable jobs always retry in running 
state unless their error is marked as a permanent error. In
addition, this commit makes all reverting jobs to retry when
they fail. As a result, non-cancelable running jobs and all
reverting jobs do not fail due to transient errors.

Release justification: low-risk updates to new functionality.

Release note (general change): Non-cancelable jobs, such as
schema-change GC jobs, now do not fail unless they fail with
a permanent error. They retry with exponential-backoff if
they fail due to a transient error. Furthermore, Jobs that 
perform reverting tasks do not fail. Instead, they are retried 
with exponential-backoff if an error is encountered while 
reverting. As a result, transient errors do not impact the jobs 
that are reverting.

Fixes: #66685