### PR TITLE
ui: fix table height overflowing parent div

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionPage.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionPage.module.scss
@@ -10,7 +10,8 @@
 
 @import "../core/index.module.scss";
 
-.sessions-page{
+.sessions-page {
+  position: relative;
   all: initial;
   font-family: $font-family--base;
 }

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.module.scss
@@ -54,6 +54,7 @@ h2.base-heading {
 }
 
 .table-area {
+  position: relative;
   width: fit-content;
 }
 


### PR DESCRIPTION
Fixes: #67769

This commit prevents statements, transactions, and sessions
tables from overflowing parent containers when overflow is
hidden.

The absence of a relatively positioned parent for absolutely
positioned elements within an overflow: hidden container was
causing incorrect behaviour where users could scroll vertically
on the body of the statements, transactions and sessions pages.

Release justification: bug fixes and low-risk updates
to new functionality

Release note (bug fix): Users can now only scroll in the content
section of the transactions, statements and sessions pages.