### PR TITLE
sql: change plan_hash in system.statement_statistics from Int to Bytes

### DIFF
--- a/pkg/sql/catalog/systemschema/system.go
+++ b/pkg/sql/catalog/systemschema/system.go
@@ -468,7 +468,7 @@ CREATE TABLE system.statement_statistics (
     aggregated_ts              TIMESTAMPTZ NOT NULL,
     fingerprint_id             BYTES NOT NULL,
     transaction_fingerprint_id BYTES NOT NULL,
-    plan_hash                  INT8 NOT NULL,
+    plan_hash                  BYTES NOT NULL,
     app_name                   STRING NOT NULL,
     node_id                    INT8 NOT NULL,
 
@@ -1908,7 +1908,7 @@ var (
 				{Name: "aggregated_ts", ID: 1, Type: types.TimestampTZ, Nullable: false},
 				{Name: "fingerprint_id", ID: 2, Type: types.Bytes, Nullable: false},
 				{Name: "transaction_fingerprint_id", ID: 3, Type: types.Bytes, Nullable: false},
-				{Name: "plan_hash", ID: 4, Type: types.Int, Nullable: false},
+				{Name: "plan_hash", ID: 4, Type: types.Bytes, Nullable: false},
 				{Name: "app_name", ID: 5, Type: types.String, Nullable: false},
 				{Name: "node_id", ID: 6, Type: types.Int, Nullable: false},
 				{Name: "agg_interval", ID: 7, Type: types.Interval, Nullable: false},

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -1082,7 +1082,7 @@ CREATE TABLE crdb_internal.session_variables (
 CREATE TABLE crdb_internal.statement_statistics (
    aggregated_ts TIMESTAMPTZ NOT NULL,
    fingerprint_id BYTES NOT NULL,
-   plan_hash INT8 NOT NULL,
+   plan_hash BYTES NOT NULL,
    app_name STRING NOT NULL,
    metadata JSONB NOT NULL,
    statistics JSONB NOT NULL,
@@ -1090,7 +1090,7 @@ CREATE TABLE crdb_internal.statement_statistics (
 )  CREATE TABLE crdb_internal.statement_statistics (
    aggregated_ts TIMESTAMPTZ NOT NULL,
    fingerprint_id BYTES NOT NULL,
-   plan_hash INT8 NOT NULL,
+   plan_hash BYTES NOT NULL,
    app_name STRING NOT NULL,
    metadata JSONB NOT NULL,
    statistics JSONB NOT NULL,

--- a/pkg/sql/sqlstats/persistedsqlstats/stmt_reader.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/stmt_reader.go
@@ -151,8 +151,13 @@ func rowToStmtStats(row tree.Datums) (*roachpb.CollectedStatementStatistics, err
 	if err != nil {
 		return nil, err
 	}
+
 	stats.ID = roachpb.StmtFingerprintID(stmtFingerprintID)
-	stats.Key.PlanHash = uint64(tree.MustBeDInt(row[2]))
+	stats.Key.PlanHash, err = sqlstatsutil.DatumToUint64(row[2])
+	if err != nil {
+		return nil, err
+	}
+
 	stats.Key.App = string(tree.MustBeDString(row[3]))
 
 	metadata := tree.MustBeDJSON(row[4]).JSON


### PR DESCRIPTION
Previously, `plan_hash` column in {crdb_internal,system}.statement_statistics
has the type Int. However, since `plan_hash` behaves with more
blob-like nature, Bytes is a more suitable data type.
This commit change the column type for plan hash to Bytes.

Release justification: Category 2: Bug fixes and low-risk updates to
new functionality

Release note (sql change): plan_hash column in both
system.statement_statistics and crdb_internal.statement_statistics
is changed from Int to Bytes.