### PR TITLE
bazel: bazel builder image doesn't run builds as root

### DIFF
--- a/build/bazelbuilder/Dockerfile
+++ b/build/bazelbuilder/Dockerfile
@@ -62,7 +62,12 @@ RUN curl -fsSL https://github.com/bazelbuild/bazelisk/releases/download/v1.10.1/
 
 RUN rm -rf /tmp/* /var/lib/apt/lists/*
 
-COPY entrypoint.sh /usr/bin
 COPY autom4te /usr/local/sbin
-ENTRYPOINT ["/usr/bin/entrypoint.sh"]
+
+RUN curl -fsSL https://github.com/benesch/autouseradd/releases/download/1.2.0/autouseradd-1.2.0-amd64.tar.gz -o autouseradd.tar.gz \
+  && echo 'f7b0cf67564044c31ffc5e84c961726098b88b0296a57c84421659d56434a365 autouseradd.tar.gz' | sha256sum -c - \
+  && tar xzf autouseradd.tar.gz --strip-components 1 \
+  && rm autouseradd.tar.gz
+
+ENTRYPOINT ["autouseradd", "--user", "roach", "--no-create-home"]
 CMD ["/usr/bin/bash"]

--- a/build/bazelbuilder/entrypoint.sh
+++ b/build/bazelbuilder/entrypoint.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/bash
-# Without this `umask`, the image will create build artifacts that the host
-# won't have permission to delete (which can pollute the workspace with files
-# that can't be cleaned up).
-umask 0000
-exec "$@"

--- a/build/builder/Dockerfile
+++ b/build/builder/Dockerfile
@@ -198,10 +198,12 @@ RUN apt-get purge -y \
 RUN rm -rf /tmp/* /var/lib/apt/lists/*
 
 RUN ln -s /go/src/github.com/cockroachdb/cockroach/build/builder/mkrelease.sh /usr/local/bin/mkrelease \
-    && ln -s /usr/bin/bazel-3.6.0 /usr/bin/bazel
+  && ln -s /usr/bin/bazel-3.6.0 /usr/bin/bazel
 
-RUN curl -fsSL https://github.com/benesch/autouseradd/releases/download/1.2.0/autouseradd-1.2.0-amd64.tar.gz \
-    | tar xz -C / --strip-components 1
+RUN curl -fsSL https://github.com/benesch/autouseradd/releases/download/1.2.0/autouseradd-1.2.0-amd64.tar.gz -o autouseradd.tar.gz \
+  && echo 'f7b0cf67564044c31ffc5e84c961726098b88b0296a57c84421659d56434a365 autouseradd.tar.gz' | sha256sum -c - \
+  && tar xzf autouseradd.tar.gz --strip-components 1 \
+  && rm autouseradd.tar.gz
 
 COPY entrypoint.sh /usr/local/bin
 

--- a/build/teamcity-bazel-support.sh
+++ b/build/teamcity-bazel-support.sh
@@ -1,7 +1,7 @@
 # FYI: You can run `./dev builder` to run this Docker image. :)
 # `dev` depends on this variable! Don't change the name or format unless you
 # also update `dev` accordingly.
-BAZEL_IMAGE=cockroachdb/bazel:20210729-154657
+BAZEL_IMAGE=cockroachdb/bazel:20210831-144443
 
 # Call `run_bazel $NAME_OF_SCRIPT` to start an appropriately-configured Docker
 # container with the `cockroachdb/bazel` image running the given script.
@@ -13,18 +13,20 @@ run_bazel() {
     fi
 
     # Set up volumes.
-    vols="--volume /home/agent/.bazelcache:/root/.cache/bazel"
     # TeamCity uses git alternates, so make sure we mount the path to the real
     # git objects.
     teamcity_alternates="/home/agent/system/git"
-    vols="${vols} --volume ${teamcity_alternates}:${teamcity_alternates}:ro"
+    vols="--volume ${teamcity_alternates}:${teamcity_alternates}:ro"
     artifacts_dir=$root/artifacts
     mkdir -p "$artifacts_dir"
-    workspace_vol="--volume ${root}:/go/src/github.com/cockroachdb/cockroach"
-    vols="${vols} ${workspace_vol}"
     vols="${vols} --volume ${artifacts_dir}:/artifacts"
+    cache=/home/agent/.bzlhome
+    mkdir -p $cache
+    vols="${vols} --volume ${root}:/go/src/github.com/cockroachdb/cockroach"
+    vols="${vols} --volume ${cache}:/home/roach"
 
     docker run -i ${tty-} --rm --init \
+        -u "$(id -u):$(id -g)" \
         --workdir="/go/src/github.com/cockroachdb/cockroach" \
         ${vols} \
         $BAZEL_IMAGE "$@"

--- a/pkg/cmd/bazci/watch.go
+++ b/pkg/cmd/bazci/watch.go
@@ -151,7 +151,7 @@ func (w watcher) stageTestArtifacts(phase Phase) error {
 			{path.Join(relDir, "test.xml"), mungeTestXML},
 			{path.Join(relDir, "*", "test.xml"), mungeTestXML},
 		} {
-			err := w.maybeStageArtifact(testlogsSourceDir, tup.relPath, 0666, phase,
+			err := w.maybeStageArtifact(testlogsSourceDir, tup.relPath, 0644, phase,
 				tup.stagefn)
 			if err != nil {
 				return err
@@ -209,7 +209,7 @@ func (w watcher) stageBinaryArtifacts() error {
 		if usingCrossWindowsConfig() {
 			relBinPath = relBinPath + ".exe"
 		}
-		err := w.maybeStageArtifact(binSourceDir, relBinPath, 0777, finalizePhase,
+		err := w.maybeStageArtifact(binSourceDir, relBinPath, 0755, finalizePhase,
 			copyContentTo)
 		if err != nil {
 			return err
@@ -226,7 +226,7 @@ func (w watcher) stageBinaryArtifacts() error {
 			return err
 		}
 		for _, relBinPath := range outs {
-			err := w.maybeStageArtifact(binSourceDir, relBinPath, 0666, finalizePhase, copyContentTo)
+			err := w.maybeStageArtifact(binSourceDir, relBinPath, 0644, finalizePhase, copyContentTo)
 			if err != nil {
 				return err
 			}
@@ -249,7 +249,7 @@ func (w watcher) stageBinaryArtifacts() error {
 				fmt.Sprintf("c-deps/libgeos/lib/libgeos_c.%s", ext),
 				fmt.Sprintf("c-deps/libgeos/lib/libgeos.%s", ext),
 			} {
-				err := w.maybeStageArtifact(binSourceDir, relBinPath, 0666, finalizePhase, copyContentTo)
+				err := w.maybeStageArtifact(binSourceDir, relBinPath, 0644, finalizePhase, copyContentTo)
 				if err != nil {
 					return err
 				}
@@ -326,7 +326,7 @@ func (w *cancelableWriter) Write(p []byte) (n int, err error) {
 
 func (w *cancelableWriter) Close() error {
 	if !w.Canceled {
-		err := os.MkdirAll(path.Dir(w.filename), 0777)
+		err := os.MkdirAll(path.Dir(w.filename), 0755)
 		if err != nil {
 			return err
 		}
@@ -372,7 +372,7 @@ func (w *cancelableWriter) Close() error {
 //
 // For example, one might stage a set of log files with a call like:
 // w.maybeStageArtifact(testlogsSourceDir, "pkg/server/server_test/*/test.log",
-//                      0666, incrementalUpdatePhase, copycontentTo)
+//                      0644, incrementalUpdatePhase, copycontentTo)
 func (w watcher) maybeStageArtifact(
 	root SourceDir,
 	pattern string,
@@ -501,7 +501,7 @@ func (w watcher) stageTmpDir() error {
 			return err
 		}
 		dstPath := filepath.Join(artifactsDir, "tmp", relPath)
-		err = os.MkdirAll(filepath.Dir(dstPath), 0777)
+		err = os.MkdirAll(filepath.Dir(dstPath), 0755)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/dev/build.go
+++ b/pkg/cmd/dev/build.go
@@ -44,7 +44,7 @@ func makeBuildCmd(runE func(cmd *cobra.Command, args []string) error) *cobra.Com
 		Args: cobra.MinimumNArgs(0),
 		RunE: runE,
 	}
-	buildCmd.Flags().String(volumeFlag, "bzlcache", "the Docker volume to use as the Bazel cache (only used for cross builds)")
+	buildCmd.Flags().String(volumeFlag, "bzlhome", "the Docker volume to use as the container home directory (only used for cross builds)")
 	buildCmd.Flags().String(crossFlag, "", `
         Turns on cross-compilation. Builds the binary using the builder image w/ Docker.
         You can optionally set a config, as in --cross=windows.
@@ -111,7 +111,6 @@ func (d *dev) build(cmd *cobra.Command, targets []string) error {
 	script.WriteString(fmt.Sprintf("BAZELBIN=`bazel info bazel-bin --color=no --config=%s`\n", cross))
 	for _, target := range fullTargets {
 		script.WriteString(fmt.Sprintf("cp $BAZELBIN/%s /artifacts\n", bazelutil.OutputOfBinaryRule(target)))
-		script.WriteString(fmt.Sprintf("chmod +w /artifacts/%s\n", targetToBinBasename(target)))
 	}
 	_, err = d.exec.CommandContextWithInput(ctx, script.String(), "docker", dockerArgs...)
 	if err != nil {

--- a/pkg/cmd/dev/builder.go
+++ b/pkg/cmd/dev/builder.go
@@ -12,8 +12,10 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/cockroachdb/errors"
@@ -32,7 +34,7 @@ func makeBuilderCmd(runE func(cmd *cobra.Command, args []string) error) *cobra.C
 		Args:    cobra.ExactArgs(0),
 		RunE:    runE,
 	}
-	builderCmd.Flags().String(volumeFlag, "bzlcache", "the Docker volume to use as the Bazel cache")
+	builderCmd.Flags().String(volumeFlag, "bzlhome", "the Docker volume to use as the container home directory")
 	return builderCmd
 }
 
@@ -46,18 +48,6 @@ func (d *dev) builder(cmd *cobra.Command, _ []string) error {
 	return d.exec.CommandContextInheritingStdStreams(ctx, "docker", args...)
 }
 
-func (d *dev) ensureDockerVolume(ctx context.Context, volume string) error {
-	_, err := d.exec.CommandContextSilent(ctx, "docker", "volume", "inspect", volume)
-	if err != nil {
-		log.Printf("Creating volume %s with Docker...", volume)
-		_, err := d.exec.CommandContextSilent(ctx, "docker", "volume", "create", volume)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 func (d *dev) getDockerRunArgs(
 	ctx context.Context, volume string, tty bool,
 ) (args []string, err error) {
@@ -65,35 +55,35 @@ func (d *dev) getDockerRunArgs(
 	if err != nil {
 		return
 	}
-	err = d.ensureDockerVolume(ctx, volume)
+
+	// Apply the same munging for the UID/GID that we do in build/builder.sh.
+	// Quoth a comment from there:
+	// Attempt to run in the container with the same UID/GID as we have on the host,
+	// as this results in the correct permissions on files created in the shared
+	// volumes. This isn't always possible, however, as IDs less than 100 are
+	// reserved by Debian, and IDs in the low 100s are dynamically assigned to
+	// various system users and groups. To be safe, if we see a UID/GID less than
+	// 500, promote it to 501. This is notably necessary on macOS Lion and later,
+	// where administrator accounts are created with a GID of 20. This solution is
+	// not foolproof, but it works well in practice.
+	uid, gid, err := d.os.CurrentUserAndGroup()
 	if err != nil {
 		return
 	}
-
-	args = append(args, "run", "--rm")
-	if tty {
-		args = append(args, "-it")
-	} else {
-		args = append(args, "-i")
+	uidInt, err := strconv.Atoi(uid)
+	if err == nil && uidInt < 500 {
+		uid = "501"
 	}
+	gidInt, err := strconv.Atoi(gid)
+	if err == nil && gidInt < 500 {
+		gid = uid
+	}
+
+	// Read the Docker image from build/teamcity-bazel-support.sh.
 	workspace, err := d.getWorkspace(ctx)
 	if err != nil {
 		return
 	}
-	args = append(args, "-v", workspace+":/cockroach")
-	args = append(args, "--workdir=/cockroach")
-	// Create the artifacts directory.
-	artifacts := filepath.Join(workspace, "artifacts")
-	err = d.os.MkdirAll(artifacts)
-	if err != nil {
-		return
-	}
-	args = append(args, "-v", artifacts+":/artifacts")
-	// The `delegated` switch ensures that the container's view of the cache
-	// is authoritative. This can result in writes to the actual underlying
-	// filesystem to be lost, but it's a cache so we don't care about that.
-	args = append(args, "-v", volume+":/root/.cache/bazel:delegated")
-	// Read the Docker image from build/teamcity-bazel-support.sh.
 	buf, err := d.os.ReadFile(filepath.Join(workspace, "build/teamcity-bazel-support.sh"))
 	if err != nil {
 		return
@@ -108,6 +98,46 @@ func (d *dev) getDockerRunArgs(
 		err = errors.New("Could not find BAZEL_IMAGE in build/teamcity-bazel-support.sh")
 		return
 	}
+
+	// Ensure the Docker volume exists.
+	_, err = d.exec.CommandContextSilent(ctx, "docker", "volume", "inspect", volume)
+	if err != nil {
+		log.Printf("Creating volume %s with Docker...", volume)
+		_, err := d.exec.CommandContextSilent(ctx, "docker", "volume", "create", volume)
+		if err != nil {
+			return nil, err
+		}
+		// When Docker creates the volume, the owner will be `root`.
+		// Fix that with a quick chown.
+		_, err = d.exec.CommandContextSilent(
+			ctx, "docker", "run", "--rm", "-v", volume+":/vol",
+			"--entrypoint=/usr/bin/chown", bazelImage,
+			"-R", fmt.Sprintf("%s:%s", uid, gid), "/vol")
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	args = append(args, "run", "--rm")
+	if tty {
+		args = append(args, "-it")
+	} else {
+		args = append(args, "-i")
+	}
+	args = append(args, "-v", workspace+":/cockroach")
+	args = append(args, "--workdir=/cockroach")
+	// Create the artifacts directory.
+	artifacts := filepath.Join(workspace, "artifacts")
+	err = d.os.MkdirAll(artifacts)
+	if err != nil {
+		return
+	}
+	args = append(args, "-v", artifacts+":/artifacts")
+	// The `delegated` switch ensures that the container's view of the cache
+	// is authoritative. This can result in writes to the actual underlying
+	// filesystem to be lost, but it's a cache so we don't care about that.
+	args = append(args, "-v", volume+":/home/roach:delegated")
+	args = append(args, "-u", fmt.Sprintf("%s:%s", uid, gid))
 	args = append(args, bazelImage)
 	return
 }

--- a/pkg/cmd/dev/io/os/os.go
+++ b/pkg/cmd/dev/io/os/os.go
@@ -17,6 +17,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"os/user"
 	"path/filepath"
 	"strings"
 
@@ -256,6 +257,31 @@ func (o *OS) ListFilesWithSuffix(root, suffix string) ([]string, error) {
 		return nil, err
 	}
 	return strings.Split(strings.TrimSpace(lines), "\n"), nil
+}
+
+// CurrentUserAndGroup returns the user and effective group.
+func (o *OS) CurrentUserAndGroup() (uid string, gid string, err error) {
+	command := "id"
+	o.logger.Print(command)
+
+	if o.Recording == nil {
+		// Do the real thing.
+		var currentUser *user.User
+		currentUser, err = user.Current()
+		if err != nil {
+			return
+		}
+		uid = currentUser.Uid
+		gid = currentUser.Gid
+		return
+	}
+
+	output, err := o.replay(command)
+	if err != nil {
+		return
+	}
+	ids := strings.Split(strings.TrimSpace(output), ":")
+	return ids[0], ids[1], nil
 }
 
 // replay replays the specified command, erroring out if it's mismatched with

--- a/pkg/cmd/dev/testdata/builder.txt
+++ b/pkg/cmd/dev/testdata/builder.txt
@@ -4,8 +4,9 @@ getenv PATH
 which cc
 readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-docker volume inspect bzlcache
+id
 bazel info workspace --color=no --config=dev
-mkdir go/src/github.com/cockroachdb/cockroach/artifacts
 cat go/src/github.com/cockroachdb/cockroach/build/teamcity-bazel-support.sh
-docker run --rm -it -v go/src/github.com/cockroachdb/cockroach:/cockroach --workdir=/cockroach -v go/src/github.com/cockroachdb/cockroach/artifacts:/artifacts -v bzlcache:/root/.cache/bazel:delegated mock_bazel_image:1234
+docker volume inspect bzlhome
+mkdir go/src/github.com/cockroachdb/cockroach/artifacts
+docker run --rm -it -v go/src/github.com/cockroachdb/cockroach:/cockroach --workdir=/cockroach -v go/src/github.com/cockroachdb/cockroach/artifacts:/artifacts -v bzlhome:/home/roach:delegated -u 1001:1002 mock_bazel_image:1234

--- a/pkg/cmd/dev/testdata/recording/builder.txt
+++ b/pkg/cmd/dev/testdata/recording/builder.txt
@@ -13,19 +13,23 @@ readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 ----
 
-docker volume inspect bzlcache
+id
 ----
+1001:1002
 
 bazel info workspace --color=no --config=dev
 ----
 go/src/github.com/cockroachdb/cockroach
 
-mkdir go/src/github.com/cockroachdb/cockroach/artifacts
-----
-
 cat go/src/github.com/cockroachdb/cockroach/build/teamcity-bazel-support.sh
 ----
 BAZEL_IMAGE=mock_bazel_image:1234
 
-docker run --rm -it -v go/src/github.com/cockroachdb/cockroach:/cockroach --workdir=/cockroach -v go/src/github.com/cockroachdb/cockroach/artifacts:/artifacts -v bzlcache:/root/.cache/bazel:delegated mock_bazel_image:1234
+docker volume inspect bzlhome
+----
+
+mkdir go/src/github.com/cockroachdb/cockroach/artifacts
+----
+
+docker run --rm -it -v go/src/github.com/cockroachdb/cockroach:/cockroach --workdir=/cockroach -v go/src/github.com/cockroachdb/cockroach/artifacts:/artifacts -v bzlhome:/home/roach:delegated -u 1001:1002 mock_bazel_image:1234
 ----


### PR DESCRIPTION
Adopt the same `autouseradd` script that we use in `cockroachdb/builder`
to avoid creating these files as `root`. Also step down the permissions
on some files that `bazci` creates -- they don't need to be so
permissive any more.

Closes #66162

Release justification: Non-production code change
Release note: None