### PR TITLE
storage/fs: remove RemoveDir function

### DIFF
--- a/pkg/kv/kvserver/replica_sideload_disk.go
+++ b/pkg/kv/kvserver/replica_sideload_disk.go
@@ -237,7 +237,7 @@ func (ss *diskSideloadStorage) TruncateTo(
 	if deletedAll {
 		// The directory may not exist, or it may exist and have been empty.
 		// Not worth trying to figure out which one, just try to delete.
-		err := ss.eng.RemoveDir(ss.dir)
+		err := ss.eng.Remove(ss.dir)
 		if err != nil && !oserror.IsNotExist(err) {
 			log.Infof(ctx, "unable to remove sideloaded dir %s: %v", ss.dir, err)
 			err = nil // handled

--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -1285,7 +1285,7 @@ func TestEngineFS(t *testing.T) {
 				"9e: list-dir /dir1 == bar,baz",
 				"9f: delete /dir1/bar",
 				"9g: delete /dir1/baz",
-				"9h: delete-dir /dir1",
+				"9h: delete /dir1",
 			}
 
 			var f fs.File
@@ -1326,8 +1326,6 @@ func TestEngineFS(t *testing.T) {
 					err = e.Rename(s[1], s[2])
 				case "create-dir":
 					err = e.MkdirAll(s[1])
-				case "delete-dir":
-					err = e.RemoveDir(s[1])
 				case "list-dir":
 					result, err := e.List(s[1])
 					if err != nil {

--- a/pkg/storage/fs/fs.go
+++ b/pkg/storage/fs/fs.go
@@ -28,8 +28,8 @@ type File interface {
 
 // FS provides a filesystem interface.
 type FS interface {
-	// Create creates the named file for writing, truncating it if it already
-	// exists.
+	// Create creates the named file for writing, removing the file at
+	// the provided path if one already exists.
 	Create(name string) (File, error)
 
 	// CreateWithSync is similar to Create, but the file is periodically
@@ -58,9 +58,6 @@ type FS interface {
 	// MkdirAll creates the named dir and its parents. Does nothing if the
 	// directory already exists.
 	MkdirAll(name string) error
-
-	// RemoveDir removes the named dir.
-	RemoveDir(name string) error
 
 	// RemoveAll deletes the path and any children it contains.
 	RemoveAll(dir string) error

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1362,11 +1362,6 @@ func (p *Pebble) MkdirAll(name string) error {
 	return p.fs.MkdirAll(name, 0755)
 }
 
-// RemoveDir implements the FS interface.
-func (p *Pebble) RemoveDir(name string) error {
-	return p.fs.Remove(name)
-}
-
 // List implements the FS interface.
 func (p *Pebble) List(name string) ([]string, error) {
 	dirents, err := p.fs.List(name)


### PR DESCRIPTION
Remove the RemoveDir function from the storage/fs.FS interface. It's a
vestige from the RocksDB Env and its Pebble implementation simply called
the existing Remove function.

Release justification: non-production code changes
Release note: None