### PR TITLE
sql: make schema change jobs without mutations IDs to be non-cancellable

### DIFF
--- a/pkg/sql/schemachanger/BUILD.bazel
+++ b/pkg/sql/schemachanger/BUILD.bazel
@@ -28,6 +28,7 @@ go_test(
         "//pkg/testutils/testcluster",
         "//pkg/util/ctxgroup",
         "//pkg/util/leaktest",
+        "//pkg/util/log",
         "//pkg/util/randutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//assert",


### PR DESCRIPTION
Fixes: #59545

Previously, certain jobs like drop tables were incorrectly
labeled as cancellable, when a proper or full rollback could
not have been executed. This was inadequate because in certain
cases like DROP TABLE you could end up in scenarios where a
table is dropped but not GCed due to a user cancel. These
scenarios could potentially be recovered with another schema
change, but this was confusing for users. To address this, this
patch marks all schema changes without a mutation ID as non-cancellable.

Release justification: low risk and should only impact light weight
schema changes (renames, drops, etc..)
Release note (sql change): DROPS, RENAMES, and other light schema
changes are no longer user cancellable to avoid scenarios that do
not properly rollback.