### PR TITLE
row: avoid txnKVFetcher batching for bounded staleness reads

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/as_of
+++ b/pkg/ccl/logictestccl/testdata/logic_test/as_of
@@ -5,9 +5,7 @@ CREATE TABLE t (
   i INT PRIMARY KEY,
   j INT UNIQUE,
   k INT,
-  UNIQUE (k) STORING (j),
-  -- this is in a single family as multi-family fetches are not yet supported.
-  FAMILY (i, j, k)
+  UNIQUE (k) STORING (j)
 )
 
 statement ok


### PR DESCRIPTION
Previously, fetching using a bounded staleness read over multiple
batches in `txnKVFetcher` potentially resulted in a panic if there are
multiple families as the batches would split between families. Resolve
this by avoiding batching for bounded staleness reads, as we are always
reading a single row.

Resolves: #69063

Release justification: fix to new functionality

Release note: None