### PR TITLE
kv/kvnemesis: make deletes distinct from other writes in errors

### DIFF
--- a/pkg/kv/kvnemesis/validator.go
+++ b/pkg/kv/kvnemesis/validator.go
@@ -984,6 +984,10 @@ func printObserved(observedOps ...observedOp) string {
 		}
 		switch o := observed.(type) {
 		case *observedWrite:
+			opCode := "w"
+			if o.isDelete() {
+				opCode = "d"
+			}
 			ts := `missing`
 			if o.Materialized {
 				if o.isDelete() && o.Timestamp.IsEmpty() {
@@ -992,8 +996,8 @@ func printObserved(observedOps ...observedOp) string {
 					ts = o.Timestamp.String()
 				}
 			}
-			fmt.Fprintf(&buf, "[w]%s:%s->%s",
-				o.Key, ts, mustGetStringValue(o.Value.RawBytes))
+			fmt.Fprintf(&buf, "[%s]%s:%s->%s",
+				opCode, o.Key, ts, mustGetStringValue(o.Value.RawBytes))
 		case *observedRead:
 			fmt.Fprintf(&buf, "[r]%s:", o.Key)
 			validTimes := o.ValidTimes


### PR DESCRIPTION
Previously when kvnemesis performed validation, in error messaging,
delete operations were only distinguishable from other writes by the
value written.  With this change, they will be identified as follows:

```
committed txn missing write: [w]"a":missing->v1
committed txn missing write: [d]"a":missing-><nil>
```
This will also allow us to distinguish between point and ranged deletes,
once they are introduced.

Release justification: Non-production code change.
Release note: None