### PR TITLE
sql/pgwire: fix race condition with default_int_size

### DIFF
--- a/pkg/sql/conn_executor_internal_test.go
+++ b/pkg/sql/conn_executor_internal_test.go
@@ -320,7 +320,8 @@ func startConnExecutor(
 	}
 	sqlMetrics := MakeMemMetrics("test" /* endpoint */, time.Second /* histogramWindow */)
 
-	conn, err := s.SetupConn(ctx, SessionArgs{}, buf, cc, sqlMetrics)
+	onDefaultIntSizeChange := func(int32) {}
+	conn, err := s.SetupConn(ctx, SessionArgs{}, buf, cc, sqlMetrics, onDefaultIntSizeChange)
 	if err != nil {
 		return nil, nil, nil, nil, nil, err
 	}
@@ -355,7 +356,8 @@ func TestSessionCloseWithPendingTempTableInTxn(t *testing.T) {
 			flushed <- res
 		},
 	}
-	connHandler, err := srv.SetupConn(ctx, SessionArgs{User: security.RootUserName()}, stmtBuf, clientComm, MemoryMetrics{})
+	onDefaultIntSizeChange := func(int32) {}
+	connHandler, err := srv.SetupConn(ctx, SessionArgs{User: security.RootUserName()}, stmtBuf, clientComm, MemoryMetrics{}, onDefaultIntSizeChange)
 	require.NoError(t, err)
 
 	stmts, err := parser.Parse(`

--- a/pkg/sql/distsql_running_test.go
+++ b/pkg/sql/distsql_running_test.go
@@ -35,7 +35,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/pgtest"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -376,8 +375,6 @@ func TestDistSQLReceiverDrainsOnError(t *testing.T) {
 func TestDistSQLReceiverDrainsMeta(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-
-	skip.UnderRace(t, "See #69451")
 
 	var accumulatedMeta []execinfrapb.ProducerMetadata
 	// Set up a 3 node cluster and inject a callback to accumulate all metadata

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -246,7 +246,11 @@ func (s *Stack) Push(elem *SessionData) {
 
 // PushTopClone pushes a copy of the top element to the stack.
 func (s *Stack) PushTopClone() {
-	s.Push(s.Top().Clone())
+	if len(s.stack) == 0 {
+		return
+	}
+	sd := s.stack[len(s.stack)-1]
+	s.stack = append(s.stack, sd.Clone())
 }
 
 // Pop removes the top SessionData element from the stack.

--- a/pkg/testutils/pgtest/datadriven.go
+++ b/pkg/testutils/pgtest/datadriven.go
@@ -68,8 +68,6 @@ func WalkWithNewServer(
 // posrgres), then the exchange is skipped. With noncrdb_only, the inverse
 // happens.
 func RunTest(t *testing.T, path, addr, user string) {
-	skip.UnderRace(t, "See #69451")
-
 	p, err := NewPGTest(context.Background(), addr, user)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/69451

The default_int_size session variable needs to be read in a different
goroutine from the session itself. It's read at parsing time, when
reading from the pgwire stmtBuf, but is written in the session.

This was a race condition. Now, the value is changed atomically
using a callback.

Release justification: bug fix for new feature
Release note: None