### PR TITLE
pgwire: make TestPGTest/param_status test `-rewrite` idempotent

### DIFF
--- a/pkg/sql/pgwire/testdata/pgtest/param_status
+++ b/pkg/sql/pgwire/testdata/pgtest/param_status
@@ -129,6 +129,17 @@ ReadyForQuery
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
 send
+Query {"String": "DROP ROLE IF EXISTS testuser"}
+----
+
+# Ignore the notice, as the user might exist.
+until ignore=NoticeResponse
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"DROP ROLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
 Query {"String": "CREATE ROLE testuser"}
 ----
 


### PR DESCRIPTION
Add an `ignore_all` directive which ignores all output. This is
important as notices may be generated, but we want `-rewrite` to be
idempotent and ignore little difference between changes like this.

Release justification: test only change

Release note: None