### PR TITLE
sessiondata: introduce sessiondata.Stack and thread to EvalContext and connExecutor

### DIFF
--- a/pkg/ccl/changefeedccl/avro_test.go
+++ b/pkg/ccl/changefeedccl/avro_test.go
@@ -370,7 +370,9 @@ func TestAvroSchema(t *testing.T) {
 			require.NoError(t, err)
 
 			for _, row := range rows {
-				evalCtx := &tree.EvalContext{SessionData: &sessiondata.SessionData{}}
+				evalCtx := &tree.EvalContext{
+					SessionDataStack: sessiondata.NewStack(&sessiondata.SessionData{}),
+				}
 				serialized, err := origSchema.textualFromRow(row)
 				require.NoError(t, err)
 				roundtripped, err := roundtrippedSchema.rowFromTextual(serialized)

--- a/pkg/ccl/importccl/bench_test.go
+++ b/pkg/ccl/importccl/bench_test.go
@@ -176,8 +176,8 @@ func benchmarkConvertToKVs(b *testing.B, g workload.Generator) {
 			wc := importccl.NewWorkloadKVConverter(
 				0, tableDesc, t.InitialRows, 0, t.InitialRows.NumBatches, kvCh)
 			evalCtx := &tree.EvalContext{
-				SessionData: &sessiondata.SessionData{},
-				Codec:       keys.SystemSQLCodec,
+				SessionDataStack: sessiondata.NewStack(&sessiondata.SessionData{}),
+				Codec:            keys.SystemSQLCodec,
 			}
 			return wc.Worker(ctx, evalCtx)
 		})

--- a/pkg/ccl/importccl/import_table_creation.go
+++ b/pkg/ccl/importccl/import_table_creation.go
@@ -205,7 +205,7 @@ func MakeSimpleTableDescriptor(
 	evalCtx := tree.EvalContext{
 		Context:            ctx,
 		Sequence:           &importSequenceOperators{},
-		SessionData:        &sessiondata.SessionData{},
+		SessionDataStack:   sessiondata.NewStack(&sessiondata.SessionData{}),
 		ClientNoticeSender: &faketreeeval.DummyClientNoticeSender{},
 		Settings:           st,
 	}
@@ -226,7 +226,7 @@ func MakeSimpleTableDescriptor(
 		affected,
 		semaCtx,
 		&evalCtx,
-		evalCtx.SessionData, /* sessionData */
+		evalCtx.SessionData(), /* sessionData */
 		tree.PersistencePermanent,
 		// We need to bypass the LOCALITY on non multi-region check here because
 		// we cannot access the database region config at import level.

--- a/pkg/ccl/importccl/read_import_base.go
+++ b/pkg/ccl/importccl/read_import_base.go
@@ -657,7 +657,7 @@ func (p *parallelImporter) importWorker(
 	if err != nil {
 		return err
 	}
-	if conv.EvalCtx.SessionData == nil {
+	if conv.EvalCtx.SessionData() == nil {
 		panic("uninitialized session data")
 	}
 

--- a/pkg/ccl/importccl/testutils_test.go
+++ b/pkg/ccl/importccl/testutils_test.go
@@ -86,9 +86,11 @@ func descForTable(
 }
 
 var testEvalCtx = &tree.EvalContext{
-	SessionData: &sessiondata.SessionData{
-		Location: time.UTC,
-	},
+	SessionDataStack: sessiondata.NewStack(
+		&sessiondata.SessionData{
+			Location: time.UTC,
+		},
+	),
 	StmtTimestamp: timeutil.Unix(100000000, 0),
 	Settings:      cluster.MakeTestingClusterSettings(),
 	Codec:         keys.SystemSQLCodec,

--- a/pkg/ccl/workloadccl/format/sstable.go
+++ b/pkg/ccl/workloadccl/format/sstable.go
@@ -82,8 +82,8 @@ func ToSSTable(t workload.Table, tableID descpb.ID, ts time.Time) ([]byte, error
 	g.GoCtx(func(ctx context.Context) error {
 		defer close(kvCh)
 		evalCtx := &tree.EvalContext{
-			SessionData: &sessiondata.SessionData{},
-			Codec:       keys.SystemSQLCodec,
+			SessionDataStack: sessiondata.NewStack(&sessiondata.SessionData{}),
+			Codec:            keys.SystemSQLCodec,
 		}
 		return wc.Worker(ctx, evalCtx)
 	})

--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -1112,7 +1112,7 @@ func (p *planner) AlterDatabasePlacement(
 		return nil, err
 	}
 
-	if !p.EvalContext().SessionData.PlacementEnabled {
+	if !p.EvalContext().SessionData().PlacementEnabled {
 		return nil, errors.WithHint(pgerror.New(
 			pgcode.FeatureNotSupported,
 			"ALTER DATABASE PLACEMENT requires that the session setting "+

--- a/pkg/sql/alter_index.go
+++ b/pkg/sql/alter_index.go
@@ -85,7 +85,7 @@ func (n *alterIndexNode) startExec(params runParams) error {
 					"cannot ALTER INDEX PARTITION BY on an index which already has implicit column partitioning",
 				)
 			}
-			allowImplicitPartitioning := params.p.EvalContext().SessionData.ImplicitColumnPartitioningEnabled ||
+			allowImplicitPartitioning := params.p.EvalContext().SessionData().ImplicitColumnPartitioningEnabled ||
 				n.tableDesc.IsLocalityRegionalByRow()
 			alteredIndexDesc := n.index.IndexDescDeepCopy()
 			newImplicitCols, newPartitioning, err := CreatePartitioning(

--- a/pkg/sql/alter_primary_key.go
+++ b/pkg/sql/alter_primary_key.go
@@ -78,7 +78,7 @@ func (p *planner) AlterPrimaryKey(
 	}
 
 	if alterPKNode.Sharded != nil {
-		if !p.EvalContext().SessionData.HashShardedIndexesEnabled {
+		if !p.EvalContext().SessionData().HashShardedIndexesEnabled {
 			return hashShardedIndexesDisabledError
 		}
 		if alterPKNode.Interleave != nil {

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -899,7 +899,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 				newPrimaryIndexDesc,
 				t.PartitionBy,
 				nil, /* allowedNewColumnNames */
-				params.p.EvalContext().SessionData.ImplicitColumnPartitioningEnabled ||
+				params.p.EvalContext().SessionData().ImplicitColumnPartitioningEnabled ||
 					n.tableDesc.IsLocalityRegionalByRow(),
 			)
 			if err != nil {

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -2486,7 +2486,7 @@ func indexTruncateInTxn(
 	for done := false; !done; done = sp.Key == nil {
 		rd := row.MakeDeleter(
 			execCfg.Codec, tableDesc, nil /* requestedCols */, &execCfg.Settings.SV,
-			evalCtx.SessionData.Internal,
+			evalCtx.SessionData().Internal,
 		)
 		td := tableDeleter{rd: rd, alloc: alloc}
 		if err := td.init(ctx, txn, evalCtx); err != nil {

--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -267,7 +267,7 @@ func (cb *ColumnBackfiller) RunColumnBackfillChunk(
 		row.UpdaterOnlyColumns,
 		&cb.alloc,
 		&cb.evalCtx.Settings.SV,
-		cb.evalCtx.SessionData.Internal,
+		cb.evalCtx.SessionData().Internal,
 	)
 	if err != nil {
 		return roachpb.Key{}, err

--- a/pkg/sql/buffer_util.go
+++ b/pkg/sql/buffer_util.go
@@ -38,7 +38,7 @@ func (c *rowContainerHelper) init(
 ) {
 	distSQLCfg := &evalContext.DistSQLPlanner.distSQLSrv.ServerConfig
 	c.memMonitor = execinfra.NewLimitedMonitorNoFlowCtx(
-		evalContext.Context, evalContext.Mon, distSQLCfg, evalContext.SessionData,
+		evalContext.Context, evalContext.Mon, distSQLCfg, evalContext.SessionData(),
 		fmt.Sprintf("%s-limited", opName),
 	)
 	c.diskMonitor = execinfra.NewMonitor(evalContext.Context, distSQLCfg.ParentDiskMonitor, fmt.Sprintf("%s-disk", opName))

--- a/pkg/sql/catalog/schemaexpr/expr.go
+++ b/pkg/sql/catalog/schemaexpr/expr.go
@@ -303,7 +303,7 @@ func newNameResolver(
 // unresolved names replaced with IndexedVars.
 func (nr *nameResolver) resolveNames(expr tree.Expr) (tree.Expr, error) {
 	var v NameResolutionVisitor
-	return ResolveNamesUsingVisitor(&v, expr, nr.source, *nr.ivarHelper, nr.evalCtx.SessionData.SearchPath)
+	return ResolveNamesUsingVisitor(&v, expr, nr.source, *nr.ivarHelper, nr.evalCtx.SessionData().SearchPath)
 }
 
 // addColumn adds a new column to the nameResolver so that it can be resolved in

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -556,7 +556,7 @@ func (r opResult) createAndWrapRowSource(
 		return errors.New("processorConstructor is nil")
 	}
 	log.VEventf(ctx, 1, "planning a row-execution processor in the vectorized flow: %v", causeToWrap)
-	if err := canWrap(flowCtx.EvalCtx.SessionData.VectorizeMode, spec); err != nil {
+	if err := canWrap(flowCtx.EvalCtx.SessionData().VectorizeMode, spec); err != nil {
 		log.VEventf(ctx, 1, "planning a wrapped processor failed: %v", err)
 		// Return the original error for why we don't support this spec
 		// natively since it is more interesting.

--- a/pkg/sql/colfetcher/cfetcher.go
+++ b/pkg/sql/colfetcher/cfetcher.go
@@ -1654,7 +1654,7 @@ func initCFetcher(
 
 	if err := fetcher.Init(
 		flowCtx.Codec(), allocator, args.memoryLimit, args.reverse, args.lockingStrength,
-		args.lockingWaitPolicy, flowCtx.EvalCtx.SessionData.LockTimeout, tableArgs,
+		args.lockingWaitPolicy, flowCtx.EvalCtx.SessionData().LockTimeout, tableArgs,
 	); err != nil {
 		return nil, err
 	}

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -1177,7 +1177,7 @@ func (s *vectorizedFlowCreator) setupFlow(
 				err = errors.Wrapf(err, "unable to vectorize execution plan")
 				return
 			}
-			if flowCtx.EvalCtx.SessionData.TestingVectorizeInjectPanics {
+			if flowCtx.EvalCtx.SessionData().TestingVectorizeInjectPanics {
 				result.Root = newPanicInjector(result.Root)
 			}
 			if util.CrdbTestBuild {

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -2365,7 +2365,7 @@ func (ex *connExecutor) initEvalCtx(ctx context.Context, evalCtx *extendedEvalCo
 			Tenant:                 p,
 			JoinTokenCreator:       p,
 			PreparedStatementState: &ex.extraTxnState.prepStmtsNamespace,
-			SessionData:            ex.sessionDataStack.Top(),
+			SessionDataStack:       ex.sessionDataStack,
 			Settings:               ex.server.cfg.Settings,
 			TestingKnobs:           ex.server.cfg.EvalContextTestingKnobs,
 			ClusterID:              ex.server.cfg.ClusterID(),

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -612,7 +612,7 @@ func (h ConnectionHandler) GetUnqualifiedIntSize() *types.T {
 	if h.ex != nil {
 		// The executor will be nil in certain testing situations where
 		// no server is actually present.
-		size = h.ex.sessionData.DefaultIntSize
+		size = h.ex.sessionData().DefaultIntSize
 	}
 	return parser.NakedIntTypeFromDefaultIntSize(size)
 }
@@ -742,14 +742,14 @@ func (s *Server) newConnExecutor(
 	sdMutator := new(sessionDataMutator)
 	*sdMutator = s.makeSessionDataMutator(sd, sdDefaults)
 	ex := &connExecutor{
-		server:      s,
-		metrics:     srvMetrics,
-		stmtBuf:     stmtBuf,
-		clientComm:  clientComm,
-		mon:         sessionRootMon,
-		sessionMon:  sessionMon,
-		sessionData: sd,
-		dataMutator: sdMutator,
+		server:           s,
+		metrics:          srvMetrics,
+		stmtBuf:          stmtBuf,
+		clientComm:       clientComm,
+		mon:              sessionRootMon,
+		sessionMon:       sessionMon,
+		sessionDataStack: sessiondata.NewStack(sd),
+		dataMutator:      sdMutator,
 		state: txnState{
 			mon:                          txnMon,
 			connCtx:                      ctx,
@@ -791,7 +791,7 @@ func (s *Server) newConnExecutor(
 		ex.hasCreatedTemporarySchema = true
 	}
 
-	ex.applicationName.Store(ex.sessionData.ApplicationName)
+	ex.applicationName.Store(ex.sessionData().ApplicationName)
 	ex.statsWriter = statsWriter
 	ex.statsCollector = sslocal.NewStatsCollector(statsWriter, ex.phaseTimes)
 	sdMutator.RegisterOnSessionDataChange("application_name", func(newName string) {
@@ -1224,8 +1224,8 @@ type connExecutor struct {
 		hasAdminRoleCache HasAdminRoleCache
 	}
 
-	// sessionData contains the user-configurable connection variables.
-	sessionData *sessiondata.SessionData
+	// sessionDataStack contains the user-configurable connection variables.
+	sessionDataStack *sessiondata.Stack
 	// dataMutator is nil for session-bound internal executors; we shouldn't issue
 	// statements that manipulate session state to an internal executor.
 	dataMutator *sessionDataMutator
@@ -1425,7 +1425,7 @@ func (ex *connExecutor) resetExtraTxnState(ctx context.Context, ev txnEvent) err
 	ex.extraTxnState.jobs = nil
 	ex.extraTxnState.hasAdminRoleCache = HasAdminRoleCache{}
 	ex.extraTxnState.schemaChangerState = SchemaChangerState{
-		mode: ex.sessionData.NewSchemaChangerMode,
+		mode: ex.sessionData().NewSchemaChangerMode,
 	}
 
 	for k := range ex.extraTxnState.schemaChangeJobRecords {
@@ -1477,6 +1477,14 @@ func (ex *connExecutor) Ctx() context.Context {
 	return ctx
 }
 
+// sessionData returns the top SessionData on the executor.
+func (ex *connExecutor) sessionData() *sessiondata.SessionData {
+	if ex.sessionDataStack == nil {
+		return nil
+	}
+	return ex.sessionDataStack.Top()
+}
+
 // activate engages the use of resources that must be cleaned up
 // afterwards. after activate() completes, the close() method must be
 // called.
@@ -1499,11 +1507,11 @@ func (ex *connExecutor) activate(
 	// Enable the trace if configured.
 	if traceSessionEventLogEnabled.Get(&ex.server.cfg.Settings.SV) {
 		remoteStr := "<admin>"
-		if ex.sessionData.RemoteAddr != nil {
-			remoteStr = ex.sessionData.RemoteAddr.String()
+		if ex.sessionData().RemoteAddr != nil {
+			remoteStr = ex.sessionData().RemoteAddr.String()
 		}
 		ex.eventLog = trace.NewEventLog(
-			fmt.Sprintf("sql session [%s]", ex.sessionData.User()), remoteStr)
+			fmt.Sprintf("sql session [%s]", ex.sessionData().User()), remoteStr)
 	}
 
 	ex.activated = true
@@ -1637,8 +1645,8 @@ func (ex *connExecutor) execCmd(ctx context.Context) error {
 				NeedRowDesc,
 				pos,
 				nil, /* formatCodes */
-				ex.sessionData.DataConversionConfig,
-				ex.sessionData.GetLocation(),
+				ex.sessionData().DataConversionConfig,
+				ex.sessionData().GetLocation(),
 				0,  /* limit */
 				"", /* portalName */
 				ex.implicitTxn(),
@@ -1706,8 +1714,8 @@ func (ex *connExecutor) execCmd(ctx context.Context) error {
 				// needed.
 				DontNeedRowDesc,
 				pos, portal.OutFormats,
-				ex.sessionData.DataConversionConfig,
-				ex.sessionData.GetLocation(),
+				ex.sessionData().DataConversionConfig,
+				ex.sessionData().GetLocation(),
 				tcmd.Limit,
 				portalName,
 				ex.implicitTxn(),
@@ -2299,7 +2307,7 @@ func txnPriorityToProto(mode tree.UserPriority) roachpb.UserPriority {
 
 func (ex *connExecutor) txnPriorityWithSessionDefault(mode tree.UserPriority) roachpb.UserPriority {
 	if mode == tree.UnspecifiedUserPriority {
-		mode = tree.UserPriority(ex.sessionData.DefaultTxnPriority)
+		mode = tree.UserPriority(ex.sessionData().DefaultTxnPriority)
 	}
 	return txnPriorityToProto(mode)
 }
@@ -2308,7 +2316,7 @@ func (ex *connExecutor) readWriteModeWithSessionDefault(
 	mode tree.ReadWriteMode,
 ) tree.ReadWriteMode {
 	if mode == tree.UnspecifiedReadWriteMode {
-		if ex.sessionData.DefaultTxnReadOnly {
+		if ex.sessionData().DefaultTxnReadOnly {
 			return tree.ReadOnly
 		}
 		return tree.ReadWrite
@@ -2327,7 +2335,7 @@ var followerReadTimestampExpr = &tree.FuncExpr{
 
 func (ex *connExecutor) asOfClauseWithSessionDefault(expr tree.AsOfClause) tree.AsOfClause {
 	if expr.Expr == nil {
-		if ex.sessionData.DefaultTxnUseFollowerReads {
+		if ex.sessionData().DefaultTxnUseFollowerReads {
 			return tree.AsOfClause{Expr: followerReadTimestampExpr}
 		}
 		return tree.AsOfClause{}
@@ -2345,7 +2353,7 @@ func (ex *connExecutor) initEvalCtx(ctx context.Context, evalCtx *extendedEvalCo
 		ex.memMetrics,
 		ex.server.cfg.Settings,
 	)
-	ie.SetSessionData(ex.sessionData)
+	ie.SetSessionData(ex.sessionData())
 
 	*evalCtx = extendedEvalContext{
 		EvalContext: tree.EvalContext{
@@ -2357,7 +2365,7 @@ func (ex *connExecutor) initEvalCtx(ctx context.Context, evalCtx *extendedEvalCo
 			Tenant:                 p,
 			JoinTokenCreator:       p,
 			PreparedStatementState: &ex.extraTxnState.prepStmtsNamespace,
-			SessionData:            ex.sessionData,
+			SessionData:            ex.sessionDataStack.Top(),
 			Settings:               ex.server.cfg.Settings,
 			TestingKnobs:           ex.server.cfg.EvalContextTestingKnobs,
 			ClusterID:              ex.server.cfg.ClusterID(),
@@ -2472,14 +2480,14 @@ func (ex *connExecutor) resetPlanner(
 	p.cancelChecker.Reset(ctx)
 
 	p.semaCtx = tree.MakeSemaContext()
-	p.semaCtx.SearchPath = ex.sessionData.SearchPath
-	p.semaCtx.IntervalStyleEnabled = ex.sessionData.IntervalStyleEnabled
-	p.semaCtx.DateStyleEnabled = ex.sessionData.DateStyleEnabled
+	p.semaCtx.SearchPath = ex.sessionData().SearchPath
+	p.semaCtx.IntervalStyleEnabled = ex.sessionData().IntervalStyleEnabled
+	p.semaCtx.DateStyleEnabled = ex.sessionData().DateStyleEnabled
 	p.semaCtx.Annotations = nil
 	p.semaCtx.TypeResolver = p
 	p.semaCtx.TableNameResolver = p
-	p.semaCtx.DateStyle = ex.sessionData.GetDateStyle()
-	p.semaCtx.IntervalStyle = ex.sessionData.GetIntervalStyle()
+	p.semaCtx.DateStyle = ex.sessionData().GetDateStyle()
+	p.semaCtx.IntervalStyle = ex.sessionData().GetIntervalStyle()
 
 	ex.resetEvalCtx(&p.extendedEvalCtx, txn, stmtTS)
 
@@ -2692,7 +2700,7 @@ func (ex *connExecutor) cancelSession() {
 
 // user is part of the registrySession interface.
 func (ex *connExecutor) user() security.SQLUsername {
-	return ex.sessionData.User()
+	return ex.sessionData().User()
 }
 
 // serialize is part of the registrySession interface.
@@ -2768,12 +2776,12 @@ func (ex *connExecutor) serialize() serverpb.Session {
 	}
 
 	remoteStr := "<admin>"
-	if ex.sessionData.RemoteAddr != nil {
-		remoteStr = ex.sessionData.RemoteAddr.String()
+	if ex.sessionData().RemoteAddr != nil {
+		remoteStr = ex.sessionData().RemoteAddr.String()
 	}
 
 	return serverpb.Session{
-		Username:        ex.sessionData.User().Normalized(),
+		Username:        ex.sessionData().User().Normalized(),
 		ClientAddress:   remoteStr,
 		ApplicationName: ex.applicationName.Load().(string),
 		Start:           ex.phaseTimes.GetSessionPhaseTime(sessionphase.SessionInit).UTC(),

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1045,7 +1045,7 @@ func (ex *connExecutor) makeExecPlan(ctx context.Context, planner *planner) erro
 	flags := planner.curPlan.flags
 
 	if flags.IsSet(planFlagContainsFullIndexScan) || flags.IsSet(planFlagContainsFullTableScan) {
-		if ex.executorType == executorTypeExec && planner.EvalContext().SessionData.DisallowFullTableScans {
+		if ex.executorType == executorTypeExec && planner.EvalContext().SessionData().DisallowFullTableScans {
 			// We don't execute the statement if:
 			// - plan contains a full table or full index scan.
 			// - the session setting disallows full table/index scans.

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -111,11 +111,11 @@ func (ex *connExecutor) execStmt(
 	case stateOpen:
 		if ex.server.cfg.Settings.CPUProfileType() == cluster.CPUProfileWithLabels {
 			remoteAddr := "internal"
-			if rAddr := ex.sessionData.RemoteAddr; rAddr != nil {
+			if rAddr := ex.sessionData().RemoteAddr; rAddr != nil {
 				remoteAddr = rAddr.String()
 			}
 			labels := pprof.Labels(
-				"appname", ex.sessionData.ApplicationName,
+				"appname", ex.sessionData().ApplicationName,
 				"addr", remoteAddr,
 				"stmt.tag", ast.StatementTag(),
 				"stmt.anonymized", anonymizeStmt(ast),
@@ -141,15 +141,15 @@ func (ex *connExecutor) execStmt(
 		panic(errors.AssertionFailedf("unexpected txn state: %#v", ex.machine.CurState()))
 	}
 
-	if ex.sessionData.IdleInSessionTimeout > 0 {
+	if ex.sessionData().IdleInSessionTimeout > 0 {
 		// Cancel the session if the idle time exceeds the idle in session timeout.
 		ex.mu.IdleInSessionTimeout = timeout{time.AfterFunc(
-			ex.sessionData.IdleInSessionTimeout,
+			ex.sessionData().IdleInSessionTimeout,
 			ex.cancelSession,
 		)}
 	}
 
-	if ex.sessionData.IdleInTransactionSessionTimeout > 0 {
+	if ex.sessionData().IdleInTransactionSessionTimeout > 0 {
 		startIdleInTransactionSessionTimeout := func() {
 			switch ast.(type) {
 			case *tree.CommitTransaction, *tree.RollbackTransaction:
@@ -157,7 +157,7 @@ func (ex *connExecutor) execStmt(
 				// an idle timer.
 			default:
 				ex.mu.IdleInTransactionSessionTimeout = timeout{time.AfterFunc(
-					ex.sessionData.IdleInTransactionSessionTimeout,
+					ex.sessionData().IdleInTransactionSessionTimeout,
 					ex.cancelSession,
 				)}
 			}
@@ -421,7 +421,7 @@ func (ex *connExecutor) execStmtInOpenState(
 			return makeErrEvent(err)
 		}
 		var err error
-		pinfo, err = fillInPlaceholders(ctx, ps, name, e.Params, ex.sessionData.SearchPath)
+		pinfo, err = fillInPlaceholders(ctx, ps, name, e.Params, ex.sessionData().SearchPath)
 		if err != nil {
 			return makeErrEvent(err)
 		}
@@ -465,9 +465,9 @@ func (ex *connExecutor) execStmtInOpenState(
 
 	// We exempt `SET` statements from the statement timeout, particularly so as
 	// not to block the `SET statement_timeout` command itself.
-	if ex.sessionData.StmtTimeout > 0 && ast.StatementTag() != "SET" {
+	if ex.sessionData().StmtTimeout > 0 && ast.StatementTag() != "SET" {
 		timerDuration :=
-			ex.sessionData.StmtTimeout - timeutil.Since(ex.phaseTimes.GetSessionPhaseTime(sessionphase.SessionQueryReceived))
+			ex.sessionData().StmtTimeout - timeutil.Since(ex.phaseTimes.GetSessionPhaseTime(sessionphase.SessionQueryReceived))
 		// There's no need to proceed with execution if the timer has already expired.
 		if timerDuration < 0 {
 			queryTimedOut = true
@@ -488,7 +488,7 @@ func (ex *connExecutor) execStmtInOpenState(
 			if perr, ok := retPayload.(payloadWithError); ok {
 				execErr = perr.errorCause()
 			}
-			filter(ctx, ex.sessionData, ast.String(), execErr)
+			filter(ctx, ex.sessionData(), ast.String(), execErr)
 		}
 
 		// Do the auto-commit, if necessary.
@@ -961,7 +961,7 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 
 	ex.sessionTracing.TracePlanCheckStart(ctx)
 	distributePlan := getPlanDistribution(
-		ctx, planner, planner.execCfg.NodeID, ex.sessionData.DistSQLMode, planner.curPlan.main,
+		ctx, planner, planner.execCfg.NodeID, ex.sessionData().DistSQLMode, planner.curPlan.main,
 	)
 	ex.sessionTracing.TracePlanCheckEnd(ctx, nil, distributePlan.WillDistribute())
 

--- a/pkg/sql/conn_executor_savepoints.go
+++ b/pkg/sql/conn_executor_savepoints.go
@@ -277,7 +277,7 @@ func (ex *connExecutor) execRollbackToSavepointInAbortedState(
 // isCommitOnReleaseSavepoint returns true if the savepoint name implies special
 // release semantics: releasing it commits the underlying KV txn.
 func (ex *connExecutor) isCommitOnReleaseSavepoint(savepoint tree.Name) bool {
-	if ex.sessionData.ForceSavepointRestart {
+	if ex.sessionData().ForceSavepointRestart {
 		// The session setting force_savepoint_restart implies that all
 		// uses of the SAVEPOINT statement are targeting restarts.
 		return true

--- a/pkg/sql/create_database.go
+++ b/pkg/sql/create_database.go
@@ -97,7 +97,7 @@ func (p *planner) CreateDatabase(ctx context.Context, n *tree.CreateDatabase) (p
 	}
 
 	if n.Placement != tree.DataPlacementUnspecified {
-		if !p.EvalContext().SessionData.PlacementEnabled {
+		if !p.EvalContext().SessionData().PlacementEnabled {
 			return nil, errors.WithHint(pgerror.New(
 				pgcode.FeatureNotSupported,
 				"PLACEMENT requires that the session setting enable_multiregion_placement_policy "+

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -788,7 +788,7 @@ func (p *planner) configureIndexDescForNewIndexPartitioning(
 				return indexDesc, err
 			}
 		}
-		allowImplicitPartitioning := p.EvalContext().SessionData.ImplicitColumnPartitioningEnabled ||
+		allowImplicitPartitioning := p.EvalContext().SessionData().ImplicitColumnPartitioningEnabled ||
 			tableDesc.IsLocalityRegionalByRow()
 		if partitionBy != nil {
 			newImplicitCols, newPartitioning, err := CreatePartitioning(

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -611,8 +611,8 @@ func (r *createStatsResumer) Resume(ctx context.Context, execCtx interface{}) er
 			0, /* depth: use event_log=2 for vmodule filtering */
 			eventLogOptions{dst: LogEverywhere},
 			sqlEventCommonExecPayload{
-				user:         evalCtx.SessionData.User(),
-				appName:      evalCtx.SessionData.ApplicationName,
+				user:         evalCtx.SessionData().User(),
+				appName:      evalCtx.SessionData().ApplicationName,
 				stmt:         redact.Sprint(details.Statement),
 				stmtTag:      "CREATE STATISTICS",
 				placeholders: nil, /* no placeholders known at this point */

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1511,7 +1511,7 @@ func NewTableDesc(
 			}
 		}
 		if n.PartitionByTable.All {
-			if !evalCtx.SessionData.ImplicitColumnPartitioningEnabled {
+			if !evalCtx.SessionData().ImplicitColumnPartitioningEnabled {
 				return nil, errors.WithHint(
 					pgerror.New(
 						pgcode.FeatureNotSupported,
@@ -1541,7 +1541,7 @@ func NewTableDesc(
 	for i, def := range n.Defs {
 		if d, ok := def.(*tree.ColumnTableDef); ok {
 			if d.IsComputed() {
-				d.Computed.Expr = schemaexpr.MaybeRewriteComputedColumn(d.Computed.Expr, evalCtx.SessionData)
+				d.Computed.Expr = schemaexpr.MaybeRewriteComputedColumn(d.Computed.Expr, evalCtx.SessionData())
 			}
 			// NewTableDesc is called sometimes with a nil SemaCtx (for example
 			// during bootstrapping). In order to not panic, pass a nil TypeResolver
@@ -1998,7 +1998,7 @@ func NewTableDesc(
 
 	// If explicit primary keys are required, error out since a primary key was not supplied.
 	if desc.GetPrimaryIndex().NumKeyColumns() == 0 && desc.IsPhysicalTable() && evalCtx != nil &&
-		evalCtx.SessionData != nil && evalCtx.SessionData.RequireExplicitPrimaryKeys {
+		evalCtx.SessionData() != nil && evalCtx.SessionData().RequireExplicitPrimaryKeys {
 		return nil, errors.Errorf(
 			"no primary key specified for table %s (require_explicit_primary_keys = true)", desc.Name)
 	}

--- a/pkg/sql/delegate/show_default_privileges.go
+++ b/pkg/sql/delegate/show_default_privileges.go
@@ -50,7 +50,7 @@ func (d *delegator) delegateShowDefaultPrivileges(
 		query += ")"
 	} else {
 		query = fmt.Sprintf("%s AND for_all_roles=false AND role = '%s'",
-			query, d.evalCtx.SessionData.User())
+			query, d.evalCtx.SessionData().User())
 	}
 	query += " ORDER BY 1,2,3,4"
 	return parse(query)

--- a/pkg/sql/delegate/show_enums.go
+++ b/pkg/sql/delegate/show_enums.go
@@ -30,7 +30,7 @@ func (d *delegator) delegateShowEnums(n *tree.ShowEnums) (tree.Statement, error)
 	if n.ExplicitSchema {
 		schema := lexbase.EscapeSQLString(name.Schema())
 		if name.Schema() == catconstants.PgTempSchemaName {
-			schema = lexbase.EscapeSQLString(d.evalCtx.SessionData.SearchPath.GetTemporarySchemaName())
+			schema = lexbase.EscapeSQLString(d.evalCtx.SessionData().SearchPath.GetTemporarySchemaName())
 		}
 		schemaClause = fmt.Sprintf("AND nsp.nspname = %s", schema)
 	}

--- a/pkg/sql/delegate/show_grants.go
+++ b/pkg/sql/delegate/show_grants.go
@@ -87,7 +87,7 @@ FROM "".information_schema.type_privileges`
 			fmt.Fprintf(&cond, `WHERE database_name IN (%s)`, strings.Join(params, ","))
 		}
 	} else if n.Targets != nil && len(n.Targets.Schemas) > 0 {
-		currDB := d.evalCtx.SessionData.Database
+		currDB := d.evalCtx.SessionData().Database
 
 		for _, schema := range n.Targets.Schemas {
 			_, _, err := d.catalog.ResolveSchema(d.ctx, cat.Flags{AvoidDescriptorCaches: true}, &schema)
@@ -144,7 +144,7 @@ FROM "".information_schema.type_privileges`
 		if len(params) == 0 {
 			dbNameClause := "true"
 			// If the current database is set, restrict the command to it.
-			if currDB := d.evalCtx.SessionData.Database; currDB != "" {
+			if currDB := d.evalCtx.SessionData().Database; currDB != "" {
 				dbNameClause = fmt.Sprintf("database_name = %s", lexbase.EscapeSQLString(currDB))
 			}
 			cond.WriteString(fmt.Sprintf(`WHERE %s`, dbNameClause))
@@ -215,7 +215,7 @@ FROM "".information_schema.type_privileges`
 			source.WriteString(typePrivQuery)
 			source.WriteByte(')')
 			// If the current database is set, restrict the command to it.
-			if currDB := d.evalCtx.SessionData.Database; currDB != "" {
+			if currDB := d.evalCtx.SessionData().Database; currDB != "" {
 				fmt.Fprintf(&cond, ` WHERE database_name = %s`, lexbase.EscapeSQLString(currDB))
 			} else {
 				cond.WriteString(`WHERE true`)

--- a/pkg/sql/delegate/show_regions.go
+++ b/pkg/sql/delegate/show_regions.go
@@ -44,7 +44,7 @@ ORDER BY database_name
 		sqltelemetry.IncrementShowCounter(sqltelemetry.RegionsFromDatabase)
 		dbName := string(n.DatabaseName)
 		if dbName == "" {
-			dbName = d.evalCtx.SessionData.Database
+			dbName = d.evalCtx.SessionData().Database
 		}
 		// Note the LEFT JOIN here -- in the case where regions no longer exist on the cluster
 		// but still exist on the database config, we want to still see this database region

--- a/pkg/sql/delegate/show_survival_goal.go
+++ b/pkg/sql/delegate/show_survival_goal.go
@@ -23,7 +23,7 @@ func (d *delegator) delegateShowSurvivalGoal(n *tree.ShowSurvivalGoal) (tree.Sta
 	sqltelemetry.IncrementShowCounter(sqltelemetry.SurvivalGoal)
 	dbName := string(n.DatabaseName)
 	if dbName == "" {
-		dbName = d.evalCtx.SessionData.Database
+		dbName = d.evalCtx.SessionData().Database
 	}
 	query := fmt.Sprintf(
 		`SELECT

--- a/pkg/sql/delegate/show_table.go
+++ b/pkg/sql/delegate/show_table.go
@@ -226,7 +226,7 @@ func (d *delegator) delegateShowCreateAllTables() (tree.Statement, error) {
 	const showCreateAllTablesQuery = `
 	SELECT crdb_internal.show_create_all_tables(%[1]s) AS create_statement;
 `
-	databaseLiteral := d.evalCtx.SessionData.Database
+	databaseLiteral := d.evalCtx.SessionData().Database
 
 	query := fmt.Sprintf(showCreateAllTablesQuery,
 		lexbase.EscapeSQLString(databaseLiteral),

--- a/pkg/sql/delegate/show_tables.go
+++ b/pkg/sql/delegate/show_tables.go
@@ -50,7 +50,7 @@ func (d *delegator) delegateShowTables(n *tree.ShowTables) (tree.Statement, erro
 	if name.ExplicitSchema {
 		schema := lexbase.EscapeSQLString(name.Schema())
 		if name.Schema() == catconstants.PgTempSchemaName {
-			schema = lexbase.EscapeSQLString(d.evalCtx.SessionData.SearchPath.GetTemporarySchemaName())
+			schema = lexbase.EscapeSQLString(d.evalCtx.SessionData().SearchPath.GetTemporarySchemaName())
 		}
 		schemaClause = fmt.Sprintf("AND ns.nspname = %s", schema)
 	} else {

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -303,15 +303,15 @@ func (ds *ServerImpl) setupFlow(
 			return nil, nil, nil, err
 		}
 		evalCtx = &tree.EvalContext{
-			Settings:    ds.ServerConfig.Settings,
-			SessionData: sd,
-			ClusterID:   ds.ServerConfig.ClusterID.Get(),
-			ClusterName: ds.ServerConfig.ClusterName,
-			NodeID:      ds.ServerConfig.NodeID,
-			Codec:       ds.ServerConfig.Codec,
-			ReCache:     ds.regexpCache,
-			Mon:         monitor,
-			Locality:    ds.ServerConfig.Locality,
+			Settings:         ds.ServerConfig.Settings,
+			SessionDataStack: sessiondata.NewStack(sd),
+			ClusterID:        ds.ServerConfig.ClusterID.Get(),
+			ClusterName:      ds.ServerConfig.ClusterName,
+			NodeID:           ds.ServerConfig.NodeID,
+			Codec:            ds.ServerConfig.Codec,
+			ReCache:          ds.regexpCache,
+			Mon:              monitor,
+			Locality:         ds.ServerConfig.Locality,
 			// Most processors will override this Context with their own context in
 			// ProcessorBase. StartInternal().
 			Context:            ctx,
@@ -445,7 +445,7 @@ func (ds *ServerImpl) newFlowContext(
 		// If we weren't passed a descs.Collection, then make a new one. We are
 		// responsible for cleaning it up and releasing any accessed descriptors
 		// on flow cleanup.
-		collection := ds.CollectionFactory.NewCollection(evalCtx.SessionData)
+		collection := ds.CollectionFactory.NewCollection(evalCtx.SessionData())
 		flowCtx.TypeResolverFactory = &descs.DistSQLTypeResolverFactory{
 			Descriptors: collection,
 			CleanupFunc: func(ctx context.Context) {

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -294,7 +294,7 @@ func (dsp *DistSQLPlanner) setupFlows(
 		resultChan = make(chan runnerResult, len(flows)-1)
 	}
 
-	if vectorizeMode := evalCtx.SessionData.VectorizeMode; vectorizeMode != sessiondatapb.VectorizeOff {
+	if vectorizeMode := evalCtx.SessionData().VectorizeMode; vectorizeMode != sessiondatapb.VectorizeOff {
 		// Now we determine whether the vectorized engine supports the flow
 		// specs.
 		for _, spec := range flows {
@@ -1351,7 +1351,7 @@ func (dsp *DistSQLPlanner) PlanAndRunCascadesAndChecks(
 		// In cyclical reference situations, the number of cascading operations can
 		// be arbitrarily large. To avoid OOM, we enforce a limit. This is also a
 		// safeguard in case we have a bug that results in an infinite cascade loop.
-		if limit := int(evalCtx.SessionData.OptimizerFKCascadesLimit); len(plan.cascades) > limit {
+		if limit := int(evalCtx.SessionData().OptimizerFKCascadesLimit); len(plan.cascades) > limit {
 			telemetry.Inc(sqltelemetry.CascadesLimitReached)
 			err := pgerror.Newf(pgcode.TriggeredActionException, "cascades limit (%d) reached", limit)
 			recv.SetError(err)

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -76,7 +76,7 @@ func (e *distSQLSpecExecFactory) getPlanCtx(recommendation distRecommendation) *
 	distribute := false
 	if e.singleTenant && e.planningMode != distSQLLocalOnlyPlanning {
 		distribute = shouldDistributeGivenRecAndMode(
-			recommendation, e.planner.extendedEvalCtx.SessionData.DistSQLMode,
+			recommendation, e.planner.extendedEvalCtx.SessionData().DistSQLMode,
 		)
 	}
 	e.planCtx.isLocal = !distribute

--- a/pkg/sql/exec_log.go
+++ b/pkg/sql/exec_log.go
@@ -175,7 +175,7 @@ func (p *planner) maybeLogStatementInternal(
 	// Compute the pieces of data that are going to be included in logged events.
 
 	// The session's application_name.
-	appName := p.EvalContext().SessionData.ApplicationName
+	appName := p.EvalContext().SessionData().ApplicationName
 	// The duration of the query so far. Age is the duration expressed in milliseconds.
 	queryDuration := timeutil.Now().Sub(startTime)
 	age := float32(queryDuration.Nanoseconds()) / 1e6

--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -962,7 +962,7 @@ func NewLimitedMonitorNoFlowCtx(
 	flowCtx := &FlowCtx{
 		Cfg: config,
 		EvalCtx: &tree.EvalContext{
-			SessionData: sd,
+			SessionDataStack: sessiondata.NewStack(sd),
 		},
 	}
 	return NewLimitedMonitor(ctx, parent, flowCtx, name)

--- a/pkg/sql/execinfra/server_config.go
+++ b/pkg/sql/execinfra/server_config.go
@@ -278,9 +278,9 @@ func GetWorkMemLimit(flowCtx *FlowCtx) int64 {
 	if flowCtx.Cfg.TestingKnobs.MemoryLimitBytes != 0 {
 		return flowCtx.Cfg.TestingKnobs.MemoryLimitBytes
 	}
-	if flowCtx.EvalCtx.SessionData.WorkMemLimit <= 0 {
+	if flowCtx.EvalCtx.SessionData().WorkMemLimit <= 0 {
 		// If for some reason workmem limit is not set, use the default value.
 		return DefaultMemoryLimit
 	}
-	return flowCtx.EvalCtx.SessionData.WorkMemLimit
+	return flowCtx.EvalCtx.SessionData().WorkMemLimit
 }

--- a/pkg/sql/execinfrapb/api.go
+++ b/pkg/sql/execinfrapb/api.go
@@ -47,8 +47,8 @@ type DistSQLVersion uint32
 // MakeEvalContext serializes some of the fields of a tree.EvalContext into a
 // execinfrapb.EvalContext proto.
 func MakeEvalContext(evalCtx *tree.EvalContext) EvalContext {
-	sessionDataProto := evalCtx.SessionData.SessionData
-	sessiondata.MarshalNonLocal(evalCtx.SessionData, &sessionDataProto)
+	sessionDataProto := evalCtx.SessionData().SessionData
+	sessiondata.MarshalNonLocal(evalCtx.SessionData(), &sessionDataProto)
 	return EvalContext{
 		SessionData:        sessionDataProto,
 		StmtTimestampNanos: evalCtx.StmtTimestamp.UnixNano(),

--- a/pkg/sql/execinfrapb/expr.go
+++ b/pkg/sql/execinfrapb/expr.go
@@ -59,7 +59,7 @@ func processExpression(
 	}
 	expr, err := parser.ParseExprWithInt(
 		exprSpec.Expr,
-		parser.NakedIntTypeFromDefaultIntSize(evalCtx.SessionData.DefaultIntSize),
+		parser.NakedIntTypeFromDefaultIntSize(evalCtx.SessionData().DefaultIntSize),
 	)
 	if err != nil {
 		return nil, err
@@ -155,7 +155,7 @@ func DeserializeExpr(
 		return deserializedExpr, err
 	}
 	var t transform.ExprTransformContext
-	if t.AggregateInExpr(deserializedExpr, evalCtx.SessionData.SearchPath) {
+	if t.AggregateInExpr(deserializedExpr, evalCtx.SessionData().SearchPath) {
 		return nil, errors.Errorf("expression '%s' has aggregate", deserializedExpr)
 	}
 	return deserializedExpr, nil

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -55,7 +55,7 @@ func (e *explainPlanNode) startExec(params runParams) error {
 
 	distribution := getPlanDistribution(
 		params.ctx, params.p, params.extendedEvalCtx.ExecCfg.NodeID,
-		params.extendedEvalCtx.SessionData.DistSQLMode, plan.main,
+		params.extendedEvalCtx.SessionData().DistSQLMode, plan.main,
 	)
 	ob.AddDistribution(distribution.String())
 
@@ -84,7 +84,7 @@ func (e *explainPlanNode) startExec(params runParams) error {
 		flows := physicalPlan.GenerateFlowSpecs()
 		flowCtx := newFlowCtxForExplainPurposes(planCtx, params.p)
 
-		ctxSessionData := flowCtx.EvalCtx.SessionData
+		ctxSessionData := flowCtx.EvalCtx.SessionData()
 		var willVectorize bool
 		if ctxSessionData.VectorizeMode == sessiondatapb.VectorizeOff {
 			willVectorize = false

--- a/pkg/sql/explain_vec.go
+++ b/pkg/sql/explain_vec.go
@@ -43,7 +43,7 @@ func (n *explainVecNode) startExec(params runParams) error {
 	distSQLPlanner := params.extendedEvalCtx.DistSQLPlanner
 	distribution := getPlanDistribution(
 		params.ctx, params.p, params.extendedEvalCtx.ExecCfg.NodeID,
-		params.extendedEvalCtx.SessionData.DistSQLMode, n.plan.main,
+		params.extendedEvalCtx.SessionData().DistSQLMode, n.plan.main,
 	)
 	willDistribute := distribution.WillDistribute()
 	outerSubqueries := params.p.curPlan.subqueryPlans
@@ -70,7 +70,7 @@ func (n *explainVecNode) startExec(params runParams) error {
 	// With all other options, we don't change the setting to the
 	// most-inclusive option as we used to because the plan can be different
 	// based on 'vectorize' setting.
-	if flowCtx.EvalCtx.SessionData.VectorizeMode == sessiondatapb.VectorizeOff {
+	if flowCtx.EvalCtx.SessionData().VectorizeMode == sessiondatapb.VectorizeOff {
 		return errors.New("vectorize is set to 'off'")
 	}
 	verbose := n.options.Flags[tree.ExplainFlagVerbose]

--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -129,10 +129,10 @@ func New(
 		initialAllowAutoCommit: allowAutoCommit,
 	}
 	if evalCtx != nil {
-		if evalCtx.SessionData.SaveTablesPrefix != "" {
-			b.nameGen = memo.NewExprNameGenerator(evalCtx.SessionData.SaveTablesPrefix)
+		if evalCtx.SessionData().SaveTablesPrefix != "" {
+			b.nameGen = memo.NewExprNameGenerator(evalCtx.SessionData().SaveTablesPrefix)
 		}
-		b.allowInsertFastPath = evalCtx.SessionData.InsertFastPath
+		b.allowInsertFastPath = evalCtx.SessionData().InsertFastPath
 	}
 	return b
 }

--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -1115,7 +1115,7 @@ func (b *Builder) shouldApplyImplicitLockingToMutationInput(mutExpr memo.RelExpr
 // not worth risking the transformation being a pessimization, so it is only
 // applied when doing so does not risk creating artificial contention.
 func (b *Builder) shouldApplyImplicitLockingToUpdateInput(upd *memo.UpdateExpr) bool {
-	if !b.evalCtx.SessionData.ImplicitSelectForUpdate {
+	if !b.evalCtx.SessionData().ImplicitSelectForUpdate {
 		return false
 	}
 
@@ -1136,7 +1136,7 @@ func (b *Builder) shouldApplyImplicitLockingToUpdateInput(upd *memo.UpdateExpr) 
 // should apply a FOR UPDATE row-level locking mode to the initial row scan of
 // an UPSERT statement.
 func (b *Builder) shouldApplyImplicitLockingToUpsertInput(ups *memo.UpsertExpr) bool {
-	if !b.evalCtx.SessionData.ImplicitSelectForUpdate {
+	if !b.evalCtx.SessionData().ImplicitSelectForUpdate {
 		return false
 	}
 

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -1568,7 +1568,7 @@ func BuildSharedProps(e opt.Expr, shared *props.Shared, evalCtx *tree.EvalContex
 
 	case *CastExpr:
 		from, to := t.Input.DataType(), t.Typ
-		volatility, ok := tree.LookupCastVolatility(from, to, evalCtx.SessionData)
+		volatility, ok := tree.LookupCastVolatility(from, to, evalCtx.SessionData())
 		if !ok {
 			panic(errors.AssertionFailedf("no volatility for cast %s::%s", from, to))
 		}

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -175,18 +175,18 @@ func (m *Memo) Init(evalCtx *tree.EvalContext) {
 	// reused. Field reuse must be explicit.
 	*m = Memo{
 		metadata:                m.metadata,
-		reorderJoinsLimit:       int(evalCtx.SessionData.ReorderJoinsLimit),
-		zigzagJoinEnabled:       evalCtx.SessionData.ZigzagJoinEnabled,
-		useHistograms:           evalCtx.SessionData.OptimizerUseHistograms,
-		useMultiColStats:        evalCtx.SessionData.OptimizerUseMultiColStats,
-		localityOptimizedSearch: evalCtx.SessionData.LocalityOptimizedSearch,
-		safeUpdates:             evalCtx.SessionData.SafeUpdates,
-		preferLookupJoinsForFKs: evalCtx.SessionData.PreferLookupJoinsForFKs,
-		saveTablesPrefix:        evalCtx.SessionData.SaveTablesPrefix,
-		intervalStyleEnabled:    evalCtx.SessionData.IntervalStyleEnabled,
-		dateStyleEnabled:        evalCtx.SessionData.DateStyleEnabled,
-		dateStyle:               evalCtx.SessionData.GetDateStyle(),
-		intervalStyle:           evalCtx.SessionData.GetIntervalStyle(),
+		reorderJoinsLimit:       int(evalCtx.SessionData().ReorderJoinsLimit),
+		zigzagJoinEnabled:       evalCtx.SessionData().ZigzagJoinEnabled,
+		useHistograms:           evalCtx.SessionData().OptimizerUseHistograms,
+		useMultiColStats:        evalCtx.SessionData().OptimizerUseMultiColStats,
+		localityOptimizedSearch: evalCtx.SessionData().LocalityOptimizedSearch,
+		safeUpdates:             evalCtx.SessionData().SafeUpdates,
+		preferLookupJoinsForFKs: evalCtx.SessionData().PreferLookupJoinsForFKs,
+		saveTablesPrefix:        evalCtx.SessionData().SaveTablesPrefix,
+		intervalStyleEnabled:    evalCtx.SessionData().IntervalStyleEnabled,
+		dateStyleEnabled:        evalCtx.SessionData().DateStyleEnabled,
+		dateStyle:               evalCtx.SessionData().GetDateStyle(),
+		intervalStyle:           evalCtx.SessionData().GetIntervalStyle(),
 	}
 	m.metadata.Init()
 	m.logPropsBuilder.init(evalCtx, m)
@@ -287,18 +287,18 @@ func (m *Memo) IsStale(
 ) (bool, error) {
 	// Memo is stale if fields from SessionData that can affect planning have
 	// changed.
-	if m.reorderJoinsLimit != int(evalCtx.SessionData.ReorderJoinsLimit) ||
-		m.zigzagJoinEnabled != evalCtx.SessionData.ZigzagJoinEnabled ||
-		m.useHistograms != evalCtx.SessionData.OptimizerUseHistograms ||
-		m.useMultiColStats != evalCtx.SessionData.OptimizerUseMultiColStats ||
-		m.localityOptimizedSearch != evalCtx.SessionData.LocalityOptimizedSearch ||
-		m.safeUpdates != evalCtx.SessionData.SafeUpdates ||
-		m.preferLookupJoinsForFKs != evalCtx.SessionData.PreferLookupJoinsForFKs ||
-		m.saveTablesPrefix != evalCtx.SessionData.SaveTablesPrefix ||
-		m.intervalStyleEnabled != evalCtx.SessionData.IntervalStyleEnabled ||
-		m.dateStyleEnabled != evalCtx.SessionData.DateStyleEnabled ||
-		m.dateStyle != evalCtx.SessionData.GetDateStyle() ||
-		m.intervalStyle != evalCtx.SessionData.GetIntervalStyle() {
+	if m.reorderJoinsLimit != int(evalCtx.SessionData().ReorderJoinsLimit) ||
+		m.zigzagJoinEnabled != evalCtx.SessionData().ZigzagJoinEnabled ||
+		m.useHistograms != evalCtx.SessionData().OptimizerUseHistograms ||
+		m.useMultiColStats != evalCtx.SessionData().OptimizerUseMultiColStats ||
+		m.localityOptimizedSearch != evalCtx.SessionData().LocalityOptimizedSearch ||
+		m.safeUpdates != evalCtx.SessionData().SafeUpdates ||
+		m.preferLookupJoinsForFKs != evalCtx.SessionData().PreferLookupJoinsForFKs ||
+		m.saveTablesPrefix != evalCtx.SessionData().SaveTablesPrefix ||
+		m.intervalStyleEnabled != evalCtx.SessionData().IntervalStyleEnabled ||
+		m.dateStyleEnabled != evalCtx.SessionData().DateStyleEnabled ||
+		m.dateStyle != evalCtx.SessionData().GetDateStyle() ||
+		m.intervalStyle != evalCtx.SessionData().GetIntervalStyle() {
 		return true, nil
 	}
 

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -143,7 +143,7 @@ func TestMemoIsStale(t *testing.T) {
 
 	// Initialize context with starting values.
 	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
-	evalCtx.SessionData.Database = "t"
+	evalCtx.SessionData().Database = "t"
 
 	var o xform.Optimizer
 	opttestutils.BuildQuery(t, &o, catalog, &evalCtx, "SELECT a, b+1 FROM abcview WHERE c='foo'")
@@ -183,69 +183,69 @@ func TestMemoIsStale(t *testing.T) {
 	notStale()
 
 	// Stale reorder joins limit.
-	evalCtx.SessionData.ReorderJoinsLimit = 4
+	evalCtx.SessionData().ReorderJoinsLimit = 4
 	stale()
-	evalCtx.SessionData.ReorderJoinsLimit = 0
+	evalCtx.SessionData().ReorderJoinsLimit = 0
 	notStale()
 
 	// Stale zig zag join enable.
-	evalCtx.SessionData.ZigzagJoinEnabled = true
+	evalCtx.SessionData().ZigzagJoinEnabled = true
 	stale()
-	evalCtx.SessionData.ZigzagJoinEnabled = false
+	evalCtx.SessionData().ZigzagJoinEnabled = false
 	notStale()
 
 	// Stale optimizer histogram usage enable.
-	evalCtx.SessionData.OptimizerUseHistograms = true
+	evalCtx.SessionData().OptimizerUseHistograms = true
 	stale()
-	evalCtx.SessionData.OptimizerUseHistograms = false
+	evalCtx.SessionData().OptimizerUseHistograms = false
 	notStale()
 
 	// Stale optimizer multi-col stats usage enable.
-	evalCtx.SessionData.OptimizerUseMultiColStats = true
+	evalCtx.SessionData().OptimizerUseMultiColStats = true
 	stale()
-	evalCtx.SessionData.OptimizerUseMultiColStats = false
+	evalCtx.SessionData().OptimizerUseMultiColStats = false
 	notStale()
 
 	// Stale locality optimized search enable.
-	evalCtx.SessionData.LocalityOptimizedSearch = true
+	evalCtx.SessionData().LocalityOptimizedSearch = true
 	stale()
-	evalCtx.SessionData.LocalityOptimizedSearch = false
+	evalCtx.SessionData().LocalityOptimizedSearch = false
 	notStale()
 
 	// Stale safe updates.
-	evalCtx.SessionData.SafeUpdates = true
+	evalCtx.SessionData().SafeUpdates = true
 	stale()
-	evalCtx.SessionData.SafeUpdates = false
+	evalCtx.SessionData().SafeUpdates = false
 	notStale()
 
 	// Stale intervalStyleEnabled.
-	evalCtx.SessionData.IntervalStyleEnabled = true
+	evalCtx.SessionData().IntervalStyleEnabled = true
 	stale()
-	evalCtx.SessionData.IntervalStyleEnabled = false
+	evalCtx.SessionData().IntervalStyleEnabled = false
 	notStale()
 
 	// Stale dateStyleEnabled.
-	evalCtx.SessionData.DateStyleEnabled = true
+	evalCtx.SessionData().DateStyleEnabled = true
 	stale()
-	evalCtx.SessionData.DateStyleEnabled = false
+	evalCtx.SessionData().DateStyleEnabled = false
 	notStale()
 
 	// Stale DateStyle.
-	evalCtx.SessionData.DataConversionConfig.DateStyle = pgdate.DateStyle{Order: pgdate.Order_YMD}
+	evalCtx.SessionData().DataConversionConfig.DateStyle = pgdate.DateStyle{Order: pgdate.Order_YMD}
 	stale()
-	evalCtx.SessionData.DataConversionConfig.DateStyle = pgdate.DefaultDateStyle()
+	evalCtx.SessionData().DataConversionConfig.DateStyle = pgdate.DefaultDateStyle()
 	notStale()
 
 	// Stale IntervalStyle.
-	evalCtx.SessionData.DataConversionConfig.IntervalStyle = duration.IntervalStyle_ISO_8601
+	evalCtx.SessionData().DataConversionConfig.IntervalStyle = duration.IntervalStyle_ISO_8601
 	stale()
-	evalCtx.SessionData.DataConversionConfig.IntervalStyle = duration.IntervalStyle_POSTGRES
+	evalCtx.SessionData().DataConversionConfig.IntervalStyle = duration.IntervalStyle_POSTGRES
 	notStale()
 
 	// Stale prefer lookup joins for FKs.
-	evalCtx.SessionData.PreferLookupJoinsForFKs = true
+	evalCtx.SessionData().PreferLookupJoinsForFKs = true
 	stale()
-	evalCtx.SessionData.PreferLookupJoinsForFKs = false
+	evalCtx.SessionData().PreferLookupJoinsForFKs = false
 	notStale()
 
 	// Stale data sources and schema. Create new catalog so that data sources are

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -547,7 +547,7 @@ func (sb *statisticsBuilder) makeTableStatistics(tabID opt.TableID) *props.Stati
 		// column set. Stats are ordered with most recent first.
 		for i := 0; i < tab.StatisticCount(); i++ {
 			stat := tab.Statistic(i)
-			if stat.ColumnCount() > 1 && !sb.evalCtx.SessionData.OptimizerUseMultiColStats {
+			if stat.ColumnCount() > 1 && !sb.evalCtx.SessionData().OptimizerUseMultiColStats {
 				continue
 			}
 
@@ -560,7 +560,7 @@ func (sb *statisticsBuilder) makeTableStatistics(tabID opt.TableID) *props.Stati
 				colStat.DistinctCount = float64(stat.DistinctCount())
 				colStat.NullCount = float64(stat.NullCount())
 				if cols.Len() == 1 && stat.Histogram() != nil &&
-					sb.evalCtx.SessionData.OptimizerUseHistograms {
+					sb.evalCtx.SessionData().OptimizerUseHistograms {
 					col, _ := cols.Next(0)
 
 					// If this column is invertable, the histogram describes the inverted index
@@ -3572,7 +3572,7 @@ func (sb *statisticsBuilder) selectivityFromMultiColDistinctCounts(
 	cols opt.ColSet, e RelExpr, s *props.Statistics,
 ) (selectivity props.Selectivity) {
 	// Respect the session setting OptimizerUseMultiColStats.
-	if !sb.evalCtx.SessionData.OptimizerUseMultiColStats {
+	if !sb.evalCtx.SessionData().OptimizerUseMultiColStats {
 		return sb.selectivityFromSingleColDistinctCounts(cols, e, s)
 	}
 

--- a/pkg/sql/opt/memo/statistics_builder_test.go
+++ b/pkg/sql/opt/memo/statistics_builder_test.go
@@ -30,7 +30,7 @@ import (
 // by the optimizer.
 func TestGetStatsFromConstraint(t *testing.T) {
 	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
-	evalCtx.SessionData.OptimizerUseMultiColStats = true
+	evalCtx.SessionData().OptimizerUseMultiColStats = true
 
 	catalog := testcat.New()
 	if _, err := catalog.ExecuteDDL(

--- a/pkg/sql/opt/norm/fold_constants_funcs.go
+++ b/pkg/sql/opt/norm/fold_constants_funcs.go
@@ -356,7 +356,7 @@ func (c *CustomFuncs) FoldCast(input opt.ScalarExpr, typ *types.T) (_ opt.Scalar
 		return nil, false
 	}
 
-	volatility, ok := tree.LookupCastVolatility(input.DataType(), typ, c.f.evalCtx.SessionData)
+	volatility, ok := tree.LookupCastVolatility(input.DataType(), typ, c.f.evalCtx.SessionData())
 	if !ok || !c.CanFoldOperator(volatility) {
 		return nil, false
 	}

--- a/pkg/sql/opt/optbuilder/builder_test.go
+++ b/pkg/sql/opt/optbuilder/builder_test.go
@@ -76,9 +76,9 @@ func TestBuilder(t *testing.T) {
 				ctx := context.Background()
 				semaCtx := tree.MakeSemaContext()
 				evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
-				evalCtx.SessionData.OptimizerUseHistograms = true
-				evalCtx.SessionData.OptimizerUseMultiColStats = true
-				evalCtx.SessionData.LocalityOptimizedSearch = true
+				evalCtx.SessionData().OptimizerUseHistograms = true
+				evalCtx.SessionData().OptimizerUseMultiColStats = true
+				evalCtx.SessionData().LocalityOptimizedSearch = true
 
 				var o xform.Optimizer
 				o.Init(&evalCtx, catalog)

--- a/pkg/sql/opt/optbuilder/delete.go
+++ b/pkg/sql/opt/optbuilder/delete.go
@@ -29,7 +29,7 @@ import (
 // become a physical property required of the Delete operator).
 func (b *Builder) buildDelete(del *tree.Delete, inScope *scope) (outScope *scope) {
 	// UX friendliness safeguard.
-	if del.Where == nil && b.evalCtx.SessionData.SafeUpdates {
+	if del.Where == nil && b.evalCtx.SessionData().SafeUpdates {
 		panic(pgerror.DangerousStatementf("DELETE without WHERE clause"))
 	}
 

--- a/pkg/sql/opt/optbuilder/mutation_builder_fk.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder_fk.go
@@ -732,7 +732,7 @@ func (h *fkCheckHelper) buildInsertionCheck() memo.FKChecksItem {
 		)
 	}
 	var p memo.JoinPrivate
-	if h.mb.b.evalCtx.SessionData.PreferLookupJoinsForFKs {
+	if h.mb.b.evalCtx.SessionData().PreferLookupJoinsForFKs {
 		p.Flags = memo.PreferLookupJoinIntoRight
 	}
 	antiJoin := f.ConstructAntiJoin(withScanScope.expr, scanScope.expr, antiJoinFilters, &p)
@@ -774,7 +774,7 @@ func (h *fkCheckHelper) buildDeletionCheck(
 		)
 	}
 	var p memo.JoinPrivate
-	if h.mb.b.evalCtx.SessionData.PreferLookupJoinsForFKs {
+	if h.mb.b.evalCtx.SessionData().PreferLookupJoinsForFKs {
 		p.Flags = memo.PreferLookupJoinIntoRight
 	}
 	semiJoin := f.ConstructSemiJoin(deletedRows, scanScope.expr, semiJoinFilters, &p)

--- a/pkg/sql/opt/optbuilder/project.go
+++ b/pkg/sql/opt/optbuilder/project.go
@@ -24,7 +24,7 @@ import (
 // different set of columns than its input. Either way, it updates
 // projectionsScope.group with the output memo group ID.
 func (b *Builder) constructProjectForScope(inScope, projectionsScope *scope) {
-	if b.evalCtx.SessionData.PropagateInputOrdering && len(projectionsScope.ordering) == 0 {
+	if b.evalCtx.SessionData().PropagateInputOrdering && len(projectionsScope.ordering) == 0 {
 		// Preserve the input ordering.
 		projectionsScope.copyOrdering(inScope)
 	}

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -89,7 +89,7 @@ func (b *Builder) buildDataSource(
 				outCols[i] = newCol.id
 			}
 
-			if b.evalCtx.SessionData.PropagateInputOrdering && len(inScope.ordering) > 0 {
+			if b.evalCtx.SessionData().PropagateInputOrdering && len(inScope.ordering) > 0 {
 				var oldToNew opt.ColMap
 				for i := range inCols {
 					oldToNew.Set(int(inCols[i]), int(outCols[i]))

--- a/pkg/sql/opt/optbuilder/update.go
+++ b/pkg/sql/opt/optbuilder/update.go
@@ -69,7 +69,7 @@ func (b *Builder) buildUpdate(upd *tree.Update, inScope *scope) (outScope *scope
 	}
 
 	// UX friendliness safeguard.
-	if upd.Where == nil && b.evalCtx.SessionData.SafeUpdates {
+	if upd.Where == nil && b.evalCtx.SessionData().SafeUpdates {
 		panic(pgerror.DangerousStatementf("UPDATE without WHERE clause"))
 	}
 

--- a/pkg/sql/opt/optbuilder/with.go
+++ b/pkg/sql/opt/optbuilder/with.go
@@ -186,7 +186,7 @@ func (b *Builder) buildCTE(
 	if !isRecursive {
 		cteScope := b.buildStmt(cte.Stmt, nil /* desiredTypes */, inScope)
 		cteScope.removeHiddenCols()
-		if b.evalCtx.SessionData.PropagateInputOrdering && len(inScope.ordering) == 0 {
+		if b.evalCtx.SessionData().PropagateInputOrdering && len(inScope.ordering) == 0 {
 			// Preserve the CTE ordering.
 			inScope.copyOrdering(cteScope)
 		} else {

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -254,14 +254,14 @@ func New(catalog cat.Catalog, sql string) *OptTester {
 
 	// Set any OptTester-wide session flags here.
 
-	ot.evalCtx.SessionData.UserProto = security.MakeSQLUsernameFromPreNormalizedString("opttester").EncodeProto()
-	ot.evalCtx.SessionData.Database = "defaultdb"
-	ot.evalCtx.SessionData.ZigzagJoinEnabled = true
-	ot.evalCtx.SessionData.OptimizerUseHistograms = true
-	ot.evalCtx.SessionData.OptimizerUseMultiColStats = true
-	ot.evalCtx.SessionData.LocalityOptimizedSearch = true
-	ot.evalCtx.SessionData.ReorderJoinsLimit = opt.DefaultJoinOrderLimit
-	ot.evalCtx.SessionData.InsertFastPath = true
+	ot.evalCtx.SessionData().UserProto = security.MakeSQLUsernameFromPreNormalizedString("opttester").EncodeProto()
+	ot.evalCtx.SessionData().Database = "defaultdb"
+	ot.evalCtx.SessionData().ZigzagJoinEnabled = true
+	ot.evalCtx.SessionData().OptimizerUseHistograms = true
+	ot.evalCtx.SessionData().OptimizerUseMultiColStats = true
+	ot.evalCtx.SessionData().LocalityOptimizedSearch = true
+	ot.evalCtx.SessionData().ReorderJoinsLimit = opt.DefaultJoinOrderLimit
+	ot.evalCtx.SessionData().InsertFastPath = true
 
 	return ot
 }
@@ -480,13 +480,13 @@ func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 
 	ot.semaCtx.Placeholders = tree.PlaceholderInfo{}
 
-	ot.evalCtx.SessionData.ReorderJoinsLimit = int64(ot.Flags.JoinLimit)
-	ot.evalCtx.SessionData.PreferLookupJoinsForFKs = ot.Flags.PreferLookupJoinsForFKs
-	ot.evalCtx.SessionData.PropagateInputOrdering = ot.Flags.PropagateInputOrdering
+	ot.evalCtx.SessionData().ReorderJoinsLimit = int64(ot.Flags.JoinLimit)
+	ot.evalCtx.SessionData().PreferLookupJoinsForFKs = ot.Flags.PreferLookupJoinsForFKs
+	ot.evalCtx.SessionData().PropagateInputOrdering = ot.Flags.PropagateInputOrdering
 
 	ot.evalCtx.TestingKnobs.OptimizerCostPerturbation = ot.Flags.PerturbCost
 	ot.evalCtx.Locality = ot.Flags.Locality
-	ot.evalCtx.SessionData.SaveTablesPrefix = ot.Flags.SaveTablesPrefix
+	ot.evalCtx.SessionData().SaveTablesPrefix = ot.Flags.SaveTablesPrefix
 	ot.evalCtx.Placeholders = nil
 
 	switch d.Cmd {

--- a/pkg/sql/opt/xform/join_funcs.go
+++ b/pkg/sql/opt/xform/join_funcs.go
@@ -63,7 +63,7 @@ func (c *CustomFuncs) GenerateMergeJoins(
 		mustGenerateMergeJoin = true
 	}
 
-	if !c.NoJoinHints(joinPrivate) || c.e.evalCtx.SessionData.ReorderJoinsLimit == 0 {
+	if !c.NoJoinHints(joinPrivate) || c.e.evalCtx.SessionData().ReorderJoinsLimit == 0 {
 		// If we are using a hint, or the join limit is set to zero, the join won't
 		// be commuted. Add the orderings from the right side.
 		rightOrders := ordering.DeriveInterestingOrderings(right).Copy()
@@ -1420,7 +1420,7 @@ func (c *CustomFuncs) GetLocalityOptimizedLookupJoinExprs(
 	input memo.RelExpr, private *memo.LookupJoinPrivate,
 ) (localExpr memo.FiltersExpr, remoteExpr memo.FiltersExpr, ok bool) {
 	// Respect the session setting LocalityOptimizedSearch.
-	if !c.e.evalCtx.SessionData.LocalityOptimizedSearch {
+	if !c.e.evalCtx.SessionData().LocalityOptimizedSearch {
 		return nil, nil, false
 	}
 

--- a/pkg/sql/opt/xform/join_order_builder.go
+++ b/pkg/sql/opt/xform/join_order_builder.go
@@ -357,7 +357,7 @@ func (jb *JoinOrderBuilder) populateGraph(rel memo.RelExpr) (vertexSet, edgeSet)
 		jb.joinCount++
 
 		flags := t.Private().(*memo.JoinPrivate).Flags
-		if !flags.Empty() || jb.joinCount > int(jb.evalCtx.SessionData.ReorderJoinsLimit) {
+		if !flags.Empty() || jb.joinCount > int(jb.evalCtx.SessionData().ReorderJoinsLimit) {
 			// If the join has flags or the join limit has been reached, we can't
 			// reorder. Simply treat the join as a base relation.
 			jb.addBaseRelation(t)

--- a/pkg/sql/opt/xform/scan_funcs.go
+++ b/pkg/sql/opt/xform/scan_funcs.go
@@ -99,7 +99,7 @@ const regionKey = "region"
 // GenerateLocalityOptimizedScan rule for details.
 func (c *CustomFuncs) CanMaybeGenerateLocalityOptimizedScan(scanPrivate *memo.ScanPrivate) bool {
 	// Respect the session setting LocalityOptimizedSearch.
-	if !c.e.evalCtx.SessionData.LocalityOptimizedSearch {
+	if !c.e.evalCtx.SessionData().LocalityOptimizedSearch {
 		return false
 	}
 

--- a/pkg/sql/opt/xform/select_funcs.go
+++ b/pkg/sql/opt/xform/select_funcs.go
@@ -914,7 +914,7 @@ func (c *CustomFuncs) GenerateZigzagJoins(
 	grp memo.RelExpr, scanPrivate *memo.ScanPrivate, filters memo.FiltersExpr,
 ) {
 	// Short circuit unless zigzag joins are explicitly enabled.
-	if !c.e.evalCtx.SessionData.ZigzagJoinEnabled || scanPrivate.Flags.NoZigzagJoin {
+	if !c.e.evalCtx.SessionData().ZigzagJoinEnabled || scanPrivate.Flags.NoZigzagJoin {
 		return
 	}
 
@@ -1270,7 +1270,7 @@ func (c *CustomFuncs) GenerateInvertedIndexZigzagJoins(
 	grp memo.RelExpr, scanPrivate *memo.ScanPrivate, filters memo.FiltersExpr,
 ) {
 	// Short circuit unless zigzag joins are explicitly enabled.
-	if !c.e.evalCtx.SessionData.ZigzagJoinEnabled || scanPrivate.Flags.NoZigzagJoin {
+	if !c.e.evalCtx.SessionData().ZigzagJoinEnabled || scanPrivate.Flags.NoZigzagJoin {
 		return
 	}
 

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -833,7 +833,7 @@ func populateTableConstraints(
 				&buf, db.GetName(),
 				table, con.FK,
 				tableLookup,
-				p.extendedEvalCtx.SessionData.SearchPath,
+				p.extendedEvalCtx.SessionData().SearchPath,
 			); err != nil {
 				return err
 			}

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -47,7 +47,7 @@ func (r *runParams) EvalContext() *tree.EvalContext {
 
 // SessionData gives convenient access to the runParam's SessionData.
 func (r *runParams) SessionData() *sessiondata.SessionData {
-	return r.extendedEvalCtx.SessionData
+	return r.extendedEvalCtx.SessionData()
 }
 
 // ExecCfg gives convenient access to the runParam's ExecutorConfig.

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -349,7 +349,7 @@ func (opc *optPlanningCtx) buildReusableMemo(ctx context.Context) (_ *memo.Memo,
 
 	_, isCanned := opc.p.stmt.AST.(*tree.CannedOptPlan)
 	if isCanned {
-		if !p.EvalContext().SessionData.AllowPrepareAsOptPlan {
+		if !p.EvalContext().SessionData().AllowPrepareAsOptPlan {
 			return nil, pgerror.New(pgcode.InsufficientPrivilege,
 				"PREPARE AS OPT PLAN is a testing facility that should not be used directly",
 			)

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -437,7 +437,7 @@ func internalExtendedEvalCtx(
 	return extendedEvalContext{
 		EvalContext: tree.EvalContext{
 			Txn:                txn,
-			SessionData:        sd,
+			SessionDataStack:   sessiondata.NewStack(sd),
 			TxnReadOnly:        false,
 			TxnImplicit:        true,
 			Settings:           execCfg.Settings,
@@ -773,7 +773,7 @@ func (p *planner) TypeAsStringArray(
 
 // SessionData is part of the PlanHookState interface.
 func (p *planner) SessionData() *sessiondata.SessionData {
-	return p.EvalContext().SessionData
+	return p.EvalContext().SessionData()
 }
 
 // Ann is a shortcut for the Annotations from the eval context.

--- a/pkg/sql/row/row_converter.go
+++ b/pkg/sql/row/row_converter.go
@@ -348,7 +348,7 @@ func NewDatumRowConverter(
 		cols,
 		&rowenc.DatumAlloc{},
 		&evalCtx.Settings.SV,
-		evalCtx.SessionData.Internal,
+		evalCtx.SessionData().Internal,
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "make row inserter")

--- a/pkg/sql/rowexec/bulk_row_writer.go
+++ b/pkg/sql/rowexec/bulk_row_writer.go
@@ -106,7 +106,7 @@ func (sp *bulkRowWriter) work(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	if conv.EvalCtx.SessionData == nil {
+	if conv.EvalCtx.SessionData() == nil {
 		panic("uninitialized session data")
 	}
 

--- a/pkg/sql/rowexec/rowfetcher.go
+++ b/pkg/sql/rowexec/rowfetcher.go
@@ -98,7 +98,7 @@ func initRowFetcher(
 		reverseScan,
 		lockStrength,
 		lockWaitPolicy,
-		flowCtx.EvalCtx.SessionData.LockTimeout,
+		flowCtx.EvalCtx.SessionData().LockTimeout,
 		isCheck,
 		alloc,
 		mon,

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -344,7 +344,7 @@ func (sc *SchemaChanger) backfillQueryIntoTable(
 
 			isLocal := !getPlanDistribution(
 				ctx, localPlanner, localPlanner.execCfg.NodeID,
-				localPlanner.extendedEvalCtx.SessionData.DistSQLMode,
+				localPlanner.extendedEvalCtx.SessionData().DistSQLMode,
 				localPlanner.curPlan.main,
 			).WillDistribute()
 			out := execinfrapb.ProcessorCoreUnion{BulkRowWriter: &execinfrapb.BulkRowWriterSpec{
@@ -2005,7 +2005,7 @@ func createSchemaChangeEvalCtx(
 		ExecCfg: execCfg,
 		Descs:   descriptors,
 		EvalContext: tree.EvalContext{
-			SessionData:      sd,
+			SessionDataStack: sessiondata.NewStack(sd),
 			InternalExecutor: ieFactory(ctx, sd),
 			// TODO(andrei): This is wrong (just like on the main code path on
 			// setupFlow). Each processor should override Ctx with its own context.

--- a/pkg/sql/schemachanger/scbuild/table.go
+++ b/pkg/sql/schemachanger/scbuild/table.go
@@ -75,7 +75,7 @@ func (b *buildContext) alterTableAddColumn(
 	d := t.ColumnDef
 
 	if d.IsComputed() {
-		d.Computed.Expr = schemaexpr.MaybeRewriteComputedColumn(d.Computed.Expr, b.EvalCtx.SessionData)
+		d.Computed.Expr = schemaexpr.MaybeRewriteComputedColumn(d.Computed.Expr, b.EvalCtx.SessionData())
 	}
 
 	toType, err := tree.ResolveType(ctx, d.Type, b.SemaCtx.GetTypeResolver())
@@ -267,7 +267,7 @@ func (b *buildContext) findOrAddColumnFamily(
 func (b *buildContext) alterTableDropColumn(
 	ctx context.Context, table catalog.TableDescriptor, t *tree.AlterTableDropColumn,
 ) {
-	if b.EvalCtx.SessionData.SafeUpdates {
+	if b.EvalCtx.SessionData().SafeUpdates {
 		panic(pgerror.DangerousStatementf("ALTER TABLE DROP COLUMN will " +
 			"remove all data in that column"))
 	}

--- a/pkg/sql/sem/builtins/aggregate_builtins.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins.go
@@ -3647,7 +3647,7 @@ func newJSONAggregate(_ []*types.T, evalCtx *tree.EvalContext, _ tree.Datums) tr
 func (a *jsonAggregate) Add(ctx context.Context, datum tree.Datum, _ ...tree.Datum) error {
 	j, err := tree.AsJSON(
 		datum,
-		a.evalCtx.SessionData.DataConversionConfig,
+		a.evalCtx.SessionData().DataConversionConfig,
 		a.evalCtx.GetLocation(),
 	)
 	if err != nil {
@@ -3985,7 +3985,7 @@ func (a *jsonObjectAggregate) Add(
 
 	key, err := asJSONBuildObjectKey(
 		datum,
-		a.evalCtx.SessionData.DataConversionConfig,
+		a.evalCtx.SessionData().DataConversionConfig,
 		a.evalCtx.GetLocation(),
 	)
 	if err != nil {
@@ -3993,7 +3993,7 @@ func (a *jsonObjectAggregate) Add(
 	}
 	val, err := tree.AsJSON(
 		others[0],
-		a.evalCtx.SessionData.DataConversionConfig,
+		a.evalCtx.SessionData().DataConversionConfig,
 		a.evalCtx.GetLocation(),
 	)
 	if err != nil {

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -7343,7 +7343,7 @@ func stAsGeoJSONFromTuple(
 		}
 		tupleJSON, err := tree.AsJSON(
 			d,
-			ctx.SessionData.DataConversionConfig,
+			ctx.SessionData().DataConversionConfig,
 			ctx.GetLocation(),
 		)
 		if err != nil {

--- a/pkg/sql/sem/tree/casts.go
+++ b/pkg/sql/sem/tree/casts.go
@@ -977,7 +977,7 @@ func performCastWithoutPrecisionTruncation(ctx *EvalContext, d Datum, t *types.T
 			s = t.BitArray.String()
 		case *DFloat:
 			s = strconv.FormatFloat(float64(*t), 'g',
-				ctx.SessionData.DataConversionConfig.GetFloatPrec(), 64)
+				ctx.SessionData().DataConversionConfig.GetFloatPrec(), 64)
 		case *DBool, *DInt, *DDecimal:
 			s = d.String()
 		case *DTimestamp, *DDate, *DTime, *DTimeTZ, *DGeography, *DGeometry, *DBox2D:
@@ -996,13 +996,13 @@ func performCastWithoutPrecisionTruncation(ctx *EvalContext, d Datum, t *types.T
 			s = AsStringWithFlags(
 				d,
 				FmtPgwireText,
-				FmtDataConversionConfig(ctx.SessionData.DataConversionConfig),
+				FmtDataConversionConfig(ctx.SessionData().DataConversionConfig),
 			)
 		case *DArray:
 			s = AsStringWithFlags(
 				d,
 				FmtPgwireText,
-				FmtDataConversionConfig(ctx.SessionData.DataConversionConfig),
+				FmtDataConversionConfig(ctx.SessionData().DataConversionConfig),
 			)
 		case *DInterval:
 			// When converting an interval to string, we need a string representation
@@ -1011,7 +1011,7 @@ func performCastWithoutPrecisionTruncation(ctx *EvalContext, d Datum, t *types.T
 			s = AsStringWithFlags(
 				d,
 				FmtPgwireText,
-				FmtDataConversionConfig(ctx.SessionData.DataConversionConfig),
+				FmtDataConversionConfig(ctx.SessionData().DataConversionConfig),
 			)
 		case *DUuid:
 			s = t.UUID.String()
@@ -1024,7 +1024,7 @@ func performCastWithoutPrecisionTruncation(ctx *EvalContext, d Datum, t *types.T
 		case *DBytes:
 			s = lex.EncodeByteArrayToRawBytes(
 				string(*t),
-				ctx.SessionData.DataConversionConfig.BytesEncodeFormat,
+				ctx.SessionData().DataConversionConfig.BytesEncodeFormat,
 				false, /* skipHexPrefix */
 			)
 		case *DOid:

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -4415,7 +4415,7 @@ func ParseDOid(ctx *EvalContext, s string, t *types.T) (*DOid, error) {
 		for i := 0; i < len(substrs); i++ {
 			name.Parts[i] = substrs[len(substrs)-1-i]
 		}
-		funcDef, err := name.ResolveFunction(ctx.SessionData.SearchPath)
+		funcDef, err := name.ResolveFunction(ctx.SessionData().SearchPath)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/sem/tree/datum_integration_test.go
+++ b/pkg/sql/sem/tree/datum_integration_test.go
@@ -883,9 +883,9 @@ func TestDTimeTZ(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := &tree.EvalContext{
-		SessionData: &sessiondata.SessionData{
+		SessionDataStack: sessiondata.NewStack(&sessiondata.SessionData{
 			Location: time.UTC,
-		},
+		}),
 	}
 
 	maxTime, depOnCtx, err := tree.ParseDTimeTZ(ctx, "24:00:00-1559", time.Microsecond)

--- a/pkg/sql/sem/tree/datum_test.go
+++ b/pkg/sql/sem/tree/datum_test.go
@@ -140,9 +140,11 @@ func TestCompareTimestamps(t *testing.T) {
 			tc.desc,
 			func(t *testing.T) {
 				ctx := &EvalContext{
-					SessionData: &sessiondata.SessionData{
-						Location: tc.location,
-					},
+					SessionDataStack: sessiondata.NewStack(
+						&sessiondata.SessionData{
+							Location: tc.location,
+						},
+					),
 				}
 				assert.Equal(t, tc.expected, compareTimestamps(ctx, tc.left, tc.right))
 				assert.Equal(t, -tc.expected, compareTimestamps(ctx, tc.right, tc.left))

--- a/pkg/sql/sem/tree/normalize.go
+++ b/pkg/sql/sem/tree/normalize.go
@@ -829,7 +829,7 @@ var _ Visitor = &isConstVisitor{}
 
 func (v *isConstVisitor) VisitPre(expr Expr) (recurse bool, newExpr Expr) {
 	if v.isConst {
-		if !operatorIsImmutable(expr, v.ctx.SessionData) || isVar(v.ctx, expr, true /*allowConstPlaceholders*/) {
+		if !operatorIsImmutable(expr, v.ctx.SessionData()) || isVar(v.ctx, expr, true /*allowConstPlaceholders*/) {
 			v.isConst = false
 			return false, expr
 		}
@@ -916,7 +916,7 @@ func (v *fastIsConstVisitor) VisitPre(expr Expr) (recurse bool, newExpr Expr) {
 	// If the parent expression is a variable or non-immutable operator, we know
 	// that it is not constant.
 
-	if !operatorIsImmutable(expr, v.ctx.SessionData) || isVar(v.ctx, expr, true /*allowConstPlaceholders*/) {
+	if !operatorIsImmutable(expr, v.ctx.SessionData()) || isVar(v.ctx, expr, true /*allowConstPlaceholders*/) {
 		v.isConst = false
 		return false, expr
 	}

--- a/pkg/sql/sessiondata/BUILD.bazel
+++ b/pkg/sql/sessiondata/BUILD.bazel
@@ -21,13 +21,21 @@ go_library(
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/util/timeutil/pgdate",
+        "@com_github_cockroachdb_errors//:errors",
     ],
 )
 
 go_test(
     name = "sessiondata_test",
     size = "small",
-    srcs = ["search_path_test.go"],
+    srcs = [
+        "search_path_test.go",
+        "session_data_test.go",
+    ],
     embed = [":sessiondata"],
-    deps = ["@com_github_stretchr_testify//assert"],
+    deps = [
+        "//pkg/sql/sessiondatapb",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/pkg/sql/sessiondata/session_data_test.go
+++ b/pkg/sql/sessiondata/session_data_test.go
@@ -1,0 +1,50 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sessiondata
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStack(t *testing.T) {
+	initialElem := &SessionData{
+		SessionData: sessiondatapb.SessionData{
+			ApplicationName: "bob",
+		},
+	}
+	secondElem := &SessionData{
+		SessionData: sessiondatapb.SessionData{
+			ApplicationName: "jane",
+		},
+	}
+	thirdElem := &SessionData{
+		SessionData: sessiondatapb.SessionData{
+			ApplicationName: "t-marts",
+		},
+	}
+	s := NewStack(initialElem)
+	require.Equal(t, s.Top(), initialElem)
+	require.EqualError(t, s.Pop(), "there must always be at least one element in the SessionData stack")
+
+	s.Push(secondElem)
+	require.Equal(t, s.Top(), secondElem)
+	s.Push(thirdElem)
+	require.Equal(t, s.Top(), thirdElem)
+
+	require.NoError(t, s.Pop())
+	require.Equal(t, s.Top(), secondElem)
+	require.NoError(t, s.Pop())
+	require.Equal(t, s.Top(), initialElem)
+	require.EqualError(t, s.Pop(), "there must always be at least one element in the SessionData stack")
+}

--- a/pkg/sql/tablewriter.go
+++ b/pkg/sql/tablewriter.go
@@ -146,7 +146,7 @@ func (tb *tableWriterBase) init(
 	tb.desc = tableDesc
 	tb.lockTimeout = 0
 	if evalCtx != nil {
-		tb.lockTimeout = evalCtx.SessionData.LockTimeout
+		tb.lockTimeout = evalCtx.SessionData().LockTimeout
 	}
 	tb.forceProductionBatchSizes = evalCtx != nil && evalCtx.TestingKnobs.ForceProductionBatchSizes
 	tb.maxBatchSize = mutations.MaxBatchSize(tb.forceProductionBatchSizes)

--- a/pkg/sql/unsupported_vars.go
+++ b/pkg/sql/unsupported_vars.go
@@ -20,7 +20,7 @@ var DummyVars = map[string]sessionVar{
 	"enable_seqscan": makeDummyBooleanSessionVar(
 		"enable_seqscan",
 		func(evalCtx *extendedEvalContext) string {
-			return formatBoolAsPostgresSetting(evalCtx.SessionData.EnableSeqScan)
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().EnableSeqScan)
 		},
 		func(m *sessionDataMutator, v bool) {
 			m.SetEnableSeqScan(v)
@@ -30,7 +30,7 @@ var DummyVars = map[string]sessionVar{
 	"synchronous_commit": makeDummyBooleanSessionVar(
 		"synchronous_commit",
 		func(evalCtx *extendedEvalContext) string {
-			return formatBoolAsPostgresSetting(evalCtx.SessionData.SynchronousCommit)
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().SynchronousCommit)
 		},
 		func(m *sessionDataMutator, v bool) {
 			m.SetSynchronousCommit(v)

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -141,7 +141,7 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 		Get: func(evalCtx *extendedEvalContext) string {
-			return evalCtx.SessionData.ApplicationName
+			return evalCtx.SessionData().ApplicationName
 		},
 		GlobalDefault: func(_ *settings.Values) string { return "" },
 	},
@@ -160,7 +160,7 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 		Get: func(evalCtx *extendedEvalContext) string {
-			return evalCtx.SessionData.DataConversionConfig.BytesEncodeFormat.String()
+			return evalCtx.SessionData().DataConversionConfig.BytesEncodeFormat.String()
 		},
 		GlobalDefault: func(sv *settings.Values) string { return sessiondatapb.BytesEncodeHex.String() },
 	},
@@ -185,7 +185,7 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 		Get: func(evalCtx *extendedEvalContext) string {
-			return pgnotice.DisplaySeverity(evalCtx.SessionData.NoticeDisplaySeverity).String()
+			return pgnotice.DisplaySeverity(evalCtx.SessionData().NoticeDisplaySeverity).String()
 		},
 		GlobalDefault: func(_ *settings.Values) string { return "notice" },
 	},
@@ -224,7 +224,7 @@ var varGen = map[string]sessionVar{
 				return "", err
 			}
 
-			if len(dbName) == 0 && evalCtx.SessionData.SafeUpdates {
+			if len(dbName) == 0 && evalCtx.SessionData().SafeUpdates {
 				return "", pgerror.DangerousStatementf("SET database to empty string")
 			}
 
@@ -247,7 +247,7 @@ var varGen = map[string]sessionVar{
 			p.sessionDataMutator.SetDatabase(dbName)
 			return nil
 		},
-		Get: func(evalCtx *extendedEvalContext) string { return evalCtx.SessionData.Database },
+		Get: func(evalCtx *extendedEvalContext) string { return evalCtx.SessionData().Database },
 		GlobalDefault: func(_ *settings.Values) string {
 			// The "defaultdb" value is set as session default in the pgwire
 			// connection code. The global default is the empty string,
@@ -295,7 +295,7 @@ var varGen = map[string]sessionVar{
 	},
 	`datestyle_enabled`: {
 		Get: func(evalCtx *extendedEvalContext) string {
-			return formatBoolAsPostgresSetting(evalCtx.SessionData.DateStyleEnabled)
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().DateStyleEnabled)
 		},
 		GetStringVal: makePostgresBoolGetStringValFn("datestyle_enabled"),
 		Set: func(_ context.Context, m *sessionDataMutator, s string) error {
@@ -315,7 +315,7 @@ var varGen = map[string]sessionVar{
 	// TODO(bob): Remove or no-op this in v2.4: https://github.com/cockroachdb/cockroach/issues/32844
 	`default_int_size`: {
 		Get: func(evalCtx *extendedEvalContext) string {
-			return strconv.FormatInt(int64(evalCtx.SessionData.DefaultIntSize), 10)
+			return strconv.FormatInt(int64(evalCtx.SessionData().DefaultIntSize), 10)
 		},
 		GetStringVal: makeIntGetStringValFn("default_int_size"),
 		Set: func(ctx context.Context, m *sessionDataMutator, val string) error {
@@ -390,7 +390,7 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 		Get: func(evalCtx *extendedEvalContext) string {
-			pri := tree.UserPriority(evalCtx.SessionData.DefaultTxnPriority)
+			pri := tree.UserPriority(evalCtx.SessionData().DefaultTxnPriority)
 			if pri == tree.UnspecifiedUserPriority {
 				pri = tree.Normal
 			}
@@ -413,7 +413,7 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 		Get: func(evalCtx *extendedEvalContext) string {
-			return formatBoolAsPostgresSetting(evalCtx.SessionData.DefaultTxnReadOnly)
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().DefaultTxnReadOnly)
 		},
 		GlobalDefault: globalFalse,
 	},
@@ -430,7 +430,7 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 		Get: func(evalCtx *extendedEvalContext) string {
-			return formatBoolAsPostgresSetting(evalCtx.SessionData.DefaultTxnUseFollowerReads)
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().DefaultTxnUseFollowerReads)
 		},
 		GlobalDefault: globalFalse,
 	},
@@ -446,7 +446,7 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 		Get: func(evalCtx *extendedEvalContext) string {
-			return evalCtx.SessionData.DistSQLMode.String()
+			return evalCtx.SessionData().DistSQLMode.String()
 		},
 		GlobalDefault: func(sv *settings.Values) string {
 			return sessiondatapb.DistSQLExecMode(DistSQLClusterExecMode.Get(sv)).String()
@@ -467,7 +467,7 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 		Get: func(evalCtx *extendedEvalContext) string {
-			return humanizeutil.IBytes(evalCtx.SessionData.WorkMemLimit)
+			return humanizeutil.IBytes(evalCtx.SessionData().WorkMemLimit)
 		},
 		GlobalDefault: func(sv *settings.Values) string {
 			return humanizeutil.IBytes(settingWorkMemBytes.Get(sv))
@@ -487,7 +487,7 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 		Get: func(evalCtx *extendedEvalContext) string {
-			return evalCtx.SessionData.ExperimentalDistSQLPlanningMode.String()
+			return evalCtx.SessionData().ExperimentalDistSQLPlanningMode.String()
 		},
 		GlobalDefault: func(sv *settings.Values) string {
 			return sessiondatapb.ExperimentalDistSQLPlanningMode(experimentalDistSQLPlanningClusterMode.Get(sv)).String()
@@ -506,7 +506,7 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 		Get: func(evalCtx *extendedEvalContext) string {
-			return formatBoolAsPostgresSetting(evalCtx.SessionData.PartiallyDistributedPlansDisabled)
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().PartiallyDistributedPlansDisabled)
 		},
 		GlobalDefault: func(sv *settings.Values) string {
 			return formatBoolAsPostgresSetting(false)
@@ -525,7 +525,7 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 		Get: func(evalCtx *extendedEvalContext) string {
-			return formatBoolAsPostgresSetting(evalCtx.SessionData.ZigzagJoinEnabled)
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().ZigzagJoinEnabled)
 		},
 		GlobalDefault: func(sv *settings.Values) string {
 			return formatBoolAsPostgresSetting(zigzagJoinClusterMode.Get(sv))
@@ -548,7 +548,7 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 		Get: func(evalCtx *extendedEvalContext) string {
-			return strconv.FormatInt(evalCtx.SessionData.ReorderJoinsLimit, 10)
+			return strconv.FormatInt(evalCtx.SessionData().ReorderJoinsLimit, 10)
 		},
 		GlobalDefault: func(sv *settings.Values) string {
 			return strconv.FormatInt(ReorderJoinsLimitClusterValue.Get(sv), 10)
@@ -567,7 +567,7 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 		Get: func(evalCtx *extendedEvalContext) string {
-			return formatBoolAsPostgresSetting(evalCtx.SessionData.RequireExplicitPrimaryKeys)
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().RequireExplicitPrimaryKeys)
 		},
 		GlobalDefault: func(sv *settings.Values) string {
 			return formatBoolAsPostgresSetting(requireExplicitPrimaryKeysClusterMode.Get(sv))
@@ -586,7 +586,7 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 		Get: func(evalCtx *extendedEvalContext) string {
-			return evalCtx.SessionData.VectorizeMode.String()
+			return evalCtx.SessionData().VectorizeMode.String()
 		},
 		GlobalDefault: func(sv *settings.Values) string {
 			return sessiondatapb.VectorizeExecMode(
@@ -606,7 +606,7 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 		Get: func(evalCtx *extendedEvalContext) string {
-			return formatBoolAsPostgresSetting(evalCtx.SessionData.TestingVectorizeInjectPanics)
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().TestingVectorizeInjectPanics)
 		},
 		GlobalDefault: func(sv *settings.Values) string {
 			return formatBoolAsPostgresSetting(false)
@@ -646,7 +646,7 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 		Get: func(evalCtx *extendedEvalContext) string {
-			return strconv.FormatInt(evalCtx.SessionData.OptimizerFKCascadesLimit, 10)
+			return strconv.FormatInt(evalCtx.SessionData().OptimizerFKCascadesLimit, 10)
 		},
 		GlobalDefault: func(sv *settings.Values) string {
 			return strconv.FormatInt(optDrivenFKCascadesClusterLimit.Get(sv), 10)
@@ -665,7 +665,7 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 		Get: func(evalCtx *extendedEvalContext) string {
-			return formatBoolAsPostgresSetting(evalCtx.SessionData.OptimizerUseHistograms)
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().OptimizerUseHistograms)
 		},
 		GlobalDefault: func(sv *settings.Values) string {
 			return formatBoolAsPostgresSetting(optUseHistogramsClusterMode.Get(sv))
@@ -684,7 +684,7 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 		Get: func(evalCtx *extendedEvalContext) string {
-			return formatBoolAsPostgresSetting(evalCtx.SessionData.OptimizerUseMultiColStats)
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().OptimizerUseMultiColStats)
 		},
 		GlobalDefault: func(sv *settings.Values) string {
 			return formatBoolAsPostgresSetting(optUseMultiColStatsClusterMode.Get(sv))
@@ -703,7 +703,7 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 		Get: func(evalCtx *extendedEvalContext) string {
-			return formatBoolAsPostgresSetting(evalCtx.SessionData.LocalityOptimizedSearch)
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().LocalityOptimizedSearch)
 		},
 		GlobalDefault: func(sv *settings.Values) string {
 			return formatBoolAsPostgresSetting(localityOptimizedSearchMode.Get(sv))
@@ -722,7 +722,7 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 		Get: func(evalCtx *extendedEvalContext) string {
-			return formatBoolAsPostgresSetting(evalCtx.SessionData.ImplicitSelectForUpdate)
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().ImplicitSelectForUpdate)
 		},
 		GlobalDefault: func(sv *settings.Values) string {
 			return formatBoolAsPostgresSetting(implicitSelectForUpdateClusterMode.Get(sv))
@@ -741,7 +741,7 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 		Get: func(evalCtx *extendedEvalContext) string {
-			return formatBoolAsPostgresSetting(evalCtx.SessionData.InsertFastPath)
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().InsertFastPath)
 		},
 		GlobalDefault: func(sv *settings.Values) string {
 			return formatBoolAsPostgresSetting(insertFastPathClusterMode.Get(sv))
@@ -760,7 +760,7 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 		Get: func(evalCtx *extendedEvalContext) string {
-			return evalCtx.SessionData.SerialNormalizationMode.String()
+			return evalCtx.SessionData().SerialNormalizationMode.String()
 		},
 		GlobalDefault: func(sv *settings.Values) string {
 			return sessiondatapb.SerialNormalizationMode(
@@ -780,7 +780,7 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 		Get: func(evalCtx *extendedEvalContext) string {
-			return formatBoolAsPostgresSetting(evalCtx.SessionData.StubCatalogTablesEnabled)
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().StubCatalogTablesEnabled)
 		},
 		GlobalDefault: func(sv *settings.Values) string {
 			return formatBoolAsPostgresSetting(stubCatalogTablesEnabledClusterValue.Get(sv))
@@ -808,7 +808,7 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 		Get: func(evalCtx *extendedEvalContext) string {
-			return fmt.Sprintf("%d", evalCtx.SessionData.DataConversionConfig.ExtraFloatDigits)
+			return fmt.Sprintf("%d", evalCtx.SessionData().DataConversionConfig.ExtraFloatDigits)
 		},
 		GlobalDefault: func(sv *settings.Values) string { return "0" },
 	},
@@ -817,7 +817,7 @@ var varGen = map[string]sessionVar{
 	// https://github.com/cockroachdb/cockroach/issues/30588
 	`force_savepoint_restart`: {
 		Get: func(evalCtx *extendedEvalContext) string {
-			return formatBoolAsPostgresSetting(evalCtx.SessionData.ForceSavepointRestart)
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().ForceSavepointRestart)
 		},
 		GetStringVal: makePostgresBoolGetStringValFn("force_savepoint_restart"),
 		Set: func(_ context.Context, m *sessionDataMutator, val string) error {
@@ -870,7 +870,7 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 		Get: func(evalCtx *extendedEvalContext) string {
-			return strings.ToLower(evalCtx.SessionData.GetIntervalStyle().String())
+			return strings.ToLower(evalCtx.SessionData().GetIntervalStyle().String())
 		},
 		GlobalDefault: func(sv *settings.Values) string {
 			return strings.ToLower(duration.IntervalStyle_name[int32(intervalStyle.Get(sv))])
@@ -878,7 +878,7 @@ var varGen = map[string]sessionVar{
 	},
 	`intervalstyle_enabled`: {
 		Get: func(evalCtx *extendedEvalContext) string {
-			return formatBoolAsPostgresSetting(evalCtx.SessionData.IntervalStyleEnabled)
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().IntervalStyleEnabled)
 		},
 		GetStringVal: makePostgresBoolGetStringValFn("intervalstyle_enabled"),
 		Set: func(_ context.Context, m *sessionDataMutator, s string) error {
@@ -906,7 +906,7 @@ var varGen = map[string]sessionVar{
 		GetStringVal: makeTimeoutVarGetter(`lock_timeout`),
 		Set:          lockTimeoutVarSet,
 		Get: func(evalCtx *extendedEvalContext) string {
-			ms := evalCtx.SessionData.LockTimeout.Nanoseconds() / int64(time.Millisecond)
+			ms := evalCtx.SessionData().LockTimeout.Nanoseconds() / int64(time.Millisecond)
 			return strconv.FormatInt(ms, 10)
 		},
 		GlobalDefault: func(sv *settings.Values) string {
@@ -941,7 +941,7 @@ var varGen = map[string]sessionVar{
 	// TODO(dan): This should also work with SET.
 	`results_buffer_size`: {
 		Get: func(evalCtx *extendedEvalContext) string {
-			return strconv.FormatInt(evalCtx.SessionData.ResultsBufferSize, 10)
+			return strconv.FormatInt(evalCtx.SessionData().ResultsBufferSize, 10)
 		},
 	},
 
@@ -949,7 +949,7 @@ var varGen = map[string]sessionVar{
 	// See https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_sql_safe_updates
 	`sql_safe_updates`: {
 		Get: func(evalCtx *extendedEvalContext) string {
-			return formatBoolAsPostgresSetting(evalCtx.SessionData.SafeUpdates)
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().SafeUpdates)
 		},
 		GetStringVal: makePostgresBoolGetStringValFn("sql_safe_updates"),
 		Set: func(_ context.Context, m *sessionDataMutator, s string) error {
@@ -966,7 +966,7 @@ var varGen = map[string]sessionVar{
 	// CockroachDB extension.
 	`prefer_lookup_joins_for_fks`: {
 		Get: func(evalCtx *extendedEvalContext) string {
-			return formatBoolAsPostgresSetting(evalCtx.SessionData.PreferLookupJoinsForFKs)
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().PreferLookupJoinsForFKs)
 		},
 		GetStringVal: makePostgresBoolGetStringValFn("prefer_lookup_joins_for_fks"),
 		Set: func(_ context.Context, m *sessionDataMutator, s string) error {
@@ -985,10 +985,10 @@ var varGen = map[string]sessionVar{
 	// See https://www.postgresql.org/docs/current/sql-set-role.html.
 	`role`: {
 		Get: func(evalCtx *extendedEvalContext) string {
-			if evalCtx.SessionData.SessionUserProto == "" {
+			if evalCtx.SessionData().SessionUserProto == "" {
 				return security.NoneRole
 			}
-			return evalCtx.SessionData.User().Normalized()
+			return evalCtx.SessionData().User().Normalized()
 		},
 		SetWithPlanner: func(ctx context.Context, p *planner, s string) error {
 			u, err := security.MakeSQLUsernameFromUserInput(s, security.UsernameValidation)
@@ -1036,7 +1036,7 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 		Get: func(evalCtx *extendedEvalContext) string {
-			return evalCtx.SessionData.SearchPath.SQLIdentifiers()
+			return evalCtx.SessionData().SearchPath.SQLIdentifiers()
 		},
 		GlobalDefault: func(sv *settings.Values) string {
 			return sessiondata.DefaultSearchPath.String()
@@ -1082,14 +1082,14 @@ var varGen = map[string]sessionVar{
 	// In PG this is a pseudo-function used with SELECT, not SHOW.
 	// See https://www.postgresql.org/docs/10/static/functions-info.html
 	`session_user`: {
-		Get: func(evalCtx *extendedEvalContext) string { return evalCtx.SessionData.User().Normalized() },
+		Get: func(evalCtx *extendedEvalContext) string { return evalCtx.SessionData().User().Normalized() },
 	},
 
 	// See pg sources src/backend/utils/misc/guc.c. The variable is defined
 	// but is hidden from SHOW ALL.
 	`session_authorization`: {
 		Hidden: true,
-		Get:    func(evalCtx *extendedEvalContext) string { return evalCtx.SessionData.User().Normalized() },
+		Get:    func(evalCtx *extendedEvalContext) string { return evalCtx.SessionData().User().Normalized() },
 	},
 
 	// Supported for PG compatibility only.
@@ -1121,7 +1121,7 @@ var varGen = map[string]sessionVar{
 		GetStringVal: makeTimeoutVarGetter(`statement_timeout`),
 		Set:          stmtTimeoutVarSet,
 		Get: func(evalCtx *extendedEvalContext) string {
-			ms := evalCtx.SessionData.StmtTimeout.Nanoseconds() / int64(time.Millisecond)
+			ms := evalCtx.SessionData().StmtTimeout.Nanoseconds() / int64(time.Millisecond)
 			return strconv.FormatInt(ms, 10)
 		},
 		GlobalDefault: func(sv *settings.Values) string {
@@ -1133,7 +1133,7 @@ var varGen = map[string]sessionVar{
 		GetStringVal: makeTimeoutVarGetter(`idle_in_session_timeout`),
 		Set:          idleInSessionTimeoutVarSet,
 		Get: func(evalCtx *extendedEvalContext) string {
-			ms := evalCtx.SessionData.IdleInSessionTimeout.Nanoseconds() / int64(time.Millisecond)
+			ms := evalCtx.SessionData().IdleInSessionTimeout.Nanoseconds() / int64(time.Millisecond)
 			return strconv.FormatInt(ms, 10)
 		},
 		GlobalDefault: func(sv *settings.Values) string {
@@ -1145,7 +1145,7 @@ var varGen = map[string]sessionVar{
 		GetStringVal: makeTimeoutVarGetter(`idle_in_transaction_session_timeout`),
 		Set:          idleInTransactionSessionTimeoutVarSet,
 		Get: func(evalCtx *extendedEvalContext) string {
-			ms := evalCtx.SessionData.IdleInTransactionSessionTimeout.Nanoseconds() / int64(time.Millisecond)
+			ms := evalCtx.SessionData().IdleInTransactionSessionTimeout.Nanoseconds() / int64(time.Millisecond)
 			return strconv.FormatInt(ms, 10)
 		},
 		GlobalDefault: func(sv *settings.Values) string {
@@ -1156,7 +1156,7 @@ var varGen = map[string]sessionVar{
 	// See https://www.postgresql.org/docs/10/static/runtime-config-client.html#GUC-TIMEZONE
 	`timezone`: {
 		Get: func(evalCtx *extendedEvalContext) string {
-			return sessionDataTimeZoneFormat(evalCtx.SessionData.GetLocation())
+			return sessionDataTimeZoneFormat(evalCtx.SessionData().GetLocation())
 		},
 		GetStringVal:  timeZoneVarGetStringVal,
 		Set:           timeZoneVarSet,
@@ -1230,7 +1230,7 @@ var varGen = map[string]sessionVar{
 	`allow_prepare_as_opt_plan`: {
 		Hidden: true,
 		Get: func(evalCtx *extendedEvalContext) string {
-			return formatBoolAsPostgresSetting(evalCtx.SessionData.AllowPrepareAsOptPlan)
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().AllowPrepareAsOptPlan)
 		},
 		Set: func(_ context.Context, m *sessionDataMutator, s string) error {
 			b, err := paramparse.ParseBoolVar("allow_prepare_as_opt_plan", s)
@@ -1247,7 +1247,7 @@ var varGen = map[string]sessionVar{
 	`save_tables_prefix`: {
 		Hidden: true,
 		Get: func(evalCtx *extendedEvalContext) string {
-			return evalCtx.SessionData.SaveTablesPrefix
+			return evalCtx.SessionData().SaveTablesPrefix
 		},
 		Set: func(_ context.Context, m *sessionDataMutator, s string) error {
 			m.SetSaveTablesPrefix(s)
@@ -1268,7 +1268,7 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 		Get: func(evalCtx *extendedEvalContext) string {
-			return formatBoolAsPostgresSetting(evalCtx.SessionData.TempTablesEnabled)
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().TempTablesEnabled)
 		},
 		GlobalDefault: func(sv *settings.Values) string {
 			return formatBoolAsPostgresSetting(temporaryTablesEnabledClusterMode.Get(sv))
@@ -1287,7 +1287,7 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 		Get: func(evalCtx *extendedEvalContext) string {
-			return formatBoolAsPostgresSetting(evalCtx.SessionData.PlacementEnabled)
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().PlacementEnabled)
 		},
 		GlobalDefault: func(sv *settings.Values) string {
 			return formatBoolAsPostgresSetting(placementEnabledClusterMode.Get(sv))
@@ -1306,7 +1306,7 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 		Get: func(evalCtx *extendedEvalContext) string {
-			return formatBoolAsPostgresSetting(evalCtx.SessionData.ImplicitColumnPartitioningEnabled)
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().ImplicitColumnPartitioningEnabled)
 		},
 		GlobalDefault: func(sv *settings.Values) string {
 			return formatBoolAsPostgresSetting(implicitColumnPartitioningEnabledClusterMode.Get(sv))
@@ -1325,7 +1325,7 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 		Get: func(evalCtx *extendedEvalContext) string {
-			return formatBoolAsPostgresSetting(evalCtx.SessionData.DropEnumValueEnabled)
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().DropEnumValueEnabled)
 		},
 		GlobalDefault: func(sv *settings.Values) string {
 			return formatBoolAsPostgresSetting(dropEnumValueEnabledClusterMode.Get(sv))
@@ -1344,7 +1344,7 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 		Get: func(evalCtx *extendedEvalContext) string {
-			return formatBoolAsPostgresSetting(evalCtx.SessionData.OverrideMultiRegionZoneConfigEnabled)
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().OverrideMultiRegionZoneConfigEnabled)
 		},
 		GlobalDefault: func(sv *settings.Values) string {
 			return formatBoolAsPostgresSetting(overrideMultiRegionZoneConfigClusterMode.Get(sv))
@@ -1363,7 +1363,7 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 		Get: func(evalCtx *extendedEvalContext) string {
-			return formatBoolAsPostgresSetting(evalCtx.SessionData.HashShardedIndexesEnabled)
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().HashShardedIndexesEnabled)
 		},
 		GlobalDefault: func(sv *settings.Values) string {
 			return formatBoolAsPostgresSetting(hashShardedIndexesEnabledClusterMode.Get(sv))
@@ -1381,7 +1381,7 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 		Get: func(evalCtx *extendedEvalContext) string {
-			return formatBoolAsPostgresSetting(evalCtx.SessionData.DisallowFullTableScans)
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().DisallowFullTableScans)
 		},
 		GlobalDefault: func(sv *settings.Values) string {
 			return formatBoolAsPostgresSetting(disallowFullTableScans.Get(sv))
@@ -1400,7 +1400,7 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 		Get: func(evalCtx *extendedEvalContext) string {
-			return formatBoolAsPostgresSetting(evalCtx.SessionData.AlterColumnTypeGeneralEnabled)
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().AlterColumnTypeGeneralEnabled)
 		},
 		GlobalDefault: func(sv *settings.Values) string {
 			return formatBoolAsPostgresSetting(experimentalAlterColumnTypeGeneralMode.Get(sv))
@@ -1420,7 +1420,7 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 		Get: func(evalCtx *extendedEvalContext) string {
-			return formatBoolAsPostgresSetting(evalCtx.SessionData.EnableUniqueWithoutIndexConstraints)
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().EnableUniqueWithoutIndexConstraints)
 		},
 		GlobalDefault: func(sv *settings.Values) string {
 			return formatBoolAsPostgresSetting(experimentalUniqueWithoutIndexConstraintsMode.Get(sv))
@@ -1439,7 +1439,7 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 		Get: func(evalCtx *extendedEvalContext) string {
-			return evalCtx.SessionData.NewSchemaChangerMode.String()
+			return evalCtx.SessionData().NewSchemaChangerMode.String()
 		},
 		GlobalDefault: func(sv *settings.Values) string {
 			return sessiondatapb.NewSchemaChangerMode(experimentalUseNewSchemaChanger.Get(sv)).String()
@@ -1457,7 +1457,7 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 		Get: func(evalCtx *extendedEvalContext) string {
-			return formatBoolAsPostgresSetting(evalCtx.SessionData.EnableStreamReplication)
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().EnableStreamReplication)
 		},
 		GlobalDefault: func(sv *settings.Values) string {
 			return formatBoolAsPostgresSetting(experimentalStreamReplicationEnabled.Get(sv))
@@ -1478,7 +1478,7 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 		Get: func(evalCtx *extendedEvalContext) string {
-			return evalCtx.SessionData.ExperimentalComputedColumnRewrites
+			return evalCtx.SessionData().ExperimentalComputedColumnRewrites
 		},
 		GlobalDefault: func(sv *settings.Values) string {
 			return experimentalComputedColumnRewrites.Get(sv)
@@ -1496,7 +1496,7 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 		Get: func(evalCtx *extendedEvalContext) string {
-			return formatBoolAsPostgresSetting(evalCtx.SessionData.CopyPartitioningWhenDeinterleavingTable)
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().CopyPartitioningWhenDeinterleavingTable)
 		},
 		GlobalDefault: func(sv *settings.Values) string {
 			return formatBoolAsPostgresSetting(copyPartitioningWhenDeinterleavingTable.Get(sv))
@@ -1514,7 +1514,7 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 		Get: func(evalCtx *extendedEvalContext) string {
-			return formatBoolAsPostgresSetting(evalCtx.SessionData.PropagateInputOrdering)
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().PropagateInputOrdering)
 		},
 		GlobalDefault: func(sv *settings.Values) string {
 			return formatBoolAsPostgresSetting(propagateInputOrdering.Get(sv))

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -418,8 +418,8 @@ func (e *virtualDefEntry) Desc() catalog.Descriptor {
 func canQueryVirtualTable(evalCtx *tree.EvalContext, e *virtualDefEntry) bool {
 	return !e.unimplemented ||
 		evalCtx == nil ||
-		evalCtx.SessionData == nil ||
-		evalCtx.SessionData.StubCatalogTablesEnabled
+		evalCtx.SessionData() == nil ||
+		evalCtx.SessionData().StubCatalogTablesEnabled
 }
 
 type mutableVirtualDefEntry struct {


### PR DESCRIPTION
See individual commits for details. This one is needed ASAP to prevent merge conflicts.
Part 1 of a series of PRs to merge SET LOCAL.
Refs: #32562

Release justification: low risk, high pri change.
