### PR TITLE
ui: range table loads correctly when replica is being gc-ed

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/range/rangeInfo.ts
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/range/rangeInfo.ts
@@ -16,7 +16,7 @@ import { FixLong } from "src/util/fixLong";
 
 export function GetLocalReplica(
   info: protos.cockroach.server.serverpb.IRangeInfo,
-) {
+): protos.cockroach.roachpb.IReplicaDescriptor {
   return _.find(
     info.state.state.desc.internal_replicas,
     rep => rep.store_id === info.source_store_id,

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/range/rangeTable.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/range/rangeTable.tsx
@@ -682,7 +682,9 @@ export default class RangeTable extends React.Component<RangeTableProps, {}> {
           `${info.span.start_key} to ${info.span.end_key}`,
         ),
         problems: this.contentProblems(info.problems, awaitingGC),
-        replicaType: this.createContent(contentReplicaType(localReplica.type)),
+        replicaType: awaitingGC
+          ? this.createContent("") // `problems` above will report "Awaiting GC" in this case
+          : this.createContent(contentReplicaType(localReplica.type)),
         raftState: raftState,
         quiescent: info.quiescent
           ? rangeTableQuiescent


### PR DESCRIPTION
Previously, there was a bug where the range table component would fail
to load if the `GetLocalReplica` function returned a null or undefined
value. This is an expected scenario where we may be in the Awaiting GC
state for a problematic range.

This change gates the retrieval of `.type` on the `localReplica` object
on the `awaitingGC` boolean like a few other cases in the component do
already. We render blank text for the `replicaType` in this scenario
since the row right above will show "Awaiting GC" already.

Release justification: this is a high-severity bug on the page since it
doesn't load in scenarios where we would want to debug problematic
ranges.

Release note (ui change, bug fix): replicas awaiting to be GCed were
causing the range report page to not load at all due to a JS error. The
page will now load and display an empty "Replica Type" while in this
state.