### PR TITLE
kv: specify + test behavior of NegotiateAndSend with paginated reads

### DIFF
--- a/pkg/kv/kvserver/replica_closedts_internal_test.go
+++ b/pkg/kv/kvserver/replica_closedts_internal_test.go
@@ -12,6 +12,7 @@ package kvserver
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
 	"sync/atomic"
 	"testing"
@@ -1002,4 +1003,188 @@ func TestServerSideBoundedStalenessNegotiation(t *testing.T) {
 			})
 		}
 	})
+}
+
+// TestServerSideBoundedStalenessNegotiationWithResumeSpan verifies that the
+// server-side bounded staleness negotiation fast-path negotiates a timestamp
+// over a batch's entire set of read spans even if it only performs reads and
+// returns results from part of them due to a key/byte limit.
+func TestServerSideBoundedStalenessNegotiationWithResumeSpan(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	// Setup:
+	//
+	//  a: value  @ 9
+	//  b: value  @ 20 // ts above res ts, ignored by reads
+	//  c: value  @ 5
+	//  d: intent @ 20
+	//  e: value  @ 10 // ts above res ts, ignored by reads
+	//  f: value  @ 6
+	//  g: intent @ 10
+	//  h: value  @ 7
+	//
+	//  closed_timestamp: 30
+	//
+	//  expected_resolved_timestamp: 10.Prev()
+	//
+	makeTS := func(ts int64) hlc.Timestamp {
+		return hlc.Timestamp{WallTime: ts}
+	}
+	setup := func(t *testing.T, tc *testContext) hlc.Timestamp {
+		// Write values and intents.
+		val := []byte("val")
+		send := func(h roachpb.Header, args roachpb.Request) {
+			_, pErr := kv.SendWrappedWith(ctx, tc.Sender(), h, args)
+			require.Nil(t, pErr)
+		}
+		writeValue := func(k string, ts int64) {
+			pArgs := putArgs(roachpb.Key(k), val)
+			send(roachpb.Header{Timestamp: makeTS(ts)}, &pArgs)
+		}
+		writeIntent := func(k string, ts int64) {
+			txn := roachpb.MakeTransaction("test", roachpb.Key(k), 0, makeTS(ts), 0)
+			pArgs := putArgs(roachpb.Key(k), val)
+			assignSeqNumsForReqs(&txn, &pArgs)
+			send(roachpb.Header{Txn: &txn}, &pArgs)
+		}
+		writeValue("a", 9)
+		writeValue("b", 20)
+		writeValue("c", 5)
+		writeIntent("d", 20)
+		writeValue("e", 10)
+		writeValue("f", 6)
+		writeIntent("g", 10)
+		writeValue("h", 7)
+
+		// Inject a closed timestamp.
+		tc.repl.mu.Lock()
+		tc.repl.mu.state.RaftClosedTimestamp = makeTS(30)
+		tc.repl.mu.Unlock()
+
+		// Return the timestamp of the earliest intent.
+		return makeTS(10)
+	}
+
+	// Reqs:
+	//
+	//  scan: [a, f)
+	//  get:  [f]
+	//  get:  [g]
+	//  get:  [h]
+	//
+	makeReq := func(maxKeys int) (ba roachpb.BatchRequest) {
+		ba.BoundedStaleness = &roachpb.BoundedStalenessHeader{
+			MinTimestampBound: makeTS(5),
+		}
+		ba.WaitPolicy = lock.WaitPolicy_Error
+		ba.MaxSpanRequestKeys = int64(maxKeys)
+
+		scan := scanArgsString("a", "f")
+		get1 := getArgsString("f")
+		get2 := getArgsString("g")
+		get3 := getArgsString("h")
+		ba.Add(scan, get1, get2, get3)
+		return ba
+	}
+
+	for _, test := range []struct {
+		maxKeys int
+
+		expRespKeys   []string
+		expResumeSpan string
+	}{
+		{
+			maxKeys:     0, // no limit
+			expRespKeys: []string{"a", "c", "f", "h"},
+		},
+		{
+			maxKeys:       1,
+			expRespKeys:   []string{"a"},
+			expResumeSpan: "b",
+		},
+		{
+			maxKeys:       2,
+			expRespKeys:   []string{"a", "c"},
+			expResumeSpan: "d",
+		},
+		{
+			maxKeys:       3,
+			expRespKeys:   []string{"a", "c", "f"},
+			expResumeSpan: "g",
+		},
+		{
+			maxKeys:     4,
+			expRespKeys: []string{"a", "c", "f", "h"},
+		},
+		{
+			maxKeys:     5,
+			expRespKeys: []string{"a", "c", "f", "h"},
+		},
+	} {
+		t.Run(fmt.Sprintf("maxKeys=%d", test.maxKeys), func(t *testing.T) {
+			stopper := stop.NewStopper()
+			defer stopper.Stop(ctx)
+
+			// Create a single range.
+			var tc testContext
+			tc.manualClock = hlc.NewManualClock(1) // required by StartWithStoreConfig
+			cfg := TestStoreConfig(hlc.NewClock(tc.manualClock.UnixNano, 100*time.Nanosecond))
+			cfg.TestingKnobs.DontCloseTimestamps = true
+			tc.StartWithStoreConfig(t, stopper, cfg)
+
+			// Set up the test.
+			earliestIntentTS := setup(t, &tc)
+
+			// Construct the request.
+			ba := makeReq(test.maxKeys)
+			ba.RangeID = tc.rangeID
+
+			// Regardless of the keys returned, we expect negotiation to decide on the
+			// timestamp immediately preceding the earliest intent. This is the
+			// primary focus of this test. It would be incorrect for the negotiated
+			// spans to be limited to only the spans read before the key limit was
+			// reached.
+			expRespTS := earliestIntentTS.Prev()
+
+			// Issue the request.
+			br, pErr := tc.store.Send(ctx, ba)
+			require.Nil(t, pErr)
+			require.NotNil(t, br)
+			require.Equal(t, expRespTS, br.Timestamp)
+			require.Equal(t, len(ba.Requests), len(br.Responses))
+
+			// Validate response keys and resume span.
+			var respKeys []string
+			var resumeStart roachpb.Key
+			for i, ru := range br.Responses {
+				req := ru.GetInner()
+				switch v := req.(type) {
+				case *roachpb.ScanResponse:
+					for _, kv := range v.Rows {
+						respKeys = append(respKeys, string(kv.Key))
+					}
+				case *roachpb.GetResponse:
+					if v.Value.IsPresent() {
+						respKeys = append(respKeys, string(ba.Requests[i].GetGet().Key))
+					}
+				default:
+					t.Fatalf("unexpected response type %T", req)
+				}
+				if resume := req.Header().ResumeSpan; resume != nil {
+					if resumeStart == nil || resume.Key.Compare(resumeStart) < 0 {
+						resumeStart = resume.Key
+					}
+				}
+			}
+			require.Equal(t, test.expRespKeys, respKeys)
+			if test.expResumeSpan == "" {
+				require.Nil(t, resumeStart)
+			} else {
+				require.NotNil(t, resumeStart)
+				require.Equal(t, test.expResumeSpan, string(resumeStart))
+			}
+		})
+	}
 }

--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -1044,6 +1044,14 @@ func (txn *Txn) handleErrIfRetryableLocked(ctx context.Context, err error) {
 // successfully, the transaction will have been given a fixed timestamp equal to
 // the timestamp that the read-only request was evaluated at.
 //
+// If the read-only request hits a key or byte limit and returns a resume span,
+// meaning that it was paginated and did not return all desired results, the
+// transaction's timestamp will have still been fixed to a timestamp that was
+// negotiated over the entire set of read spans in the provided batch. As such,
+// it is safe for callers to resume reading at the bounded-staleness timestamp
+// by using Send. Future calls to Send must not include a BoundedStaleness
+// header, but may still specify the same routing policy.
+//
 // The method accepts requests with min_timestamp_bound_strict set to either
 // true or false, which dictates whether a bounded staleness read whose
 // min_timestamp_bound cannot be satisfied by the first replica it visits

--- a/pkg/kv/txn_test.go
+++ b/pkg/kv/txn_test.go
@@ -709,3 +709,82 @@ func TestTxnNegotiateAndSendWithDeadline(t *testing.T) {
 		})
 	}
 }
+
+// TestTxnNegotiateAndSendWithResumeSpan tests that a bounded staleness read
+// request performed using NegotiateAndSend negotiates a timestamp over the
+// provided batch's entire set of read spans even if it only performs reads and
+// returns results from part of them due to a key/byte limit. It then uses this
+// negotiated timestamp to fix its transaction's commit timestamp.
+func TestTxnNegotiateAndSendWithResumeSpan(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+
+	testutils.RunTrueAndFalse(t, "fast-path", func(t *testing.T, fastPath bool) {
+		ts10 := hlc.Timestamp{WallTime: 10}
+		ts20 := hlc.Timestamp{WallTime: 20}
+		mc := hlc.NewManualClock(1)
+		clock := hlc.NewClock(mc.UnixNano, time.Nanosecond)
+		txnSender := MakeMockTxnSenderFactoryWithNonTxnSender(nil /* senderFunc */, func(
+			_ context.Context, ba roachpb.BatchRequest,
+		) (*roachpb.BatchResponse, *roachpb.Error) {
+			require.NotNil(t, ba.BoundedStaleness)
+			require.Equal(t, ts10, ba.BoundedStaleness.MinTimestampBound)
+			require.False(t, ba.BoundedStaleness.MinTimestampBoundStrict)
+			require.Zero(t, ba.BoundedStaleness.MaxTimestampBound)
+			require.Equal(t, int64(2), ba.MaxSpanRequestKeys)
+
+			if !fastPath {
+				return nil, roachpb.NewError(&roachpb.OpRequiresTxnError{})
+			}
+			br := ba.CreateReply()
+			br.Timestamp = ts20
+			scanResp := br.Responses[0].GetScan()
+			scanResp.Rows = []roachpb.KeyValue{
+				{Key: roachpb.Key("a")},
+				{Key: roachpb.Key("b")},
+			}
+			scanResp.ResumeSpan = &roachpb.Span{
+				Key:    roachpb.Key("c"),
+				EndKey: roachpb.Key("d"),
+			}
+			scanResp.ResumeReason = roachpb.RESUME_KEY_LIMIT
+			return br, nil
+		})
+		db := NewDB(testutils.MakeAmbientCtx(), txnSender, clock, stopper)
+		txn := NewTxn(ctx, db, 0 /* gatewayNodeID */)
+
+		var ba roachpb.BatchRequest
+		ba.BoundedStaleness = &roachpb.BoundedStalenessHeader{
+			MinTimestampBound: ts10,
+		}
+		ba.RoutingPolicy = roachpb.RoutingPolicy_NEAREST
+		ba.MaxSpanRequestKeys = 2
+		ba.Add(roachpb.NewScan(roachpb.Key("a"), roachpb.Key("d"), false /* forUpdate */))
+		br, pErr := txn.NegotiateAndSend(ctx, ba)
+
+		if fastPath {
+			require.Nil(t, pErr)
+			require.NotNil(t, br)
+			// The negotiated timestamp should be returned and fixed.
+			require.Equal(t, ts20, br.Timestamp)
+			require.True(t, txn.CommitTimestampFixed())
+			require.Equal(t, ts20, txn.CommitTimestamp())
+			// Even though the response is paginated and carries a resume span.
+			require.Len(t, br.Responses, 1)
+			scanResp := br.Responses[0].GetScan()
+			require.Len(t, scanResp.Rows, 2)
+			require.NotNil(t, scanResp.ResumeSpan)
+			require.Equal(t, roachpb.Key("c"), scanResp.ResumeSpan.Key)
+			require.Equal(t, roachpb.Key("d"), scanResp.ResumeSpan.EndKey)
+			require.Equal(t, roachpb.RESUME_KEY_LIMIT, scanResp.ResumeReason)
+		} else {
+			require.Nil(t, br)
+			require.NotNil(t, pErr)
+			require.Regexp(t, "unimplemented: cross-range bounded staleness reads not yet implemented", pErr)
+			require.False(t, txn.CommitTimestampFixed())
+		}
+	})
+}


### PR DESCRIPTION
Fixes #69386.

In #69350, we began relying on the previously unspecified behavior of
Txn.NegotiateAndSend that negotiation was completed across all read
spans in a request, even if the request itself was paginated. This
commit clarifies this contract. It also adds client and server-side
tests that exercise the behavior.

Release justification: added testing for new functionality