### PR TITLE
sql/catalog/multiregion: move multiregion validation to its package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -48,6 +48,7 @@
 /pkg/sql/tests/rsg_test.go   @cockroachdb/sql-experience
 
 /pkg/sql/catalog/            @cockroachdb/sql-schema
+/pkg/sql/catalog/multiregion @cockroachdb/multiregion
 /pkg/sql/doctor/             @cockroachdb/sql-schema
 /pkg/sql/gcjob/              @cockroachdb/sql-schema
 /pkg/sql/gcjob_test/         @cockroachdb/sql-schema

--- a/pkg/ccl/backupccl/backupresolver/targets.go
+++ b/pkg/ccl/backupccl/backupresolver/targets.go
@@ -434,7 +434,7 @@ func DescriptorsMatchingTargets(
 			// Get all the types used by this table.
 			desc := r.DescByID[tableDesc.GetParentID()]
 			dbDesc := desc.(catalog.DatabaseDescriptor)
-			typeIDs, err := tableDesc.GetAllReferencedTypeIDs(dbDesc, getTypeByID)
+			typeIDs, _, err := tableDesc.GetAllReferencedTypeIDs(dbDesc, getTypeByID)
 			if err != nil {
 				return ret, err
 			}
@@ -526,7 +526,7 @@ func DescriptorsMatchingTargets(
 				// Get all the types used by this table.
 				dbRaw := r.DescByID[desc.GetParentID()]
 				dbDesc := dbRaw.(catalog.DatabaseDescriptor)
-				typeIDs, err := desc.GetAllReferencedTypeIDs(dbDesc, getTypeByID)
+				typeIDs, _, err := desc.GetAllReferencedTypeIDs(dbDesc, getTypeByID)
 				if err != nil {
 					return err
 				}

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1315,7 +1315,7 @@ func createImportingDescriptors(
 				if err != nil {
 					return err
 				}
-				typeIDs, err := table.GetAllReferencedTypeIDs(dbDesc, func(id descpb.ID) (catalog.TypeDescriptor, error) {
+				typeIDs, _, err := table.GetAllReferencedTypeIDs(dbDesc, func(id descpb.ID) (catalog.TypeDescriptor, error) {
 					return typesByID[id], nil
 				})
 				if err != nil {
@@ -2343,7 +2343,7 @@ func (r *restoreResumer) removeExistingTypeBackReferences(
 		}
 
 		// Get all types that this descriptor references.
-		referencedTypes, err := tbl.GetAllReferencedTypeIDs(dbDesc, lookup)
+		referencedTypes, _, err := tbl.GetAllReferencedTypeIDs(dbDesc, lookup)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/alter_table_locality.go
+++ b/pkg/sql/alter_table_locality.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/multiregion"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
@@ -101,7 +102,7 @@ func (n *alterTableSetLocalityNode) alterTableLocalityGlobalToRegionalByTable(
 ) error {
 	if !n.tableDesc.IsLocalityGlobal() {
 		f := params.p.EvalContext().FmtCtx(tree.FmtSimple)
-		if err := tabledesc.FormatTableLocalityConfig(n.tableDesc.LocalityConfig, f); err != nil {
+		if err := multiregion.FormatTableLocalityConfig(n.tableDesc.LocalityConfig, f); err != nil {
 			// While we're in an error path and generally it's bad to return a
 			// different error in an error path, we will only get an error here if the
 			// locality is corrupted, in which case, it's probably the right error

--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -326,7 +326,7 @@ type TableDescriptor interface {
 	GetReplacementOf() descpb.TableDescriptor_Replacement
 	GetAllReferencedTypeIDs(
 		databaseDesc DatabaseDescriptor, getType func(descpb.ID) (TypeDescriptor, error),
-	) (descpb.IDs, error)
+	) (referencedAnywhere, referencedInColumns descpb.IDs, _ error)
 
 	ForeachDependedOnBy(f func(dep *descpb.TableDescriptor_Reference) error) error
 	GetDependedOnBy() []descpb.TableDescriptor_Reference

--- a/pkg/sql/catalog/multiregion/BUILD.bazel
+++ b/pkg/sql/catalog/multiregion/BUILD.bazel
@@ -2,13 +2,18 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "multiregion",
-    srcs = ["region_config.go"],
+    srcs = [
+        "region_config.go",
+        "validate_table.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/catalog/multiregion",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/sql/catalog",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
+        "//pkg/sql/sem/tree",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/sql/catalog/multiregion/validate_table.go
+++ b/pkg/sql/catalog/multiregion/validate_table.go
@@ -1,0 +1,270 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package multiregion
+
+import (
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/errors"
+)
+
+// ValidateTableLocalityConfig validates whether the descriptor's locality
+// config is valid under the given database.
+func ValidateTableLocalityConfig(
+	desc catalog.TableDescriptor, db catalog.DatabaseDescriptor, vdg catalog.ValidationDescGetter,
+) error {
+
+	lc := desc.GetLocalityConfig()
+	if lc == nil {
+		if db.IsMultiRegion() {
+			return pgerror.Newf(
+				pgcode.InvalidTableDefinition,
+				"database %s is multi-region enabled, but table %s has no locality set",
+				db.GetName(),
+				desc.GetName(),
+			)
+		}
+		// Nothing to validate for non-multi-region databases.
+		return nil
+	}
+
+	if !db.IsMultiRegion() {
+		s := tree.NewFmtCtx(tree.FmtSimple)
+		var locality string
+		// Formatting the table locality config should never fail; if it does, the
+		// error message is more clear if we construct a dummy locality here.
+		if err := FormatTableLocalityConfig(lc, s); err != nil {
+			locality = "INVALID LOCALITY"
+		}
+		locality = s.String()
+		return pgerror.Newf(
+			pgcode.InvalidTableDefinition,
+			"database %s is not multi-region enabled, but table %s has locality %s set",
+			db.GetName(),
+			desc.GetName(),
+			locality,
+		)
+	}
+
+	regionsEnumID, err := db.MultiRegionEnumID()
+	if err != nil {
+		return err
+	}
+	regionsEnumDesc, err := vdg.GetTypeDescriptor(regionsEnumID)
+	if err != nil {
+		return errors.Wrapf(err, "multi-region enum with ID %d does not exist", regionsEnumID)
+	}
+
+	// Check non-table items have a correctly set locality.
+	if desc.IsSequence() {
+		if !desc.IsLocalityRegionalByTable() {
+			return errors.AssertionFailedf(
+				"expected sequence %s to have locality REGIONAL BY TABLE",
+				desc.GetName(),
+			)
+		}
+	}
+	if desc.IsView() {
+		if desc.MaterializedView() {
+			if !desc.IsLocalityGlobal() {
+				return errors.AssertionFailedf(
+					"expected materialized view %s to have locality GLOBAL",
+					desc.GetName(),
+				)
+			}
+		} else {
+			if !desc.IsLocalityRegionalByTable() {
+				return errors.AssertionFailedf(
+					"expected view %s to have locality REGIONAL BY TABLE",
+					desc.GetName(),
+				)
+			}
+		}
+	}
+
+	// REGIONAL BY TABLE tables homed in the primary region should include a
+	// reference to the multi-region type descriptor and a corresponding
+	// backreference. All other patterns should only contain a reference if there
+	// is an explicit column which uses the multi-region type descriptor as its
+	// *types.T. While the specific cases are validated below, we search for the
+	// region enum ID in the references list just once, up top here.
+	typeIDs, typeIDsReferencedByColumns, err := desc.GetAllReferencedTypeIDs(db, vdg.GetTypeDescriptor)
+	if err != nil {
+		return err
+	}
+	regionEnumIDReferenced := false
+	for _, typeID := range typeIDs {
+		if typeID == regionsEnumID {
+			regionEnumIDReferenced = true
+			break
+		}
+	}
+	columnTypesTypeIDs := catalog.MakeDescriptorIDSet(typeIDsReferencedByColumns...)
+	switch lc := lc.Locality.(type) {
+	case *descpb.TableDescriptor_LocalityConfig_Global_:
+		if regionEnumIDReferenced {
+			if !columnTypesTypeIDs.Contains(regionsEnumID) {
+				return errors.AssertionFailedf(
+					"expected no region Enum ID to be referenced by a GLOBAL TABLE: %q"+
+						" but found: %d",
+					desc.GetName(),
+					regionsEnumDesc.GetID(),
+				)
+			}
+		}
+	case *descpb.TableDescriptor_LocalityConfig_RegionalByRow_:
+		if !desc.IsPartitionAllBy() {
+			return errors.AssertionFailedf("expected REGIONAL BY ROW table to have PartitionAllBy set")
+		}
+		// For REGIONAL BY ROW tables, ensure partitions in the PRIMARY KEY match
+		// the database descriptor. Ensure each public region has a partition,
+		// and each transitioning region name to possibly have a partition.
+		// We do validation that ensures all index partitions are the same on
+		// PARTITION ALL BY.
+		regions, err := regionsEnumDesc.RegionNames()
+		if err != nil {
+			return err
+		}
+		regionNames := make(map[descpb.RegionName]struct{}, len(regions))
+		for _, region := range regions {
+			regionNames[region] = struct{}{}
+		}
+		transitioningRegions, err := regionsEnumDesc.TransitioningRegionNames()
+		if err != nil {
+			return err
+		}
+		transitioningRegionNames := make(map[descpb.RegionName]struct{}, len(regions))
+		for _, region := range transitioningRegions {
+			transitioningRegionNames[region] = struct{}{}
+		}
+
+		part := desc.GetPrimaryIndex().GetPartitioning()
+		err = part.ForEachList(func(name string, _ [][]byte, _ catalog.Partitioning) error {
+			regionName := descpb.RegionName(name)
+			// Any transitioning region names may exist.
+			if _, ok := transitioningRegionNames[regionName]; ok {
+				return nil
+			}
+			// If a region is not found in any of the region names, we have an unknown
+			// partition.
+			if _, ok := regionNames[regionName]; !ok {
+				return errors.AssertionFailedf(
+					"unknown partition %s on PRIMARY INDEX of table %s",
+					name,
+					desc.GetName(),
+				)
+			}
+			delete(regionNames, regionName)
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+
+		// Any regions that are not deleted from the above loop is missing.
+		for regionName := range regionNames {
+			return errors.AssertionFailedf(
+				"missing partition %s on PRIMARY INDEX of table %s",
+				regionName,
+				desc.GetName(),
+			)
+		}
+
+	case *descpb.TableDescriptor_LocalityConfig_RegionalByTable_:
+
+		// Table is homed in an explicit (non-primary) region.
+		if lc.RegionalByTable.Region != nil {
+			foundRegion := false
+			regions, err := regionsEnumDesc.RegionNamesForValidation()
+			if err != nil {
+				return err
+			}
+			for _, r := range regions {
+				if *lc.RegionalByTable.Region == r {
+					foundRegion = true
+					break
+				}
+			}
+			if !foundRegion {
+				return errors.WithHintf(
+					pgerror.Newf(
+						pgcode.InvalidTableDefinition,
+						`region "%s" has not been added to database "%s"`,
+						*lc.RegionalByTable.Region,
+						db.DatabaseDesc().Name,
+					),
+					"available regions: %s",
+					strings.Join(regions.ToStrings(), ", "),
+				)
+			}
+			if !regionEnumIDReferenced {
+				return errors.AssertionFailedf(
+					"expected multi-region enum ID %d to be referenced on REGIONAL BY TABLE: %q locality "+
+						"config, but did not find it",
+					regionsEnumID,
+					desc.GetName(),
+				)
+			}
+		} else {
+			if regionEnumIDReferenced {
+				// It may be the case that the multi-region type descriptor is used
+				// as the type of the table column. Validations should only fail if
+				// that is not the case.
+				if !columnTypesTypeIDs.Contains(regionsEnumID) {
+					return errors.AssertionFailedf(
+						"expected no region Enum ID to be referenced by a REGIONAL BY TABLE: %q homed in the "+
+							"primary region, but found: %d",
+						desc.GetName(),
+						regionsEnumDesc.GetID(),
+					)
+				}
+			}
+		}
+	default:
+		return pgerror.Newf(
+			pgcode.InvalidTableDefinition,
+			"unknown locality level: %T",
+			lc,
+		)
+	}
+	return nil
+}
+
+// FormatTableLocalityConfig formats the table locality.
+func FormatTableLocalityConfig(c *descpb.TableDescriptor_LocalityConfig, f *tree.FmtCtx) error {
+	switch v := c.Locality.(type) {
+	case *descpb.TableDescriptor_LocalityConfig_Global_:
+		f.WriteString("GLOBAL")
+	case *descpb.TableDescriptor_LocalityConfig_RegionalByTable_:
+		f.WriteString("REGIONAL BY TABLE IN ")
+		if v.RegionalByTable.Region != nil {
+			region := tree.Name(*v.RegionalByTable.Region)
+			f.FormatNode(&region)
+		} else {
+			f.WriteString("PRIMARY REGION")
+		}
+	case *descpb.TableDescriptor_LocalityConfig_RegionalByRow_:
+		f.WriteString("REGIONAL BY ROW")
+		if v.RegionalByRow.As != nil {
+			f.WriteString(" AS ")
+			col := tree.Name(*v.RegionalByRow.As)
+			f.FormatNode(&col)
+		}
+	default:
+		return errors.Newf("unknown locality: %T", v)
+	}
+	return nil
+}

--- a/pkg/sql/catalog/tabledesc/BUILD.bazel
+++ b/pkg/sql/catalog/tabledesc/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//pkg/sql/catalog/catprivilege",
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/descpb",
+        "//pkg/sql/catalog/multiregion",
         "//pkg/sql/catalog/schemaexpr",
         "//pkg/sql/catalog/typedesc",
         "//pkg/sql/parser",

--- a/pkg/sql/catalog/tabledesc/validate.go
+++ b/pkg/sql/catalog/tabledesc/validate.go
@@ -11,14 +11,13 @@
 package tabledesc
 
 import (
-	"strings"
-
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catprivilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/multiregion"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
@@ -138,7 +137,7 @@ func (desc *wrapper) ValidateCrossReferences(
 
 	if dbDesc != nil {
 		// Validate the all types present in the descriptor exist.
-		typeIDs, err := desc.GetAllReferencedTypeIDs(dbDesc, vdg.GetTypeDescriptor)
+		typeIDs, _, err := desc.GetAllReferencedTypeIDs(dbDesc, vdg.GetTypeDescriptor)
 		if err != nil {
 			vea.Report(err)
 		} else {
@@ -149,7 +148,7 @@ func (desc *wrapper) ValidateCrossReferences(
 		}
 
 		// Validate table locality.
-		if err := desc.validateTableLocalityConfig(dbDesc, vdg); err != nil {
+		if err := multiregion.ValidateTableLocalityConfig(desc, dbDesc, vdg); err != nil {
 			vea.Report(errors.Wrap(err, "invalid locality config"))
 			return
 		}
@@ -1339,228 +1338,4 @@ func (desc *wrapper) validatePartitioning() error {
 			a, idx, idx.GetPartitioning(), 0 /* colOffset */, partitionNames,
 		)
 	})
-}
-
-// validateTableLocalityConfig validates whether the descriptor's locality
-// config is valid under the given database.
-func (desc *wrapper) validateTableLocalityConfig(
-	db catalog.DatabaseDescriptor, vdg catalog.ValidationDescGetter,
-) error {
-
-	if desc.LocalityConfig == nil {
-		if db.IsMultiRegion() {
-			return pgerror.Newf(
-				pgcode.InvalidTableDefinition,
-				"database %s is multi-region enabled, but table %s has no locality set",
-				db.GetName(),
-				desc.GetName(),
-			)
-		}
-		// Nothing to validate for non-multi-region databases.
-		return nil
-	}
-
-	if !db.IsMultiRegion() {
-		s := tree.NewFmtCtx(tree.FmtSimple)
-		var locality string
-		// Formatting the table locality config should never fail; if it does, the
-		// error message is more clear if we construct a dummy locality here.
-		if err := FormatTableLocalityConfig(desc.LocalityConfig, s); err != nil {
-			locality = "INVALID LOCALITY"
-		}
-		locality = s.String()
-		return pgerror.Newf(
-			pgcode.InvalidTableDefinition,
-			"database %s is not multi-region enabled, but table %s has locality %s set",
-			db.GetName(),
-			desc.GetName(),
-			locality,
-		)
-	}
-
-	regionsEnumID, err := db.MultiRegionEnumID()
-	if err != nil {
-		return err
-	}
-	regionsEnumDesc, err := vdg.GetTypeDescriptor(regionsEnumID)
-	if err != nil {
-		return errors.Wrapf(err, "multi-region enum with ID %d does not exist", regionsEnumID)
-	}
-
-	// Check non-table items have a correctly set locality.
-	if desc.IsSequence() {
-		if !desc.IsLocalityRegionalByTable() {
-			return errors.AssertionFailedf(
-				"expected sequence %s to have locality REGIONAL BY TABLE",
-				desc.Name,
-			)
-		}
-	}
-	if desc.IsView() {
-		if desc.MaterializedView() {
-			if !desc.IsLocalityGlobal() {
-				return errors.AssertionFailedf(
-					"expected materialized view %s to have locality GLOBAL",
-					desc.Name,
-				)
-			}
-		} else {
-			if !desc.IsLocalityRegionalByTable() {
-				return errors.AssertionFailedf(
-					"expected view %s to have locality REGIONAL BY TABLE",
-					desc.Name,
-				)
-			}
-		}
-	}
-
-	// REGIONAL BY TABLE tables homed in the primary region should include a
-	// reference to the multi-region type descriptor and a corresponding
-	// backreference. All other patterns should only contain a reference if there
-	// is an explicit column which uses the multi-region type descriptor as its
-	// *types.T. While the specific cases are validated below, we search for the
-	// region enum ID in the references list just once, up top here.
-	typeIDs, err := desc.GetAllReferencedTypeIDs(db, vdg.GetTypeDescriptor)
-	if err != nil {
-		return err
-	}
-	regionEnumIDReferenced := false
-	for _, typeID := range typeIDs {
-		if typeID == regionsEnumID {
-			regionEnumIDReferenced = true
-			break
-		}
-	}
-	columnTypesTypeIDs, err := desc.getAllReferencedTypesInTableColumns(vdg.GetTypeDescriptor)
-	if err != nil {
-		return err
-	}
-	switch lc := desc.LocalityConfig.Locality.(type) {
-	case *descpb.TableDescriptor_LocalityConfig_Global_:
-		if regionEnumIDReferenced {
-			if _, found := columnTypesTypeIDs[regionsEnumID]; !found {
-				return errors.AssertionFailedf(
-					"expected no region Enum ID to be referenced by a GLOBAL TABLE: %q"+
-						" but found: %d",
-					desc.GetName(),
-					regionsEnumDesc.GetID(),
-				)
-			}
-		}
-	case *descpb.TableDescriptor_LocalityConfig_RegionalByRow_:
-		if !desc.IsPartitionAllBy() {
-			return errors.AssertionFailedf("expected REGIONAL BY ROW table to have PartitionAllBy set")
-		}
-		// For REGIONAL BY ROW tables, ensure partitions in the PRIMARY KEY match
-		// the database descriptor. Ensure each public region has a partition,
-		// and each transitioning region name to possibly have a partition.
-		// We do validation that ensures all index partitions are the same on
-		// PARTITION ALL BY.
-		regions, err := regionsEnumDesc.RegionNames()
-		if err != nil {
-			return err
-		}
-		regionNames := make(map[descpb.RegionName]struct{}, len(regions))
-		for _, region := range regions {
-			regionNames[region] = struct{}{}
-		}
-		transitioningRegions, err := regionsEnumDesc.TransitioningRegionNames()
-		if err != nil {
-			return err
-		}
-		transitioningRegionNames := make(map[descpb.RegionName]struct{}, len(regions))
-		for _, region := range transitioningRegions {
-			transitioningRegionNames[region] = struct{}{}
-		}
-
-		part := desc.GetPrimaryIndex().GetPartitioning()
-		err = part.ForEachList(func(name string, _ [][]byte, _ catalog.Partitioning) error {
-			regionName := descpb.RegionName(name)
-			// Any transitioning region names may exist.
-			if _, ok := transitioningRegionNames[regionName]; ok {
-				return nil
-			}
-			// If a region is not found in any of the region names, we have an unknown
-			// partition.
-			if _, ok := regionNames[regionName]; !ok {
-				return errors.AssertionFailedf(
-					"unknown partition %s on PRIMARY INDEX of table %s",
-					name,
-					desc.GetName(),
-				)
-			}
-			delete(regionNames, regionName)
-			return nil
-		})
-		if err != nil {
-			return err
-		}
-
-		// Any regions that are not deleted from the above loop is missing.
-		for regionName := range regionNames {
-			return errors.AssertionFailedf(
-				"missing partition %s on PRIMARY INDEX of table %s",
-				regionName,
-				desc.GetName(),
-			)
-		}
-
-	case *descpb.TableDescriptor_LocalityConfig_RegionalByTable_:
-
-		// Table is homed in an explicit (non-primary) region.
-		if lc.RegionalByTable.Region != nil {
-			foundRegion := false
-			regions, err := regionsEnumDesc.RegionNamesForValidation()
-			if err != nil {
-				return err
-			}
-			for _, r := range regions {
-				if *lc.RegionalByTable.Region == r {
-					foundRegion = true
-					break
-				}
-			}
-			if !foundRegion {
-				return errors.WithHintf(
-					pgerror.Newf(
-						pgcode.InvalidTableDefinition,
-						`region "%s" has not been added to database "%s"`,
-						*lc.RegionalByTable.Region,
-						db.DatabaseDesc().Name,
-					),
-					"available regions: %s",
-					strings.Join(regions.ToStrings(), ", "),
-				)
-			}
-			if !regionEnumIDReferenced {
-				return errors.AssertionFailedf(
-					"expected multi-region enum ID %d to be referenced on REGIONAL BY TABLE: %q locality "+
-						"config, but did not find it",
-					regionsEnumID,
-					desc.GetName(),
-				)
-			}
-		} else {
-			if regionEnumIDReferenced {
-				// It may be the case that the multi-region type descriptor is used
-				// as the type of the table column. Validations should only fail if
-				// that is not the case.
-				if _, found := columnTypesTypeIDs[regionsEnumID]; !found {
-					return errors.AssertionFailedf(
-						"expected no region Enum ID to be referenced by a REGIONAL BY TABLE: %q homed in the "+
-							"primary region, but found: %d",
-						desc.GetName(),
-						regionsEnumDesc.GetID(),
-					)
-				}
-			}
-		}
-	default:
-		return pgerror.Newf(
-			pgcode.InvalidTableDefinition,
-			"unknown locality level: %T",
-			lc,
-		)
-	}
-	return nil
 }

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -46,6 +46,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catprivilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/multiregion"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/idxusage"
@@ -399,7 +400,7 @@ CREATE TABLE crdb_internal.tables (
 				locality := tree.DNull
 				if c := table.GetLocalityConfig(); c != nil {
 					f := p.EvalContext().FmtCtx(tree.FmtSimple)
-					if err := tabledesc.FormatTableLocalityConfig(c, f); err != nil {
+					if err := multiregion.FormatTableLocalityConfig(c, f); err != nil {
 						return err
 					}
 					locality = tree.NewDString(f.String())

--- a/pkg/sql/drop_type.go
+++ b/pkg/sql/drop_type.go
@@ -195,7 +195,7 @@ func (p *planner) addBackRefsFromAllTypesInTable(
 	if err != nil {
 		return err
 	}
-	typeIDs, err := desc.GetAllReferencedTypeIDs(dbDesc, func(id descpb.ID) (catalog.TypeDescriptor, error) {
+	typeIDs, _, err := desc.GetAllReferencedTypeIDs(dbDesc, func(id descpb.ID) (catalog.TypeDescriptor, error) {
 		mutDesc, err := p.Descriptors().GetMutableTypeVersionByID(ctx, p.txn, id)
 		if err != nil {
 			return nil, err
@@ -222,7 +222,7 @@ func (p *planner) removeBackRefsFromAllTypesInTable(
 	if err != nil {
 		return err
 	}
-	typeIDs, err := desc.GetAllReferencedTypeIDs(dbDesc, func(id descpb.ID) (catalog.TypeDescriptor, error) {
+	typeIDs, _, err := desc.GetAllReferencedTypeIDs(dbDesc, func(id descpb.ID) (catalog.TypeDescriptor, error) {
 		mutDesc, err := p.Descriptors().GetMutableTypeVersionByID(ctx, p.txn, id)
 		if err != nil {
 			return nil, err

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1062,7 +1062,7 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		referencedTypeIDs, err := scTable.GetAllReferencedTypeIDs(dbDesc,
+		referencedTypeIDs, _, err := scTable.GetAllReferencedTypeIDs(dbDesc,
 			func(id descpb.ID) (catalog.TypeDescriptor, error) {
 				desc, err := descsCol.GetImmutableTypeByID(ctx, txn, id, tree.ObjectLookupFlags{})
 				if err != nil {
@@ -1314,7 +1314,7 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 		// type descriptors. If this table has been dropped in the mean time, then
 		// don't install any backreferences.
 		if !scTable.Dropped() {
-			newReferencedTypeIDs, err := scTable.GetAllReferencedTypeIDs(dbDesc,
+			newReferencedTypeIDs, _, err := scTable.GetAllReferencedTypeIDs(dbDesc,
 				func(id descpb.ID) (catalog.TypeDescriptor, error) {
 					typ, err := descsCol.GetMutableTypeVersionByID(ctx, txn, id)
 					if err != nil {

--- a/pkg/sql/schemachanger/scbuild/relation_common.go
+++ b/pkg/sql/schemachanger/scbuild/relation_common.go
@@ -33,7 +33,7 @@ func (b *buildContext) removeTypeBackRefDeps(
 	if err != nil {
 		panic(err)
 	}
-	typeIDs, err := tableDesc.GetAllReferencedTypeIDs(dbDesc, func(id descpb.ID) (catalog.TypeDescriptor, error) {
+	typeIDs, _, err := tableDesc.GetAllReferencedTypeIDs(dbDesc, func(id descpb.ID) (catalog.TypeDescriptor, error) {
 		mutDesc, err := b.Descs.GetMutableTypeByID(ctx, b.EvalCtx.Txn, id, tree.ObjectLookupFlagsWithRequired())
 		if err != nil {
 			return nil, err

--- a/pkg/sql/show_create_clauses.go
+++ b/pkg/sql/show_create_clauses.go
@@ -19,8 +19,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/multiregion"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -376,7 +376,7 @@ func showFamilyClause(desc catalog.TableDescriptor, f *tree.FmtCtx) {
 func showCreateLocality(desc catalog.TableDescriptor, f *tree.FmtCtx) error {
 	if c := desc.GetLocalityConfig(); c != nil {
 		f.WriteString(" LOCALITY ")
-		return tabledesc.FormatTableLocalityConfig(c, f)
+		return multiregion.FormatTableLocalityConfig(c, f)
 	}
 	return nil
 }


### PR DESCRIPTION
This code and these invariants are seen as the responsibility of the
multiregion team, so, let's move them to a package that that team owns.

Release justification: Low risk code movement.

Release note: None