### PR TITLE
roachtest: update 21.2 version map to 21.1.8

### DIFF
--- a/pkg/cmd/roachtest/tests/predecessor_version.go
+++ b/pkg/cmd/roachtest/tests/predecessor_version.go
@@ -34,7 +34,7 @@ func PredecessorVersion(buildVersion version.Version) (string, error) {
 	// (see runVersionUpgrade). The same is true for adding a new key to this
 	// map.
 	verMap := map[string]string{
-		"21.2": "21.1.7",
+		"21.2": "21.1.8",
 		"21.1": "20.2.12",
 		"20.2": "20.1.16",
 		"20.1": "19.2.11",


### PR DESCRIPTION
Release justification: non-production code change
Release note: None