### PR TITLE
bazel,ci: mount workspace as writeable in bazel builder container

### DIFF
--- a/build/teamcity-check-genfiles.sh
+++ b/build/teamcity-check-genfiles.sh
@@ -27,7 +27,6 @@ if ! run run_bazel build/bazelutil/check.sh &> artifacts/buildshort.log || (cat 
     exit 1
 fi
 rm artifacts/buildshort.log
-TEAMCITY_BAZEL_SUPPORT_GENERATE=1  # See teamcity-bazel-support.sh.
 run run_bazel build/bazelutil/bazel-generate.sh &> artifacts/buildshort.log || (cat artifacts/buildshort.log && false)
 rm artifacts/buildshort.log
 check_clean "Run \`./dev generate bazel\` to automatically regenerate these."

--- a/pkg/cmd/dev/builder.go
+++ b/pkg/cmd/dev/builder.go
@@ -80,7 +80,7 @@ func (d *dev) getDockerRunArgs(
 	if err != nil {
 		return
 	}
-	args = append(args, "-v", workspace+":/cockroach:ro")
+	args = append(args, "-v", workspace+":/cockroach")
 	args = append(args, "--workdir=/cockroach")
 	// Create the artifacts directory.
 	artifacts := filepath.Join(workspace, "artifacts")

--- a/pkg/cmd/dev/testdata/builder.txt
+++ b/pkg/cmd/dev/testdata/builder.txt
@@ -8,4 +8,4 @@ docker volume inspect bzlcache
 bazel info workspace --color=no --config=dev
 mkdir go/src/github.com/cockroachdb/cockroach/artifacts
 cat go/src/github.com/cockroachdb/cockroach/build/teamcity-bazel-support.sh
-docker run --rm -it -v go/src/github.com/cockroachdb/cockroach:/cockroach:ro --workdir=/cockroach -v go/src/github.com/cockroachdb/cockroach/artifacts:/artifacts -v bzlcache:/root/.cache/bazel:delegated mock_bazel_image:1234
+docker run --rm -it -v go/src/github.com/cockroachdb/cockroach:/cockroach --workdir=/cockroach -v go/src/github.com/cockroachdb/cockroach/artifacts:/artifacts -v bzlcache:/root/.cache/bazel:delegated mock_bazel_image:1234

--- a/pkg/cmd/dev/testdata/recording/builder.txt
+++ b/pkg/cmd/dev/testdata/recording/builder.txt
@@ -27,5 +27,5 @@ cat go/src/github.com/cockroachdb/cockroach/build/teamcity-bazel-support.sh
 ----
 BAZEL_IMAGE=mock_bazel_image:1234
 
-docker run --rm -it -v go/src/github.com/cockroachdb/cockroach:/cockroach:ro --workdir=/cockroach -v go/src/github.com/cockroachdb/cockroach/artifacts:/artifacts -v bzlcache:/root/.cache/bazel:delegated mock_bazel_image:1234
+docker run --rm -it -v go/src/github.com/cockroachdb/cockroach:/cockroach --workdir=/cockroach -v go/src/github.com/cockroachdb/cockroach/artifacts:/artifacts -v bzlcache:/root/.cache/bazel:delegated mock_bazel_image:1234
 ----


### PR DESCRIPTION
Until today we haven't had a reason not to mount the workspace as
read-only, but since the UI build will write `node_modules` to the
workspace, this needs to change moving forward.

Release justification: Non-production code change
Release note: None