### PR TITLE
ui: adding isTenant flag so the ui can hide necessary features 

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/store/uiConfig/uiConfig.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/uiConfig/uiConfig.reducer.ts
@@ -13,6 +13,7 @@ import { merge } from "lodash";
 import { DOMAIN_NAME } from "../utils";
 
 export type UIConfigState = {
+  isTenant: boolean;
   pages: {
     statementDetails: {
       showStatementDiagnosticsLink: boolean;
@@ -24,6 +25,7 @@ export type UIConfigState = {
 };
 
 const initialState: UIConfigState = {
+  isTenant: false,
   pages: {
     statementDetails: {
       showStatementDiagnosticsLink: true,


### PR DESCRIPTION
Some features or visuals will be different on serverless,
this commit is adding a flag that is updated by managed service when
is serverless, so each page can use it accordingly.

Release justification: Category 4
Release note: None