### PR TITLE
roachtest: allow non-interactive roachstress.sh

### DIFF
--- a/pkg/cmd/roachtest/roachstress.sh
+++ b/pkg/cmd/roachtest/roachstress.sh
@@ -12,9 +12,9 @@ set -euo pipefail
 
 
 # Read user input.
-read -r -e -i "${TEST-}" -p "Test regexp: " TEST
-read -r -e -i "${COUNT-10}" -p "Count: " COUNT
-read -r -e -i "${LOCAL-n}" -p "Local: " LOCAL
+if [ -z "${TEST-}" ]; then read -r -e -p "Test regexp: " TEST; fi
+if [ -z "${COUNT-}" ]; then read -r -e -i "10" -p "Count: " COUNT; fi
+if [ -z "${LOCAL-}" ]; then read -r -e -i "n" -p "Local: " LOCAL; fi
 case $LOCAL in
   [Nn]* | false | "") LOCAL="";;
   *) LOCAL=".local";;
@@ -50,8 +50,8 @@ a="${abase}/$(date '+%H%M%S')"
 
 short="short"
 if [ ! -f "${cr}" ]; then
-  yn=""
-  read -r -e -i "${SHORT-y}" -p "Build cockroach without the UI: " yn
+  yn="${SHORT-}"
+  if [ -z "${yn}" ]; then read -r -e -i "y" -p "Build cockroach without the UI: " yn; fi
   case $yn in
     [Nn]* | false | "") short=""
   esac

--- a/pkg/cmd/roachtest/roachstress.sh
+++ b/pkg/cmd/roachtest/roachstress.sh
@@ -12,9 +12,9 @@ set -euo pipefail
 
 
 # Read user input.
-if [ -z "${TEST-}" ]; then read -r -e -p "Test regexp: " TEST; fi
-if [ -z "${COUNT-}" ]; then read -r -e -i "10" -p "Count: " COUNT; fi
-if [ -z "${LOCAL-}" ]; then read -r -e -i "n" -p "Local: " LOCAL; fi
+if [ ! -v TEST ]; then read -r -e -p "Test regexp: " TEST; fi
+if [ ! -v COUNT ]; then read -r -e -i "10" -p "Count: " COUNT; fi
+if [ ! -v LOCAL ]; then read -r -e -i "n" -p "Local: " LOCAL; fi
 case $LOCAL in
   [Nn]* | false | "") LOCAL="";;
   *) LOCAL=".local";;

--- a/pkg/cmd/roachtest/roachstress.sh
+++ b/pkg/cmd/roachtest/roachstress.sh
@@ -69,7 +69,7 @@ if [ ! -f "${cr}" ]; then
   fi
 fi
 
-if [ ! -f "${rt}" ]; then
+if [ ! -f "${wl}" ]; then
   if [ -z "${LOCAL}" ]; then
     ./build/builder.sh mkrelease amd64-linux-gnu bin/workload
     cp bin.docker_amd64/workload "${wl}"


### PR DESCRIPTION
This allows using `roachstress.sh` for fully autonomous `git bisect
runs`, such as

```
git bisect run /bin/bash -c \
  'TEST=splits/load/uniform/nodes=3 LOCAL=y COUNT=1 SHORT=y ./pkg/cmd/roachtest/roachstress.sh'
````

which was helpful in
https://github.com/cockroachdb/cockroach/issues/69411.

Release justification: testing only change
Release note: None
