### PR TITLE
roachtest: disable ballast during disk-stall roachtest

### DIFF
--- a/pkg/cmd/roachtest/tests/disk_stall.go
+++ b/pkg/cmd/roachtest/tests/disk_stall.go
@@ -106,7 +106,10 @@ func runDiskStalledDetection(
 	go func() {
 		t.WorkerStatus("running server")
 		out, err := c.RunWithBuffer(ctx, l, n,
-			fmt.Sprintf("timeout --signal 9 %ds env COCKROACH_ENGINE_MAX_SYNC_DURATION_DEFAULT=%s COCKROACH_LOG_MAX_SYNC_DURATION=%s "+
+			fmt.Sprintf("timeout --signal 9 %ds env "+
+				"COCKROACH_ENGINE_MAX_SYNC_DURATION_DEFAULT=%s "+
+				"COCKROACH_LOG_MAX_SYNC_DURATION=%s "+
+				"COCKROACH_AUTO_BALLAST=false "+
 				"./cockroach start-single-node --insecure --store {store-dir}/%s --log '{sinks: {stderr: {filter: INFO}}, file-defaults: {dir: \"{store-dir}/%s\"}}'",
 				int(dur.Seconds()), maxDataSync, maxLogSync, dataDir, logDir,
 			),


### PR DESCRIPTION
The charybdefs FUSE filesystem used in the disk-stall roachtest slows
down file writes. Creating a default 1 GiB emergency ballast via the
FUSE filesystem was prohibitively slow.

Fix #64240.
Fix #58238.

Release justification: non-production code changes
Release note: none