### PR TITLE
roachtest: use noprepare for multi-region TPC-C

### DIFF
--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -606,7 +606,7 @@ func registerTPCC(r registry.Registry) {
 						Warehouses:     len(regions) * warehousesPerRegion,
 						Duration:       duration,
 						ExtraSetupArgs: partitionArgs,
-						ExtraRunArgs:   `--method=simple --wait=false --tolerate-errors ` + partitionArgs,
+						ExtraRunArgs:   `--method=noprepare --wait=false --tolerate-errors ` + partitionArgs,
 						Chaos: func() Chaos {
 							return Chaos{
 								Timer: Periodic{


### PR DESCRIPTION
Simple mode errors right now; noprepare restore parity with past 
state.

Resolves #69471
Resolves #69472

Release justification: test only change

Release note: None