### PR TITLE
ui: fix tooltip text on stmt and txn pages

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -547,6 +547,7 @@ export class StatementsPage extends React.Component<
               search={search}
               totalCount={totalCount}
               arrayItemName="statements"
+              tooltipType="statement"
               activeFilters={activeFilters}
               onClearFilters={this.onClearFilters}
               resetSQLStats={resetSQLStats}

--- a/pkg/ui/workspaces/cluster-ui/src/tableStatistics/tableStatistics.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/tableStatistics/tableStatistics.tsx
@@ -16,13 +16,15 @@ import { ISortedTablePagination } from "../sortedtable";
 import { Button } from "src/button";
 import { ResultsPerPageLabel } from "src/pagination";
 import { Tooltip } from "@cockroachlabs/ui-components";
-import statementStyles from "src/statementDetails/statementDetails.module.scss";
 import tableStatsStyles from "./tableStatistics.module.scss";
 import classNames from "classnames/bind";
 import { Icon } from "@cockroachlabs/ui-components";
+import {
+  contentModifiers,
+  StatisticType,
+} from "../statsTableUtil/statsTableUtil";
 
 const { statistic, countTitle, lastCleared } = statisticsClasses;
-const cxStmt = classNames.bind(statementStyles);
 const cxStats = classNames.bind(tableStatsStyles);
 
 interface TableStatistics {
@@ -30,14 +32,12 @@ interface TableStatistics {
   totalCount: number;
   lastReset: Date | string;
   arrayItemName: string;
+  tooltipType: StatisticType;
   activeFilters: number;
   search?: string;
   onClearFilters?: () => void;
   resetSQLStats: () => void;
 }
-
-const toolTipText = `Statement history is cleared once an hour by default, which can be configured with the cluster setting
- diagnostics.reporting.interval. Clicking ‘Clear SQL stats’ will reset SQL stats on the statements and transactions pages.`;
 
 const renderLastCleared = (lastReset: string | Date) => {
   return `Last cleared ${moment.utc(lastReset).format(DATE_FORMAT)}`;
@@ -49,6 +49,7 @@ export const TableStatistics: React.FC<TableStatistics> = ({
   lastReset,
   search,
   arrayItemName,
+  tooltipType,
   onClearFilters,
   activeFilters,
   resetSQLStats,
@@ -70,6 +71,24 @@ export const TableStatistics: React.FC<TableStatistics> = ({
       </Button>
     </>
   );
+
+  let toolTipText = ` history is cleared once an hour by default, which can be configured with 
+  the cluster setting diagnostics.sql_stat_reset.interval. Clicking ‘Clear SQL stats’ will reset SQL stats 
+  on the statements and transactions pages.`;
+
+  switch (tooltipType) {
+    case "transaction":
+      toolTipText = contentModifiers.transactionCapital + toolTipText;
+      break;
+    case "statement":
+      toolTipText = contentModifiers.statementCapital + toolTipText;
+      break;
+    case "transactionDetails":
+      toolTipText = contentModifiers.statementCapital + toolTipText;
+      break;
+    default:
+      break;
+  }
 
   return (
     <div className={statistic}>

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
@@ -248,6 +248,7 @@ export class TransactionDetails extends React.Component<
                     arrayItemName={
                       "statement fingerprints for this transaction"
                     }
+                    tooltipType="transactionDetails"
                     activeFilters={0}
                     resetSQLStats={resetSQLStats}
                   />

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -356,6 +356,7 @@ export class TransactionsPage extends React.Component<
                     search={search}
                     totalCount={transactionsToDisplay.length}
                     arrayItemName="transactions"
+                    tooltipType="transaction"
                     activeFilters={activeFilters}
                     onClearFilters={this.onClearFilters}
                     resetSQLStats={resetSQLStats}


### PR DESCRIPTION
Previously, all reset SQL stats tooltips were showing the
wrong setting and always mentioning Statement history, instead
of Transaction history.

Fixes #68462

Release justification: Category 2
Release note (ui change): Fix tooltip text on Statement and Transaction
pages, to use correct setting "diagnostics.sql_stat_reset.interval", instead
of the previous value "diagnostics.reporting.interval"


<img width="481" alt="Screen Shot 2021-08-30 at 10 32 03 AM" src="https://user-images.githubusercontent.com/1017486/131355907-edf50fdd-406e-4b1e-a3a2-9a8e510d336a.png">
<img width="466" alt="Screen Shot 2021-08-30 at 10 32 14 AM" src="https://user-images.githubusercontent.com/1017486/131355924-7d193bd0-bc78-444f-a413-169ab1f54680.png">
