### PR TITLE
sql/row: avoid NegotiateAndSend on a multi-batch request

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/as_of
+++ b/pkg/ccl/logictestccl/testdata/logic_test/as_of
@@ -5,9 +5,7 @@ CREATE TABLE t (
   i INT PRIMARY KEY,
   j INT UNIQUE,
   k INT,
-  UNIQUE (k) STORING (j),
-  -- this is in a single family as multi-family fetches are not yet supported.
-  FAMILY (i, j, k)
+  UNIQUE (k) STORING (j)
 )
 
 statement ok

--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -980,6 +980,12 @@ func (txn *Txn) Send(
 		ba.Header.GatewayNodeID = txn.gatewayNodeID
 	}
 
+	// Requests with a bounded staleness header should use NegotiateAndSend.
+	if ba.BoundedStaleness != nil {
+		return nil, roachpb.NewError(errors.AssertionFailedf(
+			"bounded staleness header passed to Txn.Send: %s", ba.String()))
+	}
+
 	// Some callers have not initialized ba using a Batch constructed using
 	// Txn.NewBatch. So we fallback to partially overwriting here.
 	noMem := ba.AdmissionHeader.NoMemoryReservedAtSource


### PR DESCRIPTION
Avoid the double NegotiateAndSend on a bounded staleness request if
there are multiple column families for the given row by tracking
whether a negotiate was already made. If so, use Send, as
SetFixedTimestamp would already have the correct value.

Release justification: fix to new feature

Resolves: #69063

Release note: None