### PR TITLE
sql: no-op interleaved syntax for CREATE TABLE/INDEX

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning
@@ -97,13 +97,19 @@ CREATE TABLE interleave_root (a INT PRIMARY KEY) PARTITION BY LIST (a) (
     PARTITION p0 VALUES IN (0)
 )
 
-statement error pq: creation of new interleaved tables and interleaved indexes is no longer supported. For details, see https://www.cockroachlabs.com/docs/releases/v20.2.0#deprecations
+statement notice ERROR: creation of new interleaved tables or interleaved indexes is no longer supported and will be ignored. For details, see https://www.cockroachlabs.com/docs/releases/v20.2.0#deprecations
 CREATE TABLE interleave_child (a INT PRIMARY KEY) INTERLEAVE IN PARENT interleave_root (a)
 
-statement error pq: creation of new interleaved tables and interleaved indexes is no longer supported. For details, see https://www.cockroachlabs.com/docs/releases/v20.2.0#deprecations
+statement notice ERROR: creation of new interleaved tables or interleaved indexes is no longer supported and will be ignored. For details, see https://www.cockroachlabs.com/docs/releases/v20.2.0#deprecations
 CREATE TABLE t (a INT PRIMARY KEY) INTERLEAVE IN PARENT interleave_root (a) PARTITION BY LIST (a) (
     PARTITION p0 VALUES IN (0)
 )
+
+statement ok
+DROP TABLE interleave_child
+
+statement ok
+DROP TABLE t;
 
 statement error PARTITION p1: partition has 1 columns but 2 values were supplied
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -115,12 +115,15 @@ LOCALITY REGIONAL BY ROW
 statement ok
 CREATE TABLE parent_table (pk INT PRIMARY KEY)
 
-statement error pq: creation of new interleaved tables and interleaved indexes is no longer supported. For details, see https://www.cockroachlabs.com/docs/releases/v20.2.0#deprecations
-CREATE TABLE regional_by_row_table (
+statement notice ERROR: creation of new interleaved tables or interleaved indexes is no longer supported and will be ignored. For details, see https://www.cockroachlabs.com/docs/releases/v20.2.0#deprecations
+CREATE TABLE regional_by_row_table_int (
   pk INT NOT NULL PRIMARY KEY
 )
 INTERLEAVE IN PARENT parent_table(pk)
 LOCALITY REGIONAL BY ROW
+
+statement ok
+DROP TABLE regional_by_row_table_int
 
 statement ok
 CREATE TABLE regional_by_row_table_explicit_crdb_region_column (
@@ -532,8 +535,11 @@ CREATE INDEX bad_idx ON regional_by_row_table(a) USING HASH WITH BUCKET_COUNT = 
 statement error hash sharded indexes are not compatible with REGIONAL BY ROW tables
 ALTER TABLE regional_by_row_table ALTER PRIMARY KEY USING COLUMNS(pk2) USING HASH WITH BUCKET_COUNT = 8
 
-statement error pq: creation of new interleaved tables and interleaved indexes is no longer supported. For details, see https://www.cockroachlabs.com/docs/releases/v20.2.0#deprecations
-CREATE INDEX bad_idx ON regional_by_row_table(pk) INTERLEAVE IN PARENT parent_table(pk)
+statement notice ERROR: creation of new interleaved tables or interleaved indexes is no longer supported and will be ignored. For details, see https://www.cockroachlabs.com/docs/releases/v20.2.0#deprecations
+CREATE INDEX bad_idx_int ON regional_by_row_table(pk) INTERLEAVE IN PARENT parent_table(pk)
+
+statement ok
+DROP INDEX bad_idx_int
 
 # Try add a new unique column.
 statement ok
@@ -831,9 +837,9 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  OR message LIKE 'Scan%'
  ORDER BY ordinality ASC
 ----
-Scan /Table/72/1/"\x80"/1/0
-Scan /Table/72/1/"\xc0"/1/0
-Scan /Table/72/1/"@"/1/0
+Scan /Table/73/1/"\x80"/1/0
+Scan /Table/73/1/"\xc0"/1/0
+Scan /Table/73/1/"@"/1/0
 fetched: /regional_by_row_table/primary/'ap-southeast-2'/1/pk2/a/b/j -> /1/2/3/'{"a": "b"}'
 output row: [1 1 2 3 '{"a": "b"}']
 
@@ -899,7 +905,7 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  OR message LIKE 'Scan%'
  ORDER BY ordinality ASC
 ----
-Scan /Table/72/1/"@"/1/0
+Scan /Table/73/1/"@"/1/0
 fetched: /regional_by_row_table/primary/'ap-southeast-2'/1/pk2/a/b/j -> /1/2/3/'{"a": "b"}'
 output row: [1 1 2 3 '{"a": "b"}']
 
@@ -917,9 +923,9 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  OR message LIKE 'Scan%'
  ORDER BY ordinality ASC
 ----
-Scan /Table/72/1/"@"/10/0
-Scan /Table/72/1/"\xc0"/10/0
-Scan /Table/72/1/"\x80"/10/0
+Scan /Table/73/1/"@"/10/0
+Scan /Table/73/1/"\xc0"/10/0
+Scan /Table/73/1/"\x80"/10/0
 fetched: /regional_by_row_table/primary/'ca-central-1'/10/pk2/a/b -> /10/11/12
 output row: [10 10 11 12 NULL]
 
@@ -937,8 +943,8 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  OR message LIKE 'Scan%'
  ORDER BY ordinality ASC
 ----
-Scan /Table/72/1/"@"/10/0
-Scan /Table/72/1/"\x80"/10/0, /Table/72/1/"\xc0"/10/0
+Scan /Table/73/1/"@"/10/0
+Scan /Table/73/1/"\x80"/10/0, /Table/73/1/"\xc0"/10/0
 fetched: /regional_by_row_table/primary/'ca-central-1'/10/pk2/a/b -> /10/11/12
 output row: [10 10 11 12 NULL]
 
@@ -1031,9 +1037,9 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  OR message LIKE 'Scan%'
  ORDER BY ordinality ASC
 ----
-Scan /Table/74/1/"@"/10/0, /Table/74/1/"\x80"/10/0, /Table/74/1/"\xc0"/10/0
+Scan /Table/75/1/"@"/10/0, /Table/75/1/"\x80"/10/0, /Table/75/1/"\xc0"/10/0
 fetched: /child/primary/'ap-southeast-2'/10/c_p_id -> /10
-Scan /Table/73/1/"@"/10/0, /Table/73/1/"\x80"/10/0, /Table/73/1/"\xc0"/10/0
+Scan /Table/74/1/"@"/10/0, /Table/74/1/"\x80"/10/0, /Table/74/1/"\xc0"/10/0
 fetched: /parent/primary/'ap-southeast-2'/10 -> NULL
 
 # Semi join with locality optimized search disabled.
@@ -1061,9 +1067,9 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  OR message LIKE 'Scan%'
  ORDER BY ordinality ASC
 ----
-Scan /Table/74/1/"@"/10/0, /Table/74/1/"\x80"/10/0, /Table/74/1/"\xc0"/10/0
+Scan /Table/75/1/"@"/10/0, /Table/75/1/"\x80"/10/0, /Table/75/1/"\xc0"/10/0
 fetched: /child/primary/'ap-southeast-2'/10/c_p_id -> /10
-Scan /Table/73/1/"@"/10/0, /Table/73/1/"\x80"/10/0, /Table/73/1/"\xc0"/10/0
+Scan /Table/74/1/"@"/10/0, /Table/74/1/"\x80"/10/0, /Table/74/1/"\xc0"/10/0
 fetched: /parent/primary/'ap-southeast-2'/10 -> NULL
 output row: [10 10]
 
@@ -1092,9 +1098,9 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  OR message LIKE 'Scan%'
  ORDER BY ordinality ASC
 ----
-Scan /Table/74/1/"@"/10/0, /Table/74/1/"\x80"/10/0, /Table/74/1/"\xc0"/10/0
+Scan /Table/75/1/"@"/10/0, /Table/75/1/"\x80"/10/0, /Table/75/1/"\xc0"/10/0
 fetched: /child/primary/'ap-southeast-2'/10/c_p_id -> /10
-Scan /Table/73/1/"@"/10/0, /Table/73/1/"\x80"/10/0, /Table/73/1/"\xc0"/10/0
+Scan /Table/74/1/"@"/10/0, /Table/74/1/"\x80"/10/0, /Table/74/1/"\xc0"/10/0
 fetched: /parent/primary/'ap-southeast-2'/10 -> NULL
 output row: [10 10 10]
 
@@ -1123,9 +1129,9 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  OR message LIKE 'Scan%'
  ORDER BY ordinality ASC
 ----
-Scan /Table/74/1/"@"/10/0, /Table/74/1/"\x80"/10/0, /Table/74/1/"\xc0"/10/0
+Scan /Table/75/1/"@"/10/0, /Table/75/1/"\x80"/10/0, /Table/75/1/"\xc0"/10/0
 fetched: /child/primary/'ap-southeast-2'/10/c_p_id -> /10
-Scan /Table/73/1/"@"/10/0, /Table/73/1/"\x80"/10/0, /Table/73/1/"\xc0"/10/0
+Scan /Table/74/1/"@"/10/0, /Table/74/1/"\x80"/10/0, /Table/74/1/"\xc0"/10/0
 fetched: /parent/primary/'ap-southeast-2'/10 -> NULL
 output row: [10 10 10]
 
@@ -1190,9 +1196,9 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  OR message LIKE 'Scan%'
  ORDER BY ordinality ASC
 ----
-Scan /Table/74/1/"@"/10/0
+Scan /Table/75/1/"@"/10/0
 fetched: /child/primary/'ap-southeast-2'/10/c_p_id -> /10
-Scan /Table/73/1/"@"/10/0
+Scan /Table/74/1/"@"/10/0
 fetched: /parent/primary/'ap-southeast-2'/10 -> NULL
 
 statement ok
@@ -1206,11 +1212,11 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  OR message LIKE 'Scan%'
  ORDER BY ordinality ASC
 ----
+Scan /Table/75/1/"@"/20/0
+Scan /Table/75/1/"\x80"/20/0, /Table/75/1/"\xc0"/20/0
+fetched: /child/primary/'ca-central-1'/20/c_p_id -> /20
 Scan /Table/74/1/"@"/20/0
 Scan /Table/74/1/"\x80"/20/0, /Table/74/1/"\xc0"/20/0
-fetched: /child/primary/'ca-central-1'/20/c_p_id -> /20
-Scan /Table/73/1/"@"/20/0
-Scan /Table/73/1/"\x80"/20/0, /Table/73/1/"\xc0"/20/0
 fetched: /parent/primary/'ca-central-1'/20 -> NULL
 
 # Semi join with locality optimized search enabled.
@@ -1266,9 +1272,9 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  OR message LIKE 'Scan%'
  ORDER BY ordinality ASC
 ----
-Scan /Table/74/1/"@"/10/0
+Scan /Table/75/1/"@"/10/0
 fetched: /child/primary/'ap-southeast-2'/10/c_p_id -> /10
-Scan /Table/73/1/"@"/10/0
+Scan /Table/74/1/"@"/10/0
 fetched: /parent/primary/'ap-southeast-2'/10 -> NULL
 output row: [10 10]
 
@@ -1283,11 +1289,11 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  OR message LIKE 'Scan%'
  ORDER BY ordinality ASC
 ----
+Scan /Table/75/1/"@"/20/0
+Scan /Table/75/1/"\x80"/20/0, /Table/75/1/"\xc0"/20/0
+fetched: /child/primary/'ca-central-1'/20/c_p_id -> /20
 Scan /Table/74/1/"@"/20/0
 Scan /Table/74/1/"\x80"/20/0, /Table/74/1/"\xc0"/20/0
-fetched: /child/primary/'ca-central-1'/20/c_p_id -> /20
-Scan /Table/73/1/"@"/20/0
-Scan /Table/73/1/"\x80"/20/0, /Table/73/1/"\xc0"/20/0
 fetched: /parent/primary/'ca-central-1'/20 -> NULL
 output row: [20 20]
 
@@ -1344,9 +1350,9 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  OR message LIKE 'Scan%'
  ORDER BY ordinality ASC
 ----
-Scan /Table/74/1/"@"/10/0
+Scan /Table/75/1/"@"/10/0
 fetched: /child/primary/'ap-southeast-2'/10/c_p_id -> /10
-Scan /Table/73/1/"@"/10/0
+Scan /Table/74/1/"@"/10/0
 fetched: /parent/primary/'ap-southeast-2'/10 -> NULL
 output row: [10 10 10]
 
@@ -1361,11 +1367,11 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  OR message LIKE 'Scan%'
  ORDER BY ordinality ASC
 ----
+Scan /Table/75/1/"@"/20/0
+Scan /Table/75/1/"\x80"/20/0, /Table/75/1/"\xc0"/20/0
+fetched: /child/primary/'ca-central-1'/20/c_p_id -> /20
 Scan /Table/74/1/"@"/20/0
 Scan /Table/74/1/"\x80"/20/0, /Table/74/1/"\xc0"/20/0
-fetched: /child/primary/'ca-central-1'/20/c_p_id -> /20
-Scan /Table/73/1/"@"/20/0
-Scan /Table/73/1/"\x80"/20/0, /Table/73/1/"\xc0"/20/0
 fetched: /parent/primary/'ca-central-1'/20 -> NULL
 output row: [20 20 20]
 
@@ -1422,9 +1428,9 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  OR message LIKE 'Scan%'
  ORDER BY ordinality ASC
 ----
-Scan /Table/74/1/"@"/10/0
+Scan /Table/75/1/"@"/10/0
 fetched: /child/primary/'ap-southeast-2'/10/c_p_id -> /10
-Scan /Table/73/1/"@"/10/0
+Scan /Table/74/1/"@"/10/0
 fetched: /parent/primary/'ap-southeast-2'/10 -> NULL
 output row: [10 10 10]
 
@@ -1439,11 +1445,11 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  OR message LIKE 'Scan%'
  ORDER BY ordinality ASC
 ----
+Scan /Table/75/1/"@"/20/0
+Scan /Table/75/1/"\x80"/20/0, /Table/75/1/"\xc0"/20/0
+fetched: /child/primary/'ca-central-1'/20/c_p_id -> /20
 Scan /Table/74/1/"@"/20/0
 Scan /Table/74/1/"\x80"/20/0, /Table/74/1/"\xc0"/20/0
-fetched: /child/primary/'ca-central-1'/20/c_p_id -> /20
-Scan /Table/73/1/"@"/20/0
-Scan /Table/73/1/"\x80"/20/0, /Table/73/1/"\xc0"/20/0
 fetched: /parent/primary/'ca-central-1'/20 -> NULL
 output row: [20 20 20]
 

--- a/pkg/sql/alter_primary_key.go
+++ b/pkg/sql/alter_primary_key.go
@@ -72,8 +72,12 @@ func (p *planner) AlterPrimaryKey(
 	}
 
 	if alterPKNode.Interleave != nil {
-		if err := interleavedTableDeprecationAction(p.RunParams(ctx)); err != nil {
+		interleaveIgnored, err := interleavedTableDeprecationAction(p.RunParams(ctx))
+		if err != nil {
 			return err
+		}
+		if interleaveIgnored {
+			alterPKNode.Interleave = nil
 		}
 	}
 

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -227,8 +227,12 @@ func (n *createTableNode) startExec(params runParams) error {
 	}
 	if n.n.Interleave != nil {
 		telemetry.Inc(sqltelemetry.CreateInterleavedTableCounter)
-		if err := interleavedTableDeprecationAction(params); err != nil {
+		interleaveIgnored, err := interleavedTableDeprecationAction(params)
+		if err != nil {
 			return err
+		}
+		if interleaveIgnored {
+			n.n.Interleave = nil
 		}
 	}
 	if n.n.Persistence.IsTemporary() {


### PR DESCRIPTION
Fixes: #68344

Previously, CREATE TABLE/INDEX operations were completely
blocked with an error once support was removed. This
was inadequate because for migrations may still use this
syntax and we can't fully block it. To address this, this
patch will make the interleaved syntax a no-op with a client
warning.

Release justification: low risk and saner behaviour for customer
migrations on this release.
Release note (sql change): Interleaved syntax for CREATE TABLE/INDEX
is now a no-op, since support has been removed.