### PR TITLE
server: make first node and store ID easy to change

### DIFF
--- a/pkg/cli/initial_sql.go
+++ b/pkg/cli/initial_sql.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -31,7 +32,7 @@ import (
 func runInitialSQL(
 	ctx context.Context, s *server.Server, startSingleNode bool, adminUser, adminPassword string,
 ) error {
-	newCluster := s.InitialStart() && s.NodeID() == server.FirstNodeID
+	newCluster := s.InitialStart() && s.NodeID() == kvserver.FirstNodeID
 	if !newCluster {
 		// The initial SQL code only runs the first time the cluster is initialized.
 		return nil

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cli/exit"
 	"github.com/cockroachdb/cockroach/pkg/docs"
 	"github.com/cockroachdb/cockroach/pkg/geo/geos"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/security"
@@ -716,7 +717,7 @@ If problems persist, please see %s.`
 			buf.Printf("storage engine: \t%s\n", &serverCfg.StorageEngine)
 			nodeID := s.NodeID()
 			if initialStart {
-				if nodeID == server.FirstNodeID {
+				if nodeID == kvserver.FirstNodeID {
 					buf.Printf("status:\tinitialized new cluster\n")
 				} else {
 					buf.Printf("status:\tinitialized new node, joined pre-existing cluster\n")

--- a/pkg/kv/kvserver/store_init.go
+++ b/pkg/kv/kvserver/store_init.go
@@ -28,6 +28,10 @@ import (
 // FirstNodeID is the NodeID assigned to the node bootstrapping a new cluster.
 const FirstNodeID = roachpb.NodeID(1)
 
+// FirstStoreID is the StoreID assigned to the first store on the node with ID
+// FirstNodeID.
+const FirstStoreID = roachpb.StoreID(1)
+
 // InitEngine writes a new store ident to the underlying engine. To
 // ensure that no crufty data already exists in the engine, it scans
 // the engine contents before writing the new store ident. The engine
@@ -104,8 +108,8 @@ func WriteInitialClusterData(
 	var nodeIDVal, storeIDVal, rangeIDVal, livenessVal roachpb.Value
 
 	nodeIDVal.SetInt(int64(FirstNodeID))
-	// The caller will initialize the stores with ids 1..numStores.
-	storeIDVal.SetInt(int64(numStores))
+	// The caller will initialize the stores with ids FirstStoreID, ..., FirstStoreID+numStores-1.
+	storeIDVal.SetInt(int64(FirstStoreID) + int64(numStores) - 1)
 	// The last range has id = len(splits) + 1
 	rangeIDVal.SetInt(int64(len(splits) + 1))
 
@@ -172,7 +176,7 @@ func WriteInitialClusterData(
 		replicas := []roachpb.ReplicaDescriptor{
 			{
 				NodeID:    FirstNodeID,
-				StoreID:   1,
+				StoreID:   FirstStoreID,
 				ReplicaID: 1,
 			},
 		}

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -230,7 +230,6 @@ func bootstrapCluster(
 	// TODO(andrei): It'd be cool if this method wouldn't do anything to engines
 	// other than the first one, and let regular node startup code deal with them.
 	var bootstrapVersion clusterversion.ClusterVersion
-	const firstStoreID = 1
 	for i, eng := range engines {
 		cv, err := kvserver.ReadClusterVersion(ctx, eng)
 		if err != nil {
@@ -249,7 +248,7 @@ func bootstrapCluster(
 		sIdent := roachpb.StoreIdent{
 			ClusterID: clusterID,
 			NodeID:    kvserver.FirstNodeID,
-			StoreID:   roachpb.StoreID(i + firstStoreID),
+			StoreID:   kvserver.FirstStoreID + roachpb.StoreID(i),
 		}
 
 		// Initialize the engine backing the store with the store ident and cluster

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -65,8 +65,6 @@ const (
 	// gossipStatusInterval is the interval for logging gossip status.
 	gossipStatusInterval = 1 * time.Minute
 
-	// FirstNodeID is the node ID of the first node in a new cluster.
-	FirstNodeID         = 1
 	graphiteIntervalKey = "external.graphite.interval"
 	maxGraphiteInterval = 15 * time.Minute
 )
@@ -250,7 +248,7 @@ func bootstrapCluster(
 
 		sIdent := roachpb.StoreIdent{
 			ClusterID: clusterID,
-			NodeID:    FirstNodeID,
+			NodeID:    kvserver.FirstNodeID,
 			StoreID:   roachpb.StoreID(i + firstStoreID),
 		}
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2008,6 +2008,10 @@ func maybeImportTS(ctx context.Context, s *Server) error {
 		return errors.New("cannot import timeseries into an existing cluster or a multi-{store,node} cluster")
 	}
 
+	// Also do a best effort at disabling the timeseries of the local node to cause
+	// confusion.
+	ts.TimeseriesStorageEnabled.Override(ctx, &s.ClusterSettings().SV, false)
+
 	f, err := os.Open(tsImport)
 	if err != nil {
 		return err
@@ -2090,7 +2094,7 @@ func maybeImportTS(ctx context.Context, s *Server) error {
 				return err
 			}
 			ss = append(ss, statuspb.StoreStatus{Desc: roachpb.StoreDescriptor{StoreID: roachpb.StoreID(sid)}})
-			delete(storeIDs, nodeString)
+			delete(storeIDs, storeString)
 		}
 
 		ns := statuspb.NodeStatus{


### PR DESCRIPTION
This is to enable the (sorry, internal) [runbook] to visualize a copy of the
internal timeseries data of a cluster. While writing the runbook I found some
sharp nails that this PR addresses. Mainly, the running node (n1) on top of
which the timeseries data is imported used to clobber some data for n1. The
interim solution is to start that server with a very high NodeID/StoreID (via
a manual code change & build). This isn't the most user-friendly, but it's
enough to unblock us and besides, the code changes here also constitute a
desirable cleanup.

[runbook]: https://cockroachlabs.atlassian.net/wiki/spaces/TS/pages/2168520776/Exporting+Internal+Timeseries+beta
