### PR TITLE
changefeedccl: fix default retry config parsing for webhook sink

### DIFF
--- a/pkg/ccl/changefeedccl/cdctest/testfeed.go
+++ b/pkg/ccl/changefeedccl/cdctest/testfeed.go
@@ -72,6 +72,8 @@ type EnterpriseTestFeed interface {
 	WaitForStatus(func(s jobs.Status) bool) error
 	// FetchTerminalJobErr retrieves the error message from changefeed job.
 	FetchTerminalJobErr() error
+	// FetchRunningStatus retrieves running status from changefeed job.
+	FetchRunningStatus() (string, error)
 	// Details returns changefeed details for this feed.
 	Details() (*jobspb.ChangefeedDetails, error)
 }

--- a/pkg/ccl/changefeedccl/sink_webhook.go
+++ b/pkg/ccl/changefeedccl/sink_webhook.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -138,10 +139,40 @@ type batchConfig struct {
 	Frequency       jsonDuration `json:",omitempty"`
 }
 
+type jsonMaxRetries int
+
+func (j *jsonMaxRetries) UnmarshalJSON(b []byte) error {
+	var i int64
+	// try to parse as int
+	i, err := strconv.ParseInt(string(b), 10, 64)
+	if err == nil {
+		if i <= 0 {
+			return errors.Errorf("max retry count must be a positive integer. use 'inf' for infinite retries.")
+		}
+		*j = jsonMaxRetries(i)
+	} else {
+		// if that fails, try to parse as string (only accept 'inf')
+		var s string
+		// using unmarshal here to remove quotes around the string
+		if err := json.Unmarshal(b, &s); err != nil {
+			return err
+		}
+		if strings.ToLower(s) == "inf" {
+			// if used wants infinite retries, set to zero as retry.Options interprets this as infinity
+			*j = 0
+		} else if n, err := strconv.Atoi(s); err == nil { // also accept ints as strings
+			*j = jsonMaxRetries(n)
+		} else {
+			return errors.Errorf("max retries must be either a positive int or 'inf' for infinite retries.")
+		}
+	}
+	return nil
+}
+
 // wrapper structs to unmarshal json, retry.Options will be the actual config
 type retryConfig struct {
-	Max     int          `json:",omitempty"`
-	Backoff jsonDuration `json:",omitempty"`
+	Max     jsonMaxRetries `json:",omitempty"`
+	Backoff jsonDuration   `json:",omitempty"`
 }
 
 // proper JSON schema for webhook sink config:
@@ -167,10 +198,10 @@ func (s *webhookSink) getWebhookSinkConfig(
 	retryCfg = defaultRetryConfig()
 
 	var cfg webhookSinkConfig
+	cfg.Retry.Max = jsonMaxRetries(retryCfg.MaxRetries)
+	cfg.Retry.Backoff = jsonDuration(retryCfg.InitialBackoff)
 	if configStr, ok := opts[changefeedbase.OptWebhookSinkConfig]; ok {
 		// set retry defaults to be overridden if included in JSON
-		cfg.Retry.Max = retryCfg.MaxRetries
-		cfg.Retry.Backoff = jsonDuration(retryCfg.InitialBackoff)
 		if err = json.Unmarshal([]byte(configStr), &cfg); err != nil {
 			return batchCfg, retryCfg, errors.Wrapf(err, "error unmarshalling json")
 		}
@@ -187,7 +218,7 @@ func (s *webhookSink) getWebhookSinkConfig(
 		return batchCfg, retryCfg, errors.Errorf("invalid option value %s, flush frequency is not set, messages may never be sent", changefeedbase.OptWebhookSinkConfig)
 	}
 
-	retryCfg.MaxRetries = cfg.Retry.Max
+	retryCfg.MaxRetries = int(cfg.Retry.Max)
 	retryCfg.InitialBackoff = time.Duration(cfg.Retry.Backoff)
 	return cfg.Flush, retryCfg, nil
 }
@@ -506,11 +537,6 @@ func (s *webhookSink) workerLoop(workerIndex int) {
 				return
 			}
 			alloc.Release(s.workerCtx)
-			// shut down all other workers immediately if error encountered
-			if err != nil {
-				s.exitWorkers()
-				return
-			}
 		}
 	}
 }
@@ -586,7 +612,9 @@ func (s *webhookSink) EmitRow(
 	select {
 	// check the webhook sink context in case workers have been terminated
 	case <-s.workerCtx.Done():
-		return s.workerCtx.Err()
+		// check again for error in case it triggered since last check
+		// will return more verbose error instead of "context canceled"
+		return errors.CombineErrors(s.workerCtx.Err(), s.sinkError())
 	case <-ctx.Done():
 		return ctx.Err()
 	case err := <-s.errChan:

--- a/pkg/ccl/changefeedccl/testfeed_test.go
+++ b/pkg/ccl/changefeedccl/testfeed_test.go
@@ -351,6 +351,16 @@ func (f *jobFeed) FetchTerminalJobErr() error {
 	return nil
 }
 
+// FetchRunningStatus retrieves running status from changefeed job.
+func (f *jobFeed) FetchRunningStatus() (runningStatusStr string, err error) {
+	if err = f.db.QueryRow(
+		`SELECT running_status FROM [SHOW JOBS] WHERE job_id=$1`, f.jobID,
+	).Scan(&runningStatusStr); err != nil {
+		return "", err
+	}
+	return runningStatusStr, err
+}
+
 // Close closes job feed.
 func (f *jobFeed) Close() error {
 	// Signal shutdown.


### PR DESCRIPTION
Fixes bug where HTTP requests would be retried indefinitely if
no webhook sink config was provided. Now, max retries cannot be
set as zero, "inf" should be used instead.

Release justification: Essential fix to webhook sink which is a
major component of changefeeds in 21.2.

Resolves #69325

Release note: None