### PR TITLE
build: increase pebble nightly metamorphic test runtime

### DIFF
--- a/build/teamcity-nightly-pebble-metamorphic.sh
+++ b/build/teamcity-nightly-pebble-metamorphic.sh
@@ -27,7 +27,7 @@ env=(
   "TC_SERVER_URL=$TC_SERVER_URL"
   "TC_BUILD_BRANCH=$TC_BUILD_BRANCH"
   "PKG=internal/metamorphic"
-  "STRESSFLAGS=-maxtime 1h -maxfails 1 -stderr -p 1"
+  "STRESSFLAGS=-maxtime 3h -maxfails 1 -stderr -p 1"
   "TZ=America/New_York"
 )
 


### PR DESCRIPTION
Increase the runtime of the Pebble nightly metamorphic test run from 1h
to 3h. More test time increases the chance of catching a test failure.

See #69414.

Release justification: non-production code change

Release note: None