### PR TITLE
kvserver: cleanup liveness retry code

### DIFF
--- a/pkg/base/testing_knobs.go
+++ b/pkg/base/testing_knobs.go
@@ -44,4 +44,5 @@ type TestingKnobs struct {
 	SpanConfig              ModuleTestingKnobs
 	SQLLivenessKnobs        ModuleTestingKnobs
 	TelemetryLoggingKnobs   ModuleTestingKnobs
+	DialerKnobs             ModuleTestingKnobs
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -388,7 +388,14 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		cfg.Locality,
 		&cfg.DefaultZoneConfig,
 	)
-	nodeDialer := nodedialer.New(rpcContext, gossip.AddressResolver(g))
+
+	var dialerKnobs nodedialer.DialerTestingKnobs
+	if dk := cfg.TestingKnobs.DialerKnobs; dk != nil {
+		dialerKnobs = dk.(nodedialer.DialerTestingKnobs)
+	}
+
+	nodeDialer := nodedialer.NewWithOpt(rpcContext, gossip.AddressResolver(g),
+		nodedialer.DialerOpt{TestingKnobs: dialerKnobs})
 
 	runtimeSampler := status.NewRuntimeStatSampler(ctx, clock)
 	registry.AddMetricStruct(runtimeSampler)


### PR DESCRIPTION
This patch improves the code around retries of liveness heartbeat.
Before this patch, if a heartbeat was canceled, it might have resulted
in an AmbiguousResultError, which was turned into an explicitly
retriable error, which was causing a retry but the retry was explicitly
short-circuited on canceled ctx. The convoluted logic was
mis-interpreted by me a fellow on first read. The patch also has the

This patch simplifies the logic by making an AmbiguousResultError caused
by a canceled ctx not result in a retryable error in the first place.
As a nice side-effect, this results in the original error propagating to
the Heartbeat() caller, rather than a vanilla "context canceled"
before.

The patch also adds a test about the behavior on this kind of error,
which was a bug in the past but not tested when it was fixed.

Release note: None