### PR TITLE
ui: hide node/regions info on tenants

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/sortedtable/sortedtable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sortedtable/sortedtable.tsx
@@ -56,6 +56,8 @@ export interface ColumnDescriptor<T> {
   showByDefault?: boolean;
   // If true, the user can't overwrite the setting for this column. False if not defined.
   alwaysShow?: boolean;
+  // If true, hide this column for tenant clusters. False if not defined.
+  hideIfTenant?: boolean;
 }
 
 /**

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.fixture.ts
@@ -217,4 +217,5 @@ export const getStatementDetailsPropsFixture = (): StatementDetailsProps => ({
   uiConfig: {
     showStatementDiagnosticsLink: true,
   },
+  isTenant: false,
 });

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetailsConnected.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetailsConnected.ts
@@ -15,13 +15,13 @@ import {
   StatementDetails,
   StatementDetailsDispatchProps,
   StatementDetailsProps,
-  StatementDetailsStateProps,
 } from "./statementDetails";
 import { AppState } from "../store";
 import {
   selectStatement,
   selectStatementDetailsUiConfig,
 } from "./statementDetails.selectors";
+import { selectIsTenant } from "../store/uiConfig";
 import {
   nodeDisplayNameByIDSelector,
   nodeRegionsByIDSelector,
@@ -49,6 +49,7 @@ const mapStateToProps = (state: AppState, props: StatementDetailsProps) => {
       statementFingerprint,
     ),
     uiConfig: selectStatementDetailsUiConfig(state),
+    isTenant: selectIsTenant(state),
   };
 };
 

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
@@ -33,6 +33,7 @@ import {
   selectTotalFingerprints,
   selectColumns,
 } from "./statementsPage.selectors";
+import { selectIsTenant } from "../store/uiConfig";
 import { AggregateStatistics } from "../statementsTable";
 import { nodeRegionsByIDSelector } from "../store/nodes";
 
@@ -51,6 +52,7 @@ export const ConnectedStatementsPage = withRouter(
       lastReset: selectLastReset(state),
       columns: selectColumns(state),
       nodeRegions: nodeRegionsByIDSelector(state),
+      isTenant: selectIsTenant(state),
     }),
     (dispatch: Dispatch) => ({
       refreshStatements: () => dispatch(statementActions.refresh()),

--- a/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.tsx
@@ -174,6 +174,7 @@ function makeCommonColumns(
       },
       sort: (stmt: AggregateStatistics) => stmt.regionNodes.sort().join(", "),
       showByDefault: false,
+      hideIfTenant: true,
     },
   ];
   return columns;
@@ -311,8 +312,13 @@ export function makeNodesColumns(
 export function populateRegionNodeForStatements(
   statements: AggregateStatistics[],
   nodeRegions: { [p: string]: string },
+  isTenant: boolean,
 ) {
   statements.forEach(stmt => {
+    if (isTenant) {
+      stmt.regionNodes = [];
+      return;
+    }
     const regions: { [region: string]: Set<number> } = {};
     // For each region, populate a list of all nodes where the statement was executed.
     // E.g. {"gcp-us-east1" : [1,3,4]}

--- a/pkg/ui/workspaces/cluster-ui/src/store/uiConfig/uiConfig.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/uiConfig/uiConfig.reducer.ts
@@ -11,6 +11,8 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { merge } from "lodash";
 import { DOMAIN_NAME } from "../utils";
+import { createSelector } from "reselect";
+import { AppState } from "../reducers";
 
 export type UIConfigState = {
   isTenant: boolean;
@@ -51,5 +53,15 @@ const uiConfigSlice = createSlice({
     },
   },
 });
+
+export const selectUIConfig = createSelector(
+  (state: AppState) => state.adminUI.uiConfig,
+  uiConfig => uiConfig,
+);
+
+export const selectIsTenant = createSelector(
+  selectUIConfig,
+  uiConfig => uiConfig.isTenant,
+);
 
 export const { actions, reducer } = uiConfigSlice;

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.stories.tsx
@@ -32,6 +32,7 @@ storiesOf("Transactions Details", module)
       lastReset={Date().toString()}
       handleDetails={() => {}}
       resetSQLStats={() => {}}
+      isTenant={false}
     />
   ))
   .add("with loading indicator", () => (
@@ -42,6 +43,7 @@ storiesOf("Transactions Details", module)
       lastReset={Date().toString()}
       handleDetails={() => {}}
       resetSQLStats={() => {}}
+      isTenant={false}
     />
   ))
   .add("with error alert", () => (
@@ -53,5 +55,6 @@ storiesOf("Transactions Details", module)
       lastReset={Date().toString()}
       handleDetails={() => {}}
       resetSQLStats={() => {}}
+      isTenant={false}
     />
   ));

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
@@ -29,12 +29,8 @@ import { aggregateStatements } from "../transactionsPage/utils";
 import Long from "long";
 import { Loading } from "../loading";
 import { SummaryCard } from "../summaryCard";
-import {
-  Bytes,
-  Duration,
-  formatNumberForDisplay,
-  calculateTotalWorkload,
-} from "src/util";
+import { Bytes, Duration, formatNumberForDisplay } from "src/util";
+import { UIConfigState } from "../store/uiConfig";
 
 import summaryCardStyles from "../summaryCard/summaryCard.module.scss";
 import transactionDetailsStyles from "./transactionDetails.modules.scss";
@@ -68,6 +64,7 @@ interface TransactionDetailsProps {
   ) => void;
   error?: Error | null;
   resetSQLStats: () => void;
+  isTenant: UIConfigState["isTenant"];
 }
 
 interface TState {
@@ -89,6 +86,10 @@ export class TransactionDetails extends React.Component<
       pageSize: 10,
       current: 1,
     },
+  };
+
+  static defaultProps: Partial<TransactionDetailsProps> = {
+    isTenant: false,
   };
 
   onChangeSortSetting = (ss: SortSetting) => {
@@ -130,11 +131,19 @@ export class TransactionDetails extends React.Component<
           error={error}
           loading={!statements || !transactionStats}
           render={() => {
-            const { statements, transactionStats, lastReset } = this.props;
+            const {
+              statements,
+              transactionStats,
+              lastReset,
+              isTenant,
+            } = this.props;
             const { sortSetting, pagination } = this.state;
             const aggregatedStatements = aggregateStatements(statements);
-            const totalWorkload = calculateTotalWorkload(statements);
-            populateRegionNodeForStatements(aggregatedStatements, nodeRegions);
+            populateRegionNodeForStatements(
+              aggregatedStatements,
+              nodeRegions,
+              isTenant,
+            );
             const duration = (v: number) => Duration(v * 1e9);
             return (
               <React.Fragment>

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageConnected.tsx
@@ -24,6 +24,7 @@ import {
   selectTransactionsData,
   selectTransactionsLastError,
 } from "./transactionsPage.selectors";
+import { selectIsTenant } from "../store/uiConfig";
 import { nodeRegionsByIDSelector } from "../store/nodes";
 
 export const TransactionsPageConnected = withRouter(
@@ -36,6 +37,7 @@ export const TransactionsPageConnected = withRouter(
       data: selectTransactionsData(state),
       nodeRegions: nodeRegionsByIDSelector(state),
       error: selectTransactionsLastError(state),
+      isTenant: selectIsTenant(state),
     }),
     (dispatch: Dispatch) => ({
       refreshData: () => dispatch(transactionsActions.refresh()),

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.spec.ts
@@ -55,6 +55,7 @@ describe("Filter transactions", () => {
         "$ internal",
         data.statements,
         nodeRegions,
+        false,
       ).transactions.length,
       11,
     );
@@ -75,6 +76,7 @@ describe("Filter transactions", () => {
         "$ internal",
         data.statements,
         nodeRegions,
+        false,
       ).transactions.length,
       3,
     );
@@ -95,6 +97,7 @@ describe("Filter transactions", () => {
         "$ internal",
         data.statements,
         nodeRegions,
+        false,
       ).transactions.length,
       1,
     );
@@ -115,6 +118,7 @@ describe("Filter transactions", () => {
         "$ internal",
         data.statements,
         nodeRegions,
+        false,
       ).transactions.length,
       7,
     );
@@ -135,6 +139,7 @@ describe("Filter transactions", () => {
         "$ internal",
         data.statements,
         nodeRegions,
+        false,
       ).transactions.length,
       8,
     );
@@ -155,6 +160,7 @@ describe("Filter transactions", () => {
         "$ internal",
         data.statements,
         nodeRegions,
+        false,
       ).transactions.length,
       6,
     );
@@ -175,6 +181,7 @@ describe("Filter transactions", () => {
         "$ internal",
         data.statements,
         nodeRegions,
+        false,
       ).transactions.length,
       8,
     );
@@ -195,6 +202,7 @@ describe("Filter transactions", () => {
         "$ internal",
         data.statements,
         nodeRegions,
+        false,
       ).transactions.length,
       4,
     );
@@ -215,6 +223,7 @@ describe("Filter transactions", () => {
         "$ internal",
         data.statements,
         nodeRegions,
+        false,
       ).transactions.length,
       9,
     );

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
@@ -107,6 +107,7 @@ export const filterTransactions = (
   internalAppNamePrefix: string,
   statements: Statement[],
   nodeRegions: { [key: string]: string },
+  isTenant: boolean,
 ): { transactions: Transaction[]; activeFilters: number } => {
   if (!filters)
     return {
@@ -139,6 +140,9 @@ export const filterTransactions = (
       // The transaction must contain at least one value of the nodes
       // and regions list (if the list is not empty).
       if (regions.length == 0 && nodes.length == 0) return true;
+      // If the cluster is a tenant cluster we don't care
+      // about node/regions.
+      if (isTenant) return true;
       let foundRegion: boolean = regions.length == 0;
       let foundNode: boolean = nodes.length == 0;
 

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsTable.tsx
@@ -41,7 +41,6 @@ import statsTablePageStyles from "src/statementsTable/statementsTableContent.mod
 
 type Transaction = protos.cockroach.server.serverpb.StatementsResponse.IExtendedCollectedTransactionStatistics;
 type TransactionStats = protos.cockroach.sql.ITransactionStatistics;
-type CollectedTransactionStatistics = protos.cockroach.sql.ICollectedTransactionStatistics;
 type Statement = protos.cockroach.server.serverpb.StatementsResponse.ICollectedStatementStatistics;
 
 interface TransactionsTable {
@@ -55,6 +54,7 @@ interface TransactionsTable {
   pagination: ISortedTablePagination;
   statements: Statement[];
   nodeRegions: { [key: string]: string };
+  isTenant: boolean;
   search?: string;
   renderNoResult?: React.ReactNode;
 }
@@ -81,7 +81,7 @@ export const TransactionsTable: React.FC<TransactionsTable> = props => {
     },
   };
 
-  const { transactions, handleDetails, statements, search } = props;
+  const { transactions, handleDetails, statements, search, isTenant } = props;
   const countBar = transactionsCountBarChart(transactions);
   const rowsReadBar = transactionsRowsReadBarChart(
     transactions,
@@ -200,6 +200,7 @@ export const TransactionsTable: React.FC<TransactionsTable> = props => {
         return longListWithTooltip(item.regionNodes.sort().join(", "), 50);
       },
       sort: (item: TransactionInfo) => item.regionNodes.sort().join(", "),
+      hideIfTenant: true,
     },
     {
       name: "statements",
@@ -209,7 +210,7 @@ export const TransactionsTable: React.FC<TransactionsTable> = props => {
       sort: (item: TransactionInfo) =>
         item.stats_data.statement_fingerprint_ids.length,
     },
-  ];
+  ].filter(c => !(isTenant && c.hideIfTenant));
 
   return (
     <SortedTable


### PR DESCRIPTION
On tenant clusters we don't want to show information
about nodes and regions.

This commit hides that information on:
- statements page (table, filter, column selector)
- statement details page (overview, exec stats)
- transactions page (table, filter)

Release justification: Category 4
Release note (ui change): Hide node and regions information
on the new tenant plan (serverless / free tier)