### PR TITLE
release-21.1: backupccl: fix restore aost bug with dropped desc revisions

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -8174,3 +8174,43 @@ DROP INDEX idx_3;
 
 	sqlDB.Exec(t, `BACKUP test.t TO 'nodelocal://1/backup_test' WITH revision_history`)
 }
+
+// TestDroppedDescriptorRevisionAndSystemDBIDClash is a regression test for a
+// discrepancy in the descriptor resolution logic during restore planning and
+// execution.
+//
+// While the resolution logic in restore planning filtered out descriptor
+// revisions in the dropped state, the logic in execution did not do this. As a
+// a result of this, the restore job would process additional descriptors (the
+// dropped revisions). In the case of full cluster restores, the planning phase
+// picks an id higher than all restored desc ids, for the tempSystemDB. The
+// additional dropped descriptor revisions during execution could have the same
+// id as the tempSystemDB. This id clash would cause issues when processing
+// descriptor rewrites which are keyed on the descriptor id.
+//
+// Table and database restores are not affected by this bug since we filter the
+// descriptors during execution based on the descriptor rewrites we allocated in
+// planning. Since no additional entries for system tables are added to the
+// rewrites, we expect to filter out all dropped revisions since there will be
+// no rewrites allocated for them in the first place.
+func TestDroppedDescriptorRevisionAndSystemDBIDClash(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	_, _, sqlDB, tempDir, cleanupFn := BackupRestoreTestSetup(t, singleNode, 1, InitManualReplication)
+	defer cleanupFn()
+
+	sqlDB.Exec(t, `
+CREATE TABLE foo (id INT);
+BACKUP TO 'nodelocal://0/foo' WITH revision_history;
+DROP TABLE foo;
+`)
+
+	var aost string
+	sqlDB.QueryRow(t, "SELECT cluster_logical_timestamp()").Scan(&aost)
+	sqlDB.Exec(t, `BACKUP TO $1 WITH revision_history`, LocalFoo)
+
+	_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir,
+		InitManualReplication, base.TestClusterArgs{})
+	defer cleanupEmptyCluster()
+	sqlDBRestore.Exec(t, "RESTORE FROM $1 AS OF SYSTEM TIME "+aost, LocalFoo)
+}

--- a/pkg/ccl/backupccl/manifest_handling.go
+++ b/pkg/ccl/backupccl/manifest_handling.go
@@ -834,6 +834,12 @@ func getBackupIndexAtTime(backupManifests []BackupManifest, asOf hlc.Timestamp) 
 	return backupManifestIndex, nil
 }
 
+// loadSQLDescsFromBackupsAtTime is the common method used during restore
+// planning and execution to resolve the descriptors from the appropriate
+// backup.
+// The method identifies the appropriate backup manifest, descriptors, and
+// descriptor changes, and filters out descriptor revisions that we do not
+// require during the restore.
 func loadSQLDescsFromBackupsAtTime(
 	backupManifests []BackupManifest, asOf hlc.Timestamp,
 ) ([]catalog.Descriptor, BackupManifest) {
@@ -878,8 +884,14 @@ func loadSQLDescsFromBackupsAtTime(
 		// backed up -- if the DB is missing, filter the object.
 		desc := catalogkv.NewBuilder(raw).BuildExistingMutable()
 		var isObject bool
-		switch desc.(type) {
-		case catalog.TableDescriptor, catalog.TypeDescriptor, catalog.SchemaDescriptor:
+		switch d := desc.(type) {
+		case catalog.TableDescriptor:
+			// Filter out revisions in the dropped state.
+			if d.GetState() == descpb.DescriptorState_DROP {
+				continue
+			}
+			isObject = true
+		case catalog.TypeDescriptor, catalog.SchemaDescriptor:
 			isObject = true
 		}
 		if isObject && byID[desc.GetParentID()] == nil {


### PR DESCRIPTION
This is a fix for a discrepancy in the descriptor resolution
logic during restore planning and execution, for a full cluster restore.

While the resolution logic in restore planning filtered out descriptor
revisions in the dropped state, the logic in execution did not do this. As a
a result of this, the restore job would process additional descriptors (the
dropped revisions). In the case of full cluster restores, the planning phase
picks an id higher than all restored desc ids, for the tempSystemDB. The
additional dropped descriptor revisions during execution could have the same
id as the tempSystemDB. This id clash would cause issues when processing
descriptor rewrites which are keyed on the descriptor id.

Table and database restores are not affected by this bug since we filter the
descriptors during execution based on the descriptor rewrites we allocated in
planning. Since no additional entries for system tables are added to the
rewrites, we expect to filter out all dropped revisions since there will be
no rewrites allocated for them in the first place.

Release note (bug fix): Fixes a bug in full cluster restores where
dropped descriptor revisions would cause the restore to fail.

Release justification: Fixes a bug in full cluster restore where dropped
descriptor revisions were causing restore jobs to fail.