### PR TITLE
opt: fix internal error in set ops when left side columns projected twice

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/union
+++ b/pkg/sql/logictest/testdata/logic_test/union
@@ -653,3 +653,16 @@ SELECT e, f, g, h FROM efgh EXCEPT SELECT a, b, c, d FROM abcd ORDER by e, f
 3  2  3  3
 4  2  2  2
 5  2  3  3
+
+# Regression test for #68702. Ensure correct behavior when a column is projected
+# twice on the left side.
+query III
+SELECT a, b AS b1, b AS b2 FROM abc EXCEPT SELECT a, b, c FROM abc ORDER by a, b1
+----
+
+query III
+SELECT a, b AS b1, b AS b2 FROM abc INTERSECT SELECT a, c, b FROM abc ORDER by a, b2
+----
+1  1  1
+1  2  2
+2  2  2

--- a/pkg/sql/opt/exec/execbuilder/testdata/dist_union
+++ b/pkg/sql/opt/exec/execbuilder/testdata/dist_union
@@ -103,6 +103,7 @@ vectorized: true
 ·
 • project
 │ columns: (a)
+│ estimated row count: 1
 │
 └── • except all
     │ columns: (a, a)

--- a/pkg/sql/opt/exec/execbuilder/testdata/srfs
+++ b/pkg/sql/opt/exec/execbuilder/testdata/srfs
@@ -483,26 +483,30 @@ vectorized: true
 │ estimated row count: 10
 │
 └── • project set
-    │ columns: (a, a, generate_series)
+    │ columns: (a, generate_series)
     │ estimated row count: 10
     │ render 0: generate_series(a + 1, a + 1)
     │
-    └── • except all
-        │ columns: (a, a)
+    └── • project
+        │ columns: (a)
         │ estimated row count: 1
         │
-        ├── • project
-        │   │ columns: (a, a)
-        │   │
-        │   └── • values
-        │         columns: (a)
-        │         size: 1 column, 1 row
-        │         row 0, expr 0: 1
-        │
-        └── • project
-            │ columns: ("?column?", "?column?")
+        └── • except all
+            │ columns: (a, a)
+            │ estimated row count: 1
             │
-            └── • values
-                  columns: ("?column?")
-                  size: 1 column, 1 row
-                  row 0, expr 0: 0
+            ├── • project
+            │   │ columns: (a, a)
+            │   │
+            │   └── • values
+            │         columns: (a)
+            │         size: 1 column, 1 row
+            │         row 0, expr 0: 1
+            │
+            └── • project
+                │ columns: ("?column?", "?column?")
+                │
+                └── • values
+                      columns: ("?column?")
+                      size: 1 column, 1 row
+                      row 0, expr 0: 0

--- a/pkg/sql/opt/exec/execbuilder/testdata/union
+++ b/pkg/sql/opt/exec/execbuilder/testdata/union
@@ -103,6 +103,7 @@ vectorized: true
 ·
 • project
 │ columns: (a)
+│ estimated row count: 1
 │
 └── • except all
     │ columns: (a, a)
@@ -1030,3 +1031,101 @@ vectorized: true
           spans: FULL SCAN
 ·
 Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyckm9r2zAQxt_vU4h71dIrie28EgzUPx4E0jqzw-gYJijWxTE4lifJ0BLy3YdtSmuv6cjeCHS6537Pc-gA9ncJHMKn5eJm_sgu7ufJKvm-QPYjjG-jJLxkSbgI71aMkG2R5ch27FscPTDa5jsWPt2Fy9Vri0S2QZYhU32L3GSKRfF9GLPbn90AQKi0oke5Jwv8F3iQItRGZ2StNm3p0DXM1TPwKUJR1Y1ryylCpg0BP4ArXEnAYSU3JcUkFZnJFBAUOVmU3djWm6hNsZfmBRCSWlaWs2tIjwi6cW8zrZM5AfeO-H9cb8htA4v2WMv1Zp2tC_X8Ho8QNY4z4aHwUQQoZicd-ec4SrRxZCb-0IzwrlD4VyiCaxSzK0DYS5ftWEkVZ8FJcnCS_AZsKm0UGVIDYtoq_9Xygf0HMjkl5KJ6EgwjrF5q4q-f7GaxAISStu5iFO3yqyny3d_lcxY-O2fhMdlaV5bG8T-cPG0zk8qp36HVjcloaXTWYfpr1Om6giLr-tegv8yr7qn7o-_F3qdifyCejsX-GWR_LA4-Fc9G5PT45U8AAAD__ySlYvg=
+
+# Regression test for #68702. Ensure correct behavior when a column is projected
+# twice on the left side.
+statement ok
+CREATE TABLE t68702 (k INT8 PRIMARY KEY)
+
+query T
+EXPLAIN (DISTSQL,VERBOSE) SELECT tableoid AS col1, tableoid AS col2, k AS col3 FROM t68702
+EXCEPT ALL SELECT * FROM (VALUES (NULL, 2505326470:::OID, (-1643624263):::INT8))
+----
+distribution: local
+vectorized: true
+·
+• except all
+│ columns: (col1, col2, col3)
+│ estimated row count: 1,000 (missing stats)
+│
+├── • project
+│   │ columns: (tableoid, tableoid, k)
+│   │ ordering: +k
+│   │
+│   └── • scan
+│         columns: (k, tableoid)
+│         ordering: +k
+│         estimated row count: 1,000 (missing stats)
+│         table: t68702@primary
+│         spans: FULL SCAN
+│
+└── • values
+      columns: (column1, column2, column3)
+      size: 3 columns, 1 row
+      row 0, expr 0: 2505326470
+      row 0, expr 1: -1643624263
+      row 0, expr 2: CAST(NULL AS OID)
+·
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyUUWFrnEAQ_d5fscyns5lwul5MWCh4TSwI5ryeJgSKH6xOr1Lj2t21NBz334vaJvHItQ34wX0zb957MzvQ32sQENyto2W4YrOrMEmTjxGy22DzPk4CiyVBFFymzOSfa5JVyZYJK2Tt4CHCkX37_euyD5v4mhnv4tzmLLi7DNYpW0bRn1lvx_rsdhndBAmbrW6iCBk_s89c7i3ObSFEHF4hm5063sL1-IJ7riWECFfphWUBQiNLWuX3pEF8AgcyhFbJgrSWqod2Q0NY_gRhI1RN25kezhAKqQjEDkxlagIBaZ9hQ3lJam4DQkkmr-ph7Ojeb1V1n6sHQEjavNGCnQJC3BnBfBf7z4FsjyA786SiTb4lEM4e_99JLYu8Zj_yuiPN7LkzNfMo6KDPjwryo4JPOl0jVUmKyolA1jP_1fKC62tSW0rIxO2cTx2nDy2JZ7cHhJq-mJnvnqDvnKDPT6x3qtp-nUKPy-2Dou8ezeq-Zrkb0q1sNB1mfnGy3Qelckvj4rTsVEFrJYtBZnzGA28AStJmrPLxETZDabj-c7LzCjI_JPO_kt0J2d5n-ze_AgAA__-pczGn
+
+query T
+EXPLAIN (DISTSQL,VERBOSE) SELECT a, b AS b1, b AS b2 FROM abc EXCEPT SELECT a, b, c FROM abc ORDER by a, b1
+----
+distribution: local
+vectorized: true
+·
+• except
+│ columns: (a, b1, b2)
+│ ordering: +a,+b1
+│ estimated row count: 1,000 (missing stats)
+│
+├── • project
+│   │ columns: (a, b, b)
+│   │ ordering: +a,+b
+│   │
+│   └── • scan
+│         columns: (a, b)
+│         ordering: +a,+b
+│         estimated row count: 1,000 (missing stats)
+│         table: abc@abc_a_b_c_idx
+│         spans: FULL SCAN
+│
+└── • scan
+      columns: (a, b, c)
+      ordering: +a,+b,-c
+      estimated row count: 1,000 (missing stats)
+      table: abc@abc_a_b_c_idx
+      spans: FULL SCAN
+·
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJycklFro0AQx9_vUyzz1NIpiZq-CAemjQcBW3MqR49DwrrO5QTP9XZX6BHy3Q-VXmpobJK37Mz-5vefjVvQf0pwwX9eBfPlE7taLOMk_hog--ZH92HsX7PYD_yHhHFkGZvHLLNef9jsSxQ-Mp4J5j8_-Kvk7VVkYt8Oo4UfsfvvXccChErm9MR_kwb3B1iQItRKCtJaqra07S4s8xdwpwhFVTemLacIQioCdwumMCWBCwnPSoqI56QmU0DIyfCi7MbyTHg8E2u-ztZiXeQvgBDXvNIuuwWEsDEu8yz0bPRsSHcIsjF7kTZ8Q-BaO7wsjHVxGOdoGPucMItCm6ISZmIPk_y3IIQqJ0V5bz6udS7SOqdpRxeeHTXvhU0l-3kDX9qSH115J_4jqQ3FZMJ6MhsukPytyX390OdBAAgl_TRXnnWDnn2DnnN7_VkVm1_D0sl_7t05rxyRrmWl6XDndydP20Up31D_cFo2StBKSdFp-mPYcV0hJ236rt0fllXfagO-ha1R2BmH7VF4NoCtQ9g5A7YP4dkofHcQO919-hcAAP___aifEw==
+
+query T
+EXPLAIN (DISTSQL,VERBOSE) SELECT a, b AS b1, b AS b2 FROM abc INTERSECT SELECT a, c, b FROM abc ORDER by a, b2
+----
+distribution: local
+vectorized: true
+·
+• intersect
+│ columns: (a, b1, b2)
+│ ordering: +a,+b1
+│ estimated row count: 1,000 (missing stats)
+│
+├── • project
+│   │ columns: (a, b, b)
+│   │ ordering: +a,+b
+│   │
+│   └── • scan
+│         columns: (a, b)
+│         ordering: +a,+b
+│         estimated row count: 1,000 (missing stats)
+│         table: abc@abc_a_b_c_idx
+│         spans: FULL SCAN
+│
+└── • scan
+      columns: (a, c, b)
+      ordering: +a,+b,-c
+      estimated row count: 1,000 (missing stats)
+      table: abc@abc_a_b_c_idx
+      spans: FULL SCAN
+·
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJycktFvmzAQxt_3V1j31KquEkz6gjSJdGFSJBo6QNOmCUXGvmVIDDPbSJ2i_O8T0C0FNazJGz5_v_u-O7wH86sED4Ivj-FyvSFXq3WSJp9CSj4H8X2UBNckCcLgQ0o4JTlZJiR3_n4w8jGOHgjPBVlv0iBOWtlRLVrdP0UUr4KY3H_t-jCgUCmJG_4TDXjfwIGMQq2VQGOUbkv7TrCWT-DNKRRV3di2nFEQSiN4e7CFLRE8SHleYoxcop7NgYJEy4uya8tz4fNcbPk234ptIZ-AQlLzynjkFihEjfWI71DfpT6D7EBBNfZoZCzfIXjOgV4WxrksDJsKw84JsyqMLSphZ2yY5NnFbV21RI3yeQ0nbd2LbN032k4NvDjpfDRsKtX3G_hlLfk_ySvxH1DvMEEb1bPFcID0d43ei7e-DEOgUOJ3e-U7N9R3b6jPbq_f62L3Y1ga_d_Ti747Z9ExmlpVBsdjv9p53s6Kcof97oxqtMBHrURn0x-jjusKEo3tb93-sK76qzbgS9iZhNk0zCbhxQB2xrB7BszG8GISvhvFzg7v_gQAAP__Zfug5A==

--- a/pkg/sql/opt/memo/testdata/logprops/set
+++ b/pkg/sql/opt/memo/testdata/logprops/set
@@ -45,20 +45,20 @@ build
 SELECT x, y, x FROM xy INTERSECT SELECT v, u, rowid FROM (SELECT *, rowid FROM uv WHERE u=1) uv
 ----
 intersect
- ├── columns: x:1(int!null) y:2(int) x:1(int!null)
- ├── left columns: x:1(int!null) y:2(int) x:1(int!null)
+ ├── columns: x:10(int!null) y:11(int) x:12(int!null)
+ ├── left columns: xy.x:1(int) xy.y:2(int) xy.x:1(int)
  ├── right columns: v:6(int) u:5(int) rowid:7(int)
- ├── key: (1)
- ├── fd: ()-->(2)
- ├── interesting orderings: (+1)
+ ├── key: (12)
+ ├── fd: ()-->(11), (10)==(12), (12)==(10), (12)-->(10,11)
+ ├── interesting orderings: (+12)
  ├── project
- │    ├── columns: x:1(int!null) y:2(int)
+ │    ├── columns: xy.x:1(int!null) xy.y:2(int)
  │    ├── key: (1)
  │    ├── fd: (1)-->(2)
  │    ├── prune: (1,2)
  │    ├── interesting orderings: (+1)
  │    └── scan xy
- │         ├── columns: x:1(int!null) y:2(int) xy.crdb_internal_mvcc_timestamp:3(decimal) xy.tableoid:4(oid)
+ │         ├── columns: xy.x:1(int!null) xy.y:2(int) xy.crdb_internal_mvcc_timestamp:3(decimal) xy.tableoid:4(oid)
  │         ├── key: (1)
  │         ├── fd: (1)-->(2-4)
  │         ├── prune: (1-4)
@@ -90,20 +90,20 @@ build
 SELECT x, x, y FROM xy EXCEPT SELECT u, v, v FROM (SELECT * FROM uv WHERE u=1) uv
 ----
 except
- ├── columns: x:1(int!null) x:1(int!null) y:2(int)
- ├── left columns: x:1(int!null) x:1(int!null) y:2(int)
+ ├── columns: x:10(int!null) x:11(int!null) y:12(int)
+ ├── left columns: xy.x:1(int) xy.x:1(int) xy.y:2(int)
  ├── right columns: u:5(int) v:6(int) v:6(int)
- ├── key: (1)
- ├── fd: (1)-->(2)
- ├── interesting orderings: (+1)
+ ├── key: (11)
+ ├── fd: (11)-->(10,12), (10)==(11), (11)==(10)
+ ├── interesting orderings: (+(10|11))
  ├── project
- │    ├── columns: x:1(int!null) y:2(int)
+ │    ├── columns: xy.x:1(int!null) xy.y:2(int)
  │    ├── key: (1)
  │    ├── fd: (1)-->(2)
  │    ├── prune: (1,2)
  │    ├── interesting orderings: (+1)
  │    └── scan xy
- │         ├── columns: x:1(int!null) y:2(int) xy.crdb_internal_mvcc_timestamp:3(decimal) xy.tableoid:4(oid)
+ │         ├── columns: xy.x:1(int!null) xy.y:2(int) xy.crdb_internal_mvcc_timestamp:3(decimal) xy.tableoid:4(oid)
  │         ├── key: (1)
  │         ├── fd: (1)-->(2-4)
  │         ├── prune: (1-4)

--- a/pkg/sql/opt/memo/testdata/stats/set
+++ b/pkg/sql/opt/memo/testdata/stats/set
@@ -237,19 +237,19 @@ build
 SELECT x, y, x FROM a INTERSECT SELECT z, x, rowid FROM (SELECT *, rowid FROM b WHERE b.x=1) b
 ----
 intersect
- ├── columns: x:1(int!null) y:2(int) x:1(int!null)
- ├── left columns: a.x:1(int!null) y:2(int) a.x:1(int!null)
+ ├── columns: x:12(int!null) y:13(int) x:14(int!null)
+ ├── left columns: a.x:1(int) a.y:2(int) a.x:1(int)
  ├── right columns: z:7(int) b.x:6(int) rowid:9(int)
- ├── stats: [rows=2, distinct(1,2)=2, null(1,2)=0]
- ├── key: (1)
- ├── fd: ()-->(2)
+ ├── stats: [rows=2, distinct(12-14)=2, null(12-14)=0]
+ ├── key: (14)
+ ├── fd: ()-->(13), (12)==(14), (14)==(12), (14)-->(12,13)
  ├── project
- │    ├── columns: a.x:1(int!null) y:2(int)
+ │    ├── columns: a.x:1(int!null) a.y:2(int)
  │    ├── stats: [rows=5000, distinct(1,2)=5000, null(1,2)=0]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2)
  │    └── scan a
- │         ├── columns: a.x:1(int!null) y:2(int) a.s:3(string) a.crdb_internal_mvcc_timestamp:4(decimal) a.tableoid:5(oid)
+ │         ├── columns: a.x:1(int!null) a.y:2(int) a.s:3(string) a.crdb_internal_mvcc_timestamp:4(decimal) a.tableoid:5(oid)
  │         ├── stats: [rows=5000, distinct(1,2)=5000, null(1,2)=0]
  │         ├── key: (1)
  │         └── fd: (1)-->(2-5)
@@ -280,19 +280,19 @@ build
 SELECT x, y, x FROM a INTERSECT ALL SELECT z, x, rowid FROM (SELECT *, rowid FROM b WHERE b.x=1) b
 ----
 intersect-all
- ├── columns: x:1(int!null) y:2(int) x:1(int!null)
- ├── left columns: a.x:1(int!null) y:2(int) a.x:1(int!null)
+ ├── columns: x:12(int!null) y:13(int) x:14(int!null)
+ ├── left columns: a.x:1(int) a.y:2(int) a.x:1(int)
  ├── right columns: z:7(int) b.x:6(int) rowid:9(int)
  ├── stats: [rows=2]
- ├── key: (1)
- ├── fd: ()-->(2)
+ ├── key: (14)
+ ├── fd: ()-->(13), (12)==(14), (14)==(12)
  ├── project
- │    ├── columns: a.x:1(int!null) y:2(int)
+ │    ├── columns: a.x:1(int!null) a.y:2(int)
  │    ├── stats: [rows=5000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2)
  │    └── scan a
- │         ├── columns: a.x:1(int!null) y:2(int) a.s:3(string) a.crdb_internal_mvcc_timestamp:4(decimal) a.tableoid:5(oid)
+ │         ├── columns: a.x:1(int!null) a.y:2(int) a.s:3(string) a.crdb_internal_mvcc_timestamp:4(decimal) a.tableoid:5(oid)
  │         ├── stats: [rows=5000]
  │         ├── key: (1)
  │         └── fd: (1)-->(2-5)
@@ -400,19 +400,19 @@ build
 SELECT x, x, y FROM a EXCEPT SELECT x, z, z FROM (SELECT * FROM b WHERE b.x=1) b
 ----
 except
- ├── columns: x:1(int!null) x:1(int!null) y:2(int)
- ├── left columns: a.x:1(int!null) a.x:1(int!null) y:2(int)
+ ├── columns: x:12(int!null) x:13(int!null) y:14(int)
+ ├── left columns: a.x:1(int) a.x:1(int) a.y:2(int)
  ├── right columns: b.x:6(int) z:7(int) z:7(int)
- ├── stats: [rows=5000, distinct(1,2)=5000, null(1,2)=0]
- ├── key: (1)
- ├── fd: (1)-->(2)
+ ├── stats: [rows=5000, distinct(12-14)=5000, null(12-14)=0]
+ ├── key: (13)
+ ├── fd: (13)-->(12,14), (12)==(13), (13)==(12)
  ├── project
- │    ├── columns: a.x:1(int!null) y:2(int)
+ │    ├── columns: a.x:1(int!null) a.y:2(int)
  │    ├── stats: [rows=5000, distinct(1,2)=5000, null(1,2)=0]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2)
  │    └── scan a
- │         ├── columns: a.x:1(int!null) y:2(int) a.s:3(string) a.crdb_internal_mvcc_timestamp:4(decimal) a.tableoid:5(oid)
+ │         ├── columns: a.x:1(int!null) a.y:2(int) a.s:3(string) a.crdb_internal_mvcc_timestamp:4(decimal) a.tableoid:5(oid)
  │         ├── stats: [rows=5000, distinct(1,2)=5000, null(1,2)=0]
  │         ├── key: (1)
  │         └── fd: (1)-->(2-5)
@@ -441,19 +441,19 @@ build
 SELECT x, x, y FROM a EXCEPT ALL SELECT x, z, z FROM (SELECT * FROM b WHERE b.x=1) b
 ----
 except-all
- ├── columns: x:1(int!null) x:1(int!null) y:2(int)
- ├── left columns: a.x:1(int!null) a.x:1(int!null) y:2(int)
+ ├── columns: x:12(int!null) x:13(int!null) y:14(int)
+ ├── left columns: a.x:1(int) a.x:1(int) a.y:2(int)
  ├── right columns: b.x:6(int) z:7(int) z:7(int)
  ├── stats: [rows=5000]
- ├── key: (1)
- ├── fd: (1)-->(2)
+ ├── key: (13)
+ ├── fd: (12,13)-->(14), (12)==(13), (13)==(12)
  ├── project
- │    ├── columns: a.x:1(int!null) y:2(int)
+ │    ├── columns: a.x:1(int!null) a.y:2(int)
  │    ├── stats: [rows=5000]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2)
  │    └── scan a
- │         ├── columns: a.x:1(int!null) y:2(int) a.s:3(string) a.crdb_internal_mvcc_timestamp:4(decimal) a.tableoid:5(oid)
+ │         ├── columns: a.x:1(int!null) a.y:2(int) a.s:3(string) a.crdb_internal_mvcc_timestamp:4(decimal) a.tableoid:5(oid)
  │         ├── stats: [rows=5000]
  │         ├── key: (1)
  │         └── fd: (1)-->(2-5)

--- a/pkg/sql/opt/optbuilder/testdata/union
+++ b/pkg/sql/opt/optbuilder/testdata/union
@@ -1029,3 +1029,53 @@ union
       │         └── columns: i8:9 i4:10 ab.f8:11 f4:12 ab.d:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
       └── projections
            └── ab.f8:11::DECIMAL [as=f8:17]
+
+# Regression test for #68702. When a column is projected twice on the left side,
+# assign new column IDs for the output columns.
+exec-ddl
+CREATE TABLE t68702 (a INT, b INT, c INT, INDEX (a, b, c DESC))
+----
+
+# This is the same error as Postgres.
+build
+SELECT a, b, b FROM t68702 EXCEPT SELECT a, b, c FROM t68702 ORDER by a, b
+----
+error (42P09): ORDER BY "b" is ambiguous
+
+build
+SELECT a, b AS b1, b AS b2 FROM t68702 EXCEPT SELECT a, b, c FROM t68702 ORDER by a, b1
+----
+sort
+ ├── columns: a:13 b1:14 b2:15
+ ├── ordering: +13,+14
+ └── except
+      ├── columns: a:13 b1:14 b2:15
+      ├── left columns: t68702.a:1 b:2 b:2
+      ├── right columns: t68702.a:7 b:8 c:9
+      ├── project
+      │    ├── columns: t68702.a:1 b:2
+      │    └── scan t68702
+      │         └── columns: t68702.a:1 b:2 c:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+      └── project
+           ├── columns: t68702.a:7 b:8 c:9
+           └── scan t68702
+                └── columns: t68702.a:7 b:8 c:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+
+build
+SELECT a, b AS b1, b AS b2 FROM t68702 INTERSECT SELECT a, c, b FROM t68702 ORDER by a, b2
+----
+sort
+ ├── columns: a:13 b1:14 b2:15
+ ├── ordering: +13,+15
+ └── intersect
+      ├── columns: a:13 b1:14 b2:15
+      ├── left columns: t68702.a:1 b:2 b:2
+      ├── right columns: t68702.a:7 c:9 b:8
+      ├── project
+      │    ├── columns: t68702.a:1 b:2
+      │    └── scan t68702
+      │         └── columns: t68702.a:1 b:2 c:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+      └── project
+           ├── columns: t68702.a:7 b:8 c:9
+           └── scan t68702
+                └── columns: t68702.a:7 b:8 c:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12

--- a/pkg/sql/opt/props/func_dep.go
+++ b/pkg/sql/opt/props/func_dep.go
@@ -677,6 +677,9 @@ func (f *FuncDepSet) ComputeClosure(cols opt.ColSet) opt.ColSet {
 
 // AreColsEquiv returns true if the two given columns are equivalent.
 func (f *FuncDepSet) AreColsEquiv(col1, col2 opt.ColumnID) bool {
+	if col1 == col2 {
+		return true
+	}
 	for i := range f.deps {
 		fd := &f.deps[i]
 


### PR DESCRIPTION
This commit fixes an internal error that could occur when a set operation
such as `EXCEPT` or `INTERSECT` had a left side column projected multiple times
and the set op was executed with a streaming operation. This was happening
due to the fact that we were using the same column IDs as the left side
columns for the output columns. If the same column ID was used multiple
times (due to multiple projections), it was not possible to match the merge
ordering columns to output ordinals at execbuild time. This commit fixes
the problem by assigning new column IDs to the output columns in the
optbuilder if any left column is projected twice. This is similar to the
logic we already use for `UNION` in assigning new column IDs to the output
columns.

Fixes #68702

There is no release note since this bug has not been part of any release.

Release note: None

Release justification: fixes a bug in existing functionality that would
be a regression from prior releases.