### PR TITLE
kv/kvnemesis: add logging of operations prior to applying them

### DIFF
--- a/pkg/kv/kvnemesis/kvnemesis.go
+++ b/pkg/kv/kvnemesis/kvnemesis.go
@@ -60,8 +60,11 @@ func RunNemesis(
 
 			recCtx, collect, cancel := tracing.ContextWithRecordingSpan(
 				ctx, tracing.NewTracer(), "txn step")
+			buf.Reset()
+			fmt.Fprintf(&buf, "step:")
+			step.format(&buf, formatCtx{indent: `  ` + workerName + ` PRE  `})
+			log.VEventf(recCtx, 2, "%v", buf.String())
 			err := a.Apply(recCtx, &step)
-			log.VEventf(recCtx, 2, "step: %v", step)
 			step.Trace = collect().String()
 			cancel()
 			if err != nil {


### PR DESCRIPTION
While previously kvnemesis only logged the operations it applied to the
cluster after they completed, with this change we will log the
operations prior to starting them to increase visibility into what is
happening when errors may occur.

Release justification: Non-production code change.
Release note: None

Closes #68789