### PR TITLE
sql: fix telemetry for SQL syntax

### DIFF
--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -63,16 +63,16 @@ func TestParseDatadriven(t *testing.T) {
 				// first the literals are removed from statement to form a stat key,
 				// then the stat key is re-parsed, to undergo the anonymization stage.
 				// We also want to check the re-parsing is fine.
-				//
-				// TODO(knz,rafiss): Turn the following two cases into proper test
-				// errors once the bugs are fixed.
 				reparsedStmts, err := parser.Parse(constantsHidden)
 				if err != nil {
-					fmt.Fprintln(&buf, "REPARSE WITHOUT LITERALS FAILS:", err)
+					d.Fatalf(t, "unexpected error when reparsing without literals: %+v", err)
 				} else {
 					reparsedStmtsS := reparsedStmts.String()
 					if reparsedStmtsS != constantsHidden {
-						fmt.Fprintln(&buf, reparsedStmtsS, "-- UNEXPECTED REPARSED AST WITHOUT LITERALS")
+						d.Fatalf(t,
+							"mismatched AST when reparsing without literals:\noriginal: %s\nexpected: %s\nactual:   %s",
+							d.Input, constantsHidden, reparsedStmtsS,
+						)
 					}
 				}
 

--- a/pkg/sql/parser/testdata/alter_user
+++ b/pkg/sql/parser/testdata/alter_user
@@ -19,11 +19,11 @@ ALTER USER 'foo' WITH PASSWORD 'bar' -- passwords exposed
 parse
 ALTER USER foo WITH PASSWORD NULL
 ----
-ALTER USER 'foo' WITH PASSWORD NULL -- normalized!
-ALTER USER ('foo') WITH PASSWORD (NULL) -- fully parenthesized
-ALTER USER '_' WITH PASSWORD _ -- literals removed
-ALTER USER '_' WITH PASSWORD '*****' -- UNEXPECTED REPARSED AST WITHOUT LITERALS
-ALTER USER 'foo' WITH PASSWORD NULL -- identifiers removed
+ALTER USER 'foo' WITH PASSWORD '*****' -- normalized!
+ALTER USER ('foo') WITH PASSWORD '*****' -- fully parenthesized
+ALTER USER '_' WITH PASSWORD '*****' -- literals removed
+ALTER USER 'foo' WITH PASSWORD '*****' -- identifiers removed
+ALTER USER 'foo' WITH PASSWORD NULL -- passwords exposed
 
 parse
 ALTER ROLE foo WITH CREATEDB

--- a/pkg/sql/parser/testdata/comment
+++ b/pkg/sql/parser/testdata/comment
@@ -36,8 +36,7 @@ COMMENT ON DATABASE foo IS 'a'
 ----
 COMMENT ON DATABASE foo IS 'a'
 COMMENT ON DATABASE foo IS 'a' -- fully parenthesized
-COMMENT ON DATABASE foo IS _ -- literals removed
-REPARSE WITHOUT LITERALS FAILS: at or near "_": syntax error
+COMMENT ON DATABASE foo IS '_' -- literals removed
 COMMENT ON DATABASE _ IS 'a' -- identifiers removed
 
 parse
@@ -53,8 +52,7 @@ COMMENT ON INDEX foo IS 'a'
 ----
 COMMENT ON INDEX foo IS 'a'
 COMMENT ON INDEX foo IS 'a' -- fully parenthesized
-COMMENT ON INDEX foo IS _ -- literals removed
-REPARSE WITHOUT LITERALS FAILS: at or near "_": syntax error
+COMMENT ON INDEX foo IS '_' -- literals removed
 COMMENT ON INDEX _ IS 'a' -- identifiers removed
 
 parse
@@ -70,8 +68,7 @@ COMMENT ON TABLE foo IS 'a'
 ----
 COMMENT ON TABLE foo IS 'a'
 COMMENT ON TABLE foo IS 'a' -- fully parenthesized
-COMMENT ON TABLE foo IS _ -- literals removed
-REPARSE WITHOUT LITERALS FAILS: at or near "_": syntax error
+COMMENT ON TABLE foo IS '_' -- literals removed
 COMMENT ON TABLE _ IS 'a' -- identifiers removed
 
 parse

--- a/pkg/sql/parser/testdata/create_user
+++ b/pkg/sql/parser/testdata/create_user
@@ -107,20 +107,20 @@ CREATE USER 'foo' WITH PASSWORD 'bar' -- passwords exposed
 parse
 CREATE USER foo PASSWORD NULL
 ----
-CREATE USER 'foo' WITH PASSWORD NULL -- normalized!
-CREATE USER ('foo') WITH PASSWORD (NULL) -- fully parenthesized
-CREATE USER '_' WITH PASSWORD _ -- literals removed
-CREATE USER '_' WITH PASSWORD '*****' -- UNEXPECTED REPARSED AST WITHOUT LITERALS
-CREATE USER 'foo' WITH PASSWORD NULL -- identifiers removed
+CREATE USER 'foo' WITH PASSWORD '*****' -- normalized!
+CREATE USER ('foo') WITH PASSWORD '*****' -- fully parenthesized
+CREATE USER '_' WITH PASSWORD '*****' -- literals removed
+CREATE USER 'foo' WITH PASSWORD '*****' -- identifiers removed
+CREATE USER 'foo' WITH PASSWORD NULL -- passwords exposed
 
 parse
 CREATE USER foo LOGIN VALID UNTIL NULL PASSWORD NULL
 ----
-CREATE USER 'foo' WITH LOGIN VALID UNTIL NULL PASSWORD NULL -- normalized!
-CREATE USER ('foo') WITH LOGIN VALID UNTIL (NULL) PASSWORD (NULL) -- fully parenthesized
-CREATE USER '_' WITH LOGIN VALID UNTIL _ PASSWORD _ -- literals removed
-CREATE USER '_' WITH LOGIN VALID UNTIL '_' PASSWORD '*****' -- UNEXPECTED REPARSED AST WITHOUT LITERALS
-CREATE USER 'foo' WITH LOGIN VALID UNTIL NULL PASSWORD NULL -- identifiers removed
+CREATE USER 'foo' WITH LOGIN VALID UNTIL NULL PASSWORD '*****' -- normalized!
+CREATE USER ('foo') WITH LOGIN VALID UNTIL (NULL) PASSWORD '*****' -- fully parenthesized
+CREATE USER '_' WITH LOGIN VALID UNTIL '_' PASSWORD '*****' -- literals removed
+CREATE USER 'foo' WITH LOGIN VALID UNTIL NULL PASSWORD '*****' -- identifiers removed
+CREATE USER 'foo' WITH LOGIN VALID UNTIL NULL PASSWORD NULL -- passwords exposed
 
 error
 CREATE USER foo WITH PASSWORD

--- a/pkg/sql/parser/testdata/select_clauses
+++ b/pkg/sql/parser/testdata/select_clauses
@@ -1089,8 +1089,7 @@ SELECT a FROM t WHERE a IS true
 ----
 SELECT a FROM t WHERE a IS true
 SELECT (a) FROM t WHERE ((a) IS (true)) -- fully parenthesized
-SELECT a FROM t WHERE a IS _ -- literals removed
-REPARSE WITHOUT LITERALS FAILS: at or near "_": syntax error
+SELECT a FROM t WHERE a IS NOT DISTINCT FROM _ -- literals removed
 SELECT _ FROM _ WHERE _ IS true -- identifiers removed
 
 parse
@@ -1098,8 +1097,7 @@ SELECT a FROM t WHERE a IS NOT true
 ----
 SELECT a FROM t WHERE a IS NOT true
 SELECT (a) FROM t WHERE ((a) IS NOT (true)) -- fully parenthesized
-SELECT a FROM t WHERE a IS NOT _ -- literals removed
-REPARSE WITHOUT LITERALS FAILS: at or near "_": syntax error
+SELECT a FROM t WHERE a IS DISTINCT FROM _ -- literals removed
 SELECT _ FROM _ WHERE _ IS NOT true -- identifiers removed
 
 parse
@@ -1107,8 +1105,7 @@ SELECT a FROM t WHERE a IS false
 ----
 SELECT a FROM t WHERE a IS false
 SELECT (a) FROM t WHERE ((a) IS (false)) -- fully parenthesized
-SELECT a FROM t WHERE a IS _ -- literals removed
-REPARSE WITHOUT LITERALS FAILS: at or near "_": syntax error
+SELECT a FROM t WHERE a IS NOT DISTINCT FROM _ -- literals removed
 SELECT _ FROM _ WHERE _ IS false -- identifiers removed
 
 parse
@@ -1116,8 +1113,7 @@ SELECT a FROM t WHERE a IS NOT false
 ----
 SELECT a FROM t WHERE a IS NOT false
 SELECT (a) FROM t WHERE ((a) IS NOT (false)) -- fully parenthesized
-SELECT a FROM t WHERE a IS NOT _ -- literals removed
-REPARSE WITHOUT LITERALS FAILS: at or near "_": syntax error
+SELECT a FROM t WHERE a IS DISTINCT FROM _ -- literals removed
 SELECT _ FROM _ WHERE _ IS NOT false -- identifiers removed
 
 parse

--- a/pkg/sql/sem/tree/comment_on_database.go
+++ b/pkg/sql/sem/tree/comment_on_database.go
@@ -27,7 +27,7 @@ func (n *CommentOnDatabase) Format(ctx *FmtCtx) {
 		// TODO(knz): Replace all this with ctx.FormatNode
 		// when COMMENT supports expressions.
 		if ctx.flags.HasFlags(FmtHideConstants) {
-			ctx.WriteByte('_')
+			ctx.WriteString("'_'")
 		} else {
 			lexbase.EncodeSQLStringWithFlags(&ctx.Buffer, *n.Comment, ctx.flags.EncodeFlags())
 		}

--- a/pkg/sql/sem/tree/comment_on_index.go
+++ b/pkg/sql/sem/tree/comment_on_index.go
@@ -27,7 +27,7 @@ func (n *CommentOnIndex) Format(ctx *FmtCtx) {
 		// TODO(knz): Replace all this with ctx.FormatNode
 		// when COMMENT supports expressions.
 		if ctx.flags.HasFlags(FmtHideConstants) {
-			ctx.WriteByte('_')
+			ctx.WriteString("'_'")
 		} else {
 			lexbase.EncodeSQLStringWithFlags(&ctx.Buffer, *n.Comment, ctx.flags.EncodeFlags())
 		}

--- a/pkg/sql/sem/tree/comment_on_table.go
+++ b/pkg/sql/sem/tree/comment_on_table.go
@@ -27,7 +27,7 @@ func (n *CommentOnTable) Format(ctx *FmtCtx) {
 		// TODO(knz): Replace all this with ctx.FormatNode
 		// when COMMENT supports expressions.
 		if ctx.flags.HasFlags(FmtHideConstants) {
-			ctx.WriteByte('_')
+			ctx.WriteString("'_'")
 		} else {
 			lexbase.EncodeSQLStringWithFlags(&ctx.Buffer, *n.Comment, ctx.flags.EncodeFlags())
 		}

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -1853,7 +1853,7 @@ func (o *KVOptions) formatAsRoleOptions(ctx *FmtCtx) {
 		)
 
 		// Password is a special case.
-		if strings.ToUpper(option.Key.String()) == "PASSWORD" && option.Value != DNull {
+		if strings.ToUpper(option.Key.String()) == "PASSWORD" {
 			ctx.WriteString(" ")
 			if ctx.flags.HasFlags(FmtShowPasswords) {
 				ctx.FormatNode(option.Value)
@@ -1862,7 +1862,11 @@ func (o *KVOptions) formatAsRoleOptions(ctx *FmtCtx) {
 			}
 		} else if option.Value != nil {
 			ctx.WriteString(" ")
-			ctx.FormatNode(option.Value)
+			if ctx.HasFlags(FmtHideConstants) {
+				ctx.WriteString("'_'")
+			} else {
+				ctx.FormatNode(option.Value)
+			}
 		}
 	}
 }

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -503,11 +503,15 @@ func (node *ComparisonExpr) Format(ctx *FmtCtx) {
 	opStr := node.Operator.String()
 	// IS and IS NOT are equivalent to IS NOT DISTINCT FROM and IS DISTINCT
 	// FROM, respectively, when the RHS is true or false. We prefer the less
-	// verbose IS and IS NOT in those cases.
-	if node.Operator.Symbol == IsDistinctFrom && (node.Right == DBoolTrue || node.Right == DBoolFalse) {
-		opStr = "IS NOT"
-	} else if node.Operator.Symbol == IsNotDistinctFrom && (node.Right == DBoolTrue || node.Right == DBoolFalse) {
-		opStr = "IS"
+	// verbose IS and IS NOT in those cases, unless we are in FmtHideConstants
+	// mode. In that mode we need the more verbose form in order to be able
+	// to re-parse the statement when reporting telemetry.
+	if !ctx.HasFlags(FmtHideConstants) {
+		if node.Operator.Symbol == IsDistinctFrom && (node.Right == DBoolTrue || node.Right == DBoolFalse) {
+			opStr = "IS NOT"
+		} else if node.Operator.Symbol == IsNotDistinctFrom && (node.Right == DBoolTrue || node.Right == DBoolFalse) {
+			opStr = "IS"
+		}
 	}
 	if node.Operator.Symbol.HasSubOperator() {
 		binExprFmtWithParenAndSubOp(ctx, node.Left, node.SubOperator.String(), opStr, node.Right)


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/60722

This fixes the last broken cases for telemetry of SQL statements.
CREATE USER, IS true, and COMMENT syntax now can be successfully
reparsed after being formatted with constants removed.

Release justification: telemetry only change
Release note: None