### PR TITLE
kvprober: scan meta2 at a historical timestamp

### DIFF
--- a/pkg/kv/kvprober/helpers_test.go
+++ b/pkg/kv/kvprober/helpers_test.go
@@ -21,11 +21,12 @@ import (
 // Below are exported to enable testing from kvprober_test.
 
 var (
-	ReadEnabled          = readEnabled
-	ReadInterval         = readInterval
-	WriteEnabled         = writeEnabled
-	WriteInterval        = writeInterval
-	NumStepsToPlanAtOnce = numStepsToPlanAtOnce
+	ReadEnabled            = readEnabled
+	ReadInterval           = readInterval
+	WriteEnabled           = writeEnabled
+	WriteInterval          = writeInterval
+	NumStepsToPlanAtOnce   = numStepsToPlanAtOnce
+	ScanMeta2ThisFarInPast = scanMeta2ThisFarInPast
 )
 
 func (p *Prober) ReadProbe(ctx context.Context, db *kv.DB) {

--- a/pkg/kv/kvprober/kvprober_integration_test.go
+++ b/pkg/kv/kvprober/kvprober_integration_test.go
@@ -314,8 +314,11 @@ func initTestProber(
 		Settings:                s.ClusterSettings(),
 	})
 
+	ctx := context.Background()
 	// Given small test cluster, this better exercises the planning logic.
-	kvprober.NumStepsToPlanAtOnce.Override(context.Background(), &s.ClusterSettings().SV, 10)
+	kvprober.NumStepsToPlanAtOnce.Override(ctx, &s.ClusterSettings().SV, 10)
+	// Test cluster lifetime implies need to scan meta2 closer to current time than the default.
+	kvprober.ScanMeta2ThisFarInPast.Override(ctx, &s.ClusterSettings().SV, -1*time.Millisecond)
 	// Want these tests to run as fast as possible; see planner_test.go for a
 	// unit test of the rate limiting.
 	p.SetPlanningRateLimits(0)

--- a/pkg/kv/kvprober/settings.go
+++ b/pkg/kv/kvprober/settings.go
@@ -92,6 +92,17 @@ var scanMeta2Timeout = settings.RegisterDurationSetting(
 		return nil
 	})
 
+var scanMeta2ThisFarInPast = settings.RegisterDurationSetting(
+	"kv.prober.planner.scan_meta2.this_far_in_past",
+	"how far in the past to scan meta2 at via a historical read; do not"+
+		"change this setting unless you know what you are doing",
+	-10*time.Second, func(d time.Duration) error {
+		if d > 0 {
+			return errors.New("param must be <=0, as reads in the future are not allowed")
+		}
+		return nil
+	})
+
 var numStepsToPlanAtOnce = settings.RegisterIntSetting(
 	"kv.prober.planner.num_steps_to_plan_at_once",
 	"the number of Steps to plan at once, where a Step is a decision on "+


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/cockroach/issues/65996.

**kvprober: scan meta2 at a historical timestamp**

This PR updates kvprober to scan meta2 N seconds in the past via a historical
read. There is no need for very fresh data, as the worst case result is planner
believing it is probing range X when actually it is probing range Y. Also,
planner caches plans, so this already happens during normal operation. Scanning
via a historical read may reduce the chances of kvprober causing or
contributing to some kind of production issue affecting meta2, tho we don't
think such a situation is likely even if the read is done at the current time.

Release justification: Component off by default. Used only by SRE today.
Release note: None.