### PR TITLE
sql: depointerise sessionDataMutator arguments

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -597,7 +597,7 @@ func (s *Server) SetupConn(
 	// Set the SessionData from args.SessionDefaults. This also validates the
 	// respective values.
 	sdMutIterator := s.makeSessionDataMutatorIterator(sds, args.SessionDefaults)
-	if err := sdMutIterator.applyOnEachMutatorError(func(m *sessionDataMutator) error {
+	if err := sdMutIterator.applyOnEachMutatorError(func(m sessionDataMutator) error {
 		return resetSessionVars(ctx, m)
 	}); err != nil {
 		log.Errorf(ctx, "error setting up client session: %s", err)
@@ -871,7 +871,7 @@ func (s *Server) newConnExecutorWithTxn(
 	if txn.Type() == kv.LeafTxn {
 		// If the txn is a leaf txn it is not allowed to perform mutations. For
 		// sanity, set read only on the session.
-		ex.dataMutatorIterator.applyForEachMutator(func(m *sessionDataMutator) {
+		ex.dataMutatorIterator.applyForEachMutator(func(m sessionDataMutator) {
 			m.SetReadOnly(true)
 		})
 	}

--- a/pkg/sql/discard.go
+++ b/pkg/sql/discard.go
@@ -31,7 +31,7 @@ func (p *planner) Discard(ctx context.Context, s *tree.Discard) (planNode, error
 
 		// RESET ALL
 		if err := p.sessionDataMutatorIterator.applyOnEachMutatorError(
-			func(m *sessionDataMutator) error {
+			func(m sessionDataMutator) error {
 				return resetSessionVars(ctx, m)
 			},
 		); err != nil {
@@ -46,7 +46,7 @@ func (p *planner) Discard(ctx context.Context, s *tree.Discard) (planNode, error
 	return newZeroNode(nil /* columns */), nil
 }
 
-func resetSessionVars(ctx context.Context, m *sessionDataMutator) error {
+func resetSessionVars(ctx context.Context, m sessionDataMutator) error {
 	for _, varName := range varNames {
 		v := varGen[varName]
 		if v.Set != nil {

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -2549,8 +2549,8 @@ type sessionDataMutatorIterator struct {
 // mutator returns a mutator for the given sessionData.
 func (it *sessionDataMutatorIterator) mutator(
 	applyCallbacks bool, sd *sessiondata.SessionData,
-) *sessionDataMutator {
-	ret := &sessionDataMutator{
+) sessionDataMutator {
+	ret := sessionDataMutator{
 		data:                   sd,
 		sessionDataMutatorBase: it.sessionDataMutatorBase,
 	}
@@ -2566,7 +2566,7 @@ func (it *sessionDataMutatorIterator) mutator(
 // SetSessionDefaultIntSize sets the default int size for the session.
 // It is exported for use in import which is a CCL package.
 func (it *sessionDataMutatorIterator) SetSessionDefaultIntSize(size int32) {
-	it.applyForEachMutator(func(m *sessionDataMutator) {
+	it.applyForEachMutator(func(m sessionDataMutator) {
 		m.SetDefaultIntSize(size)
 	})
 }
@@ -2574,7 +2574,7 @@ func (it *sessionDataMutatorIterator) SetSessionDefaultIntSize(size int32) {
 // applyOnTopMutator applies the given function on the mutator for the top
 // element on the sessiondata Stack only.
 func (it *sessionDataMutatorIterator) applyOnTopMutator(
-	applyFunc func(m *sessionDataMutator) error,
+	applyFunc func(m sessionDataMutator) error,
 ) error {
 	return applyFunc(it.mutator(true /* applyCallbacks */, it.sds.Top()))
 }
@@ -2582,7 +2582,7 @@ func (it *sessionDataMutatorIterator) applyOnTopMutator(
 // applyForEachMutator iterates over each mutator over all SessionData elements
 // in the stack and applies the given function to them.
 // It is the equivalent of SET SESSION x = y.
-func (it *sessionDataMutatorIterator) applyForEachMutator(applyFunc func(m *sessionDataMutator)) {
+func (it *sessionDataMutatorIterator) applyForEachMutator(applyFunc func(m sessionDataMutator)) {
 	elems := it.sds.Elems()
 	for i, sd := range elems {
 		applyFunc(it.mutator(i == 0, sd))
@@ -2592,7 +2592,7 @@ func (it *sessionDataMutatorIterator) applyForEachMutator(applyFunc func(m *sess
 // applyOnEachMutatorError is the same as applyForEachMutator, but takes in a function
 // that can return an error, erroring if any of applications error.
 func (it *sessionDataMutatorIterator) applyOnEachMutatorError(
-	applyFunc func(m *sessionDataMutator) error,
+	applyFunc func(m sessionDataMutator) error,
 ) error {
 	elems := it.sds.Elems()
 	for i, sd := range elems {

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -515,7 +515,7 @@ func (p *planner) ExecCfg() *ExecutorConfig {
 	return p.extendedEvalCtx.ExecCfg
 }
 
-func (p *planner) applyOnEachMutatorError(applyFunc func(m *sessionDataMutator) error) error {
+func (p *planner) applyOnEachMutatorError(applyFunc func(m sessionDataMutator) error) error {
 	return p.sessionDataMutatorIterator.applyOnEachMutatorError(applyFunc)
 }
 
@@ -525,7 +525,7 @@ func (p *planner) applyOnEachMutatorError(applyFunc func(m *sessionDataMutator) 
 func (p *planner) GetOrInitSequenceCache() sessiondatapb.SequenceCache {
 	if p.SessionData().SequenceCache == nil {
 		p.ExtendedEvalContext().SessionMutatorIterator.applyForEachMutator(
-			func(m *sessionDataMutator) {
+			func(m sessionDataMutator) {
 				m.initSequenceCache()
 			},
 		)

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -131,7 +131,7 @@ func incrementSequenceHelper(
 	}
 
 	p.ExtendedEvalContext().SessionMutatorIterator.applyForEachMutator(
-		func(m *sessionDataMutator) {
+		func(m sessionDataMutator) {
 			m.RecordLatestSequenceVal(uint32(descriptor.GetID()), val)
 		},
 	)

--- a/pkg/sql/set_default_isolation.go
+++ b/pkg/sql/set_default_isolation.go
@@ -27,7 +27,7 @@ func (p *planner) SetSessionCharacteristics(n *tree.SetSessionCharacteristics) (
 			"unsupported default isolation level: %s", n.Modes.Isolation)
 	}
 
-	if err := p.applyOnEachMutatorError(func(m *sessionDataMutator) error {
+	if err := p.applyOnEachMutatorError(func(m sessionDataMutator) error {
 		// Note: We also support SET DEFAULT_TRANSACTION_PRIORITY TO ' .... '.
 		switch n.Modes.UserPriority {
 		case tree.UnspecifiedUserPriority:

--- a/pkg/sql/set_var.go
+++ b/pkg/sql/set_var.go
@@ -142,7 +142,7 @@ func (n *setVarNode) startExec(params runParams) error {
 // applyOnSessionDataMutators applies the given function on the relevant
 // sessionDataMutators.
 func (p *planner) applyOnSessionDataMutators(
-	ctx context.Context, local bool, applyFunc func(m *sessionDataMutator) error,
+	ctx context.Context, local bool, applyFunc func(m sessionDataMutator) error,
 ) error {
 	if local {
 		// We don't allocate a new SessionData object on implicit transactions.
@@ -254,7 +254,7 @@ func timeZoneVarGetStringVal(
 	return loc.String(), nil
 }
 
-func timeZoneVarSet(_ context.Context, m *sessionDataMutator, s string) error {
+func timeZoneVarSet(_ context.Context, m sessionDataMutator, s string) error {
 	loc, err := timeutil.TimeZoneStringToLocation(
 		s,
 		timeutil.TimeZoneStringToLocationISO8601Standard,
@@ -326,7 +326,7 @@ func validateTimeoutVar(
 	return timeout, nil
 }
 
-func stmtTimeoutVarSet(ctx context.Context, m *sessionDataMutator, s string) error {
+func stmtTimeoutVarSet(ctx context.Context, m sessionDataMutator, s string) error {
 	timeout, err := validateTimeoutVar(
 		m.data.GetIntervalStyle(),
 		s,
@@ -340,7 +340,7 @@ func stmtTimeoutVarSet(ctx context.Context, m *sessionDataMutator, s string) err
 	return nil
 }
 
-func lockTimeoutVarSet(ctx context.Context, m *sessionDataMutator, s string) error {
+func lockTimeoutVarSet(ctx context.Context, m sessionDataMutator, s string) error {
 	timeout, err := validateTimeoutVar(
 		m.data.GetIntervalStyle(),
 		s,
@@ -354,7 +354,7 @@ func lockTimeoutVarSet(ctx context.Context, m *sessionDataMutator, s string) err
 	return nil
 }
 
-func idleInSessionTimeoutVarSet(ctx context.Context, m *sessionDataMutator, s string) error {
+func idleInSessionTimeoutVarSet(ctx context.Context, m sessionDataMutator, s string) error {
 	timeout, err := validateTimeoutVar(
 		m.data.GetIntervalStyle(),
 		s,
@@ -369,7 +369,7 @@ func idleInSessionTimeoutVarSet(ctx context.Context, m *sessionDataMutator, s st
 }
 
 func idleInTransactionSessionTimeoutVarSet(
-	ctx context.Context, m *sessionDataMutator, s string,
+	ctx context.Context, m sessionDataMutator, s string,
 ) error {
 	timeout, err := validateTimeoutVar(
 		m.data.GetIntervalStyle(),

--- a/pkg/sql/temporary_schema.go
+++ b/pkg/sql/temporary_schema.go
@@ -110,7 +110,7 @@ func (p *planner) getOrCreateTemporarySchema(
 	if err := p.CreateSchemaNamespaceEntry(ctx, catalogkeys.EncodeNameKey(p.ExecCfg().Codec, sKey), id); err != nil {
 		return nil, err
 	}
-	p.sessionDataMutatorIterator.applyForEachMutator(func(m *sessionDataMutator) {
+	p.sessionDataMutatorIterator.applyForEachMutator(func(m sessionDataMutator) {
 		m.SetTemporarySchemaName(sKey.GetName())
 		m.SetTemporarySchemaIDForDatabase(uint32(db.GetID()), uint32(id))
 	})

--- a/pkg/sql/unsupported_vars.go
+++ b/pkg/sql/unsupported_vars.go
@@ -22,7 +22,7 @@ var DummyVars = map[string]sessionVar{
 		func(evalCtx *extendedEvalContext) string {
 			return formatBoolAsPostgresSetting(evalCtx.SessionData().EnableSeqScan)
 		},
-		func(m *sessionDataMutator, v bool) {
+		func(m sessionDataMutator, v bool) {
 			m.SetEnableSeqScan(v)
 		},
 		func(sv *settings.Values) string { return "on" },
@@ -32,7 +32,7 @@ var DummyVars = map[string]sessionVar{
 		func(evalCtx *extendedEvalContext) string {
 			return formatBoolAsPostgresSetting(evalCtx.SessionData().SynchronousCommit)
 		},
-		func(m *sessionDataMutator, v bool) {
+		func(m sessionDataMutator, v bool) {
 			m.SetSynchronousCommit(v)
 		},
 		func(sv *settings.Values) string { return "on" },

--- a/pkg/sql/user.go
+++ b/pkg/sql/user.go
@@ -514,7 +514,7 @@ func (p *planner) setRole(ctx context.Context, local bool, s security.SQLUsernam
 	return p.applyOnSessionDataMutators(
 		ctx,
 		local,
-		func(m *sessionDataMutator) error {
+		func(m sessionDataMutator) error {
 			m.data.IsSuperuser = willBecomeAdmin
 			m.bufferParamStatusUpdate("is_superuser", updateStr)
 


### PR DESCRIPTION
Avoid a heap allocation to sessionDataMutator objects as they no longer
require pointer-yness to work.

Refs: #69391

Release justification: small fix to new functionality

Release note: None