### PR TITLE
kvserver: fix buglet in range state exporting

### DIFF
--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1196,10 +1196,9 @@ func (r *Replica) State(ctx context.Context) kvserverpb.RangeInfo {
 				return true // done
 			})
 		}
-
-		if r.mu.tenantID != (roachpb.TenantID{}) {
-			ri.TenantID = r.mu.tenantID.ToUint64()
-		}
+	}
+	if r.mu.tenantID != (roachpb.TenantID{}) {
+		ri.TenantID = r.mu.tenantID.ToUint64()
 	}
 	ri.ClosedTimestampPolicy = r.closedTimestampPolicyRLocked()
 	r.sideTransportClosedTimestamp.mu.Lock()


### PR DESCRIPTION
It looks like assigning a field was guarded by an unrelated nil check.

Release note: None
Release justification: bug fix