### PR TITLE
sql: set_config builtin supports local=true

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -2954,6 +2954,10 @@ SELECT * FROM crdb_internal.check_consistency(true, ‘\x02’, ‘\x04’)</p>
 <table>
 <thead><tr><th>Function &rarr; Returns</th><th>Description</th></tr></thead>
 <tbody>
+<tr><td><a name="current_setting"></a><code>current_setting(setting_name: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>System info</p>
+</span></td></tr>
+<tr><td><a name="current_setting"></a><code>current_setting(setting_name: <a href="string.html">string</a>, missing_ok: <a href="bool.html">bool</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>System info</p>
+</span></td></tr>
 <tr><td><a name="format_type"></a><code>format_type(type_oid: oid, typemod: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the SQL name of a data type that is identified by its type OID and possibly a type modifier. Currently, the type modifier is ignored.</p>
 </span></td></tr>
 <tr><td><a name="getdatabaseencoding"></a><code>getdatabaseencoding() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the current encoding name used by the database.</p>
@@ -3127,6 +3131,8 @@ SELECT * FROM crdb_internal.check_consistency(true, ‘\x02’, ‘\x04’)</p>
 <tr><td><a name="pg_table_is_visible"></a><code>pg_table_is_visible(oid: oid) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns whether the table with the given OID belongs to one of the schemas on the search path.</p>
 </span></td></tr>
 <tr><td><a name="pg_type_is_visible"></a><code>pg_type_is_visible(oid: oid) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns whether the type with the given OID belongs to one of the schemas on the search path.</p>
+</span></td></tr>
+<tr><td><a name="set_config"></a><code>set_config(setting_name: <a href="string.html">string</a>, new_value: <a href="string.html">string</a>, is_local: <a href="bool.html">bool</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>System info</p>
 </span></td></tr></tbody>
 </table>
 

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -374,7 +374,9 @@ func (ep *DummySessionAccessor) GetSessionVar(
 }
 
 // SetSessionVar is part of the tree.EvalSessionAccessor interface.
-func (ep *DummySessionAccessor) SetSessionVar(_ context.Context, _, _ string) error {
+func (ep *DummySessionAccessor) SetSessionVar(
+	ctx context.Context, settingName, newValue string, isLocal bool,
+) error {
 	return errors.WithStack(errEvalSessionVar)
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/pg_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/pg_builtins
@@ -239,3 +239,104 @@ relation does not exist               0
 relation does not exist               false
 relation exists, but column does not  true
 system column                         false
+
+query T
+SELECT current_setting('statement_timeout')
+----
+0
+
+query T
+SELECT current_setting('statement_timeout', false)
+----
+0
+
+# check returns null on unsupported session var.
+query T
+SELECT IFNULL(current_setting('woo', true), 'OK')
+----
+OK
+
+# check that current_setting handles null.
+query T
+SELECT current_setting(NULL, false)
+----
+NULL
+
+# check that multiple settings can be queried at once.
+query TT
+SELECT current_setting('statement_timeout'), current_setting('search_path')
+----
+0  "$user", public
+
+# check error on nonexistent session var.
+query error unrecognized configuration parameter
+SELECT pg_catalog.current_setting('woo', false)
+
+# check error on unsupported session var.
+query error configuration setting.*not supported
+SELECT current_setting('vacuum_cost_delay', false)
+
+query T
+SHOW application_name
+----
+·
+
+query T
+SELECT set_config('application_name', 'woo', false)
+----
+woo
+
+query T
+SHOW application_name
+----
+woo
+
+# check that multiple settings can be set at once
+query TTT
+SELECT
+  set_config('application_name', 'foo', false),
+  set_config('statement_timeout', '60s', false),
+  set_config(NULL, 'foo', false)
+----
+foo  60000  NULL
+
+# check that the value doesn't change with isLocal=true outside of a
+# transaction. Note: in Postgres, set_config returns 'woo' here even though
+# the value doesn't change. This difference doesn't seem too important.
+query T
+SELECT set_config('application_name', 'woo', true)
+----
+foo
+
+query T
+SELECT current_setting('application_name')
+----
+foo
+
+# verify that the setting change is scoped to the transaction with isLocal=true.
+statement ok
+BEGIN
+
+query T
+SELECT set_config('application_name', 'woo', true)
+----
+woo
+
+query TT
+SELECT current_setting('application_name'), current_setting('statement_timeout')
+----
+woo  60000
+
+statement ok
+COMMIT
+
+query T
+SELECT current_setting('application_name')
+----
+foo
+
+query error unrecognized configuration parameter
+SELECT pg_catalog.set_config('woo', 'woo', false)
+
+query error configuration setting.*not supported
+SELECT set_config('vacuum_cost_delay', '0', false)

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -4597,56 +4597,6 @@ v_x_y_key   NULL
 statement ok
 DROP DATABASE d34862 CASCADE; SET database=test
 
-subtest regression_35108
-
-query T
-SELECT pg_catalog.current_setting('statement_timeout')
-----
-0
-
-query T
-SELECT pg_catalog.current_setting('statement_timeout', false)
-----
-0
-
-# check returns null on unsupported session var.
-query T
-SELECT IFNULL(pg_catalog.current_setting('woo', true), 'OK')
-----
-OK
-
-# check error on nonexistent session var.
-query error unrecognized configuration parameter
-SELECT pg_catalog.current_setting('woo', false)
-
-# check error on unsupported session var.
-query error configuration setting.*not supported
-SELECT pg_catalog.current_setting('vacuum_cost_delay', false)
-
-query T
-SHOW application_name
-----
-·
-
-query T
-SELECT pg_catalog.set_config('application_name', 'woo', false)
-----
-woo
-
-query T
-SHOW application_name
-----
-woo
-
-query error transaction-scoped settings are not supported
-SELECT  pg_catalog.set_config('application_name', 'woo', true)
-
-query error unrecognized configuration parameter
-SELECT  pg_catalog.set_config('woo', 'woo', false)
-
-query error configuration setting.*not supported
-SELECT  pg_catalog.set_config('vacuum_cost_delay', '0', false)
-
 subtest regression_46450
 
 statement ok

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3241,11 +3241,12 @@ type CompactEngineSpanFunc func(
 
 // EvalSessionAccessor is a limited interface to access session variables.
 type EvalSessionAccessor interface {
-	// SetConfig sets a session variable to a new value.
+	// SetSessionVar sets a session variable to a new value. If isLocal is true,
+	// the setting change is scoped to the current transaction (as in SET LOCAL).
 	//
 	// This interface only supports strings as this is sufficient for
 	// pg_catalog.set_config().
-	SetSessionVar(ctx context.Context, settingName, newValue string) error
+	SetSessionVar(ctx context.Context, settingName, newValue string, isLocal bool) error
 
 	// GetSessionVar retrieves the current value of a session variable.
 	GetSessionVar(ctx context.Context, settingName string, missingOk bool) (bool, string, error)
@@ -3253,7 +3254,7 @@ type EvalSessionAccessor interface {
 	// HasAdminRole returns true iff the current session user has the admin role.
 	HasAdminRole(ctx context.Context) (bool, error)
 
-	// HasAdminRole returns nil iff the current session user has the specified
+	// HasRoleOption returns nil iff the current session user has the specified
 	// role option.
 	HasRoleOption(ctx context.Context, roleOption roleoption.Option) (bool, error)
 }

--- a/pkg/sql/set_var.go
+++ b/pkg/sql/set_var.go
@@ -136,27 +136,7 @@ func (n *setVarNode) startExec(params runParams) error {
 		)
 	}
 
-	// Note for RuntimeSet and SetWithPlanner we do not use the sessionDataMutator
-	// as the callers need items that are only accessible by higher level
-	// objects - and some of the computation potentially expensive so should be
-	// batched instead of performing the computation on each mutator.
-	// It is their responsibility to set LOCAL or SESSION after
-	// doing the computation.
-	if n.v.RuntimeSet != nil {
-		return n.v.RuntimeSet(params.ctx, params.p.ExtendedEvalContext(), n.local, strVal)
-	}
-
-	if n.v.SetWithPlanner != nil {
-		return n.v.SetWithPlanner(params.ctx, params.p, n.local, strVal)
-	}
-
-	return params.p.applyOnSessionDataMutators(
-		params.ctx,
-		n.local,
-		func(m *sessionDataMutator) error {
-			return n.v.Set(params.ctx, m, strVal)
-		},
-	)
+	return params.p.SetSessionVar(params.ctx, n.name, strVal, n.local)
 }
 
 // applyOnSessionDataMutators applies the given function on the relevant


### PR DESCRIPTION
refs https://github.com/cockroachdb/cockroach/issues/32562

Now that SET LOCAL is implemented, this builtin can be supported.

Release justification: low-risk update to new functionality.
Release note (sql change): The set_config builtin function now allows
the `local` parameter to be true. This is the same as using SET LOCAL.