### PR TITLE
builtins: harden some builtins against OidWrappers

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -904,3 +904,10 @@ query TT
 SELECT * FROM crdb_internal.regions ORDER BY 1
 ----
 test  {}
+
+# Regression test for incorrectly handling tree.DOidWrappers by some builtins
+# (#69684).
+statement ok
+CREATE TABLE t69684(a NAME);
+INSERT INTO t69684 VALUES ('foo');
+SELECT * FROM t69684 WHERE crdb_internal.increment_feature_counter(a)

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -4363,7 +4363,11 @@ value if you rely on the HLC for accuracy.`,
 			Types:      tree.ArgTypes{{"key", types.String}},
 			ReturnType: tree.FixedReturnType(types.String),
 			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
-				key := string(*(args[0].(*tree.DString)))
+				s, ok := tree.AsDString(args[0])
+				if !ok {
+					return nil, errors.Newf("expected string value, got %T", args[0])
+				}
+				key := string(s)
 				for i := range ctx.Locality.Tiers {
 					tier := &ctx.Locality.Tiers[i]
 					if tier.Key == key {
@@ -4662,8 +4666,16 @@ value if you rely on the HLC for accuracy.`,
 			Types:      tree.ArgTypes{{"errorCode", types.String}, {"msg", types.String}},
 			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
-				errCode := string(*args[0].(*tree.DString))
-				msg := string(*args[1].(*tree.DString))
+				s, ok := tree.AsDString(args[0])
+				if !ok {
+					return nil, errors.Newf("expected string value, got %T", args[0])
+				}
+				errCode := string(s)
+				s, ok = tree.AsDString(args[1])
+				if !ok {
+					return nil, errors.Newf("expected string value, got %T", args[1])
+				}
+				msg := string(s)
 				// We construct the errors below via %s as the
 				// message may contain PII.
 				if errCode == "" {
@@ -4684,7 +4696,11 @@ value if you rely on the HLC for accuracy.`,
 			Types:      tree.ArgTypes{{"msg", types.String}},
 			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
-				msg := string(*args[0].(*tree.DString))
+				s, ok := tree.AsDString(args[0])
+				if !ok {
+					return nil, errors.Newf("expected string value, got %T", args[0])
+				}
+				msg := string(s)
 				return crdbInternalSendNotice(ctx, "NOTICE", msg)
 			},
 			Info:       "This function is used only by CockroachDB's developers for testing purposes.",
@@ -4694,8 +4710,16 @@ value if you rely on the HLC for accuracy.`,
 			Types:      tree.ArgTypes{{"severity", types.String}, {"msg", types.String}},
 			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
-				severityString := string(*args[0].(*tree.DString))
-				msg := string(*args[1].(*tree.DString))
+				s, ok := tree.AsDString(args[0])
+				if !ok {
+					return nil, errors.Newf("expected string value, got %T", args[0])
+				}
+				severityString := string(s)
+				s, ok = tree.AsDString(args[1])
+				if !ok {
+					return nil, errors.Newf("expected string value, got %T", args[1])
+				}
+				msg := string(s)
 				if _, ok := pgnotice.ParseDisplaySeverity(severityString); !ok {
 					return nil, pgerror.Newf(pgcode.InvalidParameterValue, "severity %s is invalid", severityString)
 				}
@@ -4714,7 +4738,11 @@ value if you rely on the HLC for accuracy.`,
 			Types:      tree.ArgTypes{{"msg", types.String}},
 			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
-				msg := string(*args[0].(*tree.DString))
+				s, ok := tree.AsDString(args[0])
+				if !ok {
+					return nil, errors.Newf("expected string value, got %T", args[0])
+				}
+				msg := string(s)
 				return nil, errors.AssertionFailedf("%s", msg)
 			},
 			Info:       "This function is used only by CockroachDB's developers for testing purposes.",
@@ -4733,7 +4761,11 @@ value if you rely on the HLC for accuracy.`,
 				if err := checkPrivilegedUser(ctx); err != nil {
 					return nil, err
 				}
-				msg := string(*args[0].(*tree.DString))
+				s, ok := tree.AsDString(args[0])
+				if !ok {
+					return nil, errors.Newf("expected string value, got %T", args[0])
+				}
+				msg := string(s)
 				// Use a special method to panic in order to go around the
 				// vectorized panic-catcher (which would catch the panic from
 				// Golang's 'panic' and would convert it into an internal
@@ -4758,7 +4790,11 @@ value if you rely on the HLC for accuracy.`,
 				if err := checkPrivilegedUser(ctx); err != nil {
 					return nil, err
 				}
-				msg := string(*args[0].(*tree.DString))
+				s, ok := tree.AsDString(args[0])
+				if !ok {
+					return nil, errors.Newf("expected string value, got %T", args[0])
+				}
+				msg := string(s)
 				log.Fatalf(ctx.Ctx(), "force_log_fatal(): %s", msg)
 				return nil, nil
 			},
@@ -5019,7 +5055,12 @@ value if you rely on the HLC for accuracy.`,
 				if err := checkPrivilegedUser(ctx); err != nil {
 					return nil, err
 				}
-				return tree.DZero, log.SetVModule(string(*args[0].(*tree.DString)))
+				s, ok := tree.AsDString(args[0])
+				if !ok {
+					return nil, errors.Newf("expected string value, got %T", args[0])
+				}
+				vmodule := string(s)
+				return tree.DZero, log.SetVModule(vmodule)
 			},
 			Info: "Set the equivalent of the `--vmodule` flag on the gateway node processing this request; " +
 				"it affords control over the logging verbosity of different files. " +
@@ -5660,7 +5701,11 @@ value if you rely on the HLC for accuracy.`,
 			Types:      tree.ArgTypes{{"feature", types.String}},
 			ReturnType: tree.FixedReturnType(types.Bool),
 			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
-				feature := string(*args[0].(*tree.DString))
+				s, ok := tree.AsDString(args[0])
+				if !ok {
+					return nil, errors.Newf("expected string value, got %T", args[0])
+				}
+				feature := string(s)
 				telemetry.Inc(sqltelemetry.HashedFeatureCounter(feature))
 				return tree.DBoolTrue, nil
 			},

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -147,7 +147,11 @@ var generators = map[string]builtinDefinition{
 			tree.ArgTypes{{"name", types.String}},
 			types.Int,
 			func(ctx *tree.EvalContext, args tree.Datums) (tree.ValueGenerator, error) {
-				name := string(*args[0].(*tree.DString))
+				s, ok := tree.AsDString(args[0])
+				if !ok {
+					return nil, errors.Newf("expected string value, got %T", args[0])
+				}
+				name := string(s)
 				gen, ok := ctx.TestingKnobs.CallbackGenerators[name]
 				if !ok {
 					return nil, errors.Errorf("callback %q not registered", name)


### PR DESCRIPTION
This commit replaces several usages of unsafe `*tree.DString` interface
conversions with safe `tree.AsDString` function calls.

Release note (bug fix): Previously, an internal error or a crash could
occur when some `crdb_internal` builtin functions took string-like type
arguments (e.g. `name`). This is now fixed.

Fixes: #69684.

Release justification: low-risk bug fix.