### PR TITLE
ui: bookmarkable database pages

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.stories.tsx
@@ -9,7 +9,9 @@
 // licenses/APL.txt.
 
 import React from "react";
+import { match } from "react-router-dom";
 import { storiesOf } from "@storybook/react";
+import { History, createMemoryHistory } from "history";
 import _ from "lodash";
 
 import { withBackground, withRouterProvider } from "src/storybook/decorators";
@@ -23,6 +25,14 @@ import {
   DatabaseDetailsPageProps,
 } from "./databaseDetailsPage";
 
+const fakeHistory: History = createMemoryHistory();
+const fakeMatch: match = {
+  params: {},
+  isExact: true,
+  path: "",
+  url: "",
+};
+
 const withLoadingIndicator: DatabaseDetailsPageProps = {
   loading: true,
   loaded: false,
@@ -31,6 +41,9 @@ const withLoadingIndicator: DatabaseDetailsPageProps = {
   refreshDatabaseDetails: () => {},
   refreshTableDetails: () => {},
   refreshTableStats: () => {},
+  history: fakeHistory,
+  location: fakeHistory.location,
+  match: fakeMatch,
 };
 
 const withoutData: DatabaseDetailsPageProps = {
@@ -41,6 +54,9 @@ const withoutData: DatabaseDetailsPageProps = {
   refreshDatabaseDetails: () => {},
   refreshTableDetails: () => {},
   refreshTableStats: () => {},
+  history: fakeHistory,
+  location: fakeHistory.location,
+  match: fakeMatch,
 };
 
 const withData: DatabaseDetailsPageProps = {
@@ -77,6 +93,9 @@ const withData: DatabaseDetailsPageProps = {
   refreshDatabaseDetails: () => {},
   refreshTableDetails: () => {},
   refreshTableStats: () => {},
+  history: fakeHistory,
+  location: fakeHistory.location,
+  match: fakeMatch,
 };
 
 storiesOf("Database Details Page", module)

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.tsx
@@ -9,7 +9,7 @@
 // licenses/APL.txt.
 
 import React from "react";
-import { Link } from "react-router-dom";
+import { Link, RouteComponentProps } from "react-router-dom";
 import { Tooltip } from "antd";
 import classNames from "classnames/bind";
 import _ from "lodash";
@@ -27,6 +27,7 @@ import {
   SortSetting,
   SortedTable,
 } from "src/sortedtable";
+import { QueryParams } from "src/sortedtable/queryParams";
 import * as format from "src/util/format";
 
 import styles from "./databaseDetailsPage.module.scss";
@@ -108,7 +109,8 @@ export interface DatabaseDetailsPageActions {
 }
 
 export type DatabaseDetailsPageProps = DatabaseDetailsPageData &
-  DatabaseDetailsPageActions;
+  DatabaseDetailsPageActions &
+  RouteComponentProps;
 
 enum ViewMode {
   Tables = "Tables",
@@ -127,17 +129,15 @@ export class DatabaseDetailsPage extends React.Component<
   DatabaseDetailsPageProps,
   DatabaseDetailsPageState
 > {
+  private queryParams: QueryParams;
+
   constructor(props: DatabaseDetailsPageProps) {
     super(props);
+    this.queryParams = new QueryParams(props.history);
 
     this.state = {
-      pagination: {
-        current: 1,
-        pageSize: 20,
-      },
-      sortSetting: {
-        ascending: true,
-      },
+      pagination: this.queryParams.pagination,
+      sortSetting: this.queryParams.sortSetting,
       viewMode: ViewMode.Tables,
     };
   }
@@ -167,10 +167,12 @@ export class DatabaseDetailsPage extends React.Component<
   }
 
   private changePage(current: number) {
-    this.setState({ pagination: { ...this.state.pagination, current } });
+    this.queryParams.pagination = { current, pageSize: 20 };
+    this.setState({ pagination: { current, pageSize: 20 } });
   }
 
   private changeSortSetting(sortSetting: SortSetting) {
+    this.queryParams.sortSetting = sortSetting;
     this.setState({ sortSetting });
   }
 

--- a/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.stories.tsx
@@ -9,12 +9,22 @@
 // licenses/APL.txt.
 
 import React from "react";
+import { match } from "react-router-dom";
 import { storiesOf } from "@storybook/react";
+import { History, createMemoryHistory } from "history";
 import _ from "lodash";
 
 import { withBackground, withRouterProvider } from "src/storybook/decorators";
 import { randomName } from "src/storybook/fixtures";
 import { DatabasesPage, DatabasesPageProps } from "./databasesPage";
+
+const fakeHistory: History = createMemoryHistory();
+const fakeMatch: match = {
+  params: {},
+  isExact: true,
+  path: "",
+  url: "",
+};
 
 const withLoadingIndicator: DatabasesPageProps = {
   loading: true,
@@ -23,6 +33,9 @@ const withLoadingIndicator: DatabasesPageProps = {
   refreshDatabases: () => {},
   refreshDatabaseDetails: () => {},
   refreshTableStats: () => {},
+  history: fakeHistory,
+  location: fakeHistory.location,
+  match: fakeMatch,
 };
 
 const withoutData: DatabasesPageProps = {
@@ -32,6 +45,9 @@ const withoutData: DatabasesPageProps = {
   refreshDatabases: () => {},
   refreshDatabaseDetails: () => {},
   refreshTableStats: () => {},
+  history: fakeHistory,
+  location: fakeHistory.location,
+  match: fakeMatch,
 };
 
 const withData: DatabasesPageProps = {
@@ -51,6 +67,9 @@ const withData: DatabasesPageProps = {
   refreshDatabases: () => {},
   refreshDatabaseDetails: () => {},
   refreshTableStats: () => {},
+  history: fakeHistory,
+  location: fakeHistory.location,
+  match: fakeMatch,
 };
 
 storiesOf("Databases Page", module)

--- a/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.tsx
@@ -9,7 +9,7 @@
 // licenses/APL.txt.
 
 import React from "react";
-import { Link } from "react-router-dom";
+import { Link, RouteComponentProps } from "react-router-dom";
 import { Tooltip } from "antd";
 import classNames from "classnames/bind";
 import _ from "lodash";
@@ -22,6 +22,7 @@ import {
   SortSetting,
   SortedTable,
 } from "src/sortedtable";
+import { QueryParams } from "src/sortedtable/queryParams";
 import * as format from "src/util/format";
 
 import styles from "./databasesPage.module.scss";
@@ -93,7 +94,9 @@ export interface DatabasesPageActions {
   refreshTableStats: (database: string, table: string) => void;
 }
 
-export type DatabasesPageProps = DatabasesPageData & DatabasesPageActions;
+export type DatabasesPageProps = DatabasesPageData &
+  DatabasesPageActions &
+  RouteComponentProps;
 
 interface DatabasesPageState {
   pagination: ISortedTablePagination;
@@ -106,18 +109,14 @@ export class DatabasesPage extends React.Component<
   DatabasesPageProps,
   DatabasesPageState
 > {
+  private queryParams: QueryParams;
+
   constructor(props: DatabasesPageProps) {
     super(props);
-
+    this.queryParams = new QueryParams(props.history);
     this.state = {
-      pagination: {
-        current: 1,
-        pageSize: 20,
-      },
-      sortSetting: {
-        ascending: true,
-        columnTitle: null,
-      },
+      pagination: this.queryParams.pagination,
+      sortSetting: this.queryParams.sortSetting,
     };
   }
 
@@ -148,10 +147,12 @@ export class DatabasesPage extends React.Component<
   }
 
   private changePage(current: number) {
-    this.setState({ pagination: { ...this.state.pagination, current } });
+    this.queryParams.pagination = { current, pageSize: 20 };
+    this.setState({ pagination: { current, pageSize: 20 } });
   }
 
   private changeSortSetting(sortSetting: SortSetting) {
+    this.queryParams.sortSetting = sortSetting;
     this.setState({ sortSetting });
   }
 

--- a/pkg/ui/workspaces/cluster-ui/src/sortedtable/queryParams/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/sortedtable/queryParams/index.ts
@@ -1,0 +1,11 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+export * from "./queryParams";

--- a/pkg/ui/workspaces/cluster-ui/src/sortedtable/queryParams/queryParams.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/sortedtable/queryParams/queryParams.spec.ts
@@ -1,0 +1,120 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import assert from "assert";
+import { History, createMemoryHistory } from "history";
+import { QueryParams } from "./queryParams";
+
+describe("SortedTable/QueryParams", function() {
+  let subject: QueryParams;
+  let history: History;
+
+  beforeEach(function() {
+    history = createMemoryHistory();
+    subject = new QueryParams(history);
+  });
+
+  describe("pagination", function() {
+    describe("reading", function() {
+      it("defaults to page 1", function() {
+        history.location.search = "";
+        assert.deepStrictEqual(subject.pagination, {
+          current: 1,
+          pageSize: 20,
+        });
+      });
+
+      it("respects the page number in the url", function() {
+        history.location.search = "?page=2";
+        assert.deepStrictEqual(subject.pagination, {
+          current: 2,
+          pageSize: 20,
+        });
+      });
+
+      it("falls back to page 1 for bogus values", function() {
+        history.location.search = "?page=BOGUS";
+        assert.deepStrictEqual(subject.pagination, {
+          current: 1,
+          pageSize: 20,
+        });
+      });
+    });
+
+    describe("writing", function() {
+      it("puts a page parameter in the query string", function() {
+        history.location.search = "";
+        subject.pagination = { current: 2, pageSize: 20 };
+        assert.deepStrictEqual(history.location.search, "?page=2");
+      });
+
+      it("clears the page parameter in the query string for page 1", function() {
+        history.location.search = "?page=2";
+        subject.pagination = { current: 1, pageSize: 20 };
+        assert.deepStrictEqual(history.location.search, "");
+      });
+
+      it("uses history.push", function() {
+        subject.pagination = { current: 2, pageSize: 20 };
+        assert.deepStrictEqual(history.action, "PUSH");
+      });
+    });
+  });
+
+  describe("sortSetting", function() {
+    describe("reading", function() {
+      it("defaults to no column, ascending", function() {
+        history.location.search = "";
+        assert.deepStrictEqual(subject.sortSetting, {
+          ascending: true,
+          columnTitle: null,
+        });
+      });
+
+      it("respects a descending parameter in the url", function() {
+        history.location.search = "?descending=true";
+        assert.deepStrictEqual(subject.sortSetting.ascending, false);
+      });
+
+      it("respects a sortBy parameter in the url", function() {
+        history.location.search = "?sortBy=foo";
+        assert.deepStrictEqual(subject.sortSetting.columnTitle, "foo");
+      });
+    });
+
+    describe("writing", function() {
+      it("puts descending and sortBy parameters in the query string", function() {
+        history.location.search = "";
+        subject.sortSetting = { ascending: false, columnTitle: "foo" };
+        assert.deepStrictEqual(
+          history.location.search,
+          "?descending=true&sortBy=foo",
+        );
+      });
+
+      it("clears the descending parameter in the query string when ascending", function() {
+        history.location.search = "?descending=true";
+        subject.sortSetting = { ascending: true };
+        assert.deepStrictEqual(history.location.search, "");
+      });
+
+      it("clears the sortBy parameter in the query string when no columnTitle is given", function() {
+        history.location.search = "?sortBy=foo";
+        subject.sortSetting = { ascending: true };
+        assert.deepStrictEqual(history.location.search, "");
+      });
+
+      it("uses history.replace", function() {
+        subject.sortSetting = { ascending: false, columnTitle: "foo" };
+        assert.deepStrictEqual(history.action, "REPLACE");
+      });
+    });
+  });
+});

--- a/pkg/ui/workspaces/cluster-ui/src/sortedtable/queryParams/queryParams.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/sortedtable/queryParams/queryParams.ts
@@ -1,0 +1,84 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { History, Path, createPath } from "history";
+import { ISortedTablePagination, SortSetting } from "../sortedtable";
+
+export class QueryParams {
+  constructor(private readonly history: History) {}
+
+  get pagination(): ISortedTablePagination {
+    return { current: this.page, pageSize: 20 };
+  }
+
+  set pagination(pagination: ISortedTablePagination) {
+    this.history.push(
+      this.pathWithUpdatedParams(params => {
+        if (pagination.current == 1) {
+          params.delete("page");
+        } else {
+          params.set("page", pagination.current.toString());
+        }
+      }),
+    );
+  }
+
+  get sortSetting(): SortSetting {
+    return { ascending: this.ascending, columnTitle: this.sortBy };
+  }
+
+  set sortSetting(sortSetting: SortSetting) {
+    this.history.replace(
+      this.pathWithUpdatedParams(params => {
+        if (sortSetting.ascending) {
+          params.delete("descending");
+        } else {
+          params.set("descending", "true");
+        }
+
+        if (sortSetting.columnTitle == null) {
+          params.delete("sortBy");
+        } else {
+          params.set("sortBy", sortSetting.columnTitle);
+        }
+      }),
+    );
+  }
+
+  private get ascending(): boolean {
+    return !this.params.has("descending");
+  }
+
+  private get page(): number {
+    return parseInt(this.params.get("page")) || 1;
+  }
+
+  private get sortBy(): string {
+    return this.params.get("sortBy");
+  }
+
+  private get params(): URLSearchParams {
+    return new URLSearchParams(this.history.location.search);
+  }
+
+  private pathWithUpdatedParams(
+    updater: (params: URLSearchParams) => void,
+  ): Path {
+    const params = this.params;
+    updater(params);
+    params.sort();
+
+    return createPath({
+      pathname: this.history.location.pathname,
+      search: params.toString(),
+      hash: this.history.location.hash,
+    });
+  }
+}


### PR DESCRIPTION
Previously, the internal state of the database pages was not exposed in
the URL, making deep-linking to particular pages or sortings of the
tables impossible.

This change adds the query parameters `page`, `sortBy`, and `descending`
to the top-level databases page and the second-level database details
page.

Partially addresses #68824.

Release justification: Category 2: Bug fixes and low-risk updates to new
functionality.

Release note (ui change): The pagination and sort states of the
top-level databases page and the second-level database details page are
now bookmarkable.