### PR TITLE
server: simplify use of COCKROACH_DEBUG_TS_IMPORT_FILE

### DIFF
--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -74,8 +74,16 @@ import (
 // node throwaway clusters and consequently this variable is only used for
 // the start-single-node command.
 //
+// To be able to visualize the timeseries data properly, a mapping file must be
+// provided as well. This maps StoreIDs to the owning NodeID, i.e. the file
+// looks like this (if s1 is on n3 and s2 is on n4):
+// 1: 3
+// 2: 4
+// [...]
+//
 // See #64329 for details.
 var debugTSImportFile = envutil.EnvOrDefaultString("COCKROACH_DEBUG_TS_IMPORT_FILE", "")
+var debugTSImportMappingFile = envutil.EnvOrDefaultString("COCKROACH_DEBUG_TS_IMPORT_MAPPING_FILE", debugTSImportFile+".yaml")
 
 // startCmd starts a node by initializing the stores and joining
 // the cluster.
@@ -288,7 +296,10 @@ func runStartSingleNode(cmd *cobra.Command, args []string) error {
 
 	// Allow passing in a timeseries file.
 	if debugTSImportFile != "" {
-		serverCfg.TestingKnobs.Server = &server.TestingKnobs{ImportTimeseriesFile: debugTSImportFile}
+		serverCfg.TestingKnobs.Server = &server.TestingKnobs{
+			ImportTimeseriesFile:        debugTSImportFile,
+			ImportTimeseriesMappingFile: debugTSImportMappingFile,
+		}
 	}
 
 	return runStart(cmd, args, true /*startSingleNode*/)

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -209,6 +209,7 @@ go_library(
         "@com_github_grpc_ecosystem_grpc_gateway//utilities:go_default_library",
         "@com_github_marusama_semaphore//:semaphore",
         "@com_github_opentracing_opentracing_go//ext",
+        "@in_gopkg_yaml_v2//:yaml_v2",
         "@io_etcd_go_etcd_raft_v3//:raft",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//codes",

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -180,6 +180,10 @@ type Node struct {
 	tenantUsage multitenant.TenantUsageServer
 
 	spanConfigAccessor spanconfig.KVAccessor // powers the span configuration RPCs
+
+	// Turns `Node.writeNodeStatus` into a no-op. This is a hack to enable the
+	// COCKROACH_DEBUG_TS_IMPORT_FILE env var.
+	suppressNodeStatus syncutil.AtomicBool
 }
 
 var _ roachpb.InternalServer = &Node{}
@@ -778,6 +782,9 @@ func (n *Node) startWriteNodeStatus(frequency time.Duration) error {
 // If mustExist is true the status key must already exist and must
 // not change during writing -- if false, the status is always written.
 func (n *Node) writeNodeStatus(ctx context.Context, alertTTL time.Duration, mustExist bool) error {
+	if n.suppressNodeStatus.Get() {
+		return nil
+	}
 	var err error
 	if runErr := n.stopper.RunTask(ctx, "node.Node: writing summary", func(ctx context.Context) {
 		nodeStatus := n.recorder.GenerateNodeStatus(ctx)

--- a/pkg/server/server_import_ts_test.go
+++ b/pkg/server/server_import_ts_test.go
@@ -12,6 +12,7 @@ package server_test
 
 import (
 	"context"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -40,6 +41,9 @@ func TestServerWithTimeseriesImport(t *testing.T) {
 	ctx := context.Background()
 
 	path := filepath.Join(t.TempDir(), "dump.raw")
+	require.NoError(t,
+		ioutil.WriteFile(path+".yaml", []byte("1: 1"), 0644),
+	)
 
 	var bytesDumped int64
 	func() {
@@ -58,7 +62,8 @@ func TestServerWithTimeseriesImport(t *testing.T) {
 	args.ServerArgs.Settings = cluster.MakeTestingClusterSettings()
 	ts.TimeseriesStorageEnabled.Override(ctx, &args.ServerArgs.Settings.SV, false)
 	args.ServerArgs.Knobs.Server = &server.TestingKnobs{
-		ImportTimeseriesFile: path,
+		ImportTimeseriesFile:        path,
+		ImportTimeseriesMappingFile: path + ".yaml",
 	}
 	srv := testcluster.StartTestCluster(t, 1, args)
 	defer srv.Stopper().Stop(ctx)

--- a/pkg/server/testing_knobs.go
+++ b/pkg/server/testing_knobs.go
@@ -95,6 +95,9 @@ type TestingKnobs struct {
 	// ImportTimeseriesFile, if set, is a file created via `DumpRaw` that written
 	// back to the KV layer upon server start.
 	ImportTimeseriesFile string
+	// ImportTimeseriesMappingFile points to a file containing a YAML map from storeID
+	// to nodeID, for use with ImportTimeseriesFile.
+	ImportTimeseriesMappingFile string
 	// DrainSleepFn used in testing to override the usual sleep function with
 	// a custom function that counts the number of times the sleep function is called.
 	DrainSleepFn func(time.Duration)


### PR DESCRIPTION
Previously, an update to the hard-coded store-to-node mapping
in the import code was necessary for each use. Now there is
a `COCKROACH_DEBUG_TS_IMPORT_MAPPING_FILE` env var (that defaults
to `<COCKROACH_DEBUG_TS_IMPORT_FILE>.yaml` that takes entries
of the form `<storeID>: <nodeID>`.

Also, there is no longer a need to set a nonstandard `FirstNodeID`.
Instead, we avoid the node's node summary writes.

Release justification: low-risk debuggability improvement (tsdump
runbook)
Release note: None
