### PR TITLE
sql: showing correct information on createDB, and settings

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -5000,7 +5000,7 @@ CREATE TABLE crdb_internal.default_privileges (
 					}
 					return nil
 				}
-				if err := forEachRole(ctx, p, func(username security.SQLUsername, isRole bool, noLogin bool, rolValidUntil *time.Time) error {
+				if err := forEachRole(ctx, p, func(username security.SQLUsername, isRole bool, options roleOptions, settings tree.Datum) error {
 					role := descpb.DefaultPrivilegesRole{
 						Role: username,
 					}

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -19,6 +19,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/docs"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
@@ -32,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/vtable"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil/pgdate"
 	"github.com/cockroachdb/errors"
 	"golang.org/x/text/collate"
 )
@@ -2486,31 +2488,102 @@ func forEachTableDescWithTableLookupInternalFromDescriptors(
 	return nil
 }
 
-func forEachRole(
-	ctx context.Context,
-	p *planner,
-	fn func(username security.SQLUsername, isRole bool, noLogin bool, rolValidUntil *time.Time) error,
-) error {
-	query := `
+type roleOptions struct {
+	*tree.DJSON
+}
+
+func (r roleOptions) noLogin() (tree.DBool, error) {
+	nologin, err := r.Exists("NOLOGIN")
+	return tree.DBool(nologin), err
+}
+
+func (r roleOptions) validUntil(p *planner) (tree.Datum, error) {
+	const validUntilKey = "VALID UNTIL"
+	exists, err := r.Exists(validUntilKey)
+	if err != nil {
+		return nil, err
+	}
+
+	var rolValidUntil *time.Time = nil
+	if exists {
+		val, err := r.FetchValKey(validUntilKey)
+		if err != nil {
+			return nil, err
+		}
+		valStr, err := val.AsText()
+		if err != nil {
+			return nil, err
+		}
+
+		validUntil, _, err := pgdate.ParseTimestamp(
+			p.EvalContext().GetRelativeParseTime(),
+			pgdate.DefaultDateStyle(),
+			*valStr,
+		)
+		if err != nil {
+			return nil, errors.Errorf("rolValidUntil string %s could not be parsed with datestyle %s", *valStr, p.EvalContext().GetDateStyle())
+		}
+		rolValidUntil = &validUntil
+	}
+
+	if rolValidUntil == nil {
+		return tree.DNull, nil
+	}
+
+	return tree.MakeDTimestampTZ(*rolValidUntil, time.Second)
+}
+
+func (r roleOptions) createDB() (tree.DBool, error) {
+	createDB, err := r.Exists("CREATEDB")
+	return tree.DBool(createDB), err
+}
+
+func (r roleOptions) createRole() (tree.DBool, error) {
+	createRole, err := r.Exists("CREATEROLE")
+	return tree.DBool(createRole), err
+}
+
+func forEachRoleQuery(ctx context.Context, p *planner) string {
+	if p.EvalContext().Settings.Version.IsActive(ctx, clusterversion.DatabaseRoleSettings) {
+		return `
 SELECT
 	u.username,
 	"isRole",
-	EXISTS(
-		SELECT
-			option
-		FROM
-			system.role_options AS r
-		WHERE
-			r.username = u.username AND option = 'NOLOGIN'
-	)
-		AS nologin,
-	ro.value::TIMESTAMPTZ AS rolvaliduntil
+  drs.settings,
+	json_object_agg(COALESCE(ro.option, 'null'), ro.value)
 FROM
 	system.users AS u
 	LEFT JOIN system.role_options AS ro ON
 			ro.username = u.username
-			AND option = 'VALID UNTIL';
+  LEFT JOIN system.database_role_settings AS drs ON 
+			drs.role_name = u.username AND drs.database_id = 0
+GROUP BY
+	u.username, "isRole", drs.settings;
 `
+	}
+
+	return `
+SELECT
+	u.username,
+	"isRole",
+	NULL::STRING[] AS settings,
+	json_object_agg(COALESCE(ro.option, 'null'), ro.value)
+FROM
+	system.users AS u
+	LEFT JOIN system.role_options AS ro ON
+			ro.username = u.username
+GROUP BY
+	u.username, "isRole", settings;
+`
+}
+
+func forEachRole(
+	ctx context.Context,
+	p *planner,
+	fn func(username security.SQLUsername, isRole bool, options roleOptions, settings tree.Datum) error,
+) error {
+	query := forEachRoleQuery(ctx, p)
+
 	// For some reason, using the iterator API here causes privilege_builtins
 	// logic test fail in 3node-tenant config with 'txn already encountered an
 	// error' (because of the context cancellation), so we buffer all roles
@@ -2528,19 +2601,17 @@ FROM
 		if !ok {
 			return errors.Errorf("isRole should be a boolean value, found %s instead", row[1].ResolvedType())
 		}
-		noLogin, ok := row[2].(*tree.DBool)
+
+		defaultSettings := row[2]
+		roleOptionsJSON, ok := row[3].(*tree.DJSON)
 		if !ok {
-			return errors.Errorf("noLogin should be a boolean value, found %s instead", row[2].ResolvedType())
+			return errors.Errorf("roleOptionJson should be a JSON value, found %s instead", row[3].ResolvedType())
 		}
-		var rolValidUntil *time.Time
-		if rolValidUntilDatum, ok := row[3].(*tree.DTimestampTZ); ok {
-			rolValidUntil = &rolValidUntilDatum.Time
-		} else if row[3] != tree.DNull {
-			return errors.Errorf("rolValidUntil should be a timestamp or null value, found %s instead", row[3].ResolvedType())
-		}
+		options := roleOptions{roleOptionsJSON}
+
 		// system tables already contain normalized usernames.
 		username := security.MakeSQLUsernameFromPreNormalizedString(string(usernameS))
-		if err := fn(username, bool(*isRole), bool(*noLogin), rolValidUntil); err != nil {
+		if err := fn(username, bool(*isRole), options, defaultSettings); err != nil {
 			return err
 		}
 	}

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -5849,7 +5849,7 @@ CREATE TABLE pg_catalog.pg_user (
    userepl BOOL NULL,
    usebypassrls BOOL NULL,
    passwd STRING NULL,
-   valuntil TIMESTAMP NULL,
+   valuntil TIMESTAMPTZ NULL,
    useconfig STRING[] NULL
 )  CREATE TABLE pg_catalog.pg_user (
    usename NAME NULL,
@@ -5859,7 +5859,7 @@ CREATE TABLE pg_catalog.pg_user (
    userepl BOOL NULL,
    usebypassrls BOOL NULL,
    passwd STRING NULL,
-   valuntil TIMESTAMP NULL,
+   valuntil TIMESTAMPTZ NULL,
    useconfig STRING[] NULL
 )  {}  {}
 CREATE TABLE pg_catalog.pg_user_mapping (

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -5235,3 +5235,48 @@ datname     rolname   deptype
 sh_db       sh_owner  o
 sh_db       sh_role   a
 sh_db_root  sh_role   a
+
+# Testing settings and createDB from forEachRoles
+statement ok
+CREATE USER testuser1;
+CREATE USER testuser2;
+CREATE ROLE testrole1;
+CREATE DATABASE foreachroles;
+ALTER USER testuser1 WITH CREATEDB;
+ALTER USER testuser1 SET TimeZone = 'America/Los_Angeles';
+ALTER USER testuser1 SET application_name = 'a';
+ALTER USER testuser1 IN DATABASE foreachroles SET application_name = 'b';
+ALTER USER testuser2 WITH CREATEROLE PASSWORD '123' VALID UNTIL '3022-01-01';
+
+query TBT colnames
+SELECT usename, usecreatedb, useconfig
+FROM pg_user
+WHERE usename IN ('testuser1', 'testuser2')
+ORDER BY usename
+----
+usename    usecreatedb  useconfig
+testuser1  true         {timezone=America/Los_Angeles,application_name=a}
+testuser2  false        NULL
+
+query TBTBBT colnames
+SELECT rolname, rolcreatedb, rolconfig, rolinherit, rolcanlogin, rolvaliduntil
+FROM pg_roles
+WHERE rolname IN ('testuser1', 'testuser2', 'testrole1')
+ORDER BY rolname
+----
+rolname    rolcreatedb  rolconfig                                          rolinherit  rolcanlogin  rolvaliduntil
+testrole1  false        NULL                                               true        false        NULL
+testuser1  true         {timezone=America/Los_Angeles,application_name=a}  false       true         NULL
+testuser2  false        NULL                                               false       true         3022-01-01 00:00:00 +0000 UTC
+
+query TBBBBT colnames
+SELECT rolname, rolcreatedb, rolcreaterole, rolinherit, rolcanlogin, rolvaliduntil
+FROM pg_authid
+WHERE rolname IN ('testuser1', 'testuser2', 'testrole1', 'root')
+ORDER BY rolname
+----
+rolname    rolcreatedb  rolcreaterole  rolinherit  rolcanlogin  rolvaliduntil
+root       true         true           false       true         NULL
+testrole1  false        false          true        false        NULL
+testuser1  true         false          false       true         NULL
+testuser2  false        true           false       true         3022-01-01 00:00:00 +0000 UTC

--- a/pkg/sql/vtable/pg_catalog.go
+++ b/pkg/sql/vtable/pg_catalog.go
@@ -823,7 +823,7 @@ CREATE TABLE pg_catalog.pg_user (
 	userepl  BOOL,
 	usebypassrls BOOL,
 	passwd TEXT,
-	valuntil TIMESTAMP,
+	valuntil TIMESTAMPTZ,
 	useconfig TEXT[]
 )`
 


### PR DESCRIPTION
Previously, pg_catalog shows true for createDB only for admin and root
roles, and null for settings columns
This was inadequate because there are roles/users wich can create db
and we store the settings values
To address this, this patch edits forEachRole to provide the role
options and user/role settings to populate at tables: pg_roles,
pg_user and pg_authid

Release justification: bug fixes and low-risk updates to new functionality
Release note (sql change): fixed createdb and settings columns for
tables: pg_user, pg_roles and pg_authid