### PR TITLE
sqlproxyccl: allow options params in connection string

### DIFF
--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -769,7 +769,10 @@ func TestClusterNameAndTenantFromParams(t *testing.T) {
 			},
 			expectedClusterName: "happy-koala",
 			expectedTenantID:    7,
-			expectedParams:      map[string]string{"database": "defaultdb"},
+			expectedParams: map[string]string{
+				"database": "defaultdb",
+				"options":  "-c  -c -c -c",
+			},
 		},
 		{
 			name: "short option: cluster name in options param",
@@ -799,7 +802,23 @@ func TestClusterNameAndTenantFromParams(t *testing.T) {
 			},
 			expectedClusterName: "happy-koala",
 			expectedTenantID:    7,
-			expectedParams:      map[string]string{"database": "defaultdb"},
+			expectedParams: map[string]string{
+				"database": "defaultdb",
+				"options":  "--foo=test",
+			},
+		},
+		{
+			name: "long option: cluster name in options param with other options",
+			params: map[string]string{
+				"database": "defaultdb",
+				"options":  "-csearch_path=public --cluster=happy-koala-7\t--foo=test",
+			},
+			expectedClusterName: "happy-koala",
+			expectedTenantID:    7,
+			expectedParams: map[string]string{
+				"database": "defaultdb",
+				"options":  "-csearch_path=public \t--foo=test",
+			},
 		},
 		{
 			name:                "leading 0s are ok",

--- a/pkg/sql/pgwire/conn_test.go
+++ b/pkg/sql/pgwire/conn_test.go
@@ -1366,6 +1366,15 @@ func TestParseClientProvidedSessionParameters(t *testing.T) {
 			},
 		},
 		{
+			desc:  "success parsing options with a tab (%09) separating the options",
+			query: "user=root&options=-csearch_path=default,test%09-coptimizer_use_multicol_stats=true",
+			assert: func(t *testing.T, args sql.SessionArgs, err error) {
+				require.NoError(t, err)
+				require.Equal(t, "default,test", args.SessionDefaults["search_path"])
+				require.Equal(t, "true", args.SessionDefaults["optimizer_use_multicol_stats"])
+			},
+		},
+		{
 			desc:  "error when no leading '-c'",
 			query: "user=root&options=search_path=default",
 			assert: func(t *testing.T, args sql.SessionArgs, err error) {

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
+	"unicode"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security"
@@ -918,7 +919,7 @@ func splitOptions(options string) []string {
 	for i < len(options) {
 		sb.Reset()
 		// skip leading space
-		for i < len(options) && options[i] == ' ' {
+		for i < len(options) && unicode.IsSpace(rune(options[i])) {
 			i++
 		}
 		if i == len(options) {
@@ -928,7 +929,7 @@ func splitOptions(options string) []string {
 		lastWasEscape := false
 
 		for i < len(options) {
-			if options[i] == ' ' && !lastWasEscape {
+			if unicode.IsSpace(rune(options[i])) && !lastWasEscape {
 				break
 			}
 			if !lastWasEscape && options[i] == '\\' {


### PR DESCRIPTION
CC-3612

Previously, the sqlproxy would not send the options param from the
connection string to the backend SQL pod. This prevented PGJDBC clients
from being able to configure session variables in the connection string.

This also includes a small fix to sql/pgwire to check for any whitespace
in the options param, rather than just ' ' characters.

Release justification: sqlproxy only change
Release note: None