### PR TITLE
opt: fix incorrect results returned by streaming set ops

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/union
+++ b/pkg/sql/logictest/testdata/logic_test/union
@@ -624,3 +624,32 @@ e  a
 e  b
 e  c
 e  d
+
+# Regression test for #69497. Ensure streaming set ops return correct results
+# when some input columns are in descending order.
+statement ok
+CREATE TABLE abc (a INT, b INT, c INT, INDEX (a, b, c DESC));
+INSERT INTO abc VALUES (1, 1, 1), (1, 2, 2), (1, 2, 3), (2, 2, 2), (2, 2, 3);
+CREATE TABLE def (d INT PRIMARY KEY, e INT, f INT);
+INSERT INTO def VALUES (1, 1, 1), (2, 2, 2), (3, 2, 3), (4, 2, 2), (5, 2, 3);
+
+query III
+SELECT d, e, f FROM def EXCEPT SELECT a, b, c FROM abc ORDER by d, e
+----
+3  2  3
+4  2  2
+5  2  3
+
+# Example where the interesting orderings do not include all columns.
+statement ok
+CREATE TABLE abcd (a INT, b INT, c INT, d INT, INDEX (a, b, c DESC) STORING (d));
+INSERT INTO abcd VALUES (1, 1, 1, 1), (1, 2, 2, 2), (1, 2, 3, 3), (2, 2, 2, 2), (2, 2, 3, 3);
+CREATE TABLE efgh (e INT PRIMARY KEY, f INT, g INT, h INT);
+INSERT INTO efgh VALUES (1, 1, 1, 1), (2, 2, 2, 2), (3, 2, 3, 3), (4, 2, 2, 2), (5, 2, 3, 3);
+
+query IIII
+SELECT e, f, g, h FROM efgh EXCEPT SELECT a, b, c, d FROM abcd ORDER by e, f
+----
+3  2  3  3
+4  2  2  2
+5  2  3  3

--- a/pkg/sql/opt/exec/execbuilder/testdata/union
+++ b/pkg/sql/opt/exec/execbuilder/testdata/union
@@ -957,3 +957,76 @@ vectorized: true
       spans: FULL SCAN
 ·
 Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJykkUFrq0AUhffvVwx39R7cEDVvNSvT1oJgNdW0FIqLiXMJgnHszAgtwf9eMlKSlKQ07fKee849n84WzEsDHKKnRTKPU_b3Ji6WxX2C7DHKr7Ii-seKKImul0wgWyGr2G2e3TGxqiSxhzTOUjZPkg_PzoBMHngAoVWSUrEhA_wZfCgROq0qMkbpnbR1hli-AvcQ6rbr7U4uESqlCfgWbG0bAg5LsWooJyFJTz1AkGRF3bizrivsdL0R-g0Qik60hrMJIGS95SwMMJxh-B_KAUH1dl9irFgTcH_An4H4F4L46FjOggRnQfb9hnQtGta3SkvSJI8QyuEEcaomqpsGn4ynCbxLfkVOplOtoW9eLhFIrmn8HKN6XdFCq8rVjGPmck6QZOy4DcYhbt3KvdVh2P9NOPgyPDsKe0M5_HkPAAD__-GfBxI=
+
+# Regression test for #69497. Ensure the merge ordering for streaming set ops
+# matches the input ordering.
+statement ok
+DROP TABLE abc;
+CREATE TABLE abc (a INT, b INT, c INT, INDEX (a, b, c DESC));
+CREATE TABLE def (d INT PRIMARY KEY, e INT, f INT);
+
+query T
+EXPLAIN (VERBOSE, DISTSQL) SELECT d, e, f FROM def EXCEPT SELECT a, b, c FROM abc ORDER by d, e
+----
+distribution: local
+vectorized: true
+·
+• except all
+│ columns: (d, e, f)
+│ ordering: +d
+│ estimated row count: 1,000 (missing stats)
+│
+├── • scan
+│     columns: (d, e, f)
+│     ordering: +d
+│     estimated row count: 1,000 (missing stats)
+│     table: def@primary
+│     spans: FULL SCAN
+│
+└── • scan
+      columns: (a, b, c)
+      ordering: +a,+b,-c
+      estimated row count: 1,000 (missing stats)
+      table: abc@abc_a_b_c_idx
+      spans: FULL SCAN
+·
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyckl9r2zAUxd_3KcR9auktjZ03wcD9o0HArTPbjI5hgizdZAbX8iQZWkK--7BMaV3abdmjztHvnntk78H9aoGDuF-nl6s7dnKzKsria4rsm8ivskKcskKk4rpkGhkh27IveXbLNG2ZuL8W6_LZlshqZGqyZa1Ylt-InF19DyAgdEbTnXwgB_wHRFAh9NYocs7YUdqHCyv9CHyB0HT94Ee5QlDGEvA9-Ma3BBxKWbeUk9RkLxaAoMnLpg1jNW2T3jYP0j4BQtHLznF2DtUBwQz-ZaTzckfAowP-X2w0j5W1SmStNnJTb9Sm0Y-vwxGywXOWRJjEmCw_XCb-cJmXHYbOWE2W9Cy_Gsm_XXmn0S3ZHRXks_4inhcqn3rizx_4Mk0BoaWtP0miM0ziM0yW56efbbP7OZf-uevymIfPyfWmc_S287uTF2NR0juaHs6ZwSpaW6NCzHTMAhcETc5PbjwdVl2wwp_xGo6OgOO3cPxHeDmDF4fq8Ol3AAAA__8P8yLp
+
+# Example where the interesting orderings do not include all columns.
+statement ok
+CREATE TABLE abcd (a INT, b INT, c INT, d INT, INDEX (a, b, c DESC) STORING (d));
+CREATE TABLE efgh (e INT PRIMARY KEY, f INT, g INT, h INT)
+
+query T
+EXPLAIN (VERBOSE, DISTSQL) SELECT e, f, g, h FROM efgh EXCEPT SELECT a, b, c, d FROM abcd ORDER by e, f
+----
+distribution: local
+vectorized: true
+·
+• except all
+│ columns: (e, f, g, h)
+│ ordering: +e
+│ estimated row count: 1,000 (missing stats)
+│
+├── • scan
+│     columns: (e, f, g, h)
+│     ordering: +e
+│     estimated row count: 1,000 (missing stats)
+│     table: efgh@primary
+│     spans: FULL SCAN
+│
+└── • sort
+    │ columns: (a, b, c, d)
+    │ ordering: +a,+b,-c,+d
+    │ estimated row count: 1,000 (missing stats)
+    │ order: +a,+b,-c,+d
+    │ already ordered: +a,+b,-c
+    │
+    └── • scan
+          columns: (a, b, c, d)
+          ordering: +a,+b,-c
+          estimated row count: 1,000 (missing stats)
+          table: abcd@abcd_a_b_c_idx
+          spans: FULL SCAN
+·
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyckm9r2zAQxt_vU4h71dIrie28EgzUPx4E0jqzw-gYJijWxTE4lifJ0BLy3YdtSmuv6cjeCHS6537Pc-gA9ncJHMKn5eJm_sgu7ufJKvm-QPYjjG-jJLxkSbgI71aMkG2R5ch27FscPTDa5jsWPt2Fy9Vri0S2QZYhU32L3GSKRfF9GLPbn90AQKi0oke5Jwv8F3iQItRGZ2StNm3p0DXM1TPwKUJR1Y1ryylCpg0BP4ArXEnAYSU3JcUkFZnJFBAUOVmU3djWm6hNsZfmBRCSWlaWs2tIjwi6cW8zrZM5AfeO-H9cb8htA4v2WMv1Zp2tC_X8Ho8QNY4z4aHwUQQoZicd-ec4SrRxZCb-0IzwrlD4VyiCaxSzK0DYS5ftWEkVZ8FJcnCS_AZsKm0UGVIDYtoq_9Xygf0HMjkl5KJ6EgwjrF5q4q-f7GaxAISStu5iFO3yqyny3d_lcxY-O2fhMdlaV5bG8T-cPG0zk8qp36HVjcloaXTWYfpr1Om6giLr-tegv8yr7qn7o-_F3qdifyCejsX-GWR_LA4-Fc9G5PT45U8AAAD__ySlYvg=

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpcc
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpcc
@@ -1415,7 +1415,7 @@ except-all
  ├── columns: o_w_id:3(int!null) o_d_id:2(int!null) o_id:1(int!null) o_ol_cnt:7(int)
  ├── left columns: o_w_id:3(int!null) o_d_id:2(int!null) o_id:1(int!null) o_ol_cnt:7(int)
  ├── right columns: ol_w_id:13(int) ol_d_id:12(int) ol_o_id:11(int) count_rows:23(int)
- ├── internal-ordering: +3,+2,-1
+ ├── internal-ordering: +3,+2,-1,+7
  ├── stats: [rows=300000, distinct(1)=2999, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=0, distinct(7)=11, null(7)=0]
  ├── key: (1-3)
  ├── fd: (1-3)-->(7)
@@ -1528,7 +1528,7 @@ except-all
  ├── columns: ol_w_id:3(int!null) ol_d_id:2(int!null) ol_o_id:1(int!null) count:13(int)
  ├── left columns: ol_w_id:3(int!null) ol_d_id:2(int!null) ol_o_id:1(int!null) count_rows:13(int)
  ├── right columns: o_w_id:16(int) o_d_id:15(int) o_id:14(int) o_ol_cnt:20(int)
- ├── internal-ordering: +3,+2,-1
+ ├── internal-ordering: +3,+2,-1,+13
  ├── stats: [rows=295745, distinct(1)=2999, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=0, distinct(13)=295745, null(13)=0]
  ├── key: (1-3)
  ├── fd: (1-3)-->(13)

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -848,6 +848,11 @@ define SetPrivate {
     # The ordering can be mapped to the input columns using the LeftCols and
     # RightCols ColLists.
     #
+    # Note that for all operations except UnionAll, this ordering must include
+    # all output columns, and therefore it may not be simplified according to
+    # the FDs. All columns are needed to ensure correct execution of the
+    # streaming set operation.
+    #
     # This field cannot be set for LocalityOptimizedSearch.
     Ordering OrderingChoice
 }

--- a/pkg/sql/opt/ordering/set.go
+++ b/pkg/sql/opt/ordering/set.go
@@ -73,14 +73,14 @@ func setOpBuildRequired(expr memo.RelExpr, required *props.OrderingChoice) *prop
 	}
 
 	result := required.Intersection(&private.Ordering)
-	fds := &expr.Relational().FuncDeps
-	if result.CanSimplify(fds) {
-		result.Simplify(fds)
-	}
 
 	// UNION ALL is implemented with only an ordered synchronizer, so there is no
 	// need to add extra ordering columns.
 	if expr.Op() == opt.UnionAllOp {
+		fds := &expr.Relational().FuncDeps
+		if result.CanSimplify(fds) {
+			result.Simplify(fds)
+		}
 		return &result
 	}
 
@@ -91,9 +91,6 @@ func setOpBuildRequired(expr memo.RelExpr, required *props.OrderingChoice) *prop
 		missing.ForEach(func(col opt.ColumnID) {
 			result.AppendCol(col, false /* descending */)
 		})
-		if result.CanSimplify(fds) {
-			result.Simplify(fds)
-		}
 	}
 
 	return &result

--- a/pkg/sql/opt/xform/set_funcs.go
+++ b/pkg/sql/opt/xform/set_funcs.go
@@ -40,19 +40,12 @@ func (c *CustomFuncs) GenerateStreamingSetOp(
 		// A streaming set operation must have an ordering that includes all output
 		// columns. If the interesting ordering includes some columns but not all,
 		// add the remaining columns in an arbitrary (but deterministic) order.
-		// Note that some columns still may be removed when calling Simplify (e.g.,
-		// if the first column is a key, the others will be removed), but they will
-		// be added back by the execbuilder.
 		missing := grp.Relational().OutputCols.Difference(order.ColSet())
 		if !missing.Empty() {
 			order = order.Copy()
 			missing.ForEach(func(col opt.ColumnID) {
 				order.AppendCol(col, false /* descending */)
 			})
-			fds := &grp.Relational().FuncDeps
-			if order.CanSimplify(fds) {
-				order.Simplify(fds)
-			}
 		}
 
 		newPrivate := *private

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -1306,7 +1306,7 @@ except-all
  ├── columns: o_w_id:3!null o_d_id:2!null o_id:1!null o_ol_cnt:7
  ├── left columns: o_w_id:3!null o_d_id:2!null o_id:1!null o_ol_cnt:7
  ├── right columns: ol_w_id:13 ol_d_id:12 ol_o_id:11 count_rows:23
- ├── internal-ordering: +3,+2,-1
+ ├── internal-ordering: +3,+2,-1,+7
  ├── key: (1-3)
  ├── fd: (1-3)-->(7)
  ├── scan order
@@ -1344,7 +1344,7 @@ except-all
  ├── columns: ol_w_id:3!null ol_d_id:2!null ol_o_id:1!null count:13
  ├── left columns: ol_w_id:3!null ol_d_id:2!null ol_o_id:1!null count_rows:13
  ├── right columns: o_w_id:16 o_d_id:15 o_id:14 o_ol_cnt:20
- ├── internal-ordering: +3,+2,-1
+ ├── internal-ordering: +3,+2,-1,+13
  ├── key: (1-3)
  ├── fd: (1-3)-->(13)
  ├── group-by

--- a/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
@@ -1308,7 +1308,7 @@ except-all
  ├── columns: o_w_id:3!null o_d_id:2!null o_id:1!null o_ol_cnt:7
  ├── left columns: o_w_id:3!null o_d_id:2!null o_id:1!null o_ol_cnt:7
  ├── right columns: ol_w_id:13 ol_d_id:12 ol_o_id:11 count_rows:23
- ├── internal-ordering: +3,+2,-1
+ ├── internal-ordering: +3,+2,-1,+7
  ├── key: (1-3)
  ├── fd: (1-3)-->(7)
  ├── scan order
@@ -1346,7 +1346,7 @@ except-all
  ├── columns: ol_w_id:3!null ol_d_id:2!null ol_o_id:1!null count:13
  ├── left columns: ol_w_id:3!null ol_d_id:2!null ol_o_id:1!null count_rows:13
  ├── right columns: o_w_id:16 o_d_id:15 o_id:14 o_ol_cnt:20
- ├── internal-ordering: +3,+2,-1
+ ├── internal-ordering: +3,+2,-1,+13
  ├── key: (1-3)
  ├── fd: (1-3)-->(13)
  ├── group-by

--- a/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
@@ -1320,7 +1320,7 @@ except-all
  ├── columns: o_w_id:3!null o_d_id:2!null o_id:1!null o_ol_cnt:7
  ├── left columns: o_w_id:3!null o_d_id:2!null o_id:1!null o_ol_cnt:7
  ├── right columns: ol_w_id:13 ol_d_id:12 ol_o_id:11 count_rows:23
- ├── internal-ordering: +3,+2,-1
+ ├── internal-ordering: +3,+2,-1,+7
  ├── key: (1-3)
  ├── fd: (1-3)-->(7)
  ├── scan order
@@ -1358,7 +1358,7 @@ except-all
  ├── columns: ol_w_id:3!null ol_d_id:2!null ol_o_id:1!null count:13
  ├── left columns: ol_w_id:3!null ol_d_id:2!null ol_o_id:1!null count_rows:13
  ├── right columns: o_w_id:16 o_d_id:15 o_id:14 o_ol_cnt:20
- ├── internal-ordering: +3,+2,-1
+ ├── internal-ordering: +3,+2,-1,+13
  ├── key: (1-3)
  ├── fd: (1-3)-->(13)
  ├── group-by

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -1685,6 +1685,68 @@ intersect-all
       ├── fd: ()-->(2)
       └── (1,)
 
+# Regression test for #69497. Ensure streaming set ops specify all columns in
+# the ordering.
+exec-ddl
+CREATE TABLE t69497_abc (a INT, b INT, c INT, INDEX (a, b, c DESC))
+----
+
+exec-ddl
+CREATE TABLE t69497_def (d INT PRIMARY KEY, e INT, f INT)
+----
+
+opt
+SELECT d, e, f FROM t69497_def EXCEPT SELECT a, b, c FROM t69497_abc ORDER by d, e
+----
+except-all
+ ├── columns: d:1 e:2 f:3
+ ├── left columns: d:1 e:2 f:3
+ ├── right columns: a:6 b:7 c:8
+ ├── internal-ordering: +1,+2,-3
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── ordering: +1
+ ├── scan t69497_def
+ │    ├── columns: d:1!null e:2 f:3
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    └── ordering: +1
+ └── scan t69497_abc@secondary
+      ├── columns: a:6 b:7 c:8
+      └── ordering: +6,+7,-8
+
+# Example where the interesting orderings do not include all columns.
+exec-ddl
+CREATE TABLE t69497_abcd (a INT, b INT, c INT, d INT, INDEX (a, b, c DESC) STORING (d))
+----
+
+exec-ddl
+CREATE TABLE t69497_efgh (e INT PRIMARY KEY, f INT, g INT, h INT)
+----
+
+opt
+SELECT e, f, g, h FROM t69497_efgh EXCEPT SELECT a, b, c, d FROM t69497_abcd ORDER by e, f
+----
+except-all
+ ├── columns: e:1 f:2 g:3 h:4
+ ├── left columns: e:1 f:2 g:3 h:4
+ ├── right columns: a:7 b:8 c:9 d:10
+ ├── internal-ordering: +1,+2,-3,+4
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ ├── ordering: +1
+ ├── scan t69497_efgh
+ │    ├── columns: e:1!null f:2 g:3 h:4
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4)
+ │    └── ordering: +1
+ └── sort (segmented)
+      ├── columns: a:7 b:8 c:9 d:10
+      ├── ordering: +7,+8,-9,+10
+      └── scan t69497_abcd@secondary
+           ├── columns: a:7 b:8 c:9 d:10
+           └── ordering: +7,+8,-9
+
 # --------------------------------------------------
 # Insert operator.
 # --------------------------------------------------

--- a/pkg/sql/opt/xform/testdata/rules/set
+++ b/pkg/sql/opt/xform/testdata/rules/set
@@ -59,9 +59,9 @@ memo expect=GenerateStreamingSetOp
 SELECT * FROM kuvw INTERSECT SELECT * FROM kuvw
 ----
 memo (optimized, ~9KB, required=[presentation: k:1,u:2,v:3,w:4])
- ├── G1: (intersect-all G2 G3) (intersect-all G2 G3 ordering=+1) (intersect-all G2 G3 ordering=+2,+3,+4,+1) (intersect-all G2 G3 ordering=+4,+3,+2,+1) (intersect-all G2 G3 ordering=+3,+4,+1) (intersect-all G2 G3 ordering=+4,+1)
+ ├── G1: (intersect-all G2 G3) (intersect-all G2 G3 ordering=+1,+2,+3,+4) (intersect-all G2 G3 ordering=+2,+3,+4,+1) (intersect-all G2 G3 ordering=+4,+3,+2,+1) (intersect-all G2 G3 ordering=+3,+4,+1,+2) (intersect-all G2 G3 ordering=+4,+1,+2,+3)
  │    └── [presentation: k:1,u:2,v:3,w:4]
- │         ├── best: (intersect-all G2="[ordering: +1]" G3="[ordering: +7]" ordering=+1)
+ │         ├── best: (intersect-all G2="[ordering: +1]" G3="[ordering: +7]" ordering=+1,+2,+3,+4)
  │         └── cost: 2219.63
  ├── G2: (scan kuvw,cols=(1-4)) (scan kuvw@uvw,cols=(1-4)) (scan kuvw@wvu,cols=(1-4)) (scan kuvw@vw,cols=(1-4)) (scan kuvw@w,cols=(1-4))
  │    ├── [ordering: +1]
@@ -106,9 +106,9 @@ memo expect=GenerateStreamingSetOp
 SELECT * FROM kuvw INTERSECT ALL SELECT * FROM kuvw
 ----
 memo (optimized, ~9KB, required=[presentation: k:1,u:2,v:3,w:4])
- ├── G1: (intersect-all G2 G3) (intersect-all G2 G3 ordering=+1) (intersect-all G2 G3 ordering=+2,+3,+4,+1) (intersect-all G2 G3 ordering=+4,+3,+2,+1) (intersect-all G2 G3 ordering=+3,+4,+1) (intersect-all G2 G3 ordering=+4,+1)
+ ├── G1: (intersect-all G2 G3) (intersect-all G2 G3 ordering=+1,+2,+3,+4) (intersect-all G2 G3 ordering=+2,+3,+4,+1) (intersect-all G2 G3 ordering=+4,+3,+2,+1) (intersect-all G2 G3 ordering=+3,+4,+1,+2) (intersect-all G2 G3 ordering=+4,+1,+2,+3)
  │    └── [presentation: k:1,u:2,v:3,w:4]
- │         ├── best: (intersect-all G2="[ordering: +1]" G3="[ordering: +7]" ordering=+1)
+ │         ├── best: (intersect-all G2="[ordering: +1]" G3="[ordering: +7]" ordering=+1,+2,+3,+4)
  │         └── cost: 2219.63
  ├── G2: (scan kuvw,cols=(1-4)) (scan kuvw@uvw,cols=(1-4)) (scan kuvw@wvu,cols=(1-4)) (scan kuvw@vw,cols=(1-4)) (scan kuvw@w,cols=(1-4))
  │    ├── [ordering: +1]
@@ -153,9 +153,9 @@ memo expect=GenerateStreamingSetOp
 SELECT * FROM kuvw EXCEPT SELECT * FROM kuvw
 ----
 memo (optimized, ~9KB, required=[presentation: k:1,u:2,v:3,w:4])
- ├── G1: (except-all G2 G3) (except-all G2 G3 ordering=+1) (except-all G2 G3 ordering=+2,+3,+4,+1) (except-all G2 G3 ordering=+4,+3,+2,+1) (except-all G2 G3 ordering=+3,+4,+1) (except-all G2 G3 ordering=+4,+1)
+ ├── G1: (except-all G2 G3) (except-all G2 G3 ordering=+1,+2,+3,+4) (except-all G2 G3 ordering=+2,+3,+4,+1) (except-all G2 G3 ordering=+4,+3,+2,+1) (except-all G2 G3 ordering=+3,+4,+1,+2) (except-all G2 G3 ordering=+4,+1,+2,+3)
  │    └── [presentation: k:1,u:2,v:3,w:4]
- │         ├── best: (except-all G2="[ordering: +1]" G3="[ordering: +7]" ordering=+1)
+ │         ├── best: (except-all G2="[ordering: +1]" G3="[ordering: +7]" ordering=+1,+2,+3,+4)
  │         └── cost: 2219.63
  ├── G2: (scan kuvw,cols=(1-4)) (scan kuvw@uvw,cols=(1-4)) (scan kuvw@wvu,cols=(1-4)) (scan kuvw@vw,cols=(1-4)) (scan kuvw@w,cols=(1-4))
  │    ├── [ordering: +1]
@@ -200,9 +200,9 @@ memo expect=GenerateStreamingSetOp
 SELECT * FROM kuvw EXCEPT ALL SELECT * FROM kuvw
 ----
 memo (optimized, ~9KB, required=[presentation: k:1,u:2,v:3,w:4])
- ├── G1: (except-all G2 G3) (except-all G2 G3 ordering=+1) (except-all G2 G3 ordering=+2,+3,+4,+1) (except-all G2 G3 ordering=+4,+3,+2,+1) (except-all G2 G3 ordering=+3,+4,+1) (except-all G2 G3 ordering=+4,+1)
+ ├── G1: (except-all G2 G3) (except-all G2 G3 ordering=+1,+2,+3,+4) (except-all G2 G3 ordering=+2,+3,+4,+1) (except-all G2 G3 ordering=+4,+3,+2,+1) (except-all G2 G3 ordering=+3,+4,+1,+2) (except-all G2 G3 ordering=+4,+1,+2,+3)
  │    └── [presentation: k:1,u:2,v:3,w:4]
- │         ├── best: (except-all G2="[ordering: +1]" G3="[ordering: +7]" ordering=+1)
+ │         ├── best: (except-all G2="[ordering: +1]" G3="[ordering: +7]" ordering=+1,+2,+3,+4)
  │         └── cost: 2219.63
  ├── G2: (scan kuvw,cols=(1-4)) (scan kuvw@uvw,cols=(1-4)) (scan kuvw@wvu,cols=(1-4)) (scan kuvw@vw,cols=(1-4)) (scan kuvw@w,cols=(1-4))
  │    ├── [ordering: +1]


### PR DESCRIPTION
This commit fixes a logical error that could occur when a set
operation such as `EXCEPT` or `INTERSECT` was executed with a streaming
operation, the left side had a unique key on a prefix of the
merge ordering columns, and the right side included at least one
descending column after that prefix. This error could happen because
we were simplifying the merge ordering according to the FDs of the
set operation, but this caused the ordering of the right child to be
only partially specified according the FDs of the right child.

Fixes #69497

There is no release note since this bug is not part of any release.

Release note: None

Release justification: fixes a high severity bug in existing
functionality.