### PR TITLE
Updated broken docs tutorial link in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ See our online documentation: [Quickstart with CockroachCloud](https://www.cockr
 CockroachDB supports the PostgreSQL wire protocol, so you can use any available PostgreSQL client drivers to connect from various languages.
 
 - For recommended drivers that we've tested, see [Install Client Drivers](https://www.cockroachlabs.com/docs/stable/install-client-drivers.html).
-- For tutorials using these drivers, as well as supported ORMs, see [Build an App with CockroachDB](https://www.cockroachlabs.com/docs/stable/build-an-app-with-cockroachdb.html).
+- For tutorials using these drivers, as well as supported ORMs, see [Example Apps](https://www.cockroachlabs.com/docs/stable/example-apps.html).
 
 ## Deployment
 


### PR DESCRIPTION
Follow-up on https://cockroachlabs.slack.com/archives/C01PHNMUFLN/p1629993907000800.

Fixes https://github.com/cockroachdb/docs/issues/11137.