### PR TITLE
cli: deflake TestPartialZip

### DIFF
--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -337,6 +337,7 @@ go_test(
         "//pkg/sql",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/protoreflect",
+        "//pkg/sql/tests",
         "//pkg/storage",
         "//pkg/testutils",
         "//pkg/testutils/buildutil",

--- a/pkg/cli/zip_test.go
+++ b/pkg/cli/zip_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
@@ -358,8 +359,10 @@ func TestPartialZip(t *testing.T) {
 	ctx := context.Background()
 
 	// Three nodes. We want to see what `zip` thinks when one of the nodes is down.
+	params, _ := tests.CreateTestServerParams()
+	params.Insecure = true
 	tc := testcluster.StartTestCluster(t, 3,
-		base.TestClusterArgs{ServerArgs: base.TestServerArgs{Insecure: true}})
+		base.TestClusterArgs{ServerArgs: params})
 	defer tc.Stopper().Stop(ctx)
 
 	// Switch off the second node.


### PR DESCRIPTION
Previsouly, TestPartialZip occasionally fails due to the follower read
timestamp being too low for SQL Stats queries. This causes descriptor
not found error.
This commit addresses this issue by using tests.CreateTestServerParams()
to create test server params with testing knob that mitigates
that behavior.

Resolves: #69450

Release justification: Category 2: Bug fixes and low-risk updates
to new functionality

Release note: None