### PR TITLE
sql: deflake TestSQLStatsScheduleOperations

### DIFF
--- a/pkg/sql/sqlstats/persistedsqlstats/scheduled_sql_stats_compaction_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/scheduled_sql_stats_compaction_test.go
@@ -196,7 +196,7 @@ func TestSQLStatsScheduleOperations(t *testing.T) {
 
 	t.Run("warn_schedule_long_run_interval", func(t *testing.T) {
 		t.Run("via cluster setting", func(t *testing.T) {
-			helper.sqlDB.Exec(t, "SET CLUSTER SETTING sql.stats.cleanup.recurrence = '@weekly'")
+			helper.sqlDB.Exec(t, "SET CLUSTER SETTING sql.stats.cleanup.recurrence = '0 59 23 24 12 ? 2099'")
 
 			var err error
 			testutils.SucceedsSoon(t, func() error {
@@ -206,7 +206,7 @@ func TestSQLStatsScheduleOperations(t *testing.T) {
 				if err == nil {
 					return errors.Newf("retry: next_run=%s, schedule_expr=%s", sj.NextRun(), sj.ScheduleExpr())
 				}
-				require.Equal(t, "@weekly", sj.ScheduleExpr())
+				require.Equal(t, "0 59 23 24 12 ? 2099", sj.ScheduleExpr())
 				return nil
 			})
 			require.True(t, errors.Is(


### PR DESCRIPTION
Previsouly, TestSQLStatsScheduleOperations sets the SQL
stats compaction schedule expr to @weekly in tests to check
if a warning will be generated. However, this means the
next_run column for SQL Stats compaction schedule will be
set to 00:00 UTC on Sunday. Which means this test will fail
from Saturaday Midnight UTC to Sunday Midnight UTC for 24 hours.
This commit changes the cron tab so the next_run column is
update to update to 2099.

Release justification: Category 2: Bug fixes and low-risk
updates to new functionality
Release note: None