### PR TITLE
util: add ip addr test for Postgres compatibility.

### DIFF
--- a/pkg/util/ipaddr/ipaddr_test.go
+++ b/pkg/util/ipaddr/ipaddr_test.go
@@ -79,6 +79,9 @@ func TestIPAddrParseInet(t *testing.T) {
 		{"192/10", &IPAddr{Family: IPv4family, Addr: Addr(uint128.FromBytes([]byte(net.ParseIP("192.0.0.0")))), Mask: 10}, ""},
 		{"192.168/23", &IPAddr{Family: IPv4family, Addr: Addr(uint128.FromBytes([]byte(net.ParseIP("192.168.0.0")))), Mask: 23}, ""},
 		{"192.168./10", &IPAddr{Family: IPv4family, Addr: Addr(uint128.FromBytes([]byte(net.ParseIP("192.168.0.0")))), Mask: 10}, ""},
+
+		// Postgres allows leading 0s, '10.0.0.017'::INET parses as 10.0.0.17
+		{"10.0.0.017", &IPAddr{Family: IPv4family, Addr: Addr(uint128.FromBytes([]byte(net.ParseIP("10.0.0.17")))), Mask: 32}, ""},
 	}
 	for i, testCase := range testCases {
 		var actual IPAddr


### PR DESCRIPTION
go1.17 is changing how IPs are parsed, leading 0s will not be accepted.
This test will ensure we don't upgrade to go1.17 causing a regression
before making an update to the ip address parsing fix introduced in go1.17.

Release justification: test only change
Release note: None

References #68578 