### PR TITLE
bazel: add more directories to `.bazelignore`, `gazelle:exclude` list

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -2,4 +2,7 @@ artifacts
 bin
 build/builder_home
 lib
+pkg/ui/node_modules
+pkg/ui/workspaces/cluster-ui/node_modules
+pkg/ui/workspaces/db-console/node_modules
 vendor

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -90,7 +90,13 @@ load("@bazel_gazelle//:def.bzl", "gazelle")
 # gazelle:exclude _bazel
 # gazelle:exclude c-deps/krb5
 # gazelle:exclude artifacts
+# gazelle:exclude bin
+# gazelle:exclude build/builder_home
+# gazelle:exclude lib
 # gazelle:exclude pkg/ccl/gssapiccl
+# gazelle:exclude pkg/ui/node_modules
+# gazelle:exclude pkg/ui/workspaces/cluster-ui/node_modules
+# gazelle:exclude pkg/ui/workspaces/db-console/node_modules
 # gazelle:exclude vendor
 # gazelle:exclude .vendor.tmp.*
 # gazelle:exclude **/zcgo_flags.go


### PR DESCRIPTION
On some dev machines, bazel was looking in `pkg/ui/node_modules` for
`bazel query`s, which was causing `make bazel-generate` to fail. We
exclude that directory (and other `node_modules` directories)
accordingly. Also I updated the `gazelle:exclude` list to reduce
discrepancies between it and `.bazelignore`.

Release justification: Non-production code change
Release note: None