### PR TITLE
sql: bump default value for sql.stats.persisted_rows.max

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -147,7 +147,7 @@ sql.stats.flush.enabled	boolean	true	if set, SQL execution statistics are period
 sql.stats.flush.interval	duration	1h0m0s	the interval at which SQL execution statistics are flushed to disk
 sql.stats.histogram_collection.enabled	boolean	true	histogram collection mode
 sql.stats.multi_column_collection.enabled	boolean	true	multi-column statistics collection mode
-sql.stats.persisted_rows.max	integer	10000	maximum number of rows of statement and transaction statistics that will be persisted in the system tables
+sql.stats.persisted_rows.max	integer	1000000	maximum number of rows of statement and transaction statistics that will be persisted in the system tables
 sql.stats.post_events.enabled	boolean	false	if set, an event is logged for every CREATE STATISTICS job
 sql.temp_object_cleaner.cleanup_interval	duration	30m0s	how often to clean up orphaned temporary objects
 sql.trace.log_statement_execute	boolean	false	set to true to enable logging of executed statements

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -151,7 +151,7 @@
 <tr><td><code>sql.stats.flush.interval</code></td><td>duration</td><td><code>1h0m0s</code></td><td>the interval at which SQL execution statistics are flushed to disk</td></tr>
 <tr><td><code>sql.stats.histogram_collection.enabled</code></td><td>boolean</td><td><code>true</code></td><td>histogram collection mode</td></tr>
 <tr><td><code>sql.stats.multi_column_collection.enabled</code></td><td>boolean</td><td><code>true</code></td><td>multi-column statistics collection mode</td></tr>
-<tr><td><code>sql.stats.persisted_rows.max</code></td><td>integer</td><td><code>10000</code></td><td>maximum number of rows of statement and transaction statistics that will be persisted in the system tables</td></tr>
+<tr><td><code>sql.stats.persisted_rows.max</code></td><td>integer</td><td><code>1000000</code></td><td>maximum number of rows of statement and transaction statistics that will be persisted in the system tables</td></tr>
 <tr><td><code>sql.stats.post_events.enabled</code></td><td>boolean</td><td><code>false</code></td><td>if set, an event is logged for every CREATE STATISTICS job</td></tr>
 <tr><td><code>sql.temp_object_cleaner.cleanup_interval</code></td><td>duration</td><td><code>30m0s</code></td><td>how often to clean up orphaned temporary objects</td></tr>
 <tr><td><code>sql.trace.log_statement_execute</code></td><td>boolean</td><td><code>false</code></td><td>set to true to enable logging of executed statements</td></tr>

--- a/pkg/sql/sqlstats/persistedsqlstats/cluster_settings.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/cluster_settings.go
@@ -58,7 +58,7 @@ var SQLStatsMaxPersistedRows = settings.RegisterIntSetting(
 	"sql.stats.persisted_rows.max",
 	"maximum number of rows of statement and transaction"+
 		" statistics that will be persisted in the system tables",
-	10000, /* defaultValue */
+	1000000, /* defaultValue */
 ).WithPublic()
 
 // SQLStatsCleanupRecurrence is the cron-tab string specifying the recurrence


### PR DESCRIPTION
Previsouly, sql.stats.persisted_rows.max has a default value
of 10,000 rows. This is significantly lower than even the
in-memory fingerprint count limits (100,000 entries).
This commit bumps the default value for sql.stats.persisted_rows.max
to 1,000,000 rows. With average row size = 1 KiB, this is equivalent
of 1 GiB limit for system.statement_statistics and
system.transaction_statistics tables respectively.

Release justification: Bug fixes and low-risk updates to new
functionality

Release note (sql change): sql.stats.persisted_rows.max's default
value is now 1,000,000.