### PR TITLE
colflow: propagate concurrency info from vectorized to FlowBase

### DIFF
--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -227,6 +227,7 @@ func (f *vectorizedFlow) Setup(
 	f.batchFlowCoordinator = batchFlowCoordinator
 	f.testingInfo.numClosers = f.creator.numClosers
 	f.testingInfo.numClosed = &f.creator.numClosed
+	f.SetStartedGoroutines(f.creator.operatorConcurrency)
 	log.VEventf(ctx, 2, "vectorized flow setup succeeded")
 	if !f.IsLocal() {
 		// For distributed flows set opChains to nil, per the contract of


### PR DESCRIPTION
**colflow: propagate concurrency info from vectorized to FlowBase**

We've recently merged a change to introduce concurrency in the local
flows. Those new concurrent goroutines are started by the vectorized
parallel unordered synchronizer, and `FlowBase` isn't aware of them; as
a result, `FlowBase.Wait` currently might not wait for all goroutines to
exit (which is an optimization when there are no concurrent goroutines).
This commit fixes the problem by propagating the information from the
vectorized flow to the FlowBase.

Addresses: #69419.

Release note: None (no stable release with this bug)

Release justification: bug fix to new functionality.

**sql: loosen up the physical planning of parallel scans**

This commit makes it so that in case we try to plan parallel
TableReaders but encounter an error during planning, we fallback to
having a single TableReader.

Release note: None

Release justification: bug fix to new functionality.