### PR TITLE
sql: alter ALTER TYPE ... OWNER TO ... for multi-region enum

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region
@@ -143,6 +143,15 @@ ALTER TYPE multi_region_test_db.public.crdb_internal_region ADD VALUE 'us-east-1
 statement error "multi_region_test_db.public.crdb_internal_region" is a multi-region enum and can't be modified using the alter type command
 ALTER TYPE multi_region_test_db.public.crdb_internal_region DROP VALUE 'us-east-1'
 
+statement ok
+GRANT ALL ON DATABASE multi_region_test_db TO testuser;
+ALTER TYPE multi_region_test_db.public.crdb_internal_region OWNER TO testuser
+
+query T
+SELECT owner FROM [SHOW TYPES] WHERE name = 'crdb_internal_region' AND schema = 'public'
+----
+testuser
+
 statement error region "region_no_exists" does not exist\nHINT:.*valid regions: ap-southeast-2, ca-central-1, us-east-1
 CREATE DATABASE invalid_region_db PRIMARY REGION "region_no_exists" REGION "region_no_exists"
 

--- a/pkg/sql/alter_type.go
+++ b/pkg/sql/alter_type.go
@@ -67,13 +67,15 @@ func (p *planner) AlterType(ctx context.Context, n *tree.AlterType) (planNode, e
 			tree.AsStringWithFQNames(n.Type, &p.semaCtx.Annotations),
 		)
 	case descpb.TypeDescriptor_MULTIREGION_ENUM:
-		// Multi-region enums can't be directly modified.
-		return nil, errors.WithHint(
-			pgerror.Newf(
-				pgcode.WrongObjectType,
-				"%q is a multi-region enum and can't be modified using the alter type command",
-				tree.AsStringWithFQNames(n.Type, &p.semaCtx.Annotations)),
-			"try adding/removing the region using ALTER DATABASE")
+		// Multi-region enums can't be directly modified except for OWNER TO.
+		if _, isAlterTypeOwner := n.Cmd.(*tree.AlterTypeOwner); !isAlterTypeOwner {
+			return nil, errors.WithHint(
+				pgerror.Newf(
+					pgcode.WrongObjectType,
+					"%q is a multi-region enum and can't be modified using the alter type command",
+					tree.AsStringWithFQNames(n.Type, &p.semaCtx.Annotations)),
+				"try adding/removing the region using ALTER DATABASE")
+		}
 	case descpb.TypeDescriptor_ENUM:
 		sqltelemetry.IncrementEnumCounter(sqltelemetry.EnumAlter)
 	}


### PR DESCRIPTION
Release justification: fix for old functionality

Resolves #69714

Release note (sql change): Previously, one could not alter the owner of
the crdb_internal_region type which is created by initiating a
multi-region database. This is now possible.