### PR TITLE
release-21.1: sql: show hash-sharded column CHECK constraints in SHOW CREATE TABLE

### DIFF
--- a/pkg/sql/catalog/descpb/structured.pb.go
+++ b/pkg/sql/catalog/descpb/structured.pb.go
@@ -75,7 +75,7 @@ func (x *ConstraintValidity) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ConstraintValidity) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{0}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{0}
 }
 
 // SystemColumnKind is an enum representing the different kind of system
@@ -120,7 +120,7 @@ func (x *SystemColumnKind) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (SystemColumnKind) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{1}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{1}
 }
 
 // State indicates whether a descriptor is public (i.e., normally visible,
@@ -172,7 +172,7 @@ func (x *DescriptorState) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (DescriptorState) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{2}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{2}
 }
 
 // SurvivalGoal is the survival goal for a database.
@@ -211,7 +211,7 @@ func (x *SurvivalGoal) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (SurvivalGoal) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{3}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{3}
 }
 
 type ForeignKeyReference_Action int32
@@ -256,7 +256,7 @@ func (x *ForeignKeyReference_Action) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ForeignKeyReference_Action) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{0, 0}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{0, 0}
 }
 
 // Match is the algorithm used to compare composite keys.
@@ -296,7 +296,7 @@ func (x *ForeignKeyReference_Match) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ForeignKeyReference_Match) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{0, 1}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{0, 1}
 }
 
 // The direction of a column in the index.
@@ -333,7 +333,7 @@ func (x *IndexDescriptor_Direction) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (IndexDescriptor_Direction) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{8, 0}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{8, 0}
 }
 
 // The type of the index.
@@ -370,7 +370,7 @@ func (x *IndexDescriptor_Type) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (IndexDescriptor_Type) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{8, 1}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{8, 1}
 }
 
 type ConstraintToUpdate_ConstraintType int32
@@ -416,7 +416,7 @@ func (x *ConstraintToUpdate_ConstraintType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ConstraintToUpdate_ConstraintType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{9, 0}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{9, 0}
 }
 
 // A descriptor within a mutation is unavailable for reads, writes
@@ -481,7 +481,7 @@ func (x *DescriptorMutation_State) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (DescriptorMutation_State) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{13, 0}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{13, 0}
 }
 
 // Direction of mutation.
@@ -524,7 +524,7 @@ func (x *DescriptorMutation_Direction) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (DescriptorMutation_Direction) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{13, 1}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{13, 1}
 }
 
 // AuditMode indicates which auditing actions to take when this table is used.
@@ -561,7 +561,7 @@ func (x *TableDescriptor_AuditMode) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (TableDescriptor_AuditMode) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{15, 0}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{15, 0}
 }
 
 // Represents the kind of type that this type descriptor represents.
@@ -606,7 +606,7 @@ func (x *TypeDescriptor_Kind) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (TypeDescriptor_Kind) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{17, 0}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{17, 0}
 }
 
 // Represents what operations are allowed on this ENUM member.
@@ -647,7 +647,7 @@ func (x *TypeDescriptor_EnumMember_Capability) UnmarshalJSON(data []byte) error 
 	return nil
 }
 func (TypeDescriptor_EnumMember_Capability) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{17, 0, 0}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{17, 0, 0}
 }
 
 type TypeDescriptor_EnumMember_Direction int32
@@ -689,7 +689,7 @@ func (x *TypeDescriptor_EnumMember_Direction) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (TypeDescriptor_EnumMember_Direction) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{17, 0, 1}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{17, 0, 1}
 }
 
 // ForeignKeyReference is deprecated, replaced by ForeignKeyConstraint in v19.2
@@ -719,7 +719,7 @@ func (m *ForeignKeyReference) Reset()         { *m = ForeignKeyReference{} }
 func (m *ForeignKeyReference) String() string { return proto.CompactTextString(m) }
 func (*ForeignKeyReference) ProtoMessage()    {}
 func (*ForeignKeyReference) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{0}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{0}
 }
 func (m *ForeignKeyReference) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -767,7 +767,7 @@ func (m *ForeignKeyConstraint) Reset()         { *m = ForeignKeyConstraint{} }
 func (m *ForeignKeyConstraint) String() string { return proto.CompactTextString(m) }
 func (*ForeignKeyConstraint) ProtoMessage()    {}
 func (*ForeignKeyConstraint) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{1}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{1}
 }
 func (m *ForeignKeyConstraint) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -809,7 +809,7 @@ func (m *UniqueWithoutIndexConstraint) Reset()         { *m = UniqueWithoutIndex
 func (m *UniqueWithoutIndexConstraint) String() string { return proto.CompactTextString(m) }
 func (*UniqueWithoutIndexConstraint) ProtoMessage()    {}
 func (*UniqueWithoutIndexConstraint) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{2}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{2}
 }
 func (m *UniqueWithoutIndexConstraint) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -877,7 +877,7 @@ func (m *ColumnDescriptor) Reset()         { *m = ColumnDescriptor{} }
 func (m *ColumnDescriptor) String() string { return proto.CompactTextString(m) }
 func (*ColumnDescriptor) ProtoMessage()    {}
 func (*ColumnDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{3}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{3}
 }
 func (m *ColumnDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -933,7 +933,7 @@ func (m *ColumnFamilyDescriptor) Reset()         { *m = ColumnFamilyDescriptor{}
 func (m *ColumnFamilyDescriptor) String() string { return proto.CompactTextString(m) }
 func (*ColumnFamilyDescriptor) ProtoMessage()    {}
 func (*ColumnFamilyDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{4}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{4}
 }
 func (m *ColumnFamilyDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -979,7 +979,7 @@ func (m *InterleaveDescriptor) Reset()         { *m = InterleaveDescriptor{} }
 func (m *InterleaveDescriptor) String() string { return proto.CompactTextString(m) }
 func (*InterleaveDescriptor) ProtoMessage()    {}
 func (*InterleaveDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{5}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{5}
 }
 func (m *InterleaveDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1023,7 +1023,7 @@ func (m *InterleaveDescriptor_Ancestor) Reset()         { *m = InterleaveDescrip
 func (m *InterleaveDescriptor_Ancestor) String() string { return proto.CompactTextString(m) }
 func (*InterleaveDescriptor_Ancestor) ProtoMessage()    {}
 func (*InterleaveDescriptor_Ancestor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{5, 0}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{5, 0}
 }
 func (m *InterleaveDescriptor_Ancestor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1078,7 +1078,7 @@ func (m *ShardedDescriptor) Reset()         { *m = ShardedDescriptor{} }
 func (m *ShardedDescriptor) String() string { return proto.CompactTextString(m) }
 func (*ShardedDescriptor) ProtoMessage()    {}
 func (*ShardedDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{6}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{6}
 }
 func (m *ShardedDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1129,7 +1129,7 @@ func (m *PartitioningDescriptor) Reset()         { *m = PartitioningDescriptor{}
 func (m *PartitioningDescriptor) String() string { return proto.CompactTextString(m) }
 func (*PartitioningDescriptor) ProtoMessage()    {}
 func (*PartitioningDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{7}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{7}
 }
 func (m *PartitioningDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1172,7 +1172,7 @@ func (m *PartitioningDescriptor_List) Reset()         { *m = PartitioningDescrip
 func (m *PartitioningDescriptor_List) String() string { return proto.CompactTextString(m) }
 func (*PartitioningDescriptor_List) ProtoMessage()    {}
 func (*PartitioningDescriptor_List) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{7, 0}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{7, 0}
 }
 func (m *PartitioningDescriptor_List) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1217,7 +1217,7 @@ func (m *PartitioningDescriptor_Range) Reset()         { *m = PartitioningDescri
 func (m *PartitioningDescriptor_Range) String() string { return proto.CompactTextString(m) }
 func (*PartitioningDescriptor_Range) ProtoMessage()    {}
 func (*PartitioningDescriptor_Range) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{7, 1}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{7, 1}
 }
 func (m *PartitioningDescriptor_Range) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1384,7 +1384,7 @@ func (m *IndexDescriptor) Reset()         { *m = IndexDescriptor{} }
 func (m *IndexDescriptor) String() string { return proto.CompactTextString(m) }
 func (*IndexDescriptor) ProtoMessage()    {}
 func (*IndexDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{8}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{8}
 }
 func (m *IndexDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1436,7 +1436,7 @@ func (m *ConstraintToUpdate) Reset()         { *m = ConstraintToUpdate{} }
 func (m *ConstraintToUpdate) String() string { return proto.CompactTextString(m) }
 func (*ConstraintToUpdate) ProtoMessage()    {}
 func (*ConstraintToUpdate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{9}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{9}
 }
 func (m *ConstraintToUpdate) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1487,7 +1487,7 @@ func (m *PrimaryKeySwap) Reset()         { *m = PrimaryKeySwap{} }
 func (m *PrimaryKeySwap) String() string { return proto.CompactTextString(m) }
 func (*PrimaryKeySwap) ProtoMessage()    {}
 func (*PrimaryKeySwap) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{10}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{10}
 }
 func (m *PrimaryKeySwap) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1535,7 +1535,7 @@ func (m *PrimaryKeySwap_LocalityConfigSwap) Reset()         { *m = PrimaryKeySwa
 func (m *PrimaryKeySwap_LocalityConfigSwap) String() string { return proto.CompactTextString(m) }
 func (*PrimaryKeySwap_LocalityConfigSwap) ProtoMessage()    {}
 func (*PrimaryKeySwap_LocalityConfigSwap) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{10, 0}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{10, 0}
 }
 func (m *PrimaryKeySwap_LocalityConfigSwap) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1575,7 +1575,7 @@ func (m *ComputedColumnSwap) Reset()         { *m = ComputedColumnSwap{} }
 func (m *ComputedColumnSwap) String() string { return proto.CompactTextString(m) }
 func (*ComputedColumnSwap) ProtoMessage()    {}
 func (*ComputedColumnSwap) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{11}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{11}
 }
 func (m *ComputedColumnSwap) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1623,7 +1623,7 @@ func (m *MaterializedViewRefresh) Reset()         { *m = MaterializedViewRefresh
 func (m *MaterializedViewRefresh) String() string { return proto.CompactTextString(m) }
 func (*MaterializedViewRefresh) ProtoMessage()    {}
 func (*MaterializedViewRefresh) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{12}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{12}
 }
 func (m *MaterializedViewRefresh) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1680,7 +1680,7 @@ func (m *DescriptorMutation) Reset()         { *m = DescriptorMutation{} }
 func (m *DescriptorMutation) String() string { return proto.CompactTextString(m) }
 func (*DescriptorMutation) ProtoMessage()    {}
 func (*DescriptorMutation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{13}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{13}
 }
 func (m *DescriptorMutation) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2018,7 +2018,7 @@ func (m *NameInfo) Reset()         { *m = NameInfo{} }
 func (m *NameInfo) String() string { return proto.CompactTextString(m) }
 func (*NameInfo) ProtoMessage()    {}
 func (*NameInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{14}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{14}
 }
 func (m *NameInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2208,7 +2208,7 @@ func (m *TableDescriptor) Reset()         { *m = TableDescriptor{} }
 func (m *TableDescriptor) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor) ProtoMessage()    {}
 func (*TableDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{15}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{15}
 }
 func (m *TableDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2536,7 +2536,7 @@ func (m *TableDescriptor_SchemaChangeLease) Reset()         { *m = TableDescript
 func (m *TableDescriptor_SchemaChangeLease) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_SchemaChangeLease) ProtoMessage()    {}
 func (*TableDescriptor_SchemaChangeLease) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{15, 0}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{15, 0}
 }
 func (m *TableDescriptor_SchemaChangeLease) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2573,8 +2573,10 @@ type TableDescriptor_CheckConstraint struct {
 	// An ordered list of column IDs used by the check constraint.
 	ColumnIDs           []ColumnID `protobuf:"varint,5,rep,name=column_ids,json=columnIds,casttype=ColumnID" json:"column_ids,omitempty"`
 	IsNonNullConstraint bool       `protobuf:"varint,6,opt,name=is_non_null_constraint,json=isNonNullConstraint" json:"is_non_null_constraint"`
-	// Whether the check constraint should show up in the result of a `SHOW CREATE
-	// TABLE..` statement.
+	// Hidden is set to true for hash-sharded column check constraints.
+	// Previously, this field was used to hide these constraints in the output
+	// of SHOW CREATE TABLE. We no longer them in order to make the output to be
+	// round-trippable, but we still set this field for now. See #68031.
 	Hidden bool `protobuf:"varint,7,opt,name=hidden" json:"hidden"`
 }
 
@@ -2582,7 +2584,7 @@ func (m *TableDescriptor_CheckConstraint) Reset()         { *m = TableDescriptor
 func (m *TableDescriptor_CheckConstraint) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_CheckConstraint) ProtoMessage()    {}
 func (*TableDescriptor_CheckConstraint) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{15, 1}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{15, 1}
 }
 func (m *TableDescriptor_CheckConstraint) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2627,7 +2629,7 @@ func (m *TableDescriptor_Reference) Reset()         { *m = TableDescriptor_Refer
 func (m *TableDescriptor_Reference) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_Reference) ProtoMessage()    {}
 func (*TableDescriptor_Reference) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{15, 2}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{15, 2}
 }
 func (m *TableDescriptor_Reference) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2665,7 +2667,7 @@ func (m *TableDescriptor_MutationJob) Reset()         { *m = TableDescriptor_Mut
 func (m *TableDescriptor_MutationJob) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_MutationJob) ProtoMessage()    {}
 func (*TableDescriptor_MutationJob) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{15, 3}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{15, 3}
 }
 func (m *TableDescriptor_MutationJob) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2711,7 +2713,7 @@ func (m *TableDescriptor_SequenceOpts) Reset()         { *m = TableDescriptor_Se
 func (m *TableDescriptor_SequenceOpts) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_SequenceOpts) ProtoMessage()    {}
 func (*TableDescriptor_SequenceOpts) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{15, 4}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{15, 4}
 }
 func (m *TableDescriptor_SequenceOpts) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2751,7 +2753,7 @@ func (m *TableDescriptor_SequenceOpts_SequenceOwner) String() string {
 }
 func (*TableDescriptor_SequenceOpts_SequenceOwner) ProtoMessage() {}
 func (*TableDescriptor_SequenceOpts_SequenceOwner) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{15, 4, 0}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{15, 4, 0}
 }
 func (m *TableDescriptor_SequenceOpts_SequenceOwner) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2791,7 +2793,7 @@ func (m *TableDescriptor_Replacement) Reset()         { *m = TableDescriptor_Rep
 func (m *TableDescriptor_Replacement) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_Replacement) ProtoMessage()    {}
 func (*TableDescriptor_Replacement) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{15, 5}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{15, 5}
 }
 func (m *TableDescriptor_Replacement) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2828,7 +2830,7 @@ func (m *TableDescriptor_GCDescriptorMutation) Reset()         { *m = TableDescr
 func (m *TableDescriptor_GCDescriptorMutation) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_GCDescriptorMutation) ProtoMessage()    {}
 func (*TableDescriptor_GCDescriptorMutation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{15, 6}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{15, 6}
 }
 func (m *TableDescriptor_GCDescriptorMutation) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2865,7 +2867,7 @@ func (m *TableDescriptor_LocalityConfig) Reset()         { *m = TableDescriptor_
 func (m *TableDescriptor_LocalityConfig) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_LocalityConfig) ProtoMessage()    {}
 func (*TableDescriptor_LocalityConfig) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{15, 7}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{15, 7}
 }
 func (m *TableDescriptor_LocalityConfig) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3059,7 +3061,7 @@ func (m *TableDescriptor_LocalityConfig_RegionalByTable) String() string {
 }
 func (*TableDescriptor_LocalityConfig_RegionalByTable) ProtoMessage() {}
 func (*TableDescriptor_LocalityConfig_RegionalByTable) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{15, 7, 0}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{15, 7, 0}
 }
 func (m *TableDescriptor_LocalityConfig_RegionalByTable) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3097,7 +3099,7 @@ func (m *TableDescriptor_LocalityConfig_RegionalByRow) String() string {
 }
 func (*TableDescriptor_LocalityConfig_RegionalByRow) ProtoMessage() {}
 func (*TableDescriptor_LocalityConfig_RegionalByRow) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{15, 7, 1}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{15, 7, 1}
 }
 func (m *TableDescriptor_LocalityConfig_RegionalByRow) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3129,7 +3131,7 @@ func (m *TableDescriptor_LocalityConfig_Global) Reset()         { *m = TableDesc
 func (m *TableDescriptor_LocalityConfig_Global) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_LocalityConfig_Global) ProtoMessage()    {}
 func (*TableDescriptor_LocalityConfig_Global) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{15, 7, 2}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{15, 7, 2}
 }
 func (m *TableDescriptor_LocalityConfig_Global) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3180,7 +3182,7 @@ func (m *DatabaseDescriptor) Reset()         { *m = DatabaseDescriptor{} }
 func (m *DatabaseDescriptor) String() string { return proto.CompactTextString(m) }
 func (*DatabaseDescriptor) ProtoMessage()    {}
 func (*DatabaseDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{16}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{16}
 }
 func (m *DatabaseDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3288,7 +3290,7 @@ func (m *DatabaseDescriptor_SchemaInfo) Reset()         { *m = DatabaseDescripto
 func (m *DatabaseDescriptor_SchemaInfo) String() string { return proto.CompactTextString(m) }
 func (*DatabaseDescriptor_SchemaInfo) ProtoMessage()    {}
 func (*DatabaseDescriptor_SchemaInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{16, 0}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{16, 0}
 }
 func (m *DatabaseDescriptor_SchemaInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3327,7 +3329,7 @@ func (m *DatabaseDescriptor_RegionConfig) Reset()         { *m = DatabaseDescrip
 func (m *DatabaseDescriptor_RegionConfig) String() string { return proto.CompactTextString(m) }
 func (*DatabaseDescriptor_RegionConfig) ProtoMessage()    {}
 func (*DatabaseDescriptor_RegionConfig) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{16, 2}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{16, 2}
 }
 func (m *DatabaseDescriptor_RegionConfig) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3390,7 +3392,7 @@ func (m *TypeDescriptor) Reset()         { *m = TypeDescriptor{} }
 func (m *TypeDescriptor) String() string { return proto.CompactTextString(m) }
 func (*TypeDescriptor) ProtoMessage()    {}
 func (*TypeDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{17}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{17}
 }
 func (m *TypeDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3539,7 +3541,7 @@ func (m *TypeDescriptor_EnumMember) Reset()         { *m = TypeDescriptor_EnumMe
 func (m *TypeDescriptor_EnumMember) String() string { return proto.CompactTextString(m) }
 func (*TypeDescriptor_EnumMember) ProtoMessage()    {}
 func (*TypeDescriptor_EnumMember) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{17, 0}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{17, 0}
 }
 func (m *TypeDescriptor_EnumMember) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3575,7 +3577,7 @@ func (m *TypeDescriptor_RegionConfig) Reset()         { *m = TypeDescriptor_Regi
 func (m *TypeDescriptor_RegionConfig) String() string { return proto.CompactTextString(m) }
 func (*TypeDescriptor_RegionConfig) ProtoMessage()    {}
 func (*TypeDescriptor_RegionConfig) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{17, 1}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{17, 1}
 }
 func (m *TypeDescriptor_RegionConfig) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3623,7 +3625,7 @@ func (m *SchemaDescriptor) Reset()         { *m = SchemaDescriptor{} }
 func (m *SchemaDescriptor) String() string { return proto.CompactTextString(m) }
 func (*SchemaDescriptor) ProtoMessage()    {}
 func (*SchemaDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{18}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{18}
 }
 func (m *SchemaDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3726,7 +3728,7 @@ func (m *Descriptor) Reset()         { *m = Descriptor{} }
 func (m *Descriptor) String() string { return proto.CompactTextString(m) }
 func (*Descriptor) ProtoMessage()    {}
 func (*Descriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_364a18a7216daa8c, []int{19}
+	return fileDescriptor_structured_1cfe7702181988f4, []int{19}
 }
 func (m *Descriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -18564,10 +18566,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("sql/catalog/descpb/structured.proto", fileDescriptor_structured_364a18a7216daa8c)
+	proto.RegisterFile("sql/catalog/descpb/structured.proto", fileDescriptor_structured_1cfe7702181988f4)
 }
 
-var fileDescriptor_structured_364a18a7216daa8c = []byte{
+var fileDescriptor_structured_1cfe7702181988f4 = []byte{
 	// 5326 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xbc, 0x7c, 0xc9, 0x73, 0x23, 0xd7,
 	0x79, 0x38, 0xb1, 0x03, 0x1f, 0xb6, 0xe6, 0x1b, 0xce, 0x0c, 0x44, 0x4b, 0x24, 0x07, 0xa3, 0x91,

--- a/pkg/sql/catalog/descpb/structured.proto
+++ b/pkg/sql/catalog/descpb/structured.proto
@@ -925,8 +925,10 @@ message TableDescriptor {
     repeated uint32 column_ids = 5 [(gogoproto.customname) = "ColumnIDs",
       (gogoproto.casttype) = "ColumnID"];
     optional bool is_non_null_constraint = 6 [(gogoproto.nullable) = false];
-    // Whether the check constraint should show up in the result of a `SHOW CREATE
-    // TABLE..` statement.
+    // Hidden is set to true for hash-sharded column check constraints.
+    // Previously, this field was used to hide these constraints in the output
+    // of SHOW CREATE TABLE. We no longer them in order to make the output to be
+    // round-trippable, but we still set this field for now. See #68031.
     optional bool hidden = 7 [(gogoproto.nullable) = false];
   }
 

--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -372,7 +372,8 @@ t  CREATE TABLE public.t (
    UNIQUE INDEX i5 (w ASC) STORING (y),
    INVERTED INDEX i6 (v),
    INDEX i7 (z ASC) USING HASH WITH BUCKET_COUNT = 4,
-   FAMILY fam_0_x_y_z_w_v_crdb_internal_z_shard_4 (x, y, z, w, v, crdb_internal_z_shard_4)
+   FAMILY fam_0_x_y_z_w_v_crdb_internal_z_shard_4 (x, y, z, w, v, crdb_internal_z_shard_4),
+   CONSTRAINT check_crdb_internal_z_shard_4 CHECK (crdb_internal_z_shard_4 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8))
 )
 
 # Test that the indexes we expect got rewritten. All but i3 should have been rewritten,
@@ -521,7 +522,9 @@ t  CREATE TABLE public.t (
    CONSTRAINT "primary" PRIMARY KEY (y ASC) USING HASH WITH BUCKET_COUNT = 10,
    UNIQUE INDEX t_x_key (x ASC),
    INDEX i1 (z ASC) USING HASH WITH BUCKET_COUNT = 5,
-   FAMILY fam_0_x_y_z_crdb_internal_z_shard_5 (x, y, z, crdb_internal_z_shard_5, crdb_internal_y_shard_10)
+   FAMILY fam_0_x_y_z_crdb_internal_z_shard_5 (x, y, z, crdb_internal_z_shard_5, crdb_internal_y_shard_10),
+   CONSTRAINT check_crdb_internal_z_shard_5 CHECK (crdb_internal_z_shard_5 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8)),
+   CONSTRAINT check_crdb_internal_y_shard_10 CHECK (crdb_internal_y_shard_10 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8, 8:::INT8, 9:::INT8))
 )
 
 query T
@@ -585,7 +588,8 @@ t  CREATE TABLE public.t (
    CONSTRAINT "primary" PRIMARY KEY (y ASC),
    UNIQUE INDEX t_x_key (x ASC) USING HASH WITH BUCKET_COUNT = 5,
    INDEX i (z ASC),
-   FAMILY fam_0_x_y_z_crdb_internal_x_shard_5 (x, y, z, crdb_internal_x_shard_5)
+   FAMILY fam_0_x_y_z_crdb_internal_x_shard_5 (x, y, z, crdb_internal_x_shard_5),
+   CONSTRAINT check_crdb_internal_x_shard_5 CHECK (crdb_internal_x_shard_5 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8))
 )
 
 query III
@@ -738,7 +742,8 @@ t  CREATE TABLE public.t (
    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
    crdb_internal_x_shard_4 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(x AS STRING), '':::STRING)), 4:::INT8)) STORED,
    CONSTRAINT "primary" PRIMARY KEY (x ASC) USING HASH WITH BUCKET_COUNT = 4,
-   FAMILY "primary" (x, rowid, crdb_internal_x_shard_4)
+   FAMILY "primary" (x, rowid, crdb_internal_x_shard_4),
+   CONSTRAINT check_crdb_internal_x_shard_4 CHECK (crdb_internal_x_shard_4 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8))
 )
 
 statement ok
@@ -1195,7 +1200,9 @@ t  CREATE TABLE public.t (
    x INT8 NOT NULL,
    crdb_internal_x_shard_3 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(x AS STRING), '':::STRING)), 3:::INT8)) STORED,
    CONSTRAINT "primary" PRIMARY KEY (x ASC) USING HASH WITH BUCKET_COUNT = 3,
-   FAMILY "primary" (crdb_internal_x_shard_2, x, crdb_internal_x_shard_3)
+   FAMILY "primary" (crdb_internal_x_shard_2, x, crdb_internal_x_shard_3),
+   CONSTRAINT check_crdb_internal_x_shard_2 CHECK (crdb_internal_x_shard_2 IN (0:::INT8, 1:::INT8)),
+   CONSTRAINT check_crdb_internal_x_shard_3 CHECK (crdb_internal_x_shard_3 IN (0:::INT8, 1:::INT8, 2:::INT8))
 )
 
 # Changes on a hash sharded index that change the columns will cause the old
@@ -1215,7 +1222,9 @@ t  CREATE TABLE public.t (
    crdb_internal_y_shard_2 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(y AS STRING), '':::STRING)), 2:::INT8)) STORED,
    CONSTRAINT "primary" PRIMARY KEY (y ASC) USING HASH WITH BUCKET_COUNT = 2,
    UNIQUE INDEX t_x_key (x ASC) USING HASH WITH BUCKET_COUNT = 2,
-   FAMILY fam_0_x_y_crdb_internal_x_shard_2 (x, y, crdb_internal_x_shard_2, crdb_internal_y_shard_2)
+   FAMILY fam_0_x_y_crdb_internal_x_shard_2 (x, y, crdb_internal_x_shard_2, crdb_internal_y_shard_2),
+   CONSTRAINT check_crdb_internal_x_shard_2 CHECK (crdb_internal_x_shard_2 IN (0:::INT8, 1:::INT8)),
+   CONSTRAINT check_crdb_internal_y_shard_2 CHECK (crdb_internal_y_shard_2 IN (0:::INT8, 1:::INT8))
 )
 
 # Regression for #49079.

--- a/pkg/sql/logictest/testdata/logic_test/create_table
+++ b/pkg/sql/logictest/testdata/logic_test/create_table
@@ -342,7 +342,8 @@ like_hash  CREATE TABLE public.like_hash (
            rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
            CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
            INDEX like_hash_base_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 4,
-           FAMILY "primary" (a, crdb_internal_a_shard_4, rowid)
+           FAMILY "primary" (a, crdb_internal_a_shard_4, rowid),
+           CONSTRAINT check_crdb_internal_a_shard_4 CHECK (crdb_internal_a_shard_4 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8))
 )
 
 statement error unimplemented

--- a/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
+++ b/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
@@ -12,7 +12,8 @@ sharded_primary  CREATE TABLE public.sharded_primary (
                  crdb_internal_a_shard_10 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(a AS STRING), '':::STRING)), 10:::INT8)) STORED,
                  a INT8 NOT NULL,
                  CONSTRAINT "primary" PRIMARY KEY (a ASC) USING HASH WITH BUCKET_COUNT = 10,
-                 FAMILY "primary" (crdb_internal_a_shard_10, a)
+                 FAMILY "primary" (crdb_internal_a_shard_10, a),
+                 CONSTRAINT check_crdb_internal_a_shard_10 CHECK (crdb_internal_a_shard_10 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8, 8:::INT8, 9:::INT8))
 )
 
 statement error pgcode 22023 BUCKET_COUNT must be an integer greater than 1
@@ -45,7 +46,8 @@ sharded_primary  CREATE TABLE public.sharded_primary (
                  a INT8 NOT NULL,
                  crdb_internal_a_shard_10 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(a AS STRING), '':::STRING)), 10:::INT8)) STORED,
                  CONSTRAINT "primary" PRIMARY KEY (a ASC) USING HASH WITH BUCKET_COUNT = 10,
-                 FAMILY "primary" (crdb_internal_a_shard_10, a)
+                 FAMILY "primary" (crdb_internal_a_shard_10, a),
+                 CONSTRAINT check_crdb_internal_a_shard_10 CHECK (crdb_internal_a_shard_10 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8, 8:::INT8, 9:::INT8))
 )
 
 query TTT colnames
@@ -102,7 +104,8 @@ specific_family  CREATE TABLE public.specific_family (
                  CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                  INDEX specific_family_b_idx (b ASC) USING HASH WITH BUCKET_COUNT = 10,
                  FAMILY a_family (a, rowid),
-                 FAMILY b_family (b, crdb_internal_b_shard_10)
+                 FAMILY b_family (b, crdb_internal_b_shard_10),
+                 CONSTRAINT check_crdb_internal_b_shard_10 CHECK (crdb_internal_b_shard_10 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8, 8:::INT8, 9:::INT8))
 )
 
 # Tests for secondary sharded indexes
@@ -118,7 +121,8 @@ sharded_secondary  CREATE TABLE public.sharded_secondary (
                    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
                    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                    INDEX sharded_secondary_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 4,
-                   FAMILY "primary" (a, crdb_internal_a_shard_4, rowid)
+                   FAMILY "primary" (a, crdb_internal_a_shard_4, rowid),
+                   CONSTRAINT check_crdb_internal_a_shard_4 CHECK (crdb_internal_a_shard_4 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8))
 )
 
 statement ok
@@ -140,7 +144,8 @@ sharded_secondary  CREATE TABLE public.sharded_secondary (
                    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
                    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                    INDEX sharded_secondary_crdb_internal_a_shard_4_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 4,
-                   FAMILY "primary" (a, crdb_internal_a_shard_4, rowid)
+                   FAMILY "primary" (a, crdb_internal_a_shard_4, rowid),
+                   CONSTRAINT check_crdb_internal_a_shard_4 CHECK (crdb_internal_a_shard_4 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8))
 )
 
 statement ok
@@ -169,7 +174,8 @@ sharded_secondary  CREATE TABLE public.sharded_secondary (
                    crdb_internal_a_shard_10 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(a AS STRING), '':::STRING)), 10:::INT8)) STORED,
                    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                    INDEX sharded_secondary_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 10,
-                   FAMILY "primary" (a, rowid, crdb_internal_a_shard_10)
+                   FAMILY "primary" (a, rowid, crdb_internal_a_shard_10),
+                   CONSTRAINT check_crdb_internal_a_shard_10 CHECK (crdb_internal_a_shard_10 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8, 8:::INT8, 9:::INT8))
 )
 
 statement ok
@@ -190,7 +196,9 @@ sharded_secondary  CREATE TABLE public.sharded_secondary (
                    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                    INDEX sharded_secondary_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 10,
                    INDEX sharded_secondary_a_idx1 (a ASC) USING HASH WITH BUCKET_COUNT = 4,
-                   FAMILY "primary" (a, rowid, crdb_internal_a_shard_10, crdb_internal_a_shard_4)
+                   FAMILY "primary" (a, rowid, crdb_internal_a_shard_10, crdb_internal_a_shard_4),
+                   CONSTRAINT check_crdb_internal_a_shard_10 CHECK (crdb_internal_a_shard_10 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8, 8:::INT8, 9:::INT8)),
+                   CONSTRAINT check_crdb_internal_a_shard_4 CHECK (crdb_internal_a_shard_4 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8))
 )
 
 # Drop a sharded index and ensure that the shard column is dropped with it.
@@ -206,7 +214,8 @@ sharded_secondary  CREATE TABLE public.sharded_secondary (
                    crdb_internal_a_shard_4 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(a AS STRING), '':::STRING)), 4:::INT8)) STORED,
                    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                    INDEX sharded_secondary_a_idx1 (a ASC) USING HASH WITH BUCKET_COUNT = 4,
-                   FAMILY "primary" (a, rowid, crdb_internal_a_shard_4)
+                   FAMILY "primary" (a, rowid, crdb_internal_a_shard_4),
+                   CONSTRAINT check_crdb_internal_a_shard_4 CHECK (crdb_internal_a_shard_4 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8))
 )
 
 statement ok
@@ -267,7 +276,8 @@ sharded_secondary  CREATE TABLE public.sharded_secondary (
                    INDEX sharded_secondary_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 10,
                    INDEX sharded_secondary_a_idx1 (a ASC) USING HASH WITH BUCKET_COUNT = 10,
                    INDEX sharded_secondary_a_idx2 (a ASC) USING HASH WITH BUCKET_COUNT = 10,
-                   FAMILY "primary" (a, rowid, crdb_internal_a_shard_10)
+                   FAMILY "primary" (a, rowid, crdb_internal_a_shard_10),
+                   CONSTRAINT check_crdb_internal_a_shard_10 CHECK (crdb_internal_a_shard_10 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8, 8:::INT8, 9:::INT8))
 )
 
 
@@ -289,7 +299,9 @@ sharded_primary  CREATE TABLE public.sharded_primary (
                  crdb_internal_a_shard_4 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(a AS STRING), '':::STRING)), 4:::INT8)) STORED,
                  CONSTRAINT "primary" PRIMARY KEY (a ASC) USING HASH WITH BUCKET_COUNT = 10,
                  INDEX sharded_primary_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 4,
-                 FAMILY "primary" (crdb_internal_a_shard_10, a, crdb_internal_a_shard_4)
+                 FAMILY "primary" (crdb_internal_a_shard_10, a, crdb_internal_a_shard_4),
+                 CONSTRAINT check_crdb_internal_a_shard_10 CHECK (crdb_internal_a_shard_10 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8, 8:::INT8, 9:::INT8)),
+                 CONSTRAINT check_crdb_internal_a_shard_4 CHECK (crdb_internal_a_shard_4 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8))
 )
 
 statement ok
@@ -305,7 +317,8 @@ sharded_primary  CREATE TABLE public.sharded_primary (
                  a INT8 NOT NULL,
                  crdb_internal_a_shard_10 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(a AS STRING), '':::STRING)), 10:::INT8)) STORED,
                  CONSTRAINT "primary" PRIMARY KEY (a ASC) USING HASH WITH BUCKET_COUNT = 10,
-                 FAMILY "primary" (crdb_internal_a_shard_10, a)
+                 FAMILY "primary" (crdb_internal_a_shard_10, a),
+                 CONSTRAINT check_crdb_internal_a_shard_10 CHECK (crdb_internal_a_shard_10 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8, 8:::INT8, 9:::INT8))
 )
 
 statement ok
@@ -319,7 +332,8 @@ sharded_primary  CREATE TABLE public.sharded_primary (
                  crdb_internal_a_shard_10 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(a AS STRING), '':::STRING)), 10:::INT8)) STORED,
                  CONSTRAINT "primary" PRIMARY KEY (a ASC) USING HASH WITH BUCKET_COUNT = 10,
                  INDEX sharded_primary_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 10,
-                 FAMILY "primary" (crdb_internal_a_shard_10, a)
+                 FAMILY "primary" (crdb_internal_a_shard_10, a),
+                 CONSTRAINT check_crdb_internal_a_shard_10 CHECK (crdb_internal_a_shard_10 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8, 8:::INT8, 9:::INT8))
 )
 
 statement ok
@@ -399,7 +413,8 @@ column_used_on_unsharded  CREATE TABLE public.column_used_on_unsharded (
                           rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
                           CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                           INDEX column_used_on_unsharded_crdb_internal_a_shard_10_idx (crdb_internal_a_shard_10 ASC),
-                          FAMILY "primary" (a, crdb_internal_a_shard_10, rowid)
+                          FAMILY "primary" (a, crdb_internal_a_shard_10, rowid),
+                          CONSTRAINT check_crdb_internal_a_shard_10 CHECK (crdb_internal_a_shard_10 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8, 8:::INT8, 9:::INT8))
 )
 
 statement ok
@@ -424,7 +439,8 @@ column_used_on_unsharded_create_table  CREATE TABLE public.column_used_on_unshar
                                        rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
                                        CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                                        INDEX column_used_on_unsharded_create_table_crdb_internal_a_shard_10_idx (crdb_internal_a_shard_10 ASC),
-                                       FAMILY "primary" (a, crdb_internal_a_shard_10, rowid)
+                                       FAMILY "primary" (a, crdb_internal_a_shard_10, rowid),
+                                       CONSTRAINT check_crdb_internal_a_shard_10 CHECK (crdb_internal_a_shard_10 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8, 8:::INT8, 9:::INT8))
 )
 
 statement ok
@@ -480,7 +496,9 @@ weird_names  CREATE TABLE public.weird_names (
              "crdb_internal_'quotes' in the column's name_shard_4" INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST("'quotes' in the column's name" AS STRING), '':::STRING)), 4:::INT8)) STORED,
              CONSTRAINT "primary" PRIMARY KEY ("I am a column with spaces" ASC) USING HASH WITH BUCKET_COUNT = 12,
              INDEX foo ("'quotes' in the column's name" ASC) USING HASH WITH BUCKET_COUNT = 4,
-             FAMILY "primary" ("I am a column with spaces", "'quotes' in the column's name", "crdb_internal_I am a column with spaces_shard_12", "crdb_internal_'quotes' in the column's name_shard_4")
+             FAMILY "primary" ("I am a column with spaces", "'quotes' in the column's name", "crdb_internal_I am a column with spaces_shard_12", "crdb_internal_'quotes' in the column's name_shard_4"),
+             CONSTRAINT "check_crdb_internal_I am a column with spaces_shard_12" CHECK ("crdb_internal_I am a column with spaces_shard_12" IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8, 8:::INT8, 9:::INT8, 10:::INT8, 11:::INT8)),
+             CONSTRAINT "check_crdb_internal_'quotes' in the column's name_shard_4" CHECK ("crdb_internal_'quotes' in the column's name_shard_4" IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8))
 )
 
 subtest interleave_disabled
@@ -575,7 +593,9 @@ rename_column  CREATE TABLE public.rename_column (
                crdb_internal_c2_shard_8 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(c2 AS STRING), '':::STRING)), 8:::INT8)) STORED,
                CONSTRAINT "primary" PRIMARY KEY (c0 ASC, c1 ASC) USING HASH WITH BUCKET_COUNT = 8,
                INDEX rename_column_c2_idx (c2 ASC) USING HASH WITH BUCKET_COUNT = 8,
-               FAMILY "primary" (c0, c1, c2, crdb_internal_c0_c1_shard_8, crdb_internal_c2_shard_8)
+               FAMILY "primary" (c0, c1, c2, crdb_internal_c0_c1_shard_8, crdb_internal_c2_shard_8),
+               CONSTRAINT check_crdb_internal_c0_c1_shard_8 CHECK (crdb_internal_c0_c1_shard_8 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8)),
+               CONSTRAINT check_crdb_internal_c2_shard_8 CHECK (crdb_internal_c2_shard_8 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8))
 )
 
 statement ok
@@ -599,7 +619,9 @@ rename_column  CREATE TABLE public.rename_column (
                crdb_internal_c3_shard_8 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(c3 AS STRING), '':::STRING)), 8:::INT8)) STORED,
                CONSTRAINT "primary" PRIMARY KEY (c1 ASC, c2 ASC) USING HASH WITH BUCKET_COUNT = 8,
                INDEX rename_column_c2_idx (c3 ASC) USING HASH WITH BUCKET_COUNT = 8,
-               FAMILY "primary" (c1, c2, c3, crdb_internal_c1_c2_shard_8, crdb_internal_c3_shard_8)
+               FAMILY "primary" (c1, c2, c3, crdb_internal_c1_c2_shard_8, crdb_internal_c3_shard_8),
+               CONSTRAINT check_crdb_internal_c0_c1_shard_8 CHECK (crdb_internal_c1_c2_shard_8 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8)),
+               CONSTRAINT check_crdb_internal_c2_shard_8 CHECK (crdb_internal_c3_shard_8 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8))
 )
 
 query III
@@ -622,7 +644,9 @@ rename_column  CREATE TABLE public.rename_column (
                crdb_internal_c2_shard_8 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(COALESCE(CAST(c2 AS STRING), '':::STRING)), 8:::INT8)) STORED,
                CONSTRAINT "primary" PRIMARY KEY (c0 ASC, c1 ASC) USING HASH WITH BUCKET_COUNT = 8,
                INDEX rename_column_c2_idx (c2 ASC) USING HASH WITH BUCKET_COUNT = 8,
-               FAMILY "primary" (c0, c1, c2, crdb_internal_c0_c1_shard_8, crdb_internal_c2_shard_8)
+               FAMILY "primary" (c0, c1, c2, crdb_internal_c0_c1_shard_8, crdb_internal_c2_shard_8),
+               CONSTRAINT check_crdb_internal_c0_c1_shard_8 CHECK (crdb_internal_c0_c1_shard_8 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8)),
+               CONSTRAINT check_crdb_internal_c2_shard_8 CHECK (crdb_internal_c2_shard_8 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8))
 )
 
 query III

--- a/pkg/sql/show_create_clauses.go
+++ b/pkg/sql/show_create_clauses.go
@@ -454,9 +454,6 @@ func showConstraintClause(
 	ctx context.Context, desc catalog.TableDescriptor, semaCtx *tree.SemaContext, f *tree.FmtCtx,
 ) error {
 	for _, e := range desc.AllActiveAndInactiveChecks() {
-		if e.Hidden {
-			continue
-		}
 		f.WriteString(",\n\t")
 		if len(e.Name) > 0 {
 			f.WriteString("CONSTRAINT ")

--- a/pkg/sql/show_test.go
+++ b/pkg/sql/show_test.go
@@ -295,7 +295,8 @@ func TestShowCreateTable(t *testing.T) {
 	rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
 	CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
 	INDEX t14_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 8,
-	FAMILY "primary" (a, crdb_internal_a_shard_8, rowid)
+	FAMILY "primary" (a, crdb_internal_a_shard_8, rowid),
+	CONSTRAINT check_crdb_internal_a_shard_8 CHECK (crdb_internal_a_shard_8 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8))
 )`,
 		},
 	}


### PR DESCRIPTION
Backport 1/1 commits from #69001.

/cc @cockroachdb/release

---

Showing hash-sharded column CHECK constraints makes the output of SHOW
CREATE TABLE round-trippable.

Informs #68031

Release note (bug fix): Given a table with hash-sharded indexes, the
output of SHOW CREATE TABLE was not round-trippable - executing the
output would not create an identical table. This has been fixed by
showing CHECK constraints that are automatically created for these
indexes in the output of SHOW CREATE TABLE. The bug existed since
version 21.1.

---

Release justification: This is a low-risk bug fix.