### PR TITLE
workload: fix Query for `prepare` method

### DIFF
--- a/pkg/workload/BUILD.bazel
+++ b/pkg/workload/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/sql/types",
         "//pkg/util/bufalloc",
         "//pkg/util/encoding/csv",
+        "//pkg/util/log",
         "//pkg/util/timeutil",
         "//pkg/workload/histogram",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/workload/sql_runner.go
+++ b/pkg/workload/sql_runner.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
-	"github.com/jackc/pgx/v4/pgxpool"
 )
 
 // SQLRunner is a helper for issuing SQL statements; it supports multiple
@@ -120,6 +119,7 @@ func (sr *SQLRunner) Init(
 		for i, s := range sr.stmts {
 			stmtName := fmt.Sprintf("%s-%d", name, i+1)
 			s.preparedName = stmtName
+			mcp.preparedStatements[stmtName] = s.sql
 		}
 	}
 
@@ -156,19 +156,7 @@ func (h StmtHandle) Exec(ctx context.Context, args ...interface{}) (pgconn.Comma
 	p := h.s.sr.mcp.Get()
 	switch h.s.sr.method {
 	case prepare:
-		// Note that calling `Prepare` with a name that has already been prepared
-		// is idempotent and short-circuits before doing any communication to the
-		// server.
-		var commandTag pgconn.CommandTag
-		err := p.AcquireFunc(ctx, func(conn *pgxpool.Conn) error {
-			if _, err := conn.Conn().Prepare(ctx, h.s.preparedName, h.s.sql); err != nil {
-				return err
-			}
-			var connErr error
-			commandTag, connErr = conn.Conn().Exec(ctx, h.s.preparedName, args...)
-			return connErr
-		})
-		return commandTag, err
+		return p.Exec(ctx, h.s.preparedName, args...)
 
 	case noprepare:
 		return p.Exec(ctx, h.s.sql, args...)
@@ -191,12 +179,6 @@ func (h StmtHandle) ExecTx(
 	h.check()
 	switch h.s.sr.method {
 	case prepare:
-		// Note that calling `Prepare` with a name that has already been prepared
-		// is idempotent and short-circuits before doing any communication to the
-		// server.
-		if _, err := tx.Prepare(ctx, h.s.preparedName, h.s.sql); err != nil {
-			return nil, err
-		}
 		return tx.Exec(ctx, h.s.preparedName, args...)
 
 	case noprepare:
@@ -219,19 +201,7 @@ func (h StmtHandle) Query(ctx context.Context, args ...interface{}) (pgx.Rows, e
 	p := h.s.sr.mcp.Get()
 	switch h.s.sr.method {
 	case prepare:
-		// Note that calling `Prepare` with a name that has already been prepared
-		// is idempotent and short-circuits before doing any communication to the
-		// server.
-		var rows pgx.Rows
-		err := p.AcquireFunc(ctx, func(conn *pgxpool.Conn) error {
-			if _, err := conn.Conn().Prepare(ctx, h.s.preparedName, h.s.sql); err != nil {
-				return err
-			}
-			var connErr error
-			rows, connErr = conn.Conn().Query(ctx, h.s.preparedName, args...)
-			return connErr
-		})
-		return rows, err
+		return p.Query(ctx, h.s.preparedName, args...)
 
 	case noprepare:
 		return p.Query(ctx, h.s.sql, args...)
@@ -252,12 +222,6 @@ func (h StmtHandle) QueryTx(ctx context.Context, tx pgx.Tx, args ...interface{})
 	h.check()
 	switch h.s.sr.method {
 	case prepare:
-		// Note that calling `Prepare` with a name that has already been prepared
-		// is idempotent and short-circuits before doing any communication to the
-		// server.
-		if _, err := tx.Prepare(ctx, h.s.preparedName, h.s.sql); err != nil {
-			return nil, err
-		}
 		return tx.Query(ctx, h.s.preparedName, args...)
 
 	case noprepare:
@@ -280,22 +244,7 @@ func (h StmtHandle) QueryRow(ctx context.Context, args ...interface{}) pgx.Row {
 	p := h.s.sr.mcp.Get()
 	switch h.s.sr.method {
 	case prepare:
-		// Note that calling `Prepare` with a name that has already been prepared
-		// is idempotent and short-circuits before doing any communication to the
-		// server.
-		var row pgx.Row
-		err := p.AcquireFunc(ctx, func(conn *pgxpool.Conn) error {
-			if _, err := conn.Conn().Prepare(ctx, h.s.preparedName, h.s.sql); err != nil {
-				return err
-			}
-			row = conn.Conn().QueryRow(ctx, h.s.preparedName, args...)
-			return nil
-		})
-		if err != nil {
-			r := errRow{retErr: err}
-			return &r
-		}
-		return row
+		return p.QueryRow(ctx, h.s.preparedName, args...)
 
 	case noprepare:
 		return p.QueryRow(ctx, h.s.sql, args...)
@@ -317,13 +266,6 @@ func (h StmtHandle) QueryRowTx(ctx context.Context, tx pgx.Tx, args ...interface
 	h.check()
 	switch h.s.sr.method {
 	case prepare:
-		// Note that calling `Prepare` with a name that has already been prepared
-		// is idempotent and short-circuits before doing any communication to the
-		// server.
-		if _, err := tx.Prepare(ctx, h.s.preparedName, h.s.sql); err != nil {
-			r := errRow{retErr: err}
-			return &r
-		}
 		return tx.QueryRow(ctx, h.s.preparedName, args...)
 
 	case noprepare:
@@ -337,16 +279,6 @@ func (h StmtHandle) QueryRowTx(ctx context.Context, tx pgx.Tx, args ...interface
 		panic("invalid method")
 	}
 }
-
-// errRow implements the pgx.Row interface. It's used only in the `prepare`
-// mode.
-type errRow struct {
-	retErr error
-}
-
-var _ pgx.Row = &errRow{}
-
-func (r *errRow) Scan(_ ...interface{}) error { return r.retErr }
 
 // Appease the linter.
 var _ = StmtHandle.QueryRow


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/69411
fixes https://github.com/cockroachdb/cockroach/issues/69403
fixes https://github.com/cockroachdb/cockroach/issues/69404

There was a bug because the connection would be released back to the
pool before the rows were read.

The only reason the connection was being borrowed explicitly was to
prepare statements, so now the statements have been changed to be
prepared as part of the BeforeAcquire callback instead.

Release justification: test only change
Release note: None