### PR TITLE
backupccl: throw warning if SHOW BACKUP points to collection

### DIFF
--- a/pkg/ccl/backupccl/manifest_handling.go
+++ b/pkg/ccl/backupccl/manifest_handling.go
@@ -640,6 +640,21 @@ func FindPriorBackups(
 	return prev, nil
 }
 
+// checkForLatestFileInCollection checks whether the directory pointed by store contains the
+// latestFileName pointer directory.
+func checkForLatestFileInCollection(
+	ctx context.Context, store cloud.ExternalStorage,
+) (bool, error) {
+	_, err := store.ReadFile(ctx, latestFileName)
+	if err != nil {
+		if errors.Is(err, cloud.ErrFileDoesNotExist) {
+			return false, nil
+		}
+		return false, pgerror.WithCandidateCode(err, pgcode.Io)
+	}
+	return true, nil
+}
+
 // resolveBackupManifests resolves a list of list of URIs that point to the
 // incremental layers (each of which can be partitioned) of backups into the
 // actual backup manifests and metadata required to RESTORE. If only one layer

--- a/pkg/ccl/backupccl/show_test.go
+++ b/pkg/ccl/backupccl/show_test.go
@@ -651,3 +651,21 @@ func TestShowBackupWithDebugIDs(t *testing.T) {
 	require.Equal(t, expectedObjects, res)
 
 }
+
+func TestShowBackupPathIsCollectionRoot(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	const numAccounts = 11
+
+	// Create test database with bank table.
+	_, _, sqlDB, _, cleanupFn := BackupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)
+	defer cleanupFn()
+
+	// Make an initial backup.
+	sqlDB.Exec(t, `BACKUP data.bank INTO $1`, LocalFoo)
+
+	// Ensure proper error gets returned from back SHOW BACKUP Path
+	sqlDB.ExpectErr(t, "The specified path is the root of a backup collection.",
+		"SHOW BACKUP $1", LocalFoo)
+}


### PR DESCRIPTION
Prior to 21.1 we only supported BACKUP TO a particular user-specified directory.
At that time, SHOW BACKUP pointed to the backup directory and was the only way
to view metadata about a particular backup. With the addition of BACKUP INTO and
the concept of collections we now have two flavours of SHOW, namely SHOW BACKUP
and SHOW BACKUPS IN. The former still unwraps the metadata of a backup, while
the latter lists paths to all the backups that are part of a collection, thereby
allowing a user to then run SHOW BACKUP against one of those paths.

A frequent stumbling block for users of SHOW BACKUP has been when they run the
command against the top-level directory of a backup collection, instead of
against a specific backup directory. Before, the show command returned a
non-descriptive error. Now, we hint to users to use SHOW BACKUPS IN followed by
SHOW BACKUP.

Fixes: #69568, #55266

Release Note (sql change): add a hint to the error the user receives when they
call SHOW BACKUP with a path pointing to the root of the collection, rather than
a specific backup in the collection.
    
Release justification: low risk, high benefit changes to existing functionality

