### PR TITLE
sql: fix some issues around the portal state management

### DIFF
--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -488,7 +488,7 @@ func (ex *connExecutor) deletePortal(ctx context.Context, name string) {
 	if !ok {
 		return
 	}
-	portal.decRef(ctx, &ex.extraTxnState.prepStmtsNamespaceMemAcc, name)
+	portal.close(ctx, &ex.extraTxnState.prepStmtsNamespaceMemAcc, name)
 	delete(ex.extraTxnState.prepStmtsNamespace.portals, name)
 }
 

--- a/pkg/sql/prepared_stmt.go
+++ b/pkg/sql/prepared_stmt.go
@@ -115,23 +115,14 @@ type preparedStatementsAccessor interface {
 	DeleteAll(ctx context.Context)
 }
 
-// PreparedPortal is a PreparedStatement that has been bound with query arguments.
-//
-// Note that PreparedPortals maintain a reference counter internally.
-// References need to be registered with incRef() and de-registered with
-// decRef().
+// PreparedPortal is a PreparedStatement that has been bound with query
+// arguments.
 type PreparedPortal struct {
 	Stmt  *PreparedStatement
 	Qargs tree.QueryArguments
 
 	// OutFormats contains the requested formats for the output columns.
 	OutFormats []pgwirebase.FormatCode
-
-	// refCount keeps track of the number of references to this PreparedStatement.
-	// New references are registered through incRef().
-	// Most references are being held by portals created from this prepared
-	// statement.
-	refCount int
 
 	// exhausted tracks whether this portal has already been fully exhausted,
 	// meaning that any additional attempts to execute it should return no
@@ -141,8 +132,7 @@ type PreparedPortal struct {
 
 // makePreparedPortal creates a new PreparedPortal.
 //
-// incRef() doesn't need to be called on the result.
-// When no longer in use, the PreparedPortal needs to be decRef()d.
+// accountForCopy() doesn't need to be called on the prepared statement.
 func (ex *connExecutor) makePreparedPortal(
 	ctx context.Context,
 	name string,
@@ -154,37 +144,25 @@ func (ex *connExecutor) makePreparedPortal(
 		Stmt:       stmt,
 		Qargs:      qargs,
 		OutFormats: outFormats,
-		refCount:   1,
 	}
-	if err := ex.extraTxnState.prepStmtsNamespaceMemAcc.Grow(ctx, portal.size(name)); err != nil {
-		return PreparedPortal{}, err
-	}
-	// The portal keeps a reference to the PreparedStatement, so register it.
-	stmt.incRef(ctx)
-	return portal, nil
+	return portal, portal.accountForCopy(ctx, &ex.extraTxnState.prepStmtsNamespaceMemAcc, name)
 }
 
-func (p *PreparedPortal) incRef(ctx context.Context) {
-	if p.refCount <= 0 {
-		log.Fatal(ctx, "corrupt PreparedPortal refcount")
-	}
-	p.refCount++
+// accountForCopy updates the state to account for the copy of the
+// PreparedPortal (p is the copy).
+func (p PreparedPortal) accountForCopy(
+	ctx context.Context, prepStmtsNamespaceMemAcc *mon.BoundAccount, portalName string,
+) error {
+	p.Stmt.incRef(ctx)
+	return prepStmtsNamespaceMemAcc.Grow(ctx, p.size(portalName))
 }
 
-// decRef decrements the number of references to this portal. If the refCount
-// reaches 0, then the memory account is shrunk accordingly.
-func (p *PreparedPortal) decRef(
+// close closes this portal.
+func (p PreparedPortal) close(
 	ctx context.Context, prepStmtsNamespaceMemAcc *mon.BoundAccount, portalName string,
 ) {
-	if p.refCount <= 0 {
-		log.Fatal(ctx, "corrupt PreparedPortal refcount")
-	}
-	p.refCount--
-
-	if p.refCount == 0 {
-		prepStmtsNamespaceMemAcc.Shrink(ctx, p.size(portalName))
-		p.Stmt.decRef(ctx)
-	}
+	prepStmtsNamespaceMemAcc.Shrink(ctx, p.size(portalName))
+	p.Stmt.decRef(ctx)
 }
 
 func (p PreparedPortal) size(portalName string) int64 {


### PR DESCRIPTION
This commit fixes some issues around the handling of portals in the
prepared statements namespace. Namely:
- it fixes the reference counting that was broken in cf0d5e4 (where we
switched to storing the portal by value instead of by pointer, but the
refcounts need to be shared between all references which wasn't true
in that commit) by entirely removing the ref counting
- it fixes the missing memory accounting for a copy of the portal
- it deletes all of the portals from `prepStmtsNamespaceAtTxnRewindPos`
in `resetExtraTxnState` whenever a txn commits or rolls back
- it adjusts a comment on the method deleting a prepared statement to
match the implementation.

Release note: None.

Release justification: fix to a long-standing bug.