### PR TITLE
roachtest: update 21.1 version map to 20.2.15

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1211,13 +1211,15 @@ func PredecessorVersion(buildVersion version.Version) (string, error) {
 
 	buildVersionMajorMinor := fmt.Sprintf("%d.%d", buildVersion.Major(), buildVersion.Minor())
 
-	// NB: you can update the values in this map to point at newer patch
-	// releases. You will need to run acceptance/version-upgrade with the
-	// checkpoint option enabled to create the missing store directory fixture
-	// (see runVersionUpgrade). The same is true for adding a new key to this
-	// map.
+	// You can update the values in verMap to point at newer patch releases.
+	//
+	// NB: If a new key was added (e.g. if you're releasing a new major
+	// release), you'll also need to regenerate fixtures. To regenerate
+	// fixtures, you will need to run acceptance/version-upgrade with the
+	// checkpoint option enabled to create the missing store directory
+	// fixture (see runVersionUpgrade).
 	verMap := map[string]string{
-		"21.1": "20.2.14",
+		"21.1": "20.2.15",
 		"20.2": "20.1.13",
 		"20.1": "19.2.11",
 		"19.2": "19.1.11",


### PR DESCRIPTION
This updates the version mapping of the 21.1 branch to point to the
latest version (20.2.15).

Release note: None
