### PR TITLE
kv,kvcoord: assign high priority for admission control if the txn has…

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -1082,6 +1082,13 @@ func (tc *TxnCoordSender) Epoch() enginepb.TxnEpoch {
 	return tc.mu.txn.Epoch
 }
 
+// IsLocking is part of the client.TxnSender interface.
+func (tc *TxnCoordSender) IsLocking() bool {
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+	return tc.mu.txn.IsLocking()
+}
+
 // IsTracking returns true if the heartbeat loop is running.
 func (tc *TxnCoordSender) IsTracking() bool {
 	tc.mu.Lock()

--- a/pkg/kv/mock_transactional_sender.go
+++ b/pkg/kv/mock_transactional_sender.go
@@ -160,6 +160,9 @@ func (m *MockTransactionalSender) ReleaseSavepoint(context.Context, SavepointTok
 // Epoch is part of the TxnSender interface.
 func (m *MockTransactionalSender) Epoch() enginepb.TxnEpoch { panic("unimplemented") }
 
+// IsLocking is part of the TxnSender interface.
+func (m *MockTransactionalSender) IsLocking() bool { return false }
+
 // TestingCloneTxn is part of the TxnSender interface.
 func (m *MockTransactionalSender) TestingCloneTxn() *roachpb.Transaction {
 	return m.txn.Clone()

--- a/pkg/kv/sender.go
+++ b/pkg/kv/sender.go
@@ -260,6 +260,9 @@ type TxnSender interface {
 	// Epoch returns the txn's epoch.
 	Epoch() enginepb.TxnEpoch
 
+	// IsLocking returns whether the transaction has begun acquiring locks.
+	IsLocking() bool
+
 	// PrepareRetryableError generates a
 	// TransactionRetryWithProtoRefreshError with a payload initialized
 	// from this txn.


### PR DESCRIPTION
… locks

This is a crude way to limit priority inversion where a txn holding locks
could be waiting in an admission queue while admitted requests are waiting
in the lock table queues for this txn to make progress and release locks.

It can also fare better than no admission control, since work from txns
holding locks will get prioritized, versus no prioritization in goroutine
scheduler. 

A tpcc run with 3000 warehouses shows 2x reduction in lock waiters and
10+% improvement in txn throughput with this change (both before and 
after experiments running with admission control enabled). When compared 
with admission control disabled, we see even higher improvements in lock 
waiters and txn throughput.

Some before/after graphs from running tpcc with 3000 warehouses, and
comparison with no admission control.

before (lock waiters):
<img width="841" alt="Screen Shot 2021-08-24 at 5 53 48 PM" src="https://user-images.githubusercontent.com/54990988/130698250-be5b8ce8-68ae-4fbd-aaba-14d83a342656.png">
after (lock waiters):
<img width="816" alt="Screen Shot 2021-08-24 at 5 54 14 PM" src="https://user-images.githubusercontent.com/54990988/130698283-97bced1a-453c-43f9-aa25-cdc33bd42e35.png">
no admission control (lock waiters):
<img width="840" alt="Screen Shot 2021-08-24 at 7 53 10 PM" src="https://user-images.githubusercontent.com/54990988/130705072-363656ee-3520-47d4-a30a-e44ef1065d72.png">

before (txn throughput and latency):
<img width="674" alt="Screen Shot 2021-08-24 at 5 53 01 PM" src="https://user-images.githubusercontent.com/54990988/130698378-3f1eeec0-e44a-4c62-ac36-14393369e181.png">
after (txn throughput and latency):
<img width="667" alt="Screen Shot 2021-08-24 at 5 53 17 PM" src="https://user-images.githubusercontent.com/54990988/130698421-7e838f1f-e7ab-4b3a-8d2d-c368bd728ff7.png">
no admission control (txn throughput and latency):
<img width="683" alt="Screen Shot 2021-08-24 at 7 52 12 PM" src="https://user-images.githubusercontent.com/54990988/130705166-5e06b4f5-b5ed-40d7-a126-6468bbdce76a.png">

Informs #65955

Release note: None

Release justification: Low-risk update to new functionality.