### PR TITLE
ci: add bazel local roachtest job

### DIFF
--- a/build/bazelbuilder/Dockerfile
+++ b/build/bazelbuilder/Dockerfile
@@ -15,8 +15,10 @@ RUN apt-get update \
     gnupg2 \
     libncurses-dev \
     libtinfo-dev \
+    lsof \
     make \
     netbase \
+    openjdk-8-jre \
     unzip \
  && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-10 100 \
     --slave /usr/bin/clang++ clang++ /usr/bin/clang++-10 \

--- a/build/teamcity-bazel-support.sh
+++ b/build/teamcity-bazel-support.sh
@@ -1,7 +1,7 @@
 # FYI: You can run `./dev builder` to run this Docker image. :)
 # `dev` depends on this variable! Don't change the name or format unless you
 # also update `dev` accordingly.
-BAZEL_IMAGE=cockroachdb/bazel:20210831-144443
+BAZEL_IMAGE=cockroachdb/bazel:20210914-174235
 
 # Call `run_bazel $NAME_OF_SCRIPT` to start an appropriately-configured Docker
 # container with the `cockroachdb/bazel` image running the given script.

--- a/build/teamcity/cockroach/ci/tests/local_roachtest.sh
+++ b/build/teamcity/cockroach/ci/tests/local_roachtest.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
+
+source "$dir/teamcity-support.sh"  # For $root
+source "$dir/teamcity-bazel-support.sh"  # For run_bazel
+
+tc_start_block "Prepare environment"
+# Grab a testing license good for one hour.
+COCKROACH_DEV_LICENSE=$(curl --retry 3 --retry-connrefused -f "https://register.cockroachdb.com/api/prodtest")
+tc_end_block "Prepare environment"
+
+tc_start_block "Run local roachtests"
+run_bazel env \
+    COCKROACH_DEV_LICENSE="${COCKROACH_DEV_LICENSE}" \
+    GITHUB_API_TOKEN="${GITHUB_API_TOKEN-}" \
+    BUILD_VCS_NUMBER="${BUILD_VCS_NUMBER-}" \
+    TC_BUILD_ID="${TC_BUILD_ID-}" \
+    TC_SERVER_URL="${TC_SERVER_URL-}" \
+    TC_BUILD_BRANCH="${TC_BUILD_BRANCH-}" \
+    build/teamcity/cockroach/ci/tests/local_roachtest_impl.sh
+tc_end_block "Run local roachtests"

--- a/build/teamcity/cockroach/ci/tests/local_roachtest_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/local_roachtest_impl.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+bazel build --config=crosslinux //pkg/cmd/cockroach-short \
+      //pkg/cmd/roachprod \
+      //pkg/cmd/roachtest \
+      //pkg/cmd/workload
+
+BAZEL_BIN=$(bazel info bazel-bin --config=crosslinux)
+$BAZEL_BIN/pkg/cmd/roachtest/roachtest_/roachtest run acceptance kv/splits cdc/bank \
+  --local \
+  --parallelism=1 \
+  --cockroach "$BAZEL_BIN/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short" \
+  --roachprod "$BAZEL_BIN/pkg/cmd/roachprod/roachprod_/roachprod" \
+  --workload "$BAZEL_BIN/pkg/cmd/workload/workload_/workload" \
+  --artifacts /artifacts \
+  --teamcity


### PR DESCRIPTION
These tests require `lsof` and a JRE for the `cdc/bank` test.

Closes #67139.

Release justification: Non-production code change
Release note: None