### PR TITLE
sql/schemachanger: use non-`ignore` build tag

### DIFF
--- a/pkg/sql/schemachanger/scop/BUILD.bazel
+++ b/pkg/sql/schemachanger/scop/BUILD.bazel
@@ -24,7 +24,7 @@ go_library(
 go_binary(
     name = "gen-visitors",
     srcs = ["generate_visitor.go"],
-    gotags = ["ignore"],
+    gotags = ["generator"],
     deps = [
         "//pkg/cli/exit",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/sql/schemachanger/scop/generate_visitor.go
+++ b/pkg/sql/schemachanger/scop/generate_visitor.go
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-// +build ignore
+// +build generator
 
 package main
 


### PR DESCRIPTION
When using the `race` configuration, Bazel was building the Go stdlib
with the `ignore` build tag. Evidently the stdlib doesn't build with
this tag, which makes sense. Here I just rename the tag so we don't have
to worry about it.

Closes #69240.

Release justification: Non-production code change
Release note: None