### PR TITLE
admission: simplify ioLoadListener token calculation

### DIFF
--- a/pkg/util/admission/granter_test.go
+++ b/pkg/util/admission/granter_test.go
@@ -299,7 +299,7 @@ func (g *testGranterWithIOTokens) setAvailableIOTokensLocked(tokens int64) {
 	fmt.Fprintf(&g.buf, "setAvailableIOTokens: %s", tokensFor1sToString(tokens))
 }
 
-func tokensFor60sToString(tokens int64) string {
+func tokensForIntervalToString(tokens int64) string {
 	if tokens == unlimitedTokens {
 		return "unlimited"
 	}
@@ -307,9 +307,7 @@ func tokensFor60sToString(tokens int64) string {
 }
 
 func tokensFor1sToString(tokens int64) string {
-	// ioLoadListener works with floats, so we just approximate the unlimited
-	// calculation here.
-	if tokens >= (unlimitedTokens/adjustmentInterval - 15) {
+	if tokens >= unlimitedTokens/adjustmentInterval {
 		return "unlimited"
 	}
 	return fmt.Sprintf("%d", tokens)
@@ -350,13 +348,13 @@ func TestIOLoadListener(t *testing.T) {
 					ioll = &ioLoadListener{
 						settings:    st,
 						kvRequester: req,
-						// The mutex is needed by ioLoadListener but is not useful in this
-						// test -- the channels provide synchronization and prevent this
-						// test code and the ioLoadListener from being concurrently
-						// active.
-						mu:        &syncutil.Mutex{},
-						kvGranter: kvGranter,
 					}
+					// The mutex is needed by ioLoadListener but is not useful in this
+					// test -- the channels provide synchronization and prevent this
+					// test code and the ioLoadListener from being concurrently
+					// active.
+					ioll.mu.Mutex = &syncutil.Mutex{}
+					ioll.mu.kvGranter = kvGranter
 				}
 				ioll.pebbleMetricsTick(metrics)
 				// Do the ticks until just before next adjustment.
@@ -364,7 +362,7 @@ func TestIOLoadListener(t *testing.T) {
 				fmt.Fprintf(&buf, "admitted: %d, bytes: %d, added-bytes: %d,\nsmoothed-removed: %d, "+
 					"smoothed-admit: %d,\ntokens: %s, tokens-allocated: %s\n", ioll.admittedCount,
 					ioll.l0Bytes, ioll.l0AddedBytes, ioll.smoothedBytesRemoved,
-					int64(ioll.smoothedNumAdmit), tokensFor60sToString(ioll.totalTokens),
+					int64(ioll.smoothedNumAdmit), tokensForIntervalToString(ioll.totalTokens),
 					tokensFor1sToString(ioll.tokensAllocated))
 				for i := 0; i < adjustmentInterval; i++ {
 					ioll.allocateTokensTick()


### PR DESCRIPTION
The code was using float64 to avoid overflow, but it
caused unnecessary confusion in tests. And using int
arithmetic is actually simpler.

Release justification: Low-risk update to new functionality.

Release note: None