### PR TITLE
migrations: pass owning job to migration functions

### DIFF
--- a/pkg/ccl/kvccl/kvtenantccl/BUILD.bazel
+++ b/pkg/ccl/kvccl/kvtenantccl/BUILD.bazel
@@ -46,6 +46,7 @@ go_test(
         "//pkg/clusterversion",
         "//pkg/config",
         "//pkg/gossip",
+        "//pkg/jobs",
         "//pkg/kv/kvclient/kvtenant",
         "//pkg/migration",
         "//pkg/migration/migrations",

--- a/pkg/ccl/kvccl/kvtenantccl/tenant_upgrade_test.go
+++ b/pkg/ccl/kvccl/kvtenantccl/tenant_upgrade_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/migration"
 	"github.com/cockroachdb/cockroach/pkg/migration/migrations"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -262,7 +263,7 @@ func TestTenantUpgradeFailure(t *testing.T) {
 							},
 								migrations.NoPrecondition,
 								func(
-									ctx context.Context, version clusterversion.ClusterVersion, deps migration.TenantDeps,
+									ctx context.Context, version clusterversion.ClusterVersion, deps migration.TenantDeps, _ *jobs.Job,
 								) error {
 									return nil
 								}), true
@@ -272,7 +273,7 @@ func TestTenantUpgradeFailure(t *testing.T) {
 							},
 								migrations.NoPrecondition,
 								func(
-									ctx context.Context, version clusterversion.ClusterVersion, deps migration.TenantDeps,
+									ctx context.Context, version clusterversion.ClusterVersion, deps migration.TenantDeps, _ *jobs.Job,
 								) error {
 									tenantStopperChannel <- struct{}{}
 									return nil

--- a/pkg/migration/BUILD.bazel
+++ b/pkg/migration/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     deps = [
         "//pkg/base",
         "//pkg/clusterversion",
+        "//pkg/jobs",
         "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/kv",

--- a/pkg/migration/migrationjob/migration_job.go
+++ b/pkg/migration/migrationjob/migration_job.go
@@ -78,7 +78,7 @@ func (r resumer) Resume(ctx context.Context, execCtxI interface{}) error {
 	}
 	switch m := m.(type) {
 	case *migration.SystemMigration:
-		err = m.Run(ctx, cv, mc.SystemDeps())
+		err = m.Run(ctx, cv, mc.SystemDeps(), r.j)
 	case *migration.TenantMigration:
 		err = m.Run(ctx, cv, migration.TenantDeps{
 			DB:                execCtx.ExecCfg().DB,
@@ -88,7 +88,7 @@ func (r resumer) Resume(ctx context.Context, execCtxI interface{}) error {
 			LeaseManager:      execCtx.ExecCfg().LeaseManager,
 			InternalExecutor:  execCtx.ExecCfg().InternalExecutor,
 			TestingKnobs:      execCtx.ExecCfg().MigrationTestingKnobs,
-		})
+		}, r.j)
 	default:
 		return errors.AssertionFailedf("unknown migration type %T", m)
 	}

--- a/pkg/migration/migrations/BUILD.bazel
+++ b/pkg/migration/migrations/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
     deps = [
         "//pkg/clusterversion",
         "//pkg/config/zonepb",
+        "//pkg/jobs",
         "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/kv",

--- a/pkg/migration/migrations/database_role_settings.go
+++ b/pkg/migration/migrations/database_role_settings.go
@@ -14,13 +14,14 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/migration"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/startupmigrations"
 )
 
 func databaseRoleSettingsTableMigration(
-	ctx context.Context, _ clusterversion.ClusterVersion, d migration.TenantDeps,
+	ctx context.Context, _ clusterversion.ClusterVersion, d migration.TenantDeps, _ *jobs.Job,
 ) error {
 	return startupmigrations.CreateSystemTable(
 		ctx, d.DB, d.Codec, d.Settings, systemschema.DatabaseRoleSettingsTable,

--- a/pkg/migration/migrations/delete_deprecated_namespace_tabledesc.go
+++ b/pkg/migration/migrations/delete_deprecated_namespace_tabledesc.go
@@ -14,6 +14,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/migration"
@@ -28,7 +29,7 @@ import (
 )
 
 func deleteDeprecatedNamespaceTableDescriptorMigration(
-	ctx context.Context, _ clusterversion.ClusterVersion, d migration.TenantDeps,
+	ctx context.Context, _ clusterversion.ClusterVersion, d migration.TenantDeps, _ *jobs.Job,
 ) error {
 	const pageSize = 1000
 	deprecatedTablePrefix := d.Codec.TablePrefix(uint32(keys.DeprecatedNamespaceTableID))

--- a/pkg/migration/migrations/fix_descriptor_migration.go
+++ b/pkg/migration/migrations/fix_descriptor_migration.go
@@ -14,6 +14,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/migration"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
@@ -34,7 +35,7 @@ type descIDAndVersion struct {
 
 // fixDescriptorMigration calls RunPostDeserializationChanges on every descriptor.
 func fixDescriptorMigration(
-	ctx context.Context, _ clusterversion.ClusterVersion, d migration.TenantDeps,
+	ctx context.Context, _ clusterversion.ClusterVersion, d migration.TenantDeps, _ *jobs.Job,
 ) error {
 	fixDescriptorFunc := func(ids []descpb.ID, descs []descpb.Descriptor, timestamps []hlc.Timestamp) error {
 		var descIDAndVersions []descIDAndVersion

--- a/pkg/migration/migrations/interleaved_tables.go
+++ b/pkg/migration/migrations/interleaved_tables.go
@@ -14,6 +14,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/migration"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -22,6 +23,12 @@ import (
 )
 
 func interleavedTablesRemovedMigration(
+	ctx context.Context, cv clusterversion.ClusterVersion, d migration.TenantDeps, _ *jobs.Job,
+) error {
+	return interleavedTablesRemovedCheck(ctx, cv, d)
+}
+
+func interleavedTablesRemovedCheck(
 	ctx context.Context, _ clusterversion.ClusterVersion, d migration.TenantDeps,
 ) error {
 	rows, err := d.InternalExecutor.QueryRowEx(ctx, "check-for-interleaved",

--- a/pkg/migration/migrations/join_tokens.go
+++ b/pkg/migration/migrations/join_tokens.go
@@ -14,13 +14,14 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/migration"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/startupmigrations"
 )
 
 func joinTokensTableMigration(
-	ctx context.Context, _ clusterversion.ClusterVersion, d migration.TenantDeps,
+	ctx context.Context, _ clusterversion.ClusterVersion, d migration.TenantDeps, _ *jobs.Job,
 ) error {
 	return startupmigrations.CreateSystemTable(
 		ctx, d.DB, d.Codec, d.Settings, systemschema.JoinTokensTable,

--- a/pkg/migration/migrations/migrations.go
+++ b/pkg/migration/migrations/migrations.go
@@ -118,7 +118,7 @@ var migrations = []migration.Migration{
 	migration.NewTenantMigration(
 		"validates no interleaved tables exist",
 		toCV(clusterversion.EnsureNoInterleavedTables),
-		interleavedTablesRemovedMigration,
+		interleavedTablesRemovedCheck,
 		interleavedTablesRemovedMigration,
 	),
 	migration.NewTenantMigration(

--- a/pkg/migration/migrations/records_based_registry.go
+++ b/pkg/migration/migrations/records_based_registry.go
@@ -14,12 +14,13 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/migration"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 )
 
 func recordsBasedRegistryMigration(
-	ctx context.Context, cv clusterversion.ClusterVersion, deps migration.SystemDeps,
+	ctx context.Context, cv clusterversion.ClusterVersion, deps migration.SystemDeps, _ *jobs.Job,
 ) error {
 	return deps.Cluster.ForEveryNode(ctx, "deprecate-base-encryption-registry", func(ctx context.Context, client serverpb.MigrationClient) error {
 		req := &serverpb.DeprecateBaseEncryptionRegistryRequest{Version: &cv.Version}

--- a/pkg/migration/migrations/retry_jobs_with_exponential_backoff.go
+++ b/pkg/migration/migrations/retry_jobs_with_exponential_backoff.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
@@ -51,7 +52,7 @@ CREATE INDEX jobs_run_stats_idx
 // retryJobsWithExponentialBackoff changes the schema of system.jobs table in
 // two steps. It first adds two new columns and then an index.
 func retryJobsWithExponentialBackoff(
-	ctx context.Context, cs clusterversion.ClusterVersion, d migration.TenantDeps,
+	ctx context.Context, cs clusterversion.ClusterVersion, d migration.TenantDeps, _ *jobs.Job,
 ) error {
 	jobsTable := systemschema.JobsTable
 	ops := [...]struct {

--- a/pkg/migration/migrations/separated_intents.go
+++ b/pkg/migration/migrations/separated_intents.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
@@ -406,7 +407,7 @@ func runSeparatedIntentsMigration(
 }
 
 func separatedIntentsMigration(
-	ctx context.Context, cv clusterversion.ClusterVersion, deps migration.SystemDeps,
+	ctx context.Context, cv clusterversion.ClusterVersion, deps migration.SystemDeps, _ *jobs.Job,
 ) error {
 	ir := intentresolver.New(intentresolver.Config{
 		Clock:                deps.DB.Clock(),
@@ -420,7 +421,7 @@ func separatedIntentsMigration(
 }
 
 func postSeparatedIntentsMigration(
-	ctx context.Context, cv clusterversion.ClusterVersion, deps migration.SystemDeps,
+	ctx context.Context, cv clusterversion.ClusterVersion, deps migration.SystemDeps, _ *jobs.Job,
 ) error {
 	var batchIdx, numMigratedRanges int
 	init := func() { batchIdx, numMigratedRanges = 1, 0 }

--- a/pkg/migration/migrations/span_configurations.go
+++ b/pkg/migration/migrations/span_configurations.go
@@ -14,13 +14,14 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/migration"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/startupmigrations"
 )
 
 func spanConfigurationsTableMigration(
-	ctx context.Context, _ clusterversion.ClusterVersion, d migration.TenantDeps,
+	ctx context.Context, _ clusterversion.ClusterVersion, d migration.TenantDeps, _ *jobs.Job,
 ) error {
 	if !d.Codec.ForSystemTenant() {
 		return nil

--- a/pkg/migration/migrations/sql_instances.go
+++ b/pkg/migration/migrations/sql_instances.go
@@ -14,13 +14,14 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/migration"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/startupmigrations"
 )
 
 func sqlInstancesTableMigration(
-	ctx context.Context, _ clusterversion.ClusterVersion, d migration.TenantDeps,
+	ctx context.Context, _ clusterversion.ClusterVersion, d migration.TenantDeps, _ *jobs.Job,
 ) error {
 	return startupmigrations.CreateSystemTable(
 		ctx, d.DB, d.Codec, d.Settings, systemschema.SQLInstancesTable,

--- a/pkg/migration/migrations/sql_stats.go
+++ b/pkg/migration/migrations/sql_stats.go
@@ -14,13 +14,14 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/migration"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/startupmigrations"
 )
 
 func sqlStatementStatsTableMigration(
-	ctx context.Context, _ clusterversion.ClusterVersion, d migration.TenantDeps,
+	ctx context.Context, _ clusterversion.ClusterVersion, d migration.TenantDeps, _ *jobs.Job,
 ) error {
 	return startupmigrations.CreateSystemTable(
 		ctx, d.DB, d.Codec, d.Settings, systemschema.StatementStatisticsTable,
@@ -28,7 +29,7 @@ func sqlStatementStatsTableMigration(
 }
 
 func sqlTransactionStatsTableMigration(
-	ctx context.Context, _ clusterversion.ClusterVersion, d migration.TenantDeps,
+	ctx context.Context, _ clusterversion.ClusterVersion, d migration.TenantDeps, _ *jobs.Job,
 ) error {
 	return startupmigrations.CreateSystemTable(
 		ctx, d.DB, d.Codec, d.Settings, systemschema.TransactionStatisticsTable,

--- a/pkg/migration/migrations/tenant_usage.go
+++ b/pkg/migration/migrations/tenant_usage.go
@@ -14,13 +14,14 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/migration"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/startupmigrations"
 )
 
 func tenantUsageTableMigration(
-	ctx context.Context, _ clusterversion.ClusterVersion, d migration.TenantDeps,
+	ctx context.Context, _ clusterversion.ClusterVersion, d migration.TenantDeps, _ *jobs.Job,
 ) error {
 	// Only create the table on the system tenant.
 	if !d.Codec.ForSystemTenant() {

--- a/pkg/migration/migrations/truncated_state.go
+++ b/pkg/migration/migrations/truncated_state.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/migration"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -37,7 +38,7 @@ import (
 const defaultPageSize = 200
 
 func truncatedStateMigration(
-	ctx context.Context, cv clusterversion.ClusterVersion, deps migration.SystemDeps,
+	ctx context.Context, cv clusterversion.ClusterVersion, deps migration.SystemDeps, _ *jobs.Job,
 ) error {
 	var batchIdx, numMigratedRanges int
 	init := func() { batchIdx, numMigratedRanges = 1, 0 }
@@ -80,7 +81,7 @@ func truncatedStateMigration(
 }
 
 func postTruncatedStateMigration(
-	ctx context.Context, cv clusterversion.ClusterVersion, deps migration.SystemDeps,
+	ctx context.Context, cv clusterversion.ClusterVersion, deps migration.SystemDeps, _ *jobs.Job,
 ) error {
 	// Purge all replicas that haven't been migrated to use the unreplicated
 	// truncated state and the range applied state.

--- a/pkg/migration/migrations/zones.go
+++ b/pkg/migration/migrations/zones.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/migration"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
@@ -25,7 +26,7 @@ import (
 // zonesTableForSecondaryTenants adds system.zones to secondary tenants and
 // seeds it.
 func zonesTableForSecondaryTenants(
-	ctx context.Context, _ clusterversion.ClusterVersion, d migration.TenantDeps,
+	ctx context.Context, _ clusterversion.ClusterVersion, d migration.TenantDeps, _ *jobs.Job,
 ) error {
 	if d.Codec.ForSystemTenant() {
 		// We don't need to add system.zones to the system tenant as it should

--- a/pkg/migration/system_migration.go
+++ b/pkg/migration/system_migration.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -140,7 +141,7 @@ type SystemMigration struct {
 
 // SystemMigrationFunc is used to perform kv-level migrations. It should only be
 // run from the system tenant.
-type SystemMigrationFunc func(context.Context, clusterversion.ClusterVersion, SystemDeps) error
+type SystemMigrationFunc func(context.Context, clusterversion.ClusterVersion, SystemDeps, *jobs.Job) error
 
 // NewSystemMigration constructs a SystemMigration.
 func NewSystemMigration(
@@ -157,8 +158,8 @@ func NewSystemMigration(
 
 // Run kickstarts the actual migration process for system-level migrations.
 func (m *SystemMigration) Run(
-	ctx context.Context, cv clusterversion.ClusterVersion, d SystemDeps,
+	ctx context.Context, cv clusterversion.ClusterVersion, d SystemDeps, job *jobs.Job,
 ) error {
 	ctx = logtags.AddTag(ctx, fmt.Sprintf("migration=%s", cv), nil)
-	return m.fn(ctx, cv, d)
+	return m.fn(ctx, cv, d, job)
 }

--- a/pkg/migration/tenant_migration.go
+++ b/pkg/migration/tenant_migration.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -38,14 +39,14 @@ type TenantDeps struct {
 
 // TenantMigrationFunc is used to perform sql-level migrations. It may be run from
 // any tenant.
-type TenantMigrationFunc func(context.Context, clusterversion.ClusterVersion, TenantDeps) error
+type TenantMigrationFunc func(context.Context, clusterversion.ClusterVersion, TenantDeps, *jobs.Job) error
 
 // PreconditionFunc is a function run without isolation before attempting an
 // upgrade that includes this migration. It is used to verify that the
 // required conditions for the migration to succeed are met. This can allow
 // users to fix any problems before "crossing the rubicon" and no longer
 // being able to upgrade.
-type PreconditionFunc TenantMigrationFunc
+type PreconditionFunc func(context.Context, clusterversion.ClusterVersion, TenantDeps) error
 
 // TenantMigration is an implementation of Migration for tenant-level
 // migrations. This is used for all migration which might affect the state of
@@ -78,10 +79,10 @@ func NewTenantMigration(
 
 // Run kickstarts the actual migration process for tenant-level migrations.
 func (m *TenantMigration) Run(
-	ctx context.Context, cv clusterversion.ClusterVersion, d TenantDeps,
+	ctx context.Context, cv clusterversion.ClusterVersion, d TenantDeps, job *jobs.Job,
 ) error {
 	ctx = logtags.AddTag(ctx, fmt.Sprintf("migration=%s", cv), nil)
-	return m.fn(ctx, cv, d)
+	return m.fn(ctx, cv, d, job)
 }
 
 // Precondition runs the precondition check if there is one and reports

--- a/pkg/server/version_cluster_test.go
+++ b/pkg/server/version_cluster_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/migration"
 	"github.com/cockroachdb/cockroach/pkg/migration/migrations"
@@ -432,7 +433,7 @@ func TestClusterVersionMixedVersionTooOld(t *testing.T) {
 				},
 					migrations.NoPrecondition,
 					func(
-						ctx context.Context, version clusterversion.ClusterVersion, deps migration.TenantDeps,
+						ctx context.Context, version clusterversion.ClusterVersion, deps migration.TenantDeps, _ *jobs.Job,
 					) error {
 						return nil
 					}), true


### PR DESCRIPTION
This is a pure-refactor change to pass the job that is performing a given
migration to the migration function, adding the jobs.Job to the signature
of migraiton functions, passing it in the job resumer and then extending
all current migrations to ignore this extra argument.

Release justification: low-risk change to new functionality.

Release note: none.