### PR TITLE
sql: populate Nodes field in roachpb.StatementStatistics

### DIFF
--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding.go
@@ -82,6 +82,12 @@ func BuildStmtMetadataJSON(statistics *roachpb.CollectedStatementStatistics) (js
 //          },
 //          "required": ["mean", "sqDiff"]
 //        },
+//        "node_ids": {
+//          "type": "array",
+//          "items": {
+//            "type": "int",
+//          },
+//        },
 //        "statistics": {
 //          "type": "object",
 //          "properties": {
@@ -97,6 +103,7 @@ func BuildStmtMetadataJSON(statistics *roachpb.CollectedStatementStatistics) (js
 //            "rowsRead":          { "$ref": "#/definitions/numeric_stats" }
 //            "firstExecAt":       { "type": "string" },
 //            "lastExecAt":        { "type": "string" },
+//            "nodes":             { "type": "node_ids" },
 //          },
 //          "required": [
 //            "firstAttemptCnt",
@@ -108,7 +115,8 @@ func BuildStmtMetadataJSON(statistics *roachpb.CollectedStatementStatistics) (js
 //            "svcLat",
 //            "ovhLat",
 //            "bytesRead",
-//            "rowsRead"
+//            "rowsRead",
+//            "nodes"
 //          ]
 //        },
 //        "execution_statistics": {

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding_test.go
@@ -29,7 +29,7 @@ func jsonTestHelper(t *testing.T, expectedStr string, actual json.JSON) {
 
 	cmp, err := actual.Compare(expected)
 	require.NoError(t, err)
-	require.True(t, cmp == 0, "expected %s\nbut found %s", expected.String(), actual.String())
+	require.Zerof(t, cmp, "expected %s\nbut found %s", expected.String(), actual.String())
 }
 func TestSQLStatsJsonEncoding(t *testing.T) {
 	defer leaktest.AfterTest(t)()
@@ -91,7 +91,8 @@ func TestSQLStatsJsonEncoding(t *testing.T) {
          "rowsRead": {
            "mean": {{.Float}},
            "sqDiff": {{.Float}}
-         }
+         },
+         "nodes": [{{joinInts .IntArray}}]
        },
        "execution_statistics": {
          "cnt": {{.Int64}},


### PR DESCRIPTION
Previously, we were not populating the Nodes field in the
roachpb.StatementStatistics for stats we read from SQL tables.
(both virtual table and system table). This breaks the
Statement/Transaction Page in the frontend where we would
not have the data to filter the multiregion workloads.
This commit fixes this issue and expanded the randomized
testing framework to test JSON array type.

Release justification: Bug fixes and low-risk updates to new
functionality
Release note: None