### PR TITLE
roachtest: ignore pgx COPY error test

### DIFF
--- a/pkg/cmd/roachtest/tests/pgx_blocklist.go
+++ b/pkg/cmd/roachtest/tests/pgx_blocklist.go
@@ -30,6 +30,7 @@ var pgxIgnorelist21_2 = pgxIgnorelist21_1
 var pgxIgnorelist21_1 = pgxIgnorelist20_2
 
 var pgxIgnorelist20_2 = blocklist{
-	"v4.TestBeginIsoLevels":   "We don't support isolation levels",
-	"v4.TestQueryEncodeError": "This test checks the exact error message",
+	"v4.TestBeginIsoLevels": "We don't support isolation levels",
+	"v4.TestConnCopyFromFailServerSideMidwayAbortsWithoutWaiting": "https://github.com/cockroachdb/cockroach/issues/69291#issuecomment-906898940",
+	"v4.TestQueryEncodeError":                                     "This test checks the exact error message",
 }


### PR DESCRIPTION
resolves https://github.com/cockroachdb/cockroach/issues/69291

This is failing after https://github.com/cockroachdb/cockroach/pull/69066 got merged.
`TestConnCopyFromFailServerSideMidwayAbortsWithoutWaiting` is checking
that the COPY command errors out quickly if it tries to insert a null
value into a non-nullable column.

Previously this would pass against CRDB, since it would actually error
out due to CRDB not handling partial batches of data (https://github.com/cockroachdb/cockroach/issues/68805).
Now that https://github.com/cockroachdb/cockroach/issues/68805 is fixed,
the pgx test gets a bit further.

It fails this assertion:
```
	endTime := time.Now()
	copyTime := endTime.Sub(startTime)
	if copyTime > time.Second {
		t.Errorf("Failing CopyFrom shouldn't have taken so long: %v", copyTime)
	}
```

The COPY command does not fail immediately against CRDB because we have logic to delay
inserting rows until we see 100 rows total:
https://github.com/cockroachdb/cockroach/blob/8cae60f603ccc4d83137167b3b31cab09be9d41a/pkg/sql/copy.go#L370-L374

I don't think we should change our row batching behavior, so for now
it makes sense to ignore this pgx test.

Release justification: test only change
Release note: None