### PR TITLE
sql/catalog/lease: unskip test marked as flakey

### DIFF
--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -2196,7 +2196,6 @@ func ensureTestTakesLessThan(t *testing.T, allowed time.Duration) func() {
 // too old.
 func TestRangefeedUpdatesHandledProperlyInTheFaceOfRaces(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.WithIssue(t, 68801, "flaky test")
 	defer ensureTestTakesLessThan(t, 30*time.Second)()
 
 	ctx := context.Background()


### PR DESCRIPTION
I went back and looked and the artifacts were gone but it looked like the
whole package rimed out rahter than just this test. I've run it under
stress for some time now on a lot of machines (160 cores) and not
gotten a flake.

`stress` of the whole package with this test enabled, 90s timeout
```
4892 runs so far, 0 failures, over 8m20s
```

`stress-race` of just this test, 90s timeout
```
6390 runs so far, 0 failures, over 5m55s
```

Closes #68801

Release justification: non-production code changes

Release note: None