### PR TITLE
server: fix sampled_plan not being returned in combined stmts response

### DIFF
--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -1881,6 +1881,10 @@ func TestStatusAPIStatements(t *testing.T) {
 				// Ignore the ALTER USER ... VIEWACTIVITY statement.
 				continue
 			}
+			if len(respStatement.Stats.SensitiveInfo.MostRecentPlanDescription.Name) == 0 {
+				// Ensure that we populate the explain plan.
+				t.Fatal("expected MostRecentPlanDescription to be populated")
+			}
 			statementsInResponse = append(statementsInResponse, respStatement.Key.KeyData.Query)
 		}
 
@@ -1980,6 +1984,12 @@ func TestStatusAPICombinedStatements(t *testing.T) {
 				// Ignore the ALTER USER ... VIEWACTIVITY statement.
 				continue
 			}
+
+			if len(respStatement.Stats.SensitiveInfo.MostRecentPlanDescription.Name) == 0 {
+				// Ensure that we populate the explain plan.
+				t.Fatal("expected MostRecentPlanDescription to be populated")
+			}
+
 			statementsInResponse = append(statementsInResponse, respStatement.Key.KeyData.Query)
 		}
 


### PR DESCRIPTION
Sampled plans are currently stored in a separate column from
stats in crdb_internal.statement_statistics and were not being
returned as part of the combined statements API response.
This commit adds the sampled_plan to the response.

Release justification: bug fixes and low-risk updates to new
functionality

Release note: None