### PR TITLE
changefeedccl: replace sync.Cond with channel in TestBlockingBuffer

### DIFF
--- a/pkg/ccl/changefeedccl/kvevent/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/kvevent/BUILD.bazel
@@ -50,7 +50,6 @@ go_test(
         "//pkg/util/mon",
         "//pkg/util/quotapool",
         "//pkg/util/randutil",
-        "//pkg/util/syncutil",
         "@com_github_stretchr_testify//require",
     ],
 )


### PR DESCRIPTION
I wasn't able to reproduce the deadlock locally without adding manual
sleeps into the code, but I believe this test code was using sync.Cond
incorrectly. Signal() only wakes up _current_ waiters, not all future
waiters. So, the following could happen:

- producer goroutine hits blocking allocation
- notifyWait callback called, (*sync.Cond).Signal() called
- main goroutine enters (*sync.Cond).Wait() and does not return

At this point the producer is blocked until the buffer is consumed,
but the buffer won't be consumed because the consumer won't start
until Signal is called again.

We could have fixed the usage of sync.Cond here, but I think using a
channel is easier to follow.

Potentially fixes #69373

Release justification: Non-production code change
Release note: None