### PR TITLE
bazel,ci: propagate `TEST_TMPDIR` down to go tests and capture artifacts

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,7 +12,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 # Load go bazel tools. This gives us access to the go bazel SDK/toolchains.
 git_repository(
     name = "io_bazel_rules_go",
-    commit = "91c4e2b0f233c7031b191b93587f562ffe21f86f",
+    commit = "4a7bcc9b9051eb6a12bcb03a9bf38138c4bbc2ea",
     remote = "https://github.com/cockroachdb/rules_go",
 )
 

--- a/pkg/cmd/bazci/bazci.go
+++ b/pkg/cmd/bazci/bazci.go
@@ -29,6 +29,7 @@ const (
 
 var (
 	artifactsDir    string
+	tmpDir          string
 	configs         []string
 	compilationMode string
 
@@ -53,6 +54,11 @@ func init() {
 		"artifacts_dir",
 		"/artifacts",
 		"path where artifacts should be staged")
+	rootCmd.Flags().StringVar(
+		&tmpDir,
+		"tmp_dir",
+		"/tmp/bazelbuild",
+		"path to temporary directory to use for tests")
 	rootCmd.Flags().StringVar(
 		&compilationMode,
 		"compilation_mode",
@@ -231,6 +237,9 @@ func bazciImpl(cmd *cobra.Command, args []string) error {
 		processArgs = append(processArgs, configArgList()...)
 		processArgs = append(processArgs, "-c", compilationMode)
 		processArgs = append(processArgs, parsedArgs.additional...)
+		if parsedArgs.subcmd == "test" {
+			processArgs = append(processArgs, fmt.Sprintf("--test_tmpdir=%s", tmpDir))
+		}
 		fmt.Println("running bazel w/ args: ", processArgs)
 		cmd := exec.Command("bazel", processArgs...)
 		cmd.Stdout = os.Stdout

--- a/pkg/cmd/bazci/watch.go
+++ b/pkg/cmd/bazci/watch.go
@@ -14,6 +14,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
+	"io/fs"
 	"io/ioutil"
 	"log"
 	"os"
@@ -103,8 +104,9 @@ func (w watcher) Watch() error {
 			// Note that even if the build failed, we still want to
 			// try to stage test artifacts.
 			testErr := w.stageTestArtifacts(finalizePhase)
-			// Also stage binary artifacts this time.
+			// Also stage binary and tmpdir artifacts this time.
 			binErr := w.stageBinaryArtifacts()
+			tmpErr := w.stageTmpDir()
 			// Only check errors after we're done staging all
 			// artifacts -- we don't want to miss anything because
 			// the build failed.
@@ -116,6 +118,9 @@ func (w watcher) Watch() error {
 			}
 			if binErr != nil {
 				return binErr
+			}
+			if tmpErr != nil {
+				return tmpErr
 			}
 			return nil
 		case <-time.After(10 * time.Second):
@@ -467,4 +472,45 @@ func (w watcher) maybeStageArtifact(
 		}
 	}
 	return nil
+}
+
+// stageTmpDir stages the contents of the tmpDir to $artifactsDir/tmp. As with
+// binary artifacts, we only ever stage them during the finalize phase.
+func (w watcher) stageTmpDir() error {
+	if len(w.info.tests) == 0 {
+		return nil
+	}
+	return filepath.WalkDir(tmpDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			log.Printf("WARNING: failing to stage tmpdir artifact at %s due to error %v", path, err)
+			return nil
+		}
+		if d.IsDir() {
+			if filepath.Base(path) == ".gocache" {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		src, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer src.Close()
+		relPath, err := filepath.Rel(tmpDir, path)
+		if err != nil {
+			return err
+		}
+		dstPath := filepath.Join(artifactsDir, "tmp", relPath)
+		err = os.MkdirAll(filepath.Dir(dstPath), 0777)
+		if err != nil {
+			return err
+		}
+		dst, err := os.Create(dstPath)
+		if err != nil {
+			return err
+		}
+		defer dst.Close()
+		_, err = io.Copy(dst, src)
+		return err
+	})
 }

--- a/pkg/cmd/bazci/watch_test.go
+++ b/pkg/cmd/bazci/watch_test.go
@@ -39,6 +39,9 @@ func TestWatch(t *testing.T) {
 	dir, cleanup := testutils.TempDir(t)
 	defer cleanup()
 	artifactsDir = dir
+	dir, cleanup = testutils.TempDir(t)
+	defer cleanup()
+	tmpDir = dir
 	testdata := testutils.TestDataPath(t)
 	info := buildInfo{
 		binDir:      path.Join(testdata, "bazel-bin"),


### PR DESCRIPTION
This fulfills a long-standing request to capture left-over artifacts in
`TMPDIR` (see #59045 (comment)).

Bazel sets the `TEST_TMPDIR` environment variable for the temporary
directory and expects all tests to write temporary files to that
directory. In our Go tests, however, we consult the `TMPDIR` environment
variable to find that directory. So we pull in a custom change to
`rules_go` to copy `TEST_TMPDIR` to `TMPDIR`. Update `.bazelrc` to use
`/artifacts/tmp` as the `TEST_TMPDIR`.

Closes #59045.
Closes #69372.

Release justification: Non-production code change
Release note: None