### PR TITLE
release-21.1: distsql: restore EvalCtx.Mon on the flow cleanup

### DIFF
--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -203,7 +203,7 @@ func (ds *ServerImpl) setupFlow(
 	req *execinfrapb.SetupFlowRequest,
 	syncFlowConsumer execinfra.RowReceiver,
 	localState LocalState,
-) (context.Context, flowinfra.Flow, error) {
+) (retCtx context.Context, _ flowinfra.Flow, retErr error) {
 	if !FlowVerIsCompatible(req.Version, execinfra.MinAcceptedVersion, execinfra.Version) {
 		err := errors.Errorf(
 			"version mismatch in flow request: %d; this node accepts %d through %d",
@@ -213,8 +213,27 @@ func (ds *ServerImpl) setupFlow(
 		return ctx, nil, err
 	}
 
+	var sp *tracing.Span          // will be Finish()ed by Flow.Cleanup()
+	var monitor *mon.BytesMonitor // will be closed in Flow.Cleanup()
+	var onFlowCleanup func()
+	// Make sure that we clean up all resources (which in the happy case are
+	// cleaned up in Flow.Cleanup()) if an error is encountered.
+	defer func() {
+		if retErr != nil {
+			if sp != nil {
+				sp.Finish()
+			}
+			if monitor != nil {
+				monitor.Stop(ctx)
+			}
+			if onFlowCleanup != nil {
+				onFlowCleanup()
+			}
+			retCtx = tracing.ContextWithSpan(ctx, nil)
+		}
+	}()
+
 	const opName = "flow"
-	var sp *tracing.Span // will be Finish()ed by Flow.Cleanup()
 	if parentSpan == nil {
 		ctx, sp = ds.Tracer.StartSpanCtx(ctx, opName)
 	} else if localState.IsLocal {
@@ -234,8 +253,7 @@ func (ds *ServerImpl) setupFlow(
 		)
 	}
 
-	// The monitor opened here is closed in Flow.Cleanup().
-	monitor := mon.NewMonitor(
+	monitor = mon.NewMonitor(
 		"flow",
 		mon.MemoryResource,
 		ds.Metrics.CurBytesCount,
@@ -264,7 +282,6 @@ func (ds *ServerImpl) setupFlow(
 
 	var evalCtx *tree.EvalContext
 	var leafTxn *kv.Txn
-	var onFlowCleanup func()
 	if localState.EvalContext != nil {
 		evalCtx = localState.EvalContext
 		// We're about to mutate the evalCtx and we want to restore its original
@@ -284,7 +301,6 @@ func (ds *ServerImpl) setupFlow(
 
 		sd, err := sessiondata.UnmarshalNonLocal(req.EvalContext.SessionData)
 		if err != nil {
-			sp.Finish()
 			return ctx, nil, err
 		}
 		ie := &lazyInternalExecutor{
@@ -350,14 +366,6 @@ func (ds *ServerImpl) setupFlow(
 	var err error
 	if ctx, err = f.Setup(ctx, &req.Flow, opt); err != nil {
 		log.Errorf(ctx, "error setting up flow: %s", err)
-		// Flow.Cleanup will not be called, so we have to close the memory monitor
-		// and finish the span manually.
-		monitor.Stop(ctx)
-		sp.Finish()
-		if onFlowCleanup != nil {
-			onFlowCleanup()
-		}
-		ctx = tracing.ContextWithSpan(ctx, nil)
 		return ctx, nil, err
 	}
 	if !f.IsLocal() {
@@ -379,7 +387,6 @@ func (ds *ServerImpl) setupFlow(
 	} else {
 		// If I haven't created the leaf already, do it now.
 		if leafTxn == nil {
-			var err error
 			leafTxn, err = makeLeaf(req)
 			if err != nil {
 				return nil, nil, err

--- a/pkg/sql/distsql/vectorized_panic_propagation_test.go
+++ b/pkg/sql/distsql/vectorized_panic_propagation_test.go
@@ -47,6 +47,7 @@ func TestNonVectorizedPanicDoesntHangServer(t *testing.T) {
 		nil, /* flowReg */
 		nil, /* syncFlowConsumer */
 		nil, /* localProcessors */
+		nil, /* onFlowCleanup */
 	)
 	flow := colflow.NewVectorizedFlow(base)
 

--- a/pkg/sql/flowinfra/flow.go
+++ b/pkg/sql/flowinfra/flow.go
@@ -161,6 +161,8 @@ type FlowBase struct {
 	//  - outboxes
 	waitGroup sync.WaitGroup
 
+	onFlowCleanup func()
+
 	doneFn func()
 
 	status flowStatus
@@ -212,12 +214,14 @@ func NewFlowBase(
 	flowReg *FlowRegistry,
 	syncFlowConsumer execinfra.RowReceiver,
 	localProcessors []execinfra.LocalProcessor,
+	onFlowCleanup func(),
 ) *FlowBase {
 	base := &FlowBase{
 		FlowCtx:          flowCtx,
 		flowRegistry:     flowReg,
 		syncFlowConsumer: syncFlowConsumer,
 		localProcessors:  localProcessors,
+		onFlowCleanup:    onFlowCleanup,
 	}
 	base.status = FlowNotStarted
 	return base
@@ -466,6 +470,9 @@ func (f *FlowBase) Cleanup(ctx context.Context) {
 	}
 	f.status = FlowFinished
 	f.ctxCancel()
+	if f.onFlowCleanup != nil {
+		f.onFlowCleanup()
+	}
 	if f.doneFn != nil {
 		f.doneFn()
 	}


### PR DESCRIPTION
Backport 2/2 commits from #69483.

/cc @cockroachdb/release

---

**distsql: restore EvalCtx.Mon on the flow cleanup**

In `setupFlow`, if we're setting up a flow on the gateway, we're using
`LocalState` to save on deserialization of some state. Notably, we pass
the eval context that we used during the physical planning. That eval
context can be mutated (in particular, we're updating its `Mon` field to
the "flow" memory monitor), and previously this could cause issues when
automatically retrying stats collection jobs (possibly there could be
other issues).

This commit introduces a callback to restore the local eval context to
its original state which is done on the flow cleanup.

Fixes: #68670.
Fixes: #67113.

Release note (bug fix): Previously, table stats collection issued via
`ANALYZE` statement or via `CREATE STATISTICS` statement without
specifying `AS OF SYSTEM TIME` option could run into
`flow: memory budget exceeded`, and this has been fixed.

Release justification: fix to a long standing bug.

**distsql: fix cleaning up resources in an error case in setupFlow**

Release note: None

Release justification: low-risk improvement to resources' cleanup in an
edge case.
