### PR TITLE
sql: Fix SHOW ZONE CONFIGURATIONS with very long constraints

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -4419,8 +4419,8 @@ def go_deps():
         build_file_proto_mode = "disable_global",
         importpath = "gopkg.in/yaml.v2",
         replace = "github.com/cockroachdb/yaml",
-        sum = "h1:EqoCicA1pbWWDGniFxhTElh2hvui7E7tEvuBNJSDn3A=",
-        version = "v0.0.0-20180705215940-0e2822948641",
+        sum = "h1:vVVz+IAeHhYPxGW9EC8j6HR7uZl/1wSP0Wijaxs4frw=",
+        version = "v0.0.0-20210825132133-2d6955c8edbc",
     )
     go_repository(
         name = "in_gopkg_yaml_v3",

--- a/go.mod
+++ b/go.mod
@@ -188,7 +188,7 @@ replace honnef.co/go/tools => honnef.co/go/tools v0.0.1-2020.1.6
 
 replace vitess.io/vitess => github.com/cockroachdb/vitess v0.0.0-20210218160543-54524729cc82
 
-replace gopkg.in/yaml.v2 => github.com/cockroachdb/yaml v0.0.0-20180705215940-0e2822948641
+replace gopkg.in/yaml.v2 => github.com/cockroachdb/yaml v0.0.0-20210825132133-2d6955c8edbc
 
 replace github.com/knz/go-libedit => github.com/otan-cockroach/go-libedit v1.10.2-0.20201030151939-7cced08450e7
 

--- a/go.sum
+++ b/go.sum
@@ -300,8 +300,8 @@ github.com/cockroachdb/ttycolor v0.0.0-20210717002733-a2a538deeb8c h1:S2vg+TZySZ
 github.com/cockroachdb/ttycolor v0.0.0-20210717002733-a2a538deeb8c/go.mod h1:NltwFG0VBANi1jHKpn5KL9AbsHTE+8fPaAHT0TzL20k=
 github.com/cockroachdb/vitess v0.0.0-20210218160543-54524729cc82 h1:8htEd1lLILqfjKardWfKKGgXVCs0WmcgEj9cXnmcuos=
 github.com/cockroachdb/vitess v0.0.0-20210218160543-54524729cc82/go.mod h1:+bhevpN4bd6bstiRREkJDaMWZR3lTe5ypydTtXgf7GU=
-github.com/cockroachdb/yaml v0.0.0-20180705215940-0e2822948641 h1:EqoCicA1pbWWDGniFxhTElh2hvui7E7tEvuBNJSDn3A=
-github.com/cockroachdb/yaml v0.0.0-20180705215940-0e2822948641/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+github.com/cockroachdb/yaml v0.0.0-20210825132133-2d6955c8edbc h1:vVVz+IAeHhYPxGW9EC8j6HR7uZl/1wSP0Wijaxs4frw=
+github.com/cockroachdb/yaml v0.0.0-20210825132133-2d6955c8edbc/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd h1:qMd81Ts1T2OTKmB4acZcyKaMtRnY5Y44NuXGX2GFJ1w=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/codegangsta/cli v1.20.0/go.mod h1:/qJNoX69yVSKu5o4jLyXAENLRyk1uhi7zkbQ3slBdOA=

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs_long_regions
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs_long_regions
@@ -1,0 +1,33 @@
+# LogicTest: multiregion-3node-3superlongregions
+
+query TTTT
+SHOW REGIONS
+----
+veryveryveryveryveryveryverylongregion1  {}  {}  {}
+veryveryveryveryveryveryverylongregion2  {}  {}  {}
+veryveryveryveryveryveryverylongregion3  {}  {}  {}
+
+statement ok
+SELECT crdb_internal.validate_multi_region_zone_configs()
+
+statement ok
+CREATE DATABASE "mr-zone-configs" primary region "veryveryveryveryveryveryverylongregion1" regions "veryveryveryveryveryveryverylongregion2","veryveryveryveryveryveryverylongregion3"
+
+statement ok
+use "mr-zone-configs"
+
+statement ok
+SELECT crdb_internal.validate_multi_region_zone_configs()
+
+query TT
+SHOW ZONE CONFIGURATION FOR DATABASE "mr-zone-configs"
+----
+DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING
+                            range_min_bytes = 134217728,
+                            range_max_bytes = 536870912,
+                            gc.ttlseconds = 90000,
+                            num_replicas = 5,
+                            num_voters = 3,
+                            constraints = '{+region=veryveryveryveryveryveryverylongregion1: 1, +region=veryveryveryveryveryveryverylongregion2: 1, +region=veryveryveryveryveryveryverylongregion3: 1}',
+                            voter_constraints = '[+region=veryveryveryveryveryveryverylongregion1]',
+                            lease_preferences = '[[+region=veryveryveryveryveryveryverylongregion1]]'

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -684,6 +684,28 @@ var logicTestConfigs = []testClusterConfig{
 		},
 	},
 	{
+		name:              "multiregion-3node-3superlongregions",
+		numNodes:          3,
+		overrideAutoStats: "false",
+		localities: map[int]roachpb.Locality{
+			1: {
+				Tiers: []roachpb.Tier{
+					{Key: "region", Value: "veryveryveryveryveryveryverylongregion1"},
+				},
+			},
+			2: {
+				Tiers: []roachpb.Tier{
+					{Key: "region", Value: "veryveryveryveryveryveryverylongregion2"},
+				},
+			},
+			3: {
+				Tiers: []roachpb.Tier{
+					{Key: "region", Value: "veryveryveryveryveryveryverylongregion3"},
+				},
+			},
+		},
+	},
+	{
 		name:              "multiregion-9node-3region-3azs",
 		numNodes:          9,
 		overrideAutoStats: "false",

--- a/pkg/sql/show_zone_config.go
+++ b/pkg/sql/show_zone_config.go
@@ -175,6 +175,7 @@ func getShowZoneConfigRow(
 
 // zoneConfigToSQL pretty prints a zone configuration as a SQL string.
 func zoneConfigToSQL(zs *tree.ZoneSpecifier, zone *zonepb.ZoneConfig) (string, error) {
+	yaml.FutureLineWrap()
 	constraints, err := yamlMarshalFlow(zonepb.ConstraintsList{
 		Constraints: zone.Constraints,
 		Inherited:   zone.InheritedConstraints})


### PR DESCRIPTION
Previously, in the presence of very long constraints fields, SHOW ZONE
CONFIGURATIONS would output the constraints with `\n` characters mixed in. This
was due to the fact that the yaml.v2 library contained an 80 character line
limit. We recently pulled in some commits to our fork of the yaml library which
allows the line length to be configurable. With that change, we can now
configure the line length to be unlimited in the case where we're showing the
zone configuration, and get around the ugliness of the `\n` characters.

Release note (sql change): Fixes a bug in SHOW ZONE CONFIGURATIONS where long
constraints fields may show `\n` characters.

Release justification: Low risk, high reward change to existing functionality 