### PR TITLE
sql: fix reassign owned by privilege checks

### DIFF
--- a/pkg/sql/alter_type.go
+++ b/pkg/sql/alter_type.go
@@ -404,7 +404,22 @@ func (p *planner) alterTypeOwner(
 		return err
 	}
 
-	if err := p.checkCanAlterTypeAndSetNewOwner(ctx, typeDesc, arrayDesc, newOwner); err != nil {
+	if err := p.checkCanAlterToNewOwner(ctx, typeDesc, newOwner); err != nil {
+		return err
+	}
+
+	// Ensure the new owner has CREATE privilege on the type's schema.
+	if err := p.canCreateOnSchema(
+		ctx, typeDesc.GetParentSchemaID(), typeDesc.ParentID, newOwner, checkPublicSchema); err != nil {
+		return err
+	}
+
+	typeNameWithPrefix := tree.MakeTypeNameWithPrefix(n.prefix.NamePrefix(), typeDesc.GetName())
+
+	arrayTypeNameWithPrefix := tree.MakeTypeNameWithPrefix(n.prefix.NamePrefix(), arrayDesc.GetName())
+
+	if err := p.setNewTypeOwner(ctx, typeDesc, arrayDesc, typeNameWithPrefix,
+		arrayTypeNameWithPrefix, newOwner); err != nil {
 		return err
 	}
 
@@ -424,24 +439,16 @@ func (p *planner) alterTypeOwner(
 	)
 }
 
-// checkCanAlterTypeAndSetNewOwner handles privilege checking and setting new owner.
+// setNewTypeOwner handles setting a new type owner.
 // Called in ALTER TYPE and REASSIGN OWNED BY.
-func (p *planner) checkCanAlterTypeAndSetNewOwner(
+func (p *planner) setNewTypeOwner(
 	ctx context.Context,
 	typeDesc *typedesc.Mutable,
 	arrayTypeDesc *typedesc.Mutable,
+	typeName tree.TypeName,
+	arrayTypeName tree.TypeName,
 	newOwner security.SQLUsername,
 ) error {
-	if err := p.checkCanAlterToNewOwner(ctx, typeDesc, newOwner); err != nil {
-		return err
-	}
-
-	// Ensure the new owner has CREATE privilege on the type's schema.
-	if err := p.canCreateOnSchema(
-		ctx, typeDesc.GetParentSchemaID(), typeDesc.ParentID, newOwner, checkPublicSchema); err != nil {
-		return err
-	}
-
 	privs := typeDesc.GetPrivileges()
 	privs.SetOwner(newOwner)
 
@@ -451,9 +458,7 @@ func (p *planner) checkCanAlterTypeAndSetNewOwner(
 	if err := p.logEvent(ctx,
 		typeDesc.GetID(),
 		&eventpb.AlterTypeOwner{
-			// TODO(knz): This name is insufficiently qualified.
-			// See: https://github.com/cockroachdb/cockroach/issues/57734
-			TypeName: typeDesc.GetName(),
+			TypeName: typeName.FQString(),
 			Owner:    newOwner.Normalized(),
 		}); err != nil {
 		return err
@@ -461,9 +466,7 @@ func (p *planner) checkCanAlterTypeAndSetNewOwner(
 	return p.logEvent(ctx,
 		arrayTypeDesc.GetID(),
 		&eventpb.AlterTypeOwner{
-			// TODO(knz): This name is insufficiently qualified.
-			// See: https://github.com/cockroachdb/cockroach/issues/57734
-			TypeName: arrayTypeDesc.GetName(),
+			TypeName: arrayTypeName.FQString(),
 			Owner:    newOwner.Normalized(),
 		})
 }

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -821,8 +821,8 @@ ORDER BY "timestamp", info
 1  alter_database_owner  {"DatabaseName": "atest", "EventType": "alter_database_owner", "Owner": "u", "Statement": "ALTER DATABASE atest OWNER TO u", "Tag": "ALTER DATABASE OWNER", "User": "root"}
 1  alter_schema_owner    {"EventType": "alter_schema_owner", "Owner": "u", "SchemaName": "atest.sc", "Statement": "ALTER SCHEMA atest.sc OWNER TO u", "Tag": "ALTER SCHEMA", "User": "root"}
 1  alter_table_owner     {"EventType": "alter_table_owner", "Owner": "u", "Statement": "ALTER TABLE atest.sc.t OWNER TO u", "TableName": "atest.sc.t", "Tag": "ALTER TABLE OWNER", "User": "root"}
-1  alter_type_owner      {"EventType": "alter_type_owner", "Owner": "u", "Statement": "ALTER TYPE atest.sc.ty OWNER TO u", "Tag": "ALTER TYPE", "TypeName": "ty", "User": "root"}
-1  alter_type_owner      {"EventType": "alter_type_owner", "Owner": "u", "Statement": "ALTER TYPE atest.sc.ty OWNER TO u", "Tag": "ALTER TYPE", "TypeName": "_ty", "User": "root"}
+1  alter_type_owner      {"EventType": "alter_type_owner", "Owner": "u", "Statement": "ALTER TYPE atest.sc.ty OWNER TO u", "Tag": "ALTER TYPE", "TypeName": "atest.sc.ty", "User": "root"}
+1  alter_type_owner      {"EventType": "alter_type_owner", "Owner": "u", "Statement": "ALTER TYPE atest.sc.ty OWNER TO u", "Tag": "ALTER TYPE", "TypeName": "atest.sc._ty", "User": "root"}
 
 subtest alter_owner
 
@@ -862,8 +862,8 @@ ORDER BY "timestamp", info
 1  alter_table_owner     {"EventType": "alter_table_owner", "Owner": "v", "Statement": "REASSIGN OWNED BY testuser TO v", "TableName": "atest.sc.t", "Tag": "REASSIGN OWNED BY", "User": "root"}
 1  alter_table_owner     {"EventType": "alter_table_owner", "Owner": "v", "Statement": "REASSIGN OWNED BY testuser TO v", "TableName": "atest.sc.v", "Tag": "REASSIGN OWNED BY", "User": "root"}
 1  alter_table_owner     {"EventType": "alter_table_owner", "Owner": "v", "Statement": "REASSIGN OWNED BY testuser TO v", "TableName": "atest.sc.s", "Tag": "REASSIGN OWNED BY", "User": "root"}
-1  alter_type_owner      {"EventType": "alter_type_owner", "Owner": "v", "Statement": "REASSIGN OWNED BY testuser TO v", "Tag": "REASSIGN OWNED BY", "TypeName": "ty", "User": "root"}
-1  alter_type_owner      {"EventType": "alter_type_owner", "Owner": "v", "Statement": "REASSIGN OWNED BY testuser TO v", "Tag": "REASSIGN OWNED BY", "TypeName": "_ty", "User": "root"}
+1  alter_type_owner      {"EventType": "alter_type_owner", "Owner": "v", "Statement": "REASSIGN OWNED BY testuser TO v", "Tag": "REASSIGN OWNED BY", "TypeName": "atest.sc.ty", "User": "root"}
+1  alter_type_owner      {"EventType": "alter_type_owner", "Owner": "v", "Statement": "REASSIGN OWNED BY testuser TO v", "Tag": "REASSIGN OWNED BY", "TypeName": "atest.sc._ty", "User": "root"}
 
 statement ok
 USE defaultdb

--- a/pkg/sql/logictest/testdata/logic_test/reassign_owned_by
+++ b/pkg/sql/logictest/testdata/logic_test/reassign_owned_by
@@ -10,6 +10,17 @@ CREATE ROLE old_role;
 GRANT CREATE ON DATABASE test TO old_role;
 ALTER TABLE t OWNER TO old_role
 
+user testuser
+
+# Ensure the current user is a member of the old roles.
+statement error pq: permission denied to reassign objects\nHINT: user must be a member of the old roles
+REASSIGN OWNED BY old_role TO testuser
+
+statement error pq: permission denied to reassign objects\nHINT: user must be a member of the old roles
+REASSIGN OWNED BY testuser, old_role TO testuser
+
+user root
+
 # Make testuser a member of old_role.
 statement ok
 GRANT old_role TO testuser
@@ -29,8 +40,11 @@ GRANT CREATE ON DATABASE test TO new_role
 user testuser
 
 # Ensure the current user is a member of the role we're setting to.
-statement error pq: must be member of role "new_role"
+statement error pq: permission denied to reassign objects\nHINT: user must be a member of the new role
 REASSIGN OWNED BY old_role TO new_role
+
+statement error pq: permission denied to reassign objects\nHINT: user must be a member of the new role
+REASSIGN OWNED BY old_role, testuser TO new_role
 
 user root
 
@@ -50,11 +64,7 @@ DROP TABLE t
 user root
 
 statement ok
-GRANT testuser TO root
-
-statement ok
 CREATE ROLE testuser2 WITH LOGIN;
-GRANT testuser2 TO root
 
 # Create database for old role
 statement ok
@@ -97,7 +107,6 @@ DROP ROLE testuser
 statement ok
 use test;
 CREATE ROLE testuser;
-GRANT testuser TO root
 
 # Create schema for testuser and one for root.
 statement ok
@@ -113,6 +122,9 @@ SELECT nspname, nspowner FROM pg_namespace WHERE nspname='s1' OR nspname='s2'
 ----
 s1  2264919399
 s2  1546506610
+
+# root / superusers can always perform REASSIGN OWNED BY.
+user root
 
 statement ok
 REASSIGN OWNED BY testuser, root TO testuser2
@@ -268,7 +280,6 @@ t2  testuser
 
 statement ok
 CREATE ROLE testuser2;
-GRANT testuser2 TO root;
 GRANT CREATE ON DATABASE test TO testuser2
 
 statement ok

--- a/pkg/sql/reassign_owned_by.go
+++ b/pkg/sql/reassign_owned_by.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
+	"github.com/cockroachdb/errors"
 )
 
 // ReassignOwnedByNode represents a REASSIGN OWNED BY <role(s)> TO <role> statement.
@@ -48,6 +49,7 @@ func (p *planner) ReassignOwnedBy(ctx context.Context, n *tree.ReassignOwnedBy) 
 	}
 	// Check all roles in old roles exist. Checks in authorization.go will confirm that current user
 	// is a member of old roles and new roles and has CREATE privilege.
+	// Postgres first checks if the role exists before checking privileges.
 	for _, oldRole := range normalizedOldRole {
 		roleExists, err := RoleExists(ctx, p.ExecCfg(), p.Txn(), oldRole)
 		if err != nil {
@@ -55,6 +57,46 @@ func (p *planner) ReassignOwnedBy(ctx context.Context, n *tree.ReassignOwnedBy) 
 		}
 		if !roleExists {
 			return nil, pgerror.Newf(pgcode.UndefinedObject, "role/user %q does not exist", oldRole)
+		}
+	}
+	roleExists, err := RoleExists(ctx, p.ExecCfg(), p.Txn(), n.NewRole)
+	if !roleExists {
+		return nil, pgerror.Newf(pgcode.UndefinedObject, "role/user %q does not exist", n.NewRole)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	hasAdminRole, err := p.HasAdminRole(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// The current user must either be an admin or we have to check that
+	// the current user is a member of both the new roles and all the
+	// old roles.
+	if !hasAdminRole {
+		memberOf, err := p.MemberOfWithAdminOption(ctx, p.User())
+		if err != nil {
+			return nil, err
+		}
+		if p.User() != n.NewRole {
+			if _, ok := memberOf[n.NewRole]; !ok {
+				return nil, errors.WithHint(
+					pgerror.Newf(pgcode.InsufficientPrivilege,
+						"permission denied to reassign objects"),
+					"user must be a member of the new role")
+			}
+		}
+		for _, oldRole := range normalizedOldRole {
+			if p.User() != oldRole {
+				if _, ok := memberOf[oldRole]; !ok {
+					return nil, errors.WithHint(
+						pgerror.Newf(pgcode.InsufficientPrivilege,
+							"permission denied to reassign objects"),
+						"user must be a member of the old roles")
+				}
+			}
 		}
 	}
 	return &reassignOwnedByNode{n: n, normalizedOldRoles: normalizedOldRole}, nil
@@ -91,7 +133,7 @@ func (n *reassignOwnedByNode) startExec(params runParams) error {
 		}
 		for _, schemaID := range lCtx.schemaIDs {
 			if IsOwner(lCtx.schemaDescs[schemaID], oldRole) {
-				if err := n.reassignSchemaOwner(lCtx.schemaDescs[schemaID], params); err != nil {
+				if err := n.reassignSchemaOwner(lCtx.schemaDescs[schemaID], currentDbDesc, params); err != nil {
 					return err
 				}
 			}
@@ -121,8 +163,7 @@ func (n *reassignOwnedByNode) reassignDatabaseOwner(
 	if err != nil {
 		return err
 	}
-	if err := params.p.checkCanAlterDatabaseAndSetNewOwner(params.ctx,
-		mutableDbDesc.(*dbdesc.Mutable), n.n.NewRole); err != nil {
+	if err := params.p.setNewDatabaseOwner(params.ctx, mutableDbDesc, n.n.NewRole); err != nil {
 		return err
 	}
 	if err := params.p.writeNonDropDatabaseChange(
@@ -136,15 +177,15 @@ func (n *reassignOwnedByNode) reassignDatabaseOwner(
 }
 
 func (n *reassignOwnedByNode) reassignSchemaOwner(
-	schemaDesc catalog.SchemaDescriptor, params runParams,
+	schemaDesc catalog.SchemaDescriptor, dbDesc *dbdesc.Mutable, params runParams,
 ) error {
 	mutableSchemaDesc, err := params.p.Descriptors().GetMutableDescriptorByID(
 		params.ctx, schemaDesc.GetID(), params.p.txn)
 	if err != nil {
 		return err
 	}
-	if err := params.p.checkCanAlterSchemaAndSetNewOwner(
-		params.ctx, mutableSchemaDesc.(*schemadesc.Mutable), n.n.NewRole); err != nil {
+	if err := params.p.setNewSchemaOwner(
+		params.ctx, dbDesc, mutableSchemaDesc.(*schemadesc.Mutable), n.n.NewRole); err != nil {
 		return err
 	}
 	if err := params.p.writeSchemaDescChange(params.ctx,
@@ -164,8 +205,14 @@ func (n *reassignOwnedByNode) reassignTableOwner(
 	if err != nil {
 		return err
 	}
-	if err := params.p.checkCanAlterTableAndSetNewOwner(
-		params.ctx, mutableTbDesc.(*tabledesc.Mutable), n.n.NewRole); err != nil {
+
+	tableName, err := params.p.getQualifiedTableName(params.ctx, tbDesc)
+	if err != nil {
+		return err
+	}
+
+	if err := params.p.setNewTableOwner(
+		params.ctx, mutableTbDesc.(*tabledesc.Mutable), *tableName, n.n.NewRole); err != nil {
 		return err
 	}
 	if err := params.p.writeSchemaChange(
@@ -189,8 +236,19 @@ func (n *reassignOwnedByNode) reassignTypeOwner(
 	if err != nil {
 		return err
 	}
-	if err := params.p.checkCanAlterTypeAndSetNewOwner(
-		params.ctx, mutableTypDesc.(*typedesc.Mutable), arrayDesc, n.n.NewRole); err != nil {
+
+	typeName, err := params.p.getQualifiedTypeName(params.ctx, mutableTypDesc.(*typedesc.Mutable))
+	if err != nil {
+		return err
+	}
+	arrayTypeName, err := params.p.getQualifiedTypeName(params.ctx, arrayDesc)
+	if err != nil {
+		return err
+	}
+
+	if err := params.p.setNewTypeOwner(
+		params.ctx, mutableTypDesc.(*typedesc.Mutable), arrayDesc, *typeName,
+		*arrayTypeName, n.n.NewRole); err != nil {
 		return err
 	}
 	if err := params.p.writeTypeSchemaChange(


### PR DESCRIPTION
 sql: fix reassign owned by privilege checks

  Release justification: low risk bug fix, only privilege check

  Release note (sql change): To perform REASSIGN OWNED BY, the current user
  running the command must be a member of both the old and new roles.

  Previously the new owner would need (this is not necessary in PG)
  - CREATEDB role option if object being changed is a database
  - CREATE privilege for the database if object being changed is a schema
  - CREATE privilege for the schema if object being changed is a table or type

Resolves https://github.com/cockroachdb/cockroach/issues/68519