### PR TITLE
cli: add --{from,to} to `tsdump` command

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -1565,6 +1565,8 @@ func init() {
 
 	f = debugTimeSeriesDumpCmd.Flags()
 	f.Var(&debugTimeSeriesDumpOpts.format, "format", "output format (text, csv, tsv, raw)")
+	f.Var(&debugTimeSeriesDumpOpts.from, "from", "oldest timestamp to include (inclusive)")
+	f.Var(&debugTimeSeriesDumpOpts.to, "to", "newest timestamp to include (inclusive)")
 }
 
 func initPebbleCmds(cmd *cobra.Command) {


### PR DESCRIPTION
This allows restricting which range of datapoints is pulled by
`./cockroach debug tsdump` via the `--from` and `--to` flags.

This command also touches up the `tsdump` command a little bit.

Release justification: low-risk observability change
Release note (cli change): The `debug tsdump` command now accepts
`--from` and `--to` flags that limit for which dates timeseries
are exported.
