### PR TITLE
workload: reintroduce old `prepare` behavior

### DIFF
--- a/pkg/workload/connection.go
+++ b/pkg/workload/connection.go
@@ -36,7 +36,7 @@ func NewConnFlags(genFlags *Flags) *ConnFlags {
 		`Override for the SQL database to use. If empty, defaults to the generator name`)
 	c.IntVar(&c.Concurrency, `concurrency`, 2*runtime.GOMAXPROCS(0),
 		`Number of concurrent workers`)
-	c.StringVar(&c.Method, `method`, `prepare`, `SQL issue method (prepare, simple)`)
+	c.StringVar(&c.Method, `method`, `prepare`, `SQL issue method (prepare, noprepare, simple)`)
 	genFlags.AddFlagSet(c.FlagSet)
 	if genFlags.Meta == nil {
 		genFlags.Meta = make(map[string]FlagMeta)

--- a/pkg/workload/indexes/indexes.go
+++ b/pkg/workload/indexes/indexes.go
@@ -159,7 +159,7 @@ func (w *indexes) Ops(
 	cfg := workload.MultiConnPoolCfg{
 		MaxTotalConnections: w.connFlags.Concurrency + 1,
 	}
-	mcp, err := workload.NewMultiConnPool(ctx, cfg, w.connFlags, urls...)
+	mcp, err := workload.NewMultiConnPool(ctx, cfg, urls...)
 	if err != nil {
 		return workload.QueryLoad{}, err
 	}
@@ -174,7 +174,7 @@ func (w *indexes) Ops(
 			buf:    make([]byte, w.payload),
 		}
 		op.stmt = op.sr.Define(stmt)
-		if err := op.sr.Init(ctx, mcp); err != nil {
+		if err := op.sr.Init(ctx, "indexes", mcp, w.connFlags); err != nil {
 			return workload.QueryLoad{}, err
 		}
 		ql.WorkerFns = append(ql.WorkerFns, op.run)

--- a/pkg/workload/kv/kv.go
+++ b/pkg/workload/kv/kv.go
@@ -259,7 +259,7 @@ func (w *kv) Ops(
 	cfg := workload.MultiConnPoolCfg{
 		MaxTotalConnections: w.connFlags.Concurrency + 1,
 	}
-	mcp, err := workload.NewMultiConnPool(ctx, cfg, w.connFlags, urls...)
+	mcp, err := workload.NewMultiConnPool(ctx, cfg, urls...)
 	if err != nil {
 		return workload.QueryLoad{}, err
 	}
@@ -353,7 +353,7 @@ func (w *kv) Ops(
 			op.sfuStmt = op.sr.Define(sfuStmtStr)
 		}
 		op.spanStmt = op.sr.Define(spanStmtStr)
-		if err := op.sr.Init(ctx, mcp); err != nil {
+		if err := op.sr.Init(ctx, "kv", mcp, w.connFlags); err != nil {
 			return workload.QueryLoad{}, err
 		}
 		op.mcp = mcp

--- a/pkg/workload/pgx_helpers.go
+++ b/pkg/workload/pgx_helpers.go
@@ -12,10 +12,8 @@ package workload
 
 import (
 	"context"
-	"strings"
 	"sync/atomic"
 
-	"github.com/cockroachdb/errors"
 	"github.com/jackc/pgx/v4/pgxpool"
 	"golang.org/x/sync/errgroup"
 )
@@ -49,21 +47,13 @@ type MultiConnPoolCfg struct {
 // The pools have approximately the same number of max connections, adding up to
 // MaxTotalConnections.
 func NewMultiConnPool(
-	ctx context.Context, cfg MultiConnPoolCfg, flags *ConnFlags, urls ...string,
+	ctx context.Context, cfg MultiConnPoolCfg, urls ...string,
 ) (*MultiConnPool, error) {
 	m := &MultiConnPool{}
 	connsPerURL := distribute(cfg.MaxTotalConnections, len(urls))
 	maxConnsPerPool := cfg.MaxConnsPerPool
 	if maxConnsPerPool == 0 {
 		maxConnsPerPool = cfg.MaxTotalConnections
-	}
-	method := prepare
-	if flags != nil {
-		var ok bool
-		method, ok = stringToMethod[strings.ToLower(flags.Method)]
-		if !ok {
-			return nil, errors.Errorf("unknown method %s", flags.Method)
-		}
 	}
 
 	var warmupConns [][]*pgxpool.Conn
@@ -75,10 +65,6 @@ func NewMultiConnPool(
 				return nil, err
 			}
 			connCfg.MaxConns = int32(numConns)
-			if method == simple {
-				connCfg.ConnConfig.PreferSimpleProtocol = true
-			}
-
 			p, err := pgxpool.ConnectConfig(ctx, connCfg)
 			if err != nil {
 				return nil, err

--- a/pkg/workload/pgx_helpers.go
+++ b/pkg/workload/pgx_helpers.go
@@ -61,6 +61,9 @@ func NewMultiConnPool(
 		connsPerPool := distributeMax(connsPerURL[i], maxConnsPerPool)
 		for _, numConns := range connsPerPool {
 			connCfg, err := pgxpool.ParseConfig(urls[i])
+			// Disable the automatic prepared statement cache. We've seen a lot of
+			// churn in this cache since workloads create many of different queries.
+			connCfg.ConnConfig.BuildStatementCache = nil
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -154,7 +154,7 @@ func (s *schemaChange) Ops(
 	cfg := workload.MultiConnPoolCfg{
 		MaxTotalConnections: s.concurrency * 2, //TODO(spaskob): pick a sensible default.
 	}
-	pool, err := workload.NewMultiConnPool(ctx, cfg, nil, urls...)
+	pool, err := workload.NewMultiConnPool(ctx, cfg, urls...)
 	if err != nil {
 		return workload.QueryLoad{}, err
 	}

--- a/pkg/workload/sql_runner.go
+++ b/pkg/workload/sql_runner.go
@@ -93,11 +93,10 @@ func (sr *SQLRunner) Define(sql string) StmtHandle {
 //    workers; this avoids lock contention in the sql.Rows objects they produce.
 //    See #30811.
 //
-//  - "noprepare": don't use explicit prepared statements, but use the internal
-//    pgx prepared statement cache. See jackc/pgconn/stmtcache. This cache
-//    automatically prepares every statement, but has a maximum capacity. It
-//    will evict prepared statements and deallocate (a.k.a. unprepare)
-//    statements that were least recently uses.
+//  - "noprepare": each query is issued separately (on the given connection).
+//    This results in Parse, Bind, Execute on the server each time we run a
+//    query. The statement is an anonymous prepared statement; that is, the
+//    name is the empty string.
 //
 //  - "simple": each query is issued in a single string; parameters are
 //    rendered inside the string. This results in a single SimpleExecute

--- a/pkg/workload/sql_runner.go
+++ b/pkg/workload/sql_runner.go
@@ -12,9 +12,13 @@ package workload
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
+	"github.com/cockroachdb/errors"
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
+	"github.com/jackc/pgx/v4/pgxpool"
 )
 
 // SQLRunner is a helper for issuing SQL statements; it supports multiple
@@ -45,6 +49,7 @@ type SQLRunner struct {
 
 	// The fields below are set by Init.
 	initialized bool
+	method      method
 	mcp         *MultiConnPool
 }
 
@@ -52,12 +57,14 @@ type method int
 
 const (
 	prepare method = iota
+	noprepare
 	simple
 )
 
 var stringToMethod = map[string]method{
-	"prepare": prepare,
-	"simple":  simple,
+	"prepare":   prepare,
+	"noprepare": noprepare,
+	"simple":    simple,
 }
 
 // Define creates a handle for the given statement. The handle can be used after
@@ -73,9 +80,48 @@ func (sr *SQLRunner) Define(sql string) StmtHandle {
 
 // Init initializes the runner; must be called after calls to Define and before
 // the StmtHandles are used.
-func (sr *SQLRunner) Init(ctx context.Context, mcp *MultiConnPool) error {
+//
+// The name is used for naming prepared statements. Multiple workers that use
+// the same set of defined queries can and should use the same name.
+//
+// The way we issue queries is set by flags.Method:
+//
+//  - "prepare": explicitly prepare the query once per connection, then we reuse
+//    it for each execution. This results in a Bind and Execute on the server
+//    each time we run a query (on the given connection). Note that it's
+//    important to prepare on separate connections if there are many parallel
+//    workers; this avoids lock contention in the sql.Rows objects they produce.
+//    See #30811.
+//
+//  - "noprepare": don't use explicit prepared statements, but use the internal
+//    pgx prepared statement cache. See jackc/pgconn/stmtcache. This cache
+//    automatically prepares every statement, but has a maximum capacity. It
+//    will evict prepared statements and deallocate (a.k.a. unprepare)
+//    statements that were least recently uses.
+//
+//  - "simple": each query is issued in a single string; parameters are
+//    rendered inside the string. This results in a single SimpleExecute
+//    request to the server for each query. Note that only a few parameter types
+//    are supported.
+//
+func (sr *SQLRunner) Init(
+	ctx context.Context, name string, mcp *MultiConnPool, flags *ConnFlags,
+) error {
 	if sr.initialized {
 		panic("already initialized")
+	}
+
+	var ok bool
+	sr.method, ok = stringToMethod[strings.ToLower(flags.Method)]
+	if !ok {
+		return errors.Errorf("unknown method %s", flags.Method)
+	}
+
+	if sr.method == prepare {
+		for i, s := range sr.stmts {
+			stmtName := fmt.Sprintf("%s-%d", name, i+1)
+			s.preparedName = stmtName
+		}
 	}
 
 	sr.mcp = mcp
@@ -92,6 +138,8 @@ func (h StmtHandle) check() {
 type stmt struct {
 	sr  *SQLRunner
 	sql string
+	// preparedName is only used for the prepare method.
+	preparedName string
 }
 
 // StmtHandle is associated with a (possibly prepared) statement; created by
@@ -107,7 +155,32 @@ type StmtHandle struct {
 func (h StmtHandle) Exec(ctx context.Context, args ...interface{}) (pgconn.CommandTag, error) {
 	h.check()
 	p := h.s.sr.mcp.Get()
-	return p.Exec(ctx, h.s.sql, args...)
+	switch h.s.sr.method {
+	case prepare:
+		// Note that calling `Prepare` with a name that has already been prepared
+		// is idempotent and short-circuits before doing any communication to the
+		// server.
+		var commandTag pgconn.CommandTag
+		err := p.AcquireFunc(ctx, func(conn *pgxpool.Conn) error {
+			if _, err := conn.Conn().Prepare(ctx, h.s.preparedName, h.s.sql); err != nil {
+				return err
+			}
+			var connErr error
+			commandTag, connErr = conn.Conn().Exec(ctx, h.s.preparedName, args...)
+			return connErr
+		})
+		return commandTag, err
+
+	case noprepare:
+		return p.Exec(ctx, h.s.sql, args...)
+
+	case simple:
+		newArgs := []interface{}{pgx.QuerySimpleProtocol(true)}
+		return p.Exec(ctx, h.s.sql, append(newArgs, args)...)
+
+	default:
+		panic("invalid method")
+	}
 }
 
 // ExecTx executes a query that doesn't return rows, inside a transaction.
@@ -117,7 +190,26 @@ func (h StmtHandle) ExecTx(
 	ctx context.Context, tx pgx.Tx, args ...interface{},
 ) (pgconn.CommandTag, error) {
 	h.check()
-	return tx.Exec(ctx, h.s.sql, args...)
+	switch h.s.sr.method {
+	case prepare:
+		// Note that calling `Prepare` with a name that has already been prepared
+		// is idempotent and short-circuits before doing any communication to the
+		// server.
+		if _, err := tx.Prepare(ctx, h.s.preparedName, h.s.sql); err != nil {
+			return nil, err
+		}
+		return tx.Exec(ctx, h.s.preparedName, args...)
+
+	case noprepare:
+		return tx.Exec(ctx, h.s.sql, args...)
+
+	case simple:
+		newArgs := []interface{}{pgx.QuerySimpleProtocol(true)}
+		return tx.Exec(ctx, h.s.sql, append(newArgs, args)...)
+
+	default:
+		panic("invalid method")
+	}
 }
 
 // Query executes a query that returns rows.
@@ -126,7 +218,32 @@ func (h StmtHandle) ExecTx(
 func (h StmtHandle) Query(ctx context.Context, args ...interface{}) (pgx.Rows, error) {
 	h.check()
 	p := h.s.sr.mcp.Get()
-	return p.Query(ctx, h.s.sql, args...)
+	switch h.s.sr.method {
+	case prepare:
+		// Note that calling `Prepare` with a name that has already been prepared
+		// is idempotent and short-circuits before doing any communication to the
+		// server.
+		var rows pgx.Rows
+		err := p.AcquireFunc(ctx, func(conn *pgxpool.Conn) error {
+			if _, err := conn.Conn().Prepare(ctx, h.s.preparedName, h.s.sql); err != nil {
+				return err
+			}
+			var connErr error
+			rows, connErr = conn.Conn().Query(ctx, h.s.preparedName, args...)
+			return connErr
+		})
+		return rows, err
+
+	case noprepare:
+		return p.Query(ctx, h.s.sql, args...)
+
+	case simple:
+		newArgs := []interface{}{pgx.QuerySimpleProtocol(true)}
+		return p.Query(ctx, h.s.sql, append(newArgs, args)...)
+
+	default:
+		panic("invalid method")
+	}
 }
 
 // QueryTx executes a query that returns rows, inside a transaction.
@@ -134,7 +251,26 @@ func (h StmtHandle) Query(ctx context.Context, args ...interface{}) (pgx.Rows, e
 // See pgx.Tx.Query.
 func (h StmtHandle) QueryTx(ctx context.Context, tx pgx.Tx, args ...interface{}) (pgx.Rows, error) {
 	h.check()
-	return tx.Query(ctx, h.s.sql, args...)
+	switch h.s.sr.method {
+	case prepare:
+		// Note that calling `Prepare` with a name that has already been prepared
+		// is idempotent and short-circuits before doing any communication to the
+		// server.
+		if _, err := tx.Prepare(ctx, h.s.preparedName, h.s.sql); err != nil {
+			return nil, err
+		}
+		return tx.Query(ctx, h.s.preparedName, args...)
+
+	case noprepare:
+		return tx.Query(ctx, h.s.sql, args...)
+
+	case simple:
+		newArgs := []interface{}{pgx.QuerySimpleProtocol(true)}
+		return tx.Query(ctx, h.s.sql, append(newArgs, args)...)
+
+	default:
+		panic("invalid method")
+	}
 }
 
 // QueryRow executes a query that is expected to return at most one row.
@@ -143,7 +279,35 @@ func (h StmtHandle) QueryTx(ctx context.Context, tx pgx.Tx, args ...interface{})
 func (h StmtHandle) QueryRow(ctx context.Context, args ...interface{}) pgx.Row {
 	h.check()
 	p := h.s.sr.mcp.Get()
-	return p.QueryRow(ctx, h.s.sql, args...)
+	switch h.s.sr.method {
+	case prepare:
+		// Note that calling `Prepare` with a name that has already been prepared
+		// is idempotent and short-circuits before doing any communication to the
+		// server.
+		var row pgx.Row
+		err := p.AcquireFunc(ctx, func(conn *pgxpool.Conn) error {
+			if _, err := conn.Conn().Prepare(ctx, h.s.preparedName, h.s.sql); err != nil {
+				return err
+			}
+			row = conn.Conn().QueryRow(ctx, h.s.preparedName, args...)
+			return nil
+		})
+		if err != nil {
+			r := errRow{retErr: err}
+			return &r
+		}
+		return row
+
+	case noprepare:
+		return p.QueryRow(ctx, h.s.sql, args...)
+
+	case simple:
+		newArgs := []interface{}{pgx.QuerySimpleProtocol(true)}
+		return p.QueryRow(ctx, h.s.sql, append(newArgs, args)...)
+
+	default:
+		panic("invalid method")
+	}
 }
 
 // QueryRowTx executes a query that is expected to return at most one row,
@@ -152,8 +316,38 @@ func (h StmtHandle) QueryRow(ctx context.Context, args ...interface{}) pgx.Row {
 // See pgx.Conn.QueryRow.
 func (h StmtHandle) QueryRowTx(ctx context.Context, tx pgx.Tx, args ...interface{}) pgx.Row {
 	h.check()
-	return tx.QueryRow(ctx, h.s.sql, args...)
+	switch h.s.sr.method {
+	case prepare:
+		// Note that calling `Prepare` with a name that has already been prepared
+		// is idempotent and short-circuits before doing any communication to the
+		// server.
+		if _, err := tx.Prepare(ctx, h.s.preparedName, h.s.sql); err != nil {
+			r := errRow{retErr: err}
+			return &r
+		}
+		return tx.QueryRow(ctx, h.s.preparedName, args...)
+
+	case noprepare:
+		return tx.QueryRow(ctx, h.s.sql, args...)
+
+	case simple:
+		newArgs := []interface{}{pgx.QuerySimpleProtocol(true)}
+		return tx.QueryRow(ctx, h.s.sql, append(newArgs, args)...)
+
+	default:
+		panic("invalid method")
+	}
 }
+
+// errRow implements the pgx.Row interface. It's used only in the `prepare`
+// mode.
+type errRow struct {
+	retErr error
+}
+
+var _ pgx.Row = &errRow{}
+
+func (r *errRow) Scan(_ ...interface{}) error { return r.retErr }
 
 // Appease the linter.
 var _ = StmtHandle.QueryRow

--- a/pkg/workload/tpcc/delivery.go
+++ b/pkg/workload/tpcc/delivery.go
@@ -72,7 +72,7 @@ func createDelivery(
 		WHERE ol_w_id = $1 AND ol_d_id = $2 AND ol_o_id = $3`,
 	)
 
-	if err := del.sr.Init(ctx, mcp); err != nil {
+	if err := del.sr.Init(ctx, "delivery", mcp, config.connFlags); err != nil {
 		return nil, err
 	}
 

--- a/pkg/workload/tpcc/new_order.go
+++ b/pkg/workload/tpcc/new_order.go
@@ -123,7 +123,7 @@ func createNewOrder(
 		VALUES ($1, $2, $3)`,
 	)
 
-	if err := n.sr.Init(ctx, mcp); err != nil {
+	if err := n.sr.Init(ctx, "new-order", mcp, config.connFlags); err != nil {
 		return nil, err
 	}
 

--- a/pkg/workload/tpcc/order_status.go
+++ b/pkg/workload/tpcc/order_status.go
@@ -109,7 +109,7 @@ func createOrderStatus(
 		WHERE ol_w_id = $1 AND ol_d_id = $2 AND ol_o_id = $3`,
 	)
 
-	if err := o.sr.Init(ctx, mcp); err != nil {
+	if err := o.sr.Init(ctx, "order-status", mcp, config.connFlags); err != nil {
 		return nil, err
 	}
 

--- a/pkg/workload/tpcc/payment.go
+++ b/pkg/workload/tpcc/payment.go
@@ -142,7 +142,7 @@ func createPayment(ctx context.Context, config *tpcc, mcp *workload.MultiConnPoo
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
 	)
 
-	if err := p.sr.Init(ctx, mcp); err != nil {
+	if err := p.sr.Init(ctx, "payment", mcp, config.connFlags); err != nil {
 		return nil, err
 	}
 

--- a/pkg/workload/tpcc/stock_level.go
+++ b/pkg/workload/tpcc/stock_level.go
@@ -83,7 +83,7 @@ func createStockLevel(
 		)`,
 	)
 
-	if err := s.sr.Init(ctx, mcp); err != nil {
+	if err := s.sr.Init(ctx, "stock-level", mcp, config.connFlags); err != nil {
 		return nil, err
 	}
 

--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -764,7 +764,7 @@ func (w *tpcc) Ops(
 		i := i
 		g.Go(func() error {
 			var err error
-			dbs[i], err = workload.NewMultiConnPool(ctx, cfg, w.connFlags, urls[i])
+			dbs[i], err = workload.NewMultiConnPool(ctx, cfg, urls[i])
 			return err
 		})
 	}


### PR DESCRIPTION
This reverts commit f446498d487783ffbec2b1dec084d85ac65c7647,
and makes the 'prepare' setting work more closely to how it used to.

This is needed because we are seeing that the schemachange workload is
deallocating huge amounts of automatically prepared statements. By
explicitly preparing statements again, they should no longer be
deallocated.

This also disables the automatic prepared statement cache in pgx entirely,
which was enabled in https://github.com/jackc/pgx/commit/0c3e59b07a882e25a896f1b0e75a84461cc889cf

Release justification: test-only change
Release note: None