### PR TITLE
logictest: avoid parallelizing multiregion logic tests

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1199,10 +1199,6 @@ type ExecutorTestingKnobs struct {
 	// tracing spans for every statement.
 	ForceRealTracingSpans bool
 
-	// ClusterSettingUpdateTimeout, if set, controls the time to wait for a
-	// CLUSTER SETTING to update across all nodes.
-	ClusterSettingUpdateTimeout time.Duration
-
 	// DistSQLReceiverPushCallbackFactory, if set, will be called every time a
 	// DistSQLReceiver is created for a new query execution, and it should
 	// return, possibly nil, a callback that will be called every time

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1341,10 +1341,6 @@ func (t *logicTest) newCluster(serverArgs TestServerArgs) {
 				},
 				SQLExecutor: &sql.ExecutorTestingKnobs{
 					DeterministicExplain: true,
-					// Bump to a larger timeout as multi-node tests in CI take a while longer
-					// to update.
-					// TODO(#69227): lower this timeout.
-					ClusterSettingUpdateTimeout: 30 * time.Second,
 				},
 			},
 			ClusterName:   "testclustername",

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -3289,7 +3289,13 @@ func RunLogicTestWithDefaultConfig(
 					//  - we're generating testfiles, or
 					//  - we are in race mode (where we can hit a limit on alive
 					//    goroutines).
-					if !*showSQL && !*rewriteResultsInTestfiles && !*rewriteSQL && !util.RaceEnabled && !cfg.useTenant {
+					//  - we have too many nodes (this can lead to general slowness)
+					if !*showSQL &&
+						!*rewriteResultsInTestfiles &&
+						!*rewriteSQL &&
+						!util.RaceEnabled &&
+						!cfg.useTenant &&
+						cfg.numNodes <= 3 {
 						// Skip parallelizing tests that use the kv-batch-size directive since
 						// the batch size is a global variable.
 						//

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -3265,9 +3265,6 @@ func RunLogicTestWithDefaultConfig(
 			if logicTestsConfigFilter != "" && cfg.name != logicTestsConfigFilter {
 				skip.IgnoreLint(t, "config does not match env var")
 			}
-			if cfg.numNodes > 3 {
-				skip.UnderBazelWithIssue(t, 69276, "multi-node tests fail")
-			}
 			for i, path := range paths {
 				path := path // Rebind range variable.
 				onlyNonMetamorphic := nonMetamorphic[i]

--- a/pkg/sql/set_cluster_setting.go
+++ b/pkg/sql/set_cluster_setting.go
@@ -367,11 +367,7 @@ func (n *setClusterSettingNode) startExec(params runParams) error {
 	}
 	errNotReady := errors.New("setting updated but timed out waiting to read new value")
 	var observed string
-	retryDuration := 10 * time.Second
-	if override := params.p.ExecCfg().TestingKnobs.ClusterSettingUpdateTimeout; override != 0 {
-		retryDuration = override
-	}
-	err := retry.ForDuration(retryDuration, func() error {
+	err := retry.ForDuration(10*time.Second, func() error {
 		observed = n.setting.Encoded(&execCfg.Settings.SV)
 		if observed != expectedEncodedValue {
 			return errNotReady


### PR DESCRIPTION
Starting multi-node servers for multi-region is expensive, especially in
parallel. As such, avoid parallelising logic tests with multiple
servers.

Resolves #69272
Resolves #69276 

Release justification: testing only change

Release note: None