### PR TITLE
release-20.2: distsql: restore EvalCtx.Mon on the flow cleanup

### DIFF
--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -184,7 +184,7 @@ func (ds *ServerImpl) setupFlow(
 	req *execinfrapb.SetupFlowRequest,
 	syncFlowConsumer execinfra.RowReceiver,
 	localState LocalState,
-) (context.Context, flowinfra.Flow, error) {
+) (retCtx context.Context, _ flowinfra.Flow, retErr error) {
 	if !FlowVerIsCompatible(req.Version, execinfra.MinAcceptedVersion, execinfra.Version) {
 		err := errors.Errorf(
 			"version mismatch in flow request: %d; this node accepts %d through %d",
@@ -194,8 +194,27 @@ func (ds *ServerImpl) setupFlow(
 		return ctx, nil, err
 	}
 
+	var sp opentracing.Span       // will be Finish()ed by Flow.Cleanup()
+	var monitor *mon.BytesMonitor // will be closed in Flow.Cleanup()
+	var onFlowCleanup func()
+	// Make sure that we clean up all resources (which in the happy case are
+	// cleaned up in Flow.Cleanup()) if an error is encountered.
+	defer func() {
+		if retErr != nil {
+			if sp != nil {
+				tracing.FinishSpan(sp)
+			}
+			if monitor != nil {
+				monitor.Stop(ctx)
+			}
+			if onFlowCleanup != nil {
+				onFlowCleanup()
+			}
+			retCtx = opentracing.ContextWithSpan(ctx, nil)
+		}
+	}()
+
 	const opName = "flow"
-	var sp opentracing.Span
 	if parentSpan == nil {
 		sp = ds.Tracer.(*tracing.Tracer).StartRootSpan(
 			opName, logtags.FromContext(ctx), tracing.NonRecordableSpan)
@@ -217,11 +236,9 @@ func (ds *ServerImpl) setupFlow(
 			tracing.LogTagsFromCtx(ctx),
 		)
 	}
-	// sp will be Finish()ed by Flow.Cleanup().
 	ctx = opentracing.ContextWithSpan(ctx, sp)
 
-	// The monitor opened here is closed in Flow.Cleanup().
-	monitor := mon.NewMonitor(
+	monitor = mon.NewMonitor(
 		"flow",
 		mon.MemoryResource,
 		ds.Metrics.CurBytesCount,
@@ -250,7 +267,6 @@ func (ds *ServerImpl) setupFlow(
 
 	var evalCtx *tree.EvalContext
 	var leafTxn *kv.Txn
-	var onFlowCleanup func()
 	if localState.EvalContext != nil {
 		evalCtx = localState.EvalContext
 		// We're about to mutate the evalCtx and we want to restore its original
@@ -375,14 +391,6 @@ func (ds *ServerImpl) setupFlow(
 	var err error
 	if ctx, err = f.Setup(ctx, &req.Flow, opt); err != nil {
 		log.Errorf(ctx, "error setting up flow: %s", err)
-		// Flow.Cleanup will not be called, so we have to close the memory monitor
-		// and finish the span manually.
-		monitor.Stop(ctx)
-		tracing.FinishSpan(sp)
-		if onFlowCleanup != nil {
-			onFlowCleanup()
-		}
-		ctx = opentracing.ContextWithSpan(ctx, nil)
 		return ctx, nil, err
 	}
 	if !f.IsLocal() {
@@ -404,7 +412,6 @@ func (ds *ServerImpl) setupFlow(
 	} else {
 		// If I haven't created the leaf already, do it now.
 		if leafTxn == nil {
-			var err error
 			leafTxn, err = makeLeaf(req)
 			if err != nil {
 				return nil, nil, err

--- a/pkg/sql/distsql/vectorized_panic_propagation_test.go
+++ b/pkg/sql/distsql/vectorized_panic_propagation_test.go
@@ -47,6 +47,7 @@ func TestNonVectorizedPanicDoesntHangServer(t *testing.T) {
 		nil, /* flowReg */
 		nil, /* syncFlowConsumer */
 		nil, /* localProcessors */
+		nil, /* onFlowCleanup */
 	)
 	flow := colflow.NewVectorizedFlow(base)
 


### PR DESCRIPTION
Backport 2/2 commits from #69483.

/cc @cockroachdb/release

---

**distsql: restore EvalCtx.Mon on the flow cleanup**

In `setupFlow`, if we're setting up a flow on the gateway, we're using
`LocalState` to save on deserialization of some state. Notably, we pass
the eval context that we used during the physical planning. That eval
context can be mutated (in particular, we're updating its `Mon` field to
the "flow" memory monitor), and previously this could cause issues when
automatically retrying stats collection jobs (possibly there could be
other issues).

This commit introduces a callback to restore the local eval context to
its original state which is done on the flow cleanup.

Fixes: #68670.
Fixes: #67113.

Release note (bug fix): Previously, table stats collection issued via
`ANALYZE` statement or via `CREATE STATISTICS` statement without
specifying `AS OF SYSTEM TIME` option could run into
`flow: memory budget exceeded`, and this has been fixed.

Release justification: fix to a long standing bug.

**distsql: fix cleaning up resources in an error case in setupFlow**

Release note: None

Release justification: low-risk improvement to resources' cleanup in an
edge case.
