### PR TITLE
release-21.1: ui: handle new parameters on versions before 21.1.7

### DIFF
--- a/pkg/ui/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -462,18 +462,20 @@ export class StatementDetails extends React.Component<
     const totalWorkload = calculateTotalWorkload(statsByNode);
     populateRegionNodeForStatements(statsByNode, nodeRegions);
     const nodes: string[] = unique(
-      stats.nodes.map(node => node.toString()),
+      (stats.nodes || []).map(node => node.toString()),
     ).sort();
     const regions = unique(
-      stats.nodes.map(node => nodeRegions[node.toString()]),
+      (stats.nodes || []).map(node => nodeRegions[node.toString()]),
     ).sort();
     const logicalPlan =
       stats.sensitive_info && stats.sensitive_info.most_recent_plan_description;
     const duration = (v: number) => Duration(v * 1e9);
     const hasDiagnosticReports = diagnosticsReports.length > 0;
-    const lastExec = moment(stats.last_exec_timestamp.seconds.low * 1e3).format(
-      "MMM DD, YYYY HH:MM",
-    );
+    const lastExec =
+      stats.last_exec_timestamp &&
+      moment(stats.last_exec_timestamp.seconds.low * 1e3).format(
+        "MMM DD, YYYY HH:MM",
+      );
     return (
       <Tabs
         defaultActiveKey="1"

--- a/pkg/ui/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -341,23 +341,25 @@ export class StatementsPage extends React.Component<
         // list if the list is not empty.
         statement =>
           regions.length == 0 ||
-          containAny(
-            statement.stats.nodes.map(
-              node => nodeRegions[node.toString()],
+          (statement.stats.nodes &&
+            containAny(
+              statement.stats.nodes.map(
+                node => nodeRegions[node.toString()],
+                regions,
+              ),
               regions,
-            ),
-            regions,
-          ),
+            )),
       )
       .filter(
         // The statement must contain at least one value from the selected regions
         // list if the list is not empty.
         statement =>
           nodes.length == 0 ||
-          containAny(
-            statement.stats.nodes.map(node => "n" + node),
-            nodes,
-          ),
+          (statement.stats.nodes &&
+            containAny(
+              statement.stats.nodes.map(node => "n" + node),
+              nodes,
+            )),
       );
   };
 

--- a/pkg/ui/cluster-ui/src/statementsTable/statementsTable.tsx
+++ b/pkg/ui/cluster-ui/src/statementsTable/statementsTable.tsx
@@ -301,13 +301,15 @@ export function populateRegionNodeForStatements(
     const regions: { [region: string]: Set<number> } = {};
     // For each region, populate a list of all nodes where the statement was executed.
     // E.g. {"gcp-us-east1" : [1,3,4]}
-    stmt.stats.nodes.forEach(node => {
-      if (Object.keys(regions).includes(nodeRegions[node.toString()])) {
-        regions[nodeRegions[node.toString()]].add(longToInt(node));
-      } else {
-        regions[nodeRegions[node.toString()]] = new Set([longToInt(node)]);
-      }
-    });
+    if (stmt.stats.nodes) {
+      stmt.stats.nodes.forEach(node => {
+        if (Object.keys(regions).includes(nodeRegions[node.toString()])) {
+          regions[nodeRegions[node.toString()]].add(longToInt(node));
+        } else {
+          regions[nodeRegions[node.toString()]] = new Set([longToInt(node)]);
+        }
+      });
+    }
     // Create a list nodes/regions where a statement was executed on, with
     // format: region (node1,node2)
     const regionNodes: string[] = [];

--- a/pkg/ui/cluster-ui/src/transactionsPage/utils.ts
+++ b/pkg/ui/cluster-ui/src/transactionsPage/utils.ts
@@ -129,15 +129,16 @@ export const filterTransactions = (
       let foundNode: boolean = nodes.length == 0;
 
       getStatementsById(t.stats_data.statement_ids, statements).some(stmt => {
-        stmt.stats.nodes.some(node => {
-          if (foundRegion || regions.includes(nodeRegions[node.toString()])) {
-            foundRegion = true;
-          }
-          if (foundNode || nodes.includes("n" + node)) {
-            foundNode = true;
-          }
-          if (foundNode && foundRegion) return true;
-        });
+        stmt.stats.nodes &&
+          stmt.stats.nodes.some(node => {
+            if (foundRegion || regions.includes(nodeRegions[node.toString()])) {
+              foundRegion = true;
+            }
+            if (foundNode || nodes.includes("n" + node)) {
+              foundNode = true;
+            }
+            if (foundNode && foundRegion) return true;
+          });
       });
 
       return foundRegion && foundNode;
@@ -170,14 +171,15 @@ export const generateRegionNode = (
   // E.g. {"gcp-us-east1" : [1,3,4]}
   getStatementsById(transaction.stats_data.statement_ids, statements).forEach(
     stmt => {
-      stmt.stats.nodes.forEach(n => {
-        const node = n.toString();
-        if (Object.keys(regions).includes(nodeRegions[node])) {
-          regions[nodeRegions[node]].add(longToInt(n));
-        } else {
-          regions[nodeRegions[node]] = new Set([longToInt(n)]);
-        }
-      });
+      stmt.stats.nodes &&
+        stmt.stats.nodes.forEach(n => {
+          const node = n.toString();
+          if (Object.keys(regions).includes(nodeRegions[node])) {
+            regions[nodeRegions[node]].add(longToInt(n));
+          } else {
+            regions[nodeRegions[node]] = new Set([longToInt(n)]);
+          }
+        });
     },
   );
 

--- a/pkg/ui/cluster-ui/src/util/appStats/appStats.ts
+++ b/pkg/ui/cluster-ui/src/util/appStats/appStats.ts
@@ -158,6 +158,8 @@ export function addStatementStats(
     exec_stats: addExecStats(a.exec_stats, b.exec_stats),
     sql_type: a.sql_type,
     last_exec_timestamp:
+      a.last_exec_timestamp &&
+      b.last_exec_timestamp &&
       a.last_exec_timestamp.seconds > b.last_exec_timestamp.seconds
         ? a.last_exec_timestamp
         : b.last_exec_timestamp,


### PR DESCRIPTION
Backport 1/1 commits from #69205.

/cc @cockroachdb/release

---

A few changes were backported to 21.1 that added new parameters
to protobuf (`last_exec_timestamp` and `nodes`). To be able to update cluster-ui version on
managed repo, this commit is introducing some checks on the ui,
so when cluster-ui is loaded on versions prior to 21.1.8 it will
not crash

Release justification: Category 2 Bug Fix

Release note (bug fix): Introduce checks on statements and transaction
pages so managed repo can update cluster-ui version.
