### PR TITLE
liveness: make CreateLivenessRecord retry on a TransactionError

### DIFF
--- a/pkg/cli/debug_test.go
+++ b/pkg/cli/debug_test.go
@@ -132,7 +132,6 @@ func TestOpenReadOnlyStore(t *testing.T) {
 
 func TestRemoveDeadReplicas(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.WithIssue(t, 50977, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	// This test is pretty slow under race (200+ cpu-seconds) because it

--- a/pkg/kv/kvserver/liveness/liveness.go
+++ b/pkg/kv/kvserver/liveness/liveness.go
@@ -76,6 +76,22 @@ func (e *errRetryLiveness) Error() string {
 	return fmt.Sprintf("%T: %s", *e, e.error)
 }
 
+func isErrRetryLiveness(ctx context.Context, err error) bool {
+	if errors.HasType(err, (*roachpb.AmbiguousResultError)(nil)) {
+		// We generally want to retry ambiguous errors immediately, except if the
+		// ctx is canceled - in which case the ambiguous error is probably caused
+		// by the cancellation (and in any case it's pointless to retry with a
+		// canceled ctx).
+		return ctx.Err() == nil
+	} else if errors.HasType(err, (*roachpb.TransactionStatusError)(nil)) {
+		// 21.2 nodes can return a TransactionStatusError when they should have
+		// returned an AmbiguousResultError.
+		// TODO(andrei): Remove this in 22.2.
+		return true
+	}
+	return false
+}
+
 // Node liveness metrics counter names.
 var (
 	metaLiveNodes = metric.Metadata{
@@ -527,41 +543,50 @@ type livenessUpdate struct {
 // NB: An existing liveness record is not overwritten by this method, we return
 // an error instead.
 func (nl *NodeLiveness) CreateLivenessRecord(ctx context.Context, nodeID roachpb.NodeID) error {
-	// We start off at epoch=0, entrusting the initial heartbeat to increment it
-	// to epoch=1 to signal the very first time the node is up and running.
-	liveness := livenesspb.Liveness{NodeID: nodeID, Epoch: 0}
+	for r := retry.StartWithCtx(ctx, base.DefaultRetryOptions()); r.Next(); {
+		// We start off at epoch=0, entrusting the initial heartbeat to increment it
+		// to epoch=1 to signal the very first time the node is up and running.
+		liveness := livenesspb.Liveness{NodeID: nodeID, Epoch: 0}
 
-	// We skip adding an expiration, we only really care about the liveness
-	// record existing within KV.
+		// We skip adding an expiration, we only really care about the liveness
+		// record existing within KV.
 
-	v := new(roachpb.Value)
-	if err := nl.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-		b := txn.NewBatch()
-		key := keys.NodeLivenessKey(nodeID)
-		if err := v.SetProto(&liveness); err != nil {
-			log.Fatalf(ctx, "failed to marshall proto: %s", err)
-		}
-		// Given we're looking to create a new liveness record here, we don't
-		// expect to find anything.
-		b.CPut(key, v, nil)
+		v := new(roachpb.Value)
+		err := nl.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+			b := txn.NewBatch()
+			key := keys.NodeLivenessKey(nodeID)
+			if err := v.SetProto(&liveness); err != nil {
+				log.Fatalf(ctx, "failed to marshall proto: %s", err)
+			}
+			// Given we're looking to create a new liveness record here, we don't
+			// expect to find anything.
+			b.CPut(key, v, nil)
 
-		// We don't bother adding a gossip trigger, that'll happen with the
-		// first heartbeat. We still keep it as a 1PC commit to avoid leaving
-		// write intents.
-		b.AddRawRequest(&roachpb.EndTxnRequest{
-			Commit:     true,
-			Require1PC: true,
+			// We don't bother adding a gossip trigger, that'll happen with the
+			// first heartbeat. We still keep it as a 1PC commit to avoid leaving
+			// write intents.
+			b.AddRawRequest(&roachpb.EndTxnRequest{
+				Commit:     true,
+				Require1PC: true,
+			})
+			return txn.Run(ctx, b)
 		})
-		return txn.Run(ctx, b)
-	}); err != nil {
+
+		if err == nil {
+			// We'll learn about this liveness record through gossip eventually, so we
+			// don't bother updating our in-memory view of node liveness.
+			log.Infof(ctx, "created liveness record for n%d", nodeID)
+			return nil
+		}
+		if !isErrRetryLiveness(ctx, err) {
+			return err
+		}
+		log.VEventf(ctx, 2, "failed to create liveness record for node %d, because of %s. retrying...", nodeID, err)
+	}
+	if err := ctx.Err(); err != nil {
 		return err
 	}
-
-	// We'll learn about this liveness record through gossip eventually, so we
-	// don't bother updating our in-memory view of node liveness.
-
-	log.Infof(ctx, "created liveness record for n%d", nodeID)
-	return nil
+	return errors.AssertionFailedf("unexpected problem while creating liveness record for node %d", nodeID)
 }
 
 func (nl *NodeLiveness) setMembershipStatusInternal(
@@ -1318,19 +1343,7 @@ func (nl *NodeLiveness) updateLivenessAttempt(
 				return Record{}, errors.Wrapf(err, "couldn't update node liveness from CPut actual value")
 			}
 			return Record{}, handleCondFailed(Record{Liveness: actualLiveness, raw: tErr.ActualValue.TagAndDataBytes()})
-		} else if errors.HasType(err, (*roachpb.AmbiguousResultError)(nil)) {
-			// We generally want to retry ambiguous errors immediately, except if the
-			// ctx is canceled - in which case the ambiguous error is probably caused
-			// by the cancellation (and in any case it's pointless to retry with a
-			// canceled ctx).
-			if ctx.Err() != nil {
-				return Record{}, err
-			}
-			return Record{}, &errRetryLiveness{err}
-		} else if errors.HasType(err, (*roachpb.TransactionStatusError)(nil)) {
-			// 21.2 nodes can return a TransactionStatusError when they should have
-			// returned an AmbiguousResultError.
-			// TODO(andrei): Remove this in 22.2.
+		} else if isErrRetryLiveness(ctx, err) {
 			return Record{}, &errRetryLiveness{err}
 		}
 		return Record{}, err


### PR DESCRIPTION
Fixes #50977

CreateLivenessRecord has no fault tolerance built in, which makes
the server startup facility flaky. The startup procesure allocates a
nodeId, storeId and then creates a liveness record. If there
is a hiccup or brief period of unavailability during the liveness
creation we end up cycing through node/store ids which is undesirable.
This made the TestRemoveDeadReplicas test flaky because nodes
ended up cycling through a few node ids on startup, making it no possible
to match epected node ids with the actual ones. To fix this issue
we retry liveness creation when it encounters an AmbigiousError
or TransactionError. This is similar behavior to the update code
path for the liveness record.

Release note: None