### PR TITLE
ci: clean up the bazel CI scripts a bit

### DIFF
--- a/build/teamcity/cockroach/ci/builds/build_impl.sh
+++ b/build/teamcity/cockroach/ci/builds/build_impl.sh
@@ -20,6 +20,6 @@ then
 fi
 
 bazel build //pkg/cmd/bazci --config=ci
-$(bazel info bazel-bin)/pkg/cmd/bazci/bazci_/bazci --compilation_mode opt \
+$(bazel info bazel-bin --config=ci)/pkg/cmd/bazci/bazci_/bazci --compilation_mode opt \
 		       --config "$CONFIG" \
 		       build //pkg/cmd/cockroach-short //c-deps:libgeos $GENFILES_TARGETS

--- a/build/teamcity/cockroach/ci/builds/build_linux_arm64.sh
+++ b/build/teamcity/cockroach/ci/builds/build_linux_arm64.sh
@@ -7,8 +7,6 @@ dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
 source "$dir/teamcity-support.sh"  # For $root
 source "$dir/teamcity-bazel-support.sh"  # For run_bazel
 
-tc_prepare
-
 tc_start_block "Run Bazel build"
 run_bazel build/teamcity/cockroach/ci/builds/build_impl.sh crosslinuxarm
 tc_end_block "Run Bazel build"

--- a/build/teamcity/cockroach/ci/builds/build_linux_x86_64.sh
+++ b/build/teamcity/cockroach/ci/builds/build_linux_x86_64.sh
@@ -7,8 +7,6 @@ dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
 source "$dir/teamcity-support.sh"  # For $root
 source "$dir/teamcity-bazel-support.sh"  # For run_bazel
 
-tc_prepare
-
 tc_start_block "Run Bazel build"
 run_bazel build/teamcity/cockroach/ci/builds/build_impl.sh crosslinux
 tc_end_block "Run Bazel build"

--- a/build/teamcity/cockroach/ci/builds/build_macos_x86_64.sh
+++ b/build/teamcity/cockroach/ci/builds/build_macos_x86_64.sh
@@ -7,8 +7,6 @@ dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
 source "$dir/teamcity-support.sh"  # For $root
 source "$dir/teamcity-bazel-support.sh"  # For run_bazel
 
-tc_prepare
-
 tc_start_block "Run Bazel build"
 run_bazel build/teamcity/cockroach/ci/builds/build_impl.sh crossmacos
 tc_end_block "Run Bazel build"

--- a/build/teamcity/cockroach/ci/builds/build_windows_x86_64.sh
+++ b/build/teamcity/cockroach/ci/builds/build_windows_x86_64.sh
@@ -7,8 +7,6 @@ dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
 source "$dir/teamcity-support.sh"  # For $root
 source "$dir/teamcity-bazel-support.sh"  # For run_bazel
 
-tc_prepare
-
 tc_start_block "Run Bazel build"
 run_bazel build/teamcity/cockroach/ci/builds/build_impl.sh crosswindows
 tc_end_block "Run Bazel build"

--- a/build/teamcity/cockroach/ci/tests/bench.sh
+++ b/build/teamcity/cockroach/ci/tests/bench.sh
@@ -7,8 +7,6 @@ dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
 source "$dir/teamcity-support.sh"  # For $root
 source "$dir/teamcity-bazel-support.sh"  # For run_bazel
 
-tc_prepare
-
 tc_start_block "Run benchmark tests"
 run_bazel build/teamcity/cockroach/ci/tests/bench_impl.sh
 tc_end_block "Run benchmark tests"

--- a/build/teamcity/cockroach/ci/tests/lint.sh
+++ b/build/teamcity/cockroach/ci/tests/lint.sh
@@ -7,8 +7,6 @@ dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
 source "$dir/teamcity-support.sh"  # For $root
 source "$dir/teamcity-bazel-support.sh"  # For run_bazel
 
-tc_prepare
-
 tc_start_block "Run lints"
 run_bazel build/teamcity/cockroach/ci/tests/lint_impl.sh
 tc_end_block "Run lints"

--- a/build/teamcity/cockroach/ci/tests/lint_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/lint_impl.sh
@@ -7,4 +7,4 @@ XML_OUTPUT_FILE=/artifacts/test.xml GO_TEST_WRAP_TESTV=1 GO_TEST_WRAP=1 bazel \
 	       run --config=ci --config=test //build/bazelutil:lint
 # The schema of the output test.xml will be slightly wrong -- ask `bazci` to fix
 # it up.
-$(bazel info bazel-bin)/pkg/cmd/bazci/bazci_/bazci munge-test-xml /artifacts/test.xml
+$(bazel info bazel-bin --config=ci)/pkg/cmd/bazci/bazci_/bazci munge-test-xml /artifacts/test.xml

--- a/build/teamcity/cockroach/ci/tests/maybe_stress.sh
+++ b/build/teamcity/cockroach/ci/tests/maybe_stress.sh
@@ -7,8 +7,6 @@ dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
 source "$dir/teamcity-support.sh"  # For $root, would_stress
 source "$dir/teamcity-bazel-support.sh"  # For run_bazel
 
-tc_prepare
-
 if would_stress; then
     tc_start_block "Run stress tests"
     run_bazel env BUILD_VCS_NUMBER="$BUILD_VCS_NUMBER" build/teamcity/cockroach/ci/tests/maybe_stress_impl.sh stress

--- a/build/teamcity/cockroach/ci/tests/maybe_stress_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/maybe_stress_impl.sh
@@ -11,6 +11,6 @@ fi
 TARGET="$1"
 
 bazel build //pkg/cmd/github-pull-request-make //pkg/cmd/bazci @com_github_cockroachdb_stress//:stress --config=ci
-BAZEL_BIN=$(bazel info bazel-bin)
+BAZEL_BIN=$(bazel info bazel-bin --config=ci)
 PATH=$PATH:$BAZEL_BIN/pkg/cmd/bazci/bazci_:$BAZEL_BIN/external/com_github_cockroachdb_stress/stress_ TARGET=$TARGET \
     $BAZEL_BIN/pkg/cmd/github-pull-request-make/github-pull-request-make_/github-pull-request-make

--- a/build/teamcity/cockroach/ci/tests/maybe_stressrace.sh
+++ b/build/teamcity/cockroach/ci/tests/maybe_stressrace.sh
@@ -7,8 +7,6 @@ dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
 source "$dir/teamcity-support.sh"  # For $root, would_stress
 source "$dir/teamcity-bazel-support.sh"  # For run_bazel
 
-tc_prepare
-
 if would_stress; then
     tc_start_block "Run stress tests"
     run_bazel env BUILD_VCS_NUMBER="$BUILD_VCS_NUMBER" build/teamcity/cockroach/ci/tests/maybe_stress_impl.sh stressrace

--- a/build/teamcity/cockroach/ci/tests/testrace.sh
+++ b/build/teamcity/cockroach/ci/tests/testrace.sh
@@ -7,8 +7,6 @@ dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
 source "$dir/teamcity-support.sh"  # For $root
 source "$dir/teamcity-bazel-support.sh"  # For run_bazel
 
-tc_prepare
-
 tc_start_block "Determine changed packages"
 if tc_release_branch; then
   pkgspec=./pkg/...

--- a/build/teamcity/cockroach/ci/tests/testrace_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/testrace_impl.sh
@@ -19,7 +19,7 @@ do
     # Run affected tests.
     for test in $tests
     do
-        $(bazel info bazel-bin)/pkg/cmd/bazci/bazci_/bazci --config ci --config race test "$test" -- \
+        $(bazel info bazel-bin --config=ci)/pkg/cmd/bazci/bazci_/bazci --config=ci --config=race test "$test" -- \
                                --test_env=COCKROACH_LOGIC_TESTS_SKIP=true \
                                --test_env=GOMAXPROCS=8
     done

--- a/build/teamcity/cockroach/ci/tests/unit_tests.sh
+++ b/build/teamcity/cockroach/ci/tests/unit_tests.sh
@@ -7,8 +7,6 @@ dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
 source "$dir/teamcity-support.sh"  # For $root
 source "$dir/teamcity-bazel-support.sh"  # For run_bazel
 
-tc_prepare
-
 tc_start_block "Run unit tests"
 run_bazel build/teamcity/cockroach/ci/tests/unit_tests_impl.sh
 tc_end_block "Run unit tests"

--- a/build/teamcity/cockroach/ci/tests/unit_tests_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/unit_tests_impl.sh
@@ -3,5 +3,5 @@
 set -xeuo pipefail
 
 bazel build //pkg/cmd/bazci --config=ci
-$(bazel info bazel-bin)/pkg/cmd/bazci/bazci_/bazci --config ci \
+$(bazel info bazel-bin --config=ci)/pkg/cmd/bazci/bazci_/bazci --config=ci \
 		       test //pkg:small_tests //pkg:medium_tests //pkg:large_tests //pkg:enormous_tests


### PR DESCRIPTION
1. Prefer to pass in the appropriate `--config` flags when calling
   `bazel info`. This doesn't change anything in practice, but certain
   `--config`s CAN change the output of `bazel info`, so this is kind of
   like future-proofing.
2. Don't call into `tc_prepare` anywhere. It doesn't do anything for
   Bazel builds.

Release justification: Non-production code change
Release note: None