### PR TITLE
release-21.1: changefeedccl: remove fatals

### DIFF
--- a/pkg/ccl/changefeedccl/kvfeed/buffer.go
+++ b/pkg/ccl/changefeedccl/kvfeed/buffer.go
@@ -62,6 +62,9 @@ const (
 	// ResolvedEvent indicates that the Resolved method on the Event will be
 	// meaningful.
 	ResolvedEvent
+
+	// TypeUnknown indicates the event could not be parsed. Will fail the feed.
+	TypeUnknown
 )
 
 // Event represents an event emitted by a kvfeed. It is either a KV
@@ -82,8 +85,7 @@ func (b *Event) Type() EventType {
 	if b.resolved != nil {
 		return ResolvedEvent
 	}
-	log.Fatalf(context.TODO(), "found event with unknown type: %+v", *b)
-	return 0 // unreachable
+	return TypeUnknown
 }
 
 // ApproximateSize returns events approximate size in bytes.
@@ -141,8 +143,9 @@ func (b *Event) Timestamp() hlc.Timestamp {
 		}
 		return b.kv.Value.Timestamp
 	default:
-		log.Fatalf(context.TODO(), "unknown event type")
-		return hlc.Timestamp{} // unreachable
+		log.Warningf(context.TODO(),
+			"setting empty timestamp for unknown event type")
+		return hlc.Timestamp{}
 	}
 }
 

--- a/pkg/ccl/changefeedccl/kvfeed/physical_kv_feed.go
+++ b/pkg/ccl/changefeedccl/kvfeed/physical_kv_feed.go
@@ -15,7 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
 )
 
 // physicalFeedFactory constructs a physical feed which writes into sink and
@@ -106,7 +106,7 @@ func (p *rangefeed) addEventsToBuffer(ctx context.Context) error {
 					return err
 				}
 			default:
-				log.Fatalf(ctx, "unexpected RangeFeedEvent variant %v", t)
+				return errors.Errorf("unexpected RangeFeedEvent variant %v", t)
 			}
 		case <-ctx.Done():
 			return ctx.Err()


### PR DESCRIPTION
Backport 1/1 commits from #68512.

/cc @cockroachdb/release

---

All events we get from a kvfeed are currently one of two types,
so in a bunch of places we call log.Fatalf if we can't categorize
an event into one of those two. This kills the entire server, which
seems like an overreaction. Let's preemptively change this to a
normal error so that new event types can be more safely added in the
future.

Release note: None

Release justification: Category 2, baked backport of a low-risk bit of futureproofing/stability enhancement.
