### PR TITLE
ts: include histogram quantiles in tsdump

### DIFF
--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -381,6 +381,7 @@ go_test(
         "@com_github_grpc_ecosystem_grpc_gateway//runtime:go_default_library",
         "@com_github_kr_pretty//:pretty",
         "@com_github_lib_pq//:pq",
+        "@com_github_prometheus_client_model//go",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_grpc//:go_default_library",

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -66,6 +66,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/kr/pretty"
+	io_prometheus_client "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -929,6 +930,17 @@ func TestChartCatalogGen(t *testing.T) {
 	}
 }
 
+// walkAllSections invokes the visitor on each of the ChartSections nestled under
+// the input one.
+func walkAllSections(chartCatalog []catalog.ChartSection, visit func(c *catalog.ChartSection)) {
+	for _, c := range chartCatalog {
+		visit(&c)
+		for _, ic := range c.Subsections {
+			visit(ic)
+		}
+	}
+}
+
 // findUndefinedMetrics finds metrics listed in pkg/ts/catalog/chart_catalog.go
 // that are not defined. This is most likely caused by a metric being removed.
 func findUndefinedMetrics(c *catalog.ChartSection, metadata map[string]metric.Metadata) []string {
@@ -1015,9 +1027,35 @@ func TestChartCatalogMetrics(t *testing.T) {
 			metricNames = append(metricNames, metricName)
 		}
 		sort.Strings(metricNames)
-		t.Fatalf(`The following metrics need to be added to the chart catalog
+		t.Errorf(`The following metrics need to be added to the chart catalog
 		    (pkg/ts/catalog/chart_catalog.go): %v`, metricNames)
 	}
+
+	internalTSDBMetricNamesWithoutPrefix := map[string]struct{}{}
+	for _, name := range catalog.AllInternalTimeseriesMetricNames() {
+		name = strings.TrimPrefix(name, "cr.node.")
+		name = strings.TrimPrefix(name, "cr.store.")
+		internalTSDBMetricNamesWithoutPrefix[name] = struct{}{}
+	}
+	walkAllSections(chartCatalog, func(cs *catalog.ChartSection) {
+		for _, chart := range cs.Charts {
+			for _, metric := range chart.Metrics {
+				if *metric.MetricType.Enum() != io_prometheus_client.MetricType_HISTOGRAM {
+					continue
+				}
+				// We have a histogram. Make sure that it is properly represented in
+				// AllInternalTimeseriesMetricNames(). It's not a complete check but good enough in
+				// practice. Ideally we wouldn't require `histogramMetricsNames` and
+				// the associated manual step when adding a histogram. See:
+				// https://github.com/cockroachdb/cockroach/issues/64373
+				_, ok := internalTSDBMetricNamesWithoutPrefix[metric.Name+"-p50"]
+				if !ok {
+					t.Errorf("histogram %s needs to be added to `catalog.histogramMetricsNames` manually",
+						metric.Name)
+				}
+			}
+		}
+	})
 }
 
 func TestHotRangesResponse(t *testing.T) {

--- a/pkg/ts/server.go
+++ b/pkg/ts/server.go
@@ -337,7 +337,7 @@ func dumpImpl(
 ) error {
 	names := req.Names
 	if len(names) == 0 {
-		names = catalog.AllMetricsNames()
+		names = catalog.AllInternalTimeseriesMetricNames()
 	}
 	resolutions := req.Resolutions
 	if len(resolutions) == 0 {


### PR DESCRIPTION
`cockroach debug tsdump` previously silently did not return metrics
backed by histograms. This is for technical reasons related to the
bookkeeping of metrics names and is rectified here by requiring some
extra tagging of metrics that are histograms so that they can be picked
up by tsdump. It's not pretty, but pragmatic: it works and it'll be
clear to anyone adding a histogram in the future how to proceed, even if
they may wonder why things work in such a roundabout manner (and if
they're curious about that, the relevant issues are linked in comments
as well).

I also renamed AllMetricsNames to AllInternalTimeseriesMetricsNames
to make clear what is being returned.

Demo:

```
killall -9 cockroach; rm -rf cockroach-data;
./cockroach start-single-node --insecure --background && \
./cockroach workload run kv --init \
    'postgres://root@127.0.0.1:26257?sslmode=disable' --duration=300s && \
./cockroach debug tsdump --format=raw --insecure > tsdump.gob && \
killall -9 cockroach && rm -rf cockroach-data && \
COCKROACH_DEBUG_TS_IMPORT_FILE=tsdump.gob ./cockroach start-single-node --insecure
```

![image](https://user-images.githubusercontent.com/5076964/131134624-b5471621-d23b-4ce7-9026-e8aeb3613231.png)

Release justification: low-risk observability fix
Release note (ops change): The ./cockroach debug tsdump command now
downloads histogram timeseries it silently omitted previously.