### PR TITLE
kvserver: don't attempt txn evaluation for Require1PC requests

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
@@ -189,10 +189,9 @@ func EndTxn(
 	}
 	if args.Require1PC {
 		// If a 1PC txn was required and we're in EndTxn, we've failed to evaluate
-		// the batch as a 1PC. We're returning early instead of preferring a
-		// possible retriable error because we might want to leave locks behind in
-		// case of retriable errors - which Require1PC does not want.
-		return result.Result{}, roachpb.NewTransactionStatusError("could not commit in one phase as requested")
+		// the batch as a 1PC. We shouldn't have gotten here; if we couldn't
+		// evaluate as 1PC, evaluateWriteBatch() was supposed to short-circuit.
+		return result.Result{}, errors.AssertionFailedf("unexpectedly trying to evaluate EndTxn with the Require1PC flag set")
 	}
 	if args.Commit && args.Poison {
 		return result.Result{}, errors.AssertionFailedf("cannot poison during a committing EndTxn request")

--- a/pkg/kv/kvserver/node_liveness_test.go
+++ b/pkg/kv/kvserver/node_liveness_test.go
@@ -1032,6 +1032,7 @@ func TestNodeLivenessRetryAmbiguousResultError(t *testing.T) {
 	s := serv.(*server.TestServer)
 	defer s.Stopper().Stop(ctx)
 
+	// Verify retry of the ambiguous result for heartbeat loop.
 	testutils.SucceedsSoon(t, func() error {
 		return verifyLivenessServer(s, 1)
 	})

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -12181,7 +12181,7 @@ func TestTxnRecordLifecycleTransitions(t *testing.T) {
 				et.Require1PC = true
 				return sendWrappedWithErr(etH, &et)
 			},
-			expError: "TransactionStatusError: could not commit in one phase as requested",
+			expError: "could not commit in one phase as requested",
 			expTxn:   txnWithoutChanges,
 		},
 		{

--- a/pkg/roachpb/batch.go
+++ b/pkg/roachpb/batch.go
@@ -225,6 +225,17 @@ func (ba *BatchRequest) IsSingleEndTxnRequest() bool {
 	return ba.isSingleRequestWithMethod(EndTxn)
 }
 
+// Require1PC returns true if the batch contains an EndTxn with the Require1PC
+// flag set.
+func (ba *BatchRequest) Require1PC() bool {
+	arg, ok := ba.GetArg(EndTxn)
+	if !ok {
+		return false
+	}
+	etArg := arg.(*EndTxnRequest)
+	return etArg.Require1PC
+}
+
 // IsSingleAbortTxnRequest returns true iff the batch contains a single request,
 // and that request is an EndTxnRequest(commit=false).
 func (ba *BatchRequest) IsSingleAbortTxnRequest() bool {


### PR DESCRIPTION
Before this patch, an error encountered by the 1PC evaluation resulted
in the batch being re-evaluated transactionally. In the case of
Require1PC batches, this re-evaluation resulted in a
TransactionStatusError{"requires 1PC"}. Instead of flowing to this
predictable outcome, this patch makes it so that we don't attempt
transactional evaluation and return the original error.

This seems generally sane and, at the very least, helps
TestNodeLivenessRetryAmbiguousResultError which was injecting an error
into the 1PC path and wanted that error to be returned to the client,
only to have the TransactionStatusError returned instead. Similarly,
this removes the need from handling TransactionStatusError specially in
the liveness code.

Release note: None