### PR TITLE
sql: refactor Reset() method for sqlstats's stats collector

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -809,6 +809,7 @@ func (s *Server) newConnExecutor(
 	ex.dataMutatorIterator.onApplicationNameChange = func(newName string) {
 		ex.applicationName.Store(newName)
 		ex.statsWriter = ex.server.sqlStats.GetWriterForApplication(newName)
+		ex.statsCollector.ResetWriter(ex.statsWriter)
 	}
 
 	ex.phaseTimes.SetSessionPhaseTime(sessionphase.SessionInit, timeutil.Now())
@@ -2136,7 +2137,7 @@ func (ex *connExecutor) execCopyIn(
 		// state machine, but the copyMachine manages its own transactions without
 		// going through the state machine.
 		ex.state.sqlTimestamp = txnTS
-		ex.statsCollector.Reset(ex.statsWriter, ex.phaseTimes)
+		ex.statsCollector.ResetPhaseTime(ex.phaseTimes)
 		ex.initPlanner(ctx, p)
 		ex.resetPlanner(ctx, p, txn, stmtTS)
 	}

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -91,7 +91,7 @@ func (ex *connExecutor) execStmt(
 	// Run observer statements in a separate code path; their execution does not
 	// depend on the current transaction state.
 	if _, ok := ast.(tree.ObserverStatement); ok {
-		ex.statsCollector.Reset(ex.statsWriter, ex.phaseTimes)
+		ex.statsCollector.ResetPhaseTime(ex.phaseTimes)
 		err := ex.runObserverStatement(ctx, ast, res)
 		// Note that regardless of res.Err(), these observer statements don't
 		// generate error events; transactions are always allowed to continue.
@@ -363,7 +363,7 @@ func (ex *connExecutor) execStmtInOpenState(
 
 	p := &ex.planner
 	stmtTS := ex.server.cfg.Clock.PhysicalTime()
-	ex.statsCollector.Reset(ex.statsWriter, ex.phaseTimes)
+	ex.statsCollector.ResetPhaseTime(ex.phaseTimes)
 	ex.resetPlanner(ctx, p, ex.state.mu.txn, stmtTS)
 	p.sessionDataMutatorIterator.paramStatusUpdater = res
 	p.noticeSender = res
@@ -1371,7 +1371,7 @@ func (ex *connExecutor) beginTransactionTimestampsAndReadMode(
 		rwMode = ex.readWriteModeWithSessionDefault(modes.ReadWriteMode)
 		return rwMode, now, nil, nil
 	}
-	ex.statsCollector.Reset(ex.statsWriter, ex.phaseTimes)
+	ex.statsCollector.ResetPhaseTime(ex.phaseTimes)
 	p := &ex.planner
 
 	// NB: this use of p.txn is totally bogus. The planner's txn should

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -161,7 +161,7 @@ func (ex *connExecutor) prepare(
 
 	var flags planFlags
 	prepare := func(ctx context.Context, txn *kv.Txn) (err error) {
-		ex.statsCollector.Reset(ex.statsWriter, ex.phaseTimes)
+		ex.statsCollector.ResetPhaseTime(ex.phaseTimes)
 		p := &ex.planner
 		if origin != PreparedStatementOriginSQL {
 			// If the PREPARE command was issued as a SQL statement, then we

--- a/pkg/sql/sqlstats/sslocal/sslocal_stats_collector.go
+++ b/pkg/sql/sqlstats/sslocal/sslocal_stats_collector.go
@@ -48,12 +48,13 @@ func (s *statsCollector) PreviousPhaseTimes() *sessionphase.Times {
 	return s.previousPhaseTimes
 }
 
-// Reset implements sqlstats.StatsCollector interface.
-func (s *statsCollector) Reset(writer sqlstats.Writer, phaseTime *sessionphase.Times) {
-	previousPhaseTime := s.phaseTimes
-	*s = statsCollector{
-		Writer:             writer,
-		previousPhaseTimes: previousPhaseTime,
-		phaseTimes:         phaseTime.Clone(),
-	}
+// ResetPhaseTime implements sqlstats.StatsCollector interface.
+func (s *statsCollector) ResetPhaseTime(phaseTime *sessionphase.Times) {
+	s.previousPhaseTimes = s.phaseTimes
+	s.phaseTimes = phaseTime.Clone()
+}
+
+// ResetWriter implements sqlstats.StatsCollector interface.
+func (s *statsCollector) ResetWriter(writer sqlstats.Writer) {
+	s.Writer = writer
 }

--- a/pkg/sql/sqlstats/ssprovider.go
+++ b/pkg/sql/sqlstats/ssprovider.go
@@ -126,9 +126,11 @@ type StatsCollector interface {
 	// was previously tracking before being Reset.
 	PreviousPhaseTimes() *sessionphase.Times
 
-	// Reset resets the StatsCollector with a new Writer and a new copy of the
-	// sessionphase.Times.
-	Reset(Writer, *sessionphase.Times)
+	// ResetPhaseTime resets the sessionphase.Times tracked by the StatsCollector.
+	ResetPhaseTime(*sessionphase.Times)
+
+	// ResetWriter resets the Writer used by the StatsCollector.
+	ResetWriter(Writer)
 }
 
 // Storage provides clients with interface to perform read and write operations


### PR DESCRIPTION
Previously, SQL Stat's Stats Collector uses a single Reset()
method to reset both StatsWriter as well as phase time. This
is unnecessary since most of the time we would only need to
reset phase time. This also introduces problem for us later
when we need to use a temporary StatsWriter to track explict
transactions.
This commit splits the Reset() method into two separate method,
ResetPhaseTime() and ResetWriter().

Release justification: Bug fixes and low-risk updates to new
functionality

Release note: None