### PR TITLE
admission,goschedstats: reduce scheduler sampling frequency when unde…

### DIFF
--- a/pkg/util/admission/testdata/granter
+++ b/pkg/util/admission/testdata/granter
@@ -366,3 +366,83 @@ kv: granted in chain 0, and returning true
 GrantCoordinator:
 (chain: id: 6 active: false index: 0) kv: used: 3, total: 3 io-avail: 0 sql-kv-response: avail: 0
 sql-sql-response: avail: 1 sql-leaf-start: used: 2, total: 2 sql-root-start: used: 1, total: 1
+
+#####################################################################
+# Test skipping of enforcements when CPULoad has high sampling period.
+init-grant-coordinator min-cpu=1 max-cpu=3 sql-kv-tokens=1 sql-sql-tokens=1 sql-leaf=2 sql-root=2
+----
+GrantCoordinator:
+(chain: id: 1 active: false index: 0) kv: used: 0, total: 1 sql-kv-response: avail: 1
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 2
+
+# No more slots after this slot is granted.
+try-get work=kv
+----
+kv: tryGet returned true
+GrantCoordinator:
+(chain: id: 1 active: false index: 0) kv: used: 1, total: 1 sql-kv-response: avail: 1
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 2
+
+# Since no more KV slots, cannot grant token to sql-kv-response.
+try-get work=sql-kv-response
+----
+sql-kv-response: tryGet returned false
+GrantCoordinator:
+(chain: id: 1 active: false index: 0) kv: used: 1, total: 1 sql-kv-response: avail: 1
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 2
+
+# Since no more KV slots, cannot grant token to sql-sql-response.
+try-get work=sql-sql-response
+----
+sql-sql-response: tryGet returned false
+GrantCoordinator:
+(chain: id: 1 active: false index: 0) kv: used: 1, total: 1 sql-kv-response: avail: 1
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 2
+
+# CPULoad shows overload, so cannot increase KV slots, but since it is
+# infrequent, slot and token enforcement is disabled.
+cpu-load runnable=20 procs=1 infrequent=true
+----
+GrantCoordinator:
+(chain: id: 1 active: false index: 5) kv: used: 1, total: 1 sql-kv-response: avail: 1
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 2
+
+# sql-kv-response can get a token.
+try-get work=sql-kv-response
+----
+sql-kv-response: tryGet returned true
+GrantCoordinator:
+(chain: id: 1 active: false index: 5) kv: used: 1, total: 1 sql-kv-response: avail: 0
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 2
+
+# sql-kv-response can get another token, even though tokens are exhausted.
+try-get work=sql-kv-response
+----
+sql-kv-response: tryGet returned true
+GrantCoordinator:
+(chain: id: 1 active: false index: 5) kv: used: 1, total: 1 sql-kv-response: avail: -1
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 2
+
+# sql-sql-response can get a token.
+try-get work=sql-sql-response
+----
+sql-sql-response: tryGet returned true
+GrantCoordinator:
+(chain: id: 1 active: false index: 5) kv: used: 1, total: 1 sql-kv-response: avail: -1
+sql-sql-response: avail: 0 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 2
+
+# sql-sql-response can get another token, even though tokens are exhausted.
+try-get work=sql-sql-response
+----
+sql-sql-response: tryGet returned true
+GrantCoordinator:
+(chain: id: 1 active: false index: 5) kv: used: 1, total: 1 sql-kv-response: avail: -1
+sql-sql-response: avail: -1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 2
+
+# KV can get another slot even though slots are exhausted.
+try-get work=kv
+----
+kv: tryGet returned true
+GrantCoordinator:
+(chain: id: 1 active: false index: 5) kv: used: 2, total: 1 sql-kv-response: avail: -1
+sql-sql-response: avail: -1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 2

--- a/pkg/util/goschedstats/BUILD.bazel
+++ b/pkg/util/goschedstats/BUILD.bazel
@@ -19,5 +19,9 @@ go_test(
     name = "goschedstats_test",
     srcs = ["runnable_test.go"],
     embed = [":goschedstats"],
-    deps = ["//pkg/testutils"],
+    deps = [
+        "//pkg/testutils",
+        "//pkg/util/timeutil",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/pkg/util/goschedstats/runnable_test.go
+++ b/pkg/util/goschedstats/runnable_test.go
@@ -14,8 +14,11 @@ import (
 	"fmt"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNumRunnableGoroutines(t *testing.T) {
@@ -38,4 +41,78 @@ func TestNumRunnableGoroutines(t *testing.T) {
 		}
 		return nil
 	})
+}
+
+type testTimeTicker struct {
+	numResets         int
+	lastResetDuration time.Duration
+}
+
+func (t *testTimeTicker) Reset(d time.Duration) {
+	t.numResets++
+	t.lastResetDuration = d
+}
+
+func TestSchedStatsTicker(t *testing.T) {
+	runnable := 0
+	numRunnable := func() (numRunnable int, numProcs int) {
+		return runnable, 1
+	}
+	var callbackSamplePeriod time.Duration
+	var numCallbacks int
+	cb := func(numRunnable int, numProcs int, samplePeriod time.Duration) {
+		require.Equal(t, runnable, numRunnable)
+		require.Equal(t, 1, numProcs)
+		callbackSamplePeriod = samplePeriod
+		numCallbacks++
+	}
+	cbs := []callbackWithID{{cb, 0}}
+	now := timeutil.UnixEpoch
+	startTime := now
+	sst := schedStatsTicker{
+		lastTime:              now,
+		curPeriod:             samplePeriodShort,
+		numRunnableGoroutines: numRunnable,
+	}
+	tt := testTimeTicker{}
+	// Tick every 1ms until the reportingPeriod has elapsed.
+	for i := 1; ; i++ {
+		now = now.Add(samplePeriodShort)
+		sst.getStatsOnTick(now, cbs, &tt)
+		if now.Sub(startTime) <= reportingPeriod {
+			// No reset of the time ticker.
+			require.Equal(t, 0, tt.numResets)
+			// Each tick causes a callback.
+			require.Equal(t, i, numCallbacks)
+			require.Equal(t, samplePeriodShort, callbackSamplePeriod)
+		} else {
+			break
+		}
+	}
+	// Since underloaded, the time ticker is reset to samplePeriodLong, and this
+	// period is provided to the latest callback.
+	require.Equal(t, 1, tt.numResets)
+	require.Equal(t, samplePeriodLong, tt.lastResetDuration)
+	require.Equal(t, samplePeriodLong, callbackSamplePeriod)
+	// Increase load so no longer underloaded.
+	runnable = 2
+	startTime = now
+	tt.numResets = 0
+	for i := 1; ; i++ {
+		now = now.Add(samplePeriodLong)
+		sst.getStatsOnTick(now, cbs, &tt)
+		if now.Sub(startTime) <= reportingPeriod {
+			// No reset of the time ticker.
+			require.Equal(t, 0, tt.numResets)
+			// Each tick causes a callback.
+			require.Equal(t, samplePeriodLong, callbackSamplePeriod)
+		} else {
+			break
+		}
+	}
+	// No longer underloaded, so the time ticker is reset to samplePeriodShort,
+	// and this period is provided to the latest callback.
+	require.Equal(t, 1, tt.numResets)
+	require.Equal(t, samplePeriodShort, tt.lastResetDuration)
+	require.Equal(t, samplePeriodShort, callbackSamplePeriod)
 }


### PR DESCRIPTION
…rloaded

The kvSlotAdjuster keeps track of a history of CPULoad ticks
to decide whether sufficient fraction of that history was
underloaded or not. If underloaded we disable slot and token
enforcement in kvGranter and tokenGranter since the reduced
frequency of CPULoad could cause us to not adjust slots fast
enough. This information is fed back to goschedstats so that
it can adjust the period of the ticker.

Fixes #66881

Release justification: Fix for high-priority issue in new
functionality.

Release note: None