### PR TITLE
partitionccl: massage and unskip TestRepartitioning

### DIFF
--- a/pkg/ccl/partitionccl/BUILD.bazel
+++ b/pkg/ccl/partitionccl/BUILD.bazel
@@ -80,6 +80,7 @@ go_test(
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_gogo_protobuf//proto",
+        "@com_github_stretchr_testify//require",
         "@in_gopkg_yaml_v2//:yaml_v2",
     ],
 )


### PR DESCRIPTION
I've run this test a few times and it does pass, usually in ~2m20s.
Give the SucceedsSoon more time and unskip the test.

Closes #49112.

Release justification: testing-only change
Release note: None
