### PR TITLE
sql: restructure sqlstats public writer API

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -91,7 +91,7 @@ func (ex *connExecutor) execStmt(
 	// Run observer statements in a separate code path; their execution does not
 	// depend on the current transaction state.
 	if _, ok := ast.(tree.ObserverStatement); ok {
-		ex.statsCollector.Reset(ex.statsWriter, ex.phaseTimes)
+		ex.statsCollector.Reset(ex.applicationStats, ex.phaseTimes)
 		err := ex.runObserverStatement(ctx, ast, res)
 		// Note that regardless of res.Err(), these observer statements don't
 		// generate error events; transactions are always allowed to continue.
@@ -364,7 +364,7 @@ func (ex *connExecutor) execStmtInOpenState(
 
 	p := &ex.planner
 	stmtTS := ex.server.cfg.Clock.PhysicalTime()
-	ex.statsCollector.Reset(ex.statsWriter, ex.phaseTimes)
+	ex.statsCollector.Reset(ex.applicationStats, ex.phaseTimes)
 	ex.resetPlanner(ctx, p, ex.state.mu.txn, stmtTS)
 	p.sessionDataMutatorIterator.paramStatusUpdater = res
 	p.noticeSender = res
@@ -1426,7 +1426,7 @@ func (ex *connExecutor) beginTransactionTimestampsAndReadMode(
 		rwMode = ex.readWriteModeWithSessionDefault(modes.ReadWriteMode)
 		return rwMode, now, nil, nil
 	}
-	ex.statsCollector.Reset(ex.statsWriter, ex.phaseTimes)
+	ex.statsCollector.Reset(ex.applicationStats, ex.phaseTimes)
 	p := &ex.planner
 
 	// NB: this use of p.txn is totally bogus. The planner's txn should

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -161,7 +161,7 @@ func (ex *connExecutor) prepare(
 
 	var flags planFlags
 	prepare := func(ctx context.Context, txn *kv.Txn) (err error) {
-		ex.statsCollector.Reset(ex.statsWriter, ex.phaseTimes)
+		ex.statsCollector.Reset(ex.applicationStats, ex.phaseTimes)
 		p := &ex.planner
 		if origin != PreparedStatementOriginSQL {
 			// If the PREPARE command was issued as a SQL statement, then we

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -173,7 +173,7 @@ func (ie *InternalExecutor) initConnEx(
 		// If this is already an "internal app", don't put more prefix.
 		appStatsBucketName = sd.ApplicationName
 	}
-	statsWriter := ie.s.sqlStats.GetWriterForApplication(appStatsBucketName)
+	applicationStats := ie.s.sqlStats.GetApplicationStats(appStatsBucketName)
 
 	sds := sessiondata.NewStack(sd)
 	sdMutIterator := ie.s.makeSessionDataMutatorIterator(sds, nil /* sessionDefaults */)
@@ -186,7 +186,7 @@ func (ie *InternalExecutor) initConnEx(
 			clientComm,
 			ie.memMetrics,
 			&ie.s.InternalMetrics,
-			statsWriter,
+			applicationStats,
 		)
 	} else {
 		ex = ie.s.newConnExecutorWithTxn(
@@ -199,7 +199,7 @@ func (ie *InternalExecutor) initConnEx(
 			&ie.s.InternalMetrics,
 			txn,
 			ie.syntheticDescriptors,
-			statsWriter,
+			applicationStats,
 		)
 	}
 

--- a/pkg/sql/sqlstats/persistedsqlstats/BUILD.bazel
+++ b/pkg/sql/sqlstats/persistedsqlstats/BUILD.bazel
@@ -5,6 +5,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "persistedsqlstats",
     srcs = [
+        "appStats.go",
         "cluster_settings.go",
         "combined_iterator.go",
         "compaction_exec.go",
@@ -16,7 +17,6 @@ go_library(
         "scheduled_job_monitor.go",
         "stmt_reader.go",
         "txn_reader.go",
-        "writer.go",
     ],
     embed = [":persistedsqlstats_go_proto"],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats",
@@ -34,7 +34,6 @@ go_library(
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/sql/catalog/systemschema",
-        "//pkg/sql/execstats",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/sql/sqlstats",

--- a/pkg/sql/sqlstats/persistedsqlstats/provider.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/provider.go
@@ -77,7 +77,7 @@ type PersistedSQLStats struct {
 
 	cfg *Config
 
-	// memoryPressureSignal is used by the persistedsqlstats.StatsWriter to signal
+	// memoryPressureSignal is used by the persistedsqlstats.ApplicationStats to signal
 	// memory pressure during stats recording. A signal is emitted through this
 	// channel either if the fingerprint limit or the memory limit has been
 	// exceeded.
@@ -199,11 +199,11 @@ func (s *PersistedSQLStats) jitterInterval(interval time.Duration) time.Duration
 	return jitteredInterval
 }
 
-// GetWriterForApplication implements sqlstats.Provider interface.
-func (s *PersistedSQLStats) GetWriterForApplication(appName string) sqlstats.Writer {
-	writer := s.SQLStats.GetWriterForApplication(appName)
-	return &StatsWriter{
-		memWriter:            writer,
+// GetApplicationStats implements sqlstats.Provider interface.
+func (s *PersistedSQLStats) GetApplicationStats(appName string) sqlstats.ApplicationStats {
+	appStats := s.SQLStats.GetApplicationStats(appName)
+	return &ApplicationStats{
+		ApplicationStats:     appStats,
 		memoryPressureSignal: s.memoryPressureSignal,
 	}
 }

--- a/pkg/sql/sqlstats/sslocal/sslocal_provider.go
+++ b/pkg/sql/sqlstats/sslocal/sslocal_provider.go
@@ -101,8 +101,8 @@ func (s *SQLStats) periodicallyClearSQLStats(
 	})
 }
 
-// GetWriterForApplication implements sqlstats.Provider interface.
-func (s *SQLStats) GetWriterForApplication(appName string) sqlstats.Writer {
+// GetApplicationStats implements sqlstats.Provider interface.
+func (s *SQLStats) GetApplicationStats(appName string) sqlstats.ApplicationStats {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if a, ok := s.mu.apps[appName]; ok {
@@ -173,7 +173,7 @@ func (s *SQLStats) TxnStatsIterator(options *sqlstats.IteratorOptions) *TxnStats
 
 // IterateAggregatedTransactionStats implements sqlstats.Provider interface.
 func (s *SQLStats) IterateAggregatedTransactionStats(
-	_ context.Context,
+	ctx context.Context,
 	options *sqlstats.IteratorOptions,
 	visitor sqlstats.AggregatedTransactionVisitor,
 ) error {
@@ -182,7 +182,7 @@ func (s *SQLStats) IterateAggregatedTransactionStats(
 	for _, appName := range appNames {
 		statsContainer := s.getStatsForApplication(appName)
 
-		err := statsContainer.IterateAggregatedTransactionStats(appName, visitor)
+		err := statsContainer.IterateAggregatedTransactionStats(ctx, options, visitor)
 		if err != nil {
 			return fmt.Errorf("sql stats iteration abort: %s", err)
 		}

--- a/pkg/sql/sqlstats/sslocal/sslocal_stats_collector.go
+++ b/pkg/sql/sqlstats/sslocal/sslocal_stats_collector.go
@@ -15,8 +15,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
 )
 
-type statsCollector struct {
-	sqlstats.Writer
+// StatsCollector is used to collect statement and transaction statistics
+// from connExecutor.
+type StatsCollector struct {
+	sqlstats.ApplicationStats
 
 	// phaseTimes tracks session-level phase times.
 	phaseTimes *sessionphase.Times
@@ -26,33 +28,33 @@ type statsCollector struct {
 	previousPhaseTimes *sessionphase.Times
 }
 
-var _ sqlstats.StatsCollector = &statsCollector{}
+var _ sqlstats.ApplicationStats = &StatsCollector{}
 
 // NewStatsCollector returns an instance of sqlstats.StatsCollector.
 func NewStatsCollector(
-	writer sqlstats.Writer, phaseTime *sessionphase.Times,
-) sqlstats.StatsCollector {
-	return &statsCollector{
-		Writer:     writer,
-		phaseTimes: phaseTime.Clone(),
+	appStats sqlstats.ApplicationStats, phaseTime *sessionphase.Times,
+) *StatsCollector {
+	return &StatsCollector{
+		ApplicationStats: appStats,
+		phaseTimes:       phaseTime.Clone(),
 	}
 }
 
 // PhaseTimes implements sqlstats.StatsCollector interface.
-func (s *statsCollector) PhaseTimes() *sessionphase.Times {
+func (s *StatsCollector) PhaseTimes() *sessionphase.Times {
 	return s.phaseTimes
 }
 
 // PreviousPhaseTimes implements sqlstats.StatsCollector interface.
-func (s *statsCollector) PreviousPhaseTimes() *sessionphase.Times {
+func (s *StatsCollector) PreviousPhaseTimes() *sessionphase.Times {
 	return s.previousPhaseTimes
 }
 
 // Reset implements sqlstats.StatsCollector interface.
-func (s *statsCollector) Reset(writer sqlstats.Writer, phaseTime *sessionphase.Times) {
+func (s *StatsCollector) Reset(appStats sqlstats.ApplicationStats, phaseTime *sessionphase.Times) {
 	previousPhaseTime := s.phaseTimes
-	*s = statsCollector{
-		Writer:             writer,
+	*s = StatsCollector{
+		ApplicationStats:   appStats,
 		previousPhaseTimes: previousPhaseTime,
 		phaseTimes:         phaseTime.Clone(),
 	}

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
@@ -99,7 +99,7 @@ type Container struct {
 	txnCounts transactionCounts
 }
 
-var _ sqlstats.Writer = &Container{}
+var _ sqlstats.ApplicationStats = &Container{}
 
 // New returns a new instance of Container.
 func New(
@@ -131,17 +131,17 @@ func New(
 	return s
 }
 
-// IterateAggregatedTransactionStats iterates through the stored aggregated
-// transaction statistics stored in this Container.
+// IterateAggregatedTransactionStats implements sqlstats.ApplicationStats
+// interface.
 func (s *Container) IterateAggregatedTransactionStats(
-	appName string, visitor sqlstats.AggregatedTransactionVisitor,
+	_ context.Context, _ *sqlstats.IteratorOptions, visitor sqlstats.AggregatedTransactionVisitor,
 ) error {
 	var txnStat roachpb.TxnStats
 	s.txnCounts.mu.Lock()
 	txnStat = s.txnCounts.mu.TxnStats
 	s.txnCounts.mu.Unlock()
 
-	err := visitor(appName, &txnStat)
+	err := visitor(s.appName, &txnStat)
 	if err != nil {
 		return fmt.Errorf("sql stats iteration abort: %s", err)
 	}
@@ -205,6 +205,37 @@ func (s *Container) StmtStatsIterator(options *sqlstats.IteratorOptions) *StmtSt
 // TxnStatsIterator returns an instance of TxnStatsIterator.
 func (s *Container) TxnStatsIterator(options *sqlstats.IteratorOptions) *TxnStatsIterator {
 	return NewTxnStatsIterator(s, options)
+}
+
+// IterateStatementStats implements sqlstats.Provider interface.
+func (s *Container) IterateStatementStats(
+	ctx context.Context, options *sqlstats.IteratorOptions, visitor sqlstats.StatementVisitor,
+) error {
+	iter := s.StmtStatsIterator(options)
+
+	for iter.Next() {
+		if err := visitor(ctx, iter.Cur()); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// IterateTransactionStats implements sqlstats.Provider interface.
+func (s *Container) IterateTransactionStats(
+	ctx context.Context, options *sqlstats.IteratorOptions, visitor sqlstats.TransactionVisitor,
+) error {
+	iter := s.TxnStatsIterator(options)
+
+	for iter.Next() {
+		stats := iter.Cur()
+		if err := visitor(ctx, stats); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // NewTempContainerFromExistingStmtStats creates a new Container by ingesting a slice


### PR DESCRIPTION
Follow up PR: #70261

Previously, SQL Stats's public writer interface is very limited
in its functionality. This was intentional back in the time where
SQL Stat's writer is injected into stats collector and directly
writes statistics into the in-memory store. However, as we move
to support grouping of statement statistics within an explicit
transaction, this limited interface becomes a hurdle for stats
collector to implement that behavior.
This commit restructure the SQL Stats Writer API to introduce
the concept of sqlstats.ApplicationStats, which maps to
ssmemstorage.Container struct. Now, sqlstats.Storage interface
would return the new sqlstats.ApplicationStats intead of
sqlstats.Writer to the connExecutor, which can be injected into
the sqlstats.StatsCollector.

This is the initial step to address #59205

Release justification: Low risk, high benefit changes to existing
functionality
Release note: None