### PR TITLE
roachtest: bump tpcc load warehouses and estimates

### DIFF
--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -739,16 +739,16 @@ func registerTPCC(r registry.Registry) {
 		Nodes: 3,
 		CPUs:  16,
 
-		LoadWarehouses: gceOrAws(cloud, 2500, 3000),
-		EstimatedMax:   gceOrAws(cloud, 2100, 2500),
+		LoadWarehouses: gceOrAws(cloud, 3000, 3500),
+		EstimatedMax:   gceOrAws(cloud, 2400, 3000),
 	})
 	registerTPCCBenchSpec(r, tpccBenchSpec{
 		Nodes:                   3,
 		CPUs:                    16,
 		AdmissionControlEnabled: true,
 
-		LoadWarehouses: gceOrAws(cloud, 2500, 3000),
-		EstimatedMax:   gceOrAws(cloud, 2100, 2500),
+		LoadWarehouses: gceOrAws(cloud, 3000, 3500),
+		EstimatedMax:   gceOrAws(cloud, 2400, 3000),
 	})
 	registerTPCCBenchSpec(r, tpccBenchSpec{
 		Nodes: 12,


### PR DESCRIPTION
We're hitting the limits on both AWS and GCE sometimes. Pretty much all the
time on AWS.

<img width="903" alt="Screen Shot 2021-08-31 at 3 11 17 PM" src="https://user-images.githubusercontent.com/1839234/131561909-1cacbe18-9a15-488b-b8cf-21120ae7d8ad.png">

Release justification: non-production code changes.

Release note: None