### PR TITLE
kvserver: improve some obscure error reporting

### DIFF
--- a/pkg/kv/kvserver/replica_gossip.go
+++ b/pkg/kv/kvserver/replica_gossip.go
@@ -270,7 +270,7 @@ func (r *Replica) getLeaseForGossip(ctx context.Context) (bool, *roachpb.Error) 
 					}
 				default:
 					// Any other error is worth being logged visibly.
-					log.Warningf(ctx, "could not acquire lease for range gossip: %s", e)
+					log.Warningf(ctx, "could not acquire lease for range gossip: %s", pErr)
 				}
 			}
 		}); err != nil {


### PR DESCRIPTION
This code was trying to print an ErrorDetail, but pErrs don't
necessarily have details (at least not any more). So, it was sometimes
printing an unhelpful nil.

Release note: None