### PR TITLE
storageccl,schemafeed: paginate export requests

### DIFF
--- a/pkg/ccl/storageccl/revision_reader.go
+++ b/pkg/ccl/storageccl/revision_reader.go
@@ -31,48 +31,57 @@ type VersionedValues struct {
 func GetAllRevisions(
 	ctx context.Context, db *kv.DB, startKey, endKey roachpb.Key, startTime, endTime hlc.Timestamp,
 ) ([]VersionedValues, error) {
-	// TODO(dt): version check.
-	header := roachpb.Header{Timestamp: endTime}
-	req := &roachpb.ExportRequest{
-		RequestHeader: roachpb.RequestHeader{Key: startKey, EndKey: endKey},
-		StartTime:     startTime,
-		MVCCFilter:    roachpb.MVCCFilter_All,
-		ReturnSST:     true,
-	}
-	resp, pErr := kv.SendWrappedWith(ctx, db.NonTransactionalSender(), header, req)
-	if pErr != nil {
-		return nil, pErr.GoError()
-	}
-
 	var res []VersionedValues
-	for _, file := range resp.(*roachpb.ExportResponse).Files {
-		iter, err := storage.NewMemSSTIterator(file.SST, false)
-		if err != nil {
-			return nil, err
+	for {
+		// TODO(dt): version check.
+		header := roachpb.Header{Timestamp: endTime, TargetBytes: 1}
+		req := &roachpb.ExportRequest{
+			RequestHeader:  roachpb.RequestHeader{Key: startKey, EndKey: endKey},
+			StartTime:      startTime,
+			MVCCFilter:     roachpb.MVCCFilter_All,
+			ReturnSST:      true,
+			TargetFileSize: 1 << 20,
 		}
-		defer iter.Close()
-		iter.SeekGE(storage.MVCCKey{Key: startKey})
+		rawResp, pErr := kv.SendWrappedWith(ctx, db.NonTransactionalSender(), header, req)
+		if pErr != nil {
+			return nil, pErr.GoError()
+		}
 
-		for ; ; iter.Next() {
-			if valid, err := iter.Valid(); !valid || err != nil {
-				if err != nil {
-					return nil, err
+		resp := rawResp.(*roachpb.ExportResponse)
+
+		for _, file := range resp.Files {
+			iter, err := storage.NewMemSSTIterator(file.SST, false)
+			if err != nil {
+				return nil, err
+			}
+			defer iter.Close()
+			iter.SeekGE(storage.MVCCKey{Key: startKey})
+
+			for ; ; iter.Next() {
+				if valid, err := iter.Valid(); !valid || err != nil {
+					if err != nil {
+						return nil, err
+					}
+					break
+				} else if iter.UnsafeKey().Key.Compare(endKey) >= 0 {
+					break
 				}
-				break
-			} else if iter.UnsafeKey().Key.Compare(endKey) >= 0 {
-				break
+				key := iter.UnsafeKey()
+				keyCopy := make([]byte, len(key.Key))
+				copy(keyCopy, key.Key)
+				key.Key = keyCopy
+				value := make([]byte, len(iter.UnsafeValue()))
+				copy(value, iter.UnsafeValue())
+				if len(res) == 0 || !res[len(res)-1].Key.Equal(key.Key) {
+					res = append(res, VersionedValues{Key: key.Key})
+				}
+				res[len(res)-1].Values = append(res[len(res)-1].Values, roachpb.Value{Timestamp: key.Timestamp, RawBytes: value})
 			}
-			key := iter.UnsafeKey()
-			keyCopy := make([]byte, len(key.Key))
-			copy(keyCopy, key.Key)
-			key.Key = keyCopy
-			value := make([]byte, len(iter.UnsafeValue()))
-			copy(value, iter.UnsafeValue())
-			if len(res) == 0 || !res[len(res)-1].Key.Equal(key.Key) {
-				res = append(res, VersionedValues{Key: key.Key})
-			}
-			res[len(res)-1].Values = append(res[len(res)-1].Values, roachpb.Value{Timestamp: key.Timestamp, RawBytes: value})
 		}
+		if resp.ResumeSpan == nil {
+			break
+		}
+		startKey = resp.ResumeSpan.Key
 	}
 	return res, nil
 }


### PR DESCRIPTION
This paginates ExportRequests when reading descriptors for backup
using a simplistic approach that fetches and buffers all the responses
and then processes them all. A follow-up change should instead process
each response as it goes, but this at least localizes the burden of the
large reply to just the caller, who already had to hold the whole reply
in memory, rather an also asking the server to send the whole thing in
one reply.

Release justification: stability improvement by reducing chance of KV OOM.

Release note: none.