### PR TITLE
changefeedccl: Implement backfill pushback.

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -78,7 +78,7 @@ type changeAggregator struct {
 	resolvedSpanBuf encDatumRowBuffer
 
 	// eventProducer produces the next event from the kv feed.
-	eventProducer kvEventProducer
+	eventProducer kvevent.Reader
 	// eventConsumer consumes the event.
 	eventConsumer kvEventConsumer
 
@@ -257,26 +257,36 @@ func (ca *changeAggregator) Start(ctx context.Context) {
 	ca.sink = makeMetricsSink(ca.metrics, ca.sink)
 	ca.sink = &errorWrapperSink{wrapped: ca.sink}
 
-	cfg := ca.flowCtx.Cfg
-	buf := kvevent.NewThrottlingBuffer(
-		kvevent.MakeChanBuffer(), cdcutils.NodeLevelThrottler(&cfg.Settings.SV))
-	kvfeedCfg := makeKVFeedCfg(ctx, ca.flowCtx.Cfg, ca.kvFeedMemMon,
-		ca.spec, spans, buf, ca.metrics, ca.knobs.FeedKnobs)
-
-	ca.eventProducer = &bufEventProducer{buf}
+	initialHighWater, needsInitialScan := getKVFeedInitialParameters(ca.spec)
+	ca.eventProducer, err = ca.startKVFeed(ctx, spans, initialHighWater, needsInitialScan)
+	if err != nil {
+		// Early abort in the case that there is an error creating the sink.
+		ca.MoveToDraining(err)
+		ca.cancel()
+		return
+	}
 
 	if ca.spec.Feed.Opts[changefeedbase.OptFormat] == string(changefeedbase.OptFormatNative) {
 		ca.eventConsumer = newNativeKVConsumer(ca.sink)
 	} else {
 		ca.eventConsumer = newKVEventToRowConsumer(
-			ctx, cfg, ca.frontier.SpanFrontier(), kvfeedCfg.InitialHighWater,
+			ctx, ca.flowCtx.Cfg, ca.frontier.SpanFrontier(), initialHighWater,
 			ca.sink, ca.encoder, ca.spec.Feed, ca.knobs)
 	}
-
-	ca.startKVFeed(ctx, kvfeedCfg)
 }
 
-func (ca *changeAggregator) startKVFeed(ctx context.Context, kvfeedCfg kvfeed.Config) {
+func (ca *changeAggregator) startKVFeed(
+	ctx context.Context, spans []roachpb.Span, initialHighWater hlc.Timestamp, needsInitialScan bool,
+) (kvevent.Reader, error) {
+	cfg := ca.flowCtx.Cfg
+	buf := kvevent.NewThrottlingBuffer(
+		kvevent.NewMemBuffer(ca.kvFeedMemMon.MakeBoundAccount(), &cfg.Settings.SV, &ca.metrics.KVFeedMetrics),
+		cdcutils.NodeLevelThrottler(&cfg.Settings.SV))
+
+	// KVFeed takes ownership of the kvevent.Writer portion of the buffer, while
+	// we return the kvevent.Reader part to the caller.
+	kvfeedCfg := ca.makeKVFeedCfg(ctx, spans, buf, initialHighWater, needsInitialScan)
+
 	// Give errCh enough buffer both possible errors from supporting goroutines,
 	// but only the first one is ever used.
 	ca.errCh = make(chan error, 2)
@@ -294,43 +304,33 @@ func (ca *changeAggregator) startKVFeed(ctx context.Context, kvfeedCfg kvfeed.Co
 		close(ca.kvFeedDoneCh)
 		ca.errCh <- err
 		ca.cancel()
+		return nil, err
 	}
+
+	return buf, nil
 }
 
-func newSchemaFeed(
+func (ca *changeAggregator) makeKVFeedCfg(
 	ctx context.Context,
-	cfg *execinfra.ServerConfig,
-	spec execinfrapb.ChangeAggregatorSpec,
-	metrics *Metrics,
-) schemafeed.SchemaFeed {
-	schemaChangePolicy := changefeedbase.SchemaChangePolicy(
-		spec.Feed.Opts[changefeedbase.OptSchemaChangePolicy])
-	if schemaChangePolicy == changefeedbase.OptSchemaChangePolicyIgnore {
-		return schemafeed.DoNothingSchemaFeed
-	}
-	schemaChangeEvents := changefeedbase.SchemaChangeEventClass(
-		spec.Feed.Opts[changefeedbase.OptSchemaChangeEvents])
-	initialHighWater, _ := getKVFeedInitialParameters(spec)
-	return schemafeed.New(ctx, cfg, schemaChangeEvents,
-		spec.Feed.Targets, initialHighWater, &metrics.SchemaFeedMetrics)
-}
-
-func makeKVFeedCfg(
-	ctx context.Context,
-	cfg *execinfra.ServerConfig,
-	mm *mon.BytesMonitor,
-	spec execinfrapb.ChangeAggregatorSpec,
 	spans []roachpb.Span,
-	buf kvevent.Buffer,
-	metrics *Metrics,
-	knobs kvfeed.TestingKnobs,
+	buf kvevent.Writer,
+	initialHighWater hlc.Timestamp,
+	needsInitialScan bool,
 ) kvfeed.Config {
 	schemaChangeEvents := changefeedbase.SchemaChangeEventClass(
-		spec.Feed.Opts[changefeedbase.OptSchemaChangeEvents])
+		ca.spec.Feed.Opts[changefeedbase.OptSchemaChangeEvents])
 	schemaChangePolicy := changefeedbase.SchemaChangePolicy(
-		spec.Feed.Opts[changefeedbase.OptSchemaChangePolicy])
-	_, withDiff := spec.Feed.Opts[changefeedbase.OptDiff]
-	initialHighWater, needsInitialScan := getKVFeedInitialParameters(spec)
+		ca.spec.Feed.Opts[changefeedbase.OptSchemaChangePolicy])
+	_, withDiff := ca.spec.Feed.Opts[changefeedbase.OptDiff]
+	cfg := ca.flowCtx.Cfg
+
+	var sf schemafeed.SchemaFeed
+	if schemaChangePolicy == changefeedbase.OptSchemaChangePolicyIgnore {
+		sf = schemafeed.DoNothingSchemaFeed
+	} else {
+		sf = schemafeed.New(ctx, cfg, schemaChangeEvents, ca.spec.Feed.Targets,
+			initialHighWater, &ca.metrics.SchemaFeedMetrics)
+	}
 
 	return kvfeed.Config{
 		Writer:             buf,
@@ -340,17 +340,17 @@ func makeKVFeedCfg(
 		Clock:              cfg.DB.Clock(),
 		Gossip:             cfg.Gossip,
 		Spans:              spans,
-		BackfillCheckpoint: spec.Checkpoint.Spans,
-		Targets:            spec.Feed.Targets,
-		Metrics:            &metrics.KVFeedMetrics,
-		MM:                 mm,
+		BackfillCheckpoint: ca.spec.Checkpoint.Spans,
+		Targets:            ca.spec.Feed.Targets,
+		Metrics:            &ca.metrics.KVFeedMetrics,
+		MM:                 ca.kvFeedMemMon,
 		InitialHighWater:   initialHighWater,
 		WithDiff:           withDiff,
 		NeedsInitialScan:   needsInitialScan,
 		SchemaChangeEvents: schemaChangeEvents,
 		SchemaChangePolicy: schemaChangePolicy,
-		SchemaFeed:         newSchemaFeed(ctx, cfg, spec, metrics),
-		Knobs:              knobs,
+		SchemaFeed:         sf,
+		Knobs:              ca.knobs.FeedKnobs,
 	}
 }
 
@@ -426,6 +426,7 @@ func (ca *changeAggregator) close() {
 				log.Warningf(ca.Ctx, `error closing sink. goroutines may have leaked: %v`, err)
 			}
 		}
+
 		ca.memAcc.Close(ca.Ctx)
 		if ca.kvFeedMemMon != nil {
 			ca.kvFeedMemMon.Stop(ca.Ctx)
@@ -469,7 +470,7 @@ func (ca *changeAggregator) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMet
 // kvFeed, sends off this event to the event consumer, and flushes the sink
 // if necessary.
 func (ca *changeAggregator) tick() error {
-	event, err := ca.eventProducer.GetEvent(ca.Ctx)
+	event, err := ca.eventProducer.Get(ca.Ctx)
 	if err != nil {
 		return err
 	}
@@ -489,7 +490,8 @@ func (ca *changeAggregator) tick() error {
 	case kvevent.TypeKV:
 		return ca.eventConsumer.ConsumeEvent(ca.Ctx, event)
 	case kvevent.TypeResolved:
-		event.DetachAlloc().Release(ca.Ctx)
+		a := event.DetachAlloc()
+		a.Release(ca.Ctx)
 		resolved := event.Resolved()
 		if ca.knobs.ShouldSkipResolved == nil || !ca.knobs.ShouldSkipResolved(resolved) {
 			return ca.noteResolvedSpan(resolved)
@@ -572,22 +574,6 @@ func (ca *changeAggregator) emitResolved(batch jobspb.ResolvedSpans) error {
 func (ca *changeAggregator) ConsumerClosed() {
 	// The consumer is done, Next() will not be called again.
 	ca.close()
-}
-
-type kvEventProducer interface {
-	// GetEvent returns the next kv event.
-	GetEvent(ctx context.Context) (kvevent.Event, error)
-}
-
-type bufEventProducer struct {
-	kvevent.Reader
-}
-
-var _ kvEventProducer = &bufEventProducer{}
-
-// GetEvent implements kvEventProducer interface
-func (p *bufEventProducer) GetEvent(ctx context.Context) (kvevent.Event, error) {
-	return p.Get(ctx)
 }
 
 type kvEventConsumer interface {

--- a/pkg/ccl/changefeedccl/kvevent/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/kvevent/BUILD.bazel
@@ -33,9 +33,12 @@ go_library(
 
 go_test(
     name = "kvevent_test",
-    srcs = ["blocking_buffer_test.go"],
+    srcs = [
+        "alloc_test.go",
+        "blocking_buffer_test.go",
+    ],
+    embed = [":kvevent"],
     deps = [
-        ":kvevent",
         "//pkg/keys",
         "//pkg/roachpb:with-mocks",
         "//pkg/settings/cluster",
@@ -50,6 +53,7 @@ go_test(
         "//pkg/util/mon",
         "//pkg/util/quotapool",
         "//pkg/util/randutil",
+        "//pkg/util/syncutil",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/ccl/changefeedccl/kvevent/alloc.go
+++ b/pkg/ccl/changefeedccl/kvevent/alloc.go
@@ -18,30 +18,14 @@ type Alloc struct {
 	bytes   int64 // memory allocated for this request.
 	entries int64 // number of entries using those bytes, usually 1.
 	ap      pool  // pool where those resources ought to be released.
-}
 
-// Release releases resources associated with this allocation.
-func (a Alloc) Release(ctx context.Context) {
-	if a.ap != nil {
-		a.ap.Release(ctx, a.bytes, a.entries)
-	}
-}
-
-// Merge merges other resources into this allocation.
-func (a *Alloc) Merge(other *Alloc) {
-	if a.ap == nil {
-		// Okay to merge into nil allocation -- just use the other.
-		*a = *other
-		return
-	}
-
-	if a.ap != other.ap {
-		panic("cannot merge allocations from two different pools")
-	}
-	a.bytes += other.bytes
-	a.entries += other.entries
-	other.bytes = 0
-	other.entries = 0
+	// otherPoolAllocs is a map from pool to Alloc that exists to deal with
+	// cases where allocs from different pools might be merged into this pool.
+	// This can happen, at the time of writing, when the backfill concludes.
+	// By merging on a per-pool basis, we can accumulate exactly the number of
+	// allocs as there are pools in use. Any entry in this map must have a
+	// nil otherPoolAllocs field.
+	otherPoolAllocs map[pool]*Alloc
 }
 
 // pool is an allocation pool responsible for freeing up previously acquired resources.
@@ -49,6 +33,57 @@ type pool interface {
 	// Release releases resources to this pool.
 	Release(ctx context.Context, bytes, entries int64)
 }
+
+// Release releases resources associated with this allocation.
+func (a *Alloc) Release(ctx context.Context) {
+	if a.isZero() {
+		return
+	}
+	for _, oa := range a.otherPoolAllocs {
+		oa.Release(ctx)
+	}
+	a.ap.Release(ctx, a.bytes, a.entries)
+	a.clear()
+}
+
+// Merge merges other resources into this allocation.
+func (a *Alloc) Merge(other *Alloc) {
+	defer other.clear()
+	if a.isZero() { // a is a zero allocation -- just use the other.
+		*a = *other
+		return
+	}
+
+	// If other has any allocs from a pool other than its own, merge those
+	// into this. Flattening first means that any alloc in otherPoolAllocs
+	// will have a nil otherPoolAllocs.
+	if other.otherPoolAllocs != nil {
+		for _, oa := range other.otherPoolAllocs {
+			a.Merge(oa)
+		}
+		other.otherPoolAllocs = nil
+	}
+
+	if samePool := a.ap == other.ap; samePool {
+		a.bytes += other.bytes
+		a.entries += other.entries
+	} else {
+		// If other is from another pool, either store it in the map or merge it
+		// into an existing map entry.
+		if a.otherPoolAllocs == nil {
+			a.otherPoolAllocs = make(map[pool]*Alloc, 1)
+		}
+		if mergeAlloc, ok := a.otherPoolAllocs[other.ap]; ok {
+			mergeAlloc.Merge(other)
+		} else {
+			otherCpy := *other
+			a.otherPoolAllocs[other.ap] = &otherCpy
+		}
+	}
+}
+
+func (a *Alloc) clear()       { *a = Alloc{} }
+func (a *Alloc) isZero() bool { return a.ap == nil }
 
 // TestingMakeAlloc creates allocation for the specified number of bytes
 // in a single message using allocation pool 'p'.

--- a/pkg/ccl/changefeedccl/kvevent/alloc_test.go
+++ b/pkg/ccl/changefeedccl/kvevent/alloc_test.go
@@ -1,0 +1,111 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package kvevent
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAllocMergeRandomized(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	run := func(t *testing.T, N, P int) {
+		require.True(t, N >= P) // test assumes this invariant
+		pools := make([]*testAllocPool, P)
+		allocs := make([]Alloc, N)
+
+		// Make P pools.
+		for i := range pools {
+			pools[i] = &testAllocPool{}
+		}
+
+		// Allocate N allocs from the P pools.
+		poolPerm := rand.Perm(P)
+		for i := range allocs {
+			allocs[i] = pools[poolPerm[i%P]].alloc()
+		}
+
+		// Randomly merge the allocs together.
+		perm := rand.Perm(N)
+		for i := 0; i < N-1; i++ {
+			p := perm[i]
+			toMergeInto := perm[i+1+rand.Intn(N-i-1)]
+			allocs[toMergeInto].Merge(&allocs[p])
+		}
+
+		// Ensure that the remaining alloc, which has received all of the
+		// others, has P-1 other allocs.
+		require.Len(t, allocs[perm[N-1]].otherPoolAllocs, P-1)
+		for i := 0; i < N-1; i++ {
+			require.True(t, allocs[perm[i]].isZero())
+		}
+
+		// Ensure that all N allocations worth of data are still outstanding
+		sum := func() (ret int) {
+			for _, p := range pools {
+				ret += p.getN()
+			}
+			return ret
+		}
+		require.Equal(t, N, sum())
+
+		// Release the remaining alloc.
+		allocs[perm[N-1]].Release(context.Background())
+		// Ensure it now is zero-valued.
+		require.True(t, allocs[perm[N-1]].isZero())
+		// Ensure that all of the resources have been released.
+		require.Equal(t, 0, sum())
+	}
+	for _, np := range []struct{ N, P int }{
+		{1, 1},
+		{2, 2},
+		{1000, 2},
+		{10000, 1000},
+	} {
+		t.Run(fmt.Sprintf("N=%d,P=%d", np.N, np.P), func(t *testing.T) {
+			run(t, np.N, np.P)
+		})
+	}
+}
+
+type testAllocPool struct {
+	syncutil.Mutex
+	n int64
+}
+
+// Release implements kvevent.pool interface.
+func (ap *testAllocPool) Release(ctx context.Context, bytes, entries int64) {
+	ap.Lock()
+	defer ap.Unlock()
+	if ap.n == 0 {
+		panic("can't release zero resources")
+	}
+	ap.n -= bytes
+}
+
+func (ap *testAllocPool) alloc() Alloc {
+	ap.Lock()
+	defer ap.Unlock()
+	ap.n++
+	return TestingMakeAlloc(1, ap)
+}
+
+func (ap *testAllocPool) getN() int {
+	ap.Lock()
+	defer ap.Unlock()
+	return int(ap.n)
+}

--- a/pkg/ccl/changefeedccl/kvevent/blocking_buffer_test.go
+++ b/pkg/ccl/changefeedccl/kvevent/blocking_buffer_test.go
@@ -106,7 +106,8 @@ func TestBlockingBuffer(t *testing.T) {
 	for metrics.BufferPushbackNanos.Count() == 0 {
 		e, err := buf.Get(context.Background())
 		require.NoError(t, err)
-		e.DetachAlloc().Release(context.Background())
+		a := e.DetachAlloc()
+		a.Release(context.Background())
 	}
 	stopProducers()
 }

--- a/pkg/ccl/changefeedccl/kvevent/chan_buffer.go
+++ b/pkg/ccl/changefeedccl/kvevent/chan_buffer.go
@@ -39,6 +39,12 @@ func (b *chanBuffer) Add(ctx context.Context, event Event) error {
 	}
 }
 
+// Drain implements Writer interface.
+func (b *chanBuffer) Drain(ctx context.Context) error {
+	// channel buffer is unbuffered.
+	return nil
+}
+
 func (b *chanBuffer) Close(_ context.Context) error {
 	close(b.entriesCh)
 	return nil

--- a/pkg/ccl/changefeedccl/kvevent/event.go
+++ b/pkg/ccl/changefeedccl/kvevent/event.go
@@ -41,6 +41,8 @@ type Reader interface {
 type Writer interface {
 	// Add adds event to this writer.
 	Add(ctx context.Context, event Event) error
+	// Drain waits until all events buffered by this writer has been consumed.
+	Drain(ctx context.Context) error
 	// Close closes this writer.
 	Close(ctx context.Context) error
 }

--- a/pkg/ccl/changefeedccl/kvfeed/scanner_test.go
+++ b/pkg/ccl/changefeedccl/kvfeed/scanner_test.go
@@ -38,6 +38,10 @@ func (r *recordResolvedWriter) Add(ctx context.Context, e kvevent.Event) error {
 	return nil
 }
 
+func (r *recordResolvedWriter) Drain(ctx context.Context) error {
+	return nil
+}
+
 func (r *recordResolvedWriter) Close(ctx context.Context) error {
 	return nil
 }


### PR DESCRIPTION
Recent changes to memory accounting, allocation and pushback,
caused backfills to not track any memory at all.

This PR corrects this by associating `kvevent.Alloc` with each
event produced during the backfill.  With an allocation associated
with each event, backfills now gain pushback functionality.

The accounting and pushback is implemented by using a blocking memory
buffer, instead of the channel buffer.

The use of blocking buffer also improved performance during the backfill.
Backfills issue concurrent scan requests, while the rest of the event
processing is single threading. Having a buffer improves throughput
by around ~10%.

Fixes #69248

Release Justification: Complete feature work previusly done for changefeeds
by adding pushback signal to the backfills.

Release Notes: Changefeeds correctly account for memory during backfills
and "pushback" under memory pressure -- that is, slow down backfills.