### PR TITLE
build: change Roachtest stress GCE zones

### DIFF
--- a/build/teamcity-roachtest-stress.sh
+++ b/build/teamcity-roachtest-stress.sh
@@ -19,7 +19,7 @@ build/builder/mkrelease.sh amd64-linux-gnu build bin/workload bin/roachtest bin/
 
 build/teamcity-roachtest-invoke.sh \
   --cloud=gce \
-  --zones=us-central1-b,us-west1-b,europe-west2-b \
+  --zones="${GCE_ZONES-us-east4-b,us-west4-a,europe-west4-c}" \
   --debug="${DEBUG-false}" \
   --count="${COUNT-16}" \
   --parallelism="${PARALLELISM-16}" \


### PR DESCRIPTION
This changes the default Roachtest stress GCE zones and makes them
configurable, due to recent hardware unavailability issues in
`us-central1-b` and to avoid conflicts with zones used by nightlies.

Release justification: non-production code changes
Release note: None