### PR TITLE
release-21.1: kvserver: check if a node is available before checking draining or de…

### DIFF
--- a/pkg/kv/kvserver/store_pool.go
+++ b/pkg/kv/kvserver/store_pool.go
@@ -174,13 +174,13 @@ func LivenessStatus(
 		}
 		return livenesspb.NodeLivenessStatus_DEAD
 	}
-	if !l.Membership.Active() {
-		return livenesspb.NodeLivenessStatus_DECOMMISSIONING
-	}
-	if l.Draining {
-		return livenesspb.NodeLivenessStatus_DRAINING
-	}
 	if l.IsLive(now) {
+		if !l.Membership.Active() {
+			return livenesspb.NodeLivenessStatus_DECOMMISSIONING
+		}
+		if l.Draining {
+			return livenesspb.NodeLivenessStatus_DRAINING
+		}
 		return livenesspb.NodeLivenessStatus_LIVE
 	}
 	return livenesspb.NodeLivenessStatus_UNAVAILABLE

--- a/pkg/kv/kvserver/store_pool_test.go
+++ b/pkg/kv/kvserver/store_pool_test.go
@@ -1227,7 +1227,7 @@ func TestNodeLivenessLivenessStatus(t *testing.T) {
 			},
 			expected: livenesspb.NodeLivenessStatus_DECOMMISSIONED,
 		},
-		// Draining (reports as unavailable).
+		// Draining
 		{
 			liveness: livenesspb.Liveness{
 				NodeID: 1,
@@ -1238,6 +1238,31 @@ func TestNodeLivenessLivenessStatus(t *testing.T) {
 				Draining: true,
 			},
 			expected: livenesspb.NodeLivenessStatus_DRAINING,
+		},
+		// Decommissioning that is unavailable.
+		{
+			liveness: livenesspb.Liveness{
+				NodeID: 1,
+				Epoch:  1,
+				Expiration: hlc.LegacyTimestamp{
+					WallTime: now.UnixNano(),
+				},
+				Draining:   false,
+				Membership: livenesspb.MembershipStatus_DECOMMISSIONING,
+			},
+			expected: livenesspb.NodeLivenessStatus_UNAVAILABLE,
+		},
+		// Draining that is unavailable.
+		{
+			liveness: livenesspb.Liveness{
+				NodeID: 1,
+				Epoch:  1,
+				Expiration: hlc.LegacyTimestamp{
+					WallTime: now.UnixNano(),
+				},
+				Draining: true,
+			},
+			expected: livenesspb.NodeLivenessStatus_UNAVAILABLE,
 		},
 	} {
 		t.Run("", func(t *testing.T) {


### PR DESCRIPTION
Backport 1/1 commits from #67319.

/cc @cockroachdb/release

---

…commissioning status

Fixes #66648

Check if a node is alive before checking if it's draining or decommissioning.
We only want to check those flags if the node is up and heartbeating, because we
don't want to accidentally treat that node as live and move a lease to it. If
a node is draining or decommissioning and it's liveness has expired we will consider it
unavailable. 

Release note (bug fix): Previously an unavailable node that started draining or
decommissioning would be treated as live and thus could receive a lease transfer,
leading to the range becoming unavailable.

Release justification: Small bug fix to the allocator to prevent a lease
transfer to an unavailable node, which leads to unavailability.
