### PR TITLE
engineccl: copy registry metadata before rename

### DIFF
--- a/pkg/ccl/storageccl/engineccl/encrypted_fs.go
+++ b/pkg/ccl/storageccl/engineccl/encrypted_fs.go
@@ -192,12 +192,38 @@ func (fs *encryptedFS) Remove(name string) error {
 	return fs.fileRegistry.MaybeDeleteEntry(name)
 }
 
-// Rename implements vfs.FS.Rename.
+// Rename implements vfs.FS.Rename. A rename operation needs to both
+// move the file's file registry entry and move the files on the
+// physical filesystem. These operations cannot be done atomically. The
+// encryptedFS's Rename operation provides atomicity only if the
+// destination path does not exist.
+//
+// Rename will first copy the old path's file registry entry to the
+// new path. If the destination exists, a crash after this copy will
+// leave the file at the new path unreadable.
+//
+// Rename then performs a filesystem rename of the actual file. If a
+// crash occurs after the rename, the file at the new path will be
+// readable. The file at the old path won't exist, but the file registry
+// will contain a dangling entry for the old path. The dangling entry
+// will be elided when the file registry is loaded again.
 func (fs *encryptedFS) Rename(oldname, newname string) error {
+	// First copy the metadata from the old name to the new name. If a
+	// file exists at newname, this copy action will make the file at
+	// newname unlegible, because the encryption-at-rest metadata will
+	// not match the file's encryption. This is what makes Rename
+	// non-atomic. If no file exists at newname, the dangling copied
+	// entry has no effect.
+	if err := fs.fileRegistry.MaybeCopyEntry(oldname, newname); err != nil {
+		return err
+	}
+	// Perform the filesystem rename. After the filesystem rename, the
+	// new path is guaranteed to be readable.
 	if err := fs.FS.Rename(oldname, newname); err != nil {
 		return err
 	}
-	return fs.fileRegistry.MaybeRenameEntry(oldname, newname)
+	// Remove the old name's metadata.
+	return fs.fileRegistry.MaybeDeleteEntry(oldname)
 }
 
 // ReuseForWrite implements vfs.FS.ReuseForWrite.

--- a/pkg/storage/pebble_file_registry_test.go
+++ b/pkg/storage/pebble_file_registry_test.go
@@ -110,9 +110,13 @@ func TestFileRegistryOps(t *testing.T) {
 	expected["file2"] = barFileEntry
 	checkEquality()
 
-	// {file3 => foo, file2 => bar}
-	require.NoError(t, registry.MaybeRenameEntry("file1", "file3"))
+	// {file1 => foo, file3 => foo, file2 => bar}
+	require.NoError(t, registry.MaybeCopyEntry("file1", "file3"))
 	expected["file3"] = fooFileEntry
+	checkEquality()
+
+	// {file3 => foo, file2 => bar}
+	require.NoError(t, registry.MaybeDeleteEntry("file1"))
 	delete(expected, "file1")
 	checkEquality()
 
@@ -127,7 +131,7 @@ func TestFileRegistryOps(t *testing.T) {
 	checkEquality()
 
 	// {file3 => foo}
-	require.NoError(t, registry.MaybeRenameEntry("file7", "file4"))
+	require.NoError(t, registry.MaybeCopyEntry("file7", "file4"))
 	delete(expected, "file4")
 	checkEquality()
 
@@ -153,7 +157,7 @@ func TestFileRegistryOps(t *testing.T) {
 
 	// Noops
 	require.NoError(t, registry.MaybeDeleteEntry("file1"))
-	require.NoError(t, registry.MaybeRenameEntry("file4", "file5"))
+	require.NoError(t, registry.MaybeCopyEntry("file4", "file5"))
 	require.NoError(t, registry.MaybeLinkEntry("file6", "file7"))
 	checkEquality()
 
@@ -162,7 +166,7 @@ func TestFileRegistryOps(t *testing.T) {
 	require.NoError(t, roRegistry.Load())
 	require.Error(t, roRegistry.SetFileEntry("file3", bazFileEntry))
 	require.Error(t, roRegistry.MaybeDeleteEntry("file3"))
-	require.Error(t, roRegistry.MaybeRenameEntry("file3", "file4"))
+	require.Error(t, roRegistry.MaybeCopyEntry("file3", "file4"))
 	require.Error(t, roRegistry.MaybeLinkEntry("file3", "file4"))
 }
 


### PR DESCRIPTION
During a rename operation on an `encryptedFS`, copy the source's file
metadata to the destination first, perform the rename, then remove the
source's metadata.

This ensures that if the destination path does not exist, the rename is
atomic.

Release justification: partial fix for a high-severity bug in existing
functionality
Release note: None