### PR TITLE
server: add basic TLS support to tenant HTTP server

### DIFF
--- a/pkg/ccl/serverccl/BUILD.bazel
+++ b/pkg/ccl/serverccl/BUILD.bazel
@@ -41,7 +41,6 @@ go_test(
         "//pkg/testutils/testcluster",
         "//pkg/util",
         "//pkg/util/envutil",
-        "//pkg/util/httputil",
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/randutil",


### PR DESCRIPTION
Previously, the tenant HTTP server only served non-TLS connections by
default. This change will use the TLS config when it's present and serve
the HTTP server over TLS on the tenant. As on dedicated nodes, the
configuration will pick up the optional UI cert or the node cert as a
fallback.

This change also adds TLS to all other HTTP servers on the tenant server
including the `_status/vars` endpoint and `pprof` endpoints.

Resolves cockroachdb#69927

Release justification: fixing high-priority bug in existing
functionality.

Release note (security update): sql tenant servers will now use a TLS
certificate for their HTTP server when it's present. Previously this
server never used TLS.