### PR TITLE
build: point people to `dev generate bazel` over `make bazel-generate`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1785,14 +1785,10 @@ fuzz: ## Run fuzz tests.
 fuzz: bin/fuzz
 	bin/fuzz $(TESTFLAGS) -tests $(TESTS) -timeout $(TESTTIMEOUT) $(PKG)
 
-# Short hand to re-generate all bazel BUILD files.
-#
-# Even with --symlink_prefix, some sub-command somewhere hardcodes the
-# creation of a "bazel-out" symlink. This bazel-out symlink can only
-# be blocked by the existence of a file before the bazel command is
-# invoked. For now, this is left as an exercise for the user.
-#
-bazel-generate: ## Generate all bazel BUILD files.
+# Short hand to re-generate all bazel BUILD files. (Does the same thing as
+# `./dev generate bazel`.)
+.PHONY: bazel-generate
+bazel-generate:
 	@echo 'Generating DEPS.bzl and BUILD files using gazelle'
 	./build/bazelutil/bazel-generate.sh
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -34,7 +34,7 @@ git_repository(
 
 # Load up cockroachdb's go dependencies (the ones listed under go.mod). The
 # `DEPS.bzl` file is kept up to date using the `update-repos` Gazelle command
-# (see `make bazel-generate`).
+# (see `build/bazelutil/bazel-generate.sh`).
 #
 # gazelle:repository_macro DEPS.bzl%go_deps
 load("//:DEPS.bzl", "go_deps")

--- a/build/README.md
+++ b/build/README.md
@@ -160,7 +160,7 @@ is missing, ensure it is used in code. This can be a blank dependency, e.g.
 `import _ "golang.org/api/compute/v1"`. These changes must then be committed in the submodule directory
 (see [Working with Submodules](#working-with-submodules)).
 
-Finally, run `make bazel-generate` to regenerate `DEPS.bzl` with the updated Go dependency information.
+Finally, run `./dev generate bazel` to regenerate `DEPS.bzl` with the updated Go dependency information.
 
 Programs can then be run using `go build ...` or `go test ...`.
 

--- a/build/bazelutil/bazel-generate.sh
+++ b/build/bazelutil/bazel-generate.sh
@@ -2,6 +2,11 @@
 
 set -exuo pipefail
 
+# Even with --symlink_prefix, some sub-command somewhere hardcodes the
+# creation of a "bazel-out" symlink. This bazel-out symlink can only
+# be blocked by the existence of a file before the bazel command is
+# invoked. For now, this is left as an exercise for the user.
+
 bazel run //:gazelle -- update-repos -from_file=go.mod -build_file_proto_mode=disable_global -to_macro=DEPS.bzl%go_deps -prune=true
 bazel run //pkg/cmd/generate-test-suites --run_under="cd $PWD && " > pkg/BUILD.bazel
 bazel run //:gazelle

--- a/build/teamcity-check-genfiles.sh
+++ b/build/teamcity-check-genfiles.sh
@@ -30,7 +30,7 @@ rm artifacts/buildshort.log
 TEAMCITY_BAZEL_SUPPORT_GENERATE=1  # See teamcity-bazel-support.sh.
 run run_bazel build/bazelutil/bazel-generate.sh &> artifacts/buildshort.log || (cat artifacts/buildshort.log && false)
 rm artifacts/buildshort.log
-check_clean "Run \`make bazel-generate\` to automatically regenerate these."
+check_clean "Run \`./dev generate bazel\` to automatically regenerate these."
 run build/builder.sh make generate &> artifacts/generate.log || (cat artifacts/generate.log && false)
 rm artifacts/generate.log
 check_clean "Run \`make generate\` to automatically regenerate these."

--- a/pkg/cmd/dev/generate.go
+++ b/pkg/cmd/dev/generate.go
@@ -80,8 +80,7 @@ func (d *dev) generateBazel(cmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
-	_, err = d.exec.CommandContext(ctx, filepath.Join(workspace, "build", "bazelutil", "bazel-generate.sh"))
-	return err
+	return d.exec.CommandContextInheritingStdStreams(ctx, filepath.Join(workspace, "build", "bazelutil", "bazel-generate.sh"))
 }
 
 func (d *dev) generateDocs(cmd *cobra.Command) error {

--- a/pkg/cmd/dev/io/exec/exec.go
+++ b/pkg/cmd/dev/io/exec/exec.go
@@ -80,12 +80,6 @@ func WithRecording(r *recording.Recording) func(e *Exec) {
 	}
 }
 
-// CommandContext wraps around exec.CommandContext, executing the named program
-// with the given arguments.
-func (e *Exec) CommandContext(ctx context.Context, name string, args ...string) ([]byte, error) {
-	return e.commandContextImpl(ctx, nil, false, name, args...)
-}
-
 // CommandContextSilent is like CommandContext, but does not take over
 // stdout/stderr. It's to be used for "internal" operations.
 func (e *Exec) CommandContextSilent(


### PR DESCRIPTION
These two methods for generating Bazel files do the exact same thing,
but making this change might train people to use `dev` a little bit.

Release justification: Non-production code change
Release note: None