### PR TITLE
sql: fix telemetry test flake

### DIFF
--- a/pkg/sql/testdata/telemetry/planning
+++ b/pkg/sql/testdata/telemetry/planning
@@ -216,13 +216,17 @@ sql.plan.ops.array.cons
 # Test a few sql.plan.opt.node counters.
 feature-allowlist
 sql.plan.opt.node.project-set
-sql.plan.opt.node.join.*
 ----
 
 feature-usage
 SELECT EXISTS(SELECT * FROM generate_series(1,2))
 ----
 sql.plan.opt.node.project-set
+
+feature-allowlist
+sql.plan.opt.node.join.algo.merge
+sql.plan.opt.node.join.type.inner
+----
 
 feature-usage
 SELECT *
@@ -236,7 +240,6 @@ sql.plan.opt.node.join.type.inner
 
 feature-allowlist
 sql.plan.opt.partial-index.scan
-sql.plan.opt.partial-index.lookup-join
 ----
 
 exec
@@ -247,6 +250,11 @@ feature-usage
 SELECT a FROM x@i WHERE a > 0
 ----
 sql.plan.opt.partial-index.scan
+
+feature-allowlist
+sql.plan.opt.partial-index.scan
+sql.plan.opt.partial-index.lookup-join
+----
 
 feature-usage
 SELECT x1.a FROM x x1 INNER LOOKUP JOIN x x2 ON x1.a = x2.a WHERE x2.a > 0


### PR DESCRIPTION
I have not been able to repro the flakiness but I'm hoping this fixes it.

#### sql: fix telemetry test flake

TestTelemetry sometimes flakes with extra lookup and inner join
counters. This is probably due to a new internal background query
(though note that if that's the case, the value of those counters
existing in the first place is dubious).

This change modifies the test to have more specific feature
allow-lists.

Fixes #69284.

Release note: None

Release justification: test-only change.