### PR TITLE
sql: apply zone configs for copied INDEX for ALTER PK on RBR tables

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -561,6 +561,9 @@ DELETE FROM regional_by_row_table WHERE pk = 1000
 statement ok
 ALTER TABLE regional_by_row_table ALTER PRIMARY KEY USING COLUMNS (pk2)
 
+statement ok
+SELECT crdb_internal.validate_multi_region_zone_configs()
+
 query T
 SELECT
   create_statement
@@ -596,6 +599,19 @@ PARTITION "ap-southeast-2" OF INDEX regional_by_row_table@primary  ALTER PARTITI
                                                                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
                                                                    voter_constraints = '{+region=ap-southeast-2: 2}',
                                                                    lease_preferences = '[[+region=ap-southeast-2]]'
+
+query TT
+SHOW ZONE CONFIGURATION FOR PARTITION "ap-southeast-2" OF INDEX regional_by_row_table@regional_by_row_table_pk_key
+----
+PARTITION "ap-southeast-2" OF INDEX regional_by_row_table@regional_by_row_table_pk_key  ALTER PARTITION "ap-southeast-2" OF INDEX regional_by_row_table@regional_by_row_table_pk_key CONFIGURE ZONE USING
+                                                                                        range_min_bytes = 134217728,
+                                                                                        range_max_bytes = 536870912,
+                                                                                        gc.ttlseconds = 90000,
+                                                                                        num_replicas = 5,
+                                                                                        num_voters = 5,
+                                                                                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                                                        voter_constraints = '{+region=ap-southeast-2: 2}',
+                                                                                        lease_preferences = '[[+region=ap-southeast-2]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "ap-southeast-2" OF INDEX regional_by_row_table@unique_b_a

--- a/pkg/sql/alter_primary_key.go
+++ b/pkg/sql/alter_primary_key.go
@@ -408,6 +408,16 @@ func (p *planner) AlterPrimaryKey(
 		if err := addIndexMutationWithSpecificPrimaryKey(ctx, tableDesc, &newUniqueIdx, newPrimaryIndexDesc); err != nil {
 			return err
 		}
+		// Copy the old zone configuration into the newly created unique index for PARTITION ALL BY.
+		if tableDesc.IsLocalityRegionalByRow() {
+			if err := p.configureZoneConfigForNewIndexPartitioning(
+				ctx,
+				tableDesc,
+				newUniqueIdx,
+			); err != nil {
+				return err
+			}
+		}
 	}
 
 	// We have to rewrite all indexes that either:


### PR DESCRIPTION
Release justification: bug fix for existing feature

Release note (bug fix): Previously, when using ALTER PRIMARY KEY on a
REGIONAL BY ROW table, the copied unique index from the old PRIMARY KEY
would not have the correct zone configurations applied. This commit
fixes that. Users who encountered this bug should re-create the
index.