### PR TITLE
sql: avoid init-ing unused sessionDataMutatorIterator

### DIFF
--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -169,12 +169,13 @@ func (ie *InternalExecutor) initConnEx(
 	}
 	statsWriter := ie.s.sqlStats.GetWriterForApplication(appStatsBucketName)
 
+	sds := sessiondata.NewStack(sd)
+	sdMutIterator := ie.s.makeSessionDataMutatorIterator(sds, nil /* sessionDefaults */)
 	var ex *connExecutor
 	if txn == nil {
 		ex = ie.s.newConnExecutor(
 			ctx,
-			sd,
-			nil, /* sdDefaults */
+			sdMutIterator,
 			stmtBuf,
 			clientComm,
 			ie.memMetrics,
@@ -184,8 +185,7 @@ func (ie *InternalExecutor) initConnEx(
 	} else {
 		ex = ie.s.newConnExecutorWithTxn(
 			ctx,
-			sd,
-			nil, /* sdDefaults */
+			sdMutIterator,
 			stmtBuf,
 			clientComm,
 			ie.mon,


### PR DESCRIPTION
Reuse the one that was created rather than making a new one.

Release justification: low risk update to new functionality.
Release note: none