### PR TITLE
status: also produce runtime stats on the DEV channel

### DIFF
--- a/pkg/server/status/BUILD.bazel
+++ b/pkg/server/status/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "runtime.go",
         "runtime_jemalloc.go",
         "runtime_jemalloc_darwin.go",
+        "runtime_log.go",
     ],
     # keep
     cdeps = [

--- a/pkg/server/status/runtime.go
+++ b/pkg/server/status/runtime.go
@@ -529,7 +529,7 @@ func (rsr *RuntimeStatSampler) SampleEnvironment(
 	goStatsStaleness := float32(timeutil.Now().Sub(ms.Collected)) / float32(time.Second)
 	goTotal := ms.Sys - ms.HeapReleased
 
-	log.StructuredEvent(ctx, &eventpb.RuntimeStats{
+	stats := &eventpb.RuntimeStats{
 		MemRSSBytes:       mem.Resident,
 		GoroutineCount:    uint64(numGoroutine),
 		MemStackSysBytes:  ms.StackSys,
@@ -548,7 +548,9 @@ func (rsr *RuntimeStatSampler) SampleEnvironment(
 		GCRunCount:        uint64(gc.NumGC),
 		NetHostRecvBytes:  deltaNet.BytesRecv,
 		NetHostSendBytes:  deltaNet.BytesSent,
-	})
+	}
+
+	logStats(ctx, stats)
 
 	rsr.last.cgoCall = numCgoCall
 	rsr.last.gcCount = gc.NumGC

--- a/pkg/server/status/runtime_log.go
+++ b/pkg/server/status/runtime_log.go
@@ -1,0 +1,47 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package status
+
+import (
+	"context"
+	"strings"
+	"text/template"
+
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
+	"github.com/cockroachdb/redact"
+	humanize "github.com/dustin/go-humanize"
+)
+
+// statsTemplate formats an event of type eventpb.RuntimeStats into a
+// user-facing string.
+// TODO(knz): It may be beneficial to make this configurable at run-time.
+var statsTemplate = template.Must(template.New("runtime stats").Funcs(template.FuncMap{
+	"iBytes": humanize.IBytes,
+}).Parse(`{{iBytes .MemRSSBytes}} RSS, {{.GoroutineCount}} goroutines (stacks: {{iBytes .MemStackSysBytes}}), ` +
+	`{{iBytes .GoAllocBytes}}/{{iBytes .GoTotalBytes}} Go alloc/total{{if .GoStatsStaleness}}(stale){{end}} ` +
+	`(heap fragmentation: {{iBytes .HeapFragmentBytes}}, heap reserved: {{iBytes .HeapReservedBytes}}, heap released: {{iBytes .HeapReleasedBytes}}), ` +
+	`{{iBytes .CGoAllocBytes}}/{{iBytes .CGoTotalBytes}} CGO alloc/total ({{printf "%.1f" .CGoCallRate}} CGO/sec), ` +
+	`{{printf "%.1f" .CPUUserPercent}}/{{printf "%.1f" .CPUSysPercent}} %(u/s)time, {{printf "%.1f" .GCPausePercent}} %gc ({{.GCRunCount}}x), ` +
+	`{{iBytes .NetHostRecvBytes}}/{{iBytes .NetHostSendBytes}} (r/w)net`))
+
+func logStats(ctx context.Context, stats *eventpb.RuntimeStats) {
+	// In any case, log the structured event to its native channel (HEALTH).
+	log.StructuredEvent(ctx, stats)
+
+	// Also, log a formatted version of the structured event on the DEV channel,
+	// for use by humans while troubleshooting from log files.
+	var buf strings.Builder
+	if err := statsTemplate.Execute(&buf, stats); err != nil {
+		log.Warningf(ctx, "failed to render runtime stats: %v", err)
+	}
+	log.Dev.Infof(ctx, "runtime stats: %s", redact.SafeString(buf.String()))
+}


### PR DESCRIPTION
Fixes  #67518.
Replaces #69440.

Requested by @andreimatei ; approach recommended by @bdarnell .

We found out during support cases that it is useful to see a human
version of the runtime stats payload in the DEV log events.

Release justification: low risk, high benefit changes to existing functionality

Release note: None