### PR TITLE
release-20.2: backupccl: add ordering to system table restore

### DIFF
--- a/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
+++ b/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
@@ -885,3 +885,37 @@ func TestReintroduceOfflineSpans(t *testing.T) {
 		destDB.ExpectErr(t, `relation "restoredb.bank" does not exist`, `SELECT count(*) FROM restoredb.bank`)
 	})
 }
+
+func TestClusterRestoreSystemTableOrdering(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	const numAccounts = 10
+	_, _, sqlDB, tempDir, cleanupFn := BackupRestoreTestSetup(t, singleNode, numAccounts, InitNone)
+	_, tcRestore, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode,
+		tempDir, InitNone, base.TestClusterArgs{})
+	defer cleanupFn()
+	defer cleanupEmptyCluster()
+
+	restoredSystemTables := make([]string, 0)
+	for _, server := range tcRestore.Servers {
+		registry := server.JobRegistry().(*jobs.Registry)
+		registry.TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{
+			jobspb.TypeRestore: func(raw jobs.Resumer) jobs.Resumer {
+				r := raw.(*restoreResumer)
+				r.testingKnobs.duringSystemTableRestoration = func(systemTableName string) error {
+					restoredSystemTables = append(restoredSystemTables, systemTableName)
+					return nil
+				}
+				return r
+			},
+		}
+	}
+
+	sqlDB.Exec(t, `BACKUP TO $1`, LocalFoo)
+	sqlDBRestore.Exec(t, `RESTORE FROM $1`, LocalFoo)
+	// Check that the settings table is the last of the system tables to be
+	// restored.
+	require.Equal(t, restoredSystemTables[len(restoredSystemTables)-1],
+		systemschema.SettingsTable.GetName())
+}


### PR DESCRIPTION
This is a backport of #67875.

Release note: None

Release justification: enforcing an ordering on the system tables
being restored such that the settings table is restored last, avoids
a situation where the user wants the restore to run using certain settings
but is unable to do so since they are overwritten by the premature
restoration of the settings table. This has caused issues in production
clusters and prevented customers from being able to restore their data.