### PR TITLE
sql: fix in-memory stmt stats not properly updating

### DIFF
--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/BUILD.bazel
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "json_decoding.go",
         "json_encoding.go",
         "json_impl.go",
+        "testutils.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil",
     visibility = ["//visibility:public"],
@@ -15,6 +16,7 @@ go_library(
         "//pkg/util/json",
         "@com_github_cockroachdb_apd_v2//:apd",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_stretchr_testify//require",
     ],
 )
 

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/testutils.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/testutils.go
@@ -1,0 +1,123 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sqlstatsutil
+
+import (
+	"html/template"
+	"math/rand"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/stretchr/testify/require"
+)
+
+// GetRandomizedCollectedStatementStatisticsForTest returns a
+// roachpb.CollectedStatementStatistics with its fields randomly filled.
+func GetRandomizedCollectedStatementStatisticsForTest(
+	t *testing.T,
+) (result roachpb.CollectedStatementStatistics) {
+	data := genRandomData()
+	fillObject(t, reflect.ValueOf(&result), &data)
+
+	// TODO(azhng): Gone after https://github.com/cockroachdb/cockroach/issues/68077.
+	result.Key.Opt = true
+
+	return result
+}
+
+type randomData struct {
+	Bool   bool
+	String string
+	Int64  int64
+	Float  float64
+}
+
+var alphabet = []rune("abcdefghijklmkopqrstuvwxyz")
+
+func genRandomData() randomData {
+	r := randomData{}
+	r.Bool = rand.Float64() > 0.5
+
+	// Randomly generating 20-character string.
+	b := strings.Builder{}
+	for i := 0; i < 20; i++ {
+		b.WriteRune(alphabet[rand.Intn(26)])
+	}
+	r.String = b.String()
+
+	r.Int64 = rand.Int63()
+	r.Float = rand.Float64()
+
+	return r
+}
+
+func fillTemplate(t *testing.T, tmplStr string, data randomData) string {
+	tmpl, err := template.New("").Parse(tmplStr)
+	require.NoError(t, err)
+
+	b := strings.Builder{}
+	err = tmpl.Execute(&b, data)
+	require.NoError(t, err)
+
+	return b.String()
+}
+
+var fieldBlacklist = map[string]struct{}{
+	"App":                     {},
+	"SensitiveInfo":           {},
+	"LegacyLastErr":           {},
+	"LegacyLastErrRedacted":   {},
+	"LastExecTimestamp":       {},
+	"StatementFingerprintIDs": {},
+	"AggregatedTs":            {},
+}
+
+func fillObject(t *testing.T, val reflect.Value, data *randomData) {
+	// Do not set the fields that are not being encoded as json.
+	if val.Kind() != reflect.Ptr {
+		t.Fatal("not a pointer type")
+	}
+
+	val = reflect.Indirect(val)
+
+	switch val.Kind() {
+	case reflect.Uint64:
+		val.SetUint(uint64(0))
+	case reflect.Int64:
+		val.SetInt(data.Int64)
+	case reflect.String:
+		val.SetString(data.String)
+	case reflect.Float64:
+		val.SetFloat(data.Float)
+	case reflect.Bool:
+		val.SetBool(data.Bool)
+	case reflect.Slice:
+		numElem := val.Len()
+		for i := 0; i < numElem; i++ {
+			fillObject(t, val.Index(i).Addr(), data)
+		}
+	case reflect.Struct:
+		numFields := val.NumField()
+		for i := 0; i < numFields; i++ {
+			fieldName := val.Type().Field(i).Name
+			fieldAddr := val.Field(i).Addr()
+			if _, ok := fieldBlacklist[fieldName]; ok {
+				continue
+			}
+
+			fillObject(t, fieldAddr, data)
+		}
+	default:
+		t.Fatalf("unsupported type: %s", val.Kind().String())
+	}
+}

--- a/pkg/sql/sqlstats/sslocal/BUILD.bazel
+++ b/pkg/sql/sqlstats/sslocal/BUILD.bazel
@@ -48,6 +48,7 @@ go_test(
         "//pkg/server/serverpb",
         "//pkg/sql",
         "//pkg/sql/sqlstats",
+        "//pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil",
         "//pkg/sql/tests",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/sqlutils",

--- a/pkg/sql/sqlstats/sslocal/sql_stats_test.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats_test.go
@@ -17,10 +17,53 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/stretchr/testify/require"
 )
+
+// TestStmtStatsBulkIngestWithRandomMetadata generates a sequence of random
+// serverpb.StatementsResponse_CollectedStatementStatistics that simulates the
+// response from RPC fanout, and use a temporary SQLStats object to ingest
+// that sequence. This test checks if the metadata are being properly
+// updated in the temporary SQLStats object.
+func TestStmtStatsBulkIngestWithRandomMetadata(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	var testData []serverpb.StatementsResponse_CollectedStatementStatistics
+
+	for i := 0; i < 50; i++ {
+		var stats serverpb.StatementsResponse_CollectedStatementStatistics
+		randomData := sqlstatsutil.GetRandomizedCollectedStatementStatisticsForTest(t)
+		stats.Key.KeyData = randomData.Key
+		testData = append(testData, stats)
+	}
+
+	sqlStats, err := NewTempSQLStatsFromExistingStmtStats(testData)
+	require.NoError(t, err)
+
+	require.NoError(t,
+		sqlStats.IterateStatementStats(
+			context.Background(),
+			&sqlstats.IteratorOptions{},
+			func(
+				ctx context.Context,
+				statistics *roachpb.CollectedStatementStatistics,
+			) error {
+				var found bool
+				for i := range testData {
+					if testData[i].Key.KeyData == statistics.Key {
+						found = true
+						break
+					}
+				}
+				require.True(t, found, "expected metadata %+v, but not found", statistics.Key)
+				return nil
+			}))
+
+}
 
 func TestSQLStatsStmtStatsBulkIngest(t *testing.T) {
 	defer leaktest.AfterTest(t)()
@@ -34,8 +77,9 @@ func TestSQLStatsStmtStatsBulkIngest(t *testing.T) {
 		{
 			id: 0,
 			key: roachpb.StatementStatisticsKey{
-				App:   "app1",
-				Query: "SELECT 1",
+				App:      "app1",
+				Query:    "SELECT 1",
+				Database: "testdb",
 			},
 			stats: roachpb.StatementStatistics{
 				Count: 7,
@@ -44,8 +88,9 @@ func TestSQLStatsStmtStatsBulkIngest(t *testing.T) {
 		{
 			id: 0,
 			key: roachpb.StatementStatisticsKey{
-				App:   "app0",
-				Query: "SELECT 1",
+				App:      "app0",
+				Query:    "SELECT 1",
+				Database: "testdb",
 			},
 			stats: roachpb.StatementStatistics{
 				Count: 2,
@@ -54,8 +99,9 @@ func TestSQLStatsStmtStatsBulkIngest(t *testing.T) {
 		{
 			id: 1,
 			key: roachpb.StatementStatisticsKey{
-				App:   "app100",
-				Query: "SELECT 1,1",
+				App:      "app100",
+				Query:    "SELECT 1,1",
+				Database: "testdb",
 			},
 			stats: roachpb.StatementStatistics{
 				Count: 31,
@@ -64,8 +110,9 @@ func TestSQLStatsStmtStatsBulkIngest(t *testing.T) {
 		{
 			id: 1,
 			key: roachpb.StatementStatisticsKey{
-				App:   "app0",
-				Query: "SELECT 1,1",
+				App:      "app0",
+				Query:    "SELECT 1,1",
+				Database: "testdb",
 			},
 			stats: roachpb.StatementStatistics{
 				Count: 32,
@@ -74,8 +121,9 @@ func TestSQLStatsStmtStatsBulkIngest(t *testing.T) {
 		{
 			id: 0,
 			key: roachpb.StatementStatisticsKey{
-				App:   "app1",
-				Query: "SELECT 1",
+				App:      "app1",
+				Query:    "SELECT 1",
+				Database: "testdb",
 			},
 			stats: roachpb.StatementStatistics{
 				Count: 33,
@@ -84,8 +132,9 @@ func TestSQLStatsStmtStatsBulkIngest(t *testing.T) {
 		{
 			id: 1,
 			key: roachpb.StatementStatisticsKey{
-				App:   "app100",
-				Query: "SELECT 1,1",
+				App:      "app100",
+				Query:    "SELECT 1,1",
+				Database: "testdb",
 			},
 			stats: roachpb.StatementStatistics{
 				Count: 2,
@@ -123,6 +172,7 @@ func TestSQLStatsStmtStatsBulkIngest(t *testing.T) {
 				ctx context.Context,
 				statistics *roachpb.CollectedStatementStatistics,
 			) error {
+				require.Equal(t, "testdb", statistics.Key.Database)
 				foundStats[statistics.Key.App+statistics.Key.Query] = statistics.Stats.Count
 				return nil
 			}))

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
@@ -252,7 +252,24 @@ func NewTempContainerFromExistingStmtStats(
 		if throttled {
 			return nil /* container */, nil /* remaining */, ErrFingerprintLimitReached
 		}
+
+		// This handles all the statistics fields.
 		stmtStats.mu.data.Add(&statistics[i].Stats)
+
+		// Setting all metadata fields.
+		if stmtStats.mu.data.SensitiveInfo.LastErr == "" && key.failed {
+			stmtStats.mu.data.SensitiveInfo.LastErr = statistics[i].Stats.SensitiveInfo.LastErr
+		}
+
+		if stmtStats.mu.data.SensitiveInfo.MostRecentPlanTimestamp.Before(statistics[i].Stats.SensitiveInfo.MostRecentPlanTimestamp) {
+			stmtStats.mu.data.SensitiveInfo.MostRecentPlanDescription = statistics[i].Stats.SensitiveInfo.MostRecentPlanDescription
+			stmtStats.mu.data.SensitiveInfo.MostRecentPlanTimestamp = statistics[i].Stats.SensitiveInfo.MostRecentPlanTimestamp
+		}
+
+		stmtStats.mu.vectorized = statistics[i].Key.KeyData.Vec
+		stmtStats.mu.distSQLUsed = statistics[i].Key.KeyData.DistSQL
+		stmtStats.mu.fullScan = statistics[i].Key.KeyData.FullScan
+		stmtStats.mu.database = statistics[i].Key.KeyData.Database
 	}
 
 	return container, nil /* remaining */, nil /* err */


### PR DESCRIPTION
Previsouly, in-memeory statement statistics does not return
any metadata. This is due to the temp SQLStats object used
for aggregating RPC fanout results not properly updating the
metadata fields.
This commit address the bug and expanded testing to randomly
test all fields for statement statistics metadata.

Resolves #69363

Release justification: Category 2: Bug fixes and low-risk updates
to new functionality

Release note: None