### PR TITLE
sql: version gate ON UPDATE expressions

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -156,4 +156,4 @@ trace.datadog.project	string	CockroachDB	the project under which traces will be 
 trace.debug.enable	boolean	false	if set, traces for recent requests can be seen at https://<ui>/debug/requests
 trace.lightstep.token	string		if set, traces go to Lightstep using this token
 trace.zipkin.collector	string		if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'). Only one tracer can be configured at a time.
-version	version	21.1-150	set the active cluster version in the format '<major>.<minor>'
+version	version	21.1-152	set the active cluster version in the format '<major>.<minor>'

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -160,6 +160,6 @@
 <tr><td><code>trace.debug.enable</code></td><td>boolean</td><td><code>false</code></td><td>if set, traces for recent requests can be seen at https://<ui>/debug/requests</td></tr>
 <tr><td><code>trace.lightstep.token</code></td><td>string</td><td><code></code></td><td>if set, traces go to Lightstep using this token</td></tr>
 <tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'). Only one tracer can be configured at a time.</td></tr>
-<tr><td><code>version</code></td><td>version</td><td><code>21.1-150</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
+<tr><td><code>version</code></td><td>version</td><td><code>21.1-152</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
 </tbody>
 </table>

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -307,6 +307,9 @@ const (
 	// GeneratedAsIdentity is the syntax support for `GENERATED {ALWAYS | BY
 	// DEFAULT} AS IDENTITY` under `CREATE TABLE` syntax.
 	GeneratedAsIdentity
+	// OnUpdateExpressions setting ON UPDATE column expressions is supported in
+	// this version.
+	OnUpdateExpressions
 	// Step (1): Add new versions here.
 )
 
@@ -526,7 +529,10 @@ var versionsSingleton = keyedVersions{
 		Key:     GeneratedAsIdentity,
 		Version: roachpb.Version{Major: 21, Minor: 1, Internal: 150},
 	},
-
+	{
+		Key:     OnUpdateExpressions,
+		Version: roachpb.Version{Major: 21, Minor: 1, Internal: 152},
+	},
 	// Step (2): Add new versions here.
 }
 

--- a/pkg/clusterversion/key_string.go
+++ b/pkg/clusterversion/key_string.go
@@ -54,11 +54,12 @@ func _() {
 	_ = x[UseKeyEncodeForHashShardedIndexes-43]
 	_ = x[DatabasePlacementPolicy-44]
 	_ = x[GeneratedAsIdentity-45]
+	_ = x[OnUpdateExpressions-46]
 }
 
-const _Key_name = "Start20_2NodeMembershipStatusMinPasswordLengthAbortSpanBytesCreateLoginPrivilegeHBAForNonTLSV20_2Start21_1CPutInlineReplicaVersionsreplacedTruncatedAndRangeAppliedStateMigrationreplacedPostTruncatedAndRangeAppliedStateMigrationTruncatedAndRangeAppliedStateMigrationPostTruncatedAndRangeAppliedStateMigrationSeparatedIntentsTracingVerbosityIndependentSemanticsClosedTimestampsRaftTransportPriorReadSummariesNonVotingReplicasV21_1Start21_1PLUSStart21_2JoinTokensTableAcquisitionTypeInLeaseHistorySerializeViewUDTsExpressionIndexesDeleteDeprecatedNamespaceTableDescriptorMigrationFixDescriptorsSQLStatsTableDatabaseRoleSettingsTenantUsageTableSQLInstancesTableNewRetryableRangefeedErrorsAlterSystemWebSessionsCreateIndexesSeparatedIntentsMigrationPostSeparatedIntentsMigrationRetryJobsWithExponentialBackoffRecordsBasedRegistryAutoSpanConfigReconciliationJobPreventNewInterleavedTablesEnsureNoInterleavedTablesDefaultPrivilegesZonesTableForSecondaryTenantsUseKeyEncodeForHashShardedIndexesDatabasePlacementPolicyGeneratedAsIdentity"
+const _Key_name = "Start20_2NodeMembershipStatusMinPasswordLengthAbortSpanBytesCreateLoginPrivilegeHBAForNonTLSV20_2Start21_1CPutInlineReplicaVersionsreplacedTruncatedAndRangeAppliedStateMigrationreplacedPostTruncatedAndRangeAppliedStateMigrationTruncatedAndRangeAppliedStateMigrationPostTruncatedAndRangeAppliedStateMigrationSeparatedIntentsTracingVerbosityIndependentSemanticsClosedTimestampsRaftTransportPriorReadSummariesNonVotingReplicasV21_1Start21_1PLUSStart21_2JoinTokensTableAcquisitionTypeInLeaseHistorySerializeViewUDTsExpressionIndexesDeleteDeprecatedNamespaceTableDescriptorMigrationFixDescriptorsSQLStatsTableDatabaseRoleSettingsTenantUsageTableSQLInstancesTableNewRetryableRangefeedErrorsAlterSystemWebSessionsCreateIndexesSeparatedIntentsMigrationPostSeparatedIntentsMigrationRetryJobsWithExponentialBackoffRecordsBasedRegistryAutoSpanConfigReconciliationJobPreventNewInterleavedTablesEnsureNoInterleavedTablesDefaultPrivilegesZonesTableForSecondaryTenantsUseKeyEncodeForHashShardedIndexesDatabasePlacementPolicyGeneratedAsIdentityOnUpdateExpressions"
 
-var _Key_index = [...]uint16{0, 9, 29, 46, 60, 80, 92, 97, 106, 116, 131, 177, 227, 265, 307, 323, 359, 388, 406, 423, 428, 441, 450, 465, 494, 511, 528, 577, 591, 604, 624, 640, 657, 684, 719, 744, 773, 804, 824, 855, 882, 907, 924, 953, 986, 1009, 1028}
+var _Key_index = [...]uint16{0, 9, 29, 46, 60, 80, 92, 97, 106, 116, 131, 177, 227, 265, 307, 323, 359, 388, 406, 423, 428, 441, 450, 465, 494, 511, 528, 577, 591, 604, 624, 640, 657, 684, 719, 744, 773, 804, 824, 855, 882, 907, 924, 953, 986, 1009, 1028, 1047}
 
 func (i Key) String() string {
 	if i < 0 || i >= Key(len(_Key_index)-1) {

--- a/pkg/migration/migrations/BUILD.bazel
+++ b/pkg/migration/migrations/BUILD.bazel
@@ -64,6 +64,7 @@ go_test(
         "helpers_test.go",
         "interleaved_tables_external_test.go",
         "main_test.go",
+        "on_update_test.go",
         "retry_jobs_with_exponential_backoff_external_test.go",
         "separated_intents_external_test.go",
         "separated_intents_test.go",

--- a/pkg/migration/migrations/on_update_test.go
+++ b/pkg/migration/migrations/on_update_test.go
@@ -1,0 +1,70 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package migrations_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestOnUpdateVersionGating(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				Server: &server.TestingKnobs{
+					DisableAutomaticVersionUpgrade: 1,
+					BinaryVersionOverride: clusterversion.ByKey(
+						clusterversion.OnUpdateExpressions - 1,
+					),
+				},
+			},
+		},
+	})
+
+	defer tc.Stopper().Stop(ctx)
+	db := tc.ServerConn(0)
+	tdb := sqlutils.MakeSQLRunner(db)
+
+	tdb.ExpectErr(t,
+		"pq: version 21.1-152 must be finalized to use ON UPDATE",
+		"CREATE TABLE test (p INT, j INT ON UPDATE 5)")
+
+	tdb.Exec(t, "CREATE TABLE test (p INT, j INT);")
+
+	tdb.ExpectErr(t,
+		"pq: version 21.1-152 must be finalized to use ON UPDATE",
+		"ALTER TABLE test ALTER COLUMN j SET ON UPDATE 5")
+
+	tdb.ExpectErr(t,
+		"pq: version 21.1-152 must be finalized to use ON UPDATE",
+		"ALTER TABLE test ADD COLUMN k INT ON UPDATE 5")
+
+	tdb.Exec(t,
+		"SET CLUSTER SETTING version = $1",
+		clusterversion.ByKey(clusterversion.OnUpdateExpressions).String(),
+	)
+
+	tdb.Exec(t, "CREATE TABLE test_create (p INT, j INT ON UPDATE 5)")
+
+	tdb.Exec(t, "ALTER TABLE test ALTER COLUMN j SET ON UPDATE 5")
+
+	tdb.Exec(t, "ALTER TABLE test ADD COLUMN k INT ON UPDATE 5")
+}

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -1163,6 +1163,12 @@ func applyColumnMutation(
 		}
 
 	case *tree.AlterTableSetOnUpdate:
+		if !params.ExecCfg().Settings.Version.IsActive(ctx, clusterversion.OnUpdateExpressions) {
+			return pgerror.Newf(pgcode.FeatureNotSupported,
+				"version %v must be finalized to use ON UPDATE",
+				clusterversion.ByKey(clusterversion.OnUpdateExpressions))
+		}
+
 		// We want to reject uses of ON UPDATE where there is also a foreign key ON
 		// UPDATE.
 		for _, fk := range tableDesc.OutboundFKs {

--- a/pkg/sql/catalog/tabledesc/BUILD.bazel
+++ b/pkg/sql/catalog/tabledesc/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/clusterversion",
         "//pkg/docs",
         "//pkg/geo/geoindex",
         "//pkg/keys",


### PR DESCRIPTION
This change version gates all changes to ON UPDATE expressions so that
ON UPDATE cannot be used unless the entire cluster has completed the
migration to 21.2.

Release justification: low risk change, adding safety to existing
feature
Release note: None