### PR TITLE
server: remove non-deterministic test

### DIFF
--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -1994,8 +1994,6 @@ func TestStatusAPICombinedStatements(t *testing.T) {
 	testPath(fmt.Sprintf("combinedstmts?end=%d", nowInSecs), expectedStatements)
 	// Test with start = 1 hour ago end = now; should give the same results as get all.
 	testPath(fmt.Sprintf("combinedstmts?start=%d&end=%d", nowInSecs-3600, nowInSecs), expectedStatements)
-	// Test with start = now; should give no results.
-	testPath(fmt.Sprintf("combinedstmts?start=%d", nowInSecs), nil)
 }
 
 func TestListSessionsSecurity(t *testing.T) {


### PR DESCRIPTION
A new test was added but it would fail depending on the
time it was executed. This commit remove this flaky test
so in a future PR we can add new set of tests that make
more sense to test this functionality.

Fixes #69533

Release justification: Category 3 bug fix
Release note: None