### PR TITLE
ccl/backupccl: skip TestFullClusterBackup under race

### DIFF
--- a/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
+++ b/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
@@ -41,6 +41,7 @@ import (
 // the new cluster. Ensures that all the moving pieces are working together.
 func TestFullClusterBackup(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.UnderRaceWithIssue(t, 69466, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	const numAccounts = 10


### PR DESCRIPTION
Refs: #69466

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None