### PR TITLE
server: provide /_status/sessions on tenants

### DIFF
--- a/pkg/ccl/serverccl/tenant_grpc_test.go
+++ b/pkg/ccl/serverccl/tenant_grpc_test.go
@@ -149,4 +149,10 @@ func TestTenantGRPCServices(t *testing.T) {
 		require.Errorf(t, err, "statements endpoint should not be accessed on KV node by tenant")
 	})
 
+	t.Run("sessions endpoint is available", func(t *testing.T) {
+		resp, err := httputil.Get(ctx, "http://"+tenant.HTTPAddr()+"/_status/sessions")
+		defer http.DefaultClient.CloseIdleConnections()
+		require.NoError(t, err)
+		require.Equal(t, 200, resp.StatusCode)
+	})
 }

--- a/pkg/rpc/auth_tenant.go
+++ b/pkg/rpc/auth_tenant.go
@@ -68,6 +68,9 @@ func (a tenantAuthorizer) authorize(
 	case "/cockroach.server.serverpb.Status/Statements":
 		return a.authTenant(tenID)
 
+	case "/cockroach.server.serverpb.Status/ListSessions":
+		return a.authTenant(tenID)
+
 	default:
 		return authErrorf("unknown method %q", fullMethod)
 	}


### PR DESCRIPTION
Release justification: Category 2: Bug fixes and low-risk updates to new functionality.

Release note (api change): Tenant pods now expose the ListSessions API at `/_status/sessions` on their HTTP port.