### PR TITLE
sql: set SearchPath during SET ROLE correctly

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/set_role
+++ b/pkg/sql/logictest/testdata/logic_test/set_role
@@ -1,9 +1,15 @@
 statement ok
 CREATE TABLE priv_t (pk INT PRIMARY KEY);
-CREATE TABLE no_priv_t (pk INT PRIMARY KEY)
+CREATE TABLE no_priv_t (pk INT PRIMARY KEY);
+GRANT SELECT ON priv_t TO testuser
 
 statement ok
-GRANT SELECT ON priv_t TO testuser
+CREATE SCHEMA root;
+CREATE TABLE root.root_table ();
+CREATE SCHEMA testuser;
+GRANT ALL ON SCHEMA testuser TO testuser;
+CREATE TABLE testuser.testuser_table ();
+GRANT ALL ON TABLE testuser.testuser_table TO testuser
 
 # Cannot become node or public.
 statement error role name "public" is reserved
@@ -59,6 +65,12 @@ SHOW ROLE
 root
 
 statement ok
+SELECT * FROM root_table
+
+statement error relation "testuser_table" does not exist
+SELECT * FROM testuser_table
+
+statement ok
 SET ROLE = 'testuser'
 
 query TT
@@ -72,8 +84,20 @@ SELECT * FROM priv_t
 statement error user testuser does not have SELECT privilege on relation no_priv_t
 SELECT * FROM no_priv_t
 
+statement error relation "root_table" does not exist
+SELECT * FROM root_table
+
+statement ok
+SELECT * FROM testuser_table
+
 statement ok
 RESET ROLE
+
+statement ok
+SELECT * FROM root_table
+
+statement error relation "testuser_table" does not exist
+SELECT * FROM testuser_table
 
 # Check root can transition between testuser and testuser2.
 statement ok

--- a/pkg/sql/user.go
+++ b/pkg/sql/user.go
@@ -468,12 +468,13 @@ func (p *planner) setRole(ctx context.Context, s security.SQLUsername) error {
 	}
 	m.paramStatusUpdater.BufferParamStatusUpdate("is_superuser", updateStr)
 
-	// The "none" user does resets the SessionUserProto in a SET ROLE.
+	// The "none" user resets the SessionUserProto in a SET ROLE.
 	if becomeUser.IsNoneRole() {
 		if m.data.SessionUserProto.Decode().Normalized() != "" {
 			m.data.UserProto = m.data.SessionUserProto
 			m.data.SessionUserProto = ""
 		}
+		m.data.SearchPath = m.data.SearchPath.WithUserSchemaName(m.data.User().Normalized())
 		return nil
 	}
 
@@ -483,6 +484,7 @@ func (p *planner) setRole(ctx context.Context, s security.SQLUsername) error {
 		m.data.SessionUserProto = m.data.UserProto
 	}
 	m.data.UserProto = becomeUser.EncodeProto()
+	m.data.SearchPath = m.data.SearchPath.WithUserSchemaName(m.data.User().Normalized())
 	return nil
 }
 


### PR DESCRIPTION
We previously did not set SearchPath on SET ROLE. This is now fixed.

Release justification: bug fix for new feature

Release note: None