### PR TITLE
kvserver: avoid retaining memory in rangefeed catch up scan

### DIFF
--- a/pkg/kv/kvserver/rangefeed/catchup_scan.go
+++ b/pkg/kv/kvserver/rangefeed/catchup_scan.go
@@ -117,6 +117,7 @@ func (i *CatchUpIterator) CatchUpScan(
 			if err := outputFn(&e); err != nil {
 				return err
 			}
+			reorderBuf[i] = roachpb.RangeFeedEvent{} // Drop references to values to allow GC
 		}
 		reorderBuf = reorderBuf[:0]
 		return nil


### PR DESCRIPTION
Previously, the reorderBuf's backing array would have held onto memory
that had already been output. Here, we zero out the reorderBuf as
we output events to allow it to be garbage collected.

Informs #69596.

Release justification: Helps address unbounded memory usage recently
seen in high-priority escalation.

Release note: None