### PR TITLE
admission,server: tune admission control based on tpcc, kv experiments

### DIFF
--- a/pkg/util/admission/testdata/io_load_listener
+++ b/pkg/util/admission/testdata/io_load_listener
@@ -1,5 +1,5 @@
 # Even though above the threshold, the first 60 ticks don't limit the tokens.
-set-state admitted=0 l0-bytes=10000 l0-added=1000 l0-files=11 l0-sublevels=11
+set-state admitted=0 l0-bytes=10000 l0-added=1000 l0-files=21 l0-sublevels=21
 ----
 admitted: 0, bytes: 10000, added-bytes: 1000,
 smoothed-removed: 0, smoothed-admit: 0,
@@ -19,192 +19,57 @@ tick: 11, setAvailableIOTokens: unlimited
 tick: 12, setAvailableIOTokens: unlimited
 tick: 13, setAvailableIOTokens: unlimited
 tick: 14, setAvailableIOTokens: unlimited
-tick: 15, setAvailableIOTokens: unlimited
-tick: 16, setAvailableIOTokens: unlimited
-tick: 17, setAvailableIOTokens: unlimited
-tick: 18, setAvailableIOTokens: unlimited
-tick: 19, setAvailableIOTokens: unlimited
-tick: 20, setAvailableIOTokens: unlimited
-tick: 21, setAvailableIOTokens: unlimited
-tick: 22, setAvailableIOTokens: unlimited
-tick: 23, setAvailableIOTokens: unlimited
-tick: 24, setAvailableIOTokens: unlimited
-tick: 25, setAvailableIOTokens: unlimited
-tick: 26, setAvailableIOTokens: unlimited
-tick: 27, setAvailableIOTokens: unlimited
-tick: 28, setAvailableIOTokens: unlimited
-tick: 29, setAvailableIOTokens: unlimited
-tick: 30, setAvailableIOTokens: unlimited
-tick: 31, setAvailableIOTokens: unlimited
-tick: 32, setAvailableIOTokens: unlimited
-tick: 33, setAvailableIOTokens: unlimited
-tick: 34, setAvailableIOTokens: unlimited
-tick: 35, setAvailableIOTokens: unlimited
-tick: 36, setAvailableIOTokens: unlimited
-tick: 37, setAvailableIOTokens: unlimited
-tick: 38, setAvailableIOTokens: unlimited
-tick: 39, setAvailableIOTokens: unlimited
-tick: 40, setAvailableIOTokens: unlimited
-tick: 41, setAvailableIOTokens: unlimited
-tick: 42, setAvailableIOTokens: unlimited
-tick: 43, setAvailableIOTokens: unlimited
-tick: 44, setAvailableIOTokens: unlimited
-tick: 45, setAvailableIOTokens: unlimited
-tick: 46, setAvailableIOTokens: unlimited
-tick: 47, setAvailableIOTokens: unlimited
-tick: 48, setAvailableIOTokens: unlimited
-tick: 49, setAvailableIOTokens: unlimited
-tick: 50, setAvailableIOTokens: unlimited
-tick: 51, setAvailableIOTokens: unlimited
-tick: 52, setAvailableIOTokens: unlimited
-tick: 53, setAvailableIOTokens: unlimited
-tick: 54, setAvailableIOTokens: unlimited
-tick: 55, setAvailableIOTokens: unlimited
-tick: 56, setAvailableIOTokens: unlimited
-tick: 57, setAvailableIOTokens: unlimited
-tick: 58, setAvailableIOTokens: unlimited
-tick: 59, setAvailableIOTokens: unlimited
 
 # Delta added is 100,000. The l0-bytes are the same, so compactions removed
 # 100,000 bytes. Smoothed removed by compactions is 50,000. Each admitted is
 # expected to add 10 bytes. We want to add only 25,000 (half the smoothed
 # removed), which is 2500, but smoothing it drops it to 1250.
-set-state admitted=10000 l0-bytes=10000 l0-added=101000 l0-files=11 l0-sublevels=11
+set-state admitted=10000 l0-bytes=10000 l0-added=101000 l0-files=21 l0-sublevels=21
 ----
 admitted: 10000, bytes: 10000, added-bytes: 101000,
 smoothed-removed: 50000, smoothed-admit: 1250,
 tokens: 1250, tokens-allocated: 0
-tick: 0, setAvailableIOTokens: 21
-tick: 1, setAvailableIOTokens: 21
-tick: 2, setAvailableIOTokens: 21
-tick: 3, setAvailableIOTokens: 21
-tick: 4, setAvailableIOTokens: 21
-tick: 5, setAvailableIOTokens: 21
-tick: 6, setAvailableIOTokens: 21
-tick: 7, setAvailableIOTokens: 21
-tick: 8, setAvailableIOTokens: 21
-tick: 9, setAvailableIOTokens: 21
-tick: 10, setAvailableIOTokens: 21
-tick: 11, setAvailableIOTokens: 21
-tick: 12, setAvailableIOTokens: 21
-tick: 13, setAvailableIOTokens: 21
-tick: 14, setAvailableIOTokens: 21
-tick: 15, setAvailableIOTokens: 21
-tick: 16, setAvailableIOTokens: 21
-tick: 17, setAvailableIOTokens: 21
-tick: 18, setAvailableIOTokens: 21
-tick: 19, setAvailableIOTokens: 21
-tick: 20, setAvailableIOTokens: 21
-tick: 21, setAvailableIOTokens: 21
-tick: 22, setAvailableIOTokens: 21
-tick: 23, setAvailableIOTokens: 21
-tick: 24, setAvailableIOTokens: 21
-tick: 25, setAvailableIOTokens: 21
-tick: 26, setAvailableIOTokens: 21
-tick: 27, setAvailableIOTokens: 21
-tick: 28, setAvailableIOTokens: 21
-tick: 29, setAvailableIOTokens: 21
-tick: 30, setAvailableIOTokens: 21
-tick: 31, setAvailableIOTokens: 21
-tick: 32, setAvailableIOTokens: 21
-tick: 33, setAvailableIOTokens: 21
-tick: 34, setAvailableIOTokens: 21
-tick: 35, setAvailableIOTokens: 21
-tick: 36, setAvailableIOTokens: 21
-tick: 37, setAvailableIOTokens: 21
-tick: 38, setAvailableIOTokens: 21
-tick: 39, setAvailableIOTokens: 21
-tick: 40, setAvailableIOTokens: 21
-tick: 41, setAvailableIOTokens: 21
-tick: 42, setAvailableIOTokens: 21
-tick: 43, setAvailableIOTokens: 21
-tick: 44, setAvailableIOTokens: 21
-tick: 45, setAvailableIOTokens: 21
-tick: 46, setAvailableIOTokens: 21
-tick: 47, setAvailableIOTokens: 21
-tick: 48, setAvailableIOTokens: 21
-tick: 49, setAvailableIOTokens: 21
-tick: 50, setAvailableIOTokens: 21
-tick: 51, setAvailableIOTokens: 21
-tick: 52, setAvailableIOTokens: 21
-tick: 53, setAvailableIOTokens: 21
-tick: 54, setAvailableIOTokens: 21
-tick: 55, setAvailableIOTokens: 21
-tick: 56, setAvailableIOTokens: 21
-tick: 57, setAvailableIOTokens: 21
-tick: 58, setAvailableIOTokens: 21
-tick: 59, setAvailableIOTokens: 11
+tick: 0, setAvailableIOTokens: 84
+tick: 1, setAvailableIOTokens: 84
+tick: 2, setAvailableIOTokens: 84
+tick: 3, setAvailableIOTokens: 84
+tick: 4, setAvailableIOTokens: 84
+tick: 5, setAvailableIOTokens: 84
+tick: 6, setAvailableIOTokens: 84
+tick: 7, setAvailableIOTokens: 84
+tick: 8, setAvailableIOTokens: 84
+tick: 9, setAvailableIOTokens: 84
+tick: 10, setAvailableIOTokens: 84
+tick: 11, setAvailableIOTokens: 84
+tick: 12, setAvailableIOTokens: 84
+tick: 13, setAvailableIOTokens: 84
+tick: 14, setAvailableIOTokens: 74
 
 # Same as previous but smoothing bumps up the smoothed-admit to 2500.
-set-state admitted=20000 l0-bytes=10000 l0-added=201000 l0-files=11 l0-sublevels=11
+set-state admitted=20000 l0-bytes=10000 l0-added=201000 l0-files=21 l0-sublevels=21
 ----
 admitted: 20000, bytes: 10000, added-bytes: 201000,
 smoothed-removed: 75000, smoothed-admit: 2500,
 tokens: 2500, tokens-allocated: 0
-tick: 0, setAvailableIOTokens: 42
-tick: 1, setAvailableIOTokens: 42
-tick: 2, setAvailableIOTokens: 42
-tick: 3, setAvailableIOTokens: 42
-tick: 4, setAvailableIOTokens: 42
-tick: 5, setAvailableIOTokens: 42
-tick: 6, setAvailableIOTokens: 42
-tick: 7, setAvailableIOTokens: 42
-tick: 8, setAvailableIOTokens: 42
-tick: 9, setAvailableIOTokens: 42
-tick: 10, setAvailableIOTokens: 42
-tick: 11, setAvailableIOTokens: 42
-tick: 12, setAvailableIOTokens: 42
-tick: 13, setAvailableIOTokens: 42
-tick: 14, setAvailableIOTokens: 42
-tick: 15, setAvailableIOTokens: 42
-tick: 16, setAvailableIOTokens: 42
-tick: 17, setAvailableIOTokens: 42
-tick: 18, setAvailableIOTokens: 42
-tick: 19, setAvailableIOTokens: 42
-tick: 20, setAvailableIOTokens: 42
-tick: 21, setAvailableIOTokens: 42
-tick: 22, setAvailableIOTokens: 42
-tick: 23, setAvailableIOTokens: 42
-tick: 24, setAvailableIOTokens: 42
-tick: 25, setAvailableIOTokens: 42
-tick: 26, setAvailableIOTokens: 42
-tick: 27, setAvailableIOTokens: 42
-tick: 28, setAvailableIOTokens: 42
-tick: 29, setAvailableIOTokens: 42
-tick: 30, setAvailableIOTokens: 42
-tick: 31, setAvailableIOTokens: 42
-tick: 32, setAvailableIOTokens: 42
-tick: 33, setAvailableIOTokens: 42
-tick: 34, setAvailableIOTokens: 42
-tick: 35, setAvailableIOTokens: 42
-tick: 36, setAvailableIOTokens: 42
-tick: 37, setAvailableIOTokens: 42
-tick: 38, setAvailableIOTokens: 42
-tick: 39, setAvailableIOTokens: 42
-tick: 40, setAvailableIOTokens: 42
-tick: 41, setAvailableIOTokens: 42
-tick: 42, setAvailableIOTokens: 42
-tick: 43, setAvailableIOTokens: 42
-tick: 44, setAvailableIOTokens: 42
-tick: 45, setAvailableIOTokens: 42
-tick: 46, setAvailableIOTokens: 42
-tick: 47, setAvailableIOTokens: 42
-tick: 48, setAvailableIOTokens: 42
-tick: 49, setAvailableIOTokens: 42
-tick: 50, setAvailableIOTokens: 42
-tick: 51, setAvailableIOTokens: 42
-tick: 52, setAvailableIOTokens: 42
-tick: 53, setAvailableIOTokens: 42
-tick: 54, setAvailableIOTokens: 42
-tick: 55, setAvailableIOTokens: 42
-tick: 56, setAvailableIOTokens: 42
-tick: 57, setAvailableIOTokens: 42
-tick: 58, setAvailableIOTokens: 42
-tick: 59, setAvailableIOTokens: 22
+tick: 0, setAvailableIOTokens: 167
+tick: 1, setAvailableIOTokens: 167
+tick: 2, setAvailableIOTokens: 167
+tick: 3, setAvailableIOTokens: 167
+tick: 4, setAvailableIOTokens: 167
+tick: 5, setAvailableIOTokens: 167
+tick: 6, setAvailableIOTokens: 167
+tick: 7, setAvailableIOTokens: 167
+tick: 8, setAvailableIOTokens: 167
+tick: 9, setAvailableIOTokens: 167
+tick: 10, setAvailableIOTokens: 167
+tick: 11, setAvailableIOTokens: 167
+tick: 12, setAvailableIOTokens: 167
+tick: 13, setAvailableIOTokens: 167
+tick: 14, setAvailableIOTokens: 162
 
 # l0-sublevels drops below threshold. We calculate the smoothed values, but
 # don't limit the tokens.
-set-state admitted=30000 l0-bytes=10000 l0-added=301000 l0-files=11 l0-sublevels=10
+set-state admitted=30000 l0-bytes=10000 l0-added=301000 l0-files=21 l0-sublevels=20
 ----
 admitted: 30000, bytes: 10000, added-bytes: 301000,
 smoothed-removed: 87500, smoothed-admit: 6250,
@@ -224,48 +89,3 @@ tick: 11, setAvailableIOTokens: unlimited
 tick: 12, setAvailableIOTokens: unlimited
 tick: 13, setAvailableIOTokens: unlimited
 tick: 14, setAvailableIOTokens: unlimited
-tick: 15, setAvailableIOTokens: unlimited
-tick: 16, setAvailableIOTokens: unlimited
-tick: 17, setAvailableIOTokens: unlimited
-tick: 18, setAvailableIOTokens: unlimited
-tick: 19, setAvailableIOTokens: unlimited
-tick: 20, setAvailableIOTokens: unlimited
-tick: 21, setAvailableIOTokens: unlimited
-tick: 22, setAvailableIOTokens: unlimited
-tick: 23, setAvailableIOTokens: unlimited
-tick: 24, setAvailableIOTokens: unlimited
-tick: 25, setAvailableIOTokens: unlimited
-tick: 26, setAvailableIOTokens: unlimited
-tick: 27, setAvailableIOTokens: unlimited
-tick: 28, setAvailableIOTokens: unlimited
-tick: 29, setAvailableIOTokens: unlimited
-tick: 30, setAvailableIOTokens: unlimited
-tick: 31, setAvailableIOTokens: unlimited
-tick: 32, setAvailableIOTokens: unlimited
-tick: 33, setAvailableIOTokens: unlimited
-tick: 34, setAvailableIOTokens: unlimited
-tick: 35, setAvailableIOTokens: unlimited
-tick: 36, setAvailableIOTokens: unlimited
-tick: 37, setAvailableIOTokens: unlimited
-tick: 38, setAvailableIOTokens: unlimited
-tick: 39, setAvailableIOTokens: unlimited
-tick: 40, setAvailableIOTokens: unlimited
-tick: 41, setAvailableIOTokens: unlimited
-tick: 42, setAvailableIOTokens: unlimited
-tick: 43, setAvailableIOTokens: unlimited
-tick: 44, setAvailableIOTokens: unlimited
-tick: 45, setAvailableIOTokens: unlimited
-tick: 46, setAvailableIOTokens: unlimited
-tick: 47, setAvailableIOTokens: unlimited
-tick: 48, setAvailableIOTokens: unlimited
-tick: 49, setAvailableIOTokens: unlimited
-tick: 50, setAvailableIOTokens: unlimited
-tick: 51, setAvailableIOTokens: unlimited
-tick: 52, setAvailableIOTokens: unlimited
-tick: 53, setAvailableIOTokens: unlimited
-tick: 54, setAvailableIOTokens: unlimited
-tick: 55, setAvailableIOTokens: unlimited
-tick: 56, setAvailableIOTokens: unlimited
-tick: 57, setAvailableIOTokens: unlimited
-tick: 58, setAvailableIOTokens: unlimited
-tick: 59, setAvailableIOTokens: unlimited


### PR DESCRIPTION
- Introduce admission.l0_sub_level_count_overload_threshold and
  admission.l0_file_count_overload_threshold cluster settings, that
  default to the existing const values. This allows for further
  tuning in production clusters if needed.
- The default value of l0SubLevelCountOverloadThreshold is increased
  to 20. We were observing certain normal tpcc runs hitting 10+
  sub-levels with only 100 files in L0, and which was recoverable
  without throttling.
- BatchRequests with a single request that is a HeartbeatTxnRequest
  fully bypass storage admission control. These requests significantly
  increase in frequency when admission control is throttling request
  evaluation. They were never queued by admission control but would
  consume a write token on the store, so when the store was
  overloaded, they would prevent any useful work from happening (which
  was responsible for kv roachtest throughput dropping to 0 when the
  store was overloaded).
- The adjustment interval for IO tokens is reduced from 60s to 15s.
  This should increase responsiveness to changes in store state,
  while still being longer than most compactions.

`kv95/enc=false/nodes=3/cpu=32/size=64kb/admission` running with these changes shows that the troughs in LSM health and Admission Work Rate are less deep:
<img width="501" alt="Screen Shot 2021-08-24 at 12 11 45 PM" src="https://user-images.githubusercontent.com/54990988/130657123-e4c8d7f1-fc9a-4323-a15d-5f79b5061338.png">


Release note (ops change): New cluster settings
admission.l0_sub_level_count_overload_threshold and
admission.l0_file_count_overload_threshold can be used to tune
admission control.

Release justification: Low-risk update to new functionality.