### PR TITLE
importccl: unskip TestImportJobEventLogging

### DIFF
--- a/pkg/ccl/backupccl/testutils.go
+++ b/pkg/ccl/backupccl/testutils.go
@@ -40,7 +40,8 @@ func CheckEmittedEvents(
 			t.Fatal(err)
 		}
 		foundEntry := false
-		for i, e := range entries {
+		var matchingEntryIndex int
+		for _, e := range entries {
 			if !strings.Contains(e.Message, expectedMessage) {
 				continue
 			}
@@ -56,10 +57,11 @@ func CheckEmittedEvents(
 			}
 			require.Equal(t, expectedJobType, ev.JobType)
 			require.Equal(t, jobID, ev.JobID)
-			if i >= len(expectedStatus) {
+			if matchingEntryIndex >= len(expectedStatus) {
 				return errors.New("more events fround in log than expected")
 			}
-			require.Equal(t, expectedStatus[i], ev.Status)
+			require.Equal(t, expectedStatus[matchingEntryIndex], ev.Status)
+			matchingEntryIndex++
 		}
 		if !foundEntry {
 			return errors.New("structured entry for import not found in log")

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -6932,7 +6932,6 @@ func TestDetachedImport(t *testing.T) {
 
 func TestImportJobEventLogging(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.WithIssue(t, 65290, "flaky test")
 	defer log.ScopeWithoutShowLogs(t).Close(t)
 
 	defer jobs.TestingSetProgressThresholds()()


### PR DESCRIPTION
Previously, the test used the range index when matching
the current event against the expected event. This was incorrect
because the slice of events we are iterating over could contain
more events than just those added by import. We skip over these
but don't forward the index to match against.

Fixes: #65290

Release note: None

Release justification: non-production code changes