### PR TITLE
spanconfig: introduce the spanconfig.SQLWatcher

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -182,6 +182,7 @@ ALL_TESTS = [
     "//pkg/settings:settings_test",
     "//pkg/spanconfig/spanconfigkvaccessor:spanconfigkvaccessor_test",
     "//pkg/spanconfig/spanconfigmanager:spanconfigmanager_test",
+    "//pkg/spanconfig/spanconfigsqlwatcher:spanconfigsqlwatcher_test",
     "//pkg/spanconfig/spanconfigstore:spanconfigstore_test",
     "//pkg/sql/catalog/catalogkeys:catalogkeys_test",
     "//pkg/sql/catalog/catformat:catformat_test",

--- a/pkg/ccl/changefeedccl/helpers_tenant_shim_test.go
+++ b/pkg/ccl/changefeedccl/helpers_tenant_shim_test.go
@@ -71,6 +71,7 @@ func (t *testServerShim) DistSenderI() interface{}              { panic(unsuppor
 func (t *testServerShim) MigrationServer() interface{}          { panic(unsupportedShimMethod) }
 func (t *testServerShim) SpanConfigAccessor() interface{}       { panic(unsupportedShimMethod) }
 func (t *testServerShim) SpanConfigSQLTranslator() interface{}  { panic(unsupportedShimMethod) }
+func (t *testServerShim) SpanConfigSQLWatcher() interface{}     { panic(unsupportedShimMethod) }
 func (t *testServerShim) SQLServer() interface{}                { panic(unsupportedShimMethod) }
 func (t *testServerShim) SQLLivenessProvider() interface{}      { panic(unsupportedShimMethod) }
 func (t *testServerShim) StartupMigrationsManager() interface{} { panic(unsupportedShimMethod) }

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -115,6 +115,7 @@ go_library(
         "//pkg/spanconfig/spanconfigkvaccessor",
         "//pkg/spanconfig/spanconfigmanager",
         "//pkg/spanconfig/spanconfigsqltranslator",
+        "//pkg/spanconfig/spanconfigsqlwatcher",
         "//pkg/sql",
         "//pkg/sql/catalog/bootstrap",
         "//pkg/sql/catalog/catalogkeys",

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -53,6 +53,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigmanager"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigsqltranslator"
+	"github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigsqlwatcher"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
@@ -842,6 +843,12 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		// only do it if COCKROACH_EXPERIMENTAL_SPAN_CONFIGS is set.
 		spanConfigKnobs, _ := cfg.TestingKnobs.SpanConfig.(*spanconfig.TestingKnobs)
 		sqlTranslator := spanconfigsqltranslator.New(execCfg, codec)
+		sqlWatcher := spanconfigsqlwatcher.New(
+			codec,
+			cfg.Settings,
+			cfg.rangeFeedFactory,
+			cfg.stopper,
+		)
 		spanConfigMgr = spanconfigmanager.New(
 			cfg.db,
 			jobRegistry,
@@ -849,6 +856,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 			cfg.stopper,
 			cfg.Settings,
 			cfg.spanConfigAccessor,
+			sqlWatcher,
 			sqlTranslator,
 			spanConfigKnobs,
 		)

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -962,6 +962,16 @@ func (ts *TestServer) SpanConfigSQLTranslator() interface{} {
 	return ts.sqlServer.spanconfigMgr.SQLTranslator
 }
 
+// SpanConfigSQLWatcher is part of TestServerInterface.
+func (ts *TestServer) SpanConfigSQLWatcher() interface{} {
+	if ts.sqlServer.spanconfigMgr == nil {
+		panic(
+			"span config manager uninitialized; see EnableSpanConfigs testing knob to use span configs",
+		)
+	}
+	return ts.sqlServer.spanconfigMgr.SQLWatcher
+}
+
 // SQLServer is part of TestServerInterface.
 func (ts *TestServer) SQLServer() interface{} {
 	return ts.PGServer().SQLServer

--- a/pkg/spanconfig/BUILD.bazel
+++ b/pkg/spanconfig/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//pkg/base",
         "//pkg/keys",
         "//pkg/roachpb:with-mocks",
+        "//pkg/sql/catalog",
         "//pkg/sql/catalog/descpb",
         "//pkg/util/hlc",
     ],

--- a/pkg/spanconfig/spanconfigmanager/BUILD.bazel
+++ b/pkg/spanconfig/spanconfigmanager/BUILD.bazel
@@ -41,6 +41,7 @@ go_test(
         "//pkg/server",
         "//pkg/settings/cluster",
         "//pkg/spanconfig",
+        "//pkg/spanconfig/testspanconfig",
         "//pkg/sql",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",

--- a/pkg/spanconfig/spanconfigmanager/manager.go
+++ b/pkg/spanconfig/spanconfigmanager/manager.go
@@ -60,6 +60,7 @@ type Manager struct {
 	knobs    *spanconfig.TestingKnobs
 
 	spanconfig.KVAccessor
+	spanconfig.SQLWatcher
 	spanconfig.SQLTranslator
 }
 
@@ -73,6 +74,7 @@ func New(
 	stopper *stop.Stopper,
 	settings *cluster.Settings,
 	kvAccessor spanconfig.KVAccessor,
+	sqlWatcher spanconfig.SQLWatcher,
 	sqlTranslator spanconfig.SQLTranslator,
 	knobs *spanconfig.TestingKnobs,
 ) *Manager {
@@ -86,6 +88,7 @@ func New(
 		stopper:       stopper,
 		settings:      settings,
 		KVAccessor:    kvAccessor,
+		SQLWatcher:    sqlWatcher,
 		SQLTranslator: sqlTranslator,
 		knobs:         knobs,
 	}

--- a/pkg/spanconfig/spanconfigmanager/manager_test.go
+++ b/pkg/spanconfig/spanconfigmanager/manager_test.go
@@ -74,6 +74,7 @@ func TestManagerConcurrentJobCreation(t *testing.T) {
 		ts.Stopper(),
 		ts.ClusterSettings(),
 		ts.SpanConfigAccessor().(spanconfig.KVAccessor),
+		ts.SpanConfigSQLWatcher().(spanconfig.SQLWatcher),
 		ts.SpanConfigSQLTranslator().(spanconfig.SQLTranslator),
 		&spanconfig.TestingKnobs{
 			ManagerCreatedJobInterceptor: func(jobI interface{}) {
@@ -162,6 +163,7 @@ func TestManagerStartsJobIfFailed(t *testing.T) {
 		ts.Stopper(),
 		ts.ClusterSettings(),
 		ts.SpanConfigAccessor().(spanconfig.KVAccessor),
+		ts.SpanConfigSQLWatcher().(spanconfig.SQLWatcher),
 		ts.SpanConfigSQLTranslator().(spanconfig.SQLTranslator),
 		&spanconfig.TestingKnobs{
 			ManagerAfterCheckedReconciliationJobExistsInterceptor: func(exists bool) {
@@ -237,6 +239,7 @@ func TestManagerCheckJobConditions(t *testing.T) {
 		ts.Stopper(),
 		ts.ClusterSettings(),
 		ts.SpanConfigAccessor().(spanconfig.KVAccessor),
+		ts.SpanConfigSQLWatcher().(spanconfig.SQLWatcher),
 		ts.SpanConfigSQLTranslator().(spanconfig.SQLTranslator),
 		&spanconfig.TestingKnobs{
 			ManagerDisableJobCreation: true,

--- a/pkg/spanconfig/spanconfigsqlwatcher/BUILD.bazel
+++ b/pkg/spanconfig/spanconfigsqlwatcher/BUILD.bazel
@@ -1,0 +1,62 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "spanconfigsqlwatcher",
+    srcs = [
+        "event_buffer.go",
+        "sql_watcher.go",
+        "zones_decoder.go",
+    ],
+    importpath = "github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigsqlwatcher",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/keys",
+        "//pkg/kv/kvclient/rangefeed:with-mocks",
+        "//pkg/roachpb:with-mocks",
+        "//pkg/settings/cluster",
+        "//pkg/spanconfig",
+        "//pkg/sql/catalog",
+        "//pkg/sql/catalog/descpb",
+        "//pkg/sql/catalog/systemschema",
+        "//pkg/sql/rowenc",
+        "//pkg/sql/sem/tree",
+        "//pkg/sql/types",
+        "//pkg/util/hlc",
+        "//pkg/util/log",
+        "//pkg/util/log/logcrash",
+        "//pkg/util/stop",
+        "//pkg/util/syncutil",
+        "@com_github_cockroachdb_errors//:errors",
+    ],
+)
+
+go_test(
+    name = "spanconfigsqlwatcher_test",
+    srcs = [
+        "event_buffer_test.go",
+        "main_test.go",
+        "sql_watcher_test.go",
+        "zones_decoder_test.go",
+    ],
+    embed = [":spanconfigsqlwatcher"],
+    deps = [
+        "//pkg/base",
+        "//pkg/config/zonepb",
+        "//pkg/jobs",
+        "//pkg/keys",
+        "//pkg/kv/kvclient/rangefeed:with-mocks",
+        "//pkg/security",
+        "//pkg/security/securitytest",
+        "//pkg/server",
+        "//pkg/spanconfig",
+        "//pkg/sql/catalog",
+        "//pkg/sql/catalog/descpb",
+        "//pkg/testutils/serverutils",
+        "//pkg/testutils/testcluster",
+        "//pkg/util/hlc",
+        "//pkg/util/leaktest",
+        "//pkg/util/protoutil",
+        "@com_github_gogo_protobuf//proto",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/spanconfig/spanconfigsqlwatcher/event_buffer.go
+++ b/pkg/spanconfig/spanconfigsqlwatcher/event_buffer.go
@@ -1,0 +1,157 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package spanconfigsqlwatcher
+
+import (
+	"container/heap"
+
+	"github.com/cockroachdb/cockroach/pkg/spanconfig"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+)
+
+// eventBuffer is a helper struct for the SQLWatcher intended to keep track of
+// and buffer events resulting from rangefeeds over system.zones and
+// system.descriptors. All methods lock internally, so they can be called
+// concurrently.
+//
+// The eventBuffer maintains the notion of a checkpointTS, computed as the
+// minimum checkpoint timestamps for the zones and descriptors event channels.
+// Internally, it uses a heap to return all events below this checkpointTS.
+type eventBuffer struct {
+	mu struct {
+		syncutil.Mutex
+
+		eventInfoHeap eventInfoHeap
+
+		eventChannelCheckpointTSs [numEventChannels]hlc.Timestamp
+	}
+}
+
+// eventChannel is used to represent the rangefeed channel from which the
+// watcher's event originated from.
+type eventChannel int
+
+const (
+	zonesEventChannel eventChannel = iota
+	descriptorsEventChannel
+
+	// numEventChannels should be listed last.
+	numEventChannels
+)
+
+// newEventBuffer constructs and returns a new eventBuffer.
+func newEventBuffer() *eventBuffer {
+	return &eventBuffer{}
+}
+
+// recordRangefeedEvent records the given rangefeedEvent in the eventBuffer.
+func (b *eventBuffer) recordRangefeedEvent(rangefeedEvent watcherRangefeedEvent) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if rangefeedEvent.isCheckpoint {
+		b.mu.eventChannelCheckpointTSs[rangefeedEvent.eventChannel].Forward(rangefeedEvent.timestamp)
+		return
+	}
+	if rangefeedEvent.timestamp.Less(b.mu.eventChannelCheckpointTSs[rangefeedEvent.eventChannel]) {
+		// If the rangefeedEvent is at a timestamp below the checkpoint then we
+		// don't need to record it.
+		return
+	}
+	eventInfo := &eventInfo{
+		event: spanconfig.SQLWatcherEvent{
+			ID:             rangefeedEvent.id,
+			DescriptorType: rangefeedEvent.descriptorType,
+		},
+		timestamp: rangefeedEvent.timestamp,
+	}
+	heap.Push(&b.mu.eventInfoHeap, eventInfo)
+}
+
+// flushSQLWatcherEventsBelowCheckpoint returns a list of unique
+// spanconfig.SQLWatcher events below the event buffer's checkpoint timestamp.
+// The checkpoint timestamp is also returned.
+func (b *eventBuffer) flushSQLWatcherEventsBelowCheckpoint() (
+	events []spanconfig.SQLWatcherEvent,
+	checkpointTS hlc.Timestamp,
+) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	seenIDs := make(map[descpb.ID]struct{})
+	// First we determine the checkpoint timestamp, which is the minimum
+	// checkpoint timestamp of all event types.
+	checkpointTS = hlc.MaxTimestamp
+	for _, ts := range b.mu.eventChannelCheckpointTSs {
+		checkpointTS.Backward(ts)
+	}
+
+	// Next we accumulate all IDs for which we have received events at timestamps
+	// less than than or equal to the checkpoint timestamp.
+	for {
+		if len(b.mu.eventInfoHeap) == 0 || !b.mu.eventInfoHeap[0].timestamp.LessEq(checkpointTS) {
+			break
+		}
+
+		eventInfo := heap.Pop(&b.mu.eventInfoHeap).(*eventInfo)
+		// De-duplicate IDs from the returned result.
+		if _, seen := seenIDs[eventInfo.event.ID]; !seen {
+			seenIDs[eventInfo.event.ID] = struct{}{}
+			events = append(events, eventInfo.event)
+		}
+	}
+
+	return events, checkpointTS
+}
+
+// eventInfo is a SQLWatcherEvent <-> timestamp pair corresponding to an event
+// received by the eventBuffer.
+type eventInfo struct {
+	event spanconfig.SQLWatcherEvent
+
+	timestamp hlc.Timestamp
+}
+
+// eventInfoHeap is a min heap based on timestamp.
+type eventInfoHeap []*eventInfo
+
+var _ heap.Interface = (*eventInfoHeap)(nil)
+
+// Len is part of heap.Interface.
+func (ih *eventInfoHeap) Len() int {
+	return len(*ih)
+}
+
+// Less is part of heap.Interface.
+func (ih *eventInfoHeap) Less(i, j int) bool {
+	return (*ih)[i].timestamp.Less((*ih)[j].timestamp)
+}
+
+// Swap is part of heap.Interface.
+func (ih *eventInfoHeap) Swap(i, j int) {
+	(*ih)[i], (*ih)[j] = (*ih)[j], (*ih)[i]
+}
+
+// Push is part of heap.Interface.
+func (ih *eventInfoHeap) Push(x interface{}) {
+	item := x.(*eventInfo)
+	*ih = append(*ih, item)
+}
+
+// Pop is part of heap.Interface.
+func (ih *eventInfoHeap) Pop() interface{} {
+	old := *ih
+	n := len(old)
+	item := old[n-1]
+	old[n-1] = nil
+	*ih = old[0 : n-1]
+	return item
+}

--- a/pkg/spanconfig/spanconfigsqlwatcher/event_buffer_test.go
+++ b/pkg/spanconfig/spanconfigsqlwatcher/event_buffer_test.go
@@ -1,0 +1,151 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package spanconfigsqlwatcher
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/spanconfig"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEventBuffer sends forth descriptor/zones rangefeed events to the event
+// buffer and ensures the checkpointing and ID flushing semantics work
+// correctly.
+func TestEventBuffer(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ts := func(nanos int) hlc.Timestamp {
+		return hlc.Timestamp{
+			WallTime: int64(nanos),
+		}
+	}
+
+	buffer := newEventBuffer()
+
+	// Sanity check the newly initialized event buffer.
+	events, checkpointTS := buffer.flushSQLWatcherEventsBelowCheckpoint()
+	require.Equal(t, ts(0), checkpointTS)
+	require.True(t, len(events) == 0)
+
+	// Send through some zone and descriptor events that aren't checkpoints.
+	// We don't expect anything to be returned by flushSQLWatcherEventsBelowCheckpoint as
+	// nothing has been checkpointed.
+	buffer.recordRangefeedEvent(watcherRangefeedEvent{
+		id:             1,
+		descriptorType: catalog.Any,
+		eventChannel:   zonesEventChannel,
+		timestamp:      ts(10),
+		isCheckpoint:   false,
+	})
+	buffer.recordRangefeedEvent(watcherRangefeedEvent{
+		id:             2,
+		descriptorType: catalog.Any,
+		eventChannel:   descriptorsEventChannel,
+		timestamp:      ts(11),
+		isCheckpoint:   false,
+	})
+	events, checkpointTS = buffer.flushSQLWatcherEventsBelowCheckpoint()
+	require.Equal(t, ts(0), checkpointTS)
+	require.True(t, len(events) == 0)
+
+	// Send forth a zones checkpoint event. We expect flushSQLWatcherEventsBelowCheckpoint to
+	// still not  return no results as we haven't sent a descriptors checkpoint
+	// yet.
+	buffer.recordRangefeedEvent(watcherRangefeedEvent{
+		eventChannel: zonesEventChannel,
+		timestamp:    ts(11),
+		isCheckpoint: true,
+	})
+	events, checkpointTS = buffer.flushSQLWatcherEventsBelowCheckpoint()
+	require.Equal(t, ts(0), checkpointTS)
+	require.True(t, len(events) == 0)
+
+	// Send forth a descriptors checkpoint event at a lower timestamp than zones
+	// checkpoint timestamp above.
+	// flushSQLWatcherEventsBelowCheckpoint should return the lower timestamp as the
+	// checkpointTS. Furthermore, we only expect one id to be returned.
+	buffer.recordRangefeedEvent(watcherRangefeedEvent{
+		eventChannel: descriptorsEventChannel,
+		timestamp:    ts(10),
+		isCheckpoint: true,
+	})
+	events, checkpointTS = buffer.flushSQLWatcherEventsBelowCheckpoint()
+	require.Equal(t, ts(10), checkpointTS)
+	require.Equal(t, []spanconfig.SQLWatcherEvent{{ID: 1, DescriptorType: catalog.Any}}, events)
+
+	// Bump the descriptors checkpoint past the zones checkpoint. This bumps the
+	// checkpointTS of the eventBuffer to 11 and we end up returning the last ID
+	// in the eventBuffer.
+	buffer.recordRangefeedEvent(watcherRangefeedEvent{
+		eventChannel: descriptorsEventChannel,
+		timestamp:    ts(20),
+		isCheckpoint: true,
+	})
+	events, checkpointTS = buffer.flushSQLWatcherEventsBelowCheckpoint()
+	require.Equal(t, ts(11), checkpointTS)
+	require.Equal(t, []spanconfig.SQLWatcherEvent{{ID: 2, DescriptorType: catalog.Any}}, events)
+
+	// No events are left in the buffer below the checkpoint (which should be the
+	// same as above).
+	events, checkpointTS = buffer.flushSQLWatcherEventsBelowCheckpoint()
+	require.Equal(t, ts(11), checkpointTS)
+	require.True(t, len(events) == 0)
+
+	// Send a checkpoint for zonesEventChannel at a timestamp below what has been
+	// checkpointed (11). This should essentially no-op, which we can check by
+	// asking for the event buffers checkpoint.
+	buffer.recordRangefeedEvent(watcherRangefeedEvent{
+		eventChannel: zonesEventChannel,
+		timestamp:    ts(5),
+		isCheckpoint: true,
+	})
+	events, checkpointTS = buffer.flushSQLWatcherEventsBelowCheckpoint()
+	require.Equal(t, ts(11), checkpointTS)
+	require.True(t, len(events) == 0)
+
+	// Send a non-checkpoint event for zonesEventChannel at a timestamp below what
+	// has been checkpointed (11). This should no-op as well, and the ID should
+	// not be returned when flushing.
+	buffer.recordRangefeedEvent(watcherRangefeedEvent{
+		id:           1,
+		eventChannel: zonesEventChannel,
+		timestamp:    ts(5),
+	})
+	events, checkpointTS = buffer.flushSQLWatcherEventsBelowCheckpoint()
+	require.Equal(t, ts(11), checkpointTS)
+	require.True(t, len(events) == 0)
+
+	// Lastly, ensure that flushing doesn't return duplicate IDs even when more
+	// than one events have been received for a given ID.
+	buffer.recordRangefeedEvent(watcherRangefeedEvent{
+		id:             1,
+		descriptorType: catalog.Any,
+		eventChannel:   zonesEventChannel,
+		timestamp:      ts(12),
+	})
+	buffer.recordRangefeedEvent(watcherRangefeedEvent{
+		id:             1,
+		descriptorType: catalog.Any,
+		eventChannel:   zonesEventChannel,
+		timestamp:      ts(13),
+	})
+	buffer.recordRangefeedEvent(watcherRangefeedEvent{
+		eventChannel: zonesEventChannel,
+		timestamp:    ts(14),
+		isCheckpoint: true,
+	})
+	events, checkpointTS = buffer.flushSQLWatcherEventsBelowCheckpoint()
+	require.Equal(t, ts(14), checkpointTS)
+	require.Equal(t, []spanconfig.SQLWatcherEvent{{ID: 1, DescriptorType: catalog.Any}}, events)
+}

--- a/pkg/spanconfig/spanconfigsqlwatcher/main_test.go
+++ b/pkg/spanconfig/spanconfigsqlwatcher/main_test.go
@@ -1,0 +1,31 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package spanconfigsqlwatcher_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+)
+
+func TestMain(m *testing.M) {
+	security.SetAssetLoader(securitytest.EmbeddedAssets)
+	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
+	os.Exit(m.Run())
+}
+
+//go:generate ../../util/leaktest/add-leaktest.sh *_test.go

--- a/pkg/spanconfig/spanconfigsqlwatcher/sql_watcher.go
+++ b/pkg/spanconfig/spanconfigsqlwatcher/sql_watcher.go
@@ -1,0 +1,303 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package spanconfigsqlwatcher
+
+import (
+	"context"
+	"sync"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/spanconfig"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+)
+
+// SQLWatcher implements the spanconfig.SQLWatcher interface.
+var _ spanconfig.SQLWatcher = &SQLWatcher{}
+
+// SQLWatcher is the concrete implementation of spanconfig.SQLWatcher. It
+// establishes rangefeeds over system.zones and system.descriptors to
+// incrementally watch for SQL events.
+type SQLWatcher struct {
+	codec            keys.SQLCodec
+	settings         *cluster.Settings
+	rangeFeedFactory *rangefeed.Factory
+	stopper          *stop.Stopper
+	eventBuffer      *eventBuffer
+
+	closeOnce sync.Once
+	cancel    context.CancelFunc
+	stopped   chan struct{}
+
+	descriptorsRF *rangefeed.RangeFeed
+	zonesRF       *rangefeed.RangeFeed
+}
+
+// New constructs and returns a SQLWatcher.
+func New(
+	codec keys.SQLCodec,
+	settings *cluster.Settings,
+	rangeFeedFactory *rangefeed.Factory,
+	stopper *stop.Stopper,
+) *SQLWatcher {
+	return &SQLWatcher{
+		codec:            codec,
+		settings:         settings,
+		rangeFeedFactory: rangeFeedFactory,
+		stopper:          stopper,
+		eventBuffer:      newEventBuffer(),
+		stopped:          make(chan struct{}),
+	}
+}
+
+// WatchForSQLUpdates is part of the spanconfig.SQLWatcher interface.
+func (s *SQLWatcher) WatchForSQLUpdates(
+	ctx context.Context, timestamp hlc.Timestamp, handle spanconfig.SQLWatcherHandleFunc,
+) error {
+	updatesCh := make(chan watcherRangefeedEvent)
+	err := s.watchForDescriptorUpdates(ctx, timestamp, updatesCh)
+	if err != nil {
+		log.Warningf(ctx, "error establishing rangefeed over system.descritpors %v", err)
+		return err
+	}
+	err = s.watchForZoneConfigUpdates(ctx, timestamp, updatesCh)
+	if err != nil {
+		log.Warningf(ctx, "error establishing rangefeed over system.zones %v", err)
+		return err
+	}
+
+	ctx, s.cancel = s.stopper.WithCancelOnQuiesce(ctx)
+	if err := s.stopper.RunAsyncTask(ctx, "sql-watcher-rangefeed-consumer", func(ctx context.Context) {
+		defer close(s.stopped)
+		for {
+			var ev watcherRangefeedEvent
+			select {
+			case <-ctx.Done():
+				return
+			case <-s.stopper.ShouldQuiesce():
+				return
+			case ev = <-updatesCh:
+				s.eventBuffer.recordRangefeedEvent(ev)
+			}
+		}
+	}); err != nil {
+		s.cancel()
+		return err
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		// TODO(arul): Should we add a timer here to accumulate updates for some
+		// amount of time before calling the handler?
+		default:
+		}
+		events, checkpointTS := s.eventBuffer.flushSQLWatcherEventsBelowCheckpoint()
+		if len(events) != 0 {
+			if err := handle(events, checkpointTS); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+// Close implements the spanconfig.SQLWatcher interface.
+func (s *SQLWatcher) Close() {
+	s.closeOnce.Do(func() {
+		s.zonesRF.Close()
+		s.descriptorsRF.Close()
+		s.cancel()
+		<-s.stopped
+	})
+}
+
+// watcherRangefeedEvent is the struct produced by the rangefeeds the SQLWatcher
+// establishes over system.zones and system.descriptors.
+type watcherRangefeedEvent struct {
+	// timestamp for which the event was received. It should always be set.
+	timestamp hlc.Timestamp
+
+	// eventChannel represents the channel (zones, descriptors) an event
+	// originated from. It should always be set.
+	eventChannel eventChannel
+
+	// isCheckpoint is set to true iff the event is a checkpoint event.
+	isCheckpoint bool
+
+	// id of the descriptor for which the event was received. It is only set if
+	// the event is not a checkpoint.
+	id descpb.ID
+
+	// descriptorType represents the descriptor type corresponding to the ID above.
+	// It is only set if the event is not a checkpoint.
+	descriptorType catalog.DescriptorType
+}
+
+// watchForDescriptorUpdates establishes a rangefeed over system.descriptors and
+// sends updates on the provided channel.
+func (s *SQLWatcher) watchForDescriptorUpdates(
+	ctx context.Context, timestamp hlc.Timestamp, updatesCh chan watcherRangefeedEvent,
+) error {
+	descriptorTableStart := s.codec.TablePrefix(keys.DescriptorTableID)
+	descriptorTableSpan := roachpb.Span{
+		Key:    descriptorTableStart,
+		EndKey: descriptorTableStart.PrefixEnd(),
+	}
+	handleEvent := func(ctx context.Context, ev *roachpb.RangeFeedValue) {
+		value := ev.Value
+		if !ev.Value.IsPresent() {
+			// The descriptor was deleted.
+			value = ev.PrevValue
+		}
+		if !value.IsPresent() {
+			return
+		}
+
+		var descriptor descpb.Descriptor
+		if err := value.GetProto(&descriptor); err != nil {
+			logcrash.ReportOrPanic(
+				ctx,
+				&s.settings.SV,
+				"%s: failed to unmarshal descriptor %v",
+				ev.Key,
+				value,
+			)
+			return
+		}
+		if descriptor.Union == nil {
+			return
+		}
+
+		table, database, typ, schema := descpb.FromDescriptorWithMVCCTimestamp(&descriptor, value.Timestamp)
+
+		var id descpb.ID
+		var descType catalog.DescriptorType
+		switch {
+		case table != nil:
+			id = table.GetID()
+			descType = catalog.Table
+		case database != nil:
+			id = database.GetID()
+			descType = catalog.Database
+		case typ != nil:
+			id = typ.GetID()
+			descType = catalog.Type
+		case schema != nil:
+			id = schema.GetID()
+			descType = catalog.Schema
+		default:
+			logcrash.ReportOrPanic(ctx, &s.settings.SV, "unknown descriptor unmarshalled %v", descriptor)
+		}
+
+		select {
+		case <-ctx.Done():
+		case updatesCh <- watcherRangefeedEvent{
+			id:             id,
+			descriptorType: descType,
+			timestamp:      value.Timestamp,
+			eventChannel:   descriptorsEventChannel,
+			isCheckpoint:   false,
+		}:
+		}
+	}
+	rf, err := s.rangeFeedFactory.RangeFeed(
+		ctx,
+		"sql-watcher-descriptor-rangefeed",
+		descriptorTableSpan,
+		timestamp,
+		handleEvent,
+		rangefeed.WithDiff(),
+		rangefeed.WithOnCheckpoint(func(ctx context.Context, checkpoint *roachpb.RangeFeedCheckpoint) {
+			updatesCh <- watcherRangefeedEvent{
+				timestamp:    checkpoint.ResolvedTS,
+				eventChannel: descriptorsEventChannel,
+				isCheckpoint: true,
+			}
+		}),
+	)
+	if err != nil {
+		return err
+	}
+	s.stopper.AddCloser(rf)
+	s.descriptorsRF = rf
+
+	log.Infof(ctx, "established range feed over system.descriptors table starting at time %s", timestamp)
+	return nil
+}
+
+// watchForZoneConfigUpdates establishes a rangefeed over system.zones and sends
+// updates on the provided channel.
+func (s *SQLWatcher) watchForZoneConfigUpdates(
+	ctx context.Context, timestamp hlc.Timestamp, updatesCh chan watcherRangefeedEvent,
+) error {
+	zoneTableStart := s.codec.TablePrefix(keys.ZonesTableID)
+	zoneTableSpan := roachpb.Span{
+		Key:    zoneTableStart,
+		EndKey: zoneTableStart.PrefixEnd(),
+	}
+
+	decoder := NewZonesDecoder(s.codec)
+	handleEvent := func(ctx context.Context, ev *roachpb.RangeFeedValue) {
+		descID, err := decoder.DecodePrimaryKey(ev.Key)
+		if err != nil {
+			logcrash.ReportOrPanic(
+				ctx,
+				&s.settings.SV,
+				"sql watcher zones range feed error: %v",
+				err,
+			)
+			return
+		}
+
+		event := watcherRangefeedEvent{
+			id:             descID,
+			descriptorType: catalog.Any,
+			timestamp:      ev.Value.Timestamp,
+			eventChannel:   zonesEventChannel,
+			isCheckpoint:   false,
+		}
+
+		select {
+		case <-ctx.Done():
+		case updatesCh <- event:
+		}
+	}
+	rf, err := s.rangeFeedFactory.RangeFeed(
+		ctx,
+		"sql-watcher-zones-rangefeed",
+		zoneTableSpan,
+		timestamp,
+		handleEvent,
+		rangefeed.WithOnCheckpoint(func(ctx context.Context, checkpoint *roachpb.RangeFeedCheckpoint) {
+			updatesCh <- watcherRangefeedEvent{
+				timestamp:    checkpoint.ResolvedTS,
+				eventChannel: zonesEventChannel,
+				isCheckpoint: true,
+			}
+		}),
+	)
+	if err != nil {
+		return err
+	}
+	s.stopper.AddCloser(rf)
+	s.zonesRF = rf
+
+	log.Infof(ctx, "established range feed over system.zones table starting at time %s", timestamp)
+	return nil
+}

--- a/pkg/spanconfig/spanconfigsqlwatcher/sql_watcher_test.go
+++ b/pkg/spanconfig/spanconfigsqlwatcher/sql_watcher_test.go
@@ -1,0 +1,156 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package spanconfigsqlwatcher_test
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed"
+	"github.com/cockroachdb/cockroach/pkg/spanconfig"
+	"github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigsqlwatcher"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSQLWatcherReactsToUpdates verifies that the SQLWatcher emits the correct
+// updates following changes made to system.descriptor or system.zones.
+func TestSQLWatcherReactsToUpdates(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testCases := []struct {
+		setup       string
+		stmt        string
+		expectedIDs descpb.IDs
+	}{
+		{
+			stmt:        "CREATE TABLE t()",
+			expectedIDs: descpb.IDs{52},
+		},
+		{
+			setup:       "CREATE TABLE t2()",
+			stmt:        "ALTER TABLE t2 CONFIGURE ZONE USING num_replicas = 3",
+			expectedIDs: descpb.IDs{53},
+		},
+		{
+			setup:       "CREATE DATABASE d; CREATE TABLE d.t1(); CREATE TABLE d.t2()",
+			stmt:        "ALTER DATABASE d CONFIGURE ZONE USING num_replicas=5",
+			expectedIDs: descpb.IDs{54},
+		},
+		{
+			setup:       "CREATE TABLE t3(); CREATE TABLE t4()",
+			stmt:        "ALTER TABLE t3 CONFIGURE ZONE USING num_replicas=5; CREATE TABLE t5(); DROP TABLE t4;",
+			expectedIDs: descpb.IDs{57, 58, 59},
+		},
+		// Named zone tests.
+		{
+			stmt:        "ALTER RANGE DEFAULT CONFIGURE ZONE USING num_replicas = 7",
+			expectedIDs: descpb.IDs{keys.RootNamespaceID},
+		},
+		{
+			stmt:        "ALTER RANGE liveness CONFIGURE ZONE USING num_replicas = 7",
+			expectedIDs: descpb.IDs{keys.LivenessRangesID},
+		},
+		{
+			stmt:        "ALTER RANGE meta CONFIGURE ZONE USING num_replicas = 7",
+			expectedIDs: descpb.IDs{keys.MetaRangesID},
+		},
+		{
+			stmt:        "ALTER RANGE system CONFIGURE ZONE USING num_replicas = 7",
+			expectedIDs: descpb.IDs{keys.SystemRangesID},
+		},
+		{
+			stmt:        "ALTER RANGE timeseries CONFIGURE ZONE USING num_replicas = 7",
+			expectedIDs: descpb.IDs{keys.TimeseriesRangesID},
+		},
+		// Test that events on types/schemas are also captured.
+		{
+			setup: "CREATE DATABASE db",
+			stmt:  "CREATE SCHEMA db.sc",
+			// one ID each for the parent database and the schema.
+			expectedIDs: descpb.IDs{60, 61},
+		},
+		{
+			stmt: "CREATE TYPE typ AS ENUM()",
+			// One ID each for the enum and the array type.
+			expectedIDs: descpb.IDs{62, 63},
+		},
+	}
+
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				SpanConfig: &spanconfig.TestingKnobs{
+					ManagerDisableJobCreation: true, // disable the automatic job creation.
+				},
+				JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+			},
+		},
+	})
+	defer tc.Stopper().Stop(context.Background())
+
+	ts := tc.Server(0 /* idx */)
+
+	sqlDB := tc.ServerConn(0 /* idx */)
+	for _, tc := range testCases {
+		sqlWatcher := spanconfigsqlwatcher.New(
+			keys.SystemSQLCodec,
+			ts.ClusterSettings(),
+			ts.RangeFeedFactory().(*rangefeed.Factory),
+			ts.Stopper(),
+		)
+
+		_, err := sqlDB.Exec(tc.setup)
+		require.NoError(t, err)
+
+		prevCheckpointTS := ts.Clock().Now()
+
+		done := make(chan struct{})
+
+		var receivedIds descpb.IDs
+
+		go func() {
+			err = sqlWatcher.WatchForSQLUpdates(context.Background(),
+				prevCheckpointTS,
+				func(events []spanconfig.SQLWatcherEvent, checkpointTS hlc.Timestamp) error {
+					require.True(t, prevCheckpointTS.Less(checkpointTS))
+					for _, event := range events {
+						receivedIds = append(receivedIds, event.ID)
+					}
+					if len(receivedIds) == len(tc.expectedIDs) {
+						close(done)
+					}
+					prevCheckpointTS = checkpointTS
+					return nil
+				})
+			require.NoError(t, err)
+		}()
+
+		_, err = sqlDB.Exec(tc.stmt)
+		require.NoError(t, err)
+
+		<-done
+
+		// Rangefeed events aren't guaranteed to be in any particular order for
+		// different keys.
+		sort.Sort(receivedIds)
+		require.Equal(t, receivedIds, tc.expectedIDs)
+
+		sqlWatcher.Close()
+	}
+}

--- a/pkg/spanconfig/spanconfigsqlwatcher/zones_decoder.go
+++ b/pkg/spanconfig/spanconfigsqlwatcher/zones_decoder.go
@@ -1,0 +1,57 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package spanconfigsqlwatcher
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
+	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/errors"
+)
+
+// ZonesDecoder decodes the zone ID (primary key) of rows from system.zones.
+// It's not safe for concurrent use.
+type ZonesDecoder struct {
+	alloc rowenc.DatumAlloc
+	codec keys.SQLCodec
+}
+
+// NewZonesDecoder instantiates a ZonesDecoder.
+func NewZonesDecoder(codec keys.SQLCodec) *ZonesDecoder {
+	return &ZonesDecoder{
+		codec: codec,
+	}
+}
+
+// DecodePrimaryKey decodes the primary key (zone ID) from the system.zones
+// table.
+func (zd *ZonesDecoder) DecodePrimaryKey(key roachpb.Key) (descpb.ID, error) {
+	// Decode the descriptor ID from the key.
+	tbl := systemschema.ZonesTable
+	types := []*types.T{tbl.PublicColumns()[0].GetType()}
+	startKeyRow := make([]rowenc.EncDatum, 1)
+	_, matches, _, err := rowenc.DecodeIndexKey(
+		zd.codec, tbl, tbl.GetPrimaryIndex(),
+		types, startKeyRow, nil, key,
+	)
+	if err != nil || !matches {
+		return descpb.InvalidID, errors.Newf("failed to decode key in system.zones %v", key)
+	}
+	if err := startKeyRow[0].EnsureDecoded(types[0], &zd.alloc); err != nil {
+		return descpb.InvalidID, errors.Newf("failed to decode key in system.zones %v", key)
+	}
+	descID := descpb.ID(tree.MustBeDInt(startKeyRow[0].Datum))
+	return descID, nil
+}

--- a/pkg/spanconfig/spanconfigsqlwatcher/zones_decoder_test.go
+++ b/pkg/spanconfig/spanconfigsqlwatcher/zones_decoder_test.go
@@ -1,0 +1,101 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package spanconfigsqlwatcher_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/spanconfig"
+	"github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigsqlwatcher"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/gogo/protobuf/proto"
+	"github.com/stretchr/testify/require"
+)
+
+// TestZoneDecoder verifies that we can decode the primary key stored in the
+// system.zones table.
+func TestZonesDecoder(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				SpanConfig: &spanconfig.TestingKnobs{
+					ManagerDisableJobCreation: true,
+				},
+			},
+		},
+	})
+	defer tc.Stopper().Stop(ctx)
+	sqlDB := tc.ServerConn(0)
+
+	k := keys.SystemSQLCodec.TablePrefix(keys.ZonesTableID)
+
+	rows, err := tc.Server(0).DB().Scan(ctx, k, k.PrefixEnd(), 0 /* maxRows */)
+	require.NoError(t, err)
+	initialCount := len(rows)
+
+	entries := []struct {
+		id    descpb.ID
+		proto zonepb.ZoneConfig
+	}{
+		{
+			id:    50,
+			proto: zonepb.ZoneConfig{},
+		},
+		{
+			id:    55,
+			proto: zonepb.DefaultZoneConfig(),
+		},
+		{
+			id: 60,
+			proto: zonepb.ZoneConfig{
+				NumReplicas: proto.Int32(5),
+			},
+		},
+	}
+
+	for _, entry := range entries {
+		buf, err := protoutil.Marshal(&entry.proto)
+		require.NoError(t, err)
+
+		_, err = sqlDB.Exec(
+			"UPSERT INTO system.zones (id, config) VALUES ($1, $2) ", entry.id, buf,
+		)
+		require.NoError(t, err)
+	}
+
+	rows, err = tc.Server(0).DB().Scan(ctx, k, k.PrefixEnd(), 0 /* maxRows */)
+	require.NoError(t, err)
+	require.Equal(t, initialCount+len(entries)*2, len(rows))
+
+	// Don't bother with the system populated zone configurations for the purposes
+	// of this test.
+	rows = rows[initialCount:]
+
+	dec := spanconfigsqlwatcher.NewZonesDecoder(keys.SystemSQLCodec)
+	for i, row := range rows {
+		got, err := dec.DecodePrimaryKey(row.Key)
+		require.NoError(t, err)
+
+		// system.zones has 2 column families, so for every entry that was upserted
+		// into the table we expect there to be 2 rows corresponding to it.
+		require.Equal(t, entries[i/2].id, got)
+	}
+}

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -122,6 +122,10 @@ type TestServerInterface interface {
 	// an interface{}.
 	SpanConfigSQLTranslator() interface{}
 
+	// SpanConfigSQLWatcher returns the underlying spanconfig.SQLWatcher as an
+	// interface{}.
+	SpanConfigSQLWatcher() interface{}
+
 	// SQLServer returns the *sql.Server as an interface{}.
 	SQLServer() interface{}
 


### PR DESCRIPTION
This patch introduces a few more span config interfaces/structs, namely
the SQLReconciler, SQLWatcher, and an eventBuffer helper struct for the
SQLWatcher.

The SQLReconciler is responsible for reconciling SQL descriptors and
their zone configurations to span configurations. It simply constructs
the implied span configuration state and is agnostic to the actual span
configuration state in KV.

The SQLWatcher is intended to incrementally process zone configuration
updates in the SQL layer. It does so by establishing a rangefeed on
system.zones and system.descriptors from a given checkpoint. It buffers
events until the next checkpoint. The list of buffered descriptor IDs,
along with the new checkpoint, are passed to a handler callback.

The SQLWatcher uses an eventBuffer helper struct to buffer rangefeed
updates. This thing maintains the notion of a checkpoint timestamp,
which is minimum timestamp for a {zones, descriptor} event.

This flow doesn't quite work end to end yet because rangefeeds don't
expose checkpoint events yet. These interfaces aren't hooked up to
anything yet either.

References cockroachdb#67679

Release justification: non-production code changes
Release note: None